### PR TITLE
fix(theme): agent state colors to amber

### DIFF
--- a/docs/color-palette.md
+++ b/docs/color-palette.md
@@ -1,0 +1,322 @@
+# Synapse Color Palette Research
+
+> Research covering successful dark-mode developer tools and AI products (2023–2025). All values in OKLCH for Skeleton UI v4 compatibility.
+
+---
+
+## Status Color Mapping (existing)
+
+Current Skeleton slot → task status:
+- `primary` → `in-progress`
+- `secondary` → `testing`
+- `tertiary` → `new` / `planning` / `plan-review`
+- `success` → `done`
+- `warning` → `in-review`
+- `error` → `human-required`
+- `surface` → `todo`
+
+---
+
+## Key Research Findings
+
+### Hue conventions in AI dev tools (2024–2025)
+
+- **Indigo/violet 260–280deg** dominates AI product accents: GitHub Copilot, Perplexity, Devin, Cursor — encodes "intelligence/automation"
+- **Teal 185–200deg** universally used for "active AI processing" states: Perplexity stream, Claude thinking, Copilot active
+- **Amber 50–60deg** is 2024's differentiated alternative: Bun, Astro, Cloudflare — warm, decisive, non-generic
+
+### Dark mode surface tint
+
+- True neutral (C=0): maximum contrast, zero personality — Generic
+- Cool blue-gray (C=0.005–0.01, H=245–265°): industry default — GitHub, Cursor, Linear
+- Warm-black tint (C=0.005–0.01, H=20–40°): Claude's approach — warm, unusual in dev tools
+- Indigo-tinted (C=0.01–0.015, H=270°): Cursor variant — AI-native, cohesive with indigo accent
+
+### Saturation guidelines for dark mode
+
+- Surface chroma: 0–0.02 (above 0.03 = noticeable colored background)
+- Accent sweet spot: L 60–72%, C 0.16–0.22
+- Badge backgrounds: C 0.05–0.1 at L 25–35%
+- Text primary: L 88–95%, C 0–0.02
+
+---
+
+## Palette Options
+
+### A — "Slate Professional"
+
+**Personality**: Linear-meets-GitHub. Cool neutral, single blue accent. The "just ship it" palette.
+
+**Base hue**: 250deg (cool blue-gray), C=0.006–0.010
+
+| Role | OKLCH |
+|---|---|
+| Background | `oklch(9.5% 0.006 250deg)` |
+| Card | `oklch(13% 0.007 252deg)` |
+| Border | `oklch(25% 0.009 255deg)` |
+| Text primary | `oklch(92% 0.005 250deg)` |
+| **Accent (blue)** | `oklch(69% 0.16 245deg)` |
+
+**Status colors (accent hues)**: blue / amber / teal / violet / rose / jade
+
+**Verdict**: Familiar, professional, zero controversy. Won't stand out visually.
+
+---
+
+### B — "Synapse Indigo" ⭐ RECOMMENDED
+
+**Personality**: Linear-precise meets AI-native. Indigo-tinted dark surface (270deg, very low chroma). Single indigo accent at high chroma. Teal secondary for running/testing states.
+
+**Base hue**: 270deg (indigo), C=0.012–0.016 — you feel the cohesion, not the color
+
+| Role | OKLCH |
+|---|---|
+| Background (`surface-950`) | `oklch(9% 0.012 270deg)` |
+| Card (`surface-900`) | `oklch(12.5% 0.013 271deg)` |
+| Elevated (`surface-800`) | `oklch(17% 0.013 272deg)` |
+| Border default (`surface-700`) | `oklch(26% 0.015 273deg)` |
+| Border strong (`surface-600`) | `oklch(35% 0.016 274deg)` |
+| Text muted (`surface-400`) | `oklch(58% 0.015 272deg)` |
+| Text secondary (`surface-200`) | `oklch(75% 0.012 270deg)` |
+| Text primary (`surface-50`) | `oklch(93% 0.006 268deg)` |
+
+**Accent — Indigo (primary)**:
+| Stop | OKLCH |
+|---|---|
+| 500 (main) | `oklch(62% 0.22 270deg)` |
+| 400 (hover) | `oklch(68% 0.23 268deg)` |
+| 600 (pressed) | `oklch(55% 0.20 272deg)` |
+
+**Full status palette**:
+| Status | Slot | Badge bg | Badge text |
+|---|---|---|---|
+| `in-progress` | `primary` | `oklch(20% 0.12 270deg)` | `oklch(78% 0.18 268deg)` |
+| `in-review` | `warning` | `oklch(26% 0.10 55deg)` | `oklch(88% 0.14 58deg)` |
+| `testing` | `secondary` | `oklch(20% 0.12 192deg)` | `oklch(75% 0.17 190deg)` |
+| `planning`/`new` | `tertiary` | `oklch(20% 0.10 295deg)` | `oklch(76% 0.14 293deg)` |
+| `human-required` | `error` | `oklch(24% 0.11 28deg)` | `oklch(82% 0.16 25deg)` |
+| `done` | `success` | `oklch(20% 0.12 160deg)` | `oklch(74% 0.17 158deg)` |
+| `todo` | `surface` | `oklch(20% 0.013 272deg)` | `oklch(65% 0.012 270deg)` |
+
+**Tailwind class pattern for badges**:
+```
+in-progress:      bg-primary-900 text-primary-300
+in-review:        bg-warning-900 text-warning-300
+testing:          bg-secondary-900 text-secondary-300
+planning/new:     bg-tertiary-900 text-tertiary-300
+human-required:   bg-error-900 text-error-300
+done:             bg-success-900 text-success-300
+todo:             bg-surface-800 text-surface-400
+```
+
+**Why indigo-270deg?** It's the convergent AI product hue in 2025 (Perplexity, Cursor, Devin, Copilot) — not trend-following, but because it reads as "intelligence/automation" to developers using these tools daily. The low-chroma surface tint ties the background to the accent, creating cohesion that pure neutral palettes lack. Current `vox` theme is at 294–302deg (lavender-purple) with excessive chroma (0.03–0.07 at dark stops) — this is a more restrained upgrade in the same hue family.
+
+---
+
+### C — "Amber Command" ⭐ SELECTED
+
+**Personality**: Warm-dark like a mission control terminal. Amber accent — unusual in AI tooling, high visual memory. Think Bun's orange meets Warp's dark. Light mode reads as "parchment + gold" — warm cream surfaces with amber accent.
+
+**Base hue**: 32–35deg (warm-black dark / warm-white light), C=0.003–0.010
+
+**Note**: `warning` slot reassigned to violet (280deg) since amber IS the brand color. `in-review` reads as "pending judgment" via violet.
+
+#### Dark mode surfaces
+| Role | OKLCH | Hex |
+|---|---|---|
+| Background | `oklch(9% 0.008 32deg)` | `#110e0b` |
+| Card | `oklch(13% 0.009 33deg)` | `#1a1510` |
+| Elevated | `oklch(18% 0.009 34deg)` | `#231c16` |
+| Border default | `oklch(27% 0.010 35deg)` | `#352c22` |
+| Text muted | `oklch(58% 0.009 34deg)` | `#7a7064` |
+| Text secondary | `oklch(76% 0.007 32deg)` | `#b5ae9e` |
+| Text primary | `oklch(93% 0.004 30deg)` | `#eee8df` |
+
+#### Light mode surfaces
+| Role | OKLCH | Hex |
+|---|---|---|
+| Background | `oklch(98% 0.003 30deg)` | `#faf8f7` |
+| Card | `oklch(96% 0.004 31deg)` | `#f4f1f0` |
+| Elevated | `oklch(94% 0.005 32deg)` | `#eeeae9` |
+| Border default | `oklch(88% 0.007 33deg)` | `#dcd6d4` |
+| Border strong | `oklch(80% 0.009 33deg)` | `#c3bcba` |
+| Text muted | `oklch(55% 0.009 34deg)` | `#77706e` |
+| Text secondary | `oklch(35% 0.010 33deg)` | `#403937` |
+| Text primary | `oklch(15% 0.008 32deg)` | `#0e0a09` |
+
+#### Light mode badge colors
+| Status | Badge bg | Badge text |
+|---|---|---|
+| `in-progress` (amber) | `oklch(94% 0.07 51deg)` `#ffdfc1` | `oklch(32% 0.13 59deg)` `#5f1700` |
+| `testing` (teal) | `oklch(93% 0.06 183deg)` `#bcf6eb` | `oklch(30% 0.13 191deg)` `#003f3d` |
+| `planning` (warm) | `oklch(95% 0.04 33deg)` `#ffe6de` | `oklch(28% 0.09 38deg)` `#4b1301` |
+| `done` (jade) | `oklch(93% 0.06 151deg)` `#ccf4d4` | `oklch(28% 0.12 158deg)` `#00380e` |
+| `in-review` (violet) | `oklch(95% 0.04 272deg)` `#e5eeff` | `oklch(28% 0.13 280deg)` `#221766` |
+| `human-required` (coral) | `oklch(94% 0.05 14deg)` `#ffdee1` | `oklch(30% 0.14 20deg)` `#62000c` |
+| `todo` (neutral) | `oklch(96% 0.004 31deg)` `#f4f1f0` | `oklch(47% 0.010 35deg)` `#605957` |
+
+#### Visualization links
+- **Dark — Coolors**: https://coolors.co/040202-0a0605-fe860f-00a292-6567e7-009f4b-e93954-eae7e6
+- **Dark — Realtime Colors**: https://www.realtimecolors.com/?colors=eae7e6-040202-fe860f-00a292-6567e7&fonts=Inter-Inter
+- **Light — Coolors**: https://coolors.co/faf8f7-f4f1f0-c35600-006f63-4544ab-006422-9d2a39-0e0a09
+- **Light — Realtime Colors**: https://www.realtimecolors.com/?colors=0e0a09-faf8f7-c35600-006f63-4544ab&fonts=Inter-Inter
+
+---
+
+### D — "Neutral Edge"
+
+**Personality**: Maximum restraint. True neutral dark, white accent. Zero hue distraction. Typography does the work.
+
+**Base**: `oklch(8.5% 0 0)` — achromatic
+
+**Verdict**: Timeless, works beautifully in dense list views, zero brand differentiation. Status badges pop with maximum contrast against the neutral base.
+
+---
+
+## Full Skeleton Theme CSS — Palette B
+
+Create `frontend/src/theme-synapse.css`:
+
+```css
+[data-theme='synapse'] {
+  --text-scaling: 1.067;
+  --base-font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --heading-font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --heading-font-weight: 600;
+  --heading-letter-spacing: 0.015em;
+  --spacing: 0.25rem;
+  --radius-base: 0.375rem;
+  --radius-container: 0.75rem;
+  --default-border-width: 1px;
+  --body-background-color-dark: oklch(9% 0.012 270deg);
+
+  /* primary: indigo 270deg */
+  --color-primary-50:  oklch(96% 0.05 264deg);
+  --color-primary-100: oklch(90% 0.08 266deg);
+  --color-primary-200: oklch(82% 0.12 267deg);
+  --color-primary-300: oklch(76% 0.18 266deg);
+  --color-primary-400: oklch(68% 0.23 268deg);
+  --color-primary-500: oklch(62% 0.22 270deg);
+  --color-primary-600: oklch(55% 0.20 272deg);
+  --color-primary-700: oklch(43% 0.17 274deg);
+  --color-primary-800: oklch(32% 0.14 276deg);
+  --color-primary-900: oklch(22% 0.11 278deg);
+  --color-primary-950: oklch(14% 0.09 280deg);
+
+  /* secondary: teal 190deg */
+  --color-secondary-50:  oklch(95% 0.05 186deg);
+  --color-secondary-100: oklch(88% 0.09 187deg);
+  --color-secondary-200: oklch(80% 0.13 188deg);
+  --color-secondary-300: oklch(78% 0.16 188deg);
+  --color-secondary-400: oklch(70% 0.19 189deg);
+  --color-secondary-500: oklch(60% 0.20 190deg);
+  --color-secondary-600: oklch(50% 0.17 191deg);
+  --color-secondary-700: oklch(40% 0.15 192deg);
+  --color-secondary-800: oklch(30% 0.12 193deg);
+  --color-secondary-900: oklch(20% 0.11 192deg);
+  --color-secondary-950: oklch(12% 0.09 193deg);
+
+  /* tertiary: lavender 293deg */
+  --color-tertiary-50:  oklch(96% 0.04 289deg);
+  --color-tertiary-100: oklch(90% 0.07 290deg);
+  --color-tertiary-200: oklch(82% 0.10 291deg);
+  --color-tertiary-300: oklch(78% 0.12 291deg);
+  --color-tertiary-400: oklch(70% 0.14 292deg);
+  --color-tertiary-500: oklch(58% 0.16 293deg);
+  --color-tertiary-600: oklch(48% 0.14 294deg);
+  --color-tertiary-700: oklch(38% 0.12 295deg);
+  --color-tertiary-800: oklch(28% 0.10 296deg);
+  --color-tertiary-900: oklch(20% 0.09 296deg);
+  --color-tertiary-950: oklch(13% 0.07 297deg);
+
+  /* success: jade 158deg */
+  --color-success-50:  oklch(95% 0.05 154deg);
+  --color-success-100: oklch(88% 0.09 155deg);
+  --color-success-200: oklch(80% 0.13 156deg);
+  --color-success-300: oklch(78% 0.14 156deg);
+  --color-success-400: oklch(70% 0.17 157deg);
+  --color-success-500: oklch(60% 0.19 158deg);
+  --color-success-600: oklch(50% 0.16 159deg);
+  --color-success-700: oklch(40% 0.14 160deg);
+  --color-success-800: oklch(30% 0.12 161deg);
+  --color-success-900: oklch(20% 0.10 160deg);
+  --color-success-950: oklch(12% 0.08 161deg);
+
+  /* warning: gold 55deg */
+  --color-warning-50:  oklch(97% 0.04 51deg);
+  --color-warning-100: oklch(92% 0.08 52deg);
+  --color-warning-200: oklch(86% 0.12 53deg);
+  --color-warning-300: oklch(88% 0.13 53deg);
+  --color-warning-400: oklch(80% 0.16 54deg);
+  --color-warning-500: oklch(72% 0.18 55deg);
+  --color-warning-600: oklch(62% 0.16 56deg);
+  --color-warning-700: oklch(50% 0.14 58deg);
+  --color-warning-800: oklch(38% 0.12 59deg);
+  --color-warning-900: oklch(26% 0.10 60deg);
+  --color-warning-950: oklch(16% 0.08 61deg);
+
+  /* error: coral 25deg */
+  --color-error-50:  oklch(96% 0.05 20deg);
+  --color-error-100: oklch(90% 0.09 21deg);
+  --color-error-200: oklch(82% 0.14 22deg);
+  --color-error-300: oklch(82% 0.15 22deg);
+  --color-error-400: oklch(74% 0.18 23deg);
+  --color-error-500: oklch(62% 0.20 25deg);
+  --color-error-600: oklch(52% 0.17 27deg);
+  --color-error-700: oklch(42% 0.15 28deg);
+  --color-error-800: oklch(32% 0.12 29deg);
+  --color-error-900: oklch(23% 0.10 30deg);
+  --color-error-950: oklch(14% 0.08 31deg);
+
+  /* surface: indigo-tinted dark 270deg */
+  --color-surface-50:  oklch(95% 0.006 268deg);
+  --color-surface-100: oklch(88% 0.009 269deg);
+  --color-surface-200: oklch(80% 0.012 270deg);
+  --color-surface-300: oklch(70% 0.013 271deg);
+  --color-surface-400: oklch(58% 0.015 272deg);
+  --color-surface-500: oklch(46% 0.016 274deg);
+  --color-surface-600: oklch(35% 0.016 274deg);
+  --color-surface-700: oklch(26% 0.015 273deg);
+  --color-surface-800: oklch(17% 0.013 272deg);
+  --color-surface-900: oklch(12.5% 0.013 271deg);
+  --color-surface-950: oklch(9% 0.012 270deg);
+}
+```
+
+### Wiring it up
+
+In `frontend/src/style.css`, replace:
+```css
+/* @import '@skeletonlabs/skeleton/themes/vox'; */
+@import './theme-synapse.css';
+```
+
+In root HTML element or `App.svelte`, change:
+```html
+<!-- data-theme="vox" → data-theme="synapse" -->
+```
+
+---
+
+## Semantic Design Rationale (Palette B)
+
+| Slot | Hue | Why this color |
+|---|---|---|
+| `primary` / `in-progress` | Indigo 270deg | Brand accent = active/running — most visible state |
+| `secondary` / `testing` | Teal 190deg | Universal "AI actively processing" color in 2025 |
+| `tertiary` / `planning` | Lavender 293deg | Slightly cooler than indigo = "thinking, not yet running" |
+| `warning` / `in-review` | Gold 55deg | Review gate = awaiting judgment, not dangerous |
+| `error` / `human-required` | Coral 25deg | Urgency without red-danger connotation |
+| `success` / `done` | Jade 158deg | Modern completion color (Stripe uses it too) |
+| `surface` / `todo` | Indigo-tinted neutral | Invisible until needed — the "not yet" state |
+
+---
+
+## Sources
+
+- Linear design system (LCH migration writeup)
+- Radix Colors documentation (12-step perceptual scale)
+- Skeleton UI v4 theme API
+- OKLCH.com reference
+- Vercel/v0.dev, GitHub dark mode, Cursor, Warp visual inspection
+- Perplexity, Devin, Claude.ai color analysis

