### PR TITLE
perf(agent): validate codex reliability

### DIFF
--- a/cmd/fake-codex/main.go
+++ b/cmd/fake-codex/main.go
@@ -53,6 +53,16 @@ func runExec() {
 		emitAgentMessage("Triaging task...")
 		runCLI(taskID, "update", taskID, "--status", "planning", "--tags", "large,nocritic")
 		emitTurnCompleted(100, 20)
+	case "overloaded_error":
+		emitError("Service overloaded (529)")
+		os.Exit(1)
+	case "overloaded_error_structured":
+		emit(map[string]any{
+			"type":    "error",
+			"message": "Service overloaded",
+			"code":    529,
+		})
+		os.Exit(1)
 	case "implement", "interactive_implement":
 		emitAgentMessage("Implementing...")
 		emitTurnCompleted(100, 20)

--- a/e2e_workflow_test.go
+++ b/e2e_workflow_test.go
@@ -604,6 +604,47 @@ func TestE2E_CodexInteractiveAgent_StopTransitionsToStopped(t *testing.T) {
 	}
 }
 
+// TestE2E_Codex_HeadlessRetry_Overloaded verifies that a Codex headless agent
+// retries when the provider emits an overloaded error (substring match on the
+// message). The first invocation returns "overloaded_error" (exits 1 with an
+// error event containing "overloaded" in the message); the second succeeds.
+// Before the provider-guard fix, Codex never retried and the agent stayed
+// failed permanently.
+func TestE2E_Codex_HeadlessRetry_Overloaded(t *testing.T) {
+	env := setupE2EMultiProvider(t, "codex", []string{"overloaded_error", "success"})
+
+	ag, err := env.agents.Run(agent.RunConfig{
+		TaskID:   "task-codex-retry",
+		Name:     "codex retry overloaded",
+		Mode:     "headless",
+		Provider: "codex",
+		Prompt:   "do work",
+		Dir:      t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The first attempt exits 1 after emitting an overloaded error event.
+	// After backoff the agent retries and the second scenario (success) runs.
+	// First attempt exits 1 after ~0s; retry waits headlessRetryBackoffs[0]=30s;
+	// second attempt succeeds. Budget 90s to accommodate the backoff.
+	waitFor(t, 90*time.Second, "codex agent stops after retry", func() bool {
+		return ag.GetState() == agent.StateStopped
+	})
+
+	// Verify the agent produced a result event from the successful second attempt.
+	hasResult := false
+	for _, ev := range ag.Output() {
+		if ev.Type == "result" && ev.Subtype == "" {
+			hasResult = true
+		}
+	}
+	if !hasResult {
+		t.Error("expected result event from second attempt, got none")
+	}
+}
+
 // TestE2E_InteractiveImplement_OneShotAdvancesToEvaluate locks in the fix
 // for interactive implement steps stalling the workflow. Before the fix, a
 // conversational claude agent would emit its result event, flip to

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -55,6 +55,8 @@ func codexEventToConvoEvent(e CodexEvent) ConvoEvent {
 			ev.CostUSD = e.Result.CostUSD
 			ev.InputTokens = e.Result.InputTokens
 			ev.OutputTokens = e.Result.OutputTokens
+			ev.ErrorType = e.Result.ErrorType
+			ev.ErrorStatus = e.Result.ErrorStatus
 		}
 	}
 	return ev

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -134,7 +134,7 @@ func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfi
 		if prevLen > len(all) {
 			prevLen = len(all)
 		}
-		if a.Provider == "claude" && shouldRetry(stderrOut, all[prevLen:], m.logger) {
+		if shouldRetry(stderrOut, all[prevLen:], m.logger) {
 			return true, nil
 		}
 	}
@@ -407,6 +407,8 @@ func codexEventToStreamEvent(e CodexEvent) StreamEvent {
 			ev.CostUSD = e.Result.CostUSD
 			ev.InputTokens = e.Result.InputTokens
 			ev.OutputTokens = e.Result.OutputTokens
+			ev.ErrorType = e.Result.ErrorType
+			ev.ErrorStatus = e.Result.ErrorStatus
 		}
 	}
 	return ev

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -1,6 +1,8 @@
 package agent
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestParseCodexStreamEvent_AgentMessage(t *testing.T) {
 	line := []byte(`{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"hi"}}`)
@@ -54,5 +56,84 @@ func TestParseCodexStreamEvent_TurnCompleted(t *testing.T) {
 	}
 	if got.InputTokens != 16012 || got.OutputTokens != 18 {
 		t.Fatalf("tokens = %d/%d, want 16012/18", got.InputTokens, got.OutputTokens)
+	}
+}
+
+func TestParseCodexStreamEvent_Error_SubstringFallback(t *testing.T) {
+	line := []byte(`{"type":"error","message":"Service overloaded (529)"}`)
+
+	parsed, err := ParseCodexLine(line)
+	if err != nil {
+		t.Fatalf("ParseCodexLine: %v", err)
+	}
+	if parsed.Type != "result" || parsed.Subtype != "error" {
+		t.Fatalf("got type=%q subtype=%q, want result/error", parsed.Type, parsed.Subtype)
+	}
+	got := codexEventToStreamEvent(parsed)
+	if got.Type != "result" || got.Subtype != "error" {
+		t.Fatalf("StreamEvent type=%q subtype=%q, want result/error", got.Type, got.Subtype)
+	}
+
+	if !shouldRetry("", []StreamEvent{got}, nil) {
+		t.Fatal("shouldRetry = false, want true (substring fallback on overloaded message)")
+	}
+}
+
+func TestParseCodexStreamEvent_Error_StructuredCode(t *testing.T) {
+	line := []byte(`{"type":"error","message":"Service overloaded","code":529}`)
+
+	parsed, err := ParseCodexLine(line)
+	if err != nil {
+		t.Fatalf("ParseCodexLine: %v", err)
+	}
+	if parsed.Result == nil {
+		t.Fatal("Result is nil")
+	}
+	if parsed.Result.ErrorStatus != 529 {
+		t.Fatalf("ErrorStatus = %d, want 529", parsed.Result.ErrorStatus)
+	}
+
+	got := codexEventToStreamEvent(parsed)
+	if got.ErrorStatus != 529 {
+		t.Fatalf("StreamEvent.ErrorStatus = %d, want 529", got.ErrorStatus)
+	}
+	if !shouldRetry("", []StreamEvent{got}, nil) {
+		t.Fatal("shouldRetry = false, want true (structured ErrorStatus=529)")
+	}
+}
+
+func TestParseCodexStreamEvent_Error_StructuredErrorType(t *testing.T) {
+	line := []byte(`{"type":"error","message":"Overloaded","error_type":"overloaded_error","code":529}`)
+
+	parsed, err := ParseCodexLine(line)
+	if err != nil {
+		t.Fatalf("ParseCodexLine: %v", err)
+	}
+	if parsed.Result == nil {
+		t.Fatal("Result is nil")
+	}
+	if parsed.Result.ErrorType != "overloaded_error" {
+		t.Fatalf("ErrorType = %q, want overloaded_error", parsed.Result.ErrorType)
+	}
+
+	got := codexEventToStreamEvent(parsed)
+	if got.ErrorType != "overloaded_error" {
+		t.Fatalf("StreamEvent.ErrorType = %q, want overloaded_error", got.ErrorType)
+	}
+	if !shouldRetry("", []StreamEvent{got}, nil) {
+		t.Fatal("shouldRetry = false, want true (structured ErrorType=overloaded_error)")
+	}
+}
+
+func TestShouldRetry_Stderr529(t *testing.T) {
+	if !shouldRetry("error: 529 overloaded", nil, nil) {
+		t.Fatal("shouldRetry = false on stderr containing 529")
+	}
+}
+
+func TestShouldRetry_FatalError_NoRetry(t *testing.T) {
+	events := []StreamEvent{{Type: "result", Subtype: "error", Content: "permission denied"}}
+	if shouldRetry("", events, nil) {
+		t.Fatal("shouldRetry = true on non-transient error, want false")
 	}
 }

