### PR TITLE
build(docker): pin mise to released v2026.4.15

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,49 @@
+name: Docker Build
+
+# Verifies the prod Dockerfile actually builds before it reaches main.
+# Catches URL 404s on pinned tool versions, apt/npm resolution failures,
+# and platform-specific build errors that hadolint can't detect — e.g.
+# the v2026.1.17 mise pin that landed on main and broke Docker Publish.
+#
+# Scope is deliberately narrow: only runs when the Dockerfile or
+# .dockerignore change. Source-only PRs skip this to avoid paying for a
+# full multi-stage build on every commit. The main-branch Docker Publish
+# workflow still covers the full image lifecycle on release.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+  push:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Build image (no push)
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        with:
+          context: .
+          push: false
+          load: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN npm install -g \
 # own tool (npm ci, uv sync, cargo build, ./.sybra/bootstrap.sh …).
 #
 # renovate: datasource=github-releases depName=jdx/mise
-ARG MISE_VERSION=v2026.1.17
+ARG MISE_VERSION=v2026.4.15
 RUN ARCH="$(dpkg --print-architecture)" \
     && case "${ARCH}" in \
          amd64) MISE_ARCH=x64 ;; \


### PR DESCRIPTION
## Motivation

The Docker Publish workflow on `main` fails with a 404 when fetching the `mise` binary: `v2026.1.17` was a best-guess version that does not exist on `jdx/mise` GitHub releases. Run that surfaced the bug: https://github.com/Automaat/sybra/actions/runs/24525863627/job/71695809506

## Implementation information

Bump `MISE_VERSION` ARG in the Dockerfile from `v2026.1.17` → `v2026.4.15` (the current latest `jdx/mise` release). Renovate annotation is unchanged; future bumps will be automated.

## Supporting documentation

Unblocks deployment of the repo-level setup + interactive history replay landed in PR #527.

> Changelog: build(docker): pin mise to released v2026.4.15