--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -1,0 +1,142 @@
+# Synapse Design Guidelines
+
+## Theme: Amber Command
+
+Warm-dark + amber accent. Light mode reads as parchment + gold. Think mission control, not generic SaaS.
+
+**Theme file:** `frontend/src/theme-amber.css`  
+**data-theme:** `amber`
+
+---
+
+## Color Palette
+
+### Hue Map
+
+| Slot | Hue | Degrees | Assigned to |
+|---|---|---|---|
+| `primary` | Amber | 55deg | `in-progress` / brand accent / interactive |
+| `secondary` | Teal | 190deg | `testing` / active-AI indicator |
+| `tertiary` | Warm-muted | 36deg | `planning` / `new` / `plan-review` |
+| `success` | Jade | 156deg | `done` |
+| `warning` | Violet | 278deg | `in-review` (reassigned — amber is brand, not warning) |
+| `error` | Coral | 22deg | `human-required` |
+| `surface` | Warm | 33deg | backgrounds / `todo` / neutral chrome |
+
+### Dark Mode Surfaces
+
+| Role | OKLCH | Hex | Usage |
+|---|---|---|---|
+| Background | `oklch(9% 0.008 32deg)` | `#110e0b` | Page bg (`surface-950`) |
+| Card | `oklch(18% 0.009 34deg)` | `#231c16` | Task cards, panels (`surface-800`) |
+| Elevated | `oklch(27% 0.010 35deg)` | `#352c22` | Modals, popovers (`surface-700`) |
+| Border | `oklch(36% 0.010 36deg)` | `#453c30` | Dividers, outlines (`surface-600`) |
+| Text muted | `oklch(58% 0.009 34deg)` | `#7a7064` | Secondary labels (`surface-500`) |
+| Text secondary | `oklch(76% 0.007 32deg)` | `#b5ae9e` | Metadata, timestamps (`surface-300`) |
+| Text primary | `oklch(93% 0.004 30deg)` | `#eee8df` | Titles, body (`surface-50`) |
+
+### Light Mode Surfaces
+
+| Role | OKLCH | Hex | Usage |
+|---|---|---|---|
+| Background | `oklch(98% 0.003 30deg)` | `#faf8f7` | Page bg (`surface-50`) |
+| Card | `oklch(96% 0.004 31deg)` | `#f4f1f0` | Task cards, panels (`surface-100`) |
+| Elevated | `oklch(93% 0.005 32deg)` | `#eeeae9` | Modals, popovers (`surface-200`) |
+| Border | `oklch(88% 0.007 33deg)` | `#dcd6d4` | Dividers, outlines (`surface-300`) |
+| Text muted | `oklch(55% 0.009 34deg)` | `#77706e` | Secondary labels |
+| Text secondary | `oklch(35% 0.010 33deg)` | `#403937` | Metadata |
+| Text primary | `oklch(15% 0.008 32deg)` | `#0e0a09` | Titles, body |
+
+### Accent — Amber
+
+| Stop | OKLCH | Use |
+|---|---|---|
+| 500 | `oklch(74% 0.18 55deg)` | Brand / on dark backgrounds |
+| 600 | `oklch(67% 0.17 57deg)` | Interactive on light bg |
+| 700 | `oklch(55% 0.15 59deg)` | Hover state / link text (light mode) |
+| 400 | `oklch(79% 0.17 54deg)` | Hover state (dark mode) |
+| 200 | `oklch(88% 0.12 52deg)` | Light mode badge background |
+| 800 | `oklch(42% 0.13 61deg)` | Light mode badge text |
+
+---
+
+## Status Badge Colors
+
+Badges use Skeleton semantic Tailwind classes — no hardcoded hex needed.
+
+### Class Pattern
+
+| Mode | bg | text |
+|---|---|---|
+| Light | `bg-{slot}-200` | `text-{slot}-800` |
+| Dark | `dark:bg-{slot}-700` | `dark:text-{slot}-200` |
+
+### Per Status
+
+| Status | Skeleton slot | Light bg | Light text | Dark bg | Dark text |
+|---|---|---|---|---|---|
+| `in-progress` | `primary` | amber-200 | amber-800 | amber-700 | amber-200 |
+| `in-review` | `warning` | violet-200 | violet-800 | violet-700 | violet-200 |
+| `testing` | `secondary` | teal-200 | teal-800 | teal-700 | teal-200 |
+| `planning` / `new` | `tertiary` | warm-200 | warm-800 | warm-700 | warm-200 |
+| `human-required` | `error` | coral-200 | coral-800 | coral-700 | coral-200 |
+| `done` | `success` | jade-200 | jade-800 | jade-700 | jade-200 |
+| `todo` | `surface` | surface-200 | surface-800 | surface-700 | surface-200 |
+
+---
+
+## Visualization Links
+
+| Mode | Tool | Link |
+|---|---|---|
+| Dark | Coolors | https://coolors.co/040202-0a0605-fe860f-00a292-6567e7-009f4b-e93954-eae7e6 |
+| Dark | Realtime Colors | https://www.realtimecolors.com/?colors=eae7e6-040202-fe860f-00a292-6567e7&fonts=Inter-Inter |
+| Light | Coolors | https://coolors.co/faf8f7-f4f1f0-c35600-006f63-4544ab-006422-9d2a39-0e0a09 |
+| Light | Realtime Colors | https://www.realtimecolors.com/?colors=0e0a09-faf8f7-c35600-006f63-4544ab&fonts=Inter-Inter |
+
+---
+
+## Typography
+
+- Font: system UI stack (`ui-sans-serif, system-ui, -apple-system`) — native on every platform
+- Heading weight: 600
+- Heading letter-spacing: 0.015em
+- Body: normal weight, 0em letter-spacing
+- Responsive base: 16px mobile / 18px desktop (768px+)
+
+---
+
+## Spacing & Shape
+
+- Spacing unit: 0.25rem (Tailwind default)
+- Base radius: 0.375rem (sm — for badges, inputs, small elements)
+- Container radius: 0.75rem (lg — for cards, modals, panels)
+- Border width: 1px
+
+---
+
+## Dark Mode Implementation
+
+Dark mode is applied via `.dark` class on `document.documentElement` (not via data-theme change). Controlled from `frontend/src/main.ts`.
+
+- System preference detected via `window.matchMedia`
+- User override persisted in `localStorage` as `colorScheme` (`'system' | 'light' | 'dark'`)
+- Custom Tailwind variant: `@custom-variant dark (&:where(.dark, .dark *))`
+
+All dark variants use `dark:` prefix: e.g. `bg-surface-100 dark:bg-surface-900`
+
+---
+
+## Anti-patterns
+
+- Never use hardcoded hex/rgb colors in components — always use Skeleton semantic tokens
+- Never use `bg-yellow-*` or `bg-orange-*` as "warning" — `warning` = violet in this theme
+- Never use `bg-red-*` for human-required — use `bg-error-*` (coral, not red)
+- Never use pure `#000000` or `#ffffff` backgrounds — the warm surface tokens handle this
+- Don't use high-chroma amber for text on light backgrounds — use 700/800 stops for legibility
+
+---
+
+## Color Research
+
+Full research basis in `docs/color-palette.md` and `docs/ux-research.md`.

