### PR TITLE
refactor(stores): extract EntityStore<T> base class

### DIFF
--- a/frontend/src/stores/agents.svelte.ts
+++ b/frontend/src/stores/agents.svelte.ts
@@ -1,19 +1,35 @@
-import { StartAgent, StopAgent, ListAgents, GetAgentOutput, DiscoverAgents } from '../../wailsjs/go/main/App.js'
+import {
+  StartAgent,
+  StopAgent,
+  ListAgents,
+  GetAgentOutput,
+  DiscoverAgents,
+} from '../../wailsjs/go/main/App.js'
 import { agent } from '../../wailsjs/go/models.js'
+import { EntityStore } from './entity-store.svelte.js'
 
-class AgentStore {
-  agents = $state<Map<string, agent.Agent>>(new Map())
+class AgentStore extends EntityStore<agent.Agent> {
   outputs = $state<Map<string, agent.StreamEvent[]>>(new Map())
-  loading = $state(false)
-  error = $state('')
-  private pollTimer: ReturnType<typeof setInterval> | null = null
 
-  get list(): agent.Agent[] {
-    return [...this.agents.values()].sort((a, b) => {
-      const ta = a.startedAt ? new Date(a.startedAt).getTime() : 0
-      const tb = b.startedAt ? new Date(b.startedAt).getTime() : 0
-      return tb - ta
-    })
+  constructor() {
+    super(
+      async () => {
+        await DiscoverAgents()
+        return ListAgents()
+      },
+      (a, b) => {
+        const ta = a.startedAt ? new Date(a.startedAt).getTime() : 0
+        const tb = b.startedAt ? new Date(b.startedAt).getTime() : 0
+        return tb - ta
+      },
+    )
+  }
+
+  get agents() {
+    return this.items
+  }
+  set agents(v: Map<string, agent.Agent>) {
+    this.items = v
   }
 
   byTask(taskID: string): agent.Agent | undefined {
@@ -25,37 +41,19 @@ class AgentStore {
     return this.list.filter((a) => a.state === state)
   }
 
-  async load(): Promise<void> {
-    this.loading = true
-    this.error = ''
-    try {
-      await DiscoverAgents()
-      const result = await ListAgents()
-      const map = new Map<string, agent.Agent>()
-      for (const a of result ?? []) {
-        map.set(a.id, a)
-      }
-      this.agents = map
-    } catch (e) {
-      this.error = String(e)
-    } finally {
-      this.loading = false
-    }
-  }
-
   async start(taskID: string, mode: string, prompt: string): Promise<agent.Agent> {
     const result = await StartAgent(taskID, mode, prompt)
-    this.agents.set(result.id, result)
+    this.items.set(result.id, result)
     this.outputs.set(result.id, [])
     return result
   }
 
   async stop(agentID: string): Promise<void> {
     await StopAgent(agentID)
-    const a = this.agents.get(agentID)
+    const a = this.items.get(agentID)
     if (a) {
       a.state = 'stopped'
-      this.agents.set(agentID, a)
+      this.items.set(agentID, a)
     }
   }
 
@@ -71,19 +69,7 @@ class AgentStore {
   }
 
   updateAgent(agentID: string, data: agent.Agent): void {
-    this.agents.set(agentID, data)
-  }
-
-  startPolling(): void {
-    this.stopPolling()
-    this.pollTimer = setInterval(() => this.load(), 5000)
-  }
-
-  stopPolling(): void {
-    if (this.pollTimer) {
-      clearInterval(this.pollTimer)
-      this.pollTimer = null
-    }
+    this.items.set(agentID, data)
   }
 }
 

--- a/frontend/src/stores/entity-store.svelte.ts
+++ b/frontend/src/stores/entity-store.svelte.ts
@@ -1,0 +1,42 @@
+export class EntityStore<T extends { id: string }> {
+  items = $state<Map<string, T>>(new Map())
+  loading = $state(false)
+  error = $state('')
+  private pollTimer: ReturnType<typeof setInterval> | null = null
+
+  constructor(
+    private readonly loadFn: () => Promise<T[]>,
+    private readonly sortFn: (a: T, b: T) => number,
+  ) {}
+
+  get list(): T[] {
+    return [...this.items.values()].sort(this.sortFn)
+  }
+
+  async load(): Promise<void> {
+    this.loading = true
+    this.error = ''
+    try {
+      const result = await this.loadFn()
+      const map = new Map<string, T>()
+      for (const item of result ?? []) map.set(item.id, item)
+      this.items = map
+    } catch (e) {
+      this.error = String(e)
+    } finally {
+      this.loading = false
+    }
+  }
+
+  startPolling(interval = 5000): void {
+    this.stopPolling()
+    this.pollTimer = setInterval(() => this.load(), interval)
+  }
+
+  stopPolling(): void {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer)
+      this.pollTimer = null
+    }
+  }
+}

--- a/frontend/src/stores/projects.svelte.ts
+++ b/frontend/src/stores/projects.svelte.ts
@@ -1,70 +1,53 @@
-import { ListProjects, GetProject, CreateProject, UpdateProject, DeleteProject } from '../../wailsjs/go/main/App.js'
+import {
+  ListProjects,
+  GetProject,
+  CreateProject,
+  UpdateProject,
+  DeleteProject,
+} from '../../wailsjs/go/main/App.js'
 import { project } from '../../wailsjs/go/models.js'
+import { EntityStore } from './entity-store.svelte.js'
 
-class ProjectStore {
-  projects = $state<Map<string, project.Project>>(new Map())
-  loading = $state(false)
-  error = $state('')
-  private pollTimer: ReturnType<typeof setInterval> | null = null
-
-  get list(): project.Project[] {
-    return [...this.projects.values()].sort((a, b) => {
-      const ta = a.createdAt ? new Date(a.createdAt).getTime() : 0
-      const tb = b.createdAt ? new Date(b.createdAt).getTime() : 0
-      return tb - ta
-    })
+class ProjectStore extends EntityStore<project.Project> {
+  constructor() {
+    super(
+      () => ListProjects(),
+      (a, b) => {
+        const ta = a.createdAt ? new Date(a.createdAt).getTime() : 0
+        const tb = b.createdAt ? new Date(b.createdAt).getTime() : 0
+        return tb - ta
+      },
+    )
   }
 
-  async load(): Promise<void> {
-    this.loading = true
-    this.error = ''
-    try {
-      const result = await ListProjects()
-      const map = new Map<string, project.Project>()
-      for (const p of result ?? []) {
-        map.set(p.id, p)
-      }
-      this.projects = map
-    } catch (e) {
-      this.error = String(e)
-    } finally {
-      this.loading = false
-    }
+  get projects() {
+    return this.items
+  }
+  set projects(v: Map<string, project.Project>) {
+    this.items = v
   }
 
   async get(id: string): Promise<project.Project> {
     const result = await GetProject(id)
-    this.projects.set(result.id, result)
+    this.items.set(result.id, result)
     return result
   }
 
   async create(url: string, type: string = 'pet'): Promise<project.Project> {
     const result = await CreateProject(url, type)
-    this.projects.set(result.id, result)
+    this.items.set(result.id, result)
     return result
   }
 
   async update(id: string, type: string): Promise<project.Project> {
     const result = await UpdateProject(id, type)
-    this.projects.set(result.id, result)
+    this.items.set(result.id, result)
     return result
   }
 
   async remove(id: string): Promise<void> {
     await DeleteProject(id)
-    this.projects.delete(id)
-  }
-
-  startPolling(): void {
-    this.stopPolling()
-    this.pollTimer = setInterval(() => this.load(), 5000)
-  }
-
-  stopPolling(): void {
-    if (this.pollTimer) {
-      clearInterval(this.pollTimer)
-      this.pollTimer = null
-    }
+    this.items.delete(id)
   }
 }
 

--- a/frontend/src/stores/tasks.svelte.ts
+++ b/frontend/src/stores/tasks.svelte.ts
@@ -1,18 +1,32 @@
-import { ListTasks, GetTask, CreateTask, UpdateTask, DeleteTask, ApprovePlan, RejectPlan } from '../../wailsjs/go/main/App.js'
+import {
+  ListTasks,
+  GetTask,
+  CreateTask,
+  UpdateTask,
+  DeleteTask,
+  ApprovePlan,
+  RejectPlan,
+} from '../../wailsjs/go/main/App.js'
 import { task } from '../../wailsjs/go/models.js'
+import { EntityStore } from './entity-store.svelte.js'
 
-class TaskStore {
-  tasks = $state<Map<string, task.Task>>(new Map())
-  loading = $state(false)
-  error = $state('')
-  private pollTimer: ReturnType<typeof setInterval> | null = null
+class TaskStore extends EntityStore<task.Task> {
+  constructor() {
+    super(
+      () => ListTasks(),
+      (a, b) => {
+        const ta = a.updatedAt ? new Date(a.updatedAt).getTime() : 0
+        const tb = b.updatedAt ? new Date(b.updatedAt).getTime() : 0
+        return tb - ta
+      },
+    )
+  }
 
-  get list(): task.Task[] {
-    return [...this.tasks.values()].sort((a, b) => {
-      const ta = a.updatedAt ? new Date(a.updatedAt).getTime() : 0
-      const tb = b.updatedAt ? new Date(b.updatedAt).getTime() : 0
-      return tb - ta
-    })
+  get tasks() {
+    return this.items
+  }
+  set tasks(v: Map<string, task.Task>) {
+    this.items = v
   }
 
   byStatus(status: string): task.Task[] {
@@ -20,68 +34,39 @@ class TaskStore {
     return this.list.filter((t) => t.status === status)
   }
 
-  async load(): Promise<void> {
-    this.loading = true
-    this.error = ''
-    try {
-      const result = await ListTasks()
-      const map = new Map<string, task.Task>()
-      for (const t of result ?? []) {
-        map.set(t.id, t)
-      }
-      this.tasks = map
-    } catch (e) {
-      this.error = String(e)
-    } finally {
-      this.loading = false
-    }
-  }
-
   async get(id: string): Promise<task.Task> {
     const result = await GetTask(id)
-    this.tasks.set(result.id, result)
+    this.items.set(result.id, result)
     return result
   }
 
   async create(title: string, body: string, mode: string): Promise<task.Task> {
     const result = await CreateTask(title, body, mode)
-    this.tasks.set(result.id, result)
+    this.items.set(result.id, result)
     return result
   }
 
   async update(id: string, updates: Record<string, any>): Promise<task.Task> {
     const result = await UpdateTask(id, updates)
-    this.tasks.set(result.id, result)
+    this.items.set(result.id, result)
     return result
   }
 
   async remove(id: string): Promise<void> {
     await DeleteTask(id)
-    this.tasks.delete(id)
+    this.items.delete(id)
   }
 
   async approvePlan(id: string): Promise<task.Task> {
     const result = await ApprovePlan(id)
-    this.tasks.set(result.id, result)
+    this.items.set(result.id, result)
     return result
   }
 
   async rejectPlan(id: string, feedback: string): Promise<task.Task> {
     const result = await RejectPlan(id, feedback)
-    this.tasks.set(result.id, result)
+    this.items.set(result.id, result)
     return result
-  }
-
-  startPolling(): void {
-    this.stopPolling()
-    this.pollTimer = setInterval(() => this.load(), 5000)
-  }
-
-  stopPolling(): void {
-    if (this.pollTimer) {
-      clearInterval(this.pollTimer)
-      this.pollTimer = null
-    }
   }
 }
 


### PR DESCRIPTION
## Motivation

Eliminate ~150 lines of duplicated boilerplate across `tasks.svelte.ts`, `agents.svelte.ts`, and `projects.svelte.ts`. All three stores shared identical `items/loading/error` state, `load()` pattern, and `startPolling/stopPolling` logic with no variation.

Closes #73

## Implementation information

Extracted `EntityStore<T extends { id: string }>` in `entity-store.svelte.ts` with:
- `items`, `loading`, `error` reactive state
- Generic `load(loadFn)` with map building and error handling
- `startPolling` / `stopPolling` shared implementation

Each store now extends `EntityStore<T>` and provides:
- A backward-compat getter/setter alias (`tasks`/`agents`/`projects` → `items`) so all existing component and test code continues to work unchanged
- Only store-specific logic: sort fn, CRUD methods, domain filters

`AgentStore` passes `DiscoverAgents()` + `ListAgents()` as a single async `loadFn`, keeping the override transparent to the base class.

All 41 store unit tests pass without modification.

> Changelog: refactor(stores): extract EntityStore<T> base class