### PR TITLE
fix(workflow): drop stale agent completions

### DIFF
--- a/e2e_workflow_test.go
+++ b/e2e_workflow_test.go
@@ -1435,6 +1435,100 @@ func TestE2E_StaleAgentCompletionAfterWorkflowTerminal(t *testing.T) {
 	}
 }
 
+// TestE2E_StaleAgentCompletionAtWaitHuman reproduces the production cascade
+// that left task 5a5ad276 stuck: a ResumeStalled race spawned a duplicate
+// plan agent; the first completion advanced plan → review_plan (wait_human);
+// the delayed second completion crashed resolveNext against an unset
+// human_action var and set state=ExecFailed, permanently sealing the human
+// review gate. The user's "reject" click then failed with "not waiting for
+// human action".
+//
+// This test drives the real workflow to the review_plan wait_human step and
+// fires a stray HandleAgentComplete at that gate — the defensive wait_human
+// guard must drop it without corrupting the workflow, and a subsequent
+// reject (which is what the user actually wanted to do) must succeed.
+func TestE2E_StaleAgentCompletionAtWaitHuman(t *testing.T) {
+	// Drive test-simple: triage flips to planning → plan → review_plan (waits).
+	// Third scenario covers the re-plan after reject loops back.
+	env := setupE2EMulti(t, []string{"triage_to_planning", "success", "success"})
+
+	created, err := env.tasks.Create("stale at wait_human", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := env.engine.StartWorkflow(created.ID, "test-simple"); err != nil {
+		t.Fatal(err)
+	}
+
+	waitFor(t, 30*time.Second, "workflow reaches review_plan wait_human", func() bool {
+		tk, gErr := env.tasks.Get(created.ID)
+		if gErr != nil {
+			return false
+		}
+		return tk.Workflow != nil &&
+			tk.Workflow.CurrentStep == "review_plan" &&
+			tk.Workflow.State == workflow.ExecWaiting
+	})
+
+	tkBefore, _ := env.tasks.Get(created.ID)
+	historyBefore := len(tkBefore.Workflow.StepHistory)
+
+	// Stray completion lands on the wait_human step. In the pre-fix engine
+	// this would drive resolveNext → ExecFailed; post-fix it's a silent
+	// no-op because output.AgentID != "" and human_action is unset.
+	env.engine.HandleAgentComplete(created.ID, "stray-duplicate-plan-agent", "late plan result", "stopped")
+	time.Sleep(50 * time.Millisecond)
+
+	tkAfter, _ := env.tasks.Get(created.ID)
+	if tkAfter.Workflow.State != workflow.ExecWaiting {
+		t.Errorf("state = %q, want ExecWaiting — stray completion must not fail wait_human",
+			tkAfter.Workflow.State)
+	}
+	if tkAfter.Workflow.CurrentStep != "review_plan" {
+		t.Errorf("current_step = %q, want review_plan", tkAfter.Workflow.CurrentStep)
+	}
+	if got := len(tkAfter.Workflow.StepHistory); got != historyBefore {
+		t.Errorf("step_history len = %d, want %d — stray completion must not append",
+			got, historyBefore)
+	}
+
+	// The user's reject click — the symptom that surfaced the bug — must
+	// now work. Pre-fix, HandleHumanAction would reject with "task X is
+	// not waiting for human action" because State had been flipped to
+	// ExecFailed by the stray completion's transition miss.
+	if err := env.engine.HandleHumanAction(created.ID, "reject",
+		map[string]string{"feedback": "needs more detail"}); err != nil {
+		t.Fatalf("HandleHumanAction reject after stray completion: %v", err)
+	}
+
+	// Reject must have recorded the wait_human step with action=reject and
+	// advanced the workflow past the gate. Either the engine is already
+	// spawning the next plan agent (CurrentStep=plan) or it came back
+	// around to review_plan after the new plan agent ran — both outcomes
+	// are acceptable; the invariant is that the workflow is not stuck in
+	// ExecFailed at review_plan.
+	tkPostReject, _ := env.tasks.Get(created.ID)
+	if tkPostReject.Workflow.State == workflow.ExecFailed {
+		t.Fatalf("workflow state after reject = ExecFailed — the bug reproduced")
+	}
+	if got := tkPostReject.Workflow.Variables["human_action"]; got != "reject" {
+		t.Errorf("human_action var = %q, want reject", got)
+	}
+	// review_plan must appear in step history with the reject as output —
+	// this is the proof that AdvanceStep ran to completion for the human
+	// action rather than being short-circuited by the defensive guard.
+	var reviewRec *workflow.StepRecord
+	for i := range tkPostReject.Workflow.StepHistory {
+		if tkPostReject.Workflow.StepHistory[i].StepID == "review_plan" {
+			reviewRec = &tkPostReject.Workflow.StepHistory[i]
+		}
+	}
+	if reviewRec == nil {
+		t.Fatal("review_plan missing from step history after reject")
+	}
+}
+
 // TestE2E_RestartStaleSkipsTerminalWorkflow verifies that restartStaleInProgress
 // does NOT respawn an agent on a task whose workflow is already terminal
 // (completed or failed). In prod, the absence of this guard produced a 5-min

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -82,23 +82,25 @@ const WorkflowVarDir = "_dir"
 
 // Engine executes workflow definitions against tasks.
 type Engine struct {
-	store    *Store
-	tasks    TaskProvider
-	agents   AgentLauncher
-	prLinker PRLinker
-	logger   *slog.Logger
-	mu       sync.Mutex
-	inflight map[string]struct{} // taskID → step in flight (prevent double-advance)
+	store      *Store
+	tasks      TaskProvider
+	agents     AgentLauncher
+	prLinker   PRLinker
+	logger     *slog.Logger
+	mu         sync.Mutex
+	inflight   map[string]struct{} // taskID → step in flight (prevent double-advance)
+	agentSteps map[string]string   // agentID → stepID it was spawned for
 }
 
 // NewEngine creates a workflow engine.
 func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *slog.Logger) *Engine {
 	return &Engine{
-		store:    store,
-		tasks:    tasks,
-		agents:   agents,
-		logger:   logger,
-		inflight: make(map[string]struct{}),
+		store:      store,
+		tasks:      tasks,
+		agents:     agents,
+		logger:     logger,
+		inflight:   make(map[string]struct{}),
+		agentSteps: make(map[string]string),
 	}
 }
 
