### PR TITLE
feat(skills): embed skills and sync to codex

### DIFF
--- a/cmd/synapse-server/main.go
+++ b/cmd/synapse-server/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Automaat/synapse/internal/httpapi"
 	"github.com/Automaat/synapse/internal/logging"
 	"github.com/Automaat/synapse/internal/metrics"
+	"github.com/Automaat/synapse/internal/skills"
 	"github.com/Automaat/synapse/internal/sse"
 	"github.com/Automaat/synapse/internal/synapse"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -68,7 +69,7 @@ func run() error {
 
 	broker := sse.New()
 
-	app := synapse.NewApp(logger, levelVar, cfg, synapse.WithEmit(broker.Emit))
+	app := synapse.NewApp(logger, levelVar, cfg, synapse.WithEmit(broker.Emit), synapse.WithSkillsFS(skills.FS))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/internal/skills/data/synapse-audit.md
+++ b/internal/skills/data/synapse-audit.md
@@ -1,0 +1,184 @@
+---
+name: synapse-audit
+description: Analyze Synapse health findings + audit summary to explain workflow issues and propose grounded fixes. Use when asked to review how work is flowing or suggest process improvements.
+allowed-tools: Bash, Read
+user-invocable: true
+---
+
+# Synapse Audit Analysis
+
+The Go side already runs every detector and, when the selfmonitor service is
+enabled, distills each finding's agent log into a `LogSummary` (stall
+detection, repeated calls, error classes, cost attribution) and classifies it
+with an LLM judge. Your job is to **read those pre-computed results, ground
+them in real context, and produce concrete fixes** — not to recompute them.
+
+## Step 1: Pull the selfmonitor report
+
+```bash
+synapse-cli --json selfmonitor scan
+```
+
+Returns a `selfmonitor.Report` with:
+- `healthScore` — `good` | `warning` | `critical`
+- `findings[]` — each `InvestigatedFinding` has:
+  - `.finding` — `category`, `severity`, `title`, `evidence`, `taskId`
+  - `.logSummary` — `stallDetected`, `stallReason`, `repeatedCalls`,
+    `errorClasses`, `inferredCostPerTool`, `lastToolCalls`, `totalCostUsd`
+  - `.verdict` — `classification`, `rootCause`, `confidence`, `nextAction`
+    (may be `"pending"` if judge is disabled or no log file resolved)
+- `correlations[]` — `kind` (`same_project` | `same_error_class` | `cascade`),
+  `key`, `count`, `fingerprints`, `description`
+
+**Fallback** — if the report is missing or `generatedAt` is > 2h ago:
+
+```bash
+synapse-cli --json health
+```
+
+## Step 2: Pull the workflow summary
+
+```bash
+synapse-cli --json audit --since 7d --summary
+```
+
+Use for trend context only: cycle time, total cost, plan rejection rate, status
+bottleneck dwell over the longer window.
+
+## Step 3: Ground each finding
+
+For the top 3 findings (by severity, then impact):
+
+**If `logSummary` is present:**
+- Cite `stallReason` directly when `stallDetected: true` — no need to read task
+- Cite the top `repeatedCalls` entry (tool name + count + sampleInput) for tool-loop findings
+- Cite `errorClasses[0]` (class + sample) for failure findings
+- Use `inferredCostPerTool` to name the expensive tool for cost outliers
+
+**If `verdict.classification != "pending"`:**
+- Use `verdict.rootCause` as the primary diagnosis
+- Use `verdict.nextAction` as the fix — only refine if task content adds nuance
+
+**Otherwise (no logSummary, verdict pending):**
+
+```bash
+synapse-cli --json get <taskId>
+```
+
+Read task body, status_reason, and any embedded run results to explain why
+the finding fired.
+
+## Step 4: Produce the report
+
+```
+Health: <healthScore>
+Period: <periodStart> → <periodEnd>
+
+Findings: <N> (critical: <C>, warning: <W>)
+{{if correlations}}
+Correlations: <K>
+{{end}}
+
+Top issues:
+1. [category] <title>
+   - Task: <taskId> — <one-line task summary>
+   - Root cause: <verdict.rootCause OR logSummary-derived explanation>
+   - Evidence: <specific signal — stallReason, repeatedCalls[0], errorClasses[0].sample>
+   - Fix: <verdict.nextAction OR specific actionable change>
+
+2. ...
+3. ...
+
+{{if correlations}}
+Correlations:
+- [<kind>] <description>
+{{end}}
+
+Recommendations (cross-cutting):
+- <patterns spanning multiple findings or correlations>
+- <triage rule changes grounded in triage_mismatch findings>
+- <cost optimizations grounded in cost_outlier evidence>
+```
+
+## Rules
+
+- **Never recompute what the report gives you.** If you find yourself filtering
+  raw audit events, stop — use findings and stats.
+- **Cite log-summary signals by name.** Say "stall: last 5 calls are identical
+  Read invocations" not "the agent seemed stuck."
+- **Skip the report entirely** if `healthScore == "good"` and no findings:
+  output one line: `Health: good — no findings in the last 24h.`
+- **Trust the verdict when confidence ≥ 0.8.** Confirm with task content only
+  when confidence is lower or verdict is pending.
+
+<example>
+`synapse-cli --json selfmonitor scan` returns:
+```json
+{
+  "healthScore": "critical",
+  "findings": [
+    {
+      "finding": {"category": "agent_retry_loop", "severity": "critical",
+                  "taskId": "task-abc123", "title": "task task-abc123 has 3 failed agent runs",
+                  "evidence": {"failure_count": 3}},
+      "logSummary": {
+        "stallDetected": true,
+        "stallReason": "last 5 tool calls are identical Read(path='internal/agent/manager.go') invocations",
+        "totalCostUsd": 0.43,
+        "inferredCostPerTool": {"Read": 0.38, "Bash": 0.05}
+      },
+      "verdict": {"classification": "confirmed", "confidence": 0.92,
+                  "rootCause": "agent loops on reading the same 2000-line file without making progress",
+                  "nextAction": "split task into 3 subtasks scoped per concern, or flip to interactive mode"}
+    },
+    {
+      "finding": {"category": "triage_mismatch", "severity": "warning",
+                  "taskId": "task-def456", "title": "task task-def456 triaged headless but escalated to human-required",
+                  "evidence": {"classified_mode": "headless", "final_status": "human-required"}},
+      "logSummary": null,
+      "verdict": {"classification": "pending"}
+    }
+  ],
+  "correlations": []
+}
+```
+
+Then for the pending triage_mismatch, `synapse-cli --json get task-def456` shows
+a task about integrating a new auth provider (touches secrets + IAM).
+
+Output:
+
+```
+Health: critical
+Period: 2026-04-13 → 2026-04-14
+
+Findings: 2 (critical: 1, warning: 1)
+
+Top issues:
+1. [agent_retry_loop] task task-abc123 has 3 failed agent runs
+   - Task: refactor internal/agent/manager.go (~2000 LOC)
+   - Root cause: agent loops on reading the same 2000-line file without making progress
+   - Evidence: stall — last 5 calls are identical Read('internal/agent/manager.go');
+     78% of $0.43 cost attributed to Read
+   - Fix: split into 3 subtasks scoped per concern, or flip to interactive mode
+
+2. [triage_mismatch] task task-def456 triaged headless but escalated to human-required
+   - Task: integrate new auth provider (touches secrets + IAM)
+   - Root cause: triage saw "integrate" + small description and chose headless;
+     task needs credential setup no agent can do autonomously
+   - Evidence: classified_mode=headless → final_status=human-required
+   - Fix: add triage rule "tasks tagged secrets or iam → interactive"
+
+Recommendations:
+- Add triage heuristic: tasks targeting files >1000 LOC default to interactive
+  or get auto-split before dispatch.
+- The selfmonitor actor (when dry_run=false) will auto-flip task-def456 to
+  interactive on the next selfmonitor tick.
+```
+</example>
+
+<example>
+`synapse-cli --json selfmonitor scan` returns `{"healthScore": "good", "findings": []}`.
+
+Output: `Health: good — no findings in the last 24h.`
+</example>

