### PR TITLE
feat(agent): add log viewer for history

### DIFF
--- a/app.go
+++ b/app.go
@@ -351,6 +351,7 @@ func (a *App) onAgentComplete(ag *agent.Agent) {
 		"state":    string(state),
 		"cost_usd": cost,
 		"result":   truncated,
+		"log_file": ag.LogPath,
 	}); err != nil {
 		a.logger.Error("task.update-run", "task_id", ag.TaskID, "agent_id", ag.ID, "err", err)
 	}
@@ -419,6 +420,9 @@ func (a *App) wireServices(emit func(string, any)) {
 	a.agentSvc.agents = a.agents
 	a.agentSvc.tmux = a.tmux
 	a.agentSvc.logger = a.logger
+	a.agentSvc.tasks = a.tasks
+	a.agentSvc.cfg = a.cfg
+	a.agentSvc.logsDir = a.logDir
 	a.orchSvc.agents = a.agents
 	a.orchSvc.audit = a.audit
 	a.orchSvc.logger = a.logger

--- a/frontend/src/components/ChatView.svelte
+++ b/frontend/src/components/ChatView.svelte
@@ -11,9 +11,10 @@
     costUsd?: number
     inputTokens?: number
     outputTokens?: number
+    bounded?: boolean
   }
 
-  const { agentId, agentState = 'running', costUsd = 0, inputTokens = 0, outputTokens = 0 }: Props = $props()
+  const { agentId, agentState = 'running', costUsd = 0, inputTokens = 0, outputTokens = 0, bounded = false }: Props = $props()
 
   let events = $state<agent.ConvoEvent[]>([])
   let container: HTMLDivElement | undefined = $state()
@@ -106,7 +107,7 @@
   <!-- Messages -->
   <div
     bind:this={container}
