### PR TITLE
perf(eval): skip LLM eval when PR is recoverable

### DIFF
--- a/app_workflow.go
+++ b/app_workflow.go
@@ -59,6 +59,11 @@ func (a *taskAdapter) UpdateTaskStatus(id, status, reason string) error {
 	return err
 }
 
+func (a *taskAdapter) UpdateTaskPR(id string, prNumber int) error {
+	_, err := a.tasks.Update(id, task.Update{PRNumber: &prNumber})
+	return err
+}
+
 func (a *taskAdapter) SetWorkflow(id string, wf *workflow.Execution) error {
 	_, err := a.tasks.Update(id, task.Update{Workflow: &wf})
 	return err

--- a/internal/workflow/builtin/pr-fix.yaml
+++ b/internal/workflow/builtin/pr-fix.yaml
@@ -42,6 +42,26 @@ steps:
           operator: equals
           value: human-required
         goto: ""
+      - goto: link_pr_and_review
+
+  # Non-LLM step: recover PR number from task, agent result history, or
+  # gh pr list. Sets task to in-review and skips the LLM eval when a PR
+  # is unambiguously found. Falls through to evaluate only when all three
+  # sources fail to find a PR.
+  - id: link_pr_and_review
+    name: Link PR and Review
+    type: link_pr_and_review
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: in-review
+        goto: ensure_pr_closes_issue
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
       - goto: evaluate
 
   - id: evaluate

--- a/internal/workflow/builtin/simple-task.yaml
+++ b/internal/workflow/builtin/simple-task.yaml
@@ -217,6 +217,26 @@ steps:
           operator: equals
           value: human-required
         goto: ""
+      - goto: link_pr_and_review
+
+  # Non-LLM step: recover PR number from task, agent result history, or
+  # gh pr list. Sets task to in-review and skips the LLM eval when a PR
+  # is unambiguously found. Falls through to evaluate only when all three
+  # sources fail to find a PR.
+  - id: link_pr_and_review
+    name: Link PR and Review
+    type: link_pr_and_review
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: in-review
+        goto: ensure_pr_closes_issue
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
       - goto: evaluate
 
   - id: evaluate

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -2,10 +2,12 @@ package workflow
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"maps"
 	"os/exec"
+	"regexp"
 	"slices"
 	"sort"
 	"strconv"
@@ -54,6 +56,7 @@ type TaskProvider interface {
 	GetTask(id string) (TaskInfo, error)
 	ListTasks() ([]TaskInfo, error)
 	UpdateTaskStatus(id, status, reason string) error
+	UpdateTaskPR(id string, prNumber int) error
 	SetWorkflow(id string, wf *Execution) error
 }
 
@@ -652,7 +655,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			return e.execRunAgent(taskID, step, wfExec, ctx)
 		case StepWaitHuman:
 			return e.execWaitHuman(taskID, step, wfExec)
-		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepVerifyCommits:
+		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepVerifyCommits, StepLinkPRAndReview:
 			// handled below as sync steps
 		default:
 			return fmt.Errorf("unknown step type %q", step.Type)
@@ -718,6 +721,8 @@ func (e *Engine) execSyncStep(taskID string, step *Step, wfExec *Execution, ctx 
 		return e.execEnsurePRClosesIssue(taskID, step, t)
 	case StepVerifyCommits:
 		return e.execVerifyCommits(taskID, step, t)
+	case StepLinkPRAndReview:
+		return e.execLinkPRAndReview(taskID, step, wfExec, t)
 	default:
 		return StepOutput{}, fmt.Errorf("unknown step type %q", step.Type)
 	}
@@ -1006,6 +1011,74 @@ func (e *Engine) execVerifyCommits(taskID string, step *Step, t TaskInfo) (StepO
 	}
 
 	return StepOutput{StepID: step.ID, Status: "completed", Output: "commits verified"}, nil
+}
+
+var prURLRe = regexp.MustCompile(`github\.com/[^/\s]+/[^/\s]+/pull/(\d+)`)
+
+// execLinkPRAndReview is a non-LLM mechanical step that tries to recover the
+// PR number from three sources and flip the task to in-review:
+//
+//  1. task.pr_number already set → set in-review, skip eval
+//  2. regex match on agent result text in step history → link + in-review
+//  3. gh pr list --head <branch> → single result → link + in-review
+//
+// When no PR is found the step returns without touching task status, allowing
+// the workflow to fall through to the LLM eval step.
+func (e *Engine) execLinkPRAndReview(taskID string, step *Step, wfExec *Execution, t TaskInfo) (StepOutput, error) {
+	setInReview := func(prNumber int, source string) (StepOutput, error) {
+		if err := e.tasks.UpdateTaskPR(taskID, prNumber); err != nil {
+			return StepOutput{}, fmt.Errorf("link pr: %w", err)
+		}
+		if err := e.tasks.UpdateTaskStatus(taskID, "in-review", ""); err != nil {
+			return StepOutput{}, fmt.Errorf("set in-review: %w", err)
+		}
+		msg := fmt.Sprintf("pr #%d found via %s → in-review", prNumber, source)
+		e.logger.Info("workflow.link-pr.linked", "task_id", taskID, "pr", prNumber, "source", source)
+		return StepOutput{StepID: step.ID, Status: "completed", Output: msg}, nil
+	}
+
+	// Path 1: PR already linked on task.
+	if t.PRNumber > 0 {
+		return setInReview(t.PRNumber, "task.pr_number")
+	}
+
+	// Path 2: Scan step history for a GitHub PR URL in agent output.
+	for i := len(wfExec.StepHistory) - 1; i >= 0; i-- {
+		rec := wfExec.StepHistory[i]
+		if rec.Status != "completed" || rec.Output == "" {
+			continue
+		}
+		if m := prURLRe.FindStringSubmatch(rec.Output); len(m) > 1 {
+			n, err := strconv.Atoi(m[1])
+			if err == nil && n > 0 {
+				return setInReview(n, "agent result")
+			}
+		}
+	}
+
+	// Path 3: Query GitHub when branch is known.
+	// Use bash -c with env vars to keep project/branch out of arg list (gosec G204).
+	if t.ProjectID != "" && t.Branch != "" {
+		ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "bash", "-c",
+			"gh pr list --repo \"$_REPO\" --head \"$_BRANCH\" --json number --limit 2")
+		cmd.Env = append(cmd.Environ(), "_REPO="+t.ProjectID, "_BRANCH="+t.Branch)
+		out, err := cmd.Output()
+		if err != nil {
+			e.logger.Warn("workflow.link-pr.gh-list", "task_id", taskID, "err", err)
+		} else {
+			var prs []struct {
+				Number int `json:"number"`
+			}
+			if jsonErr := json.Unmarshal(out, &prs); jsonErr == nil && len(prs) == 1 {
+				return setInReview(prs[0].Number, "gh pr list")
+			}
+		}
+	}
+
+	e.logger.Info("workflow.link-pr.no-pr", "task_id", taskID)
+	return StepOutput{StepID: step.ID, Status: "completed", Output: "no pr found: falling through to eval"}, nil
 }
 
 // parseIssueURL extracts owner/repo and issue number from a GitHub

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -104,6 +104,17 @@ func (m *memTasks) UpdateTaskStatus(id, status, _ string) error {
 	return nil
 }
 
