### PR TITLE
feat(worktree): human-readable dir names

### DIFF
--- a/app.go
+++ b/app.go
@@ -188,11 +188,11 @@ func (a *App) prepareWorktree(t task.Task) (string, error) {
 		return "", fmt.Errorf("default branch: %w", err)
 	}
 
-	wtPath := filepath.Join(a.worktreesDir, t.ID)
+	wtPath := filepath.Join(a.worktreesDir, t.DirName())
 	if _, statErr := os.Stat(wtPath); statErr == nil {
 		return wtPath, nil
 	}
-	wtBranch := "synapse/" + t.ID
+	wtBranch := "synapse/" + t.DirName()
 	if err := project.CreateWorktree(proj.ClonePath, wtPath, wtBranch, branch); err != nil {
 		// Branch may exist from a previous run — try checkout instead of new branch
 		if errRe := project.CreateWorktreeExisting(proj.ClonePath, wtPath, wtBranch); errRe != nil {
@@ -208,13 +208,12 @@ func (a *App) cleanupWorktree(ag *agent.Agent) {
 	if ag.TaskID == "" {
 		return
 	}
-	wtPath := filepath.Join(a.worktreesDir, ag.TaskID)
-	if _, err := os.Stat(wtPath); err != nil {
-		return
-	}
-
 	t, err := a.tasks.Get(ag.TaskID)
 	if err != nil || t.ProjectID == "" {
+		return
+	}
+	wtPath := filepath.Join(a.worktreesDir, t.DirName())
+	if _, err := os.Stat(wtPath); err != nil {
 		return
 	}
 	proj, err := a.projects.Get(t.ProjectID)

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -116,9 +116,13 @@ func parseWorktreePorcelain(raw string) []Worktree {
 			case strings.HasPrefix(line, "branch "):
 				ref := strings.TrimPrefix(line, "branch ")
 				wt.Branch = strings.TrimPrefix(ref, "refs/heads/")
-				wt.TaskID = strings.TrimPrefix(wt.Branch, "synapse/")
-				if wt.TaskID == wt.Branch {
-					wt.TaskID = ""
+				if name, ok := strings.CutPrefix(wt.Branch, "synapse/"); ok {
+					// Task ID is always the last 8 chars (uuid[:8])
+					if len(name) >= 8 {
+						wt.TaskID = name[len(name)-8:]
+					} else {
+						wt.TaskID = name
+					}
 				}
 			}
 		}

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -203,6 +203,55 @@ func TestCreateAndRemoveWorktree(t *testing.T) {
 	}
 }
 
+func TestParseWorktreePorcelain(t *testing.T) {
+	tests := []struct {
+		name       string
+		raw        string
+		wantLen    int
+		wantTaskID string
+		wantBranch string
+	}{
+		{
+			name:    "old format bare id",
+			raw:     "worktree /tmp/wt\nHEAD abc1234567890\nbranch refs/heads/synapse/a1b2c3d4\n",
+			wantLen: 1, wantTaskID: "a1b2c3d4", wantBranch: "synapse/a1b2c3d4",
+		},
+		{
+			name:    "new format slug-id",
+			raw:     "worktree /tmp/wt\nHEAD abc1234567890\nbranch refs/heads/synapse/implement-auth-a1b2c3d4\n",
+			wantLen: 1, wantTaskID: "a1b2c3d4", wantBranch: "synapse/implement-auth-a1b2c3d4",
+		},
+		{
+			name:    "non-synapse branch",
+			raw:     "worktree /tmp/wt\nHEAD abc1234567890\nbranch refs/heads/feature/foo\n",
+			wantLen: 1, wantTaskID: "", wantBranch: "feature/foo",
+		},
+		{
+			name:    "bare entry skipped",
+			raw:     "worktree /tmp/bare.git\nbare\n",
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseWorktreePorcelain(tt.raw)
+			if len(got) != tt.wantLen {
+				t.Fatalf("len = %d, want %d", len(got), tt.wantLen)
+			}
+			if tt.wantLen == 0 {
+				return
+			}
+			if got[0].TaskID != tt.wantTaskID {
+				t.Errorf("TaskID = %q, want %q", got[0].TaskID, tt.wantTaskID)
+			}
+			if got[0].Branch != tt.wantBranch {
+				t.Errorf("Branch = %q, want %q", got[0].Branch, tt.wantBranch)
+			}
+		})
+	}
+}
+
 func TestCreateWorktreeInvalidBase(t *testing.T) {
 	if !hasGit() {
 		t.Skip("git not available")

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -27,6 +27,7 @@ type AgentRun struct {
 
 type Task struct {
 	ID           string     `yaml:"id" json:"id"`
+	Slug         string     `yaml:"slug,omitempty" json:"slug"`
 	Title        string     `yaml:"title" json:"title"`
 	Status       Status     `yaml:"status" json:"status"`
 	AgentMode    string     `yaml:"agent_mode" json:"agentMode"`
@@ -39,4 +40,11 @@ type Task struct {
 
 	Body     string `yaml:"-" json:"body"`
 	FilePath string `yaml:"-" json:"filePath"`
+}
+
+func (t Task) DirName() string {
+	if t.Slug == "" {
+		return t.ID
+	}
+	return t.Slug + "-" + t.ID
 }

--- a/internal/task/slug.go
+++ b/internal/task/slug.go
@@ -1,0 +1,31 @@
+package task
+
+import (
+	"regexp"
+	"strings"
+)
+
+var nonAlnum = regexp.MustCompile(`[^a-z0-9]+`)
+
+// Slugify converts a title into a filesystem-safe slug.
+// Returns "task" for empty or all-special-character inputs.
+func Slugify(title string) string {
+	s := strings.ToLower(title)
+	s = nonAlnum.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+
+	if s == "" {
+		return "task"
+	}
+
+	const maxLen = 40
+	if len(s) <= maxLen {
+		return s
+	}
+
+	s = s[:maxLen]
+	if i := strings.LastIndex(s, "-"); i > 0 {
+		s = s[:i]
+	}
+	return s
+}

--- a/internal/task/slug_test.go
+++ b/internal/task/slug_test.go
@@ -1,0 +1,35 @@
+package task
+
+import "testing"
+
+func TestSlugify(t *testing.T) {
+	tests := []struct {
+		title string
+		want  string
+	}{
+		{"Implement auth middleware", "implement-auth-middleware"},
+		{"Fix bug #42 (urgent!)", "fix-bug-42-urgent"},
+		{"refactor", "refactor"},
+		{"--hello world--", "hello-world"},
+		{"", "task"},
+		{"   ", "task"},
+		{"!!!@@@", "task"},
+		{"Deploy to production 🚀", "deploy-to-production"},
+		{
+			"This is a very long task title that exceeds the maximum allowed slug length",
+			"this-is-a-very-long-task-title-that",
+		},
+		{"a-b", "a-b"},
+		{"UPPER case MIX", "upper-case-mix"},
+		{"multiple   spaces   here", "multiple-spaces-here"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			got := Slugify(tt.title)
+			if got != tt.want {
+				t.Errorf("Slugify(%q) = %q, want %q", tt.title, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -59,8 +59,10 @@ func (s *Store) Create(title, body, mode string) (Task, error) {
 		mode = "interactive"
 	}
 	now := time.Now().UTC()
+	id := uuid.NewString()[:8]
 	t := Task{
-		ID:        uuid.NewString()[:8],
+		ID:        id,
+		Slug:      Slugify(title),
 		Title:     title,
 		Status:    StatusNew,
 		AgentMode: mode,


### PR DESCRIPTION
## Motivation

Worktree directories and branch names used bare 8-char UUIDs (e.g. `a1b2c3d4`), making them hard to identify in terminal, file manager, and GUI.

## Implementation information

- Added `Slugify()` utility that converts task title to filesystem-safe slug (lowercase, hyphens, max 40 chars)
- Added `Slug` field to Task model, computed once at creation time (immutable after that)
- `DirName()` method returns `{slug}-{id}` pattern, e.g. `implement-auth-middleware-a1b2c3d4`
- Branch parsing extracts task ID from last 8 chars, supporting both old (`synapse/{id}`) and new (`synapse/{slug}-{id}`) formats
- Old tasks without slug fall back to bare ID for backward compatibility