--- a/internal/skills/data/synapse-evaluate.md
+++ b/internal/skills/data/synapse-evaluate.md
@@ -1,0 +1,92 @@
+---
+name: synapse-evaluate
+description: Evaluate completed Synapse tasks — determine status transition and link PRs. Use when asked to evaluate task completion.
+allowed-tools: Bash
+user-invocable: true
+disable-model-invocation: true
+---
+
+# Synapse Task Evaluation
+
+Decide what happens to a task after an agent finishes. Do NOT read source code, review diffs, or explore the codebase.
+
+## Constraints
+
+- Do NOT use Read tool or explore any files
+- Do NOT review code quality, style, or correctness
+- Only analyze the agent result text provided in the prompt
+- Keep total cost under $0.02 per evaluation
+
+## Process
+
+### 1. Read the task
+
+```bash
+synapse-cli --json get <id>
+```
+
+### 2. Link PR if created
+
+Search the agent result for PR references. Look for:
+- `gh pr create` output containing a URL like `https://github.com/.../pull/N`
+- Mentions of "PR #N" or "pull request #N"
+- Branch names pushed (for branch linking)
+
+If found, link to task:
+
+```bash
+# Link PR number
+synapse-cli --json update <id> --pr <number>
+
+# Link branch if known and not already set
+synapse-cli --json update <id> --branch <branch-name>
+```
+
+### 3. Decide status transition
+
+Based ONLY on the agent result text:
+
+| Condition | New Status |
+|-----------|-----------|
+| Agent completed work, PR created or code pushed | in-review |
+| Agent completed but no PR/push (partial work) | human-required |
+| Agent failed, hit errors, looped | human-required |
+| Agent blocked, needs input | human-required |
+
+### Rules
+
+- **Never set `done`** — only humans do that
+- **Never set `todo`** — triggers auto-dispatch, creates duplicate agents
+- Default to `in-review` when uncertain
+- Set `human-required` if agent output shows errors, loops, or incomplete work
+
+### 4. Update status
+
+```bash
+synapse-cli --json update <id> --status <new-status>
+```
+
+<example>
+Input: Agent result text contains `https://github.com/acme/repo/pull/42` and "Successfully created PR".
+
+Actions:
+```bash
+synapse-cli --json update task-abc --pr 42
+synapse-cli --json update task-abc --status in-review
+```
+</example>
+
+<example>
+Input: Agent result text contains "Error: rate limit exceeded" with no PR reference.
+
+Actions:
+```bash
+synapse-cli --json update task-abc --status human-required
+```
+</example>
+
+<example>
+Input: Agent result says "Refactored auth.go, all tests pass" but no branch/PR reference.
+
+Actions: status=`human-required` (partial work, no push detected).
+</example>

--- a/internal/skills/data/synapse-monitor.md
+++ b/internal/skills/data/synapse-monitor.md
@@ -1,0 +1,38 @@
+---
+name: synapse-monitor
+description: Deprecated. Monitor now runs in-process inside Synapse. Use `synapse-cli monitor scan` for an ad-hoc detector pass or read the `monitor:report` event from the GUI.
+allowed-tools: Bash, Read
+user-invocable: true
+---
+
+# Synapse Monitor (legacy skill stub)
+
+The monitor loop previously driven by `/loop 5m /synapse-monitor` now runs
+inside the Synapse Go backend (`internal/monitor/`). It ticks every 5 min,
+detects anomalies, applies idempotent remediations, and spawns focused
+headless Claude agents for anything that needs LLM judgment.
+
+This skill no longer runs in a loop. Do **not** register a cron or `/loop`
+for it.
+
+## Read-only ad-hoc pass
+
+```bash
+synapse-cli monitor scan            # human summary line
+synapse-cli monitor scan --json     # full Report JSON
+```
+
+The `--json` output matches `monitor.Report` in `internal/monitor/report.go`
+and is emitted over the Wails `monitor:report` event on every tick.
+
+## What moved to Go
+
+- **Board + audit snapshot, dwell check, threshold detection** — `internal/monitor/detector.go`.
+- **`lost_agent` reset + `untriaged` status reason** — `internal/monitor/remediator.go`.
+- **Issue dedup + creation via `gh`** — `internal/monitor/issuesink.go`.
+- **LLM dispatch (pr_gap, stuck_human_blocked, failure_spike, bottleneck)** —
+  `internal/monitor/dispatcher.go` via `agent.Manager.Run`.
+- **Heartbeat** — removed. The in-process service is its own liveness signal.
+
+If something in the loop is broken, start at `internal/monitor/service.go`
+and follow the references.

--- a/internal/skills/data/synapse-plan.md
+++ b/internal/skills/data/synapse-plan.md
@@ -1,0 +1,123 @@
+---
+name: synapse-plan
+description: Plan Synapse tasks — analyze scope, explore codebase, produce implementation plan without writing code. Use when asked to plan a task.
+allowed-tools: Bash, Read, Glob, WebFetch
+user-invocable: true
+---
+
+# Synapse Task Planning
+
+Produce a detailed implementation plan for a task. Do NOT implement, write code, create files, or make changes.
+
+You run inside an interactive tmux session. After producing a plan you STAY at the prompt and wait for feedback from the user — you never exit.
+
+## CLI Reference
+
+The ONLY valid flags for `synapse-cli update` are: `--title`, `--status`, `--body`, `--plan`, `--plan-file`, `--mode`, `--tags`, `--project`. Do NOT use any other flag.
+
+## Process
+
+### 1. Read the task
+
+```bash
+synapse-cli --json get <id>
+```
+
+### 2. Analyze scope
+
+- Read the task body, understand what's being asked
+- If URLs are referenced, fetch context (GitHub PRs/issues via `gh`, or WebFetch)
+- Explore the codebase: find relevant files, understand existing patterns
+- Identify dependencies and potential risks
+
+### 3. Produce a structured plan
+
+Output a markdown plan with these sections:
+
+```markdown
+## Approach
+
+Brief description of the chosen approach and why.
+
+## Files to Change
+
+- `path/to/file.go` — what changes and why
+- `path/to/other.go` — what changes and why
+
+## Steps
+
+1. First step — details
+2. Second step — details
+3. ...
+
+## Risks
+
+- Risk 1 and mitigation
+- Risk 2 and mitigation
+```
+
+### 4. Publish the plan + hand off for review
+
+```bash
+synapse-cli --json update <id> --plan "<full plan markdown>"
+synapse-cli --json update <id> --status plan-review
+```
+
+Then STOP and wait at the chat prompt. Do NOT exit. Do NOT implement.
+
+### 5. Respond to feedback
+
+The user may send feedback in the same chat session. When feedback arrives:
+
+1. Read it carefully
+2. Revise the plan (use prior context — do not re-analyze files you already read)
+3. `synapse-cli --json update <id> --plan "<revised plan>"`
+4. `synapse-cli --json update <id> --status plan-review`
+5. Wait again
+
+### Guidelines
+
+- Be specific: name files, functions, types
+- Keep it actionable — each step should be implementable
+- Note existing patterns to follow
+- Flag anything ambiguous that needs human input
+- Do NOT write code, create files, or make any changes
+- Do NOT exit after publishing the plan — keep the session alive for review rounds
+
+<example>
+Input: Task `task-abc` body: "Add rate limiting to /api/login endpoint, 5 req/min per IP".
+
+Output plan:
+```markdown
+## Approach
+Middleware using token bucket keyed by client IP. Reuse existing `internal/middleware` package.
+
+## Files to Change
+- `internal/middleware/ratelimit.go` — new, token bucket implementation
+- `internal/middleware/ratelimit_test.go` — new, table-driven tests
+- `cmd/api/main.go` — wire middleware into `/api/login` route
+
+## Steps
+1. Add `golang.org/x/time/rate` to go.mod
+2. Implement `NewIPLimiter(rps, burst)` returning `func(http.Handler) http.Handler`
+3. Write tests covering allow/deny/reset scenarios
+4. Wire into login route in main.go
+
+## Risks
+- Memory growth from IP map — mitigate with LRU eviction (cap 10k entries)
+- Behind proxy: read `X-Forwarded-For` header, trust only proxy range
+```
+
+Then:
+```bash
+synapse-cli --json update task-abc --plan "<plan above>"
+synapse-cli --json update task-abc --status plan-review
+```
+Stay at prompt, wait for feedback.
+</example>
+
+<example>
+Input: User feedback "also add metrics for blocked requests".
+
+Action: Revise Steps section to add prometheus counter, re-publish plan, set status plan-review, wait again. Do NOT re-read files already explored.
+</example>

