### PR TITLE
fix(worktree): rebase reused wt onto main

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -187,3 +187,18 @@ func PushUpstream(worktreePath, branch string) error {
 func RemoveWorktree(barePath, worktreePath string) error {
 	return executil.Run(barePath, "git", "worktree", "remove", "--force", worktreePath)
 }
+
+// PruneWorktrees removes stale worktree admin entries from the bare repo.
+func PruneWorktrees(barePath string) error {
+	return executil.Run(barePath, "git", "worktree", "prune")
+}
+
+// RebaseOnto rebases the worktree's current branch onto the given ref.
+// Aborts and returns an error on conflict.
+func RebaseOnto(worktreePath, ref string) error {
+	if err := executil.Run(worktreePath, "git", "rebase", ref); err != nil {
+		_ = executil.Run(worktreePath, "git", "rebase", "--abort")
+		return fmt.Errorf("rebase onto %s: %w", ref, err)
+	}
+	return nil
+}

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -84,7 +84,7 @@ func (m *Manager) PrepareForTask(t task.Task) (string, error) {
 		return "", fmt.Errorf("get project: %w", err)
 	}
 	if err := project.FetchOrigin(proj.ClonePath); err != nil {
-		m.logger.Warn("worktree.fetch", "project", proj.ID, "err", err)
+		return "", fmt.Errorf("fetch origin: %w", err)
 	}
 
 	branch, err := project.DefaultBranch(proj.ClonePath)
@@ -94,16 +94,21 @@ func (m *Manager) PrepareForTask(t task.Task) (string, error) {
 
 	wtPath := m.PathFor(t)
 	wtBranch := "synapse/" + t.DirName()
+	baseRef := "refs/remotes/origin/" + branch
 
 	if _, statErr := os.Stat(wtPath); statErr == nil {
 		if err := project.SanitizeWorktree(wtPath); err != nil {
 			m.logger.Warn("worktree.sanitize", "task_id", t.ID, "err", err)
 		}
+		if err := project.RebaseOnto(wtPath, baseRef); err != nil {
+			return "", fmt.Errorf("rebase worktree onto %s: %w", baseRef, err)
+		}
+		m.logger.Info("worktree.rebased", "task_id", t.ID, "path", wtPath, "base", baseRef)
 		m.ensureBranch(t, wtBranch)
 		return wtPath, nil
 	}
 
-	if err := project.CreateWorktree(proj.ClonePath, wtPath, wtBranch, "refs/remotes/origin/"+branch); err != nil {
+	if err := project.CreateWorktree(proj.ClonePath, wtPath, wtBranch, baseRef); err != nil {
 		return "", fmt.Errorf("create worktree: %w", err)
 	}
 	m.logger.Info("worktree.created", "task_id", t.ID, "path", wtPath)
@@ -233,10 +238,37 @@ func (m *Manager) CleanupOrphaned() {
 			continue
 		}
 
-		if err := os.RemoveAll(wtPath); err != nil {
-			m.logger.Error("worktree.orphan-cleanup", "path", wtPath, "err", err)
-		} else {
-			m.logger.Info("worktree.orphan-cleaned", "path", wtPath)
+		removed := false
+		if exists && t.ProjectID != "" {
+			if proj, perr := m.projects.Get(t.ProjectID); perr == nil {
+				if err := project.RemoveWorktree(proj.ClonePath, wtPath); err != nil {
+					m.logger.Error("worktree.orphan-cleanup", "path", wtPath, "err", err)
+				} else {
+					removed = true
+				}
+			}
+		}
+		if !removed {
+			// Task deleted or project lookup failed — force-remove and prune after.
+			if err := os.RemoveAll(wtPath); err != nil {
+				m.logger.Error("worktree.orphan-cleanup", "path", wtPath, "err", err)
+				continue
+			}
+		}
+		m.logger.Info("worktree.orphan-cleaned", "path", wtPath)
+	}
+
+	// Prune dangling admin entries across all projects.
+	if m.projects == nil {
+		return
+	}
+	projects, err := m.projects.List()
+	if err != nil {
+		return
+	}
+	for i := range projects {
+		if err := project.PruneWorktrees(projects[i].ClonePath); err != nil {
+			m.logger.Warn("worktree.prune", "project", projects[i].ID, "err", err)
 		}
 	}
 }


### PR DESCRIPTION
## Motivation

Tasks started after main moved forward were getting merge conflicts even though no concurrent work touched the same lines. Root cause: when a worktree already existed for a task (stop/resume, crash/restart, pr-fix re-run), `PrepareForTask` reused the dir as-is, keeping its original base commit. New merges into main were never pulled in.

Related silent failure: `FetchOrigin` errors were warn-only, so a failed fetch would silently produce a worktree based on stale `refs/remotes/origin/main`.

Related cleanup bug: `CleanupOrphaned` called `os.RemoveAll` instead of `git worktree remove`, leaving dangling admin entries in the bare repo's `.git/worktrees/`.

## Implementation information

- `FetchOrigin` failure is now a hard error in `PrepareForTask`.
- On worktree reuse, the branch is rebased onto `refs/remotes/origin/<default>`; conflicts abort the rebase and surface to the caller so the agent does not start on a stale base.
- `CleanupOrphaned` uses `project.RemoveWorktree` when the project is known, falls back to `os.RemoveAll` otherwise, then runs `git worktree prune` across all projects to sweep dangling entries.
- New helpers in `internal/project/git.go`: `PruneWorktrees`, `RebaseOnto`.

Alternative considered: always destroy+recreate worktree on agent start. Rejected because it would discard any in-progress uncommitted work across stop/resume cycles. Rebase preserves local commits while refreshing the base.

## Supporting documentation

N/A

> Changelog: fix(worktree): rebase reused wt onto main