### PR TITLE
docs(readme): sync Go version to 1.26.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,16 @@ jobs:
       - name: Build
         run: wails build
 
+  doc-version-sync:
+    name: Doc Version Sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: |
+          GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')
+          grep -q "$GO_VERSION" README.md || (echo "README Go version stale (want $GO_VERSION)" && exit 1)
+          grep -q "$GO_VERSION" CLAUDE.md || (echo "CLAUDE.md Go version stale (want $GO_VERSION)" && exit 1)
+
   security:
     name: Security Audit
     runs-on: macos-15

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ synapse/
 
 ### Backend
 
-- **Go 1.26.1** (Wails v2 bound methods)
+- **Go 1.26.2** (Wails v2 bound methods)
 - **Wails v2.12** — desktop app framework, IPC via bound methods + events
 - **fsnotify** — file watching for task changes
 - **gopkg.in/yaml.v3** — YAML frontmatter parsing
@@ -65,7 +65,7 @@ synapse/
 
 ### Tooling
 
-- **mise** — tool version management (Go 1.26.1, Node 24)
+- **mise** — tool version management (Go 1.26.2, Node 24)
 - **golangci-lint v2** — Go linting (gocritic, nilerr, nilnesserr, nilnil, nolintlint, modernize)
 - **oxlint** — frontend linting
 - **GitHub Actions** — CI (lint-go, lint-frontend, build)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Complex tasks go through a planning phase. Simple tasks go straight to execution
 
 | Layer | Stack |
 |-------|-------|
-| Backend | Go 1.26.1, Wails v2.12 |
+| Backend | Go 1.26.2, Wails v2.12 |
 | Frontend | Svelte 5, TypeScript 6, Skeleton UI v4, Tailwind v4 |
 | IPC | Wails bound methods + events (no HTTP, no WebSocket) |
 | File format | YAML frontmatter + GFM markdown |
@@ -40,7 +40,7 @@ Complex tasks go through a planning phase. Simple tasks go straight to execution
 
 ## Getting started
 
-**Prerequisites:** Go 1.26.1, Node 24, [mise](https://mise.jdx.dev/), [Wails v2](https://wails.io/)
+**Prerequisites:** Go 1.26.2, Node 24, [mise](https://mise.jdx.dev/), [Wails v2](https://wails.io/)
 
 ```bash
 # Install tool versions


### PR DESCRIPTION
## Motivation

go.mod was at 1.26.2 but README and CLAUDE.md still said 1.26.1. New contributors installing the wrong toolchain version.

## Implementation information

- Bumped 1.26.1 → 1.26.2 in README.md (tech stack table + prerequisites line)
- Bumped 1.26.1 → 1.26.2 in CLAUDE.md (tech stack section, mise line)
- Added `doc-version-sync` CI job that extracts the version from go.mod and fails if README or CLAUDE.md don't match

> Changelog: docs(readme): sync Go version to 1.26.2

Closes https://github.com/Automaat/synapse/issues/324