### PR TITLE
refactor(agent): split discovery.go into 3 layers

### DIFF
--- a/internal/agent/discovery.go
+++ b/internal/agent/discovery.go
@@ -35,12 +35,85 @@ type claudeSession struct {
 var nonAlphanumDash = regexp.MustCompile(`[^a-zA-Z0-9-]`)
 
 func (m *Manager) DiscoverAgents() []*Agent {
-	claudeSessions := readClaudeSessions()
-	codexSessions := readCodexSessions()
+	sources := []SessionSource{
+		claudeSessionSource{},
+		codexSessionSource{},
+	}
 	m.refreshTracked()
-	discovered := m.discoverNew(claudeSessions)
-	discovered = append(discovered, m.discoverNewCodex(codexSessions)...)
+	opts := m.buildFilterOpts()
+
+	var discovered []*Agent
+	for _, src := range sources {
+		filtered := filterSessions(src.List(), opts)
+		discovered = append(discovered, m.reconcile(filtered)...)
+	}
 	return discovered
+}
+
+// buildFilterOpts collects already-tracked identifiers for deduplication in filterSessions.
+func (m *Manager) buildFilterOpts() FilterOpts {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	opts := FilterOpts{
+		TrackedPIDs:       make(map[int]bool),
+		TrackedPaths:      make(map[string]bool),
+		TrackedSessionIDs: make(map[string]bool),
+	}
+	for _, a := range m.agents {
+		if a.cmd != nil && a.cmd.Process != nil {
+			opts.TrackedPIDs[a.cmd.Process.Pid] = true
+		}
+		if a.PID != 0 {
+			opts.TrackedPIDs[a.PID] = true
+		}
+		if fp := a.GetSessionFilePath(); fp != "" {
+			opts.TrackedPaths[fp] = true
+		}
+		if sid := a.GetSessionID(); sid != "" {
+			opts.TrackedSessionIDs[sid] = true
+		}
+	}
+	return opts
+}
+
+// reconcile registers filtered sessions as external agents and returns newly added ones.
+func (m *Manager) reconcile(sessions []RawSession) []*Agent {
+	var discovered []*Agent
+	for i := range sessions {
+		s := &sessions[i]
+		a := &Agent{
+			ID:              externalAgentID(s),
+			Mode:            s.Mode,
+			State:           s.State,
+			External:        true,
+			PID:             s.PID,
+			SessionID:       s.SessionID,
+			StartedAt:       s.StartedAt,
+			Name:            s.Name,
+			Project:         projectName(s.CWD),
+			Provider:        s.Provider,
+			sessionCWD:      s.CWD,
+			sessionFilePath: s.FilePath,
+		}
+		m.mu.Lock()
+		if _, exists := m.agents[a.ID]; !exists {
+			m.agents[a.ID] = a
+		}
+		m.mu.Unlock()
+		discovered = append(discovered, a)
+	}
+	return discovered
+}
+
+func externalAgentID(s *RawSession) string {
+	if s.Provider == "codex" {
+		shortID := s.SessionID
+		if len(shortID) > 8 {
+			shortID = shortID[:8]
+		}
+		return fmt.Sprintf("ext-codex-%s", shortID)
+	}
+	return fmt.Sprintf("ext-%d", s.PID)
 }
 
 // refreshTracked updates state of already-tracked external agents.
@@ -104,53 +177,6 @@ func refreshCodexAgent(pid int, filePath string) State {
 		return inferCodexState(filePath)
 	}
 	return StateIdle
-}
-
-// discoverNew registers and returns external agents not yet tracked.
-func (m *Manager) discoverNew(sessions []claudeSession) []*Agent {
-	m.mu.RLock()
-	trackedPIDs := make(map[int]bool)
-	for _, a := range m.agents {
-		if a.cmd != nil && a.cmd.Process != nil {
-			trackedPIDs[a.cmd.Process.Pid] = true
-		}
-		if a.PID != 0 {
-			trackedPIDs[a.PID] = true
-		}
-	}
-	m.mu.RUnlock()
-
-	var discovered []*Agent
-	for _, s := range sessions {
-		if trackedPIDs[s.PID] {
-			continue
-		}
-		if !processAlive(s.PID) {
-			continue
-		}
-
-		a := &Agent{
-			ID:         fmt.Sprintf("ext-%d", s.PID),
-			Mode:       sessionKind(s.Kind),
-			State:      inferState(s.CWD, s.SessionID),
-			External:   true,
-			PID:        s.PID,
-			SessionID:  s.SessionID,
-			StartedAt:  time.UnixMilli(s.StartedAt).UTC(),
-			Name:       s.Name,
-			Project:    projectName(s.CWD),
-			sessionCWD: s.CWD,
-		}
-
-		m.mu.Lock()
-		if _, exists := m.agents[a.ID]; !exists {
-			m.agents[a.ID] = a
-		}
-		m.mu.Unlock()
-
-		discovered = append(discovered, a)
-	}
-	return discovered
 }
 
 const staleThreshold = 10 * time.Second
