### PR TITLE
refactor(sort): sort.Slice → slices.SortFunc

### DIFF
--- a/internal/loopagent/store.go
+++ b/internal/loopagent/store.go
@@ -1,10 +1,11 @@
 package loopagent
 
 import (
+	"cmp"
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"time"
 
 	"github.com/Automaat/synapse/internal/fsutil"
@@ -38,7 +39,7 @@ func (s *Store) List() ([]LoopAgent, error) {
 		}
 		out = append(out, la)
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	slices.SortFunc(out, func(a, b LoopAgent) int { return cmp.Compare(a.Name, b.Name) })
 	return out, nil
 }
 

--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -1,9 +1,10 @@
 package monitor
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 )
@@ -195,11 +196,11 @@ func suggestedInvestigation(kind AnomalyKind) string {
 // SortAnomalies returns the same slice with a stable ordering so reports are
 // deterministic across ticks (useful for snapshot tests and human reviewers).
 func SortAnomalies(anoms []Anomaly) []Anomaly {
-	sort.SliceStable(anoms, func(i, j int) bool {
-		if anoms[i].Kind != anoms[j].Kind {
-			return anoms[i].Kind < anoms[j].Kind
+	slices.SortStableFunc(anoms, func(a, b Anomaly) int {
+		if c := cmp.Compare(a.Kind, b.Kind); c != 0 {
+			return c
 		}
-		return anoms[i].Fingerprint < anoms[j].Fingerprint
+		return cmp.Compare(a.Fingerprint, b.Fingerprint)
 	})
 	return anoms
 }

--- a/internal/selfmonitor/ledger.go
+++ b/internal/selfmonitor/ledger.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"sync"
 	"time"
 )
@@ -218,9 +218,7 @@ func (l *Ledger) OpenIssues() []LedgerEntry {
 		cp.Fingerprint = fp
 		out = append(out, cp)
 	}
-	sort.Slice(out, func(i, j int) bool {
-		return out[i].CreatedAt.Before(out[j].CreatedAt)
-	})
+	slices.SortFunc(out, func(a, b LedgerEntry) int { return a.CreatedAt.Compare(b.CreatedAt) })
 	return out
 }
 

--- a/internal/selfmonitor/loganalyzer.go
+++ b/internal/selfmonitor/loganalyzer.go
@@ -10,13 +10,14 @@ package selfmonitor
 
 import (
 	"bufio"
+	"cmp"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"maps"
 	"os"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/Automaat/synapse/internal/agent"
@@ -316,11 +317,11 @@ func (st *analyzerState) populateRepeatedCalls() {
 			})
 		}
 	}
-	sort.Slice(st.summary.RepeatedCalls, func(i, j int) bool {
-		if st.summary.RepeatedCalls[i].Count != st.summary.RepeatedCalls[j].Count {
-			return st.summary.RepeatedCalls[i].Count > st.summary.RepeatedCalls[j].Count
+	slices.SortFunc(st.summary.RepeatedCalls, func(a, b RepeatedCall) int {
+		if c := cmp.Compare(b.Count, a.Count); c != 0 {
+			return c
 		}
-		return st.summary.RepeatedCalls[i].Tool < st.summary.RepeatedCalls[j].Tool
+		return cmp.Compare(a.Tool, b.Tool)
 	})
 }
 
@@ -332,11 +333,11 @@ func (st *analyzerState) populateErrorClasses() {
 			Sample: st.errorClassSamples[class],
 		})
 	}
