### PR TITLE
test(e2e): fix panics, flaky sleeps; add workflow cycle detection

### DIFF
--- a/e2e_workflow_test.go
+++ b/e2e_workflow_test.go
@@ -27,31 +27,48 @@ import (
 var (
 	testBinDir    string
 	testBuildOnce sync.Once
+	testBuildErr  string // non-empty if binary build failed
 )
+
+// TestMain tears down the shared binary directory after all tests complete.
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if testBinDir != "" {
+		_ = os.RemoveAll(testBinDir)
+	}
+	os.Exit(code)
+}
 
 func buildTestBinaries(t *testing.T) string {
 	t.Helper()
 	testBuildOnce.Do(func() {
 		dir, err := os.MkdirTemp("", "synapse-test-bins-*")
 		if err != nil {
-			panic(err)
+			testBuildErr = err.Error()
+			return
 		}
 		// Build fake claude.
 		cmd := exec.Command("go", "build", "-o", filepath.Join(dir, "claude"), "./cmd/fake-claude")
 		if out, err := cmd.CombinedOutput(); err != nil {
-			panic("build fake-claude: " + err.Error() + "\n" + string(out))
+			testBuildErr = "build fake-claude: " + err.Error() + "\n" + string(out)
+			return
 		}
 		cmd = exec.Command("go", "build", "-o", filepath.Join(dir, "codex"), "./cmd/fake-codex")
 		if out, err := cmd.CombinedOutput(); err != nil {
-			panic("build fake-codex: " + err.Error() + "\n" + string(out))
+			testBuildErr = "build fake-codex: " + err.Error() + "\n" + string(out)
+			return
 		}
 		// Build real synapse-cli.
 		cmd = exec.Command("go", "build", "-o", filepath.Join(dir, "synapse-cli"), "./cmd/synapse-cli")
 		if out, err := cmd.CombinedOutput(); err != nil {
-			panic("build synapse-cli: " + err.Error() + "\n" + string(out))
+			testBuildErr = "build synapse-cli: " + err.Error() + "\n" + string(out)
+			return
 		}
 		testBinDir = dir
 	})
+	if testBuildErr != "" {
+		t.Fatalf("build test binaries: %s", testBuildErr)
+	}
 	return testBinDir
 }
 
