### PR TITLE
feat(frontend): light/dark color scheme toggle

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,6 +2,22 @@ import './style.css'
 import { mount } from 'svelte'
 import App from './App.svelte'
 
+type ColorScheme = 'system' | 'light' | 'dark'
+
+function applyColorScheme(scheme: ColorScheme) {
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+  const isDark = scheme === 'dark' || (scheme === 'system' && prefersDark)
+  document.documentElement.classList.toggle('dark', isDark)
+}
+
+const saved = (localStorage.getItem('colorScheme') ?? 'system') as ColorScheme
+applyColorScheme(saved)
+
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+  const current = (localStorage.getItem('colorScheme') ?? 'system') as ColorScheme
+  if (current === 'system') applyColorScheme('system')
+})
+
 const app = mount(App, {
   target: document.getElementById('app')!,
 })

--- a/frontend/src/pages/Settings.svelte
+++ b/frontend/src/pages/Settings.svelte
@@ -2,6 +2,23 @@
   import { GetSettings, UpdateSettings } from '../../wailsjs/go/main/ConfigService.js'
   import type { main } from '../../wailsjs/go/models.js'
 
+  type ColorScheme = 'system' | 'light' | 'dark'
+
+  let colorScheme = $state<ColorScheme>(
+    (localStorage.getItem('colorScheme') ?? 'system') as ColorScheme
+  )
+
+  function applyColorScheme(scheme: ColorScheme) {
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+    const isDark = scheme === 'dark' || (scheme === 'system' && prefersDark)
+    document.documentElement.classList.toggle('dark', isDark)
+    localStorage.setItem('colorScheme', scheme)
+  }
+
+  $effect(() => {
+    applyColorScheme(colorScheme)
+  })
+
   type AppSettings = main.AppSettings
 
   let settings = $state<AppSettings | null>(null)
@@ -96,6 +113,24 @@
       >
         {saving ? 'Saving…' : 'Save'}
       </button>
+    </div>
+  </div>
+
+  <!-- Appearance (localStorage-backed, no save required) -->
+  <div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
+    <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Appearance</h2>
+    <div class="flex flex-col gap-1 sm:max-w-xs">
+      <label class="text-sm font-medium" for="color-scheme">Color Scheme</label>
+      <select
+        id="color-scheme"
+        class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
+        bind:value={colorScheme}
+      >
+        <option value="system">System</option>
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+      </select>
+      <span class="text-xs text-surface-400">Applied immediately, no save needed</span>
     </div>
   </div>
 

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3,6 +3,8 @@
 @import '@skeletonlabs/skeleton-svelte';
 @import '@skeletonlabs/skeleton/themes/vox';
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 html, body {
   margin: 0;
   padding: 0;
@@ -19,9 +21,7 @@ html, body {
   background-color: var(--color-surface-200);
 }
 
-@media (prefers-color-scheme: dark) {
-  [data-active] {
-    background-color: var(--color-surface-700);
-  }
+.dark [data-active] {
+  background-color: var(--color-surface-700);
 }
 


### PR DESCRIPTION
## Motivation

Add a light/dark/system color scheme toggle in the Settings page. Previously, the app only respected the OS `prefers-color-scheme` media query with no way to override it.

## Implementation information

- Switched Tailwind CSS v4's `dark` variant from media-query-based to class-based via `@custom-variant dark (&:where(.dark, .dark *));` in `style.css` — this also affects Skeleton UI's internal `@variant dark` uses since they resolve through the same Tailwind variant
- `main.ts` reads `localStorage.colorScheme` and applies `.dark` class to `<html>` synchronously before mount (prevents FOUC)
- Watches `prefers-color-scheme` media query to auto-update when in system mode
- Settings page has a new "Appearance" section with a `<select>` for system/light/dark — applied immediately via `$effect`, persisted to `localStorage` (no backend save required)

## Supporting documentation

> Changelog: feat(frontend): light/dark color scheme toggle in settings