### PR TITLE
feat(gui): worktree tab in project view

### DIFF
--- a/app.go
+++ b/app.go
@@ -244,6 +244,56 @@ func (a *App) DeleteProject(id string) error {
 	return a.projects.Delete(id)
 }
 
+func (a *App) ListWorktrees(projectID string) ([]project.Worktree, error) {
+	proj, err := a.projects.Get(projectID)
+	if err != nil {
+		return nil, err
+	}
+	return project.ListWorktrees(proj.ClonePath)
+}
+
+func (a *App) OpenInTerminal(path string) error {
+	clean := filepath.Clean(path)
+	if !strings.HasPrefix(clean, filepath.Clean(a.worktreesDir)) {
+		return fmt.Errorf("path not within worktrees directory")
+	}
+	if info, err := os.Stat(clean); err != nil || !info.IsDir() {
+		return fmt.Errorf("path is not a valid directory")
+	}
+	return openDirInGhostty(clean)
+}
+
+func (a *App) OpenInEditor(path string) error {
+	clean := filepath.Clean(path)
+	if !strings.HasPrefix(clean, filepath.Clean(a.worktreesDir)) {
+		return fmt.Errorf("path not within worktrees directory")
+	}
+	if info, err := os.Stat(clean); err != nil || !info.IsDir() {
+		return fmt.Errorf("path is not a valid directory")
+	}
+	return exec.Command("zed", clean).Start()
+}
+
+func openDirInGhostty(dir string) error {
+	script := fmt.Sprintf(`tell application "Ghostty"
+	activate
+	set synapseWins to (every window whose name contains "Synapse:")
+	set winCount to (count of synapseWins)
+	set cfg to new surface configuration
+	set command of cfg to "/bin/zsh -lic 'cd %s && exec zsh'"
+	if winCount > 0 then
+		new tab in (item 1 of synapseWins) with configuration cfg
+	else
+		new window with configuration cfg
+	end if
+end tell`, dir)
+	out, err := exec.Command("osascript", "-e", script).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("osascript: %w: %s", err, string(out))
+	}
+	return nil
+}
+
 func (a *App) StopAgent(agentID string) error {
 	return a.agents.StopAgent(agentID)
 }

