### PR TITLE
fix(theme): semantic tokens for all components

### DIFF
--- a/frontend/src/components/CommandPalette.svelte
+++ b/frontend/src/components/CommandPalette.svelte
@@ -110,17 +110,16 @@
     }
   }
 
-  function typeIcon(type: 'page' | 'task' | 'project'): string {
-    if (type === 'page') return '→'
-    if (type === 'task') return '□'
-    return '◈'
-  }
 </script>
 
 <MobileSheet {open} onOpenChange={(o) => { if (!o) onclose() }} variant="top">
   <div class="flex flex-col">
-    <div class="flex items-center border-b border-surface-300 px-4 dark:border-surface-600">
-      <svg class="h-4 w-4 shrink-0 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <!-- Search bar -->
+    <div class="flex items-center gap-3 border-b border-surface-200 px-4 dark:border-surface-700">
+      <svg
+        class="h-4 w-4 shrink-0 transition-colors {query ? 'text-primary-500' : 'text-surface-400'}"
+        fill="none" stroke="currentColor" viewBox="0 0 24 24"
+      >
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
       </svg>
       <input
@@ -128,36 +127,53 @@
         bind:value={query}
         type="text"
         placeholder="Search tasks, pages, projects..."
-        class="flex-1 bg-transparent py-3.5 pl-3 text-base outline-none placeholder:text-surface-400 md:text-sm"
+        class="flex-1 bg-transparent py-3.5 text-base outline-none placeholder:text-surface-400 md:text-sm"
       />
       <button
         type="button"
         onclick={onclose}
-        class="tap -mr-2 rounded text-surface-400 active:bg-surface-200 dark:active:bg-surface-700"
+        class="tap -mr-2 flex items-center gap-1.5 text-surface-400 hover:text-surface-600 dark:hover:text-surface-300"
         aria-label="Close"
       >
-        <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+        <kbd class="hidden rounded border border-surface-300 px-1.5 py-0.5 font-mono text-[10px] text-surface-400 dark:border-surface-600 md:inline">Esc</kbd>
+        <svg class="h-5 w-5 md:hidden" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
         </svg>
       </button>
     </div>
 
