### PR TITLE
feat(github): use issue body as task desc

### DIFF
--- a/app_issues.go
+++ b/app_issues.go
@@ -60,7 +60,7 @@ func (a *App) syncIssuesToTasks(issues []github.Issue) {
 			continue
 		}
 
-		t, err := a.tasks.Create(issue.Title, issue.URL, "headless")
+		t, err := a.tasks.Create(issue.Title, issue.Body, "headless")
 		if err != nil {
 			a.logger.Error("issue-sync.create", "issue", issue.URL, "err", err)
 			continue

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -659,6 +659,7 @@ const issueQuery = `query($q: String!) {
       ... on Issue {
         number
         title
+        body
         url
         state
         createdAt
@@ -685,6 +686,7 @@ type gqlIssueResponse struct {
 type gqlIssue struct {
 	Number    int    `json:"number"`
 	Title     string `json:"title"`
+	Body      string `json:"body"`
 	URL       string `json:"url"`
 	State     string `json:"state"`
 	CreatedAt string `json:"createdAt"`
@@ -748,6 +750,7 @@ func convertIssues(nodes []gqlIssue) []Issue {
 		issues = append(issues, Issue{
 			Number:     n.Number,
 			Title:      n.Title,
+			Body:       n.Body,
 			URL:        n.URL,
 			Repository: n.Repository.NameWithOwner,
 			RepoName:   n.Repository.Name,

--- a/internal/github/model.go
+++ b/internal/github/model.go
@@ -43,6 +43,7 @@ type RenovatePR struct {
 type Issue struct {
 	Number     int      `json:"number"`
 	Title      string   `json:"title"`
+	Body       string   `json:"body"`
 	URL        string   `json:"url"`
 	Repository string   `json:"repository"`
 	RepoName   string   `json:"repoName"`


### PR DESCRIPTION
## Motivation

When tasks are created from GitHub issues (auto-sync), the task body was set to the issue URL instead of the actual issue description. This made tasks lack context.

## Implementation information

- Added `body` field to the GraphQL issue query
- Added `Body` field to `Issue` model and `gqlIssue` struct
- Pass `issue.Body` instead of `issue.URL` when creating tasks in `syncIssuesToTasks`