### PR TITLE
fix(chat): unblock new chat input + queue

### DIFF
--- a/frontend/e2e/chat.spec.ts
+++ b/frontend/e2e/chat.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Chat UI smoke. Cannot exercise the full stack in CI because:
+ *   - no `claude` / `codex` binary is installed,
+ *   - no project is registered in the seed fixtures.
+ *
+ * What this DOES verify is the UX contract that backs the
+ * "fix(chat): unblock new chat input + queue" change:
+ *   - the New Chat dialog advertises an OPTIONAL prompt and points users
+ *     at the "idle chat" path,
+ *   - the chat list is reachable from the sidebar.
+ *
+ * The behavioural assertions (input enabled while running, queue drains
+ * on result, etc.) live in the vitest component test
+ * `ChatView.svelte.test.ts` and the Go tests in `internal/agent/`.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+async function goToChats(page: Page) {
+  await page.goto('/')
+  await page.locator('[data-part="trigger"]', { hasText: /Chats/ }).click()
+  await expect(page.locator('h2', { hasText: 'Chats' })).toBeVisible()
+}
+
+test.describe('Chat list', () => {
+  test('chat list page renders with new chat entry point', async ({ page }) => {
+    await goToChats(page)
+    await expect(page.getByRole('button', { name: /New Chat/ })).toBeVisible()
+  })
+
+  test('new chat dialog exposes optional prompt for idle-start chats', async ({ page }) => {
+    await goToChats(page)
+    await page.getByRole('button', { name: /New Chat/ }).first().click()
+
+    await expect(page.getByText('New Chat', { exact: true })).toBeVisible()
+
+    // The optional-prompt copy is the user-facing contract: it tells the
+    // user they can skip the prompt and land on an idle chat. The fix
+    // depends on that flow producing a typeable input.
+    await expect(page.getByPlaceholder('Leave empty to land in an idle chat...')).toBeVisible()
+    await expect(page.getByText(/Prompt/).first()).toBeVisible()
+    await expect(page.getByText(/optional/i).first()).toBeVisible()
+
+    // Provider toggle must offer both options so chat works for the
+    // active provider matrix.
+    await expect(page.getByLabel('Claude')).toBeVisible()
+    await expect(page.getByLabel('Codex')).toBeVisible()
+  })
+})

--- a/frontend/e2e/chat.spec.ts
+++ b/frontend/e2e/chat.spec.ts
@@ -18,31 +18,31 @@ import { test, expect, type Page } from '@playwright/test'
 async function goToChats(page: Page) {
   await page.goto('/')
   await page.locator('[data-part="trigger"]', { hasText: /Chats/ }).click()
-  await expect(page.locator('h2', { hasText: 'Chats' })).toBeVisible()
+  // Sidebar nav also has an "h2 Chats" heading, so scope to the main region.
+  await expect(page.getByRole('main').getByRole('heading', { name: 'Chats' })).toBeVisible()
 }
 
 test.describe('Chat list', () => {
   test('chat list page renders with new chat entry point', async ({ page }) => {
     await goToChats(page)
-    await expect(page.getByRole('button', { name: /New Chat/ })).toBeVisible()
+    await expect(page.getByRole('main').getByRole('button', { name: /New Chat/ }).first()).toBeVisible()
   })
 
   test('new chat dialog exposes optional prompt for idle-start chats', async ({ page }) => {
     await goToChats(page)
-    await page.getByRole('button', { name: /New Chat/ }).first().click()
+    await page.getByRole('main').getByRole('button', { name: /New Chat/ }).first().click()
 
-    await expect(page.getByText('New Chat', { exact: true })).toBeVisible()
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
 
     // The optional-prompt copy is the user-facing contract: it tells the
     // user they can skip the prompt and land on an idle chat. The fix
     // depends on that flow producing a typeable input.
-    await expect(page.getByPlaceholder('Leave empty to land in an idle chat...')).toBeVisible()
-    await expect(page.getByText(/Prompt/).first()).toBeVisible()
-    await expect(page.getByText(/optional/i).first()).toBeVisible()
+    await expect(dialog.getByPlaceholder('Leave empty to land in an idle chat...')).toBeVisible()
 
     // Provider toggle must offer both options so chat works for the
     // active provider matrix.
-    await expect(page.getByLabel('Claude')).toBeVisible()
-    await expect(page.getByLabel('Codex')).toBeVisible()
+    await expect(dialog.getByLabel('Claude')).toBeVisible()
+    await expect(dialog.getByLabel('Codex')).toBeVisible()
   })
 })

