### PR TITLE
refactor(sync): migrate wg.Add/go/Done to wg.Go

### DIFF
--- a/internal/sandbox/integration_test.go
+++ b/internal/sandbox/integration_test.go
@@ -157,14 +157,12 @@ func TestDockerSandbox_ConcurrentTasks(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for i := range n {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			taskID := fmt.Sprintf("task-concurrent-%d", idx)
-			tasks[idx] = taskID
+		wg.Go(func() {
+			taskID := fmt.Sprintf("task-concurrent-%d", i)
+			tasks[i] = taskID
 			cfg := &project.SandboxConfig{Image: "nginx:alpine", Port: 80}
-			insts[idx], errs[idx] = m.Start(ctx, taskID, "", cfg)
-		}(i)
+			insts[i], errs[i] = m.Start(ctx, taskID, "", cfg)
+		})
 	}
 	wg.Wait()
 

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -4397,15 +4397,13 @@ func TestE2E_StatusHookStorm_NoDuplicateAdvance(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for i := range 120 {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
+		wg.Go(func() {
 			if i%3 == 0 {
 				env.engine.HandleStatusChange(created.ID, "plan-review")
 			} else {
 				env.engine.HandleStatusChange(created.ID, "todo")
 			}
-		}(i)
+		})
 	}
 	wg.Wait()
 
@@ -4571,11 +4569,9 @@ func TestE2E_InteractivePromptQueuePressure_NoDropOrCrash(t *testing.T) {
 	var wg sync.WaitGroup
 	errCh := make(chan error, 50)
 	for i := range 50 {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
+		wg.Go(func() {
 			errCh <- env.agents.SendPromptToAgent(ag.ID, fmt.Sprintf("msg-%d", i))
-		}(i)
+		})
 	}
 	wg.Wait()
 	close(errCh)

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -905,16 +905,14 @@ func TestStoreConcurrentCreate(t *testing.T) {
 	ids := make(chan string, n)
 	errs := make(chan error, n)
 	for i := range n {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
+		wg.Go(func() {
 			tk, cerr := store.Create(fmt.Sprintf("task-%d", i), "body", "headless")
 			if cerr != nil {
 				errs <- cerr
 				return
 			}
 			ids <- tk.ID
-		}(i)
+		})
 	}
 	wg.Wait()
 	close(ids)

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -3104,12 +3104,10 @@ func TestStartWorkflow_ConcurrentSameTaskSingleWinner(t *testing.T) {
 	errs := make([]error, callers)
 	start := make(chan struct{})
 	for i := range callers {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
 			errs[i] = engine.StartWorkflow("t1", "test-simple")
-		}(i)
+		})
 	}
 	close(start)
 	wg.Wait()


### PR DESCRIPTION
## Motivation

Replace the verbose `wg.Add(1); go func() { defer wg.Done(); ... }(i)` pattern with the idiomatic `wg.Go(func() { ... })` call available in Go 1.22+ sync.WaitGroup. Reduces boilerplate and eliminates the common mistake of forgetting `defer wg.Done()`.

## Implementation information

Updated four test files that used the old pattern:
- `internal/sandbox/integration_test.go`
- `internal/sybra/e2e_workflow_test.go`
- `internal/task/store_test.go`
- `internal/workflow/engine_test.go`

Each goroutine closure now captures loop variables directly (safe since Go 1.22 loop variable semantics), removing the need for explicit index parameters.

> Changelog: refactor(sync): migrate wg.Add/go/Done to wg.Go

Closes https://github.com/Automaat/sybra/issues/427