### PR TITLE
docs(e2e): screenshot spec + website sync workflow

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,106 @@
+name: Screenshots
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  screenshots:
+    name: Generate & Sync Screenshots
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      SYBRA_HOME: /tmp/sybra-screenshots
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+      - name: Install frontend deps
+        run: cd frontend && npm ci
+
+      - name: Install Playwright browsers
+        run: cd frontend && npx playwright install chromium
+
+      - name: Seed fixtures
+        run: |
+          mkdir -p "$SYBRA_HOME/tasks" "$SYBRA_HOME/workflows"
+          cp frontend/e2e/fixtures/*.md "$SYBRA_HOME/tasks/"
+          cp frontend/e2e/fixtures/wf-editor-e2e.yaml "$SYBRA_HOME/workflows/"
+
+      - name: Build web frontend
+        run: cd frontend && npm run build:web
+
+      - name: Build sybra-server
+        run: go build -o bin/sybra-server ./cmd/sybra-server
+
+      - name: Start sybra-server
+        run: |
+          SYBRA_STATIC_DIR=frontend/dist-web ./bin/sybra-server > /tmp/sybra-server.log 2>&1 &
+          echo "Waiting for sybra-server..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/health > /dev/null 2>&1; then
+              echo "Ready after ${i}s"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "::error::sybra-server timed out"
+              cat /tmp/sybra-server.log
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Generate screenshots
+        run: cd frontend && npx playwright test e2e/screenshots.spec.ts --reporter=github
+
+      - name: Dump server log
+        if: failure()
+        run: cat /tmp/sybra-server.log || true
+
+      - name: Upload screenshots on failure
+        if: failure()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: screenshots
+          path: docs/screenshots/
+          retention-days: 3
+
+      - name: Checkout sybra-website
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: Automaat/sybra-website
+          path: sybra-website
+          token: ${{ secrets.WEBSITE_DEPLOY_PAT }}
+
+      - name: Copy screenshots to website
+        run: |
+          mkdir -p sybra-website/public/screenshots
+          cp -r docs/screenshots/. sybra-website/public/screenshots/
+
+      - name: Open PR if changed
+        env:
+          GH_TOKEN: ${{ secrets.WEBSITE_DEPLOY_PAT }}
+        run: |
+          cd sybra-website
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add public/screenshots/
+          if git diff --cached --quiet; then
+            echo "No screenshot changes — skipping PR"
+            exit 0
+          fi
+          SYBRA_SHA=$(git -C .. rev-parse --short HEAD)
+          BRANCH="screenshots/sync-${SYBRA_SHA}"
+          git checkout -b "$BRANCH"
+          git commit -m "chore(screenshots): sync from sybra@${SYBRA_SHA}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --repo Automaat/sybra-website \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(screenshots): sync from sybra@${SYBRA_SHA}" \
+            --body "Automated screenshot sync from automaat/sybra@${SYBRA_SHA}."

--- a/frontend/e2e/lib/github-mocks.ts
+++ b/frontend/e2e/lib/github-mocks.ts
@@ -1,0 +1,351 @@
+import type { Page } from '@playwright/test'
+
+// ─── Fixture data ─────────────────────────────────────────────────────────────
+
+const MY_PRS = [
+  {
+    number: 512,
+    title: 'feat(agent): streaming output improvements',
+    url: 'https://github.com/automaat/sybra/pull/512',
+    repository: 'automaat/sybra',
+    repoName: 'sybra',
+    author: 'mskalski',
+    isDraft: false,
+    labels: ['enhancement'],
+    headRefName: 'feat/streaming-output',
+    ciStatus: 'SUCCESS',
+    hasPendingChecks: false,
+    reviewDecision: 'APPROVED',
+    mergeable: 'MERGEABLE',
+    unresolvedCount: 0,
+    viewerHasApproved: true,
+    createdAt: '2026-04-10T09:00:00Z',
+    updatedAt: '2026-04-16T14:30:00Z',
+  },
+  {
+    number: 508,
+    title: 'fix(tasks): kanban drag-and-drop on mobile',
+    url: 'https://github.com/automaat/sybra/pull/508',
+    repository: 'automaat/sybra',
+    repoName: 'sybra',
+    author: 'mskalski',
+    isDraft: false,
+    labels: ['bug', 'mobile'],
+    headRefName: 'fix/kanban-mobile',
+    ciStatus: 'PENDING',
+    hasPendingChecks: true,
+    reviewDecision: 'REVIEW_REQUIRED',
+    mergeable: 'MERGEABLE',
+    unresolvedCount: 1,
+    viewerHasApproved: false,
+    createdAt: '2026-04-14T11:00:00Z',
+    updatedAt: '2026-04-16T13:00:00Z',
+  },
+  {
+    number: 503,
+    title: 'refactor(github): extract PR card into component',
+    url: 'https://github.com/automaat/sybra/pull/503',
+    repository: 'automaat/sybra',
+    repoName: 'sybra',
+    author: 'mskalski',
+    isDraft: true,
+    labels: ['refactor'],
+    headRefName: 'refactor/pr-card',
+    ciStatus: 'FAILURE',
+    hasPendingChecks: false,
+    reviewDecision: '',
+    mergeable: 'CONFLICTING',
+    unresolvedCount: 0,
+    viewerHasApproved: false,
+    createdAt: '2026-04-12T16:00:00Z',
+    updatedAt: '2026-04-15T10:00:00Z',
+  },
+  {
+    number: 497,
+    title: 'docs(readme): update installation guide',
+    url: 'https://github.com/automaat/sybra/pull/497',
+    repository: 'automaat/synapse-infra',
+    repoName: 'synapse-infra',
+    author: 'mskalski',
+    isDraft: false,
+    labels: ['documentation'],
+    headRefName: 'docs/install-guide',
+    ciStatus: 'SUCCESS',
+    hasPendingChecks: false,
+    reviewDecision: 'APPROVED',
+    mergeable: 'MERGEABLE',
+    unresolvedCount: 0,
+    viewerHasApproved: true,
+    createdAt: '2026-04-08T08:30:00Z',
+    updatedAt: '2026-04-13T17:00:00Z',
+  },
+]
+
+const REVIEW_REQUESTED = [
+  {
+    number: 215,
+    title: 'feat(orchestrator): multi-agent task routing',
+    url: 'https://github.com/automaat/sybra/pull/215',
+    repository: 'automaat/sybra',
+    repoName: 'sybra',
+    author: 'jdoe',
+    isDraft: false,
+    labels: ['enhancement', 'architecture'],
+    headRefName: 'feat/multi-agent-routing',
+    ciStatus: 'SUCCESS',
+    hasPendingChecks: false,
+    reviewDecision: 'REVIEW_REQUIRED',
+    mergeable: 'MERGEABLE',
+    unresolvedCount: 3,
+    viewerHasApproved: false,
+    createdAt: '2026-04-09T14:00:00Z',
+    updatedAt: '2026-04-16T09:00:00Z',
+  },
+  {
+    number: 209,
+    title: 'fix(auth): token refresh race condition',
+    url: 'https://github.com/automaat/synapse-infra/pull/209',
+    repository: 'automaat/synapse-infra',
+    repoName: 'synapse-infra',
+    author: 'asmith',
+    isDraft: false,
+    labels: ['bug', 'security'],
+    headRefName: 'fix/token-refresh',
+    ciStatus: 'SUCCESS',
+    hasPendingChecks: false,
+    reviewDecision: 'REVIEW_REQUIRED',
+    mergeable: 'MERGEABLE',
+    unresolvedCount: 0,
+    viewerHasApproved: false,
+    createdAt: '2026-04-15T10:00:00Z',
+    updatedAt: '2026-04-16T11:30:00Z',
+  },
+]
+
+const RENOVATE_PRS = [
+  // ── automaat/sybra ───────────────────────────────────────────────────────────
+
+  // State: ready to merge — green dot, Approved badge, Merge button
+  {
+    number: 514,
+    title: 'chore(deps): update dependency vite to v8.2.1',
+    url: 'https://github.com/automaat/sybra/pull/514',
+    repository: 'automaat/sybra',
+    repoName: 'sybra',
+    author: 'renovate[bot]',
+    isDraft: false,
+    labels: ['dependencies'],
+    headRefName: 'renovate/vite-8.x',
+    ciStatus: 'SUCCESS',
+    hasPendingChecks: false,
+    reviewDecision: 'APPROVED',
+    mergeable: 'MERGEABLE',
+    unresolvedCount: 0,
+    viewerHasApproved: true,
+    createdAt: '2026-04-16T08:00:00Z',
+    updatedAt: '2026-04-16T10:00:00Z',
+    checkRuns: [
+      { name: 'lint-go', status: 'COMPLETED', conclusion: 'SUCCESS' },
+      { name: 'lint-frontend', status: 'COMPLETED', conclusion: 'SUCCESS' },
+      { name: 'build', status: 'COMPLETED', conclusion: 'SUCCESS' },
+    ],
+  },
+
+  // State: needs approval, CI passing — green dot, Approve + Merge buttons
+  {
+    number: 511,
+    title: 'chore(deps): update dependency @skeletonlabs/skeleton-svelte to v4.1.0',
+    url: 'https://github.com/automaat/sybra/pull/511',
+    repository: 'automaat/sybra',
+    repoName: 'sybra',
+    author: 'renovate[bot]',
+    isDraft: false,
+    labels: ['dependencies'],
+    headRefName: 'renovate/skeleton-svelte-4.x',
+    ciStatus: 'SUCCESS',
+    hasPendingChecks: false,
+    reviewDecision: '',
+    mergeable: 'MERGEABLE',
+    unresolvedCount: 0,
+    viewerHasApproved: false,
+    createdAt: '2026-04-16T06:00:00Z',
+    updatedAt: '2026-04-16T07:30:00Z',
+    checkRuns: [
+      { name: 'lint-go', status: 'COMPLETED', conclusion: 'SUCCESS' },
+      { name: 'lint-frontend', status: 'COMPLETED', conclusion: 'SUCCESS' },
+      { name: 'build', status: 'COMPLETED', conclusion: 'SUCCESS' },
+    ],
+  },
+
+  // State: CI failing — red dot, Approve + Rerun + Fix buttons
+  {
+    number: 509,
+    title: 'chore(deps): update golang.org/x/net to v0.37.0',
+    url: 'https://github.com/automaat/sybra/pull/509',
+    repository: 'automaat/sybra',
+    repoName: 'sybra',
+    author: 'renovate[bot]',
+    isDraft: false,
+    labels: ['dependencies'],
+    headRefName: 'renovate/golang-net',
+    ciStatus: 'FAILURE',
+    hasPendingChecks: false,
+    reviewDecision: '',
+    mergeable: 'MERGEABLE',
+    unresolvedCount: 0,
+    viewerHasApproved: false,
+    createdAt: '2026-04-15T06:00:00Z',
+    updatedAt: '2026-04-15T08:00:00Z',
+    checkRuns: [
+      { name: 'lint-go', status: 'COMPLETED', conclusion: 'SUCCESS' },
+      { name: 'lint-frontend', status: 'COMPLETED', conclusion: 'SUCCESS' },
+      { name: 'build', status: 'COMPLETED', conclusion: 'FAILURE' },
+    ],
+  },
+
+  // State: CI pending — yellow dot, Approve button, no Merge
+  {
+    number: 507,
+    title: 'chore(deps): update dependency typescript to v6.1.0',
+    url: 'https://github.com/automaat/sybra/pull/507',
+    repository: 'automaat/sybra',
+    repoName: 'sybra',
+    author: 'renovate[bot]',
+    isDraft: false,
+    labels: ['dependencies'],
+    headRefName: 'renovate/typescript-6.x',
+    ciStatus: 'PENDING',
+    hasPendingChecks: true,
+    reviewDecision: '',
+    mergeable: 'MERGEABLE',
+    unresolvedCount: 0,
+    viewerHasApproved: false,
+    createdAt: '2026-04-16T09:00:00Z',
+    updatedAt: '2026-04-16T09:10:00Z',
+    checkRuns: [
+      { name: 'lint-go', status: 'COMPLETED', conclusion: 'SUCCESS' },
+      { name: 'lint-frontend', status: 'IN_PROGRESS', conclusion: '' },
+      { name: 'build', status: 'QUEUED', conclusion: '' },
+    ],
+  },
+
+  // ── automaat/synapse-infra ───────────────────────────────────────────────────
+
+  // State: approved, CI pending — yellow dot, Approved badge, no Merge yet
+  {
+    number: 88,
+    title: 'chore(deps): update dependency ansible to v11.4.0',
+    url: 'https://github.com/automaat/synapse-infra/pull/88',
+    repository: 'automaat/synapse-infra',
+    repoName: 'synapse-infra',
+    author: 'renovate[bot]',
+    isDraft: false,
+    labels: ['dependencies'],
+    headRefName: 'renovate/ansible-11.x',
+    ciStatus: 'PENDING',
+    hasPendingChecks: true,
+    reviewDecision: 'APPROVED',
+    mergeable: 'MERGEABLE',
+    unresolvedCount: 0,
+    viewerHasApproved: true,
+    createdAt: '2026-04-15T12:00:00Z',
+    updatedAt: '2026-04-16T08:30:00Z',
+    checkRuns: [
+      { name: 'ansible-lint', status: 'IN_PROGRESS', conclusion: '' },
+    ],
+  },
+
+  // State: merge conflict — Conflicts badge, Approve button, no Merge
+  {
+    number: 85,
+    title: 'chore(deps): update node.js to v24.1.0',
+    url: 'https://github.com/automaat/synapse-infra/pull/85',
+    repository: 'automaat/synapse-infra',
+    repoName: 'synapse-infra',
+    author: 'renovate[bot]',
+    isDraft: false,
+    labels: ['dependencies'],
+    headRefName: 'renovate/node-24.x',
+    ciStatus: 'SUCCESS',
+    hasPendingChecks: false,
+    reviewDecision: '',
+    mergeable: 'CONFLICTING',
+    unresolvedCount: 0,
+    viewerHasApproved: false,
+    createdAt: '2026-04-14T06:00:00Z',
+    updatedAt: '2026-04-14T09:00:00Z',
+    checkRuns: [
+      { name: 'lint', status: 'COMPLETED', conclusion: 'SUCCESS' },
+      { name: 'test', status: 'COMPLETED', conclusion: 'SUCCESS' },
+    ],
+  },
+]
+
+const ISSUES = [
+  {
+    number: 487,
+    title: 'Agent output panel should auto-scroll when new lines arrive',
+    body: 'Currently the output panel does not scroll to the bottom when new stream events come in. The user has to manually scroll.',
+    url: 'https://github.com/automaat/sybra/issues/487',
+    repository: 'automaat/sybra',
+    repoName: 'sybra',
+    labels: ['bug', 'ux'],
+    author: 'user42',
+    createdAt: '2026-04-11T10:00:00Z',
+    updatedAt: '2026-04-16T08:00:00Z',
+  },
+  {
+    number: 473,
+    title: 'Add keyboard shortcut to approve plan from task detail',
+    body: 'Power-users want a keyboard shortcut (e.g. `a`) to approve a plan without reaching for the mouse.',
+    url: 'https://github.com/automaat/sybra/issues/473',
+    repository: 'automaat/sybra',
+    repoName: 'sybra',
+    labels: ['enhancement'],
+    author: 'poweruser99',
+    createdAt: '2026-04-07T15:00:00Z',
+    updatedAt: '2026-04-14T12:00:00Z',
+  },
+  {
+    number: 461,
+    title: 'Workflow editor loses unsaved changes on navigation',
+    body: 'If you click away from the workflow editor without saving, changes are silently discarded with no confirmation dialog.',
+    url: 'https://github.com/automaat/sybra/issues/461',
+    repository: 'automaat/sybra',
+    repoName: 'sybra',
+    labels: ['bug', 'workflow'],
+    author: 'contributor7',
+    createdAt: '2026-04-03T09:00:00Z',
+    updatedAt: '2026-04-13T16:00:00Z',
+  },
+]
+
+// ─── Route interceptor ────────────────────────────────────────────────────────
+
+/**
+ * Call before navigating to the GitHub page.
+ * Intercepts all three GitHub-data endpoints and returns realistic mock data
+ * so screenshots show a populated UI instead of empty/error states.
+ */
+export async function mockGitHub(page: Page) {
+  await page.route('**/api/ReviewService/FetchReviews', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ createdByMe: MY_PRS, reviewRequested: REVIEW_REQUESTED }),
+    }),
+  )
+
+  await page.route('**/api/IntegrationService/FetchRenovatePRs', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify(RENOVATE_PRS),
+    }),
+  )
+
+  await page.route('**/api/IntegrationService/FetchAssignedIssues', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify(ISSUES),
+    }),
+  )
+}

