### PR TITLE
feat(layout): context-aware agent session view

### DIFF
--- a/frontend/src/components/ChatView.svelte
+++ b/frontend/src/components/ChatView.svelte
@@ -14,10 +14,11 @@
     outputTokens?: number
     bounded?: boolean
     highlightIndex?: number | null
+    suppressApprovals?: boolean
     onvisibleindex?: (index: number) => void
   }
 
-  const { agentId, agentState = 'running', costUsd = 0, inputTokens = 0, outputTokens = 0, bounded = false, highlightIndex = null, onvisibleindex }: Props = $props()
+  const { agentId, agentState = 'running', costUsd = 0, inputTokens = 0, outputTokens = 0, bounded = false, highlightIndex = null, suppressApprovals = false, onvisibleindex }: Props = $props()
 
   let events = $state<agent.ConvoEvent[]>([])
   let container: HTMLDivElement | undefined = $state()
@@ -169,15 +170,17 @@
       {/each}
     {/if}
 
-    <!-- Pending approvals -->
-    {#each approvals as approval (approval.toolUseId)}
-      <ToolApproval
-        toolUseId={approval.toolUseId}
-        toolName={approval.toolName}
-        input={approval.input}
-        onrespond={handleApproval}
-      />
-    {/each}
+    <!-- Pending approvals (suppressed when hoisted by BlockedLayout) -->
+    {#if !suppressApprovals}
+      {#each approvals as approval (approval.toolUseId)}
+        <ToolApproval
+          toolUseId={approval.toolUseId}
+          toolName={approval.toolName}
+          input={approval.input}
+          onrespond={handleApproval}
+        />
+      {/each}
+    {/if}
 
     <!-- Streaming indicator -->
     {#if isRunning && events.length > 0}

--- a/frontend/src/components/agent-view/AgentHeader.svelte
+++ b/frontend/src/components/agent-view/AgentHeader.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+  import type { agent } from '../../../wailsjs/go/models.js'
+  import type { task } from '../../../wailsjs/go/models.js'
+  import type { PhaseConfig, AgentPhase } from '$lib/agent-phases.js'
+
+  interface Props {
+    a: agent.Agent
+    phase: AgentPhase
+    phaseConfig: PhaseConfig
+    stepText?: string
+    linkedTask?: task.Task | null
+    onstop: () => void
+    onviewtask: (taskId: string) => void
+  }
+
+  const { a, phase, phaseConfig, stepText, linkedTask, onstop, onviewtask }: Props = $props()
+
+  const isRunning = $derived(a.state === 'running')
+
+  function formatDate(date: any): string {
+    if (!date) return '-'
+    return new Date(date).toLocaleString()
+  }
+</script>
+
+<div class="flex flex-col gap-6">
+  <div class="flex items-start justify-between gap-4">
+    <div>
+      <h1 class="text-2xl font-bold">{a.project || a.id}</h1>
+      {#if a.name}
+        <span class="text-sm text-surface-400">{a.name}</span>
+      {/if}
+      {#if phase === 'running'}
+        <p class="mt-0.5 text-sm italic text-surface-400">
+          {stepText ?? 'Working...'}
+        </p>
+      {:else if phase === 'waiting'}
+        <p class="mt-0.5 text-sm text-surface-400">Waiting for reply</p>
+      {:else if phase === 'blocked'}
+        <p class="mt-0.5 text-sm text-tertiary-600 dark:text-tertiary-400">
+          Awaiting tool approval
+        </p>
+      {:else if phase === 'human-required'}
+        <p class="mt-0.5 text-sm font-medium text-error-600 dark:text-error-400">
+          Waiting for human input
+        </p>
+      {:else if phase === 'reviewing'}
+        <p class="mt-0.5 text-sm text-warning-600 dark:text-warning-400">
+          Under review
+        </p>
+      {/if}
+    </div>
+    <div class="flex items-center gap-2">
+      <span class="inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-medium {phaseConfig.badgeClasses}">
+        {#if phaseConfig.animate}
+          <span class="h-2 w-2 animate-pulse-subtle rounded-full {phaseConfig.dotClasses}"></span>
+        {:else if phase !== 'queued' && phase !== 'done'}
+          <span class="h-2 w-2 rounded-full {phaseConfig.dotClasses}"></span>
+        {/if}
+        {phaseConfig.label}
+      </span>
+      {#if isRunning}
+        <button
+          type="button"
+          class="rounded-lg bg-error-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-error-600"
+          onclick={onstop}
+        >
+          Stop
+        </button>
+      {/if}
+    </div>
+  </div>
+
+  <div class="flex flex-wrap gap-6 text-sm">
+    {#if a.taskId}
+      <div class="flex flex-col gap-1">
+        <span class="font-medium text-surface-500">Task</span>
+        <button
+          type="button"
+          class="text-left text-primary-500 hover:underline"
+          onclick={() => onviewtask(a.taskId)}
+        >
+          {linkedTask?.title ?? a.taskId}
+        </button>
+      </div>
+    {/if}
+    {#if linkedTask?.branch}
+      <div class="flex flex-col gap-1">
+        <span class="font-medium text-surface-500">Branch</span>
+        <span class="rounded bg-surface-200 px-2 py-0.5 font-mono text-xs dark:bg-surface-700">{linkedTask.branch}</span>
+      </div>
+    {/if}
+    <div class="flex flex-col gap-1">
+      <span class="font-medium text-surface-500">Mode</span>
+      <span class="rounded bg-surface-200 px-2 py-0.5 dark:bg-surface-700">{a.mode}</span>
+    </div>
+    {#if a.project}
+      <div class="flex flex-col gap-1">
+        <span class="font-medium text-surface-500">Project</span>
+        <span class="rounded bg-surface-200 px-2 py-0.5 dark:bg-surface-700">{a.project}</span>
+      </div>
+    {/if}
+    {#if a.name}
+      <div class="flex flex-col gap-1">
+        <span class="font-medium text-surface-500">Session Name</span>
+        <span class="rounded bg-surface-200 px-2 py-0.5 dark:bg-surface-700">{a.name}</span>
+      </div>
+    {/if}
+    {#if a.external}
+      <div class="flex flex-col gap-1">
+        <span class="font-medium text-surface-500">Source</span>
+        <span class="rounded bg-warning-200 px-2 py-0.5 text-warning-800 dark:bg-warning-700 dark:text-warning-200">external</span>
+      </div>
+    {/if}
+    {#if a.pid}
+      <div class="flex flex-col gap-1">
+        <span class="font-medium text-surface-500">PID</span>
+        <span class="rounded bg-surface-200 px-2 py-0.5 font-mono text-xs dark:bg-surface-700">{a.pid}</span>
+      </div>
+    {/if}
+    {#if a.command}
+      <div class="flex flex-col gap-1">
+        <span class="font-medium text-surface-500">Command</span>
+        <span class="max-w-md truncate rounded bg-surface-200 px-2 py-0.5 font-mono text-xs dark:bg-surface-700">{a.command}</span>
+      </div>
+    {/if}
+    {#if a.sessionId}
+      <div class="flex flex-col gap-1">
+        <span class="font-medium text-surface-500">Session</span>
+        <span class="rounded bg-surface-200 px-2 py-0.5 font-mono text-xs dark:bg-surface-700">{a.sessionId}</span>
+      </div>
+    {/if}
+    {#if a.costUsd > 0}
+      <div class="flex flex-col gap-1">
+        <span class="font-medium text-surface-500">Cost</span>
+        <span class="rounded bg-surface-200 px-2 py-0.5 dark:bg-surface-700">${a.costUsd.toFixed(2)}</span>
+      </div>
+    {/if}
+    <div class="flex flex-col gap-1">
+      <span class="font-medium text-surface-500">Started</span>
+      <span>{formatDate(a.startedAt)}</span>
+    </div>
+  </div>
+</div>

--- a/frontend/src/components/agent-view/AgentViewBody.svelte
+++ b/frontend/src/components/agent-view/AgentViewBody.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  import { fade } from 'svelte/transition'
+  import type { agent } from '../../../wailsjs/go/models.js'
+  import type { task } from '../../../wailsjs/go/models.js'
+  import type { AgentPhase } from '$lib/agent-phases.js'
+  import type { TimestampedStreamEvent, TimelineEntry } from '$lib/timeline.js'
+  import type { PlanStep } from '$lib/plan-steps.js'
+  import QueuedLayout from './QueuedLayout.svelte'
+  import RunningLayout from './RunningLayout.svelte'
+  import BlockedLayout from './BlockedLayout.svelte'
+  import HumanRequiredLayout from './HumanRequiredLayout.svelte'
+  import ReviewingLayout from './ReviewingLayout.svelte'
+  import DoneLayout from './DoneLayout.svelte'
+
+  interface Props {
+    phase: AgentPhase
+    a: agent.Agent
+    linkedTask?: task.Task | null
+    streamOutputs: TimestampedStreamEvent[]
+    convoEvents: agent.ConvoEvent[]
+    timelineEntries: TimelineEntry[]
+    planSteps: PlanStep[]
+    selectedIndex: number | null
+    onselect: (i: number) => void
+  }
+
+  const {
+    phase,
+    a,
+    linkedTask,
+    streamOutputs,
+    convoEvents,
+    timelineEntries,
+    planSteps,
+    selectedIndex,
+    onselect,
+  }: Props = $props()
+</script>
+
+<div class="min-h-[60vh]">
+  {#key phase}
+    <div in:fade={{ duration: 180 }} out:fade={{ duration: 120 }}>
+      {#if phase === 'queued'}
+        <QueuedLayout {linkedTask} />
+      {:else if phase === 'running'}
+        <RunningLayout
+          {a}
+          {planSteps}
+          {timelineEntries}
+          {selectedIndex}
+          {onselect}
+        />
+      {:else if phase === 'blocked'}
+        <BlockedLayout
+          {a}
+          {planSteps}
+          {timelineEntries}
+          {selectedIndex}
+          {onselect}
+        />
+      {:else if phase === 'waiting' || phase === 'human-required'}
+        <HumanRequiredLayout
+          {a}
+          urgency={phase === 'human-required' ? 'required' : 'waiting'}
+          {planSteps}
+          {timelineEntries}
+          {selectedIndex}
+          {onselect}
+        />
+      {:else if phase === 'reviewing'}
+        <ReviewingLayout {a} {linkedTask} {streamOutputs} {convoEvents} />
+      {:else}
+        <DoneLayout {a} {linkedTask} {streamOutputs} {convoEvents} />
+      {/if}
+    </div>
+  {/key}
+</div>

--- a/frontend/src/components/agent-view/BlockedLayout.svelte
+++ b/frontend/src/components/agent-view/BlockedLayout.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+  import { fly } from 'svelte/transition'
+  import { ChevronDown, ChevronUp, PanelLeft } from '@lucide/svelte'
+  import type { agent } from '../../../wailsjs/go/models.js'
+  import type { TimelineEntry } from '$lib/timeline.js'
+  import type { PlanStep } from '$lib/plan-steps.js'
+  import { convoStore } from '../../stores/convo.svelte.js'
+  import ToolApproval from '../ToolApproval.svelte'
+  import ChatView from '../ChatView.svelte'
+  import StreamOutput from '../StreamOutput.svelte'
+  import ActionTimeline from '../ActionTimeline.svelte'
+  import PlanSteps from '../PlanSteps.svelte'
+
+  interface Props {
+    a: agent.Agent
+    planSteps: PlanStep[]
+    timelineEntries: TimelineEntry[]
+    selectedIndex: number | null
+    onselect: (i: number) => void
+  }
+
+  const { a, planSteps, timelineEntries, selectedIndex, onselect }: Props = $props()
+
+  let historyOpen = $state(false)
+  let timelineOpen = $state(true)
+  let planCollapsed = $state(false)
+
+  const approvals = $derived([...convoStore.pendingApprovals.values()])
+
+  async function handleApproval(toolUseId: string, approved: boolean) {
+    await convoStore.respondApproval(toolUseId, approved)
+  }
+</script>
+
+<div class="flex flex-col gap-4">
+  {#if planSteps.length > 0}
+    <PlanSteps steps={planSteps} bind:collapsed={planCollapsed} />
+  {/if}
+
+  <!-- Hoisted approval cards — full width, prominent -->
+  {#if approvals.length > 0}
+    <div in:fly={{ y: 8, duration: 150 }} class="flex flex-col gap-3">
+      <div class="flex items-center gap-2">
+        <span class="rounded-full bg-tertiary-200 px-3 py-1 text-xs font-semibold text-tertiary-800 dark:bg-tertiary-700 dark:text-tertiary-200">
+          Needs your response
+        </span>
+        <span class="text-xs text-surface-500">{approvals.length} pending {approvals.length === 1 ? 'approval' : 'approvals'}</span>
+      </div>
+      {#each approvals as approval (approval.toolUseId)}
+        <ToolApproval
+          toolUseId={approval.toolUseId}
+          toolName={approval.toolName}
+          input={approval.input}
+          onrespond={handleApproval}
+        />
+      {/each}
+    </div>
+  {:else}
+    <p class="text-sm text-surface-400">Waiting for tool approval...</p>
+  {/if}
+
+  <!-- Chat history — collapsed by default when blocked -->
+  <div>
+    <button
+      type="button"
+      class="flex items-center gap-1.5 text-sm text-surface-500 hover:text-surface-700 dark:hover:text-surface-300"
+      onclick={() => { historyOpen = !historyOpen }}
+    >
+      {#if historyOpen}
+        <ChevronUp size={16} />
+      {:else}
+        <ChevronDown size={16} />
+      {/if}
+      {historyOpen ? 'Hide' : 'Show'} conversation history
+    </button>
+
+    {#if historyOpen}
+      <div class="mt-3 flex min-h-0 items-start gap-3 opacity-75" in:fly={{ y: 4, duration: 120 }}>
+        {#if timelineOpen}
+          <div class="hidden w-64 shrink-0 overflow-hidden rounded-lg border border-surface-300 dark:border-surface-700 md:flex md:flex-col" style="max-height: 600px; min-height: 300px;">
+            <ActionTimeline
+              entries={timelineEntries}
+              activeIndex={selectedIndex}
+              onselect={(i) => { onselect(i) }}
+            />
+          </div>
+        {/if}
+        <div class="min-w-0 flex-1">
+          {#if a.mode === 'interactive'}
+            <ChatView
+              agentId={a.id}
+              agentState={a.state}
+              costUsd={a.costUsd}
+              inputTokens={a.inputTokens ?? 0}
+              outputTokens={a.outputTokens ?? 0}
+              highlightIndex={selectedIndex}
+              suppressApprovals={true}
+              onvisibleindex={(i) => { if (selectedIndex === null) onselect(i) }}
+            />
+          {:else}
+            <StreamOutput
+              agentId={a.id}
+              highlightIndex={selectedIndex}
+              onvisibleindex={(i) => { if (selectedIndex === null) onselect(i) }}
+            />
+          {/if}
+        </div>
+      </div>
+    {/if}
+  </div>
+</div>

--- a/frontend/src/components/agent-view/DoneLayout.svelte
+++ b/frontend/src/components/agent-view/DoneLayout.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+  import { fly } from 'svelte/transition'
+  import { FileEdit, Terminal, GitBranch, GitPullRequest, Clock, DollarSign, ChevronDown, ChevronUp } from '@lucide/svelte'
+  import type { agent } from '../../../wailsjs/go/models.js'
+  import type { task } from '../../../wailsjs/go/models.js'
+  import type { TimestampedStreamEvent } from '$lib/timeline.js'
+  import { summarizeAgent } from '$lib/agent-summary.js'
+  import StreamOutput from '../StreamOutput.svelte'
+  import ChatView from '../ChatView.svelte'
+
+  interface Props {
+    a: agent.Agent
+    linkedTask?: task.Task | null
+    streamOutputs: TimestampedStreamEvent[]
+    convoEvents: agent.ConvoEvent[]
+  }
+
+  const { a, linkedTask, streamOutputs, convoEvents }: Props = $props()
+
+  let activityOpen = $state(false)
+
+  const summary = $derived(summarizeAgent(streamOutputs, convoEvents))
+
+  function formatDuration(start: any, end: any): string {
+    if (!start) return '—'
+    const s = new Date(start).getTime()
+    const e = end ? new Date(end).getTime() : Date.now()
+    const diff = Math.round((e - s) / 1000)
+    if (diff < 60) return `${diff}s`
+    const m = Math.floor(diff / 60)
+    const rem = diff % 60
+    return rem > 0 ? `${m}m ${rem}s` : `${m}m`
+  }
+</script>
+
+<div class="flex flex-col gap-4">
+  <div in:fly={{ y: 8, duration: 150 }} class="rounded-xl border border-success-300 bg-success-50 p-6 dark:border-success-700 dark:bg-success-950/40">
+    <div class="mb-4 flex items-center gap-3">
+      <span class="rounded-full bg-success-200 px-3 py-1 text-sm font-semibold text-success-800 dark:bg-success-800 dark:text-success-200">
+        Done
+      </span>
+      {#if summary.finalMessage}
+        <p class="min-w-0 flex-1 truncate text-sm text-surface-700 dark:text-surface-300" title={summary.finalMessage}>
+          {summary.finalMessage}
+        </p>
+      {/if}
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4">
+      <div class="flex items-center gap-2">
+        <Clock size={16} class="shrink-0 text-surface-400" />
+        <div>
+          <p class="text-xs text-surface-500">Duration</p>
+          <p class="text-sm font-medium">{formatDuration(a.startedAt, a.lastEventAt)}</p>
+        </div>
+      </div>
+
+      {#if a.costUsd > 0}
+        <div class="flex items-center gap-2">
+          <DollarSign size={16} class="shrink-0 text-surface-400" />
+          <div>
+            <p class="text-xs text-surface-500">Cost</p>
+            <p class="text-sm font-medium">${a.costUsd.toFixed(3)}</p>
+          </div>
+        </div>
+      {/if}
+
+      {#if a.turnCount && a.turnCount > 0}
+        <div class="flex flex-col">
+          <p class="text-xs text-surface-500">Turns</p>
+          <p class="text-sm font-medium">{a.turnCount}</p>
+        </div>
+      {/if}
+
+      {#if summary.filesEdited.length > 0}
+        <div class="flex items-center gap-2">
+          <FileEdit size={16} class="shrink-0 text-surface-400" />
+          <div>
+            <p class="text-xs text-surface-500">Files edited</p>
+            <p class="text-sm font-medium">{summary.filesEdited.length}</p>
+          </div>
+        </div>
+      {/if}
+
+      {#if summary.commandsRun > 0}
+        <div class="flex items-center gap-2">
+          <Terminal size={16} class="shrink-0 text-surface-400" />
+          <div>
+            <p class="text-xs text-surface-500">Commands run</p>
+            <p class="text-sm font-medium">{summary.commandsRun}</p>
+          </div>
+        </div>
+      {/if}
+
+      {#if linkedTask?.branch}
+        <div class="flex items-center gap-2">
+          <GitBranch size={16} class="shrink-0 text-surface-400" />
+          <div>
+            <p class="text-xs text-surface-500">Branch</p>
+            <p class="truncate font-mono text-xs font-medium">{linkedTask.branch}</p>
+          </div>
+        </div>
+      {/if}
+
+      {#if (linkedTask?.prNumber ?? 0) > 0}
+        <div class="flex items-center gap-2">
+          <GitPullRequest size={16} class="shrink-0 text-surface-400" />
+          <div>
+            <p class="text-xs text-surface-500">PR</p>
+            <p class="text-sm font-medium">#{linkedTask?.prNumber}</p>
+          </div>
+        </div>
+      {/if}
+    </div>
+
+    {#if summary.filesEdited.length > 0}
+      <div class="mt-4">
+        <p class="mb-1.5 text-xs font-medium text-surface-500">Files changed</p>
+        <ul class="flex flex-wrap gap-1.5">
+          {#each summary.filesEdited as f}
+            <li class="rounded bg-surface-200 px-2 py-0.5 font-mono text-xs dark:bg-surface-700">{f}</li>
+          {/each}
+        </ul>
+      </div>
+    {:else}
+      <p class="mt-4 text-sm text-surface-400">Agent completed without modifying files.</p>
+    {/if}
+  </div>
+
+  <div>
+    <button
+      type="button"
+      class="flex items-center gap-1.5 text-sm text-surface-500 hover:text-surface-700 dark:hover:text-surface-300"
+      onclick={() => { activityOpen = !activityOpen }}
+    >
+      {#if activityOpen}
+        <ChevronUp size={16} />
+      {:else}
+        <ChevronDown size={16} />
+      {/if}
+      {activityOpen ? 'Hide activity' : 'Show full activity'}
+    </button>
+
+    {#if activityOpen}
+      <div class="mt-3" in:fly={{ y: 4, duration: 120 }}>
+        {#if a.mode === 'interactive'}
+          <ChatView agentId={a.id} agentState={a.state} costUsd={a.costUsd} inputTokens={a.inputTokens ?? 0} outputTokens={a.outputTokens ?? 0} />
+        {:else}
+          <StreamOutput agentId={a.id} />
+        {/if}
+      </div>
+    {/if}
+  </div>
+</div>

--- a/frontend/src/components/agent-view/HumanRequiredLayout.svelte
+++ b/frontend/src/components/agent-view/HumanRequiredLayout.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+  import { fly } from 'svelte/transition'
+  import { ChevronDown, ChevronUp, PanelLeft } from '@lucide/svelte'
+  import type { agent } from '../../../wailsjs/go/models.js'
+  import type { TimelineEntry } from '$lib/timeline.js'
+  import type { PlanStep } from '$lib/plan-steps.js'
+  import { convoStore } from '../../stores/convo.svelte.js'
+  import ChatView from '../ChatView.svelte'
+  import StreamOutput from '../StreamOutput.svelte'
+  import ActionTimeline from '../ActionTimeline.svelte'
+  import PlanSteps from '../PlanSteps.svelte'
+  import ChatInput from '../ChatInput.svelte'
+
+  interface Props {
+    a: agent.Agent
+    urgency: 'waiting' | 'required'
+    planSteps: PlanStep[]
+    timelineEntries: TimelineEntry[]
+    selectedIndex: number | null
+    onselect: (i: number) => void
+  }
+
+  const { a, urgency, planSteps, timelineEntries, selectedIndex, onselect }: Props = $props()
+
+  let historyOpen = $state(false)
+  let timelineOpen = $state(true)
+  let planCollapsed = $state(false)
+
+  const isUrgent = $derived(urgency === 'required')
+  const escalationReason = $derived(a.escalationReason)
+
+  async function handleSend(text: string) {
+    await convoStore.sendMessage(a.id, text)
+  }
+</script>
+
+<div class="flex flex-col gap-4">
+  {#if planSteps.length > 0}
+    <PlanSteps steps={planSteps} bind:collapsed={planCollapsed} />
+  {/if}
+
+  <!-- Escalation / waiting banner -->
+  <div
+    in:fly={{ y: 8, duration: 150 }}
+    class="rounded-xl border-2 p-5
+      {isUrgent
+        ? 'border-error-400 bg-error-50 dark:border-error-600 dark:bg-error-950/40'
+        : 'border-surface-300 bg-surface-50 dark:border-surface-600 dark:bg-surface-900'}"
+  >
+    <div class="mb-4 flex items-center gap-2">
+      {#if isUrgent}
+        <span class="rounded-full bg-error-200 px-3 py-1 text-xs font-semibold text-error-800 dark:bg-error-700 dark:text-error-200">
+          Needs your input
+        </span>
+        {#if escalationReason}
+          <span class="text-sm text-surface-700 dark:text-surface-300">
+            {escalationReason === 'turns' ? 'Turn limit reached' : 'Cost limit reached'} — agent is paused
+          </span>
+        {:else}
+          <span class="text-sm text-surface-700 dark:text-surface-300">Agent is waiting for your response</span>
+        {/if}
+      {:else}
+        <span class="rounded-full bg-surface-200 px-3 py-1 text-xs font-medium text-surface-600 dark:bg-surface-700 dark:text-surface-400">
+          Waiting for reply
+        </span>
+        <span class="text-sm text-surface-500">Agent has paused and is waiting for your input</span>
+      {/if}
+    </div>
+
+    <!-- Centered reply form -->
+    <ChatInput
+      placeholder={isUrgent ? 'What should the agent do next?' : 'Type a message...'}
+      onsend={handleSend}
+    />
+  </div>
+
+  <!-- Conversation history toggle -->
+  <div>
+    <button
+      type="button"
+      class="flex items-center gap-1.5 text-sm text-surface-500 hover:text-surface-700 dark:hover:text-surface-300"
+      onclick={() => { historyOpen = !historyOpen }}
+    >
+      {#if historyOpen}
+        <ChevronUp size={16} />
+      {:else}
+        <ChevronDown size={16} />
+      {/if}
+      {historyOpen ? 'Hide' : 'Show'} recent activity
+    </button>
+
+    {#if historyOpen}
+      <div class="mt-3 flex min-h-0 items-start gap-3 opacity-80" in:fly={{ y: 4, duration: 120 }}>
+        {#if timelineOpen}
+          <div class="hidden w-64 shrink-0 overflow-hidden rounded-lg border border-surface-300 dark:border-surface-700 md:flex md:flex-col" style="max-height: 600px; min-height: 300px;">
+            <ActionTimeline
+              entries={timelineEntries}
+              activeIndex={selectedIndex}
+              onselect={(i) => { onselect(i) }}
+            />
+          </div>
+        {/if}
+        <div class="min-w-0 flex-1">
+          {#if a.mode === 'interactive'}
+            <ChatView
+              agentId={a.id}
+              agentState={a.state}
+              costUsd={a.costUsd}
+              inputTokens={a.inputTokens ?? 0}
+              outputTokens={a.outputTokens ?? 0}
+              highlightIndex={selectedIndex}
+              onvisibleindex={(i) => { if (selectedIndex === null) onselect(i) }}
+            />
+          {:else}
+            <StreamOutput
+              agentId={a.id}
+              highlightIndex={selectedIndex}
+              onvisibleindex={(i) => { if (selectedIndex === null) onselect(i) }}
+            />
+          {/if}
+        </div>
+      </div>
+    {/if}
+  </div>
+</div>

--- a/frontend/src/components/agent-view/QueuedLayout.svelte
+++ b/frontend/src/components/agent-view/QueuedLayout.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { fly } from 'svelte/transition'
+  import type { task } from '../../../wailsjs/go/models.js'
+
+  interface Props {
+    linkedTask?: task.Task | null
+  }
+
+  const { linkedTask }: Props = $props()
+</script>
+
+<div class="flex flex-col gap-6" in:fly={{ y: 8, duration: 150 }}>
+  <div class="rounded-xl border border-surface-300 bg-surface-50 p-6 dark:border-surface-700 dark:bg-surface-900">
+    <div class="mb-4 flex items-center gap-3">
+      <span class="flex items-center gap-1.5 rounded-full bg-surface-200 px-3 py-1 text-sm font-medium text-surface-600 dark:bg-surface-700 dark:text-surface-300">
+        <span class="h-2 w-2 animate-pulse rounded-full bg-surface-400"></span>
+        Agent starting…
+      </span>
+    </div>
+
+    {#if linkedTask}
+      <div class="prose prose-sm max-w-none dark:prose-invert">
+        <h2 class="mb-2 text-lg font-semibold">{linkedTask.title}</h2>
+        {#if linkedTask.body}
+          <p class="whitespace-pre-wrap text-sm text-surface-700 dark:text-surface-300">{linkedTask.body}</p>
+        {:else}
+          <p class="text-sm text-surface-400">No description provided.</p>
+        {/if}
+      </div>
+    {:else}
+      <p class="text-sm text-surface-400">Agent hasn't started producing output yet.</p>
+    {/if}
+  </div>
+</div>

--- a/frontend/src/components/agent-view/ReviewingLayout.svelte
+++ b/frontend/src/components/agent-view/ReviewingLayout.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+  import { fly } from 'svelte/transition'
+  import { FolderOpen, GitBranch, GitPullRequest, ChevronDown, ChevronUp } from '@lucide/svelte'
+  import type { agent } from '../../../wailsjs/go/models.js'
+  import type { task } from '../../../wailsjs/go/models.js'
+  import type { TimestampedStreamEvent } from '$lib/timeline.js'
+  import { OpenWorktree } from '$lib/api.js'
+  import { summarizeAgent } from '$lib/agent-summary.js'
+  import StreamOutput from '../StreamOutput.svelte'
+  import ChatView from '../ChatView.svelte'
+
+  interface Props {
+    a: agent.Agent
+    linkedTask?: task.Task | null
+    streamOutputs: TimestampedStreamEvent[]
+    convoEvents: agent.ConvoEvent[]
+  }
+
+  const { a, linkedTask, streamOutputs, convoEvents }: Props = $props()
+
+  let activityOpen = $state(false)
+  let openError = $state('')
+
+  const summary = $derived(summarizeAgent(streamOutputs, convoEvents))
+
+  async function handleOpenWorktree() {
+    if (!linkedTask?.id) return
+    openError = ''
+    try {
+      await OpenWorktree(linkedTask.id)
+    } catch (e) {
+      openError = String(e)
+    }
+  }
+</script>
+
+<div class="flex flex-col gap-4">
+  <div in:fly={{ y: 8, duration: 150 }} class="rounded-xl border border-warning-300 bg-warning-50 p-6 dark:border-warning-700 dark:bg-warning-950/40">
+    <div class="mb-4 flex items-center gap-3">
+      <span class="rounded-full bg-warning-200 px-3 py-1 text-sm font-semibold text-warning-800 dark:bg-warning-800 dark:text-warning-200">
+        In Review
+      </span>
+      <p class="text-sm text-surface-600 dark:text-surface-300">
+        Agent has finished — review the output before merging
+      </p>
+    </div>
+
+    {#if summary.finalMessage}
+      <div class="mb-4 rounded-lg bg-surface-100 p-4 dark:bg-surface-800">
+        <p class="text-xs font-medium text-surface-500 mb-1">Final message</p>
+        <p class="text-sm text-surface-800 dark:text-surface-200 whitespace-pre-wrap">{summary.finalMessage}</p>
+      </div>
+    {/if}
+
+    <div class="flex flex-wrap items-center gap-3">
+      {#if linkedTask?.branch}
+        <div class="flex items-center gap-1.5 rounded-lg bg-surface-200 px-3 py-2 dark:bg-surface-700">
+          <GitBranch size={16} class="text-surface-500" />
+          <span class="font-mono text-sm">{linkedTask.branch}</span>
+        </div>
+      {/if}
+
+      {#if (linkedTask?.prNumber ?? 0) > 0}
+        <div class="flex items-center gap-1.5 rounded-lg bg-surface-200 px-3 py-2 dark:bg-surface-700">
+          <GitPullRequest size={16} class="text-surface-500" />
+          <span class="text-sm font-medium">PR #{linkedTask?.prNumber}</span>
+        </div>
+      {/if}
+
+      {#if linkedTask?.id}
+        <button
+          type="button"
+          class="flex items-center gap-1.5 rounded-lg bg-primary-600 px-3 py-2 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50"
+          onclick={handleOpenWorktree}
+        >
+          <FolderOpen size={16} />
+          Open worktree
+        </button>
+      {/if}
+    </div>
+
+    {#if !linkedTask?.branch && !linkedTask?.prNumber}
+      <p class="mt-4 text-sm text-surface-400">No branch or PR recorded — open the linked task for context.</p>
+    {/if}
+
+    {#if openError}
+      <p class="mt-2 text-xs text-error-500">{openError}</p>
+    {/if}
+  </div>
+
+  <div>
+    <button
+      type="button"
+      class="flex items-center gap-1.5 text-sm text-surface-500 hover:text-surface-700 dark:hover:text-surface-300"
+      onclick={() => { activityOpen = !activityOpen }}
+    >
+      {#if activityOpen}
+        <ChevronUp size={16} />
+      {:else}
+        <ChevronDown size={16} />
+      {/if}
+      {activityOpen ? 'Hide activity' : 'Show full activity'}
+    </button>
+
+    {#if activityOpen}
+      <div class="mt-3" in:fly={{ y: 4, duration: 120 }}>
+        {#if a.mode === 'interactive'}
+          <ChatView agentId={a.id} agentState={a.state} costUsd={a.costUsd} inputTokens={a.inputTokens ?? 0} outputTokens={a.outputTokens ?? 0} />
+        {:else}
+          <StreamOutput agentId={a.id} />
+        {/if}
+      </div>
+    {/if}
+  </div>
+</div>

--- a/frontend/src/components/agent-view/RunningLayout.svelte
+++ b/frontend/src/components/agent-view/RunningLayout.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  import { PanelLeft } from '@lucide/svelte'
+  import type { agent } from '../../../wailsjs/go/models.js'
+  import type { TimelineEntry } from '$lib/timeline.js'
+  import type { PlanStep } from '$lib/plan-steps.js'
+  import StreamOutput from '../StreamOutput.svelte'
+  import ChatView from '../ChatView.svelte'
+  import ActionTimeline from '../ActionTimeline.svelte'
+  import PlanSteps from '../PlanSteps.svelte'
+
+  interface Props {
+    a: agent.Agent
+    planSteps: PlanStep[]
+    timelineEntries: TimelineEntry[]
+    selectedIndex: number | null
+    onselect: (i: number) => void
+  }
+
+  const { a, planSteps, timelineEntries, selectedIndex, onselect }: Props = $props()
+
+  let timelineOpen = $state(true)
+  let planCollapsed = $state(false)
+</script>
+
+<div class="flex flex-col gap-4">
+  {#if planSteps.length > 0}
+    <PlanSteps steps={planSteps} bind:collapsed={planCollapsed} />
+  {/if}
+
+  <div class="flex min-h-0 flex-1 flex-col gap-2">
+    <div class="flex items-center gap-2">
+      <span class="text-sm font-medium text-surface-500">Output</span>
+      <button
+        type="button"
+        title={timelineOpen ? 'Hide timeline' : 'Show timeline'}
+        onclick={() => { timelineOpen = !timelineOpen }}
+        class="ml-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors
+          {timelineOpen
+            ? 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200'
+            : 'bg-surface-200 text-surface-500 dark:bg-surface-700 dark:text-surface-400'}"
+      >
+        <PanelLeft size={12} />
+        Timeline
+      </button>
+    </div>
+    <div class="flex min-h-0 items-start gap-3">
+      {#if timelineOpen}
+        <div class="hidden w-64 shrink-0 overflow-hidden rounded-lg border border-surface-300 dark:border-surface-700 md:flex md:flex-col" style="max-height: 600px; min-height: 300px;">
+          <ActionTimeline
+            entries={timelineEntries}
+            activeIndex={selectedIndex}
+            onselect={(i) => { onselect(i) }}
+          />
+        </div>
+      {/if}
+      <div class="min-w-0 flex-1">
+        {#if a.mode === 'interactive'}
+          <ChatView
+            agentId={a.id}
+            agentState={a.state}
+            costUsd={a.costUsd}
+            inputTokens={a.inputTokens ?? 0}
+            outputTokens={a.outputTokens ?? 0}
+            highlightIndex={selectedIndex}
+            onvisibleindex={(i) => { if (selectedIndex === null) onselect(i) }}
+          />
+        {:else}
+          <StreamOutput
+            agentId={a.id}
+            highlightIndex={selectedIndex}
+            onvisibleindex={(i) => { if (selectedIndex === null) onselect(i) }}
+          />
+        {/if}
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/lib/agent-phases.ts
+++ b/frontend/src/lib/agent-phases.ts
@@ -10,6 +10,8 @@ export type AgentPhase =
 export interface PhaseConfig {
   phase: AgentPhase
   label: string
+  /** One-sentence description of what this phase emphasises (used by empty-state copy). */
+  body: string
   /** Tailwind classes for the dot indicator */
   dotClasses: string
   /** Tailwind classes for the badge pill */
@@ -24,6 +26,7 @@ export const PHASE_CONFIG: Record<AgentPhase, PhaseConfig> = {
   queued: {
     phase: 'queued',
     label: 'Queued',
+    body: 'Task description and starting context.',
     dotClasses: 'bg-surface-400 dark:bg-surface-500',
     badgeClasses: 'bg-surface-200 text-surface-500 dark:bg-surface-700 dark:text-surface-400',
     animate: false,
@@ -32,6 +35,7 @@ export const PHASE_CONFIG: Record<AgentPhase, PhaseConfig> = {
   waiting: {
     phase: 'waiting',
     label: 'Waiting',
+    body: 'Agent has paused and is waiting for your reply.',
     dotClasses: 'bg-surface-400 dark:bg-surface-500',
     badgeClasses: 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-300',
     animate: false,
@@ -40,6 +44,7 @@ export const PHASE_CONFIG: Record<AgentPhase, PhaseConfig> = {
   running: {
     phase: 'running',
     label: 'Running',
+    body: 'Live output stream and current step.',
     dotClasses: 'bg-primary-500',
     badgeClasses: 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200',
     animate: true,
@@ -48,6 +53,7 @@ export const PHASE_CONFIG: Record<AgentPhase, PhaseConfig> = {
   blocked: {
     phase: 'blocked',
     label: 'Blocked',
+    body: 'Agent requires your approval before proceeding.',
     // tertiary = warm amber — distinct from primary amber, matches "amber dot" spec
     dotClasses: 'bg-tertiary-500',
     badgeClasses: 'bg-tertiary-200 text-tertiary-800 dark:bg-tertiary-700 dark:text-tertiary-200',
@@ -57,6 +63,7 @@ export const PHASE_CONFIG: Record<AgentPhase, PhaseConfig> = {
   'human-required': {
     phase: 'human-required',
     label: 'Needs Input',
+    body: 'Agent has escalated and needs your explicit response.',
     // error = coral/orange — matches "orange dot" spec
     dotClasses: 'bg-error-500',
     badgeClasses: 'bg-error-200 text-error-800 dark:bg-error-700 dark:text-error-200',
@@ -66,6 +73,7 @@ export const PHASE_CONFIG: Record<AgentPhase, PhaseConfig> = {
   reviewing: {
     phase: 'reviewing',
     label: 'Reviewing',
+    body: 'Branch and PR ready for review.',
     // warning = violet/purple in amber theme — matches "purple dot" spec
     dotClasses: 'bg-warning-500',
     badgeClasses: 'bg-warning-200 text-warning-800 dark:bg-warning-700 dark:text-warning-200',
@@ -75,6 +83,7 @@ export const PHASE_CONFIG: Record<AgentPhase, PhaseConfig> = {
   done: {
     phase: 'done',
     label: 'Done',
+    body: 'Completion summary: actions taken, files changed, branch created.',
     dotClasses: 'bg-success-400',
     badgeClasses: 'bg-success-100 text-success-700 dark:bg-success-900 dark:text-success-300',
     animate: false,

--- a/frontend/src/lib/agent-summary.test.ts
+++ b/frontend/src/lib/agent-summary.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest'
+import { summarizeAgent } from './agent-summary.js'
+import type { TimestampedStreamEvent } from './timeline.js'
+import type { agent } from '../../wailsjs/go/models.js'
+
+function makeStreamEvent(type: string, content?: string): TimestampedStreamEvent {
+  return {
+    event: { type, content } as agent.StreamEvent,
+    receivedAt: new Date(),
+  }
+}
+
+function makeConvoEvent(overrides: Partial<agent.ConvoEvent>): agent.ConvoEvent {
+  return {
+    type: 'assistant',
+    timestamp: new Date().toISOString(),
+    toolUses: [],
+    toolResults: [],
+    ...overrides,
+  } as agent.ConvoEvent
+}
+
+describe('summarizeAgent', () => {
+  it('returns zero summary for empty inputs', () => {
+    const result = summarizeAgent([], [])
+    expect(result.filesEdited).toEqual([])
+    expect(result.commandsRun).toBe(0)
+    expect(result.toolUseCount).toBe(0)
+    expect(result.assistantMessageCount).toBe(0)
+    expect(result.finalMessage).toBe('')
+  })
+
+  describe('stream events (headless mode)', () => {
+    it('counts assistant messages', () => {
+      const events = [
+        makeStreamEvent('assistant', 'Working on it'),
+        makeStreamEvent('assistant', 'Done'),
+      ]
+      const result = summarizeAgent(events, [])
+      expect(result.assistantMessageCount).toBe(2)
+    })
+
+    it('extracts files from [Edit] lines', () => {
+      const events = [
+        makeStreamEvent('assistant', '[Edit] src/foo.ts\n[Write] src/bar.ts'),
+      ]
+      const result = summarizeAgent(events, [])
+      expect(result.filesEdited).toContain('src/foo.ts')
+      expect(result.filesEdited).toContain('src/bar.ts')
+    })
+
+    it('counts Bash tool uses', () => {
+      const events = [
+        makeStreamEvent('assistant', '[Bash] npm test\n[Bash] go build'),
+      ]
+      const result = summarizeAgent(events, [])
+      expect(result.commandsRun).toBe(2)
+    })
+
+    it('deduplicates file paths', () => {
+      const events = [
+        makeStreamEvent('assistant', '[Edit] src/foo.ts'),
+        makeStreamEvent('assistant', '[Edit] src/foo.ts'),
+      ]
+      const result = summarizeAgent(events, [])
+      expect(result.filesEdited).toEqual(['src/foo.ts'])
+    })
+
+    it('uses result event content as finalMessage', () => {
+      const events = [
+        makeStreamEvent('assistant', 'Working...'),
+        makeStreamEvent('result', 'Task completed successfully'),
+      ]
+      const result = summarizeAgent(events, [])
+      expect(result.finalMessage).toBe('Task completed successfully')
+    })
+
+    it('ignores lines without [ToolName] prefix', () => {
+      const events = [
+        makeStreamEvent('assistant', 'I will now edit the file.\n[Edit] src/foo.ts\nDone.'),
+      ]
+      const result = summarizeAgent(events, [])
+      expect(result.filesEdited).toEqual(['src/foo.ts'])
+      expect(result.toolUseCount).toBe(1)
+    })
+  })
+
+  describe('convo events (interactive mode)', () => {
+    it('extracts files from structured toolUses', () => {
+      const convoEvents = [
+        makeConvoEvent({
+          type: 'assistant',
+          toolUses: [
+            { id: '1', name: 'Edit', input: { file_path: 'src/app.ts' } },
+            { id: '2', name: 'Write', input: { file_path: 'src/new.ts' } },
+          ] as agent.ToolUseBlock[],
+        }),
+      ]
+      const result = summarizeAgent([], convoEvents)
+      expect(result.filesEdited).toContain('src/app.ts')
+      expect(result.filesEdited).toContain('src/new.ts')
+    })
+
+    it('counts Bash tool uses', () => {
+      const convoEvents = [
+        makeConvoEvent({
+          type: 'assistant',
+          toolUses: [
+            { id: '1', name: 'Bash', input: { command: 'npm test' } },
+          ] as agent.ToolUseBlock[],
+        }),
+      ]
+      const result = summarizeAgent([], convoEvents)
+      expect(result.commandsRun).toBe(1)
+    })
+
+    it('uses assistant text as finalMessage', () => {
+      const convoEvents = [
+        makeConvoEvent({ type: 'assistant', text: 'First message' }),
+        makeConvoEvent({ type: 'assistant', text: 'Final message' }),
+      ]
+      const result = summarizeAgent([], convoEvents)
+      expect(result.finalMessage).toBe('Final message')
+    })
+
+    it('uses result event text as finalMessage', () => {
+      const convoEvents = [
+        makeConvoEvent({ type: 'assistant', text: 'Working' }),
+        makeConvoEvent({ type: 'result', text: 'Completed' }),
+      ]
+      const result = summarizeAgent([], convoEvents)
+      expect(result.finalMessage).toBe('Completed')
+    })
+
+    it('ignores tools without file_path', () => {
+      const convoEvents = [
+        makeConvoEvent({
+          type: 'assistant',
+          toolUses: [
+            { id: '1', name: 'Edit', input: {} },
+          ] as agent.ToolUseBlock[],
+        }),
+      ]
+      const result = summarizeAgent([], convoEvents)
+      expect(result.filesEdited).toEqual([])
+    })
+  })
+
+  it('merges both stream and convo events', () => {
+    const stream = [makeStreamEvent('assistant', '[Edit] stream-file.ts')]
+    const convo = [
+      makeConvoEvent({
+        toolUses: [{ id: '1', name: 'Edit', input: { file_path: 'convo-file.ts' } }] as agent.ToolUseBlock[],
+      }),
+    ]
+    const result = summarizeAgent(stream, convo)
+    expect(result.filesEdited).toContain('stream-file.ts')
+    expect(result.filesEdited).toContain('convo-file.ts')
+  })
+})

--- a/frontend/src/lib/agent-summary.ts
+++ b/frontend/src/lib/agent-summary.ts
@@ -1,0 +1,78 @@
+import type { agent } from '../../wailsjs/go/models.js'
+import type { TimestampedStreamEvent } from './timeline.js'
+
+const EDIT_TOOLS = new Set(['Edit', 'Write', 'MultiEdit'])
+
+export interface AgentSummary {
+  filesEdited: string[]
+  commandsRun: number
+  toolUseCount: number
+  assistantMessageCount: number
+  finalMessage: string
+}
+
+/**
+ * Derive a human-readable summary from agent output buffers.
+ * Pass stream events for headless agents, convo events for interactive agents.
+ * Both slices can be populated simultaneously; results are merged.
+ */
+export function summarizeAgent(
+  streamEvents: TimestampedStreamEvent[],
+  convoEvents: agent.ConvoEvent[],
+): AgentSummary {
+  const filesEdited = new Set<string>()
+  let commandsRun = 0
+  let toolUseCount = 0
+  let assistantMessageCount = 0
+  let finalMessage = ''
+
+  // Interactive mode: convo events carry structured tool use data.
+  for (const ev of convoEvents) {
+    if (ev.type === 'assistant') {
+      assistantMessageCount++
+      if (ev.text) finalMessage = ev.text
+      for (const tu of ev.toolUses ?? []) {
+        toolUseCount++
+        if (EDIT_TOOLS.has(tu.name)) {
+          const fp = tu.input?.file_path
+          if (typeof fp === 'string' && fp) filesEdited.add(fp)
+        } else if (tu.name === 'Bash') {
+          commandsRun++
+        }
+      }
+    } else if (ev.type === 'result' && ev.text) {
+      finalMessage = ev.text
+    }
+  }
+
+  // Headless mode: assistant events carry "[ToolName] arg" lines in content.
+  for (const tse of streamEvents) {
+    const ev = tse.event
+    if (ev.type === 'assistant') {
+      assistantMessageCount++
+      if (ev.content) {
+        finalMessage = ev.content
+        for (const line of ev.content.split('\n')) {
+          const m = line.match(/^\[(\w+)\]\s+(.+)$/)
+          if (m) {
+            const name = m[1]
+            const arg = m[2].trim()
+            toolUseCount++
+            if (EDIT_TOOLS.has(name) && arg) filesEdited.add(arg)
+            else if (name === 'Bash') commandsRun++
+          }
+        }
+      }
+    } else if (ev.type === 'result' && ev.content) {
+      finalMessage = ev.content
+    }
+  }
+
+  return {
+    filesEdited: [...filesEdited],
+    commandsRun,
+    toolUseCount,
+    assistantMessageCount,
+    finalMessage,
+  }
+}

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -38,6 +38,7 @@ export function RespondApproval(arg1: string, arg2: boolean): Promise<void> { re
 export function RespondEscalation(arg1: string, arg2: boolean): Promise<void> { return call('AgentService', 'RespondEscalation', arg1, arg2) }
 export function SendMessage(arg1: string, arg2: string): Promise<void> { return call('AgentService', 'SendMessage', arg1, arg2) }
 export function StopAgent(arg1: string): Promise<void> { return call('AgentService', 'StopAgent', arg1) }
+export function OpenWorktree(arg1: string): Promise<void> { return call('AgentService', 'OpenWorktree', arg1) }
 
 // App
 export function GetMonitorReport(): Promise<sybra.MonitorReportBinding> { return call('App', 'GetMonitorReport') }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -33,6 +33,7 @@ export const RespondApproval = pick(AgentSvc.RespondApproval, http.RespondApprov
 export const RespondEscalation = pick(AgentSvc.RespondEscalation, http.RespondEscalation)
 export const SendMessage = pick(AgentSvc.SendMessage, http.SendMessage)
 export const StopAgent = pick(AgentSvc.StopAgent, http.StopAgent)
+export const OpenWorktree = pick(AgentSvc.OpenWorktree, http.OpenWorktree)
 
 // App
 export const GetMonitorReport = pick(AppSvc.GetMonitorReport, http.GetMonitorReport)

--- a/frontend/src/pages/AgentDetail.svelte
+++ b/frontend/src/pages/AgentDetail.svelte
@@ -1,19 +1,17 @@
 <script lang="ts">
-  import { ChevronLeft, PanelLeft } from '@lucide/svelte'
+  import { ChevronLeft } from '@lucide/svelte'
   import type { agent } from '../../wailsjs/go/models.js'
   import { EventsOn, RespondEscalation } from '$lib/api'
   import { agentStore } from '../stores/agents.svelte.js'
   import { convoStore } from '../stores/convo.svelte.js'
   import { taskStore } from '../stores/tasks.svelte.js'
   import { agentState, agentEscalation, agentError } from '../lib/events.js'
-  import StreamOutput from '../components/StreamOutput.svelte'
-  import ChatView from '../components/ChatView.svelte'
-  import ActionTimeline from '../components/ActionTimeline.svelte'
   import AgentErrorBanner from '../components/AgentErrorBanner.svelte'
-  import PlanSteps from '../components/PlanSteps.svelte'
   import { getAgentPhase, PHASE_CONFIG } from '$lib/agent-phases.js'
   import { buildStreamTimeline, buildConvoTimeline } from '$lib/timeline.js'
   import { extractLatestPlanSteps, extractLatestPlanStepsFromConvo } from '$lib/plan-steps.js'
+  import AgentHeader from '../components/agent-view/AgentHeader.svelte'
+  import AgentViewBody from '../components/agent-view/AgentViewBody.svelte'
 
   interface EscalationEvent {
     reason: string
@@ -41,11 +39,7 @@
   let escalation = $state<EscalationEvent | null>(null)
   let escalationResponding = $state(false)
   let errorDismissed = $state(false)
-  let timelineOpen = $state(true)
   let selectedIndex = $state<number | null>(null)
-  let planCollapsed = $state(false)
-
-  const isRunning = $derived(a?.state === 'running')
 
   // Seed error from cached agent state (already stopped with errorKind set).
   const cachedError = $derived(
@@ -81,11 +75,6 @@
       ? extractLatestPlanStepsFromConvo(convoEvents)
       : extractLatestPlanSteps(streamOutputs),
   )
-
-  // Auto-expand plan when agent starts running, collapse when done.
-  $effect(() => {
-    if (a?.state === 'running') planCollapsed = false
-  })
 
   $effect(() => {
     const cached = agentStore.agents.get(agentId)
@@ -142,11 +131,6 @@
       escalation = null
       escalationResponding = false
     }
-  }
-
-  function formatDate(date: any): string {
-    if (!date) return '-'
-    return new Date(date).toLocaleString()
   }
 
   function onkeydown(e: KeyboardEvent) {
@@ -236,177 +220,27 @@
 
   {#if a}
     <div class="flex flex-col gap-6">
-      <div class="flex items-start justify-between gap-4">
-        <div>
-          <h1 class="text-2xl font-bold">{a.project || a.id}</h1>
-          {#if a.name}
-            <span class="text-sm text-surface-400">{a.name}</span>
-          {/if}
-          {#if phase === 'running'}
-            <p class="mt-0.5 text-sm italic text-surface-400">
-              {agentStore.stepTexts.get(agentId) ?? 'Working...'}
-            </p>
-          {:else if phase === 'waiting'}
-            <p class="mt-0.5 text-sm text-surface-400">
-              Waiting for reply
-            </p>
-          {:else if phase === 'blocked'}
-            <p class="mt-0.5 text-sm text-tertiary-600 dark:text-tertiary-400">
-              Awaiting tool approval
-            </p>
-          {:else if phase === 'human-required'}
-            <p class="mt-0.5 text-sm font-medium text-error-600 dark:text-error-400">
-              Waiting for human input
-            </p>
-          {:else if phase === 'reviewing'}
-            <p class="mt-0.5 text-sm text-warning-600 dark:text-warning-400">
-              Under review
-            </p>
-          {/if}
-        </div>
-        <div class="flex items-center gap-2">
-          <span class="inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-medium {phaseConfig.badgeClasses}">
-            {#if phaseConfig.animate}
-              <span class="h-2 w-2 animate-pulse-subtle rounded-full {phaseConfig.dotClasses}"></span>
-            {:else if phase !== 'queued' && phase !== 'done'}
-              <span class="h-2 w-2 rounded-full {phaseConfig.dotClasses}"></span>
-            {/if}
-            {phaseConfig.label}
-          </span>
-          {#if isRunning}
-            <button
-              type="button"
-              class="rounded-lg bg-error-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-error-600"
-              onclick={handleStop}
-            >
-              Stop
-            </button>
-          {/if}
-        </div>
-      </div>
+      <AgentHeader
+        {a}
+        {phase}
+        {phaseConfig}
+        stepText={agentStore.stepTexts.get(agentId)}
+        {linkedTask}
+        onstop={handleStop}
+        {onviewtask}
+      />
 
-      <div class="flex flex-wrap gap-6 text-sm">
-        {#if a.taskId}
-          <div class="flex flex-col gap-1">
-            <span class="font-medium text-surface-500">Task</span>
-            <button
-              type="button"
-              class="text-left text-primary-500 hover:underline"
-              onclick={() => onviewtask(a!.taskId)}
-            >
-              {linkedTask?.title ?? a.taskId}
-            </button>
-          </div>
-        {/if}
-        {#if linkedTask?.branch}
-          <div class="flex flex-col gap-1">
-            <span class="font-medium text-surface-500">Branch</span>
-            <span class="rounded bg-surface-200 px-2 py-0.5 font-mono text-xs dark:bg-surface-700">{linkedTask.branch}</span>
-          </div>
-        {/if}
-        <div class="flex flex-col gap-1">
-          <span class="font-medium text-surface-500">Mode</span>
-          <span class="rounded bg-surface-200 px-2 py-0.5 dark:bg-surface-700">{a.mode}</span>
-        </div>
-        {#if a.project}
-          <div class="flex flex-col gap-1">
-            <span class="font-medium text-surface-500">Project</span>
-            <span class="rounded bg-surface-200 px-2 py-0.5 dark:bg-surface-700">{a.project}</span>
-          </div>
-        {/if}
-        {#if a.name}
-          <div class="flex flex-col gap-1">
-            <span class="font-medium text-surface-500">Session Name</span>
-            <span class="rounded bg-surface-200 px-2 py-0.5 dark:bg-surface-700">{a.name}</span>
-          </div>
-        {/if}
-        {#if a.external}
-          <div class="flex flex-col gap-1">
-            <span class="font-medium text-surface-500">Source</span>
-            <span class="rounded bg-warning-200 px-2 py-0.5 text-warning-800 dark:bg-warning-700 dark:text-warning-200">external</span>
-          </div>
-        {/if}
-        {#if a.pid}
-          <div class="flex flex-col gap-1">
-            <span class="font-medium text-surface-500">PID</span>
-            <span class="rounded bg-surface-200 px-2 py-0.5 font-mono text-xs dark:bg-surface-700">{a.pid}</span>
-          </div>
-        {/if}
-        {#if a.command}
-          <div class="flex flex-col gap-1">
-            <span class="font-medium text-surface-500">Command</span>
-            <span class="max-w-md truncate rounded bg-surface-200 px-2 py-0.5 font-mono text-xs dark:bg-surface-700">{a.command}</span>
-          </div>
-        {/if}
-        {#if a.sessionId}
-          <div class="flex flex-col gap-1">
-            <span class="font-medium text-surface-500">Session</span>
-            <span class="rounded bg-surface-200 px-2 py-0.5 font-mono text-xs dark:bg-surface-700">{a.sessionId}</span>
-          </div>
-        {/if}
-        {#if a.costUsd > 0}
-          <div class="flex flex-col gap-1">
-            <span class="font-medium text-surface-500">Cost</span>
-            <span class="rounded bg-surface-200 px-2 py-0.5 dark:bg-surface-700">${a.costUsd.toFixed(2)}</span>
-          </div>
-        {/if}
-        <div class="flex flex-col gap-1">
-          <span class="font-medium text-surface-500">Started</span>
-          <span>{formatDate(a.startedAt)}</span>
-        </div>
-      </div>
-
-      {#if planSteps.length > 0}
-        <PlanSteps steps={planSteps} bind:collapsed={planCollapsed} />
-      {/if}
-
-      <div class="flex min-h-0 flex-1 flex-col gap-2">
-        <div class="flex items-center gap-2">
-          <span class="text-sm font-medium text-surface-500">Output</span>
-          <button
-            type="button"
-            title={timelineOpen ? 'Hide timeline' : 'Show timeline'}
-            onclick={() => { timelineOpen = !timelineOpen }}
-            class="ml-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors
-              {timelineOpen
-                ? 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200'
-                : 'bg-surface-200 text-surface-500 dark:bg-surface-700 dark:text-surface-400'}"
-          >
-            <PanelLeft size={12} />
-            Timeline
-          </button>
-        </div>
-        <div class="flex min-h-0 items-start gap-3">
-          {#if timelineOpen}
-            <div class="hidden w-64 shrink-0 overflow-hidden rounded-lg border border-surface-300 dark:border-surface-700 md:flex md:flex-col" style="max-height: 600px; min-height: 300px;">
-              <ActionTimeline
-                entries={timelineEntries}
-                activeIndex={selectedIndex}
-                onselect={(i) => { selectedIndex = i }}
-              />
-            </div>
-          {/if}
-          <div class="min-w-0 flex-1">
-            {#if a.mode === 'interactive'}
-              <ChatView
-                agentId={agentId}
-                agentState={a.state}
-                costUsd={a.costUsd}
-                inputTokens={a.inputTokens ?? 0}
-                outputTokens={a.outputTokens ?? 0}
-                highlightIndex={selectedIndex}
-                onvisibleindex={(i) => { if (selectedIndex === null) selectedIndex = i }}
-              />
-            {:else}
-              <StreamOutput
-                agentId={agentId}
-                highlightIndex={selectedIndex}
-                onvisibleindex={(i) => { if (selectedIndex === null) selectedIndex = i }}
-              />
-            {/if}
-          </div>
-        </div>
-      </div>
+      <AgentViewBody
+        {phase}
+        {a}
+        {linkedTask}
+        {streamOutputs}
+        {convoEvents}
+        {timelineEntries}
+        {planSteps}
+        {selectedIndex}
+        onselect={(i) => { selectedIndex = i }}
+      />
     </div>
   {:else if !error}
     <p class="text-sm opacity-60">Loading...</p>

--- a/frontend/wailsjs/go/sybra/AgentService.d.ts
+++ b/frontend/wailsjs/go/sybra/AgentService.d.ts
@@ -12,6 +12,8 @@ export function GetConvoOutput(arg1:string):Promise<Array<agent.ConvoEvent>>;
 
 export function ListAgents():Promise<Array<agent.Agent>>;
 
+export function OpenWorktree(arg1:string):Promise<void>;
+
 export function RespondApproval(arg1:string,arg2:boolean):Promise<void>;
 
 export function RespondEscalation(arg1:string,arg2:boolean):Promise<void>;

--- a/frontend/wailsjs/go/sybra/AgentService.js
+++ b/frontend/wailsjs/go/sybra/AgentService.js
@@ -22,6 +22,10 @@ export function ListAgents() {
   return window['go']['sybra']['AgentService']['ListAgents']();
 }
 
+export function OpenWorktree(arg1) {
+  return window['go']['sybra']['AgentService']['OpenWorktree'](arg1);
+}
+
 export function RespondApproval(arg1, arg2) {
   return window['go']['sybra']['AgentService']['RespondApproval'](arg1, arg2);
 }

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -796,6 +796,7 @@ func (a *App) wireServices(emit func(string, any)) {
 	a.agentSvc.tasks = a.tasks
 	a.agentSvc.cfg = a.cfg
 	a.agentSvc.logsDir = a.logDir
+	a.agentSvc.worktrees = a.worktrees
 	a.orchSvc.agents = a.agents
 	a.orchSvc.audit = a.audit
 	a.orchSvc.logger = a.logger

--- a/internal/sybra/svc_agents.go
+++ b/internal/sybra/svc_agents.go
@@ -6,17 +6,20 @@ import (
 
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/sysopen"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/worktree"
 )
 
 // AgentService exposes agent operations as Wails-bound methods.
 type AgentService struct {
-	agents   *agent.Manager
-	logger   *slog.Logger
-	approval *agent.ApprovalServer
-	tasks    *task.Manager
-	cfg      *config.Config
-	logsDir  string
+	agents    *agent.Manager
+	logger    *slog.Logger
+	approval  *agent.ApprovalServer
+	tasks     *task.Manager
+	cfg       *config.Config
+	logsDir   string
+	worktrees *worktree.Manager
 }
 
 // StopAgent sends a stop signal to the given agent.
@@ -97,4 +100,20 @@ func (s *AgentService) GetAgentRunLog(taskID, agentID string) ([]agent.StreamEve
 // continueRun=true lets the agent keep running; false kills it.
 func (s *AgentService) RespondEscalation(agentID string, continueRun bool) error {
 	return s.agents.RespondEscalation(agentID, continueRun)
+}
+
+// OpenWorktree opens the git worktree for taskID in the OS file manager.
+// Returns an error if the worktree does not exist or the OS command fails.
+func (s *AgentService) OpenWorktree(taskID string) error {
+	if s.worktrees == nil {
+		return fmt.Errorf("worktree manager not available")
+	}
+	t, err := s.tasks.Get(taskID)
+	if err != nil {
+		return fmt.Errorf("task %s: %w", taskID, err)
+	}
+	if !s.worktrees.Exists(t) {
+		return fmt.Errorf("no worktree for task %s", taskID)
+	}
+	return sysopen.Dir(s.worktrees.PathFor(t))
 }

--- a/internal/sysopen/sysopen.go
+++ b/internal/sysopen/sysopen.go
@@ -1,0 +1,29 @@
+// Package sysopen opens a local directory in the OS file manager.
+package sysopen
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// Dir opens path in the platform file manager.
+// Supported platforms: linux (xdg-open), darwin (open), windows (explorer).
+// Returns a wrapped error if the command exits non-zero or is not found.
+func Dir(path string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "linux":
+		cmd = exec.Command("xdg-open", path)
+	case "darwin":
+		cmd = exec.Command("open", path)
+	case "windows":
+		cmd = exec.Command("explorer", path)
+	default:
+		return fmt.Errorf("sysopen: unsupported OS %q", runtime.GOOS)
+	}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("sysopen: %w", err)
+	}
+	return nil
+}

--- a/internal/sysopen/sysopen_test.go
+++ b/internal/sysopen/sysopen_test.go
@@ -1,0 +1,29 @@
+package sysopen
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestDir_UnsupportedOS(t *testing.T) {
+	// Only meaningful when running on a platform we don't support,
+	// or to verify the function exists and compiles on all platforms.
+	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		t.Skip("skipped on supported platforms")
+	}
+	if err := Dir("/tmp"); err == nil {
+		t.Error("expected error for unsupported OS, got nil")
+	}
+}
+
+func TestDir_InvalidPath(t *testing.T) {
+	// xdg-open/open/explorer on a nonexistent path should still succeed
+	// (they open a file manager at the nearest valid parent or show an error
+	// dialog). This test mainly verifies the function wires up correctly.
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" && runtime.GOOS != "windows" {
+		t.Skip("skipped on unsupported platforms")
+	}
+	// We cannot actually run xdg-open/open/explorer in a headless CI
+	// environment without a display. So just verify the command is built.
+	t.Skip("skipped: requires display / file manager")
+}


### PR DESCRIPTION
## Motivation

Agent detail view was a single monolithic component with no awareness of execution phase. All states (queued, running, blocked, done) rendered the same layout, making it hard to surface the right controls and information at the right time.

Closes https://github.com/Automaat/sybra/issues/465

## Implementation information

Introduced `AgentViewBody` as a phase-router shell that swaps layout components on phase change with fade transitions. Each phase gets a dedicated component:

- `QueuedLayout` — task description card + starting indicator
- `RunningLayout` — output stream + timeline split (existing UX)
- `BlockedLayout` — hoisted `ToolApproval` full-width, history collapsed
- `HumanRequiredLayout` — centered reply form, urgency variants
- `ReviewingLayout` — branch/PR card + Open worktree CTA
- `DoneLayout` — summary card (duration, cost, files, commands)

`AgentHeader` extracted from `AgentDetail`; `AgentDetail` gutted to shell + routing only (~150 lines).

Supporting changes:
- `agent-summary.ts`: pure fn summarising stream/convo events
- `agent-summary.test.ts`: 13 Vitest table-driven tests
- `ChatView`: `suppressApprovals` prop used by `BlockedLayout`
- `agent-phases.ts`: `body` field added to `PhaseConfig`
- `svc_agents.go` + `sysopen` pkg: `OpenWorktree` bound method
- Wails bindings + `api.ts`: `OpenWorktree` exposed to frontend