### PR TITLE
fix(task): prevent yaml |N- roundtrip bug

### DIFF
--- a/internal/task/parser.go
+++ b/internal/task/parser.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -46,6 +47,13 @@ func ParseBytes(data []byte) (Task, error) {
 func Marshal(t Task) ([]byte, error) {
 	t.UpdatedAt = time.Now().UTC()
 
+	// Strip leading whitespace from agent run results so yaml.v3 doesn't
+	// emit |N- block scalars that it fails to parse back (known round-trip
+	// bug with nested sequences containing indented literal blocks).
+	for i := range t.AgentRuns {
+		t.AgentRuns[i].Result = stripLineIndent(t.AgentRuns[i].Result)
+	}
+
 	fm, err := yaml.Marshal(t)
 	if err != nil {
 		return nil, fmt.Errorf("marshal frontmatter: %w", err)
@@ -60,4 +68,18 @@ func Marshal(t Task) ([]byte, error) {
 		buf.WriteString("\n")
 	}
 	return buf.Bytes(), nil
+}
+
+// stripLineIndent removes leading spaces/tabs from each line. This prevents
+// yaml.v3 from emitting |N- block scalars (explicit indent indicator) which
+// it then fails to round-trip when nested inside sequences.
+func stripLineIndent(s string) string {
+	if s == "" {
+		return s
+	}
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimLeft(line, " \t")
+	}
+	return strings.Join(lines, "\n")
 }

--- a/internal/task/parser_test.go
+++ b/internal/task/parser_test.go
@@ -343,6 +343,50 @@ func TestMarshalRoundTripAgentRuns(t *testing.T) {
 	}
 }
 
+func TestMarshalRoundTripAgentRunsIndentedResult(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC().Truncate(time.Second)
+	original := Task{
+		ID:        "indent1",
+		Title:     "Indented result roundtrip",
+		Status:    StatusDone,
+		AgentMode: "headless",
+		AgentRuns: []AgentRun{
+			{
+				AgentID:   "a1",
+				Mode:      "headless",
+				State:     "stopped",
+				StartedAt: now,
+				Result:    "    indented line\nnormal line\n- bullet",
+			},
+			{
+				AgentID:   "a2",
+				Mode:      "headless",
+				State:     "stopped",
+				StartedAt: now,
+				Result:    "second run result",
+			},
+		},
+	}
+
+	data, err := Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	parsed, err := ParseBytes(data)
+	if err != nil {
+		t.Fatalf("parse round-trip failed (this was the |4- bug): %v", err)
+	}
+
+	if len(parsed.AgentRuns) != 2 {
+		t.Fatalf("AgentRuns len = %d, want 2", len(parsed.AgentRuns))
+	}
+	if parsed.AgentRuns[1].Result != "second run result" {
+		t.Errorf("AgentRuns[1].Result = %q, want %q", parsed.AgentRuns[1].Result, "second run result")
+	}
+}
+
 func TestMarshalUpdatesTimestamp(t *testing.T) {
 	t.Parallel()
 	before := time.Now().UTC().Add(-time.Second)


### PR DESCRIPTION
## Motivation

Task file `e853e8c6.md` causes constant parse errors every 5 seconds:
```
WARN task.parse.skip err="yaml: line 32: did not find expected key"
```

`yaml.v3` emits `|4-` (explicit indent indicator) block scalars when agent run `result` strings contain leading whitespace. It then fails to parse its own output back when the block is nested inside a YAML sequence — a known round-trip bug in the library.

## Implementation information

`stripLineIndent()` in `parser.go` strips leading spaces/tabs from each line of `AgentRun.Result` before marshaling. Agent output text is plain-text summaries — leading whitespace is formatting, not semantic.

Also manually fixed the existing broken task file `e853e8c6.md`.