### PR TITLE
feat(gui): start window maximised

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,9 +30,10 @@ func main() {
 	app := NewApp(logger, cfg.Logging.Dir, cfg.TasksDir, cfg.SkillsDir, cfg.RepoDir)
 
 	err = wails.Run(&options.App{
-		Title:  "Synapse",
-		Width:  1280,
-		Height: 800,
+		Title:            "Synapse",
+		Width:            1280,
+		Height:           800,
+		WindowStartState: options.Maximised,
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 		},


### PR DESCRIPTION
## Motivation

App window started at fixed 1280×800 which felt small on modern displays. Start maximised to fill screen automatically.

## Implementation information

Added `WindowStartState: options.Maximised` to Wails app options. Keeps 1280×800 as fallback dimensions when user un-maximises.