### PR TITLE
feat(issues): auto-create tasks from 'synapse' labeled issues

### DIFF
--- a/app_issues.go
+++ b/app_issues.go
@@ -6,10 +6,14 @@ import (
 	"time"
 
 	"github.com/Automaat/synapse/internal/github"
+	"github.com/Automaat/synapse/internal/project"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
 const issuesPollInterval = 5 * time.Minute
+
+// synapseIssueLabel is the GitHub label that triggers auto-creation of Synapse tasks.
+const synapseIssueLabel = "synapse"
 
 // FetchAssignedIssues is exposed as a Wails-bound method for manual refresh.
 func (a *App) FetchAssignedIssues() ([]github.Issue, error) {
@@ -36,9 +40,38 @@ func (a *App) issuesPollLoop(ctx context.Context) {
 			a.logger.Debug("issues.poll", "count", len(issues))
 
 			a.syncIssuesToTasks(issues)
+			a.syncLabeledIssuesToTasks()
 			timer.Reset(issuesPollInterval)
 		}
 	}
+}
+
+// syncLabeledIssuesToTasks fetches issues labeled 'synapse' across all registered
+// pet projects and creates tasks for any not yet tracked.
+func (a *App) syncLabeledIssuesToTasks() {
+	projects, err := a.projects.List()
+	if err != nil {
+		a.logger.Error("labeled-issues.list-projects", "err", err)
+		return
+	}
+
+	var repos []string
+	for i := range projects {
+		if projects[i].Type == project.ProjectTypePet {
+			repos = append(repos, projects[i].ID)
+		}
+	}
+	if len(repos) == 0 {
+		return
+	}
+
+	labeled, err := github.FetchLabeledIssuesForRepos(repos, synapseIssueLabel)
+	if err != nil {
+		a.logger.Warn("labeled-issues.fetch", "err", err)
+		return
+	}
+	a.logger.Debug("labeled-issues.poll", "count", len(labeled))
+	a.syncIssuesToTasks(labeled)
 }
 
 func (a *App) syncIssuesToTasks(issues []github.Issue) {
@@ -100,6 +133,10 @@ func (a *App) syncIssuesToTasks(issues []github.Issue) {
 
 		if _, projErr := a.projects.Get(issue.Repository); projErr == nil {
 			updates["project_id"] = issue.Repository
+		}
+
+		if len(issue.Labels) > 0 {
+			updates["tags"] = issue.Labels
 		}
 
 		if _, err := a.tasks.Update(t.ID, updates); err != nil {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -714,6 +714,23 @@ func fetchAssignedIssuesWith(e execer) ([]Issue, error) {
 	return searchIssuesWith(e, "is:issue is:open assignee:@me sort:updated-desc")
 }
 
+// FetchLabeledIssuesForRepos returns open issues with the given label across the specified repos.
+func FetchLabeledIssuesForRepos(repos []string, label string) ([]Issue, error) {
+	return fetchLabeledIssuesForReposWith(defaultExecer, repos, label)
+}
+
+func fetchLabeledIssuesForReposWith(e execer, repos []string, label string) ([]Issue, error) {
+	if len(repos) == 0 {
+		return nil, nil
+	}
+	parts := make([]string, len(repos))
+	for i, r := range repos {
+		parts[i] = "repo:" + r
+	}
+	query := fmt.Sprintf("is:issue is:open label:%s %s sort:updated-desc", label, strings.Join(parts, " "))
+	return searchIssuesWith(e, query)
+}
+
 func searchIssuesWith(e execer, query string) ([]Issue, error) {
 	out, err := e.run("api", "graphql",
 		"-f", "query="+issueQuery,


### PR DESCRIPTION
## Motivation

Watch registered pet project GitHub repos for issues labeled 'synapse' and automatically create Synapse tasks when found. Removes the manual step of creating a task for each issue you want Synapse to track.

## Implementation information

Extended the existing `issuesPollLoop` (5 min interval) to call `syncLabeledIssuesToTasks` after the assigned-issues sync. That method:

1. Lists all registered pet projects
2. Calls `FetchLabeledIssuesForRepos` (new) which queries GitHub GraphQL for `is:issue is:open label:synapse repo:owner/repo ...` across all repos in one request
3. Feeds results into the existing `syncIssuesToTasks` which handles deduplication by issue URL, URL-titled task enrichment, and project linking

Issue labels are also propagated as task tags on creation (labels are already available in the `Issue` struct).

No new polling loops, no new config — runs as part of the existing issues poll cycle.

> Changelog: feat(issues): auto-create tasks from 'synapse' labeled issues