### PR TITLE
fix(workflow): propagate engine ctx to shell steps

### DIFF
--- a/app.go
+++ b/app.go
@@ -351,6 +351,7 @@ func (a *App) initWorkflowEngine() {
 		a.logger,
 	)
 	a.workflowEngine.SetPRLinker(prLinkerAdapter{})
+	a.workflowEngine.SetContext(a.ctx)
 }
 
 func (a *App) initApprovalServer(emit func(string, any)) {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -97,6 +97,7 @@ type Engine struct {
 	agents     AgentLauncher
 	prLinker   PRLinker
 	logger     *slog.Logger
+	ctx        context.Context
 	mu         sync.Mutex
 	inflight   map[string]struct{} // taskID → step in flight (prevent double-advance)
 	agentSteps map[string]string   // agentID → stepID it was spawned for
@@ -109,10 +110,16 @@ func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *s
 		tasks:      tasks,
 		agents:     agents,
 		logger:     logger,
+		ctx:        context.Background(),
 		inflight:   make(map[string]struct{}),
 		agentSteps: make(map[string]string),
 	}
 }
+
+// SetContext binds a parent context to the engine. Shell steps use
+// context.WithTimeout(parent, shellTimeout) so they are cancelled when
+// the parent context is cancelled (e.g. on app shutdown).
+func (e *Engine) SetContext(ctx context.Context) { e.ctx = ctx }
 
 // Defs returns the workflow definition store.
 func (e *Engine) Defs() *Store { return e.store }
@@ -856,7 +863,7 @@ func (e *Engine) execShell(step *Step, ctx TemplateContext) (StepOutput, error) 
 		return StepOutput{}, fmt.Errorf("render command: %w", err)
 	}
 
-	shellCtx, cancel := context.WithTimeout(context.Background(), shellTimeout)
+	shellCtx, cancel := context.WithTimeout(e.ctx, shellTimeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(shellCtx, "bash", "-c", command)


### PR DESCRIPTION
## Motivation

`execShell` created its timeout via `context.WithTimeout(context.Background(), shellTimeout)`, completely detaching shell steps from the engine's lifecycle. When a workflow was cancelled (app shutdown, user stops workflow), the shell process kept running until `shellTimeout` elapsed or exited naturally.

## Implementation information

Added a `ctx context.Context` field to `Engine`, defaulting to `context.Background()` in `NewEngine` so all existing tests need no changes. Exposed `SetContext(ctx)` and called it from `initWorkflowEngine()` in `app.go` using the already-cancelled-on-shutdown `a.ctx`. `execShell` now derives its shell timeout from `e.ctx` — `exec.CommandContext` propagates SIGTERM/SIGKILL when the parent context is cancelled.

> Changelog: fix(workflow): propagate engine ctx to shell steps

Closes https://github.com/Automaat/synapse/issues/312