### PR TITLE
fix(agent): detect dead tmux sessions

### DIFF
--- a/internal/agent/discovery.go
+++ b/internal/agent/discovery.go
@@ -186,6 +186,22 @@ func readLastJSONL(path string) sessionState {
 	}
 }
 
+func readClaudeSessionByPID(pidStr string) claudeSession {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return claudeSession{}
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".claude", "sessions", pidStr+".json"))
+	if err != nil {
+		return claudeSession{}
+	}
+	var s claudeSession
+	if err := json.Unmarshal(data, &s); err != nil {
+		return claudeSession{}
+	}
+	return s
+}
+
 func readClaudeSessions() []claudeSession {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -271,20 +271,34 @@ func (m *Manager) CheckInteractiveSessions() {
 			m.markStopped(a)
 			continue
 		}
-		out, err := m.tmux.CapturePaneOutput(a.TmuxSession)
-		if err != nil {
+		// Resolve claude session via tmux pane PID → ~/.claude/sessions/{pid}.json
+		if a.SessionID == "" {
+			m.resolveInteractiveSession(a)
+		}
+		if a.SessionID == "" {
 			continue
 		}
-		// Detect idle: pane has the ❯ input prompt and shows activity markers
-		// (tool use ⏺, cost ✻) meaning agent worked then returned to prompt.
-		hasPrompt := strings.Contains(out, "\u276f") && !strings.Contains(out, "Yes, I accept")
-		hasActivity := strings.Contains(out, "\u23fa") || strings.Contains(out, "\u273b")
-		if !a.tmuxActive && hasActivity {
-			a.tmuxActive = true
-		}
-		if a.tmuxActive && hasPrompt && hasActivity {
-			m.logger.Info("agent.interactive.idle", "id", a.ID, "session", a.TmuxSession)
+		state := inferState(a.sessionCWD, a.SessionID)
+		if state == StateIdle {
+			m.logger.Info("agent.interactive.idle", "id", a.ID, "session", a.TmuxSession, "claude_session", a.SessionID)
 			m.markStopped(a)
+		}
+	}
+}
+
+// resolveInteractiveSession reads the tmux pane PID, then looks up
+// ~/.claude/sessions/{pid}.json to find the claude session ID.
+func (m *Manager) resolveInteractiveSession(a *Agent) {
+	pidStr, err := m.tmux.PanePID(a.TmuxSession)
+	if err != nil {
+		return
+	}
+	pidStr = strings.TrimSpace(pidStr)
+	sess := readClaudeSessionByPID(pidStr)
+	if sess.SessionID != "" {
+		a.SessionID = sess.SessionID
+		if a.sessionCWD == "" {
+			a.sessionCWD = sess.CWD
 		}
 	}
 }

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -36,7 +36,6 @@ type Agent struct {
 	cmd          *exec.Cmd
 	cancel       context.CancelFunc
 	sessionCWD   string
-	tmuxActive   bool // true once interactive agent started working (left initial prompt)
 }
 
 func (a *Agent) Output() []StreamEvent {

--- a/internal/tmux/manager.go
+++ b/internal/tmux/manager.go
@@ -94,6 +94,10 @@ func (m *Manager) PaneCommand(name string) (string, error) {
 	return output("list-panes", "-t", name, "-F", "#{pane_current_command}")
 }
 
+func (m *Manager) PanePID(name string) (string, error) {
+	return output("list-panes", "-t", name, "-F", "#{pane_pid}")
+}
+
 func run(args ...string) error {
 	cmd := exec.Command("tmux", args...)
 	if out, err := cmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
## Motivation

Interactive agents whose tmux session dies (crash, exit, manual kill) stay in "running" state forever. The UI keeps polling `tmux capture-pane` on a non-existent session, showing a persistent error.

## Implementation information

Two-pronged fix:

- **Reactive**: `CapturePane()` now checks `SessionExists()` when capture fails — if the session is gone, the agent is auto-marked stopped and the state event is emitted to the frontend
- **Proactive**: New `CheckInteractiveSessions()` scans all running interactive agents for dead tmux sessions every minute via the orchestrator loop

Extracted `markStopped()` helper to centralize the stopped transition (state change, cancel context, emit event, call onComplete).

> Changelog: fix(agent): detect dead tmux sessions