--- a/docs/ux-research.md
+++ b/docs/ux-research.md
@@ -1,0 +1,528 @@
+# UX/UI Design Knowledge Base for Synapse
+
+> Research covering 2020–2025 award-winning apps in project management, AI orchestration, developer tooling, and productivity. Compiled as a reference for improving Synapse's UX and UI.
+
+---
+
+## 1. Apple Design Awards — Interaction & Innovation Patterns
+
+### What Apple Consistently Rewards
+
+- **State-awareness** — UI knows where you are, shows only what's relevant now
+- **Progressive complexity** — starts simple, reveals depth on demand
+- **Platform-native feel** — OS conventions, not generic web patterns
+- **Failure grace** — explicitly designed for when things go wrong
+- **Emotional completion** — finishing a task feels satisfying
+
+### Notable Winners Relevant to Synapse
+
+**Flighty (2023, Interaction)**
+- 15 context-aware states — different UI per lifecycle phase (gate / boarding / in-flight / arrived)
+- Mimics airport departure board: one line per item, time-critical info dominant
+- Dynamic Island shows circular progress in-flight; full detail pre-flight
+- **Synapse pattern**: Agent lifecycle phases (queued/running/blocked/reviewing/done) should each have a distinct purposeful display — not just a status label change
+
+**Things 3 (multiple ADAs)**
+- Two Apple Design Awards
+- Completion animations matter — done should feel satisfying
+- Every animation communicates state change, never decorative
+- Progressive disclosure: item opens and "rises as a card from background"
+
+**Procreate Dreams (2024, Innovation)**
+- Familiar patterns + new capabilities layered on top
+- **Synapse pattern**: Reuse git/terminal conventions as mental model backbone
+
+---
+
+## 2. Linear — Best-in-Class Project Management UX
+
+### Color System
+
+- **LCH color space** (perceptually uniform) — a red and yellow at L50 appear equally light
+- Reduced from 98 specific variables to 3: base color, accent color, contrast
+- Limited accent (blue) usage in chrome calculations
+- Dark mode: text/icons lightened; light mode: darkened — increases content contrast
+
+### Typography
+
+- Inter for body; Inter Display for headings (expression without sacrificing readability)
+- Bold, direct typefaces dominate visual hierarchy
+
+### Visual Effects
+
+- Predominantly dark mode, not pure black — brand colors at 1–10% lightness as background
+- Complex gradients for dimensional depth
+- Glassmorphism used selectively
+- Subtle noise overlays, high contrast ratios
+
+### Navigation Architecture
+
+**"Inverted L-shape" chrome** — sidebar + top tabs control all main content views.
+
+**G+letter shortcut system** (most praised by power users):
+```
+G I  → Inbox
+G M  → My Issues
+G A  → Active Issues
+G B  → Backlog
+G C  → Cycles
+G P  → Projects
+G S  → Settings
+```
+
+**Full keyboard shortcut vocabulary:**
+```
+C            → New issue
+E            → Edit issue
+S            → Change status
+P            → Change priority
+Cmd+K        → Command menu
+/            → Open search
+Cmd+B        → Toggle list/board view
+Cmd+I        → Open details sidebar
+Cmd+D        → Set due date
+Cmd+.        → Copy issue ID
+Shift+Cmd+.  → Copy git branch name
+Shift+C      → Add to cycle
+Shift+P      → Add to project
+```
+
+### What Makes Linear Specifically Praised
+
+1. **3.7x faster than Jira** for common ops — performance as primary UX feature
+2. **No zig-zagging** — content flows in reading direction, single subject per view
+3. **Issue creation to PR branch in 3 keystrokes** — workflow completion time
+4. **Multiple view modes**: list, board, timeline, split, fullscreen — density preferences respected
+5. **Information density without clutter** — tight spacing + gestalt, not raw data dump
+
+---
+
+## 3. Things 3 — Task Manager UX Patterns
+
+### Core Patterns
+
+**Type Travel** — no shortcut to start navigation, just type anywhere. App-wide tag search auto-detected.
+
+**Magic Plus Button** — drag-to-place insertion: drop onto list position to create item there. Context-aware: creates to-dos, headings, or routes to Inbox depending on gesture.
+
+**Progressive Disclosure Hierarchy**
+- Tasks appear minimal by default (title only)
+- Extra fields (tags, dates, checklists, notes) appear when item is opened
+- Items "rise up out of the background as a card-like object" on selection
+
+**Natural Language Date Parsing**
+- "Tomorrow", "Saturday", "in four days", "next Wednesday", "Wed 8pm"
+- Unified scheduling popover consolidates all date/time decisions in one place
+
+**Time-Based Organization**
+- Today / This Evening split — temporal context within a single day
+- Logbook: searchable completion history rather than deletion
+- Task cancellation distinct from completion (preserves intent record)
+
+**Animation Philosophy**
+- Every animation communicates state change — never decorative
+- To-do opening transforms into "white piece of paper"
+- Completion items fade and slide away
+- Progress pie charts on projects visible at list level
+
+**Slim Mode** — two-finger swipe collapses sidebar for focus writing mode
+
+### Extracted Principles
+
+1. Show only what's needed — extra fields on demand
+2. Every animation = state communication, not decoration
+3. Keyboard-first: power users never touch mouse
+4. Logbook/history as first-class feature (completion has weight)
+5. Multi-select via swipe-up gesture without entering a separate mode
+
+---
+
+## 4. Raycast — Developer Productivity Launcher
+
+### Core Design Architecture
+
+**Command Palette as First-Class OS** — everything accessible through single keyboard shortcut; fuzzy search across all extensions, commands, files, apps; system-wide rather than per-app.
+
+**Extension Component System (React-based)** — four primitives only:
+1. **List** — similar items (open PRs, todos)
+2. **Grid** — image-forward content
+3. **Detail** — single item deep dive
+4. **Form** — creation workflows
+
+Every component integrates ActionPanel with keyboard shortcuts for every action.
+
+**Keyboard-First Throughout**
+- `⌘1–9` for favorited commands
+- Aliases assigned per extension for single-word activation
+- Recent commands surfaced at top
+- Contextual suggestions based on current directory/project type
+
+**Performance as Design** — components render immediately with `isLoading` state — no blank screen wait.
+
+**Cross-App Unification** — GitHub, Linear, Notion, Slack all accessible from same interface; eliminates context switching between tool UIs.
+
+---
+
+## 5. Notion — Information Architecture & Flexibility
+
+### Block-Based Architecture
+
+- Everything is a block: paragraphs, headings, checkboxes, databases, embeds, code
+- Blocks are composable, movable, nestable
+- Same content block can display as Table, Board, Gallery, Calendar, Timeline, List
+- **Pattern**: flexibility without configuration menus — just change the view type
+
+### Slash Command Palette
+
+Triggered by `/` inline:
+- Groups commands by type: building blocks, databases, inline, embeds
+- AI commands grouped separately
+- Recent commands shown in palette
+- Free-form prompt allowed beyond predefined commands
+
+### Database Flexibility Pattern
+
+Six database views of the same data: Table / Board / Gallery / Calendar / List / Timeline
+
+**Synapse application**: Tasks should support view switching (list → kanban → timeline) without migrating data — just perspective switching.
+
+### Design Principles
+
+1. **Horizontal flexibility** — same data, infinite display modes
+2. **Inline editing everywhere** — no separate "edit mode"
+3. **Blocks as atomic units** — reshuffle information without restructuring
+4. **Linked data** — reference without copying
+
+---
+
+## 6. Cron / Notion Calendar — Temporal UX Innovation
+
+### UX Patterns Worth Extracting
+
+1. Drag-to-create events (no modal required)
+2. Natural language event creation ("team standup tomorrow 9am")
+3. Speed — temporal data freshness perceived as a design quality
+4. Unified time layer vision — tasks, projects, calendar items share one temporal view
+
+---
+
+## 7. AI Agent Interfaces — UX Patterns (2024–2025)
+
+### Devin (Cognition) — Three-Panel Agent Workspace
+
+**Layout**: Left sidebar (session list) + Center (chat) + Right (workspace)
+
+**Workspace tabs** (maps to how a human developer actually works):
+- Shell — terminal environment
+- Browser — web testing/verification
+- Editor — code review (read-only diffs)
+- Planner — autonomous to-do list
+
+**Timeline slider** — scrub backward through agent's history of actions
+
+**"Following" toggle** — auto-switch between workspace tabs as agent uses them
+
+**Status indicator** — "Devin is thinking..." or task-specific text ("Installing dependencies"), never a generic spinner
+
+**Chat model** — complete messages after "typing..." indicator rather than character-by-character streaming; multiple messages queued naturally
+
+**In-flow task updates** — sub-tasks appear inline within messages as expandable sections, not in separate panel
+
+### GitHub Copilot Workspace — Steerable Pipeline
+
+Four-stage workflow made explicit and editable:
+1. **Specification** — current state + desired state as two editable bullet lists
+2. **Plan** — files to create/modify/delete + actions per file
+3. **Implementation** — directly editable diffs
+4. **PR** — one-click creation
+
+**Key pattern**: Every upstream artifact is editable; edits trigger downstream regeneration. User always in control of reasoning, not just output.
+
+### v0.dev (Vercel) — Streaming Artifacts
+
+- Split-screen: chat (left) + live rendered preview (right)
+- Generated code runs immediately in preview without build step
+- "Blocks" = complex UI artifacts appearing inline in chat, previewable, then installable
+- Agentic mode: multi-step planning (schema → routes → components → connection)
+
+### Cursor — Agent-Centric IDE
+
+- Background agents work on separate git branches in parallel VMs
+- Agent as "small team" mental model, not single chatbot
+- Rules system (.mdc files) for persistent context across sessions
+- Composer interface for multi-file multi-agent work
+
+### Claude Artifacts — Split-Screen Collaboration
+
+- Thread + Artifact split-screen layout
+- Code preview renders live automatically
+- Persistent storage across sessions
+- Remix/share capability
+
+### Universal AI Agent UX Patterns
+
+**Transparency mechanisms:**
+- Real-time status: what is the agent doing *right now*
+- History timeline: what did the agent do (scrollable/scrubbable)
+- Intermediate artifacts: specs, plans, diffs before final output
+
+**Control points:**
+- Human-in-the-loop confirmations at destructive steps
+- Edit-at-any-stage (upstream edits regenerate downstream)
+- Pause/resume (not just cancel)
+- Parallel agents with per-agent status visibility
+
+**Streaming UX:**
+- Streaming text = 4-second wait becomes 4-second experience
+- Status as text beats spinners — specificity reduces anxiety
+- Task hierarchy shown inline, not in separate panel
+
+**Agent personality signals:**
+- Devin's "Devin is thinking..." humanizes the wait
+- Specificity in status text reduces anxiety more than any spinner
+- Sub-tasks appear inline within messages as expandable sections
+
+---
+
+## 8. Terminal / Developer GUI Hybrids
+
+### Warp — Block-Based Terminal
+
+**Core innovation**: Every command + its output = one selectable, referenceable block
+
+- Copy/share/re-run/reference individual blocks (not raw text)
+- Vertical tabs with metadata overlays: git branch, worktree, PR number
+- File tree embedded in terminal
+- AI integration: multi-step goal description → agent plans → pauses for confirmation
+- Human-in-the-loop confirmation at each step as a design principle
+
+### Zed — Multiplayer-First Code Editor
+
+**Performance as design:**
+- GPUI: self-developed GPU-accelerated UI framework
+- 120fps rendering via GPU parallel processing
+- "Butter-smooth scrolling, immediate keystroke response"
+- Subtle animations at 120fps feel qualitatively different from 60fps
+
+**Minimal aesthetic:**
+- "Intentionally minimal UI" — not a feature gap, a philosophy
+- Command palette, customizable keybindings, Vim-modal editing
+
+### Ghostty — Configuration-as-Aesthetic
+
+- 50MB vs Warp's 300MB — binary size itself is a design statement
+- Zero-config defaults that work out-of-the-box
+- Resilient to misconfiguration (ignores unsupported settings gracefully)
+- Window state persistence via config
+
+---
+
+## 9. Dark Mode Implementation — Best Practices
+
+### Color Fundamentals
+
+**Never pure black:**
+- `#121212` (Material Design) or `#141414` for surfaces
+- Pure black causes optical harshness and OLED "halo" bleeding
+- Add subtle dark blue tint to grays for warmth
+
+**Saturation reduction (critical):**
+- Dark mode colors should be ~20 points lower saturation than light mode equivalents
+- Saturated colors on dark backgrounds create optical vibration + eye strain
+
+**Linear's approach:**
+- LCH/OKLCH color space — perceptually uniform lightness
+- Three variables only: base color, accent color, contrast
+- Limited accent usage in chrome calculations
+
+**Elevation via color:**
+- Lighter = higher elevation (inverse of light mode)
+- Each elevation step adds ~5% white overlay
+- Creates depth without shadows (shadows don't work on dark)
+
+### Semantic Color System
+
+```
+Surface:          #121212
+Surface+1:        #1E1E1E
+Surface+2:        #2A2A2A
+Border:           rgba(255,255,255, 0.08)
+Text primary:     rgba(255,255,255, 0.87)
+Text secondary:   rgba(255,255,255, 0.60)
+Text disabled:    rgba(255,255,255, 0.38)
+```
+
+### Status Color System for Task/Agent States
+
+```
+Running/Active:   muted blue (focus, progress)
+Done:             muted green
+Blocked/Error:    muted red
+Waiting/Queued:   muted amber
+Idle:             gray (neutral)
+Human-required:   muted orange (attention needed, not error)
+```
+
+**Avoid traffic-light literalism** — muted tones read as professional; pure red/green/yellow reads as toy software.
+
+---
+
+## 10. Command Palette — Design Specification
+
+### Trigger Conventions
+
+- **Primary**: `Cmd+K` (Linear, Notion, Raycast, Claude)
+- **Alternatives**: `/` for search-in-context
+- Expose the shortcut visibly in the UI for discoverability
+
+### Search Behavior
+
+- Fuzzy matching required — exact names not needed
+- Keywords assigned to each action
+- Mode switching within palette (e.g., `>` prefix for commands vs. raw search)
+
+### History & Recency
+
+- Recently used commands at top
+- Contextual suggestions on open (before any input)
+- Usage frequency weighting for ranking
+
+### Keyboard Navigation
+
+- Arrow keys to navigate, Enter to execute, Escape to dismiss
+- Tab to autocomplete / expand subcommand
+
+### Visual Design
+
+- Centered modal with backdrop blur
+- Input field at top, results below (max ~8 visible without scroll)
+- Keyboard shortcut shown right-aligned on each result row
+- Category groupings with subtle section headers
+- Selected item: colored background, not just text color change
+
+### Advanced Patterns
+
+- **Action chaining** (Tana pattern): each selection reveals subsequent available commands
+- **Contextual palette**: `/` inline shows different commands based on current context
+- **Display shortcuts alongside results** to build power-user muscle memory passively
+
+---
+
+## 11. UI Density Framework
+
+### The Value Density Model
+
+> "UI density = value user gets from interface ÷ time and space occupied"
+
+**Temporal density thresholds:**
+- Under 100ms: feel simultaneous, no feedback needed
+- 100ms–1s: animation bridges the gap, makes action feel connected
+- 1–10s: indeterminate loader acceptable
+- Over 1min: defer + notify on completion (never block)
+
+### Developer Tool Density Patterns
+
+**High information, low visual noise** (Bloomberg Terminal, Linear):
+- Tables for relational data (scan, sort, compare without cognitive overhead)
+- Progressive disclosure: show skeleton, reveal detail on hover/click
+- Configurable row density (compact/comfortable/spacious)
+- Monospace for code/IDs, proportional for prose
+- Color used for state, not decoration
+
+**Anti-patterns:**
+- Whitespace that signals emptiness vs. intended breathing room
+- Modal dialogs for inline decisions
+- Confirmation dialogs for reversible actions
+- Loading spinners with no time estimate
+
+---
+
+## 12. Navigation Paradigms — Decision Matrix
+
+| Pattern | Best For | Examples | When to Use in Synapse |
+|---|---|---|---|
+| Sidebar tree | Hierarchical content, many items | Notion, Linear | Project + task hierarchy |
+| Command palette | Power users, action discovery | Raycast, Linear, Notion | Global actions, navigation |
+| Tab bar | Switching major views | Flighty, Things, Devin | Agent workspace panels |
+| G+letter navigation | Fast switching between known views | Linear | Tasks/projects/agents |
+| Three-panel layout | Chat + work + context | Devin, v0.dev, Cursor | Agent session view |
+| Kanban board | Workflow stage visualization | Linear, Notion | Task status pipeline |
+| Inline agent panel | Non-blocking agent status | Cursor | Agent running alongside tasks |
+
+---
+
+## 13. Actionable Design Principles for Synapse
+
+### Agent State Visualization
+
+1. **Named states with distinct visual signatures** — Running/Awaiting Human/Blocked/Done should each have color + icon, never just a text label
+2. **Live activity indicators** — pulsing dot for running agents (not spinner), static dot for idle
+3. **What is it doing right now** — show current task/step, not just overall status
+4. **Timeline scrubbing** — ability to scroll back through agent actions (Devin pattern)
+5. **Inline sub-task hierarchy** — show nested steps as expandable list, not separate panel
+6. **Status as text** — "Installing dependencies" beats a generic spinner
+
+### Task Board Design
+
+7. **View switching without data migration** — list/kanban/timeline are perspectives, same data
+8. **Keyboard-first** — every common action has a shortcut; show shortcuts in UI while learning
+9. **Inline editing** — click to edit in place, not a separate form/modal
+10. **Natural language dates** — "tomorrow", "next week" in date fields
+11. **Logbook/history** — completed tasks are searchable history, not deleted
+12. **Status colors that scale** — use muted semantic palette, avoid pure traffic lights
+
+### Agent + Task Integration
+
+13. **Agent linked to task** — running agent and its source task visually connected
+14. **Branch name surfaced** — copy-to-clipboard as first-class action (Linear's `Shift+Cmd+.`)
+15. **Worktree = task context** — show which worktree/branch an agent is working in
+16. **Parallel agent visualization** — show multiple running agents with per-agent status
+
+### Command Palette
+
+17. **`Cmd+K` to open** — standard expectation
+18. **G+letter for views** — fast navigation between Inbox / My Tasks / All Tasks / Agents / Projects
+19. **Contextual suggestions** on open (recent tasks, running agents)
+20. **Fuzzy search** across tasks, projects, agents
+21. **Actions shown with shortcuts** to build muscle memory passively
+
+### Dark Mode Implementation
+
+22. **Background `#141414` not `#000000`** — dark gray, not black
+23. **3-variable system**: base, accent, contrast (Linear approach)
+24. **Saturation -20 points** for all semantic colors vs. their light-mode equivalents
+25. **LCH/OKLCH color space** for perceptually uniform theme variants
+26. **Elevation via lightness** — cards, modals, popovers each step up ~5% lightness
+
+### Animation & Interaction
+
+27. **Under 100ms transitions** need no indicator — just happen
+28. **100ms–1s transitions** — animate to bridge (task status changes, agent state transitions)
+29. **Over 1min work** — background + notification on complete (Warp pattern)
+30. **Completion animations** matter — done should feel satisfying (Things-inspired)
+31. **Every animation communicates state** — never decorative (Things principle)
+
+### Information Hierarchy
+
+32. **One level of priority per screen** — what is most important at this moment
+33. **Context-appropriate state** — like Flighty's 15 states, agent view changes based on lifecycle phase
+34. **Graceful degradation** — design explicitly for blocked/error/offline states
+35. **Emotional completion** — when all agents finish, celebrate it
+
+---
+
+## Sources
+
+- Apple Design Awards 2020–2025 (developer.apple.com/design/awards)
+- Linear UI Redesign blog (linear.app/now/how-we-redesigned-the-linear-ui)
+- Things 3 Features (culturedcode.com/things/features)
+- Flighty Behind the Design (developer.apple.com/news)
+- Devin Product Analysis (Cognition Labs)
+- GitHub Copilot Workspace (githubnext.com/projects/copilot-workspace)
+- Command K Bars — Maggie Appleton (maggieappleton.com/command-bar)
+- UI Density — Matt Ström
+- Warp Terminal (warp.dev)
+- Zed Blog (zed.dev/blog/between-editors-and-ides)
+- Dark Mode Best Practices (Atmos)
+- Raycast Developer API (developers.raycast.com)
+- 10 Things Developers Want from Agentic IDEs (RedMonk, 2025)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="vox">
+<html lang="en" data-theme="amber">
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="color-scheme" content="light dark" />
-    <meta name="theme-color" content="#1a1625" media="(prefers-color-scheme: dark)" />
-    <meta name="theme-color" content="#f4f0f9" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#110e0b" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#faf8f7" media="(prefers-color-scheme: light)" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Synapse" />

--- a/frontend/src/components/AgentCard.svelte
+++ b/frontend/src/components/AgentCard.svelte
@@ -10,7 +10,7 @@
 
   const stateConfig: Record<string, { label: string; classes: string }> = {
     idle: { label: 'Idle', classes: 'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200' },
-    running: { label: 'Running', classes: 'bg-success-200 text-success-800 dark:bg-success-700 dark:text-success-200' },
+    running: { label: 'Running', classes: 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200' },
     paused: { label: 'Waiting', classes: 'bg-warning-200 text-warning-800 dark:bg-warning-700 dark:text-warning-200' },
     stopped: { label: 'Stopped', classes: 'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200' },
   }
@@ -43,7 +43,7 @@
     </div>
     <span class="inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium {resolved.classes}">
       {#if a.state === 'running'}
-        <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-success-500"></span>
+        <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-primary-500"></span>
       {:else if a.state === 'paused'}
         <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-warning-500"></span>
       {/if}

--- a/frontend/src/components/CommandPalette.svelte
+++ b/frontend/src/components/CommandPalette.svelte
@@ -110,17 +110,16 @@
     }
   }
 
-  function typeIcon(type: 'page' | 'task' | 'project'): string {
-    if (type === 'page') return '→'
-    if (type === 'task') return '□'
-    return '◈'
-  }
 </script>
 
 <MobileSheet {open} onOpenChange={(o) => { if (!o) onclose() }} variant="top">
   <div class="flex flex-col">
-    <div class="flex items-center border-b border-surface-300 px-4 dark:border-surface-600">
-      <svg class="h-4 w-4 shrink-0 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <!-- Search bar -->
+    <div class="flex items-center gap-3 border-b border-surface-200 px-4 dark:border-surface-700">
+      <svg
+        class="h-4 w-4 shrink-0 transition-colors {query ? 'text-primary-500' : 'text-surface-400'}"
+        fill="none" stroke="currentColor" viewBox="0 0 24 24"
+      >
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
       </svg>
       <input
@@ -128,36 +127,53 @@
         bind:value={query}
         type="text"
         placeholder="Search tasks, pages, projects..."
-        class="flex-1 bg-transparent py-3.5 pl-3 text-base outline-none placeholder:text-surface-400 md:text-sm"
+        class="flex-1 bg-transparent py-3.5 text-base outline-none placeholder:text-surface-400 md:text-sm"
       />
       <button
         type="button"
         onclick={onclose}
-        class="tap -mr-2 rounded text-surface-400 active:bg-surface-200 dark:active:bg-surface-700"
+        class="tap -mr-2 flex items-center gap-1.5 text-surface-400 hover:text-surface-600 dark:hover:text-surface-300"
         aria-label="Close"
       >
-        <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+        <kbd class="hidden rounded border border-surface-300 px-1.5 py-0.5 font-mono text-[10px] text-surface-400 dark:border-surface-600 md:inline">Esc</kbd>
+        <svg class="h-5 w-5 md:hidden" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
         </svg>
       </button>
     </div>
 
-    <ul class="max-h-[60dvh] overflow-y-auto py-2 md:max-h-80">
+    <!-- Results -->
+    <ul class="max-h-[60dvh] overflow-y-auto py-1 md:max-h-80">
       {#if results.length === 0}
-        <li class="px-4 py-3 text-sm italic text-surface-400">No results</li>
+        <li class="px-4 py-8 text-center text-sm text-surface-400">
+          No results for "<span class="text-surface-700 dark:text-surface-300">{query}</span>"
+        </li>
       {:else}
         {#each results as result, i}
           <li>
             <button
               type="button"
-              class="tap flex w-full items-center gap-3 px-4 py-3 text-left text-sm transition-colors {i === selectedIndex ? 'bg-primary-100 text-primary-800 dark:bg-primary-900/40 dark:text-primary-200' : 'active:bg-surface-200 dark:active:bg-surface-700'}"
+              class="tap flex w-full items-center gap-3 border-l-2 px-3 py-2.5 text-left text-sm transition-colors
+                {i === selectedIndex
+                  ? 'border-primary-500 bg-primary-50 text-primary-900 dark:bg-primary-950/50 dark:text-primary-100'
+                  : 'border-transparent hover:bg-surface-100 dark:hover:bg-surface-800'}"
               onclick={() => selectResult(result)}
               onmouseenter={() => { selectedIndex = i }}
             >
-              <span class="w-4 shrink-0 text-center font-mono text-xs text-surface-400">{typeIcon(result.type)}</span>
+              <span class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold uppercase
+                {result.type === 'page'
+                  ? 'bg-primary-100 text-primary-700 dark:bg-primary-900/50 dark:text-primary-300'
+                  : result.type === 'task'
+                    ? 'bg-secondary-100 text-secondary-700 dark:bg-secondary-900/50 dark:text-secondary-300'
+                    : 'bg-tertiary-100 text-tertiary-700 dark:bg-tertiary-900/50 dark:text-tertiary-300'}">
+                {result.type === 'page' ? 'PAGE' : result.type === 'task' ? 'TASK' : 'PROJ'}
+              </span>
               <span class="flex-1 font-medium">{result.title}</span>
               {#if result.subtitle}
                 <span class="text-xs text-surface-400">{result.subtitle}</span>
+              {/if}
+              {#if i === selectedIndex}
+                <span class="shrink-0 font-mono text-xs text-primary-500">↵</span>
               {/if}
             </button>
           </li>
@@ -165,11 +181,17 @@
       {/if}
     </ul>
 
-    <div class="hidden border-t border-surface-300 px-4 py-2 dark:border-surface-600 md:block">
+    <!-- Footer hints -->
+    <div class="hidden items-center gap-4 border-t border-surface-200 px-4 py-2.5 dark:border-surface-700 md:flex">
       <div class="flex gap-4 text-xs text-surface-400">
-        <span><kbd class="font-mono">↑↓</kbd> navigate</span>
-        <span><kbd class="font-mono">↵</kbd> open</span>
-        <span><kbd class="font-mono">Esc</kbd> close</span>
+        <span class="flex items-center gap-1">
+          <kbd class="rounded border border-surface-300 px-1 py-0.5 font-mono text-[10px] dark:border-surface-600">↑↓</kbd>
+          navigate
+        </span>
+        <span class="flex items-center gap-1">
+          <kbd class="rounded border border-surface-300 px-1 py-0.5 font-mono text-[10px] dark:border-surface-600">↵</kbd>
+          open
+        </span>
       </div>
     </div>
   </div>

--- a/frontend/src/components/MessageBubble.svelte
+++ b/frontend/src/components/MessageBubble.svelte
@@ -51,7 +51,7 @@
       {#each event.toolUses as tool (tool.id)}
         <div class="rounded-lg border border-surface-300 bg-surface-50 dark:border-surface-600 dark:bg-surface-900">
           <div class="flex items-center gap-2 border-b border-surface-200 px-3 py-1.5 dark:border-surface-700">
-            <span class="rounded bg-blue-200 px-1.5 py-0.5 text-[10px] font-bold text-blue-800 dark:bg-blue-700 dark:text-blue-200">
+            <span class="rounded bg-secondary-200 px-1.5 py-0.5 text-[10px] font-bold text-secondary-800 dark:bg-secondary-700 dark:text-secondary-200">
               TOOL
             </span>
             <span class="text-xs font-medium text-surface-700 dark:text-surface-300">{tool.name}</span>
@@ -67,7 +67,7 @@
                 filePath={String(tool.input.file_path ?? '')}
               />
             {:else if tool.name === 'Bash' && tool.input?.command}
-              <pre class="rounded bg-surface-900 px-2 py-1.5 text-xs text-green-400 dark:bg-surface-950">{tool.input.command}</pre>
+              <pre class="rounded bg-surface-900 px-2 py-1.5 text-xs text-success-400 dark:bg-surface-950">{tool.input.command}</pre>
             {:else if tool.name === 'Write' && tool.input?.content}
               <pre class="max-h-40 overflow-y-auto rounded bg-surface-900 px-2 py-1.5 text-xs text-surface-200 dark:bg-surface-950">{truncate(String(tool.input.content), 500)}</pre>
             {:else if tool.input}
@@ -85,7 +85,7 @@
       <div class="ml-4 rounded border-l-2 px-3 py-1.5 text-xs
         {result.isError
           ? 'border-error-500 bg-error-50 text-error-800 dark:bg-error-950 dark:text-error-200'
-          : 'border-green-500 bg-green-50 text-green-800 dark:bg-green-950 dark:text-green-200'}">
+          : 'border-success-500 bg-success-50 text-success-800 dark:bg-success-950 dark:text-success-200'}">
         <pre class="max-h-40 overflow-y-auto whitespace-pre-wrap break-words">{truncate(result.content, 1000)}</pre>
       </div>
     {/each}

--- a/frontend/src/components/PRCard.svelte
+++ b/frontend/src/components/PRCard.svelte
@@ -34,7 +34,7 @@
     <div class="flex items-center gap-2">
       {#if pr.ciStatus}
         <span
-          class="inline-block h-2.5 w-2.5 shrink-0 rounded-full {pr.ciStatus === 'SUCCESS' ? 'bg-green-500' : pr.ciStatus === 'FAILURE' ? 'bg-red-500' : 'bg-yellow-500'}"
+          class="inline-block h-2.5 w-2.5 shrink-0 rounded-full {pr.ciStatus === 'SUCCESS' ? 'bg-success-500' : pr.ciStatus === 'FAILURE' ? 'bg-error-500' : 'bg-warning-500'}"
           title="CI: {pr.ciStatus.toLowerCase()}"
         ></span>
       {/if}
@@ -45,12 +45,12 @@
         <span class="rounded bg-surface-200 px-1.5 py-0.5 text-xs dark:bg-surface-700">Draft</span>
       {/if}
       {#if pr.reviewDecision === 'APPROVED'}
-        <span class="rounded bg-green-500/15 px-1.5 py-0.5 text-xs font-medium text-green-600 dark:text-green-400">Approved</span>
+        <span class="rounded bg-success-500/15 px-1.5 py-0.5 text-xs font-medium text-success-700 dark:text-success-400">Approved</span>
       {:else if pr.reviewDecision === 'CHANGES_REQUESTED'}
-        <span class="rounded bg-red-500/15 px-1.5 py-0.5 text-xs font-medium text-red-600 dark:text-red-400">Changes</span>
+        <span class="rounded bg-error-500/15 px-1.5 py-0.5 text-xs font-medium text-error-700 dark:text-error-400">Changes</span>
       {/if}
       {#if pr.unresolvedCount > 0}
-        <span class="rounded bg-yellow-500/15 px-1.5 py-0.5 text-xs font-medium text-yellow-600 dark:text-yellow-400"
+        <span class="rounded bg-warning-500/15 px-1.5 py-0.5 text-xs font-medium text-warning-700 dark:text-warning-400"
           title="{pr.unresolvedCount} unresolved thread{pr.unresolvedCount !== 1 ? 's' : ''}"
         >{pr.unresolvedCount} unresolved</span>
       {/if}

--- a/frontend/src/components/PRCard.svelte.test.ts
+++ b/frontend/src/components/PRCard.svelte.test.ts
@@ -82,21 +82,21 @@ describe('PRCard', () => {
       render(PRCard, { props: { pr: makePR({ ciStatus: 'SUCCESS' }) } })
       const dot = document.querySelector('[title="CI: success"]')
       expect(dot).toBeDefined()
-      expect(dot?.className).toContain('bg-green-500')
+      expect(dot?.className).toContain('bg-success-500')
     })
 
     it('shows red dot for FAILURE', () => {
       render(PRCard, { props: { pr: makePR({ ciStatus: 'FAILURE' }) } })
       const dot = document.querySelector('[title="CI: failure"]')
       expect(dot).toBeDefined()
-      expect(dot?.className).toContain('bg-red-500')
+      expect(dot?.className).toContain('bg-error-500')
     })
 
     it('shows yellow dot for PENDING', () => {
       render(PRCard, { props: { pr: makePR({ ciStatus: 'PENDING' }) } })
       const dot = document.querySelector('[title="CI: pending"]')
       expect(dot).toBeDefined()
-      expect(dot?.className).toContain('bg-yellow-500')
+      expect(dot?.className).toContain('bg-warning-500')
     })
 
     it('shows no dot when empty', () => {

--- a/frontend/src/components/PRDetailView.svelte
+++ b/frontend/src/components/PRDetailView.svelte
@@ -61,20 +61,20 @@
     <div class="mt-4 flex flex-wrap items-center gap-2">
       {#if pr.ciStatus}
         <span class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium
-          {pr.ciStatus === 'SUCCESS' ? 'bg-green-500/15 text-green-600 dark:text-green-400' :
-           pr.ciStatus === 'FAILURE' ? 'bg-red-500/15 text-red-600 dark:text-red-400' :
-           'bg-yellow-500/15 text-yellow-600 dark:text-yellow-400'}">
+          {pr.ciStatus === 'SUCCESS' ? 'bg-success-500/15 text-success-700 dark:text-success-400' :
+           pr.ciStatus === 'FAILURE' ? 'bg-error-500/15 text-error-700 dark:text-error-400' :
+           'bg-warning-500/15 text-warning-700 dark:text-warning-400'}">
           <span class="inline-block h-2 w-2 rounded-full
-            {pr.ciStatus === 'SUCCESS' ? 'bg-green-500' :
-             pr.ciStatus === 'FAILURE' ? 'bg-red-500' : 'bg-yellow-500'}"></span>
+            {pr.ciStatus === 'SUCCESS' ? 'bg-success-500' :
+             pr.ciStatus === 'FAILURE' ? 'bg-error-500' : 'bg-warning-500'}"></span>
           CI: {pr.ciStatus.toLowerCase()}
         </span>
       {/if}
 
       {#if pr.mergeable}
         <span class="rounded-full px-2.5 py-1 text-xs font-medium
-          {pr.mergeable === 'MERGEABLE' ? 'bg-green-500/15 text-green-600 dark:text-green-400' :
-           pr.mergeable === 'CONFLICTING' ? 'bg-red-500/15 text-red-600 dark:text-red-400' :
+          {pr.mergeable === 'MERGEABLE' ? 'bg-success-500/15 text-success-700 dark:text-success-400' :
+           pr.mergeable === 'CONFLICTING' ? 'bg-error-500/15 text-error-700 dark:text-error-400' :
            'bg-surface-200 text-surface-500 dark:bg-surface-700'}">
           {pr.mergeable === 'MERGEABLE' ? 'Mergeable' :
            pr.mergeable === 'CONFLICTING' ? 'Conflicts' : 'Unknown'}
@@ -82,15 +82,15 @@
       {/if}
 
       {#if pr.reviewDecision === 'APPROVED'}
-        <span class="rounded-full bg-green-500/15 px-2.5 py-1 text-xs font-medium text-green-600 dark:text-green-400">Approved</span>
+        <span class="rounded-full bg-success-500/15 px-2.5 py-1 text-xs font-medium text-success-700 dark:text-success-400">Approved</span>
       {:else if pr.reviewDecision === 'CHANGES_REQUESTED'}
-        <span class="rounded-full bg-red-500/15 px-2.5 py-1 text-xs font-medium text-red-600 dark:text-red-400">Changes Requested</span>
+        <span class="rounded-full bg-error-500/15 px-2.5 py-1 text-xs font-medium text-error-700 dark:text-error-400">Changes Requested</span>
       {:else if pr.reviewDecision === 'REVIEW_REQUIRED'}
-        <span class="rounded-full bg-yellow-500/15 px-2.5 py-1 text-xs font-medium text-yellow-600 dark:text-yellow-400">Review Required</span>
+        <span class="rounded-full bg-warning-500/15 px-2.5 py-1 text-xs font-medium text-warning-700 dark:text-warning-400">Review Required</span>
       {/if}
 
       {#if pr.unresolvedCount > 0}
-        <span class="rounded-full bg-yellow-500/15 px-2.5 py-1 text-xs font-medium text-yellow-600 dark:text-yellow-400">
+        <span class="rounded-full bg-warning-500/15 px-2.5 py-1 text-xs font-medium text-warning-700 dark:text-warning-400">
           {pr.unresolvedCount} unresolved
         </span>
       {/if}
@@ -112,9 +112,9 @@
         {#each checkRuns as check}
           <div class="flex items-center gap-2 text-sm">
             <span class="inline-block h-2 w-2 shrink-0 rounded-full
-              {check.conclusion === 'SUCCESS' ? 'bg-green-500' :
-               check.conclusion === 'FAILURE' ? 'bg-red-500' :
-               check.status === 'IN_PROGRESS' ? 'bg-yellow-500' : 'bg-surface-400'}"></span>
+              {check.conclusion === 'SUCCESS' ? 'bg-success-500' :
+               check.conclusion === 'FAILURE' ? 'bg-error-500' :
+               check.status === 'IN_PROGRESS' ? 'bg-warning-500' : 'bg-surface-400'}"></span>
             <span class="flex-1 truncate">{check.name}</span>
             <span class="text-xs text-surface-400">
               {check.conclusion ? check.conclusion.toLowerCase() : check.status?.toLowerCase() ?? ''}
@@ -137,7 +137,7 @@
     {#if onapprove && !pr.viewerHasApproved && pr.reviewDecision !== 'APPROVED'}
       <button
         type="button"
-        class="rounded-lg bg-green-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-700"
+        class="rounded-lg bg-success-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-success-700"
         onclick={onapprove}
       >
         Approve
@@ -157,7 +157,7 @@
     {#if onrerun && hasFailed}
       <button
         type="button"
-        class="rounded-lg bg-yellow-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-yellow-700"
+        class="rounded-lg bg-warning-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-warning-700"
         onclick={onrerun}
       >
         Rerun Failed
@@ -167,7 +167,7 @@
     {#if onfix && hasFailed}
       <button
         type="button"
-        class="rounded-lg bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700"
+        class="rounded-lg bg-error-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-error-700"
         onclick={onfix}
       >
         Fix

--- a/frontend/src/components/RenovatePRCard.svelte
+++ b/frontend/src/components/RenovatePRCard.svelte
@@ -91,7 +91,7 @@
     <div class="flex items-center gap-2">
       {#if pr.ciStatus}
         <span
-          class="inline-block h-2.5 w-2.5 shrink-0 rounded-full {pr.ciStatus === 'SUCCESS' ? 'bg-green-500' : pr.ciStatus === 'FAILURE' ? 'bg-red-500' : 'bg-yellow-500'}"
+          class="inline-block h-2.5 w-2.5 shrink-0 rounded-full {pr.ciStatus === 'SUCCESS' ? 'bg-success-500' : pr.ciStatus === 'FAILURE' ? 'bg-error-500' : 'bg-warning-500'}"
           title="CI: {pr.ciStatus.toLowerCase()}"
         ></span>
       {/if}
@@ -99,10 +99,10 @@
     </div>
     <div class="flex shrink-0 items-center gap-1.5">
       {#if pr.reviewDecision === 'APPROVED'}
-        <span class="rounded bg-green-500/15 px-1.5 py-0.5 text-xs font-medium text-green-600 dark:text-green-400">Approved</span>
+        <span class="rounded bg-success-500/15 px-1.5 py-0.5 text-xs font-medium text-success-700 dark:text-success-400">Approved</span>
       {/if}
       {#if pr.mergeable === 'CONFLICTING'}
-        <span class="rounded bg-red-500/15 px-1.5 py-0.5 text-xs font-medium text-red-600 dark:text-red-400">Conflicts</span>
+        <span class="rounded bg-error-500/15 px-1.5 py-0.5 text-xs font-medium text-error-700 dark:text-error-400">Conflicts</span>
       {/if}
     </div>
   </div>
@@ -123,7 +123,7 @@
     {#if !pr.viewerHasApproved && pr.reviewDecision !== 'APPROVED'}
       <button
         type="button"
-        class="rounded bg-green-600 px-2 py-0.5 text-xs font-medium text-white transition-colors hover:bg-green-700 disabled:opacity-50"
+        class="rounded bg-success-600 px-2 py-0.5 text-xs font-medium text-white transition-colors hover:bg-success-700 disabled:opacity-50"
         onclick={approve}
         disabled={busy !== ''}
       >
@@ -145,7 +145,7 @@
     {#if pr.ciStatus === 'FAILURE'}
       <button
         type="button"
-        class="rounded bg-yellow-600 px-2 py-0.5 text-xs font-medium text-white transition-colors hover:bg-yellow-700 disabled:opacity-50"
+        class="rounded bg-warning-600 px-2 py-0.5 text-xs font-medium text-white transition-colors hover:bg-warning-700 disabled:opacity-50"
         onclick={rerun}
         disabled={busy !== ''}
       >
@@ -153,7 +153,7 @@
       </button>
       <button
         type="button"
-        class="rounded bg-red-600 px-2 py-0.5 text-xs font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+        class="rounded bg-error-600 px-2 py-0.5 text-xs font-medium text-white transition-colors hover:bg-error-700 disabled:opacity-50"
         onclick={fix}
         disabled={busy !== ''}
       >

--- a/frontend/src/components/StreamOutput.svelte
+++ b/frontend/src/components/StreamOutput.svelte
@@ -18,8 +18,8 @@
   const typeStyles: Record<string, { label: string; classes: string }> = {
     init: { label: 'INIT', classes: 'bg-surface-300 text-surface-800 dark:bg-surface-600 dark:text-surface-200' },
     assistant: { label: 'ASST', classes: 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200' },
-    tool_use: { label: 'TOOL', classes: 'bg-blue-200 text-blue-800 dark:bg-blue-700 dark:text-blue-200' },
-    tool_result: { label: 'RSLT', classes: 'bg-green-200 text-green-800 dark:bg-green-700 dark:text-green-200' },
+    tool_use: { label: 'TOOL', classes: 'bg-secondary-200 text-secondary-800 dark:bg-secondary-700 dark:text-secondary-200' },
+    tool_result: { label: 'RSLT', classes: 'bg-tertiary-200 text-tertiary-800 dark:bg-tertiary-700 dark:text-tertiary-200' },
     result: { label: 'DONE', classes: 'bg-warning-200 text-warning-800 dark:bg-warning-700 dark:text-warning-200' },
   }
 

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -70,11 +70,11 @@
   >
   <div class="mb-1.5 flex items-center gap-1.5">
     {#if topPR?.ciStatus === 'SUCCESS'}
-      <svg class="h-4 w-4 shrink-0 text-green-500" viewBox="0 0 16 16" fill="currentColor"><title>CI passed</title><path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16Zm3.78-9.72a.751.751 0 0 0-1.06-1.06L6.75 9.19 5.28 7.72a.751.751 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l4.5-4.5Z"/></svg>
+      <svg class="h-4 w-4 shrink-0 text-success-500" viewBox="0 0 16 16" fill="currentColor"><title>CI passed</title><path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16Zm3.78-9.72a.751.751 0 0 0-1.06-1.06L6.75 9.19 5.28 7.72a.751.751 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l4.5-4.5Z"/></svg>
     {:else if topPR?.ciStatus === 'FAILURE'}
-      <svg class="h-4 w-4 shrink-0 text-red-500" viewBox="0 0 16 16" fill="currentColor"><title>CI failed</title><path d="M2.343 13.657A8 8 0 1 1 13.658 2.343 8 8 0 0 1 2.343 13.657ZM6.03 4.97a.751.751 0 0 0-1.06 1.06L6.94 8 4.97 9.97a.751.751 0 1 0 1.06 1.06L8 9.06l1.97 1.97a.751.751 0 1 0 1.06-1.06L9.06 8l1.97-1.97a.751.751 0 1 0-1.06-1.06L8 6.94 6.03 4.97Z"/></svg>
+      <svg class="h-4 w-4 shrink-0 text-error-500" viewBox="0 0 16 16" fill="currentColor"><title>CI failed</title><path d="M2.343 13.657A8 8 0 1 1 13.658 2.343 8 8 0 0 1 2.343 13.657ZM6.03 4.97a.751.751 0 0 0-1.06 1.06L6.94 8 4.97 9.97a.751.751 0 1 0 1.06 1.06L8 9.06l1.97 1.97a.751.751 0 1 0 1.06-1.06L9.06 8l1.97-1.97a.751.751 0 1 0-1.06-1.06L8 6.94 6.03 4.97Z"/></svg>
     {:else if topPR?.ciStatus === 'PENDING'}
-      <svg class="h-4 w-4 shrink-0 text-yellow-500" viewBox="0 0 16 16" fill="currentColor"><title>CI pending</title><path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16Zm1-8.577V4.75a.75.75 0 0 0-1.5 0V8a.75.75 0 0 0 .388.657l3 1.5a.75.75 0 1 0 .67-1.342L9 7.423Z"/></svg>
+      <svg class="h-4 w-4 shrink-0 text-warning-500" viewBox="0 0 16 16" fill="currentColor"><title>CI pending</title><path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16Zm1-8.577V4.75a.75.75 0 0 0-1.5 0V8a.75.75 0 0 0 .388.657l3 1.5a.75.75 0 1 0 .67-1.342L9 7.423Z"/></svg>
     {/if}
     <h3 class="text-sm font-semibold leading-tight">{t.title}</h3>
   </div>
@@ -115,8 +115,8 @@
     {/if}
 
     {#if agentRunning}
-      <span class="inline-flex items-center gap-1 rounded bg-success-200 px-1.5 py-0.5 text-success-800 dark:bg-success-700 dark:text-success-200">
-        <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-success-500"></span>
+      <span class="inline-flex items-center gap-1 rounded bg-primary-200 px-1.5 py-0.5 text-primary-800 dark:bg-primary-700 dark:text-primary-200">
+        <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-primary-500"></span>
         Agent
       </span>
     {/if}
@@ -129,20 +129,20 @@
     {/if}
 
     {#if topPR}
-      <span class="inline-flex items-center gap-1 rounded bg-purple-500/15 px-1.5 py-0.5 font-medium text-purple-600 dark:text-purple-400" title={topPR.title}>
+      <span class="inline-flex items-center gap-1 rounded bg-warning-500/15 px-1.5 py-0.5 font-medium text-warning-700 dark:text-warning-400" title={topPR.title}>
         <svg class="h-3 w-3" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"/></svg>
         #{topPR.number}
         {#if topPR.reviewDecision === 'APPROVED'}
-          <span class="text-green-500" title="Approved">✓</span>
+          <span class="text-success-500" title="Approved">✓</span>
         {:else if topPR.reviewDecision === 'CHANGES_REQUESTED'}
-          <span class="text-red-500" title="Changes requested">✗</span>
+          <span class="text-error-500" title="Changes requested">✗</span>
         {/if}
         {#if topPR.mergeable === 'CONFLICTING'}
-          <span class="text-red-500" title="Merge conflicts">⚠</span>
+          <span class="text-error-500" title="Merge conflicts">⚠</span>
         {/if}
       </span>
     {:else if t.prNumber}
-      <span class="inline-flex items-center gap-1 rounded bg-purple-500/15 px-1.5 py-0.5 font-medium text-purple-600 dark:text-purple-400">
+      <span class="inline-flex items-center gap-1 rounded bg-warning-500/15 px-1.5 py-0.5 font-medium text-warning-700 dark:text-warning-400">
         <svg class="h-3 w-3" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"/></svg>
         #{t.prNumber}
       </span>
@@ -150,7 +150,7 @@
 
     {#if t.issue}
       <span
-        class="inline-flex items-center gap-1 rounded bg-blue-500/15 px-1.5 py-0.5 font-medium text-blue-600 dark:text-blue-400"
+        class="inline-flex items-center gap-1 rounded bg-secondary-500/15 px-1.5 py-0.5 font-medium text-secondary-700 dark:text-secondary-400"
         title={t.issue}
       >
         <svg class="h-3 w-3" viewBox="0 0 16 16" fill="currentColor"><path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"/><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"/></svg>

--- a/frontend/src/components/ToolApproval.svelte
+++ b/frontend/src/components/ToolApproval.svelte
@@ -47,7 +47,7 @@
         filePath={String(input.file_path ?? '')}
       />
     {:else if toolName === 'Bash' && input.command}
-      <div class="rounded bg-surface-900 px-3 py-2 font-mono text-xs text-green-400 dark:bg-surface-950">
+      <div class="rounded bg-surface-900 px-3 py-2 font-mono text-xs text-success-400 dark:bg-surface-950">
         $ {input.command}
       </div>
       {#if input.description}

--- a/frontend/src/pages/AgentDetail.svelte
+++ b/frontend/src/pages/AgentDetail.svelte
@@ -151,12 +151,12 @@
         </div>
         <div class="flex items-center gap-2">
           <span class="inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-medium
-            {a.state === 'running' ? 'bg-success-200 text-success-800 dark:bg-success-700 dark:text-success-200' :
+            {a.state === 'running' ? 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200' :
              a.state === 'paused' ? 'bg-warning-200 text-warning-800 dark:bg-warning-700 dark:text-warning-200' :
              a.state === 'stopped' ? 'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200' :
              'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200'}">
             {#if isRunning}
-              <span class="h-2 w-2 animate-pulse rounded-full bg-success-500"></span>
+              <span class="h-2 w-2 animate-pulse rounded-full bg-primary-500"></span>
             {:else if a.state === 'paused'}
               <span class="h-2 w-2 animate-pulse rounded-full bg-warning-500"></span>
             {/if}

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -402,8 +402,8 @@
             </span>
           {/if}
           {#if reviewingAgent}
-            <span class="inline-flex items-center gap-1 rounded-full bg-purple-200 px-2 py-0.5 text-xs font-medium text-purple-800 dark:bg-purple-700 dark:text-purple-200">
-              <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-purple-500"></span>
+            <span class="inline-flex items-center gap-1 rounded-full bg-warning-200 px-2 py-0.5 text-xs font-medium text-warning-800 dark:bg-warning-700 dark:text-warning-200">
+              <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-warning-500"></span>
               Reviewing
             </span>
           {/if}
@@ -415,7 +415,7 @@
           {#if isReviewTask && t.prNumber && t.projectId}
             <button
               type="button"
-              class="rounded bg-purple-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-purple-600 disabled:opacity-50"
+              class="rounded bg-warning-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-warning-600 disabled:opacity-50"
               onclick={runReview}
               disabled={reviewLoading || reviewingAgent}
             >
@@ -425,7 +425,7 @@
           {#if t.status === 'in-review' && t.prNumber && t.projectId && !isReviewTask}
             <button
               type="button"
-              class="rounded bg-orange-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-orange-600 disabled:opacity-50"
+              class="rounded bg-tertiary-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-tertiary-600 disabled:opacity-50"
               onclick={runFixReview}
               disabled={fixReviewLoading || fixingReviewAgent}
               title="Run fix-review skill to apply unresolved PR review comments"
@@ -434,8 +434,8 @@
             </button>
           {/if}
           {#if fixingReviewAgent}
-            <span class="inline-flex items-center gap-1 rounded-full bg-orange-200 px-2 py-0.5 text-xs font-medium text-orange-800 dark:bg-orange-700 dark:text-orange-200">
-              <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-orange-500"></span>
+            <span class="inline-flex items-center gap-1 rounded-full bg-tertiary-200 px-2 py-0.5 text-xs font-medium text-tertiary-800 dark:bg-tertiary-700 dark:text-tertiary-200">
+              <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-tertiary-500"></span>
               Fixing review
             </span>
           {/if}
@@ -493,7 +493,7 @@
             <span class="font-medium text-surface-500">Issue</span>
             <button
               type="button"
-              class="flex w-fit items-center gap-1.5 text-sm text-blue-600 hover:underline dark:text-blue-400"
+              class="flex w-fit items-center gap-1.5 text-sm text-secondary-600 hover:underline dark:text-secondary-400"
               onclick={() => t && BrowserOpenURL(t.issue)}
             >
               <svg class="h-4 w-4 shrink-0" viewBox="0 0 16 16" fill="currentColor"><path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"/><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"/></svg>
@@ -526,11 +526,11 @@
               <div class="flex items-center gap-2">
                 {#if pr.ciStatus}
                   <span
-                    class="inline-block h-2.5 w-2.5 shrink-0 rounded-full {pr.ciStatus === 'SUCCESS' ? 'bg-green-500' : pr.ciStatus === 'FAILURE' ? 'bg-red-500' : 'bg-yellow-500'}"
+                    class="inline-block h-2.5 w-2.5 shrink-0 rounded-full {pr.ciStatus === 'SUCCESS' ? 'bg-success-500' : pr.ciStatus === 'FAILURE' ? 'bg-error-500' : 'bg-warning-500'}"
                     title="CI: {pr.ciStatus.toLowerCase()}"
                   ></span>
                 {/if}
-                <svg class="h-4 w-4 shrink-0 text-purple-500" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"/></svg>
+                <svg class="h-4 w-4 shrink-0 text-warning-500" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"/></svg>
                 <div class="flex flex-col">
                   <span class="text-sm font-semibold">{pr.title}</span>
                   <span class="text-xs text-surface-500">{pr.repository}#{pr.number} by {pr.author}</span>
@@ -541,14 +541,14 @@
                   <span class="rounded bg-surface-200 px-1.5 py-0.5 text-xs dark:bg-surface-700">Draft</span>
                 {/if}
                 {#if pr.reviewDecision === 'APPROVED'}
-                  <span class="rounded bg-green-500/15 px-1.5 py-0.5 text-xs font-medium text-green-600 dark:text-green-400">Approved</span>
+                  <span class="rounded bg-success-500/15 px-1.5 py-0.5 text-xs font-medium text-success-700 dark:text-success-400">Approved</span>
                 {:else if pr.reviewDecision === 'CHANGES_REQUESTED'}
-                  <span class="rounded bg-red-500/15 px-1.5 py-0.5 text-xs font-medium text-red-600 dark:text-red-400">Changes</span>
+                  <span class="rounded bg-error-500/15 px-1.5 py-0.5 text-xs font-medium text-error-700 dark:text-error-400">Changes</span>
                 {:else if pr.reviewDecision === 'REVIEW_REQUIRED'}
-                  <span class="rounded bg-yellow-500/15 px-1.5 py-0.5 text-xs font-medium text-yellow-600 dark:text-yellow-400">Review needed</span>
+                  <span class="rounded bg-warning-500/15 px-1.5 py-0.5 text-xs font-medium text-warning-700 dark:text-warning-400">Review needed</span>
                 {/if}
                 {#if pr.unresolvedCount > 0}
-                  <span class="rounded bg-yellow-500/15 px-1.5 py-0.5 text-xs font-medium text-yellow-600 dark:text-yellow-400"
+                  <span class="rounded bg-warning-500/15 px-1.5 py-0.5 text-xs font-medium text-warning-700 dark:text-warning-400"
                     title="{pr.unresolvedCount} unresolved"
                   >{pr.unresolvedCount} unresolved</span>
                 {/if}
@@ -561,7 +561,7 @@
           <span class="text-sm font-medium text-surface-500">Pull Request</span>
           <button
             type="button"
-            class="flex w-fit items-center gap-1.5 text-sm text-purple-600 hover:underline dark:text-purple-400"
+            class="flex w-fit items-center gap-1.5 text-sm text-warning-700 hover:underline dark:text-warning-400"
             onclick={() => t && BrowserOpenURL(`https://github.com/${t.projectId}/pull/${t.prNumber}`)}
           >
             <svg class="h-4 w-4 shrink-0" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"/></svg>
@@ -674,9 +674,9 @@
                 {runningAgent.id}
               </button>
               <span class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium
-                {runningAgent.state === 'running' ? 'bg-success-200 text-success-800 dark:bg-success-700 dark:text-success-200' : 'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200'}">
+                {runningAgent.state === 'running' ? 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200' : 'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200'}">
                 {#if runningAgent.state === 'running'}
-                  <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-success-500"></span>
+                  <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-primary-500"></span>
                 {/if}
                 {runningAgent.state}
               </span>
@@ -742,7 +742,7 @@
                 <div class="flex items-center gap-2">
                   <span class="font-mono text-surface-400">{run.agentId}</span>
                   <span class="rounded bg-surface-200 px-1.5 py-0.5 dark:bg-surface-700">{run.mode}</span>
-                  <span class="rounded px-1.5 py-0.5 {run.state === 'stopped' ? 'bg-surface-200 dark:bg-surface-700' : 'bg-success-200 text-success-800 dark:bg-success-700 dark:text-success-200'}">
+                  <span class="rounded px-1.5 py-0.5 {run.state === 'stopped' ? 'bg-surface-200 dark:bg-surface-700' : 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200'}">
                     {run.state || 'running'}
                   </span>
                 </div>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,7 +1,7 @@
 @import 'tailwindcss';
 @import '@skeletonlabs/skeleton';
 @import '@skeletonlabs/skeleton-svelte';
-@import '@skeletonlabs/skeleton/themes/vox';
+@import './theme-amber.css';
 
 @custom-variant dark (&:where(.dark, .dark *));
 

--- a/frontend/src/theme-amber.css
+++ b/frontend/src/theme-amber.css
@@ -1,0 +1,236 @@
+/*
+ * Synapse — Amber Command theme
+ *
+ * Dark:  warm-black surfaces (#110e0b) + amber accent + jade/teal/coral semantics
+ * Light: parchment surfaces (#faf8f7) + deeper amber accent + same semantic hues
+ *
+ * Hue map
+ *   primary   amber      H=55deg    in-progress / brand
+ *   secondary teal       H=190deg   testing / active-AI
+ *   tertiary  warm-muted H=36deg    planning / new
+ *   success   jade       H=156deg   done
+ *   warning   violet     H=278deg   in-review  (reassigned — amber IS the brand)
+ *   error     coral      H=22deg    human-required
+ *   surface   warm-dark  H=33deg    backgrounds / todo
+ */
+
+[data-theme='amber'] {
+  --text-scaling: 1.067;
+  --base-font-color: var(--color-surface-950);
+  --base-font-color-dark: var(--color-surface-50);
+  --base-font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --base-font-size: inherit;
+  --base-line-height: inherit;
+  --base-font-weight: normal;
+  --base-font-style: normal;
+  --base-letter-spacing: 0em;
+  --heading-font-color: inherit;
+  --heading-font-color-dark: inherit;
+  --heading-font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --heading-font-weight: 600;
+  --heading-font-style: normal;
+  --heading-letter-spacing: 0.015em;
+  --anchor-font-color: var(--color-primary-700);
+  --anchor-font-color-dark: var(--color-primary-400);
+  --anchor-font-family: inherit;
+  --anchor-font-size: inherit;
+  --anchor-line-height: inherit;
+  --anchor-font-weight: inherit;
+  --anchor-font-style: inherit;
+  --anchor-letter-spacing: inherit;
+  --anchor-text-decoration: none;
+  --anchor-text-decoration-hover: underline;
+  --anchor-text-decoration-active: none;
+  --anchor-text-decoration-focus: none;
+  --spacing: 0.25rem;
+  --radius-base: 0.375rem;
+  --radius-container: 0.75rem;
+  --default-border-width: 1px;
+  --default-divide-width: 1px;
+  --default-ring-width: 1px;
+  --body-background-color: var(--color-surface-50);
+  --body-background-color-dark: var(--color-surface-950);
+
+  /* ── primary: amber 55deg ───────────────────────────────────────────────── */
+  --color-primary-50:  oklch(97%   0.04  50deg);
+  --color-primary-100: oklch(93%   0.07  51deg);
+  --color-primary-200: oklch(88%   0.12  52deg);
+  --color-primary-300: oklch(83%   0.15  53deg);
+  --color-primary-400: oklch(79%   0.17  54deg);
+  --color-primary-500: oklch(74%   0.18  55deg);
+  --color-primary-600: oklch(67%   0.17  57deg);
+  --color-primary-700: oklch(55%   0.15  59deg);
+  --color-primary-800: oklch(42%   0.13  61deg);
+  --color-primary-900: oklch(28%   0.10  63deg);
+  --color-primary-950: oklch(18%   0.08  65deg);
+  --color-primary-contrast-dark:  oklch(0% 0 none);
+  --color-primary-contrast-light: var(--color-primary-50);
+  --color-primary-contrast-50:  var(--color-primary-contrast-dark);
+  --color-primary-contrast-100: var(--color-primary-contrast-dark);
+  --color-primary-contrast-200: var(--color-primary-contrast-dark);
+  --color-primary-contrast-300: var(--color-primary-contrast-dark);
+  --color-primary-contrast-400: var(--color-primary-contrast-dark);
+  --color-primary-contrast-500: var(--color-primary-contrast-dark);
+  --color-primary-contrast-600: var(--color-primary-contrast-dark);
+  --color-primary-contrast-700: var(--color-primary-contrast-dark);
+  --color-primary-contrast-800: var(--color-primary-contrast-light);
+  --color-primary-contrast-900: var(--color-primary-contrast-light);
+  --color-primary-contrast-950: var(--color-primary-contrast-light);
+
+  /* ── secondary: teal 190deg ─────────────────────────────────────────────── */
+  --color-secondary-50:  oklch(96%   0.04  182deg);
+  --color-secondary-100: oklch(90%   0.07  184deg);
+  --color-secondary-200: oklch(83%   0.11  186deg);
+  --color-secondary-300: oklch(75%   0.15  188deg);
+  --color-secondary-400: oklch(67%   0.18  189deg);
+  --color-secondary-500: oklch(60%   0.20  190deg);
+  --color-secondary-600: oklch(50%   0.17  191deg);
+  --color-secondary-700: oklch(40%   0.15  192deg);
+  --color-secondary-800: oklch(30%   0.12  193deg);
+  --color-secondary-900: oklch(20%   0.11  192deg);
+  --color-secondary-950: oklch(12%   0.09  193deg);
+  --color-secondary-contrast-dark:  oklch(0% 0 none);
+  --color-secondary-contrast-light: var(--color-secondary-50);
+  --color-secondary-contrast-50:  var(--color-secondary-contrast-dark);
+  --color-secondary-contrast-100: var(--color-secondary-contrast-dark);
+  --color-secondary-contrast-200: var(--color-secondary-contrast-dark);
+  --color-secondary-contrast-300: var(--color-secondary-contrast-dark);
+  --color-secondary-contrast-400: var(--color-secondary-contrast-dark);
+  --color-secondary-contrast-500: var(--color-secondary-contrast-dark);
+  --color-secondary-contrast-600: var(--color-secondary-contrast-light);
+  --color-secondary-contrast-700: var(--color-secondary-contrast-light);
+  --color-secondary-contrast-800: var(--color-secondary-contrast-light);
+  --color-secondary-contrast-900: var(--color-secondary-contrast-light);
+  --color-secondary-contrast-950: var(--color-secondary-contrast-light);
+
+  /* ── tertiary: warm-muted 36deg  (planning / new) ───────────────────────── */
+  --color-tertiary-50:  oklch(97%   0.03  30deg);
+  --color-tertiary-100: oklch(93%   0.05  32deg);
+  --color-tertiary-200: oklch(88%   0.07  33deg);
+  --color-tertiary-300: oklch(82%   0.09  34deg);
+  --color-tertiary-400: oklch(74%   0.11  35deg);
+  --color-tertiary-500: oklch(64%   0.12  36deg);
+  --color-tertiary-600: oklch(52%   0.11  37deg);
+  --color-tertiary-700: oklch(42%   0.09  38deg);
+  --color-tertiary-800: oklch(30%   0.08  39deg);
+  --color-tertiary-900: oklch(20%   0.07  40deg);
+  --color-tertiary-950: oklch(13%   0.06  41deg);
+  --color-tertiary-contrast-dark:  oklch(0% 0 none);
+  --color-tertiary-contrast-light: var(--color-tertiary-50);
+  --color-tertiary-contrast-50:  var(--color-tertiary-contrast-dark);
+  --color-tertiary-contrast-100: var(--color-tertiary-contrast-dark);
+  --color-tertiary-contrast-200: var(--color-tertiary-contrast-dark);
+  --color-tertiary-contrast-300: var(--color-tertiary-contrast-dark);
+  --color-tertiary-contrast-400: var(--color-tertiary-contrast-dark);
+  --color-tertiary-contrast-500: var(--color-tertiary-contrast-dark);
+  --color-tertiary-contrast-600: var(--color-tertiary-contrast-light);
+  --color-tertiary-contrast-700: var(--color-tertiary-contrast-light);
+  --color-tertiary-contrast-800: var(--color-tertiary-contrast-light);
+  --color-tertiary-contrast-900: var(--color-tertiary-contrast-light);
+  --color-tertiary-contrast-950: var(--color-tertiary-contrast-light);
+
+  /* ── success: jade 156deg ───────────────────────────────────────────────── */
+  --color-success-50:  oklch(96%   0.04  150deg);
+  --color-success-100: oklch(90%   0.07  152deg);
+  --color-success-200: oklch(83%   0.11  154deg);
+  --color-success-300: oklch(75%   0.15  155deg);
+  --color-success-400: oklch(68%   0.17  156deg);
+  --color-success-500: oklch(60%   0.19  156deg);
+  --color-success-600: oklch(50%   0.16  158deg);
+  --color-success-700: oklch(40%   0.14  159deg);
+  --color-success-800: oklch(30%   0.12  160deg);
+  --color-success-900: oklch(20%   0.10  161deg);
+  --color-success-950: oklch(12%   0.08  162deg);
+  --color-success-contrast-dark:  oklch(0% 0 none);
+  --color-success-contrast-light: var(--color-success-50);
+  --color-success-contrast-50:  var(--color-success-contrast-dark);
+  --color-success-contrast-100: var(--color-success-contrast-dark);
+  --color-success-contrast-200: var(--color-success-contrast-dark);
+  --color-success-contrast-300: var(--color-success-contrast-dark);
+  --color-success-contrast-400: var(--color-success-contrast-dark);
+  --color-success-contrast-500: var(--color-success-contrast-dark);
+  --color-success-contrast-600: var(--color-success-contrast-light);
+  --color-success-contrast-700: var(--color-success-contrast-light);
+  --color-success-contrast-800: var(--color-success-contrast-light);
+  --color-success-contrast-900: var(--color-success-contrast-light);
+  --color-success-contrast-950: var(--color-success-contrast-light);
+
+  /* ── warning: violet 278deg  (in-review — amber is the brand, not a warning) */
+  --color-warning-50:  oklch(97%   0.03  272deg);
+  --color-warning-100: oklch(91%   0.06  274deg);
+  --color-warning-200: oklch(84%   0.09  275deg);
+  --color-warning-300: oklch(77%   0.13  276deg);
+  --color-warning-400: oklch(68%   0.16  277deg);
+  --color-warning-500: oklch(58%   0.19  278deg);
+  --color-warning-600: oklch(48%   0.16  279deg);
+  --color-warning-700: oklch(38%   0.14  280deg);
+  --color-warning-800: oklch(28%   0.12  281deg);
+  --color-warning-900: oklch(19%   0.10  282deg);
+  --color-warning-950: oklch(12%   0.08  283deg);
+  --color-warning-contrast-dark:  oklch(0% 0 none);
+  --color-warning-contrast-light: var(--color-warning-50);
+  --color-warning-contrast-50:  var(--color-warning-contrast-dark);
+  --color-warning-contrast-100: var(--color-warning-contrast-dark);
+  --color-warning-contrast-200: var(--color-warning-contrast-dark);
+  --color-warning-contrast-300: var(--color-warning-contrast-dark);
+  --color-warning-contrast-400: var(--color-warning-contrast-dark);
+  --color-warning-contrast-500: var(--color-warning-contrast-light);
+  --color-warning-contrast-600: var(--color-warning-contrast-light);
+  --color-warning-contrast-700: var(--color-warning-contrast-light);
+  --color-warning-contrast-800: var(--color-warning-contrast-light);
+  --color-warning-contrast-900: var(--color-warning-contrast-light);
+  --color-warning-contrast-950: var(--color-warning-contrast-light);
+
+  /* ── error: coral 22deg  (human-required) ───────────────────────────────── */
+  --color-error-50:  oklch(96%   0.04  15deg);
+  --color-error-100: oklch(91%   0.07  17deg);
+  --color-error-200: oklch(84%   0.12  19deg);
+  --color-error-300: oklch(76%   0.16  20deg);
+  --color-error-400: oklch(69%   0.18  21deg);
+  --color-error-500: oklch(62%   0.20  22deg);
+  --color-error-600: oklch(52%   0.17  24deg);
+  --color-error-700: oklch(42%   0.15  26deg);
+  --color-error-800: oklch(32%   0.12  28deg);
+  --color-error-900: oklch(22%   0.10  29deg);
+  --color-error-950: oklch(13%   0.08  30deg);
+  --color-error-contrast-dark:  oklch(0% 0 none);
+  --color-error-contrast-light: var(--color-error-50);
+  --color-error-contrast-50:  var(--color-error-contrast-dark);
+  --color-error-contrast-100: var(--color-error-contrast-dark);
+  --color-error-contrast-200: var(--color-error-contrast-dark);
+  --color-error-contrast-300: var(--color-error-contrast-dark);
+  --color-error-contrast-400: var(--color-error-contrast-dark);
+  --color-error-contrast-500: var(--color-error-contrast-dark);
+  --color-error-contrast-600: var(--color-error-contrast-light);
+  --color-error-contrast-700: var(--color-error-contrast-light);
+  --color-error-contrast-800: var(--color-error-contrast-light);
+  --color-error-contrast-900: var(--color-error-contrast-light);
+  --color-error-contrast-950: var(--color-error-contrast-light);
+
+  /* ── surface: warm 33deg ────────────────────────────────────────────────── */
+  /* light → dark: parchment white (#faf8f7) to warm black (#110e0b)          */
+  --color-surface-50:  oklch(98%   0.003 30deg);
+  --color-surface-100: oklch(96%   0.004 31deg);
+  --color-surface-200: oklch(93%   0.005 32deg);
+  --color-surface-300: oklch(88%   0.007 33deg);
+  --color-surface-400: oklch(80%   0.008 33deg);
+  --color-surface-500: oklch(65%   0.009 34deg);
+  --color-surface-600: oklch(50%   0.010 34deg);
+  --color-surface-700: oklch(36%   0.010 35deg);
+  --color-surface-800: oklch(27%   0.010 35deg);
+  --color-surface-900: oklch(18%   0.009 34deg);
+  --color-surface-950: oklch(9%    0.008 32deg);
+  --color-surface-contrast-dark:  var(--color-surface-950);
+  --color-surface-contrast-light: var(--color-surface-50);
+  --color-surface-contrast-50:  var(--color-surface-contrast-dark);
+  --color-surface-contrast-100: var(--color-surface-contrast-dark);
+  --color-surface-contrast-200: var(--color-surface-contrast-dark);
+  --color-surface-contrast-300: var(--color-surface-contrast-dark);
+  --color-surface-contrast-400: var(--color-surface-contrast-dark);
+  --color-surface-contrast-500: var(--color-surface-contrast-dark);
+  --color-surface-contrast-600: var(--color-surface-contrast-light);
+  --color-surface-contrast-700: var(--color-surface-contrast-light);
+  --color-surface-contrast-800: var(--color-surface-contrast-light);
+  --color-surface-contrast-900: var(--color-surface-contrast-light);
+  --color-surface-contrast-950: var(--color-surface-contrast-light);
+}


### PR DESCRIPTION
## Motivation

Agent `running` state used `success` (jade green) instead of `primary` (amber). Stream output blocks had hardcoded `bg-blue-*` / `bg-green-*` Tailwind colors bypassing the theme.

## Implementation information

- `AgentCard.svelte`: `running` → `bg-primary-*` (amber), pulse dot → `bg-primary-500`
- `AgentDetail.svelte`: same fix for the full-page state badge
- `StreamOutput.svelte`: `tool_use` → `secondary` (teal), `tool_result` → `tertiary` (warm)

Depends on #468.

> Changelog: fix(theme): agent state colors to amber