### PR TITLE
feat(workflow): add verify_commits step before eval

### DIFF
--- a/app.go
+++ b/app.go
@@ -370,6 +370,7 @@ func (a *App) initWorkflowEngine() {
 		a.logger,
 	)
 	a.workflowEngine.SetPRLinker(prLinkerAdapter{})
+	a.workflowEngine.SetWorktreeGetter(&worktreeGetterAdapter{tasks: a.tasks, mgr: a.worktrees})
 	a.workflowEngine.SetContext(a.ctx)
 }
 

--- a/app_workflow.go
+++ b/app_workflow.go
@@ -3,19 +3,22 @@ package main
 import (
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/Automaat/synapse/internal/agent"
 	"github.com/Automaat/synapse/internal/config"
 	"github.com/Automaat/synapse/internal/github"
 	"github.com/Automaat/synapse/internal/task"
 	"github.com/Automaat/synapse/internal/workflow"
+	"github.com/Automaat/synapse/internal/worktree"
 )
 
 // Compile-time interface checks.
 var (
-	_ workflow.TaskProvider  = (*taskAdapter)(nil)
-	_ workflow.AgentLauncher = (*agentAdapter)(nil)
-	_ workflow.PRLinker      = (*prLinkerAdapter)(nil)
+	_ workflow.TaskProvider   = (*taskAdapter)(nil)
+	_ workflow.AgentLauncher  = (*agentAdapter)(nil)
+	_ workflow.PRLinker       = (*prLinkerAdapter)(nil)
+	_ workflow.WorktreeGetter = (*worktreeGetterAdapter)(nil)
 )
 
 // taskAdapter bridges task.Manager → workflow.TaskProvider.
