### PR TITLE
fix(skills): dir layout for skill discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ frontend/dist-web/
 frontend/node_modules/
 frontend/package.json.md5
 
-# Runtime data (lives in ~/.synapse at runtime)
+# Runtime data (lives in ~/.sybra at runtime)
 tasks/
 
 # Claude Code
@@ -26,7 +26,9 @@ frontend/test-results/
 frontend/playwright-report/
 
 # Binary
-/synapse
-/synapse-cli
+/sybra
+/sybra-cli
+/sybra-server
+/sybra-perf
 /fake-claude
-/synapse-server
+/fake-codex

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,3 @@
 # Agent Instructions
 
-Codex: read [CLAUDE.md](/Users/marcin.skalski/sideprojects/synapse-tmux-improve/CLAUDE.md) before making changes in this repository. Follow the guidance there as the primary repo-specific instruction set.
+Codex: read [CLAUDE.md](./CLAUDE.md) before making changes in this repository. Follow the guidance there as the primary repo-specific instruction set.

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN npm install -g \
 
 # --- Layer D: mise binary only (tools installed per-worktree) ---
 # The prod image intentionally does NOT bake language toolchains. Each
-# project declares its tools (e.g. synapse's mise.toml pins Go/Node/etc.)
+# project declares its tools (e.g. sybra's mise.toml pins Go/Node/etc.)
 # and Sybra runs `mise install` in every worktree via SetupCommands on
 # creation — cached in ~/.sybra/mise-data, shared across worktrees, version
 # pinned per branch. This keeps the image lean and supports projects in any

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Synapse
+# Sybra
 
 Autonomous Claude Code orchestrator. Local desktop app that manages a swarm of AI agents: triage incoming work, spawn agents, monitor progress, handle failures — all through a markdown-based task board.
 
 ## What it does
 
-You create tasks. Synapse triages them, spawns Claude Code agents to implement them, monitors progress, reviews results, and keeps the board healthy. Each agent gets an isolated git worktree so parallel work never steps on itself.
+You create tasks. Sybra triages them, spawns Claude Code agents to implement them, monitors progress, reviews results, and keeps the board healthy. Each agent gets an isolated git worktree so parallel work never steps on itself.
 
 ```
 new → todo → in-progress → in-review → done
@@ -26,7 +26,7 @@ Complex tasks go through a planning phase. Simple tasks go straight to execution
 - **Spotlight** — keyboard-driven task creation from anywhere in the app
 - **Todoist sync** — bidirectional sync with configurable polling
 - **Audit log** — structured NDJSON event log for failure analysis and cycle-time tracking
-- **CLI** (`synapse-cli`) — task CRUD from the terminal, used by Claude Code skills
+- **CLI** (`sybra-cli`) — task CRUD from the terminal, used by Claude Code skills
 
 ## Tech stack
 
@@ -53,13 +53,13 @@ mise run dev
 mise run build
 
 # Install CLI
-go install ./cmd/synapse-cli
+go install ./cmd/sybra-cli
 ```
 
 ## CLI
 
 ```bash
-synapse-cli [--json] <command> [flags]
+sybra-cli [--json] <command> [flags]
 
 list     [--status STATUS] [--tag TAG] [--project PROJECT]
 get      <id>
@@ -87,22 +87,22 @@ project_id: owner/repo
 What needs to be done.
 ```
 
-Tasks live in `~/.synapse/tasks/`. The app watches for file changes and updates the board in real time.
+Tasks live in `~/.sybra/tasks/`. The app watches for file changes and updates the board in real time.
 
 ## Projects
 
-Projects mirror GitHub repos as bare clones. Assign a `project_id` to a task and Synapse automatically creates an isolated worktree when the agent starts.
+Projects mirror GitHub repos as bare clones. Assign a `project_id` to a task and Sybra automatically creates an isolated worktree when the agent starts.
 
 ```bash
-synapse-cli project create --url https://github.com/owner/repo
-synapse-cli create --title "Add feature" --project "owner/repo"
+sybra-cli project create --url https://github.com/owner/repo
+sybra-cli create --title "Add feature" --project "owner/repo"
 ```
 
 ## Orchestrator
 
-Synapse ships with a Claude Code system prompt (`orchestrator/CLAUDE.md`) that turns a Claude Code session into the orchestration brain — triage, dispatch, monitor, resolve. Load it in any Claude Code session pointed at `~/.synapse/`.
+Sybra ships with a Claude Code system prompt (`orchestrator/CLAUDE.md`) that turns a Claude Code session into the orchestration brain — triage, dispatch, monitor, resolve. Load it in any Claude Code session pointed at `~/.sybra/`.
 
-Claude Code skills (`synapse-tasks`, `synapse-triage`, `synapse-plan`, `synapse-evaluate`) are auto-installed to `~/.synapse/skills/` on app startup.
+Claude Code skills (`sybra-tasks`, `sybra-triage`, `sybra-plan`, `sybra-evaluate`) are auto-installed to `~/.claude/skills/` on app startup, laid out as `<skill-name>/SKILL.md` subdirectories — the format Claude Code's skill loader requires.
 
 ## File naming conventions
 

--- a/docs/codex-setup.md
+++ b/docs/codex-setup.md
@@ -1,6 +1,6 @@
 # Codex Agent Setup
 
