### PR TITLE
ci(actions): stabilize screenshot pipeline

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -78,31 +78,46 @@ jobs:
           path: sybra-website
           token: ${{ secrets.WEBSITE_DEPLOY_PAT }}
 
-      - name: Copy screenshots to website
-        run: |
-          mkdir -p sybra-website/public/screenshots
-          cp -r docs/screenshots/. sybra-website/public/screenshots/
-
-      - name: Open PR if changed
+      - name: Open or update PR if changed
         env:
           GH_TOKEN: ${{ secrets.WEBSITE_DEPLOY_PAT }}
         run: |
           cd sybra-website
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          BRANCH="screenshots/sync"
+          git fetch origin "$BRANCH" || true
+          if git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+          else
+            git checkout -b "$BRANCH"
+          fi
+
+          mkdir -p public/screenshots
+          rm -rf public/screenshots
+          cp -r ../docs/screenshots public/screenshots
+
           git add public/screenshots/
           if git diff --cached --quiet; then
-            echo "No screenshot changes — skipping PR"
+            echo "No screenshot changes vs $BRANCH — skipping PR"
             exit 0
           fi
+
           SYBRA_SHA=$(git -C .. rev-parse --short HEAD)
-          BRANCH="screenshots/sync-${SYBRA_SHA}"
-          git checkout -b "$BRANCH"
           git commit -m "chore(screenshots): sync from sybra@${SYBRA_SHA}"
-          git push origin "$BRANCH"
-          gh pr create \
-            --repo Automaat/sybra-website \
-            --base main \
-            --head "$BRANCH" \
-            --title "chore(screenshots): sync from sybra@${SYBRA_SHA}" \
-            --body "Automated screenshot sync from automaat/sybra@${SYBRA_SHA}."
+          git push --force-with-lease origin "$BRANCH"
+
+          if gh pr view "$BRANCH" --repo Automaat/sybra-website >/dev/null 2>&1; then
+            gh pr edit "$BRANCH" \
+              --repo Automaat/sybra-website \
+              --title "chore(screenshots): sync from sybra@${SYBRA_SHA}" \
+              --body "Automated screenshot sync from automaat/sybra@${SYBRA_SHA}."
+          else
+            gh pr create \
+              --repo Automaat/sybra-website \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore(screenshots): sync from sybra@${SYBRA_SHA}" \
+              --body "Automated screenshot sync from automaat/sybra@${SYBRA_SHA}."
+          fi

--- a/frontend/e2e/lib/provider-mocks.ts
+++ b/frontend/e2e/lib/provider-mocks.ts
@@ -1,0 +1,37 @@
+import type { Page } from '@playwright/test'
+
+const HEALTHY = [
+  {
+    provider: 'claude',
+    healthy: true,
+    reason: 'ok',
+    lastCheck: '2026-04-16T12:00:00Z',
+  },
+  {
+    provider: 'codex',
+    healthy: true,
+    reason: 'ok',
+    lastCheck: '2026-04-16T12:00:00Z',
+  },
+]
+
+/**
+ * Mocks provider-health endpoints so the CLI-probe banners
+ * (`claude unavailable — probe_error`) never appear in screenshots.
+ * Apply in `beforeEach` before any navigation.
+ */
+export async function mockProviderHealth(page: Page) {
+  await page.route('**/api/IntegrationService/GetProviderHealth', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify(HEALTHY),
+    }),
+  )
+
+  await page.route('**/api/IntegrationService/ProviderHealthEnabled', (route) =>
+    route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify(true),
+    }),
+  )
+}

