### PR TITLE
refactor(modernize): use CutPrefix/CutSuffix idioms

### DIFF
--- a/internal/audit/reader.go
+++ b/internal/audit/reader.go
@@ -52,10 +52,10 @@ func auditFiles(dir string, since, until time.Time) ([]string, error) {
 
 	var paths []string
 	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".ndjson") {
+		day, ok := strings.CutSuffix(e.Name(), ".ndjson")
+		if e.IsDir() || !ok {
 			continue
 		}
-		day := strings.TrimSuffix(e.Name(), ".ndjson")
 		if day >= sinceDay && day <= untilDay {
 			paths = append(paths, filepath.Join(dir, e.Name()))
 		}

--- a/internal/audit/retention.go
+++ b/internal/audit/retention.go
@@ -19,10 +19,10 @@ func Cleanup(dir string, retentionDays int) error {
 	cutoff := time.Now().UTC().AddDate(0, 0, -retentionDays).Format(time.DateOnly)
 
 	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".ndjson") {
+		day, ok := strings.CutSuffix(e.Name(), ".ndjson")
+		if e.IsDir() || !ok {
 			continue
 		}
-		day := strings.TrimSuffix(e.Name(), ".ndjson")
 		if day < cutoff {
 			_ = os.Remove(filepath.Join(dir, e.Name()))
 		}

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -104,18 +104,16 @@ func parseWorktreePorcelain(raw string) []Worktree {
 		}
 		var wt Worktree
 		for line := range strings.SplitSeq(block, "\n") {
-			switch {
-			case strings.HasPrefix(line, "worktree "):
-				wt.Path = strings.TrimPrefix(line, "worktree ")
-			case strings.HasPrefix(line, "HEAD "):
-				h := strings.TrimPrefix(line, "HEAD ")
-				if len(h) > 7 {
-					h = h[:7]
+			if rest, ok := strings.CutPrefix(line, "worktree "); ok {
+				wt.Path = rest
+			} else if rest, ok := strings.CutPrefix(line, "HEAD "); ok {
+				if len(rest) > 7 {
+					rest = rest[:7]
 				}
-				wt.Head = h
-			case strings.HasPrefix(line, "branch "):
-				ref := strings.TrimPrefix(line, "branch ")
-				wt.Branch = strings.TrimPrefix(ref, "refs/heads/")
+				wt.Head = rest
+			} else if ref, ok := strings.CutPrefix(line, "branch "); ok {
+				branch, _ := strings.CutPrefix(ref, "refs/heads/")
+				wt.Branch = branch
 				if name, ok := strings.CutPrefix(wt.Branch, "synapse/"); ok {
 					// Task ID is always the last 8 chars (uuid[:8])
 					if len(name) >= 8 {


### PR DESCRIPTION
## Motivation

Modernize Go idioms per go fix analysis. `go fix ./...` confirmed no automated changes needed (code already uses `any`, `slices.Contains`, `range int`, `min/max`). Manually applied the remaining HasPrefix/TrimPrefix → CutPrefix and HasSuffix/TrimSuffix → CutSuffix patterns that the analyzer doesn't auto-fix in switch/case contexts.

## Implementation information

- `internal/project/git.go`: restructured switch with HasPrefix/TrimPrefix to if-else chain using `strings.CutPrefix`
- `internal/audit/retention.go`, `internal/audit/reader.go`: replaced HasSuffix+TrimSuffix with `strings.CutSuffix`

All tests pass, golangci-lint clean.

## Supporting documentation

Closes #68

> Changelog: refactor(modernize): use CutPrefix/CutSuffix idioms