### PR TITLE
refactor(workflow): remove parallel step placeholder

### DIFF
--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1127,12 +1127,13 @@ export namespace workflow {
 	    type: string;
 	    config: StepConfig;
 	    next: Transition[];
+	    parallel: Step[];
 	    position?: Position;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new Step(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
@@ -1140,6 +1141,7 @@ export namespace workflow {
 	        this.type = source["type"];
 	        this.config = this.convertValues(source["config"], StepConfig);
 	        this.next = this.convertValues(source["next"], Transition);
+	        this.parallel = this.convertValues(source["parallel"], Step);
 	        this.position = this.convertValues(source["position"], Position);
 	    }
 	

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1127,7 +1127,6 @@ export namespace workflow {
 	    type: string;
 	    config: StepConfig;
 	    next: Transition[];
-	    parallel: Step[];
 	    position?: Position;
 	
 	    static createFrom(source: any = {}) {
@@ -1141,7 +1140,6 @@ export namespace workflow {
 	        this.type = source["type"];
 	        this.config = this.convertValues(source["config"], StepConfig);
 	        this.next = this.convertValues(source["next"], Transition);
-	        this.parallel = this.convertValues(source["parallel"], Step);
 	        this.position = this.convertValues(source["position"], Position);
 	    }
 	

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1129,11 +1129,11 @@ export namespace workflow {
 	    next: Transition[];
 	    parallel: Step[];
 	    position?: Position;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new Step(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -612,8 +612,6 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			return e.execRunAgent(taskID, step, wfExec, ctx)
 		case StepWaitHuman:
 			return e.execWaitHuman(taskID, step, wfExec)
-		case StepParallel:
-			return e.execParallel(taskID, step, wfExec)
 		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue:
 			// handled below as sync steps
 		default:
@@ -920,11 +918,6 @@ func parseIssueURL(rawURL string) (repo string, number int) {
 		return "", 0
 	}
 	return parts[0] + "/" + parts[1], n
-}
-
-func (e *Engine) execParallel(_ string, _ *Step, _ *Execution) error {
-	// Parallel execution is deferred to Phase 2.
-	return fmt.Errorf("parallel steps not yet implemented")
 }
 
 func taskFields(t TaskInfo) map[string]string {

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -75,7 +75,8 @@ type Step struct {
 	Name   string       `yaml:"name" json:"name"`
 	Type   StepType     `yaml:"type" json:"type"`
 	Config StepConfig   `yaml:"config" json:"config"`
-	Next   []Transition `yaml:"next,omitempty" json:"next"`
+	Next     []Transition `yaml:"next,omitempty" json:"next"`
+	Parallel []Step       `yaml:"parallel,omitempty" json:"parallel"`
 
 	// Position stores x,y for the graph editor (not used by engine).
 	Position *Position `yaml:"position,omitempty" json:"position"`

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -71,10 +71,10 @@ const (
 
 // Step is one node in the workflow graph.
 type Step struct {
-	ID     string       `yaml:"id" json:"id"`
-	Name   string       `yaml:"name" json:"name"`
-	Type   StepType     `yaml:"type" json:"type"`
-	Config StepConfig   `yaml:"config" json:"config"`
+	ID       string       `yaml:"id" json:"id"`
+	Name     string       `yaml:"name" json:"name"`
+	Type     StepType     `yaml:"type" json:"type"`
+	Config   StepConfig   `yaml:"config" json:"config"`
 	Next     []Transition `yaml:"next,omitempty" json:"next"`
 	Parallel []Step       `yaml:"parallel,omitempty" json:"parallel"`
 

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -25,12 +25,6 @@ func (d *Definition) StepByID(id string) *Step {
 		if d.Steps[i].ID == id {
 			return &d.Steps[i]
 		}
-		// Check parallel sub-steps.
-		for j := range d.Steps[i].Parallel {
-			if d.Steps[i].Parallel[j].ID == id {
-				return &d.Steps[i].Parallel[j]
-			}
-		}
 	}
 	return nil
 }
@@ -72,7 +66,6 @@ const (
 	StepSetStatus           StepType = "set_status"
 	StepCondition           StepType = "condition"
 	StepShell               StepType = "shell"
-	StepParallel            StepType = "parallel"
 	StepEnsurePRClosesIssue StepType = "ensure_pr_closes_issue"
 )
 
@@ -83,9 +76,6 @@ type Step struct {
 	Type   StepType     `yaml:"type" json:"type"`
 	Config StepConfig   `yaml:"config" json:"config"`
 	Next   []Transition `yaml:"next,omitempty" json:"next"`
-
-	// Parallel holds sub-steps for StepParallel type.
-	Parallel []Step `yaml:"parallel,omitempty" json:"parallel"`
 
 	// Position stores x,y for the graph editor (not used by engine).
 	Position *Position `yaml:"position,omitempty" json:"position"`
@@ -141,12 +131,6 @@ func (d *Definition) Validate() error {
 		s := &d.Steps[i]
 		if s.Config.MaxRetries > maxRetries {
 			return fmt.Errorf("step %q: max_retries %d exceeds limit %d", s.ID, s.Config.MaxRetries, maxRetries)
-		}
-		for j := range s.Parallel {
-			p := &s.Parallel[j]
-			if p.Config.MaxRetries > maxRetries {
-				return fmt.Errorf("step %q/%q: max_retries %d exceeds limit %d", s.ID, p.ID, p.Config.MaxRetries, maxRetries)
-			}
 		}
 	}
 	if err := d.ValidateFields(); err != nil {

--- a/internal/workflow/model_test.go
+++ b/internal/workflow/model_test.go
@@ -27,19 +27,6 @@ func TestValidate_MaxRetriesExceedsLimit(t *testing.T) {
 	}
 }
 
-func TestValidate_MaxRetriesExceedsInParallel(t *testing.T) {
-	d := Definition{
-		Steps: []Step{
-			{ID: "s1", Parallel: []Step{
-				{ID: "p1", Config: StepConfig{MaxRetries: 20}},
-			}},
-		},
-	}
-	if err := d.Validate(); err == nil {
-		t.Fatal("expected error for max_retries in parallel step")
-	}
-}
-
 func TestValidate_ZeroMaxRetries(t *testing.T) {
 	d := Definition{
 		Steps: []Step{
@@ -66,15 +53,6 @@ func TestStepByID_NotFound(t *testing.T) {
 	d := Definition{Steps: []Step{{ID: "a"}}}
 	if s := d.StepByID("missing"); s != nil {
 		t.Fatalf("expected nil, got %q", s.ID)
-	}
-}
-
-func TestStepByID_InParallel(t *testing.T) {
-	d := Definition{
-		Steps: []Step{{ID: "a", Parallel: []Step{{ID: "b"}}}},
-	}
-	if s := d.StepByID("b"); s == nil {
-		t.Fatal("expected to find parallel step 'b'")
 	}
 }
 


### PR DESCRIPTION
## Motivation

`StepParallel` was defined in the schema but always returned an error at runtime. Workflow authors could write `type: parallel` steps that would never succeed. No builtin or user workflow YAML in the repo uses this type.

## Implementation information

Option A from the task description: deleted the dead code entirely.

- Removed `StepParallel` constant from `model.go`
- Removed `Parallel []Step` field from `Step` struct
- Simplified `StepByID` (dropped parallel sub-step traversal)
- Simplified `Validate` (dropped parallel sub-step max_retries check)
- Removed `case StepParallel` arm in `executeSteps`
- Deleted `execParallel` stub function
- Removed two tests that exercised the now-deleted parallel field

> Changelog: refactor(workflow): remove parallel step placeholder

Closes https://github.com/Automaat/synapse/issues/273