### PR TITLE
feat(task): add completion logbook

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -894,7 +894,7 @@ func usage() {
 
 Commands:
   list     [--status STATUS] [--tag TAG] [--project ID]
-           STATUS: new|todo|planning|plan-review|in-progress|in-review|testing|test-plan-review|human-required|done
+           STATUS: new|todo|planning|plan-review|in-progress|in-review|testing|test-plan-review|human-required|done|cancelled
   get      <id>
   create   --title TITLE [--body BODY] [--plan PLAN] [--mode MODE] [--type TYPE] [--tags t1,t2] [--project ID] [--branch B] [--pr N] [--issue URL]
            TYPE: normal|debug|research

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -26,6 +26,7 @@
   import ChatDetail from './pages/ChatDetail.svelte'
   import WorkflowList from './pages/WorkflowList.svelte'
   import WorkflowDetail from './pages/WorkflowDetail.svelte'
+  import Logbook from './pages/Logbook.svelte'
   import CreateTaskDialog from './components/CreateTaskDialog.svelte'
   import CreateProjectDialog from './components/CreateProjectDialog.svelte'
   import QuickAddTask from './components/QuickAddTask.svelte'
@@ -409,6 +410,8 @@
         workflowId={navStore.page.workflowId}
         onback={() => navStore.back()}
       />
+    {:else if navStore.page.kind === 'logbook'}
+      <Logbook onviewtask={navTaskDetail} />
     {:else if navStore.page.kind === 'settings'}
       <Settings />
     {/if}

--- a/frontend/src/components/shell/SideRail.svelte
+++ b/frontend/src/components/shell/SideRail.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { LayoutGrid, ClipboardList, Folder, MessageCircle, UserCircle, GitBranch, ClipboardCheck, LayoutDashboard, BarChart3, Settings } from '@lucide/svelte'
+  import { LayoutGrid, ClipboardList, Folder, MessageCircle, UserCircle, GitBranch, ClipboardCheck, LayoutDashboard, BarChart3, Settings, Archive } from '@lucide/svelte'
   import { Navigation } from '@skeletonlabs/skeleton-svelte'
   import { navStore } from '../../lib/navigation.svelte.js'
   import { taskStore } from '../../stores/tasks.svelte.js'
@@ -86,6 +86,13 @@
         {/if}
       </div>
       <Navigation.TriggerText>Reviews</Navigation.TriggerText>
+    </Navigation.Trigger>
+    <Navigation.Trigger
+      onclick={() => navStore.reset({ kind: 'logbook' })}
+      data-active={navStore.page.kind === 'logbook' || undefined}
+    >
+      <Archive size={20} />
+      <Navigation.TriggerText>Logbook</Navigation.TriggerText>
     </Navigation.Trigger>
     <Navigation.Trigger
       onclick={() => navStore.reset({ kind: 'workflows' })}

--- a/frontend/src/lib/navigation.svelte.ts
+++ b/frontend/src/lib/navigation.svelte.ts
@@ -17,6 +17,7 @@ export type Page =
   | { kind: 'settings' }
   | { kind: 'workflows' }
   | { kind: 'workflow-detail'; workflowId: string }
+  | { kind: 'logbook' }
 
 export type TabKey = 'board' | 'chats' | 'agents' | 'reviews' | 'more'
 
@@ -73,6 +74,7 @@ class NavStore {
       case 'settings': return 'Settings'
       case 'workflows': return 'Workflows'
       case 'workflow-detail': return 'Workflow Editor'
+      case 'logbook': return 'Logbook'
     }
   }
 

--- a/frontend/src/lib/statuses.ts
+++ b/frontend/src/lib/statuses.ts
@@ -9,6 +9,7 @@ export type TaskStatus =
   | 'test-plan-review'
   | 'human-required'
   | 'done'
+  | 'cancelled'
 
 export interface StatusMeta {
   value: TaskStatus
@@ -79,6 +80,12 @@ export const ALL_STATUSES: StatusMeta[] = [
     badgeClasses: 'bg-success-200 text-success-800 dark:bg-success-700 dark:text-success-200',
     pillClasses: 'bg-success-200 text-success-800 dark:bg-success-700 dark:text-success-200',
   },
+  {
+    value: 'cancelled',
+    label: 'Cancelled',
+    badgeClasses: 'bg-surface-200 text-surface-500 dark:bg-surface-700 dark:text-surface-400',
+    pillClasses: 'bg-surface-200 text-surface-500 dark:bg-surface-700 dark:text-surface-400',
+  },
 ]
 
 /** O(1) lookup by status value */
@@ -99,7 +106,7 @@ export interface BoardColumn {
   includes: TaskStatus[]
 }
 
