### PR TITLE
feat(workflow): engine ingests sidecar files

### DIFF
--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1608,6 +1608,20 @@ export namespace workflow {
 		    return a;
 		}
 	}
+	export class ImportSidecar {
+	    kind: string;
+	    from: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new ImportSidecar(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.kind = source["kind"];
+	        this.from = source["from"];
+	    }
+	}
 	export class StepConfig {
 	    role: string;
 	    mode: string;
@@ -1626,6 +1640,7 @@ export namespace workflow {
 	    command: string;
 	    dir: string;
 	    sidecar: string;
+	    importSidecar?: ImportSidecar;
 	
 	    static createFrom(source: any = {}) {
 	        return new StepConfig(source);
@@ -1650,6 +1665,7 @@ export namespace workflow {
 	        this.command = source["command"];
 	        this.dir = source["dir"];
 	        this.sidecar = source["sidecar"];
+	        this.importSidecar = this.convertValues(source["importSidecar"], ImportSidecar);
 	    }
 	
 		convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -1898,6 +1914,7 @@ export namespace workflow {
 		    return a;
 		}
 	}
+	
 	
 	
 	

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -87,6 +87,20 @@ func (a *taskAdapter) SetWorkflow(id string, wf *workflow.Execution) error {
 	return err
 }
 
+func (a *taskAdapter) WriteSidecar(id, kind, content string) error {
+	var u task.Update
+	switch kind {
+	case "code_review":
+		u.CodeReview = &content
+	case "plan_critique":
+		u.PlanCritique = &content
+	default:
+		return fmt.Errorf("unknown sidecar kind %q (want code_review|plan_critique)", kind)
+	}
+	_, err := a.tasks.Update(id, u)
+	return err
+}
+
 func taskToInfo(t task.Task) workflow.TaskInfo {
 	return workflow.TaskInfo{
 		ID:           t.ID,

--- a/internal/workflow/builtin/simple-task.yaml
+++ b/internal/workflow/builtin/simple-task.yaml
@@ -140,10 +140,11 @@ steps:
           3. Invoke: /plan-critic /tmp/sybra-plan-{{.Task.ID}}.md
           4. Capture the full markdown Plan Review report you produce and
              write it to /tmp/sybra-critique-{{.Task.ID}}.md
-          5. Save it: sybra-cli update {{.Task.ID}} --plan-critique-file /tmp/sybra-critique-{{.Task.ID}}.md
 
-        Do NOT modify the plan. Do NOT change the task status. Your only
-        side effect is writing the critique sidecar via sybra-cli.
+        Do NOT modify the plan. Do NOT change the task status. Sybra
+        will ingest /tmp/sybra-critique-{{.Task.ID}}.md as the task's
+        plan_critique sidecar after you exit — you do not need to call
+        sybra-cli yourself.
       allowed_tools:
         - Bash
         - Read
@@ -152,15 +153,18 @@ steps:
         - Write
         - Skill
         - Agent
+      import_sidecar:
+        kind: plan_critique
+        from: /tmp/sybra-critique-{{.Task.ID}}.md
     next:
       - goto: require_plan_critique
 
-  # Guard: the critic agent above exits cleanly even when it is blocked
-  # from executing any shell command (e.g. codex bwrap sandbox failure
-  # inside Docker). Without this check the workflow silently advances to
-  # address_critique with an empty sidecar, and the human sees only the
-  # plan — no critique — in the review UI. Flips task to human-required
-  # when the sidecar is empty so the failure is visible.
+  # Guard: the critic agent above can exit cleanly even when it never
+  # produced its output file (e.g. shell blocked by a sandbox). Without
+  # this check the workflow silently advances to address_critique with
+  # an empty sidecar, and the human sees only the plan — no critique —
+  # in the review UI. Flips task to human-required when the sidecar is
+  # empty so the failure is visible.
   - id: require_plan_critique
     name: Require Plan Critique
     type: require_sidecar
@@ -322,18 +326,23 @@ steps:
           1. git diff origin/main..HEAD > /tmp/sybra-diff-{{.Task.ID}}.patch
           2. Run /staff-code-review against that patch and the worktree source
           3. Save the full review to /tmp/sybra-review-{{.Task.ID}}.md
-          4. sybra-cli update {{.Task.ID}} --code-review-file /tmp/sybra-review-{{.Task.ID}}.md
 
-        Do NOT submit anything to GitHub. The /tmp file remains for the
-        next step (fix_review) to read; the sybra-cli call preserves
-        the review as a task sidecar visible in the GUI.
+        Do NOT submit anything to GitHub. Sybra will ingest
+        /tmp/sybra-review-{{.Task.ID}}.md as the code_review sidecar
+        after you exit — you do not need to call sybra-cli yourself.
+        The /tmp file also remains for the next step (fix_review) to
+        read directly.
+      import_sidecar:
+        kind: code_review
+        from: /tmp/sybra-review-{{.Task.ID}}.md
     next:
       - goto: require_code_review
 
   # Guard: mirrors require_plan_critique above. Flips task to
-  # human-required when the review sidecar is empty (e.g. agent exited
-  # without running step 4). Without this, fix_review reads /tmp and
-  # the GUI never sees what the reviewer wrote.
+  # human-required when the review sidecar is empty (e.g. agent never
+  # wrote /tmp/sybra-review-…md, or its sandbox blocked the path).
+  # Without this, fix_review reads /tmp and the GUI never sees what
+  # the reviewer wrote.
   - id: require_code_review
     name: Require Code Review
     type: require_sidecar

--- a/internal/workflow/builtin/testing-task.yaml
+++ b/internal/workflow/builtin/testing-task.yaml
@@ -89,10 +89,10 @@ steps:
           3. Invoke: /plan-critic /tmp/sybra-plan-{{.Task.ID}}.md
           4. Capture the full markdown Plan Review report you produce and
              write it to /tmp/sybra-critique-{{.Task.ID}}.md
-          5. Save it: sybra-cli update {{.Task.ID}} --plan-critique-file /tmp/sybra-critique-{{.Task.ID}}.md
 
-        Do NOT modify the plan. Do NOT change the task status. Your only
-        side effect is writing the critique sidecar via sybra-cli.
+        Do NOT modify the plan. Do NOT change the task status. Sybra
+        ingests /tmp/sybra-critique-{{.Task.ID}}.md as the plan_critique
+        sidecar after you exit — no need to call sybra-cli.
       allowed_tools:
         - Bash
         - Read
@@ -101,6 +101,9 @@ steps:
         - Write
         - Skill
         - Agent
+      import_sidecar:
+        kind: plan_critique
+        from: /tmp/sybra-critique-{{.Task.ID}}.md
     next:
       - goto: review_test_plan
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"os"
 	"os/exec"
 	"regexp"
 	"slices"
@@ -70,6 +71,12 @@ type TaskProvider interface {
 	UpdateTaskPR(id string, prNumber int) error
 	MarkTaskReviewed(id string) error
 	SetWorkflow(id string, wf *Execution) error
+	// WriteSidecar stores content as the named sidecar (`code_review` or
+	// `plan_critique`) for the task. Used by run_agent steps that declare
+	// import_sidecar so the engine can ingest the agent's output file
+	// without depending on the agent's sandbox being able to write to
+	// ~/.sybra/tasks/.
+	WriteSidecar(id, kind, content string) error
 }
 
 // WorktreeGetter resolves the filesystem path of a task's git worktree.
@@ -625,6 +632,10 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 		status = "failed"
 	}
 
+	if c.Success {
+		e.importSidecarIfConfigured(taskID, spawnedStep, t)
+	}
+
 	if err := e.AdvanceStep(taskID, StepOutput{
 		StepID:   spawnedStep,
 		Status:   status,
@@ -635,6 +646,48 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 		e.logger.Error("workflow.agent-complete.advance", "task_id", taskID, "err", err)
 	}
 	e.clearAgentStep(c.AgentID)
+}
+
+// importSidecarIfConfigured reads the file the agent produced (template
+// rendered from step.config.import_sidecar.from) and stores its content
+// as the configured task sidecar. Called from HandleAgentComplete on
+// success so the host — which can write anywhere — closes the gap when
+// the agent's sandbox blocks ~/.sybra/tasks/. Errors are logged, not
+// returned: the require_sidecar guard surfaces an empty sidecar by
+// flipping the task to human-required, which is the correct UX.
+func (e *Engine) importSidecarIfConfigured(taskID, stepID string, info TaskInfo) {
+	if info.Workflow == nil {
+		return
+	}
+	def, err := e.store.Get(info.Workflow.WorkflowID)
+	if err != nil {
+		return
+	}
+	step := def.StepByID(stepID)
+	if step == nil || step.Type != StepRunAgent || step.Config.ImportSidecar == nil {
+		return
+	}
+	cfg := step.Config.ImportSidecar
+	path, rErr := RenderTemplate(cfg.From, TemplateContext{
+		Task:     info,
+		Step:     *step,
+		Vars:     info.Workflow.Variables,
+		Workflow: info.Workflow,
+	})
+	if rErr != nil {
+		e.logger.Warn("workflow.import-sidecar.render", "task_id", taskID, "step", stepID, "err", rErr)
+		return
+	}
+	content, readErr := os.ReadFile(path)
+	if readErr != nil {
+		e.logger.Warn("workflow.import-sidecar.read", "task_id", taskID, "step", stepID, "path", path, "err", readErr)
+		return
+	}
+	if writeErr := e.tasks.WriteSidecar(taskID, cfg.Kind, string(content)); writeErr != nil {
+		e.logger.Error("workflow.import-sidecar.write", "task_id", taskID, "step", stepID, "kind", cfg.Kind, "err", writeErr)
+		return
+	}
+	e.logger.Info("workflow.import-sidecar", "task_id", taskID, "step", stepID, "kind", cfg.Kind, "path", path, "bytes", len(content))
 }
 
 // lookupAgentStep returns the stepID an agent was spawned for and whether it

--- a/internal/workflow/engine_import_sidecar_test.go
+++ b/internal/workflow/engine_import_sidecar_test.go
@@ -1,0 +1,117 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// importSidecarFixture wires a Store with the test-import-sidecar workflow,
+// a memTasks holding a task whose Workflow.Variables points sidecar_path at
+// fixturePath, and a fresh Engine. Returns engine + tasks so the test can
+// drive importSidecarIfConfigured directly without needing a full
+// HandleAgentComplete plumbing.
+func importSidecarFixture(t *testing.T, fixturePath string) (*Engine, *memTasks) {
+	t.Helper()
+	store := newTestStoreWith(t, "test-import-sidecar.yaml")
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{
+		ID:     "t1",
+		Status: "in-progress",
+		Workflow: &Execution{
+			WorkflowID:  "test-import-sidecar",
+			CurrentStep: "review",
+			Variables:   map[string]string{"sidecar_path": fixturePath},
+		},
+	})
+	agents := newMockAgents()
+	return NewEngine(store, tasks, agents, discardLogger()), tasks
+}
+
+func TestImportSidecar_WritesContentFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "review.md")
+	body := "# Review\n\nNo findings.\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	engine, tasks := importSidecarFixture(t, path)
+
+	info, _ := tasks.GetTask("t1")
+	engine.importSidecarIfConfigured("t1", "review", info)
+
+	got, _ := tasks.GetTask("t1")
+	if got.CodeReview != body {
+		t.Errorf("CodeReview = %q, want %q", got.CodeReview, body)
+	}
+}
+
+func TestImportSidecar_MissingFileIsLoggedNotFatal(t *testing.T) {
+	engine, tasks := importSidecarFixture(t, filepath.Join(t.TempDir(), "missing.md"))
+
+	info, _ := tasks.GetTask("t1")
+	engine.importSidecarIfConfigured("t1", "review", info)
+
+	got, _ := tasks.GetTask("t1")
+	if got.CodeReview != "" {
+		t.Errorf("CodeReview = %q, want empty (require_sidecar should surface)", got.CodeReview)
+	}
+}
+
+func TestImportSidecar_NoConfigIsNoop(t *testing.T) {
+	store := newTestStore(t) // test-simple.yaml has no import_sidecar
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{
+		ID: "t1",
+		Workflow: &Execution{
+			WorkflowID:  "test-simple",
+			CurrentStep: "implement",
+		},
+	})
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+
+	info, _ := tasks.GetTask("t1")
+	engine.importSidecarIfConfigured("t1", "implement", info)
+
+	got, _ := tasks.GetTask("t1")
+	if got.CodeReview != "" || got.PlanCritique != "" {
+		t.Errorf("sidecars touched without config: code=%q plan=%q", got.CodeReview, got.PlanCritique)
+	}
+}
+
+func TestImportSidecar_NoWorkflowIsNoop(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1"}) // no Workflow attached
+	engine := NewEngine(newTestStore(t), tasks, newMockAgents(), discardLogger())
+
+	info, _ := tasks.GetTask("t1")
+	engine.importSidecarIfConfigured("t1", "review", info) // must not panic
+}
+
+func TestImportSidecar_UnknownKindLogsAndDoesNotWrite(t *testing.T) {
+	store := newTestStoreWith(t, "test-import-sidecar-bad-kind.yaml")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "review.md")
+	if err := os.WriteFile(path, []byte("body"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{
+		ID: "t1",
+		Workflow: &Execution{
+			WorkflowID:  "test-import-sidecar-bad-kind",
+			CurrentStep: "review",
+			Variables:   map[string]string{"sidecar_path": path},
+		},
+	})
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+
+	info, _ := tasks.GetTask("t1")
+	engine.importSidecarIfConfigured("t1", "review", info) // must not panic
+
+	got, _ := tasks.GetTask("t1")
+	if got.CodeReview != "" || got.PlanCritique != "" {
+		t.Errorf("unknown kind silently wrote a sidecar: code=%q plan=%q", got.CodeReview, got.PlanCritique)
+	}
+}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -148,6 +148,24 @@ func (m *memTasks) SetWorkflow(id string, wf *Execution) error {
 	return nil
 }
 
