### PR TITLE
feat(gui): remove inbox column, rename tab

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -136,7 +136,7 @@
         <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
         </svg>
-        <Navigation.TriggerText>Tasks</Navigation.TriggerText>
+        <Navigation.TriggerText>Board</Navigation.TriggerText>
       </Navigation.Trigger>
       <Navigation.Trigger
         onclick={() => (page = { kind: 'agent-list' })}

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -21,7 +21,6 @@
   }
 
   const columns = [
-    { status: 'new', label: 'Inbox', border: 'border-t-tertiary-500 dark:border-t-tertiary-400' },
     { status: 'todo', label: 'Todo', border: 'border-t-surface-400 dark:border-t-surface-500' },
     { status: 'in-progress', label: 'In Progress', border: 'border-t-primary-500 dark:border-t-primary-400' },
     { status: 'in-review', label: 'In Review', border: 'border-t-warning-500 dark:border-t-warning-400' },

--- a/frontend/src/pages/TaskList.svelte.test.ts
+++ b/frontend/src/pages/TaskList.svelte.test.ts
@@ -62,7 +62,7 @@ describe('TaskList', () => {
   it('calls byStatus for each column status', () => {
     mockByStatus.mockReturnValue([])
     render(TaskList, { props: { onselect: vi.fn() } })
-    expect(mockByStatus).toHaveBeenCalledWith('new')
+    expect(mockByStatus).not.toHaveBeenCalledWith('new')
     expect(mockByStatus).toHaveBeenCalledWith('todo')
     expect(mockByStatus).toHaveBeenCalledWith('in-progress')
     expect(mockByStatus).toHaveBeenCalledWith('in-review')
@@ -73,6 +73,6 @@ describe('TaskList', () => {
     const tasks = [mockTask('t-1', 'First Task'), mockTask('t-2', 'Second Task')]
     mockByStatus.mockReturnValue(tasks)
     render(TaskList, { props: { onselect: vi.fn() } })
-    expect(screen.getAllByText('First Task')).toHaveLength(5)
+    expect(screen.getAllByText('First Task')).toHaveLength(4)
   })
 })


### PR DESCRIPTION
## Motivation

Board view had an Inbox column (status: `new`) that's unnecessary — tasks auto-triage from `new` to `todo` via agent, so users never interact with the inbox column directly. Tab label "Tasks" didn't reflect the board-style view.

## Implementation information

- Removed `new`/Inbox column from board columns array in `TaskList.svelte`
- Renamed nav tab from "Tasks" to "Board" in `App.svelte`
- Updated tests to reflect 4 columns instead of 5
- Backend `new` status preserved — still used by auto-triage flow