--- a/frontend/src/components/ChatInput.svelte
+++ b/frontend/src/components/ChatInput.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   interface Props {
     disabled?: boolean
+    placeholder?: string
     onsend: (text: string) => void
   }
 
-  const { disabled = false, onsend }: Props = $props()
+  const { disabled = false, placeholder = 'Type a message...', onsend }: Props = $props()
 
   let text = $state('')
   let textarea: HTMLTextAreaElement | undefined = $state()
@@ -39,7 +40,7 @@
       bind:this={textarea}
       bind:value={text}
       {disabled}
-      placeholder={disabled ? 'Agent is thinking...' : 'Type a message...'}
+      placeholder={disabled ? 'Waiting for approval...' : placeholder}
       rows="1"
       class="flex-1 resize-none rounded-lg border border-surface-300 bg-surface-50 px-3 py-2 text-sm
         text-surface-900 placeholder:text-surface-400

--- a/frontend/src/components/ChatView.svelte
+++ b/frontend/src/components/ChatView.svelte
@@ -138,7 +138,8 @@
 
   <!-- Input -->
   <ChatInput
-    disabled={isRunning || isWaitingForApproval}
+    disabled={isWaitingForApproval}
+    placeholder={isRunning ? 'Queue a follow-up...' : 'Type a message...'}
     onsend={handleSend}
   />
 </div>

--- a/frontend/src/components/ChatView.svelte.test.ts
+++ b/frontend/src/components/ChatView.svelte.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
+import { SvelteMap } from 'svelte/reactivity'
+
+const mockGetOutput = vi.fn()
+const mockSendMessage = vi.fn()
+const mockRespondApproval = vi.fn()
+const mockSubscribe = vi.fn((..._args: unknown[]) => () => {})
+
+const conversations = new SvelteMap<string, unknown[]>()
+const pendingApprovals = new SvelteMap<string, unknown>()
+
+vi.mock('../stores/convo.svelte.js', () => ({
+  convoStore: {
+    conversations,
+    pendingApprovals,
+    getOutput: (...args: unknown[]) => mockGetOutput(...args),
+    sendMessage: (...args: unknown[]) => mockSendMessage(...args),
+    respondApproval: (...args: unknown[]) => mockRespondApproval(...args),
+    subscribe: (...args: unknown[]) => mockSubscribe(...args),
+  },
+}))
+
+describe('ChatView', () => {
+  let ChatView: typeof import('./ChatView.svelte').default
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    conversations.clear()
+    pendingApprovals.clear()
+    mockGetOutput.mockResolvedValue([])
+    ChatView = (await import('./ChatView.svelte')).default
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  // Bug regression: a fresh chat starts with state=running and zero events.
+  // The textarea must NOT be disabled — otherwise the user is locked out and
+  // cannot send the first message (the "Waiting for response..." deadlock).
+  it('keeps input enabled when running with no events', async () => {
+    render(ChatView, { props: { agentId: 'a1', agentState: 'running' } })
+
+    const textarea = await screen.findByRole('textbox')
+    expect((textarea as HTMLTextAreaElement).disabled).toBe(false)
+    expect((textarea as HTMLTextAreaElement).placeholder).toBe('Queue a follow-up...')
+  })
+
+  it('keeps input enabled when paused without approval', async () => {
+    render(ChatView, { props: { agentId: 'a1', agentState: 'paused' } })
+
+    const textarea = await screen.findByRole('textbox')
+    expect((textarea as HTMLTextAreaElement).disabled).toBe(false)
+    expect((textarea as HTMLTextAreaElement).placeholder).toBe('Type a message...')
+  })
+
+  // Approval is the only state where the input must be hard-locked: typing
+  // a follow-up while a tool-use is awaiting consent would race the queue
+  // ahead of the approval handshake.
+  it('disables input when a tool approval is pending', async () => {
+    pendingApprovals.set('tool-1', {
+      toolUseId: 'tool-1',
+      toolName: 'Bash',
+      input: {},
+    })
+
+    render(ChatView, { props: { agentId: 'a1', agentState: 'paused' } })
+
+    const textarea = await screen.findByRole('textbox')
+    expect((textarea as HTMLTextAreaElement).disabled).toBe(true)
+    expect((textarea as HTMLTextAreaElement).placeholder).toBe('Waiting for approval...')
+  })
+
+  it('forwards typed messages to convoStore.sendMessage', async () => {
+    mockSendMessage.mockResolvedValue(undefined)
+    render(ChatView, { props: { agentId: 'a1', agentState: 'running' } })
+
+    const textarea = (await screen.findByRole('textbox')) as HTMLTextAreaElement
+    await fireEvent.input(textarea, { target: { value: 'queue me' } })
+    await fireEvent.keyDown(textarea, { key: 'Enter' })
+
+    expect(mockSendMessage).toHaveBeenCalledWith('a1', 'queue me')
+  })
+
+  it('shows the waiting placeholder until the first event arrives', async () => {
+    render(ChatView, { props: { agentId: 'a1', agentState: 'running' } })
+
+    expect(await screen.findByText('Waiting for response...')).toBeDefined()
+  })
+})

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -669,3 +669,116 @@ func TestSendPromptToAgent_RejectsAgentWithoutTransport(t *testing.T) {
 		t.Fatal("expected error when agent has no transport")
 	}
 }
