### PR TITLE
feat(workflow): cross-provider critique

### DIFF
--- a/.claude/skills/synapse-test-plan.md
+++ b/.claude/skills/synapse-test-plan.md
@@ -1,6 +1,6 @@
 ---
 name: synapse-test-plan
-description: Build a manual test plan for a Synapse task in the testing phase — spawns three distinct expert-tester personas (Bach, Kaner, Hendrickson) in parallel, each drafting test cases from their own frame, then merges and reviews before publishing. Covers Kubernetes and GUI app changes. Use whenever a task enters the testing status, when asked to "write a test plan", "plan manual tests", "figure out how to test X", or when reviewing a change that needs manual verification before merge. Prefer this over ad-hoc test ideas — the three-persona approach catches bugs any single frame would miss.
+description: Build a manual test plan for a Synapse task in the testing phase — spawns three distinct expert-tester personas (Bach, Kaner, Hendrickson) in parallel, each drafting test cases from their own frame, then merges before publishing. Critique is handled by a separate cross-provider workflow step. Covers Kubernetes and GUI app changes. Use whenever a task enters the testing status, when asked to "write a test plan", "plan manual tests", "figure out how to test X", or when reviewing a change that needs manual verification before merge.
 allowed-tools: Bash, Read, Agent
 user-invocable: true
 ---
@@ -10,7 +10,7 @@ user-invocable: true
 
 # Synapse Test Plan
 
-Produce a rigorous manual test plan for a task by spawning three expert-tester personas in parallel, merging their outputs, sanity-checking the merged result, and publishing. Plan manual verification only — do not execute tests and do not write automated tests.
+Produce a rigorous manual test plan for a task by spawning three expert-tester personas in parallel, merging their outputs, and publishing. Critique is handled by a separate cross-provider workflow step. Plan manual verification only — do not execute tests and do not write automated tests.
 
 Runs inside an interactive tmux session. After publishing, stay at the prompt and wait for feedback — never exit, so the human can send revisions in the same chat.
 
@@ -161,52 +161,16 @@ Merge in the main context, not a subagent — a merge needs all three outputs he
 5. **Reorganize** into the plan template below, grouped by area not persona (the tester executes by area; persona origin is provenance, not structure).
 6. **Prune** over ~15 cases by dropping weakest oracles / smallest blast radius. Keep at least 6 — below that, one persona's contribution is lost, breaking the three-frame guarantee.
 
-### 5. Consolidated sanity-check review
-
-Spawn **one** final review subagent on the merged plan (not the original drafts) to catch merge-introduced gaps and verify coherence.
-
-```
-Review a merged manual test plan. No prior context — judge on merits.
-
-## The change under test
-<paste change summary + file list>
-
-## The merged plan
-<paste merged plan>
-
-## Your job
-Answer these six questions. Cite test case numbers. Under 400 words. Blunt.
-
-1. **Coverage gaps**: failure modes the plan misses. k8s: probes/RBAC/
-   PDB/rollback/resources/graceful shutdown. GUI: keyboard-only, focus
-   order, resize, error states, state persistence.
-2. **Concreteness**: cases too vague to execute without guessing.
-3. **Scope match**: gold-plating outside the PR surface, or cases that
-   belong in automated tests instead.
-4. **Oracle clarity**: cases where pass/fail is ambiguous.
-5. **Risk ranking**: are the "Risk areas" the actual 3 riskiest spots?
-6. **Verdict**: Approve / Refine / Reject. If Refine, top 3 fixes.
-```
-
-### 6. Act on the review
-
-| Verdict | Action |
-|---------|--------|
-| Approve | Publish plan as-is |
-| Refine | Apply the top-3 fixes, publish revised plan |
-| Reject | Return to step 3 with persona briefs updated to address the gap. Cap at one re-run — publish after the second attempt regardless, because more iterations past that point usually indicate the plan is fine and the review is chasing perfection rather than catching real gaps. |
-
-### 7. Publish and hand off
+### 5. Publish and hand off
 
 ```bash
 synapse-cli --json update <id> --plan "<final plan>"
-synapse-cli --json update <id> --plan-critique "<review verdict + persona attribution summary>"
 synapse-cli --json update <id> --status test-plan-review
 ```
 
 After publishing, stay at the chat prompt. Do not execute tests and do not exit, because the human reviewer will send feedback in the same chat session and needs the agent alive to receive it.
 
