### PR TITLE
ci(e2e): migrate to synapse-server + ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
 
   e2e:
     name: E2E Tests (${{ matrix.provider }})
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -166,9 +166,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-
-      - name: Install wails
-        run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
 
       - name: Install frontend deps
         run: cd frontend && npm ci
@@ -187,33 +184,31 @@ jobs:
         env:
           SYNAPSE_HOME: /tmp/synapse-e2e
 
-      - name: Start wails dev
+      - name: Build web frontend
+        run: cd frontend && npm run build:web
+
+      - name: Build synapse-server
+        run: go build -o bin/synapse-server ./cmd/synapse-server
+
+      - name: Start synapse-server
         run: |
-          SYNAPSE_HOME=/tmp/synapse-e2e wails dev > /tmp/wails-dev.log 2>&1 &
-          WAILS_PID=$!
-          echo "WAILS_PID=$WAILS_PID" >> "$GITHUB_ENV"
-          echo "Waiting for wails dev (pid $WAILS_PID)..."
-          for i in $(seq 1 90); do
-            if ! kill -0 $WAILS_PID 2>/dev/null; then
-              echo "::error::wails dev exited prematurely"
-              cat /tmp/wails-dev.log
-              exit 1
-            fi
-            if curl -s http://localhost:34115 > /dev/null 2>&1; then
-              echo "Wails dev ready after $((i*2))s"
+          SYNAPSE_HOME=/tmp/synapse-e2e \
+          SYNAPSE_STATIC_DIR=frontend/dist-web \
+          ./bin/synapse-server > /tmp/synapse-server.log 2>&1 &
+          echo "SERVER_PID=$!" >> "$GITHUB_ENV"
+          echo "Waiting for synapse-server..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/health > /dev/null 2>&1; then
+              echo "Ready after ${i}s"
               break
             fi
-            if [ "$i" -eq 90 ]; then
-              echo "::error::wails dev timed out"
-              cat /tmp/wails-dev.log
+            if [ "$i" -eq 30 ]; then
+              echo "::error::synapse-server timed out"
+              cat /tmp/synapse-server.log
               exit 1
             fi
-            sleep 2
+            sleep 1
           done
-          # Extra wait for Go backend binding bridge
-          sleep 5
-          echo "--- wails dev log ---"
-          cat /tmp/wails-dev.log
 
       - name: Run e2e tests
         run: cd frontend && npx playwright test --reporter=github
@@ -221,9 +216,9 @@ jobs:
           SYNAPSE_HOME: /tmp/synapse-e2e
           SYNAPSE_E2E_PROVIDER: ${{ matrix.provider }}
 
-      - name: Dump wails dev log
+      - name: Dump server log
         if: failure()
-        run: cat /tmp/wails-dev.log || true
+        run: cat /tmp/synapse-server.log || true
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   test-go:
     name: Go Tests
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -26,7 +26,7 @@ jobs:
 
   test-frontend:
     name: Frontend Tests
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -49,7 +49,7 @@ jobs:
 
   lint-go:
     name: Go Lint
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -142,7 +142,7 @@ jobs:
 
   security:
     name: Security Audit
-    runs-on: macos-15
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   reporter: process.env.CI ? 'github' : 'list',
   use: {
-    baseURL: 'http://localhost:34115',
+    baseURL: 'http://localhost:8080',
     screenshot: 'only-on-failure',
     trace: 'on-first-retry',
   },
@@ -17,9 +17,9 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'cd .. && wails dev',
-    url: 'http://localhost:34115',
+    command: 'cd .. && mise run dev:server',
+    url: 'http://localhost:8080',
     reuseExistingServer: true,
-    timeout: 60_000,
+    timeout: 120_000,
   },
 })

--- a/frontend/src/components/StreamOutput.svelte.test.ts
+++ b/frontend/src/components/StreamOutput.svelte.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { agentOutput } from '../lib/events.js'
 import { render, screen, cleanup } from '@testing-library/svelte'
+import StreamOutput from './StreamOutput.svelte'
 
 const mockGetOutput = vi.fn()
 const mockAppendEvent = vi.fn()
@@ -26,12 +27,9 @@ function makeTSE(type: string, content: string | undefined = undefined) {
 }
 
 describe('StreamOutput', () => {
-  let StreamOutput: typeof import('./StreamOutput.svelte').default
-
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks()
     mockGetOutput.mockResolvedValue([])
-    StreamOutput = (await import('./StreamOutput.svelte')).default
   })
 
   afterEach(() => {

--- a/mise.toml
+++ b/mise.toml
@@ -38,6 +38,15 @@ run = ["cd frontend && npm run build:web", "SYNAPSE_STATIC_DIR=frontend/dist-web
 description = "Build web frontend then run HTTP server"
 env = { SYNAPSE_PORT = "8080" }
 
+[tasks."test:e2e"]
+run = [
+  "mkdir -p /tmp/synapse-e2e/tasks",
+  "cp frontend/e2e/fixtures/*.md /tmp/synapse-e2e/tasks/",
+  "cd frontend && npx playwright test",
+]
+description = "Run e2e tests (run 'mise run dev:server' in another terminal first)"
+env = { SYNAPSE_HOME = "/tmp/synapse-e2e" }
+
 [tasks."perf:bench"]
 run = "go test -run XXX -bench . -benchmem -benchtime=2s ./internal/task/ ./internal/agent/ ./internal/sse/ ./internal/watcher/"
 description = "Run Go benchmarks for perf-critical backend packages"


### PR DESCRIPTION
## Motivation

E2E tests targeted the Wails dev server (`localhost:34115`) via `wails dev`, requiring the Wails toolchain, macOS, and a ~90s startup wait. Synapse already has a headless HTTP server (`cmd/synapse-server`) that serves the web frontend as static files. Targeting it instead removes platform friction and tests the actual server transport (HTTP + SSE).

## Implementation information

- `playwright.config.ts`: `baseURL` and `webServer.url` → `localhost:8080`; `webServer.command` → `mise run dev:server` (builds web frontend + starts server); timeout bumped to 120s for the initial build
- `ci.yml` e2e job: drop `Install wails` step; replace 90s `wails dev` startup with build + `synapse-server` start + 30s `/health` poll; switch runner from `macos-15` → `ubuntu-latest` (no Wails GUI dependency)
- `mise.toml`: add `test:e2e` convenience task for local runs (requires `mise run dev:server` in a separate terminal)

> Changelog: ci(e2e): migrate to synapse-server + ubuntu