@@ -236,46 +238,16 @@ func (e *Engine) DispatchEvent(taskID, event string, extraFields, vars map[strin
 // double-delivered callback — from triggering "step not found" errors that
 // would otherwise spam the log and re-persist the task file on every hit.
 func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
-	e.mu.Lock()
-	if _, ok := e.inflight[taskID]; ok {
-		e.mu.Unlock()
+	if !e.acquireInflight(taskID) {
 		e.logger.Debug("workflow.advance.skip", "task_id", taskID, "reason", "already_advancing")
 		return nil
 	}
-	e.inflight[taskID] = struct{}{}
-	e.mu.Unlock()
-	defer func() {
-		e.mu.Lock()
-		delete(e.inflight, taskID)
-		e.mu.Unlock()
-	}()
+	defer e.releaseInflight(taskID)
 
-	t, err := e.tasks.GetTask(taskID)
-	if err != nil {
+	wfExec, def, currentStep, skip, err := e.loadAdvanceContext(taskID, output)
+	if err != nil || skip {
 		return err
 	}
-	if t.Workflow == nil {
-		return fmt.Errorf("task %s has no active workflow", taskID)
-	}
-	if t.Workflow.State == ExecCompleted || t.Workflow.State == ExecFailed {
-		e.logger.Debug("workflow.advance.skip",
-			"task_id", taskID, "reason", "workflow_terminal",
-			"state", string(t.Workflow.State), "step_id", output.StepID)
-		return nil
-	}
-	if output.StepID == "" {
-		e.logger.Debug("workflow.advance.skip",
-			"task_id", taskID, "reason", "empty_step_id",
-			"state", string(t.Workflow.State))
-		return nil
-	}
-
-	def, err := e.store.Get(t.Workflow.WorkflowID)
-	if err != nil {
-		return err
-	}
-
-	wfExec := t.Workflow
 
 	// Record step completion.
 	now := time.Now().UTC()
@@ -287,14 +259,8 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 		StartedAt: now,
 		EndedAt:   now,
 	})
-
 	if output.Output != "" {
 		wfExec.SetVar("step."+output.StepID+".output", truncate(output.Output, 2000))
-	}
-
-	currentStep := def.StepByID(output.StepID)
-	if currentStep == nil {
-		return fmt.Errorf("step %s not found in workflow %s", output.StepID, def.ID)
 	}
 
 	// Retry failed steps if max_retries configured and not exhausted.
@@ -313,7 +279,7 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 	}
 
 	// Re-read task for latest state (agent may have changed tags/status).
-	t, err = e.tasks.GetTask(taskID)
+	t, err := e.tasks.GetTask(taskID)
 	if err != nil {
 		return err
 	}
@@ -329,6 +295,81 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 
 	e.logger.Info("workflow.advance", "task_id", taskID, "from", output.StepID, "to", nextStep.ID)
 	return e.executeSteps(taskID, &def, nextStep, wfExec)
+}
+
+// acquireInflight attempts to mark a task as actively advancing. Returns
+// false when another AdvanceStep call already owns the slot, in which case
+// the caller must no-op rather than racing.
+func (e *Engine) acquireInflight(taskID string) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if _, ok := e.inflight[taskID]; ok {
+		return false
+	}
+	e.inflight[taskID] = struct{}{}
+	return true
+}
+
+// releaseInflight clears the in-flight marker for a task.
+func (e *Engine) releaseInflight(taskID string) {
+	e.mu.Lock()
+	delete(e.inflight, taskID)
+	e.mu.Unlock()
+}
+
+// loadAdvanceContext validates and resolves the state needed by AdvanceStep.
+// Returns skip=true (with nil error) for every legitimate no-op path: a
+// terminal workflow, an empty step ID, a stale step (the ResumeStalled-race
+// duplicate-agent guard), or an unexpected agent callback hitting a
+// wait_human step without a human_action var set (defense-in-depth).
+func (e *Engine) loadAdvanceContext(taskID string, output StepOutput) (*Execution, Definition, *Step, bool, error) {
+	var emptyDef Definition
+	t, err := e.tasks.GetTask(taskID)
+	if err != nil {
+		return nil, emptyDef, nil, false, err
+	}
+	if t.Workflow == nil {
+		return nil, emptyDef, nil, false, fmt.Errorf("task %s has no active workflow", taskID)
+	}
+	if t.Workflow.State == ExecCompleted || t.Workflow.State == ExecFailed {
+		e.logger.Debug("workflow.advance.skip",
+			"task_id", taskID, "reason", "workflow_terminal",
+			"state", string(t.Workflow.State), "step_id", output.StepID)
+		return nil, emptyDef, nil, true, nil
+	}
+	if output.StepID == "" {
+		e.logger.Debug("workflow.advance.skip",
+			"task_id", taskID, "reason", "empty_step_id",
+			"state", string(t.Workflow.State))
+		return nil, emptyDef, nil, true, nil
+	}
+	if output.StepID != t.Workflow.CurrentStep {
+		e.logger.Debug("workflow.advance.skip",
+			"task_id", taskID, "reason", "stale_step",
+			"output_step", output.StepID, "current_step", t.Workflow.CurrentStep,
+			"agent_id", output.AgentID)
+		return nil, emptyDef, nil, true, nil
+	}
+
+	def, err := e.store.Get(t.Workflow.WorkflowID)
+	if err != nil {
+		return nil, emptyDef, nil, false, err
+	}
+	currentStep := def.StepByID(output.StepID)
+	if currentStep == nil {
+		return nil, emptyDef, nil, false, fmt.Errorf("step %s not found in workflow %s", output.StepID, def.ID)
+	}
+
+	if currentStep.Type == StepWaitHuman && output.AgentID != "" {
+		if _, set := t.Workflow.Variables["human_action"]; !set {
+			e.logger.Debug("workflow.advance.skip",
+				"task_id", taskID, "reason", "wait_human_no_action",
+				"step", output.StepID, "agent_id", output.AgentID)
+			return nil, emptyDef, nil, true, nil
+		}
+	}
+
+	return t.Workflow, def, currentStep, false, nil
 }
 
 // HandleHumanAction processes approve/reject/input from the UI.
