### PR TITLE
fix(workflow): retry pr-close verify + trust body

### DIFF
--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -20,6 +20,16 @@ const (
 	shellTimeout   = 30 * time.Second
 )
 
+// prVerifyBackoffs controls the retry schedule after editing a PR
+// body to add a closing reference. GitHub populates
+// closingIssuesReferences asynchronously, so a verify fetch right
+// after gh pr edit commonly reads stale data; back off and retry.
+// Indirected for tests — test init swaps in zeros to skip real waits.
+var (
+	prVerifyBackoffs = []time.Duration{2 * time.Second, 4 * time.Second, 6 * time.Second}
+	prVerifySleep    = time.Sleep
+)
+
 // TaskInfo is the subset of task data the engine needs.
 type TaskInfo struct {
 	ID           string
@@ -901,20 +911,31 @@ func (e *Engine) execEnsurePRClosesIssue(taskID string, step *Step, t TaskInfo) 
 		return StepOutput{StepID: step.ID, Status: "failed", Output: "edit failed: " + editErr.Error()}, nil
 	}
 
-	verified, _, verifyErr := e.prLinker.GetClosingIssues(t.ProjectID, t.PRNumber)
-	if verifyErr != nil || !slices.Contains(verified, issueNum) {
-		reason := "PR does not close linked issue after auto-fix"
-		if verifyErr != nil {
-			reason += ": " + verifyErr.Error()
+	// Verify with retry — GitHub updates closingIssuesReferences
+	// asynchronously after a body edit, so the first fetch can miss
+	// refs that populate seconds later. If every retry still misses,
+	// trust the body: we just wrote "Closes <url>" into it with a
+	// known-good format, so the link will resolve once GitHub catches
+	// up. Only edit failures (above) flip to human-required.
+	var verifyErr error
+	for attempt := 0; attempt <= len(prVerifyBackoffs); attempt++ {
+		if attempt > 0 {
+			prVerifySleep(prVerifyBackoffs[attempt-1])
 		}
-		if statusErr := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); statusErr != nil {
-			e.logger.Error("workflow.pr-close.status", "task_id", taskID, "err", statusErr)
+		var verified []int
+		verified, _, verifyErr = e.prLinker.GetClosingIssues(t.ProjectID, t.PRNumber)
+		if verifyErr == nil && slices.Contains(verified, issueNum) {
+			e.logger.Info("workflow.pr-close.linked", "task_id", taskID, "pr", t.PRNumber, "issue", issueNum, "attempt", attempt)
+			return StepOutput{StepID: step.ID, Status: "completed", Output: fmt.Sprintf("linked issue #%d", issueNum)}, nil
 		}
-		return StepOutput{StepID: step.ID, Status: "failed", Output: reason}, nil
 	}
 
-	e.logger.Info("workflow.pr-close.linked", "task_id", taskID, "pr", t.PRNumber, "issue", issueNum)
-	return StepOutput{StepID: step.ID, Status: "completed", Output: fmt.Sprintf("linked issue #%d", issueNum)}, nil
+	e.logger.Warn("workflow.pr-close.verify-lag", "task_id", taskID, "pr", t.PRNumber, "issue", issueNum, "err", verifyErr)
+	msg := fmt.Sprintf("edited body to close #%d; verification lagged — trusting body contents", issueNum)
+	if verifyErr != nil {
+		msg = fmt.Sprintf("edited body to close #%d; last verify err: %s — trusting body contents", issueNum, verifyErr.Error())
+	}
+	return StepOutput{StepID: step.ID, Status: "completed", Output: msg}, nil
 }
 
 // parseIssueURL extracts owner/repo and issue number from a GitHub

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -15,6 +15,13 @@ import (
 
 // --- Test helpers ---
 
+func init() {
+	// Skip real backoff waits in the ensure_pr_closes_issue verify
+	// retry loop — tests drive attempt counts via the linker queue.
+	prVerifySleep = func(time.Duration) {}
+	prVerifyBackoffs = []time.Duration{0, 0, 0}
+}
+
 func discardLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
@@ -1772,16 +1779,23 @@ func TestExecEnsurePRClosesIssue_EditFailureFlipsHumanRequired(t *testing.T) {
 	}
 }
 
-func TestExecEnsurePRClosesIssue_VerifyFailureFlipsHumanRequired(t *testing.T) {
+// Verification lag is a false negative: gh pr edit succeeded, the
+// body contains "Closes <url>", but GitHub hasn't re-parsed
+// closingIssuesReferences yet. The step must trust the body and
+// leave the task status alone instead of flipping to human-required.
+func TestExecEnsurePRClosesIssue_VerifyLagTrustsBody(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	engine := NewEngine(store, tasks, agents, discardLogger())
 	linker := &fakePRLinker{
 		getQueue: []getResult{
+			// 1 pre-check + 4 verify attempts, all miss.
 			{issues: nil, body: "body"},
-			// Second fetch still does not contain issue 7 — the edit didn't take.
-			{issues: []int{99}, body: "body"},
+			{issues: nil, body: "body\n\nCloses https://github.com/owner/repo/issues/7"},
+			{issues: nil, body: "body\n\nCloses https://github.com/owner/repo/issues/7"},
+			{issues: nil, body: "body\n\nCloses https://github.com/owner/repo/issues/7"},
+			{issues: nil, body: "body\n\nCloses https://github.com/owner/repo/issues/7"},
 		},
 	}
 	engine.SetPRLinker(linker)
@@ -1792,13 +1806,97 @@ func TestExecEnsurePRClosesIssue_VerifyFailureFlipsHumanRequired(t *testing.T) {
 		ID: "t1", ProjectID: "owner/repo", PRNumber: 5,
 		Issue: "https://github.com/owner/repo/issues/7",
 	}
-	out, _ := engine.execEnsurePRClosesIssue("t1", newEnsurePRStep(), ti)
-	if out.Status != "failed" {
-		t.Errorf("Status = %q, want failed", out.Status)
+	out, err := engine.execEnsurePRClosesIssue("t1", newEnsurePRStep(), ti)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed (verification lag is soft-fail)", out.Status)
+	}
+	if !strings.Contains(out.Output, "trusting body") {
+		t.Errorf("Output = %q, want 'trusting body' message", out.Output)
 	}
 	after, _ := tasks.GetTask("t1")
-	if after.Status != "human-required" {
-		t.Errorf("task status = %q, want human-required", after.Status)
+	if after.Status != "in-review" {
+		t.Errorf("task status = %q, want in-review (unchanged)", after.Status)
+	}
+	// 1 pre-check + 1 initial verify + 3 retries = 5 fetches.
+	if linker.getCalls != 5 {
+		t.Errorf("GetClosingIssues calls = %d, want 5 (pre-check + 4 verify attempts)", linker.getCalls)
+	}
+}
+
+// Verification should retry: first post-edit fetch misses (GitHub
+// lagging), second fetch sees the parsed closing reference.
+func TestExecEnsurePRClosesIssue_VerifyRetrySucceeds(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	linker := &fakePRLinker{
+		getQueue: []getResult{
+			{issues: nil, body: "body"},                    // pre-check miss → triggers edit
+			{issues: nil, body: "body\n\nCloses ..."},      // verify attempt 0: still stale
+			{issues: []int{7}, body: "body\n\nCloses ..."}, // verify attempt 1: parsed
+		},
+	}
+	engine.SetPRLinker(linker)
+
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-review"})
+
+	ti := TaskInfo{
+		ID: "t1", ProjectID: "owner/repo", PRNumber: 5,
+		Issue: "https://github.com/owner/repo/issues/7",
+	}
+	out, err := engine.execEnsurePRClosesIssue("t1", newEnsurePRStep(), ti)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" || !strings.Contains(out.Output, "linked issue #7") {
+		t.Errorf("out = %+v, want completed/linked issue #7", out)
+	}
+	if linker.getCalls != 3 {
+		t.Errorf("GetClosingIssues calls = %d, want 3 (pre-check + 2 verify attempts)", linker.getCalls)
+	}
+}
+
+// Verification fetch that errors on every retry is still a soft-fail:
+// the edit went through, so trust the body we wrote.
+func TestExecEnsurePRClosesIssue_VerifyErrorTrustsBody(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	linker := &fakePRLinker{
+		getQueue: []getResult{
+			{issues: nil, body: "body"},
+			{err: errors.New("network timeout")},
+			{err: errors.New("network timeout")},
+			{err: errors.New("network timeout")},
+			{err: errors.New("network timeout")},
+		},
+	}
+	engine.SetPRLinker(linker)
+
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-review"})
+
+	ti := TaskInfo{
+		ID: "t1", ProjectID: "owner/repo", PRNumber: 5,
+		Issue: "https://github.com/owner/repo/issues/7",
+	}
+	out, err := engine.execEnsurePRClosesIssue("t1", newEnsurePRStep(), ti)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed", out.Status)
+	}
+	if !strings.Contains(out.Output, "trusting body") {
+		t.Errorf("Output = %q, want 'trusting body' message", out.Output)
+	}
+	after, _ := tasks.GetTask("t1")
+	if after.Status != "in-review" {
+		t.Errorf("task status = %q, want in-review (unchanged)", after.Status)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Tasks were flipping to `human-required` with "PR does not close linked issue after auto-fix" even when the PR body already contained a valid `Closes <url>` reference and the issue was in fact linked on GitHub.

Root cause: `closingIssuesReferences` is a GraphQL field GitHub populates **asynchronously** after parsing the PR body. `gh pr edit` returns as soon as the REST update is accepted, but cross-ref re-parsing lags by seconds (sometimes tens). The immediate re-fetch in `execEnsurePRClosesIssue` read stale data and reported a false negative.

## Implementation information

`execEnsurePRClosesIssue` (`internal/workflow/engine.go`) now:

- Retries the verify fetch up to 4 attempts (initial + 3 retries) with 2s/4s/6s backoff — ~12s total, tunable via `prVerifyBackoffs`.
- On any attempt that confirms the issue is linked: log `workflow.pr-close.linked` with attempt count, return `completed`.
- If all retries still miss (or error): log `workflow.pr-close.verify-lag` warn and return `completed` with "trusting body contents". Task status stays untouched. The body demonstrably contains `Closes <url>` (we just wrote it with a known-good format), so GitHub links it once it catches up.
- Edit-path failures still flip to `human-required` — that's a real failure (permissions, PR closed, etc).

Tests use an `init()` hook to swap `prVerifySleep` to a no-op so the retry schedule runs instantly. Three new cases:

- `VerifyRetrySucceeds` — first verify misses, second hits.
- `VerifyLagTrustsBody` — all 4 verify attempts miss, status stays `in-review`, output contains "trusting body".
- `VerifyErrorTrustsBody` — all verify attempts return network errors, same outcome.

The obsolete `VerifyFailureFlipsHumanRequired` test was removed.

Considered alternatives:

- **Trust body unconditionally (no verify)** — simpler, but loses the telemetry signal when GitHub really does fail to parse the body (e.g. format we didn't anticipate).
- **Retry-only, still flip on final miss** — doesn't solve the reported problem; the race window can exceed any reasonable backoff.

## Supporting documentation

Originating step: #281 `feat(workflow): ensure_pr_closes_issue step`.

> Changelog: fix(workflow): retry pr-close verify + trust body