### PR TITLE
fix(ui): stop board flicker on task refresh

### DIFF
--- a/frontend/src/stores/entity-store.svelte.ts
+++ b/frontend/src/stores/entity-store.svelte.ts
@@ -24,7 +24,10 @@ export class EntityStore<T extends { id: string }> {
   }
 
   async load(): Promise<void> {
-    this.loading = true
+    // Only flip loading for the initial load so background refreshes
+    // (polling + fsnotify events) don't blank out the UI.
+    const isInitial = this.items.size === 0
+    if (isInitial) this.loading = true
     this.error = ''
     try {
       const result = await this.loadFn()
@@ -34,7 +37,7 @@ export class EntityStore<T extends { id: string }> {
     } catch (e) {
       this.error = String(e)
     } finally {
-      this.loading = false
+      if (isInitial) this.loading = false
     }
   }
 


### PR DESCRIPTION
## Motivation

Task cards on the board visibly disappear and reappear whenever the watcher emits `task:updated` (agent runs writing to the task file) or polling fires every 5s. Looks like flicker; in the reporting case a task kept toggling out of view as its agent wrote updates.

## Implementation information

Root cause: `EntityStore.load()` sets `loading=true` on every refresh. `TaskList.svelte` renders a "Loading tasks..." overlay whenever `taskStore.loading` is true, blanking the entire board during each background reload.

Fix: only flip `loading` on the initial load (when `items.size === 0`). Background refreshes atomically swap the items map without touching `loading`, so the board stays put.

## Supporting documentation

N/A

> Changelog: fix(ui): stop board flicker on task refresh