### PR TITLE
test(e2e): gate chaos settle on onComplete drain

### DIFF
--- a/internal/sybra/e2e_chaos_test.go
+++ b/internal/sybra/e2e_chaos_test.go
@@ -209,7 +209,17 @@ func waitForChaosSettle(t *testing.T, env *e2eEnv, taskID string, timeout time.D
 // terminal state with no live agent. Used by waitForChaosSettle as a
 // per-poll predicate; the caller requires sustained truth before declaring
 // settlement to filter out transient between-step observations.
+//
+// The pendingCompletions gate closes the race window between
+// agent.Manager.markAgentDone (which flips HasRunningAgentForTask to false
+// before the onComplete callback runs) and the engine's AdvanceStep/
+// executeSteps chain actually advancing workflow state. Without it, under
+// CI load the gap widens past the stable-poll budget and the invariant-4
+// check observes state=Running mid-transition.
 func isChaosSettled(env *e2eEnv, taskID string) bool {
+	if env.pendingCompletions.Load() > 0 {
+		return false
+	}
 	if env.agents.HasRunningAgentForTask(taskID) {
 		return false
 	}

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -89,6 +90,12 @@ type e2eEnv struct {
 	scenarioFile string
 	provider     string
 	cancel       context.CancelFunc
+	// pendingCompletions counts agent-completion callbacks currently executing
+	// (between the onComplete wrapper's enter and exit). The chaos settle
+	// check consults this to distinguish "workflow truly quiesced" from the
+	// gap between markAgentDone (which flips HasRunningAgentForTask to false)
+	// and HandleAgentComplete finishing its AdvanceStep/executeSteps chain.
+	pendingCompletions atomic.Int64
 }
 
 // startWorkflow seeds the reserved _dir variable so that run_agent steps have
@@ -219,7 +226,29 @@ func setupE2EProvider(t *testing.T, provider, scenario string) *e2eEnv {
 	engine := workflow.NewEngine(wfStore, ta, aa, logger)
 	engine.SetWorktreeGetter(&worktreeGetterAdapter{tasks: taskMgr, mgr: wm})
 
+	// Pre-create a working directory so run_agent steps can satisfy the
+	// Manager.Run guard that rejects empty Dir.
+	agentDir, err := os.MkdirTemp("", "sybra-e2e-agent-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(agentDir) })
+
+	env := &e2eEnv{
+		tasks:        taskMgr,
+		agents:       agentMgr,
+		engine:       engine,
+		wfStore:      wfStore,
+		taskDir:      taskDir,
+		agentDir:     agentDir,
+		worktreesDir: wtDir,
+		provider:     provider,
+		cancel:       cancel,
+	}
+
 	agentMgr.SetOnComplete(func(ag *agent.Agent) {
+		env.pendingCompletions.Add(1)
+		defer env.pendingCompletions.Add(-1)
 		var result string
 		output := ag.Output()
 		for i := range output {
@@ -235,25 +264,7 @@ func setupE2EProvider(t *testing.T, provider, scenario string) *e2eEnv {
 		})
 	})
 
-	// Pre-create a working directory so run_agent steps can satisfy the
-	// Manager.Run guard that rejects empty Dir.
-	agentDir, err := os.MkdirTemp("", "sybra-e2e-agent-*")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(agentDir) })
-
-	return &e2eEnv{
-		tasks:        taskMgr,
-		agents:       agentMgr,
-		engine:       engine,
-		wfStore:      wfStore,
-		taskDir:      taskDir,
-		agentDir:     agentDir,
-		worktreesDir: wtDir,
-		provider:     provider,
-		cancel:       cancel,
-	}
+	return env
 }
 
 // waitFor polls a condition with timeout.


### PR DESCRIPTION
## Motivation

Fixes #513. `TestE2E_ChaosFullLifecycle/seed-22` fails intermittently on CI with `incoherent settle: state="running" status="in-progress" step="implement"`.

`agent.Manager.markAgentDone` flips `HasRunningAgentForTask` to `false` before the `onComplete` callback runs `engine.HandleAgentComplete` → `AdvanceStep` → `executeSteps`. During this window the workflow state is still `Waiting` (persisted when the agent started) so `isChaosSettled` returns true, but the engine is about to transition to `Running` as it dispatches the next step. Under CI load the gap widens past the 4×50ms stable-poll budget, and the invariant-4 check observes the mid-transition state.

## Implementation information

- Wrap the test's `onComplete` callback with a `pendingCompletions atomic.Int64` counter on `e2eEnv` (incremented before `HandleAgentComplete`, decremented after).
- `isChaosSettled` requires `pendingCompletions == 0` in addition to the existing agent/state gates, so settle cannot be declared while an agent completion is still being drained through the engine's sync step chain.
- `setupE2EProvider` is restructured so `env` is constructed before the callback is wired up, letting the closure capture it.

No production code changes; the race was purely a test observability gap.

Verified:
- `go test -run 'TestE2E_ChaosFullLifecycle/seed-22$'` passes.
- `go test -race -run 'TestE2E_ChaosFullLifecycle$' -count=3` passes (~30s).
- `go test -race ./internal/sybra/...` passes (~126s).
- `golangci-lint run ./internal/sybra/...` clean.

## Supporting documentation

- Issue: #513
- Introduced by: #510

> Changelog: skip