@@ -1604,10 +1621,7 @@ func TestE2E_StaleAgentCompletionAfterWorkflowTerminal(t *testing.T) {
 	// with StepID="". After the fix it is a silent no-op.
 	env.engine.HandleAgentComplete(created.ID, "stray-agent-xyz", "late result", "stopped")
 
-	// Allow any async side effects to land — there should be none, but give
-	// the scheduler a chance so we're not racing a future write.
-	time.Sleep(50 * time.Millisecond)
-
+	// HandleAgentComplete is synchronous; no async side effects to wait for.
 	tkAfter, _ := env.tasks.Get(created.ID)
 	if tkAfter.Workflow.State != workflow.ExecCompleted {
 		t.Errorf("state = %q, want ExecCompleted (stray completion must not mutate)",
@@ -1679,8 +1693,8 @@ func TestE2E_StaleAgentCompletionAtWaitHuman(t *testing.T) {
 	// this would drive resolveNext → ExecFailed; post-fix it's a silent
 	// no-op because output.AgentID != "" and human_action is unset.
 	env.engine.HandleAgentComplete(created.ID, "stray-duplicate-plan-agent", "late plan result", "stopped")
-	time.Sleep(50 * time.Millisecond)
 
+	// HandleAgentComplete is synchronous; no async side effects to wait for.
 	tkAfter, _ := env.tasks.Get(created.ID)
 	if tkAfter.Workflow.State != workflow.ExecWaiting {
 		t.Errorf("state = %q, want ExecWaiting — stray completion must not fail wait_human",
@@ -1779,7 +1793,7 @@ func TestE2E_RestartStaleSkipsTerminalWorkflow(t *testing.T) {
 	// workflow cannot be re-started on this task without explicit reset —
 	// the engine's state is preserved, not mutated.
 	before := *tk.Workflow
-	time.Sleep(50 * time.Millisecond)
+	// No background activity targets this task; assert state is unchanged immediately.
 	tkAfter, _ := env.tasks.Get(created.ID)
 	if tkAfter.Workflow.State != before.State {
 		t.Errorf("workflow state mutated: %q → %q", before.State, tkAfter.Workflow.State)

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -597,11 +597,28 @@ func (e *Engine) ResumeStalled() {
 	}
 }
 
+// CycleError is returned when executeSteps detects a cycle in the synchronous
+// step chain — the same step ID was visited twice without an async step
+// (run_agent, wait_human) breaking the loop.
+type CycleError struct {
+	StepID string
+	// At is the iteration index at which the cycle was detected (0-based).
+	At int
+	// FirstAt is the iteration index at which the step was first visited.
+	FirstAt int
+}
+
+func (e *CycleError) Error() string {
+	return fmt.Sprintf("workflow cycle detected: step %q revisited at iteration %d (first seen at %d)",
+		e.StepID, e.At, e.FirstAt)
+}
+
 // executeSteps iterates through synchronous steps until it hits an async step
 // (run_agent, wait_human) or the workflow ends. This avoids recursive calls
 // between executeStep/AdvanceStep that caused inflight guard deadlocks.
 func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec *Execution) error {
-	for range maxSyncSteps {
+	visited := make(map[string]int) // stepID → first-seen iteration index
+	for i := range maxSyncSteps {
 		t, err := e.tasks.GetTask(taskID)
 		if err != nil {
 			return err
@@ -641,6 +658,14 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 		default:
 			return fmt.Errorf("unknown step type %q", step.Type)
 		}
+
+		// Detect cycles: a sync step revisited without an async break means
+		// the workflow loops forever. Return a CycleError instead of hitting
+		// the generic maxSyncSteps limit.
+		if firstAt, seen := visited[step.ID]; seen {
+			return &CycleError{StepID: step.ID, At: i, FirstAt: firstAt}
+		}
+		visited[step.ID] = i
 
 		// Sync steps: execute, record result, resolve next, loop.
 		output, execErr := e.execSyncStep(taskID, step, wfExec, ctx, t)

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2174,6 +2174,31 @@ func TestExecRunAgent_TracksSpawnedStep(t *testing.T) {
 	}
 }
 
+func TestExecuteSteps_CycleDetection(t *testing.T) {
+	store := newTestStoreWith(t, "test-cycle.yaml")
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{ID: "cycle1", Status: "todo", AgentMode: "headless"})
+
+	err := engine.StartWorkflow("cycle1", "test-cycle")
+	if err == nil {
+		t.Fatal("expected error for cyclic workflow, got nil")
+	}
+
+	var cycleErr *CycleError
+	if !errors.As(err, &cycleErr) {
+		t.Fatalf("expected *CycleError, got %T: %v", err, err)
+	}
+	if cycleErr.StepID == "" {
+		t.Error("CycleError.StepID is empty")
+	}
+	if cycleErr.At <= cycleErr.FirstAt {
+		t.Errorf("CycleError.At (%d) should be > FirstAt (%d)", cycleErr.At, cycleErr.FirstAt)
+	}
+}
+
 func TestParseIssueURL(t *testing.T) {
 	tests := []struct {
 		url      string

--- a/internal/workflow/testdata/test-cycle.yaml
+++ b/internal/workflow/testdata/test-cycle.yaml
@@ -1,0 +1,21 @@
+id: test-cycle
+name: Test Cycle
+description: Workflow with a sync-step cycle for engine tests
+trigger:
+  on: task.created
+steps:
+  - id: step_a
+    name: Step A
+    type: set_status
+    config:
+      status: todo
+    next:
+      - goto: step_b
+
+  - id: step_b
+    name: Step B
+    type: set_status
+    config:
+      status: in-progress
+    next:
+      - goto: step_a


### PR DESCRIPTION
## Motivation

Four testing quality issues from the tech-debt backlog:

1. `buildTestBinaries` called `panic()` on build errors, crashing the test process instead of failing the individual test with a proper message.
2. No `TestMain` meant the shared binary temp dir in `/tmp/synapse-test-bins-*` was never cleaned up between runs.
3. Three `time.Sleep(50ms)` calls after synchronous `HandleAgentComplete` invocations — no async work happens, yet CI on slow machines could flake if timing assumptions drift.
4. A sync-step cycle (A→B→A) would exhaust `maxSyncSteps=100` and return the generic "max steps exceeded" error instead of a diagnostic "cycle detected at step X".

## Implementation information

- `buildTestBinaries`: stores build error in package-level `testBuildErr`; `sync.Once` returns early on failure; caller calls `t.Fatalf()` after the `Once` block. Adds `TestMain` that removes `testBinDir` after all tests complete.
- Removed three `time.Sleep(50ms)` calls after `HandleAgentComplete` — the method is fully synchronous (mutex-protected), so the sleeps provided no guarantee.
- `CycleError` struct added to `engine.go`; `executeSteps` now tracks visited sync step IDs in a `map[string]int` and returns `*CycleError` on revisit before hitting the depth limit.
- `TestExecuteSteps_CycleDetection` drives `test-cycle.yaml` (step_a→step_b→step_a) and asserts `errors.As(err, &cycleErr)`.

> Changelog: test(e2e): fix panics, flaky sleeps; add workflow cycle detection

Closes https://github.com/Automaat/synapse/issues/325