### PR TITLE
refactor(workflow): mechanical evaluate step

### DIFF
--- a/cmd/fake-claude/main.go
+++ b/cmd/fake-claude/main.go
@@ -20,6 +20,8 @@
 //     turns. Exits when the parent closes stdin — e.g. the one-shot runner
 //     path that closes stdin after the first result event.
 //   - evaluate: runs synapse-cli to set status=in-review, emits result
+//   - pr_created: emits result with a github.com/.../pull/N URL so the
+//     mechanical link_pr_and_review step can extract the PR number via regex
 package main
 
 import (
@@ -124,6 +126,11 @@ func main() {
 			runCLI("update", taskID, "--status", "in-review")
 		}
 		emitResult("Evaluation complete. Status set to in-review.")
+
+	case "pr_created":
+		emitSystem()
+		emitAssistant("Implementing and pushing PR...")
+		emitResult("Implementation done. Created PR https://github.com/test-org/test-repo/pull/42")
 
 	default:
 		fmt.Fprintf(os.Stderr, "unknown scenario: %s\n", scenario)

--- a/cmd/fake-codex/main.go
+++ b/cmd/fake-codex/main.go
@@ -89,6 +89,9 @@ func runExec() {
 		emitAgentMessage("Evaluating...")
 		runCLI(taskID, "update", taskID, "--status", "in-review")
 		emitTurnCompleted(100, 20)
+	case "pr_created":
+		emitAgentMessage("Implementation done. Created PR https://github.com/test-org/test-repo/pull/42")
+		emitTurnCompleted(100, 20)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown scenario: %s\n", scenario)
 		os.Exit(2)

--- a/internal/synapse/e2e_workflow_test.go
+++ b/internal/synapse/e2e_workflow_test.go
@@ -467,11 +467,16 @@ func TestE2E_FullLifecycle_TriageThenImplement(t *testing.T) {
 	})
 }
 
