### PR TITLE
fix(app): sync skills to correct dir before agents start

### DIFF
--- a/app.go
+++ b/app.go
@@ -105,10 +105,10 @@ func (a *App) startup(ctx context.Context) {
 	}
 
 	a.prTracker = github.NewIssueTracker(30 * time.Minute)
+	a.syncSkills()
 	a.reconnectAgents()
 	a.cleanStaleRuns()
 	a.restartStaleInProgress()
-	a.syncSkills()
 	a.RegisterSpotlightHotkey()
 	a.wg.Go(func() { a.orchestratorLoop(ctx) })
 	a.wg.Go(func() { a.prPollLoop(ctx) })
@@ -228,15 +228,13 @@ func (a *App) syncSkills() {
 		a.logger.Info("skills.sync.fallback_cwd", "dir", cwd)
 	}
 
-	home := config.HomeDir()
-	a.logger.Info("skills.sync.start", "src", repoDir, "dst", home)
+	a.logger.Info("skills.sync.start", "src", repoDir, "dst", a.skillsDir)
 
 	skillsSrc := filepath.Join(repoDir, ".claude", "skills")
-	skillsDst := filepath.Join(home, ".claude", "skills")
-	a.syncDir(skillsSrc, skillsDst)
+	a.syncDir(skillsSrc, a.skillsDir)
 
 	claudeSrc := filepath.Join(repoDir, "orchestrator", "CLAUDE.md")
-	claudeDst := filepath.Join(home, "CLAUDE.md")
+	claudeDst := filepath.Join(config.HomeDir(), "CLAUDE.md")
 	a.syncFile(claudeSrc, claudeDst)
 
 	a.logger.Info("skills.sync.done")


### PR DESCRIPTION
## Motivation

`/synapse-triage` wasn't registered as a slash command in one session.
Two bugs caused this:
1. Skills were copied to `~/.synapse/.claude/skills/` instead of `~/.synapse/skills/` (the configured `skills_dir`)
2. `syncSkills()` ran after `reconnectAgents()`, so reconnected agents started without skills available

## Implementation information

- Use `a.skillsDir` as the sync destination (was hardcoded to `filepath.Join(home, ".claude", "skills")`)
- Move `syncSkills()` before `reconnectAgents()` in the startup sequence

> Changelog: fix(app): sync skills to correct dir before agents start