-    <ul class="max-h-[60dvh] overflow-y-auto py-2 md:max-h-80">
+    <!-- Results -->
+    <ul class="max-h-[60dvh] overflow-y-auto py-1 md:max-h-80">
       {#if results.length === 0}
-        <li class="px-4 py-3 text-sm italic text-surface-400">No results</li>
+        <li class="px-4 py-8 text-center text-sm text-surface-400">
+          No results for "<span class="text-surface-700 dark:text-surface-300">{query}</span>"
+        </li>
       {:else}
         {#each results as result, i}
           <li>
             <button
               type="button"
-              class="tap flex w-full items-center gap-3 px-4 py-3 text-left text-sm transition-colors {i === selectedIndex ? 'bg-primary-100 text-primary-800 dark:bg-primary-900/40 dark:text-primary-200' : 'active:bg-surface-200 dark:active:bg-surface-700'}"
+              class="tap flex w-full items-center gap-3 border-l-2 px-3 py-2.5 text-left text-sm transition-colors
+                {i === selectedIndex
+                  ? 'border-primary-500 bg-primary-50 text-primary-900 dark:bg-primary-950/50 dark:text-primary-100'
+                  : 'border-transparent hover:bg-surface-100 dark:hover:bg-surface-800'}"
               onclick={() => selectResult(result)}
               onmouseenter={() => { selectedIndex = i }}
             >
-              <span class="w-4 shrink-0 text-center font-mono text-xs text-surface-400">{typeIcon(result.type)}</span>
+              <span class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold uppercase
+                {result.type === 'page'
+                  ? 'bg-primary-100 text-primary-700 dark:bg-primary-900/50 dark:text-primary-300'
+                  : result.type === 'task'
+                    ? 'bg-secondary-100 text-secondary-700 dark:bg-secondary-900/50 dark:text-secondary-300'
+                    : 'bg-tertiary-100 text-tertiary-700 dark:bg-tertiary-900/50 dark:text-tertiary-300'}">
+                {result.type === 'page' ? 'PAGE' : result.type === 'task' ? 'TASK' : 'PROJ'}
+              </span>
               <span class="flex-1 font-medium">{result.title}</span>
               {#if result.subtitle}
                 <span class="text-xs text-surface-400">{result.subtitle}</span>
+              {/if}
+              {#if i === selectedIndex}
+                <span class="shrink-0 font-mono text-xs text-primary-500">↵</span>
               {/if}
             </button>
           </li>
@@ -165,11 +181,17 @@
       {/if}
     </ul>
 
-    <div class="hidden border-t border-surface-300 px-4 py-2 dark:border-surface-600 md:block">
+    <!-- Footer hints -->
+    <div class="hidden items-center gap-4 border-t border-surface-200 px-4 py-2.5 dark:border-surface-700 md:flex">
       <div class="flex gap-4 text-xs text-surface-400">
-        <span><kbd class="font-mono">↑↓</kbd> navigate</span>
-        <span><kbd class="font-mono">↵</kbd> open</span>
-        <span><kbd class="font-mono">Esc</kbd> close</span>
+        <span class="flex items-center gap-1">
+          <kbd class="rounded border border-surface-300 px-1 py-0.5 font-mono text-[10px] dark:border-surface-600">↑↓</kbd>
+          navigate
+        </span>
+        <span class="flex items-center gap-1">
+          <kbd class="rounded border border-surface-300 px-1 py-0.5 font-mono text-[10px] dark:border-surface-600">↵</kbd>
+          open
+        </span>
       </div>
     </div>
   </div>

--- a/frontend/src/components/MessageBubble.svelte
+++ b/frontend/src/components/MessageBubble.svelte
@@ -51,7 +51,7 @@
       {#each event.toolUses as tool (tool.id)}
         <div class="rounded-lg border border-surface-300 bg-surface-50 dark:border-surface-600 dark:bg-surface-900">
           <div class="flex items-center gap-2 border-b border-surface-200 px-3 py-1.5 dark:border-surface-700">
-            <span class="rounded bg-blue-200 px-1.5 py-0.5 text-[10px] font-bold text-blue-800 dark:bg-blue-700 dark:text-blue-200">
+            <span class="rounded bg-secondary-200 px-1.5 py-0.5 text-[10px] font-bold text-secondary-800 dark:bg-secondary-700 dark:text-secondary-200">
               TOOL
             </span>
             <span class="text-xs font-medium text-surface-700 dark:text-surface-300">{tool.name}</span>
@@ -67,7 +67,7 @@
                 filePath={String(tool.input.file_path ?? '')}
               />
             {:else if tool.name === 'Bash' && tool.input?.command}
-              <pre class="rounded bg-surface-900 px-2 py-1.5 text-xs text-green-400 dark:bg-surface-950">{tool.input.command}</pre>
+              <pre class="rounded bg-surface-900 px-2 py-1.5 text-xs text-success-400 dark:bg-surface-950">{tool.input.command}</pre>
             {:else if tool.name === 'Write' && tool.input?.content}
               <pre class="max-h-40 overflow-y-auto rounded bg-surface-900 px-2 py-1.5 text-xs text-surface-200 dark:bg-surface-950">{truncate(String(tool.input.content), 500)}</pre>
             {:else if tool.input}
@@ -85,7 +85,7 @@
       <div class="ml-4 rounded border-l-2 px-3 py-1.5 text-xs
         {result.isError
           ? 'border-error-500 bg-error-50 text-error-800 dark:bg-error-950 dark:text-error-200'
-          : 'border-green-500 bg-green-50 text-green-800 dark:bg-green-950 dark:text-green-200'}">
+          : 'border-success-500 bg-success-50 text-success-800 dark:bg-success-950 dark:text-success-200'}">
         <pre class="max-h-40 overflow-y-auto whitespace-pre-wrap break-words">{truncate(result.content, 1000)}</pre>
       </div>
     {/each}

--- a/frontend/src/components/PRCard.svelte
+++ b/frontend/src/components/PRCard.svelte
@@ -34,7 +34,7 @@
     <div class="flex items-center gap-2">
       {#if pr.ciStatus}
         <span
-          class="inline-block h-2.5 w-2.5 shrink-0 rounded-full {pr.ciStatus === 'SUCCESS' ? 'bg-green-500' : pr.ciStatus === 'FAILURE' ? 'bg-red-500' : 'bg-yellow-500'}"
+          class="inline-block h-2.5 w-2.5 shrink-0 rounded-full {pr.ciStatus === 'SUCCESS' ? 'bg-success-500' : pr.ciStatus === 'FAILURE' ? 'bg-error-500' : 'bg-warning-500'}"
           title="CI: {pr.ciStatus.toLowerCase()}"
         ></span>
       {/if}
@@ -45,12 +45,12 @@
         <span class="rounded bg-surface-200 px-1.5 py-0.5 text-xs dark:bg-surface-700">Draft</span>
       {/if}
       {#if pr.reviewDecision === 'APPROVED'}
-        <span class="rounded bg-green-500/15 px-1.5 py-0.5 text-xs font-medium text-green-600 dark:text-green-400">Approved</span>
+        <span class="rounded bg-success-500/15 px-1.5 py-0.5 text-xs font-medium text-success-700 dark:text-success-400">Approved</span>
       {:else if pr.reviewDecision === 'CHANGES_REQUESTED'}
-        <span class="rounded bg-red-500/15 px-1.5 py-0.5 text-xs font-medium text-red-600 dark:text-red-400">Changes</span>
+        <span class="rounded bg-error-500/15 px-1.5 py-0.5 text-xs font-medium text-error-700 dark:text-error-400">Changes</span>
       {/if}
       {#if pr.unresolvedCount > 0}
-        <span class="rounded bg-yellow-500/15 px-1.5 py-0.5 text-xs font-medium text-yellow-600 dark:text-yellow-400"
+        <span class="rounded bg-warning-500/15 px-1.5 py-0.5 text-xs font-medium text-warning-700 dark:text-warning-400"
           title="{pr.unresolvedCount} unresolved thread{pr.unresolvedCount !== 1 ? 's' : ''}"
         >{pr.unresolvedCount} unresolved</span>
       {/if}

--- a/frontend/src/components/PRCard.svelte.test.ts
+++ b/frontend/src/components/PRCard.svelte.test.ts
@@ -82,21 +82,21 @@ describe('PRCard', () => {
       render(PRCard, { props: { pr: makePR({ ciStatus: 'SUCCESS' }) } })
       const dot = document.querySelector('[title="CI: success"]')
       expect(dot).toBeDefined()
-      expect(dot?.className).toContain('bg-green-500')
+      expect(dot?.className).toContain('bg-success-500')
     })
 
     it('shows red dot for FAILURE', () => {
       render(PRCard, { props: { pr: makePR({ ciStatus: 'FAILURE' }) } })
       const dot = document.querySelector('[title="CI: failure"]')
       expect(dot).toBeDefined()
-      expect(dot?.className).toContain('bg-red-500')
+      expect(dot?.className).toContain('bg-error-500')
     })
 
     it('shows yellow dot for PENDING', () => {
       render(PRCard, { props: { pr: makePR({ ciStatus: 'PENDING' }) } })
       const dot = document.querySelector('[title="CI: pending"]')
       expect(dot).toBeDefined()
-      expect(dot?.className).toContain('bg-yellow-500')
+      expect(dot?.className).toContain('bg-warning-500')
     })
 
     it('shows no dot when empty', () => {

--- a/frontend/src/components/PRDetailView.svelte
+++ b/frontend/src/components/PRDetailView.svelte
@@ -61,20 +61,20 @@
     <div class="mt-4 flex flex-wrap items-center gap-2">
       {#if pr.ciStatus}
         <span class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium
-          {pr.ciStatus === 'SUCCESS' ? 'bg-green-500/15 text-green-600 dark:text-green-400' :
-           pr.ciStatus === 'FAILURE' ? 'bg-red-500/15 text-red-600 dark:text-red-400' :
-           'bg-yellow-500/15 text-yellow-600 dark:text-yellow-400'}">
+          {pr.ciStatus === 'SUCCESS' ? 'bg-success-500/15 text-success-700 dark:text-success-400' :
+           pr.ciStatus === 'FAILURE' ? 'bg-error-500/15 text-error-700 dark:text-error-400' :
+           'bg-warning-500/15 text-warning-700 dark:text-warning-400'}">
           <span class="inline-block h-2 w-2 rounded-full
-            {pr.ciStatus === 'SUCCESS' ? 'bg-green-500' :
-             pr.ciStatus === 'FAILURE' ? 'bg-red-500' : 'bg-yellow-500'}"></span>
+            {pr.ciStatus === 'SUCCESS' ? 'bg-success-500' :
+             pr.ciStatus === 'FAILURE' ? 'bg-error-500' : 'bg-warning-500'}"></span>
           CI: {pr.ciStatus.toLowerCase()}
         </span>
       {/if}
 
       {#if pr.mergeable}
         <span class="rounded-full px-2.5 py-1 text-xs font-medium
-          {pr.mergeable === 'MERGEABLE' ? 'bg-green-500/15 text-green-600 dark:text-green-400' :
-           pr.mergeable === 'CONFLICTING' ? 'bg-red-500/15 text-red-600 dark:text-red-400' :
+          {pr.mergeable === 'MERGEABLE' ? 'bg-success-500/15 text-success-700 dark:text-success-400' :
+           pr.mergeable === 'CONFLICTING' ? 'bg-error-500/15 text-error-700 dark:text-error-400' :
            'bg-surface-200 text-surface-500 dark:bg-surface-700'}">
           {pr.mergeable === 'MERGEABLE' ? 'Mergeable' :
            pr.mergeable === 'CONFLICTING' ? 'Conflicts' : 'Unknown'}
@@ -82,15 +82,15 @@
       {/if}
 
       {#if pr.reviewDecision === 'APPROVED'}
-        <span class="rounded-full bg-green-500/15 px-2.5 py-1 text-xs font-medium text-green-600 dark:text-green-400">Approved</span>
+        <span class="rounded-full bg-success-500/15 px-2.5 py-1 text-xs font-medium text-success-700 dark:text-success-400">Approved</span>
       {:else if pr.reviewDecision === 'CHANGES_REQUESTED'}
-        <span class="rounded-full bg-red-500/15 px-2.5 py-1 text-xs font-medium text-red-600 dark:text-red-400">Changes Requested</span>
+        <span class="rounded-full bg-error-500/15 px-2.5 py-1 text-xs font-medium text-error-700 dark:text-error-400">Changes Requested</span>
       {:else if pr.reviewDecision === 'REVIEW_REQUIRED'}
-        <span class="rounded-full bg-yellow-500/15 px-2.5 py-1 text-xs font-medium text-yellow-600 dark:text-yellow-400">Review Required</span>
+        <span class="rounded-full bg-warning-500/15 px-2.5 py-1 text-xs font-medium text-warning-700 dark:text-warning-400">Review Required</span>
       {/if}
 
       {#if pr.unresolvedCount > 0}
-        <span class="rounded-full bg-yellow-500/15 px-2.5 py-1 text-xs font-medium text-yellow-600 dark:text-yellow-400">
+        <span class="rounded-full bg-warning-500/15 px-2.5 py-1 text-xs font-medium text-warning-700 dark:text-warning-400">
           {pr.unresolvedCount} unresolved
         </span>
       {/if}
@@ -112,9 +112,9 @@
         {#each checkRuns as check}
           <div class="flex items-center gap-2 text-sm">
             <span class="inline-block h-2 w-2 shrink-0 rounded-full
-              {check.conclusion === 'SUCCESS' ? 'bg-green-500' :
-               check.conclusion === 'FAILURE' ? 'bg-red-500' :
-               check.status === 'IN_PROGRESS' ? 'bg-yellow-500' : 'bg-surface-400'}"></span>
+              {check.conclusion === 'SUCCESS' ? 'bg-success-500' :
+               check.conclusion === 'FAILURE' ? 'bg-error-500' :
+               check.status === 'IN_PROGRESS' ? 'bg-warning-500' : 'bg-surface-400'}"></span>
             <span class="flex-1 truncate">{check.name}</span>
             <span class="text-xs text-surface-400">
               {check.conclusion ? check.conclusion.toLowerCase() : check.status?.toLowerCase() ?? ''}
@@ -137,7 +137,7 @@
     {#if onapprove && !pr.viewerHasApproved && pr.reviewDecision !== 'APPROVED'}
       <button
         type="button"
-        class="rounded-lg bg-green-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-green-700"
+        class="rounded-lg bg-success-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-success-700"
         onclick={onapprove}
       >
         Approve
@@ -157,7 +157,7 @@
     {#if onrerun && hasFailed}
       <button
         type="button"
-        class="rounded-lg bg-yellow-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-yellow-700"
+        class="rounded-lg bg-warning-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-warning-700"
         onclick={onrerun}
       >
         Rerun Failed
@@ -167,7 +167,7 @@
     {#if onfix && hasFailed}
       <button
         type="button"
-        class="rounded-lg bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700"
+        class="rounded-lg bg-error-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-error-700"
         onclick={onfix}
       >
         Fix

--- a/frontend/src/components/RenovatePRCard.svelte
+++ b/frontend/src/components/RenovatePRCard.svelte
@@ -91,7 +91,7 @@
     <div class="flex items-center gap-2">
       {#if pr.ciStatus}
         <span
-          class="inline-block h-2.5 w-2.5 shrink-0 rounded-full {pr.ciStatus === 'SUCCESS' ? 'bg-green-500' : pr.ciStatus === 'FAILURE' ? 'bg-red-500' : 'bg-yellow-500'}"
+          class="inline-block h-2.5 w-2.5 shrink-0 rounded-full {pr.ciStatus === 'SUCCESS' ? 'bg-success-500' : pr.ciStatus === 'FAILURE' ? 'bg-error-500' : 'bg-warning-500'}"
           title="CI: {pr.ciStatus.toLowerCase()}"
         ></span>
       {/if}
@@ -99,10 +99,10 @@
     </div>
     <div class="flex shrink-0 items-center gap-1.5">
       {#if pr.reviewDecision === 'APPROVED'}
-        <span class="rounded bg-green-500/15 px-1.5 py-0.5 text-xs font-medium text-green-600 dark:text-green-400">Approved</span>
+        <span class="rounded bg-success-500/15 px-1.5 py-0.5 text-xs font-medium text-success-700 dark:text-success-400">Approved</span>
       {/if}
       {#if pr.mergeable === 'CONFLICTING'}
-        <span class="rounded bg-red-500/15 px-1.5 py-0.5 text-xs font-medium text-red-600 dark:text-red-400">Conflicts</span>
+        <span class="rounded bg-error-500/15 px-1.5 py-0.5 text-xs font-medium text-error-700 dark:text-error-400">Conflicts</span>
       {/if}
     </div>
   </div>
@@ -123,7 +123,7 @@
     {#if !pr.viewerHasApproved && pr.reviewDecision !== 'APPROVED'}
       <button
         type="button"
-        class="rounded bg-green-600 px-2 py-0.5 text-xs font-medium text-white transition-colors hover:bg-green-700 disabled:opacity-50"
+        class="rounded bg-success-600 px-2 py-0.5 text-xs font-medium text-white transition-colors hover:bg-success-700 disabled:opacity-50"
         onclick={approve}
         disabled={busy !== ''}
       >
@@ -145,7 +145,7 @@
     {#if pr.ciStatus === 'FAILURE'}
       <button
         type="button"
-        class="rounded bg-yellow-600 px-2 py-0.5 text-xs font-medium text-white transition-colors hover:bg-yellow-700 disabled:opacity-50"
+        class="rounded bg-warning-600 px-2 py-0.5 text-xs font-medium text-white transition-colors hover:bg-warning-700 disabled:opacity-50"
         onclick={rerun}
         disabled={busy !== ''}
       >
@@ -153,7 +153,7 @@
       </button>
       <button
         type="button"
-        class="rounded bg-red-600 px-2 py-0.5 text-xs font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+        class="rounded bg-error-600 px-2 py-0.5 text-xs font-medium text-white transition-colors hover:bg-error-700 disabled:opacity-50"
         onclick={fix}
         disabled={busy !== ''}
       >

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -70,11 +70,11 @@
   >
   <div class="mb-1.5 flex items-center gap-1.5">
     {#if topPR?.ciStatus === 'SUCCESS'}
-      <svg class="h-4 w-4 shrink-0 text-green-500" viewBox="0 0 16 16" fill="currentColor"><title>CI passed</title><path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16Zm3.78-9.72a.751.751 0 0 0-1.06-1.06L6.75 9.19 5.28 7.72a.751.751 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l4.5-4.5Z"/></svg>
+      <svg class="h-4 w-4 shrink-0 text-success-500" viewBox="0 0 16 16" fill="currentColor"><title>CI passed</title><path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16Zm3.78-9.72a.751.751 0 0 0-1.06-1.06L6.75 9.19 5.28 7.72a.751.751 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l4.5-4.5Z"/></svg>
     {:else if topPR?.ciStatus === 'FAILURE'}
-      <svg class="h-4 w-4 shrink-0 text-red-500" viewBox="0 0 16 16" fill="currentColor"><title>CI failed</title><path d="M2.343 13.657A8 8 0 1 1 13.658 2.343 8 8 0 0 1 2.343 13.657ZM6.03 4.97a.751.751 0 0 0-1.06 1.06L6.94 8 4.97 9.97a.751.751 0 1 0 1.06 1.06L8 9.06l1.97 1.97a.751.751 0 1 0 1.06-1.06L9.06 8l1.97-1.97a.751.751 0 1 0-1.06-1.06L8 6.94 6.03 4.97Z"/></svg>
+      <svg class="h-4 w-4 shrink-0 text-error-500" viewBox="0 0 16 16" fill="currentColor"><title>CI failed</title><path d="M2.343 13.657A8 8 0 1 1 13.658 2.343 8 8 0 0 1 2.343 13.657ZM6.03 4.97a.751.751 0 0 0-1.06 1.06L6.94 8 4.97 9.97a.751.751 0 1 0 1.06 1.06L8 9.06l1.97 1.97a.751.751 0 1 0 1.06-1.06L9.06 8l1.97-1.97a.751.751 0 1 0-1.06-1.06L8 6.94 6.03 4.97Z"/></svg>
     {:else if topPR?.ciStatus === 'PENDING'}
-      <svg class="h-4 w-4 shrink-0 text-yellow-500" viewBox="0 0 16 16" fill="currentColor"><title>CI pending</title><path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16Zm1-8.577V4.75a.75.75 0 0 0-1.5 0V8a.75.75 0 0 0 .388.657l3 1.5a.75.75 0 1 0 .67-1.342L9 7.423Z"/></svg>
+      <svg class="h-4 w-4 shrink-0 text-warning-500" viewBox="0 0 16 16" fill="currentColor"><title>CI pending</title><path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16Zm1-8.577V4.75a.75.75 0 0 0-1.5 0V8a.75.75 0 0 0 .388.657l3 1.5a.75.75 0 1 0 .67-1.342L9 7.423Z"/></svg>
     {/if}
     <h3 class="text-sm font-semibold leading-tight">{t.title}</h3>
   </div>
@@ -115,8 +115,8 @@
     {/if}
 
     {#if agentRunning}
-      <span class="inline-flex items-center gap-1 rounded bg-success-200 px-1.5 py-0.5 text-success-800 dark:bg-success-700 dark:text-success-200">
-        <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-success-500"></span>
+      <span class="inline-flex items-center gap-1 rounded bg-primary-200 px-1.5 py-0.5 text-primary-800 dark:bg-primary-700 dark:text-primary-200">
+        <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-primary-500"></span>
         Agent
       </span>
     {/if}
@@ -129,20 +129,20 @@
     {/if}
 
     {#if topPR}
-      <span class="inline-flex items-center gap-1 rounded bg-purple-500/15 px-1.5 py-0.5 font-medium text-purple-600 dark:text-purple-400" title={topPR.title}>
+      <span class="inline-flex items-center gap-1 rounded bg-warning-500/15 px-1.5 py-0.5 font-medium text-warning-700 dark:text-warning-400" title={topPR.title}>
         <svg class="h-3 w-3" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"/></svg>
         #{topPR.number}
         {#if topPR.reviewDecision === 'APPROVED'}
-          <span class="text-green-500" title="Approved">✓</span>
+          <span class="text-success-500" title="Approved">✓</span>
         {:else if topPR.reviewDecision === 'CHANGES_REQUESTED'}
-          <span class="text-red-500" title="Changes requested">✗</span>
+          <span class="text-error-500" title="Changes requested">✗</span>
         {/if}
         {#if topPR.mergeable === 'CONFLICTING'}
-          <span class="text-red-500" title="Merge conflicts">⚠</span>
+          <span class="text-error-500" title="Merge conflicts">⚠</span>
         {/if}
       </span>
     {:else if t.prNumber}
-      <span class="inline-flex items-center gap-1 rounded bg-purple-500/15 px-1.5 py-0.5 font-medium text-purple-600 dark:text-purple-400">
+      <span class="inline-flex items-center gap-1 rounded bg-warning-500/15 px-1.5 py-0.5 font-medium text-warning-700 dark:text-warning-400">
         <svg class="h-3 w-3" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"/></svg>
         #{t.prNumber}
       </span>
@@ -150,7 +150,7 @@
 
     {#if t.issue}
       <span
-        class="inline-flex items-center gap-1 rounded bg-blue-500/15 px-1.5 py-0.5 font-medium text-blue-600 dark:text-blue-400"
+        class="inline-flex items-center gap-1 rounded bg-secondary-500/15 px-1.5 py-0.5 font-medium text-secondary-700 dark:text-secondary-400"
         title={t.issue}
       >
         <svg class="h-3 w-3" viewBox="0 0 16 16" fill="currentColor"><path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"/><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"/></svg>

--- a/frontend/src/components/ToolApproval.svelte
+++ b/frontend/src/components/ToolApproval.svelte
@@ -47,7 +47,7 @@
         filePath={String(input.file_path ?? '')}
       />
     {:else if toolName === 'Bash' && input.command}
-      <div class="rounded bg-surface-900 px-3 py-2 font-mono text-xs text-green-400 dark:bg-surface-950">
+      <div class="rounded bg-surface-900 px-3 py-2 font-mono text-xs text-success-400 dark:bg-surface-950">
         $ {input.command}
       </div>
       {#if input.description}

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -402,8 +402,8 @@
             </span>
           {/if}
           {#if reviewingAgent}
-            <span class="inline-flex items-center gap-1 rounded-full bg-purple-200 px-2 py-0.5 text-xs font-medium text-purple-800 dark:bg-purple-700 dark:text-purple-200">
-              <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-purple-500"></span>
+            <span class="inline-flex items-center gap-1 rounded-full bg-warning-200 px-2 py-0.5 text-xs font-medium text-warning-800 dark:bg-warning-700 dark:text-warning-200">
+              <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-warning-500"></span>
               Reviewing
             </span>
           {/if}
@@ -415,7 +415,7 @@
           {#if isReviewTask && t.prNumber && t.projectId}
             <button
               type="button"
-              class="rounded bg-purple-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-purple-600 disabled:opacity-50"
+              class="rounded bg-warning-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-warning-600 disabled:opacity-50"
               onclick={runReview}
               disabled={reviewLoading || reviewingAgent}
             >
@@ -425,7 +425,7 @@
           {#if t.status === 'in-review' && t.prNumber && t.projectId && !isReviewTask}
             <button
               type="button"
-              class="rounded bg-orange-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-orange-600 disabled:opacity-50"
+              class="rounded bg-tertiary-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-tertiary-600 disabled:opacity-50"
               onclick={runFixReview}
               disabled={fixReviewLoading || fixingReviewAgent}
               title="Run fix-review skill to apply unresolved PR review comments"
@@ -434,8 +434,8 @@
             </button>
           {/if}
           {#if fixingReviewAgent}
-            <span class="inline-flex items-center gap-1 rounded-full bg-orange-200 px-2 py-0.5 text-xs font-medium text-orange-800 dark:bg-orange-700 dark:text-orange-200">
-              <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-orange-500"></span>
+            <span class="inline-flex items-center gap-1 rounded-full bg-tertiary-200 px-2 py-0.5 text-xs font-medium text-tertiary-800 dark:bg-tertiary-700 dark:text-tertiary-200">
+              <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-tertiary-500"></span>
               Fixing review
             </span>
           {/if}
@@ -493,7 +493,7 @@
             <span class="font-medium text-surface-500">Issue</span>
             <button
               type="button"
-              class="flex w-fit items-center gap-1.5 text-sm text-blue-600 hover:underline dark:text-blue-400"
+              class="flex w-fit items-center gap-1.5 text-sm text-secondary-600 hover:underline dark:text-secondary-400"
               onclick={() => t && BrowserOpenURL(t.issue)}
             >
               <svg class="h-4 w-4 shrink-0" viewBox="0 0 16 16" fill="currentColor"><path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"/><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"/></svg>
@@ -526,11 +526,11 @@
               <div class="flex items-center gap-2">
                 {#if pr.ciStatus}
                   <span
-                    class="inline-block h-2.5 w-2.5 shrink-0 rounded-full {pr.ciStatus === 'SUCCESS' ? 'bg-green-500' : pr.ciStatus === 'FAILURE' ? 'bg-red-500' : 'bg-yellow-500'}"
+                    class="inline-block h-2.5 w-2.5 shrink-0 rounded-full {pr.ciStatus === 'SUCCESS' ? 'bg-success-500' : pr.ciStatus === 'FAILURE' ? 'bg-error-500' : 'bg-warning-500'}"
                     title="CI: {pr.ciStatus.toLowerCase()}"
                   ></span>
                 {/if}
-                <svg class="h-4 w-4 shrink-0 text-purple-500" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"/></svg>
+                <svg class="h-4 w-4 shrink-0 text-warning-500" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"/></svg>
                 <div class="flex flex-col">
                   <span class="text-sm font-semibold">{pr.title}</span>
                   <span class="text-xs text-surface-500">{pr.repository}#{pr.number} by {pr.author}</span>
@@ -541,14 +541,14 @@
                   <span class="rounded bg-surface-200 px-1.5 py-0.5 text-xs dark:bg-surface-700">Draft</span>
                 {/if}
                 {#if pr.reviewDecision === 'APPROVED'}
-                  <span class="rounded bg-green-500/15 px-1.5 py-0.5 text-xs font-medium text-green-600 dark:text-green-400">Approved</span>
+                  <span class="rounded bg-success-500/15 px-1.5 py-0.5 text-xs font-medium text-success-700 dark:text-success-400">Approved</span>
                 {:else if pr.reviewDecision === 'CHANGES_REQUESTED'}
-                  <span class="rounded bg-red-500/15 px-1.5 py-0.5 text-xs font-medium text-red-600 dark:text-red-400">Changes</span>
+                  <span class="rounded bg-error-500/15 px-1.5 py-0.5 text-xs font-medium text-error-700 dark:text-error-400">Changes</span>
                 {:else if pr.reviewDecision === 'REVIEW_REQUIRED'}
-                  <span class="rounded bg-yellow-500/15 px-1.5 py-0.5 text-xs font-medium text-yellow-600 dark:text-yellow-400">Review needed</span>
+                  <span class="rounded bg-warning-500/15 px-1.5 py-0.5 text-xs font-medium text-warning-700 dark:text-warning-400">Review needed</span>
                 {/if}
                 {#if pr.unresolvedCount > 0}
-                  <span class="rounded bg-yellow-500/15 px-1.5 py-0.5 text-xs font-medium text-yellow-600 dark:text-yellow-400"
+                  <span class="rounded bg-warning-500/15 px-1.5 py-0.5 text-xs font-medium text-warning-700 dark:text-warning-400"
                     title="{pr.unresolvedCount} unresolved"
                   >{pr.unresolvedCount} unresolved</span>
                 {/if}
@@ -561,7 +561,7 @@
           <span class="text-sm font-medium text-surface-500">Pull Request</span>
           <button
             type="button"
-            class="flex w-fit items-center gap-1.5 text-sm text-purple-600 hover:underline dark:text-purple-400"
+            class="flex w-fit items-center gap-1.5 text-sm text-warning-700 hover:underline dark:text-warning-400"
             onclick={() => t && BrowserOpenURL(`https://github.com/${t.projectId}/pull/${t.prNumber}`)}
           >
             <svg class="h-4 w-4 shrink-0" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"/></svg>
@@ -674,9 +674,9 @@
                 {runningAgent.id}
               </button>
               <span class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium
-                {runningAgent.state === 'running' ? 'bg-success-200 text-success-800 dark:bg-success-700 dark:text-success-200' : 'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200'}">
+                {runningAgent.state === 'running' ? 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200' : 'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200'}">
                 {#if runningAgent.state === 'running'}
-                  <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-success-500"></span>
+                  <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-primary-500"></span>
                 {/if}
                 {runningAgent.state}
               </span>
@@ -742,7 +742,7 @@
                 <div class="flex items-center gap-2">
                   <span class="font-mono text-surface-400">{run.agentId}</span>
                   <span class="rounded bg-surface-200 px-1.5 py-0.5 dark:bg-surface-700">{run.mode}</span>
-                  <span class="rounded px-1.5 py-0.5 {run.state === 'stopped' ? 'bg-surface-200 dark:bg-surface-700' : 'bg-success-200 text-success-800 dark:bg-success-700 dark:text-success-200'}">
+                  <span class="rounded px-1.5 py-0.5 {run.state === 'stopped' ? 'bg-surface-200 dark:bg-surface-700' : 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200'}">
                     {run.state || 'running'}
                   </span>
                 </div>


### PR DESCRIPTION
## Motivation

All hardcoded Tailwind color classes (green/red/yellow/blue/purple/orange) bypassed the Amber Command palette entirely. This caused visual inconsistency — CI badges, review status, PR badges, action buttons, and agent state indicators all used raw colors instead of semantic theme tokens.

## Implementation information

Mapped 7 components to semantic tokens:
- CI status dots/badges: `bg-green-*` → `bg-success-*`, `bg-red-*` → `bg-error-*`, `bg-yellow-*` → `bg-warning-*`
- PR review badges: green/red/yellow → success/error/warning
- PR badges (TaskCard/TaskDetail): `bg-purple-*` → `bg-warning-*` (violet = our review color)
- Issue badges: `bg-blue-*` → `bg-secondary-*` (teal)
- Agent running badge: `bg-success-*` → `bg-primary-*` (amber = running)
- Reviewing/fixing agent badges: purple/orange → warning/tertiary
- Action buttons (approve/rerun/fix): green/yellow/red → success/warning/error
- TOOL badge in MessageBubble: blue → secondary
- Terminal text: `text-green-400` → `text-success-400`

DiffViewer red/green diff lines intentionally kept (universal diff standard).

> Changelog: fix(theme): semantic tokens for all components