### PR TITLE
fix(agent): filter resume session_id by role

### DIFF
--- a/internal/synapse/app_agents.go
+++ b/internal/synapse/app_agents.go
@@ -42,6 +42,27 @@ func resolvePermission(t task.Task, cfg *config.Config) bool {
 	return cfg.DefaultRequirePermissions()
 }
 
+// pickImplementationResumeSession walks AgentRuns newest-first and returns
+// the most recent session_id from a prior implementation run. Other roles
+// (triage, plan, eval, …) own their own session state, often run in a
+// different cwd, and resuming them from the implementation worktree makes
+// claude bail with error_during_execution before the prompt is ever sent.
+// Empty Role is treated as implementation since AgentOrchestrator records
+// implementation runs without a role string.
+func pickImplementationResumeSession(runs []task.AgentRun) string {
+	for i := len(runs) - 1; i >= 0; i-- {
+		run := runs[i]
+		if run.SessionID == "" {
+			continue
+		}
+		if run.Role != "" && run.Role != string(agent.RoleImplementation) {
+			continue
+		}
+		return run.SessionID
+	}
+	return ""
+}
+
 // AgentOrchestrator manages agent lifecycle: worktree setup, project
 // assignment, and agent launching for a task.
 type AgentOrchestrator struct {
@@ -97,13 +118,7 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, oneShot bool
 		return nil, fmt.Errorf("task %s: no working dir resolved (skipWorktree=%v) — refusing to run agent in Synapse cwd", taskID, skipWT)
 	}
 
-	resumeSessionID := ""
-	for i := len(t.AgentRuns) - 1; i >= 0; i-- {
-		if t.AgentRuns[i].SessionID != "" {
-			resumeSessionID = t.AgentRuns[i].SessionID
-			break
-		}
-	}
+	resumeSessionID := pickImplementationResumeSession(t.AgentRuns)
 
 	fullPrompt := fmt.Sprintf("# Task: %s\n\n%s\n\n---\n\n%s", t.Title, t.Body, prompt)
 	ag, err := o.agents.Run(agent.RunConfig{

--- a/internal/synapse/app_agents_test.go
+++ b/internal/synapse/app_agents_test.go
@@ -1,0 +1,87 @@
+package synapse
+
+import (
+	"testing"
+
+	"github.com/Automaat/synapse/internal/agent"
+	"github.com/Automaat/synapse/internal/task"
+)
+
+// TestPickImplementationResumeSession guards against the regression where
+// the resume-session walker grabbed the latest non-empty session_id from
+// any prior run (including triage), which made the implementation agent
+// launch with --resume against a session that lived in a different cwd.
+// Claude CLI then bailed with subtype "error_during_execution", $0 cost,
+// and verify_commits flipped the task to human-required immediately.
+func TestPickImplementationResumeSession(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		runs []task.AgentRun
+		want string
+	}{
+		{
+			name: "empty",
+			runs: nil,
+			want: "",
+		},
+		{
+			name: "only triage with session — must not resume",
+			runs: []task.AgentRun{
+				{Role: "triage", SessionID: "ses-triage"},
+			},
+			want: "",
+		},
+		{
+			name: "triage then implementation — return implementation",
+			runs: []task.AgentRun{
+				{Role: "triage", SessionID: "ses-triage"},
+				{Role: "", SessionID: "ses-impl"},
+			},
+			want: "ses-impl",
+		},
+		{
+			name: "implementation then triage — skip triage, return impl",
+			runs: []task.AgentRun{
+				{Role: "", SessionID: "ses-impl-1"},
+				{Role: "triage", SessionID: "ses-triage"},
+			},
+			want: "ses-impl-1",
+		},
+		{
+			name: "explicit implementation role",
+			runs: []task.AgentRun{
+				{Role: string(agent.RoleImplementation), SessionID: "ses-impl-explicit"},
+			},
+			want: "ses-impl-explicit",
+		},
+		{
+			name: "skip empty session_id, return previous impl",
+			runs: []task.AgentRun{
+				{Role: "", SessionID: "ses-old"},
+				{Role: "", SessionID: ""},
+			},
+			want: "ses-old",
+		},
+		{
+			name: "non-impl roles only — never resume",
+			runs: []task.AgentRun{
+				{Role: "plan", SessionID: "ses-plan"},
+				{Role: "eval", SessionID: "ses-eval"},
+				{Role: "triage", SessionID: "ses-triage"},
+			},
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := pickImplementationResumeSession(tc.runs)
+			if got != tc.want {
+				t.Errorf("pickImplementationResumeSession() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Brand-new tasks on the home-nas server were being flipped to `human-required` immediately after triage with reason `no commits pushed to branch`. Two tasks reproduced this back-to-back (`27107b7a`, `e1b18401`) — triage agent succeeded (~$0.13), implementation agent died instantly with `subtype: error_during_execution`, zero cost, and `verify_commits` then flipped the task.

Root cause is in #483 (`feat(agent): persist session_id for resume`). The resume-session walker in `internal/synapse/app_agents.go` grabs the newest non-empty `session_id` from any prior `AgentRun`:

```go
for i := len(t.AgentRuns) - 1; i >= 0; i-- {
    if t.AgentRuns[i].SessionID != "" {
        resumeSessionID = t.AgentRuns[i].SessionID
        break
    }
}
```

Triage runs first and persists its own `session_id`. When the workflow advances to the implementation step, `StartAgent` picks up the **triage** session and passes it as `--resume` to `claude` — but in the implementation worktree, which is a different cwd than where triage ran. Claude CLI errors out before any API call (`runConvoAttempt` also short-circuits the initial prompt write because `SessionID != ""`, see `internal/agent/runner_convo.go:180`).

## Implementation information

- Extracted picker into pure helper `pickImplementationResumeSession(runs)` in `internal/synapse/app_agents.go`.
- Helper now skips runs whose `Role` is set and not `"implementation"`. Empty role still matches because `AgentOrchestrator.StartAgent` records implementation runs without a role string today (see `AddRunWithStatus` call).
- Added table-driven regression test `TestPickImplementationResumeSession` in `internal/synapse/app_agents_test.go` covering empty, triage-only, triage→impl, impl→triage, explicit `RoleImplementation`, empty-session_id skipping, and non-impl-only roles.

Alternatives considered:
- Threading role through `agentOrch.StartAgent` signature — bigger blast radius, every caller would need updating.
- Letting the workflow engine pass `ResumeSessionID` explicitly on retry — cleaner long-term but requires reshuffling the agent adapter.

The role filter is the minimal fix that unblocks the broken path immediately and keeps the original retry-after-5xx intent intact.

## Supporting documentation

> Changelog: fix(agent): filter resume session_id by role