### PR TITLE
fix(task): strip leading blanks in run result

### DIFF
--- a/internal/task/parser.go
+++ b/internal/task/parser.go
@@ -50,11 +50,13 @@ func ParseBytes(data []byte) (Task, error) {
 func Marshal(t Task) ([]byte, error) {
 	t.UpdatedAt = time.Now().UTC()
 
-	// Strip leading whitespace from agent run results so yaml.v3 doesn't
-	// emit |N- block scalars that it fails to parse back (known round-trip
-	// bug with nested sequences containing indented literal blocks).
+	// Strip leading whitespace/newlines from agent run results so yaml.v3
+	// doesn't emit |N- block scalars that it fails to parse back (known
+	// round-trip bug: leading blank lines or indented first line force an
+	// explicit indentation indicator that miscounts columns inside a
+	// nested sequence).
 	for i := range t.AgentRuns {
-		t.AgentRuns[i].Result = stripLineIndent(t.AgentRuns[i].Result)
+		t.AgentRuns[i].Result = strings.TrimLeft(t.AgentRuns[i].Result, " \t\n\r")
 	}
 
 	fm, err := yaml.Marshal(t)
@@ -71,18 +73,4 @@ func Marshal(t Task) ([]byte, error) {
 		buf.WriteString("\n")
 	}
 	return buf.Bytes(), nil
-}
-
-// stripLineIndent removes leading spaces/tabs from each line. This prevents
-// yaml.v3 from emitting |N- block scalars (explicit indent indicator) which
-// it then fails to round-trip when nested inside sequences.
-func stripLineIndent(s string) string {
-	if s == "" {
-		return s
-	}
-	lines := strings.Split(s, "\n")
-	for i, line := range lines {
-		lines[i] = strings.TrimLeft(line, " \t")
-	}
-	return strings.Join(lines, "\n")
 }

--- a/internal/task/parser_test.go
+++ b/internal/task/parser_test.go
@@ -387,6 +387,42 @@ func TestMarshalRoundTripAgentRunsIndentedResult(t *testing.T) {
 	}
 }
 
+func TestMarshalRoundTripAgentRunsLeadingBlankLines(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC().Truncate(time.Second)
+	original := Task{
+		ID:        "blank1",
+		Title:     "Leading blank lines roundtrip",
+		Status:    StatusInReview,
+		AgentMode: "headless",
+		AgentRuns: []AgentRun{
+			{
+				AgentID:   "a1",
+				Mode:      "headless",
+				State:     "stopped",
+				StartedAt: now,
+				Result:    "\n\nThe PR URL is invalid.\n\nPlease provide a valid URL:\n```\nhttps://example.com\n```",
+			},
+		},
+	}
+
+	data, err := Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	parsed, err := ParseBytes(data)
+	if err != nil {
+		t.Fatalf("parse round-trip failed (leading blank lines triggered |N- bug): %v", err)
+	}
+	if len(parsed.AgentRuns) != 1 {
+		t.Fatalf("AgentRuns len = %d, want 1", len(parsed.AgentRuns))
+	}
+	if !strings.Contains(parsed.AgentRuns[0].Result, "The PR URL is invalid.") {
+		t.Errorf("AgentRuns[0].Result = %q, missing expected content", parsed.AgentRuns[0].Result)
+	}
+}
+
 func TestMarshalUpdatesTimestamp(t *testing.T) {
 	t.Parallel()
 	before := time.Now().UTC().Add(-time.Second)


### PR DESCRIPTION
## Motivation

Tasks with agent run results starting with blank lines fail to parse:

```
parse /Users/.../tasks/b7522253.md: unmarshal frontmatter: yaml: line 13: did not find expected key
```

yaml.v3 emits `|N-` block scalars with an explicit indentation indicator when the content starts with blank lines or leading whitespace. Inside a nested sequence, the indicator's column math is wrong and the output cannot be parsed back.

## Implementation information

- Replace per-line `stripLineIndent` with `strings.TrimLeft(result, " \t\n\r")` — only the leading run matters for yaml.v3's auto-indent detection, and per-line stripping destroyed legitimate indentation in code blocks / diffs.
- Regression test covering the exact shape that broke `b7522253.md` (leading `\n\n`, fenced code block in body).

## Supporting documentation

Existing test `TestMarshalRoundTripAgentRunsIndentedResult` already guarded the indented-first-line case; this PR adds the leading-blank-line case.