### PR TITLE
feat(ui): replace inline SVGs with lucide icons

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@lucide/svelte": "^1.8.0",
         "@xyflow/svelte": "^1.5.2",
         "highlight.js": "^11.11.1",
         "marked": "^18.0.0",
@@ -453,6 +454,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lucide/svelte": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@lucide/svelte/-/svelte-1.8.0.tgz",
+      "integrity": "sha512-+zYQUKqEOVP5lxbGmxL1OVgGMQtRK91eIJ0bR+3Cr1ts4oQEsQfxyzzd5X47psJlblAuGFrl2xm4YuATjR9oaA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "svelte": "^5"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "vitest": "4.1.2"
   },
   "dependencies": {
+    "@lucide/svelte": "^1.8.0",
     "@xyflow/svelte": "^1.5.2",
     "highlight.js": "^11.11.1",
     "marked": "^18.0.0",

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -31,6 +31,7 @@
   import ToastContainer from './components/ToastContainer.svelte'
   import CommandPalette from './components/CommandPalette.svelte'
   import KeyboardHelp from './components/KeyboardHelp.svelte'
+  import { Cloud, AlertTriangle } from '@lucide/svelte'
 
   type SimplePageKind = 'dashboard' | 'task-list' | 'project-list' | 'chats' | 'agents' | 'github' | 'reviews' | 'stats' | 'settings' | 'workflows'
 
@@ -236,9 +237,7 @@
 <AppShell onsearch={() => (commandPaletteOpen = true)} {primaryAction}>
   {#if !connectionStore.online}
     <div class="flex shrink-0 items-center gap-2 border-b border-warning-600 bg-warning-800/90 px-4 py-2 text-sm text-warning-100">
-      <svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z" />
-      </svg>
+      <Cloud size={16} class="shrink-0" />
       <span>
         <strong>Offline</strong> — task board is read-only.
         {connectionStore.networkOnline ? 'Backend unreachable.' : 'No network connection.'}
@@ -251,9 +250,7 @@
     <div class="flex shrink-0 flex-col gap-0.5">
       {#each unhealthyProviders as p (p.provider)}
         <div class="flex items-center gap-2 bg-error-800/90 border-b border-error-600 px-4 py-2 text-error-100 text-sm">
-          <svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
-          </svg>
+          <AlertTriangle size={16} class="shrink-0" />
           <span>
             <strong>{p.provider}</strong> unavailable — {p.reason}
             {#if p.ratelimitedUntil}· until {new Date(p.ratelimitedUntil).toLocaleTimeString()}{/if}
@@ -268,9 +265,7 @@
     <div class="flex shrink-0 flex-col gap-0.5">
       {#each degradedWarnings as w, i (w.subsystem)}
         <div class="flex items-center gap-2 bg-warning-800/90 border-b border-warning-600 px-4 py-2 text-warning-100 text-sm">
-          <svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
-          </svg>
+          <AlertTriangle size={16} class="shrink-0" />
           <span><strong>{w.subsystem}</strong> degraded — {w.reason}</span>
           <button
             type="button"

--- a/frontend/src/components/AgentErrorBanner.svelte
+++ b/frontend/src/components/AgentErrorBanner.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import type { Component } from 'svelte'
+  import { ArrowUpDown, Cloud, Ban, Clock, AlertTriangle, RotateCcw, ChevronRight } from '@lucide/svelte'
   import { agentStore } from '../stores/agents.svelte.js'
 
   interface ErrorEvent {
@@ -19,7 +21,7 @@
 
   type ErrorSpec = {
     label: string
-    icon: string
+    icon: Component<{ size?: number }>
     what: string
     todo: string
     color: string
@@ -29,7 +31,7 @@
   const ERROR_SPECS: Record<string, ErrorSpec> = {
     worktree_conflict: {
       label: 'Worktree conflict',
-      icon: `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4" />`,
+      icon: ArrowUpDown,
       what: 'Git worktree is already checked out by another agent.',
       todo: 'Stop the conflicting agent or retry once it finishes.',
       color: 'bg-error-50 border-error-400 dark:bg-error-950 dark:border-error-600',
@@ -37,7 +39,7 @@
     },
     git_clone: {
       label: 'Git / network error',
-      icon: `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z" />`,
+      icon: Cloud,
       what: 'Failed to clone or fetch the repository.',
       todo: 'Check network connectivity and repository access, then retry.',
       color: 'bg-warning-50 border-warning-400 dark:bg-warning-950 dark:border-warning-600',
@@ -45,7 +47,7 @@
     },
     permission_denied: {
       label: 'Permission denied',
-      icon: `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />`,
+      icon: Ban,
       what: 'A tool call was rejected due to insufficient permissions.',
       todo: 'Review allowed tools in task settings and retry.',
       color: 'bg-error-50 border-error-400 dark:bg-error-950 dark:border-error-600',
@@ -53,7 +55,7 @@
     },
     rate_limit: {
       label: 'API rate limited',
-      icon: `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />`,
+      icon: Clock,
       what: 'The API provider rate limit was reached.',
       todo: 'Wait a few minutes and retry, or check provider health.',
       color: 'bg-warning-50 border-warning-400 dark:bg-warning-950 dark:border-warning-600',
@@ -61,7 +63,7 @@
     },
     crash: {
       label: 'Agent crashed',
-      icon: `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />`,
+      icon: AlertTriangle,
       what: 'The agent process exited unexpectedly.',
       todo: 'View logs for details, then retry.',
       color: 'bg-error-50 border-error-400 dark:bg-error-950 dark:border-error-600',
@@ -75,9 +77,9 @@
 
 <div class="rounded-lg border-2 {spec.color} p-4">
   <div class="flex items-start gap-3">
-    <svg class="h-5 w-5 shrink-0 {spec.iconColor} mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      {@html spec.icon}
-    </svg>
+    <span class="mt-0.5 shrink-0 {spec.iconColor}">
+      <spec.icon size={20} />
+    </span>
     <div class="min-w-0 flex-1">
       <div class="flex flex-wrap items-center gap-2">
         <span class="text-sm font-semibold text-surface-800 dark:text-surface-100">{spec.label}</span>
@@ -98,9 +100,7 @@
         class="flex items-center gap-1.5 rounded-md bg-surface-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-surface-800 dark:bg-surface-600 dark:hover:bg-surface-500"
         onclick={onretry}
       >
-        <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-        </svg>
+        <RotateCcw size={14} />
         Retry
       </button>
     {/if}
@@ -110,9 +110,7 @@
         class="flex items-center gap-1.5 rounded-md border border-surface-300 px-3 py-1.5 text-sm font-medium text-surface-700 hover:bg-surface-100 dark:border-surface-600 dark:text-surface-300 dark:hover:bg-surface-800"
         onclick={() => (logsExpanded = !logsExpanded)}
       >
-        <svg class="h-3.5 w-3.5 transition-transform {logsExpanded ? 'rotate-90' : ''}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-        </svg>
+        <ChevronRight size={14} class="transition-transform {logsExpanded ? 'rotate-90' : ''}" />
         View logs
       </button>
     {/if}

--- a/frontend/src/components/ChatInput.svelte
+++ b/frontend/src/components/ChatInput.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { ArrowUp } from '@lucide/svelte'
+
   interface Props {
     disabled?: boolean
     placeholder?: string
@@ -60,9 +62,7 @@
         disabled:cursor-not-allowed disabled:opacity-50"
       onclick={submit}
     >
-      <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19V5m0 0l-7 7m7-7l7 7" />
-      </svg>
+      <ArrowUp size={20} />
     </button>
   </div>
 </div>

--- a/frontend/src/components/ChatView.svelte
+++ b/frontend/src/components/ChatView.svelte
@@ -4,6 +4,7 @@
   import MessageBubble from './MessageBubble.svelte'
   import ToolApproval from './ToolApproval.svelte'
   import ChatInput from './ChatInput.svelte'
+  import { ArrowDown } from '@lucide/svelte'
 
   interface Props {
     agentId: string
@@ -117,9 +118,7 @@
           ? 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200'
           : 'bg-surface-200 text-surface-500 dark:bg-surface-700 dark:text-surface-400'}"
     >
-      <svg class="h-3 w-3" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2">
-        <path d="M8 3v8M5 8l3 3 3-3" stroke-linecap="round" stroke-linejoin="round"/>
-      </svg>
+      <ArrowDown size={12} />
       {autoScroll ? 'Auto-scroll on' : 'Auto-scroll off'}
     </button>
   </div>

--- a/frontend/src/components/CommandPalette.svelte
+++ b/frontend/src/components/CommandPalette.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Search, X } from '@lucide/svelte'
   import MobileSheet from './shell/MobileSheet.svelte'
   import { taskStore } from '../stores/tasks.svelte.js'
   import { projectStore } from '../stores/projects.svelte.js'
@@ -116,12 +117,7 @@
   <div class="flex flex-col">
     <!-- Search bar -->
     <div class="flex items-center gap-3 border-b border-surface-200 px-4 dark:border-surface-700">
-      <svg
-        class="h-4 w-4 shrink-0 transition-colors {query ? 'text-primary-500' : 'text-surface-400'}"
-        fill="none" stroke="currentColor" viewBox="0 0 24 24"
-      >
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-      </svg>
+      <Search size={16} class="shrink-0 transition-colors {query ? 'text-primary-500' : 'text-surface-400'}" />
       <input
         bind:this={inputRef}
         bind:value={query}
@@ -136,9 +132,7 @@
         aria-label="Close"
       >
         <kbd class="hidden rounded border border-surface-300 px-1.5 py-0.5 font-mono text-[10px] text-surface-400 dark:border-surface-600 md:inline">Esc</kbd>
-        <svg class="h-5 w-5 md:hidden" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-        </svg>
+        <X size={20} class="md:hidden" />
       </button>
     </div>
 

--- a/frontend/src/components/CreateTaskDialog.svelte
+++ b/frontend/src/components/CreateTaskDialog.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import MobileSheet from './shell/MobileSheet.svelte'
+  import { Folder, X } from '@lucide/svelte'
   import { taskStore } from '../stores/tasks.svelte.js'
   import { projectStore } from '../stores/projects.svelte.js'
 
@@ -117,9 +118,7 @@
             <span class="text-sm font-medium">Project</span>
             {#if selectedProject}
               <div class="flex items-center gap-2 rounded-lg border border-surface-300 bg-surface-100 px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700">
-                <svg class="h-4 w-4 shrink-0 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-                </svg>
+                <Folder size={16} class="shrink-0 text-surface-400" />
                 <span class="flex-1">{selectedProjectName}</span>
                 <button
                   type="button"
@@ -127,9 +126,7 @@
                   aria-label="Clear project"
                   onclick={clearProject}
                 >
-                  <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                  </svg>
+                  <X size={16} />
                 </button>
               </div>
             {:else}
@@ -157,9 +154,7 @@
                         class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-surface-100 dark:hover:bg-surface-700"
                         onclick={() => selectProject(p.id)}
                       >
-                        <svg class="h-4 w-4 shrink-0 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-                        </svg>
+                        <Folder size={16} class="shrink-0 text-surface-400" />
                         {p.owner}/{p.repo}
                       </button>
                     {/each}

--- a/frontend/src/components/DiffViewer.svelte
+++ b/frontend/src/components/DiffViewer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { ChevronRight } from '@lucide/svelte'
   interface Props {
     oldText: string
     newText: string
@@ -20,9 +21,7 @@
       class="flex w-full items-center gap-2 border-b border-surface-200 px-2 py-1 text-left dark:border-surface-700"
       onclick={() => (expanded = !expanded)}
     >
-      <svg class="h-3 w-3 transition-transform {expanded ? 'rotate-90' : ''}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-      </svg>
+      <ChevronRight size={12} class="transition-transform {expanded ? 'rotate-90' : ''}" />
       <span class="font-mono text-surface-600 dark:text-surface-400">{filePath}</span>
     </button>
   {/if}

--- a/frontend/src/components/MobileWorkflowNotice.svelte
+++ b/frontend/src/components/MobileWorkflowNotice.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { ChevronLeft } from '@lucide/svelte'
   import type { workflow } from '../../wailsjs/go/models.js'
 
   interface Props {
@@ -17,9 +18,7 @@
       class="tap -ml-2 rounded-lg active:bg-surface-200 dark:active:bg-surface-700"
       aria-label="Back"
     >
-      <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
-      </svg>
+      <ChevronLeft size={24} />
     </button>
     <h2 class="truncate text-base font-semibold">{def?.name ?? 'Loading...'}</h2>
   </div>

--- a/frontend/src/components/NewChatDialog.svelte
+++ b/frontend/src/components/NewChatDialog.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import MobileSheet from './shell/MobileSheet.svelte'
+  import { Folder, X } from '@lucide/svelte'
   import { agentStore } from '../stores/agents.svelte.js'
   import { projectStore } from '../stores/projects.svelte.js'
 
@@ -95,9 +96,7 @@
             <p class="text-sm text-surface-500">No projects registered. Create one first.</p>
           {:else if selectedProject}
             <div class="flex items-center gap-2 rounded-lg border border-surface-300 bg-surface-100 px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700">
-              <svg class="h-4 w-4 shrink-0 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-              </svg>
+              <Folder size={16} class="shrink-0 text-surface-400" />
               <span class="flex-1">{selectedProjectName}</span>
               <button
                 type="button"
@@ -105,9 +104,7 @@
                 aria-label="Clear project"
                 onclick={clearProject}
               >
-                <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                </svg>
+                <X size={16} />
               </button>
             </div>
           {:else}
@@ -128,9 +125,7 @@
                       class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-surface-100 dark:hover:bg-surface-700"
                       onclick={() => selectProject(p.id)}
                     >
-                      <svg class="h-4 w-4 shrink-0 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-                      </svg>
+                      <Folder size={16} class="shrink-0 text-surface-400" />
                       {p.owner}/{p.repo}
                     </button>
                   {/each}

--- a/frontend/src/components/QuickAddTask.svelte
+++ b/frontend/src/components/QuickAddTask.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import MobileSheet from './shell/MobileSheet.svelte'
+  import { Folder, X } from '@lucide/svelte'
   import { taskStore } from '../stores/tasks.svelte.js'
   import { projectStore } from '../stores/projects.svelte.js'
   import { detectProject } from '../lib/detectProject.js'
@@ -148,9 +149,7 @@
           {#if autoDetected && !userOverrode}
             <!-- Auto-detected project chip -->
             <div class="flex items-center gap-2 px-5 py-2 text-xs text-surface-500">
-              <svg class="h-3.5 w-3.5 shrink-0 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-              </svg>
+              <Folder size={14} class="shrink-0 text-surface-400" />
               <span class="inline-flex items-center gap-1 rounded-md bg-primary-100 px-2 py-0.5 font-medium text-primary-700 dark:bg-primary-900/30 dark:text-primary-300">
                 {autoDetected.project.owner}/{autoDetected.project.repo}
                 <button
@@ -159,9 +158,7 @@
                   class="ml-0.5 hover:text-primary-900 dark:hover:text-primary-100"
                   onclick={dismissDetection}
                 >
-                  <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                  </svg>
+                  <X size={12} />
                 </button>
               </span>
               <span class="text-surface-400">from {autoDetected.matchType === 'url' ? 'link' : 'title'}</span>
@@ -169,9 +166,7 @@
           {:else if selectedProject && userOverrode}
             <!-- Manually selected project chip -->
             <div class="flex items-center gap-2 px-5 py-2 text-xs">
-              <svg class="h-3.5 w-3.5 shrink-0 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-              </svg>
+              <Folder size={14} class="shrink-0 text-surface-400" />
               <span class="text-sm">{projectStore.list.find((p) => p.id === selectedProject)?.id}</span>
               <button
                 type="button"
@@ -179,9 +174,7 @@
                 class="text-surface-400 hover:text-surface-600 dark:hover:text-surface-300"
                 onclick={clearManualProject}
               >
-                <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                </svg>
+                <X size={12} />
               </button>
             </div>
           {:else}
@@ -204,9 +197,7 @@
                       class="flex w-full items-center gap-2 px-4 py-1.5 text-left text-xs hover:bg-surface-100 dark:hover:bg-surface-700"
                       onmousedown={() => selectProjectManual(p.id)}
                     >
-                      <svg class="h-3.5 w-3.5 shrink-0 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-                      </svg>
+                      <Folder size={14} class="shrink-0 text-surface-400" />
                       {p.owner}/{p.repo}
                     </button>
                   {/each}

--- a/frontend/src/components/StreamOutput.svelte
+++ b/frontend/src/components/StreamOutput.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { ArrowDown } from '@lucide/svelte'
   import { EventsOn } from '$lib/api'
   import type { agent } from '../../wailsjs/go/models.js'
   import { agentStore } from '../stores/agents.svelte.js'
@@ -70,9 +71,7 @@
           ? 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200'
           : 'bg-surface-200 text-surface-500 dark:bg-surface-700 dark:text-surface-400'}"
     >
-      <svg class="h-3 w-3" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2">
-        <path d="M8 3v8M5 8l3 3 3-3" stroke-linecap="round" stroke-linejoin="round"/>
-      </svg>
+      <ArrowDown size={12} />
       {autoScroll ? 'Auto-scroll on' : 'Auto-scroll off'}
     </button>
   </div>

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { CheckCircle, XCircle, Clock, GitPullRequest, CircleDot } from '@lucide/svelte'
   import type { task } from '../../wailsjs/go/models.js'
   import { agentStore } from '../stores/agents.svelte.js'
   import { reviewStore } from '../stores/reviews.svelte.js'
@@ -70,11 +71,11 @@
   >
   <div class="mb-1.5 flex items-center gap-1.5">
     {#if topPR?.ciStatus === 'SUCCESS'}
-      <svg class="h-4 w-4 shrink-0 text-success-500" viewBox="0 0 16 16" fill="currentColor"><title>CI passed</title><path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16Zm3.78-9.72a.751.751 0 0 0-1.06-1.06L6.75 9.19 5.28 7.72a.751.751 0 0 0-1.06 1.06l2 2a.75.75 0 0 0 1.06 0l4.5-4.5Z"/></svg>
+      <CheckCircle size={16} class="shrink-0 text-success-500" />
     {:else if topPR?.ciStatus === 'FAILURE'}
-      <svg class="h-4 w-4 shrink-0 text-error-500" viewBox="0 0 16 16" fill="currentColor"><title>CI failed</title><path d="M2.343 13.657A8 8 0 1 1 13.658 2.343 8 8 0 0 1 2.343 13.657ZM6.03 4.97a.751.751 0 0 0-1.06 1.06L6.94 8 4.97 9.97a.751.751 0 1 0 1.06 1.06L8 9.06l1.97 1.97a.751.751 0 1 0 1.06-1.06L9.06 8l1.97-1.97a.751.751 0 1 0-1.06-1.06L8 6.94 6.03 4.97Z"/></svg>
+      <XCircle size={16} class="shrink-0 text-error-500" />
     {:else if topPR?.ciStatus === 'PENDING'}
-      <svg class="h-4 w-4 shrink-0 text-warning-500" viewBox="0 0 16 16" fill="currentColor"><title>CI pending</title><path d="M8 16A8 8 0 1 1 8 0a8 8 0 0 1 0 16Zm1-8.577V4.75a.75.75 0 0 0-1.5 0V8a.75.75 0 0 0 .388.657l3 1.5a.75.75 0 1 0 .67-1.342L9 7.423Z"/></svg>
+      <Clock size={16} class="shrink-0 text-warning-500" />
     {/if}
     <h3 class="text-sm font-semibold leading-tight">{t.title}</h3>
   </div>
@@ -130,7 +131,7 @@
 
     {#if topPR}
       <span class="inline-flex items-center gap-1 rounded bg-warning-500/15 px-1.5 py-0.5 font-medium text-warning-700 dark:text-warning-400" title={topPR.title}>
-        <svg class="h-3 w-3" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"/></svg>
+        <GitPullRequest size={12} />
         #{topPR.number}
         {#if topPR.reviewDecision === 'APPROVED'}
           <span class="text-success-500" title="Approved">✓</span>
@@ -143,7 +144,7 @@
       </span>
     {:else if t.prNumber}
       <span class="inline-flex items-center gap-1 rounded bg-warning-500/15 px-1.5 py-0.5 font-medium text-warning-700 dark:text-warning-400">
-        <svg class="h-3 w-3" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"/></svg>
+        <GitPullRequest size={12} />
         #{t.prNumber}
       </span>
     {/if}
@@ -153,7 +154,7 @@
         class="inline-flex items-center gap-1 rounded bg-secondary-500/15 px-1.5 py-0.5 font-medium text-secondary-700 dark:text-secondary-400"
         title={t.issue}
       >
-        <svg class="h-3 w-3" viewBox="0 0 16 16" fill="currentColor"><path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"/><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"/></svg>
+        <CircleDot size={12} />
         Issue
       </span>
     {/if}

--- a/frontend/src/components/ToolApproval.svelte
+++ b/frontend/src/components/ToolApproval.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Check, X } from '@lucide/svelte'
   import DiffViewer from './DiffViewer.svelte'
 
   interface Props {
@@ -70,9 +71,7 @@
       class="flex items-center gap-1.5 rounded-lg bg-success-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-success-700 disabled:opacity-50"
       onclick={handleApprove}
     >
-      <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
-      </svg>
+      <Check size={16} />
       Approve
     </button>
     <button
@@ -81,9 +80,7 @@
       class="flex items-center gap-1.5 rounded-lg bg-error-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-error-700 disabled:opacity-50"
       onclick={handleReject}
     >
-      <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-      </svg>
+      <X size={16} />
       Reject
     </button>
   </div>

--- a/frontend/src/components/WorktreeList.svelte
+++ b/frontend/src/components/WorktreeList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { project } from '../../wailsjs/go/models.js'
   import { ListWorktrees, OpenInTerminal, OpenInEditor } from '$lib/api'
+  import { Terminal, Code } from '@lucide/svelte'
 
   interface Props {
     projectId: string
@@ -75,9 +76,7 @@
             title="Open in Ghostty"
             onclick={() => openTerminal(wt.path)}
           >
-            <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-            </svg>
+            <Terminal size={16} />
           </button>
           <button
             type="button"
@@ -85,9 +84,7 @@
             title="Open in Zed"
             onclick={() => openEditor(wt.path)}
           >
-            <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4" />
-            </svg>
+            <Code size={16} />
           </button>
         </div>
       </div>

--- a/frontend/src/components/shell/BottomTabBar.svelte
+++ b/frontend/src/components/shell/BottomTabBar.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { ClipboardList, MessageCircle, UserCircle, ClipboardCheck, Menu } from '@lucide/svelte'
   import { navStore, type TabKey } from '../../lib/navigation.svelte.js'
   import { taskStore } from '../../stores/tasks.svelte.js'
   import { agentStore } from '../../stores/agents.svelte.js'
@@ -39,9 +40,7 @@
     class:dark:text-primary-400={navStore.activeTab === 'board'}
     aria-label="Board"
   >
-    <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-      <path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-    </svg>
+    <ClipboardList size={24} />
     Board
   </button>
 
@@ -55,9 +54,7 @@
     aria-label="Chats"
   >
     <div class="relative">
-      <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-      </svg>
+      <MessageCircle size={24} />
       {#if interactiveAgentCount > 0}
         <span class="absolute -right-1.5 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary-500 px-1 text-[9px] font-bold text-white">{interactiveAgentCount}</span>
       {/if}
@@ -74,9 +71,7 @@
     class:dark:text-primary-400={navStore.activeTab === 'agents'}
     aria-label="Agents"
   >
-    <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-      <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-    </svg>
+    <UserCircle size={24} />
     Agents
   </button>
 
@@ -90,9 +85,7 @@
     aria-label="Reviews"
   >
     <div class="relative">
-      <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
-      </svg>
+      <ClipboardCheck size={24} />
       {#if reviewCount > 0}
         <span class="absolute -right-1.5 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-warning-500 px-1 text-[9px] font-bold text-white">{reviewCount}</span>
       {/if}
@@ -109,9 +102,7 @@
     class:dark:text-primary-400={navStore.activeTab === 'more'}
     aria-label="More"
   >
-    <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-      <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-    </svg>
+    <Menu size={24} />
     More
   </button>
 </nav>

--- a/frontend/src/components/shell/MobileAppBar.svelte
+++ b/frontend/src/components/shell/MobileAppBar.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { ChevronLeft, Search } from '@lucide/svelte'
   import { navStore } from '../../lib/navigation.svelte.js'
 
   interface PrimaryAction {
@@ -25,9 +26,7 @@
         class="tap -ml-2 flex items-center justify-center rounded-lg text-surface-600 active:bg-surface-200 dark:text-surface-300 dark:active:bg-surface-800"
         aria-label="Back"
       >
-        <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
-        </svg>
+        <ChevronLeft size={24} />
       </button>
     {:else}
       <span class="px-2 text-base font-bold text-primary-600 dark:text-primary-400">S</span>
@@ -41,9 +40,7 @@
       class="tap flex items-center justify-center rounded-lg text-surface-600 active:bg-surface-200 dark:text-surface-300 dark:active:bg-surface-800"
       aria-label="Search"
     >
-      <svg class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-      </svg>
+      <Search size={20} />
     </button>
 
     {#if primaryAction}

--- a/frontend/src/components/shell/MoreSheet.svelte
+++ b/frontend/src/components/shell/MoreSheet.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { ChevronRight } from '@lucide/svelte'
   import MobileSheet from './MobileSheet.svelte'
   import { navStore, type Page } from '../../lib/navigation.svelte.js'
   import { taskStore } from '../../stores/tasks.svelte.js'
@@ -46,9 +47,7 @@
             {#if item.badge}
               <span class="rounded-full bg-warning-500 px-2 py-0.5 text-xs font-bold text-white">{item.badge}</span>
             {/if}
-            <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
-            </svg>
+            <ChevronRight size={16} />
           </span>
         </button>
       </li>

--- a/frontend/src/components/shell/SideRail.svelte
+++ b/frontend/src/components/shell/SideRail.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { LayoutGrid, ClipboardList, Folder, MessageCircle, UserCircle, GitBranch, ClipboardCheck, LayoutDashboard, BarChart3, Settings } from '@lucide/svelte'
   import { Navigation } from '@skeletonlabs/skeleton-svelte'
   import { navStore } from '../../lib/navigation.svelte.js'
   import { taskStore } from '../../stores/tasks.svelte.js'
@@ -22,27 +23,21 @@
       onclick={() => navStore.reset({ kind: 'dashboard' })}
       data-active={navStore.page.kind === 'dashboard' || undefined}
     >
-      <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
-      </svg>
+      <LayoutGrid size={20} />
       <Navigation.TriggerText>Dashboard</Navigation.TriggerText>
     </Navigation.Trigger>
     <Navigation.Trigger
       onclick={() => navStore.reset({ kind: 'task-list' })}
       data-active={navStore.page.kind === 'task-list' || navStore.page.kind === 'task-detail' || undefined}
     >
-      <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-      </svg>
+      <ClipboardList size={20} />
       <Navigation.TriggerText>Board</Navigation.TriggerText>
     </Navigation.Trigger>
     <Navigation.Trigger
       onclick={() => navStore.reset({ kind: 'project-list' })}
       data-active={navStore.page.kind === 'project-list' || navStore.page.kind === 'project-detail' || undefined}
     >
-      <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-      </svg>
+      <Folder size={20} />
       <Navigation.TriggerText>Projects</Navigation.TriggerText>
     </Navigation.Trigger>
     <Navigation.Trigger
@@ -50,9 +45,7 @@
       data-active={navStore.page.kind === 'chats' || navStore.page.kind === 'chat-detail' || undefined}
     >
       <div class="relative">
-        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-        </svg>
+        <MessageCircle size={20} />
         {#if interactiveAgentCount > 0}
           <span class="absolute -right-1 -top-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-primary-500 text-[9px] font-bold text-white">{interactiveAgentCount}</span>
         {/if}
@@ -63,18 +56,14 @@
       onclick={() => navStore.reset({ kind: 'agents' })}
       data-active={navStore.page.kind === 'agents' || navStore.page.kind === 'agent-detail' || undefined}
     >
-      <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-      </svg>
+      <UserCircle size={20} />
       <Navigation.TriggerText>Agents</Navigation.TriggerText>
     </Navigation.Trigger>
     <Navigation.Trigger
       onclick={() => navStore.reset({ kind: 'github' })}
       data-active={navStore.page.kind === 'github' || undefined}
     >
-      <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.166 6.839 9.489.5.092.682-.217.682-.482 0-.237-.009-.866-.013-1.7-2.782.604-3.369-1.341-3.369-1.341-.454-1.155-1.11-1.462-1.11-1.462-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.337-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z" />
-      </svg>
+      <GitBranch size={20} />
       <Navigation.TriggerText>GitHub</Navigation.TriggerText>
     </Navigation.Trigger>
     <Navigation.Trigger
@@ -82,9 +71,7 @@
       data-active={navStore.page.kind === 'reviews' || undefined}
     >
       <div class="relative">
-        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
-        </svg>
+        <ClipboardCheck size={20} />
         {#if reviewCount > 0}
           <span class="absolute -right-1 -top-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-warning-500 text-[9px] font-bold text-white">{reviewCount}</span>
         {/if}
@@ -95,18 +82,14 @@
       onclick={() => navStore.reset({ kind: 'workflows' })}
       data-active={navStore.page.kind === 'workflows' || navStore.page.kind === 'workflow-detail' || undefined}
     >
-      <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z" />
-      </svg>
+      <LayoutDashboard size={20} />
       <Navigation.TriggerText>Workflows</Navigation.TriggerText>
     </Navigation.Trigger>
     <Navigation.Trigger
       onclick={() => navStore.reset({ kind: 'stats' })}
       data-active={navStore.page.kind === 'stats' || undefined}
     >
-      <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-      </svg>
+      <BarChart3 size={20} />
       <Navigation.TriggerText>Stats</Navigation.TriggerText>
     </Navigation.Trigger>
     <Navigation.Trigger
@@ -114,10 +97,7 @@
       data-active={navStore.page.kind === 'settings' || undefined}
       title="Settings (Cmd+,)"
     >
-      <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-      </svg>
+      <Settings size={20} />
       <Navigation.TriggerText>Settings</Navigation.TriggerText>
     </Navigation.Trigger>
   </Navigation.Content>

--- a/frontend/src/components/workflow/ConditionRow.svelte
+++ b/frontend/src/components/workflow/ConditionRow.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { workflow } from '../../../wailsjs/go/models.js'
+  import { X } from '@lucide/svelte'
 
   interface Props {
     condition: workflow.Condition
@@ -51,9 +52,7 @@
       title="Remove"
       aria-label="Remove condition"
     >
-      <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-      </svg>
+      <X size={12} />
     </button>
   {/if}
 </div>

--- a/frontend/src/components/workflow/StepConfigPanel.svelte
+++ b/frontend/src/components/workflow/StepConfigPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Trash2, X } from '@lucide/svelte'
   import { workflow } from '../../../wailsjs/go/models.js'
   import ConditionRow from './ConditionRow.svelte'
 
@@ -110,9 +111,7 @@
         title="Delete step"
         aria-label="Delete step"
       >
-        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-        </svg>
+        <Trash2 size={16} />
       </button>
     </div>
 
@@ -369,9 +368,7 @@
                 title="Remove transition"
                 aria-label="Remove transition"
               >
-                <svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                </svg>
+                <X size={12} />
               </button>
             </div>
             <label class="flex items-center gap-1 text-xs">

--- a/frontend/src/components/workflow/TriggerConfigPanel.svelte
+++ b/frontend/src/components/workflow/TriggerConfigPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { workflow } from '../../../wailsjs/go/models.js'
+  import { Zap } from '@lucide/svelte'
   import ConditionRow from './ConditionRow.svelte'
 
   interface Props {
@@ -51,17 +52,7 @@
 
 <aside class="w-80 flex-shrink-0 overflow-y-auto border-l border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800/50">
   <div class="mb-3 flex items-center gap-2">
-    <svg
-      class="h-4 w-4 text-amber-600 dark:text-amber-400"
-      fill="currentColor"
-      viewBox="0 0 20 20"
-    >
-      <path
-        fill-rule="evenodd"
-        d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z"
-        clip-rule="evenodd"
-      />
-    </svg>
+    <Zap size={16} class="text-amber-600 dark:text-amber-400" />
     <h3 class="text-sm font-semibold">Trigger</h3>
   </div>
 

--- a/frontend/src/components/workflow/nodes/EndNode.svelte
+++ b/frontend/src/components/workflow/nodes/EndNode.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
   import { Handle, Position } from '@xyflow/svelte'
+  import { StopCircle } from '@lucide/svelte'
 </script>
 
 <Handle type="target" position={Position.Top} />
 
 <div class="flex h-10 w-10 items-center justify-center rounded-full border-2 border-surface-400 bg-surface-200 dark:border-surface-500 dark:bg-surface-700">
-  <svg class="h-4 w-4 text-surface-500 dark:text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 10a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z" />
-  </svg>
+  <StopCircle size={16} class="text-surface-500 dark:text-surface-400" />
 </div>

--- a/frontend/src/components/workflow/nodes/TriggerNode.svelte
+++ b/frontend/src/components/workflow/nodes/TriggerNode.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { Handle, Position } from '@xyflow/svelte'
+  import { Zap } from '@lucide/svelte'
   import type { TriggerNodeData } from '../../../lib/workflow-graph.js'
 
   interface Props {
@@ -19,17 +20,7 @@
   style="min-width: 180px;"
 >
   <div class="flex items-center gap-2">
-    <svg
-      class="h-4 w-4 text-amber-600 dark:text-amber-400"
-      fill="currentColor"
-      viewBox="0 0 20 20"
-    >
-      <path
-        fill-rule="evenodd"
-        d="M11.3 1.046A1 1 0 0112 2v5h4a1 1 0 01.82 1.573l-7 10A1 1 0 018 18v-5H4a1 1 0 01-.82-1.573l7-10a1 1 0 011.12-.38z"
-        clip-rule="evenodd"
-      />
-    </svg>
+    <Zap size={16} class="text-amber-600 dark:text-amber-400" />
     <span class="text-xs font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300">
       Trigger
     </span>

--- a/frontend/src/pages/AgentDetail.svelte
+++ b/frontend/src/pages/AgentDetail.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { ChevronLeft } from '@lucide/svelte'
   import type { agent } from '../../wailsjs/go/models.js'
   import { EventsOn, RespondEscalation } from '$lib/api'
   import { agentStore } from '../stores/agents.svelte.js'
@@ -125,9 +126,7 @@
     class="flex w-fit items-center gap-1 text-sm text-surface-500 hover:text-surface-800 dark:hover:text-surface-200"
     onclick={onback}
   >
-    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-    </svg>
+    <ChevronLeft size={16} />
     Back to agents
   </button>
 

--- a/frontend/src/pages/ChatDetail.svelte
+++ b/frontend/src/pages/ChatDetail.svelte
@@ -4,6 +4,7 @@
   import { agentStore } from '../stores/agents.svelte.js'
   import { agentState } from '../lib/events.js'
   import ChatView from '../components/ChatView.svelte'
+  import { ChevronLeft } from '@lucide/svelte'
 
   interface Props {
     agentId: string
@@ -56,9 +57,7 @@
       class="flex items-center gap-1 text-sm text-surface-500 hover:text-surface-800 dark:hover:text-surface-200"
       onclick={onback}
     >
-      <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-      </svg>
+      <ChevronLeft size={16} />
       Chats
     </button>
 

--- a/frontend/src/pages/ChatList.svelte
+++ b/frontend/src/pages/ChatList.svelte
@@ -4,6 +4,7 @@
   import { projectStore } from '../stores/projects.svelte.js'
   import { getAgentPhase, PHASE_CONFIG } from '$lib/agent-phases.js'
   import NewChatDialog from '../components/NewChatDialog.svelte'
+  import { MessageCircle } from '@lucide/svelte'
 
   interface Props {
     onselect: (agentId: string) => void
@@ -57,9 +58,7 @@
 
   {#if interactiveAgents.length === 0}
     <div class="flex flex-col items-center gap-3 py-16 text-center">
-      <svg class="h-12 w-12 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
-      </svg>
+      <MessageCircle size={48} class="text-surface-400" />
       <p class="text-sm text-surface-500">No interactive chats yet</p>
       <button
         type="button"

--- a/frontend/src/pages/ProjectDetail.svelte
+++ b/frontend/src/pages/ProjectDetail.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { ChevronLeft } from '@lucide/svelte'
   import { SegmentedControl } from '@skeletonlabs/skeleton-svelte'
   import type { project } from '../../wailsjs/go/models.js'
   import { projectStore } from '../stores/projects.svelte.js'
@@ -88,9 +89,7 @@
     class="flex w-fit items-center gap-1 text-sm text-surface-500 hover:text-surface-800 dark:hover:text-surface-200"
     onclick={onback}
   >
-    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-    </svg>
+    <ChevronLeft size={16} />
     Back to projects
   </button>
 

--- a/frontend/src/pages/ProjectList.svelte
+++ b/frontend/src/pages/ProjectList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Folder } from '@lucide/svelte'
   import { projectStore } from '../stores/projects.svelte.js'
 
   interface Props {
@@ -32,9 +33,7 @@
     <p class="text-sm text-error-500">{projectStore.error}</p>
   {:else if projectStore.list.length === 0}
     <div class="flex flex-col items-center gap-3 py-16 text-center">
-      <svg class="h-12 w-12 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-      </svg>
+      <Folder size={48} class="text-surface-400" />
       <p class="text-sm text-surface-500">No projects yet</p>
       <button
         type="button"
@@ -53,9 +52,7 @@
           onclick={() => onselect(p.id)}
         >
           <div class="flex items-center gap-2">
-            <svg class="h-5 w-5 shrink-0 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
-            </svg>
+            <Folder size={20} class="shrink-0 text-surface-400" />
             <span class="text-sm font-semibold">{p.owner}/{p.repo}</span>
             {#if p.type === 'work'}
               <span class="rounded px-1.5 py-0.5 text-xs font-medium bg-warning-100 text-warning-700 dark:bg-warning-900/40 dark:text-warning-300">work</span>

--- a/frontend/src/pages/Reviews.svelte
+++ b/frontend/src/pages/Reviews.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { FileText, ChevronLeft } from '@lucide/svelte'
   import { renderMarkdown } from '../lib/markdown.js'
   import { taskStore } from '../stores/tasks.svelte.js'
   import { commentStore } from '../stores/comments.svelte.js'
@@ -225,9 +226,7 @@
     {#if !selectedTask}
       <div class="flex flex-1 items-center justify-center text-surface-400">
         <div class="text-center">
-          <svg class="mx-auto mb-3 h-12 w-12 opacity-40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-          </svg>
+          <FileText size={48} class="mx-auto mb-3 opacity-40" />
           <p class="text-sm">Select a task to review its {isTestPlan ? 'test plan' : 'plan'}</p>
         </div>
       </div>
@@ -242,9 +241,7 @@
               class="tap -ml-2 shrink-0 rounded-lg text-surface-600 active:bg-surface-200 dark:text-surface-300 dark:active:bg-surface-700"
               aria-label="Back to list"
             >
-              <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
-              </svg>
+              <ChevronLeft size={24} />
             </button>
           {/if}
           <h2 class="truncate text-base font-semibold">{selectedTask.title}</h2>
@@ -276,9 +273,7 @@
           </details>
         {/if}
         <div class="mb-3 flex items-center gap-2">
-          <svg class="h-4 w-4 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-          </svg>
+          <FileText size={16} class="text-surface-400" />
           <span class="text-xs font-medium text-surface-500">{isTestPlan ? 'TEST_PLAN.md' : 'PLAN.md'}</span>
           <span class="text-xs text-surface-400">— click <kbd class="rounded bg-surface-200 px-1 dark:bg-surface-700">+</kbd> on any line to comment</span>
         </div>

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { ChevronLeft, CircleDot, GitPullRequest, ChevronDown } from '@lucide/svelte'
   import type { agent, task } from '../../wailsjs/go/models.js'
   import { EventsOn, BrowserOpenURL, StartFixReview, StartReview, GetAgentRunLog } from '$lib/api'
   import { agentState } from '../lib/events.js'
@@ -331,9 +332,7 @@
     class="flex w-fit items-center gap-1 text-sm text-surface-500 hover:text-surface-800 dark:hover:text-surface-200"
     onclick={onback}
   >
-    <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-    </svg>
+    <ChevronLeft size={16} />
     Back to tasks
   </button>
 
@@ -498,7 +497,7 @@
               class="flex w-fit items-center gap-1.5 text-sm text-secondary-600 hover:underline dark:text-secondary-400"
               onclick={() => t && BrowserOpenURL(t.issue)}
             >
-              <svg class="h-4 w-4 shrink-0" viewBox="0 0 16 16" fill="currentColor"><path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z"/><path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z"/></svg>
+              <CircleDot size={16} class="shrink-0" />
               {t.issue}
             </button>
           </div>
@@ -532,7 +531,7 @@
                     title="CI: {pr.ciStatus.toLowerCase()}"
                   ></span>
                 {/if}
-                <svg class="h-4 w-4 shrink-0 text-warning-500" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"/></svg>
+                <GitPullRequest size={16} class="shrink-0 text-warning-500" />
                 <div class="flex flex-col">
                   <span class="text-sm font-semibold">{pr.title}</span>
                   <span class="text-xs text-surface-500">{pr.repository}#{pr.number} by {pr.author}</span>
@@ -566,7 +565,7 @@
             class="flex w-fit items-center gap-1.5 text-sm text-warning-700 hover:underline dark:text-warning-400"
             onclick={() => t && BrowserOpenURL(`https://github.com/${t.projectId}/pull/${t.prNumber}`)}
           >
-            <svg class="h-4 w-4 shrink-0" viewBox="0 0 16 16" fill="currentColor"><path d="M1.5 3.25a2.25 2.25 0 1 1 3 2.122v5.256a2.251 2.251 0 1 1-1.5 0V5.372A2.25 2.25 0 0 1 1.5 3.25Zm5.677-.177L9.573.677A.25.25 0 0 1 10 .854V2.5h1A2.5 2.5 0 0 1 13.5 5v5.628a2.251 2.251 0 1 1-1.5 0V5a1 1 0 0 0-1-1h-1v1.646a.25.25 0 0 1-.427.177L7.177 3.427a.25.25 0 0 1 0-.354Z"/></svg>
+            <GitPullRequest size={16} class="shrink-0" />
             {t.projectId}#{t.prNumber}
           </button>
         </div>
@@ -765,9 +764,7 @@
                     <span>${run.costUsd.toFixed(4)}</span>
                   {/if}
                   <span>{formatDate(run.startedAt)}</span>
-                  <svg class="h-4 w-4 transition-transform {expandedRun === run.agentId ? 'rotate-180' : ''}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                  </svg>
+                  <ChevronDown size={16} class="transition-transform {expandedRun === run.agentId ? 'rotate-180' : ''}" />
                 </div>
               </button>
               {#if expandedRun === run.agentId}

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Search, Filter, ChevronDown } from '@lucide/svelte'
   import type { task } from '../../wailsjs/go/models.js'
   import { taskStore } from '../stores/tasks.svelte.js'
   import { projectStore } from '../stores/projects.svelte.js'
@@ -311,9 +312,7 @@
   <!-- Mobile filter trigger -->
   <div class="flex shrink-0 items-center gap-2 border-b border-surface-200 px-3 py-2 dark:border-surface-800 md:hidden">
     <div class="relative flex-1">
-      <svg class="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-      </svg>
+      <Search size={16} class="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-surface-400" />
       <input
         type="text"
         bind:value={searchQuery}
@@ -327,9 +326,7 @@
       class="tap relative flex items-center gap-1 rounded-md border border-surface-300 bg-surface-50 px-3 text-sm font-medium dark:border-surface-700 dark:bg-surface-800"
       aria-label="Filters"
     >
-      <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
-      </svg>
+      <Filter size={16} />
       Filters
       {#if hasActiveFilters}
         <span class="h-2 w-2 rounded-full bg-primary-500"></span>
@@ -341,9 +338,7 @@
   <div class="hidden flex-wrap items-center gap-3 border-b border-surface-200 px-6 py-3 dark:border-surface-800 md:flex">
     <!-- Search -->
     <div class="relative">
-      <svg class="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-      </svg>
+      <Search size={16} class="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-surface-400" />
       <input
         bind:this={searchInputRef}
         type="text"
@@ -362,9 +357,7 @@
           onclick={() => (projectDropdownOpen = !projectDropdownOpen)}
         >
           <span class={selectedProjectId ? '' : 'text-surface-400'}>{selectedProjectLabel}</span>
-          <svg class="h-3.5 w-3.5 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-          </svg>
+          <ChevronDown size={14} class="text-surface-400" />
         </button>
         {#if projectDropdownOpen}
           <div class="absolute top-full z-10 mt-1 min-w-full rounded-md border border-surface-300 bg-surface-50 py-1 shadow-lg dark:border-surface-700 dark:bg-surface-800">
@@ -481,13 +474,7 @@
             class="tap flex w-full items-center justify-between gap-2 px-3 py-2 text-left active:bg-surface-200 dark:active:bg-surface-800 md:cursor-default md:active:bg-transparent dark:md:active:bg-transparent"
           >
             <span class="flex items-center gap-2">
-              <svg
-                class="h-4 w-4 transition-transform md:hidden {isCollapsed ? '-rotate-90' : ''}"
-                fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
-              </svg>
+              <ChevronDown size={16} class="transition-transform md:hidden {isCollapsed ? '-rotate-90' : ''}" aria-hidden="true" />
               <h2 class="text-sm font-semibold">{col.label}</h2>
             </span>
             <span class="rounded-full bg-surface-200 px-2 py-0.5 text-xs font-medium dark:bg-surface-700">

--- a/frontend/src/pages/WorkflowDetail.svelte
+++ b/frontend/src/pages/WorkflowDetail.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { ChevronLeft } from '@lucide/svelte'
   import type { Node, Edge } from '@xyflow/svelte'
   import { workflowStore } from '../stores/workflows.svelte.js'
   import { workflow } from '../../wailsjs/go/models.js'
@@ -163,9 +164,7 @@
       title="Back"
       aria-label="Back"
     >
-      <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
-      </svg>
+      <ChevronLeft size={20} />
     </button>
     <h2 class="text-sm font-semibold">{def?.name ?? 'Loading...'}</h2>
     {#if def?.builtin}

--- a/frontend/src/pages/WorkflowList.svelte
+++ b/frontend/src/pages/WorkflowList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { LayoutDashboard } from '@lucide/svelte'
   import { workflowStore } from '../stores/workflows.svelte.js'
 
   interface Props {
@@ -24,9 +25,7 @@
     <p class="text-sm text-error-500">{workflowStore.error}</p>
   {:else if workflowStore.list.length === 0}
     <div class="flex flex-col items-center gap-3 py-16 text-center">
-      <svg class="h-12 w-12 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z" />
-      </svg>
+      <LayoutDashboard size={48} class="text-surface-400" />
       <p class="text-sm text-surface-500">No workflows found</p>
     </div>
   {:else}
@@ -38,9 +37,7 @@
           onclick={() => onselect(wf.id)}
         >
           <div class="flex items-center gap-2">
-            <svg class="h-5 w-5 shrink-0 text-surface-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z" />
-            </svg>
+            <LayoutDashboard size={20} class="shrink-0 text-surface-400" />
             <span class="text-sm font-semibold">{wf.name}</span>
             {#if wf.builtin}
               <span class="rounded px-1.5 py-0.5 text-xs font-medium bg-primary-100 text-primary-700 dark:bg-primary-900/40 dark:text-primary-300">built-in</span>


### PR DESCRIPTION
## Motivation

Inline SVG path blobs scattered across 35+ files made icon updates painful and inconsistent. Replacing them with a single named-component library improves readability and ensures visual consistency.

## Implementation information

Installed `@lucide/svelte` (Skeleton UI's recommended icon library). Replaced all inline `<svg>` elements across 35 files with named Lucide components (`Search`, `Folder`, `X`, `ChevronLeft`, etc.).

`AgentErrorBanner` was also refactored to store the icon component directly in the error spec object (using Svelte 5's `Component` type) instead of a string discriminant + `{#if}` chain.

`ProviderLogo.svelte` was intentionally left untouched — it contains brand logos (Anthropic, OpenAI) with no Lucide equivalents.

> Changelog: feat(ui): replace inline SVGs with lucide icons