### PR TITLE
refactor(workflow): replace recovery sentinel with Execution.Recovered

### DIFF
--- a/app.go
+++ b/app.go
@@ -581,14 +581,18 @@ func (a *App) recoverStaleInteractive(t *task.Task) {
 			"task_id", t.ID, "state", string(t.Workflow.State))
 		return
 	}
-	// Feed a recovery marker as the result instead of the stored lr.Result —
-	// templates that embed {{.Prev.Output}} (e.g. the evaluate step) would
-	// otherwise see stale content. Downstream agents should re-inspect the
-	// task state via synapse-cli rather than trust the previous output.
-	const recoveryResult = "(recovered stale interactive session — no fresh agent result; inspect task state directly)"
+	// Mark the execution as recovered so the next step's template context
+	// knows not to trust .Prev.Output (use recoveredOrPrev instead). Persist
+	// before driving HandleAgentComplete so the engine reloads the flag.
+	t.Workflow.Recovered = true
+	wf := t.Workflow
+	if _, err := a.tasks.Update(t.ID, task.Update{Workflow: &wf}); err != nil {
+		a.logger.Error("recover-stale.set-recovered", "task_id", t.ID, "err", err)
+		return
+	}
 	a.logger.Info("recover-stale.advance",
 		"task_id", t.ID, "agent_id", lr.AgentID, "step", t.Workflow.CurrentStep)
