### PR TITLE
feat(selfmonitor): Phase C/D judge + actor

### DIFF
--- a/.claude/skills/synapse-audit.md
+++ b/.claude/skills/synapse-audit.md
@@ -7,34 +7,34 @@ user-invocable: true
 
 # Synapse Audit Analysis
 
-The Go side already runs every detector you would otherwise reproduce here:
-failure rate, cost outliers (per-role), stuck tasks, plan-rejection loops,
-status bounce, cost drift, agent retry loops, triage mode mismatches, and
-status bottlenecks. Your job is to **read the findings + summary, ground them
-in the actual tasks, and propose concrete fixes** — not to recompute them.
+The Go side already runs every detector and, when the selfmonitor service is
+enabled, distills each finding's agent log into a `LogSummary` (stall
+detection, repeated calls, error classes, cost attribution) and classifies it
+with an LLM judge. Your job is to **read those pre-computed results, ground
+them in real context, and produce concrete fixes** — not to recompute them.
 
-## Step 1: Pull the pre-computed health report
+## Step 1: Pull the selfmonitor report
+
+```bash
+synapse-cli --json selfmonitor scan
+```
+
+Returns a `selfmonitor.Report` with:
+- `healthScore` — `good` | `warning` | `critical`
+- `findings[]` — each `InvestigatedFinding` has:
+  - `.finding` — `category`, `severity`, `title`, `evidence`, `taskId`
+  - `.logSummary` — `stallDetected`, `stallReason`, `repeatedCalls`,
+    `errorClasses`, `inferredCostPerTool`, `lastToolCalls`, `totalCostUsd`
+  - `.verdict` — `classification`, `rootCause`, `confidence`, `nextAction`
+    (may be `"pending"` if judge is disabled or no log file resolved)
+- `correlations[]` — `kind` (`same_project` | `same_error_class` | `cascade`),
+  `key`, `count`, `fingerprints`, `description`
+
+**Fallback** — if the report is missing or `generatedAt` is > 2h ago:
 
 ```bash
 synapse-cli --json health
 ```
-
-Returns a `Report` with:
-- `score` — `good` | `warning` | `critical` (rollup across all findings)
-- `findings[]` — each has `category`, `severity`, `title`, `description`,
-  `taskId`, `agentId`, `role`, `evidence`, `detectedAt`
-- `stats` — totals, failure rate, cost by role
-
-Categories you may see and what each means:
-- `failure_rate` — too many agent runs failed today
-- `cost_outlier` — a single run exceeded the per-role budget
-- `cost_drift` — today's avg cost is way above the 7-day rolling avg
-- `stuck_task` — a task has been in-progress >6h with no agent activity
-- `workflow_loop` — a task hit 3+ plan rejections (triage→plan→reject loop)
-- `status_bounce` — task ping-ponged the same status transition 2+ times
-- `agent_retry_loop` — same task accumulated 2+ failed agent runs
-- `triage_mismatch` — task triaged as headless that escalated to human-required
-- `status_bottleneck` — average dwell in a status exceeded its threshold
 
 ## Step 2: Pull the workflow summary
 
@@ -42,41 +42,60 @@ Categories you may see and what each means:
 synapse-cli --json audit --since 7d --summary
 ```
 
-Use this for trend context: cycle time, total cost, plan rejection rate,
-status bottleneck dwell hours over the longer window. Don't recompute these.
+Use for trend context only: cycle time, total cost, plan rejection rate, status
+bottleneck dwell over the longer window.
 
 ## Step 3: Ground each finding
 
-For the top 3 findings (by severity, then by impact), read the actual task so
-your suggestions cite real content, not generic advice:
+For the top 3 findings (by severity, then impact):
+
+**If `logSummary` is present:**
+- Cite `stallReason` directly when `stallDetected: true` — no need to read task
+- Cite the top `repeatedCalls` entry (tool name + count + sampleInput) for tool-loop findings
+- Cite `errorClasses[0]` (class + sample) for failure findings
+- Use `inferredCostPerTool` to name the expensive tool for cost outliers
+
+**If `verdict.classification != "pending"`:**
+- Use `verdict.rootCause` as the primary diagnosis
+- Use `verdict.nextAction` as the fix — only refine if task content adds nuance
+
+**Otherwise (no logSummary, verdict pending):**
 
 ```bash
-synapse-cli --json get <task_id>
+synapse-cli --json get <taskId>
 ```
 
-Use the task body, status_reason, plan, and any embedded run results to
-explain *why* the finding fired and what specifically should change.
+Read task body, status_reason, and any embedded run results to explain why
+the finding fired.
 
 ## Step 4: Produce the report
 
 ```
-Health: <report.score>
-Period: <report.periodStart> → <report.periodEnd>
+Health: <healthScore>
+Period: <periodStart> → <periodEnd>
 
 Findings: <N> (critical: <C>, warning: <W>)
+{{if correlations}}
+Correlations: <K>
+{{end}}
 
 Top issues:
 1. [category] <title>
-   - Task: <task_id> — <one-line task summary from the task body>
-   - Why it fired: <evidence-grounded explanation>
-   - Fix: <specific, actionable change — prompt diff, mode flip, triage
-     rule update, subtask split — referencing real task content>
+   - Task: <taskId> — <one-line task summary>
+   - Root cause: <verdict.rootCause OR logSummary-derived explanation>
+   - Evidence: <specific signal — stallReason, repeatedCalls[0], errorClasses[0].sample>
+   - Fix: <verdict.nextAction OR specific actionable change>
+
 2. ...
 3. ...
 
+{{if correlations}}
+Correlations:
+- [<kind>] <description>
+{{end}}
+
 Recommendations (cross-cutting):
-- <patterns spanning multiple findings: e.g., "3 of 5 retry loops are eval
-  agents — the eval prompt template needs a verification step">
+- <patterns spanning multiple findings or correlations>
 - <triage rule changes grounded in triage_mismatch findings>
 - <cost optimizations grounded in cost_outlier evidence>
 ```
@@ -84,33 +103,50 @@ Recommendations (cross-cutting):
 ## Rules
 
 - **Never recompute what the report gives you.** If you find yourself filtering
-  raw audit events to count failures or measuring dwell times, stop — those
-  are already in `findings` and `stats`.
-- **Always read the underlying task** for the top findings before suggesting a
-  fix. Generic advice ("split into smaller subtasks") is not useful.
-- **Cite evidence values** from `finding.evidence` in your explanation so the
-  user can verify the call.
-- **Skip the report entirely** if `score == "good"` and no findings — output
-  one line: `Health: good — no findings in the last 24h.`
+  raw audit events, stop — use findings and stats.
+- **Cite log-summary signals by name.** Say "stall: last 5 calls are identical
+  Read invocations" not "the agent seemed stuck."
+- **Skip the report entirely** if `healthScore == "good"` and no findings:
+  output one line: `Health: good — no findings in the last 24h.`
+- **Trust the verdict when confidence ≥ 0.8.** Confirm with task content only
+  when confidence is lower or verdict is pending.
 
 <example>
-`synapse-cli --json health` returns:
+`synapse-cli --json selfmonitor scan` returns:
 ```json
 {
-  "score": "critical",
+  "healthScore": "critical",
   "findings": [
-    {"category": "agent_retry_loop", "severity": "critical", "taskId": "task-abc123",
-     "title": "task task-abc123 has 3 failed agent runs",
-     "evidence": {"failure_count": 3}},
-    {"category": "triage_mismatch", "severity": "warning", "taskId": "task-def456",
-     "title": "task task-def456 triaged headless but escalated to human-required"}
+    {
+      "finding": {"category": "agent_retry_loop", "severity": "critical",
+                  "taskId": "task-abc123", "title": "task task-abc123 has 3 failed agent runs",
+                  "evidence": {"failure_count": 3}},
+      "logSummary": {
+        "stallDetected": true,
+        "stallReason": "last 5 tool calls are identical Read(path='internal/agent/manager.go') invocations",
+        "totalCostUsd": 0.43,
+        "inferredCostPerTool": {"Read": 0.38, "Bash": 0.05}
+      },
+      "verdict": {"classification": "confirmed", "confidence": 0.92,
+                  "rootCause": "agent loops on reading the same 2000-line file without making progress",
+                  "nextAction": "split task into 3 subtasks scoped per concern, or flip to interactive mode"}
+    },
+    {
+      "finding": {"category": "triage_mismatch", "severity": "warning",
+                  "taskId": "task-def456", "title": "task task-def456 triaged headless but escalated to human-required",
+                  "evidence": {"classified_mode": "headless", "final_status": "human-required"}},
+      "logSummary": null,
+      "verdict": {"classification": "pending"}
+    }
   ],
-  "stats": {"totalAgentRuns": 18, "failedAgentRuns": 5, "failureRate": 0.28}
+  "correlations": []
 }
 ```
 
-Then `synapse-cli --json get task-abc123` shows a task asking the agent to
-refactor a 2000-line file. Output:
+Then for the pending triage_mismatch, `synapse-cli --json get task-def456` shows
+a task about integrating a new auth provider (touches secrets + IAM).
+
+Output:
 
 ```
 Health: critical
@@ -121,27 +157,28 @@ Findings: 2 (critical: 1, warning: 1)
 Top issues:
 1. [agent_retry_loop] task task-abc123 has 3 failed agent runs
    - Task: refactor internal/agent/manager.go (~2000 LOC)
