### PR TITLE
fix(ui): resolve 10 svelte-check a11y warnings

### DIFF
--- a/frontend/src/components/CommandPalette.svelte
+++ b/frontend/src/components/CommandPalette.svelte
@@ -117,12 +117,15 @@
 </script>
 
 {#if open}
-  <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-  <div class="fixed inset-0 z-50 flex items-start justify-center bg-black/40 pt-[18vh]" onclick={onclose}>
-    <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+  <div class="fixed inset-0 z-50 flex items-start justify-center bg-black/40 pt-[18vh]" role="presentation" onclick={onclose}>
     <div
       class="w-full max-w-lg rounded-xl border border-surface-300 bg-surface-50 shadow-2xl dark:border-surface-600 dark:bg-surface-800"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Command palette"
+      tabindex="-1"
       onclick={(e) => e.stopPropagation()}
+      onkeydown={(e) => e.stopPropagation()}
     >
       <div class="flex items-center border-b border-surface-300 px-4 dark:border-surface-600">
         <svg class="h-4 w-4 shrink-0 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/components/CreateTaskDialog.svelte
+++ b/frontend/src/components/CreateTaskDialog.svelte
@@ -126,6 +126,7 @@
                 <button
                   type="button"
                   class="text-surface-400 hover:text-surface-600 dark:hover:text-surface-300"
+                  aria-label="Clear project"
                   onclick={clearProject}
                 >
                   <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/components/KeyboardHelp.svelte
+++ b/frontend/src/components/KeyboardHelp.svelte
@@ -23,12 +23,15 @@
 </script>
 
 {#if open}
-  <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onclick={onclose}>
-    <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+  <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40" role="presentation" onclick={onclose}>
     <div
       class="w-full max-w-xl rounded-xl border border-surface-300 bg-surface-50 shadow-2xl dark:border-surface-600 dark:bg-surface-800"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+      tabindex="-1"
       onclick={(e) => e.stopPropagation()}
+      onkeydown={(e) => e.stopPropagation()}
     >
       <div class="flex items-center justify-between border-b border-surface-300 px-5 py-3 dark:border-surface-600">
         <h2 class="text-sm font-semibold">Keyboard Shortcuts</h2>

--- a/frontend/src/components/PlanFileView.svelte
+++ b/frontend/src/components/PlanFileView.svelte
@@ -7,6 +7,11 @@
   let addingLine = $state<number | null>(null)
   let newCommentBody = $state('')
   let submitting = $state(false)
+  let commentTextareaRef = $state<HTMLTextAreaElement | null>(null)
+
+  $effect(() => {
+    if (addingLine !== null && commentTextareaRef) commentTextareaRef.focus()
+  })
 
   const lines = $derived(planBody ? planBody.split('\n') : [])
 
@@ -85,12 +90,12 @@
       {#if addingLine === lineNum}
         <div class="ml-18 my-1 rounded border border-primary-400 dark:border-primary-600 bg-surface-50 dark:bg-surface-800 p-3">
           <textarea
+            bind:this={commentTextareaRef}
             class="w-full resize-y rounded border border-surface-300 bg-white p-2 text-sm dark:border-surface-600 dark:bg-surface-900"
             rows="3"
             placeholder="Add a comment..."
             bind:value={newCommentBody}
             onkeydown={(e) => { if (e.key === 'Escape') cancelComment() }}
-            autofocus
           ></textarea>
           <div class="mt-2 flex gap-2">
             <button

--- a/frontend/src/components/ToastContainer.svelte
+++ b/frontend/src/components/ToastContainer.svelte
@@ -38,25 +38,28 @@
 
 <div class="fixed bottom-4 right-4 z-50 flex flex-col gap-2 w-80">
   {#each visible as toast (toast.id)}
-    <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions a11y_no_noninteractive_element_interactions -->
     <div
-      class="rounded-lg border px-4 py-3 shadow-lg text-left w-full cursor-pointer {levelClass(toast.level)}"
-      onclick={() => {
-        if (toast.taskId) onviewtask?.(toast.taskId)
-        dismiss(toast.id)
-      }}
+      class="rounded-lg border shadow-lg w-full {levelClass(toast.level)}"
       role="alert"
       transition:fly={{ x: 100, duration: 200 }}
       use:autoDismiss={toast.id}
     >
       <div class="flex justify-between items-start">
-        <div>
+        <button
+          type="button"
+          class="flex-1 px-4 py-3 text-left cursor-pointer"
+          onclick={() => {
+            if (toast.taskId) onviewtask?.(toast.taskId)
+            dismiss(toast.id)
+          }}
+        >
           <div class="font-medium text-sm">{toast.title}</div>
           <div class="text-xs opacity-75 mt-0.5">{toast.message}</div>
-        </div>
+        </button>
         <button
-          class="ml-2 opacity-50 hover:opacity-100 text-xs"
-          onclick={(e: MouseEvent) => { e.stopPropagation(); dismiss(toast.id) }}
+          type="button"
+          class="px-3 py-3 opacity-50 hover:opacity-100 text-xs"
+          onclick={() => dismiss(toast.id)}
           aria-label="Dismiss"
         >
           ✕

--- a/frontend/src/components/ToastContainer.svelte.test.ts
+++ b/frontend/src/components/ToastContainer.svelte.test.ts
@@ -72,8 +72,7 @@ describe('ToastContainer', () => {
   it('calls dismiss when toast body clicked', async () => {
     mockNotifications.push(makeNotification({ id: 'notif-1' }))
     render(ToastContainer, { props: {} })
-    const alert = screen.getByRole('alert')
-    await fireEvent.click(alert)
+    await fireEvent.click(screen.getByText('Test Toast'))
     expect(mockDismiss).toHaveBeenCalledWith('notif-1')
   })
 
@@ -81,8 +80,7 @@ describe('ToastContainer', () => {
     mockNotifications.push(makeNotification({ id: 'notif-1', taskId: 'task-42' }))
     const onviewtask = vi.fn()
     render(ToastContainer, { props: { onviewtask } })
-    const alert = screen.getByRole('alert')
-    await fireEvent.click(alert)
+    await fireEvent.click(screen.getByText('Test Toast'))
     expect(onviewtask).toHaveBeenCalledWith('task-42')
   })
 

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -24,6 +24,11 @@
   const { taskId, onback, onviewagent, ondelete, onreviewplan }: Props = $props()
 
   let statusSelectRef = $state<HTMLSelectElement | null>(null)
+  let titleInputRef = $state<HTMLInputElement | null>(null)
+
+  $effect(() => {
+    if (editingTitle && titleInputRef) titleInputRef.focus()
+  })
 
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === 'Escape') {
@@ -311,18 +316,21 @@
       <div class="flex items-start justify-between gap-4">
         {#if editingTitle}
           <input
+            bind:this={titleInputRef}
             class="text-2xl font-bold bg-transparent border-b-2 border-primary-500 outline-none w-full"
             bind:value={titleDraft}
             onblur={saveTitle}
             onkeydown={handleTitleKeydown}
-            autofocus
           />
         {:else}
-          <h1
-            class="text-2xl font-bold cursor-pointer hover:text-primary-500 transition-colors"
-            onclick={startEditingTitle}
-            title="Click to edit title"
-          >{t.title}</h1>
+          <h1 class="text-2xl font-bold">
+            <button
+              type="button"
+              class="cursor-pointer hover:text-primary-500 transition-colors"
+              onclick={startEditingTitle}
+              title="Click to edit title"
+            >{t.title}</button>
+          </h1>
         {/if}
         <div class="flex items-center gap-2">
           <select


### PR DESCRIPTION
## Motivation

`npm run check` reported 10 a11y warnings across 6 components, blocking keyboard-only navigation in command palette, keyboard help modal, and task title editing — all flows Marcin uses daily.

## Implementation information

Four patterns applied across 6 files:

1. **`autofocus` → `bind:this` + `$effect` focus** (`TaskDetail.svelte`, `PlanFileView.svelte`): Svelte recommends this over `autofocus` to avoid surprising screen readers; focus is triggered reactively when the element enters the DOM.

2. **`<h1 onclick>` → `<button>` inside `<h1>`** (`TaskDetail.svelte`): Non-interactive elements can't hold interactive roles; wrapping the title text in a `<button>` preserves heading semantics while making the edit trigger properly keyboard-accessible.

3. **Modal backdrop/dialog divs** (`CommandPalette.svelte`, `KeyboardHelp.svelte`): Added `role="presentation"` to backdrop (click-to-close overlay) and `role="dialog" aria-modal tabindex="-1" onkeydown` to the content panel, satisfying `a11y_no_static_element_interactions` and `a11y_interactive_supports_focus`.

4. **`ToastContainer.svelte`**: Removed onclick from `role="alert"` div (non-interactive live region); split into two `<button>` elements — one for view-task action, one for dismiss — keeping the existing dismiss `✕` button accessible independently.

5. **`CreateTaskDialog.svelte`**: Added `aria-label="Clear project"` to the icon-only button.

Result: `npm run check` → 0 errors, 0 warnings.

> Changelog: fix(ui): resolve 10 svelte-check a11y warnings

Closes https://github.com/Automaat/synapse/issues/267