### PR TITLE
feat(task): inline editing for title, status, tags, date

### DIFF
--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -7,7 +7,7 @@
   import { agentStore } from '../stores/agents.svelte.js'
   import { reviewStore } from '../stores/reviews.svelte.js'
   import { connectionStore } from '../stores/connection.svelte.js'
-  import { STATUS_OPTIONS } from '../lib/statuses.js'
+  import { STATUS_OPTIONS, STATUS_MAP } from '../lib/statuses.js'
   import StreamOutput from '../components/StreamOutput.svelte'
   import ChatView from '../components/ChatView.svelte'
   import ProviderLogo from '../components/ProviderLogo.svelte'
@@ -31,7 +31,7 @@
 
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === 'Escape') {
-      if (editingTitle || editingBody) return
+      if (editingTitle || editingBody || editingTags || editingDueDate) return
       onback()
       return
     }
@@ -71,6 +71,21 @@
   let bodyDraft = $state('')
   let editingTitle = $state(false)
   let titleDraft = $state('')
+  let editingTags = $state(false)
+  let tagsDraft = $state<string[]>([])
+  let tagInput = $state('')
+  let tagInputRef = $state<HTMLInputElement | null>(null)
+  let editingDueDate = $state(false)
+  let dueDateDraft = $state('')
+  let dueDateInputRef = $state<HTMLInputElement | null>(null)
+
+  $effect(() => {
+    if (editingTags && tagInputRef) tagInputRef.focus()
+  })
+
+  $effect(() => {
+    if (editingDueDate && dueDateInputRef) dueDateInputRef.focus()
+  })
 
   let t = $state<task.Task | null>(null)
   let error = $state('')
