### PR TITLE
feat(gui): auto-detect project in QuickAdd

### DIFF
--- a/frontend/src/components/QuickAddTask.svelte
+++ b/frontend/src/components/QuickAddTask.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { taskStore } from '../stores/tasks.svelte.js'
+  import { projectStore } from '../stores/projects.svelte.js'
+  import { detectProject } from '../lib/detectProject.js'
 
   interface Props {
     open: boolean
@@ -13,9 +15,48 @@
   let submitting = $state(false)
   let inputEl = $state<HTMLInputElement | null>(null)
 
+  // Project state
+  let selectedProject = $state('')
+  let userOverrode = $state(false)
+  let projectSearch = $state('')
+  let projectDropdownOpen = $state(false)
+
+  const autoDetected = $derived(detectProject(value, projectStore.list))
+
+  // Split input into [before, match, after] for highlight overlay
+  const highlightParts = $derived.by(() => {
+    if (!autoDetected || userOverrode) return null
+    const { matchStart, matchEnd } = autoDetected
+    return {
+      before: value.slice(0, matchStart),
+      match: value.slice(matchStart, matchEnd),
+      after: value.slice(matchEnd),
+    }
+  })
+
+  $effect(() => {
+    if (!userOverrode && autoDetected) {
+      selectedProject = autoDetected.project.id
+    } else if (!userOverrode && !autoDetected) {
+      selectedProject = ''
+    }
+  })
+
+  const filteredProjects = $derived(
+    projectStore.list.filter((p) => {
+      if (!projectSearch) return true
+      const q = projectSearch.toLowerCase()
+      return p.id.toLowerCase().includes(q) || p.name.toLowerCase().includes(q)
+    }),
+  )
+
   $effect(() => {
     if (open) {
       value = ''
+      selectedProject = ''
+      userOverrode = false
+      projectSearch = ''
+      projectDropdownOpen = false
       requestAnimationFrame(() => inputEl?.focus())
     }
   })
@@ -23,7 +64,23 @@
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === 'Escape') {
       e.preventDefault()
-      onclose()
+      if (projectDropdownOpen) {
+        projectDropdownOpen = false
+        inputEl?.focus()
+      } else {
+        onclose()
+      }
+    }
+  }
+
+  function handleProjectKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      handleSubmit(e)
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      projectDropdownOpen = false
+      inputEl?.focus()
     }
   }
 
@@ -33,7 +90,10 @@
 
     submitting = true
     try {
-      const t = await taskStore.create(value.trim(), '', 'interactive')
+      let t = await taskStore.create(value.trim(), '', 'interactive')
+      if (selectedProject) {
+        t = await taskStore.update(t.id, { project_id: selectedProject })
+      }
       value = ''
       onclose()
       oncreated?.(t.id)
@@ -41,21 +101,125 @@
       submitting = false
     }
   }