@@ -89,6 +92,24 @@ func (prLinkerAdapter) GetClosingIssues(repo string, prNumber int) (issues []int
 
 func (prLinkerAdapter) EditBody(repo string, prNumber int, body string) error {
 	return github.EditPRBody(repo, prNumber, body)
+}
+
+// worktreeGetterAdapter bridges worktree.Manager + task.Manager → workflow.WorktreeGetter.
+type worktreeGetterAdapter struct {
+	tasks *task.Manager
+	mgr   *worktree.Manager
+}
+
+func (a *worktreeGetterAdapter) GetWorktreePath(taskID string) (string, bool) {
+	t, err := a.tasks.Get(taskID)
+	if err != nil {
+		return "", false
+	}
+	path := a.mgr.PathFor(t)
+	if _, err := os.Stat(path); err != nil {
+		return "", false
+	}
+	return path, true
 }
 
 // agentAdapter bridges agent.Manager + AgentOrchestrator → workflow.AgentLauncher.

--- a/internal/workflow/builtin/pr-fix.yaml
+++ b/internal/workflow/builtin/pr-fix.yaml
@@ -27,6 +27,21 @@ steps:
       prompt: >-
         {{ getvar .Vars "prompt" }}
     next:
+      - goto: verify_commits
+
+  # Mechanical check (no LLM): verifies the task's branch has at least one
+  # commit ahead of origin/main before running eval. Flips to human-required
+  # with reason "no commits pushed to branch" when the branch is empty.
+  # Skips gracefully when no worktree exists (e.g. task has no project).
+  - id: verify_commits
+    name: Verify Commits
+    type: verify_commits
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
       - goto: evaluate
 
   - id: evaluate

--- a/internal/workflow/builtin/simple-task.yaml
+++ b/internal/workflow/builtin/simple-task.yaml
@@ -202,6 +202,21 @@ steps:
         {{.Task.Plan}}
         {{- end}}
     next:
+      - goto: verify_commits
+
+  # Mechanical check (no LLM): verifies the task's branch has at least one
+  # commit ahead of origin/main before running eval. Flips to human-required
+  # with reason "no commits pushed to branch" when the branch is empty.
+  # Skips gracefully when no worktree exists (e.g. task has no project).
+  - id: verify_commits
+    name: Verify Commits
+    type: verify_commits
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
       - goto: evaluate
 
   - id: evaluate

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -57,6 +57,14 @@ type TaskProvider interface {
 	SetWorkflow(id string, wf *Execution) error
 }
 
+// WorktreeGetter resolves the filesystem path of a task's git worktree.
+// Returns (path, true) when a worktree exists for the task; ("", false) when
+// none is found. Implementations may stat the path to confirm existence.
+// Engine operates with a nil WorktreeGetter — verify_commits becomes a no-op.
+type WorktreeGetter interface {
+	GetWorktreePath(taskID string) (string, bool)
+}
+
 // PRLinker inspects and updates GitHub pull request metadata for the
 // `ensure_pr_closes_issue` step. Implementations wrap `gh` CLI calls.
 // Engine operates with a nil PRLinker — the step becomes a no-op when
@@ -76,6 +84,7 @@ type Engine struct {
 	tasks       TaskProvider
 	agents      AgentLauncher
 	prLinker    PRLinker
+	worktrees   WorktreeGetter
 	logger      *slog.Logger
 	ctx         context.Context
 	mu          sync.Mutex
@@ -109,6 +118,10 @@ func (e *Engine) Defs() *Store { return e.store }
 // SetPRLinker wires an implementation of PRLinker used by the
 // `ensure_pr_closes_issue` step. Leaving it unset makes the step a no-op.
 func (e *Engine) SetPRLinker(l PRLinker) { e.prLinker = l }
+
+// SetWorktreeGetter wires a WorktreeGetter used by the `verify_commits` step.
+// Leaving it unset makes the step a no-op.
+func (e *Engine) SetWorktreeGetter(g WorktreeGetter) { e.worktrees = g }
 
 // StartWorkflow assigns a workflow to a task and executes the first step.
 func (e *Engine) StartWorkflow(taskID, workflowID string) error {
@@ -639,7 +652,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			return e.execRunAgent(taskID, step, wfExec, ctx)
 		case StepWaitHuman:
 			return e.execWaitHuman(taskID, step, wfExec)
-		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue:
+		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepVerifyCommits:
 			// handled below as sync steps
 		default:
 			return fmt.Errorf("unknown step type %q", step.Type)
@@ -703,6 +716,8 @@ func (e *Engine) execSyncStep(taskID string, step *Step, wfExec *Execution, ctx 
 		return e.execShell(step, ctx)
 	case StepEnsurePRClosesIssue:
 		return e.execEnsurePRClosesIssue(taskID, step, t)
+	case StepVerifyCommits:
+		return e.execVerifyCommits(taskID, step, t)
 	default:
 		return StepOutput{}, fmt.Errorf("unknown step type %q", step.Type)
 	}
@@ -947,6 +962,50 @@ func (e *Engine) execEnsurePRClosesIssue(taskID string, step *Step, t TaskInfo) 
 		msg = fmt.Sprintf("edited body to close #%d; last verify err: %s — trusting body contents", issueNum, verifyErr.Error())
 	}
 	return StepOutput{StepID: step.ID, Status: "completed", Output: msg}, nil
+}
+
+// execVerifyCommits checks that the task's branch has at least one commit
+// ahead of origin/main. This is a non-LLM mechanical gate that runs before
+// the eval agent to detect incomplete work without giving eval git access.
+//
+// Skip conditions (no-op, returns "completed"):
+//   - No WorktreeGetter configured
+//   - No worktree found for the task
+//   - git command error (e.g. remote unreachable, detached HEAD)
+//
+// When the branch has no commits ahead of origin/main the task is flipped to
+// human-required with reason "no commits pushed to branch" and the step
+// returns "completed" so the workflow can route to end via a task.status
+// transition condition rather than a failed step.
+func (e *Engine) execVerifyCommits(taskID string, step *Step, t TaskInfo) (StepOutput, error) {
+	if e.worktrees == nil {
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no worktree getter configured"}, nil
+	}
+	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
+	if !ok {
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no worktree for task"}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "log", "origin/main..HEAD", "--oneline")
+	cmd.Dir = wtPath
+	output, err := cmd.Output()
+	if err != nil {
+		e.logger.Warn("workflow.verify-commits.git-error", "task_id", taskID, "worktree", wtPath, "err", err)
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: git error: " + err.Error()}, nil
+	}
+
+	if strings.TrimSpace(string(output)) == "" {
+		reason := "no commits pushed to branch"
+		if statusErr := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); statusErr != nil {
+			e.logger.Error("workflow.verify-commits.status", "task_id", taskID, "err", statusErr)
+		}
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "no commits: flipped to human-required"}, nil
+	}
+
+	return StepOutput{StepID: step.ID, Status: "completed", Output: "commits verified"}, nil
 }
 
 // parseIssueURL extracts owner/repo and issue number from a GitHub

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -2220,5 +2221,161 @@ func TestParseIssueURL(t *testing.T) {
 					tt.url, gotRepo, gotNum, tt.wantRepo, tt.wantNum)
 			}
 		})