@@ -547,71 +573,6 @@ func parseLsofCWD(output string) string {
 		}
 	}
 	return ""
-}
-
-func (m *Manager) discoverNewCodex(sessions []codexSession) []*Agent {
-	m.mu.RLock()
-	trackedPaths := make(map[string]bool)
-	trackedSessionIDs := make(map[string]bool)
-	for _, a := range m.agents {
-		if fp := a.GetSessionFilePath(); fp != "" {
-			trackedPaths[fp] = true
-		}
-		if sid := a.GetSessionID(); sid != "" {
-			trackedSessionIDs[sid] = true
-		}
-	}
-	m.mu.RUnlock()
-
-	pidMap := findCodexPIDs()
-
-	var discovered []*Agent
-	for _, s := range sessions {
-		if trackedPaths[s.FilePath] || trackedSessionIDs[s.SessionID] {
-			continue
-		}
-
-		state := inferCodexState(s.FilePath)
-		pid := pidMap[s.CWD]
-
-		// Skip sessions that are dead with no associated process.
-		if state == StateStopped && pid == 0 {
-			continue
-		}
-
-		mode := "headless"
-		if s.Originator == "codex_tui" {
-			mode = "interactive"
-		}
-
-		shortID := s.SessionID
-		if len(shortID) > 8 {
-			shortID = shortID[:8]
-		}
-
-		a := &Agent{
-			ID:              fmt.Sprintf("ext-codex-%s", shortID),
-			Mode:            mode,
-			State:           state,
-			External:        true,
-			PID:             pid,
-			SessionID:       s.SessionID,
-			StartedAt:       s.StartedAt,
-			Project:         projectName(s.CWD),
-			Provider:        "codex",
-			sessionCWD:      s.CWD,
-			sessionFilePath: s.FilePath,
-		}
-
-		m.mu.Lock()
-		if _, exists := m.agents[a.ID]; !exists {
-			m.agents[a.ID] = a
-		}
-		m.mu.Unlock()
-
-		discovered = append(discovered, a)
-	}
-	return discovered
 }
 
 // resolveCodexSessionFile returns the JSONL path for a given Codex session ID.

