### PR TITLE
fix(planning): prevent duplicate plan agents

### DIFF
--- a/app_planning.go
+++ b/app_planning.go
@@ -30,6 +30,7 @@ type TaskWorkflow struct {
 	notifier      *notification.Emitter
 	agentOrch     *AgentOrchestrator
 	evalsInFlight sync.Map // taskID -> struct{}
+	plansInFlight sync.Map // taskID -> struct{}
 }
 
 func newTaskWorkflow(
@@ -136,6 +137,12 @@ func (w *TaskWorkflow) postTriage(taskID string) {
 }
 
 func (w *TaskWorkflow) PlanTask(id string) error {
+	if _, loaded := w.plansInFlight.LoadOrStore(id, struct{}{}); loaded {
+		w.logger.Info("plan.skip", "task_id", id, "reason", "plan_in_flight")
+		return nil
+	}
+	defer w.plansInFlight.Delete(id)
+
 	t, err := w.tasks.Get(id)
 	if err != nil {
 		return err
@@ -199,7 +206,7 @@ func (w *TaskWorkflow) ApprovePlan(id string) (task.Task, error) {
 	}
 	w.logger.Info("plan.approve", "task_id", id, "title", t.Title)
 	w.logAudit(audit.EventPlanApproved, id, "", map[string]any{"title": t.Title})
-	if planAg := w.agents.FindRunningAgentForTask(id, agent.RolePlan); planAg != nil {
+	for _, planAg := range w.agents.FindAllRunningAgentsForTask(id, agent.RolePlan) {
 		if stopErr := w.agents.StopAgent(planAg.ID); stopErr != nil {
 			w.logger.Warn("plan.approve.stop-agent", "task_id", id, "agent_id", planAg.ID, "err", stopErr)
 		}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -259,6 +259,24 @@ func (m *Manager) FindRunningAgentForTask(taskID string, role Role) *Agent {
 	return nil
 }
 
+// FindAllRunningAgentsForTask returns all running agents for the given task
+// matching the provided role.
+func (m *Manager) FindAllRunningAgentsForTask(taskID string, role Role) []*Agent {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var result []*Agent
+	for _, a := range m.agents {
+		if a.TaskID != taskID || a.State != StateRunning {
+			continue
+		}
+		if RoleFromName(a.Name) != role {
+			continue
+		}
+		result = append(result, a)
+	}
+	return result
+}
+
 func (m *Manager) StopAgent(agentID string) error {
 	m.mu.Lock()
 	a, ok := m.agents[agentID]


### PR DESCRIPTION
## Motivation

Race condition between `postTriage` and `maybeResumePlanning` spawned two plan agents for the same task. When the plan was approved, `ApprovePlan` only stopped one agent (via `FindRunningAgentForTask` which returns first match), so `HasRunningAgentForTask` still returned `true` — blocking auto-implement dispatch.

## Implementation information

- Add `plansInFlight` sync.Map guard in `PlanTask` (same pattern as existing `evalsInFlight`) to prevent concurrent planning for the same task
- `ApprovePlan` now uses `FindAllRunningAgentsForTask` to stop **all** plan agents, not just the first found
- Added `FindAllRunningAgentsForTask` method to agent.Manager

> Changelog: fix(planning): prevent duplicate plan agents