### PR TITLE
fix(skills): sync to ~/.synapse/.claude/skills

### DIFF
--- a/app.go
+++ b/app.go
@@ -694,6 +694,8 @@ func (a *App) syncDir(src, dst string) {
 	}
 	cleanSrc := filepath.Clean(src) + string(filepath.Separator)
 	cleanDst := filepath.Clean(dst) + string(filepath.Separator)
+
+	srcNames := make(map[string]struct{}, len(entries))
 	for _, e := range entries {
 		if e.IsDir() || filepath.Ext(e.Name()) != ".md" {
 			continue
@@ -712,6 +714,30 @@ func (a *App) syncDir(src, dst string) {
 			continue
 		}
 		a.syncFile(srcPath, dstPath)
+		srcNames[e.Name()] = struct{}{}
+	}
+
+	// Remove orphan .md files in dst that no longer exist in src.
+	dstEntries, err := os.ReadDir(dst)
+	if err != nil {
+		return
+	}
+	for _, e := range dstEntries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".md" {
+			continue
+		}
+		if _, ok := srcNames[e.Name()]; ok {
+			continue
+		}
+		dstPath := filepath.Join(filepath.Clean(dst), e.Name())
+		if !strings.HasPrefix(dstPath+string(filepath.Separator), cleanDst) {
+			continue
+		}
+		if err := os.Remove(dstPath); err != nil {
+			a.logger.Warn("sync.orphan.remove.fail", "file", e.Name(), "err", err)
+		} else {
+			a.logger.Info("sync.orphan.removed", "file", e.Name())
+		}
 	}
 }
 

--- a/app_test.go
+++ b/app_test.go
@@ -435,6 +435,40 @@ func TestSyncDir(t *testing.T) {
 	}
 }
 
+func TestSyncDirRemovesOrphans(t *testing.T) {
+	a := setupApp(t)
+
+	srcDir := filepath.Join(t.TempDir(), "skills")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "keep.md"), []byte("# keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dstDir := filepath.Join(t.TempDir(), "dst-skills")
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-populate orphan file that should be removed.
+	if err := os.WriteFile(filepath.Join(dstDir, "orphan.md"), []byte("# orphan"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a.syncDir(srcDir, dstDir)
+
+	entries, err := os.ReadDir(dstDir)
+	if err != nil {
+		t.Fatalf("read dst: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("got %d files, want 1 (orphan removed)", len(entries))
+	}
+	if entries[0].Name() != "keep.md" {
+		t.Errorf("expected keep.md, got %s", entries[0].Name())
+	}
+}
+
 func TestSyncDirMissingSrc(t *testing.T) {
 	a := setupApp(t)
 	dstDir := filepath.Join(t.TempDir(), "should-not-exist")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -242,7 +242,7 @@ func defaultTasksDir() string {
 }
 
 func defaultSkillsDir() string {
-	return filepath.Join(HomeDir(), "skills")
+	return filepath.Join(HomeDir(), ".claude", "skills")
 }
 
 func defaultProjectsDir() string {


### PR DESCRIPTION
## Motivation

Orchestrator sessions (cwd=~/.synapse) hit Unknown skill: synapse-triage and Unknown skill: synapse-monitor 18 times across 2026-04-11 sessions. Claude Code resolves skills from <cwd>/.claude/skills/ but syncSkills() was writing to ~/.synapse/skills/ — a path CC never reads.

## Implementation information

- internal/config/config.go: defaultSkillsDir() now returns ~/.synapse/.claude/skills/ instead of ~/.synapse/skills/
- app.go syncDir(): after copying src files, reads dst and removes any orphan .md files not present in src (cleans up stale skill.md left from old sync path)
- app_test.go: added TestSyncDirRemovesOrphans covering the orphan removal path

> Changelog: fix(skills): sync to ~/.synapse/.claude/skills

Closes https://github.com/Automaat/synapse/issues/350