### PR TITLE
build(docker): add codex CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends gh \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && npm install -g @anthropic-ai/claude-code \
+    && npm install -g @anthropic-ai/claude-code @openai/codex \
     && rm -rf /root/.npm
 
 COPY --from=go-builder /bin/synapse-server /usr/local/bin/synapse-server


### PR DESCRIPTION
## Motivation

Synapse supports codex provider but Docker image only had claude-code CLI installed. Need codex for NAS deployment.

## Implementation information

Added `@openai/codex` to npm global install in Dockerfile alongside `@anthropic-ai/claude-code`.