### PR TITLE
feat(agent): add watchdog for stuck agents

### DIFF
--- a/app.go
+++ b/app.go
@@ -145,6 +145,7 @@ func (a *App) startup(ctx context.Context) {
 	a.RegisterSpotlightHotkey()
 	a.wg.Go(func() { a.orchestratorLoop(ctx) })
 	a.wg.Go(func() { a.prPollLoop(ctx) })
+	a.wg.Go(func() { a.agentWatchdogLoop(ctx) })
 	a.logger.Info("app.started")
 }
 

--- a/app_watchdog.go
+++ b/app_watchdog.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/Automaat/synapse/internal/agent"
+	"github.com/Automaat/synapse/internal/events"
+	"github.com/Automaat/synapse/internal/task"
+	"github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+const (
+	watchdogTickInterval = 30 * time.Second
+	watchdogStallLimit   = 3 * time.Minute
+	watchdogDebounce     = 5 * time.Minute
+	inspectorTimeout     = 2 * time.Minute
+)
+
+// sizeBudget returns the maximum total runtime for a headless agent based on
+// its task's size tag. Trigger inspection once total runtime exceeds this.
+func sizeBudget(tags []string) time.Duration {
+	switch {
+	case slices.Contains(tags, "large"):
+		return 3 * time.Hour
+	case slices.Contains(tags, "small"):
+		return 10 * time.Minute
+	default: // medium or unset
+		return 45 * time.Minute
+	}
+}
+
+type watchdogState struct {
+	mu             sync.Mutex
+	lastInspection map[string]time.Time
+}
+
+func newWatchdogState() *watchdogState {
+	return &watchdogState{lastInspection: make(map[string]time.Time)}
+}
+
+func (s *watchdogState) shouldInspect(id string, now time.Time) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	last, ok := s.lastInspection[id]
+	if ok && now.Sub(last) < watchdogDebounce {
+		return false
+	}
+	s.lastInspection[id] = now
+	return true
+}
+
+func (a *App) agentWatchdogLoop(ctx context.Context) {
+	state := newWatchdogState()
+	ticker := time.NewTicker(watchdogTickInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			a.watchdogTick(ctx, state, now)
+		}
+	}
+}
+
+func (a *App) watchdogTick(ctx context.Context, state *watchdogState, now time.Time) {
+	for _, ag := range a.agents.ListAgents() {
+		if ag.State != agent.StateRunning || ag.Mode != "headless" || ag.External {
+			continue
+		}
+		if ag.LogPath == "" {
+			continue
+		}
+
+		stall := now.Sub(ag.LastEventAt)
+		total := now.Sub(ag.StartedAt)
+
+		t, err := a.tasks.Get(ag.TaskID)
+		var budget time.Duration
+		if err == nil {
+			budget = sizeBudget(t.Tags)
+		} else {
+			budget = sizeBudget(nil)
+		}
+
+		trigger := ""
+		switch {
+		case stall > watchdogStallLimit:
+			trigger = "stall"
+		case total > budget:
+			trigger = "budget"
+		}
+		if trigger == "" {
+			continue
+		}
+		if !state.shouldInspect(ag.ID, now) {
+			continue
+		}
+
+		a.logger.Info("agent.watchdog.inspect",
+			"id", ag.ID, "trigger", trigger,
+			"stall_sec", int(stall.Seconds()), "total_sec", int(total.Seconds()))
+
+		a.wg.Go(func() { a.inspectAgent(ctx, ag, t, int(stall.Seconds()), int(total.Seconds())) })
+	}
+}
+
+func (a *App) inspectAgent(ctx context.Context, ag *agent.Agent, t task.Task, stallSec, totalSec int) {
+	ictx, cancel := context.WithTimeout(ctx, inspectorTimeout)
+	defer cancel()
+
+	verdict, err := agent.Inspect(ictx, agent.InspectInput{
+		AgentID:   ag.ID,
+		TaskTitle: t.Title,
+		LogPath:   ag.LogPath,
+		StallSec:  stallSec,
+		TotalSec:  totalSec,
+	})
+	if err != nil {
+		a.logger.Warn("agent.watchdog.inspect.failed", "id", ag.ID, "err", err)
+		return
+	}
+
+	a.logger.Info("agent.watchdog.verdict",
+		"id", ag.ID, "stuck", verdict.Stuck,
+		"recommendation", verdict.Recommendation, "reason", verdict.Reason)
+
+	runtime.EventsEmit(a.ctx, events.AgentStuck(ag.ID), verdict)
+
+	switch verdict.Recommendation {
+	case "stop":
+		if err := a.agents.StopAgent(ag.ID); err != nil {
+			a.logger.Error("agent.watchdog.stop.failed", "id", ag.ID, "err", err)
+		}
+		if ag.TaskID != "" {
+			if _, err := a.tasks.Update(ag.TaskID, map[string]any{"status": string(task.StatusHumanRequired)}); err != nil {
+				a.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
+			}
+		}
+	case "escalate":
+		if ag.TaskID != "" {
+			if _, err := a.tasks.Update(ag.TaskID, map[string]any{"status": string(task.StatusHumanRequired)}); err != nil {
+				a.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
+			}
+		}
+	case "continue":
+		// intentional no-op; debounce suppresses re-check
+	}
+}

