### PR TITLE
feat(agent): real-time step status text

### DIFF
--- a/frontend/src/components/AgentCard.svelte
+++ b/frontend/src/components/AgentCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { agent } from '../../wailsjs/go/models.js'
+  import { agentStore } from '../stores/agents.svelte.js'
 
   interface Props {
     agent: agent.Agent
@@ -39,6 +40,11 @@
       <h3 class="text-sm font-semibold leading-tight">{a.project || a.id}</h3>
       {#if a.name}
         <span class="text-xs text-surface-400">{a.name}</span>
+      {/if}
+      {#if a.state === 'running'}
+        <span class="text-xs italic text-surface-400">
+          {agentStore.stepTexts.get(a.id) ?? 'Working...'}
+        </span>
       {/if}
     </div>
     <span class="inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium {resolved.classes}">

--- a/frontend/src/components/AgentCard.svelte.test.ts
+++ b/frontend/src/components/AgentCard.svelte.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/svelte'
 import AgentCard from './AgentCard.svelte'
+import { agentStore } from '../stores/agents.svelte.js'
 
 function makeAgent(overrides: Record<string, unknown> = {}) {
   return {
@@ -102,6 +103,30 @@ describe('AgentCard', () => {
     render(AgentCard, { props: { agent: makeAgent(), onclick: handler } })
     await fireEvent.click(screen.getByRole('button'))
     expect(handler).toHaveBeenCalledOnce()
+  })
+
+  describe('step text', () => {
+    afterEach(() => {
+      agentStore.stepTexts.delete('agent-1')
+    })
+
+    it('shows "Working..." when running with no step text', () => {
+      render(AgentCard, { props: { agent: makeAgent({ state: 'running' }), onclick: () => {} } })
+      expect(screen.getByText('Working...')).toBeDefined()
+    })
+
+    it('shows step text from store when running', () => {
+      agentStore.setStepText('agent-1', '[Bash] npm install')
+      render(AgentCard, { props: { agent: makeAgent({ state: 'running' }), onclick: () => {} } })
+      expect(screen.getByText('[Bash] npm install')).toBeDefined()
+    })
+
+    it('does not show step text when not running', () => {
+      agentStore.setStepText('agent-1', '[Bash] npm install')
+      render(AgentCard, { props: { agent: makeAgent({ state: 'idle' }), onclick: () => {} } })
+      expect(screen.queryByText('[Bash] npm install')).toBeNull()
+      expect(screen.queryByText('Working...')).toBeNull()
+    })
   })
 
   describe('timeAgo', () => {

--- a/frontend/src/lib/step-text.test.ts
+++ b/frontend/src/lib/step-text.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { extractStepText } from './step-text.js'
+
+function makeEvent(type: string, content: string) {
+  return { type, content } as any
+}
+
+describe('extractStepText', () => {
+  it('returns null for result events', () => {
+    expect(extractStepText(makeEvent('result', 'done'))).toBeNull()
+  })
+
+  it('returns null for assistant event with no tool-use lines', () => {
+    expect(extractStepText(makeEvent('assistant', 'Thinking about the problem...'))).toBeNull()
+  })
+
+  it('returns null for empty content', () => {
+    expect(extractStepText(makeEvent('assistant', ''))).toBeNull()
+    expect(extractStepText(makeEvent('tool_use', ''))).toBeNull()
+  })
+
+  it('extracts tool_use content for Codex events', () => {
+    expect(extractStepText(makeEvent('tool_use', 'npm install'))).toBe('npm install')
+  })
+
+  it('extracts [ToolName] line from Claude assistant event', () => {
+    expect(extractStepText(makeEvent('assistant', '[Bash] npm install'))).toBe('[Bash] npm install')
+  })
+
+  it('prefers last tool-use line in multi-line assistant content', () => {
+    const content = 'Some thinking\n[Read] file.go\n[Bash] go test ./...'
+    expect(extractStepText(makeEvent('assistant', content))).toBe('[Bash] go test ./...')
+  })
+
+  it('ignores non-tool lines after tool-use lines', () => {
+    const content = '[Bash] npm install\nsome trailing text'
+    expect(extractStepText(makeEvent('assistant', content))).toBe('[Bash] npm install')
+  })
+
+  it('truncates long content to 80 chars', () => {
+    const long = '[Bash] ' + 'a'.repeat(100)
+    const result = extractStepText(makeEvent('assistant', long))
+    expect(result).toHaveLength(81) // 80 chars + '…'
+    expect(result!.endsWith('…')).toBe(true)
+  })
+
+  it('truncates long tool_use content', () => {
+    const long = 'a'.repeat(100)
+    const result = extractStepText(makeEvent('tool_use', long))
+    expect(result).toHaveLength(81)
+    expect(result!.endsWith('…')).toBe(true)
+  })
+})

--- a/frontend/src/lib/step-text.ts
+++ b/frontend/src/lib/step-text.ts
@@ -1,0 +1,36 @@
+import type { agent } from '../../wailsjs/go/models.js'
+
+const MAX_LEN = 80
+
+function truncate(s: string): string {
+  return s.length > MAX_LEN ? s.slice(0, MAX_LEN) + '…' : s
+}
+
+/**
+ * Extract a human-readable step description from a stream event.
+ * Returns null when the event carries no useful step information.
+ *
+ * Claude headless: assistant events carry "[ToolName] description" lines.
+ * Codex headless: tool_use events carry the shell command as content.
+ */
+export function extractStepText(event: agent.StreamEvent): string | null {
+  // Codex: tool_use event, content is the shell command
+  if (event.type === 'tool_use' && event.content) {
+    const text = event.content.trim()
+    return text ? truncate(text) : null
+  }
+
+  // Claude: assistant event, content is text + "[ToolName] desc" lines joined by \n
+  if (event.type === 'assistant' && event.content) {
+    const lines = event.content.split('\n')
+    // Prefer the last tool-use line (starts with '[')
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i].trim()
+      if (line.startsWith('[')) {
+        return truncate(line)
+      }
+    }
+  }
+
+  return null
+}

--- a/frontend/src/pages/AgentDetail.svelte
+++ b/frontend/src/pages/AgentDetail.svelte
@@ -148,6 +148,11 @@
           {#if a.name}
             <span class="text-sm text-surface-400">{a.name}</span>
           {/if}
+          {#if a.state === 'running'}
+            <p class="mt-0.5 text-sm italic text-surface-400">
+              {agentStore.stepTexts.get(agentId) ?? 'Working...'}
+            </p>
+          {/if}
         </div>
         <div class="flex items-center gap-2">
           <span class="inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-medium

--- a/frontend/src/pages/AgentDetail.svelte.test.ts
+++ b/frontend/src/pages/AgentDetail.svelte.test.ts
@@ -11,6 +11,7 @@ const mockAgents = new Map()
 vi.mock('../stores/agents.svelte.js', () => ({
   agentStore: {
     agents: mockAgents,
+    stepTexts: new Map<string, string>(),
     stop: (...args: unknown[]) => mockStop(...args),
     updateAgent: (...args: unknown[]) => mockUpdateAgent(...args),
   },

--- a/frontend/src/pages/AgentList.svelte
+++ b/frontend/src/pages/AgentList.svelte
@@ -2,6 +2,10 @@
   import { SegmentedControl } from '@skeletonlabs/skeleton-svelte'
   import { agentStore } from '../stores/agents.svelte.js'
   import AgentCard from '../components/AgentCard.svelte'
+  import { EventsOn } from '$lib/api'
+  import { agentOutput } from '../lib/events.js'
+  import { extractStepText } from '$lib/step-text.js'
+  import type { agent } from '../../wailsjs/go/models.js'
 
   interface Props {
     onselect: (id: string) => void
@@ -10,6 +14,21 @@
   const { onselect }: Props = $props()
 
   let filter = $state('all')
+
+  // Subscribe to output events for all running agents so AgentCard step text
+  // stays live even when StreamOutput (AgentDetail) is not mounted.
+  $effect(() => {
+    const runningIds = agentStore.list
+      .filter((a) => a.state === 'running')
+      .map((a) => a.id)
+    const unsubs = runningIds.map((id) =>
+      EventsOn(agentOutput(id), (event: agent.StreamEvent) => {
+        const text = extractStepText(event)
+        if (text) agentStore.setStepText(id, text)
+      }),
+    )
+    return () => unsubs.forEach((u) => u())
+  })
 
   const states = [
     { value: 'all', label: 'All' },

--- a/frontend/src/pages/AgentList.svelte.test.ts
+++ b/frontend/src/pages/AgentList.svelte.test.ts
@@ -7,6 +7,8 @@ const mockAgentStoreData = {
   error: '',
   byState: (...args: unknown[]) => mockByState(...args),
   list: [],
+  stepTexts: new Map<string, string>(),
+  setStepText: vi.fn(),
 }
 
 vi.mock('../stores/agents.svelte.js', () => ({

--- a/frontend/src/pages/Dashboard.svelte
+++ b/frontend/src/pages/Dashboard.svelte
@@ -3,7 +3,10 @@
   import { agentStore } from '../stores/agents.svelte.js'
   import { reviewStore } from '../stores/reviews.svelte.js'
   import { ALL_STATUSES } from '../lib/statuses.js'
-  import { MarkPRReady } from '$lib/api'
+  import { MarkPRReady, EventsOn } from '$lib/api'
+  import { agentOutput } from '../lib/events.js'
+  import { extractStepText } from '$lib/step-text.js'
+  import type { agent } from '../../wailsjs/go/models.js'
   import AgentCard from '../components/AgentCard.svelte'
   import PRCard from '../components/PRCard.svelte'
 
@@ -27,6 +30,18 @@
   )
 
   const draftPRs = $derived(reviewStore.createdByMe.filter((pr) => pr.isDraft))
+
+  // Subscribe to output events for running agents so step text stays live.
+  $effect(() => {
+    const runningIds = runningAgents.map((a) => a.id)
+    const unsubs = runningIds.map((id) =>
+      EventsOn(agentOutput(id), (event: agent.StreamEvent) => {
+        const text = extractStepText(event)
+        if (text) agentStore.setStepText(id, text)
+      }),
+    )
+    return () => unsubs.forEach((u) => u())
+  })
 
   async function markReady(repo: string, number: number) {
     await MarkPRReady(repo, number)

--- a/frontend/src/stores/agents.svelte.test.ts
+++ b/frontend/src/stores/agents.svelte.test.ts
@@ -39,6 +39,7 @@ describe('AgentStore', () => {
     // Reset store state
     agentStore.agents = new Map()
     agentStore.outputs.clear()
+    agentStore.stepTexts.clear()
     agentStore.error = ''
     agentStore.loading = false
     agentStore.stopPolling()
@@ -137,6 +138,31 @@ describe('AgentStore', () => {
 
       expect(result).toEqual([])
       expect(agentStore.outputs.get('a1')).toEqual([])
+    })
+
+    it('seeds stepTexts from last extractable event in history', async () => {
+      const events = [
+        { type: 'init', content: '' },
+        { type: 'assistant', content: 'hello\n[Read] reading file' },
+        { type: 'tool_result', content: 'done' },
+      ]
+      mockGetAgentOutput.mockResolvedValue(events)
+
+      await agentStore.getOutput('a1')
+
+      expect(agentStore.stepTexts.get('a1')).toBe('[Read] reading file')
+    })
+
+    it('does not set stepTexts when no extractable event in history', async () => {
+      const events = [
+        { type: 'init', content: '' },
+        { type: 'tool_result', content: 'done' },
+      ]
+      mockGetAgentOutput.mockResolvedValue(events)
+
+      await agentStore.getOutput('a1')
+
+      expect(agentStore.stepTexts.get('a1')).toBeUndefined()
     })
   })
 

--- a/frontend/src/stores/agents.svelte.ts
+++ b/frontend/src/stores/agents.svelte.ts
@@ -10,9 +10,11 @@ import {
 } from '$lib/api'
 import { agent } from '../../wailsjs/go/models.js'
 import { EntityStore } from './entity-store.svelte.js'
+import { extractStepText } from '$lib/step-text.js'
 
 class AgentStore extends EntityStore<agent.Agent> {
   outputs = new SvelteMap<string, agent.StreamEvent[]>()
+  stepTexts = new SvelteMap<string, string>()
 
   constructor() {
     super(
@@ -82,6 +84,12 @@ class AgentStore extends EntityStore<agent.Agent> {
   appendEvent(agentID: string, event: agent.StreamEvent): void {
     const existing = this.outputs.get(agentID) ?? []
     this.outputs.set(agentID, [...existing, event])
+    const text = extractStepText(event)
+    if (text) this.stepTexts.set(agentID, text)
+  }
+
+  setStepText(agentID: string, text: string): void {
+    this.stepTexts.set(agentID, text)
   }
 
   updateAgent(agentID: string, data: agent.Agent): void {

--- a/frontend/src/stores/agents.svelte.ts
+++ b/frontend/src/stores/agents.svelte.ts
@@ -77,8 +77,16 @@ class AgentStore extends EntityStore<agent.Agent> {
 
   async getOutput(agentID: string): Promise<agent.StreamEvent[]> {
     const events = await GetAgentOutput(agentID)
-    this.outputs.set(agentID, events ?? [])
-    return events ?? []
+    const list = events ?? []
+    this.outputs.set(agentID, list)
+    for (let i = list.length - 1; i >= 0; i--) {
+      const text = extractStepText(list[i])
+      if (text) {
+        this.stepTexts.set(agentID, text)
+        break
+      }
+    }
+    return list
   }
 
   appendEvent(agentID: string, event: agent.StreamEvent): void {


### PR DESCRIPTION
## Motivation

Generic spinners give no signal about what an agent is actually doing. Following Devin's pattern of showing specific step text (e.g. "Devin is thinking..."), specificity reduces anxiety more than animation.

## Implementation information

- `frontend/src/lib/step-text.ts` — `extractStepText(event)` utility extracts the last tool-use line (`[ToolName] desc`) from Claude assistant events, or the command string from Codex `tool_use` events. Returns `null` when no useful step info is available.
- `agentStore.stepTexts` — reactive `SvelteMap<agentId, string>` updated via `appendEvent` (called by `StreamOutput` in detail view) and by new `setStepText` method.
- `AgentList.svelte` — `$effect` subscribes to `agent:output` events for all running agents while the list is mounted, so cards stay live without `StreamOutput` being in the DOM.
- `AgentCard.svelte` — shows `agentStore.stepTexts.get(a.id) ?? 'Working...'` under agent name when `state === 'running'`.
- `AgentDetail.svelte` — shows same step text under the agent name heading when running; text flows in via `StreamOutput → appendEvent → setStepText`.

Fallback is always "Working..." — never a bare spinner.

> Changelog: feat(agent): real-time step status text

Closes https://github.com/Automaat/synapse/issues/447