-	a.workflowEngine.HandleAgentComplete(t.ID, lr.AgentID, recoveryResult, "stopped")
+	a.workflowEngine.HandleAgentComplete(t.ID, lr.AgentID, "", "stopped")
 }
 
 func lastAgentRun(t *task.Task) *task.AgentRun {

--- a/e2e_workflow_test.go
+++ b/e2e_workflow_test.go
@@ -944,9 +944,13 @@ func TestE2E_RecoverStaleInteractive(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Drive the same engine call that recoverStaleInteractive makes.
-	const recoveryMarker = "(recovered stale interactive session — no fresh result)"
-	env.engine.HandleAgentComplete(created.ID, "stale-agent", recoveryMarker, "stopped")
+	// Mirror what recoverStaleInteractive does: set Recovered on the execution,
+	// persist, then drive HandleAgentComplete with an empty result.
+	wfExec.Recovered = true
+	if _, err := env.tasks.UpdateMap(created.ID, map[string]any{"workflow": wfExec}); err != nil {
+		t.Fatal(err)
+	}
+	env.engine.HandleAgentComplete(created.ID, "stale-agent", "", "stopped")
 
 	// Evaluate fires (fake-claude "evaluate" scenario sets status=in-review),
 	// then the workflow reaches ExecCompleted.
@@ -976,8 +980,8 @@ func TestE2E_RecoverStaleInteractive(t *testing.T) {
 	if implementRec == nil {
 		t.Fatal("expected 'implement' step record after recovery")
 	}
-	if !strings.Contains(implementRec.Output, "recovered stale") {
-		t.Errorf("implement output = %q, want recovery marker", implementRec.Output)
+	if implementRec.Output != "" {
+		t.Errorf("implement output = %q, want empty (structured recovery, no sentinel string)", implementRec.Output)
 	}
 	if evaluateRec == nil {
 		t.Fatal("expected 'evaluate' step record — recovery should drive the next step")

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1311,6 +1311,7 @@ export namespace workflow {
 	    startedAt: any;
 	    // Go type: time
 	    completedAt?: any;
+	    recovered?: boolean;
 	
 	    static createFrom(source: any = {}) {
 	        return new Execution(source);
@@ -1325,6 +1326,7 @@ export namespace workflow {
 	        this.variables = source["variables"];
 	        this.startedAt = this.convertValues(source["startedAt"], null);
 	        this.completedAt = this.convertValues(source["completedAt"], null);
+	        this.recovered = source["recovered"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/workflow/builtin/pr-fix.yaml
+++ b/internal/workflow/builtin/pr-fix.yaml
@@ -53,7 +53,7 @@ steps:
 
         ## Agent Result
 
-        {{.Prev.Output}}
+        {{recoveredorprev .Workflow .Prev}}
       allowed_tools:
         - Bash
     next:

--- a/internal/workflow/builtin/simple-task.yaml
+++ b/internal/workflow/builtin/simple-task.yaml
@@ -229,7 +229,7 @@ steps:
 
         ## Agent Result
 
-        {{.Prev.Output}}
+        {{recoveredorprev .Workflow .Prev}}
       allowed_tools:
         - Bash
     next:

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -597,12 +597,26 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			return err
 		}
 
+		// Snapshot the execution for the template context so that clearing
+		// the Recovered flag below doesn't affect what the template sees.
+		execSnap := *wfExec
 		ctx := TemplateContext{
-			Task:    t,
-			Step:    *step,
-			Prev:    wfExec.LastRecord(),
-			Vars:    wfExec.Variables,
-			Project: nil,
+			Task:     t,
+			Step:     *step,
+			Prev:     wfExec.LastRecord(),
+			Vars:     wfExec.Variables,
+			Project:  nil,
+			Workflow: &execSnap,
+		}
+
+		// Consume the recovery flag: it applies only to the step being
+		// dispatched here. Clear and persist before spawning the agent so
+		// subsequent HandleAgentComplete reloads don't see a stale flag.
+		if wfExec.Recovered {
+			wfExec.Recovered = false
+			if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
+				return err
+			}
 		}
 
 		// Async steps: execute and return. Callback (HandleAgentComplete/HandleHumanAction)
@@ -678,6 +692,9 @@ func (e *Engine) resolveNext(taskID string, def *Definition, current *Step, wfEx
 	fields := taskFields(t)
 	for k, v := range wfExec.Variables {
 		fields["vars."+k] = v
+	}
+	if wfExec.Recovered {
+		fields["vars.recovered"] = "true"
 	}
 
 	nextID, tErr := ResolveTransition(current.Next, fields)

--- a/internal/workflow/execution.go
+++ b/internal/workflow/execution.go
@@ -21,6 +21,11 @@ type Execution struct {
 	Variables   map[string]string `yaml:"variables,omitempty" json:"variables"`
 	StartedAt   time.Time         `yaml:"started_at" json:"startedAt"`
 	CompletedAt *time.Time        `yaml:"completed_at,omitempty" json:"completedAt"`
+	// Recovered is set when the execution was advanced by a stale-session
+	// recovery path rather than a live agent result. Cleared after the first
+	// step consumes it. Workflow prompts should use recoveredOrPrev instead of
+	// .Prev.Output to guard against stale content.
+	Recovered bool `yaml:"recovered,omitempty" json:"recovered,omitempty"`
 }
 
 // SetVar sets a variable in the execution context.

--- a/internal/workflow/template.go
+++ b/internal/workflow/template.go
@@ -9,11 +9,12 @@ import (
 
 // TemplateContext provides data available in prompt templates and shell commands.
 type TemplateContext struct {
-	Task    TaskInfo
-	Step    Step
-	Prev    *StepRecord
-	Vars    map[string]string
-	Project any // *project.Project or nil
+	Task     TaskInfo
+	Step     Step
+	Prev     *StepRecord
+	Vars     map[string]string
+	Project  any        // *project.Project or nil
+	Workflow *Execution // current execution snapshot; nil outside workflow context
 }
 
 // RenderTemplate renders a Go text/template string with the given context.
@@ -30,8 +31,9 @@ func RenderTemplate(tmpl string, ctx TemplateContext) (string, error) {
 }
 
 var templateFuncs = template.FuncMap{
-	"shellquote": shellQuote,
-	"getvar":     getVar,
+	"shellquote":      shellQuote,
+	"getvar":          getVar,
+	"recoveredorprev": recoveredOrPrev,
 }
 
 // getVar safely retrieves a variable from a map, returning "" if absent.
@@ -42,4 +44,18 @@ func getVar(vars map[string]string, key string) string {
 // shellQuote wraps a string in single quotes with proper escaping for bash.
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}
+
+// recoveredOrPrev returns empty when the execution was recovered from a stale
+// interactive session (no real agent output exists), otherwise returns the
+// previous step's output. Use in workflow prompts instead of .Prev.Output to
+// guard against stale content after a session recovery.
+func recoveredOrPrev(wf *Execution, prev *StepRecord) string {
+	if wf != nil && wf.Recovered {
+		return ""
+	}
+	if prev == nil {
+		return ""
+	}
+	return prev.Output
 }

--- a/internal/workflow/template_test.go
+++ b/internal/workflow/template_test.go
@@ -99,6 +99,67 @@ func TestShellQuote(t *testing.T) {
 	}
 }
 
+func TestRecoveredOrPrev(t *testing.T) {
+	t.Parallel()
+	prev := &StepRecord{Output: "agent output"}
+	tests := []struct {
+		name string
+		wf   *Execution
+		prev *StepRecord
+		want string
+	}{
+		{"recovered clears output", &Execution{Recovered: true}, prev, ""},
+		{"not recovered returns prev", &Execution{Recovered: false}, prev, "agent output"},
+		{"nil prev returns empty", &Execution{Recovered: false}, nil, ""},
+		{"nil workflow returns prev", nil, prev, "agent output"},
+		{"nil workflow nil prev", nil, nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := recoveredOrPrev(tt.wf, tt.prev)
+			if got != tt.want {
+				t.Errorf("recoveredOrPrev = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderTemplate_RecoveredOrPrev(t *testing.T) {
+	t.Parallel()
+	prev := &StepRecord{Output: "real output"}
+
+	t.Run("recovered returns empty", func(t *testing.T) {
+		t.Parallel()
+		ctx := TemplateContext{
+			Workflow: &Execution{Recovered: true},
+			Prev:     prev,
+		}
+		got, err := RenderTemplate("{{recoveredorprev .Workflow .Prev}}", ctx)
+		if err != nil {
+			t.Fatalf("RenderTemplate: %v", err)
+		}
+		if got != "" {
+			t.Errorf("got %q, want empty on recovery", got)
+		}
+	})
+
+	t.Run("not recovered returns prev output", func(t *testing.T) {
+		t.Parallel()
+		ctx := TemplateContext{
+			Workflow: &Execution{Recovered: false},
+			Prev:     prev,
+		}
+		got, err := RenderTemplate("{{recoveredorprev .Workflow .Prev}}", ctx)
+		if err != nil {
+			t.Fatalf("RenderTemplate: %v", err)
+		}
+		if got != "real output" {
+			t.Errorf("got %q, want %q", got, "real output")
+		}
+	})
+}
+
 func TestGetVar(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
## Motivation

`recoverStaleInteractive` was injecting a hardcoded sentinel string into `HandleAgentComplete` to signal recovery to downstream workflow steps. Any step templating `{{.Prev.Output}}` had to special-case this exact string — an invisible contract with no type safety and a localization footgun.

## Implementation information

Replaced the sentinel string with a typed `Execution.Recovered bool` field:

- `Execution.Recovered` (`yaml/json omitempty`) set by `recoverStaleInteractive`, persisted before calling `HandleAgentComplete` with an empty result
- `TemplateContext.Workflow *Execution` — execution snapshot available in all step prompts
- `recoveredorprev .Workflow .Prev` — new template function replacing `{{.Prev.Output}}` in evaluate prompts; returns empty string on recovery, prev output otherwise
- `executeSteps` snapshots `wfExec` before clearing the flag so the template sees `Recovered=true` while the persisted execution is already cleared (one-shot semantics)
- `resolveNext` exposes `vars.recovered=true` in condition fields so `when:` clauses can branch on recovery
- Builtin workflows (`simple-task.yaml`, `pr-fix.yaml`) updated to use `recoveredorprev`
- e2e recovery test updated to match new behavior (empty output, no sentinel)

> Changelog: refactor(workflow): replace recovery sentinel with Execution.Recovered flag

Closes https://github.com/Automaat/synapse/issues/274