-   - Why it fired: 3/3 headless attempts failed; file is too large for
-     a single agent context.
-   - Fix: split into 3 subtasks scoped per concern (lifecycle, persistence,
-     events), or flip to interactive mode so a human can guide the boundaries.
+   - Root cause: agent loops on reading the same 2000-line file without making progress
+   - Evidence: stall — last 5 calls are identical Read('internal/agent/manager.go');
+     78% of $0.43 cost attributed to Read
+   - Fix: split into 3 subtasks scoped per concern, or flip to interactive mode
 
 2. [triage_mismatch] task task-def456 triaged headless but escalated to human-required
    - Task: integrate new auth provider (touches secrets + IAM)
-   - Why it fired: triage saw "integrate" + small description and chose
-     headless; task actually needs credential setup that no agent can do.
-   - Fix: add triage rule "tasks tagged `secrets` or `iam` → interactive".
+   - Root cause: triage saw "integrate" + small description and chose headless;
+     task needs credential setup no agent can do autonomously
+   - Evidence: classified_mode=headless → final_status=human-required
+   - Fix: add triage rule "tasks tagged secrets or iam → interactive"
 
 Recommendations:
-- Add a triage heuristic: tasks targeting files >1000 LOC default to interactive
+- Add triage heuristic: tasks targeting files >1000 LOC default to interactive
   or get auto-split before dispatch.
