### PR TITLE
fix(ui): show test plan content in review tab

### DIFF
--- a/frontend/src/pages/Reviews.svelte
+++ b/frontend/src/pages/Reviews.svelte
@@ -267,7 +267,7 @@
           <span class="text-xs text-surface-400">— click <kbd class="rounded bg-surface-200 px-1 dark:bg-surface-700">+</kbd> on any line to comment</span>
         </div>
         <div class="rounded-lg border border-surface-300 bg-white dark:border-surface-700 dark:bg-surface-900">
-          <PlanFileView taskId={selectedTask.id} planBody={isTestPlan ? selectedTask.body : (selectedTask.plan || selectedTask.body)} />
+          <PlanFileView taskId={selectedTask.id} planBody={selectedTask.plan || selectedTask.body} />
         </div>
       </div>
 


### PR DESCRIPTION
## Motivation

Test-plan reviews in the Reviews tab rendered the task description instead of the actual test plan. Opening the task directly showed the plan correctly, so only the Reviews view was broken.

## Implementation information

`Reviews.svelte` branched on `isTestPlan` and passed `selectedTask.body` to `PlanFileView` for test-plan reviews. Test plans are written via `synapse-cli update --plan ...` (see `internal/workflow/builtin/testing-task.yaml`), landing in the same `.plan.md` sidecar as regular plans and exposed as `task.plan`. Dropped the branch — both plan and test-plan reviews now use `selectedTask.plan || selectedTask.body`, matching how `TaskDetail.svelte` renders it.

## Supporting documentation

None.