### PR TITLE
fix(worktree): preserve uncommitted agent work

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -90,8 +90,24 @@ func SanitizeWorktree(wtPath string) error {
 		}
 	}
 
-	// Discard uncommitted changes so rebase can proceed. Committed work on the
-	// branch is preserved; only working-tree/index dirt is dropped.
+	// Auto-commit any uncommitted changes before resetting. Agents are expected
+	// to commit before finishing, but if they forget this preserves their work
+	// on the branch rather than destroying it.
+	statusCmd := exec.Command("git", "status", "--porcelain")
+	statusCmd.Dir = wtPath
+	if statusOut, err := statusCmd.Output(); err == nil && len(strings.TrimSpace(string(statusOut))) > 0 {
+		add := exec.Command("git", "add", "-A")
+		add.Dir = wtPath
+		if _ = add.Run(); true {
+			commit := exec.Command("git", "commit", "--no-gpg-sign", "-m", "wip: auto-commit uncommitted agent work\n\nSanitizeWorktree preserved uncommitted changes before reset.")
+			commit.Dir = wtPath
+			_ = commit.Run()
+		}
+	}
+
+	// Discard any remaining working-tree dirt (e.g. ignored files, failed
+	// commit) so the rebase can proceed cleanly. Committed work on the branch
+	// is preserved.
 	reset := exec.Command("git", "reset", "--hard", "HEAD")
 	reset.Dir = wtPath
 	_ = reset.Run()

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -370,6 +370,61 @@ func contains(s, sub string) bool {
 	return strings.Contains(s, sub)
 }
 
+func TestSanitizeWorktree_AutoCommitsUncommitted(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(src, bare); err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+
+	wtPath := filepath.Join(t.TempDir(), "wt")
+	branch, _ := DefaultBranch(bare)
+	if err := CreateWorktree(bare, wtPath, "synapse/test", branch); err != nil {
+		t.Fatalf("worktree: %v", err)
+	}
+
+	// Configure git identity so commit works.
+	for _, args := range [][]string{
+		{"config", "user.email", "test@test.com"},
+		{"config", "user.name", "Test"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = wtPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+
+	// Simulate agent leaving uncommitted work.
+	if err := os.WriteFile(filepath.Join(wtPath, "new_file.go"), []byte("package main"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SanitizeWorktree(wtPath); err != nil {
+		t.Fatalf("SanitizeWorktree: %v", err)
+	}
+
+	// Uncommitted file should now be in a commit, not lost.
+	out, err := exec.Command("git", "-C", wtPath, "log", "--oneline", "-1").Output()
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	if !strings.Contains(string(out), "wip:") {
+		t.Errorf("expected wip commit, got: %s", out)
+	}
+
+	// Working tree should be clean after sanitize.
+	statusOut, _ := exec.Command("git", "-C", wtPath, "status", "--porcelain").Output()
+	if strings.TrimSpace(string(statusOut)) != "" {
+		t.Errorf("expected clean working tree, got: %s", statusOut)
+	}
+}
+
 func TestCreateWorktreeInvalidBase(t *testing.T) {
 	t.Parallel()
 	if !hasGit() {

--- a/orchestrator/CLAUDE.md
+++ b/orchestrator/CLAUDE.md
@@ -214,3 +214,35 @@ Run audit analysis during the monitor phase of the core loop. Suggested cadence:
 - Add context to task body when triaging (gathered from URLs, repos)
 - Never start work without first checking current task board state
 - Keep task titles concise (<80 chars), put details in body
+
+## Agent Commit Requirement
+
+Every headless implementation agent **must commit its work before finishing**. This is critical — uncommitted changes are destroyed when the worktree is reused for a subsequent agent run.
+
+### Required final steps in every headless agent prompt
+
+Include this block verbatim at the end of every implementation prompt:
+
+```
+## Required: Commit Your Work
+
+Before marking this task complete, you MUST commit all changes:
+
+```bash
+git add -A
+git commit -s -S -m "type(scope): description"
+```
+
+Do NOT finish without committing. Uncommitted work will be lost.
+```
+
+### Eval agent verification
+
+When an eval agent checks implementation results, it **must verify** a commit exists before accepting the claim:
+
+```bash
+# Confirm at least one commit beyond the base branch exists
+git log --oneline origin/main..HEAD
+```
+
+If the output is empty, the implementation was not committed — mark `human-required` immediately regardless of quality gate results.


### PR DESCRIPTION
## Motivation

Agent 062a568b spent \$7.77 implementing a full refactor (9 new files, ~25 modified, all quality gates passing) but never committed. When the next agent run called `SanitizeWorktree`, `git reset --hard HEAD && git clean -fd` silently destroyed all the work.

## Implementation information

Two fixes:

**`SanitizeWorktree` auto-commit** — before resetting, checks `git status --porcelain`. If the worktree is dirty, runs `git add -A && git commit --no-gpg-sign -m "wip: auto-commit..."` to land the work on the branch before the reset wipes it. New test `TestSanitizeWorktree_AutoCommitsUncommitted` covers this path.

**Orchestrator commit requirement** — added "Agent Commit Requirement" section to `orchestrator/CLAUDE.md` with a verbatim commit block to include in every headless agent prompt, and a requirement for eval agents to verify `git log origin/main..HEAD` is non-empty before accepting any "done" claim.

> Changelog: fix(worktree): preserve uncommitted agent work