### PR TITLE
feat(web): dual frontend builds desktop vs web

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Build frontend (needed for go:embed)
-        run: cd frontend && npm ci && npm run build
+        run: cd frontend && npm ci && npm run build:desktop
 
       - name: Run Go tests
         run: go test ./...
@@ -38,6 +38,12 @@ jobs:
       - name: Type-check
         run: cd frontend && npm run check
 
+      - name: Build desktop variant
+        run: cd frontend && npm run build:desktop
+
+      - name: Build web variant
+        run: cd frontend && npm run build:web
+
       - name: Run unit tests
         run: cd frontend && npx vitest run --passWithNoTests
 
@@ -50,7 +56,7 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Build frontend (needed for go:embed)
-        run: cd frontend && npm ci && npm run build
+        run: cd frontend && npm ci && npm run build:desktop
 
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
@@ -68,7 +74,7 @@ jobs:
         run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
 
       - name: Build frontend (needed for go:embed)
-        run: cd frontend && npm ci && npm run build
+        run: cd frontend && npm ci && npm run build:desktop
 
       - name: Regenerate bindings
         run: wails generate module

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:desktop": "VITE_MODE=desktop vite build",
+    "build:web": "VITE_MODE=web vite build",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "lint": "oxlint .",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,11 +3,20 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 import tailwindcss from '@tailwindcss/vite'
 import { fileURLToPath, URL } from 'url'
 
+const mode = process.env.VITE_MODE ?? 'desktop'
+const outDir = mode === 'web' ? 'dist-web' : 'dist'
+
 export default defineConfig({
   plugins: [
     tailwindcss(),
     svelte(),
   ],
+  build: {
+    outDir,
+  },
+  define: {
+    'import.meta.env.VITE_MODE': JSON.stringify(mode),
+  },
   resolve: {
     conditions: ['browser'],
     alias: {

--- a/mise.toml
+++ b/mise.toml
@@ -33,6 +33,6 @@ run = "cd frontend && npm run build:web && go build -o bin/synapse-server ./cmd/
 description = "Build HTTP server binary (builds web frontend first)"
 
 [tasks."dev:server"]
-run = "SYNAPSE_STATIC_DIR=frontend/dist-web go run ./cmd/synapse-server"
-description = "Run HTTP server with frontend static serving"
+run = ["cd frontend && npm run build:web", "SYNAPSE_STATIC_DIR=frontend/dist-web go run ./cmd/synapse-server"]
+description = "Build web frontend then run HTTP server"
 env = { SYNAPSE_PORT = "8080" }

--- a/mise.toml
+++ b/mise.toml
@@ -20,11 +20,19 @@ description = "Build CLI binary"
 run = ["golangci-lint run ./...", "cd frontend && npx oxlint ."]
 description = "Run all linters"
 
+[tasks."build:frontend:desktop"]
+run = "cd frontend && npm run build:desktop"
+description = "Build frontend for desktop (output: frontend/dist/)"
+
+[tasks."build:frontend:web"]
+run = "cd frontend && npm run build:web"
+description = "Build frontend for web (output: frontend/dist-web/)"
+
 [tasks."build:server"]
-run = "cd frontend && npm run build && go build -o bin/synapse-server ./cmd/synapse-server"
-description = "Build HTTP server binary (builds frontend first)"
+run = "cd frontend && npm run build:web && go build -o bin/synapse-server ./cmd/synapse-server"
+description = "Build HTTP server binary (builds web frontend first)"
 
 [tasks."dev:server"]
-run = "SYNAPSE_STATIC_DIR=frontend/dist go run ./cmd/synapse-server"
+run = "SYNAPSE_STATIC_DIR=frontend/dist-web go run ./cmd/synapse-server"
 description = "Run HTTP server with frontend static serving"
 env = { SYNAPSE_PORT = "8080" }


### PR DESCRIPTION
## Motivation

Frontend needs two build targets sharing all Svelte components but using different transport layers — desktop embeds into Wails via `go:embed`, web is served by synapse-server.

## Implementation information

- `vite.config.ts`: reads `VITE_MODE` env var (default: `desktop`), sets `outDir` to `dist/` or `dist-web/` and injects the constant via `define` so Vite tree-shakes the dead transport branch in `api.ts`
- `package.json`: adds `build:desktop` (`VITE_MODE=desktop vite build`) and `build:web` (`VITE_MODE=web vite build`) scripts; `build` script unchanged for backwards compatibility
- `mise.toml`: adds `build:frontend:desktop` and `build:frontend:web` tasks; updates `build:server` and `dev:server` to use web variant (`dist-web/`)
- CI: `test-go`, `lint-go`, `check-wailsjs` use `build:desktop` (needed for `go:embed`); `test-frontend` now builds both variants explicitly

## Supporting documentation

Depends on: #365 (api.ts shim — already merged)

> Changelog: feat(web): dual frontend builds desktop vs web

Closes https://github.com/Automaat/synapse/issues/368