### PR TITLE
feat(workflow): ensure_pr_closes_issue step

### DIFF
--- a/app.go
+++ b/app.go
@@ -323,6 +323,7 @@ func (a *App) initWorkflowEngine() {
 		&agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks},
 		a.logger,
 	)
+	a.workflowEngine.SetPRLinker(prLinkerAdapter{})
 }
 
 func (a *App) initApprovalServer(emit func(string, any)) {

--- a/app_workflow.go
+++ b/app_workflow.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 
 	"github.com/Automaat/synapse/internal/agent"
+	"github.com/Automaat/synapse/internal/github"
 	"github.com/Automaat/synapse/internal/task"
 	"github.com/Automaat/synapse/internal/workflow"
 )
@@ -12,6 +13,7 @@ import (
 var (
 	_ workflow.TaskProvider  = (*taskAdapter)(nil)
 	_ workflow.AgentLauncher = (*agentAdapter)(nil)
+	_ workflow.PRLinker      = (*prLinkerAdapter)(nil)
 )
 
 // taskAdapter bridges task.Manager → workflow.TaskProvider.
@@ -70,8 +72,21 @@ func taskToInfo(t task.Task) workflow.TaskInfo {
 		Body:         t.Body,
 		Plan:         t.Plan,
 		PlanCritique: t.PlanCritique,
+		Issue:        t.Issue,
 		Workflow:     t.Workflow,
 	}
+}
+
+// prLinkerAdapter wires the workflow engine's PRLinker interface to
+// the github package. Stateless — all state lives in `gh` / GitHub.
+type prLinkerAdapter struct{}
+
+func (prLinkerAdapter) GetClosingIssues(repo string, prNumber int) (issues []int, body string, err error) {
+	return github.FetchPRClosingIssues(repo, prNumber)
+}
+
+func (prLinkerAdapter) EditBody(repo string, prNumber int, body string) error {
+	return github.EditPRBody(repo, prNumber, body)
 }
 
 // agentAdapter bridges agent.Manager + AgentOrchestrator → workflow.AgentLauncher.

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -897,6 +897,67 @@ func fetchPRWith(e execer, repo string, number int) (PullRequest, error) {
 	}, nil
 }
 
