### PR TITLE
fix(agents): prevent duplicate dispatch

### DIFF
--- a/.claude/skills/synapse-evaluate.md
+++ b/.claude/skills/synapse-evaluate.md
@@ -30,14 +30,15 @@ Review the agent result provided in the prompt. Consider:
 | Condition | New Status | Rationale |
 |-----------|-----------|-----------|
 | Agent completed work successfully | in-review | Human must review before done |
-| Agent failed, hit errors, or produced no useful output | todo | Reset for retry |
+| Agent failed, hit errors, or produced no useful output | human-required | Needs human to decide retry |
 | Agent explicitly said it's blocked or needs input | human-required | Needs human intervention |
 
 ### Guidelines
 
 - **Never set `done`** — only humans move tasks to `done` after review
+- **Never set `todo`** — this triggers auto-dispatch and can create duplicate agents
 - Default to `in-review` when uncertain
-- Set `todo` if the agent output shows errors, loops, or incomplete work
+- Set `human-required` if the agent output shows errors, loops, or incomplete work
 
 ### 4. Update the task status
 

--- a/app.go
+++ b/app.go
@@ -75,6 +75,7 @@ func (a *App) startup(ctx context.Context) {
 	_ = w.Start(ctx)
 
 	a.reconnectAgents()
+	a.cleanStaleRuns()
 	a.syncSkills()
 	a.RegisterSpotlightHotkey()
 	go a.orchestratorLoop(ctx)
@@ -104,6 +105,30 @@ func (a *App) reconnectAgents() {
 	n := a.agents.ReconnectSessions(infos)
 	if n > 0 {
 		a.logger.Info("reconnect.done", "count", n)
+	}
+}
+
+// cleanStaleRuns marks agent_runs still showing "running" as "stopped" if no
+// matching in-memory agent exists. Fixes leftover state from crashes/restarts.
+func (a *App) cleanStaleRuns() {
+	tasks, err := a.tasks.List()
+	if err != nil {
+		return
+	}
+	for i := range tasks {
+		for _, run := range tasks[i].AgentRuns {
+			if run.State != string(agent.StateRunning) {
+				continue
+			}
+			if a.agents.HasRunningAgentForTask(tasks[i].ID) {
+				continue
+			}
+			a.logger.Info("stale-run.cleanup", "task_id", tasks[i].ID, "agent_id", run.AgentID)
+			_ = a.tasks.UpdateRun(tasks[i].ID, run.AgentID, map[string]any{
+				"state":  string(agent.StateStopped),
+				"result": "stale: marked stopped on startup",
+			})
+		}
 	}
 }
 
@@ -144,7 +169,7 @@ func (a *App) UpdateTask(id string, updates map[string]any) (task.Task, error) {
 			}
 		}()
 	}
-	if t.Status == task.StatusInProgress {
+	if t.Status == task.StatusInProgress && !a.agents.HasRunningAgentForTask(t.ID) {
 		a.logger.Info("auto-implement.start", "task_id", t.ID, "title", t.Title)
 		go func() {
 			if _, err := a.StartAgent(t.ID, t.AgentMode, "Implement this task. When done, create a draft PR with `gh pr create --draft`."); err != nil {
@@ -531,6 +556,9 @@ func (a *App) maybeDispatchTasks() {
 			continue
 		}
 		if slices.Contains(tasks[i].Tags, "large") {
+			continue
+		}
+		if a.agents.HasRunningAgentForTask(tasks[i].ID) {
 			continue
 		}
 		candidates = append(candidates, tasks[i])

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -169,6 +169,18 @@ func (m *Manager) ListAgents() []*Agent {
 	return agents
 }
 
+// HasRunningAgentForTask returns true if any agent is currently running for the given task.
+func (m *Manager) HasRunningAgentForTask(taskID string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, a := range m.agents {
+		if a.TaskID == taskID && a.State == StateRunning {
+			return true
+		}
+	}
+	return false
+}
+
 func (m *Manager) CapturePane(agentID string) (string, error) {
 	a, err := m.GetAgent(agentID)
 	if err != nil {


### PR DESCRIPTION
## Motivation

Agents were spawning multiple times for the same task due to missing dedup checks. The eval→todo→dispatch loop and stale "running" agent_runs compounded the problem, wasting API credits and creating confusing UI state.

## Implementation information

Three fixes:

1. **Per-task dedup guard** — `HasRunningAgentForTask()` on `Manager` checks in-memory agents. Used in both `maybeDispatchTasks()` and `UpdateTask()` auto-implement trigger to skip tasks with already-running agents.

2. **Eval skill: error → `human-required`** — previously errors set task back to `todo`, which re-entered the auto-dispatch pool. Now uses `human-required` to break the loop.

3. **Stale run cleanup on startup** — `cleanStaleRuns()` runs after `reconnectAgents()`, marking any `agent_runs` entry with `state: running` as `stopped` if no matching in-memory agent exists.

> Changelog: fix(agents): prevent duplicate dispatch