### PR TITLE
refactor(task): add Manager as single entrypoint

### DIFF
--- a/app.go
+++ b/app.go
@@ -30,7 +30,7 @@ type App struct {
 	ctx          context.Context
 	cancel       context.CancelFunc
 	wg           sync.WaitGroup
-	tasks        *task.Store
+	tasks        *task.Manager
 	projects     *project.Store
 	agents       *agent.Manager
 	tmux         *tmux.Manager
@@ -94,7 +94,6 @@ func (a *App) startup(ctx context.Context) {
 		runtime.Quit(ctx)
 		return
 	}
-	a.tasks = store
 
 	projStore, err := project.NewStore(
 		filepath.Join(config.HomeDir(), "projects"),
@@ -111,6 +110,7 @@ func (a *App) startup(ctx context.Context) {
 	emit := func(event string, data any) {
 		runtime.EventsEmit(ctx, event, data)
 	}
+	a.tasks = task.NewManager(store, task.EmitterFunc(emit))
 	a.notifier = notification.New(emit)
 	a.agents = agent.NewManager(ctx, a.tmux, emit, a.logger, a.logDir)
 

--- a/app_agents.go
+++ b/app_agents.go
@@ -16,7 +16,7 @@ import (
 // AgentOrchestrator manages agent lifecycle: worktree setup, project
 // assignment, and agent launching for a task.
 type AgentOrchestrator struct {
-	tasks     *task.Store
+	tasks     *task.Manager
 	projects  *project.Store
 	agents    *agent.Manager
 	audit     *audit.Logger
@@ -25,7 +25,7 @@ type AgentOrchestrator struct {
 }
 
 func newAgentOrchestrator(
-	tasks *task.Store,
+	tasks *task.Manager,
 	projects *project.Store,
 	agents *agent.Manager,
 	al *audit.Logger,

--- a/app_planning.go
+++ b/app_planning.go
@@ -17,7 +17,7 @@ import (
 
 // TaskWorkflow handles triage, planning, evaluation, and agent completion callbacks.
 type TaskWorkflow struct {
-	tasks     *task.Store
+	tasks     *task.Manager
 	agents    *agent.Manager
 	audit     *audit.Logger
 	logger    *slog.Logger
@@ -26,7 +26,7 @@ type TaskWorkflow struct {
 }
 
 func newTaskWorkflow(
-	tasks *task.Store,
+	tasks *task.Manager,
 	agents *agent.Manager,
 	al *audit.Logger,
 	logger *slog.Logger,

--- a/app_reviews.go
+++ b/app_reviews.go
@@ -27,7 +27,7 @@ const (
 
 // ReviewHandler manages PR review task creation, agent dispatch, and status tracking.
 type ReviewHandler struct {
-	tasks     *task.Store
+	tasks     *task.Manager
 	projects  *project.Store
 	agents    *agent.Manager
 	audit     *audit.Logger
@@ -38,7 +38,7 @@ type ReviewHandler struct {
 }
 
 func newReviewHandler(
-	tasks *task.Store,
+	tasks *task.Manager,
 	projects *project.Store,
 	agents *agent.Manager,
 	al *audit.Logger,

--- a/app_test.go
+++ b/app_test.go
@@ -33,6 +33,7 @@ func setupApp(t *testing.T) *App {
 	if err != nil {
 		t.Fatal(err)
 	}
+	taskMgr := task.NewManager(store, nil)
 
 	logger := discardLogger()
 	emit := func(string, any) {}
@@ -43,15 +44,15 @@ func setupApp(t *testing.T) *App {
 	notifier := notification.New(emit)
 	wm := worktree.New(worktree.Config{
 		WorktreesDir: t.TempDir(),
-		Tasks:        store,
+		Tasks:        taskMgr,
 		Logger:       logger,
 		AgentChecker: mgr.HasRunningAgentForTask,
 	})
-	agentOrch := newAgentOrchestrator(store, nil, mgr, nil, logger, wm)
-	workflow := newTaskWorkflow(store, mgr, nil, logger, notifier, agentOrch)
+	agentOrch := newAgentOrchestrator(taskMgr, nil, mgr, nil, logger, wm)
+	workflow := newTaskWorkflow(taskMgr, mgr, nil, logger, notifier, agentOrch)
 
 	return &App{
-		tasks:     store,
+		tasks:     taskMgr,
 		agents:    mgr,
 		tasksDir:  dir,
 		logger:    logger,

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -47,10 +47,11 @@ func run(args []string) int {
 		return fatal(jsonOut, "load config: %v", err)
 	}
 
-	store, err := task.NewStore(cfg.TasksDir)
+	rawStore, err := task.NewStore(cfg.TasksDir)
 	if err != nil {
 		return fatal(jsonOut, "open store: %v", err)
 	}
+	store := task.NewManager(rawStore, nil)
 
 	projStore, err := project.NewStore(cfg.ProjectsDir, cfg.ClonesDir)
 	if err != nil {
@@ -78,7 +79,7 @@ func run(args []string) int {
 	}
 }
 
-func cmdList(s *task.Store, args []string, jsonOut bool) int {
+func cmdList(s *task.Manager, args []string, jsonOut bool) int {
 	fs := flag.NewFlagSet("list", flag.ContinueOnError)
 	status := fs.String("status", "", "filter by status")
 	tag := fs.String("tag", "", "filter by tag")
@@ -121,7 +122,7 @@ func cmdList(s *task.Store, args []string, jsonOut bool) int {
 	return 0
 }
 
-func cmdGet(s *task.Store, args []string, jsonOut bool) int {
+func cmdGet(s *task.Manager, args []string, jsonOut bool) int {
 	if len(args) < 1 {
 		return fatal(jsonOut, "usage: get <id>")
 	}
@@ -162,7 +163,7 @@ func cmdGet(s *task.Store, args []string, jsonOut bool) int {
 	return 0
 }
 
-func cmdCreate(s *task.Store, args []string, jsonOut bool) int {
+func cmdCreate(s *task.Manager, args []string, jsonOut bool) int {
 	fs := flag.NewFlagSet("create", flag.ContinueOnError)
 	title := fs.String("title", "", "task title (required)")
 	body := fs.String("body", "", "task body markdown")
@@ -218,7 +219,7 @@ func cmdCreate(s *task.Store, args []string, jsonOut bool) int {
 	return 0
 }
 
-func cmdUpdate(s *task.Store, args []string, jsonOut bool) int {
+func cmdUpdate(s *task.Manager, args []string, jsonOut bool) int {
 	if len(args) < 1 {
 		return fatal(jsonOut, "usage: update <id> [flags]")
 	}
@@ -291,7 +292,7 @@ func cmdUpdate(s *task.Store, args []string, jsonOut bool) int {
 	return 0
 }
 
-func cmdDelete(s *task.Store, args []string, jsonOut bool) int {
+func cmdDelete(s *task.Manager, args []string, jsonOut bool) int {
 	if len(args) < 1 {
 		return fatal(jsonOut, "usage: delete <id>")
 	}

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -1,0 +1,130 @@
+package task
+
+import (
+	"sync"
+
+	"github.com/Automaat/synapse/internal/events"
+)
+
+// EventEmitter publishes task lifecycle events.
+type EventEmitter interface {
+	Emit(event string, data any)
+}
+
+// EmitterFunc adapts a function into an EventEmitter.
+type EmitterFunc func(event string, data any)
+
+func (f EmitterFunc) Emit(event string, data any) { f(event, data) }
+
+type noopEmitter struct{}
+
+func (noopEmitter) Emit(string, any) {}
+
+// NoopEmitter returns an EventEmitter that discards events.
+func NoopEmitter() EventEmitter { return noopEmitter{} }
+
+// Manager is the single entrypoint for task mutations. It wraps Store with
+// per-task mutual exclusion and emits events on mutations.
+type Manager struct {
+	store   *Store
+	emitter EventEmitter
+	locks   sync.Map // string -> *sync.Mutex
+}
+
+// NewManager constructs a Manager over the given Store. If emitter is nil,
+// events are discarded.
+func NewManager(store *Store, emitter EventEmitter) *Manager {
+	if emitter == nil {
+		emitter = NoopEmitter()
+	}
+	return &Manager{store: store, emitter: emitter}
+}
+
+// Store returns the underlying Store. Use for operations not covered by Manager.
+func (m *Manager) Store() *Store { return m.store }
+
+// Comments returns the underlying CommentStore.
+func (m *Manager) Comments() *CommentStore { return m.store.Comments() }
+
+func (m *Manager) lockFor(id string) *sync.Mutex {
+	existing, _ := m.locks.LoadOrStore(id, &sync.Mutex{})
+	mu, _ := existing.(*sync.Mutex)
+	return mu
+}
+
+// List returns all tasks (lock-free).
+func (m *Manager) List() ([]Task, error) { return m.store.List() }
+
+// Get returns a single task by ID (lock-free).
+func (m *Manager) Get(id string) (Task, error) { return m.store.Get(id) }
+
+// Create persists a new task and emits task:created.
+func (m *Manager) Create(title, body, mode string) (Task, error) {
+	t, err := m.store.Create(title, body, mode)
+	if err != nil {
+		return t, err
+	}
+	m.emitter.Emit(events.TaskCreated, t.FilePath)
+	return t, nil
+}
+
+// Update applies field updates to a task and emits task:updated.
+// Serializes with other Update/AddRun/UpdateRun/Delete calls for the same id.
+func (m *Manager) Update(id string, updates map[string]any) (Task, error) {
+	mu := m.lockFor(id)
+	mu.Lock()
+	defer mu.Unlock()
+	t, err := m.store.Update(id, updates)
+	if err != nil {
+		return t, err
+	}
+	m.emitter.Emit(events.TaskUpdated, t.FilePath)
+	return t, nil
+}
+
+// Delete removes a task and emits task:deleted.
+func (m *Manager) Delete(id string) error {
+	mu := m.lockFor(id)
+	mu.Lock()
+	defer mu.Unlock()
+	t, err := m.store.Get(id)
+	if err != nil {
+		return err
+	}
+	if err := m.store.Delete(id); err != nil {
+		return err
+	}
+	m.locks.Delete(id)
+	m.emitter.Emit(events.TaskDeleted, t.FilePath)
+	return nil
+}
+
+// AddRun appends an agent run to the task and emits task:updated.
+func (m *Manager) AddRun(taskID string, run AgentRun) error {
+	mu := m.lockFor(taskID)
+	mu.Lock()
+	defer mu.Unlock()
+	if err := m.store.AddRun(taskID, run); err != nil {
+		return err
+	}
+	t, err := m.store.Get(taskID)
+	if err == nil {
+		m.emitter.Emit(events.TaskUpdated, t.FilePath)
+	}
+	return nil
+}
+
+// UpdateRun updates fields on a specific agent run and emits task:updated.
+func (m *Manager) UpdateRun(taskID, agentID string, updates map[string]any) error {
+	mu := m.lockFor(taskID)
+	mu.Lock()
+	defer mu.Unlock()
+	if err := m.store.UpdateRun(taskID, agentID, updates); err != nil {
+		return err
+	}
+	t, err := m.store.Get(taskID)
+	if err == nil {
+		m.emitter.Emit(events.TaskUpdated, t.FilePath)
+	}
+	return nil
+}

--- a/internal/task/manager_test.go
+++ b/internal/task/manager_test.go
@@ -1,0 +1,239 @@
+package task
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/Automaat/synapse/internal/events"
+)
+
+type recordingEmitter struct {
+	mu     sync.Mutex
+	events []recordedEvent
+}
+
+type recordedEvent struct {
+	name string
+	data any
+}
+
+func (r *recordingEmitter) Emit(name string, data any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, recordedEvent{name: name, data: data})
+}
+
+func (r *recordingEmitter) names() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.events))
+	for i, e := range r.events {
+		out[i] = e.name
+	}
+	return out
+}
+
+func newTestManager(t *testing.T) (*Manager, *recordingEmitter) {
+	t.Helper()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	emitter := &recordingEmitter{}
+	return NewManager(store, emitter), emitter
+}
+
+func TestManagerCreateEmitsEvent(t *testing.T) {
+	t.Parallel()
+	m, emitter := newTestManager(t)
+
+	task, err := m.Create("Title", "body", "headless")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	names := emitter.names()
+	if len(names) != 1 || names[0] != events.TaskCreated {
+		t.Fatalf("events = %v, want [%s]", names, events.TaskCreated)
+	}
+	if emitter.events[0].data != task.FilePath {
+		t.Fatalf("event data = %v, want %s", emitter.events[0].data, task.FilePath)
+	}
+}
+
+func TestManagerUpdateEmitsEvent(t *testing.T) {
+	t.Parallel()
+	m, emitter := newTestManager(t)
+
+	task, err := m.Create("Title", "", "headless")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := m.Update(task.ID, map[string]any{"title": "New"}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	names := emitter.names()
+	if len(names) != 2 || names[1] != events.TaskUpdated {
+		t.Fatalf("events = %v, want [%s %s]", names, events.TaskCreated, events.TaskUpdated)
+	}
+}
+
+func TestManagerDeleteEmitsEvent(t *testing.T) {
+	t.Parallel()
+	m, emitter := newTestManager(t)
+
+	task, err := m.Create("Title", "", "headless")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := m.Delete(task.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	names := emitter.names()
+	if len(names) != 2 || names[1] != events.TaskDeleted {
+		t.Fatalf("events = %v, want [%s %s]", names, events.TaskCreated, events.TaskDeleted)
+	}
+}
+
+func TestManagerAddRunEmitsUpdated(t *testing.T) {
+	t.Parallel()
+	m, emitter := newTestManager(t)
+
+	task, err := m.Create("Title", "", "headless")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := m.AddRun(task.ID, AgentRun{AgentID: "a1", State: "running"}); err != nil {
+		t.Fatalf("AddRun: %v", err)
+	}
+
+	names := emitter.names()
+	if len(names) != 2 || names[1] != events.TaskUpdated {
+		t.Fatalf("events = %v", names)
+	}
+
+	got, err := m.Get(task.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(got.AgentRuns) != 1 || got.AgentRuns[0].AgentID != "a1" {
+		t.Fatalf("AgentRuns = %+v", got.AgentRuns)
+	}
+}
+
+func TestManagerUpdateRunEmitsUpdated(t *testing.T) {
+	t.Parallel()
+	m, emitter := newTestManager(t)
+
+	task, err := m.Create("Title", "", "headless")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := m.AddRun(task.ID, AgentRun{AgentID: "a1", State: "running"}); err != nil {
+		t.Fatalf("AddRun: %v", err)
+	}
+	if err := m.UpdateRun(task.ID, "a1", map[string]any{"state": "stopped"}); err != nil {
+		t.Fatalf("UpdateRun: %v", err)
+	}
+
+	names := emitter.names()
+	// create + add_run + update_run = 3 updated/created events
+	if len(names) != 3 || names[2] != events.TaskUpdated {
+		t.Fatalf("events = %v", names)
+	}
+
+	got, err := m.Get(task.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.AgentRuns[0].State != "stopped" {
+		t.Fatalf("run state = %q, want stopped", got.AgentRuns[0].State)
+	}
+}
+
+func TestManagerConcurrentUpdateSerializes(t *testing.T) {
+	t.Parallel()
+	m, _ := newTestManager(t)
+
+	task, err := m.Create("Title", "", "headless")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Two concurrent updates on the same id touching different fields
+	// should both land without one overwriting the other.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		if _, err := m.Update(task.ID, map[string]any{"title": "AAA"}); err != nil {
+			t.Errorf("Update title: %v", err)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		if _, err := m.Update(task.ID, map[string]any{"body": "BBB"}); err != nil {
+			t.Errorf("Update body: %v", err)
+		}
+	}()
+	wg.Wait()
+
+	got, err := m.Get(task.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	// Whichever ran second wins for title; but body must be set since that
+	// update is isolated. With no locking, a read-modify-write race could
+	// cause body to be lost.
+	if got.Body != "BBB" && got.Title != "AAA" {
+		t.Fatalf("both updates lost: title=%q body=%q", got.Title, got.Body)
+	}
+}
+
+func TestManagerConcurrentDifferentIDsParallel(t *testing.T) {
+	t.Parallel()
+	m, _ := newTestManager(t)
+
+	t1, err := m.Create("One", "", "headless")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	t2, err := m.Create("Two", "", "headless")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		if _, err := m.Update(t1.ID, map[string]any{"body": "x"}); err != nil {
+			t.Errorf("Update t1: %v", err)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		if _, err := m.Update(t2.ID, map[string]any{"body": "y"}); err != nil {
+			t.Errorf("Update t2: %v", err)
+		}
+	}()
+	wg.Wait()
+
+	g1, _ := m.Get(t1.ID)
+	g2, _ := m.Get(t2.ID)
+	if g1.Body != "x" || g2.Body != "y" {
+		t.Fatalf("bodies = %q / %q", g1.Body, g2.Body)
+	}
+}
+
+func TestNoopEmitter(t *testing.T) {
+	t.Parallel()
+	m := NewManager(nil, nil)
+	if m.emitter == nil {
+		t.Fatal("emitter should never be nil")
+	}
+	// should not panic
+	m.emitter.Emit("x", "y")
+}

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -22,7 +22,7 @@ type AgentChecker func(taskID string) bool
 type Config struct {
 	WorktreesDir     string
 	Projects         *project.Store
-	Tasks            *task.Store
+	Tasks            *task.Manager
 	Logger           *slog.Logger
 	PRBranchResolver PRBranchResolver
 	AgentChecker     AgentChecker
@@ -31,7 +31,7 @@ type Config struct {
 type Manager struct {
 	dir      string
 	projects *project.Store
-	tasks    *task.Store
+	tasks    *task.Manager
 	logger   *slog.Logger
 	prBranch PRBranchResolver
 	hasAgent AgentChecker

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -83,6 +83,7 @@ func TestCleanupOrphaned(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	taskMgr := task.NewManager(store, nil)
 
 	tk, err := store.Create("test task", "", "headless")
 	if err != nil {
@@ -100,7 +101,7 @@ func TestCleanupOrphaned(t *testing.T) {
 
 	m := New(Config{
 		WorktreesDir: dir,
-		Tasks:        store,
+		Tasks:        taskMgr,
 		Logger:       discardLogger(),
 	})
 


### PR DESCRIPTION
## Motivation

`*task.Store` is accessed directly from ~6 call sites (app_tasks.go,
app_planning.go, app_reviews.go, app_agents.go, worktree/manager.go,
synapse-cli). Each site wired concerns separately: no per-task mutex
(read-modify-write races between UpdateTask, AddRun, UpdateRun), and
in-process mutations relied on the filesystem watcher firing after
atomic writes rather than emitting events directly.

## Implementation information

New `task.Manager` wraps `*task.Store`:

- Per-id keyed mutex via `sync.Map` serializes Update / Delete /
  AddRun / UpdateRun on the same task; different ids run in parallel.
- Emits `task:created/updated/deleted` via injected `EventEmitter`
  (with `EmitterFunc` adapter + `NoopEmitter` helper).
- Same event payload shape as the watcher (file path), so frontend
  handlers are unchanged. Duplicate events from watcher are tolerated
  (refetch is idempotent).

All callers migrated to `*task.Manager` (field name `tasks` kept, so
call sites like `a.tasks.Update(...)` compile unchanged). CLI uses
`NoopEmitter` since it runs out-of-process.

Scope deliberately limited to CRUD + events + concurrency. Status-driven
side effects (auto-triage, worktree lifecycle, auto-dispatch) stay in
existing handlers for a follow-up.

## Supporting documentation

Plan: /Users/marcin.skalski/.claude/plans/flickering-sprouting-avalanche.md

> Changelog: refactor(task): add Manager as single entrypoint