+func (m *memTasks) WriteSidecar(id, kind, content string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	t, ok := m.tasks[id]
+	if !ok {
+		return fmt.Errorf("task %s not found", id)
+	}
+	switch kind {
+	case "code_review":
+		t.CodeReview = content
+	case "plan_critique":
+		t.PlanCritique = content
+	default:
+		return fmt.Errorf("unknown sidecar kind %q", kind)
+	}
+	return nil
+}
+
 // SetStatus is a test helper to simulate an agent changing task status.
 func (m *memTasks) SetStatus(id, status string) {
 	m.mu.Lock()

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -131,6 +131,26 @@ type StepConfig struct {
 	// require_sidecar: which sidecar must be non-empty for the step to pass.
 	// Valid values: "plan_critique", "code_review".
 	Sidecar string `yaml:"sidecar,omitempty" json:"sidecar"`
+
+	// run_agent: when set, the engine ingests a file produced by the agent
+	// (typically under /tmp) and stores its content as the named task
+	// sidecar after the agent exits. Lets review/critique steps work with
+	// codex agents whose sandbox blocks writes outside the worktree —
+	// the engine runs on the host with full filesystem access and closes
+	// the gap. Read failures are logged, not fatal: the require_sidecar
+	// guard still flips the task to human-required when the sidecar ends
+	// up empty, preserving the existing safety net.
+	ImportSidecar *ImportSidecar `yaml:"import_sidecar,omitempty" json:"importSidecar,omitempty"`
+}
+
+// ImportSidecar describes a sidecar file the engine should ingest after a
+// run_agent step succeeds.
+type ImportSidecar struct {
+	// Kind is the sidecar slot to populate: "code_review" or "plan_critique".
+	Kind string `yaml:"kind" json:"kind"`
+	// From is a Go template path the engine renders against the run's
+	// TemplateContext (e.g. /tmp/sybra-review-{{.Task.ID}}.md).
+	From string `yaml:"from" json:"from"`
 }
 
 const maxRetries = 10

--- a/internal/workflow/testdata/test-import-sidecar-bad-kind.yaml
+++ b/internal/workflow/testdata/test-import-sidecar-bad-kind.yaml
@@ -1,0 +1,18 @@
+id: test-import-sidecar-bad-kind
+name: Test Import Sidecar Bad Kind
+description: Variant with an unknown sidecar kind to verify graceful failure
+trigger:
+  on: task.created
+steps:
+  - id: review
+    name: Code Review
+    type: run_agent
+    config:
+      role: review
+      mode: headless
+      prompt: "review {{.Task.ID}}"
+      import_sidecar:
+        kind: not_a_real_kind
+        from: '{{getvar .Vars "sidecar_path"}}'
+    next:
+      - goto: ""

--- a/internal/workflow/testdata/test-import-sidecar.yaml
+++ b/internal/workflow/testdata/test-import-sidecar.yaml
@@ -1,0 +1,18 @@
+id: test-import-sidecar
+name: Test Import Sidecar
+description: Single-step workflow exercising import_sidecar
+trigger:
+  on: task.created
+steps:
+  - id: review
+    name: Code Review
+    type: run_agent
+    config:
+      role: review
+      mode: headless
+      prompt: "review {{.Task.ID}}"
+      import_sidecar:
+        kind: code_review
+        from: '{{getvar .Vars "sidecar_path"}}'
+    next:
+      - goto: ""


### PR DESCRIPTION
## Motivation

Codex review/critique agents run with `--sandbox workspace-write`, which blocks writes outside the worktree and scratch storage. The agent prompt instructed them to call `sybra-cli update --code-review-file …` (or `--plan-critique-file`) to persist the sidecar — but `sybra-cli` writes to `~/.sybra/tasks/`, a path the codex sandbox refuses. The agent exited cleanly, the file landed in `/tmp`, and `require_sidecar` flipped the task to `human-required` because the sidecar slot stayed empty.

Concrete failure: `4990f37c` (lightroom-mcp). Codex review verdict was "approve, no findings" but the task got stuck on the require_code_review guard.

## Implementation information

Move sidecar ingestion off the agent and onto the engine:

- New `ImportSidecar { Kind, From }` on `run_agent` step config (`internal/workflow/model.go`). `Kind` is `code_review` or `plan_critique`; `From` is a Go-template path rendered against the run's `TemplateContext`.
- `WriteSidecar(id, kind, content)` added to the `TaskProvider` interface and implemented on `taskAdapter` via `task.Update{CodeReview|PlanCritique}`.
- `Engine.HandleAgentComplete` calls `importSidecarIfConfigured` on success: render path, read file, write sidecar. Read failures log + return; the existing `require_sidecar` guard still surfaces empty sidecars by flipping to `human-required`.
- Built-in workflows (`simple-task.yaml`, `testing-task.yaml`) drop the `sybra-cli` line from review/critique prompts and declare `import_sidecar` instead. Worded prompts to make clear sybra ingests the file post-exit.
- Tests: 5 cases in `engine_import_sidecar_test.go` (happy path, missing file, no config, no workflow, unknown kind) + 2 testdata fixtures. All workflow + sybra tests pass; `golangci-lint` clean on touched packages.

### Alternatives considered

- **Widen the codex sandbox** to make `~/.sybra/tasks/` writable (`-c sandbox_workspace_write.writable_roots=…`). Couples the sandbox config to the filesystem layout and leaves agents that write *anywhere* outside the worktree exposed to the next sandbox tightening. Rejected.
- **Disable the codex sandbox entirely** (`SYBRA_DISABLE_CODEX_SANDBOX=1`). Too broad — gives reviewers `danger-full-access` for an avoidable reason.

## Supporting documentation

- Diagnosis context: task `4990f37c` log showed `Sandbox blocks that path here. write blocked on /Users/marcin.skalski/.sybra/tasks/4990f37c.review.md…tmp`.
- Same pattern applies to plan-critique runs (`require_plan_critique` guard) — fix covers both.

> Changelog: feat(workflow): engine ingests sidecar files