### PR TITLE
fix(skills): codex interop + prevent dir poisoning

### DIFF
--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -456,7 +456,8 @@ func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args []strin
 		if a.sessionCWD != "" {
 			args = append(args, "-C", a.sessionCWD)
 		}
-		args = append(args, cfg.Prompt)
+		prompt := rewriteSkillInvocations(cfg.Prompt, discoverCodexSkills())
+		args = append(args, prompt)
 		command = "codex " + strings.Join(args, " ")
 		return
 	}

--- a/internal/agent/skill_invoke.go
+++ b/internal/agent/skill_invoke.go
@@ -1,0 +1,67 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// rewriteSkillInvocations converts Claude-style `/skill-name` invocations
+// into Codex-style `$skill-name` invocations for prompts routed to codex.
+// Only exact matches against the given skill names are rewritten, and the
+// invocation must be preceded by start-of-line or a non-word, non-`/`
+// character, and followed by a non-identifier char or end — so path
+// segments like `/tmp/synapse-plan-xxx.md` are never touched.
+func rewriteSkillInvocations(prompt string, skillNames []string) string {
+	if len(skillNames) == 0 || prompt == "" {
+		return prompt
+	}
+	// Sort descending by length so longer names are tried first (avoids a
+	// shorter prefix like "plan" consuming part of "plan-critic").
+	sorted := make([]string, len(skillNames))
+	copy(sorted, skillNames)
+	sort.Slice(sorted, func(i, j int) bool { return len(sorted[i]) > len(sorted[j]) })
+	for _, name := range sorted {
+		if name == "" {
+			continue
+		}
+		pattern := `(^|[^\w/])/` + regexp.QuoteMeta(name) + `([^a-z0-9-]|$)`
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			continue
+		}
+		prompt = re.ReplaceAllString(prompt, "${1}$$"+name+"${2}")
+	}
+	return prompt
+}
+
+// discoverCodexSkills returns the list of skill names installed under
+// ~/.codex/skills/. A skill name is a direct subdir containing a SKILL.md
+// file. Returns nil on any error — the caller treats that as "no rewrite".
+func discoverCodexSkills() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	return listSkillDirs(filepath.Join(home, ".codex", "skills"))
+}
+
+func listSkillDirs(root string) []string {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(root, e.Name(), "SKILL.md")); err != nil {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	return names
+}

