### PR TITLE
fix(app): graceful degrade on stats/audit init fail

### DIFF
--- a/app.go
+++ b/app.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Automaat/synapse/internal/agent"
 	"github.com/Automaat/synapse/internal/audit"
 	"github.com/Automaat/synapse/internal/config"
+	"github.com/Automaat/synapse/internal/events"
 	"github.com/Automaat/synapse/internal/github"
 	"github.com/Automaat/synapse/internal/notification"
 	"github.com/Automaat/synapse/internal/poll"
@@ -112,11 +113,12 @@ func (a *App) startup(ctx context.Context) {
 
 	statsStore, err := stats.NewStore(config.StatsFile())
 	if err != nil {
-		a.logger.Error("stats.init", "err", err)
+		a.logger.Warn("stats.init.degraded", "err", err)
+		// a.stats remains nil; StatsService.GetStats() guards against nil.
 	} else {
 		a.stats = statsStore
 		if err := statsStore.Backfill(a.auditDir); err != nil {
-			a.logger.Error("stats.backfill", "err", err)
+			a.logger.Warn("stats.backfill", "err", err)
 		}
 	}
 
@@ -143,6 +145,7 @@ func (a *App) startup(ctx context.Context) {
 		runtime.EventsEmit(ctx, event, data)
 	}
 	a.emit = emit
+	a.emitDegradedWarnings(emit)
 	a.tasks = task.NewManager(store, task.EmitterFunc(emit))
 	a.initStatusHook()
 	a.notifier = notification.New(emit)
@@ -249,7 +252,9 @@ func (a *App) initStatusHook() {
 func (a *App) initAudit() {
 	al, err := audit.NewLogger(a.auditDir)
 	if err != nil {
-		a.logger.Error("audit.init", "err", err)
+		a.logger.Warn("audit.init.degraded", "err", err)
+		// a.audit remains nil; logAudit() is a no-op when audit is nil.
+		return
 	}
 	a.audit = al
 	retentionDays := a.cfg.Audit.RetentionDays
@@ -257,7 +262,22 @@ func (a *App) initAudit() {
 		retentionDays = 30
 	}
 	if err := audit.Cleanup(a.auditDir, retentionDays); err != nil {
-		a.logger.Error("audit.cleanup", "err", err)
+		a.logger.Warn("audit.cleanup", "err", err)
+	}
+}
+
+// emitDegradedWarnings fires startup:degraded for any subsystem that failed
+// to initialize. Called after emit is configured so the frontend receives the events.
+func (a *App) emitDegradedWarnings(emit func(string, any)) {
+	type degraded struct {
+		Subsystem string `json:"subsystem"`
+		Reason    string `json:"reason"`
+	}
+	if a.audit == nil {
+		emit(events.StartupDegraded, degraded{"audit", "audit logger failed to initialize; audit trail unavailable"})
+	}
+	if a.stats == nil {
+		emit(events.StartupDegraded, degraded{"stats", "stats store failed to initialize; metrics unavailable"})
 	}
 }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,22 +15,22 @@
         "snarkdown": "^2.0.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.59.1",
-        "@skeletonlabs/skeleton": "^4.0.0",
-        "@skeletonlabs/skeleton-svelte": "^4.0.0",
-        "@sveltejs/vite-plugin-svelte": "^7.0.0",
-        "@tailwindcss/vite": "^4.0.0",
-        "@testing-library/jest-dom": "^6.9.1",
-        "@testing-library/svelte": "^5.3.1",
-        "@vitest/coverage-v8": "^4.1.2",
-        "jsdom": "^29.0.1",
-        "oxlint": "^1.58.0",
-        "svelte": "^5.0.0",
-        "svelte-check": "^4.0.0",
-        "tailwindcss": "^4.0.0",
-        "typescript": "^6.0.0",
-        "vite": "^8.0.0",
-        "vitest": "^4.1.2"
+        "@playwright/test": "1.59.1",
+        "@skeletonlabs/skeleton": "4.15.0",
+        "@skeletonlabs/skeleton-svelte": "4.15.0",
+        "@sveltejs/vite-plugin-svelte": "7.0.0",
+        "@tailwindcss/vite": "4.2.2",
+        "@testing-library/jest-dom": "6.9.1",
+        "@testing-library/svelte": "5.3.1",
+        "@vitest/coverage-v8": "4.1.2",
+        "jsdom": "29.0.1",
+        "oxlint": "1.58.0",
+        "svelte": "5.55.1",
+        "svelte-check": "4.4.6",
+        "tailwindcss": "4.2.2",
+        "typescript": "6.0.2",
+        "vite": "8.0.5",
+        "vitest": "4.1.2"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -59,6 +59,9 @@
     }
   }
 
