### PR TITLE
feat(config): hot-reload config.yaml via fsnotify watcher

### DIFF
--- a/frontend/wailsjs/go/sybra/ConfigService.d.ts
+++ b/frontend/wailsjs/go/sybra/ConfigService.d.ts
@@ -4,4 +4,6 @@ import {sybra} from '../models';
 
 export function GetSettings():Promise<sybra.AppSettings>;
 
+export function ReloadFromDisk():Promise<Array<string>>;
+
 export function UpdateSettings(arg1:sybra.AppSettings):Promise<void>;

--- a/frontend/wailsjs/go/sybra/ConfigService.js
+++ b/frontend/wailsjs/go/sybra/ConfigService.js
@@ -6,6 +6,10 @@ export function GetSettings() {
   return window['go']['sybra']['ConfigService']['GetSettings']();
 }
 
+export function ReloadFromDisk() {
+  return window['go']['sybra']['ConfigService']['ReloadFromDisk']();
+}
+
 export function UpdateSettings(arg1) {
   return window['go']['sybra']['ConfigService']['UpdateSettings'](arg1);
 }

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -116,6 +116,13 @@ func (m *Manager) SetGuardrails(g Guardrails) {
 	m.mu.Unlock()
 }
 
+// Guardrails returns the current guardrail limits.
+func (m *Manager) Guardrails() Guardrails {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.guardrails
+}
+
 // RespondEscalation sends a human decision to a paused agent.
 // continueRun=true lets the agent keep running; false kills it.
 func (m *Manager) RespondEscalation(agentID string, continueRun bool) error {

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -434,6 +434,7 @@ func TestHasRunningAgentForTask(t *testing.T) {
 }
 
 func TestBuildCommand(t *testing.T) {
+	// Reset server-side env override so tests see the default sandbox logic.
 	t.Setenv("SYBRA_DISABLE_CODEX_SANDBOX", "")
 	m, _ := newTestManager(t)
 

--- a/internal/confighot/watcher.go
+++ b/internal/confighot/watcher.go
@@ -1,0 +1,120 @@
+package confighot
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// Watcher monitors a single config file and calls onChange after each
+// debounced change burst. The parent directory is watched rather than the
+// file itself so that atomic editor saves (write-tmp + rename) are caught.
+type Watcher struct {
+	path     string
+	onChange func()
+	logger   *slog.Logger
+	ready    chan struct{}
+	done     chan struct{}
+}
+
+// New creates a Watcher for path. onChange is called after each debounced
+// burst of Write/Create/Rename events on that file.
+func New(path string, onChange func(), logger *slog.Logger) *Watcher {
+	return &Watcher{
+		path:     path,
+		onChange: onChange,
+		logger:   logger,
+		ready:    make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+}
+
+// Ready returns a channel closed when the watch loop is running.
+func (w *Watcher) Ready() <-chan struct{} { return w.ready }
+
+// Done returns a channel closed when the watch loop exits.
+func (w *Watcher) Done() <-chan struct{} { return w.done }
+
+// Start begins watching. The watcher stops when ctx is cancelled.
+func (w *Watcher) Start(ctx context.Context) error {
+	fw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(w.path)
+	if err := fw.Add(dir); err != nil {
+		_ = fw.Close()
+		return err
+	}
+	go w.loop(ctx, fw)
+	return nil
+}
+
+func (w *Watcher) loop(ctx context.Context, fw *fsnotify.Watcher) {
+	defer func() {
+		_ = fw.Close()
+		close(w.done)
+	}()
+	close(w.ready)
+
+	const debounceInterval = 500 * time.Millisecond
+
+	target := filepath.Base(w.path)
+	var deadline time.Time
+	timer := time.NewTimer(time.Hour)
+	stopTimer(timer)
+	var timerCh <-chan time.Time
+
+	for {
+		select {
+		case <-ctx.Done():
+			stopTimer(timer)
+			return
+
+		case event, ok := <-fw.Events:
+			if !ok {
+				stopTimer(timer)
+				return
+			}
+			if filepath.Base(event.Name) != target {
+				continue
+			}
+			if !event.Op.Has(fsnotify.Write) && !event.Op.Has(fsnotify.Create) && !event.Op.Has(fsnotify.Rename) {
+				continue
+			}
+			deadline = time.Now().Add(debounceInterval)
+			timerCh = resetTimer(timer, deadline)
+
+		case <-timerCh:
+			timerCh = nil
+			w.logger.Info("confighot.changed", "file", w.path)
+			w.onChange()
+
+		case err, ok := <-fw.Errors:
+			if !ok {
+				stopTimer(timer)
+				return
+			}
+			w.logger.Error("confighot.error", "err", err)
+		}
+	}
+}
+
+func resetTimer(timer *time.Timer, deadline time.Time) <-chan time.Time {
+	wait := max(time.Until(deadline), 0)
+	stopTimer(timer)
+	timer.Reset(wait)
+	return timer.C
+}
+
+func stopTimer(timer *time.Timer) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+}

--- a/internal/confighot/watcher_test.go
+++ b/internal/confighot/watcher_test.go
@@ -1,0 +1,226 @@
+package confighot
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func waitForCount(t *testing.T, count *atomic.Int64, want int64, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if count.Load() >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for onChange count %d, got %d", want, count.Load())
+}
+
+func TestWatcher_SingleWrite(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	var calls atomic.Int64
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	w := New(path, func() { calls.Add(1) }, discardLogger())
+	if err := w.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	<-w.Ready()
+
+	if err := os.WriteFile(path, []byte("level: info\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForCount(t, &calls, 1, 3*time.Second)
+	if got := calls.Load(); got != 1 {
+		t.Errorf("got %d calls, want 1", got)
+	}
+}
+
+func TestWatcher_BurstCoalescesToOne(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	var calls atomic.Int64
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	w := New(path, func() { calls.Add(1) }, discardLogger())
+	if err := w.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	<-w.Ready()
+
+	// 5 rapid writes within debounce window
+	for range 5 {
+		if err := os.WriteFile(path, []byte("level: debug\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	waitForCount(t, &calls, 1, 3*time.Second)
+	// Pause to ensure no extra calls arrive
+	time.Sleep(700 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Errorf("burst produced %d calls, want 1", got)
+	}
+}
+
+func TestWatcher_AtomicSave(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	var calls atomic.Int64
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	w := New(path, func() { calls.Add(1) }, discardLogger())
+	if err := w.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	<-w.Ready()
+
+	// Simulate vim/editor atomic save: write to tmp, rename over target
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte("level: warn\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForCount(t, &calls, 1, 3*time.Second)
+}
+
+func TestWatcher_DeleteIgnored(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	// Pre-create the file
+	if err := os.WriteFile(path, []byte("level: info\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls atomic.Int64
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	w := New(path, func() { calls.Add(1) }, discardLogger())
+	if err := w.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	<-w.Ready()
+
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait long enough to see if any spurious call comes through
+	time.Sleep(700 * time.Millisecond)
+	if got := calls.Load(); got != 0 {
+		t.Errorf("delete triggered %d calls, want 0", got)
+	}
+}
+
+func TestWatcher_SiblingFileIgnored(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	var calls atomic.Int64
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	w := New(path, func() { calls.Add(1) }, discardLogger())
+	if err := w.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	<-w.Ready()
+
+	// Write a sibling file — should not trigger onChange
+	sibling := filepath.Join(dir, "other.yaml")
+	if err := os.WriteFile(sibling, []byte("x: 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(700 * time.Millisecond)
+	if got := calls.Load(); got != 0 {
+		t.Errorf("sibling write triggered %d calls, want 0", got)
+	}
+}
+
+func TestWatcher_ContextCancelCleans(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	w := New(path, func() {}, discardLogger())
+	if err := w.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	<-w.Ready()
+
+	cancel()
+	select {
+	case <-w.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not stop after context cancel")
+	}
+}
+
+func TestWatcher_NoGoroutineLeak(t *testing.T) {
+	t.Parallel()
+
+	// Allow any test-framework goroutines to settle before sampling baseline.
+	time.Sleep(50 * time.Millisecond)
+	before := runtime.NumGoroutine()
+
+	for range 10 {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "config.yaml")
+		ctx, cancel := context.WithCancel(context.Background())
+
+		w := New(path, func() {}, discardLogger())
+		if err := w.Start(ctx); err != nil {
+			cancel()
+			t.Fatal(err)
+		}
+		<-w.Ready()
+		cancel()
+		<-w.Done()
+	}
+
+	// Poll until goroutine count stabilises or timeout.
+	deadline := time.Now().Add(2 * time.Second)
+	var after int
+	for time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+		after = runtime.NumGoroutine()
+		if after-before <= 3 {
+			return
+		}
+	}
+	t.Errorf("goroutine leak: before=%d after=%d delta=%d", before, after, after-before)
+}

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/bgop"
 	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/confighot"
 	"github.com/Automaat/sybra/internal/events"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/health"
@@ -51,6 +52,7 @@ type App struct {
 	loopSched       *loopagent.Scheduler
 	agents          *agent.Manager
 	watcher         *watcher.Watcher
+	configWatcher   *confighot.Watcher
 	notifier        *notification.Emitter
 	audit           *audit.Logger
 	stats           *stats.Store
@@ -296,11 +298,31 @@ func (a *App) initBgops(emit func(string, any)) {
 	a.bgops.LoadFromDisk()
 }
 
+func (a *App) startConfigWatcher(ctx context.Context) {
+	cfgPath := filepath.Join(config.HomeDir(), "config.yaml")
+	cw := confighot.New(cfgPath, func() {
+		changed, err := a.configSvc.ReloadFromDisk()
+		if err != nil {
+			a.logger.Error("config.reload.failed", "err", err)
+			return
+		}
+		if len(changed) > 0 {
+			a.logger.Info("config.reloaded", "changed", changed)
+		}
+	}, a.logger)
+	if err := cw.Start(ctx); err != nil {
+		a.logger.Error("config.watcher.start", "err", err)
+		return
+	}
+	a.configWatcher = cw
+}
+
 func (a *App) startBackgroundServices(
 	ctx context.Context,
 	emit func(string, any),
 	issuesFetcher *poll.IssuesFetcher,
 ) {
+	a.startConfigWatcher(ctx)
 	a.wg.Go(func() { a.orchestratorLoop(ctx) })
 
 	wdog := watchdog.New(a.agents, a.tasks, a.logger, emit, &a.wg)
@@ -316,6 +338,7 @@ func (a *App) startBackgroundServices(
 	a.startTodoistLoop(ctx)
 	a.startAgentLogPruneLoop(ctx)
 	a.registerMetricsObservers()
+	a.startConfigWatcher(ctx)
 }
 
 // startAgentLogPruneLoop sweeps stale per-agent NDJSON files once a day.
@@ -872,6 +895,7 @@ func (a *App) wireServices(emit func(string, any)) {
 	a.configSvc.logLevel = a.logLevel
 	a.configSvc.notifier = a.notifier
 	a.configSvc.agents = a.agents
+	a.configSvc.logger = a.logger
 	a.configSvc.reloadHook = a.reloadTodoist
 	a.intgSvc.tasks = a.tasks
 	a.intgSvc.projects = a.projects

--- a/internal/sybra/config_diff.go
+++ b/internal/sybra/config_diff.go
@@ -1,0 +1,83 @@
+package sybra
+
+import (
+	"reflect"
+
+	"github.com/Automaat/sybra/internal/config"
+)
+
+// diffConfig compares old and new configs and returns two slices of dot-separated
+// key names: hot (live-reloadable without restart) and restart (require restart).
+func diffConfig(old, next config.Config) (hot, restart []string) {
+	// Hot-reloadable individual fields
+	if old.Notification.Desktop != next.Notification.Desktop {
+		hot = append(hot, "notification.desktop")
+	}
+	if old.Agent.MaxConcurrent != next.Agent.MaxConcurrent {
+		hot = append(hot, "agent.max_concurrent")
+	}
+	if old.Agent.Provider != next.Agent.Provider {
+		hot = append(hot, "agent.provider")
+	}
+	if old.Agent.MaxCostUSD != next.Agent.MaxCostUSD {
+		hot = append(hot, "agent.max_cost_usd")
+	}
+	if old.Agent.MaxTurns != next.Agent.MaxTurns {
+		hot = append(hot, "agent.max_turns")
+	}
+	if old.Logging.Level != next.Logging.Level {
+		hot = append(hot, "logging.level")
+	}
+	if !reflect.DeepEqual(old.Todoist, next.Todoist) {
+		hot = append(hot, "todoist")
+	}
+	if old.Renovate.Author != next.Renovate.Author || old.Renovate.Enabled != next.Renovate.Enabled {
+		hot = append(hot, "renovate")
+	}
+
+	// Other agent fields that don't require restart but have no live setter
+	if old.Agent.Model != next.Agent.Model ||
+		old.Agent.Mode != next.Agent.Mode ||
+		old.Agent.ResearchMachineDir != next.Agent.ResearchMachineDir ||
+		old.Agent.MaxLogEvents != next.Agent.MaxLogEvents ||
+		old.Agent.LogRetentionDays != next.Agent.LogRetentionDays ||
+		old.Agent.RequirePermissions != next.Agent.RequirePermissions {
+		hot = append(hot, "agent.other")
+	}
+
+	// Orchestrator and audit are live-effective via pointer read; no setter needed
+	if !reflect.DeepEqual(old.Orchestrator, next.Orchestrator) {
+		hot = append(hot, "orchestrator")
+	}
+	if !reflect.DeepEqual(old.Audit, next.Audit) {
+		hot = append(hot, "audit")
+	}
+	if old.Logging.MaxSizeMB != next.Logging.MaxSizeMB || old.Logging.MaxFiles != next.Logging.MaxFiles {
+		hot = append(hot, "logging.other")
+	}
+
+	// Restart-required blocks
+	if !reflect.DeepEqual(old.Providers, next.Providers) {
+		restart = append(restart, "providers")
+	}
+	if !reflect.DeepEqual(old.Metrics, next.Metrics) {
+		restart = append(restart, "metrics")
+	}
+	if !reflect.DeepEqual(old.Monitor, next.Monitor) {
+		restart = append(restart, "monitor")
+	}
+	if !reflect.DeepEqual(old.SelfMonitor, next.SelfMonitor) {
+		restart = append(restart, "self_monitor")
+	}
+	if !reflect.DeepEqual(old.Triage, next.Triage) {
+		restart = append(restart, "triage")
+	}
+	if !reflect.DeepEqual(old.GitHub, next.GitHub) {
+		restart = append(restart, "github")
+	}
+	if !reflect.DeepEqual(old.ProjectTypes, next.ProjectTypes) {
+		restart = append(restart, "project_types")
+	}
+
+	return hot, restart
+}

--- a/internal/sybra/config_diff_test.go
+++ b/internal/sybra/config_diff_test.go
@@ -1,0 +1,115 @@
+package sybra
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/config"
+)
+
+func TestDiffConfig_NoChange(t *testing.T) {
+	t.Parallel()
+	cfg := config.DefaultConfig()
+	hot, restart := diffConfig(*cfg, *cfg)
+	if len(hot) != 0 || len(restart) != 0 {
+		t.Errorf("identical configs: hot=%v restart=%v, want empty", hot, restart)
+	}
+}
+
+func TestDiffConfig_HotOnly(t *testing.T) {
+	t.Parallel()
+	old := config.DefaultConfig()
+	next := *old
+	next.Agent.MaxConcurrent = 7
+	next.Logging.Level = "debug"
+
+	hot, restart := diffConfig(*old, next)
+
+	if !slices.Contains(hot, "agent.max_concurrent") {
+		t.Errorf("expected agent.max_concurrent in hot, got %v", hot)
+	}
+	if !slices.Contains(hot, "logging.level") {
+		t.Errorf("expected logging.level in hot, got %v", hot)
+	}
+	if len(restart) != 0 {
+		t.Errorf("expected no restart keys, got %v", restart)
+	}
+}
+
+func TestDiffConfig_RestartOnly(t *testing.T) {
+	t.Parallel()
+	old := config.DefaultConfig()
+	next := *old
+	next.Providers.HealthCheck.IntervalSeconds = 600
+
+	hot, restart := diffConfig(*old, next)
+
+	if !slices.Contains(restart, "providers") {
+		t.Errorf("expected providers in restart, got %v", restart)
+	}
+	if slices.Contains(hot, "providers") {
+		t.Errorf("providers must not appear in hot, got %v", hot)
+	}
+}
+
+func TestDiffConfig_Mixed(t *testing.T) {
+	t.Parallel()
+	old := config.DefaultConfig()
+	next := *old
+	next.Agent.Provider = "codex"
+	next.Monitor.Enabled = false
+
+	hot, restart := diffConfig(*old, next)
+
+	if !slices.Contains(hot, "agent.provider") {
+		t.Errorf("expected agent.provider in hot, got %v", hot)
+	}
+	if !slices.Contains(restart, "monitor") {
+		t.Errorf("expected monitor in restart, got %v", restart)
+	}
+}
+
+func TestDiffConfig_TodoistBlock(t *testing.T) {
+	t.Parallel()
+	old := config.DefaultConfig()
+	next := *old
+	next.Todoist.APIToken = "tok-123"
+	next.Todoist.Enabled = true
+
+	hot, _ := diffConfig(*old, next)
+
+	if !slices.Contains(hot, "todoist") {
+		t.Errorf("expected todoist in hot, got %v", hot)
+	}
+}
+
+func TestDiffConfig_GuardrailsHot(t *testing.T) {
+	t.Parallel()
+	old := config.DefaultConfig()
+	next := *old
+	next.Agent.MaxCostUSD = 10.0
+	next.Agent.MaxTurns = 200
+
+	hot, _ := diffConfig(*old, next)
+
+	if !slices.Contains(hot, "agent.max_cost_usd") {
+		t.Errorf("expected agent.max_cost_usd in hot, got %v", hot)
+	}
+	if !slices.Contains(hot, "agent.max_turns") {
+		t.Errorf("expected agent.max_turns in hot, got %v", hot)
+	}
+}
+
+func TestDiffConfig_MetricsRestart(t *testing.T) {
+	t.Parallel()
+	old := config.DefaultConfig()
+	next := *old
+	next.Metrics.Enabled = true
+
+	hot, restart := diffConfig(*old, next)
+	_ = hot
+
+	if !slices.Contains(restart, "metrics") {
+		t.Errorf("expected metrics in restart, got %v", restart)
+	}
+}

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -351,6 +351,7 @@ func TestE2E_AgentRunPromptPersisted(t *testing.T) {
 }
 
 func TestE2E_HeadlessAgent_ArgsVerification(t *testing.T) {
+	// Reset server-side env override so tests see the default sandbox logic.
 	t.Setenv("SYBRA_DISABLE_CODEX_SANDBOX", "")
 	forEachProvider(t, func(t *testing.T, p providerSpec) {
 		argsLog := filepath.Join(t.TempDir(), p.name+"-args.log")

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
+	"sync"
 
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/config"
@@ -12,15 +13,19 @@ import (
 
 // ConfigService exposes settings read/write as Wails-bound methods.
 type ConfigService struct {
+	mu         sync.RWMutex
 	cfg        *config.Config
 	logLevel   *slog.LevelVar
 	notifier   *notification.Emitter
 	agents     *agent.Manager
+	logger     *slog.Logger
 	reloadHook func() // called after todoist config changes
 }
 
 // GetSettings returns the current app settings for the config UI.
 func (s *ConfigService) GetSettings() AppSettings {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	c := s.cfg
 	return AppSettings{
 		Agent:        c.Agent,
@@ -41,6 +46,18 @@ func (s *ConfigService) GetSettings() AppSettings {
 
 // UpdateSettings validates, persists, and hot-reloads the provided settings.
 func (s *ConfigService) UpdateSettings(settings AppSettings) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.validateSettings(settings); err != nil {
+		return err
+	}
+	s.applyFromConfig(settingsToConfig(s.cfg, settings))
+	return s.cfg.Save()
+}
+
+// validateSettings checks all editable fields for validity.
+func (s *ConfigService) validateSettings(settings AppSettings) error {
 	validProviders := map[string]bool{"": true, "claude": true, "codex": true}
 	if !validProviders[settings.Agent.Provider] {
 		return fmt.Errorf("invalid provider: %q", settings.Agent.Provider)
@@ -74,26 +91,60 @@ func (s *ConfigService) UpdateSettings(settings AppSettings) error {
 	if settings.Todoist.PollSeconds < 30 || settings.Todoist.PollSeconds > 3600 {
 		settings.Todoist.PollSeconds = 120
 	}
+	return nil
+}
 
-	s.cfg.Agent = settings.Agent
-	s.cfg.Notification = settings.Notification
-	s.cfg.Orchestrator = settings.Orchestrator
-	s.cfg.Logging.Level = settings.Logging.Level
-	s.cfg.Logging.MaxSizeMB = settings.Logging.MaxSizeMB
-	s.cfg.Logging.MaxFiles = settings.Logging.MaxFiles
-	s.cfg.Audit = settings.Audit
-	s.cfg.Todoist = settings.Todoist
-	s.cfg.Renovate = settings.Renovate
+// applyFromConfig assigns all hot-reloadable fields from next into s.cfg and
+// calls the corresponding live setters. s.mu must be held by the caller.
+// This never writes to disk — callers that need persistence must call s.cfg.Save().
+func (s *ConfigService) applyFromConfig(next config.Config) {
+	s.cfg.Agent = next.Agent
+	s.cfg.Notification = next.Notification
+	s.cfg.Orchestrator = next.Orchestrator
+	s.cfg.Logging.Level = next.Logging.Level
+	s.cfg.Logging.MaxSizeMB = next.Logging.MaxSizeMB
+	s.cfg.Logging.MaxFiles = next.Logging.MaxFiles
+	s.cfg.Audit = next.Audit
+	s.cfg.Todoist = next.Todoist
+	// In-place field assignment: renovateHandler holds &s.cfg.Renovate
+	s.cfg.Renovate.Enabled = next.Renovate.Enabled
+	s.cfg.Renovate.Author = next.Renovate.Author
+	s.cfg.Providers = next.Providers
+	s.cfg.GitHub = next.GitHub
+	s.cfg.Triage = next.Triage
+	s.cfg.Monitor = next.Monitor
+	s.cfg.SelfMonitor = next.SelfMonitor
+	s.cfg.Metrics = next.Metrics
+	s.cfg.ProjectTypes = next.ProjectTypes
 
-	s.notifier.SetDesktop(settings.Notification.Desktop)
-	s.agents.SetMaxConcurrent(settings.Agent.MaxConcurrent)
-	s.agents.SetDefaultProvider(settings.Agent.Provider)
+	s.notifier.SetDesktop(next.Notification.Desktop)
+	s.agents.SetMaxConcurrent(next.Agent.MaxConcurrent)
+	s.agents.SetDefaultProvider(next.Agent.Provider)
+	s.agents.SetGuardrails(agent.Guardrails{
+		MaxCostUSD: next.Agent.MaxCostUSD,
+		MaxTurns:   next.Agent.MaxTurns,
+	})
 	if s.logLevel != nil {
 		s.logLevel.Set(s.cfg.Logging.SlogLevel())
 	}
 	if s.reloadHook != nil {
 		s.reloadHook()
 	}
+}
 
-	return s.cfg.Save()
+// settingsToConfig converts AppSettings into a config.Config overlay, filling
+// fields not present in AppSettings from the existing cfg.
+func settingsToConfig(existing *config.Config, settings AppSettings) config.Config {
+	next := *existing
+	next.Agent = settings.Agent
+	next.Notification = settings.Notification
+	next.Orchestrator = settings.Orchestrator
+	next.Logging.Level = settings.Logging.Level
+	next.Logging.MaxSizeMB = settings.Logging.MaxSizeMB
+	next.Logging.MaxFiles = settings.Logging.MaxFiles
+	next.Audit = settings.Audit
+	next.Todoist = settings.Todoist
+	next.Renovate = settings.Renovate
+	next.Providers = settings.Providers
+	return next
 }

--- a/internal/sybra/svc_config_reload.go
+++ b/internal/sybra/svc_config_reload.go
@@ -1,0 +1,106 @@
+package sybra
+
+import (
+	"slices"
+
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/config"
+)
+
+// ReloadFromDisk re-reads ~/.sybra/config.yaml, validates it, diffs against
+// the in-memory config, and applies hot-reloadable changes. Returns the list
+// of hot-reloadable keys that changed. On any error the in-memory config is
+// left unchanged. Never writes to disk.
+func (s *ConfigService) ReloadFromDisk() (changedHot []string, err error) {
+	next, err := config.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	nextSettings := configToSettings(next)
+	if err := s.validateSettings(nextSettings); err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	hot, restart := diffConfig(*s.cfg, *next)
+
+	// Always update s.cfg to match disk — including restart-required fields —
+	// so subsequent reloads with the same content produce no diff and no
+	// repeated restart warnings. renovateHandler holds &s.cfg.Renovate, so
+	// assign its fields in-place rather than replacing the whole struct.
+	s.cfg.Agent = next.Agent
+	s.cfg.Notification = next.Notification
+	s.cfg.Orchestrator = next.Orchestrator
+	s.cfg.Logging.Level = next.Logging.Level
+	s.cfg.Logging.MaxSizeMB = next.Logging.MaxSizeMB
+	s.cfg.Logging.MaxFiles = next.Logging.MaxFiles
+	s.cfg.Audit = next.Audit
+	s.cfg.Todoist = next.Todoist
+	s.cfg.Renovate.Enabled = next.Renovate.Enabled
+	s.cfg.Renovate.Author = next.Renovate.Author
+	s.cfg.Providers = next.Providers
+	s.cfg.GitHub = next.GitHub
+	s.cfg.Triage = next.Triage
+	s.cfg.Monitor = next.Monitor
+	s.cfg.SelfMonitor = next.SelfMonitor
+	s.cfg.Metrics = next.Metrics
+	s.cfg.ProjectTypes = next.ProjectTypes
+
+	// Selectively call live setters only for fields that actually changed.
+	// This avoids restarting Todoist or other services on every config write
+	// when nothing relevant changed (e.g. UI saves non-Todoist settings).
+	for _, k := range hot {
+		switch k {
+		case "notification.desktop":
+			s.notifier.SetDesktop(next.Notification.Desktop)
+		case "agent.max_concurrent":
+			s.agents.SetMaxConcurrent(next.Agent.MaxConcurrent)
+		case "agent.provider":
+			s.agents.SetDefaultProvider(next.Agent.Provider)
+		case "logging.level":
+			if s.logLevel != nil {
+				s.logLevel.Set(next.Logging.SlogLevel())
+			}
+		case "todoist":
+			if s.reloadHook != nil {
+				s.reloadHook()
+			}
+		}
+	}
+	// SetGuardrails once if either guardrail field changed.
+	if slices.Contains(hot, "agent.max_cost_usd") || slices.Contains(hot, "agent.max_turns") {
+		s.agents.SetGuardrails(agent.Guardrails{
+			MaxCostUSD: next.Agent.MaxCostUSD,
+			MaxTurns:   next.Agent.MaxTurns,
+		})
+	}
+
+	if s.logger != nil {
+		for _, k := range restart {
+			s.logger.Warn("config.reload.restart_required", "field", k)
+		}
+	}
+
+	return hot, nil
+}
+
+// configToSettings converts a *config.Config into AppSettings for validation.
+func configToSettings(c *config.Config) AppSettings {
+	return AppSettings{
+		Agent:        c.Agent,
+		Notification: c.Notification,
+		Orchestrator: c.Orchestrator,
+		Logging: LoggingSettings{
+			Level:     c.Logging.Level,
+			MaxSizeMB: c.Logging.MaxSizeMB,
+			MaxFiles:  c.Logging.MaxFiles,
+		},
+		Audit:     c.Audit,
+		Todoist:   c.Todoist,
+		Renovate:  c.Renovate,
+		Providers: c.Providers,
+	}
+}

--- a/internal/sybra/svc_config_reload_test.go
+++ b/internal/sybra/svc_config_reload_test.go
@@ -1,0 +1,341 @@
+package sybra
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/notification"
+	"gopkg.in/yaml.v3"
+)
+
+// setupConfigSvc creates a ConfigService wired to a temp SYBRA_HOME.
+// Returns the service and the path to config.yaml for mutation.
+func setupConfigSvc(t *testing.T) (svc *ConfigService, cfgPath string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("SYBRA_HOME", home)
+
+	// Write seed config; Load applies all defaults so s.cfg matches what
+	// ReloadFromDisk will produce (e.g. Todoist.PollSeconds = 120).
+	seed := config.DefaultConfig()
+	seed.Agent.MaxConcurrent = 3
+	seed.Agent.Provider = "claude"
+	seed.Agent.MaxCostUSD = 5.0
+	seed.Agent.MaxTurns = 150
+	seed.Logging.Level = "info"
+	seed.Logging.MaxSizeMB = 50
+	seed.Logging.MaxFiles = 5
+	seed.Audit.RetentionDays = 30
+
+	cfgPath = filepath.Join(home, "config.yaml")
+	writeConfigYAML(t, cfgPath, seed)
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+
+	logLevel := new(slog.LevelVar)
+	logLevel.Set(slog.LevelInfo)
+	emit := func(string, any) {}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logDir := filepath.Join(home, "logs")
+	mgr := agent.NewManager(context.Background(), emit, logger, logDir)
+	mgr.SetMaxConcurrent(cfg.Agent.MaxConcurrent)
+	mgr.SetDefaultProvider(cfg.Agent.Provider)
+	mgr.SetGuardrails(agent.Guardrails{MaxCostUSD: cfg.Agent.MaxCostUSD, MaxTurns: cfg.Agent.MaxTurns})
+
+	notifier := notification.New(emit)
+
+	svc = &ConfigService{
+		cfg:      cfg,
+		logLevel: logLevel,
+		notifier: notifier,
+		agents:   mgr,
+		logger:   logger,
+	}
+	return
+}
+
+func writeConfigYAML(t *testing.T, path string, cfg *config.Config) {
+	t.Helper()
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReloadFromDisk_MaxConcurrent(t *testing.T) {
+	svc, cfgPath := setupConfigSvc(t)
+
+	// Rewrite config with higher concurrency
+	next := *svc.cfg
+	next.Agent.MaxConcurrent = 8
+	writeConfigYAML(t, cfgPath, &next)
+
+	hot, err := svc.ReloadFromDisk()
+	if err != nil {
+		t.Fatalf("ReloadFromDisk: %v", err)
+	}
+	if !slices.Contains(hot, "agent.max_concurrent") {
+		t.Errorf("expected agent.max_concurrent in hot, got %v", hot)
+	}
+	if got := svc.agents.RunningCount(); got < 0 {
+		t.Error("unexpected RunningCount")
+	}
+	// Verify manager updated (can spin agents up to new limit)
+	if svc.cfg.Agent.MaxConcurrent != 8 {
+		t.Errorf("cfg.Agent.MaxConcurrent = %d, want 8", svc.cfg.Agent.MaxConcurrent)
+	}
+}
+
+func TestReloadFromDisk_Guardrails(t *testing.T) {
+	svc, cfgPath := setupConfigSvc(t)
+
+	next := *svc.cfg
+	next.Agent.MaxCostUSD = 20.0
+	next.Agent.MaxTurns = 300
+	writeConfigYAML(t, cfgPath, &next)
+
+	hot, err := svc.ReloadFromDisk()
+	if err != nil {
+		t.Fatalf("ReloadFromDisk: %v", err)
+	}
+	if !slices.Contains(hot, "agent.max_cost_usd") {
+		t.Errorf("expected agent.max_cost_usd in hot, got %v", hot)
+	}
+	g := svc.agents.Guardrails()
+	if g.MaxCostUSD != 20.0 {
+		t.Errorf("Guardrails.MaxCostUSD = %v, want 20.0", g.MaxCostUSD)
+	}
+	if g.MaxTurns != 300 {
+		t.Errorf("Guardrails.MaxTurns = %d, want 300", g.MaxTurns)
+	}
+}
+
+func TestReloadFromDisk_Provider(t *testing.T) {
+	svc, cfgPath := setupConfigSvc(t)
+
+	next := *svc.cfg
+	next.Agent.Provider = "codex"
+	writeConfigYAML(t, cfgPath, &next)
+
+	hot, err := svc.ReloadFromDisk()
+	if err != nil {
+		t.Fatalf("ReloadFromDisk: %v", err)
+	}
+	if !slices.Contains(hot, "agent.provider") {
+		t.Errorf("expected agent.provider in hot, got %v", hot)
+	}
+	if got := svc.agents.DefaultProvider(); got != "codex" {
+		t.Errorf("DefaultProvider = %q, want codex", got)
+	}
+}
+
+func TestReloadFromDisk_LogLevel(t *testing.T) {
+	svc, cfgPath := setupConfigSvc(t)
+
+	next := *svc.cfg
+	next.Logging.Level = "debug"
+	writeConfigYAML(t, cfgPath, &next)
+
+	hot, err := svc.ReloadFromDisk()
+	if err != nil {
+		t.Fatalf("ReloadFromDisk: %v", err)
+	}
+	if !slices.Contains(hot, "logging.level") {
+		t.Errorf("expected logging.level in hot, got %v", hot)
+	}
+	if svc.logLevel.Level() != slog.LevelDebug {
+		t.Errorf("logLevel = %v, want Debug", svc.logLevel.Level())
+	}
+}
+
+func TestReloadFromDisk_InvalidYAML(t *testing.T) {
+	svc, cfgPath := setupConfigSvc(t)
+
+	if err := os.WriteFile(cfgPath, []byte(":::invalid yaml{{{\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origMax := svc.cfg.Agent.MaxConcurrent
+	_, err := svc.ReloadFromDisk()
+	if err == nil {
+		t.Fatal("expected error for invalid YAML, got nil")
+	}
+	if svc.cfg.Agent.MaxConcurrent != origMax {
+		t.Errorf("cfg mutated on error: got %d, want %d", svc.cfg.Agent.MaxConcurrent, origMax)
+	}
+}
+
+func TestReloadFromDisk_ValidationError(t *testing.T) {
+	svc, cfgPath := setupConfigSvc(t)
+
+	next := *svc.cfg
+	next.Logging.Level = "verbose" // invalid
+	writeConfigYAML(t, cfgPath, &next)
+
+	origLevel := svc.cfg.Logging.Level
+	_, err := svc.ReloadFromDisk()
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	if svc.cfg.Logging.Level != origLevel {
+		t.Errorf("cfg.Logging.Level mutated on validation error")
+	}
+}
+
+func TestReloadFromDisk_RestartRequiredWarned(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SYBRA_HOME", home)
+
+	seed := config.DefaultConfig()
+	seed.Logging.Level = "info"
+	seed.Logging.MaxSizeMB = 50
+	seed.Logging.MaxFiles = 5
+	seed.Audit.RetentionDays = 30
+
+	cfgPath := filepath.Join(home, "config.yaml")
+	writeConfigYAML(t, cfgPath, seed)
+
+	// Use Load() so s.cfg matches what ReloadFromDisk will see.
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+
+	// Capture log records
+	var records []slog.Record
+	handler := &recordHandler{records: &records}
+	logger := slog.New(handler)
+
+	emit := func(string, any) {}
+	logLevel := new(slog.LevelVar)
+	logLevel.Set(slog.LevelInfo)
+	logDir := filepath.Join(home, "logs")
+	mgr := agent.NewManager(context.Background(), emit, logger, logDir)
+	mgr.SetMaxConcurrent(cfg.Agent.MaxConcurrent)
+	mgr.SetDefaultProvider(cfg.Agent.Provider)
+	mgr.SetGuardrails(agent.Guardrails{MaxCostUSD: cfg.Agent.MaxCostUSD, MaxTurns: cfg.Agent.MaxTurns})
+	notifier := notification.New(emit)
+
+	svc := &ConfigService{
+		cfg:      cfg,
+		logLevel: logLevel,
+		notifier: notifier,
+		agents:   mgr,
+		logger:   logger,
+	}
+
+	// Change a restart-required field
+	next := *cfg
+	next.Providers.HealthCheck.IntervalSeconds = 600
+	writeConfigYAML(t, cfgPath, &next)
+
+	hot, err := svc.ReloadFromDisk()
+	if err != nil {
+		t.Fatalf("ReloadFromDisk: %v", err)
+	}
+	if len(hot) != 0 {
+		t.Errorf("expected no hot keys, got %v", hot)
+	}
+
+	// Check that restart_required was logged
+	found := false
+	for _, r := range records {
+		if r.Message == "config.reload.restart_required" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected config.reload.restart_required warning, got none")
+	}
+
+	// Verify s.cfg updated to disk value (prevents repeated warnings)
+	if svc.cfg.Providers.HealthCheck.IntervalSeconds != 600 {
+		t.Error("s.cfg not updated with restart-required field after reload")
+	}
+
+	// Second reload with same content: no new warnings
+	prevCount := len(records)
+	hot2, err := svc.ReloadFromDisk()
+	if err != nil {
+		t.Fatalf("second ReloadFromDisk: %v", err)
+	}
+	if len(hot2) != 0 {
+		t.Errorf("second reload: expected no hot keys, got %v", hot2)
+	}
+	warnCount := 0
+	for _, r := range records[prevCount:] {
+		if r.Message == "config.reload.restart_required" {
+			warnCount++
+		}
+	}
+	if warnCount != 0 {
+		t.Errorf("second reload with same content emitted %d restart warnings, want 0", warnCount)
+	}
+}
+
+func TestReloadFromDisk_NoFeedbackLoop(t *testing.T) {
+
+	// UpdateSettings saves to disk; watcher fires ReloadFromDisk; diff should
+	// be empty since disk now matches in-memory cfg.
+	svc, _ := setupConfigSvc(t)
+
+	// UpdateSettings mutates cfg and saves
+	settings := AppSettings{
+		Agent:        svc.cfg.Agent,
+		Notification: svc.cfg.Notification,
+		Orchestrator: svc.cfg.Orchestrator,
+		Logging: LoggingSettings{
+			Level:     "warn",
+			MaxSizeMB: svc.cfg.Logging.MaxSizeMB,
+			MaxFiles:  svc.cfg.Logging.MaxFiles,
+		},
+		Audit:     svc.cfg.Audit,
+		Todoist:   svc.cfg.Todoist,
+		Renovate:  svc.cfg.Renovate,
+		Providers: svc.cfg.Providers,
+	}
+	settings.Agent.MaxConcurrent = 3 // ensure valid
+	if err := svc.UpdateSettings(settings); err != nil {
+		t.Fatalf("UpdateSettings: %v", err)
+	}
+
+	// Simulate watcher-triggered reload — disk now matches in-memory
+	hot, err := svc.ReloadFromDisk()
+	if err != nil {
+		t.Fatalf("ReloadFromDisk: %v", err)
+	}
+	if len(hot) != 0 {
+		t.Errorf("feedback loop: expected empty hot keys after UpdateSettings+Reload, got %v", hot)
+	}
+}
+
+// recordHandler captures log records for assertion in tests.
+type recordHandler struct {
+	records *[]slog.Record
+	slog.Handler
+}
+
+func (h *recordHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *recordHandler) Handle(_ context.Context, r slog.Record) error {
+	*h.records = append(*h.records, r)
+	return nil
+}
+func (h *recordHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *recordHandler) WithGroup(_ string) slog.Handler      { return h }


### PR DESCRIPTION
## Motivation

`~/.sybra/config.yaml` only reloads at process startup or via the Settings UI. Headless server deployments have no GUI, so config changes (e.g. raising `max_concurrent`) require a container restart that kills in-flight agents.

## Implementation information

- `internal/confighot`: fsnotify watcher on `config.yaml`, 500ms trailing-edge debounce, handles atomic editor saves (vim rename/create pattern)
- Refactored `ConfigService`: `sync.RWMutex`, extracted `validateSettings` + `applyFromConfig` helpers shared by UI and watcher paths
- `config_diff.go`: computes hot vs restart key sets; hot keys get live setters, restart keys emit warnings
- `ReloadFromDisk`: selective setters — only calls `SetMaxConcurrent`, `SetGuardrails`, `SetDefaultProvider`, `logLevel.Set`, todoist reload, etc. when that specific key changed
- Wired in `startBackgroundServices`; logs changed hot keys and `config.reload.restart_required` warnings for non-hot fields

> Changelog: feat(config): hot-reload config.yaml via fsnotify watcher

Closes https://github.com/Automaat/sybra/issues/518