### PR TITLE
feat(nav): cmd+k command palette with fuzzy search

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -31,20 +31,15 @@
   import QuickAddTask from './components/QuickAddTask.svelte'
   import ToastContainer from './components/ToastContainer.svelte'
   import CommandPalette from './components/CommandPalette.svelte'
+  import type { PaletteCtx } from './lib/palette-commands.js'
   import KeyboardHelp from './components/KeyboardHelp.svelte'
   import { Cloud, AlertTriangle } from '@lucide/svelte'
 
-  type SimplePageKind = 'dashboard' | 'task-list' | 'project-list' | 'chats' | 'agents' | 'github' | 'reviews' | 'stats' | 'settings' | 'workflows'
-
-  function handlePaletteNavigate(kind: string, params?: { taskId?: string; projectId?: string }): void {
-    commandPaletteOpen = false
-    if (kind === 'task-detail' && params?.taskId) {
-      navStore.navigate({ kind: 'task-detail', taskId: params.taskId })
-    } else if (kind === 'project-detail' && params?.projectId) {
-      navStore.navigate({ kind: 'project-detail', projectId: params.projectId })
-    } else {
-      navStore.reset({ kind: kind as SimplePageKind })
-    }
+  const paletteCtx: PaletteCtx = {
+    navigate: (page) => { commandPaletteOpen = false; navStore.reset(page) },
+    openNewTask: () => { commandPaletteOpen = false; dialogOpen = true },
+    openNewProject: () => { commandPaletteOpen = false; projectDialogOpen = true },
+    openKeyboardHelp: () => { commandPaletteOpen = false; helpOpen = true },
   }
 
   type DegradedWarning = { subsystem: string; reason: string }
@@ -160,7 +155,16 @@
     const hasFinePointer = typeof window !== 'undefined' && window.matchMedia?.('(pointer: fine)').matches
     let removeKeyHandler: (() => void) | undefined
     if (hasFinePointer) {
+      let pendingG = false
+      let gTimer: ReturnType<typeof setTimeout> | null = null
+
       function handleKeydown(e: KeyboardEvent) {
+        // Clear G-chord when a modifier key combo fires
+        if ((e.metaKey || e.ctrlKey || e.altKey) && pendingG) {
+          pendingG = false
+          if (gTimer) { clearTimeout(gTimer); gTimer = null }
+        }
+
         if (e.metaKey && e.key === 'n') {
           e.preventDefault()
           quickAddOpen = true
@@ -210,9 +214,36 @@
           navStore.reset({ kind: 'task-list' })
           requestAnimationFrame(() => window.dispatchEvent(new CustomEvent('focus-search')))
         }
+
+        // G-chord navigation: bare keypresses only, not in input/textarea/contenteditable
+        if (!e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey) {
+          const target = e.target as HTMLElement
+          const inInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable
+          if (!inInput) {
+            if (pendingG) {
+              pendingG = false
+              if (gTimer) { clearTimeout(gTimer); gTimer = null }
+              if (e.key === 'i') { e.preventDefault(); navStore.reset({ kind: 'task-list' }) }
+              else if (e.key === 'a') { e.preventDefault(); navStore.reset({ kind: 'task-list', filter: 'in-progress' }) }
+              else if (e.key === 'p') { e.preventDefault(); navStore.reset({ kind: 'project-list' }) }
+              else if (e.key === 's') { e.preventDefault(); navStore.reset({ kind: 'settings' }) }
+              // unmapped letters: clear pendingG silently, no navigation
+              return
+            }
+            if (e.key === 'g') {
+              e.preventDefault()
+              pendingG = true
+              gTimer = setTimeout(() => { pendingG = false; gTimer = null }, 1500)
+              return
+            }
+          }
+        }
       }
       window.addEventListener('keydown', handleKeydown)
-      removeKeyHandler = () => window.removeEventListener('keydown', handleKeydown)
+      removeKeyHandler = () => {
+        window.removeEventListener('keydown', handleKeydown)
+        if (gTimer) clearTimeout(gTimer)
+      }
     }
 
     return () => {
@@ -286,7 +317,7 @@
     {#if navStore.page.kind === 'dashboard'}
       <Dashboard onviewagent={navAgentDetail} />
     {:else if navStore.page.kind === 'task-list'}
-      <TaskList onselect={navTaskDetail} />
+      <TaskList onselect={navTaskDetail} filter={navStore.page.filter} />
     {:else if navStore.page.kind === 'task-detail'}
       <TaskDetail
         taskId={navStore.page.taskId}
@@ -364,7 +395,7 @@
 <CommandPalette
   open={commandPaletteOpen}
   onclose={() => (commandPaletteOpen = false)}
-  onnavigate={handlePaletteNavigate}
+  ctx={paletteCtx}
 />
 
 {#if !viewport.hasCoarsePointer}

--- a/frontend/src/components/CommandPalette.svelte
+++ b/frontend/src/components/CommandPalette.svelte
@@ -1,68 +1,57 @@
 <script lang="ts">
   import { Search, X } from '@lucide/svelte'
   import MobileSheet from './shell/MobileSheet.svelte'
-  import { taskStore } from '../stores/tasks.svelte.js'
-  import { projectStore } from '../stores/projects.svelte.js'
-
-  interface Result {
-    type: 'page' | 'task' | 'project'
-    id: string
-    title: string
-    subtitle?: string
-  }
+  import { buildCommands, type Command, type PaletteCtx } from '../lib/palette-commands.js'
+  import { score } from '../lib/fuzzy.js'
+  import { getRecent, pushRecent } from '../lib/palette-recent.js'
 
   interface Props {
     open: boolean
     onclose: () => void
-    onnavigate: (kind: string, params?: { taskId?: string; projectId?: string }) => void
+    ctx: PaletteCtx
   }
 
-  const { open, onclose, onnavigate }: Props = $props()
-
-  const PAGES: Result[] = [
-    { type: 'page', id: 'dashboard', title: 'Dashboard' },
-    { type: 'page', id: 'task-list', title: 'Board', subtitle: 'Task Board' },
-    { type: 'page', id: 'project-list', title: 'Projects' },
-    { type: 'page', id: 'chats', title: 'Chats' },
-    { type: 'page', id: 'agents', title: 'Agents' },
-    { type: 'page', id: 'github', title: 'GitHub' },
-    { type: 'page', id: 'reviews', title: 'Reviews' },
-    { type: 'page', id: 'stats', title: 'Stats' },
-    { type: 'page', id: 'settings', title: 'Settings' },
-    { type: 'page', id: 'workflows', title: 'Workflows' },
-  ]
+  const { open, onclose, ctx }: Props = $props()
 
   let query = $state('')
   let selectedIndex = $state(0)
   let inputRef = $state<HTMLInputElement | null>(null)
 
-  const results = $derived.by((): Result[] => {
+  const allCommands = $derived(buildCommands(ctx))
+
+  const results = $derived.by((): Command[] => {
     const q = query.toLowerCase().trim()
-    if (!q) return PAGES.slice(0, 8)
 
-    const matches: Result[] = []
-
-    for (const p of PAGES) {
-      if (p.title.toLowerCase().includes(q) || p.subtitle?.toLowerCase().includes(q)) {
-        matches.push(p)
-      }
+    if (!q) {
+      const recentIds = getRecent()
+      const cmdMap = new Map(allCommands.map((c) => [c.id, c]))
+      const recentCmds = recentIds.map((id) => cmdMap.get(id)).filter((c): c is Command => Boolean(c))
+      const topActions = allCommands.filter((c) => c.section === 'action')
+      const seen = new Set(recentCmds.map((c) => c.id))
+      const extra = topActions.filter((c) => !seen.has(c.id))
+      return [...recentCmds, ...extra].slice(0, 8)
     }
 
-    for (const t of taskStore.list) {
-      if (matches.length >= 15) break
-      if (t.title.toLowerCase().includes(q)) {
-        matches.push({ type: 'task', id: t.id, title: t.title, subtitle: t.status })
+    const scored: { cmd: Command; total: number }[] = []
+    for (const cmd of allCommands) {
+      const ts = score(q, cmd.title)
+
+      const ss = cmd.subtitle ? score(q, cmd.subtitle) : null
+
+      let ks: number | null = null
+      if (cmd.keywords?.length) {
+        const best = Math.max(...cmd.keywords.map((kw) => score(q, kw) ?? -Infinity))
+        if (isFinite(best)) ks = best
       }
+
+      if (ts === null && ss === null && ks === null) continue
+
+      const total = (ts ?? 0) + 0.5 * (ss ?? 0) + 0.3 * (ks ?? 0)
+      scored.push({ cmd, total })
     }
 
-    for (const p of projectStore.list) {
-      const name = `${p.owner}/${p.repo}`
-      if (name.toLowerCase().includes(q)) {
-        matches.push({ type: 'project', id: p.id, title: name, subtitle: 'Project' })
-      }
-    }
-
-    return matches.slice(0, 15)
+    scored.sort((a, b) => b.total - a.total)
+    return scored.slice(0, 15).map((s) => s.cmd)
   })
 
   $effect(() => {
@@ -100,20 +89,25 @@
     return () => window.removeEventListener('keydown', handleKeydown)
   })
 
-  function selectResult(result: Result | undefined) {
-    if (!result) return
-    if (result.type === 'page') {
-      onnavigate(result.id)
-    } else if (result.type === 'task') {
-      onnavigate('task-detail', { taskId: result.id })
-    } else if (result.type === 'project') {
-      onnavigate('project-detail', { projectId: result.id })
-    }
+  function selectResult(cmd: Command | undefined) {
+    if (!cmd) return
+    pushRecent(cmd.id)
+    cmd.run()
   }
 
+  function sectionLabel(section: string): string {
+    switch (section) {
+      case 'action': return 'Actions'
+      case 'page': return 'Pages'
+      case 'task': return 'Tasks'
+      case 'project': return 'Projects'
+      case 'agent': return 'Agents'
+      default: return section
+    }
+  }
 </script>
 
-<MobileSheet {open} onOpenChange={(o) => { if (!o) onclose() }} variant="top">
+<MobileSheet {open} onOpenChange={(o) => { if (!o) onclose() }} variant="top" backdropClass="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm">
   <div class="flex flex-col">
     <!-- Search bar -->
     <div class="flex items-center gap-3 border-b border-surface-200 px-4 dark:border-surface-700">
@@ -122,7 +116,7 @@
         bind:this={inputRef}
         bind:value={query}
         type="text"
-        placeholder="Search tasks, pages, projects..."
+        placeholder="Search tasks, projects, agents, pages..."
         class="flex-1 bg-transparent py-3.5 text-base outline-none placeholder:text-surface-400 md:text-sm"
       />
       <button
@@ -137,36 +131,35 @@
     </div>
 
     <!-- Results -->
-    <ul class="max-h-[60dvh] overflow-y-auto py-1 md:max-h-80">
+    <ul class="max-h-[60dvh] overflow-y-auto py-1 md:max-h-80" role="listbox" aria-label="Command palette results">
       {#if results.length === 0}
         <li class="px-4 py-8 text-center text-sm text-surface-400">
           No results for "<span class="text-surface-700 dark:text-surface-300">{query}</span>"
         </li>
       {:else}
-        {#each results as result, i}
-          <li>
+        {#each results as cmd, i}
+          {#if i === 0 || results[i - 1].section !== cmd.section}
+            <li role="presentation" class="px-3 pb-0.5 pt-2 text-[10px] font-semibold uppercase tracking-wider text-surface-400 first:pt-1.5">
+              {sectionLabel(cmd.section)}
+            </li>
+          {/if}
+          <li role="option" aria-selected={i === selectedIndex}>
             <button
               type="button"
-              class="tap flex w-full items-center gap-3 border-l-2 px-3 py-2.5 text-left text-sm transition-colors
+              class="tap flex w-full items-center gap-3 border-l-2 px-3 py-2 text-left text-sm transition-colors
                 {i === selectedIndex
                   ? 'border-primary-500 bg-primary-50 text-primary-900 dark:bg-primary-950/50 dark:text-primary-100'
                   : 'border-transparent hover:bg-surface-100 dark:hover:bg-surface-800'}"
-              onclick={() => selectResult(result)}
+              onclick={() => selectResult(cmd)}
               onmouseenter={() => { selectedIndex = i }}
             >
-              <span class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold uppercase
-                {result.type === 'page'
-                  ? 'bg-primary-100 text-primary-700 dark:bg-primary-900/50 dark:text-primary-300'
-                  : result.type === 'task'
-                    ? 'bg-secondary-100 text-secondary-700 dark:bg-secondary-900/50 dark:text-secondary-300'
-                    : 'bg-tertiary-100 text-tertiary-700 dark:bg-tertiary-900/50 dark:text-tertiary-300'}">
-                {result.type === 'page' ? 'PAGE' : result.type === 'task' ? 'TASK' : 'PROJ'}
-              </span>
-              <span class="flex-1 font-medium">{result.title}</span>
-              {#if result.subtitle}
-                <span class="text-xs text-surface-400">{result.subtitle}</span>
+              <span class="flex-1 font-medium">{cmd.title}</span>
+              {#if cmd.subtitle}
+                <span class="shrink-0 text-xs text-surface-400">{cmd.subtitle}</span>
               {/if}
-              {#if i === selectedIndex}
+              {#if cmd.shortcut}
+                <kbd class="shrink-0 rounded border border-surface-300 px-1.5 py-0.5 font-mono text-[10px] text-surface-400 dark:border-surface-600">{cmd.shortcut}</kbd>
+              {:else if i === selectedIndex}
                 <span class="shrink-0 font-mono text-xs text-primary-500">↵</span>
               {/if}
             </button>
@@ -185,6 +178,10 @@
         <span class="flex items-center gap-1">
           <kbd class="rounded border border-surface-300 px-1 py-0.5 font-mono text-[10px] dark:border-surface-600">↵</kbd>
           open
+        </span>
+        <span class="flex items-center gap-1">
+          <kbd class="rounded border border-surface-300 px-1 py-0.5 font-mono text-[10px] dark:border-surface-600">Esc</kbd>
+          close
         </span>
       </div>
     </div>

--- a/frontend/src/components/shell/MobileSheet.svelte
+++ b/frontend/src/components/shell/MobileSheet.svelte
@@ -7,10 +7,11 @@
     onOpenChange: (open: boolean) => void
     variant?: 'bottom' | 'top' | 'center'
     title?: string
+    backdropClass?: string
     children: Snippet
   }
 
-  const { open, onOpenChange, variant = 'bottom', title, children }: Props = $props()
+  const { open, onOpenChange, variant = 'bottom', title, backdropClass, children }: Props = $props()
 
   const positionerClass = $derived(
     variant === 'bottom'
@@ -33,7 +34,7 @@
   {open}
   onOpenChange={(d) => onOpenChange(d.open)}
 >
-  <Dialog.Backdrop class="fixed inset-0 z-40 bg-black/50" />
+  <Dialog.Backdrop class={backdropClass ?? 'fixed inset-0 z-40 bg-black/50'} />
   <Dialog.Positioner class={positionerClass}>
     <Dialog.Content class={contentClass}>
       {#if open}

--- a/frontend/src/lib/fuzzy.test.ts
+++ b/frontend/src/lib/fuzzy.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import { score, matchRanges } from './fuzzy.js'
+
+describe('score', () => {
+  it('returns 0 for empty query', () => {
+    expect(score('', 'anything')).toBe(0)
+  })
+
+  it('returns null for empty target with non-empty query', () => {
+    expect(score('a', '')).toBeNull()
+  })
+
+  it('returns null when query chars not in target', () => {
+    expect(score('xyz', 'abc')).toBeNull()
+  })
+
+  it('matches case-insensitively', () => {
+    expect(score('abc', 'ABC')).not.toBeNull()
+    expect(score('ABC', 'abc')).not.toBeNull()
+  })
+
+  it('exact match scores higher than spread subsequence', () => {
+    // 'cmd' as exact string vs 'cmd' scattered across 'c_m_d'
+    const exact = score('cmd', 'cmd')
+    const subseq = score('cmd', 'c_m_d')
+    expect(exact).not.toBeNull()
+    expect(subseq).not.toBeNull()
+    expect(exact!).toBeGreaterThan(subseq!)
+  })
+
+  it('consecutive match bonus: chars found consecutively score higher than spread', () => {
+    // 'cmd' consecutive from start of 'cmds' vs spread in 'c-m-d'
+    const consecutive = score('cmd', 'cmds')
+    const spread = score('cmd', 'c-m-d')
+    expect(consecutive).not.toBeNull()
+    expect(spread).not.toBeNull()
+    expect(consecutive!).toBeGreaterThan(spread!)
+  })
+
+  it('word boundary bonus: match at start scores higher than mid-word', () => {
+    const atStart = score('set', 'Settings')
+    const midWord = score('set', 'reset')
+    expect(atStart).not.toBeNull()
+    expect(midWord).not.toBeNull()
+    expect(atStart!).toBeGreaterThan(midWord!)
+  })
+
+  it('word boundary bonus applies after hyphen/underscore/slash/space', () => {
+    const afterHyphen = score('c', 'a-c')
+    const afterSlash = score('c', 'a/c')
+    const afterUnderscore = score('c', 'a_c')
+    const afterSpace = score('c', 'a c')
+    const midWord = score('c', 'ac')
+    expect(afterHyphen!).toBeGreaterThan(midWord!)
+    expect(afterSlash!).toBeGreaterThan(midWord!)
+    expect(afterUnderscore!).toBeGreaterThan(midWord!)
+    expect(afterSpace!).toBeGreaterThan(midWord!)
+  })
+
+  it('shorter gap penalty: few gaps scores higher than many gaps', () => {
+    const noGap = score('ab', 'ab')
+    const bigGap = score('ab', 'a___b')
+    expect(noGap!).toBeGreaterThan(bigGap!)
+  })
+
+  it('no spurious consecutive bonus on the first matched character', () => {
+    // First char always gets base + (optional boundary), never consecutive
+    const first = score('a', 'axxx')  // a at pos 0, word boundary
+    const boundary = score('a', 'x-a') // a at pos 2, word boundary
+    // Both get word boundary; first char shouldn't inflate via consecutive
+    expect(first).toBe(20) // 10 base + 10 boundary
+    expect(boundary).toBe(20) // 10 base + 10 boundary
+  })
+
+  it('returns null if target is too short to contain all query chars', () => {
+    expect(score('abcde', 'abc')).toBeNull()
+  })
+
+  it('full match on short query', () => {
+    expect(score('s', 'settings')).not.toBeNull()
+    expect(score('s', 'dashboard')).not.toBeNull()
+  })
+})
+
+describe('matchRanges', () => {
+  it('returns empty array for empty query', () => {
+    expect(matchRanges('', 'abc')).toEqual([])
+  })
+
+  it('returns null if no match', () => {
+    expect(matchRanges('xyz', 'abc')).toBeNull()
+  })
+
+  it('merges consecutive positions into a single range', () => {
+    expect(matchRanges('abc', 'abcdef')).toEqual([[0, 3]])
+  })
+
+  it('separates non-consecutive positions into multiple ranges', () => {
+    expect(matchRanges('ac', 'abc')).toEqual([[0, 1], [2, 3]])
+  })
+
+  it('is case-insensitive', () => {
+    expect(matchRanges('abc', 'ABC')).toEqual([[0, 3]])
+  })
+})

--- a/frontend/src/lib/fuzzy.ts
+++ b/frontend/src/lib/fuzzy.ts
@@ -1,0 +1,72 @@
+/**
+ * Fuzzy string scorer for the command palette.
+ *
+ * score(query, target):
+ *   - Returns null if any query character is unmatched (subsequence test fails).
+ *   - Returns 0 for an empty query.
+ *   - Higher score = better match.
+ *
+ * Scoring weights:
+ *   +10 per matched character (base)
+ *   +15 consecutive-match bonus (match immediately follows previous match)
+ *   +10 word-boundary bonus (match at position 0, or after whitespace/hyphen/underscore/slash)
+ *   −3  per gap character between matches
+ */
+export function score(query: string, target: string): number | null {
+  if (!query) return 0
+  const q = query.toLowerCase()
+  const t = target.toLowerCase()
+
+  let qi = 0
+  let prevMatchIdx = -2 // sentinel: no previous match yet
+  let sc = 0
+
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] !== q[qi]) continue
+    sc += 10
+    if (prevMatchIdx >= 0 && prevMatchIdx === ti - 1) sc += 15
+    if (ti === 0 || /[\s\-_/]/.test(t[ti - 1])) sc += 10
+    if (prevMatchIdx >= 0) sc -= 3 * (ti - prevMatchIdx - 1)
+    prevMatchIdx = ti
+    qi++
+  }
+
+  return qi < q.length ? null : sc
+}
+
+/**
+ * Returns [start, end) ranges of matched characters in target for highlighting.
+ * Returns null if no match.
+ */
+export function matchRanges(query: string, target: string): [number, number][] | null {
+  if (!query) return []
+  const q = query.toLowerCase()
+  const t = target.toLowerCase()
+
+  const positions: number[] = []
+  let qi = 0
+
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) {
+      positions.push(ti)
+      qi++
+    }
+  }
+
+  if (qi < q.length) return null
+
+  const ranges: [number, number][] = []
+  let start = positions[0]
+  let end = positions[0] + 1
+  for (let i = 1; i < positions.length; i++) {
+    if (positions[i] === end) {
+      end++
+    } else {
+      ranges.push([start, end])
+      start = positions[i]
+      end = positions[i] + 1
+    }
+  }
+  ranges.push([start, end])
+  return ranges
+}

--- a/frontend/src/lib/keyboard.svelte.ts
+++ b/frontend/src/lib/keyboard.svelte.ts
@@ -51,4 +51,14 @@ export const SHORTCUTS: { scope: string; label: string; shortcuts: Shortcut[] }[
       { keys: 'C', description: 'Focus feedback input' },
     ],
   },
+  {
+    scope: 'global',
+    label: 'Quick Navigation',
+    shortcuts: [
+      { keys: 'G  I', description: 'All Tasks' },
+      { keys: 'G  A', description: 'Active (In Progress)' },
+      { keys: 'G  P', description: 'Projects' },
+      { keys: 'G  S', description: 'Settings' },
+    ],
+  },
 ]

--- a/frontend/src/lib/navigation.svelte.ts
+++ b/frontend/src/lib/navigation.svelte.ts
@@ -3,7 +3,7 @@
 
 export type Page =
   | { kind: 'dashboard' }
-  | { kind: 'task-list' }
+  | { kind: 'task-list'; filter?: 'in-progress' }
   | { kind: 'task-detail'; taskId: string }
   | { kind: 'project-list' }
   | { kind: 'project-detail'; projectId: string }
@@ -98,6 +98,7 @@ class NavStore {
 
 function samePage(a: Page, b: Page): boolean {
   if (a.kind !== b.kind) return false
+  if (a.kind === 'task-list' && b.kind === 'task-list') return (a.filter ?? '') === (b.filter ?? '')
   if (a.kind === 'task-detail' && b.kind === 'task-detail') return a.taskId === b.taskId
   if (a.kind === 'project-detail' && b.kind === 'project-detail') return a.projectId === b.projectId
   if (a.kind === 'chat-detail' && b.kind === 'chat-detail') return a.agentId === b.agentId

--- a/frontend/src/lib/palette-commands.ts
+++ b/frontend/src/lib/palette-commands.ts
@@ -1,0 +1,125 @@
+/**
+ * Command palette unified command list.
+ *
+ * ID stability contract: all command ids are deterministic string literals
+ * (e.g. "action:new-task", "page:settings", "task:<id>"). They must NOT be
+ * derived from user-visible labels (which may change). The recents store
+ * depends on id stability; stale ids are silently dropped on lookup.
+ */
+
+import type { Page } from './navigation.svelte.js'
+import { taskStore } from '../stores/tasks.svelte.js'
+import { projectStore } from '../stores/projects.svelte.js'
+import { agentStore } from '../stores/agents.svelte.js'
+
+export type CommandSection = 'action' | 'page' | 'task' | 'project' | 'agent'
+
+export interface Command {
+  id: string
+  title: string
+  subtitle?: string
+  section: CommandSection
+  shortcut?: string
+  keywords?: string[]
+  run: () => void
+}
+
+export interface PaletteCtx {
+  navigate: (page: Page) => void
+  openNewTask: () => void
+  openNewProject: () => void
+  openKeyboardHelp: () => void
+}
+
+const ACTIVE_AGENT_STATES = new Set(['running', 'waiting', 'errored'])
+
+export function buildCommands(ctx: PaletteCtx): Command[] {
+  const cmds: Command[] = []
+
+  // --- ACTIONS ---
+  cmds.push({
+    id: 'action:new-task',
+    title: 'New Task',
+    section: 'action',
+    shortcut: '⌘N',
+    run: ctx.openNewTask,
+  })
+  cmds.push({
+    id: 'action:new-project',
+    title: 'New Project',
+    section: 'action',
+    run: ctx.openNewProject,
+  })
+  cmds.push({
+    id: 'action:new-chat',
+    title: 'New Chat',
+    section: 'action',
+    run: () => ctx.navigate({ kind: 'chats' }),
+  })
+  cmds.push({
+    id: 'action:keyboard-help',
+    title: 'Keyboard Shortcuts',
+    section: 'action',
+    shortcut: '⌘/',
+    run: ctx.openKeyboardHelp,
+  })
+
+  // --- PAGES ---
+  const pageEntries: { id: string; title: string; shortcut?: string; page: Page }[] = [
+    { id: 'page:dashboard', title: 'Dashboard', shortcut: '⌘1', page: { kind: 'dashboard' } },
+    { id: 'page:task-list', title: 'Tasks', shortcut: '⌘2', page: { kind: 'task-list' } },
+    { id: 'page:project-list', title: 'Projects', shortcut: '⌘3', page: { kind: 'project-list' } },
+    { id: 'page:agents', title: 'Agents', shortcut: '⌘4', page: { kind: 'agents' } },
+    { id: 'page:github', title: 'GitHub', shortcut: '⌘5', page: { kind: 'github' } },
+    { id: 'page:reviews', title: 'Reviews', shortcut: '⌘6', page: { kind: 'reviews' } },
+    { id: 'page:stats', title: 'Stats', shortcut: '⌘7', page: { kind: 'stats' } },
+    { id: 'page:settings', title: 'Settings', shortcut: '⌘,', page: { kind: 'settings' } },
+    { id: 'page:chats', title: 'Chats', page: { kind: 'chats' } },
+    { id: 'page:workflows', title: 'Workflows', page: { kind: 'workflows' } },
+  ]
+  for (const p of pageEntries) {
+    cmds.push({
+      id: p.id,
+      title: p.title,
+      section: 'page',
+      shortcut: p.shortcut,
+      run: () => ctx.navigate(p.page),
+    })
+  }
+
+  // --- TASKS ---
+  for (const t of taskStore.list) {
+    cmds.push({
+      id: `task:${t.id}`,
+      title: t.title,
+      subtitle: t.status,
+      section: 'task',
+      keywords: [t.id, ...(t.tags ?? [])],
+      run: () => ctx.navigate({ kind: 'task-detail', taskId: t.id }),
+    })
+  }
+
+  // --- PROJECTS ---
+  for (const p of projectStore.list) {
+    cmds.push({
+      id: `project:${p.id}`,
+      title: `${p.owner}/${p.repo}`,
+      section: 'project',
+      run: () => ctx.navigate({ kind: 'project-detail', projectId: p.id }),
+    })
+  }
+
+  // --- AGENTS (active states only — excludes terminated/stopped) ---
+  for (const a of agentStore.list) {
+    if (!ACTIVE_AGENT_STATES.has(a.state)) continue
+    cmds.push({
+      id: `agent:${a.id}`,
+      title: agentStore.stepTexts.get(a.id) ?? a.id,
+      subtitle: a.state,
+      section: 'agent',
+      run: () => ctx.navigate({ kind: 'agent-detail', agentId: a.id }),
+    })
+  }
+
+  return cmds
+}

--- a/frontend/src/lib/palette-recent.test.ts
+++ b/frontend/src/lib/palette-recent.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getRecent, pushRecent } from './palette-recent.js'
+
+const KEY = 'sybra.palette.recent'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('getRecent', () => {
+  it('returns empty array when storage is empty', () => {
+    expect(getRecent()).toEqual([])
+  })
+
+  it('returns empty array when storage is malformed JSON', () => {
+    localStorage.setItem(KEY, 'not-json{{')
+    expect(getRecent()).toEqual([])
+  })
+
+  it('returns empty array when stored value is not an array', () => {
+    localStorage.setItem(KEY, '{"a":1}')
+    expect(getRecent()).toEqual([])
+  })
+
+  it('filters out non-string entries', () => {
+    localStorage.setItem(KEY, '["a", 1, null, "b"]')
+    expect(getRecent()).toEqual(['a', 'b'])
+  })
+
+  it('returns stored ids in order', () => {
+    localStorage.setItem(KEY, '["id1", "id2", "id3"]')
+    expect(getRecent()).toEqual(['id1', 'id2', 'id3'])
+  })
+})
+
+describe('pushRecent', () => {
+  it('adds id to front', () => {
+    pushRecent('a')
+    expect(getRecent()).toEqual(['a'])
+  })
+
+  it('prepends new id and deduplicates existing', () => {
+    localStorage.setItem(KEY, '["a", "b", "c"]')
+    pushRecent('d')
+    expect(getRecent()).toEqual(['d', 'a', 'b', 'c'])
+  })
+
+  it('moves existing id to front (no duplicate)', () => {
+    localStorage.setItem(KEY, '["a", "b", "c"]')
+    pushRecent('b')
+    expect(getRecent()).toEqual(['b', 'a', 'c'])
+  })
+
+  it('caps at 5 entries (FIFO drop)', () => {
+    localStorage.setItem(KEY, '["a", "b", "c", "d", "e"]')
+    pushRecent('f')
+    expect(getRecent()).toEqual(['f', 'a', 'b', 'c', 'd'])
+  })
+
+  it('moving existing id to front does not exceed cap', () => {
+    localStorage.setItem(KEY, '["a", "b", "c", "d", "e"]')
+    pushRecent('e')
+    expect(getRecent()).toHaveLength(5)
+    expect(getRecent()[0]).toBe('e')
+  })
+})

--- a/frontend/src/lib/palette-recent.ts
+++ b/frontend/src/lib/palette-recent.ts
@@ -1,0 +1,20 @@
+const KEY = 'sybra.palette.recent'
+const MAX = 5
+
+export function getRecent(): string[] {
+  try {
+    const raw = localStorage.getItem(KEY)
+    if (!raw) return []
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((x): x is string => typeof x === 'string')
+  } catch {
+    return []
+  }
+}
+
+export function pushRecent(id: string): void {
+  const current = getRecent().filter((x) => x !== id)
+  const next = [id, ...current].slice(0, MAX)
+  localStorage.setItem(KEY, JSON.stringify(next))
+}

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -14,9 +14,10 @@
 
   interface Props {
     onselect: (id: string) => void
+    filter?: 'in-progress'
   }
 
-  const { onselect }: Props = $props()
+  const { onselect, filter }: Props = $props()
 
   let dragOverStatus = $state<string | null>(null)
   let addingToColumn = $state<string | null>(null)
@@ -159,6 +160,19 @@
     }
     window.addEventListener('focus-search', onFocusSearch)
     return () => window.removeEventListener('focus-search', onFocusSearch)
+  })
+
+  $effect(() => {
+    if (filter !== 'in-progress') return
+    requestAnimationFrame(() => {
+      document.querySelector('[data-col-status="in-progress"]')?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+        inline: 'start',
+      })
+      const idx = BOARD_COLUMNS.findIndex((c) => c.status === 'in-progress')
+      if (idx >= 0) focusedColIdx = idx
+    })
   })
 
   // Filter state
@@ -463,6 +477,7 @@
         {@const isCollapsed = !viewport.isDesktop && collapsedColumns.has(col.status)}
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <div
+          data-col-status={col.status}
           class="flex w-full shrink-0 flex-col rounded-lg border-t-4 bg-surface-100 transition-shadow dark:bg-surface-900 md:min-w-[260px] md:flex-1 md:shrink {col.border} {dragOverStatus === col.status ? 'ring-2 ring-primary-400 dark:ring-primary-500' : ''}"
           ondragover={(e) => { e.preventDefault(); dragOverStatus = col.status }}
           ondragleave={() => { dragOverStatus = null }}


### PR DESCRIPTION
## Motivation

Navigating between tasks, projects, and agents required multiple clicks through the sidebar. Power users need a fast keyboard-driven way to jump anywhere in the app without lifting hands from the keyboard.

## Implementation information

- Fuzzy scorer in `frontend/src/lib/fuzzy.ts` with consecutive/boundary/gap scoring for ranked matches
- Recents tracking via localStorage (`palette-recent.ts`, capped at 5, FIFO)
- Unified `Command` type in `palette-commands.ts` covering actions, pages, tasks, projects, and agents
- Section headers in the palette (Actions / Pages / Tasks / Projects / Agents) with right-aligned shortcut hints
- Backdrop blur via `backdropClass` prop on `CommandPalette.svelte`
- G+letter chord shortcuts (`G I/A/P/S`) for navigating app views, registered in `keyboard.svelte.ts`
- `task-list?filter=in-progress` URL param scrolls TaskList to that column
- Quick Navigation group added to keyboard help overlay

> Changelog: feat(nav): cmd+k command palette with fuzzy search

Closes https://github.com/Automaat/synapse/issues/459