### PR TITLE
feat(review): triage reviews by PR size

### DIFF
--- a/app_agents.go
+++ b/app_agents.go
@@ -288,6 +288,9 @@ func (a *App) handleAgentComplete(ag *agent.Agent) {
 	if strings.HasPrefix(ag.Name, "review:") {
 		a.logger.Info("review.complete", "agent_id", ag.ID, "task_id", ag.TaskID)
 		a.logAudit(audit.EventReviewStarted, ag.TaskID, ag.ID, agentData)
+		if _, err := a.tasks.Update(ag.TaskID, map[string]any{"reviewed": true}); err != nil {
+			a.logger.Error("review.mark-reviewed", "task_id", ag.TaskID, "err", err)
+		}
 		go a.resolveReviewStatus(ag.TaskID)
 		return
 	}

--- a/app_reviews.go
+++ b/app_reviews.go
@@ -28,6 +28,11 @@ func (a *App) MarkPRReady(repo string, number int) error {
 	return github.MarkReady(repo, number)
 }
 
+const (
+	reviewSmallAdditions = 200
+	reviewSmallFiles     = 5
+)
+
 func (a *App) createReviewTask(pr github.PullRequest, projectID string) {
 	title := "Review: " + pr.Title
 	body := fmt.Sprintf("%s\n\nAuthor: @%s", pr.URL, pr.Author)
@@ -42,7 +47,7 @@ func (a *App) createReviewTask(pr github.PullRequest, projectID string) {
 		"tags":       "review",
 		"project_id": projectID,
 		"pr_number":  pr.Number,
-		"status":     string(task.StatusInReview),
+		"status":     string(task.StatusTodo),
 	})
 	if err != nil {
 		a.logger.Error("review.update-task", "task_id", t.ID, "err", err)
@@ -50,9 +55,50 @@ func (a *App) createReviewTask(pr github.PullRequest, projectID string) {
 	}
 	a.logger.Info("review.task-created", "task_id", t.ID, "pr", pr.Number, "project", projectID)
 
-	if err := a.startReviewAgent(t); err != nil {
-		a.logger.Error("review.auto-start", "task_id", t.ID, "err", err)
+	a.wg.Go(func() { a.triageReview(t) })
+}
+
+func (a *App) triageReview(t task.Task) {
+	stats, err := github.FetchPRStats(t.ProjectID, t.PRNumber)
+	if err != nil {
+		a.logger.Warn("review.triage.stats", "task_id", t.ID, "err", err)
+		// fallback: start agent when we can't determine size
+		if _, err := a.tasks.Update(t.ID, map[string]any{"status": string(task.StatusInReview)}); err != nil {
+			a.logger.Error("review.triage.status", "task_id", t.ID, "err", err)
+		}
+		if err := a.startReviewAgent(t); err != nil {
+			a.logger.Error("review.triage.start", "task_id", t.ID, "err", err)
+		}
+		return
 	}
+
+	a.logger.Info("review.triage", "task_id", t.ID, "additions", stats.Additions, "files", stats.ChangedFiles)
+
+	if stats.Additions < reviewSmallAdditions && stats.ChangedFiles < reviewSmallFiles {
+		if _, err := a.tasks.Update(t.ID, map[string]any{"status": string(task.StatusHumanRequired)}); err != nil {
+			a.logger.Error("review.triage.human", "task_id", t.ID, "err", err)
+		}
+		a.logger.Info("review.triage.small", "task_id", t.ID, "additions", stats.Additions, "files", stats.ChangedFiles)
+		return
+	}
+
+	if _, err := a.tasks.Update(t.ID, map[string]any{"status": string(task.StatusInReview)}); err != nil {
+		a.logger.Error("review.triage.status", "task_id", t.ID, "err", err)
+	}
+	if err := a.startReviewAgent(t); err != nil {
+		a.logger.Error("review.triage.start", "task_id", t.ID, "err", err)
+	}
+}
+
+func (a *App) StartReview(taskID string) error {
+	t, err := a.tasks.Get(taskID)
+	if err != nil {
+		return err
+	}
+	if t.ProjectID == "" || t.PRNumber == 0 {
+		return fmt.Errorf("task %s has no linked PR", taskID)
+	}
+	return a.startReviewAgent(t)
 }
 
 func (a *App) startReviewAgent(t task.Task) error {

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -3,6 +3,7 @@
   import type { agent, task } from '../../wailsjs/go/models.js'
   import { EventsOn } from '../../wailsjs/runtime/runtime.js'
   import { BrowserOpenURL } from '../../wailsjs/runtime/runtime.js'
+  import { StartReview } from '../../wailsjs/go/main/App.js'
   import { taskStore } from '../stores/tasks.svelte.js'
   import { agentStore } from '../stores/agents.svelte.js'
   import { reviewStore } from '../stores/reviews.svelte.js'
@@ -181,6 +182,28 @@
 
   const linkedPRs = $derived(t ? reviewStore.byTask(t) : [])
 
+  let reviewLoading = $state(false)
+
+  const isReviewTask = $derived(t?.tags?.includes('review') ?? false)
+
+  const reviewingAgent = $derived(
+    (agentStore.list ?? []).some((a) => a.taskId === taskId && a.name?.startsWith('review:') && a.state === 'running')
+  )
+
+  async function runReview() {
+    if (!t) return
+    reviewLoading = true
+    error = ''
+    try {
+      await StartReview(taskId)
+      await loadTask()
+    } catch (e) {
+      error = String(e)
+    } finally {
+      reviewLoading = false
+    }
+  }
+
   let rejectFeedback = $state('')
   let planActionLoading = $state(false)
 
@@ -274,6 +297,27 @@
               <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-warning-500"></span>
               Evaluating
             </span>
+          {/if}
+          {#if reviewingAgent}
+            <span class="inline-flex items-center gap-1 rounded-full bg-purple-200 px-2 py-0.5 text-xs font-medium text-purple-800 dark:bg-purple-700 dark:text-purple-200">
+              <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-purple-500"></span>
+              Reviewing
+            </span>
+          {/if}
+          {#if t.reviewed}
+            <span class="inline-flex items-center gap-1 rounded-full bg-success-200 px-2 py-0.5 text-xs font-medium text-success-800 dark:bg-success-700 dark:text-success-200" title="Review agent completed">
+              ✓ Reviewed
+            </span>
+          {/if}
+          {#if isReviewTask && t.prNumber && t.projectId}
+            <button
+              type="button"
+              class="rounded bg-purple-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-purple-600 disabled:opacity-50"
+              onclick={runReview}
+              disabled={reviewLoading || reviewingAgent}
+            >
+              {reviewLoading ? 'Starting...' : t.reviewed ? 'Re-run Review' : 'Run Review'}
+            </button>
           {/if}
           <button
             type="button"

--- a/frontend/src/stores/agents.svelte.ts
+++ b/frontend/src/stores/agents.svelte.ts
@@ -43,7 +43,7 @@ class AgentStore extends EntityStore<agent.Agent> {
 
   async start(taskID: string, mode: string, prompt: string): Promise<agent.Agent> {
     const result = await StartAgent(taskID, mode, prompt)
-    this.items.set(result.id, result)
+    this.set(result.id, result)
     this.outputs.set(result.id, [])
     return result
   }
@@ -53,7 +53,7 @@ class AgentStore extends EntityStore<agent.Agent> {
     const a = this.items.get(agentID)
     if (a) {
       a.state = 'stopped'
-      this.items.set(agentID, a)
+      this.set(agentID, a)
     }
   }
 
@@ -69,7 +69,7 @@ class AgentStore extends EntityStore<agent.Agent> {
   }
 
   updateAgent(agentID: string, data: agent.Agent): void {
-    this.items.set(agentID, data)
+    this.set(agentID, data)
   }
 }
 

--- a/frontend/src/stores/entity-store.svelte.ts
+++ b/frontend/src/stores/entity-store.svelte.ts
@@ -13,6 +13,16 @@ export class EntityStore<T extends { id: string }> {
     return [...this.items.values()].sort(this.sortFn)
   }
 
+  protected set(id: string, item: T): void {
+    this.items = new Map(this.items).set(id, item)
+  }
+
+  protected delete(id: string): void {
+    const next = new Map(this.items)
+    next.delete(id)
+    this.items = next
+  }
+
   async load(): Promise<void> {
     this.loading = true
     this.error = ''

--- a/frontend/src/stores/projects.svelte.ts
+++ b/frontend/src/stores/projects.svelte.ts
@@ -29,25 +29,25 @@ class ProjectStore extends EntityStore<project.Project> {
 
   async get(id: string): Promise<project.Project> {
     const result = await GetProject(id)
-    this.items.set(result.id, result)
+    this.set(result.id, result)
     return result
   }
 
   async create(url: string, type: string = 'pet'): Promise<project.Project> {
     const result = await CreateProject(url, type)
-    this.items.set(result.id, result)
+    this.set(result.id, result)
     return result
   }
 
   async update(id: string, type: string): Promise<project.Project> {
     const result = await UpdateProject(id, type)
-    this.items.set(result.id, result)
+    this.set(result.id, result)
     return result
   }
 
   async remove(id: string): Promise<void> {
     await DeleteProject(id)
-    this.items.delete(id)
+    this.delete(id)
   }
 }
 

--- a/frontend/src/stores/tasks.svelte.ts
+++ b/frontend/src/stores/tasks.svelte.ts
@@ -36,36 +36,36 @@ class TaskStore extends EntityStore<task.Task> {
 
   async get(id: string): Promise<task.Task> {
     const result = await GetTask(id)
-    this.items.set(result.id, result)
+    this.set(result.id, result)
     return result
   }
 
   async create(title: string, body: string, mode: string): Promise<task.Task> {
     const result = await CreateTask(title, body, mode)
-    this.items.set(result.id, result)
+    this.set(result.id, result)
     return result
   }
 
   async update(id: string, updates: Record<string, any>): Promise<task.Task> {
     const result = await UpdateTask(id, updates)
-    this.items.set(result.id, result)
+    this.set(result.id, result)
     return result
   }
 
   async remove(id: string): Promise<void> {
     await DeleteTask(id)
-    this.items.delete(id)
+    this.delete(id)
   }
 
   async approvePlan(id: string): Promise<task.Task> {
     const result = await ApprovePlan(id)
-    this.items.set(result.id, result)
+    this.set(result.id, result)
     return result
   }
 
   async rejectPlan(id: string, feedback: string): Promise<task.Task> {
     const result = await RejectPlan(id, feedback)
-    this.items.set(result.id, result)
+    this.set(result.id, result)
     return result
   }
 }

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -73,6 +73,8 @@ export function StartAgent(arg1:string,arg2:string,arg3:string):Promise<agent.Ag
 
 export function StartOrchestrator():Promise<void>;
 
+export function StartReview(arg1:string):Promise<void>;
+
 export function StopAgent(arg1:string):Promise<void>;
 
 export function StopOrchestrator():Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -134,6 +134,10 @@ export function StartOrchestrator() {
   return window['go']['main']['App']['StartOrchestrator']();
 }
 
+export function StartReview(arg1) {
+  return window['go']['main']['App']['StartReview'](arg1);
+}
+
 export function StopAgent(arg1) {
   return window['go']['main']['App']['StopAgent'](arg1);
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -315,6 +315,7 @@ export namespace task {
 	    projectId: string;
 	    branch: string;
 	    prNumber: number;
+	    reviewed: boolean;
 	    agentRuns: AgentRun[];
 	    // Go type: time
 	    createdAt: any;
@@ -339,6 +340,7 @@ export namespace task {
 	        this.projectId = source["projectId"];
 	        this.branch = source["branch"];
 	        this.prNumber = source["prNumber"];
+	        this.reviewed = source["reviewed"];
 	        this.agentRuns = this.convertValues(source["agentRuns"], AgentRun);
 	        this.createdAt = this.convertValues(source["createdAt"], null);
 	        this.updatedAt = this.convertValues(source["updatedAt"], null);

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -234,6 +234,31 @@ func hasPendingReviewWith(e execer, repo string, number int) (bool, error) {
 	return false, nil
 }
 
+// PRStats holds size metrics for a pull request.
+type PRStats struct {
+	Additions    int `json:"additions"`
+	Deletions    int `json:"deletions"`
+	ChangedFiles int `json:"changedFiles"`
+}
+
+// FetchPRStats returns additions, deletions, and changed file count for a PR.
+func FetchPRStats(repo string, number int) (PRStats, error) {
+	return fetchPRStatsWith(defaultExecer, repo, number)
+}
+
+func fetchPRStatsWith(e execer, repo string, number int) (PRStats, error) {
+	out, err := e.run("pr", "view", fmt.Sprintf("%d", number),
+		"--repo", repo, "--json", "additions,deletions,changedFiles")
+	if err != nil {
+		return PRStats{}, fmt.Errorf("gh pr view %d stats: %s: %w", number, strings.TrimSpace(string(out)), err)
+	}
+	var s PRStats
+	if err := json.Unmarshal(out, &s); err != nil {
+		return PRStats{}, fmt.Errorf("parse pr stats: %w", err)
+	}
+	return s, nil
+}
+
 // PRState holds the current state of a specific PR.
 type PRState struct {
 	State    string `json:"state"`    // OPEN, CLOSED, MERGED

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -54,6 +54,7 @@ type Task struct {
 	ProjectID    string     `yaml:"project_id,omitempty" json:"projectId"`
 	Branch       string     `yaml:"branch,omitempty" json:"branch"`
 	PRNumber     int        `yaml:"pr_number,omitempty" json:"prNumber"`
+	Reviewed     bool       `yaml:"reviewed,omitempty" json:"reviewed"`
 	AgentRuns    []AgentRun `yaml:"agent_runs,omitempty" json:"agentRuns"`
 	CreatedAt    time.Time  `yaml:"created_at" json:"createdAt"`
 	UpdatedAt    time.Time  `yaml:"updated_at" json:"updatedAt"`

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -134,6 +134,9 @@ func (s *Store) Update(id string, updates map[string]any) (Task, error) {
 	case int:
 		t.PRNumber = v
 	}
+	if v, ok := updates["reviewed"].(bool); ok {
+		t.Reviewed = v
+	}
 
 	data, err := Marshal(t)
 	if err != nil {


### PR DESCRIPTION
## Motivation

Review tasks were auto-starting the review agent on all PRs regardless of size. Small/straightforward PRs don't need AI review — user can review them faster. Also no way to track if review was run or re-trigger it.

## Implementation information

- Triage reviews by PR size via `gh pr view` stats (additions, changed files)
- Small PRs (<200 additions, <5 files) → `human-required` status
- Large/complex PRs → start review agent with `/staff-code-review`
- Added `reviewed` bool field on Task model, set on review agent completion
- Added `StartReview` bound method + "Run Review" button on task detail
- Fixed Svelte 5 reactivity: `EntityStore` Map mutations now create new Map instances to trigger `$state` updates (was causing board not updating on drag)

## Supporting documentation

- Closes #107 (svelte-check CI gap discovered during this work)