### PR TITLE
feat(task): show agent prompt in task view

### DIFF
--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -1025,6 +1025,12 @@
               </button>
             {/if}
           </div>
+          {#if runningAgent.prompt}
+            <details class="rounded-lg border border-surface-300 bg-surface-50 dark:border-surface-600 dark:bg-surface-800">
+              <summary class="cursor-pointer select-none px-3 py-2 text-xs font-medium text-surface-600 dark:text-surface-300">Prompt</summary>
+              <pre class="max-h-64 overflow-y-auto whitespace-pre-wrap border-t border-surface-300 px-3 py-2 text-xs text-surface-700 dark:border-surface-600 dark:text-surface-300">{runningAgent.prompt}</pre>
+            </details>
+          {/if}
           {#if runningAgent.mode === 'interactive'}
             <ChatView agentId={runningAgent.id} agentState={runningAgent.state} costUsd={runningAgent.costUsd} inputTokens={runningAgent.inputTokens ?? 0} outputTokens={runningAgent.outputTokens ?? 0} bounded={true} />
           {:else}
@@ -1099,6 +1105,12 @@
               </button>
               {#if expandedRun === run.agentId}
                 <div class="border-t border-surface-300 px-3 py-2 dark:border-surface-600">
+                  {#if run.prompt}
+                    <details class="mb-3 rounded-lg border border-surface-300 bg-surface-100 dark:border-surface-600 dark:bg-surface-900">
+                      <summary class="cursor-pointer select-none px-3 py-2 text-xs font-medium text-surface-600 dark:text-surface-300">Prompt</summary>
+                      <pre class="max-h-64 overflow-y-auto whitespace-pre-wrap border-t border-surface-300 px-3 py-2 text-xs text-surface-700 dark:border-surface-600 dark:text-surface-300">{run.prompt}</pre>
+                    </details>
+                  {/if}
                   {#if runLogLoading.has(run.agentId)}
                     <p class="py-4 text-center text-xs text-surface-500">Loading log...</p>
                   {:else if run.mode === 'interactive' && (runLogConvoEvents.get(run.agentId)?.length ?? 0) > 0}

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -21,16 +21,17 @@ export namespace agent {
 	    project?: string;
 	    provider?: string;
 	    model?: string;
+	    prompt?: string;
 	    turnCount?: number;
 	    escalationReason?: string;
 	    errorKind?: string;
 	    errorMsg?: string;
 	    awaitingApproval?: boolean;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new Agent(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
@@ -51,6 +52,7 @@ export namespace agent {
 	        this.project = source["project"];
 	        this.provider = source["provider"];
 	        this.model = source["model"];
+	        this.prompt = source["prompt"];
 	        this.turnCount = source["turnCount"];
 	        this.escalationReason = source["escalationReason"];
 	        this.errorKind = source["errorKind"];
@@ -1363,14 +1365,15 @@ export namespace task {
 	    // Go type: time
 	    startedAt: any;
 	    costUsd: number;
+	    prompt?: string;
 	    result: string;
 	    logFile: string;
 	    sessionId?: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new AgentRun(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.agentId = source["agentId"];
@@ -1380,6 +1383,7 @@ export namespace task {
 	        this.state = source["state"];
 	        this.startedAt = this.convertValues(source["startedAt"], null);
 	        this.costUsd = source["costUsd"];
+	        this.prompt = source["prompt"];
 	        this.result = source["result"];
 	        this.logFile = source["logFile"];
 	        this.sessionId = source["sessionId"];

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -27,11 +27,11 @@ export namespace agent {
 	    errorKind?: string;
 	    errorMsg?: string;
 	    awaitingApproval?: boolean;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new Agent(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.id = source["id"];
@@ -1369,11 +1369,11 @@ export namespace task {
 	    result: string;
 	    logFile: string;
 	    sessionId?: string;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new AgentRun(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.agentId = source["agentId"];

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -186,6 +186,7 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 		Mode:        cfg.Mode,
 		Provider:    resolvedProvider,
 		Model:       normalizeModel(resolvedProvider, cfg.Model),
+		Prompt:      cfg.Prompt,
 		State:       StateRunning,
 		StartedAt:   now,
 		LastEventAt: now,

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -48,6 +48,7 @@ type Agent struct {
 	Project      string    `json:"project,omitempty"`
 	Provider     string    `json:"provider,omitempty"`
 	Model        string    `json:"model,omitempty"`
+	Prompt       string    `json:"prompt,omitempty"`
 
 	TurnCount        int    `json:"turnCount,omitempty"`
 	EscalationReason string `json:"escalationReason,omitempty"`

--- a/internal/sybra/app_agents.go
+++ b/internal/sybra/app_agents.go
@@ -207,6 +207,7 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, oneShot bool
 		Provider:  ag.Provider,
 		State:     string(agent.StateRunning),
 		StartedAt: ag.StartedAt,
+		Prompt:    fullPrompt,
 	}, nextStatus); err != nil {
 		o.logger.Error("task.add-run", "task_id", taskID, "err", err)
 	}
@@ -275,6 +276,7 @@ func (o *AgentOrchestrator) StartChat(projectID, providerName, prompt string) (*
 		Provider:  ag.Provider,
 		State:     string(agent.StateRunning),
 		StartedAt: ag.StartedAt,
+		Prompt:    prompt,
 	}); err != nil {
 		o.logger.Error("chat.add-run", "task_id", t.ID, "err", err)
 	}
@@ -352,6 +354,7 @@ func (o *AgentOrchestrator) StartPRFixAgent(taskID string) error {
 	if err := o.tasks.AddRun(taskID, task.AgentRun{
 		AgentID: ag.ID, Role: string(agent.RolePRFix), Mode: effMode,
 		State: string(agent.StateRunning), StartedAt: ag.StartedAt,
+		Prompt: prompt,
 	}); err != nil {
 		o.logger.Error("task.add-run", "task_id", taskID, "err", err)
 	}

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -150,6 +150,7 @@ func (r *ReviewHandler) startFixReviewAgent(t task.Task) error {
 	}
 	if err := r.tasks.AddRun(t.ID, task.AgentRun{
 		AgentID: ag.ID, Role: string(agent.RoleFixReview), Mode: "headless", State: string(agent.StateRunning), StartedAt: ag.StartedAt,
+		Prompt: prompt,
 	}); err != nil {
 		r.logger.Error("task.add-run", "task_id", t.ID, "err", err)
 	}
@@ -184,6 +185,7 @@ func (r *ReviewHandler) startReviewAgent(t task.Task) error {
 	}
 	if err := r.tasks.AddRun(t.ID, task.AgentRun{
 		AgentID: ag.ID, Role: string(agent.RoleReview), Mode: "headless", State: string(agent.StateRunning), StartedAt: ag.StartedAt,
+		Prompt: prompt,
 	}); err != nil {
 		r.logger.Error("task.add-run", "task_id", t.ID, "err", err)
 	}

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -221,6 +221,7 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		Provider:  ag.Provider,
 		State:     string(agent.StateRunning),
 		StartedAt: ag.StartedAt,
+		Prompt:    cfg.Prompt,
 	}); addErr != nil {
 		slog.Error("agent-adapter.add-run", "task_id", taskID, "agent_id", ag.ID, "err", addErr)
 	}

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -311,6 +311,45 @@ func TestE2E_HeadlessAgent_Success(t *testing.T) {
 	}
 }
 
+// TestE2E_AgentRunPromptPersisted verifies that the prompt passed to an agent
+// is captured on the persisted AgentRun and survives a parse round-trip.
+// The triage step of test-simple.yaml uses prompt "Triage {{.Task.ID}}", so
+// after the agent runs the task file's AgentRuns[0].Prompt must contain the
+// rendered value — this is what powers the "prompt at top of task view"
+// UI in TaskDetail.svelte.
+func TestE2E_AgentRunPromptPersisted(t *testing.T) {
+	env := setupE2E(t, "success")
+
+	created, err := env.tasks.Create("prompt persistence", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := env.startWorkflow(created.ID, "test-simple"); err != nil {
+		t.Fatal(err)
+	}
+
+	waitFor(t, 10*time.Second, "triage agent run recorded with prompt", func() bool {
+		tk, err := env.tasks.Get(created.ID)
+		if err != nil || len(tk.AgentRuns) == 0 {
+			return false
+		}
+		return tk.AgentRuns[0].Prompt != ""
+	})
+
+	tk, err := env.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "Triage " + created.ID
+	if got := tk.AgentRuns[0].Prompt; got != want {
+		t.Fatalf("AgentRuns[0].Prompt = %q, want %q", got, want)
+	}
+	if tk.AgentRuns[0].Role != "triage" {
+		t.Errorf("AgentRuns[0].Role = %q, want %q", tk.AgentRuns[0].Role, "triage")
+	}
+}
+
 func TestE2E_HeadlessAgent_ArgsVerification(t *testing.T) {
 	forEachProvider(t, func(t *testing.T, p providerSpec) {
 		argsLog := filepath.Join(t.TempDir(), p.name+"-args.log")

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -264,6 +264,7 @@ func (s *TaskService) startPRReviewAgent(t task.Task) error {
 		Mode:      "headless",
 		State:     string(agent.StateRunning),
 		StartedAt: ag.StartedAt,
+		Prompt:    prompt,
 	}); err != nil {
 		s.logger.Error("task.add-run", "task_id", t.ID, "err", err)
 	}

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -136,6 +136,7 @@ type AgentRun struct {
 	State     string    `yaml:"state" json:"state"`
 	StartedAt time.Time `yaml:"started_at" json:"startedAt"`
 	CostUSD   float64   `yaml:"cost_usd,omitempty" json:"costUsd"`
+	Prompt    string    `yaml:"prompt,omitempty" json:"prompt,omitempty"`
 	Result    string    `yaml:"result,omitempty" json:"result"`
 	LogFile   string    `yaml:"log_file,omitempty" json:"logFile"`
 	SessionID string    `yaml:"session_id,omitempty" json:"sessionId,omitempty"`

--- a/internal/task/parser.go
+++ b/internal/task/parser.go
@@ -66,13 +66,14 @@ func ParseBytes(data []byte) (Task, error) {
 func Marshal(t Task) ([]byte, error) {
 	t.UpdatedAt = time.Now().UTC()
 
-	// Strip leading whitespace/newlines from agent run results so yaml.v3
-	// doesn't emit |N- block scalars that it fails to parse back (known
-	// round-trip bug: leading blank lines or indented first line force an
-	// explicit indentation indicator that miscounts columns inside a
-	// nested sequence).
+	// Strip leading whitespace/newlines from agent run results and prompts
+	// so yaml.v3 doesn't emit |N- block scalars that it fails to parse back
+	// (known round-trip bug: leading blank lines or indented first line
+	// force an explicit indentation indicator that miscounts columns inside
+	// a nested sequence).
 	for i := range t.AgentRuns {
 		t.AgentRuns[i].Result = strings.TrimLeft(t.AgentRuns[i].Result, " \t\n\r")
+		t.AgentRuns[i].Prompt = strings.TrimLeft(t.AgentRuns[i].Prompt, " \t\n\r")
 	}
 
 	fm, err := yaml.Marshal(t)

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -440,6 +440,7 @@ func TestStoreAddRun(t *testing.T) {
 		Mode:      "headless",
 		State:     "running",
 		StartedAt: time.Now().UTC(),
+		Prompt:    "# Task: Foo\n\nDo the thing\n\n---\n\nuser prompt",
 	}
 
 	if err := store.AddRun(created.ID, run); err != nil {
@@ -458,6 +459,9 @@ func TestStoreAddRun(t *testing.T) {
 	}
 	if got.AgentRuns[0].State != "running" {
 		t.Errorf("State = %q, want %q", got.AgentRuns[0].State, "running")
+	}
+	if got.AgentRuns[0].Prompt != run.Prompt {
+		t.Errorf("Prompt = %q, want %q", got.AgentRuns[0].Prompt, run.Prompt)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Task view showed what an agent did (stream / chat output) but never what
it was asked. The prompt handed to the provider was ephemeral — passed
into `RunConfig.Prompt` and thrown away. No way to audit why a run did
what it did, compare past attempts, or see the full context (task title
+ body + user prompt) that was sent.

## Implementation information

- `AgentRun.Prompt` persisted to YAML frontmatter (omitempty → legacy
  runs render unchanged).
- `Agent.Prompt` exposed on the live struct so the running-agent panel
  reads it without a refetch.
- 7 `AddRun` / `AddRunWithStatus` call sites populate it (`app_agents`
  StartAgent / StartChat / StartPRFixAgent, `app_workflow`, `app_reviews`
  ×2, `svc_tasks`).
- `TaskDetail.svelte` renders a collapsed `<details>` "Prompt" block
  above the running agent and at the top of each expanded past run.
  Closed by default — composite prompt (`# Task: … / body / --- /
  user prompt`) is often long.
- `parser.go` trims leading whitespace on `Prompt` the same way as
  `Result` — workflow-generated replan prompts start with a space,
  which forces yaml.v3 to emit `|4-` block scalars it can't parse
  back inside a nested sequence.

## Supporting documentation

- Plan: ~/.claude/plans/when-we-look-at-peaceful-quasar.md
- New e2e test `TestE2E_AgentRunPromptPersisted` drives a real
  workflow and asserts `AgentRuns[0].Prompt == "Triage <id>"`
  survives to the task file.