### PR TITLE
feat(spotlight): match QuickAdd UI + projects

### DIFF
--- a/app.go
+++ b/app.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -709,17 +710,30 @@ func (a *App) FetchReviews() (github.ReviewSummary, error) {
 }
 
 func (a *App) RegisterSpotlightHotkey() {
-	spotlight.OnSubmit(func(text string) {
-		a.logger.Info("spotlight.submit", "text", text)
+	spotlight.OnSubmit(func(title, projectID string) {
+		a.logger.Info("spotlight.submit", "title", title, "project", projectID)
 		go func() {
-			if _, err := a.CreateTask(text, "", "headless"); err != nil {
+			t, err := a.CreateTask(title, "", "headless")
+			if err != nil {
 				a.logger.Error("spotlight.create", "err", err)
+				return
+			}
+			if projectID != "" {
+				if _, err := a.UpdateTask(t.ID, map[string]any{"project_id": projectID}); err != nil {
+					a.logger.Error("spotlight.project", "err", err)
+				}
 			}
 		}()
 	})
 
 	if err := spotlight.Register(func() {
-		spotlight.ShowPanel(680, 72)
+		projectsJSON := "[]"
+		if projects, err := a.ListProjects(); err == nil {
+			if data, err := json.Marshal(projects); err == nil {
+				projectsJSON = string(data)
+			}
+		}
+		spotlight.ShowPanel(projectsJSON)
 	}); err != nil {
 		a.logger.Error("spotlight.register", "err", err)
 		return

--- a/internal/spotlight/spotlight_darwin.go
+++ b/internal/spotlight/spotlight_darwin.go
@@ -2,23 +2,26 @@ package spotlight
 
 /*
 #cgo CFLAGS: -x objective-c
-#cgo LDFLAGS: -framework AppKit -framework Carbon
+#cgo LDFLAGS: -framework AppKit -framework Carbon -framework WebKit
+#include <stdlib.h>
 
 int registerGlobalHotkey(void);
-void showSpotlightPanel(int width, int height);
+void showSpotlightPanel(const char *projectsJSON);
 void dismissSpotlightPanel(void);
+void resizeSpotlightPanel(int height);
 */
 import "C"
 
 import (
 	"fmt"
 	"sync"
+	"unsafe"
 )
 
 var (
 	callbackMu sync.Mutex
 	callbackFn func()
-	submitFn   func(text string)
+	submitFn   func(title, projectID string)
 )
 
 //export goHotkeyCallback
@@ -32,13 +35,14 @@ func goHotkeyCallback() {
 }
 
 //export goSpotlightSubmit
-func goSpotlightSubmit(ctext *C.char) {
-	text := C.GoString(ctext)
+func goSpotlightSubmit(ctitle, cprojectID *C.char) {
+	title := C.GoString(ctitle)
+	projectID := C.GoString(cprojectID)
 	callbackMu.Lock()
 	fn := submitFn
 	callbackMu.Unlock()
 	if fn != nil {
-		fn(text)
+		fn(title, projectID)
 	}
 }
 
@@ -55,19 +59,21 @@ func Register(callback func()) error {
 	return nil
 }
 
-// OnSubmit sets the callback invoked when user submits text in the spotlight panel.
-func OnSubmit(fn func(text string)) {
+// OnSubmit sets the callback invoked when user submits in the spotlight panel.
+func OnSubmit(fn func(title, projectID string)) {
 	callbackMu.Lock()
 	submitFn = fn
 	callbackMu.Unlock()
 }
 
-// ShowPanel shows the spotlight overlay panel on the current screen.
-func ShowPanel(width, height int) {
-	C.showSpotlightPanel(C.int(width), C.int(height))
+// ShowPanel shows the spotlight panel with the given projects JSON array.
+func ShowPanel(projectsJSON string) {
+	cstr := C.CString(projectsJSON)
+	defer C.free(unsafe.Pointer(cstr))
+	C.showSpotlightPanel(cstr)
 }
 
-// DismissPanel hides the spotlight panel and returns focus.
+// DismissPanel hides the spotlight panel.
 func DismissPanel() {
 	C.dismissSpotlightPanel()
 }

--- a/internal/spotlight/spotlight_darwin.m
+++ b/internal/spotlight/spotlight_darwin.m
@@ -1,9 +1,13 @@
 #import <AppKit/AppKit.h>
 #import <Carbon/Carbon.h>
+#import <WebKit/WebKit.h>
 
 // Forward declarations of Go callbacks.
 extern void goHotkeyCallback(void);
-extern void goSpotlightSubmit(char *text);
+extern void goSpotlightSubmit(const char *title, const char *projectID);
+
+// Forward declarations.
+void resizeSpotlightPanel(int height);
 
 // --- Hotkey ---
 
@@ -26,9 +30,8 @@ int registerGlobalHotkey(void) {
 	return (int)status;
 }
 
-// --- Spotlight Panel ---
+// --- Spotlight Panel with WKWebView ---
 
-// Subclass so borderless nonactivating panel can still become key and receive keyboard.
 @interface SpotlightPanel : NSPanel
 @end
 
@@ -37,59 +40,61 @@ int registerGlobalHotkey(void) {
 - (BOOL)canBecomeMainWindow { return NO; }
 @end
 
-// Text field delegate: Enter submits, Escape dismisses.
-@interface SpotlightFieldDelegate : NSObject <NSTextFieldDelegate>
-@property (nonatomic, assign) SpotlightPanel *panel;
+@interface SpotlightController : NSObject <WKScriptMessageHandler>
+@property (nonatomic, strong) SpotlightPanel *panel;
+@property (nonatomic, strong) WKWebView *webView;
 @end
 
-@implementation SpotlightFieldDelegate
+@implementation SpotlightController
 
-- (BOOL)control:(NSControl *)control textView:(NSTextView *)textView doCommandBySelector:(SEL)commandSelector {
-	(void)textView;
-	if (commandSelector == @selector(insertNewline:)) {
-		NSString *text = [control stringValue];
-		if ([text length] > 0) {
-			goSpotlightSubmit((char *)[text UTF8String]);
+- (void)userContentController:(WKUserContentController *)controller didReceiveScriptMessage:(WKScriptMessage *)message {
+	(void)controller;
+	if (![message.name isEqualToString:@"spotlight"]) return;
+
+	NSDictionary *body = message.body;
+	NSString *action = body[@"action"];
+
+	if ([action isEqualToString:@"resize"]) {
+		NSNumber *h = body[@"height"];
+		if (h) resizeSpotlightPanel([h intValue]);
+		return;
+	} else if ([action isEqualToString:@"submit"]) {
+		NSString *title = body[@"title"] ?: @"";
+		NSString *projectID = body[@"projectId"] ?: @"";
+		if ([title length] > 0) {
+			goSpotlightSubmit([title UTF8String], [projectID UTF8String]);
 		}
-		[self dismissPanel];
-		return YES;
+		[self dismiss];
+	} else if ([action isEqualToString:@"dismiss"]) {
+		[self dismiss];
 	}
-	if (commandSelector == @selector(cancelOperation:)) {
-		[self dismissPanel];
-		return YES;
-	}
-	return NO;
 }
 
-- (void)dismissPanel {
+- (void)dismiss {
 	if (self.panel) {
 		[self.panel orderOut:nil];
-		self.panel = nil;
 	}
 }
 
 @end
 
 static SpotlightPanel *spotlightPanel = nil;
-static SpotlightFieldDelegate *fieldDelegate = nil;
-static char previousBundleID[256] = {0};
+static SpotlightController *spotlightCtrl = nil;
 
-void showSpotlightPanel(int width, int height) {
+static NSString *spotlightHTML(void);
+
+void showSpotlightPanel(const char *projectsJSON) {
+	NSString *json = [NSString stringWithUTF8String:projectsJSON];
+
 	dispatch_async(dispatch_get_main_queue(), ^{
-		// Remember the currently focused app.
-		NSRunningApplication *frontApp = [[NSWorkspace sharedWorkspace] frontmostApplication];
-		if (frontApp && [frontApp bundleIdentifier]) {
-			strlcpy(previousBundleID, [[frontApp bundleIdentifier] UTF8String], sizeof(previousBundleID));
-		} else {
-			previousBundleID[0] = '\0';
-		}
-
-		// If panel already visible, dismiss it (toggle).
+		// Toggle off if visible.
 		if (spotlightPanel && [spotlightPanel isVisible]) {
 			[spotlightPanel orderOut:nil];
-			spotlightPanel = nil;
 			return;
 		}
+
+		int width = 512;
+		int height = 120;
 
 		// Find screen with mouse cursor.
 		NSPoint mouseLoc = [NSEvent mouseLocation];
@@ -101,14 +106,17 @@ void showSpotlightPanel(int width, int height) {
 			}
 		}
 
-		// Position: centered horizontally, near top of screen.
 		NSRect screenFrame = [targetScreen frame];
 		CGFloat x = screenFrame.origin.x + (screenFrame.size.width - width) / 2;
 		CGFloat y = screenFrame.origin.y + screenFrame.size.height * 0.70;
 		NSRect panelFrame = NSMakeRect(x, y, width, height);
 
-		// Create nonactivating panel — receives keyboard WITHOUT activating the app.
-		// NSWindowStyleMaskNonactivatingPanel MUST be set at init time.
+		// Create controller if needed.
+		if (!spotlightCtrl) {
+			spotlightCtrl = [[SpotlightController alloc] init];
+		}
+
+		// Create panel.
 		spotlightPanel = [[SpotlightPanel alloc]
 			initWithContentRect:panelFrame
 			styleMask:NSWindowStyleMaskBorderless | NSWindowStyleMaskNonactivatingPanel
@@ -121,46 +129,44 @@ void showSpotlightPanel(int width, int height) {
 			NSWindowCollectionBehaviorStationary |
 			NSWindowCollectionBehaviorIgnoresCycle];
 		[spotlightPanel setLevel:kCGScreenSaverWindowLevel - 1];
-		[spotlightPanel setBackgroundColor:[NSColor colorWithRed:0.12 green:0.14 blue:0.18 alpha:0.95]];
+		[spotlightPanel setBackgroundColor:[NSColor clearColor]];
 		[spotlightPanel setOpaque:NO];
 		[spotlightPanel setHasShadow:YES];
 		[spotlightPanel setHidesOnDeactivate:NO];
 		[spotlightPanel setFloatingPanel:YES];
 
-		// Round corners.
-		[spotlightPanel.contentView setWantsLayer:YES];
+		spotlightCtrl.panel = spotlightPanel;
+
+		// Create WKWebView.
+		WKWebViewConfiguration *config = [[WKWebViewConfiguration alloc] init];
+		[config.userContentController addScriptMessageHandler:spotlightCtrl name:@"spotlight"];
+		// Inject project data.
+		NSString *initScript = [NSString stringWithFormat:@"window.__PROJECTS__ = %@;", json];
+		WKUserScript *userScript = [[WKUserScript alloc]
+			initWithSource:initScript
+			injectionTime:WKUserScriptInjectionTimeAtDocumentStart
+			forMainFrameOnly:YES];
+		[config.userContentController addUserScript:userScript];
+
+		NSRect webFrame = NSMakeRect(0, 0, width, height);
+		WKWebView *webView = [[WKWebView alloc] initWithFrame:webFrame configuration:config];
+		[webView setValue:@NO forKey:@"drawsBackground"];
+		webView.wantsLayer = YES;
+		webView.layer.cornerRadius = 12;
+		webView.layer.masksToBounds = YES;
+
+		spotlightCtrl.webView = webView;
+
+		spotlightPanel.contentView = webView;
+		spotlightPanel.contentView.wantsLayer = YES;
 		spotlightPanel.contentView.layer.cornerRadius = 12;
 		spotlightPanel.contentView.layer.masksToBounds = YES;
 
-		// Create text field.
-		NSTextField *field = [[NSTextField alloc] initWithFrame:NSMakeRect(16, 16, width - 32, height - 32)];
-		[field setFont:[NSFont systemFontOfSize:20 weight:NSFontWeightRegular]];
-		[field setTextColor:[NSColor whiteColor]];
-		[field setBackgroundColor:[NSColor clearColor]];
-		[field setFocusRingType:NSFocusRingTypeNone];
-		[field setBordered:NO];
-		[field setBezeled:NO];
-		[[field cell] setPlaceholderAttributedString:
-			[[NSAttributedString alloc]
-				initWithString:@"New task..."
-				attributes:@{
-					NSForegroundColorAttributeName: [NSColor colorWithWhite:0.5 alpha:1.0],
-					NSFontAttributeName: [NSFont systemFontOfSize:20 weight:NSFontWeightRegular]
-				}]];
+		[webView loadHTMLString:spotlightHTML() baseURL:nil];
 
-		// Set delegate for Enter/Escape handling.
-		if (!fieldDelegate) {
-			fieldDelegate = [[SpotlightFieldDelegate alloc] init];
-		}
-		fieldDelegate.panel = spotlightPanel;
-		[field setDelegate:fieldDelegate];
-
-		[[spotlightPanel contentView] addSubview:field];
-
-		// Show panel and focus field. NO app activation — nonactivating panel handles keyboard.
 		[spotlightPanel orderFrontRegardless];
 		[spotlightPanel makeKeyWindow];
-		[spotlightPanel makeFirstResponder:field];
+		[spotlightPanel makeFirstResponder:webView];
 	});
 }
 
@@ -168,7 +174,206 @@ void dismissSpotlightPanel(void) {
 	dispatch_async(dispatch_get_main_queue(), ^{
 		if (spotlightPanel) {
 			[spotlightPanel orderOut:nil];
-			spotlightPanel = nil;
 		}
 	});
+}
+
+void resizeSpotlightPanel(int height) {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		if (!spotlightPanel || ![spotlightPanel isVisible]) return;
+		NSRect frame = [spotlightPanel frame];
+		CGFloat dy = height - frame.size.height;
+		frame.origin.y -= dy;
+		frame.size.height = height;
+		[spotlightPanel setFrame:frame display:YES animate:NO];
+	});
+}
+
+static NSString *spotlightHTML(void) {
+	return @"<!DOCTYPE html>"
+	"<html><head><meta charset='utf-8'>"
+	"<style>"
+	"*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }"
+	"html, body { background: transparent; font-family: -apple-system, BlinkMacSystemFont, sans-serif; color: #e2e2e8; }"
+	"body { border: 1px solid rgba(140,120,170,0.35); border-radius: 12px; background: rgba(45,38,65,0.97); overflow: hidden; }"
+	""
+	"#title-row { position: relative; }"
+	"#highlight { position: absolute; inset: 0; overflow: hidden; white-space: pre; padding: 14px 20px; font-size: 16px; color: transparent; pointer-events: none; line-height: 1.4; }"
+	"#highlight mark { background: rgba(139,92,246,0.3); color: transparent; border-radius: 3px; }"
+	"#title { display: block; width: 100%; border: none; outline: none; background: transparent; padding: 14px 20px; font-size: 16px; color: #e2e2e8; line-height: 1.4; }"
+	"#title::placeholder { color: rgba(160,150,180,0.55); }"
+	""
+	"#project-row { border-top: 1px solid rgba(140,120,170,0.2); padding: 8px 20px; display: none; align-items: center; gap: 8px; font-size: 12px; color: rgba(160,150,180,0.7); }"
+	"#project-row.visible { display: flex; }"
+	""
+	".folder-icon { width: 14px; height: 14px; flex-shrink: 0; opacity: 0.5; }"
+	""
+	".chip { display: inline-flex; align-items: center; gap: 4px; background: rgba(139,92,246,0.15); color: rgba(180,160,220,0.9); padding: 2px 8px; border-radius: 6px; font-weight: 500; font-size: 12px; }"
+	".chip button { background: none; border: none; color: inherit; cursor: pointer; padding: 0; margin-left: 2px; opacity: 0.7; font-size: 11px; }"
+	".chip button:hover { opacity: 1; }"
+	""
+	"#project-search { display: none; border: none; outline: none; background: transparent; font-size: 12px; color: #e2e2e8; flex: 1; }"
+	"#project-search::placeholder { color: rgba(160,150,180,0.55); }"
+	"#project-search.visible { display: block; }"
+	""
+	"#dropdown { display: none; position: absolute; bottom: 100%; left: 0; width: 100%; max-height: 192px; overflow-y: auto; background: rgba(50,42,72,0.98); border: 1px solid rgba(140,120,170,0.3); border-radius: 8px; margin-bottom: 4px; }"
+	"#dropdown.visible { display: block; }"
+	"#dropdown button { display: flex; width: 100%; align-items: center; gap: 8px; padding: 6px 16px; border: none; background: none; color: #e2e2e8; font-size: 12px; cursor: pointer; text-align: left; }"
+	"#dropdown button:hover { background: rgba(139,92,246,0.12); }"
+	".no-match { padding: 6px 16px; font-size: 12px; color: rgba(160,150,180,0.5); }"
+	"</style></head><body>"
+	""
+	"<div id='title-row'>"
+	"  <div id='highlight'></div>"
+	"  <input id='title' type='text' placeholder='Task title, link, or note...' autocomplete='off' spellcheck='false' />"
+	"</div>"
+	"<div id='project-row'>"
+	"  <svg class='folder-icon' fill='none' stroke='currentColor' viewBox='0 0 24 24'><path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z'/></svg>"
+	"  <span id='chip-area'></span>"
+	"  <span id='match-hint'></span>"
+	"  <input id='project-search' type='text' placeholder='Project (optional)...' autocomplete='off' />"
+	"  <div id='dropdown'></div>"
+	"</div>"
+	""
+	"<script>"
+	"const projects = window.__PROJECTS__ || [];"
+	"const titleInput = document.getElementById('title');"
+	"const highlight = document.getElementById('highlight');"
+	"const projectRow = document.getElementById('project-row');"
+	"const chipArea = document.getElementById('chip-area');"
+	"const matchHint = document.getElementById('match-hint');"
+	"const projectSearch = document.getElementById('project-search');"
+	"const dropdown = document.getElementById('dropdown');"
+	""
+	"let selectedProject = null;"
+	"let userOverrode = false;"
+	"let dropdownOpen = false;"
+	""
+	"const ghRe = /(?:https?:\\/\\/)?github\\.com\\/(([^\\/\\s]+)\\/([^\\/\\s#?]+))/gi;"
+	""
+	"function detectProject(input) {"
+	"  if (!input || projects.length === 0) return null;"
+	"  for (const m of input.matchAll(ghRe)) {"
+	"    const owner = m[2].toLowerCase();"
+	"    const repo = m[3].replace(/\\.git$/, '').toLowerCase();"
+	"    const found = projects.find(p => p.owner.toLowerCase() === owner && p.repo.toLowerCase() === repo);"
+	"    if (found) {"
+	"      const s = m.index + m[0].indexOf(m[1]);"
+	"      return { project: found, matchType: 'url', matchStart: s, matchEnd: s + m[1].length };"
+	"    }"
+	"  }"
+	"  const words = input.split(/[\\s,;:!?()\\[\\]{}]+/).filter(Boolean);"
+	"  for (const word of words) {"
+	"    const w = word.toLowerCase();"
+	"    const found = projects.find(p => p.repo.toLowerCase() === w || p.name.toLowerCase() === w);"
+	"    if (found) {"
+	"      const idx = input.indexOf(word);"
+	"      return { project: found, matchType: 'name', matchStart: idx, matchEnd: idx + word.length };"
+	"    }"
+	"  }"
+	"  return null;"
+	"}"
+	""
+	"function esc(s) { const d = document.createElement('span'); d.textContent = s; return d.innerHTML; }"
+	""
+	"function updateHighlight() {"
+	"  const val = titleInput.value;"
+	"  const det = detectProject(val);"
+	"  if (det && !userOverrode) {"
+	"    selectedProject = det.project.id;"
+	"    const before = esc(val.slice(0, det.matchStart));"
+	"    const match = esc(val.slice(det.matchStart, det.matchEnd));"
+	"    const after = esc(val.slice(det.matchEnd));"
+	"    highlight.innerHTML = before + '<mark>' + match + '</mark>' + after;"
+	"  } else {"
+	"    highlight.innerHTML = '';"
+	"    if (!userOverrode) selectedProject = null;"
+	"  }"
+	"  updateProjectRow();"
+	"}"
+	""
+	"function updateProjectRow() {"
+	"  if (projects.length === 0) { projectRow.classList.remove('visible'); resize(); return; }"
+	"  projectRow.classList.add('visible');"
+	"  const det = detectProject(titleInput.value);"
+	""
+	"  if (det && !userOverrode) {"
+	"    chipArea.innerHTML = '<span class=\"chip\">' + esc(det.project.owner + '/' + det.project.repo)"
+	"      + ' <button onclick=\"dismissDetection()\">&times;</button></span>';"
+	"    matchHint.textContent = 'from ' + (det.matchType === 'url' ? 'link' : 'title');"
+	"    projectSearch.classList.remove('visible');"
+	"    dropdown.classList.remove('visible');"
+	"  } else if (selectedProject && userOverrode) {"
+	"    const p = projects.find(pr => pr.id === selectedProject);"
+	"    chipArea.innerHTML = '<span class=\"chip\">' + esc(p ? p.id : selectedProject)"
+	"      + ' <button onclick=\"clearManual()\">&times;</button></span>';"
+	"    matchHint.textContent = '';"
+	"    projectSearch.classList.remove('visible');"
+	"    dropdown.classList.remove('visible');"
+	"  } else {"
+	"    chipArea.innerHTML = '';"
+	"    matchHint.textContent = '';"
+	"    projectSearch.classList.add('visible');"
+	"  }"
+	"  resize();"
+	"}"
+	""
+	"function resize() {"
+	"  const h = document.body.offsetHeight;"
+	"  window.webkit.messageHandlers.spotlight.postMessage({ action: 'resize', height: h });"
+	"}"
+	""
+	"function dismissDetection() { selectedProject = null; userOverrode = true; updateHighlight(); titleInput.focus(); }"
+	"function clearManual() { selectedProject = null; userOverrode = false; updateHighlight(); titleInput.focus(); }"
+	""
+	"function selectManual(id) { selectedProject = id; userOverrode = true; dropdownOpen = false; projectSearch.value = ''; updateProjectRow(); titleInput.focus(); }"
+	""
+	"function renderDropdown() {"
+	"  const q = projectSearch.value.toLowerCase();"
+	"  const filtered = projects.filter(p => !q || p.id.toLowerCase().includes(q) || p.name.toLowerCase().includes(q));"
+	"  if (filtered.length === 0) {"
+	"    dropdown.innerHTML = '<div class=\"no-match\">No matches</div>';"
+	"  } else {"
+	"    dropdown.innerHTML = filtered.map(p =>"
+	"      '<button onmousedown=\"selectManual(\\'' + esc(p.id) + '\\')\">' +"
+	"      '<svg class=\"folder-icon\" fill=\"none\" stroke=\"currentColor\" viewBox=\"0 0 24 24\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z\"/></svg>' +"
+	"      esc(p.owner + '/' + p.repo) + '</button>'"
+	"    ).join('');"
+	"  }"
+	"  dropdown.classList.toggle('visible', dropdownOpen);"
+	"  resize();"
+	"}"
+	""
+	"titleInput.addEventListener('input', updateHighlight);"
+	""
+	"titleInput.addEventListener('keydown', function(e) {"
+	"  if (e.key === 'Enter') {"
+	"    e.preventDefault();"
+	"    const title = titleInput.value.trim();"
+	"    if (title) {"
+	"      window.webkit.messageHandlers.spotlight.postMessage({ action: 'submit', title: title, projectId: selectedProject || '' });"
+	"    }"
+	"  } else if (e.key === 'Escape') {"
+	"    e.preventDefault();"
+	"    window.webkit.messageHandlers.spotlight.postMessage({ action: 'dismiss' });"
+	"  } else if (e.key === 'Tab' && projects.length > 0) {"
+	"    e.preventDefault();"
+	"    projectSearch.classList.add('visible');"
+	"    projectSearch.focus();"
+	"  }"
+	"});"
+	""
+	"projectSearch.addEventListener('focus', function() { dropdownOpen = true; renderDropdown(); });"
+	"projectSearch.addEventListener('blur', function() { setTimeout(function() { dropdownOpen = false; dropdown.classList.remove('visible'); resize(); }, 150); });"
+	"projectSearch.addEventListener('input', renderDropdown);"
+	"projectSearch.addEventListener('keydown', function(e) {"
+	"  if (e.key === 'Escape') { e.preventDefault(); dropdownOpen = false; dropdown.classList.remove('visible'); titleInput.focus(); resize(); }"
+	"  else if (e.key === 'Enter') { e.preventDefault(); titleInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' })); }"
+	"});"
+	""
+	"titleInput.focus();"
+	"updateProjectRow();"
+	"setTimeout(resize, 0);"
+	"</script>"
+	"</body></html>";
 }

--- a/internal/spotlight/spotlight_other.go
+++ b/internal/spotlight/spotlight_other.go
@@ -8,6 +8,6 @@ func Register(_ func()) error {
 	return fmt.Errorf("global hotkey not supported on this platform")
 }
 
-func OnSubmit(_ func(string)) {}
-func ShowPanel(_, _ int)      {}
-func DismissPanel()           {}
+func OnSubmit(_ func(string, string)) {}
+func ShowPanel(_ string)              {}
+func DismissPanel()                   {}


### PR DESCRIPTION
## Motivation

Spotlight panel (Ctrl+Space) was a bare native text field with no project support. Should match the QuickAdd modal (Cmd+N) in both look and functionality.

## Implementation information

Replace the native `NSTextField` in the spotlight `NSPanel` with a `WKWebView` that renders the same UI as QuickAdd:

- **Title input** with highlight overlay for detected projects
- **Project auto-detection** from GitHub URLs and repo names (same regex logic as `detectProject.ts`)
- **Project search dropdown** — Tab to focus, type to filter, click to select
- **Auto-detected / manual chips** with dismiss buttons
- **Dynamic panel resize** via `WKScriptMessageHandler` → native `resizeSpotlightPanel`
- Project list passed as JSON from Go on each hotkey press
- Submit now sends both title and projectID; `app.go` creates task + assigns project

Kept: non-activating NSPanel, global Ctrl+Space hotkey, toggle behavior.