### PR TITLE
feat(ui): add auto-scroll toggle to agent output

### DIFF
--- a/frontend/src/components/ChatView.svelte
+++ b/frontend/src/components/ChatView.svelte
@@ -36,6 +36,11 @@
     contextPct > 80 ? 'bg-error-500' : contextPct > 50 ? 'bg-warning-500' : 'bg-success-500',
   )
 
+  function onScroll() {
+    if (!container) return
+    autoScroll = container.scrollHeight - container.scrollTop - container.clientHeight < 10
+  }
+
   function scrollToBottom() {
     if (autoScroll && container) {
       container.scrollTop = container.scrollHeight
@@ -122,6 +127,7 @@
   <!-- Messages -->
   <div
     bind:this={container}
+    onscroll={onScroll}
     class="flex min-h-0 flex-col gap-3 overflow-y-auto overscroll-contain px-3 py-3 md:px-4 {bounded ? 'max-h-[60dvh] md:max-h-[600px]' : 'flex-1'}"
   >
     {#if events.length === 0}

--- a/frontend/src/components/ChatView.svelte
+++ b/frontend/src/components/ChatView.svelte
@@ -18,6 +18,7 @@
 
   let events = $state<agent.ConvoEvent[]>([])
   let container: HTMLDivElement | undefined = $state()
+  let autoScroll = $state(true)
 
   const isRunning = $derived(agentState === 'running')
   const isPaused = $derived(agentState === 'paused')
@@ -36,7 +37,7 @@
   )
 
   function scrollToBottom() {
-    if (container) {
+    if (autoScroll && container) {
       container.scrollTop = container.scrollHeight
     }
   }
@@ -102,6 +103,20 @@
     {#if costUsd > 0}
       <span class="text-xs text-surface-500">${costUsd.toFixed(2)}</span>
     {/if}
+
+    <button
+      onclick={() => { autoScroll = !autoScroll }}
+      title={autoScroll ? 'Disable auto-scroll' : 'Enable auto-scroll'}
+      class="ml-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors
+        {autoScroll
+          ? 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200'
+          : 'bg-surface-200 text-surface-500 dark:bg-surface-700 dark:text-surface-400'}"
+    >
+      <svg class="h-3 w-3" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M8 3v8M5 8l3 3 3-3" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      {autoScroll ? 'Auto-scroll on' : 'Auto-scroll off'}
+    </button>
   </div>
 
   <!-- Messages -->

--- a/frontend/src/components/StreamOutput.svelte
+++ b/frontend/src/components/StreamOutput.svelte
@@ -13,6 +13,7 @@
 
   let events = $state<agent.StreamEvent[]>([])
   let container: HTMLDivElement | undefined = $state()
+  let autoScroll = $state(true)
 
   const typeStyles: Record<string, { label: string; classes: string }> = {
     init: { label: 'INIT', classes: 'bg-surface-300 text-surface-800 dark:bg-surface-600 dark:text-surface-200' },
@@ -23,7 +24,7 @@
   }
 
   function scrollToBottom() {
-    if (container) {
+    if (autoScroll && container) {
       container.scrollTop = container.scrollHeight
     }
   }
@@ -54,21 +55,38 @@
   })
 </script>
 
-<div
-  bind:this={container}
-  class="flex max-h-[60dvh] md:max-h-[600px] flex-col gap-1 overflow-y-auto rounded-lg border border-surface-300 bg-surface-900 p-3 font-mono text-xs dark:border-surface-600"
->
-  {#if events.length === 0}
-    <p class="py-8 text-center text-surface-500">Waiting for output...</p>
-  {:else}
-    {#each events as event, i (i)}
-      {@const style = typeStyles[event.type] ?? { label: event.type.toUpperCase(), classes: 'bg-surface-300 text-surface-800' }}
-      <div class="flex items-start gap-2">
-        <span class="mt-0.5 inline-block shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold {style.classes}">
-          {style.label}
-        </span>
-        <pre class="min-w-0 flex-1 whitespace-pre-wrap break-words text-surface-200">{event.content ?? ''}</pre>
-      </div>
-    {/each}
-  {/if}
+<div class="flex flex-col gap-1">
+  <div class="flex items-center justify-end">
+    <button
+      onclick={() => { autoScroll = !autoScroll }}
+      title={autoScroll ? 'Disable auto-scroll' : 'Enable auto-scroll'}
+      class="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors
+        {autoScroll
+          ? 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200'
+          : 'bg-surface-200 text-surface-500 dark:bg-surface-700 dark:text-surface-400'}"
+    >
+      <svg class="h-3 w-3" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M8 3v8M5 8l3 3 3-3" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      {autoScroll ? 'Auto-scroll on' : 'Auto-scroll off'}
+    </button>
+  </div>
+  <div
+    bind:this={container}
+    class="flex max-h-[60dvh] md:max-h-[600px] flex-col gap-1 overflow-y-auto rounded-lg border border-surface-300 bg-surface-900 p-3 font-mono text-xs dark:border-surface-600"
+  >
+    {#if events.length === 0}
+      <p class="py-8 text-center text-surface-500">Waiting for output...</p>
+    {:else}
+      {#each events as event, i (i)}
+        {@const style = typeStyles[event.type] ?? { label: event.type.toUpperCase(), classes: 'bg-surface-300 text-surface-800' }}
+        <div class="flex items-start gap-2">
+          <span class="mt-0.5 inline-block shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold {style.classes}">
+            {style.label}
+          </span>
+          <pre class="min-w-0 flex-1 whitespace-pre-wrap break-words text-surface-200">{event.content ?? ''}</pre>
+        </div>
+      {/each}
+    {/if}
+  </div>
 </div>

--- a/frontend/src/components/StreamOutput.svelte
+++ b/frontend/src/components/StreamOutput.svelte
@@ -23,6 +23,11 @@
     result: { label: 'DONE', classes: 'bg-warning-200 text-warning-800 dark:bg-warning-700 dark:text-warning-200' },
   }
 
+  function onScroll() {
+    if (!container) return
+    autoScroll = container.scrollHeight - container.scrollTop - container.clientHeight < 10
+  }
+
   function scrollToBottom() {
     if (autoScroll && container) {
       container.scrollTop = container.scrollHeight
@@ -73,6 +78,7 @@
   </div>
   <div
     bind:this={container}
+    onscroll={onScroll}
     class="flex max-h-[60dvh] md:max-h-[600px] flex-col gap-1 overflow-y-auto rounded-lg border border-surface-300 bg-surface-900 p-3 font-mono text-xs dark:border-surface-600"
   >
     {#if events.length === 0}


### PR DESCRIPTION
## Motivation

When watching long agent runs, users want to scroll up to review earlier output without being yanked back to the bottom on every new message.

## Implementation information

Added an `autoScroll` boolean state to both `ChatView.svelte` and `StreamOutput.svelte`. The `scrollToBottom()` function now checks this flag before scrolling. A toggle button in the header area of each component shows the current state and flips it on click — styled to match existing badge conventions (primary when on, muted when off).

- `ChatView`: button placed in the existing header bar (right-aligned via `ml-auto`)
- `StreamOutput`: thin toolbar row above the scrollable container

> Changelog: feat(ui): add auto-scroll toggle to agent output