### PR TITLE
refactor(stores): type EventsOn callbacks, drop any

### DIFF
--- a/frontend/src/stores/issues.svelte.ts
+++ b/frontend/src/stores/issues.svelte.ts
@@ -27,7 +27,7 @@ class IssueStore {
 
   listen(): void {
     this.stopListening()
-    this.cancelListener = EventsOn(IssuesUpdated, (issues: any) => {
+    this.cancelListener = EventsOn(IssuesUpdated, (issues: github.Issue[]) => {
       this.issues = issues ?? []
     })
   }

--- a/frontend/src/stores/renovate.svelte.ts
+++ b/frontend/src/stores/renovate.svelte.ts
@@ -40,7 +40,7 @@ class RenovateStore {
 
   listen(): void {
     this.stopListening()
-    this.cancelListener = EventsOn(RenovateUpdated, (prs: any) => {
+    this.cancelListener = EventsOn(RenovateUpdated, (prs: github.RenovatePR[]) => {
       this.prs = prs ?? []
     })
   }

--- a/frontend/src/stores/reviews.svelte.ts
+++ b/frontend/src/stores/reviews.svelte.ts
@@ -60,7 +60,7 @@ class ReviewStore {
 
   listen(): void {
     this.stopListening()
-    this.cancelListener = EventsOn(ReviewsUpdated, (summary: any) => {
+    this.cancelListener = EventsOn(ReviewsUpdated, (summary: github.ReviewSummary) => {
       this.createdByMe = summary.createdByMe ?? []
       this.reviewRequested = summary.reviewRequested ?? []
     })


### PR DESCRIPTION
## Motivation

Frontend stores were using `any` as the callback type for `runtime.EventsOn` subscriptions, bypassing TypeScript's type system and hiding potential type mismatches at the call sites.

## Implementation information

Replaced `any` with concrete payload types in the three affected stores:
- `issues.svelte.ts` — typed to the issues event payload
- `renovate.svelte.ts` — typed to the renovate event payload
- `reviews.svelte.ts` — typed to the reviews event payload

This is a pure type-level change; no runtime behaviour is altered.

Closes https://github.com/Automaat/sybra/issues/431