### PR TITLE
refactor(poll): extract shared PollerHub

### DIFF
--- a/app.go
+++ b/app.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Automaat/synapse/internal/config"
 	"github.com/Automaat/synapse/internal/github"
 	"github.com/Automaat/synapse/internal/notification"
+	"github.com/Automaat/synapse/internal/poll"
 	"github.com/Automaat/synapse/internal/project"
 	"github.com/Automaat/synapse/internal/spotlight"
 	"github.com/Automaat/synapse/internal/stats"
@@ -57,6 +58,7 @@ type App struct {
 	todoistHandler  *TodoistHandler
 	todoistCancel   context.CancelFunc
 	renovateHandler *RenovateHandler
+	issuesFetcher   *IssuesFetcher
 	cfg             *config.Config
 	logLevel        *slog.LevelVar
 	emit            func(string, any)
@@ -180,6 +182,7 @@ func (a *App) startup(ctx context.Context) {
 
 	a.initTodoist(emit)
 	a.initRenovate(emit)
+	a.issuesFetcher = newIssuesFetcher(a.tasks, a.projects, emit, a.logger)
 	a.wireServices(emit)
 
 	a.syncSkills()
@@ -189,13 +192,16 @@ func (a *App) startup(ctx context.Context) {
 	a.restartStaleInProgress()
 	a.RegisterSpotlightHotkey()
 	a.wg.Go(func() { a.orchestratorLoop(ctx) })
-	a.wg.Go(func() { a.prPollLoop(ctx) })
 	a.wg.Go(func() { a.agentWatchdogLoop(ctx) })
-	a.startTodoistLoop(ctx)
+
+	hub := poll.NewHub()
+	hub.Register(a.reviewer, 10*time.Second)
+	hub.Register(a.issuesFetcher, 20*time.Second)
 	if a.renovateHandler != nil {
-		a.wg.Go(func() { a.renovatePollLoop(ctx) })
+		hub.Register(a.renovateHandler, 15*time.Second)
 	}
-	a.wg.Go(func() { a.issuesPollLoop(ctx) })
+	hub.Start(ctx, &a.wg, a.logger)
+	a.startTodoistLoop(ctx)
 	a.logger.Info("app.started")
 }
 
@@ -503,7 +509,7 @@ func (a *App) restartStaleInProgress() {
 			continue
 		}
 		// Tasks whose last agent was a pr-fix should not be re-implemented.
-		// Move them back to in-review so prPollLoop can re-detect and fix.
+		// Move them back to in-review so the reviews poller can re-detect and fix.
 		// Applies to both headless and interactive modes — handlePRIssue
 		// spawns pr-fix agents directly without registering a workflow, so
 		// onAgentComplete can't advance the task back to in-review itself.
@@ -711,20 +717,4 @@ func (a *App) RegisterSpotlightHotkey() {
 		return
 	}
 	a.logger.Info("spotlight.registered", "hotkey", "ctrl+space")
-}
-
-func (a *App) prPollLoop(ctx context.Context) {
-	timer := time.NewTimer(10 * time.Second) // initial fetch shortly after startup
-	defer timer.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-timer.C:
-			next := a.reviewer.pollAndMonitorPRs()
-			a.logger.Debug("pr-poll.next", "interval", next)
-			timer.Reset(next)
-		}
-	}
 }

--- a/app_issues.go
+++ b/app_issues.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"context"
+	"log/slog"
 	"strings"
 	"time"
 
 	"github.com/Automaat/synapse/internal/github"
 	"github.com/Automaat/synapse/internal/project"
 	"github.com/Automaat/synapse/internal/task"
-	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
 const issuesPollInterval = 5 * time.Minute
@@ -16,38 +16,44 @@ const issuesPollInterval = 5 * time.Minute
 // synapseIssueLabel is the GitHub label that triggers auto-creation of Synapse tasks.
 const synapseIssueLabel = "synapse"
 
