### PR TITLE
refactor(sync): migrate wg.Add/go/Done to wg.Go

### DIFF
--- a/cmd/synapse-perf/main.go
+++ b/cmd/synapse-perf/main.go
@@ -680,9 +680,7 @@ func launchAgents(ctx context.Context, c *apiClient, o options) []agentResult {
 		if o.concurrency > 1 && o.rampDuration > 0 {
 			delay = time.Duration(i) * o.rampDuration / time.Duration(o.concurrency-1)
 		}
-		wg.Add(1)
-		go func(i int, delay time.Duration) {
-			defer wg.Done()
+		wg.Go(func() {
 			select {
 			case <-ctx.Done():
 				return
@@ -693,7 +691,7 @@ func launchAgents(ctx context.Context, c *apiClient, o options) []agentResult {
 			if o.verbose {
 				log.Printf("agent[%d] task=%s err=%q events=%d", i, r.taskID, r.err, r.totalEvents)
 			}
-		}(i, delay)
+		})
 	}
 	wg.Wait()
 	return results
@@ -814,9 +812,8 @@ func runChurn(ctx context.Context, c *apiClient, o options, report *Report) erro
 			// worker pool saturated — count as backpressure event
 			continue
 		}
-		wg.Add(1)
-		go func(seq int64) {
-			defer wg.Done()
+		seq := total.Load()
+		wg.Go(func() {
 			defer func() { <-sem }()
 
 			cStart := time.Now()
@@ -856,7 +853,7 @@ func runChurn(ctx context.Context, c *apiClient, o options, report *Report) erro
 			deleteLat = append(deleteLat, dDur)
 			mu.Unlock()
 			total.Add(1)
-		}(total.Load())
+		})
 	}
 
 done:

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -916,11 +916,9 @@ func TestConcurrentAdvance(t *testing.T) {
 	var wg sync.WaitGroup
 	errs := make([]error, 2)
 	for i := range 2 {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			errs[idx] = engine.AdvanceStep("t1", StepOutput{StepID: "triage", Status: "completed"})
-		}(i)
+		wg.Go(func() {
+			errs[i] = engine.AdvanceStep("t1", StepOutput{StepID: "triage", Status: "completed"})
+		})
 	}
 	wg.Wait()
 


### PR DESCRIPTION
## Motivation

Go 1.25 added `sync.WaitGroup.Go(func())`, replacing the 3-line `Add/go func/Done` pattern. The old pattern risks mismatched `Add`/`Done` calls (goroutine leak class).

## Implementation information

Replaced all 3 sites:
- `cmd/synapse-perf/main.go` — 2 goroutines in load generator
- `internal/workflow/engine_test.go` — concurrent advance test

`wg.Go` calls `Done` automatically; no explicit `defer wg.Done()` needed. Loop variable capture aliases removed (unnecessary in Go 1.22+ per-iteration semantics).

> Changelog: refactor(sync): migrate wg.Add/go/Done to wg.Go