### PR TITLE
fix(orchestrator): drop auto-seed, use CronCreate

### DIFF
--- a/app.go
+++ b/app.go
@@ -427,7 +427,6 @@ func (a *App) wireServices(emit func(string, any)) {
 	a.orchSvc.audit = a.audit
 	a.orchSvc.logger = a.logger
 	a.orchSvc.emit = emit
-	a.orchSvc.cfg = a.cfg
 	a.projectSvc.projects = a.projects
 	a.projectSvc.worktrees = a.worktrees
 	a.projectSvc.logger = a.logger

--- a/orchestrator/CLAUDE.md
+++ b/orchestrator/CLAUDE.md
@@ -5,12 +5,21 @@ You are the Synapse orchestrator — an autonomous Claude Code session managing 
 ## Session runtime
 
 This session runs in-app as a conversational Claude agent (stream-json over
-stdin/stdout, not tmux). Your first user message is always
-`/loop 5m /synapse-monitor` — the app seeds it automatically on startup so the
-periodic monitor cycle begins immediately via the `loop` skill. Do not
-re-invoke `/loop` manually and do not stop it unless the human asks; the loop
-drives your core work cycle. Your output streams into a bounded box on the
+stdin/stdout, not tmux). Your output streams into a bounded box on the
 Orchestrator page, so prefer concise updates over verbose narration.
+
+## Starting the monitor loop
+
+On every session start, immediately set up the recurring monitor cycle via
+CronCreate:
+
+```
+CronCreate(schedule="*/5 * * * *", prompt="/synapse-monitor")
+```
+
+Do this before any other work. If a cron job with this prompt already exists,
+skip creation. The monitor loop drives your core work cycle — without it you
+will only act once and then idle.
 
 ## Core Loop
 

--- a/svc_orchestrator.go
+++ b/svc_orchestrator.go
@@ -15,27 +15,22 @@ import (
 // so the frontend and tests can identify it in agent listings.
 const orchestratorAgentName = "orchestrator"
 
-// orchestratorInitialPrompt bootstraps the periodic monitor loop. See
-// .claude/skills/synapse-monitor.md and the loop skill.
-const orchestratorInitialPrompt = "/loop 5m /synapse-monitor"
-
 // OrchestratorService exposes orchestrator session operations as Wails-bound methods.
 type OrchestratorService struct {
 	agents *agent.Manager
 	audit  *audit.Logger
 	logger *slog.Logger
 	emit   func(string, any)
-	cfg    *config.Config
 
 	mu      sync.Mutex
 	agentID string
 }
 
 // StartOrchestrator launches the orchestrator as an in-app conversational
-// Claude agent rooted at ~/.synapse (where the brain CLAUDE.md + skills live)
-// and seeds it with /loop 5m /synapse-monitor so the periodic monitor cycle
-// begins immediately. Provider is pinned to claude because /loop and
-// /synapse-monitor are Claude-only skills.
+// Claude agent rooted at ~/.synapse (where the brain CLAUDE.md + skills live).
+// The orchestrator bootstraps its own monitor loop via CronCreate on first
+// turn, as instructed by orchestrator/CLAUDE.md. Provider is pinned to claude
+// because /synapse-monitor is a Claude-only skill.
 func (s *OrchestratorService) StartOrchestrator() error {
 	s.mu.Lock()
 	if id := s.agentID; id != "" {
@@ -50,7 +45,6 @@ func (s *OrchestratorService) StartOrchestrator() error {
 	a, err := s.agents.Run(agent.RunConfig{
 		Name:                   orchestratorAgentName,
 		Mode:                   "interactive",
-		Prompt:                 orchestratorInitialPrompt,
 		Dir:                    config.HomeDir(),
 		Provider:               "claude",
 		IgnoreConcurrencyLimit: true,

--- a/svc_orchestrator_test.go
+++ b/svc_orchestrator_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/Automaat/synapse/internal/agent"
-	"github.com/Automaat/synapse/internal/config"
 	"github.com/Automaat/synapse/internal/tmux"
 )
 
@@ -23,7 +22,6 @@ func newOrchSvcForTest(t *testing.T) (*OrchestratorService, *agent.Manager, cont
 		agents: mgr,
 		logger: logger,
 		emit:   func(string, any) {},
-		cfg:    &config.Config{Agent: config.AgentDefaults{Provider: "codex"}},
 	}
 	return svc, mgr, cancel
 }


### PR DESCRIPTION
## Motivation

The `/loop 5m /synapse-monitor` auto-seed injected at session start was unreliable — session e114a717 bypassed it and called CronCreate directly. The backend-seeded initial prompt is a fragile mechanism; CronCreate is deterministic and idempotent.

## Implementation information

- Removed `orchestratorInitialPrompt` constant and `Prompt` field from `agent.RunConfig` in `StartOrchestrator()`
- Updated `orchestrator/CLAUDE.md`: replaced "app seeds it automatically" paragraph with explicit instruction to call `CronCreate(schedule="*/5 * * * *", prompt="/synapse-monitor")` on every session start, with an idempotency guard
- Removed unused `cfg *config.Config` field from `OrchestratorService` (pre-existing lint error)

Fixes #352

> Changelog: fix(orchestrator): drop auto-seed, use CronCreate