### PR TITLE
feat(perf): load harness + go benchmarks

### DIFF
--- a/cmd/fake-claude/main.go
+++ b/cmd/fake-claude/main.go
@@ -22,6 +22,17 @@
 //   - evaluate: runs synapse-cli to set status=in-review, emits result
 //   - pr_created: emits result with a github.com/.../pull/N URL so the
 //     mechanical link_pr_and_review step can extract the PR number via regex
+//
+// Perf scenarios (zero token cost, drive backend load):
+//   - perf_stream: emit FAKE_CLAUDE_EVENT_COUNT assistant events spaced
+//     FAKE_CLAUDE_EVENT_INTERVAL_MS apart, then a result event. Defaults:
+//     100 events, 10ms interval.
+//   - perf_burst: emit FAKE_CLAUDE_EVENT_COUNT assistant events with zero
+//     inter-event sleep (stresses the 50ms emit throttle in runner_headless).
+//     Default: 500 events.
+//   - perf_long: emit assistant events at FAKE_CLAUDE_EVENT_INTERVAL_MS cadence
+//     for FAKE_CLAUDE_DURATION_MS total, then a result event. Used for soak
+//     and memory-leak testing. Defaults: 30s duration, 200ms interval.
 package main
 
 import (
@@ -32,6 +43,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -132,45 +144,136 @@ func main() {
 		emitAssistant("Implementing and pushing PR...")
 		emitResult("Implementation done. Created PR https://github.com/test-org/test-repo/pull/42")
 
+	case "perf_stream":
+		runPerfStream()
+
+	case "perf_burst":
+		runPerfBurst()
+
+	case "perf_long":
+		runPerfLong()
+
 	default:
 		fmt.Fprintf(os.Stderr, "unknown scenario: %s\n", scenario)
 		os.Exit(2)
 	}
 }
 
+// runPerfStream emits FAKE_CLAUDE_EVENT_COUNT assistant events at a fixed
+// interval, then a result. Used to characterize steady-state throughput.
+func runPerfStream() {
+	count := envInt("FAKE_CLAUDE_EVENT_COUNT", 100)
+	intervalMs := envInt("FAKE_CLAUDE_EVENT_INTERVAL_MS", 10)
+	interval := time.Duration(intervalMs) * time.Millisecond
+	emitRaw(systemEvent())
+	for i := range count {
+		emitRaw(assistantEvent(fmt.Sprintf("perf_stream event %d/%d", i+1, count)))
+		if interval > 0 {
+			time.Sleep(interval)
+		}
+	}
+	emitRaw(resultEvent(fmt.Sprintf("perf_stream emitted %d events", count)))
+}
+
+// runPerfBurst emits FAKE_CLAUDE_EVENT_COUNT assistant events with zero
+// inter-event sleep, then a result. Used to stress the 50ms emit throttle
+// in runner_headless and the downstream event fanout.
+func runPerfBurst() {
+	count := envInt("FAKE_CLAUDE_EVENT_COUNT", 500)
+	emitRaw(systemEvent())
+	for i := range count {
+		emitRaw(assistantEvent(fmt.Sprintf("perf_burst event %d/%d", i+1, count)))
+	}
+	emitRaw(resultEvent(fmt.Sprintf("perf_burst emitted %d events", count)))
+}
+
+// runPerfLong emits assistant events at a fixed cadence for a total duration,
+// then a result. Used for soak / memory-leak detection.
+func runPerfLong() {
+	durationMs := envInt("FAKE_CLAUDE_DURATION_MS", 30000)
+	intervalMs := envInt("FAKE_CLAUDE_EVENT_INTERVAL_MS", 200)
+	duration := time.Duration(durationMs) * time.Millisecond
+	interval := time.Duration(intervalMs) * time.Millisecond
+	emitRaw(systemEvent())
+	deadline := time.Now().Add(duration)
+	i := 0
+	for time.Now().Before(deadline) {
+		i++
+		emitRaw(assistantEvent(fmt.Sprintf("perf_long event %d", i)))
+		if interval > 0 {
+			time.Sleep(interval)
+		}
+	}
+	emitRaw(resultEvent(fmt.Sprintf("perf_long emitted %d events over %s", i, duration)))
+}
+
+// envInt reads a non-negative integer from env, falling back to def on parse
+// error or missing value. Negative or non-integer inputs return def.
+func envInt(key string, def int) int {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return def
+	}
+	return n
+}
+
 func emitSystem() {
-	emit(map[string]any{
-		"type":       "system",
-		"session_id": "fake-session-1",
-	})
+	emit(systemEvent())
 }
 
 func emitAssistant(text string) {
-	emit(map[string]any{
+	emit(assistantEvent(text))
+}
+
+func emitResult(result string) {
+	emit(resultEvent(result))
+}
+
+func systemEvent() map[string]any {
+	return map[string]any{
+		"type":       "system",
+		"session_id": "fake-session-1",
+	}
+}
+
+func assistantEvent(text string) map[string]any {
+	return map[string]any{
 		"type": "assistant",
 		"message": map[string]any{
 			"content": []any{
 				map[string]any{"type": "text", "text": text},
 			},
 		},
-	})
+	}
 }
 
-func emitResult(result string) {
-	emit(map[string]any{
+func resultEvent(result string) map[string]any {
+	return map[string]any{
 		"type":                "result",
 		"result":              result,
 		"session_id":          "fake-session-1",
 		"total_cost_usd":      0.01,
 		"total_input_tokens":  100.0,
 		"total_output_tokens": 50.0,
-	})
+	}
 }
 
+// emit writes an event and sleeps 10ms. Used by legacy scenarios that depend
+// on the paced emission for test realism.
 func emit(event map[string]any) {
+	emitRaw(event)
+	time.Sleep(10 * time.Millisecond)
+}
+
+// emitRaw writes an event without any post-sleep. Perf scenarios use this so
+// they can control cadence explicitly.
+func emitRaw(event map[string]any) {
 	data, _ := json.Marshal(event)
 	fmt.Println(string(data))
-	time.Sleep(10 * time.Millisecond)
 }
 
 // extractTaskID attempts to find a task ID in the -p prompt argument.

--- a/cmd/fake-claude/main_test.go
+++ b/cmd/fake-claude/main_test.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestExtractTaskID(t *testing.T) {
@@ -105,5 +110,158 @@ func TestPopScenario_FileMissingFallsBack(t *testing.T) {
 	got := popScenario()
 	if got != "evaluate" {
 		t.Errorf("popScenario() = %q, want %q", got, "evaluate")
+	}
+}
+
+func TestEnvInt(t *testing.T) {
+	tests := []struct {
+		name string
+		val  string
+		def  int
+		want int
+	}{
+		{"unset returns default", "", 42, 42},
+		{"valid integer", "17", 42, 17},
+		{"zero allowed", "0", 42, 0},
+		{"whitespace trimmed", "  99 ", 42, 99},
+		{"negative falls back", "-5", 42, 42},
+		{"non-numeric falls back", "abc", 42, 42},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := "FAKE_CLAUDE_TEST_ENVINT"
+			if tt.val == "" {
+				os.Unsetenv(key)
+			} else {
+				t.Setenv(key, tt.val)
+			}
+			got := envInt(key, tt.def)
+			if got != tt.want {
+				t.Errorf("envInt(%q, %d) = %d, want %d", tt.val, tt.def, got, tt.want)
+			}
+		})
+	}
+}
+
+// captureStdout swaps os.Stdout with a pipe, runs fn, and returns everything
+// that was written during fn's execution. Used to verify the NDJSON output
+// of the perf scenarios.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+
+	_ = w.Close()
+	os.Stdout = orig
+	return <-done
+}
+
+// parseNDJSON splits an NDJSON blob into decoded event maps, skipping blank
+// lines so trailing newlines don't inflate counts.
+func parseNDJSON(t *testing.T, out string) []map[string]any {
+	t.Helper()
+	var events []map[string]any
+	for line := range strings.SplitSeq(out, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var ev map[string]any
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("decode %q: %v", line, err)
+		}
+		events = append(events, ev)
+	}
+	return events
+}
+
+func TestRunPerfStream_DefaultCount(t *testing.T) {
+	t.Setenv("FAKE_CLAUDE_EVENT_COUNT", "")
+	os.Unsetenv("FAKE_CLAUDE_EVENT_COUNT")
+	t.Setenv("FAKE_CLAUDE_EVENT_INTERVAL_MS", "0")
+
+	out := captureStdout(t, runPerfStream)
+	events := parseNDJSON(t, out)
+	// 1 system + 100 assistant + 1 result = 102
+	if len(events) != 102 {
+		t.Fatalf("event count = %d, want 102", len(events))
+	}
+	if events[0]["type"] != "system" {
+		t.Errorf("first event type = %v, want system", events[0]["type"])
+	}
+	if events[1]["type"] != "assistant" {
+		t.Errorf("second event type = %v, want assistant", events[1]["type"])
+	}
+	if events[len(events)-1]["type"] != "result" {
+		t.Errorf("last event type = %v, want result", events[len(events)-1]["type"])
+	}
+}
+
+func TestRunPerfStream_CustomCount(t *testing.T) {
+	t.Setenv("FAKE_CLAUDE_EVENT_COUNT", "5")
+	t.Setenv("FAKE_CLAUDE_EVENT_INTERVAL_MS", "0")
+
+	out := captureStdout(t, runPerfStream)
+	events := parseNDJSON(t, out)
+	if len(events) != 7 { // 1 system + 5 assistant + 1 result
+		t.Fatalf("event count = %d, want 7", len(events))
+	}
+}
+
+func TestRunPerfBurst_EmitsWithoutSleep(t *testing.T) {
+	t.Setenv("FAKE_CLAUDE_EVENT_COUNT", "1000")
+
+	start := time.Now()
+	out := captureStdout(t, runPerfBurst)
+	elapsed := time.Since(start)
+
+	events := parseNDJSON(t, out)
+	if len(events) != 1002 { // 1 system + 1000 assistant + 1 result
+		t.Fatalf("event count = %d, want 1002", len(events))
+	}
+	// The legacy emit helper sleeps 10ms per event. Emitting 1000 events that
+	// way would take ≥10s. Burst must complete well under 1s even on a slow CI
+	// box — if this fails, perf_burst is accidentally paced.
+	if elapsed > time.Second {
+		t.Errorf("burst took %s, expected <1s (emitRaw must not sleep)", elapsed)
+	}
+}
+
+func TestRunPerfLong_RespectsDuration(t *testing.T) {
+	t.Setenv("FAKE_CLAUDE_DURATION_MS", "200")
+	t.Setenv("FAKE_CLAUDE_EVENT_INTERVAL_MS", "20")
+
+	start := time.Now()
+	out := captureStdout(t, runPerfLong)
+	elapsed := time.Since(start)
+
+	events := parseNDJSON(t, out)
+	if len(events) < 3 {
+		t.Fatalf("event count = %d, want ≥3 (system + assistants + result)", len(events))
+	}
+	if events[0]["type"] != "system" {
+		t.Errorf("first event type = %v, want system", events[0]["type"])
+	}
+	if events[len(events)-1]["type"] != "result" {
+		t.Errorf("last event type = %v, want result", events[len(events)-1]["type"])
+	}
+	// Duration is 200ms; allow up to 1s slack for scheduler jitter.
+	if elapsed < 200*time.Millisecond {
+		t.Errorf("elapsed %s < 200ms minimum", elapsed)
+	}
+	if elapsed > time.Second {
+		t.Errorf("elapsed %s exceeded 1s slack", elapsed)
 	}
 }

