### PR TITLE
feat(checks): repo-level git hooks for agents

### DIFF
--- a/.synapse.yaml
+++ b/.synapse.yaml
@@ -1,0 +1,8 @@
+checks:
+  pre_commit:
+    - golangci-lint run ./...
+    - cd frontend && npx oxlint .
+    - wails generate module && git diff --exit-code frontend/wailsjs/
+  pre_push:
+    - go test ./...
+    - cd frontend && npm run check

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -857,6 +857,20 @@ export namespace notification {
 
 export namespace project {
 	
+	export class ChecksConfig {
+	    preCommit?: string[];
+	    prePush?: string[];
+	
+	    static createFrom(source: any = {}) {
+	        return new ChecksConfig(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.preCommit = source["preCommit"];
+	        this.prePush = source["prePush"];
+	    }
+	}
 	export class SandboxConfig {
 	    image?: string;
 	    build?: string;
@@ -898,6 +912,7 @@ export namespace project {
 	    status: string;
 	    setupCommands?: string[];
 	    sandbox?: SandboxConfig;
+	    checks?: ChecksConfig;
 	    // Go type: time
 	    createdAt: any;
 	    // Go type: time
@@ -919,6 +934,7 @@ export namespace project {
 	        this.status = source["status"];
 	        this.setupCommands = source["setupCommands"];
 	        this.sandbox = this.convertValues(source["sandbox"], SandboxConfig);
+	        this.checks = this.convertValues(source["checks"], ChecksConfig);
 	        this.createdAt = this.convertValues(source["createdAt"], null);
 	        this.updatedAt = this.convertValues(source["updatedAt"], null);
 	    }

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -9,7 +9,71 @@ import (
 	"strings"
 
 	"github.com/Automaat/synapse/internal/executil"
+	"gopkg.in/yaml.v3"
 )
+
+// LoadRepoConfig reads .synapse.yaml from the worktree root. Returns an empty
+// RepoConfig (not an error) if the file does not exist.
+func LoadRepoConfig(worktreePath string) (*RepoConfig, error) {
+	data, err := os.ReadFile(filepath.Join(worktreePath, ".synapse.yaml"))
+	if os.IsNotExist(err) {
+		return &RepoConfig{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read .synapse.yaml: %w", err)
+	}
+	var cfg RepoConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse .synapse.yaml: %w", err)
+	}
+	return &cfg, nil
+}
+
+// InstallHooks writes pre-commit and pre-push git hooks into the worktree's
+// hooks directory. Existing hooks are overwritten. No-op if checks is nil or
+// both slices are empty.
+func InstallHooks(worktreePath string, checks *ChecksConfig) error {
+	if checks == nil || (len(checks.PreCommit) == 0 && len(checks.PrePush) == 0) {
+		return nil
+	}
+
+	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
+	cmd.Dir = worktreePath
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("resolve git dir: %w", err)
+	}
+	gitDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(worktreePath, gitDir)
+	}
+	hooksDir := filepath.Join(gitDir, "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		return fmt.Errorf("create hooks dir: %w", err)
+	}
+
+	write := func(name string, commands []string) error {
+		if len(commands) == 0 {
+			return nil
+		}
+		var sb strings.Builder
+		sb.WriteString("#!/bin/sh\nset -e\n")
+		for _, c := range commands {
+			sb.WriteString(c)
+			sb.WriteByte('\n')
+		}
+		path := filepath.Join(hooksDir, name)
+		if err := os.WriteFile(path, []byte(sb.String()), 0o755); err != nil {
+			return fmt.Errorf("write %s hook: %w", name, err)
+		}
+		return nil
+	}
+
+	if err := write("pre-commit", checks.PreCommit); err != nil {
+		return err
+	}
+	return write("pre-push", checks.PrePush)
+}
 
 func ParseGitHubURL(raw string) (owner, repo string, err error) {
 	raw = strings.TrimSpace(raw)

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -438,3 +438,381 @@ func TestCreateWorktreeInvalidBase(t *testing.T) {
 		t.Fatal("expected error for invalid base branch")
 	}
 }
+
+func initWorktree(t *testing.T) (bare, wtPath string) {
+	t.Helper()
+	src := initRepoWithCommit(t)
+	bare = filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(src, bare); err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+	branch, err := DefaultBranch(bare)
+	if err != nil {
+		t.Fatalf("default branch: %v", err)
+	}
+	wtPath = filepath.Join(t.TempDir(), "wt")
+	if err := CreateWorktree(bare, wtPath, "synapse/test", branch); err != nil {
+		t.Fatalf("create worktree: %v", err)
+	}
+	for _, args := range [][]string{
+		{"config", "user.email", "test@test.com"},
+		{"config", "user.name", "Test"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = wtPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	return bare, wtPath
+}
+
+func TestMergeChecks(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		repo          *ChecksConfig
+		app           *ChecksConfig
+		wantPreCommit []string
+		wantPrePush   []string
+		wantNil       bool
+	}{
+		{
+			name:    "both nil",
+			wantNil: true,
+		},
+		{
+			name:          "repo only",
+			repo:          &ChecksConfig{PreCommit: []string{"echo repo"}},
+			wantPreCommit: []string{"echo repo"},
+		},
+		{
+			name:          "app only",
+			app:           &ChecksConfig{PreCommit: []string{"echo app"}},
+			wantPreCommit: []string{"echo app"},
+		},
+		{
+			name:          "repo wins pre_commit",
+			repo:          &ChecksConfig{PreCommit: []string{"echo repo"}},
+			app:           &ChecksConfig{PreCommit: []string{"echo app"}},
+			wantPreCommit: []string{"echo repo"},
+		},
+		{
+			name:        "repo wins pre_push",
+			repo:        &ChecksConfig{PrePush: []string{"echo repo-push"}},
+			app:         &ChecksConfig{PrePush: []string{"echo app-push"}},
+			wantPrePush: []string{"echo repo-push"},
+		},
+		{
+			name:          "composable: repo pre_commit, app pre_push",
+			repo:          &ChecksConfig{PreCommit: []string{"echo repo-commit"}},
+			app:           &ChecksConfig{PrePush: []string{"echo app-push"}},
+			wantPreCommit: []string{"echo repo-commit"},
+			wantPrePush:   []string{"echo app-push"},
+		},
+		{
+			name:          "empty repo slice falls back to app",
+			repo:          &ChecksConfig{PreCommit: []string{}},
+			app:           &ChecksConfig{PreCommit: []string{"echo app"}},
+			wantPreCommit: []string{"echo app"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := MergeChecks(tt.repo, tt.app)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("want nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("got nil, want non-nil")
+			}
+			if !slicesEqual(got.PreCommit, tt.wantPreCommit) {
+				t.Errorf("PreCommit = %v, want %v", got.PreCommit, tt.wantPreCommit)
+			}
+			if !slicesEqual(got.PrePush, tt.wantPrePush) {
+				t.Errorf("PrePush = %v, want %v", got.PrePush, tt.wantPrePush)
+			}
+		})
+	}
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestLoadRepoConfig_Missing(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfg, err := LoadRepoConfig(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil || cfg.Checks != nil {
+		t.Errorf("expected empty RepoConfig, got %+v", cfg)
+	}
+}
+
+func TestLoadRepoConfig_Valid(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	content := "checks:\n  pre_commit:\n    - echo hello\n  pre_push:\n    - echo world\n"
+	if err := os.WriteFile(filepath.Join(dir, ".synapse.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadRepoConfig(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Checks == nil {
+		t.Fatal("expected checks, got nil")
+	}
+	if len(cfg.Checks.PreCommit) != 1 || cfg.Checks.PreCommit[0] != "echo hello" {
+		t.Errorf("PreCommit = %v", cfg.Checks.PreCommit)
+	}
+	if len(cfg.Checks.PrePush) != 1 || cfg.Checks.PrePush[0] != "echo world" {
+		t.Errorf("PrePush = %v", cfg.Checks.PrePush)
+	}
+}
+
+func TestLoadRepoConfig_Invalid(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".synapse.yaml"), []byte(":\n  bad: [yaml"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadRepoConfig(dir)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}
+
+func TestInstallHooks_RepoConfigPriority(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	_, wtPath := initWorktree(t)
+
+	// Write .synapse.yaml with a failing pre-commit to prove repo config is used.
+	repoYAML := "checks:\n  pre_commit:\n    - exit 1\n"
+	if err := os.WriteFile(filepath.Join(wtPath, ".synapse.yaml"), []byte(repoYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// App config has a passing pre-commit — repo should win.
+	appChecks := &ChecksConfig{PreCommit: []string{"exit 0"}}
+	repoCfg, err := LoadRepoConfig(wtPath)
+	if err != nil {
+		t.Fatalf("LoadRepoConfig: %v", err)
+	}
+	merged := MergeChecks(repoCfg.Checks, appChecks)
+	if err := InstallHooks(wtPath, merged); err != nil {
+		t.Fatalf("InstallHooks: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(wtPath, "change.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	addCmd := exec.Command("git", "add", ".")
+	addCmd.Dir = wtPath
+	if out, err := addCmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v: %s", err, out)
+	}
+	commitCmd := exec.Command("git", "commit", "--no-gpg-sign", "-m", "test")
+	commitCmd.Dir = wtPath
+	if err := commitCmd.Run(); err == nil {
+		t.Fatal("commit should have been blocked by repo pre-commit hook (exit 1)")
+	}
+}
+
+func TestInstallHooks_NilChecks(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	_, wtPath := initWorktree(t)
+	if err := InstallHooks(wtPath, nil); err != nil {
+		t.Fatalf("InstallHooks(nil): %v", err)
+	}
+}
+
+func TestInstallHooks_EmptySlices(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	_, wtPath := initWorktree(t)
+	if err := InstallHooks(wtPath, &ChecksConfig{}); err != nil {
+		t.Fatalf("InstallHooks(empty): %v", err)
+	}
+
+	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
+	cmd.Dir = wtPath
+	out, _ := cmd.Output()
+	gitDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(wtPath, gitDir)
+	}
+	for _, name := range []string{"pre-commit", "pre-push"} {
+		if _, err := os.Stat(filepath.Join(gitDir, "hooks", name)); err == nil {
+			t.Errorf("hook %s should not exist for empty config", name)
+		}
+	}
+}
+
+func TestInstallHooks_PreCommitBlocksOnFailure(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	_, wtPath := initWorktree(t)
+
+	checks := &ChecksConfig{
+		PreCommit: []string{"exit 1"},
+	}
+	if err := InstallHooks(wtPath, checks); err != nil {
+		t.Fatalf("InstallHooks: %v", err)
+	}
+
+	// Verify hook file exists and is executable.
+	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
+	cmd.Dir = wtPath
+	out, _ := cmd.Output()
+	gitDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(wtPath, gitDir)
+	}
+	hookPath := filepath.Join(gitDir, "hooks", "pre-commit")
+	info, err := os.Stat(hookPath)
+	if err != nil {
+		t.Fatalf("pre-commit hook missing: %v", err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Error("pre-commit hook not executable")
+	}
+
+	// Commit should be blocked by the failing hook.
+	if err := os.WriteFile(filepath.Join(wtPath, "change.txt"), []byte("change"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	addCmd := exec.Command("git", "add", ".")
+	addCmd.Dir = wtPath
+	if out, err := addCmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v: %s", err, out)
+	}
+	commitCmd := exec.Command("git", "commit", "--no-gpg-sign", "-m", "test")
+	commitCmd.Dir = wtPath
+	if err := commitCmd.Run(); err == nil {
+		t.Fatal("expected commit to fail due to pre-commit hook")
+	}
+}
+
+func TestInstallHooks_PreCommitPassesOnSuccess(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	_, wtPath := initWorktree(t)
+
+	checks := &ChecksConfig{
+		PreCommit: []string{"exit 0"},
+	}
+	if err := InstallHooks(wtPath, checks); err != nil {
+		t.Fatalf("InstallHooks: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(wtPath, "change.txt"), []byte("change"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	addCmd := exec.Command("git", "add", ".")
+	addCmd.Dir = wtPath
+	if out, err := addCmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v: %s", err, out)
+	}
+	commitCmd := exec.Command("git", "commit", "--no-gpg-sign", "-m", "test")
+	commitCmd.Dir = wtPath
+	if out, err := commitCmd.CombinedOutput(); err != nil {
+		t.Fatalf("commit should succeed with passing hook: %v: %s", err, out)
+	}
+}
+
+func TestInstallHooks_PrePushInstalled(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	_, wtPath := initWorktree(t)
+
+	checks := &ChecksConfig{
+		PrePush: []string{"echo pre-push ok"},
+	}
+	if err := InstallHooks(wtPath, checks); err != nil {
+		t.Fatalf("InstallHooks: %v", err)
+	}
+
+	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
+	cmd.Dir = wtPath
+	out, _ := cmd.Output()
+	gitDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(wtPath, gitDir)
+	}
+	hookPath := filepath.Join(gitDir, "hooks", "pre-push")
+	info, err := os.Stat(hookPath)
+	if err != nil {
+		t.Fatalf("pre-push hook missing: %v", err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Error("pre-push hook not executable")
+	}
+	content, _ := os.ReadFile(hookPath)
+	if !strings.Contains(string(content), "echo pre-push ok") {
+		t.Errorf("hook content missing command: %s", content)
+	}
+}
+
+func TestInstallHooks_Overwrites(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	_, wtPath := initWorktree(t)
+
+	// Install first version.
+	if err := InstallHooks(wtPath, &ChecksConfig{PreCommit: []string{"echo v1"}}); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	// Overwrite with second version.
+	if err := InstallHooks(wtPath, &ChecksConfig{PreCommit: []string{"echo v2"}}); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+
+	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
+	cmd.Dir = wtPath
+	out, _ := cmd.Output()
+	gitDir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(wtPath, gitDir)
+	}
+	content, _ := os.ReadFile(filepath.Join(gitDir, "hooks", "pre-commit"))
+	if strings.Contains(string(content), "v1") {
+		t.Error("hook should have been overwritten with v2")
+	}
+	if !strings.Contains(string(content), "v2") {
+		t.Errorf("hook should contain v2: %s", content)
+	}
+}

--- a/internal/project/model.go
+++ b/internal/project/model.go
@@ -9,6 +9,42 @@ const (
 	ProjectTypeWork ProjectType = "work"
 )
 
+// ChecksConfig defines shell commands run as git hooks in agent worktrees.
+// Commands execute in the worktree root; non-zero exit blocks the git operation.
+type ChecksConfig struct {
+	PreCommit []string `yaml:"pre_commit,omitempty" json:"preCommit,omitempty"`
+	PrePush   []string `yaml:"pre_push,omitempty"   json:"prePush,omitempty"`
+}
+
+// RepoConfig is the subset of Synapse config that can be defined in a repo's
+// .synapse.yaml file. Repo config takes priority over the app-level project config.
+type RepoConfig struct {
+	Checks *ChecksConfig `yaml:"checks,omitempty" json:"checks,omitempty"`
+}
+
+// MergeChecks returns a merged ChecksConfig where repo fields take priority over
+// app fields on a per-slice basis. A non-nil, non-empty slice in repo wins.
+func MergeChecks(repo, app *ChecksConfig) *ChecksConfig {
+	if repo == nil && app == nil {
+		return nil
+	}
+	out := &ChecksConfig{}
+	if repo != nil && len(repo.PreCommit) > 0 {
+		out.PreCommit = repo.PreCommit
+	} else if app != nil {
+		out.PreCommit = app.PreCommit
+	}
+	if repo != nil && len(repo.PrePush) > 0 {
+		out.PrePush = repo.PrePush
+	} else if app != nil {
+		out.PrePush = app.PrePush
+	}
+	if len(out.PreCommit) == 0 && len(out.PrePush) == 0 {
+		return nil
+	}
+	return out
+}
+
 // SandboxConfig describes how to spin up an isolated app environment for a task.
 // Three modes are supported, detected by field presence:
 //   - K8s mode:             Cluster != ""
@@ -65,6 +101,7 @@ type Project struct {
 	Status        ProjectStatus  `yaml:"status,omitempty" json:"status"`
 	SetupCommands []string       `yaml:"setup_commands,omitempty" json:"setupCommands,omitempty"`
 	Sandbox       *SandboxConfig `yaml:"sandbox,omitempty" json:"sandbox,omitempty"`
+	Checks        *ChecksConfig  `yaml:"checks,omitempty"  json:"checks,omitempty"`
 	CreatedAt     time.Time      `yaml:"created_at" json:"createdAt"`
 	UpdatedAt     time.Time      `yaml:"updated_at" json:"updatedAt"`
 }

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -127,6 +127,7 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 				m.logger.Warn("worktree.push-force", "task_id", t.ID, "branch", wtBranch, "err", err)
 			}
 		}
+		m.installChecks(wtPath, proj)
 		m.ensureBranch(t, wtBranch)
 		return wtPath, nil
 	}
@@ -153,6 +154,7 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 		}
 		m.logger.Info("worktree.reused-branch", "task_id", t.ID, "path", wtPath, "branch", wtBranch)
 		m.runSetup(wtPath, proj.SetupCommands)
+		m.installChecks(wtPath, proj)
 		m.ensureBranch(t, wtBranch)
 		return wtPath, nil
 	}
@@ -163,6 +165,7 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 	}
 	m.logger.Info("worktree.created", "task_id", t.ID, "path", wtPath)
 	m.runSetup(wtPath, proj.SetupCommands)
+	m.installChecks(wtPath, proj)
 
 	callPhase(onPhase, "Pushing upstream…")
 	if err := project.PushUpstream(wtPath, wtBranch); err != nil {
@@ -397,6 +400,21 @@ func (m *Manager) runSetup(wtPath string, commands []string) {
 			continue
 		}
 		m.logger.Info("worktree.setup-cmd", "cmd", raw, "path", wtPath)
+	}
+}
+
+func (m *Manager) installChecks(wtPath string, proj project.Project) {
+	repoCfg, err := project.LoadRepoConfig(wtPath)
+	if err != nil {
+		m.logger.Warn("worktree.repo-config", "path", wtPath, "err", err)
+	}
+	var repoChecks *project.ChecksConfig
+	if repoCfg != nil {
+		repoChecks = repoCfg.Checks
+	}
+	checks := project.MergeChecks(repoChecks, proj.Checks)
+	if err := project.InstallHooks(wtPath, checks); err != nil {
+		m.logger.Warn("worktree.hooks", "path", wtPath, "err", err)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Quality gates were only enforced via LLM prompts (wasting tokens, ignorable).
This enforces them at the app layer by installing real git hooks into agent
worktrees — hooks block commits/pushes on non-zero exit, no LLM involvement.

Repo can define its own checks in `.synapse.yaml`, composable with the
app-level project config (repo fields take priority per-slice).

## Implementation information

- `ChecksConfig` struct added to `internal/project/model.go` alongside
  `SandboxConfig` — same pattern
- `RepoConfig` + `MergeChecks()` in `model.go` — per-field merge, repo wins
- `LoadRepoConfig(worktreePath)` in `git.go` — reads `.synapse.yaml` from
  worktree root, no-op if absent
- `InstallHooks(worktreePath, checks)` in `git.go` — writes `pre-commit` /
  `pre-push` scripts to the project's common gitdir (shared across all
  worktrees)
- `worktree.Manager.installChecks()` called at all 3 `PrepareForTask` paths;
  not called for chat/review worktrees
- `.synapse.yaml` added to this repo with golangci-lint, oxlint, wails
  bindings check on pre-commit; go test + svelte-check on pre-push

> Changelog: feat(checks): repo-level git hooks for agents