### PR TITLE
feat(gui): global spotlight for quick task add

### DIFF
--- a/.claude/skills/synapse-triage.md
+++ b/.claude/skills/synapse-triage.md
@@ -9,6 +9,10 @@ user-invocable: true
 
 Triage incoming tasks: analyze content, assign tags, set appropriate agent mode, update status.
 
+## CLI Reference
+
+The ONLY valid flags for `synapse-cli update` are: `--title`, `--status`, `--body`, `--mode`, `--tags`. Do NOT use `--agent-mode` or any other flag — they do not exist and will error.
+
 ## Process
 
 ### 1. List pending tasks

--- a/app.go
+++ b/app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Automaat/synapse/internal/agent"
 	"github.com/Automaat/synapse/internal/config"
 	"github.com/Automaat/synapse/internal/github"
+	"github.com/Automaat/synapse/internal/spotlight"
 	"github.com/Automaat/synapse/internal/task"
 	"github.com/Automaat/synapse/internal/tmux"
 	"github.com/Automaat/synapse/internal/watcher"
@@ -61,6 +62,7 @@ func (a *App) startup(ctx context.Context) {
 	_ = w.Start(ctx)
 
 	a.syncSkills()
+	a.RegisterSpotlightHotkey()
 	a.logger.Info("app.started")
 }
 