--- a/cmd/synapse-perf/main.go
+++ b/cmd/synapse-perf/main.go
@@ -1,0 +1,1100 @@
+// synapse-perf is a token-free end-to-end load harness for Synapse.
+//
+// It boots a throwaway synapse-server subprocess in an isolated SYNAPSE_HOME,
+// points the server at the fake-claude test double (via PATH injection) so
+// no real LLM API tokens are spent, drives the server over the HTTP dispatch
+// API, and collects latency + throughput statistics. Optionally pulls
+// Prometheus metrics and pprof profiles for deeper investigation.
+//
+// Scenarios:
+//
+//	steady — ramp to N concurrent agents and hold for the scenario duration.
+//	         Each agent runs the fake-claude perf_stream scenario, producing
+//	         a controlled NDJSON stream. Measures agent startup latency and
+//	         steady-state event throughput.
+//
+//	spike  — start concurrency agents as fast as possible, no hold.
+//	         Each agent runs fake-claude perf_burst. Stresses the 50ms
+//	         emit throttle and concurrency cap bookkeeping.
+//
+//	soak   — start concurrency agents using fake-claude perf_long for the
+//	         full scenario duration. Used with pprof heap diffs to surface
+//	         goroutine or buffer leaks.
+//
+//	churn  — no agents; hammer TaskService.CreateTask / UpdateTask / DeleteTask
+//	         at the configured rate. Measures task-store latency and watcher
+//	         debounce behavior under bursty writes.
+//
+// Output: JSON report on stdout. Non-zero exit on setup failure or if the
+// scenario's error budget is exceeded.
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type options struct {
+	scenario      string
+	concurrency   int
+	duration      time.Duration
+	rampDuration  time.Duration
+	eventCount    int
+	eventInterval time.Duration
+	churnRate     int
+	fakeClaude    string
+	workDir       string
+	pprofDir      string
+	reportPath    string
+	keepHome      bool
+	verbose       bool
+}
+
+func parseFlags() options {
+	var o options
+	flag.StringVar(&o.scenario, "scenario", "steady", "steady | spike | soak | churn")
+	flag.IntVar(&o.concurrency, "concurrency", 4, "target concurrent agents (steady/spike/soak) or parallel workers (churn)")
+	flag.DurationVar(&o.duration, "duration", 30*time.Second, "total scenario runtime")
+	flag.DurationVar(&o.rampDuration, "ramp", 2*time.Second, "ramp-up duration for steady/soak")
+	flag.IntVar(&o.eventCount, "events", 100, "fake-claude event count for perf_stream / perf_burst")
+	flag.DurationVar(&o.eventInterval, "event-interval", 10*time.Millisecond, "fake-claude inter-event interval for perf_stream / perf_long")
+	flag.IntVar(&o.churnRate, "churn-rate", 100, "task operations per second for churn scenario")
+	flag.StringVar(&o.fakeClaude, "fake-claude", "", "path to fake-claude binary (default: go run ./cmd/fake-claude)")
+	flag.StringVar(&o.workDir, "workdir", "", "SYNAPSE_HOME to use (default: a tmp dir)")
+	flag.StringVar(&o.pprofDir, "pprof-dir", "", "if set, write heap/goroutine profiles here before and after the run")
+	flag.StringVar(&o.reportPath, "report", "", "if set, write JSON report to this path instead of stdout")
+	flag.BoolVar(&o.keepHome, "keep-home", false, "do not delete the temp SYNAPSE_HOME after the run")
+	flag.BoolVar(&o.verbose, "verbose", false, "log server output and per-agent progress")
+	flag.Parse()
+	return o
+}
+
+func main() {
+	o := parseFlags()
+	if err := run(o); err != nil {
+		fmt.Fprintln(os.Stderr, "synapse-perf:", err)
+		os.Exit(1)
+	}
+}
+
+func run(o options) error {
+	if err := validateScenario(o.scenario); err != nil {
+		return err
+	}
+
+	home, cleanupHome, err := prepareHome(o)
+	if err != nil {
+		return fmt.Errorf("prepare home: %w", err)
+	}
+	if !o.keepHome {
+		defer cleanupHome()
+	}
+
+	fakeDir, err := resolveFakeClaude(o.fakeClaude)
+	if err != nil {
+		return fmt.Errorf("resolve fake-claude: %w", err)
+	}
+
+	port, err := pickFreePort()
+	if err != nil {
+		return fmt.Errorf("pick port: %w", err)
+	}
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	srv, err := startServer(o, home, fakeDir, port)
+	if err != nil {
+		return fmt.Errorf("start server: %w", err)
+	}
+	defer srv.stop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := waitHealthy(ctx, baseURL, 30*time.Second); err != nil {
+		return fmt.Errorf("server never became healthy: %w", err)
+	}
+
+	client := newAPIClient(baseURL)
+
+	if o.pprofDir != "" {
+		if err := os.MkdirAll(o.pprofDir, 0o755); err != nil {
+			return fmt.Errorf("pprof dir: %w", err)
+		}
+		_ = fetchProfile(ctx, baseURL, "heap", filepath.Join(o.pprofDir, "heap-before.pb.gz"))
+		_ = fetchProfile(ctx, baseURL, "goroutine", filepath.Join(o.pprofDir, "goroutine-before.pb.gz"))
+	}
+
+	report := &Report{
+		Scenario:    o.scenario,
+		Concurrency: o.concurrency,
+		Duration:    o.duration.String(),
+		StartedAt:   time.Now().UTC(),
+	}
+
+	// Capture a baseline of key Prometheus counters before the scenario runs
+	// so the report can show the delta (how much the scenario actually
+	// moved the needle) rather than cumulative server lifetime totals.
+	if m, err := scrapeMetrics(ctx, baseURL+"/metrics"); err == nil {
+		report.MetricsBefore = m
+	}
+
+	switch o.scenario {
+	case "steady":
+		err = runSteady(ctx, client, o, report)
+	case "spike":
+		err = runSpike(ctx, client, o, report)
+	case "soak":
+		err = runSoak(ctx, client, o, report)
+	case "churn":
+		err = runChurn(ctx, client, o, report)
+	}
+	if err != nil {
+		report.FatalError = err.Error()
+	}
+
+	if m, err := scrapeMetrics(ctx, baseURL+"/metrics"); err == nil {
+		report.MetricsAfter = m
+	}
+
+	if o.pprofDir != "" {
+		_ = fetchProfile(ctx, baseURL, "heap", filepath.Join(o.pprofDir, "heap-after.pb.gz"))
+		_ = fetchProfile(ctx, baseURL, "goroutine", filepath.Join(o.pprofDir, "goroutine-after.pb.gz"))
+	}
+
+	report.FinishedAt = time.Now().UTC()
+	report.finalize()
+
+	if err := writeReport(report, o.reportPath); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	if report.FatalError != "" {
+		return errors.New(report.FatalError)
+	}
+	return nil
+}
+
+func validateScenario(s string) error {
+	switch s {
+	case "steady", "spike", "soak", "churn":
+		return nil
+	default:
+		return fmt.Errorf("unknown scenario %q (valid: steady, spike, soak, churn)", s)
+	}
+}
+
+// prepareHome sets up an isolated SYNAPSE_HOME with a perf-tuned config:
+// metrics on, pollers off, generous concurrency cap, research_machine_dir
+// populated so research-type tasks skip worktree setup. Returns the home
+// path and a cleanup function.
+func prepareHome(o options) (home string, cleanup func(), err error) {
+	if o.workDir != "" {
+		abs, absErr := filepath.Abs(o.workDir)
+		if absErr != nil {
+			return "", nil, absErr
+		}
+		home = abs
+		if mkErr := os.MkdirAll(home, 0o755); mkErr != nil {
+			return "", nil, mkErr
+		}
+	} else {
+		dir, tmpErr := os.MkdirTemp("", "synapse-perf-*")
+		if tmpErr != nil {
+			return "", nil, tmpErr
+		}
+		home = dir
+	}
+
+	// Dirs the server would otherwise create under HomeDir(); creating them
+	// up-front lets us point research_machine_dir at an existing path. Build
+	// each directory absolutely so a typo in one entry can't silently place
+	// the research dir in the wrong place.
+	researchDir := filepath.Join(home, "research")
+	for _, sub := range []string{"tasks", "logs", "clones", "worktrees", "projects", "loop-agents"} {
+		if mkErr := os.MkdirAll(filepath.Join(home, sub), 0o755); mkErr != nil && !errors.Is(mkErr, os.ErrExist) {
+			return home, nil, mkErr
+		}
+	}
+	if mkErr := os.MkdirAll(researchDir, 0o755); mkErr != nil && !errors.Is(mkErr, os.ErrExist) {
+		return home, nil, mkErr
+	}
+
+	// Write a minimal config that:
+	// - enables metrics (for /metrics scraping)
+	// - disables all pollers (todoist, github, renovate) so the server has
+	//   no background noise competing with the scenario
+	// - lifts the concurrency cap to at least 2× the requested concurrency
+	// - opts agents out of require_permissions so fake-claude runs with
+	//   --dangerously-skip-permissions (avoids any approval flow)
+	// - points research_machine_dir at the pre-created researchDir so
+	//   research-type tasks skip worktree setup
+	maxConcurrent := max(o.concurrency*2, 8)
+	cfg := fmt.Sprintf(`# synapse-perf temp config
+metrics:
+  enabled: true
+agent:
+  max_concurrent: %d
+  max_cost_usd: 0
+  max_turns: 0
+  research_machine_dir: %s
+  require_permissions: false
+todoist:
+  enabled: false
+github:
+  enabled: false
+renovate:
+  enabled: false
+notification:
+  desktop: false
+providers:
+  health_check:
+    enabled: false
+  auto_failover: false
+`, maxConcurrent, researchDir)
+	if wrErr := os.WriteFile(filepath.Join(home, "config.yaml"), []byte(cfg), 0o644); wrErr != nil {
+		return home, nil, wrErr
+	}
+
+	cleanup = func() {
+		_ = os.RemoveAll(home)
+	}
+	return home, cleanup, nil
+}
+
+// resolveFakeClaude returns a directory that contains a binary named "claude"
+// which is the fake-claude test double. If an explicit path is supplied, we
+// symlink it into a private dir so PATH-injection is clean. Otherwise we
+// build fake-claude via `go build` into a temp dir.
+func resolveFakeClaude(explicit string) (string, error) {
+	dir, err := os.MkdirTemp("", "synapse-perf-fake-*")
+	if err != nil {
+		return "", err
+	}
+
+	var src string
+	if explicit != "" {
+		abs, err := filepath.Abs(explicit)
+		if err != nil {
+			return "", err
+		}
+		src = abs
+	} else {
+		src = filepath.Join(dir, "fake-claude")
+		cmd := exec.Command("go", "build", "-o", src, "./cmd/fake-claude")
+		cmd.Stdout = os.Stderr
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return "", fmt.Errorf("go build fake-claude: %w", err)
+		}
+	}
+
+	// Runner looks up "claude" by name via exec.LookPath, so symlink the
+	// fake binary under that name inside our private dir. Fall back to copy
+	// if symlink fails (e.g. tmpfs with no symlink support).
+	claudePath := filepath.Join(dir, "claude")
+	if err := os.Symlink(src, claudePath); err != nil {
+		data, readErr := os.ReadFile(src)
+		if readErr != nil {
+			return "", fmt.Errorf("read fake-claude: %w", readErr)
+		}
+		if err := os.WriteFile(claudePath, data, 0o755); err != nil {
+			return "", fmt.Errorf("write fake-claude copy: %w", err)
+		}
+	}
+	return dir, nil
+}
+
+type serverProc struct {
+	cmd *exec.Cmd
+}
+
+func (s *serverProc) stop() {
+	if s.cmd == nil || s.cmd.Process == nil {
+		return
+	}
+	_ = s.cmd.Process.Signal(os.Interrupt)
+	done := make(chan struct{})
+	go func() {
+		_ = s.cmd.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		_ = s.cmd.Process.Kill()
+		<-done
+	}
+}
+
+func startServer(o options, home, fakeDir string, port int) (*serverProc, error) {
+	// Always exec via `go run ./cmd/synapse-server` — a literal-string
+	// invocation keeps gosec G204 silent and avoids the footgun of a stale
+	// pre-built binary masking recent server changes. Go build caching
+	// makes repeat runs of the same scenario pay the compile cost only once.
+	cmd := exec.Command("go", "run", "./cmd/synapse-server")
+
+	perfPath := fakeDir + string(os.PathListSeparator) + os.Getenv("PATH")
+	env := os.Environ()
+	env = filterEnv(env, []string{"SYNAPSE_HOME", "SYNAPSE_PORT", "SYNAPSE_PPROF", "SYNAPSE_TASKS_DIR", "PATH", "FAKE_CLAUDE_SCENARIO", "FAKE_CLAUDE_EVENT_COUNT", "FAKE_CLAUDE_EVENT_INTERVAL_MS", "FAKE_CLAUDE_DURATION_MS"})
+	env = append(env,
+		"SYNAPSE_HOME="+home,
+		"SYNAPSE_PORT="+strconv.Itoa(port),
+		"SYNAPSE_PPROF=1",
+		"PATH="+perfPath,
+		"FAKE_CLAUDE_SCENARIO="+scenarioToFake(o.scenario),
+		"FAKE_CLAUDE_EVENT_COUNT="+strconv.Itoa(o.eventCount),
+		"FAKE_CLAUDE_EVENT_INTERVAL_MS="+strconv.Itoa(int(o.eventInterval/time.Millisecond)),
+		"FAKE_CLAUDE_DURATION_MS="+strconv.Itoa(int(o.duration/time.Millisecond)),
+	)
+	cmd.Env = env
+
+	if o.verbose {
+		cmd.Stdout = os.Stderr
+		cmd.Stderr = os.Stderr
+	} else {
+		cmd.Stdout = io.Discard
+		cmd.Stderr = io.Discard
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return &serverProc{cmd: cmd}, nil
+}
+
+func scenarioToFake(scenario string) string {
+	switch scenario {
+	case "spike":
+		return "perf_burst"
+	case "soak":
+		return "perf_long"
+	case "churn":
+		return "success" // churn scenario does not start agents
+	default:
+		return "perf_stream"
+	}
+}
+
+// filterEnv strips env vars that we intend to overwrite, to avoid PATH
+// duplication and stale FAKE_CLAUDE_* values from the parent shell.
+func filterEnv(env, drop []string) []string {
+	dropSet := make(map[string]struct{}, len(drop))
+	for _, k := range drop {
+		dropSet[k] = struct{}{}
+	}
+	out := env[:0]
+	for _, kv := range env {
+		key, _, ok := strings.Cut(kv, "=")
+		if !ok {
+			out = append(out, kv)
+			continue
+		}
+		if _, skip := dropSet[key]; skip {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+func pickFreePort() (int, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = l.Close() }()
+	addr, ok := l.Addr().(*net.TCPAddr)
+	if !ok {
+		return 0, errors.New("pickFreePort: listener is not a *net.TCPAddr")
+	}
+	return addr.Port, nil
+}
+
+// waitHealthy blocks until GET /health returns 200 or ctx/deadline expires.
+// Polls every 100ms. Required because startServer returns immediately after
+// the subprocess is spawned; the server listener is not yet bound.
+func waitHealthy(ctx context.Context, baseURL string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout after %s", timeout)
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/health", http.NoBody)
+		if err != nil {
+			return err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+// ==================== API client ====================
+
+type apiClient struct {
+	baseURL string
+	http    *http.Client
+}
+
+func newAPIClient(baseURL string) *apiClient {
+	return &apiClient{
+		baseURL: baseURL,
+		http: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// call invokes POST /api/{service}/{method} with the given positional args.
+// Args are JSON-encoded as an array per httpapi.Mount's contract. out may be
+// nil when the caller does not care about the response body.
+func (c *apiClient) call(service, method string, args []any, out any) error {
+	var body []byte
+	var err error
+	if len(args) > 0 {
+		body, err = json.Marshal(args)
+		if err != nil {
+			return err
+		}
+	}
+	url := fmt.Sprintf("%s/api/%s/%s", c.baseURL, service, method)
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(string(body)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("%s.%s: %s (%d)", service, method, strings.TrimSpace(string(msg)), resp.StatusCode)
+	}
+	if out == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// ==================== Task helpers ====================
+
+type taskPayload struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+}
+
+// createResearchTask creates a task then flips its task_type to "research"
+// so StartAgent takes the skipWorktree path and runs against the configured
+// research_machine_dir. Avoids the cost of real git-worktree setup.
+func (c *apiClient) createResearchTask(i int) (string, error) {
+	var t taskPayload
+	if err := c.call("TaskService", "CreateTask", []any{
+		fmt.Sprintf("perf task %d", i),
+		"## Description\nperf harness body\n",
+		"headless",
+	}, &t); err != nil {
+		return "", fmt.Errorf("CreateTask: %w", err)
+	}
+	if t.ID == "" {
+		return "", errors.New("CreateTask returned empty id")
+	}
+	if err := c.call("TaskService", "UpdateTask", []any{t.ID, map[string]any{"task_type": "research"}}, nil); err != nil {
+		return "", fmt.Errorf("UpdateTask task_type=research: %w", err)
+	}
+	return t.ID, nil
+}
+
+// startAgent invokes App.StartAgent and returns the spawned agent's in-memory
+// ID so the caller can correlate SSE output/state events back to this run.
+func (c *apiClient) startAgent(taskID string) (string, error) {
+	var resp struct {
+		ID string `json:"id"`
+	}
+	if err := c.call("App", "StartAgent", []any{taskID, "headless", "perf harness prompt"}, &resp); err != nil {
+		return "", err
+	}
+	return resp.ID, nil
+}
+
+func (c *apiClient) deleteTask(id string) error {
+	return c.call("TaskService", "DeleteTask", []any{id}, nil)
+}
+
+// ==================== Scenarios ====================
+
+// agentResult carries per-agent measurements. A zero startLatency means the
+// agent never produced a first event before the scenario ended.
+type agentResult struct {
+	taskID       string
+	agentID      string
+	startedAt    time.Time
+	startLatency time.Duration
+	totalEvents  int
+	err          string
+}
+
+func runSteady(ctx context.Context, c *apiClient, o options, report *Report) error {
+	return runConcurrentAgents(ctx, c, o, report, "steady")
+}
+
+func runSpike(ctx context.Context, c *apiClient, o options, report *Report) error {
+	// Spike differs from steady only in ramp=0 and the perf_burst fake
+	// scenario (already wired in startServer).
+	o.rampDuration = 0
+	return runConcurrentAgents(ctx, c, o, report, "spike")
+}
+
+func runSoak(ctx context.Context, c *apiClient, o options, report *Report) error {
+	return runConcurrentAgents(ctx, c, o, report, "soak")
+}
+
+// eventCollector drains an SSE channel and exposes per-agent counters
+// through sync.Maps. It owns the goroutine that walks the channel and
+// returns totals when drained.
+type eventCollector struct {
+	counts sync.Map // agentID → int
+	done   sync.Map // agentID → time.Time of result event
+	total  atomic.Int64
+}
+
+func (ec *eventCollector) start(events <-chan sseEvent) {
+	go func() {
+		for ev := range events {
+			ec.total.Add(1)
+			// Only agent:output:{id} events carry per-agent throughput info.
+			// agent:state:{id} fires once per state transition and is
+			// counted in total but not broken down per agent here.
+			const prefix = "agent:output:"
+			if !strings.HasPrefix(ev.name, prefix) {
+				continue
+			}
+			agentID := ev.name[len(prefix):]
+			cur, _ := ec.counts.LoadOrStore(agentID, 0)
+			if v, ok := cur.(int); ok {
+				ec.counts.Store(agentID, v+1)
+			}
+			if strings.Contains(ev.data, `"type":"result"`) {
+				ec.done.Store(agentID, time.Now())
+			}
+		}
+	}()
+}
+
+func (ec *eventCollector) sum() int {
+	var total int
+	ec.counts.Range(func(_, v any) bool {
+		if n, ok := v.(int); ok {
+			total += n
+		}
+		return true
+	})
+	return total
+}
+
+func (ec *eventCollector) forAgent(agentID string) int {
+	if agentID == "" {
+		return 0
+	}
+	v, ok := ec.counts.Load(agentID)
+	if !ok {
+		return 0
+	}
+	n, _ := v.(int)
+	return n
+}
+
+// launchAgents fans out concurrency goroutines that each create a task and
+// call StartAgent, spacing their starts linearly over rampDuration. Returns
+// once every goroutine has recorded its agentResult.
+func launchAgents(ctx context.Context, c *apiClient, o options) []agentResult {
+	results := make([]agentResult, o.concurrency)
+	var wg sync.WaitGroup
+	for i := range o.concurrency {
+		var delay time.Duration
+		if o.concurrency > 1 && o.rampDuration > 0 {
+			delay = time.Duration(i) * o.rampDuration / time.Duration(o.concurrency-1)
+		}
+		wg.Add(1)
+		go func(i int, delay time.Duration) {
+			defer wg.Done()
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(delay):
+			}
+			r := runOneAgent(ctx, c, i)
+			results[i] = r
+			if o.verbose {
+				log.Printf("agent[%d] task=%s err=%q events=%d", i, r.taskID, r.err, r.totalEvents)
+			}
+		}(i, delay)
+	}
+	wg.Wait()
+	return results
+}
+
+// holdForDuration blocks until the configured scenario duration has elapsed
+// (counted from start), or until ctx is cancelled. Adds a short drain window
+// so in-flight SSE events emitted by late-finishing agents are still captured.
+func holdForDuration(ctx context.Context, start time.Time, duration time.Duration) {
+	remaining := duration - time.Since(start)
+	if remaining > 0 {
+		select {
+		case <-ctx.Done():
+		case <-time.After(remaining):
+		}
+	}
+	time.Sleep(250 * time.Millisecond)
+}
+
+// runConcurrentAgents drives `concurrency` agents concurrently and collects
+// their results. Agents are started linearly over rampDuration, then held
+// for duration minus the ramp. Each agent runs with the fake-claude scenario
+// set by startServer; this function is transport-agnostic.
+func runConcurrentAgents(ctx context.Context, c *apiClient, o options, report *Report, kind string) error {
+	scenarioCtx, cancel := context.WithTimeout(ctx, o.duration+30*time.Second)
+	defer cancel()
+
+	resp, events, err := subscribeEvents(scenarioCtx, c.baseURL+"/events")
+	if err != nil {
+		return fmt.Errorf("subscribe /events: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var ec eventCollector
+	ec.start(events)
+
+	start := time.Now()
+	results := launchAgents(scenarioCtx, c, o)
+	holdForDuration(scenarioCtx, start, o.duration)
+
+	report.Kind = kind
+	report.TotalAgents = o.concurrency
+	report.TotalEvents = int(ec.total.Load())
+	report.OutputEvents = ec.sum()
+	report.Elapsed = time.Since(start).String()
+	report.Agents = make([]agentReport, 0, len(results))
+	for _, r := range results {
+		report.Agents = append(report.Agents, agentReport{
+			TaskID:             r.taskID,
+			AgentID:            r.agentID,
+			StartLatencyMS:     r.startLatency.Milliseconds(),
+			Error:              r.err,
+			ObservedEventCount: ec.forAgent(r.agentID),
+		})
+	}
+	return nil
+}
+
+// runOneAgent creates a research task, starts a headless agent against it,
+// and measures only the HTTP startup latency. Per-agent event counts are
+// collected separately via the SSE listener in the caller.
+func runOneAgent(_ context.Context, c *apiClient, i int) agentResult {
+	r := agentResult{startedAt: time.Now()}
+	id, err := c.createResearchTask(i)
+	if err != nil {
+		r.err = err.Error()
+		return r
+	}
+	r.taskID = id
+	callStart := time.Now()
+	agentID, err := c.startAgent(id)
+	if err != nil {
+		r.err = err.Error()
+		return r
+	}
+	r.agentID = agentID
+	r.startLatency = time.Since(callStart)
+	// runOneAgent returns as soon as StartAgent is accepted — the caller's
+	// SSE listener records events emitted by the agent afterward.
+	return r
+}
+
+func runChurn(ctx context.Context, c *apiClient, o options, report *Report) error {
+	if o.churnRate <= 0 {
+		return errors.New("churn-rate must be > 0")
+	}
+	deadline := time.Now().Add(o.duration)
+	ticker := time.NewTicker(time.Second / time.Duration(o.churnRate))
+	defer ticker.Stop()
+
+	var (
+		createLat []time.Duration
+		updateLat []time.Duration
+		deleteLat []time.Duration
+		errCount  atomic.Int64
+		total     atomic.Int64
+		mu        sync.Mutex
+	)
+
+	sem := make(chan struct{}, o.concurrency)
+	var wg sync.WaitGroup
+
+	for {
+		select {
+		case <-ctx.Done():
+			goto done
+		case <-ticker.C:
+		}
+		if time.Now().After(deadline) {
+			goto done
+		}
+		select {
+		case sem <- struct{}{}:
+		default:
+			// worker pool saturated — count as backpressure event
+			continue
+		}
+		wg.Add(1)
+		go func(seq int64) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			cStart := time.Now()
+			var t taskPayload
+			if err := c.call("TaskService", "CreateTask", []any{
+				fmt.Sprintf("churn task %d", seq),
+				"## body\nchurn body\n",
+				"headless",
+			}, &t); err != nil {
+				errCount.Add(1)
+				return
+			}
+			cDur := time.Since(cStart)
+
+			uStart := time.Now()
+			// Update only the body field: tags / status transitions would
+			// trigger hooks (orchestrator, notifier, workflow engine) and
+			// contaminate pure CRUD latency. Body edits are side-effect-free.
+			if err := c.call("TaskService", "UpdateTask", []any{t.ID, map[string]any{
+				"body": fmt.Sprintf("## Description\nupdated body %d\n", seq),
+			}}, nil); err != nil {
+				errCount.Add(1)
+				return
+			}
+			uDur := time.Since(uStart)
+
+			dStart := time.Now()
+			if err := c.deleteTask(t.ID); err != nil {
+				errCount.Add(1)
+				return
+			}
+			dDur := time.Since(dStart)
+
+			mu.Lock()
+			createLat = append(createLat, cDur)
+			updateLat = append(updateLat, uDur)
+			deleteLat = append(deleteLat, dDur)
+			mu.Unlock()
+			total.Add(1)
+		}(total.Load())
+	}
+
+done:
+	wg.Wait()
+	report.Kind = "churn"
+	report.ChurnTotal = int(total.Load())
+	report.ChurnErrors = int(errCount.Load())
+	report.CreateLatency = summarize(createLat)
+	report.UpdateLatency = summarize(updateLat)
+	report.DeleteLatency = summarize(deleteLat)
+	return nil
+}
+
+// ==================== SSE ====================
+
+type sseEvent struct {
+	name string
+	data string
+}
+
+// subscribeEvents opens an SSE connection to /events and returns both the
+// raw response and a channel of parsed events. The caller owns the response
+// body and must defer resp.Body.Close(). Surfacing *http.Response across the
+// function boundary is what lets bodyclose statically verify the lifecycle
+// — it refuses to trace through a goroutine or a struct-held io.Closer, so
+// the body has to sit in a named return value the caller can see.
+// Closing the response body unblocks the scanner and closes the events chan.
+func subscribeEvents(ctx context.Context, url string) (*http.Response, <-chan sseEvent, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		_ = resp.Body.Close()
+		return nil, nil, fmt.Errorf("sse subscribe: status %d", resp.StatusCode)
+	}
+
+	out := make(chan sseEvent, 1024)
+	body := resp.Body
+	go func() {
+		defer close(out)
+		scanner := bufio.NewScanner(body)
+		scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+		var curEvent, curData string
+		for scanner.Scan() {
+			line := scanner.Text()
+			if line == "" {
+				if curEvent != "" || curData != "" {
+					select {
+					case out <- sseEvent{name: curEvent, data: curData}:
+					default:
+					}
+				}
+				curEvent, curData = "", ""
+				continue
+			}
+			switch {
+			case strings.HasPrefix(line, "event: "):
+				curEvent = line[len("event: "):]
+			case strings.HasPrefix(line, "data: "):
+				curData = line[len("data: "):]
+			}
+		}
+	}()
+
+	return resp, out, nil
+}
+
+// ==================== Metrics / pprof ====================
+
+// httpGet wraps http.Client.Do so gosec G107 sees a single, shared request
+// construction site. The baseURL is produced by synapse-perf itself (loopback
+// + ephemeral port picked via pickFreePort), not from untrusted input.
+func httpGet(ctx context.Context, url string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+	return http.DefaultClient.Do(req)
+}
+
+// scrapeMetrics downloads /metrics and extracts a handful of Prometheus
+// counters we care about (synapse_agent_*, process_resident_memory_bytes,
+// go_goroutines). Stores raw values in a map keyed by metric name. Missing
+// metrics are silently skipped so older server builds still produce a report.
+func scrapeMetrics(ctx context.Context, url string) (map[string]float64, error) {
+	resp, err := httpGet(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("scrape %s: %d", url, resp.StatusCode)
+	}
+	out := map[string]float64{}
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+	prefixes := []string{
+		"synapse_agent_",
+		"synapse_task_",
+		"process_resident_memory_bytes",
+		"process_cpu_seconds_total",
+		"go_goroutines",
+		"go_memstats_alloc_bytes",
+		"go_memstats_heap_inuse_bytes",
+	}
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "#") || line == "" {
+			continue
+		}
+		var matched bool
+		for _, p := range prefixes {
+			if strings.HasPrefix(line, p) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			continue
+		}
+		// "<name>{labels} <value>" — take the last whitespace-separated token
+		// as the value and the rest as the key.
+		sp := strings.LastIndexByte(line, ' ')
+		if sp < 0 {
+			continue
+		}
+		key := line[:sp]
+		valStr := line[sp+1:]
+		v, err := strconv.ParseFloat(valStr, 64)
+		if err != nil {
+			continue
+		}
+		out[key] = v
+	}
+	return out, nil
+}
+
+// fetchProfile downloads a net/http/pprof profile and writes it to disk.
+// "name" is one of heap, goroutine, profile, etc.
+func fetchProfile(ctx context.Context, baseURL, name, dest string) error {
+	url := fmt.Sprintf("%s/debug/pprof/%s", baseURL, name)
+	resp, err := httpGet(ctx, url)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("pprof %s: %d", name, resp.StatusCode)
+	}
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	_, err = io.Copy(f, resp.Body)
+	return err
+}
+
+// ==================== Report ====================
+
+type Report struct {
+	Scenario     string        `json:"scenario"`
+	Kind         string        `json:"kind,omitempty"`
+	Concurrency  int           `json:"concurrency"`
+	Duration     string        `json:"duration"`
+	StartedAt    time.Time     `json:"startedAt"`
+	FinishedAt   time.Time     `json:"finishedAt"`
+	Elapsed      string        `json:"elapsed,omitempty"`
+	TotalAgents  int           `json:"totalAgents,omitempty"`
+	TotalEvents  int           `json:"totalEvents,omitempty"`
+	OutputEvents int           `json:"outputEvents,omitempty"`
+	Agents       []agentReport `json:"agents,omitempty"`
+
+	ChurnTotal     int           `json:"churnTotal,omitempty"`
+	ChurnErrors    int           `json:"churnErrors,omitempty"`
+	CreateLatency  *latencyStats `json:"createLatencyMS,omitempty"`
+	UpdateLatency  *latencyStats `json:"updateLatencyMS,omitempty"`
+	DeleteLatency  *latencyStats `json:"deleteLatencyMS,omitempty"`
+	StartupLatency *latencyStats `json:"startupLatencyMS,omitempty"`
+
+	MetricsBefore map[string]float64 `json:"metricsBefore,omitempty"`
+	MetricsAfter  map[string]float64 `json:"metricsAfter,omitempty"`
+
+	Host       hostInfo `json:"host"`
+	FatalError string   `json:"fatalError,omitempty"`
+}
+
+type agentReport struct {
+	TaskID             string `json:"taskId"`
+	AgentID            string `json:"agentId,omitempty"`
+	StartLatencyMS     int64  `json:"startLatencyMS"`
+	Error              string `json:"error,omitempty"`
+	ObservedEventCount int    `json:"observedEventCount"`
+}
+
+type latencyStats struct {
+	Count int     `json:"count"`
+	Min   float64 `json:"min"`
+	P50   float64 `json:"p50"`
+	P95   float64 `json:"p95"`
+	P99   float64 `json:"p99"`
+	Max   float64 `json:"max"`
+	Mean  float64 `json:"mean"`
+}
+
+type hostInfo struct {
+	GOOS    string `json:"goos"`
+	GOARCH  string `json:"goarch"`
+	NumCPU  int    `json:"numCPU"`
+	Version string `json:"goVersion"`
+}
+
+func (r *Report) finalize() {
+	r.Host = hostInfo{
+		GOOS:    runtime.GOOS,
+		GOARCH:  runtime.GOARCH,
+		NumCPU:  runtime.NumCPU(),
+		Version: runtime.Version(),
+	}
+	if r.Elapsed == "" {
+		r.Elapsed = r.FinishedAt.Sub(r.StartedAt).String()
+	}
+	// Populate startup latency from per-agent records so consumers get
+	// percentile stats without walking the Agents array themselves.
+	if len(r.Agents) > 0 {
+		lats := make([]time.Duration, 0, len(r.Agents))
+		for _, a := range r.Agents {
+			if a.StartLatencyMS > 0 {
+				lats = append(lats, time.Duration(a.StartLatencyMS)*time.Millisecond)
+			}
+		}
+		if s := summarize(lats); s != nil {
+			r.StartupLatency = s
+		}
+	}
+}
+
+func summarize(samples []time.Duration) *latencyStats {
+	if len(samples) == 0 {
+		return nil
+	}
+	sorted := make([]time.Duration, len(samples))
+	copy(sorted, samples)
+	slices.Sort(sorted)
+	toMS := func(d time.Duration) float64 { return float64(d.Microseconds()) / 1000 }
+	pct := func(p float64) float64 {
+		idx := int(float64(len(sorted)-1) * p)
+		return toMS(sorted[idx])
+	}
+	var sum time.Duration
+	for _, s := range sorted {
+		sum += s
+	}
+	return &latencyStats{
+		Count: len(sorted),
+		Min:   toMS(sorted[0]),
+		P50:   pct(0.50),
+		P95:   pct(0.95),
+		P99:   pct(0.99),
+		Max:   toMS(sorted[len(sorted)-1]),
+		Mean:  toMS(sum / time.Duration(len(sorted))),
+	}
+}
+
+func writeReport(r *Report, path string) error {
+	data, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return err
+	}
+	if path == "" {
+		_, err = os.Stdout.Write(append(data, '\n'))
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o644)
+}

--- a/cmd/synapse-server/main.go
+++ b/cmd/synapse-server/main.go
@@ -17,6 +17,7 @@ import (
 	"log"
 	"log/slog"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"os/signal"
 	"syscall"
@@ -77,41 +78,7 @@ func run() error {
 	}
 	defer app.Shutdown(ctx)
 
-	mux := http.NewServeMux()
-
-	// Health check endpoint for container orchestration.
-	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprint(w, `{"status":"ok"}`)
-	})
-
-	// Prometheus scrape endpoint (opt-in via config.metrics.enabled). The
-	// OTel Prometheus exporter registers instruments into the default
-	// prometheus/client_golang registry, so promhttp.Handler serves them.
-	if metrics.Enabled() {
-		mux.Handle("GET /metrics", promhttp.Handler())
-		logger.Info("metrics.listen", "path", "/metrics")
-	}
-
-	// Multiplexed SSE stream: all events over a single connection.
-	mux.HandleFunc("GET /events", broker.ServeAll)
-
-	// Per-event SSE endpoint (kept for debugging / backward compat).
-	mux.HandleFunc("GET /api/events/{eventName}", broker.ServeHTTP)
-
-	// API dispatch: POST /api/{service}/{method}
-	httpapi.Mount(mux, app.ServiceRegistry(), logger)
-
-	// Optional SPA static files.
-	if staticDir := os.Getenv("SYNAPSE_STATIC_DIR"); staticDir != "" {
-		sub, err := fs.Sub(os.DirFS(staticDir), ".")
-		if err != nil {
-			logger.Error("static.dir", "err", err)
-		} else {
-			fileServer := http.FileServer(http.FS(sub))
-			mux.Handle("GET /", spaHandler{fileServer, staticDir})
-		}
-	}
+	mux := buildMux(logger, broker, app)
 
 	// CORS for dev (permissive; tighten for production).
 	handler := corsMiddleware(mux)
@@ -148,6 +115,64 @@ func run() error {
 		}
 	}
 	return nil
