### PR TITLE
fix(security): escape AppleScript injections

### DIFF
--- a/app_agents.go
+++ b/app_agents.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Automaat/synapse/internal/agent"
 	"github.com/Automaat/synapse/internal/audit"
 	"github.com/Automaat/synapse/internal/config"
+	"github.com/Automaat/synapse/internal/executil"
 	"github.com/Automaat/synapse/internal/project"
 	"github.com/Automaat/synapse/internal/task"
 	"github.com/Automaat/synapse/internal/tmux"
@@ -262,7 +263,7 @@ func openTmuxInGhostty(session, tabTitle string) error {
 	else
 		new window with configuration cfg
 	end if
-end tell`, label, session)
+end tell`, executil.EscapeAppleScript(label), executil.EscapeAppleScript(session))
 	out, err := exec.Command("osascript", "-e", script).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("osascript: %w: %s", err, string(out))

--- a/app_projects.go
+++ b/app_projects.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 
+	"github.com/Automaat/synapse/internal/executil"
 	"github.com/Automaat/synapse/internal/project"
 )
 
@@ -83,7 +84,7 @@ func openDirInGhostty(dir string) error {
 	else
 		new window with configuration cfg
 	end if
-end tell`, dir)
+end tell`, executil.EscapeAppleScript(dir))
 	out, err := exec.Command("osascript", "-e", script).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("osascript: %w: %s", err, string(out))

--- a/internal/executil/executil.go
+++ b/internal/executil/executil.go
@@ -6,6 +6,14 @@ import (
 	"strings"
 )
 
+// EscapeAppleScript escapes a string for safe embedding inside an AppleScript
+// double-quoted string literal. It escapes backslashes first, then double quotes.
+func EscapeAppleScript(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return s
+}
+
 // Run executes a command in dir, returning a formatted error with stderr on failure.
 func Run(dir, name string, args ...string) error {
 	cmd := exec.Command(name, args...)

--- a/internal/executil/executil_test.go
+++ b/internal/executil/executil_test.go
@@ -1,0 +1,28 @@
+package executil
+
+import "testing"
+
+func TestEscapeAppleScript(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"clean path", "/home/user/project", "/home/user/project"},
+		{"double quote", `say "hello"`, `say \"hello\"`},
+		{"backslash", `foo\bar`, `foo\\bar`},
+		{"backslash then quote", `foo\"bar`, `foo\\\"bar`},
+		{"shell metachar semicolon", "foo; rm -rf /", "foo; rm -rf /"},
+		{"newline", "foo\nbar", "foo\nbar"},
+		{"single quote passthrough", "it's fine", "it's fine"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EscapeAppleScript(tt.input)
+			if got != tt.want {
+				t.Errorf("EscapeAppleScript(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Directory names and tmux session names were interpolated directly into AppleScript double-quoted strings via `fmt.Sprintf`, allowing crafted input to break out and execute arbitrary AppleScript or shell commands (CWE-78, OWASP Command Injection).

Affected: `openDirInGhostty` (app_projects.go:80) and `openTmuxInGhostty` (app_agents.go:259).

## Implementation information

Added `EscapeAppleScript(s string) string` to `internal/executil` — escapes backslashes then double quotes, the two characters that can terminate an AppleScript string literal. Applied at all interpolation sites in both Ghostty launcher functions.

Table-driven unit tests cover clean paths, double quotes, backslashes, combined sequences, and passthrough characters (semicolon, newline, single quote).

## Supporting documentation

Closes #186