### PR TITLE
feat(dispatch): skip tasks with PR ready to merge

### DIFF
--- a/app_orchestrator.go
+++ b/app_orchestrator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Automaat/synapse/internal/agent"
 	"github.com/Automaat/synapse/internal/audit"
 	"github.com/Automaat/synapse/internal/config"
+	"github.com/Automaat/synapse/internal/github"
 	"github.com/Automaat/synapse/internal/task"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
@@ -134,6 +135,14 @@ func (a *App) maybeDispatchTasks() {
 		}
 		if a.agents.HasRunningAgentForTask(tasks[i].ID) {
 			continue
+		}
+		if tasks[i].PRNumber > 0 && tasks[i].ProjectID != "" {
+			prState, err := github.FetchPRState(tasks[i].ProjectID, tasks[i].PRNumber)
+			if err == nil && prState.ReadyToMerge() {
+				a.logger.Info("auto-dispatch.skip", "task_id", tasks[i].ID, "reason", "pr_ready_to_merge",
+					"pr", tasks[i].PRNumber, "mergeable", prState.Mergeable, "ci", prState.CIStatus())
+				continue
+			}
 		}
 		candidates = append(candidates, tasks[i])
 	}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -236,8 +236,40 @@ func hasPendingReviewWith(e execer, repo string, number int) (bool, error) {
 
 // PRState holds the current state of a specific PR.
 type PRState struct {
-	State    string `json:"state"`    // OPEN, CLOSED, MERGED
-	MergedAt string `json:"mergedAt"` // non-empty if merged
+	State             string `json:"state"`     // OPEN, CLOSED, MERGED
+	MergedAt          string `json:"mergedAt"`  // non-empty if merged
+	Mergeable         string `json:"mergeable"` // MERGEABLE, CONFLICTING, UNKNOWN
+	StatusCheckRollup []struct {
+		State string `json:"state"` // SUCCESS, FAILURE, PENDING, ERROR, etc.
+	} `json:"statusCheckRollup"`
+}
+
+// CIStatus returns a simplified CI status: SUCCESS, FAILURE, PENDING, or "".
+// FAILURE takes precedence over PENDING.
+func (s PRState) CIStatus() string {
+	if len(s.StatusCheckRollup) == 0 {
+		return ""
+	}
+	hasPending := false
+	for _, c := range s.StatusCheckRollup {
+		switch c.State {
+		case "FAILURE", "ERROR":
+			return "FAILURE"
+		case "PENDING", "QUEUED", "IN_PROGRESS", "WAITING", "STALE":
+			hasPending = true
+		}
+	}
+	if hasPending {
+		return "PENDING"
+	}
+	return "SUCCESS"
+}
+
+// ReadyToMerge reports whether the PR is open, has no conflicts, and CI passes.
+func (s PRState) ReadyToMerge() bool {
+	return s.State == "OPEN" &&
+		s.Mergeable == "MERGEABLE" &&
+		(s.CIStatus() == "SUCCESS" || s.CIStatus() == "")
 }
 
 // FetchPRState fetches the current state of a specific PR by repo and number.
@@ -247,7 +279,7 @@ func FetchPRState(repo string, number int) (PRState, error) {
 
 func fetchPRStateWith(e execer, repo string, number int) (PRState, error) {
 	out, err := e.run("pr", "view", fmt.Sprintf("%d", number),
-		"--repo", repo, "--json", "state,mergedAt")
+		"--repo", repo, "--json", "state,mergedAt,mergeable,statusCheckRollup")
 	if err != nil {
 		return PRState{}, fmt.Errorf("gh pr view %d: %s: %w", number, strings.TrimSpace(string(out)), err)
 	}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -586,6 +586,68 @@ func TestFetchPRStateWith(t *testing.T) {
 	}
 }
 
+func TestPRState_CIStatus(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		checks []struct{ State string }
+		want   string
+	}{
+		{"no checks", nil, ""},
+		{"all success", []struct{ State string }{{"SUCCESS"}, {"NEUTRAL"}}, "SUCCESS"},
+		{"has failure", []struct{ State string }{{"SUCCESS"}, {"FAILURE"}}, "FAILURE"},
+		{"has error", []struct{ State string }{{"ERROR"}}, "FAILURE"},
+		{"has pending", []struct{ State string }{{"SUCCESS"}, {"PENDING"}}, "PENDING"},
+		{"failure beats pending", []struct{ State string }{{"PENDING"}, {"FAILURE"}}, "FAILURE"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			checks := make([]struct {
+				State string `json:"state"`
+			}, len(tt.checks))
+			for i, c := range tt.checks {
+				checks[i].State = c.State
+			}
+			s := PRState{StatusCheckRollup: checks}
+			if got := s.CIStatus(); got != tt.want {
+				t.Errorf("CIStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPRState_ReadyToMerge(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		state     PRState
+		wantReady bool
+	}{
+		{"open mergeable no ci", PRState{State: "OPEN", Mergeable: "MERGEABLE"}, true},
+		{"open mergeable ci success", PRState{State: "OPEN", Mergeable: "MERGEABLE", StatusCheckRollup: []struct {
+			State string `json:"state"`
+		}{{"SUCCESS"}}}, true},
+		{"not open", PRState{State: "MERGED", Mergeable: "MERGEABLE"}, false},
+		{"conflicting", PRState{State: "OPEN", Mergeable: "CONFLICTING"}, false},
+		{"unknown mergeable", PRState{State: "OPEN", Mergeable: "UNKNOWN"}, false},
+		{"ci failing", PRState{State: "OPEN", Mergeable: "MERGEABLE", StatusCheckRollup: []struct {
+			State string `json:"state"`
+		}{{"FAILURE"}}}, false},
+		{"ci pending", PRState{State: "OPEN", Mergeable: "MERGEABLE", StatusCheckRollup: []struct {
+			State string `json:"state"`
+		}{{"PENDING"}}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.state.ReadyToMerge(); got != tt.wantReady {
+				t.Errorf("ReadyToMerge() = %v, want %v", got, tt.wantReady)
+			}
+		})
+	}
+}
+
 func TestParseGQLResponse_botFiltered(t *testing.T) {
 	t.Parallel()
 	raw := `{


### PR DESCRIPTION
## Motivation

Orchestrator was dispatching multiple agents for tasks whose PRs were already mergeable with passing CI, wasting tokens. Closes #90.

## Implementation information

Added pre-dispatch check in `maybeDispatchTasks()`: before adding a task to candidates, fetch PR state via `gh pr view --json state,mergedAt,mergeable,statusCheckRollup`. Skip the task if the PR is open, conflict-free, and CI passes.

Extended `PRState` with `Mergeable`, `StatusCheckRollup`, `CIStatus()` and `ReadyToMerge()`. Error fetching PR state is non-blocking — dispatch proceeds on failure.

> Changelog: feat(dispatch): skip tasks with PR ready to merge