### PR TITLE
feat(agent): timeline action scrubbing

### DIFF
--- a/frontend/src/components/ActionTimeline.svelte
+++ b/frontend/src/components/ActionTimeline.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+  import type { TimelineEntry } from '$lib/timeline.js'
+
+  interface Props {
+    entries: TimelineEntry[]
+    activeIndex: number | null
+    onselect: (index: number) => void
+  }
+
+  const { entries, activeIndex, onselect }: Props = $props()
+
+  let container: HTMLDivElement | undefined = $state()
+
+  const typeStyles: Record<string, string> = {
+    init: 'bg-surface-400 dark:bg-surface-500',
+    system: 'bg-surface-400 dark:bg-surface-500',
+    assistant: 'bg-primary-500',
+    tool_use: 'bg-secondary-500',
+    tool_result: 'bg-tertiary-500',
+    result: 'bg-warning-500',
+    user_input: 'bg-primary-400',
+    user: 'bg-tertiary-500',
+  }
+
+  function dotColor(type: string): string {
+    return typeStyles[type] ?? 'bg-surface-400'
+  }
+
+  function formatTime(date: Date): string {
+    try {
+      const d = new Date(date)
+      return d.toLocaleTimeString('en-US', {
+        hour12: false,
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      })
+    } catch {
+      return '--:--:--'
+    }
+  }
+
+  function onkeydown(e: KeyboardEvent, index: number) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      onselect(index)
+    }
+  }
+
+  // Auto-scroll to keep active entry visible
+  $effect(() => {
+    if (activeIndex === null || !container) return
+    const el = container.querySelector(`[data-timeline-index="${activeIndex}"]`)
+    el?.scrollIntoView({ block: 'nearest' })
+  })
+</script>
+
+<div class="flex h-full flex-col">
+  <div class="shrink-0 border-b border-surface-300 px-3 py-2 dark:border-surface-700">
+    <span class="text-xs font-medium text-surface-500">Timeline</span>
+    <span class="ml-2 text-xs text-surface-400">{entries.length}</span>
+  </div>
+
+  <div
+    bind:this={container}
+    class="min-h-0 flex-1 overflow-y-auto"
+    role="listbox"
+    aria-label="Action timeline"
+  >
+    {#if entries.length === 0}
+      <p class="px-3 py-6 text-center text-xs text-surface-400">No events yet</p>
+    {:else}
+      {#each entries as entry (entry.index)}
+        <button
+          type="button"
+          role="option"
+          aria-selected={activeIndex === entry.index}
+          data-timeline-index={entry.index}
+          class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors hover:bg-surface-100 dark:hover:bg-surface-800
+            {activeIndex === entry.index
+              ? 'bg-primary-50 dark:bg-primary-900/30'
+              : ''}"
+          onclick={() => onselect(entry.index)}
+          onkeydown={(e) => onkeydown(e, entry.index)}
+        >
+          <span class="shrink-0 font-mono text-[10px] tabular-nums text-surface-400">
+            {formatTime(entry.timestamp)}
+          </span>
+          <span class="mt-0.5 h-2 w-2 shrink-0 rounded-full {dotColor(entry.type)}"></span>
+          <span class="min-w-0 flex-1 truncate text-surface-700 dark:text-surface-300">
+            {entry.summary}
+          </span>
+        </button>
+      {/each}
+    {/if}
+  </div>
+</div>

--- a/frontend/src/components/AgentErrorBanner.svelte
+++ b/frontend/src/components/AgentErrorBanner.svelte
@@ -128,8 +128,8 @@
   {#if logsExpanded && logs.length > 0}
     <div class="mt-3 max-h-48 overflow-y-auto rounded bg-surface-900 p-3 font-mono text-xs text-surface-200">
       {#each logs as ev}
-        {#if ev.content}
-          <div class="mb-0.5 leading-relaxed">{ev.content}</div>
+        {#if ev.event.content}
+          <div class="mb-0.5 leading-relaxed">{ev.event.content}</div>
         {/if}
       {/each}
     </div>

--- a/frontend/src/components/ChatView.svelte
+++ b/frontend/src/components/ChatView.svelte
@@ -13,13 +13,16 @@
     inputTokens?: number
     outputTokens?: number
     bounded?: boolean
+    highlightIndex?: number | null
+    onvisibleindex?: (index: number) => void
   }
 
-  const { agentId, agentState = 'running', costUsd = 0, inputTokens = 0, outputTokens = 0, bounded = false }: Props = $props()
+  const { agentId, agentState = 'running', costUsd = 0, inputTokens = 0, outputTokens = 0, bounded = false, highlightIndex = null, onvisibleindex }: Props = $props()
 
   let events = $state<agent.ConvoEvent[]>([])
   let container: HTMLDivElement | undefined = $state()
   let autoScroll = $state(true)
+  let flashIndex = $state<number | null>(null)
 
   const isRunning = $derived(agentState === 'running')
   const isPaused = $derived(agentState === 'paused')
@@ -40,6 +43,17 @@
   function onScroll() {
     if (!container) return
     autoScroll = container.scrollHeight - container.scrollTop - container.clientHeight < 10
+    if (onvisibleindex) {
+      const els = container.querySelectorAll<HTMLElement>('[data-event-index]')
+      for (const el of els) {
+        const rect = el.getBoundingClientRect()
+        const parentRect = container.getBoundingClientRect()
+        if (rect.top >= parentRect.top && rect.bottom <= parentRect.bottom) {
+          onvisibleindex(Number(el.dataset.eventIndex))
+          break
+        }
+      }
+    }
   }
 
   function scrollToBottom() {
@@ -47,6 +61,18 @@
       container.scrollTop = container.scrollHeight
     }
   }
+
+  // Scroll to highlighted event
+  $effect(() => {
+    if (highlightIndex === null || !container) return
+    const el = container.querySelector<HTMLElement>(`[data-event-index="${highlightIndex}"]`)
+    if (!el) return
+    autoScroll = false
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    flashIndex = highlightIndex
+    const t = setTimeout(() => { flashIndex = null }, 600)
+    return () => clearTimeout(t)
+  })
 
   $effect(() => {
     convoStore.getOutput(agentId).then((initial) => {
@@ -133,7 +159,13 @@
       <p class="py-12 text-center text-sm text-surface-500">Waiting for response...</p>
     {:else}
       {#each events as event, i (i)}
-        <MessageBubble {event} />
+        <div
+          data-event-index={i}
+          class="rounded transition-colors duration-300
+            {flashIndex === i ? 'bg-warning-100/50 dark:bg-warning-900/20' : ''}"
+        >
+          <MessageBubble {event} />
+        </div>
       {/each}
     {/if}
 

--- a/frontend/src/components/StreamOutput.svelte
+++ b/frontend/src/components/StreamOutput.svelte
@@ -71,7 +71,7 @@
     if (!agentId) return
 
     agentStore.getOutput(agentId).then((initial) => {
-      events = initial
+      events = initial.map((tse) => tse.event)
       scrollToBottom()
     })
 

--- a/frontend/src/components/StreamOutput.svelte
+++ b/frontend/src/components/StreamOutput.svelte
@@ -8,13 +8,16 @@
   interface Props {
     agentId?: string
     staticEvents?: agent.StreamEvent[]
+    highlightIndex?: number | null
+    onvisibleindex?: (index: number) => void
   }
 
-  const { agentId, staticEvents }: Props = $props()
+  const { agentId, staticEvents, highlightIndex = null, onvisibleindex }: Props = $props()
 
   let events = $state<agent.StreamEvent[]>([])
   let container: HTMLDivElement | undefined = $state()
   let autoScroll = $state(true)
+  let flashIndex = $state<number | null>(null)
 
   const typeStyles: Record<string, { label: string; classes: string }> = {
     init: { label: 'INIT', classes: 'bg-surface-300 text-surface-800 dark:bg-surface-600 dark:text-surface-200' },
@@ -27,6 +30,17 @@
   function onScroll() {
     if (!container) return
     autoScroll = container.scrollHeight - container.scrollTop - container.clientHeight < 10
+    if (onvisibleindex) {
+      const els = container.querySelectorAll<HTMLElement>('[data-event-index]')
+      for (const el of els) {
+        const rect = el.getBoundingClientRect()
+        const parentRect = container.getBoundingClientRect()
+        if (rect.top >= parentRect.top && rect.bottom <= parentRect.bottom) {
+          onvisibleindex(Number(el.dataset.eventIndex))
+          break
+        }
+      }
+    }
   }
 
   function scrollToBottom() {
@@ -34,6 +48,18 @@
       container.scrollTop = container.scrollHeight
     }
   }
+
+  // Scroll to highlighted event
+  $effect(() => {
+    if (highlightIndex === null || !container) return
+    const el = container.querySelector<HTMLElement>(`[data-event-index="${highlightIndex}"]`)
+    if (!el) return
+    autoScroll = false
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    flashIndex = highlightIndex
+    const t = setTimeout(() => { flashIndex = null }, 600)
+    return () => clearTimeout(t)
+  })
 
   $effect(() => {
     if (staticEvents) {
@@ -85,7 +111,11 @@
     {:else}
       {#each events as event, i (i)}
         {@const style = typeStyles[event.type] ?? { label: event.type.toUpperCase(), classes: 'bg-surface-700 text-surface-200' }}
-        <div class="flex items-start gap-2">
+        <div
+          data-event-index={i}
+          class="flex items-start gap-2 rounded transition-colors duration-300
+            {flashIndex === i ? 'bg-warning-900/40' : ''}"
+        >
           <span class="mt-0.5 inline-block shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold {style.classes}">
             {style.label}
           </span>

--- a/frontend/src/components/StreamOutput.svelte.test.ts
+++ b/frontend/src/components/StreamOutput.svelte.test.ts
@@ -21,6 +21,10 @@ function makeEvent(type: string, content: string | undefined = undefined) {
   return { type, content }
 }
 
+function makeTSE(type: string, content: string | undefined = undefined) {
+  return { event: makeEvent(type, content), receivedAt: new Date() }
+}
+
 describe('StreamOutput', () => {
   let StreamOutput: typeof import('./StreamOutput.svelte').default
 
@@ -43,8 +47,8 @@ describe('StreamOutput', () => {
 
   it('renders events when getOutput returns data', async () => {
     mockGetOutput.mockResolvedValue([
-      makeEvent('assistant', 'Hello world'),
-      makeEvent('tool_use', 'Running tests'),
+      makeTSE('assistant', 'Hello world'),
+      makeTSE('tool_use', 'Running tests'),
     ])
 
     render(StreamOutput, { props: { agentId: 'test-1' } })
@@ -58,7 +62,7 @@ describe('StreamOutput', () => {
   })
 
   it('renders unknown event type label as uppercase', async () => {
-    mockGetOutput.mockResolvedValue([makeEvent('custom', 'data')])
+    mockGetOutput.mockResolvedValue([makeTSE('custom', 'data')])
 
     render(StreamOutput, { props: { agentId: 'test-1' } })
 
@@ -69,11 +73,11 @@ describe('StreamOutput', () => {
 
   it('renders all known type labels', async () => {
     mockGetOutput.mockResolvedValue([
-      makeEvent('init', ''),
-      makeEvent('assistant', ''),
-      makeEvent('tool_use', ''),
-      makeEvent('tool_result', ''),
-      makeEvent('result', ''),
+      makeTSE('init', ''),
+      makeTSE('assistant', ''),
+      makeTSE('tool_use', ''),
+      makeTSE('tool_result', ''),
+      makeTSE('result', ''),
     ])
 
     render(StreamOutput, { props: { agentId: 'test-1' } })
@@ -88,7 +92,7 @@ describe('StreamOutput', () => {
   })
 
   it('handles event with undefined content', async () => {
-    mockGetOutput.mockResolvedValue([makeEvent('assistant')])
+    mockGetOutput.mockResolvedValue([makeTSE('assistant')])
 
     render(StreamOutput, { props: { agentId: 'test-1' } })
 

--- a/frontend/src/lib/timeline.ts
+++ b/frontend/src/lib/timeline.ts
@@ -52,3 +52,39 @@ export function buildStreamTimeline(events: TimestampedStreamEvent[]): TimelineE
     summary: summarize(e.event),
   }))
 }
+
+function summarizeConvo(event: agent.ConvoEvent): string {
+  switch (event.type) {
+    case 'user_input':
+      return event.text ? 'User: ' + trunc(event.text.split('\n')[0].trim()) : 'User input'
+    case 'assistant': {
+      if (event.toolUses && event.toolUses.length > 0) {
+        return event.toolUses.map((t) => t.name).join(', ')
+      }
+      if (event.text) return trunc(event.text.split('\n')[0].trim() || 'Assistant')
+      return 'Assistant'
+    }
+    case 'user': {
+      // tool results
+      const hasError = event.toolResults?.some((r) => r.isError)
+      return hasError ? 'Result (error)' : 'Result'
+    }
+    case 'result': {
+      const cost = event.costUsd ? ` — $${event.costUsd.toFixed(2)}` : ''
+      return `Done${cost}`
+    }
+    case 'system':
+      return 'System'
+    default:
+      return event.type
+  }
+}
+
+export function buildConvoTimeline(events: agent.ConvoEvent[]): TimelineEntry[] {
+  return events.map((e, i) => ({
+    index: i,
+    timestamp: new Date(e.timestamp),
+    type: e.type,
+    summary: summarizeConvo(e),
+  }))
+}

--- a/frontend/src/lib/timeline.ts
+++ b/frontend/src/lib/timeline.ts
@@ -1,0 +1,54 @@
+import type { agent } from '../../wailsjs/go/models.js'
+
+export interface TimestampedStreamEvent {
+  event: agent.StreamEvent
+  receivedAt: Date
+}
+
+export interface TimelineEntry {
+  index: number
+  timestamp: Date
+  type: string
+  summary: string
+}
+
+const MAX_SUMMARY = 60
+
+function trunc(s: string): string {
+  return s.length > MAX_SUMMARY ? s.slice(0, MAX_SUMMARY) + '…' : s
+}
+
+function summarize(event: agent.StreamEvent): string {
+  switch (event.type) {
+    case 'init':
+      return 'Session started'
+    case 'assistant': {
+      if (!event.content) return 'Assistant'
+      const lines = event.content.split('\n')
+      for (let i = lines.length - 1; i >= 0; i--) {
+        const line = lines[i].trim()
+        if (line.startsWith('[')) return trunc(line)
+      }
+      return trunc(lines[0].trim() || 'Assistant')
+    }
+    case 'tool_use':
+      return event.content ? trunc(event.content.trim()) : 'Tool use'
+    case 'tool_result':
+      return event.content ? 'Result: ' + trunc(event.content.trim()) : 'Result'
+    case 'result': {
+      const cost = event.cost_usd ? ` — $${event.cost_usd.toFixed(2)}` : ''
+      return `Done${cost}`
+    }
+    default:
+      return event.type
+  }
+}
+
+export function buildStreamTimeline(events: TimestampedStreamEvent[]): TimelineEntry[] {
+  return events.map((e, i) => ({
+    index: i,
+    timestamp: e.receivedAt,
+    type: e.event.type,
+    summary: summarize(e.event),
+  }))
+}

--- a/frontend/src/pages/AgentDetail.svelte
+++ b/frontend/src/pages/AgentDetail.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
-  import { ChevronLeft } from '@lucide/svelte'
+  import { ChevronLeft, PanelLeft } from '@lucide/svelte'
   import type { agent } from '../../wailsjs/go/models.js'
   import { EventsOn, RespondEscalation } from '$lib/api'
   import { agentStore } from '../stores/agents.svelte.js'
   import { taskStore } from '../stores/tasks.svelte.js'
+  import { convoStore } from '../stores/convo.svelte.js'
   import { agentState, agentEscalation, agentError } from '../lib/events.js'
   import StreamOutput from '../components/StreamOutput.svelte'
   import ChatView from '../components/ChatView.svelte'
   import AgentErrorBanner from '../components/AgentErrorBanner.svelte'
+  import ActionTimeline from '../components/ActionTimeline.svelte'
   import { getAgentPhase, PHASE_CONFIG } from '$lib/agent-phases.js'
+  import { buildStreamTimeline, buildConvoTimeline } from '$lib/timeline.js'
 
   interface EscalationEvent {
     reason: string
@@ -36,6 +39,8 @@
   let escalation = $state<EscalationEvent | null>(null)
   let escalationResponding = $state(false)
   let errorDismissed = $state(false)
+  let timelineOpen = $state(true)
+  let selectedIndex = $state<number | null>(null)
 
   const isRunning = $derived(a?.state === 'running')
 
@@ -58,6 +63,15 @@
       : 'done',
   )
   const phaseConfig = $derived(PHASE_CONFIG[phase])
+
+  // Timeline entries — reactive to store changes
+  const streamOutputs = $derived(agentStore.outputs.get(agentId) ?? [])
+  const convoEvents = $derived(convoStore.conversations.get(agentId) ?? [])
+  const timelineEntries = $derived(
+    a?.mode === 'interactive'
+      ? buildConvoTimeline(convoEvents)
+      : buildStreamTimeline(streamOutputs),
+  )
 
   $effect(() => {
     const cached = agentStore.agents.get(agentId)
@@ -120,7 +134,29 @@
     if (!date) return '-'
     return new Date(date).toLocaleString()
   }
+
+  function onkeydown(e: KeyboardEvent) {
+    // Don't hijack when typing in an input/textarea
+    const tag = (e.target as HTMLElement).tagName
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || (e.target as HTMLElement).isContentEditable) return
+
+    if (e.key === '[' || e.key === 'ArrowLeft') {
+      e.preventDefault()
+      selectedIndex = selectedIndex === null
+        ? Math.max(0, timelineEntries.length - 1)
+        : Math.max(0, selectedIndex - 1)
+    } else if (e.key === ']' || e.key === 'ArrowRight') {
+      e.preventDefault()
+      selectedIndex = selectedIndex === null
+        ? 0
+        : Math.min(timelineEntries.length - 1, selectedIndex + 1)
+    } else if (e.key === 'Escape') {
+      selectedIndex = null
+    }
+  }
 </script>
+
+<svelte:window onkeydown={onkeydown} />
 
 <div class="flex flex-col gap-4 p-4 md:gap-6 md:p-6">
   <button
@@ -307,12 +343,51 @@
       </div>
 
       <div class="flex min-h-0 flex-1 flex-col gap-2">
-        <span class="text-sm font-medium text-surface-500">Output</span>
-        {#if a.mode === 'interactive'}
-          <ChatView agentId={agentId} agentState={a.state} costUsd={a.costUsd} inputTokens={a.inputTokens ?? 0} outputTokens={a.outputTokens ?? 0} />
-        {:else}
-          <StreamOutput agentId={agentId} />
-        {/if}
+        <div class="flex items-center gap-2">
+          <span class="text-sm font-medium text-surface-500">Output</span>
+          <button
+            type="button"
+            title={timelineOpen ? 'Hide timeline' : 'Show timeline'}
+            onclick={() => { timelineOpen = !timelineOpen }}
+            class="ml-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors
+              {timelineOpen
+                ? 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200'
+                : 'bg-surface-200 text-surface-500 dark:bg-surface-700 dark:text-surface-400'}"
+          >
+            <PanelLeft size={12} />
+            Timeline
+          </button>
+        </div>
+        <div class="flex min-h-0 items-start gap-3">
+          {#if timelineOpen}
+            <div class="hidden w-64 shrink-0 overflow-hidden rounded-lg border border-surface-300 dark:border-surface-700 md:flex md:flex-col" style="max-height: 600px; min-height: 300px;">
+              <ActionTimeline
+                entries={timelineEntries}
+                activeIndex={selectedIndex}
+                onselect={(i) => { selectedIndex = i }}
+              />
+            </div>
+          {/if}
+          <div class="min-w-0 flex-1">
+            {#if a.mode === 'interactive'}
+              <ChatView
+                agentId={agentId}
+                agentState={a.state}
+                costUsd={a.costUsd}
+                inputTokens={a.inputTokens ?? 0}
+                outputTokens={a.outputTokens ?? 0}
+                highlightIndex={selectedIndex}
+                onvisibleindex={(i) => { if (selectedIndex === null) selectedIndex = i }}
+              />
+            {:else}
+              <StreamOutput
+                agentId={agentId}
+                highlightIndex={selectedIndex}
+                onvisibleindex={(i) => { if (selectedIndex === null) selectedIndex = i }}
+              />
+            {/if}
+          </div>
+        </div>
       </div>
     </div>
   {:else if !error}

--- a/frontend/src/pages/AgentDetail.svelte.test.ts
+++ b/frontend/src/pages/AgentDetail.svelte.test.ts
@@ -11,6 +11,7 @@ const mockAgents = new Map()
 vi.mock('../stores/agents.svelte.js', () => ({
   agentStore: {
     agents: mockAgents,
+    outputs: new Map<string, unknown[]>(),
     stepTexts: new Map<string, string>(),
     stop: (...args: unknown[]) => mockStop(...args),
     updateAgent: (...args: unknown[]) => mockUpdateAgent(...args),

--- a/frontend/src/stores/agents.svelte.test.ts
+++ b/frontend/src/stores/agents.svelte.test.ts
@@ -168,12 +168,12 @@ describe('AgentStore', () => {
 
   describe('appendEvent', () => {
     it('appends to existing output', () => {
-      agentStore.outputs.set('a1', [{ type: 'init', content: 'start' }])
+      agentStore.outputs.set('a1', [{ event: { type: 'init', content: 'start' }, receivedAt: new Date() }])
       agentStore.appendEvent('a1', { type: 'assistant', content: 'hi' })
 
       const events = agentStore.outputs.get('a1')!
       expect(events).toHaveLength(2)
-      expect(events[1].type).toBe('assistant')
+      expect(events[1].event.type).toBe('assistant')
     })
 
     it('creates new array if none exists', () => {

--- a/frontend/src/stores/agents.svelte.test.ts
+++ b/frontend/src/stores/agents.svelte.test.ts
@@ -127,8 +127,12 @@ describe('AgentStore', () => {
 
       const result = await agentStore.getOutput('a1')
 
-      expect(result).toEqual(events)
-      expect(agentStore.outputs.get('a1')).toEqual(events)
+      expect(result).toHaveLength(1)
+      expect(result[0].event).toEqual(events[0])
+      expect(result[0].receivedAt).toBeInstanceOf(Date)
+      const stored = agentStore.outputs.get('a1')!
+      expect(stored).toHaveLength(1)
+      expect(stored[0].event).toEqual(events[0])
     })
 
     it('handles null result', async () => {

--- a/frontend/src/stores/agents.svelte.ts
+++ b/frontend/src/stores/agents.svelte.ts
@@ -11,9 +11,10 @@ import {
 import { agent } from '../../wailsjs/go/models.js'
 import { EntityStore } from './entity-store.svelte.js'
 import { extractStepText } from '$lib/step-text.js'
+import type { TimestampedStreamEvent } from '$lib/timeline.js'
 
 class AgentStore extends EntityStore<agent.Agent> {
-  outputs = new SvelteMap<string, agent.StreamEvent[]>()
+  outputs = new SvelteMap<string, TimestampedStreamEvent[]>()
   stepTexts = new SvelteMap<string, string>()
 
   constructor() {
@@ -75,23 +76,26 @@ class AgentStore extends EntityStore<agent.Agent> {
     this.outputs.delete(agentID)
   }
 
-  async getOutput(agentID: string): Promise<agent.StreamEvent[]> {
+  async getOutput(agentID: string): Promise<TimestampedStreamEvent[]> {
     const events = await GetAgentOutput(agentID)
     const list = events ?? []
-    this.outputs.set(agentID, list)
-    for (let i = list.length - 1; i >= 0; i--) {
-      const text = extractStepText(list[i])
+    const now = new Date()
+    const wrapped: TimestampedStreamEvent[] = list.map((e) => ({ event: e, receivedAt: now }))
+    this.outputs.set(agentID, wrapped)
+    for (let i = wrapped.length - 1; i >= 0; i--) {
+      const text = extractStepText(wrapped[i].event)
       if (text) {
         this.stepTexts.set(agentID, text)
         break
       }
     }
-    return list
+    return wrapped
   }
 
   appendEvent(agentID: string, event: agent.StreamEvent): void {
+    const tse: TimestampedStreamEvent = { event, receivedAt: new Date() }
     const existing = this.outputs.get(agentID) ?? []
-    this.outputs.set(agentID, [...existing, event])
+    this.outputs.set(agentID, [...existing, tse])
     const text = extractStepText(event)
     if (text) this.stepTexts.set(agentID, text)
   }


### PR DESCRIPTION
## Motivation

Implement the most-cited AI agent UX feature: a scrollable timeline of all session actions, allowing users to scrub back through an agent's full action history — similar to Devin's timeline slider.

Closes https://github.com/Automaat/synapse/issues/448

## Implementation information

- `ActionTimeline.svelte`: collapsible sidebar listing all StreamEvents and ConvoEvents as compact clickable entries (timestamp, type dot, summary); keyboard `[`/`]` nav; auto-scroll to active entry
- `timeline.ts`: `buildConvoTimeline()` for interactive mode event aggregation
- `StreamOutput` / `ChatView`: `data-event-index` attrs + `highlightIndex` prop for scroll-to with 600ms flash on selected event
- `AgentDetail`: two-column layout, timeline toggle button, `[`/`]` / Escape keyboard shortcuts, reactive timeline entries
- Timeline is in-memory only (not file-backed), persists for session lifetime