-- Eval-agent failure rate (28%) is approaching the 30% threshold — review the
-  last week of eval prompts for common failure modes.
+- The selfmonitor actor (when dry_run=false) will auto-flip task-def456 to
+  interactive on the next selfmonitor tick.
 ```
 </example>
 
 <example>
-`synapse-cli --json health` returns `{"score": "good", "findings": []}`.
+`synapse-cli --json selfmonitor scan` returns `{"healthScore": "good", "findings": []}`.
 
 Output: `Health: good — no findings in the last 24h.`
 </example>

--- a/internal/selfmonitor/actor.go
+++ b/internal/selfmonitor/actor.go
@@ -1,0 +1,84 @@
+package selfmonitor
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/Automaat/synapse/internal/health"
+	"github.com/Automaat/synapse/internal/task"
+)
+
+// taskUpdater is the write-path slice of task.Manager the actor needs.
+// Defined as a local interface so tests can inject a fake without pulling in
+// the full filesystem-backed store.
+type taskUpdater interface {
+	Update(id string, u task.Update) (task.Task, error)
+}
+
+// Actor applies autonomous remediations to confirmed health findings.
+// DryRun=true (the config default) logs the intended action without modifying
+// any task — safe for operators who want to observe before enabling.
+type Actor struct {
+	Tasks  taskUpdater
+	DryRun bool
+	Logger *slog.Logger
+}
+
+// Act inspects a confirmed InvestigatedFinding and applies the appropriate
+// remediation. Returns a zero ActionRecord (Kind=="") when the finding
+// category has no actor handler or the verdict is not confirmed.
+func (a *Actor) Act(_ context.Context, inv InvestigatedFinding) ActionRecord {
+	if inv.Verdict.Classification != VerdictConfirmed {
+		return ActionRecord{}
+	}
+	switch health.Category(inv.Finding.Category) {
+	case health.CatTriageMismatch:
+		return a.flipAgentMode(inv)
+	default:
+		return ActionRecord{}
+	}
+}
+
+// flipAgentMode updates the task's agent_mode from headless to interactive
+// when a triage_mismatch finding is confirmed. The task already escalated to
+// human-required at least once, so headless re-dispatch will loop again.
+func (a *Actor) flipAgentMode(inv InvestigatedFinding) ActionRecord {
+	rec := ActionRecord{
+		Category:    string(inv.Finding.Category),
+		Fingerprint: inv.Fingerprint,
+		Kind:        "flip_agent_mode",
+		DryRun:      a.DryRun,
+		TakenAt:     time.Now().UTC(),
+	}
+
+	if inv.Finding.TaskID == "" {
+		rec.Error = "no task id"
+		return rec
+	}
+	rec.Reference = inv.Finding.TaskID
+
+	if a.DryRun {
+		a.logDryRun("flip_agent_mode", inv.Finding.TaskID)
+		return rec
+	}
+
+	mode := task.AgentModeInteractive
+	if _, err := a.Tasks.Update(inv.Finding.TaskID, task.Update{AgentMode: &mode}); err != nil {
+		rec.Error = fmt.Sprintf("update task: %s", err)
+		a.Logger.Warn("actor.flip_agent_mode.failed",
+			"task", inv.Finding.TaskID, "err", err)
+		return rec
+	}
+
+	a.Logger.Info("actor.flip_agent_mode",
+		"task", inv.Finding.TaskID, "fingerprint", inv.Fingerprint)
+	return rec
+}
+
+func (a *Actor) logDryRun(kind, taskID string) {
+	if a.Logger != nil {
+		a.Logger.Info("actor.dry_run", "kind", kind, "task", taskID)
+	}
+}

--- a/internal/selfmonitor/actor_test.go
+++ b/internal/selfmonitor/actor_test.go
@@ -1,0 +1,215 @@
+package selfmonitor
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/Automaat/synapse/internal/config"
+	"github.com/Automaat/synapse/internal/health"
+	"github.com/Automaat/synapse/internal/task"
+)
+
+// configWithAutoAct returns a SelfMonitorConfig that auto-acts on the given categories.
+func configWithAutoAct(categories ...string) config.SelfMonitorConfig {
+	return config.SelfMonitorConfig{
+		Enabled:           true,
+		IntervalHours:     6,
+		AutoActCategories: categories,
+	}
+}
+
+// stubTaskUpdater satisfies taskUpdater for actor tests.
+type stubTaskUpdater struct {
+	updated map[string]task.Update
+	err     error
+}
+
+func newStubUpdater() *stubTaskUpdater {
+	return &stubTaskUpdater{updated: map[string]task.Update{}}
+}
+
+func (s *stubTaskUpdater) Update(id string, u task.Update) (task.Task, error) {
+	if s.err != nil {
+		return task.Task{}, s.err
+	}
+	s.updated[id] = u
+	return task.Task{ID: id}, nil
+}
+
+func confirmedTriageMismatch(taskID string) InvestigatedFinding {
+	return InvestigatedFinding{
+		Fingerprint: "triage_mismatch:" + taskID,
+		Finding: health.Finding{
+			Category: health.CatTriageMismatch,
+			TaskID:   taskID,
+		},
+		Verdict: Verdict{Classification: VerdictConfirmed},
+	}
+}
+
+func TestActor_FlipsAgentMode_ConfirmedTriageMismatch(t *testing.T) {
+	updater := newStubUpdater()
+	actor := &Actor{Tasks: updater, DryRun: false, Logger: slog.Default()}
+
+	inv := confirmedTriageMismatch("task-flip")
+	rec := actor.Act(context.Background(), inv)
+
+	if rec.Kind != "flip_agent_mode" {
+		t.Errorf("Kind = %q, want flip_agent_mode", rec.Kind)
+	}
+	if rec.DryRun {
+		t.Error("DryRun = true, want false")
+	}
+	if rec.Error != "" {
+		t.Errorf("Error = %q, want empty", rec.Error)
+	}
+	if rec.Reference != "task-flip" {
+		t.Errorf("Reference = %q, want task-flip", rec.Reference)
+	}
+
+	u, ok := updater.updated["task-flip"]
+	if !ok {
+		t.Fatal("task-flip not updated")
+	}
+	if u.AgentMode == nil || *u.AgentMode != task.AgentModeInteractive {
+		t.Errorf("AgentMode = %v, want interactive", u.AgentMode)
+	}
+}
+
+func TestActor_DryRun_DoesNotUpdate(t *testing.T) {
+	updater := newStubUpdater()
+	actor := &Actor{Tasks: updater, DryRun: true, Logger: slog.Default()}
+
+	inv := confirmedTriageMismatch("task-dry")
+	rec := actor.Act(context.Background(), inv)
+
+	if rec.Kind != "flip_agent_mode" {
+		t.Errorf("Kind = %q, want flip_agent_mode", rec.Kind)
+	}
+	if !rec.DryRun {
+		t.Error("DryRun = false, want true")
+	}
+	if len(updater.updated) != 0 {
+		t.Errorf("task updated in dry run: %v", updater.updated)
+	}
+}
+
+func TestActor_SkipsNonConfirmedVerdicts(t *testing.T) {
+	tests := []struct {
+		classification string
+	}{
+		{VerdictPending},
+		{VerdictFalsePositive},
+		{"needs_human"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.classification, func(t *testing.T) {
+			updater := newStubUpdater()
+			actor := &Actor{Tasks: updater, DryRun: false, Logger: slog.Default()}
+
+			inv := InvestigatedFinding{
+				Fingerprint: "triage_mismatch:t1",
+				Finding: health.Finding{
+					Category: health.CatTriageMismatch,
+					TaskID:   "t1",
+				},
+				Verdict: Verdict{Classification: tt.classification},
+			}
+			rec := actor.Act(context.Background(), inv)
+
+			if rec.Kind != "" {
+				t.Errorf("Kind = %q, want empty for non-confirmed verdict %q", rec.Kind, tt.classification)
+			}
+			if len(updater.updated) != 0 {
+				t.Errorf("task updated for non-confirmed verdict: %v", updater.updated)
+			}
+		})
+	}
+}
+
+func TestActor_SkipsUnhandledCategories(t *testing.T) {
+	categories := []health.Category{
+		health.CatCostOutlier,
+		health.CatStuckTask,
+		health.CatAgentRetryLoop,
+		health.CatFailureRate,
+	}
+	for _, cat := range categories {
+		t.Run(string(cat), func(t *testing.T) {
+			updater := newStubUpdater()
+			actor := &Actor{Tasks: updater, DryRun: false, Logger: slog.Default()}
+
+			inv := InvestigatedFinding{
+				Fingerprint: string(cat) + ":t1",
+				Finding: health.Finding{
+					Category: cat,
+					TaskID:   "t1",
+				},
+				Verdict: Verdict{Classification: VerdictConfirmed},
+			}
+			rec := actor.Act(context.Background(), inv)
+
+			if rec.Kind != "" {
+				t.Errorf("Kind = %q, want empty for category %q", rec.Kind, cat)
+			}
+		})
+	}
+}
+
+func TestActor_RecordsErrorWhenUpdateFails(t *testing.T) {
+	updater := &stubTaskUpdater{
+		updated: map[string]task.Update{},
+		err:     os.ErrPermission,
+	}
+	actor := &Actor{Tasks: updater, DryRun: false, Logger: slog.Default()}
+
+	inv := confirmedTriageMismatch("task-fail")
+	rec := actor.Act(context.Background(), inv)
+
+	if rec.Kind != "flip_agent_mode" {
+		t.Errorf("Kind = %q, want flip_agent_mode even on failure", rec.Kind)
+	}
+	if rec.Error == "" {
+		t.Error("Error = empty, want non-empty on update failure")
+	}
+}
+
+func TestActor_FlipsAgentModeViaServicePipeline(t *testing.T) {
+	// Integration: service wires Actor into tick loop for AutoActCategories.
+	updater := newStubUpdater()
+
+	logPath := writeFixture(t, fixtureLines())
+
+	rep := &health.Report{
+		Findings: []health.Finding{{
+			Category:    health.CatTriageMismatch,
+			Fingerprint: "triage_mismatch:task-wired",
+			TaskID:      "task-wired",
+			LogFile:     logPath,
+		}},
+	}
+
+	svc := NewService(Deps{
+		Health: &stubHealth{Report: rep},
+		Judge:  &stubJudge{verdict: Verdict{Classification: VerdictConfirmed}},
+		Actor:  &Actor{Tasks: updater, DryRun: false, Logger: slog.Default()},
+		Cfg:    configWithAutoAct(string(health.CatTriageMismatch)),
+	})
+
+	r, err := svc.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	if len(r.ActionsTaken) != 1 {
+		t.Fatalf("ActionsTaken = %d, want 1", len(r.ActionsTaken))
+	}
+	if r.ActionsTaken[0].Kind != "flip_agent_mode" {
+		t.Errorf("Kind = %q, want flip_agent_mode", r.ActionsTaken[0].Kind)
+	}
+	if _, ok := updater.updated["task-wired"]; !ok {
+		t.Error("task-wired not updated via pipeline")
+	}
+}

--- a/internal/selfmonitor/actor_test.go
+++ b/internal/selfmonitor/actor_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/Automaat/synapse/internal/config"
 	"github.com/Automaat/synapse/internal/health"
@@ -211,5 +213,97 @@ func TestActor_FlipsAgentModeViaServicePipeline(t *testing.T) {
 	}
 	if _, ok := updater.updated["task-wired"]; !ok {
 		t.Error("task-wired not updated via pipeline")
+	}
+}
+
+func TestActor_RespectsMaxAutoActionsPerDay(t *testing.T) {
+	updater := newStubUpdater()
+
+	ledgerPath := filepath.Join(t.TempDir(), "ledger.jsonl")
+	ledger, err := Open(ledgerPath)
+	if err != nil {
+		t.Fatalf("Open ledger: %v", err)
+	}
+	if err := ledger.Append(LedgerEntry{
+		Fingerprint: "fp-old",
+		Verdict:     VerdictConfirmed,
+		Action:      "flip_agent_mode",
+		CreatedAt:   time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed ledger: %v", err)
+	}
+
+	logPath := writeFixture(t, fixtureLines())
+	rep := &health.Report{
+		Findings: []health.Finding{{
+			Category:    health.CatTriageMismatch,
+			Fingerprint: "triage_mismatch:task-capped",
+			TaskID:      "task-capped",
+			LogFile:     logPath,
+		}},
+	}
+
+	cfg := configWithAutoAct(string(health.CatTriageMismatch))
+	cfg.MaxAutoActionsPerDay = 1
+
+	svc := NewService(Deps{
+		Health: &stubHealth{Report: rep},
+		Ledger: ledger,
+		Judge:  &stubJudge{verdict: Verdict{Classification: VerdictConfirmed}},
+		Actor:  &Actor{Tasks: updater, DryRun: false, Logger: slog.Default()},
+		Cfg:    cfg,
+	})
+
+	r, err := svc.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(r.ActionsTaken) != 0 {
+		t.Fatalf("ActionsTaken = %d, want 0 when budget exhausted", len(r.ActionsTaken))
+	}
+	if _, ok := updater.updated["task-capped"]; ok {
+		t.Error("task-capped updated despite exhausted budget")
+	}
+}
+
+func TestActor_RecordsActionToLedger(t *testing.T) {
+	updater := newStubUpdater()
+
+	ledgerPath := filepath.Join(t.TempDir(), "ledger.jsonl")
+	ledger, err := Open(ledgerPath)
+	if err != nil {
+		t.Fatalf("Open ledger: %v", err)
+	}
+
+	logPath := writeFixture(t, fixtureLines())
+	rep := &health.Report{
+		Findings: []health.Finding{{
+			Category:    health.CatTriageMismatch,
+			Fingerprint: "triage_mismatch:task-ledger",
+			TaskID:      "task-ledger",
+			LogFile:     logPath,
+		}},
+	}
+
+	cfg := configWithAutoAct(string(health.CatTriageMismatch))
+	cfg.MaxAutoActionsPerDay = 3
+
+	svc := NewService(Deps{
+		Health: &stubHealth{Report: rep},
+		Ledger: ledger,
+		Judge:  &stubJudge{verdict: Verdict{Classification: VerdictConfirmed}},
+		Actor:  &Actor{Tasks: updater, DryRun: false, Logger: slog.Default()},
+		Cfg:    cfg,
+	})
+
+	r, err := svc.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(r.ActionsTaken) != 1 {
+		t.Fatalf("ActionsTaken = %d, want 1", len(r.ActionsTaken))
+	}
+	if got := ledger.ActionsInWindow(24 * time.Hour); got != 1 {
+		t.Fatalf("ActionsInWindow = %d, want 1", got)
 	}
 }

--- a/internal/selfmonitor/correlator.go
+++ b/internal/selfmonitor/correlator.go
@@ -2,6 +2,7 @@ package selfmonitor
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/Automaat/synapse/internal/health"
 	"github.com/Automaat/synapse/internal/task"
@@ -46,10 +47,17 @@ func correlateByProject(findings []InvestigatedFinding, getTask func(id string) 
 		byProject[t.ProjectID] = append(byProject[t.ProjectID], inv.Fingerprint)
 	}
 	var out []Correlation
-	for projID, fps := range byProject {
+	projectIDs := make([]string, 0, len(byProject))
+	for projID := range byProject {
+		projectIDs = append(projectIDs, projID)
+	}
+	sort.Strings(projectIDs)
+	for _, projID := range projectIDs {
+		fps := append([]string(nil), byProject[projID]...)
 		if len(fps) < 2 {
 			continue
 		}
+		sort.Strings(fps)
 		out = append(out, Correlation{
 			Kind:         "same_project",
 			Key:          projID,
@@ -76,10 +84,17 @@ func correlateByErrorClass(findings []InvestigatedFinding) []Correlation {
 		byClass[cls] = append(byClass[cls], inv.Fingerprint)
 	}
 	var out []Correlation
-	for cls, fps := range byClass {
+	classes := make([]string, 0, len(byClass))
+	for cls := range byClass {
+		classes = append(classes, cls)
+	}
+	sort.Strings(classes)
+	for _, cls := range classes {
+		fps := append([]string(nil), byClass[cls]...)
 		if len(fps) < 2 {
 			continue
 		}
+		sort.Strings(fps)
 		out = append(out, Correlation{
 			Kind:         "same_error_class",
 			Key:          cls,
@@ -109,16 +124,24 @@ func correlateCascades(findings []InvestigatedFinding) []Correlation {
 		}
 	}
 	var out []Correlation
-	for tid, fp1 := range retryByTask {
+	taskIDs := make([]string, 0, len(retryByTask))
+	for tid := range retryByTask {
+		taskIDs = append(taskIDs, tid)
+	}
+	sort.Strings(taskIDs)
+	for _, tid := range taskIDs {
+		fp1 := retryByTask[tid]
 		fp2, ok := stuckByTask[tid]
 		if !ok {
 			continue
 		}
+		fps := []string{fp1, fp2}
+		sort.Strings(fps)
 		out = append(out, Correlation{
 			Kind:         "cascade",
 			Key:          tid,
 			Count:        2,
-			Fingerprints: []string{fp1, fp2},
+			Fingerprints: fps,
 			Description:  fmt.Sprintf("agent_retry_loop → stuck_task cascade on task %s", tid),
 		})
 	}

--- a/internal/selfmonitor/correlator.go
+++ b/internal/selfmonitor/correlator.go
@@ -1,0 +1,126 @@
+package selfmonitor
+
+import (
+	"fmt"
+
+	"github.com/Automaat/synapse/internal/health"
+	"github.com/Automaat/synapse/internal/task"
+)
+
+// Correlate groups a slice of InvestigatedFinding into cross-finding
+// Correlation entries using three deterministic strategies:
+//
+//   - same_project  — ≥2 findings whose TaskID resolves to the same ProjectID
+//   - same_error_class — ≥2 findings whose LogSummary top error class matches
+//   - cascade — agent_retry_loop + stuck_task sharing the same TaskID
+//
+// getTask is used only for same_project lookups; a nil result or error is
+// treated as "no project" and the finding is skipped for that strategy.
+// Returns nil when fewer than 2 findings are supplied.
+func Correlate(findings []InvestigatedFinding, getTask func(id string) (task.Task, error)) []Correlation {
+	if len(findings) < 2 {
+		return nil
+	}
+
+	var out []Correlation
+	out = append(out, correlateByProject(findings, getTask)...)
+	out = append(out, correlateByErrorClass(findings)...)
+	out = append(out, correlateCascades(findings)...)
+	return out
+}
+
+func correlateByProject(findings []InvestigatedFinding, getTask func(id string) (task.Task, error)) []Correlation {
+	if getTask == nil {
+		return nil
+	}
+	byProject := map[string][]string{} // projectID → fingerprints
+	for i := range findings {
+		inv := &findings[i]
+		if inv.Finding.TaskID == "" {
+			continue
+		}
+		t, err := getTask(inv.Finding.TaskID)
+		if err != nil || t.ProjectID == "" {
+			continue
+		}
+		byProject[t.ProjectID] = append(byProject[t.ProjectID], inv.Fingerprint)
+	}
+	var out []Correlation
+	for projID, fps := range byProject {
+		if len(fps) < 2 {
+			continue
+		}
+		out = append(out, Correlation{
+			Kind:         "same_project",
+			Key:          projID,
+			Count:        len(fps),
+			Fingerprints: fps,
+			Description:  fmt.Sprintf("%d findings share project %s", len(fps), projID),
+		})
+	}
+	return out
+}
+
+func correlateByErrorClass(findings []InvestigatedFinding) []Correlation {
+	byClass := map[string][]string{} // error class → fingerprints
+	for i := range findings {
+		inv := &findings[i]
+		if inv.LogSummary == nil || len(inv.LogSummary.ErrorClasses) == 0 {
+			continue
+		}
+		// ErrorClasses sorted by count descending; use the dominant class.
+		cls := inv.LogSummary.ErrorClasses[0].Class
+		if cls == "" || cls == "tool_error" || cls == "unknown" {
+			continue
+		}
+		byClass[cls] = append(byClass[cls], inv.Fingerprint)
+	}
+	var out []Correlation
+	for cls, fps := range byClass {
+		if len(fps) < 2 {
+			continue
+		}
+		out = append(out, Correlation{
+			Kind:         "same_error_class",
+			Key:          cls,
+			Count:        len(fps),
+			Fingerprints: fps,
+			Description:  fmt.Sprintf("%d findings share error class %q", len(fps), cls),
+		})
+	}
+	return out
+}
+
+func correlateCascades(findings []InvestigatedFinding) []Correlation {
+	retryByTask := map[string]string{} // taskID → fingerprint
+	stuckByTask := map[string]string{}
+	for i := range findings {
+		inv := &findings[i]
+		tid := inv.Finding.TaskID
+		if tid == "" {
+			continue
+		}
+		switch inv.Finding.Category {
+		case health.CatAgentRetryLoop:
+			retryByTask[tid] = inv.Fingerprint
+		case health.CatStuckTask:
+			stuckByTask[tid] = inv.Fingerprint
+		default:
+		}
+	}
+	var out []Correlation
+	for tid, fp1 := range retryByTask {
+		fp2, ok := stuckByTask[tid]
+		if !ok {
+			continue
+		}
+		out = append(out, Correlation{
+			Kind:         "cascade",
+			Key:          tid,
+			Count:        2,
+			Fingerprints: []string{fp1, fp2},
+			Description:  fmt.Sprintf("agent_retry_loop → stuck_task cascade on task %s", tid),
+		})
+	}
+	return out
+}

--- a/internal/selfmonitor/correlator_test.go
+++ b/internal/selfmonitor/correlator_test.go
@@ -208,3 +208,44 @@ func TestCorrelate_Cascade_NoMatchWhenDifferentTaskIDs(t *testing.T) {
 		}
 	}
 }
+
+func TestCorrelate_DeterministicOrder(t *testing.T) {
+	taskStore := map[string]task.Task{
+		"t1": {ID: "t1", ProjectID: "owner/b"},
+		"t2": {ID: "t2", ProjectID: "owner/a"},
+	}
+	getTask := func(id string) (task.Task, error) {
+		t, ok := taskStore[id]
+		if !ok {
+			return task.Task{}, os.ErrNotExist
+		}
+		return t, nil
+	}
+
+	findings := []InvestigatedFinding{
+		makeInv("fp3", health.CatAgentRetryLoop, "task-z", errorClassLS("permission_denied")),
+		makeInv("fp2", health.CatStuckTask, "task-z", errorClassLS("permission_denied")),
+		makeInv("fp1", health.CatCostOutlier, "t1", errorClassLS("auth_error")),
+		makeInv("fp4", health.CatStuckTask, "t2", errorClassLS("auth_error")),
+	}
+
+	cors := Correlate(findings, getTask)
+	if len(cors) != 3 {
+		t.Fatalf("correlations = %d, want 3", len(cors))
+	}
+
+	got := make([]string, 0, len(cors))
+	for _, c := range cors {
+		got = append(got, c.Kind+":"+c.Key)
+	}
+	want := []string{
+		"same_error_class:auth_error",
+		"same_error_class:permission_denied",
+		"cascade:task-z",
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order[%d] = %q, want %q (full=%v)", i, got[i], want[i], got)
+		}
+	}
+}

--- a/internal/selfmonitor/correlator_test.go
+++ b/internal/selfmonitor/correlator_test.go
@@ -1,0 +1,210 @@
+package selfmonitor
+
+import (
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/Automaat/synapse/internal/health"
+	"github.com/Automaat/synapse/internal/task"
+)
+
+// makeInv builds a minimal InvestigatedFinding for correlator tests.
+func makeInv(fp string, cat health.Category, taskID string, ls *LogSummary) InvestigatedFinding {
+	return InvestigatedFinding{
+		Fingerprint: fp,
+		Finding: health.Finding{
+			Category: cat,
+			TaskID:   taskID,
+		},
+		LogSummary: ls,
+		Verdict:    Verdict{Classification: VerdictPending},
+	}
+}
+
+// errorClassLS returns a LogSummary whose dominant error class is cls.
+func errorClassLS(cls string) *LogSummary {
+	return &LogSummary{
+		ErrorClasses: []ErrorClass{{Class: cls, Count: 3}},
+	}
+}
+
+func TestCorrelate_ReturnsNilForFewerThanTwoFindings(t *testing.T) {
+	got := Correlate([]InvestigatedFinding{makeInv("fp1", health.CatCostOutlier, "t1", nil)}, nil)
+	if got != nil {
+		t.Errorf("Correlate(1 finding) = %v, want nil", got)
+	}
+}
+
+func TestCorrelate_SameProject(t *testing.T) {
+	taskStore := map[string]task.Task{
+		"t1": {ID: "t1", ProjectID: "owner/repo"},
+		"t2": {ID: "t2", ProjectID: "owner/repo"},
+	}
+	getTask := func(id string) (task.Task, error) {
+		t, ok := taskStore[id]
+		if !ok {
+			return task.Task{}, os.ErrNotExist
+		}
+		return t, nil
+	}
+
+	findings := []InvestigatedFinding{
+		makeInv("fp1", health.CatCostOutlier, "t1", nil),
+		makeInv("fp2", health.CatStuckTask, "t2", nil),
+	}
+
+	cors := Correlate(findings, getTask)
+
+	var sameProj []Correlation
+	for _, c := range cors {
+		if c.Kind == "same_project" {
+			sameProj = append(sameProj, c)
+		}
+	}
+	if len(sameProj) != 1 {
+		t.Fatalf("same_project correlations = %d, want 1", len(sameProj))
+	}
+	c := sameProj[0]
+	if c.Key != "owner/repo" {
+		t.Errorf("Key = %q, want owner/repo", c.Key)
+	}
+	if c.Count != 2 {
+		t.Errorf("Count = %d, want 2", c.Count)
+	}
+	fps := append([]string(nil), c.Fingerprints...)
+	sort.Strings(fps)
+	if fps[0] != "fp1" || fps[1] != "fp2" {
+		t.Errorf("Fingerprints = %v, want [fp1 fp2]", fps)
+	}
+}
+
+func TestCorrelate_SameProject_SkipsWhenGetTaskNil(t *testing.T) {
+	findings := []InvestigatedFinding{
+		makeInv("fp1", health.CatCostOutlier, "t1", nil),
+		makeInv("fp2", health.CatStuckTask, "t2", nil),
+	}
+	cors := Correlate(findings, nil)
+	for _, c := range cors {
+		if c.Kind == "same_project" {
+			t.Errorf("same_project emitted with nil getTask: %+v", c)
+		}
+	}
+}
+
+func TestCorrelate_SameProject_SkipsSingleFindingPerProject(t *testing.T) {
+	taskStore := map[string]task.Task{
+		"t1": {ID: "t1", ProjectID: "owner/a"},
+		"t2": {ID: "t2", ProjectID: "owner/b"},
+	}
+	getTask := func(id string) (task.Task, error) {
+		t, ok := taskStore[id]
+		if !ok {
+			return task.Task{}, os.ErrNotExist
+		}
+		return t, nil
+	}
+	findings := []InvestigatedFinding{
+		makeInv("fp1", health.CatCostOutlier, "t1", nil),
+		makeInv("fp2", health.CatStuckTask, "t2", nil),
+	}
+	cors := Correlate(findings, getTask)
+	for _, c := range cors {
+		if c.Kind == "same_project" {
+			t.Errorf("same_project emitted for different projects: %+v", c)
+		}
+	}
+}
+
+func TestCorrelate_SameErrorClass(t *testing.T) {
+	findings := []InvestigatedFinding{
+		makeInv("fp1", health.CatCostOutlier, "t1", errorClassLS("permission_denied")),
+		makeInv("fp2", health.CatAgentRetryLoop, "t2", errorClassLS("permission_denied")),
+		makeInv("fp3", health.CatStuckTask, "t3", errorClassLS("auth_error")),
+	}
+	cors := Correlate(findings, nil)
+
+	var sameErr []Correlation
+	for _, c := range cors {
+		if c.Kind == "same_error_class" {
+			sameErr = append(sameErr, c)
+		}
+	}
+	if len(sameErr) != 1 {
+		t.Fatalf("same_error_class = %d, want 1", len(sameErr))
+	}
+	if sameErr[0].Key != "permission_denied" {
+		t.Errorf("Key = %q, want permission_denied", sameErr[0].Key)
+	}
+	if sameErr[0].Count != 2 {
+		t.Errorf("Count = %d, want 2", sameErr[0].Count)
+	}
+}
+
+func TestCorrelate_SameErrorClass_IgnoresToolErrorAndUnknown(t *testing.T) {
+	tests := []struct {
+		name string
+		cls  string
+	}{
+		{"tool_error ignored", "tool_error"},
+		{"unknown ignored", "unknown"},
+		{"empty ignored", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := []InvestigatedFinding{
+				makeInv("fp1", health.CatCostOutlier, "t1", errorClassLS(tt.cls)),
+				makeInv("fp2", health.CatStuckTask, "t2", errorClassLS(tt.cls)),
+			}
+			cors := Correlate(findings, nil)
+			for _, c := range cors {
+				if c.Kind == "same_error_class" {
+					t.Errorf("%s: same_error_class emitted for class %q: %+v", tt.name, tt.cls, c)
+				}
+			}
+		})
+	}
+}
+
+func TestCorrelate_Cascade(t *testing.T) {
+	findings := []InvestigatedFinding{
+		makeInv("fp-retry", health.CatAgentRetryLoop, "task-shared", nil),
+		makeInv("fp-stuck", health.CatStuckTask, "task-shared", nil),
+	}
+	cors := Correlate(findings, nil)
+
+	var cascades []Correlation
+	for _, c := range cors {
+		if c.Kind == "cascade" {
+			cascades = append(cascades, c)
+		}
+	}
+	if len(cascades) != 1 {
+		t.Fatalf("cascade = %d, want 1", len(cascades))
+	}
+	c := cascades[0]
+	if c.Key != "task-shared" {
+		t.Errorf("Key = %q, want task-shared", c.Key)
+	}
+	if c.Count != 2 {
+		t.Errorf("Count = %d, want 2", c.Count)
+	}
+	fps := append([]string(nil), c.Fingerprints...)
+	sort.Strings(fps)
+	if fps[0] != "fp-retry" || fps[1] != "fp-stuck" {
+		t.Errorf("Fingerprints = %v, want [fp-retry fp-stuck]", fps)
+	}
+}
+
+func TestCorrelate_Cascade_NoMatchWhenDifferentTaskIDs(t *testing.T) {
+	findings := []InvestigatedFinding{
+		makeInv("fp-retry", health.CatAgentRetryLoop, "task-a", nil),
+		makeInv("fp-stuck", health.CatStuckTask, "task-b", nil),
+	}
+	cors := Correlate(findings, nil)
+	for _, c := range cors {
+		if c.Kind == "cascade" {
+			t.Errorf("cascade emitted for different task IDs: %+v", c)
+		}
+	}
+}

--- a/internal/selfmonitor/judge.go
+++ b/internal/selfmonitor/judge.go
@@ -1,0 +1,197 @@
+package selfmonitor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"strings"
+
+	"github.com/Automaat/synapse/internal/health"
+	"github.com/Automaat/synapse/internal/task"
+)
+
+// Judge classifies a single health Finding given its distilled log summary
+// and optional task context. Returns a filled Verdict; callers should treat
+// errors as transient and keep the existing VerdictPending rather than
+// failing the whole tick.
+type Judge interface {
+	Judge(ctx context.Context, f health.Finding, ls *LogSummary, t *task.Task) (Verdict, error)
+}
+
+// ClaudeJudge is the production implementation. It spawns `claude -p` with a
+// compact prompt and parses the JSON verdict from the response envelope —
+// identical pattern to internal/triage.ClaudeClassifier.
+type ClaudeJudge struct {
+	Model  string // default: claude-haiku-4-5-20251001
+	Logger *slog.Logger
+}
+
+// Judge shells out to claude -p and returns a validated Verdict.
+func (j *ClaudeJudge) Judge(ctx context.Context, f health.Finding, ls *LogSummary, t *task.Task) (Verdict, error) {
+	model := j.Model
+	if model == "" {
+		model = "claude-haiku-4-5-20251001"
+	}
+
+	prompt := buildJudgePrompt(f, ls, t)
+
+	cmd := exec.CommandContext(ctx, "claude",
+		"-p", prompt,
+		"--output-format", "json",
+		"--dangerously-skip-permissions",
+		"--model", model,
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return Verdict{Classification: VerdictPending}, fmt.Errorf("claude -p: %w", err)
+	}
+
+	v, err := parseJudgeVerdict(out)
+	if err != nil {
+		return Verdict{Classification: VerdictPending}, fmt.Errorf("parse verdict: %w", err)
+	}
+	return v, nil
+}
+
+func buildJudgePrompt(f health.Finding, ls *LogSummary, t *task.Task) string {
+	var b strings.Builder
+
+	b.WriteString("You are diagnosing a Synapse agent workflow finding.\n")
+	b.WriteString("Output ONLY a single JSON object on the final line.\n\n")
+
+	b.WriteString("Finding:\n")
+	fmt.Fprintf(&b, "  category=%s severity=%s\n", f.Category, f.Severity)
+	fmt.Fprintf(&b, "  title=%s\n", f.Title)
+	if len(f.Evidence) > 0 {
+		ev, _ := json.Marshal(f.Evidence)
+		fmt.Fprintf(&b, "  evidence=%s\n", ev)
+	}
+	b.WriteString("\n")
+
+	if ls != nil {
+		b.WriteString("Log analysis:\n")
+		fmt.Fprintf(&b, "  totalToolCalls=%d costUSD=%.4f\n", ls.TotalToolCalls, ls.TotalCostUSD)
+		if ls.StallDetected {
+			fmt.Fprintf(&b, "  STALL: %s\n", ls.StallReason)
+		}
+		if len(ls.RepeatedCalls) > 0 {
+			rc, _ := json.Marshal(ls.RepeatedCalls)
+			fmt.Fprintf(&b, "  repeatedCalls=%s\n", rc)
+		}
+		if len(ls.ErrorClasses) > 0 {
+			ec, _ := json.Marshal(ls.ErrorClasses)
+			fmt.Fprintf(&b, "  errorClasses=%s\n", ec)
+		}
+		if len(ls.LastToolCalls) > 0 {
+			lc, _ := json.Marshal(ls.LastToolCalls)
+			fmt.Fprintf(&b, "  lastToolCalls=%s\n", lc)
+		}
+		b.WriteString("\n")
+	}
+
+	if t != nil {
+		fmt.Fprintf(&b, "Task: %s\n", t.Title)
+		body := t.Body
+		if len(body) > 500 {
+			body = body[:500] + "…"
+		}
+		if body != "" {
+			fmt.Fprintf(&b, "Body: %s\n", body)
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString(`Output schema (single JSON object, nothing else):
+{"classification":"confirmed|false_positive|needs_human","rootCause":"...","evidenceExcerpt":"...","confidence":0.0,"nextAction":"..."}
+
+Rules:
+- confirmed: run is genuinely broken or expensive beyond task scope
+- false_positive: cost/failure is proportional to task size or complexity
+- needs_human: ambiguous, no clear log signal
+- evidenceExcerpt: most diagnostic line from the log (stall reason, repeated call, error)
+- nextAction: one specific actionable fix — not "investigate further"
+`)
+	return b.String()
+}
+
+// parseJudgeVerdict extracts the verdict from `claude -p --output-format json`
+// stdout. The envelope has a `result` string field; we extract the last JSON
+// object from it.
+func parseJudgeVerdict(raw []byte) (Verdict, error) {
+	var envelope struct {
+		Result string `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return Verdict{}, fmt.Errorf("unmarshal envelope: %w", err)
+	}
+	if envelope.Result == "" {
+		return Verdict{}, fmt.Errorf("empty result field")
+	}
+	jsonStr := judgeExtractLastJSON(envelope.Result)
+	if jsonStr == "" {
+		return Verdict{}, fmt.Errorf("no JSON object in result: %q", envelope.Result)
+	}
+	var v Verdict
+	if err := json.Unmarshal([]byte(jsonStr), &v); err != nil {
+		return Verdict{}, fmt.Errorf("unmarshal verdict: %w", err)
+	}
+	if v.Classification == "" {
+		v.Classification = VerdictPending
+	}
+	return v, nil
+}
+
+// judgeExtractLastJSON returns the last balanced {...} substring in s, or "".
+// Mirrors triage.extractLastJSONObject and internal/agent/inspector.go.
+func judgeExtractLastJSON(s string) string {
+	s = strings.TrimSpace(s)
+	var (
+		inString  bool
+		escape    bool
+		depth     int
+		objStart  = -1
+		lastStart = -1
+		lastEnd   = -1
+	)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if escape {
+			escape = false
+			continue
+		}
+		if inString {
+			switch c {
+			case '\\':
+				escape = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inString = true
+		case '{':
+			if depth == 0 {
+				objStart = i
+			}
+			depth++
+		case '}':
+			if depth == 0 {
+				continue
+			}
+			depth--
+			if depth == 0 && objStart >= 0 {
+				lastStart = objStart
+				lastEnd = i
+				objStart = -1
+			}
+		}
+	}
+	if lastStart < 0 {
+		return ""
+	}
+	return s[lastStart : lastEnd+1]
+}

