### PR TITLE
fix(workflow): release inflight early

### DIFF
--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -242,6 +242,10 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 		e.logger.Debug("workflow.advance.skip", "task_id", taskID, "reason", "already_advancing")
 		return nil
 	}
+	// Released explicitly before executeSteps (below) so the dispatched
+	// agent's completion callback isn't dropped as "already_advancing"
+	// when it races with the outer call. Deferred release is idempotent
+	// and covers every early-return path.
 	defer e.releaseInflight(taskID)
 
 	wfExec, def, currentStep, skip, err := e.loadAdvanceContext(taskID, output)
@@ -272,6 +276,7 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 			if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
 				return err
 			}
+			e.releaseInflight(taskID)
 			return e.executeSteps(taskID, &def, currentStep, wfExec)
 		}
 		e.logger.Warn("workflow.retry.exhausted", "task_id", taskID, "step", output.StepID,
@@ -294,6 +299,7 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 	}
 
 	e.logger.Info("workflow.advance", "task_id", taskID, "from", output.StepID, "to", nextStep.ID)
+	e.releaseInflight(taskID)
 	return e.executeSteps(taskID, &def, nextStep, wfExec)
 }
 

--- a/svc_orchestrator_test.go
+++ b/svc_orchestrator_test.go
@@ -41,15 +41,15 @@ func TestOrchestratorService_StartOrchestrator_Codex(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmd, err := svc.tmux.PaneCommand(orchestratorSession)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(cmd, "codex") {
-		t.Fatalf("pane command = %q, want command containing codex", cmd)
-	}
 	waitFor(t, 2*time.Second, "fake codex invoked", func() bool {
 		_, err := os.Stat(argsLog)
 		return err == nil
+	})
+	waitFor(t, 2*time.Second, "pane command is codex", func() bool {
+		cmd, err := svc.tmux.PaneCommand(orchestratorSession)
+		if err != nil {
+			return false
+		}
+		return strings.Contains(cmd, "codex")
 	})
 }


### PR DESCRIPTION
## Motivation

CI on main flakes on two tests:

- `TestE2E_RetryCount` — timeout waiting for workflow to advance past triage (run 24229272411).
- `TestOrchestratorService_StartOrchestrator_Codex` — reproducible locally ~5% of runs.

## Implementation information

**Workflow retry race.** `AdvanceStep` held the `inflight` guard across `executeSteps`. On the retry path, `executeSteps` synchronously dispatched a new agent; the new agent's headless goroutine could call `onComplete` → `HandleAgentComplete` → `AdvanceStep` before the outer call returned. The inner call hit `already_advancing`, got silently dropped, and the retry chain stalled — workflow stuck at triage until timeout.

Fix: explicitly release `inflight` before both `executeSteps` calls (retry and next-step). Deferred release stays in place; `delete` on a missing key is a no-op, so double-release is safe and covers all early-return paths. Concurrent callbacks arriving during dispatch are now processed correctly — the stale-step guard in `loadAdvanceContext` handles the normal-advance case; for retry the `CurrentStep` remains the same and each agent's `onComplete` fires exactly once.

**Codex orchestrator test race.** `PaneCommand` was queried immediately after `CreateSessionInDir`; tmux briefly reports the pane's default shell (`zsh`) before resolving to the configured command. Poll the check via `waitFor` instead of a one-shot read. Also reordered so the `argsLog` wait runs first (it's the authoritative signal that fake-codex actually started).

Verified: 20x stress runs of both tests pass locally; full `go test ./...` and `golangci-lint run ./...` clean.

## Supporting documentation

CI run: https://github.com/Automaat/synapse/actions/runs/24229272411