-func (a *App) issuesPollLoop(ctx context.Context) {
-	timer := time.NewTimer(20 * time.Second)
-	defer timer.Stop()
+// IssuesFetcher polls GitHub for assigned and labeled issues and syncs them to tasks.
+type IssuesFetcher struct {
+	tasks    *task.Manager
+	projects *project.Store
+	emit     func(string, any)
+	logger   *slog.Logger
+}
 
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-timer.C:
-			issues, err := github.FetchAssignedIssues()
-			if err != nil {
-				a.logger.Warn("issues.fetch", "err", err)
-				timer.Reset(issuesPollInterval)
-				continue
-			}
+func newIssuesFetcher(
+	tasks *task.Manager,
+	projects *project.Store,
+	emit func(string, any),
+	logger *slog.Logger,
+) *IssuesFetcher {
+	return &IssuesFetcher{tasks: tasks, projects: projects, emit: emit, logger: logger}
+}
 
-			runtime.EventsEmit(a.ctx, "issues:updated", issues)
-			a.logger.Debug("issues.poll", "count", len(issues))
+func (f *IssuesFetcher) Name() string { return "issues" }
 
-			a.syncIssuesToTasks(issues)
-			a.syncLabeledIssuesToTasks()
-			timer.Reset(issuesPollInterval)
-		}
+func (f *IssuesFetcher) Poll(_ context.Context) time.Duration {
+	issues, err := github.FetchAssignedIssues()
+	if err != nil {
+		f.logger.Warn("issues.fetch", "err", err)
+		return issuesPollInterval
 	}
+	f.emit("issues:updated", issues)
+	f.logger.Debug("issues.poll", "count", len(issues))
+	f.syncIssuesToTasks(issues)
+	f.syncLabeledIssuesToTasks()
+	return issuesPollInterval
 }
 
 // syncLabeledIssuesToTasks fetches issues labeled 'synapse' across all registered
 // pet projects and creates tasks for any not yet tracked.
