### PR TITLE
feat(workflow): cross-provider review+fix

### DIFF
--- a/internal/synapse/e2e_crossprovider_test.go
+++ b/internal/synapse/e2e_crossprovider_test.go
@@ -1,0 +1,229 @@
+//go:build !short
+
+package synapse
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Automaat/synapse/internal/task"
+	"github.com/Automaat/synapse/internal/workflow"
+)
+
+// setupCrossProviderEnv creates an e2e env with both fake-claude and fake-codex
+// on PATH, separate scenario files for each provider, and the test-review-fix
+// workflow loaded.
+func setupCrossProviderEnv(t *testing.T, defaultProvider string, claudeScenarios, codexScenarios []string) *e2eEnv {
+	t.Helper()
+
+	claudeSF := filepath.Join(t.TempDir(), "claude-scenarios.txt")
+	if err := os.WriteFile(claudeSF, []byte(strings.Join(claudeScenarios, "\n")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	codexSF := filepath.Join(t.TempDir(), "codex-scenarios.txt")
+	if err := os.WriteFile(codexSF, []byte(strings.Join(codexScenarios, "\n")), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := setupE2EProvider(t, defaultProvider, "")
+	t.Setenv("FAKE_CLAUDE_SCENARIO_FILE", claudeSF)
+	t.Setenv("FAKE_CODEX_SCENARIO_FILE", codexSF)
+	t.Setenv("FAKE_CLAUDE_SCENARIO", "")
+	t.Setenv("FAKE_CODEX_SCENARIO", "")
+
+	// Load test-review-fix workflow.
+	src, err := os.ReadFile("../../internal/workflow/testdata/test-review-fix.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(env.wfStore.Dir(), "test-review-fix.yaml")
+	if err := os.WriteFile(dst, src, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	return env
+}
+
+// TestE2E_CrossProvider_ReviewThenFix drives the test-review-fix workflow
+// through implement → maybe_review → code_review (cross-provider) → fix_review
+// and asserts all steps execute with correct roles and providers.
+func TestE2E_CrossProvider_ReviewThenFix(t *testing.T) {
+	// Default provider is claude → implement runs on claude.
+	// code_review has provider: cross → runs on codex.
+	// fix_review has no provider → runs on claude (default).
+	env := setupCrossProviderEnv(t, "claude",
+		[]string{"success", "success"}, // claude: implement, fix_review
+		[]string{"success"},            // codex: code_review (cross)
+	)
+
+	created, err := env.tasks.Create("cross-provider review test", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := env.startWorkflow(created.ID, "test-review-fix"); err != nil {
+		t.Fatal(err)
+	}
+
+	waitFor(t, 30*time.Second, "workflow completes", func() bool {
+		tk, gErr := env.tasks.Get(created.ID)
+		if gErr != nil {
+			return false
+		}
+		return tk.Workflow != nil &&
+			(tk.Workflow.State == workflow.ExecCompleted || tk.Workflow.State == workflow.ExecFailed)
+	})
+
+	tk, err := env.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tk.Workflow.State != workflow.ExecCompleted {
+		t.Fatalf("workflow state = %q, want completed (step: %s)", tk.Workflow.State, tk.Workflow.CurrentStep)
+	}
+
+	// Verify all expected steps ran in order.
+	stepIDs := stepIDsFromHistory(tk.Workflow)
+	for _, want := range []string{"implement", "maybe_review", "code_review", "fix_review"} {
+		if !slices.Contains(stepIDs, want) {
+			t.Errorf("step %q missing from history: %v", want, stepIDs)
+		}
+	}
+
+	// Verify step ordering: implement < code_review < fix_review.
+	implIdx := slices.Index(stepIDs, "implement")
+	reviewIdx := slices.Index(stepIDs, "code_review")
+	fixIdx := slices.Index(stepIDs, "fix_review")
+	if implIdx >= reviewIdx || reviewIdx >= fixIdx {
+		t.Errorf("step order wrong: want implement(%d) < code_review(%d) < fix_review(%d)",
+			implIdx, reviewIdx, fixIdx)
+	}
+
+	// Verify agent roles were recorded.
+	roles := agentRunRoles(tk)
+	for _, want := range []string{"implementation", "review", "fix-review"} {
+		if !slices.Contains(roles, want) {
+			t.Errorf("role %q missing from agent runs: %v", want, roles)
+		}
+	}
+}
+
+// TestE2E_CrossProvider_NoreviewTagSkipsReview verifies that a task tagged
+// "noreview" bypasses code_review and fix_review via the maybe_review
+// condition step.
+func TestE2E_CrossProvider_NoreviewTagSkipsReview(t *testing.T) {
+	env := setupCrossProviderEnv(t, "claude",
+		[]string{"success"}, // claude: implement only
+		[]string{},          // codex: nothing (review skipped)
+	)
+
+	created, err := env.tasks.Create("noreview test", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tags := []string{"noreview"}
+	if _, err := env.tasks.Update(created.ID, task.Update{Tags: &tags}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := env.startWorkflow(created.ID, "test-review-fix"); err != nil {
+		t.Fatal(err)
+	}
+
+	waitFor(t, 30*time.Second, "workflow completes", func() bool {
+		tk, gErr := env.tasks.Get(created.ID)
+		if gErr != nil {
+			return false
+		}
+		return tk.Workflow != nil &&
+			(tk.Workflow.State == workflow.ExecCompleted || tk.Workflow.State == workflow.ExecFailed)
+	})
+
+	tk, err := env.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tk.Workflow.State != workflow.ExecCompleted {
+		t.Fatalf("workflow state = %q, want completed (step: %s)", tk.Workflow.State, tk.Workflow.CurrentStep)
+	}
+
+	stepIDs := stepIDsFromHistory(tk.Workflow)
+
+	// maybe_review condition must still execute.
+	if !slices.Contains(stepIDs, "maybe_review") {
+		t.Errorf("maybe_review missing — condition must still run: %v", stepIDs)
+	}
+
+	// Review and fix steps must NOT run.
+	if slices.Contains(stepIDs, "code_review") {
+		t.Errorf("code_review must be skipped with noreview tag: %v", stepIDs)
+	}
+	if slices.Contains(stepIDs, "fix_review") {
+		t.Errorf("fix_review must be skipped with noreview tag: %v", stepIDs)
+	}
+
+	// No review/fix-review agent roles spawned.
+	roles := agentRunRoles(tk)
+	if slices.Contains(roles, "review") {
+		t.Errorf("review agent must not spawn with noreview tag: %v", roles)
+	}
+	if slices.Contains(roles, "fix-review") {
+		t.Errorf("fix-review agent must not spawn with noreview tag: %v", roles)
+	}
+}
+
+// TestE2E_CrossProvider_ReviewUsesOppositeProvider verifies that the
+// code_review step dispatches to the opposite provider via provider: cross.
+func TestE2E_CrossProvider_ReviewUsesOppositeProvider(t *testing.T) {
+	codexArgsLog := filepath.Join(t.TempDir(), "codex-args.log")
+	claudeArgsLog := filepath.Join(t.TempDir(), "claude-args.log")
+
+	env := setupCrossProviderEnv(t, "claude",
+		[]string{"success", "success"}, // claude: implement, fix_review
+		[]string{"success"},            // codex: code_review
+	)
+	t.Setenv("FAKE_CODEX_ARGS_LOG", codexArgsLog)
+	t.Setenv("FAKE_CLAUDE_ARGS_LOG", claudeArgsLog)
+
+	created, err := env.tasks.Create("provider verify test", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := env.startWorkflow(created.ID, "test-review-fix"); err != nil {
+		t.Fatal(err)
+	}
+
+	waitFor(t, 30*time.Second, "workflow completes", func() bool {
+		tk, gErr := env.tasks.Get(created.ID)
+		if gErr != nil {
+			return false
+		}
+		return tk.Workflow != nil &&
+			(tk.Workflow.State == workflow.ExecCompleted || tk.Workflow.State == workflow.ExecFailed)
+	})
+
+	tk, err := env.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tk.Workflow.State != workflow.ExecCompleted {
+		t.Fatalf("workflow state = %q, want completed (step: %s)", tk.Workflow.State, tk.Workflow.CurrentStep)
+	}
+
+	// Codex fake must have been invoked (review step).
+	if _, err := os.Stat(codexArgsLog); err != nil {
+		t.Fatalf("codex args log not written — review step did not invoke codex: %v", err)
+	}
+	codexArgs, err := os.ReadFile(codexArgsLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(codexArgs), "Review") {
+		t.Errorf("codex invocation should contain review prompt, got:\n%s", string(codexArgs))
+	}
+}

--- a/internal/workflow/builtin/simple-task.yaml
+++ b/internal/workflow/builtin/simple-task.yaml
@@ -279,4 +279,57 @@ steps:
     name: Ensure PR Closes Issue
     type: ensure_pr_closes_issue
     next:
+      - goto: maybe_review
+
+  # Skip review when tagged noreview (mirrors maybe_critique/nocritic pattern)
+  - id: maybe_review
+    name: Review Decision
+    type: condition
+    config:
+      check:
+        field: task.tags
+        operator: not_contains
+        value: noreview
+    next:
+      - when:
+          field: task.tags
+          operator: not_contains
+          value: noreview
+        goto: code_review
+      - goto: ""
+
+  - id: code_review
+    name: Code Review
+    type: run_agent
+    config:
+      role: review
+      mode: headless
+      provider: cross
+      needs_worktree: true
+      max_retries: 2
+      prompt: >-
+        Run /staff-code-review on https://github.com/{{.Task.ProjectID}}/pull/{{.Task.PRNumber}}
+
+        Save the full review output to /tmp/synapse-review-{{.Task.ID}}.md
+        Do NOT submit anything to GitHub. Only save to the file.
+    next:
+      - goto: fix_review
+
+  - id: fix_review
+    name: Fix Review Comments
+    type: run_agent
+    config:
+      role: fix-review
+      mode: headless
+      needs_worktree: true
+      max_retries: 2
+      prompt: >-
+        Read the code review at /tmp/synapse-review-{{.Task.ID}}.md
+
+        For each actionable finding (critical/high/medium severity), fix the code.
+        Skip low-severity nitpicks and style-only comments.
+
+        When done, commit and push. Sign commits with `git commit -s -S`.
+        Use conventional commit format: `fix(review): address review comments`.
+    next:
       - goto: ""

--- a/internal/workflow/testdata/test-review-fix.yaml
+++ b/internal/workflow/testdata/test-review-fix.yaml
@@ -1,0 +1,52 @@
+id: test-review-fix
+name: Test Review Fix
+description: Minimal workflow for testing cross-provider review + fix cycle
+trigger:
+  on: task.created
+steps:
+  - id: implement
+    name: Implement
+    type: run_agent
+    config:
+      role: implementation
+      mode: headless
+      prompt: "Implement {{.Task.ID}}"
+    next:
+      - goto: maybe_review
+
+  - id: maybe_review
+    name: Review Decision
+    type: condition
+    config:
+      check:
+        field: task.tags
+        operator: not_contains
+        value: noreview
+    next:
+      - when:
+          field: task.tags
+          operator: not_contains
+          value: noreview
+        goto: code_review
+      - goto: ""
+
+  - id: code_review
+    name: Code Review
+    type: run_agent
+    config:
+      role: review
+      mode: headless
+      provider: cross
+      prompt: "Review {{.Task.ID}}"
+    next:
+      - goto: fix_review
+
+  - id: fix_review
+    name: Fix Review Comments
+    type: run_agent
+    config:
+      role: fix-review
+      mode: headless
+      prompt: "Fix review comments for {{.Task.ID}}"
+    next:
+      - goto: ""


### PR DESCRIPTION
## Motivation

After implementation completes, run automated code review with a different provider (cross-provider) and then fix actionable findings with the original provider. Mirrors manual workflow: implement → staff-code-review (different provider) → fix-review (original provider, clean context).

## Implementation information

Extends simple-task.yaml with 3 new steps after ensure_pr_closes_issue:

- **maybe_review** (condition): skip when tagged `noreview`, mirrors existing `nocritic` pattern
- **code_review** (run_agent): `provider: cross` flips provider, runs `/staff-code-review` skill, saves output to temp file for handoff
- **fix_review** (run_agent): default provider, reads review file, fixes critical/high/medium findings

File-based handoff between review and fix avoids GitHub pending review visibility issues. No Go changes needed — all infrastructure (cross-provider resolution, roles, worktree reuse) already exists.

New e2e test suite (`e2e_crossprovider_test.go`) with separate per-provider scenario files:
- Full review+fix cycle with cross-provider dispatch
- `noreview` tag skip verification
- Opposite provider invocation verification via args log