### PR TITLE
fix(agent): reduce conflict token waste

### DIFF
--- a/app_reviews.go
+++ b/app_reviews.go
@@ -207,6 +207,42 @@ func (r *ReviewHandler) prepareReviewWorktree(t task.Task) (string, error) {
 	return wtPath, nil
 }
 
+// prepareFixWorktree checks out the PR's head branch so the agent can rebase and push.
+func (r *ReviewHandler) prepareFixWorktree(t task.Task, prNumber int) (string, error) {
+	proj, err := r.projects.Get(t.ProjectID)
+	if err != nil {
+		return "", fmt.Errorf("get project: %w", err)
+	}
+
+	if err := project.FetchOrigin(proj.ClonePath); err != nil {
+		r.logger.Warn("fix.worktree.fetch", "project", proj.ID, "err", err)
+	}
+
+	branch, err := github.FetchPRBranch(t.ProjectID, prNumber)
+	if err != nil {
+		return "", fmt.Errorf("fetch pr branch: %w", err)
+	}
+
+	wtPath := filepath.Join(r.agentOrch.worktreesDir, t.DirName())
+
+	// Remove stale worktree — previous agent may have left dirty state.
+	if _, statErr := os.Stat(wtPath); statErr == nil {
+		_ = project.RemoveWorktree(proj.ClonePath, wtPath)
+	}
+
+	ref := "refs/remotes/origin/" + branch
+	if err := project.CreateWorktreeExisting(proj.ClonePath, wtPath, ref); err != nil {
+		return "", fmt.Errorf("create fix worktree: %w", err)
+	}
+
+	if err := project.SanitizeWorktree(wtPath); err != nil {
+		r.logger.Warn("fix.worktree.sanitize", "task_id", t.ID, "err", err)
+	}
+
+	r.logger.Info("fix.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
+	return wtPath, nil
+}
+
 func (r *ReviewHandler) maybeCreateReviewTasks(tasks []task.Task, reviewPRs []github.PullRequest) {
 	projects, err := r.projects.List()
 	if err != nil || len(projects) == 0 {
@@ -359,18 +395,7 @@ func (r *ReviewHandler) handlePRIssue(issue github.PRIssue) {
 	var prompt string
 	switch issue.Kind {
 	case github.PRIssueConflict:
-		prompt = fmt.Sprintf(
-			"Fix merge conflicts on branch `%s` (PR #%d). "+
-				"Do NOT investigate — go straight to fixing.\n\n"+
-				"```bash\n"+
-				"git fetch origin main\n"+
-				"git rebase origin/main\n"+
-				"# resolve each conflict, git add, git rebase --continue\n"+
-				"git push --force-with-lease\n"+
-				"```\n\n"+
-				"Resolve conflicts to keep BOTH sides' changes. Push when done.",
-			issue.PR.HeadRefName, issue.PR.Number,
-		)
+		prompt = conflictPrompt(issue.PR)
 		r.logAudit(audit.EventPRConflictDetected, t.ID, "", map[string]any{
 			"pr": issue.PR.Number, "repo": issue.PR.Repository,
 		})
@@ -394,7 +419,13 @@ func (r *ReviewHandler) handlePRIssue(issue github.PRIssue) {
 
 	dir := ""
 	if t.ProjectID != "" {
-		d, wtErr := r.agentOrch.prepareWorktree(t)
+		var d string
+		var wtErr error
+		if issue.Kind == github.PRIssueConflict {
+			d, wtErr = r.prepareFixWorktree(t, issue.PR.Number)
+		} else {
+			d, wtErr = r.agentOrch.prepareWorktree(t)
+		}
 		if wtErr != nil {
 			r.logger.Error("pr-monitor.worktree", "task_id", t.ID, "err", wtErr)
 			return
@@ -431,6 +462,35 @@ func (r *ReviewHandler) handlePRIssue(issue github.PRIssue) {
 	r.logger.Info("pr-monitor.fix-started",
 		"task_id", t.ID, "issue", string(issue.Kind),
 		"pr", issue.PR.Number, "agent_id", ag.ID,
+	)
+}
+
+func conflictPrompt(pr github.PullRequest) string {
+	filesCtx := ""
+	if files, err := github.FetchPRFiles(pr.Repository, pr.Number); err == nil && len(files) > 0 {
+		filesCtx = "\n\nFiles changed in this PR:\n"
+		for _, f := range files {
+			filesCtx += "- " + f + "\n"
+		}
+	}
+
+	return fmt.Sprintf(
+		"Fix merge conflicts on branch `%s` (PR #%d). "+
+			"Do NOT investigate git state — go straight to rebasing.\n\n"+
+			"Steps:\n"+
+			"```bash\n"+
+			"git fetch origin\n"+
+			"git rebase refs/remotes/origin/main\n"+
+			"# resolve each conflict, git add, git rebase --continue\n"+
+			"git push --force-with-lease\n"+
+			"```\n\n"+
+			"Rules:\n"+
+			"- Use `refs/remotes/origin/main` (not `origin/main`) to avoid ambiguous refs\n"+
+			"- Resolve conflicts keeping BOTH sides' intent\n"+
+			"- If rebase produces more than 3 conflicting files, run `git rebase --abort` and stop — the task needs human review\n"+
+			"- No investigation, no extra commits, no unrelated changes"+
+			"%s",
+		pr.HeadRefName, pr.Number, filesCtx,
 	)
 }
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -315,6 +315,35 @@ func fetchPRStateWith(e execer, repo string, number int) (PRState, error) {
 	return s, nil
 }
 
+// PRFiles holds the list of files changed by a PR.
+type PRFiles struct {
+	Files []struct {
+		Path string `json:"path"`
+	} `json:"files"`
+}
+
+// FetchPRFiles returns the paths of files changed by a PR.
+func FetchPRFiles(repo string, number int) ([]string, error) {
+	return fetchPRFilesWith(defaultExecer, repo, number)
+}
+
+func fetchPRFilesWith(e execer, repo string, number int) ([]string, error) {
+	out, err := e.run("pr", "view", fmt.Sprintf("%d", number),
+		"--repo", repo, "--json", "files")
+	if err != nil {
+		return nil, fmt.Errorf("gh pr view %d files: %s: %w", number, strings.TrimSpace(string(out)), err)
+	}
+	var f PRFiles
+	if err := json.Unmarshal(out, &f); err != nil {
+		return nil, fmt.Errorf("parse pr files: %w", err)
+	}
+	paths := make([]string, len(f.Files))
+	for i := range f.Files {
+		paths[i] = f.Files[i].Path
+	}
+	return paths, nil
+}
+
 // PRBranch holds the head branch name of a PR.
 type PRBranch struct {
 	HeadRefName string `json:"headRefName"`

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -682,6 +682,66 @@ func TestParseGQLResponse_botFiltered(t *testing.T) {
 	}
 }
 
+func TestFetchPRFilesWith(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		output  string
+		execErr error
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:   "multiple files",
+			output: `{"files":[{"path":"app.go"},{"path":"internal/task/store.go"},{"path":"main.go"}]}`,
+			want:   []string{"app.go", "internal/task/store.go", "main.go"},
+		},
+		{
+			name:   "single file",
+			output: `{"files":[{"path":"README.md"}]}`,
+			want:   []string{"README.md"},
+		},
+		{
+			name:   "no files",
+			output: `{"files":[]}`,
+			want:   []string{},
+		},
+		{
+			name:    "exec error",
+			output:  "gh: not found",
+			execErr: fmt.Errorf("exit 1"),
+			wantErr: true,
+		},
+		{
+			name:    "invalid JSON",
+			output:  "not json",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fe := &fakeExecer{output: []byte(tt.output), err: tt.execErr}
+			got, err := fetchPRFilesWith(fe, "o/r", 42)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d files, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("file[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestHasPendingReview_pending(t *testing.T) {
 	t.Parallel()
 	fe := &fakeExecer{output: []byte(`[{"state":"COMMENTED"},{"state":"PENDING"}]`)}


### PR DESCRIPTION
## Motivation

Agent 379e34df burned 37 bash calls (~88K tokens) fixing a simple merge conflict. Root causes:
- `handlePRIssue` used generic `prepareWorktree()` which creates branch from `origin/main`, not the PR's head branch — agent lands on wrong branch, spends 10+ calls investigating
- Prompt used ambiguous `origin/main` ref (local branch can shadow remote tracking ref)
- No file context provided, agent wastes calls discovering conflicting files

## Implementation information

Three changes:

1. **`prepareFixWorktree`** (`app_reviews.go`) — new worktree prep for conflict fixes that checks out the PR's actual head branch (via `CreateWorktreeExisting`), removes stale worktrees from previous attempts, and sanitizes state. Only used for conflict fixes; CI failures still use generic `prepareWorktree`.

2. **Improved conflict prompt** (`app_reviews.go`) — uses `refs/remotes/origin/main` (unambiguous), includes list of changed files from `FetchPRFiles`, adds bail-out rule (abort if >3 conflicting files). Extracted to `conflictPrompt()` to keep `handlePRIssue` under funlen limit.

3. **`FetchPRFiles`** (`internal/github/client.go`) — fetches file paths changed by a PR via `gh pr view --json files`. Table-driven tests included.