### PR TITLE
refactor(workflow): type-safe AgentCompletion contract

### DIFF
--- a/app.go
+++ b/app.go
@@ -328,11 +328,11 @@ func (a *App) onAgentComplete(ag *agent.Agent) {
 
 	// Advance workflow.
 	if a.workflowEngine != nil {
-		agentState := "stopped"
-		if exitErr != nil {
-			agentState = "failed"
-		}
-		a.workflowEngine.HandleAgentComplete(ag.TaskID, ag.ID, resultContent, agentState)
+		a.workflowEngine.HandleAgentComplete(ag.TaskID, workflow.AgentCompletion{
+			AgentID: ag.ID,
+			Result:  resultContent,
+			Success: exitErr == nil,
+		})
 	}
 
 	// Worktree cleanup for done tasks (after engine advances, so status is final).
@@ -627,7 +627,10 @@ func (a *App) recoverStaleInteractive(t *task.Task) {
 	}
 	a.logger.Info("recover-stale.advance",
 		"task_id", t.ID, "agent_id", lr.AgentID, "step", t.Workflow.CurrentStep)
-	a.workflowEngine.HandleAgentComplete(t.ID, lr.AgentID, "", "stopped")
+	a.workflowEngine.HandleAgentComplete(t.ID, workflow.AgentCompletion{
+		AgentID: lr.AgentID,
+		Success: true,
+	})
 }
 
 func lastAgentRun(t *task.Task) *task.AgentRun {

--- a/e2e_workflow_test.go
+++ b/e2e_workflow_test.go
@@ -224,11 +224,11 @@ func setupE2EProvider(t *testing.T, provider, scenario string) *e2eEnv {
 				result = ev.Content
 			}
 		}
-		agentState := "stopped"
-		if ag.GetExitErr() != nil {
-			agentState = "failed"
-		}
-		engine.HandleAgentComplete(ag.TaskID, ag.ID, result, agentState)
+		engine.HandleAgentComplete(ag.TaskID, workflow.AgentCompletion{
+			AgentID: ag.ID,
+			Result:  result,
+			Success: ag.GetExitErr() == nil,
+		})
 	})
 
 	// Pre-create a working directory so run_agent steps can satisfy the
