### PR TITLE
fix(project): sanitize worktree before reuse

### DIFF
--- a/app_agents.go
+++ b/app_agents.go
@@ -110,6 +110,9 @@ func (a *App) prepareWorktree(t task.Task) (string, error) {
 
 	wtBranch := "synapse/" + t.DirName()
 	if _, statErr := os.Stat(wtPath); statErr == nil {
+		if err := project.SanitizeWorktree(wtPath); err != nil {
+			a.logger.Warn("worktree.sanitize", "task_id", t.ID, "err", err)
+		}
 		if t.Branch == "" {
 			if _, err := a.tasks.Update(t.ID, map[string]any{"branch": wtBranch}); err != nil {
 				a.logger.Error("worktree.set-branch", "task_id", t.ID, "err", err)

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -3,6 +3,7 @@ package project
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -66,6 +67,68 @@ func FetchOrigin(barePath string) error {
 		return fmt.Errorf("git fetch origin: %w: %s", err, string(out))
 	}
 	return nil
+}
+
+// SanitizeWorktree cleans up worktree state that would confuse agents:
+//   - aborts any stuck rebase/merge/cherry-pick
+//   - deletes local branches that shadow remote refs (e.g. local "origin/main")
+func SanitizeWorktree(wtPath string) error {
+	// Abort stuck rebase if any.
+	if _, err := os.Stat(rebaseStateDir(wtPath)); err == nil {
+		cmd := exec.Command("git", "rebase", "--abort")
+		cmd.Dir = wtPath
+		_ = cmd.Run() // best-effort
+	}
+
+	// Abort stuck merge if any.
+	cmd := exec.Command("git", "rev-parse", "--git-path", "MERGE_HEAD")
+	cmd.Dir = wtPath
+	if out, err := cmd.Output(); err == nil {
+		if _, statErr := os.Stat(strings.TrimSpace(string(out))); statErr == nil {
+			abort := exec.Command("git", "merge", "--abort")
+			abort.Dir = wtPath
+			_ = abort.Run()
+		}
+	}
+
+	// Delete local branches that shadow remote tracking refs.
+	// A local branch named "origin/foo" shadows "refs/remotes/origin/foo".
+	listCmd := exec.Command("git", "branch", "--format=%(refname:short)")
+	listCmd.Dir = wtPath
+	branchOut, err := listCmd.Output()
+	if err != nil {
+		return err
+	}
+	for line := range strings.SplitSeq(strings.TrimSpace(string(branchOut)), "\n") {
+		if !strings.HasPrefix(line, "origin/") {
+			continue
+		}
+		del := exec.Command("git", "branch", "-D", line)
+		del.Dir = wtPath
+		_ = del.Run()
+	}
+	return nil
+}
+
+// rebaseStateDir returns the path to the rebase-merge or rebase-apply dir.
+func rebaseStateDir(wtPath string) string {
+	// git worktrees store rebase state inside the .git dir (which is a file
+	// pointing to the actual gitdir). Use rev-parse to resolve it.
+	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	cmd.Dir = wtPath
+	out, err := cmd.Output()
+	if err != nil {
+		return filepath.Join(wtPath, ".git", "rebase-merge")
+	}
+	gitDir := strings.TrimSpace(string(out))
+	// Check both rebase-merge (interactive) and rebase-apply (am-style).
+	for _, sub := range []string{"rebase-merge", "rebase-apply"} {
+		p := filepath.Join(gitDir, sub)
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return filepath.Join(gitDir, "rebase-merge")
 }
 
 func CreateWorktree(barePath, worktreePath, branch, baseBranch string) error {

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -261,6 +262,112 @@ func TestParseWorktreePorcelain(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSanitizeWorktree_AbortsRebase(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(src, bare); err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+
+	wtPath := filepath.Join(t.TempDir(), "wt")
+	branch, _ := DefaultBranch(bare)
+	if err := CreateWorktree(bare, wtPath, "synapse/test", branch); err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+
+	// Create a conflicting commit on main.
+	gitWt := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = wtPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	gitWt("config", "user.email", "test@test.com")
+	gitWt("config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), []byte("branch change"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitWt("add", ".")
+	gitWt("commit", "-m", "branch")
+
+	// Make a conflicting commit on a new branch from original base.
+	gitWt("checkout", "-b", "conflict-base", "HEAD~1")
+	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), []byte("conflicting"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitWt("add", ".")
+	gitWt("commit", "-m", "conflict")
+	gitWt("checkout", "synapse/test")
+
+	// Start a rebase that will conflict.
+	cmd := exec.Command("git", "rebase", "conflict-base")
+	cmd.Dir = wtPath
+	_ = cmd.Run() // expected to fail with conflict
+
+	// Verify rebase is in progress.
+	statusOut, _ := exec.Command("git", "-C", wtPath, "status").Output()
+	if !contains(string(statusOut), "rebase") {
+		t.Skip("could not create rebase conflict state")
+	}
+
+	if err := SanitizeWorktree(wtPath); err != nil {
+		t.Fatalf("SanitizeWorktree: %v", err)
+	}
+
+	// Rebase should be aborted.
+	statusOut, _ = exec.Command("git", "-C", wtPath, "status").Output()
+	if contains(string(statusOut), "rebase") {
+		t.Error("rebase still in progress after sanitize")
+	}
+}
+
+func TestSanitizeWorktree_DeletesShadowBranches(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(src, bare); err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+
+	wtPath := filepath.Join(t.TempDir(), "wt")
+	branch, _ := DefaultBranch(bare)
+	if err := CreateWorktree(bare, wtPath, "synapse/test", branch); err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+
+	// Create a local branch that shadows origin/main.
+	cmd := exec.Command("git", "branch", "origin/main", "HEAD")
+	cmd.Dir = wtPath
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("create shadow branch: %v: %s", err, out)
+	}
+
+	if err := SanitizeWorktree(wtPath); err != nil {
+		t.Fatalf("SanitizeWorktree: %v", err)
+	}
+
+	// Shadow branch should be deleted.
+	out, _ := exec.Command("git", "-C", wtPath, "branch", "--list", "origin/main").Output()
+	if strings.TrimSpace(string(out)) != "" {
+		t.Errorf("shadow branch origin/main still exists: %s", out)
+	}
+}
+
+func contains(s, sub string) bool {
+	return strings.Contains(s, sub)
 }
 
 func TestCreateWorktreeInvalidBase(t *testing.T) {


### PR DESCRIPTION
## Motivation

PR-fix agents entered an infinite retry loop on PR #145. Root cause: a previous agent ran `git checkout -b origin/main`, creating a local branch that shadows `refs/remotes/origin/main`. All subsequent `git rebase origin/main` targeted the stale local branch. Failed rebases left stuck rebase-merge state, blocking every future agent on that worktree.

## Implementation information

Added `SanitizeWorktree()` in `internal/project/git.go`, called from `prepareWorktree` when a worktree already exists. It:

- Aborts stuck rebase (`rebase-merge`/`rebase-apply`) and merge (`MERGE_HEAD`) — uses `git rev-parse --git-dir` to correctly resolve worktree gitdir
- Deletes local branches prefixed `origin/` that shadow remote tracking refs

Two table-driven tests cover both scenarios.