### PR TITLE
feat(task): add issue field to task model

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -148,6 +148,9 @@ func cmdGet(s *task.Store, args []string, jsonOut bool) int {
 	if t.PRNumber > 0 {
 		fmt.Printf("PR: #%d\n", t.PRNumber)
 	}
+	if t.Issue != "" {
+		fmt.Printf("Issue: %s\n", t.Issue)
+	}
 	fmt.Printf("Created: %s\n", t.CreatedAt.Format("2006-01-02 15:04"))
 	fmt.Printf("Updated: %s\n", t.UpdatedAt.Format("2006-01-02 15:04"))
 	if t.Body != "" {
@@ -165,6 +168,7 @@ func cmdCreate(s *task.Store, args []string, jsonOut bool) int {
 	proj := fs.String("project", "", "project id (owner/repo)")
 	branch := fs.String("branch", "", "Git branch name")
 	pr := fs.Int("pr", 0, "GitHub PR number")
+	issue := fs.String("issue", "", "GitHub issue URL")
 	if err := fs.Parse(args); err != nil {
 		return fatal(jsonOut, "%v", err)
 	}
@@ -193,6 +197,9 @@ func cmdCreate(s *task.Store, args []string, jsonOut bool) int {
 	}
 	if *pr > 0 {
 		updates["pr_number"] = float64(*pr)
+	}
+	if *issue != "" {
+		updates["issue"] = *issue
 	}
 	if len(updates) > 0 {
 		t, err = s.Update(t.ID, updates)
@@ -223,6 +230,7 @@ func cmdUpdate(s *task.Store, args []string, jsonOut bool) int {
 	proj := fs.String("project", "", "project id (owner/repo)")
 	branch := fs.String("branch", "", "Git branch name")
 	pr := fs.Int("pr", 0, "GitHub PR number")
+	issue := fs.String("issue", "", "GitHub issue URL")
 	if err := fs.Parse(args[1:]); err != nil {
 		return fatal(jsonOut, "%v", err)
 	}
@@ -255,6 +263,9 @@ func cmdUpdate(s *task.Store, args []string, jsonOut bool) int {
 	}
 	if *pr > 0 {
 		updates["pr_number"] = float64(*pr)
+	}
+	if *issue != "" {
+		updates["issue"] = *issue
 	}
 
 	if len(updates) == 0 {
@@ -544,8 +555,8 @@ func usage() {
 Commands:
   list     [--status STATUS] [--tag TAG] [--project ID]
   get      <id>
-  create   --title TITLE [--body BODY] [--mode MODE] [--tags t1,t2] [--project ID] [--branch B] [--pr N]
-  update   <id> [--title T] [--status S] [--body B] [--mode M] [--tags T] [--project ID] [--branch B] [--pr N]
+  create   --title TITLE [--body BODY] [--mode MODE] [--tags t1,t2] [--project ID] [--branch B] [--pr N] [--issue URL]
+  update   <id> [--title T] [--status S] [--body B] [--mode M] [--tags T] [--project ID] [--branch B] [--pr N] [--issue URL]
   delete   <id>
 
   project list

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -131,6 +131,16 @@
       </span>
     {/if}
 
+    {#if t.issue}
+      <span
+        class="inline-flex items-center gap-1 rounded bg-blue-500/15 px-1.5 py-0.5 font-medium text-blue-600 dark:text-blue-400"
+        title={t.issue}
+      >
+        <svg class="h-3 w-3" viewBox="0 0 16 16" fill="currentColor"><path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"/><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"/></svg>
+        Issue
+      </span>
+    {/if}
+
     {#if t.tags?.length}
       {#each t.tags as tag}
         <span class="rounded bg-surface-200 px-1.5 py-0.5 dark:bg-surface-700">

--- a/frontend/src/components/TaskCard.svelte.test.ts
+++ b/frontend/src/components/TaskCard.svelte.test.ts
@@ -13,6 +13,7 @@ const mockTask = {
   projectId: '',
   branch: '',
   prNumber: 0,
+  issue: '',
   reviewed: false,
   agentRuns: [],
   createdAt: '2026-04-01T00:00:00Z',

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -380,6 +380,20 @@
           </div>
         {/if}
 
+        {#if t.issue}
+          <div class="flex flex-col gap-1">
+            <span class="font-medium text-surface-500">Issue</span>
+            <button
+              type="button"
+              class="flex w-fit items-center gap-1.5 text-sm text-blue-600 hover:underline dark:text-blue-400"
+              onclick={() => t && BrowserOpenURL(t.issue)}
+            >
+              <svg class="h-4 w-4 shrink-0" viewBox="0 0 16 16" fill="currentColor"><path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"/><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"/></svg>
+              {t.issue}
+            </button>
+          </div>
+        {/if}
+
         {#if t.allowedTools?.length}
           <div class="flex flex-col gap-1">
             <span class="font-medium text-surface-500">Allowed Tools</span>

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -315,6 +315,7 @@ export namespace task {
 	    projectId: string;
 	    branch: string;
 	    prNumber: number;
+	    issue: string;
 	    reviewed: boolean;
 	    agentRuns: AgentRun[];
 	    // Go type: time
@@ -340,6 +341,7 @@ export namespace task {
 	        this.projectId = source["projectId"];
 	        this.branch = source["branch"];
 	        this.prNumber = source["prNumber"];
+	        this.issue = source["issue"];
 	        this.reviewed = source["reviewed"];
 	        this.agentRuns = this.convertValues(source["agentRuns"], AgentRun);
 	        this.createdAt = this.convertValues(source["createdAt"], null);

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -54,6 +54,7 @@ type Task struct {
 	ProjectID    string     `yaml:"project_id,omitempty" json:"projectId"`
 	Branch       string     `yaml:"branch,omitempty" json:"branch"`
 	PRNumber     int        `yaml:"pr_number,omitempty" json:"prNumber"`
+	Issue        string     `yaml:"issue,omitempty" json:"issue"`
 	Reviewed     bool       `yaml:"reviewed,omitempty" json:"reviewed"`
 	AgentRuns    []AgentRun `yaml:"agent_runs,omitempty" json:"agentRuns"`
 	CreatedAt    time.Time  `yaml:"created_at" json:"createdAt"`

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -134,6 +134,9 @@ func (s *Store) Update(id string, updates map[string]any) (Task, error) {
 	case int:
 		t.PRNumber = v
 	}
+	if v, ok := updates["issue"].(string); ok {
+		t.Issue = v
+	}
 	if v, ok := updates["reviewed"].(bool); ok {
 		t.Reviewed = v
 	}


### PR DESCRIPTION
## Motivation

When tasks are created from GitHub issues, there's no way to store or display the source issue. This adds an `issue` field (URL string) so tasks can link back to their originating GitHub issue.

## Implementation information

- Added `Issue string` field to `Task` struct with YAML/JSON tags
- Store `Update()` handles the new `issue` key
- CLI `create`/`update` commands accept `--issue URL` flag, `get` displays it
- TaskDetail shows clickable issue link (blue, opens via `BrowserOpenURL`)
- TaskCard shows blue "Issue" badge with tooltip
- Wails TS bindings regenerated, test fixtures updated

> Changelog: feat(task): add issue field to task model