### PR TITLE
ci(screenshots): enable testIgnore override

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Generate screenshots
         run: cd frontend && npx playwright test e2e/screenshots.spec.ts --reporter=github
+        env:
+          PLAYWRIGHT_SCREENSHOTS: '1'
 
       - name: Dump server log
         if: failure()


### PR DESCRIPTION
## Motivation

Screenshots workflow fails with "No tests found" because `playwright.config.ts` has `testIgnore: ['**/screenshots.spec.ts']` (added to prevent the spec from running in the regular e2e suite), but the screenshots workflow doesn't bypass it.

## Implementation information

Sets `PLAYWRIGHT_SCREENSHOTS=1` env var on the Generate screenshots step, which the config checks to clear `testIgnore`.

> Changelog: skip