### PR TITLE
fix(github): collapse HTML 5xx error pages

### DIFF
--- a/frontend/src/pages/GitHub.svelte
+++ b/frontend/src/pages/GitHub.svelte
@@ -178,7 +178,17 @@
       {#if renovateStore.loading && renovateStore.count === 0}
         <p class="text-center text-sm opacity-60">Loading...</p>
       {:else if renovateStore.error}
-        <p class="text-center text-sm text-error-500">{renovateStore.error}</p>
+        <div class="flex flex-col items-center gap-2 py-8">
+          <p class="text-center text-sm text-error-500">Failed to load Renovate PRs</p>
+          <p class="max-w-lg break-words text-center text-xs opacity-70">{renovateStore.error}</p>
+          <button
+            type="button"
+            class="btn btn-sm preset-tonal"
+            onclick={() => renovateStore.load()}
+          >
+            Retry
+          </button>
+        </div>
       {:else if renovateStore.count === 0}
         <p class="py-8 text-center text-sm opacity-50">No Renovate PRs</p>
       {:else}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -58,6 +58,27 @@ func resetCachedViewerForTest() {
 	viewerMu.Unlock()
 }
 
+// sanitizeGHOutput trims the `gh` CLI's combined output for use in error
+// messages. When GitHub returns a 5xx with an HTML error page (e.g. the
+// "Unicorn!" 504 page), gh prints the entire HTML body followed by a
+// "gh: HTTP <code>" status line. Returning that wall of HTML to the UI
+// is unreadable, so collapse it to just the status line.
+func sanitizeGHOutput(out []byte) string {
+	s := strings.TrimSpace(string(out))
+	if !strings.Contains(s, "<!DOCTYPE html") && !strings.Contains(s, "<html") {
+		return s
+	}
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] != '\n' {
+			continue
+		}
+		if line := strings.TrimSpace(s[i+1:]); strings.HasPrefix(line, "gh:") {
+			return line
+		}
+	}
+	return "GitHub returned an HTML error page"
+}
+
 const prQuery = `query($q: String!) {
   search(query: $q, type: ISSUE, first: 50) {
     nodes {
@@ -173,7 +194,7 @@ func searchPRsWith(e execer, query string) ([]PullRequest, error) {
 		"-f", "query="+prQuery,
 		"-f", "q="+query)
 	if err != nil {
-		return nil, fmt.Errorf("gh api graphql: %s: %w", strings.TrimSpace(string(out)), err)
+		return nil, fmt.Errorf("gh api graphql: %s: %w", sanitizeGHOutput(out), err)
 	}
 
 	var resp gqlResponse

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -636,3 +636,46 @@ func TestParseIssueURL(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitizeGHOutput(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "plain text passthrough",
+			in:   "  gh: not logged in  ",
+			want: "gh: not logged in",
+		},
+		{
+			name: "empty",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "html unicorn 504 collapses to status line",
+			in:   "<!DOCTYPE html>\n<html><body>Unicorn</body></html>\ngh: HTTP 504",
+			want: "gh: HTTP 504",
+		},
+		{
+			name: "html with no trailing gh line",
+			in:   "<!DOCTYPE html><html><body>Unicorn</body></html>",
+			want: "GitHub returned an HTML error page",
+		},
+		{
+			name: "lowercase html tag",
+			in:   "<html><body>x</body></html>\ngh: HTTP 502",
+			want: "gh: HTTP 502",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := sanitizeGHOutput([]byte(tt.in)); got != tt.want {
+				t.Errorf("sanitizeGHOutput = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -89,7 +89,7 @@ func searchIssuesWith(e execer, query string) ([]Issue, error) {
 		"-f", "query="+issueQuery,
 		"-f", "q="+query)
 	if err != nil {
-		return nil, fmt.Errorf("gh api graphql: %s: %w", strings.TrimSpace(string(out)), err)
+		return nil, fmt.Errorf("gh api graphql: %s: %w", sanitizeGHOutput(out), err)
 	}
 
 	var resp gqlIssueResponse

--- a/internal/github/renovate.go
+++ b/internal/github/renovate.go
@@ -3,7 +3,6 @@ package github
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 )
 
 // renovatePRQuery includes individual check run contexts for rerun support.
@@ -94,7 +93,7 @@ func searchRenovatePRsWith(e execer, query string) ([]RenovatePR, error) {
 		"-f", "query="+renovatePRQuery,
 		"-f", "q="+query)
 	if err != nil {
-		return nil, fmt.Errorf("gh api graphql: %s: %w", strings.TrimSpace(string(out)), err)
+		return nil, fmt.Errorf("gh api graphql: %s: %w", sanitizeGHOutput(out), err)
 	}
 
 	var resp gqlResponse


### PR DESCRIPTION
## Motivation

When GitHub responds with a 504 (the "Unicorn!" page), `gh api graphql` dumps the entire HTML body into combined output. The renovate fetch error wrapped that as `fetch renovate PRs for X: gh api graphql: <html>...</html>: exit status 1` and the GUI rendered the wall of HTML literally in the renovate tab.

## Implementation information

- `internal/github/client.go`: new `sanitizeGHOutput` helper. Detects `<!DOCTYPE html>` / `<html` and collapses to the trailing `gh: HTTP <code>` status line that gh appends after the body, or `"GitHub returned an HTML error page"` if no status line.
- Applied at the three GraphQL call sites (`renovate.go`, `client.go` `searchPRsWith`, `issues.go` `searchIssuesWith`) — these talk to GitHub directly and are the realistic 5xx/HTML sources.
- `frontend/src/pages/GitHub.svelte`: renovate-tab error block now shows a "Failed to load Renovate PRs" headline, the (short) error string, and a Retry button instead of one stranded line of text.
- Table-driven test in `client_test.go` covers passthrough, empty, HTML-with-status, HTML-without-status, lowercase `<html>`.

## Supporting documentation

n/a