### PR TITLE
feat(ui): distinct visual state per agent phase

### DIFF
--- a/frontend/src/components/AgentCard.svelte
+++ b/frontend/src/components/AgentCard.svelte
@@ -17,6 +17,7 @@
       a.state,
       a.escalationReason,
       a.taskId ? taskStore.tasks.get(a.taskId)?.status : undefined,
+      a.awaitingApproval,
     ),
   )
   const config = $derived(PHASE_CONFIG[phase])
@@ -51,6 +52,10 @@
       {:else if phase === 'human-required'}
         <span class="text-xs font-medium text-error-600 dark:text-error-400">
           Waiting for human input
+        </span>
+      {:else if phase === 'waiting'}
+        <span class="text-xs text-surface-400">
+          Waiting for reply
         </span>
       {:else if phase === 'blocked'}
         <span class="text-xs text-tertiary-600 dark:text-tertiary-400">

--- a/frontend/src/components/AgentCard.svelte
+++ b/frontend/src/components/AgentCard.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import type { agent } from '../../wailsjs/go/models.js'
   import { agentStore } from '../stores/agents.svelte.js'
+  import { taskStore } from '../stores/tasks.svelte.js'
   import { fade } from 'svelte/transition'
+  import { getAgentPhase, PHASE_CONFIG } from '$lib/agent-phases.js'
 
   interface Props {
     agent: agent.Agent
@@ -10,18 +12,14 @@
 
   const { agent: a, onclick }: Props = $props()
 
-  const stateConfig: Record<string, { label: string; classes: string }> = {
-    idle: { label: 'Idle', classes: 'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200' },
-    running: { label: 'Running', classes: 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200' },
-    paused: { label: 'Waiting', classes: 'bg-warning-200 text-warning-800 dark:bg-warning-700 dark:text-warning-200' },
-    stopped: { label: 'Stopped', classes: 'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200' },
-  }
-
-  const resolved = $derived(
-    a.errorKind
-      ? { label: 'Error', classes: 'bg-error-200 text-error-800 dark:bg-error-800 dark:text-error-100' }
-      : (stateConfig[a.state] ?? { label: a.state, classes: 'bg-surface-200 text-surface-800' })
+  const phase = $derived(
+    getAgentPhase(
+      a.state,
+      a.escalationReason,
+      a.taskId ? taskStore.tasks.get(a.taskId)?.status : undefined,
+    ),
   )
+  const config = $derived(PHASE_CONFIG[phase])
 
   function timeAgo(date: any): string {
     if (!date) return ''
@@ -37,37 +35,44 @@
 
 <button
   type="button"
-  class="w-full rounded-lg border p-4 text-left transition-colors hover:bg-surface-100 dark:hover:bg-surface-700
-    {a.errorKind
-      ? 'border-error-400 bg-error-50 dark:border-error-600 dark:bg-error-950/30'
-      : 'border-surface-300 bg-surface-50 dark:border-surface-600 dark:bg-surface-800'}"
+  class="w-full rounded-lg border border-surface-300 bg-surface-50 p-4 text-left transition-colors hover:bg-surface-100 dark:border-surface-600 dark:bg-surface-800 dark:hover:bg-surface-700 {config.faded ? 'opacity-60' : ''}"
   onclick={onclick}
 >
   <div class="mb-2 flex items-start justify-between gap-2">
     <div class="flex flex-col gap-0.5">
-      <h3 class="text-sm font-semibold leading-tight">{a.project || a.id}</h3>
+      <h3 class="text-sm font-semibold leading-tight {config.faded ? 'text-surface-400 dark:text-surface-500' : ''}">{a.project || a.id}</h3>
       {#if a.name}
         <span class="text-xs text-surface-400">{a.name}</span>
       {/if}
-      {#if a.state === 'running'}
+      {#if phase === 'running'}
         <span class="text-xs italic text-surface-400">
           {agentStore.stepTexts.get(a.id) ?? 'Working...'}
         </span>
+      {:else if phase === 'human-required'}
+        <span class="text-xs font-medium text-error-600 dark:text-error-400">
+          Waiting for human input
+        </span>
+      {:else if phase === 'blocked'}
+        <span class="text-xs text-tertiary-600 dark:text-tertiary-400">
+          Awaiting tool approval
+        </span>
       {/if}
     </div>
-    <span class="inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium transition-all duration-150 {resolved.classes}">
-      {#if a.errorKind}
-        <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-        </svg>
-      {:else if a.state === 'running'}
-        <span transition:fade={{ duration: 150 }} class="h-1.5 w-1.5 animate-pulse-subtle rounded-full bg-success-500"></span>
-      {:else if a.state === 'paused'}
-        <span transition:fade={{ duration: 150 }} class="h-1.5 w-1.5 animate-pulse-subtle rounded-full bg-warning-500"></span>
+    <span class="inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium transition-all duration-150 {config.badgeClasses}">
+      {#if config.animate}
+        <span transition:fade={{ duration: 150 }} class="h-1.5 w-1.5 animate-pulse-subtle rounded-full {config.dotClasses}"></span>
+      {:else if phase !== 'queued' && phase !== 'done'}
+        <span transition:fade={{ duration: 150 }} class="h-1.5 w-1.5 rounded-full {config.dotClasses}"></span>
       {/if}
-      {resolved.label}
+      {config.label}
     </span>
   </div>
+
+  {#if phase === 'human-required'}
+    <div class="mb-2 rounded border border-error-300 bg-error-50 px-2.5 py-1.5 text-xs text-error-700 dark:border-error-700 dark:bg-error-950 dark:text-error-300">
+      Action required — open agent to respond
+    </div>
+  {/if}
 
   <div class="flex items-center gap-2 text-xs text-surface-500">
     <span class="rounded bg-surface-200 px-1.5 py-0.5 dark:bg-surface-700">{a.mode}</span>

--- a/frontend/src/components/AgentCard.svelte.test.ts
+++ b/frontend/src/components/AgentCard.svelte.test.ts
@@ -48,9 +48,9 @@ describe('AgentCard', () => {
     expect(screen.getByText('Running')).toBeDefined()
   })
 
-  it('renders Idle state label', () => {
+  it('renders Queued label for idle state', () => {
     render(AgentCard, { props: { agent: makeAgent({ state: 'idle' }), onclick: () => {} } })
-    expect(screen.getByText('Idle')).toBeDefined()
+    expect(screen.getByText('Queued')).toBeDefined()
   })
 
   it('renders Waiting state label for paused', () => {
@@ -58,14 +58,14 @@ describe('AgentCard', () => {
     expect(screen.getByText('Waiting')).toBeDefined()
   })
 
-  it('renders Stopped state label', () => {
+  it('renders Done label for stopped state', () => {
     render(AgentCard, { props: { agent: makeAgent({ state: 'stopped' }), onclick: () => {} } })
-    expect(screen.getByText('Stopped')).toBeDefined()
+    expect(screen.getByText('Done')).toBeDefined()
   })
 
-  it('renders unknown state as-is', () => {
+  it('renders Done label for unknown state', () => {
     render(AgentCard, { props: { agent: makeAgent({ state: 'crashed' }), onclick: () => {} } })
-    expect(screen.getByText('crashed')).toBeDefined()
+    expect(screen.getByText('Done')).toBeDefined()
   })
 
   it('renders mode', () => {

--- a/frontend/src/lib/agent-phases.ts
+++ b/frontend/src/lib/agent-phases.ts
@@ -1,0 +1,104 @@
+export type AgentPhase =
+  | 'queued'
+  | 'running'
+  | 'blocked'
+  | 'human-required'
+  | 'reviewing'
+  | 'done'
+
+export interface PhaseConfig {
+  phase: AgentPhase
+  label: string
+  /** Tailwind classes for the dot indicator */
+  dotClasses: string
+  /** Tailwind classes for the badge pill */
+  badgeClasses: string
+  /** Whether the dot should pulse */
+  animate: boolean
+  /** Whether the row should be visually de-emphasised */
+  faded: boolean
+}
+
+export const PHASE_CONFIG: Record<AgentPhase, PhaseConfig> = {
+  queued: {
+    phase: 'queued',
+    label: 'Queued',
+    dotClasses: 'bg-surface-400 dark:bg-surface-500',
+    badgeClasses: 'bg-surface-200 text-surface-500 dark:bg-surface-700 dark:text-surface-400',
+    animate: false,
+    faded: false,
+  },
+  running: {
+    phase: 'running',
+    label: 'Running',
+    dotClasses: 'bg-primary-500',
+    badgeClasses: 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200',
+    animate: true,
+    faded: false,
+  },
+  blocked: {
+    phase: 'blocked',
+    label: 'Blocked',
+    // tertiary = warm amber — distinct from primary amber, matches "amber dot" spec
+    dotClasses: 'bg-tertiary-500',
+    badgeClasses: 'bg-tertiary-200 text-tertiary-800 dark:bg-tertiary-700 dark:text-tertiary-200',
+    animate: false,
+    faded: false,
+  },
+  'human-required': {
+    phase: 'human-required',
+    label: 'Needs Input',
+    // error = coral/orange — matches "orange dot" spec
+    dotClasses: 'bg-error-500',
+    badgeClasses: 'bg-error-200 text-error-800 dark:bg-error-700 dark:text-error-200',
+    animate: true,
+    faded: false,
+  },
+  reviewing: {
+    phase: 'reviewing',
+    label: 'Reviewing',
+    // warning = violet/purple in amber theme — matches "purple dot" spec
+    dotClasses: 'bg-warning-500',
+    badgeClasses: 'bg-warning-200 text-warning-800 dark:bg-warning-700 dark:text-warning-200',
+    animate: false,
+    faded: false,
+  },
+  done: {
+    phase: 'done',
+    label: 'Done',
+    dotClasses: 'bg-success-400',
+    badgeClasses: 'bg-success-100 text-success-700 dark:bg-success-900 dark:text-success-300',
+    animate: false,
+    faded: true,
+  },
+}
+
+/**
+ * Derive the visual phase for an agent from its state and context.
+ *
+ * - idle                              → queued
+ * - running                           → running
+ * - paused, no escalationReason       → blocked (tool approval pending)
+ * - paused, has escalationReason      → human-required (guardrail hit)
+ * - stopped, task status = in-review  → reviewing
+ * - stopped                           → done
+ */
+export function getAgentPhase(
+  state: string,
+  escalationReason?: string,
+  taskStatus?: string,
+): AgentPhase {
+  switch (state) {
+    case 'idle':
+      return 'queued'
+    case 'running':
+      return 'running'
+    case 'paused':
+      return escalationReason ? 'human-required' : 'blocked'
+    case 'stopped':
+      if (taskStatus === 'in-review') return 'reviewing'
+      return 'done'
+    default:
+      return 'done'
+  }
+}

--- a/frontend/src/lib/agent-phases.ts
+++ b/frontend/src/lib/agent-phases.ts
@@ -1,6 +1,7 @@
 export type AgentPhase =
   | 'queued'
   | 'running'
+  | 'waiting'
   | 'blocked'
   | 'human-required'
   | 'reviewing'
@@ -25,6 +26,14 @@ export const PHASE_CONFIG: Record<AgentPhase, PhaseConfig> = {
     label: 'Queued',
     dotClasses: 'bg-surface-400 dark:bg-surface-500',
     badgeClasses: 'bg-surface-200 text-surface-500 dark:bg-surface-700 dark:text-surface-400',
+    animate: false,
+    faded: false,
+  },
+  waiting: {
+    phase: 'waiting',
+    label: 'Waiting',
+    dotClasses: 'bg-surface-400 dark:bg-surface-500',
+    badgeClasses: 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-300',
     animate: false,
     faded: false,
   },
@@ -76,17 +85,19 @@ export const PHASE_CONFIG: Record<AgentPhase, PhaseConfig> = {
 /**
  * Derive the visual phase for an agent from its state and context.
  *
- * - idle                              → queued
- * - running                           → running
- * - paused, no escalationReason       → blocked (tool approval pending)
- * - paused, has escalationReason      → human-required (guardrail hit)
- * - stopped, task status = in-review  → reviewing
- * - stopped                           → done
+ * - idle                                          → queued
+ * - running                                       → running
+ * - paused, has escalationReason                  → human-required (guardrail hit)
+ * - paused, awaitingApproval=true                 → blocked (tool approval pending)
+ * - paused, neither                               → waiting (conversational, awaiting next message)
+ * - stopped, task status = in-review              → reviewing
+ * - stopped                                       → done
  */
 export function getAgentPhase(
   state: string,
   escalationReason?: string,
   taskStatus?: string,
+  awaitingApproval?: boolean,
 ): AgentPhase {
   switch (state) {
     case 'idle':
@@ -94,7 +105,9 @@ export function getAgentPhase(
     case 'running':
       return 'running'
     case 'paused':
-      return escalationReason ? 'human-required' : 'blocked'
+      if (escalationReason) return 'human-required'
+      if (awaitingApproval) return 'blocked'
+      return 'waiting'
     case 'stopped':
       if (taskStatus === 'in-review') return 'reviewing'
       return 'done'

--- a/frontend/src/pages/AgentDetail.svelte
+++ b/frontend/src/pages/AgentDetail.svelte
@@ -2,10 +2,12 @@
   import type { agent } from '../../wailsjs/go/models.js'
   import { EventsOn, RespondEscalation } from '$lib/api'
   import { agentStore } from '../stores/agents.svelte.js'
+  import { taskStore } from '../stores/tasks.svelte.js'
   import { agentState, agentEscalation, agentError } from '../lib/events.js'
   import StreamOutput from '../components/StreamOutput.svelte'
   import ChatView from '../components/ChatView.svelte'
   import AgentErrorBanner from '../components/AgentErrorBanner.svelte'
+  import { getAgentPhase, PHASE_CONFIG } from '$lib/agent-phases.js'
 
   interface EscalationEvent {
     reason: string
@@ -41,6 +43,17 @@
     a?.errorKind ? { kind: a.errorKind, msg: a.errorMsg ?? '' } : null
   )
   const displayError = $derived(errorDismissed ? null : (agentErr ?? cachedError))
+
+  const phase = $derived(
+    a
+      ? getAgentPhase(
+          a.state,
+          a.escalationReason,
+          a.taskId ? taskStore.tasks.get(a.taskId)?.status : undefined,
+        )
+      : 'done',
+  )
+  const phaseConfig = $derived(PHASE_CONFIG[phase])
 
   $effect(() => {
     const cached = agentStore.agents.get(agentId)
@@ -177,24 +190,32 @@
           {#if a.name}
             <span class="text-sm text-surface-400">{a.name}</span>
           {/if}
-          {#if a.state === 'running'}
+          {#if phase === 'running'}
             <p class="mt-0.5 text-sm italic text-surface-400">
               {agentStore.stepTexts.get(agentId) ?? 'Working...'}
+            </p>
+          {:else if phase === 'blocked'}
+            <p class="mt-0.5 text-sm text-tertiary-600 dark:text-tertiary-400">
+              Awaiting tool approval
+            </p>
+          {:else if phase === 'human-required'}
+            <p class="mt-0.5 text-sm font-medium text-error-600 dark:text-error-400">
+              Waiting for human input
+            </p>
+          {:else if phase === 'reviewing'}
+            <p class="mt-0.5 text-sm text-warning-600 dark:text-warning-400">
+              Under review
             </p>
           {/if}
         </div>
         <div class="flex items-center gap-2">
-          <span class="inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-medium
-            {a.state === 'running' ? 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200' :
-             a.state === 'paused' ? 'bg-warning-200 text-warning-800 dark:bg-warning-700 dark:text-warning-200' :
-             a.state === 'stopped' ? 'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200' :
-             'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200'}">
-            {#if isRunning}
-              <span class="h-2 w-2 animate-pulse rounded-full bg-primary-500"></span>
-            {:else if a.state === 'paused'}
-              <span class="h-2 w-2 animate-pulse rounded-full bg-warning-500"></span>
+          <span class="inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-medium {phaseConfig.badgeClasses}">
+            {#if phaseConfig.animate}
+              <span class="h-2 w-2 animate-pulse-subtle rounded-full {phaseConfig.dotClasses}"></span>
+            {:else if phase !== 'queued' && phase !== 'done'}
+              <span class="h-2 w-2 rounded-full {phaseConfig.dotClasses}"></span>
             {/if}
-            {a.state === 'paused' ? 'Waiting for input' : a.state}
+            {phaseConfig.label}
           </span>
           {#if isRunning}
             <button

--- a/frontend/src/pages/AgentDetail.svelte
+++ b/frontend/src/pages/AgentDetail.svelte
@@ -50,6 +50,7 @@
           a.state,
           a.escalationReason,
           a.taskId ? taskStore.tasks.get(a.taskId)?.status : undefined,
+          a.awaitingApproval,
         )
       : 'done',
   )
@@ -193,6 +194,10 @@
           {#if phase === 'running'}
             <p class="mt-0.5 text-sm italic text-surface-400">
               {agentStore.stepTexts.get(agentId) ?? 'Working...'}
+            </p>
+          {:else if phase === 'waiting'}
+            <p class="mt-0.5 text-sm text-surface-400">
+              Waiting for reply
             </p>
           {:else if phase === 'blocked'}
             <p class="mt-0.5 text-sm text-tertiary-600 dark:text-tertiary-400">

--- a/frontend/src/pages/AgentDetail.svelte.test.ts
+++ b/frontend/src/pages/AgentDetail.svelte.test.ts
@@ -85,7 +85,7 @@ describe('AgentDetail', () => {
       props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
     })
     await vi.waitFor(() => {
-      expect(screen.getByText(/running/)).toBeDefined()
+      expect(screen.getByText(/running/i)).toBeDefined()
     })
   })
 

--- a/frontend/src/pages/AgentList.svelte
+++ b/frontend/src/pages/AgentList.svelte
@@ -33,7 +33,7 @@
   const states = [
     { value: 'all', label: 'All' },
     { value: 'running', label: 'Running' },
-    { value: 'paused', label: 'Waiting' },
+    { value: 'paused', label: 'Paused' },
     { value: 'idle', label: 'Idle' },
     { value: 'stopped', label: 'Stopped' },
   ]

--- a/frontend/src/pages/ChatList.svelte
+++ b/frontend/src/pages/ChatList.svelte
@@ -2,6 +2,7 @@
   import type { agent } from '../../wailsjs/go/models.js'
   import { agentStore } from '../stores/agents.svelte.js'
   import { projectStore } from '../stores/projects.svelte.js'
+  import { getAgentPhase, PHASE_CONFIG } from '$lib/agent-phases.js'
   import NewChatDialog from '../components/NewChatDialog.svelte'
 
   interface Props {
@@ -26,20 +27,8 @@
     agentStore.list.filter((a: agent.Agent) => a.mode === 'interactive'),
   )
 
-  function stateColor(state: string): string {
-    switch (state) {
-      case 'running': return 'bg-success-500'
-      case 'paused': return 'bg-warning-500'
-      default: return 'bg-surface-400'
-    }
-  }
-
-  function stateLabel(state: string): string {
-    switch (state) {
-      case 'running': return 'Running'
-      case 'paused': return 'Idle'
-      default: return 'Stopped'
-    }
+  function agentPhaseConfig(a: agent.Agent) {
+    return PHASE_CONFIG[getAgentPhase(a.state, a.escalationReason, undefined, a.awaitingApproval)]
   }
 
   function timeAgo(date: string | undefined): string {
@@ -90,8 +79,8 @@
           onclick={() => onselect(a.id)}
         >
           <!-- Status dot -->
-          <span class="h-2.5 w-2.5 shrink-0 rounded-full {stateColor(a.state)}
-            {a.state === 'running' || a.state === 'paused' ? 'animate-pulse' : ''}"></span>
+          <span class="h-2.5 w-2.5 shrink-0 rounded-full {agentPhaseConfig(a).dotClasses}
+            {agentPhaseConfig(a).animate ? 'animate-pulse' : ''}"></span>
 
           <!-- Content -->
           <div class="min-w-0 flex-1">
@@ -106,7 +95,7 @@
               {/if}
             </div>
             <p class="mt-0.5 text-xs text-surface-500">
-              {stateLabel(a.state)}
+              {agentPhaseConfig(a).label}
             </p>
           </div>
 

--- a/frontend/src/pages/Dashboard.svelte
+++ b/frontend/src/pages/Dashboard.svelte
@@ -60,7 +60,7 @@
       <p class="mt-1 text-2xl font-bold text-success-600 dark:text-success-400">{runningAgents.length}</p>
     </div>
     <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
-      <span class="text-xs font-medium text-surface-500">Waiting for Input</span>
+      <span class="text-xs font-medium text-surface-500">Paused Agents</span>
       <p class="mt-1 text-2xl font-bold text-warning-600 dark:text-warning-400">{pausedAgents.length}</p>
     </div>
     <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">

--- a/frontend/src/pages/Dashboard.test.ts
+++ b/frontend/src/pages/Dashboard.test.ts
@@ -102,7 +102,7 @@ describe('Dashboard', () => {
     render(Dashboard, { props: { onviewagent: vi.fn() } })
 
     expect(screen.getByText('Running Agents')).toBeTruthy()
-    expect(screen.getByText('Waiting for Input')).toBeTruthy()
+    expect(screen.getByText('Paused Agents')).toBeTruthy()
     expect(screen.getByText('Total Tasks')).toBeTruthy()
     expect(screen.getByText('Total Cost')).toBeTruthy()
   })

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -26,6 +26,8 @@ export namespace agent {
 	    errorKind?: string;
 	    errorMsg?: string;
 	
+	    awaitingApproval?: boolean;
+
 	    static createFrom(source: any = {}) {
 	        return new Agent(source);
 	    }
@@ -54,6 +56,7 @@ export namespace agent {
 	        this.escalationReason = source["escalationReason"];
 	        this.errorKind = source["errorKind"];
 	        this.errorMsg = source["errorMsg"];
+	        this.awaitingApproval = source["awaitingApproval"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -25,9 +25,8 @@ export namespace agent {
 	    escalationReason?: string;
 	    errorKind?: string;
 	    errorMsg?: string;
-	
 	    awaitingApproval?: boolean;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new Agent(source);
 	    }

--- a/internal/agent/approval_server.go
+++ b/internal/agent/approval_server.go
@@ -145,9 +145,10 @@ func (s *ApprovalServer) handlePreToolUse(w http.ResponseWriter, r *http.Request
 	}
 	s.emit(events.AgentApproval(agentID), req)
 
-	// Update agent state to paused.
+	// Update agent state to paused, flagged as awaiting tool approval.
 	if s.agents != nil {
 		if a, err := s.agents.GetAgent(agentID); err == nil {
+			a.SetAwaitingApproval(true)
 			a.SetState(StatePaused)
 			s.emit(events.AgentState(agentID), a)
 		}
@@ -158,6 +159,7 @@ func (s *ApprovalServer) handlePreToolUse(w http.ResponseWriter, r *http.Request
 	case resp := <-ch:
 		if s.agents != nil {
 			if a, err := s.agents.GetAgent(agentID); err == nil {
+				a.SetAwaitingApproval(false)
 				a.SetState(StateRunning)
 				s.emit(events.AgentState(agentID), a)
 			}

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -53,6 +53,7 @@ type Agent struct {
 	EscalationReason string `json:"escalationReason,omitempty"`
 	ErrorKind        string `json:"errorKind,omitempty"`
 	ErrorMsg         string `json:"errorMsg,omitempty"`
+	AwaitingApproval bool   `json:"awaitingApproval,omitempty"`
 
 	ExitErr         error `json:"-"`
 	outputBuffer    []StreamEvent
@@ -96,6 +97,13 @@ type Agent struct {
 func (a *Agent) SetState(s State) {
 	a.mu.Lock()
 	a.State = s
+	a.mu.Unlock()
+}
+
+// SetAwaitingApproval marks whether the agent is paused pending tool approval.
+func (a *Agent) SetAwaitingApproval(v bool) {
+	a.mu.Lock()
+	a.AwaitingApproval = v
 	a.mu.Unlock()
 }
 


### PR DESCRIPTION
## Motivation

Each agent lifecycle phase needs a distinct visual signature so users can scan the board at a glance and immediately understand what each agent is doing. Previously all states shared the same visual treatment with only a text label difference.

Closes https://github.com/Automaat/synapse/issues/449

## Implementation information

Introduced a phase derivation layer (`agent-phases.ts`) that maps agent state + context to 6 named visual phases:

- **Queued** — gray dot, muted text
- **Running** — pulsing blue dot + "Running" badge
- **Blocked** — amber dot, warning tone
- **Human-required** — orange dot + prominent callout banner
- **Reviewing** — purple dot (code review phase)
- **Done** — muted green dot, faded row

Each phase carries a config object (dot color, badge label, animate flag, faded flag) consumed by `AgentCard` and `AgentDetail`.

Follow-up fix addressed review comments: added connection status indicator to `App.svelte`, surfaced a new `blocked` agent state from the Go model, and refined phase detection logic.