### PR TITLE
ci(actions): add actionlint workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,31 @@
+name: Lint Actions
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+      - name: Install actionlint
+        run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+
+      - name: Run actionlint
+        run: actionlint -color


### PR DESCRIPTION
## Motivation

Lint GitHub Actions workflows to catch syntax errors, unused vars, and misused expressions before merge.

## Implementation information

- New workflow `.github/workflows/actionlint.yml` runs `actionlint` via `go install` (consistent with repo's pinned Go-tools pattern — matches wails install approach).
- Triggers only on changes to `.github/workflows/**` or `.github/actions/**` via `paths` filter, so unrelated PRs don't pay the cost.
- Uses `jdx/mise-action` for Go toolchain (reuses pinned SHAs from other workflows).
- Verified locally: `actionlint` passes clean on all three existing workflows.

Alternatives considered:
- Adding to `ci.yml` as a new job — rejected, would run on every push.
- Community `raven-actions/actionlint` — rejected, extra supply-chain surface vs. `go install` of upstream.
- Adding to `.mise.toml` — rejected, not needed as a local dev tool yet.

## Supporting documentation

None.

> Changelog: skip