### PR TITLE
feat(review): add PR review flow

### DIFF
--- a/app.go
+++ b/app.go
@@ -228,7 +228,7 @@ func (a *App) UpdateTask(id string, updates map[string]any) (task.Task, error) {
 			}
 		}()
 	}
-	if t.Status == task.StatusInProgress && !a.agents.HasRunningAgentForTask(t.ID) {
+	if t.Status == task.StatusInProgress && !a.agents.HasRunningAgentForTask(t.ID) && !slices.Contains(t.Tags, "review") {
 		a.logger.Info("auto-implement.start", "task_id", t.ID, "title", t.Title)
 		go func() {
 			if _, err := a.StartAgent(t.ID, t.AgentMode, "Implement this task. When done, create a draft PR with `gh pr create --draft`."); err != nil {
@@ -692,6 +692,16 @@ func (a *App) maybeDispatchTasks() {
 	for i := range min(slots, len(candidates)) {
 		t := candidates[i]
 		a.logger.Info("auto-dispatch", "task_id", t.ID, "title", t.Title)
+		if slices.Contains(t.Tags, "review") {
+			if _, err := a.tasks.Update(t.ID, map[string]any{"status": string(task.StatusInProgress)}); err != nil {
+				a.logger.Error("auto-dispatch.review.status", "task_id", t.ID, "err", err)
+				continue
+			}
+			if err := a.startReviewAgent(t); err != nil {
+				a.logger.Error("auto-dispatch.review.failed", "task_id", t.ID, "err", err)
+			}
+			continue
+		}
 		if _, err := a.UpdateTask(t.ID, map[string]any{"status": string(task.StatusInProgress)}); err != nil {
 			a.logger.Error("auto-dispatch.failed", "task_id", t.ID, "err", err)
 		}
@@ -822,6 +832,82 @@ func (a *App) TriageTask(id string) error {
 	return nil
 }
 
+func (a *App) createReviewTask(pr github.PullRequest, projectID string) {
+	title := "Review: " + pr.Title
+	body := fmt.Sprintf("%s\n\nAuthor: @%s", pr.URL, pr.Author)
+
+	t, err := a.tasks.Create(title, body, "headless")
+	if err != nil {
+		a.logger.Error("review.create-task", "pr", pr.Number, "err", err)
+		return
+	}
+
+	if _, err := a.tasks.Update(t.ID, map[string]any{
+		"tags":       "review",
+		"project_id": projectID,
+		"pr_number":  pr.Number,
+		"status":     string(task.StatusTodo),
+	}); err != nil {
+		a.logger.Error("review.update-task", "task_id", t.ID, "err", err)
+		return
+	}
+	a.logger.Info("review.task-created", "task_id", t.ID, "pr", pr.Number, "project", projectID)
+}
+
+func (a *App) startReviewAgent(t task.Task) error {
+	prompt := fmt.Sprintf("Run /staff-code-review on https://github.com/%s/pull/%d", t.ProjectID, t.PRNumber)
+
+	ag, err := a.agents.Run(agent.RunConfig{
+		TaskID: t.ID,
+		Name:   "review:" + t.Title,
+		Mode:   "headless",
+		Prompt: prompt,
+		Dir:    config.HomeDir(),
+		Model:  "opus",
+	})
+	if err != nil {
+		return err
+	}
+	if err := a.tasks.AddRun(t.ID, task.AgentRun{
+		AgentID: ag.ID, Role: "review", Mode: "headless", State: string(agent.StateRunning), StartedAt: ag.StartedAt,
+	}); err != nil {
+		a.logger.Error("task.add-run", "task_id", t.ID, "err", err)
+	}
+	a.logAudit(audit.EventReviewStarted, t.ID, ag.ID, map[string]any{"pr": t.PRNumber})
+	a.logger.Info("review.agent-started", "task_id", t.ID, "agent_id", ag.ID, "pr", t.PRNumber)
+	return nil
+}
+
+func (a *App) resolveReviewStatus(taskID string) {
+	t, err := a.tasks.Get(taskID)
+	if err != nil {
+		return
+	}
+	if t.PRNumber == 0 || t.ProjectID == "" {
+		if _, err := a.tasks.Update(taskID, map[string]any{"status": string(task.StatusInReview)}); err != nil {
+			a.logger.Error("review.status-update", "task_id", taskID, "err", err)
+		}
+		return
+	}
+
+	pending, err := github.HasPendingReview(t.ProjectID, t.PRNumber)
+	if err != nil {
+		a.logger.Warn("review.pending-check", "task_id", taskID, "err", err)
+		if _, err := a.tasks.Update(taskID, map[string]any{"status": string(task.StatusInReview)}); err != nil {
+			a.logger.Error("review.status-update", "task_id", taskID, "err", err)
+		}
+		return
+	}
+
+	nextStatus := task.StatusInReview
+	if pending {
+		nextStatus = task.StatusHumanRequired
+	}
+	if _, err := a.tasks.Update(taskID, map[string]any{"status": string(nextStatus)}); err != nil {
+		a.logger.Error("review.status-update", "task_id", taskID, "err", err)
+	}
+}
+
 func (a *App) handleAgentComplete(ag *agent.Agent) {
 	var resultContent string
 	for _, ev := range ag.Output() {
@@ -913,6 +999,13 @@ func (a *App) handleAgentComplete(ag *agent.Agent) {
 				a.logger.Error("eval.revert_status", "task_id", ag.TaskID, "err", uerr)
 			}
 		}
+		return
+	}
+
+	if strings.HasPrefix(ag.Name, "review:") {
+		a.logger.Info("review.complete", "agent_id", ag.ID, "task_id", ag.TaskID)
+		a.logAudit(audit.EventReviewStarted, ag.TaskID, ag.ID, agentData)
+		go a.resolveReviewStatus(ag.TaskID)
 		return
 	}
 
@@ -1176,6 +1269,7 @@ func (a *App) pollAndMonitorPRs() time.Duration {
 		return prPollSlow
 	}
 
+	// Monitor PRs created by the user (conflicts, CI, merged/closed)
 	var matchers []github.TaskMatcher
 	for i := range tasks {
 		if tasks[i].Status != task.StatusInReview {
@@ -1192,36 +1286,40 @@ func (a *App) pollAndMonitorPRs() time.Duration {
 		})
 	}
 
-	if len(matchers) == 0 {
-		return prPollSlow
+	if len(matchers) > 0 {
+		issues := github.MatchTaskPRs(summary.CreatedByMe, matchers)
+		a.prTracker.Cleanup()
+
+		for i := range issues {
+			if a.agents.HasRunningAgentForTask(issues[i].TaskID) {
+				continue
+			}
+			if !a.prTracker.ShouldHandle(issues[i].TaskID, issues[i].Kind) {
+				continue
+			}
+			a.handlePRIssue(issues[i])
+		}
+
+		closedPRs := github.DetectClosedTaskPRs(summary.CreatedByMe, matchers, github.FetchPRState)
+		for _, c := range closedPRs {
+			if _, err := a.tasks.Update(c.TaskID, map[string]any{"status": string(task.StatusDone)}); err != nil {
+				a.logger.Error("pr-monitor.closed-update", "task_id", c.TaskID, "err", err)
+				continue
+			}
+			eventType := audit.EventPRMerged
+			if c.State == "CLOSED" {
+				eventType = audit.EventPRClosed
+			}
+			a.logAudit(eventType, c.TaskID, "", map[string]any{"pr": c.PRNumber, "state": c.State})
+			a.logger.Info("pr-monitor.auto-done", "task_id", c.TaskID, "pr", c.PRNumber, "state", c.State)
+		}
 	}
 
-	issues := github.MatchTaskPRs(summary.CreatedByMe, matchers)
-	a.prTracker.Cleanup()
+	// Auto-create review tasks from review-requested PRs
+	a.maybeCreateReviewTasks(tasks, summary.ReviewRequested)
 
-	for i := range issues {
-		if a.agents.HasRunningAgentForTask(issues[i].TaskID) {
-			continue
-		}
-		if !a.prTracker.ShouldHandle(issues[i].TaskID, issues[i].Kind) {
-			continue
-		}
-		a.handlePRIssue(issues[i])
-	}
-
-	closedPRs := github.DetectClosedTaskPRs(summary.CreatedByMe, matchers, github.FetchPRState)
-	for _, c := range closedPRs {
-		if _, err := a.tasks.Update(c.TaskID, map[string]any{"status": string(task.StatusDone)}); err != nil {
-			a.logger.Error("pr-monitor.closed-update", "task_id", c.TaskID, "err", err)
-			continue
-		}
-		eventType := audit.EventPRMerged
-		if c.State == "CLOSED" {
-			eventType = audit.EventPRClosed
-		}
-		a.logAudit(eventType, c.TaskID, "", map[string]any{"pr": c.PRNumber, "state": c.State})
-		a.logger.Info("pr-monitor.auto-done", "task_id", c.TaskID, "pr", c.PRNumber, "state", c.State)
-	}
+	// Detect published reviews (human-required → in-review)
+	a.detectPublishedReviews(tasks)
 
 	if prNeedsAttention(summary.CreatedByMe) {
 		return prPollFast
@@ -1239,6 +1337,68 @@ func prNeedsAttention(prs []github.PullRequest) bool {
 		}
 	}
 	return false
+}
+
+func (a *App) maybeCreateReviewTasks(tasks []task.Task, reviewPRs []github.PullRequest) {
+	projects, err := a.projects.List()
+	if err != nil || len(projects) == 0 {
+		return
+	}
+
+	projectMatchers := make([]github.ProjectMatcher, 0, len(projects))
+	for i := range projects {
+		projectMatchers = append(projectMatchers, github.ProjectMatcher{
+			ID:         projects[i].Owner + "/" + projects[i].Repo,
+			Repository: projects[i].Owner + "/" + projects[i].Repo,
+		})
+	}
+
+	matches := github.MatchReviewPRs(reviewPRs, projectMatchers)
+	for i := range matches {
+		if a.hasReviewTask(tasks, matches[i].PR.Number) {
+			continue
+		}
+		a.createReviewTask(matches[i].PR, matches[i].ProjectID)
+	}
+}
+
+func (a *App) hasReviewTask(tasks []task.Task, prNumber int) bool {
+	for i := range tasks {
+		if tasks[i].PRNumber == prNumber && slices.Contains(tasks[i].Tags, "review") {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *App) detectPublishedReviews(tasks []task.Task) {
+	for i := range tasks {
+		if tasks[i].Status != task.StatusHumanRequired {
+			continue
+		}
+		if !slices.Contains(tasks[i].Tags, "review") {
+			continue
+		}
+		if tasks[i].PRNumber == 0 || tasks[i].ProjectID == "" {
+			continue
+		}
+
+		pending, err := github.HasPendingReview(tasks[i].ProjectID, tasks[i].PRNumber)
+		if err != nil {
+			a.logger.Warn("review.poll-pending", "task_id", tasks[i].ID, "err", err)
+			continue
+		}
+		if !pending {
+			if _, err := a.tasks.Update(tasks[i].ID, map[string]any{
+				"status": string(task.StatusInReview),
+			}); err != nil {
+				a.logger.Error("review.published-update", "task_id", tasks[i].ID, "err", err)
+				continue
+			}
+			a.logAudit(audit.EventReviewPublished, tasks[i].ID, "", map[string]any{"pr": tasks[i].PRNumber})
+			a.logger.Info("review.published", "task_id", tasks[i].ID, "pr", tasks[i].PRNumber)
+		}
+	}
 }
 
 func (a *App) handlePRIssue(issue github.PRIssue) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -158,7 +158,7 @@ export namespace github {
 }
 
 export namespace notification {
-
+	
 	export class Notification {
 	    id: string;
 	    level: string;
@@ -167,11 +167,11 @@ export namespace notification {
 	    taskId?: string;
 	    agentId?: string;
 	    createdAt: string;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new Notification(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
@@ -187,7 +187,7 @@ export namespace notification {
 }
 
 export namespace project {
-
+	
 	export class Project {
 	    id: string;
 	    name: string;
@@ -200,11 +200,11 @@ export namespace project {
 	    createdAt: any;
 	    // Go type: time
 	    updatedAt: any;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new Project(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
@@ -217,7 +217,7 @@ export namespace project {
 	        this.createdAt = this.convertValues(source["createdAt"], null);
 	        this.updatedAt = this.convertValues(source["updatedAt"], null);
 	    }
-
+	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
 		    if (!a) {
 		        return a;
@@ -241,11 +241,11 @@ export namespace project {
 	    branch: string;
 	    taskId: string;
 	    head: string;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new Worktree(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.path = source["path"];

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -21,6 +21,8 @@ const (
 	EventPRFixAgentStarted   = "pr_monitor.fix_agent_started"
 	EventPRMerged            = "pr_monitor.merged"
 	EventPRClosed            = "pr_monitor.closed"
+	EventReviewStarted       = "review.agent_started"
+	EventReviewPublished     = "review.published"
 )
 
 type Event struct {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -209,6 +209,31 @@ func isBot(typeName, login string) bool {
 	return typeName == "Bot" || strings.Contains(login, "[bot]")
 }
 
+// HasPendingReview checks if the authenticated user has a pending (draft) review on a PR.
+// Pending reviews are only visible to their author via the REST API.
+func HasPendingReview(repo string, number int) (bool, error) {
+	return hasPendingReviewWith(defaultExecer, repo, number)
+}
+
+func hasPendingReviewWith(e execer, repo string, number int) (bool, error) {
+	out, err := e.run("api", fmt.Sprintf("repos/%s/pulls/%d/reviews", repo, number))
+	if err != nil {
+		return false, fmt.Errorf("fetch reviews for %s#%d: %s: %w", repo, number, strings.TrimSpace(string(out)), err)
+	}
+	var reviews []struct {
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(out, &reviews); err != nil {
+		return false, fmt.Errorf("parse reviews: %w", err)
+	}
+	for i := range reviews {
+		if reviews[i].State == "PENDING" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // PRState holds the current state of a specific PR.
 type PRState struct {
 	State    string `json:"state"`    // OPEN, CLOSED, MERGED

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -617,3 +617,48 @@ func TestParseGQLResponse_botFiltered(t *testing.T) {
 		t.Errorf("got %d PRs, want 0 (bot should be filtered)", len(prs))
 	}
 }
+
+func TestHasPendingReview_pending(t *testing.T) {
+	t.Parallel()
+	fe := &fakeExecer{output: []byte(`[{"state":"COMMENTED"},{"state":"PENDING"}]`)}
+	got, err := hasPendingReviewWith(fe, "owner/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got {
+		t.Error("expected pending review, got false")
+	}
+}
+
+func TestHasPendingReview_noPending(t *testing.T) {
+	t.Parallel()
+	fe := &fakeExecer{output: []byte(`[{"state":"APPROVED"},{"state":"COMMENTED"}]`)}
+	got, err := hasPendingReviewWith(fe, "owner/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got {
+		t.Error("expected no pending review, got true")
+	}
+}
+
+func TestHasPendingReview_empty(t *testing.T) {
+	t.Parallel()
+	fe := &fakeExecer{output: []byte(`[]`)}
+	got, err := hasPendingReviewWith(fe, "owner/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got {
+		t.Error("expected no pending review, got true")
+	}
+}
+
+func TestHasPendingReview_error(t *testing.T) {
+	t.Parallel()
+	fe := &fakeExecer{output: []byte("not found"), err: fmt.Errorf("exit 1")}
+	_, err := hasPendingReviewWith(fe, "owner/repo", 42)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}


### PR DESCRIPTION
## Motivation

Synapse monitors PRs I create but does nothing with PRs where my review is requested. Need a full review flow: auto-create tasks, run `/staff-code-review` skill, detect pending draft reviews, and track through publication.

## Implementation information

**Task lifecycle:**
```
ReviewRequested PR detected → auto-create task (review tag, todo)
→ dispatch → startReviewAgent (opus, /staff-code-review)
→ agent completes → check GitHub for PENDING review
  → pending → human-required (user publishes)
  → not pending → in-review
→ poll detects published → in-review
```

**Changes:**
- `HasPendingReview()` in github client — REST API check for draft reviews
- `createReviewTask()` / `startReviewAgent()` / `resolveReviewStatus()` in app.go
- `handleAgentComplete` review branch — skips eval, checks pending status
- `maybeDispatchTasks` — review tasks use review-specific agent config
- `pollAndMonitorPRs` restructured — auto-creates review tasks from `ReviewRequested` PRs, detects published reviews (`human-required` → `in-review`)
- Guards to prevent review tasks from triggering implementation dispatch