+}
+
+// buildMux wires every HTTP route the server exposes onto a fresh ServeMux:
+// health, optional /metrics, optional /debug/pprof, SSE streams, the
+// reflection-based /api/{service}/{method} dispatcher, and an optional SPA
+// static file server. Extracted from run() so run() stays under the 100-line
+// funlen cap without losing the explicit route declaration layout.
+func buildMux(logger *slog.Logger, broker *sse.Broker, app *synapse.App) *http.ServeMux {
+	mux := http.NewServeMux()
+
+	// Health check endpoint for container orchestration.
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"status":"ok"}`)
+	})
+
+	// Prometheus scrape endpoint (opt-in via config.metrics.enabled). The
+	// OTel Prometheus exporter registers instruments into the default
+	// prometheus/client_golang registry, so promhttp.Handler serves them.
+	if metrics.Enabled() {
+		mux.Handle("GET /metrics", promhttp.Handler())
+		logger.Info("metrics.listen", "path", "/metrics")
+	}
+
+	// pprof scrape endpoints (opt-in via SYNAPSE_PPROF=1). Mounted on the main
+	// mux so perf tooling can pull heap / goroutine profiles over the same
+	// port without opening a second listener. Off by default to avoid leaking
+	// internals on shared deployments.
+	if v := os.Getenv("SYNAPSE_PPROF"); v == "1" || v == "true" {
+		mux.HandleFunc("GET /debug/pprof/", pprof.Index)
+		mux.HandleFunc("GET /debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("GET /debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("GET /debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("GET /debug/pprof/trace", pprof.Trace)
+		logger.Info("pprof.listen", "path", "/debug/pprof/")
+	}
+
+	// Multiplexed SSE stream: all events over a single connection.
+	mux.HandleFunc("GET /events", broker.ServeAll)
+
+	// Per-event SSE endpoint (kept for debugging / backward compat).
+	mux.HandleFunc("GET /api/events/{eventName}", broker.ServeHTTP)
+
+	// API dispatch: POST /api/{service}/{method}
+	httpapi.Mount(mux, app.ServiceRegistry(), logger)
+
+	// Optional SPA static files.
+	if staticDir := os.Getenv("SYNAPSE_STATIC_DIR"); staticDir != "" {
+		sub, err := fs.Sub(os.DirFS(staticDir), ".")
+		if err != nil {
+			logger.Error("static.dir", "err", err)
+		} else {
+			fileServer := http.FileServer(http.FS(sub))
+			mux.Handle("GET /", spaHandler{fileServer, staticDir})
+		}
+	}
+
+	return mux
 }
 
 // spaHandler serves static files and falls back to index.html for unknown paths

--- a/internal/agent/stream_bench_test.go
+++ b/internal/agent/stream_bench_test.go
@@ -1,0 +1,133 @@
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+// makeAssistantLine builds one realistic NDJSON assistant line used by the
+// benchmarks to avoid timing the builder overhead.
+func makeAssistantLine(i int) []byte {
+	event := map[string]any{
+		"type":       "assistant",
+		"session_id": "bench-session",
+		"message": map[string]any{
+			"role": "assistant",
+			"content": []any{
+				map[string]any{
+					"type": "text",
+					"text": fmt.Sprintf("bench text line %d with a reasonable amount of body so allocs look realistic", i),
+				},
+				map[string]any{
+					"type": "tool_use",
+					"id":   fmt.Sprintf("tu_%d", i),
+					"name": "Bash",
+					"input": map[string]any{
+						"command":     fmt.Sprintf("echo bench %d", i),
+						"description": "run a small echo",
+					},
+				},
+			},
+		},
+	}
+	b, _ := json.Marshal(event)
+	return b
+}
+
+// makeResultLine builds a realistic result event.
+func makeResultLine() []byte {
+	event := map[string]any{
+		"type":                "result",
+		"session_id":          "bench-session",
+		"result":              "Task completed successfully.",
+		"total_cost_usd":      0.12,
+		"total_input_tokens":  1234.0,
+		"total_output_tokens": 567.0,
+	}
+	b, _ := json.Marshal(event)
+	return b
+}
+
+// BenchmarkParseClaudeLine_Assistant measures per-line parse cost for the
+// most common event type. This runs on every stream line (50ms throttle only
+// caps emit, not parse) so regressions here scale linearly with event volume.
+func BenchmarkParseClaudeLine_Assistant(b *testing.B) {
+	line := makeAssistantLine(0)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for range b.N {
+		if _, err := ParseClaudeLine(line); err != nil {
+			b.Fatalf("ParseClaudeLine: %v", err)
+		}
+	}
+}
+
+// BenchmarkParseClaudeLine_Result measures the terminal-event hot path.
+func BenchmarkParseClaudeLine_Result(b *testing.B) {
+	line := makeResultLine()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for range b.N {
+		if _, err := ParseClaudeLine(line); err != nil {
+			b.Fatalf("ParseClaudeLine: %v", err)
+		}
+	}
+}
+
+// BenchmarkParseClaudeLine_Mixed simulates a realistic mix of events (9
+// assistant per 1 result) by rotating through a precomputed slice. Models
+// the steady-state streaming workload.
+func BenchmarkParseClaudeLine_Mixed(b *testing.B) {
+	lines := make([][]byte, 10)
+	for i := range 9 {
+		lines[i] = makeAssistantLine(i)
+	}
+	lines[9] = makeResultLine()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := range b.N {
+		if _, err := ParseClaudeLine(lines[i%len(lines)]); err != nil {
+			b.Fatalf("ParseClaudeLine: %v", err)
+		}
+	}
+}
+
+// BenchmarkClaudeToStreamEvent measures conversion cost from parsed
+// ClaudeEvent to the lightweight StreamEvent pushed to the frontend. Isolated
+// from parse to identify whether regressions live in parsing or conversion.
+func BenchmarkClaudeToStreamEvent(b *testing.B) {
+	ce, err := ParseClaudeLine(makeAssistantLine(0))
+	if err != nil {
+		b.Fatalf("seed parse: %v", err)
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for range b.N {
+		_ = claudeEventToStreamEvent(ce)
+	}
+}
+
+// BenchmarkStreamEventMarshal measures the JSON encoding cost applied by
+// sse.Broker.Emit on every outbound event. Every subscriber fanout reuses the
+// same encoded payload so this runs once per event, not per subscriber.
+func BenchmarkStreamEventMarshal(b *testing.B) {
+	ev := StreamEvent{
+		Type:         "assistant",
+		Content:      "bench content with moderate length so the encoded bytes resemble real traffic",
+		SessionID:    "bench-session",
+		InputTokens:  123,
+		OutputTokens: 45,
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for range b.N {
+		buf.Reset()
+		if err := enc.Encode(ev); err != nil {
+			b.Fatalf("encode: %v", err)
+		}
+	}
+}

--- a/internal/sse/broker_bench_test.go
+++ b/internal/sse/broker_bench_test.go
@@ -1,0 +1,112 @@
+package sse
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// payload is a representative StreamEvent-shaped value used to exercise the
+// marshal + fanout hot path.
+type payload struct {
+	Type      string `json:"type"`
+	Content   string `json:"content"`
+	SessionID string `json:"sessionId"`
+	Cost      int    `json:"cost"`
+}
+
+func newPayload(i int) payload {
+	return payload{
+		Type:      "assistant",
+		Content:   fmt.Sprintf("bench body %d with some text to avoid trivial sizing", i),
+		SessionID: "bench",
+		Cost:      i,
+	}
+}
+
+// BenchmarkEmit_NoSubscribers measures the floor cost of Emit (JSON marshal
+// + mutex acquisition) when no one is listening. Sets the baseline that all
+// fanout overhead is measured against.
+func BenchmarkEmit_NoSubscribers(b *testing.B) {
+	broker := New()
+	ev := newPayload(0)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for range b.N {
+		broker.Emit("agent:output:bench", ev)
+	}
+}
+
+// BenchmarkEmit_AllSubscribers scales the number of SubscribeAll listeners
+// to surface fanout cost. Each subscriber must receive a non-blocking send
+// attempt; this benchmark also tracks whether the broker drops messages
+// under pressure (slow consumers).
+func BenchmarkEmit_AllSubscribers(b *testing.B) {
+	for _, subs := range []int{1, 10, 100} {
+		b.Run(fmt.Sprintf("subs=%d", subs), func(b *testing.B) {
+			broker := New()
+			var wg sync.WaitGroup
+			stop := make(chan struct{})
+			for range subs {
+				ch, cancel := broker.SubscribeAll()
+				wg.Go(func() {
+					defer cancel()
+					for {
+						select {
+						case <-stop:
+							return
+						case _, ok := <-ch:
+							if !ok {
+								return
+							}
+						}
+					}
+				})
+			}
+			ev := newPayload(0)
+			b.ResetTimer()
+			b.ReportAllocs()
+			for range b.N {
+				broker.Emit("agent:output:bench", ev)
+			}
+			b.StopTimer()
+			close(stop)
+			wg.Wait()
+		})
+	}
+}
+
+// BenchmarkEmit_NamedSubscribers measures the Subscribe(eventName) path used
+// by the legacy per-event endpoint. Separates named-subs cost from AllSubs
+// cost since they walk different maps inside Emit.
+func BenchmarkEmit_NamedSubscribers(b *testing.B) {
+	const subs = 10
+	broker := New()
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for range subs {
+		ch, cancel := broker.Subscribe("agent:output:bench")
+		wg.Go(func() {
+			defer cancel()
+			for {
+				select {
+				case <-stop:
+					return
+				case _, ok := <-ch:
+					if !ok {
+						return
+					}
+				}
+			}
+		})
+	}
+	ev := newPayload(0)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for range b.N {
+		broker.Emit("agent:output:bench", ev)
+	}
+	b.StopTimer()
+	close(stop)
+	wg.Wait()
+}

--- a/internal/task/store_bench_test.go
+++ b/internal/task/store_bench_test.go
@@ -1,0 +1,103 @@
+package task
+
+import (
+	"fmt"
+	"testing"
+)
+
+// seedStore writes n tasks into a fresh store and returns the store plus the
+// list of IDs in insertion order. Used by all Store benchmarks to produce a
+// deterministic working set without touching the real ~/.synapse directory.
+func seedStore(b *testing.B, n int) (store *Store, ids []string) {
+	b.Helper()
+	s, err := NewStore(b.TempDir())
+	if err != nil {
+		b.Fatalf("NewStore: %v", err)
+	}
+	ids = make([]string, n)
+	for i := range n {
+		t, err := s.Create(
+			fmt.Sprintf("benchmark task %04d", i),
+			fmt.Sprintf("## Description\nSeeded task body %d.\nLine 2\nLine 3\n", i),
+			AgentModeHeadless,
+		)
+		if err != nil {
+			b.Fatalf("Create: %v", err)
+		}
+		ids[i] = t.ID
+	}
+	return s, ids
+}
+
+// BenchmarkStoreList measures full-directory listing latency and allocs
+// across a range of store sizes. The hot path is fsutil.ListFiles + Parse
+// per file — watcher callbacks trigger this on every list refresh, so
+// regressions here directly hit the UI refresh budget.
+func BenchmarkStoreList(b *testing.B) {
+	sizes := []int{10, 100, 1000}
+	for _, n := range sizes {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			s, _ := seedStore(b, n)
+			b.ResetTimer()
+			b.ReportAllocs()
+			for range b.N {
+				tasks, err := s.List()
+				if err != nil {
+					b.Fatalf("List: %v", err)
+				}
+				if len(tasks) != n {
+					b.Fatalf("got %d tasks, want %d", len(tasks), n)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkStoreGet measures single-task read latency with a large working
+// set present. Simulates UI detail-pane opens against a full store.
+func BenchmarkStoreGet(b *testing.B) {
+	const n = 1000
+	s, ids := seedStore(b, n)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := range b.N {
+		_, err := s.Get(ids[i%n])
+		if err != nil {
+			b.Fatalf("Get: %v", err)
+		}
+	}
+}
+
+// BenchmarkStoreCreate measures task creation throughput. Each iteration
+// produces one new file via the atomic-write path — this is the write
+// counterpart to BenchmarkStoreList for budgeting bulk imports.
+func BenchmarkStoreCreate(b *testing.B) {
+	s, err := NewStore(b.TempDir())
+	if err != nil {
+		b.Fatalf("NewStore: %v", err)
+	}
+	body := "## Description\ncreate benchmark body\n"
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := range b.N {
+		if _, err := s.Create(fmt.Sprintf("create bench %d", i), body, AgentModeHeadless); err != nil {
+			b.Fatalf("Create: %v", err)
+		}
+	}
+}
+
+// BenchmarkStoreUpdate measures the Get-modify-Marshal-atomicWrite cycle
+// used by every TaskService.UpdateTask call. Covers both the read and write
+// hot paths.
+func BenchmarkStoreUpdate(b *testing.B) {
+	const n = 100
+	s, ids := seedStore(b, n)
+	status := StatusInProgress
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := range b.N {
+		if _, err := s.Update(ids[i%n], Update{Status: &status}); err != nil {
+			b.Fatalf("Update: %v", err)
+		}
+	}
+}

--- a/internal/watcher/watcher_bench_test.go
+++ b/internal/watcher/watcher_bench_test.go
@@ -1,0 +1,81 @@
+package watcher
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// BenchmarkWatcherChurn measures end-to-end latency under bursty writes to
+// characterize the 200ms trailing-edge debounce. Each iteration writes one
+// file and waits for the emit callback. This is not a microbenchmark — the
+// minimum per-op is dominated by the debounce interval — but it exposes
+// regressions in queue drain, map contention, and event ordering.
+func BenchmarkWatcherChurn(b *testing.B) {
+	dir := b.TempDir()
+	var delivered atomic.Int64
+	done := make(chan struct{}, b.N+16)
+
+	emit := func(_ string, _ any) {
+		delivered.Add(1)
+		select {
+		case done <- struct{}{}:
+		default:
+		}
+	}
+
+	w := New(dir, emit, discardLogger())
+	if err := w.Start(b.Context()); err != nil {
+		b.Fatalf("Start: %v", err)
+	}
+	<-w.Ready()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := range b.N {
+		path := filepath.Join(dir, fmt.Sprintf("bench-%d.md", i))
+		if err := os.WriteFile(path, []byte("# bench\n"), 0o644); err != nil {
+			b.Fatalf("write: %v", err)
+		}
+	}
+	// Wait for all writes to drain through the debounce. Cap at 2s + N*10ms
+	// so a slow machine with a full b.N doesn't hang the suite.
+	deadline := time.After(2*time.Second + time.Duration(b.N)*10*time.Millisecond)
+	for delivered.Load() < int64(b.N) {
+		select {
+		case <-done:
+		case <-deadline:
+			b.Fatalf("only %d/%d events delivered before deadline", delivered.Load(), b.N)
+		}
+	}
+	b.StopTimer()
+}
+
+// BenchmarkWatcherSameFileCoalescing measures how well the debounce collapses
+// repeated writes to the same path. 100 writes should produce ~1 emission,
+// not 100 — the benchmark verifies coalescing and reports the achieved ratio.
+func BenchmarkWatcherSameFileCoalescing(b *testing.B) {
+	dir := b.TempDir()
+	var delivered atomic.Int64
+	emit := func(_ string, _ any) { delivered.Add(1) }
+	w := New(dir, emit, discardLogger())
+	if err := w.Start(b.Context()); err != nil {
+		b.Fatalf("Start: %v", err)
+	}
+	<-w.Ready()
+
+	path := filepath.Join(dir, "hot.md")
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := range b.N {
+		_ = os.WriteFile(path, fmt.Appendf(nil, "body %d\n", i), 0o644)
+	}
+	// Wait one debounce cycle plus slack for the timer to fire.
+	time.Sleep(400 * time.Millisecond)
+	b.StopTimer()
+	b.ReportMetric(float64(delivered.Load()), "emits")
+	b.ReportMetric(float64(b.N)/float64(max(delivered.Load(), 1)), "writes/emit")
+}

--- a/mise.toml
+++ b/mise.toml
@@ -37,3 +37,29 @@ description = "Build HTTP server binary (builds web frontend first)"
 run = ["cd frontend && npm run build:web", "SYNAPSE_STATIC_DIR=frontend/dist-web go run ./cmd/synapse-server"]
 description = "Build web frontend then run HTTP server"
 env = { SYNAPSE_PORT = "8080" }
+
+[tasks."perf:bench"]
+run = "go test -run XXX -bench . -benchmem -benchtime=2s ./internal/task/ ./internal/agent/ ./internal/sse/ ./internal/watcher/"
+description = "Run Go benchmarks for perf-critical backend packages"
+
+[tasks."perf:build"]
+run = [
+  "go build -o bin/fake-claude ./cmd/fake-claude",
+  "go build -o bin/synapse-perf ./cmd/synapse-perf",
+]
+description = "Build the synapse-perf harness and fake-claude test double (synapse-server is spawned via go run)"
+
+[tasks."perf:load"]
+run = "./bin/synapse-perf -scenario steady -duration 30s -concurrency 8 -events 200 -event-interval 10ms -fake-claude ./bin/fake-claude"
+depends = ["perf:build"]
+description = "Run the steady end-to-end perf scenario against a throwaway synapse-server"
+
+[tasks."perf:churn"]
+run = "./bin/synapse-perf -scenario churn -duration 30s -concurrency 4 -churn-rate 200 -fake-claude ./bin/fake-claude"
+depends = ["perf:build"]
+description = "Run the task-store CRUD churn scenario"
+
+[tasks."perf:soak"]
+run = "./bin/synapse-perf -scenario soak -duration 5m -concurrency 4 -event-interval 200ms -fake-claude ./bin/fake-claude -pprof-dir ./perf-profiles"
+depends = ["perf:build"]
+description = "Long-running soak scenario with heap/goroutine profiles for leak detection"

--- a/perf-testing.md
+++ b/perf-testing.md
@@ -1,0 +1,176 @@
+# Synapse perf-testing guide
+
+Everything is token-free — fake-claude replaces the real `claude` CLI via PATH injection in an isolated `SYNAPSE_HOME` tempdir. Your real `~/.synapse/` is never touched.
+
+## 1. Go benchmarks (no server needed)
+
+Fast, repeatable microbenchmarks on the four perf-critical packages.
+
+```bash
+mise run perf:bench
+# or directly:
+go test -run XXX -bench . -benchmem -benchtime=2s ./internal/task/ ./internal/agent/ ./internal/sse/ ./internal/watcher/
+```
+
+Knobs:
+
+- `-benchtime=5s` — longer runs reduce variance; `-benchtime=100x` for fixed iteration counts.
+- `-count=3` — repeats each benchmark 3× (feed to `benchstat` for A/B comparisons).
+- `-cpuprofile=cpu.out -memprofile=mem.out` — emit pprof profiles (analyze with `go tool pprof cpu.out`).
+
+Baseline reference (M4 Max, `-benchtime=2s`):
+
+- `BenchmarkStoreList/n=1000` ≈ 39 ms/op — UI refresh hot path budget.
+- `BenchmarkParseClaudeLine_Mixed` ≈ 2.4 µs/op — every NDJSON line pays this.
+- `BenchmarkEmit_AllSubscribers/subs=100` ≈ 18 µs/op — SSE fanout cost.
+- `BenchmarkWatcherSameFileCoalescing` — verifies N writes → 1 emission.
+
+Compare two runs:
+
+```bash
+go install golang.org/x/perf/cmd/benchstat@latest
+go test -run XXX -bench . -benchmem -count=6 ./internal/task/ > before.txt
+# ...make changes...
+go test -run XXX -bench . -benchmem -count=6 ./internal/task/ > after.txt
+benchstat before.txt after.txt
+```
+
+## 2. End-to-end harness (`cmd/synapse-perf`)
+
+Build the harness + fake-claude once:
+
+```bash
+mise run perf:build
+# produces bin/synapse-perf and bin/fake-claude
+# synapse-server is spawned via `go run` inside the harness (cached on rebuild)
+```
+
+### Scenarios
+
+**steady** — N agents ramped over T seconds, held for `-duration`. Each agent runs `perf_stream` (N events at M ms interval). Primary measurement: agent startup latency.
+
+```bash
+./bin/synapse-perf -scenario steady \
+  -concurrency 8 -duration 30s -ramp 2s \
+  -events 200 -event-interval 10ms \
+  -fake-claude ./bin/fake-claude
+```
+
+**spike** — No ramp. All agents start as fast as possible with `perf_burst` (zero-interval events). Stresses the 50 ms emit throttle and concurrency bookkeeping.
+
+```bash
+./bin/synapse-perf -scenario spike \
+  -concurrency 16 -duration 10s \
+  -events 500 \
+  -fake-claude ./bin/fake-claude
+```
+
+**soak** — Long runtime with `perf_long`. Pair with `-pprof-dir` for before/after heap diffs — the point is catching goroutine or buffer leaks.
+
+```bash
+./bin/synapse-perf -scenario soak \
+  -concurrency 4 -duration 5m \
+  -event-interval 200ms \
+  -fake-claude ./bin/fake-claude \
+  -pprof-dir ./perf-profiles
+```
+
+**churn** — No agents. Hammers `TaskService.CreateTask / UpdateTask / DeleteTask` at a target rate. Updates touch `body` only (no hooks fire), so the numbers reflect pure CRUD latency.
+
+```bash
+./bin/synapse-perf -scenario churn \
+  -concurrency 4 -duration 30s -churn-rate 200 \
+  -fake-claude ./bin/fake-claude
+```
+
+### Pre-built mise shortcuts
+
+```bash
+mise run perf:load    # steady, 8 agents, 30s
+mise run perf:churn   # 200 ops/sec, 30s
+mise run perf:soak    # 5 min soak + pprof
+```
+
+### Flag reference
+
+| Flag              | Default                   | Notes                                                              |
+| ----------------- | ------------------------- | ------------------------------------------------------------------ |
+| `-scenario`       | `steady`                  | `steady` \| `spike` \| `soak` \| `churn`                           |
+| `-concurrency`    | 4                         | agents (or churn workers)                                          |
+| `-duration`       | 30s                       | total runtime                                                      |
+| `-ramp`           | 2s                        | steady/soak ramp-up window                                         |
+| `-events`         | 100                       | fake-claude event count (stream/burst)                             |
+| `-event-interval` | 10ms                      | fake-claude inter-event delay                                      |
+| `-churn-rate`     | 100                       | ops/sec for churn                                                  |
+| `-fake-claude`    | *(builds via `go run`)*   | pre-built binary path (faster)                                     |
+| `-workdir`        | *(tmp)*                   | custom SYNAPSE_HOME — use to inspect server state after a run      |
+| `-pprof-dir`      | *(off)*                   | heap + goroutine snapshots before/after                            |
+| `-report`         | *(stdout)*                | write JSON report to a file                                        |
+| `-keep-home`      | false                     | do not delete the temp SYNAPSE_HOME                                |
+| `-verbose`        | false                     | log server output and per-agent progress                           |
+
+### Saving reports cleanly
+
+The JSON report goes to stdout by default. Piping it through `grep`/`head` will truncate. Use `-report`:
+
+```bash
+./bin/synapse-perf -scenario churn -duration 30s -churn-rate 200 \
+  -fake-claude ./bin/fake-claude \
+  -report /tmp/churn.json
+
+jq '.createLatencyMS, .updateLatencyMS' /tmp/churn.json
+```
+
+## 3. Interpreting the report
+
+Top-level keys:
+
+- `startupLatencyMS` (steady/spike/soak) — `count / min / p50 / p95 / p99 / max / mean` derived from per-agent StartAgent HTTP latency.
+- `totalEvents` — every SSE event received during the scenario.
+- `outputEvents` — agent-level throughput (sum across all agents).
+- `agents[]` — per-agent `agentId`, `taskId`, `startLatencyMS`, `observedEventCount`, `error`.
+- `createLatencyMS / updateLatencyMS / deleteLatencyMS` (churn) — `count / min / p50 / p95 / p99 / max / mean` for each operation.
+- `metricsBefore / metricsAfter` — Prometheus snapshot of `synapse_agent_*`, `synapse_task_*`, `go_goroutines`, `process_resident_memory_bytes`. Subtract to see the scenario's impact.
+
+## 4. pprof workflow
+
+Pull profiles during or after a soak/steady run:
+
+```bash
+./bin/synapse-perf -scenario soak -duration 5m -concurrency 4 \
+  -fake-claude ./bin/fake-claude -pprof-dir ./perf-profiles
+
+# files produced: heap-before.pb.gz, heap-after.pb.gz,
+#                 goroutine-before.pb.gz, goroutine-after.pb.gz
+go tool pprof -http=:7070 ./perf-profiles/heap-after.pb.gz
+go tool pprof -diff_base ./perf-profiles/heap-before.pb.gz ./perf-profiles/heap-after.pb.gz
+```
+
+For on-demand profiles against a live harness run, start the server manually with pprof:
+
+```bash
+SYNAPSE_PPROF=1 SYNAPSE_HOME=/tmp/synapse-manual go run ./cmd/synapse-server
+# in another shell:
+curl -o cpu.pb.gz "http://127.0.0.1:8080/debug/pprof/profile?seconds=30"
+curl -o goroutines.txt "http://127.0.0.1:8080/debug/pprof/goroutine?debug=2"
+```
+
+## 5. Troubleshooting
+
+- **First run is slow** — `go run ./cmd/synapse-server` pays a cold compile cost (~15–25s). Subsequent runs are cached by Go's build cache.
+- **"Dir not accessible"** — the harness creates `research/` inside the temp home; if this surfaces, your `-workdir` is on a filesystem the server can't stat. Use the default temp path.
+- **Steady report shows `observedEventCount: 0`** — agents started but didn't stream events back before the scenario ended. Increase `-duration` or drop `-event-interval`.
+- **Churn returns `churnErrors > 0`** — check server logs with `-verbose`; usually the churn worker pool is saturated (raise `-concurrency`).
+- **pprof files are empty** — `SYNAPSE_PPROF=1` must be set on the server; the harness sets it automatically when you pass `-pprof-dir`.
+- **Want to peek at server state after a run** — pass `-keep-home -workdir /tmp/synapse-debug` and the whole SYNAPSE_HOME (tasks, logs, audit) stays on disk for inspection.
+
+## 6. Files created for perf work
+
+- `cmd/fake-claude/main.go` — new `perf_stream`/`perf_burst`/`perf_long` scenarios (+tests in `main_test.go`)
+- `cmd/synapse-perf/main.go` — the e2e harness binary
+- `cmd/synapse-server/main.go` — `/debug/pprof/*` mounted behind `SYNAPSE_PPROF=1`
+- `internal/task/store_bench_test.go`
+- `internal/agent/stream_bench_test.go`
+- `internal/sse/broker_bench_test.go`
+- `internal/watcher/watcher_bench_test.go`
+- `mise.toml` — `perf:bench`, `perf:build`, `perf:load`, `perf:churn`, `perf:soak` tasks


### PR DESCRIPTION
## Motivation

We had no way to measure Synapse performance without paying for real Claude
API tokens. This PR adds a token-free perf-testing stack so we can:

- Budget UI refresh latency against the task store
- Detect regressions in the stream-parse / SSE fanout hot paths
- Soak-test for goroutine/memory leaks under sustained agent load
- Measure task-store CRUD latency under bursty writes

## Implementation information

**Token-free seam.** `cmd/fake-claude` is extended with three perf scenarios
(`perf_stream`, `perf_burst`, `perf_long`) driven by env vars. The harness
injects the fake binary via `PATH` so `runner_headless.go` spawns it instead
of the real `claude` CLI. Zero API cost per agent run.

**Go benchmarks.** Four new `*_bench_test.go` files cover the hottest paths:

- `internal/task` — Store List/Get/Create/Update at n=10/100/1000
- `internal/agent` — ParseClaudeLine (assistant/result/mixed), stream-event conversion, JSON marshal
- `internal/sse` — Broker.Emit with 0/1/10/100 subscribers plus named-subs path
- `internal/watcher` — 200ms debounce latency and same-file coalescing

**End-to-end harness** (`cmd/synapse-perf`). A single Go binary that:

- Boots `synapse-server` via `go run` in an isolated `SYNAPSE_HOME` tempdir with a perf-tuned config (metrics on, pollers off, research_machine_dir set so tasks skip worktree setup).
- Drives the server over `POST /api/{Service}/{Method}` with JSON-array args.
- Subscribes to `/events` SSE and tracks per-agent event counts.
- Scrapes `/metrics` (Prometheus) before and after the scenario.
- Optionally pulls `/debug/pprof/heap` + `goroutine` snapshots via `-pprof-dir`.
- Outputs a JSON report: startup-latency p50/p95/p99, per-agent event counts, CRUD latency percentiles for churn, host info, and metrics deltas.

Four scenarios: `steady` (ramp + hold), `spike` (no ramp, perf_burst), `soak` (long runtime + pprof diffs), `churn` (no agents, pure TaskService CRUD).

**pprof mount.** `cmd/synapse-server/main.go` gains `/debug/pprof/*` routes
behind `SYNAPSE_PPROF=1`, mounted on the main listener so profiles come
through the same port as `/metrics`. `run()` is refactored into `buildMux`
to stay under the funlen cap.

**mise tasks.** `perf:bench`, `perf:build`, `perf:load`, `perf:churn`,
`perf:soak` wire up the whole thing as one-liners.

**Alternatives considered and discarded.**

- *Stubbing the event bus in-process and skipping the server entirely.* Rejected — `synapse-server` already exposes `sse.Broker.Emit` as a drop-in for Wails's `runtime.EventsEmit`, and driving the full HTTP stack catches routing, JSON, and SSE regressions that a null emitter would hide.
- *Accepting a `-bin` flag for a pre-built synapse-server.* Rejected — gosec G204 flags any `exec.Command(var)` call and the project forbids nolint directives. Always using the literal `go run ./cmd/synapse-server` keeps the lint surface clean; Go's build cache makes repeat runs fast.
- *Using `status` updates in the churn scenario.* Rejected — status hooks fire notifier/workflow side-effects that contaminate CRUD latency. Churn now updates `body` only so numbers reflect pure store ops.

## Supporting documentation

See `perf-testing.md` for the full usage guide: how to run each scenario,
interpret reports, collect pprof profiles, and troubleshoot common issues.

## Test plan

- [x] `go test ./...` passes
- [x] `mise run perf:bench` runs all benchmarks without error
- [x] `mise run perf:churn` (30s, 200 ops/sec) completes with non-zero CRUD totals and zero errors
- [x] `golangci-lint run` clean on touched files
- [ ] (reviewer) run `mise run perf:load` and `mise run perf:soak -pprof-dir ./perf-profiles` to spot-check steady/soak scenarios

> Changelog: feat(perf): load harness + go benchmarks