### PR TITLE
feat(dashboard): draft PRs with ready action

### DIFF
--- a/app.go
+++ b/app.go
@@ -1080,6 +1080,10 @@ func hasResultEvent(ag *agent.Agent) bool {
 	return false
 }
 
+func (a *App) MarkPRReady(repo string, number int) error {
+	return github.MarkReady(repo, number)
+}
+
 func (a *App) RegisterSpotlightHotkey() {
 	spotlight.OnSubmit(func(title, projectID string) {
 		a.logger.Info("spotlight.submit", "title", title, "project", projectID)

--- a/frontend/src/components/PRCard.svelte
+++ b/frontend/src/components/PRCard.svelte
@@ -4,9 +4,11 @@
 
   interface Props {
     pr: github.PullRequest
+    actionLabel?: string
+    onaction?: () => void
   }
 
-  const { pr }: Props = $props()
+  const { pr, actionLabel, onaction }: Props = $props()
 
   function timeAgo(date: string): string {
     if (!date) return ''
@@ -64,4 +66,14 @@
 
     <span class="ml-auto opacity-60">{timeAgo(pr.updatedAt)}</span>
   </div>
+
+  {#if onaction}
+    <button
+      type="button"
+      class="mt-2 rounded bg-primary-600 px-2.5 py-1 text-xs font-medium text-white transition-colors hover:bg-primary-700"
+      onclick={(e) => { e.stopPropagation(); onaction(); }}
+    >
+      {actionLabel ?? 'Action'}
+    </button>
+  {/if}
 </button>

--- a/frontend/src/pages/Dashboard.svelte
+++ b/frontend/src/pages/Dashboard.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { taskStore } from '../stores/tasks.svelte.js'
   import { agentStore } from '../stores/agents.svelte.js'
+  import { reviewStore } from '../stores/reviews.svelte.js'
+  import { MarkPRReady } from '../../wailsjs/go/main/App.js'
   import AgentCard from '../components/AgentCard.svelte'
+  import PRCard from '../components/PRCard.svelte'
 
   interface Props {
     onviewagent: (agentId: string) => void
@@ -25,6 +28,13 @@
   const totalCost = $derived(
     agentStore.list.reduce((sum, a) => sum + (a.costUsd ?? 0), 0),
   )
+
+  const draftPRs = $derived(reviewStore.createdByMe.filter((pr) => pr.isDraft))
+
+  async function markReady(repo: string, number: number) {
+    await MarkPRReady(repo, number)
+    await reviewStore.load()
+  }
 
 </script>
 
@@ -72,6 +82,18 @@
       </span>
     </div>
   </div>
+
+  <!-- Draft PRs -->
+  {#if draftPRs.length > 0}
+    <div class="flex flex-col gap-2">
+      <span class="text-sm font-medium text-surface-500">Draft PRs</span>
+      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {#each draftPRs as pr (pr.url)}
+          <PRCard {pr} actionLabel="Ready for Review" onaction={() => markReady(pr.repository, pr.number)} />
+        {/each}
+      </div>
+    </div>
+  {/if}
 
   <!-- Running + waiting agents -->
   {#if runningAgents.length > 0 || pausedAgents.length > 0}

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -55,6 +55,8 @@ export function ListTmuxSessions():Promise<Array<tmux.SessionInfo>>;
 
 export function ListWorktrees(arg1:string):Promise<Array<project.Worktree>>;
 
+export function MarkPRReady(arg1:string,arg2:number):Promise<void>;
+
 export function OpenInEditor(arg1:string):Promise<void>;
 
 export function OpenInTerminal(arg1:string):Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -98,6 +98,10 @@ export function ListWorktrees(arg1) {
   return window['go']['main']['App']['ListWorktrees'](arg1);
 }
 
+export function MarkPRReady(arg1, arg2) {
+  return window['go']['main']['App']['MarkPRReady'](arg1, arg2);
+}
+
 export function OpenInEditor(arg1) {
   return window['go']['main']['App']['OpenInEditor'](arg1);
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -15,6 +15,7 @@ export namespace agent {
 	    command?: string;
 	    name?: string;
 	    project?: string;
+	    model?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new Agent(source);
@@ -35,6 +36,7 @@ export namespace agent {
 	        this.command = source["command"];
 	        this.name = source["name"];
 	        this.project = source["project"];
+	        this.model = source["model"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -192,6 +192,19 @@ func convertPRs(nodes []gqlPR) []PullRequest {
 	return prs
 }
 
+// MarkReady marks a draft pull request as ready for review.
+func MarkReady(repo string, number int) error {
+	return markReadyWith(defaultExecer, repo, number)
+}
+
+func markReadyWith(e execer, repo string, number int) error {
+	out, err := e.run("pr", "ready", fmt.Sprintf("%d", number), "-R", repo)
+	if err != nil {
+		return fmt.Errorf("gh pr ready: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
 func isBot(typeName, login string) bool {
 	return typeName == "Bot" || strings.Contains(login, "[bot]")
 }


### PR DESCRIPTION
## Motivation

Marking draft PRs as ready for review requires opening GitHub manually. This adds the workflow directly to the dashboard.

## Implementation information

- Backend: `MarkReady()` in `internal/github/client.go` shells out to `gh pr ready <number> -R <repo>`
- Bound method `MarkPRReady` exposed to frontend via `app.go`
- Dashboard filters `reviewStore.createdByMe` for `isDraft` PRs and renders them with a "Ready for Review" action button
- PRCard component extended with optional `actionLabel`/`onaction` props for reusable action buttons