### PR TITLE
fix(tasks): post-triage dispatch and URL titles

### DIFF
--- a/app_issues.go
+++ b/app_issues.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/Automaat/synapse/internal/github"
@@ -48,15 +49,41 @@ func (a *App) syncIssuesToTasks(issues []github.Issue) {
 	}
 
 	issueURLs := make(map[string]struct{})
+	// Map URL-titled tasks so we can enrich them instead of creating duplicates.
+	urlTitleTasks := make(map[string]string) // issue URL → task ID
 	for i := range tasks {
 		if tasks[i].Issue != "" {
 			issueURLs[tasks[i].Issue] = struct{}{}
+		}
+		if strings.HasPrefix(tasks[i].Title, "https://github.com/") {
+			urlTitleTasks[tasks[i].Title] = tasks[i].ID
 		}
 	}
 
 	for i := range issues {
 		issue := &issues[i]
 		if _, exists := issueURLs[issue.URL]; exists {
+			continue
+		}
+
+		// Task already exists with the issue URL as title (manually created).
+		// Enrich it with the real title and link instead of creating a duplicate.
+		if taskID, exists := urlTitleTasks[issue.URL]; exists {
+			updates := map[string]any{
+				"title": issue.Title,
+				"issue": issue.URL,
+			}
+			if issue.Body != "" {
+				updates["body"] = issue.Body
+			}
+			if _, projErr := a.projects.Get(issue.Repository); projErr == nil {
+				updates["project_id"] = issue.Repository
+			}
+			if _, err := a.tasks.Update(taskID, updates); err != nil {
+				a.logger.Error("issue-sync.enrich", "task_id", taskID, "err", err)
+			} else {
+				a.logger.Info("issue-sync.enriched", "task_id", taskID, "issue", issue.URL, "title", issue.Title)
+			}
 			continue
 		}
 

--- a/app_planning.go
+++ b/app_planning.go
@@ -66,7 +66,7 @@ func (w *TaskWorkflow) TriageTask(id string) error {
 	}
 
 	dir := config.HomeDir()
-	prompt := fmt.Sprintf("Triage task %s using /synapse-triage skill. Get the task with synapse-cli, analyze it, assign tags, mode, and update status.", t.ID)
+	prompt := fmt.Sprintf("Triage task %s using /synapse-triage skill. Get the task with synapse-cli, analyze it, assign tags, mode, and update status. IMPORTANT: if the task title is a URL (e.g. a GitHub issue/PR link), you MUST fetch the real title from that URL using gh and update the task title to a human-readable summary. Never leave a raw URL as the task title.", t.ID)
 
 	w.logger.Info("triage.start", "task_id", t.ID, "title", t.Title, "dir", dir)
 
@@ -89,6 +89,45 @@ func (w *TaskWorkflow) TriageTask(id string) error {
 	}
 	w.logger.Info("triage.agent_started", "task_id", t.ID, "agent_id", ag.ID)
 	return nil
+}
+
+// postTriage re-reads the task after triage completes and triggers the
+// appropriate next step based on the status the triage agent set.
+// The triage agent updates status via the CLI (store-level), which bypasses
+// UpdateTask's auto-dispatch logic, so we replicate it here.
+func (w *TaskWorkflow) postTriage(taskID string) {
+	t, err := w.tasks.Get(taskID)
+	if err != nil {
+		w.logger.Error("post-triage.get", "task_id", taskID, "err", err)
+		return
+	}
+
+	switch t.Status {
+	case task.StatusTodo:
+		if slices.Contains(t.Tags, "review") {
+			return
+		}
+		if _, err := w.tasks.Update(taskID, map[string]any{"status": string(task.StatusInProgress)}); err != nil {
+			w.logger.Error("post-triage.start", "task_id", taskID, "err", err)
+			return
+		}
+		go func() {
+			if _, err := w.agentOrch.StartAgent(taskID, t.AgentMode, "Implement this task. When done, create a draft PR with `gh pr create --draft`."); err != nil {
+				w.logger.Error("post-triage.implement", "task_id", taskID, "err", err)
+			}
+		}()
+
+	case task.StatusPlanning:
+		go func() {
+			if err := w.PlanTask(taskID); err != nil {
+				w.logger.Error("post-triage.plan", "task_id", taskID, "err", err)
+			}
+		}()
+
+	case task.StatusNew, task.StatusInProgress, task.StatusInReview,
+		task.StatusPlanReview, task.StatusHumanRequired, task.StatusDone:
+		w.logger.Debug("post-triage.noop", "task_id", taskID, "status", string(t.Status))
+	}
 }
 
 func (w *TaskWorkflow) PlanTask(id string) error {
@@ -382,8 +421,9 @@ func (w *TaskWorkflow) handleAgentComplete(ag *agent.Agent) {
 
 	switch role {
 	case agent.RoleTriage:
-		w.logger.Info("eval.skip", "agent_id", ag.ID, "name", ag.Name, "reason", "system_agent")
+		w.logger.Info("triage.complete", "agent_id", ag.ID, "name", ag.Name)
 		w.logAudit(audit.EventTriageCompleted, ag.TaskID, ag.ID, agentData)
+		w.postTriage(ag.TaskID)
 
 	case agent.RoleEval:
 		w.completeEvalAgent(ag, agentData)


### PR DESCRIPTION
## Motivation

Two bugs in task lifecycle after triage:
1. Implementation agents never start after triage — triage agent updates status via CLI (store-level), bypassing `UpdateTask`'s auto-dispatch. `handleAgentComplete` for triage did nothing.
2. Manually-created tasks with GitHub URL as title stay with URL titles — triage agent inconsistently enriches them, and `syncIssuesToTasks` creates duplicates instead of enriching existing ones.

## Implementation information

**`app_planning.go`:**
- `postTriage()` — new method called after triage completes. Re-reads task status and dispatches: `todo` → `in-progress` + start agent, `planning` → start plan agent.
- Triage prompt now explicitly instructs agent to replace URL titles with real issue titles via `gh`.

**`app_issues.go`:**
- `syncIssuesToTasks` now detects tasks whose title is a GitHub URL matching an incoming issue. Enriches them (sets real title, body, issue link, project) instead of creating a duplicate task.