### PR TITLE
ci(security): make security job a hard gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,6 @@ jobs:
   security:
     name: Security Audit
     runs-on: macos-15
-    continue-on-error: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## Motivation

`security` job had `continue-on-error: true`, meaning govulncheck and `npm audit` ran but never failed the build. Any vulnerable dependency would merge silently. The job provided zero gate value.

## Implementation information

Removed `continue-on-error: true` (line 104). Ran govulncheck and npm audit locally — both clean, so no suppressions needed.

> Changelog: ci(security): make security job a hard gate

Closes https://github.com/Automaat/synapse/issues/310