### PR TITLE
fix(ui): clamp task card title to 2 lines

### DIFF
--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -105,7 +105,7 @@
       {@const pm = priorityMeta(t.priority)}
       <span class="shrink-0 font-mono text-xs {pm.classes}" title="Priority: {pm.label}">{pm.icon}</span>
     {/if}
-    <h3 class="text-sm font-semibold leading-tight">{t.title}</h3>
+    <h3 class="line-clamp-2 text-sm font-semibold leading-tight">{t.title}</h3>
   </div>
 
   {#if t.statusReason}


### PR DESCRIPTION
## Motivation

Long task titles wrap across 3+ lines on board cards in smaller views, making the board hard to scan.

## Implementation information

Added `line-clamp-2` Tailwind utility to the `h3` title element in `TaskCard.svelte`. Titles longer than 2 lines are truncated with ellipsis.

> Changelog: fix(ui): clamp task card title to 2 lines