@@ -427,12 +468,23 @@ func (e *Engine) HandleAgentComplete(taskID, agentID, result, agentState string)
 	if t.Workflow.State == ExecCompleted || t.Workflow.State == ExecFailed {
 		e.logger.Debug("workflow.agent-complete.terminal",
 			"task_id", taskID, "agent_id", agentID, "state", string(t.Workflow.State))
+		e.clearAgentStep(agentID)
 		return
 	}
 	if t.Workflow.CurrentStep == "" {
 		e.logger.Debug("workflow.agent-complete.no-current-step",
 			"task_id", taskID, "agent_id", agentID, "state", string(t.Workflow.State))
+		e.clearAgentStep(agentID)
 		return
+	}
+
+	// Resolve the step this agent was actually spawned for. Fallback to the
+	// workflow's current step for agents that were never tracked (recovery
+	// flows calling with synthetic IDs). The resolved ID is then checked
+	// against the current step inside AdvanceStep to drop stale completions.
+	spawnedStep, tracked := e.lookupAgentStep(agentID)
+	if !tracked {
+		spawnedStep = t.Workflow.CurrentStep
 	}
 
 	status := "completed"
@@ -441,13 +493,33 @@ func (e *Engine) HandleAgentComplete(taskID, agentID, result, agentState string)
 	}
 
 	if err := e.AdvanceStep(taskID, StepOutput{
-		StepID:  t.Workflow.CurrentStep,
+		StepID:  spawnedStep,
 		Status:  status,
 		Output:  result,
 		AgentID: agentID,
 	}); err != nil {
 		e.logger.Error("workflow.agent-complete.advance", "task_id", taskID, "err", err)
 	}
