### PR TITLE
feat(agent): log JSON parse failures in headless runner

### DIFF
--- a/internal/agent/parser_test.go
+++ b/internal/agent/parser_test.go
@@ -85,7 +85,7 @@ func TestParseStreamEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := parseStreamEvent([]byte(tt.line))
+			got, _ := parseStreamEvent([]byte(tt.line))
 			if got.Type != tt.want.Type {
 				t.Errorf("Type = %q, want %q", got.Type, tt.want.Type)
 			}

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -69,7 +69,11 @@ func (m *Manager) runHeadless(ctx context.Context, a *Agent, prompt string, allo
 			_, _ = outFile.WriteString("\n")
 		}
 
-		event := parseStreamEvent(line)
+		event, err := parseStreamEvent(line)
+		if err != nil {
+			m.logger.Warn("agent.headless.parse", "id", a.ID, "err", err, "line", string(line))
+			continue
+		}
 		if event.Type == "" {
 			continue
 		}
@@ -102,10 +106,10 @@ func (m *Manager) runHeadless(ctx context.Context, a *Agent, prompt string, allo
 	}
 }
 
-func parseStreamEvent(line []byte) StreamEvent {
+func parseStreamEvent(line []byte) (StreamEvent, error) {
 	var raw map[string]any
 	if err := json.Unmarshal(line, &raw); err != nil {
-		return StreamEvent{}
+		return StreamEvent{}, fmt.Errorf("unmarshal stream event: %w", err)
 	}
 
 	eventType, _ := raw["type"].(string)
@@ -135,7 +139,7 @@ func parseStreamEvent(line []byte) StreamEvent {
 		// rate_limit_event, etc — keep type, no content
 	}
 
-	return event
+	return event, nil
 }
 
 func extractMessageContent(raw map[string]any) string {


### PR DESCRIPTION
## Motivation

Silent JSON parse failures in `parseStreamEvent` made it impossible to diagnose malformed output from the `claude` process. Parse errors were swallowed, making debugging headless agent issues harder.

## Implementation information

- Changed `parseStreamEvent` signature from `StreamEvent` to `(StreamEvent, error)`
- Returns wrapped error on `json.Unmarshal` failure instead of empty struct
- Caller in `runHeadless` logs `Warn` with the raw line on parse error
- Updated `parser_test.go` to handle new return signature

Closes #75

> Changelog: feat(agent): log JSON parse failures in headless runner