### PR TITLE
feat(web): SSE endpoint replacing Wails EventsEmit

### DIFF
--- a/cmd/synapse-server/main.go
+++ b/cmd/synapse-server/main.go
@@ -66,7 +66,10 @@ func run() error {
 
 	mux := http.NewServeMux()
 
-	// SSE endpoint: GET /api/events/{eventName}
+	// Multiplexed SSE stream: all events over a single connection.
+	mux.HandleFunc("GET /events", broker.ServeAll)
+
+	// Per-event SSE endpoint (kept for debugging / backward compat).
 	mux.HandleFunc("GET /api/events/{eventName}", broker.ServeHTTP)
 
 	// API dispatch: POST /api/{service}/{method}

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -125,13 +125,44 @@ export function ResetBuiltin(arg1: string): Promise<void> { return call('Workflo
 export function SaveWorkflow(arg1: workflow.Definition): Promise<void> { return call('WorkflowService', 'SaveWorkflow', arg1) }
 export function StartWorkflow(arg1: string, arg2: string): Promise<void> { return call('WorkflowService', 'StartWorkflow', arg1, arg2) }
 
-// Runtime: EventsOn via Server-Sent Events
+// Shared EventSource for the multiplexed /events SSE stream.
+// All EventsOn subscriptions funnel through a single connection.
+const EVENTS_URL = (() => {
+  // Strip /api suffix to get server root, then append /events.
+  const base = (import.meta.env.VITE_API_BASE as string | undefined) ?? '/api'
+  return base.replace(/\/api$/, '') + '/events'
+})()
+
+let _sharedES: EventSource | null = null
+let _subCount = 0
+
+function getSharedES(): EventSource {
+  if (!_sharedES) {
+    _sharedES = new EventSource(EVENTS_URL)
+  }
+  return _sharedES
+}
+
+// Runtime: EventsOn via multiplexed SSE stream (GET /events).
+// All subscriptions share a single EventSource connection.
+// The server uses SSE named-event format so each listener only fires for its event.
 export function EventsOn(eventName: string, callback: (...data: any[]) => void): () => void {
-  const es = new EventSource(`${API_BASE}/events/${encodeURIComponent(eventName)}`)
-  es.onmessage = (e: MessageEvent) => {
+  const es = getSharedES()
+  _subCount++
+
+  const handler = (e: MessageEvent) => {
     try { callback(JSON.parse(e.data as string)) } catch { callback(e.data) }
   }
-  return () => es.close()
+  es.addEventListener(eventName, handler)
+
+  return () => {
+    _sharedES?.removeEventListener(eventName, handler)
+    _subCount--
+    if (_subCount === 0) {
+      _sharedES?.close()
+      _sharedES = null
+    }
+  }
 }
 
 // Runtime: BrowserOpenURL via window.open

--- a/internal/sse/broker.go
+++ b/internal/sse/broker.go
@@ -11,12 +11,20 @@ import (
 
 const chanBuf = 256
 
+// Event carries a named event with its JSON-encoded payload.
+// Used by ServeAll to multiplex all events over a single SSE stream.
+type Event struct {
+	Name string
+	Data string // JSON-encoded
+}
+
 // Broker fans out named events to SSE subscribers.
 // The Emit method implements func(string, any) and can be passed directly to
 // WithEmit when constructing an App.
 type Broker struct {
-	mu   sync.RWMutex
-	subs map[string][]chan string
+	mu      sync.RWMutex
+	subs    map[string][]chan string
+	allSubs []chan Event
 }
 
 // New returns an initialised Broker.
@@ -24,7 +32,32 @@ func New() *Broker {
 	return &Broker{subs: make(map[string][]chan string)}
 }
 
-// Emit JSON-encodes data and fans it out to all subscribers of event.
+// SubscribeAll returns a channel that receives every emitted event regardless
+// of name, plus a cancel function that removes the subscription.
+func (b *Broker) SubscribeAll() (ch <-chan Event, cancel func()) {
+	inner := make(chan Event, chanBuf)
+	ch = inner
+
+	b.mu.Lock()
+	b.allSubs = append(b.allSubs, inner)
+	b.mu.Unlock()
+
+	cancel = func() {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		for i, c := range b.allSubs {
+			if c == inner {
+				b.allSubs = append(b.allSubs[:i], b.allSubs[i+1:]...)
+				break
+			}
+		}
+		close(inner)
+	}
+	return
+}
+
+// Emit JSON-encodes data and fans it out to all subscribers of event and to
+// all SubscribeAll subscribers.
 // Safe for concurrent use. Slow consumers are dropped (non-blocking send).
 func (b *Broker) Emit(event string, data any) {
 	payload, err := json.Marshal(data)
@@ -35,14 +68,23 @@ func (b *Broker) Emit(event string, data any) {
 
 	b.mu.RLock()
 	chans := b.subs[event]
-	// Copy slice so we can iterate outside the lock.
-	snapshot := make([]chan string, len(chans))
-	copy(snapshot, chans)
+	namedSnap := make([]chan string, len(chans))
+	copy(namedSnap, chans)
+	allSnap := make([]chan Event, len(b.allSubs))
+	copy(allSnap, b.allSubs)
 	b.mu.RUnlock()
 
-	for _, ch := range snapshot {
+	for _, ch := range namedSnap {
 		select {
 		case ch <- msg:
+		default: // drop slow consumer
+		}
+	}
+
+	ev := Event{Name: event, Data: msg}
+	for _, ch := range allSnap {
+		select {
+		case ch <- ev:
 		default: // drop slow consumer
 		}
 	}
@@ -71,6 +113,43 @@ func (b *Broker) Subscribe(event string) (ch <-chan string, cancel func()) {
 		close(inner)
 	}
 	return
+}
+
+// ServeAll handles GET /events as a multiplexed SSE stream.
+// Every emitted event is forwarded using SSE named-event format:
+//
+//	event: <name>
+//	data: <json>
+//
+// Clients subscribe to specific event types with addEventListener(name, fn).
+func (b *Broker) ServeAll(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.WriteHeader(http.StatusOK)
+
+	ch, cancel := b.SubscribeAll()
+	defer cancel()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case ev, open := <-ch:
+			if !open {
+				return
+			}
+			_, _ = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.Name, ev.Data)
+			flusher.Flush()
+		}
+	}
 }
 
 // ServeHTTP handles GET /api/events/{eventName} as an SSE stream.

--- a/internal/sse/broker_test.go
+++ b/internal/sse/broker_test.go
@@ -65,6 +65,68 @@ func TestBroker_CancelUnsubscribes(t *testing.T) {
 	b.Emit("cancel.test", "after-cancel")
 }
 
+func TestBroker_ServeAll(t *testing.T) {
+	b := sse.New()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /events", b.ServeAll)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	type result struct {
+		eventType string
+		data      string
+	}
+	resultCh := make(chan result, 2)
+
+	go func() {
+		resp, err := http.Get(srv.URL + "/events")
+		if err != nil {
+			return
+		}
+		defer resp.Body.Close()
+		sc := bufio.NewScanner(resp.Body)
+		var pending result
+		received := 0
+		for sc.Scan() {
+			line := sc.Text()
+			if name, ok := strings.CutPrefix(line, "event: "); ok {
+				pending.eventType = name
+			} else if data, ok := strings.CutPrefix(line, "data: "); ok {
+				pending.data = data
+				resultCh <- pending
+				pending = result{}
+				received++
+				if received == 2 {
+					return // close body so srv.Close() doesn't block
+				}
+			}
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	b.Emit("issues:updated", map[string]int{"count": 3})
+	b.Emit("loopagent:updated", nil)
+
+	for range 2 {
+		select {
+		case got := <-resultCh:
+			switch got.eventType {
+			case "issues:updated":
+				if !strings.Contains(got.data, "count") {
+					t.Fatalf("unexpected issues data: %s", got.data)
+				}
+			case "loopagent:updated":
+				// nil marshals to "null"
+			default:
+				t.Fatalf("unexpected event type: %s", got.eventType)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("timeout waiting for SSE event")
+		}
+	}
+}
+
 func TestBroker_ServeHTTP(t *testing.T) {
 	b := sse.New()
 


### PR DESCRIPTION
## Motivation

Wails uses `runtime.EventsEmit` for Go→Frontend push events. In web mode this needs to be replaced with Server-Sent Events (SSE). The previous per-event approach opened one `EventSource` connection per subscribed event name, which is wasteful.

## Implementation information

Single multiplexed `GET /events` SSE stream replaces N per-event connections:

- `sse.Broker`: added `Event` type, `SubscribeAll()`, and `ServeAll()` HTTP handler that uses SSE named-event format (`event: <name>\ndata: <json>`)
- `synapse-server`: registers `GET /events`; existing `GET /api/events/{eventName}` kept for debugging/backward compat
- `api-http.ts`: `EventsOn` now shares a single `EventSource` instance — subscriptions use `addEventListener(name, fn)` so each listener only fires for its event type; ref-counted cleanup closes the connection when all listeners are removed
- `broker_test`: `TestBroker_ServeAll` verifies multiplexed delivery of `issues:updated` and `loopagent:updated` events

Desktop mode unchanged — still uses `runtime.EventsEmit`.

> Changelog: feat(web): SSE endpoint replacing Wails EventsEmit

Closes https://github.com/Automaat/synapse/issues/367