+	}
+}
+
+// --- verify_commits step ---
+
+// fakeWorktreeGetter is a scripted WorktreeGetter for tests.
+type fakeWorktreeGetter struct {
+	path string
+	ok   bool
+}
+
+func (f *fakeWorktreeGetter) GetWorktreePath(_ string) (string, bool) {
+	return f.path, f.ok
+}
+
+func newVerifyCommitsStep() *Step {
+	return &Step{ID: "verify", Type: StepVerifyCommits}
+}
+
+// makeGitRepo creates a bare-minimum git repo with an initial commit on main
+// and optionally an extra commit on the current HEAD (simulating a task branch
+// that is ahead of origin/main).
+//
+// Returns the worktree directory path.
+func makeGitRepo(t *testing.T, withExtraCommit bool) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	run("init", "-b", "main")
+	run("config", "user.email", "test@test.com")
+	run("config", "user.name", "Test")
+
+	// Create initial commit so origin/main exists.
+	f := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(f, []byte("init\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "README.md")
+	run("commit", "-m", "init")
+
+	// Teach git about a local "remote" so origin/main resolves.
+	// We use the repo itself as its own origin (bare clone not needed for tests).
+	run("remote", "add", "origin", dir)
+	run("fetch", "origin")
+
+	if withExtraCommit {
+		f2 := filepath.Join(dir, "change.txt")
+		if err := os.WriteFile(f2, []byte("change\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		run("add", "change.txt")
+		run("commit", "-m", "feat: task work")
+	}
+
+	return dir
+}
+
+func TestExecVerifyCommits_NoGetterSkips(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	// worktrees nil by default
+
+	ti := TaskInfo{ID: "t1"}
+	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), ti)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed", out.Status)
+	}
+	if !strings.Contains(out.Output, "skipped") {
+		t.Errorf("Output = %q, want skipped", out.Output)
+	}
+}
+
+func TestExecVerifyCommits_NoWorktreeSkips(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{ok: false})
+
+	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed", out.Status)
+	}
+	if !strings.Contains(out.Output, "skipped") {
+		t.Errorf("Output = %q, want skipped", out.Output)
+	}
+}
+
+func TestExecVerifyCommits_WithCommitsVerified(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	wtDir := makeGitRepo(t, true /* withExtraCommit */)
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
+
+	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed", out.Status)
+	}
+	if !strings.Contains(out.Output, "commits verified") {
+		t.Errorf("Output = %q, want 'commits verified'", out.Output)
+	}
+	// Task status must not change.
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "in-progress" {
+		t.Errorf("task status = %q, want in-progress", ti.Status)
+	}
+}
+
+func TestExecVerifyCommits_NoCommitsFlipsHumanRequired(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	wtDir := makeGitRepo(t, false /* no extra commit */)
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
+
+	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed", out.Status)
+	}
+	if !strings.Contains(out.Output, "no commits") {
+		t.Errorf("Output = %q, want 'no commits'", out.Output)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "human-required" {
+		t.Errorf("task status = %q, want human-required", ti.Status)
 	}
 }

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -67,6 +67,7 @@ const (
 	StepCondition           StepType = "condition"
 	StepShell               StepType = "shell"
 	StepEnsurePRClosesIssue StepType = "ensure_pr_closes_issue"
+	StepVerifyCommits       StepType = "verify_commits"
 )
 
 // Step is one node in the workflow graph.


### PR DESCRIPTION
## Motivation

Eval (`RoleEval`) is a system role that runs in `~/.synapse` with no worktree access. Any git commands inside eval (e.g. `git log`, `gh pr create`) silently fail or run against the wrong directory. Issue #355 tracks removing git from eval entirely; this PR closes the gap by adding a mechanical pre-eval gate.

## Implementation information

Adds a new `verify_commits` workflow step (`StepVerifyCommits`) that runs before `eval` in both `simple-task.yaml` and `pr-fix.yaml`. The step:

- Calls `git log origin/main..HEAD --oneline` in the task's worktree
- If output is empty → flips task to `human-required` with reason `"no commits pushed to branch"` and the workflow ends (transition on `task.status == human-required`)
- If commits exist → proceeds to `evaluate` as before
- Skips gracefully (no-op `completed`) when: no `WorktreeGetter` wired, no worktree found for task, or `git` returns an error

New types:
- `workflow.WorktreeGetter` interface — resolves task ID → worktree path
- `worktreeGetterAdapter` in `app_workflow.go` — bridges `task.Manager` + `worktree.Manager`
- Wired via `Engine.SetWorktreeGetter()` in `app.go` alongside `SetPRLinker`

Eval remains a system role running in `~/.synapse` — no change to its cwd logic.

> Changelog: feat(workflow): add verify_commits step before eval

## Supporting documentation

Closes #355