### PR TITLE
feat(health): more checks + score rollup

### DIFF
--- a/.claude/skills/synapse-audit.md
+++ b/.claude/skills/synapse-audit.md
@@ -1,95 +1,147 @@
 ---
 name: synapse-audit
-description: Analyze Synapse audit logs to identify workflow bottlenecks, failure patterns, cost outliers, and suggest improvements. Use when asked to review how work is flowing or suggest process improvements.
+description: Analyze Synapse health findings + audit summary to explain workflow issues and propose grounded fixes. Use when asked to review how work is flowing or suggest process improvements.
 allowed-tools: Bash, Read
 user-invocable: true
 ---
 
 # Synapse Audit Analysis
 
-Analyze audit log data to identify patterns, bottlenecks, and improvement opportunities.
+The Go side already runs every detector you would otherwise reproduce here:
+failure rate, cost outliers (per-role), stuck tasks, plan-rejection loops,
+status bounce, cost drift, agent retry loops, triage mode mismatches, and
+status bottlenecks. Your job is to **read the findings + summary, ground them
+in the actual tasks, and propose concrete fixes** — not to recompute them.
 
-## Step 1: Get the summary
+## Step 1: Pull the pre-computed health report
+
+```bash
+synapse-cli --json health
+```
+
+Returns a `Report` with:
+- `score` — `good` | `warning` | `critical` (rollup across all findings)
+- `findings[]` — each has `category`, `severity`, `title`, `description`,
+  `taskId`, `agentId`, `role`, `evidence`, `detectedAt`
+- `stats` — totals, failure rate, cost by role
+
+Categories you may see and what each means:
+- `failure_rate` — too many agent runs failed today
+- `cost_outlier` — a single run exceeded the per-role budget
+- `cost_drift` — today's avg cost is way above the 7-day rolling avg
+- `stuck_task` — a task has been in-progress >6h with no agent activity
+- `workflow_loop` — a task hit 3+ plan rejections (triage→plan→reject loop)
+- `status_bounce` — task ping-ponged the same status transition 2+ times
+- `agent_retry_loop` — same task accumulated 2+ failed agent runs
+- `triage_mismatch` — task triaged as headless that escalated to human-required
+- `status_bottleneck` — average dwell in a status exceeded its threshold
+
+## Step 2: Pull the workflow summary
 
 ```bash
 synapse-cli --json audit --since 7d --summary
 ```
 
-Review key metrics:
-- **failure_rate** > 0.2 → investigate failing agents
-- **plan_rejection_rate** > 0.3 → triage is under-specifying tasks
-- **avg_cycle_time_hours** → compare across weeks for trends
-- **status_bottlenecks_hours** → which statuses have the longest dwell time
+Use this for trend context: cycle time, total cost, plan rejection rate,
+status bottleneck dwell hours over the longer window. Don't recompute these.
 
-## Step 2: Investigate bottlenecks
+## Step 3: Ground each finding
 
-If `plan-review` or `human-required` have high dwell times:
-```bash
-synapse-cli --json audit --since 7d --type task.status_changed
-```
-
-Look for tasks stuck waiting for human action. Suggest:
-- Auto-approve plans for small/simple tasks
-- Set up notifications for plan-review tasks
-
-## Step 3: Analyze failures
+For the top 3 findings (by severity, then by impact), read the actual task so
+your suggestions cite real content, not generic advice:
 
 ```bash
-synapse-cli --json audit --since 7d --type agent.failed
+synapse-cli --json get <task_id>
 ```
 
-Look for patterns:
-- Same task failing multiple times → needs different approach or mode change
-- High cost on failed agents → prompt needs refinement
-- Specific task types failing more → triage rules need adjustment
+Use the task body, status_reason, plan, and any embedded run results to
+explain *why* the finding fired and what specifically should change.
 
-## Step 4: Cost analysis
+## Step 4: Produce the report
 
