### PR TITLE
fix(ui): exclude running agents from history list

### DIFF
--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -518,7 +518,7 @@
   }
 
   const pastRuns = $derived(
-    (t?.agentRuns ?? []).slice().reverse()
+    (t?.agentRuns ?? []).filter((r) => r.state !== 'running').reverse()
   )
 
   function formatDate(date: any): string {


### PR DESCRIPTION
## Motivation

In the task detail view, the *Agent History* panel currently lists every entry from `task.agentRuns`, including agents whose `state` is still `running`. Those entries always render as `No output available` because the live stream goes to the dedicated output panel above, so they are duplicates that look broken.

Spotted on task `d3233f1a` — interactive agent `35c5124d` was visible in both the live panel and Agent History.

## Implementation information

`frontend/src/pages/TaskDetail.svelte:520` — filter `agentRuns` by `state !== 'running'` before reversing for display.

Alternatives considered:
- Clearing the entry once the agent finishes — rejected, the run is also persisted to the task file as historical record and we want to keep it after completion.
- Hiding the live panel when `agentRuns` already contains the run — rejected, live panel handles streaming output that's not yet in the persisted run record.

## Supporting documentation

n/a