### PR TITLE
fix(frontend): SvelteMap in stores for reactivity

### DIFF
--- a/frontend/src/components/ChatView.svelte
+++ b/frontend/src/components/ChatView.svelte
@@ -53,10 +53,7 @@
     }
   })
 
-  // Watch conversation changes to update local events + auto-scroll.
-  // Reading eventVersion triggers reactivity on every append without full Map copy.
   $effect(() => {
-    void convoStore.eventVersion
     const current = convoStore.conversations.get(agentId)
     if (current && current.length > events.length) {
       events = current

--- a/frontend/src/components/PlanFileView.svelte.test.ts
+++ b/frontend/src/components/PlanFileView.svelte.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent, screen } from '@testing-library/svelte'
+
+let resolveAdd: ((value: unknown) => void) | null = null
+
+vi.mock('../../wailsjs/go/main/ReviewService.js', () => ({
+  ListReviewComments: vi.fn().mockResolvedValue([]),
+  AddReviewComment: vi.fn(
+    () =>
+      new Promise((resolve) => {
+        resolveAdd = resolve
+      }),
+  ),
+  ResolveReviewComment: vi.fn().mockResolvedValue(undefined),
+  DeleteReviewComment: vi.fn().mockResolvedValue(undefined),
+}))
+
+const { commentStore } = await import('../stores/comments.svelte.js')
+const { default: PlanFileView } = await import('./PlanFileView.svelte')
+const { task } = await import('../../wailsjs/go/models.js')
+
+describe('PlanFileView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(commentStore as unknown as { byTask: Map<string, unknown> }).byTask.clear()
+    resolveAdd = null
+  })
+
+  it('renders optimistic comment immediately, before backend resolves', async () => {
+    render(PlanFileView, {
+      props: { taskId: 'task-1', planBody: 'first line\nsecond line' },
+    })
+
+    const addButtons = screen.getAllByTitle('Add comment')
+    await fireEvent.click(addButtons[0])
+
+    const textarea = screen.getByPlaceholderText('Add a comment...')
+    await fireEvent.input(textarea, { target: { value: 'needs work' } })
+
+    const submit = screen.getByRole('button', { name: 'Add Comment' })
+    await fireEvent.click(submit)
+
+    // Backend promise is still pending (resolveAdd not called).
+    // The optimistic comment must already be visible — this guards the
+    // Svelte 5 Map reactivity pitfall that caused the perceived delay.
+    expect(screen.getByText('needs work')).toBeDefined()
+
+    resolveAdd?.(
+      task.ReviewComment.createFrom({
+        id: 'persisted-1',
+        line: 1,
+        body: 'needs work',
+        resolved: false,
+        createdAt: '2026-04-10T00:00:00Z',
+      }),
+    )
+  })
+})

--- a/frontend/src/components/TerminalView.test.ts
+++ b/frontend/src/components/TerminalView.test.ts
@@ -48,7 +48,7 @@ describe('TerminalView', () => {
     vi.useFakeTimers()
     vi.clearAllMocks()
     agentStore.agents = new Map()
-    agentStore.outputs = new Map()
+    agentStore.outputs.clear()
     agentStore.error = ''
     agentStore.loading = false
   })