--- a/internal/selfmonitor/judge_test.go
+++ b/internal/selfmonitor/judge_test.go
@@ -1,0 +1,235 @@
+package selfmonitor
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Automaat/synapse/internal/health"
+	"github.com/Automaat/synapse/internal/task"
+)
+
+// stubJudge satisfies the Judge interface for unit tests.
+type stubJudge struct {
+	verdict Verdict
+	err     error
+}
+
+func (s *stubJudge) Judge(_ context.Context, _ health.Finding, _ *LogSummary, _ *task.Task) (Verdict, error) {
+	return s.verdict, s.err
+}
+
+func TestJudge_FillsVerdictWhenLogSummaryAvailable(t *testing.T) {
+	j := &stubJudge{
+		verdict: Verdict{
+			Classification: VerdictConfirmed,
+			RootCause:      "tool loop on Bash",
+			Confidence:     0.9,
+		},
+	}
+
+	logsDir := t.TempDir()
+	logPath := writeFixture(t, fixtureLines())
+
+	rep := &health.Report{
+		Score: health.ScoreWarning,
+		Findings: []health.Finding{{
+			Category:    health.CatCostOutlier,
+			Fingerprint: "cost_outlier:task-judge",
+			TaskID:      "task-judge",
+			LogFile:     logPath,
+		}},
+	}
+
+	svc := NewService(Deps{
+		Health:  &stubHealth{Report: rep},
+		LogsDir: logsDir,
+		Judge:   j,
+	})
+
+	r, err := svc.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings = %d, want 1", len(r.Findings))
+	}
+	inv := r.Findings[0]
+	if inv.Verdict.Classification != VerdictConfirmed {
+		t.Errorf("Classification = %q, want confirmed", inv.Verdict.Classification)
+	}
+	if inv.Verdict.RootCause != "tool loop on Bash" {
+		t.Errorf("RootCause = %q, want 'tool loop on Bash'", inv.Verdict.RootCause)
+	}
+}
+
+func TestJudge_KeepsVerdictPendingOnError(t *testing.T) {
+	j := &stubJudge{err: errors.New("claude unavailable")}
+
+	logPath := writeFixture(t, fixtureLines())
+
+	rep := &health.Report{
+		Findings: []health.Finding{{
+			Category:    health.CatCostOutlier,
+			Fingerprint: "cost_outlier:task-judge-err",
+			LogFile:     logPath,
+		}},
+	}
+
+	svc := NewService(Deps{
+		Health: &stubHealth{Report: rep},
+		Judge:  j,
+	})
+
+	r, err := svc.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if len(r.Findings) != 1 {
+		t.Fatalf("Findings = %d, want 1", len(r.Findings))
+	}
+	if r.Findings[0].Verdict.Classification != VerdictPending {
+		t.Errorf("Classification = %q, want pending after judge error", r.Findings[0].Verdict.Classification)
+	}
+}
+
+func TestJudge_SkippedWhenNoLogSummary(t *testing.T) {
+	called := false
+	j := &stubJudge{verdict: Verdict{Classification: VerdictConfirmed}}
+	_ = j
+
+	// Wrap stubJudge to detect calls.
+	spyJudge := &spyCallJudge{inner: j, onCall: func() { called = true }}
+
+	rep := &health.Report{
+		Findings: []health.Finding{{
+			Category:    health.CatStuckTask,
+			Fingerprint: "stuck_task:task-no-log",
+			// No LogFile, no AgentID → no LogSummary.
+		}},
+	}
+
+	svc := NewService(Deps{
+		Health: &stubHealth{Report: rep},
+		Judge:  spyJudge,
+	})
+
+	r, err := svc.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if called {
+		t.Error("Judge called when LogSummary is nil, want skipped")
+	}
+	if r.Findings[0].Verdict.Classification != VerdictPending {
+		t.Errorf("Classification = %q, want pending when judge skipped", r.Findings[0].Verdict.Classification)
+	}
+}
+
+// spyCallJudge wraps a Judge and calls onCall before delegating.
+type spyCallJudge struct {
+	inner  Judge
+	onCall func()
+}
+
+func (s *spyCallJudge) Judge(ctx context.Context, f health.Finding, ls *LogSummary, t *task.Task) (Verdict, error) {
+	s.onCall()
+	return s.inner.Judge(ctx, f, ls, t)
+}
+
+func TestParseJudgeVerdict_ExtractsLastJSONObject(t *testing.T) {
+	tests := []struct {
+		name          string
+		raw           []byte
+		wantClass     string
+		wantRootCause string
+		wantErr       bool
+	}{
+		{
+			name:          "clean JSON in result",
+			raw:           []byte(`{"result":"{\"classification\":\"confirmed\",\"rootCause\":\"tool loop\",\"confidence\":0.85}"}`),
+			wantClass:     VerdictConfirmed,
+			wantRootCause: "tool loop",
+		},
+		{
+			name:          "JSON preceded by prose",
+			raw:           []byte(`{"result":"Analysis follows.\n{\"classification\":\"false_positive\",\"rootCause\":\"proportional cost\"}"}`),
+			wantClass:     VerdictFalsePositive,
+			wantRootCause: "proportional cost",
+		},
+		{
+			name:    "empty result field",
+			raw:     []byte(`{"result":""}`),
+			wantErr: true,
+		},
+		{
+			name:    "malformed envelope",
+			raw:     []byte(`not json`),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := parseJudgeVerdict(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("parseJudgeVerdict: want error, got nil (verdict=%+v)", v)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseJudgeVerdict: %v", err)
+			}
+			if v.Classification != tt.wantClass {
+				t.Errorf("Classification = %q, want %q", v.Classification, tt.wantClass)
+			}
+			if v.RootCause != tt.wantRootCause {
+				t.Errorf("RootCause = %q, want %q", v.RootCause, tt.wantRootCause)
+			}
+		})
+	}
+}
+
+func TestJudgeExtractLastJSON_ReturnsLastObject(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "single object",
+			input: `{"a":"b"}`,
+			want:  `{"a":"b"}`,
+		},
+		{
+			name:  "prose then object",
+			input: `some text {"classification":"confirmed"}`,
+			want:  `{"classification":"confirmed"}`,
+		},
+		{
+			name:  "two objects, returns last",
+			input: `{"first":1} more text {"second":2}`,
+			want:  `{"second":2}`,
+		},
+		{
+			name:  "no object",
+			input: `plain text only`,
+			want:  "",
+		},
+		{
+			name:  "nested object",
+			input: `{"outer":{"inner":1}}`,
+			want:  `{"outer":{"inner":1}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := judgeExtractLastJSON(tt.input)
+			if got != tt.want {
+				t.Errorf("judgeExtractLastJSON(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/selfmonitor/provider_feedback_test.go
+++ b/internal/selfmonitor/provider_feedback_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Automaat/synapse/internal/health"
+	"github.com/Automaat/synapse/internal/task"
 )
 
 // stubProviderGate records calls to ReportRateLimit for assertion.
@@ -91,6 +92,50 @@ func TestProviderFeedback_ReportsRateLimitForOverloadedError(t *testing.T) {
 	}
 	if !strings.Contains(call.reason, "overloaded_error") {
 		t.Errorf("reason = %q, want to mention overloaded_error", call.reason)
+	}
+}
+
+func TestProviderFeedback_UsesTaskRunProviderWhenAvailable(t *testing.T) {
+	logsDir := t.TempDir()
+	logPath := writeFixtureInAgentsDir(t, logsDir, "agent-codex", overloadedFixtureLines())
+
+	gate := &stubProviderGate{}
+	tasks := &stubTasks{
+		byID: map[string]task.Task{
+			"task-codex": {
+				ID: "task-codex",
+				AgentRuns: []task.AgentRun{
+					{AgentID: "agent-codex", Provider: "codex", LogFile: logPath},
+				},
+			},
+		},
+	}
+	rep := &health.Report{
+		Findings: []health.Finding{{
+			Category:    health.CatAgentRetryLoop,
+			Fingerprint: "agent_retry_loop:task-codex",
+			TaskID:      "task-codex",
+			AgentID:     "agent-codex",
+			LogFile:     logPath,
+		}},
+	}
+
+	svc := NewService(Deps{
+		Health:       &stubHealth{Report: rep},
+		Tasks:        tasks,
+		ProviderGate: gate,
+	})
+
+	_, err := svc.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	if len(gate.calls) != 1 {
+		t.Fatalf("ReportRateLimit calls = %d, want 1", len(gate.calls))
+	}
+	if gate.calls[0].provider != "codex" {
+		t.Errorf("provider = %q, want codex", gate.calls[0].provider)
 	}
 }
 

--- a/internal/selfmonitor/provider_feedback_test.go
+++ b/internal/selfmonitor/provider_feedback_test.go
@@ -1,0 +1,213 @@
+package selfmonitor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Automaat/synapse/internal/health"
+)
+
+// stubProviderGate records calls to ReportRateLimit for assertion.
+type stubProviderGate struct {
+	calls []providerRateLimitCall
+}
+
+type providerRateLimitCall struct {
+	provider string
+	after    time.Duration
+	reason   string
+}
+
+func (s *stubProviderGate) IsHealthy(_ string) bool       { return true }
+func (s *stubProviderGate) Failover(_ string) string      { return "" }
+func (s *stubProviderGate) Reason(_ string) string        { return "" }
+func (s *stubProviderGate) ReportAuthFailure(_, _ string) {}
+func (s *stubProviderGate) ReportRateLimit(provider string, after time.Duration, reason string) {
+	s.calls = append(s.calls, providerRateLimitCall{provider: provider, after: after, reason: reason})
+}
+
+// overloadedFixtureLines returns a Codex-format NDJSON stream that produces
+// an overloaded_error class. ClaudeResult.ErrorType is NOT populated from
+// Claude stream-json (extractResultFieldsTyped doesn't map it), so we use
+// the Codex envelope format where "type":"error" carries error_type directly.
+func overloadedFixtureLines() []string {
+	return []string{
+		`{"type":"thread.started","thread_id":"t1"}`,
+		`{"type":"error","error_type":"overloaded_error","message":"API overloaded","code":529}`,
+	}
+}
+
+func writeFixtureInAgentsDir(t *testing.T, logsDir, agentID string, lines []string) string {
+	t.Helper()
+	agentsDir := filepath.Join(logsDir, "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatalf("mkdir agents: %v", err)
+	}
+	path := filepath.Join(agentsDir, agentID+"-2026-04-14T10-00-00.ndjson")
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func TestProviderFeedback_ReportsRateLimitForOverloadedError(t *testing.T) {
+	logsDir := t.TempDir()
+	logPath := writeFixtureInAgentsDir(t, logsDir, "agent-overload", overloadedFixtureLines())
+
+	gate := &stubProviderGate{}
+	rep := &health.Report{
+		Findings: []health.Finding{{
+			Category:    health.CatAgentRetryLoop,
+			Fingerprint: "agent_retry_loop:task-ol",
+			TaskID:      "task-ol",
+			AgentID:     "agent-overload",
+			LogFile:     logPath,
+		}},
+	}
+
+	svc := NewService(Deps{
+		Health:       &stubHealth{Report: rep},
+		ProviderGate: gate,
+	})
+
+	_, err := svc.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	if len(gate.calls) != 1 {
+		t.Fatalf("ReportRateLimit calls = %d, want 1", len(gate.calls))
+	}
+	call := gate.calls[0]
+	if call.provider != "claude" {
+		t.Errorf("provider = %q, want claude", call.provider)
+	}
+	if call.after != 15*time.Minute {
+		t.Errorf("retryAfter = %v, want 15m", call.after)
+	}
+	if !strings.Contains(call.reason, "overloaded_error") {
+		t.Errorf("reason = %q, want to mention overloaded_error", call.reason)
+	}
+}
+
+func TestProviderFeedback_SkipsNonRetryLoopCategory(t *testing.T) {
+	categories := []health.Category{
+		health.CatCostOutlier,
+		health.CatStuckTask,
+		health.CatTriageMismatch,
+		health.CatFailureRate,
+	}
+
+	for _, cat := range categories {
+		t.Run(string(cat), func(t *testing.T) {
+			logPath := writeFixture(t, overloadedFixtureLines())
+
+			gate := &stubProviderGate{}
+			rep := &health.Report{
+				Findings: []health.Finding{{
+					Category:    cat,
+					Fingerprint: string(cat) + ":t1",
+					TaskID:      "t1",
+					LogFile:     logPath,
+				}},
+			}
+
+			svc := NewService(Deps{
+				Health:       &stubHealth{Report: rep},
+				ProviderGate: gate,
+			})
+
+			_, err := svc.Scan(context.Background())
+			if err != nil {
+				t.Fatalf("Scan: %v", err)
+			}
+
+			if len(gate.calls) != 0 {
+				t.Errorf("ReportRateLimit called for category %q, want skipped", cat)
+			}
+		})
+	}
+}
+
+func TestProviderFeedback_SkipsWhenNoMatchingErrorClass(t *testing.T) {
+	// permission_denied error: should not trigger provider feedback.
+	logPath := writeFixture(t, fixtureLines()) // fixture has permission_denied
+
+	gate := &stubProviderGate{}
+	rep := &health.Report{
+		Findings: []health.Finding{{
+			Category:    health.CatAgentRetryLoop,
+			Fingerprint: "agent_retry_loop:t1",
+			TaskID:      "t1",
+			LogFile:     logPath,
+		}},
+	}
+
+	svc := NewService(Deps{
+		Health:       &stubHealth{Report: rep},
+		ProviderGate: gate,
+	})
+
+	_, err := svc.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	if len(gate.calls) != 0 {
+		t.Errorf("ReportRateLimit called for permission_denied error class, want skipped")
+	}
+}
+
+func TestProviderFeedback_SkipsWhenProviderGateNil(t *testing.T) {
+	logPath := writeFixture(t, overloadedFixtureLines())
+
+	rep := &health.Report{
+		Findings: []health.Finding{{
+			Category:    health.CatAgentRetryLoop,
+			Fingerprint: "agent_retry_loop:t1",
+			TaskID:      "t1",
+			LogFile:     logPath,
+		}},
+	}
+
+	svc := NewService(Deps{
+		Health:       &stubHealth{Report: rep},
+		ProviderGate: nil,
+	})
+
+	// Must not panic or error.
+	_, err := svc.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan with nil ProviderGate: %v", err)
+	}
+}
+
+func TestProviderFeedback_SkipsWhenLogSummaryNil(t *testing.T) {
+	// No LogFile, no AgentID → no LogSummary.
+	gate := &stubProviderGate{}
+	rep := &health.Report{
+		Findings: []health.Finding{{
+			Category:    health.CatAgentRetryLoop,
+			Fingerprint: "agent_retry_loop:t1",
+			TaskID:      "t1",
+		}},
+	}
+
+	svc := NewService(Deps{
+		Health:       &stubHealth{Report: rep},
+		ProviderGate: gate,
+	})
+
+	_, err := svc.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	if len(gate.calls) != 0 {
+		t.Errorf("ReportRateLimit called with nil LogSummary, want skipped")
+	}
+}

--- a/internal/selfmonitor/service.go
+++ b/internal/selfmonitor/service.go
@@ -8,12 +8,14 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"time"
 
 	"github.com/Automaat/synapse/internal/agent"
 	"github.com/Automaat/synapse/internal/config"
 	"github.com/Automaat/synapse/internal/events"
 	"github.com/Automaat/synapse/internal/health"
+	"github.com/Automaat/synapse/internal/provider"
 	"github.com/Automaat/synapse/internal/task"
 )
 
@@ -85,6 +87,16 @@ type Deps struct {
 	Now              func() time.Time
 	AllowsProject    func(projectID string) bool
 	MaxLogEventsHint int // caps loganalyzer.Analyze; 0 → default
+
+	// Judge is the LLM classifier for Phase C verdict generation.
+	// nil disables verdict generation (tests, opt-out).
+	Judge Judge
+	// Actor is the autonomous remediator for Phase D actions.
+	// nil disables remediation.
+	Actor *Actor
+	// ProviderGate receives passive rate-limit signals derived from log analysis.
+	// nil disables provider feedback.
+	ProviderGate provider.HealthGate
 }
 
 // Service is the in-process self-monitor loop. Each tick snapshots the
@@ -171,7 +183,7 @@ func (s *Service) tickAndLog(ctx context.Context) {
 	)
 }
 
-func (s *Service) tick(_ context.Context) (Report, error) {
+func (s *Service) tick(ctx context.Context) (Report, error) {
 	start := s.deps.Now()
 	report := Report{
 		SchemaVersion: ReportSchemaVersion,
@@ -200,12 +212,30 @@ func (s *Service) tick(_ context.Context) (Report, error) {
 	report.PeriodEnd = hr.PeriodEnd
 
 	for i := range hr.Findings {
-		inv, skipped := s.investigate(&hr.Findings[i])
+		inv, skipped := s.investigate(ctx, &hr.Findings[i])
 		if skipped {
 			report.Suppressed++
 			continue
 		}
 		report.Findings = append(report.Findings, inv)
+	}
+
+	// Cross-finding correlations (pure Go, no I/O).
+	if s.deps.Tasks != nil && len(report.Findings) > 1 {
+		report.Correlations = Correlate(report.Findings, s.deps.Tasks.Get)
+	}
+
+	// Phase D: act on confirmed findings in allowed categories.
+	if s.deps.Actor != nil {
+		for i := range report.Findings {
+			cat := string(report.Findings[i].Finding.Category)
+			if !slices.Contains(s.deps.Cfg.AutoActCategories, cat) {
+				continue
+			}
+			if rec := s.deps.Actor.Act(ctx, report.Findings[i]); rec.Kind != "" {
+				report.ActionsTaken = append(report.ActionsTaken, rec)
+			}
+		}
 	}
 
 	return s.finalize(report, start), nil
@@ -214,7 +244,7 @@ func (s *Service) tick(_ context.Context) (Report, error) {
 // investigate runs the per-finding distillation pipeline. Returns skipped=true
 // when the ledger auto-suppresses the fingerprint or the AllowsProject gate
 // rejects the task's project.
-func (s *Service) investigate(f *health.Finding) (InvestigatedFinding, bool) {
+func (s *Service) investigate(ctx context.Context, f *health.Finding) (InvestigatedFinding, bool) {
 	if !s.projectAllowed(f) {
 		return InvestigatedFinding{}, true
 	}
@@ -236,7 +266,47 @@ func (s *Service) investigate(f *health.Finding) (InvestigatedFinding, bool) {
 			inv.LogSummary = &summary
 		}
 	}
+
+	// Phase C: LLM judge — fill Verdict when a LogSummary is available.
+	if s.deps.Judge != nil && inv.LogSummary != nil {
+		var tp *task.Task
+		if f.TaskID != "" && s.deps.Tasks != nil {
+			if t, err := s.deps.Tasks.Get(f.TaskID); err == nil {
+				tp = &t
+			}
+		}
+		if v, err := s.deps.Judge.Judge(ctx, *f, inv.LogSummary, tp); err != nil {
+			s.deps.Logger.Warn("selfmonitor.judge", "fp", f.Fingerprint, "err", err)
+		} else {
+			inv.Verdict = v
+		}
+	}
+
+	// Provider feedback: passive rate-limit signal from retry-loop logs.
+	s.reportProviderSignal(f, inv.LogSummary)
+
 	return inv, false
+}
+
+// reportProviderSignal calls ReportRateLimit on the provider gate when an
+// agent_retry_loop finding's log shows overloaded or rate-limit errors. This
+// lets the provider health system trigger failover without waiting for a probe.
+func (s *Service) reportProviderSignal(f *health.Finding, ls *LogSummary) {
+	if s.deps.ProviderGate == nil || ls == nil {
+		return
+	}
+	if f.Category != health.CatAgentRetryLoop {
+		return
+	}
+	for _, ec := range ls.ErrorClasses {
+		if ec.Class == "overloaded_error" || ec.Class == "rate_limit" {
+			s.deps.ProviderGate.ReportRateLimit("claude", 15*time.Minute,
+				"selfmonitor: agent_retry_loop with "+ec.Class)
+			s.deps.Logger.Info("selfmonitor.provider_signal",
+				"class", ec.Class, "task", f.TaskID)
+			return
+		}
+	}
 }
 
 func (s *Service) projectAllowed(f *health.Finding) bool {

--- a/internal/selfmonitor/service.go
+++ b/internal/selfmonitor/service.go
@@ -232,8 +232,14 @@ func (s *Service) tick(ctx context.Context) (Report, error) {
 			if !slices.Contains(s.deps.Cfg.AutoActCategories, cat) {
 				continue
 			}
+			if !s.canTakeAutoAction(len(report.ActionsTaken)) {
+				s.deps.Logger.Info("selfmonitor.actor.budget_reached",
+					"max_auto_actions_per_day", s.deps.Cfg.MaxAutoActionsPerDay)
+				break
+			}
 			if rec := s.deps.Actor.Act(ctx, report.Findings[i]); rec.Kind != "" {
 				report.ActionsTaken = append(report.ActionsTaken, rec)
+				s.recordAction(report.Findings[i], rec)
 			}
 		}
 	}
@@ -298,14 +304,89 @@ func (s *Service) reportProviderSignal(f *health.Finding, ls *LogSummary) {
 	if f.Category != health.CatAgentRetryLoop {
 		return
 	}
+	providerName := s.resolveProvider(f)
+	if providerName == "" {
+		providerName = "claude"
+	}
 	for _, ec := range ls.ErrorClasses {
 		if ec.Class == "overloaded_error" || ec.Class == "rate_limit" {
-			s.deps.ProviderGate.ReportRateLimit("claude", 15*time.Minute,
+			s.deps.ProviderGate.ReportRateLimit(providerName, 15*time.Minute,
 				"selfmonitor: agent_retry_loop with "+ec.Class)
 			s.deps.Logger.Info("selfmonitor.provider_signal",
-				"class", ec.Class, "task", f.TaskID)
+				"class", ec.Class, "task", f.TaskID, "provider", providerName)
 			return
 		}
+	}
+}
+
+func (s *Service) resolveProvider(f *health.Finding) string {
+	if f == nil || f.TaskID == "" || s.deps.Tasks == nil {
+		return ""
+	}
+	t, err := s.deps.Tasks.Get(f.TaskID)
+	if err != nil {
+		return ""
+	}
+
+	latestByTime := ""
+	latestByTimeAt := time.Time{}
+	latestAny := ""
+	for i := range t.AgentRuns {
+		run := t.AgentRuns[i]
+		if run.Provider == "" {
+			continue
+		}
+		if latestAny == "" {
+			latestAny = run.Provider
+		}
+		if f.AgentID != "" && run.AgentID == f.AgentID {
+			return run.Provider
+		}
+		if f.LogFile != "" && run.LogFile != "" && run.LogFile == f.LogFile {
+			return run.Provider
+		}
+		if run.StartedAt.After(latestByTimeAt) {
+			latestByTimeAt = run.StartedAt
+			latestByTime = run.Provider
+		}
+	}
+	if latestByTime != "" {
+		return latestByTime
+	}
+	return latestAny
+}
+
+func (s *Service) canTakeAutoAction(takenThisTick int) bool {
+	maxActions := s.deps.Cfg.MaxAutoActionsPerDay
+	if maxActions <= 0 {
+		return true
+	}
+	alreadyTaken := takenThisTick
+	if s.deps.Ledger != nil {
+		alreadyTaken += s.deps.Ledger.ActionsInWindow(24 * time.Hour)
+	}
+	return alreadyTaken < maxActions
+}
+
+func (s *Service) recordAction(inv InvestigatedFinding, rec ActionRecord) {
+	if s.deps.Ledger == nil {
+		return
+	}
+	entry := LedgerEntry{
+		Fingerprint: inv.Fingerprint,
+		Category:    string(inv.Finding.Category),
+		TaskID:      inv.Finding.TaskID,
+		Verdict:     inv.Verdict.Classification,
+		Action:      rec.Kind,
+		ActionRef:   rec.Reference,
+		DryRun:      rec.DryRun,
+		Confidence:  inv.Verdict.Confidence,
+		Summary:     inv.Verdict.RootCause,
+		CreatedAt:   rec.TakenAt,
+	}
+	if err := s.deps.Ledger.Append(entry); err != nil {
+		s.deps.Logger.Warn("selfmonitor.ledger.append_action",
+			"fingerprint", inv.Fingerprint, "action", rec.Kind, "err", err)
 	}
 }
 

--- a/internal/synapse/app.go
+++ b/internal/synapse/app.go
@@ -409,6 +409,16 @@ func (a *App) startSelfMonitorService(ctx context.Context, emit func(string, any
 			}
 			return a.allowsProjectType(p.Type)
 		},
+		Judge: &selfmonitor.ClaudeJudge{
+			Model:  a.cfg.SelfMonitor.JudgeModel,
+			Logger: a.logger,
+		},
+		Actor: &selfmonitor.Actor{
+			Tasks:  a.tasks,
+			DryRun: a.cfg.SelfMonitor.DryRun,
+			Logger: a.logger,
+		},
+		ProviderGate: a.providerHealth,
 	})
 	a.selfMonitorSvc = svc
 	a.wg.Go(func() { svc.Run(ctx) })


### PR DESCRIPTION
## Motivation

The selfmonitor service shipped with Phase A (loganalyzer, ledger) and
Phase B (log distillation, investigate pipeline) but Phase C (LLM judge
→ Verdict) and Phase D (actor → ActionRecord) were scaffolded with all
the right types and config fields and never implemented. Three mechanical
gaps also existed: no Go correlator, no provider health feedback from
retry-loop findings, and `synapse-audit` reading the older `health`
report instead of the richer `selfmonitor scan` output.

> Changelog: feat(selfmonitor): Phase C/D judge + actor

## Implementation information

**New files:**

- `internal/selfmonitor/judge.go` — `ClaudeJudge` mirrors
  `triage.ClaudeClassifier` exactly: spawns `claude -p` (haiku by
  default via `cfg.SelfMonitor.JudgeModel`), parses JSON envelope,
  fills `Verdict.{Classification,RootCause,EvidenceExcerpt,Confidence,
  NextAction}`. Judge is nil-safe — skipped when no LogSummary.
- `internal/selfmonitor/actor.go` — `Actor` acts on confirmed
  `triage_mismatch` findings by flipping `agent_mode` to `interactive`.
  Respects `DryRun` (config default: `true`).
- `internal/selfmonitor/correlator.go` — `Correlate()` groups findings
  by `same_project`, `same_error_class`, and `cascade`
  (retry+stuck same task). Populates `Report.Correlations`.

**Modified:**

- `internal/selfmonitor/service.go` — threaded `ctx` into
  `tick`/`investigate`; added `Judge`/`Actor`/`ProviderGate` to `Deps`;
  `reportProviderSignal` calls `ReportRateLimit("claude", 15m)` when
  retry-loop logs show `overloaded_error`/`rate_limit`.
- `internal/synapse/app.go` — injects `ClaudeJudge`, `Actor`,
  `a.providerHealth` into `startSelfMonitorService`.
- `.claude/skills/synapse-audit.md` — Step 1 reads `selfmonitor scan`
  (with `health` fallback); Step 3 cites `logSummary` signals directly;
  output includes correlations section.

**Tests:** 23 new tests across `correlator_test.go`, `judge_test.go`,
`actor_test.go`, `provider_feedback_test.go`.