### PR TITLE
fix(app): suppress repeated error log spam

### DIFF
--- a/app.go
+++ b/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Automaat/synapse/internal/config"
 	"github.com/Automaat/synapse/internal/events"
 	"github.com/Automaat/synapse/internal/github"
+	"github.com/Automaat/synapse/internal/logging"
 	"github.com/Automaat/synapse/internal/notification"
 	"github.com/Automaat/synapse/internal/poll"
 	"github.com/Automaat/synapse/internal/project"
@@ -64,6 +65,7 @@ type App struct {
 	cfg             *config.Config
 	logLevel        *slog.LevelVar
 	emit            func(string, any)
+	restartStaleErr *logging.ErrorThrottle
 
 	// Wails-bound services (created in startup)
 	taskSvc     *TaskService
@@ -80,15 +82,16 @@ type App struct {
 
 func NewApp(logger *slog.Logger, logLevel *slog.LevelVar, cfg *config.Config) *App {
 	a := &App{
-		tasksDir:     cfg.TasksDir,
-		skillsDir:    cfg.SkillsDir,
-		repoDir:      cfg.RepoDir,
-		worktreesDir: cfg.WorktreesDir,
-		logger:       logger,
-		logDir:       cfg.Logging.Dir,
-		auditDir:     cfg.AuditDir(),
-		cfg:          cfg,
-		logLevel:     logLevel,
+		tasksDir:        cfg.TasksDir,
+		skillsDir:       cfg.SkillsDir,
+		repoDir:         cfg.RepoDir,
+		worktreesDir:    cfg.WorktreesDir,
+		logger:          logger,
+		logDir:          cfg.Logging.Dir,
+		auditDir:        cfg.AuditDir(),
+		cfg:             cfg,
+		logLevel:        logLevel,
+		restartStaleErr: logging.NewErrorThrottle(),
 	}
 	// Pre-allocate service structs so Wails can bind them before startup().
 	// Fields are populated in startup() once dependencies are initialized.
@@ -302,6 +305,26 @@ func (a *App) onAgentComplete(ag *agent.Agent) {
 	cost := ag.GetCostUSD()
 	exitErr := ag.GetExitErr()
 
+	// Audit logging always fires — orchestrator brain agents have no parent
+	// task and skip the storage paths below, but their lifecycle still
+	// belongs in the audit trail.
+	duration := time.Since(ag.StartedAt).Seconds()
+	a.logAudit(audit.EventAgentCompleted, ag.TaskID, ag.ID, map[string]any{
+		"mode":       ag.Mode,
+		"cost_usd":   cost,
+		"duration_s": duration,
+		"state":      string(state),
+		"role":       agent.RoleFromName(ag.Name),
+		"provider":   ag.Provider,
+	})
+
+	// Orchestrator brain agents run with TaskID="" (rooted at ~/.synapse,
+	// no parent task). Calling UpdateRun / HandleAgentComplete / Get with
+	// an empty ID joins to ".synapse/tasks/.md" and crashes the handler.
+	if ag.TaskID == "" {
+		return
+	}
+
 	// Persist run result to task file.
 	truncated := resultContent
 	if len(truncated) > maxResultLen {
@@ -314,17 +337,6 @@ func (a *App) onAgentComplete(ag *agent.Agent) {
 	}); err != nil {
 		a.logger.Error("task.update-run", "task_id", ag.TaskID, "agent_id", ag.ID, "err", err)
 	}
-
-	// Audit logging.
-	duration := time.Since(ag.StartedAt).Seconds()
-	a.logAudit(audit.EventAgentCompleted, ag.TaskID, ag.ID, map[string]any{
-		"mode":       ag.Mode,
-		"cost_usd":   cost,
-		"duration_s": duration,
-		"state":      string(state),
-		"role":       agent.RoleFromName(ag.Name),
-		"provider":   ag.Provider,
-	})
 
 	// Advance workflow.
 	if a.workflowEngine != nil {
@@ -564,9 +576,8 @@ func (a *App) restartStaleInProgress() {
 		runRole := t.RunRole
 		if runRole == "pr-fix" {
 			a.wg.Go(func() {
-				if err := a.agentOrch.StartPRFixAgent(taskID); err != nil {
-					a.logger.Error("restart.pr-fix.failed", "task_id", taskID, "err", err)
-				}
+				err := a.agentOrch.StartPRFixAgent(taskID)
+				a.restartStaleErr.Log(a.logger, "restart.pr-fix.failed", "pr-fix:"+taskID, err, "task_id", taskID)
 			})
 		} else {
 			mode := t.AgentMode
@@ -574,9 +585,8 @@ func (a *App) restartStaleInProgress() {
 				// Restart-stale only ever reaches this branch for headless
 				// mode (interactive tasks are handled by recoverStaleInteractive
 				// above), so OneShot is irrelevant here — pass false.
-				if _, err := a.agentOrch.StartAgent(taskID, mode, "Continue implementing this task. When done, create a draft PR with `gh pr create --draft`.", false); err != nil {
-					a.logger.Error("restart-stale.failed", "task_id", taskID, "err", err)
-				}
+				_, err := a.agentOrch.StartAgent(taskID, mode, "Continue implementing this task. When done, create a draft PR with `gh pr create --draft`.", false)
+				a.restartStaleErr.Log(a.logger, "restart-stale.failed", "stale:"+taskID, err, "task_id", taskID)
 			})
 		}
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -124,6 +124,48 @@ func testConfig(t *testing.T) *config.Config {
 	}
 }
 
+func TestOnAgentComplete_EmptyTaskID_NoCrash(t *testing.T) {
+	// Orchestrator brain agents run with TaskID="" — feeding that into
+	// UpdateRun/HandleAgentComplete/Get used to crash the handler with
+	// "open .synapse/tasks/.md: no such file or directory" because the
+	// empty ID was joined to the tasks dir. Verify the short-circuit.
+	a := setupApp(t)
+
+	// Pre-existing task that must NOT be touched: an empty-id call must
+	// not accidentally rewrite a task file (the original bug joined "" to
+	// the tasks dir as ".md" — the path it would have hit is here too).
+	other, err := a.tasks.Create("Other task", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherStat, err := os.Stat(other.FilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ag := &agent.Agent{
+		ID:        "orch-agent",
+		TaskID:    "",
+		Mode:      "interactive",
+		StartedAt: other.CreatedAt,
+	}
+
+	// Should not panic, and should not touch any task file. The historical
+	// bug created/touched ".md" in tasksDir; assert no such file exists.
+	a.onAgentComplete(ag)
+
+	if _, err := os.Stat(filepath.Join(a.tasksDir, ".md")); !os.IsNotExist(err) {
+		t.Errorf("expected no .md file in tasks dir, got err=%v", err)
+	}
+	otherStat2, err := os.Stat(other.FilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !otherStat.ModTime().Equal(otherStat2.ModTime()) {
+		t.Errorf("unrelated task file was rewritten: mtime %v -> %v", otherStat.ModTime(), otherStat2.ModTime())
+	}
+}
+
 func TestNewApp(t *testing.T) {
 	cfg := testConfig(t)
 	a := NewApp(discardLogger(), &slog.LevelVar{}, cfg)

--- a/internal/logging/throttle.go
+++ b/internal/logging/throttle.go
@@ -1,0 +1,60 @@
+package logging
+
+import (
+	"log/slog"
+	"sync"
+)
+
+// ErrorThrottle suppresses repeated identical error log entries that would
+// otherwise dominate the log when a transient or unfixable failure recurs on
+// every poller tick (e.g. todoist outage, restart-stale loop hitting an
+// unrunnable task once a minute).
+//
+// On the first occurrence of a given (key, err) pair the throttle logs at
+// ERROR. While the same error keeps recurring under that key the throttle
+// downgrades subsequent entries to DEBUG. A different error message under the
+// same key — or an explicit Clear after success — re-arms the ERROR log so
+// state changes are never lost.
+type ErrorThrottle struct {
+	mu   sync.Mutex
+	last map[string]string
+}
+
+// NewErrorThrottle returns an empty throttle ready for use.
+func NewErrorThrottle() *ErrorThrottle {
+	return &ErrorThrottle{last: make(map[string]string)}
+}
+
+// Log emits err under msg. The first occurrence (or any change in err.Error()
+// for the given key) is logged at ERROR; identical repeats are logged at DEBUG.
+// attrs are forwarded to slog as key/value pairs.
+func (t *ErrorThrottle) Log(logger *slog.Logger, msg, key string, err error, attrs ...any) {
+	if err == nil {
+		t.Clear(key)
+		return
+	}
+	cur := err.Error()
+	t.mu.Lock()
+	prev, seen := t.last[key]
+	repeat := seen && prev == cur
+	t.last[key] = cur
+	t.mu.Unlock()
+
+	out := make([]any, 0, len(attrs)+2)
+	out = append(out, attrs...)
+	out = append(out, "err", err)
+	if repeat {
+		logger.Debug(msg, out...)
+		return
+	}
+	logger.Error(msg, out...)
+}
+
+// Clear forgets the last-error state for key. Call after a successful run so
+// the next failure is logged at ERROR even if the message matches a stale
+// suppressed value.
+func (t *ErrorThrottle) Clear(key string) {
+	t.mu.Lock()
+	delete(t.last, key)
+	t.mu.Unlock()
+}

--- a/internal/logging/throttle_test.go
+++ b/internal/logging/throttle_test.go
@@ -1,0 +1,113 @@
+package logging
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func newTestLogger(t *testing.T) (*slog.Logger, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return slog.New(h), &buf
+}
+
+func countLines(buf *bytes.Buffer, substr string) int {
+	n := 0
+	for line := range strings.SplitSeq(buf.String(), "\n") {
+		if strings.Contains(line, substr) {
+			n++
+		}
+	}
+	return n
+}
+
+func TestErrorThrottle_FirstErrorAtError(t *testing.T) {
+	t.Parallel()
+	logger, buf := newTestLogger(t)
+	th := NewErrorThrottle()
+
+	th.Log(logger, "todoist.import", "import", errors.New("dial: no host"))
+
+	if got := countLines(buf, "level=ERROR"); got != 1 {
+		t.Fatalf("ERROR lines = %d, want 1", got)
+	}
+}
+
+func TestErrorThrottle_RepeatDowngradedToDebug(t *testing.T) {
+	t.Parallel()
+	logger, buf := newTestLogger(t)
+	th := NewErrorThrottle()
+
+	for range 5 {
+		th.Log(logger, "todoist.import", "import", errors.New("dial: no host"))
+	}
+
+	if got := countLines(buf, "level=ERROR"); got != 1 {
+		t.Errorf("ERROR lines = %d, want 1", got)
+	}
+	if got := countLines(buf, "level=DEBUG"); got != 4 {
+		t.Errorf("DEBUG lines = %d, want 4", got)
+	}
+}
+
+func TestErrorThrottle_DifferentErrorReArms(t *testing.T) {
+	t.Parallel()
+	logger, buf := newTestLogger(t)
+	th := NewErrorThrottle()
+
+	th.Log(logger, "todoist.import", "import", errors.New("dial: no host"))
+	th.Log(logger, "todoist.import", "import", errors.New("dial: no host"))
+	th.Log(logger, "todoist.import", "import", errors.New("HTTP 500"))
+
+	if got := countLines(buf, "level=ERROR"); got != 2 {
+		t.Errorf("ERROR lines = %d, want 2", got)
+	}
+}
+
+func TestErrorThrottle_ClearReArms(t *testing.T) {
+	t.Parallel()
+	logger, buf := newTestLogger(t)
+	th := NewErrorThrottle()
+
+	err := errors.New("dial: no host")
+	th.Log(logger, "todoist.import", "import", err)
+	th.Clear("import")
+	th.Log(logger, "todoist.import", "import", err)
+
+	if got := countLines(buf, "level=ERROR"); got != 2 {
+		t.Errorf("ERROR lines = %d, want 2", got)
+	}
+}
+
+func TestErrorThrottle_NilErrorClears(t *testing.T) {
+	t.Parallel()
+	logger, _ := newTestLogger(t)
+	th := NewErrorThrottle()
+
+	th.Log(logger, "todoist.import", "import", errors.New("boom"))
+	th.Log(logger, "todoist.import", "import", nil) // success: clears state
+	th.mu.Lock()
+	_, present := th.last["import"]
+	th.mu.Unlock()
+	if present {
+		t.Error("expected entry to be cleared after nil err")
+	}
+}
+
+func TestErrorThrottle_KeysAreIndependent(t *testing.T) {
+	t.Parallel()
+	logger, buf := newTestLogger(t)
+	th := NewErrorThrottle()
+
+	err := errors.New("same message")
+	th.Log(logger, "op", "task-a", err)
+	th.Log(logger, "op", "task-b", err)
+
+	if got := countLines(buf, "level=ERROR"); got != 2 {
+		t.Errorf("ERROR lines = %d, want 2 (one per key)", got)
+	}
+}

--- a/internal/poll/todoist.go
+++ b/internal/poll/todoist.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Automaat/synapse/internal/audit"
 	"github.com/Automaat/synapse/internal/config"
 	"github.com/Automaat/synapse/internal/events"
+	"github.com/Automaat/synapse/internal/logging"
 	"github.com/Automaat/synapse/internal/task"
 	"github.com/Automaat/synapse/internal/todoist"
 )
@@ -25,6 +26,7 @@ type TodoistHandler struct {
 	audit      *audit.Logger
 	logger     *slog.Logger
 	emit       func(string, any)
+	throttle   *logging.ErrorThrottle
 }
 
 // NewTodoistHandler creates a TodoistHandler.
@@ -45,6 +47,7 @@ func NewTodoistHandler(
 		audit:      al,
 		logger:     logger,
 		emit:       emit,
+		throttle:   logging.NewErrorThrottle(),
 	}
 }
 
@@ -59,14 +62,10 @@ func (h *TodoistHandler) PollAndSync() time.Duration {
 	interval := time.Duration(h.cfg.PollSeconds) * time.Second
 
 	imported, importErr := h.ImportNewTasks()
-	if importErr != nil {
-		h.logger.Error("todoist.import", "err", importErr)
-	}
+	h.throttle.Log(h.logger, "todoist.import", "import", importErr)
 
 	completed, compErr := h.syncCompletions()
-	if compErr != nil {
-		h.logger.Error("todoist.complete", "err", compErr)
-	}
+	h.throttle.Log(h.logger, "todoist.complete", "complete", compErr)
 
 	if imported > 0 || completed > 0 {
 		h.logger.Info("todoist.synced", "imported", imported, "completed", completed)
@@ -147,8 +146,10 @@ func (h *TodoistHandler) syncCompletions() (int, error) {
 		if t.TodoistID == "" || t.Status != task.StatusDone {
 			continue
 		}
-		if closeErr := h.client.CloseTask(t.TodoistID); closeErr != nil {
-			h.logger.Error("todoist.close", "task_id", t.ID, "todoist_id", t.TodoistID, "err", closeErr)
+		closeErr := h.client.CloseTask(t.TodoistID)
+		h.throttle.Log(h.logger, "todoist.close", "close:"+t.TodoistID, closeErr,
+			"task_id", t.ID, "todoist_id", t.TodoistID)
+		if closeErr != nil {
 			continue
 		}
 		h.logAudit(audit.EventTodoistCompleted, t.ID, "", map[string]any{

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Automaat/synapse/internal/logging"
 )
 
 const (
@@ -70,27 +72,29 @@ type PRLinker interface {
 
 // Engine executes workflow definitions against tasks.
 type Engine struct {
-	store      *Store
-	tasks      TaskProvider
-	agents     AgentLauncher
-	prLinker   PRLinker
-	logger     *slog.Logger
-	ctx        context.Context
-	mu         sync.Mutex
-	inflight   map[string]struct{} // taskID → step in flight (prevent double-advance)
-	agentSteps map[string]string   // agentID → stepID it was spawned for
+	store       *Store
+	tasks       TaskProvider
+	agents      AgentLauncher
+	prLinker    PRLinker
+	logger      *slog.Logger
+	ctx         context.Context
+	mu          sync.Mutex
+	inflight    map[string]struct{} // taskID → step in flight (prevent double-advance)
+	agentSteps  map[string]string   // agentID → stepID it was spawned for
+	resumeError *logging.ErrorThrottle
 }
 
 // NewEngine creates a workflow engine.
 func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *slog.Logger) *Engine {
 	return &Engine{
-		store:      store,
-		tasks:      tasks,
-		agents:     agents,
-		logger:     logger,
-		ctx:        context.Background(),
-		inflight:   make(map[string]struct{}),
-		agentSteps: make(map[string]string),
+		store:       store,
+		tasks:       tasks,
+		agents:      agents,
+		logger:      logger,
+		ctx:         context.Background(),
+		inflight:    make(map[string]struct{}),
+		agentSteps:  make(map[string]string),
+		resumeError: logging.NewErrorThrottle(),
 	}
 }
 
@@ -574,9 +578,8 @@ func (e *Engine) ResumeStalled() {
 		}
 
 		e.logger.Info("workflow.resume-stalled", "task_id", t.ID, "step", step.ID)
-		if rErr := e.executeSteps(t.ID, &def, step, t.Workflow); rErr != nil {
-			e.logger.Error("workflow.resume-stalled.exec", "task_id", t.ID, "err", rErr)
-		}
+		rErr := e.executeSteps(t.ID, &def, step, t.Workflow)
+		e.resumeError.Log(e.logger, "workflow.resume-stalled.exec", t.ID, rErr, "task_id", t.ID)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Audit of `synapse.log` after the `agent_mode` validation PR turned up
three issues that together produced ~1.5k ERROR entries on one day:

1. **Empty TaskID crashes the agent-complete handler.** The
   orchestrator brain agent is launched with `TaskID=""` and rooted
   at `~/.synapse`. When it exits, `onAgentComplete` calls
   `tasks.UpdateRun("", ...)`, `workflow.HandleAgentComplete("")`,
   and `tasks.Get("")`. All three join the empty id to the tasks
   dir and fail with `open .synapse/tasks/.md: no such file or
   directory`. Logged ERROR every time the brain agent dies.

2. **Repeated identical errors dominate the log.** A single
   unrunnable task generated 821 `workflow.resume-stalled.exec`
   entries and 746 `restart-stale.failed` entries in one day.
   An overnight network blip produced 27 identical
   `todoist.import` / `todoist.close` ERROR lines. Operators lose
   the signal in the noise.

## Implementation information

**Fix 1** — `app.go onAgentComplete`: short-circuit storage paths
when `ag.TaskID == ""`. Audit logging stays so the orchestrator
brain lifecycle is still recorded. Test
`TestOnAgentComplete_EmptyTaskID_NoCrash` constructs a brain-agent
literal, calls the handler, and asserts no `.md` file is created
in the tasks dir and no unrelated task file is rewritten.

**Fix 2** — new `internal/logging.ErrorThrottle`. First occurrence
of an error under a key logs at ERROR; identical repeats under the
same key log at DEBUG; a different error or explicit `Clear` re-arms
ERROR. Six unit tests cover first/repeat/change/clear/nil/key
isolation.

**Fix 3** — wire the throttle into:
- `internal/poll/todoist.go` — `import`, `complete`, and per-task
  `close:<todoist-id>` keys.
- `app.go restartStaleInProgress` — `stale:<task-id>` and
  `pr-fix:<task-id>` keys.
- `internal/workflow/engine.go ResumeStalled` — keyed on task id.

Considered alternatives: rate-limit by time window (more complex,
needs a timer), or fix the underlying schedulers' precondition
checks (deeper change, doesn't address todoist). The throttle is
the smallest fix that addresses both unrunnable-task spam and
network-blip spam, and it's reusable for the next noisy poller.

## Supporting documentation

Follow-up to #347 (`fix(task): validate agent_mode`) — same
log-audit pass.

> Changelog: fix(app): suppress repeated error log spam