### PR TITLE
fix(task): match --- only at line start

### DIFF
--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -66,6 +66,10 @@
     <h3 class="text-sm font-semibold leading-tight">{t.title}</h3>
   </div>
 
+  {#if t.statusReason}
+    <p class="mb-1.5 line-clamp-2 text-xs text-warning-600 dark:text-warning-400">{t.statusReason}</p>
+  {/if}
+
   <div class="flex flex-wrap items-center gap-1.5 text-xs text-surface-500">
     <span class="rounded bg-surface-200 px-1.5 py-0.5 dark:bg-surface-700">
       {t.agentMode}

--- a/internal/task/parser.go
+++ b/internal/task/parser.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"regexp"
 	"time"
 
 	"gopkg.in/yaml.v3"
 )
 
-const frontmatterDelim = "---"
+var frontmatterRe = regexp.MustCompile(`(?m)^---\s*$`)
 
 func Parse(path string) (Task, error) {
 	data, err := os.ReadFile(path)
@@ -26,17 +27,19 @@ func Parse(path string) (Task, error) {
 }
 
 func ParseBytes(data []byte) (Task, error) {
-	parts := bytes.SplitN(data, []byte(frontmatterDelim), 3)
-	if len(parts) < 3 {
+	locs := frontmatterRe.FindAllIndex(data, 2)
+	if len(locs) < 2 {
 		return Task{}, fmt.Errorf("invalid frontmatter: expected --- delimiters")
 	}
 
+	fm := data[locs[0][1]:locs[1][0]]
+
 	var t Task
-	if err := yaml.Unmarshal(parts[1], &t); err != nil {
+	if err := yaml.Unmarshal(fm, &t); err != nil {
 		return Task{}, fmt.Errorf("unmarshal frontmatter: %w", err)
 	}
 
-	t.Body = string(bytes.TrimSpace(parts[2]))
+	t.Body = string(bytes.TrimSpace(data[locs[1][1]:]))
 	return t, nil
 }
 
@@ -49,9 +52,9 @@ func Marshal(t Task) ([]byte, error) {
 	}
 
 	var buf bytes.Buffer
-	buf.WriteString(frontmatterDelim + "\n")
+	buf.WriteString("---" + "\n")
 	buf.Write(fm)
-	buf.WriteString(frontmatterDelim + "\n")
+	buf.WriteString("---" + "\n")
 	if t.Body != "" {
 		buf.WriteString(t.Body)
 		buf.WriteString("\n")


### PR DESCRIPTION
## Motivation

Task files with agent results containing markdown `---` (horizontal rules) or `---` in inline YAML strings failed to parse. The frontmatter parser used `bytes.SplitN(data, "---", 3)` which matched `---` anywhere in a line, not just as a standalone frontmatter delimiter. Additionally, `statusReason` was stored on tasks but never displayed in the GUI.

## Implementation information

- Replace `SplitN` with a line-anchored regex `^---\s*$` that only matches `---` on its own line
- Display `statusReason` on `TaskCard` as warning-colored text (line-clamped to 2 lines) below the title

> Changelog: fix(task): match --- only at line start