### PR TITLE
feat(triage): Go classifier + bg worker

### DIFF
--- a/.claude/skills/synapse-triage.md
+++ b/.claude/skills/synapse-triage.md
@@ -1,209 +1,47 @@
 ---
 name: synapse-triage
-description: Triage Synapse tasks — read incoming tasks, categorize, set priority tags, assign agent mode. Use when asked to triage, categorize, or prioritize tasks.
-allowed-tools: Bash, Read, WebFetch
+description: Triage Synapse tasks — delegate to the Go classifier which rewrites the title, assigns tags/mode/status, and matches a project in one atomic update. Use when asked to triage, categorize, or prioritize tasks.
+allowed-tools: Bash
 user-invocable: true
 ---
 
 # Synapse Task Triage
 
-Triage incoming tasks: analyze content, assign tags, set appropriate agent mode, update status.
-
-## CLI Reference
-
-The ONLY valid flags for `synapse-cli update` are: `--title`, `--status`, `--body`, `--mode`, `--tags`, `--project`. Do NOT use `--agent-mode` or any other flag — they do not exist and will error.
-
-## Constraints
-
-- Do NOT explore the codebase, read source files, or spawn sub-agents
-- Triage based on title, body, and URL context only
-- Keep total cost under $0.05 per task
-- Code exploration happens during planning/implementation, not triage
-- Ignore agent runs with a `role` field (triage, plan, eval, pr-fix) — those are system agents, not implementation agents
-- Always shorten titles >80 chars — keep them actionable/descriptive, not just truncated
-- When shortening, move the verbose original title into the task body (prepend, preserve existing content)
+Classify pending tasks via the Go classifier. Go owns routing rules, tag validation, project auto-match, and atomic multi-field updates. The LLM only produces the structured verdict.
 
 ## Process
 
-### 1. List pending tasks
+1. List pending tasks:
 
-```bash
-synapse-cli --json list --status new
-```
+   ```bash
+   synapse-cli --json list --status new
+   ```
 
-### 2. For each task, analyze and categorize
+2. For each task, run the classifier:
 
-Read the task body to understand scope:
+   ```bash
+   synapse-cli --json triage classify <id>
+   ```
 
-```bash
-synapse-cli --json get <id>
-```
+   This makes a single `claude -p` call that:
+   - Rewrites the title into a clean imperative conventional-commit form (always, even if the input already looked fine)
+   - Preserves the original title in the body
+   - Assigns tags from the controlled vocabulary (backend, frontend, infra, docs, ci, auth, db, test + size + type)
+   - Picks size (small|medium|large), type (bug|feature|refactor|review|chore|docs), and mode (headless|interactive)
+   - Auto-matches a registered project if a github.com URL is in the title or body
+   - Applies routing rules (medium/large features → planning; everything else → todo)
+   - Forces `interactive` mode for `work` projects unless it's a PR review
+   - Writes a `triage.classified` audit event
 
-If the task title or body is just a URL with no description, fetch context and enrich the task:
+3. Batch mode for larger queues:
 
-```bash
-# GitHub PR
-gh pr view <url> --json title,body,files,additions,deletions
+   ```bash
+   synapse-cli --json triage classify --all
+   ```
 
-# GitHub issue
-gh issue view <url> --json title,body,labels,comments
+## Constraints
 
-# Generic URL — use WebFetch to read page title/content
-```
-
-Update the task with a human-readable summary — replace the raw URL title with what it actually is, add key details to body, preserve original URL:
-
-```bash
-synapse-cli --json update <id> \
-  --title "<concise title from fetched context>" \
-  --body "Source: <url>
-Files: N changed (+A/-D)
-
-<description excerpt, max ~500 chars>"
-```
-
-### 3. Detect and rewrite freeform instruction-style titles
-
-Check if the title looks like natural-language/casual instruction rather than a structured task title. Indicators:
-
-- Starts with "i ", "we ", "maybe ", "i think", "i want", "could we", "let's", "should we", etc.
-- Written as a sentence/thought, not an imperative action
-- Contains filler phrases like "i often", "i feel like", "sometimes", "random stuff"
-- Clearly conversational in tone
-
-If detected, rewrite the title as a concise, imperative, structured task title. Move the original freeform text into the body so context is preserved.
-
-<example>
-Input title: "in synapse i often write random stuff as task name"
-Output title: "feat(triage): rewrite freeform titles into structured task titles"
-</example>
-
-<example>
-Input title: "i think we should add auth"
-Output title: "feat(auth): add authentication"
-</example>
-
-<example>
-Input title: "make the button blue"
-Output title: "fix(ui): change button color to blue"
-</example>
-
-Use conventional commit format (`type(scope): description`) when the domain/type is clear. Otherwise use a plain imperative title.
-
-```bash
-synapse-cli --json update <id> \
-  --title "<structured imperative title>" \
-  --body "**Original instruction:** <original freeform title>
-
-<existing body content preserved here>"
-```
-
-Skip if the title is already structured/imperative.
-
-### 4. Shorten title if too long
-
-If the title exceeds 80 characters, rewrite it as a concise ≤80 char summary. Move the original verbose title into the task body so no context is lost.
-
-Read the current body first (already done in step 2), then update with both `--title` and `--body` in a single call:
-
-```bash
-synapse-cli --json update <id> \
-  --title "<concise summary ≤80 chars>" \
-  --body "**Original title:** <original verbose title>
-
-<existing body content preserved here>"
-```
-
-- Keep the rewritten title actionable and descriptive — summarize intent, don't just truncate
-- If the task already has body content, prepend the original title line above it
-- Skip if title is already ≤80 chars
-
-### 5. Add brief description if missing
-
-If the task body is empty or has no meaningful context beyond a URL, add a 2-3 sentence description based on what you know from the title, URL context (if fetched), and general understanding. Do NOT explore the codebase or read source files — just clarify what the task is about and what "done" looks like.
-
-```bash
-synapse-cli --json update <id> \
-  --body "Brief description of what needs to happen and expected outcome.
-
-Original context preserved here if any."
-```
-
-Skip if the task already has a clear, descriptive body.
-
-### 6. Assign tags based on analysis
-
-Common tag categories:
-- **Domain**: `backend`, `frontend`, `infra`, `docs`, `ci`
-- **Size**: `small`, `medium`, `large`
-- **Type**: `bug`, `feature`, `refactor`, `review`
-
-```bash
-synapse-cli --json update <id> --tags "backend,small,review"
-```
-
-### 7. Set agent mode
-
-- `headless` — automated tasks: code reviews, simple fixes, test writing
-- `interactive` — tasks needing human guidance: architecture decisions, complex debugging
-
-```bash
-synapse-cli --json update <id> --mode headless
-```
-
-### 8. Assign project (if applicable)
-
-Check if the task references a known project (GitHub repo). List available projects:
-
-```bash
-synapse-cli --json project list
-```
-
-If the task body/URL matches a registered project, assign it:
-
-```bash
-synapse-cli --json update <id> --project "owner/repo"
-```
-
-After assigning, look up the project type:
-
-```bash
-synapse-cli --json project get "owner/repo"
-```
-
-If `type` is `work`, apply these overrides in the next steps:
-- Force `planning` status for medium/large features (regardless of other signals)
-- Set mode to `interactive` unless the task is a PR review
-- Add note to body: "Work project — enforcing higher standards"
-
-### 9. Decide: planning or direct implementation
-
-Complex tasks go to `planning` status (triggers auto-planning agent). Simple tasks go to `todo`.
-
-```bash
-# Complex tasks: medium/large features, architecture decisions → planning
-synapse-cli --json update <id> --status planning
-
-# Simple tasks: small bugs, refactors, reviews, chores → todo
-synapse-cli --json update <id> --status todo
-```
-
-| Signal | Status |
-|--------|--------|
-| Size `medium` or `large` + type `feature` | planning |
-| Architecture decision, unclear scope | planning |
-| Size `small`, type `bug`/`refactor`/`review`/`chore` | todo |
-| PR review | todo |
-| **Work project** + size `medium`/`large` + type `feature` | planning (forced) |
-
-Step 8 already sets the status — no further status update needed. Skip if a previous step already changed the status.
-
-## Decision Criteria
-
-| Signal | Mode | Tags |
-|--------|------|------|
-| PR review URL | headless | review, size based on diff |
-| Bug report with repro | headless | bug, domain from stack trace |
-| Feature request, unclear scope | interactive | feature, large |
-| Simple refactor/rename | headless | refactor, small |
-| Architecture decision | interactive | feature, large |
+- Do NOT call `synapse-cli update` directly during triage — the Go classifier owns every field change. Manual updates will race the classifier and break audit trails.
+- Do NOT explore the codebase or read source files — the classifier sees only `{title, body, registered projects}`. Codebase exploration belongs in planning/implementation.
+- If `classify` returns an error, flag the task with `synapse-cli update <id> --status human-required --status-reason "triage failed"` and move on.
+- Ignore tasks with `role` field set (triage, plan, eval, pr-fix) — those are system agents, not implementation work.

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -79,6 +79,8 @@ func run(args []string) int {
 		return cmdBoard(store, jsonOut)
 	case "health":
 		return cmdHealth(cfg, rest, jsonOut)
+	case "triage":
+		return cmdTriage(cfg, store, projStore, rest, jsonOut)
 	default:
 		return fatal(jsonOut, "unknown command: %s", cmd)
 	}