--- a/frontend/src/pages/Dashboard.test.ts
+++ b/frontend/src/pages/Dashboard.test.ts
@@ -89,7 +89,7 @@ function makeTask(overrides: Partial<task.Task> = {}): task.Task {
 describe('Dashboard', () => {
   beforeEach(() => {
     agentStore.agents = new Map()
-    agentStore.outputs = new Map()
+    agentStore.outputs.clear()
     agentStore.error = ''
     agentStore.loading = false
     taskStore.tasks = new Map()

--- a/frontend/src/stores/agents.svelte.test.ts
+++ b/frontend/src/stores/agents.svelte.test.ts
@@ -42,7 +42,7 @@ describe('AgentStore', () => {
     vi.clearAllMocks()
     // Reset store state
     agentStore.agents = new Map()
-    agentStore.outputs = new Map()
+    agentStore.outputs.clear()
     agentStore.error = ''
     agentStore.loading = false
     agentStore.stopPolling()

--- a/frontend/src/stores/agents.svelte.ts
+++ b/frontend/src/stores/agents.svelte.ts
@@ -1,3 +1,4 @@
+import { SvelteMap } from 'svelte/reactivity'
 import {
   StopAgent,
   ListAgents,
@@ -9,7 +10,7 @@ import { agent } from '../../wailsjs/go/models.js'
 import { EntityStore } from './entity-store.svelte.js'
 
 class AgentStore extends EntityStore<agent.Agent> {
-  outputs = $state<Map<string, agent.StreamEvent[]>>(new Map())
+  outputs = new SvelteMap<string, agent.StreamEvent[]>()
 
   constructor() {
     super(

--- a/frontend/src/stores/comments.svelte.ts
+++ b/frontend/src/stores/comments.svelte.ts
@@ -1,3 +1,4 @@
+import { SvelteMap } from 'svelte/reactivity'
 import {
   ListReviewComments,
   AddReviewComment,
@@ -7,7 +8,7 @@ import {
 import { task } from '../../wailsjs/go/models.js'
 
 class CommentStore {
-  private byTask = $state<Map<string, task.ReviewComment[]>>(new Map())
+  private byTask = new SvelteMap<string, task.ReviewComment[]>()
 
   get(taskID: string): task.ReviewComment[] {
     return this.byTask.get(taskID) ?? []

--- a/frontend/src/stores/convo.svelte.ts
+++ b/frontend/src/stores/convo.svelte.ts
@@ -1,3 +1,4 @@
+import { SvelteMap } from 'svelte/reactivity'
 import {
   GetConvoOutput,
   SendMessage,
@@ -14,28 +15,19 @@ export interface ApprovalRequest {
 }
 
 class ConvoStore {
-  conversations = $state<Map<string, agent.ConvoEvent[]>>(new Map())
-  pendingApprovals = $state<Map<string, ApprovalRequest>>(new Map())
+  conversations = new SvelteMap<string, agent.ConvoEvent[]>()
+  pendingApprovals = new SvelteMap<string, ApprovalRequest>()
 
   async getOutput(agentId: string): Promise<agent.ConvoEvent[]> {
     const events = (await GetConvoOutput(agentId)) ?? []
-    this.conversations = new Map(this.conversations).set(agentId, events)
+    this.conversations.set(agentId, events)
     return events
   }
 
   appendEvent(agentId: string, event: agent.ConvoEvent): void {
-    let arr = this.conversations.get(agentId)
-    if (!arr) {
-      arr = []
-      this.conversations.set(agentId, arr)
-    }
-    arr.push(event)
-    // Trigger Svelte reactivity with a version bump instead of full copy.
-    this.eventVersion++
+    const existing = this.conversations.get(agentId) ?? []
+    this.conversations.set(agentId, [...existing, event])
   }
-
-  // Bump counter to trigger Svelte reactivity without copying the Map.
-  eventVersion = $state(0)
 
   async sendMessage(agentId: string, text: string): Promise<void> {
     await SendMessage(agentId, text)
@@ -43,9 +35,7 @@ class ConvoStore {
 
   async respondApproval(toolUseId: string, approved: boolean): Promise<void> {
     await RespondApproval(toolUseId, approved)
-    const next = new Map(this.pendingApprovals)
-    next.delete(toolUseId)
-    this.pendingApprovals = next
+    this.pendingApprovals.delete(toolUseId)
   }
 
   subscribe(agentId: string): () => void {
@@ -59,7 +49,7 @@ class ConvoStore {
     const unsubApproval = EventsOn(
       agentApproval(agentId),
       (req: ApprovalRequest) => {
-        this.pendingApprovals = new Map(this.pendingApprovals).set(req.toolUseId, req)
+        this.pendingApprovals.set(req.toolUseId, req)
       },
     )
 


### PR DESCRIPTION
## Motivation

Adding a comment to a plan in the GUI plan review felt unresponsive — the new comment only appeared after a noticeable delay, not immediately on click. The comment store already did optimistic updates, yet the UI never reflected them until something else forced a re-render.

Root cause: plain `Map` wrapped in `$state` is **not** deeply reactive in Svelte 5. Only plain objects and arrays get the reactive proxy; classes like `Map`/`Set` need `SvelteMap`/`SvelteSet` from `svelte/reactivity`. Mutations via `byTask.set(...)` silently skipped reactivity, so optimistic comments were invisible until `submitting = false` (or another `$state` flip) triggered a re-render — which only happened after the full backend roundtrip (read + unmarshal + marshal + `os.WriteFile` of `.comments.json`).

Same latent bug in `agents.outputs` and `convo.conversations` / `pendingApprovals`. `convo` had an `eventVersion` counter as a workaround, now removable.

## Implementation information

- `comments.svelte.ts` — `byTask` → `SvelteMap`
- `agents.svelte.ts` — `outputs` → `SvelteMap`
- `convo.svelte.ts` — `conversations`, `pendingApprovals` → `SvelteMap`; dropped `eventVersion` bump hack
- `ChatView.svelte` — dropped `void convoStore.eventVersion` workaround
- Tests updated to use `.clear()` instead of reassigning `outputs`
- New `PlanFileView.svelte.test.ts` asserts the optimistic comment is visible **before** the backend promise resolves (verified: fails on pre-fix code, passes after)

`entity-store.svelte.ts` intentionally left alone — its reassignment pattern (`this.items = new Map(this.items).set(...)`) already triggers reactivity correctly.

## Supporting documentation

Svelte 5 docs: https://svelte.dev/docs/svelte/svelte-reactivity — `SvelteMap`/`SvelteSet` are required for reactive collection mutations.

> Changelog: fix(frontend): SvelteMap in stores for reactivity