### PR TITLE
fix(agent): restart stale tasks on startup

### DIFF
--- a/app.go
+++ b/app.go
@@ -110,6 +110,7 @@ func (a *App) startup(ctx context.Context) {
 	a.prTracker = github.NewIssueTracker(30 * time.Minute)
 	a.reconnectAgents()
 	a.cleanStaleRuns()
+	a.restartStaleInProgress()
 	a.syncSkills()
 	a.RegisterSpotlightHotkey()
 	a.wg.Go(func() { a.orchestratorLoop(ctx) })
@@ -186,6 +187,35 @@ func (a *App) cleanStaleRuns() {
 				"result": "stale: marked stopped on startup",
 			})
 		}
+	}
+}
+
+// restartStaleInProgress finds in-progress tasks with no running agent and
+// restarts them. Covers headless agents lost during app restart.
+func (a *App) restartStaleInProgress() {
+	tasks, err := a.tasks.List()
+	if err != nil {
+		return
+	}
+	for i := range tasks {
+		t := &tasks[i]
+		if t.Status != task.StatusInProgress {
+			continue
+		}
+		if a.agents.HasRunningAgentForTask(t.ID) {
+			continue
+		}
+		if slices.Contains(t.Tags, "review") {
+			continue
+		}
+		a.logger.Info("restart-stale.start", "task_id", t.ID, "title", t.Title)
+		taskID := t.ID
+		mode := t.AgentMode
+		a.wg.Go(func() {
+			if _, err := a.StartAgent(taskID, mode, "Continue implementing this task. When done, create a draft PR with `gh pr create --draft`."); err != nil {
+				a.logger.Error("restart-stale.failed", "task_id", taskID, "err", err)
+			}
+		})
 	}
 }
 
@@ -349,11 +379,8 @@ func (a *App) prepareWorktree(t task.Task) (string, error) {
 		}
 		return wtPath, nil
 	}
-	if err := project.CreateWorktree(proj.ClonePath, wtPath, wtBranch, "origin/"+branch); err != nil {
-		// Branch may exist from a previous run — try checkout instead of new branch
-		if errRe := project.CreateWorktreeExisting(proj.ClonePath, wtPath, wtBranch); errRe != nil {
-			return "", fmt.Errorf("create worktree: %w (retry: %w)", err, errRe)
-		}
+	if err := project.CreateWorktree(proj.ClonePath, wtPath, wtBranch, "refs/remotes/origin/"+branch); err != nil {
+		return "", fmt.Errorf("create worktree: %w", err)
 	}
 
 	a.logger.Info("worktree.created", "task_id", t.ID, "path", wtPath)

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -72,16 +72,12 @@ func CreateWorktree(barePath, worktreePath, branch, baseBranch string) error {
 	cmd := exec.Command("git", "worktree", "add", worktreePath, "-b", branch, baseBranch)
 	cmd.Dir = barePath
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git worktree add: %w: %s", err, string(out))
-	}
-	return nil
-}
-
-func CreateWorktreeExisting(barePath, worktreePath, branch string) error {
-	cmd := exec.Command("git", "worktree", "add", worktreePath, branch)
-	cmd.Dir = barePath
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git worktree add (existing): %w: %s", err, string(out))
+		// Branch already exists from a previous run — reuse it
+		cmd2 := exec.Command("git", "worktree", "add", worktreePath, branch)
+		cmd2.Dir = barePath
+		if out2, err2 := cmd2.CombinedOutput(); err2 != nil {
+			return fmt.Errorf("git worktree add: %w: %s (retry: %w: %s)", err, string(out), err2, string(out2))
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Motivation

Headless agents are killed on app shutdown but their tasks remain `in-progress`. On next startup nothing picks them back up, leaving orphaned tasks that appear running but have no agent.

Additionally, `CreateWorktree` used short `origin/main` ref which becomes ambiguous in bare clones that have both `refs/heads/origin/main` and `refs/remotes/origin/main`.

## Implementation information

- Add `restartStaleInProgress()` called during startup after `reconnectAgents()` and `cleanStaleRuns()` — finds in-progress tasks with no running agent (excluding review tasks) and restarts them
- Use fully qualified `refs/remotes/origin/<branch>` in `prepareWorktree` to avoid ambiguous ref errors
- Consolidate `CreateWorktree` + `CreateWorktreeExisting` into single function that auto-retries with existing branch if `-b` fails