@@ -842,6 +844,9 @@ Commands:
   audit    [--since DURATION|DATE] [--until DATE] [--type TYPE] [--task ID] [--summary]
   board    (status counts + in-progress/plan-review/human-required task lists)
   health   [--severity warning|critical] [--category CATEGORY]
+
+  triage classify <id>         Classify a single task via claude -p and apply the verdict.
+  triage classify --all        Classify every task with status=new.
 
 Global flags:
   --json   Output as JSON`)

--- a/cmd/synapse-cli/triage.go
+++ b/cmd/synapse-cli/triage.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/Automaat/synapse/internal/audit"
+	"github.com/Automaat/synapse/internal/config"
+	"github.com/Automaat/synapse/internal/project"
+	"github.com/Automaat/synapse/internal/task"
+	"github.com/Automaat/synapse/internal/triage"
+)
+
+// triageResult is the CLI's JSON output for a classify call.
+type triageResult struct {
+	Verdict triage.Verdict `json:"verdict"`
+	Task    task.Task      `json:"task"`
+}
+
+func cmdTriage(
+	cfg *config.Config,
+	store *task.Manager,
+	projStore *project.Store,
+	args []string,
+	jsonOut bool,
+) int {
+	if len(args) == 0 {
+		return fatal(jsonOut, "usage: triage <classify> [flags]")
+	}
+	sub, rest := args[0], args[1:]
+	switch sub {
+	case "classify":
+		return cmdTriageClassify(cfg, store, projStore, rest, jsonOut)
+	default:
+		return fatal(jsonOut, "unknown triage command: %s", sub)
+	}
+}
+
+func cmdTriageClassify(
+	cfg *config.Config,
+	store *task.Manager,
+	projStore *project.Store,
+	args []string,
+	jsonOut bool,
+) int {
+	fs := flag.NewFlagSet("triage classify", flag.ContinueOnError)
+	all := fs.Bool("all", false, "classify every task with status=new")
+	model := fs.String("model", cfg.Triage.Model, "claude model")
+	timeout := fs.Duration("timeout", 2*time.Minute, "per-task LLM timeout")
+	if err := fs.Parse(args); err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+
+	projects, err := projStore.List()
+	if err != nil {
+		return fatal(jsonOut, "list projects: %v", err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	classifier := &triage.ClaudeClassifier{Model: *model, Logger: logger}
+	al, _ := audit.NewLogger(cfg.AuditDir())
+
+	var targets []task.Task
+	switch {
+	case *all:
+		list, listErr := store.List()
+		if listErr != nil {
+			return fatal(jsonOut, "list tasks: %v", listErr)
+		}
+		for i := range list {
+			if list[i].Status == task.StatusNew {
+				targets = append(targets, list[i])
+			}
+		}
+	case len(fs.Args()) == 1:
+		id := fs.Args()[0]
+		t, getErr := store.Get(id)
+		if getErr != nil {
+			return fatal(jsonOut, "get %s: %v", id, getErr)
+		}
+		targets = append(targets, t)
+	default:
+		return fatal(jsonOut, "usage: triage classify <id> | triage classify --all")
+	}
+
+	if len(targets) == 0 {
+		if jsonOut {
+			return printJSON([]triageResult{})
+		}
+		fmt.Println("no tasks to classify")
+		return 0
+	}
+
+	results := make([]triageResult, 0, len(targets))
+	var hadErr bool
+	for i := range targets {
+		result, classErr := classifyOne(classifier, store, al, targets[i], projects, *timeout)
+		if classErr != nil {
+			hadErr = true
+			if jsonOut {
+				fmt.Fprintf(os.Stderr, `{"error":"classify %s: %v"}`+"\n", targets[i].ID, classErr)
+			} else {
+				fmt.Fprintf(os.Stderr, "classify %s: %v\n", targets[i].ID, classErr)
+			}
+			continue
+		}
+		results = append(results, result)
+	}
+
+	if jsonOut {
+		switch {
+		case *all:
+			_ = printJSON(results)
+		case len(results) == 1:
+			_ = printJSON(results[0])
+		default:
+			_ = printJSON(results)
+		}
+	} else {
+		for i := range results {
+			fmt.Printf("Classified %s → %s (%s, %s, %s)\n",
+				results[i].Task.ID,
+				results[i].Verdict.Title,
+				results[i].Verdict.Size,
+				results[i].Verdict.Type,
+				results[i].Task.Status,
+			)
+		}
+	}
+
+	if hadErr {
+		return 1
+	}
+	return 0
+}
+
+func classifyOne(
+	classifier triage.Classifier,
+	store *task.Manager,
+	al *audit.Logger,
+	t task.Task,
+	projects []project.Project,
+	timeout time.Duration,
+) (triageResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	v, err := classifier.Classify(ctx, t, projects)
+	if err != nil {
+		return triageResult{}, err
+	}
+	updated, err := triage.Apply(store, t, v, projects)
+	if err != nil {
+		return triageResult{}, err
+	}
+	if al != nil {
+		_ = al.Log(audit.Event{
+			Type:   audit.EventTriageClassified,
+			TaskID: t.ID,
+			Data: map[string]any{
+				"title":      v.Title,
+				"tags":       v.Tags,
+				"size":       v.Size,
+				"type":       v.Type,
+				"mode":       v.Mode,
+				"project_id": updated.ProjectID,
+				"status":     string(updated.Status),
+			},
+		})
+	}
+	return triageResult{Verdict: v, Task: updated}, nil
+}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -10,6 +10,7 @@ const (
 	EventAgentCompleted      = "agent.completed"
 	EventAgentFailed         = "agent.failed"
 	EventTriageCompleted     = "triage.completed"
+	EventTriageClassified    = "triage.classified"
 	EventPlanCompleted       = "plan.completed"
 	EventPlanApproved        = "plan.approved"
 	EventPlanRejected        = "plan.rejected"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	Todoist       TodoistConfig      `yaml:"todoist" json:"todoist"`
 	Renovate      RenovateConfig     `yaml:"renovate" json:"renovate"`
 	GitHub        GitHubConfig       `yaml:"github" json:"github"`
+	Triage        TriageConfig       `yaml:"triage" json:"triage"`
 	Providers     ProvidersConfig    `yaml:"providers" json:"providers"`
 	Metrics       MetricsConfig      `yaml:"metrics" json:"metrics"`
 	ProjectTypes  []string           `yaml:"project_types" json:"projectTypes"`
@@ -108,6 +109,15 @@ type RenovateConfig struct {
 
 type GitHubConfig struct {
 	Enabled bool `yaml:"enabled" json:"enabled"`
+}
+
+// TriageConfig controls the background auto-triage worker. When Enabled,
+// synapse periodically classifies tasks in status=new via claude -p and
+// atomically applies the verdict (title, tags, size/type, mode, project).
+type TriageConfig struct {
+	Enabled     bool   `yaml:"enabled" json:"enabled"`
+	PollSeconds int    `yaml:"poll_seconds" json:"pollSeconds"`
+	Model       string `yaml:"model" json:"model"`
 }
 
 // ProvidersConfig groups per-machine routing for CLI providers (claude, codex)
@@ -281,6 +291,12 @@ func Load() (*Config, error) {
 
 	if cfg.Renovate.Author == "" {
 		cfg.Renovate.Author = "app/renovate"
+	}
+	if cfg.Triage.PollSeconds <= 0 {
+		cfg.Triage.PollSeconds = 60
+	}
+	if cfg.Triage.Model == "" {
+		cfg.Triage.Model = "sonnet"
 	}
 	if cfg.Agent.Provider == "" {
 		cfg.Agent.Provider = "claude"

--- a/internal/poll/triage.go
+++ b/internal/poll/triage.go
@@ -1,0 +1,141 @@
+package poll
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/Automaat/synapse/internal/audit"
+	"github.com/Automaat/synapse/internal/config"
+	"github.com/Automaat/synapse/internal/project"
+	"github.com/Automaat/synapse/internal/task"
+	"github.com/Automaat/synapse/internal/triage"
+)
+
+// classifierFactory lets tests inject a fake classifier. Production
+// callers leave it nil and the handler constructs a *triage.ClaudeClassifier.
+type classifierFactory func(model string, logger *slog.Logger) triage.Classifier
+
+// TriageHandler runs the auto-triage loop. Each poll cycle:
+//  1. Lists tasks in status=new.
+//  2. For each, runs triage.Classify + triage.Apply.
+//  3. Writes a triage.classified audit event.
+//
+// Classification is serial to avoid rate-limit surprises. The worker is
+// opt-in per machine via config.Triage.Enabled.
+type TriageHandler struct {
+	tasks      *task.Manager
+	projects   *project.Store
+	cfg        *config.TriageConfig
+	logger     *slog.Logger
+	audit      *audit.Logger
+	factory    classifierFactory
+	perTaskTTL time.Duration
+}
+
+// NewTriageHandler constructs a TriageHandler.
+func NewTriageHandler(
+	tasks *task.Manager,
+	projects *project.Store,
+	al *audit.Logger,
+	logger *slog.Logger,
+	cfg *config.TriageConfig,
+) *TriageHandler {
+	return &TriageHandler{
+		tasks:      tasks,
+		projects:   projects,
+		cfg:        cfg,
+		logger:     logger,
+		audit:      al,
+		perTaskTTL: 2 * time.Minute,
+	}
+}
+
+// Name implements poll.Fetcher.
+func (h *TriageHandler) Name() string { return "triage" }
+
+// Poll implements poll.Fetcher. Returns the next poll interval.
+func (h *TriageHandler) Poll(ctx context.Context) time.Duration {
+	interval := time.Duration(h.cfg.PollSeconds) * time.Second
+	if interval <= 0 {
+		interval = 60 * time.Second
+	}
+
+	tasks, err := h.tasks.List()
+	if err != nil {
+		h.logger.Warn("triage.list", "err", err)
+		return interval
+	}
+
+	projects, err := h.projects.List()
+	if err != nil {
+		h.logger.Warn("triage.projects", "err", err)
+		return interval
+	}
+
+	classifier := h.buildClassifier()
+
+	var classified int
+	for i := range tasks {
+		if ctx.Err() != nil {
+			return interval
+		}
+		t := tasks[i]
+		if t.Status != task.StatusNew {
+			continue
+		}
+		if !t.UpdatedAt.IsZero() && time.Since(t.UpdatedAt) < 5*time.Second {
+			continue
+		}
+		h.classifyOne(ctx, classifier, t, projects)
+		classified++
+	}
+
+	if classified > 0 {
+		h.logger.Info("triage.poll", "classified", classified)
+	}
+	return interval
+}
+
+func (h *TriageHandler) buildClassifier() triage.Classifier {
+	if h.factory != nil {
+		return h.factory(h.cfg.Model, h.logger)
+	}
+	return &triage.ClaudeClassifier{Model: h.cfg.Model, Logger: h.logger}
+}
+
+func (h *TriageHandler) classifyOne(
+	parent context.Context,
+	classifier triage.Classifier,
+	t task.Task,
+	projects []project.Project,
+) {
+	ctx, cancel := context.WithTimeout(parent, h.perTaskTTL)
+	defer cancel()
+
+	v, err := classifier.Classify(ctx, t, projects)
+	if err != nil {
+		h.logger.Warn("triage.classify", "task", t.ID, "err", err)
+		return
+	}
+	updated, err := triage.Apply(h.tasks, t, v, projects)
+	if err != nil {
+		h.logger.Warn("triage.apply", "task", t.ID, "err", err)
+		return
+	}
+	if h.audit != nil {
+		_ = h.audit.Log(audit.Event{
+			Type:   audit.EventTriageClassified,
+			TaskID: t.ID,
+			Data: map[string]any{
+				"title":      v.Title,
+				"tags":       v.Tags,
+				"size":       v.Size,
+				"type":       v.Type,
+				"mode":       v.Mode,
+				"project_id": updated.ProjectID,
+				"status":     string(updated.Status),
+			},
+		})
+	}
+}

--- a/internal/poll/triage_test.go
+++ b/internal/poll/triage_test.go
@@ -1,0 +1,91 @@
+package poll
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/Automaat/synapse/internal/config"
+	"github.com/Automaat/synapse/internal/project"
+	"github.com/Automaat/synapse/internal/task"
+	"github.com/Automaat/synapse/internal/triage"
+)
+
+type fakeClassifier struct {
+	calls int
+}
+
+func (f *fakeClassifier) Classify(_ context.Context, t task.Task, _ []project.Project) (triage.Verdict, error) {
+	f.calls++
+	return triage.Verdict{
+		Title: "feat(x): " + t.Title,
+		Size:  "small",
+		Type:  "bug",
+		Mode:  "headless",
+		Tags:  []string{"backend", "small", "bug"},
+	}, nil
+}
+
+func TestTriageHandlerClassifiesNewTasks(t *testing.T) {
+	dir := t.TempDir()
+	ts, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	mgr := task.NewManager(ts, nil)
+
+	_, err = mgr.Create("a task", "body", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	_, err = mgr.Create("another", "body2", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Skip debounce: backdate updated_at by mutating status to todo+back.
+	// Simpler: use short perTaskTTL and override the debounce via sleep.
+	time.Sleep(10 * time.Millisecond)
+
+	projDir := t.TempDir()
+	ps, err := project.NewStore(projDir, t.TempDir())
+	if err != nil {
+		t.Fatalf("project.NewStore: %v", err)
+	}
+
+	fc := &fakeClassifier{}
+	h := NewTriageHandler(mgr, ps, nil,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		&config.TriageConfig{Enabled: true, PollSeconds: 5, Model: "sonnet"})
+	h.factory = func(string, *slog.Logger) triage.Classifier { return fc }
+	// Disable the 5-second debounce for the test.
+	h.perTaskTTL = time.Second
+
+	// The handler skips tasks whose updated_at < 5s; backdate manually.
+	list, _ := mgr.List()
+	for i := range list {
+		_, err := mgr.UpdateMap(list[i].ID, map[string]any{"status_reason": "seed"})
+		if err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	// Wait past 5s debounce. Use a tighter override: set perTaskTTL does not affect debounce.
+	// Instead, bypass by directly calling classifyOne for each target.
+	projects, _ := ps.List()
+	for i := range list {
+		updated, _ := mgr.Get(list[i].ID)
+		h.classifyOne(context.Background(), fc, updated, projects)
+	}
+
+	if fc.calls != 2 {
+		t.Errorf("classifier calls: got %d, want 2", fc.calls)
+	}
+	after, _ := mgr.List()
+	for i := range after {
+		if after[i].Status == task.StatusNew {
+			t.Errorf("task %s still new", after[i].ID)
+		}
+	}
+}

--- a/internal/synapse/app.go
+++ b/internal/synapse/app.go
@@ -68,6 +68,7 @@ type App struct {
 	todoistHandler  *poll.TodoistHandler
 	todoistCancel   context.CancelFunc
 	renovateHandler *poll.RenovateHandler
+	triageHandler   *poll.TriageHandler
 	cfg             *config.Config
 	logLevel        *slog.LevelVar
 	emit            func(string, any)
@@ -243,6 +244,7 @@ func (a *App) Startup(ctx context.Context) error {
 
 	a.initTodoist(emit)
 	a.initRenovate(emit)
+	a.initTriage()
 	issuesFetcher := a.initIssuesFetcher(emit)
 	a.wireServices(emit)
 
@@ -341,6 +343,9 @@ func (a *App) startPollHub(ctx context.Context, issuesFetcher *poll.IssuesFetche
 	if a.renovateHandler != nil {
 		hub.Register(a.renovateHandler, 15*time.Second)
 	}
+	if a.triageHandler != nil {
+		hub.Register(a.triageHandler, 30*time.Second)
+	}
 	hub.Start(ctx, &a.wg, a.logger)
 }
 
@@ -382,6 +387,7 @@ func (a *App) logAutomationsSummary() {
 		"todoist", a.cfg.Todoist.Enabled && a.cfg.Todoist.APIToken != "",
 		"github", a.cfg.GitHub.Enabled,
 		"renovate", a.cfg.Renovate.Enabled,
+		"triage", a.cfg.Triage.Enabled,
 		"project_types", projectTypes,
 		"loop_agents_enabled", loopAgentsEnabled,
 	)

--- a/internal/synapse/app_triage.go
+++ b/internal/synapse/app_triage.go
@@ -1,0 +1,14 @@
+package synapse
+
+import "github.com/Automaat/synapse/internal/poll"
+
+// initTriage constructs the background auto-triage handler if enabled.
+// The handler is registered with the poll hub in startPollHub alongside
+// renovate and the issues fetcher.
+func (a *App) initTriage() {
+	if !a.cfg.Triage.Enabled {
+		return
+	}
+	a.triageHandler = poll.NewTriageHandler(a.tasks, a.projects, a.audit, a.logger, &a.cfg.Triage)
+	a.logger.Info("triage.enabled", "poll_seconds", a.cfg.Triage.PollSeconds, "model", a.cfg.Triage.Model)
+}

--- a/internal/triage/apply.go
+++ b/internal/triage/apply.go
@@ -1,0 +1,87 @@
+package triage
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Automaat/synapse/internal/project"
+	"github.com/Automaat/synapse/internal/task"
+)
+
+// Apply writes the classifier verdict to the task via Manager.UpdateMap.
+// All field changes happen in a single UpdateMap call so the write is
+// atomic per task (Manager holds a per-task mutex).
+//
+// projects is used to look up the project type after ProjectID is matched,
+// which feeds into routing rules (work projects force interactive mode).
+func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project) (task.Task, error) {
+	updates := make(map[string]any, 8)
+
+	projectID := v.ProjectID
+	if projectID == "" {
+		projectID = MatchProject(t.Title, t.Body, projects)
+	}
+
+	projectType := ""
+	if projectID != "" {
+		for i := range projects {
+			if projects[i].ID == projectID {
+				projectType = string(projects[i].Type)
+				break
+			}
+		}
+	}
+
+	newTitle := strings.TrimSpace(v.Title)
+	if newTitle == "" {
+		return task.Task{}, fmt.Errorf("empty verdict title")
+	}
+	if newTitle != t.Title {
+		updates["title"] = newTitle
+		updates["body"] = prependOriginalTitle(t.Body, t.Title)
+	}
+
+	if strings.TrimSpace(t.Body) == "" && v.Description != "" {
+		body := v.Description
+		if existing, ok := updates["body"].(string); ok {
+			body = existing + "\n\n" + v.Description
+		}
+		updates["body"] = body
+	}
+
+	if len(v.Tags) > 0 {
+		updates["tags"] = v.Tags
+	}
+
+	mode := RouteMode(v.Mode, v.Type, projectType)
+	updates["agent_mode"] = mode
+
+	if projectID != "" {
+		updates["project_id"] = projectID
+	}
+
+	status := RouteStatus(v.Size, v.Type, projectType)
+	updates["status"] = string(status)
+	updates["status_reason"] = "triage"
+
+	updated, err := mgr.UpdateMap(t.ID, updates)
+	if err != nil {
+		return task.Task{}, fmt.Errorf("update task: %w", err)
+	}
+	return updated, nil
+}
+
+// prependOriginalTitle adds a line preserving the original verbose title
+// above any existing body content. Idempotent: if the body already contains
+// the original-title marker, it is returned unchanged.
+func prependOriginalTitle(body, originalTitle string) string {
+	marker := "**Original title:** "
+	if strings.Contains(body, marker) {
+		return body
+	}
+	line := marker + originalTitle
+	if strings.TrimSpace(body) == "" {
+		return line
+	}
+	return line + "\n\n" + body
+}

--- a/internal/triage/apply_test.go
+++ b/internal/triage/apply_test.go
@@ -1,0 +1,130 @@
+package triage
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Automaat/synapse/internal/project"
+	"github.com/Automaat/synapse/internal/task"
+)
+
+func newTestManager(t *testing.T) *task.Manager {
+	t.Helper()
+	dir := t.TempDir()
+	s, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return task.NewManager(s, nil)
+}
+
+func TestApplyRewritesTitleAndPreservesOriginal(t *testing.T) {
+	mgr := newTestManager(t)
+	created, err := mgr.Create("i often write random stuff as task name", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	v := Verdict{
+		Title:         "feat(triage): rewrite freeform titles into structured form",
+		OriginalTitle: created.Title,
+		Tags:          []string{"backend", "small", "feature"},
+		Size:          "small",
+		Type:          "feature",
+		Mode:          "headless",
+	}
+	updated, err := Apply(mgr, created, v, nil)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if updated.Title != v.Title {
+		t.Errorf("title not updated: got %q", updated.Title)
+	}
+	if !strings.Contains(updated.Body, "**Original title:**") {
+		t.Errorf("body missing original title marker: %q", updated.Body)
+	}
+	if !strings.Contains(updated.Body, "i often write random stuff") {
+		t.Errorf("body missing original title text: %q", updated.Body)
+	}
+	if updated.Status != task.StatusTodo {
+		t.Errorf("status: got %s, want todo", updated.Status)
+	}
+	if updated.StatusReason != "triage" {
+		t.Errorf("status_reason: got %q", updated.StatusReason)
+	}
+	if len(updated.Tags) != 3 {
+		t.Errorf("tags: got %v", updated.Tags)
+	}
+}
+
+func TestApplyMediumFeatureGoesToPlanning(t *testing.T) {
+	mgr := newTestManager(t)
+	created, err := mgr.Create("add auth middleware", "some body", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	v := Verdict{
+		Title: "feat(auth): add JWT middleware",
+		Size:  "medium",
+		Type:  "feature",
+		Mode:  "headless",
+		Tags:  []string{"backend", "medium", "feature"},
+	}
+	updated, err := Apply(mgr, created, v, nil)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if updated.Status != task.StatusPlanning {
+		t.Errorf("status: got %s, want planning", updated.Status)
+	}
+}
+
+func TestApplyWorkProjectForcesInteractive(t *testing.T) {
+	mgr := newTestManager(t)
+	created, err := mgr.Create("refactor ingestion", "https://github.com/myco/work-repo/issues/1", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	projects := []project.Project{
+		{ID: "myco/work-repo", Owner: "myco", Repo: "work-repo", Type: project.ProjectTypeWork},
+	}
+	v := Verdict{
+		Title: "refactor(ingestion): split pipeline stages",
+		Size:  "small",
+		Type:  "refactor",
+		Mode:  "headless",
+		Tags:  []string{"backend", "small", "refactor"},
+	}
+	updated, err := Apply(mgr, created, v, projects)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if updated.AgentMode != task.AgentModeInteractive {
+		t.Errorf("mode: got %q, want interactive", updated.AgentMode)
+	}
+	if updated.ProjectID != "myco/work-repo" {
+		t.Errorf("project_id: got %q", updated.ProjectID)
+	}
+}
+
+func TestApplyEmptyBodyFillsDescription(t *testing.T) {
+	mgr := newTestManager(t)
+	created, err := mgr.Create("https://example.com/thing", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	v := Verdict{
+		Title:       "docs(thing): update API reference",
+		Description: "Update the example.com thing's API docs to match the new schema.",
+		Size:        "small",
+		Type:        "docs",
+		Mode:        "headless",
+		Tags:        []string{"docs", "small"},
+	}
+	updated, err := Apply(mgr, created, v, nil)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !strings.Contains(updated.Body, "example.com thing") {
+		t.Errorf("body missing description: %q", updated.Body)
+	}
+}

--- a/internal/triage/classifier.go
+++ b/internal/triage/classifier.go
@@ -1,0 +1,188 @@
+package triage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"strings"
+
+	"github.com/Automaat/synapse/internal/project"
+	"github.com/Automaat/synapse/internal/task"
+)
+
+// Classifier wraps the claude -p invocation. Exposed as an interface so
+// tests can inject a canned verdict without shelling out.
+type Classifier interface {
+	Classify(ctx context.Context, t task.Task, projects []project.Project) (Verdict, error)
+}
+
+// ClaudeClassifier is the production implementation. It spawns `claude -p`
+// with a strict JSON schema prompt and parses the envelope.
+type ClaudeClassifier struct {
+	Model  string       // default: "sonnet"
+	Logger *slog.Logger // required
+}
+
+// Classify shells out to claude -p and returns a validated verdict.
+func (c *ClaudeClassifier) Classify(ctx context.Context, t task.Task, projects []project.Project) (Verdict, error) {
+	model := c.Model
+	if model == "" {
+		model = "sonnet"
+	}
+
+	prompt := buildPrompt(t, projects)
+
+	cmd := exec.CommandContext(ctx, "claude",
+		"-p", prompt,
+		"--output-format", "json",
+		"--dangerously-skip-permissions",
+		"--model", model,
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return Verdict{}, fmt.Errorf("claude -p: %w", err)
+	}
+
+	v, err := parseVerdict(out)
+	if err != nil {
+		return Verdict{}, fmt.Errorf("parse verdict: %w", err)
+	}
+	if err := ValidateVerdict(&v); err != nil {
+		return Verdict{}, fmt.Errorf("validate verdict: %w", err)
+	}
+	return v, nil
+}
+
+func buildPrompt(t task.Task, projects []project.Project) string {
+	var b strings.Builder
+	b.WriteString(`You are triaging a task from a task-management system.
+Classify it into a strict JSON verdict. Output ONLY a single JSON object on the final line, nothing else before or after.
+
+Rules:
+- title: ALWAYS rewrite into a clean, human-readable, imperative conventional-commit-style title (e.g. "feat(auth): add JWT middleware", "fix(api): handle nil pointer on empty body"). Even if the input title already looks fine, produce your best version. Max 80 chars.
+- original_title: copy the input title verbatim so the user can recover it later.
+- description: ONLY set if the input body is empty/just-a-URL. 2-3 sentences describing what the task is about and what "done" looks like. Otherwise leave empty string.
+- tags: pick from: backend, frontend, infra, docs, ci, auth, db, test. Also include one of small|medium|large and one of bug|feature|refactor|review|chore|docs. 2-5 tags total.
+- size: small|medium|large
+- type: bug|feature|refactor|review|chore|docs
+- mode: headless (automated, no human-in-the-loop needed) or interactive (needs human judgment during execution)
+- project_id: if the task title or body contains a github.com URL matching one of the registered projects below, set this to that project's "owner/repo". Otherwise empty string.
+
+Decision guide for mode:
+- PR review, simple fix, test writing, refactor → headless
+- Architecture decision, unclear scope, complex debugging → interactive
+
+Decision guide for size:
+- small: <50 LOC, single file, trivial
+- medium: multiple files, clear scope, design mostly known
+- large: cross-cutting, new subsystem, or unclear scope
+
+Output schema (single JSON object):
+{"title":"...","original_title":"...","description":"","tags":["..."],"size":"small","type":"feature","mode":"headless","project_id":""}
+
+`)
+
+	if len(projects) > 0 {
+		b.WriteString("Registered projects:\n")
+		for i := range projects {
+			b.WriteString("- ")
+			b.WriteString(projects[i].ID)
+			b.WriteString(" (")
+			b.WriteString(string(projects[i].Type))
+			b.WriteString(")\n")
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("Task to classify:\n")
+	b.WriteString("TITLE: ")
+	b.WriteString(t.Title)
+	b.WriteString("\nBODY:\n")
+	if strings.TrimSpace(t.Body) == "" {
+		b.WriteString("(empty)\n")
+	} else {
+		b.WriteString(t.Body)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// parseVerdict extracts the verdict from `claude -p --output-format json` stdout.
+// The top-level response has a `result` string field containing the model's
+// final message, from which we extract the last JSON object.
+func parseVerdict(raw []byte) (Verdict, error) {
+	var envelope struct {
+		Result string `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return Verdict{}, fmt.Errorf("unmarshal envelope: %w", err)
+	}
+	if envelope.Result == "" {
+		return Verdict{}, fmt.Errorf("empty result field")
+	}
+	jsonStr := extractLastJSONObject(envelope.Result)
+	if jsonStr == "" {
+		return Verdict{}, fmt.Errorf("no JSON object in result: %q", envelope.Result)
+	}
+	var v Verdict
+	if err := json.Unmarshal([]byte(jsonStr), &v); err != nil {
+		return Verdict{}, fmt.Errorf("unmarshal verdict: %w", err)
+	}
+	return v, nil
+}
+
+// extractLastJSONObject returns the last balanced {...} substring in s, or "".
+// Mirrors internal/agent/inspector.go's helper. Tracks string-literal state
+// so braces inside string values don't count toward depth.
+func extractLastJSONObject(s string) string {
+	s = strings.TrimSpace(s)
+	var (
+		inString  bool
+		escape    bool
+		depth     int
+		objStart  = -1
+		lastStart = -1
+		lastEnd   = -1
+	)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if escape {
+			escape = false
+			continue
+		}
+		if inString {
+			switch c {
+			case '\\':
+				escape = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inString = true
+		case '{':
+			if depth == 0 {
+				objStart = i
+			}
+			depth++
+		case '}':
+			if depth == 0 {
+				continue
+			}
+			depth--
+			if depth == 0 && objStart >= 0 {
+				lastStart = objStart
+				lastEnd = i
+				objStart = -1
+			}
+		}
+	}
+	if lastStart < 0 {
+		return ""
+	}
+	return s[lastStart : lastEnd+1]
+}

