### PR TITLE
refactor(agent): finish provider split

### DIFF
--- a/app.go
+++ b/app.go
@@ -290,6 +290,7 @@ func (a *App) onAgentComplete(ag *agent.Agent) {
 		"duration_s": duration,
 		"state":      string(state),
 		"role":       agent.RoleFromName(ag.Name),
+		"provider":   ag.Provider,
 	})
 
 	// Advance workflow.

--- a/app_agents.go
+++ b/app_agents.go
@@ -109,7 +109,7 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, oneShot bool
 	if err != nil {
 		return nil, err
 	}
-	o.logAudit(audit.EventAgentStarted, taskID, ag.ID, map[string]any{"mode": effMode, "title": t.Title, "task_type": string(t.TaskType)})
+	o.logAudit(audit.EventAgentStarted, taskID, ag.ID, map[string]any{"mode": effMode, "title": t.Title, "task_type": string(t.TaskType), "provider": ag.Provider})
 	if err := o.tasks.AddRun(taskID, task.AgentRun{
 		AgentID:   ag.ID,
 		Mode:      effMode,
@@ -181,7 +181,7 @@ func (o *AgentOrchestrator) StartPRFixAgent(taskID string) error {
 		return err
 	}
 
-	o.logAudit(audit.EventAgentStarted, taskID, ag.ID, map[string]any{"mode": effMode, "title": t.Title, "role": "pr-fix", "task_type": string(t.TaskType)})
+	o.logAudit(audit.EventAgentStarted, taskID, ag.ID, map[string]any{"mode": effMode, "title": t.Title, "role": "pr-fix", "task_type": string(t.TaskType), "provider": ag.Provider})
 	if err := o.tasks.AddRun(taskID, task.AgentRun{
 		AgentID: ag.ID, Role: string(agent.RolePRFix), Mode: effMode,
 		State: string(agent.StateRunning), StartedAt: ag.StartedAt,

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -721,11 +721,11 @@ export namespace stats {
 	    outcome: string;
 	    // Go type: time
 	    timestamp: any;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new RunRecord(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
@@ -772,11 +772,11 @@ export namespace stats {
 	    byModel: GroupedStat[];
 	    byProvider: GroupedStat[];
 	    recentRuns: RunRecord[];
-
+	
 	    static createFrom(source: any = {}) {
 	        return new StatsResponse(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.today = this.convertValues(source["today"], Summary);

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -713,6 +713,7 @@ export namespace stats {
 	    mode: string;
 	    role: string;
 	    model?: string;
+	    provider?: string;
 	    costUsd: number;
 	    durationS: number;
 	    inputTokens?: number;
@@ -720,11 +721,11 @@ export namespace stats {
 	    outcome: string;
 	    // Go type: time
 	    timestamp: any;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new RunRecord(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
@@ -733,6 +734,7 @@ export namespace stats {
 	        this.mode = source["mode"];
 	        this.role = source["role"];
 	        this.model = source["model"];
+	        this.provider = source["provider"];
 	        this.costUsd = source["costUsd"];
 	        this.durationS = source["durationS"];
 	        this.inputTokens = source["inputTokens"];
@@ -768,12 +770,13 @@ export namespace stats {
 	    byMode: GroupedStat[];
 	    byRole: GroupedStat[];
 	    byModel: GroupedStat[];
+	    byProvider: GroupedStat[];
 	    recentRuns: RunRecord[];
-	
+
 	    static createFrom(source: any = {}) {
 	        return new StatsResponse(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.today = this.convertValues(source["today"], Summary);
@@ -784,6 +787,7 @@ export namespace stats {
 	        this.byMode = this.convertValues(source["byMode"], GroupedStat);
 	        this.byRole = this.convertValues(source["byRole"], GroupedStat);
 	        this.byModel = this.convertValues(source["byModel"], GroupedStat);
+	        this.byProvider = this.convertValues(source["byProvider"], GroupedStat);
 	        this.recentRuns = this.convertValues(source["recentRuns"], RunRecord);
 	    }
 	

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -204,32 +204,41 @@ func (m *Manager) buildCommand(cfg RunConfig) (string, error) {
 			return "", fmt.Errorf("invalid tool %q: must match %s", tool, safeArgRe)
 		}
 	}
-
 	model := normalizeModel(provider, cfg.Model)
 	switch provider {
 	case "codex":
-		parts := []string{"codex", "exec", "--json", "--skip-git-repo-check"}
-		if !cfg.RequirePermissions {
-			parts = append(parts, "--full-auto")
-		} else {
-			parts = append(parts, "--sandbox", "workspace-write")
-		}
-		if model != "" {
-			parts = append(parts, "--model", model)
-		}
-		return strings.Join(parts, " "), nil
+		return buildCodexCommand(model, cfg.RequirePermissions), nil
 	default:
-		parts := []string{"claude"}
-		if len(cfg.AllowedTools) > 0 {
-			parts = append(parts, "--allowedTools", strings.Join(cfg.AllowedTools, ","))
-		} else if !cfg.RequirePermissions {
-			parts = append(parts, "--dangerously-skip-permissions")
-		}
-		if model != "" {
-			parts = append(parts, "--model", model)
-		}
-		return strings.Join(parts, " "), nil
+		return buildClaudeCommand(model, cfg.AllowedTools, cfg.RequirePermissions), nil
 	}
+}
+
+// buildClaudeCommand builds the display command string for a Claude agent.
+func buildClaudeCommand(model string, allowedTools []string, requirePerms bool) string {
+	parts := []string{"claude"}
+	if len(allowedTools) > 0 {
+		parts = append(parts, "--allowedTools", strings.Join(allowedTools, ","))
+	} else if !requirePerms {
+		parts = append(parts, "--dangerously-skip-permissions")
+	}
+	if model != "" {
+		parts = append(parts, "--model", model)
+	}
+	return strings.Join(parts, " ")
+}
+
+// buildCodexCommand builds the display command string for a Codex agent.
+func buildCodexCommand(model string, requirePerms bool) string {
+	parts := []string{"codex", "exec", "--json", "--skip-git-repo-check"}
+	if !requirePerms {
+		parts = append(parts, "--full-auto")
+	} else {
+		parts = append(parts, "--sandbox", "workspace-write")
+	}
+	if model != "" {
+		parts = append(parts, "--model", model)
+	}
+	return strings.Join(parts, " ")
 }
 
 func (m *Manager) providerForRun(provider string) string {
@@ -283,7 +292,7 @@ func (m *Manager) sendInteractivePrompt(ctx context.Context, a *Agent, prompt st
 		case <-ctx.Done():
 			return
 		case <-timeout:
-			m.logger.Error("agent.interactive.timeout", "id", a.ID, "msg", "claude did not become ready in 30s")
+			m.logger.Error("agent.interactive.timeout", "id", a.ID, "msg", "agent did not become ready in 30s")
 			return
 		case <-ticker.C:
 			out, err := m.tmux.CapturePaneOutput(a.TmuxSession)
@@ -593,8 +602,9 @@ func (m *Manager) CheckInteractiveSessions() {
 		if RoleFromName(a.Name) == RolePlan {
 			continue
 		}
-		// Resolve claude session via tmux pane PID → ~/.claude/sessions/{pid}.json
-		if a.GetSessionID() == "" {
+		// Resolve Claude session via tmux pane PID → ~/.claude/sessions/{pid}.json.
+		// Codex agents use a different session model and do not have tmux sessions.
+		if a.Provider != "codex" && a.GetSessionID() == "" {
 			m.resolveInteractiveSession(a)
 		}
 		sid := a.GetSessionID()
@@ -610,7 +620,8 @@ func (m *Manager) CheckInteractiveSessions() {
 }
 
 // resolveInteractiveSession reads the tmux pane PID, then looks up
-// ~/.claude/sessions/{pid}.json to find the claude session ID.
+// ~/.claude/sessions/{pid}.json to find the Claude session ID.
+// Only valid for Claude agents; Codex does not use this mechanism.
 func (m *Manager) resolveInteractiveSession(a *Agent) {
 	pidStr, err := m.tmux.PanePID(a.TmuxSession)
 	if err != nil {

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -145,14 +145,14 @@ func (a *Agent) SetLogPath(p string) {
 	a.mu.Unlock()
 }
 
-// SetSessionID records the Claude session ID.
+// SetSessionID records the provider session ID.
 func (a *Agent) SetSessionID(id string) {
 	a.mu.Lock()
 	a.SessionID = id
 	a.mu.Unlock()
 }
 
-// GetSessionID returns the current Claude session ID.
+// GetSessionID returns the current provider session ID.
 func (a *Agent) GetSessionID() string {
 	a.mu.RLock()
 	defer a.mu.RUnlock()

--- a/internal/stats/backfill.go
+++ b/internal/stats/backfill.go
@@ -50,6 +50,9 @@ func (s *Store) Backfill(auditDir string) error {
 		} else {
 			r.Outcome = "failed"
 		}
+		if v, ok := ev.Data["provider"].(string); ok {
+			r.Provider = v
+		}
 
 		s.runs = append(s.runs, r)
 	}

--- a/internal/stats/model.go
+++ b/internal/stats/model.go
@@ -10,6 +10,7 @@ type RunRecord struct {
 	Mode         string    `json:"mode"`
 	Role         string    `json:"role"`
 	Model        string    `json:"model,omitempty"`
+	Provider     string    `json:"provider,omitempty"`
 	CostUSD      float64   `json:"costUsd"`
 	DurationS    float64   `json:"durationS"`
 	InputTokens  int       `json:"inputTokens,omitempty"`
@@ -45,5 +46,6 @@ type StatsResponse struct {
 	ByMode     []GroupedStat `json:"byMode"`
 	ByRole     []GroupedStat `json:"byRole"`
 	ByModel    []GroupedStat `json:"byModel"`
+	ByProvider []GroupedStat `json:"byProvider"`
 	RecentRuns []RunRecord   `json:"recentRuns"`
 }

--- a/internal/stats/store.go
+++ b/internal/stats/store.go
@@ -64,6 +64,7 @@ func (s *Store) Query() StatsResponse {
 	byMode := map[string][]RunRecord{}
 	byRole := map[string][]RunRecord{}
 	byModel := map[string][]RunRecord{}
+	byProvider := map[string][]RunRecord{}
 
 	for i := range s.runs {
 		r := &s.runs[i]
@@ -98,17 +99,24 @@ func (s *Store) Query() StatsResponse {
 			model = "(unknown)"
 		}
 		byModel[model] = append(byModel[model], *r)
+
+		provider := r.Provider
+		if provider == "" {
+			provider = "(unknown)"
+		}
+		byProvider[provider] = append(byProvider[provider], *r)
 	}
 
 	resp := StatsResponse{
-		Today:     summarize(today),
-		ThisWeek:  summarize(week),
-		ThisMonth: summarize(month),
-		AllTime:   summarize(all),
-		ByProject: groupedStats(byProject),
-		ByMode:    groupedStats(byMode),
-		ByRole:    groupedStats(byRole),
-		ByModel:   groupedStats(byModel),
+		Today:      summarize(today),
+		ThisWeek:   summarize(week),
+		ThisMonth:  summarize(month),
+		AllTime:    summarize(all),
+		ByProject:  groupedStats(byProject),
+		ByMode:     groupedStats(byMode),
+		ByRole:     groupedStats(byRole),
+		ByModel:    groupedStats(byModel),
+		ByProvider: groupedStats(byProvider),
 	}
 
 	// Recent runs: last 50, newest first


### PR DESCRIPTION
## Motivation

Provider-specific logic was leaking through shared agent paths after the initial Codex integration (#255). This makes adding future providers harder and creates subtle bugs (e.g. Claude session resolution firing for Codex agents).

## Implementation information

**Command building separation:**
- Extracted `buildClaudeCommand` and `buildCodexCommand` helpers from the `buildCommand` switch in `manager.go` — provider logic is now in named functions rather than an anonymous switch branch

**Claude-specific assumptions removed from shared paths:**
- `sendInteractivePrompt`: log message no longer says "claude did not become ready"
- `CheckInteractiveSessions`: `resolveInteractiveSession` (reads `~/.claude/sessions/`) now guarded with `a.Provider != "codex"` — Codex agents would never have a tmux session but this makes the intent explicit
- `model.go`: `SetSessionID`/`GetSessionID` comments say "provider session ID" not "Claude session ID"

**Stats/audit provider visibility:**
- `stats.RunRecord` gains `Provider` field
- `StatsResponse` gains `ByProvider []GroupedStat` grouping
- `agent.started` and `agent.completed` audit events now include `"provider"` in their data map
- Stats backfill extracts provider from audit data
- Frontend Wails models updated accordingly

> Changelog: refactor(agent): finish provider split

Closes https://github.com/Automaat/synapse/issues/259