@@ -193,6 +208,165 @@
       saveBody()
     } else if (e.key === 'Escape') {
       editingBody = false
+    }
+  }
+
+  function startEditingTags() {
+    if (!t) return
+    tagsDraft = [...(t.tags ?? [])]
+    tagInput = ''
+    editingTags = true
+  }
+
+  function addTag() {
+    const tag = tagInput.trim().replace(/,/g, '')
+    if (tag && !tagsDraft.includes(tag)) tagsDraft = [...tagsDraft, tag]
+    tagInput = ''
+  }
+
+  function removeTag(tag: string) {
+    tagsDraft = tagsDraft.filter((x) => x !== tag)
+  }
+
+  async function saveTags() {
+    editingTags = false
+    if (!t) return
+    const current = t.tags ?? []
+    const same =
+      current.length === tagsDraft.length && current.every((v, i) => v === tagsDraft[i])
+    if (same) return
+    try {
+      t = await taskStore.update(taskId, { tags: tagsDraft })
+    } catch (e) {
+      error = String(e)
+    }
+  }
+
+  function handleTagInputKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      if (tagInput.trim()) {
+        addTag()
+      } else {
+        saveTags()
+      }
+    } else if (e.key === 'Escape') {
+      editingTags = false
+    } else if (e.key === 'Backspace' && !tagInput && tagsDraft.length > 0) {
+      tagsDraft = tagsDraft.slice(0, -1)
+    } else if (e.key === ',') {
+      e.preventDefault()
+      addTag()
+    }
+  }
+
+  function handleTagsContainerFocusout(e: FocusEvent) {
+    const related = e.relatedTarget as Node | null
+    const container = e.currentTarget as HTMLElement
+    if (!related || !container.contains(related)) saveTags()
+  }
+
+  function parseNaturalDate(input: string): Date | null {
+    const lower = input.toLowerCase().trim()
+    if (!lower || lower === 'none' || lower === 'clear') return null
+    const now = new Date()
+    if (lower === 'today') {
+      const d = new Date(now)
+      d.setHours(23, 59, 59, 0)
+      return d
+    }
+    if (lower === 'tomorrow') {
+      const d = new Date(now)
+      d.setDate(d.getDate() + 1)
+      d.setHours(23, 59, 59, 0)
+      return d
+    }
+    if (lower === 'yesterday') {
+      const d = new Date(now)
+      d.setDate(d.getDate() - 1)
+      d.setHours(23, 59, 59, 0)
+      return d
+    }
+    const weekdays = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday']
+    const nextMatch = lower.match(/^(?:next\s+)?(\w+)$/)
+    if (nextMatch) {
+      const day = weekdays.indexOf(nextMatch[1])
+      if (day !== -1) {
+        const d = new Date(now)
+        const current = d.getDay()
+        const diff = ((day - current + 7) % 7) || 7
+        d.setDate(d.getDate() + diff)
+        d.setHours(23, 59, 59, 0)
+        return d
+      }
+    }
+    const inMatch = lower.match(/^in\s+(\d+)\s+(day|days|week|weeks)$/)
+    if (inMatch) {
+      const n = parseInt(inMatch[1])
+      const d = new Date(now)
+      d.setDate(d.getDate() + (inMatch[2].startsWith('week') ? n * 7 : n))
+      d.setHours(23, 59, 59, 0)
+      return d
+    }
+    const parsed = new Date(input)
+    return isNaN(parsed.getTime()) ? null : parsed
+  }
+
+  function formatDueDateDisplay(date: any): string {
+    if (!date) return 'Set due date'
+    const d = new Date(date)
+    if (isNaN(d.getTime())) return 'Set due date'
+    const now = new Date()
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+    const target = new Date(d.getFullYear(), d.getMonth(), d.getDate())
+    const diff = Math.round((target.getTime() - today.getTime()) / 86400000)
+    if (diff === 0) return 'Today'
+    if (diff === 1) return 'Tomorrow'
+    if (diff === -1) return 'Yesterday'
+    if (diff > 1 && diff < 7) return `In ${diff} days`
+    if (diff < 0) return `${Math.abs(diff)}d overdue`
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: d.getFullYear() !== now.getFullYear() ? 'numeric' : undefined })
+  }
+
+  function startEditingDueDate() {
+    if (!t) return
+    if (t.dueDate) {
+      const d = new Date(t.dueDate)
+      dueDateDraft = isNaN(d.getTime()) ? '' : d.toISOString().split('T')[0]
+    } else {
+      dueDateDraft = ''
+    }
+    editingDueDate = true
+  }
+
+  async function saveDueDate() {
+    editingDueDate = false
+    if (!t) return
+    const input = dueDateDraft.trim()
+    let newVal: string | null = null
+    if (input && input.toLowerCase() !== 'none' && input.toLowerCase() !== 'clear') {
+      const parsed = parseNaturalDate(input)
+      if (!parsed) {
+        error = `Invalid date: "${input}". Try "today", "tomorrow", "next monday", "in 3 days", or YYYY-MM-DD.`
+        return
+      }
+      newVal = parsed.toISOString()
+    }
+    const currentISO = t.dueDate ? new Date(t.dueDate).toISOString() : null
+    if (newVal === currentISO) return
+    try {
+      t = await taskStore.update(taskId, { due_date: newVal })
+    } catch (e) {
+      error = String(e)
+    }
+  }
+
+  function handleDueDateKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      saveDueDate()
+    } else if (e.key === 'Escape') {
+      editingDueDate = false
     }
   }
 
@@ -366,9 +540,11 @@
           <select
             bind:this={statusSelectRef}
             data-testid="task-status-select"
-            class="rounded border border-surface-300 bg-surface-100 px-2 py-0.5 text-xs font-medium dark:border-surface-600 dark:bg-surface-700"
+            class="cursor-pointer rounded-full px-2.5 py-0.5 text-xs font-semibold transition-opacity hover:opacity-80 {STATUS_MAP[t.status]?.badgeClasses ?? 'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200'}"
+            style="appearance: auto"
             value={t.status}
             onchange={(e) => updateStatus((e.target as HTMLSelectElement).value)}
