### PR TITLE
feat(gui): precise PR linking on cards

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -135,6 +135,15 @@ func cmdGet(s *task.Store, args []string, jsonOut bool) int {
 	if len(t.Tags) > 0 {
 		fmt.Printf("Tags:   %s\n", strings.Join(t.Tags, ", "))
 	}
+	if t.ProjectID != "" {
+		fmt.Printf("Project: %s\n", t.ProjectID)
+	}
+	if t.Branch != "" {
+		fmt.Printf("Branch: %s\n", t.Branch)
+	}
+	if t.PRNumber > 0 {
+		fmt.Printf("PR: #%d\n", t.PRNumber)
+	}
 	fmt.Printf("Created: %s\n", t.CreatedAt.Format("2006-01-02 15:04"))
 	fmt.Printf("Updated: %s\n", t.UpdatedAt.Format("2006-01-02 15:04"))
 	if t.Body != "" {
@@ -150,6 +159,8 @@ func cmdCreate(s *task.Store, args []string, jsonOut bool) int {
 	mode := fs.String("mode", "headless", "agent mode: headless|interactive")
 	tags := fs.String("tags", "", "comma-separated tags")
 	proj := fs.String("project", "", "project id (owner/repo)")
+	branch := fs.String("branch", "", "Git branch name")
+	pr := fs.Int("pr", 0, "GitHub PR number")
 	if err := fs.Parse(args); err != nil {
 		return fatal(jsonOut, "%v", err)
 	}
@@ -172,6 +183,12 @@ func cmdCreate(s *task.Store, args []string, jsonOut bool) int {
 	}
 	if *proj != "" {
 		updates["project_id"] = *proj
+	}
+	if *branch != "" {
+		updates["branch"] = *branch
+	}
+	if *pr > 0 {
+		updates["pr_number"] = float64(*pr)
 	}
 	if len(updates) > 0 {
 		t, err = s.Update(t.ID, updates)
@@ -200,6 +217,8 @@ func cmdUpdate(s *task.Store, args []string, jsonOut bool) int {
 	mode := fs.String("mode", "", "new agent mode")
 	tags := fs.String("tags", "", "comma-separated tags (replaces existing)")
 	proj := fs.String("project", "", "project id (owner/repo)")
+	branch := fs.String("branch", "", "Git branch name")
+	pr := fs.Int("pr", 0, "GitHub PR number")
 	if err := fs.Parse(args[1:]); err != nil {
 		return fatal(jsonOut, "%v", err)
 	}
@@ -226,6 +245,12 @@ func cmdUpdate(s *task.Store, args []string, jsonOut bool) int {
 	}
 	if *proj != "" {
 		updates["project_id"] = *proj
+	}
+	if *branch != "" {
+		updates["branch"] = *branch
+	}
+	if *pr > 0 {
+		updates["pr_number"] = float64(*pr)
 	}
 
 	if len(updates) == 0 {
@@ -405,8 +430,8 @@ func usage() {
 Commands:
   list     [--status STATUS] [--tag TAG] [--project ID]
   get      <id>
-  create   --title TITLE [--body BODY] [--mode MODE] [--tags t1,t2] [--project ID]
-  update   <id> [--title T] [--status S] [--body B] [--mode M] [--tags T] [--project ID]
+  create   --title TITLE [--body BODY] [--mode MODE] [--tags t1,t2] [--project ID] [--branch B] [--pr N]
+  update   <id> [--title T] [--status S] [--body B] [--mode M] [--tags T] [--project ID] [--branch B] [--pr N]
   delete   <id>
 
   project list

--- a/frontend/src/components/PRCard.svelte.test.ts
+++ b/frontend/src/components/PRCard.svelte.test.ts
@@ -18,6 +18,7 @@ function makePR(overrides: Record<string, unknown> = {}) {
     author: 'dev',
     isDraft: false,
     labels: [],
+    headRefName: 'feature/test',
     ciStatus: '',
     reviewDecision: '',
     unresolvedCount: 0,

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { task } from '../../wailsjs/go/models.js'
   import { agentStore } from '../stores/agents.svelte.js'
+  import { reviewStore } from '../stores/reviews.svelte.js'
 
   interface Props {
     task: task.Task
@@ -27,6 +28,9 @@
     (agentStore.list ?? []).some((a) => a.taskId === t.id && a.state === 'running' && !a.name?.startsWith('triage:') && !a.name?.startsWith('eval:') && !a.name?.startsWith('plan:'))
   )
 
+  const linkedPRs = $derived(reviewStore.byTask(t))
+  const topPR = $derived(linkedPRs.length > 0 ? linkedPRs[0] : null)
+
   function timeAgo(date: any): string {
     if (!date) return ''
     const now = Date.now()
@@ -51,7 +55,15 @@
   }}
   ondragend={() => { dragging = false }}
 >
-  <h3 class="mb-1.5 text-sm font-semibold leading-tight">{t.title}</h3>
+  <div class="mb-1.5 flex items-center gap-1.5">
+    {#if topPR?.ciStatus}
+      <span
+        class="inline-block h-2.5 w-2.5 shrink-0 rounded-full {topPR.ciStatus === 'SUCCESS' ? 'bg-green-500' : topPR.ciStatus === 'FAILURE' ? 'bg-red-500' : 'bg-yellow-500'}"
+        title="CI: {topPR.ciStatus.toLowerCase()}"
+      ></span>
+    {/if}
+    <h3 class="text-sm font-semibold leading-tight">{t.title}</h3>
+  </div>
 
   <div class="flex flex-wrap items-center gap-1.5 text-xs text-surface-500">
     <span class="rounded bg-surface-200 px-1.5 py-0.5 dark:bg-surface-700">
@@ -89,6 +101,18 @@
       <span class="inline-flex items-center gap-1 rounded bg-warning-200 px-1.5 py-0.5 text-warning-800 dark:bg-warning-700 dark:text-warning-200">
         <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-warning-500"></span>
         Evaluating
+      </span>
+    {/if}
+
+    {#if topPR}
+      <span class="inline-flex items-center gap-1 rounded bg-purple-500/15 px-1.5 py-0.5 font-medium text-purple-600 dark:text-purple-400" title={topPR.title}>
+        <svg class="h-3 w-3" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"/></svg>
+        #{topPR.number}
+        {#if topPR.reviewDecision === 'APPROVED'}
+          <span class="text-green-500" title="Approved">✓</span>
+        {:else if topPR.reviewDecision === 'CHANGES_REQUESTED'}
+          <span class="text-red-500" title="Changes requested">✗</span>
+        {/if}
       </span>
     {/if}
 

--- a/frontend/src/components/TaskCard.svelte.test.ts
+++ b/frontend/src/components/TaskCard.svelte.test.ts
@@ -10,6 +10,8 @@ const mockTask = {
   allowedTools: [],
   tags: ['backend'],
   projectId: '',
+  branch: '',
+  prNumber: 0,
   agentRuns: [],
   createdAt: '2026-04-01T00:00:00Z',
   updatedAt: '2026-04-01T00:00:00Z',

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -2,8 +2,10 @@
   import { SegmentedControl } from '@skeletonlabs/skeleton-svelte'
   import type { agent, task } from '../../wailsjs/go/models.js'
   import { EventsOn } from '../../wailsjs/runtime/runtime.js'
+  import { BrowserOpenURL } from '../../wailsjs/runtime/runtime.js'
   import { taskStore } from '../stores/tasks.svelte.js'
   import { agentStore } from '../stores/agents.svelte.js'
+  import { reviewStore } from '../stores/reviews.svelte.js'
   import StatusBadge from '../components/StatusBadge.svelte'
   import StreamOutput from '../components/StreamOutput.svelte'
   import TerminalView from '../components/TerminalView.svelte'
@@ -147,6 +149,8 @@
     (agentStore.list ?? []).some((a) => a.taskId === taskId && a.name?.startsWith('plan:') && a.state === 'running')
   )
 
+  const linkedPRs = $derived(t ? reviewStore.byTask(t) : [])
+
   let rejectFeedback = $state('')
   let planActionLoading = $state(false)
 
@@ -274,6 +278,20 @@
           </div>
         {/if}
 
+        {#if t.projectId}
+          <div class="flex flex-col gap-1">
+            <span class="font-medium text-surface-500">Project</span>
+            <span class="rounded bg-surface-200 px-2 py-0.5 font-mono dark:bg-surface-700">{t.projectId}</span>
+          </div>
+        {/if}
+
+        {#if t.branch}
+          <div class="flex flex-col gap-1">
+            <span class="font-medium text-surface-500">Branch</span>
+            <span class="rounded bg-surface-200 px-2 py-0.5 font-mono dark:bg-surface-700">{t.branch}</span>
+          </div>
+        {/if}
+
         {#if t.allowedTools?.length}
           <div class="flex flex-col gap-1">
             <span class="font-medium text-surface-500">Allowed Tools</span>
@@ -285,6 +303,50 @@
           </div>
         {/if}
       </div>
+
+      {#if linkedPRs.length > 0}
+        <div class="flex flex-col gap-2">
+          <span class="text-sm font-medium text-surface-500">Pull Requests</span>
+          {#each linkedPRs as pr (pr.number)}
+            <button
+              type="button"
+              class="flex w-full items-start justify-between gap-3 rounded-lg border border-surface-300 bg-surface-50 p-3 text-left transition-colors hover:bg-surface-100 dark:border-surface-600 dark:bg-surface-800 dark:hover:bg-surface-700"
+              onclick={() => BrowserOpenURL(pr.url)}
+            >
+              <div class="flex items-center gap-2">
+                {#if pr.ciStatus}
+                  <span
+                    class="inline-block h-2.5 w-2.5 shrink-0 rounded-full {pr.ciStatus === 'SUCCESS' ? 'bg-green-500' : pr.ciStatus === 'FAILURE' ? 'bg-red-500' : 'bg-yellow-500'}"
+                    title="CI: {pr.ciStatus.toLowerCase()}"
+                  ></span>
+                {/if}
+                <svg class="h-4 w-4 shrink-0 text-purple-500" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"/></svg>
+                <div class="flex flex-col">
+                  <span class="text-sm font-semibold">{pr.title}</span>
+                  <span class="text-xs text-surface-500">{pr.repository}#{pr.number} by {pr.author}</span>
+                </div>
+              </div>
+              <div class="flex shrink-0 items-center gap-1.5">
+                {#if pr.isDraft}
+                  <span class="rounded bg-surface-200 px-1.5 py-0.5 text-xs dark:bg-surface-700">Draft</span>
+                {/if}
+                {#if pr.reviewDecision === 'APPROVED'}
+                  <span class="rounded bg-green-500/15 px-1.5 py-0.5 text-xs font-medium text-green-600 dark:text-green-400">Approved</span>
+                {:else if pr.reviewDecision === 'CHANGES_REQUESTED'}
+                  <span class="rounded bg-red-500/15 px-1.5 py-0.5 text-xs font-medium text-red-600 dark:text-red-400">Changes</span>
+                {:else if pr.reviewDecision === 'REVIEW_REQUIRED'}
+                  <span class="rounded bg-yellow-500/15 px-1.5 py-0.5 text-xs font-medium text-yellow-600 dark:text-yellow-400">Review needed</span>
+                {/if}
+                {#if pr.unresolvedCount > 0}
+                  <span class="rounded bg-yellow-500/15 px-1.5 py-0.5 text-xs font-medium text-yellow-600 dark:text-yellow-400"
+                    title="{pr.unresolvedCount} unresolved"
+                  >{pr.unresolvedCount} unresolved</span>
+                {/if}
+              </div>
+            </button>
+          {/each}
+        </div>
+      {/if}
 
       <div class="flex flex-col gap-1">
         <div class="flex items-center justify-between">

--- a/frontend/src/stores/reviews.svelte.ts
+++ b/frontend/src/stores/reviews.svelte.ts
@@ -12,6 +12,37 @@ class ReviewStore {
     return this.createdByMe.length + this.reviewRequested.length
   }
 
+  get allPRs(): github.PullRequest[] {
+    const seen = new Set<string>()
+    const result: github.PullRequest[] = []
+    for (const pr of [...this.createdByMe, ...this.reviewRequested]) {
+      const key = `${pr.repository}#${pr.number}`
+      if (!seen.has(key)) {
+        seen.add(key)
+        result.push(pr)
+      }
+    }
+    return result
+  }
+
+  byRepo(repo: string): github.PullRequest[] {
+    return this.allPRs.filter((pr) => pr.repository === repo)
+  }
+
+  byTask(task: { projectId?: string; prNumber?: number; branch?: string }): github.PullRequest[] {
+    if (!task.projectId) return []
+    const repoPRs = this.byRepo(task.projectId)
+    if (task.prNumber) {
+      const exact = repoPRs.filter((pr) => pr.number === task.prNumber)
+      if (exact.length > 0) return exact
+    }
+    if (task.branch) {
+      const byBranch = repoPRs.filter((pr) => pr.headRefName === task.branch)
+      if (byBranch.length > 0) return byBranch
+    }
+    return repoPRs
+  }
+
   async load(): Promise<void> {
     this.loading = true
     this.error = ''

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -84,6 +84,7 @@ export namespace github {
 	    number: number;
 	    title: string;
 	    url: string;
+	    headRefName: string;
 	    repository: string;
 	    repoName: string;
 	    author: string;
@@ -104,6 +105,7 @@ export namespace github {
 	        this.number = source["number"];
 	        this.title = source["title"];
 	        this.url = source["url"];
+	        this.headRefName = source["headRefName"];
 	        this.repository = source["repository"];
 	        this.repoName = source["repoName"];
 	        this.author = source["author"];
@@ -273,6 +275,8 @@ export namespace task {
 	    allowedTools: string[];
 	    tags: string[];
 	    projectId: string;
+	    branch: string;
+	    prNumber: number;
 	    agentRuns: AgentRun[];
 	    // Go type: time
 	    createdAt: any;
@@ -294,6 +298,8 @@ export namespace task {
 	        this.allowedTools = source["allowedTools"];
 	        this.tags = source["tags"];
 	        this.projectId = source["projectId"];
+	        this.branch = source["branch"];
+	        this.prNumber = source["prNumber"];
 	        this.agentRuns = this.convertValues(source["agentRuns"], AgentRun);
 	        this.createdAt = this.convertValues(source["createdAt"], null);
 	        this.updatedAt = this.convertValues(source["updatedAt"], null);

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -14,6 +14,7 @@ const prQuery = `query($q: String!) {
         number
         title
         url
+        headRefName
         isDraft
         createdAt
         updatedAt
@@ -51,6 +52,7 @@ type gqlPR struct {
 	Number         int    `json:"number"`
 	Title          string `json:"title"`
 	URL            string `json:"url"`
+	HeadRefName    string `json:"headRefName"`
 	IsDraft        bool   `json:"isDraft"`
 	CreatedAt      string `json:"createdAt"`
 	UpdatedAt      string `json:"updatedAt"`
@@ -154,6 +156,7 @@ func convertPRs(nodes []gqlPR) []PullRequest {
 			Number:          n.Number,
 			Title:           n.Title,
 			URL:             n.URL,
+			HeadRefName:     n.HeadRefName,
 			Repository:      n.Repository.NameWithOwner,
 			RepoName:        n.Repository.Name,
 			Author:          n.Author.Login,

--- a/internal/github/model.go
+++ b/internal/github/model.go
@@ -10,6 +10,7 @@ type PullRequest struct {
 	Author          string   `json:"author"`
 	IsDraft         bool     `json:"isDraft"`
 	Labels          []string `json:"labels"`
+	HeadRefName     string   `json:"headRefName"`
 	CIStatus        string   `json:"ciStatus"`       // SUCCESS, FAILURE, PENDING, or ""
 	ReviewDecision  string   `json:"reviewDecision"` // APPROVED, CHANGES_REQUESTED, REVIEW_REQUIRED, or ""
 	UnresolvedCount int      `json:"unresolvedCount"`

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -34,6 +34,8 @@ type Task struct {
 	AllowedTools []string   `yaml:"allowed_tools" json:"allowedTools"`
 	Tags         []string   `yaml:"tags" json:"tags"`
 	ProjectID    string     `yaml:"project_id,omitempty" json:"projectId"`
+	Branch       string     `yaml:"branch,omitempty" json:"branch"`
+	PRNumber     int        `yaml:"pr_number,omitempty" json:"prNumber"`
 	AgentRuns    []AgentRun `yaml:"agent_runs,omitempty" json:"agentRuns"`
 	CreatedAt    time.Time  `yaml:"created_at" json:"createdAt"`
 	UpdatedAt    time.Time  `yaml:"updated_at" json:"updatedAt"`

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -119,6 +119,12 @@ func (s *Store) Update(id string, updates map[string]any) (Task, error) {
 	if v, ok := updates["project_id"].(string); ok {
 		t.ProjectID = v
 	}
+	if v, ok := updates["branch"].(string); ok {
+		t.Branch = v
+	}
+	if v, ok := updates["pr_number"].(float64); ok {
+		t.PRNumber = int(v)
+	}
 
 	data, err := Marshal(t)
 	if err != nil {


### PR DESCRIPTION
## Motivation

Task cards on the board match PRs by repo name only — if a project has multiple open PRs, all show as linked. Need precise matching by PR number or branch, plus the existing CI/review indicators already work but need the linkage fix.

## Implementation information

- **Task model**: added `branch` (string) and `pr_number` (int) fields with `omitempty` for backward compat
- **GitHub GraphQL**: now fetches `headRefName` on PRs
- **Review store**: new `byTask()` method matches PR number → branch → repo (fallback chain)
- **Card/Detail views**: switched from `byRepo()` to `byTask()` for precise matching
- **CLI**: added `--branch` and `--pr` flags to create/update commands
- **Detail view**: shows branch field in task metadata
- Test fixtures updated for new model fields