--- a/internal/agent/inspector.go
+++ b/internal/agent/inspector.go
@@ -1,0 +1,120 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// InspectorVerdict is the structured judgment returned by the inspector agent.
+type InspectorVerdict struct {
+	Stuck          bool   `json:"stuck"`
+	Reason         string `json:"reason"`
+	Recommendation string `json:"recommendation"` // "stop" | "continue" | "escalate"
+}
+
+// InspectInput holds the context handed to the inspector about the target agent.
+type InspectInput struct {
+	AgentID   string
+	TaskTitle string
+	LogPath   string
+	StallSec  int
+	TotalSec  int
+}
+
+// Inspect spawns `claude -p` to analyze a running agent's NDJSON log and return
+// a verdict on whether it appears stuck. The caller must supply a context with
+// a reasonable timeout (e.g. 2 minutes).
+func Inspect(ctx context.Context, in InspectInput) (InspectorVerdict, error) {
+	prompt := buildInspectorPrompt(in)
+
+	cmd := exec.CommandContext(ctx, "claude",
+		"-p", prompt,
+		"--output-format", "json",
+		"--dangerously-skip-permissions",
+		"--model", "sonnet",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return InspectorVerdict{}, fmt.Errorf("inspector claude: %w", err)
+	}
+	return parseInspectorOutput(out)
+}
+
+func buildInspectorPrompt(in InspectInput) string {
+	return fmt.Sprintf(`You are a watchdog inspecting a running Claude Code agent that may be stuck.
+
+Agent ID: %s
+Task: %s
+Stalled for: %d seconds (no new stream events)
+Total runtime: %d seconds
+NDJSON log path: %s
+
+Read the log file (last ~200 lines are most relevant). Look for:
+- Repeating tool calls with identical arguments
+- Same reasoning/text being repeated
+- Thrashing between the same files or commands
+- No forward progress toward the task goal
+
+Output ONLY a single JSON object on the final line, nothing else:
+{"stuck": bool, "reason": "short explanation", "recommendation": "stop"|"continue"|"escalate"}
+
+Recommendations:
+- "stop": agent is clearly looping/stuck, kill it
+- "escalate": ambiguous or needs human judgment, flag for human
+- "continue": agent is making progress, leave it alone`,
+		in.AgentID, in.TaskTitle, in.StallSec, in.TotalSec, in.LogPath)
+}
+
+// parseInspectorOutput extracts the verdict from `claude -p --output-format json` stdout.
+// The top-level response has a `result` string field containing the model's final message,
+// from which we extract the last JSON object.
+func parseInspectorOutput(raw []byte) (InspectorVerdict, error) {
+	var envelope struct {
+		Result string `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return InspectorVerdict{}, fmt.Errorf("unmarshal envelope: %w", err)
+	}
+	if envelope.Result == "" {
+		return InspectorVerdict{}, fmt.Errorf("empty result field")
+	}
+	jsonStr := extractLastJSONObject(envelope.Result)
+	if jsonStr == "" {
+		return InspectorVerdict{}, fmt.Errorf("no JSON object in result: %q", envelope.Result)
+	}
+	var v InspectorVerdict
+	if err := json.Unmarshal([]byte(jsonStr), &v); err != nil {
+		return InspectorVerdict{}, fmt.Errorf("unmarshal verdict: %w", err)
+	}
+	switch v.Recommendation {
+	case "stop", "continue", "escalate":
+	default:
+		return InspectorVerdict{}, fmt.Errorf("invalid recommendation: %q", v.Recommendation)
+	}
+	return v, nil
+}
+
+// extractLastJSONObject returns the last balanced {...} substring in s, or "".
+func extractLastJSONObject(s string) string {
+	s = strings.TrimSpace(s)
+	end := strings.LastIndex(s, "}")
+	if end < 0 {
+		return ""
+	}
+	depth := 0
+	for i := end; i >= 0; i-- {
+		switch s[i] {
+		case '}':
+			depth++
+		case '{':
+			depth--
+			if depth == 0 {
+				return s[i : end+1]
+			}
+		}
+	}
+	return ""
+}

--- a/internal/agent/inspector_test.go
+++ b/internal/agent/inspector_test.go
@@ -1,0 +1,88 @@
+package agent
+
+import "testing"
+
+func TestParseInspectorOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    InspectorVerdict
+		wantErr bool
+	}{
+		{
+			name: "clean stop verdict",
+			raw:  `{"result":"{\"stuck\":true,\"reason\":\"loop\",\"recommendation\":\"stop\"}"}`,
+			want: InspectorVerdict{Stuck: true, Reason: "loop", Recommendation: "stop"},
+		},
+		{
+			name: "verdict with prose before JSON",
+			raw:  `{"result":"Analysis: repeated ls commands.\n{\"stuck\":true,\"reason\":\"repeat\",\"recommendation\":\"stop\"}"}`,
+			want: InspectorVerdict{Stuck: true, Reason: "repeat", Recommendation: "stop"},
+		},
+		{
+			name: "continue recommendation",
+			raw:  `{"result":"{\"stuck\":false,\"reason\":\"progress\",\"recommendation\":\"continue\"}"}`,
+			want: InspectorVerdict{Stuck: false, Reason: "progress", Recommendation: "continue"},
+		},
+		{
+			name: "escalate recommendation",
+			raw:  `{"result":"{\"stuck\":true,\"reason\":\"ambiguous\",\"recommendation\":\"escalate\"}"}`,
+			want: InspectorVerdict{Stuck: true, Reason: "ambiguous", Recommendation: "escalate"},
+		},
+		{
+			name:    "invalid recommendation",
+			raw:     `{"result":"{\"stuck\":true,\"reason\":\"x\",\"recommendation\":\"kill\"}"}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty result",
+			raw:     `{"result":""}`,
+			wantErr: true,
+		},
+		{
+			name:    "no JSON in result",
+			raw:     `{"result":"agent looks fine to me"}`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid envelope",
+			raw:     `not json`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseInspectorOutput([]byte(tc.raw))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got nil (verdict=%+v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractLastJSONObject(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{`{"a":1}`, `{"a":1}`},
+		{`noise {"a":1} more {"b":2}`, `{"b":2}`},
+		{`{"outer":{"inner":1}}`, `{"outer":{"inner":1}}`},
+		{`no braces`, ``},
+		{`{unbalanced`, ``},
+	}
+	for _, tc := range tests {
+		if got := extractLastJSONObject(tc.in); got != tc.want {
+			t.Errorf("extractLastJSONObject(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -54,16 +54,18 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 	id := uuid.NewString()[:8]
 	ctx, cancel := context.WithCancel(m.ctx)
 
+	now := time.Now().UTC()
 	a := &Agent{
-		ID:         id,
-		TaskID:     cfg.TaskID,
-		Name:       cfg.Name,
-		Mode:       cfg.Mode,
-		Model:      cfg.Model,
-		State:      StateRunning,
-		StartedAt:  time.Now().UTC(),
-		cancel:     cancel,
-		sessionCWD: cfg.Dir,
+		ID:          id,
+		TaskID:      cfg.TaskID,
+		Name:        cfg.Name,
+		Mode:        cfg.Mode,
+		Model:       cfg.Model,
+		State:       StateRunning,
+		StartedAt:   now,
+		LastEventAt: now,
+		cancel:      cancel,
+		sessionCWD:  cfg.Dir,
 	}
 	if cfg.Mode == "headless" {
 		a.done = make(chan struct{})
@@ -392,6 +394,7 @@ func (m *Manager) ReconnectSessions(tasks []TaskInfo) int {
 			TaskID:      t.ID,
 			Name:        t.Title,
 			StartedAt:   time.Now().UTC(),
+			LastEventAt: time.Now().UTC(),
 		}
 
 		m.agents[id] = a

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -26,6 +26,8 @@ type Agent struct {
 	InputTokens  int       `json:"inputTokens,omitempty"`
 	OutputTokens int       `json:"outputTokens,omitempty"`
 	StartedAt    time.Time `json:"startedAt"`
+	LastEventAt  time.Time `json:"lastEventAt"`
+	LogPath      string    `json:"logPath,omitempty"`
 	External     bool      `json:"external"`
 	PID          int       `json:"pid,omitempty"`
 	Command      string    `json:"command,omitempty"`

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os/exec"
 	"strings"
 	"time"
@@ -64,43 +65,15 @@ func (m *Manager) runHeadless(ctx context.Context, a *Agent, prompt string, allo
 		m.logger.Error("agent.output.file", "id", a.ID, "err", fileErr)
 	}
 	if outFile != nil {
+		a.LogPath = outFile.Name()
 		defer func() { _ = outFile.Close() }()
 	}
 
-	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
-	var lastEmit time.Time
-	for scanner.Scan() {
-		line := scanner.Bytes()
-
-		if outFile != nil {
-			_, _ = outFile.Write(line)
-			_, _ = outFile.WriteString("\n")
-		}
-
-		event, err := parseStreamEvent(line)
-		if err != nil {
-			m.logger.Warn("agent.headless.parse", "id", a.ID, "err", err, "line", string(line))
-			continue
-		}
-		if event.Type == "" {
-			continue
-		}
-
-		a.outputBuffer = append(a.outputBuffer, event)
-		if event.Type == "result" || time.Since(lastEmit) >= headlessEmitInterval {
-			m.emit(events.AgentOutput(a.ID), event)
-			lastEmit = time.Now()
-		}
-
-		if event.Type == "result" {
-			a.SessionID = event.SessionID
-			a.CostUSD += event.CostUSD
-			a.InputTokens += event.InputTokens
-			a.OutputTokens += event.OutputTokens
-			m.logger.Info("agent.headless.result", "id", a.ID, "session_id", event.SessionID, "cost", a.CostUSD)
-		}
+	var logWriter io.Writer
+	if outFile != nil {
+		logWriter = outFile
 	}
+	m.streamHeadlessOutput(a, stdout, logWriter)
 
 	waitErr := cmd.Wait()
 
@@ -120,6 +93,44 @@ func (m *Manager) runHeadless(ctx context.Context, a *Agent, prompt string, allo
 	m.emit(events.AgentState(a.ID), a)
 	if m.onComplete != nil {
 		m.onComplete(a)
+	}
+}
+
+func (m *Manager) streamHeadlessOutput(a *Agent, stdout io.Reader, outFile io.Writer) {
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+	var lastEmit time.Time
+	for scanner.Scan() {
+		line := scanner.Bytes()
+
+		if outFile != nil {
+			_, _ = outFile.Write(line)
+			_, _ = outFile.Write([]byte("\n"))
+		}
+
+		event, err := parseStreamEvent(line)
+		if err != nil {
+			m.logger.Warn("agent.headless.parse", "id", a.ID, "err", err, "line", string(line))
+			continue
+		}
+		if event.Type == "" {
+			continue
+		}
+
+		a.outputBuffer = append(a.outputBuffer, event)
+		a.LastEventAt = time.Now().UTC()
+		if event.Type == "result" || time.Since(lastEmit) >= headlessEmitInterval {
+			m.emit(events.AgentOutput(a.ID), event)
+			lastEmit = time.Now()
+		}
+
+		if event.Type == "result" {
+			a.SessionID = event.SessionID
+			a.CostUSD += event.CostUSD
+			a.InputTokens += event.InputTokens
+			a.OutputTokens += event.OutputTokens
+			m.logger.Info("agent.headless.result", "id", a.ID, "session_id", event.SessionID, "cost", a.CostUSD)
+		}
 	}
 }
 

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -11,6 +11,7 @@ const (
 	AgentStatePrefix  = "agent:state:"
 	AgentOutputPrefix = "agent:output:"
 	AgentErrorPrefix  = "agent:error:"
+	AgentStuckPrefix  = "agent:stuck:"
 
 	// Orchestrator events.
 	OrchestratorState = "orchestrator:state"
@@ -33,3 +34,6 @@ func AgentOutput(id string) string { return AgentOutputPrefix + id }
 
 // AgentError returns the agent error event name for the given agent ID.
 func AgentError(id string) string { return AgentErrorPrefix + id }
+
+// AgentStuck returns the agent stuck event name for the given agent ID.
+func AgentStuck(id string) string { return AgentStuckPrefix + id }


### PR DESCRIPTION
## Motivation

Headless agents sometimes run long and go in circles (e.g. agent 5d55cf5d). Today Synapse has no stuck-detection: once `claude -p` starts, it runs to completion no matter what. The orchestrator loop only checks tmux sessions and dispatches tasks, never inspects running agent behavior.

## Implementation information

**Tracking.** `Agent` gains `LastEventAt` and `LogPath`. `runHeadless` stamps `LastEventAt` on every stream event and records the NDJSON log path when the file opens.

**Watchdog loop.** New `agentWatchdogLoop` (30s ticker) scans running headless agents. Triggers inspection when:
- stall > 3 min (no new stream events), OR
- total runtime > size-based budget: small=10m, medium=45m, large=3h

Debounces re-inspection per agent for 5 min.

**Inspector.** `agent.Inspect()` spawns a separate `claude -p --output-format json --model sonnet` process with a prompt that reads the target agent's NDJSON log and returns `{stuck, reason, recommendation: stop|continue|escalate}`. 2-minute hard timeout. Inspector does NOT go through `Manager` so it doesn't show up as a regular agent or hold a worktree.

**Acting on verdict.**
- `stop` → kill agent, set task to `human-required`
- `escalate` → set task to `human-required`, let agent keep running
- `continue` → no-op (debounce suppresses re-check)

Emits `agent:stuck:<id>` event so the frontend can surface it later.

**Alternative considered:** pure heuristic auto-stop (no inspector) was simpler but would false-positive on legitimately long running tasks. Nudging the existing orchestrator tmux session via send-keys was rejected as fragile.

## Supporting documentation

Plan: `~/.claude/plans/keen-scribbling-platypus.md`