### PR TITLE
feat(board): replace plan-review column with badge

### DIFF
--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -91,6 +91,12 @@
       </span>
     {/if}
 
+    {#if t.status === 'plan-review'}
+      <span class="inline-flex items-center gap-1 rounded bg-error-200 px-1.5 py-0.5 font-semibold text-error-800 dark:bg-error-700 dark:text-error-200">
+        Needs Review
+      </span>
+    {/if}
+
     {#if agentRunning}
       <span class="inline-flex items-center gap-1 rounded bg-success-200 px-1.5 py-0.5 text-success-800 dark:bg-success-700 dark:text-success-200">
         <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-success-500"></span>

--- a/frontend/src/components/TaskCard.svelte.test.ts
+++ b/frontend/src/components/TaskCard.svelte.test.ts
@@ -53,6 +53,16 @@ describe('TaskCard', () => {
     expect(handler).toHaveBeenCalledOnce()
   })
 
+  it('shows Needs Review badge for plan-review status', () => {
+    render(TaskCard, { props: { task: { ...mockTask, status: 'plan-review' }, onclick: () => {} } })
+    expect(screen.getByText('Needs Review')).toBeDefined()
+  })
+
+  it('does not show Needs Review badge for other statuses', () => {
+    render(TaskCard, { props: { task: mockTask, onclick: () => {} } })
+    expect(screen.queryByText('Needs Review')).toBeNull()
+  })
+
   describe('timeAgo', () => {
     beforeEach(() => {
       vi.useFakeTimers()

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -59,7 +59,6 @@
   const columns = [
     { status: 'todo', label: 'Todo', border: 'border-t-surface-400 dark:border-t-surface-500' },
     { status: 'planning', label: 'Planning', border: 'border-t-tertiary-500 dark:border-t-tertiary-400' },
-    { status: 'plan-review', label: 'Plan Review', border: 'border-t-tertiary-300 dark:border-t-tertiary-600' },
     { status: 'in-progress', label: 'In Progress', border: 'border-t-primary-500 dark:border-t-primary-400' },
     { status: 'in-review', label: 'In Review', border: 'border-t-warning-500 dark:border-t-warning-400' },
     { status: 'human-required', label: 'Human Required', border: 'border-t-error-500 dark:border-t-error-400' },
@@ -74,7 +73,9 @@
     <p class="m-auto text-sm text-error-500">{taskStore.error}</p>
   {:else}
     {#each columns as col}
-      {@const tasks = taskStore.byStatus(col.status)}
+      {@const tasks = col.status === 'planning'
+        ? [...taskStore.byStatus('planning'), ...taskStore.byStatus('plan-review')]
+        : taskStore.byStatus(col.status)}
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
         class="flex min-w-[250px] flex-1 flex-col rounded-lg border-t-4 bg-surface-100 transition-shadow dark:bg-surface-900 {col.border} {dragOverStatus === col.status ? 'ring-2 ring-primary-400 dark:ring-primary-500' : ''}"

--- a/frontend/src/pages/TaskList.svelte.test.ts
+++ b/frontend/src/pages/TaskList.svelte.test.ts
@@ -55,7 +55,6 @@ describe('TaskList', () => {
     render(TaskList, { props: { onselect: vi.fn() } })
     expect(screen.getByText('Todo')).toBeDefined()
     expect(screen.getByText('Planning')).toBeDefined()
-    expect(screen.getByText('Plan Review')).toBeDefined()
     expect(screen.getByText('In Progress')).toBeDefined()
     expect(screen.getByText('In Review')).toBeDefined()
     expect(screen.getByText('Human Required')).toBeDefined()
@@ -68,7 +67,7 @@ describe('TaskList', () => {
     expect(mockByStatus).not.toHaveBeenCalledWith('new')
     expect(mockByStatus).toHaveBeenCalledWith('todo')
     expect(mockByStatus).toHaveBeenCalledWith('planning')
-    expect(mockByStatus).toHaveBeenCalledWith('plan-review')
+    expect(mockByStatus).toHaveBeenCalledWith('plan-review') // merged into Planning column
     expect(mockByStatus).toHaveBeenCalledWith('in-progress')
     expect(mockByStatus).toHaveBeenCalledWith('in-review')
     expect(mockByStatus).toHaveBeenCalledWith('human-required')
@@ -77,8 +76,10 @@ describe('TaskList', () => {
 
   it('renders task cards in columns', () => {
     const tasks = [mockTask('t-1', 'First Task'), mockTask('t-2', 'Second Task')]
-    mockByStatus.mockReturnValue(tasks)
+    mockByStatus.mockImplementation((status: string) =>
+      status === 'plan-review' ? [] : tasks,
+    )
     render(TaskList, { props: { onselect: vi.fn() } })
-    expect(screen.getAllByText('First Task')).toHaveLength(7)
+    expect(screen.getAllByText('First Task')).toHaveLength(6)
   })
 })


### PR DESCRIPTION
## Motivation

Plan Review as a separate board column adds clutter. A badge on the card is sufficient to signal that a task needs human review, while keeping the board more compact.

## Implementation information

- Removed `plan-review` column from `TaskList.svelte`
- Planning column now fetches both `planning` and `plan-review` tasks
- Added red "Needs Review" badge to `TaskCard.svelte` for `plan-review` status
- Backend `ApprovePlan`/`RejectPlan` logic unchanged
- `TaskDetail` approve/reject UI unchanged