### PR TITLE
fix(workflow): repair stale builtin drift

### DIFF
--- a/internal/workflow/builtin.go
+++ b/internal/workflow/builtin.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"fmt"
 	"path/filepath"
+	"reflect"
 
 	"gopkg.in/yaml.v3"
 )
@@ -37,20 +38,48 @@ func BuiltinDefinitions() ([]Definition, error) {
 	return defs, nil
 }
 
-// SyncBuiltins writes built-in workflows to the store directory if they
-// don't already exist. Existing user-modified files are not overwritten.
+// SyncBuiltins writes built-in workflows to the store directory. For each
+// embedded definition:
+//
+//   - If no stored version exists, it is saved.
+//   - If a stored version exists with Builtin=true and its semantic content
+//     differs from the embedded version, it is overwritten. This repairs
+//     drift from older app versions that seeded now-broken definitions.
+//   - If a stored version exists with Builtin=false (user cleared the flag
+//     to opt out of sync), it is preserved.
 func SyncBuiltins(store *Store) error {
 	defs, err := BuiltinDefinitions()
 	if err != nil {
 		return err
 	}
 	for i := range defs {
-		if _, getErr := store.Get(defs[i].ID); getErr == nil {
-			continue // already exists
+		existing, getErr := store.Get(defs[i].ID)
+		if getErr != nil {
+			// Not present yet → create.
+			if sErr := store.Save(defs[i]); sErr != nil {
+				return fmt.Errorf("sync builtin %s: %w", defs[i].ID, sErr)
+			}
+			continue
 		}
+		if !existing.Builtin {
+			continue // user opted out by clearing the builtin flag
+		}
+		if builtinsEqual(existing, defs[i]) {
+			continue
+		}
+		// Preserve creation time; Save() refreshes UpdatedAt.
+		defs[i].CreatedAt = existing.CreatedAt
 		if sErr := store.Save(defs[i]); sErr != nil {
 			return fmt.Errorf("sync builtin %s: %w", defs[i].ID, sErr)
 		}
 	}
 	return nil
+}
+
+// builtinsEqual compares two definitions ignoring timestamps. Timestamps are
+// set by Save() each write, so byte-level comparison would always diverge.
+func builtinsEqual(a, b Definition) bool {
+	a.CreatedAt = b.CreatedAt
+	a.UpdatedAt = b.UpdatedAt
+	return reflect.DeepEqual(a, b)
 }

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -110,3 +110,75 @@ func TestSyncBuiltins_NoOverwrite(t *testing.T) {
 		t.Errorf("SyncBuiltins overwrote user modification: got %q, want %q", got.Name, "user-modified")
 	}
 }
