### PR TITLE
feat(todoist): add task sync integration

### DIFF
--- a/app.go
+++ b/app.go
@@ -21,37 +21,39 @@ import (
 	"github.com/Automaat/synapse/internal/stats"
 	"github.com/Automaat/synapse/internal/task"
 	"github.com/Automaat/synapse/internal/tmux"
+	"github.com/Automaat/synapse/internal/todoist"
 	"github.com/Automaat/synapse/internal/watcher"
 	"github.com/Automaat/synapse/internal/worktree"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
 type App struct {
-	ctx          context.Context
-	cancel       context.CancelFunc
-	wg           sync.WaitGroup
-	tasks        *task.Manager
-	projects     *project.Store
-	agents       *agent.Manager
-	tmux         *tmux.Manager
-	watcher      *watcher.Watcher
-	notifier     *notification.Emitter
-	audit        *audit.Logger
-	stats        *stats.Store
-	tasksDir     string
-	skillsDir    string
-	repoDir      string
-	worktreesDir string
-	logger       *slog.Logger
-	logDir       string
-	auditDir     string
-	prTracker    *github.IssueTracker
-	worktrees    *worktree.Manager
-	agentOrch    *AgentOrchestrator
-	reviewer     *ReviewHandler
-	workflow     *TaskWorkflow
-	cfg          *config.Config
-	logLevel     *slog.LevelVar
+	ctx            context.Context
+	cancel         context.CancelFunc
+	wg             sync.WaitGroup
+	tasks          *task.Manager
+	projects       *project.Store
+	agents         *agent.Manager
+	tmux           *tmux.Manager
+	watcher        *watcher.Watcher
+	notifier       *notification.Emitter
+	audit          *audit.Logger
+	stats          *stats.Store
+	tasksDir       string
+	skillsDir      string
+	repoDir        string
+	worktreesDir   string
+	logger         *slog.Logger
+	logDir         string
+	auditDir       string
+	prTracker      *github.IssueTracker
+	worktrees      *worktree.Manager
+	agentOrch      *AgentOrchestrator
+	reviewer       *ReviewHandler
+	workflow       *TaskWorkflow
+	todoistHandler *TodoistHandler
+	cfg            *config.Config
+	logLevel       *slog.LevelVar
 }
 
 func NewApp(logger *slog.Logger, logLevel *slog.LevelVar, cfg *config.Config) *App {
@@ -150,6 +152,12 @@ func (a *App) startup(ctx context.Context) {
 		a.logger.Error("watcher.start", "err", err)
 	}
 
+	if a.cfg.Todoist.Enabled && a.cfg.Todoist.APIToken != "" {
+		tc := todoist.NewClient(a.cfg.Todoist.APIToken)
+		a.todoistHandler = newTodoistHandler(a.tasks, tc, a.audit, a.logger, emit, a.cfg.Todoist)
+		a.logger.Info("todoist.enabled", "project_id", a.cfg.Todoist.ProjectID)
+	}
+
 	a.syncSkills()
 	a.reconnectAgents()
 	a.worktrees.CleanupOrphaned()
@@ -159,6 +167,9 @@ func (a *App) startup(ctx context.Context) {
 	a.wg.Go(func() { a.orchestratorLoop(ctx) })
 	a.wg.Go(func() { a.prPollLoop(ctx) })
 	a.wg.Go(func() { a.agentWatchdogLoop(ctx) })
+	if a.todoistHandler != nil {
+		a.wg.Go(func() { a.todoistPollLoop(ctx) })
+	}
 	a.logger.Info("app.started")
 }
 

--- a/app_config.go
+++ b/app_config.go
@@ -20,6 +20,7 @@ type AppSettings struct {
 	Orchestrator config.OrchestratorConfig `json:"orchestrator"`
 	Logging      LoggingSettings           `json:"logging"`
 	Audit        config.AuditConfig        `json:"audit"`
+	Todoist      config.TodoistConfig      `json:"todoist"`
 	Directories  map[string]string         `json:"directories"`
 }
 
@@ -36,6 +37,7 @@ func (a *App) GetSettings() AppSettings {
 			MaxFiles:  c.Logging.MaxFiles,
 		},
 		Audit:       c.Audit,
+		Todoist:     c.Todoist,
 		Directories: c.Directories(),
 	}
 }
