### PR TITLE
refactor(agent): replace sort.Slice with slices.SortFunc

### DIFF
--- a/internal/agent/skill_invoke.go
+++ b/internal/agent/skill_invoke.go
@@ -1,10 +1,11 @@
 package agent
 
 import (
+	"cmp"
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -22,7 +23,7 @@ func rewriteSkillInvocations(prompt string, skillNames []string) string {
 	// shorter prefix like "plan" consuming part of "plan-critic").
 	sorted := make([]string, len(skillNames))
 	copy(sorted, skillNames)
-	sort.Slice(sorted, func(i, j int) bool { return len(sorted[i]) > len(sorted[j]) })
+	slices.SortFunc(sorted, func(a, b string) int { return cmp.Compare(len(b), len(a)) })
 	for _, name := range sorted {
 		if name == "" {
 			continue

--- a/internal/agent/skill_invoke_test.go
+++ b/internal/agent/skill_invoke_test.go
@@ -10,9 +10,10 @@ func TestRewriteSkillInvocations(t *testing.T) {
 	t.Parallel()
 	skills := []string{"plan-critic", "sybra-triage", "sybra-plan", "staff-code-review"}
 	tests := []struct {
-		name string
-		in   string
-		want string
+		name   string
+		in     string
+		want   string
+		skills []string // nil = use package-level skills
 	}{
 		{
 			name: "leading slash invocation",
@@ -50,17 +51,26 @@ func TestRewriteSkillInvocations(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "no skill names leaves prompt untouched",
-			in:   "/plan-critic here",
-			want: "/plan-critic here",
+			name:   "no skill names leaves prompt untouched",
+			in:     "/plan-critic here",
+			want:   "/plan-critic here",
+			skills: []string{},
+		},
+		{
+			// Validates descending-length sort: "plan" must not consume the
+			// prefix of "plan-critic" when both are present.
+			name:   "overlapping names: longer match wins",
+			in:     "Run /plan-critic then /plan to finish.",
+			want:   "Run $plan-critic then $plan to finish.",
+			skills: []string{"plan", "plan-critic"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			names := skills
-			if tt.name == "no skill names leaves prompt untouched" {
-				names = nil
+			if tt.skills != nil {
+				names = tt.skills
 			}
 			got := rewriteSkillInvocations(tt.in, names)
 			if got != tt.want {


### PR DESCRIPTION
## Motivation

`sort.Slice` uses `interface{}` internally and requires capturing the slice twice (once for length, once in the less function). The `slices.SortFunc` from the Go 1.21 `slices` package is type-safe, more readable, and avoids the implicit closure overhead.

This is part of the broader tech-debt cleanup tracked in #428.

## Implementation information

Replaced `sort.Slice` call in `internal/agent/skill_invoke.go` with `slices.SortFunc`, using a direct comparison via `cmp.Compare`. Added a test covering the sort contract for overlapping skill names to pin the behaviour.

Closes https://github.com/Automaat/sybra/issues/428

> Changelog: refactor(agent): replace sort.Slice with slices.SortFunc