### PR TITLE
fix(agent): preserve fix-review context across restarts

### DIFF
--- a/app.go
+++ b/app.go
@@ -199,16 +199,20 @@ func (a *App) cleanStaleRuns() {
 	}
 }
 
-// restartStaleInProgress finds in-progress tasks with no running agent and
-// restarts them. Covers headless agents lost during app restart.
+// restartStaleInProgress re-dispatches headless in-progress tasks that lost
+// their agent due to a crash or restart. Interactive tasks are handled by
+// reconnectAgents (tmux sessions survive restarts).
 func (a *App) restartStaleInProgress() {
 	tasks, err := a.tasks.List()
 	if err != nil {
 		return
 	}
 	for i := range tasks {
-		t := &tasks[i]
+		t := tasks[i]
 		if t.Status != task.StatusInProgress {
+			continue
+		}
+		if t.AgentMode != "headless" {
 			continue
 		}
 		if a.agents.HasRunningAgentForTask(t.ID) {
@@ -219,7 +223,7 @@ func (a *App) restartStaleInProgress() {
 		}
 		// Tasks whose last agent was a pr-fix should not be re-implemented.
 		// Move them back to in-review so prPollLoop can re-detect and fix.
-		if lastRun := lastAgentRun(t); lastRun != nil && lastRun.Role == "pr-fix" {
+		if lastRun := lastAgentRun(&t); lastRun != nil && lastRun.Role == "pr-fix" {
 			a.logger.Info("restart-stale.revert-to-review", "task_id", t.ID)
 			if _, err := a.tasks.Update(t.ID, map[string]any{
 				"status": string(task.StatusInReview),
@@ -232,14 +236,22 @@ func (a *App) restartStaleInProgress() {
 			a.logger.Warn("restart-stale.skip", "task_id", t.ID, "reason", "no project_id")
 			continue
 		}
-		a.logger.Info("restart-stale.start", "task_id", t.ID, "title", t.Title)
+		a.logger.Info("restart.stale-in-progress", "task_id", t.ID, "run_role", t.RunRole)
 		taskID := t.ID
-		mode := t.AgentMode
-		a.wg.Go(func() {
-			if _, err := a.StartAgent(taskID, mode, "Continue implementing this task. When done, create a draft PR with `gh pr create --draft`."); err != nil {
-				a.logger.Error("restart-stale.failed", "task_id", taskID, "err", err)
-			}
-		})
+		runRole := t.RunRole
+		if runRole == "pr-fix" {
+			a.wg.Go(func() {
+				if err := a.startPRFixReviewAgent(taskID); err != nil {
+					a.logger.Error("restart.pr-fix.failed", "task_id", taskID, "err", err)
+				}
+			})
+		} else {
+			a.wg.Go(func() {
+				if _, err := a.StartAgent(taskID, "headless", "Continue implementing this task. When done, create a draft PR with `gh pr create --draft`."); err != nil {
+					a.logger.Error("restart.implement.failed", "task_id", taskID, "err", err)
+				}
+			})
+		}
 	}
 }
 

--- a/app_agents.go
+++ b/app_agents.go
@@ -156,6 +156,48 @@ func (a *App) cleanupWorktree(taskID string) {
 	}
 }
 
+// startPRFixReviewAgent starts a headless agent to address review comments on
+// the task's PR. Named "pr-fix:" so handleAgentComplete routes it correctly.
+func (a *App) startPRFixReviewAgent(taskID string) error {
+	t, err := a.tasks.Get(taskID)
+	if err != nil {
+		return err
+	}
+
+	t = a.autoAssignProject(t)
+	dir := ""
+	if t.ProjectID != "" {
+		d, wtErr := a.prepareWorktree(t)
+		if wtErr != nil {
+			return fmt.Errorf("worktree required: %w", wtErr)
+		}
+		dir = d
+	}
+
+	prompt := fmt.Sprintf("# Task: %s\n\n%s\n\n---\n\nFix the issues raised in the PR review. Push the changes when done.", t.Title, t.Body)
+	ag, err := a.agents.Run(agent.RunConfig{
+		TaskID:       taskID,
+		Name:         "pr-fix:" + t.Title,
+		Mode:         t.AgentMode,
+		Prompt:       prompt,
+		AllowedTools: t.AllowedTools,
+		Dir:          dir,
+		Model:        "sonnet",
+	})
+	if err != nil {
+		return err
+	}
+
+	a.logAudit(audit.EventAgentStarted, taskID, ag.ID, map[string]any{"mode": t.AgentMode, "title": t.Title, "role": "pr-fix"})
+	if err := a.tasks.AddRun(taskID, task.AgentRun{
+		AgentID: ag.ID, Role: "pr-fix", Mode: t.AgentMode,
+		State: string(agent.StateRunning), StartedAt: ag.StartedAt,
+	}); err != nil {
+		a.logger.Error("task.add-run", "task_id", taskID, "err", err)
+	}
+	return nil
+}
+
 // StopAgent sends a stop signal to the given agent.
 func (a *App) StopAgent(agentID string) error {
 	return a.agents.StopAgent(agentID)

--- a/app_tasks.go
+++ b/app_tasks.go
@@ -60,12 +60,24 @@ func (a *App) UpdateTask(id string, updates map[string]any) (task.Task, error) {
 		})
 	}
 	if t.Status == task.StatusInProgress && !a.agents.HasRunningAgentForTask(t.ID) && !slices.Contains(t.Tags, "review") {
-		a.logger.Info("auto-implement.start", "task_id", t.ID, "title", t.Title)
-		a.wg.Go(func() {
-			if _, err := a.StartAgent(t.ID, t.AgentMode, "Implement this task. When done, create a draft PR with `gh pr create --draft`."); err != nil {
-				a.logger.Error("auto-implement.failed", "task_id", t.ID, "err", err)
+		if prevStatus == string(task.StatusInReview) {
+			a.logger.Info("auto-fix-review.start", "task_id", t.ID, "title", t.Title)
+			if _, err := a.tasks.Update(t.ID, map[string]any{"run_role": "pr-fix"}); err != nil {
+				a.logger.Error("auto-fix-review.set-role", "task_id", t.ID, "err", err)
 			}
-		})
+			a.wg.Go(func() {
+				if err := a.startPRFixReviewAgent(t.ID); err != nil {
+					a.logger.Error("auto-fix-review.failed", "task_id", t.ID, "err", err)
+				}
+			})
+		} else {
+			a.logger.Info("auto-implement.start", "task_id", t.ID, "title", t.Title)
+			a.wg.Go(func() {
+				if _, err := a.StartAgent(t.ID, t.AgentMode, "Implement this task. When done, create a draft PR with `gh pr create --draft`."); err != nil {
+					a.logger.Error("auto-implement.failed", "task_id", t.ID, "err", err)
+				}
+			})
+		}
 	}
 	if t.Status == task.StatusDone {
 		a.wg.Go(func() { a.cleanupWorktree(t.ID) })

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -65,6 +65,7 @@ type Task struct {
 	Issue        string     `yaml:"issue,omitempty" json:"issue"`
 	StatusReason string     `yaml:"status_reason,omitempty" json:"statusReason"`
 	Reviewed     bool       `yaml:"reviewed,omitempty" json:"reviewed"`
+	RunRole      string     `yaml:"run_role,omitempty" json:"runRole"` // pr-fix when fixing review issues, "" for initial impl
 	AgentRuns    []AgentRun `yaml:"agent_runs,omitempty" json:"agentRuns"`
 	CreatedAt    time.Time  `yaml:"created_at" json:"createdAt"`
 	UpdatedAt    time.Time  `yaml:"updated_at" json:"updatedAt"`

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -170,6 +170,9 @@ func (s *Store) Update(id string, updates map[string]any) (Task, error) {
 	if v, ok := updates["reviewed"].(bool); ok {
 		t.Reviewed = v
 	}
+	if v, ok := updates["run_role"].(string); ok {
+		t.RunRole = v
+	}
 
 	data, err := Marshal(t)
 	if err != nil {


### PR DESCRIPTION
## Motivation

When a task transitions in-review → in-progress to fix review issues and Synapse restarts, the agent was re-dispatched with "Implement this task" — treating it as a fresh implementation instead of a review fix. This caused agents to re-implement rather than address PR review comments.

## Implementation information

Three-part fix:

1. **`Task.RunRole` field** (`internal/task/model.go`) — persists why the task is in-progress (`pr-fix` or empty for initial impl). Survives restarts since it's stored in the task YAML.

2. **`UpdateTask()` transition detection** (`app.go`) — when `prevStatus == in-review` and new status is `in-progress`, sets `run_role=pr-fix` and starts a `startPRFixReviewAgent()` instead of the generic implement agent. The agent is named `pr-fix:` so `handleAgentComplete` routes it to `EvaluateTask` correctly.

3. **`restartStaleInProgress()`** (`app.go`) — called on startup after `cleanStaleRuns()`. Finds headless in-progress tasks with no running agent and re-dispatches them using `run_role` to pick the correct prompt: "Fix the issues raised in the PR review" vs "Continue implementing".

> Changelog: fix(agent): preserve fix-review context across restarts