### PR TITLE
docs(claude): add synapse SSH access info

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,12 +181,22 @@ Startup logs an `app.automations` summary line so you can verify the role of eac
 Sybra also runs headless as a server, deployed from `~/sideprojects/home-nas`.
 
 - **Host:** `synapse` LXC (CT 114) on Proxmox, `192.168.20.219` (VLAN 20), Ubuntu 24.04, 6 cores / 16GB RAM
-- **Container:** `ghcr.io/automaat/sybra:<version>` via Docker Compose
+- **Container:** `ghcr.io/automaat/sybra:<version>` via Docker Compose (container name: `sybra`)
 - **Compose file:** `/opt/synapse/docker-compose.yml` on host (source: `ansible/docker-compose/synapse-stack.yml`)
-- **Volumes:** `/data/synapse/home` (→ `~/.synapse` inside container), `/data/synapse/claude` (Claude Code settings + hooks), `/data/synapse/codex` (Codex config)
+- **Volumes:** `/data/sybra/home` (→ `~/.sybra` inside container), `/data/sybra/claude` (Claude Code settings + hooks), `/data/sybra/codex` (Codex config)
 - **Exposure:** local `:8080` → Traefik → `synapse.mskalski.dev` (Cloudflare DNS+TLS). ACL-locked to LAN, Cloudflare Tunnel, Tailscale CIDRs.
 - **Deploy:** `ansible/playbooks/setup-synapse-lxc.yml` (provision LXC), `ansible/playbooks/deploy-synapse.yml` (push compose + restart)
 - **Klaudiush hooks:** enabled in both Claude Code `settings.json` and Codex `config.toml` (`codex_hooks = true`) for event monitoring
+
+**SSH access:** `ssh root@192.168.20.219` (no DNS for `synapse`/`synapse.mskalski.dev` from outside LAN — use IP). Inventory: `home-nas/ansible/inventory.yml` → group `synapse_lxc`. Common debug commands:
+
+```bash
+ssh root@192.168.20.219 "docker ps"                                  # container status
+ssh root@192.168.20.219 "tail -100 /data/sybra/home/logs/sybra.log"  # sybra-server logs
+ssh root@192.168.20.219 "ls /data/sybra/home/tasks/"                 # task files
+ssh root@192.168.20.219 "cat /data/sybra/home/config.yaml"           # server config
+ssh root@192.168.20.219 "docker exec sybra sybra-cli list"           # CLI inside container
+```
 
 Bumping the deployed version = update image tag in `ansible/docker-compose/synapse-stack.yml`, run the deploy playbook.
 


### PR DESCRIPTION
## Motivation

When debugging the headless sybra-server on the synapse LXC, the project CLAUDE.md said the host was `synapse` / `synapse.mskalski.dev` and the data dir was `/data/synapse/`. Neither hostname resolves from outside the LAN, and the actual data dir is `/data/sybra/` (renamed at some point). Result: agents (and humans) can't follow the docs to debug.

## Implementation information

- Add an explicit \`ssh root@192.168.20.219\` entry plus a short list of common debug commands (logs, tasks, config, in-container CLI)
- Reference \`home-nas/ansible/inventory.yml\` group \`synapse_lxc\` so the source of truth is discoverable
- Fix stale volume paths \`/data/synapse/...\` → \`/data/sybra/...\` and \`~/.synapse\` → \`~/.sybra\`
- Note container name (\`sybra\`)

## Supporting documentation

n/a — discovered while investigating task 4fb338ad triage stall.