### PR TITLE
refactor(events): add Wails event name constants

### DIFF
--- a/app_orchestrator.go
+++ b/app_orchestrator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Automaat/synapse/internal/agent"
 	"github.com/Automaat/synapse/internal/audit"
 	"github.com/Automaat/synapse/internal/config"
+	"github.com/Automaat/synapse/internal/events"
 	"github.com/Automaat/synapse/internal/github"
 	"github.com/Automaat/synapse/internal/task"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
@@ -27,7 +28,7 @@ func (a *App) StartOrchestrator() error {
 	}
 	a.logger.Info("orchestrator.started")
 	a.logAudit(audit.EventOrchestratorStart, "", "", nil)
-	runtime.EventsEmit(a.ctx, "orchestrator:state", "running")
+	runtime.EventsEmit(a.ctx, events.OrchestratorState, "running")
 	return nil
 }
 
@@ -38,7 +39,7 @@ func (a *App) StopOrchestrator() error {
 	}
 	a.logger.Info("orchestrator.stopped")
 	a.logAudit(audit.EventOrchestratorStop, "", "", nil)
-	runtime.EventsEmit(a.ctx, "orchestrator:state", "stopped")
+	runtime.EventsEmit(a.ctx, events.OrchestratorState, "stopped")
 	return nil
 }
 

--- a/app_reviews.go
+++ b/app_reviews.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Automaat/synapse/internal/agent"
 	"github.com/Automaat/synapse/internal/audit"
 	"github.com/Automaat/synapse/internal/config"
+	"github.com/Automaat/synapse/internal/events"
 	"github.com/Automaat/synapse/internal/github"
 	"github.com/Automaat/synapse/internal/project"
 	"github.com/Automaat/synapse/internal/task"
@@ -227,7 +228,7 @@ func (a *App) pollAndMonitorPRs() time.Duration {
 		return prPollSlow
 	}
 
-	runtime.EventsEmit(a.ctx, "reviews:updated", summary)
+	runtime.EventsEmit(a.ctx, events.ReviewsUpdated, summary)
 
 	tasks, err := a.tasks.List()
 	if err != nil {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Navigation, AppBar } from '@skeletonlabs/skeleton-svelte'
   import { EventsOn } from '../wailsjs/runtime/runtime.js'
+  import * as ev from './lib/events.js'
   import { taskStore } from './stores/tasks.svelte.js'
   import { agentStore } from './stores/agents.svelte.js'
   import { projectStore } from './stores/projects.svelte.js'
@@ -68,10 +69,10 @@
     projectStore.load()
     projectStore.startPolling()
 
-    const unsubTasks = onEvents(['task:created', 'task:updated', 'task:deleted'], () => taskStore.load())
+    const unsubTasks = onEvents([ev.TaskCreated, ev.TaskUpdated, ev.TaskDeleted], () => taskStore.load())
     notificationStore.load()
     const unsubNotif = notificationStore.listen()
