### PR TITLE
feat(task): add task_type field

### DIFF
--- a/app_agents.go
+++ b/app_agents.go
@@ -13,6 +13,23 @@ import (
 	"github.com/Automaat/synapse/internal/worktree"
 )
 
+// ResearchMachineDir is the fixed working directory for research tasks.
+const ResearchMachineDir = "/Users/marcin.skalski/sideprojects/research-machine"
+
+// resolveExecution derives the effective mode, directory, permission mode, and
+// whether project worktree setup should be skipped based on the task's type.
+// hintMode is used when the task type does not force a specific mode.
+func resolveExecution(t task.Task, hintMode string) (mode, dir string, requirePerm, skipWorktree bool) {
+	switch t.TaskType {
+	case task.TaskTypeDebug:
+		return "interactive", "", true, false
+	case task.TaskTypeResearch:
+		return "headless", ResearchMachineDir, false, true
+	default:
+		return hintMode, "", false, false
+	}
+}
+
 // AgentOrchestrator manages agent lifecycle: worktree setup, project
 // assignment, and agent launching for a task.
 type AgentOrchestrator struct {
@@ -67,34 +84,36 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string) (*agent.Agen
 		}
 	}
 
-	t = o.autoAssignProject(t)
-
-	dir := ""
-	if t.ProjectID != "" {
-		d, wtErr := o.worktrees.PrepareForTask(t)
-		if wtErr != nil {
-			return nil, fmt.Errorf("worktree required for project task: %w", wtErr)
+	effMode, dir, requirePerm, skipWT := resolveExecution(t, mode)
+	if !skipWT {
+		t = o.autoAssignProject(t)
+		if t.ProjectID != "" {
+			d, wtErr := o.worktrees.PrepareForTask(t)
+			if wtErr != nil {
+				return nil, fmt.Errorf("worktree required for project task: %w", wtErr)
+			}
+			dir = d
 		}
-		dir = d
 	}
 
 	fullPrompt := fmt.Sprintf("# Task: %s\n\n%s\n\n---\n\n%s", t.Title, t.Body, prompt)
 	ag, err := o.agents.Run(agent.RunConfig{
-		TaskID:       taskID,
-		Name:         t.Title,
-		Mode:         mode,
-		Prompt:       fullPrompt,
-		AllowedTools: t.AllowedTools,
-		Dir:          dir,
-		Model:        "sonnet",
+		TaskID:             taskID,
+		Name:               t.Title,
+		Mode:               effMode,
+		Prompt:             fullPrompt,
+		AllowedTools:       t.AllowedTools,
+		Dir:                dir,
+		Model:              "sonnet",
+		RequirePermissions: requirePerm,
 	})
 	if err != nil {
 		return nil, err
 	}
-	o.logAudit(audit.EventAgentStarted, taskID, ag.ID, map[string]any{"mode": mode, "title": t.Title})
+	o.logAudit(audit.EventAgentStarted, taskID, ag.ID, map[string]any{"mode": effMode, "title": t.Title, "task_type": string(t.TaskType)})
 	if err := o.tasks.AddRun(taskID, task.AgentRun{
 		AgentID:   ag.ID,
-		Mode:      mode,
+		Mode:      effMode,
 		State:     string(agent.StateRunning),
 		StartedAt: ag.StartedAt,
 	}); err != nil {
@@ -128,33 +147,36 @@ func (a *App) startPRFixReviewAgent(taskID string) error {
 		return err
 	}
 
-	t = a.agentOrch.autoAssignProject(t)
-	dir := ""
-	if t.ProjectID != "" {
-		d, wtErr := a.worktrees.PrepareForTask(t)
-		if wtErr != nil {
-			return fmt.Errorf("worktree required: %w", wtErr)
+	effMode, dir, requirePerm, skipWT := resolveExecution(t, t.AgentMode)
+	if !skipWT {
+		t = a.agentOrch.autoAssignProject(t)
+		if t.ProjectID != "" {
+			d, wtErr := a.worktrees.PrepareForTask(t)
+			if wtErr != nil {
+				return fmt.Errorf("worktree required: %w", wtErr)
+			}
+			dir = d
 		}
-		dir = d
 	}
 
 	prompt := fmt.Sprintf("# Task: %s\n\n%s\n\n---\n\nFix the issues raised in the PR review. Push the changes when done.", t.Title, t.Body)
 	ag, err := a.agents.Run(agent.RunConfig{
-		TaskID:       taskID,
-		Name:         agent.RolePRFix.AgentName(t.Title),
-		Mode:         t.AgentMode,
-		Prompt:       prompt,
-		AllowedTools: t.AllowedTools,
-		Dir:          dir,
-		Model:        "sonnet",
+		TaskID:             taskID,
+		Name:               agent.RolePRFix.AgentName(t.Title),
+		Mode:               effMode,
+		Prompt:             prompt,
+		AllowedTools:       t.AllowedTools,
+		Dir:                dir,
+		Model:              "sonnet",
+		RequirePermissions: requirePerm,
 	})
 	if err != nil {
 		return err
 	}
 
-	a.logAudit(audit.EventAgentStarted, taskID, ag.ID, map[string]any{"mode": t.AgentMode, "title": t.Title, "role": "pr-fix"})
+	a.logAudit(audit.EventAgentStarted, taskID, ag.ID, map[string]any{"mode": effMode, "title": t.Title, "role": "pr-fix", "task_type": string(t.TaskType)})
 	if err := a.tasks.AddRun(taskID, task.AgentRun{
-		AgentID: ag.ID, Role: string(agent.RolePRFix), Mode: t.AgentMode,
+		AgentID: ag.ID, Role: string(agent.RolePRFix), Mode: effMode,
 		State: string(agent.StateRunning), StartedAt: ag.StartedAt,
 	}); err != nil {
 		a.logger.Error("task.add-run", "task_id", taskID, "err", err)

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -140,6 +140,9 @@ func cmdGet(s *task.Manager, args []string, jsonOut bool) int {
 	fmt.Printf("Title:  %s\n", t.Title)
 	fmt.Printf("Status: %s\n", t.Status)
 	fmt.Printf("Mode:   %s\n", t.AgentMode)
+	if t.TaskType != "" {
+		fmt.Printf("Type:   %s\n", t.TaskType)
+	}
 	if len(t.Tags) > 0 {
 		fmt.Printf("Tags:   %s\n", strings.Join(t.Tags, ", "))
 	}
@@ -168,6 +171,7 @@ func cmdCreate(s *task.Manager, args []string, jsonOut bool) int {
 	title := fs.String("title", "", "task title (required)")
 	body := fs.String("body", "", "task body markdown")
 	mode := fs.String("mode", "headless", "agent mode: headless|interactive")
+	ttype := fs.String("type", "normal", "task type: normal|debug|research")
 	tags := fs.String("tags", "", "comma-separated tags")
 	proj := fs.String("project", "", "project id (owner/repo)")
 	branch := fs.String("branch", "", "Git branch name")
@@ -179,6 +183,9 @@ func cmdCreate(s *task.Manager, args []string, jsonOut bool) int {
 	if *title == "" {
 		return fatal(jsonOut, "title is required")
 	}
+	if _, err := task.ValidateTaskType(*ttype); err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
 
 	t, err := s.Create(*title, *body, *mode)
 	if err != nil {
@@ -186,6 +193,9 @@ func cmdCreate(s *task.Manager, args []string, jsonOut bool) int {
 	}
 
 	updates := map[string]any{}
+	if *ttype != "" && *ttype != string(task.TaskTypeNormal) {
+		updates["task_type"] = *ttype
+	}
 	if *tags != "" {
 		tagList := strings.Split(*tags, ",")
 		for i := range tagList {
@@ -230,6 +240,7 @@ func cmdUpdate(s *task.Manager, args []string, jsonOut bool) int {
 	status := fs.String("status", "", "new status")
 	body := fs.String("body", "", "new body")
 	mode := fs.String("mode", "", "new agent mode")
+	ttype := fs.String("type", "", "new task type: normal|debug|research")
 	tags := fs.String("tags", "", "comma-separated tags (replaces existing)")
 	proj := fs.String("project", "", "project id (owner/repo)")
 	branch := fs.String("branch", "", "Git branch name")
@@ -255,6 +266,12 @@ func cmdUpdate(s *task.Manager, args []string, jsonOut bool) int {
 	}
 	if *mode != "" {
 		updates["agent_mode"] = *mode
+	}
+	if *ttype != "" {
+		if _, err := task.ValidateTaskType(*ttype); err != nil {
+			return fatal(jsonOut, "%v", err)
+		}
+		updates["task_type"] = *ttype
 	}
 	if *tags != "" {
 		tagList := strings.Split(*tags, ",")
@@ -564,8 +581,9 @@ Commands:
   list     [--status STATUS] [--tag TAG] [--project ID]
            STATUS: new|todo|planning|plan-review|in-progress|in-review|human-required|done
   get      <id>
-  create   --title TITLE [--body BODY] [--mode MODE] [--tags t1,t2] [--project ID] [--branch B] [--pr N] [--issue URL]
-  update   <id> [--title T] [--status S] [--status-reason R] [--body B] [--mode M] [--tags T] [--project ID] [--branch B] [--pr N] [--issue URL]
+  create   --title TITLE [--body BODY] [--mode MODE] [--type TYPE] [--tags t1,t2] [--project ID] [--branch B] [--pr N] [--issue URL]
+           TYPE: normal|debug|research
+  update   <id> [--title T] [--status S] [--status-reason R] [--body B] [--mode M] [--type TYPE] [--tags T] [--project ID] [--branch B] [--pr N] [--issue URL]
   delete   <id>
 
   project list

--- a/frontend/src/components/CreateTaskDialog.svelte
+++ b/frontend/src/components/CreateTaskDialog.svelte
@@ -14,6 +14,7 @@
   let title = $state('')
   let body = $state('')
   let headless = $state(false)
+  let taskType = $state('normal')
   let selectedProject = $state('')
   let projectSearch = $state('')
   let projectDropdownOpen = $state(false)
@@ -48,6 +49,7 @@
     title = ''
     body = ''
     headless = false
+    taskType = 'normal'
     selectedProject = ''
     projectSearch = ''
     projectDropdownOpen = false
@@ -65,9 +67,17 @@
     submitting = true
     error = ''
     try {
-      let t = await taskStore.create(title.trim(), body, headless ? 'headless' : 'interactive')
-      if (selectedProject) {
-        t = await taskStore.update(t.id, { project_id: selectedProject })
+      // debug/research task types force the agent mode; ignore checkbox.
+      const effectiveMode =
+        taskType === 'debug' ? 'interactive'
+        : taskType === 'research' ? 'headless'
+        : (headless ? 'headless' : 'interactive')
+      let t = await taskStore.create(title.trim(), body, effectiveMode)
+      const updates: Record<string, unknown> = {}
+      if (taskType !== 'normal') updates.task_type = taskType
+      if (selectedProject) updates.project_id = selectedProject
+      if (Object.keys(updates).length > 0) {
+        t = await taskStore.update(t.id, updates)
       }
       reset()
       onOpenChange(false)
@@ -164,14 +174,28 @@
           </div>
         {/if}
 
-        <label class="flex items-center gap-2">
-          <input
-            type="checkbox"
-            bind:checked={headless}
-            class="rounded border-surface-300 dark:border-surface-600"
-          />
-          <span class="text-sm font-medium">Headless</span>
+        <label class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Type</span>
+          <select
+            bind:value={taskType}
+            class="rounded-lg border border-surface-300 bg-surface-100 px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
+          >
+            <option value="normal">normal</option>
+            <option value="debug">debug (interactive, per-tool perms)</option>
+            <option value="research">research (headless, research-machine)</option>
+          </select>
         </label>
+
+        {#if taskType === 'normal'}
+          <label class="flex items-center gap-2">
+            <input
+              type="checkbox"
+              bind:checked={headless}
+              class="rounded border-surface-300 dark:border-surface-600"
+            />
+            <span class="text-sm font-medium">Headless</span>
+          </label>
+        {/if}
 
         <label class="flex flex-col gap-1">
           <span class="text-sm font-medium">Description</span>

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -79,7 +79,7 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 
 	switch cfg.Mode {
 	case "headless":
-		go m.runHeadless(ctx, a, cfg.Prompt, cfg.AllowedTools)
+		go m.runHeadless(ctx, a, cfg.Prompt, cfg.AllowedTools, cfg.RequirePermissions)
 	case "interactive":
 		a.TmuxSession = fmt.Sprintf("synapse-%s-%s", sanitizeSessionName(cfg.Name), id)
 		claudeCmd, buildErr := m.buildClaudeCmd(cfg)
@@ -129,7 +129,7 @@ func (m *Manager) buildClaudeCmd(cfg RunConfig) (string, error) {
 	parts := []string{"claude"}
 	if len(cfg.AllowedTools) > 0 {
 		parts = append(parts, "--allowedTools", strings.Join(cfg.AllowedTools, ","))
-	} else {
+	} else if !cfg.RequirePermissions {
 		parts = append(parts, "--dangerously-skip-permissions")
 	}
 	if cfg.Model != "" {

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -51,13 +51,14 @@ func (a *Agent) Output() []StreamEvent {
 
 // RunConfig is the single entry point for starting any agent.
 type RunConfig struct {
-	TaskID       string
-	Name         string
-	Mode         string // "headless" or "interactive"
-	Prompt       string
-	AllowedTools []string
-	Dir          string
-	Model        string // "opus", "sonnet", or full model ID
+	TaskID             string
+	Name               string
+	Mode               string // "headless" or "interactive"
+	Prompt             string
+	AllowedTools       []string
+	Dir                string
+	Model              string // "opus", "sonnet", or full model ID
+	RequirePermissions bool   // when true, suppress --dangerously-skip-permissions
 }
 
 type StreamEvent struct {

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -21,7 +21,7 @@ import (
 // GetAgentOutput which reads from outputBuffer.
 const headlessEmitInterval = 50 * time.Millisecond
 
-func (m *Manager) runHeadless(ctx context.Context, a *Agent, prompt string, allowedTools []string) {
+func (m *Manager) runHeadless(ctx context.Context, a *Agent, prompt string, allowedTools []string, requirePermissions bool) {
 	args := []string{"-p", prompt, "--output-format", "stream-json", "--verbose"}
 
 	if a.SessionID != "" {
@@ -30,7 +30,7 @@ func (m *Manager) runHeadless(ctx context.Context, a *Agent, prompt string, allo
 
 	if len(allowedTools) > 0 {
 		args = append(args, "--allowedTools", strings.Join(allowedTools, ","))
-	} else {
+	} else if !requirePermissions {
 		args = append(args, "--dangerously-skip-permissions")
 	}
 

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -68,7 +68,7 @@ func TestRunHeadlessFailsToStart(t *testing.T) {
 		State: StateRunning,
 	}
 
-	m.runHeadless(t.Context(), a, "test prompt", nil)
+	m.runHeadless(t.Context(), a, "test prompt", nil, false)
 
 	if a.State != StateStopped {
 		t.Errorf("State = %q, want %q", a.State, StateStopped)
@@ -87,7 +87,7 @@ func TestRunHeadlessWithAllowedTools(t *testing.T) {
 		State: StateRunning,
 	}
 
-	m.runHeadless(t.Context(), a, "test prompt", []string{"Read", "Write"})
+	m.runHeadless(t.Context(), a, "test prompt", []string{"Read", "Write"}, false)
 
 	if a.State != StateStopped {
 		t.Errorf("State = %q, want %q", a.State, StateStopped)
@@ -103,7 +103,7 @@ func TestRunHeadlessWithResume(t *testing.T) {
 		SessionID: "prev-session-id",
 	}
 
-	m.runHeadless(t.Context(), a, "test prompt", nil)
+	m.runHeadless(t.Context(), a, "test prompt", nil, false)
 
 	if a.State != StateStopped {
 		t.Errorf("State = %q, want %q", a.State, StateStopped)
@@ -122,7 +122,7 @@ func TestRunHeadlessCancelledContext(t *testing.T) {
 		State: StateRunning,
 	}
 
-	m.runHeadless(ctx, a, "test prompt", nil)
+	m.runHeadless(ctx, a, "test prompt", nil, false)
 
 	if a.State != StateStopped {
 		t.Errorf("State = %q, want %q", a.State, StateStopped)

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -40,6 +40,31 @@ func ValidateStatus(s string) (Status, error) {
 	return st, nil
 }
 
+type TaskType string
+
+const (
+	TaskTypeNormal   TaskType = "normal"
+	TaskTypeDebug    TaskType = "debug"
+	TaskTypeResearch TaskType = "research"
+)
+
+var validTaskTypes = map[TaskType]bool{
+	TaskTypeNormal: true, TaskTypeDebug: true, TaskTypeResearch: true,
+}
+
+// AllTaskTypes returns every valid task type in display order.
+func AllTaskTypes() []TaskType {
+	return []TaskType{TaskTypeNormal, TaskTypeDebug, TaskTypeResearch}
+}
+
+func ValidateTaskType(s string) (TaskType, error) {
+	tt := TaskType(s)
+	if !validTaskTypes[tt] {
+		return "", fmt.Errorf("invalid task_type %q (valid: %v)", s, AllTaskTypes())
+	}
+	return tt, nil
+}
+
 type AgentRun struct {
 	AgentID   string    `yaml:"agent_id" json:"agentId"`
 	Role      string    `yaml:"role,omitempty" json:"role"` // triage, plan, eval, pr-fix, or "" for implementation
@@ -56,6 +81,7 @@ type Task struct {
 	Slug         string     `yaml:"slug,omitempty" json:"slug"`
 	Title        string     `yaml:"title" json:"title"`
 	Status       Status     `yaml:"status" json:"status"`
+	TaskType     TaskType   `yaml:"task_type,omitempty" json:"taskType"`
 	AgentMode    string     `yaml:"agent_mode" json:"agentMode"`
 	AllowedTools []string   `yaml:"allowed_tools" json:"allowedTools"`
 	Tags         []string   `yaml:"tags" json:"tags"`

--- a/internal/task/parser.go
+++ b/internal/task/parser.go
@@ -41,6 +41,9 @@ func ParseBytes(data []byte) (Task, error) {
 	}
 
 	t.Body = string(bytes.TrimSpace(data[locs[1][1]:]))
+	if t.TaskType == "" {
+		t.TaskType = TaskTypeNormal
+	}
 	return t, nil
 }
 

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -69,6 +69,7 @@ func (s *Store) Create(title, body, mode string) (Task, error) {
 		Slug:      Slugify(title),
 		Title:     title,
 		Status:    StatusTodo,
+		TaskType:  TaskTypeNormal,
 		AgentMode: mode,
 		CreatedAt: now,
 		UpdatedAt: now,
@@ -125,6 +126,13 @@ func (s *Store) Update(id string, updates map[string]any) (Task, error) {
 	}
 	if v, ok := updates["agent_mode"].(string); ok {
 		t.AgentMode = v
+	}
+	if v, ok := updates["task_type"].(string); ok {
+		tt, vErr := ValidateTaskType(v)
+		if vErr != nil {
+			return Task{}, vErr
+		}
+		t.TaskType = tt
 	}
 	if v, ok := updates["body"].(string); ok {
 		t.Body = v


### PR DESCRIPTION
## Motivation

Tasks currently expose `agent_mode` (interactive|headless) as the only execution knob. That forces users to remember which mode + permission flags + working dir fits each workflow. This adds a higher-level `task_type` classification that dictates those parameters at once.

- **normal** (default): current behavior
- **debug**: force interactive mode + per-tool permission prompts (drop `--dangerously-skip-permissions`) for safely poking around a codebase
- **research**: force headless, run in a fixed `research-machine` dir, skip project/worktree setup

Designed extensibly — more types can be added.

## Implementation information

- `TaskType` enum on `task.Task` mirroring the `Status` enum pattern (constants + `validTaskTypes` map + `ValidateTaskType`/`AllTaskTypes`). Empty value on load defaults to `normal`.
- `RunConfig.RequirePermissions` added. When true, both headless and interactive command builders skip `--dangerously-skip-permissions` so claude prompts per tool.
- Translation lives in a single `resolveExecution(task, hintMode)` helper in `app_agents.go`, used by `StartAgent` and `startPRFixReviewAgent`. Research tasks bypass `autoAssignProject` + worktree setup entirely.
- CLI: `--type` flag on `create`/`update`, validated. Printed in `get`.
- Frontend: `CreateTaskDialog.svelte` gains a type dropdown; headless checkbox is hidden for debug/research since mode is forced.

Alternative considered: storing the permission flag on the task itself. Rejected — task_type is the semantic knob; permission behavior is a derived property.

## Supporting documentation

n/a