### PR TITLE
fix(watchdog): track stdout bytes for stall

### DIFF
--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -225,6 +225,15 @@ func (a *Agent) GetLastEventAt() time.Time {
 	return a.LastEventAt
 }
 
+// TouchLastEvent refreshes LastEventAt without appending any event.
+// Used by the stdout reader to keep the stall clock alive during
+// extended thinking, where no complete NDJSON lines are emitted.
+func (a *Agent) TouchLastEvent() {
+	a.mu.Lock()
+	a.LastEventAt = time.Now().UTC()
+	a.mu.Unlock()
+}
+
 // Output returns a snapshot of the stream events produced so far. The
 // returned slice is safe to inspect concurrently with the agent's runner
 // goroutine appending more events.

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -205,8 +205,25 @@ func warnSubstringFallback(logger *slog.Logger) {
 	}
 }
 
+// trackingReader wraps an io.Reader and calls touch on every Read, keeping
+// LastEventAt alive during extended thinking where no complete NDJSON lines
+// are emitted for several minutes.
+type trackingReader struct {
+	r     io.Reader
+	touch func()
+}
+
+func (t *trackingReader) Read(p []byte) (int, error) {
+	n, err := t.r.Read(p)
+	if n > 0 {
+		t.touch()
+	}
+	return n, err
+}
+
 func (m *Manager) streamHeadlessOutput(ctx context.Context, a *Agent, stdout io.Reader, outFile io.Writer) {
-	scanner := bufio.NewScanner(stdout)
+	tracked := &trackingReader{r: stdout, touch: a.TouchLastEvent}
+	scanner := bufio.NewScanner(tracked)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
 	var lastEmit time.Time
 	isCodex := normalizeProvider(a.Provider) == "codex"

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	TickInterval   = 30 * time.Second
-	StallLimit     = 3 * time.Minute
+	StallLimit     = 15 * time.Minute
 	Debounce       = 5 * time.Minute
 	InspectTimeout = 2 * time.Minute
 )


### PR DESCRIPTION
## Motivation

`StallLimit` was firing on false stalls. `LastEventAt` is only refreshed when a complete NDJSON line is parsed — but during extended thinking, `claude` buffers internally and emits nothing to stdout for several minutes. The watchdog sees no events, treats the agent as stalled, and escalates the task to `human-required`.

## Implementation information

Wrap `stdout` in a `trackingReader` that calls `TouchLastEvent` on every `Read()` call. This keeps the stall clock alive even when the scanner is blocked mid-line waiting for a `\n`.

`StallLimit` also bumped 3m→15m as a secondary safety margin.

> Changelog: fix(watchdog): track stdout bytes for stall