+	e.clearAgentStep(agentID)
+}
+
+// lookupAgentStep returns the stepID an agent was spawned for and whether it
+// was tracked. Untracked agents fall back to the workflow's current step.
+func (e *Engine) lookupAgentStep(agentID string) (string, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	stepID, ok := e.agentSteps[agentID]
+	return stepID, ok
+}
+
+// clearAgentStep removes the agent→step mapping. Safe to call for unknown IDs.
+func (e *Engine) clearAgentStep(agentID string) {
+	if agentID == "" {
+		return
+	}
+	e.mu.Lock()
+	delete(e.agentSteps, agentID)
+	e.mu.Unlock()
 }
 
 // ResumeStalled finds tasks with running/waiting workflows where no agent
@@ -485,6 +557,20 @@ func (e *Engine) ResumeStalled() {
 			continue
 		}
 		if e.agents.HasRunningAgent(t.ID) {
+			continue
+		}
+		// Skip tasks whose step is currently being dispatched. Interactive
+		// spawns (worktree creation, rebase, agent process start) take
+		// several seconds during which no agent is yet registered — without
+		// this guard the ticker would spawn a duplicate and the second
+		// agent's completion would corrupt the workflow at the wait_human
+		// gate.
+		e.mu.Lock()
+		_, dispatching := e.inflight[t.ID]
+		e.mu.Unlock()
+		if dispatching {
+			e.logger.Debug("workflow.resume-stalled.skip",
+				"task_id", t.ID, "reason", "inflight", "step", step.ID)
 			continue
 		}
 
@@ -667,6 +753,13 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 	if err != nil {
 		return fmt.Errorf("start agent: %w", err)
 	}