@@ -1008,7 +1008,7 @@ func TestE2E_RecoverStaleInteractive(t *testing.T) {
 	if _, err := env.tasks.UpdateMap(created.ID, map[string]any{"workflow": wfExec}); err != nil {
 		t.Fatal(err)
 	}
-	env.engine.HandleAgentComplete(created.ID, "stale-agent", "", "stopped")
+	env.engine.HandleAgentComplete(created.ID, workflow.AgentCompletion{AgentID: "stale-agent", Success: true})
 
 	// Evaluate fires (fake-claude "evaluate" scenario sets status=in-review),
 	// then the workflow reaches ExecCompleted.
@@ -1619,7 +1619,7 @@ func TestE2E_StaleAgentCompletionAfterWorkflowTerminal(t *testing.T) {
 	// after the workflow ended) calling back into HandleAgentComplete. Prior
 	// to the fix this fired an ERROR log AND wrote a bogus StepHistory entry
 	// with StepID="". After the fix it is a silent no-op.
-	env.engine.HandleAgentComplete(created.ID, "stray-agent-xyz", "late result", "stopped")
+	env.engine.HandleAgentComplete(created.ID, workflow.AgentCompletion{AgentID: "stray-agent-xyz", Result: "late result", Success: true})
 
 	// HandleAgentComplete is synchronous; no async side effects to wait for.
 	tkAfter, _ := env.tasks.Get(created.ID)
@@ -1692,7 +1692,7 @@ func TestE2E_StaleAgentCompletionAtWaitHuman(t *testing.T) {
 	// Stray completion lands on the wait_human step. In the pre-fix engine
 	// this would drive resolveNext → ExecFailed; post-fix it's a silent
 	// no-op because output.AgentID != "" and human_action is unset.
-	env.engine.HandleAgentComplete(created.ID, "stray-duplicate-plan-agent", "late plan result", "stopped")
+	env.engine.HandleAgentComplete(created.ID, workflow.AgentCompletion{AgentID: "stray-duplicate-plan-agent", Result: "late plan result", Success: true})
 
 	// HandleAgentComplete is synchronous; no async side effects to wait for.
 	tkAfter, _ := env.tasks.Get(created.ID)

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -1,0 +1,34 @@
+package workflow
+
+// AgentCompletion carries the result of an agent run to the workflow engine.
+// Using a typed struct instead of positional string args makes the
+// success/failure contract explicit and independent of agent package constants.
+type AgentCompletion struct {
+	AgentID string
+	Result  string
+	// Success reports whether the agent exited cleanly. false triggers the
+	// step failure/retry path in AdvanceStep.
+	Success bool
+}
+
+// AgentLauncher starts agents and queries running state.
+// `dir` overrides worktree preparation — when non-empty the caller has
+// already staged a directory (e.g. PrepareForFix) and the adapter must reuse
+// it instead of calling PrepareForTask.
+// `oneShot` asks the runner to close stdin after the first `result` event in
+// conversational mode so the process exits naturally. Required for interactive
+// workflow steps that expect a single turn — otherwise the agent sits paused
+// forever and the workflow never advances to the next step.
+type AgentLauncher interface {
+	StartAgent(taskID, role, mode, model, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool) (agentID string, err error)
+	HasRunningAgent(taskID string) bool
+	FindRunningAgentForRole(taskID, role string) (agentID string, found bool)
+	StopAgentsForTask(taskID string, role string)
+	SendPrompt(agentID, message string) error
+}
+
+// WorkflowVarDir is the reserved variable name used to pass a pre-prepared
+// working directory to run_agent steps, bypassing worktree creation inside
+// the engine. Callers set this before StartWorkflowWithVars when they have
+// already prepared the worktree (e.g. PR-fix flow that needs PrepareForFix).
+const WorkflowVarDir = "_dir"

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -68,28 +68,6 @@ type PRLinker interface {
 	EditBody(repo string, prNumber int, body string) error
 }
 
-// AgentLauncher starts agents and queries running state.
-// `dir` overrides the worktree preparation — when non-empty the caller has
-// already staged a directory (e.g. PrepareForFix) and the adapter must reuse
-// it instead of calling PrepareForTask.
-// `oneShot` asks the runner to close stdin after the first `result` event in
-// conversational mode so the process exits naturally. Required for interactive
-// workflow steps that expect a single turn — otherwise the agent sits paused
-// forever and the workflow never advances to the next step.
-type AgentLauncher interface {
-	StartAgent(taskID, role, mode, model, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool) (agentID string, err error)
-	HasRunningAgent(taskID string) bool
-	FindRunningAgentForRole(taskID, role string) (agentID string, found bool)
-	StopAgentsForTask(taskID string, role string)
-	SendPrompt(agentID, message string) error
-}
-
-// WorkflowVarDir is the reserved variable name used to pass a pre-prepared
-// working directory to run_agent steps, bypassing worktree creation inside
-// the engine. Callers set this before StartWorkflowWithVars when they have
-// already prepared the worktree (e.g. PR-fix flow that needs PrepareForFix).
-const WorkflowVarDir = "_dir"
-
 // Engine executes workflow definitions against tasks.
 type Engine struct {
 	store      *Store
@@ -469,16 +447,14 @@ func (e *Engine) HandleStatusChange(taskID, newStatus string) {
 }
 
 // HandleAgentComplete is called when an agent finishes. It maps the agent
-// back to the workflow step and advances. The agentState parameter should
-// reflect the actual agent exit state (e.g. "stopped" for success, "failed"
-// for crashes) so the retry logic in AdvanceStep can trigger correctly.
+// back to the workflow step and advances.
 //
 // Silently skips (Debug log) when the task's workflow is already terminal or
 // has no current step. Agents that were started outside the workflow engine
 // (e.g. manual pr-fix retries, recovery spawns) land here on completion; the
 // guard avoids the "step not found" error loop that followed workflow
 // completion in older versions.
-func (e *Engine) HandleAgentComplete(taskID, agentID, result, agentState string) {
+func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 	t, err := e.tasks.GetTask(taskID)
 	if err != nil {
 		e.logger.Error("workflow.agent-complete.get", "task_id", taskID, "err", err)
@@ -490,14 +466,14 @@ func (e *Engine) HandleAgentComplete(taskID, agentID, result, agentState string)
 	}
 	if t.Workflow.State == ExecCompleted || t.Workflow.State == ExecFailed {
 		e.logger.Debug("workflow.agent-complete.terminal",
-			"task_id", taskID, "agent_id", agentID, "state", string(t.Workflow.State))
-		e.clearAgentStep(agentID)
+			"task_id", taskID, "agent_id", c.AgentID, "state", string(t.Workflow.State))
+		e.clearAgentStep(c.AgentID)
 		return
 	}
 	if t.Workflow.CurrentStep == "" {
 		e.logger.Debug("workflow.agent-complete.no-current-step",
-			"task_id", taskID, "agent_id", agentID, "state", string(t.Workflow.State))
-		e.clearAgentStep(agentID)
+			"task_id", taskID, "agent_id", c.AgentID, "state", string(t.Workflow.State))
+		e.clearAgentStep(c.AgentID)
 		return
 	}
 
@@ -505,25 +481,25 @@ func (e *Engine) HandleAgentComplete(taskID, agentID, result, agentState string)
 	// workflow's current step for agents that were never tracked (recovery
 	// flows calling with synthetic IDs). The resolved ID is then checked
 	// against the current step inside AdvanceStep to drop stale completions.
-	spawnedStep, tracked := e.lookupAgentStep(agentID)
+	spawnedStep, tracked := e.lookupAgentStep(c.AgentID)
 	if !tracked {
 		spawnedStep = t.Workflow.CurrentStep
 	}
 
 	status := "completed"
-	if agentState != "" && agentState != "stopped" {
+	if !c.Success {
 		status = "failed"
 	}
 
 	if err := e.AdvanceStep(taskID, StepOutput{
 		StepID:  spawnedStep,
 		Status:  status,
-		Output:  result,
-		AgentID: agentID,
+		Output:  c.Result,
+		AgentID: c.AgentID,
 	}); err != nil {
 		e.logger.Error("workflow.agent-complete.advance", "task_id", taskID, "err", err)
 	}
-	e.clearAgentStep(agentID)
+	e.clearAgentStep(c.AgentID)
 }
 
 // lookupAgentStep returns the stepID an agent was spawned for and whether it

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -783,7 +783,7 @@ func TestNoWorkflowField(t *testing.T) {
 	tasks.Put(TaskInfo{ID: "t1", Status: "todo"}) // no Workflow
 
 	// Should not panic or error fatally.
-	engine.HandleAgentComplete("t1", "agent-1", "result", "stopped")
+	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: "agent-1", Result: "result", Success: true})
 }
 
 func TestResumeStalled_RunAgent(t *testing.T) {
@@ -1155,7 +1155,7 @@ func TestHandleAgentComplete_CompletedWorkflowIsNoop(t *testing.T) {
 	// Another agent complete on an already-completed workflow should not
 	// start new agents, mutate step history, or record an error.
 	callsBefore := agents.CallCount()
-	engine.HandleAgentComplete("t1", "stale-agent", "late result", "stopped")
+	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: "stale-agent", Result: "late result", Success: true})
 
 	if agents.CallCount() != callsBefore {
 		t.Error("HandleAgentComplete on completed workflow should not start new agents")
@@ -1957,7 +1957,7 @@ func TestDuplicatePlanAgent_StaleCompletionDoesNotFailWaitHuman(t *testing.T) {
 	triageAgent := agents.LastID()
 	tasks.SetStatus("t1", "planning")
 	agents.SimulateComplete("t1")
-	engine.HandleAgentComplete("t1", triageAgent, "triaged", "stopped")
+	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: triageAgent, Result: "triaged", Success: true})
 
 	planAgent1 := agents.LastID()
 	ti, _ := tasks.GetTask("t1")
@@ -1981,7 +1981,7 @@ func TestDuplicatePlanAgent_StaleCompletionDoesNotFailWaitHuman(t *testing.T) {
 
 	// Agent 1 completes first → workflow advances to review_plan/wait_human.
 	agents.SimulateComplete("t1")
-	engine.HandleAgentComplete("t1", planAgent1, "plan ready", "stopped")
+	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: planAgent1, Result: "plan ready", Success: true})
 
 	ti, _ = tasks.GetTask("t1")
 	if ti.Workflow.CurrentStep != "review_plan" {
@@ -1993,7 +1993,7 @@ func TestDuplicatePlanAgent_StaleCompletionDoesNotFailWaitHuman(t *testing.T) {
 
 	// Agent 2 (the duplicate) finishes seconds later. Old behavior would
 	// drive review_plan into ExecFailed. New behavior: dropped as stale.
-	engine.HandleAgentComplete("t1", planAgent2, "plan ready", "stopped")
+	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: planAgent2, Result: "plan ready", Success: true})
 
 	ti, _ = tasks.GetTask("t1")
 	if ti.Workflow.State != ExecWaiting {
@@ -2043,7 +2043,7 @@ func TestHandleAgentComplete_WaitHumanWithoutActionIsNoop(t *testing.T) {
 
 	// Agent callback arrives for the current (wait_human) step with no
 	// human_action set. Must be a no-op.
-	engine.HandleAgentComplete("t1", "untracked-legacy-agent", "unexpected result", "stopped")
+	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: "untracked-legacy-agent", Result: "unexpected result", Success: true})
 
 	ti, _ := tasks.GetTask("t1")
 	if ti.Workflow.State != ExecWaiting {
@@ -2164,7 +2164,7 @@ func TestExecRunAgent_TracksSpawnedStep(t *testing.T) {
 	// unbounded across long-lived sessions.
 	tasks.SetStatus("t1", "plan-review")
 	agents.SimulateComplete("t1")
-	engine.HandleAgentComplete("t1", agentID, "done", "stopped")
+	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: agentID, Result: "done", Success: true})
 
 	engine.mu.Lock()
 	_, stillThere := engine.agentSteps[agentID]


