### PR TITLE
chore(deps): expand renovate config with best practices

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,24 +1,62 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": [
+    "config:best-practices",
+    ":semanticCommits",
+    ":gitSignOff",
+    ":dependencyDashboard",
+    ":label(dependencies)",
+    ":rebaseStalePrs",
+    ":enableVulnerabilityAlertsWithAdditionalLabel(security)",
+    ":automergeMinor",
+    ":automergeLinters",
+    ":automergeTesters",
+    ":prConcurrentLimit20",
+    "helpers:pinGitHubActionDigests"
+  ],
   "schedule": ["after 10pm every weekday"],
+  "osvVulnerabilityAlerts": true,
+  "automergeStrategy": "squash",
   "packageRules": [
     {
+      "description": "GitHub Actions dependencies",
+      "matchManagers": ["github-actions"],
+      "addLabels": ["area/ci"],
+      "semanticCommitType": "ci",
+      "commitMessageTopic": "{{depName}} action"
+    },
+    {
+      "description": "Group patch updates",
       "matchUpdateTypes": ["patch"],
       "automerge": true,
       "groupName": "patch dependencies"
     },
     {
-      "matchUpdateTypes": ["minor"],
-      "groupName": "minor dependencies"
+      "description": "Group vitest packages",
+      "matchPackageNames": ["vitest", "@vitest/*"],
+      "groupName": "vitest"
     },
     {
-      "matchPackageNames": ["golang.org/x/*"],
+      "description": "Group Playwright packages",
+      "matchPackageNames": ["@playwright/*"],
+      "groupName": "playwright"
+    },
+    {
+      "description": "Group golang.org/x updates",
+      "matchPackageNames": ["/^golang\\.org/x//"],
       "groupName": "golang.org/x updates"
     },
     {
-      "matchPackageNames": ["@testing-library/*", "vitest", "@vitest/*"],
-      "groupName": "testing dependencies"
+      "description": "Enable Go version updates in go.mod",
+      "matchManagers": ["gomod"],
+      "matchDepNames": ["go"],
+      "rangeStrategy": "bump"
+    },
+    {
+      "description": "Group Go version updates across mise and go.mod",
+      "groupName": "Go",
+      "matchPackageNames": ["go"],
+      "matchDatasources": ["golang-version"]
     }
   ]
 }


### PR DESCRIPTION
## Motivation

No automated dependency tracking for 20+ frontend and Go deps. Manual `npm audit` only runs in CI security job with `continue-on-error`.

## Implementation information

Upgrades `renovate.json` from `config:recommended` baseline to `config:best-practices` with:

- Semantic commits + git sign-off on Renovate PRs
- Dependency dashboard issue
- OSV vulnerability alerts with `security` label
- Automerge for minor, patch, linters, testers
- GH Actions digest pinning
- Groupings: vitest, playwright, golang.org/x, Go version (across mise + go.mod)
- GitHub Actions PRs tagged `area/ci` with `ci:` commit type

> Changelog: chore(deps): expand renovate config with best practices

Closes https://github.com/Automaat/synapse/issues/321