--- a/internal/skills/data/synapse-self-monitor.md
+++ b/internal/skills/data/synapse-self-monitor.md
@@ -1,0 +1,219 @@
+---
+name: synapse-self-monitor
+description: Periodic deep analysis of agent runs and workflow health. Reads structured findings from Go health checker, investigates root causes by reading agent logs, cross-correlates patterns, and files deduped GitHub issues. Designed for loop-agent invocation every ~6h.
+allowed-tools: Bash, Read, Grep, Glob
+user-invocable: true
+---
+
+# Synapse Self-Monitor
+
+Deep reasoning analysis of Synapse agent runs and workflow health. The Go health checker (`internal/health/`) runs every 10 minutes and produces structured findings (cost outliers, failure spikes, stuck tasks, workflow loops, status bounces, cost drift). This skill consumes those findings and investigates the **why** — reading agent conversation logs, cross-correlating patterns, and producing actionable recommendations.
+
+Designed to run as a loop agent (`/synapse-self-monitor` every 6h) but also works as a one-shot invocation.
+
+## When not to use
+
+- Real-time board monitoring → use `/synapse-monitor` (runs every 5m inside the orchestrator session).
+- Deep historical audit report → use `/synapse-audit`.
+- Triaging tasks → use `/synapse-triage`.
+
+## Hard rules
+
+- **Cap at 5 new issues per run.** Beyond that, stop filing and report the overflow count in the summary.
+- **Never reopen closed issues.** If the same finding matches a closed issue, skip it.
+- **Always emit a JSON summary line at the end.** Parseable by downstream audit analysis.
+- **Read-only analysis.** Never modify tasks, agent state, or config. Only side effects: filing GitHub issues.
+- **Be specific.** Don't say "agent was expensive" — say "agent spent 47 turns reading every file in src/ instead of grepping for the symbol."
+
+## Phase 1 — Gather structured health data
+
+```bash
+synapse-cli --json health
+```
+
+This returns the latest health report from the Go checker with all findings and stats.
+
+If no report exists (app not running), fall back to manual audit analysis:
+
+```bash
+synapse-cli --json audit --since 24h --summary
+```
+
+For each finding with a `taskId`, fetch task details:
+
+```bash
+synapse-cli --json get <taskId>
+```
+
+## Phase 2 — Deep investigation
+
+For each finding, investigate the root cause. Prioritize: critical findings first, then warnings.
+
+### Cost outliers
+
+1. Read the agent's NDJSON log file (path in finding's `logFile` or task's `agentRuns[].logFile`)
+2. Analyze tool call patterns:
+   - Is the agent reading too many files instead of grepping?
+   - Is it running expensive bash commands repeatedly?
+   - Is it stuck in a reasoning loop (same tool call 3+ times with similar args)?
+   - Is the task appropriately sized? (small task shouldn't need $15 of agent time)
+3. Check if the prompt/skill being invoked is inefficient
+
+### Agent failures
+
+1. Read failed agent's log to find the actual error
+2. Classify: transient (API rate limit, overloaded_error, network) vs systematic (bad prompt, missing context, wrong approach)
+3. Cross-reference: do multiple failures involve the same project, same codebase area, or same skill?
+4. Check if the failure is a known issue (same error pattern in recent runs)
+
+### Workflow loops (plan-reject cycles)
+
+1. Read the task's plan and plan-critique content
+2. Determine: is plan quality poor (agent not reading enough code), or are rejection criteria too strict?
+3. Check if the planner and critic are using the same codebase context
+
+### Stuck tasks
+
+1. Check if there's a live agent that simply hasn't reported (watchdog may handle this)
+2. Read the last agent's log to understand where progress stalled
+3. Check if the task depends on external input (human review, PR merge)
+
+### Status bounces
+
+1. Read task history to understand the back-and-forth
+2. Determine: is the workflow definition causing the bounce, or is it agent failures triggering retries?
+
+### Cost drift
+
+1. Compare cost patterns by role — which role is driving the increase?
+2. Check if task complexity has changed (more large tasks) or if agents are becoming less efficient
+3. Look at recent skill/prompt changes that might affect token usage
+
+## Phase 3 — Cross-correlation
+
+After investigating individual findings, look for patterns across them:
+
+- **Codebase hotspots:** Multiple failures or expensive runs touching the same project or directory?
+- **Skill degradation:** Is one skill (triage, plan, eval) responsible for a disproportionate share of findings?
+- **Time patterns:** Do problems cluster at certain times? (e.g., rate limits during peak hours)
+- **Cascade effects:** Did one failure trigger a chain? (failed impl → stuck task → status bounce)
+
+## Phase 4 — File issues
+
+Determine the target repo:
+
+```bash
+REPO=$(cd ~/.synapse && gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
+```
+
+If empty, try the first registered project:
+
+```bash
+REPO=$(synapse-cli --json project list 2>/dev/null | jq -r '.[0].id // empty')
+```
+
+If still empty, skip issue filing and just print findings to stdout.
+
+Ensure label exists:
+
+```bash
+gh label create synapse-self-monitor --repo "$REPO" --color C5DEF5 --description "Filed by /synapse-self-monitor" 2>/dev/null || true
+```
+
+For each confirmed finding (not false positives), derive a stable title and search for duplicates:
+
+```bash
+gh issue list --repo "$REPO" --label synapse-self-monitor --state all --search "in:title \"<title prefix>\"" --json number,state,title --limit 3
+```
+
+- Open match → skip
+- Closed match → skip
+- No match → file (up to 5-issue cap)
+
+Issue body format:
+
+```bash
+gh issue create --repo "$REPO" --label synapse-self-monitor --title "<title>" --body "$(cat <<'EOF'
+## Detection
+
+- **Time:** <ISO timestamp>
+- **Category:** <finding category>
+- **Severity:** <severity>
+
+## Root cause
+
+<1-3 sentences explaining WHY this happened, based on log analysis>
+
+## Evidence
+
+```
+<relevant log excerpts, max 20 lines — tool calls, errors, patterns found>
+```
+
+## Recommended action
+
+<specific, actionable recommendation — not "investigate further" but "update the eval skill prompt to grep for changed files instead of reading the full tree">
+
+## Context
+
+Filed by synapse-self-monitor. Findings from Go health checker investigated with agent log analysis.
+EOF
+)"
+```
+
+## Phase 5 — Summary
+
+Print exactly one JSON line to stdout as the final output:
+
+```json
+{"findings_total": 5, "investigated": 5, "confirmed": 3, "false_positives": 2, "filed": 2, "skipped_dup": 1, "skipped_cap": 0, "errors": 0}
+```
+
+## Examples
+
+<example>
+**Clean run — no findings from health checker.**
+
+Health report shows 0 findings. Stats look normal.
+
+Output:
+```json
+{"findings_total": 0, "investigated": 0, "confirmed": 0, "false_positives": 0, "filed": 0, "skipped_dup": 0, "skipped_cap": 0, "errors": 0}
+```
+</example>
+
+<example>
+**Cost outlier investigated — false positive.**
+
+Health checker flags eval agent at $0.65 (threshold $0.50). Reading the log reveals the task was a large PR review (800 lines changed) — the cost is proportional to the work. Mark as false positive, don't file.
+
+Output:
+```json
+{"findings_total": 1, "investigated": 1, "confirmed": 0, "false_positives": 1, "filed": 0, "skipped_dup": 0, "skipped_cap": 0, "errors": 0}
+```
+</example>
+
+<example>
+**Multiple failures cross-correlated.**
+
+Health checker flags 3 agent failures + high failure rate. Reading logs reveals all 3 failed on the same project with `permission denied` errors on worktree paths. Root cause: stale worktree not cleaned up. File one consolidated issue instead of three.
+
+Actions:
+- Investigate 4 findings (3 failures + 1 failure_rate)
+- Confirm 1 root cause (stale worktree)
+- File 1 issue: `fix(worktree): stale worktree blocking agents on project X`
+
+Output:
+```json
+{"findings_total": 4, "investigated": 4, "confirmed": 4, "false_positives": 0, "filed": 1, "skipped_dup": 0, "skipped_cap": 0, "errors": 0}
+```
+</example>
+
+## Errors
+
+| Error | Response |
+|---|---|
+| No health report and audit unavailable | Report `errors: 1` in summary. Skip investigation. |
+| Agent log file missing or unreadable | Note in investigation, don't fail the whole run. Continue with other findings. |
+| `gh` auth failure or rate limit | Skip Phase 4. Print findings to stdout only. Report `errors: 1`. |
+| No repo determinable | Skip Phase 4. Print findings to stdout only. Not an error. |

--- a/internal/skills/data/synapse-tasks.md
+++ b/internal/skills/data/synapse-tasks.md
@@ -1,0 +1,84 @@
+---
+name: synapse-tasks
+description: Manage Synapse tasks (list, create, update, delete) via synapse-cli. Use when user mentions tasks, work items, TODOs, or asks to track/create/update work.
+allowed-tools: Bash
+user-invocable: true
+argument-hint: "[list|create|update|delete] [args]"
+---
+
+# Synapse Task Management
+
+Use `synapse-cli` to manage tasks. Always use `--json` for machine-parseable output.
+
+## Commands
+
+```bash
+# List all tasks
+synapse-cli --json list
+
+# Filter by status (todo, in-progress, in-review, done)
+synapse-cli --json list --status todo
+
+# Filter by tag
+synapse-cli --json list --tag backend
+
+# Get single task
+synapse-cli --json get <id>
+
+# Create task
+synapse-cli --json create --title "task title" --body "markdown body" --mode headless --tags "tag1,tag2"
+
+# Update task fields (only specify what changes)
+synapse-cli --json update <id> --status in-progress
+synapse-cli --json update <id> --title "new title" --tags "new,tags"
+
+# Delete task
+synapse-cli --json delete <id>
+```
+
+## Task Fields
+
+- **status**: `new` | `todo` | `in-progress` | `in-review` | `human-required` | `done`
+- **mode**: `headless` (automated claude -p) | `interactive` (tmux session)
+- **tags**: comma-separated labels
+
+## Workflow
+
+1. `synapse-cli --json list --status todo` — see open tasks
+2. `synapse-cli --json update <id> --status in-progress` — pick up task
+3. Do the work
+4. `synapse-cli --json update <id> --status done` — mark complete
+
+## Output Format
+
+Single task: JSON object with `id`, `title`, `status`, `agentMode`, `tags`, `body`, `createdAt`, `updatedAt`.
+List: JSON array of task objects. Empty list returns `[]`.
+Delete: `{"deleted": "<id>"}`.
+Errors: stderr `{"error": "message"}` with non-zero exit.
+
+<example>
+Input: User says "show me all open backend tasks".
+
+Command: `synapse-cli --json list --status todo --tag backend`
+
+Output: JSON array of tasks matching both filters.
+</example>
+
+<example>
+Input: User says "create a task to fix the login bug, tag as auth, headless mode".
+
+Command:
+```bash
+synapse-cli --json create --title "fix login bug" --mode headless --tags "auth,bug"
+```
+
+Output: `{"id": "task-xyz", "title": "fix login bug", "status": "new", ...}`
+</example>
+
+<example>
+Input: User says "mark task-abc as in progress".
+
+Command: `synapse-cli --json update task-abc --status in-progress`
+
+Output: Updated task JSON.
+</example>

--- a/internal/skills/data/synapse-test-plan.md
+++ b/internal/skills/data/synapse-test-plan.md
@@ -1,0 +1,324 @@
+---
+name: synapse-test-plan
+description: Build a manual test plan for a Synapse task in the testing phase — spawns three distinct expert-tester personas (Bach, Kaner, Hendrickson) in parallel, each drafting test cases from their own frame, then merges before publishing. Critique is handled by a separate cross-provider workflow step. Covers Kubernetes and GUI app changes. Use whenever a task enters the testing status, when asked to "write a test plan", "plan manual tests", "figure out how to test X", or when reviewing a change that needs manual verification before merge.
+allowed-tools: Bash, Read, Agent
+user-invocable: true
+---
+
+<!-- justify: I2 flat single-file convention matches sibling synapse skills and the runtime ~/.synapse/skills/ sync; extracting to references/ would break parity -->
+<!-- justify: I17 side-effect signals appear inside domain checklists as example cases the human runs during manual testing, not commands the skill itself executes -->
+
+# Synapse Test Plan
+
+Produce a rigorous manual test plan for a task by spawning three expert-tester personas in parallel, merging their outputs, and publishing. Critique is handled by a separate cross-provider workflow step. Plan manual verification only — do not execute tests and do not write automated tests.
+
+Runs inside an interactive tmux session. After publishing, stay at the prompt and wait for feedback — never exit, so the human can send revisions in the same chat.
+
+## When not to use
+
+- **Trivial changes** — typo, pure internal refactor with no behavior change, docs-only. Write a one-paragraph smoke-test plan and publish directly; the three-persona flow is overkill.
+- **No PR or diff available** — personas can't frame out of thin air. Ask the human for the change surface before spawning anything.
+- **Automated-test territory** — unit tests, integration tests, contract tests. This skill plans *manual* verification only; use `test-writer` for automated coverage.
+- **Executing tests** — this skill plans, it does not run. A separate agent or human runs the cases.
+
+## Why three personas
+
+Three distinct voices from the testing world each generate **different** test cases because they start from different mental models:
+
+- **James Bach** (Rapid Software Testing) — heuristic bug-hunter. Generates attack vectors, boundary assaults, oracle violations.
+- **Cem Kaner** (Context-Driven, psychologist + lawyer) — user-harm analyst. Generates cases around data integrity, legibility, trust, ambiguous states.
+- **Elisabeth Hendrickson** ("Explore It!") — charter-driven state explorer. Generates cases around state machines, interrupted flows, concurrency, soak.
+
+Parallel drafting (not parallel reviewing of a shared draft) preserves each persona's generative frame — reviewers of a blended draft only patch gaps inside its existing structure.
+
+## CLI reference
+
+Test plan lives in the task's `--plan` field (same mechanism as `synapse-plan`). Valid `synapse-cli update` flags: `--title`, `--status`, `--body`, `--plan`, `--plan-file`, `--plan-critique`, `--plan-critique-file`, `--mode`, `--tags`, `--project`.
+
+Status flow: `testing` → (parallel drafts + merge + review) → `test-plan-review`.
+
+## Process
+
+### 1. Read the task and the change
+
+```bash
+synapse-cli --json get <id>
+```
+
+Read the task body, `plan` field, and any linked PR (`gh pr view <n> --json title,body,files`). Then read the changed files directly, because a plan written against a prose description misses real behavior — the code is the only reliable source of the actual surface area. Build a short "change under test" summary to hand to every persona.
+
+### 2. Classify the domain
+
+- **Kubernetes** — manifests, controllers/operators, Helm, probes, RBAC, networking, storage, CRDs. Use the [k8s checklist](#kubernetes-checklist).
+- **GUI app** — Svelte/Wails frontend, desktop windows, forms, panels, event streams. Use the [GUI checklist](#gui-app-checklist).
+- **Both / neither** — combine or skip the domain section; the persona frames still apply.
+
+For trivial changes see the "When not to use" section at the top — produce a one-paragraph smoke plan and publish directly, because the three-persona overhead isn't justified for a one-line change.
+
+### 3. Spawn three personas in parallel
+
+Invoke three `Agent` tool calls in a **single assistant message** — sequential spawning leaks context between personas and erodes the frame diversity that makes this skill work. Use `subagent_type: general-purpose`. Each prompt contains:
+
+1. The change under test (same for all three)
+2. The relevant domain checklist (same for all three)
+3. A persona-specific brief (different — see templates below)
+
+Ask each persona for **5–8 test cases** in their voice, using the standard test-case format. Fewer than 5 means the persona skipped its own heuristics; more than 8 dilutes the merge.
+
+**Shared scaffold (append to every persona brief):**
+
+```
+## Change under test
+<paste change summary + file list + PR description>
+
+## Domain checklist
+<paste k8s or GUI checklist>
+
+## Output format
+<paste test case format>
+
+## Task
+Generate 5–8 test cases in your voice. Stay in your frame — cover only
+what you see, not what other testers would cover.
+```
+
+**Bach brief** — Rapid Software Testing, heuristic bug-hunter:
+
+```
+You are James Bach. Software is an opponent; your job is to attack it
+where it's weakest. Don't trust any claim until you've tried to falsify
+it.
+
+Toolkit:
+- FEW HICCUPPS oracles (Familiar, Explainable, World, History, Image,
+  Comparable products, Claims, User expectations, Product, Purpose,
+  Statutes) — for each letter, find an inconsistency you can expose.
+- SFDPOT coverage (Structure, Function, Data, Platform, Operations, Time).
+- Goldilocks / Zero-One-Many — test 0, 1, 2, many, way-too-many, and
+  exact boundaries.
+- Error guessing from known bug patterns.
+
+Prefer cases a developer would NOT think to write: interrupt operations,
+feed garbage, run twice simultaneously, falsify product claims. Cite the
+heuristic or oracle each case came from.
+```
+
+**Kaner brief** — Context-Driven, user-harm analyst:
+
+```
+You are Cem Kaner — psychologist, lawyer, testing academic. Quality is
+value to some person who matters. A bug is a threat to that value. Find
+defects AND understand who is harmed, how badly, and whether behavior
+can be explained to a reasonable user (or a courtroom).
+
+Lenses:
+- Who is the user of this change? What do they believe will happen?
+- Oracle: how does a tester know pass vs fail, and can they defend that
+  judgment with evidence?
+- CRUSSPIC STMPL quality criteria: Capability, Reliability, Usability,
+  Security, Scalability, Performance, Installability, Compatibility,
+  Supportability, Testability, Maintainability, Portability,
+  Localizability — which apply?
+- Data integrity and legibility — can the user still trust what they
+  see? Could silent data loss or ambiguous state slip through?
+- Error messages, audit trails, reversibility, consent.
+
+Prefer cases a developer would dismiss as "UX issue" or "technically
+correct data". State the oracle explicitly for each case: what the
+tester observes and why it counts as pass or fail.
+```
+
+**Hendrickson brief** — Explore It!, state-based tours:
+
+```
+You are Elisabeth Hendrickson — author of "Explore It!" and pioneer of
+charter-driven exploratory testing. Software is a state machine; most
+bugs live at transitions nobody mapped. Test by taking tours — deliberate
+walks through the state space with a mission.
+
+Toolkit:
+- State modeling: what states can this feature be in? Which transitions
+  are untested?
+- Tours: Feature Tour, Data Tour, Interruption Tour, Back Button Tour,
+  Configuration Tour, Soak Tour.
+- Charters: "Explore <area> with <resources> to discover <information>."
+- Concurrency: same operation twice, second user mid-flow, backend
+  replies out of order.
+- Persistence: what survives a restart? what shouldn't?
+
+Frame each case as a mini-charter or tour. Name the tour or state
+transition each case exercises.
+```
+
+### 4. Merge the three drafts
+
+Merge in the main context, not a subagent — a merge needs all three outputs held simultaneously to reason about overlap vs uniqueness.
+
+1. **Collect** all cases (typically 15–24 total).
+2. **Dedupe by test intent**, not wording. Same behavior + same oracle = one case; keep the clearer wording, attribute to the finder so the human reviewer sees provenance.
+3. **Resolve conflicts.** If personas disagree on expected behavior, flag as open question — silently picking a winner hides a real design ambiguity.
+4. **Preserve diversity.** Keep cases unique to one persona even if weird; weird cases are usually the valuable ones, and discarding them defeats three frames.
+5. **Reorganize** into the plan template below, grouped by area not persona (the tester executes by area; persona origin is provenance, not structure).
+6. **Prune** over ~15 cases by dropping weakest oracles / smallest blast radius. Keep at least 6 — below that, one persona's contribution is lost, breaking the three-frame guarantee.
+
+### 5. Publish and hand off
+
+```bash
+synapse-cli --json update <id> --plan "<final plan>"
+synapse-cli --json update <id> --status test-plan-review
+```
+
+After publishing, stay at the chat prompt. Do not execute tests and do not exit, because the human reviewer will send feedback in the same chat session and needs the agent alive to receive it.
+
+### 6. Respond to human feedback
+
+The human may push back. Revise and re-publish. Skip re-running personas for small tweaks — only re-run them if the change's scope fundamentally shifts, because persona re-runs are expensive and rarely add value for wording changes.
+
+---
+
+## Test case format
+
+Every test case — whether produced by a persona or written into the merged plan — uses this format:
+
+```markdown
+### TC-<n>: <short actionable name>
+**Setup:** <pre-conditions specific to this case>
+**Steps:**
+1. ...
+2. ...
+**Expected:** <what should happen>
+**Oracle:** <how the tester knows pass vs fail — be explicit>
+**Source:** <Bach | Kaner | Hendrickson | merge> — <which heuristic / tour / lens>
+```
+
+## Merged plan template
+
+```markdown
+## Scope
+<one paragraph — what's being tested, link PR / files>
+
+## Pre-conditions
+- Environment: ...
+- Version under test: ...
+- Fixtures/accounts: ...
+
+## Test cases
+<grouped by area, TC-1 through TC-N>
+
+## Risk areas
+- <the 3 riskiest spots, with reasoning — this is where bugs most likely hide>
+
+## Out of scope
+- <explicit non-goals>
+
+## Open questions
+- <anything the plan can't answer without human input, including conflicts between personas>
+
+## Persona attribution
+- Bach contributed: TC-x, TC-y
+- Kaner contributed: TC-z
+- Hendrickson contributed: TC-a, TC-b
+- Merged/shared: TC-c
+```
+
+---
+
+## Kubernetes checklist
+
+Share with every persona as context. Not every item applies to every change — personas decide relevance through their own frame.
+
+- **Rollout & lifecycle**: fresh install; rolling update (zero downtime); rollback via `rollout undo` / `helm rollback`; failed rollout → `ProgressDeadlineExceeded`, no traffic to bad pods; mid-rollout pod eviction recovery.
+- **Probes**: liveness catches deadlock; readiness drops unready pod from LB when dependency unavailable; startup probe covers slow boot; timeouts/thresholds have headroom under load.
+- **Resources & scheduling**: requests/limits under load; OOM → clean restart + events; CPU throttling visible; node drain respects PDB; anti-affinity spreads pods.
+- **RBAC & security**: ServiceAccount only has claimed perms (forbidden verb → 403); non-root + read-only FS where applicable; secrets not in logs/env dumps; NetworkPolicy allows/blocks correctly.
+- **Data & state**: PVC persists across pod restart; concurrent writes don't corrupt; backup/restore exercised.
+- **Chaos / failure**: force-terminate pod — recovery within SLO; network partition (Chaos Mesh); API server briefly unreachable — controller resumes; etcd latency spike.
+- **Operator/controller**: reconcile idempotent (apply twice, no drift/thrash); delete CR → GC owned resources; CR mutation picked up within requeue; invalid spec → rejected or graceful, never crash-loop; controller restart mid-reconcile resumes cleanly.
+- **Helm**: `helm lint`/`helm template` clean across profiles; install → upgrade → rollback all succeed; default values work; each override actually changes rendered manifest.
+- **Observability**: expected metrics present, cardinality bounded; structured logs with correlation IDs; traces propagate.
+- **Version/platform**: lowest + highest supported k8s version; arm64 + amd64 if claimed.
+
+---
+
+## GUI app checklist
+
+Synapse frontend is Svelte 5 + Wails v2 in a desktop window. Share with every persona.
+
+- **Visual & layout**: components render without overlap at default size; no typos/Lorem Ipsum/debug text; loading/empty/error states distinct; dark + light theme (Skeleton UI); consistent font sizes.
+- **Responsiveness & resize**: resize to ~800×600 and very large; content reflows, no clipped text or unintended scrollbars; split panes snap to min/max.
+- **Input & forms**: empty, max+1, pasted, unicode, emoji, RTL; validation errors inline + clear; required-field check; submit disabled while in-flight (no double-submit); Escape closes modals, Enter submits where expected.
+- **Keyboard & focus** (WCAG 2.4.3 / 2.4.7): Tab reaches every interactive element in logical order; Shift+Tab reverses; focus ring visible; modals trap focus, restore to trigger on close.
+- **State transitions**: happy path; interrupt mid-flow (no orphan state); state persists across restart where intended; panels stay in sync via Wails events.
+- **Backend interactions**: Wails bound methods succeed/error/timeout (simulate via slow Go handler); event stream (`agent:output:<id>`) renders each event, no drops/dupes; backend returns empty/one/many/thousands; long-running calls keep UI responsive.
+- **Errors & edge cases**: disconnect network mid-op; malformed data (degrade, don't crash); filesystem permission denied; task/project deleted while UI has it open.
+- **Platform & accessibility**: macOS primary, spot-check Windows/Linux if claimed; system dark-mode toggle mid-session; VoiceOver announces controls meaningfully; 3:1 contrast on focus, 4.5:1 on text.
+
+---
+
+## Examples
+
+<example>
+**GUI change** — task `task-xyz`: "Add rollback button to task detail panel. Calls `rollbackTask(id)` Wails method, shows confirmation dialog."
+
+Classify as GUI change. Read `TaskDetail.svelte` and `app.go`. Spawn three personas in parallel with GUI checklist + change summary.
+
+**Bach returns:** double-click assault, click-then-escape-mid-dialog, Wails method returning an error the UI doesn't handle, rollback of a task with no prior revision, concurrent rollback + edit, keyboard-only activation.
+
+**Kaner returns:** confirmation dialog wording is ambiguous about reversibility, audit trail check (can user see what was rolled back?), state after rollback should match state before edit — is the oracle provable?, error message legibility when backend fails, button visible to users without permission to rollback.
+
+**Hendrickson returns:** Feature Tour (happy path), Interruption Tour (close window mid-dialog, then reopen), Back Button Tour (Escape cancels, focus returns to button), Data Tour (rollback on task with 0, 1, many prior states), Soak Tour (rollback repeatedly, any state leak?).
+
+**Merge:** 18 → 12 cases after dedupe. Bach's "click-then-escape-mid-dialog" dupes Hendrickson's Interruption Tour — keep Hendrickson's framing. Kaner's "audit trail" is unique, keep. Keep all of Hendrickson's tours. Group into sections: Happy path, Keyboard & focus, Error handling, State persistence.
+
+**Publish:**
+```bash
+synapse-cli --json update task-xyz --plan "<merged plan>"
+synapse-cli --json update task-xyz --status test-plan-review
+```
+Stay at prompt.
+</example>
+
+<example>
+**Kubernetes change** — task `task-k8s-42`: "Add PodDisruptionBudget to synapse-agent Helm chart with `minAvailable: 1`; bump chart version to 0.4.0."
+
+Classify as Kubernetes change. Read `charts/synapse-agent/templates/pdb.yaml`, `values.yaml`, and `Chart.yaml`. Spawn three personas in parallel with k8s checklist.
+
+**Bach returns:** drain a node with only 1 replica running (does drain block forever?), set `minAvailable` higher than replicas (`helm lint` should catch), upgrade from 0.3.x → 0.4.0 then rollback, PDB with 0 replicas at time of drain, concurrent drain of 2 nodes.
+
+**Kaner returns:** rollback from 0.4.0 → 0.3.x — does the PDB resource get cleaned up, or is it orphaned (user trust in "rollback = previous state")?, what does the operator see when drain is blocked (is the error legible)?, PDB label selector audit (does it actually match pods, or does it silently match nothing?).
+
+**Hendrickson returns:** Configuration Tour (every `values.yaml` combination that affects PDB), Interruption Tour (`helm upgrade` interrupted mid-apply), State Tour (PDB state across pod restart, node cordoning, and autoscaler scale-down), Soak Tour (leave cluster for 24h under rolling updates, PDB count never drifts).
+
+**Merge:** 16 → 11 cases. Bach's "minAvailable > replicas" is a `helm lint` case — demote to smoke check, not a full TC. Kaner's orphan-resource-after-rollback is unique — keep. Group: Install/upgrade/rollback, Drain behavior, Label selector, Observability.
+
+**Review:** Approve. Publish, stay at prompt.
+</example>
+
+<example>
+**Trivial change — skip personas** — task `task-typo-7`: "Fix typo in task detail panel: 'Recieved' → 'Received'."
+
+No personas needed. Publish a one-line smoke plan:
+
+```markdown
+## Scope
+Verify the word "Received" renders correctly in the task detail panel header.
+
+## Test cases
+1. Open any task in the detail panel — confirm the header reads "Received" (not "Recieved"). No other behavior should change.
+```
+
+```bash
+synapse-cli --json update task-typo-7 --plan "<smoke plan>"
+synapse-cli --json update task-typo-7 --status test-plan-review
+```
+</example>
+
+## Guardrails
+
+- Plan manual verification only; automated tests belong in `test-writer`.
+- Don't execute cases — this skill produces the plan, a human runs it.
+- Stay at the prompt after publishing, so the human can send feedback.
+- Spawn personas in **parallel** (single message, three `Agent` calls). Sequential spawning leaks context and erodes frame diversity.
+- Skip personas for trivial changes (docs, typos, pure refactor) — publish a one-paragraph smoke plan instead.
+- Surface persona disagreements in Open questions; silently picking a winner hides real design ambiguity.
+- If the change is unidentifiable (no PR, no diff, vague body), ask the human before spawning personas.

--- a/internal/skills/data/synapse-triage.md
+++ b/internal/skills/data/synapse-triage.md
@@ -1,0 +1,47 @@
+---
+name: synapse-triage
+description: Triage Synapse tasks — delegate to the Go classifier which rewrites the title, assigns tags/mode/status, and matches a project in one atomic update. Use when asked to triage, categorize, or prioritize tasks.
+allowed-tools: Bash
+user-invocable: true
+---
+
+# Synapse Task Triage
+
+Classify pending tasks via the Go classifier. Go owns routing rules, tag validation, project auto-match, and atomic multi-field updates. The LLM only produces the structured verdict.
+
+## Process
+
+1. List pending tasks:
+
+   ```bash
+   synapse-cli --json list --status new
+   ```
+
+2. For each task, run the classifier:
+
+   ```bash
+   synapse-cli --json triage classify <id>
+   ```
+
+   This makes a single `claude -p` call that:
+   - Rewrites the title into a clean imperative conventional-commit form (always, even if the input already looked fine)
+   - Preserves the original title in the body
+   - Assigns tags from the controlled vocabulary (backend, frontend, infra, docs, ci, auth, db, test + size + type)
+   - Picks size (small|medium|large), type (bug|feature|refactor|review|chore|docs), and mode (headless|interactive)
+   - Auto-matches a registered project if a github.com URL is in the title or body
+   - Applies routing rules (medium/large features → planning; everything else → todo)
+   - Forces `interactive` mode for `work` projects unless it's a PR review
+   - Writes a `triage.classified` audit event
+
+3. Batch mode for larger queues:
+
+   ```bash
+   synapse-cli --json triage classify --all
+   ```
+
+## Constraints
+
+- Do NOT call `synapse-cli update` directly during triage — the Go classifier owns every field change. Manual updates will race the classifier and break audit trails.
+- Do NOT explore the codebase or read source files — the classifier sees only `{title, body, registered projects}`. Codebase exploration belongs in planning/implementation.
+- If `classify` returns an error, flag the task with `synapse-cli update <id> --status human-required --status-reason "triage failed"` and move on.
+- Ignore tasks with `role` field set (triage, plan, eval, pr-fix) — those are system agents, not implementation work.

--- a/internal/skills/embed.go
+++ b/internal/skills/embed.go
@@ -1,0 +1,11 @@
+// Package skills embeds the bundled Claude Code skill definitions so that
+// synapse-server can seed ~/.claude/skills/ even when the source repository is
+// not present on disk (e.g. Docker deployments).
+package skills
+
+import "embed"
+
+// FS contains the bundled .md skill files under data/.
+//
+//go:embed data/*.md
+var FS embed.FS

--- a/internal/synapse/app.go
+++ b/internal/synapse/app.go
@@ -83,6 +83,10 @@ type App struct {
 
 	bgops *bgop.Tracker
 
+	// skillsFS is an optional embedded FS used as a fallback when the
+	// repository's .claude/skills/ directory is not present on disk.
+	skillsFS fs.FS
+
 	// Wails-bound services (created in startup)
 	taskSvc      *TaskService
 	planSvc      *PlanningService
@@ -113,6 +117,13 @@ func WithEmit(fn func(string, any)) Option {
 	return func(a *App) {
 		a.emitFactory = func(context.Context) func(string, any) { return fn }
 	}
+}
+
+// WithSkillsFS sets an embedded FS used as a fallback source for skill files
+// when the repository's .claude/skills/ directory is not present on disk.
+// Typically populated from the internal/skills package in the server binary.
+func WithSkillsFS(skillsFS fs.FS) Option {
+	return func(a *App) { a.skillsFS = skillsFS }
 }
 
 // ServiceRegistry returns the named service instances for HTTP dispatch.
@@ -1164,22 +1175,38 @@ func (a *App) syncSkills() {
 		cwd, err := os.Getwd()
 		if err != nil {
 			a.logger.Error("skills.sync.skip", "reason", "no repo_dir and cannot get cwd")
-			return
+		} else {
+			repoDir = cwd
+			a.logger.Info("skills.sync.fallback_cwd", "dir", cwd)
 		}
-		repoDir = cwd
-		a.logger.Info("skills.sync.fallback_cwd", "dir", cwd)
+	}
+
+	skillsSrc := filepath.Join(repoDir, ".claude", "skills")
+
+	// When the filesystem source doesn't exist (e.g. Docker deployments where
+	// the repo is absent), fall back to the embedded bundle so skills are
+	// always available in ~/.claude/skills/ and ~/.codex/skills/.
+	if _, err := os.Stat(skillsSrc); os.IsNotExist(err) && a.skillsFS != nil {
+		a.logger.Info("skills.sync.embedded_fallback", "dst", a.skillsDir)
+		a.syncFSDir(a.skillsFS, "data", a.skillsDir)
+		if userHome, err2 := os.UserHomeDir(); err2 == nil {
+			a.syncFSDir(a.skillsFS, "data", filepath.Join(userHome, ".claude", "skills"))
+			a.syncFSToCodexDir(a.skillsFS, "data", filepath.Join(userHome, ".codex", "skills"))
+		}
+		// orchestrator CLAUDE.md is not in the embedded bundle; skip it.
+		a.logger.Info("skills.sync.done")
+		return
 	}
 
 	a.logger.Info("skills.sync.start", "src", repoDir, "dst", a.skillsDir)
 
-	skillsSrc := filepath.Join(repoDir, ".claude", "skills")
 	a.syncDir(skillsSrc, a.skillsDir)
 
-	// Also sync to the system Claude Code skills dir so headless agents
-	// launched via `claude -p` can discover skills with the Skill tool.
+	// Also sync to the system Claude Code and Codex skills dirs so headless
+	// agents launched via `claude -p` or `codex exec` can discover skills.
 	if userHome, err := os.UserHomeDir(); err == nil {
-		claudeSkillsDst := filepath.Join(userHome, ".claude", "skills")
-		a.syncDir(skillsSrc, claudeSkillsDst)
+		a.syncDir(skillsSrc, filepath.Join(userHome, ".claude", "skills"))
+		a.syncToCodexDir(skillsSrc, filepath.Join(userHome, ".codex", "skills"))
 	}
 
 	claudeSrc := filepath.Join(repoDir, "orchestrator", "CLAUDE.md")
@@ -1264,6 +1291,217 @@ func (a *App) syncFile(src, dst string) {
 		return
 	}
 	a.logger.Info("sync.copied", "file", filepath.Base(dst))
+}
+
+// syncFSDir copies .md files from srcDir inside fsys to the dst filesystem path.
+// It mirrors syncDir but reads from an fs.FS instead of the host filesystem.
+func (a *App) syncFSDir(fsys fs.FS, srcDir, dst string) {
+	entries, err := fs.ReadDir(fsys, srcDir)
+	if err != nil {
+		a.logger.Debug("sync.fs.skip", "src", srcDir, "reason", err)
+		return
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		a.logger.Error("sync.mkdir", "dst", dst, "err", err)
+		return
+	}
+	cleanDst := filepath.Clean(dst) + string(filepath.Separator)
+
+	srcNames := make(map[string]struct{}, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".md" {
+			continue
+		}
+		dstPath := filepath.Join(filepath.Clean(dst), e.Name())
+		if !strings.HasPrefix(dstPath+string(filepath.Separator), cleanDst) {
+			a.logger.Warn("sync.skip.traversal", "name", e.Name())
+			continue
+		}
+		data, err := fs.ReadFile(fsys, srcDir+"/"+e.Name())
+		if err != nil {
+			a.logger.Warn("sync.fs.read.fail", "name", e.Name(), "err", err)
+			continue
+		}
+		if err := os.WriteFile(dstPath, data, 0o644); err != nil {
+			a.logger.Error("sync.write", "dst", dstPath, "err", err)
+			continue
+		}
+		a.logger.Info("sync.copied", "file", e.Name())
+		srcNames[e.Name()] = struct{}{}
+	}
+
+	// Remove orphan .md files in dst that are not in the embedded bundle.
+	dstEntries, err := os.ReadDir(dst)
+	if err != nil {
+		return
+	}
+	for _, e := range dstEntries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".md" {
+			continue
+		}
+		if _, ok := srcNames[e.Name()]; ok {
+			continue
+		}
+		dstPath := filepath.Join(filepath.Clean(dst), e.Name())
+		if !strings.HasPrefix(dstPath+string(filepath.Separator), cleanDst) {
+			continue
+		}
+		if err := os.Remove(dstPath); err != nil {
+			a.logger.Warn("sync.orphan.remove.fail", "file", e.Name(), "err", err)
+		} else {
+			a.logger.Info("sync.orphan.removed", "file", e.Name())
+		}
+	}
+}
+
+// syncToCodexDir reads flat .md skill files from src and writes each one as
+// dst/<name>/SKILL.md — the subdirectory layout expected by the Codex CLI.
+// Orphan skill subdirs (present in dst but absent from src) are removed.
+func (a *App) syncToCodexDir(src, dst string) {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		a.logger.Debug("sync.codex.skip", "src", src, "reason", err)
+		return
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		a.logger.Error("sync.codex.mkdir", "dst", dst, "err", err)
+		return
+	}
+	cleanSrc := filepath.Clean(src) + string(filepath.Separator)
+	cleanDst := filepath.Clean(dst) + string(filepath.Separator)
+
+	srcNames := make(map[string]struct{}, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".md" {
+			continue
+		}
+		if e.Type()&fs.ModeSymlink != 0 {
+			continue
+		}
+		srcPath := filepath.Join(filepath.Clean(src), e.Name())
+		if !strings.HasPrefix(srcPath+string(filepath.Separator), cleanSrc) {
+			a.logger.Warn("sync.codex.skip.traversal", "name", e.Name())
+			continue
+		}
+		name := strings.TrimSuffix(e.Name(), ".md")
+		skillDir := filepath.Join(filepath.Clean(dst), name)
+		if !strings.HasPrefix(skillDir+string(filepath.Separator), cleanDst) {
+			a.logger.Warn("sync.codex.skip.traversal", "name", e.Name())
+			continue
+		}
+		dstPath := filepath.Join(skillDir, "SKILL.md")
+		data, err := os.ReadFile(srcPath)
+		if err != nil {
+			a.logger.Warn("sync.codex.read.fail", "name", e.Name(), "err", err)
+			continue
+		}
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			a.logger.Error("sync.codex.mkdir.skill", "dir", skillDir, "err", err)
+			continue
+		}
+		if err := os.WriteFile(dstPath, data, 0o644); err != nil {
+			a.logger.Error("sync.codex.write", "dst", dstPath, "err", err)
+			continue
+		}
+		a.logger.Info("sync.codex.copied", "skill", name)
+		srcNames[name] = struct{}{}
+	}
+
+	// Remove orphan skill subdirs that no longer exist in src.
+	dstEntries, err := os.ReadDir(dst)
+	if err != nil {
+		return
+	}
+	for _, e := range dstEntries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, ok := srcNames[e.Name()]; ok {
+			continue
+		}
+		// Only remove dirs that contain a SKILL.md we could have written.
+		skillMD := filepath.Join(filepath.Clean(dst), e.Name(), "SKILL.md")
+		if !strings.HasPrefix(skillMD, cleanDst) {
+			continue
+		}
+		if _, statErr := os.Stat(skillMD); statErr != nil {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(filepath.Clean(dst), e.Name())); err != nil {
+			a.logger.Warn("sync.codex.orphan.remove.fail", "skill", e.Name(), "err", err)
+		} else {
+			a.logger.Info("sync.codex.orphan.removed", "skill", e.Name())
+		}
+	}
+}
+
+// syncFSToCodexDir mirrors syncToCodexDir but reads source files from an fs.FS.
+func (a *App) syncFSToCodexDir(fsys fs.FS, srcDir, dst string) {
+	entries, err := fs.ReadDir(fsys, srcDir)
+	if err != nil {
+		a.logger.Debug("sync.codex.fs.skip", "src", srcDir, "reason", err)
+		return
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		a.logger.Error("sync.codex.mkdir", "dst", dst, "err", err)
+		return
+	}
+	cleanDst := filepath.Clean(dst) + string(filepath.Separator)
+
+	srcNames := make(map[string]struct{}, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".md" {
+			continue
+		}
+		name := strings.TrimSuffix(e.Name(), ".md")
+		skillDir := filepath.Join(filepath.Clean(dst), name)
+		if !strings.HasPrefix(skillDir+string(filepath.Separator), cleanDst) {
+			a.logger.Warn("sync.codex.skip.traversal", "name", e.Name())
+			continue
+		}
+		dstPath := filepath.Join(skillDir, "SKILL.md")
+		data, err := fs.ReadFile(fsys, srcDir+"/"+e.Name())
+		if err != nil {
+			a.logger.Warn("sync.codex.fs.read.fail", "name", e.Name(), "err", err)
+			continue
+		}
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			a.logger.Error("sync.codex.mkdir.skill", "dir", skillDir, "err", err)
+			continue
+		}
+		if err := os.WriteFile(dstPath, data, 0o644); err != nil {
+			a.logger.Error("sync.codex.write", "dst", dstPath, "err", err)
+			continue
+		}
+		a.logger.Info("sync.codex.copied", "skill", name)
+		srcNames[name] = struct{}{}
+	}
+
+	// Remove orphan skill subdirs not in the embedded bundle.
+	dstEntries, err := os.ReadDir(dst)
+	if err != nil {
+		return
+	}
+	for _, e := range dstEntries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, ok := srcNames[e.Name()]; ok {
+			continue
+		}
+		skillMD := filepath.Join(filepath.Clean(dst), e.Name(), "SKILL.md")
+		if !strings.HasPrefix(skillMD, cleanDst) {
+			continue
+		}
+		if _, statErr := os.Stat(skillMD); statErr != nil {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(filepath.Clean(dst), e.Name())); err != nil {
+			a.logger.Warn("sync.codex.orphan.remove.fail", "skill", e.Name(), "err", err)
+		} else {
+			a.logger.Info("sync.codex.orphan.removed", "skill", e.Name())
+		}
+	}
 }
 
 // ListBackgroundOps returns active and recently-completed background operations.


