### PR TITLE
ci(renovate): add scheduling and grouping rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,24 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended"],
+  "schedule": ["after 10pm every weekday"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "groupName": "patch dependencies"
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "groupName": "minor dependencies"
+    },
+    {
+      "matchPackageNames": ["golang.org/x/*"],
+      "groupName": "golang.org/x updates"
+    },
+    {
+      "matchPackageNames": ["@testing-library/*", "vitest", "@vitest/*"],
+      "groupName": "testing dependencies"
+    }
   ]
 }


### PR DESCRIPTION
## Motivation

Minimal Renovate config generated individual PRs for every dep update, creating noise. No automerge for safe patches, no scheduling.

## Implementation information

- Schedule: after 10pm weekdays (off-hours batching)
- Patch updates: grouped + automerge
- Minor updates: grouped
- `golang.org/x/*`: grouped
- Testing deps (`@testing-library/*`, `vitest`, `@vitest/*`): grouped

Closes #133

> Changelog: ci(renovate): add scheduling and grouping rules