-    class="flex flex-1 flex-col gap-3 overflow-y-auto px-4 py-3"
+    class="flex flex-col gap-3 overflow-y-auto px-4 py-3 {bounded ? 'max-h-[600px]' : 'flex-1'}"
   >
     {#if events.length === 0}
       <p class="py-12 text-center text-sm text-surface-500">Waiting for response...</p>

--- a/frontend/src/components/StreamOutput.svelte
+++ b/frontend/src/components/StreamOutput.svelte
@@ -5,10 +5,11 @@
   import { agentOutput } from '../lib/events.js'
 
   interface Props {
-    agentId: string
+    agentId?: string
+    staticEvents?: agent.StreamEvent[]
   }
 
-  const { agentId }: Props = $props()
+  const { agentId, staticEvents }: Props = $props()
 
   let events = $state<agent.StreamEvent[]>([])
   let container: HTMLDivElement | undefined = $state()
@@ -28,6 +29,14 @@
   }
 
   $effect(() => {
+    if (staticEvents) {
+      events = staticEvents
+      requestAnimationFrame(scrollToBottom)
+      return
+    }
+
+    if (!agentId) return
+
     agentStore.getOutput(agentId).then((initial) => {
       events = initial
       scrollToBottom()

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -9,6 +9,7 @@
   import { agentStore } from '../stores/agents.svelte.js'
   import { reviewStore } from '../stores/reviews.svelte.js'
   import { STATUS_OPTIONS } from '../lib/statuses.js'
+  import { GetAgentRunLog } from '../../wailsjs/go/main/AgentService.js'
   import StreamOutput from '../components/StreamOutput.svelte'
   import TerminalView from '../components/TerminalView.svelte'
   import ChatView from '../components/ChatView.svelte'
@@ -293,6 +294,28 @@
   }
 
   let expandedRun = $state<string | null>(null)
+  let runLogEvents = $state<Map<string, agent.StreamEvent[]>>(new Map())
+  let runLogLoading = $state<Set<string>>(new Set())
+
+  async function toggleRunLog(agentId: string) {
+    if (expandedRun === agentId) {
+      expandedRun = null
+      return
+    }
+    expandedRun = agentId
+    if (!runLogEvents.has(agentId) && !runLogLoading.has(agentId) && taskId) {
+      runLogLoading = new Set([...runLogLoading, agentId])
+      try {
+        const events = await GetAgentRunLog(taskId, agentId)
+        runLogEvents = new Map([...runLogEvents, [agentId, events ?? []]])
+      } catch {
+        runLogEvents = new Map([...runLogEvents, [agentId, []]])
+      }
+      const next = new Set(runLogLoading)
+      next.delete(agentId)
+      runLogLoading = next
+    }
+  }
 
   const pastRuns = $derived(
     (t?.agentRuns ?? []).slice().reverse()
@@ -673,7 +696,7 @@
             {/if}
           </div>
           {#if runningAgent.mode === 'interactive' && !runningAgent.tmuxSession}
-            <ChatView agentId={runningAgent.id} agentState={runningAgent.state} costUsd={runningAgent.costUsd} inputTokens={runningAgent.inputTokens ?? 0} outputTokens={runningAgent.outputTokens ?? 0} />
+            <ChatView agentId={runningAgent.id} agentState={runningAgent.state} costUsd={runningAgent.costUsd} inputTokens={runningAgent.inputTokens ?? 0} outputTokens={runningAgent.outputTokens ?? 0} bounded={true} />
           {:else if runningAgent.mode === 'interactive' && runningAgent.tmuxSession}
             <TerminalView agentId={runningAgent.id} />
           {:else}
@@ -720,7 +743,7 @@
               <button
                 type="button"
                 class="flex w-full items-center justify-between px-3 py-2 text-left text-xs"
-                onclick={() => { expandedRun = expandedRun === run.agentId ? null : run.agentId }}
+                onclick={() => toggleRunLog(run.agentId)}
               >
                 <div class="flex items-center gap-2">
                   <span class="font-mono text-surface-400">{run.agentId}</span>
@@ -739,9 +762,17 @@
                   </svg>
                 </div>
               </button>
-              {#if expandedRun === run.agentId && run.result}
+              {#if expandedRun === run.agentId}
                 <div class="border-t border-surface-300 px-3 py-2 dark:border-surface-600">
-                  <pre class="whitespace-pre-wrap text-xs text-surface-300">{run.result}</pre>
+                  {#if runLogLoading.has(run.agentId)}
+                    <p class="py-4 text-center text-xs text-surface-500">Loading log...</p>
+                  {:else if (runLogEvents.get(run.agentId)?.length ?? 0) > 0}
+                    <StreamOutput staticEvents={runLogEvents.get(run.agentId)} />
+                  {:else if run.result}
+                    <pre class="max-h-[600px] overflow-y-auto whitespace-pre-wrap rounded-lg border border-surface-300 bg-surface-900 p-3 text-xs text-surface-300 dark:border-surface-600">{run.result}</pre>
+                  {:else}
+                    <p class="py-4 text-center text-xs text-surface-500">No output available</p>
+                  {/if}
                 </div>
               {/if}
             </div>

--- a/frontend/wailsjs/go/main/AgentService.d.ts
+++ b/frontend/wailsjs/go/main/AgentService.d.ts
@@ -13,6 +13,8 @@ export function DiscoverAgents():Promise<Array<agent.Agent>>;
 
 export function GetAgentOutput(arg1:string):Promise<Array<agent.StreamEvent>>;
 
+export function GetAgentRunLog(arg1:string,arg2:string):Promise<Array<agent.StreamEvent>>;
+
 export function GetConvoOutput(arg1:string):Promise<Array<agent.ConvoEvent>>;
 
 export function KillTmuxSession(arg1:string):Promise<void>;

--- a/frontend/wailsjs/go/main/AgentService.js
+++ b/frontend/wailsjs/go/main/AgentService.js
@@ -22,6 +22,10 @@ export function GetAgentOutput(arg1) {
   return window['go']['main']['AgentService']['GetAgentOutput'](arg1);
 }
 
+export function GetAgentRunLog(arg1, arg2) {
+  return window['go']['main']['AgentService']['GetAgentRunLog'](arg1, arg2);
+}
+
 export function GetConvoOutput(arg1) {
   return window['go']['main']['AgentService']['GetConvoOutput'](arg1);
 }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -204,6 +204,7 @@ export namespace config {
 	    maxCostUsd: number;
 	    maxTurns: number;
 	    requirePermissions?: boolean;
+	    maxLogEvents: number;
 	
 	    static createFrom(source: any = {}) {
 	        return new AgentDefaults(source);
@@ -219,6 +220,7 @@ export namespace config {
 	        this.maxCostUsd = source["maxCostUsd"];
 	        this.maxTurns = source["maxTurns"];
 	        this.requirePermissions = source["requirePermissions"];
+	        this.maxLogEvents = source["maxLogEvents"];
 	    }
 	}
 	export class AuditConfig {

--- a/internal/agent/logfile.go
+++ b/internal/agent/logfile.go
@@ -1,0 +1,52 @@
+package agent
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ParseLogFile reads an NDJSON agent log and returns up to maxEvents
+// StreamEvents (the last N if the file exceeds the cap).
+// Malformed lines are silently skipped.
+func ParseLogFile(path string, maxEvents int) ([]StreamEvent, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	var events []StreamEvent
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 256*1024), 1024*1024)
+	for sc.Scan() {
+		var ev StreamEvent
+		if json.Unmarshal(sc.Bytes(), &ev) != nil || ev.Type == "" {
+			continue
+		}
+		events = append(events, ev)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	if maxEvents > 0 && len(events) > maxEvents {
+		events = events[len(events)-maxEvents:]
+	}
+	return events, nil
+}
+
+// FindLogFile locates the NDJSON log for agentID inside logsDir/agents/ by
+// globbing "{agentID}-*.ndjson". Returns the first match or an error.
+func FindLogFile(logsDir, agentID string) (string, error) {
+	pattern := filepath.Join(logsDir, "agents", agentID+"-*.ndjson")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return "", err
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no log file for agent %s", agentID)
+	}
+	return matches[0], nil
+}

--- a/internal/agent/logfile_test.go
+++ b/internal/agent/logfile_test.go
@@ -1,0 +1,101 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseLogFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.ndjson")
+
+	lines := `{"type":"init","content":"session started"}
+{"type":"assistant","content":"hello world"}
+bad line
+{"type":"tool_use","content":"Read file.go"}
+{"type":"result","content":"done"}
+`
+	if err := os.WriteFile(path, []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	events, err := ParseLogFile(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 4 {
+		t.Fatalf("expected 4 events, got %d", len(events))
+	}
+	if events[0].Type != "init" {
+		t.Errorf("expected init, got %s", events[0].Type)
+	}
+	if events[3].Type != "result" {
+		t.Errorf("expected result, got %s", events[3].Type)
+	}
+}
+
+func TestParseLogFile_MaxEvents(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.ndjson")
+
+	lines := `{"type":"assistant","content":"msg1"}
+{"type":"assistant","content":"msg2"}
+{"type":"assistant","content":"msg3"}
+{"type":"result","content":"done"}
+`
+	if err := os.WriteFile(path, []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	events, err := ParseLogFile(path, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events (tail), got %d", len(events))
+	}
+	if events[0].Content != "msg3" {
+		t.Errorf("expected msg3, got %s", events[0].Content)
+	}
+	if events[1].Content != "done" {
+		t.Errorf("expected done, got %s", events[1].Content)
+	}
+}
+
+func TestFindLogFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	agentsDir := filepath.Join(dir, "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	name := "abc123-2026-04-12T10-00-00.ndjson"
+	if err := os.WriteFile(filepath.Join(agentsDir, name), []byte(`{"type":"init"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := FindLogFile(dir, "abc123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if filepath.Base(got) != name {
+		t.Errorf("expected %s, got %s", name, filepath.Base(got))
+	}
+}
+
+func TestFindLogFile_NotFound(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "agents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := FindLogFile(dir, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing log file")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,17 @@ type AgentDefaults struct {
 	// nil means not configured (falls back to true — safe default).
 	// Set to false in config to opt all tasks into skip-permissions mode.
 	RequirePermissions *bool `yaml:"require_permissions" json:"requirePermissions"`
+	// MaxLogEvents caps how many NDJSON events are returned when replaying
+	// a completed agent's log file. 0 means use DefaultMaxLogEvents (500).
+	MaxLogEvents int `yaml:"max_log_events" json:"maxLogEvents"`
+}
+
+// DefaultMaxLogEvents returns the configured cap or 500 if unset.
+func (c *Config) DefaultMaxLogEvents() int {
+	if c != nil && c.Agent.MaxLogEvents > 0 {
+		return c.Agent.MaxLogEvents
+	}
+	return 500
 }
 
 // DefaultRequirePermissions returns the configured default, or true if unset.

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -254,6 +254,9 @@ func (s *Store) UpdateRun(taskID, agentID string, updates map[string]any) error 
 		if v, ok := updates["result"].(string); ok {
 			t.AgentRuns[i].Result = v
 		}
+		if v, ok := updates["log_file"].(string); ok {
+			t.AgentRuns[i].LogFile = v
+		}
 		break
 	}
 	d, err := Marshal(t)

--- a/svc_agents.go
+++ b/svc_agents.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 
 	"github.com/Automaat/synapse/internal/agent"
+	"github.com/Automaat/synapse/internal/config"
+	"github.com/Automaat/synapse/internal/task"
 	"github.com/Automaat/synapse/internal/tmux"
 )
 
@@ -14,6 +16,9 @@ type AgentService struct {
 	tmux     *tmux.Manager
 	logger   *slog.Logger
 	approval *agent.ApprovalServer
+	tasks    *task.Manager
+	cfg      *config.Config
+	logsDir  string
 }
 
 // StopAgent sends a stop signal to the given agent.
@@ -93,6 +98,38 @@ func (s *AgentService) RespondApproval(toolUseID string, approved bool) error {
 // GetConvoOutput returns the full conversation event buffer for an agent.
 func (s *AgentService) GetConvoOutput(agentID string) ([]agent.ConvoEvent, error) {
 	return s.agents.GetConvoOutput(agentID)
+}
+
+// GetAgentRunLog returns stream events for a past or running agent.
+// Live agents return the in-memory buffer; completed agents are replayed
+// from the NDJSON log file on disk.
+func (s *AgentService) GetAgentRunLog(taskID, agentID string) ([]agent.StreamEvent, error) {
+	if ag, err := s.agents.GetAgent(agentID); err == nil {
+		return ag.Output(), nil
+	}
+
+	t, err := s.tasks.Get(taskID)
+	if err != nil {
+		return nil, fmt.Errorf("task %s: %w", taskID, err)
+	}
+
+	var logFile string
+	for i := range t.AgentRuns {
+		if t.AgentRuns[i].AgentID == agentID {
+			logFile = t.AgentRuns[i].LogFile
+			break
+		}
+	}
+
+	if logFile == "" {
+		var findErr error
+		logFile, findErr = agent.FindLogFile(s.logsDir, agentID)
+		if findErr != nil {
+			return nil, findErr
+		}
+	}
+
+	return agent.ParseLogFile(logFile, s.cfg.DefaultMaxLogEvents())
 }
 
 // RespondEscalation sends a human decision to a guardrail-paused agent.


### PR DESCRIPTION
## Motivation

Agent output was only held in-memory during execution. On completion, only a truncated result (2000 chars) was saved. NDJSON log files existed on disk but were never read back, so agent history showed empty or minimal output.

## Implementation information

**Backend:**
- Persist `log_file` path in `AgentRun` on agent completion (`app.go`, `store.go`)
- Add `ParseLogFile` + `FindLogFile` in `internal/agent/logfile.go` — NDJSON replay with configurable tail cap (`max_log_events` in config, default 500)
- Add `GetAgentRunLog(taskID, agentID)` bound method — returns live buffer for running agents, replays NDJSON from disk for completed ones
- `FindLogFile` globs by agent ID as fallback for pre-existing runs without persisted `log_file`

**Frontend:**
- `StreamOutput.svelte` — new `staticEvents` prop for rendering pre-fetched events (history mode)
- `ChatView.svelte` — new `bounded` prop; constrains messages to `max-h-[600px]` when embedded in task detail
- `TaskDetail.svelte` — agent history fetches full log on expand, renders via `StreamOutput`; falls back to `run.result` if no log file

All agent output containers (live + history) are now bounded to 600px max height with overflow scroll.