### PR TITLE
feat(chat): add syntax highlighting to Claude output

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@xyflow/svelte": "^1.5.2",
+        "highlight.js": "^11.11.1",
         "marked": "^18.0.0",
+        "marked-highlight": "^2.2.4",
         "snarkdown": "^2.0.0"
       },
       "devDependencies": {
@@ -2841,6 +2843,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -3306,6 +3317,15 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/marked-highlight": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/marked-highlight/-/marked-highlight-2.2.4.tgz",
+      "integrity": "sha512-PZxisNMJDduSjc0q6uvjsnqqHCXc9s0eyzxDO9sB1eNGJnd/H1/Fu+z6g/liC1dfJdFW4SftMwMlLvsBhUPrqQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "marked": ">=4 <19"
       }
     },
     "node_modules/mdn-data": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,9 @@
   },
   "dependencies": {
     "@xyflow/svelte": "^1.5.2",
+    "highlight.js": "^11.11.1",
     "marked": "^18.0.0",
+    "marked-highlight": "^2.2.4",
     "snarkdown": "^2.0.0"
   }
 }

--- a/frontend/src/components/MessageBubble.svelte
+++ b/frontend/src/components/MessageBubble.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import type { agent } from '../../wailsjs/go/models.js'
   import { marked } from 'marked'
+  import { markedHighlight } from 'marked-highlight'
+  import hljs from 'highlight.js'
+  import 'highlight.js/styles/github-dark.css'
   import DiffViewer from './DiffViewer.svelte'
 
   interface Props {
@@ -15,6 +18,13 @@
   const isResult = $derived(event.type === 'result')
   const isSystem = $derived(event.type === 'system')
 
+  marked.use(markedHighlight({
+    langPrefix: 'hljs language-',
+    highlight(code, lang) {
+      const language = hljs.getLanguage(lang) ? lang : 'plaintext'
+      return hljs.highlight(code, { language }).value
+    }
+  }))
   marked.setOptions({ breaks: true, gfm: true })
 
   // Cache markdown rendering per text value to avoid re-parsing on parent re-renders.
@@ -120,17 +130,20 @@
   :global(.markdown-body p) { margin: 0.25em 0; }
   :global(.markdown-body pre) {
     margin: 0.5em 0;
-    padding: 0.5em;
     border-radius: 0.375rem;
     overflow-x: auto;
     font-size: 0.75rem;
   }
-  :global(.markdown-body code) {
+  :global(.markdown-body pre code.hljs) {
+    border-radius: 0.375rem;
+    font-size: 0.75rem;
+  }
+  :global(.markdown-body code:not(.hljs)) {
     font-size: 0.8em;
     padding: 0.1em 0.3em;
     border-radius: 0.25rem;
+    background: rgb(var(--color-surface-800) / 0.5);
   }
-  :global(.markdown-body pre code) { padding: 0; }
   :global(.markdown-body ul, .markdown-body ol) { padding-left: 1.5em; margin: 0.25em 0; }
   :global(.markdown-body h1, .markdown-body h2, .markdown-body h3) { margin: 0.5em 0 0.25em; font-weight: 600; }
   :global(.markdown-body blockquote) { border-left: 3px solid currentColor; padding-left: 0.75em; opacity: 0.8; margin: 0.25em 0; }


### PR DESCRIPTION
## Motivation

Code blocks in Claude's chat responses were rendered as plain text, making them hard to read — especially for multi-language outputs common in agent workflows.

## Implementation information

Integrated `highlight.js` + `marked-highlight` (the official `marked` extension) into `MessageBubble.svelte`:

- `markedHighlight` wraps `marked` so code fences are auto-detected and highlighted
- Falls back to `plaintext` for unknown/unspecified languages
- Imports the `github-dark` hljs CSS theme (consistent with dark-mode UI)
- Updated `.markdown-body` styles: removed conflicting `pre`/`code` background overrides, let hljs theme control code block appearance; inline code (non-hljs) gets a subtle surface tint

> Changelog: feat(chat): add syntax highlighting to Claude output