+            title="Click to change status"
           >
             {#each statusOptions as s}
               <option value={s.value}>{s.label}</option>
@@ -465,16 +641,51 @@
           <span class="rounded bg-surface-200 px-2 py-0.5 dark:bg-surface-700">{t.agentMode}</span>
         </div>
 
-        {#if t.tags?.length}
-          <div class="flex flex-col gap-1">
-            <span class="font-medium text-surface-500">Tags</span>
-            <div class="flex gap-1">
-              {#each t.tags as tag}
-                <span class="rounded bg-surface-200 px-2 py-0.5 dark:bg-surface-700">{tag}</span>
+        <div class="flex flex-col gap-1">
+          <span class="font-medium text-surface-500">Tags</span>
+          {#if editingTags}
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
+            <div
+              class="flex min-w-[8rem] flex-wrap items-center gap-1 rounded-lg border border-primary-400 bg-surface-50 px-2 py-1 dark:border-primary-500 dark:bg-surface-900"
+              onfocusout={handleTagsContainerFocusout}
+            >
+              {#each tagsDraft as tag}
+                <span class="inline-flex items-center gap-0.5 rounded bg-surface-200 px-1.5 py-0.5 text-xs dark:bg-surface-700">
+                  {tag}
+                  <button
+                    type="button"
+                    class="ml-0.5 text-surface-400 hover:text-error-500"
+                    onclick={() => removeTag(tag)}
+                    tabindex="-1"
+                    aria-label="Remove tag {tag}"
+                  >×</button>
+                </span>
               {/each}
+              <input
+                bind:this={tagInputRef}
+                bind:value={tagInput}
+                class="min-w-[4rem] flex-1 bg-transparent text-xs outline-none"
+                placeholder={tagsDraft.length ? '' : 'add tags...'}
+                onkeydown={handleTagInputKeydown}
+              />
             </div>
-          </div>
-        {/if}
+          {:else}
+            <button
+              type="button"
+              class="flex flex-wrap items-center gap-1 rounded-lg border border-transparent px-1 py-0.5 text-left transition-colors hover:border-surface-300 hover:bg-surface-100 dark:hover:border-surface-600 dark:hover:bg-surface-800"
+              onclick={startEditingTags}
+              title="Click to edit tags"
+            >
+              {#if t.tags?.length}
+                {#each t.tags as tag}
+                  <span class="rounded bg-surface-200 px-2 py-0.5 text-xs dark:bg-surface-700">{tag}</span>
+                {/each}
+              {:else}
+                <span class="text-xs italic text-surface-400">add tags</span>
+              {/if}
+            </button>
+          {/if}
+        </div>
 
         {#if t.projectId}
           <div class="flex flex-col gap-1">
@@ -617,9 +828,32 @@
         </div>
       {/if}
 
-      <div class="flex gap-6 text-xs text-surface-400">
+      <div class="flex flex-wrap items-center gap-4 text-xs text-surface-400">
         <span>Created: {formatDate(t.createdAt)}</span>
         <span>Updated: {formatDate(t.updatedAt)}</span>
+        <div class="flex items-center gap-1">
+          <span>Due:</span>
+          {#if editingDueDate}
+            <input
+              bind:this={dueDateInputRef}
+              bind:value={dueDateDraft}
+              class="rounded border border-primary-400 bg-surface-50 px-2 py-0.5 text-xs outline-none dark:border-primary-500 dark:bg-surface-900"
+              placeholder="today / tomorrow / YYYY-MM-DD"
+              onblur={saveDueDate}
+              onkeydown={handleDueDateKeydown}
+            />
+            <span class="text-surface-300 dark:text-surface-600">Esc to cancel</span>
+          {:else}
+            <button
+              type="button"
+              class="rounded px-1 py-0.5 transition-colors hover:bg-surface-200 hover:text-surface-700 dark:hover:bg-surface-700 dark:hover:text-surface-300 {t.dueDate && new Date(t.dueDate) < new Date() ? 'text-error-500 dark:text-error-400' : ''}"
+              onclick={startEditingDueDate}
+              title="Click to set due date"
+            >
+              {formatDueDateDisplay(t.dueDate)}
+            </button>
+          {/if}
+        </div>
       </div>
 
       {#if t.status === 'plan-review'}

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1308,6 +1308,8 @@ export namespace task {
 	    reviewed: boolean;
 	    runRole: string;
 	    todoistId: string;
+	    // Go type: time
+	    dueDate?: any;
 	    requirePermissions?: boolean;
 	    agentRuns: AgentRun[];
 	    workflow?: workflow.Execution;
@@ -1342,6 +1344,7 @@ export namespace task {
 	        this.reviewed = source["reviewed"];
 	        this.runRole = source["runRole"];
 	        this.todoistId = source["todoistId"];
+	        this.dueDate = this.convertValues(source["dueDate"], null);
 	        this.requirePermissions = source["requirePermissions"];
 	        this.agentRuns = this.convertValues(source["agentRuns"], AgentRun);
 	        this.workflow = this.convertValues(source["workflow"], workflow.Execution);

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -112,21 +112,21 @@ type AgentRun struct {
 }
 
 type Task struct {
-	ID           string   `yaml:"id" json:"id"`
-	Slug         string   `yaml:"slug,omitempty" json:"slug"`
-	Title        string   `yaml:"title" json:"title"`
-	Status       Status   `yaml:"status" json:"status"`
-	TaskType     TaskType `yaml:"task_type,omitempty" json:"taskType"`
-	AgentMode    string   `yaml:"agent_mode" json:"agentMode"`
-	AllowedTools []string `yaml:"allowed_tools" json:"allowedTools"`
-	Tags         []string `yaml:"tags" json:"tags"`
-	ProjectID    string   `yaml:"project_id,omitempty" json:"projectId"`
-	Branch       string   `yaml:"branch,omitempty" json:"branch"`
-	PRNumber     int      `yaml:"pr_number,omitempty" json:"prNumber"`
-	Issue        string   `yaml:"issue,omitempty" json:"issue"`
-	StatusReason string   `yaml:"status_reason,omitempty" json:"statusReason"`
-	Reviewed     bool     `yaml:"reviewed,omitempty" json:"reviewed"`
-	RunRole      string   `yaml:"run_role,omitempty" json:"runRole"` // pr-fix when fixing review issues, "" for initial impl
+	ID           string     `yaml:"id" json:"id"`
+	Slug         string     `yaml:"slug,omitempty" json:"slug"`
+	Title        string     `yaml:"title" json:"title"`
+	Status       Status     `yaml:"status" json:"status"`
+	TaskType     TaskType   `yaml:"task_type,omitempty" json:"taskType"`
+	AgentMode    string     `yaml:"agent_mode" json:"agentMode"`
+	AllowedTools []string   `yaml:"allowed_tools" json:"allowedTools"`
+	Tags         []string   `yaml:"tags" json:"tags"`
+	ProjectID    string     `yaml:"project_id,omitempty" json:"projectId"`
+	Branch       string     `yaml:"branch,omitempty" json:"branch"`
+	PRNumber     int        `yaml:"pr_number,omitempty" json:"prNumber"`
+	Issue        string     `yaml:"issue,omitempty" json:"issue"`
+	StatusReason string     `yaml:"status_reason,omitempty" json:"statusReason"`
+	Reviewed     bool       `yaml:"reviewed,omitempty" json:"reviewed"`
+	RunRole      string     `yaml:"run_role,omitempty" json:"runRole"` // pr-fix when fixing review issues, "" for initial impl
 	TodoistID    string     `yaml:"todoist_id,omitempty" json:"todoistId"`
 	DueDate      *time.Time `yaml:"due_date,omitempty" json:"dueDate,omitempty"`
 	// RequirePermissions overrides the system default when set.

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -127,7 +127,8 @@ type Task struct {
 	StatusReason string   `yaml:"status_reason,omitempty" json:"statusReason"`
 	Reviewed     bool     `yaml:"reviewed,omitempty" json:"reviewed"`
 	RunRole      string   `yaml:"run_role,omitempty" json:"runRole"` // pr-fix when fixing review issues, "" for initial impl
-	TodoistID    string   `yaml:"todoist_id,omitempty" json:"todoistId"`
+	TodoistID    string     `yaml:"todoist_id,omitempty" json:"todoistId"`
+	DueDate      *time.Time `yaml:"due_date,omitempty" json:"dueDate,omitempty"`
 	// RequirePermissions overrides the system default when set.
 	// nil = use system default (true). false = opt out (--dangerously-skip-permissions).
 	RequirePermissions *bool               `yaml:"require_permissions,omitempty" json:"requirePermissions,omitempty"`

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -235,6 +235,9 @@ func (s *Store) Update(id string, u Update) (Task, error) {
 	if u.TodoistID != nil {
 		t.TodoistID = *u.TodoistID
 	}
+	if u.DueDate != nil {
+		t.DueDate = *u.DueDate
+	}
 	if u.Workflow != nil {
 		t.Workflow = *u.Workflow
 	}
@@ -348,6 +351,10 @@ func cloneTask(t Task) Task {
 	clone.AllowedTools = slices.Clone(t.AllowedTools)
 	clone.Tags = slices.Clone(t.Tags)
 	clone.AgentRuns = slices.Clone(t.AgentRuns)
+	if t.DueDate != nil {
+		d := *t.DueDate
+		clone.DueDate = &d
+	}
 	if t.Workflow != nil {
 		wfClone := cloneWorkflow(*t.Workflow)
 		clone.Workflow = &wfClone

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -3,6 +3,7 @@ package task
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Automaat/synapse/internal/workflow"
 )
@@ -26,6 +27,7 @@ type Update struct {
 	Reviewed     *bool
 	RunRole      *string
 	TodoistID    *string
+	DueDate      **time.Time
 	Workflow     **workflow.Execution
 	Plan         *string
 	PlanCritique *string
@@ -66,6 +68,8 @@ func applyMapField(u *Update, k string, v any) error {
 		return applyTagsField(u, k, v)
 	case "pr_number":
 		return applyPRNumberField(u, k, v)
+	case "due_date":
+		return applyDueDateField(u, v)
 	case "reviewed":
 		b, ok := v.(bool)
 		if !ok {
@@ -180,5 +184,29 @@ func applyPRNumberField(u *Update, k string, v any) error {
 	default:
 		return fmt.Errorf("field %q: want int or float64, got %T", k, v)
 	}
+	return nil
+}
+
+func applyDueDateField(u *Update, v any) error {
+	if v == nil {
+		var nilTime *time.Time
+		u.DueDate = &nilTime
+		return nil
+	}
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("field \"due_date\": want string or nil, got %T", v)
+	}
+	if s == "" {
+		var nilTime *time.Time
+		u.DueDate = &nilTime
+		return nil
+	}
+	parsed, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return fmt.Errorf("field \"due_date\": invalid RFC3339 date %q: %w", s, err)
+	}
+	tp := &parsed
+	u.DueDate = &tp
 	return nil
 }


### PR DESCRIPTION
## Motivation

Closes https://github.com/Automaat/synapse/issues/457

Task detail view required navigating away or using external tooling to update basic task metadata. Inline editing for title, status, tags, and due date removes that friction — all core fields are editable in place without leaving the detail panel.

## Implementation information

**Frontend (`TaskDetail.svelte`):**
- Status: badge-style pill `<select>` with per-status color mapping
- Tags: chip-area edit mode — type to add, backspace removes last, comma/Enter confirms, blur saves
- Due date: new optional field; click to edit with natural language parsing (`today`, `tomorrow`, `next monday`, `in N days`) or ISO date; overdue dates shown in error color

**Backend:**
- `DueDate *time.Time` added to `Task` model (RFC3339 round-trip via Wails)
- `UpdateFromMap` extended to handle `due_date`
- `Store.Update` persists the new field
- `cloneTask` copies it correctly