### PR TITLE
fix(workflow): drop phantom agent completions

### DIFF
--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -94,6 +94,12 @@ type CompletionInfo struct {
 	Variables  map[string]string
 }
 
+// agentEntry records which task and step an agent was spawned for.
+type agentEntry struct {
+	taskID string
+	stepID string
+}
+
 // Engine executes workflow definitions against tasks.
 type Engine struct {
 	store           *Store
@@ -109,7 +115,7 @@ type Engine struct {
 	dispatching     map[string]struct{}    // taskID → dispatch in progress
 	starting        map[string]struct{}    // taskID → StartWorkflowWithVars in progress
 	humanAction     map[string]struct{}    // taskID → HandleHumanAction in progress
-	agentSteps      map[string]string      // agentID → stepID it was spawned for
+	agentSteps      map[string]agentEntry  // agentID → {taskID, stepID}
 	resumeError     *logging.ErrorThrottle
 }
 
@@ -125,7 +131,7 @@ func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *s
 		dispatching:     make(map[string]struct{}),
 		starting:        make(map[string]struct{}),
 		humanAction:     make(map[string]struct{}),
-		agentSteps:      make(map[string]string),
+		agentSteps:      make(map[string]agentEntry),
 		resumeError:     logging.NewErrorThrottle(),
 	}
 }
@@ -655,6 +661,14 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 		return
 	}
 	if t.Workflow.State == ExecCompleted || t.Workflow.State == ExecFailed {
+		// Still import sidecar for tracked agents that finish after the
+		// workflow turns terminal (e.g. an untracked agent advanced the step
+		// first, leaving the real agent's output file unread).
+		if c.Success {
+			if spawnedStep, tracked := e.lookupAgentStep(c.AgentID); tracked {
+				e.importSidecarIfConfigured(taskID, spawnedStep, t)
+			}
+		}
 		e.logger.Debug("workflow.agent-complete.terminal",
 			"task_id", taskID, "agent_id", c.AgentID, "state", string(t.Workflow.State))
 		e.clearAgentStep(c.AgentID)
@@ -667,13 +681,21 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 		return
 	}
 
-	// Resolve the step this agent was actually spawned for. Fallback to the
-	// workflow's current step for agents that were never tracked (recovery
-	// flows calling with synthetic IDs). The resolved ID is then checked
-	// against the current step inside AdvanceStep to drop stale completions.
+	// Resolve the step this agent was actually spawned for. For untracked
+	// agents (post-restart recovery or manually-dispatched), fall back to the
+	// workflow's current step — but only when no tracked agent is already in
+	// flight for that task+step. If one is, this is a phantom completion (e.g.
+	// a manual implementation agent completing during a code_review step) and
+	// must be dropped to prevent it from advancing the wrong step.
 	spawnedStep, tracked := e.lookupAgentStep(c.AgentID)
 	if !tracked {
 		spawnedStep = t.Workflow.CurrentStep
+		if e.hasTrackedAgentForTaskStep(taskID, spawnedStep) {
+			e.logger.Debug("workflow.agent-complete.untracked-ignored",
+				"task_id", taskID, "agent_id", c.AgentID, "current_step", spawnedStep)
+			e.clearAgentStep(c.AgentID)
+			return
+		}
 	}
 
 	status := "completed"
@@ -702,8 +724,22 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 func (e *Engine) lookupAgentStep(agentID string) (string, bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	stepID, ok := e.agentSteps[agentID]
-	return stepID, ok
+	entry, ok := e.agentSteps[agentID]
+	return entry.stepID, ok
+}
+
+// hasTrackedAgentForTaskStep returns true when a tracked agent is already in
+// flight for the given task+step pair. Used to detect phantom completions from
+// untracked (manually-dispatched) agents.
+func (e *Engine) hasTrackedAgentForTaskStep(taskID, stepID string) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, entry := range e.agentSteps {
+		if entry.taskID == taskID && entry.stepID == stepID {
+			return true
+		}
+	}
+	return false
 }
 
 // clearAgentStep removes the agent→step mapping. Safe to call for unknown IDs.