-func TestE2E_ProviderMatrix_FullLifecycleSetsReviewStatus(t *testing.T) {
+// TestE2E_ProviderMatrix_FullLifecycleEvalFlipsHumanRequired verifies that
+// the mechanical evaluate step (no LLM) flips a successful task to
+// human-required when the workflow has no link_pr_and_review chain to find
+// a PR. test-simple.yaml goes implement → evaluate directly, so the eval
+// always reaches the "commits pushed but no PR created" branch.
+func TestE2E_ProviderMatrix_FullLifecycleEvalFlipsHumanRequired(t *testing.T) {
 	forEachProvider(t, func(t *testing.T, p providerSpec) {
-		env := setupE2EMultiProvider(t, p.provider, []string{"triage", "success", "evaluate"})
+		env := setupE2EMultiProvider(t, p.provider, []string{"triage", "success"})
 
-		created, err := env.tasks.Create("review lifecycle task", "", "headless")
+		created, err := env.tasks.Create("eval lifecycle task", "", "headless")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -480,13 +485,18 @@ func TestE2E_ProviderMatrix_FullLifecycleSetsReviewStatus(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		waitFor(t, 30*time.Second, "workflow completes with in-review status", func() bool {
+		waitFor(t, 30*time.Second, "workflow completes with human-required status", func() bool {
 			tk, err := env.tasks.Get(created.ID)
 			if err != nil {
 				return false
 			}
-			return tk.Workflow != nil && tk.Workflow.State == workflow.ExecCompleted && tk.Status == task.StatusInReview
+			return tk.Workflow != nil && tk.Workflow.State == workflow.ExecCompleted && tk.Status == task.StatusHumanRequired
 		})
+
+		tk, _ := env.tasks.Get(created.ID)
+		if tk.StatusReason != "commits pushed but no PR created" {
+			t.Errorf("status_reason = %q, want %q", tk.StatusReason, "commits pushed but no PR created")
+		}
 	})
 }
 
@@ -671,9 +681,10 @@ func TestE2E_Codex_HeadlessRetry_Overloaded(t *testing.T) {
 func TestE2E_InteractiveImplement_OneShotAdvancesToEvaluate(t *testing.T) {
 	// triage (sets status=todo) → interactive_implement (conversational,
 	// blocks on stdin for Claude / exits naturally for Codex) → evaluate
-	// (sets status=in-review).
+	// (mechanical, flips to human-required since test-simple.yaml has no
+	// link_pr_and_review chain).
 	forEachProvider(t, func(t *testing.T, p providerSpec) {
-		env := setupE2EMultiProvider(t, p.provider, []string{"triage", "interactive_implement", "evaluate"})
+		env := setupE2EMultiProvider(t, p.provider, []string{"triage", "interactive_implement"})
 
 		created, err := env.tasks.Create("interactive one-shot task", "", "interactive")
 		if err != nil {
@@ -700,10 +711,13 @@ func TestE2E_InteractiveImplement_OneShotAdvancesToEvaluate(t *testing.T) {
 			t.Fatalf("workflow state = %q (step %q), want completed",
 				tk.Workflow.State, tk.Workflow.CurrentStep)
 		}
-		// Evaluate sets status to in-review — the whole point of the fix is
-		// that interactive tasks can now reach this state automatically.
-		if tk.Status != task.StatusInReview {
-			t.Errorf("task status = %q, want in-review", tk.Status)
+		// Mechanical evaluate flips to human-required ("commits pushed but no
+		// PR created"); the original assertion was in-review when the LLM
+		// eval set the status itself. The point of this test is that
+		// interactive tasks now advance past implement at all — the exact
+		// terminal status is now decided by the mechanical eval.
+		if tk.Status != task.StatusHumanRequired {
+			t.Errorf("task status = %q, want human-required", tk.Status)
 		}
 
 		// Verify both the interactive implement and the headless evaluate ran.
@@ -963,8 +977,9 @@ func TestE2E_ConcurrentWorkflows(t *testing.T) {
 // evaluate and reaches ExecCompleted without re-running the interactive
 // implement step.
 func TestE2E_RecoverStaleInteractive(t *testing.T) {
-	// Only evaluate runs for real — implement is "recovered" via marker.
-	env := setupE2EMulti(t, []string{"evaluate"})
+	// No agent runs for real — implement is "recovered" via marker, and
+	// evaluate is now a mechanical Go step that doesn't invoke fake-claude.
+	env := setupE2EMulti(t, []string{})
 
 	created, err := env.tasks.Create("stale interactive task", "", "interactive")
 	if err != nil {
@@ -1002,8 +1017,8 @@ func TestE2E_RecoverStaleInteractive(t *testing.T) {
 	}
 	env.engine.HandleAgentComplete(created.ID, workflow.AgentCompletion{AgentID: "stale-agent", Success: true})
 
-	// Evaluate fires (fake-claude "evaluate" scenario sets status=in-review),
-	// then the workflow reaches ExecCompleted.
+	// Mechanical evaluate fires (no fake-claude invocation), flips the task
+	// to human-required, then the workflow reaches ExecCompleted.
 	waitFor(t, 20*time.Second, "workflow completes after stale recovery", func() bool {
 		tk, err := env.tasks.Get(created.ID)
 		if err != nil {
@@ -1071,12 +1086,7 @@ steps:
 
   - id: evaluate
     name: Evaluate Fix
-    type: run_agent
-    config:
-      role: eval
-      mode: headless
-      model: sonnet
-      prompt: "Evaluate {{.Task.ID}}"
+    type: evaluate
     next:
       - goto: ""
 `
@@ -1087,8 +1097,9 @@ steps:
 // Also verifies that a repeat DispatchEvent while the first is still running
 // returns ErrWorkflowAlreadyActive instead of launching a second workflow.
 func TestE2E_DispatchPREvent_FullRun(t *testing.T) {
-	// fix (success) → evaluate (sets status=in-review).
-	env := setupE2EMulti(t, []string{"success", "evaluate"})
+	// fix (success) → evaluate (mechanical, flips to human-required since
+	// the test workflow has no link_pr_and_review chain).
+	env := setupE2EMulti(t, []string{"success"})
 
 	// Install the test pr.event workflow alongside test-simple.
 	if err := os.WriteFile(
@@ -1142,9 +1153,10 @@ func TestE2E_DispatchPREvent_FullRun(t *testing.T) {
 	if tk.Workflow.WorkflowID != "test-pr-fix" {
 		t.Errorf("workflow on task = %q, want test-pr-fix", tk.Workflow.WorkflowID)
 	}
-	// evaluate scenario in fake-claude sets status=in-review via synapse-cli.
-	if tk.Status != task.StatusInReview {
-		t.Errorf("task status = %q, want in-review", tk.Status)
+	// Mechanical evaluate flips the task to human-required when no PR was
+	// found by the (absent) link_pr_and_review step.
+	if tk.Status != task.StatusHumanRequired {
+		t.Errorf("task status = %q, want human-required", tk.Status)
 	}
 	// Step history should record all three steps.
 	steps := map[string]bool{}

--- a/internal/synapse/e2e_workflow_test.go
+++ b/internal/synapse/e2e_workflow_test.go
@@ -1170,6 +1170,160 @@ func TestE2E_DispatchPREvent_FullRun(t *testing.T) {
 	}
 }
 
+// testEvalChainWorkflowYAML mirrors the real simple-task.yaml mechanical
+// chain (implement → link_pr_and_review → evaluate) used by the e2e tests
+// that exercise the full path from a successful agent through the two
+// mechanical fallback steps. verify_commits is intentionally omitted —
+// it requires a real git worktree and is independently covered by unit
+// tests in internal/workflow/engine_test.go.
+const testEvalChainWorkflowYAML = `id: test-eval-chain
+name: Test Eval Chain
+steps:
+  - id: set_in_progress
+    name: Mark In Progress
+    type: set_status
+    config:
+      status: in-progress
+    next:
+      - goto: implement
+
+  - id: implement
+    name: Implement
+    type: run_agent
+    config:
+      role: implementation
+      mode: headless
+      model: sonnet
+      prompt: "Implement {{.Task.ID}}"
+    next:
+      - goto: link_pr_and_review
+
+  - id: link_pr_and_review
+    name: Link PR and Review
+    type: link_pr_and_review
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: in-review
+        goto: ""
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
+      - goto: evaluate
+
+  - id: evaluate
+    name: Evaluate
+    type: evaluate
+    next:
+      - goto: ""
+`
+
+// TestE2E_EvalChain_PRURLInResultGoesInReview exercises the happy path
+// through the mechanical chain: implement emits a PR URL in its result,
+// link_pr_and_review picks it up via the regex path (path 2), flips the
+// task to in-review, and the workflow terminates without ever reaching
+// the mechanical evaluate step.
+func TestE2E_EvalChain_PRURLInResultGoesInReview(t *testing.T) {
+	env := setupE2EMulti(t, []string{"pr_created"})
+
+	if err := os.WriteFile(
+		filepath.Join(env.wfStore.Dir(), "test-eval-chain.yaml"),
+		[]byte(testEvalChainWorkflowYAML), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := env.tasks.Create("eval chain happy", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := env.startWorkflow(created.ID, "test-eval-chain"); err != nil {
+		t.Fatal(err)
+	}
+
+	waitFor(t, 20*time.Second, "eval chain workflow completes", func() bool {
+		tk, err := env.tasks.Get(created.ID)
+		if err != nil {
+			return false
+		}
+		return tk.Workflow != nil && tk.Workflow.State == workflow.ExecCompleted
+	})
+
+	tk, _ := env.tasks.Get(created.ID)
+	if tk.Status != task.StatusInReview {
+		t.Errorf("task status = %q, want in-review", tk.Status)
+	}
+	if tk.PRNumber != 42 {
+		t.Errorf("task pr_number = %d, want 42", tk.PRNumber)
+	}
+
+	// link_pr_and_review should have terminated the workflow before
+	// the mechanical evaluate step ran.
+	for _, r := range tk.Workflow.StepHistory {
+		if r.StepID == "evaluate" {
+			t.Errorf("evaluate step recorded — link_pr_and_review should have terminated the workflow")
+		}
+	}
+}
+
+// TestE2E_EvalChain_NoPRFlipsHumanRequired exercises the fallback path:
+// implement emits no PR URL, link_pr_and_review's three discovery paths
+// all miss, the mechanical evaluate step runs and flips the task to
+// human-required with the "commits pushed but no PR created" reason.
+func TestE2E_EvalChain_NoPRFlipsHumanRequired(t *testing.T) {
+	env := setupE2EMulti(t, []string{"success"})
+
+	if err := os.WriteFile(
+		filepath.Join(env.wfStore.Dir(), "test-eval-chain.yaml"),
+		[]byte(testEvalChainWorkflowYAML), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := env.tasks.Create("eval chain fallback", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := env.startWorkflow(created.ID, "test-eval-chain"); err != nil {
+		t.Fatal(err)
+	}
+
+	waitFor(t, 20*time.Second, "eval chain workflow completes", func() bool {
+		tk, err := env.tasks.Get(created.ID)
+		if err != nil {
+			return false
+		}
+		return tk.Workflow != nil && tk.Workflow.State == workflow.ExecCompleted
+	})
+
+	tk, _ := env.tasks.Get(created.ID)
+	if tk.Status != task.StatusHumanRequired {
+		t.Errorf("task status = %q, want human-required", tk.Status)
+	}
+	if tk.StatusReason != "commits pushed but no PR created" {
+		t.Errorf("status_reason = %q, want %q", tk.StatusReason, "commits pushed but no PR created")
+	}
+	if tk.PRNumber != 0 {
+		t.Errorf("task pr_number = %d, want 0", tk.PRNumber)
+	}
+
+	// Both the link_pr_and_review and evaluate steps must have run.
+	seen := map[string]bool{}
+	for _, r := range tk.Workflow.StepHistory {
+		seen[r.StepID] = true
+	}
+	for _, want := range []string{"implement", "link_pr_and_review", "evaluate"} {
+		if !seen[want] {
+			t.Errorf("missing step %q in history, got %v", want, seen)
+		}
+	}
+}
+
 // testAutoMergeWorkflowYAML mirrors the real builtin auto-merge.yaml trigger
 // (value: ready_to_merge) but replaces the shell merge step with a trivial
 // set_status step so the workflow can run to completion in e2e without

--- a/internal/workflow/builtin/pr-fix.yaml
+++ b/internal/workflow/builtin/pr-fix.yaml
@@ -64,35 +64,14 @@ steps:
         goto: ""
       - goto: evaluate
 
+  # Mechanical fallback (no LLM): reached only when link_pr_and_review failed
+  # to find a PR. Walks step history for the last run_agent record and flips
+  # the task to human-required with a truncated reason.
   - id: evaluate
     name: Evaluate Fix
-    type: run_agent
-    config:
-      role: eval
-      mode: headless
-      model: sonnet
-      prompt: >-
-        Evaluate task {{.Task.ID}}. Do NOT read source code or review diffs.
-
-        1. Run: synapse-cli --json get {{.Task.ID}}
-        2. Find the PR number:
-           a. Check task's pr_number field from step 1
-           b. Check agent result below for PR URLs (github.com/.../pull/N)
-           c. If neither found AND task has a branch, run: gh pr list --repo <project_id> --head <branch> --json number
-           If PR found by any method, link: synapse-cli --json update {{.Task.ID}} --pr <number>
-        3. Set status based on findings:
-           - PR exists → in-review
-           - Work done but no PR → human-required
-           - Failed/errors/incomplete → human-required (MUST include --status-reason)
-           Run: synapse-cli --json update {{.Task.ID}} --status <status> [--status-reason "reason"]
-
-        ## Agent Result
-
-        {{recoveredorprev .Workflow .Prev}}
-      allowed_tools:
-        - Bash
+    type: evaluate
     next:
-      - goto: ensure_pr_closes_issue
+      - goto: ""
 
   # Mechanical check (no LLM): if the task is linked to a GitHub issue,
   # make sure the PR's body carries a `Closes <issue-url>` reference so

--- a/internal/workflow/builtin/simple-task.yaml
+++ b/internal/workflow/builtin/simple-task.yaml
@@ -240,36 +240,14 @@ steps:
         goto: ""
       - goto: evaluate
 
+  # Mechanical fallback (no LLM): reached only when link_pr_and_review failed
+  # to find a PR. Walks step history for the last run_agent record and flips
+  # the task to human-required with a truncated reason.
   - id: evaluate
     name: Evaluate
-    type: run_agent
-    config:
-      role: eval
-      mode: headless
-      model: sonnet
-      prompt: >-
-        Evaluate task {{.Task.ID}}. Do NOT read source code or review diffs.
-
-        1. Run: synapse-cli --json get {{.Task.ID}}
-        2. Find the PR number:
-           a. Check task's pr_number field from step 1
-           b. Check agent result below for PR URLs (github.com/.../pull/N)
-           c. If neither found AND task has a branch, run: gh pr list --repo <project_id> --head <branch> --json number
-           If PR found by any method, link: synapse-cli --json update {{.Task.ID}} --pr <number>
-        3. Set status based on findings:
-           - PR exists → in-review
-           - Work done but no PR → human-required
-           - Failed/errors/incomplete → human-required (MUST include --status-reason)
-           - Never set done or todo
-           Run: synapse-cli --json update {{.Task.ID}} --status <status> [--status-reason "reason"]
-
-        ## Agent Result
-
-        {{recoveredorprev .Workflow .Prev}}
-      allowed_tools:
-        - Bash
+    type: evaluate
     next:
-      - goto: ensure_pr_closes_issue
+      - goto: ""
 
   # Mechanical check (no LLM): if the task is linked to a GitHub issue,
   # make sure the PR's body carries a `Closes <issue-url>` reference so

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -669,7 +669,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			return e.execRunAgent(taskID, step, wfExec, ctx)
 		case StepWaitHuman:
 			return e.execWaitHuman(taskID, step, wfExec)
-		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepVerifyCommits, StepLinkPRAndReview:
+		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate:
 			// handled below as sync steps
 		default:
 			return fmt.Errorf("unknown step type %q", step.Type)
@@ -737,6 +737,8 @@ func (e *Engine) execSyncStep(taskID string, step *Step, wfExec *Execution, ctx 
 		return e.execVerifyCommits(taskID, step, t)
 	case StepLinkPRAndReview:
 		return e.execLinkPRAndReview(taskID, step, wfExec, t)
+	case StepEvaluate:
+		return e.execEvaluate(taskID, step, wfExec)
 	default:
 		return StepOutput{}, fmt.Errorf("unknown step type %q", step.Type)
 	}
@@ -1145,6 +1147,41 @@ func (e *Engine) execLinkPRAndReview(taskID string, step *Step, wfExec *Executio
 
 	e.logger.Info("workflow.link-pr.no-pr", "task_id", taskID)
 	return StepOutput{StepID: step.ID, Status: "completed", Output: "no pr found: falling through to eval"}, nil
+}
+
+// execEvaluate is a non-LLM mechanical step that decides the terminal status
+// after link_pr_and_review has exhausted its PR-discovery paths. It walks step
+// history backwards for the most recent run_agent record (the impl/fix step)
+// and flips the task to human-required with a bounded reason string.
+//
+// This runs only when link_pr_and_review could not find a PR, so the task
+// always ends in human-required here — there is no in-review path.
+func (e *Engine) execEvaluate(taskID string, step *Step, wfExec *Execution) (StepOutput, error) {
+	var last *StepRecord
+	for i := len(wfExec.StepHistory) - 1; i >= 0; i-- {
+		if wfExec.StepHistory[i].AgentID != "" {
+			last = &wfExec.StepHistory[i]
+			break
+		}
+	}
+
+	reason := "no agent result to evaluate"
+	if last != nil {
+		if last.Status == "failed" {
+			reason = truncate(strings.TrimSpace(last.Output), 200)
+			if reason == "" {
+				reason = "agent failed with no output"
+			}
+		} else {
+			reason = "commits pushed but no PR created"
+		}
+	}
+
+	if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
+		return StepOutput{}, fmt.Errorf("evaluate: set human-required: %w", err)
+	}
+	e.logger.Info("workflow.evaluate.human-required", "task_id", taskID, "reason", reason)
+	return StepOutput{StepID: step.ID, Status: "completed", Output: reason}, nil
 }
 
 // parseIssueURL extracts owner/repo and issue number from a GitHub

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -59,12 +59,13 @@ func newTestStoreWith(t *testing.T, files ...string) *Store {
 // --- In-memory TaskProvider ---
 
 type memTasks struct {
-	mu    sync.Mutex
-	tasks map[string]*TaskInfo
+	mu      sync.Mutex
+	tasks   map[string]*TaskInfo
+	reasons map[string]string
 }
 
 func newMemTasks() *memTasks {
-	return &memTasks{tasks: make(map[string]*TaskInfo)}
+	return &memTasks{tasks: make(map[string]*TaskInfo), reasons: make(map[string]string)}
 }
 
 func (m *memTasks) Put(t TaskInfo) {
@@ -93,7 +94,7 @@ func (m *memTasks) ListTasks() ([]TaskInfo, error) {
 	return out, nil
 }
 
-func (m *memTasks) UpdateTaskStatus(id, status, _ string) error {
+func (m *memTasks) UpdateTaskStatus(id, status, reason string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	t, ok := m.tasks[id]
@@ -101,7 +102,15 @@ func (m *memTasks) UpdateTaskStatus(id, status, _ string) error {
 		return fmt.Errorf("task %s not found", id)
 	}
 	t.Status = status
+	m.reasons[id] = reason
 	return nil
+}
+
+// Reason returns the last status reason recorded for a task.
+func (m *memTasks) Reason(id string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.reasons[id]
 }
 
 func (m *memTasks) UpdateTaskPR(id string, prNumber int) error {
@@ -282,27 +291,26 @@ func TestFullLifecycle_DirectImplement(t *testing.T) {
 		t.Fatalf("expected implementation, got %q", agents.LastCall().Role)
 	}
 
-	// Simulate implement completes.
+	// Simulate implement completes. The mechanical evaluate step runs
+	// inline during AdvanceStep and terminates the workflow without
+	// spawning a new agent.
+	implCallCount := agents.CallCount()
 	agents.SimulateComplete("t1")
-	if err := engine.AdvanceStep("t1", StepOutput{StepID: "implement", Status: "completed", Output: "Done."}); err != nil {
+	if err := engine.AdvanceStep("t1", StepOutput{StepID: "implement", Status: "completed", Output: "Done.", AgentID: "agent-impl"}); err != nil {
 		t.Fatal(err)
 	}
 
-	// Evaluate step.
-	if agents.LastCall().Role != "eval" {
-		t.Fatalf("expected eval, got %q", agents.LastCall().Role)
+	if got := agents.CallCount(); got != implCallCount {
+		t.Errorf("evaluate spawned an agent (calls before=%d, after=%d) — should be mechanical", implCallCount, got)
 	}
 
-	// Simulate evaluate completes.
-	agents.SimulateComplete("t1")
-	if err := engine.AdvanceStep("t1", StepOutput{StepID: "evaluate", Status: "completed", Output: "evaluated"}); err != nil {
-		t.Fatal(err)
-	}
-
-	// Workflow should be completed.
+	// Workflow should be completed; mechanical evaluate flips to human-required.
 	ti, _ = tasks.GetTask("t1")
 	if ti.Workflow.State != ExecCompleted {
-		t.Fatalf("expected completed, got %q", ti.Workflow.State)
+		t.Fatalf("expected completed, got %q (current step %q)", ti.Workflow.State, ti.Workflow.CurrentStep)
+	}
+	if ti.Status != "human-required" {
+		t.Errorf("task status = %q, want human-required", ti.Status)
 	}
 }
 
@@ -2390,5 +2398,145 @@ func TestExecVerifyCommits_NoCommitsFlipsHumanRequired(t *testing.T) {
 	ti, _ := tasks.GetTask("t1")
 	if ti.Status != "human-required" {
 		t.Errorf("task status = %q, want human-required", ti.Status)
+	}
+}
+
+// --- evaluate step ---
+
+func newEvaluateStep() *Step {
+	return &Step{ID: "evaluate", Type: StepEvaluate}
+}
+
+func newEngineForEval(t *testing.T, tasks *memTasks) *Engine {
+	t.Helper()
+	store := newTestStore(t)
+	agents := newMockAgents()
+	return NewEngine(store, tasks, agents, discardLogger())
+}
+
+func TestExecEvaluate_LastAgentFailedFlipsHumanRequired(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := newEngineForEval(t, tasks)
+	wfExec := &Execution{
+		StepHistory: []StepRecord{
+			{StepID: "implement", Status: "failed", AgentID: "a1", Output: "rate limit exceeded"},
+		},
+	}
+
+	out, err := engine.execEvaluate("t1", newEvaluateStep(), wfExec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("step Status = %q, want completed", out.Status)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "human-required" {
+		t.Errorf("task status = %q, want human-required", ti.Status)
+	}
+	if got := tasks.Reason("t1"); got != "rate limit exceeded" {
+		t.Errorf("reason = %q, want %q", got, "rate limit exceeded")
+	}
+}
+
+func TestExecEvaluate_LastAgentFailedTruncatesLongReason(t *testing.T) {
+	long := strings.Repeat("x", 500)
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := newEngineForEval(t, tasks)
+	wfExec := &Execution{
+		StepHistory: []StepRecord{
+			{StepID: "implement", Status: "failed", AgentID: "a1", Output: long},
+		},
+	}
+
+	if _, err := engine.execEvaluate("t1", newEvaluateStep(), wfExec); err != nil {
+		t.Fatal(err)
+	}
+	got := tasks.Reason("t1")
+	if !strings.Contains(got, "(truncated)") {
+		t.Errorf("reason missing truncation marker: %q", got)
+	}
+	if len(got) >= len(long) {
+		t.Errorf("reason not truncated: %d chars", len(got))
+	}
+}
+
+func TestExecEvaluate_LastAgentSucceededFlipsHumanRequiredWithDefault(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := newEngineForEval(t, tasks)
+	wfExec := &Execution{
+		StepHistory: []StepRecord{
+			{StepID: "implement", Status: "completed", AgentID: "a1", Output: "Implementation done."},
+		},
+	}
+
+	if _, err := engine.execEvaluate("t1", newEvaluateStep(), wfExec); err != nil {
+		t.Fatal(err)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "human-required" {
+		t.Errorf("task status = %q, want human-required", ti.Status)
+	}
+	if got := tasks.Reason("t1"); got != "commits pushed but no PR created" {
+		t.Errorf("reason = %q, want %q", got, "commits pushed but no PR created")
+	}
+}
+
+func TestExecEvaluate_SkipsMechanicalStepsInHistory(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := newEngineForEval(t, tasks)
+	wfExec := &Execution{
+		StepHistory: []StepRecord{
+			{StepID: "implement", Status: "failed", AgentID: "a1", Output: "real error"},
+			{StepID: "verify_commits", Status: "completed"},
+			{StepID: "link_pr_and_review", Status: "completed", Output: "no pr found"},
+		},
+	}
+
+	if _, err := engine.execEvaluate("t1", newEvaluateStep(), wfExec); err != nil {
+		t.Fatal(err)
+	}
+	if got := tasks.Reason("t1"); got != "real error" {
+		t.Errorf("reason = %q, want %q (mechanical steps must be skipped)", got, "real error")
+	}
+}
+
+func TestExecEvaluate_EmptyHistory(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := newEngineForEval(t, tasks)
+	wfExec := &Execution{}
+
+	if _, err := engine.execEvaluate("t1", newEvaluateStep(), wfExec); err != nil {
+		t.Fatal(err)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "human-required" {
+		t.Errorf("task status = %q, want human-required", ti.Status)
+	}
+	if got := tasks.Reason("t1"); got != "no agent result to evaluate" {
+		t.Errorf("reason = %q, want %q", got, "no agent result to evaluate")
+	}
+}
+
+func TestExecEvaluate_FailedWithEmptyOutput(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := newEngineForEval(t, tasks)
+	wfExec := &Execution{
+		StepHistory: []StepRecord{
+			{StepID: "implement", Status: "failed", AgentID: "a1", Output: "   "},
+		},
+	}
+
+	if _, err := engine.execEvaluate("t1", newEvaluateStep(), wfExec); err != nil {
+		t.Fatal(err)
+	}
+	if got := tasks.Reason("t1"); got != "agent failed with no output" {
+		t.Errorf("reason = %q, want %q", got, "agent failed with no output")
 	}
 }

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -69,6 +69,7 @@ const (
 	StepEnsurePRClosesIssue StepType = "ensure_pr_closes_issue"
 	StepVerifyCommits       StepType = "verify_commits"
 	StepLinkPRAndReview     StepType = "link_pr_and_review"
+	StepEvaluate            StepType = "evaluate"
 )
 
 // Step is one node in the workflow graph.

--- a/internal/workflow/testdata/test-simple.yaml
+++ b/internal/workflow/testdata/test-simple.yaml
@@ -82,13 +82,6 @@ steps:
 
   - id: evaluate
     name: Evaluate
-    type: run_agent
-    config:
-      role: eval
-      mode: headless
-      model: sonnet
-      prompt: "Evaluate {{.Task.ID}}"
-      allowed_tools:
-        - Bash
+    type: evaluate
     next:
       - goto: ""


### PR DESCRIPTION
## Motivation

The `evaluate` workflow step was an LLM agent (`role: eval`, `model: sonnet`)
that fired after every implement/fix run. It only ever ran as a fallback —
two mechanical gates already handle the common cases:

1. `verify_commits` — flips `human-required` if the branch has 0 commits
   ahead of `origin/main`.
2. `link_pr_and_review` — three-path PR discovery (`task.pr_number` → regex
   on step history → `gh pr list --head <branch>`); sets `in-review` on hit.

When both miss, the LLM eval ran an inline prompt that duplicated that
logic and defaulted to `human-required` anyway. Cost: ~\$0.02 and ~5s per
completed task.

The backend already has everything needed: `AgentCompletion.Success` is
persisted into `StepRecord.Status`, and the agent result text is in
`StepRecord.Output`.

## Implementation information

New `StepEvaluate` step type with `execEvaluate` handler in
`internal/workflow/engine.go`, mirroring the existing `execVerifyCommits`
and `execLinkPRAndReview` mechanical-step pattern.

**Algorithm:**

1. Walk `wfExec.StepHistory` backwards, return the first record where
   `AgentID != ""` (the last `run_agent` step — `implement` for
   `simple-task.yaml`, `fix` for `pr-fix.yaml`). Mechanical steps in
   between are ignored.
2. If `Status == "failed"` → `human-required` with reason =
   `truncate(strings.TrimSpace(Output), 200)` (or `"agent failed with
   no output"` for empty output).
3. If `Status == "completed"` (reached only because `link_pr_and_review`
   did not find a PR) → `human-required` with reason =
   `"commits pushed but no PR created"`.
4. If history has no agent record at all → `human-required` with reason =
   `"no agent result to evaluate"`.

Reuses the existing `truncate()` helper. No new task model fields, no
`TaskProvider` interface changes, no `StepRecord` shape changes.

YAMLs (`simple-task.yaml`, `pr-fix.yaml`, `test-simple.yaml`, embedded
`testPRFixWorkflowYAML` in `e2e_workflow_test.go`) drop the 30-line
`run_agent` block for a 5-line `type: evaluate` + `goto: ""`. The
previous `next: ensure_pr_closes_issue` transition was unreachable —
eval only fired when no PR was found, so no PR to close.

**Test changes:**

- 6 new `TestExecEvaluate_*` cases covering failed / failed-truncated /
  succeeded / skips-mechanical-history / empty-history / failed-empty-output.
- `memTasks` fake extended to capture the `reason` argument so tests
  can assert the bounded message.
- `TestFullLifecycle_DirectImplement` updated: implement → AdvanceStep
  no longer spawns a new agent for eval, asserts workflow terminates in
  `human-required`.
- 3 e2e tests (`...InteractiveImplement_OneShotAdvancesToEvaluate`,
  `...DispatchPREvent_FullRun`, renamed `...FullLifecycleEvalFlipsHumanRequired`)
  flipped from asserting `in-review` to asserting `human-required` since
  the test workflows have no `link_pr_and_review` chain.

The `synapse-evaluate.md` skill file (user-invocable, manual re-triage)
is left untouched.

## Supporting documentation

Considered but rejected: keeping the LLM eval as a manual fallback path
and adding mechanical handlers in parallel. Rejected because the only
reachable case for the LLM was already a default-to-human-required, so
parallel paths would have been pure dead weight.

> Changelog: refactor(workflow): mechanical evaluate step