### PR TITLE
fix(task): validate agent_mode

### DIFF
--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -72,6 +72,30 @@ func ValidateTaskType(s string) (TaskType, error) {
 	return tt, nil
 }
 
+const (
+	AgentModeHeadless    = "headless"
+	AgentModeInteractive = "interactive"
+)
+
+var validAgentModes = map[string]bool{
+	AgentModeHeadless: true, AgentModeInteractive: true,
+}
+
+// AllAgentModes returns every valid agent mode in display order.
+func AllAgentModes() []string {
+	return []string{AgentModeHeadless, AgentModeInteractive}
+}
+
+// ValidateAgentMode rejects unknown agent modes. Empty strings are rejected
+// here; callers that need to allow "unset" (e.g. parser legacy compat) must
+// guard the empty case before calling.
+func ValidateAgentMode(s string) (string, error) {
+	if !validAgentModes[s] {
+		return "", fmt.Errorf("invalid agent_mode %q (valid: %v)", s, AllAgentModes())
+	}
+	return s, nil
+}
+
 type AgentRun struct {
 	AgentID   string    `yaml:"agent_id" json:"agentId"`
 	Role      string    `yaml:"role,omitempty" json:"role"` // triage, plan, eval, pr-fix, or "" for implementation

--- a/internal/task/model_test.go
+++ b/internal/task/model_test.go
@@ -71,6 +71,50 @@ func TestAllTaskTypes(t *testing.T) {
 	}
 }
 
+func TestValidateAgentMode_Valid(t *testing.T) {
+	t.Parallel()
+	for _, m := range AllAgentModes() {
+		t.Run(m, func(t *testing.T) {
+			t.Parallel()
+			got, err := ValidateAgentMode(m)
+			if err != nil {
+				t.Fatalf("ValidateAgentMode(%q): %v", m, err)
+			}
+			if got != m {
+				t.Errorf("got %q, want %q", got, m)
+			}
+		})
+	}
+}
+
+func TestValidateAgentMode_Invalid(t *testing.T) {
+	t.Parallel()
+	cases := []string{"", "supervised", "Headless", "auto", " interactive"}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			t.Parallel()
+			if _, err := ValidateAgentMode(c); err == nil {
+				t.Fatalf("expected error for %q", c)
+			}
+		})
+	}
+}
+
+func TestAllAgentModes(t *testing.T) {
+	t.Parallel()
+	modes := AllAgentModes()
+	if len(modes) != 2 {
+		t.Errorf("got %d modes, want 2", len(modes))
+	}
+	seen := make(map[string]bool)
+	for _, m := range modes {
+		if seen[m] {
+			t.Errorf("duplicate mode %q", m)
+		}
+		seen[m] = true
+	}
+}
+
 func TestTask_DirName_WithSlug(t *testing.T) {
 	t.Parallel()
 	task := Task{ID: "a1b2c3d4", Slug: "my-task"}

--- a/internal/task/parser.go
+++ b/internal/task/parser.go
@@ -44,6 +44,11 @@ func ParseBytes(data []byte) (Task, error) {
 	if t.TaskType == "" {
 		t.TaskType = TaskTypeNormal
 	}
+	if t.AgentMode != "" {
+		if _, err := ValidateAgentMode(t.AgentMode); err != nil {
+			return Task{}, err
+		}
+	}
 	return t, nil
 }
 

--- a/internal/task/parser_test.go
+++ b/internal/task/parser_test.go
@@ -90,6 +90,16 @@ allowed_tools: [Read, Write, Bash]
 				AllowedTools: []string{"Read", "Write", "Bash"},
 			},
 		},
