### PR TITLE
ci(actions): create gh release on docker publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -81,3 +81,11 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.version }}" \
+            --title "${{ steps.version.outputs.version }}" \
+            --generate-notes


### PR DESCRIPTION
## Motivation

Docker Publish workflow tagged + pushed image but never created a GitHub Release, leaving tags orphaned from release notes.

## Implementation information

Added `gh release create` step after image push. Uses `--generate-notes` for auto changelog from commits. `contents: write` permission already present.

## Supporting documentation

N/A