-	sort.Slice(st.summary.ErrorClasses, func(i, j int) bool {
-		if st.summary.ErrorClasses[i].Count != st.summary.ErrorClasses[j].Count {
-			return st.summary.ErrorClasses[i].Count > st.summary.ErrorClasses[j].Count
+	slices.SortFunc(st.summary.ErrorClasses, func(a, b ErrorClass) int {
+		if c := cmp.Compare(b.Count, a.Count); c != 0 {
+			return c
 		}
-		return st.summary.ErrorClasses[i].Class < st.summary.ErrorClasses[j].Class
+		return cmp.Compare(a.Class, b.Class)
 	})
 }
 

--- a/internal/stats/store.go
+++ b/internal/stats/store.go
@@ -1,9 +1,10 @@
 package stats
 
 import (
+	"cmp"
 	"encoding/json"
 	"os"
-	"sort"
+	"slices"
 	"sync"
 	"time"
 
@@ -122,9 +123,7 @@ func (s *Store) Query() StatsResponse {
 	// Recent runs: last 50, newest first
 	recent := make([]RunRecord, len(s.runs))
 	copy(recent, s.runs)
-	sort.Slice(recent, func(i, j int) bool {
-		return recent[i].Timestamp.After(recent[j].Timestamp)
-	})
+	slices.SortFunc(recent, func(a, b RunRecord) int { return b.Timestamp.Compare(a.Timestamp) })
 	if len(recent) > 50 {
 		recent = recent[:50]
 	}
@@ -163,8 +162,6 @@ func groupedStats(groups map[string][]RunRecord) []GroupedStat {
 	for key, runs := range groups {
 		result = append(result, GroupedStat{Key: key, Stats: summarize(runs)})
 	}
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].Stats.TotalCostUSD > result[j].Stats.TotalCostUSD
-	})
+	slices.SortFunc(result, func(a, b GroupedStat) int { return cmp.Compare(b.Stats.TotalCostUSD, a.Stats.TotalCostUSD) })
 	return result
 }

--- a/internal/synapse/svc_loopagents.go
+++ b/internal/synapse/svc_loopagents.go
@@ -2,12 +2,13 @@ package synapse
 
 import (
 	"bufio"
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -122,9 +123,7 @@ func (s *LoopAgentService) ListLoopAgentRuns(id string, limit int) ([]LoopAgentR
 		runs = append(runs, fileRuns...)
 	}
 
-	sort.Slice(runs, func(i, j int) bool {
-		return runs[i].FinishedAt.After(runs[j].FinishedAt)
-	})
+	slices.SortFunc(runs, func(a, b LoopAgentRun) int { return b.FinishedAt.Compare(a.FinishedAt) })
 	if len(runs) > limit {
 		runs = runs[:limit]
 	}
@@ -148,7 +147,7 @@ func auditFilesNewestFirst(dir string) ([]string, error) {
 		}
 		paths = append(paths, filepath.Join(dir, e.Name()))
 	}
-	sort.Sort(sort.Reverse(sort.StringSlice(paths)))
+	slices.SortFunc(paths, func(a, b string) int { return cmp.Compare(b, a) })
 	return paths, nil
 }
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -9,7 +10,6 @@ import (
 	"os/exec"
 	"regexp"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -210,8 +210,8 @@ func (e *Engine) matchWorkflow(t TaskInfo, event string, extra map[string]string
 	}
 	// Stable sort preserves store order (alphabetical) within the same
 	// priority bucket, so tiebreaks stay deterministic across runs.
-	sort.SliceStable(matches, func(i, j int) bool {
-		return matches[i].Trigger.Priority > matches[j].Trigger.Priority
+	slices.SortStableFunc(matches, func(a, b *Definition) int {
+		return cmp.Compare(b.Trigger.Priority, a.Trigger.Priority)
 	})
 	if len(matches) > 1 {
 		e.logger.Info("workflow.match.multiple",


### PR DESCRIPTION
## Motivation

Modernize sorting calls to use the idiomatic Go 1.21+ `slices` package APIs instead of the older `sort.Slice`/`sort.SliceStable` pattern. This is one of the patterns Go 1.26 `go fix` auto-applies.

## Implementation information

Replaced 9 `sort.Slice`/`sort.SliceStable` calls across 7 files with `slices.SortFunc`/`slices.SortStableFunc`. Also replaced one `sort.Sort(sort.Reverse(sort.StringSlice(...)))` call.

Key semantic equivalences applied:
- `func(i, j int) bool { return a[i] < a[j] }` → `func(a, b T) int { return cmp.Compare(a, b) }`
- `time.After/Before` → `time.Time.Compare` (returns int directly)
- Multi-field comparisons: `if a != b { return a < b }; return c < d` → `if c := cmp.Compare(a, b); c != 0 { return c }; return cmp.Compare(c, d)`
- `sort.Sort(sort.Reverse(sort.StringSlice(s)))` → `slices.SortFunc(s, func(a, b string) int { return cmp.Compare(b, a) })`

Removed `"sort"` import from 6 files; added `"cmp"` and/or `"slices"` as needed.

> Changelog: refactor(sort): sort.Slice → slices.SortFunc

Closes https://github.com/Automaat/synapse/issues/426