### PR TITLE
fix(workflow): skip critique on replan iterations

### DIFF
--- a/internal/workflow/builtin/simple-task.yaml
+++ b/internal/workflow/builtin/simple-task.yaml
@@ -94,8 +94,12 @@ steps:
     next:
       - goto: maybe_critique
 
-  # Branch around critique_plan when the task is tagged `nocritic`.
-  # Substring match on the comma-joined tag list (see workflow/condition.go).
+  # Branch around critique_plan when the task is tagged `nocritic`, and also
+  # on replan iterations after a human reject — the plan has already been
+  # critiqued and addressed once; re-critiquing each revision just burns
+  # tokens and delays the human review loop. `vars.step.review_plan.output`
+  # only exists after the wait_human step has produced a verdict, which is
+  # the reliable marker for "this is a replan, not the first pass".
   - id: maybe_critique
     name: Critique Decision
     type: condition
@@ -105,6 +109,10 @@ steps:
         operator: not_contains
         value: nocritic
     next:
+      - when:
+          field: vars.step.review_plan.output
+          operator: exists
+        goto: review_plan
       - when:
           field: task.tags
           operator: not_contains

--- a/internal/workflow/builtin/testing-task.yaml
+++ b/internal/workflow/builtin/testing-task.yaml
@@ -44,6 +44,11 @@ steps:
     next:
       - goto: maybe_critique_test
 
+  # Skip critique on replan iterations (after a human reject) — the plan has
+  # already been critiqued once; re-critiquing each revision just burns tokens.
+  # `vars.step.review_test_plan.output` only exists after wait_human produced
+  # a verdict, which is the reliable marker for "this is a replan, not the
+  # first pass".
   - id: maybe_critique_test
     name: Test Critique Decision
     type: condition
@@ -53,6 +58,10 @@ steps:
         operator: not_contains
         value: nocritic
     next:
+      - when:
+          field: vars.step.review_test_plan.output
+          operator: exists
+        goto: review_test_plan
       - when:
           field: task.tags
           operator: not_contains

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -1,6 +1,141 @@
 package workflow
 
-import "testing"
+import (
+	"testing"
+)
+
+// TestBuiltinSimpleTask_MaybeCritiqueReplanSkip locks the behavior that
+// critique_plan runs only on the first plan pass. On replan (after a human
+// reject), `vars.step.review_plan.output` exists, so maybe_critique must
+// route directly to review_plan and spare the critic a second run on a
+// plan the human already eyeballed once. Substring-checking tag "nocritic"
+// is still honored as an opt-out on the first pass.
+func TestBuiltinSimpleTask_MaybeCritiqueReplanSkip(t *testing.T) {
+	t.Parallel()
+
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var simple *Definition
+	for i := range defs {
+		if defs[i].ID == "simple-task" {
+			simple = &defs[i]
+			break
+		}
+	}
+	if simple == nil {
+		t.Fatal("simple-task builtin definition not found")
+	}
+	step := simple.StepByID("maybe_critique")
+	if step == nil {
+		t.Fatal("maybe_critique step not found in simple-task")
+	}
+
+	cases := []struct {
+		name   string
+		fields map[string]string
+		want   string
+	}{
+		{
+			name: "first_pass_runs_critique",
+			fields: map[string]string{
+				"task.tags": "backend,feature",
+			},
+			want: "critique_plan",
+		},
+		{
+			name: "nocritic_tag_skips_critique",
+			fields: map[string]string{
+				"task.tags": "backend,nocritic",
+			},
+			want: "review_plan",
+		},
+		{
+			name: "replan_skips_critique_even_without_nocritic",
+			fields: map[string]string{
+				"task.tags":                    "backend,feature",
+				"vars.step.review_plan.output": "reject",
+				"vars.human_action":            "reject",
+			},
+			want: "review_plan",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveTransition(step.Next, tc.fields)
+			if err != nil {
+				t.Fatalf("ResolveTransition: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("goto = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuiltinTestingTask_MaybeCritiqueReplanSkip is the testing-task
+// mirror of the simple-task replan-skip guarantee above.
+func TestBuiltinTestingTask_MaybeCritiqueReplanSkip(t *testing.T) {
+	t.Parallel()
+
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var testing_ *Definition
+	for i := range defs {
+		if defs[i].ID == "testing-task" {
+			testing_ = &defs[i]
+			break
+		}
+	}
+	if testing_ == nil {
+		t.Fatal("testing-task builtin definition not found")
+	}
+	step := testing_.StepByID("maybe_critique_test")
+	if step == nil {
+		t.Fatal("maybe_critique_test step not found in testing-task")
+	}
+
+	cases := []struct {
+		name   string
+		fields map[string]string
+		want   string
+	}{
+		{
+			name:   "first_pass_runs_critique",
+			fields: map[string]string{"task.tags": "testing"},
+			want:   "critique_test_plan",
+		},
+		{
+			name:   "nocritic_tag_skips_critique",
+			fields: map[string]string{"task.tags": "testing,nocritic"},
+			want:   "review_test_plan",
+		},
+		{
+			name: "replan_skips_critique_even_without_nocritic",
+			fields: map[string]string{
+				"task.tags":                         "testing",
+				"vars.step.review_test_plan.output": "reject",
+			},
+			want: "review_test_plan",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveTransition(step.Next, tc.fields)
+			if err != nil {
+				t.Fatalf("ResolveTransition: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("goto = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
 
 func TestBuiltinDefinitions(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Motivation

Plan critique ran on every plan iteration, including replans triggered by
human reject. Wasted critic turn on a plan the human already looked at,
and delayed the human review loop. Surfaced on task `eeeb2252` on synapse:
user tried to approve plan after reject+revise, got `task X is not at a
wait_human step` because workflow was sitting in the second critique pass
while the UI showed `plan-review` (status set by prior plan iteration).

## Implementation information

- `maybe_critique` (and `maybe_critique_test`) now route straight to the
  review step when `vars.step.review_plan.output` exists. That var is set
  only after the wait_human step produces a verdict, so it's a reliable
  "this is a replan, not the first pass" marker.
- First-pass behavior unchanged: `critique_plan` still runs between plan
  and review_plan on the initial iteration.
- `nocritic` tag opt-out still honored on first pass.
- Tests added in `builtin_test.go` table-driven against `ResolveTransition`
  on the builtin definitions — locks first-pass, nocritic, and replan-skip
  paths for both simple-task and testing-task.

Alternatives considered:
- Tracking a dedicated `critique_done` var via a hypothetical `set_var`
  step type — rejected, no such step exists and adding one for a single
  callsite is overkill.
- Using `vars.step.critique_plan.output` exists — rejected, that var is
  often empty since critique_plan doesn't produce step output.

## Supporting documentation

None.

> Changelog: fix(workflow): skip critique on replan iterations