### PR TITLE
feat(ui): enable macOS fullscreen support

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,9 +89,9 @@ func main() {
 				FullscreenEnabled: mac.Enabled,
 			},
 		},
-		OnStartup:        app.startup,
-		OnShutdown:       app.shutdown,
-		Menu:             appMenu,
+		OnStartup:  app.startup,
+		OnShutdown: app.shutdown,
+		Menu:       appMenu,
 		Bind: []any{
 			app,
 		},


### PR DESCRIPTION
## Motivation

Users couldn't use Synapse in macOS native fullscreen mode (green button / Ctrl+Cmd+F).

## Implementation information

Two changes to `main.go`:
- Add `menu.WindowMenu()` to the app menu bar — provides the standard macOS Window menu with Minimize, Zoom, and Full Screen (Ctrl+Cmd+F)
- Add `Mac.Preferences.FullscreenEnabled: mac.Enabled` to Wails options — allows the WebView to display content in fullscreen

The Wails framework already wires `NSWindowCollectionBehaviorFullScreenPrimary` when entering fullscreen; these changes unlock the entry points.

> Changelog: feat(ui): enable macOS fullscreen support