### PR TITLE
feat(gui): board drag-and-drop for cards

### DIFF
--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -9,6 +9,8 @@
 
   const { task: t, onclick }: Props = $props()
 
+  let dragging = $state(false)
+
   const triaging = $derived(
     (agentStore.list ?? []).some((a) => a.taskId === t.id && a.name?.startsWith('triage:') && a.state === 'running')
   )
@@ -31,8 +33,15 @@
 
 <button
   type="button"
-  class="w-full rounded-lg border border-surface-300 bg-surface-50 p-3 text-left transition-colors hover:bg-surface-100 dark:border-surface-600 dark:bg-surface-800 dark:hover:bg-surface-700"
+  draggable="true"
+  class="w-full rounded-lg border border-surface-300 bg-surface-50 p-3 text-left transition-colors hover:bg-surface-100 dark:border-surface-600 dark:bg-surface-800 dark:hover:bg-surface-700 {dragging ? 'opacity-40' : ''}"
   onclick={onclick}
+  ondragstart={(e) => {
+    dragging = true
+    e.dataTransfer!.setData('text/plain', t.id)
+    e.dataTransfer!.effectAllowed = 'move'
+  }}
+  ondragend={() => { dragging = false }}
 >
   <h3 class="mb-1.5 text-sm font-semibold leading-tight">{t.title}</h3>
 

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -8,6 +8,18 @@
 
   const { onselect }: Props = $props()
 
+  let dragOverStatus = $state<string | null>(null)
+
+  async function handleDrop(e: DragEvent, targetStatus: string) {
+    e.preventDefault()
+    dragOverStatus = null
+    const taskId = e.dataTransfer?.getData('text/plain')
+    if (!taskId) return
+    const existing = taskStore.tasks.get(taskId)
+    if (!existing || existing.status === targetStatus) return
+    await taskStore.update(taskId, { status: targetStatus })
+  }
+
   const columns = [
     { status: 'new', label: 'Inbox', border: 'border-t-tertiary-500 dark:border-t-tertiary-400' },
     { status: 'todo', label: 'Todo', border: 'border-t-surface-400 dark:border-t-surface-500' },
@@ -25,7 +37,13 @@
   {:else}
     {#each columns as col}
       {@const tasks = taskStore.byStatus(col.status)}
-      <div class="flex min-w-[250px] flex-1 flex-col rounded-lg border-t-4 bg-surface-100 dark:bg-surface-900 {col.border}">
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <div
+        class="flex min-w-[250px] flex-1 flex-col rounded-lg border-t-4 bg-surface-100 transition-shadow dark:bg-surface-900 {col.border} {dragOverStatus === col.status ? 'ring-2 ring-primary-400 dark:ring-primary-500' : ''}"
+        ondragover={(e) => { e.preventDefault(); dragOverStatus = col.status }}
+        ondragleave={() => { dragOverStatus = null }}
+        ondrop={(e) => handleDrop(e, col.status)}
+      >
         <div class="flex items-center justify-between px-3 py-2">
           <h2 class="text-sm font-semibold">{col.label}</h2>
           <span class="rounded-full bg-surface-200 px-2 py-0.5 text-xs font-medium dark:bg-surface-700">


### PR DESCRIPTION
## Motivation

Board cards can only change status via TaskDetail view. This adds drag-and-drop so cards can be moved between columns directly on the board.

## Implementation information

Uses native HTML5 Drag and Drop API — no new dependencies.

- `TaskCard.svelte`: `draggable="true"`, sets task ID in `dataTransfer`, fades card while dragging
- `TaskList.svelte`: columns accept drops via `ondragover`/`ondrop`, show ring highlight on hover, call `taskStore.update(id, { status })` on drop (skips if same column)