--- a/internal/agent/stream.go
+++ b/internal/agent/stream.go
@@ -22,6 +22,10 @@ type ClaudeResult struct {
 	CostUSD      float64
 	InputTokens  int
 	OutputTokens int
+	// ErrorType and ErrorStatus carry structured error info when Subtype == "error".
+	// Codex: mapped from the "code" field. Claude: reserved for future extraction.
+	ErrorType   string
+	ErrorStatus int
 }
 
 // ClaudeEvent is the shared envelope for all Claude stream-json events.
@@ -114,11 +118,18 @@ func ParseCodexLine(line []byte) (CodexEvent, error) {
 		return CodexEvent{Type: "init", Raw: rawCopy}, nil
 
 	case "error":
+		errStatus := int(floatVal(raw, "code"))
+		errType, _ := raw["error_type"].(string)
 		return CodexEvent{
 			Type:    "result",
 			Subtype: "error",
 			Raw:     rawCopy,
-			Result:  &ClaudeResult{Subtype: "error", Text: strVal(raw, "message")},
+			Result: &ClaudeResult{
+				Subtype:     "error",
+				Text:        strVal(raw, "message"),
+				ErrorType:   errType,
+				ErrorStatus: errStatus,
+			},
 		}, nil
 
 	case "turn.completed":


### PR DESCRIPTION
## Motivation

Codex was never retrying on 529/overloaded transient API errors — the retry loop in `runHeadlessAttempt` was guarded by `a.Provider == "claude"`, silently abandoning Codex agents on the first transient failure. Additionally, Codex error events had no structured error field extraction, forcing full reliance on substring fallback even when the provider emits a parseable `code` field.

## Implementation information

- **Remove provider guard** (`runner_headless.go:137`): `shouldRetry` now applies to all providers. Codex agents now retry up to 3× with 30s/60s/120s backoff on overloaded errors, matching Claude behavior.
- **Structured Codex error parsing** (`stream.go`): `ParseCodexLine` extracts `code` (int → `ErrorStatus`) and `error_type` (string → `ErrorType`) from Codex error events. `ClaudeResult` gains `ErrorType`/`ErrorStatus` fields to carry these through the pipeline.
- **Propagation** (`runner_headless.go`, `runner_codex_convo.go`): `codexEventToStreamEvent` and `codexEventToConvoEvent` now copy `ErrorType`/`ErrorStatus` onto the emitted events so `shouldRetry` can use the structured path instead of substring fallback.
- **fake-codex scenarios**: `overloaded_error` (message-only, tests substring fallback) and `overloaded_error_structured` (includes `code: 529`, tests structured path).
- **Unit tests**: substring fallback, structured code, structured error_type, stderr match, non-transient no-retry.
- **E2E test**: `TestE2E_Codex_HeadlessRetry_Overloaded` — uses scenario file with `overloaded_error → success`, asserts agent reaches StateStopped and produces a result event from the second attempt.

## Supporting documentation

- Umbrella: #256
- Phase 1 PR: #255

> Changelog: perf(agent): enable codex retry on 529/overloaded errors

Closes https://github.com/Automaat/synapse/issues/260