### PR TITLE
feat(security): audit agent permission bypass

### DIFF
--- a/app.go
+++ b/app.go
@@ -328,11 +328,11 @@ func (a *App) onAgentComplete(ag *agent.Agent) {
 
 	// Advance workflow.
 	if a.workflowEngine != nil {
-		agentState := "stopped"
-		if exitErr != nil {
-			agentState = "failed"
-		}
-		a.workflowEngine.HandleAgentComplete(ag.TaskID, ag.ID, resultContent, agentState)
+		a.workflowEngine.HandleAgentComplete(ag.TaskID, workflow.AgentCompletion{
+			AgentID: ag.ID,
+			Result:  resultContent,
+			Success: exitErr == nil,
+		})
 	}
 
 	// Worktree cleanup for done tasks (after engine advances, so status is final).
@@ -627,7 +627,10 @@ func (a *App) recoverStaleInteractive(t *task.Task) {
 	}
 	a.logger.Info("recover-stale.advance",
 		"task_id", t.ID, "agent_id", lr.AgentID, "step", t.Workflow.CurrentStep)
-	a.workflowEngine.HandleAgentComplete(t.ID, lr.AgentID, "", "stopped")
+	a.workflowEngine.HandleAgentComplete(t.ID, workflow.AgentCompletion{
+		AgentID: lr.AgentID,
+		Success: true,
+	})
 }
 
 func lastAgentRun(t *task.Task) *task.AgentRun {

--- a/app_agents.go
+++ b/app_agents.go
@@ -19,15 +19,25 @@ import (
 // resolveExecution derives the effective mode, directory, permission mode, and
 // whether project worktree setup should be skipped based on the task's type.
 // hintMode is used when the task type does not force a specific mode.
-func resolveExecution(t task.Task, hintMode, researchMachineDir string) (mode, dir string, requirePerm, skipWorktree bool) {
+// Permission priority: task-level override > TaskType hardcoded > config default > true.
+func resolveExecution(t task.Task, hintMode, researchMachineDir string, cfg *config.Config) (mode, dir string, requirePerm, skipWorktree bool) {
 	switch t.TaskType {
 	case task.TaskTypeDebug:
 		return "interactive", "", true, false
 	case task.TaskTypeResearch:
-		return "headless", researchMachineDir, false, true
+		return "headless", researchMachineDir, resolvePermission(t, cfg), true
 	default:
-		return hintMode, "", false, false
+		return hintMode, "", resolvePermission(t, cfg), false
 	}
+}
+
+// resolvePermission returns the effective require_permissions value for a task.
+// Priority: task field > config default > true (safe default).
+func resolvePermission(t task.Task, cfg *config.Config) bool {
+	if t.RequirePermissions != nil {
+		return *t.RequirePermissions
+	}
+	return cfg.DefaultRequirePermissions()
 }
 
 // AgentOrchestrator manages agent lifecycle: worktree setup, project
@@ -69,7 +79,7 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, oneShot bool
 	if o.cfg != nil {
 		researchDir = o.cfg.Agent.ResearchMachineDir
 	}
-	effMode, dir, requirePerm, skipWT := resolveExecution(t, mode, researchDir)
+	effMode, dir, requirePerm, skipWT := resolveExecution(t, mode, researchDir, o.cfg)
 	if !skipWT {
 		t = o.autoAssignProject(t)
 		if t.ProjectID == "" {
@@ -109,7 +119,11 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, oneShot bool
 	if err != nil {
 		return nil, err
 	}
-	o.logAudit(audit.EventAgentStarted, taskID, ag.ID, map[string]any{"mode": effMode, "title": t.Title, "task_type": string(t.TaskType), "provider": ag.Provider})
+	skipPerm := !requirePerm && len(t.AllowedTools) == 0
+	o.logAudit(audit.EventAgentStarted, taskID, ag.ID, map[string]any{
+		"mode": effMode, "title": t.Title, "task_type": string(t.TaskType), "provider": ag.Provider,
+		"allowed_tools": t.AllowedTools, "require_permissions": requirePerm, "skip_permissions": skipPerm,
+	})
 	if err := o.tasks.AddRun(taskID, task.AgentRun{
 		AgentID:   ag.ID,
 		Mode:      effMode,
@@ -150,7 +164,7 @@ func (o *AgentOrchestrator) StartPRFixAgent(taskID string) error {
 	if o.cfg != nil {
 		researchDir = o.cfg.Agent.ResearchMachineDir
 	}
-	effMode, dir, requirePerm, skipWT := resolveExecution(t, t.AgentMode, researchDir)
+	effMode, dir, requirePerm, skipWT := resolveExecution(t, t.AgentMode, researchDir, o.cfg)
 	if !skipWT {
 		t = o.autoAssignProject(t)
 		if t.ProjectID == "" {
@@ -181,7 +195,11 @@ func (o *AgentOrchestrator) StartPRFixAgent(taskID string) error {
 		return err
 	}
 
-	o.logAudit(audit.EventAgentStarted, taskID, ag.ID, map[string]any{"mode": effMode, "title": t.Title, "role": "pr-fix", "task_type": string(t.TaskType), "provider": ag.Provider})
+	skipPerm := !requirePerm && len(t.AllowedTools) == 0
+	o.logAudit(audit.EventAgentStarted, taskID, ag.ID, map[string]any{
+		"mode": effMode, "title": t.Title, "role": "pr-fix", "task_type": string(t.TaskType), "provider": ag.Provider,
+		"allowed_tools": t.AllowedTools, "require_permissions": requirePerm, "skip_permissions": skipPerm,
+	})
 	if err := o.tasks.AddRun(taskID, task.AgentRun{
 		AgentID: ag.ID, Role: string(agent.RolePRFix), Mode: effMode,
 		State: string(agent.StateRunning), StartedAt: ag.StartedAt,

--- a/app_test.go
+++ b/app_test.go
@@ -450,8 +450,6 @@ func TestStartup(t *testing.T) {
 	}
 }
 
-func boolPtr(b bool) *bool { return &b }
-
 func TestResolvePermission(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -460,10 +458,10 @@ func TestResolvePermission(t *testing.T) {
 		cfgPerm  *bool
 		want     bool
 	}{
-		{"task false overrides config true", boolPtr(false), boolPtr(true), false},
-		{"task true overrides config false", boolPtr(true), boolPtr(false), true},
-		{"task nil falls back to config false", nil, boolPtr(false), false},
-		{"task nil falls back to config true", nil, boolPtr(true), true},
+		{"task false overrides config true", task.Ptr(false), task.Ptr(true), false},
+		{"task true overrides config false", task.Ptr(true), task.Ptr(false), true},
+		{"task nil falls back to config false", nil, task.Ptr(false), false},
+		{"task nil falls back to config true", nil, task.Ptr(true), true},
 		{"task nil config nil defaults true", nil, nil, true},
 	}
 	for _, tt := range tests {
@@ -483,7 +481,7 @@ func TestResolvePermission(t *testing.T) {
 
 func TestResolveExecutionDebugAlwaysRequiresPermissions(t *testing.T) {
 	t.Parallel()
-	tk := task.Task{TaskType: task.TaskTypeDebug, RequirePermissions: boolPtr(false)}
+	tk := task.Task{TaskType: task.TaskTypeDebug, RequirePermissions: task.Ptr(false)}
 	// TaskTypeDebug hardcodes requirePerm=true regardless of task field.
 	_, _, requirePerm, _ := resolveExecution(tk, "headless", "", nil)
 	if !requirePerm {

--- a/app_test.go
+++ b/app_test.go
@@ -449,3 +449,44 @@ func TestStartup(t *testing.T) {
 		t.Error("tasksDir should not be empty")
 	}
 }
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestResolvePermission(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		taskPerm *bool
+		cfgPerm  *bool
+		want     bool
+	}{
+		{"task false overrides config true", boolPtr(false), boolPtr(true), false},
+		{"task true overrides config false", boolPtr(true), boolPtr(false), true},
+		{"task nil falls back to config false", nil, boolPtr(false), false},
+		{"task nil falls back to config true", nil, boolPtr(true), true},
+		{"task nil config nil defaults true", nil, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tk := task.Task{RequirePermissions: tt.taskPerm}
+			var cfg *config.Config
+			if tt.cfgPerm != nil {
+				cfg = &config.Config{Agent: config.AgentDefaults{RequirePermissions: tt.cfgPerm}}
+			}
+			if got := resolvePermission(tk, cfg); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveExecutionDebugAlwaysRequiresPermissions(t *testing.T) {
+	t.Parallel()
+	tk := task.Task{TaskType: task.TaskTypeDebug, RequirePermissions: boolPtr(false)}
+	// TaskTypeDebug hardcodes requirePerm=true regardless of task field.
+	_, _, requirePerm, _ := resolveExecution(tk, "headless", "", nil)
+	if !requirePerm {
+		t.Error("debug task should always require permissions")
+	}
+}

--- a/e2e_workflow_test.go
+++ b/e2e_workflow_test.go
@@ -224,11 +224,11 @@ func setupE2EProvider(t *testing.T, provider, scenario string) *e2eEnv {
 				result = ev.Content
 			}
 		}
-		agentState := "stopped"
-		if ag.GetExitErr() != nil {
-			agentState = "failed"
-		}
-		engine.HandleAgentComplete(ag.TaskID, ag.ID, result, agentState)
+		engine.HandleAgentComplete(ag.TaskID, workflow.AgentCompletion{
+			AgentID: ag.ID,
+			Result:  result,
+			Success: ag.GetExitErr() == nil,
+		})
 	})
 
 	// Pre-create a working directory so run_agent steps can satisfy the
@@ -1008,7 +1008,7 @@ func TestE2E_RecoverStaleInteractive(t *testing.T) {
 	if _, err := env.tasks.UpdateMap(created.ID, map[string]any{"workflow": wfExec}); err != nil {
 		t.Fatal(err)
 	}
-	env.engine.HandleAgentComplete(created.ID, "stale-agent", "", "stopped")
+	env.engine.HandleAgentComplete(created.ID, workflow.AgentCompletion{AgentID: "stale-agent", Success: true})
 
 	// Evaluate fires (fake-claude "evaluate" scenario sets status=in-review),
 	// then the workflow reaches ExecCompleted.
@@ -1619,7 +1619,7 @@ func TestE2E_StaleAgentCompletionAfterWorkflowTerminal(t *testing.T) {
 	// after the workflow ended) calling back into HandleAgentComplete. Prior
 	// to the fix this fired an ERROR log AND wrote a bogus StepHistory entry
 	// with StepID="". After the fix it is a silent no-op.
-	env.engine.HandleAgentComplete(created.ID, "stray-agent-xyz", "late result", "stopped")
+	env.engine.HandleAgentComplete(created.ID, workflow.AgentCompletion{AgentID: "stray-agent-xyz", Result: "late result", Success: true})
 
 	// HandleAgentComplete is synchronous; no async side effects to wait for.
 	tkAfter, _ := env.tasks.Get(created.ID)
@@ -1692,7 +1692,7 @@ func TestE2E_StaleAgentCompletionAtWaitHuman(t *testing.T) {
 	// Stray completion lands on the wait_human step. In the pre-fix engine
 	// this would drive resolveNext → ExecFailed; post-fix it's a silent
 	// no-op because output.AgentID != "" and human_action is unset.
-	env.engine.HandleAgentComplete(created.ID, "stray-duplicate-plan-agent", "late plan result", "stopped")
+	env.engine.HandleAgentComplete(created.ID, workflow.AgentCompletion{AgentID: "stray-duplicate-plan-agent", Result: "late plan result", Success: true})
 
 	// HandleAgentComplete is synchronous; no async side effects to wait for.
 	tkAfter, _ := env.tasks.Get(created.ID)

--- a/frontend/e2e/tasks.spec.ts
+++ b/frontend/e2e/tasks.spec.ts
@@ -29,7 +29,7 @@ async function waitForTasks(page: Page) {
 
 // Select a status value on the task detail status dropdown
 async function selectStatus(page: Page, value: string) {
-  await page.getByRole('main').locator('select').selectOption(value)
+  await page.getByTestId('task-status-select').selectOption(value)
 }
 
 test.afterAll(async () => {

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -148,6 +148,15 @@
     }
   }
 
+  async function updateTaskType(value: string) {
+    if (!t || (t.taskType ?? 'normal') === value) return
+    try {
+      t = await taskStore.update(taskId, { task_type: value })
+    } catch (e) {
+      error = String(e)
+    }
+  }
+
   async function startAgent() {
     if (!t || !prompt.trim()) return
     starting = true
@@ -335,6 +344,7 @@
         <div class="flex items-center gap-2">
           <select
             bind:this={statusSelectRef}
+            data-testid="task-status-select"
             class="rounded border border-surface-300 bg-surface-100 px-2 py-0.5 text-xs font-medium dark:border-surface-600 dark:bg-surface-700"
             value={t.status}
             onchange={(e) => updateStatus((e.target as HTMLSelectElement).value)}
@@ -342,6 +352,17 @@
             {#each statusOptions as s}
               <option value={s.value}>{s.label}</option>
             {/each}
+          </select>
+          <select
+            data-testid="task-type-select"
+            class="rounded border border-surface-300 bg-surface-100 px-2 py-0.5 text-xs font-medium dark:border-surface-600 dark:bg-surface-700"
+            value={t.taskType || 'normal'}
+            onchange={(e) => updateTaskType((e.target as HTMLSelectElement).value)}
+            title="Task type — controls execution mode and worktree behavior"
+          >
+            <option value="normal">normal</option>
+            <option value="debug">debug</option>
+            <option value="research">research</option>
           </select>
           {#if triaging}
             <span class="inline-flex items-center gap-1 rounded-full bg-primary-200 px-2 py-0.5 text-xs font-medium text-primary-800 dark:bg-primary-700 dark:text-primary-200">

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -916,8 +916,8 @@ export namespace task {
 	    statusReason: string;
 	    reviewed: boolean;
 	    runRole: string;
-	    requirePermissions?: boolean;
 	    todoistId: string;
+	    requirePermissions?: boolean;
 	    agentRuns: AgentRun[];
 	    workflow?: workflow.Execution;
 	    // Go type: time
@@ -928,11 +928,11 @@ export namespace task {
 	    plan?: string;
 	    planCritique?: string;
 	    filePath: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new Task(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
@@ -950,8 +950,8 @@ export namespace task {
 	        this.statusReason = source["statusReason"];
 	        this.reviewed = source["reviewed"];
 	        this.runRole = source["runRole"];
-	        this.requirePermissions = source["requirePermissions"];
 	        this.todoistId = source["todoistId"];
+	        this.requirePermissions = source["requirePermissions"];
 	        this.agentRuns = this.convertValues(source["agentRuns"], AgentRun);
 	        this.workflow = this.convertValues(source["workflow"], workflow.Execution);
 	        this.createdAt = this.convertValues(source["createdAt"], null);

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -928,11 +928,11 @@ export namespace task {
 	    plan?: string;
 	    planCritique?: string;
 	    filePath: string;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new Task(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -203,6 +203,7 @@ export namespace config {
 	    researchMachineDir: string;
 	    maxCostUsd: number;
 	    maxTurns: number;
+	    requirePermissions?: boolean;
 	
 	    static createFrom(source: any = {}) {
 	        return new AgentDefaults(source);
@@ -217,6 +218,7 @@ export namespace config {
 	        this.researchMachineDir = source["researchMachineDir"];
 	        this.maxCostUsd = source["maxCostUsd"];
 	        this.maxTurns = source["maxTurns"];
+	        this.requirePermissions = source["requirePermissions"];
 	    }
 	}
 	export class AuditConfig {
@@ -914,6 +916,7 @@ export namespace task {
 	    statusReason: string;
 	    reviewed: boolean;
 	    runRole: string;
+	    requirePermissions?: boolean;
 	    todoistId: string;
 	    agentRuns: AgentRun[];
 	    workflow?: workflow.Execution;
@@ -947,6 +950,7 @@ export namespace task {
 	        this.statusReason = source["statusReason"];
 	        this.reviewed = source["reviewed"];
 	        this.runRole = source["runRole"];
+	        this.requirePermissions = source["requirePermissions"];
 	        this.todoistId = source["todoistId"];
 	        this.agentRuns = this.convertValues(source["agentRuns"], AgentRun);
 	        this.workflow = this.convertValues(source["workflow"], workflow.Execution);

--- a/internal/agent/inspector.go
+++ b/internal/agent/inspector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os/exec"
 	"strings"
 )
@@ -27,7 +28,12 @@ type InspectInput struct {
 // Inspect spawns `claude -p` to analyze a running agent's NDJSON log and return
 // a verdict on whether it appears stuck. The caller must supply a context with
 // a reasonable timeout (e.g. 2 minutes).
-func Inspect(ctx context.Context, in InspectInput) (InspectorVerdict, error) {
+// The inspector always runs with --dangerously-skip-permissions because it is
+// short-lived and read-only; logger receives a warning on each invocation.
+func Inspect(ctx context.Context, logger *slog.Logger, in InspectInput) (InspectorVerdict, error) {
+	logger.Warn("inspector: running with --dangerously-skip-permissions",
+		"agent_id", in.AgentID, "task_title", in.TaskTitle)
+
 	prompt := buildInspectorPrompt(in)
 
 	cmd := exec.CommandContext(ctx, "claude",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,18 @@ type AgentDefaults struct {
 	ResearchMachineDir string  `yaml:"research_machine_dir" json:"researchMachineDir"`
 	MaxCostUSD         float64 `yaml:"max_cost_usd" json:"maxCostUsd"`
 	MaxTurns           int     `yaml:"max_turns" json:"maxTurns"`
+	// RequirePermissions sets the default permission requirement for agents.
+	// nil means not configured (falls back to true — safe default).
+	// Set to false in config to opt all tasks into skip-permissions mode.
+	RequirePermissions *bool `yaml:"require_permissions" json:"requirePermissions"`
+}
+
+// DefaultRequirePermissions returns the configured default, or true if unset.
+func (c *Config) DefaultRequirePermissions() bool {
+	if c != nil && c.Agent.RequirePermissions != nil {
+		return *c.Agent.RequirePermissions
+	}
+	return true
 }
 
 type NotificationConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -173,6 +173,30 @@ func TestLoadEmptyDirFallsBackToDefault(t *testing.T) {
 	}
 }
 
+func TestDefaultRequirePermissions(t *testing.T) {
+	t.Parallel()
+	boolPtr := func(b bool) *bool { return &b }
+
+	tests := []struct {
+		name string
+		cfg  *Config
+		want bool
+	}{
+		{"nil config", nil, true},
+		{"nil field", &Config{}, true},
+		{"explicit true", &Config{Agent: AgentDefaults{RequirePermissions: boolPtr(true)}}, true},
+		{"explicit false", &Config{Agent: AgentDefaults{RequirePermissions: boolPtr(false)}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.cfg.DefaultRequirePermissions(); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHomeDirDefault(t *testing.T) {
 	t.Setenv("SYNAPSE_HOME", "")
 

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -84,26 +84,29 @@ type AgentRun struct {
 }
 
 type Task struct {
-	ID           string              `yaml:"id" json:"id"`
-	Slug         string              `yaml:"slug,omitempty" json:"slug"`
-	Title        string              `yaml:"title" json:"title"`
-	Status       Status              `yaml:"status" json:"status"`
-	TaskType     TaskType            `yaml:"task_type,omitempty" json:"taskType"`
-	AgentMode    string              `yaml:"agent_mode" json:"agentMode"`
-	AllowedTools []string            `yaml:"allowed_tools" json:"allowedTools"`
-	Tags         []string            `yaml:"tags" json:"tags"`
-	ProjectID    string              `yaml:"project_id,omitempty" json:"projectId"`
-	Branch       string              `yaml:"branch,omitempty" json:"branch"`
-	PRNumber     int                 `yaml:"pr_number,omitempty" json:"prNumber"`
-	Issue        string              `yaml:"issue,omitempty" json:"issue"`
-	StatusReason string              `yaml:"status_reason,omitempty" json:"statusReason"`
-	Reviewed     bool                `yaml:"reviewed,omitempty" json:"reviewed"`
-	RunRole      string              `yaml:"run_role,omitempty" json:"runRole"` // pr-fix when fixing review issues, "" for initial impl
-	TodoistID    string              `yaml:"todoist_id,omitempty" json:"todoistId"`
-	AgentRuns    []AgentRun          `yaml:"agent_runs,omitempty" json:"agentRuns"`
-	Workflow     *workflow.Execution `yaml:"workflow,omitempty" json:"workflow"`
-	CreatedAt    time.Time           `yaml:"created_at" json:"createdAt"`
-	UpdatedAt    time.Time           `yaml:"updated_at" json:"updatedAt"`
+	ID           string   `yaml:"id" json:"id"`
+	Slug         string   `yaml:"slug,omitempty" json:"slug"`
+	Title        string   `yaml:"title" json:"title"`
+	Status       Status   `yaml:"status" json:"status"`
+	TaskType     TaskType `yaml:"task_type,omitempty" json:"taskType"`
+	AgentMode    string   `yaml:"agent_mode" json:"agentMode"`
+	AllowedTools []string `yaml:"allowed_tools" json:"allowedTools"`
+	Tags         []string `yaml:"tags" json:"tags"`
+	ProjectID    string   `yaml:"project_id,omitempty" json:"projectId"`
+	Branch       string   `yaml:"branch,omitempty" json:"branch"`
+	PRNumber     int      `yaml:"pr_number,omitempty" json:"prNumber"`
+	Issue        string   `yaml:"issue,omitempty" json:"issue"`
+	StatusReason string   `yaml:"status_reason,omitempty" json:"statusReason"`
+	Reviewed     bool     `yaml:"reviewed,omitempty" json:"reviewed"`
+	RunRole      string   `yaml:"run_role,omitempty" json:"runRole"` // pr-fix when fixing review issues, "" for initial impl
+	TodoistID    string   `yaml:"todoist_id,omitempty" json:"todoistId"`
+	// RequirePermissions overrides the system default when set.
+	// nil = use system default (true). false = opt out (--dangerously-skip-permissions).
+	RequirePermissions *bool               `yaml:"require_permissions,omitempty" json:"requirePermissions,omitempty"`
+	AgentRuns          []AgentRun          `yaml:"agent_runs,omitempty" json:"agentRuns"`
+	Workflow           *workflow.Execution `yaml:"workflow,omitempty" json:"workflow"`
+	CreatedAt          time.Time           `yaml:"created_at" json:"createdAt"`
+	UpdatedAt          time.Time           `yaml:"updated_at" json:"updatedAt"`
 
 	Body         string `yaml:"-" json:"body"`
 	Plan         string `yaml:"-" json:"plan,omitempty"`

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -141,7 +141,7 @@ func (w *Watchdog) inspect(ctx context.Context, ag *agent.Agent, t task.Task, st
 	ictx, cancel := context.WithTimeout(ctx, InspectTimeout)
 	defer cancel()
 
-	verdict, err := agent.Inspect(ictx, agent.InspectInput{
+	verdict, err := agent.Inspect(ictx, w.logger, agent.InspectInput{
 		AgentID:   ag.ID,
 		TaskTitle: t.Title,
 		LogPath:   ag.GetLogPath(),

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -1,0 +1,34 @@
+package workflow
+
+// AgentCompletion carries the result of an agent run to the workflow engine.
+// Using a typed struct instead of positional string args makes the
+// success/failure contract explicit and independent of agent package constants.
+type AgentCompletion struct {
+	AgentID string
+	Result  string
+	// Success reports whether the agent exited cleanly. false triggers the
+	// step failure/retry path in AdvanceStep.
+	Success bool
+}
+
+// AgentLauncher starts agents and queries running state.
+// `dir` overrides worktree preparation — when non-empty the caller has
+// already staged a directory (e.g. PrepareForFix) and the adapter must reuse
+// it instead of calling PrepareForTask.
+// `oneShot` asks the runner to close stdin after the first `result` event in
+// conversational mode so the process exits naturally. Required for interactive
+// workflow steps that expect a single turn — otherwise the agent sits paused
+// forever and the workflow never advances to the next step.
+type AgentLauncher interface {
+	StartAgent(taskID, role, mode, model, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool) (agentID string, err error)
+	HasRunningAgent(taskID string) bool
+	FindRunningAgentForRole(taskID, role string) (agentID string, found bool)
+	StopAgentsForTask(taskID string, role string)
+	SendPrompt(agentID, message string) error
+}
+
+// WorkflowVarDir is the reserved variable name used to pass a pre-prepared
+// working directory to run_agent steps, bypassing worktree creation inside
+// the engine. Callers set this before StartWorkflowWithVars when they have
+// already prepared the worktree (e.g. PR-fix flow that needs PrepareForFix).
+const WorkflowVarDir = "_dir"

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -68,28 +68,6 @@ type PRLinker interface {
 	EditBody(repo string, prNumber int, body string) error
 }
 
-// AgentLauncher starts agents and queries running state.
-// `dir` overrides the worktree preparation — when non-empty the caller has
-// already staged a directory (e.g. PrepareForFix) and the adapter must reuse
-// it instead of calling PrepareForTask.
-// `oneShot` asks the runner to close stdin after the first `result` event in
-// conversational mode so the process exits naturally. Required for interactive
-// workflow steps that expect a single turn — otherwise the agent sits paused
-// forever and the workflow never advances to the next step.
-type AgentLauncher interface {
-	StartAgent(taskID, role, mode, model, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool) (agentID string, err error)
-	HasRunningAgent(taskID string) bool
-	FindRunningAgentForRole(taskID, role string) (agentID string, found bool)
-	StopAgentsForTask(taskID string, role string)
-	SendPrompt(agentID, message string) error
-}
-
-// WorkflowVarDir is the reserved variable name used to pass a pre-prepared
-// working directory to run_agent steps, bypassing worktree creation inside
-// the engine. Callers set this before StartWorkflowWithVars when they have
-// already prepared the worktree (e.g. PR-fix flow that needs PrepareForFix).
-const WorkflowVarDir = "_dir"
-
 // Engine executes workflow definitions against tasks.
 type Engine struct {
 	store      *Store
@@ -469,16 +447,14 @@ func (e *Engine) HandleStatusChange(taskID, newStatus string) {
 }
 
 // HandleAgentComplete is called when an agent finishes. It maps the agent
-// back to the workflow step and advances. The agentState parameter should
-// reflect the actual agent exit state (e.g. "stopped" for success, "failed"
-// for crashes) so the retry logic in AdvanceStep can trigger correctly.
+// back to the workflow step and advances.
 //
 // Silently skips (Debug log) when the task's workflow is already terminal or
 // has no current step. Agents that were started outside the workflow engine
 // (e.g. manual pr-fix retries, recovery spawns) land here on completion; the
 // guard avoids the "step not found" error loop that followed workflow
 // completion in older versions.
-func (e *Engine) HandleAgentComplete(taskID, agentID, result, agentState string) {
+func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 	t, err := e.tasks.GetTask(taskID)
 	if err != nil {
 		e.logger.Error("workflow.agent-complete.get", "task_id", taskID, "err", err)
@@ -490,14 +466,14 @@ func (e *Engine) HandleAgentComplete(taskID, agentID, result, agentState string)
 	}
 	if t.Workflow.State == ExecCompleted || t.Workflow.State == ExecFailed {
 		e.logger.Debug("workflow.agent-complete.terminal",
-			"task_id", taskID, "agent_id", agentID, "state", string(t.Workflow.State))
-		e.clearAgentStep(agentID)
+			"task_id", taskID, "agent_id", c.AgentID, "state", string(t.Workflow.State))
+		e.clearAgentStep(c.AgentID)
 		return
 	}
 	if t.Workflow.CurrentStep == "" {
 		e.logger.Debug("workflow.agent-complete.no-current-step",
-			"task_id", taskID, "agent_id", agentID, "state", string(t.Workflow.State))
-		e.clearAgentStep(agentID)
+			"task_id", taskID, "agent_id", c.AgentID, "state", string(t.Workflow.State))
+		e.clearAgentStep(c.AgentID)
 		return
 	}
 
@@ -505,25 +481,25 @@ func (e *Engine) HandleAgentComplete(taskID, agentID, result, agentState string)
 	// workflow's current step for agents that were never tracked (recovery
 	// flows calling with synthetic IDs). The resolved ID is then checked
 	// against the current step inside AdvanceStep to drop stale completions.
-	spawnedStep, tracked := e.lookupAgentStep(agentID)
+	spawnedStep, tracked := e.lookupAgentStep(c.AgentID)
 	if !tracked {
 		spawnedStep = t.Workflow.CurrentStep
 	}
 
 	status := "completed"
-	if agentState != "" && agentState != "stopped" {
+	if !c.Success {
 		status = "failed"
 	}
 
 	if err := e.AdvanceStep(taskID, StepOutput{
 		StepID:  spawnedStep,
 		Status:  status,
-		Output:  result,
-		AgentID: agentID,
+		Output:  c.Result,
+		AgentID: c.AgentID,
 	}); err != nil {
 		e.logger.Error("workflow.agent-complete.advance", "task_id", taskID, "err", err)
 	}
-	e.clearAgentStep(agentID)
+	e.clearAgentStep(c.AgentID)
 }
 
 // lookupAgentStep returns the stepID an agent was spawned for and whether it

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -783,7 +783,7 @@ func TestNoWorkflowField(t *testing.T) {
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo"}) // no Workflow
 
 	// Should not panic or error fatally.
-	engine.HandleAgentComplete("t1", "agent-1", "result", "stopped")
+	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: "agent-1", Result: "result", Success: true})
 }
 
 func TestResumeStalled_RunAgent(t *testing.T) {
@@ -1155,7 +1155,7 @@ func TestHandleAgentComplete_CompletedWorkflowIsNoop(t *testing.T) {
 	// Another agent complete on an already-completed workflow should not
 	// start new agents, mutate step history, or record an error.
 	callsBefore := agents.CallCount()
-	engine.HandleAgentComplete("t1", "stale-agent", "late result", "stopped")
+	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: "stale-agent", Result: "late result", Success: true})
 
 	if agents.CallCount() != callsBefore {
 		t.Error("HandleAgentComplete on completed workflow should not start new agents")
@@ -1957,7 +1957,7 @@ func TestDuplicatePlanAgent_StaleCompletionDoesNotFailWaitHuman(t *testing.T) {
 	triageAgent := agents.LastID()
 	tasks.SetStatus("t1", "planning")
 	agents.SimulateComplete("t1")
-	engine.HandleAgentComplete("t1", triageAgent, "triaged", "stopped")
+	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: triageAgent, Result: "triaged", Success: true})
 
 	planAgent1 := agents.LastID()
 	ti, _ := tasks.GetTask("t1")
@@ -1981,7 +1981,7 @@ func TestDuplicatePlanAgent_StaleCompletionDoesNotFailWaitHuman(t *testing.T) {
 
 	// Agent 1 completes first → workflow advances to review_plan/wait_human.
 	agents.SimulateComplete("t1")
-	engine.HandleAgentComplete("t1", planAgent1, "plan ready", "stopped")
+	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: planAgent1, Result: "plan ready", Success: true})
 
 	ti, _ = tasks.GetTask("t1")
 	if ti.Workflow.CurrentStep != "review_plan" {
@@ -1993,7 +1993,7 @@ func TestDuplicatePlanAgent_StaleCompletionDoesNotFailWaitHuman(t *testing.T) {
 
 	// Agent 2 (the duplicate) finishes seconds later. Old behavior would
 	// drive review_plan into ExecFailed. New behavior: dropped as stale.
-	engine.HandleAgentComplete("t1", planAgent2, "plan ready", "stopped")
+	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: planAgent2, Result: "plan ready", Success: true})
 
 	ti, _ = tasks.GetTask("t1")
 	if ti.Workflow.State != ExecWaiting {
@@ -2043,7 +2043,7 @@ func TestHandleAgentComplete_WaitHumanWithoutActionIsNoop(t *testing.T) {
 
 	// Agent callback arrives for the current (wait_human) step with no
 	// human_action set. Must be a no-op.
-	engine.HandleAgentComplete("t1", "untracked-legacy-agent", "unexpected result", "stopped")
+	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: "untracked-legacy-agent", Result: "unexpected result", Success: true})
 
 	ti, _ := tasks.GetTask("t1")
 	if ti.Workflow.State != ExecWaiting {
@@ -2164,7 +2164,7 @@ func TestExecRunAgent_TracksSpawnedStep(t *testing.T) {
 	// unbounded across long-lived sessions.
 	tasks.SetStatus("t1", "plan-review")
 	agents.SimulateComplete("t1")
-	engine.HandleAgentComplete("t1", agentID, "done", "stopped")
+	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: agentID, Result: "done", Success: true})
 
 	engine.mu.Lock()
 	_, stillThere := engine.agentSteps[agentID]


### PR DESCRIPTION
## Motivation

`--dangerously-skip-permissions` was appended unconditionally when `RequirePermissions=false` (the default for all task types except debug). No audit trail recorded which agents ran with which permission level, making it impossible to answer "what did agent X actually do?" in a world of unattended workflows.

## Implementation information

Four changes:

1. **Per-task opt-out** — `require_permissions: *bool` field on `Task`. `nil` = use system default. `false` = explicit opt-out (skip-permissions).

2. **System default** — `RequirePermissions *bool` on `AgentDefaults` config. `nil`/unset defaults to `true` (safe default). Existing installs that omit the field now require permissions by default; tasks that need the old skip-permissions behavior set `require_permissions: false` in the task frontmatter or set `agent.require_permissions: false` in config.

3. **Audit log enrichment** — `EventAgentStarted` now records `allowed_tools`, `require_permissions`, and `skip_permissions` (computed: `!requirePerm && len(allowedTools) == 0`) for every agent start.

4. **Inspector warning** — `Inspect()` gains a `*slog.Logger` parameter and logs a `Warn` on every invocation since it always uses `--dangerously-skip-permissions`. Risk is bounded (read-only, short-lived), so the flag stays.

Permission resolution priority: task-level field > TaskType hardcode (debug=always true) > config default > `true`.

Step 3 from the original fix approach (AllowedTools enforcement) was already implemented in the runners — confirmed in code review, no change needed.

## Supporting documentation

> Changelog: feat(security): audit agent permission bypass

Closes https://github.com/Automaat/synapse/issues/320