### PR TITLE
fix(workflow): use sybra-cli in review prompt

### DIFF
--- a/internal/workflow/builtin/simple-task.yaml
+++ b/internal/workflow/builtin/simple-task.yaml
@@ -322,10 +322,10 @@ steps:
           1. git diff origin/main..HEAD > /tmp/sybra-diff-{{.Task.ID}}.patch
           2. Run /staff-code-review against that patch and the worktree source
           3. Save the full review to /tmp/sybra-review-{{.Task.ID}}.md
-          4. synapse-cli update {{.Task.ID}} --code-review-file /tmp/sybra-review-{{.Task.ID}}.md
+          4. sybra-cli update {{.Task.ID}} --code-review-file /tmp/sybra-review-{{.Task.ID}}.md
 
         Do NOT submit anything to GitHub. The /tmp file remains for the
-        next step (fix_review) to read; the synapse-cli call preserves
+        next step (fix_review) to read; the sybra-cli call preserves
         the review as a task sidecar visible in the GUI.
     next:
       - goto: require_code_review


### PR DESCRIPTION
## Motivation

Task 2613363f ended in `human-required` because the `code_review` step
ran `synapse-cli update --code-review-file ...`. The legacy
`synapse-cli` binary still on PATH predates that flag and exits 1, so
the review sidecar never got written and `require_code_review` flipped
the task to `human-required`.

## Implementation information

Two stale `synapse-cli` references in `simple-task.yaml` (the only
survivors of the project rename) renamed to `sybra-cli`. Everything
else in the codebase already uses `sybra-cli`.

## Supporting documentation

Failed agent log: `~/.sybra/logs/agents/482449a9-2026-05-05T15-02-25.ndjson`

> Changelog: fix(workflow): use sybra-cli in review prompt