### PR DESCRIPTION
## Motivation

Synapse skills (`/synapse-triage`, `/synapse-tasks`, etc.) were not available to agents on the home-nas Docker deployment. `syncSkills()` falls back to `cwd=/home/synapse` when no `repo_dir` is configured, looks for `/home/synapse/.claude/skills/` as source (absent in the mounted volume), and silently skips — leaving `~/.claude/skills/` empty.

Additionally, skills were never synced to `~/.codex/skills/`, so Codex agents couldn't discover them at all.

## Implementation information

**Embedded bundle** (`internal/skills/`): all 8 synapse `.md` skill files are embedded into the binary via `//go:embed data/*.md`. `cmd/synapse-server` passes `skills.FS` through the new `WithSkillsFS` option.

**Fallback in `syncSkills()`**: when the filesystem source (`.claude/skills/`) doesn't exist and `skillsFS` is set, sync runs from the embedded FS instead of the missing directory.

**Codex sync** (`syncToCodexDir` / `syncFSToCodexDir`): flat `.md` skill files are written as `~/.codex/skills/<name>/SKILL.md` — the subdirectory layout the Codex CLI expects. Both the filesystem and embedded-FS paths now sync to both `~/.claude/skills/` and `~/.codex/skills/`. Orphan skill subdirs are cleaned up on each sync.

> Changelog: feat(skills): embed skills and sync to codex