### PR TITLE
refactor(worktree): centralize worktree ops

### DIFF
--- a/app.go
+++ b/app.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Automaat/synapse/internal/task"
 	"github.com/Automaat/synapse/internal/tmux"
 	"github.com/Automaat/synapse/internal/watcher"
+	"github.com/Automaat/synapse/internal/worktree"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
@@ -45,6 +46,7 @@ type App struct {
 	logDir       string
 	auditDir     string
 	prTracker    *github.IssueTracker
+	worktrees    *worktree.Manager
 	agentOrch    *AgentOrchestrator
 	reviewer     *ReviewHandler
 	workflow     *TaskWorkflow
@@ -114,9 +116,17 @@ func (a *App) startup(ctx context.Context) {
 
 	a.prTracker = github.NewIssueTracker(30 * time.Minute)
 
-	// Initialize domain services (dependency order: agentOrch → reviewer, workflow)
-	a.agentOrch = newAgentOrchestrator(a.tasks, a.projects, a.agents, a.audit, a.logger, a.worktreesDir)
-	a.reviewer = newReviewHandler(a.tasks, a.projects, a.agents, a.audit, a.logger, a.prTracker, emit, a.agentOrch)
+	// Initialize domain services (dependency order: worktrees → agentOrch → reviewer, workflow)
+	a.worktrees = worktree.New(worktree.Config{
+		WorktreesDir:     a.worktreesDir,
+		Projects:         a.projects,
+		Tasks:            a.tasks,
+		Logger:           a.logger,
+		PRBranchResolver: github.FetchPRBranch,
+		AgentChecker:     a.agents.HasRunningAgentForTask,
+	})
+	a.agentOrch = newAgentOrchestrator(a.tasks, a.projects, a.agents, a.audit, a.logger, a.worktrees)
+	a.reviewer = newReviewHandler(a.tasks, a.projects, a.agents, a.audit, a.logger, a.prTracker, emit, a.worktrees)
 	a.workflow = newTaskWorkflow(a.tasks, a.agents, a.audit, a.logger, a.notifier, a.agentOrch)
 
 	a.agents.SetOnComplete(a.workflow.handleAgentComplete)
@@ -129,7 +139,7 @@ func (a *App) startup(ctx context.Context) {
 
 	a.syncSkills()
 	a.reconnectAgents()
-	a.cleanupOrphanedWorktrees()
+	a.worktrees.CleanupOrphaned()
 	a.cleanStaleRuns()
 	a.restartStaleInProgress()
 	a.RegisterSpotlightHotkey()

--- a/app_agents.go
+++ b/app_agents.go
@@ -3,26 +3,25 @@ package main
 import (
 	"fmt"
 	"log/slog"
-	"os"
 	"os/exec"
-	"path/filepath"
 
 	"github.com/Automaat/synapse/internal/agent"
 	"github.com/Automaat/synapse/internal/audit"
 	"github.com/Automaat/synapse/internal/project"
 	"github.com/Automaat/synapse/internal/task"
 	"github.com/Automaat/synapse/internal/tmux"
+	"github.com/Automaat/synapse/internal/worktree"
 )
 
 // AgentOrchestrator manages agent lifecycle: worktree setup, project
 // assignment, and agent launching for a task.
 type AgentOrchestrator struct {
-	tasks        *task.Store
-	projects     *project.Store
-	agents       *agent.Manager
-	audit        *audit.Logger
-	logger       *slog.Logger
-	worktreesDir string
+	tasks     *task.Store
+	projects  *project.Store
+	agents    *agent.Manager
+	audit     *audit.Logger
+	logger    *slog.Logger
+	worktrees *worktree.Manager
 }
 
 func newAgentOrchestrator(
@@ -31,15 +30,15 @@ func newAgentOrchestrator(
 	agents *agent.Manager,
 	al *audit.Logger,
 	logger *slog.Logger,
-	worktreesDir string,
+	worktrees *worktree.Manager,
 ) *AgentOrchestrator {
 	return &AgentOrchestrator{
-		tasks:        tasks,
-		projects:     projects,
-		agents:       agents,
-		audit:        al,
-		logger:       logger,
-		worktreesDir: worktreesDir,
+		tasks:     tasks,
+		projects:  projects,
+		agents:    agents,
+		audit:     al,
+		logger:    logger,
+		worktrees: worktrees,
 	}
 }
 
@@ -72,7 +71,7 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string) (*agent.Agen
 
 	dir := ""
 	if t.ProjectID != "" {
-		d, wtErr := o.prepareWorktree(t)
+		d, wtErr := o.worktrees.PrepareForTask(t)
 		if wtErr != nil {
 			return nil, fmt.Errorf("worktree required for project task: %w", wtErr)
 		}
@@ -121,115 +120,6 @@ func (o *AgentOrchestrator) autoAssignProject(t task.Task) task.Task {
 	return t
 }
 
-func (o *AgentOrchestrator) prepareWorktree(t task.Task) (string, error) {
-	proj, err := o.projects.Get(t.ProjectID)
-	if err != nil {
-		return "", fmt.Errorf("get project: %w", err)
-	}
-	if err := project.FetchOrigin(proj.ClonePath); err != nil {
-		o.logger.Warn("worktree.fetch", "project", proj.ID, "err", err)
-	}
-
-	branch, err := project.DefaultBranch(proj.ClonePath)
-	if err != nil {
-		return "", fmt.Errorf("default branch: %w", err)
-	}
-
-	wtPath := filepath.Join(o.worktreesDir, t.DirName())
-	wtBranch := "synapse/" + t.DirName()
-	if _, statErr := os.Stat(wtPath); statErr == nil {
-		if err := project.SanitizeWorktree(wtPath); err != nil {
-			o.logger.Warn("worktree.sanitize", "task_id", t.ID, "err", err)
-		}
-		if t.Branch == "" {
-			if _, err := o.tasks.Update(t.ID, map[string]any{"branch": wtBranch}); err != nil {
-				o.logger.Error("worktree.set-branch", "task_id", t.ID, "err", err)
-			}
-		}
-		return wtPath, nil
-	}
-	if err := project.CreateWorktree(proj.ClonePath, wtPath, wtBranch, "origin/"+branch); err != nil {
-		return "", fmt.Errorf("create worktree: %w", err)
-	}
-
-	o.logger.Info("worktree.created", "task_id", t.ID, "path", wtPath)
-
-	if err := project.PushUpstream(wtPath, wtBranch); err != nil {
-		o.logger.Warn("worktree.push-upstream", "task_id", t.ID, "branch", wtBranch, "err", err)
-	}
-
-	if t.Branch == "" {
-		if _, err := o.tasks.Update(t.ID, map[string]any{"branch": wtBranch}); err != nil {
-			o.logger.Error("worktree.set-branch", "task_id", t.ID, "err", err)
-		}
-	}
-
-	return wtPath, nil
-}
-
-func (o *AgentOrchestrator) cleanupWorktree(taskID string) {
-	t, err := o.tasks.Get(taskID)
-	if err != nil || t.ProjectID == "" {
-		return
-	}
-	wtPath := filepath.Join(o.worktreesDir, t.DirName())
-	if _, err := os.Stat(wtPath); err != nil {
-		return
-	}
-	proj, err := o.projects.Get(t.ProjectID)
-	if err != nil {
-		return
-	}
-
-	if err := project.RemoveWorktree(proj.ClonePath, wtPath); err != nil {
-		o.logger.Error("worktree.cleanup", "path", wtPath, "err", err)
-	} else {
-		o.logger.Info("worktree.cleaned", "path", wtPath)
-	}
-}
-
-// cleanupOrphanedWorktrees scans the worktrees directory and removes entries
-// that no longer have an active task or running agent.
-func (a *App) cleanupOrphanedWorktrees() {
-	entries, err := os.ReadDir(a.worktreesDir)
-	if err != nil {
-		return
-	}
-	tasks, err := a.tasks.List()
-	if err != nil {
-		return
-	}
-	// Build lookup: dirName → task
-	active := make(map[string]*task.Task, len(tasks))
-	for i := range tasks {
-		active[tasks[i].DirName()] = &tasks[i]
-	}
-
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		name := e.Name()
-		wtPath := filepath.Join(a.worktreesDir, name)
-
-		t, exists := active[name]
-		switch {
-		case !exists:
-			// Task deleted — remove worktree directory.
-		case t.Status != task.StatusDone:
-			continue
-		case a.agents.HasRunningAgentForTask(t.ID):
-			continue
-		}
-
-		if err := os.RemoveAll(wtPath); err != nil {
-			a.logger.Error("worktree.orphan-cleanup", "path", wtPath, "err", err)
-		} else {
-			a.logger.Info("worktree.orphan-cleaned", "path", wtPath)
-		}
-	}
-}
-
 // startPRFixReviewAgent starts a headless agent to address review comments on
 // the task's PR. Named "pr-fix:" so handleAgentComplete routes it correctly.
 func (a *App) startPRFixReviewAgent(taskID string) error {
@@ -241,7 +131,7 @@ func (a *App) startPRFixReviewAgent(taskID string) error {
 	t = a.agentOrch.autoAssignProject(t)
 	dir := ""
 	if t.ProjectID != "" {
-		d, wtErr := a.agentOrch.prepareWorktree(t)
+		d, wtErr := a.worktrees.PrepareForTask(t)
 		if wtErr != nil {
 			return fmt.Errorf("worktree required: %w", wtErr)
 		}

--- a/app_orchestrator.go
+++ b/app_orchestrator.go
@@ -77,7 +77,7 @@ func (a *App) orchestratorLoop(ctx context.Context) {
 			a.maybeStartOrchestrator()
 			a.maybeDispatchTasks()
 			a.maybeResumePlanning()
-			a.cleanupOrphanedWorktrees()
+			a.worktrees.CleanupOrphaned()
 		}
 	}
 }

--- a/app_planning.go
+++ b/app_planning.go
@@ -98,7 +98,7 @@ func (w *TaskWorkflow) PlanTask(id string) error {
 
 	dir := ""
 	if t.ProjectID != "" {
-		d, wtErr := w.agentOrch.prepareWorktree(t)
+		d, wtErr := w.agentOrch.worktrees.PrepareForTask(t)
 		if wtErr != nil {
 			return fmt.Errorf("worktree required for project task: %w", wtErr)
 		}
@@ -335,7 +335,7 @@ func (w *TaskWorkflow) handleAgentComplete(ag *agent.Agent) {
 
 		// Cleanup worktree if task is done and no other agent is running.
 		if t, err := w.tasks.Get(ag.TaskID); err == nil && t.Status == task.StatusDone {
-			go w.agentOrch.cleanupWorktree(ag.TaskID)
+			go w.agentOrch.worktrees.Remove(ag.TaskID)
 		}
 	}
 }

--- a/app_projects.go
+++ b/app_projects.go
@@ -2,10 +2,7 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
 
 	"github.com/Automaat/synapse/internal/project"
 )
@@ -55,35 +52,23 @@ func (a *App) DeleteProject(id string) error {
 
 // ListWorktrees returns all git worktrees for the given project's bare clone.
 func (a *App) ListWorktrees(projectID string) ([]project.Worktree, error) {
-	proj, err := a.projects.Get(projectID)
-	if err != nil {
-		return nil, err
-	}
-	return project.ListWorktrees(proj.ClonePath)
+	return a.worktrees.List(projectID)
 }
 
 // OpenInTerminal opens a worktree path in a new Ghostty terminal tab.
 func (a *App) OpenInTerminal(path string) error {
-	clean := filepath.Clean(path)
-	if !strings.HasPrefix(clean, filepath.Clean(a.worktreesDir)) {
-		return fmt.Errorf("path not within worktrees directory")
+	if err := a.worktrees.ValidatePath(path); err != nil {
+		return err
 	}
-	if info, err := os.Stat(clean); err != nil || !info.IsDir() {
-		return fmt.Errorf("path is not a valid directory")
-	}
-	return openDirInGhostty(clean)
+	return openDirInGhostty(path)
 }
 
 // OpenInEditor opens a worktree path in Zed.
 func (a *App) OpenInEditor(path string) error {
-	clean := filepath.Clean(path)
-	if !strings.HasPrefix(clean, filepath.Clean(a.worktreesDir)) {
-		return fmt.Errorf("path not within worktrees directory")
+	if err := a.worktrees.ValidatePath(path); err != nil {
+		return err
 	}
-	if info, err := os.Stat(clean); err != nil || !info.IsDir() {
-		return fmt.Errorf("path is not a valid directory")
-	}
-	return exec.Command("zed", clean).Start()
+	return exec.Command("zed", path).Start()
 }
 
 func openDirInGhostty(dir string) error {

--- a/app_reviews.go
+++ b/app_reviews.go
@@ -3,8 +3,6 @@ package main
 import (
 	"fmt"
 	"log/slog"
-	"os"
-	"path/filepath"
 	"slices"
 	"time"
 
@@ -14,6 +12,7 @@ import (
 	"github.com/Automaat/synapse/internal/github"
 	"github.com/Automaat/synapse/internal/project"
 	"github.com/Automaat/synapse/internal/task"
+	"github.com/Automaat/synapse/internal/worktree"
 )
 
 const (
@@ -35,7 +34,7 @@ type ReviewHandler struct {
 	logger    *slog.Logger
 	prTracker *github.IssueTracker
 	emit      func(string, any)
-	agentOrch *AgentOrchestrator
+	worktrees *worktree.Manager
 }
 
 func newReviewHandler(
@@ -46,7 +45,7 @@ func newReviewHandler(
 	logger *slog.Logger,
 	prTracker *github.IssueTracker,
 	emit func(string, any),
-	agentOrch *AgentOrchestrator,
+	worktrees *worktree.Manager,
 ) *ReviewHandler {
 	return &ReviewHandler{
 		tasks:     tasks,
@@ -56,7 +55,7 @@ func newReviewHandler(
 		logger:    logger,
 		prTracker: prTracker,
 		emit:      emit,
-		agentOrch: agentOrch,
+		worktrees: worktrees,
 	}
 }
 
@@ -147,7 +146,7 @@ func (a *App) StartReview(taskID string) error {
 func (r *ReviewHandler) startReviewAgent(t task.Task) error {
 	dir := config.HomeDir()
 	if t.ProjectID != "" {
-		d, err := r.prepareReviewWorktree(t)
+		d, err := r.worktrees.PrepareForReview(t)
 		if err != nil {
 			r.logger.Error("review.worktree", "task_id", t.ID, "err", err)
 		} else {
@@ -176,71 +175,6 @@ func (r *ReviewHandler) startReviewAgent(t task.Task) error {
 	r.logAudit(audit.EventReviewStarted, t.ID, ag.ID, map[string]any{"pr": t.PRNumber})
 	r.logger.Info("review.agent-started", "task_id", t.ID, "agent_id", ag.ID, "pr", t.PRNumber)
 	return nil
-}
-
-func (r *ReviewHandler) prepareReviewWorktree(t task.Task) (string, error) {
-	proj, err := r.projects.Get(t.ProjectID)
-	if err != nil {
-		return "", fmt.Errorf("get project: %w", err)
-	}
-
-	if err := project.FetchOrigin(proj.ClonePath); err != nil {
-		r.logger.Warn("review.worktree.fetch", "project", proj.ID, "err", err)
-	}
-
-	branch, err := github.FetchPRBranch(t.ProjectID, t.PRNumber)
-	if err != nil {
-		return "", fmt.Errorf("fetch pr branch: %w", err)
-	}
-
-	wtPath := filepath.Join(r.agentOrch.worktreesDir, t.DirName())
-	if _, statErr := os.Stat(wtPath); statErr == nil {
-		return wtPath, nil
-	}
-
-	ref := "refs/remotes/origin/" + branch
-	if err := project.CreateWorktreeDetached(proj.ClonePath, wtPath, ref); err != nil {
-		return "", fmt.Errorf("create review worktree: %w", err)
-	}
-
-	r.logger.Info("review.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
-	return wtPath, nil
-}
-
-// prepareFixWorktree checks out the PR's head branch so the agent can rebase and push.
-func (r *ReviewHandler) prepareFixWorktree(t task.Task, prNumber int) (string, error) {
-	proj, err := r.projects.Get(t.ProjectID)
-	if err != nil {
-		return "", fmt.Errorf("get project: %w", err)
-	}
-
-	if err := project.FetchOrigin(proj.ClonePath); err != nil {
-		r.logger.Warn("fix.worktree.fetch", "project", proj.ID, "err", err)
-	}
-
-	branch, err := github.FetchPRBranch(t.ProjectID, prNumber)
-	if err != nil {
-		return "", fmt.Errorf("fetch pr branch: %w", err)
-	}
-
-	wtPath := filepath.Join(r.agentOrch.worktreesDir, t.DirName())
-
-	// Remove stale worktree — previous agent may have left dirty state.
-	if _, statErr := os.Stat(wtPath); statErr == nil {
-		_ = project.RemoveWorktree(proj.ClonePath, wtPath)
-	}
-
-	ref := "refs/remotes/origin/" + branch
-	if err := project.CreateWorktreeExisting(proj.ClonePath, wtPath, ref); err != nil {
-		return "", fmt.Errorf("create fix worktree: %w", err)
-	}
-
-	if err := project.SanitizeWorktree(wtPath); err != nil {
-		r.logger.Warn("fix.worktree.sanitize", "task_id", t.ID, "err", err)
-	}
-
-	r.logger.Info("fix.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
-	return wtPath, nil
 }
 
 func (r *ReviewHandler) maybeCreateReviewTasks(tasks []task.Task, reviewPRs []github.PullRequest) {
@@ -422,9 +356,9 @@ func (r *ReviewHandler) handlePRIssue(issue github.PRIssue) {
 		var d string
 		var wtErr error
 		if issue.Kind == github.PRIssueConflict {
-			d, wtErr = r.prepareFixWorktree(t, issue.PR.Number)
+			d, wtErr = r.worktrees.PrepareForFix(t, issue.PR.Number)
 		} else {
-			d, wtErr = r.agentOrch.prepareWorktree(t)
+			d, wtErr = r.worktrees.PrepareForTask(t)
 		}
 		if wtErr != nil {
 			r.logger.Error("pr-monitor.worktree", "task_id", t.ID, "err", wtErr)

--- a/app_tasks.go
+++ b/app_tasks.go
@@ -80,7 +80,7 @@ func (a *App) UpdateTask(id string, updates map[string]any) (task.Task, error) {
 		}
 	}
 	if t.Status == task.StatusDone {
-		a.wg.Go(func() { a.agentOrch.cleanupWorktree(t.ID) })
+		a.wg.Go(func() { a.worktrees.Remove(t.ID) })
 	}
 	return t, nil
 }
@@ -88,7 +88,7 @@ func (a *App) UpdateTask(id string, updates map[string]any) (task.Task, error) {
 // DeleteTask removes a task file from disk and cleans up its worktree.
 func (a *App) DeleteTask(id string) error {
 	a.logger.Info("task.delete", "task_id", id)
-	a.agentOrch.cleanupWorktree(id)
+	a.worktrees.Remove(id)
 	a.logAudit(audit.EventTaskDeleted, id, "", nil)
 	if err := a.tasks.Delete(id); err != nil {
 		a.logger.Error("task.delete.failed", "task_id", id, "err", err)

--- a/app_test.go
+++ b/app_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Automaat/synapse/internal/notification"
 	"github.com/Automaat/synapse/internal/task"
 	"github.com/Automaat/synapse/internal/tmux"
+	"github.com/Automaat/synapse/internal/worktree"
 )
 
 func discardLogger() *slog.Logger {
@@ -40,7 +41,13 @@ func setupApp(t *testing.T) *App {
 	mgr := agent.NewManager(t.Context(), tm, emit, logger, logDir)
 
 	notifier := notification.New(emit)
-	agentOrch := newAgentOrchestrator(store, nil, mgr, nil, logger, "")
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Tasks:        store,
+		Logger:       logger,
+		AgentChecker: mgr.HasRunningAgentForTask,
+	})
+	agentOrch := newAgentOrchestrator(store, nil, mgr, nil, logger, wm)
 	workflow := newTaskWorkflow(store, mgr, nil, logger, notifier, agentOrch)
 
 	return &App{
@@ -48,6 +55,7 @@ func setupApp(t *testing.T) *App {
 		agents:    mgr,
 		tasksDir:  dir,
 		logger:    logger,
+		worktrees: wm,
 		agentOrch: agentOrch,
 		workflow:  workflow,
 	}

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -1,0 +1,260 @@
+package worktree
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Automaat/synapse/internal/project"
+	"github.com/Automaat/synapse/internal/task"
+)
+
+// PRBranchResolver fetches the head branch name for a PR.
+// Injected to avoid importing internal/github.
+type PRBranchResolver func(repo string, prNumber int) (string, error)
+
+// AgentChecker reports whether a task has a running agent.
+// Injected to avoid importing internal/agent.
+type AgentChecker func(taskID string) bool
+
+type Config struct {
+	WorktreesDir     string
+	Projects         *project.Store
+	Tasks            *task.Store
+	Logger           *slog.Logger
+	PRBranchResolver PRBranchResolver
+	AgentChecker     AgentChecker
+}
+
+type Manager struct {
+	dir      string
+	projects *project.Store
+	tasks    *task.Store
+	logger   *slog.Logger
+	prBranch PRBranchResolver
+	hasAgent AgentChecker
+}
+
+func New(cfg Config) *Manager {
+	return &Manager{
+		dir:      cfg.WorktreesDir,
+		projects: cfg.Projects,
+		tasks:    cfg.Tasks,
+		logger:   cfg.Logger,
+		prBranch: cfg.PRBranchResolver,
+		hasAgent: cfg.AgentChecker,
+	}
+}
+
+// Dir returns the base worktrees directory.
+func (m *Manager) Dir() string { return m.dir }
+
+// PathFor returns the worktree path for a task.
+func (m *Manager) PathFor(t task.Task) string {
+	return filepath.Join(m.dir, t.DirName())
+}
+
+// Exists reports whether the worktree directory exists for a task.
+func (m *Manager) Exists(t task.Task) bool {
+	_, err := os.Stat(m.PathFor(t))
+	return err == nil
+}
+
+// ValidatePath checks that path is within the worktrees directory and is a directory.
+func (m *Manager) ValidatePath(path string) error {
+	clean := filepath.Clean(path)
+	if !strings.HasPrefix(clean, filepath.Clean(m.dir)) {
+		return fmt.Errorf("path not within worktrees directory")
+	}
+	info, err := os.Stat(clean)
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("path is not a valid directory")
+	}
+	return nil
+}
+
+// PrepareForTask creates (or reuses) a worktree for implementation work.
+// Fetches origin, creates branch synapse/{dirName} off default branch,
+// pushes upstream, and sets task.Branch.
+func (m *Manager) PrepareForTask(t task.Task) (string, error) {
+	proj, err := m.projects.Get(t.ProjectID)
+	if err != nil {
+		return "", fmt.Errorf("get project: %w", err)
+	}
+	if err := project.FetchOrigin(proj.ClonePath); err != nil {
+		m.logger.Warn("worktree.fetch", "project", proj.ID, "err", err)
+	}
+
+	branch, err := project.DefaultBranch(proj.ClonePath)
+	if err != nil {
+		return "", fmt.Errorf("default branch: %w", err)
+	}
+
+	wtPath := m.PathFor(t)
+	wtBranch := "synapse/" + t.DirName()
+
+	if _, statErr := os.Stat(wtPath); statErr == nil {
+		if err := project.SanitizeWorktree(wtPath); err != nil {
+			m.logger.Warn("worktree.sanitize", "task_id", t.ID, "err", err)
+		}
+		m.ensureBranch(t, wtBranch)
+		return wtPath, nil
+	}
+
+	if err := project.CreateWorktree(proj.ClonePath, wtPath, wtBranch, "origin/"+branch); err != nil {
+		return "", fmt.Errorf("create worktree: %w", err)
+	}
+	m.logger.Info("worktree.created", "task_id", t.ID, "path", wtPath)
+
+	if err := project.PushUpstream(wtPath, wtBranch); err != nil {
+		m.logger.Warn("worktree.push-upstream", "task_id", t.ID, "branch", wtBranch, "err", err)
+	}
+
+	m.ensureBranch(t, wtBranch)
+	return wtPath, nil
+}
+
+// PrepareForReview creates a detached-HEAD worktree for read-only PR review.
+func (m *Manager) PrepareForReview(t task.Task) (string, error) {
+	proj, err := m.projects.Get(t.ProjectID)
+	if err != nil {
+		return "", fmt.Errorf("get project: %w", err)
+	}
+	if err := project.FetchOrigin(proj.ClonePath); err != nil {
+		m.logger.Warn("review.worktree.fetch", "project", proj.ID, "err", err)
+	}
+
+	branch, err := m.prBranch(t.ProjectID, t.PRNumber)
+	if err != nil {
+		return "", fmt.Errorf("fetch pr branch: %w", err)
+	}
+
+	wtPath := m.PathFor(t)
+	if _, statErr := os.Stat(wtPath); statErr == nil {
+		return wtPath, nil
+	}
+
+	ref := "refs/remotes/origin/" + branch
+	if err := project.CreateWorktreeDetached(proj.ClonePath, wtPath, ref); err != nil {
+		return "", fmt.Errorf("create review worktree: %w", err)
+	}
+	m.logger.Info("review.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
+	return wtPath, nil
+}
+
+// PrepareForFix creates a worktree checking out the PR's head branch
+// so the agent can rebase and push.
+func (m *Manager) PrepareForFix(t task.Task, prNumber int) (string, error) {
+	proj, err := m.projects.Get(t.ProjectID)
+	if err != nil {
+		return "", fmt.Errorf("get project: %w", err)
+	}
+	if err := project.FetchOrigin(proj.ClonePath); err != nil {
+		m.logger.Warn("fix.worktree.fetch", "project", proj.ID, "err", err)
+	}
+
+	branch, err := m.prBranch(t.ProjectID, prNumber)
+	if err != nil {
+		return "", fmt.Errorf("fetch pr branch: %w", err)
+	}
+
+	wtPath := m.PathFor(t)
+
+	// Remove stale worktree — previous agent may have left dirty state.
+	if _, statErr := os.Stat(wtPath); statErr == nil {
+		_ = project.RemoveWorktree(proj.ClonePath, wtPath)
+	}
+
+	ref := "refs/remotes/origin/" + branch
+	if err := project.CreateWorktreeExisting(proj.ClonePath, wtPath, ref); err != nil {
+		return "", fmt.Errorf("create fix worktree: %w", err)
+	}
+	if err := project.SanitizeWorktree(wtPath); err != nil {
+		m.logger.Warn("fix.worktree.sanitize", "task_id", t.ID, "err", err)
+	}
+	m.logger.Info("fix.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
+	return wtPath, nil
+}
+
+// Remove cleans up the worktree for a task via git worktree remove.
+func (m *Manager) Remove(taskID string) {
+	t, err := m.tasks.Get(taskID)
+	if err != nil || t.ProjectID == "" {
+		return
+	}
+	wtPath := filepath.Join(m.dir, t.DirName())
+	if _, err := os.Stat(wtPath); err != nil {
+		return
+	}
+	proj, err := m.projects.Get(t.ProjectID)
+	if err != nil {
+		return
+	}
+	if err := project.RemoveWorktree(proj.ClonePath, wtPath); err != nil {
+		m.logger.Error("worktree.cleanup", "path", wtPath, "err", err)
+	} else {
+		m.logger.Info("worktree.cleaned", "path", wtPath)
+	}
+}
+
+// CleanupOrphaned removes worktree directories for deleted or completed tasks
+// that have no running agent.
+func (m *Manager) CleanupOrphaned() {
+	entries, err := os.ReadDir(m.dir)
+	if err != nil {
+		return
+	}
+	tasks, err := m.tasks.List()
+	if err != nil {
+		return
+	}
+
+	active := make(map[string]*task.Task, len(tasks))
+	for i := range tasks {
+		active[tasks[i].DirName()] = &tasks[i]
+	}
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		wtPath := filepath.Join(m.dir, name)
+
+		t, exists := active[name]
+		switch {
+		case !exists:
+			// Task deleted — remove worktree directory.
+		case t.Status != task.StatusDone:
+			continue
+		case m.hasAgent != nil && m.hasAgent(t.ID):
+			continue
+		}
+
+		if err := os.RemoveAll(wtPath); err != nil {
+			m.logger.Error("worktree.orphan-cleanup", "path", wtPath, "err", err)
+		} else {
+			m.logger.Info("worktree.orphan-cleaned", "path", wtPath)
+		}
+	}
+}
+
+// List returns all git worktrees for the given project.
+func (m *Manager) List(projectID string) ([]project.Worktree, error) {
+	proj, err := m.projects.Get(projectID)
+	if err != nil {
+		return nil, err
+	}
+	return project.ListWorktrees(proj.ClonePath)
+}
+
+func (m *Manager) ensureBranch(t task.Task, branch string) {
+	if t.Branch != "" {
+		return
+	}
+	if _, err := m.tasks.Update(t.ID, map[string]any{"branch": branch}); err != nil {
+		m.logger.Error("worktree.set-branch", "task_id", t.ID, "err", err)
+	}
+}

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -1,0 +1,117 @@
+package worktree
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Automaat/synapse/internal/task"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestPathFor(t *testing.T) {
+	m := &Manager{dir: "/tmp/wt"}
+	tk := task.Task{ID: "abc12345", Slug: "my-task"}
+	got := m.PathFor(tk)
+	want := "/tmp/wt/my-task-abc12345"
+	if got != want {
+		t.Errorf("PathFor = %q, want %q", got, want)
+	}
+}
+
+func TestPathForNoSlug(t *testing.T) {
+	m := &Manager{dir: "/tmp/wt"}
+	tk := task.Task{ID: "abc12345"}
+	got := m.PathFor(tk)
+	want := "/tmp/wt/abc12345"
+	if got != want {
+		t.Errorf("PathFor = %q, want %q", got, want)
+	}
+}
+
+func TestExists(t *testing.T) {
+	dir := t.TempDir()
+	m := &Manager{dir: dir}
+
+	tk := task.Task{ID: "exists01"}
+	if m.Exists(tk) {
+		t.Error("should not exist yet")
+	}
+
+	if err := os.MkdirAll(filepath.Join(dir, tk.DirName()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !m.Exists(tk) {
+		t.Error("should exist after mkdir")
+	}
+}
+
+func TestValidatePath(t *testing.T) {
+	dir := t.TempDir()
+	m := &Manager{dir: dir}
+
+	// Outside worktrees dir
+	if err := m.ValidatePath("/tmp/other"); err == nil {
+		t.Error("expected error for path outside worktrees dir")
+	}
+
+	// Non-existent path within dir
+	if err := m.ValidatePath(filepath.Join(dir, "nope")); err == nil {
+		t.Error("expected error for non-existent path")
+	}
+
+	// Valid directory
+	sub := filepath.Join(dir, "valid")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.ValidatePath(sub); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCleanupOrphaned(t *testing.T) {
+	dir := t.TempDir()
+	tasksDir := t.TempDir()
+
+	store, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tk, err := store.Create("test task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create worktree dirs: one matching task (not done), one orphaned
+	if err := os.MkdirAll(filepath.Join(dir, tk.DirName()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	orphanDir := filepath.Join(dir, "orphan-12345678")
+	if err := os.MkdirAll(orphanDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	m := New(Config{
+		WorktreesDir: dir,
+		Tasks:        store,
+		Logger:       discardLogger(),
+	})
+
+	m.CleanupOrphaned()
+
+	// Orphan should be removed
+	if _, err := os.Stat(orphanDir); !os.IsNotExist(err) {
+		t.Error("orphan dir should be removed")
+	}
+	// Active task's dir should remain
+	if _, err := os.Stat(filepath.Join(dir, tk.DirName())); err != nil {
+		t.Error("active task dir should remain")
+	}
+}


### PR DESCRIPTION
## Motivation

Worktree operations were scattered across `app_agents.go`, `app_reviews.go`, `app_projects.go`, and `app.go` with duplicated patterns (resolve project, fetch origin, compute path, sanitize/create, update task branch). Single point of interaction simplifies callers and makes worktree lifecycle easier to reason about.

## Implementation information

New `internal/worktree` package with a `Manager` struct exposing:

- `PrepareForTask` — implementation worktree with new synapse branch
- `PrepareForReview` — detached-HEAD worktree for read-only PR review
- `PrepareForFix` — checkout worktree for PR rebase/push
- `Remove` / `CleanupOrphaned` — cleanup
- `List` / `PathFor` / `Exists` / `ValidatePath` — helpers

Dependencies on `internal/github` and `internal/agent` injected via function values (`PRBranchResolver`, `AgentChecker`) to keep the package dependency graph acyclic.

Callers refactored:
- `AgentOrchestrator` drops `prepareWorktree`/`cleanupWorktree`, uses `worktrees.PrepareForTask`
- `ReviewHandler` drops `prepareReviewWorktree`/`prepareFixWorktree`, uses `worktrees.PrepareForReview`/`PrepareForFix`
- `App` drops `cleanupOrphanedWorktrees`, uses `worktrees.CleanupOrphaned`
- `ListWorktrees`/`OpenInTerminal`/`OpenInEditor` delegate to manager

Tests added for path computation, validation, and orphan cleanup.

> Changelog: skip