### PR TITLE
fix(monitor): wait for all checks before pr-fix

### DIFF
--- a/frontend/src/components/PRCard.svelte.test.ts
+++ b/frontend/src/components/PRCard.svelte.test.ts
@@ -20,6 +20,7 @@ function makePR(overrides: Record<string, unknown> = {}) {
     labels: [],
     headRefName: 'feature/test',
     ciStatus: '',
+    hasPendingChecks: false,
     reviewDecision: '',
     mergeable: '',
     unresolvedCount: 0,

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -464,6 +464,7 @@ export namespace github {
 	    labels: string[];
 	    headRefName: string;
 	    ciStatus: string;
+	    hasPendingChecks: boolean;
 	    reviewDecision: string;
 	    mergeable: string;
 	    unresolvedCount: number;
@@ -487,6 +488,7 @@ export namespace github {
 	        this.labels = source["labels"];
 	        this.headRefName = source["headRefName"];
 	        this.ciStatus = source["ciStatus"];
+	        this.hasPendingChecks = source["hasPendingChecks"];
 	        this.reviewDecision = source["reviewDecision"];
 	        this.mergeable = source["mergeable"];
 	        this.unresolvedCount = source["unresolvedCount"];
@@ -506,6 +508,7 @@ export namespace github {
 	    labels: string[];
 	    headRefName: string;
 	    ciStatus: string;
+	    hasPendingChecks: boolean;
 	    reviewDecision: string;
 	    mergeable: string;
 	    unresolvedCount: number;
@@ -530,6 +533,7 @@ export namespace github {
 	        this.labels = source["labels"];
 	        this.headRefName = source["headRefName"];
 	        this.ciStatus = source["ciStatus"];
+	        this.hasPendingChecks = source["hasPendingChecks"];
 	        this.reviewDecision = source["reviewDecision"];
 	        this.mergeable = source["mergeable"];
 	        this.unresolvedCount = source["unresolvedCount"];

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -77,7 +77,14 @@ const prQuery = `query($q: String!) {
         commits(last: 1) {
           nodes {
             commit {
-              statusCheckRollup { state }
+              statusCheckRollup {
+                state
+                contexts(first: 50) {
+                  nodes {
+                    ... on CheckRun { status }
+                  }
+                }
+              }
             }
           }
         }
@@ -189,9 +196,16 @@ func convertCommonPR(n *gqlPR, viewer string) PullRequest {
 	}
 
 	var ciStatus string
+	var hasPendingChecks bool
 	if len(n.Commits.Nodes) > 0 {
 		if rollup := n.Commits.Nodes[0].Commit.StatusCheckRollup; rollup != nil {
 			ciStatus = rollup.State
+			for _, ctx := range rollup.Contexts.Nodes {
+				if ctx.Status != "" && ctx.Status != "COMPLETED" {
+					hasPendingChecks = true
+					break
+				}
+			}
 		}
 	}
 
@@ -224,6 +238,7 @@ func convertCommonPR(n *gqlPR, viewer string) PullRequest {
 		Mergeable:         n.Mergeable,
 		Labels:            labels,
 		CIStatus:          ciStatus,
+		HasPendingChecks:  hasPendingChecks,
 		ReviewDecision:    n.ReviewDecision,
 		UnresolvedCount:   unresolved,
 		ViewerHasApproved: viewerApproved,

--- a/internal/github/model.go
+++ b/internal/github/model.go
@@ -11,9 +11,10 @@ type PullRequest struct {
 	IsDraft           bool     `json:"isDraft"`
 	Labels            []string `json:"labels"`
 	HeadRefName       string   `json:"headRefName"`
-	CIStatus          string   `json:"ciStatus"`       // SUCCESS, FAILURE, PENDING, or ""
-	ReviewDecision    string   `json:"reviewDecision"` // APPROVED, CHANGES_REQUESTED, REVIEW_REQUIRED, or ""
-	Mergeable         string   `json:"mergeable"`      // MERGEABLE, CONFLICTING, UNKNOWN, or ""
+	CIStatus          string   `json:"ciStatus"`         // SUCCESS, FAILURE, PENDING, or ""
+	HasPendingChecks  bool     `json:"hasPendingChecks"` // true when any check is still in-progress/queued
+	ReviewDecision    string   `json:"reviewDecision"`   // APPROVED, CHANGES_REQUESTED, REVIEW_REQUIRED, or ""
+	Mergeable         string   `json:"mergeable"`        // MERGEABLE, CONFLICTING, UNKNOWN, or ""
 	UnresolvedCount   int      `json:"unresolvedCount"`
 	ViewerHasApproved bool     `json:"viewerHasApproved"`
 	CreatedAt         string   `json:"createdAt"`

--- a/internal/github/monitor.go
+++ b/internal/github/monitor.go
@@ -89,7 +89,7 @@ func MatchTaskPRs(prs []PullRequest, tasks []TaskMatcher) []PRIssue {
 		if pr.Mergeable == "CONFLICTING" {
 			issues = append(issues, PRIssue{Kind: PRIssueConflict, TaskID: tm.ID, PR: *pr})
 		}
-		if pr.CIStatus == "FAILURE" {
+		if pr.CIStatus == "FAILURE" && !pr.HasPendingChecks {
 			issues = append(issues, PRIssue{Kind: PRIssueCIFailure, TaskID: tm.ID, PR: *pr})
 		}
 		if !pr.IsDraft && pr.Mergeable == "MERGEABLE" && (pr.CIStatus == "SUCCESS" || pr.CIStatus == "") {

--- a/internal/github/monitor_test.go
+++ b/internal/github/monitor_test.go
@@ -65,6 +65,18 @@ func TestMatchTaskPRs(t *testing.T) {
 			want:  nil,
 		},
 		{
+			name:  "FAILURE with pending checks is not yet triggered",
+			prs:   []PullRequest{{Number: 42, CIStatus: "FAILURE", HasPendingChecks: true}},
+			tasks: []TaskMatcher{{ID: "t1", PRNumber: 42}},
+			want:  nil,
+		},
+		{
+			name:  "FAILURE with all checks complete triggers fix",
+			prs:   []PullRequest{{Number: 42, CIStatus: "FAILURE", HasPendingChecks: false}},
+			tasks: []TaskMatcher{{ID: "t1", PRNumber: 42}},
+			want:  []PRIssue{{Kind: PRIssueCIFailure, TaskID: "t1", PR: PullRequest{Number: 42, CIStatus: "FAILURE"}}},
+		},
+		{
 			name:  "mergeable with CI success → ready to merge",
 			prs:   []PullRequest{{Number: 42, CIStatus: "SUCCESS", Mergeable: "MERGEABLE"}},
 			tasks: []TaskMatcher{{ID: "t1", PRNumber: 42}},


### PR DESCRIPTION
## Motivation

pr-fix was firing as soon as GitHub's statusCheckRollup flipped to
FAILURE — which happens the moment any single check fails, even if
others are still running. This caused redundant fix cycles: one fast
check fails, pr-fix launches, diagnoses a partial picture, pushes a
fix, and the next poll triggers another round.

Root cause found while investigating task 27107b7a (5 pr-fix runs to
fix a simple whitespace issue in `wailsjs/go/models.ts`).

## Implementation information

Added `HasPendingChecks bool` to `PullRequest`, populated from
`statusCheckRollup.contexts` (any context with status != COMPLETED).
`MatchTaskPRs` now gates `ci_failure` on `!HasPendingChecks`.

Updated `prQuery` to fetch `contexts(first: 50) { nodes { ... on
CheckRun { status } } }` alongside the existing rollup state.

> Changelog: fix(monitor): wait for all checks before pr-fix