### PR TITLE
fix(review): clear debounce on pr-fix done

### DIFF
--- a/internal/github/debounce.go
+++ b/internal/github/debounce.go
@@ -5,11 +5,14 @@ import (
 	"time"
 )
 
+const maxRetries = 3
+
 // IssueTracker prevents re-dispatching agents for the same PR issue
-// within a cooldown period.
+// within a cooldown period and caps total retries.
 type IssueTracker struct {
 	mu       sync.Mutex
 	handled  map[string]time.Time
+	retries  map[string]int
 	cooldown time.Duration
 	now      func() time.Time // injectable for testing
 }
@@ -18,6 +21,7 @@ type IssueTracker struct {
 func NewIssueTracker(cooldown time.Duration) *IssueTracker {
 	return &IssueTracker{
 		handled:  make(map[string]time.Time),
+		retries:  make(map[string]int),
 		cooldown: cooldown,
 		now:      time.Now,
 	}
@@ -27,11 +31,16 @@ func issueKey(taskID string, kind PRIssueKind) string {
 	return taskID + ":" + string(kind)
 }
 
-// ShouldHandle returns true if this issue hasn't been handled within the cooldown.
+// ShouldHandle returns true if this issue hasn't been handled within the
+// cooldown and hasn't exceeded max retries.
 func (t *IssueTracker) ShouldHandle(taskID string, kind PRIssueKind) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	last, ok := t.handled[issueKey(taskID, kind)]
+	key := issueKey(taskID, kind)
+	if t.retries[key] >= maxRetries {
+		return false
+	}
+	last, ok := t.handled[key]
 	if !ok {
 		return true
 	}
@@ -42,14 +51,33 @@ func (t *IssueTracker) ShouldHandle(taskID string, kind PRIssueKind) bool {
 func (t *IssueTracker) MarkHandled(taskID string, kind PRIssueKind) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.handled[issueKey(taskID, kind)] = t.now()
+	key := issueKey(taskID, kind)
+	t.handled[key] = t.now()
+	t.retries[key]++
 }
 
-// Clear removes tracking for a task+issue (call when issue resolves).
-func (t *IssueTracker) Clear(taskID string, kind PRIssueKind) {
+// ClearCooldown removes the cooldown for a task+issue so the next poll
+// can retry immediately. The retry counter is preserved.
+func (t *IssueTracker) ClearCooldown(taskID string, kind PRIssueKind) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	delete(t.handled, issueKey(taskID, kind))
+}
+
+// Clear removes all tracking for a task+issue (call when issue resolves).
+func (t *IssueTracker) Clear(taskID string, kind PRIssueKind) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	key := issueKey(taskID, kind)
+	delete(t.handled, key)
+	delete(t.retries, key)
+}
+
+// Retries returns the current retry count for a task+issue.
+func (t *IssueTracker) Retries(taskID string, kind PRIssueKind) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.retries[issueKey(taskID, kind)]
 }
 
 // Cleanup removes entries older than 2x cooldown.
@@ -60,6 +88,7 @@ func (t *IssueTracker) Cleanup() {
 	for k, v := range t.handled {
 		if v.Before(cutoff) {
 			delete(t.handled, k)
+			delete(t.retries, k)
 		}
 	}
 }

--- a/internal/github/debounce_test.go
+++ b/internal/github/debounce_test.go
@@ -45,10 +45,52 @@ func TestIssueTracker(t *testing.T) {
 		}
 	})
 
-	t.Run("clear removes tracking", func(t *testing.T) {
+	t.Run("clear removes tracking and retries", func(t *testing.T) {
 		tracker.Clear("t2", PRIssueCIFailure)
 		if !tracker.ShouldHandle("t2", PRIssueCIFailure) {
 			t.Fatal("expected ShouldHandle=true after Clear")
+		}
+		if tracker.Retries("t2", PRIssueCIFailure) != 0 {
+			t.Fatal("expected retries=0 after Clear")
+		}
+	})
+
+	t.Run("clear cooldown preserves retry count", func(t *testing.T) {
+		tracker.MarkHandled("t4", PRIssueCIFailure)
+		if tracker.Retries("t4", PRIssueCIFailure) != 1 {
+			t.Fatalf("retries = %d, want 1", tracker.Retries("t4", PRIssueCIFailure))
+		}
+
+		tracker.ClearCooldown("t4", PRIssueCIFailure)
+		if !tracker.ShouldHandle("t4", PRIssueCIFailure) {
+			t.Fatal("expected ShouldHandle=true after ClearCooldown")
+		}
+		if tracker.Retries("t4", PRIssueCIFailure) != 1 {
+			t.Fatal("expected retries preserved after ClearCooldown")
+		}
+	})
+
+	t.Run("max retries blocks handling", func(t *testing.T) {
+		now = time.Date(2026, 4, 3, 14, 0, 0, 0, time.UTC)
+		for i := range maxRetries {
+			tracker.MarkHandled("t5", PRIssueConflict)
+			now = now.Add(31 * time.Minute)
+			if i < maxRetries-1 {
+				if !tracker.ShouldHandle("t5", PRIssueConflict) {
+					t.Fatalf("expected ShouldHandle=true on retry %d", i+1)
+				}
+			}
+		}
+		// Even after cooldown, max retries should block.
+		if tracker.ShouldHandle("t5", PRIssueConflict) {
+			t.Fatal("expected ShouldHandle=false after max retries")
+		}
+	})
+
+	t.Run("clear resets retry cap", func(t *testing.T) {
+		tracker.Clear("t5", PRIssueConflict)
+		if !tracker.ShouldHandle("t5", PRIssueConflict) {
+			t.Fatal("expected ShouldHandle=true after Clear resets retries")
 		}
 	})
 
@@ -60,6 +102,9 @@ func TestIssueTracker(t *testing.T) {
 		// t3 should be cleaned up
 		if !tracker.ShouldHandle("t3", PRIssueConflict) {
 			t.Fatal("expected ShouldHandle=true after cleanup")
+		}
+		if tracker.Retries("t3", PRIssueConflict) != 0 {
+			t.Fatal("expected retries cleaned up")
 		}
 	})
 }

