### PR TITLE
feat(chat): project-scoped chats with provider

### DIFF
--- a/frontend/src/components/NewChatDialog.svelte
+++ b/frontend/src/components/NewChatDialog.svelte
@@ -1,0 +1,205 @@
+<script lang="ts">
+  import { Dialog } from '@skeletonlabs/skeleton-svelte'
+  import { agentStore } from '../stores/agents.svelte.js'
+  import { projectStore } from '../stores/projects.svelte.js'
+
+  interface Props {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    oncreated?: (agentId: string) => void
+  }
+
+  const { open, onOpenChange, oncreated }: Props = $props()
+
+  let selectedProject = $state('')
+  let projectSearch = $state('')
+  let projectDropdownOpen = $state(false)
+  let provider = $state('claude')
+  let prompt = $state('')
+  let submitting = $state(false)
+  let error = $state('')
+
+  const filteredProjects = $derived(
+    projectStore.list.filter((p) => {
+      if (!projectSearch) return true
+      const q = projectSearch.toLowerCase()
+      return p.id.toLowerCase().includes(q) || p.name.toLowerCase().includes(q)
+    })
+  )
+
+  const selectedProjectName = $derived(
+    selectedProject ? projectStore.list.find((p) => p.id === selectedProject)?.id ?? '' : ''
+  )
+
+  function selectProject(id: string) {
+    selectedProject = id
+    projectSearch = ''
+    projectDropdownOpen = false
+  }
+
+  function clearProject() {
+    selectedProject = ''
+    projectSearch = ''
+    projectDropdownOpen = false
+  }
+
+  function reset() {
+    selectedProject = ''
+    projectSearch = ''
+    projectDropdownOpen = false
+    provider = 'claude'
+    prompt = ''
+    error = ''
+  }
+
+  function handleProjectBlur() {
+    setTimeout(() => { projectDropdownOpen = false }, 150)
+  }
+
+  async function handleSubmit(e: Event) {
+    e.preventDefault()
+    if (!selectedProject) {
+      error = 'Select a project'
+      return
+    }
+    submitting = true
+    error = ''
+    try {
+      const ag = await agentStore.startChat(selectedProject, provider, prompt.trim())
+      const newId = ag.id
+      reset()
+      onOpenChange(false)
+      oncreated?.(newId)
+    } catch (e) {
+      error = String(e)
+    } finally {
+      submitting = false
+    }
+  }
+</script>
+
+<Dialog
+  {open}
+  onOpenChange={(details) => {
+    onOpenChange(details.open)
+    if (!details.open) reset()
+  }}
+>
+  <Dialog.Backdrop class="fixed inset-0 z-40 bg-black/50" />
+  <Dialog.Positioner class="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <Dialog.Content class="w-full max-w-lg rounded-xl bg-surface-50 p-6 shadow-2xl dark:bg-surface-950">
+      <Dialog.Title class="mb-4 text-lg font-bold">New Chat</Dialog.Title>
+
+      <form onsubmit={handleSubmit} class="flex flex-col gap-4">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Project</span>
+          {#if projectStore.list.length === 0}
+            <p class="text-sm text-surface-500">No projects registered. Create one first.</p>
+          {:else if selectedProject}
+            <div class="flex items-center gap-2 rounded-lg border border-surface-300 bg-surface-100 px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700">
+              <svg class="h-4 w-4 shrink-0 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+              </svg>
+              <span class="flex-1">{selectedProjectName}</span>
+              <button
+                type="button"
+                class="text-surface-400 hover:text-surface-600 dark:hover:text-surface-300"
+                aria-label="Clear project"
+                onclick={clearProject}
+              >
+                <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+          {:else}
+            <div class="relative">
+              <input
+                type="text"
+                bind:value={projectSearch}
+                placeholder="Search projects..."
+                class="w-full rounded-lg border border-surface-300 bg-surface-100 px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
+                onfocus={() => (projectDropdownOpen = true)}
+                onblur={handleProjectBlur}
+              />
+              {#if projectDropdownOpen}
+                <div class="absolute z-10 mt-1 max-h-48 w-full overflow-y-auto rounded-lg border border-surface-300 bg-surface-50 shadow-lg dark:border-surface-600 dark:bg-surface-800">
+                  {#each filteredProjects as p (p.id)}
+                    <button
+                      type="button"
+                      class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-surface-100 dark:hover:bg-surface-700"
+                      onclick={() => selectProject(p.id)}
+                    >
+                      <svg class="h-4 w-4 shrink-0 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                      </svg>
+                      {p.owner}/{p.repo}
+                    </button>
+                  {/each}
+                  {#if filteredProjects.length === 0}
+                    <div class="px-3 py-2 text-sm text-surface-400">No matches</div>
+                  {/if}
+                </div>
+              {/if}
+            </div>
+          {/if}
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Provider</span>
+          <div class="flex gap-4">
+            <label class="flex items-center gap-2">
+              <input
+                type="radio"
+                name="chat-provider"
+                value="claude"
+                bind:group={provider}
+                class="border-surface-300 dark:border-surface-600"
+              />
+              <span class="text-sm">Claude</span>
+            </label>
+            <label class="flex items-center gap-2">
+              <input
+                type="radio"
+                name="chat-provider"
+                value="codex"
+                bind:group={provider}
+                class="border-surface-300 dark:border-surface-600"
+              />
+              <span class="text-sm">Codex</span>
+            </label>
+          </div>
+        </div>
+
+        <label class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Prompt <span class="text-surface-400">(optional)</span></span>
+          <textarea
+            bind:value={prompt}
+            rows={4}
+            placeholder="Leave empty to land in an idle chat..."
+            class="rounded-lg border border-surface-300 bg-surface-100 px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
+          ></textarea>
+        </label>
+
+        {#if error}
+          <p class="text-sm text-error-500">{error}</p>
+        {/if}
+
+        <div class="flex justify-end gap-2">
+          <Dialog.CloseTrigger
+            class="rounded-lg px-4 py-2 text-sm font-medium hover:bg-surface-200 dark:hover:bg-surface-700"
+          >
+            Cancel
+          </Dialog.CloseTrigger>
+          <button
+            type="submit"
+            disabled={submitting || !selectedProject || projectStore.list.length === 0}
+            class="rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-white hover:bg-primary-600 disabled:opacity-50"
+          >
+            {submitting ? 'Starting...' : 'Start chat'}
+          </button>
+        </div>
+      </form>
+    </Dialog.Content>
+  </Dialog.Positioner>
+</Dialog>

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -44,6 +44,8 @@ export function ListNotifications(): Promise<Array<notification.Notification>> {
 export function RegisterSpotlightHotkey(): Promise<void> { return call('App', 'RegisterSpotlightHotkey') }
 export function SetDesktopNotifications(arg1: boolean): Promise<void> { return call('App', 'SetDesktopNotifications', arg1) }
 export function StartAgent(arg1: string, arg2: string, arg3: string): Promise<agent.Agent> { return call('App', 'StartAgent', arg1, arg2, arg3) }
+export function StartChat(arg1: string, arg2: string, arg3: string): Promise<agent.Agent> { return call('App', 'StartChat', arg1, arg2, arg3) }
+export function StopChat(arg1: string): Promise<void> { return call('App', 'StopChat', arg1) }
 
 // ConfigService
 export function GetSettings(): Promise<synapse.AppSettings> { return call('ConfigService', 'GetSettings') }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -39,6 +39,8 @@ export const ListNotifications = pick(AppSvc.ListNotifications, http.ListNotific
 export const RegisterSpotlightHotkey = pick(AppSvc.RegisterSpotlightHotkey, http.RegisterSpotlightHotkey)
 export const SetDesktopNotifications = pick(AppSvc.SetDesktopNotifications, http.SetDesktopNotifications)
 export const StartAgent = pick(AppSvc.StartAgent, http.StartAgent)
+export const StartChat = pick(AppSvc.StartChat, http.StartChat)
+export const StopChat = pick(AppSvc.StopChat, http.StopChat)
 
 // ConfigService
 export const GetSettings = pick(ConfigSvc.GetSettings, http.GetSettings)

--- a/frontend/src/pages/ChatDetail.svelte
+++ b/frontend/src/pages/ChatDetail.svelte
@@ -37,6 +37,15 @@
       error = String(e)
     }
   }
+
+  async function handleEndChat() {
+    try {
+      await agentStore.stopChat(agentId)
+      onback()
+    } catch (e) {
+      error = String(e)
+    }
+  }
 </script>
 
 <div class="flex h-full flex-col">
@@ -75,12 +84,20 @@
       {#if a.state === 'running' || a.state === 'paused'}
         <button
           type="button"
-          class="rounded bg-error-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-error-600"
+          class="rounded bg-surface-300 px-2.5 py-1 text-xs font-medium text-surface-900 hover:bg-surface-400 dark:bg-surface-700 dark:text-surface-100 dark:hover:bg-surface-600"
           onclick={handleStop}
         >
           Stop
         </button>
       {/if}
+      <button
+        type="button"
+        class="rounded bg-error-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-error-600"
+        onclick={handleEndChat}
+        title="Stop chat and delete worktree"
+      >
+        End chat
+      </button>
     {/if}
   </div>
 

--- a/frontend/src/pages/ChatList.svelte
+++ b/frontend/src/pages/ChatList.svelte
@@ -1,12 +1,26 @@
 <script lang="ts">
   import type { agent } from '../../wailsjs/go/models.js'
   import { agentStore } from '../stores/agents.svelte.js'
+  import { projectStore } from '../stores/projects.svelte.js'
+  import NewChatDialog from '../components/NewChatDialog.svelte'
 
   interface Props {
     onselect: (agentId: string) => void
   }
 
   const { onselect }: Props = $props()
+
+  let dialogOpen = $state(false)
+
+  $effect(() => {
+    if (projectStore.list.length === 0) {
+      projectStore.load().catch(() => {})
+    }
+  })
+
+  function openDialog() {
+    dialogOpen = true
+  }
 
   const interactiveAgents = $derived(
     agentStore.list.filter((a: agent.Agent) => a.mode === 'interactive'),
@@ -41,13 +55,30 @@
 </script>
 
 <div class="flex flex-col gap-4 p-6">
+  <div class="flex items-center justify-between">
+    <h2 class="text-lg font-semibold text-surface-900 dark:text-surface-100">Chats</h2>
+    <button
+      type="button"
+      class="rounded-lg bg-primary-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-600"
+      onclick={openDialog}
+    >
+      + New Chat
+    </button>
+  </div>
+
   {#if interactiveAgents.length === 0}
     <div class="flex flex-col items-center gap-3 py-16 text-center">
       <svg class="h-12 w-12 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
       </svg>
       <p class="text-sm text-surface-500">No interactive chats yet</p>
-      <p class="text-xs text-surface-400">Start an interactive task to begin chatting with Claude</p>
+      <button
+        type="button"
+        class="mt-2 rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-white hover:bg-primary-600"
+        onclick={openDialog}
+      >
+        Start a new chat
+      </button>
     </div>
   {:else}
     <div class="flex flex-col gap-2">
@@ -91,3 +122,9 @@
     </div>
   {/if}
 </div>
+
+<NewChatDialog
+  open={dialogOpen}
+  onOpenChange={(v) => (dialogOpen = v)}
+  oncreated={(id) => onselect(id)}
+/>

--- a/frontend/src/stores/agents.svelte.ts
+++ b/frontend/src/stores/agents.svelte.ts
@@ -5,6 +5,8 @@ import {
   GetAgentOutput,
   DiscoverAgents,
   StartAgent,
+  StartChat,
+  StopChat,
 } from '$lib/api'
 import { agent } from '../../wailsjs/go/models.js'
 import { EntityStore } from './entity-store.svelte.js'
@@ -49,6 +51,13 @@ class AgentStore extends EntityStore<agent.Agent> {
     return result
   }
 
+  async startChat(projectID: string, provider: string, prompt: string): Promise<agent.Agent> {
+    const result = await StartChat(projectID, provider, prompt)
+    this.set(result.id, result)
+    this.outputs.set(result.id, [])
+    return result
+  }
+
   async stop(agentID: string): Promise<void> {
     await StopAgent(agentID)
     const a = this.items.get(agentID)
@@ -56,6 +65,12 @@ class AgentStore extends EntityStore<agent.Agent> {
       a.state = 'stopped'
       this.set(agentID, a)
     }
+  }
+
+  async stopChat(agentID: string): Promise<void> {
+    await StopChat(agentID)
+    this.items.delete(agentID)
+    this.outputs.delete(agentID)
   }
 
   async getOutput(agentID: string): Promise<agent.StreamEvent[]> {

--- a/frontend/wailsjs/go/synapse/App.d.ts
+++ b/frontend/wailsjs/go/synapse/App.d.ts
@@ -21,4 +21,8 @@ export function SetDesktopNotifications(arg1:boolean):Promise<void>;
 
 export function StartAgent(arg1:string,arg2:string,arg3:string):Promise<agent.Agent>;
 
+export function StartChat(arg1:string,arg2:string,arg3:string):Promise<agent.Agent>;
+
+export function StopChat(arg1:string):Promise<void>;
+
 export function Startup(arg1:context.Context):Promise<void>;

--- a/frontend/wailsjs/go/synapse/App.d.ts
+++ b/frontend/wailsjs/go/synapse/App.d.ts
@@ -23,6 +23,6 @@ export function StartAgent(arg1:string,arg2:string,arg3:string):Promise<agent.Ag
 
 export function StartChat(arg1:string,arg2:string,arg3:string):Promise<agent.Agent>;
 
-export function StopChat(arg1:string):Promise<void>;
-
 export function Startup(arg1:context.Context):Promise<void>;
+
+export function StopChat(arg1:string):Promise<void>;

--- a/frontend/wailsjs/go/synapse/App.js
+++ b/frontend/wailsjs/go/synapse/App.js
@@ -34,6 +34,14 @@ export function StartAgent(arg1, arg2, arg3) {
   return window['go']['synapse']['App']['StartAgent'](arg1, arg2, arg3);
 }
 
+export function StartChat(arg1, arg2, arg3) {
+  return window['go']['synapse']['App']['StartChat'](arg1, arg2, arg3);
+}
+
+export function StopChat(arg1) {
+  return window['go']['synapse']['App']['StopChat'](arg1);
+}
+
 export function Startup(arg1) {
   return window['go']['synapse']['App']['Startup'](arg1);
 }

--- a/frontend/wailsjs/go/synapse/App.js
+++ b/frontend/wailsjs/go/synapse/App.js
@@ -38,10 +38,10 @@ export function StartChat(arg1, arg2, arg3) {
   return window['go']['synapse']['App']['StartChat'](arg1, arg2, arg3);
 }
 
-export function StopChat(arg1) {
-  return window['go']['synapse']['App']['StopChat'](arg1);
-}
-
 export function Startup(arg1) {
   return window['go']['synapse']['App']['Startup'](arg1);
+}
+
+export function StopChat(arg1) {
+  return window['go']['synapse']['App']['StopChat'](arg1);
 }

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -135,6 +135,9 @@ func checkStuckTasks(events []audit.Event, tasks []task.Task, now time.Time) []F
 	var findings []Finding
 	for i := range tasks {
 		t := &tasks[i]
+		if t.TaskType == task.TaskTypeChat {
+			continue
+		}
 		if t.Status != task.StatusInProgress {
 			continue
 		}

--- a/internal/synapse/app.go
+++ b/internal/synapse/app.go
@@ -239,9 +239,7 @@ func (a *App) Startup(ctx context.Context) error {
 	a.wireServices(emit)
 
 	a.syncSkills()
-	a.worktrees.CleanupOrphaned()
-	a.cleanStaleRuns()
-	a.restartStaleInProgress()
+	a.runStartupCleanup()
 	a.RegisterSpotlightHotkey()
 	a.wg.Go(func() { a.orchestratorLoop(ctx) })
 
@@ -686,6 +684,9 @@ func (a *App) cleanStaleRuns() {
 		return
 	}
 	for i := range tasks {
+		if tasks[i].TaskType == task.TaskTypeChat {
+			continue
+		}
 		for j := range tasks[i].AgentRuns {
 			run := &tasks[i].AgentRuns[j]
 			if run.State != string(agent.StateRunning) {
@@ -699,6 +700,42 @@ func (a *App) cleanStaleRuns() {
 				"state":  string(agent.StateStopped),
 				"result": "stale: marked stopped on startup",
 			})
+		}
+	}
+}
+
+// runStartupCleanup sequences boot-time maintenance in the order that lets
+// each step see the output of the previous one: chats first so their
+// worktrees show up as orphans to the subsequent sweep; stale run state
+// next so restart-stale sees a clean slate.
+func (a *App) runStartupCleanup() {
+	a.gcOrphanChats()
+	a.worktrees.CleanupOrphaned()
+	a.cleanStaleRuns()
+	a.restartStaleInProgress()
+}
+
+// gcOrphanChats deletes any chat-task that no longer has a running agent.
+// Chats are ephemeral by design; a stale chat-task is always noise left over
+// from a crash or kill. Runs before worktree orphan cleanup so the task
+// file is gone by the time the worktree sweeper looks.
+func (a *App) gcOrphanChats() {
+	tasks, err := a.tasks.List()
+	if err != nil {
+		return
+	}
+	for i := range tasks {
+		t := tasks[i]
+		if t.TaskType != task.TaskTypeChat {
+			continue
+		}
+		if a.agents.HasRunningAgentForTask(t.ID) {
+			continue
+		}
+		a.logger.Info("chat.gc.orphan", "task_id", t.ID, "title", t.Title)
+		a.worktrees.Remove(t.ID)
+		if err := a.tasks.Delete(t.ID); err != nil {
+			a.logger.Error("chat.gc.delete", "task_id", t.ID, "err", err)
 		}
 	}
 }
@@ -718,6 +755,9 @@ func (a *App) restartStaleInProgress() {
 	}
 	for i := range tasks {
 		t := tasks[i]
+		if t.TaskType == task.TaskTypeChat {
+			continue
+		}
 		if t.Status != task.StatusInProgress {
 			continue
 		}
@@ -862,6 +902,34 @@ func lastAgentRun(t *task.Task) *task.AgentRun {
 // steps that expect a single turn.
 func (a *App) StartAgent(taskID, mode, prompt string) (*agent.Agent, error) {
 	return a.agentOrch.StartAgent(taskID, mode, prompt, false)
+}
+
+// StartChat creates a new interactive chat bound to projectID using the
+// requested provider ("claude" or "codex"). Each chat gets a dedicated
+// local-only worktree that is cleaned up when StopChat is called.
+func (a *App) StartChat(projectID, providerName, prompt string) (*agent.Agent, error) {
+	return a.agentOrch.StartChat(projectID, providerName, prompt)
+}
+
+// StopChat stops a chat agent, deletes its synthetic task, and removes its
+// worktree. Refuses to operate on agents that are not bound to a chat task
+// so the UI cannot accidentally delete a real task.
+func (a *App) StopChat(agentID string) error {
+	ag, err := a.agents.GetAgent(agentID)
+	if err != nil {
+		return err
+	}
+	if ag.TaskID == "" {
+		return fmt.Errorf("agent %s is not bound to a task", agentID)
+	}
+	t, err := a.tasks.Get(ag.TaskID)
+	if err != nil {
+		return fmt.Errorf("lookup chat task: %w", err)
+	}
+	if t.TaskType != task.TaskTypeChat {
+		return fmt.Errorf("agent %s is not a chat (task_type=%s)", agentID, t.TaskType)
+	}
+	return a.taskSvc.DeleteTask(t.ID)
 }
 
 // seedDefaultLoopAgents creates the built-in synapse-self-monitor loop on

--- a/internal/synapse/app_agents.go
+++ b/internal/synapse/app_agents.go
@@ -26,6 +26,8 @@ func resolveExecution(t task.Task, hintMode, researchMachineDir string, cfg *con
 		return "interactive", "", true, false
 	case task.TaskTypeResearch:
 		return "headless", researchMachineDir, resolvePermission(t, cfg), true
+	case task.TaskTypeChat:
+		return "interactive", "", resolvePermission(t, cfg), false
 	default:
 		return hintMode, "", resolvePermission(t, cfg), false
 	}
@@ -140,6 +142,71 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, oneShot bool
 		StartedAt: ag.StartedAt,
 	}); err != nil {
 		o.logger.Error("task.add-run", "task_id", taskID, "err", err)
+	}
+	return ag, nil
+}
+
+// StartChat creates a synthetic chat task bound to projectID, prepares a
+// dedicated (local-only) worktree, and launches an interactive agent with
+// the requested provider. Rolls back on any failure so no orphans leak.
+func (o *AgentOrchestrator) StartChat(projectID, providerName, prompt string) (*agent.Agent, error) {
+	prov := strings.ToLower(strings.TrimSpace(providerName))
+	if prov != "claude" && prov != "codex" {
+		return nil, fmt.Errorf("invalid provider %q: must be claude or codex", providerName)
+	}
+	if strings.TrimSpace(projectID) == "" {
+		return nil, fmt.Errorf("project_id is required")
+	}
+	if _, err := o.projects.Get(projectID); err != nil {
+		return nil, fmt.Errorf("project %s: %w", projectID, err)
+	}
+
+	t, err := o.tasks.CreateChat(projectID)
+	if err != nil {
+		return nil, fmt.Errorf("create chat task: %w", err)
+	}
+
+	dir, err := o.worktrees.PrepareForChat(t)
+	if err != nil {
+		if delErr := o.tasks.Delete(t.ID); delErr != nil {
+			o.logger.Error("chat.rollback.delete-task", "task_id", t.ID, "err", delErr)
+		}
+		return nil, fmt.Errorf("prepare chat worktree: %w", err)
+	}
+
+	requirePerm := resolvePermission(t, o.cfg)
+	ag, err := o.agents.Run(agent.RunConfig{
+		TaskID:             t.ID,
+		Name:               t.Title,
+		Mode:               "interactive",
+		Provider:           prov,
+		Prompt:             prompt,
+		Dir:                dir,
+		Model:              "sonnet",
+		RequirePermissions: requirePerm,
+	})
+	if err != nil {
+		o.worktrees.Remove(t.ID)
+		if delErr := o.tasks.Delete(t.ID); delErr != nil {
+			o.logger.Error("chat.rollback.delete-task", "task_id", t.ID, "err", delErr)
+		}
+		return nil, err
+	}
+
+	o.logAudit(audit.EventAgentStarted, t.ID, ag.ID, map[string]any{
+		"mode": "interactive", "title": t.Title, "role": "chat",
+		"task_type": string(t.TaskType), "provider": ag.Provider,
+		"require_permissions": requirePerm,
+	})
+	if err := o.tasks.AddRun(t.ID, task.AgentRun{
+		AgentID:   ag.ID,
+		Role:      "chat",
+		Mode:      "interactive",
+		Provider:  ag.Provider,
+		State:     string(agent.StateRunning),
+		StartedAt: ag.StartedAt,
+	}); err != nil {
+		o.logger.Error("chat.add-run", "task_id", t.ID, "err", err)
 	}
 	return ag, nil
 }

--- a/internal/synapse/app_orchestrator.go
+++ b/internal/synapse/app_orchestrator.go
@@ -75,6 +75,9 @@ func (a *App) maybeStartOrchestrator() {
 
 	hasActive := false
 	for i := range tasks {
+		if tasks[i].TaskType == task.TaskTypeChat {
+			continue
+		}
 		switch tasks[i].Status {
 		case task.StatusPlanning, task.StatusPlanReview, task.StatusInProgress, task.StatusInReview:
 			hasActive = true

--- a/internal/synapse/app_reviews.go
+++ b/internal/synapse/app_reviews.go
@@ -271,6 +271,10 @@ func (r *ReviewHandler) detectPublishedReviews(tasks []task.Task) {
 // Branch-only matching stays gated on in-review to avoid false positives
 // from tasks that pushed a WIP branch without opening a PR yet.
 func prMonitorEligible(t *task.Task) bool {
+	if t.TaskType == task.TaskTypeChat {
+		// Chat tasks are ephemeral and never have PRs — exclude from PR monitoring.
+		return false
+	}
 	if slices.Contains(t.Tags, "review") {
 		// Review tasks are inbound (reviewing someone else's PR), not tasks
 		// whose own PR is being tracked. They're handled separately.

--- a/internal/synapse/app_workflow.go
+++ b/internal/synapse/app_workflow.go
@@ -39,9 +39,12 @@ func (a *taskAdapter) ListTasks() ([]workflow.TaskInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	infos := make([]workflow.TaskInfo, len(tasks))
+	infos := make([]workflow.TaskInfo, 0, len(tasks))
 	for i := range tasks {
-		infos[i] = taskToInfo(tasks[i])
+		if tasks[i].TaskType == task.TaskTypeChat {
+			continue
+		}
+		infos = append(infos, taskToInfo(tasks[i]))
 	}
 	return infos, nil
 }

--- a/internal/synapse/svc_tasks.go
+++ b/internal/synapse/svc_tasks.go
@@ -27,9 +27,21 @@ type TaskService struct {
 	audit          *audit.Logger
 }
 
-// ListTasks returns all tasks from the store.
+// ListTasks returns all tasks from the store, excluding ephemeral chat tasks.
+// Chat tasks are surfaced exclusively through the Chats view.
 func (s *TaskService) ListTasks() ([]task.Task, error) {
-	return s.tasks.List()
+	all, err := s.tasks.List()
+	if err != nil {
+		return nil, err
+	}
+	out := all[:0]
+	for i := range all {
+		if all[i].TaskType == task.TaskTypeChat {
+			continue
+		}
+		out = append(out, all[i])
+	}
+	return out, nil
 }
 
 // GetTask returns a single task by ID.

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -86,6 +86,17 @@ func (m *Manager) Create(title, body, mode string) (Task, error) {
 	return t, nil
 }
 
+// CreateChat persists a synthetic chat task and emits task:created.
+func (m *Manager) CreateChat(projectID string) (Task, error) {
+	t, err := m.store.CreateChat(projectID)
+	if err != nil {
+		return t, err
+	}
+	metrics.TaskCreated()
+	m.emitter.Emit(events.TaskCreated, t.FilePath)
+	return t, nil
+}
+
 // Update applies field updates to a task and emits task:updated.
 // Serializes with other Update/AddRun/UpdateRun/Delete calls for the same id.
 //

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -53,15 +53,18 @@ const (
 	TaskTypeNormal   TaskType = "normal"
 	TaskTypeDebug    TaskType = "debug"
 	TaskTypeResearch TaskType = "research"
+	// TaskTypeChat is a synthetic task created for interactive chat sessions.
+	// Hidden from the task list UI and skipped by restart-stale/watchdog.
+	TaskTypeChat TaskType = "chat"
 )
 
 var validTaskTypes = map[TaskType]bool{
-	TaskTypeNormal: true, TaskTypeDebug: true, TaskTypeResearch: true,
+	TaskTypeNormal: true, TaskTypeDebug: true, TaskTypeResearch: true, TaskTypeChat: true,
 }
 
 // AllTaskTypes returns every valid task type in display order.
 func AllTaskTypes() []TaskType {
-	return []TaskType{TaskTypeNormal, TaskTypeDebug, TaskTypeResearch}
+	return []TaskType{TaskTypeNormal, TaskTypeDebug, TaskTypeResearch, TaskTypeChat}
 }
 
 func ValidateTaskType(s string) (TaskType, error) {

--- a/internal/task/model_test.go
+++ b/internal/task/model_test.go
@@ -66,8 +66,8 @@ func TestValidateTaskType_Invalid(t *testing.T) {
 func TestAllTaskTypes(t *testing.T) {
 	t.Parallel()
 	types := AllTaskTypes()
-	if len(types) != 3 {
-		t.Errorf("got %d types, want 3", len(types))
+	if len(types) != 4 {
+		t.Errorf("got %d types, want 4", len(types))
 	}
 }
 

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -115,6 +115,39 @@ func (s *Store) Create(title, body, mode string) (Task, error) {
 	return t, nil
 }
 
+// CreateChat creates a synthetic chat task bound to projectID. Chat tasks are
+// hidden from the task list UI and never restart on app reboot. The slug is
+// "chat-<8char>" so the worktree DirName is distinctive.
+func (s *Store) CreateChat(projectID string) (Task, error) {
+	if projectID == "" {
+		return Task{}, fmt.Errorf("project_id is required for chat")
+	}
+	now := time.Now().UTC()
+	id := uuid.NewString()[:8]
+	title := "chat " + now.Format("01-02 15:04")
+	t := Task{
+		ID:        id,
+		Slug:      "chat-" + id,
+		Title:     title,
+		Status:    StatusInProgress,
+		TaskType:  TaskTypeChat,
+		AgentMode: AgentModeInteractive,
+		ProjectID: projectID,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	data, err := Marshal(t)
+	if err != nil {
+		return Task{}, err
+	}
+	filename := fmt.Sprintf("%s.md", t.ID)
+	t.FilePath = filepath.Join(s.dir, filename)
+	if err := fsutil.AtomicWrite(t.FilePath, data); err != nil {
+		return Task{}, fmt.Errorf("write chat task file: %w", err)
+	}
+	return t, nil
+}
+
 func (s *Store) Delete(id string) error {
 	t, err := s.Get(id)
 	if err != nil {

--- a/internal/watchdog/dwell.go
+++ b/internal/watchdog/dwell.go
@@ -38,6 +38,9 @@ func (w *Watchdog) checkDwell(now time.Time) {
 	}
 	for i := range tasks {
 		t := &tasks[i]
+		if t.TaskType == task.TaskTypeChat {
+			continue
+		}
 		if t.Status != task.StatusTodo && t.Status != task.StatusInProgress {
 			continue
 		}

--- a/internal/workflow/condition.go
+++ b/internal/workflow/condition.go
@@ -69,7 +69,7 @@ var FieldAllowedValues = map[string]map[string]bool{
 		"test-plan-review": true, "human-required": true, "done": true,
 	},
 	"task.task_type": {
-		"normal": true, "debug": true, "research": true,
+		"normal": true, "debug": true, "research": true, "chat": true,
 	},
 	"pr.issue_kind": {
 		"conflict": true, "ci_failure": true, "ready_to_merge": true,

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -146,6 +146,52 @@ func (m *Manager) PrepareForTask(t task.Task) (string, error) {
 	return wtPath, nil
 }
 
+// PrepareForChat creates a worktree for an ephemeral chat session. Same as
+// PrepareForTask but skips the upstream push — chat branches are local-only
+// and deleted with the worktree when the chat ends.
+func (m *Manager) PrepareForChat(t task.Task) (string, error) {
+	proj, err := m.projects.Get(t.ProjectID)
+	if err != nil {
+		return "", fmt.Errorf("get project: %w", err)
+	}
+	if err := project.FetchOrigin(proj.ClonePath); err != nil {
+		return "", fmt.Errorf("fetch origin: %w", err)
+	}
+
+	branch, err := project.DefaultBranch(proj.ClonePath)
+	if err != nil {
+		return "", fmt.Errorf("default branch: %w", err)
+	}
+
+	wtPath := m.PathFor(t)
+	wtBranch := "synapse/" + t.DirName()
+	baseRef := "refs/remotes/origin/" + branch
+
+	if _, statErr := os.Stat(wtPath); statErr == nil {
+		m.logger.Info("chat.worktree.reused", "task_id", t.ID, "path", wtPath)
+		m.ensureBranch(t, wtBranch)
+		return wtPath, nil
+	}
+
+	if project.BranchExists(proj.ClonePath, wtBranch) {
+		if err := project.CreateWorktreeExisting(proj.ClonePath, wtPath, wtBranch); err != nil {
+			return "", fmt.Errorf("checkout existing branch %s: %w", wtBranch, err)
+		}
+		m.logger.Info("chat.worktree.reused-branch", "task_id", t.ID, "path", wtPath, "branch", wtBranch)
+		m.runSetup(wtPath, proj.SetupCommands)
+		m.ensureBranch(t, wtBranch)
+		return wtPath, nil
+	}
+
+	if err := project.CreateWorktree(proj.ClonePath, wtPath, wtBranch, baseRef); err != nil {
+		return "", fmt.Errorf("create chat worktree: %w", err)
+	}
+	m.logger.Info("chat.worktree.created", "task_id", t.ID, "path", wtPath)
+	m.runSetup(wtPath, proj.SetupCommands)
+	m.ensureBranch(t, wtBranch)
+	return wtPath, nil
+}
+
 // PrepareForReview creates a detached-HEAD worktree for read-only PR review.
 func (m *Manager) PrepareForReview(t task.Task) (string, error) {
 	proj, err := m.projects.Get(t.ProjectID)


### PR DESCRIPTION
## Motivation

Chats view listed interactive agents but there was no way to create a chat directly — chats were a side effect of spawning an interactive agent on a pre-existing task. Goal: click New Chat, pick a project, pick a provider (claude/codex), get a dedicated worktree that is cleaned up on chat kill.

## Implementation information

Synthetic-task approach: every chat creates a hidden \`TaskTypeChat\` task so the existing worktree lifecycle (\`PrepareForTask\` / \`worktrees.Remove\` / task-deletion cleanup) is reused wholesale.

- \`internal/task\`: new \`TaskTypeChat\` constant, \`Store.CreateChat\` / \`Manager.CreateChat\` helpers (slug \`chat-<id>\`, status in-progress, mode interactive, auto title \`chat MM-DD HH:MM\`).
- \`internal/worktree\`: \`PrepareForChat\` mirrors \`PrepareForTask\` but skips \`PushUpstream\` — chat branches stay local.
- \`internal/synapse/app_agents.go\`: \`AgentOrchestrator.StartChat(projectID, provider, prompt)\` validates inputs, creates task, preps worktree, runs agent, rolls back on any failure. \`resolveExecution\` maps \`TaskTypeChat\` → interactive + worktree.
- \`internal/synapse/app.go\`: \`App.StartChat\` / \`App.StopChat\` Wails bindings. \`StopChat\` refuses non-chat agents so UI mis-routing cannot delete a real task. Boot-time \`gcOrphanChats\` deletes any chat-task without a live agent before worktree orphan sweep.
- Chat-task filters added to \`svc_tasks.ListTasks\` (UI), \`cleanStaleRuns\`, \`restartStaleInProgress\`, \`taskAdapter.ListTasks\` (workflow engine), \`maybeStartOrchestrator\`, \`prMonitorEligible\`, \`watchdog/dwell\`, \`health/checks.checkStuckTasks\`.
- Workflow enum crosscheck: added \`chat\` to \`FieldAllowedValues["task.task_type"]\` so the build-time check passes; chat tasks still never reach workflow matching via the filtered adapter.

Frontend:
- \`StartChat\` / \`StopChat\` bindings in \`api.ts\` / \`api-http.ts\` / \`wailsjs/go/synapse/App.{js,d.ts}\`.
- \`agentStore.startChat\` / \`stopChat\` actions.
- New \`NewChatDialog.svelte\` component: project dropdown (from \`projectStore.list\`), provider radio (claude/codex), optional prompt textarea.
- \`ChatList.svelte\` gets a New Chat button in the header and the empty state; opens the dialog.
- \`ChatDetail.svelte\` gets an End chat button that calls \`stopChat\` and navigates back.

Alternatives rejected: decoupling worktrees from tasks entirely (Option B in the plan) — would have forked every worktree/watchdog code path for no reuse win.

## Supporting documentation

Plan: \`/Users/marcin.skalski/.claude/plans/majestic-purring-toast.md\` (local)

> Changelog: feat(chat): project-scoped chats with provider