-/** Kanban board columns — used by TaskList and ProjectDetail */
+/** Kanban board columns — active work only; terminal tasks live in Logbook */
 export const BOARD_COLUMNS: BoardColumn[] = [
   { status: 'todo', label: 'Todo', border: 'border-t-surface-400 dark:border-t-surface-500', includes: ['new', 'todo'] },
   { status: 'planning', label: 'Planning', border: 'border-t-tertiary-500 dark:border-t-tertiary-400', includes: ['planning', 'plan-review'] },
@@ -107,5 +114,4 @@ export const BOARD_COLUMNS: BoardColumn[] = [
   { status: 'in-review', label: 'In Review', border: 'border-t-warning-500 dark:border-t-warning-400', includes: [] },
   { status: 'testing', label: 'Testing', border: 'border-t-secondary-500 dark:border-t-secondary-400', includes: ['testing', 'test-plan-review'] },
   { status: 'human-required', label: 'Human Required', border: 'border-t-error-500 dark:border-t-error-400', includes: [] },
-  { status: 'done', label: 'Done', border: 'border-t-success-500 dark:border-t-success-400', includes: [] },
 ]

--- a/frontend/src/pages/Logbook.svelte
+++ b/frontend/src/pages/Logbook.svelte
@@ -1,0 +1,262 @@
+<script lang="ts">
+  import { Search, X } from '@lucide/svelte'
+  import type { task } from '../../wailsjs/go/models.js'
+  import { taskStore } from '../stores/tasks.svelte.js'
+  import { projectStore } from '../stores/projects.svelte.js'
+  import { STATUS_MAP } from '../lib/statuses.js'
+
+  interface Props {
+    onviewtask: (id: string) => void
+  }
+
+  const { onviewtask }: Props = $props()
+
+  // Filter state
+  let searchQuery = $state('')
+  let selectedStatus = $state<'all' | 'done' | 'cancelled'>('all')
+  let selectedProjectId = $state('')
+  let selectedTags = $state<string[]>([])
+  let dateFrom = $state('')
+  let dateTo = $state('')
+  let sortAsc = $state(false)
+
+  const statusPills: { val: 'all' | 'done' | 'cancelled'; label: string }[] = [
+    { val: 'all', label: 'All' },
+    { val: 'done', label: 'Done' },
+    { val: 'cancelled', label: 'Cancelled' },
+  ]
+
+  const logbookTasks = $derived(
+    taskStore.list.filter((t: task.Task) => t.status === 'done' || t.status === 'cancelled')
+  )
+
+  const allTags = $derived(
+    [...new Set(logbookTasks.flatMap((t: task.Task) => t.tags ?? []))].sort()
+  )
+
+  function toUtcDayStart(dateStr: string): Date | null {
+    if (!dateStr) return null
+    const [y, m, d] = dateStr.split('-').map(Number)
+    return new Date(Date.UTC(y, m - 1, d, 0, 0, 0, 0))
+  }
+
+  function toUtcDayEnd(dateStr: string): Date | null {
+    if (!dateStr) return null
+    const [y, m, d] = dateStr.split('-').map(Number)
+    return new Date(Date.UTC(y, m - 1, d, 23, 59, 59, 999))
+  }
+
+  const filteredTasks = $derived.by(() => {
+    const query = searchQuery.toLowerCase().trim()
+    const from = toUtcDayStart(dateFrom)
+    const to = toUtcDayEnd(dateTo)
+
+    return logbookTasks
+      .filter((t: task.Task) => {
+        if (selectedStatus !== 'all' && t.status !== selectedStatus) return false
+        if (query && !t.title.toLowerCase().includes(query)
+            && !(t.body ?? '').toLowerCase().includes(query)) return false
+        if (selectedProjectId && t.projectId !== selectedProjectId) return false
+        if (selectedTags.length > 0 && !selectedTags.every(tag => t.tags?.includes(tag))) return false
+        if (from || to) {
+          const closed = t.closedAt ? new Date(t.closedAt) : null
+          if (!closed) return false
+          if (from && closed < from) return false
+          if (to && closed > to) return false
+        }
+        return true
+      })
+      .sort((a: task.Task, b: task.Task) => {
+        const aTime = a.closedAt ? new Date(a.closedAt).getTime() : 0
+        const bTime = b.closedAt ? new Date(b.closedAt).getTime() : 0
+        const diff = sortAsc ? aTime - bTime : bTime - aTime
+        if (diff !== 0) return diff
+        return a.title.localeCompare(b.title)
+      })
+  })
+
+  const hasActiveFilters = $derived(
+    searchQuery || selectedStatus !== 'all' || selectedProjectId || selectedTags.length > 0 || dateFrom || dateTo
+  )
+
+  function clearFilters() {
+    searchQuery = ''
+    selectedStatus = 'all'
+    selectedProjectId = ''
+    selectedTags = []
+    dateFrom = ''
+    dateTo = ''
+  }
+
+  function removeTag(tag: string) {
+    selectedTags = selectedTags.filter(t => t !== tag)
+  }
+
+  function formatDate(val: any): string {
+    if (!val) return '—'
+    const d = new Date(val)
+    if (isNaN(d.getTime())) return '—'
+    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+  }
+
+  const projects = $derived(projectStore.list)
+</script>
+
+<div class="flex min-h-0 flex-1 flex-col overflow-hidden">
+  <!-- Header -->
+  <div class="flex items-center gap-3 border-b border-surface-200 px-4 py-3 dark:border-surface-700">
+    <h1 class="text-lg font-semibold">Logbook</h1>
+    <span class="text-sm text-surface-400">{logbookTasks.length} closed</span>
+  </div>
+
+  <!-- Filter bar -->
+  <div class="flex flex-wrap items-center gap-2 border-b border-surface-200 px-4 py-2 dark:border-surface-700">
+    <!-- Search -->
+    <div class="relative flex items-center">
+      <Search size={14} class="absolute left-2 text-surface-400" />
+      <input
+        type="search"
+        placeholder="Search…"
+        bind:value={searchQuery}
+        class="h-7 rounded-md border border-surface-300 bg-surface-50 pl-7 pr-2 text-xs focus:outline-none focus:ring-1 focus:ring-primary-400 dark:border-surface-700 dark:bg-surface-800"
+      />
+    </div>
+
+    <!-- Status filter pills -->
+    <div class="flex gap-1">
+      {#each statusPills as pill}
+        <button
+          type="button"
+          class="rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors {selectedStatus === pill.val ? 'bg-primary-500 text-white' : 'bg-surface-100 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300'}"
+          onclick={() => { selectedStatus = pill.val }}
+        >
+          {pill.label}
+        </button>
+      {/each}
+    </div>
+
+    <!-- Project filter -->
+    {#if projects.length > 0}
+      <select
+        bind:value={selectedProjectId}
+        class="h-7 rounded-md border border-surface-300 bg-surface-50 px-2 text-xs focus:outline-none dark:border-surface-700 dark:bg-surface-800"
+      >
+        <option value="">All projects</option>
+        {#each projects as p}
+          <option value={p.id}>{p.owner}/{p.repo}</option>
+        {/each}
+      </select>
+    {/if}
+
+    <!-- Date range -->
+    <div class="flex items-center gap-1">
+      <input
+        type="date"
+        bind:value={dateFrom}
+        class="h-7 rounded-md border border-surface-300 bg-surface-50 px-2 text-xs focus:outline-none dark:border-surface-700 dark:bg-surface-800"
+        title="Closed from"
+      />
+      <span class="text-xs text-surface-400">–</span>
+      <input
+        type="date"
+        bind:value={dateTo}
+        class="h-7 rounded-md border border-surface-300 bg-surface-50 px-2 text-xs focus:outline-none dark:border-surface-700 dark:bg-surface-800"
+        title="Closed until"
+      />
+    </div>
+
+    <!-- Sort toggle -->
+    <button
+      type="button"
+      class="rounded-md border border-surface-300 bg-surface-50 px-2 py-1 text-xs font-medium transition-colors hover:bg-surface-200 dark:border-surface-700 dark:bg-surface-800"
+      onclick={() => { sortAsc = !sortAsc }}
+      title="Sort by closed date"
+    >
+      {sortAsc ? '↑ Oldest' : '↓ Newest'}
+    </button>
+
+    {#if hasActiveFilters}
+      <button
+        type="button"
+        class="flex items-center gap-1 text-xs text-surface-500 underline hover:text-surface-700 dark:hover:text-surface-300"
+        onclick={clearFilters}
+      >
+        <X size={12} />
+        Clear
+      </button>
+    {/if}
+  </div>
+
+  <!-- Tag filter row -->
+  {#if allTags.length > 0}
+    <div class="flex flex-wrap gap-1.5 border-b border-surface-200 px-4 py-2 dark:border-surface-700">
+      {#each allTags as tag}
+        <button
+          type="button"
+          class="rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors {selectedTags.includes(tag)
+            ? 'border-primary-500 bg-primary-500 text-white'
+            : 'border-surface-300 bg-surface-100 text-surface-600 hover:bg-surface-200 dark:border-surface-600 dark:bg-surface-800 dark:text-surface-300'}"
+          onclick={() => selectedTags.includes(tag) ? removeTag(tag) : selectedTags = [...selectedTags, tag]}
+        >
+          {tag}
+        </button>
+      {/each}
+    </div>
+  {/if}
+
+  <!-- Task list -->
+  <div class="min-h-0 flex-1 overflow-y-auto">
+    {#if taskStore.loading}
+      <p class="m-auto p-8 text-center text-sm opacity-60">Loading…</p>
+    {:else if logbookTasks.length === 0}
+      <div class="flex flex-col items-center gap-2 p-12 text-center text-surface-400">
+        <p class="text-sm font-medium">Nothing in the logbook yet</p>
+        <p class="text-xs">Completed and cancelled tasks will appear here.</p>
+      </div>
+    {:else if filteredTasks.length === 0}
+      <div class="flex flex-col items-center gap-2 p-12 text-center text-surface-400">
+        <p class="text-sm font-medium">No tasks match these filters</p>
+        <button type="button" class="text-xs underline" onclick={clearFilters}>Clear filters</button>
+      </div>
+    {:else}
+      <table class="w-full text-sm">
+        <thead class="sticky top-0 z-10 border-b border-surface-200 bg-surface-100 dark:border-surface-700 dark:bg-surface-900">
+          <tr>
+            <th class="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wider text-surface-500">Title</th>
+            <th class="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wider text-surface-500">Status</th>
+            <th class="hidden px-4 py-2 text-left text-xs font-semibold uppercase tracking-wider text-surface-500 md:table-cell">Project</th>
+            <th class="hidden px-4 py-2 text-left text-xs font-semibold uppercase tracking-wider text-surface-500 lg:table-cell">Tags</th>
+            <th class="px-4 py-2 text-left text-xs font-semibold uppercase tracking-wider text-surface-500">Closed</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each filteredTasks as t (t.id)}
+            {@const meta = STATUS_MAP[t.status]}
+            <tr
+              class="cursor-pointer border-b border-surface-100 transition-colors hover:bg-surface-100 dark:border-surface-800 dark:hover:bg-surface-800"
+              onclick={() => onviewtask(t.id)}
+            >
+              <td class="px-4 py-2 font-medium">{t.title}</td>
+              <td class="px-4 py-2">
+                {#if meta}
+                  <span class="rounded-full px-2 py-0.5 text-xs font-semibold {meta.badgeClasses}">{meta.label}</span>
+                {:else}
+                  <span class="rounded-full px-2 py-0.5 text-xs font-semibold bg-surface-200 dark:bg-surface-700">{t.status}</span>
+                {/if}
+              </td>
+              <td class="hidden px-4 py-2 text-surface-500 md:table-cell">{t.projectId || '—'}</td>
+              <td class="hidden px-4 py-2 lg:table-cell">
+                <div class="flex flex-wrap gap-1">
+                  {#each t.tags ?? [] as tag}
+                    <span class="rounded-full bg-surface-200 px-1.5 py-0.5 text-xs dark:bg-surface-700">{tag}</span>
+                  {/each}
+                </div>
+              </td>
+              <td class="px-4 py-2 text-xs text-surface-400">{formatDate(t.closedAt)}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+  </div>
+</div>

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -5,6 +5,7 @@
   import { projectStore } from '../stores/projects.svelte.js'
   import { notificationStore } from '../stores/notifications.svelte.js'
   import { BOARD_COLUMNS } from '../lib/statuses.js'
+  import { navStore } from '../lib/navigation.svelte.js'
   import TaskCard from '../components/TaskCard.svelte'
   import StatusPicker from '../components/StatusPicker.svelte'
   import PriorityPicker from '../components/PriorityPicker.svelte'
@@ -310,8 +311,6 @@
   let selectedProjectId = $state('')
   let selectedTags = $state<string[]>([])
   let selectedAgentMode = $state('')
-  let showDone = $state(false)
-
   // Derived: unique tags across all tasks
   const allTags = $derived(
     [...new Set(taskStore.list.flatMap((t: task.Task) => t.tags ?? []))].sort()
@@ -345,7 +344,7 @@
   const allFilteredTasks = $derived.by(() => {
     const query = searchQuery.toLowerCase().trim()
     return taskStore.list.filter((t: task.Task) => {
-      if (!showDone && t.status === 'done') return false
+      if (t.status === 'done' || t.status === 'cancelled') return false
       if (query && !t.title.toLowerCase().includes(query)
           && !(t.body ?? '').toLowerCase().includes(query)
           && !(t.issue ?? '').toLowerCase().includes(query)) return false
@@ -360,9 +359,7 @@
     })
   })
 
-  const visibleColumns = $derived(
-    showDone ? BOARD_COLUMNS : BOARD_COLUMNS.filter(c => c.status !== 'done')
-  )
+  const visibleColumns = $derived(BOARD_COLUMNS)
 
   const hasActiveFilters = $derived(
     searchQuery || selectedProjectId || selectedTags.length > 0 || selectedAgentMode
@@ -649,10 +646,13 @@
           Clear filters
         </button>
       {/if}
-      <label class="flex items-center gap-1.5 text-xs text-surface-500">
-        <input type="checkbox" bind:checked={showDone} class="accent-primary-500" />
-        Show done
-      </label>
+      <button
+        type="button"
+        class="text-xs text-surface-500 underline hover:text-surface-700 dark:hover:text-surface-300"
+        onclick={() => navStore.reset({ kind: 'logbook' })}
+      >
+        Logbook →
+      </button>
       <button
         type="button"
         class="flex items-center gap-1 rounded-md border border-surface-300 bg-surface-50 px-2 py-1 text-xs font-medium transition-colors hover:bg-surface-200 dark:border-surface-700 dark:bg-surface-800 dark:hover:bg-surface-700"
@@ -859,11 +859,6 @@
         </div>
       </div>
     {/if}
-
-    <label class="tap flex items-center gap-3 rounded-lg border border-surface-300 bg-surface-100 px-3 py-3 dark:border-surface-600 dark:bg-surface-700">
-      <input type="checkbox" bind:checked={showDone} class="h-5 w-5 accent-primary-500" />
-      <span class="text-sm font-medium">Show done</span>
-    </label>
 
     <div class="sticky bottom-0 -mx-5 -mb-5 flex gap-2 border-t border-surface-200 bg-surface-50/95 px-5 pt-3 pb-safe backdrop-blur dark:border-surface-800 dark:bg-surface-950/95">
       <button

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1460,6 +1460,8 @@ export namespace task {
 	    priority?: string;
 	    // Go type: time
 	    dueDate?: any;
+	    // Go type: time
+	    closedAt?: any;
 	    requirePermissions?: boolean;
 	    agentRuns: AgentRun[];
 	    workflow?: workflow.Execution;
@@ -1496,6 +1498,7 @@ export namespace task {
 	        this.todoistId = source["todoistId"];
 	        this.priority = source["priority"];
 	        this.dueDate = this.convertValues(source["dueDate"], null);
+	        this.closedAt = this.convertValues(source["closedAt"], null);
 	        this.requirePermissions = source["requirePermissions"];
 	        this.agentRuns = this.convertValues(source["agentRuns"], AgentRun);
 	        this.workflow = this.convertValues(source["workflow"], workflow.Execution);

--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -66,7 +66,8 @@ func countByStatus(tasks []task.Task) Counts {
 			c.HumanRequired++
 		case task.StatusDone:
 			c.Done++
-		case task.StatusPlanning, task.StatusTesting, task.StatusTestPlanReview:
+		case task.StatusPlanning, task.StatusTesting, task.StatusTestPlanReview,
+			task.StatusCancelled:
 			// Tracked in ByStatus only — not promoted to a top-level counter.
 		}
 	}

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -719,8 +719,8 @@ func (a *App) onAgentComplete(ag *agent.Agent) {
 		})
 	}
 
-	// Worktree and sandbox cleanup for done tasks (after engine advances, so status is final).
-	if t, err := a.tasks.Get(ag.TaskID); err == nil && t.Status == task.StatusDone {
+	// Worktree and sandbox cleanup for terminal tasks (after engine advances, so status is final).
+	if t, err := a.tasks.Get(ag.TaskID); err == nil && task.IsTerminalStatus(t.Status) {
 		go a.worktrees.Remove(ag.TaskID)
 		if a.sandboxes != nil {
 			go a.sandboxes.Stop(ag.TaskID)

--- a/internal/sybra/svc_integrations.go
+++ b/internal/sybra/svc_integrations.go
@@ -96,7 +96,7 @@ func (s *IntegrationService) FixRenovateCI(repo string, number int, branch, titl
 	for i := range tasks {
 		t := &tasks[i]
 		if t.PRNumber == number && t.ProjectID == repo && slices.Contains(t.Tags, "renovate-fix") {
-			if t.Status != task.StatusDone && s.agents.HasRunningAgentForTask(t.ID) {
+			if !task.IsTerminalStatus(t.Status) && s.agents.HasRunningAgentForTask(t.ID) {
 				return nil // already being fixed
 			}
 		}

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -106,11 +106,12 @@ func (s *TaskService) UpdateTask(id string, updates map[string]any) (task.Task, 
 
 	if status, ok := updates["status"].(string); ok {
 		// Reject status regressions while an agent is running on this task.
-		// Moving back to todo/new/done while an agent is active loses in-flight work.
+		// Moving back to todo/new/done/cancelled while an agent is active loses in-flight work.
 		agentBlockedStatuses := map[string]bool{
-			string(task.StatusNew):  true,
-			string(task.StatusTodo): true,
-			string(task.StatusDone): true,
+			string(task.StatusNew):       true,
+			string(task.StatusTodo):      true,
+			string(task.StatusDone):      true,
+			string(task.StatusCancelled): true,
 		}
 		if agentBlockedStatuses[status] && s.agents.HasRunningAgentForTask(id) {
 			return cur, fmt.Errorf("cannot move to %q: stop the running agent first", status)
@@ -129,7 +130,7 @@ func (s *TaskService) UpdateTask(id string, updates map[string]any) (task.Task, 
 	if err != nil {
 		return t, err
 	}
-	if t.Status == task.StatusDone {
+	if task.IsTerminalStatus(t.Status) {
 		s.wg.Go(func() {
 			s.worktrees.Remove(t.ID)
 			if s.sandboxes != nil {

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -20,13 +20,14 @@ const (
 	StatusTestPlanReview Status = "test-plan-review"
 	StatusHumanRequired  Status = "human-required"
 	StatusDone           Status = "done"
+	StatusCancelled      Status = "cancelled"
 )
 
 var validStatuses = map[Status]bool{
 	StatusNew: true, StatusTodo: true, StatusInProgress: true,
 	StatusInReview: true, StatusPlanning: true, StatusPlanReview: true,
 	StatusTesting: true, StatusTestPlanReview: true,
-	StatusHumanRequired: true, StatusDone: true,
+	StatusHumanRequired: true, StatusDone: true, StatusCancelled: true,
 }
 
 // AllStatuses returns every valid status in display order.
@@ -35,8 +36,13 @@ func AllStatuses() []Status {
 		StatusNew, StatusTodo, StatusPlanning, StatusPlanReview,
 		StatusInProgress, StatusInReview,
 		StatusTesting, StatusTestPlanReview,
-		StatusHumanRequired, StatusDone,
+		StatusHumanRequired, StatusDone, StatusCancelled,
 	}
+}
+
+// IsTerminalStatus reports whether s is a terminal (closed) status.
+func IsTerminalStatus(s Status) bool {
+	return s == StatusDone || s == StatusCancelled
 }
 
 func ValidateStatus(s string) (Status, error) {
@@ -154,6 +160,7 @@ type Task struct {
 	TodoistID    string     `yaml:"todoist_id,omitempty" json:"todoistId"`
 	Priority     Priority   `yaml:"priority,omitempty" json:"priority,omitempty"`
 	DueDate      *time.Time `yaml:"due_date,omitempty" json:"dueDate,omitempty"`
+	ClosedAt     *time.Time `yaml:"closed_at,omitempty" json:"closedAt,omitempty"`
 	// RequirePermissions overrides the system default when set.
 	// nil = use system default (true). false = opt out (--dangerously-skip-permissions).
 	RequirePermissions *bool               `yaml:"require_permissions,omitempty" json:"requirePermissions,omitempty"`

--- a/internal/task/model_test.go
+++ b/internal/task/model_test.go
@@ -28,8 +28,8 @@ func TestValidateStatus_Invalid(t *testing.T) {
 func TestAllStatuses(t *testing.T) {
 	t.Parallel()
 	statuses := AllStatuses()
-	if len(statuses) != 10 {
-		t.Errorf("got %d statuses, want 10", len(statuses))
+	if len(statuses) != 11 {
+		t.Errorf("got %d statuses, want 11", len(statuses))
 	}
 	seen := make(map[Status]bool)
 	for _, s := range statuses {

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -75,6 +75,15 @@ func (s *Store) List() ([]Task, error) {
 		}
 		t.Plan, _ = s.plans.Read(t.ID)
 		t.PlanCritique, _ = s.planCritiques.Read(t.ID)
+		// One-time migration: stamp ClosedAt for legacy terminal tasks that
+		// predate the ClosedAt field. UpdatedAt is the best approximation.
+		if IsTerminalStatus(t.Status) && t.ClosedAt == nil {
+			ts := t.UpdatedAt
+			t.ClosedAt = &ts
+			if data, merr := Marshal(t); merr == nil {
+				_ = fsutil.AtomicWrite(p, data)
+			}
+		}
 		tasks = append(tasks, t)
 	}
 	if !parseErr {
@@ -210,11 +219,22 @@ func (s *Store) Update(id string, u Update) (Task, error) {
 		t.Slug = *u.Slug
 	}
 	if u.Status != nil {
+		oldStatus := t.Status
 		t.Status = *u.Status
 		// Clear reason when status changes unless a new reason is also provided.
 		if u.StatusReason == nil {
 			t.StatusReason = ""
 		}
+		// Stamp ClosedAt on transition into a terminal status; clear on exit.
+		wasTerminal := IsTerminalStatus(oldStatus)
+		isTerminal := IsTerminalStatus(t.Status)
+		if !wasTerminal && isTerminal {
+			now := time.Now().UTC()
+			t.ClosedAt = &now
+		} else if wasTerminal && !isTerminal {
+			t.ClosedAt = nil
+		}
+		// both terminal → preserve existing ClosedAt; both non-terminal → no-op
 	}
 	if u.StatusReason != nil {
 		t.StatusReason = *u.StatusReason
@@ -378,6 +398,10 @@ func cloneTask(t Task) Task {
 		d := *t.DueDate
 		clone.DueDate = &d
 	}
+	if t.ClosedAt != nil {
+		c := *t.ClosedAt
+		clone.ClosedAt = &c
+	}
 	if t.Workflow != nil {
 		wfClone := cloneWorkflow(*t.Workflow)
 		clone.Workflow = &wfClone
@@ -423,7 +447,16 @@ func (s *Store) addRun(taskID string, run AgentRun, status *Status) error {
 		return err
 	}
 	if status != nil {
+		oldStatus := t.Status
 		t.Status = *status
+		wasTerminal := IsTerminalStatus(oldStatus)
+		isTerminal := IsTerminalStatus(t.Status)
+		if !wasTerminal && isTerminal {
+			now := time.Now().UTC()
+			t.ClosedAt = &now
+		} else if wasTerminal && !isTerminal {
+			t.ClosedAt = nil
+		}
 	}
 	t.AgentRuns = append(t.AgentRuns, run)
 	d, err := Marshal(t)

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -1050,3 +1050,217 @@ func TestStoreConcurrentUpdateSameTask(t *testing.T) {
 		t.Errorf("reloaded ID = %q, want %q", reloaded.ID, created.ID)
 	}
 }
+
+func TestClosedAtTransitions(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		from       Status
+		to         Status
+		wantNil    bool
+		wantChange bool // whether ClosedAt pointer value should change
+	}{
+		{name: "todo→done stamps", from: StatusTodo, to: StatusDone, wantNil: false, wantChange: true},
+		{name: "todo→cancelled stamps", from: StatusTodo, to: StatusCancelled, wantNil: false, wantChange: true},
+		{name: "done→in-progress clears", from: StatusDone, to: StatusInProgress, wantNil: true, wantChange: true},
+		{name: "done→cancelled preserves", from: StatusDone, to: StatusCancelled, wantNil: false, wantChange: false},
+		{name: "title edit preserves", from: StatusDone, to: StatusDone, wantNil: false, wantChange: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store, err := NewStore(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			task, err := store.Create("t", "", "headless")
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Move to 'from' status first.
+			if tc.from != StatusTodo {
+				task, err = store.Update(task.ID, Update{Status: Ptr(tc.from)})
+				if err != nil {
+					t.Fatalf("setup to %q: %v", tc.from, err)
+				}
+			}
+			origClosedAt := task.ClosedAt
+
+			if tc.to == tc.from {
+				// Title-only edit — status unchanged.
+				task, err = store.Update(task.ID, Update{Title: Ptr("updated title")})
+			} else {
+				task, err = store.Update(task.ID, Update{Status: Ptr(tc.to)})
+			}
+			if err != nil {
+				t.Fatalf("update to %q: %v", tc.to, err)
+			}
+
+			if tc.wantNil && task.ClosedAt != nil {
+				t.Errorf("ClosedAt = %v, want nil", task.ClosedAt)
+			}
+			if !tc.wantNil && task.ClosedAt == nil {
+				t.Error("ClosedAt is nil, want non-nil")
+			}
+			switch {
+			case tc.wantChange:
+				if origClosedAt == task.ClosedAt && (origClosedAt != nil && origClosedAt.Equal(*task.ClosedAt)) {
+					t.Error("ClosedAt pointer unchanged, expected change")
+				}
+			case IsTerminalStatus(tc.from) && task.ClosedAt == nil:
+				t.Error("ClosedAt cleared unexpectedly on both-terminal transition")
+			case IsTerminalStatus(tc.from) && origClosedAt != nil && task.ClosedAt != nil &&
+				!origClosedAt.Equal(*task.ClosedAt):
+				t.Errorf("ClosedAt changed on both-terminal transition: %v → %v", origClosedAt, task.ClosedAt)
+			}
+		})
+	}
+}
+
+func TestLegacyMigrationStampsClosedAt(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Create task and force status=done without ClosedAt (simulate legacy file).
+	tk, err := store.Create("legacy", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Directly write a done-status file with no closed_at field.
+	tk.Status = StatusDone
+	tk.ClosedAt = nil
+	data, err := Marshal(tk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tk.FilePath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store.invalidateListCache()
+
+	tasks, err := store.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, task := range tasks {
+		if task.ID == tk.ID {
+			if task.ClosedAt == nil {
+				t.Error("legacy migration: ClosedAt still nil after List()")
+			}
+			if !task.ClosedAt.Equal(task.UpdatedAt) {
+				t.Errorf("legacy migration: ClosedAt=%v, want UpdatedAt=%v", task.ClosedAt, task.UpdatedAt)
+			}
+			return
+		}
+	}
+	t.Fatal("task not found in List()")
+}
+
+func TestCloneTaskClosedAtNonAliased(t *testing.T) {
+	t.Parallel()
+	ts := time.Now().UTC()
+	orig := Task{
+		ID:        "x",
+		ClosedAt:  &ts,
+		CreatedAt: ts,
+		UpdatedAt: ts,
+	}
+	clone := cloneTask(orig)
+	if clone.ClosedAt == orig.ClosedAt {
+		t.Error("clone.ClosedAt shares pointer with original")
+	}
+	if !clone.ClosedAt.Equal(*orig.ClosedAt) {
+		t.Errorf("clone.ClosedAt=%v, want %v", clone.ClosedAt, orig.ClosedAt)
+	}
+	// Mutating clone must not affect original.
+	newTs := ts.Add(time.Hour)
+	*clone.ClosedAt = newTs
+	if orig.ClosedAt.Equal(newTs) {
+		t.Error("mutating clone.ClosedAt affected original")
+	}
+}
+
+func TestClosedAtYAMLRoundTrip(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	task, err := store.Create("roundtrip", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	done, err := store.Update(task.ID, Update{Status: Ptr(StatusDone)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if done.ClosedAt == nil {
+		t.Fatal("ClosedAt not set")
+	}
+	reloaded, err := Parse(done.FilePath)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if reloaded.ClosedAt == nil {
+		t.Fatal("ClosedAt lost on parse")
+	}
+	if !reloaded.ClosedAt.Equal(*done.ClosedAt) {
+		t.Errorf("ClosedAt mismatch: got %v, want %v", *reloaded.ClosedAt, *done.ClosedAt)
+	}
+	// Nil case: active task has no ClosedAt.
+	active, err := store.Create("active", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	reloaded2, err := Parse(active.FilePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded2.ClosedAt != nil {
+		t.Errorf("active task should have nil ClosedAt, got %v", reloaded2.ClosedAt)
+	}
+}
+
+func TestClosedAtLegacyMigration(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// Manually write a task file with status done but no closed_at field.
+	legacyContent := `---
+id: legacy01
+title: Legacy done task
+status: done
+agent_mode: headless
+allowed_tools: []
+tags: []
+created_at: 2025-01-01T10:00:00Z
+updated_at: 2025-06-01T12:00:00Z
+---
+body
+`
+	if err := os.WriteFile(filepath.Join(dir, "legacy01.md"), []byte(legacyContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks, err := store.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	if tasks[0].ClosedAt == nil {
+		t.Fatal("legacy task ClosedAt should be migrated")
+	}
+	want := time.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+	if !tasks[0].ClosedAt.Equal(want) {
+		t.Errorf("ClosedAt = %v, want %v", *tasks[0].ClosedAt, want)
+	}
+}

--- a/internal/workflow/condition.go
+++ b/internal/workflow/condition.go
@@ -68,6 +68,7 @@ var FieldAllowedValues = map[string]map[string]bool{
 		"new": true, "todo": true, "in-progress": true, "in-review": true,
 		"planning": true, "plan-review": true, "testing": true,
 		"test-plan-review": true, "human-required": true, "done": true,
+		"cancelled": true,
 	},
 	"task.task_type": {
 		"normal": true, "debug": true, "research": true, "chat": true,

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 go = "1.26.2"
 node = "24"
 hadolint = "2.14.0"
-golangci-lint = "2.6.0"
+golangci-lint = "2.11.4"
 "go:github.com/wailsapp/wails/v2/cmd/wails" = "v2.12.0"
 
 [tasks.dev]


### PR DESCRIPTION
## Motivation

Tasks completed or cancelled had no dedicated view — they cluttered the board or were invisible. The logbook provides a searchable, filterable archive of all terminal-state tasks, giving users a clear history of completed work.

## Implementation information

- Added `StatusCancelled` as a distinct terminal status alongside `done`
- Added `ClosedAt *time.Time` field stamped on transition to `done`/`cancelled`, cleared on exit from terminal states, preserved on terminal↔terminal moves
- Added `IsTerminalStatus()` helper; all done-checks updated to use it
- Legacy migration: stamps `ClosedAt=UpdatedAt` on first `List()` for existing tasks
- `workflow.FieldAllowedValues` updated to include `cancelled`
- Board now excludes `done`/`cancelled`; new Logbook page owns terminal tasks
- Logbook page: full-text search, status pills, project/tag/date-range filters, sort by `closedAt`, click-through to task detail
- SideRail Archive trigger added for Logbook navigation; `navStore` logbook page kind added

Closes https://github.com/Automaat/sybra/issues/458