### PR TITLE
feat(review): preserve critic output as sidecars

### DIFF
--- a/cmd/fake-claude/main.go
+++ b/cmd/fake-claude/main.go
@@ -104,25 +104,11 @@ func runScenario(scenario, taskID string) bool {
 	case "triage_to_planning_nocritic":
 		runTriage(taskID, "planning", "large,nocritic")
 	case "plan_critic_success":
-		emitSystem()
-		emitAssistant("Critiquing plan...")
-		if taskID != "" {
-			runCLI("update", taskID, "--plan-critique", "# Plan Critique\n\n## Verdict: REFINE\n\n- Consider edge case X.\n")
-		}
-		emitResult("Critique saved.")
+		runPlanCriticSuccess(taskID)
 	case "plan_critic_no_save":
-		// Simulates codex agent that exited cleanly without actually saving
-		// the critique sidecar (bwrap-blocked shell inside Docker container).
-		emitSystem()
-		emitAssistant("Blocked by env. Did not save critique.")
-		emitResult("Blocked by env.")
+		runPlanCriticNoSave()
 	case "code_review_success":
-		emitSystem()
-		emitAssistant("Reviewing code...")
-		if taskID != "" {
-			runCLI("update", taskID, "--code-review", "# Code Review\n\nLooks good.\n")
-		}
-		emitResult("Review saved.")
+		runCodeReviewSuccess(taskID)
 	case "triage_to_done":
 		runTriage(taskID, "done", "")
 	case "triage_to_in_review":
@@ -171,6 +157,30 @@ func runScenario(scenario, taskID string) bool {
 		return false
 	}
 	return true
+}
+
+func runPlanCriticSuccess(taskID string) {
+	emitSystem()
+	emitAssistant("Critiquing plan...")
+	if taskID != "" {
+		runCLI("update", taskID, "--plan-critique", "# Plan Critique\n\n## Verdict: REFINE\n\n- Consider edge case X.\n")
+	}
+	emitResult("Critique saved.")
+}
+
+func runPlanCriticNoSave() {
+	emitSystem()
+	emitAssistant("Blocked by env. Did not save critique.")
+	emitResult("Blocked by env.")
+}
+
+func runCodeReviewSuccess(taskID string) {
+	emitSystem()
+	emitAssistant("Reviewing code...")
+	if taskID != "" {
+		runCLI("update", taskID, "--code-review", "# Code Review\n\nLooks good.\n")
+	}
+	emitResult("Review saved.")
 }
 
 func runTriage(taskID, status, tags string) {

--- a/cmd/fake-claude/main.go
+++ b/cmd/fake-claude/main.go
@@ -103,6 +103,26 @@ func runScenario(scenario, taskID string) bool {
 		runTriage(taskID, "planning", "large")
 	case "triage_to_planning_nocritic":
 		runTriage(taskID, "planning", "large,nocritic")
+	case "plan_critic_success":
+		emitSystem()
+		emitAssistant("Critiquing plan...")
+		if taskID != "" {
+			runCLI("update", taskID, "--plan-critique", "# Plan Critique\n\n## Verdict: REFINE\n\n- Consider edge case X.\n")
+		}
+		emitResult("Critique saved.")
+	case "plan_critic_no_save":
+		// Simulates codex agent that exited cleanly without actually saving
+		// the critique sidecar (bwrap-blocked shell inside Docker container).
+		emitSystem()
+		emitAssistant("Blocked by env. Did not save critique.")
+		emitResult("Blocked by env.")
+	case "code_review_success":
+		emitSystem()
+		emitAssistant("Reviewing code...")
+		if taskID != "" {
+			runCLI("update", taskID, "--code-review", "# Code Review\n\nLooks good.\n")
+		}
+		emitResult("Review saved.")
 	case "triage_to_done":
 		runTriage(taskID, "done", "")
 	case "triage_to_in_review":

--- a/cmd/fake-codex/main.go
+++ b/cmd/fake-codex/main.go
@@ -72,6 +72,19 @@ func runExec() {
 		emitAgentMessage("Triaging task...")
 		runCLI(taskID, "update", taskID, "--status", "planning", "--tags", "large,nocritic")
 		emitTurnCompleted(100, 20)
+	case "plan_critic_success":
+		emitAgentMessage("Critiquing plan...")
+		runCLI(taskID, "update", taskID, "--plan-critique", "# Plan Critique\n\n## Verdict: REFINE\n\n- Consider edge case X.\n")
+		emitTurnCompleted(100, 20)
+	case "plan_critic_no_save":
+		// Simulates codex agent blocked by env (bwrap sandbox failure) — exits
+		// cleanly without saving the critique sidecar.
+		emitAgentMessage("Blocked by env. Did not save critique.")
+		emitTurnCompleted(100, 20)
+	case "code_review_success":
+		emitAgentMessage("Reviewing code...")
+		runCLI(taskID, "update", taskID, "--code-review", "# Code Review\n\nLooks good.\n")
+		emitTurnCompleted(100, 20)
 	case "triage_to_done":
 		emitAgentMessage("Triaging task...")
 		runCLI(taskID, "update", taskID, "--status", "done")

--- a/cmd/fake-codex/main.go
+++ b/cmd/fake-codex/main.go
@@ -73,18 +73,11 @@ func runExec() {
 		runCLI(taskID, "update", taskID, "--status", "planning", "--tags", "large,nocritic")
 		emitTurnCompleted(100, 20)
 	case "plan_critic_success":
-		emitAgentMessage("Critiquing plan...")
-		runCLI(taskID, "update", taskID, "--plan-critique", "# Plan Critique\n\n## Verdict: REFINE\n\n- Consider edge case X.\n")
-		emitTurnCompleted(100, 20)
+		runCodexPlanCriticSuccess(taskID)
 	case "plan_critic_no_save":
-		// Simulates codex agent blocked by env (bwrap sandbox failure) — exits
-		// cleanly without saving the critique sidecar.
-		emitAgentMessage("Blocked by env. Did not save critique.")
-		emitTurnCompleted(100, 20)
+		runCodexPlanCriticNoSave()
 	case "code_review_success":
-		emitAgentMessage("Reviewing code...")
-		runCLI(taskID, "update", taskID, "--code-review", "# Code Review\n\nLooks good.\n")
-		emitTurnCompleted(100, 20)
+		runCodexCodeReviewSuccess(taskID)
 	case "triage_to_done":
 		emitAgentMessage("Triaging task...")
 		runCLI(taskID, "update", taskID, "--status", "done")
@@ -121,16 +114,37 @@ func runExec() {
 		emitError("Authentication failed")
 		os.Exit(1)
 	case "malformed_pr_output":
-		var b strings.Builder
-		for range 200 {
-			b.WriteString("note: saw github.com/test-org/test-repo/pul/42 and github.com/test-org/test-repo/pulls/42\n")
-		}
-		emitAgentMessage(b.String())
-		emitTurnCompleted(100, 20)
+		runCodexMalformedPR()
 	default:
 		fmt.Fprintf(os.Stderr, "unknown scenario: %s\n", scenario)
 		os.Exit(2)
 	}
+}
+
+func runCodexMalformedPR() {
+	var b strings.Builder
+	for range 200 {
+		b.WriteString("note: saw github.com/test-org/test-repo/pul/42 and github.com/test-org/test-repo/pulls/42\n")
+	}
+	emitAgentMessage(b.String())
+	emitTurnCompleted(100, 20)
+}
+
+func runCodexPlanCriticSuccess(taskID string) {
+	emitAgentMessage("Critiquing plan...")
+	runCLI(taskID, "update", taskID, "--plan-critique", "# Plan Critique\n\n## Verdict: REFINE\n\n- Consider edge case X.\n")
+	emitTurnCompleted(100, 20)
+}
+
+func runCodexPlanCriticNoSave() {
+	emitAgentMessage("Blocked by env. Did not save critique.")
+	emitTurnCompleted(100, 20)
+}
+
+func runCodexCodeReviewSuccess(taskID string) {
+	emitAgentMessage("Reviewing code...")
+	runCLI(taskID, "update", taskID, "--code-review", "# Code Review\n\nLooks good.\n")
+	emitTurnCompleted(100, 20)
 }
 
 func runInteractive() {

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -182,6 +182,9 @@ func cmdGet(s *task.Manager, args []string, jsonOut bool) int {
 	if t.PlanCritique != "" {
 		fmt.Printf("\n## Plan Critique\n\n%s\n", t.PlanCritique)
 	}
+	if t.CodeReview != "" {
+		fmt.Printf("\n## Code Review\n\n%s\n", t.CodeReview)
+	}
 	return 0
 }
 
@@ -270,6 +273,8 @@ func cmdUpdate(s *task.Manager, args []string, jsonOut bool) int {
 	planFile := fs.String("plan-file", "", "path to file with plan content")
 	planCritique := fs.String("plan-critique", "", "plan critique markdown (empty string clears critique)")
 	planCritiqueFile := fs.String("plan-critique-file", "", "path to file with plan critique content")
+	codeReview := fs.String("code-review", "", "code review markdown (empty string clears review)")
+	codeReviewFile := fs.String("code-review-file", "", "path to file with code review content")
 	mode := fs.String("mode", "", "new agent mode")
 	ttype := fs.String("type", "", "new task type: normal|debug|research")
 	tags := fs.String("tags", "", "comma-separated tags (replaces existing)")
@@ -299,6 +304,9 @@ func cmdUpdate(s *task.Manager, args []string, jsonOut bool) int {
 		return fatal(jsonOut, "%v", err)
 	}
 	if err := applyFileOrStringUpdate(fs, updates, "plan-critique", "plan_critique", *planCritique, *planCritiqueFile); err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+	if err := applyFileOrStringUpdate(fs, updates, "code-review", "code_review", *codeReview, *codeReviewFile); err != nil {
 		return fatal(jsonOut, "%v", err)
 	}
 	if *mode != "" {

--- a/frontend/src/components/TaskCard.svelte.test.ts
+++ b/frontend/src/components/TaskCard.svelte.test.ts
@@ -23,6 +23,7 @@ const mockTask = {
   body: '',
   plan: '',
   planCritique: '',
+  codeReview: '',
   filePath: '',
   taskType: '',
   todoistId: '',

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -114,6 +114,7 @@
 
   const renderedBody = $derived(renderMarkdown(t?.body))
   const renderedPlan = $derived(renderMarkdown(t?.plan))
+  const renderedCodeReview = $derived(renderMarkdown(t?.codeReview))
   const taskBranchName = $derived(
     t ? 'sybra/' + (t.slug ? t.slug + '-' + t.id : t.id) : ''
   )
@@ -909,6 +910,17 @@
             <div class="markdown-body text-sm text-surface-900 dark:text-surface-100">{@html renderedPlan}</div>
           </div>
         </div>
+      {/if}
+
+      {#if t.codeReview}
+        <details open class="rounded-lg border border-warning-300 bg-warning-50 dark:border-warning-700 dark:bg-warning-900/20">
+          <summary class="cursor-pointer px-4 py-2 text-sm font-semibold text-warning-800 dark:text-warning-200">
+            Code Review (auto-generated)
+          </summary>
+          <div class="markdown-body px-4 pb-4 text-sm text-surface-900 dark:text-surface-100">
+            {@html renderedCodeReview}
+          </div>
+        </details>
       {/if}
 
       <div class="flex flex-wrap items-center gap-4 text-xs text-surface-400">

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1472,6 +1472,7 @@ export namespace task {
 	    body: string;
 	    plan?: string;
 	    planCritique?: string;
+	    codeReview?: string;
 	    filePath: string;
 	
 	    static createFrom(source: any = {}) {
@@ -1507,6 +1508,7 @@ export namespace task {
 	        this.body = source["body"];
 	        this.plan = source["plan"];
 	        this.planCritique = source["planCritique"];
+	        this.codeReview = source["codeReview"];
 	        this.filePath = source["filePath"];
 	    }
 	
@@ -1617,6 +1619,7 @@ export namespace workflow {
 	    waitForStatus: string;
 	    command: string;
 	    dir: string;
+	    sidecar: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new StepConfig(source);
@@ -1640,6 +1643,7 @@ export namespace workflow {
 	        this.waitForStatus = source["waitForStatus"];
 	        this.command = source["command"];
 	        this.dir = source["dir"];
+	        this.sidecar = source["sidecar"];
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -287,15 +287,27 @@ func buildClaudeCommand(model string, allowedTools []string, requirePerms bool) 
 // buildCodexCommand builds the display command string for a Codex agent.
 func buildCodexCommand(model string, requirePerms bool) string {
 	parts := []string{"codex", "exec", "--json", "--skip-git-repo-check"}
-	if !requirePerms {
-		parts = append(parts, "--full-auto")
-	} else {
-		parts = append(parts, "--sandbox", "workspace-write")
-	}
+	parts = append(parts, codexSandboxArgs(requirePerms)...)
 	if model != "" {
 		parts = append(parts, "--model", model)
 	}
 	return strings.Join(parts, " ")
+}
+
+// codexSandboxArgs returns the sandbox/permission flags for `codex exec`.
+// When SYBRA_DISABLE_CODEX_SANDBOX=1 is set, the bwrap-backed sandbox is
+// replaced with `--sandbox danger-full-access`. Required when running
+// inside a Docker/LXC container whose kernel blocks unprivileged user
+// namespaces (kernel.unprivileged_userns_clone=0), where bwrap crashes
+// before the agent can execute any command.
+func codexSandboxArgs(requirePerms bool) []string {
+	if os.Getenv("SYBRA_DISABLE_CODEX_SANDBOX") == "1" {
+		return []string{"--sandbox", "danger-full-access"}
+	}
+	if !requirePerms {
+		return []string{"--full-auto"}
+	}
+	return []string{"--sandbox", "workspace-write"}
 }
 
 // gateProvider resolves the run's provider through the health gate. If the

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -517,6 +517,11 @@ func TestBuildCommand(t *testing.T) {
 			cfg:     RunConfig{Provider: "codex", Model: "haiku"},
 			wantCmd: "codex exec --json --skip-git-repo-check --full-auto --model gpt-5.4-mini",
 		},
+		{
+			name:    "codex with RequirePermissions uses workspace-write sandbox",
+			cfg:     RunConfig{Provider: "codex", RequirePermissions: true},
+			wantCmd: "codex exec --json --skip-git-repo-check --sandbox workspace-write --model gpt-5.4",
+		},
 	}
 
 	for _, tt := range tests {
@@ -528,6 +533,40 @@ func TestBuildCommand(t *testing.T) {
 				}
 				return
 			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.wantCmd {
+				t.Errorf("cmd = %q, want %q", got, tt.wantCmd)
+			}
+		})
+	}
+}
+
+func TestCodexSandboxDisabledViaEnv(t *testing.T) {
+	t.Setenv("SYBRA_DISABLE_CODEX_SANDBOX", "1")
+	m, _ := newTestManager(t)
+
+	tests := []struct {
+		name    string
+		cfg     RunConfig
+		wantCmd string
+	}{
+		{
+			name:    "codex default with sandbox disabled",
+			cfg:     RunConfig{Provider: "codex"},
+			wantCmd: "codex exec --json --skip-git-repo-check --sandbox danger-full-access --model gpt-5.4",
+		},
+		{
+			name:    "codex RequirePermissions honored as danger-full-access when sandbox disabled",
+			cfg:     RunConfig{Provider: "codex", RequirePermissions: true},
+			wantCmd: "codex exec --json --skip-git-repo-check --sandbox danger-full-access --model gpt-5.4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := m.buildCommand(tt.cfg)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -173,11 +173,7 @@ func (m *Manager) runCodexTurn(ctx context.Context, a *Agent, cfg RunConfig, pro
 
 func buildCodexConvoArgs(a *Agent, cfg RunConfig, prompt string) []string {
 	args := []string{"exec", "--json", "--skip-git-repo-check"}
-	if !cfg.RequirePermissions {
-		args = append(args, "--full-auto")
-	} else {
-		args = append(args, "--sandbox", "workspace-write")
-	}
+	args = append(args, codexSandboxArgs(cfg.RequirePermissions)...)
 	if a.Model != "" {
 		args = append(args, "--model", a.Model)
 	}

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -445,11 +445,7 @@ func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args []strin
 	if a.Provider == "codex" {
 		name = "codex"
 		args = []string{"exec", "--json", "--skip-git-repo-check"}
-		if !cfg.RequirePermissions {
-			args = append(args, "--full-auto")
-		} else {
-			args = append(args, "--sandbox", "workspace-write")
-		}
+		args = append(args, codexSandboxArgs(cfg.RequirePermissions)...)
 		if a.Model != "" {
 			args = append(args, "--model", a.Model)
 		}

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -100,6 +100,7 @@ func taskToInfo(t task.Task) workflow.TaskInfo {
 		Body:         t.Body,
 		Plan:         t.Plan,
 		PlanCritique: t.PlanCritique,
+		CodeReview:   t.CodeReview,
 		Issue:        t.Issue,
 		Reviewed:     t.Reviewed,
 		Workflow:     t.Workflow,

--- a/internal/sybra/e2e_crossprovider_test.go
+++ b/internal/sybra/e2e_crossprovider_test.go
@@ -112,6 +112,60 @@ func TestE2E_CrossProvider_ReviewThenFix(t *testing.T) {
 	}
 }
 
+// TestE2E_CrossProvider_ReviewSidecarPersisted drives the cross-provider
+// review flow but uses the code_review_success scenario so the review
+// agent calls `sybra-cli update --code-review`. Asserts the CodeReview
+// sidecar is populated on the task once the workflow completes — proving
+// the end-to-end save path works: scenario → sybra-cli flag → Update →
+// CodeReviewStore → Store.Get → Task.CodeReview → frontend JSON.
+func TestE2E_CrossProvider_ReviewSidecarPersisted(t *testing.T) {
+	env := setupCrossProviderEnv(t, "claude",
+		[]string{"success", "success"},  // claude: implement, fix_review
+		[]string{"code_review_success"}, // codex: code_review writes sidecar via CLI
+	)
+
+	created, err := env.tasks.Create("review sidecar persisted", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := env.startWorkflow(created.ID, "test-review-fix"); err != nil {
+		t.Fatal(err)
+	}
+
+	waitFor(t, 30*time.Second, "workflow completes", func() bool {
+		tk, gErr := env.tasks.Get(created.ID)
+		if gErr != nil {
+			return false
+		}
+		return tk.Workflow != nil &&
+			(tk.Workflow.State == workflow.ExecCompleted || tk.Workflow.State == workflow.ExecFailed)
+	})
+
+	tk, err := env.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tk.Workflow.State != workflow.ExecCompleted {
+		t.Fatalf("workflow state = %q, want completed (step: %s)", tk.Workflow.State, tk.Workflow.CurrentStep)
+	}
+
+	if tk.CodeReview == "" {
+		t.Fatalf("CodeReview sidecar empty after workflow completed — expected scenario to persist it")
+	}
+	if !strings.Contains(tk.CodeReview, "Code Review") {
+		t.Errorf("CodeReview content unexpected: %q", tk.CodeReview)
+	}
+
+	// Sidecar file must exist on disk under the configured tasks dir.
+	sidecar := filepath.Join(env.taskDir, "tasks", created.ID+".review.md")
+	if _, statErr := os.Stat(sidecar); os.IsNotExist(statErr) {
+		t.Errorf("expected sidecar at %s, file does not exist", sidecar)
+	} else if statErr != nil {
+		t.Errorf("stat sidecar %s: %v", sidecar, statErr)
+	}
+}
+
 // TestE2E_CrossProvider_NoreviewTagSkipsReview verifies that a task tagged
 // "noreview" bypasses code_review and fix_review via the maybe_review
 // condition step.

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -2298,9 +2298,10 @@ func agentRunRoles(t task.Task) []string {
 // agent runs is the externally observable proof the step ran.
 func TestE2E_BuiltinSimpleTask_PlanCriticRunsBeforeReview(t *testing.T) {
 	env := setupE2EMulti(t, []string{
-		"triage_to_planning", // triage flips status=planning, tags=large
-		"success",            // plan agent (interactive) — exits, advances
-		"success",            // critique_plan agent (headless plan-critic)
+		"triage_to_planning",  // triage flips status=planning, tags=large
+		"success",             // plan agent (interactive) — exits, advances
+		"plan_critic_success", // critique_plan agent saves sidecar via sybra-cli
+		"success",             // address_critique agent
 	})
 	loadBuiltinWorkflow(t, env, "simple-task")
 
@@ -2348,6 +2349,69 @@ func TestE2E_BuiltinSimpleTask_PlanCriticRunsBeforeReview(t *testing.T) {
 	roles := agentRunRoles(tk)
 	if !slices.Contains(roles, "plan-critic") {
 		t.Errorf("plan-critic agent role missing from task agent runs\nroles: %v", roles)
+	}
+
+	if tk.PlanCritique == "" {
+		t.Errorf("task PlanCritique sidecar empty; expected critic scenario to save it via sybra-cli")
+	}
+	if !slices.Contains(stepIDs, "require_plan_critique") {
+		t.Errorf("require_plan_critique missing from step history\nhistory: %v", stepIDs)
+	}
+}
+
+// TestE2E_BuiltinSimpleTask_MissingCritiqueFlipsHumanRequired covers the
+// failure mode that motivated the require_sidecar guard: the critic agent
+// exits cleanly (no process error) but never ran `sybra-cli update
+// --plan-critique-file` — e.g. because its shell was sandboxed away inside
+// a Docker container. Without the guard the workflow would silently advance
+// to address_critique with nothing to address and the human review page
+// would render only the plan. The guard must flip the task to human-required
+// and halt the workflow.
+func TestE2E_BuiltinSimpleTask_MissingCritiqueFlipsHumanRequired(t *testing.T) {
+	env := setupE2EMulti(t, []string{
+		"triage_to_planning",  // triage flips status=planning, tags=large
+		"success",             // plan agent (interactive) — exits, advances
+		"plan_critic_no_save", // critic agent completes without writing sidecar
+	})
+	loadBuiltinWorkflow(t, env, "simple-task")
+
+	created, err := env.tasks.Create("missing critique e2e", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := env.startWorkflow(created.ID, "simple-task"); err != nil {
+		t.Fatal(err)
+	}
+
+	waitFor(t, 30*time.Second, "task flips to human-required via require_plan_critique", func() bool {
+		tk, gErr := env.tasks.Get(created.ID)
+		if gErr != nil {
+			return false
+		}
+		return tk.Status == task.StatusHumanRequired
+	})
+
+	tk, err := env.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stepIDs := stepIDsFromHistory(tk.Workflow)
+	if !slices.Contains(stepIDs, "critique_plan") {
+		t.Errorf("critique_plan missing from history before the guard fired\nhistory: %v", stepIDs)
+	}
+	if !slices.Contains(stepIDs, "require_plan_critique") {
+		t.Errorf("require_plan_critique guard did not execute\nhistory: %v", stepIDs)
+	}
+	if slices.Contains(stepIDs, "address_critique") {
+		t.Errorf("address_critique ran despite missing critique — guard failed to halt\nhistory: %v", stepIDs)
+	}
+	if tk.PlanCritique != "" {
+		t.Errorf("PlanCritique unexpectedly non-empty after no_save scenario: %q", tk.PlanCritique)
+	}
+	if !strings.Contains(strings.ToLower(tk.StatusReason), "plan critique") {
+		t.Errorf("status reason does not mention plan critique: %q", tk.StatusReason)
 	}
 }
 

--- a/internal/task/code_review.go
+++ b/internal/task/code_review.go
@@ -1,0 +1,54 @@
+package task
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Automaat/sybra/internal/fsutil"
+)
+
+// CodeReviewStore persists code-review reports as a plain-markdown sidecar
+// next to the task file. Mirrors PlanCritiqueStore.
+type CodeReviewStore struct {
+	dir string
+}
+
+func NewCodeReviewStore(dir string) *CodeReviewStore {
+	return &CodeReviewStore{dir: dir}
+}
+
+func (s *CodeReviewStore) sidecarPath(taskID string) string {
+	return filepath.Join(s.dir, taskID+".review.md")
+}
+
+// Read returns the review content for a task. Returns ("", nil) if no review exists.
+func (s *CodeReviewStore) Read(taskID string) (string, error) {
+	data, err := os.ReadFile(s.sidecarPath(taskID))
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read code review: %w", err)
+	}
+	return string(data), nil
+}
+
+// Write persists review content for a task. An empty content string deletes the sidecar.
+func (s *CodeReviewStore) Write(taskID, content string) error {
+	if content == "" {
+		return s.Delete(taskID)
+	}
+	if err := fsutil.AtomicWrite(s.sidecarPath(taskID), []byte(content)); err != nil {
+		return fmt.Errorf("write code review: %w", err)
+	}
+	return nil
+}
+
+// Delete removes the review sidecar for a task. Ignores not-exist errors.
+func (s *CodeReviewStore) Delete(taskID string) error {
+	if err := os.Remove(s.sidecarPath(taskID)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("delete code review: %w", err)
+	}
+	return nil
+}

--- a/internal/task/code_review_test.go
+++ b/internal/task/code_review_test.go
@@ -1,0 +1,203 @@
+package task
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCodeReviewStoreReadNonexistent(t *testing.T) {
+	t.Parallel()
+	crs := NewCodeReviewStore(t.TempDir())
+
+	content, err := crs.Read("nonexistent")
+	if err != nil {
+		t.Fatalf("expected no error for missing review, got %v", err)
+	}
+	if content != "" {
+		t.Errorf("expected empty content, got %q", content)
+	}
+}
+
+func TestCodeReviewStoreWriteRead(t *testing.T) {
+	t.Parallel()
+	crs := NewCodeReviewStore(t.TempDir())
+
+	want := "# Code Review\n\n## Verdict: APPROVE\n"
+	if err := crs.Write("task-abc", want); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := crs.Read("task-abc")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestCodeReviewStoreDeleteExisting(t *testing.T) {
+	t.Parallel()
+	crs := NewCodeReviewStore(t.TempDir())
+
+	if err := crs.Write("task-del", "some review"); err != nil {
+		t.Fatal(err)
+	}
+	if err := crs.Delete("task-del"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	content, err := crs.Read("task-del")
+	if err != nil {
+		t.Fatalf("Read after delete: %v", err)
+	}
+	if content != "" {
+		t.Errorf("expected empty after delete, got %q", content)
+	}
+}
+
+func TestCodeReviewStoreDeleteNonexistent(t *testing.T) {
+	t.Parallel()
+	crs := NewCodeReviewStore(t.TempDir())
+
+	if err := crs.Delete("nope"); err != nil {
+		t.Fatalf("Delete nonexistent should not error, got %v", err)
+	}
+}
+
+func TestCodeReviewStoreWriteEmptyClears(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	crs := NewCodeReviewStore(dir)
+
+	if err := crs.Write("task-clear", "initial review"); err != nil {
+		t.Fatal(err)
+	}
+	if err := crs.Write("task-clear", ""); err != nil {
+		t.Fatalf("Write empty: %v", err)
+	}
+
+	sidecar := filepath.Join(dir, "task-clear.review.md")
+	if _, statErr := os.Stat(sidecar); !os.IsNotExist(statErr) {
+		t.Error("sidecar file should not exist after writing empty string")
+	}
+}
+
+func TestStoreUpdateWritesCodeReviewSidecar(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("Review task", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	review := "# Code Review\n\n## Findings\n\n- Missing tests for X.\n"
+	updated, err := store.Update(created.ID, Update{CodeReview: Ptr(review)})
+	if err != nil {
+		t.Fatalf("Update with code_review: %v", err)
+	}
+	if updated.CodeReview != review {
+		t.Errorf("CodeReview = %q, want %q", updated.CodeReview, review)
+	}
+
+	sidecar := filepath.Join(dir, created.ID+".review.md")
+	data, readErr := os.ReadFile(sidecar)
+	if readErr != nil {
+		t.Fatalf("sidecar not written: %v", readErr)
+	}
+	if string(data) != review {
+		t.Errorf("sidecar = %q, want %q", string(data), review)
+	}
+}
+
+func TestStoreGetPopulatesCodeReview(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("Review get task", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	review := "# Code Review\n\n## Verdict: APPROVE\n"
+	if _, err := store.Update(created.ID, Update{CodeReview: Ptr(review)}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.CodeReview != review {
+		t.Errorf("Get CodeReview = %q, want %q", got.CodeReview, review)
+	}
+}
+
+func TestStoreDeleteCascadesCodeReview(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("Cascade review delete", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := store.Update(created.ID, Update{CodeReview: Ptr("# Code Review\n")}); err != nil {
+		t.Fatal(err)
+	}
+
+	sidecar := filepath.Join(dir, created.ID+".review.md")
+	if _, statErr := os.Stat(sidecar); os.IsNotExist(statErr) {
+		t.Fatal("sidecar should exist before delete")
+	}
+
+	if err := store.Delete(created.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if _, statErr := os.Stat(sidecar); !os.IsNotExist(statErr) {
+		t.Error("sidecar should be removed after task delete")
+	}
+}
+
+func TestStoreListPopulatesCodeReview(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("List review task", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	review := "# Code Review\n\n## Verdict: APPROVE\n"
+	if _, err := store.Update(created.ID, Update{CodeReview: Ptr(review)}); err != nil {
+		t.Fatal(err)
+	}
+
+	tasks, err := store.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("got %d tasks, want 1", len(tasks))
+	}
+	if tasks[0].CodeReview != review {
+		t.Errorf("List CodeReview = %q, want %q", tasks[0].CodeReview, review)
+	}
+}

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -78,7 +78,7 @@ func (m *Manager) OnExternalUpdate(path string) {
 		return
 	}
 	base := filepath.Base(path)
-	if strings.HasSuffix(base, ".plan.md") || strings.HasSuffix(base, ".plan-critique.md") {
+	if strings.HasSuffix(base, ".plan.md") || strings.HasSuffix(base, ".plan-critique.md") || strings.HasSuffix(base, ".review.md") {
 		m.store.InvalidatePath(path)
 		return
 	}

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -172,6 +172,7 @@ type Task struct {
 	Body         string `yaml:"-" json:"body"`
 	Plan         string `yaml:"-" json:"plan,omitempty"`
 	PlanCritique string `yaml:"-" json:"planCritique,omitempty"`
+	CodeReview   string `yaml:"-" json:"codeReview,omitempty"`
 	FilePath     string `yaml:"-" json:"filePath"`
 }
 

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -21,6 +21,7 @@ type Store struct {
 	comments      *CommentStore
 	plans         *PlanStore
 	planCritiques *PlanCritiqueStore
+	codeReviews   *CodeReviewStore
 	cacheMu       sync.RWMutex
 	listCache     []Task
 	listValid     bool
@@ -35,6 +36,7 @@ func NewStore(dir string) (*Store, error) {
 		comments:      NewCommentStore(dir),
 		plans:         NewPlanStore(dir),
 		planCritiques: NewPlanCritiqueStore(dir),
+		codeReviews:   NewCodeReviewStore(dir),
 	}, nil
 }
 
@@ -48,6 +50,10 @@ func (s *Store) Plans() *PlanStore {
 
 func (s *Store) PlanCritiques() *PlanCritiqueStore {
 	return s.planCritiques
+}
+
+func (s *Store) CodeReviews() *CodeReviewStore {
+	return s.codeReviews
 }
 
 func (s *Store) List() ([]Task, error) {
@@ -64,7 +70,7 @@ func (s *Store) List() ([]Task, error) {
 	var parseErr bool
 	for _, p := range paths {
 		base := filepath.Base(p)
-		if strings.HasSuffix(base, ".plan.md") || strings.HasSuffix(base, ".plan-critique.md") {
+		if strings.HasSuffix(base, ".plan.md") || strings.HasSuffix(base, ".plan-critique.md") || strings.HasSuffix(base, ".review.md") {
 			continue
 		}
 		t, err := Parse(p)
@@ -75,6 +81,7 @@ func (s *Store) List() ([]Task, error) {
 		}
 		t.Plan, _ = s.plans.Read(t.ID)
 		t.PlanCritique, _ = s.planCritiques.Read(t.ID)
+		t.CodeReview, _ = s.codeReviews.Read(t.ID)
 		// One-time migration: stamp ClosedAt for legacy terminal tasks that
 		// predate the ClosedAt field. UpdatedAt is the best approximation.
 		if IsTerminalStatus(t.Status) && t.ClosedAt == nil {
@@ -106,6 +113,7 @@ func (s *Store) Get(id string) (Task, error) {
 	}
 	t.Plan, _ = s.plans.Read(t.ID)
 	t.PlanCritique, _ = s.planCritiques.Read(t.ID)
+	t.CodeReview, _ = s.codeReviews.Read(t.ID)
 	return t, nil
 }
 
@@ -202,6 +210,7 @@ func (s *Store) Delete(id string) error {
 	_ = s.comments.DeleteAll(id)
 	_ = s.plans.Delete(id)
 	_ = s.planCritiques.Delete(id)
+	_ = s.codeReviews.Delete(id)
 	s.deleteCachedTask(id)
 	return nil
 }
@@ -296,6 +305,12 @@ func (s *Store) Update(id string, u Update) (Task, error) {
 		}
 		t.PlanCritique = *u.PlanCritique
 	}
+	if u.CodeReview != nil {
+		if wErr := s.codeReviews.Write(id, *u.CodeReview); wErr != nil {
+			return Task{}, fmt.Errorf("write code review: %w", wErr)
+		}
+		t.CodeReview = *u.CodeReview
+	}
 
 	data, err := Marshal(t)
 	if err != nil {
@@ -315,7 +330,7 @@ func (s *Store) InvalidatePath(path string) {
 		return
 	}
 	base := filepath.Base(path)
-	if strings.HasSuffix(base, ".plan.md") || strings.HasSuffix(base, ".plan-critique.md") {
+	if strings.HasSuffix(base, ".plan.md") || strings.HasSuffix(base, ".plan-critique.md") || strings.HasSuffix(base, ".review.md") {
 		s.invalidateListCache()
 		return
 	}

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -215,6 +215,28 @@ func (s *Store) Delete(id string) error {
 	return nil
 }
 
+func (s *Store) writeSidecars(id string, u Update, t *Task) error {
+	if u.Plan != nil {
+		if err := s.plans.Write(id, *u.Plan); err != nil {
+			return fmt.Errorf("write plan: %w", err)
+		}
+		t.Plan = *u.Plan
+	}
+	if u.PlanCritique != nil {
+		if err := s.planCritiques.Write(id, *u.PlanCritique); err != nil {
+			return fmt.Errorf("write plan critique: %w", err)
+		}
+		t.PlanCritique = *u.PlanCritique
+	}
+	if u.CodeReview != nil {
+		if err := s.codeReviews.Write(id, *u.CodeReview); err != nil {
+			return fmt.Errorf("write code review: %w", err)
+		}
+		t.CodeReview = *u.CodeReview
+	}
+	return nil
+}
+
 func (s *Store) Update(id string, u Update) (Task, error) {
 	t, err := s.Get(id)
 	if err != nil {
@@ -293,23 +315,8 @@ func (s *Store) Update(id string, u Update) (Task, error) {
 	if u.Workflow != nil {
 		t.Workflow = *u.Workflow
 	}
-	if u.Plan != nil {
-		if wErr := s.plans.Write(id, *u.Plan); wErr != nil {
-			return Task{}, fmt.Errorf("write plan: %w", wErr)
-		}
-		t.Plan = *u.Plan
-	}
-	if u.PlanCritique != nil {
-		if wErr := s.planCritiques.Write(id, *u.PlanCritique); wErr != nil {
-			return Task{}, fmt.Errorf("write plan critique: %w", wErr)
-		}
-		t.PlanCritique = *u.PlanCritique
-	}
-	if u.CodeReview != nil {
-		if wErr := s.codeReviews.Write(id, *u.CodeReview); wErr != nil {
-			return Task{}, fmt.Errorf("write code review: %w", wErr)
-		}
-		t.CodeReview = *u.CodeReview
+	if err := s.writeSidecars(id, u, &t); err != nil {
+		return Task{}, err
 	}
 
 	data, err := Marshal(t)

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -717,10 +717,11 @@ func TestStoreListSkipsPlanSidecars(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Write plan and plan-critique sidecars
+	// Write plan, plan-critique, and code-review sidecars
 	for _, name := range []string{
 		task.ID + ".plan.md",
 		task.ID + ".plan-critique.md",
+		task.ID + ".review.md",
 	} {
 		if err := os.WriteFile(filepath.Join(dir, name), []byte("# plan content"), 0o644); err != nil {
 			t.Fatal(err)

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -32,6 +32,7 @@ type Update struct {
 	Workflow     **workflow.Execution
 	Plan         *string
 	PlanCritique *string
+	CodeReview   *string
 }
 
 // Ptr returns a pointer to v. Convenience for building Update literals.
@@ -57,7 +58,7 @@ func UpdateFromMap(raw map[string]any) (Update, error) {
 func applyMapField(u *Update, k string, v any) error {
 	switch k {
 	case "title", "slug", "status_reason", "body",
-		"project_id", "branch", "issue", "run_role", "todoist_id", "plan", "plan_critique":
+		"project_id", "branch", "issue", "run_role", "todoist_id", "plan", "plan_critique", "code_review":
 		return applyPlainStringField(u, k, v)
 	case "priority":
 		return applyPriorityField(u, v)
@@ -119,6 +120,8 @@ func applyPlainStringField(u *Update, k string, v any) error {
 		u.Plan = &s
 	case "plan_critique":
 		u.PlanCritique = &s
+	case "code_review":
+		u.CodeReview = &s
 	}
 	return nil
 }

--- a/internal/workflow/builtin/simple-task.yaml
+++ b/internal/workflow/builtin/simple-task.yaml
@@ -153,6 +153,25 @@ steps:
         - Skill
         - Agent
     next:
+      - goto: require_plan_critique
+
+  # Guard: the critic agent above exits cleanly even when it is blocked
+  # from executing any shell command (e.g. codex bwrap sandbox failure
+  # inside Docker). Without this check the workflow silently advances to
+  # address_critique with an empty sidecar, and the human sees only the
+  # plan — no critique — in the review UI. Flips task to human-required
+  # when the sidecar is empty so the failure is visible.
+  - id: require_plan_critique
+    name: Require Plan Critique
+    type: require_sidecar
+    config:
+      sidecar: plan_critique
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
       - goto: reset_for_address
 
   - id: reset_for_address
@@ -303,9 +322,29 @@ steps:
           1. git diff origin/main..HEAD > /tmp/sybra-diff-{{.Task.ID}}.patch
           2. Run /staff-code-review against that patch and the worktree source
           3. Save the full review to /tmp/sybra-review-{{.Task.ID}}.md
+          4. synapse-cli update {{.Task.ID}} --code-review-file /tmp/sybra-review-{{.Task.ID}}.md
 
-        Do NOT submit anything to GitHub. Only save to the file.
+        Do NOT submit anything to GitHub. The /tmp file remains for the
+        next step (fix_review) to read; the synapse-cli call preserves
+        the review as a task sidecar visible in the GUI.
     next:
+      - goto: require_code_review
+
+  # Guard: mirrors require_plan_critique above. Flips task to
+  # human-required when the review sidecar is empty (e.g. agent exited
+  # without running step 4). Without this, fix_review reads /tmp and
+  # the GUI never sees what the reviewer wrote.
+  - id: require_code_review
+    name: Require Code Review
+    type: require_sidecar
+    config:
+      sidecar: code_review
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
       - goto: fix_review
 
   - id: fix_review

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -49,6 +49,7 @@ type TaskInfo struct {
 	Body         string
 	Plan         string
 	PlanCritique string
+	CodeReview   string
 	Issue        string
 	Reviewed     bool
 	Workflow     *Execution
@@ -784,7 +785,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			return e.execRunAgent(taskID, step, wfExec, ctx)
 		case StepWaitHuman:
 			return e.execWaitHuman(taskID, step, wfExec)
-		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate:
+		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar:
 			// handled below as sync steps
 		default:
 			return fmt.Errorf("unknown step type %q", step.Type)
@@ -854,6 +855,8 @@ func (e *Engine) execSyncStep(taskID string, step *Step, wfExec *Execution, ctx 
 		return e.execLinkPRAndReview(taskID, step, wfExec, t)
 	case StepEvaluate:
 		return e.execEvaluate(taskID, step, wfExec, t)
+	case StepRequireSidecar:
+		return e.execRequireSidecar(taskID, step, t)
 	default:
 		return StepOutput{}, fmt.Errorf("unknown step type %q", step.Type)
 	}
@@ -1167,6 +1170,36 @@ func (e *Engine) execEnsurePRClosesIssue(taskID string, step *Step, t TaskInfo) 
 // Treating git failures as a hard gate prevents the workflow from wasting
 // `code_review`/`fix_review`/`create_pr` cycles on a worktree the agent
 // cannot operate in.
+// execRequireSidecar verifies that the configured sidecar was actually
+// written for the task. When empty, flips the task to human-required
+// with a descriptive reason instead of silently advancing the workflow.
+// Catches the codex-sandbox-blocked class of failure where the agent
+// exits cleanly without producing its expected output file.
+func (e *Engine) execRequireSidecar(taskID string, step *Step, t TaskInfo) (StepOutput, error) {
+	var content, label string
+	switch step.Config.Sidecar {
+	case "plan_critique":
+		content = t.PlanCritique
+		label = "plan critique"
+	case "code_review":
+		content = t.CodeReview
+		label = "code review"
+	case "":
+		return StepOutput{}, fmt.Errorf("require_sidecar: config.sidecar is required")
+	default:
+		return StepOutput{}, fmt.Errorf("require_sidecar: unknown sidecar %q (want plan_critique|code_review)", step.Config.Sidecar)
+	}
+	if strings.TrimSpace(content) == "" {
+		reason := label + " missing — upstream agent step completed without writing its sidecar"
+		if statusErr := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); statusErr != nil {
+			e.logger.Error("workflow.require-sidecar.status", "task_id", taskID, "err", statusErr)
+		}
+		e.logger.Warn("workflow.require-sidecar.missing", "task_id", taskID, "sidecar", step.Config.Sidecar)
+		return StepOutput{StepID: step.ID, Status: "completed", Output: reason}, nil
+	}
+	return StepOutput{StepID: step.ID, Status: "completed", Output: label + " present"}, nil
+}
+
 func (e *Engine) execVerifyCommits(taskID string, step *Step, t TaskInfo) (StepOutput, error) {
 	if e.worktrees == nil {
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no worktree getter configured"}, nil

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2542,6 +2542,119 @@ func TestExecVerifyCommits_NoCommitsFlipsHumanRequired(t *testing.T) {
 	}
 }
 
+// --- require_sidecar step ---
+
+func newRequireSidecarStep(kind string) *Step {
+	return &Step{
+		ID:     "require",
+		Type:   StepRequireSidecar,
+		Config: StepConfig{Sidecar: kind},
+	}
+}
+
+func TestExecRequireSidecar_PlanCritiquePresent(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "planning", PlanCritique: "# critique\n"})
+	engine := newEngineForEval(t, tasks)
+
+	out, err := engine.execRequireSidecar("t1", newRequireSidecarStep("plan_critique"), TaskInfo{ID: "t1", PlanCritique: "# critique\n"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed", out.Status)
+	}
+	if !strings.Contains(out.Output, "present") {
+		t.Errorf("Output = %q, want 'present'", out.Output)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status == "human-required" {
+		t.Errorf("unexpected status flip to human-required")
+	}
+}
+
+func TestExecRequireSidecar_PlanCritiqueMissingFlipsHumanRequired(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "planning"})
+	engine := newEngineForEval(t, tasks)
+
+	out, err := engine.execRequireSidecar("t1", newRequireSidecarStep("plan_critique"), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed (mechanical step)", out.Status)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "human-required" {
+		t.Errorf("task status = %q, want human-required", ti.Status)
+	}
+	if !strings.Contains(tasks.Reason("t1"), "plan critique") {
+		t.Errorf("reason = %q, want substring 'plan critique'", tasks.Reason("t1"))
+	}
+}
+
+func TestExecRequireSidecar_CodeReviewMissingFlipsHumanRequired(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := newEngineForEval(t, tasks)
+
+	out, err := engine.execRequireSidecar("t1", newRequireSidecarStep("code_review"), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed", out.Status)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "human-required" {
+		t.Errorf("task status = %q, want human-required", ti.Status)
+	}
+	if !strings.Contains(tasks.Reason("t1"), "code review") {
+		t.Errorf("reason = %q, want substring 'code review'", tasks.Reason("t1"))
+	}
+}
+
+func TestExecRequireSidecar_WhitespaceOnlyTreatedAsMissing(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "planning"})
+	engine := newEngineForEval(t, tasks)
+
+	out, err := engine.execRequireSidecar("t1", newRequireSidecarStep("plan_critique"), TaskInfo{ID: "t1", PlanCritique: "   \n\t  \n"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed", out.Status)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "human-required" {
+		t.Errorf("task status = %q, want human-required", ti.Status)
+	}
+}
+
+func TestExecRequireSidecar_UnknownSidecarErrors(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "planning"})
+	engine := newEngineForEval(t, tasks)
+
+	_, err := engine.execRequireSidecar("t1", newRequireSidecarStep("bogus"), TaskInfo{ID: "t1"})
+	if err == nil {
+		t.Fatal("expected error for unknown sidecar, got nil")
+	}
+}
+
+func TestExecRequireSidecar_EmptySidecarConfigErrors(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "planning"})
+	engine := newEngineForEval(t, tasks)
+
+	_, err := engine.execRequireSidecar("t1", newRequireSidecarStep(""), TaskInfo{ID: "t1"})
+	if err == nil {
+		t.Fatal("expected error for empty sidecar config, got nil")
+	}
+}
+
 // --- evaluate step ---
 
 func newEvaluateStep() *Step {

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -70,6 +70,7 @@ const (
 	StepVerifyCommits       StepType = "verify_commits"
 	StepLinkPRAndReview     StepType = "link_pr_and_review"
 	StepEvaluate            StepType = "evaluate"
+	StepRequireSidecar      StepType = "require_sidecar"
 )
 
 // Step is one node in the workflow graph.
@@ -126,6 +127,10 @@ type StepConfig struct {
 	// shell
 	Command string `yaml:"command,omitempty" json:"command"`
 	Dir     string `yaml:"dir,omitempty" json:"dir"`
+
+	// require_sidecar: which sidecar must be non-empty for the step to pass.
+	// Valid values: "plan_critique", "code_review".
+	Sidecar string `yaml:"sidecar,omitempty" json:"sidecar"`
 }
 
 const maxRetries = 10


### PR DESCRIPTION
## Motivation

Task 8a8e353a on the server reached plan-review with only the plan
rendered — no critique. Investigation: codex plan-critic agent was
blocked by bwrap inside Docker (`kernel.unprivileged_userns_clone=0`),
exited clean, workflow marked the step completed and advanced. The
critique sidecar was never written but nothing noticed.

Separately, the `code_review` step already writes
`/tmp/synapse-review-<id>.md`, but `fix_review` consumes and discards
it — the review never surfaces in the GUI.

## Implementation information

**Codex sandbox bypass (`fix(agent)` commit)**

New `SYBRA_DISABLE_CODEX_SANDBOX=1` gate swaps `--full-auto` for
`--sandbox danger-full-access`. Off by default on the laptop; server
compose should set it (tracked separately in home-nas repo). The
container already isolates the process — inner bwrap is redundant
and, on this kernel, fatal.

**Critic save path + guard (`feat(review)` commit)**

- New `require_sidecar` workflow step: verifies the named sidecar
  (`plan_critique` | `code_review`) is non-empty; flips task to
  `human-required` when missing. Wired into simple-task.yaml after
  both `critique_plan` and `code_review`.
- `code_review` prompt now also calls
  `synapse-cli update --code-review-file /tmp/synapse-review-<id>.md`
  after writing the tmp file, so the review persists as a sidecar
  (`<id>.review.md`) visible from the CLI and GUI.
- New `CodeReviewStore` mirrors `PlanCritiqueStore`. Wired through
  the same layers: `Task.CodeReview`, `Update.CodeReview`,
  `--code-review` / `--code-review-file` CLI flags, Wails binding,
  and a collapsible section in `TaskDetail.svelte`.

**Why TaskDetail not Reviews.svelte for code review**

Reviews.svelte filters to `plan-review` / `test-plan-review` only.
Code reviews surface on `in-review` tasks, which are navigated via
TaskDetail — putting the collapsible there matches the existing
navigation.

**Server-side follow-up (out of this repo)**

`ansible/docker-compose/synapse-stack.yml` in `home-nas` must set
`SYBRA_DISABLE_CODEX_SANDBOX=1` on the `sybra` service. Without
that env var the codex critic will still be blocked. No change in
this repo enables it — laptop behavior is unchanged.

## Supporting documentation

- Diagnostic evidence: codex agent log on synapse showed
  `bwrap: No permissions to create a new namespace` for every
  exec while its prompt expected to call `synapse-cli update
  --plan-critique-file`.
- `require_sidecar` follows the same pattern as `verify_commits` /
  `evaluate`: mechanical step that flips to `human-required` with
  a descriptive reason rather than silently failing.