-    const unsubQuit = EventsOn('app:quit-confirm', () => {
+    const unsubQuit = EventsOn(ev.AppQuitConfirm, () => {
       quitConfirmVisible = true
       if (quitConfirmTimer) clearTimeout(quitConfirmTimer)
       quitConfirmTimer = setTimeout(() => { quitConfirmVisible = false }, 3000)

--- a/frontend/src/App.svelte.test.ts
+++ b/frontend/src/App.svelte.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
+import { TaskCreated, TaskUpdated, TaskDeleted } from './lib/events.js'
 import { render, cleanup } from '@testing-library/svelte'
 
 const mockLoad = vi.fn()
@@ -115,8 +116,8 @@ describe('App', () => {
     await new Promise((r) => setTimeout(r, 0))
 
     const eventNames = mockEventsOn.mock.calls.map((c: unknown[]) => c[0])
-    expect(eventNames).toContain('task:created')
-    expect(eventNames).toContain('task:updated')
-    expect(eventNames).toContain('task:deleted')
+    expect(eventNames).toContain(TaskCreated)
+    expect(eventNames).toContain(TaskUpdated)
+    expect(eventNames).toContain(TaskDeleted)
   })
 })

--- a/frontend/src/components/StreamOutput.svelte
+++ b/frontend/src/components/StreamOutput.svelte
@@ -2,6 +2,7 @@
   import { EventsOn } from '../../wailsjs/runtime/runtime.js'
   import type { agent } from '../../wailsjs/go/models.js'
   import { agentStore } from '../stores/agents.svelte.js'
+  import { agentOutput } from '../lib/events.js'
 
   interface Props {
     agentId: string
@@ -32,7 +33,7 @@
       scrollToBottom()
     })
 
-    const unsub = EventsOn(`agent:output:${agentId}`, (event: agent.StreamEvent) => {
+    const unsub = EventsOn(agentOutput(agentId), (event: agent.StreamEvent) => {
       events = [...events, event]
       agentStore.appendEvent(agentId, event)
       requestAnimationFrame(scrollToBottom)

--- a/frontend/src/components/StreamOutput.svelte.test.ts
+++ b/frontend/src/components/StreamOutput.svelte.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { agentOutput } from '../lib/events.js'
 import { render, screen, cleanup } from '@testing-library/svelte'
 
 const mockGetOutput = vi.fn()
@@ -100,7 +101,7 @@ describe('StreamOutput', () => {
     render(StreamOutput, { props: { agentId: 'agent-42' } })
 
     await vi.waitFor(() => {
-      expect(mockEventsOn).toHaveBeenCalledWith('agent:output:agent-42', expect.any(Function))
+      expect(mockEventsOn).toHaveBeenCalledWith(agentOutput('agent-42'), expect.any(Function))
     })
   })
 

--- a/frontend/src/lib/events.ts
+++ b/frontend/src/lib/events.ts
@@ -1,0 +1,18 @@
+// Wails event name constants — must stay in sync with internal/events/events.go
+
+export const TaskCreated = 'task:created'
+export const TaskUpdated = 'task:updated'
+export const TaskDeleted = 'task:deleted'
+
+export const AgentStatePrefix = 'agent:state:'
+export const AgentOutputPrefix = 'agent:output:'
+export const AgentErrorPrefix = 'agent:error:'
+
+export const OrchestratorState = 'orchestrator:state'
+export const ReviewsUpdated = 'reviews:updated'
+export const Notification = 'notification'
+export const AppQuitConfirm = 'app:quit-confirm'
+
+export const agentState = (id: string) => `${AgentStatePrefix}${id}`
+export const agentOutput = (id: string) => `${AgentOutputPrefix}${id}`
+export const agentError = (id: string) => `${AgentErrorPrefix}${id}`

--- a/frontend/src/pages/AgentDetail.svelte
+++ b/frontend/src/pages/AgentDetail.svelte
@@ -2,6 +2,7 @@
   import type { agent } from '../../wailsjs/go/models.js'
   import { EventsOn } from '../../wailsjs/runtime/runtime.js'
   import { agentStore } from '../stores/agents.svelte.js'
+  import { agentState } from '../lib/events.js'
   import StreamOutput from '../components/StreamOutput.svelte'
   import TerminalView from '../components/TerminalView.svelte'
 
@@ -22,7 +23,7 @@
     const cached = agentStore.agents.get(agentId)
     if (cached) a = cached
 
-    const unsub = EventsOn(`agent:state:${agentId}`, (data: agent.Agent) => {
+    const unsub = EventsOn(agentState(agentId), (data: agent.Agent) => {
       a = data
       agentStore.updateAgent(agentId, data)
     })

--- a/frontend/src/pages/AgentDetail.svelte.test.ts
+++ b/frontend/src/pages/AgentDetail.svelte.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { agentState } from '../lib/events.js'
 import { render, screen, cleanup } from '@testing-library/svelte'
 
 const mockStop = vi.fn()
@@ -110,7 +111,7 @@ describe('AgentDetail', () => {
     })
     await vi.waitFor(() => {
       expect(mockEventsOn).toHaveBeenCalledWith(
-        'agent:state:agent-1',
+        agentState('agent-1'),
         expect.any(Function),
       )
     })

--- a/frontend/src/pages/Orchestrator.svelte
+++ b/frontend/src/pages/Orchestrator.svelte
@@ -8,6 +8,7 @@
   } from '../../wailsjs/go/main/App.js'
   import { EventsOn } from '../../wailsjs/runtime/runtime.js'
   import { agentStore } from '../stores/agents.svelte.js'
+  import { OrchestratorState } from '../lib/events.js'
   import StreamOutput from '../components/StreamOutput.svelte'
 
   let running = $state(false)
@@ -87,7 +88,7 @@
   $effect(() => {
     checkStatus()
 
-    const unsub = EventsOn('orchestrator:state', (state: string) => {
+    const unsub = EventsOn(OrchestratorState, (state: string) => {
       running = state === 'running'
       if (!running) output = ''
     })

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -2,6 +2,7 @@
   import { SegmentedControl } from '@skeletonlabs/skeleton-svelte'
   import type { agent, task } from '../../wailsjs/go/models.js'
   import { EventsOn } from '../../wailsjs/runtime/runtime.js'
+  import { agentState } from '../lib/events.js'
   import { BrowserOpenURL } from '../../wailsjs/runtime/runtime.js'
   import { StartReview } from '../../wailsjs/go/main/App.js'
   import { taskStore } from '../stores/tasks.svelte.js'
@@ -55,7 +56,7 @@
 
   $effect(() => {
     if (!runningAgent) return
-    const unsub = EventsOn(`agent:state:${runningAgent.id}`, (data: agent.Agent) => {
+    const unsub = EventsOn(agentState(runningAgent.id), (data: agent.Agent) => {
       runningAgent = data
       agentStore.updateAgent(data.id, data)
     })

--- a/frontend/src/stores/notifications.svelte.ts
+++ b/frontend/src/stores/notifications.svelte.ts
@@ -1,6 +1,7 @@
 import { EventsOn } from '../../wailsjs/runtime/runtime.js'
 import { ListNotifications } from '../../wailsjs/go/main/App.js'
 import type { notification } from '../../wailsjs/go/models.js'
+import { Notification as NotificationEvent } from '../lib/events.js'
 
 class NotificationStore {
   notifications = $state<notification.Notification[]>([])
@@ -10,7 +11,7 @@ class NotificationStore {
   }
 
   listen(): () => void {
-    return EventsOn('notification', (n: notification.Notification) => {
+    return EventsOn(NotificationEvent, (n: notification.Notification) => {
       this.notifications = [n, ...this.notifications].slice(0, 50)
     })
   }

--- a/frontend/src/stores/reviews.svelte.test.ts
+++ b/frontend/src/stores/reviews.svelte.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ReviewsUpdated } from '../lib/events.js'
 
 const mockFetchReviews = vi.fn()
 let eventCallbacks: Record<string, (data: unknown) => void> = {}
@@ -114,7 +115,7 @@ describe('ReviewStore', () => {
     it('updates state from reviews:updated event', () => {
       reviewStore.listen()
 
-      const cb = eventCallbacks['reviews:updated']
+      const cb = eventCallbacks[ReviewsUpdated]
       expect(cb).toBeDefined()
 
       cb({ createdByMe: [makePR({ number: 10 })], reviewRequested: [makePR({ number: 20 })] })
@@ -127,7 +128,7 @@ describe('ReviewStore', () => {
 
     it('handles null in event data', () => {
       reviewStore.listen()
-      eventCallbacks['reviews:updated']({ createdByMe: null, reviewRequested: null })
+      eventCallbacks[ReviewsUpdated]({ createdByMe: null, reviewRequested: null })
 
       expect(reviewStore.createdByMe).toHaveLength(0)
       expect(reviewStore.reviewRequested).toHaveLength(0)
@@ -135,10 +136,10 @@ describe('ReviewStore', () => {
 
     it('stopListening removes callback', () => {
       reviewStore.listen()
-      expect(eventCallbacks['reviews:updated']).toBeDefined()
+      expect(eventCallbacks[ReviewsUpdated]).toBeDefined()
 
       reviewStore.stopListening()
-      expect(eventCallbacks['reviews:updated']).toBeUndefined()
+      expect(eventCallbacks[ReviewsUpdated]).toBeUndefined()
     })
   })
 })

--- a/frontend/src/stores/reviews.svelte.ts
+++ b/frontend/src/stores/reviews.svelte.ts
@@ -1,5 +1,6 @@
 import { FetchReviews } from '../../wailsjs/go/main/App.js'
 import { EventsOn } from '../../wailsjs/runtime/runtime.js'
+import { ReviewsUpdated } from '../lib/events.js'
 import type { github } from '../../wailsjs/go/models.js'
 
 class ReviewStore {
@@ -60,7 +61,7 @@ class ReviewStore {
 
   listen(): void {
     this.stopListening()
-    this.cancelListener = EventsOn('reviews:updated', (summary: any) => {
+    this.cancelListener = EventsOn(ReviewsUpdated, (summary: any) => {
       this.createdByMe = summary.createdByMe ?? []
       this.reviewRequested = summary.reviewRequested ?? []
     })

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Automaat/synapse/internal/events"
 	"github.com/Automaat/synapse/internal/tmux"
 	"github.com/google/uuid"
 )
@@ -102,7 +103,7 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 		return nil, fmt.Errorf("unknown mode: %s", cfg.Mode)
 	}
 
-	m.emit("agent:state:"+id, a)
+	m.emit(events.AgentState(id), a)
 	return a, nil
 }
 
@@ -176,7 +177,7 @@ func (m *Manager) StopAgent(agentID string) error {
 	a.State = StateStopped
 
 	m.logger.Info("agent.stop", "id", agentID)
-	m.emit("agent:state:"+agentID, a)
+	m.emit(events.AgentState(agentID), a)
 
 	if a.Mode == "interactive" {
 		if a.TmuxSession != "" {
@@ -265,7 +266,7 @@ func (m *Manager) markStopped(a *Agent) {
 	if a.cancel != nil {
 		a.cancel()
 	}
-	m.emit("agent:state:"+a.ID, a)
+	m.emit(events.AgentState(a.ID), a)
 	if m.onComplete != nil {
 		m.onComplete(a)
 	}
@@ -393,7 +394,7 @@ func (m *Manager) ReconnectSessions(tasks []TaskInfo) int {
 
 		m.agents[id] = a
 		m.logger.Info("reconnect.session", "id", id, "session", s.Name, "task", a.TaskID)
-		m.emit("agent:state:"+id, a)
+		m.emit(events.AgentState(id), a)
 		reconnected++
 	}
 	return reconnected

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Automaat/synapse/internal/events"
 	"github.com/Automaat/synapse/internal/tmux"
 )
 
@@ -23,12 +24,12 @@ func discardLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
-func newTestManager(t *testing.T) (mgr *Manager, events *[]string) {
+func newTestManager(t *testing.T) (mgr *Manager, emitted *[]string) {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	emitted := &[]string{}
+	emitted = &[]string{}
 	emit := func(event string, _ any) {
 		*emitted = append(*emitted, event)
 	}
@@ -140,7 +141,7 @@ func TestStopAgent(t *testing.T) {
 	// Should have emitted state events for start and stop
 	hasStop := false
 	for _, e := range *emitted {
-		if e == "agent:state:"+a.ID {
+		if e == events.AgentState(a.ID) {
 			hasStop = true
 		}
 	}

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/Automaat/synapse/internal/events"
 	"github.com/Automaat/synapse/internal/logging"
 )
 
@@ -79,7 +80,7 @@ func (m *Manager) runHeadless(ctx context.Context, a *Agent, prompt string, allo
 		}
 
 		a.outputBuffer = append(a.outputBuffer, event)
-		m.emit("agent:output:"+a.ID, event)
+		m.emit(events.AgentOutput(a.ID), event)
 
 		if event.Type == "result" {
 			a.SessionID = event.SessionID
@@ -105,7 +106,7 @@ func (m *Manager) runHeadless(ctx context.Context, a *Agent, prompt string, allo
 		close(a.done)
 	}
 	m.logger.Info("agent.headless.done", "id", a.ID, "cost", a.CostUSD)
-	m.emit("agent:state:"+a.ID, a)
+	m.emit(events.AgentState(a.ID), a)
 	if m.onComplete != nil {
 		m.onComplete(a)
 	}
@@ -228,7 +229,7 @@ func (m *Manager) handleError(a *Agent, err error) {
 		close(a.done)
 	}
 	m.logger.Error("agent.error", "id", a.ID, "err", err)
-	m.emit("agent:error:"+a.ID, err.Error())
+	m.emit(events.AgentError(a.ID), err.Error())
 	if m.onComplete != nil {
 		m.onComplete(a)
 	}

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Automaat/synapse/internal/events"
 	"github.com/Automaat/synapse/internal/tmux"
 )
 
@@ -34,7 +35,7 @@ func TestHandleError(t *testing.T) {
 		t.Errorf("State = %q, want %q", a.State, StateStopped)
 	}
 
-	wantEvent := "agent:error:test-123"
+	wantEvent := events.AgentError("test-123")
 	if emittedEvent != wantEvent {
 		t.Errorf("event = %q, want %q", emittedEvent, wantEvent)
 	}
@@ -73,7 +74,7 @@ func TestRunHeadlessFailsToStart(t *testing.T) {
 		t.Errorf("State = %q, want %q", a.State, StateStopped)
 	}
 
-	if lastEvent != "agent:error:test-headless" && lastEvent != "agent:state:test-headless" {
+	if lastEvent != events.AgentError("test-headless") && lastEvent != events.AgentState("test-headless") {
 		t.Errorf("last event = %q, want error or state event", lastEvent)
 	}
 }

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -1,0 +1,35 @@
+// Package events defines Wails event name constants shared across the app.
+package events
+
+const (
+	// Task lifecycle events (emitted by watcher).
+	TaskCreated = "task:created"
+	TaskUpdated = "task:updated"
+	TaskDeleted = "task:deleted"
+
+	// Agent events — prefix only; append ":"+agentID to form full event name.
+	AgentStatePrefix  = "agent:state:"
+	AgentOutputPrefix = "agent:output:"
+	AgentErrorPrefix  = "agent:error:"
+
+	// Orchestrator events.
+	OrchestratorState = "orchestrator:state"
+
+	// Review/PR events.
+	ReviewsUpdated = "reviews:updated"
+
+	// Notification events.
+	Notification = "notification"
+
+	// App lifecycle events.
+	AppQuitConfirm = "app:quit-confirm"
+)
+
+// AgentState returns the agent state event name for the given agent ID.
+func AgentState(id string) string { return AgentStatePrefix + id }
+
+// AgentOutput returns the agent output event name for the given agent ID.
+func AgentOutput(id string) string { return AgentOutputPrefix + id }
+
+// AgentError returns the agent error event name for the given agent ID.
+func AgentError(id string) string { return AgentErrorPrefix + id }

--- a/internal/notification/emitter.go
+++ b/internal/notification/emitter.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Automaat/synapse/internal/events"
 	"github.com/google/uuid"
 )
 
@@ -45,7 +46,7 @@ func (e *Emitter) Send(level Level, title, message, taskID, agentID string) {
 	e.buffer = append(e.buffer, n)
 	e.mu.Unlock()
 
-	e.emit("notification", n)
+	e.emit(events.Notification, n)
 
 	if e.desktop {
 		_ = sendDesktopNotification(title, message)

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Automaat/synapse/internal/events"
 	"github.com/fsnotify/fsnotify"
 )
 
@@ -81,13 +82,13 @@ func (w *Watcher) loop(ctx context.Context, fw *fsnotify.Watcher) {
 			switch {
 			case event.Has(fsnotify.Create):
 				w.logger.Info("watcher.event", "op", "created", "file", event.Name)
-				w.emit("task:created", event.Name)
+				w.emit(events.TaskCreated, event.Name)
 			case event.Has(fsnotify.Write):
 				w.logger.Debug("watcher.event", "op", "updated", "file", event.Name)
-				w.emit("task:updated", event.Name)
+				w.emit(events.TaskUpdated, event.Name)
 			case event.Has(fsnotify.Remove):
 				w.logger.Info("watcher.event", "op", "deleted", "file", event.Name)
-				w.emit("task:deleted", event.Name)
+				w.emit(events.TaskDeleted, event.Name)
 			}
 
 		case err, ok := <-fw.Errors:

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	ev "github.com/Automaat/synapse/internal/events"
 )
 
 func discardLogger() *slog.Logger {
@@ -65,7 +67,7 @@ func TestStartAndEmitCreate(t *testing.T) {
 
 	select {
 	case event := <-got:
-		if event != "task:created" && event != "task:updated" {
+		if event != ev.TaskCreated && event != ev.TaskUpdated {
 			t.Errorf("unexpected event %q, want task:created or task:updated", event)
 		}
 	case <-time.After(2 * time.Second):
@@ -104,11 +106,11 @@ func TestStartAndEmitDelete(t *testing.T) {
 	for {
 		select {
 		case event := <-got:
-			if event == "task:deleted" {
+			if event == ev.TaskDeleted {
 				return
 			}
 		case <-timeout:
-			t.Error("expected task:deleted event")
+			t.Error("expected " + ev.TaskDeleted + " event")
 			return
 		}
 	}
@@ -168,7 +170,7 @@ func TestDebounce(t *testing.T) {
 
 	got := make(chan string, 10)
 	emit := func(event string, _ any) {
-		if event == "task:created" {
+		if event == ev.TaskCreated {
 			select {
 			case got <- event:
 			default:

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Automaat/synapse/internal/config"
+	"github.com/Automaat/synapse/internal/events"
 	"github.com/Automaat/synapse/internal/logging"
 	"github.com/wailsapp/wails/v2"
 	"github.com/wailsapp/wails/v2/pkg/menu"
@@ -56,7 +57,7 @@ func main() {
 		}
 
 		quitArmed = true
-		wailsruntime.EventsEmit(app.ctx, "app:quit-confirm")
+		wailsruntime.EventsEmit(app.ctx, events.AppQuitConfirm)
 		quitTimer = time.AfterFunc(3*time.Second, func() {
 			quitMu.Lock()
 			defer quitMu.Unlock()


### PR DESCRIPTION
## Motivation

Hardcoded event strings like `"task:created"` and `"agent:state:"` were scattered across Go and TypeScript files. Typos cause silent failures with no compiler/linter help.

## Implementation information

- `internal/events/events.go` — Go constants + helper funcs (`AgentState(id)`, `AgentOutput(id)`, `AgentError(id)`)
- `frontend/src/lib/events.ts` — matching TS constants + helpers
- All call sites in Go (app.go, main.go, internal/watcher, internal/agent, internal/notification) and TS (App.svelte, stores, pages, components) updated
- Test files updated to use constants too, fixing an importShadow linter issue in manager_test.go along the way

> Changelog: refactor(events): add Wails event name constants