### PR TITLE
test(notification,stats): add emitter and backfill tests

### DIFF
--- a/internal/notification/emitter.go
+++ b/internal/notification/emitter.go
@@ -12,18 +12,20 @@ const ringCap = 100
 
 // Emitter sends notifications via Wails events and optional desktop alerts.
 type Emitter struct {
-	emit    func(event string, data any)
-	buffer  []Notification
-	mu      sync.RWMutex
-	desktop bool
+	emit      func(event string, data any)
+	buffer    []Notification
+	mu        sync.RWMutex
+	desktop   bool
+	desktopFn func(title, message string) error
 }
 
 // New creates an Emitter that broadcasts via the provided emit function.
 func New(emit func(event string, data any)) *Emitter {
 	return &Emitter{
-		emit:    emit,
-		buffer:  make([]Notification, 0, ringCap),
-		desktop: true,
+		emit:      emit,
+		buffer:    make([]Notification, 0, ringCap),
+		desktop:   true,
+		desktopFn: sendDesktopNotification,
 	}
 }
 
@@ -49,7 +51,7 @@ func (e *Emitter) Send(level Level, title, message, taskID, agentID string) {
 	e.emit(events.Notification, n)
 
 	if e.desktop {
-		_ = sendDesktopNotification(title, message)
+		_ = e.desktopFn(title, message)
 	}
 }
 

--- a/internal/notification/emitter_test.go
+++ b/internal/notification/emitter_test.go
@@ -1,0 +1,209 @@
+package notification
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/Automaat/synapse/internal/events"
+)
+
+func nopEmit(_ string, _ any) {}
+
+func TestSendBuffersNotification(t *testing.T) {
+	e := New(nopEmit)
+	e.SetDesktop(false)
+
+	e.Send(LevelInfo, "title", "msg", "t1", "a1")
+
+	list := e.List()
+	if len(list) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(list))
+	}
+	n := list[0]
+	if n.Level != LevelInfo {
+		t.Errorf("level: got %s, want info", n.Level)
+	}
+	if n.Title != "title" {
+		t.Errorf("title: got %s, want title", n.Title)
+	}
+	if n.Message != "msg" {
+		t.Errorf("message: got %s, want msg", n.Message)
+	}
+	if n.TaskID != "t1" {
+		t.Errorf("taskID: got %s, want t1", n.TaskID)
+	}
+	if n.AgentID != "a1" {
+		t.Errorf("agentID: got %s, want a1", n.AgentID)
+	}
+	if n.ID == "" {
+		t.Error("ID should be non-empty")
+	}
+	if n.CreatedAt == "" {
+		t.Error("CreatedAt should be non-empty")
+	}
+}
+
+func TestSendEmitsEvent(t *testing.T) {
+	type emitCall struct {
+		event string
+		data  any
+	}
+	var mu sync.Mutex
+	var calls []emitCall
+
+	emit := func(event string, data any) {
+		mu.Lock()
+		calls = append(calls, emitCall{event, data})
+		mu.Unlock()
+	}
+
+	e := New(emit)
+	e.SetDesktop(false)
+	e.Send(LevelSuccess, "t", "m", "", "")
+
+	mu.Lock()
+	count := len(calls)
+	var call emitCall
+	if count > 0 {
+		call = calls[0]
+	}
+	mu.Unlock()
+
+	if count != 1 {
+		t.Fatalf("expected 1 emit, got %d", count)
+	}
+	if call.event != events.Notification {
+		t.Errorf("event name: got %s, want %s", call.event, events.Notification)
+	}
+	n, ok := call.data.(Notification)
+	if !ok {
+		t.Fatalf("emitted value type %T, want Notification", call.data)
+	}
+	if n.Level != LevelSuccess {
+		t.Errorf("emitted level: got %s, want success", n.Level)
+	}
+	if n.Title != "t" {
+		t.Errorf("emitted title: got %s, want t", n.Title)
+	}
+}
+
+func TestListNewestFirst(t *testing.T) {
+	e := New(nopEmit)
+	e.SetDesktop(false)
+
+	e.Send(LevelInfo, "first", "", "", "")
+	e.Send(LevelInfo, "second", "", "", "")
+	e.Send(LevelInfo, "third", "", "", "")
+
+	list := e.List()
+	if len(list) != 3 {
+		t.Fatalf("expected 3, got %d", len(list))
+	}
+	if list[0].Title != "third" {
+		t.Errorf("newest first: got %s, want third", list[0].Title)
+	}
+	if list[2].Title != "first" {
+		t.Errorf("oldest last: got %s, want first", list[2].Title)
+	}
+}
+
+func TestBufferRingCapacity(t *testing.T) {
+	e := New(nopEmit)
+	e.SetDesktop(false)
+
+	extra := 5
+	for i := 0; i < ringCap+extra; i++ {
+		e.Send(LevelInfo, fmt.Sprintf("n%d", i), "", "", "")
+	}
+
+	list := e.List()
+	if len(list) != ringCap {
+		t.Fatalf("expected %d notifications, got %d", ringCap, len(list))
+	}
+	// Newest should be the last sent.
+	wantNewest := fmt.Sprintf("n%d", ringCap+extra-1)
+	if list[0].Title != wantNewest {
+		t.Errorf("newest: got %s, want %s", list[0].Title, wantNewest)
+	}
+	// Oldest should be n5 (first `extra` evicted).
+	wantOldest := fmt.Sprintf("n%d", extra)
+	if list[ringCap-1].Title != wantOldest {
+		t.Errorf("oldest: got %s, want %s", list[ringCap-1].Title, wantOldest)
+	}
+}
+
+func TestConcurrentSend(t *testing.T) {
+	e := New(nopEmit)
+	e.SetDesktop(false)
+
+	const goroutines = 20
+	const perGoroutine = 10
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range perGoroutine {
+				e.Send(LevelInfo, "t", "m", "", "")
+			}
+		}()
+	}
+	wg.Wait()
+
+	total := goroutines * perGoroutine
+	list := e.List()
+	want := min(total, ringCap)
+	if len(list) != want {
+		t.Errorf("expected %d notifications, got %d", want, len(list))
+	}
+}
+
+func TestDesktopNotificationFailureIgnored(t *testing.T) {
+	e := New(nopEmit)
+	e.desktopFn = func(_, _ string) error {
+		return errors.New("osascript unavailable")
+	}
+	e.desktop = true
+
+	// Should not panic; error is intentionally discarded.
+	e.Send(LevelError, "fail", "desktop failed", "", "")
+
+	if len(e.List()) != 1 {
+		t.Error("notification should still be buffered despite desktop failure")
+	}
+}
+
+func TestDesktopNotificationDisabled(t *testing.T) {
+	called := false
+	e := New(nopEmit)
+	e.desktopFn = func(_, _ string) error {
+		called = true
+		return nil
+	}
+
+	e.SetDesktop(false)
+	e.Send(LevelInfo, "t", "m", "", "")
+
+	if called {
+		t.Error("desktop notification should not be called when disabled")
+	}
+}
+
+func TestDesktopNotificationEnabled(t *testing.T) {
+	called := false
+	e := New(nopEmit)
+	e.desktopFn = func(_, _ string) error {
+		called = true
+		return nil
+	}
+	e.desktop = true
+
+	e.Send(LevelInfo, "t", "m", "", "")
+
+	if !called {
+		t.Error("desktop notification should be called when enabled")
+	}
+}

