### PR TITLE
feat(frontend): edit task type from detail view

### DIFF
--- a/frontend/e2e/tasks.spec.ts
+++ b/frontend/e2e/tasks.spec.ts
@@ -29,7 +29,7 @@ async function waitForTasks(page: Page) {
 
 // Select a status value on the task detail status dropdown
 async function selectStatus(page: Page, value: string) {
-  await page.getByRole('main').locator('select').selectOption(value)
+  await page.getByTestId('task-status-select').selectOption(value)
 }
 
 test.afterAll(async () => {

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -148,6 +148,15 @@
     }
   }
 
+  async function updateTaskType(value: string) {
+    if (!t || (t.taskType ?? 'normal') === value) return
+    try {
+      t = await taskStore.update(taskId, { task_type: value })
+    } catch (e) {
+      error = String(e)
+    }
+  }
+
   async function startAgent() {
     if (!t || !prompt.trim()) return
     starting = true
@@ -342,6 +351,16 @@
             {#each statusOptions as s}
               <option value={s.value}>{s.label}</option>
             {/each}
+          </select>
+          <select
+            class="rounded border border-surface-300 bg-surface-100 px-2 py-0.5 text-xs font-medium dark:border-surface-600 dark:bg-surface-700"
+            value={t.taskType || 'normal'}
+            onchange={(e) => updateTaskType((e.target as HTMLSelectElement).value)}
+            title="Task type — controls execution mode and worktree behavior"
+          >
+            <option value="normal">normal</option>
+            <option value="debug">debug</option>
+            <option value="research">research</option>
           </select>
           {#if triaging}
             <span class="inline-flex items-center gap-1 rounded-full bg-primary-200 px-2 py-0.5 text-xs font-medium text-primary-800 dark:bg-primary-700 dark:text-primary-200">

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -344,6 +344,7 @@
         <div class="flex items-center gap-2">
           <select
             bind:this={statusSelectRef}
+            data-testid="task-status-select"
             class="rounded border border-surface-300 bg-surface-100 px-2 py-0.5 text-xs font-medium dark:border-surface-600 dark:bg-surface-700"
             value={t.status}
             onchange={(e) => updateStatus((e.target as HTMLSelectElement).value)}
@@ -353,6 +354,7 @@
             {/each}
           </select>
           <select
+            data-testid="task-type-select"
             class="rounded border border-surface-300 bg-surface-100 px-2 py-0.5 text-xs font-medium dark:border-surface-600 dark:bg-surface-700"
             value={t.taskType || 'normal'}
             onchange={(e) => updateTaskType((e.target as HTMLSelectElement).value)}


### PR DESCRIPTION
## Motivation

When triage promotes a task to `research` or `debug`, it can only be reverted by editing the markdown file or running `synapse-cli update`. The TaskDetail page has no UI for `task_type`, even though the backend `UpdateTask` binding already supports the field.

Hit this concretely on issue #319 (Wails v3 migration plan) — triage flipped it to `task_type: research`, which then failed to start because `agent.research_machine_dir` was unset, with no obvious recovery path from the GUI.

## Implementation information

- Added `updateTaskType` in `TaskDetail.svelte`, mirrors `updateStatus`.
- Added a Type select next to the Status select in the task header. Options: `normal` / `debug` / `research`.
- No backend changes — `applyMapField` in `internal/task/update.go:132` already accepts the `task_type` key, and `CreateTaskDialog` already used the same map shape.
- No Wails binding regen needed.

## Supporting documentation

Field semantics live in `internal/task/model.go:50-73` (`TaskType` + `ValidateTaskType`). Execution side effects in `app_agents.go:22-31` (`resolveExecution`).