### PR TITLE
feat(anim): state-communicating transitions

### DIFF
--- a/frontend/src/components/AgentCard.svelte
+++ b/frontend/src/components/AgentCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { agent } from '../../wailsjs/go/models.js'
   import { agentStore } from '../stores/agents.svelte.js'
+  import { fade } from 'svelte/transition'
 
   interface Props {
     agent: agent.Agent
@@ -47,11 +48,11 @@
         </span>
       {/if}
     </div>
-    <span class="inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium {resolved.classes}">
+    <span class="inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium transition-all duration-150 {resolved.classes}">
       {#if a.state === 'running'}
-        <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-primary-500"></span>
+        <span transition:fade={{ duration: 150 }} class="h-1.5 w-1.5 animate-pulse-subtle rounded-full bg-success-500"></span>
       {:else if a.state === 'paused'}
-        <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-warning-500"></span>
+        <span transition:fade={{ duration: 150 }} class="h-1.5 w-1.5 animate-pulse-subtle rounded-full bg-warning-500"></span>
       {/if}
       {resolved.label}
     </span>

--- a/frontend/src/components/StatusBadge.svelte
+++ b/frontend/src/components/StatusBadge.svelte
@@ -10,6 +10,6 @@
   const resolved = $derived(STATUS_MAP[status] ?? { label: status, badgeClasses: 'bg-surface-200 text-surface-800' })
 </script>
 
-<span class="inline-block rounded-full px-2.5 py-0.5 text-xs font-medium {resolved.badgeClasses}">
+<span class="inline-block rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors duration-100 {resolved.badgeClasses}">
   {resolved.label}
 </span>

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -54,7 +54,7 @@
 
 <div
   data-focused-task={focused ? '' : undefined}
-  class="w-full select-none rounded-lg border bg-surface-50 p-3 text-left transition-colors active:bg-surface-100 dark:bg-surface-800 dark:active:bg-surface-700 md:hover:bg-surface-100 md:dark:hover:bg-surface-700 {focused ? 'border-primary-400 ring-2 ring-primary-400/50 dark:border-primary-500 dark:ring-primary-500/50' : 'border-surface-300 dark:border-surface-600'} {dragging ? 'opacity-40' : ''}"
+  class="w-full select-none rounded-lg border bg-surface-50 p-3 text-left transition-all duration-100 active:bg-surface-100 dark:bg-surface-800 dark:active:bg-surface-700 md:hover:bg-surface-100 md:dark:hover:bg-surface-700 {focused ? 'border-primary-400 ring-2 ring-primary-400/50 dark:border-primary-500 dark:ring-primary-500/50' : 'border-surface-300 dark:border-surface-600'} {dragging ? 'opacity-40 shadow-lg' : ''}"
 >
   <button
     type="button"
@@ -96,14 +96,14 @@
 
     {#if triaging}
       <span class="inline-flex items-center gap-1 rounded bg-primary-200 px-1.5 py-0.5 text-primary-800 dark:bg-primary-700 dark:text-primary-200">
-        <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-primary-500"></span>
+        <span class="h-1.5 w-1.5 animate-pulse-subtle rounded-full bg-primary-500"></span>
         Triaging
       </span>
     {/if}
 
     {#if planning}
       <span class="inline-flex items-center gap-1 rounded bg-tertiary-200 px-1.5 py-0.5 text-tertiary-800 dark:bg-tertiary-700 dark:text-tertiary-200">
-        <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-tertiary-500"></span>
+        <span class="h-1.5 w-1.5 animate-pulse-subtle rounded-full bg-tertiary-500"></span>
         Planning
       </span>
     {/if}
@@ -115,15 +115,15 @@
     {/if}
 
     {#if agentRunning}
-      <span class="inline-flex items-center gap-1 rounded bg-primary-200 px-1.5 py-0.5 text-primary-800 dark:bg-primary-700 dark:text-primary-200">
-        <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-primary-500"></span>
+      <span class="inline-flex items-center gap-1 rounded bg-success-200 px-1.5 py-0.5 text-success-800 dark:bg-success-700 dark:text-success-200">
+        <span class="h-1.5 w-1.5 animate-pulse-subtle rounded-full bg-success-500"></span>
         Agent
       </span>
     {/if}
 
     {#if evaluating}
       <span class="inline-flex items-center gap-1 rounded bg-warning-200 px-1.5 py-0.5 text-warning-800 dark:bg-warning-700 dark:text-warning-200">
-        <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-warning-500"></span>
+        <span class="h-1.5 w-1.5 animate-pulse-subtle rounded-full bg-warning-500"></span>
         Evaluating
       </span>
     {/if}

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -7,6 +7,9 @@
   import TaskCard from '../components/TaskCard.svelte'
   import MobileSheet from '../components/shell/MobileSheet.svelte'
   import { viewport } from '../lib/viewport.svelte.js'
+  import { fly } from 'svelte/transition'
+  import { flip } from 'svelte/animate'
+  import { cubicOut } from 'svelte/easing'
 
   interface Props {
     onselect: (id: string) => void
@@ -494,12 +497,18 @@
           {#if !isCollapsed}
             <div class="flex flex-col gap-2 px-2 pb-2 md:flex-1 md:overflow-y-auto">
               {#each tasks as t (t.id)}
-                <TaskCard
-                  task={t}
-                  onclick={() => onselect(t.id)}
-                  focused={focusedTaskId === t.id}
-                  onstatuschange={(s) => moveTask(t.id, s)}
-                />
+                <div
+                  in:fly={{ y: -12, duration: 150, easing: cubicOut }}
+                  out:fly={{ y: 12, duration: 200, easing: cubicOut }}
+                  animate:flip={{ duration: 200, easing: cubicOut }}
+                >
+                  <TaskCard
+                    task={t}
+                    onclick={() => onselect(t.id)}
+                    focused={focusedTaskId === t.id}
+                    onstatuschange={(s) => moveTask(t.id, s)}
+                  />
+                </div>
               {/each}
             </div>
             <div class="px-2 pb-2">

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -67,3 +67,12 @@ html, body {
 .dark [data-active] {
   background-color: var(--color-surface-700);
 }
+
+@keyframes pulse-subtle {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+@utility animate-pulse-subtle {
+  animation: pulse-subtle 2s ease-in-out infinite;
+}


### PR DESCRIPTION
## Motivation

Every animation should communicate state change, not decorate. This implements purposeful motion aligned with Things 3 / Apple HIG philosophy: animations connect cause to effect, never delay the next action.

## Implementation information

Five targeted changes, no new dependencies:

- **`style.css`**: `@keyframes pulse-subtle` (0→40%→0 opacity) + `animate-pulse-subtle` utility — replaces Tailwind's `animate-pulse` with a more restrained 2s loop
- **`StatusBadge`**: `transition-colors duration-100` — badge color cross-fades on status change
- **`AgentCard`**: `transition-all duration-150` on state badge + `svelte/transition fade` on indicator dots — color and dot cross-fade when agent state changes (idle/running/paused/stopped)
- **`TaskCard`**: `transition-all duration-100` + `shadow-lg` on drag — card lifts visually when dragging; all pulsing dots use `animate-pulse-subtle`
- **`TaskList`**: `svelte/transition fly` (in: y=-12 150ms, out: y=+12 200ms) + `svelte/animate flip` (200ms) — task creation slides in from top, removal/completion slides down, reordering uses physics-based flip

Thresholds respected: all transitions 100–200ms. No animations on data loading. No bounce/elastic easing.

> Changelog: feat(anim): state-communicating transitions

Closes https://github.com/Automaat/synapse/issues/462