### PR TITLE
feat(workflow): skip --draft for pet projects

### DIFF
--- a/internal/synapse/app.go
+++ b/internal/synapse/app.go
@@ -713,7 +713,7 @@ func (a *App) initWorkflowEngine() {
 	}
 	a.workflowEngine = workflow.NewEngine(
 		wfStore,
-		&taskAdapter{tasks: a.tasks},
+		&taskAdapter{tasks: a.tasks, projects: a.projects},
 		&agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks},
 		a.logger,
 	)
@@ -966,11 +966,16 @@ func (a *App) restartStaleInProgress() {
 			})
 		} else {
 			mode := t.AgentMode
+			prFlag := " --draft"
+			if proj, pErr := a.projects.Get(t.ProjectID); pErr == nil && proj.Type == project.ProjectTypePet {
+				prFlag = ""
+			}
+			prompt := "Continue implementing this task. When done, create a PR with `gh pr create" + prFlag + "`."
 			a.wg.Go(func() {
 				// Restart-stale only ever reaches this branch for headless
 				// mode (interactive tasks are handled by recoverStaleInteractive
 				// above), so OneShot is irrelevant here — pass false.
-				_, err := a.agentOrch.StartAgent(taskID, mode, "Continue implementing this task. When done, create a draft PR with `gh pr create --draft`.", false)
+				_, err := a.agentOrch.StartAgent(taskID, mode, prompt, false)
 				metrics.OrchestratorStaleRestart(err == nil)
 				a.restartStaleErr.Log(a.logger, "restart-stale.failed", "stale:"+taskID, err, "task_id", taskID)
 			})

--- a/internal/synapse/app_workflow.go
+++ b/internal/synapse/app_workflow.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Automaat/synapse/internal/agent"
 	"github.com/Automaat/synapse/internal/config"
 	"github.com/Automaat/synapse/internal/github"
+	"github.com/Automaat/synapse/internal/project"
 	"github.com/Automaat/synapse/internal/task"
 	"github.com/Automaat/synapse/internal/workflow"
 	"github.com/Automaat/synapse/internal/worktree"
@@ -23,7 +24,8 @@ var (
 
 // taskAdapter bridges task.Manager → workflow.TaskProvider.
 type taskAdapter struct {
-	tasks *task.Manager
+	tasks    *task.Manager
+	projects *project.Store
 }
 
 func (a *taskAdapter) GetTask(id string) (workflow.TaskInfo, error) {
@@ -31,7 +33,13 @@ func (a *taskAdapter) GetTask(id string) (workflow.TaskInfo, error) {
 	if err != nil {
 		return workflow.TaskInfo{}, err
 	}
-	return taskToInfo(t), nil
+	info := taskToInfo(t)
+	if t.ProjectID != "" && a.projects != nil {
+		if p, pErr := a.projects.Get(t.ProjectID); pErr == nil {
+			info.ProjectType = string(p.Type)
+		}
+	}
+	return info, nil
 }
 
 func (a *taskAdapter) ListTasks() ([]workflow.TaskInfo, error) {

--- a/internal/workflow/builtin/simple-task.yaml
+++ b/internal/workflow/builtin/simple-task.yaml
@@ -195,7 +195,7 @@ steps:
       mode: "{{.Task.AgentMode}}"
       model: sonnet
       prompt: >-
-        Implement this task. When done, create a draft PR with `gh pr create --draft`.
+        Implement this task. When done, create a PR with `gh pr create{{if ne .Task.ProjectType "pet"}} --draft{{end}}`.
         {{- if .Task.Plan}}
 
         ## Plan

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -42,6 +42,7 @@ type TaskInfo struct {
 	Tags         []string
 	AgentMode    string
 	ProjectID    string
+	ProjectType  string
 	PRNumber     int
 	Branch       string
 	Body         string


### PR DESCRIPTION
## Motivation

Pet projects should auto-create normal PRs, not drafts. Draft PRs add unnecessary friction when iterating on side projects.

## Implementation information

- Added `ProjectType string` to `workflow.TaskInfo` so templates can branch on it
- Wired `*project.Store` into `taskAdapter` to populate the field in `GetTask`
- Updated `simple-task.yaml` implement step: `gh pr create{{if ne .Task.ProjectType "pet"}} --draft{{end}}`
- Updated stale-restart prompt in `app.go` to compute `--draft` flag from project type at runtime

> Changelog: feat(workflow): skip --draft for pet projects