### PR TITLE
ci(screenshots): enable testIgnore override

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Generate screenshots
         run: cd frontend && npx playwright test e2e/screenshots.spec.ts --reporter=github
+        env:
+          PLAYWRIGHT_SCREENSHOTS: '1'
 
       - name: Dump server log
         if: failure()

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from '@playwright/test'
 
 export default defineConfig({
   testDir: './e2e',
-  testIgnore: ['**/screenshots.spec.ts'],
+  testIgnore: process.env.PLAYWRIGHT_SCREENSHOTS ? [] : ['**/screenshots.spec.ts'],
   timeout: 10_000,
   retries: process.env.CI ? 2 : 0,
   reporter: process.env.CI ? 'github' : 'list',


### PR DESCRIPTION
## Motivation

Screenshots workflow still fails — `playwright.config.ts` has static `testIgnore` without the env var conditional that was missing from the squash merge.

## Implementation information

- `playwright.config.ts`: make `testIgnore` conditional on `PLAYWRIGHT_SCREENSHOTS` env var
- `screenshots.yml`: set `PLAYWRIGHT_SCREENSHOTS=1` on the generate step

> Changelog: skip