--- a/frontend/e2e/lib/project-mocks.ts
+++ b/frontend/e2e/lib/project-mocks.ts
@@ -1,0 +1,68 @@
+import type { Page } from '@playwright/test'
+
+const PROJECT_ID = 'automaat/sybra'
+
+const PROJECT = {
+  id: PROJECT_ID,
+  name: 'sybra',
+  owner: 'automaat',
+  repo: 'sybra',
+  url: 'https://github.com/automaat/sybra',
+  clonePath: '/data/synapse/clones/automaat-sybra',
+  type: 'pet',
+  status: 'cloned',
+  setupCommands: ['mise install', 'cd frontend && npm install'],
+  sandbox: {
+    image: 'ubuntu:24.04',
+    build: 'docker build -t sybra-dev .',
+    with: ['docker', 'mise'],
+    port: 8080,
+    env: { NODE_ENV: 'development', GO_ENV: 'development' },
+  },
+  checks: {
+    preCommit: ['golangci-lint run ./...', 'cd frontend && npx oxlint .'],
+    prePush: ['go test ./...'],
+  },
+  createdAt: '2026-01-15T10:00:00Z',
+  updatedAt: '2026-04-16T12:00:00Z',
+}
+
+const WORKTREES = [
+  {
+    path: '/data/synapse/worktrees/automaat-sybra-feat-streaming',
+    branch: 'feat/streaming-output',
+    taskId: 'a1b2c3d4',
+    head: 'f3a8c21',
+  },
+  {
+    path: '/data/synapse/worktrees/automaat-sybra-fix-kanban',
+    branch: 'fix/kanban-mobile',
+    taskId: 'e5f6a7b8',
+    head: 'b9d4e12',
+  },
+]
+
+export async function mockProjects(page: Page) {
+  await page.route('**/api/ProjectService/ListProjects', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify([PROJECT]),
+    }),
+  )
+
+  await page.route('**/api/ProjectService/GetProject', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify(PROJECT),
+    }),
+  )
+
+  await page.route('**/api/ProjectService/ListWorktrees', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify(WORKTREES),
+    }),
+  )
+}
+
+export { PROJECT_ID }