-Synapse supports [OpenAI Codex CLI](https://github.com/openai/codex) as an alternative agent provider alongside Claude Code. This document covers local setup, authentication, Synapse configuration, and known behavioral differences.
+Sybra supports [OpenAI Codex CLI](https://github.com/openai/codex) as an alternative agent provider alongside Claude Code. This document covers local setup, authentication, Sybra configuration, and known behavioral differences.
 
 ## Prerequisites
 
@@ -18,13 +18,13 @@ codex --version
 
 ### Authenticate
 
-Codex requires an OpenAI API key. Set it in your shell environment before starting Synapse:
+Codex requires an OpenAI API key. Set it in your shell environment before starting Sybra:
 
 ```bash
 export OPENAI_API_KEY=sk-...
 ```
 
-Add the export to your shell profile (`~/.zshrc`, `~/.bashrc`) so it persists across sessions. Synapse inherits the parent process environment — the key must be set before the app launches.
+Add the export to your shell profile (`~/.zshrc`, `~/.bashrc`) so it persists across sessions. Sybra inherits the parent process environment — the key must be set before the app launches.
 
 If you prefer interactive login:
 
@@ -32,16 +32,16 @@ If you prefer interactive login:
 codex auth
 ```
 
-> **macOS GUI launch note:** Apps launched from Finder or Spotlight do not inherit shell profile exports. Set `OPENAI_API_KEY` via `launchctl setenv` or a `launchd` plist to ensure Synapse picks it up:
+> **macOS GUI launch note:** Apps launched from Finder or Spotlight do not inherit shell profile exports. Set `OPENAI_API_KEY` via `launchctl setenv` or a `launchd` plist to ensure Sybra picks it up:
 >
 > ```bash
 > launchctl setenv OPENAI_API_KEY "sk-..."
-> # then relaunch Synapse
+> # then relaunch Sybra
 > ```
 
-## Enable Codex in Synapse
+## Enable Codex in Sybra
 
-Edit `~/.synapse/config.yaml`:
+Edit `~/.sybra/config.yaml`:
 
 ```yaml
 agent:
@@ -58,20 +58,20 @@ agent:
 
 ### Model Aliases
 
-Synapse maps generic aliases to provider-specific model IDs at runtime:
+Sybra maps generic aliases to provider-specific model IDs at runtime:
 
-| Synapse alias | Codex model |
+| Sybra alias | Codex model |
 |---------------|-------------|
 | `sonnet` (default) | `gpt-5.4` |
 | `opus` | `gpt-5.4` |
 | `haiku` | `gpt-5.4-mini` |
 | any other string | passed through verbatim |
 
-## How Codex Runs in Synapse
+## How Codex Runs in Sybra
 
 ### Headless mode
 
-Synapse spawns a `codex exec` subprocess per task:
+Sybra spawns a `codex exec` subprocess per task:
 
 ```bash
 # Default (no permission restrictions)
@@ -81,11 +81,11 @@ codex exec --json --skip-git-repo-check --full-auto --model gpt-5.4 -C <worktree
 codex exec --json --skip-git-repo-check --sandbox workspace-write --model gpt-5.4 -C <worktree> "<prompt>"
 ```
 
-Stdout is read as NDJSON. Synapse parses Codex event types (`agent_message`, `command_execution`, `task_complete`, etc.) and maps them to its unified `StreamEvent` format for display.
+Stdout is read as NDJSON. Sybra parses Codex event types (`agent_message`, `command_execution`, `task_complete`, etc.) and maps them to its unified `StreamEvent` format for display.
 
 ### Interactive (conversational) mode
 
-Synapse spawns a new `codex exec --json` process for each user turn. Unlike Claude conversational mode (which keeps a single process alive on stdin), each Codex turn is a discrete subprocess invocation. This means there is **no persistent stdin pipe** — the UI sends messages by launching a new process with the follow-up prompt.
+Sybra spawns a new `codex exec --json` process for each user turn. Unlike Claude conversational mode (which keeps a single process alive on stdin), each Codex turn is a discrete subprocess invocation. This means there is **no persistent stdin pipe** — the UI sends messages by launching a new process with the follow-up prompt.
 
 ## Differences vs Claude Code
 
@@ -101,13 +101,13 @@ Synapse spawns a new `codex exec --json` process for each user turn. Unlike Clau
 
 ## Commit Requirements
 
-Codex agents must commit their work before finishing — the same requirement as Claude agents. Git commit flags (`-s` for sign-off, `-S` for GPG signing) work normally inside Synapse-managed worktrees. See the orchestrator's "Agent Commit Requirement" section for the required commit block to include in every headless prompt.
+Codex agents must commit their work before finishing — the same requirement as Claude agents. Git commit flags (`-s` for sign-off, `-S` for GPG signing) work normally inside Sybra-managed worktrees. See the orchestrator's "Agent Commit Requirement" section for the required commit block to include in every headless prompt.
 
 ## Skill and Prompt Compatibility
 
-Existing Synapse skills (`/synapse-tasks`, `/synapse-triage`, `/synapse-plan`, etc.) are provider-agnostic — they use `synapse-cli` and shell commands, not the Claude SDK directly. They work without modification under either provider.
+Existing Sybra skills (`/sybra-tasks`, `/sybra-triage`, `/sybra-plan`, etc.) are provider-agnostic — they use `sybra-cli` and shell commands, not the Claude SDK directly. They work without modification under either provider.
 
-The orchestrator prompt (`orchestrator/CLAUDE.md`) governs the Synapse orchestrator session, which always runs as a Claude Code agent. Codex is used for implementation agents dispatched by the orchestrator, not for the orchestrator itself.
+The orchestrator prompt (`orchestrator/CLAUDE.md`) governs the Sybra orchestrator session, which always runs as a Claude Code agent. Codex is used for implementation agents dispatched by the orchestrator, not for the orchestrator itself.
 
 ## Troubleshooting
 
@@ -128,16 +128,16 @@ codex auth             # re-authenticate interactively
 
 **Agent starts but produces no events**
 
-Confirm `OPENAI_API_KEY` is set in Synapse's process environment (see macOS GUI note above). Also verify the `codex` binary path is in the `PATH` that Synapse sees:
+Confirm `OPENAI_API_KEY` is set in Sybra's process environment (see macOS GUI note above). Also verify the `codex` binary path is in the `PATH` that Sybra sees:
 
 ```bash
-# Check from Synapse's inherited PATH
+# Check from Sybra's inherited PATH
 which codex
 ```
 
 **External Codex sessions not appearing**
 
-Synapse discovers live Codex sessions via `pgrep -f codex` and reads JSONL from `~/.codex/sessions/`. Sessions appear as `ext-codex-*` agents in the UI. If sessions are absent, confirm:
+Sybra discovers live Codex sessions via `pgrep -f codex` and reads JSONL from `~/.codex/sessions/`. Sessions appear as `ext-codex-*` agents in the UI. If sessions are absent, confirm:
 
 1. The Codex process is running (`pgrep -f codex`)
 2. Session files exist at `~/.codex/sessions/rollout-<id>.jsonl`

--- a/internal/agent/skill_invoke.go
+++ b/internal/agent/skill_invoke.go
@@ -13,7 +13,7 @@ import (
 // Only exact matches against the given skill names are rewritten, and the
 // invocation must be preceded by start-of-line or a non-word, non-`/`
 // character, and followed by a non-identifier char or end — so path
-// segments like `/tmp/synapse-plan-xxx.md` are never touched.
+// segments like `/tmp/sybra-plan-xxx.md` are never touched.
 func rewriteSkillInvocations(prompt string, skillNames []string) string {
 	if len(skillNames) == 0 || prompt == "" {
 		return prompt

--- a/internal/agent/skill_invoke_test.go
+++ b/internal/agent/skill_invoke_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestRewriteSkillInvocations(t *testing.T) {
 	t.Parallel()
-	skills := []string{"plan-critic", "synapse-triage", "synapse-plan", "staff-code-review"}
+	skills := []string{"plan-critic", "sybra-triage", "sybra-plan", "staff-code-review"}
 	tests := []struct {
 		name string
 		in   string
@@ -16,13 +16,13 @@ func TestRewriteSkillInvocations(t *testing.T) {
 	}{
 		{
 			name: "leading slash invocation",
-			in:   "/plan-critic /tmp/synapse-plan-abc.md",
-			want: "$plan-critic /tmp/synapse-plan-abc.md",
+			in:   "/plan-critic /tmp/sybra-plan-abc.md",
+			want: "$plan-critic /tmp/sybra-plan-abc.md",
 		},
 		{
 			name: "mid-sentence invocation",
-			in:   "Triage task 123 using /synapse-triage skill.",
-			want: "Triage task 123 using $synapse-triage skill.",
+			in:   "Triage task 123 using /sybra-triage skill.",
+			want: "Triage task 123 using $sybra-triage skill.",
 		},
 		{
 			name: "multiple invocations",
@@ -31,8 +31,8 @@ func TestRewriteSkillInvocations(t *testing.T) {
 		},
 		{
 			name: "path must not be rewritten",
-			in:   "Save to /tmp/synapse-plan-xxx.md and read /home/user/synapse-triage/log",
-			want: "Save to /tmp/synapse-plan-xxx.md and read /home/user/synapse-triage/log",
+			in:   "Save to /tmp/sybra-plan-xxx.md and read /home/user/sybra-triage/log",
+			want: "Save to /tmp/sybra-plan-xxx.md and read /home/user/sybra-triage/log",
 		},
 		{
 			name: "unknown slash command left alone",

--- a/internal/project/model.go
+++ b/internal/project/model.go
@@ -16,7 +16,7 @@ type ChecksConfig struct {
 	PrePush   []string `yaml:"pre_push,omitempty"   json:"prePush,omitempty"`
 }
 
-// RepoConfig is the subset of Synapse config that can be defined in a repo's
+// RepoConfig is the subset of Sybra config that can be defined in a repo's
 // .sybra.yaml file. Repo config takes priority over the app-level project config.
 type RepoConfig struct {
 	Checks *ChecksConfig `yaml:"checks,omitempty" json:"checks,omitempty"`

--- a/internal/skills/data/sybra-audit.md
+++ b/internal/skills/data/sybra-audit.md
@@ -1,11 +1,11 @@
 ---
-name: synapse-audit
-description: Analyze Synapse health findings + audit summary to explain workflow issues and propose grounded fixes. Use when asked to review how work is flowing or suggest process improvements.
+name: sybra-audit
+description: Analyze Sybra health findings + audit summary to explain workflow issues and propose grounded fixes. Use when asked to review how work is flowing or suggest process improvements.
 allowed-tools: Bash, Read
 user-invocable: true
 ---
 
-# Synapse Audit Analysis
+# Sybra Audit Analysis
 
 The Go side already runs every detector and, when the selfmonitor service is
 enabled, distills each finding's agent log into a `LogSummary` (stall
@@ -16,7 +16,7 @@ them in real context, and produce concrete fixes** — not to recompute them.
 ## Step 1: Pull the selfmonitor report
 
 ```bash
-synapse-cli --json selfmonitor scan
+sybra-cli --json selfmonitor scan
 ```
 
 Returns a `selfmonitor.Report` with:
@@ -33,13 +33,13 @@ Returns a `selfmonitor.Report` with:
 **Fallback** — if the report is missing or `generatedAt` is > 2h ago:
 
 ```bash
-synapse-cli --json health
+sybra-cli --json health
 ```
 
 ## Step 2: Pull the workflow summary
 
 ```bash
-synapse-cli --json audit --since 7d --summary
+sybra-cli --json audit --since 7d --summary
 ```
 
 Use for trend context only: cycle time, total cost, plan rejection rate, status
@@ -62,7 +62,7 @@ For the top 3 findings (by severity, then impact):
 **Otherwise (no logSummary, verdict pending):**
 
 ```bash
-synapse-cli --json get <taskId>
+sybra-cli --json get <taskId>
 ```
 
 Read task body, status_reason, and any embedded run results to explain why
@@ -112,7 +112,7 @@ Recommendations (cross-cutting):
   when confidence is lower or verdict is pending.
 
 <example>
-`synapse-cli --json selfmonitor scan` returns:
+`sybra-cli --json selfmonitor scan` returns:
 ```json
 {
   "healthScore": "critical",
@@ -143,7 +143,7 @@ Recommendations (cross-cutting):
 }
 ```
 
-Then for the pending triage_mismatch, `synapse-cli --json get task-def456` shows
+Then for the pending triage_mismatch, `sybra-cli --json get task-def456` shows
 a task about integrating a new auth provider (touches secrets + IAM).
 
 Output:
@@ -178,7 +178,7 @@ Recommendations:
 </example>
 
 <example>
-`synapse-cli --json selfmonitor scan` returns `{"healthScore": "good", "findings": []}`.
+`sybra-cli --json selfmonitor scan` returns `{"healthScore": "good", "findings": []}`.
 
 Output: `Health: good — no findings in the last 24h.`
 </example>

--- a/internal/skills/data/sybra-evaluate.md
+++ b/internal/skills/data/sybra-evaluate.md
@@ -1,12 +1,12 @@
 ---
-name: synapse-evaluate
-description: Evaluate completed Synapse tasks — determine status transition and link PRs. Use when asked to evaluate task completion.
+name: sybra-evaluate
+description: Evaluate completed Sybra tasks — determine status transition and link PRs. Use when asked to evaluate task completion.
 allowed-tools: Bash
 user-invocable: true
 disable-model-invocation: true
 ---
 
-# Synapse Task Evaluation
+# Sybra Task Evaluation
 
 Decide what happens to a task after an agent finishes. Do NOT read source code, review diffs, or explore the codebase.
 
@@ -22,7 +22,7 @@ Decide what happens to a task after an agent finishes. Do NOT read source code, 
 ### 1. Read the task
 
 ```bash
-synapse-cli --json get <id>
+sybra-cli --json get <id>
 ```
 
 ### 2. Link PR if created
@@ -36,10 +36,10 @@ If found, link to task:
 
 ```bash
 # Link PR number
-synapse-cli --json update <id> --pr <number>
+sybra-cli --json update <id> --pr <number>
 
 # Link branch if known and not already set
-synapse-cli --json update <id> --branch <branch-name>
+sybra-cli --json update <id> --branch <branch-name>
 ```
 
 ### 3. Decide status transition
@@ -63,7 +63,7 @@ Based ONLY on the agent result text:
 ### 4. Update status
 
 ```bash
-synapse-cli --json update <id> --status <new-status>
+sybra-cli --json update <id> --status <new-status>
 ```
 
 <example>
@@ -71,8 +71,8 @@ Input: Agent result text contains `https://github.com/acme/repo/pull/42` and "Su
 
 Actions:
 ```bash
-synapse-cli --json update task-abc --pr 42
-synapse-cli --json update task-abc --status in-review
+sybra-cli --json update task-abc --pr 42
+sybra-cli --json update task-abc --status in-review
 ```
 </example>
 
@@ -81,7 +81,7 @@ Input: Agent result text contains "Error: rate limit exceeded" with no PR refere
 
 Actions:
 ```bash
-synapse-cli --json update task-abc --status human-required
+sybra-cli --json update task-abc --status human-required
 ```
 </example>
 

--- a/internal/skills/data/sybra-monitor.md
+++ b/internal/skills/data/sybra-monitor.md
@@ -1,14 +1,14 @@
 ---
-name: synapse-monitor
-description: Deprecated. Monitor now runs in-process inside Synapse. Use `synapse-cli monitor scan` for an ad-hoc detector pass or read the `monitor:report` event from the GUI.
+name: sybra-monitor
+description: Deprecated. Monitor now runs in-process inside Sybra. Use `sybra-cli monitor scan` for an ad-hoc detector pass or read the `monitor:report` event from the GUI.
 allowed-tools: Bash, Read
 user-invocable: true
 ---
 
-# Synapse Monitor (legacy skill stub)
+# Sybra Monitor (legacy skill stub)
 
-The monitor loop previously driven by `/loop 5m /synapse-monitor` now runs
-inside the Synapse Go backend (`internal/monitor/`). It ticks every 5 min,
+The monitor loop previously driven by `/loop 5m /sybra-monitor` now runs
+inside the Sybra Go backend (`internal/monitor/`). It ticks every 5 min,
 detects anomalies, applies idempotent remediations, and spawns focused
 headless Claude agents for anything that needs LLM judgment.
 
@@ -18,8 +18,8 @@ for it.
 ## Read-only ad-hoc pass
 
 ```bash
-synapse-cli monitor scan            # human summary line
-synapse-cli monitor scan --json     # full Report JSON
+sybra-cli monitor scan            # human summary line
+sybra-cli monitor scan --json     # full Report JSON
 ```
 
 The `--json` output matches `monitor.Report` in `internal/monitor/report.go`

--- a/internal/skills/data/sybra-plan.md
+++ b/internal/skills/data/sybra-plan.md
@@ -1,11 +1,11 @@
 ---
-name: synapse-plan
-description: Plan Synapse tasks — analyze scope, explore codebase, produce implementation plan without writing code. Use when asked to plan a task.
+name: sybra-plan
+description: Plan Sybra tasks — analyze scope, explore codebase, produce implementation plan without writing code. Use when asked to plan a task.
 allowed-tools: Bash, Read, Glob, WebFetch
 user-invocable: true
 ---
 
-# Synapse Task Planning
+# Sybra Task Planning
 
 Produce a detailed implementation plan for a task. Do NOT implement, write code, create files, or make changes.
 
@@ -13,14 +13,14 @@ You run inside an interactive tmux session. After producing a plan you STAY at t
 
 ## CLI Reference
 
-The ONLY valid flags for `synapse-cli update` are: `--title`, `--status`, `--body`, `--plan`, `--plan-file`, `--mode`, `--tags`, `--project`. Do NOT use any other flag.
+The ONLY valid flags for `sybra-cli update` are: `--title`, `--status`, `--body`, `--plan`, `--plan-file`, `--mode`, `--tags`, `--project`. Do NOT use any other flag.
 
 ## Process
 
 ### 1. Read the task
 
 ```bash
-synapse-cli --json get <id>
+sybra-cli --json get <id>
 ```
 
 ### 2. Analyze scope
@@ -59,8 +59,8 @@ Brief description of the chosen approach and why.
 ### 4. Publish the plan + hand off for review
 
 ```bash
-synapse-cli --json update <id> --plan "<full plan markdown>"
-synapse-cli --json update <id> --status plan-review
+sybra-cli --json update <id> --plan "<full plan markdown>"
+sybra-cli --json update <id> --status plan-review
 ```
 
 Then STOP and wait at the chat prompt. Do NOT exit. Do NOT implement.
@@ -71,8 +71,8 @@ The user may send feedback in the same chat session. When feedback arrives:
 
 1. Read it carefully
 2. Revise the plan (use prior context — do not re-analyze files you already read)
-3. `synapse-cli --json update <id> --plan "<revised plan>"`
-4. `synapse-cli --json update <id> --status plan-review`
+3. `sybra-cli --json update <id> --plan "<revised plan>"`
+4. `sybra-cli --json update <id> --status plan-review`
 5. Wait again
 
 ### Guidelines
@@ -110,8 +110,8 @@ Middleware using token bucket keyed by client IP. Reuse existing `internal/middl
 
 Then:
 ```bash
-synapse-cli --json update task-abc --plan "<plan above>"
-synapse-cli --json update task-abc --status plan-review
+sybra-cli --json update task-abc --plan "<plan above>"
+sybra-cli --json update task-abc --status plan-review
 ```
 Stay at prompt, wait for feedback.
 </example>

--- a/internal/skills/data/sybra-self-monitor.md
+++ b/internal/skills/data/sybra-self-monitor.md
@@ -1,21 +1,21 @@
 ---
-name: synapse-self-monitor
+name: sybra-self-monitor
 description: Periodic deep analysis of agent runs and workflow health. Reads structured findings from Go health checker, investigates root causes by reading agent logs, cross-correlates patterns, and files deduped GitHub issues. Designed for loop-agent invocation every ~6h.
 allowed-tools: Bash, Read, Grep, Glob
 user-invocable: true
 ---
 
-# Synapse Self-Monitor
+# Sybra Self-Monitor
 
-Deep reasoning analysis of Synapse agent runs and workflow health. The Go health checker (`internal/health/`) runs every 10 minutes and produces structured findings (cost outliers, failure spikes, stuck tasks, workflow loops, status bounces, cost drift). This skill consumes those findings and investigates the **why** — reading agent conversation logs, cross-correlating patterns, and producing actionable recommendations.
+Deep reasoning analysis of Sybra agent runs and workflow health. The Go health checker (`internal/health/`) runs every 10 minutes and produces structured findings (cost outliers, failure spikes, stuck tasks, workflow loops, status bounces, cost drift). This skill consumes those findings and investigates the **why** — reading agent conversation logs, cross-correlating patterns, and producing actionable recommendations.
 
-Designed to run as a loop agent (`/synapse-self-monitor` every 6h) but also works as a one-shot invocation.
+Designed to run as a loop agent (`/sybra-self-monitor` every 6h) but also works as a one-shot invocation.
 
 ## When not to use
 
-- Real-time board monitoring → use `/synapse-monitor` (runs every 5m inside the orchestrator session).
-- Deep historical audit report → use `/synapse-audit`.
-- Triaging tasks → use `/synapse-triage`.
+- Real-time board monitoring → use `/sybra-monitor` (runs every 5m inside the orchestrator session).
+- Deep historical audit report → use `/sybra-audit`.
+- Triaging tasks → use `/sybra-triage`.
 
 ## Hard rules
 
@@ -28,7 +28,7 @@ Designed to run as a loop agent (`/synapse-self-monitor` every 6h) but also work
 ## Phase 1 — Gather structured health data
 
 ```bash
-synapse-cli --json health
+sybra-cli --json health
 ```
 
 This returns the latest health report from the Go checker with all findings and stats.
@@ -36,13 +36,13 @@ This returns the latest health report from the Go checker with all findings and 
 If no report exists (app not running), fall back to manual audit analysis:
 
 ```bash
-synapse-cli --json audit --since 24h --summary
+sybra-cli --json audit --since 24h --summary
 ```
 
 For each finding with a `taskId`, fetch task details:
 
 ```bash
-synapse-cli --json get <taskId>
+sybra-cli --json get <taskId>
 ```
 
 ## Phase 2 — Deep investigation
@@ -103,13 +103,13 @@ After investigating individual findings, look for patterns across them:
 Determine the target repo:
 
 ```bash
-REPO=$(cd ~/.synapse && gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
+REPO=$(cd ~/.sybra && gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
 ```
 
 If empty, try the first registered project:
 
 ```bash
-REPO=$(synapse-cli --json project list 2>/dev/null | jq -r '.[0].id // empty')
+REPO=$(sybra-cli --json project list 2>/dev/null | jq -r '.[0].id // empty')
 ```
 
 If still empty, skip issue filing and just print findings to stdout.
@@ -117,13 +117,13 @@ If still empty, skip issue filing and just print findings to stdout.
 Ensure label exists:
 
 ```bash
-gh label create synapse-self-monitor --repo "$REPO" --color C5DEF5 --description "Filed by /synapse-self-monitor" 2>/dev/null || true
+gh label create sybra-self-monitor --repo "$REPO" --color C5DEF5 --description "Filed by /sybra-self-monitor" 2>/dev/null || true
 ```
 
 For each confirmed finding (not false positives), derive a stable title and search for duplicates:
 
 ```bash
-gh issue list --repo "$REPO" --label synapse-self-monitor --state all --search "in:title \"<title prefix>\"" --json number,state,title --limit 3
+gh issue list --repo "$REPO" --label sybra-self-monitor --state all --search "in:title \"<title prefix>\"" --json number,state,title --limit 3
 ```
 
 - Open match → skip
@@ -133,7 +133,7 @@ gh issue list --repo "$REPO" --label synapse-self-monitor --state all --search "
 Issue body format:
 
 ```bash
-gh issue create --repo "$REPO" --label synapse-self-monitor --title "<title>" --body "$(cat <<'EOF'
+gh issue create --repo "$REPO" --label sybra-self-monitor --title "<title>" --body "$(cat <<'EOF'
 ## Detection
 
 - **Time:** <ISO timestamp>
@@ -156,7 +156,7 @@ gh issue create --repo "$REPO" --label synapse-self-monitor --title "<title>" --
 
 ## Context
 
-Filed by synapse-self-monitor. Findings from Go health checker investigated with agent log analysis.
+Filed by sybra-self-monitor. Findings from Go health checker investigated with agent log analysis.
 EOF
 )"
 ```

--- a/internal/skills/data/sybra-tasks.md
+++ b/internal/skills/data/sybra-tasks.md
@@ -1,39 +1,39 @@
 ---
-name: synapse-tasks
-description: Manage Synapse tasks (list, create, update, delete) via synapse-cli. Use when user mentions tasks, work items, TODOs, or asks to track/create/update work.
+name: sybra-tasks
+description: Manage Sybra tasks (list, create, update, delete) via sybra-cli. Use when user mentions tasks, work items, TODOs, or asks to track/create/update work.
 allowed-tools: Bash
 user-invocable: true
 argument-hint: "[list|create|update|delete] [args]"
 ---
 
-# Synapse Task Management
+# Sybra Task Management
 
-Use `synapse-cli` to manage tasks. Always use `--json` for machine-parseable output.
+Use `sybra-cli` to manage tasks. Always use `--json` for machine-parseable output.
 
 ## Commands
 
 ```bash
 # List all tasks
-synapse-cli --json list
+sybra-cli --json list
 
 # Filter by status (todo, in-progress, in-review, done)
-synapse-cli --json list --status todo
+sybra-cli --json list --status todo
 
 # Filter by tag
-synapse-cli --json list --tag backend
+sybra-cli --json list --tag backend
 
 # Get single task
-synapse-cli --json get <id>
+sybra-cli --json get <id>
 
 # Create task
-synapse-cli --json create --title "task title" --body "markdown body" --mode headless --tags "tag1,tag2"
+sybra-cli --json create --title "task title" --body "markdown body" --mode headless --tags "tag1,tag2"
 
 # Update task fields (only specify what changes)
-synapse-cli --json update <id> --status in-progress
-synapse-cli --json update <id> --title "new title" --tags "new,tags"
+sybra-cli --json update <id> --status in-progress
+sybra-cli --json update <id> --title "new title" --tags "new,tags"
 
 # Delete task
-synapse-cli --json delete <id>
+sybra-cli --json delete <id>
 ```
 
 ## Task Fields
@@ -44,10 +44,10 @@ synapse-cli --json delete <id>
 
 ## Workflow
 
-1. `synapse-cli --json list --status todo` — see open tasks
-2. `synapse-cli --json update <id> --status in-progress` — pick up task
+1. `sybra-cli --json list --status todo` — see open tasks
+2. `sybra-cli --json update <id> --status in-progress` — pick up task
 3. Do the work
-4. `synapse-cli --json update <id> --status done` — mark complete
+4. `sybra-cli --json update <id> --status done` — mark complete
 
 ## Output Format
 
@@ -59,7 +59,7 @@ Errors: stderr `{"error": "message"}` with non-zero exit.
 <example>
 Input: User says "show me all open backend tasks".
 
-Command: `synapse-cli --json list --status todo --tag backend`
+Command: `sybra-cli --json list --status todo --tag backend`
 
 Output: JSON array of tasks matching both filters.
 </example>
@@ -69,7 +69,7 @@ Input: User says "create a task to fix the login bug, tag as auth, headless mode
 
 Command:
 ```bash
-synapse-cli --json create --title "fix login bug" --mode headless --tags "auth,bug"
+sybra-cli --json create --title "fix login bug" --mode headless --tags "auth,bug"
 ```
 
 Output: `{"id": "task-xyz", "title": "fix login bug", "status": "new", ...}`
@@ -78,7 +78,7 @@ Output: `{"id": "task-xyz", "title": "fix login bug", "status": "new", ...}`
 <example>
 Input: User says "mark task-abc as in progress".
 
-Command: `synapse-cli --json update task-abc --status in-progress`
+Command: `sybra-cli --json update task-abc --status in-progress`
 
 Output: Updated task JSON.
 </example>

--- a/internal/skills/data/sybra-test-plan.md
+++ b/internal/skills/data/sybra-test-plan.md
@@ -1,14 +1,14 @@
 ---
-name: synapse-test-plan
-description: Build a manual test plan for a Synapse task in the testing phase — spawns three distinct expert-tester personas (Bach, Kaner, Hendrickson) in parallel, each drafting test cases from their own frame, then merges before publishing. Critique is handled by a separate cross-provider workflow step. Covers Kubernetes and GUI app changes. Use whenever a task enters the testing status, when asked to "write a test plan", "plan manual tests", "figure out how to test X", or when reviewing a change that needs manual verification before merge.
+name: sybra-test-plan
+description: Build a manual test plan for a Sybra task in the testing phase — spawns three distinct expert-tester personas (Bach, Kaner, Hendrickson) in parallel, each drafting test cases from their own frame, then merges before publishing. Critique is handled by a separate cross-provider workflow step. Covers Kubernetes and GUI app changes. Use whenever a task enters the testing status, when asked to "write a test plan", "plan manual tests", "figure out how to test X", or when reviewing a change that needs manual verification before merge.
 allowed-tools: Bash, Read, Agent
 user-invocable: true
 ---
 
-<!-- justify: I2 flat single-file convention matches sibling synapse skills and the runtime ~/.synapse/skills/ sync; extracting to references/ would break parity -->
+<!-- justify: I2 flat single-file convention matches sibling sybra skills and the runtime ~/.sybra/skills/ sync; extracting to references/ would break parity -->
 <!-- justify: I17 side-effect signals appear inside domain checklists as example cases the human runs during manual testing, not commands the skill itself executes -->
 
-# Synapse Test Plan
+# Sybra Test Plan
 
 Produce a rigorous manual test plan for a task by spawning three expert-tester personas in parallel, merging their outputs, and publishing. Critique is handled by a separate cross-provider workflow step. Plan manual verification only — do not execute tests and do not write automated tests.
 
@@ -33,7 +33,7 @@ Parallel drafting (not parallel reviewing of a shared draft) preserves each pers
 
 ## CLI reference
 
-Test plan lives in the task's `--plan` field (same mechanism as `synapse-plan`). Valid `synapse-cli update` flags: `--title`, `--status`, `--body`, `--plan`, `--plan-file`, `--plan-critique`, `--plan-critique-file`, `--mode`, `--tags`, `--project`.
+Test plan lives in the task's `--plan` field (same mechanism as `sybra-plan`). Valid `sybra-cli update` flags: `--title`, `--status`, `--body`, `--plan`, `--plan-file`, `--plan-critique`, `--plan-critique-file`, `--mode`, `--tags`, `--project`.
 
 Status flow: `testing` → (parallel drafts + merge + review) → `test-plan-review`.
 
@@ -42,7 +42,7 @@ Status flow: `testing` → (parallel drafts + merge + review) → `test-plan-rev
 ### 1. Read the task and the change
 
 ```bash
-synapse-cli --json get <id>
+sybra-cli --json get <id>
 ```
 
 Read the task body, `plan` field, and any linked PR (`gh pr view <n> --json title,body,files`). Then read the changed files directly, because a plan written against a prose description misses real behavior — the code is the only reliable source of the actual surface area. Build a short "change under test" summary to hand to every persona.
@@ -164,8 +164,8 @@ Merge in the main context, not a subagent — a merge needs all three outputs he
 ### 5. Publish and hand off
 
 ```bash
-synapse-cli --json update <id> --plan "<final plan>"
-synapse-cli --json update <id> --status test-plan-review
+sybra-cli --json update <id> --plan "<final plan>"
+sybra-cli --json update <id> --status test-plan-review
 ```
 
 After publishing, stay at the chat prompt. Do not execute tests and do not exit, because the human reviewer will send feedback in the same chat session and needs the agent alive to receive it.
@@ -242,7 +242,7 @@ Share with every persona as context. Not every item applies to every change — 
 
 ## GUI app checklist
 
-Synapse frontend is Svelte 5 + Wails v2 in a desktop window. Share with every persona.
+Sybra frontend is Svelte 5 + Wails v2 in a desktop window. Share with every persona.
 
 - **Visual & layout**: components render without overlap at default size; no typos/Lorem Ipsum/debug text; loading/empty/error states distinct; dark + light theme (Skeleton UI); consistent font sizes.
 - **Responsiveness & resize**: resize to ~800×600 and very large; content reflows, no clipped text or unintended scrollbars; split panes snap to min/max.
@@ -272,16 +272,16 @@ Classify as GUI change. Read `TaskDetail.svelte` and `app.go`. Spawn three perso
 
 **Publish:**
 ```bash
-synapse-cli --json update task-xyz --plan "<merged plan>"
-synapse-cli --json update task-xyz --status test-plan-review
+sybra-cli --json update task-xyz --plan "<merged plan>"
+sybra-cli --json update task-xyz --status test-plan-review
 ```
 Stay at prompt.
 </example>
 
 <example>
-**Kubernetes change** — task `task-k8s-42`: "Add PodDisruptionBudget to synapse-agent Helm chart with `minAvailable: 1`; bump chart version to 0.4.0."
+**Kubernetes change** — task `task-k8s-42`: "Add PodDisruptionBudget to sybra-agent Helm chart with `minAvailable: 1`; bump chart version to 0.4.0."
 
-Classify as Kubernetes change. Read `charts/synapse-agent/templates/pdb.yaml`, `values.yaml`, and `Chart.yaml`. Spawn three personas in parallel with k8s checklist.
+Classify as Kubernetes change. Read `charts/sybra-agent/templates/pdb.yaml`, `values.yaml`, and `Chart.yaml`. Spawn three personas in parallel with k8s checklist.
 
 **Bach returns:** drain a node with only 1 replica running (does drain block forever?), set `minAvailable` higher than replicas (`helm lint` should catch), upgrade from 0.3.x → 0.4.0 then rollback, PDB with 0 replicas at time of drain, concurrent drain of 2 nodes.
 
@@ -308,8 +308,8 @@ Verify the word "Received" renders correctly in the task detail panel header.
 ```
 
 ```bash
-synapse-cli --json update task-typo-7 --plan "<smoke plan>"
-synapse-cli --json update task-typo-7 --status test-plan-review
+sybra-cli --json update task-typo-7 --plan "<smoke plan>"
+sybra-cli --json update task-typo-7 --status test-plan-review
 ```
 </example>
 

--- a/internal/skills/data/sybra-triage.md
+++ b/internal/skills/data/sybra-triage.md
@@ -1,11 +1,11 @@
 ---
-name: synapse-triage
-description: Triage Synapse tasks — delegate to the Go classifier which rewrites the title, assigns tags/mode/status, and matches a project in one atomic update. Use when asked to triage, categorize, or prioritize tasks.
+name: sybra-triage
+description: Triage Sybra tasks — delegate to the Go classifier which rewrites the title, assigns tags/mode/status, and matches a project in one atomic update. Use when asked to triage, categorize, or prioritize tasks.
 allowed-tools: Bash
 user-invocable: true
 ---
 
-# Synapse Task Triage
+# Sybra Task Triage
 
 Classify pending tasks via the Go classifier. Go owns routing rules, tag validation, project auto-match, and atomic multi-field updates. The LLM only produces the structured verdict.
 
@@ -14,13 +14,13 @@ Classify pending tasks via the Go classifier. Go owns routing rules, tag validat
 1. List pending tasks:
 
    ```bash
-   synapse-cli --json list --status new
+   sybra-cli --json list --status new
    ```
 
 2. For each task, run the classifier:
 
    ```bash
-   synapse-cli --json triage classify <id>
+   sybra-cli --json triage classify <id>
    ```
 
    This makes a single `claude -p` call that:
@@ -36,12 +36,12 @@ Classify pending tasks via the Go classifier. Go owns routing rules, tag validat
 3. Batch mode for larger queues:
 
    ```bash
-   synapse-cli --json triage classify --all
+   sybra-cli --json triage classify --all
    ```
 
 ## Constraints
 
-- Do NOT call `synapse-cli update` directly during triage — the Go classifier owns every field change. Manual updates will race the classifier and break audit trails.
+- Do NOT call `sybra-cli update` directly during triage — the Go classifier owns every field change. Manual updates will race the classifier and break audit trails.
 - Do NOT explore the codebase or read source files — the classifier sees only `{title, body, registered projects}`. Codebase exploration belongs in planning/implementation.
-- If `classify` returns an error, flag the task with `synapse-cli update <id> --status human-required --status-reason "triage failed"` and move on.
+- If `classify` returns an error, flag the task with `sybra-cli update <id> --status human-required --status-reason "triage failed"` and move on.
 - Ignore tasks with `role` field set (triage, plan, eval, pr-fix) — those are system agents, not implementation work.

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -1198,10 +1198,12 @@ func (a *App) syncSkills() {
 
 	if useEmbedded {
 		a.logger.Info("skills.sync.embedded", "dst", a.skillsDir)
-		a.syncFSDir(a.skillsFS, "data", a.skillsDir)
+		a.syncFSSkillsDir(a.skillsFS, "data", a.skillsDir)
+		if userHome, err2 := os.UserHomeDir(); err2 == nil && filepath.Clean(a.skillsDir) != filepath.Clean(filepath.Join(userHome, ".claude", "skills")) {
+			a.syncFSSkillsDir(a.skillsFS, "data", filepath.Join(userHome, ".claude", "skills"))
+		}
 		if userHome, err2 := os.UserHomeDir(); err2 == nil {
-			a.syncFSDir(a.skillsFS, "data", filepath.Join(userHome, ".claude", "skills"))
-			a.syncFSToCodexDir(a.skillsFS, "data", filepath.Join(userHome, ".codex", "skills"))
+			a.syncFSSkillsDir(a.skillsFS, "data", filepath.Join(userHome, ".codex", "skills"))
 		}
 		a.logger.Info("skills.sync.done")
 		return
@@ -1209,13 +1211,15 @@ func (a *App) syncSkills() {
 
 	a.logger.Info("skills.sync.start", "src", repoDir, "dst", a.skillsDir)
 
-	a.syncDir(skillsSrc, a.skillsDir)
+	a.syncSkillsDir(skillsSrc, a.skillsDir)
 
 	// Also sync to the system Claude Code and Codex skills dirs so headless
 	// agents launched via `claude -p` or `codex exec` can discover skills.
 	if userHome, err := os.UserHomeDir(); err == nil {
-		a.syncDir(skillsSrc, filepath.Join(userHome, ".claude", "skills"))
-		a.syncToCodexDir(skillsSrc, filepath.Join(userHome, ".codex", "skills"))
+		if filepath.Clean(a.skillsDir) != filepath.Clean(filepath.Join(userHome, ".claude", "skills")) {
+			a.syncSkillsDir(skillsSrc, filepath.Join(userHome, ".claude", "skills"))
+		}
+		a.syncSkillsDir(skillsSrc, filepath.Join(userHome, ".codex", "skills"))
 	}
 
 	claudeSrc := filepath.Join(repoDir, "orchestrator", "CLAUDE.md")
@@ -1224,103 +1228,6 @@ func (a *App) syncSkills() {
 	a.syncFile(claudeSrc, filepath.Join(config.HomeDir(), "AGENTS.md"))
 
 	a.logger.Info("skills.sync.done")
-}
-
-func (a *App) syncDir(src, dst string) {
-	entries, err := os.ReadDir(src)
-	if err != nil {
-		a.logger.Debug("sync.skip", "src", src, "reason", err)
-		return
-	}
-	if err := os.MkdirAll(dst, 0o755); err != nil {
-		a.logger.Error("sync.mkdir", "dst", dst, "err", err)
-		return
-	}
-	cleanSrc := filepath.Clean(src) + string(filepath.Separator)
-	cleanDst := filepath.Clean(dst) + string(filepath.Separator)
-
-	srcNames := make(map[string]struct{}, len(entries))
-	srcDirs := make(map[string]struct{}, len(entries))
-	for _, e := range entries {
-		if e.Type()&fs.ModeSymlink != 0 {
-			a.logger.Debug("sync.skip.symlink", "name", e.Name())
-			continue
-		}
-		if e.IsDir() {
-			if a.copySkillDir(src, dst, cleanSrc, cleanDst, e.Name(), "sync") {
-				a.logger.Info("sync.copied", "dir", e.Name())
-				srcDirs[e.Name()] = struct{}{}
-			}
-			continue
-		}
-		if filepath.Ext(e.Name()) != ".md" {
-			continue
-		}
-		srcPath := filepath.Join(filepath.Clean(src), e.Name())
-		dstPath := filepath.Join(filepath.Clean(dst), e.Name())
-		if !strings.HasPrefix(srcPath+string(filepath.Separator), cleanSrc) ||
-			!strings.HasPrefix(dstPath+string(filepath.Separator), cleanDst) {
-			a.logger.Warn("sync.skip.traversal", "name", e.Name())
-			continue
-		}
-		data, err := os.ReadFile(srcPath)
-		if err != nil {
-			a.logger.Warn("sync.read.fail", "name", e.Name(), "err", err)
-			continue
-		}
-		if !hasYAMLFrontmatter(data) {
-			a.logger.Warn("sync.skip.invalid", "name", e.Name(), "reason", "missing YAML frontmatter")
-			continue
-		}
-		if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
-			a.logger.Error("sync.mkdir", "dst", dstPath, "err", err)
-			continue
-		}
-		if err := os.WriteFile(dstPath, data, 0o644); err != nil {
-			a.logger.Error("sync.write", "dst", dstPath, "err", err)
-			continue
-		}
-		a.logger.Info("sync.copied", "file", e.Name())
-		srcNames[e.Name()] = struct{}{}
-	}
-
-	// Remove orphan .md files and directory skills in dst.
-	dstEntries, err := os.ReadDir(dst)
-	if err != nil {
-		return
-	}
-	for _, e := range dstEntries {
-		dstPath := filepath.Join(filepath.Clean(dst), e.Name())
-		if !strings.HasPrefix(dstPath+string(filepath.Separator), cleanDst) {
-			continue
-		}
-		if e.IsDir() {
-			if _, ok := srcDirs[e.Name()]; ok {
-				continue
-			}
-			// Only remove orphan dirs that look like skill dirs (have SKILL.md).
-			if _, statErr := os.Stat(filepath.Join(dstPath, "SKILL.md")); statErr != nil {
-				continue
-			}
-			if err := os.RemoveAll(dstPath); err != nil {
-				a.logger.Warn("sync.orphan.remove.fail", "dir", e.Name(), "err", err)
-			} else {
-				a.logger.Info("sync.orphan.removed", "dir", e.Name())
-			}
-			continue
-		}
-		if filepath.Ext(e.Name()) != ".md" {
-			continue
-		}
-		if _, ok := srcNames[e.Name()]; ok {
-			continue
-		}
-		if err := os.Remove(dstPath); err != nil {
-			a.logger.Warn("sync.orphan.remove.fail", "file", e.Name(), "err", err)
-		} else {
-			a.logger.Info("sync.orphan.removed", "file", e.Name())
-		}
-	}
 }
 
 func (a *App) syncFile(src, dst string) {
@@ -1338,71 +1245,6 @@ func (a *App) syncFile(src, dst string) {
 		return
 	}
 	a.logger.Info("sync.copied", "file", filepath.Base(dst))
-}
-
-// syncFSDir copies .md files from srcDir inside fsys to the dst filesystem path.
-// It mirrors syncDir but reads from an fs.FS instead of the host filesystem.
-func (a *App) syncFSDir(fsys fs.FS, srcDir, dst string) {
-	entries, err := fs.ReadDir(fsys, srcDir)
-	if err != nil {
-		a.logger.Debug("sync.fs.skip", "src", srcDir, "reason", err)
-		return
-	}
-	if err := os.MkdirAll(dst, 0o755); err != nil {
-		a.logger.Error("sync.mkdir", "dst", dst, "err", err)
-		return
-	}
-	cleanDst := filepath.Clean(dst) + string(filepath.Separator)
-
-	srcNames := make(map[string]struct{}, len(entries))
-	for _, e := range entries {
-		if e.IsDir() || filepath.Ext(e.Name()) != ".md" {
-			continue
-		}
-		dstPath := filepath.Join(filepath.Clean(dst), e.Name())
-		if !strings.HasPrefix(dstPath+string(filepath.Separator), cleanDst) {
-			a.logger.Warn("sync.skip.traversal", "name", e.Name())
-			continue
-		}
-		data, err := fs.ReadFile(fsys, srcDir+"/"+e.Name())
-		if err != nil {
-			a.logger.Warn("sync.fs.read.fail", "name", e.Name(), "err", err)
-			continue
-		}
-		if !hasYAMLFrontmatter(data) {
-			a.logger.Warn("sync.skip.invalid", "name", e.Name(), "reason", "missing YAML frontmatter")
-			continue
-		}
-		if err := os.WriteFile(dstPath, data, 0o644); err != nil {
-			a.logger.Error("sync.write", "dst", dstPath, "err", err)
-			continue
-		}
-		a.logger.Info("sync.copied", "file", e.Name())
-		srcNames[e.Name()] = struct{}{}
-	}
-
-	// Remove orphan .md files in dst that are not in the embedded bundle.
-	dstEntries, err := os.ReadDir(dst)
-	if err != nil {
-		return
-	}
-	for _, e := range dstEntries {
-		if e.IsDir() || filepath.Ext(e.Name()) != ".md" {
-			continue
-		}
-		if _, ok := srcNames[e.Name()]; ok {
-			continue
-		}
-		dstPath := filepath.Join(filepath.Clean(dst), e.Name())
-		if !strings.HasPrefix(dstPath+string(filepath.Separator), cleanDst) {
-			continue
-		}
-		if err := os.Remove(dstPath); err != nil {
-			a.logger.Warn("sync.orphan.remove.fail", "file", e.Name(), "err", err)
-		} else {
-			a.logger.Info("sync.orphan.removed", "file", e.Name())
-		}
-	}
 }
 
 // hasYAMLFrontmatter reports whether data begins with a YAML frontmatter
@@ -1487,17 +1329,19 @@ func (a *App) copySkillDir(src, dst, cleanSrc, cleanDst, name, logPrefix string)
 	return true
 }
 
-// syncToCodexDir reads flat .md skill files from src and writes each one as
-// dst/<name>/SKILL.md — the subdirectory layout expected by the Codex CLI.
+// syncSkillsDir reads flat .md skill files (and directory-style skills) from
+// src and writes each one as dst/<name>/SKILL.md — the subdirectory layout
+// Claude Code and Codex both expect. Flat files in dst are NOT discovered by
+// Claude Code's skill loader, so this layout is mandatory.
 // Orphan skill subdirs (present in dst but absent from src) are removed.
-func (a *App) syncToCodexDir(src, dst string) {
+func (a *App) syncSkillsDir(src, dst string) {
 	entries, err := os.ReadDir(src)
 	if err != nil {
-		a.logger.Debug("sync.codex.skip", "src", src, "reason", err)
+		a.logger.Debug("sync.skill.skip", "src", src, "reason", err)
 		return
 	}
 	if err := os.MkdirAll(dst, 0o755); err != nil {
-		a.logger.Error("sync.codex.mkdir", "dst", dst, "err", err)
+		a.logger.Error("sync.skill.mkdir", "dst", dst, "err", err)
 		return
 	}
 	cleanSrc := filepath.Clean(src) + string(filepath.Separator)
@@ -1509,8 +1353,8 @@ func (a *App) syncToCodexDir(src, dst string) {
 			continue
 		}
 		if e.IsDir() {
-			if a.copySkillDir(src, dst, cleanSrc, cleanDst, e.Name(), "sync.codex") {
-				a.logger.Info("sync.codex.copied", "skill", e.Name())
+			if a.copySkillDir(src, dst, cleanSrc, cleanDst, e.Name(), "sync.skill") {
+				a.logger.Info("sync.skill.copied", "skill", e.Name())
 				srcNames[e.Name()] = struct{}{}
 			}
 			continue
@@ -1520,34 +1364,34 @@ func (a *App) syncToCodexDir(src, dst string) {
 		}
 		srcPath := filepath.Join(filepath.Clean(src), e.Name())
 		if !strings.HasPrefix(srcPath+string(filepath.Separator), cleanSrc) {
-			a.logger.Warn("sync.codex.skip.traversal", "name", e.Name())
+			a.logger.Warn("sync.skill.skip.traversal", "name", e.Name())
 			continue
 		}
 		name := strings.TrimSuffix(e.Name(), ".md")
 		skillDir := filepath.Join(filepath.Clean(dst), name)
 		if !strings.HasPrefix(skillDir+string(filepath.Separator), cleanDst) {
-			a.logger.Warn("sync.codex.skip.traversal", "name", e.Name())
+			a.logger.Warn("sync.skill.skip.traversal", "name", e.Name())
 			continue
 		}
 		dstPath := filepath.Join(skillDir, "SKILL.md")
 		data, err := os.ReadFile(srcPath)
 		if err != nil {
-			a.logger.Warn("sync.codex.read.fail", "name", e.Name(), "err", err)
+			a.logger.Warn("sync.skill.read.fail", "name", e.Name(), "err", err)
 			continue
 		}
 		if !hasYAMLFrontmatter(data) {
-			a.logger.Warn("sync.codex.skip.invalid", "name", e.Name(), "reason", "missing YAML frontmatter")
+			a.logger.Warn("sync.skill.skip.invalid", "name", e.Name(), "reason", "missing YAML frontmatter")
 			continue
 		}
 		if err := os.MkdirAll(skillDir, 0o755); err != nil {
-			a.logger.Error("sync.codex.mkdir.skill", "dir", skillDir, "err", err)
+			a.logger.Error("sync.skill.mkdir.skill", "dir", skillDir, "err", err)
 			continue
 		}
 		if err := os.WriteFile(dstPath, data, 0o644); err != nil {
-			a.logger.Error("sync.codex.write", "dst", dstPath, "err", err)
+			a.logger.Error("sync.skill.write", "dst", dstPath, "err", err)
 			continue
 		}
-		a.logger.Info("sync.codex.copied", "skill", name)
+		a.logger.Info("sync.skill.copied", "skill", name)
 		srcNames[name] = struct{}{}
 	}
 
@@ -1572,22 +1416,22 @@ func (a *App) syncToCodexDir(src, dst string) {
 			continue
 		}
 		if err := os.RemoveAll(filepath.Join(filepath.Clean(dst), e.Name())); err != nil {
-			a.logger.Warn("sync.codex.orphan.remove.fail", "skill", e.Name(), "err", err)
+			a.logger.Warn("sync.skill.orphan.remove.fail", "skill", e.Name(), "err", err)
 		} else {
-			a.logger.Info("sync.codex.orphan.removed", "skill", e.Name())
+			a.logger.Info("sync.skill.orphan.removed", "skill", e.Name())
 		}
 	}
 }
 
-// syncFSToCodexDir mirrors syncToCodexDir but reads source files from an fs.FS.
-func (a *App) syncFSToCodexDir(fsys fs.FS, srcDir, dst string) {
+// syncFSSkillsDir mirrors syncSkillsDir but reads source files from an fs.FS.
+func (a *App) syncFSSkillsDir(fsys fs.FS, srcDir, dst string) {
 	entries, err := fs.ReadDir(fsys, srcDir)
 	if err != nil {
-		a.logger.Debug("sync.codex.fs.skip", "src", srcDir, "reason", err)
+		a.logger.Debug("sync.skill.fs.skip", "src", srcDir, "reason", err)
 		return
 	}
 	if err := os.MkdirAll(dst, 0o755); err != nil {
-		a.logger.Error("sync.codex.mkdir", "dst", dst, "err", err)
+		a.logger.Error("sync.skill.mkdir", "dst", dst, "err", err)
 		return
 	}
 	cleanDst := filepath.Clean(dst) + string(filepath.Separator)
@@ -1600,28 +1444,28 @@ func (a *App) syncFSToCodexDir(fsys fs.FS, srcDir, dst string) {
 		name := strings.TrimSuffix(e.Name(), ".md")
 		skillDir := filepath.Join(filepath.Clean(dst), name)
 		if !strings.HasPrefix(skillDir+string(filepath.Separator), cleanDst) {
-			a.logger.Warn("sync.codex.skip.traversal", "name", e.Name())
+			a.logger.Warn("sync.skill.skip.traversal", "name", e.Name())
 			continue
 		}
 		dstPath := filepath.Join(skillDir, "SKILL.md")
 		data, err := fs.ReadFile(fsys, srcDir+"/"+e.Name())
 		if err != nil {
-			a.logger.Warn("sync.codex.fs.read.fail", "name", e.Name(), "err", err)
+			a.logger.Warn("sync.skill.fs.read.fail", "name", e.Name(), "err", err)
 			continue
 		}
 		if !hasYAMLFrontmatter(data) {
-			a.logger.Warn("sync.codex.skip.invalid", "name", e.Name(), "reason", "missing YAML frontmatter")
+			a.logger.Warn("sync.skill.skip.invalid", "name", e.Name(), "reason", "missing YAML frontmatter")
 			continue
 		}
 		if err := os.MkdirAll(skillDir, 0o755); err != nil {
-			a.logger.Error("sync.codex.mkdir.skill", "dir", skillDir, "err", err)
+			a.logger.Error("sync.skill.mkdir.skill", "dir", skillDir, "err", err)
 			continue
 		}
 		if err := os.WriteFile(dstPath, data, 0o644); err != nil {
-			a.logger.Error("sync.codex.write", "dst", dstPath, "err", err)
+			a.logger.Error("sync.skill.write", "dst", dstPath, "err", err)
 			continue
 		}
-		a.logger.Info("sync.codex.copied", "skill", name)
+		a.logger.Info("sync.skill.copied", "skill", name)
 		srcNames[name] = struct{}{}
 	}
 
@@ -1645,9 +1489,9 @@ func (a *App) syncFSToCodexDir(fsys fs.FS, srcDir, dst string) {
 			continue
 		}
 		if err := os.RemoveAll(filepath.Join(filepath.Clean(dst), e.Name())); err != nil {
-			a.logger.Warn("sync.codex.orphan.remove.fail", "skill", e.Name(), "err", err)
+			a.logger.Warn("sync.skill.orphan.remove.fail", "skill", e.Name(), "err", err)
 		} else {
-			a.logger.Info("sync.codex.orphan.removed", "skill", e.Name())
+			a.logger.Info("sync.skill.orphan.removed", "skill", e.Name())
 		}
 	}
 }

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -402,7 +402,7 @@ func TestSyncFileMissingSrc(t *testing.T) {
 	}
 }
 
-func TestSyncDir(t *testing.T) {
+func TestSyncSkillsDir(t *testing.T) {
 	a := setupApp(t)
 
 	srcDir := filepath.Join(t.TempDir(), "skills")
@@ -412,35 +412,37 @@ func TestSyncDir(t *testing.T) {
 	frontmatter := func(name string) []byte {
 		return []byte("---\nname: " + name + "\ndescription: test\n---\n\n# " + name)
 	}
-	for _, name := range []string{"a.md", "b.md"} {
-		if err := os.WriteFile(filepath.Join(srcDir, name), frontmatter(name), 0o644); err != nil {
+	for _, name := range []string{"a", "b"} {
+		if err := os.WriteFile(filepath.Join(srcDir, name+".md"), frontmatter(name), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
-	// Non-.md, subdir, and a malformed .md without frontmatter must all be skipped.
+	// Non-.md, and a malformed .md without frontmatter must be skipped.
 	if err := os.WriteFile(filepath.Join(srcDir, "c.txt"), []byte("content-c"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "no-frontmatter.md"), []byte("# nope"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(srcDir, "subdir"), 0o755); err != nil {
-		t.Fatal(err)
-	}
 
 	dstDir := filepath.Join(t.TempDir(), "dst-skills")
-	a.syncDir(srcDir, dstDir)
+	a.syncSkillsDir(srcDir, dstDir)
 
-	entries, err := os.ReadDir(dstDir)
-	if err != nil {
-		t.Fatalf("read dst: %v", err)
+	// Each valid flat skill must land as <name>/SKILL.md, which is the layout
+	// Claude Code and Codex both require — flat .md files in the destination
+	// are never discovered by the skill loader.
+	for _, name := range []string{"a", "b"} {
+		skillMD := filepath.Join(dstDir, name, "SKILL.md")
+		if _, err := os.Stat(skillMD); err != nil {
+			t.Errorf("%s/SKILL.md missing at dst: %v", name, err)
+		}
 	}
-	if len(entries) != 2 {
-		t.Errorf("got %d files, want 2 (only valid .md with frontmatter)", len(entries))
+	if _, err := os.Stat(filepath.Join(dstDir, "no-frontmatter")); !os.IsNotExist(err) {
+		t.Errorf("malformed skill should not be written: stat err=%v", err)
 	}
 }
 
-func TestSyncDirRemovesOrphans(t *testing.T) {
+func TestSyncSkillsDirRemovesOrphans(t *testing.T) {
 	a := setupApp(t)
 
 	srcDir := filepath.Join(t.TempDir(), "skills")
@@ -453,29 +455,25 @@ func TestSyncDirRemovesOrphans(t *testing.T) {
 	}
 
 	dstDir := filepath.Join(t.TempDir(), "dst-skills")
-	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+	orphan := filepath.Join(dstDir, "orphan")
+	if err := os.MkdirAll(orphan, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	// Pre-populate orphan file that should be removed.
-	if err := os.WriteFile(filepath.Join(dstDir, "orphan.md"), []byte("---\nname: orphan\ndescription: test\n---\n\n# orphan"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(orphan, "SKILL.md"), []byte("---\nname: orphan\n---\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	a.syncDir(srcDir, dstDir)
+	a.syncSkillsDir(srcDir, dstDir)
 
-	entries, err := os.ReadDir(dstDir)
-	if err != nil {
-		t.Fatalf("read dst: %v", err)
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Errorf("orphan skill dir should be removed: stat err=%v", err)
 	}
-	if len(entries) != 1 {
-		t.Errorf("got %d files, want 1 (orphan removed)", len(entries))
-	}
-	if entries[0].Name() != "keep.md" {
-		t.Errorf("expected keep.md, got %s", entries[0].Name())
+	if _, err := os.Stat(filepath.Join(dstDir, "keep", "SKILL.md")); err != nil {
+		t.Errorf("keep/SKILL.md missing: %v", err)
 	}
 }
 
-func TestSyncDirCopiesDirectoryStyleSkill(t *testing.T) {
+func TestSyncSkillsDirCopiesDirectoryStyleSkill(t *testing.T) {
 	a := setupApp(t)
 
 	srcDir := filepath.Join(t.TempDir(), "skills")
@@ -491,7 +489,6 @@ func TestSyncDirCopiesDirectoryStyleSkill(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(refDir, "checklist.md"), []byte("# checklist"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	// Malformed directory skill (no frontmatter) must be skipped.
 	badDir := filepath.Join(srcDir, "bad-skill")
 	if err := os.MkdirAll(badDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -501,7 +498,7 @@ func TestSyncDirCopiesDirectoryStyleSkill(t *testing.T) {
 	}
 
 	dstDir := filepath.Join(t.TempDir(), "dst-skills")
-	a.syncDir(srcDir, dstDir)
+	a.syncSkillsDir(srcDir, dstDir)
 
 	if _, err := os.Stat(filepath.Join(dstDir, "plan-critic", "SKILL.md")); err != nil {
 		t.Errorf("SKILL.md missing at dst: %v", err)
@@ -514,42 +511,7 @@ func TestSyncDirCopiesDirectoryStyleSkill(t *testing.T) {
 	}
 }
 
-func TestSyncDirRemovesOrphanSkillDir(t *testing.T) {
-	a := setupApp(t)
-
-	srcDir := filepath.Join(t.TempDir(), "skills")
-	if err := os.MkdirAll(srcDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	dstDir := filepath.Join(t.TempDir(), "dst-skills")
-	orphan := filepath.Join(dstDir, "orphan-skill")
-	if err := os.MkdirAll(orphan, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(orphan, "SKILL.md"), []byte("---\nname: orphan\n---\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	// A non-skill dir (no SKILL.md) must be preserved.
-	keepDir := filepath.Join(dstDir, "not-a-skill")
-	if err := os.MkdirAll(keepDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(keepDir, "hello.txt"), []byte("hi"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	a.syncDir(srcDir, dstDir)
-
-	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
-		t.Errorf("orphan skill dir should be removed: stat err=%v", err)
-	}
-	if _, err := os.Stat(keepDir); err != nil {
-		t.Errorf("non-skill dir should be preserved: %v", err)
-	}
-}
-
-func TestSyncToCodexDirDirectoryStyleAndFrontmatter(t *testing.T) {
+func TestSyncSkillsDirDirectoryStyleAndFrontmatter(t *testing.T) {
 	a := setupApp(t)
 
 	srcDir := filepath.Join(t.TempDir(), "skills")
@@ -586,7 +548,7 @@ func TestSyncToCodexDirDirectoryStyleAndFrontmatter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	a.syncToCodexDir(srcDir, dstDir)
+	a.syncSkillsDir(srcDir, dstDir)
 
 	if _, err := os.Stat(filepath.Join(dstDir, "good-flat", "SKILL.md")); err != nil {
 		t.Errorf("good-flat not written: %v", err)
@@ -632,11 +594,12 @@ func TestSyncSkillsPrefersEmbeddedWhenNoGoMod(t *testing.T) {
 
 	a.syncSkills()
 
-	// Embedded content should be present in a.skillsDir (not rogue).
-	if _, err := os.Stat(filepath.Join(a.skillsDir, "embedded-skill.md")); err != nil {
+	// Embedded content lands at <name>/SKILL.md — the layout Claude Code
+	// and Codex require. Flat .md files at the top are not discoverable.
+	if _, err := os.Stat(filepath.Join(a.skillsDir, "embedded-skill", "SKILL.md")); err != nil {
 		t.Errorf("embedded skill missing: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(a.skillsDir, "rogue.md")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(a.skillsDir, "rogue")); !os.IsNotExist(err) {
 		t.Errorf("rogue skill leaked into app skills dir")
 	}
 }
@@ -673,18 +636,18 @@ func TestSyncSkillsUsesRepoSourceWhenGoModPresent(t *testing.T) {
 
 	a.syncSkills()
 
-	if _, err := os.Stat(filepath.Join(a.skillsDir, "repo-skill.md")); err != nil {
+	if _, err := os.Stat(filepath.Join(a.skillsDir, "repo-skill", "SKILL.md")); err != nil {
 		t.Errorf("repo skill missing: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(a.skillsDir, "embed-only.md")); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(a.skillsDir, "embed-only")); !os.IsNotExist(err) {
 		t.Errorf("embedded skill should not be written in repo-source mode")
 	}
 }
 
-func TestSyncDirMissingSrc(t *testing.T) {
+func TestSyncSkillsDirMissingSrc(t *testing.T) {
 	a := setupApp(t)
 	dstDir := filepath.Join(t.TempDir(), "should-not-exist")
-	a.syncDir("/nonexistent/dir", dstDir)
+	a.syncSkillsDir("/nonexistent/dir", dstDir)
 
 	if _, err := os.Stat(dstDir); !os.IsNotExist(err) {
 		t.Error("dst dir should not be created when src missing")

--- a/internal/workflow/builtin/simple-task.yaml
+++ b/internal/workflow/builtin/simple-task.yaml
@@ -18,8 +18,8 @@ steps:
       model: sonnet
       max_retries: 3
       prompt: >-
-        Triage task {{.Task.ID}} using /synapse-triage skill.
-        Get the task with synapse-cli, analyze it, assign tags, mode, and update status.
+        Triage task {{.Task.ID}} using /sybra-triage skill.
+        Get the task with sybra-cli, analyze it, assign tags, mode, and update status.
         IMPORTANT: if the task title is a URL (e.g. a GitHub issue/PR link),
         you MUST fetch the real title from that URL using gh and update the task title
         to a human-readable summary. Never leave a raw URL as the task title.
@@ -78,13 +78,13 @@ steps:
         Revise the plan for task {{.Task.ID}} to address these points.
         Update the plan and set status back to plan-review when done.
         {{- else }}
-        Plan task {{.Task.ID}} using /synapse-plan skill.
-        Get the task with synapse-cli, analyze the codebase,
+        Plan task {{.Task.ID}} using /sybra-plan skill.
+        Get the task with sybra-cli, analyze the codebase,
         and produce a detailed implementation plan.
 
         When the plan is ready:
-          1. synapse-cli update {{.Task.ID}} --plan "<full plan markdown>"
-          2. synapse-cli update {{.Task.ID}} --status plan-review
+          1. sybra-cli update {{.Task.ID}} --plan "<full plan markdown>"
+          2. sybra-cli update {{.Task.ID}} --status plan-review
 
         Then STOP and wait. Do NOT exit. Do NOT implement.
 
@@ -134,16 +134,16 @@ steps:
         Critique the plan for task {{.Task.ID}} using the /plan-critic skill.
 
         Steps:
-          1. Run: synapse-cli --json get {{.Task.ID}}
+          1. Run: sybra-cli --json get {{.Task.ID}}
           2. Extract the .plan field from the JSON output and write it to
-             /tmp/synapse-plan-{{.Task.ID}}.md
-          3. Invoke: /plan-critic /tmp/synapse-plan-{{.Task.ID}}.md
+             /tmp/sybra-plan-{{.Task.ID}}.md
+          3. Invoke: /plan-critic /tmp/sybra-plan-{{.Task.ID}}.md
           4. Capture the full markdown Plan Review report you produce and
-             write it to /tmp/synapse-critique-{{.Task.ID}}.md
-          5. Save it: synapse-cli update {{.Task.ID}} --plan-critique-file /tmp/synapse-critique-{{.Task.ID}}.md
+             write it to /tmp/sybra-critique-{{.Task.ID}}.md
+          5. Save it: sybra-cli update {{.Task.ID}} --plan-critique-file /tmp/sybra-critique-{{.Task.ID}}.md
 
         Do NOT modify the plan. Do NOT change the task status. Your only
-        side effect is writing the critique sidecar via synapse-cli.
+        side effect is writing the critique sidecar via sybra-cli.
       allowed_tools:
         - Bash
         - Read
@@ -176,10 +176,10 @@ steps:
         The plan critic has reviewed your plan for task {{.Task.ID}}.
 
         Steps:
-          1. synapse-cli --json get {{.Task.ID}} — read the .plan_critique field
+          1. sybra-cli --json get {{.Task.ID}} — read the .plan_critique field
           2. For each concern raised, revise the plan to address it
-          3. synapse-cli update {{.Task.ID}} --plan "<full revised plan markdown>"
-          4. synapse-cli update {{.Task.ID}} --status plan-review
+          3. sybra-cli update {{.Task.ID}} --plan "<full revised plan markdown>"
+          4. sybra-cli update {{.Task.ID}} --status plan-review
 
         Then STOP and wait. Do NOT implement.
     next:
@@ -300,9 +300,9 @@ steps:
         The PR has not been created yet — review the local diff.
 
         Steps:
-          1. git diff origin/main..HEAD > /tmp/synapse-diff-{{.Task.ID}}.patch
+          1. git diff origin/main..HEAD > /tmp/sybra-diff-{{.Task.ID}}.patch
           2. Run /staff-code-review against that patch and the worktree source
-          3. Save the full review to /tmp/synapse-review-{{.Task.ID}}.md
+          3. Save the full review to /tmp/sybra-review-{{.Task.ID}}.md
 
         Do NOT submit anything to GitHub. Only save to the file.
     next:
@@ -317,7 +317,7 @@ steps:
       needs_worktree: true
       max_retries: 2
       prompt: >-
-        Read the code review at /tmp/synapse-review-{{.Task.ID}}.md
+        Read the code review at /tmp/sybra-review-{{.Task.ID}}.md
 
         For each actionable finding (critical/high/medium severity), fix the code.
         Skip low-severity nitpicks and style-only comments.

--- a/internal/workflow/builtin/testing-task.yaml
+++ b/internal/workflow/builtin/testing-task.yaml
@@ -27,14 +27,14 @@ steps:
         {{ $feedback }}
 
         Revise the manual test plan for task {{.Task.ID}} to address these points
-        using the /synapse-test-plan skill. Update --plan and set status back to
+        using the /sybra-test-plan skill. Update --plan and set status back to
         test-plan-review when done.
         {{- else }}
-        Prepare a manual test plan for task {{.Task.ID}} using the /synapse-test-plan skill.
+        Prepare a manual test plan for task {{.Task.ID}} using the /sybra-test-plan skill.
 
         When the plan is ready:
-          1. synapse-cli update {{.Task.ID}} --plan "<full plan markdown>"
-          2. synapse-cli update {{.Task.ID}} --status test-plan-review
+          1. sybra-cli update {{.Task.ID}} --plan "<full plan markdown>"
+          2. sybra-cli update {{.Task.ID}} --status test-plan-review
 
         Then STOP and wait. Do NOT exit. Do NOT execute the tests yet.
 
@@ -83,16 +83,16 @@ steps:
         Critique the test plan for task {{.Task.ID}} using the /plan-critic skill.
 
         Steps:
-          1. Run: synapse-cli --json get {{.Task.ID}}
+          1. Run: sybra-cli --json get {{.Task.ID}}
           2. Extract the .plan field from the JSON output and write it to
-             /tmp/synapse-plan-{{.Task.ID}}.md
-          3. Invoke: /plan-critic /tmp/synapse-plan-{{.Task.ID}}.md
+             /tmp/sybra-plan-{{.Task.ID}}.md
+          3. Invoke: /plan-critic /tmp/sybra-plan-{{.Task.ID}}.md
           4. Capture the full markdown Plan Review report you produce and
-             write it to /tmp/synapse-critique-{{.Task.ID}}.md
-          5. Save it: synapse-cli update {{.Task.ID}} --plan-critique-file /tmp/synapse-critique-{{.Task.ID}}.md
+             write it to /tmp/sybra-critique-{{.Task.ID}}.md
+          5. Save it: sybra-cli update {{.Task.ID}} --plan-critique-file /tmp/sybra-critique-{{.Task.ID}}.md
 
         Do NOT modify the plan. Do NOT change the task status. Your only
-        side effect is writing the critique sidecar via synapse-cli.
+        side effect is writing the critique sidecar via sybra-cli.
       allowed_tools:
         - Bash
         - Read
@@ -143,12 +143,12 @@ steps:
       prompt: >-
         Execute the approved manual test plan for task {{.Task.ID}}.
 
-        1. synapse-cli --json get {{.Task.ID}}  (the .plan field contains the approved test plan)
+        1. sybra-cli --json get {{.Task.ID}}  (the .plan field contains the approved test plan)
         2. Run each test case. Start the app/CLI as needed, interact with it,
            capture observed vs expected results.
         3. Append a "## Test Results" section to the task body documenting
            pass/fail for each case plus any reproduction notes.
-        4. synapse-cli update {{.Task.ID}} --status human-required
+        4. sybra-cli update {{.Task.ID}} --status human-required
            --status-reason "manual testing complete - verify results"
     next:
       - goto: ""

--- a/orchestrator/CLAUDE.md
+++ b/orchestrator/CLAUDE.md
@@ -1,6 +1,6 @@
-# Synapse Orchestrator
+# Sybra Orchestrator
 
-You are the Synapse orchestrator — an autonomous Claude Code session managing a swarm of tasks and agents. Your job: triage incoming work, spawn agents, monitor progress, handle failures, and keep the task board healthy.
+You are the Sybra orchestrator — an autonomous Claude Code session managing a swarm of tasks and agents. Your job: triage incoming work, spawn agents, monitor progress, handle failures, and keep the task board healthy.
 
 ## Session runtime
 
@@ -14,15 +14,15 @@ On every session start, immediately set up the recurring monitor cycle via
 CronCreate:
 
 ```
-CronCreate(schedule="*/5 * * * *", prompt="/synapse-monitor")
+CronCreate(schedule="*/5 * * * *", prompt="/sybra-monitor")
 ```
 
 Do this before any other work. If a cron job with this prompt already exists,
 skip creation. The monitor loop drives your core work cycle — without it you
 will only act once and then idle.
 
-Synapse's Go watchdog reads `~/.synapse/logs/monitor-heartbeat` on a 1-minute
-tick to detect a dead cron. The `/synapse-monitor` skill writes that file on
+Sybra's Go watchdog reads `~/.sybra/logs/monitor-heartbeat` on a 1-minute
+tick to detect a dead cron. The `/sybra-monitor` skill writes that file on
 every cycle — if you edit the skill, keep the heartbeat write intact or the
 watchdog will force-restart your session within ~12 minutes.
 
@@ -118,10 +118,10 @@ If the task references a GitHub repo that is registered as a project, assign it:
 
 ```bash
 # List registered projects
-synapse-cli --json project list
+sybra-cli --json project list
 
 # Assign project to task
-synapse-cli --json update <id> --project "owner/repo"
+sybra-cli --json update <id> --project "owner/repo"
 ```
 
 When a task has a project assigned, the system automatically creates a git worktree from the project's bare clone when starting an agent. This gives each agent an isolated working copy.
@@ -147,7 +147,7 @@ Planning uses dedicated board columns (statuses), not a sub-state:
 
 ### Provider Selection
 
-Synapse supports two agent providers: `claude` (default) and `codex`. The active provider is set globally in `~/.synapse/config.yaml` under `agent.provider`. You cannot override it per-task — all dispatched agents use the configured provider.
+Sybra supports two agent providers: `claude` (default) and `codex`. The active provider is set globally in `~/.sybra/config.yaml` under `agent.provider`. You cannot override it per-task — all dispatched agents use the configured provider.
 
 **When to prefer Codex:**
 
@@ -162,10 +162,10 @@ Synapse supports two agent providers: `claude` (default) and `codex`. The active
 
 - No session resume — every headless run starts fresh; multi-turn recovery requires re-stating context in the prompt
 - No `--allowedTools` — use `RequirePermissions=true` to restrict to `workspace-write` sandbox, or accept `--full-auto`
-- Cost not reported in stream — usage visible on OpenAI dashboard, not in Synapse UI
+- Cost not reported in stream — usage visible on OpenAI dashboard, not in Sybra UI
 - Interactive mode spawns a new process per turn (no persistent stdin)
 
-If the provider is `codex`, Synapse calls:
+If the provider is `codex`, Sybra calls:
 ```bash
 codex exec --json --skip-git-repo-check --full-auto [--model <model>] -C <worktree> "<prompt>"
 ```
@@ -177,8 +177,8 @@ See `docs/codex-setup.md` for full setup and auth details.
 Headless tasks get a structured prompt:
 
 ```bash
-synapse-cli --json update <id> --status in-progress
-# Then start agent via Synapse GUI or tmux
+sybra-cli --json update <id> --status in-progress
+# Then start agent via Sybra GUI or tmux
 ```
 
 For interactive tasks, just update status — human will attach.
@@ -190,7 +190,7 @@ For interactive tasks, just update status — human will attach.
 Get a full board snapshot in one call:
 
 ```bash
-synapse-cli --json board
+sybra-cli --json board
 ```
 
 Returns `counts` (all statuses), `in_progress` (with `running_for_s`),
@@ -238,7 +238,7 @@ Escalate to human (mark as `interactive` or `human-required`) when:
 When making non-obvious decisions, update the task body with rationale:
 
 ```bash
-synapse-cli --json update <id> --body "## Decision
+sybra-cli --json update <id> --body "## Decision
 Chose headless mode because PR is a dependency bump with <50 lines changed.
 
 ## Original Description
@@ -248,24 +248,24 @@ Chose headless mode because PR is a dependency bump with <50 lines changed.
 Plans are stored separately from the body. Use `--plan` for plan content:
 
 ```bash
-synapse-cli --json update <id> --plan "<full plan markdown>"
+sybra-cli --json update <id> --plan "<full plan markdown>"
 ```
 
 ## Audit Log Analysis
 
-Synapse records structured audit events (task lifecycle, agent runs, costs, failures) as NDJSON at `~/.synapse/logs/audit/`. Use these to identify workflow problems and suggest improvements.
+Sybra records structured audit events (task lifecycle, agent runs, costs, failures) as NDJSON at `~/.sybra/logs/audit/`. Use these to identify workflow problems and suggest improvements.
 
 ### Quick health check
 
 ```bash
-synapse-cli --json audit --since 7d --summary
+sybra-cli --json audit --since 7d --summary
 ```
 
 ### What to look for
 
 | Signal | Threshold | Action |
 |--------|-----------|--------|
-| failure_rate > 0.2 | High | Check failed agents: `synapse-cli --json audit --since 7d --type agent.failed` |
+| failure_rate > 0.2 | High | Check failed agents: `sybra-cli --json audit --since 7d --type agent.failed` |
 | plan_rejection_rate > 0.3 | High | Tasks are under-specified at triage — improve context gathering |
 | status bottleneck: plan-review > 4h | Medium | Human is the bottleneck — auto-approve small tasks |
 | status bottleneck: human-required > 8h | High | Tasks stuck — notify or escalate |
@@ -273,7 +273,7 @@ synapse-cli --json audit --since 7d --summary
 
 ### Deep analysis
 
-Use `/synapse-audit` skill for a full report covering failures, bottlenecks, cost outliers, and triage accuracy.
+Use `/sybra-audit` skill for a full report covering failures, bottlenecks, cost outliers, and triage accuracy.
 
 ### Periodic review
 
@@ -281,7 +281,7 @@ Run audit analysis during the monitor phase of the core loop. Suggested cadence:
 
 ## Working Conventions
 
-- Always use `synapse-cli --json` for task operations
+- Always use `sybra-cli --json` for task operations
 - Parse JSON output, never rely on human-readable format
 - Update task status immediately when state changes
 - Add context to task body when triaging (gathered from URLs, repos)
@@ -313,7 +313,7 @@ Do NOT finish without committing. Uncommitted work will be lost.
 
 After implementation, an eval agent runs to link the PR and flip status:
 
-1. `synapse-cli get <id>` to load the task
+1. `sybra-cli get <id>` to load the task
 2. Recover PR number from: task.pr_number, agent result text (github.com/.../pull/N), or `gh pr list --head <branch>`
 3. Status transitions:
    - PR found → `in-review` (link via `--pr`)

--- a/perf-testing.md
+++ b/perf-testing.md
@@ -1,6 +1,6 @@
-# Synapse perf-testing guide
+# Sybra perf-testing guide
 
-Everything is token-free — fake-claude replaces the real `claude` CLI via PATH injection in an isolated `SYNAPSE_HOME` tempdir. Your real `~/.synapse/` is never touched.
+Everything is token-free — fake-claude replaces the real `claude` CLI via PATH injection in an isolated `SYBRA_HOME` tempdir. Your real `~/.sybra/` is never touched.
 
 ## 1. Go benchmarks (no server needed)
 
@@ -35,14 +35,14 @@ go test -run XXX -bench . -benchmem -count=6 ./internal/task/ > after.txt
 benchstat before.txt after.txt
 ```
 
-## 2. End-to-end harness (`cmd/synapse-perf`)
+## 2. End-to-end harness (`cmd/sybra-perf`)
 
 Build the harness + fake-claude once:
 
 ```bash
 mise run perf:build
-# produces bin/synapse-perf and bin/fake-claude
-# synapse-server is spawned via `go run` inside the harness (cached on rebuild)
+# produces bin/sybra-perf and bin/fake-claude
+# sybra-server is spawned via `go run` inside the harness (cached on rebuild)
 ```
 
 ### Scenarios
@@ -50,7 +50,7 @@ mise run perf:build
 **steady** — N agents ramped over T seconds, held for `-duration`. Each agent runs `perf_stream` (N events at M ms interval). Primary measurement: agent startup latency.
 
 ```bash
-./bin/synapse-perf -scenario steady \
+./bin/sybra-perf -scenario steady \
   -concurrency 8 -duration 30s -ramp 2s \
   -events 200 -event-interval 10ms \
   -fake-claude ./bin/fake-claude
@@ -59,7 +59,7 @@ mise run perf:build
 **spike** — No ramp. All agents start as fast as possible with `perf_burst` (zero-interval events). Stresses the 50 ms emit throttle and concurrency bookkeeping.
 
 ```bash
-./bin/synapse-perf -scenario spike \
+./bin/sybra-perf -scenario spike \
   -concurrency 16 -duration 10s \
   -events 500 \
   -fake-claude ./bin/fake-claude
@@ -68,7 +68,7 @@ mise run perf:build
 **soak** — Long runtime with `perf_long`. Pair with `-pprof-dir` for before/after heap diffs — the point is catching goroutine or buffer leaks.
 
 ```bash
-./bin/synapse-perf -scenario soak \
+./bin/sybra-perf -scenario soak \
   -concurrency 4 -duration 5m \
   -event-interval 200ms \
   -fake-claude ./bin/fake-claude \
@@ -78,7 +78,7 @@ mise run perf:build
 **churn** — No agents. Hammers `TaskService.CreateTask / UpdateTask / DeleteTask` at a target rate. Updates touch `body` only (no hooks fire), so the numbers reflect pure CRUD latency.
 
 ```bash
-./bin/synapse-perf -scenario churn \
+./bin/sybra-perf -scenario churn \
   -concurrency 4 -duration 30s -churn-rate 200 \
   -fake-claude ./bin/fake-claude
 ```
@@ -103,10 +103,10 @@ mise run perf:soak    # 5 min soak + pprof
 | `-event-interval` | 10ms                      | fake-claude inter-event delay                                      |
 | `-churn-rate`     | 100                       | ops/sec for churn                                                  |
 | `-fake-claude`    | *(builds via `go run`)*   | pre-built binary path (faster)                                     |
-| `-workdir`        | *(tmp)*                   | custom SYNAPSE_HOME — use to inspect server state after a run      |
+| `-workdir`        | *(tmp)*                   | custom SYBRA_HOME — use to inspect server state after a run      |
 | `-pprof-dir`      | *(off)*                   | heap + goroutine snapshots before/after                            |
 | `-report`         | *(stdout)*                | write JSON report to a file                                        |
-| `-keep-home`      | false                     | do not delete the temp SYNAPSE_HOME                                |
+| `-keep-home`      | false                     | do not delete the temp SYBRA_HOME                                |
 | `-verbose`        | false                     | log server output and per-agent progress                           |
 
 ### Saving reports cleanly
@@ -114,7 +114,7 @@ mise run perf:soak    # 5 min soak + pprof
 The JSON report goes to stdout by default. Piping it through `grep`/`head` will truncate. Use `-report`:
 
 ```bash
-./bin/synapse-perf -scenario churn -duration 30s -churn-rate 200 \
+./bin/sybra-perf -scenario churn -duration 30s -churn-rate 200 \
   -fake-claude ./bin/fake-claude \
   -report /tmp/churn.json
 
@@ -130,14 +130,14 @@ Top-level keys:
 - `outputEvents` — agent-level throughput (sum across all agents).
 - `agents[]` — per-agent `agentId`, `taskId`, `startLatencyMS`, `observedEventCount`, `error`.
 - `createLatencyMS / updateLatencyMS / deleteLatencyMS` (churn) — `count / min / p50 / p95 / p99 / max / mean` for each operation.
-- `metricsBefore / metricsAfter` — Prometheus snapshot of `synapse_agent_*`, `synapse_task_*`, `go_goroutines`, `process_resident_memory_bytes`. Subtract to see the scenario's impact.
+- `metricsBefore / metricsAfter` — Prometheus snapshot of `sybra_agent_*`, `sybra_task_*`, `go_goroutines`, `process_resident_memory_bytes`. Subtract to see the scenario's impact.
 
 ## 4. pprof workflow
 
 Pull profiles during or after a soak/steady run:
 
 ```bash
-./bin/synapse-perf -scenario soak -duration 5m -concurrency 4 \
+./bin/sybra-perf -scenario soak -duration 5m -concurrency 4 \
   -fake-claude ./bin/fake-claude -pprof-dir ./perf-profiles
 
 # files produced: heap-before.pb.gz, heap-after.pb.gz,
@@ -149,7 +149,7 @@ go tool pprof -diff_base ./perf-profiles/heap-before.pb.gz ./perf-profiles/heap-
 For on-demand profiles against a live harness run, start the server manually with pprof:
 
 ```bash
-SYNAPSE_PPROF=1 SYNAPSE_HOME=/tmp/synapse-manual go run ./cmd/synapse-server
+SYBRA_PPROF=1 SYBRA_HOME=/tmp/sybra-manual go run ./cmd/sybra-server
 # in another shell:
 curl -o cpu.pb.gz "http://127.0.0.1:8080/debug/pprof/profile?seconds=30"
 curl -o goroutines.txt "http://127.0.0.1:8080/debug/pprof/goroutine?debug=2"
@@ -157,18 +157,18 @@ curl -o goroutines.txt "http://127.0.0.1:8080/debug/pprof/goroutine?debug=2"
 
 ## 5. Troubleshooting
 
-- **First run is slow** — `go run ./cmd/synapse-server` pays a cold compile cost (~15–25s). Subsequent runs are cached by Go's build cache.
+- **First run is slow** — `go run ./cmd/sybra-server` pays a cold compile cost (~15–25s). Subsequent runs are cached by Go's build cache.
 - **"Dir not accessible"** — the harness creates `research/` inside the temp home; if this surfaces, your `-workdir` is on a filesystem the server can't stat. Use the default temp path.
 - **Steady report shows `observedEventCount: 0`** — agents started but didn't stream events back before the scenario ended. Increase `-duration` or drop `-event-interval`.
 - **Churn returns `churnErrors > 0`** — check server logs with `-verbose`; usually the churn worker pool is saturated (raise `-concurrency`).
-- **pprof files are empty** — `SYNAPSE_PPROF=1` must be set on the server; the harness sets it automatically when you pass `-pprof-dir`.
-- **Want to peek at server state after a run** — pass `-keep-home -workdir /tmp/synapse-debug` and the whole SYNAPSE_HOME (tasks, logs, audit) stays on disk for inspection.
+- **pprof files are empty** — `SYBRA_PPROF=1` must be set on the server; the harness sets it automatically when you pass `-pprof-dir`.
+- **Want to peek at server state after a run** — pass `-keep-home -workdir /tmp/sybra-debug` and the whole SYBRA_HOME (tasks, logs, audit) stays on disk for inspection.
 
 ## 6. Files created for perf work
 
 - `cmd/fake-claude/main.go` — new `perf_stream`/`perf_burst`/`perf_long` scenarios (+tests in `main_test.go`)
-- `cmd/synapse-perf/main.go` — the e2e harness binary
-- `cmd/synapse-server/main.go` — `/debug/pprof/*` mounted behind `SYNAPSE_PPROF=1`
+- `cmd/sybra-perf/main.go` — the e2e harness binary
+- `cmd/sybra-server/main.go` — `/debug/pprof/*` mounted behind `SYBRA_PPROF=1`
 - `internal/task/store_bench_test.go`
 - `internal/agent/stream_bench_test.go`
 - `internal/sse/broker_bench_test.go`


### PR DESCRIPTION
## Motivation

Server agents on `synapse` home-nas failed with:

```
[Skill] <tool_use_error>Unknown skill: synapse-triage</tool_use_error>
```

even though `/home/sybra/.claude/skills/synapse-triage.md` existed
with valid frontmatter. Root cause: `syncSkills` wrote **flat**
`~/.claude/skills/<name>.md` files, but Claude Code's skill loader
only discovers `<name>/SKILL.md` **subdirectories**. Flat files
are silently ignored — the skills were on disk but invisible to
the agent.

Two secondary issues piggyback here: the embedded skills still used
the old `synapse-*` naming (project was renamed to `sybra`), and
workflow prompts invoked `synapse-cli` which does not exist on the
server (`sybra-cli` does).

> Changelog: fix(skills): dir layout for skill discovery

## Implementation information

**1. Directory layout**
- Delete `syncDir` / `syncFSDir` (flat writers).
- Rename `syncToCodexDir` / `syncFSToCodexDir` -> `syncSkillsDir`
  / `syncFSSkillsDir`. Codex already required the subdir layout;
  Claude Code needs the same format, so one function covers both.
- `syncSkills` now calls `syncSkillsDir` for all three
  destinations (app `skillsDir`, `~/.claude/skills/`,
  `~/.codex/skills/`). Deduped so the default `skillsDir` is not
  written twice.
- Orphan cleanup removes stale `<name>/SKILL.md` subdirs when a
  skill is deleted from the source bundle. First boot on the
  server will also garbage-collect the old flat files.

**2. Skill rename** — 8 files `synapse-*.md` -> `sybra-*.md` via
`git mv` (preserves history). Frontmatter `name:`, titles, CLI
references, cross-references, path references all updated.

**3. Sweep** — `/synapse-*` -> `/sybra-*`, `synapse-cli` ->
`sybra-cli`, `~/.synapse/` -> `~/.sybra/`, `SYNAPSE_HOME/PPROF`
-> `SYBRA_HOME/PPROF`, stale binary names in `.gitignore`,
orchestrator CLAUDE.md, README, `docs/codex-setup.md`,
`perf-testing.md`, `Dockerfile` comment, `internal/project/model.go`
comment, agent skill-invoke test data.

Infrastructure names kept as-is where they refer to real
resources: LXC hostname `synapse`, `synapse-stack.yml` compose
file, historical rename-scenario test fixtures, `synapseIssueLabel`
constant (value is already `"sybra"`).

**Deploy** — requires a server image rebuild + redeploy from
`home-nas` for the fix to apply.

## Supporting documentation

Diagnosed live on `192.168.20.219`:
- `/home/sybra/.claude/skills/` contained only flat `.md` files
- Local `~/.claude/skills/` on working machines uses `<name>/SKILL.md`
- All working plugin skills on the host follow the subdir layout

## Test plan

- [x] `go test ./internal/sybra/ ./internal/agent/ ./internal/workflow/`
- [x] `go test ./...` — all packages pass (root `main.go` fails on
      `frontend/dist` embed, pre-existing and server-irrelevant per
      `CLAUDE.md`)
- [x] `golangci-lint run ./internal/sybra/ ./internal/agent/ ./internal/workflow/` — 0 issues
- [ ] Deploy to `synapse` LXC and confirm `ls /home/sybra/.claude/skills/`
      shows `<name>/SKILL.md` subdirs
- [ ] Trigger a triage workflow on the server and confirm the Skill
      tool now finds `sybra-triage` instead of returning
      "Unknown skill"