### PR TITLE
feat(worktree): setup commands

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -505,21 +505,36 @@ func cmdProjectCreate(ps *project.Store, args []string, jsonOut bool) int {
 
 func cmdProjectUpdate(ps *project.Store, args []string, jsonOut bool) int {
 	if len(args) < 1 {
-		return fatal(jsonOut, "usage: project update <id> --type work|pet")
+		return fatal(jsonOut, "usage: project update <id> [--type work|pet] [--setup-commands cmd1,cmd2]")
 	}
 	id := args[0]
 	fs := flag.NewFlagSet("project update", flag.ContinueOnError)
-	ptype := fs.String("type", "", "project type: pet|work (required)")
+	ptype := fs.String("type", "", "project type: pet|work")
+	setupCmds := fs.String("setup-commands", "", "comma-separated commands to run after worktree creation")
 	if err := fs.Parse(args[1:]); err != nil {
 		return fatal(jsonOut, "%v", err)
 	}
-	if *ptype == "" {
-		return fatal(jsonOut, "type is required")
+	if *ptype == "" && *setupCmds == "" {
+		return fatal(jsonOut, "at least one of --type or --setup-commands is required")
 	}
-	p, err := ps.Update(id, project.ProjectType(*ptype))
-	if err != nil {
-		return fatal(jsonOut, "%v", err)
+
+	var p project.Project
+	var err error
+
+	if *ptype != "" {
+		p, err = ps.Update(id, project.ProjectType(*ptype))
+		if err != nil {
+			return fatal(jsonOut, "%v", err)
+		}
 	}
+	if *setupCmds != "" {
+		cmds := strings.Split(*setupCmds, ",")
+		p, err = ps.SetSetupCommands(id, cmds)
+		if err != nil {
+			return fatal(jsonOut, "%v", err)
+		}
+	}
+
 	if jsonOut {
 		return printJSON(p)
 	}

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -586,6 +586,7 @@ export namespace project {
 	    url: string;
 	    clonePath: string;
 	    type: string;
+	    setupCommands?: string[];
 	    // Go type: time
 	    createdAt: any;
 	    // Go type: time
@@ -604,6 +605,7 @@ export namespace project {
 	        this.url = source["url"];
 	        this.clonePath = source["clonePath"];
 	        this.type = source["type"];
+	        this.setupCommands = source["setupCommands"];
 	        this.createdAt = this.convertValues(source["createdAt"], null);
 	        this.updatedAt = this.convertValues(source["updatedAt"], null);
 	    }

--- a/frontend/wailsjs/go/synapse/ProjectService.d.ts
+++ b/frontend/wailsjs/go/synapse/ProjectService.d.ts
@@ -16,4 +16,6 @@ export function OpenInEditor(arg1:string):Promise<void>;
 
 export function OpenInTerminal(arg1:string):Promise<void>;
 
+export function SetProjectSetupCommands(arg1:string,arg2:Array<string>):Promise<project.Project>;
+
 export function UpdateProject(arg1:string,arg2:string):Promise<project.Project>;

--- a/frontend/wailsjs/go/synapse/ProjectService.js
+++ b/frontend/wailsjs/go/synapse/ProjectService.js
@@ -30,6 +30,10 @@ export function OpenInTerminal(arg1) {
   return window['go']['synapse']['ProjectService']['OpenInTerminal'](arg1);
 }
 
+export function SetProjectSetupCommands(arg1, arg2) {
+  return window['go']['synapse']['ProjectService']['SetProjectSetupCommands'](arg1, arg2);
+}
+
 export function UpdateProject(arg1, arg2) {
   return window['go']['synapse']['ProjectService']['UpdateProject'](arg1, arg2);
 }

--- a/internal/project/model.go
+++ b/internal/project/model.go
@@ -10,15 +10,16 @@ const (
 )
 
 type Project struct {
-	ID        string      `yaml:"id" json:"id"`
-	Name      string      `yaml:"name" json:"name"`
-	Owner     string      `yaml:"owner" json:"owner"`
-	Repo      string      `yaml:"repo" json:"repo"`
-	URL       string      `yaml:"url" json:"url"`
-	ClonePath string      `yaml:"clone_path" json:"clonePath"`
-	Type      ProjectType `yaml:"type" json:"type"`
-	CreatedAt time.Time   `yaml:"created_at" json:"createdAt"`
-	UpdatedAt time.Time   `yaml:"updated_at" json:"updatedAt"`
+	ID            string      `yaml:"id" json:"id"`
+	Name          string      `yaml:"name" json:"name"`
+	Owner         string      `yaml:"owner" json:"owner"`
+	Repo          string      `yaml:"repo" json:"repo"`
+	URL           string      `yaml:"url" json:"url"`
+	ClonePath     string      `yaml:"clone_path" json:"clonePath"`
+	Type          ProjectType `yaml:"type" json:"type"`
+	SetupCommands []string    `yaml:"setup_commands,omitempty" json:"setupCommands,omitempty"`
+	CreatedAt     time.Time   `yaml:"created_at" json:"createdAt"`
+	UpdatedAt     time.Time   `yaml:"updated_at" json:"updatedAt"`
 }
 
 type Worktree struct {

--- a/internal/project/store.go
+++ b/internal/project/store.go
@@ -102,6 +102,17 @@ func (s *Store) Update(id string, ptype ProjectType) (Project, error) {
 	return p, s.writeFile(p)
 }
 
+// SetSetupCommands replaces the setup commands for a project.
+func (s *Store) SetSetupCommands(id string, cmds []string) (Project, error) {
+	p, err := s.Get(id)
+	if err != nil {
+		return p, err
+	}
+	p.SetupCommands = cmds
+	p.UpdatedAt = time.Now().UTC()
+	return p, s.writeFile(p)
+}
+
 func (s *Store) Delete(id string) error {
 	p, err := s.Get(id)
 	if err != nil {

--- a/internal/project/store_test.go
+++ b/internal/project/store_test.go
@@ -260,6 +260,36 @@ func TestStoreUpdateInvalidType(t *testing.T) {
 	}
 }
 
+func TestStoreSetSetupCommands(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := Project{ID: "owner/repo", Owner: "owner", Repo: "repo", Type: ProjectTypePet}
+	if err := store.writeFile(p); err != nil {
+		t.Fatal(err)
+	}
+
+	cmds := []string{"npm install", "mkdir -p dist"}
+	got, err := store.SetSetupCommands("owner/repo", cmds)
+	if err != nil {
+		t.Fatalf("SetSetupCommands: %v", err)
+	}
+	if len(got.SetupCommands) != 2 || got.SetupCommands[0] != "npm install" {
+		t.Errorf("SetupCommands = %v, want %v", got.SetupCommands, cmds)
+	}
+
+	persisted, err := store.Get("owner/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(persisted.SetupCommands) != 2 {
+		t.Errorf("persisted SetupCommands = %v, want %v", persisted.SetupCommands, cmds)
+	}
+}
+
 func TestStoreDeleteCleansClone(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/synapse/svc_projects.go
+++ b/internal/synapse/svc_projects.go
@@ -48,6 +48,17 @@ func (s *ProjectService) UpdateProject(id, ptype string) (project.Project, error
 	return p, nil
 }
 
+// SetProjectSetupCommands replaces the setup commands for a project.
+func (s *ProjectService) SetProjectSetupCommands(id string, cmds []string) (project.Project, error) {
+	s.logger.Info("project.set-setup-commands", "id", id, "count", len(cmds))
+	p, err := s.projects.SetSetupCommands(id, cmds)
+	if err != nil {
+		s.logger.Error("project.set-setup-commands.failed", "id", id, "err", err)
+		return p, err
+	}
+	return p, nil
+}
+
 // DeleteProject removes a project and its bare clone from disk.
 func (s *ProjectService) DeleteProject(id string) error {
 	s.logger.Info("project.delete", "id", id)

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -126,6 +127,7 @@ func (m *Manager) PrepareForTask(t task.Task) (string, error) {
 			m.logger.Warn("worktree.rebase-skipped", "task_id", t.ID, "base", baseRef, "err", err)
 		}
 		m.logger.Info("worktree.reused-branch", "task_id", t.ID, "path", wtPath, "branch", wtBranch)
+		m.runSetup(wtPath, proj.SetupCommands)
 		m.ensureBranch(t, wtBranch)
 		return wtPath, nil
 	}
@@ -134,6 +136,7 @@ func (m *Manager) PrepareForTask(t task.Task) (string, error) {
 		return "", fmt.Errorf("create worktree: %w", err)
 	}
 	m.logger.Info("worktree.created", "task_id", t.ID, "path", wtPath)
+	m.runSetup(wtPath, proj.SetupCommands)
 
 	if err := project.PushUpstream(wtPath, wtBranch); err != nil {
 		m.logger.Warn("worktree.push-upstream", "task_id", t.ID, "branch", wtBranch, "err", err)
@@ -168,6 +171,7 @@ func (m *Manager) PrepareForReview(t task.Task) (string, error) {
 		return "", fmt.Errorf("create review worktree: %w", err)
 	}
 	m.logger.Info("review.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
+	m.runSetup(wtPath, proj.SetupCommands)
 	return wtPath, nil
 }
 
@@ -202,6 +206,7 @@ func (m *Manager) PrepareForFix(t task.Task, prNumber int) (string, error) {
 		m.logger.Warn("fix.worktree.sanitize", "task_id", t.ID, "err", err)
 	}
 	m.logger.Info("fix.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
+	m.runSetup(wtPath, proj.SetupCommands)
 	return wtPath, nil
 }
 
@@ -302,6 +307,21 @@ func (m *Manager) List(projectID string) ([]project.Worktree, error) {
 		return nil, err
 	}
 	return project.ListWorktrees(proj.ClonePath)
+}
+
+// runSetup executes a project's setup commands inside the worktree directory.
+// Failures are logged but do not block worktree preparation.
+func (m *Manager) runSetup(wtPath string, commands []string) {
+	for _, raw := range commands {
+		cmd := exec.Command("sh", "-c", raw)
+		cmd.Dir = wtPath
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			m.logger.Warn("worktree.setup-cmd", "cmd", raw, "path", wtPath, "err", err, "output", string(out))
+			continue
+		}
+		m.logger.Info("worktree.setup-cmd", "cmd", raw, "path", wtPath)
+	}
 }
 
 func (m *Manager) ensureBranch(t task.Task, branch string) {

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -106,6 +106,45 @@ func TestValidatePath_PrefixEscapeBug(t *testing.T) {
 	}
 }
 
+func TestRunSetup(t *testing.T) {
+	dir := t.TempDir()
+	m := &Manager{logger: discardLogger()}
+
+	m.runSetup(dir, []string{
+		"touch setup-marker",
+		"mkdir -p sub/dir",
+	})
+
+	if _, err := os.Stat(filepath.Join(dir, "setup-marker")); err != nil {
+		t.Error("setup-marker should exist after runSetup")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "sub", "dir")); err != nil {
+		t.Error("sub/dir should exist after runSetup")
+	}
+}
+
+func TestRunSetupFailureNonFatal(t *testing.T) {
+	dir := t.TempDir()
+	m := &Manager{logger: discardLogger()}
+
+	// First command fails, second should still run
+	m.runSetup(dir, []string{
+		"false",
+		"touch after-fail",
+	})
+
+	if _, err := os.Stat(filepath.Join(dir, "after-fail")); err != nil {
+		t.Error("after-fail should exist — failing command must not stop subsequent ones")
+	}
+}
+
+func TestRunSetupEmpty(t *testing.T) {
+	m := &Manager{logger: discardLogger()}
+	// Should not panic with nil/empty commands
+	m.runSetup(t.TempDir(), nil)
+	m.runSetup(t.TempDir(), []string{})
+}
+
 func TestCleanupOrphaned(t *testing.T) {
 	dir := t.TempDir()
 	tasksDir := t.TempDir()


### PR DESCRIPTION
## Motivation

Agents in worktrees waste turns on predictable setup — `npm install`, creating stub dirs for `//go:embed`, etc. These fail, retry, and burn tokens. Observed agent 133301d8 losing ~5 turns to this.

Per-project `setup_commands` run automatically after worktree creation so agents start in a ready environment.

## Implementation information

- `Project.SetupCommands []string` field persisted in YAML
- `worktree.Manager.runSetup()` executes each command via `sh -c` in worktree dir
- Called from all three `Prepare*` methods (Task, Review, Fix) on fresh creation only
- Failures logged as warnings, non-fatal — don't block agent start
- CLI: `synapse-cli project update <id> --setup-commands "cmd1,cmd2"`
- Wails bound method: `SetProjectSetupCommands(id, cmds)`

Example config:
```yaml
setup_commands:
  - npm install --prefix frontend
  - mkdir -p frontend/dist && touch frontend/dist/.gitkeep
```