+
+	// Track which step this agent was spawned for so HandleAgentComplete
+	// can detect stale completions (e.g. duplicate agent from a ResumeStalled
+	// race) rather than blindly crediting the current step.
+	e.mu.Lock()
+	e.agentSteps[agentID] = step.ID
+	e.mu.Unlock()
 
 	wfExec.State = ExecWaiting
 	e.logger.Info("workflow.run-agent", "task_id", taskID, "step", step.ID, "role", step.Config.Role, "agent_id", agentID)

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -921,10 +921,26 @@ func TestAdvanceStep_UnknownStepID(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// An advance for a step that does not match the workflow's current step
+	// is a stale completion (e.g. a duplicate agent from a ResumeStalled race,
+	// or a stray callback after the workflow advanced). The engine must
+	// silently no-op instead of crashing or mutating step history — that
+	// guard is what stops a second plan agent from driving review_plan into
+	// ExecFailed when its delayed completion arrives after the human gate.
 	agents.SimulateComplete("t1")
-	err := engine.AdvanceStep("t1", StepOutput{StepID: "nonexistent-step", Status: "completed"})
-	if err == nil {
-		t.Fatal("expected error for unknown step ID")
+	if err := engine.AdvanceStep("t1", StepOutput{StepID: "nonexistent-step", Status: "completed"}); err != nil {
+		t.Fatalf("stale stepID should be a no-op, got err: %v", err)
+	}
+
+	ti, _ := tasks.GetTask("t1")
+	if ti.Workflow.CurrentStep != "triage" {
+		t.Errorf("CurrentStep = %q, want unchanged triage", ti.Workflow.CurrentStep)
+	}
+	if got := len(ti.Workflow.StepHistory); got != 0 {
+		t.Errorf("step history len = %d, want 0 — stale advance must not append", got)
+	}
+	if ti.Workflow.State != ExecWaiting {
+		t.Errorf("state = %q, want ExecWaiting (unchanged)", ti.Workflow.State)
 	}
 }
 
@@ -1813,6 +1829,250 @@ func TestExecEnsurePRClosesIssue_FetchErrorIsSoftFail(t *testing.T) {
 	after, _ := tasks.GetTask("t1")
 	if after.Status != "in-review" {
 		t.Errorf("task status = %q, want in-review (unchanged)", after.Status)
+	}
+}
+
+// TestDuplicatePlanAgent_StaleCompletionDoesNotFailWaitHuman reproduces the
+// production bug that left task 5a5ad276 stuck: a ResumeStalled race spawned
+// two plan agents; the first completed and advanced plan → review_plan
+// (wait_human); the second completed seconds later and the engine credited
+// its completion to the current step (review_plan), ran resolveNext with no
+// human_action var set, failed to match any transition, and set state to
+// ExecFailed. HandleHumanAction then refused the user's reject click with
+// "task X is not waiting for human action".
+//
+// The fix: HandleAgentComplete uses the step the agent was actually spawned
+// for (tracked in engine.agentSteps), and AdvanceStep drops completions whose
+// StepID doesn't match the workflow's current step.
+func TestDuplicatePlanAgent_StaleCompletionDoesNotFailWaitHuman(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "interactive"})
+	if err := engine.StartWorkflow("t1", "test-simple"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Triage runs → agent flips status to planning → advance into plan step.
+	triageAgent := agents.LastID()
+	tasks.SetStatus("t1", "planning")
+	agents.SimulateComplete("t1")
+	engine.HandleAgentComplete("t1", triageAgent, "triaged", "stopped")
+
+	planAgent1 := agents.LastID()
+	ti, _ := tasks.GetTask("t1")
+	if ti.Workflow.CurrentStep != "plan" {
+		t.Fatalf("precondition: current_step = %q, want plan", ti.Workflow.CurrentStep)
+	}
+
+	// Inject a duplicate plan agent as if a ResumeStalled ticker fired
+	// during the interactive-spawn window and raced the first agent. The
+	// engine.agentSteps mapping records what execRunAgent would have set.
+	agents.mu.Lock()
+	agents.counter++
+	planAgent2 := fmt.Sprintf("agent-%d", agents.counter)
+	agents.calls = append(agents.calls, startCall{TaskID: "t1", Role: "plan", Mode: "interactive"})
+	agents.running["t1"] = planAgent2
+	agents.roles["t1/plan"] = planAgent2
+	agents.mu.Unlock()
+	engine.mu.Lock()
+	engine.agentSteps[planAgent2] = "plan"
+	engine.mu.Unlock()
+
+	// Agent 1 completes first → workflow advances to review_plan/wait_human.
+	agents.SimulateComplete("t1")
+	engine.HandleAgentComplete("t1", planAgent1, "plan ready", "stopped")
+
+	ti, _ = tasks.GetTask("t1")
+	if ti.Workflow.CurrentStep != "review_plan" {
+		t.Fatalf("after first plan completion: current_step = %q, want review_plan", ti.Workflow.CurrentStep)
+	}
+	if ti.Workflow.State != ExecWaiting {
+		t.Fatalf("after first plan completion: state = %q, want ExecWaiting", ti.Workflow.State)
+	}
+
+	// Agent 2 (the duplicate) finishes seconds later. Old behavior would
+	// drive review_plan into ExecFailed. New behavior: dropped as stale.
+	engine.HandleAgentComplete("t1", planAgent2, "plan ready", "stopped")
+
+	ti, _ = tasks.GetTask("t1")
+	if ti.Workflow.State != ExecWaiting {
+		t.Errorf("after stale completion: state = %q, want ExecWaiting", ti.Workflow.State)
+	}
+	if ti.Workflow.CurrentStep != "review_plan" {
+		t.Errorf("after stale completion: current_step = %q, want review_plan", ti.Workflow.CurrentStep)
+	}
+
+	// The human's rejection must now succeed — this is the end-to-end
+	// symptom the user reported ("task is not waiting for human action").
+	if err := engine.HandleHumanAction("t1", "reject", map[string]string{"feedback": "try again"}); err != nil {
+		t.Fatalf("HandleHumanAction reject after stale duplicate: %v", err)
+	}
+
+	ti, _ = tasks.GetTask("t1")
+	if ti.Workflow.CurrentStep != "plan" {
+		t.Errorf("after reject: current_step = %q, want plan (loop back)", ti.Workflow.CurrentStep)
+	}
+}
+
+// TestHandleAgentComplete_WaitHumanWithoutActionIsNoop is the defense-in-depth
+// guard for the same bug. If a stray agent completion slips past the stale-
+// step check and lands on a wait_human step without a human_action var set
+// (e.g. an untracked legacy agent where HandleAgentComplete falls back to
+// CurrentStep), AdvanceStep must still refuse to run resolveNext. Otherwise
+// the workflow would fail on an unmatched transition and permanently seal
+// the human review gate.
+func TestHandleAgentComplete_WaitHumanWithoutActionIsNoop(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	// Put a task directly at the wait_human step with no agent tracked.
+	tasks.Put(TaskInfo{
+		ID:        "t1",
+		Status:    "plan-review",
+		AgentMode: "interactive",
+		Workflow: &Execution{
+			WorkflowID:  "test-simple",
+			CurrentStep: "review_plan",
+			State:       ExecWaiting,
+			Variables:   map[string]string{},
+		},
+	})
+
+	// Agent callback arrives for the current (wait_human) step with no
+	// human_action set. Must be a no-op.
+	engine.HandleAgentComplete("t1", "untracked-legacy-agent", "unexpected result", "stopped")
+
+	ti, _ := tasks.GetTask("t1")
+	if ti.Workflow.State != ExecWaiting {
+		t.Errorf("state = %q, want ExecWaiting — stray completion on wait_human must not fail the workflow",
+			ti.Workflow.State)
+	}
+	if ti.Workflow.CurrentStep != "review_plan" {
+		t.Errorf("current_step = %q, want review_plan", ti.Workflow.CurrentStep)
+	}
+	if got := len(ti.Workflow.StepHistory); got != 0 {
+		t.Errorf("step_history len = %d, want 0 — stray wait_human completion must not append", got)
+	}
+
+	// Rejection still works after the defense kicks in.
+	if err := engine.HandleHumanAction("t1", "approve", nil); err != nil {
+		t.Fatalf("HandleHumanAction approve: %v", err)
+	}
+}
+
+// TestResumeStalled_SkipsInflightDispatch exercises the ResumeStalled → race
+// that actually produced the duplicate spawn in prod. The ResumeStalled
+// ticker fires during the 1-3s window while an interactive plan step is
+// still preparing its worktree and starting the claude process — at that
+// point no agent is registered yet so HasRunningAgent returns false.
+// Without the inflight guard the ticker would call executeSteps → execRunAgent
+// and spawn a second agent for the same step. With the guard it must skip.
+func TestResumeStalled_SkipsInflightDispatch(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	// Task sitting at an interactive run_agent step with no running agent —
+	// the shape ResumeStalled normally resumes.
+	tasks.Put(TaskInfo{
+		ID:        "t1",
+		Status:    "planning",
+		AgentMode: "interactive",
+		Workflow: &Execution{
+			WorkflowID:  "test-simple",
+			CurrentStep: "plan",
+			State:       ExecWaiting,
+			Variables:   map[string]string{},
+		},
+	})
+
+	// Simulate the original dispatch being mid-flight inside AdvanceStep —
+	// inflight[t1] is set, no agent registered yet (worktree still being
+	// created in the real system, fake-claude hasn't started).
+	engine.mu.Lock()
+	engine.inflight["t1"] = struct{}{}
+	engine.mu.Unlock()
+
+	before := agents.CallCount()
+	engine.ResumeStalled()
+	if got := agents.CallCount(); got != before {
+		t.Errorf("ResumeStalled spawned a duplicate agent: calls %d → %d (expected no change while inflight)",
+			before, got)
+	}
+
+	// Once the original dispatch finishes and clears inflight, a subsequent
+	// tick is allowed to resume — that's the real recovery path.
+	engine.mu.Lock()
+	delete(engine.inflight, "t1")
+	engine.mu.Unlock()
+
+	engine.ResumeStalled()
+	if got := agents.CallCount(); got != before+1 {
+		t.Errorf("ResumeStalled after inflight cleared: calls %d → %d (want +1)", before, got)
+	}
+}
+
+// TestExecRunAgent_TracksSpawnedStep verifies that execRunAgent populates
+// the engine.agentSteps map so HandleAgentComplete can route completions
+// back to the right step. Without this mapping, a delayed completion from
+// a duplicate agent would be credited to whatever CurrentStep happens to
+// be at the moment — the exact bug that corrupted review_plan.
+func TestExecRunAgent_TracksSpawnedStep(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{ID: "t1", Status: "planning", AgentMode: "interactive"})
+
+	step := &Step{
+		ID:   "plan",
+		Type: StepRunAgent,
+		Config: StepConfig{
+			Role:   "plan",
+			Mode:   "interactive",
+			Prompt: "p",
+		},
+	}
+	wfExec := &Execution{
+		WorkflowID:  "test-simple",
+		CurrentStep: "plan",
+		State:       ExecRunning,
+		Variables:   map[string]string{},
+	}
+	ctx := TemplateContext{Task: TaskInfo{ID: "t1"}, Step: *step, Vars: wfExec.Variables}
+	if err := engine.execRunAgent("t1", step, wfExec, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	agentID := agents.LastID()
+	engine.mu.Lock()
+	gotStep, tracked := engine.agentSteps[agentID]
+	engine.mu.Unlock()
+	if !tracked {
+		t.Fatalf("agentSteps missing entry for agent %s", agentID)
+	}
+	if gotStep != "plan" {
+		t.Errorf("agentSteps[%s] = %q, want plan", agentID, gotStep)
+	}
+
+	// Completing the agent must clear its mapping so the map doesn't grow
+	// unbounded across long-lived sessions.
+	tasks.SetStatus("t1", "plan-review")
+	agents.SimulateComplete("t1")
+	engine.HandleAgentComplete("t1", agentID, "done", "stopped")
+
+	engine.mu.Lock()
+	_, stillThere := engine.agentSteps[agentID]
+	engine.mu.Unlock()
+	if stillThere {
+		t.Errorf("agentSteps still has %s after completion — mapping leaked", agentID)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Task stuck at `plan-review` with `workflow.state=failed`; UI reject errored with "task X is not waiting for human action". Root cause was a cascade of three bugs in the workflow engine, reproduced from `~/.synapse/logs/synapse.log`:

1. **ResumeStalled race.** Interactive plan spawn is slow (worktree prep + rebase + process start, ~3s). The periodic `ResumeStalled` ticker only checked `HasRunningAgent`; during the spawn window no agent was registered yet, so it happily called `executeSteps` again and started a duplicate plan agent.
2. **Completion misattribution.** `HandleAgentComplete` fed `t.Workflow.CurrentStep` into `AdvanceStep` as the step ID instead of the step the agent was actually spawned for. The first plan agent completed and advanced to `review_plan` (wait_human). The duplicate completed a beat later and its callback was credited to `review_plan`.
3. **Transition failure killed the workflow.** `resolveNext` on a wait_human step with no `human_action` var set produced "no matching transition found", which set `wfExec.State = ExecFailed` and sealed the human gate. `HandleHumanAction` then refused the user's reject click.

## Implementation information

**Engine tracks agents per step.** New `agentSteps map[string]string` populated in `execRunAgent` after `StartAgent` returns; `HandleAgentComplete` looks up the spawned step ID and falls back to `CurrentStep` only for untracked recovery paths. Mapping is cleared on completion (and on terminal workflow skips) so it does not grow unbounded.

**AdvanceStep drops stale completions.** If `output.StepID != wfExec.CurrentStep`, the call no-ops with a debug log instead of recording a bogus step and running `resolveNext`. The extracted `loadAdvanceContext` / `acquireInflight` / `releaseInflight` helpers also keep AdvanceStep under the `funlen` limit.

**Defense-in-depth at wait_human.** Even if a legacy/untracked agent slips through, an agent callback (non-empty `output.AgentID`) on a wait_human step with no `human_action` var set is a no-op. Only `HandleHumanAction` can drive the gate forward.

**ResumeStalled consults inflight.** Before calling `executeSteps`, `ResumeStalled` acquires `e.mu` and skips the task when `inflight[taskID]` is set — closing the race window during interactive-spawn dispatch.

### Tests

- `TestDuplicatePlanAgent_StaleCompletionDoesNotFailWaitHuman` (unit) — injects a duplicate plan agent, completes both, asserts the second completion is dropped and reject still works.
- `TestHandleAgentComplete_WaitHumanWithoutActionIsNoop` (unit) — defense-in-depth: stray untracked callback on a wait_human step must not corrupt state; approve still works after.
- `TestResumeStalled_SkipsInflightDispatch` (unit) — sets inflight, asserts no duplicate spawn; clears inflight, asserts normal resume works.
- `TestExecRunAgent_TracksSpawnedStep` (unit) — agentSteps populated on spawn and cleared on completion.
- `TestAdvanceStep_UnknownStepID` (updated) — stale stepID is now a no-op instead of an error; asserts history/state unchanged.
- `TestE2E_StaleAgentCompletionAtWaitHuman` (e2e) — drives the real engine through fake-claude to `review_plan`, fires a stray `HandleAgentComplete`, verifies state stays `ExecWaiting` and reject records the wait_human step with `human_action=reject`.

## Supporting documentation

Reproduced from production log lines in `~/.synapse/logs/synapse.log` around task `5a5ad276`:

```
workflow.advance triage → plan
worktree.created
workflow.resume-stalled step=plan              ← race
agent 0a449970 start                            (original)
agent c5d06656 start                            (duplicate)
...
workflow.advance plan → review_plan
workflow.wait-human review_plan
workflow.transition.failed step=review_plan err="no matching transition found"
workflow.agent-complete.advance err="no matching transition found"
```