+
+// TestSendMessage_QueuesWhenRunning verifies the queue-on-busy behaviour:
+// a follow-up sent mid-turn (StateRunning) must not hit stdin and must not
+// flip state — it just lives in pendingPrompts until the next result.
+// Regression guard for the chat-input "queue follow-up" feature.
+func TestSendMessage_QueuesWhenRunning(t *testing.T) {
+	m, _ := newTestManager(t)
+	a, lines := captureStdinAgent(t, m, "busy", "task-1")
+	a.SetState(StateRunning) // simulate mid-turn
+
+	if err := m.SendMessage(a.ID, "queued text"); err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+
+	// Nothing should land on stdin while the agent is mid-turn.
+	select {
+	case got := <-lines:
+		t.Fatalf("expected no stdin write while running, got %q", got)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	if got := a.PendingPromptCount(); got != 1 {
+		t.Fatalf("PendingPromptCount = %d, want 1", got)
+	}
+	if st := a.GetState(); st != StateRunning {
+		t.Errorf("State = %q, want %q (queued send must not flip state)", st, StateRunning)
+	}
+
+	// User message must still appear in the convo buffer immediately so
+	// the chat UI shows the queued bubble before the turn drains.
+	convo := a.ConvoOutput()
+	if len(convo) != 1 {
+		t.Fatalf("convo len = %d, want 1", len(convo))
+	}
+	if convo[0].Type != "user_input" || convo[0].Text != "queued text" {
+		t.Errorf("convo[0] = %+v, want user_input/queued text", convo[0])
+	}
+}
+
+// TestSendMessage_WritesStdinWhenPaused covers the idle-chat path: when the
+// agent is parked in StatePaused (e.g. fresh chat with no initial prompt),
+// the next SendMessage must hit stdin directly and flip back to Running.
+func TestSendMessage_WritesStdinWhenPaused(t *testing.T) {
+	m, _ := newTestManager(t)
+	a, lines := captureStdinAgent(t, m, "idle", "task-1")
+	// captureStdinAgent already starts in StatePaused.
+
+	if err := m.SendMessage(a.ID, "first message"); err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+
+	select {
+	case got := <-lines:
+		if !strings.Contains(got, `first message`) {
+			t.Errorf("stdin payload missing text: %q", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no stdin write within 2s")
+	}
+
+	if got := a.PendingPromptCount(); got != 0 {
+		t.Errorf("PendingPromptCount = %d, want 0", got)
+	}
+	if st := a.GetState(); st != StateRunning {
+		t.Errorf("State = %q, want %q after immediate send", st, StateRunning)
+	}
+}
+
+// TestStreamConvoOutput_FlushesQueueOnResult verifies that streamConvoOutput
+// drains the pending prompt queue when a result event arrives — the next
+// queued prompt is written to stdin and the agent stays Running. Without
+// this drain, queued chat follow-ups would never reach claude.
+func TestStreamConvoOutput_FlushesQueueOnResult(t *testing.T) {
+	m, _ := newTestManager(t)
+	a, lines := captureStdinAgent(t, m, "drain", "task-1")
+	a.SetState(StateRunning)
+	a.EnqueuePrompt("next turn please")
+
+	resultLine := `{"type":"result","subtype":"success","session_id":"s-1","total_cost_usd":0.1,"usage":{"input_tokens":10,"output_tokens":5}}` + "\n"
+	m.streamConvoOutput(a, strings.NewReader(resultLine), nil, false)
+
+	select {
+	case got := <-lines:
+		if !strings.Contains(got, `next turn please`) {
+			t.Errorf("queued prompt not drained to stdin: %q", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("queued prompt was not written to stdin within 2s")
+	}
+
+	if got := a.PendingPromptCount(); got != 0 {
+		t.Errorf("PendingPromptCount after drain = %d, want 0", got)
+	}
+	if st := a.GetState(); st != StateRunning {
+		t.Errorf("State = %q, want Running while queue still has work in flight", st)
+	}
+}
+
+// TestStreamConvoOutput_PausesWhenQueueEmpty verifies the default no-queue
+// path: a result event with an empty pending queue must flip the agent to
+// StatePaused so the chat input goes from "thinking" to typeable.
+func TestStreamConvoOutput_PausesWhenQueueEmpty(t *testing.T) {
+	m, _ := newTestManager(t)
+	a, _ := captureStdinAgent(t, m, "calm", "task-1")
+	a.SetState(StateRunning)
+
+	resultLine := `{"type":"result","subtype":"success","session_id":"s-1","total_cost_usd":0.05}` + "\n"
+	m.streamConvoOutput(a, strings.NewReader(resultLine), nil, false)
+
+	if st := a.GetState(); st != StatePaused {
+		t.Errorf("State = %q, want %q after result with empty queue", st, StatePaused)
+	}
+}

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -72,6 +72,11 @@ type Agent struct {
 	stdinMu    sync.Mutex
 	approvalCh chan ApprovalResponse
 
+	// pendingPrompts queues follow-up user messages that arrive while a turn
+	// is mid-flight. Drained after each "result" event so the next turn fires
+	// without waiting on the user. Guarded by mu.
+	pendingPrompts []string
+
 	// promptCh delivers follow-up prompts to Codex conversational agents.
 	// Each turn spawns a new codex exec process; promptCh signals the next
 	// prompt without a stdin pipe. Guarded by mu.
@@ -185,6 +190,33 @@ func (a *Agent) AddResultStats(sessionID string, cost float64, in, out int) floa
 	result := a.CostUSD
 	a.mu.Unlock()
 	return result
+}
+
+// EnqueuePrompt appends a follow-up prompt to the pending queue.
+func (a *Agent) EnqueuePrompt(text string) {
+	a.mu.Lock()
+	a.pendingPrompts = append(a.pendingPrompts, text)
+	a.mu.Unlock()
+}
+
+// PopPendingPrompt returns the next queued prompt and a flag indicating
+// whether a value was popped.
+func (a *Agent) PopPendingPrompt() (string, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.pendingPrompts) == 0 {
+		return "", false
+	}
+	next := a.pendingPrompts[0]
+	a.pendingPrompts = a.pendingPrompts[1:]
+	return next, true
+}
+
+// PendingPromptCount returns the size of the pending prompt queue.
+func (a *Agent) PendingPromptCount() int {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return len(a.pendingPrompts)
 }
 
 // IncTurnCount increments the turn counter and returns the new value.

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -183,6 +183,12 @@ func (m *Manager) runConvoAttempt(ctx context.Context, a *Agent, cfg RunConfig, 
 		if err := m.writeUserMessage(a, cfg.Prompt); err != nil {
 			m.logger.Error("agent.convo.initial-prompt", "id", a.ID, "err", err)
 		}
+	} else if cfg.Prompt == "" && a.GetSessionID() == "" {
+		// Chat sessions can start without an initial prompt — claude is
+		// then idle on stdin waiting for the first user message. Reflect
+		// that by flipping to Paused so the chat input is enabled.
+		a.SetState(StatePaused)
+		m.emit(events.AgentState(a.ID), a)
 	}
 
 	// Open log file on first successful start; subsequent retries append.
@@ -282,8 +288,22 @@ func (m *Manager) streamConvoOutput(a *Agent, stdout io.Reader, outFile io.Write
 		case "result":
 			costNow := a.AddResultStats(event.SessionID, event.CostUSD, event.InputTokens, event.OutputTokens)
 			m.logger.Info("agent.convo.result", "id", a.ID, "session_id", event.SessionID, "cost", costNow)
-			// After result, agent is idle waiting for next user message.
-			a.SetState(StatePaused)
+			// Drain any prompts queued mid-turn before flipping to paused.
+			// Each queued prompt fires the next turn back-to-back so the
+			// user's chat-window queue executes in order without manual
+			// re-trigger.
+			if next, ok := a.PopPendingPrompt(); ok {
+				if err := m.writeUserMessage(a, next); err != nil {
+					m.logger.Error("agent.convo.flush-queue", "id", a.ID, "err", err)
+					a.SetState(StatePaused)
+				} else {
+					a.SetState(StateRunning)
+					m.logger.Info("agent.convo.queue-flushed", "id", a.ID, "remaining", a.PendingPromptCount())
+				}
+			} else {
+				// After result, agent is idle waiting for next user message.
+				a.SetState(StatePaused)
+			}
 			m.emit(events.AgentState(a.ID), a)
 			// One-shot runs (workflow steps that expect a single turn) close
 			// stdin now so the claude process sees EOF and exits. The scanner
@@ -337,6 +357,9 @@ func (m *Manager) writeUserMessage(a *Agent, text string) error {
 }
 
 // SendMessage sends a follow-up user message to a conversational agent.
+// When the agent is mid-turn (StateRunning), the message is appended to a
+// pending queue and flushed on the next "result" event, so users can pile
+// up follow-ups without waiting for each turn to settle.
 func (m *Manager) SendMessage(agentID, text string) error {
 	a, err := m.GetAgent(agentID)
 	if err != nil {
@@ -351,14 +374,22 @@ func (m *Manager) SendMessage(agentID, text string) error {
 	if !hasPipe {
 		return fmt.Errorf("agent %s has no stdin pipe (not conversational)", agentID)
 	}
-	if err := m.writeUserMessage(a, text); err != nil {
-		return err
-	}
-	a.SetState(StateRunning)
-	m.emit(events.AgentState(a.ID), a)
-	m.logger.Info("agent.convo.message_sent", "id", a.ID)
 
-	// Add user message to convo buffer.
+	queued := a.GetState() == StateRunning
+	if queued {
+		a.EnqueuePrompt(text)
+		m.logger.Info("agent.convo.message_queued", "id", a.ID, "queue_len", a.PendingPromptCount())
+	} else {
+		if err := m.writeUserMessage(a, text); err != nil {
+			return err
+		}
+		a.SetState(StateRunning)
+		m.emit(events.AgentState(a.ID), a)
+		m.logger.Info("agent.convo.message_sent", "id", a.ID)
+	}
+
+	// Add user message to convo buffer regardless — the user should see
+	// their message immediately, even if it is still queued.
 	ev := ConvoEvent{
 		Type:      "user_input",
 		Text:      text,


### PR DESCRIPTION
## Motivation

New chat from chat view stuck on "Waiting for response..." with input disabled. `StartChat` with empty initial prompt left agent in `StateRunning` while `runConvoAttempt` skipped the stdin write (`runner_convo.go:182` only writes when `cfg.Prompt != ""`), so claude idled on stdin forever. ChatView disables input on `isRunning`, hence the deadlock.

Also wanted to queue follow-ups while a turn is mid-flight instead of waiting for each result.

## Implementation information

- `runner_convo.go`: when starting with empty prompt + no session, flip to `StatePaused` and emit so input becomes typeable.
- `model.go`: `Agent.pendingPrompts` slice + `EnqueuePrompt` / `PopPendingPrompt` / `PendingPromptCount` (mu-guarded).
- `runner_convo.go` `SendMessage`: if state is `Running`, enqueue and still emit the `user_input` ConvoEvent so user sees their message immediately. Otherwise write stdin directly.
- `runner_convo.go` `streamConvoOutput`: on `result`, drain one queued prompt and write it (state stays `Running`); empty queue → `Paused`.
- `ChatInput.svelte`: new `placeholder` prop.
- `ChatView.svelte`: `disabled` only on `isWaitingForApproval`. While running, placeholder reads "Queue a follow-up...".

Alternatives considered: writing stdin from any state and letting claude interleave — rejected, claude stream-json semantics for mid-turn user messages are unclear, queue-and-flush is safer and gives explicit ordering.

> Changelog: fix(chat): unblock new chat input + queue follow-ups

## Supporting documentation

None.