### PR TITLE
refactor(frontend): remove as any casts in tests

### DIFF
--- a/frontend/src/components/TerminalView.test.ts
+++ b/frontend/src/components/TerminalView.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/svelte'
+import { agent } from '../../wailsjs/go/models.js'
 
 const mockCaptureAgentPane = vi.fn()
 const mockAttachAgent = vi.fn()
@@ -24,8 +25,8 @@ const { agentStore } = await import('../stores/agents.svelte.js')
 
 import TerminalView from './TerminalView.svelte'
 
-function makeAgent(overrides: Record<string, unknown> = {}) {
-  return {
+function makeAgent(overrides: Partial<agent.Agent> = {}): agent.Agent {
+  return agent.Agent.createFrom({
     id: 'agent-1',
     taskId: 'task-1',
     mode: 'interactive',
@@ -36,7 +37,7 @@ function makeAgent(overrides: Record<string, unknown> = {}) {
     startedAt: new Date().toISOString(),
     external: false,
     ...overrides,
-  }
+  })
 }
 
 describe('TerminalView', () => {
@@ -56,7 +57,7 @@ describe('TerminalView', () => {
 
   it('renders waiting message when no output', async () => {
     mockCaptureAgentPane.mockResolvedValue('')
-    agentStore.agents.set('agent-1', makeAgent() as any)
+    agentStore.agents.set('agent-1', makeAgent())
 
     render(TerminalView, { props: { agentId: 'agent-1' } })
 
@@ -66,7 +67,7 @@ describe('TerminalView', () => {
 
   it('displays captured pane output', async () => {
     mockCaptureAgentPane.mockResolvedValue('Hello world')
-    agentStore.agents.set('agent-1', makeAgent() as any)
+    agentStore.agents.set('agent-1', makeAgent())
 
     render(TerminalView, { props: { agentId: 'agent-1' } })
 
@@ -76,7 +77,7 @@ describe('TerminalView', () => {
 
   it('shows attach button when agent is running', async () => {
     mockCaptureAgentPane.mockResolvedValue('output')
-    agentStore.agents.set('agent-1', makeAgent({ state: 'running' }) as any)
+    agentStore.agents.set('agent-1', makeAgent({ state: 'running' }))
 
     render(TerminalView, { props: { agentId: 'agent-1' } })
 
@@ -86,7 +87,7 @@ describe('TerminalView', () => {
 
   it('hides attach button when agent is stopped', async () => {
     mockCaptureAgentPane.mockResolvedValue('output')
-    agentStore.agents.set('agent-1', makeAgent({ state: 'stopped' }) as any)
+    agentStore.agents.set('agent-1', makeAgent({ state: 'stopped' }))
 
     render(TerminalView, { props: { agentId: 'agent-1' } })
 
@@ -96,7 +97,7 @@ describe('TerminalView', () => {
 
   it('polls capture-pane on interval', async () => {
     mockCaptureAgentPane.mockResolvedValue('line1')
-    agentStore.agents.set('agent-1', makeAgent() as any)
+    agentStore.agents.set('agent-1', makeAgent())
 
     render(TerminalView, { props: { agentId: 'agent-1' } })
 
@@ -112,7 +113,7 @@ describe('TerminalView', () => {
 
   it('shows error on capture failure', async () => {
     mockCaptureAgentPane.mockRejectedValue(new Error('tmux not running'))
-    agentStore.agents.set('agent-1', makeAgent() as any)
+    agentStore.agents.set('agent-1', makeAgent())
 
     render(TerminalView, { props: { agentId: 'agent-1' } })
 
@@ -122,7 +123,7 @@ describe('TerminalView', () => {
 
   it('shows label text', async () => {
     mockCaptureAgentPane.mockResolvedValue('')
-    agentStore.agents.set('agent-1', makeAgent() as any)
+    agentStore.agents.set('agent-1', makeAgent())
 
     render(TerminalView, { props: { agentId: 'agent-1' } })
 

--- a/frontend/src/pages/AgentList.svelte.test.ts
+++ b/frontend/src/pages/AgentList.svelte.test.ts
@@ -2,14 +2,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/svelte'
 
 const mockByState = vi.fn()
+const mockAgentStoreData = {
+  loading: false,
+  error: '',
+  byState: (...args: unknown[]) => mockByState(...args),
+  list: [],
+}
 
 vi.mock('../stores/agents.svelte.js', () => ({
-  agentStore: {
-    loading: false,
-    error: '',
-    byState: (...args: unknown[]) => mockByState(...args),
-    list: [],
-  },
+  agentStore: mockAgentStoreData,
 }))
 
 vi.mock('@skeletonlabs/skeleton-svelte', () => ({
@@ -23,7 +24,6 @@ vi.mock('@skeletonlabs/skeleton-svelte', () => ({
   }),
 }))
 
-const { agentStore } = await import('../stores/agents.svelte.js')
 const AgentList = (await import('./AgentList.svelte')).default
 
 function makeAgent(overrides: Record<string, unknown> = {}) {
@@ -48,8 +48,8 @@ function makeAgent(overrides: Record<string, unknown> = {}) {
 describe('AgentList', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    ;(agentStore as any).loading = false
-    ;(agentStore as any).error = ''
+    mockAgentStoreData.loading = false
+    mockAgentStoreData.error = ''
     mockByState.mockReturnValue([])
   })
 
@@ -58,13 +58,13 @@ describe('AgentList', () => {
   })
 
   it('shows loading message when loading', () => {
-    ;(agentStore as any).loading = true
+    mockAgentStoreData.loading = true
     render(AgentList, { props: { onselect: vi.fn() } })
     expect(screen.getByText('Loading agents...')).toBeDefined()
   })
 
   it('shows error message when error is set', () => {
-    ;(agentStore as any).error = 'Failed to fetch agents'
+    mockAgentStoreData.error = 'Failed to fetch agents'
     render(AgentList, { props: { onselect: vi.fn() } })
     expect(screen.getByText('Failed to fetch agents')).toBeDefined()
   })

--- a/frontend/src/pages/Dashboard.test.ts
+++ b/frontend/src/pages/Dashboard.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/svelte'
+import { agent, task } from '../../wailsjs/go/models.js'
 
 vi.mock('../../wailsjs/go/main/App.js', () => ({
   ListAgents: vi.fn().mockResolvedValue([]),
@@ -26,8 +27,8 @@ const { agentStore } = await import('../stores/agents.svelte.js')
 
 import Dashboard from './Dashboard.svelte'
 
-function makeAgent(overrides: Record<string, unknown> = {}) {
-  return {
+function makeAgent(overrides: Partial<agent.Agent> = {}): agent.Agent {
+  return agent.Agent.createFrom({
     id: 'a1',
     taskId: 'task-1',
     mode: 'headless',
@@ -38,23 +39,34 @@ function makeAgent(overrides: Record<string, unknown> = {}) {
     startedAt: new Date().toISOString(),
     external: false,
     ...overrides,
-  }
+  })
 }
 
-function makeTask(overrides: Record<string, unknown> = {}) {
-  return {
+function makeTask(overrides: Partial<task.Task> = {}): task.Task {
+  return task.Task.createFrom({
     id: 't1',
+    slug: '',
     title: 'Test Task',
     status: 'todo',
+    taskType: '',
     agentMode: 'headless',
     allowedTools: [],
     tags: [],
+    projectId: '',
+    branch: '',
+    prNumber: 0,
+    issue: '',
+    statusReason: '',
+    reviewed: false,
+    runRole: '',
+    todoistId: '',
+    agentRuns: [],
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     body: '',
     filePath: '',
     ...overrides,
-  }
+  })
 }
 
 describe('Dashboard', () => {
@@ -78,11 +90,11 @@ describe('Dashboard', () => {
   })
 
   it('shows stat cards with correct counts', () => {
-    agentStore.agents.set('a1', makeAgent({ id: 'a1', state: 'running' }) as any)
-    agentStore.agents.set('a2', makeAgent({ id: 'a2', state: 'paused' }) as any)
-    agentStore.agents.set('a3', makeAgent({ id: 'a3', state: 'stopped' }) as any)
-    taskStore.tasks.set('t1', makeTask({ id: 't1', status: 'todo' }) as any)
-    taskStore.tasks.set('t2', makeTask({ id: 't2', status: 'done' }) as any)
+    agentStore.agents.set('a1', makeAgent({ id: 'a1', state: 'running' }))
+    agentStore.agents.set('a2', makeAgent({ id: 'a2', state: 'paused' }))
+    agentStore.agents.set('a3', makeAgent({ id: 'a3', state: 'stopped' }))
+    taskStore.tasks.set('t1', makeTask({ id: 't1', status: 'todo' }))
+    taskStore.tasks.set('t2', makeTask({ id: 't2', status: 'done' }))
 
     render(Dashboard, { props: { onviewagent: vi.fn() } })
 
@@ -93,8 +105,8 @@ describe('Dashboard', () => {
   })
 
   it('shows total cost rounded to 2 decimals', () => {
-    agentStore.agents.set('a1', makeAgent({ id: 'a1', costUsd: 1.555 }) as any)
-    agentStore.agents.set('a2', makeAgent({ id: 'a2', costUsd: 2.445 }) as any)
+    agentStore.agents.set('a1', makeAgent({ id: 'a1', costUsd: 1.555 }))
+    agentStore.agents.set('a2', makeAgent({ id: 'a2', costUsd: 2.445 }))
 
     render(Dashboard, { props: { onviewagent: vi.fn() } })
 
@@ -102,9 +114,9 @@ describe('Dashboard', () => {
   })
 
   it('shows task status breakdown', () => {
-    taskStore.tasks.set('t1', makeTask({ id: 't1', status: 'todo' }) as any)
-    taskStore.tasks.set('t2', makeTask({ id: 't2', status: 'in-progress' }) as any)
-    taskStore.tasks.set('t3', makeTask({ id: 't3', status: 'done' }) as any)
+    taskStore.tasks.set('t1', makeTask({ id: 't1', status: 'todo' }))
+    taskStore.tasks.set('t2', makeTask({ id: 't2', status: 'in-progress' }))
+    taskStore.tasks.set('t3', makeTask({ id: 't3', status: 'done' }))
 
     render(Dashboard, { props: { onviewagent: vi.fn() } })
 
@@ -112,8 +124,8 @@ describe('Dashboard', () => {
   })
 
   it('shows active agents section when running/paused agents exist', () => {
-    agentStore.agents.set('a1', makeAgent({ id: 'a1', state: 'running' }) as any)
-    agentStore.agents.set('a2', makeAgent({ id: 'a2', state: 'paused' }) as any)
+    agentStore.agents.set('a1', makeAgent({ id: 'a1', state: 'running' }))
+    agentStore.agents.set('a2', makeAgent({ id: 'a2', state: 'paused' }))
 
     render(Dashboard, { props: { onviewagent: vi.fn() } })
 
@@ -121,7 +133,7 @@ describe('Dashboard', () => {
   })
 
   it('hides active agents section when none running/paused', () => {
-    agentStore.agents.set('a1', makeAgent({ id: 'a1', state: 'stopped' }) as any)
+    agentStore.agents.set('a1', makeAgent({ id: 'a1', state: 'stopped' }))
 
     render(Dashboard, { props: { onviewagent: vi.fn() } })
 

--- a/frontend/src/pages/GitHub.svelte.test.ts
+++ b/frontend/src/pages/GitHub.svelte.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
+import type { github } from '../../wailsjs/go/models.js'
 
 const mockLoad = vi.fn()
 const mockStartPolling = vi.fn()
@@ -8,8 +9,8 @@ const mockStopPolling = vi.fn()
 const mockReviewStore = {
   loading: false,
   error: '',
-  reviewRequested: [] as any[],
-  createdByMe: [] as any[],
+  reviewRequested: [] as github.PullRequest[],
+  createdByMe: [] as github.PullRequest[],
   get totalCount() {
     return this.reviewRequested.length + this.createdByMe.length
   },
@@ -20,7 +21,7 @@ const mockReviewStore = {
 
 const mockRenovateLoad = vi.fn()
 const mockRenovateStore = {
-  prs: [] as any[],
+  prs: [] as github.RenovatePR[],
   loading: false,
   error: '',
   get count() {
@@ -48,7 +49,7 @@ vi.mock('../stores/renovate.svelte.js', () => ({
 }))
 
 const mockIssueStore = {
-  issues: [] as any[],
+  issues: [] as github.Issue[],
   loading: false,
   error: '',
   get count() {

--- a/frontend/src/pages/ProjectDetail.svelte
+++ b/frontend/src/pages/ProjectDetail.svelte
@@ -46,7 +46,7 @@
     BOARD_COLUMNS.map(col => ({
       ...col,
       tasks: col.includes.length > 0
-        ? projectTasks.filter(t => col.includes.includes(t.status as any))
+        ? projectTasks.filter(t => (col.includes as string[]).includes(t.status))
         : projectTasks.filter(t => t.status === col.status),
     }))
   )

--- a/frontend/src/pages/Stats.svelte.test.ts
+++ b/frontend/src/pages/Stats.svelte.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/svelte'
+import { stats } from '../../wailsjs/go/models.js'
 
 const mockLoad = vi.fn()
 
 const mockStatsStore = {
-  data: null as any,
+  data: null as stats.StatsResponse | null,
   loading: false,
   error: '',
   load: (...args: unknown[]) => mockLoad(...args),
@@ -16,21 +17,22 @@ vi.mock('../stores/stats.svelte.js', () => ({
 
 const Stats = (await import('./Stats.svelte')).default
 
-function makeSummary(overrides: Record<string, unknown> = {}) {
-  return {
+function makeSummary(overrides: Partial<stats.Summary> = {}): stats.Summary {
+  return stats.Summary.createFrom({
     totalCostUsd: 1.5,
     totalRuns: 10,
     avgCostPerRun: 0.15,
+    avgDurationS: 360,
     totalDurationS: 3600,
     totalInputTokens: 5000,
     totalOutputTokens: 2000,
     ...overrides,
-  }
+  })
 }
 
-function makeStatsData() {
+function makeStatsData(): stats.StatsResponse {
   const s = makeSummary()
-  return {
+  return stats.StatsResponse.createFrom({
     today: s,
     thisWeek: s,
     thisMonth: s,
@@ -40,7 +42,7 @@ function makeStatsData() {
     byMode: [],
     byModel: [],
     recentRuns: [],
-  }
+  })
 }
 
 describe('Stats', () => {

--- a/frontend/src/stores/agents.svelte.test.ts
+++ b/frontend/src/stores/agents.svelte.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { agent } from '../../wailsjs/go/models.js'
 
 // Mock Wails bindings
 const mockListAgents = vi.fn()
@@ -18,8 +19,8 @@ vi.mock('../../wailsjs/go/main/App.js', () => ({
 // Must import after mock setup
 const { agentStore } = await import('./agents.svelte.js')
 
-function makeAgent(overrides: Record<string, unknown> = {}) {
-  return {
+function makeAgent(overrides: Partial<agent.Agent> = {}): agent.Agent {
+  return agent.Agent.createFrom({
     id: 'test-1',
     taskId: 'task-1',
     mode: 'headless',
@@ -30,7 +31,7 @@ function makeAgent(overrides: Record<string, unknown> = {}) {
     startedAt: new Date().toISOString(),
     external: false,
     ...overrides,
-  }
+  })
 }
 
 describe('AgentStore', () => {
@@ -109,7 +110,7 @@ describe('AgentStore', () => {
 
   describe('stop', () => {
     it('calls StopAgent and updates state', async () => {
-      agentStore.agents.set('a1', makeAgent({ id: 'a1', state: 'running' }) as any)
+      agentStore.agents.set('a1', makeAgent({ id: 'a1', state: 'running' }))
       mockStopAgent.mockResolvedValue(undefined)
 
       await agentStore.stop('a1')
@@ -142,8 +143,8 @@ describe('AgentStore', () => {
 
   describe('appendEvent', () => {
     it('appends to existing output', () => {
-      agentStore.outputs.set('a1', [{ type: 'init', content: 'start' } as any])
-      agentStore.appendEvent('a1', { type: 'assistant', content: 'hi' } as any)
+      agentStore.outputs.set('a1', [{ type: 'init', content: 'start' }])
+      agentStore.appendEvent('a1', { type: 'assistant', content: 'hi' })
 
       const events = agentStore.outputs.get('a1')!
       expect(events).toHaveLength(2)
@@ -151,7 +152,7 @@ describe('AgentStore', () => {
     })
 
     it('creates new array if none exists', () => {
-      agentStore.appendEvent('a1', { type: 'init', content: '' } as any)
+      agentStore.appendEvent('a1', { type: 'init', content: '' })
 
       expect(agentStore.outputs.get('a1')).toHaveLength(1)
     })
@@ -160,10 +161,10 @@ describe('AgentStore', () => {
   describe('updateAgent', () => {
     it('updates agent in map', () => {
       const agent = makeAgent({ id: 'a1', state: 'running' })
-      agentStore.agents.set('a1', agent as any)
+      agentStore.agents.set('a1', agent)
 
       const updated = makeAgent({ id: 'a1', state: 'stopped' })
-      agentStore.updateAgent('a1', updated as any)
+      agentStore.updateAgent('a1', updated)
 
       expect(agentStore.agents.get('a1')!.state).toBe('stopped')
     })
@@ -174,11 +175,11 @@ describe('AgentStore', () => {
       agentStore.agents.set('old', makeAgent({
         id: 'old',
         startedAt: '2026-01-01T00:00:00Z',
-      }) as any)
+      }))
       agentStore.agents.set('new', makeAgent({
         id: 'new',
         startedAt: '2026-04-01T00:00:00Z',
-      }) as any)
+      }))
 
       const list = agentStore.list
       expect(list[0].id).toBe('new')
@@ -188,8 +189,8 @@ describe('AgentStore', () => {
 
   describe('byTask', () => {
     it('finds agent by task ID', () => {
-      agentStore.agents.set('a1', makeAgent({ id: 'a1', taskId: 'task-42' }) as any)
-      agentStore.agents.set('a2', makeAgent({ id: 'a2', taskId: 'task-99' }) as any)
+      agentStore.agents.set('a1', makeAgent({ id: 'a1', taskId: 'task-42' }))
+      agentStore.agents.set('a2', makeAgent({ id: 'a2', taskId: 'task-99' }))
 
       const found = agentStore.byTask('task-42')
       expect(found?.id).toBe('a1')
@@ -202,9 +203,9 @@ describe('AgentStore', () => {
 
   describe('byState', () => {
     it('filters by state', () => {
-      agentStore.agents.set('a1', makeAgent({ id: 'a1', state: 'running' }) as any)
-      agentStore.agents.set('a2', makeAgent({ id: 'a2', state: 'idle' }) as any)
-      agentStore.agents.set('a3', makeAgent({ id: 'a3', state: 'running' }) as any)
+      agentStore.agents.set('a1', makeAgent({ id: 'a1', state: 'running' }))
+      agentStore.agents.set('a2', makeAgent({ id: 'a2', state: 'idle' }))
+      agentStore.agents.set('a3', makeAgent({ id: 'a3', state: 'running' }))
 
       expect(agentStore.byState('running')).toHaveLength(2)
       expect(agentStore.byState('idle')).toHaveLength(1)
@@ -212,8 +213,8 @@ describe('AgentStore', () => {
     })
 
     it('returns all for "all" filter', () => {
-      agentStore.agents.set('a1', makeAgent({ id: 'a1' }) as any)
-      agentStore.agents.set('a2', makeAgent({ id: 'a2' }) as any)
+      agentStore.agents.set('a1', makeAgent({ id: 'a1' }))
+      agentStore.agents.set('a2', makeAgent({ id: 'a2' }))
 
       expect(agentStore.byState('all')).toHaveLength(2)
     })

--- a/frontend/src/stores/issues.svelte.ts
+++ b/frontend/src/stores/issues.svelte.ts
@@ -45,6 +45,6 @@ class IssueStore {
 }
 
 export const issueStore = new IssueStore()
-if (typeof window !== 'undefined' && (window as any).runtime) {
+if (typeof window !== 'undefined' && window.runtime) {
   issueStore.listen()
 }

--- a/frontend/src/stores/renovate.svelte.ts
+++ b/frontend/src/stores/renovate.svelte.ts
@@ -58,6 +58,6 @@ class RenovateStore {
 }
 
 export const renovateStore = new RenovateStore()
-if (typeof window !== 'undefined' && (window as any).runtime) {
+if (typeof window !== 'undefined' && window.runtime) {
   renovateStore.listen()
 }

--- a/frontend/src/stores/reviews.svelte.test.ts
+++ b/frontend/src/stores/reviews.svelte.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ReviewsUpdated } from '../lib/events.js'
+import { github } from '../../wailsjs/go/models.js'
 
 const mockFetchReviews = vi.fn()
 let eventCallbacks: Record<string, (data: unknown) => void> = {}
@@ -17,8 +18,8 @@ vi.mock('../../wailsjs/runtime/runtime.js', () => ({
 
 const { reviewStore } = await import('./reviews.svelte.js')
 
-function makePR(overrides: Record<string, unknown> = {}) {
-  return {
+function makePR(overrides: Partial<github.PullRequest> = {}): github.PullRequest {
+  return github.PullRequest.createFrom({
     number: 1,
     title: 'Test PR',
     url: 'https://github.com/org/repo/pull/1',
@@ -27,6 +28,7 @@ function makePR(overrides: Record<string, unknown> = {}) {
     author: 'user',
     isDraft: false,
     labels: [],
+    headRefName: '',
     ciStatus: '',
     reviewDecision: '',
     mergeable: '',
@@ -35,7 +37,7 @@ function makePR(overrides: Record<string, unknown> = {}) {
     createdAt: '2026-04-01T00:00:00Z',
     updatedAt: '2026-04-01T00:00:00Z',
     ...overrides,
-  }
+  })
 }
 
 describe('ReviewStore', () => {
@@ -101,8 +103,8 @@ describe('ReviewStore', () => {
 
   describe('totalCount', () => {
     it('sums both lists', () => {
-      reviewStore.createdByMe = [makePR({ number: 1 }), makePR({ number: 2 })] as any
-      reviewStore.reviewRequested = [makePR({ number: 3 })] as any
+      reviewStore.createdByMe = [makePR({ number: 1 }), makePR({ number: 2 })]
+      reviewStore.reviewRequested = [makePR({ number: 3 })]
 
       expect(reviewStore.totalCount).toBe(3)
     })

--- a/frontend/src/stores/reviews.svelte.ts
+++ b/frontend/src/stores/reviews.svelte.ts
@@ -80,6 +80,6 @@ class ReviewStore {
 }
 
 export const reviewStore = new ReviewStore()
-if (typeof window !== 'undefined' && (window as any).runtime) {
+if (typeof window !== 'undefined' && window.runtime) {
   reviewStore.listen()
 }

--- a/frontend/src/stores/tasks.svelte.test.ts
+++ b/frontend/src/stores/tasks.svelte.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { task } from '../../wailsjs/go/models.js'
 
 const mockListTasks = vi.fn()
 const mockGetTask = vi.fn()
@@ -14,19 +15,31 @@ vi.mock('../../wailsjs/go/main/App.js', () => ({
 
 const { taskStore } = await import('./tasks.svelte.js')
 
-function makeTask(overrides: Record<string, unknown> = {}) {
-  return {
+function makeTask(overrides: Partial<task.Task> = {}): task.Task {
+  return task.Task.createFrom({
     id: 'task-1',
+    slug: '',
     title: 'Test task',
     status: 'todo',
+    taskType: '',
     agentMode: 'headless',
     allowedTools: [],
     tags: [],
+    projectId: '',
+    branch: '',
+    prNumber: 0,
+    issue: '',
+    statusReason: '',
+    reviewed: false,
+    runRole: '',
+    todoistId: '',
+    agentRuns: [],
     createdAt: '2026-04-01T00:00:00Z',
     updatedAt: '2026-04-01T00:00:00Z',
     body: '## Description\nTest',
+    filePath: '',
     ...overrides,
-  }
+  })
 }
 
 describe('TaskStore', () => {
@@ -113,7 +126,7 @@ describe('TaskStore', () => {
 
   describe('update', () => {
     it('updates task and refreshes map', async () => {
-      taskStore.tasks.set('t1', makeTask({ id: 't1', status: 'todo' }) as any)
+      taskStore.tasks.set('t1', makeTask({ id: 't1', status: 'todo' }))
       const updated = makeTask({ id: 't1', status: 'in-progress' })
       mockUpdateTask.mockResolvedValue(updated)
 
@@ -130,11 +143,11 @@ describe('TaskStore', () => {
       taskStore.tasks.set('old', makeTask({
         id: 'old',
         updatedAt: '2026-01-01T00:00:00Z',
-      }) as any)
+      }))
       taskStore.tasks.set('new', makeTask({
         id: 'new',
         updatedAt: '2026-04-01T00:00:00Z',
-      }) as any)
+      }))
 
       const list = taskStore.list
       expect(list[0].id).toBe('new')
@@ -145,11 +158,11 @@ describe('TaskStore', () => {
       taskStore.tasks.set('a', makeTask({
         id: 'a',
         updatedAt: undefined,
-      }) as any)
+      }))
       taskStore.tasks.set('b', makeTask({
         id: 'b',
         updatedAt: '2026-04-01T00:00:00Z',
-      }) as any)
+      }))
 
       const list = taskStore.list
       expect(list[0].id).toBe('b')
@@ -158,9 +171,9 @@ describe('TaskStore', () => {
 
   describe('byStatus', () => {
     it('filters by status', () => {
-      taskStore.tasks.set('t1', makeTask({ id: 't1', status: 'todo' }) as any)
-      taskStore.tasks.set('t2', makeTask({ id: 't2', status: 'done' }) as any)
-      taskStore.tasks.set('t3', makeTask({ id: 't3', status: 'todo' }) as any)
+      taskStore.tasks.set('t1', makeTask({ id: 't1', status: 'todo' }))
+      taskStore.tasks.set('t2', makeTask({ id: 't2', status: 'done' }))
+      taskStore.tasks.set('t3', makeTask({ id: 't3', status: 'todo' }))
 
       expect(taskStore.byStatus('todo')).toHaveLength(2)
       expect(taskStore.byStatus('done')).toHaveLength(1)
@@ -168,16 +181,16 @@ describe('TaskStore', () => {
     })
 
     it('filters human-required status', () => {
-      taskStore.tasks.set('t1', makeTask({ id: 't1', status: 'human-required' }) as any)
-      taskStore.tasks.set('t2', makeTask({ id: 't2', status: 'todo' }) as any)
+      taskStore.tasks.set('t1', makeTask({ id: 't1', status: 'human-required' }))
+      taskStore.tasks.set('t2', makeTask({ id: 't2', status: 'todo' }))
 
       expect(taskStore.byStatus('human-required')).toHaveLength(1)
       expect(taskStore.byStatus('human-required')[0].id).toBe('t1')
     })
 
     it('returns all for "all" filter', () => {
-      taskStore.tasks.set('t1', makeTask({ id: 't1' }) as any)
-      taskStore.tasks.set('t2', makeTask({ id: 't2' }) as any)
+      taskStore.tasks.set('t1', makeTask({ id: 't1' }))
+      taskStore.tasks.set('t2', makeTask({ id: 't2' }))
 
       expect(taskStore.byStatus('all')).toHaveLength(2)
     })

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+interface Window {
+  runtime?: unknown
+}


### PR DESCRIPTION
## Motivation

40+ `as any` casts in frontend test files bypass TypeScript's type system, hiding potential type mismatches and reducing the value of type checking in tests. Production stores also used `(window as any).runtime` which bypassed Window type safety.

> Changelog: refactor(frontend): remove as any casts in tests

## Implementation information

- Added `interface Window { runtime?: unknown }` to `vite-env.d.ts` — enables `window.runtime` access without cast in `reviews.svelte.ts`, `issues.svelte.ts`, and `renovate.svelte.ts`
- Updated test factory functions (`makeAgent`, `makeTask`, `makePR`, `makeSummary`, `makeStatsData`) to use Wails-generated `createFrom` static methods — returns real class instances with `convertValues` method, satisfying structural typing
- Changed `overrides` parameter from `Record<string, unknown>` to `Partial<T>` — provides autocomplete and type safety at call sites
- Replaced `(agentStore as any).loading` pattern in `AgentList.svelte.test.ts` with a named mock object (`mockAgentStoreData`) that can be mutated directly
- Typed mock store arrays in `GitHub.svelte.test.ts` as `github.PullRequest[]`, `github.RenovatePR[]`, `github.Issue[]`
- Fixed `ProjectDetail.svelte`: cast `col.includes as string[]` instead of `t.status as any` for `.includes()` check

Closes #196