### PR TITLE
feat(task): branch name copy action

### DIFF
--- a/.sybra.yaml
+++ b/.sybra.yaml
@@ -1,8 +1,8 @@
 checks:
   pre_commit:
     - golangci-lint run ./...
-    - cd frontend && npx oxlint .
+    - (cd frontend && npx oxlint .)
     - wails generate module && git diff --exit-code frontend/wailsjs/
   pre_push:
     - go test ./...
-    - cd frontend && npm run check
+    - (cd frontend && npm run check)

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CheckCircle, XCircle, Clock, GitPullRequest, CircleDot } from '@lucide/svelte'
+  import { CheckCircle, XCircle, Clock, GitPullRequest, CircleDot, Copy } from '@lucide/svelte'
   import type { task } from '../../wailsjs/go/models.js'
   import { agentStore } from '../stores/agents.svelte.js'
   import { reviewStore } from '../stores/reviews.svelte.js'
@@ -21,6 +21,18 @@
   }
 
   let dragging = $state(false)
+  let copiedBranch = $state(false)
+
+  const taskBranchName = $derived(
+    'sybra/' + (t.slug ? t.slug + '-' + t.id : t.id)
+  )
+
+  async function copyBranch(e: MouseEvent) {
+    e.stopPropagation()
+    await navigator.clipboard.writeText(taskBranchName)
+    copiedBranch = true
+    setTimeout(() => { copiedBranch = false }, 1500)
+  }
 
   const triaging = $derived(
     (agentStore.list ?? []).some((a) => a.taskId === t.id && a.name?.startsWith('triage:') && a.state === 'running')
@@ -62,7 +74,7 @@
 
 <div
   data-focused-task={focused ? '' : undefined}
-  class="w-full select-none rounded-lg border bg-surface-50 p-3 text-left transition-all duration-100 active:bg-surface-100 dark:bg-surface-800 dark:active:bg-surface-700 md:hover:bg-surface-100 md:dark:hover:bg-surface-700 {focused ? 'border-primary-400 ring-2 ring-primary-400/50 dark:border-primary-500 dark:ring-primary-500/50' : 'border-surface-300 dark:border-surface-600'} {dragging ? 'opacity-40 shadow-lg' : ''}"
+  class="group w-full select-none rounded-lg border bg-surface-50 p-3 text-left transition-all duration-100 active:bg-surface-100 dark:bg-surface-800 dark:active:bg-surface-700 md:hover:bg-surface-100 md:dark:hover:bg-surface-700 {focused ? 'border-primary-400 ring-2 ring-primary-400/50 dark:border-primary-500 dark:ring-primary-500/50' : 'border-surface-300 dark:border-surface-600'} {dragging ? 'opacity-40 shadow-lg' : ''}"
 >
   <button
     type="button"
@@ -184,6 +196,19 @@
     <span class="ml-auto opacity-60">{timeAgo(t.updatedAt)}</span>
   </div>
   </button>
+  {#if t.projectId}
+    <div class="mt-1.5 flex items-center opacity-0 transition-opacity group-hover:opacity-100">
+      <button
+        type="button"
+        onclick={copyBranch}
+        class="inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-mono text-xs text-surface-400 transition-colors hover:bg-surface-200 hover:text-surface-600 dark:hover:bg-surface-600 dark:hover:text-surface-300"
+        title="Copy branch name"
+      >
+        <Copy size={10} />
+        {copiedBranch ? 'Copied!' : taskBranchName.replace(/^sybra\//, '')}
+      </button>
+    </div>
+  {/if}
   {#if onstatuschange}
     <div class="mt-2 flex justify-end">
       <select

--- a/frontend/src/lib/keyboard.svelte.ts
+++ b/frontend/src/lib/keyboard.svelte.ts
@@ -37,6 +37,8 @@ export const SHORTCUTS: { scope: string; label: string; shortcuts: Shortcut[] }[
       { keys: 'S', description: 'Focus status selector' },
       { keys: 'D', description: 'Delete task' },
       { keys: 'Esc', description: 'Back to board' },
+      { keys: '⌘.', description: 'Copy task ID' },
+      { keys: '⇧⌘.', description: 'Copy branch name' },
     ],
   },
   {

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ChevronLeft, CircleDot, GitPullRequest, ChevronDown } from '@lucide/svelte'
+  import { ChevronLeft, CircleDot, GitPullRequest, ChevronDown, Copy } from '@lucide/svelte'
   import type { agent, task } from '../../wailsjs/go/models.js'
   import { EventsOn, BrowserOpenURL, StartFixReview, StartReview, GetAgentRunLog } from '$lib/api'
   import { agentState } from '../lib/events.js'
@@ -36,6 +36,15 @@
       onback()
       return
     }
+    if ((e.metaKey || e.ctrlKey) && !e.altKey && e.key === '.') {
+      e.preventDefault()
+      if (e.shiftKey) {
+        copyBranch()
+      } else {
+        copyId()
+      }
+      return
+    }
     const target = e.target as HTMLElement
     if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) return
     if (e.metaKey || e.ctrlKey || e.altKey) return
@@ -61,13 +70,7 @@
 
   let deleting = $state(false)
   let copied = $state(false)
-
-  async function copyId() {
-    if (!t) return
-    await navigator.clipboard.writeText(t.id)
-    copied = true
-    setTimeout(() => { copied = false }, 1500)
-  }
+  let copiedBranch = $state(false)
   let editingBody = $state(false)
   let bodyDraft = $state('')
   let editingTitle = $state(false)
@@ -99,6 +102,23 @@
 
   const renderedBody = $derived(renderMarkdown(t?.body))
   const renderedPlan = $derived(renderMarkdown(t?.plan))
+  const taskBranchName = $derived(
+    t ? 'sybra/' + (t.slug ? t.slug + '-' + t.id : t.id) : ''
+  )
+
+  async function copyId() {
+    if (!t) return
+    await navigator.clipboard.writeText(t.id)
+    copied = true
+    setTimeout(() => { copied = false }, 1500)
+  }
+
+  async function copyBranch() {
+    if (!t || !t.projectId) return
+    await navigator.clipboard.writeText(taskBranchName)
+    copiedBranch = true
+    setTimeout(() => { copiedBranch = false }, 1500)
+  }
 
   $effect(() => {
     loadTask()
@@ -627,9 +647,21 @@
             type="button"
             class="rounded bg-surface-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-surface-600"
             onclick={copyId}
+            title="Copy task ID (⌘.)"
           >
             {copied ? 'Copied!' : 'Copy ID'}
           </button>
+          {#if t.projectId}
+            <button
+              type="button"
+              class="inline-flex items-center gap-1 rounded bg-surface-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-surface-600"
+              onclick={copyBranch}
+              title="Copy branch name (⇧⌘.)"
+            >
+              <Copy size={12} />
+              {copiedBranch ? 'Copied!' : 'Copy branch'}
+            </button>
+          {/if}
           <button
             type="button"
             class="rounded bg-error-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-error-600 disabled:opacity-50"
@@ -700,10 +732,18 @@
           </div>
         {/if}
 
-        {#if t.branch}
+        {#if t.projectId}
           <div class="flex flex-col gap-1">
             <span class="font-medium text-surface-500">Branch</span>
-            <span class="rounded bg-surface-200 px-2 py-0.5 font-mono dark:bg-surface-700">{t.branch}</span>
+            <button
+              type="button"
+              class="inline-flex items-center gap-1.5 rounded bg-surface-200 px-2 py-0.5 font-mono text-left transition-colors hover:bg-surface-300 dark:bg-surface-700 dark:hover:bg-surface-600"
+              onclick={copyBranch}
+              title="Copy branch name (⇧⌘.)"
+            >
+              {taskBranchName}
+              <Copy size={12} class="shrink-0 text-surface-400" />
+            </button>
           </div>
         {/if}
 

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -57,7 +57,7 @@ func InstallHooks(worktreePath string, checks *ChecksConfig) error {
 			return nil
 		}
 		var sb strings.Builder
-		sb.WriteString("#!/bin/sh\nset -e\n")
+		sb.WriteString("#!/bin/sh\nset -e\nunset GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE GIT_OBJECT_DIRECTORY\n")
 		for _, c := range commands {
 			sb.WriteString(c)
 			sb.WriteByte('\n')


### PR DESCRIPTION
## Motivation

Closes https://github.com/Automaat/sybra/issues/454

When working on a task that is linked to a project, developers need to quickly copy the branch name to check it out locally or reference it in other tools. Previously there was no way to get the branch name from the task UI without first starting an agent run (which creates the worktree).

## Implementation information

- `TaskCard`: adds a copy-branch icon button that appears on hover for project-linked tasks
- `TaskDetail`: adds a "Copy branch" button and makes the branch name display clickable; branch name is derived from task slug+id and shown even before a worktree is created
- `keyboard.svelte.ts`: `Cmd+.` copies task ID, `Shift+Cmd+.` copies branch name
- Keyboard help dialog updated with the new shortcuts

Also fixes two pre-existing hook infrastructure issues found while pushing:
- `InstallHooks` now prepends `unset GIT_DIR GIT_WORK_TREE ...` to generated hook scripts, preventing inherited git env vars from causing test `git init` calls to lock the bare-clone config during pre-push execution
- `.sybra.yaml` wraps `cd`-containing hook commands in subshells so directory changes don't persist to subsequent hook commands