### PR TITLE
fix(agents): restrict triage scope + add logging

### DIFF
--- a/.claude/skills/synapse-triage.md
+++ b/.claude/skills/synapse-triage.md
@@ -13,6 +13,13 @@ Triage incoming tasks: analyze content, assign tags, set appropriate agent mode,
 
 The ONLY valid flags for `synapse-cli update` are: `--title`, `--status`, `--body`, `--mode`, `--tags`, `--project`. Do NOT use `--agent-mode` or any other flag — they do not exist and will error.
 
+## Constraints
+
+- Do NOT explore the codebase, read source files, or spawn sub-agents
+- Triage based on title, body, and URL context only
+- Keep total cost under $0.05 per task
+- Code exploration happens during planning/implementation, not triage
+
 ## Process
 
 ### 1. List pending tasks

--- a/app.go
+++ b/app.go
@@ -134,7 +134,12 @@ func (a *App) UpdateTask(id string, updates map[string]any) (task.Task, error) {
 }
 
 func (a *App) DeleteTask(id string) error {
-	return a.tasks.Delete(id)
+	a.logger.Info("task.delete", "task_id", id)
+	if err := a.tasks.Delete(id); err != nil {
+		a.logger.Error("task.delete.failed", "task_id", id, "err", err)
+		return err
+	}
+	return nil
 }
 
 func (a *App) StartAgent(taskID, mode, prompt string) (*agent.Agent, error) {
@@ -238,11 +243,23 @@ func (a *App) GetProject(id string) (project.Project, error) {
 }
 
 func (a *App) CreateProject(url string) (project.Project, error) {
-	return a.projects.Create(url)
+	a.logger.Info("project.create", "url", url)
+	p, err := a.projects.Create(url)
+	if err != nil {
+		a.logger.Error("project.create.failed", "url", url, "err", err)
+		return p, err
+	}
+	a.logger.Info("project.created", "id", p.ID, "url", url)
+	return p, nil
 }
 
 func (a *App) DeleteProject(id string) error {
-	return a.projects.Delete(id)
+	a.logger.Info("project.delete", "id", id)
+	if err := a.projects.Delete(id); err != nil {
+		a.logger.Error("project.delete.failed", "id", id, "err", err)
+		return err
+	}
+	return nil
 }
 
 func (a *App) ListWorktrees(projectID string) ([]project.Worktree, error) {
@@ -331,6 +348,7 @@ func (a *App) ListTmuxSessions() ([]tmux.SessionInfo, error) {
 }
 
 func (a *App) KillTmuxSession(name string) error {
+	a.logger.Info("tmux.kill", "session", name)
 	return a.tmux.KillSession(name)
 }
 
@@ -516,7 +534,8 @@ func (a *App) TriageTask(id string) error {
 
 	a.logger.Info("triage.start", "task_id", t.ID, "title", t.Title, "dir", dir)
 
-	ag, err := a.agents.StartAgentInDir(t.ID, "triage:"+t.Title, "headless", prompt, nil, dir)
+	triageTools := []string{"Bash", "Read", "Skill"}
+	ag, err := a.agents.StartAgentInDir(t.ID, "triage:"+t.Title, "headless", prompt, triageTools, dir)
 	if err != nil {
 		return err
 	}
@@ -674,6 +693,7 @@ func (a *App) ApprovePlan(id string) (task.Task, error) {
 	if t.Status != task.StatusPlanReview {
 		return task.Task{}, fmt.Errorf("task %s status is %q, expected 'plan-review'", id, t.Status)
 	}
+	a.logger.Info("plan.approve", "task_id", id, "title", t.Title)
 	return a.tasks.Update(id, map[string]any{
 		"status": string(task.StatusTodo),
 	})
@@ -687,6 +707,7 @@ func (a *App) RejectPlan(id, feedback string) (task.Task, error) {
 	if t.Status != task.StatusPlanReview {
 		return task.Task{}, fmt.Errorf("task %s status is %q, expected 'plan-review'", id, t.Status)
 	}
+	a.logger.Info("plan.reject", "task_id", id, "title", t.Title, "has_feedback", feedback != "")
 	body := t.Body
 	if feedback != "" {
 		body += "\n\n## Plan Feedback\n\n" + feedback

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -62,10 +62,13 @@ func (w *Watcher) loop(ctx context.Context, fw *fsnotify.Watcher) {
 
 			switch {
 			case event.Has(fsnotify.Create):
+				w.logger.Info("watcher.event", "op", "created", "file", event.Name)
 				w.emit("task:created", event.Name)
 			case event.Has(fsnotify.Write):
+				w.logger.Debug("watcher.event", "op", "updated", "file", event.Name)
 				w.emit("task:updated", event.Name)
 			case event.Has(fsnotify.Remove):
+				w.logger.Info("watcher.event", "op", "deleted", "file", event.Name)
 				w.emit("task:deleted", event.Name)
 			}
 


### PR DESCRIPTION
## Motivation

Triage agents were doing excessive codebase exploration (30+ tool calls, $0.38/task) when they only need title/body/URL to categorize tasks. Also, several mutation operations (delete task/project, plan approve/reject) had zero logging, making it impossible to trace what happened (e.g. a task file disappeared with no audit trail).

## Implementation information

**Triage scope restriction:**
- `TriageTask()` now passes `["Bash", "Read", "Skill"]` as allowed_tools instead of `nil` (which meant all tools + `--dangerously-skip-permissions`)
- Added constraints section to `synapse-triage.md` skill: no codebase exploration, no sub-agents, cost target <$0.05

**Audit logging added to:**
- `DeleteTask` — logs task_id before delete
- `CreateProject` / `DeleteProject` — logs url/id
- `ApprovePlan` / `RejectPlan` — logs task_id + title
- `KillTmuxSession` — logs session name
- Watcher fs events — logs create/delete (INFO), update (DEBUG)