### PR TITLE
fix(docker): add synapse-cli + klaudiush overrides

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /bin/synapse-server ./cmd/synapse-server
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /bin/synapse-server ./cmd/synapse-server \
+    && CGO_ENABLED=0 GOOS=linux go build -trimpath -o /bin/synapse-cli ./cmd/synapse-cli
 
 # Stage 3: Runtime — node:24-slim for claude CLI (Node.js-based)
 #
@@ -90,11 +91,16 @@ RUN userdel -r node 2>/dev/null || true \
         '[validators.git.no_verify]' \
         'enabled = true' \
         'severity = "error"' \
+        '' \
+        '[overrides.entries.FILE005]' \
+        'disabled = true' \
+        'reason = "YAML frontmatter false positive in task files"' \
         > /home/synapse/.config/klaudiush/config.toml \
     && chown -R "${SYNAPSE_UID}:${SYNAPSE_GID}" /home/synapse
 
 # --- Layer E+F: thin, per-commit layers ---
 COPY --from=go-builder /bin/synapse-server /usr/local/bin/synapse-server
+COPY --from=go-builder /bin/synapse-cli /usr/local/bin/synapse-cli
 COPY --from=frontend-builder /app/frontend/dist-web /app/web
 
 ENV SYNAPSE_PORT=8080

--- a/internal/synapse/app.go
+++ b/internal/synapse/app.go
@@ -1013,6 +1013,13 @@ func (a *App) syncSkills() {
 	skillsSrc := filepath.Join(repoDir, ".claude", "skills")
 	a.syncDir(skillsSrc, a.skillsDir)
 
+	// Also sync to the system Claude Code skills dir so headless agents
+	// launched via `claude -p` can discover skills with the Skill tool.
+	if userHome, err := os.UserHomeDir(); err == nil {
+		claudeSkillsDst := filepath.Join(userHome, ".claude", "skills")
+		a.syncDir(skillsSrc, claudeSkillsDst)
+	}
+
 	claudeSrc := filepath.Join(repoDir, "orchestrator", "CLAUDE.md")
 	claudeDst := filepath.Join(config.HomeDir(), "CLAUDE.md")
 	a.syncFile(claudeSrc, claudeDst)


### PR DESCRIPTION
## Motivation

Three issues were causing triage agents to silently fail on the server:

1. `synapse-cli` was not built or installed in the Docker image — triage agents couldn't use it even though the prompt instructed them to
2. Skills (e.g. `synapse-triage`) were only synced to `~/.synapse/.claude/skills/` but headless `claude -p` agents look in `~/.claude/skills/` — `Unknown skill: synapse-triage` errors on every triage run
3. klaudiush `FILE005` rule fires on YAML frontmatter list items in task files, blocking the first Edit call from the triage agent; subsequent Edits then require explicit approval in headless mode (permanent permission failure)

## Implementation information

- Dockerfile: build `synapse-cli` alongside `synapse-server`, copy to `/usr/local/bin/`
- Dockerfile: bake `[overrides.entries.FILE005] disabled = true` into the global klaudiush config so it survives container rebuilds (was previously applied manually on the server)
- `app.go syncSkills()`: after syncing to `skillsDir`, also sync to `os.UserHomeDir()/.claude/skills/` — the path Claude Code agents actually discover skills from

> Changelog: fix(docker): add synapse-cli + klaudiush overrides