### PR TITLE
feat(layout): graceful error and offline states

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -8,6 +8,7 @@
   import { notificationStore } from './stores/notifications.svelte.js'
   import { navStore, type Page } from './lib/navigation.svelte.js'
   import { viewport } from './lib/viewport.svelte.js'
+  import { connectionStore } from './stores/connection.svelte.js'
   import AppShell from './components/shell/AppShell.svelte'
   import TaskList from './pages/TaskList.svelte'
   import TaskDetail from './pages/TaskDetail.svelte'
@@ -113,6 +114,7 @@
     // every subscription and EventSource connection and re-create them in a
     // tight loop (~60×/s in the wild — caused full UI flicker on the web build).
     const cleanup = untrack(() => {
+      const stopConnection = connectionStore.start()
       taskStore.load()
       taskStore.startPolling()
       agentStore.load()
@@ -145,9 +147,9 @@
         if (quitConfirmTimer) clearTimeout(quitConfirmTimer)
         quitConfirmTimer = setTimeout(() => { quitConfirmVisible = false }, 3000)
       })
-      return { unsubTasks, unsubNotif, unsubDegraded, unsubProviderHealth, unsubQuit }
+      return { stopConnection, unsubTasks, unsubNotif, unsubDegraded, unsubProviderHealth, unsubQuit }
     })
-    const { unsubTasks, unsubNotif, unsubDegraded, unsubProviderHealth, unsubQuit } = cleanup
+    const { stopConnection, unsubTasks, unsubNotif, unsubDegraded, unsubProviderHealth, unsubQuit } = cleanup
 
     // Keyboard shortcuts only on devices with a fine pointer (mouse/keyboard).
     // Touch-only devices (iPhone, iPad without keyboard) skip listener entirely.
