### PR TITLE
fix(server): mise trust, shutdown, log prune

### DIFF
--- a/cmd/sybra-server/main.go
+++ b/cmd/sybra-server/main.go
@@ -107,7 +107,12 @@ func run() error {
 	select {
 	case <-ctx.Done():
 		logger.Info("server.shutdown")
-		shutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		// 30s window covers the agent manager's 20s grace (giving SIGTERM'd
+		// claude/codex processes a chance to flush their final result event)
+		// plus headroom for HTTP handlers to drain. Previously 10s, which
+		// caused server.shutdown.err: context deadline exceeded on every
+		// restart because HTTP + agent drains both ran inside that window.
+		shutCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		if shutErr := srv.Shutdown(shutCtx); shutErr != nil {
 			logger.Error("server.shutdown.err", "err", shutErr)

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -301,6 +301,7 @@ export namespace config {
 	    maxTurns: number;
 	    requirePermissions?: boolean;
 	    maxLogEvents: number;
+	    logRetentionDays: number;
 	
 	    static createFrom(source: any = {}) {
 	        return new AgentDefaults(source);
@@ -317,6 +318,7 @@ export namespace config {
 	        this.maxTurns = source["maxTurns"];
 	        this.requirePermissions = source["requirePermissions"];
 	        this.maxLogEvents = source["maxLogEvents"];
+	        this.logRetentionDays = source["logRetentionDays"];
 	    }
 	}
 	export class AuditConfig {

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -569,15 +569,53 @@ func (m *Manager) HasRunningAgentForTask(taskID string) bool {
 	return false
 }
 
+// defaultShutdownGrace bounds how long Shutdown waits for in-flight agents
+// to notice the cancel signal and exit cleanly. Without this, agents get
+// SIGKILL'd mid-stream and the final `result` NDJSON line is truncated,
+// leaving operators with a half-written run log and a "signal: killed"
+// exit error that carries no diagnostic value.
+const defaultShutdownGrace = 20 * time.Second
+
+// Shutdown cancels all running agents and blocks until they exit or the
+// grace window elapses — whichever comes first. Subprocess runners use
+// SIGTERM + cmd.WaitDelay (see shutdownSignal in runner helpers) so this
+// grace gives claude/codex time to flush the final `result` event.
 func (m *Manager) Shutdown() {
+	m.ShutdownWithGrace(defaultShutdownGrace)
+}
+
+// ShutdownWithGrace is Shutdown with an explicit grace window. Used by
+// tests (short grace) and callers that want to override the default.
+func (m *Manager) ShutdownWithGrace(grace time.Duration) {
 	m.mu.RLock()
-	defer m.mu.RUnlock()
-	m.logger.Info("agent.shutdown", "count", len(m.agents))
+	count := len(m.agents)
+	dones := make([]chan struct{}, 0, count)
 	for _, a := range m.agents {
 		if a.cancel != nil {
 			a.cancel()
 		}
+		if a.done != nil {
+			dones = append(dones, a.done)
+		}
 	}
+	m.mu.RUnlock()
+
+	m.logger.Info("agent.shutdown", "count", count, "grace", grace, "wait", len(dones))
+	if len(dones) == 0 || grace <= 0 {
+		return
+	}
+
+	deadline := time.After(grace)
+	for i, done := range dones {
+		select {
+		case <-done:
+		case <-deadline:
+			m.logger.Warn("agent.shutdown.timeout",
+				"exited", i, "remaining", len(dones)-i, "grace", grace)
+			return
+		}
+	}
+	m.logger.Info("agent.shutdown.done", "exited", len(dones))
 }
 
 // safeArgRe matches only characters safe to embed in a shell command

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -595,6 +595,84 @@ func TestShutdown(t *testing.T) {
 	}
 }
 
+// TestShutdownWithGrace_WaitsForDoneChannels locks in the graceful-shutdown
+// contract introduced after the 2026-04-16 "signal: killed" wave: once the
+// agent manager cancels running agents, it must block on their done
+// channels until either they close or the grace window elapses. Before
+// this fix, Shutdown returned immediately and the server process exited
+// mid-stream, truncating NDJSON result lines.
+func TestShutdownWithGrace_WaitsForDoneChannels(t *testing.T) {
+	t.Parallel()
+	m, _ := newTestManager(t)
+
+	// Seed a fake running agent: registered in m.agents with a done
+	// channel the test closes from a goroutine to simulate clean exit.
+	done := make(chan struct{})
+	_, agCancel := context.WithCancel(context.Background())
+	m.mu.Lock()
+	m.agents["ag1"] = &Agent{
+		ID:     "ag1",
+		cancel: agCancel,
+		done:   done,
+	}
+	m.mu.Unlock()
+
+	// Close done after a short delay — models a well-behaved subprocess
+	// noticing SIGTERM and flushing its result before exiting.
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		close(done)
+	}()
+
+	start := time.Now()
+	m.ShutdownWithGrace(500 * time.Millisecond)
+	elapsed := time.Since(start)
+	if elapsed > 300*time.Millisecond {
+		t.Errorf("shutdown took %s, expected it to return shortly after done close", elapsed)
+	}
+	if elapsed < 30*time.Millisecond {
+		t.Errorf("shutdown took %s, must have waited for done channel", elapsed)
+	}
+}
+
+// TestShutdownWithGrace_RespectsGraceDeadline guards against the opposite
+// failure: a hung agent must not block shutdown forever. After the grace
+// window the helper returns and the outer server shutdown can complete.
+func TestShutdownWithGrace_RespectsGraceDeadline(t *testing.T) {
+	t.Parallel()
+	m, _ := newTestManager(t)
+
+	done := make(chan struct{})
+	_, agCancel := context.WithCancel(context.Background())
+	m.mu.Lock()
+	m.agents["stuck"] = &Agent{
+		ID:     "stuck",
+		cancel: agCancel,
+		done:   done, // never closed
+	}
+	m.mu.Unlock()
+
+	start := time.Now()
+	m.ShutdownWithGrace(80 * time.Millisecond)
+	elapsed := time.Since(start)
+	if elapsed < 80*time.Millisecond {
+		t.Errorf("returned early at %s, expected to wait the full grace", elapsed)
+	}
+	if elapsed > 400*time.Millisecond {
+		t.Errorf("waited %s, expected to bail around the grace window", elapsed)
+	}
+}
+
+func TestShutdownWithGrace_NoAgents(t *testing.T) {
+	t.Parallel()
+	m, _ := newTestManager(t)
+	start := time.Now()
+	m.ShutdownWithGrace(5 * time.Second)
+	if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
+		t.Errorf("empty shutdown took %s, should return immediately", elapsed)
+	}
+}
+
 // --- Plan-review fix: paused conversational agents must stay findable ---
 //
 // Interactive (conversational) agents flip to StatePaused after each

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -129,6 +129,7 @@ func (m *Manager) runCodexConversational(ctx context.Context, a *Agent, cfg RunC
 func (m *Manager) runCodexTurn(ctx context.Context, a *Agent, cfg RunConfig, prompt string, logWriter io.Writer) bool {
 	args := buildCodexConvoArgs(a, cfg, prompt)
 	cmd := exec.CommandContext(ctx, "codex", args...)
+	configureGracefulShutdown(cmd)
 	if a.sessionCWD != "" {
 		cmd.Dir = a.sessionCWD
 	}

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -98,6 +98,7 @@ func (m *Manager) buildConvoArgs(a *Agent, cfg RunConfig) []string {
 func (m *Manager) startConvoProcess(ctx context.Context, a *Agent, cfg RunConfig) (*exec.Cmd, io.ReadCloser, *bytes.Buffer, error) {
 	args := m.buildConvoArgs(a, cfg)
 	cmd := exec.CommandContext(ctx, "claude", args...)
+	configureGracefulShutdown(cmd)
 	if a.sessionCWD != "" {
 		cmd.Dir = a.sessionCWD
 	}

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -77,6 +77,7 @@ func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfi
 	}
 
 	cmd := exec.CommandContext(ctx, name, args...)
+	configureGracefulShutdown(cmd)
 	if a.sessionCWD != "" {
 		cmd.Dir = a.sessionCWD
 	}

--- a/internal/agent/shutdown.go
+++ b/internal/agent/shutdown.go
@@ -1,0 +1,35 @@
+package agent
+
+import (
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// shutdownWaitDelay is the grace window granted to a subprocess between
+// SIGTERM and SIGKILL on context cancel. claude/codex need a few seconds
+// to flush the terminal `result` NDJSON line and close their session
+// logs; anything shorter shows up in ops logs as `signal: killed` with a
+// truncated run log.
+const shutdownWaitDelay = 15 * time.Second
+
+// configureGracefulShutdown wires cmd so that a cancelled context first
+// sends SIGTERM (letting the subprocess flush its final output) and only
+// SIGKILLs after shutdownWaitDelay if it refuses to exit. The default for
+// exec.CommandContext is SIGKILL-on-cancel with no grace, which is the
+// source of the truncated-NDJSON "signal: killed" pattern in server logs.
+//
+// Safe to call on any *exec.Cmd built with exec.CommandContext before
+// cmd.Start.
+func configureGracefulShutdown(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return cmd.Process.Signal(syscall.SIGTERM)
+	}
+	cmd.WaitDelay = shutdownWaitDelay
+}

--- a/internal/agent/shutdown_test.go
+++ b/internal/agent/shutdown_test.go
@@ -1,0 +1,70 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestConfigureGracefulShutdown_NilSafe(t *testing.T) {
+	t.Parallel()
+	// Helper must tolerate nil so callers don't need a nil-check after
+	// exec.CommandContext returned an error path and left cmd unset.
+	configureGracefulShutdown(nil)
+}
+
+func TestConfigureGracefulShutdown_SetsCancelAndWaitDelay(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("true")
+	configureGracefulShutdown(cmd)
+	if cmd.Cancel == nil {
+		t.Fatal("Cancel not set")
+	}
+	if cmd.WaitDelay != shutdownWaitDelay {
+		t.Errorf("WaitDelay=%s want %s", cmd.WaitDelay, shutdownWaitDelay)
+	}
+}
+
+func TestConfigureGracefulShutdown_CancelSendsSIGTERM(t *testing.T) {
+	t.Parallel()
+	// sleep ignores the default SIGKILL-on-cancel behavior the same as any
+	// other well-behaved process: it exits on SIGTERM. If our Cancel sent
+	// SIGKILL (the old default) the signal surfaced in ProcessState would
+	// be "killed", not "terminated".
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sleep", "30")
+	configureGracefulShutdown(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	// Give the process a tick to actually be alive before we cancel,
+	// otherwise Cancel fires before cmd.Process is set and the test
+	// reduces to checking the nil-guard rather than the signal.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	waitErr := cmd.Wait()
+	if waitErr == nil {
+		t.Fatal("expected exit error after cancel, got nil")
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(waitErr, &exitErr) {
+		t.Fatalf("expected *exec.ExitError, got %T: %v", waitErr, waitErr)
+	}
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok {
+		t.Fatalf("unexpected Sys() type %T", exitErr.Sys())
+	}
+	if !status.Signaled() {
+		t.Fatal("process did not exit via signal")
+	}
+	if status.Signal() != syscall.SIGTERM {
+		t.Errorf("process received %v, want SIGTERM", status.Signal())
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,11 @@ type AgentDefaults struct {
 	// MaxLogEvents caps how many NDJSON events are returned when replaying
 	// a completed agent's log file. 0 means use DefaultMaxLogEvents (500).
 	MaxLogEvents int `yaml:"max_log_events" json:"maxLogEvents"`
+	// LogRetentionDays bounds how long per-agent NDJSON log files live
+	// under ~/.sybra/logs/agents/. Files older than this (plus all 0-byte
+	// files, regardless of age) are swept on app startup and daily
+	// thereafter. 0 falls back to DefaultLogRetentionDays (14).
+	LogRetentionDays int `yaml:"log_retention_days" json:"logRetentionDays"`
 }
 
 // DefaultMaxLogEvents returns the configured cap or 500 if unset.
@@ -77,6 +82,22 @@ func (c *Config) DefaultMaxLogEvents() int {
 		return c.Agent.MaxLogEvents
 	}
 	return 500
+}
+
+// DefaultLogRetentionDays returns the configured retention window for
+// per-agent NDJSON logs, or 14 days if unset. A negative value disables
+// age-based pruning (0-byte files are still removed).
+func (c *Config) DefaultLogRetentionDays() int {
+	if c == nil {
+		return 14
+	}
+	if c.Agent.LogRetentionDays < 0 {
+		return c.Agent.LogRetentionDays
+	}
+	if c.Agent.LogRetentionDays == 0 {
+		return 14
+	}
+	return c.Agent.LogRetentionDays
 }
 
 // DefaultRequirePermissions returns the configured default, or true if unset.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -307,3 +307,24 @@ func TestPathsUnderHomeDir(t *testing.T) {
 		t.Errorf("defaultTasksDir() = %q, want under %q", got, dir)
 	}
 }
+
+func TestDefaultLogRetentionDays(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cfg  *Config
+		want int
+	}{
+		{"nil config → 14", nil, 14},
+		{"unset → 14", &Config{}, 14},
+		{"explicit 7 → 7", &Config{Agent: AgentDefaults{LogRetentionDays: 7}}, 7},
+		{"negative disables (sentinel preserved)", &Config{Agent: AgentDefaults{LogRetentionDays: -1}}, -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.DefaultLogRetentionDays(); got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/logging/agent.go
+++ b/internal/logging/agent.go
@@ -1,8 +1,10 @@
 package logging
 
 import (
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -15,4 +17,86 @@ func NewAgentOutputFile(logDir, agentID string) (*os.File, error) {
 	ts := time.Now().UTC().Format("2006-01-02T15-04-05")
 	name := agentID + "-" + ts + ".ndjson"
 	return os.OpenFile(filepath.Join(dir, name), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+}
+
+// AgentLogPruneReport summarizes one PruneAgentLogs run for callers that
+// want to surface metrics. Kept intentionally small; totals are enough for
+// the slog line and tests, and the struct is exposed so tests can assert
+// the classification without parsing log output.
+type AgentLogPruneReport struct {
+	Scanned      int
+	DeletedOld   int
+	DeletedEmpty int
+	Kept         int
+	Errors       []error
+}
+
+// PruneAgentLogs removes per-agent NDJSON files under <logDir>/agents/
+// older than maxAge, plus all 0-byte files regardless of age. The 0-byte
+// bucket sweeps up runs that failed before the headless streamer ever
+// got to write a line (on the synapse server, 463 ndjson files had
+// accumulated and ~2/3 were empty). now is injected for tests; pass
+// time.Now() in production.
+//
+// Returns a report even on partial failure — per-file errors are
+// collected so one bad unlink doesn't abort the whole sweep. A nil or
+// empty logDir is a no-op (test fixtures often pass "").
+func PruneAgentLogs(logDir string, maxAge time.Duration, now time.Time) AgentLogPruneReport {
+	var r AgentLogPruneReport
+	if logDir == "" {
+		return r
+	}
+	dir := filepath.Join(logDir, "agents")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			r.Errors = append(r.Errors, err)
+		}
+		return r
+	}
+	cutoff := now.Add(-maxAge)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".ndjson") {
+			continue
+		}
+		r.Scanned++
+		info, err := e.Info()
+		if err != nil {
+			r.Errors = append(r.Errors, err)
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		switch {
+		case info.Size() == 0:
+			if err := os.Remove(path); err != nil {
+				r.Errors = append(r.Errors, err)
+				continue
+			}
+			r.DeletedEmpty++
+		case maxAge > 0 && info.ModTime().Before(cutoff):
+			if err := os.Remove(path); err != nil {
+				r.Errors = append(r.Errors, err)
+				continue
+			}
+			r.DeletedOld++
+		default:
+			r.Kept++
+		}
+	}
+	return r
+}
+
+// LogPruneReport bundles PruneAgentLogs output into a structured slog line
+// without forcing callers to format it themselves. Separate from the core
+// prune routine so tests can exercise the math without a logger.
+func LogPruneReport(logger *slog.Logger, r AgentLogPruneReport) {
+	if logger == nil {
+		return
+	}
+	logger.Info("logs.agents.prune",
+		"scanned", r.Scanned,
+		"deleted_old", r.DeletedOld,
+		"deleted_empty", r.DeletedEmpty,
+		"kept", r.Kept,
+		"errors", len(r.Errors))
 }

--- a/internal/logging/agent_test.go
+++ b/internal/logging/agent_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewAgentOutputFile(t *testing.T) {
@@ -45,5 +46,112 @@ func TestNewAgentOutputFile_CreatesDir(t *testing.T) {
 	agentsDir := filepath.Join(dir, "agents")
 	if _, err := os.Stat(agentsDir); err != nil {
 		t.Errorf("agents/ dir not created: %v", err)
+	}
+}
+
+func TestPruneAgentLogs(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)
+
+	// Table-driven covers the three outcomes PruneAgentLogs can produce for
+	// a single file: delete because empty, delete because old, keep.
+	// Each case writes one file, runs the sweep, and asserts the report.
+	cases := []struct {
+		name      string
+		size      int
+		ageDays   int
+		maxAge    time.Duration
+		wantOld   int
+		wantEmpty int
+		wantKept  int
+	}{
+		{"empty file always deleted", 0, 0, 14 * 24 * time.Hour, 0, 1, 0},
+		{"empty file deleted when retention disabled", 0, 0, 0, 0, 1, 0},
+		{"old non-empty file deleted", 100, 30, 14 * 24 * time.Hour, 1, 0, 0},
+		{"fresh non-empty file kept", 100, 1, 14 * 24 * time.Hour, 0, 0, 1},
+		{"old file kept when retention disabled", 100, 30, 0, 0, 0, 1},
+		{"exactly-at-cutoff file kept", 100, 14, 14 * 24 * time.Hour, 0, 0, 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			agents := filepath.Join(dir, "agents")
+			if err := os.MkdirAll(agents, 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			path := filepath.Join(agents, "f-"+time.Now().Format("150405.000000000")+".ndjson")
+			if err := os.WriteFile(path, make([]byte, tc.size), 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			mtime := now.Add(-time.Duration(tc.ageDays) * 24 * time.Hour)
+			if err := os.Chtimes(path, mtime, mtime); err != nil {
+				t.Fatalf("chtimes: %v", err)
+			}
+
+			r := PruneAgentLogs(dir, tc.maxAge, now)
+			if r.DeletedOld != tc.wantOld {
+				t.Errorf("DeletedOld=%d want %d", r.DeletedOld, tc.wantOld)
+			}
+			if r.DeletedEmpty != tc.wantEmpty {
+				t.Errorf("DeletedEmpty=%d want %d", r.DeletedEmpty, tc.wantEmpty)
+			}
+			if r.Kept != tc.wantKept {
+				t.Errorf("Kept=%d want %d", r.Kept, tc.wantKept)
+			}
+			if len(r.Errors) != 0 {
+				t.Errorf("unexpected errors: %v", r.Errors)
+			}
+
+			// The filesystem is the source of truth — verify the kept/deleted
+			// outcome matches what the report claimed, catching any report/
+			// effect divergence the unit-level comparison would miss.
+			_, statErr := os.Stat(path)
+			if tc.wantKept == 1 && statErr != nil {
+				t.Errorf("kept file removed: %v", statErr)
+			}
+			if (tc.wantOld+tc.wantEmpty) == 1 && !os.IsNotExist(statErr) {
+				t.Errorf("deleted file still present, stat err=%v", statErr)
+			}
+		})
+	}
+}
+
+func TestPruneAgentLogs_SkipsNonNDJSON(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	agents := filepath.Join(dir, "agents")
+	if err := os.MkdirAll(agents, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// A debris file that predates this change — sweep must ignore it
+	// even though it is empty and old.
+	decoy := filepath.Join(agents, "notes.txt")
+	if err := os.WriteFile(decoy, nil, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	r := PruneAgentLogs(dir, 24*time.Hour, time.Now())
+	if r.Scanned != 0 {
+		t.Errorf("non-ndjson file should not be scanned, got %d", r.Scanned)
+	}
+	if _, err := os.Stat(decoy); err != nil {
+		t.Errorf("decoy file was removed: %v", err)
+	}
+}
+
+func TestPruneAgentLogs_MissingDirIsNoop(t *testing.T) {
+	t.Parallel()
+	r := PruneAgentLogs(filepath.Join(t.TempDir(), "nope"), 24*time.Hour, time.Now())
+	if r.Scanned != 0 || len(r.Errors) != 0 {
+		t.Errorf("expected empty report for missing dir, got %+v", r)
+	}
+}
+
+func TestPruneAgentLogs_EmptyLogDirIsNoop(t *testing.T) {
+	t.Parallel()
+	r := PruneAgentLogs("", 24*time.Hour, time.Now())
+	if r.Scanned != 0 || len(r.Errors) != 0 {
+		t.Errorf("expected empty report for empty logDir, got %+v", r)
 	}
 }

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -314,7 +314,28 @@ func (a *App) startBackgroundServices(
 
 	a.startPollHub(ctx, issuesFetcher)
 	a.startTodoistLoop(ctx)
+	a.startAgentLogPruneLoop(ctx)
 	a.registerMetricsObservers()
+}
+
+// startAgentLogPruneLoop sweeps stale per-agent NDJSON files once a day.
+// Retention comes from Config.Agent.LogRetentionDays (default 14). The
+// startup call in runStartupCleanup catches the first pass; this goroutine
+// keeps the directory bounded on long-lived server deployments where a
+// single restart would otherwise be the only cleanup trigger.
+func (a *App) startAgentLogPruneLoop(ctx context.Context) {
+	a.wg.Go(func() {
+		ticker := time.NewTicker(24 * time.Hour)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				a.pruneAgentLogs()
+			}
+		}
+	})
 }
 
 // registerMetricsObservers wires the OTel observable gauge callbacks to
@@ -902,7 +923,21 @@ func (a *App) runStartupCleanup() {
 	a.gcOrphanChats()
 	a.worktrees.CleanupOrphaned()
 	a.cleanStaleRuns()
+	a.pruneAgentLogs()
 	a.restartStaleInProgress()
+}
+
+// pruneAgentLogs removes stale per-agent NDJSON files at startup. Safe
+// to call with an empty logDir (test setups) — the logging helper no-ops.
+// The periodic counterpart lives in startAgentLogPruneLoop.
+func (a *App) pruneAgentLogs() {
+	days := a.cfg.DefaultLogRetentionDays()
+	var maxAge time.Duration
+	if days > 0 {
+		maxAge = time.Duration(days) * 24 * time.Hour
+	}
+	r := logging.PruneAgentLogs(a.logDir, maxAge, time.Now())
+	logging.LogPruneReport(a.logger, r)
 }
 
 // gcOrphanChats deletes any chat-task that no longer has a running agent.

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -527,6 +527,30 @@ func (m *Manager) runSetup(taskID, wtPath string, commands []string) error {
 		taskID, wtPath, time.Now().UTC().Format(time.RFC3339), m.setupTimeout, len(commands),
 	))
 
+	// mise refuses to read an untrusted config, so a fresh worktree whose
+	// mise.toml has never been seen on this machine hard-fails `mise install`
+	// with "Config files ... are not trusted". Trust is persisted per-path in
+	// mise's state dir, so one call per worktree is enough and it is cheap
+	// when the file is already trusted. Skipped when the worktree has no
+	// mise config; failure is logged but non-fatal (the real setup command
+	// will raise a clearer error if mise is actually needed).
+	if hasMiseConfig(wtPath) {
+		trustCmd := exec.CommandContext(ctx, "mise", "trust", "--yes")
+		trustCmd.Dir = wtPath
+		if logFile != nil {
+			trustCmd.Stdout = logFile
+			trustCmd.Stderr = logFile
+		}
+		writeLog(fmt.Sprintf("\n--- [pre] %s\n$ mise trust --yes\n", time.Now().UTC().Format(time.RFC3339)))
+		if trustErr := trustCmd.Run(); trustErr != nil {
+			writeLog(fmt.Sprintf("\n!!! mise trust exit err=%v (non-fatal)\n", trustErr))
+			m.logger.Warn("worktree.mise-trust",
+				"task_id", taskID, "path", wtPath, "err", trustErr)
+		} else {
+			writeLog("\n<<< ok\n")
+		}
+	}
+
 	for i, raw := range commands {
 		if err := ctx.Err(); err != nil {
 			writeLog(fmt.Sprintf("\n!!! timeout before command %d (%s): %v\n", i+1, raw, err))
@@ -590,6 +614,19 @@ func (m *Manager) openSetupLog(path string) (*os.File, error) {
 	}
 	// Truncate: each worktree prep starts fresh, old log contents are stale.
 	return os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+}
+
+// hasMiseConfig reports whether the worktree root contains a mise config.
+// mise reads any of these names; the list mirrors mise's own discovery so
+// we only spend a trust call when mise will actually care.
+func hasMiseConfig(wtPath string) bool {
+	names := []string{"mise.toml", ".mise.toml", "mise.local.toml", ".mise.local.toml"}
+	for _, n := range names {
+		if _, err := os.Stat(filepath.Join(wtPath, n)); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveSetupCommands loads the worktree's .sybra.yaml (if present) and

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -1,6 +1,7 @@
 package worktree
 
 import (
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -452,6 +453,134 @@ func TestRunSetup_NoLogsDir(t *testing.T) {
 
 	if err := m.runSetup("task-nologs", wtDir, []string{"exit 1"}); err == nil {
 		t.Fatal("expected failure to propagate even without log dir")
+	}
+}
+
+// --- mise trust preflight -----------------------------------------------
+//
+// installFakeMise drops a tiny shim on PATH that logs invocation args to a
+// file the test can assert against, then returns the expected exit code.
+// Scoped to the test via t.Cleanup(os.Setenv) so it does not leak into
+// other tests.
+func installFakeMise(t *testing.T, exitCode int) (logPath string) {
+	t.Helper()
+	binDir := t.TempDir()
+	logPath = filepath.Join(binDir, "invocations.log")
+	script := "#!/bin/sh\necho \"$@\" >> " + logPath + "\nexit " + fmt.Sprintf("%d", exitCode) + "\n"
+	shim := filepath.Join(binDir, "mise")
+	if err := os.WriteFile(shim, []byte(script), 0o755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+	prev := os.Getenv("PATH")
+	if err := os.Setenv("PATH", binDir+string(os.PathListSeparator)+prev); err != nil {
+		t.Fatalf("setenv PATH: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Setenv("PATH", prev) })
+	return logPath
+}
+
+// TestRunSetup_TrustsMiseConfig guards the fix for the 2026-04-16 server
+// wave of "mise ERROR Config files ... are not trusted" failures. When a
+// mise.toml is present in the worktree, runSetup must call `mise trust
+// --yes` before any user setup command so first-run setup does not
+// fail.
+func TestRunSetup_TrustsMiseConfig(t *testing.T) {
+	t.Parallel()
+	logsDir := t.TempDir()
+	wtDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(wtDir, "mise.toml"), []byte("[tools]\n"), 0o644); err != nil {
+		t.Fatalf("seed mise.toml: %v", err)
+	}
+	miseLog := installFakeMise(t, 0)
+
+	m := New(Config{WorktreesDir: wtDir, LogsDir: logsDir, Logger: discardLogger()})
+	if err := m.runSetup("task-trust", wtDir, []string{"true"}); err != nil {
+		t.Fatalf("runSetup: %v", err)
+	}
+
+	data, err := os.ReadFile(miseLog)
+	if err != nil {
+		t.Fatalf("mise shim was never invoked: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "trust --yes" {
+		t.Errorf("mise invoked with %q, want %q", got, "trust --yes")
+	}
+
+	setupLog, err := os.ReadFile(filepath.Join(logsDir, "worktrees", "task-trust-setup.log"))
+	if err != nil {
+		t.Fatalf("read setup log: %v", err)
+	}
+	if !strings.Contains(string(setupLog), "mise trust --yes") {
+		t.Errorf("setup log missing trust entry:\n%s", setupLog)
+	}
+}
+
+// TestRunSetup_SkipsTrustWithoutMiseConfig prevents regressions that would
+// spend a subprocess call on every worktree regardless of whether mise is
+// actually in play.
+func TestRunSetup_SkipsTrustWithoutMiseConfig(t *testing.T) {
+	t.Parallel()
+	logsDir := t.TempDir()
+	wtDir := t.TempDir()
+	miseLog := installFakeMise(t, 0)
+
+	m := New(Config{WorktreesDir: wtDir, LogsDir: logsDir, Logger: discardLogger()})
+	if err := m.runSetup("task-no-mise", wtDir, []string{"true"}); err != nil {
+		t.Fatalf("runSetup: %v", err)
+	}
+
+	if _, err := os.Stat(miseLog); !os.IsNotExist(err) {
+		t.Errorf("mise shim was invoked despite absent mise.toml (stat err=%v)", err)
+	}
+}
+
+// TestRunSetup_TrustFailureIsNonFatal: if `mise trust` exits non-zero
+// (e.g. mise is installed but the config has a parse error that trust
+// itself cannot accept), the setup commands still run. The clearer error
+// surfaces from the real command that needs mise, not from the preflight.
+func TestRunSetup_TrustFailureIsNonFatal(t *testing.T) {
+	t.Parallel()
+	logsDir := t.TempDir()
+	wtDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(wtDir, ".mise.toml"), []byte(""), 0o644); err != nil {
+		t.Fatalf("seed .mise.toml: %v", err)
+	}
+	installFakeMise(t, 3)
+
+	m := New(Config{WorktreesDir: wtDir, LogsDir: logsDir, Logger: discardLogger()})
+	marker := filepath.Join(wtDir, "did-run")
+	if err := m.runSetup("task-trust-fail", wtDir, []string{"touch " + marker}); err != nil {
+		t.Fatalf("runSetup should succeed despite trust failure: %v", err)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Errorf("marker missing — setup command did not execute: %v", err)
+	}
+}
+
+func TestHasMiseConfig(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		file string
+		want bool
+	}{
+		{"mise.toml", "mise.toml", true},
+		{"dotfile variant", ".mise.toml", true},
+		{"local variant", "mise.local.toml", true},
+		{"dotfile local", ".mise.local.toml", true},
+		{"unrelated toml is not a mise config", "foo.toml", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, tc.file)
+			if err := os.WriteFile(path, nil, 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if got := hasMiseConfig(dir); got != tc.want {
+				t.Errorf("hasMiseConfig(%s)=%v want %v", tc.file, got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Motivation

Log review of synapse server (running `sybra:0.28.0`) on 2026-04-16
surfaced six recurring failure modes: broken pre-push hooks (already
fixed in `bdb9035`), untrusted mise config, codex bwrap sandbox
crashes, truncated NDJSON on agent shutdown, unbounded agent log
accumulation (463 ndjson files, ~2/3 empty), and `max concurrent
agents reached (3)` errors.

This PR closes every remaining issue that belongs in app code; the
codex bwrap env gate and server-side config tuning (`max_concurrent`,
`max_turns`, `log_retention_days`) ship via the home-nas ansible repo
in a companion change.

## Implementation information

**mise trust preflight** — new worktrees fail `mise install` with
`Config files ... are not trusted` on first use because mise tracks
trust per-path and the worktrees directory has never been seen
before. `runSetup` now runs `mise trust --yes` in the worktree root
before any user command when a mise config is present. Non-fatal on
failure so a malformed mise.toml still surfaces the real error from
the command that needs it.

**Graceful subprocess shutdown** — `exec.CommandContext` defaults to
SIGKILL-on-cancel with zero grace, producing the `signal: killed`
pattern and truncated result NDJSON seen 28 times around the
container restart at 18:30 UTC. New `configureGracefulShutdown(cmd)`
helper sets `cmd.Cancel` to send SIGTERM and `cmd.WaitDelay = 15s`,
applied in headless and both interactive runners.

**Manager.ShutdownWithGrace(d)** — blocks up to `d` on each running
agent's done channel after cancel, so the server doesn't exit
mid-stream. Extended the sybra-server HTTP+app shutdown window from
10s → 30s to cover this (the `server.shutdown.err context deadline
exceeded` was HTTP+agent drains both racing inside the same 10s).

**Agent log retention** — `PruneAgentLogs(logDir, maxAge, now)`
sweeps `<logDir>/agents/*.ndjson` older than `maxAge` plus all
0-byte files (crashed-before-first-line runs). New
`agent.log_retention_days` config field (default 14, negative
disables age-based pruning). Runs at startup and on a 24h ticker.

## Testing

```
go test ./...        # all pkgs green
golangci-lint run    # 0 issues
```

New test coverage:

- `logging/agent_test.go`: six-case table for prune classification +
  non-ndjson skip + missing-dir + empty-logDir no-ops.
- `agent/shutdown_test.go`: nil-safe, field-set, and a real
  subprocess asserting `SIGTERM` via `WaitStatus.Signal()`.
- `agent/manager_test.go`: `ShutdownWithGrace` waits for done
  channels, respects the deadline, no-ops without agents.
- `worktree/manager_test.go`: `mise trust --yes` invoked with config,
  skipped without, non-fatal on trust-command failure; `hasMiseConfig`
  table for all four recognized filenames.
- `config/config_test.go`: `DefaultLogRetentionDays` nil/zero/explicit/
  negative-sentinel.

## Supporting documentation

- Server log audit transcript (this session) mapping each log
  pattern to its fix.
- Companion home-nas changes (not in this PR):
  - `ansible/docker-compose/sybra-stack.yml`: add
    `SYBRA_DISABLE_CODEX_SANDBOX: "1"` to pair with the existing
    `codexSandboxArgs` gate (PR #533) and stop `bwrap: No permissions
    to create a new namespace` on the LXC kernel.
  - `ansible/playbooks/deploy-sybra.yml`: ansible-managed block
    setting `agent.max_concurrent: 10`, `max_turns: 100`,
    `log_retention_days: 7` in the server's `config.yaml`.

> Changelog: fix(server): mise trust, shutdown, log prune