### PR TITLE
docs(agent): codex setup and prompts

### DIFF
--- a/docs/codex-setup.md
+++ b/docs/codex-setup.md
@@ -1,0 +1,144 @@
+# Codex Agent Setup
+
+Synapse supports [OpenAI Codex CLI](https://github.com/openai/codex) as an alternative agent provider alongside Claude Code. This document covers local setup, authentication, Synapse configuration, and known behavioral differences.
+
+## Prerequisites
+
+### Install Codex CLI
+
+```bash
+npm install -g @openai/codex
+```
+
+Verify the binary is on `PATH`:
+
+```bash
+codex --version
+```
+
+### Authenticate
+
+Codex requires an OpenAI API key. Set it in your shell environment before starting Synapse:
+
+```bash
+export OPENAI_API_KEY=sk-...
+```
+
+Add the export to your shell profile (`~/.zshrc`, `~/.bashrc`) so it persists across sessions. Synapse inherits the parent process environment — the key must be set before the app launches.
+
+If you prefer interactive login:
+
+```bash
+codex auth
+```
+
+> **macOS GUI launch note:** Apps launched from Finder or Spotlight do not inherit shell profile exports. Set `OPENAI_API_KEY` via `launchctl setenv` or a `launchd` plist to ensure Synapse picks it up:
+>
+> ```bash
+> launchctl setenv OPENAI_API_KEY "sk-..."
+> # then relaunch Synapse
+> ```
+
+## Enable Codex in Synapse
+
+Edit `~/.synapse/config.yaml`:
+
+```yaml
+agent:
+  provider: codex
+  model: gpt-5.4   # optional; gpt-5.4 is the default
+```
+
+To revert to Claude:
+
+```yaml
+agent:
+  provider: claude
+```
+
+### Model Aliases
+
+Synapse maps generic aliases to provider-specific model IDs at runtime:
+
+| Synapse alias | Codex model |
+|---------------|-------------|
+| `sonnet` (default) | `gpt-5.4` |
+| `opus` | `gpt-5.4` |
+| `haiku` | `gpt-5.4-mini` |
+| any other string | passed through verbatim |
+
+## How Codex Runs in Synapse
+
+### Headless mode
+
+Synapse spawns a `codex exec` subprocess per task:
+
+```bash
+# Default (no permission restrictions)
+codex exec --json --skip-git-repo-check --full-auto --model gpt-5.4 -C <worktree> "<prompt>"
+
+# With RequirePermissions=true
+codex exec --json --skip-git-repo-check --sandbox workspace-write --model gpt-5.4 -C <worktree> "<prompt>"
+```
+
+Stdout is read as NDJSON. Synapse parses Codex event types (`agent_message`, `command_execution`, `task_complete`, etc.) and maps them to its unified `StreamEvent` format for display.
+
+### Interactive (conversational) mode
+
+Synapse spawns a new `codex exec --json` process for each user turn. Unlike Claude conversational mode (which keeps a single process alive on stdin), each Codex turn is a discrete subprocess invocation. This means there is **no persistent stdin pipe** — the UI sends messages by launching a new process with the follow-up prompt.
+
+## Differences vs Claude Code
+
+| Feature | Claude Code | Codex |
+|---------|-------------|-------|
+| Session resume | `--resume <session-id>` | Not supported — each run is independent |
+| Tool allowlist | `--allowedTools tool1,tool2` | Not supported; use `--sandbox workspace-write` for file-write-only mode |
+| Permissions bypass | `--dangerously-skip-permissions` | `--full-auto` |
+| Session files | `~/.claude/projects/<key>/<id>.jsonl` | `~/.codex/sessions/rollout-<id>.jsonl` |
+| External discovery | Claude process detection via session files | Codex process detection via `pgrep -f codex` + session JSONL |
+| Cost reporting | Reported in `result` event (`cost_usd`) | Not reported in stream; billed on OpenAI dashboard |
+| Conversational model | Single long-lived process with stdin pipe | New subprocess per turn |
+
+## Commit Requirements
+
+Codex agents must commit their work before finishing — the same requirement as Claude agents. Git commit flags (`-s` for sign-off, `-S` for GPG signing) work normally inside Synapse-managed worktrees. See the orchestrator's "Agent Commit Requirement" section for the required commit block to include in every headless prompt.
+
+## Skill and Prompt Compatibility
+
+Existing Synapse skills (`/synapse-tasks`, `/synapse-triage`, `/synapse-plan`, etc.) are provider-agnostic — they use `synapse-cli` and shell commands, not the Claude SDK directly. They work without modification under either provider.
+
+The orchestrator prompt (`orchestrator/CLAUDE.md`) governs the Synapse orchestrator session, which always runs as a Claude Code agent. Codex is used for implementation agents dispatched by the orchestrator, not for the orchestrator itself.
+
+## Troubleshooting
+
+**`codex: command not found`**
+
+```bash
+npm install -g @openai/codex
+# Ensure npm global bin is on PATH:
+export PATH="$(npm prefix -g)/bin:$PATH"
+```
+
+**Authentication errors at runtime**
+
+```bash
+echo $OPENAI_API_KEY   # must be non-empty
+codex auth             # re-authenticate interactively
+```
+
+**Agent starts but produces no events**
+
+Confirm `OPENAI_API_KEY` is set in Synapse's process environment (see macOS GUI note above). Also verify the `codex` binary path is in the `PATH` that Synapse sees:
+
+```bash
+# Check from Synapse's inherited PATH
+which codex
+```
+
+**External Codex sessions not appearing**
+
+Synapse discovers live Codex sessions via `pgrep -f codex` and reads JSONL from `~/.codex/sessions/`. Sessions appear as `ext-codex-*` agents in the UI. If sessions are absent, confirm:
+
+1. The Codex process is running (`pgrep -f codex`)
+2. Session files exist at `~/.codex/sessions/rollout-<id>.jsonl`
+3. The process has had time to write at least one event to the JSONL file

--- a/orchestrator/CLAUDE.md
+++ b/orchestrator/CLAUDE.md
@@ -131,6 +131,33 @@ Planning uses dedicated board columns (statuses), not a sub-state:
 | `plan-review` | **Do NOT dispatch** — wait for human to approve/reject |
 | `todo` | Dispatch implementation agent (plan in sidecar if was planned) |
 
+### Provider Selection
+
+Synapse supports two agent providers: `claude` (default) and `codex`. The active provider is set globally in `~/.synapse/config.yaml` under `agent.provider`. You cannot override it per-task — all dispatched agents use the configured provider.
+
+**When to prefer Codex:**
+
+| Signal | Use Codex |
+|--------|-----------|
+| Task is a self-contained script or shell automation | Yes |
+| Task requires OpenAI-specific models or tooling | Yes |
+| Task needs session resume across runs | No — use Claude (`--resume` not supported in Codex) |
+| Task needs fine-grained tool allowlist | No — Codex only supports `--full-auto` or `--sandbox workspace-write` |
+
+**Codex limitations to keep in mind:**
+
+- No session resume — every headless run starts fresh; multi-turn recovery requires re-stating context in the prompt
+- No `--allowedTools` — use `RequirePermissions=true` to restrict to `workspace-write` sandbox, or accept `--full-auto`
+- Cost not reported in stream — usage visible on OpenAI dashboard, not in Synapse UI
+- Interactive mode spawns a new process per turn (no persistent stdin)
+
+If the provider is `codex`, Synapse calls:
+```bash
+codex exec --json --skip-git-repo-check --full-auto [--model <model>] -C <worktree> "<prompt>"
+```
+
+See `docs/codex-setup.md` for full setup and auth details.
+
 ### Agent Spawn
 
 Headless tasks get a structured prompt:
@@ -245,7 +272,7 @@ Run audit analysis during the monitor phase of the core loop. Suggested cadence:
 
 ## Agent Commit Requirement
 
-Every headless implementation agent **must commit its work before finishing**. This is critical — uncommitted changes are destroyed when the worktree is reused for a subsequent agent run.
+Every headless implementation agent **must commit its work before finishing** — this applies to both `claude` and `codex` providers. Uncommitted changes are destroyed when the worktree is reused for a subsequent agent run.
 
 ### Required final steps in every headless agent prompt
 


### PR DESCRIPTION
## Motivation

Codex support is implemented at the plumbing level but undocumented — no guidance on local setup, auth, or how the orchestrator should reason about provider selection. Closes part of #256.

## Implementation information

- `docs/codex-setup.md`: covers Codex CLI install, `OPENAI_API_KEY` auth (including macOS GUI launch gotcha), Synapse config (`agent.provider: codex`), model alias table, headless/interactive invocation details, diff vs Claude Code, skill/prompt compatibility note, and troubleshooting steps.
- `orchestrator/CLAUDE.md`: adds Provider Selection subsection under Dispatch Rules — when to prefer Codex, known limitations (no resume, no allowedTools, no cost reporting, new-process-per-turn interactive), and the actual CLI invocation. Updates commit requirement note to explicitly cover both providers.

No Codex-specific skill variants needed — existing skills use `synapse-cli` and shell commands, which are provider-agnostic. The orchestrator itself always runs as Claude Code; Codex is used only for dispatched implementation agents.

> Changelog: docs(agent): codex setup and prompts

Closes https://github.com/Automaat/synapse/issues/262