--- a/internal/agent/discovery_test.go
+++ b/internal/agent/discovery_test.go
@@ -479,18 +479,20 @@ func TestDiscoverNewCodex(t *testing.T) {
 	now := time.Now()
 	filePath := writeCodexSessionFile(t, sessDir, sessionID, now)
 
-	sessions := []codexSession{
+	sessions := []RawSession{
 		{
-			SessionID:  sessionID,
-			CWD:        "/tmp/project",
-			Originator: "codex_exec",
-			StartedAt:  now,
-			FilePath:   filePath,
-			Branch:     "main",
+			Provider:  "codex",
+			SessionID: sessionID,
+			CWD:       "/tmp/project",
+			Mode:      "headless",
+			FilePath:  filePath,
+			StartedAt: now,
+			State:     StateIdle,
 		},
 	}
 
-	discovered := m.discoverNewCodex(sessions)
+	opts := m.buildFilterOpts()
+	discovered := m.reconcile(filterSessions(sessions, opts))
 	if len(discovered) != 1 {
 		t.Fatalf("got %d agents, want 1", len(discovered))
 	}
@@ -514,8 +516,9 @@ func TestDiscoverNewCodex(t *testing.T) {
 		t.Errorf("ID = %q, want ext-codex-* prefix", a.ID)
 	}
 
-	// Second call should not re-discover the same agent.
-	discovered2 := m.discoverNewCodex(sessions)
+	// Second call: session is now tracked; filterSessions should exclude it.
+	opts2 := m.buildFilterOpts()
+	discovered2 := m.reconcile(filterSessions(sessions, opts2))
 	if len(discovered2) != 0 {
 		t.Errorf("re-discovery got %d agents, want 0", len(discovered2))
 	}
@@ -528,11 +531,20 @@ func TestDiscoverNewCodexInteractive(t *testing.T) {
 	sessionID := "01TUISESSIONID000000000"
 	filePath := writeCodexSessionFile(t, dir, sessionID, time.Now())
 
-	sessions := []codexSession{
-		{SessionID: sessionID, CWD: "/home/user/proj", Originator: "codex_tui", FilePath: filePath, StartedAt: time.Now()},
+	sessions := []RawSession{
+		{
+			Provider:  "codex",
+			SessionID: sessionID,
+			CWD:       "/home/user/proj",
+			Mode:      "interactive",
+			FilePath:  filePath,
+			StartedAt: time.Now(),
+			State:     StateIdle,
+		},
 	}
 
-	discovered := m.discoverNewCodex(sessions)
+	opts := m.buildFilterOpts()
+	discovered := m.reconcile(filterSessions(sessions, opts))
 	if len(discovered) != 1 {
 		t.Fatalf("got %d agents, want 1", len(discovered))
 	}

--- a/internal/agent/session_filter.go
+++ b/internal/agent/session_filter.go
@@ -1,0 +1,32 @@
+package agent
+
+// FilterOpts holds the pre-computed set of already-tracked agent identifiers.
+// All maps are keyed by the relevant identifier; zero value is safe (no sessions filtered).
+type FilterOpts struct {
+	TrackedPIDs       map[int]bool
+	TrackedPaths      map[string]bool
+	TrackedSessionIDs map[string]bool
+}
+
+// filterSessions is a pure function: no I/O, no side effects.
+// It returns sessions that are not already tracked and are not definitively terminated.
+func filterSessions(sessions []RawSession, opts FilterOpts) []RawSession {
+	var result []RawSession
+	for i := range sessions {
+		s := &sessions[i]
+		if s.Terminated {
+			continue
+		}
+		if s.PID != 0 && opts.TrackedPIDs[s.PID] {
+			continue
+		}
+		if s.FilePath != "" && opts.TrackedPaths[s.FilePath] {
+			continue
+		}
+		if s.SessionID != "" && opts.TrackedSessionIDs[s.SessionID] {
+			continue
+		}
+		result = append(result, *s)
+	}
+	return result
+}

--- a/internal/agent/session_filter_test.go
+++ b/internal/agent/session_filter_test.go
@@ -1,0 +1,128 @@
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFilterSessions(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		sessions []RawSession
+		opts     FilterOpts
+		wantIDs  []string // expected SessionIDs in result; nil means empty
+	}{
+		{
+			name: "pass-through: untracked live session",
+			sessions: []RawSession{
+				{Provider: "claude", SessionID: "sess-1", PID: 1001, Mode: "interactive", StartedAt: now},
+			},
+			opts:    FilterOpts{},
+			wantIDs: []string{"sess-1"},
+		},
+		{
+			name: "stale session: Terminated=true is excluded",
+			sessions: []RawSession{
+				{Provider: "claude", SessionID: "dead-1", PID: 2001, Terminated: true},
+			},
+			opts:    FilterOpts{},
+			wantIDs: nil,
+		},
+		{
+			name: "zombie process: PID already tracked",
+			sessions: []RawSession{
+				{Provider: "claude", SessionID: "zombie-1", PID: 3001},
+			},
+			opts:    FilterOpts{TrackedPIDs: map[int]bool{3001: true}},
+			wantIDs: nil,
+		},
+		{
+			name: "codex: tracked by file path",
+			sessions: []RawSession{
+				{Provider: "codex", SessionID: "cx-1", FilePath: "/tmp/session.jsonl"},
+			},
+			opts:    FilterOpts{TrackedPaths: map[string]bool{"/tmp/session.jsonl": true}},
+			wantIDs: nil,
+		},
+		{
+			name: "codex: tracked by session ID",
+			sessions: []RawSession{
+				{Provider: "codex", SessionID: "cx-2", FilePath: "/tmp/other.jsonl"},
+			},
+			opts:    FilterOpts{TrackedSessionIDs: map[string]bool{"cx-2": true}},
+			wantIDs: nil,
+		},
+		{
+			name: "multiple providers: mixed tracking",
+			sessions: []RawSession{
+				{Provider: "claude", SessionID: "cl-alive", PID: 4001},
+				{Provider: "claude", SessionID: "cl-tracked", PID: 4002},
+				{Provider: "codex", SessionID: "cx-alive", FilePath: "/a.jsonl"},
+				{Provider: "codex", SessionID: "cx-tracked", FilePath: "/b.jsonl"},
+			},
+			opts: FilterOpts{
+				TrackedPIDs:       map[int]bool{4002: true},
+				TrackedPaths:      map[string]bool{},
+				TrackedSessionIDs: map[string]bool{"cx-tracked": true},
+			},
+			wantIDs: []string{"cl-alive", "cx-alive"},
+		},
+		{
+			name: "mode mismatches: filter does not exclude based on mode",
+			sessions: []RawSession{
+				{Provider: "claude", SessionID: "m-headless", PID: 5001, Mode: "headless"},
+				{Provider: "claude", SessionID: "m-interactive", PID: 5002, Mode: "interactive"},
+				{Provider: "codex", SessionID: "m-unknown", PID: 5003, Mode: ""},
+			},
+			opts:    FilterOpts{},
+			wantIDs: []string{"m-headless", "m-interactive", "m-unknown"},
+		},
+		{
+			name: "codex: dead with no process is excluded",
+			sessions: []RawSession{
+				{Provider: "codex", SessionID: "cx-dead", FilePath: "/dead.jsonl", State: StateStopped, PID: 0, Terminated: true},
+			},
+			opts:    FilterOpts{},
+			wantIDs: nil,
+		},
+		{
+			name: "codex: stopped state but has process remains",
+			sessions: []RawSession{
+				{Provider: "codex", SessionID: "cx-live", FilePath: "/live.jsonl", State: StateStopped, PID: 6001, Terminated: false},
+			},
+			opts:    FilterOpts{},
+			wantIDs: []string{"cx-live"},
+		},
+		{
+			name: "PID zero is not matched against tracked PIDs",
+			sessions: []RawSession{
+				{Provider: "codex", SessionID: "cx-nopid", FilePath: "/nopid.jsonl", PID: 0},
+			},
+			opts:    FilterOpts{TrackedPIDs: map[int]bool{0: true}},
+			wantIDs: []string{"cx-nopid"},
+		},
+		{
+			name:     "empty session list returns nil",
+			sessions: nil,
+			opts:     FilterOpts{},
+			wantIDs:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := filterSessions(tt.sessions, tt.opts)
+			if len(got) != len(tt.wantIDs) {
+				t.Fatalf("got %d sessions, want %d", len(got), len(tt.wantIDs))
+			}
+			for i, s := range got {
+				if s.SessionID != tt.wantIDs[i] {
+					t.Errorf("[%d] SessionID = %q, want %q", i, s.SessionID, tt.wantIDs[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/agent/session_source.go
+++ b/internal/agent/session_source.go
@@ -1,0 +1,82 @@
+package agent
+
+import "time"
+
+// RawSession is the provider-agnostic discovery record produced by a SessionSource.
+// State and Terminated are pre-computed so [filterSessions] requires no I/O.
+type RawSession struct {
+	Provider   string
+	SessionID  string
+	PID        int
+	CWD        string
+	FilePath   string // codex: JSONL path; claude: empty (state read via CWD+SessionID)
+	Mode       string // "headless" | "interactive"
+	Name       string
+	StartedAt  time.Time
+	State      State
+	Terminated bool // definitively dead/stopped; excluded by filterSessions
+}
+
+// SessionSource reads raw sessions from the filesystem.
+type SessionSource interface {
+	List() []RawSession
+}
+
+// claudeSessionSource reads from ~/.claude/sessions/.
+type claudeSessionSource struct{}
+
+func (claudeSessionSource) List() []RawSession {
+	sessions := readClaudeSessions()
+	result := make([]RawSession, 0, len(sessions))
+	for _, s := range sessions {
+		alive := processAlive(s.PID)
+		var state State
+		if alive {
+			state = inferState(s.CWD, s.SessionID)
+		}
+		result = append(result, RawSession{
+			Provider:   "claude",
+			SessionID:  s.SessionID,
+			PID:        s.PID,
+			CWD:        s.CWD,
+			Mode:       sessionKind(s.Kind),
+			Name:       s.Name,
+			StartedAt:  time.UnixMilli(s.StartedAt).UTC(),
+			State:      state,
+			Terminated: !alive,
+		})
+	}
+	return result
+}
+
+// codexSessionSource reads from ~/.codex/sessions/.
+type codexSessionSource struct{}
+
+func (codexSessionSource) List() []RawSession {
+	sessions := readCodexSessions()
+	pidMap := findCodexPIDs()
+
+	result := make([]RawSession, 0, len(sessions))
+	for _, s := range sessions {
+		pid := pidMap[s.CWD]
+		state := inferCodexState(s.FilePath)
+
+		mode := "headless"
+		if s.Originator == "codex_tui" {
+			mode = "interactive"
+		}
+
+		result = append(result, RawSession{
+			Provider:   "codex",
+			SessionID:  s.SessionID,
+			PID:        pid,
+			CWD:        s.CWD,
+			FilePath:   s.FilePath,
+			Mode:       mode,
+			StartedAt:  s.StartedAt,
+			State:      state,
+			Terminated: state == StateStopped && pid == 0,
+		})
+	}
+	return result
+}


### PR DESCRIPTION
## Motivation

discovery.go was a 644-line god file mixing filesystem I/O, filter logic, and agent registration. The duplicate filter logic in discoverNew/discoverNewCodex made it hard to test without real session directory trees. Discovery is the core of the agent list — bugs here surface as ghost agents or missing agents.

## Implementation information

Extracted three layers:

Source layer (session_source.go): SessionSource interface with claudeSessionSource and codexSessionSource implementations. Each returns []RawSession — a provider-agnostic snapshot with pre-computed State and Terminated fields so downstream code needs no I/O.

Filter layer (session_filter.go): Pure function filterSessions(sessions []RawSession, opts FilterOpts) []RawSession. Zero I/O, fully unit-testable. FilterOpts carries pre-built tracked-PID/path/sessionID maps from buildFilterOpts.

Sync layer (reconcile method on Manager): Diffs filtered sessions against the agent map and adds new external agents. Replaces the duplicated discoverNew + discoverNewCodex.

DiscoverAgents is now a 10-line orchestration loop: for src in sources: filter(src.List(), opts) → reconcile(...).

Added session_filter_test.go with 11 table-driven cases covering: stale sessions, zombie processes, multiple providers, mode mismatches, codex dead-with-no-process, PID-zero edge case.

> Changelog: refactor(agent): split discovery.go into 3 layers

Closes https://github.com/Automaat/synapse/issues/318