### PR TITLE
fix(workflow): unstick plan-review and stale resume

### DIFF
--- a/internal/synapse/app.go
+++ b/internal/synapse/app.go
@@ -205,7 +205,16 @@ func (a *App) Startup(ctx context.Context) error {
 		switch event {
 		case events.TaskCreated, events.TaskUpdated, events.TaskDeleted:
 			if path, ok := data.(string); ok {
-				store.InvalidatePath(path)
+				// Prefer Manager.OnExternalUpdate so cross-process file
+				// writes (synapse-cli inside an agent worktree) flow
+				// through the same status-change hook as in-process
+				// updates. Falls back to a bare cache invalidate if the
+				// Manager has not been wired yet (degraded-init path).
+				if a.tasks != nil {
+					a.tasks.OnExternalUpdate(path)
+				} else {
+					store.InvalidatePath(path)
+				}
 			}
 		}
 		a.emit(event, data)

--- a/internal/synapse/app_agents.go
+++ b/internal/synapse/app_agents.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/Automaat/synapse/internal/agent"
 	"github.com/Automaat/synapse/internal/audit"
@@ -45,19 +46,34 @@ func resolvePermission(t task.Task, cfg *config.Config) bool {
 }
 
 // pickImplementationResumeSession walks AgentRuns newest-first and returns
-// the most recent session_id from a prior implementation run. Other roles
-// (triage, plan, eval, …) own their own session state, often run in a
-// different cwd, and resuming them from the implementation worktree makes
-// claude bail with error_during_execution before the prompt is ever sent.
-// Empty Role is treated as implementation since AgentOrchestrator records
-// implementation runs without a role string.
-func pickImplementationResumeSession(runs []task.AgentRun) string {
+// the most recent session_id from a prior implementation run that belongs
+// to the current workflow execution.
+//
+// Two filters are applied:
+//
+//  1. Role must be implementation. Other roles (triage, plan, eval, …) own
+//     their own session state, often run in a different cwd, and resuming
+//     them from the implementation worktree makes claude bail with
+//     error_during_execution before the prompt is ever sent. Empty Role is
+//     allowed only for legacy runs predating the orchestrator role-recording
+//     fix; new runs always carry Role explicitly.
+//  2. StartedAt must be at or after workflowStart. A previous workflow
+//     execution may have left an aborted implementation run with a
+//     session_id that no longer exists in claude's session store. Resuming
+//     it would make claude exit with "No conversation found", cost $0,
+//     and verify_commits flip the task to human-required without ever
+//     running the implementation prompt. workflowStart=zero disables the
+//     time filter (useful for callers that have no execution context).
+func pickImplementationResumeSession(runs []task.AgentRun, workflowStart time.Time) string {
 	for i := len(runs) - 1; i >= 0; i-- {
 		run := runs[i]
 		if run.SessionID == "" {
 			continue
 		}
 		if run.Role != "" && run.Role != string(agent.RoleImplementation) {
+			continue
+		}
+		if !workflowStart.IsZero() && run.StartedAt.Before(workflowStart) {
 			continue
 		}
 		return run.SessionID
@@ -121,7 +137,11 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, oneShot bool
 		return nil, fmt.Errorf("task %s: no working dir resolved (skipWorktree=%v) — refusing to run agent in Synapse cwd", taskID, skipWT)
 	}
 
-	resumeSessionID := pickImplementationResumeSession(t.AgentRuns)
+	var workflowStart time.Time
+	if t.Workflow != nil {
+		workflowStart = t.Workflow.StartedAt
+	}
+	resumeSessionID := pickImplementationResumeSession(t.AgentRuns, workflowStart)
 
 	var extraEnv []string
 	if o.sandboxes != nil && t.ProjectID != "" {
@@ -177,7 +197,9 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, oneShot bool
 	}
 	if err := o.tasks.AddRunWithStatus(taskID, task.AgentRun{
 		AgentID:   ag.ID,
+		Role:      string(agent.RoleImplementation),
 		Mode:      effMode,
+		Provider:  ag.Provider,
 		State:     string(agent.StateRunning),
 		StartedAt: ag.StartedAt,
 	}, nextStatus); err != nil {

--- a/internal/synapse/app_agents_test.go
+++ b/internal/synapse/app_agents_test.go
@@ -2,24 +2,36 @@ package synapse
 
 import (
 	"testing"
+	"time"
 
 	"github.com/Automaat/synapse/internal/agent"
 	"github.com/Automaat/synapse/internal/task"
 )
 
-// TestPickImplementationResumeSession guards against the regression where
-// the resume-session walker grabbed the latest non-empty session_id from
-// any prior run (including triage), which made the implementation agent
-// launch with --resume against a session that lived in a different cwd.
-// Claude CLI then bailed with subtype "error_during_execution", $0 cost,
-// and verify_commits flipped the task to human-required immediately.
+// TestPickImplementationResumeSession pins two regression guards on the
+// resume-session walker:
+//
+//  1. Cross-role pollution: triage/plan/eval session_ids must never be
+//     handed to the implementation agent, even when they are the most
+//     recent run on the task. Claude CLI bails with
+//     "error_during_execution" because the session lives in a different
+//     cwd.
+//  2. Cross-workflow pollution: an aborted implementation run from a
+//     prior workflow execution must not leak its session_id into a fresh
+//     execution. The session_id no longer exists in claude's session
+//     store, so claude exits with "No conversation found", cost $0, and
+//     verify_commits flips the task to human-required without ever
+//     running the implementation prompt.
 func TestPickImplementationResumeSession(t *testing.T) {
 	t.Parallel()
 
+	wfStart := time.Now()
+
 	cases := []struct {
-		name string
-		runs []task.AgentRun
-		want string
+		name          string
+		runs          []task.AgentRun
+		workflowStart time.Time
+		want          string
 	}{
 		{
 			name: "empty",
@@ -37,14 +49,14 @@ func TestPickImplementationResumeSession(t *testing.T) {
 			name: "triage then implementation — return implementation",
 			runs: []task.AgentRun{
 				{Role: "triage", SessionID: "ses-triage"},
-				{Role: "", SessionID: "ses-impl"},
+				{Role: string(agent.RoleImplementation), SessionID: "ses-impl"},
 			},
 			want: "ses-impl",
 		},
 		{
 			name: "implementation then triage — skip triage, return impl",
 			runs: []task.AgentRun{
-				{Role: "", SessionID: "ses-impl-1"},
+				{Role: string(agent.RoleImplementation), SessionID: "ses-impl-1"},
 				{Role: "triage", SessionID: "ses-triage"},
 			},
 			want: "ses-impl-1",
@@ -59,8 +71,8 @@ func TestPickImplementationResumeSession(t *testing.T) {
 		{
 			name: "skip empty session_id, return previous impl",
 			runs: []task.AgentRun{
-				{Role: "", SessionID: "ses-old"},
-				{Role: "", SessionID: ""},
+				{Role: string(agent.RoleImplementation), SessionID: "ses-old"},
+				{Role: string(agent.RoleImplementation), SessionID: ""},
 			},
 			want: "ses-old",
 		},
@@ -73,12 +85,72 @@ func TestPickImplementationResumeSession(t *testing.T) {
 			},
 			want: "",
 		},
+		{
+			name: "legacy empty-Role run still picked when no time cutoff",
+			runs: []task.AgentRun{
+				{Role: "", SessionID: "ses-legacy"},
+			},
+			want: "ses-legacy",
+		},
+		{
+			name: "stale impl from prior workflow — must NOT resume",
+			runs: []task.AgentRun{
+				{
+					Role:      string(agent.RoleImplementation),
+					SessionID: "ses-stale",
+					StartedAt: wfStart.Add(-24 * time.Hour),
+				},
+			},
+			workflowStart: wfStart,
+			want:          "",
+		},
+		{
+			name: "stale empty-Role impl from prior workflow — must NOT resume",
+			runs: []task.AgentRun{
+				{
+					Role:      "",
+					SessionID: "ses-stale-empty",
+					StartedAt: wfStart.Add(-24 * time.Hour),
+				},
+			},
+			workflowStart: wfStart,
+			want:          "",
+		},
+		{
+			name: "current-workflow impl preferred over stale impl",
+			runs: []task.AgentRun{
+				{
+					Role:      string(agent.RoleImplementation),
+					SessionID: "ses-stale",
+					StartedAt: wfStart.Add(-24 * time.Hour),
+				},
+				{
+					Role:      string(agent.RoleImplementation),
+					SessionID: "ses-current",
+					StartedAt: wfStart.Add(time.Minute),
+				},
+			},
+			workflowStart: wfStart,
+			want:          "ses-current",
+		},
+		{
+			name: "run started exactly at workflow start is eligible",
+			runs: []task.AgentRun{
+				{
+					Role:      string(agent.RoleImplementation),
+					SessionID: "ses-edge",
+					StartedAt: wfStart,
+				},
+			},
+			workflowStart: wfStart,
+			want:          "ses-edge",
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := pickImplementationResumeSession(tc.runs)
+			got := pickImplementationResumeSession(tc.runs, tc.workflowStart)
 			if got != tc.want {
 				t.Errorf("pickImplementationResumeSession() = %q, want %q", got, tc.want)
 			}

--- a/internal/synapse/app_watcher_status_test.go
+++ b/internal/synapse/app_watcher_status_test.go
@@ -1,0 +1,128 @@
+package synapse
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Automaat/synapse/internal/events"
+	"github.com/Automaat/synapse/internal/fsutil"
+	"github.com/Automaat/synapse/internal/task"
+	"github.com/Automaat/synapse/internal/watcher"
+	"github.com/Automaat/synapse/internal/workflow"
+)
+
+// TestApp_WatcherStatusHook_AdvancesWorkflow reproduces the production bug
+// where two tasks sat permanently in plan-review without ever entering
+// critique_plan.
+//
+// Repro shape:
+//   - simple-task workflow parks at the `plan` step waiting for status
+//     plan-review (wait_for_status).
+//   - The plan agent runs `synapse-cli update --status plan-review` from a
+//     separate process that bypasses the in-process task.Manager and writes
+//     the file directly.
+//   - The watcher fires TaskUpdated. Before the fix, the emit callback only
+//     called store.InvalidatePath — it never invoked the status-change
+//     hook, so HandleStatusChange never ran and the workflow was stranded.
+//
+// This test simulates the cross-process write with fsutil.AtomicWrite (the
+// same primitive synapse-cli uses) and asserts that the workflow advances
+// past `plan` after the file is written.
+func TestApp_WatcherStatusHook_AdvancesWorkflow(t *testing.T) {
+	taskSvc, app := setupTaskService(t)
+	app.workflowEngine = taskSvc.workflowEngine
+	app.initStatusHook()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// Mirror app.go's emit callback: forward task file events through
+	// task.Manager.OnExternalUpdate so cross-process writes participate
+	// in the same status-hook plumbing as in-process Manager updates.
+	// Mirror app.go's emit callback: forward task file events through
+	// task.Manager.OnExternalUpdate so cross-process writes participate
+	// in the same status-hook plumbing as in-process Manager updates.
+	emit := func(event string, data any) {
+		switch event {
+		case events.TaskCreated, events.TaskUpdated, events.TaskDeleted:
+			if path, ok := data.(string); ok {
+				app.tasks.OnExternalUpdate(path)
+			}
+		}
+	}
+	w := watcher.New(app.tasksDir, emit, app.logger)
+	if err := w.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	<-w.Ready()
+
+	created, err := app.tasks.Create("watcher status hook task", "", "interactive")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Tag nocritic so the workflow's maybe_critique branch routes directly
+	// to review_plan instead of trying to launch a plan-critic agent
+	// (which would fail in this lightweight setup).
+	if _, err := app.tasks.UpdateMap(created.ID, map[string]any{"tags": []string{"nocritic"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Park the workflow at the simple-task `plan` step. The plan step
+	// declares wait_for_status: plan-review.
+	if _, err := app.tasks.UpdateMap(created.ID, map[string]any{
+		"status": "planning",
+		"workflow": &workflow.Execution{
+			WorkflowID:  "simple-task",
+			CurrentStep: "plan",
+			State:       workflow.ExecWaiting,
+			Variables:   map[string]string{},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Snapshot the on-disk task and rewrite it with status=plan-review
+	// using AtomicWrite (the same path synapse-cli takes). This bypasses
+	// task.Manager entirely, mirroring the cross-process behaviour that
+	// caused the bug in production.
+	current, err := app.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	current.Status = task.StatusPlanReview
+	data, err := task.Marshal(current)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := fsutil.AtomicWrite(current.FilePath, data); err != nil {
+		t.Fatal(err)
+	}
+
+	// The watcher should fire, the emit callback should detect the
+	// status change, and the workflow engine should advance past the
+	// `plan` step.
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			tk, _ := app.tasks.Get(created.ID)
+			step := ""
+			state := ""
+			if tk.Workflow != nil {
+				step = tk.Workflow.CurrentStep
+				state = string(tk.Workflow.State)
+			}
+			t.Fatalf("workflow stuck on step %q (state=%q, status=%q) after external status change to plan-review", step, state, tk.Status)
+		case <-time.After(50 * time.Millisecond):
+			tk, err := app.tasks.Get(created.ID)
+			if err != nil {
+				continue
+			}
+			if tk.Workflow != nil && tk.Workflow.CurrentStep != "plan" {
+				return // success — workflow advanced
+			}
+		}
+	}
+}

--- a/internal/synapse/orchestrator_resume_test.go
+++ b/internal/synapse/orchestrator_resume_test.go
@@ -1,0 +1,201 @@
+//go:build !short
+
+package synapse
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Automaat/synapse/internal/agent"
+	"github.com/Automaat/synapse/internal/project"
+	"github.com/Automaat/synapse/internal/task"
+	"github.com/Automaat/synapse/internal/workflow"
+	"github.com/Automaat/synapse/internal/worktree"
+)
+
+// TestOrchestrator_StartAgent_DoesNotResumeStaleSessionFromPriorWorkflow
+// reproduces the production failure where an `implement` agent inherited
+// a session_id from a long-finished prior workflow execution.
+//
+// Production timeline (task e1b18401):
+//  1. Workflow ran triage → set_in_progress → implement. The implement agent
+//     was launched via AgentOrchestrator.StartAgent, which records its
+//     agent_run with an empty Role and a session_id.
+//  2. The first implement attempt produced no commits and the workflow
+//     stalled. ~25 minutes later the workflow was restarted from triage and
+//     ran all the way through plan → critique → address → review → implement.
+//  3. On the second implement step, pickImplementationResumeSession walked
+//     AgentRuns newest-first looking for runs with empty/implementation Role
+//     plus a session_id. It picked up the original empty-Role run from step 1
+//     and passed `--resume <stale-session>` to claude.
+//  4. Claude stderr: `No conversation found with session ID: bb7ebc41-...`,
+//     exit status 1, cost $0, prompt never sent. verify_commits flipped the
+//     task to human-required.
+//
+// The fix has two parts:
+//   - AgentOrchestrator.StartAgent now records implementation agent runs
+//     with Role explicitly set, so the empty-Role escape hatch in
+//     pickImplementationResumeSession can be removed.
+//   - pickImplementationResumeSession only considers runs whose StartedAt
+//     is at or after the current workflow execution's StartedAt, so a
+//     stale run from a prior workflow run cannot leak in even when the
+//     role check would otherwise match.
+//
+// This test sets up a real bare git repo, a real project store, a real
+// worktree manager, and the real AgentOrchestrator — then exercises the
+// exact code path that misbehaved in production. It pre-seeds an aborted
+// prior-execution agent_run, calls AgentOrchestrator.StartAgent, and
+// asserts that the resulting fake-claude argv does NOT carry --resume
+// pointing at the stale session.
+func TestOrchestrator_StartAgent_DoesNotResumeStaleSessionFromPriorWorkflow(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	binDir := buildTestBinaries(t)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	t.Setenv("FAKE_CLAUDE_SCENARIO", "interactive_implement")
+
+	argsLog := filepath.Join(t.TempDir(), "claude-args.log")
+	t.Setenv("FAKE_CLAUDE_ARGS_LOG", argsLog)
+
+	home, err := os.MkdirTemp("", "synapse-orch-resume-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(home) })
+	t.Setenv("SYNAPSE_HOME", home)
+
+	tasksDir := filepath.Join(home, "tasks")
+	if err := os.MkdirAll(tasksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	taskStore, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskMgr := task.NewManager(taskStore, nil)
+
+	projStore, err := project.NewStore(
+		filepath.Join(home, "projects"),
+		filepath.Join(home, "clones"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	src := initSourceRepo(t)
+	barePath := filepath.Join(home, "clones", "testowner", "testrepo.git")
+	if err := os.MkdirAll(filepath.Dir(barePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := project.CloneBare(src, barePath); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+
+	projYAML := `id: testowner/testrepo
+name: testrepo
+owner: testowner
+repo: testrepo
+url: ` + src + `
+clone_path: ` + barePath + `
+type: pet
+created_at: 2025-01-01T00:00:00Z
+updated_at: 2025-01-01T00:00:00Z
+`
+	if err := os.WriteFile(filepath.Join(home, "projects", "testowner--testrepo.yaml"), []byte(projYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logDir := filepath.Join(home, "logs")
+	_ = os.MkdirAll(logDir, 0o755)
+
+	agentMgr := agent.NewManager(t.Context(), func(string, any) {}, logger, logDir)
+	agentMgr.SetDefaultProvider("claude")
+
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: filepath.Join(home, "worktrees"),
+		Projects:     projStore,
+		Tasks:        taskMgr,
+		Logger:       logger,
+		AgentChecker: agentMgr.HasRunningAgentForTask,
+	})
+
+	orch := newAgentOrchestrator(taskMgr, projStore, agentMgr, nil, logger, wm, nil)
+
+	// Create the task with the project pre-assigned so PrepareForTask succeeds.
+	created, err := taskMgr.Create("stale-resume guard", "", "interactive")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := taskMgr.Update(created.ID, task.Update{
+		ProjectID: task.Ptr("testowner/testrepo"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Park the task in a workflow execution that started "now". Anything
+	// before that timestamp is by definition from a prior execution and
+	// must not be eligible for --resume.
+	workflowStart := time.Now()
+	if _, err := taskMgr.UpdateMap(created.ID, map[string]any{
+		"workflow": &workflow.Execution{
+			WorkflowID:  "simple-task",
+			CurrentStep: "implement",
+			State:       workflow.ExecRunning,
+			StartedAt:   workflowStart,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed a prior-execution implementation run: empty Role, session_id
+	// set, started 24 hours before the current workflow execution. This
+	// is exactly what the bf0c5e34 task in production looked like before
+	// the second implement step picked up bb7ebc41-... by mistake.
+	const staleSession = "stale-session-from-prior-workflow"
+	if err := taskMgr.AddRun(created.ID, task.AgentRun{
+		AgentID:   "ancient-impl",
+		Mode:      "interactive",
+		Provider:  "claude",
+		State:     "stopped",
+		StartedAt: workflowStart.Add(-24 * time.Hour),
+		SessionID: staleSession,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := orch.StartAgent(created.ID, "interactive", "Implement the feature.", true); err != nil {
+		t.Fatalf("orchestrator StartAgent: %v", err)
+	}
+
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		if _, statErr := os.Stat(argsLog); statErr == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("fake-claude args log never written")
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	data, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatalf("read args log: %v", err)
+	}
+	args := string(data)
+	if !strings.Contains(args, "--input-format") {
+		t.Fatalf("args log does not look like an interactive claude invocation; got:\n%s", args)
+	}
+	if strings.Contains(args, staleSession) {
+		t.Fatalf("implement agent resumed stale cross-workflow session %q. argv:\n%s", staleSession, args)
+	}
+}

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -1,6 +1,8 @@
 package task
 
 import (
+	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/Automaat/synapse/internal/events"
@@ -36,6 +38,13 @@ type Manager struct {
 	emitter      EventEmitter
 	locks        sync.Map // string -> *sync.Mutex
 	onStatusHook StatusChangeHook
+
+	// firedMu/firedStatus tracks the most recent status value that has
+	// triggered onStatusHook. OnExternalUpdate uses it to dedupe repeated
+	// file events for the same status, while still detecting genuine
+	// cross-process transitions (where firedStatus is stale or unset).
+	firedMu     sync.RWMutex
+	firedStatus map[string]string
 }
 
 // SetStatusChangeHook registers a callback fired on every status transition.
@@ -53,6 +62,75 @@ func NewManager(store *Store, emitter EventEmitter) *Manager {
 
 // Store returns the underlying Store. Use for operations not covered by Manager.
 func (m *Manager) Store() *Store { return m.store }
+
+// OnExternalUpdate is invoked by the file watcher when a task file is
+// modified outside this Manager — typically by `synapse-cli` running in
+// a separate process. It invalidates the store cache and, when the
+// on-disk status differs from the value that last triggered the hook,
+// fires the registered status-change hook so workflow steps using
+// wait_for_status can advance.
+//
+// Without this, status flips written by out-of-process tools never
+// reach engine.HandleStatusChange and interactive plan agents leave
+// their workflow stranded on the plan step.
+func (m *Manager) OnExternalUpdate(path string) {
+	if !strings.HasSuffix(path, ".md") {
+		return
+	}
+	base := filepath.Base(path)
+	if strings.HasSuffix(base, ".plan.md") || strings.HasSuffix(base, ".plan-critique.md") {
+		m.store.InvalidatePath(path)
+		return
+	}
+	id := strings.TrimSuffix(base, ".md")
+	if id == "" {
+		return
+	}
+
+	m.store.InvalidatePath(path)
+
+	if m.onStatusHook == nil {
+		return
+	}
+
+	t, err := m.store.Get(id)
+	if err != nil {
+		return
+	}
+	newStatus := string(t.Status)
+
+	prev, ok := m.lastFiredStatus(id)
+	if ok && prev == newStatus {
+		return
+	}
+	m.recordFiredStatus(id, newStatus)
+	m.onStatusHook(id, prev, newStatus)
+}
+
+func (m *Manager) recordFiredStatus(id, status string) {
+	m.firedMu.Lock()
+	defer m.firedMu.Unlock()
+	if m.firedStatus == nil {
+		m.firedStatus = make(map[string]string)
+	}
+	m.firedStatus[id] = status
+}
+
+func (m *Manager) lastFiredStatus(id string) (string, bool) {
+	m.firedMu.RLock()
+	defer m.firedMu.RUnlock()
+	if m.firedStatus == nil {
+		return "", false
+	}
+	s, ok := m.firedStatus[id]
+	return s, ok
+}
+
+func (m *Manager) forgetFiredStatus(id string) {
+	m.firedMu.Lock()
+	defer m.firedMu.Unlock()
+	delete(m.firedStatus, id)
+}
 
 // Comments returns the underlying CommentStore.
 func (m *Manager) Comments() *CommentStore { return m.store.Comments() }
@@ -82,6 +160,7 @@ func (m *Manager) Create(title, body, mode string) (Task, error) {
 		return t, err
 	}
 	metrics.TaskCreated()
+	m.recordFiredStatus(t.ID, string(t.Status))
 	m.emitter.Emit(events.TaskCreated, t.FilePath)
 	return t, nil
 }
@@ -135,6 +214,7 @@ func (m *Manager) Update(id string, u Update) (Task, error) {
 	mu.Unlock()
 
 	if fireHook {
+		m.recordFiredStatus(id, newStatus)
 		m.onStatusHook(id, prevStatus, newStatus)
 	}
 	return t, nil
@@ -163,6 +243,7 @@ func (m *Manager) Delete(id string) error {
 		return err
 	}
 	m.locks.Delete(id)
+	m.forgetFiredStatus(id)
 	metrics.TaskDeleted()
 	m.emitter.Emit(events.TaskDeleted, t.FilePath)
 	return nil
@@ -201,6 +282,7 @@ func (m *Manager) AddRunWithStatus(taskID string, run AgentRun, status *Status) 
 	}
 	mu.Unlock()
 	if fireHook {
+		m.recordFiredStatus(taskID, newStatus)
 		m.onStatusHook(taskID, prevStatus, newStatus)
 	}
 	return nil


### PR DESCRIPTION
## Motivation

Two production tasks (`27107b7a`, `e1b18401`) sat stuck in the workflow on the synapse server. Investigation surfaced two distinct bugs blocking the plan/implement chain.

**Bug 1 — `plan-review` never advances past `plan` step.**
Interactive plan agents flip status via `synapse-cli` running in a separate process. The watcher detected the file change but the emit callback only called `store.InvalidatePath`. The status-change hook (and therefore `engine.HandleStatusChange`) never fired, so workflow steps with `wait_for_status: plan-review` stayed parked forever. `critique_plan` (codex cross-provider) was unreachable.

**Bug 2 — implement step inherits stale session from prior workflow run.**
`pickImplementationResumeSession` walked `AgentRuns` newest-first matching empty/implementation `Role` with a non-empty `session_id`. The empty-Role fallback existed because `AgentOrchestrator` recorded its agent runs without a `Role` string. Combined with no time bound, a previous workflow execution's aborted implementation run leaked its `session_id` into a fresh execution. Claude was launched with `--resume <stale>`, the session no longer existed in claude's session store, claude exited with `No conversation found`, cost $0, prompt never sent, and `verify_commits` flipped the task to `human-required` with `"no commits pushed to branch"`. Production trace: `bf0c5e34` inherited `bb7ebc41-...` from `180f46c1` (23 minutes old, prior workflow run), exited in 1.6s.

## Implementation information

**Bug 1 — `fix(task): hook external status writes`**

- `task.Manager.OnExternalUpdate(path)` reads the task after invalidate, dedupes against a `firedStatus` map, and fires `onStatusHook` when the on-disk status differs from the last value that triggered the hook. The map is populated only by in-process mutation paths (`Update`, `AddRunWithStatus`, `Create`), so concurrent `Get` calls between the external write and the watcher firing cannot mask the transition.
- `app.go` emit callback now routes file events through `OnExternalUpdate` instead of bare `InvalidatePath`.
- `app_watcher_status_test.go` wires the watcher + status hook + workflow engine the same way `app.go` does, parks a workflow at the `plan` step, writes the task file via `fsutil.AtomicWrite` (mirroring synapse-cli), and asserts the workflow advances. Verified to fail on the pre-fix emit callback.

**Bug 2 — `fix(agent): cap resume to current workflow`**

- `pickImplementationResumeSession` now takes a `workflowStart time.Time` cutoff. Runs whose `StartedAt` is before the current workflow execution are filtered out. `workflowStart=zero` keeps the legacy behavior for callers without an execution context.
- `AgentOrchestrator.StartAgent` reads `task.Workflow.StartedAt`, passes it to the picker, and records its agent run with `Role: implementation` (+ `Provider`).
- Existing `TestPickImplementationResumeSession` updated to the new signature with new cases pinning: stale impl from prior workflow → no resume, stale empty-Role from prior workflow → no resume, current-workflow impl preferred over stale, run started exactly at workflow start is eligible, legacy empty-Role still picked when no time cutoff.
- `orchestrator_resume_test.go` builds a real bare git repo, project store, worktree manager, and `AgentOrchestrator`. It seeds an aborted prior-execution agent run (24h before `Workflow.StartedAt`), calls `orch.StartAgent`, captures the fake-claude argv via `FAKE_CLAUDE_ARGS_LOG`, and asserts no `--resume <stale-session>`. Verified to fail on the unfixed code (dumped argv showed `--resume stale-session-from-prior-workflow`).

**Alternatives considered.** For Bug 1, I considered making synapse-cli talk to the running server over IPC instead of writing files directly — much bigger surgery and breaks the design point that synapse-cli works standalone. For Bug 2, I considered detecting `No conversation found` in claude stderr and retrying without `--resume` — fragile and depends on stderr text.

## Supporting documentation

Relates to the production stuck tasks `27107b7a` and `e1b18401` on the synapse server. Builds on prior fix #488 (`filter resume session_id by role`) which addressed cross-role pollution but left the cross-workflow-run case open.

> Changelog: fix(workflow): unstick plan-review and stale resume