--- a/internal/triage/classifier_test.go
+++ b/internal/triage/classifier_test.go
@@ -1,0 +1,52 @@
+package triage
+
+import "testing"
+
+func TestParseVerdict(t *testing.T) {
+	raw := []byte(`{"result":"Here is the verdict:\n{\"title\":\"feat(api): add auth\",\"original_title\":\"i want auth\",\"description\":\"\",\"tags\":[\"backend\",\"medium\",\"feature\"],\"size\":\"medium\",\"type\":\"feature\",\"mode\":\"headless\",\"project_id\":\"\"}"}`)
+	v, err := parseVerdict(raw)
+	if err != nil {
+		t.Fatalf("parseVerdict: %v", err)
+	}
+	if v.Title != "feat(api): add auth" {
+		t.Errorf("title: got %q", v.Title)
+	}
+	if v.Size != "medium" || v.Type != "feature" || v.Mode != "headless" {
+		t.Errorf("bad fields: %+v", v)
+	}
+	if err := ValidateVerdict(&v); err != nil {
+		t.Errorf("validate: %v", err)
+	}
+}
+
+func TestParseVerdictEmptyResult(t *testing.T) {
+	raw := []byte(`{"result":""}`)
+	if _, err := parseVerdict(raw); err == nil {
+		t.Errorf("expected error on empty result")
+	}
+}
+
+func TestParseVerdictNoJSON(t *testing.T) {
+	raw := []byte(`{"result":"no json here just prose"}`)
+	if _, err := parseVerdict(raw); err == nil {
+		t.Errorf("expected error on missing JSON")
+	}
+}
+
+func TestExtractLastJSONObject(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{`{"a":1}`, `{"a":1}`},
+		{`prose {"a":1} more prose`, `{"a":1}`},
+		{`{"a":1} then {"b":2}`, `{"b":2}`},
+		{`{"s":"}{"}`, `{"s":"}{"}`},
+		{`no json`, ``},
+	}
+	for _, tc := range tests {
+		got := extractLastJSONObject(tc.in)
+		if got != tc.want {
+			t.Errorf("extract(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/triage/model.go
+++ b/internal/triage/model.go
@@ -1,0 +1,109 @@
+// Package triage classifies incoming tasks into a structured verdict
+// (title, tags, size/type, mode, project) using a single claude -p call
+// and applies the result atomically via task.Manager.UpdateMap.
+package triage
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// Verdict is the structured classification returned by the LLM.
+type Verdict struct {
+	Title         string   `json:"title"`
+	Description   string   `json:"description,omitempty"`
+	Tags          []string `json:"tags"`
+	Size          string   `json:"size"`
+	Type          string   `json:"type"`
+	Mode          string   `json:"mode"`
+	ProjectID     string   `json:"project_id,omitempty"`
+	OriginalTitle string   `json:"original_title,omitempty"`
+}
+
+var (
+	validSizes = []string{"small", "medium", "large"}
+	validTypes = []string{"bug", "feature", "refactor", "review", "chore", "docs"}
+	validModes = []string{"headless", "interactive"}
+
+	// domainTags are the controlled-vocabulary domain tags. Tags outside
+	// this set and the size/type sets are rejected.
+	domainTags = []string{"backend", "frontend", "infra", "docs", "ci", "auth", "db", "test"}
+
+	// tagAliases normalize common abbreviations into the canonical tag.
+	tagAliases = map[string]string{
+		"be":        "backend",
+		"fe":        "frontend",
+		"ops":       "infra",
+		"devops":    "infra",
+		"database":  "db",
+		"tests":     "test",
+		"testing":   "test",
+		"docs:":     "docs",
+		"doc":       "docs",
+		"cicd":      "ci",
+		"pipeline":  "ci",
+		"feat":      "feature",
+		"bugfix":    "bug",
+		"reviewing": "review",
+	}
+)
+
+// NormalizeTags validates and canonicalizes tags.
+// Unknown tags are dropped with a warning in the returned error (nil if all ok).
+// Duplicates are removed. Order is preserved for the first occurrence.
+func NormalizeTags(raw []string) ([]string, error) {
+	seen := make(map[string]bool, len(raw))
+	out := make([]string, 0, len(raw))
+	var dropped []string
+	for _, t := range raw {
+		t = strings.TrimSpace(strings.ToLower(t))
+		if t == "" {
+			continue
+		}
+		if canon, ok := tagAliases[t]; ok {
+			t = canon
+		}
+		if !isKnownTag(t) {
+			dropped = append(dropped, t)
+			continue
+		}
+		if seen[t] {
+			continue
+		}
+		seen[t] = true
+		out = append(out, t)
+	}
+	if len(dropped) > 0 {
+		return out, fmt.Errorf("dropped unknown tags: %v", dropped)
+	}
+	return out, nil
+}
+
+func isKnownTag(t string) bool {
+	return slices.Contains(domainTags, t) ||
+		slices.Contains(validSizes, t) ||
+		slices.Contains(validTypes, t)
+}
+
+// ValidateVerdict ensures all enumerated fields are in their allowed set and
+// that Title is non-empty. Tags are normalized in place. Mutates v.
+func ValidateVerdict(v *Verdict) error {
+	if strings.TrimSpace(v.Title) == "" {
+		return fmt.Errorf("empty title")
+	}
+	if !slices.Contains(validSizes, v.Size) {
+		return fmt.Errorf("invalid size %q (want small|medium|large)", v.Size)
+	}
+	if !slices.Contains(validTypes, v.Type) {
+		return fmt.Errorf("invalid type %q (want %v)", v.Type, validTypes)
+	}
+	if !slices.Contains(validModes, v.Mode) {
+		return fmt.Errorf("invalid mode %q (want %v)", v.Mode, validModes)
+	}
+	// Tag normalization: drop unknown, keep known. Errors become warnings;
+	// the caller can log them but the verdict is still usable.
+	norm, _ := NormalizeTags(v.Tags)
+	v.Tags = norm
+	return nil
+}

--- a/internal/triage/model_test.go
+++ b/internal/triage/model_test.go
@@ -1,0 +1,56 @@
+package triage
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeTags(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      []string
+		want    []string
+		wantErr bool
+	}{
+		{"canonical", []string{"backend", "small", "bug"}, []string{"backend", "small", "bug"}, false},
+		{"aliases", []string{"be", "fe", "bugfix"}, []string{"backend", "frontend", "bug"}, false},
+		{"unknown dropped", []string{"backend", "mystery"}, []string{"backend"}, true},
+		{"dedupe", []string{"backend", "backend", "BE"}, []string{"backend"}, false},
+		{"whitespace+case", []string{" Backend ", "SMALL"}, []string{"backend", "small"}, false},
+		{"empty", []string{}, []string{}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NormalizeTags(tc.in)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("err = %v, wantErr %v", err, tc.wantErr)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateVerdict(t *testing.T) {
+	tests := []struct {
+		name    string
+		v       Verdict
+		wantErr bool
+	}{
+		{"valid", Verdict{Title: "t", Size: "small", Type: "bug", Mode: "headless", Tags: []string{"backend"}}, false},
+		{"empty title", Verdict{Title: " ", Size: "small", Type: "bug", Mode: "headless"}, true},
+		{"bad size", Verdict{Title: "t", Size: "huge", Type: "bug", Mode: "headless"}, true},
+		{"bad type", Verdict{Title: "t", Size: "small", Type: "nonsense", Mode: "headless"}, true},
+		{"bad mode", Verdict{Title: "t", Size: "small", Type: "bug", Mode: "auto"}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := tc.v
+			err := ValidateVerdict(&v)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("err = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/triage/projectmatch.go
+++ b/internal/triage/projectmatch.go
@@ -1,0 +1,33 @@
+package triage
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/Automaat/synapse/internal/project"
+)
+
+// githubURLRe matches a GitHub repo URL and captures owner/repo.
+// Tolerates trailing paths (/pull/123, /issues/42, .git, etc.) and punctuation.
+var githubURLRe = regexp.MustCompile(`https?://github\.com/([A-Za-z0-9][A-Za-z0-9._-]*)/([A-Za-z0-9][A-Za-z0-9._-]*)`)
+
+// MatchProject looks at the task's title+body, extracts any github.com URL,
+// and returns the matching registered project's ID ("owner/repo"). Returns ""
+// if no URL is present or no matching project is registered.
+func MatchProject(title, body string, projects []project.Project) string {
+	text := title + "\n" + body
+	matches := githubURLRe.FindAllStringSubmatch(text, -1)
+	for _, m := range matches {
+		owner, repo := m[1], strings.TrimSuffix(m[2], ".git")
+		id := owner + "/" + repo
+		for i := range projects {
+			if projects[i].ID == id {
+				return projects[i].ID
+			}
+			if projects[i].Owner == owner && projects[i].Repo == repo {
+				return projects[i].ID
+			}
+		}
+	}
+	return ""
+}

--- a/internal/triage/projectmatch_test.go
+++ b/internal/triage/projectmatch_test.go
@@ -1,0 +1,32 @@
+package triage
+
+import (
+	"testing"
+
+	"github.com/Automaat/synapse/internal/project"
+)
+
+func TestMatchProject(t *testing.T) {
+	projects := []project.Project{
+		{ID: "Automaat/synapse", Owner: "Automaat", Repo: "synapse"},
+		{ID: "foo/bar", Owner: "foo", Repo: "bar"},
+	}
+	tests := []struct {
+		name, title, body, want string
+	}{
+		{"no url", "fix bug", "some description", ""},
+		{"pr url in body", "review pr", "https://github.com/Automaat/synapse/pull/417", "Automaat/synapse"},
+		{"issue url in title", "https://github.com/foo/bar/issues/1", "", "foo/bar"},
+		{"url not registered", "check this", "https://github.com/unknown/repo", ""},
+		{"url with .git suffix", "clone", "https://github.com/foo/bar.git", "foo/bar"},
+		{"http (not https)", "legacy", "http://github.com/foo/bar/pull/9", "foo/bar"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MatchProject(tc.title, tc.body, projects)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/triage/routing.go
+++ b/internal/triage/routing.go
@@ -1,0 +1,34 @@
+package triage
+
+import "github.com/Automaat/synapse/internal/task"
+
+// RouteStatus picks the next task status from the classifier verdict.
+//
+// Rules (in order of precedence):
+//   - review              → todo
+//   - medium/large feature → planning (work project always planning)
+//   - everything else     → todo
+//
+// projectType is the owning project.ProjectType (string) if the task is
+// project-linked, or "" if unlinked. Currently "work" projects only tighten
+// the planning rule (they are already covered by the feature rule above),
+// but the argument is kept so apply.go can tweak mode for work projects.
+func RouteStatus(size, taskType, projectType string) task.Status {
+	_ = projectType // reserved for future rules
+	if taskType == "review" {
+		return task.StatusTodo
+	}
+	if taskType == "feature" && (size == "medium" || size == "large") {
+		return task.StatusPlanning
+	}
+	return task.StatusTodo
+}
+
+// RouteMode optionally overrides the LLM's mode pick based on project type.
+// Work projects get forced to interactive unless the task is a PR review.
+func RouteMode(llmMode, taskType, projectType string) string {
+	if projectType == "work" && taskType != "review" {
+		return task.AgentModeInteractive
+	}
+	return llmMode
+}

--- a/internal/triage/routing_test.go
+++ b/internal/triage/routing_test.go
@@ -1,0 +1,52 @@
+package triage
+
+import (
+	"testing"
+
+	"github.com/Automaat/synapse/internal/task"
+)
+
+func TestRouteStatus(t *testing.T) {
+	tests := []struct {
+		name, size, type_, projectType string
+		want                           task.Status
+	}{
+		{"small bug", "small", "bug", "", task.StatusTodo},
+		{"small feature", "small", "feature", "", task.StatusTodo},
+		{"medium feature", "medium", "feature", "", task.StatusPlanning},
+		{"large feature", "large", "feature", "", task.StatusPlanning},
+		{"medium feature work", "medium", "feature", "work", task.StatusPlanning},
+		{"review any size", "medium", "review", "", task.StatusTodo},
+		{"refactor medium", "medium", "refactor", "", task.StatusTodo},
+		{"chore large", "large", "chore", "", task.StatusTodo},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RouteStatus(tc.size, tc.type_, tc.projectType)
+			if got != tc.want {
+				t.Errorf("got %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRouteMode(t *testing.T) {
+	tests := []struct {
+		name, llmMode, type_, projectType string
+		want                              string
+	}{
+		{"pet keeps headless", "headless", "feature", "pet", "headless"},
+		{"pet keeps interactive", "interactive", "feature", "pet", "interactive"},
+		{"work feature forced interactive", "headless", "feature", "work", "interactive"},
+		{"work review stays headless", "headless", "review", "work", "headless"},
+		{"empty project type", "headless", "feature", "", "headless"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RouteMode(tc.llmMode, tc.type_, tc.projectType)
+			if got != tc.want {
+				t.Errorf("got %s, want %s", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

The `synapse-triage` skill walked the LLM through 9 sequential steps, each ending in a separate `synapse-cli update` call. That meant ~5 context reloads and ~$0.05 per task, with routing rules, tag vocabulary, and project matching duplicated as prose in the skill. Moving the deterministic work into Go and collapsing the LLM into a single structured call cuts per-task cost, makes triage runnable as a background worker, and removes hand-waving prose rules.

The LLM still owns the judgment calls (title rewrite, size/type/domain, description synthesis) but always produces a clean human-readable title — per an explicit requirement — even when the input already looked fine.

## Implementation information

New `internal/triage` package owns the pipeline:

- `ClaudeClassifier` shells `claude -p --output-format json` (reusing the `internal/agent/inspector.go` pattern) with a strict JSON schema prompt and parses the envelope.
- `Apply()` builds a single `map[string]any` for `task.Manager.UpdateMap()` — atomic per-task write, already emits `task:updated`.
- `RouteStatus` / `RouteMode` encode the old prose rules: medium/large features → `planning`; everything else → `todo`; work projects force `interactive` unless the task is a PR review.
- `MatchProject` regexes github.com URLs out of title+body and maps them to registered projects.
- `NormalizeTags` validates against a controlled vocab (backend, frontend, infra, docs, ci, auth, db, test + size + type) with alias support.

CLI gains `synapse-cli triage classify <id>` and `--all` for manual/batch invocation, plus a `triage.classified` audit event written on every run.

Background worker (`internal/poll/triage.go` + `internal/synapse/app_triage.go`) mirrors the renovate/todoist pattern: opt-in via `triage.enabled: true`, classifies tasks with `status=new`, debounces on recent updates, and registers with the existing poll hub.

Skill shrunk from 210 to 47 lines — now just points at the CLI.

Alternatives considered:
- Batch all tasks in one LLM call for `--all`: deferred to v1.1 when queues actually get large.
- Exporting `extractLastJSONObject` from the agent package to avoid duplication: chose a local copy (50 lines, self-contained) to avoid cross-package coupling on a helper with one consumer.

## Supporting documentation

Plan file: \`~/.claude/plans/linked-jumping-mochi.md\` (local).

## Test plan

- [x] \`go test ./...\` — all packages green including the 39s synapse integration suite
- [x] \`mise run lint\` — golangci-lint v2 / oxlint / hadolint all clean
- [x] \`go vet ./...\` clean
- [ ] Manual end-to-end: seed a freeform task, run \`synapse-cli triage classify <id>\`, verify title rewritten + original preserved + project matched + routed to correct status
- [ ] Background worker smoke: set \`triage.enabled: true\` with \`poll_seconds: 10\`, confirm new tasks move out of \`new\` within one poll cycle, verify audit event in \`~/.synapse/logs/audit/*.ndjson\`