### PR TITLE
fix(worktree): force-push after rebase

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -224,6 +224,13 @@ func PushUpstream(worktreePath, branch string) error {
 	return executil.Run(worktreePath, "git", "push", "-u", "origin", branch)
 }
 
+// PushForce force-pushes the branch to origin using --force-with-lease.
+// Used after a local rebase to sync the remote without overwriting commits
+// from other authors (--force-with-lease fails if remote has unknown commits).
+func PushForce(worktreePath, branch string) error {
+	return executil.Run(worktreePath, "git", "push", "--force-with-lease", "-u", "origin", branch)
+}
+
 func RemoveWorktree(barePath, worktreePath string) error {
 	return executil.Run(barePath, "git", "worktree", "remove", "--force", worktreePath)
 }

--- a/internal/workflow/builtin/simple-task.yaml
+++ b/internal/workflow/builtin/simple-task.yaml
@@ -339,6 +339,9 @@ steps:
              If a PR number is returned, skip creation — the PR already exists.
           2. If no PR exists, push the branch and create one:
              git push -u origin HEAD
+             If push is rejected because the remote has diverged (e.g. after a
+             rebase), force-push without asking for confirmation:
+             git push --force-with-lease -u origin HEAD
              gh pr create{{if ne .Task.ProjectType "pet"}} --draft{{end}} \
                --title "<conventional-commit title>" \
                --body "<PR body with ## Motivation and ## Implementation information>"
@@ -348,6 +351,7 @@ steps:
 
         PR title must follow conventional commits format matching the task work.
         PR body must have ## Motivation and ## Implementation information sections.
+        Never ask for confirmation — this is a feature branch owned by this task.
     next:
       - goto: link_pr_and_review
 

--- a/internal/workflow/builtin/simple-task.yaml
+++ b/internal/workflow/builtin/simple-task.yaml
@@ -339,9 +339,6 @@ steps:
              If a PR number is returned, skip creation — the PR already exists.
           2. If no PR exists, push the branch and create one:
              git push -u origin HEAD
-             If push is rejected because the remote has diverged (e.g. after a
-             rebase), force-push without asking for confirmation:
-             git push --force-with-lease -u origin HEAD
              gh pr create{{if ne .Task.ProjectType "pet"}} --draft{{end}} \
                --title "<conventional-commit title>" \
                --body "<PR body with ## Motivation and ## Implementation information>"
@@ -351,7 +348,6 @@ steps:
 
         PR title must follow conventional commits format matching the task work.
         PR body must have ## Motivation and ## Implementation information sections.
-        Never ask for confirmation — this is a feature branch owned by this task.
     next:
       - goto: link_pr_and_review
 

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -109,6 +109,11 @@ func (m *Manager) PrepareForTask(t task.Task) (string, error) {
 			m.logger.Warn("worktree.rebase-skipped", "task_id", t.ID, "base", baseRef, "err", err)
 		} else {
 			m.logger.Info("worktree.rebased", "task_id", t.ID, "path", wtPath, "base", baseRef)
+			// Sync remote after rebase — local SHAs changed, remote still has
+			// old commits. create_pr push would fail with "diverged" otherwise.
+			if err := project.PushForce(wtPath, wtBranch); err != nil {
+				m.logger.Warn("worktree.push-force", "task_id", t.ID, "branch", wtBranch, "err", err)
+			}
 		}
 		m.ensureBranch(t, wtBranch)
 		return wtPath, nil
@@ -125,6 +130,11 @@ func (m *Manager) PrepareForTask(t task.Task) (string, error) {
 		}
 		if err := project.RebaseOnto(wtPath, baseRef); err != nil {
 			m.logger.Warn("worktree.rebase-skipped", "task_id", t.ID, "base", baseRef, "err", err)
+		} else {
+			// Sync remote after rebase.
+			if err := project.PushForce(wtPath, wtBranch); err != nil {
+				m.logger.Warn("worktree.push-force", "task_id", t.ID, "branch", wtBranch, "err", err)
+			}
 		}
 		m.logger.Info("worktree.reused-branch", "task_id", t.ID, "path", wtPath, "branch", wtBranch)
 		m.runSetup(wtPath, proj.SetupCommands)


### PR DESCRIPTION
## Motivation

The \`create_pr\` workflow step was failing when the branch had diverged
from remote. Root cause: \`PrepareForTask\` rebases the worktree onto
main before handing it to the agent, which changes local commit SHAs.
The remote still has the old SHAs, so \`git push\` in \`create_pr\`
fails with "non-fast-forward" and the agent stops to ask for
confirmation — outputting a question instead of a PR URL, causing
\`link_pr_and_review\` to find no PR.

## Implementation information

After a successful \`RebaseOnto\` in both worktree reuse paths
(existing worktree dir and existing local branch), call \`PushForce\`
(\`--force-with-lease -u\`) to sync the remote to the rebased state.

\`--force-with-lease\` is safe here: it fails if the remote has commits
not present in the local fetch ref, protecting against overwriting
work from other authors while allowing the rebase case.

Also adds \`PushForce\` helper to \`internal/project/git.go\`.

> Changelog: fix(worktree): force-push after rebase