### PR TITLE
fix(ui): agent history dark in light mode

### DIFF
--- a/frontend/src/components/StreamOutput.svelte
+++ b/frontend/src/components/StreamOutput.svelte
@@ -104,13 +104,13 @@
   <div
     bind:this={container}
     onscroll={onScroll}
-    class="flex max-h-[60dvh] md:max-h-[600px] flex-col gap-1 overflow-y-auto rounded-lg border border-surface-700 bg-surface-950 p-3 font-mono text-xs text-surface-50"
+    class="flex max-h-[60dvh] md:max-h-[600px] flex-col gap-1 overflow-y-auto rounded-lg border border-surface-300 bg-surface-100 p-3 font-mono text-xs text-surface-900 dark:border-surface-700 dark:bg-surface-950 dark:text-surface-50"
   >
     {#if events.length === 0}
       <p class="py-8 text-center text-surface-500">Waiting for output...</p>
     {:else}
       {#each events as event, i (i)}
-        {@const style = typeStyles[event.type] ?? { label: event.type.toUpperCase(), classes: 'bg-surface-700 text-surface-200' }}
+        {@const style = typeStyles[event.type] ?? { label: event.type.toUpperCase(), classes: 'bg-surface-300 text-surface-800 dark:bg-surface-700 dark:text-surface-200' }}
         <div
           data-event-index={i}
           class="flex items-start gap-2 rounded transition-colors duration-300

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -1015,7 +1015,7 @@
                   {:else if (runLogEvents.get(run.agentId)?.length ?? 0) > 0}
                     <StreamOutput staticEvents={runLogEvents.get(run.agentId)} />
                   {:else if run.result}
-                    <pre class="max-h-[60dvh] md:max-h-[600px] overflow-y-auto whitespace-pre-wrap rounded-lg border border-surface-300 bg-surface-900 p-3 text-xs text-surface-300 dark:border-surface-600">{run.result}</pre>
+                    <pre class="max-h-[60dvh] md:max-h-[600px] overflow-y-auto whitespace-pre-wrap rounded-lg border border-surface-300 bg-surface-100 p-3 text-xs text-surface-700 dark:border-surface-600 dark:bg-surface-900 dark:text-surface-300">{run.result}</pre>
                   {:else}
                     <p class="py-4 text-center text-xs text-surface-500">No output available</p>
                   {/if}


### PR DESCRIPTION
## Motivation

Agent History panel was always rendered with dark background/text regardless of the active color scheme, making it unreadable in light mode.

## Implementation information

Three hardcoded dark-only Tailwind classes replaced with proper light/dark variants:

- `StreamOutput.svelte`: container had `bg-surface-950 border-surface-700 text-surface-50` with no light equivalents → added `bg-surface-100 border-surface-300 text-surface-900` as light defaults
- `StreamOutput.svelte`: fallback event badge used `bg-surface-700 text-surface-200` → added light variants
- `TaskDetail.svelte`: `run.result` pre block used `bg-surface-900 text-surface-300` → added light variants

> Changelog: fix(ui): agent history dark in light mode