-### 8. Respond to human feedback
+### 6. Respond to human feedback
 
 The human may push back. Revise and re-publish. Skip re-running personas for small tweaks — only re-run them if the change's scope fundamentally shifts, because persona re-runs are expensive and rarely add value for wording changes.
 
@@ -306,12 +270,9 @@ Classify as GUI change. Read `TaskDetail.svelte` and `app.go`. Spawn three perso
 
 **Merge:** 18 → 12 cases after dedupe. Bach's "click-then-escape-mid-dialog" dupes Hendrickson's Interruption Tour — keep Hendrickson's framing. Kaner's "audit trail" is unique, keep. Keep all of Hendrickson's tours. Group into sections: Happy path, Keyboard & focus, Error handling, State persistence.
 
-**Review:** sanity-check agent flags that TC-7 ("rollback on task with 0 prior states") doesn't specify expected behavior. Fix: mark button as disabled with tooltip when no prior state exists. Verdict: Refine → applied.
-
 **Publish:**
 ```bash
 synapse-cli --json update task-xyz --plan "<merged plan>"
-synapse-cli --json update task-xyz --plan-critique "<review + attribution>"
 synapse-cli --json update task-xyz --status test-plan-review
 ```
 Stay at prompt.

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -925,6 +925,7 @@ export namespace task {
 	    agentId: string;
 	    role: string;
 	    mode: string;
+	    provider?: string;
 	    state: string;
 	    // Go type: time
 	    startedAt: any;
@@ -941,6 +942,7 @@ export namespace task {
 	        this.agentId = source["agentId"];
 	        this.role = source["role"];
 	        this.mode = source["mode"];
+	        this.provider = source["provider"];
 	        this.state = source["state"];
 	        this.startedAt = this.convertValues(source["startedAt"], null);
 	        this.costUsd = source["costUsd"];
@@ -1161,6 +1163,7 @@ export namespace workflow {
 	    role: string;
 	    mode: string;
 	    model: string;
+	    provider: string;
 	    prompt: string;
 	    allowedTools: string[];
 	    needsWorktree: boolean;
@@ -1183,6 +1186,7 @@ export namespace workflow {
 	        this.role = source["role"];
 	        this.mode = source["mode"];
 	        this.model = source["model"];
+	        this.provider = source["provider"];
 	        this.prompt = source["prompt"];
 	        this.allowedTools = source["allowedTools"];
 	        this.needsWorktree = source["needsWorktree"];
@@ -1358,6 +1362,7 @@ export namespace workflow {
 	    status: string;
 	    output: string;
 	    agentId: string;
+	    provider?: string;
 	    // Go type: time
 	    startedAt: any;
 	    // Go type: time
@@ -1373,6 +1378,7 @@ export namespace workflow {
 	        this.status = source["status"];
 	        this.output = source["output"];
 	        this.agentId = source["agentId"];
+	        this.provider = source["provider"];
 	        this.startedAt = this.convertValues(source["startedAt"], null);
 	        this.endedAt = this.convertValues(source["endedAt"], null);
 	    }

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -70,6 +70,13 @@ func (m *Manager) SetDefaultProvider(provider string) {
 	m.mu.Unlock()
 }
 
+// DefaultProvider returns the current default provider name.
+func (m *Manager) DefaultProvider() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.defaultProv
+}
+
 // SetGuardrails configures cost and turn limits applied to all agents.
 func (m *Manager) SetGuardrails(g Guardrails) {
 	m.mu.Lock()

--- a/internal/agent/role.go
+++ b/internal/agent/role.go
@@ -14,6 +14,7 @@ const (
 	RoleReview         Role = "review"
 	RoleFixReview      Role = "fix-review"
 	RoleTestPlan       Role = "test-plan"
+	RoleTestPlanCritic Role = "test-plan-critic"
 	RoleTestRunner     Role = "test-runner"
 	RoleImplementation Role = "implementation"
 )
@@ -25,7 +26,7 @@ func (r Role) AgentName(title string) string { return string(r) + ":" + title }
 // IsSystem returns true for roles whose agents should not trigger
 // user-facing notifications (triage, eval, plan-critic).
 func (r Role) IsSystem() bool {
-	return r == RoleTriage || r == RoleEval || r == RolePlanCritic
+	return r == RoleTriage || r == RoleEval || r == RolePlanCritic || r == RoleTestPlanCritic
 }
 
 // RoleFromName extracts the Role from a prefixed agent name.
@@ -37,7 +38,7 @@ func RoleFromName(name string) Role {
 	}
 	r := Role(prefix)
 	switch r {
-	case RoleTriage, RolePlan, RolePlanCritic, RoleEval, RolePRFix, RoleReview, RoleFixReview, RoleTestPlan, RoleTestRunner:
+	case RoleTriage, RolePlan, RolePlanCritic, RoleEval, RolePRFix, RoleReview, RoleFixReview, RoleTestPlan, RoleTestPlanCritic, RoleTestRunner:
 		return r
 	default:
 		return RoleImplementation

--- a/internal/synapse/app.go
+++ b/internal/synapse/app.go
@@ -398,9 +398,10 @@ func (a *App) onAgentComplete(ag *agent.Agent) {
 	// Advance workflow.
 	if a.workflowEngine != nil {
 		a.workflowEngine.HandleAgentComplete(ag.TaskID, workflow.AgentCompletion{
-			AgentID: ag.ID,
-			Result:  resultContent,
-			Success: exitErr == nil,
+			AgentID:  ag.ID,
+			Result:   resultContent,
+			Provider: ag.Provider,
+			Success:  exitErr == nil,
 		})
 	}
 
@@ -686,8 +687,9 @@ func (a *App) recoverStaleInteractive(t *task.Task) {
 	a.logger.Info("recover-stale.advance",
 		"task_id", t.ID, "agent_id", lr.AgentID, "step", t.Workflow.CurrentStep)
 	a.workflowEngine.HandleAgentComplete(t.ID, workflow.AgentCompletion{
-		AgentID: lr.AgentID,
-		Success: true,
+		AgentID:  lr.AgentID,
+		Provider: lr.Provider,
+		Success:  true,
 	})
 }
 

--- a/internal/synapse/app_workflow.go
+++ b/internal/synapse/app_workflow.go
@@ -124,7 +124,7 @@ type agentAdapter struct {
 	tasks     *task.Manager
 }
 
-func (a *agentAdapter) StartAgent(taskID, role, mode, model, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool) (string, error) {
+func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool) (string, error) {
 	// For implementation agents without a pre-staged dir, use the full
 	// orchestrator (handles worktree, project assignment). A workflow that
 	// seeds WorkflowVarDir (e.g. tests or flows that pre-stage via
@@ -152,6 +152,7 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, prompt, dir string,
 		Prompt:       prompt,
 		AllowedTools: allowedTools,
 		Model:        model,
+		Provider:     provider,
 		Dir:          dir,
 		OneShot:      oneShot,
 	}
@@ -189,6 +190,7 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, prompt, dir string,
 		AgentID:   ag.ID,
 		Role:      role,
 		Mode:      mode,
+		Provider:  ag.Provider,
 		State:     string(agent.StateRunning),
 		StartedAt: ag.StartedAt,
 	}); addErr != nil {
@@ -220,4 +222,8 @@ func (a *agentAdapter) StopAgentsForTask(taskID, role string) {
 
 func (a *agentAdapter) SendPrompt(agentID, message string) error {
 	return a.agents.SendPromptToAgent(agentID, message)
+}
+
+func (a *agentAdapter) DefaultProvider() string {
+	return a.agents.DefaultProvider()
 }

--- a/internal/synapse/e2e_workflow_test.go
+++ b/internal/synapse/e2e_workflow_test.go
@@ -1357,8 +1357,8 @@ func countStepRecords(tk task.Task, stepID string) int {
 		return 0
 	}
 	n := 0
-	for _, r := range tk.Workflow.StepHistory {
-		if r.StepID == stepID {
+	for i := range tk.Workflow.StepHistory {
+		if tk.Workflow.StepHistory[i].StepID == stepID {
 			n++
 		}
 	}

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -100,6 +100,7 @@ type AgentRun struct {
 	AgentID   string    `yaml:"agent_id" json:"agentId"`
 	Role      string    `yaml:"role,omitempty" json:"role"` // triage, plan, eval, pr-fix, or "" for implementation
 	Mode      string    `yaml:"mode" json:"mode"`
+	Provider  string    `yaml:"provider,omitempty" json:"provider,omitempty"`
 	State     string    `yaml:"state" json:"state"`
 	StartedAt time.Time `yaml:"started_at" json:"startedAt"`
 	CostUSD   float64   `yaml:"cost_usd,omitempty" json:"costUsd"`

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -4,8 +4,9 @@ package workflow
 // Using a typed struct instead of positional string args makes the
 // success/failure contract explicit and independent of agent package constants.
 type AgentCompletion struct {
-	AgentID string
-	Result  string
+	AgentID  string
+	Result   string
+	Provider string
 	// Success reports whether the agent exited cleanly. false triggers the
 	// step failure/retry path in AdvanceStep.
 	Success bool
@@ -20,11 +21,12 @@ type AgentCompletion struct {
 // workflow steps that expect a single turn — otherwise the agent sits paused
 // forever and the workflow never advances to the next step.
 type AgentLauncher interface {
-	StartAgent(taskID, role, mode, model, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool) (agentID string, err error)
+	StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool) (agentID string, err error)
 	HasRunningAgent(taskID string) bool
 	FindRunningAgentForRole(taskID, role string) (agentID string, found bool)
 	StopAgentsForTask(taskID string, role string)
 	SendPrompt(agentID, message string) error
+	DefaultProvider() string
 }
 
 // WorkflowVarDir is the reserved variable name used to pass a pre-prepared

--- a/internal/workflow/builtin/simple-task.yaml
+++ b/internal/workflow/builtin/simple-task.yaml
@@ -119,6 +119,7 @@ steps:
       role: plan-critic
       mode: headless
       model: sonnet
+      provider: cross
       needs_worktree: true
       max_retries: 2
       prompt: >-

--- a/internal/workflow/builtin/testing-task.yaml
+++ b/internal/workflow/builtin/testing-task.yaml
@@ -18,6 +18,7 @@ steps:
       model: opus
       needs_worktree: true
       reuse_agent: true
+      wait_for_status: test-plan-review
       prompt: >-
         {{- $feedback := getvar .Vars "human.feedback" }}
         {{- if $feedback }}
@@ -31,18 +32,66 @@ steps:
         {{- else }}
         Prepare a manual test plan for task {{.Task.ID}} using the /synapse-test-plan skill.
 
-        The skill spawns three expert-tester personas (Bach, Kaner, Hendrickson)
-        in parallel, merges their outputs, runs a sanity-check review, and
-        publishes via:
-          1. synapse-cli update {{.Task.ID}} --plan "<merged plan>"
-          2. synapse-cli update {{.Task.ID}} --plan-critique "<review + attribution>"
-          3. synapse-cli update {{.Task.ID}} --status test-plan-review
+        When the plan is ready:
+          1. synapse-cli update {{.Task.ID}} --plan "<full plan markdown>"
+          2. synapse-cli update {{.Task.ID}} --status test-plan-review
 
         Then STOP and wait. Do NOT exit. Do NOT execute the tests yet.
 
         If you receive feedback, address it, update --plan again, set status
         back to test-plan-review, and wait again.
         {{- end }}
+    next:
+      - goto: maybe_critique_test
+
+  - id: maybe_critique_test
+    name: Test Critique Decision
+    type: condition
+    config:
+      check:
+        field: task.tags
+        operator: not_contains
+        value: nocritic
+    next:
+      - when:
+          field: task.tags
+          operator: not_contains
+          value: nocritic
+        goto: critique_test_plan
+      - goto: review_test_plan
+
+  - id: critique_test_plan
+    name: Critique Test Plan
+    type: run_agent
+    config:
+      role: test-plan-critic
+      mode: headless
+      model: sonnet
+      provider: cross
+      needs_worktree: true
+      max_retries: 2
+      prompt: >-
+        Critique the test plan for task {{.Task.ID}} using the /plan-critic skill.
+
+        Steps:
+          1. Run: synapse-cli --json get {{.Task.ID}}
+          2. Extract the .plan field from the JSON output and write it to
+             /tmp/synapse-plan-{{.Task.ID}}.md
+          3. Invoke: /plan-critic /tmp/synapse-plan-{{.Task.ID}}.md
+          4. Capture the full markdown Plan Review report you produce and
+             write it to /tmp/synapse-critique-{{.Task.ID}}.md
+          5. Save it: synapse-cli update {{.Task.ID}} --plan-critique-file /tmp/synapse-critique-{{.Task.ID}}.md
+
+        Do NOT modify the plan. Do NOT change the task status. Your only
+        side effect is writing the critique sidecar via synapse-cli.
+      allowed_tools:
+        - Bash
+        - Read
+        - Grep
+        - Glob
+        - Write
+        - Skill
+        - Agent
     next:
       - goto: review_test_plan
 
@@ -64,7 +113,15 @@ steps:
           field: vars.human_action
           operator: equals
           value: reject
-        goto: plan_test
+        goto: start_replan_test
+
+  - id: start_replan_test
+    name: Prepare Replan
+    type: set_status
+    config:
+      status: testing
+    next:
+      - goto: plan_test
 
   - id: execute_tests
     name: Execute Manual Testing

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -275,6 +275,7 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 		Status:    output.Status,
 		Output:    truncate(output.Output, 4000),
 		AgentID:   output.AgentID,
+		Provider:  output.Provider,
 		StartedAt: now,
 		EndedAt:   now,
 	})
@@ -512,10 +513,11 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 	}
 
 	if err := e.AdvanceStep(taskID, StepOutput{
-		StepID:  spawnedStep,
-		Status:  status,
-		Output:  c.Result,
-		AgentID: c.AgentID,
+		StepID:   spawnedStep,
+		Status:   status,
+		Output:   c.Result,
+		AgentID:  c.AgentID,
+		Provider: c.Provider,
 	}); err != nil {
 		e.logger.Error("workflow.agent-complete.advance", "task_id", taskID, "err", err)
 	}
@@ -804,6 +806,12 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 		model = "sonnet"
 	}
 
+	provider := resolveProvider(step.Config.Provider, wfExec, e.agents.DefaultProvider())
+	if provider != "" && !providerAvailable(provider) {
+		e.logger.Warn("workflow.cross-provider.fallback", "wanted", provider, "reason", "CLI not found")
+		provider = ""
+	}
+
 	dir := wfExec.Variables[WorkflowVarDir]
 
 	// Stop stale agents left over from earlier workflow steps (e.g. an
@@ -817,7 +825,7 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 	// event so claude exits and onComplete fires, unblocking the next step
 	// (e.g. evaluate). Without this, the workflow stalls on implement forever.
 	oneShot := mode == "interactive" && !step.Config.ReuseAgent && step.Config.WaitForStatus == ""
-	agentID, err := e.agents.StartAgent(taskID, step.Config.Role, mode, model, prompt, dir, step.Config.AllowedTools, step.Config.NeedsWorktree, oneShot)
+	agentID, err := e.agents.StartAgent(taskID, step.Config.Role, mode, model, provider, prompt, dir, step.Config.AllowedTools, step.Config.NeedsWorktree, oneShot)
 	if err != nil {
 		return fmt.Errorf("start agent: %w", err)
 	}
@@ -830,8 +838,40 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 	e.mu.Unlock()
 
 	wfExec.State = ExecWaiting
-	e.logger.Info("workflow.run-agent", "task_id", taskID, "step", step.ID, "role", step.Config.Role, "agent_id", agentID)
+	e.logger.Info("workflow.run-agent", "task_id", taskID, "step", step.ID, "role", step.Config.Role, "agent_id", agentID, "provider", provider)
 	return e.tasks.SetWorkflow(taskID, wfExec)
+}
+
+// flipProvider returns the opposite provider.
+func flipProvider(p string) string {
+	if p == "codex" {
+		return "claude"
+	}
+	return "codex"
+}
+
+// resolveProvider resolves the step-level provider string.
+// "cross" flips the last agent step's provider; "" defers to manager default.
+func resolveProvider(stepProv string, wfExec *Execution, defaultProv string) string {
+	switch stepProv {
+	case "cross":
+		for i := len(wfExec.StepHistory) - 1; i >= 0; i-- {
+			if p := wfExec.StepHistory[i].Provider; p != "" {
+				return flipProvider(p)
+			}
+		}
+		return flipProvider(defaultProv)
+	case "":
+		return ""
+	default:
+		return stepProv
+	}
+}
+
+// providerAvailable reports whether the CLI for a provider is on PATH.
+func providerAvailable(provider string) bool {
+	_, err := exec.LookPath(provider)
+	return err == nil
 }
 
 func (e *Engine) execWaitHuman(taskID string, step *Step, wfExec *Execution) error {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -138,10 +138,10 @@ func (m *memTasks) SetStatus(id, status string) {
 // --- Mock AgentLauncher ---
 
 type startCall struct {
-	TaskID, Role, Mode, Model, Prompt, Dir string
-	AllowedTools                           []string
-	NeedsWorktree                          bool
-	OneShot                                bool
+	TaskID, Role, Mode, Model, Provider, Prompt, Dir string
+	AllowedTools                                     []string
+	NeedsWorktree                                    bool
+	OneShot                                          bool
 }
 
 type sentPrompt struct {
@@ -164,13 +164,13 @@ func newMockAgents() *mockAgents {
 	}
 }
 
-func (m *mockAgents) StartAgent(taskID, role, mode, model, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool) (string, error) {
+func (m *mockAgents) StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.counter++
 	id := fmt.Sprintf("agent-%d", m.counter)
 	m.calls = append(m.calls, startCall{
-		TaskID: taskID, Role: role, Mode: mode, Model: model,
+		TaskID: taskID, Role: role, Mode: mode, Model: model, Provider: provider,
 		Prompt: prompt, Dir: dir, AllowedTools: allowedTools,
 		NeedsWorktree: needsWorktree, OneShot: oneShot,
 	})
@@ -205,6 +205,8 @@ func (m *mockAgents) SendPrompt(agentID, message string) error {
 	m.prompts = append(m.prompts, sentPrompt{AgentID: agentID, Message: message})
 	return nil
 }
+
+func (m *mockAgents) DefaultProvider() string { return "claude" }
 
 // SimulateComplete marks the agent for a task as no longer running.
 func (m *mockAgents) SimulateComplete(taskID string) {
@@ -995,7 +997,7 @@ func TestResumeStalled_SkipsTaskWithRunningAgent(t *testing.T) {
 		},
 	})
 	// Simulate an agent already running.
-	_, _ = agents.StartAgent("t1", "implementation", "headless", "sonnet", "test", "", nil, false, false)
+	_, _ = agents.StartAgent("t1", "implementation", "headless", "sonnet", "", "test", "", nil, false, false)
 
 	initialCalls := agents.CallCount()
 	engine.ResumeStalled()

--- a/internal/workflow/execution.go
+++ b/internal/workflow/execution.go
@@ -79,14 +79,16 @@ type StepRecord struct {
 	Status    string    `yaml:"status" json:"status"` // "completed", "failed", "skipped"
 	Output    string    `yaml:"output,omitempty" json:"output"`
 	AgentID   string    `yaml:"agent_id,omitempty" json:"agentId"`
+	Provider  string    `yaml:"provider,omitempty" json:"provider,omitempty"`
 	StartedAt time.Time `yaml:"started_at" json:"startedAt"`
 	EndedAt   time.Time `yaml:"ended_at,omitempty" json:"endedAt"`
 }
 
 // StepOutput is passed to AdvanceStep when a step finishes.
 type StepOutput struct {
-	StepID  string
-	Status  string // "completed", "failed"
-	Output  string
-	AgentID string
+	StepID   string
+	Status   string // "completed", "failed"
+	Output   string
+	AgentID  string
+	Provider string
 }

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -97,6 +97,7 @@ type StepConfig struct {
 	Role          string   `yaml:"role,omitempty" json:"role"`
 	Mode          string   `yaml:"mode,omitempty" json:"mode"`
 	Model         string   `yaml:"model,omitempty" json:"model"`
+	Provider      string   `yaml:"provider,omitempty" json:"provider"` // "", "claude", "codex", "cross"
 	Prompt        string   `yaml:"prompt,omitempty" json:"prompt"`
 	AllowedTools  []string `yaml:"allowed_tools,omitempty" json:"allowedTools"`
 	NeedsWorktree bool     `yaml:"needs_worktree,omitempty" json:"needsWorktree"`


### PR DESCRIPTION
## Motivation

Plan critique and test-plan critique should run on a different AI provider than the plan itself (Claude↔Codex) to get independent second-opinion quality. The testing-task workflow also bundled plan+critique into a single agent step, unlike simple-task which separates them.

## Implementation information

**Part 1: Thread `provider` through workflow engine**
- Added `Provider` field to `StepConfig`, `StepRecord`, `StepOutput`, `AgentCompletion`
- Added `provider` param to `AgentLauncher.StartAgent()` interface + `DefaultProvider()` method
- Engine resolves `"cross"` at runtime by walking StepHistory backwards and flipping the last agent's provider
- Falls back to default provider if alternate CLI not on PATH (`providerAvailable()` check)
- `agentAdapter` passes provider through to `agent.RunConfig`

**Part 2: Align testing-task with simple-task pattern**
- Added `RoleTestPlanCritic` role
- Split testing-task.yaml from single plan step into: plan → maybe_critique → critique(cross) → review
- Added `start_replan_test` step for reject loop (mirrors simple-task's `start_replan`)
- Removed internal sanity-check review from `synapse-test-plan` skill (steps 5-6) — critique now handled by separate cross-provider workflow step
- Added `provider: cross` to simple-task.yaml's `critique_plan` step

**Observability:** `Provider` added to `task.AgentRun` so run history tracks which provider was used.