### PR DESCRIPTION
## Motivation

The workflow engine called `HandleAgentComplete(taskID, agentID, result, agentState string)` — four positional strings where the caller had to know that `"stopped"` means success and anything else means failure. That string constant was an agent package internal leaking silently into workflow logic: rename `StateStopped` and the workflow would misclassify every successful agent run as failed, with no compile-time or test-time signal.

> Changelog: refactor(workflow): type-safe AgentCompletion contract

## Implementation information

- Added `internal/workflow/agent_iface.go` as the canonical home for the engine's agent-facing contract: the existing `AgentLauncher` interface (moved from `engine.go`) + the new `AgentCompletion` struct
- `AgentCompletion{AgentID, Result, Success bool}` replaces the implicit `"stopped"=success` convention with an explicit boolean
- `HandleAgentComplete` now takes `(taskID string, c AgentCompletion)` — callers in `app.go` and `e2e_workflow_test.go` build the struct from `exitErr == nil`, keeping the adapter layer as the only place that touches agent internals
- Internal engine logic `if agentState != "" && agentState != "stopped"` → `if !c.Success`
- All unit and e2e test callsites updated; linter and workflow tests pass

The `workflow` package already had no import of `internal/agent` — this PR formalises the remaining soft coupling at the completion boundary.

## Supporting documentation

Closes the agent ↔ workflow circular concern tech debt item.

Closes https://github.com/Automaat/synapse/issues/316