### PR TITLE
fix(task): guard type assertion in lockFor

### DIFF
--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -140,6 +140,7 @@ func parseStreamEvent(line []byte) (StreamEvent, error) {
 		return StreamEvent{}, fmt.Errorf("unmarshal stream event: %w", err)
 	}
 
+	// ok intentionally discarded: missing/non-string type yields "" which is handled by the default case.
 	eventType, _ := raw["type"].(string)
 	event := StreamEvent{
 		Type:    eventType,
@@ -148,6 +149,7 @@ func parseStreamEvent(line []byte) (StreamEvent, error) {
 
 	switch eventType {
 	case "system":
+		// ok intentionally discarded: zero-value "" is safe when session_id is absent.
 		event.SessionID, _ = raw["session_id"].(string)
 
 	case "assistant":
@@ -157,6 +159,7 @@ func parseStreamEvent(line []byte) (StreamEvent, error) {
 		event.Content = extractToolResult(raw)
 
 	case "result":
+		// ok intentionally discarded on string assertions: zero-value "" is acceptable when field is absent.
 		event.Content, _ = raw["result"].(string)
 		event.SessionID, _ = raw["session_id"].(string)
 		if cost, ok := raw["total_cost_usd"].(float64); ok {

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -58,7 +58,10 @@ func (m *Manager) Comments() *CommentStore { return m.store.Comments() }
 
 func (m *Manager) lockFor(id string) *sync.Mutex {
 	existing, _ := m.locks.LoadOrStore(id, &sync.Mutex{})
-	mu, _ := existing.(*sync.Mutex)
+	mu, ok := existing.(*sync.Mutex)
+	if !ok {
+		mu = &sync.Mutex{}
+	}
 	return mu
 }
 

--- a/internal/task/manager_test.go
+++ b/internal/task/manager_test.go
@@ -269,6 +269,24 @@ func TestManagerConcurrentDifferentIDsParallel(t *testing.T) {
 	}
 }
 
+func TestLockForTypeMismatchNoPanic(t *testing.T) {
+	t.Parallel()
+	m, _ := newTestManager(t)
+
+	// Manually store a non-*sync.Mutex value to simulate type mismatch.
+	m.locks.Store("bad-id", "not-a-mutex")
+
+	// Must not panic; returned mutex must be usable.
+	mu := m.lockFor("bad-id")
+	if mu == nil {
+		t.Fatal("lockFor returned nil on type mismatch")
+	}
+	func() {
+		mu.Lock()
+		defer mu.Unlock()
+	}()
+}
+
 func TestNoopEmitter(t *testing.T) {
 	t.Parallel()
 	m := NewManager(nil, nil)


### PR DESCRIPTION
## Motivation

`lockFor()` discarded the `ok` value from the type assertion on the `sync.Map` value. If anything ever stores a non-`*sync.Mutex` value under the same key, `mu` is nil and the next `mu.Lock()` panics.

## Implementation information

- `internal/task/manager.go`: check `ok`; allocate fresh mutex on mismatch so the caller always gets a usable lock.
- `internal/task/manager_test.go`: `TestLockForTypeMismatchNoPanic` injects a wrong-type value and verifies no panic + mutex is usable.
- `internal/agent/runner_headless.go`: added comments on the intentional `ok`-discard string assertions — zero-value `""` is safe when the field is absent.

Closes #187

> Changelog: fix(task): guard type assertion in lockFor