@@ -399,4 +401,23 @@ func (a *App) GetAgentOutput(agentID string) ([]agent.StreamEvent, error) {
 
 func (a *App) FetchReviews() (github.ReviewSummary, error) {
 	return github.FetchReviews()
+}
+
+func (a *App) RegisterSpotlightHotkey() {
+	spotlight.OnSubmit(func(text string) {
+		a.logger.Info("spotlight.submit", "text", text)
+		go func() {
+			if _, err := a.CreateTask(text, "", "headless"); err != nil {
+				a.logger.Error("spotlight.create", "err", err)
+			}
+		}()
+	})
+
+	if err := spotlight.Register(func() {
+		spotlight.ShowPanel(680, 72)
+	}); err != nil {
+		a.logger.Error("spotlight.register", "err", err)
+		return
+	}
+	a.logger.Info("spotlight.registered", "hotkey", "ctrl+space")
 }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -27,6 +27,8 @@
   let page = $state<Page>({ kind: 'dashboard' })
   let dialogOpen = $state(false)
   let quickAddOpen = $state(false)
+  let quitConfirmVisible = $state(false)
+  let quitConfirmTimer: ReturnType<typeof setTimeout> | null = null
 
   const pageTitle = $derived(
     page.kind === 'dashboard' ? 'Dashboard' :
@@ -48,7 +50,11 @@
     const unsub1 = EventsOn('task:created', () => taskStore.load())
     const unsub2 = EventsOn('task:updated', () => taskStore.load())
     const unsub3 = EventsOn('task:deleted', () => taskStore.load())
-
+    const unsubQuit = EventsOn('app:quit-confirm', () => {
+      quitConfirmVisible = true
+      if (quitConfirmTimer) clearTimeout(quitConfirmTimer)
+      quitConfirmTimer = setTimeout(() => { quitConfirmVisible = false }, 3000)
+    })
     function handleKeydown(e: KeyboardEvent) {
       if (e.metaKey && (e.key === '=' || e.key === '+')) {
         e.preventDefault()
@@ -99,6 +105,8 @@
       unsub1()
       unsub2()
       unsub3()
+      unsubQuit()
+      if (quitConfirmTimer) clearTimeout(quitConfirmTimer)
       taskStore.stopPolling()
       agentStore.stopPolling()
       window.removeEventListener('keydown', handleKeydown)
@@ -232,3 +240,9 @@
   open={quickAddOpen}
   onclose={() => (quickAddOpen = false)}
 />
+
+{#if quitConfirmVisible}
+  <div class="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 rounded-lg bg-surface-700 px-4 py-2 text-sm text-white shadow-lg">
+    Press <kbd class="rounded bg-surface-500 px-1.5 py-0.5 font-mono text-xs">&#8984;Q</kbd> again to quit
+  </div>
+{/if}

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -21,8 +21,6 @@ export function DeleteTask(arg1:string):Promise<void>;
 
 export function DiscoverAgents():Promise<Array<agent.Agent>>;
 
-export function EvaluateTask(arg1:string,arg2:string):Promise<void>;
-
 export function FetchReviews():Promise<github.ReviewSummary>;
 
 export function GetAgentOutput(arg1:string):Promise<Array<agent.StreamEvent>>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -34,10 +34,6 @@ export function DiscoverAgents() {
   return window['go']['main']['App']['DiscoverAgents']();
 }
 
-export function EvaluateTask(arg1, arg2) {
-  return window['go']['main']['App']['EvaluateTask'](arg1, arg2);
-}
-
 export function FetchReviews() {
   return window['go']['main']['App']['FetchReviews']();
 }

--- a/internal/spotlight/spotlight_darwin.go
+++ b/internal/spotlight/spotlight_darwin.go
@@ -1,0 +1,73 @@
+package spotlight
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework AppKit -framework Carbon
+
+int registerGlobalHotkey(void);
+void showSpotlightPanel(int width, int height);
+void dismissSpotlightPanel(void);
+*/
+import "C"
+
+import (
+	"fmt"
+	"sync"
+)
+
+var (
+	callbackMu sync.Mutex
+	callbackFn func()
+	submitFn   func(text string)
+)
+
+//export goHotkeyCallback
+func goHotkeyCallback() {
+	callbackMu.Lock()
+	fn := callbackFn
+	callbackMu.Unlock()
+	if fn != nil {
+		fn()
+	}
+}
+
+//export goSpotlightSubmit
+func goSpotlightSubmit(ctext *C.char) {
+	text := C.GoString(ctext)
+	callbackMu.Lock()
+	fn := submitFn
+	callbackMu.Unlock()
+	if fn != nil {
+		fn(text)
+	}
+}
+
+// Register sets up Ctrl+Space as a global hotkey.
+func Register(callback func()) error {
+	callbackMu.Lock()
+	callbackFn = callback
+	callbackMu.Unlock()
+
+	status := C.registerGlobalHotkey()
+	if status != 0 {
+		return fmt.Errorf("RegisterEventHotKey failed: status %d", status)
+	}
+	return nil
+}
+
+// OnSubmit sets the callback invoked when user submits text in the spotlight panel.
+func OnSubmit(fn func(text string)) {
+	callbackMu.Lock()
+	submitFn = fn
+	callbackMu.Unlock()
+}
+
+// ShowPanel shows the spotlight overlay panel on the current screen.
+func ShowPanel(width, height int) {
+	C.showSpotlightPanel(C.int(width), C.int(height))
+}
+
+// DismissPanel hides the spotlight panel and returns focus.
+func DismissPanel() {
+	C.dismissSpotlightPanel()
+}

--- a/internal/spotlight/spotlight_darwin.m
+++ b/internal/spotlight/spotlight_darwin.m
@@ -1,0 +1,174 @@
+#import <AppKit/AppKit.h>
+#import <Carbon/Carbon.h>
+
+// Forward declarations of Go callbacks.
+extern void goHotkeyCallback(void);
+extern void goSpotlightSubmit(char *text);
+
+// --- Hotkey ---
+
+static OSStatus hotkeyHandler(EventHandlerCallRef next, EventRef event, void *userData) {
+	(void)next; (void)event; (void)userData;
+	goHotkeyCallback();
+	return noErr;
+}
+
+int registerGlobalHotkey(void) {
+	EventTypeSpec eventType = {kEventClassKeyboard, kEventHotKeyPressed};
+	InstallApplicationEventHandler(&hotkeyHandler, 1, &eventType, NULL, NULL);
+
+	EventHotKeyRef hotKeyRef;
+	EventHotKeyID hotKeyID = {.signature = 'SYNP', .id = 1};
+	OSStatus status = RegisterEventHotKey(
+		kVK_Space, controlKey, hotKeyID,
+		GetApplicationEventTarget(), 0, &hotKeyRef
+	);
+	return (int)status;
+}
+
+// --- Spotlight Panel ---
+
+// Subclass so borderless nonactivating panel can still become key and receive keyboard.
+@interface SpotlightPanel : NSPanel
+@end
+
+@implementation SpotlightPanel
+- (BOOL)canBecomeKeyWindow { return YES; }
+- (BOOL)canBecomeMainWindow { return NO; }
+@end
+
+// Text field delegate: Enter submits, Escape dismisses.
+@interface SpotlightFieldDelegate : NSObject <NSTextFieldDelegate>
+@property (nonatomic, assign) SpotlightPanel *panel;
+@end
+
+@implementation SpotlightFieldDelegate
+
+- (BOOL)control:(NSControl *)control textView:(NSTextView *)textView doCommandBySelector:(SEL)commandSelector {
+	(void)textView;
+	if (commandSelector == @selector(insertNewline:)) {
+		NSString *text = [control stringValue];
+		if ([text length] > 0) {
+			goSpotlightSubmit((char *)[text UTF8String]);
+		}
+		[self dismissPanel];
+		return YES;
+	}
+	if (commandSelector == @selector(cancelOperation:)) {
+		[self dismissPanel];
+		return YES;
+	}
+	return NO;
+}
+
+- (void)dismissPanel {
+	if (self.panel) {
+		[self.panel orderOut:nil];
+		self.panel = nil;
+	}
+}
+
+@end
+
+static SpotlightPanel *spotlightPanel = nil;
+static SpotlightFieldDelegate *fieldDelegate = nil;
+static char previousBundleID[256] = {0};
+
+void showSpotlightPanel(int width, int height) {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		// Remember the currently focused app.
+		NSRunningApplication *frontApp = [[NSWorkspace sharedWorkspace] frontmostApplication];
+		if (frontApp && [frontApp bundleIdentifier]) {
+			strlcpy(previousBundleID, [[frontApp bundleIdentifier] UTF8String], sizeof(previousBundleID));
+		} else {
+			previousBundleID[0] = '\0';
+		}
+
+		// If panel already visible, dismiss it (toggle).
+		if (spotlightPanel && [spotlightPanel isVisible]) {
+			[spotlightPanel orderOut:nil];
+			spotlightPanel = nil;
+			return;
+		}
+
+		// Find screen with mouse cursor.
+		NSPoint mouseLoc = [NSEvent mouseLocation];
+		NSScreen *targetScreen = [NSScreen mainScreen];
+		for (NSScreen *screen in [NSScreen screens]) {
+			if (NSPointInRect(mouseLoc, screen.frame)) {
+				targetScreen = screen;
+				break;
+			}
+		}
+
+		// Position: centered horizontally, near top of screen.
+		NSRect screenFrame = [targetScreen frame];
+		CGFloat x = screenFrame.origin.x + (screenFrame.size.width - width) / 2;
+		CGFloat y = screenFrame.origin.y + screenFrame.size.height * 0.70;
+		NSRect panelFrame = NSMakeRect(x, y, width, height);
+
+		// Create nonactivating panel — receives keyboard WITHOUT activating the app.
+		// NSWindowStyleMaskNonactivatingPanel MUST be set at init time.
+		spotlightPanel = [[SpotlightPanel alloc]
+			initWithContentRect:panelFrame
+			styleMask:NSWindowStyleMaskBorderless | NSWindowStyleMaskNonactivatingPanel
+			backing:NSBackingStoreBuffered
+			defer:NO];
+
+		[spotlightPanel setCollectionBehavior:
+			NSWindowCollectionBehaviorCanJoinAllSpaces |
+			NSWindowCollectionBehaviorFullScreenAuxiliary |
+			NSWindowCollectionBehaviorStationary |
+			NSWindowCollectionBehaviorIgnoresCycle];
+		[spotlightPanel setLevel:kCGScreenSaverWindowLevel - 1];
+		[spotlightPanel setBackgroundColor:[NSColor colorWithRed:0.12 green:0.14 blue:0.18 alpha:0.95]];
+		[spotlightPanel setOpaque:NO];
+		[spotlightPanel setHasShadow:YES];
+		[spotlightPanel setHidesOnDeactivate:NO];
+		[spotlightPanel setFloatingPanel:YES];
+
+		// Round corners.
+		[spotlightPanel.contentView setWantsLayer:YES];
+		spotlightPanel.contentView.layer.cornerRadius = 12;
+		spotlightPanel.contentView.layer.masksToBounds = YES;
+
+		// Create text field.
+		NSTextField *field = [[NSTextField alloc] initWithFrame:NSMakeRect(16, 16, width - 32, height - 32)];
+		[field setFont:[NSFont systemFontOfSize:20 weight:NSFontWeightRegular]];
+		[field setTextColor:[NSColor whiteColor]];
+		[field setBackgroundColor:[NSColor clearColor]];
+		[field setFocusRingType:NSFocusRingTypeNone];
+		[field setBordered:NO];
+		[field setBezeled:NO];
+		[[field cell] setPlaceholderAttributedString:
+			[[NSAttributedString alloc]
+				initWithString:@"New task..."
+				attributes:@{
+					NSForegroundColorAttributeName: [NSColor colorWithWhite:0.5 alpha:1.0],
+					NSFontAttributeName: [NSFont systemFontOfSize:20 weight:NSFontWeightRegular]
+				}]];
+
+		// Set delegate for Enter/Escape handling.
+		if (!fieldDelegate) {
+			fieldDelegate = [[SpotlightFieldDelegate alloc] init];
+		}
+		fieldDelegate.panel = spotlightPanel;
+		[field setDelegate:fieldDelegate];
+
+		[[spotlightPanel contentView] addSubview:field];
+
+		// Show panel and focus field. NO app activation — nonactivating panel handles keyboard.
+		[spotlightPanel orderFrontRegardless];
+		[spotlightPanel makeKeyWindow];
+		[spotlightPanel makeFirstResponder:field];
+	});
+}
+
+void dismissSpotlightPanel(void) {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		if (spotlightPanel) {
+			[spotlightPanel orderOut:nil];
+			spotlightPanel = nil;
+		}
+	});
+}

--- a/internal/spotlight/spotlight_other.go
+++ b/internal/spotlight/spotlight_other.go
@@ -1,0 +1,13 @@
+//go:build !darwin
+
+package spotlight
+
+import "fmt"
+
+func Register(_ func()) error {
+	return fmt.Errorf("global hotkey not supported on this platform")
+}
+
+func OnSubmit(_ func(string)) {}
+func ShowPanel(_, _ int)      {}
+func DismissPanel()           {}

--- a/main.go
+++ b/main.go
@@ -2,12 +2,17 @@ package main
 
 import (
 	"embed"
+	"sync"
+	"time"
 
 	"github.com/Automaat/synapse/internal/config"
 	"github.com/Automaat/synapse/internal/logging"
 	"github.com/wailsapp/wails/v2"
+	"github.com/wailsapp/wails/v2/pkg/menu"
+	"github.com/wailsapp/wails/v2/pkg/menu/keys"
 	"github.com/wailsapp/wails/v2/pkg/options"
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
+	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
 //go:embed all:frontend/dist
@@ -29,6 +34,37 @@ func main() {
 
 	app := NewApp(logger, cfg.Logging.Dir, cfg.TasksDir, cfg.SkillsDir, cfg.RepoDir)
 
+	var (
+		quitArmed bool
+		quitMu    sync.Mutex
+		quitTimer *time.Timer
+	)
+
+	appMenu := menu.NewMenu()
+	appMenu.Append(menu.EditMenu())
+	fileMenu := appMenu.AddSubmenu("File")
+	fileMenu.AddText("Close Window", keys.CmdOrCtrl("w"), func(_ *menu.CallbackData) {
+		wailsruntime.Quit(app.ctx)
+	})
+	fileMenu.AddText("Quit", keys.CmdOrCtrl("q"), func(_ *menu.CallbackData) {
+		quitMu.Lock()
+		defer quitMu.Unlock()
+
+		if quitArmed {
+			wailsruntime.Quit(app.ctx)
+			return
+		}
+
+		quitArmed = true
+		wailsruntime.EventsEmit(app.ctx, "app:quit-confirm")
+		quitTimer = time.AfterFunc(3*time.Second, func() {
+			quitMu.Lock()
+			defer quitMu.Unlock()
+			quitArmed = false
+		})
+		_ = quitTimer
+	})
+
 	err = wails.Run(&options.App{
 		Title:            "Synapse",
 		Width:            1280,
@@ -40,6 +76,7 @@ func main() {
 		BackgroundColour: &options.RGBA{R: 27, G: 38, B: 54, A: 1},
 		OnStartup:        app.startup,
 		OnShutdown:       app.shutdown,
+		Menu:             appMenu,
 		Bind: []any{
 			app,
 		},


### PR DESCRIPTION
## Motivation

Need a way to quickly add tasks from anywhere — including over fullscreen apps — without switching to Synapse. Similar to Spotlight/Alfred/Raycast UX.

## Implementation information

Native macOS NSPanel overlay triggered by global Ctrl+Space hotkey:

- **`internal/spotlight/`** — CGo bridge + Objective-C implementation
  - `SpotlightPanel` subclass with `canBecomeKeyWindow:YES` for keyboard input
  - `NSWindowStyleMaskNonactivatingPanel` — panel gets focus without activating app (no Space switch)
  - `CanJoinAllSpaces + FullScreenAuxiliary` — appears over fullscreen apps
  - Carbon `RegisterEventHotKey` for global Ctrl+Space
  - Go callbacks for hotkey trigger and text submission
- **`app.go`** — `RegisterSpotlightHotkey()` wires hotkey to panel, `OnSubmit` calls `CreateTask` (with auto-triage)
- **`main.go`** — Cmd+W to close, Cmd+Q double-press to quit
- **`App.svelte`** — quit confirmation toast
- **Triage skill** — added valid CLI flags reference to prevent hallucinated flags

Alternatives considered:
- Repurposing main Wails window as overlay — broke Space assignment, window disappeared on restore
- `activateIgnoringOtherApps` — caused Space switching even with Accessory policy
- `golang.design/x/hotkey` — main thread conflict with Wails

> Changelog: feat(gui): global spotlight for quick task add