### PR TITLE
fix(workflow): dynamic origin base branch

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -615,8 +615,8 @@ func cmdBoard(s *task.Manager, jsonOut bool) int {
 			StatusReason: t.StatusReason,
 		}
 		// Find the latest running agent run.
-		for j := len(t.AgentRuns) - 1; j >= 0; j-- {
-			run := t.AgentRuns[j]
+		for i := range slices.Backward(t.AgentRuns) {
+			run := &t.AgentRuns[i]
 			if run.State == "running" || (!run.StartedAt.IsZero() && bt.AgentID == "") {
 				bt.AgentID = run.AgentID
 				bt.StartedAt = run.StartedAt

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 	"time"
 
@@ -174,8 +175,8 @@ func (m *Manager) reportProviderHealthSignal(a *Agent, stderrOut string, attempt
 
 func buildErrorSample(stderrOut string, attemptEvents []StreamEvent) provider.ErrorSample {
 	sample := provider.ErrorSample{Stderr: stderrOut}
-	for i := len(attemptEvents) - 1; i >= 0; i-- {
-		e := attemptEvents[i]
+	for i := range slices.Backward(attemptEvents) {
+		e := &attemptEvents[i]
 		if e.Type != "result" || e.Subtype != "error" {
 			continue
 		}
@@ -213,8 +214,8 @@ func (m *Manager) reportProviderHealthSignalConvo(a *Agent, stderrOut string, at
 
 func buildErrorSampleConvo(stderrOut string, attemptEvents []ConvoEvent) provider.ErrorSample {
 	sample := provider.ErrorSample{Stderr: stderrOut}
-	for i := len(attemptEvents) - 1; i >= 0; i-- {
-		e := attemptEvents[i]
+	for i := range slices.Backward(attemptEvents) {
+		e := &attemptEvents[i]
 		if e.Type != "result" || e.Subtype != "error" {
 			continue
 		}

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -25,7 +26,7 @@ func newParseTestManager(t *testing.T) *Manager {
 // or nil if none.
 func lastResult(a *Agent) *StreamEvent {
 	out := a.Output()
-	for i := len(out) - 1; i >= 0; i-- {
+	for i := range slices.Backward(out) {
 		if out[i].Type == "result" {
 			return &out[i]
 		}

--- a/internal/sybra/app_agents.go
+++ b/internal/sybra/app_agents.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -66,8 +67,8 @@ func resolvePermission(t task.Task, cfg *config.Config) bool {
 //     running the implementation prompt. workflowStart=zero disables the
 //     time filter (useful for callers that have no execution context).
 func pickImplementationResumeSession(runs []task.AgentRun, workflowStart time.Time) string {
-	for i := len(runs) - 1; i >= 0; i-- {
-		run := runs[i]
+	for i := range slices.Backward(runs) {
+		run := &runs[i]
 		if run.SessionID == "" {
 			continue
 		}

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -1728,7 +1728,7 @@ func lastStepStatus(tk task.Task, stepID string) string {
 	if tk.Workflow == nil {
 		return ""
 	}
-	for i := len(tk.Workflow.StepHistory) - 1; i >= 0; i-- {
+	for i := range slices.Backward(tk.Workflow.StepHistory) {
 		if tk.Workflow.StepHistory[i].StepID == stepID {
 			return tk.Workflow.StepHistory[i].Status
 		}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -995,7 +995,7 @@ func flipProvider(p string) string {
 func resolveProvider(stepProv string, wfExec *Execution, defaultProv string) string {
 	switch stepProv {
 	case "cross":
-		for i := len(wfExec.StepHistory) - 1; i >= 0; i-- {
+		for i := range slices.Backward(wfExec.StepHistory) {
 			if p := wfExec.StepHistory[i].Provider; p != "" {
 				return flipProvider(p)
 			}
@@ -1288,7 +1288,7 @@ func (e *Engine) execLinkPRAndReview(taskID string, step *Step, wfExec *Executio
 	}
 
 	// Path 2: Scan step history for a GitHub PR URL or owner/repo#N in agent output.
-	for i := len(wfExec.StepHistory) - 1; i >= 0; i-- {
+	for i := range slices.Backward(wfExec.StepHistory) {
 		rec := wfExec.StepHistory[i]
 		if rec.Status != "completed" || rec.Output == "" {
 			continue
@@ -1373,7 +1373,7 @@ func (e *Engine) execEvaluate(taskID string, step *Step, wfExec *Execution, t Ta
 	}
 
 	var last *StepRecord
-	for i := len(wfExec.StepHistory) - 1; i >= 0; i-- {
+	for i := range slices.Backward(wfExec.StepHistory) {
 		if wfExec.StepHistory[i].AgentID != "" {
 			last = &wfExec.StepHistory[i]
 			break

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -1200,6 +1200,21 @@ func (e *Engine) execRequireSidecar(taskID string, step *Step, t TaskInfo) (Step
 	return StepOutput{StepID: step.ID, Status: "completed", Output: label + " present"}, nil
 }
 
+// resolveOriginBase returns the remote ref to use as the base for commit
+// range comparisons. It checks for origin/HEAD (set when the remote HEAD
+// symbolic ref is configured), then falls back to probing master and main.
+// Returns "origin/main" if nothing resolves.
+func resolveOriginBase(ctx context.Context, wtPath string) string {
+	for _, candidate := range []string{"origin/HEAD", "origin/master", "origin/main"} {
+		cmd := exec.CommandContext(ctx, "git", "rev-parse", "--verify", candidate)
+		cmd.Dir = wtPath
+		if cmd.Run() == nil {
+			return candidate
+		}
+	}
+	return "origin/main"
+}
+
 func (e *Engine) execVerifyCommits(taskID string, step *Step, t TaskInfo) (StepOutput, error) {
 	if e.worktrees == nil {
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no worktree getter configured"}, nil
@@ -1212,7 +1227,8 @@ func (e *Engine) execVerifyCommits(taskID string, step *Step, t TaskInfo) (StepO
 	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "git", "log", "origin/main..HEAD", "--oneline")
+	baseRef := resolveOriginBase(ctx, wtPath)
+	cmd := exec.CommandContext(ctx, "git", "log", baseRef+"..HEAD", "--oneline")
 	cmd.Dir = wtPath
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/workflow/execution.go
+++ b/internal/workflow/execution.go
@@ -1,6 +1,9 @@
 package workflow
 
-import "time"
+import (
+	"slices"
+	"time"
+)
 
 // ExecState tracks the overall execution state.
 type ExecState string
@@ -65,7 +68,7 @@ func (e *Execution) CountStep(stepID string) int {
 
 // RecordForStep returns the latest record for a given step ID, or nil.
 func (e *Execution) RecordForStep(stepID string) *StepRecord {
-	for i := len(e.StepHistory) - 1; i >= 0; i-- {
+	for i := range slices.Backward(e.StepHistory) {
 		if e.StepHistory[i].StepID == stepID {
 			return &e.StepHistory[i]
 		}


### PR DESCRIPTION
## Motivation

`verify_commits` hardcoded `origin/main` as the base ref for the commit
range check. Repos that use `master` (e.g. `kumahq/kuma`) caused a
`exit status 128` git error, flipping every task to `human-required`
even when the agent successfully pushed commits.

## Implementation information

Added `resolveOriginBase` which probes `origin/HEAD`, `origin/master`,
`origin/main` in order and returns the first resolvable ref. Falls back
to `origin/main` if none resolve.

> Changelog: fix(workflow): dynamic origin base branch