### PR TITLE
fix(worktree): cleanup orphaned worktrees

### DIFF
--- a/app.go
+++ b/app.go
@@ -119,6 +119,7 @@ func (a *App) startup(ctx context.Context) {
 	a.prTracker = github.NewIssueTracker(30 * time.Minute)
 	a.syncSkills()
 	a.reconnectAgents()
+	a.cleanupOrphanedWorktrees()
 	a.cleanStaleRuns()
 	a.restartStaleInProgress()
 	a.RegisterSpotlightHotkey()

--- a/app_agents.go
+++ b/app_agents.go
@@ -156,6 +156,48 @@ func (a *App) cleanupWorktree(taskID string) {
 	}
 }
 
+// cleanupOrphanedWorktrees scans the worktrees directory and removes entries
+// that no longer have an active task or running agent.
+func (a *App) cleanupOrphanedWorktrees() {
+	entries, err := os.ReadDir(a.worktreesDir)
+	if err != nil {
+		return
+	}
+	tasks, err := a.tasks.List()
+	if err != nil {
+		return
+	}
+	// Build lookup: dirName → task
+	active := make(map[string]*task.Task, len(tasks))
+	for i := range tasks {
+		active[tasks[i].DirName()] = &tasks[i]
+	}
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		wtPath := filepath.Join(a.worktreesDir, name)
+
+		t, exists := active[name]
+		switch {
+		case !exists:
+			// Task deleted — remove worktree directory.
+		case t.Status != task.StatusDone:
+			continue
+		case a.agents.HasRunningAgentForTask(t.ID):
+			continue
+		}
+
+		if err := os.RemoveAll(wtPath); err != nil {
+			a.logger.Error("worktree.orphan-cleanup", "path", wtPath, "err", err)
+		} else {
+			a.logger.Info("worktree.orphan-cleaned", "path", wtPath)
+		}
+	}
+}
+
 // startPRFixReviewAgent starts a headless agent to address review comments on
 // the task's PR. Named "pr-fix:" so handleAgentComplete routes it correctly.
 func (a *App) startPRFixReviewAgent(taskID string) error {
@@ -352,6 +394,11 @@ func (a *App) handleAgentComplete(ag *agent.Agent) {
 	default:
 		a.handleDefaultComplete(ag, resultContent, agentData)
 	}
+
+	// Cleanup worktree if task is done and no other agent is running.
+	if t, err := a.tasks.Get(ag.TaskID); err == nil && t.Status == task.StatusDone {
+		go a.cleanupWorktree(ag.TaskID)
+	}
 }
 
 func (a *App) handleTriageComplete(ag *agent.Agent, agentData map[string]any) {
@@ -410,12 +457,6 @@ func (a *App) handleDefaultComplete(ag *agent.Agent, resultContent string, agent
 		eventType = audit.EventAgentFailed
 	}
 	a.logAudit(eventType, ag.TaskID, ag.ID, agentData)
-
-	// Cleanup worktree if task was already marked done while agent was running.
-	if t, err := a.tasks.Get(ag.TaskID); err == nil && t.Status == task.StatusDone {
-		go a.cleanupWorktree(ag.TaskID)
-		return
-	}
 
 	a.wg.Go(func() {
 		if err := a.EvaluateTask(ag.TaskID, resultContent); err != nil {

--- a/app_orchestrator.go
+++ b/app_orchestrator.go
@@ -77,6 +77,7 @@ func (a *App) orchestratorLoop(ctx context.Context) {
 			a.maybeStartOrchestrator()
 			a.maybeDispatchTasks()
 			a.maybeResumePlanning()
+			a.cleanupOrphanedWorktrees()
 		}
 	}
 }

--- a/app_tasks.go
+++ b/app_tasks.go
@@ -85,9 +85,10 @@ func (a *App) UpdateTask(id string, updates map[string]any) (task.Task, error) {
 	return t, nil
 }
 
-// DeleteTask removes a task file from disk.
+// DeleteTask removes a task file from disk and cleans up its worktree.
 func (a *App) DeleteTask(id string) error {
 	a.logger.Info("task.delete", "task_id", id)
+	a.cleanupWorktree(id)
 	a.logAudit(audit.EventTaskDeleted, id, "", nil)
 	if err := a.tasks.Delete(id); err != nil {
 		a.logger.Error("task.delete.failed", "task_id", id, "err", err)


### PR DESCRIPTION
## Motivation

Worktrees accumulate in `~/.synapse/worktrees/` and never get cleaned up. Root causes:
- Only `handleDefaultComplete` triggered cleanup — triage, eval, pr-fix, plan, review handlers never did
- No startup cleanup for crash recovery
- No periodic scan for orphaned worktrees
- `DeleteTask` left worktrees behind

## Implementation information

Four changes:
1. **`cleanupOrphanedWorktrees()`** — scans worktrees dir, builds task lookup by `DirName()`, removes dirs where task is deleted, done with no running agent. Uses `os.RemoveAll` for robustness.
2. **Startup call** — runs after `reconnectAgents()` to catch crash leftovers.
3. **Periodic call** — added to `orchestratorLoop` 1-minute ticker alongside existing checks.
4. **`handleAgentComplete`** — moved cleanup from `handleDefaultComplete` to after the handler switch, so all agent types (triage, eval, pr-fix, plan, review) trigger worktree cleanup when task is done.
5. **`DeleteTask`** — calls `cleanupWorktree(id)` before removing task file.

> Changelog: fix(worktree): cleanup orphaned worktrees