--- a/frontend/e2e/screenshots.spec.ts
+++ b/frontend/e2e/screenshots.spec.ts
@@ -1,0 +1,391 @@
+/**
+ * Screenshot generation for documentation.
+ *
+ * Run:  npx playwright test e2e/screenshots.spec.ts
+ * Output: docs/screenshots/light/*.png  docs/screenshots/dark/*.png
+ *
+ * Not part of CI — run manually when UI changes warrant updated docs images.
+ */
+import { test, type Page, type BrowserContext } from '@playwright/test'
+import { mockGitHub } from './lib/github-mocks.js'
+import { mockProjects } from './lib/project-mocks.js'
+import { copyFile, mkdir } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+
+const SYBRA_HOME = process.env.SYBRA_HOME ?? join(homedir(), '.sybra')
+const TASKS_DIR = join(SYBRA_HOME, 'tasks')
+const WORKFLOWS_DIR = join(SYBRA_HOME, 'workflows')
+
+const OUT_DIR = join(import.meta.dirname, '..', '..', 'docs', 'screenshots')
+
+async function shot(page: Page, theme: 'light' | 'dark', name: string) {
+  await page.screenshot({
+    path: join(OUT_DIR, theme, `${name}.png`),
+    fullPage: false,
+  })
+}
+
+/** Apply color scheme via localStorage (matches the Settings page persistence). */
+async function applyTheme(context: BrowserContext, theme: 'light' | 'dark') {
+  await context.addInitScript((t) => {
+    localStorage.setItem('color-scheme', t)
+  }, theme)
+}
+
+async function goToTaskList(page: Page) {
+  await page.goto('/')
+  await page.locator('[data-part="trigger"]', { hasText: /Board/ }).click()
+  await page.waitForSelector('button:has(h3), :text("No tasks")', { timeout: 10_000 })
+}
+
+test.beforeAll(async () => {
+  await mkdir(join(OUT_DIR, 'light'), { recursive: true })
+  await mkdir(join(OUT_DIR, 'dark'), { recursive: true })
+
+  // Ensure task fixtures are present
+  for (const f of ['auth0001.md', 'test0001.md', 'db0001.md', 'plan0001.md']) {
+    const src = join(import.meta.dirname, 'fixtures', f)
+    const dst = join(TASKS_DIR, f)
+    await copyFile(src, dst)
+  }
+
+  // Ensure workflow fixture is present
+  if (!existsSync(WORKFLOWS_DIR)) {
+    await mkdir(WORKFLOWS_DIR, { recursive: true })
+  }
+  await copyFile(
+    join(import.meta.dirname, 'fixtures', 'wf-editor-e2e.yaml'),
+    join(WORKFLOWS_DIR, 'wf-editor-e2e.yaml'),
+  )
+})
+
+// Run every screenshot block in both themes
+for (const theme of ['light', 'dark'] as const) {
+  test.describe(theme, () => {
+    test.use({ colorScheme: theme, viewport: { width: 1920, height: 1080 } })
+
+    test.beforeEach(async ({ context }) => {
+      await applyTheme(context, theme)
+    })
+
+    // ─── Dashboard ───────────────────────────────────────────────────────────
+
+    test('dashboard', async ({ page }) => {
+      await page.goto('/')
+      await page.locator('[data-part="trigger"]', { hasText: /Dashboard/ }).click()
+      await page.locator('h1', { hasText: 'Dashboard' }).waitFor()
+      await shot(page, theme, 'dashboard')
+    })
+
+    // ─── Task Board ───────────────────────────────────────────────────────────
+
+    test('task-board', async ({ page }) => {
+      await goToTaskList(page)
+      await shot(page, theme, 'task-board')
+    })
+
+    test('task-board-new-task-dialog', async ({ page }) => {
+      await goToTaskList(page)
+      await page.getByText('+ New Task').click()
+      await page.getByRole('dialog').waitFor()
+      await shot(page, theme, 'task-board-new-task-dialog')
+    })
+
+    test('task-board-filtered', async ({ page }) => {
+      await goToTaskList(page)
+      // Mobile input is hidden at 1920px; .nth(1) targets the visible desktop input
+      await page.locator('input[placeholder="Search tasks..."]').nth(1).fill('auth')
+      await page.waitForTimeout(300)
+      await shot(page, theme, 'task-board-filtered')
+    })
+
+    test('quick-add-task', async ({ page }) => {
+      await page.goto('/')
+      await page.keyboard.press('Meta+n')
+      await page.getByPlaceholder('Task title, link, or note...').waitFor()
+      await shot(page, theme, 'quick-add-task')
+    })
+
+    test('command-palette', async ({ page }) => {
+      await page.goto('/')
+      await page.keyboard.press('Meta+k')
+      // Wait for palette input — CommandPalette opens with a search input
+      await page.getByRole('dialog').waitFor({ timeout: 5_000 })
+      await shot(page, theme, 'command-palette')
+    })
+
+    // ─── Task Detail ──────────────────────────────────────────────────────────
+
+    test('task-detail', async ({ page }) => {
+      await goToTaskList(page)
+      await page.getByRole('button', { name: 'Implement auth middleware' }).click()
+      await page.locator('h1', { hasText: 'Implement auth middleware' }).waitFor()
+      await shot(page, theme, 'task-detail')
+    })
+
+    test('task-detail-plan-review', async ({ page }) => {
+      await goToTaskList(page)
+      await page.getByRole('button', { name: 'Refactor logging system' }).click()
+      await page.locator('h1', { hasText: 'Refactor logging system' }).waitFor()
+      await page.getByRole('button', { name: 'Approve Plan' }).waitFor()
+      await shot(page, theme, 'task-detail-plan-review')
+    })
+
+    // ─── Reviews ──────────────────────────────────────────────────────────────
+
+    async function goToReviews(page: Page) {
+      await page.goto('/')
+      await page
+        .locator('[data-part="trigger"]', { hasText: /Reviews/ })
+        .filter({ hasNotText: 'Test' })
+        .click()
+      await page.waitForSelector('button, :text("No plans")', { timeout: 10_000 })
+    }
+
+    test('reviews', async ({ page }) => {
+      await goToReviews(page)
+      await shot(page, theme, 'reviews')
+    })
+
+    test('reviews-plan-selected', async ({ page }) => {
+      await goToReviews(page)
+      // Select the plan-review fixture task to show the split panel
+      await page.getByText('Refactor logging system').click()
+      // Wait for the plan content and action bar to render
+      await page.getByRole('button', { name: 'Approve' }).waitFor({ timeout: 5_000 })
+      await shot(page, theme, 'reviews-plan-selected')
+    })
+
+    // ─── Chats ────────────────────────────────────────────────────────────────
+
+    test('chats', async ({ page }) => {
+      await page.goto('/')
+      await page.locator('[data-part="trigger"]', { hasText: /Chats/ }).click()
+      await page.getByRole('main').getByRole('heading', { name: 'Chats' }).waitFor()
+      await shot(page, theme, 'chats')
+    })
+
+    test('chats-new-chat-dialog', async ({ page }) => {
+      await page.goto('/')
+      await page.locator('[data-part="trigger"]', { hasText: /Chats/ }).click()
+      await page.getByRole('main').getByRole('heading', { name: 'Chats' }).waitFor()
+      await page.getByRole('main').getByRole('button', { name: /New Chat/ }).first().click()
+      await page.getByRole('dialog').waitFor()
+      await shot(page, theme, 'chats-new-chat-dialog')
+    })
+
+    test('chat-detail', async ({ page }) => {
+      await page.goto('/')
+      await page.locator('[data-part="trigger"]', { hasText: /Chats/ }).click()
+      await page.getByRole('main').getByRole('heading', { name: 'Chats' }).waitFor()
+      // Open the first existing chat session if present
+      const firstChat = page.getByRole('main').getByRole('listitem').first()
+      if (await firstChat.count() > 0 && await firstChat.isVisible()) {
+        await firstChat.click()
+        await page.waitForTimeout(800)
+      }
+      await shot(page, theme, 'chat-detail')
+    })
+
+    // ─── Agents ───────────────────────────────────────────────────────────────
+
+    test('agents', async ({ page }) => {
+      await page.goto('/')
+      await page.locator('[data-part="trigger"]', { hasText: /Agents/ }).click()
+      await page.getByRole('tab', { name: 'Orchestrator' }).waitFor()
+      await shot(page, theme, 'agents')
+    })
+
+    test('agents-orchestrator', async ({ page }) => {
+      await page.goto('/')
+      await page.locator('[data-part="trigger"]', { hasText: /Agents/ }).click()
+      await page.getByRole('tab', { name: 'Orchestrator' }).waitFor()
+      await page.getByRole('tab', { name: 'Orchestrator' }).click()
+      // Wait for orchestrator content to settle
+      await page.waitForTimeout(500)
+      await shot(page, theme, 'agents-orchestrator')
+    })
+
+    test('agents-loops', async ({ page }) => {
+      await page.goto('/')
+      await page.locator('[data-part="trigger"]', { hasText: /Agents/ }).click()
+      await page.getByRole('tab', { name: 'Loops' }).waitFor()
+      await page.getByRole('tab', { name: 'Loops' }).click()
+      await page.waitForTimeout(500)
+      await shot(page, theme, 'agents-loops')
+    })
+
+    test('agents-loops-new-dialog', async ({ page }) => {
+      await page.goto('/')
+      await page.locator('[data-part="trigger"]', { hasText: /Agents/ }).click()
+      await page.getByRole('tab', { name: 'Loops' }).waitFor()
+      await page.getByRole('tab', { name: 'Loops' }).click()
+      await page.getByRole('button', { name: '+ New Loop' }).waitFor()
+      await page.getByRole('button', { name: '+ New Loop' }).click()
+      await page.getByText('New Loop Agent').waitFor()
+      await shot(page, theme, 'agents-loops-new-dialog')
+    })
+
+    test('agent-detail', async ({ page }) => {
+      await page.goto('/')
+      await page.locator('[data-part="trigger"]', { hasText: /Agents/ }).click()
+      await page.getByRole('tab', { name: 'Orchestrator' }).waitFor()
+      // Click the first agent card if any exist — best-effort, skip if none
+      const firstCard = page.locator('[data-testid="agent-card"]').first()
+      const cardCount = await firstCard.count()
+      if (cardCount > 0) {
+        await firstCard.click()
+        await page.waitForTimeout(800)
+        await shot(page, theme, 'agent-detail')
+      } else {
+        // Fallback: click any card-like button in the agent list
+        const anyCard = page.locator('.agent-card, [role="button"]').nth(1)
+        if (await anyCard.count() > 0) {
+          await anyCard.click()
+          await page.waitForTimeout(800)
+        }
+        await shot(page, theme, 'agent-detail')
+      }
+    })
+
+    // ─── Projects ─────────────────────────────────────────────────────────────
+
+    test('projects', async ({ page }) => {
+      await mockProjects(page)
+      await page.goto('/')
+      await page.locator('[data-part="trigger"]', { hasText: /Projects/ }).click()
+      await page.getByText('automaat/sybra').waitFor({ timeout: 5_000 })
+      await shot(page, theme, 'projects')
+    })
+
+    async function goToProjectDetail(page: Page) {
+      await mockProjects(page)
+      await page.goto('/')
+      await page.locator('[data-part="trigger"]', { hasText: /Projects/ }).click()
+      await page.getByText('automaat/sybra').waitFor()
+      await page.getByRole('button', { name: /automaat\/sybra/ }).click()
+      // Wait for project detail header (unique to detail view)
+      await page.getByText('Clone Path').waitFor({ timeout: 5_000 })
+    }
+
+    test('project-detail-tasks', async ({ page }) => {
+      await goToProjectDetail(page)
+      await shot(page, theme, 'project-detail-tasks')
+    })
+
+    test('project-detail-worktrees', async ({ page }) => {
+      await goToProjectDetail(page)
+      await page.getByText('Worktrees').click()
+      await page.waitForTimeout(400)
+      await shot(page, theme, 'project-detail-worktrees')
+    })
+
+    test('project-detail-sandbox', async ({ page }) => {
+      await goToProjectDetail(page)
+      await page.getByText('Sandbox').click()
+      await page.waitForTimeout(400)
+      await shot(page, theme, 'project-detail-sandbox')
+    })
+
+    // ─── GitHub ───────────────────────────────────────────────────────────────
+
+    async function goToGitHub(page: Page) {
+      await mockGitHub(page)
+      await page.goto('/')
+      await page.locator('[data-part="trigger"]', { hasText: /GitHub/ }).click()
+      // Wait for mocked PR data to appear
+      await page.getByText('feat(agent): streaming output improvements').waitFor({ timeout: 10_000 })
+    }
+
+    test('github-my-prs', async ({ page }) => {
+      await goToGitHub(page)
+      await shot(page, theme, 'github-my-prs')
+    })
+
+    test('github-reviews', async ({ page }) => {
+      await goToGitHub(page)
+      await page.getByRole('button', { name: /^Reviews/ }).click()
+      await page.getByText('feat(orchestrator): multi-agent task routing').waitFor()
+      await shot(page, theme, 'github-reviews')
+    })
+
+    test('github-renovate', async ({ page }) => {
+      await goToGitHub(page)
+      await page.getByRole('button', { name: 'Renovate' }).click()
+      await page.getByText('update dependency @skeletonlabs').waitFor()
+      await shot(page, theme, 'github-renovate')
+    })
+
+    test('github-issues', async ({ page }) => {
+      await goToGitHub(page)
+      await page.getByRole('button', { name: 'Issues' }).click()
+      await page.getByText('Agent output panel should auto-scroll').waitFor()
+      await shot(page, theme, 'github-issues')
+    })
+
+    test('github-pr-detail', async ({ page }) => {
+      await goToGitHub(page)
+      // Click the first PR card (feat(agent): streaming output improvements)
+      await page.getByText('feat(agent): streaming output improvements').click()
+      await page.getByRole('button', { name: '← Back' }).waitFor()
+      await shot(page, theme, 'github-pr-detail')
+    })
+
+    // ─── Stats ────────────────────────────────────────────────────────────────
+
+    test('stats', async ({ page }) => {
+      await page.goto('/')
+      await page.locator('[data-part="trigger"]', { hasText: /Stats/ }).click()
+      await page.getByRole('main').waitFor()
+      await shot(page, theme, 'stats')
+    })
+
+    test('stats-this-week', async ({ page }) => {
+      await page.goto('/')
+      await page.locator('[data-part="trigger"]', { hasText: /Stats/ }).click()
+      await page.getByRole('main').waitFor()
+      await page.getByRole('button', { name: 'This Week' }).click()
+      await page.waitForTimeout(300)
+      await shot(page, theme, 'stats-this-week')
+    })
+
+    // ─── Workflows ────────────────────────────────────────────────────────────
+
+    test('workflows', async ({ page }) => {
+      await page.goto('/')
+      await page.locator('[data-part="trigger"]', { hasText: /Workflows/ }).click()
+      await page.getByRole('button', { name: /E2E Editor Fixture/ }).waitFor({ timeout: 10_000 })
+      await shot(page, theme, 'workflows')
+    })
+
+    test('workflow-editor', async ({ page }) => {
+      await page.goto('/')
+      await page.locator('[data-part="trigger"]', { hasText: /Workflows/ }).click()
+      await page.getByRole('button', { name: /E2E Editor Fixture/ }).waitFor({ timeout: 10_000 })
+      await page.getByRole('button', { name: /E2E Editor Fixture/ }).click()
+      await page.locator('h2', { hasText: 'E2E Editor Fixture' }).waitFor()
+      await shot(page, theme, 'workflow-editor')
+    })
+
+    test('workflow-editor-trigger-panel', async ({ page }) => {
+      await page.goto('/')
+      await page.locator('[data-part="trigger"]', { hasText: /Workflows/ }).click()
+      await page.getByRole('button', { name: /E2E Editor Fixture/ }).waitFor({ timeout: 10_000 })
+      await page.getByRole('button', { name: /E2E Editor Fixture/ }).click()
+      await page.locator('h2', { hasText: 'E2E Editor Fixture' }).waitFor()
+      await page.locator('.svelte-flow__node-triggerNode').click()
+      await shot(page, theme, 'workflow-editor-trigger-panel')
+    })
+
+    // ─── Settings ─────────────────────────────────────────────────────────────
+
+    test('settings', async ({ page }) => {
+      await page.goto('/')
+      await page.locator('[data-part="trigger"]', { hasText: /Settings/ }).click()
+      await page.locator('h1', { hasText: 'Settings' }).waitFor()
+      await shot(page, theme, 'settings')
+    })
+  })
+}

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from '@playwright/test'
 
 export default defineConfig({
   testDir: './e2e',
+  testIgnore: ['**/screenshots.spec.ts'],
   timeout: 10_000,
   retries: process.env.CI ? 2 : 0,
   reporter: process.env.CI ? 'github' : 'list',


### PR DESCRIPTION
## Motivation

Generate documentation screenshots automatically and keep them in sync with the website repo.

## Implementation information

- `frontend/e2e/screenshots.spec.ts` — dedicated Playwright spec covering all major views in both light and dark mode at 1920×1080
- `frontend/e2e/lib/github-mocks.ts` — intercepts GitHub API routes with realistic fixture data (PRs in all CI/review states, Renovate PRs, issues)
- `frontend/e2e/lib/project-mocks.ts` — intercepts Project API routes with fixture project + worktrees
- `.github/workflows/screenshots.yml` — runs on push to main; builds server, generates 66 screenshots, then opens a PR against `Automaat/sybra-website` to sync them into `public/screenshots/` (skips PR if nothing changed)

> Changelog: skip