### PR TITLE
fix(worktree): qualify base ref to avoid ambiguity

### DIFF
--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -103,7 +103,7 @@ func (m *Manager) PrepareForTask(t task.Task) (string, error) {
 		return wtPath, nil
 	}
 
-	if err := project.CreateWorktree(proj.ClonePath, wtPath, wtBranch, "origin/"+branch); err != nil {
+	if err := project.CreateWorktree(proj.ClonePath, wtPath, wtBranch, "refs/remotes/origin/"+branch); err != nil {
 		return "", fmt.Errorf("create worktree: %w", err)
 	}
 	m.logger.Info("worktree.created", "task_id", t.ID, "path", wtPath)


### PR DESCRIPTION
## Motivation

auto-implement kept failing for project tasks:

\`\`\`
worktree required for project task: create worktree:
git worktree add ... -b synapse/... origin/main:
fatal: ambiguous object name: 'origin/main'
\`\`\`

The bare clone had a stray \`refs/heads/origin/main\` shadowing
\`refs/remotes/origin/main\`, so git refused to resolve the short
\`origin/main\` ref and worktree creation aborted. Two in-progress
tasks were stuck because agents never started.

## Implementation information

Pass the fully-qualified \`refs/remotes/origin/<branch>\` to
\`git worktree add\` in \`PrepareForTask\`. Other call sites
(\`PrepareForReview\`, \`PrepareForFix\`) already qualify the ref.

\`SanitizeWorktree\` still cleans up shadow branches inside the
worktree after creation — this fix makes creation itself immune
to bare-clone ref pollution.

## Supporting documentation

n/a