### PR TITLE
feat(stats): add persistent usage analytics

### DIFF
--- a/app.go
+++ b/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Automaat/synapse/internal/notification"
 	"github.com/Automaat/synapse/internal/project"
 	"github.com/Automaat/synapse/internal/spotlight"
+	"github.com/Automaat/synapse/internal/stats"
 	"github.com/Automaat/synapse/internal/task"
 	"github.com/Automaat/synapse/internal/tmux"
 	"github.com/Automaat/synapse/internal/watcher"
@@ -35,6 +36,7 @@ type App struct {
 	watcher      *watcher.Watcher
 	notifier     *notification.Emitter
 	audit        *audit.Logger
+	stats        *stats.Store
 	tasksDir     string
 	skillsDir    string
 	repoDir      string
@@ -69,6 +71,16 @@ func (a *App) startup(ctx context.Context) {
 	a.audit = al
 	if err := audit.Cleanup(a.auditDir, 30); err != nil {
 		a.logger.Error("audit.cleanup", "err", err)
+	}
+
+	statsStore, err := stats.NewStore(config.StatsFile())
+	if err != nil {
+		a.logger.Error("stats.init", "err", err)
+	} else {
+		a.stats = statsStore
+		if err := statsStore.Backfill(a.auditDir); err != nil {
+			a.logger.Error("stats.backfill", "err", err)
+		}
 	}
 
 	store, err := task.NewStore(a.tasksDir)

--- a/app_agents.go
+++ b/app_agents.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Automaat/synapse/internal/audit"
 	"github.com/Automaat/synapse/internal/notification"
 	"github.com/Automaat/synapse/internal/project"
+	"github.com/Automaat/synapse/internal/stats"
 	"github.com/Automaat/synapse/internal/task"
 	"github.com/Automaat/synapse/internal/tmux"
 )
@@ -241,6 +242,8 @@ func (a *App) handleAgentComplete(ag *agent.Agent) {
 		"state":      string(ag.State),
 	}
 
+	a.recordStats(ag, duration)
+
 	// Persist run result to task file
 	truncatedResult := resultContent
 	if len(truncatedResult) > 2000 {
@@ -359,4 +362,41 @@ func hasResultEvent(ag *agent.Agent) bool {
 		}
 	}
 	return false
+}
+
+func (a *App) recordStats(ag *agent.Agent, duration float64) {
+	if a.stats == nil {
+		return
+	}
+	outcome := "completed"
+	if !hasResultEvent(ag) {
+		outcome = "failed"
+	}
+	var projectID string
+	if t, err := a.tasks.Get(ag.TaskID); err == nil {
+		projectID = t.ProjectID
+	}
+	_ = a.stats.Record(stats.RunRecord{
+		ID:           ag.ID,
+		TaskID:       ag.TaskID,
+		ProjectID:    projectID,
+		Mode:         ag.Mode,
+		Role:         deriveRole(ag.Name),
+		Model:        ag.Model,
+		CostUSD:      ag.CostUSD,
+		DurationS:    duration,
+		InputTokens:  ag.InputTokens,
+		OutputTokens: ag.OutputTokens,
+		Outcome:      outcome,
+		Timestamp:    ag.StartedAt,
+	})
+}
+
+func deriveRole(name string) string {
+	for _, prefix := range []string{"triage:", "plan:", "eval:", "pr-fix:", "review:"} {
+		if strings.HasPrefix(name, prefix) {
+			return strings.TrimSuffix(prefix, ":")
+		}
+	}
+	return "implementation"
 }

--- a/app_stats.go
+++ b/app_stats.go
@@ -1,0 +1,10 @@
+package main
+
+import "github.com/Automaat/synapse/internal/stats"
+
+func (a *App) GetStats() stats.StatsResponse {
+	if a.stats == nil {
+		return stats.StatsResponse{}
+	}
+	return a.stats.Query()
+}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -19,6 +19,7 @@
   import TmuxSessions from './pages/TmuxSessions.svelte'
   import Orchestrator from './pages/Orchestrator.svelte'
   import GitHub from './pages/GitHub.svelte'
+  import Stats from './pages/Stats.svelte'
 
   type Page =
     | { kind: 'dashboard' }
@@ -31,6 +32,7 @@
     | { kind: 'orchestrator' }
     | { kind: 'tmux' }
     | { kind: 'github' }
+    | { kind: 'stats' }
 
   let page = $state<Page>({ kind: 'dashboard' })
   let dialogOpen = $state(false)
@@ -49,6 +51,7 @@
     page.kind === 'orchestrator' ? 'Orchestrator' :
     page.kind === 'tmux' ? 'Tmux Sessions' :
     page.kind === 'github' ? 'GitHub' :
+    page.kind === 'stats' ? 'Stats' :
     'Agent Detail'
   )
 
