### PR TITLE
feat(frontend): add GUI zoom shortcuts

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -43,6 +43,20 @@
     const unsub3 = EventsOn('task:deleted', () => taskStore.load())
 
     function handleKeydown(e: KeyboardEvent) {
+      if (e.metaKey && (e.key === '=' || e.key === '+')) {
+        e.preventDefault()
+        const current = parseFloat(document.documentElement.style.zoom || '1')
+        document.documentElement.style.zoom = String(Math.min(current + 0.1, 2))
+      }
+      if (e.metaKey && e.key === '-') {
+        e.preventDefault()
+        const current = parseFloat(document.documentElement.style.zoom || '1')
+        document.documentElement.style.zoom = String(Math.max(current - 0.1, 0.5))
+      }
+      if (e.metaKey && e.key === '0') {
+        e.preventDefault()
+        document.documentElement.style.zoom = '1'
+      }
       if (e.metaKey && e.key === 'n') {
         e.preventDefault()
         quickAddOpen = true

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -8,6 +8,7 @@ html, body {
   padding: 0;
   height: 100%;
   overflow: hidden;
+  font-size: 18px;
 }
 
 #app {


### PR DESCRIPTION
## Motivation

GUI text was too small by default and there was no way to scale the interface without rebuilding.

## Implementation information

- Bumped default `font-size` to 18px in `style.css`
- Added Cmd+/Cmd- keyboard shortcuts to zoom in/out via CSS `zoom` (0.5x–2x range, 0.1 step)
- Added Cmd+0 to reset zoom to 1x