### PR TITLE
fix(task): skip list cache on parse errors

### DIFF
--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -61,6 +61,7 @@ func (s *Store) List() ([]Task, error) {
 	}
 
 	var tasks []Task
+	var parseErr bool
 	for _, p := range paths {
 		base := filepath.Base(p)
 		if strings.HasSuffix(base, ".plan.md") || strings.HasSuffix(base, ".plan-critique.md") {
@@ -69,13 +70,16 @@ func (s *Store) List() ([]Task, error) {
 		t, err := Parse(p)
 		if err != nil {
 			slog.Default().Warn("task.parse.skip", "file", filepath.Base(p), "err", err)
+			parseErr = true
 			continue
 		}
 		t.Plan, _ = s.plans.Read(t.ID)
 		t.PlanCritique, _ = s.planCritiques.Read(t.ID)
 		tasks = append(tasks, t)
 	}
-	s.storeListCache(tasks)
+	if !parseErr {
+		s.storeListCache(tasks)
+	}
 	return tasks, nil
 }
 


### PR DESCRIPTION
## Motivation

When any task file fails to parse (e.g. permission denied from a file written by root via `docker exec -u root`), the store cached the partial list — permanently hiding the affected task from the API until the cache was manually invalidated by another write.

## Implementation information

Track whether any parse error occurred during `List()`. If so, skip storing the list cache so the next call retries from disk. Files that fail transiently (wrong permissions, mid-write corruption) will reappear automatically once the error clears.

> Changelog: fix(task): skip list cache on parse errors