+
+  function dismissDetection() {
+    selectedProject = ''
+    userOverrode = true
+  }
+
+  function selectProjectManual(id: string) {
+    selectedProject = id
+    userOverrode = true
+    projectDropdownOpen = false
+    projectSearch = ''
+  }
+
+  function clearManualProject() {
+    selectedProject = ''
+    userOverrode = false
+  }
 </script>
 
 {#if open}
   <div class="fixed inset-0 z-40 bg-black/40" onclick={onclose} onkeydown={handleKeydown} role="none"></div>
   <div class="fixed left-1/2 top-1/4 z-50 w-full max-w-xl -translate-x-1/2">
-    <form onsubmit={handleSubmit}>
-      <input
-        bind:this={inputEl}
-        bind:value
-        type="text"
-        placeholder="Task title, link, or note..."
-        disabled={submitting}
-        onkeydown={handleKeydown}
-        class="w-full rounded-xl border border-surface-300 bg-surface-50 px-5 py-3.5 text-base shadow-2xl outline-none ring-2 ring-primary-500/50 placeholder:text-surface-400 focus:ring-primary-500 dark:border-surface-600 dark:bg-surface-900 dark:placeholder:text-surface-500"
-      />
-    </form>
+    <div class="rounded-xl border border-surface-300 bg-surface-50 shadow-2xl dark:border-surface-600 dark:bg-surface-900">
+      <!-- Title input with highlight overlay -->
+      <form onsubmit={handleSubmit} class="relative">
+        {#if highlightParts}
+          <div
+            aria-hidden="true"
+            class="pointer-events-none absolute inset-0 overflow-hidden whitespace-pre px-5 py-3.5 text-base text-transparent"
+          >{highlightParts.before}<mark class="rounded bg-primary-200/60 text-transparent dark:bg-primary-700/40">{highlightParts.match}</mark>{highlightParts.after}</div>
+        {/if}
+        <input
+          bind:this={inputEl}
+          bind:value
+          type="text"
+          placeholder="Task title, link, or note..."
+          disabled={submitting}
+          onkeydown={handleKeydown}
+          class="relative w-full rounded-t-xl border-none bg-transparent px-5 py-3.5 text-base outline-none ring-0 placeholder:text-surface-400 focus:ring-0 dark:placeholder:text-surface-500"
+        />
+      </form>
+
+      <!-- Project row: detected chip OR manual selected chip OR search input -->
+      {#if projectStore.list.length > 0}
+        <div class="relative border-t border-surface-200 dark:border-surface-700">
+          {#if autoDetected && !userOverrode}
+            <!-- Auto-detected project chip -->
+            <div class="flex items-center gap-2 px-5 py-2 text-xs text-surface-500">
+              <svg class="h-3.5 w-3.5 shrink-0 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+              </svg>
+              <span class="inline-flex items-center gap-1 rounded-md bg-primary-100 px-2 py-0.5 font-medium text-primary-700 dark:bg-primary-900/30 dark:text-primary-300">
+                {autoDetected.project.owner}/{autoDetected.project.repo}
+                <button
+                  type="button"
+                  aria-label="Dismiss detected project"
+                  class="ml-0.5 hover:text-primary-900 dark:hover:text-primary-100"
+                  onclick={dismissDetection}
+                >
+                  <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </span>
+              <span class="text-surface-400">from {autoDetected.matchType === 'url' ? 'link' : 'title'}</span>
+            </div>
+          {:else if selectedProject && userOverrode}
+            <!-- Manually selected project chip -->
+            <div class="flex items-center gap-2 px-5 py-2 text-xs">
+              <svg class="h-3.5 w-3.5 shrink-0 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+              </svg>
+              <span class="text-sm">{projectStore.list.find((p) => p.id === selectedProject)?.id}</span>
+              <button
+                type="button"
+                aria-label="Clear selected project"
+                class="text-surface-400 hover:text-surface-600 dark:hover:text-surface-300"
+                onclick={clearManualProject}
+              >
+                <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          {:else}
+            <!-- Project search dropdown -->
+            <div class="relative">
+              <input
+                type="text"
+                bind:value={projectSearch}
+                placeholder="Project (optional)..."
+                class="w-full rounded-b-xl border-none bg-transparent px-5 py-2 text-xs outline-none ring-0 placeholder:text-surface-400 focus:ring-0"
+                onfocus={() => (projectDropdownOpen = true)}
+                onblur={() => setTimeout(() => { projectDropdownOpen = false }, 150)}
+                onkeydown={handleProjectKeydown}
+              />
+              {#if projectDropdownOpen}
+                <div class="absolute bottom-full left-0 mb-1 max-h-48 w-full overflow-y-auto rounded-lg border border-surface-300 bg-surface-50 shadow-lg dark:border-surface-600 dark:bg-surface-800">
+                  {#each filteredProjects as p (p.id)}
+                    <button
+                      type="button"
+                      class="flex w-full items-center gap-2 px-4 py-1.5 text-left text-xs hover:bg-surface-100 dark:hover:bg-surface-700"
+                      onmousedown={() => selectProjectManual(p.id)}
+                    >
+                      <svg class="h-3.5 w-3.5 shrink-0 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                      </svg>
+                      {p.owner}/{p.repo}
+                    </button>
+                  {/each}
+                  {#if filteredProjects.length === 0}
+                    <div class="px-4 py-1.5 text-xs text-surface-400">No matches</div>
+                  {/if}
+                </div>
+              {/if}
+            </div>
+          {/if}
+        </div>
+      {/if}
+    </div>
   </div>
 {/if}

--- a/frontend/src/lib/detectProject.ts
+++ b/frontend/src/lib/detectProject.ts
@@ -1,0 +1,57 @@
+import type { project } from '../../wailsjs/go/models.js'
+
+export interface DetectionResult {
+  project: project.Project
+  matchType: 'url' | 'name'
+  matchedText: string
+  matchStart: number
+  matchEnd: number
+}
+
+const githubURLRe = /(?:https?:\/\/)?github\.com\/(([^/\s]+)\/([^/\s#?]+))/gi
+
+export function detectProject(
+  input: string,
+  projects: project.Project[],
+): DetectionResult | null {
+  if (!input || projects.length === 0) return null
+
+  // 1. URL match (highest priority)
+  for (const m of input.matchAll(githubURLRe)) {
+    const owner = m[2].toLowerCase()
+    const repo = m[3].replace(/\.git$/, '').toLowerCase()
+    const found = projects.find(
+      (p) => p.owner.toLowerCase() === owner && p.repo.toLowerCase() === repo,
+    )
+    if (found) {
+      // Highlight only the owner/repo portion (group 1), not the full URL
+      const ownerRepoStart = m.index! + m[0].indexOf(m[1])
+      return {
+        project: found,
+        matchType: 'url',
+        matchedText: m[1],
+        matchStart: ownerRepoStart,
+        matchEnd: ownerRepoStart + m[1].length,
+      }
+    }
+  }
+
+  // 2. Exact word match on repo name
+  const words = input.split(/[\s,;:!?()[\]{}]+/).filter(Boolean)
+  for (const word of words) {
+    const w = word.toLowerCase()
+    const found = projects.find((p) => p.repo.toLowerCase() === w || p.name.toLowerCase() === w)
+    if (found) {
+      const idx = input.indexOf(word)
+      return {
+        project: found,
+        matchType: 'name',
+        matchedText: word,
+        matchStart: idx,
+        matchEnd: idx + word.length,
+      }
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
## Motivation

QuickAdd (Cmd+N) had no project association. Users had to manually assign projects after creation. This adds automatic detection from the input text.

## Implementation information

- New `detectProject()` utility in `frontend/src/lib/detectProject.ts`:
  - Parses GitHub URLs (`github.com/owner/repo/...`) — highlights only `owner/repo` portion
  - Falls back to exact word match on repo name (case-insensitive, no substring)
  - URL match takes priority over name match
- QuickAddTask now has a single project row below the input with three states:
  - Auto-detected chip (dismissible) when match found
  - Manually selected chip when user picks from dropdown
  - Searchable project dropdown when no selection
- Highlight overlay behind the input marks the matched text with a semi-transparent primary color
- On submit, assigns `project_id` to created task if project selected