### PR TITLE
feat(gui): inline add-task button per column

### DIFF
--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -9,6 +9,9 @@
   const { onselect }: Props = $props()
 
   let dragOverStatus = $state<string | null>(null)
+  let addingToColumn = $state<string | null>(null)
+  let newTaskTitle = $state('')
+  let inputRef = $state<HTMLInputElement | null>(null)
 
   async function handleDrop(e: DragEvent, targetStatus: string) {
     e.preventDefault()
@@ -18,6 +21,39 @@
     const existing = taskStore.tasks.get(taskId)
     if (!existing || existing.status === targetStatus) return
     await taskStore.update(taskId, { status: targetStatus })
+  }
+
+  function openInlineAdd(status: string) {
+    addingToColumn = status
+    newTaskTitle = ''
+    // Focus after Svelte renders the input
+    requestAnimationFrame(() => inputRef?.focus())
+  }
+
+  function dismissInlineAdd() {
+    addingToColumn = null
+    newTaskTitle = ''
+  }
+
+  async function submitInlineAdd(status: string) {
+    const title = newTaskTitle.trim()
+    if (!title) return
+    newTaskTitle = ''
+    const created = await taskStore.create(title, '', 'headless')
+    if (status !== 'new') {
+      await taskStore.update(created.id, { status })
+    }
+    // Keep input open for rapid entry, re-focus
+    requestAnimationFrame(() => inputRef?.focus())
+  }
+
+  function handleInputKeydown(e: KeyboardEvent, status: string) {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      submitInlineAdd(status)
+    } else if (e.key === 'Escape') {
+      dismissInlineAdd()
+    }
   }
 
   const columns = [
@@ -55,6 +91,27 @@
           {#each tasks as t (t.id)}
             <TaskCard task={t} onclick={() => onselect(t.id)} />
           {/each}
+        </div>
+        <div class="px-2 pb-2">
+          {#if addingToColumn === col.status}
+            <input
+              bind:this={inputRef}
+              bind:value={newTaskTitle}
+              type="text"
+              placeholder="Task title"
+              class="w-full rounded-md border border-surface-300 bg-surface-50 px-2 py-1.5 text-sm outline-none focus:border-primary-400 focus:ring-1 focus:ring-primary-400 dark:border-surface-600 dark:bg-surface-800"
+              onkeydown={(e) => handleInputKeydown(e, col.status)}
+              onblur={() => dismissInlineAdd()}
+            />
+          {:else}
+            <button
+              type="button"
+              class="flex w-full items-center gap-1 rounded-md px-2 py-1.5 text-sm opacity-50 transition-opacity hover:bg-surface-200 hover:opacity-100 dark:hover:bg-surface-800"
+              onclick={() => openInlineAdd(col.status)}
+            >
+              <span class="text-base leading-none">+</span> Add task
+            </button>
+          {/if}
         </div>
       </div>
     {/each}


### PR DESCRIPTION
## Motivation

Quick task creation from the board view without opening dialogs. GitHub Projects-style `+ Add task` button at the bottom of each column.

## Implementation information

- `+ Add task` button at the bottom of each board column, low-opacity until hover
- Click opens inline text input in that column
- Enter creates task (defaults to headless mode), then sets column status if not "new"
- Input stays open after submit for rapid entry
- Escape or blur dismisses the input
- Styled with existing surface/primary theme tokens for dark/light compatibility