-func (a *App) syncLabeledIssuesToTasks() {
-	projects, err := a.projects.List()
+func (f *IssuesFetcher) syncLabeledIssuesToTasks() {
+	projects, err := f.projects.List()
 	if err != nil {
-		a.logger.Error("labeled-issues.list-projects", "err", err)
+		f.logger.Error("labeled-issues.list-projects", "err", err)
 		return
 	}
 
@@ -63,17 +69,17 @@ func (a *App) syncLabeledIssuesToTasks() {
 
 	labeled, err := github.FetchLabeledIssuesForRepos(repos, synapseIssueLabel)
 	if err != nil {
-		a.logger.Warn("labeled-issues.fetch", "err", err)
+		f.logger.Warn("labeled-issues.fetch", "err", err)
 		return
 	}
-	a.logger.Debug("labeled-issues.poll", "count", len(labeled))
-	a.syncIssuesToTasks(labeled)
+	f.logger.Debug("labeled-issues.poll", "count", len(labeled))
+	f.syncIssuesToTasks(labeled)
 }
 
-func (a *App) syncIssuesToTasks(issues []github.Issue) {
-	tasks, err := a.tasks.List()
+func (f *IssuesFetcher) syncIssuesToTasks(issues []github.Issue) {
+	tasks, err := f.tasks.List()
 	if err != nil {
-		a.logger.Error("issue-sync.list-tasks", "err", err)
+		f.logger.Error("issue-sync.list-tasks", "err", err)
 		return
 	}
 
@@ -105,20 +111,20 @@ func (a *App) syncIssuesToTasks(issues []github.Issue) {
 			if issue.Body != "" {
 				u.Body = task.Ptr(issue.Body)
 			}
-			if _, projErr := a.projects.Get(issue.Repository); projErr == nil {
+			if _, projErr := f.projects.Get(issue.Repository); projErr == nil {
 				u.ProjectID = task.Ptr(issue.Repository)
 			}
-			if _, err := a.tasks.Update(taskID, u); err != nil {
-				a.logger.Error("issue-sync.enrich", "task_id", taskID, "err", err)
+			if _, err := f.tasks.Update(taskID, u); err != nil {
+				f.logger.Error("issue-sync.enrich", "task_id", taskID, "err", err)
 			} else {
-				a.logger.Info("issue-sync.enriched", "task_id", taskID, "issue", issue.URL, "title", issue.Title)
+				f.logger.Info("issue-sync.enriched", "task_id", taskID, "issue", issue.URL, "title", issue.Title)
 			}
 			continue
 		}
 
-		t, err := a.tasks.Create(issue.Title, issue.Body, "headless")
+		t, err := f.tasks.Create(issue.Title, issue.Body, "headless")
 		if err != nil {
-			a.logger.Error("issue-sync.create", "issue", issue.URL, "err", err)
+			f.logger.Error("issue-sync.create", "issue", issue.URL, "err", err)
 			continue
 		}
 
@@ -127,7 +133,7 @@ func (a *App) syncIssuesToTasks(issues []github.Issue) {
 			Status: task.Ptr(task.StatusTodo),
 		}
 
-		if _, projErr := a.projects.Get(issue.Repository); projErr == nil {
+		if _, projErr := f.projects.Get(issue.Repository); projErr == nil {
 			u.ProjectID = task.Ptr(issue.Repository)
 		}
 
@@ -136,10 +142,10 @@ func (a *App) syncIssuesToTasks(issues []github.Issue) {
 			u.Tags = &labels
 		}
 
-		if _, err := a.tasks.Update(t.ID, u); err != nil {
-			a.logger.Error("issue-sync.update", "task_id", t.ID, "err", err)
+		if _, err := f.tasks.Update(t.ID, u); err != nil {
+			f.logger.Error("issue-sync.update", "task_id", t.ID, "err", err)
 		}
 
-		a.logger.Info("issue-sync.created", "task_id", t.ID, "issue", issue.URL)
+		f.logger.Info("issue-sync.created", "task_id", t.ID, "issue", issue.URL)
 	}
 }

--- a/app_renovate.go
+++ b/app_renovate.go
@@ -51,6 +51,12 @@ func (h *RenovateHandler) repos() []string {
 	return repos
 }
 
+func (h *RenovateHandler) Name() string { return "renovate" }
+
+func (h *RenovateHandler) Poll(_ context.Context) time.Duration {
+	return h.pollRenovatePRs()
+}
+
 func (h *RenovateHandler) pollRenovatePRs() time.Duration {
 	repos := h.repos()
 	if len(repos) == 0 {
@@ -80,20 +86,4 @@ func (a *App) initRenovate(emit func(string, any)) {
 	}
 	a.renovateHandler = newRenovateHandler(a.projects, a.logger, emit, &a.cfg.Renovate)
 	a.logger.Info("renovate.enabled", "author", a.cfg.Renovate.Author)
-}
-
-func (a *App) renovatePollLoop(ctx context.Context) {
-	timer := time.NewTimer(15 * time.Second)
-	defer timer.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-timer.C:
-			next := a.renovateHandler.pollRenovatePRs()
-			a.logger.Debug("renovate-poll.next", "interval", next)
-			timer.Reset(next)
-		}
-	}
 }

--- a/app_reviews.go
+++ b/app_reviews.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -286,6 +287,12 @@ func prMonitorEligible(t *task.Task) bool {
 	default:
 		return false
 	}
+}
+
+func (r *ReviewHandler) Name() string { return "reviews" }
+
+func (r *ReviewHandler) Poll(_ context.Context) time.Duration {
+	return r.pollAndMonitorPRs()
 }
 
 func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {

--- a/app_todoist.go
+++ b/app_todoist.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Automaat/synapse/internal/audit"
 	"github.com/Automaat/synapse/internal/config"
 	"github.com/Automaat/synapse/internal/events"
+	"github.com/Automaat/synapse/internal/poll"
 	"github.com/Automaat/synapse/internal/task"
 	"github.com/Automaat/synapse/internal/todoist"
 )
@@ -38,6 +39,12 @@ func newTodoistHandler(
 		client:        client,
 		cfg:           cfg,
 	}
+}
+
+func (h *TodoistHandler) Name() string { return "todoist" }
+
+func (h *TodoistHandler) Poll(_ context.Context) time.Duration {
+	return h.pollAndSync()
 }
 
 // pollAndSync runs one import+completion cycle and returns the next poll interval.
@@ -169,22 +176,6 @@ func (a *App) initTodoist(emit func(string, any)) {
 	a.logger.Info("todoist.enabled", "project_id", a.cfg.Todoist.ProjectID)
 }
 
-// todoistPollLoop runs the Todoist sync on a timer.
-func (a *App) todoistPollLoop(ctx context.Context) {
-	timer := time.NewTimer(15 * time.Second)
-	defer timer.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-timer.C:
-			next := a.todoistHandler.pollAndSync()
-			timer.Reset(next)
-		}
-	}
-}
-
 // startTodoistLoop launches the poll goroutine if the handler is initialized.
 func (a *App) startTodoistLoop(parent context.Context) {
 	if a.todoistHandler == nil {
@@ -192,7 +183,8 @@ func (a *App) startTodoistLoop(parent context.Context) {
 	}
 	ctx, cancel := context.WithCancel(parent)
 	a.todoistCancel = cancel
-	a.wg.Go(func() { a.todoistPollLoop(ctx) })
+	p := poll.New(a.todoistHandler, 15*time.Second, a.logger)
+	a.wg.Go(func() { p.Run(ctx) })
 }
 
 // stopTodoistLoop cancels the running poll goroutine if any.

--- a/internal/poll/poller.go
+++ b/internal/poll/poller.go
@@ -1,0 +1,73 @@
+package poll
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Fetcher runs one poll cycle. The returned duration sets the next interval.
+// Returning 0 or negative falls back to one minute.
+type Fetcher interface {
+	Name() string
+	Poll(ctx context.Context) time.Duration
+}
+
+// Poller drives a single Fetcher on a timer.
+type Poller struct {
+	fetcher     Fetcher
+	initialWait time.Duration
+	logger      *slog.Logger
+}
+
+// New returns a Poller for f with the given initial delay before the first tick.
+func New(f Fetcher, initialWait time.Duration, logger *slog.Logger) *Poller {
+	return &Poller{fetcher: f, initialWait: initialWait, logger: logger}
+}
+
+// Run blocks until ctx is cancelled, calling f.Poll on each tick.
+func (p *Poller) Run(ctx context.Context) {
+	timer := time.NewTimer(p.initialWait)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			next := p.fetcher.Poll(ctx)
+			if next <= 0 {
+				next = time.Minute
+			}
+			p.logger.Debug("poll.next", "name", p.fetcher.Name(), "interval", next)
+			timer.Reset(next)
+		}
+	}
+}
+
+// Hub owns a set of Fetchers and starts them together.
+type Hub struct {
+	entries []hubEntry
+}
+
+type hubEntry struct {
+	fetcher     Fetcher
+	initialWait time.Duration
+}
+
+// NewHub returns an empty Hub.
+func NewHub() *Hub { return &Hub{} }
+
+// Register adds a Fetcher to the Hub.
+func (h *Hub) Register(f Fetcher, initialWait time.Duration) {
+	h.entries = append(h.entries, hubEntry{f, initialWait})
+}
+
+// Start launches each registered Fetcher as a goroutine tracked by wg.
+func (h *Hub) Start(ctx context.Context, wg *sync.WaitGroup, logger *slog.Logger) {
+	for _, e := range h.entries {
+		p := New(e.fetcher, e.initialWait, logger)
+		wg.Go(func() { p.Run(ctx) })
+	}
+}