@@ -66,6 +68,12 @@ func (a *App) UpdateSettings(s AppSettings) error {
 	if s.Audit.RetentionDays < 1 || s.Audit.RetentionDays > 365 {
 		return fmt.Errorf("retentionDays must be 1–365")
 	}
+	if s.Todoist.Enabled && s.Todoist.APIToken == "" {
+		return fmt.Errorf("todoist API token required when enabled")
+	}
+	if s.Todoist.PollSeconds < 30 || s.Todoist.PollSeconds > 3600 {
+		s.Todoist.PollSeconds = 120
+	}
 
 	a.cfg.Agent = s.Agent
 	a.cfg.Notification = s.Notification
@@ -74,6 +82,7 @@ func (a *App) UpdateSettings(s AppSettings) error {
 	a.cfg.Logging.MaxSizeMB = s.Logging.MaxSizeMB
 	a.cfg.Logging.MaxFiles = s.Logging.MaxFiles
 	a.cfg.Audit = s.Audit
+	a.cfg.Todoist = s.Todoist
 
 	// Hot-reload side effects
 	a.notifier.SetDesktop(s.Notification.Desktop)

--- a/app_todoist.go
+++ b/app_todoist.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/Automaat/synapse/internal/audit"
+	"github.com/Automaat/synapse/internal/config"
+	"github.com/Automaat/synapse/internal/events"
+	"github.com/Automaat/synapse/internal/task"
+	"github.com/Automaat/synapse/internal/todoist"
+)
+
+// TodoistHandler syncs tasks between Todoist and Synapse.
+type TodoistHandler struct {
+	tasks  *task.Manager
+	client *todoist.Client
+	audit  *audit.Logger
+	logger *slog.Logger
+	emit   func(string, any)
+	cfg    config.TodoistConfig
+}
+
+func newTodoistHandler(
+	tasks *task.Manager,
+	client *todoist.Client,
+	al *audit.Logger,
+	logger *slog.Logger,
+	emit func(string, any),
+	cfg config.TodoistConfig,
+) *TodoistHandler {
+	return &TodoistHandler{
+		tasks:  tasks,
+		client: client,
+		audit:  al,
+		logger: logger,
+		emit:   emit,
+		cfg:    cfg,
+	}
+}
+
+// pollAndSync runs one import+completion cycle and returns the next poll interval.
+func (h *TodoistHandler) pollAndSync() time.Duration {
+	interval := time.Duration(h.cfg.PollSeconds) * time.Second
+
+	imported, importErr := h.importNewTasks()
+	if importErr != nil {
+		h.logger.Error("todoist.import", "err", importErr)
+	}
+
+	completed, compErr := h.syncCompletions()
+	if compErr != nil {
+		h.logger.Error("todoist.complete", "err", compErr)
+	}
+
+	if imported > 0 || completed > 0 {
+		h.logger.Info("todoist.synced", "imported", imported, "completed", completed)
+		h.emit(events.TodoistSynced, map[string]any{
+			"imported":  imported,
+			"completed": completed,
+		})
+	}
+
+	return interval
+}
+
+func (h *TodoistHandler) importNewTasks() (int, error) {
+	remote, err := h.client.ListActiveTasks(h.cfg.ProjectID)
+	if err != nil {
+		return 0, err
+	}
+
+	seen, err := h.buildSeenIndex()
+	if err != nil {
+		return 0, fmt.Errorf("build seen index: %w", err)
+	}
+
+	var imported int
+	for i := range remote {
+		rt := &remote[i]
+		if seen[rt.ID] {
+			continue
+		}
+		if rt.Due != nil && rt.Due.IsRecurring {
+			continue
+		}
+
+		body := rt.Description
+		if rt.URL != "" {
+			if body != "" {
+				body += "\n\n"
+			}
+			body += "Source: " + rt.URL
+		}
+
+		t, createErr := h.tasks.Create(rt.Content, body, "headless")
+		if createErr != nil {
+			h.logger.Error("todoist.create-task", "todoist_id", rt.ID, "err", createErr)
+			continue
+		}
+
+		updates := map[string]any{"todoist_id": rt.ID}
+		tags := mapPriorityTag(rt.Priority)
+		tags = append(tags, rt.Labels...)
+		if len(tags) > 0 {
+			updates["tags"] = tags
+		}
+
+		if _, updateErr := h.tasks.Update(t.ID, updates); updateErr != nil {
+			h.logger.Error("todoist.update-task", "task_id", t.ID, "err", updateErr)
+		}
+
+		h.logAudit(audit.EventTodoistImported, t.ID, map[string]any{
+			"todoist_id": rt.ID,
+			"title":      rt.Content,
+		})
+		imported++
+	}
+
+	return imported, nil
+}
+
+func (h *TodoistHandler) syncCompletions() (int, error) {
+	tasks, err := h.tasks.List()
+	if err != nil {
+		return 0, err
+	}
+
+	var completed int
+	for i := range tasks {
+		t := &tasks[i]
+		if t.TodoistID == "" || t.Status != task.StatusDone {
+			continue
+		}
+		if closeErr := h.client.CloseTask(t.TodoistID); closeErr != nil {
+			h.logger.Error("todoist.close", "task_id", t.ID, "todoist_id", t.TodoistID, "err", closeErr)
+			continue
+		}
+		h.logAudit(audit.EventTodoistCompleted, t.ID, map[string]any{
+			"todoist_id": t.TodoistID,
+		})
+		completed++
+	}
+
+	return completed, nil
+}
+
+func (h *TodoistHandler) buildSeenIndex() (map[string]bool, error) {
+	tasks, err := h.tasks.List()
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]bool, len(tasks))
+	for i := range tasks {
+		t := &tasks[i]
+		if t.TodoistID != "" {
+			seen[t.TodoistID] = true
+		}
+	}
+	return seen, nil
+}
+
+func (h *TodoistHandler) logAudit(eventType, taskID string, data map[string]any) {
+	if h.audit == nil {
+		return
+	}
+	if err := h.audit.Log(audit.Event{
+		Type:   eventType,
+		TaskID: taskID,
+		Data:   data,
+	}); err != nil {
+		h.logger.Error("todoist.audit", "type", eventType, "err", err)
+	}
+}
+
+// mapPriorityTag converts Todoist priority (1=normal, 4=urgent) to tag(s).
+func mapPriorityTag(priority int) []string {
+	switch priority {
+	case 4:
+		return []string{"p1"}
+	case 3:
+		return []string{"p2"}
+	case 2:
+		return []string{"p3"}
+	default:
+		return nil
+	}
+}
+
+// todoistPollLoop runs the Todoist sync on a timer.
+func (a *App) todoistPollLoop(ctx context.Context) {
+	timer := time.NewTimer(15 * time.Second)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			next := a.todoistHandler.pollAndSync()
+			timer.Reset(next)
+		}
+	}
+}
+
+// SyncTodoist triggers an immediate Todoist sync (bound to frontend).
+func (a *App) SyncTodoist() error {
+	if a.todoistHandler == nil {
+		return fmt.Errorf("todoist integration not enabled")
+	}
+	a.todoistHandler.pollAndSync()
+	return nil
+}
+
+// GetTodoistProjects returns Todoist projects for the settings UI.
+func (a *App) GetTodoistProjects() ([]todoist.Project, error) {
+	token := a.cfg.Todoist.APIToken
+	if token == "" {
+		return nil, fmt.Errorf("todoist API token not configured")
+	}
+	c := todoist.NewClient(token)
+	return c.ListProjects()
+}
+
+// TodoistEnabled returns whether the todoist handler is active.
+func (a *App) TodoistEnabled() bool {
+	return a.todoistHandler != nil
+}