-```bash
-synapse-cli --json audit --since 7d --type agent.completed
+```
+Health: <report.score>
+Period: <report.periodStart> → <report.periodEnd>
+
+Findings: <N> (critical: <C>, warning: <W>)
+
+Top issues:
+1. [category] <title>
+   - Task: <task_id> — <one-line task summary from the task body>
+   - Why it fired: <evidence-grounded explanation>
+   - Fix: <specific, actionable change — prompt diff, mode flip, triage
+     rule update, subtask split — referencing real task content>
+2. ...
+3. ...
+
+Recommendations (cross-cutting):
+- <patterns spanning multiple findings: e.g., "3 of 5 retry loops are eval
+  agents — the eval prompt template needs a verification step">
+- <triage rule changes grounded in triage_mismatch findings>
+- <cost optimizations grounded in cost_outlier evidence>
 ```
 
-Check for:
-- Cost outliers (agents spending much more than average)
-- Triage/eval agents costing more than expected
-- Correlation between task size tags and actual cost
+## Rules
 
-## Step 5: Triage accuracy
-
-Compare triage decisions with outcomes:
-```bash
-synapse-cli --json audit --since 7d --type triage
-synapse-cli --json audit --since 7d --type task.status_changed
-```
-
-Check if tasks triaged as `headless` ended up needing `interactive` (escalated to human-required).
-
-## Output format
-
-Produce a concise report with:
-1. **Health score** (good/warning/critical) based on failure rate + bottlenecks
-2. **Top 3 issues** with specific task IDs
-3. **Recommendations** — concrete, actionable changes to triage rules, prompts, or workflow
+- **Never recompute what the report gives you.** If you find yourself filtering
+  raw audit events to count failures or measuring dwell times, stop — those
+  are already in `findings` and `stats`.
+- **Always read the underlying task** for the top findings before suggesting a
+  fix. Generic advice ("split into smaller subtasks") is not useful.
+- **Cite evidence values** from `finding.evidence` in your explanation so the
+  user can verify the call.
+- **Skip the report entirely** if `score == "good"` and no findings — output
+  one line: `Health: good — no findings in the last 24h.`
 
 <example>
-Input: `synapse-cli --json audit --since 7d --summary` returns `{"failure_rate": 0.35, "plan_rejection_rate": 0.12, "avg_cycle_time_hours": 8.2, "status_bottlenecks_hours": {"plan-review": 22.5, "in-progress": 3.1}}`
-
-Output:
+`synapse-cli --json health` returns:
+```json
+{
+  "score": "critical",
+  "findings": [
+    {"category": "agent_retry_loop", "severity": "critical", "taskId": "task-abc123",
+     "title": "task task-abc123 has 3 failed agent runs",
+     "evidence": {"failure_count": 3}},
+    {"category": "triage_mismatch", "severity": "warning", "taskId": "task-def456",
+     "title": "task task-def456 triaged headless but escalated to human-required"}
+  ],
+  "stats": {"totalAgentRuns": 18, "failedAgentRuns": 5, "failureRate": 0.28}
+}
 ```
-Health: warning
+
+Then `synapse-cli --json get task-abc123` shows a task asking the agent to
+refactor a 2000-line file. Output:
+
+```
+Health: critical
+Period: 2026-04-13 → 2026-04-14
+
+Findings: 2 (critical: 1, warning: 1)
+
 Top issues:
-1. failure_rate 0.35 exceeds 0.2 threshold — task-abc123, task-def456 failed 3x each
-2. plan-review dwell 22.5h — tasks task-ghi789 stuck waiting human approval
-3. task-jkl012 cost $1.80 (10x avg) — prompt needs refinement
+1. [agent_retry_loop] task task-abc123 has 3 failed agent runs
+   - Task: refactor internal/agent/manager.go (~2000 LOC)
+   - Why it fired: 3/3 headless attempts failed; file is too large for
+     a single agent context.
+   - Fix: split into 3 subtasks scoped per concern (lifecycle, persistence,
+     events), or flip to interactive mode so a human can guide the boundaries.
+
+2. [triage_mismatch] task task-def456 triaged headless but escalated to human-required
+   - Task: integrate new auth provider (touches secrets + IAM)
+   - Why it fired: triage saw "integrate" + small description and chose
+     headless; task actually needs credential setup that no agent can do.
+   - Fix: add triage rule "tasks tagged `secrets` or `iam` → interactive".
+
 Recommendations:
