### PR TITLE
feat(ui): agent-task visual linkage

### DIFF
--- a/frontend/src/components/AgentCard.svelte
+++ b/frontend/src/components/AgentCard.svelte
@@ -12,11 +12,13 @@
 
   const { agent: a, onclick }: Props = $props()
 
+  const linkedTask = $derived(a.taskId ? taskStore.tasks.get(a.taskId) : null)
+
   const phase = $derived(
     getAgentPhase(
       a.state,
       a.escalationReason,
-      a.taskId ? taskStore.tasks.get(a.taskId)?.status : undefined,
+      linkedTask?.status,
       a.awaitingApproval,
     ),
   )
@@ -88,7 +90,10 @@
       <span class="rounded bg-surface-200 px-1.5 py-0.5 dark:bg-surface-700">{a.project}</span>
     {/if}
     {#if a.taskId}
-      <span class="rounded bg-surface-200 px-1.5 py-0.5 dark:bg-surface-700">task: {a.taskId}</span>
+      <span class="rounded bg-surface-200 px-1.5 py-0.5 dark:bg-surface-700">{linkedTask?.title ?? a.taskId}</span>
+    {/if}
+    {#if linkedTask?.branch}
+      <span class="rounded bg-surface-200 px-1.5 py-0.5 font-mono dark:bg-surface-700">{linkedTask.branch.replace(/^synapse\//, '')}</span>
     {/if}
     {#if a.costUsd > 0}
       <span class="rounded bg-surface-200 px-1.5 py-0.5 dark:bg-surface-700">${a.costUsd.toFixed(2)}</span>

--- a/frontend/src/components/AgentCard.svelte.test.ts
+++ b/frontend/src/components/AgentCard.svelte.test.ts
@@ -95,7 +95,7 @@ describe('AgentCard', () => {
 
   it('shows taskId when present', () => {
     render(AgentCard, { props: { agent: makeAgent({ taskId: 'task-1' }), onclick: () => {} } })
-    expect(screen.getByText('task: task-1')).toBeDefined()
+    expect(screen.getByText('task-1')).toBeDefined()
   })
 
   it('calls onclick when clicked', async () => {

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -37,6 +37,13 @@
     (agentStore.list ?? []).some((a) => a.taskId === t.id && a.state === 'running' && !a.name?.startsWith('triage:') && !a.name?.startsWith('eval:') && !a.name?.startsWith('plan:'))
   )
 
+  const hasRunningAgent = $derived(
+    (agentStore.list ?? []).some((a) => a.taskId === t.id && a.state === 'running')
+  )
+
+  // Statuses that conflict with a running agent — cannot move to these while agent is active
+  const AGENT_BLOCKED_STATUSES = new Set(['new', 'todo', 'done'])
+
   const linkedPRs = $derived(reviewStore.byTask(t))
   const topPR = $derived(linkedPRs.length > 0 ? linkedPRs[0] : null)
 
@@ -91,6 +98,13 @@
     {#if t.projectId}
       <span class="rounded bg-primary-100 px-1.5 py-0.5 text-primary-700 dark:bg-primary-800 dark:text-primary-300">
         {t.projectId}
+      </span>
+    {/if}
+
+    {#if t.branch}
+      <span class="inline-flex items-center gap-1 rounded bg-surface-200 px-1.5 py-0.5 font-mono dark:bg-surface-700">
+        <svg class="h-3 w-3 shrink-0" viewBox="0 0 16 16" fill="currentColor"><title>Branch</title><path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.493 2.493 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Z"/></svg>
+        {t.branch.replace(/^synapse\//, '')}
       </span>
     {/if}
 
@@ -179,7 +193,7 @@
         aria-label="Change status"
       >
         {#each STATUS_OPTIONS as opt}
-          <option value={opt.value}>{opt.label}</option>
+          <option value={opt.value} disabled={hasRunningAgent && AGENT_BLOCKED_STATUSES.has(opt.value)}>{opt.label}</option>
         {/each}
       </select>
     </div>

--- a/frontend/src/pages/AgentDetail.svelte
+++ b/frontend/src/pages/AgentDetail.svelte
@@ -44,12 +44,14 @@
   )
   const displayError = $derived(errorDismissed ? null : (agentErr ?? cachedError))
 
+  const linkedTask = $derived(a?.taskId ? taskStore.tasks.get(a.taskId) : null)
+
   const phase = $derived(
     a
       ? getAgentPhase(
           a.state,
           a.escalationReason,
-          a.taskId ? taskStore.tasks.get(a.taskId)?.status : undefined,
+          linkedTask?.status,
           a.awaitingApproval,
         )
       : 'done',
@@ -243,8 +245,14 @@
               class="text-left text-primary-500 hover:underline"
               onclick={() => onviewtask(a!.taskId)}
             >
-              {a.taskId}
+              {linkedTask?.title ?? a.taskId}
             </button>
+          </div>
+        {/if}
+        {#if linkedTask?.branch}
+          <div class="flex flex-col gap-1">
+            <span class="font-medium text-surface-500">Branch</span>
+            <span class="rounded bg-surface-200 px-2 py-0.5 font-mono text-xs dark:bg-surface-700">{linkedTask.branch}</span>
           </div>
         {/if}
         <div class="flex flex-col gap-1">

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -382,6 +382,13 @@
     }
   }
 
+  const hasRunningAgent = $derived(
+    (agentStore.list ?? []).some((a) => a.taskId === taskId && a.state === 'running')
+  )
+
+  // Statuses that conflict with a running agent
+  const AGENT_BLOCKED_STATUSES = new Set(['new', 'todo', 'done'])
+
   const triaging = $derived(
     (agentStore.list ?? []).some((a) => a.taskId === taskId && a.name?.startsWith('triage:') && a.state === 'running')
   )
@@ -547,7 +554,7 @@
             title="Click to change status"
           >
             {#each statusOptions as s}
-              <option value={s.value}>{s.label}</option>
+              <option value={s.value} disabled={hasRunningAgent && AGENT_BLOCKED_STATUSES.has(s.value)}>{s.label}</option>
             {/each}
           </select>
           <select

--- a/internal/synapse/app_reviews.go
+++ b/internal/synapse/app_reviews.go
@@ -346,6 +346,10 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 
 		closedPRs := github.DetectClosedTaskPRs(summary.CreatedByMe, matchers, github.FetchPRState)
 		for _, c := range closedPRs {
+			if r.agents.HasRunningAgentForTask(c.TaskID) {
+				r.logger.Info("pr-monitor.closed-skip-running-agent", "task_id", c.TaskID, "pr", c.PRNumber)
+				continue
+			}
 			if _, err := r.tasks.Update(c.TaskID, task.Update{Status: task.Ptr(task.StatusDone)}); err != nil {
 				r.logger.Error("pr-monitor.closed-update", "task_id", c.TaskID, "err", err)
 				continue

--- a/internal/synapse/svc_tasks.go
+++ b/internal/synapse/svc_tasks.go
@@ -102,12 +102,25 @@ func (s *TaskService) CreateTask(title, body, mode string) (task.Task, error) {
 func (s *TaskService) UpdateTask(id string, updates map[string]any) (task.Task, error) {
 	cur, _ := s.tasks.Get(id)
 
-	if status, ok := updates["status"].(string); ok && status == string(task.StatusTesting) {
-		if cur.Workflow != nil &&
-			cur.Workflow.State != workflow.ExecCompleted &&
-			cur.Workflow.State != workflow.ExecFailed {
-			return cur, fmt.Errorf("cannot move to testing: task has active workflow %q (state=%s)",
-				cur.Workflow.WorkflowID, cur.Workflow.State)
+	if status, ok := updates["status"].(string); ok {
+		// Reject status regressions while an agent is running on this task.
+		// Moving back to todo/new/done while an agent is active loses in-flight work.
+		agentBlockedStatuses := map[string]bool{
+			string(task.StatusNew):  true,
+			string(task.StatusTodo): true,
+			string(task.StatusDone): true,
+		}
+		if agentBlockedStatuses[status] && s.agents.HasRunningAgentForTask(id) {
+			return cur, fmt.Errorf("cannot move to %q: stop the running agent first", status)
+		}
+
+		if status == string(task.StatusTesting) {
+			if cur.Workflow != nil &&
+				cur.Workflow.State != workflow.ExecCompleted &&
+				cur.Workflow.State != workflow.ExecFailed {
+				return cur, fmt.Errorf("cannot move to testing: task has active workflow %q (state=%s)",
+					cur.Workflow.WorkflowID, cur.Workflow.State)
+			}
 		}
 	}
 	t, err := s.tasks.UpdateMap(id, updates)


### PR DESCRIPTION
## Motivation

Agents and tasks were visually disconnected — agent cards showed raw task IDs and task cards had no indication of an active agent. Users couldn't easily correlate what was running with what task it belonged to.

## Implementation information

- `AgentCard`/`AgentDetail`: display task title + branch name (with `synapse/` prefix stripped) instead of raw task ID
- `TaskCard`: branch badge showing the active worktree branch
- `TaskCard`/`TaskDetail`: status dropdown disabled for `todo`/`new`/`done` transitions while an agent is running on that task
- `svc_tasks`: rejects status regression while an agent is active to prevent race conditions
- `app_reviews`: guards closed-PR done transition behind `HasRunningAgentForTask` check

Closes https://github.com/Automaat/synapse/issues/452