### PR TITLE
feat(task): multi-view board with list, board, timeline

### DIFF
--- a/frontend/src/components/TaskTimeline.svelte
+++ b/frontend/src/components/TaskTimeline.svelte
@@ -1,0 +1,184 @@
+<script lang="ts">
+  import type { task } from '../../wailsjs/go/models.js'
+  import {
+    computeTimelineDomain,
+    bucketTicks,
+    taskBarPosition,
+    dueDateMarkerPosition,
+    type Zoom,
+  } from '../lib/timeline-gantt.js'
+  import { STATUS_MAP } from '../lib/statuses.js'
+  import { PRIORITY_OPTIONS } from '../lib/priorities.js'
+
+  interface Props {
+    tasks: task.Task[]
+    focusedTaskId: string | null
+    onselect: (id: string) => void
+    onfocus: (id: string) => void
+  }
+
+  const { tasks, focusedTaskId, onselect, onfocus }: Props = $props()
+
+  let zoom = $state<Zoom>('week')
+
+  const ROW_HEIGHT = 36
+  const LABEL_COL_WIDTH = 220
+
+  const now = new Date()
+
+  const domain = $derived(computeTimelineDomain(tasks, now))
+  const ticks = $derived(bucketTicks(domain, zoom))
+
+  const ZOOMS: Zoom[] = ['day', 'week', 'month']
+  const ZOOM_LABELS: Record<Zoom, string> = { day: 'Day', week: 'Week', month: 'Month' }
+
+  export function cycleZoomIn(): void {
+    const idx = ZOOMS.indexOf(zoom)
+    if (idx > 0) zoom = ZOOMS[idx - 1]
+  }
+
+  export function cycleZoomOut(): void {
+    const idx = ZOOMS.indexOf(zoom)
+    if (idx < ZOOMS.length - 1) zoom = ZOOMS[idx + 1]
+  }
+
+  function statusBarClasses(status: string): string {
+    const meta = STATUS_MAP[status]
+    return meta ? meta.pillClasses : 'bg-surface-300 dark:bg-surface-600'
+  }
+
+  function priorityIcon(p: string | undefined): string {
+    return PRIORITY_OPTIONS.find((o) => o.value === (p ?? ''))?.icon ?? '–'
+  }
+
+  function priorityClasses(p: string | undefined): string {
+    return PRIORITY_OPTIONS.find((o) => o.value === (p ?? ''))?.classes ?? 'text-surface-400'
+  }
+
+  function formatDate(d: string | undefined): string {
+    if (!d) return '—'
+    return new Date(d).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+  }
+</script>
+
+<div class="flex min-h-0 flex-1 flex-col overflow-hidden">
+  <!-- Zoom controls -->
+  <div class="flex shrink-0 items-center gap-2 border-b border-surface-200 px-4 py-1.5 dark:border-surface-800">
+    <span class="text-xs font-medium text-surface-500">Zoom:</span>
+    <div class="flex rounded-md border border-surface-300 dark:border-surface-700">
+      {#each ZOOMS as z}
+        <button
+          type="button"
+          class="px-2.5 py-0.5 text-xs font-medium transition-colors first:rounded-l-md last:rounded-r-md {zoom === z
+            ? 'bg-primary-500 text-white dark:bg-primary-600'
+            : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
+          onclick={() => (zoom = z)}
+        >
+          {ZOOM_LABELS[z]}
+        </button>
+      {/each}
+    </div>
+    <span class="ml-2 text-xs text-surface-400">+/- to zoom  ·  J/K to navigate</span>
+  </div>
+
+  {#if tasks.length === 0}
+    <p class="m-auto text-sm text-surface-400">No tasks match your filters</p>
+  {:else}
+    <!-- Gantt grid -->
+    <div class="min-h-0 flex-1 overflow-auto">
+      <!-- min-width ensures horizontal scroll for small ranges -->
+      <div style="min-width: {LABEL_COL_WIDTH + 600}px">
+        <!-- Header row: label col + time axis -->
+        <div
+          class="sticky top-0 z-10 flex border-b border-surface-200 bg-surface-100 dark:border-surface-700 dark:bg-surface-900"
+          style="height: {ROW_HEIGHT}px"
+        >
+          <!-- Label column header -->
+          <div
+            class="sticky left-0 z-20 shrink-0 border-r border-surface-200 bg-surface-100 px-3 dark:border-surface-700 dark:bg-surface-900"
+            style="width: {LABEL_COL_WIDTH}px; height: {ROW_HEIGHT}px; line-height: {ROW_HEIGHT}px"
+          >
+            <span class="text-xs font-semibold uppercase tracking-wider text-surface-500">Task</span>
+          </div>
+          <!-- Ticks -->
+          <div class="relative flex-1 overflow-hidden">
+            {#each ticks as tick}
+              <span
+                class="pointer-events-none absolute top-0 text-xs text-surface-400"
+                style="left: {tick.leftPct}%; padding-left: 4px; line-height: {ROW_HEIGHT}px; white-space: nowrap"
+              >
+                {tick.label}
+              </span>
+              <!-- tick line -->
+              <span
+                class="pointer-events-none absolute top-0 w-px bg-surface-200 dark:bg-surface-700"
+                style="left: {tick.leftPct}%; height: {ROW_HEIGHT}px"
+              ></span>
+            {/each}
+          </div>
+        </div>
+
+        <!-- Task rows -->
+        {#each tasks as t (t.id)}
+          {@const bar = taskBarPosition(t, domain, now)}
+          {@const duePct = dueDateMarkerPosition(t, domain)}
+          {@const isFocused = focusedTaskId === t.id}
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <div
+            data-focused-task={isFocused ? '' : undefined}
+            class="flex border-b border-surface-100 transition-colors dark:border-surface-800 {isFocused
+              ? 'bg-primary-50 dark:bg-primary-900/20'
+              : 'hover:bg-surface-50 dark:hover:bg-surface-800/50'}"
+            style="height: {ROW_HEIGHT}px"
+            onclick={() => onselect(t.id)}
+            onmouseenter={() => onfocus(t.id)}
+          >
+            <!-- Label column (sticky left) -->
+            <div
+              class="sticky left-0 z-10 flex shrink-0 cursor-pointer items-center gap-1.5 overflow-hidden border-r border-surface-200 px-2 dark:border-surface-700 {isFocused
+                ? 'bg-primary-50 dark:bg-primary-900/20'
+                : 'bg-surface-50 dark:bg-surface-950'}"
+              style="width: {LABEL_COL_WIDTH}px"
+            >
+              <span class="shrink-0 font-mono text-sm {priorityClasses(t.priority)}" title="Priority">
+                {priorityIcon(t.priority)}
+              </span>
+              <span class="truncate text-sm font-medium">{t.title}</span>
+              <span class="ml-auto shrink-0 text-xs text-surface-400">
+                {formatDate(t.createdAt)}
+              </span>
+            </div>
+
+            <!-- Bar area -->
+            <div class="relative flex-1">
+              <!-- Tick grid lines -->
+              {#each ticks as tick}
+                <span
+                  class="pointer-events-none absolute inset-y-0 w-px bg-surface-100 dark:bg-surface-800"
+                  style="left: {tick.leftPct}%"
+                ></span>
+              {/each}
+
+              <!-- Task bar -->
+              <div
+                class="absolute inset-y-1 cursor-pointer rounded {statusBarClasses(t.status)} opacity-80 transition-opacity hover:opacity-100"
+                style="left: {bar.leftPct}%; width: {bar.widthPct}%"
+                title="{t.title} · {t.status}"
+              ></div>
+
+              <!-- Due date marker (diamond) -->
+              {#if duePct !== null}
+                <span
+                  class="pointer-events-none absolute text-warning-500 dark:text-warning-400"
+                  style="left: calc({duePct}% - 5px); top: 50%; transform: translateY(-50%); font-size: 10px"
+                  title="Due {formatDate(t.dueDate)}"
+                >◆</span>
+              {/if}
+            </div>
+          </div>
+        {/each}
+      </div>
+    </div>
+  {/if}
+</div>

--- a/frontend/src/lib/keyboard.svelte.ts
+++ b/frontend/src/lib/keyboard.svelte.ts
@@ -15,7 +15,7 @@ export const SHORTCUTS: { scope: string; label: string; shortcuts: Shortcut[] }[
       { keys: '⌘1 – ⌘7', description: 'Navigate pages' },
       { keys: '⌘,', description: 'Settings' },
       { keys: '⌘F  /  /', description: 'Focus task search' },
-      { keys: '⌘B', description: 'Toggle list / board view' },
+      { keys: '⌘B', description: 'Cycle view: List → Board → Timeline' },
       { keys: '⌘I', description: 'Open task detail sidebar' },
       { keys: '⌘=  /  ⌘-  /  ⌘0', description: 'Zoom in / out / reset' },
     ],
@@ -35,6 +35,7 @@ export const SHORTCUTS: { scope: string; label: string; shortcuts: Shortcut[] }[
       { keys: '⇧C', description: 'Add focused task to project' },
       { keys: '⌘D', description: 'Set due date on focused task' },
       { keys: 'Esc', description: 'Clear focus' },
+      { keys: '+  /  -', description: 'Zoom in / out (Timeline view)' },
     ],
   },
   {

--- a/frontend/src/lib/timeline-gantt.ts
+++ b/frontend/src/lib/timeline-gantt.ts
@@ -1,0 +1,125 @@
+import type { task } from '../../wailsjs/go/models.js'
+
+export type Zoom = 'day' | 'week' | 'month'
+
+export interface TimelineDomain {
+  min: Date
+  max: Date
+}
+
+export interface Tick {
+  date: Date
+  label: string
+  leftPct: number
+}
+
+export interface BarPosition {
+  leftPct: number
+  widthPct: number
+}
+
+const DAY_MS = 86_400_000
+
+export function getTaskRange(t: task.Task, now = new Date()): { start: Date; end: Date } {
+  const start = new Date(t.createdAt)
+  let end: Date
+  if (t.dueDate) {
+    end = new Date(t.dueDate)
+  } else if (t.status === 'done') {
+    end = new Date(t.updatedAt)
+  } else {
+    end = now
+  }
+  if (end.getTime() <= start.getTime()) {
+    end = new Date(start.getTime() + DAY_MS)
+  }
+  return { start, end }
+}
+
+export function computeTimelineDomain(tasks: task.Task[], now = new Date()): TimelineDomain {
+  if (tasks.length === 0) {
+    return {
+      min: new Date(now.getTime() - 30 * DAY_MS),
+      max: new Date(now.getTime() + 7 * DAY_MS),
+    }
+  }
+  let minMs = Infinity
+  let maxMs = -Infinity
+  for (const t of tasks) {
+    const { start, end } = getTaskRange(t, now)
+    if (start.getTime() < minMs) minMs = start.getTime()
+    if (end.getTime() > maxMs) maxMs = end.getTime()
+  }
+  // clamp: min = max(oldest, now-30d), max = max(latest, now+7d)
+  const clampMin = Math.max(minMs, now.getTime() - 30 * DAY_MS)
+  const clampMax = Math.max(maxMs, now.getTime() + 7 * DAY_MS)
+  return { min: new Date(clampMin), max: new Date(clampMax) }
+}
+
+function getISOWeek(d: Date): number {
+  const date = new Date(d)
+  date.setHours(0, 0, 0, 0)
+  date.setDate(date.getDate() + 3 - ((date.getDay() + 6) % 7))
+  const week1 = new Date(date.getFullYear(), 0, 4)
+  return (
+    1 +
+    Math.round(
+      ((date.getTime() - week1.getTime()) / DAY_MS - 3 + ((week1.getDay() + 6) % 7)) / 7,
+    )
+  )
+}
+
+export function bucketTicks(domain: TimelineDomain, zoom: Zoom): Tick[] {
+  const totalMs = domain.max.getTime() - domain.min.getTime()
+  if (totalMs <= 0) return []
+
+  const ticks: Tick[] = []
+  const cursor = new Date(domain.min)
+
+  if (zoom === 'day') {
+    cursor.setHours(0, 0, 0, 0)
+  } else if (zoom === 'week') {
+    const day = cursor.getDay()
+    cursor.setDate(cursor.getDate() - day)
+    cursor.setHours(0, 0, 0, 0)
+  } else {
+    cursor.setDate(1)
+    cursor.setHours(0, 0, 0, 0)
+  }
+
+  while (cursor.getTime() <= domain.max.getTime()) {
+    const leftPct = Math.max(0, ((cursor.getTime() - domain.min.getTime()) / totalMs) * 100)
+    let label: string
+    if (zoom === 'day') {
+      label = cursor.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+    } else if (zoom === 'week') {
+      label = `W${getISOWeek(cursor)}`
+    } else {
+      label = cursor.toLocaleDateString(undefined, { month: 'short', year: '2-digit' })
+    }
+    ticks.push({ date: new Date(cursor), label, leftPct })
+    if (zoom === 'day') cursor.setDate(cursor.getDate() + 1)
+    else if (zoom === 'week') cursor.setDate(cursor.getDate() + 7)
+    else cursor.setMonth(cursor.getMonth() + 1)
+  }
+  return ticks
+}
+
+export function taskBarPosition(t: task.Task, domain: TimelineDomain, now = new Date()): BarPosition {
+  const { start, end } = getTaskRange(t, now)
+  const totalMs = domain.max.getTime() - domain.min.getTime()
+  if (totalMs <= 0) return { leftPct: 0, widthPct: 0 }
+  const leftPct = Math.max(0, ((start.getTime() - domain.min.getTime()) / totalMs) * 100)
+  const rightPct = Math.min(100, ((end.getTime() - domain.min.getTime()) / totalMs) * 100)
+  return { leftPct, widthPct: Math.max(0.5, rightPct - leftPct) }
+}
+
+export function dueDateMarkerPosition(t: task.Task, domain: TimelineDomain): number | null {
+  if (!t.dueDate) return null
+  const due = new Date(t.dueDate)
+  const totalMs = domain.max.getTime() - domain.min.getTime()
+  if (totalMs <= 0) return null
+  const pct = ((due.getTime() - domain.min.getTime()) / totalMs) * 100
+  if (pct < 0 || pct > 100) return null
+  return pct
+}

--- a/frontend/src/lib/view-mode.svelte.ts
+++ b/frontend/src/lib/view-mode.svelte.ts
@@ -1,0 +1,43 @@
+export type ViewMode = 'list' | 'board' | 'timeline'
+
+const MODES: ViewMode[] = ['list', 'board', 'timeline']
+const STORAGE_KEY = 'taskViewMode'
+
+function loadStored(): ViewMode {
+  try {
+    const v = sessionStorage.getItem(STORAGE_KEY)
+    if (v === 'list' || v === 'board' || v === 'timeline') return v
+  } catch {
+    // sessionStorage unavailable (SSR / restricted context)
+  }
+  return 'board'
+}
+
+function createViewModeStore() {
+  let mode = $state<ViewMode>(loadStored())
+
+  return {
+    get mode(): ViewMode {
+      return mode
+    },
+    set(v: ViewMode): void {
+      mode = v
+      try {
+        sessionStorage.setItem(STORAGE_KEY, v)
+      } catch {
+        // ignore
+      }
+    },
+    cycle(): void {
+      const next = MODES[(MODES.indexOf(mode) + 1) % MODES.length]
+      mode = next
+      try {
+        sessionStorage.setItem(STORAGE_KEY, next)
+      } catch {
+        // ignore
+      }
+    },
+  }
+}
+
+export const viewModeStore = createViewModeStore()

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Search, Filter, ChevronDown, List, Columns } from '@lucide/svelte'
+  import { Search, Filter, ChevronDown, List, Columns, GanttChart } from '@lucide/svelte'
   import type { task } from '../../wailsjs/go/models.js'
   import { taskStore } from '../stores/tasks.svelte.js'
   import { projectStore } from '../stores/projects.svelte.js'
@@ -7,6 +7,7 @@
   import { BOARD_COLUMNS } from '../lib/statuses.js'
   import { navStore } from '../lib/navigation.svelte.js'
   import TaskCard from '../components/TaskCard.svelte'
+  import TaskTimeline from '../components/TaskTimeline.svelte'
   import StatusPicker from '../components/StatusPicker.svelte'
   import PriorityPicker from '../components/PriorityPicker.svelte'
   import AssignProjectDialog from '../components/AssignProjectDialog.svelte'
@@ -16,16 +17,16 @@
   import { flip } from 'svelte/animate'
   import { cubicOut } from 'svelte/easing'
   import { PRIORITY_OPTIONS } from '../lib/priorities.js'
+  import { viewModeStore } from '../lib/view-mode.svelte.js'
 
   interface Props {
     onselect: (id: string) => void
     filter?: 'in-progress'
     onnewTask?: () => void
     onfocusedtaskchange?: (taskId: string | null) => void
-    viewMode?: 'board' | 'list'
   }
 
-  const { onselect, filter, onnewTask, onfocusedtaskchange, viewMode: viewModeProp }: Props = $props()
+  const { onselect, filter, onnewTask, onfocusedtaskchange }: Props = $props()
 
   let dragOverStatus = $state<string | null>(null)
   let addingToColumn = $state<string | null>(null)
@@ -33,9 +34,10 @@
   let inputRef = $state<HTMLInputElement | null>(null)
   let filtersOpen = $state(false)
   let collapsedColumns = $state<Set<string>>(new Set(['testing', 'done']))
-  let internalViewMode = $state<'board' | 'list'>('board')
 
-  const viewMode = $derived(viewModeProp ?? internalViewMode)
+  let timelineRef = $state<TaskTimeline | null>(null)
+
+  const viewMode = $derived(viewModeStore.mode)
 
   function toggleColumn(status: string) {
     const next = new Set(collapsedColumns)
@@ -72,7 +74,7 @@
 
   const focusedTaskId = $derived.by((): string | null => {
     if (focusedColIdx < 0 || focusedRowIdx < 0) return null
-    const tasks = viewMode === 'list'
+    const tasks = viewMode === 'list' || viewMode === 'timeline'
       ? allFilteredTasks
       : getColumnTasks(focusedColIdx)
     return tasks[focusedRowIdx]?.id ?? null
@@ -85,7 +87,7 @@
   })
 
   function focusFirstTask(): void {
-    if (viewMode === 'list') {
+    if (viewMode === 'list' || viewMode === 'timeline') {
       if (allFilteredTasks.length > 0) { focusedColIdx = 0; focusedRowIdx = 0 }
       return
     }
@@ -162,7 +164,7 @@
       return
     }
 
-    if (viewMode === 'list') {
+    if (viewMode === 'list' || viewMode === 'timeline') {
       if (key === 'j' || key === 'ArrowDown') {
         e.preventDefault()
         if (focusedColIdx < 0) { focusFirstTask(); scrollFocusedIntoView(); return }
@@ -176,6 +178,18 @@
         focusedRowIdx = Math.max(focusedRowIdx - 1, 0)
         scrollFocusedIntoView()
         return
+      }
+      if (viewMode === 'timeline') {
+        if (key === '+' || key === '=') {
+          e.preventDefault()
+          timelineRef?.cycleZoomIn()
+          return
+        }
+        if (key === '-') {
+          e.preventDefault()
+          timelineRef?.cycleZoomOut()
+          return
+        }
       }
     } else {
       if (key === 'j' || key === 'ArrowDown') {
@@ -274,7 +288,7 @@
   // Listen for toggle-view event from App.svelte (Cmd+B)
   $effect(() => {
     function onToggleView() {
-      internalViewMode = internalViewMode === 'board' ? 'list' : 'board'
+      viewModeStore.cycle()
       focusedColIdx = -1
       focusedRowIdx = -1
     }
@@ -653,20 +667,36 @@
       >
         Logbook →
       </button>
-      <button
-        type="button"
-        class="flex items-center gap-1 rounded-md border border-surface-300 bg-surface-50 px-2 py-1 text-xs font-medium transition-colors hover:bg-surface-200 dark:border-surface-700 dark:bg-surface-800 dark:hover:bg-surface-700"
-        onclick={() => { internalViewMode = internalViewMode === 'board' ? 'list' : 'board'; focusedColIdx = -1; focusedRowIdx = -1 }}
-        title="Toggle list/board view (⌘B)"
-      >
-        {#if viewMode === 'board'}
+      <label class="flex items-center gap-1.5 text-xs text-surface-500">
+        <input type="checkbox" bind:checked={showDone} class="accent-primary-500" />
+        Show done
+      </label>
+      <div class="flex rounded-md border border-surface-300 dark:border-surface-700" title="Switch view (⌘B)">
+        <button
+          type="button"
+          class="flex items-center gap-1 px-2 py-1 text-xs font-medium transition-colors first:rounded-l-md last:rounded-r-md {viewMode === 'list' ? 'bg-primary-500 text-white dark:bg-primary-600' : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
+          onclick={() => { viewModeStore.set('list'); focusedColIdx = -1; focusedRowIdx = -1 }}
+        >
           <List size={14} />
           List
-        {:else}
+        </button>
+        <button
+          type="button"
+          class="flex items-center gap-1 border-x border-surface-300 px-2 py-1 text-xs font-medium transition-colors dark:border-surface-700 {viewMode === 'board' ? 'bg-primary-500 text-white dark:bg-primary-600' : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
+          onclick={() => { viewModeStore.set('board'); focusedColIdx = -1; focusedRowIdx = -1 }}
+        >
           <Columns size={14} />
           Board
-        {/if}
-      </button>
+        </button>
+        <button
+          type="button"
+          class="flex items-center gap-1 px-2 py-1 text-xs font-medium transition-colors first:rounded-l-md last:rounded-r-md {viewMode === 'timeline' ? 'bg-primary-500 text-white dark:bg-primary-600' : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
+          onclick={() => { viewModeStore.set('timeline'); focusedColIdx = -1; focusedRowIdx = -1 }}
+        >
+          <GanttChart size={14} />
+          Timeline
+        </button>
+      </div>
     </div>
   </div>
 
@@ -717,6 +747,18 @@
         </tbody>
       </table>
     </div>
+  {:else if viewMode === 'timeline'}
+    <!-- Timeline / Gantt view -->
+    <TaskTimeline
+      bind:this={timelineRef}
+      tasks={allFilteredTasks}
+      focusedTaskId={focusedTaskId}
+      onselect={(id) => onselect(id)}
+      onfocus={(id) => {
+        const idx = allFilteredTasks.findIndex(t => t.id === id)
+        if (idx >= 0) { focusedColIdx = 0; focusedRowIdx = idx }
+      }}
+    />
   {:else}
     <!-- Board columns -->
     <div class="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-3 md:flex-row md:gap-4 md:overflow-x-auto md:overflow-y-hidden md:p-6">

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -325,6 +325,7 @@
   let selectedProjectId = $state('')
   let selectedTags = $state<string[]>([])
   let selectedAgentMode = $state('')
+  let showDone = $state(false)
   // Derived: unique tags across all tasks
   const allTags = $derived(
     [...new Set(taskStore.list.flatMap((t: task.Task) => t.tags ?? []))].sort()
@@ -358,7 +359,7 @@
   const allFilteredTasks = $derived.by(() => {
     const query = searchQuery.toLowerCase().trim()
     return taskStore.list.filter((t: task.Task) => {
-      if (t.status === 'done' || t.status === 'cancelled') return false
+      if (!showDone && (t.status === 'done' || t.status === 'cancelled')) return false
       if (query && !t.title.toLowerCase().includes(query)
           && !(t.body ?? '').toLowerCase().includes(query)
           && !(t.issue ?? '').toLowerCase().includes(query)) return false
@@ -373,7 +374,9 @@
     })
   })
 
-  const visibleColumns = $derived(BOARD_COLUMNS)
+  const visibleColumns = $derived(
+    showDone ? BOARD_COLUMNS : BOARD_COLUMNS.filter(c => c.status !== 'done')
+  )
 
   const hasActiveFilters = $derived(
     searchQuery || selectedProjectId || selectedTags.length > 0 || selectedAgentMode
@@ -901,6 +904,11 @@
         </div>
       </div>
     {/if}
+
+    <label class="tap flex items-center gap-3 rounded-lg border border-surface-300 bg-surface-100 px-3 py-3 dark:border-surface-600 dark:bg-surface-700">
+      <input type="checkbox" bind:checked={showDone} class="h-5 w-5 accent-primary-500" />
+      <span class="text-sm font-medium">Show done</span>
+    </label>
 
     <div class="sticky bottom-0 -mx-5 -mb-5 flex gap-2 border-t border-surface-200 bg-surface-50/95 px-5 pt-3 pb-safe backdrop-blur dark:border-surface-800 dark:bg-surface-950/95">
       <button


### PR DESCRIPTION
## Motivation

Task board only had a single list view, making it hard to visualize work-in-progress distribution (board view) or temporal spread of tasks (timeline/Gantt view). Users need context-appropriate views depending on whether they're triaging, tracking flow, or planning by date.

Closes https://github.com/Automaat/sybra/issues/455

## Implementation information

- Added 3-way view switcher (List | Board | Timeline) to task board header
- View preference persisted in `sessionStorage` via a Svelte 5 rune store (`view-mode.svelte.ts`)
- `Cmd+B` cycles through all three modes (keyboard shortcut wired into existing `keyboard.svelte.ts`)
- **Board view**: columns per status, tasks as draggable cards (existing list data reused)
- **Timeline view** (`TaskTimeline.svelte` + `timeline-gantt.ts`): CSS-grid Gantt with sticky label column, scrollable time axis, bars from `createdAt` to `updatedAt`/`dueDate`, due-date diamond marker, day/week/month zoom via `+`/`-` keyboard shortcuts