### PR TITLE
perf(core): cut startup hot path cost

### DIFF
--- a/cmd/synapse-perf/main.go
+++ b/cmd/synapse-perf/main.go
@@ -352,11 +352,12 @@ func startServer(o options, home, fakeDir string, port int) (*serverProc, error)
 
 	perfPath := fakeDir + string(os.PathListSeparator) + os.Getenv("PATH")
 	env := os.Environ()
-	env = filterEnv(env, []string{"SYNAPSE_HOME", "SYNAPSE_PORT", "SYNAPSE_PPROF", "SYNAPSE_TASKS_DIR", "PATH", "FAKE_CLAUDE_SCENARIO", "FAKE_CLAUDE_EVENT_COUNT", "FAKE_CLAUDE_EVENT_INTERVAL_MS", "FAKE_CLAUDE_DURATION_MS"})
+	env = filterEnv(env, []string{"SYNAPSE_HOME", "SYNAPSE_PORT", "SYNAPSE_PPROF", "SYNAPSE_TASKS_DIR", "SYNAPSE_DISABLE_WORKFLOWS", "PATH", "FAKE_CLAUDE_SCENARIO", "FAKE_CLAUDE_EVENT_COUNT", "FAKE_CLAUDE_EVENT_INTERVAL_MS", "FAKE_CLAUDE_DURATION_MS"})
 	env = append(env,
 		"SYNAPSE_HOME="+home,
 		"SYNAPSE_PORT="+strconv.Itoa(port),
 		"SYNAPSE_PPROF=1",
+		"SYNAPSE_DISABLE_WORKFLOWS=1",
 		"PATH="+perfPath,
 		"FAKE_CLAUDE_SCENARIO="+scenarioToFake(o.scenario),
 		"FAKE_CLAUDE_EVENT_COUNT="+strconv.Itoa(o.eventCount),
@@ -581,15 +582,29 @@ func runSoak(ctx context.Context, c *apiClient, o options, report *Report) error
 // through sync.Maps. It owns the goroutine that walks the channel and
 // returns totals when drained.
 type eventCollector struct {
-	counts sync.Map // agentID → int
-	done   sync.Map // agentID → time.Time of result event
-	total  atomic.Int64
+	counts  sync.Map // agentID → int
+	done    sync.Map // agentID → time.Time of result event
+	tasks   sync.Map // taskID → latest agentID seen on state events
+	total   atomic.Int64
+	drained chan struct{}
 }
 
 func (ec *eventCollector) start(events <-chan sseEvent) {
+	ec.drained = make(chan struct{})
 	go func() {
+		defer close(ec.drained)
 		for ev := range events {
 			ec.total.Add(1)
+			const statePrefix = "agent:state:"
+			if strings.HasPrefix(ev.name, statePrefix) {
+				var payload struct {
+					ID     string `json:"id"`
+					TaskID string `json:"taskId"`
+				}
+				if err := json.Unmarshal([]byte(ev.data), &payload); err == nil && payload.TaskID != "" && payload.ID != "" {
+					ec.tasks.Store(payload.TaskID, payload.ID)
+				}
+			}
 			// Only agent:output:{id} events carry per-agent throughput info.
 			// agent:state:{id} fires once per state transition and is
 			// counted in total but not broken down per agent here.
@@ -607,6 +622,13 @@ func (ec *eventCollector) start(events <-chan sseEvent) {
 			}
 		}
 	}()
+}
+
+func (ec *eventCollector) wait() {
+	if ec.drained == nil {
+		return
+	}
+	<-ec.drained
 }
 
 func (ec *eventCollector) sum() int {
@@ -630,6 +652,21 @@ func (ec *eventCollector) forAgent(agentID string) int {
 	}
 	n, _ := v.(int)
 	return n
+}
+
+func (ec *eventCollector) agentForTask(taskID, fallback string) string {
+	if taskID == "" {
+		return fallback
+	}
+	v, ok := ec.tasks.Load(taskID)
+	if !ok {
+		return fallback
+	}
+	id, _ := v.(string)
+	if id == "" {
+		return fallback
+	}
+	return id
 }
 
 // launchAgents fans out concurrency goroutines that each create a task and
@@ -696,6 +733,8 @@ func runConcurrentAgents(ctx context.Context, c *apiClient, o options, report *R
 	start := time.Now()
 	results := launchAgents(scenarioCtx, c, o)
 	holdForDuration(scenarioCtx, start, o.duration)
+	_ = resp.Body.Close()
+	ec.wait()
 
 	report.Kind = kind
 	report.TotalAgents = o.concurrency
@@ -704,12 +743,13 @@ func runConcurrentAgents(ctx context.Context, c *apiClient, o options, report *R
 	report.Elapsed = time.Since(start).String()
 	report.Agents = make([]agentReport, 0, len(results))
 	for _, r := range results {
+		agentID := ec.agentForTask(r.taskID, r.agentID)
 		report.Agents = append(report.Agents, agentReport{
 			TaskID:             r.taskID,
-			AgentID:            r.agentID,
+			AgentID:            agentID,
 			StartLatencyMS:     r.startLatency.Milliseconds(),
 			Error:              r.err,
-			ObservedEventCount: ec.forAgent(r.agentID),
+			ObservedEventCount: ec.forAgent(agentID),
 		})
 	}
 	return nil
@@ -872,7 +912,8 @@ func subscribeEvents(ctx context.Context, url string) (*http.Response, <-chan ss
 				if curEvent != "" || curData != "" {
 					select {
 					case out <- sseEvent{name: curEvent, data: curData}:
-					default:
+					case <-ctx.Done():
+						return
 					}
 				}
 				curEvent, curData = "", ""

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -27,6 +27,7 @@ type Guardrails struct {
 type Manager struct {
 	agents        map[string]*Agent
 	mu            sync.RWMutex
+	liveCount     int
 	ctx           context.Context
 	emit          EmitFunc
 	onComplete    func(ag *Agent)
@@ -148,23 +149,7 @@ func (m *Manager) recordCompletion(a *Agent, ok bool) {
 func (m *Manager) RunningCount() int {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return m.runningCountLocked()
-}
-
-func (m *Manager) runningCountLocked() int {
-	count := 0
-	for _, a := range m.agents {
-		if a.done != nil {
-			select {
-			case <-a.done:
-			default:
-				count++
-			}
-		} else if a.GetState() == StateRunning {
-			count++
-		}
-	}
-	return count
+	return m.liveCount
 }
 
 func (m *Manager) StartAgent(taskID, taskTitle, mode, prompt, dir string, allowedTools []string) (*Agent, error) {
@@ -215,12 +200,15 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 	}
 
 	m.mu.Lock()
-	if !cfg.IgnoreConcurrencyLimit && m.maxConcurrent > 0 && m.runningCountLocked() >= m.maxConcurrent {
+	if !cfg.IgnoreConcurrencyLimit && m.maxConcurrent > 0 && m.liveCount >= m.maxConcurrent {
 		m.mu.Unlock()
 		cancel()
 		return nil, fmt.Errorf("max concurrent agents reached (%d)", m.maxConcurrent)
 	}
 	m.agents[id] = a
+	if a.done != nil {
+		m.liveCount++
+	}
 	m.mu.Unlock()
 
 	metrics.AgentStarted(a.Provider, a.Mode)
@@ -244,6 +232,20 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 
 	m.emit(events.AgentState(id), a)
 	return a, nil
+}
+
+func (m *Manager) markAgentDone(a *Agent) {
+	if a == nil || a.done == nil {
+		return
+	}
+	a.doneOnce.Do(func() {
+		close(a.done)
+		m.mu.Lock()
+		if m.liveCount > 0 {
+			m.liveCount--
+		}
+		m.mu.Unlock()
+	})
 }
 
 func (m *Manager) buildCommand(cfg RunConfig) (string, error) {

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -265,6 +265,38 @@ func TestHasRunningAgentUsesGoroutineLifetime(t *testing.T) {
 	}
 }
 
+func TestRunningCountTracksLiveAgents(t *testing.T) {
+	m, _ := newTestManager(t)
+
+	a1 := &Agent{ID: "a1", TaskID: "task-1", State: StateRunning, done: make(chan struct{})}
+	a2 := &Agent{ID: "a2", TaskID: "task-2", State: StatePaused, done: make(chan struct{})}
+	m.mu.Lock()
+	m.agents[a1.ID] = a1
+	m.agents[a2.ID] = a2
+	m.liveCount = 2
+	m.mu.Unlock()
+
+	if got := m.RunningCount(); got != 2 {
+		t.Fatalf("RunningCount = %d, want 2", got)
+	}
+
+	m.markAgentDone(a1)
+	if got := m.RunningCount(); got != 1 {
+		t.Fatalf("RunningCount after one done = %d, want 1", got)
+	}
+
+	// Idempotent on repeated terminal paths.
+	m.markAgentDone(a1)
+	if got := m.RunningCount(); got != 1 {
+		t.Fatalf("RunningCount after duplicate done = %d, want 1", got)
+	}
+
+	m.markAgentDone(a2)
+	if got := m.RunningCount(); got != 0 {
+		t.Fatalf("RunningCount after all done = %d, want 0", got)
+	}
+}
+
 func TestStopAgentNotFound(t *testing.T) {
 	m, _ := newTestManager(t)
 	err := m.StopAgent("nonexistent")

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -62,6 +62,9 @@ type Agent struct {
 	// done is closed when the headless/conversational goroutine has fully exited.
 	// Used by HasRunningAgentForTask to guard worktree cleanup.
 	done chan struct{}
+	// doneOnce prevents double-close on done and lets Manager maintain an
+	// exact live-agent count even when multiple terminal paths race.
+	doneOnce sync.Once
 
 	// escalationCh receives the human's decision when a guardrail is hit.
 	// true = continue, false = kill.

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -69,9 +69,7 @@ func codexEventToConvoEvent(e CodexEvent) ConvoEvent {
 func (m *Manager) runCodexConversational(ctx context.Context, a *Agent, cfg RunConfig) {
 	defer func() {
 		a.SetState(StateStopped)
-		if a.done != nil {
-			close(a.done)
-		}
+		m.markAgentDone(a)
 		m.logger.Info("agent.codex.convo.done", "id", a.ID, "cost", a.GetCostUSD())
 		m.emit(events.AgentState(a.ID), a)
 		m.recordCompletion(a, a.GetExitErr() == nil)

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -158,9 +158,7 @@ func (m *Manager) runConversational(ctx context.Context, a *Agent, cfg RunConfig
 
 done:
 	a.SetState(StateStopped)
-	if a.done != nil {
-		close(a.done)
-	}
+	m.markAgentDone(a)
 	m.logger.Info("agent.convo.done", "id", a.ID, "cost", a.GetCostUSD())
 	m.emit(events.AgentState(a.ID), a)
 	m.recordCompletion(a, a.GetExitErr() == nil)

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -61,9 +61,7 @@ func (m *Manager) runHeadless(ctx context.Context, a *Agent, cfg RunConfig) {
 
 done:
 	a.SetState(StateStopped)
-	if a.done != nil {
-		close(a.done)
-	}
+	m.markAgentDone(a)
 	m.logger.Info("agent.headless.done", "id", a.ID, "cost", a.GetCostUSD())
 	m.emit(events.AgentState(a.ID), a)
 	m.recordCompletion(a, a.GetExitErr() == nil)
@@ -557,9 +555,7 @@ func formatHeadlessToolResults(results []ToolResultBlock) string {
 
 func (m *Manager) handleError(a *Agent, err error) {
 	a.SetState(StateStopped)
-	if a.done != nil {
-		close(a.done)
-	}
+	m.markAgentDone(a)
 	m.logger.Error("agent.error", "id", a.ID, "err", err)
 	m.emit(events.AgentError(a.ID), err.Error())
 	m.recordCompletion(a, false)

--- a/internal/agent/stream.go
+++ b/internal/agent/stream.go
@@ -194,66 +194,6 @@ func ParseCodexLine(line []byte) (CodexEvent, error) {
 	}
 }
 
-func parseCodexItemLine(eventType string, raw map[string]any, rawCopy json.RawMessage) (CodexEvent, error) {
-	item, _ := raw["item"].(map[string]any)
-	itemType := strVal(item, "type")
-
-	switch itemType {
-	case "agent_message":
-		return CodexEvent{
-			Type: "assistant",
-			Raw:  rawCopy,
-			Message: &ClaudeMessage{
-				Role: "assistant",
-				Text: strVal(item, "text"),
-			},
-		}, nil
-
-	case "command_execution":
-		if eventType == "item.started" {
-			return CodexEvent{
-				Type: "tool_use",
-				Raw:  rawCopy,
-				Message: &ClaudeMessage{
-					Role: "assistant",
-					ToolUses: []ToolUseBlock{{
-						ID:    strVal(item, "id"),
-						Name:  "Bash",
-						Input: map[string]any{"command": strVal(item, "command")},
-					}},
-				},
-			}, nil
-		}
-		output := strVal(item, "aggregated_output")
-		exitCode := int(floatVal(item, "exit_code"))
-		if output == "" {
-			output = fmt.Sprintf("Command exited with code %d.", exitCode)
-		}
-		return CodexEvent{
-			Type: "tool_result",
-			Raw:  rawCopy,
-			Message: &ClaudeMessage{
-				Role: "user",
-				ToolResults: []ToolResultBlock{{
-					ToolUseID: strVal(item, "id"),
-					Content:   output,
-					IsError:   exitCode != 0,
-				}},
-			},
-		}, nil
-
-	default:
-		return CodexEvent{
-			Type: "assistant",
-			Raw:  rawCopy,
-			Message: &ClaudeMessage{
-				Role: "assistant",
-				Text: strVal(item, "text"),
-			},
-		}, nil
-	}
-}
-
 func parseCodexItemLineTyped(eventType string, item *codexItem, rawCopy json.RawMessage) (CodexEvent, error) {
 	if item == nil {
 		return CodexEvent{Type: eventType, Raw: rawCopy}, nil
@@ -362,7 +302,8 @@ func extractAssistantContentTyped(msg *claudeMessagePayload) ClaudeMessage {
 	}
 	var textParts []string
 	var tools []ToolUseBlock
-	for _, block := range msg.Content {
+	for i := range msg.Content {
+		block := &msg.Content[i]
 		switch block.Type {
 		case "text":
 			if block.Text != "" {
@@ -436,7 +377,8 @@ func extractToolResultsTyped(msg *claudeMessagePayload) []ToolResultBlock {
 		return nil
 	}
 	var results []ToolResultBlock
-	for _, block := range msg.Content {
+	for i := range msg.Content {
+		block := &msg.Content[i]
 		if block.Type != "tool_result" {
 			continue
 		}
@@ -465,26 +407,6 @@ func extractToolResultsTyped(msg *claudeMessagePayload) []ToolResultBlock {
 	return results
 }
 
-// extractResultFields parses cost, token, and session fields from a "result" event.
-func extractResultFields(raw map[string]any) ClaudeResult {
-	r := ClaudeResult{
-		Subtype:   strVal(raw, "subtype"),
-		SessionID: strVal(raw, "session_id"),
-	}
-	// ok intentionally discarded: zero-value "" is acceptable when result absent.
-	r.Text, _ = raw["result"].(string)
-	if cost, ok := raw["total_cost_usd"].(float64); ok {
-		r.CostUSD = cost
-	}
-	if v, ok := raw["total_input_tokens"].(float64); ok {
-		r.InputTokens = int(v)
-	}
-	if v, ok := raw["total_output_tokens"].(float64); ok {
-		r.OutputTokens = int(v)
-	}
-	return r
-}
-
 func extractResultFieldsTyped(raw claudeEnvelope) ClaudeResult {
 	return ClaudeResult{
 		Subtype:      raw.Subtype,
@@ -511,14 +433,5 @@ func strVal(m map[string]any, key string) string {
 		return ""
 	}
 	v, _ := m[key].(string)
-	return v
-}
-
-// floatVal extracts a float64 from a map[string]any, returning 0 on any failure.
-func floatVal(m map[string]any, key string) float64 {
-	if m == nil {
-		return 0
-	}
-	v, _ := m[key].(float64)
 	return v
 }

--- a/internal/agent/stream.go
+++ b/internal/agent/stream.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -48,46 +49,94 @@ type CodexEvent struct {
 	Result    *ClaudeResult
 }
 
+type claudeEnvelope struct {
+	Type              string                `json:"type"`
+	Subtype           string                `json:"subtype"`
+	SessionID         string                `json:"session_id"`
+	Message           *claudeMessagePayload `json:"message"`
+	Result            string                `json:"result"`
+	TotalCostUSD      float64               `json:"total_cost_usd"`
+	TotalInputTokens  int                   `json:"total_input_tokens"`
+	TotalOutputTokens int                   `json:"total_output_tokens"`
+}
+
+type claudeMessagePayload struct {
+	Content []claudeContentBlock `json:"content"`
+}
+
+type claudeContentBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text"`
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Input     json.RawMessage `json:"input"`
+	ToolUseID string          `json:"tool_use_id"`
+	Content   json.RawMessage `json:"content"`
+	IsError   bool            `json:"is_error"`
+}
+
+type claudeTextBlock struct {
+	Text string `json:"text"`
+}
+
+type codexEnvelope struct {
+	Type      string      `json:"type"`
+	ThreadID  string      `json:"thread_id"`
+	Message   string      `json:"message"`
+	ErrorType string      `json:"error_type"`
+	Code      int         `json:"code"`
+	Item      *codexItem  `json:"item"`
+	Usage     *codexUsage `json:"usage"`
+}
+
+type codexItem struct {
+	ID               string `json:"id"`
+	Type             string `json:"type"`
+	Text             string `json:"text"`
+	Command          string `json:"command"`
+	AggregatedOutput string `json:"aggregated_output"`
+	ExitCode         *int   `json:"exit_code"`
+}
+
+type codexUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
 // ParseClaudeLine parses one line of Claude stream-json output.
 // The returned ClaudeEvent.Raw is an independent copy safe to keep after the
 // scanner buffer is reused.
 func ParseClaudeLine(line []byte) (ClaudeEvent, error) {
-	var raw map[string]any
+	var raw claudeEnvelope
 	if err := json.Unmarshal(line, &raw); err != nil {
 		return ClaudeEvent{}, fmt.Errorf("unmarshal: %w", err)
 	}
 
-	// ok intentionally discarded: missing/non-string type yields "" which is
-	// handled below by the default case.
-	eventType, _ := raw["type"].(string)
 	event := ClaudeEvent{
-		Type:    eventType,
-		Subtype: strVal(raw, "subtype"),
+		Type:    raw.Type,
+		Subtype: raw.Subtype,
 		Raw:     copyRaw(line),
 	}
 
-	switch eventType {
+	switch raw.Type {
 	case "system":
-		// ok intentionally discarded: zero-value "" is safe when session_id absent.
-		event.SessionID, _ = raw["session_id"].(string)
+		event.SessionID = raw.SessionID
 
 	case "assistant":
-		msg, _ := raw["message"].(map[string]any)
-		if msg != nil {
-			m := extractAssistantContent(msg)
+		if raw.Message != nil {
+			m := extractAssistantContentTyped(raw.Message)
 			event.Message = &m
 		}
-		event.SessionID = strVal(raw, "session_id")
+		event.SessionID = raw.SessionID
 
 	case "user":
-		msg, _ := raw["message"].(map[string]any)
-		if msg != nil {
-			results := extractToolResults(msg)
+		if raw.Message != nil {
+			results := extractToolResultsTyped(raw.Message)
 			event.Message = &ClaudeMessage{Role: "user", ToolResults: results}
 		}
 
 	case "result":
-		r := extractResultFields(raw)
+		r := extractResultFieldsTyped(raw)
 		event.Result = &r
 		event.SessionID = r.SessionID
 
@@ -102,50 +151,46 @@ func ParseClaudeLine(line []byte) (ClaudeEvent, error) {
 // The returned CodexEvent.Raw is an independent copy safe to keep after the
 // scanner buffer is reused.
 func ParseCodexLine(line []byte) (CodexEvent, error) {
-	var raw map[string]any
+	var raw codexEnvelope
 	if err := json.Unmarshal(line, &raw); err != nil {
 		return CodexEvent{}, fmt.Errorf("unmarshal: %w", err)
 	}
 
 	rawCopy := copyRaw(line)
-	eventType := strVal(raw, "type")
 
-	switch eventType {
+	switch raw.Type {
 	case "thread.started":
-		return CodexEvent{Type: "init", SessionID: strVal(raw, "thread_id"), Raw: rawCopy}, nil
+		return CodexEvent{Type: "init", SessionID: raw.ThreadID, Raw: rawCopy}, nil
 
 	case "turn.started":
 		return CodexEvent{Type: "init", Raw: rawCopy}, nil
 
 	case "error":
-		errStatus := int(floatVal(raw, "code"))
-		errType, _ := raw["error_type"].(string)
 		return CodexEvent{
 			Type:    "result",
 			Subtype: "error",
 			Raw:     rawCopy,
 			Result: &ClaudeResult{
 				Subtype:     "error",
-				Text:        strVal(raw, "message"),
-				ErrorType:   errType,
-				ErrorStatus: errStatus,
+				Text:        raw.Message,
+				ErrorType:   raw.ErrorType,
+				ErrorStatus: raw.Code,
 			},
 		}, nil
 
 	case "turn.completed":
-		usage, _ := raw["usage"].(map[string]any)
 		var r ClaudeResult
-		if usage != nil {
-			r.InputTokens = int(floatVal(usage, "input_tokens"))
-			r.OutputTokens = int(floatVal(usage, "output_tokens"))
+		if raw.Usage != nil {
+			r.InputTokens = raw.Usage.InputTokens
+			r.OutputTokens = raw.Usage.OutputTokens
 		}
 		return CodexEvent{Type: "result", Raw: rawCopy, Result: &r}, nil
 
 	case "item.started", "item.completed":
-		return parseCodexItemLine(eventType, raw, rawCopy)
+		return parseCodexItemLineTyped(raw.Type, raw.Item, rawCopy)
 
 	default:
-		return CodexEvent{Type: eventType, Raw: rawCopy}, nil
+		return CodexEvent{Type: raw.Type, Raw: rawCopy}, nil
 	}
 }
 
@@ -209,6 +254,70 @@ func parseCodexItemLine(eventType string, raw map[string]any, rawCopy json.RawMe
 	}
 }
 
+func parseCodexItemLineTyped(eventType string, item *codexItem, rawCopy json.RawMessage) (CodexEvent, error) {
+	if item == nil {
+		return CodexEvent{Type: eventType, Raw: rawCopy}, nil
+	}
+
+	switch item.Type {
+	case "agent_message":
+		return CodexEvent{
+			Type: "assistant",
+			Raw:  rawCopy,
+			Message: &ClaudeMessage{
+				Role: "assistant",
+				Text: item.Text,
+			},
+		}, nil
+
+	case "command_execution":
+		if eventType == "item.started" {
+			return CodexEvent{
+				Type: "tool_use",
+				Raw:  rawCopy,
+				Message: &ClaudeMessage{
+					Role: "assistant",
+					ToolUses: []ToolUseBlock{{
+						ID:    item.ID,
+						Name:  "Bash",
+						Input: map[string]any{"command": item.Command},
+					}},
+				},
+			}, nil
+		}
+		output := item.AggregatedOutput
+		exitCode := 0
+		if item.ExitCode != nil {
+			exitCode = *item.ExitCode
+		}
+		if output == "" {
+			output = fmt.Sprintf("Command exited with code %d.", exitCode)
+		}
+		return CodexEvent{
+			Type: "tool_result",
+			Raw:  rawCopy,
+			Message: &ClaudeMessage{
+				Role: "user",
+				ToolResults: []ToolResultBlock{{
+					ToolUseID: item.ID,
+					Content:   output,
+					IsError:   exitCode != 0,
+				}},
+			},
+		}, nil
+
+	default:
+		return CodexEvent{
+			Type: "assistant",
+			Raw:  rawCopy,
+			Message: &ClaudeMessage{
+				Role: "assistant",
+				Text: item.Text,
+			},
+		}, nil
+	}
+}
+
 // extractAssistantContent parses the "message" block from an assistant event.
 // Text contains only joined text blocks. ToolUses contains structured tool calls.
 func extractAssistantContent(msg map[string]any) ClaudeMessage {
@@ -236,6 +345,39 @@ func extractAssistantContent(msg map[string]any) ClaudeMessage {
 			}
 			if input, ok := block["input"].(map[string]any); ok {
 				tb.Input = input
+			}
+			tools = append(tools, tb)
+		}
+	}
+	return ClaudeMessage{
+		Role:     "assistant",
+		Text:     strings.Join(textParts, "\n"),
+		ToolUses: tools,
+	}
+}
+
+func extractAssistantContentTyped(msg *claudeMessagePayload) ClaudeMessage {
+	if msg == nil || len(msg.Content) == 0 {
+		return ClaudeMessage{Role: "assistant"}
+	}
+	var textParts []string
+	var tools []ToolUseBlock
+	for _, block := range msg.Content {
+		switch block.Type {
+		case "text":
+			if block.Text != "" {
+				textParts = append(textParts, block.Text)
+			}
+		case "tool_use":
+			tb := ToolUseBlock{
+				ID:   block.ID,
+				Name: block.Name,
+			}
+			if len(block.Input) > 0 && !bytes.Equal(block.Input, []byte("null")) {
+				var input map[string]any
+				if err := json.Unmarshal(block.Input, &input); err == nil {
+					tb.Input = input
+				}
 			}
 			tools = append(tools, tb)
 		}
@@ -289,6 +431,40 @@ func extractToolResults(msg map[string]any) []ToolResultBlock {
 	return results
 }
 
+func extractToolResultsTyped(msg *claudeMessagePayload) []ToolResultBlock {
+	if msg == nil || len(msg.Content) == 0 {
+		return nil
+	}
+	var results []ToolResultBlock
+	for _, block := range msg.Content {
+		if block.Type != "tool_result" {
+			continue
+		}
+		tr := ToolResultBlock{
+			ToolUseID: block.ToolUseID,
+			IsError:   block.IsError,
+		}
+		switch {
+		case len(block.Content) == 0 || bytes.Equal(block.Content, []byte("null")):
+		case len(block.Content) > 0 && block.Content[0] == '"':
+			_ = json.Unmarshal(block.Content, &tr.Content)
+		case len(block.Content) > 0 && block.Content[0] == '[':
+			var parts []claudeTextBlock
+			if err := json.Unmarshal(block.Content, &parts); err == nil {
+				text := make([]string, 0, len(parts))
+				for _, part := range parts {
+					if part.Text != "" {
+						text = append(text, part.Text)
+					}
+				}
+				tr.Content = strings.Join(text, "\n")
+			}
+		}
+		results = append(results, tr)
+	}
+	return results
+}
+
 // extractResultFields parses cost, token, and session fields from a "result" event.
 func extractResultFields(raw map[string]any) ClaudeResult {
 	r := ClaudeResult{
@@ -307,6 +483,17 @@ func extractResultFields(raw map[string]any) ClaudeResult {
 		r.OutputTokens = int(v)
 	}
 	return r
+}
+
+func extractResultFieldsTyped(raw claudeEnvelope) ClaudeResult {
+	return ClaudeResult{
+		Subtype:      raw.Subtype,
+		Text:         raw.Result,
+		SessionID:    raw.SessionID,
+		CostUSD:      raw.TotalCostUSD,
+		InputTokens:  raw.TotalInputTokens,
+		OutputTokens: raw.TotalOutputTokens,
+	}
 }
 
 // copyRaw returns an independent copy of line as json.RawMessage.

--- a/internal/agent/stream_bench_test.go
+++ b/internal/agent/stream_bench_test.go
@@ -50,6 +50,22 @@ func makeResultLine() []byte {
 	return b
 }
 
+func makeCodexCommandCompletedLine() []byte {
+	event := map[string]any{
+		"type": "item.completed",
+		"item": map[string]any{
+			"id":                "item_1",
+			"type":              "command_execution",
+			"command":           "pwd",
+			"aggregated_output": "/repo\n",
+			"exit_code":         0,
+			"status":            "completed",
+		},
+	}
+	b, _ := json.Marshal(event)
+	return b
+}
+
 // BenchmarkParseClaudeLine_Assistant measures per-line parse cost for the
 // most common event type. This runs on every stream line (50ms throttle only
 // caps emit, not parse) so regressions here scale linearly with event volume.
@@ -90,6 +106,17 @@ func BenchmarkParseClaudeLine_Mixed(b *testing.B) {
 	for i := range b.N {
 		if _, err := ParseClaudeLine(lines[i%len(lines)]); err != nil {
 			b.Fatalf("ParseClaudeLine: %v", err)
+		}
+	}
+}
+
+func BenchmarkParseCodexLine_CommandCompleted(b *testing.B) {
+	line := makeCodexCommandCompletedLine()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for range b.N {
+		if _, err := ParseCodexLine(line); err != nil {
+			b.Fatalf("ParseCodexLine: %v", err)
 		}
 	}
 }

--- a/internal/sse/broker.go
+++ b/internal/sse/broker.go
@@ -64,6 +64,14 @@ func (b *Broker) SubscribeAll() (ch <-chan Event, cancel func()) {
 // all SubscribeAll subscribers.
 // Safe for concurrent use. Slow consumers are dropped (non-blocking send).
 func (b *Broker) Emit(event string, data any) {
+	b.mu.RLock()
+	hasNamed := len(b.subs[event]) > 0
+	hasAll := len(b.allSubs) > 0
+	b.mu.RUnlock()
+	if !hasNamed && !hasAll {
+		return
+	}
+
 	payload, err := json.Marshal(data)
 	if err != nil {
 		return
@@ -71,14 +79,9 @@ func (b *Broker) Emit(event string, data any) {
 	msg := string(payload)
 
 	b.mu.RLock()
-	chans := b.subs[event]
-	namedSnap := make([]chan string, len(chans))
-	copy(namedSnap, chans)
-	allSnap := make([]chan Event, len(b.allSubs))
-	copy(allSnap, b.allSubs)
-	b.mu.RUnlock()
+	defer b.mu.RUnlock()
 
-	for _, ch := range namedSnap {
+	for _, ch := range b.subs[event] {
 		select {
 		case ch <- msg:
 		default: // drop slow consumer
@@ -86,7 +89,7 @@ func (b *Broker) Emit(event string, data any) {
 	}
 
 	ev := Event{Name: event, Data: msg}
-	for _, ch := range allSnap {
+	for _, ch := range b.allSubs {
 		select {
 		case ch <- ev:
 		default: // drop slow consumer

--- a/internal/synapse/app.go
+++ b/internal/synapse/app.go
@@ -192,7 +192,15 @@ func (a *App) Startup(ctx context.Context) error {
 	} else {
 		a.emit = func(string, any) {}
 	}
-	emit := a.emit
+	emit := func(event string, data any) {
+		switch event {
+		case events.TaskCreated, events.TaskUpdated, events.TaskDeleted:
+			if path, ok := data.(string); ok {
+				store.InvalidatePath(path)
+			}
+		}
+		a.emit(event, data)
+	}
 	a.emitDegradedWarnings(emit)
 	a.tasks = task.NewManager(store, task.EmitterFunc(emit))
 	a.initStatusHook()
@@ -562,6 +570,10 @@ func (a *App) onWorkflowComplete(info workflow.CompletionInfo) {
 }
 
 func (a *App) initWorkflowEngine() {
+	if os.Getenv("SYNAPSE_DISABLE_WORKFLOWS") == "1" {
+		a.logger.Info("workflow.disabled")
+		return
+	}
 	wfStore, err := workflow.NewStore(config.WorkflowsDir())
 	if err != nil {
 		a.logger.Error("workflow.store.init", "err", err)

--- a/internal/synapse/app.go
+++ b/internal/synapse/app.go
@@ -249,6 +249,17 @@ func (a *App) Startup(ctx context.Context) error {
 	a.syncSkills()
 	a.runStartupCleanup()
 	a.RegisterSpotlightHotkey()
+	a.startBackgroundServices(ctx, emit, issuesFetcher)
+	a.logAutomationsSummary()
+	a.logger.Info("app.started")
+	return nil
+}
+
+func (a *App) startBackgroundServices(
+	ctx context.Context,
+	emit func(string, any),
+	issuesFetcher *poll.IssuesFetcher,
+) {
 	a.wg.Go(func() { a.orchestratorLoop(ctx) })
 
 	wdog := watchdog.New(a.agents, a.tasks, a.logger, emit, &a.wg)
@@ -264,9 +275,6 @@ func (a *App) Startup(ctx context.Context) error {
 	a.startPollHub(ctx, issuesFetcher)
 	a.startTodoistLoop(ctx)
 	a.registerMetricsObservers()
-	a.logAutomationsSummary()
-	a.logger.Info("app.started")
-	return nil
 }
 
 // registerMetricsObservers wires the OTel observable gauge callbacks to

--- a/internal/synapse/app_agents.go
+++ b/internal/synapse/app_agents.go
@@ -97,15 +97,6 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, oneShot bool
 		return nil, fmt.Errorf("task %s: no working dir resolved (skipWorktree=%v) — refusing to run agent in Synapse cwd", taskID, skipWT)
 	}
 
-	// Flip status only after worktree prep succeeds — otherwise a failed
-	// prep leaves the task stuck at in-progress with no running agent,
-	// which triggers restart-stale respawn loops on every app restart.
-	if t.Status != task.StatusInProgress {
-		if _, err := o.tasks.Update(taskID, task.Update{Status: task.Ptr(task.StatusInProgress)}); err != nil {
-			o.logger.Error("task.auto-status", "task_id", taskID, "err", err)
-		}
-	}
-
 	fullPrompt := fmt.Sprintf("# Task: %s\n\n%s\n\n---\n\n%s", t.Title, t.Body, prompt)
 	ag, err := o.agents.Run(agent.RunConfig{
 		TaskID:             taskID,
@@ -135,12 +126,16 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, oneShot bool
 		"mode": effMode, "title": t.Title, "task_type": string(t.TaskType), "provider": ag.Provider,
 		"allowed_tools": t.AllowedTools, "require_permissions": requirePerm, "skip_permissions": skipPerm,
 	})
-	if err := o.tasks.AddRun(taskID, task.AgentRun{
+	var nextStatus *task.Status
+	if t.Status != task.StatusInProgress {
+		nextStatus = task.Ptr(task.StatusInProgress)
+	}
+	if err := o.tasks.AddRunWithStatus(taskID, task.AgentRun{
 		AgentID:   ag.ID,
 		Mode:      effMode,
 		State:     string(agent.StateRunning),
 		StartedAt: ag.StartedAt,
-	}); err != nil {
+	}, nextStatus); err != nil {
 		o.logger.Error("task.add-run", "task_id", taskID, "err", err)
 	}
 	return ag, nil

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -170,15 +170,38 @@ func (m *Manager) Delete(id string) error {
 
 // AddRun appends an agent run to the task and emits task:updated.
 func (m *Manager) AddRun(taskID string, run AgentRun) error {
+	return m.AddRunWithStatus(taskID, run, nil)
+}
+
+// AddRunWithStatus appends an agent run and optionally changes task status in one write.
+func (m *Manager) AddRunWithStatus(taskID string, run AgentRun, status *Status) error {
 	mu := m.lockFor(taskID)
 	mu.Lock()
-	defer mu.Unlock()
-	if err := m.store.AddRun(taskID, run); err != nil {
+	var prevStatus string
+	if status != nil {
+		if prev, getErr := m.store.Get(taskID); getErr == nil {
+			prevStatus = string(prev.Status)
+		}
+	}
+	if err := m.store.AddRunWithStatus(taskID, run, status); err != nil {
+		mu.Unlock()
 		return err
 	}
 	t, err := m.store.Get(taskID)
 	if err == nil {
 		m.emitter.Emit(events.TaskUpdated, t.FilePath)
+	}
+	var (
+		fireHook  bool
+		newStatus string
+	)
+	if status != nil && m.onStatusHook != nil && err == nil {
+		newStatus = string(t.Status)
+		fireHook = newStatus != prevStatus
+	}
+	mu.Unlock()
+	if fireHook {
+		m.onStatusHook(taskID, prevStatus, newStatus)
 	}
 	return nil
 }

--- a/internal/task/manager_test.go
+++ b/internal/task/manager_test.go
@@ -164,6 +164,47 @@ func TestManagerAddRunEmitsUpdated(t *testing.T) {
 	}
 }
 
+func TestManagerAddRunWithStatusEmitsUpdatedAndHook(t *testing.T) {
+	t.Parallel()
+	m, emitter := newTestManager(t)
+
+	task, err := m.Create("Title", "", "headless")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var hookCalls int
+	m.SetStatusChangeHook(func(id, from, to string) {
+		hookCalls++
+		if id != task.ID || from != string(StatusTodo) || to != string(StatusInProgress) {
+			t.Fatalf("hook got (%s,%s,%s)", id, from, to)
+		}
+	})
+
+	if err := m.AddRunWithStatus(task.ID, AgentRun{AgentID: "a1", State: "running"}, Ptr(StatusInProgress)); err != nil {
+		t.Fatalf("AddRunWithStatus: %v", err)
+	}
+	if hookCalls != 1 {
+		t.Fatalf("hookCalls = %d, want 1", hookCalls)
+	}
+
+	names := emitter.names()
+	if len(names) != 2 || names[1] != events.TaskUpdated {
+		t.Fatalf("events = %v", names)
+	}
+
+	got, err := m.Get(task.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != StatusInProgress {
+		t.Fatalf("Status = %q, want %q", got.Status, StatusInProgress)
+	}
+	if len(got.AgentRuns) != 1 || got.AgentRuns[0].AgentID != "a1" {
+		t.Fatalf("AgentRuns = %+v", got.AgentRuns)
+	}
+}
+
 func TestManagerUpdateRunEmitsUpdated(t *testing.T) {
 	t.Parallel()
 	m, emitter := newTestManager(t)

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -3,6 +3,7 @@ package task
 import (
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -359,9 +360,7 @@ func cloneWorkflow(wf workflow.Execution) workflow.Execution {
 	clone.StepHistory = slices.Clone(wf.StepHistory)
 	if wf.Variables != nil {
 		clone.Variables = make(map[string]string, len(wf.Variables))
-		for k, v := range wf.Variables {
-			clone.Variables[k] = v
-		}
+		maps.Copy(clone.Variables, wf.Variables)
 	}
 	if wf.CompletedAt != nil {
 		ts := *wf.CompletedAt

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -5,10 +5,13 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Automaat/synapse/internal/fsutil"
+	"github.com/Automaat/synapse/internal/workflow"
 	"github.com/google/uuid"
 )
 
@@ -17,6 +20,9 @@ type Store struct {
 	comments      *CommentStore
 	plans         *PlanStore
 	planCritiques *PlanCritiqueStore
+	cacheMu       sync.RWMutex
+	listCache     []Task
+	listValid     bool
 }
 
 func NewStore(dir string) (*Store, error) {
@@ -44,6 +50,10 @@ func (s *Store) PlanCritiques() *PlanCritiqueStore {
 }
 
 func (s *Store) List() ([]Task, error) {
+	if tasks, ok := s.cachedList(); ok {
+		return tasks, nil
+	}
+
 	paths, err := fsutil.ListFiles(s.dir, ".md")
 	if err != nil {
 		return nil, fmt.Errorf("read tasks dir: %w", err)
@@ -64,6 +74,7 @@ func (s *Store) List() ([]Task, error) {
 		t.PlanCritique, _ = s.planCritiques.Read(t.ID)
 		tasks = append(tasks, t)
 	}
+	s.storeListCache(tasks)
 	return tasks, nil
 }
 
@@ -112,6 +123,7 @@ func (s *Store) Create(title, body, mode string) (Task, error) {
 	if err := fsutil.AtomicWrite(t.FilePath, data); err != nil {
 		return Task{}, fmt.Errorf("write task file: %w", err)
 	}
+	s.storeTaskCache(t)
 	return t, nil
 }
 
@@ -145,6 +157,7 @@ func (s *Store) CreateChat(projectID string) (Task, error) {
 	if err := fsutil.AtomicWrite(t.FilePath, data); err != nil {
 		return Task{}, fmt.Errorf("write chat task file: %w", err)
 	}
+	s.storeTaskCache(t)
 	return t, nil
 }
 
@@ -159,6 +172,7 @@ func (s *Store) Delete(id string) error {
 	_ = s.comments.DeleteAll(id)
 	_ = s.plans.Delete(id)
 	_ = s.planCritiques.Delete(id)
+	s.deleteCachedTask(id)
 	return nil
 }
 
@@ -243,7 +257,117 @@ func (s *Store) Update(id string, u Update) (Task, error) {
 	if err := fsutil.AtomicWrite(t.FilePath, data); err != nil {
 		return Task{}, fmt.Errorf("write task file: %w", err)
 	}
+	s.storeTaskCache(t)
 	return t, nil
+}
+
+// InvalidatePath clears any cached task/list state for the given task file.
+// Non-task files are ignored.
+func (s *Store) InvalidatePath(path string) {
+	if !strings.HasSuffix(path, ".md") {
+		return
+	}
+	base := filepath.Base(path)
+	if strings.HasSuffix(base, ".plan.md") || strings.HasSuffix(base, ".plan-critique.md") {
+		s.invalidateListCache()
+		return
+	}
+	id := strings.TrimSuffix(base, ".md")
+	if id == "" {
+		return
+	}
+	s.invalidateListCache()
+}
+
+func (s *Store) cachedList() ([]Task, bool) {
+	s.cacheMu.RLock()
+	defer s.cacheMu.RUnlock()
+	if !s.listValid {
+		return nil, false
+	}
+	return cloneTasks(s.listCache), true
+}
+
+func (s *Store) storeListCache(tasks []Task) {
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+	s.listCache = cloneTasks(tasks)
+	s.listValid = true
+}
+
+func (s *Store) storeTaskCache(t Task) {
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+	cloned := cloneTask(t)
+	if !s.listValid {
+		return
+	}
+	for i := range s.listCache {
+		if s.listCache[i].ID != t.ID {
+			continue
+		}
+		s.listCache[i] = cloned
+		return
+	}
+	s.listCache = append(s.listCache, cloned)
+}
+
+func (s *Store) deleteCachedTask(id string) {
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+	if !s.listValid {
+		return
+	}
+	for i := range s.listCache {
+		if s.listCache[i].ID != id {
+			continue
+		}
+		s.listCache = append(s.listCache[:i], s.listCache[i+1:]...)
+		return
+	}
+	s.listValid = true
+}
+
+func (s *Store) invalidateListCache() {
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+	s.listValid = false
+}
+
+func cloneTasks(tasks []Task) []Task {
+	out := make([]Task, len(tasks))
+	for i := range tasks {
+		out[i] = cloneTask(tasks[i])
+	}
+	return out
+}
+
+func cloneTask(t Task) Task {
+	clone := t
+	clone.AllowedTools = slices.Clone(t.AllowedTools)
+	clone.Tags = slices.Clone(t.Tags)
+	clone.AgentRuns = slices.Clone(t.AgentRuns)
+	if t.Workflow != nil {
+		wfClone := cloneWorkflow(*t.Workflow)
+		clone.Workflow = &wfClone
+	}
+	return clone
+}
+
+func cloneWorkflow(wf workflow.Execution) workflow.Execution {
+	clone := wf
+	clone.StepHistory = slices.Clone(wf.StepHistory)
+	if wf.Variables != nil {
+		clone.Variables = make(map[string]string, len(wf.Variables))
+		for k, v := range wf.Variables {
+			clone.Variables[k] = v
+		}
+	}
+	if wf.CompletedAt != nil {
+		ts := *wf.CompletedAt
+		clone.CompletedAt = &ts
+	}
+	return clone
 }
 
 // UpdateMap converts raw to a typed Update and applies it.
@@ -257,16 +381,31 @@ func (s *Store) UpdateMap(id string, raw map[string]any) (Task, error) {
 }
 
 func (s *Store) AddRun(taskID string, run AgentRun) error {
+	return s.addRun(taskID, run, nil)
+}
+
+func (s *Store) AddRunWithStatus(taskID string, run AgentRun, status *Status) error {
+	return s.addRun(taskID, run, status)
+}
+
+func (s *Store) addRun(taskID string, run AgentRun, status *Status) error {
 	t, err := s.Get(taskID)
 	if err != nil {
 		return err
+	}
+	if status != nil {
+		t.Status = *status
 	}
 	t.AgentRuns = append(t.AgentRuns, run)
 	d, err := Marshal(t)
 	if err != nil {
 		return err
 	}
-	return fsutil.AtomicWrite(t.FilePath, d)
+	if err := fsutil.AtomicWrite(t.FilePath, d); err != nil {
+		return err
+	}
+	s.storeTaskCache(t)
+	return nil
 }
 
 func (s *Store) UpdateRun(taskID, agentID string, updates map[string]any) error {
@@ -296,5 +435,9 @@ func (s *Store) UpdateRun(taskID, agentID string, updates map[string]any) error 
 	if err != nil {
 		return err
 	}
-	return fsutil.AtomicWrite(t.FilePath, d)
+	if err := fsutil.AtomicWrite(t.FilePath, d); err != nil {
+		return err
+	}
+	s.storeTaskCache(t)
+	return nil
 }

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -505,6 +505,38 @@ func TestStoreAddRunNotFound(t *testing.T) {
 	}
 }
 
+func TestStoreAddRunWithStatus(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("Run task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.AddRunWithStatus(created.ID, AgentRun{
+		AgentID: "agent-001",
+		Mode:    "headless",
+		State:   "running",
+	}, Ptr(StatusInProgress)); err != nil {
+		t.Fatalf("AddRunWithStatus: %v", err)
+	}
+
+	got, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != StatusInProgress {
+		t.Fatalf("Status = %q, want %q", got.Status, StatusInProgress)
+	}
+	if len(got.AgentRuns) != 1 {
+		t.Fatalf("AgentRuns len = %d, want 1", len(got.AgentRuns))
+	}
+}
+
 func TestStoreUpdateRun(t *testing.T) {
 	t.Parallel()
 	store, err := NewStore(t.TempDir())
@@ -671,5 +703,108 @@ func TestStoreListSkipsMalformed(t *testing.T) {
 	}
 	if len(tasks) != 1 {
 		t.Errorf("got %d tasks, want 1 (should skip malformed)", len(tasks))
+	}
+}
+
+func TestStoreGetInvalidatePathRefreshesExternalEdit(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("Original", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.Get(created.ID); err != nil {
+		t.Fatalf("prime cache: %v", err)
+	}
+
+	created.Title = "Edited on disk"
+	data, err := Marshal(created)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(created.FilePath, data, 0o644); err != nil {
+		t.Fatalf("write edited task: %v", err)
+	}
+
+	store.InvalidatePath(created.FilePath)
+
+	got, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("get after invalidate: %v", err)
+	}
+	if got.Title != "Edited on disk" {
+		t.Fatalf("Title = %q, want %q", got.Title, "Edited on disk")
+	}
+}
+
+func TestStoreListInvalidatePathRefreshesSidecar(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("Task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.List(); err != nil {
+		t.Fatalf("prime cache: %v", err)
+	}
+
+	planPath := filepath.Join(dir, created.ID+".plan.md")
+	if err := os.WriteFile(planPath, []byte("# refreshed plan"), 0o644); err != nil {
+		t.Fatalf("write plan: %v", err)
+	}
+
+	store.InvalidatePath(planPath)
+
+	tasks, err := store.List()
+	if err != nil {
+		t.Fatalf("list after invalidate: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(tasks))
+	}
+	if tasks[0].Plan != "# refreshed plan" {
+		t.Fatalf("Plan = %q, want %q", tasks[0].Plan, "# refreshed plan")
+	}
+}
+
+func TestStoreListReturnedSliceDoesNotMutateCache(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("Original", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listed, err := store.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	listed[0].Title = "Mutated caller copy"
+	listed[0].Tags = append(listed[0].Tags, "mutated")
+
+	got, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Title != "Original" {
+		t.Fatalf("Title = %q, want %q", got.Title, "Original")
+	}
+	if len(got.Tags) != 0 {
+		t.Fatalf("Tags = %v, want empty", got.Tags)
 	}
 }

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -69,7 +69,7 @@ func (w *Watcher) loop(ctx context.Context, fw *fsnotify.Watcher) {
 	deadlines := make(map[string]time.Time)
 	timer := time.NewTimer(time.Hour)
 	stopTimer(timer)
-	timerCh := (<-chan time.Time)(nil)
+	var timerCh <-chan time.Time
 
 	for {
 		select {
@@ -124,9 +124,7 @@ func resetDebounceTimer(timer *time.Timer, deadlines map[string]time.Time) <-cha
 	}
 	next := nextDeadline(deadlines)
 	wait := time.Until(next)
-	if wait < 0 {
-		wait = 0
-	}
+	wait = max(wait, 0)
 	stopTimer(timer)
 	timer.Reset(wait)
 	return timer.C

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -66,33 +66,20 @@ func (w *Watcher) loop(ctx context.Context, fw *fsnotify.Watcher) {
 	// leading-edge implementation silently dropped the last write in a
 	// burst, leaving consumers with stale content.
 	pending := make(map[string]fsnotify.Op)
-	timers := make(map[string]*time.Timer)
-	flushCh := make(chan string, 64)
-
-	stopAllTimers := func() {
-		for _, t := range timers {
-			t.Stop()
-		}
-	}
+	deadlines := make(map[string]time.Time)
+	timer := time.NewTimer(time.Hour)
+	stopTimer(timer)
+	timerCh := (<-chan time.Time)(nil)
 
 	for {
 		select {
 		case <-ctx.Done():
-			stopAllTimers()
+			stopTimer(timer)
 			return
-
-		case name := <-flushCh:
-			op, ok := pending[name]
-			if !ok {
-				continue
-			}
-			delete(pending, name)
-			delete(timers, name)
-			w.emitFor(name, op)
 
 		case event, ok := <-fw.Events:
 			if !ok {
-				stopAllTimers()
+				stopTimer(timer)
 				return
 			}
 			if !strings.HasSuffix(event.Name, ".md") {
@@ -100,23 +87,66 @@ func (w *Watcher) loop(ctx context.Context, fw *fsnotify.Watcher) {
 			}
 			// OR ops so a Create+Write burst still surfaces as Create.
 			pending[event.Name] |= event.Op
-			if t, exists := timers[event.Name]; exists {
-				t.Stop()
-			}
-			name := event.Name
-			timers[name] = time.AfterFunc(debounceInterval, func() {
-				select {
-				case flushCh <- name:
-				case <-ctx.Done():
+			deadlines[event.Name] = time.Now().Add(debounceInterval)
+			timerCh = resetDebounceTimer(timer, deadlines)
+
+		case <-timerCh:
+			now := time.Now()
+			for name, deadline := range deadlines {
+				if deadline.After(now) {
+					continue
 				}
-			})
+				op, ok := pending[name]
+				if !ok {
+					delete(deadlines, name)
+					continue
+				}
+				delete(pending, name)
+				delete(deadlines, name)
+				w.emitFor(name, op)
+			}
+			timerCh = resetDebounceTimer(timer, deadlines)
 
 		case err, ok := <-fw.Errors:
 			if !ok {
-				stopAllTimers()
+				stopTimer(timer)
 				return
 			}
 			w.logger.Error("watcher.error", "err", err)
+		}
+	}
+}
+
+func resetDebounceTimer(timer *time.Timer, deadlines map[string]time.Time) <-chan time.Time {
+	if len(deadlines) == 0 {
+		stopTimer(timer)
+		return nil
+	}
+	next := nextDeadline(deadlines)
+	wait := time.Until(next)
+	if wait < 0 {
+		wait = 0
+	}
+	stopTimer(timer)
+	timer.Reset(wait)
+	return timer.C
+}
+
+func nextDeadline(deadlines map[string]time.Time) time.Time {
+	var next time.Time
+	for _, deadline := range deadlines {
+		if next.IsZero() || deadline.Before(next) {
+			next = deadline
+		}
+	}
+	return next
+}
+
+func stopTimer(timer *time.Timer) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
 		}
 	}
 }


### PR DESCRIPTION
## Motivation

Perf harness data was noisy and several hot paths still paid avoidable startup and event-processing overhead.

> Changelog: perf(core): cut startup hot path cost

## Implementation information

Tightened task-store list performance, agent startup bookkeeping, SSE fanout, stream parsing, and watcher debounce allocation cost.

Fixed the perf harness so it drains SSE, disables workflow auto-start during runs, and correlates task IDs to the real emitted agent IDs.

## Supporting documentation

perf-testing.md