+
+// TestSyncBuiltins_OverwriteStaleBuiltin locks the drift-repair behavior:
+// a stored workflow still marked Builtin=true must get replaced when its
+// content diverges from the embedded copy. Matches the historical pr-fix
+// drift that left `operator: contains` on a scalar enum field and silently
+// broke all auto-fix dispatch.
+func TestSyncBuiltins_OverwriteStaleBuiltin(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	defs, err := BuiltinDefinitions()
+	if err != nil || len(defs) == 0 {
+		t.Fatalf("BuiltinDefinitions: %v (len=%d)", err, len(defs))
+	}
+
+	// Simulate drift: save with Builtin=true but a stale name.
+	stale := defs[0]
+	stale.Name = "stale-drifted-name"
+	stale.Builtin = true
+	if err := store.Save(stale); err != nil {
+		t.Fatalf("Save stale: %v", err)
+	}
+
+	if err := SyncBuiltins(store); err != nil {
+		t.Fatalf("SyncBuiltins: %v", err)
+	}
+
+	got, err := store.Get(stale.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Name != defs[0].Name {
+		t.Errorf("SyncBuiltins did not repair stale builtin: got %q, want %q",
+			got.Name, defs[0].Name)
+	}
+}
+
+// TestSyncBuiltins_IdempotentOnClean verifies the no-op path: calling
+// SyncBuiltins twice in a row on a freshly seeded store must not bounce
+// the UpdatedAt timestamp on every startup.
+func TestSyncBuiltins_IdempotentOnClean(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := SyncBuiltins(store); err != nil {
+		t.Fatalf("first SyncBuiltins: %v", err)
+	}
+	defs, err := BuiltinDefinitions()
+	if err != nil || len(defs) == 0 {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	before, err := store.Get(defs[0].ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := SyncBuiltins(store); err != nil {
+		t.Fatalf("second SyncBuiltins: %v", err)
+	}
+	after, err := store.Get(defs[0].ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !after.UpdatedAt.Equal(before.UpdatedAt) {
+		t.Errorf("idempotent sync rewrote file: UpdatedAt before=%v after=%v",
+			before.UpdatedAt, after.UpdatedAt)
+	}
+}

--- a/internal/workflow/condition.go
+++ b/internal/workflow/condition.go
@@ -79,8 +79,8 @@ var FieldAllowedValues = map[string]map[string]bool{
 // checkEnumValue returns the unknown values (if any) for a condition that
 // targets an enum-shaped field. For the csv-style operators (in/not_in)
 // the comparison value is split and each entry checked independently.
-// Operators that don't do equality (contains, not_contains, exists) skip
-// enum validation because their value semantics differ.
+// The `exists` operator skips enum validation — it only tests field
+// presence, so the value is irrelevant.
 func checkEnumValue(field, operator, value string) []string {
 	allowed, ok := FieldAllowedValues[field]
 	if !ok {
@@ -105,6 +105,18 @@ func checkEnumValue(field, operator, value string) []string {
 		return bad
 	}
 	return nil
+}
+
+// checkEnumOperator reports whether the operator is semantically wrong for
+// an enum-shaped field. `contains`/`not_contains` do substring matching,
+// which silently fails on scalar enums (e.g. `contains "conflict,ci_failure"`
+// never matches `"ci_failure"`). Only free-form fields like task.tags — which
+// are joined into a single comma-separated string — should use these.
+func checkEnumOperator(field, operator string) bool {
+	if _, ok := FieldAllowedValues[field]; !ok {
+		return false
+	}
+	return operator == "contains" || operator == "not_contains"
 }
 
 // EvalCondition evaluates a condition against a context map of field→value.

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -166,62 +166,92 @@ func (d *Definition) Validate() error {
 //     while the constant emits "ci_failure" (underscore) — the original
 //     dispatch-mismatch shape.
 func (d *Definition) ValidateFields() error {
-	unknown := map[string]bool{}
-	badValues := map[string][]string{}
+	acc := fieldValidationAcc{
+		unknown:      map[string]bool{},
+		badValues:    map[string][]string{},
+		badOperators: map[string][]string{},
+	}
 	for i := range d.Trigger.Conditions {
-		collectUnknownCondition(&d.Trigger.Conditions[i], unknown, badValues)
+		collectUnknownCondition(&d.Trigger.Conditions[i], &acc)
 	}
 	for i := range d.Steps {
-		collectUnknownStepFields(&d.Steps[i], unknown, badValues)
+		collectUnknownStepFields(&d.Steps[i], &acc)
 	}
-	if len(unknown) == 0 && len(badValues) == 0 {
+	if len(acc.unknown) == 0 && len(acc.badValues) == 0 && len(acc.badOperators) == 0 {
 		return nil
 	}
 	var parts []string
-	if len(unknown) > 0 {
-		names := make([]string, 0, len(unknown))
-		for k := range unknown {
+	if len(acc.unknown) > 0 {
+		names := make([]string, 0, len(acc.unknown))
+		for k := range acc.unknown {
 			names = append(names, k)
 		}
 		sort.Strings(names)
 		parts = append(parts, "unknown field(s): "+strings.Join(names, ", "))
 	}
-	if len(badValues) > 0 {
-		fields := make([]string, 0, len(badValues))
-		for k := range badValues {
+	if len(acc.badValues) > 0 {
+		fields := make([]string, 0, len(acc.badValues))
+		for k := range acc.badValues {
 			fields = append(fields, k)
 		}
 		sort.Strings(fields)
 		for _, f := range fields {
-			vals := badValues[f]
+			vals := acc.badValues[f]
 			sort.Strings(vals)
 			parts = append(parts, fmt.Sprintf("invalid %s value(s): %s", f, strings.Join(vals, ",")))
+		}
+	}
+	if len(acc.badOperators) > 0 {
+		fields := make([]string, 0, len(acc.badOperators))
+		for k := range acc.badOperators {
+			fields = append(fields, k)
+		}
+		sort.Strings(fields)
+		for _, f := range fields {
+			ops := acc.badOperators[f]
+			sort.Strings(ops)
+			parts = append(parts, fmt.Sprintf(
+				"operator %s not allowed on enum field %s (use equals/in)",
+				strings.Join(ops, ","), f))
 		}
 	}
 	return fmt.Errorf("workflow %q: %s", d.ID, strings.Join(parts, "; "))
 }
 
-func collectUnknownCondition(c *Condition, unknown map[string]bool, badValues map[string][]string) {
+// fieldValidationAcc accumulates ValidateFields results while walking the
+// trigger and step tree. Grouped to keep the recursive collectors' signatures
+// from growing a new parameter every time a new class of error gets added.
+type fieldValidationAcc struct {
+	unknown      map[string]bool
+	badValues    map[string][]string
+	badOperators map[string][]string
+}
+
+func collectUnknownCondition(c *Condition, acc *fieldValidationAcc) {
 	if !isKnownField(c.Field) {
-		unknown[c.Field] = true
+		acc.unknown[c.Field] = true
+		return
+	}
+	if checkEnumOperator(c.Field, c.Operator) {
+		acc.badOperators[c.Field] = append(acc.badOperators[c.Field], c.Operator)
 		return
 	}
 	if bad := checkEnumValue(c.Field, c.Operator, c.Value); len(bad) > 0 {
-		badValues[c.Field] = append(badValues[c.Field], bad...)
+		acc.badValues[c.Field] = append(acc.badValues[c.Field], bad...)
 	}
 }
 
-func collectUnknownStepFields(s *Step, unknown map[string]bool, badValues map[string][]string) {
+func collectUnknownStepFields(s *Step, acc *fieldValidationAcc) {
 	if s.Config.Check != nil {
-		collectUnknownCondition(s.Config.Check, unknown, badValues)
+		collectUnknownCondition(s.Config.Check, acc)
 	}
 	for i := range s.Next {
 		if s.Next[i].When != nil {
-			collectUnknownCondition(s.Next[i].When, unknown, badValues)
+			collectUnknownCondition(s.Next[i].When, acc)
 		}
 	}
 	for i := range s.Parallel {
-		collectUnknownStepFields(&s.Parallel[i], unknown, badValues)
+		collectUnknownStepFields(&s.Parallel[i], acc)
 	}
 }
 

--- a/internal/workflow/model_test.go
+++ b/internal/workflow/model_test.go
@@ -233,21 +233,60 @@ func TestValidateFields_InOperatorChecksEachCSVEntry(t *testing.T) {
 }
 
 // TestValidateFields_ContainsOperatorSkipsEnumCheck ensures substring-style
-// operators (`contains`/`not_contains`) — which are used for tag matching
-// — don't trip enum validation even though the field is a known enum key.
+// operators (`contains`/`not_contains`) on free-form list fields like
+// task.tags still pass validation — they have no enum set registered.
 func TestValidateFields_ContainsOperatorSkipsEnumCheck(t *testing.T) {
 	d := Definition{
 		ID: "contains-skip",
 		Trigger: Trigger{
 			Conditions: []Condition{
-				// Hypothetical contains on a status-ish field: substring
-				// semantics, not equality, so enum set doesn't apply.
 				{Field: "task.tags", Operator: "contains", Value: "review"},
 			},
 		},
 	}
 	if err := d.ValidateFields(); err != nil {
 		t.Errorf("contains on free-form field should pass: %v", err)
+	}
+}
+
+// TestValidateFields_RejectsContainsOnEnumField locks the second half of
+// the pr-fix drift regression: `operator: contains` on a scalar enum field
+// like pr.issue_kind was evaluated as substring matching, and a csv-style
+// value like "conflict,ci_failure" silently never matched the actual runtime
+// value "ci_failure". ValidateFields must reject the operator so the
+// misconfiguration fails loudly at save time instead.
+func TestValidateFields_RejectsContainsOnEnumField(t *testing.T) {
+	d := Definition{
+		ID: "contains-on-enum",
+		Trigger: Trigger{
+			Conditions: []Condition{
+				{Field: "pr.issue_kind", Operator: "contains", Value: "conflict,ci_failure"},
+			},
+		},
+	}
+	err := d.ValidateFields()
+	if err == nil {
+		t.Fatal("expected error for contains on pr.issue_kind")
+	}
+	if !strings.Contains(err.Error(), "pr.issue_kind") ||
+		!strings.Contains(err.Error(), "contains") {
+		t.Errorf("error should mention field and operator, got: %v", err)
+	}
+}
+
+// TestValidateFields_RejectsNotContainsOnEnumField covers the inverse
+// operator — same semantic issue, same rule.
+func TestValidateFields_RejectsNotContainsOnEnumField(t *testing.T) {
+	d := Definition{
+		ID: "not-contains-on-enum",
+		Trigger: Trigger{
+			Conditions: []Condition{
+				{Field: "task.status", Operator: "not_contains", Value: "done"},
+			},
+		},
+	}
+	if err := d.ValidateFields(); err == nil {
+		t.Fatal("expected error for not_contains on task.status")
 	}
 }
 


### PR DESCRIPTION
## Motivation

Tasks stuck in review were not being auto-fixed. Logs showed
`pr-monitor.no-matching-workflow` firing on every PR-monitor
pass.

Root cause: the stored `~/.synapse/workflows/pr-fix.yaml` had
drifted to `operator: contains` with `value: conflict,ci_failure`
on the scalar enum field `pr.issue_kind`. `contains` is a
substring check, so `strings.Contains(\"ci_failure\", \"conflict,ci_failure\")`
always returned false. `DispatchEvent` never found a match, the
fix agent never spawned.

`SyncBuiltins` intentionally skipped existing files to preserve
user edits, so the corrected embedded YAML never reached the
runtime dir.

## Implementation information

- `SyncBuiltins` now overwrites stored workflows that still carry
  `Builtin=true` when their content differs from the embedded
  copy. `Builtin=false` (user opted out) is still preserved.
  Comparison uses `reflect.DeepEqual` with timestamps normalized
  so idempotent runs don't bounce `UpdatedAt`.
- `ValidateFields` now rejects `contains`/`not_contains` on any
  field registered in `FieldAllowedValues`. `checkEnumOperator`
  encodes the rule; `collectUnknownCondition` routes the
  violation into a new `badOperators` bucket with a dedicated
  error message: `operator X not allowed on enum field Y`.
- Collector signatures grouped into a `fieldValidationAcc`
  struct so adding future validation classes doesn't keep
  growing the parameter list.
- Tests:
  - `TestSyncBuiltins_OverwriteStaleBuiltin` locks the drift
    repair shape.
  - `TestSyncBuiltins_IdempotentOnClean` guards against
    timestamp bounce on every startup.
  - `TestValidateFields_RejectsContainsOnEnumField` /
    `RejectsNotContainsOnEnumField` lock the new operator rule.

Verified live: after overwriting the runtime pr-fix.yaml, the
three stuck tasks (`848d8ec5`, `6ed96b07`, `d33f7fa7`) advanced
through `fix → evaluate → ensure_pr_closes_issue` and logged
`workflow.completed`.

> Changelog: fix(workflow): repair stale builtin drift

## Supporting documentation

None.