### PR TITLE
fix(agent): pr-fix restart handling

### DIFF
--- a/app.go
+++ b/app.go
@@ -217,6 +217,17 @@ func (a *App) restartStaleInProgress() {
 		if slices.Contains(t.Tags, "review") {
 			continue
 		}
+		// Tasks whose last agent was a pr-fix should not be re-implemented.
+		// Move them back to in-review so prPollLoop can re-detect and fix.
+		if lastRun := lastAgentRun(t); lastRun != nil && lastRun.Role == "pr-fix" {
+			a.logger.Info("restart-stale.revert-to-review", "task_id", t.ID)
+			if _, err := a.tasks.Update(t.ID, map[string]any{
+				"status": string(task.StatusInReview),
+			}); err != nil {
+				a.logger.Error("restart-stale.revert", "task_id", t.ID, "err", err)
+			}
+			continue
+		}
 		if t.ProjectID == "" {
 			a.logger.Warn("restart-stale.skip", "task_id", t.ID, "reason", "no project_id")
 			continue
@@ -230,6 +241,13 @@ func (a *App) restartStaleInProgress() {
 			}
 		})
 	}
+}
+
+func lastAgentRun(t *task.Task) *task.AgentRun {
+	if len(t.AgentRuns) == 0 {
+		return nil
+	}
+	return &t.AgentRuns[len(t.AgentRuns)-1]
 }
 
 func (a *App) syncSkills() {

--- a/app_agents.go
+++ b/app_agents.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Automaat/synapse/internal/agent"
 	"github.com/Automaat/synapse/internal/audit"
+	"github.com/Automaat/synapse/internal/github"
 	"github.com/Automaat/synapse/internal/notification"
 	"github.com/Automaat/synapse/internal/project"
 	"github.com/Automaat/synapse/internal/stats"
@@ -294,6 +295,9 @@ func (a *App) handleAgentComplete(ag *agent.Agent) {
 	if strings.HasPrefix(ag.Name, "pr-fix:") {
 		a.logger.Info("pr-fix.complete", "agent_id", ag.ID, "task_id", ag.TaskID)
 		a.logAudit(audit.EventPRFixAgentStarted, ag.TaskID, ag.ID, agentData)
+		// Clear debounce so the next poll cycle can re-detect unresolved issues
+		a.prTracker.Clear(ag.TaskID, github.PRIssueConflict)
+		a.prTracker.Clear(ag.TaskID, github.PRIssueCIFailure)
 		go func() {
 			if err := a.EvaluateTask(ag.TaskID, resultContent); err != nil {
 				a.logger.Error("pr-fix.eval", "task_id", ag.TaskID, "err", err)


### PR DESCRIPTION
## Motivation

Two bugs prevented pr-fix agents from working correctly:

1. **Debounce never cleared** — after a pr-fix agent completed, the 30-minute cooldown in `IssueTracker` was never reset. If conflicts persisted after the fix attempt, `prPollLoop` couldn't dispatch a retry for 30 minutes.

2. **Restart re-implements instead of fixing** — `restartStaleInProgress` sent all in-progress tasks a "Continue implementing..." prompt. Tasks that were mid-PR-fix (moved to in-progress by `handlePRIssue`) got re-implemented from scratch instead of receiving conflict/CI fix instructions.

## Implementation information

**Bug 1 (`app_agents.go`):** Clear both conflict and CI-failure debounce entries in `handleAgentComplete` when a `pr-fix:` agent finishes, so the next poll cycle can re-detect unresolved issues immediately.

**Bug 2 (`app.go`):** In `restartStaleInProgress`, check `AgentRun.Role` of the last run. If it was `"pr-fix"`, move the task back to `in-review` instead of restarting with the implementation prompt. This lets `prPollLoop` re-detect the issue and dispatch with the correct fix-specific prompt.

> Changelog: fix(agent): pr-fix restart handling