### PR TITLE
feat(review): auto-resolve comments on plan reject

### DIFF
--- a/internal/synapse/svc_planning.go
+++ b/internal/synapse/svc_planning.go
@@ -97,6 +97,7 @@ func (s *PlanningService) reject(id, feedback string) (task.Task, error) {
 	if err := s.engine.HandleHumanAction(id, "reject", data); err != nil {
 		return task.Task{}, err
 	}
+	_ = s.tasks.Comments().ResolveAll(id)
 	return s.tasks.Get(id)
 }
 

--- a/internal/task/comment.go
+++ b/internal/task/comment.go
@@ -102,6 +102,18 @@ func (s *CommentStore) Delete(taskID, commentID string) error {
 	return s.write(taskID, filtered)
 }
 
+// ResolveAll marks every unresolved comment for a task as resolved.
+func (s *CommentStore) ResolveAll(taskID string) error {
+	comments, err := s.List(taskID)
+	if err != nil {
+		return err
+	}
+	for i := range comments {
+		comments[i].Resolved = true
+	}
+	return s.write(taskID, comments)
+}
+
 // DeleteAll removes the sidecar file for a task (called on task deletion).
 func (s *CommentStore) DeleteAll(taskID string) error {
 	path := s.sidecarPath(taskID)


### PR DESCRIPTION
## Motivation

When a plan is rejected, all unresolved inline review comments are bundled and sent to the agent via `assembleFeedback`. After the agent re-plans and the task returns to review, those comments still showed as unresolved — requiring the reviewer to manually click "Resolve" for each one.

## Implementation information

Added `ResolveAll` to `CommentStore` that marks all comments resolved in a single write. Called best-effort (error ignored) in `reject()` after successful `HandleHumanAction`, so the rejection itself never fails due to comment resolution.

`sendMessage()` is intentionally unchanged — a live interactive message doesn't guarantee re-planning, so auto-resolving there would be premature.

> Changelog: feat(review): auto-resolve comments on plan reject