### PR TITLE
feat(agent): persist session_id for resume

### DIFF
--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1216,6 +1216,7 @@ export namespace task {
 	    costUsd: number;
 	    result: string;
 	    logFile: string;
+	    sessionId?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new AgentRun(source);
@@ -1232,6 +1233,7 @@ export namespace task {
 	        this.costUsd = source["costUsd"];
 	        this.result = source["result"];
 	        this.logFile = source["logFile"];
+	        this.sessionId = source["sessionId"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -192,6 +192,9 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 		cancel:      cancel,
 		sessionCWD:  cfg.Dir,
 	}
+	if cfg.ResumeSessionID != "" {
+		a.SetSessionID(cfg.ResumeSessionID)
+	}
 	if cfg.Mode == "headless" || cfg.Mode == "interactive" {
 		a.done = make(chan struct{})
 	}

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -132,6 +132,32 @@ func TestStartAgentHeadless(t *testing.T) {
 	}
 }
 
+func TestRunConfigResumeSessionID(t *testing.T) {
+	t.Parallel()
+	m, _ := newTestManager(t)
+
+	dir, err := os.MkdirTemp("", "synapse-agent-resume-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	ag, err := m.Run(RunConfig{
+		TaskID:          "task-resume",
+		Name:            "Resume Test",
+		Mode:            "headless",
+		Prompt:          "continue",
+		Dir:             dir,
+		ResumeSessionID: "ses-resume-abc",
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if ag.GetSessionID() != "ses-resume-abc" {
+		t.Errorf("SessionID = %q, want %q", ag.GetSessionID(), "ses-resume-abc")
+	}
+}
+
 func TestGetAgent(t *testing.T) {
 	m, _ := newTestManager(t)
 

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -316,6 +316,10 @@ type RunConfig struct {
 	// and system-critical sessions; user-initiated runs leave this false so
 	// they surface a clear error instead of wasting a hopeless request.
 	IgnoreHealthGate bool
+	// ResumeSessionID, when set, passes --resume to the claude CLI so the
+	// agent continues a prior conversation instead of starting from scratch.
+	// Populated from the task's last AgentRun.SessionID on restart.
+	ResumeSessionID string
 }
 
 type StreamEvent struct {

--- a/internal/synapse/app.go
+++ b/internal/synapse/app.go
@@ -665,10 +665,11 @@ func (a *App) onAgentComplete(ag *agent.Agent) {
 		truncated = truncated[:maxResultLen] + "\n... (truncated)"
 	}
 	if err := a.tasks.UpdateRun(ag.TaskID, ag.ID, map[string]any{
-		"state":    string(state),
-		"cost_usd": cost,
-		"result":   truncated,
-		"log_file": ag.LogPath,
+		"state":      string(state),
+		"cost_usd":   cost,
+		"result":     truncated,
+		"log_file":   ag.LogPath,
+		"session_id": ag.GetSessionID(),
 	}); err != nil {
 		a.logger.Error("task.update-run", "task_id", ag.TaskID, "agent_id", ag.ID, "err", err)
 	}

--- a/internal/synapse/app_agents.go
+++ b/internal/synapse/app_agents.go
@@ -97,6 +97,14 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, oneShot bool
 		return nil, fmt.Errorf("task %s: no working dir resolved (skipWorktree=%v) — refusing to run agent in Synapse cwd", taskID, skipWT)
 	}
 
+	resumeSessionID := ""
+	for i := len(t.AgentRuns) - 1; i >= 0; i-- {
+		if t.AgentRuns[i].SessionID != "" {
+			resumeSessionID = t.AgentRuns[i].SessionID
+			break
+		}
+	}
+
 	fullPrompt := fmt.Sprintf("# Task: %s\n\n%s\n\n---\n\n%s", t.Title, t.Body, prompt)
 	ag, err := o.agents.Run(agent.RunConfig{
 		TaskID:             taskID,
@@ -108,6 +116,7 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, oneShot bool
 		Model:              "sonnet",
 		RequirePermissions: requirePerm,
 		OneShot:            oneShot,
+		ResumeSessionID:    resumeSessionID,
 	})
 	if err != nil {
 		// Gate block leaves no running agent. Flip the task back to todo so

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -109,6 +109,7 @@ type AgentRun struct {
 	CostUSD   float64   `yaml:"cost_usd,omitempty" json:"costUsd"`
 	Result    string    `yaml:"result,omitempty" json:"result"`
 	LogFile   string    `yaml:"log_file,omitempty" json:"logFile"`
+	SessionID string    `yaml:"session_id,omitempty" json:"sessionId,omitempty"`
 }
 
 type Task struct {

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -435,6 +435,9 @@ func (s *Store) UpdateRun(taskID, agentID string, updates map[string]any) error 
 		if v, ok := updates["log_file"].(string); ok {
 			t.AgentRuns[i].LogFile = v
 		}
+		if v, ok := updates["session_id"].(string); ok && v != "" {
+			t.AgentRuns[i].SessionID = v
+		}
 		break
 	}
 	d, err := Marshal(t)

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -629,6 +629,80 @@ func TestStoreUpdateRunNoMatchingAgent(t *testing.T) {
 	}
 }
 
+func TestStoreUpdateRunSessionID(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("Session ID task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddRun(created.ID, AgentRun{AgentID: "agent-s", Mode: "headless", State: "running"}); err != nil {
+		t.Fatal(err)
+	}
+
+	err = store.UpdateRun(created.ID, "agent-s", map[string]any{
+		"state":      "done",
+		"session_id": "ses-abc123",
+	})
+	if err != nil {
+		t.Fatalf("UpdateRun: %v", err)
+	}
+
+	got, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AgentRuns[0].SessionID != "ses-abc123" {
+		t.Errorf("SessionID = %q, want %q", got.AgentRuns[0].SessionID, "ses-abc123")
+	}
+
+	// Verify YAML round-trip persists session_id
+	reloaded, err := Parse(got.FilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.AgentRuns[0].SessionID != "ses-abc123" {
+		t.Errorf("reloaded SessionID = %q, want %q", reloaded.AgentRuns[0].SessionID, "ses-abc123")
+	}
+}
+
+func TestStoreUpdateRunSessionIDEmpty(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("Session ID empty task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddRun(created.ID, AgentRun{AgentID: "agent-e", Mode: "headless", State: "running", SessionID: "existing-id"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Empty session_id should not overwrite existing value
+	err = store.UpdateRun(created.ID, "agent-e", map[string]any{
+		"state":      "done",
+		"session_id": "",
+	})
+	if err != nil {
+		t.Fatalf("UpdateRun: %v", err)
+	}
+
+	got, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AgentRuns[0].SessionID != "existing-id" {
+		t.Errorf("SessionID = %q, want existing-id preserved", got.AgentRuns[0].SessionID)
+	}
+}
+
 func TestStoreListSkipsPlanSidecars(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()


### PR DESCRIPTION
## Motivation

Headless agents on home-nas were hitting Claude 5xx errors, escalating
tasks to `human-required`. On restart or manual status reset, agents
started from scratch because `SessionID` was only in-memory — lost when
the process died. Claude's `--resume` flag can continue a prior
conversation if the session_id is persisted.

## Implementation information

Threads session_id through the full stack:

- `AgentRun` gets a `session_id` YAML field
- `UpdateRun` persists it when `onAgentComplete` fires
- `RunConfig` gets `ResumeSessionID`; `Manager.Run()` seeds the agent
- `AgentOrchestrator.StartAgent` reads the last non-empty session_id
  from prior runs and passes it via `RunConfig.ResumeSessionID`

Codex unaffected — `buildHeadlessInvocation` only uses `GetSessionID()`
for the claude provider path.

> Changelog: feat(agent): persist session_id for resume