### PR TITLE
fix(ui): optimistic review comments

### DIFF
--- a/frontend/src/stores/comments.svelte.ts
+++ b/frontend/src/stores/comments.svelte.ts
@@ -19,28 +19,70 @@ class CommentStore {
   }
 
   async add(taskID: string, line: number, body: string): Promise<task.ReviewComment> {
-    const comment = await AddReviewComment(taskID, line, body)
+    // Optimistic placeholder so UI updates instantly
+    const optimistic = task.ReviewComment.createFrom({
+      id: crypto.randomUUID().slice(0, 8),
+      line,
+      body,
+      resolved: false,
+      createdAt: new Date().toISOString(),
+    })
     const existing = this.byTask.get(taskID) ?? []
-    this.byTask.set(taskID, [...existing, comment])
-    return comment
+    this.byTask.set(taskID, [...existing, optimistic])
+
+    try {
+      const persisted = await AddReviewComment(taskID, line, body)
+      // Replace optimistic with real server-assigned comment
+      const current = this.byTask.get(taskID) ?? []
+      this.byTask.set(
+        taskID,
+        current.map((c) => (c.id === optimistic.id ? persisted : c)),
+      )
+      return persisted
+    } catch (e) {
+      // Rollback on failure
+      const current = this.byTask.get(taskID) ?? []
+      this.byTask.set(
+        taskID,
+        current.filter((c) => c.id !== optimistic.id),
+      )
+      throw e
+    }
   }
 
   async resolve(taskID: string, commentID: string): Promise<void> {
-    await ResolveReviewComment(taskID, commentID)
+    // Optimistic update
     const existing = this.byTask.get(taskID) ?? []
     this.byTask.set(
       taskID,
       existing.map((c) => (c.id === commentID ? task.ReviewComment.createFrom({ ...c, resolved: true }) : c)),
     )
+    try {
+      await ResolveReviewComment(taskID, commentID)
+    } catch (e) {
+      // Rollback
+      this.byTask.set(
+        taskID,
+        existing.map((c) => (c.id === commentID ? task.ReviewComment.createFrom({ ...c, resolved: false }) : c)),
+      )
+      throw e
+    }
   }
 
   async remove(taskID: string, commentID: string): Promise<void> {
-    await DeleteReviewComment(taskID, commentID)
+    // Optimistic update
     const existing = this.byTask.get(taskID) ?? []
     this.byTask.set(
       taskID,
       existing.filter((c) => c.id !== commentID),
     )
+    try {
+      await DeleteReviewComment(taskID, commentID)
+    } catch (e) {
+      // Rollback
+      this.byTask.set(taskID, existing)
+      throw e
+    }
   }
 
   byLine(taskID: string, line: number): task.ReviewComment[] {


### PR DESCRIPTION
## Motivation

Adding/resolving/deleting review comments in the plan review UI had noticeable lag because the store awaited the full Wails IPC round-trip (Go JSON file I/O) before updating reactive state.

## Implementation information

Made all three CommentStore mutation methods optimistic:
- **add**: inserts a temporary `ReviewComment` immediately, swaps with server-assigned one after persist
- **resolve**: flips `resolved` flag in UI first, rolls back on error
- **remove**: filters comment from list instantly, restores on error

All three roll back to previous state if the backend call fails.