+		{
+			name: "invalid agent_mode rejected",
+			input: `---
+id: bad1
+title: Bad mode
+status: todo
+agent_mode: supervised
+---`,
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -78,7 +78,10 @@ func (s *Store) Get(id string) (Task, error) {
 
 func (s *Store) Create(title, body, mode string) (Task, error) {
 	if mode == "" {
-		mode = "interactive"
+		mode = AgentModeInteractive
+	}
+	if _, err := ValidateAgentMode(mode); err != nil {
+		return Task{}, err
 	}
 	now := time.Now().UTC()
 	id := uuid.NewString()[:8]
@@ -144,6 +147,9 @@ func (s *Store) Update(id string, u Update) (Task, error) {
 		t.StatusReason = *u.StatusReason
 	}
 	if u.AgentMode != nil {
+		if _, err := ValidateAgentMode(*u.AgentMode); err != nil {
+			return Task{}, err
+		}
 		t.AgentMode = *u.AgentMode
 	}
 	if u.TaskType != nil {

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -302,6 +302,35 @@ func TestStoreUpdateAgentMode(t *testing.T) {
 	}
 }
 
+func TestStoreCreate_InvalidAgentMode(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Create("Bad mode", "", "supervised"); err == nil {
+		t.Fatal("expected error for invalid agent_mode")
+	}
+}
+
+func TestStoreUpdate_InvalidAgentMode(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := store.Create("Mode task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Update(created.ID, Update{AgentMode: Ptr("supervised")}); err == nil {
+		t.Fatal("expected error for invalid agent_mode update")
+	}
+	if _, err := store.UpdateMap(created.ID, map[string]any{"agent_mode": "supervised"}); err == nil {
+		t.Fatal("expected error for invalid agent_mode UpdateMap")
+	}
+}
+
 func TestStoreUpdateProjectID(t *testing.T) {
 	t.Parallel()
 	store, err := NewStore(t.TempDir())

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -53,11 +53,13 @@ func UpdateFromMap(raw map[string]any) (Update, error) {
 
 func applyMapField(u *Update, k string, v any) error {
 	switch k {
-	case "title", "slug", "status_reason", "agent_mode", "body",
+	case "title", "slug", "status_reason", "body",
 		"project_id", "branch", "issue", "run_role", "todoist_id", "plan", "plan_critique":
 		return applyPlainStringField(u, k, v)
 	case "status":
 		return applyStatusField(u, k, v)
+	case "agent_mode":
+		return applyAgentModeField(u, k, v)
 	case "task_type":
 		return applyTaskTypeField(u, k, v)
 	case "tags":
@@ -94,8 +96,6 @@ func applyPlainStringField(u *Update, k string, v any) error {
 		u.Slug = &s
 	case "status_reason":
 		u.StatusReason = &s
-	case "agent_mode":
-		u.AgentMode = &s
 	case "body":
 		u.Body = &s
 	case "project_id":
@@ -126,6 +126,19 @@ func applyStatusField(u *Update, k string, v any) error {
 		return err
 	}
 	u.Status = &st
+	return nil
+}
+
+func applyAgentModeField(u *Update, k string, v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("field %q: want string, got %T", k, v)
+	}
+	mode, err := ValidateAgentMode(s)
+	if err != nil {
+		return err
+	}
+	u.AgentMode = &mode
 	return nil
 }
 


### PR DESCRIPTION
## Motivation

Triage agent set `agent_mode: supervised` on a task. Runner failed deep
in `internal/agent/manager.go` with `unknown mode: supervised`, and the
`workflow.resume-stalled` exec retried every minute — 800+ ERROR lines
in `synapse.log` for one task. Unlike `Status` and `TaskType`,
`agent_mode` had no validator: `Task.AgentMode string` was stored
verbatim from the YAML frontmatter or any caller's map.

## Implementation information

- `internal/task/model.go`: add `AgentModeHeadless`/`AgentModeInteractive`
  constants, `validAgentModes`, `AllAgentModes()`, `ValidateAgentMode()`
  (rejects empty and unknown values).
- `internal/task/update.go`: split `agent_mode` out of the plain-string
  switch into `applyAgentModeField` so `UpdateMap` validates before
  storing (mirrors `status` / `task_type`).
- `internal/task/store.go`: `Create` and `Update` both call
  `ValidateAgentMode`; `Create` uses `AgentModeInteractive` for the
  empty default.
- `internal/task/parser.go`: rejects non-empty invalid `agent_mode` on
  parse. Empty stays allowed for legacy/partial files. Bad files now
  surface as `task.parse.skip` warnings instead of looping forever in
  the runner.
- Tests cover validator (valid/invalid/all-modes), parser rejection,
  and `Create`/`Update`/`UpdateMap` rejection.

## Supporting documentation

None.

> Changelog: fix(task): validate agent_mode