--- a/internal/stats/backfill_test.go
+++ b/internal/stats/backfill_test.go
@@ -1,0 +1,291 @@
+package stats
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Automaat/synapse/internal/audit"
+)
+
+func writeAuditFile(t *testing.T, dir, filename string, evts []audit.Event) {
+	t.Helper()
+	var lines []byte
+	for _, e := range evts {
+		b, err := json.Marshal(e)
+		if err != nil {
+			t.Fatal(err)
+		}
+		lines = append(lines, b...)
+		lines = append(lines, '\n')
+	}
+	if err := os.WriteFile(filepath.Join(dir, filename), lines, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func newTestStore(t *testing.T) (store *Store, tmpDir string) {
+	t.Helper()
+	tmpDir = t.TempDir()
+	s, err := NewStore(filepath.Join(tmpDir, "stats.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s, tmpDir
+}
+
+func newAuditDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestBackfillEmptyDir(t *testing.T) {
+	s, _ := newTestStore(t)
+	auditDir := newAuditDir(t)
+
+	if err := s.Backfill(auditDir); err != nil {
+		t.Fatal(err)
+	}
+	if s.Len() != 0 {
+		t.Errorf("expected 0 runs, got %d", s.Len())
+	}
+}
+
+func TestBackfillNonExistentDir(t *testing.T) {
+	s, dir := newTestStore(t)
+
+	// audit.Read returns nil events for missing dirs, not an error.
+	if err := s.Backfill(filepath.Join(dir, "nonexistent")); err != nil {
+		t.Errorf("expected no error for missing dir, got %v", err)
+	}
+	if s.Len() != 0 {
+		t.Errorf("expected 0 runs, got %d", s.Len())
+	}
+}
+
+func TestBackfillImportsCompletedAndFailed(t *testing.T) {
+	s, _ := newTestStore(t)
+	auditDir := newAuditDir(t)
+
+	ts := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	writeAuditFile(t, auditDir, "2024-01-15.ndjson", []audit.Event{
+		{
+			Timestamp: ts,
+			Type:      audit.EventAgentCompleted,
+			TaskID:    "t1",
+			AgentID:   "a1",
+			Data:      map[string]any{"mode": "headless", "cost_usd": 0.05, "duration_s": 30.0, "state": "stopped"},
+		},
+		{
+			Timestamp: ts.Add(time.Hour),
+			Type:      audit.EventAgentFailed,
+			TaskID:    "t2",
+			AgentID:   "a2",
+			Data:      map[string]any{"mode": "interactive", "cost_usd": 0.02, "duration_s": 10.0, "state": "error"},
+		},
+	})
+
+	if err := s.Backfill(auditDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if s.Len() != 2 {
+		t.Fatalf("expected 2 runs, got %d", s.Len())
+	}
+
+	resp := s.Query()
+	if resp.AllTime.TotalRuns != 2 {
+		t.Errorf("totalRuns: got %d, want 2", resp.AllTime.TotalRuns)
+	}
+
+	wantCost := 0.05 + 0.02
+	if diff := resp.AllTime.TotalCostUSD - wantCost; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("totalCost: got %f, want %f", resp.AllTime.TotalCostUSD, wantCost)
+	}
+}
+
+func TestBackfillSkipsIfStoreHasRecords(t *testing.T) {
+	s, _ := newTestStore(t)
+	auditDir := newAuditDir(t)
+
+	if err := s.Record(RunRecord{ID: "existing", Outcome: "completed", Timestamp: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+
+	ts := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	writeAuditFile(t, auditDir, "2024-01-15.ndjson", []audit.Event{
+		{Timestamp: ts, Type: audit.EventAgentCompleted, AgentID: "a1", Data: map[string]any{"state": "stopped"}},
+	})
+
+	if err := s.Backfill(auditDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if s.Len() != 1 {
+		t.Errorf("expected 1 (no backfill), got %d", s.Len())
+	}
+}
+
+func TestBackfillFiltersNonAgentEvents(t *testing.T) {
+	s, _ := newTestStore(t)
+	auditDir := newAuditDir(t)
+
+	ts := time.Date(2024, 2, 1, 10, 0, 0, 0, time.UTC)
+	writeAuditFile(t, auditDir, "2024-02-01.ndjson", []audit.Event{
+		{Timestamp: ts, Type: audit.EventTaskCreated, TaskID: "t1"},
+		{Timestamp: ts, Type: audit.EventAgentStarted, AgentID: "a1"},
+		{Timestamp: ts, Type: audit.EventAgentCompleted, AgentID: "a2", Data: map[string]any{"state": "stopped"}},
+		{Timestamp: ts, Type: audit.EventPlanCompleted, TaskID: "t2"},
+	})
+
+	if err := s.Backfill(auditDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if s.Len() != 1 {
+		t.Errorf("expected 1 run (only agent.completed), got %d", s.Len())
+	}
+}
+
+func TestBackfillMalformedEntries(t *testing.T) {
+	s, _ := newTestStore(t)
+	auditDir := newAuditDir(t)
+
+	content := []byte(`{"ts":"2024-03-01T10:00:00Z","type":"agent.completed","agent_id":"a1","data":{"state":"stopped"}}
+{invalid json line
+{"ts":"2024-03-01T11:00:00Z","type":"agent.completed","agent_id":"a2","data":{"state":"stopped"}}
+`)
+	if err := os.WriteFile(filepath.Join(auditDir, "2024-03-01.ndjson"), content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.Backfill(auditDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if s.Len() != 2 {
+		t.Errorf("expected 2 runs (malformed line skipped), got %d", s.Len())
+	}
+}
+
+func TestBackfillOutcomes(t *testing.T) {
+	tests := []struct {
+		name        string
+		eventType   string
+		state       string
+		wantOutcome string
+	}{
+		{"completed_stopped", audit.EventAgentCompleted, "stopped", "completed"},
+		{"completed_other_state", audit.EventAgentCompleted, "error", "failed"},
+		{"failed_event", audit.EventAgentFailed, "error", "failed"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _ := newTestStore(t)
+			auditDir := newAuditDir(t)
+
+			ts := time.Date(2024, 3, 1, 12, 0, 0, 0, time.UTC)
+			writeAuditFile(t, auditDir, "2024-03-01.ndjson", []audit.Event{
+				{
+					Timestamp: ts,
+					Type:      tc.eventType,
+					AgentID:   "a1",
+					Data:      map[string]any{"state": tc.state},
+				},
+			})
+
+			if err := s.Backfill(auditDir); err != nil {
+				t.Fatal(err)
+			}
+
+			resp := s.Query()
+			if len(resp.RecentRuns) != 1 {
+				t.Fatalf("expected 1 run, got %d", len(resp.RecentRuns))
+			}
+			if resp.RecentRuns[0].Outcome != tc.wantOutcome {
+				t.Errorf("outcome: got %s, want %s", resp.RecentRuns[0].Outcome, tc.wantOutcome)
+			}
+		})
+	}
+}
+
+func TestBackfillFieldExtraction(t *testing.T) {
+	s, _ := newTestStore(t)
+	auditDir := newAuditDir(t)
+
+	ts := time.Date(2024, 5, 1, 8, 30, 0, 0, time.UTC)
+	writeAuditFile(t, auditDir, "2024-05-01.ndjson", []audit.Event{
+		{
+			Timestamp: ts,
+			Type:      audit.EventAgentCompleted,
+			TaskID:    "task-xyz",
+			AgentID:   "agent-abc",
+			Data: map[string]any{
+				"mode":       "headless",
+				"cost_usd":   0.12,
+				"duration_s": 45.5,
+				"state":      "stopped",
+			},
+		},
+	})
+
+	if err := s.Backfill(auditDir); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := s.Query()
+	if len(resp.RecentRuns) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(resp.RecentRuns))
+	}
+
+	r := resp.RecentRuns[0]
+	if r.ID != "agent-abc" {
+		t.Errorf("ID: got %s, want agent-abc", r.ID)
+	}
+	if r.TaskID != "task-xyz" {
+		t.Errorf("TaskID: got %s, want task-xyz", r.TaskID)
+	}
+	if r.Mode != "headless" {
+		t.Errorf("Mode: got %s, want headless", r.Mode)
+	}
+	if r.CostUSD != 0.12 {
+		t.Errorf("CostUSD: got %f, want 0.12", r.CostUSD)
+	}
+	if r.DurationS != 45.5 {
+		t.Errorf("DurationS: got %f, want 45.5", r.DurationS)
+	}
+	if r.Outcome != "completed" {
+		t.Errorf("Outcome: got %s, want completed", r.Outcome)
+	}
+	if !r.Timestamp.Equal(ts) {
+		t.Errorf("Timestamp: got %v, want %v", r.Timestamp, ts)
+	}
+}
+
+func TestBackfillMultipleFiles(t *testing.T) {
+	s, _ := newTestStore(t)
+	auditDir := newAuditDir(t)
+
+	writeAuditFile(t, auditDir, "2024-06-01.ndjson", []audit.Event{
+		{Timestamp: time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC), Type: audit.EventAgentCompleted, AgentID: "a1", Data: map[string]any{"state": "stopped"}},
+	})
+	writeAuditFile(t, auditDir, "2024-06-02.ndjson", []audit.Event{
+		{Timestamp: time.Date(2024, 6, 2, 10, 0, 0, 0, time.UTC), Type: audit.EventAgentCompleted, AgentID: "a2", Data: map[string]any{"state": "stopped"}},
+		{Timestamp: time.Date(2024, 6, 2, 11, 0, 0, 0, time.UTC), Type: audit.EventAgentFailed, AgentID: "a3", Data: map[string]any{"state": "error"}},
+	})
+
+	if err := s.Backfill(auditDir); err != nil {
+		t.Fatal(err)
+	}
+
+	if s.Len() != 3 {
+		t.Errorf("expected 3 runs across 2 files, got %d", s.Len())
+	}
+}


### PR DESCRIPTION
## Motivation

Closes #131. Two packages had no test coverage: the notification emitter and the stats backfill.

## Implementation information

**`internal/notification/emitter.go`** — added unexported `desktopFn` field (defaults to `sendDesktopNotification`) so tests can inject a mock without build-tag hacks.

**`internal/notification/emitter_test.go`** (8 tests, `-race`):
- Buffer-and-List round-trip with field assertions
- Event name and payload emitted to Wails
- List returns newest-first ordering
- Ring buffer evicts oldest at capacity (100)
- Concurrent `Send()` from 20 goroutines — race-safe
- Desktop failure ignored (error discarded)
- `SetDesktop(false)` suppresses `desktopFn` call
- `desktop=true` invokes `desktopFn`

**`internal/stats/backfill_test.go`** (9 tests, `-race`):
- Empty audit dir → 0 runs
- Non-existent dir → no error
- `agent.completed` + `agent.failed` events imported with correct cost aggregation
- Skip-if-store-populated guard
- Non-agent events filtered out (`task.created`, `agent.started`, `plan.completed`)
- Malformed NDJSON lines skipped, valid lines still imported
- Outcome table: `stopped` → `completed`, anything else → `failed`
- Full field extraction (ID, TaskID, Mode, CostUSD, DurationS, Timestamp)
- Multi-file aggregation across daily log files

> Changelog: test(notification,stats): add emitter and backfill tests