--- a/frontend/src/pages/Settings.svelte
+++ b/frontend/src/pages/Settings.svelte
@@ -27,12 +27,20 @@
     autoPlan: boolean
   }
 
+  interface TodoistConfig {
+    enabled: boolean
+    apiToken: string
+    projectId: string
+    pollSeconds: number
+  }
+
   interface AppSettings {
     agent: AgentDefaults
     notification: NotificationConfig
     orchestrator: OrchestratorConfig
     logging: LoggingSettings
     audit: AuditConfig
+    todoist: TodoistConfig
     directories: Record<string, string>
   }
 
@@ -263,6 +271,62 @@
           />
           <span class="text-sm">Enable audit logging</span>
         </label>
+      </div>
+    </div>
+
+    <!-- Todoist -->
+    <div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
+      <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Todoist</h2>
+      <div class="flex flex-col gap-4">
+        <label class="flex cursor-pointer items-center gap-3">
+          <input
+            type="checkbox"
+            class="h-4 w-4 cursor-pointer rounded border-surface-300"
+            bind:checked={settings.todoist.enabled}
+          />
+          <div>
+            <span class="text-sm font-medium">Enable Todoist sync</span>
+            <p class="text-xs text-surface-400">Pull tasks from a Todoist project and close them when done</p>
+          </div>
+        </label>
+        {#if settings.todoist.enabled}
+          <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div class="flex flex-col gap-1">
+              <label class="text-sm font-medium" for="todoist-token">API Token</label>
+              <input
+                id="todoist-token"
+                type="password"
+                placeholder="Your Todoist API token"
+                class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
+                bind:value={settings.todoist.apiToken}
+              />
+              <span class="text-xs text-surface-400">Settings → Integrations → API token</span>
+            </div>
+            <div class="flex flex-col gap-1">
+              <label class="text-sm font-medium" for="todoist-project">Project ID</label>
+              <input
+                id="todoist-project"
+                type="text"
+                placeholder="Todoist project ID"
+                class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
+                bind:value={settings.todoist.projectId}
+              />
+              <span class="text-xs text-surface-400">ID from project URL</span>
+            </div>
+            <div class="flex flex-col gap-1">
+              <label class="text-sm font-medium" for="todoist-poll">Poll Interval (seconds)</label>
+              <input
+                id="todoist-poll"
+                type="number"
+                min="30"
+                max="3600"
+                class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
+                bind:value={settings.todoist.pollSeconds}
+              />
+              <span class="text-xs text-surface-400">30–3600 seconds</span>
+            </div>
+          </div>
+        {/if}
       </div>
     </div>
 

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -24,6 +24,8 @@ const (
 	EventPRAutoMerged        = "pr_monitor.auto_merged"
 	EventReviewStarted       = "review.agent_started"
 	EventReviewPublished     = "review.published"
+	EventTodoistImported     = "todoist.imported"
+	EventTodoistCompleted    = "todoist.completed"
 )
 
 type Event struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	Agent        AgentDefaults      `yaml:"agent" json:"agent"`
 	Notification NotificationConfig `yaml:"notification" json:"notification"`
 	Orchestrator OrchestratorConfig `yaml:"orchestrator" json:"orchestrator"`
+	Todoist      TodoistConfig      `yaml:"todoist" json:"todoist"`
 	TasksDir     string             `yaml:"tasks_dir" json:"tasksDir"`
 	SkillsDir    string             `yaml:"skills_dir" json:"skillsDir"`
 	RepoDir      string             `yaml:"repo_dir" json:"repoDir"`
@@ -47,6 +48,13 @@ type NotificationConfig struct {
 type OrchestratorConfig struct {
 	AutoTriage bool `yaml:"auto_triage" json:"autoTriage"`
 	AutoPlan   bool `yaml:"auto_plan" json:"autoPlan"`
+}
+
+type TodoistConfig struct {
+	Enabled     bool   `yaml:"enabled" json:"enabled"`
+	APIToken    string `yaml:"api_token" json:"apiToken"`
+	ProjectID   string `yaml:"project_id" json:"projectId"`
+	PollSeconds int    `yaml:"poll_seconds" json:"pollSeconds"`
 }
 
 func HomeDir() string {
@@ -152,6 +160,13 @@ func Load() (*Config, error) {
 	}
 	if cfg.WorktreesDir == "" {
 		cfg.WorktreesDir = defaultWorktreesDir()
+	}
+
+	if v := os.Getenv("SYNAPSE_TODOIST_TOKEN"); v != "" {
+		cfg.Todoist.APIToken = v
+	}
+	if cfg.Todoist.PollSeconds <= 0 {
+		cfg.Todoist.PollSeconds = 120
 	}
 
 	return cfg, nil

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -22,6 +22,9 @@ const (
 	// Notification events.
 	Notification = "notification"
 
+	// Todoist integration events.
+	TodoistSynced = "todoist:synced"
+
 	// App lifecycle events.
 	AppQuitConfirm = "app:quit-confirm"
 )

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -92,6 +92,7 @@ type Task struct {
 	StatusReason string     `yaml:"status_reason,omitempty" json:"statusReason"`
 	Reviewed     bool       `yaml:"reviewed,omitempty" json:"reviewed"`
 	RunRole      string     `yaml:"run_role,omitempty" json:"runRole"` // pr-fix when fixing review issues, "" for initial impl
+	TodoistID    string     `yaml:"todoist_id,omitempty" json:"todoistId"`
 	AgentRuns    []AgentRun `yaml:"agent_runs,omitempty" json:"agentRuns"`
 	CreatedAt    time.Time  `yaml:"created_at" json:"createdAt"`
 	UpdatedAt    time.Time  `yaml:"updated_at" json:"updatedAt"`

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -164,6 +164,9 @@ func (s *Store) Update(id string, updates map[string]any) (Task, error) {
 	if v, ok := updates["run_role"].(string); ok {
 		t.RunRole = v
 	}
+	if v, ok := updates["todoist_id"].(string); ok {
+		t.TodoistID = v
+	}
 
 	data, err := Marshal(t)
 	if err != nil {

--- a/internal/todoist/client.go
+++ b/internal/todoist/client.go
@@ -1,0 +1,113 @@
+package todoist
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const defaultBaseURL = "https://api.todoist.com/rest/v2"
+
+// HTTPDoer abstracts HTTP execution for testing.
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Client talks to the Todoist REST API v2.
+type Client struct {
+	token   string
+	doer    HTTPDoer
+	baseURL string
+}
+
+// NewClient creates a Client using the default http.Client.
+func NewClient(token string) *Client {
+	return &Client{token: token, doer: http.DefaultClient, baseURL: defaultBaseURL}
+}
+
+// NewClientWith creates a Client with a custom HTTPDoer (for testing).
+func NewClientWith(token string, doer HTTPDoer, baseURL string) *Client {
+	return &Client{token: token, doer: doer, baseURL: baseURL}
+}
+
+// ListActiveTasks returns all active (non-completed) tasks in the given project.
+func (c *Client) ListActiveTasks(projectID string) ([]Task, error) {
+	url := fmt.Sprintf("%s/tasks?project_id=%s", c.baseURL, projectID)
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	c.setHeaders(req)
+
+	resp, err := c.doer.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("todoist list tasks: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("todoist list tasks: HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	var tasks []Task
+	if err := json.NewDecoder(resp.Body).Decode(&tasks); err != nil {
+		return nil, fmt.Errorf("decode tasks: %w", err)
+	}
+	return tasks, nil
+}
+
+// CloseTask marks a Todoist task as completed.
+func (c *Client) CloseTask(todoistID string) error {
+	url := fmt.Sprintf("%s/tasks/%s/close", c.baseURL, todoistID)
+	req, err := http.NewRequest(http.MethodPost, url, http.NoBody)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	c.setHeaders(req)
+
+	resp, err := c.doer.Do(req)
+	if err != nil {
+		return fmt.Errorf("todoist close task: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("todoist close task: HTTP %d: %s", resp.StatusCode, body)
+	}
+	return nil
+}
+
+// ListProjects returns all projects visible to the authenticated user.
+func (c *Client) ListProjects() ([]Project, error) {
+	url := fmt.Sprintf("%s/projects", c.baseURL)
+	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	c.setHeaders(req)
+
+	resp, err := c.doer.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("todoist list projects: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("todoist list projects: HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	var projects []Project
+	if err := json.NewDecoder(resp.Body).Decode(&projects); err != nil {
+		return nil, fmt.Errorf("decode projects: %w", err)
+	}
+	return projects, nil
+}
+
+func (c *Client) setHeaders(req *http.Request) {
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+}

--- a/internal/todoist/client_test.go
+++ b/internal/todoist/client_test.go
@@ -1,0 +1,98 @@
+package todoist
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListActiveTasks(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/tasks" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("project_id") != "123" {
+			t.Errorf("unexpected project_id: %s", r.URL.Query().Get("project_id"))
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Errorf("unexpected auth header: %s", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[
+			{"id":"1","content":"Buy milk","priority":1,"labels":["errand"]},
+			{"id":"2","content":"Fix bug","priority":4,"labels":["dev"],"due":{"date":"2026-04-10","is_recurring":true,"string":"every day"}}
+		]`)
+	}))
+	defer srv.Close()
+
+	c := NewClientWith("test-token", srv.Client(), srv.URL)
+	tasks, err := c.ListActiveTasks("123")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 2 {
+		t.Fatalf("expected 2 tasks, got %d", len(tasks))
+	}
+	if tasks[0].Content != "Buy milk" {
+		t.Errorf("expected 'Buy milk', got %q", tasks[0].Content)
+	}
+	if tasks[1].Due == nil || !tasks[1].Due.IsRecurring {
+		t.Error("expected task 2 to have recurring due date")
+	}
+}
+
+func TestListActiveTasks_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"error":"invalid token"}`)
+	}))
+	defer srv.Close()
+
+	c := NewClientWith("bad-token", srv.Client(), srv.URL)
+	_, err := c.ListActiveTasks("123")
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+}
+
+func TestCloseTask(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/tasks/42/close" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := NewClientWith("test-token", srv.Client(), srv.URL)
+	if err := c.CloseTask("42"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestListProjects(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/projects" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[{"id":"100","name":"Inbox"},{"id":"200","name":"Work"}]`)
+	}))
+	defer srv.Close()
+
+	c := NewClientWith("test-token", srv.Client(), srv.URL)
+	projects, err := c.ListProjects()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(projects) != 2 {
+		t.Fatalf("expected 2 projects, got %d", len(projects))
+	}
+	if projects[1].Name != "Work" {
+		t.Errorf("expected 'Work', got %q", projects[1].Name)
+	}
+}

--- a/internal/todoist/model.go
+++ b/internal/todoist/model.go
@@ -1,0 +1,29 @@
+package todoist
+
+// Task represents a task from the Todoist REST API v2.
+type Task struct {
+	ID          string   `json:"id"`
+	Content     string   `json:"content"`
+	Description string   `json:"description"`
+	ProjectID   string   `json:"project_id"`
+	SectionID   string   `json:"section_id"`
+	Priority    int      `json:"priority"` // 1=normal … 4=urgent (inverted from UI)
+	Labels      []string `json:"labels"`
+	Due         *DueDate `json:"due"`
+	IsCompleted bool     `json:"is_completed"`
+	CreatedAt   string   `json:"created_at"`
+	URL         string   `json:"url"`
+}
+
+// DueDate holds the due-date info for a Todoist task.
+type DueDate struct {
+	Date        string `json:"date"`
+	IsRecurring bool   `json:"is_recurring"`
+	String      string `json:"string"`
+}
+
+// Project represents a Todoist project (subset of API fields).
+type Project struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}


### PR DESCRIPTION
## Motivation

Todoist serves as an external task inbox. This adds programmatic integration to pull tasks from a configured Todoist project into Synapse, and close them in Todoist when Synapse tasks reach done status.

## Implementation information

- New `internal/todoist/` package: HTTP client wrapping Todoist REST API v2 (`ListActiveTasks`, `CloseTask`, `ListProjects`) with `HTTPDoer` interface for testability
- `TodoistHandler` in `app_todoist.go`: poll-based sync loop (mirrors `prPollLoop` pattern) that imports new non-recurring tasks and syncs completions back
- Task model gets `todoist_id` field to track the link and prevent duplicate imports
- `TodoistConfig` in config with `SYNAPSE_TODOIST_TOKEN` env override, enable/disable toggle, project ID filter, configurable poll interval
- Settings UI section for Todoist config (toggle, API token, project ID, poll interval)
- Field mapping: Content→Title, Description→Body, Priority→tags (p1/p2/p3), Labels→Tags
- Recurring tasks are skipped per user preference
- Bound methods: `SyncTodoist()` (manual trigger), `GetTodoistProjects()` (for settings), `TodoistEnabled()`

> Changelog: feat(todoist): add task sync integration