--- a/frontend/e2e/lib/review-mocks.ts
+++ b/frontend/e2e/lib/review-mocks.ts
@@ -1,0 +1,41 @@
+import type { Page } from '@playwright/test'
+
+const REVIEW_COMMENTS_BY_TASK: Record<string, unknown[]> = {
+  plan0001: [
+    {
+      id: 'c1',
+      line: 7,
+      body: 'Should we also migrate the middleware package? It has ~40 log.Printf calls that would benefit from structured fields.',
+      resolved: false,
+      createdAt: '2026-04-16T11:42:00Z',
+    },
+    {
+      id: 'c2',
+      line: 11,
+      body: 'LOG_LEVEL=trace should be allowed too — useful for local debugging.',
+      resolved: false,
+      createdAt: '2026-04-16T11:48:00Z',
+    },
+  ],
+}
+
+/**
+ * Mocks ListReviewComments so screenshots can show a plan with inline
+ * reviewer comments without needing a seeded store on disk.
+ */
+export async function mockReviewComments(page: Page) {
+  await page.route('**/api/ReviewService/ListReviewComments', async (route) => {
+    const body = route.request().postData() ?? '[]'
+    let taskId = ''
+    try {
+      const args = JSON.parse(body)
+      taskId = Array.isArray(args) ? String(args[0] ?? '') : ''
+    } catch {
+      // fall through to empty list
+    }
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify(REVIEW_COMMENTS_BY_TASK[taskId] ?? []),
+    })
+  })
+}

--- a/frontend/e2e/screenshots.spec.ts
+++ b/frontend/e2e/screenshots.spec.ts
@@ -9,6 +9,8 @@
 import { test, type Page, type BrowserContext } from '@playwright/test'
 import { mockGitHub } from './lib/github-mocks.js'
 import { mockProjects } from './lib/project-mocks.js'
+import { mockProviderHealth } from './lib/provider-mocks.js'
+import { mockReviewComments } from './lib/review-mocks.js'
 import { copyFile, mkdir } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
@@ -66,8 +68,9 @@ for (const theme of ['light', 'dark'] as const) {
   test.describe(theme, () => {
     test.use({ colorScheme: theme, viewport: { width: 1920, height: 1080 } })
 
-    test.beforeEach(async ({ context }) => {
+    test.beforeEach(async ({ context, page }) => {
       await applyTheme(context, theme)
+      await mockProviderHealth(page)
     })
 
     // ─── Dashboard ───────────────────────────────────────────────────────────
@@ -156,6 +159,16 @@ for (const theme of ['light', 'dark'] as const) {
       // Wait for the plan content and action bar to render
       await page.getByRole('button', { name: 'Approve' }).waitFor({ timeout: 5_000 })
       await shot(page, theme, 'reviews-plan-selected')
+    })
+
+    test('reviews-plan-with-comment', async ({ page }) => {
+      await mockReviewComments(page)
+      await goToReviews(page)
+      await page.getByText('Refactor logging system').click()
+      await page.getByRole('button', { name: 'Approve' }).waitFor({ timeout: 5_000 })
+      // Wait for the seeded comment to render inline under its line
+      await page.getByText('Should we also migrate the middleware package?').waitFor({ timeout: 5_000 })
+      await shot(page, theme, 'reviews-plan-with-comment')
     })
 
     // ─── Chats ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Motivation

Screenshots were noisy and the sync PR was churn-prone:

- Every generated screenshot could capture a red "claude/codex unavailable — probe_error" banner because the CI env has no CLI binaries and the provider health probe fires ~1s after server start, racing with page mount.
- The sybra-website sync step opened a fresh PR per sybra SHA (`screenshots/sync-<sha>`), so the review queue accumulated dozens of near-duplicate PRs.
- Even when regenerated PNGs were byte-identical to the open PR, a new commit was pushed because the diff check ran against `main` instead of the PR branch.

## Implementation information

- `frontend/e2e/lib/provider-mocks.ts` — intercepts `GetProviderHealth` / `ProviderHealthEnabled` with healthy fixtures. Applied via `beforeEach` in every theme.
- `frontend/e2e/lib/review-mocks.ts` — intercepts `ListReviewComments` and seeds two inline comments for `plan0001` (lines 7 and 11).
- `frontend/e2e/screenshots.spec.ts` — new `reviews-plan-with-comment` test in both light + dark captures the plan with inline reviewer comments rendered.
- `.github/workflows/screenshots.yml`:
  - Stable branch `screenshots/sync` (no more per-SHA branches).
  - Checks out the PR branch first, copies screenshots on top, then diffs — so identical regenerations no-op.
  - `rm -rf public/screenshots` before copy so deleted files propagate.
  - `gh pr edit` if a PR already exists, else `gh pr create`.

## Supporting documentation

Follow-up to #511.