### PR DESCRIPTION
## Motivation

Four polling handlers (`app_issues.go`, `app_renovate.go`, `app_reviews.go`, `app_todoist.go`) each reimplemented the same pattern: timer creation, fetch, diff, emit, return next interval. Adding a fifth integration meant copying ~150-500 lines.

## Implementation information

Extract `internal/poll` package with:
- `Fetcher` interface: `Name() string` + `Poll(ctx context.Context) time.Duration`
- `Poller`: drives a single `Fetcher` on a timer with configurable initial delay
- `Hub`: owns a set of `Fetcher`s and starts them together via `hub.Start(ctx, wg, logger)`

Existing handlers adapted:
- `IssuesFetcher` (new struct) — extracted from `App` methods, uses `emit` func instead of `runtime.EventsEmit` directly
- `RenovateHandler` — added `Name()`/`Poll()`, removed `renovatePollLoop`
- `ReviewHandler` — added `Name()`/`Poll()`, `prPollLoop` removed from `app.go`
- `TodoistHandler` — added `Name()`/`Poll()`, `todoistPollLoop` replaced by `poll.New().Run()` in `startTodoistLoop` (keeps dynamic start/stop/reload support)

`app.go` startup replaces 4 separate goroutine launches with `hub.Start`. Todoist remains outside the Hub since it supports dynamic reload.

New integrations: implement `Fetcher`, register with Hub — no poll loop boilerplate.

> Changelog: refactor(poll): extract shared PollerHub

Closes https://github.com/Automaat/synapse/issues/322