### PR TITLE
fix(ui): unclip bgops popup, right-align bar

### DIFF
--- a/frontend/src/components/BgOpsIndicator.svelte
+++ b/frontend/src/components/BgOpsIndicator.svelte
@@ -23,7 +23,7 @@
 </script>
 
 {#if bgopStore.ops.length > 0}
-  <div class="relative">
+  <div>
     <button
       type="button"
       class="relative flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-sm hover:bg-surface-700 transition-colors"
@@ -51,7 +51,7 @@
         tabindex="-1"
       ></button>
 
-      <div class="absolute right-0 top-full z-50 mt-1 w-72 rounded-xl border border-surface-600 bg-surface-800 shadow-xl">
+      <div class="fixed right-4 top-14 z-50 w-80 max-w-[calc(100vw-2rem)] rounded-xl border border-surface-600 bg-surface-800 shadow-xl">
         <div class="flex items-center justify-between border-b border-surface-700 px-3 py-2">
           <span class="text-xs font-medium text-surface-300">Background operations</span>
           <button

--- a/frontend/src/components/shell/AppShell.svelte
+++ b/frontend/src/components/shell/AppShell.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import type { Snippet } from 'svelte'
-  import { AppBar } from '@skeletonlabs/skeleton-svelte'
   import { viewport } from '../../lib/viewport.svelte.js'
   import { navStore } from '../../lib/navigation.svelte.js'
   import SideRail from './SideRail.svelte'
@@ -41,25 +40,21 @@
 
   <div class="flex min-w-0 flex-1 flex-col overflow-hidden">
     {#if viewport.isDesktop}
-      <AppBar>
-        <AppBar.Toolbar>
-          <AppBar.Lead>
-            <h2 class="text-lg font-semibold">{navStore.pageTitle}</h2>
-          </AppBar.Lead>
-          <AppBar.Trail>
-            <BgOpsIndicator />
-            {#if primaryAction}
-              <button
-                type="button"
-                class="rounded-lg bg-primary-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-600"
-                onclick={primaryAction.run}
-              >
-                + {primaryAction.label}
-              </button>
-            {/if}
-          </AppBar.Trail>
-        </AppBar.Toolbar>
-      </AppBar>
+      <header class="flex shrink-0 items-center justify-between gap-4 border-b border-surface-700 bg-surface-900 px-4 py-3">
+        <h2 class="text-lg font-semibold">{navStore.pageTitle}</h2>
+        <div class="flex items-center gap-2">
+          <BgOpsIndicator />
+          {#if primaryAction}
+            <button
+              type="button"
+              class="rounded-lg bg-primary-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-600"
+              onclick={primaryAction.run}
+            >
+              + {primaryAction.label}
+            </button>
+          {/if}
+        </div>
+      </header>
     {:else}
       <MobileAppBar {onsearch} {primaryAction} />
     {/if}


### PR DESCRIPTION
## Motivation

Background-ops popup in the desktop AppBar appeared as a tiny vertical sliver near the page title instead of a full-width panel. Two stacked bugs:

1. Skeleton `AppBar.Toolbar` grid collapsed to a single ~154px column, so `AppBar.Trail` (bgops dot + New Task button) rendered flush-left next to `AppBar.Lead` instead of on the right.
2. `BgOpsIndicator` popup anchored `absolute right-0 top-full w-72` to a button-width wrapper. With Trail mis-positioned near x=130 in a 1400px viewport, the popup rendered at x=-164 → only ~20px visible.

Confirmed via chrome-devtools MCP against https://sybra.mskalski.dev/: button at x=130, popup at `left=-294px right=0 width=324px`, computed grid-template-columns `154.039px`.

## Implementation information

- `frontend/src/components/shell/AppShell.svelte`: dropped Skeleton `AppBar`/`AppBar.Toolbar`/`Lead`/`Trail` in favor of a plain `<header class="flex ... justify-between">`. Removes the broken grid layout entirely — simpler, no Skeleton version dependency.
- `frontend/src/components/BgOpsIndicator.svelte`: popup switched from `absolute right-0 top-full w-72` to `fixed right-4 top-14 w-80 max-w-[calc(100vw-2rem)]`. Decouples popup position from its button wrapper and clamps width to viewport so it can't overflow on narrow windows. Dropped `.relative` on the outer div since it's no longer needed.

Alternatives considered and discarded:
- Patching the Skeleton AppBar via `classes` overrides — fragile, depends on internal grid semantics.
- Portal the popup to `document.body` — heavier, not needed once `fixed` positioning is used.

Quality gates: `npm run check` clean, `oxlint` clean, `vitest` 274/275 (one pre-existing flaky ChatView test, unrelated — passes in isolation), `npm run build` ok.

## Supporting documentation

n/a

> Changelog: fix(ui): unclip bgops popup, right-align bar