@@ -116,6 +119,10 @@
       if (e.metaKey && e.key === '7') {
         e.preventDefault()
         page = { kind: 'github' }
+      }
+      if (e.metaKey && e.key === '8') {
+        e.preventDefault()
+        page = { kind: 'stats' }
       }
     }
     window.addEventListener('keydown', handleKeydown)
@@ -204,6 +211,15 @@
         </svg>
         <Navigation.TriggerText>GitHub</Navigation.TriggerText>
       </Navigation.Trigger>
+      <Navigation.Trigger
+        onclick={() => (page = { kind: 'stats' })}
+        data-active={page.kind === 'stats' || undefined}
+      >
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+        </svg>
+        <Navigation.TriggerText>Stats</Navigation.TriggerText>
+      </Navigation.Trigger>
     </Navigation.Content>
   </Navigation>
 
@@ -265,6 +281,8 @@
         <TmuxSessions />
       {:else if page.kind === 'github'}
         <GitHub />
+      {:else if page.kind === 'stats'}
+        <Stats />
       {/if}
     </main>
   </div>

--- a/frontend/src/pages/Stats.svelte
+++ b/frontend/src/pages/Stats.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+  import { statsStore } from '../stores/stats.svelte.js'
+  import type { stats } from '../../wailsjs/go/models.js'
+
+  type Period = 'today' | 'thisWeek' | 'thisMonth' | 'allTime'
+
+  let period = $state<Period>('allTime')
+
+  const periods: { key: Period; label: string }[] = [
+    { key: 'today', label: 'Today' },
+    { key: 'thisWeek', label: 'This Week' },
+    { key: 'thisMonth', label: 'This Month' },
+    { key: 'allTime', label: 'All Time' },
+  ]
+
+  const summary = $derived(
+    statsStore.data ? statsStore.data[period] : null,
+  )
+
+  $effect(() => {
+    statsStore.load()
+  })
+
+  function formatDuration(seconds: number): string {
+    if (seconds < 60) return `${seconds.toFixed(0)}s`
+    if (seconds < 3600) return `${(seconds / 60).toFixed(1)}m`
+    return `${(seconds / 3600).toFixed(1)}h`
+  }
+
+  function formatTokens(n: number): string {
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+    return String(n)
+  }
+
+  function formatDate(ts: any): string {
+    if (!ts) return ''
+    const d = new Date(ts)
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) +
+      ' ' + d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+  }
+
+  function roleBadgeClasses(role: string): string {
+    switch (role) {
+      case 'triage': return 'bg-secondary-200 text-secondary-800 dark:bg-secondary-800 dark:text-secondary-200'
+      case 'plan': return 'bg-tertiary-200 text-tertiary-800 dark:bg-tertiary-800 dark:text-tertiary-200'
+      case 'eval': return 'bg-warning-200 text-warning-800 dark:bg-warning-800 dark:text-warning-200'
+      case 'review': return 'bg-primary-200 text-primary-800 dark:bg-primary-800 dark:text-primary-200'
+      default: return 'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200'
+    }
+  }
+</script>
+
+<div class="flex flex-col gap-6 p-6">
+  <div class="flex items-center justify-between">
+    <h1 class="text-2xl font-bold">Stats</h1>
+    <button
+      type="button"
+      class="rounded-lg bg-surface-200 px-3 py-1.5 text-sm font-medium hover:bg-surface-300 dark:bg-surface-700 dark:hover:bg-surface-600"
+      onclick={() => statsStore.load()}
+    >
+      Refresh
+    </button>
+  </div>
+
+  {#if statsStore.error}
+    <p class="text-error-500">{statsStore.error}</p>
+  {/if}
+
+  <!-- Period tabs -->
+  <div class="flex gap-1 rounded-lg bg-surface-100 p-1 dark:bg-surface-800">
+    {#each periods as p (p.key)}
+      <button
+        type="button"
+        class="rounded-md px-4 py-1.5 text-sm font-medium transition-colors {period === p.key
+          ? 'bg-white shadow dark:bg-surface-600 dark:text-white'
+          : 'text-surface-500 hover:text-surface-700 dark:hover:text-surface-300'}"
+        onclick={() => (period = p.key)}
+      >
+        {p.label}
+      </button>
+    {/each}
+  </div>
+
+  <!-- Summary cards -->
+  {#if summary}
+    <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+      <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <span class="text-xs font-medium text-surface-500">Total Cost</span>
+        <p class="mt-1 text-2xl font-bold">${summary.totalCostUsd.toFixed(2)}</p>
+      </div>
+      <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <span class="text-xs font-medium text-surface-500">Total Runs</span>
+        <p class="mt-1 text-2xl font-bold">{summary.totalRuns}</p>
+      </div>
+      <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <span class="text-xs font-medium text-surface-500">Avg Cost / Run</span>
+        <p class="mt-1 text-2xl font-bold">${summary.avgCostPerRun.toFixed(4)}</p>
+      </div>
+      <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <span class="text-xs font-medium text-surface-500">Total Duration</span>
+        <p class="mt-1 text-2xl font-bold">{formatDuration(summary.totalDurationS)}</p>
+      </div>
+      <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <span class="text-xs font-medium text-surface-500">Tokens (In / Out)</span>
+        <p class="mt-1 text-2xl font-bold">
+          {formatTokens(summary.totalInputTokens)} / {formatTokens(summary.totalOutputTokens)}
+        </p>
+      </div>
+    </div>
+  {/if}
+
+  <!-- Breakdowns -->
+  {#if statsStore.data}
+    <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+      {#each [
+        { title: 'By Project', data: statsStore.data.byProject },
+        { title: 'By Role', data: statsStore.data.byRole },
+        { title: 'By Mode', data: statsStore.data.byMode },
+        { title: 'By Model', data: statsStore.data.byModel },
+      ] as section (section.title)}
+        <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+          <h3 class="mb-3 text-sm font-semibold text-surface-500">{section.title}</h3>
+          {#if section.data && section.data.length > 0}
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="border-b border-surface-200 text-left text-xs text-surface-400 dark:border-surface-700">
+                  <th class="pb-2">Name</th>
+                  <th class="pb-2 text-right">Runs</th>
+                  <th class="pb-2 text-right">Cost</th>
+                  <th class="pb-2 text-right">Duration</th>
+                </tr>
+              </thead>
+              <tbody>
+                {#each section.data as row (row.key)}
+                  <tr class="border-b border-surface-100 last:border-0 dark:border-surface-700">
+                    <td class="py-1.5 font-mono text-xs">{row.key}</td>
+                    <td class="py-1.5 text-right">{row.stats.totalRuns}</td>
+                    <td class="py-1.5 text-right">${row.stats.totalCostUsd.toFixed(2)}</td>
+                    <td class="py-1.5 text-right">{formatDuration(row.stats.totalDurationS)}</td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+          {:else}
+            <p class="text-xs text-surface-400">No data</p>
+          {/if}
+        </div>
+      {/each}
+    </div>
+
+    <!-- Recent runs -->
+    <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+      <h3 class="mb-3 text-sm font-semibold text-surface-500">Recent Runs</h3>
+      {#if statsStore.data.recentRuns && statsStore.data.recentRuns.length > 0}
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-surface-200 text-left text-xs text-surface-400 dark:border-surface-700">
+                <th class="pb-2">Time</th>
+                <th class="pb-2">Task</th>
+                <th class="pb-2">Role</th>
+                <th class="pb-2">Mode</th>
+                <th class="pb-2">Model</th>
+                <th class="pb-2 text-right">Cost</th>
+                <th class="pb-2 text-right">Duration</th>
+                <th class="pb-2">Outcome</th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each statsStore.data.recentRuns as run (run.id)}
+                <tr class="border-b border-surface-100 last:border-0 dark:border-surface-700">
+                  <td class="py-1.5 text-xs text-surface-500">{formatDate(run.timestamp)}</td>
+                  <td class="py-1.5 font-mono text-xs">{run.taskId}</td>
+                  <td class="py-1.5">
+                    <span class="rounded px-1.5 py-0.5 text-xs {roleBadgeClasses(run.role)}">{run.role}</span>
+                  </td>
+                  <td class="py-1.5 text-xs">{run.mode}</td>
+                  <td class="py-1.5 text-xs">{run.model || '—'}</td>
+                  <td class="py-1.5 text-right text-xs">${run.costUsd.toFixed(4)}</td>
+                  <td class="py-1.5 text-right text-xs">{formatDuration(run.durationS)}</td>
+                  <td class="py-1.5">
+                    <span class="rounded px-1.5 py-0.5 text-xs {run.outcome === 'completed'
+                      ? 'bg-success-200 text-success-800 dark:bg-success-800 dark:text-success-200'
+                      : 'bg-error-200 text-error-800 dark:bg-error-800 dark:text-error-200'}">
+                      {run.outcome}
+                    </span>
+                  </td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+      {:else}
+        <p class="text-xs text-surface-400">No runs recorded yet</p>
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/frontend/src/stores/stats.svelte.ts
+++ b/frontend/src/stores/stats.svelte.ts
@@ -1,0 +1,22 @@
+import { GetStats } from '../../wailsjs/go/main/App.js'
+import type { stats } from '../../wailsjs/go/models.js'
+
+class StatsStore {
+  data = $state<stats.StatsResponse | null>(null)
+  loading = $state(false)
+  error = $state('')
+
+  async load(): Promise<void> {
+    this.loading = true
+    this.error = ''
+    try {
+      this.data = await GetStats()
+    } catch (e) {
+      this.error = String(e)
+    } finally {
+      this.loading = false
+    }
+  }
+}
+
+export const statsStore = new StatsStore()

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -4,6 +4,7 @@ import {task} from '../models';
 import {project} from '../models';
 import {agent} from '../models';
 import {github} from '../models';
+import {stats} from '../models';
 import {notification} from '../models';
 import {tmux} from '../models';
 
@@ -36,6 +37,8 @@ export function FetchReviews():Promise<github.ReviewSummary>;
 export function GetAgentOutput(arg1:string):Promise<Array<agent.StreamEvent>>;
 
 export function GetProject(arg1:string):Promise<project.Project>;
+
+export function GetStats():Promise<stats.StatsResponse>;
 
 export function GetTask(arg1:string):Promise<task.Task>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -62,6 +62,10 @@ export function GetProject(arg1) {
   return window['go']['main']['App']['GetProject'](arg1);
 }
 
+export function GetStats() {
+  return window['go']['main']['App']['GetStats']();
+}
+
 export function GetTask(arg1) {
   return window['go']['main']['App']['GetTask'](arg1);
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -8,6 +8,8 @@ export namespace agent {
 	    sessionId: string;
 	    tmuxSession: string;
 	    costUsd: number;
+	    inputTokens?: number;
+	    outputTokens?: number;
 	    // Go type: time
 	    startedAt: any;
 	    external: boolean;
@@ -30,6 +32,8 @@ export namespace agent {
 	        this.sessionId = source["sessionId"];
 	        this.tmuxSession = source["tmuxSession"];
 	        this.costUsd = source["costUsd"];
+	        this.inputTokens = source["inputTokens"];
+	        this.outputTokens = source["outputTokens"];
 	        this.startedAt = this.convertValues(source["startedAt"], null);
 	        this.external = source["external"];
 	        this.pid = source["pid"];
@@ -62,6 +66,8 @@ export namespace agent {
 	    content?: string;
 	    session_id?: string;
 	    cost_usd?: number;
+	    input_tokens?: number;
+	    output_tokens?: number;
 	    subtype?: string;
 	
 	    static createFrom(source: any = {}) {
@@ -74,6 +80,8 @@ export namespace agent {
 	        this.content = source["content"];
 	        this.session_id = source["session_id"];
 	        this.cost_usd = source["cost_usd"];
+	        this.input_tokens = source["input_tokens"];
+	        this.output_tokens = source["output_tokens"];
 	        this.subtype = source["subtype"];
 	    }
 	}
@@ -253,6 +261,166 @@ export namespace project {
 	        this.taskId = source["taskId"];
 	        this.head = source["head"];
 	    }
+	}
+
+}
+
+export namespace stats {
+	
+	export class Summary {
+	    totalCostUsd: number;
+	    totalRuns: number;
+	    avgCostPerRun: number;
+	    avgDurationS: number;
+	    totalDurationS: number;
+	    totalInputTokens: number;
+	    totalOutputTokens: number;
+	
+	    static createFrom(source: any = {}) {
+	        return new Summary(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.totalCostUsd = source["totalCostUsd"];
+	        this.totalRuns = source["totalRuns"];
+	        this.avgCostPerRun = source["avgCostPerRun"];
+	        this.avgDurationS = source["avgDurationS"];
+	        this.totalDurationS = source["totalDurationS"];
+	        this.totalInputTokens = source["totalInputTokens"];
+	        this.totalOutputTokens = source["totalOutputTokens"];
+	    }
+	}
+	export class GroupedStat {
+	    key: string;
+	    stats: Summary;
+	
+	    static createFrom(source: any = {}) {
+	        return new GroupedStat(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.key = source["key"];
+	        this.stats = this.convertValues(source["stats"], Summary);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	export class RunRecord {
+	    id: string;
+	    taskId: string;
+	    projectId?: string;
+	    mode: string;
+	    role: string;
+	    model?: string;
+	    costUsd: number;
+	    durationS: number;
+	    inputTokens?: number;
+	    outputTokens?: number;
+	    outcome: string;
+	    // Go type: time
+	    timestamp: any;
+	
+	    static createFrom(source: any = {}) {
+	        return new RunRecord(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.id = source["id"];
+	        this.taskId = source["taskId"];
+	        this.projectId = source["projectId"];
+	        this.mode = source["mode"];
+	        this.role = source["role"];
+	        this.model = source["model"];
+	        this.costUsd = source["costUsd"];
+	        this.durationS = source["durationS"];
+	        this.inputTokens = source["inputTokens"];
+	        this.outputTokens = source["outputTokens"];
+	        this.outcome = source["outcome"];
+	        this.timestamp = this.convertValues(source["timestamp"], null);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
+	}
+	export class StatsResponse {
+	    today: Summary;
+	    thisWeek: Summary;
+	    thisMonth: Summary;
+	    allTime: Summary;
+	    byProject: GroupedStat[];
+	    byMode: GroupedStat[];
+	    byRole: GroupedStat[];
+	    byModel: GroupedStat[];
+	    recentRuns: RunRecord[];
+	
+	    static createFrom(source: any = {}) {
+	        return new StatsResponse(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.today = this.convertValues(source["today"], Summary);
+	        this.thisWeek = this.convertValues(source["thisWeek"], Summary);
+	        this.thisMonth = this.convertValues(source["thisMonth"], Summary);
+	        this.allTime = this.convertValues(source["allTime"], Summary);
+	        this.byProject = this.convertValues(source["byProject"], GroupedStat);
+	        this.byMode = this.convertValues(source["byMode"], GroupedStat);
+	        this.byRole = this.convertValues(source["byRole"], GroupedStat);
+	        this.byModel = this.convertValues(source["byModel"], GroupedStat);
+	        this.recentRuns = this.convertValues(source["recentRuns"], RunRecord);
+	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
 	}
 
 }

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -16,20 +16,22 @@ const (
 )
 
 type Agent struct {
-	ID          string    `json:"id"`
-	TaskID      string    `json:"taskId"`
-	Mode        string    `json:"mode"`
-	State       State     `json:"state"`
-	SessionID   string    `json:"sessionId"`
-	TmuxSession string    `json:"tmuxSession"`
-	CostUSD     float64   `json:"costUsd"`
-	StartedAt   time.Time `json:"startedAt"`
-	External    bool      `json:"external"`
-	PID         int       `json:"pid,omitempty"`
-	Command     string    `json:"command,omitempty"`
-	Name        string    `json:"name,omitempty"`
-	Project     string    `json:"project,omitempty"`
-	Model       string    `json:"model,omitempty"`
+	ID           string    `json:"id"`
+	TaskID       string    `json:"taskId"`
+	Mode         string    `json:"mode"`
+	State        State     `json:"state"`
+	SessionID    string    `json:"sessionId"`
+	TmuxSession  string    `json:"tmuxSession"`
+	CostUSD      float64   `json:"costUsd"`
+	InputTokens  int       `json:"inputTokens,omitempty"`
+	OutputTokens int       `json:"outputTokens,omitempty"`
+	StartedAt    time.Time `json:"startedAt"`
+	External     bool      `json:"external"`
+	PID          int       `json:"pid,omitempty"`
+	Command      string    `json:"command,omitempty"`
+	Name         string    `json:"name,omitempty"`
+	Project      string    `json:"project,omitempty"`
+	Model        string    `json:"model,omitempty"`
 
 	ExitErr      error `json:"-"`
 	outputBuffer []StreamEvent
@@ -57,9 +59,11 @@ type RunConfig struct {
 }
 
 type StreamEvent struct {
-	Type      string  `json:"type"`
-	Content   string  `json:"content,omitempty"`
-	SessionID string  `json:"session_id,omitempty"`
-	CostUSD   float64 `json:"cost_usd,omitempty"`
-	Subtype   string  `json:"subtype,omitempty"`
+	Type         string  `json:"type"`
+	Content      string  `json:"content,omitempty"`
+	SessionID    string  `json:"session_id,omitempty"`
+	CostUSD      float64 `json:"cost_usd,omitempty"`
+	InputTokens  int     `json:"input_tokens,omitempty"`
+	OutputTokens int     `json:"output_tokens,omitempty"`
+	Subtype      string  `json:"subtype,omitempty"`
 }

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -84,6 +84,8 @@ func (m *Manager) runHeadless(ctx context.Context, a *Agent, prompt string, allo
 		if event.Type == "result" {
 			a.SessionID = event.SessionID
 			a.CostUSD += event.CostUSD
+			a.InputTokens += event.InputTokens
+			a.OutputTokens += event.OutputTokens
 			m.logger.Info("agent.headless.result", "id", a.ID, "session_id", event.SessionID, "cost", a.CostUSD)
 		}
 	}
@@ -136,6 +138,12 @@ func parseStreamEvent(line []byte) (StreamEvent, error) {
 		event.SessionID, _ = raw["session_id"].(string)
 		if cost, ok := raw["total_cost_usd"].(float64); ok {
 			event.CostUSD = cost
+		}
+		if v, ok := raw["total_input_tokens"].(float64); ok {
+			event.InputTokens = int(v)
+		}
+		if v, ok := raw["total_output_tokens"].(float64); ok {
+			event.OutputTokens = int(v)
 		}
 
 	default:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -154,3 +154,7 @@ func defaultClonesDir() string {
 func defaultWorktreesDir() string {
 	return filepath.Join(HomeDir(), "worktrees")
 }
+
+func StatsFile() string {
+	return filepath.Join(HomeDir(), "stats.json")
+}

--- a/internal/stats/backfill.go
+++ b/internal/stats/backfill.go
@@ -1,0 +1,61 @@
+package stats
+
+import (
+	"time"
+
+	"github.com/Automaat/synapse/internal/audit"
+)
+
+// Backfill imports historical agent runs from audit logs into the stats store.
+// It skips import if the store already has records.
+func (s *Store) Backfill(auditDir string) error {
+	if s.Len() > 0 {
+		return nil
+	}
+
+	events, err := audit.Read(auditDir, audit.Query{
+		Since: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		Until: time.Now().Add(24 * time.Hour),
+		Type:  "agent.",
+	})
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, ev := range events {
+		if ev.Type != audit.EventAgentCompleted && ev.Type != audit.EventAgentFailed {
+			continue
+		}
+
+		r := RunRecord{
+			ID:        ev.AgentID,
+			TaskID:    ev.TaskID,
+			Timestamp: ev.Timestamp,
+		}
+
+		if v, ok := ev.Data["mode"].(string); ok {
+			r.Mode = v
+		}
+		if v, ok := ev.Data["cost_usd"].(float64); ok {
+			r.CostUSD = v
+		}
+		if v, ok := ev.Data["duration_s"].(float64); ok {
+			r.DurationS = v
+		}
+		if v, ok := ev.Data["state"].(string); ok && v == "stopped" {
+			r.Outcome = "completed"
+		} else {
+			r.Outcome = "failed"
+		}
+
+		s.runs = append(s.runs, r)
+	}
+
+	if len(s.runs) > 0 {
+		return s.flush()
+	}
+	return nil
+}

--- a/internal/stats/model.go
+++ b/internal/stats/model.go
@@ -1,0 +1,49 @@
+package stats
+
+import "time"
+
+// RunRecord captures a single agent execution for analytics.
+type RunRecord struct {
+	ID           string    `json:"id"`
+	TaskID       string    `json:"taskId"`
+	ProjectID    string    `json:"projectId,omitempty"`
+	Mode         string    `json:"mode"`
+	Role         string    `json:"role"`
+	Model        string    `json:"model,omitempty"`
+	CostUSD      float64   `json:"costUsd"`
+	DurationS    float64   `json:"durationS"`
+	InputTokens  int       `json:"inputTokens,omitempty"`
+	OutputTokens int       `json:"outputTokens,omitempty"`
+	Outcome      string    `json:"outcome"`
+	Timestamp    time.Time `json:"timestamp"`
+}
+
+// Summary holds aggregate metrics over a set of runs.
+type Summary struct {
+	TotalCostUSD      float64 `json:"totalCostUsd"`
+	TotalRuns         int     `json:"totalRuns"`
+	AvgCostPerRun     float64 `json:"avgCostPerRun"`
+	AvgDurationS      float64 `json:"avgDurationS"`
+	TotalDurationS    float64 `json:"totalDurationS"`
+	TotalInputTokens  int     `json:"totalInputTokens"`
+	TotalOutputTokens int     `json:"totalOutputTokens"`
+}
+
+// GroupedStat is an aggregate keyed by a dimension (project, mode, etc).
+type GroupedStat struct {
+	Key   string  `json:"key"`
+	Stats Summary `json:"stats"`
+}
+
+// StatsResponse is the full analytics payload returned to the frontend.
+type StatsResponse struct {
+	Today      Summary       `json:"today"`
+	ThisWeek   Summary       `json:"thisWeek"`
+	ThisMonth  Summary       `json:"thisMonth"`
+	AllTime    Summary       `json:"allTime"`
+	ByProject  []GroupedStat `json:"byProject"`
+	ByMode     []GroupedStat `json:"byMode"`
+	ByRole     []GroupedStat `json:"byRole"`
+	ByModel    []GroupedStat `json:"byModel"`
+	RecentRuns []RunRecord   `json:"recentRuns"`
+}

--- a/internal/stats/store.go
+++ b/internal/stats/store.go
@@ -1,0 +1,180 @@
+package stats
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Store persists RunRecords to a JSON file and computes aggregates in memory.
+type Store struct {
+	path string
+	mu   sync.Mutex
+	runs []RunRecord
+}
+
+func NewStore(path string) (*Store, error) {
+	s := &Store{path: path}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return s, nil
+		}
+		return nil, err
+	}
+
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &s.runs); err != nil {
+			return nil, err
+		}
+	}
+	return s, nil
+}
+
+func (s *Store) Record(r RunRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.runs = append(s.runs, r)
+	return s.flush()
+}
+
+func (s *Store) Len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.runs)
+}
+
+func (s *Store) Query() StatsResponse {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	weekStart := todayStart.AddDate(0, 0, -int(todayStart.Weekday()))
+	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+
+	var today, week, month, all []RunRecord
+	byProject := map[string][]RunRecord{}
+	byMode := map[string][]RunRecord{}
+	byRole := map[string][]RunRecord{}
+	byModel := map[string][]RunRecord{}
+
+	for i := range s.runs {
+		r := &s.runs[i]
+		all = append(all, *r)
+
+		if !r.Timestamp.Before(todayStart) {
+			today = append(today, *r)
+		}
+		if !r.Timestamp.Before(weekStart) {
+			week = append(week, *r)
+		}
+		if !r.Timestamp.Before(monthStart) {
+			month = append(month, *r)
+		}
+
+		pid := r.ProjectID
+		if pid == "" {
+			pid = "(none)"
+		}
+		byProject[pid] = append(byProject[pid], *r)
+
+		byMode[r.Mode] = append(byMode[r.Mode], *r)
+
+		role := r.Role
+		if role == "" {
+			role = "implementation"
+		}
+		byRole[role] = append(byRole[role], *r)
+
+		model := r.Model
+		if model == "" {
+			model = "(unknown)"
+		}
+		byModel[model] = append(byModel[model], *r)
+	}
+
+	resp := StatsResponse{
+		Today:     summarize(today),
+		ThisWeek:  summarize(week),
+		ThisMonth: summarize(month),
+		AllTime:   summarize(all),
+		ByProject: groupedStats(byProject),
+		ByMode:    groupedStats(byMode),
+		ByRole:    groupedStats(byRole),
+		ByModel:   groupedStats(byModel),
+	}
+
+	// Recent runs: last 50, newest first
+	recent := make([]RunRecord, len(s.runs))
+	copy(recent, s.runs)
+	sort.Slice(recent, func(i, j int) bool {
+		return recent[i].Timestamp.After(recent[j].Timestamp)
+	})
+	if len(recent) > 50 {
+		recent = recent[:50]
+	}
+	resp.RecentRuns = recent
+
+	return resp
+}
+
+func (s *Store) flush() error {
+	data, err := json.Marshal(s.runs)
+	if err != nil {
+		return err
+	}
+	return atomicWrite(s.path, data)
+}
+
+func atomicWrite(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func summarize(runs []RunRecord) Summary {
+	if len(runs) == 0 {
+		return Summary{}
+	}
+	var s Summary
+	s.TotalRuns = len(runs)
+	for i := range runs {
+		s.TotalCostUSD += runs[i].CostUSD
+		s.TotalDurationS += runs[i].DurationS
+		s.TotalInputTokens += runs[i].InputTokens
+		s.TotalOutputTokens += runs[i].OutputTokens
+	}
+	s.AvgCostPerRun = s.TotalCostUSD / float64(s.TotalRuns)
+	s.AvgDurationS = s.TotalDurationS / float64(s.TotalRuns)
+	return s
+}
+
+func groupedStats(groups map[string][]RunRecord) []GroupedStat {
+	result := make([]GroupedStat, 0, len(groups))
+	for key, runs := range groups {
+		result = append(result, GroupedStat{Key: key, Stats: summarize(runs)})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Stats.TotalCostUSD > result[j].Stats.TotalCostUSD
+	})
+	return result
+}

--- a/internal/stats/store_test.go
+++ b/internal/stats/store_test.go
@@ -1,0 +1,154 @@
+package stats
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNewStoreEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stats.json")
+
+	s, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Len() != 0 {
+		t.Fatalf("expected 0 runs, got %d", s.Len())
+	}
+}
+
+func TestRecordAndQuery(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stats.json")
+
+	s, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	runs := []RunRecord{
+		{
+			ID: "a1", TaskID: "t1", ProjectID: "org/repo",
+			Mode: "headless", Role: "implementation", Model: "sonnet",
+			CostUSD: 0.05, DurationS: 30, InputTokens: 1000, OutputTokens: 500,
+			Outcome: "completed", Timestamp: now,
+		},
+		{
+			ID: "a2", TaskID: "t2", ProjectID: "org/repo",
+			Mode: "interactive", Role: "triage", Model: "opus",
+			CostUSD: 0.10, DurationS: 60, InputTokens: 2000, OutputTokens: 1000,
+			Outcome: "completed", Timestamp: now.Add(-time.Hour),
+		},
+		{
+			ID: "a3", TaskID: "t3", ProjectID: "org/other",
+			Mode: "headless", Role: "plan", Model: "sonnet",
+			CostUSD: 0.03, DurationS: 20, InputTokens: 500, OutputTokens: 200,
+			Outcome: "failed", Timestamp: now.Add(-48 * time.Hour),
+		},
+	}
+
+	for _, r := range runs {
+		if err := s.Record(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if s.Len() != 3 {
+		t.Fatalf("expected 3 runs, got %d", s.Len())
+	}
+
+	resp := s.Query()
+
+	// AllTime
+	if resp.AllTime.TotalRuns != 3 {
+		t.Errorf("allTime.totalRuns: got %d, want 3", resp.AllTime.TotalRuns)
+	}
+	wantCost := 0.05 + 0.10 + 0.03
+	if diff := resp.AllTime.TotalCostUSD - wantCost; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("allTime.totalCost: got %f, want %f", resp.AllTime.TotalCostUSD, wantCost)
+	}
+	if resp.AllTime.TotalInputTokens != 3500 {
+		t.Errorf("allTime.totalInputTokens: got %d, want 3500", resp.AllTime.TotalInputTokens)
+	}
+
+	// ByProject sorted by cost desc
+	if len(resp.ByProject) != 2 {
+		t.Fatalf("byProject: got %d groups, want 2", len(resp.ByProject))
+	}
+	if resp.ByProject[0].Key != "org/repo" {
+		t.Errorf("byProject[0].key: got %s, want org/repo", resp.ByProject[0].Key)
+	}
+
+	// ByMode
+	if len(resp.ByMode) != 2 {
+		t.Errorf("byMode: got %d groups, want 2", len(resp.ByMode))
+	}
+
+	// RecentRuns newest first
+	if len(resp.RecentRuns) != 3 {
+		t.Fatalf("recentRuns: got %d, want 3", len(resp.RecentRuns))
+	}
+	if resp.RecentRuns[0].ID != "a1" {
+		t.Errorf("recentRuns[0].id: got %s, want a1", resp.RecentRuns[0].ID)
+	}
+}
+
+func TestPersistence(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stats.json")
+
+	s, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := RunRecord{
+		ID: "a1", TaskID: "t1", Mode: "headless", Role: "implementation",
+		CostUSD: 0.05, DurationS: 30, Outcome: "completed",
+		Timestamp: time.Now(),
+	}
+	if err := s.Record(r); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify file exists
+	if _, err := os.Stat(path); err != nil {
+		t.Fatal("stats file not created")
+	}
+
+	// Reload from disk
+	s2, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s2.Len() != 1 {
+		t.Fatalf("after reload: expected 1 run, got %d", s2.Len())
+	}
+
+	resp := s2.Query()
+	if resp.AllTime.TotalCostUSD != 0.05 {
+		t.Errorf("after reload: totalCost got %f, want 0.05", resp.AllTime.TotalCostUSD)
+	}
+}
+
+func TestQueryEmptyStore(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stats.json")
+
+	s, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := s.Query()
+	if resp.AllTime.TotalRuns != 0 {
+		t.Errorf("empty store: expected 0 runs, got %d", resp.AllTime.TotalRuns)
+	}
+	if len(resp.RecentRuns) != 0 {
+		t.Errorf("empty store: expected empty recentRuns, got %d", len(resp.RecentRuns))
+	}
+}


### PR DESCRIPTION
## Motivation

No aggregate view of agent usage across app restarts. Cost data was only available per-task in AgentRun or ephemerally in-memory. Need a stats tab to track spending, run counts, token usage, and breakdowns by project/role/mode/model.

## Implementation information

**Backend (`internal/stats/`)**
- `RunRecord` model captures per-agent-run: cost, duration, tokens, role, mode, model, outcome
- JSON file-backed `Store` at `~/.synapse/stats.json` with atomic writes and mutex for concurrent access
- In-memory aggregation: periods (today/week/month/all) + dimensions (project/role/mode/model)
- Auto-backfill from existing audit logs on first run (skips if stats already populated)

**Agent token tracking**
- Extended `StreamEvent` and `Agent` structs with `InputTokens`/`OutputTokens`
- Extracts `total_input_tokens`/`total_output_tokens` from claude result events in stream parser

**Integration**
- `recordStats()` called in `handleAgentComplete` for every agent run
- `deriveRole()` maps agent name prefix to role (triage/plan/eval/pr-fix/review/implementation)
- `GetStats()` bound method exposed to frontend

**Frontend**
- Stats store (`stats.svelte.ts`) with load-on-visit pattern
- Stats page: period tab selector, 5 summary cards, 4 breakdown tables, recent runs table
- Nav rail entry with bar chart icon, Cmd+8 shortcut

## Supporting documentation

New files: `internal/stats/{model,store,backfill,store_test}.go`, `app_stats.go`, `frontend/src/{pages/Stats.svelte,stores/stats.svelte.ts}`
Modified: `app.go`, `app_agents.go`, `internal/agent/{model,runner_headless}.go`, `internal/config/config.go`, `frontend/src/App.svelte`, wails bindings