### PR TITLE
ci(actions): add hadolint dockerfile linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,18 @@ jobs:
         with:
           version: latest
 
+  lint-dockerfile:
+    name: Dockerfile Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
+        with:
+          dockerfile: Dockerfile
+          config: .hadolint.yaml
+          failure-threshold: warning
+
   check-wailsjs:
     name: Wails Bindings Sync
     runs-on: macos-15

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,8 @@
+---
+# Pinning every apt package version (gh, git, curl, gpg, ca-certificates) is
+# impractical: debian stable rolls security patches on its own cadence and
+# pinning would break builds the moment a CVE bump lands. The base image
+# already locks the package universe via its tag.
+ignored:
+  - DL3008
+failure-threshold: warning

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /bin/synapse-server ./cmd/syn
 # regenerate the blob on every build even when inputs are unchanged).
 FROM node:24-slim AS runtime
 
+# Pipe failures in subsequent RUN blocks should fail the build.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # --- Layer A: apt system packages + gh repo ---
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates git curl gpg \

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,7 @@
 [tools]
 go = "1.26.2"
 node = "24"
+hadolint = "2.14.0"
 "go:github.com/wailsapp/wails/v2/cmd/wails" = "v2.12.0"
 
 [tasks.dev]
@@ -17,7 +18,7 @@ run = "go build -o build/bin/synapse-cli ./cmd/synapse-cli"
 description = "Build CLI binary"
 
 [tasks.lint]
-run = ["golangci-lint run ./...", "cd frontend && npx oxlint ."]
+run = ["golangci-lint run ./...", "cd frontend && npx oxlint .", "hadolint Dockerfile"]
 description = "Run all linters"
 
 [tasks."build:frontend:desktop"]


### PR DESCRIPTION
## Motivation

No Dockerfile linter in the pipeline today. The server-deploy regression chain (dead mobile nav → slow ghcr pull) would have been caught earlier with hadolint: the fat runtime layer tripped DL3016 (unpinned npm) and DL4006 (pipe without pipefail) the moment hadolint ran.

## Implementation information

- \`mise.toml\` — pin \`hadolint = "2.14.0"\`, append \`hadolint Dockerfile\` to the \`lint\` task so \`mise run lint\` covers Go + frontend + Dockerfile in one pass
- \`.github/workflows/ci.yml\` — new \`lint-dockerfile\` job on \`ubuntu-latest\` using \`hadolint/hadolint-action\` pinned by SHA (matches the repo's \`helpers:pinGitHubActionDigests\` renovate policy)
- \`.hadolint.yaml\` — \`failure-threshold: warning\`, ignore \`DL3008\` only. Pinning every apt package version (gh, git, curl, gpg, ca-certificates) is impractical: debian stable rolls security patches on its own cadence and pinning would break builds the moment a CVE bump lands. Base image tag already locks the package universe.
- \`Dockerfile\` — add \`SHELL ["/bin/bash", "-o", "pipefail", "-c"]\` after the runtime \`FROM\` so the two piped \`RUN\` blocks (gpg dearmor + klaudiush install) fail on upstream errors instead of silently masking them. Fixes DL4006.

Verified locally: \`mise run lint\` clean, \`hadolint Dockerfile\` exit 0, \`docker buildx build --target runtime\` still builds.

## Supporting documentation

Based on #412 (runtime layer split). DL3016 is already fixed there by the \`CLAUDE_CODE_VERSION\` / \`CODEX_VERSION\` ARG pins — hadolint confirms it on the base branch. Merge order: #412 first, then this.

> Changelog: ci(actions): add hadolint dockerfile linter