### PR TITLE
fix(issues): only sync from registered projects

### DIFF
--- a/internal/poll/issues.go
+++ b/internal/poll/issues.go
@@ -122,10 +122,14 @@ func (f *IssuesFetcher) syncIssuesToTasks(issues []github.Issue) {
 			continue
 		}
 
-		// Skip issues from registered projects whose type isn't allowed on this
-		// machine. Issues from unregistered repos pass through (caller hasn't
-		// declared a type for them).
-		if proj, err := f.projects.Get(issue.Repository); err == nil && !f.allowsType(proj.Type) {
+		// Require the issue's repo to be a registered project. Issues from
+		// unregistered repos are dropped entirely — synapse only tracks work
+		// for repos the user has explicitly added as projects.
+		proj, err := f.projects.Get(issue.Repository)
+		if err != nil {
+			continue
+		}
+		if !f.allowsType(proj.Type) {
 			continue
 		}
 
@@ -133,14 +137,12 @@ func (f *IssuesFetcher) syncIssuesToTasks(issues []github.Issue) {
 		// Enrich it with the real title and link instead of creating a duplicate.
 		if taskID, exists := urlTitleTasks[issue.URL]; exists {
 			u := task.Update{
-				Title: task.Ptr(issue.Title),
-				Issue: task.Ptr(issue.URL),
+				Title:     task.Ptr(issue.Title),
+				Issue:     task.Ptr(issue.URL),
+				ProjectID: task.Ptr(issue.Repository),
 			}
 			if issue.Body != "" {
 				u.Body = task.Ptr(issue.Body)
-			}
-			if _, projErr := f.projects.Get(issue.Repository); projErr == nil {
-				u.ProjectID = task.Ptr(issue.Repository)
 			}
 			if _, err := f.tasks.Update(taskID, u); err != nil {
 				f.logger.Error("issue-sync.enrich", "task_id", taskID, "err", err)
@@ -157,12 +159,9 @@ func (f *IssuesFetcher) syncIssuesToTasks(issues []github.Issue) {
 		}
 
 		u := task.Update{
-			Issue:  task.Ptr(issue.URL),
-			Status: task.Ptr(task.StatusTodo),
-		}
-
-		if _, projErr := f.projects.Get(issue.Repository); projErr == nil {
-			u.ProjectID = task.Ptr(issue.Repository)
+			Issue:     task.Ptr(issue.URL),
+			Status:    task.Ptr(task.StatusTodo),
+			ProjectID: task.Ptr(issue.Repository),
 		}
 
 		if len(issue.Labels) > 0 {

--- a/internal/poll/issues_test.go
+++ b/internal/poll/issues_test.go
@@ -80,34 +80,31 @@ func TestIssuesFetcher_SyncIssuesToTasks_FiltersByProjectType(t *testing.T) {
 		name       string
 		allowsType func(project.ProjectType) bool
 		// wantIssues is the set of issue URLs expected to have resulted in a
-		// task. Unregistered repos always pass through.
+		// task. Issues from unregistered repos are always dropped.
 		wantIssues []string
 	}{
 		{
-			name:       "pet-only machine skips work repos",
+			name:       "pet-only machine skips work and unregistered repos",
 			allowsType: petOnly,
 			wantIssues: []string{
 				"https://github.com/acme/pet1/issues/1",
 				"https://github.com/acme/pet2/issues/2",
-				"https://github.com/ext/tool/issues/4",
 			},
 		},
 		{
-			name:       "work-only machine skips pet repos",
+			name:       "work-only machine skips pet and unregistered repos",
 			allowsType: workOnly,
 			wantIssues: []string{
 				"https://github.com/bigco/work1/issues/3",
-				"https://github.com/ext/tool/issues/4",
 			},
 		},
 		{
-			name:       "allow-all accepts every registered and unregistered repo",
+			name:       "allow-all accepts every registered repo but drops unregistered",
 			allowsType: allowAll,
 			wantIssues: []string{
 				"https://github.com/acme/pet1/issues/1",
 				"https://github.com/acme/pet2/issues/2",
 				"https://github.com/bigco/work1/issues/3",
-				"https://github.com/ext/tool/issues/4",
 			},
 		},
 	}


### PR DESCRIPTION
## Motivation

After enabling `GH_TOKEN` on the home-nas deploy, the GitHub issues fetcher immediately auto-created 6 task cards from `kumahq/kuma` (assigned issues on the authenticated user's account) even though kuma is not a registered project in synapse — only `Automaat/synapse` is. Synapse should only track work for repos the user has explicitly added as projects.

## Implementation information

`syncIssuesToTasks` previously let unregistered repos pass through by design — the prior filter only dropped issues from *registered* projects whose type wasn't allowed on this machine, and the matching test case asserted that "unregistered repos always pass through".

This PR inverts that: if `f.projects.Get(issue.Repository)` returns an error (repo is not a registered project), the issue is dropped. Type filtering still applies for registered projects. The enrichment path (existing task with URL-as-title) is also now gated on the repo being registered — consistent with "synapse doesn't track non-project work". Since the project is now guaranteed present past the filter, the two duplicated `projects.Get` calls used only for setting `ProjectID` on the task Update are collapsed into unconditional assignments.

Tests updated:
- `TestIssuesFetcher_SyncIssuesToTasks_FiltersByProjectType` — 3 existing cases dropped the `ext/tool/issues/4` URL from their expectations, test-case names updated to reflect the new behavior.

`syncLabeledIssuesToTasks` is unaffected — it already iterates `projects.List()` and only queries registered repos.

## Supporting documentation

None.

> Changelog: fix(issues): only sync from registered projects