--- a/frontend/src/components/WorktreeList.svelte
+++ b/frontend/src/components/WorktreeList.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  import type { project } from '../../wailsjs/go/models.js'
+  import { ListWorktrees, OpenInTerminal, OpenInEditor } from '../../wailsjs/go/main/App.js'
+
+  interface Props {
+    projectId: string
+  }
+
+  const { projectId }: Props = $props()
+
+  let worktrees = $state<project.Worktree[]>([])
+  let loading = $state(true)
+  let error = $state('')
+
+  $effect(() => {
+    load()
+  })
+
+  async function load() {
+    loading = true
+    error = ''
+    try {
+      worktrees = await ListWorktrees(projectId)
+    } catch (e) {
+      error = String(e)
+    } finally {
+      loading = false
+    }
+  }
+
+  async function openTerminal(path: string) {
+    try {
+      await OpenInTerminal(path)
+    } catch (e) {
+      error = String(e)
+    }
+  }
+
+  async function openEditor(path: string) {
+    try {
+      await OpenInEditor(path)
+    } catch (e) {
+      error = String(e)
+    }
+  }
+</script>
+
+{#if error}
+  <p class="text-sm text-error-500">{error}</p>
+{/if}
+
+{#if loading}
+  <p class="py-4 text-center text-sm opacity-60">Loading worktrees...</p>
+{:else if worktrees.length === 0}
+  <p class="py-4 text-center text-sm text-surface-400">No active worktrees</p>
+{:else}
+  <div class="flex flex-col gap-2">
+    {#each worktrees as wt (wt.path)}
+      <div class="flex items-center justify-between rounded-lg border border-surface-300 bg-surface-50 px-4 py-3 dark:border-surface-600 dark:bg-surface-800">
+        <div class="flex flex-col gap-1">
+          <div class="flex items-center gap-2">
+            <span class="text-sm font-medium">{wt.branch}</span>
+            <span class="rounded bg-surface-200 px-1.5 py-0.5 font-mono text-xs dark:bg-surface-700">{wt.head}</span>
+          </div>
+          {#if wt.taskId}
+            <span class="text-xs text-surface-400">Task: {wt.taskId}</span>
+          {/if}
+          <span class="font-mono text-xs text-surface-400">{wt.path}</span>
+        </div>
+
+        <div class="flex items-center gap-1">
+          <button
+            type="button"
+            class="rounded p-1.5 text-surface-500 hover:bg-surface-200 hover:text-surface-800 dark:hover:bg-surface-700 dark:hover:text-surface-200"
+            title="Open in Ghostty"
+            onclick={() => openTerminal(wt.path)}
+          >
+            <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            class="rounded p-1.5 text-surface-500 hover:bg-surface-200 hover:text-surface-800 dark:hover:bg-surface-700 dark:hover:text-surface-200"
+            title="Open in Zed"
+            onclick={() => openEditor(wt.path)}
+          >
+            <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    {/each}
+  </div>
+{/if}

--- a/frontend/src/pages/ProjectDetail.svelte
+++ b/frontend/src/pages/ProjectDetail.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
+  import { SegmentedControl } from '@skeletonlabs/skeleton-svelte'
   import type { project } from '../../wailsjs/go/models.js'
   import { projectStore } from '../stores/projects.svelte.js'
   import { taskStore } from '../stores/tasks.svelte.js'
   import TaskCard from '../components/TaskCard.svelte'
+  import WorktreeList from '../components/WorktreeList.svelte'
 
   interface Props {
     projectId: string
@@ -15,6 +17,12 @@
   let p = $state<project.Project | null>(null)
   let error = $state('')
   let deleting = $state(false)
+  let activeTab = $state('tasks')
+
+  const tabs = [
+    { value: 'tasks', label: 'Tasks' },
+    { value: 'worktrees', label: 'Worktrees' },
+  ]
 
   $effect(() => {
     loadProject()
@@ -109,36 +117,52 @@
 
       <hr class="border-surface-300 dark:border-surface-600" />
 
-      <div class="flex flex-col gap-3">
-        <div class="flex items-center justify-between">
-          <span class="text-sm font-medium text-surface-500">Tasks ({projectTasks.length})</span>
-        </div>
+      <SegmentedControl orientation="horizontal" value={activeTab} onValueChange={(details) => (activeTab = details.value ?? 'tasks')}>
+        <SegmentedControl.Control>
+          <SegmentedControl.Indicator />
+          {#each tabs as tab}
+            <SegmentedControl.Item value={tab.value}>
+              <SegmentedControl.ItemText>{tab.label}</SegmentedControl.ItemText>
+              <SegmentedControl.ItemHiddenInput />
+            </SegmentedControl.Item>
+          {/each}
+        </SegmentedControl.Control>
+      </SegmentedControl>
 
-        {#if projectTasks.length === 0}
-          <p class="py-4 text-center text-sm text-surface-400">No tasks assigned to this project</p>
-        {:else}
-          <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            {#each [
-              { key: 'todo', label: 'Todo', tasks: tasksByStatus.todo, border: 'border-t-surface-400' },
-              { key: 'inProgress', label: 'In Progress', tasks: tasksByStatus.inProgress, border: 'border-t-primary-500' },
-              { key: 'inReview', label: 'In Review', tasks: tasksByStatus.inReview, border: 'border-t-warning-500' },
-              { key: 'done', label: 'Done', tasks: tasksByStatus.done, border: 'border-t-success-500' },
-            ] as col (col.key)}
-              <div class="flex flex-col rounded-lg border-t-4 bg-surface-100 dark:bg-surface-900 {col.border}">
-                <div class="flex items-center justify-between px-3 py-2">
-                  <h3 class="text-xs font-semibold">{col.label}</h3>
-                  <span class="rounded-full bg-surface-200 px-1.5 py-0.5 text-xs dark:bg-surface-700">{col.tasks.length}</span>
-                </div>
-                <div class="flex flex-col gap-2 overflow-y-auto px-2 pb-2">
-                  {#each col.tasks as t (t.id)}
-                    <TaskCard task={t} onclick={() => onviewtask(t.id)} />
-                  {/each}
-                </div>
-              </div>
-            {/each}
+      {#if activeTab === 'tasks'}
+        <div class="flex flex-col gap-3">
+          <div class="flex items-center justify-between">
+            <span class="text-sm font-medium text-surface-500">Tasks ({projectTasks.length})</span>
           </div>
-        {/if}
-      </div>
+
+          {#if projectTasks.length === 0}
+            <p class="py-4 text-center text-sm text-surface-400">No tasks assigned to this project</p>
+          {:else}
+            <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              {#each [
+                { key: 'todo', label: 'Todo', tasks: tasksByStatus.todo, border: 'border-t-surface-400' },
+                { key: 'inProgress', label: 'In Progress', tasks: tasksByStatus.inProgress, border: 'border-t-primary-500' },
+                { key: 'inReview', label: 'In Review', tasks: tasksByStatus.inReview, border: 'border-t-warning-500' },
+                { key: 'done', label: 'Done', tasks: tasksByStatus.done, border: 'border-t-success-500' },
+              ] as col (col.key)}
+                <div class="flex flex-col rounded-lg border-t-4 bg-surface-100 dark:bg-surface-900 {col.border}">
+                  <div class="flex items-center justify-between px-3 py-2">
+                    <h3 class="text-xs font-semibold">{col.label}</h3>
+                    <span class="rounded-full bg-surface-200 px-1.5 py-0.5 text-xs dark:bg-surface-700">{col.tasks.length}</span>
+                  </div>
+                  <div class="flex flex-col gap-2 overflow-y-auto px-2 pb-2">
+                    {#each col.tasks as t (t.id)}
+                      <TaskCard task={t} onclick={() => onviewtask(t.id)} />
+                    {/each}
+                  </div>
+                </div>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      {:else if activeTab === 'worktrees'}
+        <WorktreeList projectId={projectId} />
+      {/if}
     </div>
   {:else if !error}
     <p class="text-sm opacity-60">Loading...</p>

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -50,6 +50,12 @@ export function ListTasks():Promise<Array<task.Task>>;
 
 export function ListTmuxSessions():Promise<Array<tmux.SessionInfo>>;
 
+export function ListWorktrees(arg1:string):Promise<Array<project.Worktree>>;
+
+export function OpenInEditor(arg1:string):Promise<void>;
+
+export function OpenInTerminal(arg1:string):Promise<void>;
+
 export function PlanTask(arg1:string):Promise<void>;
 
 export function RegisterSpotlightHotkey():Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -90,6 +90,18 @@ export function ListTmuxSessions() {
   return window['go']['main']['App']['ListTmuxSessions']();
 }
 
+export function ListWorktrees(arg1) {
+  return window['go']['main']['App']['ListWorktrees'](arg1);
+}
+
+export function OpenInEditor(arg1) {
+  return window['go']['main']['App']['OpenInEditor'](arg1);
+}
+
+export function OpenInTerminal(arg1) {
+  return window['go']['main']['App']['OpenInTerminal'](arg1);
+}
+
 export function PlanTask(arg1) {
   return window['go']['main']['App']['PlanTask'](arg1);
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -199,6 +199,24 @@ export namespace project {
 		    return a;
 		}
 	}
+	export class Worktree {
+	    path: string;
+	    branch: string;
+	    taskId: string;
+	    head: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new Worktree(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.path = source["path"];
+	        this.branch = source["branch"];
+	        this.taskId = source["taskId"];
+	        this.head = source["head"];
+	    }
+	}
 
 }
 

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -86,6 +86,49 @@ func CreateWorktreeExisting(barePath, worktreePath, branch string) error {
 	return nil
 }
 
+func ListWorktrees(barePath string) ([]Worktree, error) {
+	cmd := exec.Command("git", "worktree", "list", "--porcelain")
+	cmd.Dir = barePath
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git worktree list: %w", err)
+	}
+	return parseWorktreePorcelain(string(out)), nil
+}
+
+func parseWorktreePorcelain(raw string) []Worktree {
+	var result []Worktree
+	for block := range strings.SplitSeq(strings.TrimSpace(raw), "\n\n") {
+		if strings.Contains(block, "\nbare") || strings.HasSuffix(block, "\nbare") {
+			continue
+		}
+		var wt Worktree
+		for line := range strings.SplitSeq(block, "\n") {
+			switch {
+			case strings.HasPrefix(line, "worktree "):
+				wt.Path = strings.TrimPrefix(line, "worktree ")
+			case strings.HasPrefix(line, "HEAD "):
+				h := strings.TrimPrefix(line, "HEAD ")
+				if len(h) > 7 {
+					h = h[:7]
+				}
+				wt.Head = h
+			case strings.HasPrefix(line, "branch "):
+				ref := strings.TrimPrefix(line, "branch ")
+				wt.Branch = strings.TrimPrefix(ref, "refs/heads/")
+				wt.TaskID = strings.TrimPrefix(wt.Branch, "synapse/")
+				if wt.TaskID == wt.Branch {
+					wt.TaskID = ""
+				}
+			}
+		}
+		if wt.Path != "" {
+			result = append(result, wt)
+		}
+	}
+	return result
+}
+
 func RemoveWorktree(barePath, worktreePath string) error {
 	cmd := exec.Command("git", "worktree", "remove", "--force", worktreePath)
 	cmd.Dir = barePath

--- a/internal/project/model.go
+++ b/internal/project/model.go
@@ -12,3 +12,10 @@ type Project struct {
 	CreatedAt time.Time `yaml:"created_at" json:"createdAt"`
 	UpdatedAt time.Time `yaml:"updated_at" json:"updatedAt"`
 }
+
+type Worktree struct {
+	Path   string `json:"path"`
+	Branch string `json:"branch"`
+	TaskID string `json:"taskId"`
+	Head   string `json:"head"`
+}


### PR DESCRIPTION
## Motivation

Projects have worktrees created per-task but no way to see or interact with them from the GUI. This adds a worktrees tab to the project detail view with actions to open worktrees in Ghostty or Zed.

## Implementation information

**Backend:**
- `Worktree` struct in `internal/project/model.go` (path, branch, taskId, head)
- `ListWorktrees()` in `internal/project/git.go` — parses `git worktree list --porcelain`
- 3 bound methods in `app.go`: `ListWorktrees`, `OpenInTerminal`, `OpenInEditor`
- Path validation ensures only worktreesDir paths can be opened

**Frontend:**
- `SegmentedControl` tabs (Tasks/Worktrees) in `ProjectDetail.svelte`
- New `WorktreeList.svelte` component with terminal and editor action buttons