-- Auto-approve plans for tasks tagged `small`
-- Add slack notification on plan-review transition
-- Split task-jkl012 into smaller subtasks
+- Add a triage heuristic: tasks targeting files >1000 LOC default to interactive
+  or get auto-split before dispatch.
+- Eval-agent failure rate (28%) is approaching the 30% threshold — review the
+  last week of eval prompts for common failure modes.
 ```
 </example>
 
 <example>
-Input: `synapse-cli --json audit --since 7d --type agent.failed` returns 5 events, 3 from same task-xyz retrying.
+`synapse-cli --json health` returns `{"score": "good", "findings": []}`.
 
-Output: Recommendation — switch task-xyz to `interactive` mode, retry loop indicates headless can't resolve the blocker.
+Output: `Health: good — no findings in the last 24h.`
 </example>

--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -715,6 +715,9 @@ func cmdHealth(cfg *config.Config, args []string, jsonOut bool) int {
 
 	fmt.Printf("Health Report (generated %s)\n", report.GeneratedAt)
 	fmt.Printf("Period: %s to %s\n", report.PeriodStart, report.PeriodEnd)
+	if report.Score != "" {
+		fmt.Printf("Score: %s\n", report.Score)
+	}
 	fmt.Printf("Findings: %d\n\n", len(report.Findings))
 
 	for _, raw := range report.Findings {
@@ -736,6 +739,7 @@ type healthReport struct {
 	GeneratedAt string            `json:"generatedAt"`
 	PeriodStart string            `json:"periodStart"`
 	PeriodEnd   string            `json:"periodEnd"`
+	Score       string            `json:"score"`
 	Findings    []json.RawMessage `json:"findings"`
 	Stats       json.RawMessage   `json:"stats"`
 }

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -103,6 +103,9 @@ func (c *Checker) check() {
 	findings = append(findings, checkWorkflowLoops(dayEvents, now)...)
 	findings = append(findings, checkStatusBounce(dayEvents, now)...)
 	findings = append(findings, checkCostDrift(dayEvents, weekEvents, now)...)
+	findings = append(findings, checkAgentRetryLoops(dayEvents, now)...)
+	findings = append(findings, checkTriageMismatch(weekEvents, now)...)
+	findings = append(findings, checkStatusBottleneck(weekEvents, now)...)
 
 	stats := buildStats(dayEvents)
 
@@ -110,6 +113,7 @@ func (c *Checker) check() {
 		GeneratedAt: now,
 		PeriodStart: since,
 		PeriodEnd:   now,
+		Score:       RollupScore(findings),
 		Findings:    findings,
 		Stats:       stats,
 	}

--- a/internal/health/checks_extra.go
+++ b/internal/health/checks_extra.go
@@ -1,0 +1,181 @@
+package health
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Automaat/synapse/internal/audit"
+)
+
+const (
+	retryLoopThreshold = 2
+)
+
+// statusDwellThresholds maps task status → max acceptable hours in that status
+// before flagging a bottleneck. Statuses absent from the map are not checked.
+var statusDwellThresholds = map[string]float64{
+	"plan-review":      12,
+	"in-review":        24,
+	"test-plan-review": 12,
+	"human-required":   24,
+	"todo":             24,
+}
+
+// isAgentFailure classifies an audit event as a failed agent run. Production
+// emits failures as agent.completed with state != "stopped"; the legacy
+// agent.failed type is also accepted for forward/test compatibility.
+func isAgentFailure(e audit.Event) bool {
+	if e.Type == audit.EventAgentFailed {
+		return true
+	}
+	if e.Type != audit.EventAgentCompleted {
+		return false
+	}
+	state, _ := e.Data["state"].(string)
+	return state != "" && state != string(stoppedState)
+}
+
+const stoppedState = "stopped"
+
+// checkAgentRetryLoops flags tasks that have 2+ failed agent runs in the
+// window — an indicator that headless retries are not converging and the task
+// likely needs mode change, prompt refinement, or human intervention.
+func checkAgentRetryLoops(events []audit.Event, now time.Time) []Finding {
+	failuresPerTask := make(map[string]int)
+	lastRole := make(map[string]string)
+	for _, e := range events {
+		if !isAgentFailure(e) {
+			continue
+		}
+		if e.TaskID == "" {
+			continue
+		}
+		failuresPerTask[e.TaskID]++
+		if role, ok := e.Data["role"].(string); ok {
+			lastRole[e.TaskID] = role
+		}
+	}
+
+	var findings []Finding
+	for taskID, count := range failuresPerTask {
+		if count < retryLoopThreshold {
+			continue
+		}
+		findings = append(findings, Finding{
+			Category:    CatAgentRetryLoop,
+			Severity:    SeverityCritical,
+			Title:       fmt.Sprintf("task %s has %d failed agent runs", taskID, count),
+			Description: fmt.Sprintf("Task %s accumulated %d failed agent runs — retries are not converging, consider mode change or human review", taskID, count),
+			TaskID:      taskID,
+			Role:        lastRole[taskID],
+			Evidence: map[string]any{
+				"failure_count": count,
+			},
+			DetectedAt: now,
+		})
+	}
+	return findings
+}
+
+// checkTriageMismatch flags tasks that triage classified as headless but later
+// transitioned to human-required — the triage policy under-specified the task.
+func checkTriageMismatch(events []audit.Event, now time.Time) []Finding {
+	classifiedHeadless := make(map[string]bool)
+	for _, e := range events {
+		if e.Type != audit.EventTriageClassified {
+			continue
+		}
+		mode, _ := e.Data["mode"].(string)
+		if mode == "headless" {
+			classifiedHeadless[e.TaskID] = true
+		}
+	}
+
+	escalated := make(map[string]bool)
+	for _, e := range events {
+		if e.Type != audit.EventTaskStatusChanged {
+			continue
+		}
+		to, _ := e.Data["to"].(string)
+		if to == "human-required" && classifiedHeadless[e.TaskID] {
+			escalated[e.TaskID] = true
+		}
+	}
+
+	var findings []Finding
+	for taskID := range escalated {
+		findings = append(findings, Finding{
+			Category:    CatTriageMismatch,
+			Severity:    SeverityWarning,
+			Title:       fmt.Sprintf("task %s triaged headless but escalated to human-required", taskID),
+			Description: fmt.Sprintf("Task %s was classified as headless by triage but later required human intervention — triage rules may be under-specifying complexity", taskID),
+			TaskID:      taskID,
+			Evidence: map[string]any{
+				"classified_mode": "headless",
+				"final_status":    "human-required",
+			},
+			DetectedAt: now,
+		})
+	}
+	return findings
+}
+
+// checkStatusBottleneck flags statuses where the average dwell time exceeds a
+// per-status threshold. Dwell is measured between consecutive status changes
+// for the same task; tasks still in a status at window end are not counted.
+func checkStatusBottleneck(events []audit.Event, now time.Time) []Finding {
+	type stat struct {
+		totalHours float64
+		count      int
+	}
+	stats := make(map[string]*stat)
+	enteredAt := make(map[string]time.Time)
+
+	for _, e := range events {
+		if e.Type != audit.EventTaskStatusChanged {
+			continue
+		}
+		from, _ := e.Data["from"].(string)
+		to, _ := e.Data["to"].(string)
+
+		if from != "" {
+			if entered, ok := enteredAt[e.TaskID]; ok {
+				hours := e.Timestamp.Sub(entered).Hours()
+				if stats[from] == nil {
+					stats[from] = &stat{}
+				}
+				stats[from].totalHours += hours
+				stats[from].count++
+			}
+		}
+		if to != "" {
+			enteredAt[e.TaskID] = e.Timestamp
+		}
+	}
+
+	var findings []Finding
+	for status, threshold := range statusDwellThresholds {
+		s := stats[status]
+		if s == nil || s.count == 0 {
+			continue
+		}
+		avg := s.totalHours / float64(s.count)
+		if avg <= threshold {
+			continue
+		}
+		findings = append(findings, Finding{
+			Category:    CatStatusBottleneck,
+			Severity:    SeverityWarning,
+			Title:       fmt.Sprintf("status %s avg dwell %.1fh (threshold %.0fh)", status, avg, threshold),
+			Description: fmt.Sprintf("Tasks spent an average of %.1f hours in %s over %d transitions, exceeding the %.0fh threshold", avg, status, s.count, threshold),
+			Evidence: map[string]any{
+				"status":          status,
+				"avg_hours":       round2(avg),
+				"transitions":     s.count,
+				"threshold_hours": threshold,
+			},
+			DetectedAt: now,
+		})
+	}
+	return findings
+}

--- a/internal/health/checks_extra_test.go
+++ b/internal/health/checks_extra_test.go
@@ -1,0 +1,186 @@
+package health
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Automaat/synapse/internal/audit"
+)
+
+func TestIsAgentFailure(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		evt  audit.Event
+		want bool
+	}{
+		{"legacy failed event", audit.Event{Type: audit.EventAgentFailed}, true},
+		{"completed stopped is success", audit.Event{Type: audit.EventAgentCompleted, Data: map[string]any{"state": "stopped"}}, false},
+		{"completed error is failure", audit.Event{Type: audit.EventAgentCompleted, Data: map[string]any{"state": "error"}}, true},
+		{"completed without state is success", audit.Event{Type: audit.EventAgentCompleted, Data: map[string]any{}}, false},
+		{"unrelated event", audit.Event{Type: audit.EventTaskCreated}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isAgentFailure(tt.evt); got != tt.want {
+				t.Errorf("isAgentFailure(%s) = %v, want %v", tt.evt.Type, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckAgentRetryLoops(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+
+	tests := []struct {
+		name     string
+		failures map[string]int
+		wantN    int
+	}{
+		{"no failures", map[string]int{}, 0},
+		{"single failure ignored", map[string]int{"t1": 1}, 0},
+		{"two failures flagged", map[string]int{"t1": 2}, 1},
+		{"multiple tasks", map[string]int{"t1": 3, "t2": 1, "t3": 2}, 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var events []audit.Event
+			for taskID, n := range tt.failures {
+				for range n {
+					events = append(events, audit.Event{
+						Type:      audit.EventAgentCompleted,
+						TaskID:    taskID,
+						Timestamp: now,
+						Data:      map[string]any{"state": "error", "role": ""},
+					})
+				}
+			}
+			got := checkAgentRetryLoops(events, now)
+			if len(got) != tt.wantN {
+				t.Errorf("got %d findings, want %d", len(got), tt.wantN)
+			}
+		})
+	}
+}
+
+func TestCheckAgentRetryLoopsIgnoresSuccesses(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	events := []audit.Event{
+		{Type: audit.EventAgentCompleted, TaskID: "t1", Timestamp: now, Data: map[string]any{"state": "stopped"}},
+		{Type: audit.EventAgentCompleted, TaskID: "t1", Timestamp: now, Data: map[string]any{"state": "stopped"}},
+	}
+	if got := checkAgentRetryLoops(events, now); len(got) != 0 {
+		t.Errorf("got %d findings on all-success input, want 0", len(got))
+	}
+}
+
+func TestCheckTriageMismatch(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+
+	tests := []struct {
+		name   string
+		events []audit.Event
+		wantN  int
+	}{
+		{
+			"headless then human-required",
+			[]audit.Event{
+				{Type: audit.EventTriageClassified, TaskID: "t1", Data: map[string]any{"mode": "headless"}},
+				{Type: audit.EventTaskStatusChanged, TaskID: "t1", Data: map[string]any{"from": "in-progress", "to": "human-required"}},
+			},
+			1,
+		},
+		{
+			"interactive then human-required (not a mismatch)",
+			[]audit.Event{
+				{Type: audit.EventTriageClassified, TaskID: "t1", Data: map[string]any{"mode": "interactive"}},
+				{Type: audit.EventTaskStatusChanged, TaskID: "t1", Data: map[string]any{"from": "in-progress", "to": "human-required"}},
+			},
+			0,
+		},
+		{
+			"headless without escalation",
+			[]audit.Event{
+				{Type: audit.EventTriageClassified, TaskID: "t1", Data: map[string]any{"mode": "headless"}},
+				{Type: audit.EventTaskStatusChanged, TaskID: "t1", Data: map[string]any{"from": "in-progress", "to": "done"}},
+			},
+			0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := checkTriageMismatch(tt.events, now)
+			if len(got) != tt.wantN {
+				t.Errorf("got %d findings, want %d", len(got), tt.wantN)
+			}
+		})
+	}
+}
+
+func TestCheckStatusBottleneck(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+
+	t.Run("plan-review dwell exceeds threshold", func(t *testing.T) {
+		t.Parallel()
+		events := []audit.Event{
+			{Type: audit.EventTaskStatusChanged, TaskID: "t1", Timestamp: now.Add(-30 * time.Hour), Data: map[string]any{"from": "planning", "to": "plan-review"}},
+			{Type: audit.EventTaskStatusChanged, TaskID: "t1", Timestamp: now, Data: map[string]any{"from": "plan-review", "to": "in-progress"}},
+		}
+		got := checkStatusBottleneck(events, now)
+		if len(got) != 1 || got[0].Evidence["status"] != "plan-review" {
+			t.Errorf("expected one plan-review bottleneck, got %+v", got)
+		}
+	})
+
+	t.Run("dwell within threshold", func(t *testing.T) {
+		t.Parallel()
+		events := []audit.Event{
+			{Type: audit.EventTaskStatusChanged, TaskID: "t1", Timestamp: now.Add(-2 * time.Hour), Data: map[string]any{"from": "planning", "to": "plan-review"}},
+			{Type: audit.EventTaskStatusChanged, TaskID: "t1", Timestamp: now, Data: map[string]any{"from": "plan-review", "to": "in-progress"}},
+		}
+		if got := checkStatusBottleneck(events, now); len(got) != 0 {
+			t.Errorf("expected no findings, got %d", len(got))
+		}
+	})
+
+	t.Run("status not in threshold map ignored", func(t *testing.T) {
+		t.Parallel()
+		events := []audit.Event{
+			{Type: audit.EventTaskStatusChanged, TaskID: "t1", Timestamp: now.Add(-100 * time.Hour), Data: map[string]any{"from": "new", "to": "in-progress"}},
+			{Type: audit.EventTaskStatusChanged, TaskID: "t1", Timestamp: now, Data: map[string]any{"from": "in-progress", "to": "done"}},
+		}
+		if got := checkStatusBottleneck(events, now); len(got) != 0 {
+			t.Errorf("expected no findings for in-progress, got %d", len(got))
+		}
+	})
+}
+
+func TestRollupScore(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		findings []Finding
+		want     Score
+	}{
+		{"empty is good", nil, ScoreGood},
+		{"only warnings", []Finding{{Severity: SeverityWarning}, {Severity: SeverityWarning}}, ScoreWarning},
+		{"any critical wins", []Finding{{Severity: SeverityWarning}, {Severity: SeverityCritical}}, ScoreCritical},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := RollupScore(tt.findings); got != tt.want {
+				t.Errorf("RollupScore = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/health/e2e_test.go
+++ b/internal/health/e2e_test.go
@@ -1,0 +1,186 @@
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Automaat/synapse/internal/audit"
+	"github.com/Automaat/synapse/internal/task"
+)
+
+// TestE2E_NewChecksFireThroughChecker drives the full Checker.check pipeline
+// against a freshly seeded audit dir and asserts that the three new detectors
+// (agent_retry_loop, triage_mismatch, status_bottleneck) and the score rollup
+// surface in the persisted health-report.json that the CLI consumes.
+func TestE2E_NewChecksFireThroughChecker(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	auditDir := filepath.Join(home, "audit")
+	tasksDir := filepath.Join(home, "tasks")
+
+	logger, err := audit.NewLogger(auditDir)
+	if err != nil {
+		t.Fatalf("audit.NewLogger: %v", err)
+	}
+	t.Cleanup(func() { _ = logger.Close() })
+
+	now := time.Now().UTC()
+
+	seed := []audit.Event{
+		// task-retry: 3 failed agent runs → checkAgentRetryLoops (critical)
+		{Timestamp: now.Add(-3 * time.Hour), Type: audit.EventAgentCompleted, TaskID: "task-retry", AgentID: "a1", Data: map[string]any{"state": "error", "role": "", "cost_usd": 0.40}},
+		{Timestamp: now.Add(-2 * time.Hour), Type: audit.EventAgentCompleted, TaskID: "task-retry", AgentID: "a2", Data: map[string]any{"state": "error", "role": "", "cost_usd": 0.50}},
+		{Timestamp: now.Add(-1 * time.Hour), Type: audit.EventAgentCompleted, TaskID: "task-retry", AgentID: "a3", Data: map[string]any{"state": "error", "role": "", "cost_usd": 0.60}},
+
+		// task-mismatch: triaged headless then escalated to human-required
+		// → checkTriageMismatch (warning).
+		{Timestamp: now.Add(-26 * time.Hour), Type: audit.EventTriageClassified, TaskID: "task-mismatch", Data: map[string]any{"mode": "headless"}},
+		{Timestamp: now.Add(-2 * time.Hour), Type: audit.EventTaskStatusChanged, TaskID: "task-mismatch", Data: map[string]any{"from": "in-progress", "to": "human-required"}},
+
+		// task-bottleneck: lingered in plan-review for 30h before moving on
+		// → checkStatusBottleneck (warning, threshold 12h).
+		{Timestamp: now.Add(-50 * time.Hour), Type: audit.EventTaskStatusChanged, TaskID: "task-bottleneck", Data: map[string]any{"from": "planning", "to": "plan-review"}},
+		{Timestamp: now.Add(-20 * time.Hour), Type: audit.EventTaskStatusChanged, TaskID: "task-bottleneck", Data: map[string]any{"from": "plan-review", "to": "in-progress"}},
+	}
+	for _, e := range seed {
+		if err := logger.Log(e); err != nil {
+			t.Fatalf("audit log: %v", err)
+		}
+	}
+
+	store, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatalf("task.NewStore: %v", err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	silent := slog.New(slog.NewTextHandler(io.Discard, nil))
+	c := New(auditDir, tasks, home, silent, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	c.Run(ctx)
+
+	report := c.LatestReport()
+	if report == nil {
+		t.Fatal("LatestReport returned nil")
+	}
+
+	categories := map[Category]Finding{}
+	for _, f := range report.Findings {
+		categories[f.Category] = f
+	}
+
+	if _, ok := categories[CatAgentRetryLoop]; !ok {
+		t.Errorf("expected CatAgentRetryLoop finding, got categories=%v", findingCategories(report.Findings))
+	}
+	if _, ok := categories[CatTriageMismatch]; !ok {
+		t.Errorf("expected CatTriageMismatch finding, got categories=%v", findingCategories(report.Findings))
+	}
+	if _, ok := categories[CatStatusBottleneck]; !ok {
+		t.Errorf("expected CatStatusBottleneck finding, got categories=%v", findingCategories(report.Findings))
+	}
+
+	if retry, ok := categories[CatAgentRetryLoop]; ok {
+		if retry.TaskID != "task-retry" {
+			t.Errorf("retry-loop TaskID = %q, want task-retry", retry.TaskID)
+		}
+		if retry.Severity != SeverityCritical {
+			t.Errorf("retry-loop severity = %q, want critical", retry.Severity)
+		}
+	}
+
+	if report.Score != ScoreCritical {
+		t.Errorf("Score = %q, want critical (a critical finding fired)", report.Score)
+	}
+
+	// The persisted JSON is what synapse-cli health reads. Verify the score
+	// and findings round-trip through the file the CLI consumes.
+	data, err := os.ReadFile(filepath.Join(home, "health-report.json"))
+	if err != nil {
+		t.Fatalf("read persisted report: %v", err)
+	}
+	var persisted struct {
+		Score    string `json:"score"`
+		Findings []struct {
+			Category string `json:"category"`
+		} `json:"findings"`
+	}
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatalf("parse persisted report: %v", err)
+	}
+	if persisted.Score != string(ScoreCritical) {
+		t.Errorf("persisted score = %q, want critical", persisted.Score)
+	}
+	gotPersisted := map[string]bool{}
+	for _, f := range persisted.Findings {
+		gotPersisted[f.Category] = true
+	}
+	for _, want := range []Category{CatAgentRetryLoop, CatTriageMismatch, CatStatusBottleneck} {
+		if !gotPersisted[string(want)] {
+			t.Errorf("persisted report missing category %q", want)
+		}
+	}
+}
+
+// TestE2E_GoodScoreWhenNothingFires ensures the rollup yields ScoreGood when
+// the audit log only contains successful, well-behaved events.
+func TestE2E_GoodScoreWhenNothingFires(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	auditDir := filepath.Join(home, "audit")
+	tasksDir := filepath.Join(home, "tasks")
+
+	logger, err := audit.NewLogger(auditDir)
+	if err != nil {
+		t.Fatalf("audit.NewLogger: %v", err)
+	}
+	t.Cleanup(func() { _ = logger.Close() })
+
+	now := time.Now().UTC()
+	clean := []audit.Event{
+		{Timestamp: now.Add(-2 * time.Hour), Type: audit.EventAgentCompleted, TaskID: "task-ok", AgentID: "a1", Data: map[string]any{"state": "stopped", "role": "", "cost_usd": 0.30}},
+		{Timestamp: now.Add(-1 * time.Hour), Type: audit.EventTaskStatusChanged, TaskID: "task-ok", Data: map[string]any{"from": "in-progress", "to": "done"}},
+	}
+	for _, e := range clean {
+		if err := logger.Log(e); err != nil {
+			t.Fatalf("audit log: %v", err)
+		}
+	}
+
+	store, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatalf("task.NewStore: %v", err)
+	}
+	tasks := task.NewManager(store, nil)
+	silent := slog.New(slog.NewTextHandler(io.Discard, nil))
+	c := New(auditDir, tasks, home, silent, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	c.Run(ctx)
+
+	report := c.LatestReport()
+	if report == nil {
+		t.Fatal("LatestReport returned nil")
+	}
+	if report.Score != ScoreGood {
+		t.Errorf("Score = %q, want good (findings=%v)", report.Score, findingCategories(report.Findings))
+	}
+}
+
+func findingCategories(findings []Finding) []string {
+	out := make([]string, len(findings))
+	for i := range findings {
+		out[i] = string(findings[i].Category)
+	}
+	return out
+}

--- a/internal/health/types.go
+++ b/internal/health/types.go
@@ -14,12 +14,24 @@ const (
 type Category string
 
 const (
-	CatFailureRate  Category = "failure_rate"
-	CatCostOutlier  Category = "cost_outlier"
-	CatStuckTask    Category = "stuck_task"
-	CatWorkflowLoop Category = "workflow_loop"
-	CatStatusBounce Category = "status_bounce"
-	CatCostDrift    Category = "cost_drift"
+	CatFailureRate      Category = "failure_rate"
+	CatCostOutlier      Category = "cost_outlier"
+	CatStuckTask        Category = "stuck_task"
+	CatWorkflowLoop     Category = "workflow_loop"
+	CatStatusBounce     Category = "status_bounce"
+	CatCostDrift        Category = "cost_drift"
+	CatAgentRetryLoop   Category = "agent_retry_loop"
+	CatTriageMismatch   Category = "triage_mismatch"
+	CatStatusBottleneck Category = "status_bottleneck"
+)
+
+// Score is the rollup verdict across all findings in a report.
+type Score string
+
+const (
+	ScoreGood     Score = "good"
+	ScoreWarning  Score = "warning"
+	ScoreCritical Score = "critical"
 )
 
 // Finding is a single health issue detected by the checker.
@@ -50,6 +62,21 @@ type Report struct {
 	GeneratedAt time.Time `json:"generatedAt"`
 	PeriodStart time.Time `json:"periodStart"`
 	PeriodEnd   time.Time `json:"periodEnd"`
+	Score       Score     `json:"score"`
 	Findings    []Finding `json:"findings"`
 	Stats       Stats     `json:"stats"`
+}
+
+// RollupScore returns good if there are no findings, critical if any finding
+// is critical, otherwise warning.
+func RollupScore(findings []Finding) Score {
+	if len(findings) == 0 {
+		return ScoreGood
+	}
+	for i := range findings {
+		if findings[i].Severity == SeverityCritical {
+			return ScoreCritical
+		}
+	}
+	return ScoreWarning
 }


### PR DESCRIPTION
## Motivation

The `synapse-audit` skill was reproducing detection logic in prompt
text — fetching raw audit events via multiple CLI calls and pattern-
matching them in the LLM. The Go side already runs failure rate, cost
outliers, stuck tasks, plan-rejection loops, status bounce, and cost
drift via the periodic `health` checker, but three signals the skill
needed were missing. This PR moves them into Go so the skill becomes
"explain findings + propose grounded fixes" instead of "go fetch and
correlate."

## Implementation information

Three new detectors in `internal/health/checks_extra.go`:

- `checkAgentRetryLoops` — flags any task with 2+ failed agent runs
  in the window. Production emits failures as `agent.completed` with
  `state != "stopped"`, so a small `isAgentFailure` helper handles
  both that shape and the legacy `EventAgentFailed` for forward and
  test compat.
- `checkTriageMismatch` — joins `triage.classified mode=headless`
  events with later `task.status_changed → human-required`
  transitions to surface triage policy under-specifying complexity.
- `checkStatusBottleneck` — measures per-status average dwell time
  and flags statuses exceeding thresholds (plan-review 12h,
  in-review 24h, etc.).

`Report` gains a `Score` field (`good`/`warning`/`critical`) computed
by `RollupScore`. The CLI `health` command surfaces this in both JSON
output (already round-trips via `RawMessage`, just added the typed
field on the struct) and the human-readable view.

Three new categories in `types.go`: `CatAgentRetryLoop`,
`CatTriageMismatch`, `CatStatusBottleneck`.

E2E tests (`internal/health/e2e_test.go`) drive the full `Checker`
pipeline against a temp audit dir + task store, run `Run` with a
cancelled context to fire one check, then verify findings show up in
both the in-memory `LatestReport()` and the persisted
`health-report.json` the CLI consumes. A second e2e asserts `Score`
rolls up to `good` when only successful events are present.

`.claude/skills/synapse-audit.md` rewritten to call
`synapse-cli --json health` once, ground top findings against actual
task bodies via `synapse-cli get`, and short-circuit to a one-liner
when score is `good`. No more multi-call event filtering.

## Supporting documentation

None — internal refactor of an existing skill backed by an existing
package.