### PR TITLE
feat(agent): parallel agent visualization

### DIFF
--- a/frontend/src/components/AgentCard.svelte
+++ b/frontend/src/components/AgentCard.svelte
@@ -4,6 +4,8 @@
   import { taskStore } from '../stores/tasks.svelte.js'
   import { fade } from 'svelte/transition'
   import { getAgentPhase, PHASE_CONFIG } from '$lib/agent-phases.js'
+  import { clock } from '$lib/clock.svelte.js'
+  import { formatElapsed } from '$lib/elapsed.js'
 
   interface Props {
     agent: agent.Agent
@@ -24,6 +26,10 @@
   )
   const config = $derived(PHASE_CONFIG[phase])
 
+  const isActivePhase = $derived(
+    phase === 'running' || phase === 'blocked' || phase === 'waiting' || phase === 'human-required',
+  )
+
   function timeAgo(date: any): string {
     if (!date) return ''
     const now = Date.now()
@@ -43,7 +49,7 @@
 >
   <div class="mb-2 flex items-start justify-between gap-2">
     <div class="flex flex-col gap-0.5">
-      <h3 class="text-sm font-semibold leading-tight {config.faded ? 'text-surface-400 dark:text-surface-500' : ''}">{a.project || a.id}</h3>
+      <h3 class="text-sm font-semibold leading-tight {config.faded ? 'text-surface-400 dark:text-surface-500' : ''}">{linkedTask?.title ?? (a.project || a.id)}</h3>
       {#if a.name}
         <span class="text-xs text-surface-400">{a.name}</span>
       {/if}
@@ -89,15 +95,18 @@
     {#if a.project}
       <span class="rounded bg-surface-200 px-1.5 py-0.5 dark:bg-surface-700">{a.project}</span>
     {/if}
-    {#if a.taskId}
-      <span class="rounded bg-surface-200 px-1.5 py-0.5 dark:bg-surface-700">{linkedTask?.title ?? a.taskId}</span>
-    {/if}
     {#if linkedTask?.branch}
       <span class="rounded bg-surface-200 px-1.5 py-0.5 font-mono dark:bg-surface-700">{linkedTask.branch.replace(/^sybra\//, '')}</span>
     {/if}
     {#if a.costUsd > 0}
       <span class="rounded bg-surface-200 px-1.5 py-0.5 dark:bg-surface-700">${a.costUsd.toFixed(2)}</span>
     {/if}
-    <span class="ml-auto opacity-60">{timeAgo(a.startedAt)}</span>
+    <span class="ml-auto opacity-60">
+      {#if isActivePhase}
+        {formatElapsed(a.startedAt, clock.now)}
+      {:else}
+        {timeAgo(a.startedAt)}
+      {/if}
+    </span>
   </div>
 </button>

--- a/frontend/src/components/AgentCard.svelte.test.ts
+++ b/frontend/src/components/AgentCard.svelte.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/svelte'
 import AgentCard from './AgentCard.svelte'
 import { agentStore } from '../stores/agents.svelte.js'
+import { taskStore } from '../stores/tasks.svelte.js'
+import type { task } from '../../wailsjs/go/models.js'
+
+// Mutable clock mock — set per test as needed; vi.hoisted ensures it is accessible
+// inside the hoisted vi.mock factory
+const clockMock = vi.hoisted(() => ({ now: Date.now() }))
+vi.mock('$lib/clock.svelte.js', () => ({ clock: clockMock }))
 
 function makeAgent(overrides: Record<string, unknown> = {}) {
   return {
@@ -23,17 +30,48 @@ function makeAgent(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function makeTask(overrides: Partial<task.Task> = {}): task.Task {
+  return {
+    id: 'task-1',
+    title: 'Test task title',
+    status: 'todo',
+    slug: '',
+    taskType: '',
+    agentMode: '',
+    allowedTools: [],
+    tags: [],
+    projectId: '',
+    branch: '',
+    prNumber: 0,
+    issue: '',
+    statusReason: '',
+    reviewed: false,
+    runRole: '',
+    todoistId: '',
+    agentRuns: [],
+    convertValues: () => {},
+    ...overrides,
+  } as task.Task
+}
+
 describe('AgentCard', () => {
   afterEach(() => {
     cleanup()
+    taskStore.tasks = new Map()
   })
 
-  it('renders agent project name in heading', () => {
+  it('renders task title in heading when linked task is present', () => {
+    taskStore.tasks = new Map([['task-1', makeTask({ title: 'Implement auth' })]])
+    render(AgentCard, { props: { agent: makeAgent(), onclick: () => {} } })
+    expect(screen.getByRole('heading', { level: 3 }).textContent).toBe('Implement auth')
+  })
+
+  it('renders agent project name in heading when no linked task', () => {
     render(AgentCard, { props: { agent: makeAgent(), onclick: () => {} } })
     expect(screen.getByRole('heading', { level: 3 }).textContent).toBe('sybra')
   })
 
-  it('renders agent id as fallback when project is empty', () => {
+  it('renders agent id as fallback when project is empty and no linked task', () => {
     render(AgentCard, { props: { agent: makeAgent({ project: '' }), onclick: () => {} } })
     expect(screen.getByRole('heading', { level: 3 }).textContent).toBe('agent-1')
   })
@@ -93,11 +131,6 @@ describe('AgentCard', () => {
     expect(screen.queryByText(/^\$/)).toBeNull()
   })
 
-  it('shows taskId when present', () => {
-    render(AgentCard, { props: { agent: makeAgent({ taskId: 'task-1' }), onclick: () => {} } })
-    expect(screen.getByText('task-1')).toBeDefined()
-  })
-
   it('calls onclick when clicked', async () => {
     const handler = vi.fn()
     render(AgentCard, { props: { agent: makeAgent(), onclick: handler } })
@@ -129,7 +162,20 @@ describe('AgentCard', () => {
     })
   })
 
-  describe('timeAgo', () => {
+  describe('elapsed time for active phases', () => {
+    const START = '2026-04-01T00:00:00Z'
+    const START_MS = new Date(START).getTime()
+
+    it('shows elapsed time for running agent', () => {
+      clockMock.now = START_MS + 90 * 1000
+      render(AgentCard, {
+        props: { agent: makeAgent({ state: 'running', startedAt: START }), onclick: () => {} },
+      })
+      expect(screen.getByText('1m 30s')).toBeDefined()
+    })
+  })
+
+  describe('timeAgo for terminal phases', () => {
     beforeEach(() => {
       vi.useFakeTimers()
       vi.setSystemTime(new Date('2026-04-01T01:00:00Z'))
@@ -139,30 +185,30 @@ describe('AgentCard', () => {
       vi.useRealTimers()
     })
 
-    it('returns "just now" for < 60s ago', () => {
+    it('returns "just now" for stopped agent started < 60s ago', () => {
       render(AgentCard, {
-        props: { agent: makeAgent({ startedAt: '2026-04-01T00:59:30Z' }), onclick: () => {} },
+        props: { agent: makeAgent({ state: 'stopped', startedAt: '2026-04-01T00:59:30Z' }), onclick: () => {} },
       })
       expect(screen.getByText('just now')).toBeDefined()
     })
 
-    it('returns minutes ago', () => {
+    it('returns minutes ago for stopped agent', () => {
       render(AgentCard, {
-        props: { agent: makeAgent({ startedAt: '2026-04-01T00:55:00Z' }), onclick: () => {} },
+        props: { agent: makeAgent({ state: 'stopped', startedAt: '2026-04-01T00:55:00Z' }), onclick: () => {} },
       })
       expect(screen.getByText('5m ago')).toBeDefined()
     })
 
-    it('returns hours ago', () => {
+    it('returns hours ago for stopped agent', () => {
       render(AgentCard, {
-        props: { agent: makeAgent({ startedAt: '2026-04-01T00:00:00Z' }), onclick: () => {} },
+        props: { agent: makeAgent({ state: 'stopped', startedAt: '2026-04-01T00:00:00Z' }), onclick: () => {} },
       })
       expect(screen.getByText('1h ago')).toBeDefined()
     })
 
-    it('returns days ago', () => {
+    it('returns days ago for stopped agent', () => {
       render(AgentCard, {
-        props: { agent: makeAgent({ startedAt: '2026-03-30T00:00:00Z' }), onclick: () => {} },
+        props: { agent: makeAgent({ state: 'stopped', startedAt: '2026-03-30T00:00:00Z' }), onclick: () => {} },
       })
       expect(screen.getByText('2d ago')).toBeDefined()
     })

--- a/frontend/src/components/shell/BottomTabBar.svelte
+++ b/frontend/src/components/shell/BottomTabBar.svelte
@@ -14,6 +14,10 @@
     agentStore.list.filter(a => a.mode === 'interactive' && (a.state === 'running' || a.state === 'paused')).length
   )
 
+  const runningAgentCount = $derived(
+    agentStore.list.filter(a => a.state === 'running').length
+  )
+
   const reviewCount = $derived(
     taskStore.byStatus('plan-review').length + taskStore.byStatus('test-plan-review').length
   )
@@ -66,12 +70,17 @@
     type="button"
     onclick={() => navStore.reset({ kind: 'agents' })}
     data-active={navStore.activeTab === 'agents' || undefined}
-    class="tap flex flex-1 flex-col items-center justify-center gap-0.5 py-2 text-[10px] font-medium text-surface-500 transition-colors active:bg-surface-100 dark:active:bg-surface-800"
+    class="tap relative flex flex-1 flex-col items-center justify-center gap-0.5 py-2 text-[10px] font-medium text-surface-500 transition-colors active:bg-surface-100 dark:active:bg-surface-800"
     class:text-primary-600={navStore.activeTab === 'agents'}
     class:dark:text-primary-400={navStore.activeTab === 'agents'}
     aria-label="Agents"
   >
-    <UserCircle size={24} />
+    <div class="relative">
+      <UserCircle size={24} />
+      {#if runningAgentCount > 0}
+        <span class="absolute -right-1.5 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-success-500 px-1 text-[9px] font-bold text-white">{runningAgentCount}</span>
+      {/if}
+    </div>
     Agents
   </button>
 

--- a/frontend/src/components/shell/SideRail.svelte
+++ b/frontend/src/components/shell/SideRail.svelte
@@ -9,6 +9,10 @@
     agentStore.list.filter(a => a.mode === 'interactive' && (a.state === 'running' || a.state === 'paused')).length
   )
 
+  const runningAgentCount = $derived(
+    agentStore.list.filter(a => a.state === 'running').length
+  )
+
   const reviewCount = $derived(
     taskStore.byStatus('plan-review').length + taskStore.byStatus('test-plan-review').length
   )
@@ -56,7 +60,12 @@
       onclick={() => navStore.reset({ kind: 'agents' })}
       data-active={navStore.page.kind === 'agents' || navStore.page.kind === 'agent-detail' || undefined}
     >
-      <UserCircle size={20} />
+      <div class="relative">
+        <UserCircle size={20} />
+        {#if runningAgentCount > 0}
+          <span class="absolute -right-1 -top-1 flex h-3.5 w-3.5 items-center justify-center rounded-full bg-success-500 text-[9px] font-bold text-white">{runningAgentCount}</span>
+        {/if}
+      </div>
       <Navigation.TriggerText>Agents</Navigation.TriggerText>
     </Navigation.Trigger>
     <Navigation.Trigger

--- a/frontend/src/lib/clock.svelte.ts
+++ b/frontend/src/lib/clock.svelte.ts
@@ -1,0 +1,15 @@
+let nowMs = $state(Date.now())
+
+const timer = setInterval(() => {
+  nowMs = Date.now()
+}, 1000)
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => clearInterval(timer))
+}
+
+export const clock = {
+  get now() {
+    return nowMs
+  },
+}

--- a/frontend/src/lib/elapsed.test.ts
+++ b/frontend/src/lib/elapsed.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { formatElapsed } from './elapsed.js'
+
+const START = '2026-04-01T00:00:00Z'
+const BASE_MS = new Date(START).getTime()
+
+describe('formatElapsed', () => {
+  it.each([
+    [0, '0s'],
+    [1, '1s'],
+    [59, '59s'],
+    [60, '1m 0s'],
+    [90, '1m 30s'],
+    [119, '1m 59s'],
+    [3600, '1h 00m'],
+    [3661, '1h 01m'],
+    [7322, '2h 02m'],
+  ])('formats %ds correctly as %s', (seconds, expected) => {
+    expect(formatElapsed(START, BASE_MS + seconds * 1000)).toBe(expected)
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(formatElapsed('', BASE_MS)).toBe('')
+  })
+
+  it('returns empty string for invalid date', () => {
+    expect(formatElapsed('not-a-date', BASE_MS)).toBe('')
+  })
+
+  it('returns "0s" for negative diff (future start)', () => {
+    expect(formatElapsed(START, BASE_MS - 5000)).toBe('0s')
+  })
+})

--- a/frontend/src/lib/elapsed.ts
+++ b/frontend/src/lib/elapsed.ts
@@ -1,0 +1,21 @@
+/**
+ * Format elapsed time between a start ISO timestamp and a reference epoch ms.
+ *
+ * Returns: "0s", "59s", "1m 30s", "1h 03m"
+ * Returns empty string for invalid/missing start.
+ */
+export function formatElapsed(startIso: string, nowMs: number): string {
+  if (!startIso) return ''
+  const startMs = new Date(startIso).getTime()
+  if (isNaN(startMs)) return ''
+  const diff = Math.max(0, Math.floor((nowMs - startMs) / 1000))
+  if (diff < 60) return `${diff}s`
+  if (diff < 3600) {
+    const m = Math.floor(diff / 60)
+    const s = diff % 60
+    return `${m}m ${s}s`
+  }
+  const h = Math.floor(diff / 3600)
+  const m = Math.floor((diff % 3600) / 60)
+  return `${h}h ${String(m).padStart(2, '0')}m`
+}


### PR DESCRIPTION
## Motivation

Improve situational awareness when multiple agents run concurrently. Previously there was no way to tell at a glance how many agents were active or how long each had been running.

## Implementation information

- `AgentCard` heading now shows task title → project → id as fallback hierarchy
- Live elapsed timer (via new `clock.svelte.ts` reactive store) for active phases
- Static `timeAgo` for terminal phases (done/reviewing) to avoid unnecessary reactivity
- Running agent count badge added to Agents nav item in both `SideRail` and `BottomTabBar`
- Removed redundant task-title chip from metadata row (title now in heading)
- New `lib/elapsed.ts` (formatter) + `lib/clock.svelte.ts` (reactive clock) with tests

Closes https://github.com/Automaat/sybra/issues/451