### PR TITLE
fix(workflow): stop stale plan agent

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -334,7 +334,7 @@ func (m *Manager) FindRunningAgentForTask(taskID string, role Role) *Agent {
 }
 
 // FindAllRunningAgentsForTask returns all live agents for the given task
-// matching the provided role.
+// matching the provided role. An empty role matches all roles.
 func (m *Manager) FindAllRunningAgentsForTask(taskID string, role Role) []*Agent {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -343,7 +343,7 @@ func (m *Manager) FindAllRunningAgentsForTask(taskID string, role Role) []*Agent
 		if a.TaskID != taskID || !isLive(a.GetState()) {
 			continue
 		}
-		if RoleFromName(a.Name) != role {
+		if role != "" && RoleFromName(a.Name) != role {
 			continue
 		}
 		result = append(result, a)

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -805,6 +805,12 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 	}
 
 	dir := wfExec.Variables[WorkflowVarDir]
+
+	// Stop stale agents left over from earlier workflow steps (e.g. an
+	// interactive plan agent with reuse_agent that outlived plan approval).
+	// Empty role = stop all roles for this task.
+	e.agents.StopAgentsForTask(taskID, "")
+
 	// Interactive agents that aren't meant to persist across turns (no
 	// reuse_agent, no wait_for_status) must signal completion via process
 	// exit. OneShot tells the runner to close stdin after the first result


### PR DESCRIPTION
## Motivation

When user approves a plan, the workflow transitions from
`review_plan` → `set_in_progress` → `implement`. The plan
agent (`mode: interactive`, `reuse_agent: true`) is never
stopped — it stays alive/paused in the worktree while the
implement agent starts in the same directory. User sees
the stale plan agent and thinks the system is stuck
"in plan".

## Implementation information

Two changes:

- `internal/agent/manager.go`: `FindAllRunningAgentsForTask`
  now treats empty role as wildcard (matches all roles)
- `internal/workflow/engine.go`: `execRunAgent` calls
  `StopAgentsForTask(taskID, "")` before starting any new
  agent, cleaning up stale agents from previous steps