--- a/internal/agent/skill_invoke_test.go
+++ b/internal/agent/skill_invoke_test.go
@@ -1,0 +1,114 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRewriteSkillInvocations(t *testing.T) {
+	t.Parallel()
+	skills := []string{"plan-critic", "synapse-triage", "synapse-plan", "staff-code-review"}
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "leading slash invocation",
+			in:   "/plan-critic /tmp/synapse-plan-abc.md",
+			want: "$plan-critic /tmp/synapse-plan-abc.md",
+		},
+		{
+			name: "mid-sentence invocation",
+			in:   "Triage task 123 using /synapse-triage skill.",
+			want: "Triage task 123 using $synapse-triage skill.",
+		},
+		{
+			name: "multiple invocations",
+			in:   "Run /staff-code-review then /plan-critic to finish.",
+			want: "Run $staff-code-review then $plan-critic to finish.",
+		},
+		{
+			name: "path must not be rewritten",
+			in:   "Save to /tmp/synapse-plan-xxx.md and read /home/user/synapse-triage/log",
+			want: "Save to /tmp/synapse-plan-xxx.md and read /home/user/synapse-triage/log",
+		},
+		{
+			name: "unknown slash command left alone",
+			in:   "Run /unknown-skill now",
+			want: "Run /unknown-skill now",
+		},
+		{
+			name: "trailing punctuation",
+			in:   "Invoke: /plan-critic.",
+			want: "Invoke: $plan-critic.",
+		},
+		{
+			name: "empty prompt",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "no skill names leaves prompt untouched",
+			in:   "/plan-critic here",
+			want: "/plan-critic here",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			names := skills
+			if tt.name == "no skill names leaves prompt untouched" {
+				names = nil
+			}
+			got := rewriteSkillInvocations(tt.in, names)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestListSkillDirs(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	// Valid skill dir.
+	validDir := filepath.Join(root, "plan-critic")
+	if err := os.MkdirAll(validDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(validDir, "SKILL.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Dir without SKILL.md (skipped).
+	if err := os.MkdirAll(filepath.Join(root, "no-skill-md"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Hidden dir (skipped).
+	hidden := filepath.Join(root, ".system")
+	if err := os.MkdirAll(hidden, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hidden, "SKILL.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Plain file (skipped).
+	if err := os.WriteFile(filepath.Join(root, "foo.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := listSkillDirs(root)
+	if len(got) != 1 || got[0] != "plan-critic" {
+		t.Errorf("got %v, want [plan-critic]", got)
+	}
+}
+
+func TestListSkillDirsMissingRoot(t *testing.T) {
+	t.Parallel()
+	got := listSkillDirs("/nonexistent/path/for/skills")
+	if got != nil {
+		t.Errorf("got %v, want nil for missing root", got)
+	}
+}

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -1246,32 +1246,10 @@ func (a *App) syncDir(src, dst string) {
 			continue
 		}
 		if e.IsDir() {
-			srcSkillDir := filepath.Join(filepath.Clean(src), e.Name())
-			srcSKILL := filepath.Join(srcSkillDir, "SKILL.md")
-			data, err := os.ReadFile(srcSKILL)
-			if err != nil {
-				continue
+			if a.copySkillDir(src, dst, cleanSrc, cleanDst, e.Name(), "sync") {
+				a.logger.Info("sync.copied", "dir", e.Name())
+				srcDirs[e.Name()] = struct{}{}
 			}
-			if !hasYAMLFrontmatter(data) {
-				a.logger.Warn("sync.skip.invalid", "name", e.Name(), "reason", "missing YAML frontmatter")
-				continue
-			}
-			dstSkillDir := filepath.Join(filepath.Clean(dst), e.Name())
-			if !strings.HasPrefix(srcSkillDir+string(filepath.Separator), cleanSrc) ||
-				!strings.HasPrefix(dstSkillDir+string(filepath.Separator), cleanDst) {
-				a.logger.Warn("sync.skip.traversal", "name", e.Name())
-				continue
-			}
-			if err := os.RemoveAll(dstSkillDir); err != nil {
-				a.logger.Warn("sync.clean.fail", "name", e.Name(), "err", err)
-				continue
-			}
-			if err := copyDirTree(srcSkillDir, dstSkillDir); err != nil {
-				a.logger.Error("sync.copy.tree", "name", e.Name(), "err", err)
-				continue
-			}
-			a.logger.Info("sync.copied", "dir", e.Name())
-			srcDirs[e.Name()] = struct{}{}
 			continue
 		}
 		if filepath.Ext(e.Name()) != ".md" {
@@ -1435,25 +1413,38 @@ func hasYAMLFrontmatter(data []byte) bool {
 	return strings.HasPrefix(trimmed, "---\n") || strings.HasPrefix(trimmed, "---\r\n")
 }
 
-// copyDirTree recursively copies src into dst. Symlinks are skipped to
-// prevent escape from the destination root.
+// copyDirTree recursively copies src into dst. Uses os.Root to confine
+// reads to the source subtree, preventing symlink TOCTOU escape.
 func copyDirTree(src, dst string) error {
-	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+	srcRoot, err := os.OpenRoot(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = srcRoot.Close() }()
+
+	rootFS := srcRoot.FS()
+	return fs.WalkDir(rootFS, ".", func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == "." {
+			return os.MkdirAll(dst, 0o755)
+		}
+		info, err := d.Info()
 		if err != nil {
 			return err
 		}
-		rel, err := filepath.Rel(src, path)
-		if err != nil {
-			return err
-		}
-		target := filepath.Join(dst, rel)
 		if info.Mode()&os.ModeSymlink != 0 {
 			return nil
 		}
-		if info.IsDir() {
+		target := filepath.Join(dst, path)
+		if d.IsDir() {
 			return os.MkdirAll(target, 0o755)
 		}
-		data, err := os.ReadFile(path)
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		data, err := fs.ReadFile(rootFS, path)
 		if err != nil {
 			return err
 		}
@@ -1462,6 +1453,37 @@ func copyDirTree(src, dst string) error {
 		}
 		return os.WriteFile(target, data, 0o644)
 	})
+}
+
+// copySkillDir validates and recursively copies a directory-style skill
+// (src/<name>/SKILL.md + siblings) to dst/<name>/. Returns true if the copy
+// succeeded. Missing/malformed SKILL.md and traversal/IO errors are logged
+// and return false.
+func (a *App) copySkillDir(src, dst, cleanSrc, cleanDst, name, logPrefix string) bool {
+	srcSkillDir := filepath.Join(filepath.Clean(src), name)
+	data, err := os.ReadFile(filepath.Join(srcSkillDir, "SKILL.md"))
+	if err != nil {
+		return false
+	}
+	if !hasYAMLFrontmatter(data) {
+		a.logger.Warn(logPrefix+".skip.invalid", "name", name, "reason", "missing YAML frontmatter")
+		return false
+	}
+	dstSkillDir := filepath.Join(filepath.Clean(dst), name)
+	if !strings.HasPrefix(srcSkillDir+string(filepath.Separator), cleanSrc) ||
+		!strings.HasPrefix(dstSkillDir+string(filepath.Separator), cleanDst) {
+		a.logger.Warn(logPrefix+".skip.traversal", "name", name)
+		return false
+	}
+	if err := os.RemoveAll(dstSkillDir); err != nil {
+		a.logger.Warn(logPrefix+".clean.fail", "name", name, "err", err)
+		return false
+	}
+	if err := copyDirTree(srcSkillDir, dstSkillDir); err != nil {
+		a.logger.Error(logPrefix+".copy.tree", "name", name, "err", err)
+		return false
+	}
+	return true
 }
 
 // syncToCodexDir reads flat .md skill files from src and writes each one as
@@ -1486,32 +1508,10 @@ func (a *App) syncToCodexDir(src, dst string) {
 			continue
 		}
 		if e.IsDir() {
-			srcSkillDir := filepath.Join(filepath.Clean(src), e.Name())
-			srcSKILL := filepath.Join(srcSkillDir, "SKILL.md")
-			data, err := os.ReadFile(srcSKILL)
-			if err != nil {
-				continue
+			if a.copySkillDir(src, dst, cleanSrc, cleanDst, e.Name(), "sync.codex") {
+				a.logger.Info("sync.codex.copied", "skill", e.Name())
+				srcNames[e.Name()] = struct{}{}
 			}
-			if !hasYAMLFrontmatter(data) {
-				a.logger.Warn("sync.codex.skip.invalid", "name", e.Name(), "reason", "missing YAML frontmatter")
-				continue
-			}
-			dstSkillDir := filepath.Join(filepath.Clean(dst), e.Name())
-			if !strings.HasPrefix(srcSkillDir+string(filepath.Separator), cleanSrc) ||
-				!strings.HasPrefix(dstSkillDir+string(filepath.Separator), cleanDst) {
-				a.logger.Warn("sync.codex.skip.traversal", "name", e.Name())
-				continue
-			}
-			if err := os.RemoveAll(dstSkillDir); err != nil {
-				a.logger.Warn("sync.codex.clean.fail", "name", e.Name(), "err", err)
-				continue
-			}
-			if err := copyDirTree(srcSkillDir, dstSkillDir); err != nil {
-				a.logger.Error("sync.codex.copy.tree", "name", e.Name(), "err", err)
-				continue
-			}
-			a.logger.Info("sync.codex.copied", "skill", e.Name())
-			srcNames[e.Name()] = struct{}{}
 			continue
 		}
 		if filepath.Ext(e.Name()) != ".md" {

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -1184,17 +1184,24 @@ func (a *App) syncSkills() {
 
 	skillsSrc := filepath.Join(repoDir, ".claude", "skills")
 
-	// When the filesystem source doesn't exist (e.g. Docker deployments where
-	// the repo is absent), fall back to the embedded bundle so skills are
-	// always available in ~/.claude/skills/ and ~/.codex/skills/.
-	if _, err := os.Stat(skillsSrc); os.IsNotExist(err) && a.skillsFS != nil {
-		a.logger.Info("skills.sync.embedded_fallback", "dst", a.skillsDir)
+	// Prefer the embedded bundle whenever repoDir is not the sybra source
+	// repo. Detected by absence of go.mod. In Docker the cwd fallback resolves
+	// to the user home — treating its ~/.claude/skills/ as source is unsafe:
+	// a single rogue file there can wipe every skill via orphan cleanup.
+	useEmbedded := a.skillsFS != nil
+	if useEmbedded {
+		if _, err := os.Stat(filepath.Join(repoDir, "go.mod")); err == nil {
+			useEmbedded = false
+		}
+	}
+
+	if useEmbedded {
+		a.logger.Info("skills.sync.embedded", "dst", a.skillsDir)
 		a.syncFSDir(a.skillsFS, "data", a.skillsDir)
 		if userHome, err2 := os.UserHomeDir(); err2 == nil {
 			a.syncFSDir(a.skillsFS, "data", filepath.Join(userHome, ".claude", "skills"))
 			a.syncFSToCodexDir(a.skillsFS, "data", filepath.Join(userHome, ".codex", "skills"))
 		}
-		// orchestrator CLAUDE.md is not in the embedded bundle; skip it.
 		a.logger.Info("skills.sync.done")
 		return
 	}
@@ -1232,41 +1239,101 @@ func (a *App) syncDir(src, dst string) {
 	cleanDst := filepath.Clean(dst) + string(filepath.Separator)
 
 	srcNames := make(map[string]struct{}, len(entries))
+	srcDirs := make(map[string]struct{}, len(entries))
 	for _, e := range entries {
-		if e.IsDir() || filepath.Ext(e.Name()) != ".md" {
-			continue
-		}
-		// Reject symlinks — they could point outside the destination directory.
 		if e.Type()&fs.ModeSymlink != 0 {
 			a.logger.Debug("sync.skip.symlink", "name", e.Name())
 			continue
 		}
+		if e.IsDir() {
+			srcSkillDir := filepath.Join(filepath.Clean(src), e.Name())
+			srcSKILL := filepath.Join(srcSkillDir, "SKILL.md")
+			data, err := os.ReadFile(srcSKILL)
+			if err != nil {
+				continue
+			}
+			if !hasYAMLFrontmatter(data) {
+				a.logger.Warn("sync.skip.invalid", "name", e.Name(), "reason", "missing YAML frontmatter")
+				continue
+			}
+			dstSkillDir := filepath.Join(filepath.Clean(dst), e.Name())
+			if !strings.HasPrefix(srcSkillDir+string(filepath.Separator), cleanSrc) ||
+				!strings.HasPrefix(dstSkillDir+string(filepath.Separator), cleanDst) {
+				a.logger.Warn("sync.skip.traversal", "name", e.Name())
+				continue
+			}
+			if err := os.RemoveAll(dstSkillDir); err != nil {
+				a.logger.Warn("sync.clean.fail", "name", e.Name(), "err", err)
+				continue
+			}
+			if err := copyDirTree(srcSkillDir, dstSkillDir); err != nil {
+				a.logger.Error("sync.copy.tree", "name", e.Name(), "err", err)
+				continue
+			}
+			a.logger.Info("sync.copied", "dir", e.Name())
+			srcDirs[e.Name()] = struct{}{}
+			continue
+		}
+		if filepath.Ext(e.Name()) != ".md" {
+			continue
+		}
 		srcPath := filepath.Join(filepath.Clean(src), e.Name())
 		dstPath := filepath.Join(filepath.Clean(dst), e.Name())
-		// Canonicalize and guard against crafted entry names escaping the roots.
 		if !strings.HasPrefix(srcPath+string(filepath.Separator), cleanSrc) ||
 			!strings.HasPrefix(dstPath+string(filepath.Separator), cleanDst) {
 			a.logger.Warn("sync.skip.traversal", "name", e.Name())
 			continue
 		}
-		a.syncFile(srcPath, dstPath)
+		data, err := os.ReadFile(srcPath)
+		if err != nil {
+			a.logger.Warn("sync.read.fail", "name", e.Name(), "err", err)
+			continue
+		}
+		if !hasYAMLFrontmatter(data) {
+			a.logger.Warn("sync.skip.invalid", "name", e.Name(), "reason", "missing YAML frontmatter")
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
+			a.logger.Error("sync.mkdir", "dst", dstPath, "err", err)
+			continue
+		}
+		if err := os.WriteFile(dstPath, data, 0o644); err != nil {
+			a.logger.Error("sync.write", "dst", dstPath, "err", err)
+			continue
+		}
+		a.logger.Info("sync.copied", "file", e.Name())
 		srcNames[e.Name()] = struct{}{}
 	}
 
-	// Remove orphan .md files in dst that no longer exist in src.
+	// Remove orphan .md files and directory skills in dst.
 	dstEntries, err := os.ReadDir(dst)
 	if err != nil {
 		return
 	}
 	for _, e := range dstEntries {
-		if e.IsDir() || filepath.Ext(e.Name()) != ".md" {
+		dstPath := filepath.Join(filepath.Clean(dst), e.Name())
+		if !strings.HasPrefix(dstPath+string(filepath.Separator), cleanDst) {
+			continue
+		}
+		if e.IsDir() {
+			if _, ok := srcDirs[e.Name()]; ok {
+				continue
+			}
+			// Only remove orphan dirs that look like skill dirs (have SKILL.md).
+			if _, statErr := os.Stat(filepath.Join(dstPath, "SKILL.md")); statErr != nil {
+				continue
+			}
+			if err := os.RemoveAll(dstPath); err != nil {
+				a.logger.Warn("sync.orphan.remove.fail", "dir", e.Name(), "err", err)
+			} else {
+				a.logger.Info("sync.orphan.removed", "dir", e.Name())
+			}
+			continue
+		}
+		if filepath.Ext(e.Name()) != ".md" {
 			continue
 		}
 		if _, ok := srcNames[e.Name()]; ok {
-			continue
-		}
-		dstPath := filepath.Join(filepath.Clean(dst), e.Name())
-		if !strings.HasPrefix(dstPath+string(filepath.Separator), cleanDst) {
 			continue
 		}
 		if err := os.Remove(dstPath); err != nil {
@@ -1323,6 +1390,10 @@ func (a *App) syncFSDir(fsys fs.FS, srcDir, dst string) {
 			a.logger.Warn("sync.fs.read.fail", "name", e.Name(), "err", err)
 			continue
 		}
+		if !hasYAMLFrontmatter(data) {
+			a.logger.Warn("sync.skip.invalid", "name", e.Name(), "reason", "missing YAML frontmatter")
+			continue
+		}
 		if err := os.WriteFile(dstPath, data, 0o644); err != nil {
 			a.logger.Error("sync.write", "dst", dstPath, "err", err)
 			continue
@@ -1355,6 +1426,44 @@ func (a *App) syncFSDir(fsys fs.FS, srcDir, dst string) {
 	}
 }
 
+// hasYAMLFrontmatter reports whether data begins with a YAML frontmatter
+// block delimited by ---. Skills without frontmatter are rejected by Codex
+// (and unusable by Claude Code), so we skip copying them to avoid poisoning
+// the destination.
+func hasYAMLFrontmatter(data []byte) bool {
+	trimmed := strings.TrimLeft(string(data), " \t\r\n\ufeff")
+	return strings.HasPrefix(trimmed, "---\n") || strings.HasPrefix(trimmed, "---\r\n")
+}
+
+// copyDirTree recursively copies src into dst. Symlinks are skipped to
+// prevent escape from the destination root.
+func copyDirTree(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+		if info.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o644)
+	})
+}
+
 // syncToCodexDir reads flat .md skill files from src and writes each one as
 // dst/<name>/SKILL.md — the subdirectory layout expected by the Codex CLI.
 // Orphan skill subdirs (present in dst but absent from src) are removed.
@@ -1373,10 +1482,39 @@ func (a *App) syncToCodexDir(src, dst string) {
 
 	srcNames := make(map[string]struct{}, len(entries))
 	for _, e := range entries {
-		if e.IsDir() || filepath.Ext(e.Name()) != ".md" {
+		if e.Type()&fs.ModeSymlink != 0 {
 			continue
 		}
-		if e.Type()&fs.ModeSymlink != 0 {
+		if e.IsDir() {
+			srcSkillDir := filepath.Join(filepath.Clean(src), e.Name())
+			srcSKILL := filepath.Join(srcSkillDir, "SKILL.md")
+			data, err := os.ReadFile(srcSKILL)
+			if err != nil {
+				continue
+			}
+			if !hasYAMLFrontmatter(data) {
+				a.logger.Warn("sync.codex.skip.invalid", "name", e.Name(), "reason", "missing YAML frontmatter")
+				continue
+			}
+			dstSkillDir := filepath.Join(filepath.Clean(dst), e.Name())
+			if !strings.HasPrefix(srcSkillDir+string(filepath.Separator), cleanSrc) ||
+				!strings.HasPrefix(dstSkillDir+string(filepath.Separator), cleanDst) {
+				a.logger.Warn("sync.codex.skip.traversal", "name", e.Name())
+				continue
+			}
+			if err := os.RemoveAll(dstSkillDir); err != nil {
+				a.logger.Warn("sync.codex.clean.fail", "name", e.Name(), "err", err)
+				continue
+			}
+			if err := copyDirTree(srcSkillDir, dstSkillDir); err != nil {
+				a.logger.Error("sync.codex.copy.tree", "name", e.Name(), "err", err)
+				continue
+			}
+			a.logger.Info("sync.codex.copied", "skill", e.Name())
+			srcNames[e.Name()] = struct{}{}
+			continue
+		}
+		if filepath.Ext(e.Name()) != ".md" {
 			continue
 		}
 		srcPath := filepath.Join(filepath.Clean(src), e.Name())
@@ -1394,6 +1532,10 @@ func (a *App) syncToCodexDir(src, dst string) {
 		data, err := os.ReadFile(srcPath)
 		if err != nil {
 			a.logger.Warn("sync.codex.read.fail", "name", e.Name(), "err", err)
+			continue
+		}
+		if !hasYAMLFrontmatter(data) {
+			a.logger.Warn("sync.codex.skip.invalid", "name", e.Name(), "reason", "missing YAML frontmatter")
 			continue
 		}
 		if err := os.MkdirAll(skillDir, 0o755); err != nil {
@@ -1464,6 +1606,10 @@ func (a *App) syncFSToCodexDir(fsys fs.FS, srcDir, dst string) {
 		data, err := fs.ReadFile(fsys, srcDir+"/"+e.Name())
 		if err != nil {
 			a.logger.Warn("sync.codex.fs.read.fail", "name", e.Name(), "err", err)
+			continue
+		}
+		if !hasYAMLFrontmatter(data) {
+			a.logger.Warn("sync.codex.skip.invalid", "name", e.Name(), "reason", "missing YAML frontmatter")
 			continue
 		}
 		if err := os.MkdirAll(skillDir, 0o755); err != nil {

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -409,12 +409,21 @@ func TestSyncDir(t *testing.T) {
 	if err := os.MkdirAll(srcDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	for _, name := range []string{"a.md", "b.md", "c.txt"} {
-		if err := os.WriteFile(filepath.Join(srcDir, name), []byte("content-"+name), 0o644); err != nil {
+	frontmatter := func(name string) []byte {
+		return []byte("---\nname: " + name + "\ndescription: test\n---\n\n# " + name)
+	}
+	for _, name := range []string{"a.md", "b.md"} {
+		if err := os.WriteFile(filepath.Join(srcDir, name), frontmatter(name), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
-	// Add a subdirectory that should be skipped
+	// Non-.md, subdir, and a malformed .md without frontmatter must all be skipped.
+	if err := os.WriteFile(filepath.Join(srcDir, "c.txt"), []byte("content-c"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "no-frontmatter.md"), []byte("# nope"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.MkdirAll(filepath.Join(srcDir, "subdir"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -422,13 +431,12 @@ func TestSyncDir(t *testing.T) {
 	dstDir := filepath.Join(t.TempDir(), "dst-skills")
 	a.syncDir(srcDir, dstDir)
 
-	// Only .md files should be copied
 	entries, err := os.ReadDir(dstDir)
 	if err != nil {
 		t.Fatalf("read dst: %v", err)
 	}
 	if len(entries) != 2 {
-		t.Errorf("got %d files, want 2 (.md only)", len(entries))
+		t.Errorf("got %d files, want 2 (only valid .md with frontmatter)", len(entries))
 	}
 }
 
@@ -439,7 +447,8 @@ func TestSyncDirRemovesOrphans(t *testing.T) {
 	if err := os.MkdirAll(srcDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(srcDir, "keep.md"), []byte("# keep"), 0o644); err != nil {
+	keep := []byte("---\nname: keep\ndescription: test\n---\n\n# keep")
+	if err := os.WriteFile(filepath.Join(srcDir, "keep.md"), keep, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -448,7 +457,7 @@ func TestSyncDirRemovesOrphans(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Pre-populate orphan file that should be removed.
-	if err := os.WriteFile(filepath.Join(dstDir, "orphan.md"), []byte("# orphan"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dstDir, "orphan.md"), []byte("---\nname: orphan\ndescription: test\n---\n\n# orphan"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -463,6 +472,212 @@ func TestSyncDirRemovesOrphans(t *testing.T) {
 	}
 	if entries[0].Name() != "keep.md" {
 		t.Errorf("expected keep.md, got %s", entries[0].Name())
+	}
+}
+
+func TestSyncDirCopiesDirectoryStyleSkill(t *testing.T) {
+	a := setupApp(t)
+
+	srcDir := filepath.Join(t.TempDir(), "skills")
+	skillDir := filepath.Join(srcDir, "plan-critic")
+	refDir := filepath.Join(skillDir, "references")
+	if err := os.MkdirAll(refDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	skillMD := []byte("---\nname: plan-critic\ndescription: test\n---\n\n# plan-critic")
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), skillMD, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(refDir, "checklist.md"), []byte("# checklist"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Malformed directory skill (no frontmatter) must be skipped.
+	badDir := filepath.Join(srcDir, "bad-skill")
+	if err := os.MkdirAll(badDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(badDir, "SKILL.md"), []byte("# no frontmatter"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dstDir := filepath.Join(t.TempDir(), "dst-skills")
+	a.syncDir(srcDir, dstDir)
+
+	if _, err := os.Stat(filepath.Join(dstDir, "plan-critic", "SKILL.md")); err != nil {
+		t.Errorf("SKILL.md missing at dst: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dstDir, "plan-critic", "references", "checklist.md")); err != nil {
+		t.Errorf("nested reference missing at dst: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dstDir, "bad-skill")); !os.IsNotExist(err) {
+		t.Errorf("bad skill dir should not be copied: stat err=%v", err)
+	}
+}
+
+func TestSyncDirRemovesOrphanSkillDir(t *testing.T) {
+	a := setupApp(t)
+
+	srcDir := filepath.Join(t.TempDir(), "skills")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dstDir := filepath.Join(t.TempDir(), "dst-skills")
+	orphan := filepath.Join(dstDir, "orphan-skill")
+	if err := os.MkdirAll(orphan, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(orphan, "SKILL.md"), []byte("---\nname: orphan\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A non-skill dir (no SKILL.md) must be preserved.
+	keepDir := filepath.Join(dstDir, "not-a-skill")
+	if err := os.MkdirAll(keepDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(keepDir, "hello.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a.syncDir(srcDir, dstDir)
+
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Errorf("orphan skill dir should be removed: stat err=%v", err)
+	}
+	if _, err := os.Stat(keepDir); err != nil {
+		t.Errorf("non-skill dir should be preserved: %v", err)
+	}
+}
+
+func TestSyncToCodexDirDirectoryStyleAndFrontmatter(t *testing.T) {
+	a := setupApp(t)
+
+	srcDir := filepath.Join(t.TempDir(), "skills")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Valid flat skill.
+	flat := []byte("---\nname: good-flat\ndescription: t\n---\n\n# flat")
+	if err := os.WriteFile(filepath.Join(srcDir, "good-flat.md"), flat, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Malformed flat skill — must NOT overwrite a valid dst skill of same name.
+	if err := os.WriteFile(filepath.Join(srcDir, "bad-flat.md"), []byte("# no-fm"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Valid directory-style skill.
+	dirSkill := filepath.Join(srcDir, "good-dir")
+	if err := os.MkdirAll(dirSkill, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dirMD := []byte("---\nname: good-dir\ndescription: t\n---\n\n# dir")
+	if err := os.WriteFile(filepath.Join(dirSkill, "SKILL.md"), dirMD, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dstDir := filepath.Join(t.TempDir(), "codex-skills")
+	// Pre-populate a valid bad-flat entry in the dst to verify it survives.
+	preExisting := filepath.Join(dstDir, "bad-flat")
+	if err := os.MkdirAll(preExisting, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	preExistingContent := []byte("---\nname: bad-flat\ndescription: valid\n---\n\n# valid")
+	if err := os.WriteFile(filepath.Join(preExisting, "SKILL.md"), preExistingContent, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a.syncToCodexDir(srcDir, dstDir)
+
+	if _, err := os.Stat(filepath.Join(dstDir, "good-flat", "SKILL.md")); err != nil {
+		t.Errorf("good-flat not written: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dstDir, "good-dir", "SKILL.md")); err != nil {
+		t.Errorf("good-dir not written: %v", err)
+	}
+	// bad-flat must be treated as orphan (invalid src) and removed, OR preserved
+	// unchanged. The key invariant: dst must not contain the malformed payload.
+	got, err := os.ReadFile(filepath.Join(dstDir, "bad-flat", "SKILL.md"))
+	if err == nil && string(got) == "# no-fm" {
+		t.Errorf("malformed skill overwrote valid dst: %q", got)
+	}
+}
+
+func TestSyncSkillsPrefersEmbeddedWhenNoGoMod(t *testing.T) {
+	a := setupApp(t)
+	// Use in-memory FS stand-in: point skillsFS at a real testdata dir.
+	embeddedSrc := filepath.Join(t.TempDir(), "embedded")
+	dataDir := filepath.Join(embeddedSrc, "data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	embedded := []byte("---\nname: embedded-skill\ndescription: from embed\n---\n\n# embed")
+	if err := os.WriteFile(filepath.Join(dataDir, "embedded-skill.md"), embedded, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a.skillsFS = os.DirFS(embeddedSrc)
+
+	// repoDir with a skills dir but NO go.mod — simulates container where
+	// cwd=/home/sybra. The embedded bundle must take precedence even though
+	// the skills dir already exists with a rogue file.
+	repoDir := t.TempDir()
+	a.repoDir = repoDir
+	skillsSrc := filepath.Join(repoDir, ".claude", "skills")
+	if err := os.MkdirAll(skillsSrc, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillsSrc, "rogue.md"), []byte("# no-fm"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a.skillsDir = filepath.Join(t.TempDir(), "app-skills")
+
+	a.syncSkills()
+
+	// Embedded content should be present in a.skillsDir (not rogue).
+	if _, err := os.Stat(filepath.Join(a.skillsDir, "embedded-skill.md")); err != nil {
+		t.Errorf("embedded skill missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(a.skillsDir, "rogue.md")); !os.IsNotExist(err) {
+		t.Errorf("rogue skill leaked into app skills dir")
+	}
+}
+
+func TestSyncSkillsUsesRepoSourceWhenGoModPresent(t *testing.T) {
+	a := setupApp(t)
+
+	repoDir := t.TempDir()
+	a.repoDir = repoDir
+	// Marker that this is the actual sybra source repo.
+	if err := os.WriteFile(filepath.Join(repoDir, "go.mod"), []byte("module x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skillsSrc := filepath.Join(repoDir, ".claude", "skills")
+	if err := os.MkdirAll(skillsSrc, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	repoSkill := []byte("---\nname: repo-skill\ndescription: t\n---\n")
+	if err := os.WriteFile(filepath.Join(skillsSrc, "repo-skill.md"), repoSkill, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Even with an embedded FS available, go.mod presence selects repo source.
+	embeddedSrc := filepath.Join(t.TempDir(), "embedded")
+	dataDir := filepath.Join(embeddedSrc, "data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "embed-only.md"), []byte("---\nname: embed-only\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	a.skillsFS = os.DirFS(embeddedSrc)
+	a.skillsDir = filepath.Join(t.TempDir(), "app-skills")
+
+	a.syncSkills()
+
+	if _, err := os.Stat(filepath.Join(a.skillsDir, "repo-skill.md")); err != nil {
+		t.Errorf("repo skill missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(a.skillsDir, "embed-only.md")); !os.IsNotExist(err) {
+		t.Errorf("embedded skill should not be written in repo-source mode")
 	}
 }
 
@@ -494,7 +709,8 @@ func TestSyncSkillsWithRepoDir(t *testing.T) {
 	if err := os.MkdirAll(skillsSrc, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(skillsSrc, "skill.md"), []byte("# skill"), 0o644); err != nil {
+	skillContent := []byte("---\nname: skill\ndescription: test\n---\n\n# skill")
+	if err := os.WriteFile(filepath.Join(skillsSrc, "skill.md"), skillContent, 0o644); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
## Motivation

On synapse, plan-critic runs via codex silently produced no critique sidecar. Root cause was a poisoned skill sync: something wrote a bogus `~/.claude/skills/skill.md` (just `# skill`, no frontmatter) into the container's user home. On next sybra restart `syncSkills` treated that dir as canonical (because `cwd=/home/sybra` has no `go.mod` check), orphan-cleaned all valid `synapse-*` codex skills, and wrote `~/.codex/skills/skill/SKILL.md` containing the garbage. Every subsequent codex startup failed with `missing YAML frontmatter delimited by ---` and dropped to 0-output.

Separately, `plan-critic` (directory-style skill) never synced to codex at all — `syncToCodexDir` only processed flat `.md` files. And workflow prompts hardcode Claude's `/skill-name` invocation syntax, which codex does not recognize.

## Implementation information

- **Prefer embedded bundle when not in source repo**: `syncSkills` now uses the embedded skills FS unless `repoDir/go.mod` exists. Stops user-home paths from being treated as sybra source.
- **YAML frontmatter validation**: `hasYAMLFrontmatter` guard added to all four sync paths (`syncDir`, `syncFSDir`, `syncToCodexDir`, `syncFSToCodexDir`). Malformed `.md` files get skipped and logged rather than overwriting valid destinations.
- **Directory-style skills**: `syncDir` and `syncToCodexDir` now recursively copy `<name>/SKILL.md` directory skills via new `copyDirTree` helper. Fixes `plan-critic` not being available to codex.
- **Provider-aware skill invocation**: new `rewriteSkillInvocations` in `internal/agent/skill_invoke.go` converts `/skill-name` -> `$skill-name` for codex-routed prompts. Uses exact-match against skill names actually installed at `~/.codex/skills/`, with strict regex boundaries so path segments like `/tmp/synapse-plan-xxx.md` are never touched.

Server state (synapse LXC) was manually repaired by removing the poisoned dirs and restarting the container so the embedded bundle re-seeded correctly.

Alternatives considered: always prefer embedded bundle regardless of go.mod (rejected — breaks local dev workflow where repo `.claude/skills/` should be authoritative); regex-only rewrite without a skill allowlist (rejected — too easy to clobber path segments).

## Supporting documentation

No ADR. Issue observed as empty critique sidecars on plan-critic steps running via codex on synapse.

> Changelog: fix(skills): codex interop + prevent dir poisoning