### PR TITLE
feat(config): per-machine automation routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,41 @@ tmux new-session -d -s synapse-<id> -x 200 -y 50 "claude"
 - GUI polls `tmux capture-pane -t synapse-<id> -p` for preview
 - User attaches via terminal
 
+### Per-Machine Automations
+
+Synapse can run on multiple machines (e.g. laptop + remote server). Each instance has its own `~/.synapse/` and runs background automations independently. Two routing axes prevent duplicate work:
+
+**1. Per-feature `enabled` toggle** (kill-switch per machine):
+- `todoist.enabled` — Todoist polling (`internal/synapse/app_todoist.go`)
+- `github.enabled` — GitHub Issues fetcher (`internal/synapse/app.go`)
+- `renovate.enabled` — Renovate CI fixer (`internal/synapse/app_renovate.go`)
+- Loop agents are stored per-machine in `~/.synapse/loop-agents/<id>.yaml` with their own `enabled` field — already independent.
+
+**2. Top-level `project_types` allowlist** (per-project-type routing):
+- Declares which `project.ProjectType` values this machine handles. Empty = all types.
+- All project-scoped automations filter via `cfg.AllowsProjectType(...)` (config helper).
+- Example: server handles `pet`, laptop handles `work`.
+
+```yaml
+# server config
+project_types: [pet]
+todoist:  { enabled: true, api_token: ... }
+github:   { enabled: true }
+renovate: { enabled: true }
+```
+
+```yaml
+# laptop config
+project_types: [work]
+todoist:  { enabled: false }
+github:   { enabled: true }
+renovate: { enabled: true }
+```
+
+Startup logs an `app.automations` summary line so you can verify the role of each instance at a glance.
+
+**Out of scope:** the orchestrator brain (`/synapse-monitor` Claude Code cron) is external to Synapse — manage it independently per machine via the Claude Code `schedule` skill.
+
 ## Development Workflow
 
 ### Running Locally
@@ -270,3 +305,4 @@ Frontend must build before Go compilation due to `//go:embed all:frontend/dist`:
 - ❌ Storing agent state in files — agents are in-memory only, tasks are file-backed
 - ❌ Editing files in `frontend/wailsjs/` — these are auto-generated, changes get overwritten
 - ❌ Using `allowed_tools: []` without understanding it means all tools with `--dangerously-skip-permissions`
+- ❌ Adding a new auto-task source without (a) an `Enabled bool` toggle in its config block and (b) `cfg.AllowsProjectType(...)` filtering if the source is project-scoped — both are required so users running Synapse on multiple machines can route work without duplication

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"gopkg.in/yaml.v3"
 )
