### PR TITLE
feat(workflow): critique fix loop before review

### DIFF
--- a/internal/workflow/builtin/simple-task.yaml
+++ b/internal/workflow/builtin/simple-task.yaml
@@ -145,6 +145,36 @@ steps:
         - Skill
         - Agent
     next:
+      - goto: reset_for_address
+
+  - id: reset_for_address
+    name: Reset for Critique Address
+    type: set_status
+    config:
+      status: planning
+    next:
+      - goto: address_critique
+
+  - id: address_critique
+    name: Address Critique
+    type: run_agent
+    config:
+      role: plan
+      mode: interactive
+      model: opus
+      reuse_agent: true
+      wait_for_status: plan-review
+      prompt: >-
+        The plan critic has reviewed your plan for task {{.Task.ID}}.
+
+        Steps:
+          1. synapse-cli --json get {{.Task.ID}} — read the .plan_critique field
+          2. For each concern raised, revise the plan to address it
+          3. synapse-cli update {{.Task.ID}} --plan "<full revised plan markdown>"
+          4. synapse-cli update {{.Task.ID}} --status plan-review
+
+        Then STOP and wait. Do NOT implement.
+    next:
       - goto: review_plan
 
   - id: review_plan


### PR DESCRIPTION
## Motivation

Plan-critic ran and wrote feedback, but the workflow immediately surfaced
the task to the human as `plan-review` — the plan agent never saw or
addressed the critique. Human was reviewing an unimproved plan.

## Implementation information

Added two steps between `critique_plan` and `review_plan`:

- `reset_for_address` — sets status back to `planning` so the subsequent
  `wait_for_status: plan-review` fires correctly (same pattern as
  `start_replan`)
- `address_critique` — re-engages the interactive plan agent via
  `reuse_agent: true`, instructs it to read `.plan_critique`, revise
  the plan, and set status to `plan-review` when done

Only then does `review_plan` activate and the human sees the result.
Tasks tagged `nocritic` skip both `critique_plan` and `address_critique`
via the existing `maybe_critique` branch.

> Changelog: feat(workflow): critique fix loop before review