+// FetchPRClosingIssues returns the issue numbers GitHub parses from
+// the PR body as closing (via keywords like "Closes #N", "Fixes #N"),
+// restricted to same-repo references, plus the current PR body.
+// Cross-repo closing references are ignored by the filter so callers
+// can compare numbers directly against their own repo context.
+func FetchPRClosingIssues(repo string, number int) (issues []int, body string, err error) {
+	return fetchPRClosingIssuesWith(defaultExecer, repo, number)
+}
+
+func fetchPRClosingIssuesWith(e execer, repo string, number int) (issues []int, body string, err error) {
+	out, runErr := e.run("pr", "view", fmt.Sprintf("%d", number),
+		"--repo", repo, "--json", "closingIssuesReferences,body")
+	if runErr != nil {
+		return nil, "", fmt.Errorf("gh pr view %d: %s: %w", number, strings.TrimSpace(string(out)), runErr)
+	}
+	var raw struct {
+		Body                    string `json:"body"`
+		ClosingIssuesReferences []struct {
+			Number     int `json:"number"`
+			Repository struct {
+				Name  string `json:"name"`
+				Owner struct {
+					Login string `json:"login"`
+				} `json:"owner"`
+			} `json:"repository"`
+		} `json:"closingIssuesReferences"`
+	}
+	if jsonErr := json.Unmarshal(out, &raw); jsonErr != nil {
+		return nil, "", fmt.Errorf("parse pr closing issues: %w", jsonErr)
+	}
+	parts := strings.SplitN(repo, "/", 2)
+	var wantOwner, wantName string
+	if len(parts) == 2 {
+		wantOwner, wantName = parts[0], parts[1]
+	}
+	for _, ref := range raw.ClosingIssuesReferences {
+		// Accept any ref whose repository matches the PR repo, or refs
+		// with empty repository metadata (older gh versions).
+		refOwner := ref.Repository.Owner.Login
+		refName := ref.Repository.Name
+		if (refOwner == "" && refName == "") || (refOwner == wantOwner && refName == wantName) {
+			issues = append(issues, ref.Number)
+		}
+	}
+	return issues, raw.Body, nil
+}
+
+// EditPRBody replaces the body of a pull request.
+func EditPRBody(repo string, number int, body string) error {
+	return editPRBodyWith(defaultExecer, repo, number, body)
+}
+
+func editPRBodyWith(e execer, repo string, number int, body string) error {
+	out, err := e.run("pr", "edit", fmt.Sprintf("%d", number),
+		"--repo", repo, "--body", body)
+	if err != nil {
+		return fmt.Errorf("gh pr edit %d: %s: %w", number, strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
 // ViewerLogin returns the authenticated GitHub user's login.
 func ViewerLogin() string {
 	return viewerLogin(defaultExecer)

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1014,6 +1014,117 @@ func TestFetchPRWith_invalidJSON(t *testing.T) {
 	}
 }
 
+// recordingExecer captures the args of the most recent run() invocation
+// so tests can assert which command was dispatched.
+type recordingExecer struct {
+	output   []byte
+	err      error
+	lastArgs []string
+	calls    int
+}
+
+func (r *recordingExecer) run(args ...string) ([]byte, error) {
+	r.calls++
+	r.lastArgs = append([]string(nil), args...)
+	return r.output, r.err
+}
+
+func TestFetchPRClosingIssuesWith_sameRepo(t *testing.T) {
+	t.Parallel()
+	response := `{
+		"body": "Initial body",
+		"closingIssuesReferences": [
+			{"number": 7, "repository": {"name": "repo", "owner": {"login": "owner"}}}
+		]
+	}`
+	fe := &fakeExecer{output: []byte(response)}
+	issues, body, err := fetchPRClosingIssuesWith(fe, "owner/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 1 || issues[0] != 7 {
+		t.Errorf("issues = %v, want [7]", issues)
+	}
+	if body != "Initial body" {
+		t.Errorf("body = %q, want %q", body, "Initial body")
+	}
+}
+
+func TestFetchPRClosingIssuesWith_filtersCrossRepo(t *testing.T) {
+	t.Parallel()
+	response := `{
+		"body": "",
+		"closingIssuesReferences": [
+			{"number": 1, "repository": {"name": "repo", "owner": {"login": "owner"}}},
+			{"number": 99, "repository": {"name": "other", "owner": {"login": "elsewhere"}}}
+		]
+	}`
+	fe := &fakeExecer{output: []byte(response)}
+	issues, _, err := fetchPRClosingIssuesWith(fe, "owner/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 1 || issues[0] != 1 {
+		t.Errorf("issues = %v, want [1] (99 belongs to elsewhere/other and must be filtered)", issues)
+	}
+}
+
+func TestFetchPRClosingIssuesWith_empty(t *testing.T) {
+	t.Parallel()
+	fe := &fakeExecer{output: []byte(`{"body": "", "closingIssuesReferences": []}`)}
+	issues, _, err := fetchPRClosingIssuesWith(fe, "owner/repo", 42)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Errorf("issues = %v, want empty", issues)
+	}
+}
+
+func TestFetchPRClosingIssuesWith_execError(t *testing.T) {
+	t.Parallel()
+	fe := &fakeExecer{output: []byte("boom"), err: fmt.Errorf("exit 1")}
+	_, _, err := fetchPRClosingIssuesWith(fe, "owner/repo", 42)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestFetchPRClosingIssuesWith_invalidJSON(t *testing.T) {
+	t.Parallel()
+	fe := &fakeExecer{output: []byte("not json")}
+	_, _, err := fetchPRClosingIssuesWith(fe, "owner/repo", 42)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestEditPRBodyWith_passesArgs(t *testing.T) {
+	t.Parallel()
+	fe := &recordingExecer{}
+	if err := editPRBodyWith(fe, "owner/repo", 42, "new body with\nnewline"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Args should be: pr edit 42 --repo owner/repo --body <body>
+	want := []string{"pr", "edit", "42", "--repo", "owner/repo", "--body", "new body with\nnewline"}
+	if len(fe.lastArgs) != len(want) {
+		t.Fatalf("args = %v, want %v", fe.lastArgs, want)
+	}
+	for i, a := range fe.lastArgs {
+		if a != want[i] {
+			t.Errorf("arg[%d] = %q, want %q", i, a, want[i])
+		}
+	}
+}
+
+func TestEditPRBodyWith_execError(t *testing.T) {
+	t.Parallel()
+	fe := &fakeExecer{output: []byte("forbidden"), err: fmt.Errorf("exit 1")}
+	if err := editPRBodyWith(fe, "owner/repo", 42, "body"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
 func TestMergePRWith(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/workflow/builtin/pr-fix.yaml
+++ b/internal/workflow/builtin/pr-fix.yaml
@@ -57,4 +57,13 @@ steps:
       allowed_tools:
         - Bash
     next:
+      - goto: ensure_pr_closes_issue
+
+  # Mechanical check (no LLM): if the task is linked to a GitHub issue,
+  # make sure the PR's body carries a `Closes <issue-url>` reference so
+  # merging the PR auto-closes the issue.
+  - id: ensure_pr_closes_issue
+    name: Ensure PR Closes Issue
+    type: ensure_pr_closes_issue
+    next:
       - goto: ""

--- a/internal/workflow/builtin/simple-task.yaml
+++ b/internal/workflow/builtin/simple-task.yaml
@@ -214,4 +214,14 @@ steps:
       allowed_tools:
         - Bash
     next:
+      - goto: ensure_pr_closes_issue
+
+  # Mechanical check (no LLM): if the task is linked to a GitHub issue,
+  # make sure the PR's body carries a `Closes <issue-url>` reference so
+  # merging the PR auto-closes the issue. Auto-appends the reference if
+  # missing; flips to human-required if the edit/verification fails.
+  - id: ensure_pr_closes_issue
+    name: Ensure PR Closes Issue
+    type: ensure_pr_closes_issue
+    next:
       - goto: ""

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -6,7 +6,9 @@ import (
 	"log/slog"
 	"maps"
 	"os/exec"
+	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -31,6 +33,7 @@ type TaskInfo struct {
 	Body         string
 	Plan         string
 	PlanCritique string
+	Issue        string
 	Workflow     *Execution
 }
 
@@ -40,6 +43,19 @@ type TaskProvider interface {
 	ListTasks() ([]TaskInfo, error)
 	UpdateTaskStatus(id, status, reason string) error
 	SetWorkflow(id string, wf *Execution) error
+}
+
+// PRLinker inspects and updates GitHub pull request metadata for the
+// `ensure_pr_closes_issue` step. Implementations wrap `gh` CLI calls.
+// Engine operates with a nil PRLinker — the step becomes a no-op when
+// unset, so tests don't need to wire one.
+type PRLinker interface {
+	// GetClosingIssues returns issue numbers the PR's body is parsed by
+	// GitHub as closing, scoped to the same repo as the PR. Also returns
+	// the current PR body so callers can edit it without a second fetch.
+	GetClosingIssues(repo string, prNumber int) (issues []int, body string, err error)
+	// EditBody replaces the PR body.
+	EditBody(repo string, prNumber int, body string) error
 }
 
 // AgentLauncher starts agents and queries running state.
@@ -69,6 +85,7 @@ type Engine struct {
 	store    *Store
 	tasks    TaskProvider
 	agents   AgentLauncher
+	prLinker PRLinker
 	logger   *slog.Logger
 	mu       sync.Mutex
 	inflight map[string]struct{} // taskID → step in flight (prevent double-advance)
@@ -87,6 +104,10 @@ func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *s
 
 // Defs returns the workflow definition store.
 func (e *Engine) Defs() *Store { return e.store }
+
+// SetPRLinker wires an implementation of PRLinker used by the
+// `ensure_pr_closes_issue` step. Leaving it unset makes the step a no-op.
+func (e *Engine) SetPRLinker(l PRLinker) { e.prLinker = l }
 
 // StartWorkflow assigns a workflow to a task and executes the first step.
 func (e *Engine) StartWorkflow(taskID, workflowID string) error {
@@ -501,7 +522,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			return e.execWaitHuman(taskID, step, wfExec)
 		case StepParallel:
 			return e.execParallel(taskID, step, wfExec)
-		case StepSetStatus, StepCondition, StepShell:
+		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue:
 			// handled below as sync steps
 		default:
 			return fmt.Errorf("unknown step type %q", step.Type)
@@ -555,6 +576,8 @@ func (e *Engine) execSyncStep(taskID string, step *Step, wfExec *Execution, ctx 
 		return e.execCondition(step, wfExec, t)
 	case StepShell:
 		return e.execShell(step, ctx)
+	case StepEnsurePRClosesIssue:
+		return e.execEnsurePRClosesIssue(taskID, step, t)
 	default:
 		return StepOutput{}, fmt.Errorf("unknown step type %q", step.Type)
 	}
@@ -714,6 +737,90 @@ func (e *Engine) execShell(step *Step, ctx TemplateContext) (StepOutput, error) 
 		Status: status,
 		Output: string(output),
 	}, nil
+}
+
+// execEnsurePRClosesIssue verifies the task's PR closes its linked
+// GitHub issue. When the closing reference is missing, it appends
+// `Closes <issue-url>` to the PR body via the PRLinker and re-verifies.
+// On verification failure the task is flipped to human-required so a
+// human can fix the linkage manually.
+//
+// The step is a no-op when any of these are missing: task.Issue,
+// task.PRNumber, task.ProjectID, engine.prLinker. It also skips when
+// the issue lives in a different repo than the PR (cross-repo linking
+// needs explicit support GitHub handles but this check does not).
+func (e *Engine) execEnsurePRClosesIssue(taskID string, step *Step, t TaskInfo) (StepOutput, error) {
+	if e.prLinker == nil {
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no pr linker configured"}, nil
+	}
+	if t.Issue == "" || t.PRNumber == 0 || t.ProjectID == "" {
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: missing issue, pr, or project"}, nil
+	}
+
+	issueRepo, issueNum := parseIssueURL(t.Issue)
+	if issueNum == 0 {
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: unparseable issue url"}, nil
+	}
+	if issueRepo != t.ProjectID {
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: cross-repo issue link"}, nil
+	}
+
+	issues, body, err := e.prLinker.GetClosingIssues(t.ProjectID, t.PRNumber)
+	if err != nil {
+		e.logger.Error("workflow.pr-close.fetch", "task_id", taskID, "err", err)
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "fetch failed: " + err.Error()}, nil
+	}
+	if slices.Contains(issues, issueNum) {
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "already linked"}, nil
+	}
+
+	newBody := body
+	if newBody != "" {
+		newBody += "\n\n"
+	}
+	newBody += "Closes " + t.Issue
+	if editErr := e.prLinker.EditBody(t.ProjectID, t.PRNumber, newBody); editErr != nil {
+		e.logger.Error("workflow.pr-close.edit", "task_id", taskID, "err", editErr)
+		if statusErr := e.tasks.UpdateTaskStatus(taskID, "human-required", "PR does not close linked issue and auto-fix failed: "+editErr.Error()); statusErr != nil {
+			e.logger.Error("workflow.pr-close.status", "task_id", taskID, "err", statusErr)
+		}
+		return StepOutput{StepID: step.ID, Status: "failed", Output: "edit failed: " + editErr.Error()}, nil
+	}
+
+	verified, _, verifyErr := e.prLinker.GetClosingIssues(t.ProjectID, t.PRNumber)
+	if verifyErr != nil || !slices.Contains(verified, issueNum) {
+		reason := "PR does not close linked issue after auto-fix"
+		if verifyErr != nil {
+			reason += ": " + verifyErr.Error()
+		}
+		if statusErr := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); statusErr != nil {
+			e.logger.Error("workflow.pr-close.status", "task_id", taskID, "err", statusErr)
+		}
+		return StepOutput{StepID: step.ID, Status: "failed", Output: reason}, nil
+	}
+
+	e.logger.Info("workflow.pr-close.linked", "task_id", taskID, "pr", t.PRNumber, "issue", issueNum)
+	return StepOutput{StepID: step.ID, Status: "completed", Output: fmt.Sprintf("linked issue #%d", issueNum)}, nil
+}
+
+// parseIssueURL extracts owner/repo and issue number from a GitHub
+// issue URL like https://github.com/owner/repo/issues/123. Returns
+// ("", 0) if the URL doesn't match. Duplicated from internal/github
+// to keep the workflow package dependency-free.
+func parseIssueURL(rawURL string) (repo string, number int) {
+	const prefix = "https://github.com/"
+	if !strings.HasPrefix(rawURL, prefix) {
+		return "", 0
+	}
+	parts := strings.Split(strings.TrimPrefix(rawURL, prefix), "/")
+	if len(parts) < 4 || parts[2] != "issues" {
+		return "", 0
+	}
+	n, err := strconv.Atoi(parts[3])
+	if err != nil || n == 0 {
+		return "", 0
+	}
+	return parts[0] + "/" + parts[1], n
 }
 
 func (e *Engine) execParallel(_ string, _ *Step, _ *Execution) error {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1519,3 +1519,323 @@ func TestPlanReuse_ApproveAdvancesPastReviewPlan(t *testing.T) {
 		t.Errorf("State = %q, want ExecCompleted", ti.Workflow.State)
 	}
 }
+
+// --- ensure_pr_closes_issue step ---
+
+// fakePRLinker is a scripted PRLinker used by executor tests.
+type fakePRLinker struct {
+	// getQueue yields successive GetClosingIssues results.
+	getQueue []getResult
+	getCalls int
+
+	editErr   error
+	editCalls int
+	lastBody  string
+}
+
+type getResult struct {
+	issues []int
+	body   string
+	err    error
+}
+
+func (f *fakePRLinker) GetClosingIssues(_ string, _ int) (issues []int, body string, err error) {
+	idx := f.getCalls
+	f.getCalls++
+	if idx >= len(f.getQueue) {
+		idx = len(f.getQueue) - 1
+	}
+	r := f.getQueue[idx]
+	return r.issues, r.body, r.err
+}
+
+func (f *fakePRLinker) EditBody(_ string, _ int, body string) error {
+	f.editCalls++
+	f.lastBody = body
+	return f.editErr
+}
+
+func newEnsurePRStep() *Step {
+	return &Step{ID: "ensure", Type: StepEnsurePRClosesIssue}
+}
+
+func TestExecEnsurePRClosesIssue_NoLinkerSkips(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	ti := TaskInfo{ID: "t1", ProjectID: "owner/repo", PRNumber: 5, Issue: "https://github.com/owner/repo/issues/7"}
+	out, err := engine.execEnsurePRClosesIssue("t1", newEnsurePRStep(), ti)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed", out.Status)
+	}
+	if !strings.Contains(out.Output, "no pr linker") {
+		t.Errorf("Output = %q, want 'no pr linker' skip reason", out.Output)
+	}
+}
+
+func TestExecEnsurePRClosesIssue_MissingFieldsSkip(t *testing.T) {
+	tests := []struct {
+		name string
+		ti   TaskInfo
+	}{
+		{"no issue", TaskInfo{ID: "t1", ProjectID: "owner/repo", PRNumber: 5}},
+		{"no pr", TaskInfo{ID: "t1", ProjectID: "owner/repo", Issue: "https://github.com/owner/repo/issues/7"}},
+		{"no project", TaskInfo{ID: "t1", PRNumber: 5, Issue: "https://github.com/owner/repo/issues/7"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newTestStore(t)
+			tasks := newMemTasks()
+			agents := newMockAgents()
+			engine := NewEngine(store, tasks, agents, discardLogger())
+			engine.SetPRLinker(&fakePRLinker{})
+
+			out, err := engine.execEnsurePRClosesIssue("t1", newEnsurePRStep(), tt.ti)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if out.Status != "completed" {
+				t.Errorf("Status = %q, want completed", out.Status)
+			}
+			if !strings.Contains(out.Output, "skipped") {
+				t.Errorf("Output = %q, want 'skipped' reason", out.Output)
+			}
+		})
+	}
+}
+
+func TestExecEnsurePRClosesIssue_CrossRepoSkips(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	linker := &fakePRLinker{}
+	engine.SetPRLinker(linker)
+
+	ti := TaskInfo{
+		ID:        "t1",
+		ProjectID: "owner/repo",
+		PRNumber:  5,
+		Issue:     "https://github.com/other/elsewhere/issues/7",
+	}
+	out, _ := engine.execEnsurePRClosesIssue("t1", newEnsurePRStep(), ti)
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed", out.Status)
+	}
+	if !strings.Contains(out.Output, "cross-repo") {
+		t.Errorf("Output = %q, want cross-repo skip", out.Output)
+	}
+	if linker.getCalls != 0 {
+		t.Errorf("GetClosingIssues called %d times, want 0 (skip before fetch)", linker.getCalls)
+	}
+}
+
+func TestExecEnsurePRClosesIssue_AlreadyLinkedNoEdit(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	linker := &fakePRLinker{
+		getQueue: []getResult{{issues: []int{7}, body: "original"}},
+	}
+	engine.SetPRLinker(linker)
+
+	ti := TaskInfo{
+		ID: "t1", ProjectID: "owner/repo", PRNumber: 5,
+		Issue: "https://github.com/owner/repo/issues/7",
+	}
+	out, err := engine.execEnsurePRClosesIssue("t1", newEnsurePRStep(), ti)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" || !strings.Contains(out.Output, "already linked") {
+		t.Errorf("output = %+v, want completed/already linked", out)
+	}
+	if linker.editCalls != 0 {
+		t.Errorf("EditBody called %d times, want 0", linker.editCalls)
+	}
+}
+
+func TestExecEnsurePRClosesIssue_EditAppendsAndVerifies(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	linker := &fakePRLinker{
+		getQueue: []getResult{
+			{issues: nil, body: "Implements the feature."},
+			{issues: []int{7}, body: "Implements the feature.\n\nCloses https://github.com/owner/repo/issues/7"},
+		},
+	}
+	engine.SetPRLinker(linker)
+
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-review"})
+
+	ti := TaskInfo{
+		ID: "t1", ProjectID: "owner/repo", PRNumber: 5,
+		Issue: "https://github.com/owner/repo/issues/7",
+	}
+	out, err := engine.execEnsurePRClosesIssue("t1", newEnsurePRStep(), ti)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed", out.Status)
+	}
+	if linker.editCalls != 1 {
+		t.Errorf("EditBody called %d times, want 1", linker.editCalls)
+	}
+	wantBody := "Implements the feature.\n\nCloses https://github.com/owner/repo/issues/7"
+	if linker.lastBody != wantBody {
+		t.Errorf("edit body = %q, want %q", linker.lastBody, wantBody)
+	}
+	// Status must not have been changed on success.
+	after, _ := tasks.GetTask("t1")
+	if after.Status != "in-review" {
+		t.Errorf("Status = %q, want in-review (unchanged)", after.Status)
+	}
+}
+
+func TestExecEnsurePRClosesIssue_EmptyBodyNoLeadingNewlines(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	linker := &fakePRLinker{
+		getQueue: []getResult{
+			{issues: nil, body: ""},
+			{issues: []int{7}, body: "Closes https://github.com/owner/repo/issues/7"},
+		},
+	}
+	engine.SetPRLinker(linker)
+
+	ti := TaskInfo{
+		ID: "t1", ProjectID: "owner/repo", PRNumber: 5,
+		Issue: "https://github.com/owner/repo/issues/7",
+	}
+	if _, err := engine.execEnsurePRClosesIssue("t1", newEnsurePRStep(), ti); err != nil {
+		t.Fatal(err)
+	}
+	if linker.lastBody != "Closes https://github.com/owner/repo/issues/7" {
+		t.Errorf("edit body = %q, want no leading newlines", linker.lastBody)
+	}
+}
+
+func TestExecEnsurePRClosesIssue_EditFailureFlipsHumanRequired(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	linker := &fakePRLinker{
+		getQueue: []getResult{{issues: nil, body: "body"}},
+		editErr:  fmt.Errorf("403 forbidden"),
+	}
+	engine.SetPRLinker(linker)
+
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-review"})
+
+	ti := TaskInfo{
+		ID: "t1", ProjectID: "owner/repo", PRNumber: 5,
+		Issue: "https://github.com/owner/repo/issues/7",
+	}
+	out, err := engine.execEnsurePRClosesIssue("t1", newEnsurePRStep(), ti)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "failed" {
+		t.Errorf("Status = %q, want failed", out.Status)
+	}
+	after, _ := tasks.GetTask("t1")
+	if after.Status != "human-required" {
+		t.Errorf("task status = %q, want human-required", after.Status)
+	}
+}
+
+func TestExecEnsurePRClosesIssue_VerifyFailureFlipsHumanRequired(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	linker := &fakePRLinker{
+		getQueue: []getResult{
+			{issues: nil, body: "body"},
+			// Second fetch still does not contain issue 7 — the edit didn't take.
+			{issues: []int{99}, body: "body"},
+		},
+	}
+	engine.SetPRLinker(linker)
+
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-review"})
+
+	ti := TaskInfo{
+		ID: "t1", ProjectID: "owner/repo", PRNumber: 5,
+		Issue: "https://github.com/owner/repo/issues/7",
+	}
+	out, _ := engine.execEnsurePRClosesIssue("t1", newEnsurePRStep(), ti)
+	if out.Status != "failed" {
+		t.Errorf("Status = %q, want failed", out.Status)
+	}
+	after, _ := tasks.GetTask("t1")
+	if after.Status != "human-required" {
+		t.Errorf("task status = %q, want human-required", after.Status)
+	}
+}
+
+func TestExecEnsurePRClosesIssue_FetchErrorIsSoftFail(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	linker := &fakePRLinker{
+		getQueue: []getResult{{err: errors.New("network timeout")}},
+	}
+	engine.SetPRLinker(linker)
+
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-review"})
+
+	ti := TaskInfo{
+		ID: "t1", ProjectID: "owner/repo", PRNumber: 5,
+		Issue: "https://github.com/owner/repo/issues/7",
+	}
+	out, err := engine.execEnsurePRClosesIssue("t1", newEnsurePRStep(), ti)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Fetch failure must not block the workflow or flip status.
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed (fetch errors are soft-fail)", out.Status)
+	}
+	after, _ := tasks.GetTask("t1")
+	if after.Status != "in-review" {
+		t.Errorf("task status = %q, want in-review (unchanged)", after.Status)
+	}
+}
+
+func TestParseIssueURL(t *testing.T) {
+	tests := []struct {
+		url      string
+		wantRepo string
+		wantNum  int
+	}{
+		{"https://github.com/owner/repo/issues/42", "owner/repo", 42},
+		{"https://github.com/owner/repo/pull/42", "", 0},
+		{"https://github.com/owner/repo/issues/abc", "", 0},
+		{"https://github.com/owner/repo/issues/0", "", 0},
+		{"not a url", "", 0},
+		{"", "", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			gotRepo, gotNum := parseIssueURL(tt.url)
+			if gotRepo != tt.wantRepo || gotNum != tt.wantNum {
+				t.Errorf("parseIssueURL(%q) = %q,%d; want %q,%d",
+					tt.url, gotRepo, gotNum, tt.wantRepo, tt.wantNum)
+			}
+		})
+	}
+}

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -65,12 +65,13 @@ type Condition struct {
 type StepType string
 
 const (
-	StepRunAgent  StepType = "run_agent"
-	StepWaitHuman StepType = "wait_human"
-	StepSetStatus StepType = "set_status"
-	StepCondition StepType = "condition"
-	StepShell     StepType = "shell"
-	StepParallel  StepType = "parallel"
+	StepRunAgent            StepType = "run_agent"
+	StepWaitHuman           StepType = "wait_human"
+	StepSetStatus           StepType = "set_status"
+	StepCondition           StepType = "condition"
+	StepShell               StepType = "shell"
+	StepParallel            StepType = "parallel"
+	StepEnsurePRClosesIssue StepType = "ensure_pr_closes_issue"
 )
 
 // Step is one node in the workflow graph.


### PR DESCRIPTION
## Motivation

When a Synapse task is enriched from a GitHub issue, `task.Issue` holds the issue URL. The implementation agent creates a draft PR, but nothing verifies the PR actually references the originating issue with a closing keyword. The issue stays open after the PR merges until a human notices.

Previously proposed to fix this in the evaluator prompt — but that burns LLM tokens on a mechanical check that has no judgment component.

## Implementation information

New sync workflow step `ensure_pr_closes_issue`, wired after `evaluate` in `simple-task.yaml` and `pr-fix.yaml`.

- New `PRLinker` interface in `internal/workflow/engine.go` with `GetClosingIssues` + `EditBody`; set on the engine via `SetPRLinker`. Nil-safe — step becomes a no-op when unset, so existing tests don't need to wire a linker.
- `internal/github/client.go` gains `FetchPRClosingIssues` (wraps `gh pr view --json closingIssuesReferences,body`, filters cross-repo refs) and `EditPRBody` (wraps `gh pr edit --body`). Both testable via the existing `execer` pattern.
- `prLinkerAdapter` in `app_workflow.go` bridges the interface to the github package; wired in `initWorkflowEngine`.
- Step logic: skip when any of `Issue`/`PRNumber`/`ProjectID`/linker are missing or the issue lives cross-repo; skip with soft-fail log on fetch errors; append `\n\nCloses <url>` to the body and call `gh pr edit`; re-verify via `closingIssuesReferences`; flip task to `human-required` only if the edit or verification fails.
- Uses the canonical `closingIssuesReferences` GitHub field instead of a body regex, so it inherits GitHub's own parsing of `close`/`fix`/`resolve` keywords and all reference formats.
- `parseIssueURL` is a local copy in the workflow package to keep it dependency-free.
- Evaluator prompts in both builtin workflows revert to their pre-change state.
- Tests: executor cases (no linker, missing fields, cross-repo, already linked, successful fix, empty body, edit failure, verify failure, fetch error, URL parser); github package cases (same-repo, cross-repo filter, empty, exec error, invalid JSON, edit arg passing, edit error).

## Supporting documentation

None.