### PR TITLE
fix(task): skip plan sidecar files in Store.List()

### DIFF
--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/Automaat/synapse/internal/fsutil"
@@ -50,6 +51,10 @@ func (s *Store) List() ([]Task, error) {
 
 	var tasks []Task
 	for _, p := range paths {
+		base := filepath.Base(p)
+		if strings.HasSuffix(base, ".plan.md") || strings.HasSuffix(base, ".plan-critique.md") {
+			continue
+		}
 		t, err := Parse(p)
 		if err != nil {
 			slog.Default().Warn("task.parse.skip", "file", filepath.Base(p), "err", err)

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -597,6 +597,41 @@ func TestStoreUpdateRunNoMatchingAgent(t *testing.T) {
 	}
 }
 
+func TestStoreListSkipsPlanSidecars(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	task, err := store.Create("Real task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write plan and plan-critique sidecars
+	for _, name := range []string{
+		task.ID + ".plan.md",
+		task.ID + ".plan-critique.md",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("# plan content"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tasks, err := store.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 {
+		t.Errorf("got %d tasks, want 1 (sidecars must be skipped)", len(tasks))
+	}
+	if tasks[0].ID != task.ID {
+		t.Errorf("task ID = %q, want %q", tasks[0].ID, task.ID)
+	}
+}
+
 func TestStoreCreateDefaultMode(t *testing.T) {
 	t.Parallel()
 	store, err := NewStore(t.TempDir())


### PR DESCRIPTION
## Motivation

\`Store.List()\` parsed every \`.md\` file in the tasks dir, including \`<id>.plan.md\` and \`<id>.plan-critique.md\` sidecars. These have no task frontmatter, causing repeated WARN log lines every \`synapse-cli list\` call — 19 warnings per orchestrator monitor cycle.

## Implementation information

Added suffix check in \`Store.List()\` before attempting to parse: skip any file whose basename ends with \`.plan.md\` or \`.plan-critique.md\`. These suffixes are owned by \`PlanStore\` / \`PlanCritiqueStore\` and are already read via \`s.plans.Read(t.ID)\` after successful task parse.

Added \`TestStoreListSkipsPlanSidecars\`: tasks dir with \`abc.md\` (valid task) + \`abc.plan.md\` + \`abc.plan-critique.md\` → \`List()\` returns 1 task.

> Changelog: fix(task): skip plan sidecar files in Store.List()

Closes https://github.com/Automaat/synapse/issues/351