### PR TITLE
feat(docker): bake klaudiush into image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /bin/synapse-server ./cmd/syn
 # Stage 3: Runtime — node:24-slim for claude CLI (Node.js-based)
 FROM node:24-slim AS runtime
 
+# renovate: datasource=github-releases depName=smykla-skalski/klaudiush
+ARG KLAUDIUSH_VERSION=v1.32.0
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates git curl gpg \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
@@ -25,10 +28,36 @@ RUN apt-get update \
          > /etc/apt/sources.list.d/github-cli.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends gh \
+    && curl -sSfL https://klaudiu.sh/install.sh \
+         | sh -s -- -b /usr/local/bin -v "${KLAUDIUSH_VERSION}" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g @anthropic-ai/claude-code @openai/codex \
     && rm -rf /root/.npm
+
+# Server-tuned klaudiush config: drop -S (no GPG key on server),
+# keep -s sign-off + conventional commit rules.
+RUN mkdir -p /root/.klaudiush && printf '%s\n' \
+    '[validators.git.commit]' \
+    'enabled = true' \
+    'severity = "error"' \
+    'required_flags = ["-s"]' \
+    'check_staging_area = true' \
+    'enable_message_validation = true' \
+    '' \
+    '[validators.git.commit.message]' \
+    'title_max_length = 50' \
+    'body_max_line_length = 72' \
+    'check_conventional_commits = true' \
+    'require_scope = true' \
+    'block_infra_scope_misuse = true' \
+    'block_pr_references = true' \
+    'block_ai_attribution = true' \
+    '' \
+    '[validators.git.no_verify]' \
+    'enabled = true' \
+    'severity = "error"' \
+    > /root/.klaudiush/config.toml
 
 COPY --from=go-builder /bin/synapse-server /usr/local/bin/synapse-server
 COPY --from=frontend-builder /app/frontend/dist-web /app/web
@@ -43,5 +72,6 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 
 # Mounts expected:
 #   ~/.synapse  → /root/.synapse  (task store, config, projects)
-#   ~/.claude   → /root/.claude   (claude CLI config + session)
+#   ~/.claude   → /root/.claude   (claude CLI config + session, must contain settings.json with klaudiush hooks)
+#   ~/.codex    → /root/.codex    (codex CLI config, must contain config.toml + hooks.json with klaudiush hooks)
 ENTRYPOINT ["/usr/local/bin/synapse-server"]

--- a/renovate.json
+++ b/renovate.json
@@ -57,6 +57,13 @@
       "groupName": "Go",
       "matchPackageNames": ["go"],
       "matchDatasources": ["golang-version"]
+    },
+    {
+      "description": "klaudiush — auto-merge any update",
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["smykla-skalski/klaudiush"],
+      "extractVersion": "^v(?<version>.*)$",
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## Motivation

Need klaudiush hook validation on the home-nas server (currently
local-only via Homebrew). Server cannot enforce GPG signing (`-S`)
because the personal key is not on the box.

## Implementation information

- Install klaudiush via `install.sh` into `/usr/local/bin` in the
  runtime stage. `KLAUDIUSH_VERSION` ARG with `# renovate:` annotation
  so renovate auto-bumps it on new releases.
- Bake `/root/.klaudiush/config.toml` with `required_flags = ["-s"]`
  (sign-off only). Conventional-commit + scope checks kept.
- renovate.json: auto-merge any klaudiush update.

Hooks themselves (`~/.claude/settings.json`, `~/.codex/hooks.json`)
live on the host because the synapse mounts shadow `/root/.claude`
and `/root/.codex`. Those are deployed via the home-nas ansible
playbook in a sibling PR.

## Supporting documentation

Companion PR: Automaat/home-nas (klaudiush hooks for synapse stack).

> Changelog: feat(docker): bake klaudiush into image