### PR TITLE
feat(pr-monitor): auto-close tasks on PR merge/close

### DIFF
--- a/app.go
+++ b/app.go
@@ -1044,9 +1044,10 @@ func (a *App) pollAndMonitorPRs() time.Duration {
 			continue
 		}
 		matchers = append(matchers, github.TaskMatcher{
-			ID:       tasks[i].ID,
-			PRNumber: tasks[i].PRNumber,
-			Branch:   tasks[i].Branch,
+			ID:        tasks[i].ID,
+			PRNumber:  tasks[i].PRNumber,
+			Branch:    tasks[i].Branch,
+			ProjectID: tasks[i].ProjectID,
 		})
 	}
 
@@ -1065,6 +1066,20 @@ func (a *App) pollAndMonitorPRs() time.Duration {
 			continue
 		}
 		a.handlePRIssue(issues[i])
+	}
+
+	closedPRs := github.DetectClosedTaskPRs(summary.CreatedByMe, matchers, github.FetchPRState)
+	for _, c := range closedPRs {
+		if _, err := a.tasks.Update(c.TaskID, map[string]any{"status": string(task.StatusDone)}); err != nil {
+			a.logger.Error("pr-monitor.closed-update", "task_id", c.TaskID, "err", err)
+			continue
+		}
+		eventType := audit.EventPRMerged
+		if c.State == "CLOSED" {
+			eventType = audit.EventPRClosed
+		}
+		a.logAudit(eventType, c.TaskID, "", map[string]any{"pr": c.PRNumber, "state": c.State})
+		a.logger.Info("pr-monitor.auto-done", "task_id", c.TaskID, "pr", c.PRNumber, "state", c.State)
 	}
 
 	if prNeedsAttention(summary.CreatedByMe) {

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -19,6 +19,8 @@ const (
 	EventPRConflictDetected  = "pr_monitor.conflict_detected"
 	EventPRCIFailureDetected = "pr_monitor.ci_failure_detected"
 	EventPRFixAgentStarted   = "pr_monitor.fix_agent_started"
+	EventPRMerged            = "pr_monitor.merged"
+	EventPRClosed            = "pr_monitor.closed"
 )
 
 type Event struct {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -195,3 +195,27 @@ func convertPRs(nodes []gqlPR) []PullRequest {
 func isBot(typeName, login string) bool {
 	return typeName == "Bot" || strings.Contains(login, "[bot]")
 }
+
+// PRState holds the current state of a specific PR.
+type PRState struct {
+	State    string `json:"state"`    // OPEN, CLOSED, MERGED
+	MergedAt string `json:"mergedAt"` // non-empty if merged
+}
+
+// FetchPRState fetches the current state of a specific PR by repo and number.
+func FetchPRState(repo string, number int) (PRState, error) {
+	return fetchPRStateWith(defaultExecer, repo, number)
+}
+
+func fetchPRStateWith(e execer, repo string, number int) (PRState, error) {
+	out, err := e.run("pr", "view", fmt.Sprintf("%d", number),
+		"--repo", repo, "--json", "state,mergedAt")
+	if err != nil {
+		return PRState{}, fmt.Errorf("gh pr view %d: %s: %w", number, strings.TrimSpace(string(out)), err)
+	}
+	var s PRState
+	if err := json.Unmarshal(out, &s); err != nil {
+		return PRState{}, fmt.Errorf("parse pr state: %w", err)
+	}
+	return s, nil
+}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -508,6 +508,62 @@ func TestFetchReviewsWith_firstCallFails(t *testing.T) {
 	}
 }
 
+func TestFetchPRStateWith(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		execErr error
+		want    PRState
+		wantErr bool
+	}{
+		{
+			name:   "merged PR",
+			output: `{"state":"MERGED","mergedAt":"2026-04-01T12:00:00Z"}`,
+			want:   PRState{State: "MERGED", MergedAt: "2026-04-01T12:00:00Z"},
+		},
+		{
+			name:   "closed PR",
+			output: `{"state":"CLOSED","mergedAt":""}`,
+			want:   PRState{State: "CLOSED"},
+		},
+		{
+			name:   "open PR",
+			output: `{"state":"OPEN","mergedAt":""}`,
+			want:   PRState{State: "OPEN"},
+		},
+		{
+			name:    "exec error",
+			output:  "gh: not found",
+			execErr: fmt.Errorf("exit 1"),
+			wantErr: true,
+		},
+		{
+			name:    "invalid JSON",
+			output:  "not json",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fe := &fakeExecer{output: []byte(tt.output), err: tt.execErr}
+			got, err := fetchPRStateWith(fe, "o/r", 42)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if got.State != tt.want.State {
+				t.Errorf("State = %q, want %q", got.State, tt.want.State)
+			}
+			if got.MergedAt != tt.want.MergedAt {
+				t.Errorf("MergedAt = %q, want %q", got.MergedAt, tt.want.MergedAt)
+			}
+		})
+	}
+}
+
 func TestParseGQLResponse_botFiltered(t *testing.T) {
 	raw := `{
 		"data": {

--- a/internal/github/monitor.go
+++ b/internal/github/monitor.go
@@ -17,9 +17,46 @@ type PRIssue struct {
 
 // TaskMatcher is the minimal task info needed for PR matching.
 type TaskMatcher struct {
-	ID       string
+	ID        string
+	PRNumber  int
+	Branch    string
+	ProjectID string // owner/repo, used for closed/merged PR detection
+}
+
+// ClosedPR represents a PR linked to a task that is merged or closed.
+type ClosedPR struct {
+	TaskID   string
 	PRNumber int
-	Branch   string
+	State    string // "MERGED" or "CLOSED"
+}
+
+// DetectClosedTaskPRs finds tasks whose linked PRs are no longer open.
+// Requires TaskMatcher.ProjectID and PRNumber to be set.
+// It skips tasks whose PR still appears in openPRs.
+func DetectClosedTaskPRs(openPRs []PullRequest, tasks []TaskMatcher, fetchState func(repo string, number int) (PRState, error)) []ClosedPR {
+	openByNumber := make(map[int]struct{}, len(openPRs))
+	for i := range openPRs {
+		openByNumber[openPRs[i].Number] = struct{}{}
+	}
+
+	var closed []ClosedPR
+	for i := range tasks {
+		t := &tasks[i]
+		if t.PRNumber == 0 || t.ProjectID == "" {
+			continue
+		}
+		if _, isOpen := openByNumber[t.PRNumber]; isOpen {
+			continue
+		}
+		state, err := fetchState(t.ProjectID, t.PRNumber)
+		if err != nil {
+			continue
+		}
+		if state.State == "MERGED" || state.State == "CLOSED" {
+			closed = append(closed, ClosedPR{TaskID: t.ID, PRNumber: t.PRNumber, State: state.State})
+		}
+	}
+	return closed
 }
 
 // MatchTaskPRs finds issues on PRs that are linked to tasks.

--- a/internal/github/monitor_test.go
+++ b/internal/github/monitor_test.go
@@ -1,6 +1,9 @@
 package github
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestMatchTaskPRs(t *testing.T) {
 	tests := []struct {
@@ -89,6 +92,109 @@ func TestMatchTaskPRs(t *testing.T) {
 				}
 				if got[i].TaskID != tt.want[i].TaskID {
 					t.Errorf("issue[%d].TaskID = %q, want %q", i, got[i].TaskID, tt.want[i].TaskID)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectClosedTaskPRs(t *testing.T) {
+	merged := PRState{State: "MERGED", MergedAt: "2026-04-01T12:00:00Z"}
+	closed := PRState{State: "CLOSED"}
+	open := PRState{State: "OPEN"}
+
+	makeFetch := func(states map[int]PRState) func(string, int) (PRState, error) {
+		return func(_ string, num int) (PRState, error) {
+			if s, ok := states[num]; ok {
+				return s, nil
+			}
+			return PRState{}, fmt.Errorf("not found")
+		}
+	}
+
+	tests := []struct {
+		name    string
+		openPRs []PullRequest
+		tasks   []TaskMatcher
+		states  map[int]PRState
+		want    []ClosedPR
+	}{
+		{
+			name:    "no tasks",
+			openPRs: nil,
+			tasks:   nil,
+			states:  nil,
+			want:    nil,
+		},
+		{
+			name:    "task without PRNumber skipped",
+			openPRs: nil,
+			tasks:   []TaskMatcher{{ID: "t1", Branch: "feat/x", ProjectID: "o/r"}},
+			states:  nil,
+			want:    nil,
+		},
+		{
+			name:    "task without ProjectID skipped",
+			openPRs: nil,
+			tasks:   []TaskMatcher{{ID: "t1", PRNumber: 42}},
+			states:  map[int]PRState{42: merged},
+			want:    nil,
+		},
+		{
+			name:    "PR still open – skipped",
+			openPRs: []PullRequest{{Number: 42}},
+			tasks:   []TaskMatcher{{ID: "t1", PRNumber: 42, ProjectID: "o/r"}},
+			states:  map[int]PRState{42: open},
+			want:    nil,
+		},
+		{
+			name:    "PR merged → done",
+			openPRs: nil,
+			tasks:   []TaskMatcher{{ID: "t1", PRNumber: 42, ProjectID: "o/r"}},
+			states:  map[int]PRState{42: merged},
+			want:    []ClosedPR{{TaskID: "t1", PRNumber: 42, State: "MERGED"}},
+		},
+		{
+			name:    "PR closed → done",
+			openPRs: nil,
+			tasks:   []TaskMatcher{{ID: "t1", PRNumber: 42, ProjectID: "o/r"}},
+			states:  map[int]PRState{42: closed},
+			want:    []ClosedPR{{TaskID: "t1", PRNumber: 42, State: "CLOSED"}},
+		},
+		{
+			name:    "fetch error – skipped",
+			openPRs: nil,
+			tasks:   []TaskMatcher{{ID: "t1", PRNumber: 99, ProjectID: "o/r"}},
+			states:  map[int]PRState{},
+			want:    nil,
+		},
+		{
+			name:    "mixed: one open, one merged",
+			openPRs: []PullRequest{{Number: 10}},
+			tasks: []TaskMatcher{
+				{ID: "t1", PRNumber: 10, ProjectID: "o/r"},
+				{ID: "t2", PRNumber: 20, ProjectID: "o/r"},
+			},
+			states: map[int]PRState{10: open, 20: merged},
+			want:   []ClosedPR{{TaskID: "t2", PRNumber: 20, State: "MERGED"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := DetectClosedTaskPRs(tt.openPRs, tt.tasks, makeFetch(tt.states))
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d results, want %d: %+v", len(got), len(tt.want), got)
+			}
+			for i := range got {
+				if got[i].TaskID != tt.want[i].TaskID {
+					t.Errorf("[%d] TaskID = %q, want %q", i, got[i].TaskID, tt.want[i].TaskID)
+				}
+				if got[i].PRNumber != tt.want[i].PRNumber {
+					t.Errorf("[%d] PRNumber = %d, want %d", i, got[i].PRNumber, tt.want[i].PRNumber)
+				}
+				if got[i].State != tt.want[i].State {
+					t.Errorf("[%d] State = %q, want %q", i, got[i].State, tt.want[i].State)
 				}
 			}
 		})


### PR DESCRIPTION
## Motivation

Tasks in `in-review` status were never automatically transitioned to `done` when their linked PR was merged or closed.

## Implementation information

Extended the existing PR poll loop to detect closed/merged PRs:

- Added `FetchPRState(repo, number)` to `internal/github/client.go` — calls `gh pr view` for direct state lookup
- Added `DetectClosedTaskPRs()` to `internal/github/monitor.go` — for tasks whose PR is absent from the open PRs list, fetches state and returns those MERGED or CLOSED
- Added `TaskMatcher.ProjectID` field for repo context
- Added `EventPRMerged` / `EventPRClosed` audit events
- On detection: task status → `done`, audit event emitted

Requires `ProjectID` set on task. Detection fires every poll cycle (1–5 min).

> Changelog: feat(pr-monitor): auto-close tasks on PR merge/close