### PR TITLE
feat(health): Go health checker + skill

### DIFF
--- a/.claude/skills/synapse-self-monitor.md
+++ b/.claude/skills/synapse-self-monitor.md
@@ -1,13 +1,13 @@
 ---
 name: synapse-self-monitor
-description: Periodic meta-analysis of orchestrator + agent runs. Reads session JSONLs, audit logs, and agent ndjson; detects bugs, cost outliers, and error patterns; files deduped GitHub issues with label synapse-self-monitor. Designed for loop-agent invocation every ~6h.
+description: Periodic deep analysis of agent runs and workflow health. Reads structured findings from Go health checker, investigates root causes by reading agent logs, cross-correlates patterns, and files deduped GitHub issues. Designed for loop-agent invocation every ~6h.
 allowed-tools: Bash, Read, Grep, Glob
 user-invocable: true
 ---
 
 # Synapse Self-Monitor
 
-Automated meta-analysis of the Synapse orchestrator and its agents. Scans recent session logs, audit events, and agent output for error patterns, cost outliers, and workflow anomalies. Files deduped GitHub issues for novel findings.
+Deep reasoning analysis of Synapse agent runs and workflow health. The Go health checker (`internal/health/`) runs every 10 minutes and produces structured findings (cost outliers, failure spikes, stuck tasks, workflow loops, status bounces, cost drift). This skill consumes those findings and investigates the **why** — reading agent conversation logs, cross-correlating patterns, and producing actionable recommendations.
 
 Designed to run as a loop agent (`/synapse-self-monitor` every 6h) but also works as a one-shot invocation.
 
@@ -19,109 +19,86 @@ Designed to run as a loop agent (`/synapse-self-monitor` every 6h) but also work
 
 ## Hard rules
 
-- **Cap at 5 new issues per run.** Beyond that, stop filing and report the overflow count in the summary. Why: avoids flooding the tracker on a bad day.
-- **Never reopen closed issues.** If the same finding matches a closed issue, skip it — the fix may already be deployed. Why: prevents noise loops on known-fixed problems.
-- **Always emit a JSON summary line at the end.** Why: the loop agent's audit trail captures the headless `result` event; a parseable summary makes downstream analysis easy.
-- **Read-only analysis.** Never modify tasks, agent state, or config. Only side effects: filing GitHub issues. Why: this skill runs outside the orchestrator lifecycle; mutations would race with the active orchestrator session.
+- **Cap at 5 new issues per run.** Beyond that, stop filing and report the overflow count in the summary.
+- **Never reopen closed issues.** If the same finding matches a closed issue, skip it.
+- **Always emit a JSON summary line at the end.** Parseable by downstream audit analysis.
+- **Read-only analysis.** Never modify tasks, agent state, or config. Only side effects: filing GitHub issues.
+- **Be specific.** Don't say "agent was expensive" — say "agent spent 47 turns reading every file in src/ instead of grepping for the symbol."
 
-## Phase 1 — Gather data (24h lookback)
-
-### Orchestrator session logs
-
-```bash
-# Find session JSONLs modified in the last 24h
-find ~/.claude/projects/ -name "*.jsonl" -mtime -1 -type f 2>/dev/null
-```
-
-For each file, extract tool_result content blocks and scan for error patterns (Phase 2).
-
-### Audit logs
+## Phase 1 — Gather structured health data
 
 ```bash
-# Today + yesterday
-cat ~/.synapse/logs/audit/$(date -u +%Y-%m-%d).ndjson ~/.synapse/logs/audit/$(date -u -v-1d +%Y-%m-%d).ndjson 2>/dev/null
+synapse-cli --json health
 ```
 
-Parse as NDJSON. Build:
-- `agent_completions[]` — all `agent.completed` events with role, cost, duration, state, name
-- `agent_failures[]` — all `agent.failed` events
-- `task_events[]` — all `task.*` events
+This returns the latest health report from the Go checker with all findings and stats.
 
-### Agent output logs (spot-check)
+If no report exists (app not running), fall back to manual audit analysis:
 
 ```bash
-# Today's agent ndjson files
-ls ~/.synapse/logs/agents/*-$(date -u +%Y-%m-%d)*.ndjson 2>/dev/null
+synapse-cli --json audit --since 24h --summary
 ```
 