@@ -210,6 +212,7 @@
     }
 
     return () => {
+      stopConnection()
       unsubTasks()
       unsubNotif()
       unsubDegraded()
@@ -231,6 +234,19 @@
 </script>
 
 <AppShell onsearch={() => (commandPaletteOpen = true)} {primaryAction}>
+  {#if !connectionStore.online}
+    <div class="flex shrink-0 items-center gap-2 border-b border-warning-600 bg-warning-800/90 px-4 py-2 text-sm text-warning-100">
+      <svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z" />
+      </svg>
+      <span>
+        <strong>Offline</strong> — task board is read-only.
+        {connectionStore.networkOnline ? 'Backend unreachable.' : 'No network connection.'}
+        Agents cannot start; GitHub sync will resume when reconnected.
+      </span>
+    </div>
+  {/if}
+
   {#if unhealthyProviders.length > 0}
     <div class="flex shrink-0 flex-col gap-0.5">
       {#each unhealthyProviders as p (p.provider)}

--- a/frontend/src/components/AgentCard.svelte
+++ b/frontend/src/components/AgentCard.svelte
@@ -17,7 +17,11 @@
     stopped: { label: 'Stopped', classes: 'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200' },
   }
 
-  const resolved = $derived(stateConfig[a.state] ?? { label: a.state, classes: 'bg-surface-200 text-surface-800' })
+  const resolved = $derived(
+    a.errorKind
+      ? { label: 'Error', classes: 'bg-error-200 text-error-800 dark:bg-error-800 dark:text-error-100' }
+      : (stateConfig[a.state] ?? { label: a.state, classes: 'bg-surface-200 text-surface-800' })
+  )
 
   function timeAgo(date: any): string {
     if (!date) return ''
@@ -33,7 +37,10 @@
 
 <button
   type="button"
-  class="w-full rounded-lg border border-surface-300 bg-surface-50 p-4 text-left transition-colors hover:bg-surface-100 dark:border-surface-600 dark:bg-surface-800 dark:hover:bg-surface-700"
+  class="w-full rounded-lg border p-4 text-left transition-colors hover:bg-surface-100 dark:hover:bg-surface-700
+    {a.errorKind
+      ? 'border-error-400 bg-error-50 dark:border-error-600 dark:bg-error-950/30'
+      : 'border-surface-300 bg-surface-50 dark:border-surface-600 dark:bg-surface-800'}"
   onclick={onclick}
 >
   <div class="mb-2 flex items-start justify-between gap-2">
@@ -49,7 +56,11 @@
       {/if}
     </div>
     <span class="inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium transition-all duration-150 {resolved.classes}">
-      {#if a.state === 'running'}
+      {#if a.errorKind}
+        <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+        </svg>
+      {:else if a.state === 'running'}
         <span transition:fade={{ duration: 150 }} class="h-1.5 w-1.5 animate-pulse-subtle rounded-full bg-success-500"></span>
       {:else if a.state === 'paused'}
         <span transition:fade={{ duration: 150 }} class="h-1.5 w-1.5 animate-pulse-subtle rounded-full bg-warning-500"></span>

--- a/frontend/src/components/AgentErrorBanner.svelte
+++ b/frontend/src/components/AgentErrorBanner.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+  import { agentStore } from '../stores/agents.svelte.js'
+
+  interface ErrorEvent {
+    kind: string
+    msg: string
+  }
+
+  interface Props {
+    agentId: string
+    error: ErrorEvent
+    onretry?: () => void
+    ondismiss?: () => void
+  }
+
+  const { agentId, error, onretry, ondismiss }: Props = $props()
+
+  let logsExpanded = $state(false)
+
+  type ErrorSpec = {
+    label: string
+    icon: string
+    what: string
+    todo: string
+    color: string
+    iconColor: string
+  }
+
+  const ERROR_SPECS: Record<string, ErrorSpec> = {
+    worktree_conflict: {
+      label: 'Worktree conflict',
+      icon: `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />`,
+      what: 'Git worktree is already checked out by another agent.',
+      todo: 'Stop the conflicting agent or retry once it finishes.',
+      color: 'bg-error-50 border-error-400 dark:bg-error-950 dark:border-error-600',
+      iconColor: 'text-error-500',
+    },
+    git_clone: {
+      label: 'Git / network error',
+      icon: `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z" />`,
+      what: 'Failed to clone or fetch the repository.',
+      todo: 'Check network connectivity and repository access, then retry.',
+      color: 'bg-warning-50 border-warning-400 dark:bg-warning-950 dark:border-warning-600',
+      iconColor: 'text-warning-500',
+    },
+    permission_denied: {
+      label: 'Permission denied',
+      icon: `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />`,
+      what: 'A tool call was rejected due to insufficient permissions.',
+      todo: 'Review allowed tools in task settings and retry.',
+      color: 'bg-error-50 border-error-400 dark:bg-error-950 dark:border-error-600',
+      iconColor: 'text-error-500',
+    },
+    rate_limit: {
+      label: 'API rate limited',
+      icon: `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />`,
+      what: 'The API provider rate limit was reached.',
+      todo: 'Wait a few minutes and retry, or check provider health.',
+      color: 'bg-warning-50 border-warning-400 dark:bg-warning-950 dark:border-warning-600',
+      iconColor: 'text-warning-500',
+    },
+    crash: {
+      label: 'Agent crashed',
+      icon: `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />`,
+      what: 'The agent process exited unexpectedly.',
+      todo: 'View logs for details, then retry.',
+      color: 'bg-error-50 border-error-400 dark:bg-error-950 dark:border-error-600',
+      iconColor: 'text-error-500',
+    },
+  }
+
+  const spec = $derived(ERROR_SPECS[error.kind] ?? ERROR_SPECS.crash)
+  const logs = $derived(agentStore.outputs.get(agentId) ?? [])
+</script>
+
+<div class="rounded-lg border-2 {spec.color} p-4">
+  <div class="flex items-start gap-3">
+    <svg class="h-5 w-5 shrink-0 {spec.iconColor} mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      {@html spec.icon}
+    </svg>
+    <div class="min-w-0 flex-1">
+      <div class="flex flex-wrap items-center gap-2">
+        <span class="text-sm font-semibold text-surface-800 dark:text-surface-100">{spec.label}</span>
+        <span class="rounded bg-surface-200 px-1.5 py-0.5 font-mono text-xs text-surface-600 dark:bg-surface-700 dark:text-surface-400">{error.kind}</span>
+      </div>
+      <p class="mt-1 text-sm text-surface-700 dark:text-surface-300">{spec.what}</p>
+      <p class="text-sm text-surface-500 dark:text-surface-400">{spec.todo}</p>
+      {#if error.msg && error.msg !== spec.what}
+        <p class="mt-1 truncate font-mono text-xs text-surface-500 dark:text-surface-400" title={error.msg}>{error.msg}</p>
+      {/if}
+    </div>
+  </div>
+
+  <div class="mt-3 flex flex-wrap items-center gap-2">
+    {#if onretry}
+      <button
+        type="button"
+        class="flex items-center gap-1.5 rounded-md bg-surface-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-surface-800 dark:bg-surface-600 dark:hover:bg-surface-500"
+        onclick={onretry}
+      >
+        <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+        </svg>
+        Retry
+      </button>
+    {/if}
+    {#if logs.length > 0}
+      <button
+        type="button"
+        class="flex items-center gap-1.5 rounded-md border border-surface-300 px-3 py-1.5 text-sm font-medium text-surface-700 hover:bg-surface-100 dark:border-surface-600 dark:text-surface-300 dark:hover:bg-surface-800"
+        onclick={() => (logsExpanded = !logsExpanded)}
+      >
+        <svg class="h-3.5 w-3.5 transition-transform {logsExpanded ? 'rotate-90' : ''}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+        </svg>
+        View logs
+      </button>
+    {/if}
+    {#if ondismiss}
+      <button
+        type="button"
+        class="ml-auto flex items-center gap-1 text-sm text-surface-400 hover:text-surface-600 dark:hover:text-surface-200"
+        onclick={ondismiss}
+      >
+        Dismiss
+      </button>
+    {/if}
+  </div>
+
+  {#if logsExpanded && logs.length > 0}
+    <div class="mt-3 max-h-48 overflow-y-auto rounded bg-surface-900 p-3 font-mono text-xs text-surface-200">
+      {#each logs as ev}
+        {#if ev.content}
+          <div class="mb-0.5 leading-relaxed">{ev.content}</div>
+        {/if}
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/frontend/src/pages/AgentDetail.svelte
+++ b/frontend/src/pages/AgentDetail.svelte
@@ -32,6 +32,7 @@
   let agentErr = $state<AgentErrorEvent | null>(null)
   let escalation = $state<EscalationEvent | null>(null)
   let escalationResponding = $state(false)
+  let errorDismissed = $state(false)
 
   const isRunning = $derived(a?.state === 'running')
 
@@ -39,7 +40,7 @@
   const cachedError = $derived(
     a?.errorKind ? { kind: a.errorKind, msg: a.errorMsg ?? '' } : null
   )
-  const displayError = $derived(agentErr ?? cachedError)
+  const displayError = $derived(errorDismissed ? null : (agentErr ?? cachedError))
 
   $effect(() => {
     const cached = agentStore.agents.get(agentId)
@@ -52,6 +53,7 @@
 
     const unsubError = EventsOn(agentError(agentId), (data: AgentErrorEvent) => {
       agentErr = data
+      errorDismissed = false
     })
 
     const unsubEscalation = EventsOn(agentEscalation(agentId), (data: EscalationEvent) => {
@@ -124,7 +126,7 @@
       {agentId}
       error={displayError}
       onretry={a?.taskId ? () => onviewtask(a!.taskId) : undefined}
-      ondismiss={() => { agentErr = null }}
+      ondismiss={() => { agentErr = null; errorDismissed = true }}
     />
   {/if}
 

--- a/frontend/src/pages/AgentDetail.svelte
+++ b/frontend/src/pages/AgentDetail.svelte
@@ -2,15 +2,21 @@
   import type { agent } from '../../wailsjs/go/models.js'
   import { EventsOn, RespondEscalation } from '$lib/api'
   import { agentStore } from '../stores/agents.svelte.js'
-  import { agentState, agentEscalation } from '../lib/events.js'
+  import { agentState, agentEscalation, agentError } from '../lib/events.js'
   import StreamOutput from '../components/StreamOutput.svelte'
   import ChatView from '../components/ChatView.svelte'
+  import AgentErrorBanner from '../components/AgentErrorBanner.svelte'
 
   interface EscalationEvent {
     reason: string
     turnCount?: number
     costUsd?: number
     limit: number
+  }
+
+  interface AgentErrorEvent {
+    kind: string
+    msg: string
   }
 
   interface Props {
@@ -23,10 +29,17 @@
 
   let a = $state<agent.Agent | null>(null)
   let error = $state('')
+  let agentErr = $state<AgentErrorEvent | null>(null)
   let escalation = $state<EscalationEvent | null>(null)
   let escalationResponding = $state(false)
 
   const isRunning = $derived(a?.state === 'running')
+
+  // Seed error from cached agent state (already stopped with errorKind set).
+  const cachedError = $derived(
+    a?.errorKind ? { kind: a.errorKind, msg: a.errorMsg ?? '' } : null
+  )
+  const displayError = $derived(agentErr ?? cachedError)
 
   $effect(() => {
     const cached = agentStore.agents.get(agentId)
@@ -37,6 +50,10 @@
       agentStore.updateAgent(agentId, data)
     })
 
+    const unsubError = EventsOn(agentError(agentId), (data: AgentErrorEvent) => {
+      agentErr = data
+    })
+
     const unsubEscalation = EventsOn(agentEscalation(agentId), (data: EscalationEvent) => {
       escalation = data
       escalationResponding = false
@@ -44,6 +61,7 @@
 
     return () => {
       unsubState()
+      unsubError()
       unsubEscalation()
     }
   })
@@ -99,6 +117,15 @@
 
   {#if error}
     <p class="text-sm text-error-500">{error}</p>
+  {/if}
+
+  {#if displayError}
+    <AgentErrorBanner
+      {agentId}
+      error={displayError}
+      onretry={a?.taskId ? () => onviewtask(a!.taskId) : undefined}
+      ondismiss={() => { agentErr = null }}
+    />
   {/if}
 
   {#if escalation}

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -6,6 +6,7 @@
   import { taskStore } from '../stores/tasks.svelte.js'
   import { agentStore } from '../stores/agents.svelte.js'
   import { reviewStore } from '../stores/reviews.svelte.js'
+  import { connectionStore } from '../stores/connection.svelte.js'
   import { STATUS_OPTIONS } from '../lib/statuses.js'
   import StreamOutput from '../components/StreamOutput.svelte'
   import ChatView from '../components/ChatView.svelte'
@@ -717,14 +718,20 @@
             placeholder="Enter prompt for the agent..."
             bind:value={prompt}
           ></textarea>
-          <button
-            type="button"
-            class="w-fit rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-white hover:bg-primary-600 disabled:opacity-50"
-            onclick={startAgent}
-            disabled={starting || !prompt.trim()}
-          >
-            {starting ? 'Starting...' : 'Start agent'}
-          </button>
+          <div class="flex items-center gap-2">
+            <button
+              type="button"
+              class="w-fit rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-white hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-50"
+              onclick={startAgent}
+              disabled={starting || !prompt.trim() || !connectionStore.online}
+              title={!connectionStore.online ? 'Offline — agent cannot start until connection is restored' : undefined}
+            >
+              {starting ? 'Starting...' : 'Start agent'}
+            </button>
+            {#if !connectionStore.online}
+              <span class="text-xs text-warning-600 dark:text-warning-400">Offline</span>
+            {/if}
+          </div>
         </div>
       {/if}
 

--- a/frontend/src/stores/connection.svelte.ts
+++ b/frontend/src/stores/connection.svelte.ts
@@ -1,0 +1,71 @@
+import { GetVersion } from '$lib/api'
+
+// How often to probe the backend when the browser reports online.
+const POLL_MS = 15_000
+// How often to probe when browser reports offline (less aggressive).
+const OFFLINE_POLL_MS = 5_000
+
+class ConnectionStore {
+  /** True when the Synapse backend is reachable. */
+  backendOnline = $state(true)
+  /** True when the browser's network interface is up. */
+  networkOnline = $state(typeof navigator !== 'undefined' ? navigator.onLine : true)
+
+  private timer: ReturnType<typeof setInterval> | null = null
+
+  get online(): boolean {
+    return this.networkOnline && this.backendOnline
+  }
+
+  private async probe() {
+    // Desktop (Wails IPC): backend is always local, only network matters.
+    // Web build: GetVersion is a lightweight health check.
+    if (import.meta.env.VITE_MODE !== 'web') {
+      this.backendOnline = true
+      return
+    }
+    try {
+      await GetVersion()
+      this.backendOnline = true
+    } catch {
+      this.backendOnline = false
+    }
+  }
+
+  start(): () => void {
+    if (typeof window === 'undefined') return () => {}
+
+    const onOnline = () => {
+      this.networkOnline = true
+      this.probe()
+    }
+    const onOffline = () => {
+      this.networkOnline = false
+      this.backendOnline = false
+    }
+
+    window.addEventListener('online', onOnline)
+    window.addEventListener('offline', onOffline)
+
+    const schedule = () => {
+      if (this.timer) clearInterval(this.timer)
+      const interval = this.online ? POLL_MS : OFFLINE_POLL_MS
+      this.timer = setInterval(() => {
+        this.probe().then(() => schedule())
+      }, interval)
+    }
+
+    this.probe().then(() => schedule())
+
+    return () => {
+      window.removeEventListener('online', onOnline)
+      window.removeEventListener('offline', onOffline)
+      if (this.timer) {
+        clearInterval(this.timer)
+        this.timer = null
+      }
+    }
+  }
+}
+
+export const connectionStore = new ConnectionStore()

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -25,7 +25,7 @@ export namespace agent {
 	    escalationReason?: string;
 	    errorKind?: string;
 	    errorMsg?: string;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new Agent(source);
 	    }

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -23,7 +23,9 @@ export namespace agent {
 	    model?: string;
 	    turnCount?: number;
 	    escalationReason?: string;
-	
+	    errorKind?: string;
+	    errorMsg?: string;
+
 	    static createFrom(source: any = {}) {
 	        return new Agent(source);
 	    }
@@ -50,6 +52,8 @@ export namespace agent {
 	        this.model = source["model"];
 	        this.turnCount = source["turnCount"];
 	        this.escalationReason = source["escalationReason"];
+	        this.errorKind = source["errorKind"];
+	        this.errorMsg = source["errorMsg"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -51,6 +51,8 @@ type Agent struct {
 
 	TurnCount        int    `json:"turnCount,omitempty"`
 	EscalationReason string `json:"escalationReason,omitempty"`
+	ErrorKind        string `json:"errorKind,omitempty"`
+	ErrorMsg         string `json:"errorMsg,omitempty"`
 
 	ExitErr         error `json:"-"`
 	outputBuffer    []StreamEvent
@@ -377,6 +379,20 @@ func (a *Agent) ConvoOutput() []ConvoEvent {
 	snapshot := make([]ConvoEvent, len(a.convoBuffer))
 	copy(snapshot, a.convoBuffer)
 	return snapshot
+}
+
+// SetError records a classified error on the agent.
+func (a *Agent) SetError(kind, msg string) {
+	a.mu.Lock()
+	a.ErrorKind = kind
+	a.ErrorMsg = msg
+	a.mu.Unlock()
+}
+
+// ErrorEvent is the payload emitted on agent:error:{id}.
+type ErrorEvent struct {
+	Kind string `json:"kind"`
+	Msg  string `json:"msg"`
 }
 
 // EscalationEvent is emitted on agent:escalation:{id} when a guardrail fires.

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -576,9 +576,18 @@ func classifyAgentError(err error) string {
 	switch {
 	case strings.Contains(msg, "worktree") || strings.Contains(msg, "already checked out"):
 		return "worktree_conflict"
-	case strings.Contains(msg, "clone") || (strings.Contains(msg, "git") && strings.Contains(msg, "network")):
+	case strings.Contains(msg, "clone") ||
+		strings.Contains(msg, "fetch origin") ||
+		strings.Contains(msg, "git fetch") ||
+		strings.Contains(msg, "could not resolve host") ||
+		strings.Contains(msg, "dial tcp") ||
+		strings.Contains(msg, "i/o timeout") ||
+		strings.Contains(msg, "dns") ||
+		(strings.Contains(msg, "git") && strings.Contains(msg, "network")):
 		return "git_clone"
-	case strings.Contains(msg, "permission denied"):
+	case strings.Contains(msg, "permission denied") ||
+		strings.Contains(msg, "eacces") ||
+		strings.Contains(msg, "operation not permitted"):
 		return "permission_denied"
 	case strings.Contains(msg, "rate limit") || strings.Contains(msg, "429") || strings.Contains(msg, "overloaded"):
 		return "rate_limit"

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -554,12 +554,35 @@ func formatHeadlessToolResults(results []ToolResultBlock) string {
 }
 
 func (m *Manager) handleError(a *Agent, err error) {
+	kind := classifyAgentError(err)
+	a.SetError(kind, err.Error())
 	a.SetState(StateStopped)
 	m.markAgentDone(a)
-	m.logger.Error("agent.error", "id", a.ID, "err", err)
-	m.emit(events.AgentError(a.ID), err.Error())
+	m.logger.Error("agent.error", "id", a.ID, "kind", kind, "err", err)
+	m.emit(events.AgentError(a.ID), ErrorEvent{Kind: kind, Msg: err.Error()})
+	m.emit(events.AgentState(a.ID), a)
 	m.recordCompletion(a, false)
 	if m.onComplete != nil {
 		m.onComplete(a)
+	}
+}
+
+// classifyAgentError maps a fatal agent error to a canonical kind string.
+func classifyAgentError(err error) string {
+	if err == nil {
+		return "crash"
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "worktree") || strings.Contains(msg, "already checked out"):
+		return "worktree_conflict"
+	case strings.Contains(msg, "clone") || (strings.Contains(msg, "git") && strings.Contains(msg, "network")):
+		return "git_clone"
+	case strings.Contains(msg, "permission denied"):
+		return "permission_denied"
+	case strings.Contains(msg, "rate limit") || strings.Contains(msg, "429") || strings.Contains(msg, "overloaded"):
+		return "rate_limit"
+	default:
+		return "crash"
 	}
 }


### PR DESCRIPTION
## Motivation

Agents could fail silently with no visual feedback — users had no way to understand what went wrong or what to do next. Similarly, network loss caused confusing blank states with no indication of offline status.

## Implementation information

- Extended `Agent` struct with `ErrorKind`/`ErrorMsg` fields; headless runner classifies fatal errors into: `crash`, `worktree_conflict`, `git_clone`, `permission_denied`, `rate_limit`
- Backend emits structured `agent:error:{id}` events with `kind`+`msg` fields
- New `AgentErrorBanner` component: icon+color per error kind, what/todo copy, Retry / View logs (inline expand) / Dismiss actions
- `AgentCard`: red border+badge when `errorKind` set, distinct from amber used for blocked/paused states
- `AgentDetail`: subscribes to `agent:error` events; seeds from cached `errorKind` on load; banner renders above escalation panel
- New `connectionStore`: tracks `navigator.onLine` + backend probe (web build); starts/stops with app lifecycle
- `App.svelte`: offline banner (yellow) above provider health banners; task board remains readable with GitHub sync note
- `TaskDetail`: Start agent button disabled + tooltip when offline

Closes https://github.com/Automaat/synapse/issues/466