### PR TITLE
refactor(app): extract worktreeProject shared helper

### DIFF
--- a/app_agents.go
+++ b/app_agents.go
@@ -84,14 +84,23 @@ func (a *App) autoAssignProject(t task.Task) task.Task {
 	return t
 }
 
-func (a *App) prepareWorktree(t task.Task) (string, error) {
+// worktreeProject resolves the project for t, fetches origin, and returns
+// the project and the worktree path. Fetch errors are logged and non-fatal.
+func (a *App) worktreeProject(t task.Task) (project.Project, string, error) {
 	proj, err := a.projects.Get(t.ProjectID)
 	if err != nil {
-		return "", fmt.Errorf("get project: %w", err)
+		return project.Project{}, "", fmt.Errorf("get project: %w", err)
 	}
-
 	if err := project.FetchOrigin(proj.ClonePath); err != nil {
 		a.logger.Warn("worktree.fetch", "project", proj.ID, "err", err)
+	}
+	return proj, filepath.Join(a.worktreesDir, t.DirName()), nil
+}
+
+func (a *App) prepareWorktree(t task.Task) (string, error) {
+	proj, wtPath, err := a.worktreeProject(t)
+	if err != nil {
+		return "", err
 	}
 
 	branch, err := project.DefaultBranch(proj.ClonePath)
@@ -99,7 +108,6 @@ func (a *App) prepareWorktree(t task.Task) (string, error) {
 		return "", fmt.Errorf("default branch: %w", err)
 	}
 
-	wtPath := filepath.Join(a.worktreesDir, t.DirName())
 	wtBranch := "synapse/" + t.DirName()
 	if _, statErr := os.Stat(wtPath); statErr == nil {
 		if t.Branch == "" {

--- a/app_reviews.go
+++ b/app_reviews.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"slices"
 	"time"
 
@@ -143,13 +142,9 @@ func (a *App) startReviewAgent(t task.Task) error {
 }
 
 func (a *App) prepareReviewWorktree(t task.Task) (string, error) {
-	proj, err := a.projects.Get(t.ProjectID)
+	proj, wtPath, err := a.worktreeProject(t)
 	if err != nil {
-		return "", fmt.Errorf("get project: %w", err)
-	}
-
-	if err := project.FetchOrigin(proj.ClonePath); err != nil {
-		a.logger.Warn("review.worktree.fetch", "project", proj.ID, "err", err)
+		return "", err
 	}
 
 	branch, err := github.FetchPRBranch(t.ProjectID, t.PRNumber)
@@ -157,7 +152,6 @@ func (a *App) prepareReviewWorktree(t task.Task) (string, error) {
 		return "", fmt.Errorf("fetch pr branch: %w", err)
 	}
 
-	wtPath := filepath.Join(a.worktreesDir, t.DirName())
 	if _, statErr := os.Stat(wtPath); statErr == nil {
 		return wtPath, nil
 	}


### PR DESCRIPTION
## Motivation

`prepareWorktree` and `prepareReviewWorktree` share three identical steps: project lookup, `FetchOrigin`, and worktree path computation. Bug fixes to that boilerplate needed to be applied in both places.

## Implementation information

Extracted `worktreeProject(t task.Task) (project.Project, string, error)` into `app_agents.go` alongside the existing worktree helpers. Both functions delegate to it for the common setup, then diverge for branch resolution (`DefaultBranch` vs `github.FetchPRBranch`) and worktree creation (new tracked branch vs detached checkout).

The `review.worktree.fetch` log key is unified to `worktree.fetch` as part of the consolidation.

## Supporting documentation

Closes #130