### PR TITLE
feat(agent): codex session discovery

### DIFF
--- a/internal/agent/discovery.go
+++ b/internal/agent/discovery.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -32,9 +34,12 @@ type claudeSession struct {
 var nonAlphanumDash = regexp.MustCompile(`[^a-zA-Z0-9-]`)
 
 func (m *Manager) DiscoverAgents() []*Agent {
-	sessions := readClaudeSessions()
+	claudeSessions := readClaudeSessions()
+	codexSessions := readCodexSessions()
 	m.refreshTracked()
-	return m.discoverNew(sessions)
+	discovered := m.discoverNew(claudeSessions)
+	discovered = append(discovered, m.discoverNewCodex(codexSessions)...)
+	return discovered
 }
 
 // refreshTracked updates state of already-tracked external agents.
@@ -46,6 +51,8 @@ func (m *Manager) refreshTracked() {
 		pid       int
 		cwd       string
 		sessionID string
+		provider  string
+		filePath  string
 	}
 
 	m.mu.RLock()
@@ -54,19 +61,48 @@ func (m *Manager) refreshTracked() {
 		if !a.External {
 			continue
 		}
-		snaps = append(snaps, snap{a: a, pid: a.PID, cwd: a.sessionCWD, sessionID: a.GetSessionID()})
+		snaps = append(snaps, snap{
+			a:         a,
+			pid:       a.PID,
+			cwd:       a.sessionCWD,
+			sessionID: a.GetSessionID(),
+			provider:  a.Provider,
+			filePath:  a.GetSessionFilePath(),
+		})
 	}
 	m.mu.RUnlock()
 
 	for _, s := range snaps {
 		var next State
-		if !processAlive(s.pid) {
-			next = StateStopped
+		if s.provider == "codex" {
+			next = refreshCodexAgent(s.pid, s.filePath)
 		} else {
-			next = inferState(s.cwd, s.sessionID)
+			if !processAlive(s.pid) {
+				next = StateStopped
+			} else {
+				next = inferState(s.cwd, s.sessionID)
+			}
 		}
 		s.a.SetState(next)
 	}
+}
+
+func refreshCodexAgent(pid int, filePath string) State {
+	if pid != 0 && processAlive(pid) {
+		if filePath != "" {
+			return inferCodexState(filePath)
+		}
+		return StateRunning
+	}
+	if pid != 0 {
+		// Had a PID, process is now dead.
+		return StateStopped
+	}
+	// No PID: use file mod time as proxy.
+	if filePath != "" {
+		return inferCodexState(filePath)
+	}
+	return StateIdle
 }
 
 // discoverNew registers and returns external agents not yet tracked.
@@ -284,4 +320,325 @@ func sessionKind(kind string) string {
 		return "headless"
 	}
 	return "interactive"
+}
+
+// codexSessionMaxAge is the cutoff for Codex session discovery.
+// Sessions older than this are almost certainly dead.
+const codexSessionMaxAge = 24 * time.Hour
+
+type codexSession struct {
+	SessionID  string
+	CWD        string
+	Originator string // "codex_exec" or "codex_tui"
+	StartedAt  time.Time
+	FilePath   string
+	Branch     string
+}
+
+func readCodexSessions() []codexSession {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	return readCodexSessionsFromDir(filepath.Join(home, ".codex", "sessions"))
+}
+
+func readCodexSessionsFromDir(sessDir string) []codexSession {
+	root, err := os.OpenRoot(sessDir)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = root.Close() }()
+
+	type candidate struct {
+		path    string
+		relPath string
+	}
+	var candidates []candidate
+	_ = filepath.WalkDir(sessDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".jsonl" {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if time.Since(info.ModTime()) > codexSessionMaxAge {
+			return nil
+		}
+		relPath, err := filepath.Rel(sessDir, path)
+		if err != nil {
+			return err
+		}
+		candidates = append(candidates, candidate{path: path, relPath: relPath})
+		return nil
+	})
+
+	var sessions []codexSession
+	for _, c := range candidates {
+		f, err := root.Open(c.relPath)
+		if err != nil {
+			continue
+		}
+		scanner := bufio.NewScanner(f)
+		if !scanner.Scan() {
+			_ = f.Close()
+			continue
+		}
+		line := make([]byte, len(scanner.Bytes()))
+		copy(line, scanner.Bytes())
+		_ = f.Close()
+
+		var meta struct {
+			Type      string    `json:"type"`
+			Timestamp time.Time `json:"timestamp"`
+			Payload   struct {
+				ID         string `json:"id"`
+				CWD        string `json:"cwd"`
+				Originator string `json:"originator"`
+				Git        struct {
+					Branch string `json:"branch"`
+				} `json:"git"`
+			} `json:"payload"`
+		}
+		if err := json.Unmarshal(line, &meta); err != nil {
+			continue
+		}
+		if meta.Type != "session_meta" {
+			continue
+		}
+		sessions = append(sessions, codexSession{
+			SessionID:  meta.Payload.ID,
+			CWD:        meta.Payload.CWD,
+			Originator: meta.Payload.Originator,
+			StartedAt:  meta.Timestamp,
+			FilePath:   c.path,
+			Branch:     meta.Payload.Git.Branch,
+		})
+	}
+	return sessions
+}
+
+type codexEventState struct {
+	eventType   string
+	payloadType string
+	stale       bool
+}
+
+func readLastCodexEvent(filePath string) codexEventState {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return codexEventState{}
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil {
+		return codexEventState{}
+	}
+
+	stale := time.Since(info.ModTime()) > staleThreshold
+
+	offset := max(info.Size()-tailReadBytes, 0)
+	if _, err := f.Seek(offset, 0); err != nil {
+		return codexEventState{}
+	}
+
+	var lastLine string
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, scannerInitialBuf), scannerMaxBuf)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) != "" {
+			lastLine = line
+		}
+	}
+
+	if lastLine == "" {
+		return codexEventState{stale: stale}
+	}
+
+	var ev struct {
+		Type    string `json:"type"`
+		Payload struct {
+			Type string `json:"type"`
+		} `json:"payload"`
+	}
+	if err := json.Unmarshal([]byte(lastLine), &ev); err != nil {
+		return codexEventState{stale: stale}
+	}
+
+	return codexEventState{
+		eventType:   ev.Type,
+		payloadType: ev.Payload.Type,
+		stale:       stale,
+	}
+}
+
+func inferCodexState(filePath string) State {
+	ev := readLastCodexEvent(filePath)
+
+	switch ev.eventType {
+	case "event_msg":
+		switch ev.payloadType {
+		case "task_complete", "turn_aborted":
+			return StateStopped
+		case "task_started":
+			if !ev.stale {
+				return StateRunning
+			}
+			return StateIdle
+		case "agent_message":
+			if !ev.stale {
+				return StateRunning
+			}
+			return StateIdle
+		default:
+			// token_count and anything else → idle
+			return StateIdle
+		}
+	case "response_item":
+		if !ev.stale {
+			return StateRunning
+		}
+		return StatePaused
+	}
+	// session_meta only, empty, or unknown event type
+	return StateIdle
+}
+
+// findCodexPIDs returns a CWD→PID map for running codex processes (macOS only).
+func findCodexPIDs() map[string]int {
+	out, err := exec.Command("pgrep", "-f", "codex").Output()
+	if err != nil {
+		return nil
+	}
+
+	result := make(map[string]int)
+	for pidStr := range strings.FieldsSeq(string(out)) {
+		lsofOut, err := exec.Command("lsof", "-a", "-d", "cwd", "-Fn", "-p", pidStr).Output()
+		if err != nil {
+			continue
+		}
+		cwd := parseLsofCWD(string(lsofOut))
+		if cwd == "" {
+			continue
+		}
+		var pid int
+		if _, err := fmt.Sscanf(pidStr, "%d", &pid); err != nil || pid == 0 {
+			continue
+		}
+		result[cwd] = pid
+	}
+	return result
+}
+
+func parseLsofCWD(output string) string {
+	lines := strings.Split(output, "\n")
+	for i, line := range lines {
+		if line == "fcwd" && i+1 < len(lines) && strings.HasPrefix(lines[i+1], "n") {
+			return lines[i+1][1:]
+		}
+	}
+	return ""
+}
+
+func (m *Manager) discoverNewCodex(sessions []codexSession) []*Agent {
+	m.mu.RLock()
+	trackedPaths := make(map[string]bool)
+	trackedSessionIDs := make(map[string]bool)
+	for _, a := range m.agents {
+		if fp := a.GetSessionFilePath(); fp != "" {
+			trackedPaths[fp] = true
+		}
+		if sid := a.GetSessionID(); sid != "" {
+			trackedSessionIDs[sid] = true
+		}
+	}
+	m.mu.RUnlock()
+
+	pidMap := findCodexPIDs()
+
+	var discovered []*Agent
+	for _, s := range sessions {
+		if trackedPaths[s.FilePath] || trackedSessionIDs[s.SessionID] {
+			continue
+		}
+
+		state := inferCodexState(s.FilePath)
+		pid := pidMap[s.CWD]
+
+		// Skip sessions that are dead with no associated process.
+		if state == StateStopped && pid == 0 {
+			continue
+		}
+
+		mode := "headless"
+		if s.Originator == "codex_tui" {
+			mode = "interactive"
+		}
+
+		shortID := s.SessionID
+		if len(shortID) > 8 {
+			shortID = shortID[:8]
+		}
+
+		a := &Agent{
+			ID:              fmt.Sprintf("ext-codex-%s", shortID),
+			Mode:            mode,
+			State:           state,
+			External:        true,
+			PID:             pid,
+			SessionID:       s.SessionID,
+			StartedAt:       s.StartedAt,
+			Project:         projectName(s.CWD),
+			Provider:        "codex",
+			sessionCWD:      s.CWD,
+			sessionFilePath: s.FilePath,
+		}
+
+		m.mu.Lock()
+		if _, exists := m.agents[a.ID]; !exists {
+			m.agents[a.ID] = a
+		}
+		m.mu.Unlock()
+
+		discovered = append(discovered, a)
+	}
+	return discovered
+}
+
+// resolveCodexSessionFile returns the JSONL path for a given Codex session ID.
+// It walks ~/.codex/sessions/ looking for rollout-{sessionID}.jsonl.
+func resolveCodexSessionFile(sessionID string) string {
+	if sessionID == "" {
+		return ""
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return resolveCodexSessionFileInDir(filepath.Join(home, ".codex", "sessions"), sessionID)
+}
+
+func resolveCodexSessionFileInDir(sessDir, sessionID string) string {
+	target := "rollout-" + sessionID + ".jsonl"
+	var result string
+	_ = filepath.WalkDir(sessDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if filepath.Base(path) == target {
+			result = path
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return result
 }

--- a/internal/agent/discovery_test.go
+++ b/internal/agent/discovery_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -288,5 +289,322 @@ func TestProcessAlive(t *testing.T) {
 	// PID 0 or very high PID should not be alive
 	if processAlive(9999999) {
 		t.Error("PID 9999999 should not be alive")
+	}
+}
+
+func writeCodexSessionFile(t *testing.T, dir, sessionID string, modTime time.Time) string {
+	t.Helper()
+	dateDir := filepath.Join(dir, "2024", "01", "01")
+	if err := os.MkdirAll(dateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dateDir, "rollout-"+sessionID+".jsonl")
+	meta := `{"type":"session_meta","timestamp":"2024-01-01T00:00:00Z","payload":{"id":"` + sessionID + `","cwd":"/tmp/project","originator":"codex_exec","git":{"branch":"main"}}}`
+	if err := os.WriteFile(path, []byte(meta+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestReadCodexSessions(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	sessionID := "01ABCDEF01ABCDEF01ABCDE"
+	path := writeCodexSessionFile(t, dir, sessionID, now)
+
+	sessions := readCodexSessionsFromDir(dir)
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions))
+	}
+	s := sessions[0]
+	if s.SessionID != sessionID {
+		t.Errorf("SessionID = %q, want %q", s.SessionID, sessionID)
+	}
+	if s.CWD != "/tmp/project" {
+		t.Errorf("CWD = %q, want /tmp/project", s.CWD)
+	}
+	if s.Originator != "codex_exec" {
+		t.Errorf("Originator = %q, want codex_exec", s.Originator)
+	}
+	if s.Branch != "main" {
+		t.Errorf("Branch = %q, want main", s.Branch)
+	}
+	if s.FilePath != path {
+		t.Errorf("FilePath = %q, want %q", s.FilePath, path)
+	}
+}
+
+func TestReadCodexSessionsSkipOld(t *testing.T) {
+	dir := t.TempDir()
+	old := time.Now().Add(-25 * time.Hour)
+	writeCodexSessionFile(t, dir, "OLD0000000000000000000", old)
+
+	recent := time.Now().Add(-1 * time.Hour)
+	writeCodexSessionFile(t, dir, "NEW0000000000000000000", recent)
+
+	sessions := readCodexSessionsFromDir(dir)
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1 (old should be skipped)", len(sessions))
+	}
+	if sessions[0].SessionID != "NEW0000000000000000000" {
+		t.Errorf("expected recent session, got %q", sessions[0].SessionID)
+	}
+}
+
+func TestReadLastCodexEvent(t *testing.T) {
+	tests := []struct {
+		name            string
+		lines           []string
+		stale           bool
+		wantEventType   string
+		wantPayloadType string
+	}{
+		{
+			name:          "empty file",
+			lines:         nil,
+			wantEventType: "",
+		},
+		{
+			name:            "task_complete",
+			lines:           []string{`{"type":"event_msg","payload":{"type":"task_complete"}}`},
+			wantEventType:   "event_msg",
+			wantPayloadType: "task_complete",
+		},
+		{
+			name:          "response_item",
+			lines:         []string{`{"type":"response_item","payload":{}}`},
+			wantEventType: "response_item",
+		},
+		{
+			name:            "multiple lines, last wins",
+			lines:           []string{`{"type":"session_meta"}`, `{"type":"event_msg","payload":{"type":"agent_message"}}`},
+			wantEventType:   "event_msg",
+			wantPayloadType: "agent_message",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			path := filepath.Join(dir, "session.jsonl")
+
+			content := strings.Join(tt.lines, "\n")
+			if content != "" {
+				content += "\n"
+			}
+			if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if tt.stale {
+				past := time.Now().Add(-30 * time.Second)
+				if err := os.Chtimes(path, past, past); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			ev := readLastCodexEvent(path)
+			if ev.eventType != tt.wantEventType {
+				t.Errorf("eventType = %q, want %q", ev.eventType, tt.wantEventType)
+			}
+			if ev.payloadType != tt.wantPayloadType {
+				t.Errorf("payloadType = %q, want %q", ev.payloadType, tt.wantPayloadType)
+			}
+		})
+	}
+}
+
+func TestInferCodexState(t *testing.T) {
+	tests := []struct {
+		name        string
+		eventType   string
+		payloadType string
+		stale       bool
+		want        State
+	}{
+		{"task_complete → stopped", "event_msg", "task_complete", false, StateStopped},
+		{"task_complete stale → stopped", "event_msg", "task_complete", true, StateStopped},
+		{"turn_aborted → stopped", "event_msg", "turn_aborted", false, StateStopped},
+		{"task_started fresh → running", "event_msg", "task_started", false, StateRunning},
+		{"task_started stale → idle", "event_msg", "task_started", true, StateIdle},
+		{"agent_message fresh → running", "event_msg", "agent_message", false, StateRunning},
+		{"agent_message stale → idle", "event_msg", "agent_message", true, StateIdle},
+		{"token_count → idle", "event_msg", "token_count", true, StateIdle},
+		{"response_item fresh → running", "response_item", "", false, StateRunning},
+		{"response_item stale → paused", "response_item", "", true, StatePaused},
+		{"session_meta only → idle", "session_meta", "", true, StateIdle},
+		{"empty → idle", "", "", true, StateIdle},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			path := filepath.Join(dir, "session.jsonl")
+
+			if tt.eventType != "" {
+				line := `{"type":"` + tt.eventType + `","payload":{"type":"` + tt.payloadType + `"}}`
+				if err := os.WriteFile(path, []byte(line+"\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				if err := os.WriteFile(path, []byte(""), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if tt.stale {
+				past := time.Now().Add(-30 * time.Second)
+				if err := os.Chtimes(path, past, past); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			got := inferCodexState(path)
+			if got != tt.want {
+				t.Errorf("inferCodexState = %q, want %q (event=%q payload=%q stale=%v)",
+					got, tt.want, tt.eventType, tt.payloadType, tt.stale)
+			}
+		})
+	}
+}
+
+func TestDiscoverNewCodex(t *testing.T) {
+	m, _ := newTestManager(t)
+	sessDir := t.TempDir()
+
+	sessionID := "01TESTCODEXSESSIONID00"
+	now := time.Now()
+	filePath := writeCodexSessionFile(t, sessDir, sessionID, now)
+
+	sessions := []codexSession{
+		{
+			SessionID:  sessionID,
+			CWD:        "/tmp/project",
+			Originator: "codex_exec",
+			StartedAt:  now,
+			FilePath:   filePath,
+			Branch:     "main",
+		},
+	}
+
+	discovered := m.discoverNewCodex(sessions)
+	if len(discovered) != 1 {
+		t.Fatalf("got %d agents, want 1", len(discovered))
+	}
+	a := discovered[0]
+	if a.Provider != "codex" {
+		t.Errorf("Provider = %q, want codex", a.Provider)
+	}
+	if !a.External {
+		t.Error("External should be true")
+	}
+	if a.Mode != "headless" {
+		t.Errorf("Mode = %q, want headless", a.Mode)
+	}
+	if a.SessionID != sessionID {
+		t.Errorf("SessionID = %q, want %q", a.SessionID, sessionID)
+	}
+	if a.sessionFilePath != filePath {
+		t.Errorf("sessionFilePath = %q, want %q", a.sessionFilePath, filePath)
+	}
+	if !strings.HasPrefix(a.ID, "ext-codex-") {
+		t.Errorf("ID = %q, want ext-codex-* prefix", a.ID)
+	}
+
+	// Second call should not re-discover the same agent.
+	discovered2 := m.discoverNewCodex(sessions)
+	if len(discovered2) != 0 {
+		t.Errorf("re-discovery got %d agents, want 0", len(discovered2))
+	}
+}
+
+func TestDiscoverNewCodexInteractive(t *testing.T) {
+	m, _ := newTestManager(t)
+	dir := t.TempDir()
+
+	sessionID := "01TUISESSIONID000000000"
+	filePath := writeCodexSessionFile(t, dir, sessionID, time.Now())
+
+	sessions := []codexSession{
+		{SessionID: sessionID, CWD: "/home/user/proj", Originator: "codex_tui", FilePath: filePath, StartedAt: time.Now()},
+	}
+
+	discovered := m.discoverNewCodex(sessions)
+	if len(discovered) != 1 {
+		t.Fatalf("got %d agents, want 1", len(discovered))
+	}
+	if discovered[0].Mode != "interactive" {
+		t.Errorf("Mode = %q, want interactive", discovered[0].Mode)
+	}
+}
+
+func TestRefreshTrackedCodex(t *testing.T) {
+	m, _ := newTestManager(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+
+	// Write a stopped event.
+	line := `{"type":"event_msg","payload":{"type":"task_complete"}}`
+	if err := os.WriteFile(path, []byte(line+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &Agent{
+		ID:              "ext-codex-test",
+		External:        true,
+		Provider:        "codex",
+		State:           StateRunning,
+		sessionFilePath: path,
+	}
+	m.mu.Lock()
+	m.agents[a.ID] = a
+	m.mu.Unlock()
+
+	m.refreshTracked()
+
+	if got := a.GetState(); got != StateStopped {
+		t.Errorf("state = %q after task_complete, want stopped", got)
+	}
+
+	// Update to idle event and refresh again.
+	line2 := `{"type":"event_msg","payload":{"type":"token_count"}}`
+	if err := os.WriteFile(path, []byte(line2+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-30 * time.Second)
+	if err := os.Chtimes(path, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	m.refreshTracked()
+	if got := a.GetState(); got != StateIdle {
+		t.Errorf("state = %q after token_count stale, want idle", got)
+	}
+}
+
+func TestResolveCodexSessionFileInDir(t *testing.T) {
+	dir := t.TempDir()
+	sessionID := "01RESOLVE0000000000000"
+	dateDir := filepath.Join(dir, "2024", "03", "15")
+	if err := os.MkdirAll(dateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	expected := filepath.Join(dateDir, "rollout-"+sessionID+".jsonl")
+	if err := os.WriteFile(expected, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolveCodexSessionFileInDir(dir, sessionID)
+	if got != expected {
+		t.Errorf("got %q, want %q", got, expected)
+	}
+
+	// Non-existent session ID should return empty.
+	got2 := resolveCodexSessionFileInDir(dir, "NOTFOUND000000000000000")
+	if got2 != "" {
+		t.Errorf("expected empty for missing session, got %q", got2)
 	}
 }

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -53,12 +53,13 @@ type Agent struct {
 	TurnCount        int    `json:"turnCount,omitempty"`
 	EscalationReason string `json:"escalationReason,omitempty"`
 
-	ExitErr      error `json:"-"`
-	outputBuffer []StreamEvent
-	convoBuffer  []ConvoEvent
-	cmd          *exec.Cmd
-	cancel       context.CancelFunc
-	sessionCWD   string
+	ExitErr         error `json:"-"`
+	outputBuffer    []StreamEvent
+	convoBuffer     []ConvoEvent
+	cmd             *exec.Cmd
+	cancel          context.CancelFunc
+	sessionCWD      string
+	sessionFilePath string // path to provider session file (Codex JSONL)
 	// done is closed when the headless/conversational goroutine has fully exited.
 	// Used by HasRunningAgentForTask to guard worktree cleanup.
 	done chan struct{}
@@ -156,6 +157,20 @@ func (a *Agent) GetSessionID() string {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.SessionID
+}
+
+// SetSessionFilePath records the path to the provider session file.
+func (a *Agent) SetSessionFilePath(p string) {
+	a.mu.Lock()
+	a.sessionFilePath = p
+	a.mu.Unlock()
+}
+
+// GetSessionFilePath returns the provider session file path.
+func (a *Agent) GetSessionFilePath() string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.sessionFilePath
 }
 
 // AddResultStats merges a result-event's stats into the running totals

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -180,6 +180,9 @@ func (m *Manager) streamCodexConvoOutput(a *Agent, stdout io.Reader, outFile io.
 		case "system":
 			if event.SessionID != "" {
 				a.SetSessionID(event.SessionID)
+				if p := resolveCodexSessionFile(event.SessionID); p != "" {
+					a.SetSessionFilePath(p)
+				}
 			}
 		case "result":
 			costNow := a.AddResultStats(event.SessionID, event.CostUSD, event.InputTokens, event.OutputTokens)

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -185,6 +185,12 @@ func (m *Manager) streamHeadlessOutput(ctx context.Context, a *Agent, stdout io.
 			lastEmit = time.Now()
 		}
 
+		if event.Type == "init" && event.SessionID != "" && a.Provider == "codex" {
+			if p := resolveCodexSessionFile(event.SessionID); p != "" {
+				a.SetSessionFilePath(p)
+			}
+		}
+
 		if event.Type == "assistant" {
 			turns := a.IncTurnCount()
 			m.mu.RLock()


### PR DESCRIPTION
## Motivation

Codex sessions were not discovered or tracked. `DiscoverAgents()` only read `~/.claude/sessions/*.json`. Codex stores sessions differently: date-bucketed JSONL at `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl` with no PID files. Additionally, synapse-created Codex agents captured `thread_id` but did not track the session file path, so `refreshTracked()` could not infer their state post-restart.

## Implementation information

**New discovery pipeline:**
- `readCodexSessions()` walks `~/.codex/sessions/` for JSONL files ≤24h old, reads `session_meta` first line via `os.OpenRoot` (TOCTOU-safe), returns `[]codexSession` with ID, CWD, originator, branch
- `inferCodexState(filePath)` + `readLastCodexEvent(filePath)` parse the last JSONL line to map Codex event types (`event_msg`, `response_item`, etc.) to `State`
- `findCodexPIDs()` uses `pgrep -f codex` + `lsof -a -d cwd` to build a CWD→PID map (macOS only)
- `discoverNewCodex()` deduplicates against tracked session file paths and session IDs, constructs agents with `Provider: "codex"`, `External: true`
- `DiscoverAgents()` now calls both `discoverNew()` (Claude) and `discoverNewCodex()` (Codex)

**Refresh support:**
- `refreshTracked()` now branches on `provider == "codex"` and calls `refreshCodexAgent(pid, filePath)` which uses file mod time as proxy when no PID is known
- `sessionFilePath` field added to `Agent` with `SetSessionFilePath`/`GetSessionFilePath`
- Headless runner stores session file path when `thread.started` init event is received
- Codex convo runner stores session file path when `thread.started` system event is received
- `resolveCodexSessionFile(sessionID)` walks sessions dir for `rollout-{id}.jsonl` match

**Tests:** 9 new test functions covering session reading, age cutoff, event parsing, state inference (12 table cases), agent construction, interactive mode, refresh logic, and file resolution.

> Changelog: feat(agent): codex session discovery