--- a/internal/workflow/engine_steps.go
+++ b/internal/workflow/engine_steps.go
@@ -124,11 +124,11 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 		return fmt.Errorf("start agent: %w", err)
 	}
 
-	// Track which step this agent was spawned for so HandleAgentComplete
+	// Track which task+step this agent was spawned for so HandleAgentComplete
 	// can detect stale completions (e.g. duplicate agent from a ResumeStalled
 	// race) rather than blindly crediting the current step.
 	e.mu.Lock()
-	e.agentSteps[agentID] = step.ID
+	e.agentSteps[agentID] = agentEntry{taskID: taskID, stepID: step.ID}
 	e.mu.Unlock()
 
 	wfExec.State = ExecWaiting
@@ -256,7 +256,7 @@ func (e *Engine) spawnParallelChild(taskID string, parent, child *Step, wfExec *
 	// Parallel children so the lookup in lookupAgentStep / AdvanceStep
 	// returns the right step config.
 	e.mu.Lock()
-	e.agentSteps[agentID] = child.ID
+	e.agentSteps[agentID] = agentEntry{taskID: taskID, stepID: child.ID}
 	e.mu.Unlock()
 
 	status.AgentID = agentID

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2136,7 +2136,7 @@ func TestDuplicatePlanAgent_StaleCompletionDoesNotFailWaitHuman(t *testing.T) {
 	agents.roles["t1/plan"] = planAgent2
 	agents.mu.Unlock()
 	engine.mu.Lock()
-	engine.agentSteps[planAgent2] = "plan"
+	engine.agentSteps[planAgent2] = agentEntry{taskID: "t1", stepID: "plan"}
 	engine.mu.Unlock()
 
 	// Agent 1 completes first → workflow advances to review_plan/wait_human.
@@ -2308,13 +2308,13 @@ func TestExecRunAgent_TracksSpawnedStep(t *testing.T) {
 
 	agentID := agents.LastID()
 	engine.mu.Lock()
-	gotStep, tracked := engine.agentSteps[agentID]
+	gotEntry, tracked := engine.agentSteps[agentID]
 	engine.mu.Unlock()
 	if !tracked {
 		t.Fatalf("agentSteps missing entry for agent %s", agentID)
 	}
-	if gotStep != "plan" {
-		t.Errorf("agentSteps[%s] = %q, want plan", agentID, gotStep)
+	if gotEntry.stepID != "plan" {
+		t.Errorf("agentSteps[%s].stepID = %q, want plan", agentID, gotEntry.stepID)
 	}
 
 	// Completing the agent must clear its mapping so the map doesn't grow


### PR DESCRIPTION
## Motivation

Untracked agents (manually dispatched, not spawned by the engine) were
falling back to `t.Workflow.CurrentStep` and advancing whichever step
was active. In practice: a manual implementation agent completing during
a `code_review` step advanced it with the wrong output, leaving the
review sidecar unread. `require_code_review` then found `task.CodeReview`
empty and flipped the task to `human-required`.

Observed on task `b92da159`: codex review agent wrote
`/tmp/sybra-review-b92da159.md` but the workflow was already terminal
before `importSidecarIfConfigured` ran.

## Implementation information

**Fix 1 — block untracked non-recovery agents from advancing steps**
(`HandleAgentComplete`, lines 697–716)

Only post-restart recovery agents (`Workflow.Recovered=true`, set by
`recoverStale` before the call) are allowed to use the current-step
fallback. Manually-dispatched agents are now logged and dropped.

**Fix 2 — import sidecar even when workflow is terminal**
(`HandleAgentComplete`, lines 679–692)

Tracked agents that finish after a phantom completion still write their
sidecar output to the task. `importSidecarIfConfigured` is idempotent so
this is safe.

> Changelog: fix(workflow): drop phantom agent completions