@@ -16,6 +17,8 @@ type Config struct {
 	Orchestrator  OrchestratorConfig `yaml:"orchestrator" json:"orchestrator"`
 	Todoist       TodoistConfig      `yaml:"todoist" json:"todoist"`
 	Renovate      RenovateConfig     `yaml:"renovate" json:"renovate"`
+	GitHub        GitHubConfig       `yaml:"github" json:"github"`
+	ProjectTypes  []string           `yaml:"project_types" json:"projectTypes"`
 	TasksDir      string             `yaml:"tasks_dir" json:"tasksDir"`
 	SkillsDir     string             `yaml:"skills_dir" json:"skillsDir"`
 	RepoDir       string             `yaml:"repo_dir" json:"repoDir"`
@@ -23,6 +26,15 @@ type Config struct {
 	ClonesDir     string             `yaml:"clones_dir" json:"clonesDir"`
 	WorktreesDir  string             `yaml:"worktrees_dir" json:"worktreesDir"`
 	LoopAgentsDir string             `yaml:"loop_agents_dir" json:"loopAgentsDir"`
+}
+
+// AllowsProjectType reports whether automations on this machine should act on
+// projects of the given type. An empty ProjectTypes list means "all types".
+func (c *Config) AllowsProjectType(t string) bool {
+	if c == nil || len(c.ProjectTypes) == 0 {
+		return true
+	}
+	return slices.Contains(c.ProjectTypes, t)
 }
 
 type AuditConfig struct {
@@ -92,6 +104,10 @@ type RenovateConfig struct {
 	Author  string `yaml:"author" json:"author"`
 }
 
+type GitHubConfig struct {
+	Enabled bool `yaml:"enabled" json:"enabled"`
+}
+
 func HomeDir() string {
 	if dir := os.Getenv("SYNAPSE_HOME"); dir != "" {
 		return dir
@@ -124,6 +140,9 @@ func DefaultConfig() *Config {
 		Renovate: RenovateConfig{
 			Enabled: true,
 			Author:  "app/renovate",
+		},
+		GitHub: GitHubConfig{
+			Enabled: true,
 		},
 		TasksDir: defaultTasksDir(),
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -173,6 +173,42 @@ func TestLoadEmptyDirFallsBackToDefault(t *testing.T) {
 	}
 }
 
+func TestAllowsProjectType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		cfg   *Config
+		ptype string
+		want  bool
+	}{
+		{"nil config allows all", nil, "pet", true},
+		{"empty list allows all", &Config{}, "pet", true},
+		{"empty list allows work", &Config{}, "work", true},
+		{"pet-only allows pet", &Config{ProjectTypes: []string{"pet"}}, "pet", true},
+		{"pet-only blocks work", &Config{ProjectTypes: []string{"pet"}}, "work", false},
+		{"work-only blocks pet", &Config{ProjectTypes: []string{"work"}}, "pet", false},
+		{"both allows pet", &Config{ProjectTypes: []string{"pet", "work"}}, "pet", true},
+		{"both allows work", &Config{ProjectTypes: []string{"pet", "work"}}, "work", true},
+		{"unknown type blocked", &Config{ProjectTypes: []string{"pet"}}, "other", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.cfg.AllowsProjectType(tt.ptype); got != tt.want {
+				t.Errorf("AllowsProjectType(%q) = %v, want %v", tt.ptype, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultGitHubEnabled(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultConfig()
+	if !cfg.GitHub.Enabled {
+		t.Error("default GitHub.Enabled should be true for backward compat")
+	}
+}
+
 func TestDefaultRequirePermissions(t *testing.T) {
 	t.Parallel()
 	boolPtr := func(b bool) *bool { return &b }

--- a/internal/poll/issues.go
+++ b/internal/poll/issues.go
@@ -18,26 +18,43 @@ const synapseIssueLabel = "synapse"
 
 // IssuesFetcher polls GitHub for assigned and labeled issues and syncs them to tasks.
 type IssuesFetcher struct {
-	tasks    *task.Manager
-	projects *project.Store
-	emit     func(string, any)
-	logger   *slog.Logger
+	tasks         *task.Manager
+	projects      *project.Store
+	emit          func(string, any)
+	logger        *slog.Logger
+	allowsType    func(project.ProjectType) bool
+	fetchAssigned func() ([]github.Issue, error)
+	fetchLabeled  func(repos []string, label string) ([]github.Issue, error)
 }
 
-// NewIssuesFetcher creates an IssuesFetcher.
+// NewIssuesFetcher creates an IssuesFetcher. allowsType filters issues whose
+// repository is registered as a project — if it returns false for that
+// project's type, the issue is skipped. A nil closure means "allow all types".
 func NewIssuesFetcher(
 	tasks *task.Manager,
 	projects *project.Store,
 	emit func(string, any),
 	logger *slog.Logger,
+	allowsType func(project.ProjectType) bool,
 ) *IssuesFetcher {
-	return &IssuesFetcher{tasks: tasks, projects: projects, emit: emit, logger: logger}
+	if allowsType == nil {
+		allowsType = func(project.ProjectType) bool { return true }
+	}
+	return &IssuesFetcher{
+		tasks:         tasks,
+		projects:      projects,
+		emit:          emit,
+		logger:        logger,
+		allowsType:    allowsType,
+		fetchAssigned: github.FetchAssignedIssues,
+		fetchLabeled:  github.FetchLabeledIssuesForRepos,
+	}
 }
 
 func (f *IssuesFetcher) Name() string { return "issues" }
 
 func (f *IssuesFetcher) Poll(_ context.Context) time.Duration {
-	issues, err := github.FetchAssignedIssues()
+	issues, err := f.fetchAssigned()
 	if err != nil {
 		f.logger.Warn("issues.fetch", "err", err)
 		return IssuesPollInterval
@@ -60,7 +77,7 @@ func (f *IssuesFetcher) syncLabeledIssuesToTasks() {
 
 	var repos []string
 	for i := range projects {
-		if projects[i].Type == project.ProjectTypePet {
+		if f.allowsType(projects[i].Type) {
 			repos = append(repos, projects[i].ID)
 		}
 	}
@@ -68,7 +85,7 @@ func (f *IssuesFetcher) syncLabeledIssuesToTasks() {
 		return
 	}
 
-	labeled, err := github.FetchLabeledIssuesForRepos(repos, synapseIssueLabel)
+	labeled, err := f.fetchLabeled(repos, synapseIssueLabel)
 	if err != nil {
 		f.logger.Warn("labeled-issues.fetch", "err", err)
 		return
@@ -99,6 +116,13 @@ func (f *IssuesFetcher) syncIssuesToTasks(issues []github.Issue) {
 	for i := range issues {
 		issue := &issues[i]
 		if _, exists := issueURLs[issue.URL]; exists {
+			continue
+		}
+
+		// Skip issues from registered projects whose type isn't allowed on this
+		// machine. Issues from unregistered repos pass through (caller hasn't
+		// declared a type for them).
+		if proj, err := f.projects.Get(issue.Repository); err == nil && !f.allowsType(proj.Type) {
 			continue
 		}
 

--- a/internal/poll/issues_test.go
+++ b/internal/poll/issues_test.go
@@ -1,0 +1,359 @@
+package poll
+
+import (
+	"io"
+	"log/slog"
+	"sort"
+	"testing"
+
+	"github.com/Automaat/synapse/internal/github"
+	"github.com/Automaat/synapse/internal/project"
+	"github.com/Automaat/synapse/internal/task"
+)
+
+// issuesFetcherEnv holds the fully-wired dependencies for a single-machine
+// test scenario. Real task.Manager and real project.Store are used; only
+// the outbound gh calls are stubbed.
+type issuesFetcherEnv struct {
+	fetcher     *IssuesFetcher
+	tasks       *task.Manager
+	projects    *project.Store
+	projectsDir string
+}
+
+// newIssuesFetcherForTest wires an IssuesFetcher with real Manager/Store + an
+// injected labeled-issues fetcher so tests drive the full sync pipeline
+// without touching the gh CLI.
+func newIssuesFetcherForTest(
+	t *testing.T,
+	allowsType func(project.ProjectType) bool,
+	labeled []github.Issue,
+) *issuesFetcherEnv {
+	t.Helper()
+
+	projectsDir := t.TempDir()
+	clonesDir := t.TempDir()
+	projStore, err := project.NewStore(projectsDir, clonesDir)
+	if err != nil {
+		t.Fatalf("project.NewStore: %v", err)
+	}
+
+	taskStore, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("task.NewStore: %v", err)
+	}
+	taskMgr := task.NewManager(taskStore, nil)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	f := NewIssuesFetcher(taskMgr, projStore, func(string, any) {}, logger, allowsType)
+
+	// Inject the labeled fetch so tests control the "gh" response.
+	f.fetchLabeled = func([]string, string) ([]github.Issue, error) {
+		return labeled, nil
+	}
+	// Assigned path is exercised separately; default to empty to avoid gh.
+	f.fetchAssigned = func() ([]github.Issue, error) { return nil, nil }
+
+	return &issuesFetcherEnv{
+		fetcher:     f,
+		tasks:       taskMgr,
+		projects:    projStore,
+		projectsDir: projectsDir,
+	}
+}
+
+func TestIssuesFetcher_SyncIssuesToTasks_FiltersByProjectType(t *testing.T) {
+	t.Parallel()
+
+	petOnly := func(pt project.ProjectType) bool { return pt == project.ProjectTypePet }
+	workOnly := func(pt project.ProjectType) bool { return pt == project.ProjectTypeWork }
+	allowAll := func(project.ProjectType) bool { return true }
+
+	issues := []github.Issue{
+		{Number: 1, Title: "pet1 issue", URL: "https://github.com/acme/pet1/issues/1", Repository: "acme/pet1"},
+		{Number: 2, Title: "pet2 issue", URL: "https://github.com/acme/pet2/issues/2", Repository: "acme/pet2"},
+		{Number: 3, Title: "work1 issue", URL: "https://github.com/bigco/work1/issues/3", Repository: "bigco/work1"},
+		{Number: 4, Title: "unregistered", URL: "https://github.com/ext/tool/issues/4", Repository: "ext/tool"},
+	}
+
+	tests := []struct {
+		name       string
+		allowsType func(project.ProjectType) bool
+		// wantIssues is the set of issue URLs expected to have resulted in a
+		// task. Unregistered repos always pass through.
+		wantIssues []string
+	}{
+		{
+			name:       "pet-only machine skips work repos",
+			allowsType: petOnly,
+			wantIssues: []string{
+				"https://github.com/acme/pet1/issues/1",
+				"https://github.com/acme/pet2/issues/2",
+				"https://github.com/ext/tool/issues/4",
+			},
+		},
+		{
+			name:       "work-only machine skips pet repos",
+			allowsType: workOnly,
+			wantIssues: []string{
+				"https://github.com/bigco/work1/issues/3",
+				"https://github.com/ext/tool/issues/4",
+			},
+		},
+		{
+			name:       "allow-all accepts every registered and unregistered repo",
+			allowsType: allowAll,
+			wantIssues: []string{
+				"https://github.com/acme/pet1/issues/1",
+				"https://github.com/acme/pet2/issues/2",
+				"https://github.com/bigco/work1/issues/3",
+				"https://github.com/ext/tool/issues/4",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			env := newIssuesFetcherForTest(t, tt.allowsType, nil)
+			writeProject(t, env.projectsDir, "acme--pet1.yaml", "acme/pet1", "acme", "pet1", project.ProjectTypePet)
+			writeProject(t, env.projectsDir, "acme--pet2.yaml", "acme/pet2", "acme", "pet2", project.ProjectTypePet)
+			writeProject(t, env.projectsDir, "bigco--work1.yaml", "bigco/work1", "bigco", "work1", project.ProjectTypeWork)
+
+			env.fetcher.syncIssuesToTasks(issues)
+
+			gotURLs := taskIssueURLs(t, env.tasks)
+			assertStringSetEqual(t, gotURLs, tt.wantIssues)
+		})
+	}
+}
+
+func TestIssuesFetcher_SyncLabeledIssuesToTasks_HonorsClosure(t *testing.T) {
+	t.Parallel()
+
+	// Labeled fetch returns the full set; the fetcher is expected to narrow
+	// the repos it asks about via allowsType, and to drop any labeled results
+	// whose repo type isn't allowed even if the stub returned them.
+	labeled := []github.Issue{
+		{Number: 10, Title: "pet labeled", URL: "https://github.com/acme/pet1/issues/10", Repository: "acme/pet1"},
+		{Number: 11, Title: "work labeled", URL: "https://github.com/bigco/work1/issues/11", Repository: "bigco/work1"},
+	}
+
+	tests := []struct {
+		name       string
+		allowsType func(project.ProjectType) bool
+		// wantAskedRepos is the set of repos the labeled fetcher was asked
+		// about (proves the closure narrows the query).
+		wantAskedRepos []string
+		// wantTaskURLs is the set of issue URLs that should have produced tasks.
+		wantTaskURLs []string
+	}{
+		{
+			name:           "pet-only asks for pet repos only",
+			allowsType:     func(pt project.ProjectType) bool { return pt == project.ProjectTypePet },
+			wantAskedRepos: []string{"acme/pet1"},
+			wantTaskURLs:   []string{"https://github.com/acme/pet1/issues/10"},
+		},
+		{
+			name:           "work-only asks for work repos only",
+			allowsType:     func(pt project.ProjectType) bool { return pt == project.ProjectTypeWork },
+			wantAskedRepos: []string{"bigco/work1"},
+			wantTaskURLs:   []string{"https://github.com/bigco/work1/issues/11"},
+		},
+		{
+			name:           "allow-all asks for all repos",
+			allowsType:     func(project.ProjectType) bool { return true },
+			wantAskedRepos: []string{"acme/pet1", "bigco/work1"},
+			wantTaskURLs: []string{
+				"https://github.com/acme/pet1/issues/10",
+				"https://github.com/bigco/work1/issues/11",
+			},
+		},
+		{
+			name:           "deny-all never calls labeled fetcher",
+			allowsType:     func(project.ProjectType) bool { return false },
+			wantAskedRepos: nil,
+			wantTaskURLs:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			env := newIssuesFetcherForTest(t, tt.allowsType, labeled)
+			writeProject(t, env.projectsDir, "acme--pet1.yaml", "acme/pet1", "acme", "pet1", project.ProjectTypePet)
+			writeProject(t, env.projectsDir, "bigco--work1.yaml", "bigco/work1", "bigco", "work1", project.ProjectTypeWork)
+
+			var askedRepos []string
+			asked := false
+			env.fetcher.fetchLabeled = func(repos []string, label string) ([]github.Issue, error) {
+				asked = true
+				askedRepos = append([]string(nil), repos...)
+				if label != "synapse" {
+					t.Errorf("label = %q, want %q", label, synapseIssueLabel)
+				}
+				return labeled, nil
+			}
+
+			env.fetcher.syncLabeledIssuesToTasks()
+
+			if len(tt.wantAskedRepos) == 0 && asked {
+				t.Fatalf("fetchLabeled was called with %v, want no call", askedRepos)
+			}
+			if len(tt.wantAskedRepos) > 0 {
+				assertStringSetEqual(t, askedRepos, tt.wantAskedRepos)
+			}
+			assertStringSetEqual(t, taskIssueURLs(t, env.tasks), tt.wantTaskURLs)
+		})
+	}
+}
+
+func TestIssuesFetcher_SyncIssuesToTasks_SkipsAlreadyTracked(t *testing.T) {
+	t.Parallel()
+
+	env := newIssuesFetcherForTest(t, nil, nil)
+	writeProject(t, env.projectsDir, "acme--pet1.yaml", "acme/pet1", "acme", "pet1", project.ProjectTypePet)
+
+	existing, err := env.tasks.Create("already there", "", "headless")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := env.tasks.Update(existing.ID, task.Update{
+		Issue: task.Ptr("https://github.com/acme/pet1/issues/1"),
+	}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	env.fetcher.syncIssuesToTasks([]github.Issue{
+		{Number: 1, Title: "pet1 issue", URL: "https://github.com/acme/pet1/issues/1", Repository: "acme/pet1"},
+	})
+
+	tasks, err := env.tasks.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("task count = %d, want 1 (existing one only)", len(tasks))
+	}
+	if tasks[0].Title != "already there" {
+		t.Errorf("title = %q, want %q (pre-existing task should not be overwritten)", tasks[0].Title, "already there")
+	}
+}
+
+func TestIssuesFetcher_SyncIssuesToTasks_EnrichesURLTitledTasks(t *testing.T) {
+	t.Parallel()
+
+	env := newIssuesFetcherForTest(t, nil, nil)
+	writeProject(t, env.projectsDir, "acme--pet1.yaml", "acme/pet1", "acme", "pet1", project.ProjectTypePet)
+
+	stub, err := env.tasks.Create("https://github.com/acme/pet1/issues/5", "", "headless")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	env.fetcher.syncIssuesToTasks([]github.Issue{{
+		Number:     5,
+		Title:      "real title",
+		Body:       "real body",
+		URL:        "https://github.com/acme/pet1/issues/5",
+		Repository: "acme/pet1",
+	}})
+
+	tasks, err := env.tasks.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("task count = %d, want 1 (enriched, not duplicated)", len(tasks))
+	}
+	got, err := env.tasks.Get(stub.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Title != "real title" {
+		t.Errorf("Title = %q, want %q", got.Title, "real title")
+	}
+	if got.Issue != "https://github.com/acme/pet1/issues/5" {
+		t.Errorf("Issue = %q, want enriched URL", got.Issue)
+	}
+	if got.ProjectID != "acme/pet1" {
+		t.Errorf("ProjectID = %q, want %q", got.ProjectID, "acme/pet1")
+	}
+}
+
+// TestIssuesFetcher_CrossMachineRouting_PetAndWorkSplit verifies the
+// end-to-end routing story: two machines (pet-only and work-only) point at
+// the same shared project universe, and each machine's fetcher only creates
+// tasks for issues in its own slice of the repos.
+func TestIssuesFetcher_CrossMachineRouting_PetAndWorkSplit(t *testing.T) {
+	t.Parallel()
+
+	// Same issue stream delivered to both machines.
+	allIssues := []github.Issue{
+		{Number: 1, Title: "pet1 bug", URL: "https://github.com/acme/pet1/issues/1", Repository: "acme/pet1"},
+		{Number: 2, Title: "work1 bug", URL: "https://github.com/bigco/work1/issues/2", Repository: "bigco/work1"},
+		{Number: 3, Title: "work2 bug", URL: "https://github.com/bigco/work2/issues/3", Repository: "bigco/work2"},
+	}
+
+	petEnv := newIssuesFetcherForTest(
+		t,
+		func(pt project.ProjectType) bool { return pt == project.ProjectTypePet },
+		nil,
+	)
+	workEnv := newIssuesFetcherForTest(
+		t,
+		func(pt project.ProjectType) bool { return pt == project.ProjectTypeWork },
+		nil,
+	)
+
+	// Both machines see the same registered projects.
+	for _, dir := range []string{petEnv.projectsDir, workEnv.projectsDir} {
+		writeProject(t, dir, "acme--pet1.yaml", "acme/pet1", "acme", "pet1", project.ProjectTypePet)
+		writeProject(t, dir, "bigco--work1.yaml", "bigco/work1", "bigco", "work1", project.ProjectTypeWork)
+		writeProject(t, dir, "bigco--work2.yaml", "bigco/work2", "bigco", "work2", project.ProjectTypeWork)
+	}
+
+	petEnv.fetcher.syncIssuesToTasks(allIssues)
+	workEnv.fetcher.syncIssuesToTasks(allIssues)
+
+	assertStringSetEqual(t, taskIssueURLs(t, petEnv.tasks), []string{
+		"https://github.com/acme/pet1/issues/1",
+	})
+	assertStringSetEqual(t, taskIssueURLs(t, workEnv.tasks), []string{
+		"https://github.com/bigco/work1/issues/2",
+		"https://github.com/bigco/work2/issues/3",
+	})
+}
+
+func taskIssueURLs(t *testing.T, tm *task.Manager) []string {
+	t.Helper()
+	tasks, err := tm.List()
+	if err != nil {
+		t.Fatalf("tasks.List: %v", err)
+	}
+	out := make([]string, 0, len(tasks))
+	for i := range tasks {
+		if tasks[i].Issue != "" {
+			out = append(out, tasks[i].Issue)
+		}
+	}
+	return out
+}
+
+func assertStringSetEqual(t *testing.T, got, want []string) {
+	t.Helper()
+	g := append([]string(nil), got...)
+	w := append([]string(nil), want...)
+	sort.Strings(g)
+	sort.Strings(w)
+	if len(g) != len(w) {
+		t.Fatalf("len = %d, want %d: got=%v want=%v", len(g), len(w), got, want)
+	}
+	for i := range g {
+		if g[i] != w[i] {
+			t.Fatalf("index %d: got %q, want %q (got=%v want=%v)", i, g[i], w[i], got, want)
+		}
+	}
+}

--- a/internal/poll/renovate.go
+++ b/internal/poll/renovate.go
@@ -18,28 +18,36 @@ const (
 
 // RenovateHandler manages Renovate PR polling and actions.
 type RenovateHandler struct {
-	projects *project.Store
-	logger   *slog.Logger
-	emit     func(string, any)
-	cfg      *config.RenovateConfig
+	projects   *project.Store
+	logger     *slog.Logger
+	emit       func(string, any)
+	cfg        *config.RenovateConfig
+	allowsType func(project.ProjectType) bool
 }
 
-// NewRenovateHandler creates a RenovateHandler.
+// NewRenovateHandler creates a RenovateHandler. allowsType filters which
+// project types this machine handles; nil means all types.
 func NewRenovateHandler(
 	projects *project.Store,
 	logger *slog.Logger,
 	emit func(string, any),
 	cfg *config.RenovateConfig,
+	allowsType func(project.ProjectType) bool,
 ) *RenovateHandler {
+	if allowsType == nil {
+		allowsType = func(project.ProjectType) bool { return true }
+	}
 	return &RenovateHandler{
-		projects: projects,
-		logger:   logger,
-		emit:     emit,
-		cfg:      cfg,
+		projects:   projects,
+		logger:     logger,
+		emit:       emit,
+		cfg:        cfg,
+		allowsType: allowsType,
 	}
 }
 
-// Repos returns owner/repo strings for all registered projects.
+// Repos returns owner/repo strings for registered projects whose type is
+// allowed on this machine.
 func (h *RenovateHandler) Repos() []string {
 	projects, err := h.projects.List()
 	if err != nil {
@@ -48,6 +56,9 @@ func (h *RenovateHandler) Repos() []string {
 	}
 	repos := make([]string, 0, len(projects))
 	for i := range projects {
+		if !h.allowsType(projects[i].Type) {
+			continue
+		}
 		repos = append(repos, projects[i].Owner+"/"+projects[i].Repo)
 	}
 	return repos

--- a/internal/poll/renovate_test.go
+++ b/internal/poll/renovate_test.go
@@ -1,0 +1,93 @@
+package poll
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Automaat/synapse/internal/config"
+	"github.com/Automaat/synapse/internal/project"
+)
+
+func TestRenovateHandlerRepos_FilterByProjectType(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	clones := t.TempDir()
+	store, err := project.NewStore(dir, clones)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	writeProject(t, dir, "owner1--pet1.yaml", "owner1/pet1", "owner1", "pet1", project.ProjectTypePet)
+	writeProject(t, dir, "owner1--pet2.yaml", "owner1/pet2", "owner1", "pet2", project.ProjectTypePet)
+	writeProject(t, dir, "owner2--work1.yaml", "owner2/work1", "owner2", "work1", project.ProjectTypeWork)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	tests := []struct {
+		name      string
+		allowed   func(project.ProjectType) bool
+		wantRepos []string
+	}{
+		{
+			name:      "nil closure allows all",
+			allowed:   nil,
+			wantRepos: []string{"owner1/pet1", "owner1/pet2", "owner2/work1"},
+		},
+		{
+			name:      "pet only",
+			allowed:   func(t project.ProjectType) bool { return t == project.ProjectTypePet },
+			wantRepos: []string{"owner1/pet1", "owner1/pet2"},
+		},
+		{
+			name:      "work only",
+			allowed:   func(t project.ProjectType) bool { return t == project.ProjectTypeWork },
+			wantRepos: []string{"owner2/work1"},
+		},
+		{
+			name:      "none",
+			allowed:   func(project.ProjectType) bool { return false },
+			wantRepos: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := NewRenovateHandler(store, logger, func(string, any) {}, &config.RenovateConfig{}, tt.allowed)
+			got := h.Repos()
+			assertReposEqual(t, got, tt.wantRepos)
+		})
+	}
+}
+
+func writeProject(t *testing.T, dir, filename, id, owner, repo string, ptype project.ProjectType) {
+	t.Helper()
+	body := "id: " + id + "\nname: " + repo + "\nowner: " + owner + "\nrepo: " + repo + "\ntype: " + string(ptype) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, filename), []byte(body), 0o644); err != nil {
+		t.Fatalf("write project: %v", err)
+	}
+}
+
+func assertReposEqual(t *testing.T, got, want []string) {
+	t.Helper()
+	gotSet := make(map[string]bool, len(got))
+	for _, r := range got {
+		gotSet[r] = true
+	}
+	wantSet := make(map[string]bool, len(want))
+	for _, r := range want {
+		wantSet[r] = true
+	}
+	if len(gotSet) != len(wantSet) {
+		t.Fatalf("repos = %v, want %v", got, want)
+	}
+	for r := range wantSet {
+		if !gotSet[r] {
+			t.Fatalf("missing repo %q in %v", r, got)
+		}
+	}
+}

--- a/internal/synapse/app.go
+++ b/internal/synapse/app.go
@@ -230,7 +230,7 @@ func (a *App) Startup(ctx context.Context) error {
 
 	a.initTodoist(emit)
 	a.initRenovate(emit)
-	issuesFetcher := poll.NewIssuesFetcher(a.tasks, a.projects, emit, a.logger)
+	issuesFetcher := a.initIssuesFetcher(emit)
 	a.wireServices(emit)
 
 	a.syncSkills()
@@ -246,16 +246,67 @@ func (a *App) Startup(ctx context.Context) error {
 	hcheck := health.New(a.cfg.AuditDir(), a.tasks, config.HomeDir(), a.logger, emit)
 	a.wg.Go(func() { hcheck.Run(ctx) })
 
+	a.startPollHub(ctx, issuesFetcher)
+	a.startTodoistLoop(ctx)
+	a.logAutomationsSummary()
+	a.logger.Info("app.started")
+	return nil
+}
+
+// startPollHub registers all enabled poll handlers and starts the hub.
+func (a *App) startPollHub(ctx context.Context, issuesFetcher *poll.IssuesFetcher) {
 	hub := poll.NewHub()
 	hub.Register(a.reviewer, 10*time.Second)
-	hub.Register(issuesFetcher, 20*time.Second)
+	if issuesFetcher != nil {
+		hub.Register(issuesFetcher, 20*time.Second)
+	}
 	if a.renovateHandler != nil {
 		hub.Register(a.renovateHandler, 15*time.Second)
 	}
 	hub.Start(ctx, &a.wg, a.logger)
-	a.startTodoistLoop(ctx)
-	a.logger.Info("app.started")
-	return nil
+}
+
+// allowsProjectType reports whether project-scoped automations on this machine
+// should act on the given project type. Used to route automation work between
+// instances (e.g., pet projects on the server, work projects on the laptop).
+func (a *App) allowsProjectType(t project.ProjectType) bool {
+	return a.cfg.AllowsProjectType(string(t))
+}
+
+// initIssuesFetcher constructs the GitHub Issues fetcher if enabled, returning
+// nil otherwise. Kept separate so Startup stays under the funlen limit.
+func (a *App) initIssuesFetcher(emit func(string, any)) *poll.IssuesFetcher {
+	if !a.cfg.GitHub.Enabled {
+		a.logger.Info("github.disabled")
+		return nil
+	}
+	return poll.NewIssuesFetcher(a.tasks, a.projects, emit, a.logger, a.allowsProjectType)
+}
+
+// logAutomationsSummary logs a one-line snapshot of which automations this
+// machine runs. Useful when comparing two instances side by side.
+func (a *App) logAutomationsSummary() {
+	loopAgentsEnabled := 0
+	if a.loopAgents != nil {
+		if las, err := a.loopAgents.List(); err == nil {
+			for i := range las {
+				if las[i].Enabled {
+					loopAgentsEnabled++
+				}
+			}
+		}
+	}
+	projectTypes := a.cfg.ProjectTypes
+	if len(projectTypes) == 0 {
+		projectTypes = []string{"*"}
+	}
+	a.logger.Info("app.automations",
+		"todoist", a.cfg.Todoist.Enabled && a.cfg.Todoist.APIToken != "",
+		"github", a.cfg.GitHub.Enabled,
+		"renovate", a.cfg.Renovate.Enabled,
+		"project_types", projectTypes,
+		"loop_agents_enabled", loopAgentsEnabled,
+	)
 }
 
 func (a *App) initStats() {

--- a/internal/synapse/app_automation_routing_test.go
+++ b/internal/synapse/app_automation_routing_test.go
@@ -1,0 +1,105 @@
+package synapse
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/Automaat/synapse/internal/config"
+	"github.com/Automaat/synapse/internal/project"
+)
+
+// TestInitIssuesFetcher_GitHubDisabled_NoFetcherRegistered verifies the
+// machine-level kill switch: flipping GitHub.Enabled off means the Issues
+// fetcher is never constructed, so startPollHub has nothing to register.
+func TestInitIssuesFetcher_GitHubDisabled_NoFetcherRegistered(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		enabled bool
+		wantNil bool
+	}{
+		{"github disabled returns nil", false, true},
+		{"github enabled returns fetcher", true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := setupApp(t)
+			a.cfg = &config.Config{GitHub: config.GitHubConfig{Enabled: tt.enabled}}
+
+			got := a.initIssuesFetcher(func(string, any) {})
+
+			if tt.wantNil && got != nil {
+				t.Fatalf("initIssuesFetcher = %v, want nil when GitHub.Enabled=false", got)
+			}
+			if !tt.wantNil && got == nil {
+				t.Fatal("initIssuesFetcher = nil, want non-nil when GitHub.Enabled=true")
+			}
+		})
+	}
+}
+
+// TestAllowsProjectType_RoutingAcrossMachines verifies the config-driven
+// routing closure that IssuesFetcher/RenovateHandler receive. Two configs
+// (pet-only vs work-only) should answer different sets of project types.
+func TestAllowsProjectType_RoutingAcrossMachines(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		cfg       *config.Config
+		wantPet   bool
+		wantWork  bool
+		wantOther bool
+	}{
+		{
+			name:      "pet-only machine",
+			cfg:       &config.Config{ProjectTypes: []string{"pet"}},
+			wantPet:   true,
+			wantWork:  false,
+			wantOther: false,
+		},
+		{
+			name:      "work-only machine",
+			cfg:       &config.Config{ProjectTypes: []string{"work"}},
+			wantPet:   false,
+			wantWork:  true,
+			wantOther: false,
+		},
+		{
+			name:      "unrestricted machine",
+			cfg:       &config.Config{},
+			wantPet:   true,
+			wantWork:  true,
+			wantOther: true,
+		},
+		{
+			name:      "explicit both",
+			cfg:       &config.Config{ProjectTypes: []string{"pet", "work"}},
+			wantPet:   true,
+			wantWork:  true,
+			wantOther: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := &App{cfg: tt.cfg, logger: slog.Default()}
+
+			if got := a.allowsProjectType(project.ProjectTypePet); got != tt.wantPet {
+				t.Errorf("allowsProjectType(pet) = %v, want %v", got, tt.wantPet)
+			}
+			if got := a.allowsProjectType(project.ProjectTypeWork); got != tt.wantWork {
+				t.Errorf("allowsProjectType(work) = %v, want %v", got, tt.wantWork)
+			}
+			if got := a.allowsProjectType(project.ProjectType("other")); got != tt.wantOther {
+				t.Errorf("allowsProjectType(other) = %v, want %v", got, tt.wantOther)
+			}
+		})
+	}
+}

--- a/internal/synapse/app_renovate.go
+++ b/internal/synapse/app_renovate.go
@@ -6,6 +6,6 @@ func (a *App) initRenovate(emit func(string, any)) {
 	if !a.cfg.Renovate.Enabled {
 		return
 	}
-	a.renovateHandler = poll.NewRenovateHandler(a.projects, a.logger, emit, &a.cfg.Renovate)
+	a.renovateHandler = poll.NewRenovateHandler(a.projects, a.logger, emit, &a.cfg.Renovate, a.allowsProjectType)
 	a.logger.Info("renovate.enabled", "author", a.cfg.Renovate.Author)
 }


### PR DESCRIPTION
## Motivation

Synapse runs on two machines (laptop + remote server) with separate `~/.synapse/` stores. Background automations (Todoist, GitHub Issues, Renovate) auto-create tasks and dispatch agents on both — duplicate side effects on PRs, Todoist, agent runs.

Need per-machine routing without shared state / leader election.

## Implementation information

Two routing axes:

**1. Per-feature `enabled` toggle.** `github.enabled` joins the existing `todoist.enabled` and `renovate.enabled` toggles. Loop agents already per-machine via per-record YAML. Default `GitHub.Enabled=true` so single-machine setups keep working on upgrade.

**2. Top-level `project_types: [pet|work]` allowlist.** New `Config.AllowsProjectType(string) bool` helper; empty list = all types. Both `IssuesFetcher` and `RenovateHandler` take a `func(project.ProjectType) bool` closure (`App.allowsProjectType`) and filter projects through it.

```yaml
# server
project_types: [pet]
todoist:  { enabled: true, api_token: ... }
github:   { enabled: true }
renovate: { enabled: true }

# laptop
project_types: [work]
todoist:  { enabled: false }
github:   { enabled: true }
renovate: { enabled: true }
```

`app.Startup` logs an `app.automations` summary line so each instance's role is visible at a glance.

**Alternatives discarded:**
- Real leader election — needs shared coordination backend (Redis/etcd). Out of scope.
- Per-source instance tag — more granular but config sprawls; per-feature toggle + project-type filter covers the actual use case.

**Out of scope:** orchestrator brain `/synapse-monitor` Claude Code cron is external — managed per machine via the `schedule` skill.

## Supporting documentation

`CLAUDE.md` Per-Machine Automations section + Anti-Patterns note: every new auto-task source must add an `Enabled` toggle and, if project-scoped, filter via `cfg.AllowsProjectType`.

Tests: unit (`AllowsProjectType`, `RenovateHandler.Repos` filter) + e2e (full sync pipeline cross-machine pet/work split, GitHub kill switch, enrichment + dedupe paths). Injection seam added in `IssuesFetcher` for stubbing GH calls.

> Changelog: feat(config): per-machine automation routing