+  type DegradedWarning = { subsystem: string; reason: string }
+  let degradedWarnings = $state<DegradedWarning[]>([])
+
   let dialogOpen = $state(false)
   let projectDialogOpen = $state(false)
   let quickAddOpen = $state(false)
@@ -135,6 +138,9 @@
     const unsubTasks = onEvents([ev.TaskCreated, ev.TaskUpdated, ev.TaskDeleted], reloadTasks)
     notificationStore.load()
     const unsubNotif = notificationStore.listen()
+    const unsubDegraded = EventsOn(ev.StartupDegraded, (w: DegradedWarning) => {
+      degradedWarnings = [...degradedWarnings, w]
+    })
     const unsubQuit = EventsOn(ev.AppQuitConfirm, () => {
       quitConfirmVisible = true
       if (quitConfirmTimer) clearTimeout(quitConfirmTimer)
@@ -210,6 +216,7 @@
     return () => {
       unsubTasks()
       unsubNotif()
+      unsubDegraded()
       unsubQuit()
       if (quitConfirmTimer) clearTimeout(quitConfirmTimer)
       taskStore.stopPolling()
@@ -349,6 +356,25 @@
         </AppBar.Trail>
       </AppBar.Toolbar>
     </AppBar>
+
+    {#if degradedWarnings.length > 0}
+      <div class="flex flex-col gap-0.5">
+        {#each degradedWarnings as w, i (w.subsystem)}
+          <div class="flex items-center gap-2 bg-warning-800/90 border-b border-warning-600 px-4 py-2 text-warning-100 text-sm">
+            <svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+            </svg>
+            <span><strong>{w.subsystem}</strong> degraded — {w.reason}</span>
+            <button
+              type="button"
+              class="ml-auto opacity-60 hover:opacity-100 text-xs"
+              onclick={() => { degradedWarnings = degradedWarnings.filter((_, j) => j !== i) }}
+              aria-label="Dismiss"
+            >✕</button>
+          </div>
+        {/each}
+      </div>
+    {/if}
 
     <main class="flex-1 overflow-y-auto">
       {#if page.kind === 'dashboard'}

--- a/frontend/src/lib/events.ts
+++ b/frontend/src/lib/events.ts
@@ -21,6 +21,7 @@ export const Notification = "notification"
 export const TodoistSynced = "todoist:synced"
 export const IssuesUpdated = "issues:updated"
 export const AppQuitConfirm = "app:quit-confirm"
+export const StartupDegraded = "startup:degraded"
 
 export const agentApproval = (id: string) => `${AgentApprovalPrefix}${id}`
 export const agentConvo = (id: string) => `${AgentConvoPrefix}${id}`

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -35,7 +35,8 @@ const (
 	IssuesUpdated = "issues:updated"
 
 	// App lifecycle events.
-	AppQuitConfirm = "app:quit-confirm"
+	AppQuitConfirm  = "app:quit-confirm"
+	StartupDegraded = "startup:degraded"
 )
 
 // AgentState returns the agent state event name for the given agent ID.

--- a/internal/events/events_generated_test.go
+++ b/internal/events/events_generated_test.go
@@ -85,5 +85,5 @@ var _ = strings.Join([]string{
 	AgentStatePrefix, AgentOutputPrefix, AgentErrorPrefix,
 	AgentStuckPrefix, AgentConvoPrefix, AgentApprovalPrefix, AgentEscalationPrefix,
 	OrchestratorState, ReviewsUpdated, RenovateUpdated,
-	Notification, TodoistSynced, IssuesUpdated, AppQuitConfirm,
+	Notification, TodoistSynced, IssuesUpdated, AppQuitConfirm, StartupDegraded,
 }, ",")


### PR DESCRIPTION
## Motivation

App startup silently degraded when stats/audit subsystems failed to init — stats error was logged but ignored, audit had no error check at all. User saw a half-broken app with no indication anything went wrong.

## Implementation information

Option B (explicit graceful degrade):

- `initAudit()`: only assigns `a.audit` on success; logs at Warn on failure (was Error). Returns early so cleanup is skipped when logger isn't available.
- Stats init: logs at Warn instead of Error on failure.
- `emitDegradedWarnings()`: called after `a.emit` is configured (since emit isn't available at init time). Fires `startup:degraded` for each nil subsystem sentinel (`a.audit == nil`, `a.stats == nil`).
- `StartupDegraded` event constant added to `internal/events/events.go` + TS regenerated.
- Frontend (`App.svelte`): listens for `startup:degraded` events, renders a persistent dismissible warning banner per degraded subsystem between the AppBar and main content.

Existing nil guards in `logAudit()` and `StatsService.GetStats()` already cover consumers.

> Changelog: fix(app): graceful degrade on stats/audit init fail

Closes https://github.com/Automaat/synapse/issues/313