### PR TITLE
test(github): add t.Parallel() to missing tests

### DIFF
--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -531,6 +531,7 @@ func TestFetchReviewsWith_firstCallFails(t *testing.T) {
 }
 
 func TestFetchPRStateWith(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		output  string
@@ -568,6 +569,7 @@ func TestFetchPRStateWith(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			fe := &fakeExecer{output: []byte(tt.output), err: tt.execErr}
 			got, err := fetchPRStateWith(fe, "o/r", 42)
 			if (err != nil) != tt.wantErr {

--- a/internal/github/monitor_test.go
+++ b/internal/github/monitor_test.go
@@ -101,6 +101,7 @@ func TestMatchTaskPRs(t *testing.T) {
 }
 
 func TestDetectClosedTaskPRs(t *testing.T) {
+	t.Parallel()
 	merged := PRState{State: "MERGED", MergedAt: "2026-04-01T12:00:00Z"}
 	closed := PRState{State: "CLOSED"}
 	open := PRState{State: "OPEN"}
@@ -184,6 +185,7 @@ func TestDetectClosedTaskPRs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := DetectClosedTaskPRs(tt.openPRs, tt.tasks, makeFetch(tt.states))
 			if len(got) != len(tt.want) {
 				t.Fatalf("got %d results, want %d: %+v", len(got), len(tt.want), got)


### PR DESCRIPTION
## Motivation

Two test functions were missing `t.Parallel()`, preventing them from running in parallel with other tests and increasing test suite runtime.

## Implementation information

Added `t.Parallel()` to:
- `TestDetectClosedTaskPRs` in `internal/github/monitor_test.go` (top-level + subtests)
- `TestFetchPRStateWith` in `internal/github/client_test.go` (top-level + subtests)

`git_test.go` and `debounce_test.go` already had `t.Parallel()` where appropriate.

Verified with `go test -race ./internal/github/... ./internal/project/...`.

## Supporting documentation

Closes #126

> Changelog: skip