+func (m *memTasks) UpdateTaskPR(id string, prNumber int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	t, ok := m.tasks[id]
+	if !ok {
+		return fmt.Errorf("task %s not found", id)
+	}
+	t.PRNumber = prNumber
+	return nil
+}
+
 func (m *memTasks) SetWorkflow(id string, wf *Execution) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -68,6 +68,7 @@ const (
 	StepShell               StepType = "shell"
 	StepEnsurePRClosesIssue StepType = "ensure_pr_closes_issue"
 	StepVerifyCommits       StepType = "verify_commits"
+	StepLinkPRAndReview     StepType = "link_pr_and_review"
 )
 
 // Step is one node in the workflow graph.


### PR DESCRIPTION
## Motivation

Eval agents are running 33x/day at ~$0.08 each ($2.67/day total, 13s each). Every single run was doing the same mechanical PR-linking work that doesn't need an LLM: read task, find PR number, flip to in-review. No eval run today actually needed the LLM.

## Implementation information

Added a new non-LLM `link_pr_and_review` step type that runs between `verify_commits` and `evaluate` in both `simple-task` and `pr-fix` workflows.

The step tries three sources in order:
1. `task.pr_number` already set → set `in-review`, skip eval
2. Regex `github.com/.+/pull/(\d+)` on step history output → link + `in-review`, skip eval
3. `gh pr list --repo <project_id> --head <branch> --limit 2` → exactly 1 result → link + `in-review`, skip eval

Falls through to the LLM eval only when all three sources fail (ambiguous case: no PR found).

Implementation follows the same patterns as `verify_commits` and `ensure_pr_closes_issue` (synchronous, no agent, `StepOutput` result). Added `UpdateTaskPR(id string, prNumber int) error` to the `TaskProvider` interface with implementations in `taskAdapter` (production) and `memTasks` (tests).

The `gh pr list` call uses `bash -c` with env vars to avoid gosec G204 (matches the `execShell` pattern already used in the engine).

> Changelog: perf(eval): skip LLM eval when PR is recoverable

Closes https://github.com/Automaat/synapse/issues/356