--- a/internal/synapse/app.go
+++ b/internal/synapse/app.go
@@ -410,6 +410,17 @@ func (a *App) onAgentComplete(ag *agent.Agent) {
 	}
 }
 
+func (a *App) onWorkflowComplete(info workflow.CompletionInfo) {
+	kind := github.PRIssueKind(info.Variables["pr_issue_kind"])
+	if kind == "" {
+		return
+	}
+	a.prTracker.ClearCooldown(info.TaskID, kind)
+	a.logger.Info("pr-tracker.cooldown-cleared",
+		"task_id", info.TaskID, "kind", string(kind),
+		"retries", a.prTracker.Retries(info.TaskID, kind))
+}
+
 func (a *App) initWorkflowEngine() {
 	wfStore, err := workflow.NewStore(config.WorkflowsDir())
 	if err != nil {
@@ -428,6 +439,7 @@ func (a *App) initWorkflowEngine() {
 	)
 	a.workflowEngine.SetPRLinker(prLinkerAdapter{})
 	a.workflowEngine.SetWorktreeGetter(&worktreeGetterAdapter{tasks: a.tasks, mgr: a.worktrees})
+	a.workflowEngine.SetOnComplete(a.onWorkflowComplete)
 	a.workflowEngine.SetContext(a.ctx)
 }
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -81,6 +81,13 @@ type PRLinker interface {
 	EditBody(repo string, prNumber int, body string) error
 }
 
+// CompletionInfo is passed to the OnComplete callback when a workflow finishes.
+type CompletionInfo struct {
+	TaskID     string
+	WorkflowID string
+	Variables  map[string]string
+}
+
 // Engine executes workflow definitions against tasks.
 type Engine struct {
 	store       *Store
@@ -88,6 +95,7 @@ type Engine struct {
 	agents      AgentLauncher
 	prLinker    PRLinker
 	worktrees   WorktreeGetter
+	onComplete  func(CompletionInfo)
 	logger      *slog.Logger
 	ctx         context.Context
 	mu          sync.Mutex
@@ -125,6 +133,10 @@ func (e *Engine) SetPRLinker(l PRLinker) { e.prLinker = l }
 // SetWorktreeGetter wires a WorktreeGetter used by the `verify_commits` step.
 // Leaving it unset makes the step a no-op.
 func (e *Engine) SetWorktreeGetter(g WorktreeGetter) { e.worktrees = g }
+
+// SetOnComplete registers a callback fired when a workflow reaches the
+// completed state. Used to clear external debounce trackers.
+func (e *Engine) SetOnComplete(fn func(CompletionInfo)) { e.onComplete = fn }
 
 // StartWorkflow assigns a workflow to a task and executes the first step.
 func (e *Engine) StartWorkflow(taskID, workflowID string) error {
@@ -752,7 +764,15 @@ func (e *Engine) resolveNext(taskID string, def *Definition, current *Step, wfEx
 		wfExec.CompletedAt = &now
 		wfExec.CurrentStep = ""
 		e.logger.Info("workflow.completed", "task_id", taskID, "workflow", def.ID)
-		return nil, e.tasks.SetWorkflow(taskID, wfExec)
+		err := e.tasks.SetWorkflow(taskID, wfExec)
+		if err == nil && e.onComplete != nil {
+			e.onComplete(CompletionInfo{
+				TaskID:     taskID,
+				WorkflowID: def.ID,
+				Variables:  wfExec.Variables,
+			})
+		}
+		return nil, err
 	}
 
 	nextStep := def.StepByID(nextID)


### PR DESCRIPTION
## Motivation

When a pr-fix agent finished but CI still failed, the 30-min debounce
blocked retries even though no agent was running. The `HasRunningAgentForTask`
guard already prevents overlapping agents, so the debounce was only useful
as a retry cooldown — but too aggressive.

## Implementation information

- Add `OnComplete` callback to workflow `Engine`, fired from `resolveNext`
  when workflow reaches completed state
- `onWorkflowComplete` in `App` reads `pr_issue_kind` from workflow
  variables and calls `ClearCooldown` to remove the time gate
- `ClearCooldown` preserves retry counter (unlike `Clear` which resets both)
- Add `maxRetries = 3` cap to `IssueTracker.ShouldHandle` to prevent
  infinite fix loops — `Clear` (called when issue resolves) resets this