-Only read specific agent logs when investigating a finding from Phase 2 (don't read all — too much data).
+For each finding with a `taskId`, fetch task details:
 
-## Phase 2 — Detect findings
+```bash
+synapse-cli --json get <taskId>
+```
 
-For each detector, produce a finding with: `category`, `title`, `evidence` (sample log lines), `suggested_fix`.
+## Phase 2 — Deep investigation
 
-### 2.1 Unknown skill errors
+For each finding, investigate the root cause. Prioritize: critical findings first, then warnings.
 
-Scan orchestrator session tool_result blocks for `<tool_use_error>Unknown skill: <name></tool_use_error>`.
+### Cost outliers
 
-- Finding title: `fix(skills): unknown skill <name>`
-- Evidence: the full error line + session file path
-- Fix: check `~/.synapse/.claude/skills/` for the missing skill; if absent, check `syncSkills()` in app.go
+1. Read the agent's NDJSON log file (path in finding's `logFile` or task's `agentRuns[].logFile`)
+2. Analyze tool call patterns:
+   - Is the agent reading too many files instead of grepping?
+   - Is it running expensive bash commands repeatedly?
+   - Is it stuck in a reasoning loop (same tool call 3+ times with similar args)?
+   - Is the task appropriately sized? (small task shouldn't need $15 of agent time)
+3. Check if the prompt/skill being invoked is inefficient
 
-### 2.2 Task parser warnings
+### Agent failures
 
-Scan orchestrator session tool_results for `task.parse.skip` warnings.
+1. Read failed agent's log to find the actual error
+2. Classify: transient (API rate limit, overloaded_error, network) vs systematic (bad prompt, missing context, wrong approach)
+3. Cross-reference: do multiple failures involve the same project, same codebase area, or same skill?
+4. Check if the failure is a known issue (same error pattern in recent runs)
 
-- Finding title: `fix(task): parser rejects <filename>`
-- Evidence: the warning line
-- Fix: either the file lacks frontmatter (sidecar file leaking into List) or has malformed YAML
+### Workflow loops (plan-reject cycles)
 
-### 2.3 Tool use errors (non-skill)
+1. Read the task's plan and plan-critique content
+2. Determine: is plan quality poor (agent not reading enough code), or are rejection criteria too strict?
+3. Check if the planner and critic are using the same codebase context
 
-Scan for `<tool_use_error>` patterns that are NOT Unknown skill errors.
+### Stuck tasks
 
-- Finding title: `fix(orchestrator): tool error: <short description>`
-- Evidence: the error text
-- Deduplicate by error text prefix (first 80 chars)
+1. Check if there's a live agent that simply hasn't reported (watchdog may handle this)
+2. Read the last agent's log to understand where progress stalled
+3. Check if the task depends on external input (human review, PR merge)
 
-### 2.4 Agent failures
+### Status bounces
 
-Check audit `agent.failed` events.
+1. Read task history to understand the back-and-forth
+2. Determine: is the workflow definition causing the bounce, or is it agent failures triggering retries?
 
-- Finding title: `fix(agent): <role> agent failed on <task_id>`
-- Evidence: the full audit event JSON
-- Group by role — if the same role failed 3+ times, consolidate into one issue
+### Cost drift
 
-### 2.5 Cost outliers
+1. Compare cost patterns by role — which role is driving the increase?
+2. Check if task complexity has changed (more large tasks) or if agents are becoming less efficient
+3. Look at recent skill/prompt changes that might affect token usage
 
-From `agent_completions`, compute per-role stats:
+## Phase 3 — Cross-correlation
 
-| Role | Alert threshold |
-|------|----------------|
-| eval | > $0.50 per run |
-| triage | > $0.50 per run |
-| implementation | > $15.00 per run |
-| pr-fix | > $5.00 per run |
-| any | total daily > $200 |
+After investigating individual findings, look for patterns across them:
 
-- Finding title: `perf(<role>): cost outlier $<amount> on <task_id>`
-- Evidence: the audit event + comparison to role average
+- **Codebase hotspots:** Multiple failures or expensive runs touching the same project or directory?
+- **Skill degradation:** Is one skill (triage, plan, eval) responsible for a disproportionate share of findings?
+- **Time patterns:** Do problems cluster at certain times? (e.g., rate limits during peak hours)
+- **Cascade effects:** Did one failure trigger a chain? (failed impl → stuck task → status bounce)
 
-### 2.6 Stuck in-progress tasks
-
-From audit, find tasks that entered `in-progress` over 6h ago with no subsequent `agent.completed` event.
-
-- Finding title: `fix(workflow): task <id> stuck in-progress >6h`
-- Evidence: the last status change event + current time
-
-### 2.7 Python/script crashes in orchestrator
-
-Scan orchestrator tool_results for `Traceback`, `TypeError`, `SyntaxError`, `NameError`.
-
-- Finding title: `fix(orchestrator): inline script crash: <error type>`
-- Evidence: the traceback text
-
-## Phase 3 — Deduplicate against existing issues
+## Phase 4 — File issues
 
 Determine the target repo:
 
@@ -129,13 +106,13 @@ Determine the target repo:
 REPO=$(cd ~/.synapse && gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
 ```
 
-If empty, try reading from `~/.synapse/config.yaml` or fall back to the first registered project:
+If empty, try the first registered project:
 
 ```bash
 REPO=$(synapse-cli --json project list 2>/dev/null | jq -r '.[0].id // empty')
 ```
 
-If still empty, skip issue filing entirely and just print findings to stdout.
+If still empty, skip issue filing and just print findings to stdout.
 
 Ensure label exists:
 
@@ -143,41 +120,43 @@ Ensure label exists:
 gh label create synapse-self-monitor --repo "$REPO" --color C5DEF5 --description "Filed by /synapse-self-monitor" 2>/dev/null || true
 ```
 
-For each finding, derive a stable title and search:
+For each confirmed finding (not false positives), derive a stable title and search for duplicates:
 
 ```bash
 gh issue list --repo "$REPO" --label synapse-self-monitor --state all --search "in:title \"<title prefix>\"" --json number,state,title --limit 3
 ```
 
-- If an **open** issue matches → skip (already tracked)
-- If a **closed** issue matches → skip (already fixed)
-- If no match → file new issue (up to the 5-issue cap)
+- Open match → skip
+- Closed match → skip
+- No match → file (up to 5-issue cap)
 
-## Phase 4 — File new issues
-
-For each novel finding (up to 5):
+Issue body format:
 
 ```bash
 gh issue create --repo "$REPO" --label synapse-self-monitor --title "<title>" --body "$(cat <<'EOF'
 ## Detection
 
 - **Time:** <ISO timestamp>
-- **Source:** <file path or audit event type>
-- **Detector:** synapse-self-monitor v1
+- **Category:** <finding category>
+- **Severity:** <severity>
+
+## Root cause
+
+<1-3 sentences explaining WHY this happened, based on log analysis>
 
 ## Evidence
 
 ```
-<sample log lines, max 20 lines>
+<relevant log excerpts, max 20 lines — tool calls, errors, patterns found>
 ```
 
-## Suggested fix
+## Recommended action
 
-<1-2 sentences>
+<specific, actionable recommendation — not "investigate further" but "update the eval skill prompt to grep for changed files instead of reading the full tree">
 
 ## Context
 
-Filed automatically by the synapse-self-monitor loop agent. Review and close when addressed.
+Filed by synapse-self-monitor. Findings from Go health checker investigated with agent log analysis.
 EOF
 )"
 ```
@@ -187,49 +166,46 @@ EOF
 Print exactly one JSON line to stdout as the final output:
 
 ```json
-{"findings": <total detected>, "filed": <new issues created>, "skipped_dup": <matched existing issues>, "skipped_cap": <over the 5-issue cap>, "errors": <analysis errors>}
+{"findings_total": 5, "investigated": 5, "confirmed": 3, "false_positives": 2, "filed": 2, "skipped_dup": 1, "skipped_cap": 0, "errors": 0}
 ```
-
-This line is captured by the headless agent's `result` event and persisted in the audit log, making it queryable by `/synapse-audit` and visible in the loop agent's run history.
 
 ## Examples
 
 <example>
-**Clean run — no findings.**
+**Clean run — no findings from health checker.**
 
-Orchestrator sessions have no errors. Audit shows 0 failures, all costs within thresholds. No stuck tasks.
+Health report shows 0 findings. Stats look normal.
 
 Output:
 ```json
-{"findings": 0, "filed": 0, "skipped_dup": 0, "skipped_cap": 0, "errors": 0}
+{"findings_total": 0, "investigated": 0, "confirmed": 0, "false_positives": 0, "filed": 0, "skipped_dup": 0, "skipped_cap": 0, "errors": 0}
 ```
 </example>
 
 <example>
-**Mixed findings with dedup.**
+**Cost outlier investigated — false positive.**
 
-Detects: 2 unknown skill errors (synapse-triage, synapse-monitor), 1 cost outlier (eval at $1.20), 3 task.parse.skip warnings. Existing open issue matches the skill error pattern. Cost outlier and 1 parse warning are novel.
+Health checker flags eval agent at $0.65 (threshold $0.50). Reading the log reveals the task was a large PR review (800 lines changed) — the cost is proportional to the work. Mark as false positive, don't file.
+
+Output:
+```json
+{"findings_total": 1, "investigated": 1, "confirmed": 0, "false_positives": 1, "filed": 0, "skipped_dup": 0, "skipped_cap": 0, "errors": 0}
+```
+</example>
+
+<example>
+**Multiple failures cross-correlated.**
+
+Health checker flags 3 agent failures + high failure rate. Reading logs reveals all 3 failed on the same project with `permission denied` errors on worktree paths. Root cause: stale worktree not cleaned up. File one consolidated issue instead of three.
 
 Actions:
-- Skip 2 skill errors (open issue exists)
-- Skip 2 parse warnings (same root cause, deduplicated to 1)
-- File: `perf(eval): cost outlier $1.20 on task-abc`
-- File: `fix(task): parser rejects 08d26c47.plan-critique.md`
+- Investigate 4 findings (3 failures + 1 failure_rate)
+- Confirm 1 root cause (stale worktree)
+- File 1 issue: `fix(worktree): stale worktree blocking agents on project X`
 
 Output:
 ```json
-{"findings": 4, "filed": 2, "skipped_dup": 2, "skipped_cap": 0, "errors": 0}
-```
-</example>
-
-<example>
-**Many findings, cap applies.**
-
-Detects 8 distinct novel findings. Files the first 5, skips the remaining 3 due to the cap.
-
-Output:
-```json
-{"findings": 8, "filed": 5, "skipped_dup": 0, "skipped_cap": 3, "errors": 0}
+{"findings_total": 4, "investigated": 4, "confirmed": 4, "false_positives": 0, "filed": 1, "skipped_dup": 0, "skipped_cap": 0, "errors": 0}
 ```
 </example>
 
@@ -237,7 +213,7 @@ Output:
 
 | Error | Response |
 |---|---|
-| No orchestrator session files found | Skip Phase 2.1-2.3, 2.7. Continue with audit-only detectors. |
-| Audit log missing | Skip audit-derived detectors (2.4-2.6). Report `errors: 1` in summary. |
-| `gh` auth failure or rate limit | Skip Phase 3-4. Print findings to stdout only. Report `errors: 1`. |
-| No repo determinable | Skip Phase 3-4. Print findings to stdout only. Not an error (may be expected for local-only setups). |
+| No health report and audit unavailable | Report `errors: 1` in summary. Skip investigation. |
+| Agent log file missing or unreadable | Note in investigation, don't fail the whole run. Continue with other findings. |
+| `gh` auth failure or rate limit | Skip Phase 4. Print findings to stdout only. Report `errors: 1`. |
+| No repo determinable | Skip Phase 4. Print findings to stdout only. Not an error. |

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"text/tabwriter"
@@ -76,6 +77,8 @@ func run(args []string) int {
 		return cmdAudit(cfg, rest, jsonOut)
 	case "board":
 		return cmdBoard(store, jsonOut)
+	case "health":
+		return cmdHealth(cfg, rest, jsonOut)
 	default:
 		return fatal(jsonOut, "unknown command: %s", cmd)
 	}
@@ -661,6 +664,80 @@ func cmdBoard(s *task.Manager, jsonOut bool) int {
 	return 0
 }
 
+func cmdHealth(cfg *config.Config, args []string, jsonOut bool) int {
+	fs := flag.NewFlagSet("health", flag.ContinueOnError)
+	severity := fs.String("severity", "", "filter by severity (warning|critical)")
+	category := fs.String("category", "", "filter by category")
+	if err := fs.Parse(args); err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+
+	path := filepath.Join(config.HomeDir(), "health-report.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fatal(jsonOut, "no health report yet (app must be running)")
+		}
+		return fatal(jsonOut, "read health report: %v", err)
+	}
+
+	var report healthReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		return fatal(jsonOut, "parse health report: %v", err)
+	}
+
+	if *severity != "" || *category != "" {
+		var filtered []json.RawMessage
+		for _, raw := range report.Findings {
+			var f struct {
+				Severity string `json:"severity"`
+				Category string `json:"category"`
+			}
+			if err := json.Unmarshal(raw, &f); err != nil {
+				continue
+			}
+			if *severity != "" && f.Severity != *severity {
+				continue
+			}
+			if *category != "" && f.Category != *category {
+				continue
+			}
+			filtered = append(filtered, raw)
+		}
+		report.Findings = filtered
+	}
+
+	if jsonOut {
+		return printJSON(report)
+	}
+
+	fmt.Printf("Health Report (generated %s)\n", report.GeneratedAt)
+	fmt.Printf("Period: %s to %s\n", report.PeriodStart, report.PeriodEnd)
+	fmt.Printf("Findings: %d\n\n", len(report.Findings))
+
+	for _, raw := range report.Findings {
+		var f struct {
+			Severity string `json:"severity"`
+			Category string `json:"category"`
+			Title    string `json:"title"`
+		}
+		if err := json.Unmarshal(raw, &f); err != nil {
+			continue
+		}
+		fmt.Printf("  [%s] %s: %s\n", f.Severity, f.Category, f.Title)
+	}
+	return 0
+}
+
+// healthReport mirrors the JSON structure without importing the health package.
+type healthReport struct {
+	GeneratedAt string            `json:"generatedAt"`
+	PeriodStart string            `json:"periodStart"`
+	PeriodEnd   string            `json:"periodEnd"`
+	Findings    []json.RawMessage `json:"findings"`
+	Stats       json.RawMessage   `json:"stats"`
+}
+
 func cmdAudit(cfg *config.Config, args []string, jsonOut bool) int {
 	fs := flag.NewFlagSet("audit", flag.ContinueOnError)
 	since := fs.String("since", "24h", "start of time window (duration like 24h/7d or date YYYY-MM-DD)")
@@ -764,6 +841,7 @@ Commands:
 
   audit    [--since DURATION|DATE] [--until DATE] [--type TYPE] [--task ID] [--summary]
   board    (status counts + in-progress/plan-review/human-required task lists)
+  health   [--severity warning|critical] [--category CATEGORY]
 
 Global flags:
   --json   Output as JSON`)

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -28,6 +28,7 @@ const (
 	EventTodoistImported     = "todoist.imported"
 	EventTodoistCompleted    = "todoist.completed"
 	EventRenovateCIFix       = "renovate.ci_fix_started"
+	EventHealthReport        = "health.report"
 )
 
 type Event struct {

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -1,0 +1,172 @@
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/Automaat/synapse/internal/audit"
+	"github.com/Automaat/synapse/internal/task"
+)
+
+const (
+	TickInterval = 10 * time.Minute
+	lookback     = 24 * time.Hour
+	weekLookback = 7 * 24 * time.Hour
+)
+
+// Checker runs periodic health checks on audit data and task state.
+type Checker struct {
+	auditDir string
+	tasks    *task.Manager
+	homeDir  string
+	logger   *slog.Logger
+	emit     func(string, any)
+
+	mu     sync.RWMutex
+	report *Report
+}
+
+// New creates a Checker. Call Run to start the ticker loop.
+func New(
+	auditDir string,
+	tasks *task.Manager,
+	homeDir string,
+	logger *slog.Logger,
+	emit func(string, any),
+) *Checker {
+	return &Checker{
+		auditDir: auditDir,
+		tasks:    tasks,
+		homeDir:  homeDir,
+		logger:   logger,
+		emit:     emit,
+	}
+}
+
+// Run blocks until ctx is done, running checks every TickInterval.
+// Runs one check immediately on start.
+func (c *Checker) Run(ctx context.Context) {
+	c.check()
+
+	ticker := time.NewTicker(TickInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.check()
+		}
+	}
+}
+
+// LatestReport returns the most recent health report (nil if none yet).
+func (c *Checker) LatestReport() *Report {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.report
+}
+
+func (c *Checker) check() {
+	now := time.Now().UTC()
+	since := now.Add(-lookback)
+
+	dayEvents, err := audit.Read(c.auditDir, audit.Query{Since: since, Until: now})
+	if err != nil {
+		c.logger.Warn("health.check.audit_read", "err", err)
+		dayEvents = nil
+	}
+
+	weekSince := now.Add(-weekLookback)
+	weekEvents, err := audit.Read(c.auditDir, audit.Query{Since: weekSince, Until: now})
+	if err != nil {
+		c.logger.Warn("health.check.audit_read_week", "err", err)
+		weekEvents = nil
+	}
+
+	tasks, err := c.tasks.List()
+	if err != nil {
+		c.logger.Warn("health.check.task_list", "err", err)
+		tasks = nil
+	}
+
+	var findings []Finding
+	findings = append(findings, checkFailureRate(dayEvents, now)...)
+	findings = append(findings, checkCostOutliers(dayEvents, now)...)
+	findings = append(findings, checkStuckTasks(dayEvents, tasks, now)...)
+	findings = append(findings, checkWorkflowLoops(dayEvents, now)...)
+	findings = append(findings, checkStatusBounce(dayEvents, now)...)
+	findings = append(findings, checkCostDrift(dayEvents, weekEvents, now)...)
+
+	stats := buildStats(dayEvents)
+
+	report := &Report{
+		GeneratedAt: now,
+		PeriodStart: since,
+		PeriodEnd:   now,
+		Findings:    findings,
+		Stats:       stats,
+	}
+
+	c.mu.Lock()
+	c.report = report
+	c.mu.Unlock()
+
+	c.persist(report)
+
+	if c.emit != nil {
+		c.emit("health:report", map[string]any{
+			"findings": len(findings),
+			"stats":    stats,
+		})
+	}
+
+	c.logger.Info("health.check.done", "findings", len(findings),
+		"total_cost", stats.TotalCostUSD, "failure_rate", stats.FailureRate)
+}
+
+func buildStats(events []audit.Event) Stats {
+	s := Stats{CostByRole: make(map[string]float64)}
+
+	for _, e := range events {
+		switch e.Type {
+		case audit.EventAgentCompleted:
+			s.TotalAgentRuns++
+			cost, _ := e.Data["cost_usd"].(float64)
+			s.TotalCostUSD += cost
+			role, _ := e.Data["role"].(string)
+			s.CostByRole[roleLabel(role)] += cost
+		case audit.EventAgentFailed:
+			s.TotalAgentRuns++
+			s.FailedAgentRuns++
+		}
+	}
+
+	if s.TotalAgentRuns > 0 {
+		s.FailureRate = round2(float64(s.FailedAgentRuns) / float64(s.TotalAgentRuns))
+	}
+	s.TotalCostUSD = round2(s.TotalCostUSD)
+	for k, v := range s.CostByRole {
+		s.CostByRole[k] = round2(v)
+	}
+
+	return s
+}
+
+func (c *Checker) persist(r *Report) {
+	path := filepath.Join(c.homeDir, "health-report.json")
+	data, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		c.logger.Warn("health.persist.marshal", "err", err)
+		return
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		c.logger.Warn("health.persist.write", "err", err)
+	}
+}

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -1,0 +1,303 @@
+package health
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/Automaat/synapse/internal/audit"
+	"github.com/Automaat/synapse/internal/task"
+)
+
+// costThresholds per agent role. Empty string key covers implementation agents.
+var costThresholds = map[string]float64{
+	"eval":   0.50,
+	"triage": 0.50,
+	"plan":   2.00,
+	"":       15.00,
+	"pr-fix": 5.00,
+}
+
+const (
+	dailyCostThreshold  = 200.0
+	failureRateLimit    = 0.30
+	minRunsForAlert     = 5
+	stuckHours          = 6
+	loopRejectThreshold = 3
+	costDriftPercent    = 0.50
+	costDriftMinRuns    = 10
+)
+
+// checkFailureRate flags when agent failure rate exceeds 30% with 5+ runs.
+func checkFailureRate(events []audit.Event, now time.Time) []Finding {
+	var completed, failed int
+	for _, e := range events {
+		switch e.Type {
+		case audit.EventAgentCompleted:
+			completed++
+		case audit.EventAgentFailed:
+			failed++
+		}
+	}
+
+	total := completed + failed
+	if total < minRunsForAlert {
+		return nil
+	}
+
+	rate := float64(failed) / float64(total)
+	if rate <= failureRateLimit {
+		return nil
+	}
+
+	return []Finding{{
+		Category:    CatFailureRate,
+		Severity:    SeverityCritical,
+		Title:       fmt.Sprintf("agent failure rate %.0f%% (%d/%d)", rate*100, failed, total),
+		Description: fmt.Sprintf("%d agents failed out of %d total runs in the last 24h", failed, total),
+		Evidence: map[string]any{
+			"completed":    completed,
+			"failed":       failed,
+			"failure_rate": round2(rate),
+		},
+		DetectedAt: now,
+	}}
+}
+
+// checkCostOutliers flags individual agent runs exceeding per-role thresholds
+// and daily total exceeding $200.
+func checkCostOutliers(events []audit.Event, now time.Time) []Finding {
+	var findings []Finding
+	var dailyTotal float64
+
+	for _, e := range events {
+		if e.Type != audit.EventAgentCompleted {
+			continue
+		}
+		cost, _ := e.Data["cost_usd"].(float64)
+		role, _ := e.Data["role"].(string)
+		dailyTotal += cost
+
+		threshold, ok := costThresholds[role]
+		if !ok {
+			threshold = costThresholds[""]
+		}
+		if cost <= threshold {
+			continue
+		}
+
+		logFile, _ := e.Data["log_file"].(string)
+		findings = append(findings, Finding{
+			Category:    CatCostOutlier,
+			Severity:    SeverityWarning,
+			Title:       fmt.Sprintf("%s agent cost $%.2f (threshold $%.2f)", roleLabel(role), cost, threshold),
+			Description: fmt.Sprintf("Agent run on task %s cost $%.2f, exceeding the $%.2f threshold for %s agents", e.TaskID, cost, threshold, roleLabel(role)),
+			TaskID:      e.TaskID,
+			AgentID:     e.AgentID,
+			Role:        role,
+			LogFile:     logFile,
+			Evidence: map[string]any{
+				"cost_usd":  cost,
+				"threshold": threshold,
+				"role":      role,
+			},
+			DetectedAt: now,
+		})
+	}
+
+	if dailyTotal > dailyCostThreshold {
+		findings = append(findings, Finding{
+			Category:    CatCostOutlier,
+			Severity:    SeverityCritical,
+			Title:       fmt.Sprintf("daily cost $%.2f exceeds $%.0f", dailyTotal, dailyCostThreshold),
+			Description: fmt.Sprintf("Total agent spend in the last 24h is $%.2f", dailyTotal),
+			Evidence: map[string]any{
+				"daily_total": round2(dailyTotal),
+				"threshold":   dailyCostThreshold,
+			},
+			DetectedAt: now,
+		})
+	}
+
+	return findings
+}
+
+// checkStuckTasks flags tasks in-progress for over 6h with no completion event.
+func checkStuckTasks(events []audit.Event, tasks []task.Task, now time.Time) []Finding {
+	// Build set of tasks that had a completion/failure event.
+	resolved := make(map[string]bool)
+	for _, e := range events {
+		if e.Type == audit.EventAgentCompleted || e.Type == audit.EventAgentFailed {
+			resolved[e.TaskID] = true
+		}
+	}
+
+	var findings []Finding
+	for i := range tasks {
+		t := &tasks[i]
+		if t.Status != task.StatusInProgress {
+			continue
+		}
+		if resolved[t.ID] {
+			continue
+		}
+		stuckDuration := now.Sub(t.UpdatedAt)
+		if stuckDuration < stuckHours*time.Hour {
+			continue
+		}
+
+		findings = append(findings, Finding{
+			Category:    CatStuckTask,
+			Severity:    SeverityWarning,
+			Title:       fmt.Sprintf("task %s stuck in-progress %.1fh", t.ID, stuckDuration.Hours()),
+			Description: fmt.Sprintf("Task %q has been in-progress for %.1f hours with no agent completion event", t.Title, stuckDuration.Hours()),
+			TaskID:      t.ID,
+			Evidence: map[string]any{
+				"stuck_hours": round2(stuckDuration.Hours()),
+				"updated_at":  t.UpdatedAt.Format(time.RFC3339),
+			},
+			DetectedAt: now,
+		})
+	}
+
+	return findings
+}
+
+// checkWorkflowLoops flags tasks with 3+ plan rejections (triage→plan→reject loops).
+func checkWorkflowLoops(events []audit.Event, now time.Time) []Finding {
+	rejectCounts := make(map[string]int)
+	for _, e := range events {
+		if e.Type == audit.EventPlanRejected {
+			rejectCounts[e.TaskID]++
+		}
+	}
+
+	var findings []Finding
+	for taskID, count := range rejectCounts {
+		if count < loopRejectThreshold {
+			continue
+		}
+		findings = append(findings, Finding{
+			Category:    CatWorkflowLoop,
+			Severity:    SeverityWarning,
+			Title:       fmt.Sprintf("task %s plan rejected %d times", taskID, count),
+			Description: fmt.Sprintf("Task has been through %d plan rejection cycles, indicating a triage→plan→reject loop", count),
+			TaskID:      taskID,
+			Evidence: map[string]any{
+				"rejection_count": count,
+			},
+			DetectedAt: now,
+		})
+	}
+
+	return findings
+}
+
+// checkStatusBounce flags tasks where the same status transition occurs 2+ times.
+func checkStatusBounce(events []audit.Event, now time.Time) []Finding {
+	// taskID → "from→to" → count
+	transitions := make(map[string]map[string]int)
+
+	for _, e := range events {
+		if e.Type != audit.EventTaskStatusChanged {
+			continue
+		}
+		from, _ := e.Data["from"].(string)
+		to, _ := e.Data["to"].(string)
+		if from == "" || to == "" {
+			continue
+		}
+
+		key := from + "→" + to
+		if transitions[e.TaskID] == nil {
+			transitions[e.TaskID] = make(map[string]int)
+		}
+		transitions[e.TaskID][key]++
+	}
+
+	var findings []Finding
+	for taskID, trans := range transitions {
+		for key, count := range trans {
+			if count < 2 {
+				continue
+			}
+			findings = append(findings, Finding{
+				Category:    CatStatusBounce,
+				Severity:    SeverityWarning,
+				Title:       fmt.Sprintf("task %s status bounce: %s (%dx)", taskID, key, count),
+				Description: fmt.Sprintf("Status transition %s occurred %d times, indicating the task is bouncing between states", key, count),
+				TaskID:      taskID,
+				Evidence: map[string]any{
+					"transition": key,
+					"count":      count,
+				},
+				DetectedAt: now,
+			})
+		}
+	}
+
+	return findings
+}
+
+// checkCostDrift compares today's average agent cost to 7-day rolling average.
+// Requires reading a wider audit window (caller provides 7-day events separately).
+func checkCostDrift(todayEvents, weekEvents []audit.Event, now time.Time) []Finding {
+	todayAvg, todayCount := avgCost(todayEvents)
+	weekAvg, weekCount := avgCost(weekEvents)
+
+	if todayCount < minRunsForAlert || weekCount < costDriftMinRuns {
+		return nil
+	}
+	if weekAvg == 0 {
+		return nil
+	}
+
+	drift := (todayAvg - weekAvg) / weekAvg
+	if drift <= costDriftPercent {
+		return nil
+	}
+
+	return []Finding{{
+		Category:    CatCostDrift,
+		Severity:    SeverityWarning,
+		Title:       fmt.Sprintf("cost drift +%.0f%% ($%.2f today vs $%.2f weekly avg)", drift*100, todayAvg, weekAvg),
+		Description: fmt.Sprintf("Today's average agent cost ($%.2f over %d runs) is %.0f%% higher than the 7-day average ($%.2f over %d runs)", todayAvg, todayCount, drift*100, weekAvg, weekCount),
+		Evidence: map[string]any{
+			"today_avg":  round2(todayAvg),
+			"today_runs": todayCount,
+			"week_avg":   round2(weekAvg),
+			"week_runs":  weekCount,
+			"drift_pct":  round2(drift * 100),
+		},
+		DetectedAt: now,
+	}}
+}
+
+func avgCost(events []audit.Event) (avg float64, n int) {
+	var total float64
+	var count int
+	for _, e := range events {
+		if e.Type != audit.EventAgentCompleted {
+			continue
+		}
+		if cost, ok := e.Data["cost_usd"].(float64); ok {
+			total += cost
+			count++
+		}
+	}
+	if count == 0 {
+		return 0, 0
+	}
+	return total / float64(count), count
+}
+
+func roleLabel(role string) string {
+	if role == "" {
+		return "implementation"
+	}
+	return role
+}
+
+func round2(f float64) float64 {
+	return math.Round(f*100) / 100
+}

--- a/internal/health/checks_test.go
+++ b/internal/health/checks_test.go
@@ -1,0 +1,300 @@
+package health
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Automaat/synapse/internal/audit"
+	"github.com/Automaat/synapse/internal/task"
+)
+
+func TestCheckFailureRate(t *testing.T) {
+	now := time.Now().UTC()
+	tests := []struct {
+		name      string
+		completed int
+		failed    int
+		wantN     int
+	}{
+		{"below threshold", 8, 2, 0},
+		{"above threshold", 5, 5, 1},
+		{"too few runs", 2, 2, 0},
+		{"no failures", 10, 0, 0},
+		{"all failures", 0, 6, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var events []audit.Event
+			for range tt.completed {
+				events = append(events, audit.Event{Type: audit.EventAgentCompleted, Timestamp: now})
+			}
+			for range tt.failed {
+				events = append(events, audit.Event{Type: audit.EventAgentFailed, Timestamp: now})
+			}
+			got := checkFailureRate(events, now)
+			if len(got) != tt.wantN {
+				t.Errorf("got %d findings, want %d", len(got), tt.wantN)
+			}
+		})
+	}
+}
+
+func TestCheckCostOutliers(t *testing.T) {
+	now := time.Now().UTC()
+
+	tests := []struct {
+		name string
+		runs []struct {
+			role string
+			cost float64
+		}
+		wantN int
+	}{
+		{
+			"no outliers",
+			[]struct {
+				role string
+				cost float64
+			}{{"eval", 0.20}, {"", 5.0}},
+			0,
+		},
+		{
+			"eval outlier",
+			[]struct {
+				role string
+				cost float64
+			}{{"eval", 1.50}},
+			1,
+		},
+		{
+			"impl outlier",
+			[]struct {
+				role string
+				cost float64
+			}{{"", 20.0}},
+			1,
+		},
+		{
+			"daily total exceeded",
+			[]struct {
+				role string
+				cost float64
+			}{{"", 14.0}, {"", 14.0}, {"", 14.0}, {"", 14.0}, {"", 14.0}, {"", 14.0}, {"", 14.0}, {"", 14.0}, {"", 14.0}, {"", 14.0}, {"", 14.0}, {"", 14.0}, {"", 14.0}, {"", 14.0}, {"", 14.0}},
+			1, // daily total only (individual runs are under $15)
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var events []audit.Event
+			for _, r := range tt.runs {
+				events = append(events, audit.Event{
+					Type:      audit.EventAgentCompleted,
+					Timestamp: now,
+					Data:      map[string]any{"cost_usd": r.cost, "role": r.role},
+				})
+			}
+			got := checkCostOutliers(events, now)
+			if len(got) != tt.wantN {
+				t.Errorf("got %d findings, want %d", len(got), tt.wantN)
+			}
+		})
+	}
+}
+
+func TestCheckStuckTasks(t *testing.T) {
+	now := time.Now().UTC()
+
+	tests := []struct {
+		name     string
+		tasks    []task.Task
+		resolved []string
+		wantN    int
+	}{
+		{
+			"task stuck over 6h",
+			[]task.Task{{ID: "t1", Status: task.StatusInProgress, UpdatedAt: now.Add(-7 * time.Hour)}},
+			nil,
+			1,
+		},
+		{
+			"task in-progress but recently updated",
+			[]task.Task{{ID: "t1", Status: task.StatusInProgress, UpdatedAt: now.Add(-1 * time.Hour)}},
+			nil,
+			0,
+		},
+		{
+			"task stuck but has completion event",
+			[]task.Task{{ID: "t1", Status: task.StatusInProgress, UpdatedAt: now.Add(-7 * time.Hour)}},
+			[]string{"t1"},
+			0,
+		},
+		{
+			"task not in-progress",
+			[]task.Task{{ID: "t1", Status: task.StatusTodo, UpdatedAt: now.Add(-7 * time.Hour)}},
+			nil,
+			0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var events []audit.Event
+			for _, id := range tt.resolved {
+				events = append(events, audit.Event{
+					Type:   audit.EventAgentCompleted,
+					TaskID: id,
+				})
+			}
+			got := checkStuckTasks(events, tt.tasks, now)
+			if len(got) != tt.wantN {
+				t.Errorf("got %d findings, want %d", len(got), tt.wantN)
+			}
+		})
+	}
+}
+
+func TestCheckWorkflowLoops(t *testing.T) {
+	now := time.Now().UTC()
+
+	tests := []struct {
+		name   string
+		counts map[string]int
+		wantN  int
+	}{
+		{"no loops", map[string]int{"t1": 1}, 0},
+		{"below threshold", map[string]int{"t1": 2}, 0},
+		{"at threshold", map[string]int{"t1": 3}, 1},
+		{"multiple tasks", map[string]int{"t1": 3, "t2": 4}, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var events []audit.Event
+			for taskID, n := range tt.counts {
+				for range n {
+					events = append(events, audit.Event{
+						Type:      audit.EventPlanRejected,
+						TaskID:    taskID,
+						Timestamp: now,
+					})
+				}
+			}
+			got := checkWorkflowLoops(events, now)
+			if len(got) != tt.wantN {
+				t.Errorf("got %d findings, want %d", len(got), tt.wantN)
+			}
+		})
+	}
+}
+
+func TestCheckStatusBounce(t *testing.T) {
+	now := time.Now().UTC()
+
+	tests := []struct {
+		name        string
+		transitions []struct{ taskID, from, to string }
+		wantN       int
+	}{
+		{
+			"no bounce",
+			[]struct{ taskID, from, to string }{
+				{"t1", "todo", "in-progress"},
+				{"t1", "in-progress", "in-review"},
+			},
+			0,
+		},
+		{
+			"bounce detected",
+			[]struct{ taskID, from, to string }{
+				{"t1", "todo", "in-progress"},
+				{"t1", "in-progress", "todo"},
+				{"t1", "todo", "in-progress"},
+				{"t1", "in-progress", "todo"},
+			},
+			2, // todo→in-progress x2 and in-progress→todo x2
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var events []audit.Event
+			for _, tr := range tt.transitions {
+				events = append(events, audit.Event{
+					Type:      audit.EventTaskStatusChanged,
+					TaskID:    tr.taskID,
+					Timestamp: now,
+					Data:      map[string]any{"from": tr.from, "to": tr.to},
+				})
+			}
+			got := checkStatusBounce(events, now)
+			if len(got) != tt.wantN {
+				t.Errorf("got %d findings, want %d", len(got), tt.wantN)
+			}
+		})
+	}
+}
+
+func TestCheckCostDrift(t *testing.T) {
+	now := time.Now().UTC()
+
+	mkEvents := func(n int, cost float64) []audit.Event {
+		events := make([]audit.Event, n)
+		for i := range n {
+			events[i] = audit.Event{
+				Type:      audit.EventAgentCompleted,
+				Timestamp: now,
+				Data:      map[string]any{"cost_usd": cost},
+			}
+		}
+		return events
+	}
+
+	tests := []struct {
+		name      string
+		todayN    int
+		todayCost float64
+		weekN     int
+		weekCost  float64
+		wantN     int
+	}{
+		{"no drift", 10, 1.0, 50, 1.0, 0},
+		{"significant drift", 10, 3.0, 50, 1.0, 1},
+		{"too few today runs", 3, 5.0, 50, 1.0, 0},
+		{"too few week runs", 10, 3.0, 5, 1.0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			today := mkEvents(tt.todayN, tt.todayCost)
+			week := mkEvents(tt.weekN, tt.weekCost)
+			got := checkCostDrift(today, week, now)
+			if len(got) != tt.wantN {
+				t.Errorf("got %d findings, want %d", len(got), tt.wantN)
+			}
+		})
+	}
+}
+
+func TestBuildStats(t *testing.T) {
+	now := time.Now().UTC()
+	events := []audit.Event{
+		{Type: audit.EventAgentCompleted, Timestamp: now, Data: map[string]any{"cost_usd": 1.5, "role": "eval"}},
+		{Type: audit.EventAgentCompleted, Timestamp: now, Data: map[string]any{"cost_usd": 3.0, "role": ""}},
+		{Type: audit.EventAgentFailed, Timestamp: now},
+		{Type: audit.EventTaskCreated, Timestamp: now}, // should be ignored
+	}
+
+	s := buildStats(events)
+
+	if s.TotalAgentRuns != 3 {
+		t.Errorf("TotalAgentRuns = %d, want 3", s.TotalAgentRuns)
+	}
+	if s.FailedAgentRuns != 1 {
+		t.Errorf("FailedAgentRuns = %d, want 1", s.FailedAgentRuns)
+	}
+	if s.TotalCostUSD != 4.5 {
+		t.Errorf("TotalCostUSD = %.2f, want 4.50", s.TotalCostUSD)
+	}
+	if s.CostByRole["eval"] != 1.5 {
+		t.Errorf("CostByRole[eval] = %.2f, want 1.50", s.CostByRole["eval"])
+	}
+	if s.CostByRole["implementation"] != 3.0 {
+		t.Errorf("CostByRole[implementation] = %.2f, want 3.00", s.CostByRole["implementation"])
+	}
+}

--- a/internal/health/types.go
+++ b/internal/health/types.go
@@ -1,0 +1,55 @@
+package health
+
+import "time"
+
+// Severity indicates how urgent a finding is.
+type Severity string
+
+const (
+	SeverityWarning  Severity = "warning"
+	SeverityCritical Severity = "critical"
+)
+
+// Category classifies what a finding is about.
+type Category string
+
+const (
+	CatFailureRate  Category = "failure_rate"
+	CatCostOutlier  Category = "cost_outlier"
+	CatStuckTask    Category = "stuck_task"
+	CatWorkflowLoop Category = "workflow_loop"
+	CatStatusBounce Category = "status_bounce"
+	CatCostDrift    Category = "cost_drift"
+)
+
+// Finding is a single health issue detected by the checker.
+type Finding struct {
+	Category    Category       `json:"category"`
+	Severity    Severity       `json:"severity"`
+	Title       string         `json:"title"`
+	Description string         `json:"description"`
+	TaskID      string         `json:"taskId,omitempty"`
+	AgentID     string         `json:"agentId,omitempty"`
+	Role        string         `json:"role,omitempty"`
+	LogFile     string         `json:"logFile,omitempty"`
+	Evidence    map[string]any `json:"evidence"`
+	DetectedAt  time.Time      `json:"detectedAt"`
+}
+
+// Stats aggregates basic metrics for the check window.
+type Stats struct {
+	TotalAgentRuns  int                `json:"totalAgentRuns"`
+	FailedAgentRuns int                `json:"failedAgentRuns"`
+	FailureRate     float64            `json:"failureRate"`
+	CostByRole      map[string]float64 `json:"costByRole"`
+	TotalCostUSD    float64            `json:"totalCostUsd"`
+}
+
+// Report is the output of a single health check run.
+type Report struct {
+	GeneratedAt time.Time `json:"generatedAt"`
+	PeriodStart time.Time `json:"periodStart"`
+	PeriodEnd   time.Time `json:"periodEnd"`
+	Findings    []Finding `json:"findings"`
+	Stats       Stats     `json:"stats"`
+}

--- a/internal/synapse/app.go
+++ b/internal/synapse/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Automaat/synapse/internal/config"
 	"github.com/Automaat/synapse/internal/events"
 	"github.com/Automaat/synapse/internal/github"
+	"github.com/Automaat/synapse/internal/health"
 	"github.com/Automaat/synapse/internal/logging"
 	"github.com/Automaat/synapse/internal/loopagent"
 	"github.com/Automaat/synapse/internal/notification"
@@ -241,6 +242,9 @@ func (a *App) Startup(ctx context.Context) error {
 
 	wdog := watchdog.New(a.agents, a.tasks, a.logger, emit, &a.wg)
 	a.wg.Go(func() { wdog.Run(ctx) })
+
+	hcheck := health.New(a.cfg.AuditDir(), a.tasks, config.HomeDir(), a.logger, emit)
+	a.wg.Go(func() { hcheck.Run(ctx) })
 
 	hub := poll.NewHub()
 	hub.Register(a.reviewer, 10*time.Second)


### PR DESCRIPTION
## Motivation

The `synapse-self-monitor` skill spent 100% of Claude agent tokens doing mechanical pattern matching (regex, threshold comparisons, NDJSON parsing) that Go can do with `strings.Contains()` and arithmetic. Meanwhile it missed reasoning-heavy analysis that would actually justify spawning a Claude agent.

## Implementation information

Split self-monitor into two layers:

**Go health checker** (`internal/health/`) — 10min ticker, 6 deterministic checks:
- Failure rate spikes (>30% with 5+ runs)
- Cost outliers per role (eval >$0.50, impl >$15, etc.) + daily total >$200
- Stuck in-progress tasks (>6h, no completion event)
- Workflow loops (3+ plan rejections on same task)
- Status bounces (same transition repeated 2+ times)
- Cost drift (today's avg >50% above 7-day rolling avg)

Persists report to `~/.synapse/health-report.json`, emits SSE event.

**CLI** — `synapse-cli health [--severity] [--category]` reads the persisted report.

**Rewritten skill** — consumes structured findings, focuses on reasoning:
- Reads agent NDJSON logs to diagnose WHY (tool call patterns, reasoning loops)
- Cross-correlates failures across projects/skills
- Files GitHub issues with root cause analysis, not just "cost outlier detected"
- Can mark Go findings as false positives after investigation

Tracks to umbrella issue #393.

## Supporting documentation

- #393