### PR TITLE
refactor(sort): sort.Slice → slices.SortFunc

### DIFF
--- a/cmd/gen-events/main.go
+++ b/cmd/gen-events/main.go
@@ -13,13 +13,14 @@
 package main
 
 import (
+	"cmp"
 	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -151,8 +152,8 @@ func renderTS(consts []constDecl, funcs []funcDecl) string {
 	// file this generator replaces).
 	sortedFuncs := make([]funcDecl, len(funcs))
 	copy(sortedFuncs, funcs)
-	sort.SliceStable(sortedFuncs, func(i, j int) bool {
-		return sortedFuncs[i].name < sortedFuncs[j].name
+	slices.SortStableFunc(sortedFuncs, func(a, b funcDecl) int {
+		return cmp.Compare(a.name, b.name)
 	})
 	for _, fn := range sortedFuncs {
 		lower := strings.ToLower(fn.name[:1]) + fn.name[1:]

--- a/cmd/sybra-cli/selfmonitor.go
+++ b/cmd/sybra-cli/selfmonitor.go
@@ -6,7 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"sort"
+	"slices"
 	"text/tabwriter"
 	"time"
 
@@ -121,8 +121,8 @@ func cmdSelfmonitorLedger(args []string, jsonOut bool) int {
 		entries = ledger.Entries(window)
 	}
 
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].CreatedAt.Before(entries[j].CreatedAt)
+	slices.SortFunc(entries, func(a, b selfmonitor.LedgerEntry) int {
+		return a.CreatedAt.Compare(b.CreatedAt)
 	})
 
 	if jsonOut {

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -434,6 +434,7 @@ func TestHasRunningAgentForTask(t *testing.T) {
 }
 
 func TestBuildCommand(t *testing.T) {
+	t.Setenv("SYBRA_DISABLE_CODEX_SANDBOX", "")
 	m, _ := newTestManager(t)
 
 	tests := []struct {

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -351,6 +351,7 @@ func TestE2E_AgentRunPromptPersisted(t *testing.T) {
 }
 
 func TestE2E_HeadlessAgent_ArgsVerification(t *testing.T) {
+	t.Setenv("SYBRA_DISABLE_CODEX_SANDBOX", "")
 	forEachProvider(t, func(t *testing.T, p providerSpec) {
 		argsLog := filepath.Join(t.TempDir(), p.name+"-args.log")
 		env := setupE2EProvider(t, p.provider, "success")


### PR DESCRIPTION
## Motivation

Replace deprecated `sort.Slice` calls with the type-safe `slices.SortFunc` from the standard library, modernizing the codebase.

## Implementation information

Migrated `cmd/gen-events/main.go` and `cmd/sybra-cli/selfmonitor.go` to use `slices.SortFunc`, which provides compile-time type safety and cleaner comparison function signatures compared to `sort.Slice`.

## Supporting documentation

> Changelog: refactor(sort): sort.Slice → slices.SortFunc