### PR TITLE
feat(review): auto-diagnose human-required

### DIFF
--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -112,6 +112,19 @@
     <p class="mb-1.5 line-clamp-2 text-xs text-warning-600 dark:text-warning-400">{t.statusReason}</p>
   {/if}
 
+  {#if t.blockedByIssue}
+    <a
+      href={t.blockedByIssue}
+      target="_blank"
+      rel="noopener"
+      onclick={(e) => e.stopPropagation()}
+      class="mb-1.5 inline-flex items-center gap-1 text-xs text-error-700 hover:underline dark:text-error-300"
+    >
+      <svg class="h-3 w-3 shrink-0" viewBox="0 0 16 16" fill="currentColor"><title>Issue</title><path d="M8 1.5a6.5 6.5 0 1 1 0 13 6.5 6.5 0 0 1 0-13Zm0 1a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11Zm0 2a.75.75 0 0 1 .75.75v3a.75.75 0 0 1-1.5 0v-3A.75.75 0 0 1 8 4.5Zm0 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2Z"/></svg>
+      Blocked by Sybra bug
+    </a>
+  {/if}
+
   <div class="flex flex-wrap items-center gap-1.5 text-xs text-surface-500">
     <span class="rounded bg-surface-200 px-1.5 py-0.5 dark:bg-surface-700">
       {t.agentMode}

--- a/frontend/src/lib/statuses.ts
+++ b/frontend/src/lib/statuses.ts
@@ -8,6 +8,7 @@ export type TaskStatus =
   | 'testing'
   | 'test-plan-review'
   | 'human-required'
+  | 'blocked'
   | 'done'
   | 'cancelled'
 
@@ -75,6 +76,12 @@ export const ALL_STATUSES: StatusMeta[] = [
     pillClasses: 'bg-error-200 text-error-800 dark:bg-error-700 dark:text-error-200',
   },
   {
+    value: 'blocked',
+    label: 'Blocked',
+    badgeClasses: 'bg-error-100 text-error-700 dark:bg-error-800 dark:text-error-300',
+    pillClasses: 'bg-error-100 text-error-700 dark:bg-error-800 dark:text-error-300',
+  },
+  {
     value: 'done',
     label: 'Done',
     badgeClasses: 'bg-success-200 text-success-800 dark:bg-success-700 dark:text-success-200',
@@ -113,5 +120,5 @@ export const BOARD_COLUMNS: BoardColumn[] = [
   { status: 'in-progress', label: 'In Progress', border: 'border-t-primary-500 dark:border-t-primary-400', includes: [] },
   { status: 'in-review', label: 'In Review', border: 'border-t-warning-500 dark:border-t-warning-400', includes: [] },
   { status: 'testing', label: 'Testing', border: 'border-t-secondary-500 dark:border-t-secondary-400', includes: ['testing', 'test-plan-review'] },
-  { status: 'human-required', label: 'Human Required', border: 'border-t-error-500 dark:border-t-error-400', includes: [] },
+  { status: 'human-required', label: 'Human Required', border: 'border-t-error-500 dark:border-t-error-400', includes: ['human-required', 'blocked'] },
 ]

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1460,6 +1460,7 @@ export namespace task {
 	    prNumber: number;
 	    issue: string;
 	    statusReason: string;
+	    blockedByIssue?: string;
 	    reviewed: boolean;
 	    runRole: string;
 	    todoistId: string;
@@ -1501,6 +1502,7 @@ export namespace task {
 	        this.prNumber = source["prNumber"];
 	        this.issue = source["issue"];
 	        this.statusReason = source["statusReason"];
+	        this.blockedByIssue = source["blockedByIssue"];
 	        this.reviewed = source["reviewed"];
 	        this.runRole = source["runRole"];
 	        this.todoistId = source["todoistId"];

--- a/internal/agent/role.go
+++ b/internal/agent/role.go
@@ -17,6 +17,7 @@ const (
 	RoleTestPlanCritic Role = "test-plan-critic"
 	RoleTestRunner     Role = "test-runner"
 	RoleImplementation Role = "implementation"
+	RoleHumanReview    Role = "human-review"
 )
 
 // AgentName returns the prefixed name used when launching an agent
@@ -24,9 +25,9 @@ const (
 func (r Role) AgentName(title string) string { return string(r) + ":" + title }
 
 // IsSystem returns true for roles whose agents should not trigger
-// user-facing notifications (triage, eval, plan-critic).
+// user-facing notifications (triage, eval, plan-critic, human-review).
 func (r Role) IsSystem() bool {
-	return r == RoleTriage || r == RoleEval || r == RolePlanCritic || r == RoleTestPlanCritic
+	return r == RoleTriage || r == RoleEval || r == RolePlanCritic || r == RoleTestPlanCritic || r == RoleHumanReview
 }
 
 // RoleFromName extracts the Role from a prefixed agent name.
@@ -38,7 +39,7 @@ func RoleFromName(name string) Role {
 	}
 	r := Role(prefix)
 	switch r {
-	case RoleTriage, RolePlan, RolePlanCritic, RoleEval, RolePRFix, RoleReview, RoleFixReview, RoleTestPlan, RoleTestPlanCritic, RoleTestRunner:
+	case RoleTriage, RolePlan, RolePlanCritic, RoleEval, RolePRFix, RoleReview, RoleFixReview, RoleTestPlan, RoleTestPlanCritic, RoleTestRunner, RoleHumanReview:
 		return r
 	default:
 		return RoleImplementation

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -32,6 +32,10 @@ const (
 	EventHealthReport        = "health.report"
 	EventAgentStartFailed    = "agent.start_failed"
 	EventProviderGateBlocked = "provider.gate_blocked"
+	EventHumanReviewSpawned  = "human_review.spawned"
+	EventHumanReviewVerdict  = "human_review.verdict"
+	EventHumanReviewIssue    = "human_review.issue_filed"
+	EventHumanReviewSkipped  = "human_review.skipped"
 )
 
 type Event struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Renovate      RenovateConfig     `yaml:"renovate" json:"renovate"`
 	GitHub        GitHubConfig       `yaml:"github" json:"github"`
 	Triage        TriageConfig       `yaml:"triage" json:"triage"`
+	HumanReview   HumanReviewConfig  `yaml:"human_review" json:"humanReview"`
 	Monitor       MonitorConfig      `yaml:"monitor" json:"monitor"`
 	SelfMonitor   SelfMonitorConfig  `yaml:"self_monitor" json:"selfMonitor"`
 	Providers     ProvidersConfig    `yaml:"providers" json:"providers"`
@@ -141,6 +142,67 @@ type TriageConfig struct {
 	Enabled     bool   `yaml:"enabled" json:"enabled"`
 	PollSeconds int    `yaml:"poll_seconds" json:"pollSeconds"`
 	Model       string `yaml:"model" json:"model"`
+}
+
+// HumanReviewConfig controls the in-process automation that spawns a
+// headless review agent every time a task transitions to human-required.
+// The agent inspects the task, its agent runs, recent logs and the Sybra
+// source tree, decides whether the transition is genuine or a Sybra bug,
+// and (on bug) files a deduplicated GitHub issue + flips the task to
+// blocked. Per-machine toggle: enable on the laptop with the source
+// checkout, leave disabled on the server.
+type HumanReviewConfig struct {
+	Enabled      bool   `yaml:"enabled" json:"enabled"`
+	SybraRepoDir string `yaml:"sybra_repo_dir" json:"sybraRepoDir"`
+	// Repo is the owner/name where bug issues are filed. Defaults to
+	// "Automaat/sybra" when empty.
+	Repo string `yaml:"repo" json:"repo"`
+	// Model is the Claude model alias (e.g. "sonnet", "opus"). Defaults
+	// to "sonnet" when empty.
+	Model string `yaml:"model" json:"model"`
+	// MaxPerHour caps how many review agents may be spawned in any rolling
+	// 60-minute window across all tasks on this machine. Zero falls back
+	// to DefaultHumanReviewMaxPerHour.
+	MaxPerHour int `yaml:"max_per_hour" json:"maxPerHour"`
+	// IssueLabel is the label applied to filed issues (in addition to
+	// "bug"). Defaults to "sybra-bug".
+	IssueLabel string `yaml:"issue_label" json:"issueLabel"`
+}
+
+// DefaultHumanReviewMaxPerHour is the fallback rate-limit cap used when
+// HumanReviewConfig.MaxPerHour is zero.
+const DefaultHumanReviewMaxPerHour = 6
+
+// HumanReviewMaxPerHour returns the configured cap or the package default.
+func (c *Config) HumanReviewMaxPerHour() int {
+	if c != nil && c.HumanReview.MaxPerHour > 0 {
+		return c.HumanReview.MaxPerHour
+	}
+	return DefaultHumanReviewMaxPerHour
+}
+
+// HumanReviewRepo returns the configured target repo or "Automaat/sybra".
+func (c *Config) HumanReviewRepo() string {
+	if c != nil && c.HumanReview.Repo != "" {
+		return c.HumanReview.Repo
+	}
+	return "Automaat/sybra"
+}
+
+// HumanReviewModel returns the configured model alias or "sonnet".
+func (c *Config) HumanReviewModel() string {
+	if c != nil && c.HumanReview.Model != "" {
+		return c.HumanReview.Model
+	}
+	return "sonnet"
+}
+
+// HumanReviewIssueLabel returns the configured label or "sybra-bug".
+func (c *Config) HumanReviewIssueLabel() string {
+	if c != nil && c.HumanReview.IssueLabel != "" {
+		return c.HumanReview.IssueLabel
+	}
+	return "sybra-bug"
 }
 
 // SelfMonitorConfig controls the in-process selfmonitor service that

--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -67,7 +67,7 @@ func countByStatus(tasks []task.Task) Counts {
 		case task.StatusDone:
 			c.Done++
 		case task.StatusPlanning, task.StatusTesting, task.StatusTestPlanReview,
-			task.StatusCancelled:
+			task.StatusBlocked, task.StatusCancelled:
 			// Tracked in ByStatus only — not promoted to a top-level counter.
 		}
 	}

--- a/internal/monitor/issuesink.go
+++ b/internal/monitor/issuesink.go
@@ -60,27 +60,68 @@ func NewGHIssueSink(label, repo string) *GHIssueSink {
 // (created=true) when a new issue was created, (false) when an existing issue
 // was commented.
 func (s *GHIssueSink) Submit(ctx context.Context, a Anomaly, body string) (bool, error) {
+	created, _, err := s.SubmitIssue(ctx, IssueTitle(a.Kind, a.Fingerprint), body, []string{"bug"})
+	return created, err
+}
+
+// SubmitIssue is the generic, anomaly-agnostic dedup-and-file primitive used
+// by Submit and by other in-process automations (e.g. human-review). Behavior
+// is identical to Submit: finds an open issue with the sink's primary label
+// and matching title, comments on hit, creates on miss.
+//
+// extraLabels are appended to the sink's primary label on create. The dedup
+// search still filters by the primary label, so callers that want a separate
+// issue stream should construct their own sink with a dedicated label.
+//
+// Returns (created, url, err): url is the GitHub URL of the existing
+// (commented) or newly created issue, parsed from gh's stdout. url may be
+// empty if gh's output cannot be parsed but the operation otherwise
+// succeeded.
+func (s *GHIssueSink) SubmitIssue(ctx context.Context, title, body string, extraLabels []string) (created bool, url string, err error) {
 	s.labelsOnce.Do(func() { s.ensureLabels(ctx) })
 
-	title := IssueTitle(a.Kind, a.Fingerprint)
-	num, err := s.findOpenIssue(ctx, title)
+	num, foundURL, err := s.findOpenIssue(ctx, title)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 	if num > 0 {
-		if _, err := s.exec.run(ctx, append(s.repoArgs(), "issue", "comment", fmt.Sprint(num), "--body", body)...); err != nil {
-			return false, classifyGHError(err)
+		if _, runErr := s.exec.run(ctx, append(s.repoArgs(), "issue", "comment", fmt.Sprint(num), "--body", body)...); runErr != nil {
+			return false, foundURL, classifyGHError(runErr)
 		}
-		return false, nil
+		return false, foundURL, nil
 	}
-	if _, err := s.exec.run(ctx, append(s.repoArgs(), "issue", "create",
+	var lb strings.Builder
+	lb.WriteString(s.label)
+	for _, extra := range extraLabels {
+		extra = strings.TrimSpace(extra)
+		if extra == "" || extra == s.label {
+			continue
+		}
+		lb.WriteString(",")
+		lb.WriteString(extra)
+	}
+	out, err := s.exec.run(ctx, append(s.repoArgs(), "issue", "create",
 		"--title", title,
 		"--body", body,
-		"--label", s.label+",bug",
-	)...); err != nil {
-		return false, classifyGHError(err)
+		"--label", lb.String(),
+	)...)
+	if err != nil {
+		return false, "", classifyGHError(err)
 	}
-	return true, nil
+	return true, parseIssueCreateURL(out), nil
+}
+
+// parseIssueCreateURL pulls the first line of `gh issue create` stdout that
+// looks like a github.com issue URL. gh prints the URL on its own line; on
+// older versions it may also emit a "Creating issue ..." prefix.
+func parseIssueCreateURL(raw []byte) string {
+	for line := range strings.SplitSeq(string(raw), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "https://") && strings.Contains(line, "/issues/") {
+			return line
+		}
+	}
+	return ""
 }
 
 // repoArgs returns ["--repo", s.repo] when a repo is configured, or nil.
@@ -99,32 +140,36 @@ func (s *GHIssueSink) ensureLabels(ctx context.Context) {
 	_, _ = s.exec.run(ctx, append(s.repoArgs(), "label", "create", "bug", "--color", "D73A4A", "--description", "Something isn't working")...)
 }
 
-func (s *GHIssueSink) findOpenIssue(ctx context.Context, title string) (int, error) {
+func (s *GHIssueSink) findOpenIssue(ctx context.Context, title string) (number int, url string, err error) {
 	out, err := s.exec.run(ctx, append(s.repoArgs(), "issue", "list",
 		"--state", "open",
 		"--label", s.label,
 		"--search", "in:title \""+title+"\"",
-		"--json", "number,title",
+		"--json", "number,title,url",
 		"--limit", "5",
 	)...)
 	if err != nil {
-		return 0, classifyGHError(err)
+		return 0, "", classifyGHError(err)
 	}
-	return parseFirstMatchingIssueNumber(out, title), nil
+	num, url := parseFirstMatchingIssue(out, title)
+	return num, url, nil
 }
 
-// parseFirstMatchingIssueNumber scans gh's `--json number,title` output and
-// returns the number of the first issue whose title equals (case-sensitive)
-// the requested title. Avoids importing encoding/json indirectly via a
-// generic struct just for the test path.
-func parseFirstMatchingIssueNumber(raw []byte, want string) int {
-	// gh emits `[{"number":N,"title":"..."},...]` — minimal handcrafted
-	// scan: find each "number":N followed by "title":"..." pair.
+// parseFirstMatchingIssue scans gh's `--json number,title,url` output and
+// returns the (number, url) of the first issue whose title equals
+// (case-sensitive) the requested title. Returns (0, "") on no match.
+// Avoids importing encoding/json indirectly via a generic struct just for
+// the test path.
+func parseFirstMatchingIssue(raw []byte, want string) (number int, url string) {
+	// gh emits `[{"number":N,"title":"...","url":"..."},...]` —
+	// minimal handcrafted scan: read each object's number, title, and (if
+	// the title matches) url. Field order in gh's output is alphabetical
+	// (number, title, url).
 	s := string(raw)
 	for {
 		nIdx := strings.Index(s, "\"number\":")
 		if nIdx < 0 {
-			return 0
+			return 0, ""
 		}
 		s = s[nIdx+len("\"number\":"):]
 		// Skip whitespace.
@@ -137,7 +182,7 @@ func parseFirstMatchingIssueNumber(raw []byte, want string) int {
 			end++
 		}
 		if end == 0 {
-			return 0
+			return 0, ""
 		}
 		num := 0
 		for i := range end {
@@ -147,18 +192,29 @@ func parseFirstMatchingIssueNumber(raw []byte, want string) int {
 		// Find the matching title field.
 		tIdx := strings.Index(s, "\"title\":\"")
 		if tIdx < 0 {
-			return 0
+			return 0, ""
 		}
 		s = s[tIdx+len("\"title\":\""):]
 		closing := strings.Index(s, "\"")
 		if closing < 0 {
-			return 0
+			return 0, ""
 		}
 		got := s[:closing]
-		if got == want {
-			return num
-		}
 		s = s[closing:]
+		if got != want {
+			continue
+		}
+		// Title matched — pull url if present (alphabetical, so it follows).
+		uIdx := strings.Index(s, "\"url\":\"")
+		if uIdx < 0 {
+			return num, ""
+		}
+		s = s[uIdx+len("\"url\":\""):]
+		urlPart, _, ok := strings.Cut(s, "\"")
+		if !ok {
+			return num, ""
+		}
+		return num, urlPart
 	}
 }
 

--- a/internal/monitor/service_test.go
+++ b/internal/monitor/service_test.go
@@ -283,16 +283,25 @@ func TestServiceScanHasNoSideEffects(t *testing.T) {
 	}
 }
 
-func TestParseFirstMatchingIssueNumber(t *testing.T) {
-	out := []byte(`[{"number":42,"title":"unrelated"},{"number":87,"title":"[monitor] failure_spike"}]`)
-	got := parseFirstMatchingIssueNumber(out, "[monitor] failure_spike")
-	if got != 87 {
-		t.Errorf("want 87, got %d", got)
+func TestParseFirstMatchingIssue(t *testing.T) {
+	out := []byte(`[{"number":42,"title":"unrelated","url":"https://github.com/o/r/issues/42"},{"number":87,"title":"[monitor] failure_spike","url":"https://github.com/o/r/issues/87"}]`)
+	num, url := parseFirstMatchingIssue(out, "[monitor] failure_spike")
+	if num != 87 {
+		t.Errorf("want number 87, got %d", num)
 	}
-	if parseFirstMatchingIssueNumber(out, "no such title") != 0 {
-		t.Errorf("expected zero for no match")
+	if url != "https://github.com/o/r/issues/87" {
+		t.Errorf("want url=.../issues/87, got %q", url)
 	}
-	if parseFirstMatchingIssueNumber([]byte("[]"), "anything") != 0 {
-		t.Errorf("expected zero for empty array")
+	if n, _ := parseFirstMatchingIssue(out, "no such title"); n != 0 {
+		t.Errorf("expected zero number for no match")
+	}
+	if n, _ := parseFirstMatchingIssue([]byte("[]"), "anything"); n != 0 {
+		t.Errorf("expected zero number for empty array")
+	}
+	// Backward-compat: number-only input (no url field) still matches.
+	bareOut := []byte(`[{"number":99,"title":"[monitor] failure_spike"}]`)
+	num2, url2 := parseFirstMatchingIssue(bareOut, "[monitor] failure_spike")
+	if num2 != 99 || url2 != "" {
+		t.Errorf("bare input: want (99, \"\"), got (%d, %q)", num2, url2)
 	}
 }

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -77,6 +77,7 @@ type App struct {
 	todoistCancel   context.CancelFunc
 	renovateHandler *poll.RenovateHandler
 	triageHandler   *poll.TriageHandler
+	humanReview     *humanReviewHandler
 	cfg             *config.Config
 	logLevel        *slog.LevelVar
 	emit            func(string, any)
@@ -278,10 +279,7 @@ func (a *App) Startup(ctx context.Context) error {
 		a.logger.Error("watcher.start", "err", err)
 	}
 
-	a.initTodoist(emit)
-	a.initRenovate(emit)
-	a.initTriage()
-	issuesFetcher := a.initIssuesFetcher(emit)
+	issuesFetcher := a.initAutomations(emit)
 	a.wireServices(emit)
 
 	a.syncSkills()
@@ -582,6 +580,7 @@ func (a *App) logAutomationsSummary() {
 		"github", a.cfg.GitHub.Enabled,
 		"renovate", a.cfg.Renovate.Enabled,
 		"triage", a.cfg.Triage.Enabled,
+		"human_review", a.humanReview != nil,
 		"project_types", projectTypes,
 		"loop_agents_enabled", loopAgentsEnabled,
 	)
@@ -624,6 +623,9 @@ func (a *App) initStatusHook() {
 				msg = t.Title
 			}
 			a.notifier.Send(notification.LevelWarning, "Needs human", msg, taskID, "")
+			if a.humanReview != nil {
+				go a.humanReview.maybeSpawn(taskID, from)
+			}
 		case string(task.StatusTesting):
 			if a.workflowEngine != nil {
 				if _, err := a.workflowEngine.DispatchEvent(
@@ -725,39 +727,7 @@ func (a *App) onAgentComplete(ag *agent.Agent) {
 		"log_file":   ag.LogPath,
 	})
 
-	if a.stats != nil {
-		in := ag.GetInputTokens()
-		out := ag.GetOutputTokens()
-		agCost := cost
-		if agCost == 0 && ag.Provider == "codex" {
-			agCost = stats.EstimateCost(ag.Model, in, out)
-		}
-		outcome := "failed"
-		if exitErr == nil {
-			outcome = "completed"
-		}
-		var projectID string
-		if ag.TaskID != "" {
-			if t, err := a.tasks.Get(ag.TaskID); err == nil {
-				projectID = t.ProjectID
-			}
-		}
-		_ = a.stats.Record(stats.RunRecord{
-			ID:           ag.ID,
-			TaskID:       ag.TaskID,
-			ProjectID:    projectID,
-			Mode:         ag.Mode,
-			Role:         string(agent.RoleFromName(ag.Name)),
-			Model:        ag.Model,
-			Provider:     ag.Provider,
-			CostUSD:      agCost,
-			DurationS:    duration,
-			InputTokens:  in,
-			OutputTokens: out,
-			Outcome:      outcome,
-			Timestamp:    time.Now(),
-		})
-	}
+	a.recordAgentRunStats(ag, cost, duration, exitErr)
 
 	// Loop agents run without a TaskID — let the scheduler record cost
 	// before the early return below kicks in.
@@ -787,6 +757,16 @@ func (a *App) onAgentComplete(ag *agent.Agent) {
 		a.logger.Error("task.update-run", "task_id", ag.TaskID, "agent_id", ag.ID, "err", err)
 	}
 
+	// Human-review agents are out-of-band diagnostics — they must not feed
+	// into the workflow engine (which would advance the step that originally
+	// caused the human-required transition based on the diagnostic verdict).
+	if agent.RoleFromName(ag.Name) == agent.RoleHumanReview {
+		if a.humanReview != nil {
+			a.humanReview.onComplete(ag)
+		}
+		return
+	}
+
 	// Advance workflow.
 	if a.workflowEngine != nil {
 		a.workflowEngine.HandleAgentComplete(ag.TaskID, workflow.AgentCompletion{
@@ -804,6 +784,56 @@ func (a *App) onAgentComplete(ag *agent.Agent) {
 			go a.sandboxes.Stop(ag.TaskID)
 		}
 	}
+}
+
+// initAutomations starts every per-machine task source in dependency order
+// and returns the GitHub issues fetcher (still consumed by
+// startBackgroundServices). Extracted so Startup stays under funlen.
+func (a *App) initAutomations(emit func(string, any)) *poll.IssuesFetcher {
+	a.initTodoist(emit)
+	a.initRenovate(emit)
+	a.initTriage()
+	a.initHumanReview()
+	return a.initIssuesFetcher(emit)
+}
+
+// recordAgentRunStats persists a stats.RunRecord for the completed agent.
+// Extracted from onAgentComplete to keep that function within funlen.
+func (a *App) recordAgentRunStats(ag *agent.Agent, cost, duration float64, exitErr error) {
+	if a.stats == nil {
+		return
+	}
+	in := ag.GetInputTokens()
+	out := ag.GetOutputTokens()
+	agCost := cost
+	if agCost == 0 && ag.Provider == "codex" {
+		agCost = stats.EstimateCost(ag.Model, in, out)
+	}
+	outcome := "failed"
+	if exitErr == nil {
+		outcome = "completed"
+	}
+	var projectID string
+	if ag.TaskID != "" {
+		if t, err := a.tasks.Get(ag.TaskID); err == nil {
+			projectID = t.ProjectID
+		}
+	}
+	_ = a.stats.Record(stats.RunRecord{
+		ID:           ag.ID,
+		TaskID:       ag.TaskID,
+		ProjectID:    projectID,
+		Mode:         ag.Mode,
+		Role:         string(agent.RoleFromName(ag.Name)),
+		Model:        ag.Model,
+		Provider:     ag.Provider,
+		CostUSD:      agCost,
+		DurationS:    duration,
+		InputTokens:  in,
+		OutputTokens: out,
+		Outcome:      outcome,
+		Timestamp:    time.Now(),
+	})
 }
 
 func (a *App) onWorkflowComplete(info workflow.CompletionInfo) {

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -422,12 +423,12 @@ func parseVerdict(text string) (verdictDecision, error) {
 // The fenced verdict block always lives in the last assistant turn.
 func finalAssistantText(ag *agent.Agent) string {
 	out := ag.Output()
-	for i := len(out) - 1; i >= 0; i-- {
+	for i := range slices.Backward(out) {
 		if out[i].Type == "assistant" && strings.Contains(out[i].Content, "sybra-verdict") {
 			return out[i].Content
 		}
 	}
-	for i := len(out) - 1; i >= 0; i-- {
+	for i := range slices.Backward(out) {
 		if out[i].Type == "result" {
 			return out[i].Content
 		}

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -1,0 +1,478 @@
+package sybra
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/monitor"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// humanReviewPromptHeadTail bounds how many lines of the host log file are
+// pulled into the review prompt. Keeps the prompt size predictable.
+const (
+	humanReviewLogTail        = 200
+	humanReviewMaxAgentRuns   = 5
+	humanReviewMaxAgentTurns  = 40
+	humanReviewMaxAgentResult = 4000
+	humanReviewWindow         = time.Hour
+)
+
+// humanReviewIssueFiler is the subset of monitor.GHIssueSink the handler
+// depends on. Stub-friendly for tests; production wiring uses
+// monitor.NewGHIssueSink.
+type humanReviewIssueFiler interface {
+	SubmitIssue(ctx context.Context, title, body string, extraLabels []string) (created bool, url string, err error)
+}
+
+// humanReviewHandler spawns a headless review agent each time a task
+// transitions into status=human-required. The agent inspects task state,
+// agent runs and Sybra logs/source, then emits a fenced verdict block
+// (see verdictDecision) which the handler turns into a side-effect:
+// genuine -> append a note; sybra_bug -> file a deduplicated GitHub issue
+// and flip the task to status=blocked.
+type humanReviewHandler struct {
+	cfg     *config.Config
+	tasks   *task.Manager
+	agents  *agent.Manager
+	audit   *audit.Logger
+	logger  *slog.Logger
+	sink    humanReviewIssueFiler
+	homeDir string
+	logFile string
+	now     func() time.Time
+
+	mu       sync.Mutex
+	inflight map[string]string // taskID -> agent ID
+	recent   []time.Time       // spawn timestamps (rolling window)
+}
+
+// verdictDecision is the agent's structured output. Captured from a fenced
+// ```sybra-verdict\n{ ... }\n``` block in the agent's final assistant message.
+type verdictDecision struct {
+	Decision    string   `json:"decision"` // "human" | "sybra_bug"
+	Summary     string   `json:"summary"`
+	IssueTitle  string   `json:"issue_title,omitempty"`
+	IssueBody   string   `json:"issue_body,omitempty"`
+	IssueLabels []string `json:"issue_labels,omitempty"`
+}
+
+func newHumanReviewHandler(
+	cfg *config.Config,
+	tasks *task.Manager,
+	agents *agent.Manager,
+	al *audit.Logger,
+	logger *slog.Logger,
+	sink humanReviewIssueFiler,
+	homeDir, logFile string,
+) *humanReviewHandler {
+	return &humanReviewHandler{
+		cfg:      cfg,
+		tasks:    tasks,
+		agents:   agents,
+		audit:    al,
+		logger:   logger,
+		sink:     sink,
+		homeDir:  homeDir,
+		logFile:  logFile,
+		now:      time.Now,
+		inflight: make(map[string]string),
+	}
+}
+
+// initHumanReview is called once during App.Startup. It is a no-op when the
+// feature is disabled or no Sybra source dir is configured.
+func (a *App) initHumanReview() {
+	if a.cfg == nil || !a.cfg.HumanReview.Enabled {
+		return
+	}
+	dir := strings.TrimSpace(a.cfg.HumanReview.SybraRepoDir)
+	if dir == "" {
+		a.logger.Warn("human-review.disabled", "reason", "sybra_repo_dir is empty")
+		return
+	}
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		a.logger.Warn("human-review.disabled", "reason", "sybra_repo_dir not a directory", "dir", dir, "err", err)
+		return
+	}
+	sink := monitor.NewGHIssueSink(a.cfg.HumanReviewIssueLabel(), a.cfg.HumanReviewRepo())
+	logFile := filepath.Join(a.logDir, "sybra.log")
+	a.humanReview = newHumanReviewHandler(a.cfg, a.tasks, a.agents, a.audit, a.logger, sink, config.HomeDir(), logFile)
+	a.logger.Info("human-review.enabled", "dir", dir, "repo", a.cfg.HumanReviewRepo(), "model", a.cfg.HumanReviewModel())
+}
+
+// maybeSpawn is called from the status hook when a task lands in
+// human-required. Returns immediately if the feature is disabled, the task
+// already has an in-flight review, or the rolling rate limit is exceeded.
+func (h *humanReviewHandler) maybeSpawn(taskID, prevStatus string) {
+	if h == nil {
+		return
+	}
+	// Don't loop when an unblock flow flips blocked → todo → human-required.
+	if prevStatus == string(task.StatusBlocked) {
+		h.skip(taskID, "prev_status_blocked")
+		return
+	}
+	t, err := h.tasks.Get(taskID)
+	if err != nil {
+		h.logger.Error("human-review.task.get", "task_id", taskID, "err", err)
+		return
+	}
+
+	h.mu.Lock()
+	if _, busy := h.inflight[taskID]; busy {
+		h.mu.Unlock()
+		h.skip(taskID, "in_flight")
+		return
+	}
+	if !h.allowSpawnLocked() {
+		h.mu.Unlock()
+		h.skip(taskID, "rate_limited")
+		return
+	}
+	// Reserve the slot before spawning so a racing second flip is rejected.
+	h.inflight[taskID] = ""
+	h.recent = append(h.recent, h.now())
+	h.mu.Unlock()
+
+	prompt := h.buildPrompt(t)
+	ag, err := h.agents.Run(agent.RunConfig{
+		TaskID:             taskID,
+		Name:               agent.RoleHumanReview.AgentName(t.Title),
+		Mode:               "headless",
+		Provider:           "claude",
+		Model:              h.cfg.HumanReviewModel(),
+		Prompt:             prompt,
+		Dir:                h.cfg.HumanReview.SybraRepoDir,
+		RequirePermissions: false,
+		OneShot:            true,
+	})
+	if err != nil {
+		h.mu.Lock()
+		delete(h.inflight, taskID)
+		h.mu.Unlock()
+		h.logger.Error("human-review.spawn", "task_id", taskID, "err", err)
+		h.logAudit(audit.EventHumanReviewSkipped, taskID, "", map[string]any{"reason": "spawn_failed", "err": err.Error()})
+		return
+	}
+	h.mu.Lock()
+	h.inflight[taskID] = ag.ID
+	h.mu.Unlock()
+
+	if err := h.tasks.AddRun(taskID, task.AgentRun{
+		AgentID:   ag.ID,
+		Role:      string(agent.RoleHumanReview),
+		Mode:      "headless",
+		Provider:  ag.Provider,
+		State:     string(agent.StateRunning),
+		StartedAt: ag.StartedAt,
+		Prompt:    prompt,
+	}); err != nil {
+		h.logger.Error("human-review.add-run", "task_id", taskID, "agent_id", ag.ID, "err", err)
+	}
+	h.logAudit(audit.EventHumanReviewSpawned, taskID, ag.ID, map[string]any{
+		"prev_status": prevStatus, "model": h.cfg.HumanReviewModel(),
+	})
+}
+
+// onComplete is the routing target inside App.onAgentComplete for runs whose
+// role is RoleHumanReview. It parses the verdict and applies side-effects.
+func (h *humanReviewHandler) onComplete(ag *agent.Agent) {
+	if h == nil || ag == nil {
+		return
+	}
+	taskID := ag.TaskID
+	defer func() {
+		h.mu.Lock()
+		delete(h.inflight, taskID)
+		h.mu.Unlock()
+	}()
+
+	final := finalAssistantText(ag)
+	v, parseErr := parseVerdict(final)
+	if parseErr != nil {
+		h.logger.Warn("human-review.verdict.parse", "task_id", taskID, "agent_id", ag.ID, "err", parseErr)
+		h.appendNote(taskID, "Auto-review (unparseable verdict)", final)
+		h.logAudit(audit.EventHumanReviewVerdict, taskID, ag.ID, map[string]any{"decision": "unparseable"})
+		return
+	}
+	h.logAudit(audit.EventHumanReviewVerdict, taskID, ag.ID, map[string]any{
+		"decision": v.Decision, "summary": v.Summary,
+	})
+
+	switch v.Decision {
+	case "human":
+		h.appendNote(taskID, "Auto-review verdict: needs human", v.Summary)
+	case "sybra_bug":
+		h.fileIssue(taskID, ag.ID, v)
+	default:
+		h.logger.Warn("human-review.verdict.unknown", "task_id", taskID, "decision", v.Decision)
+		h.appendNote(taskID, "Auto-review (unknown decision)", final)
+	}
+}
+
+func (h *humanReviewHandler) fileIssue(taskID, agentID string, v verdictDecision) {
+	if strings.TrimSpace(v.IssueTitle) == "" || strings.TrimSpace(v.IssueBody) == "" {
+		h.logger.Warn("human-review.issue.empty", "task_id", taskID, "agent_id", agentID)
+		h.appendNote(taskID, "Auto-review verdict: sybra_bug (no issue payload)", v.Summary)
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	created, url, err := h.sink.SubmitIssue(ctx, v.IssueTitle, v.IssueBody, v.IssueLabels)
+	if err != nil {
+		h.logger.Error("human-review.issue.submit", "task_id", taskID, "agent_id", agentID, "err", err)
+		// On rate limit or transient failure, leave the task in human-required
+		// and append the verdict so the user has the diagnosis text.
+		h.appendNote(taskID, "Auto-review verdict: sybra_bug (issue submission failed)", v.Summary+"\n\nError: "+err.Error())
+		return
+	}
+	h.logAudit(audit.EventHumanReviewIssue, taskID, agentID, map[string]any{
+		"created": created, "url": url, "title": v.IssueTitle,
+	})
+
+	body := fmt.Sprintf("**Linked Sybra bug:** %s\n\n%s", urlOrPlaceholder(url, v.IssueTitle), v.Summary)
+	header := "Auto-review verdict: blocked by Sybra bug"
+	if !created {
+		header = "Auto-review verdict: blocked by existing Sybra bug"
+	}
+	t, err := h.tasks.Get(taskID)
+	if err != nil {
+		h.logger.Error("human-review.task.get-after-submit", "task_id", taskID, "err", err)
+		return
+	}
+	newBody := appendSection(t.Body, header, body)
+	upd := task.Update{
+		Body:           &newBody,
+		Status:         task.Ptr(task.StatusBlocked),
+		StatusReason:   task.Ptr(fmt.Sprintf("auto-review: %s (%s)", v.Summary, urlOrPlaceholder(url, v.IssueTitle))),
+		BlockedByIssue: task.Ptr(url),
+	}
+	if _, err := h.tasks.Update(taskID, upd); err != nil {
+		h.logger.Error("human-review.task.update", "task_id", taskID, "err", err)
+	}
+}
+
+func (h *humanReviewHandler) appendNote(taskID, header, body string) {
+	if strings.TrimSpace(body) == "" {
+		return
+	}
+	t, err := h.tasks.Get(taskID)
+	if err != nil {
+		h.logger.Error("human-review.append.task-get", "task_id", taskID, "err", err)
+		return
+	}
+	newBody := appendSection(t.Body, header, body)
+	if _, err := h.tasks.Update(taskID, task.Update{Body: &newBody}); err != nil {
+		h.logger.Error("human-review.append.task-update", "task_id", taskID, "err", err)
+	}
+}
+
+func (h *humanReviewHandler) skip(taskID, reason string) {
+	h.logger.Info("human-review.skip", "task_id", taskID, "reason", reason)
+	h.logAudit(audit.EventHumanReviewSkipped, taskID, "", map[string]any{"reason": reason})
+}
+
+// allowSpawnLocked must be called with h.mu held. Trims expired entries from
+// h.recent and returns false if the configured rate is exceeded.
+func (h *humanReviewHandler) allowSpawnLocked() bool {
+	limit := h.cfg.HumanReviewMaxPerHour()
+	if limit <= 0 {
+		return false
+	}
+	cutoff := h.now().Add(-humanReviewWindow)
+	kept := h.recent[:0]
+	for _, ts := range h.recent {
+		if ts.After(cutoff) {
+			kept = append(kept, ts)
+		}
+	}
+	h.recent = kept
+	return len(h.recent) < limit
+}
+
+func (h *humanReviewHandler) logAudit(evt, taskID, agentID string, data map[string]any) {
+	if h.audit == nil {
+		return
+	}
+	if err := h.audit.Log(audit.Event{
+		Timestamp: h.now(),
+		Type:      evt,
+		TaskID:    taskID,
+		AgentID:   agentID,
+		Data:      data,
+	}); err != nil {
+		h.logger.Warn("human-review.audit.log", "type", evt, "task_id", taskID, "err", err)
+	}
+}
+
+// buildPrompt assembles the review agent's instructions and context. The
+// agent runs in the Sybra source tree with skip-permissions, so it can
+// freely grep the codebase + read host logs to diagnose the transition.
+func (h *humanReviewHandler) buildPrompt(t task.Task) string {
+	var b strings.Builder
+	b.WriteString("# Sybra auto-review of human-required transition\n\n")
+	b.WriteString("You are a diagnostic agent for Sybra (the desktop task orchestrator). A user task just transitioned to status=human-required. Decide whether this is genuinely a human-input situation or whether Sybra itself misbehaved (workflow misfire, agent mis-config, infrastructure flakiness, code bug). If it's a Sybra bug, prepare a GitHub issue payload — the host process will file it.\n\n")
+	b.WriteString("## Task\n")
+	fmt.Fprintf(&b, "- ID: %s\n- Title: %s\n- Status: %s\n", t.ID, t.Title, t.Status)
+	if t.StatusReason != "" {
+		fmt.Fprintf(&b, "- Status reason: %s\n", t.StatusReason)
+	}
+	if t.ProjectID != "" {
+		fmt.Fprintf(&b, "- Project: %s\n", t.ProjectID)
+	}
+	if t.PRNumber > 0 {
+		fmt.Fprintf(&b, "- PR: #%d\n", t.PRNumber)
+	}
+	b.WriteString("\n### Task body\n")
+	b.WriteString(strings.TrimSpace(t.Body))
+	b.WriteString("\n\n")
+
+	b.WriteString("## Recent agent runs\n")
+	runs := t.AgentRuns
+	if len(runs) > humanReviewMaxAgentRuns {
+		runs = runs[len(runs)-humanReviewMaxAgentRuns:]
+	}
+	if len(runs) == 0 {
+		b.WriteString("(none)\n")
+	} else {
+		for i := range runs {
+			r := runs[i]
+			fmt.Fprintf(&b, "\n### Run %d — role=%s mode=%s state=%s started=%s\n",
+				i+1, defaultStr(r.Role, "implementation"), r.Mode, r.State, r.StartedAt.Format(time.RFC3339))
+			if r.Result != "" {
+				res := r.Result
+				if len(res) > humanReviewMaxAgentResult {
+					res = res[:humanReviewMaxAgentResult] + "\n... (truncated)"
+				}
+				b.WriteString("Result:\n```\n")
+				b.WriteString(strings.TrimSpace(res))
+				b.WriteString("\n```\n")
+			}
+			if r.LogFile != "" {
+				fmt.Fprintf(&b, "Log file (read with Read tool, last %d turns are most useful): %s\n", humanReviewMaxAgentTurns, r.LogFile)
+			}
+		}
+	}
+	b.WriteString("\n")
+
+	if t.Workflow != nil {
+		b.WriteString("## Workflow execution\n")
+		fmt.Fprintf(&b, "- Workflow ID: %s\n- Started: %s\n- Current step: %s\n",
+			t.Workflow.WorkflowID, t.Workflow.StartedAt.Format(time.RFC3339), t.Workflow.CurrentStep)
+		b.WriteString("\n")
+	}
+
+	if tail := tailFile(h.logFile, humanReviewLogTail); tail != "" {
+		b.WriteString("## Sybra host log (tail)\n```\n")
+		b.WriteString(tail)
+		b.WriteString("\n```\n\n")
+	}
+
+	b.WriteString("## Investigation hints\n")
+	b.WriteString("- Working directory is the Sybra source tree. Use Grep/Read/Glob to inspect Go code under internal/ when a stack trace or error message points there.\n")
+	fmt.Fprintf(&b, "- Audit events live under %s (newest file is today's). Run `gh issue list --repo %s --label %s` first to avoid duplicate filings.\n",
+		filepath.Join(h.homeDir, "audit"), h.cfg.HumanReviewRepo(), h.cfg.HumanReviewIssueLabel())
+	b.WriteString("- A genuine human-required reason looks like: scope question, creative decision, missing credentials, ambiguous requirement, or an external system the agent legitimately cannot reach.\n")
+	b.WriteString("- A Sybra bug looks like: workflow step never ran the agent, agent started in the wrong dir, status flipped despite a successful PR, sidecar required but never written, repeated provider gate blocks, panics in logs, mis-routed completions.\n\n")
+
+	b.WriteString("## Output protocol (REQUIRED)\n")
+	b.WriteString("End your response with EXACTLY one fenced block tagged `sybra-verdict` containing JSON:\n\n")
+	b.WriteString("```sybra-verdict\n{\n  \"decision\": \"human\" | \"sybra_bug\",\n  \"summary\": \"one-sentence diagnosis\",\n  \"issue_title\": \"type(scope): short title\",   // sybra_bug only, must follow Sybra conventional commit format (e.g. fix(workflow): ...)\n  \"issue_body\": \"## What happened\\n...\\n\\n## Repro\\n...\\n\\n## Suspected cause\\n...\",  // sybra_bug only\n  \"issue_labels\": [\"workflow\", \"bug\"]              // sybra_bug only, optional\n}\n```\n\n")
+	b.WriteString("If decision=human, omit issue_* fields. The host parses this block deterministically — any other format will be treated as a parse failure.\n")
+	return b.String()
+}
+
+// parseVerdict extracts and unmarshals the fenced sybra-verdict JSON block.
+var verdictBlockRe = regexp.MustCompile("(?s)```\\s*sybra-verdict\\s*\\n(.*?)\\n```")
+
+func parseVerdict(text string) (verdictDecision, error) {
+	if strings.TrimSpace(text) == "" {
+		return verdictDecision{}, errors.New("empty assistant text")
+	}
+	m := verdictBlockRe.FindStringSubmatch(text)
+	if len(m) < 2 {
+		return verdictDecision{}, errors.New("no sybra-verdict block")
+	}
+	var v verdictDecision
+	if err := json.Unmarshal([]byte(strings.TrimSpace(m[1])), &v); err != nil {
+		return verdictDecision{}, fmt.Errorf("verdict json: %w", err)
+	}
+	v.Decision = strings.TrimSpace(strings.ToLower(v.Decision))
+	v.Summary = strings.TrimSpace(v.Summary)
+	if v.Decision != "human" && v.Decision != "sybra_bug" {
+		return verdictDecision{}, fmt.Errorf("invalid decision %q", v.Decision)
+	}
+	return v, nil
+}
+
+// finalAssistantText concatenates the assistant text from the agent's stream.
+// The fenced verdict block always lives in the last assistant turn.
+func finalAssistantText(ag *agent.Agent) string {
+	out := ag.Output()
+	for i := len(out) - 1; i >= 0; i-- {
+		if out[i].Type == "assistant" && strings.Contains(out[i].Content, "sybra-verdict") {
+			return out[i].Content
+		}
+	}
+	for i := len(out) - 1; i >= 0; i-- {
+		if out[i].Type == "result" {
+			return out[i].Content
+		}
+	}
+	return ""
+}
+
+// appendSection appends a `## header` section to body, separated by a blank
+// line. Keeps the source body intact even if it already ends without newline.
+func appendSection(body, header, content string) string {
+	body = strings.TrimRight(body, "\n")
+	if body != "" {
+		body += "\n\n"
+	}
+	body += "## " + header + "\n\n" + strings.TrimSpace(content) + "\n"
+	return body
+}
+
+func defaultStr(s, fallback string) string {
+	if strings.TrimSpace(s) == "" {
+		return fallback
+	}
+	return s
+}
+
+func urlOrPlaceholder(url, title string) string {
+	if url != "" {
+		return url
+	}
+	return "(issue: " + title + ")"
+}
+
+// tailFile reads the last n lines of path. Best-effort: returns "" on error
+// or when the file is missing (server containers often don't ship the log).
+func tailFile(path string, n int) string {
+	if path == "" {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -1,0 +1,330 @@
+package sybra
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+type fakeIssueSink struct {
+	mu      sync.Mutex
+	calls   int
+	created bool
+	url     string
+	err     error
+
+	gotTitle  string
+	gotBody   string
+	gotLabels []string
+}
+
+func (f *fakeIssueSink) SubmitIssue(_ context.Context, title, body string, labels []string) (created bool, url string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.gotTitle = title
+	f.gotBody = body
+	f.gotLabels = labels
+	return f.created, f.url, f.err
+}
+
+func newReviewTestEnv(t *testing.T) (*humanReviewHandler, *task.Manager, *fakeIssueSink, func()) {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatalf("task.NewStore: %v", err)
+	}
+	tasks := task.NewManager(store, task.EmitterFunc(func(string, any) {}))
+	cfg := &config.Config{}
+	cfg.HumanReview.Enabled = true
+	cfg.HumanReview.SybraRepoDir = dir
+	cfg.HumanReview.MaxPerHour = 3
+	sink := &fakeIssueSink{created: true, url: "https://github.com/Automaat/sybra/issues/42"}
+	logger := slog.New(slog.DiscardHandler)
+	h := newHumanReviewHandler(cfg, tasks, nil, nil, logger, sink, dir, filepath.Join(dir, "missing.log"))
+	return h, tasks, sink, func() {}
+}
+
+func TestParseVerdict(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		input   string
+		want    verdictDecision
+		wantErr bool
+	}{
+		{
+			name: "human decision",
+			input: "Looks like a real ambiguity.\n\n```sybra-verdict\n" +
+				`{"decision":"human","summary":"needs scope clarification"}` +
+				"\n```\n",
+			want: verdictDecision{Decision: "human", Summary: "needs scope clarification"},
+		},
+		{
+			name: "sybra_bug decision",
+			input: "Found a workflow bug.\n\n```sybra-verdict\n" +
+				`{"decision":"sybra_bug","summary":"verify_commits flipped despite push","issue_title":"fix(workflow): verify_commits race","issue_body":"## What\nrace","issue_labels":["workflow"]}` +
+				"\n```\n",
+			want: verdictDecision{
+				Decision: "sybra_bug", Summary: "verify_commits flipped despite push",
+				IssueTitle: "fix(workflow): verify_commits race", IssueBody: "## What\nrace",
+				IssueLabels: []string{"workflow"},
+			},
+		},
+		{
+			name:    "missing block",
+			input:   "no fenced verdict here",
+			wantErr: true,
+		},
+		{
+			name:    "invalid json",
+			input:   "```sybra-verdict\n{broken\n```",
+			wantErr: true,
+		},
+		{
+			name:    "unknown decision",
+			input:   "```sybra-verdict\n{\"decision\":\"maybe\"}\n```",
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseVerdict(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseVerdict: %v", err)
+			}
+			if got.Decision != tc.want.Decision || got.Summary != tc.want.Summary {
+				t.Errorf("decision/summary: got %+v want %+v", got, tc.want)
+			}
+			if got.IssueTitle != tc.want.IssueTitle || got.IssueBody != tc.want.IssueBody {
+				t.Errorf("issue: got %+v want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRateLimiter(t *testing.T) {
+	t.Parallel()
+	h, _, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	now := time.Now()
+	h.now = func() time.Time { return now }
+
+	for i := range 3 {
+		h.mu.Lock()
+		ok := h.allowSpawnLocked()
+		if ok {
+			h.recent = append(h.recent, h.now())
+		}
+		h.mu.Unlock()
+		if !ok {
+			t.Fatalf("spawn %d should be allowed", i)
+		}
+	}
+	h.mu.Lock()
+	overLimit := h.allowSpawnLocked()
+	h.mu.Unlock()
+	if overLimit {
+		t.Errorf("4th spawn should be rate-limited")
+	}
+
+	// Advance past the window: old entries expire and a slot frees up.
+	h.now = func() time.Time { return now.Add(humanReviewWindow + time.Minute) }
+	h.mu.Lock()
+	allowed := h.allowSpawnLocked()
+	h.mu.Unlock()
+	if !allowed {
+		t.Errorf("after window, spawn should be allowed again")
+	}
+}
+
+func TestOnComplete_HumanVerdict_AppendsNote(t *testing.T) {
+	t.Parallel()
+	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	tk, err := tasks.Create("Refactor billing", "Original body.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+		t.Fatalf("flip to human-required: %v", err)
+	}
+
+	ag := &agent.Agent{TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
+	ag.AppendOutput(agent.StreamEvent{
+		Type: "assistant",
+		Content: "Verdict below.\n\n```sybra-verdict\n" +
+			`{"decision":"human","summary":"needs product input on scope"}` +
+			"\n```\n",
+	})
+	h.inflight[tk.ID] = "agent-1"
+	h.onComplete(ag)
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("re-load: %v", err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Errorf("status: got %q want human-required", got.Status)
+	}
+	if got.BlockedByIssue != "" {
+		t.Errorf("BlockedByIssue: want empty, got %q", got.BlockedByIssue)
+	}
+	if !strings.Contains(got.Body, "Auto-review verdict: needs human") {
+		t.Errorf("expected verdict header in body; got:\n%s", got.Body)
+	}
+	if !strings.Contains(got.Body, "needs product input on scope") {
+		t.Errorf("expected summary in body; got:\n%s", got.Body)
+	}
+	if sink.calls != 0 {
+		t.Errorf("sink should not be called for human verdict; calls=%d", sink.calls)
+	}
+	if _, busy := h.inflight[tk.ID]; busy {
+		t.Errorf("inflight should be cleared after onComplete")
+	}
+}
+
+func TestOnComplete_SybraBugVerdict_FilesIssueAndBlocks(t *testing.T) {
+	t.Parallel()
+	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	tk, err := tasks.Create("Workflow misfire", "Original body.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+		t.Fatalf("flip to human-required: %v", err)
+	}
+
+	ag := &agent.Agent{TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
+	ag.AppendOutput(agent.StreamEvent{
+		Type: "assistant",
+		Content: "Diagnosis.\n\n```sybra-verdict\n" + `{
+  "decision": "sybra_bug",
+  "summary": "verify_commits never re-checked the branch",
+  "issue_title": "fix(workflow): verify_commits race",
+  "issue_body": "## What\nrace condition",
+  "issue_labels": ["workflow", "regression"]
+}` + "\n```\n",
+	})
+	h.inflight[tk.ID] = "agent-2"
+	h.onComplete(ag)
+
+	if sink.calls != 1 {
+		t.Fatalf("sink calls: got %d want 1", sink.calls)
+	}
+	if sink.gotTitle != "fix(workflow): verify_commits race" {
+		t.Errorf("sink title: got %q", sink.gotTitle)
+	}
+	if !strings.Contains(sink.gotBody, "race condition") {
+		t.Errorf("sink body missing diagnosis: %q", sink.gotBody)
+	}
+	if len(sink.gotLabels) != 2 || sink.gotLabels[0] != "workflow" {
+		t.Errorf("sink labels: got %v", sink.gotLabels)
+	}
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("re-load: %v", err)
+	}
+	if got.Status != task.StatusBlocked {
+		t.Errorf("status: got %q want blocked", got.Status)
+	}
+	if got.BlockedByIssue != sink.url {
+		t.Errorf("BlockedByIssue: got %q want %q", got.BlockedByIssue, sink.url)
+	}
+	if !strings.Contains(got.Body, "Auto-review verdict: blocked by Sybra bug") {
+		t.Errorf("expected blocked-by-Sybra-bug header; got:\n%s", got.Body)
+	}
+	if !strings.Contains(got.Body, sink.url) {
+		t.Errorf("expected issue URL in body; got:\n%s", got.Body)
+	}
+}
+
+func TestOnComplete_SinkError_LeavesHumanRequired(t *testing.T) {
+	t.Parallel()
+	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+	sink.err = errors.New("rate limited")
+
+	tk, err := tasks.Create("Whatever", "Body.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+		t.Fatalf("flip: %v", err)
+	}
+
+	ag := &agent.Agent{TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
+	ag.AppendOutput(agent.StreamEvent{
+		Type:    "assistant",
+		Content: "```sybra-verdict\n" + `{"decision":"sybra_bug","summary":"x","issue_title":"fix(x): y","issue_body":"z"}` + "\n```",
+	})
+	h.onComplete(ag)
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("re-load: %v", err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Errorf("status: got %q want human-required (sink error path)", got.Status)
+	}
+	if got.BlockedByIssue != "" {
+		t.Errorf("BlockedByIssue should be empty on sink error; got %q", got.BlockedByIssue)
+	}
+	if !strings.Contains(got.Body, "issue submission failed") {
+		t.Errorf("expected failure note in body; got:\n%s", got.Body)
+	}
+}
+
+func TestOnComplete_MalformedVerdict_AppendsRaw(t *testing.T) {
+	t.Parallel()
+	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	tk, err := tasks.Create("Mystery", "Body.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+		t.Fatalf("flip: %v", err)
+	}
+
+	ag := &agent.Agent{TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
+	ag.AppendOutput(agent.StreamEvent{Type: "result", Content: "no fenced verdict here"})
+	h.onComplete(ag)
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("re-load: %v", err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Errorf("status: got %q want human-required", got.Status)
+	}
+	if !strings.Contains(got.Body, "unparseable verdict") {
+		t.Errorf("expected unparseable header; got:\n%s", got.Body)
+	}
+	if sink.calls != 0 {
+		t.Errorf("sink should not be called on malformed verdict; calls=%d", sink.calls)
+	}
+}

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -19,6 +19,7 @@ const (
 	StatusTesting        Status = "testing"
 	StatusTestPlanReview Status = "test-plan-review"
 	StatusHumanRequired  Status = "human-required"
+	StatusBlocked        Status = "blocked"
 	StatusDone           Status = "done"
 	StatusCancelled      Status = "cancelled"
 )
@@ -27,7 +28,8 @@ var validStatuses = map[Status]bool{
 	StatusNew: true, StatusTodo: true, StatusInProgress: true,
 	StatusInReview: true, StatusPlanning: true, StatusPlanReview: true,
 	StatusTesting: true, StatusTestPlanReview: true,
-	StatusHumanRequired: true, StatusDone: true, StatusCancelled: true,
+	StatusHumanRequired: true, StatusBlocked: true,
+	StatusDone: true, StatusCancelled: true,
 }
 
 // AllStatuses returns every valid status in display order.
@@ -36,7 +38,7 @@ func AllStatuses() []Status {
 		StatusNew, StatusTodo, StatusPlanning, StatusPlanReview,
 		StatusInProgress, StatusInReview,
 		StatusTesting, StatusTestPlanReview,
-		StatusHumanRequired, StatusDone, StatusCancelled,
+		StatusHumanRequired, StatusBlocked, StatusDone, StatusCancelled,
 	}
 }
 
@@ -143,25 +145,29 @@ type AgentRun struct {
 }
 
 type Task struct {
-	ID           string     `yaml:"id" json:"id"`
-	Slug         string     `yaml:"slug,omitempty" json:"slug"`
-	Title        string     `yaml:"title" json:"title"`
-	Status       Status     `yaml:"status" json:"status"`
-	TaskType     TaskType   `yaml:"task_type,omitempty" json:"taskType"`
-	AgentMode    string     `yaml:"agent_mode" json:"agentMode"`
-	AllowedTools []string   `yaml:"allowed_tools" json:"allowedTools"`
-	Tags         []string   `yaml:"tags" json:"tags"`
-	ProjectID    string     `yaml:"project_id,omitempty" json:"projectId"`
-	Branch       string     `yaml:"branch,omitempty" json:"branch"`
-	PRNumber     int        `yaml:"pr_number,omitempty" json:"prNumber"`
-	Issue        string     `yaml:"issue,omitempty" json:"issue"`
-	StatusReason string     `yaml:"status_reason,omitempty" json:"statusReason"`
-	Reviewed     bool       `yaml:"reviewed,omitempty" json:"reviewed"`
-	RunRole      string     `yaml:"run_role,omitempty" json:"runRole"` // pr-fix when fixing review issues, "" for initial impl
-	TodoistID    string     `yaml:"todoist_id,omitempty" json:"todoistId"`
-	Priority     Priority   `yaml:"priority,omitempty" json:"priority,omitempty"`
-	DueDate      *time.Time `yaml:"due_date,omitempty" json:"dueDate,omitempty"`
-	ClosedAt     *time.Time `yaml:"closed_at,omitempty" json:"closedAt,omitempty"`
+	ID           string   `yaml:"id" json:"id"`
+	Slug         string   `yaml:"slug,omitempty" json:"slug"`
+	Title        string   `yaml:"title" json:"title"`
+	Status       Status   `yaml:"status" json:"status"`
+	TaskType     TaskType `yaml:"task_type,omitempty" json:"taskType"`
+	AgentMode    string   `yaml:"agent_mode" json:"agentMode"`
+	AllowedTools []string `yaml:"allowed_tools" json:"allowedTools"`
+	Tags         []string `yaml:"tags" json:"tags"`
+	ProjectID    string   `yaml:"project_id,omitempty" json:"projectId"`
+	Branch       string   `yaml:"branch,omitempty" json:"branch"`
+	PRNumber     int      `yaml:"pr_number,omitempty" json:"prNumber"`
+	Issue        string   `yaml:"issue,omitempty" json:"issue"`
+	StatusReason string   `yaml:"status_reason,omitempty" json:"statusReason"`
+	// BlockedByIssue stores the URL of the GitHub issue that put the task
+	// into status=blocked. Set by the human-review automation when it
+	// concludes the human-required transition was caused by a Sybra bug.
+	BlockedByIssue string     `yaml:"blocked_by_issue,omitempty" json:"blockedByIssue,omitempty"`
+	Reviewed       bool       `yaml:"reviewed,omitempty" json:"reviewed"`
+	RunRole        string     `yaml:"run_role,omitempty" json:"runRole"` // pr-fix when fixing review issues, "" for initial impl
+	TodoistID      string     `yaml:"todoist_id,omitempty" json:"todoistId"`
+	Priority       Priority   `yaml:"priority,omitempty" json:"priority,omitempty"`
+	DueDate        *time.Time `yaml:"due_date,omitempty" json:"dueDate,omitempty"`
+	ClosedAt       *time.Time `yaml:"closed_at,omitempty" json:"closedAt,omitempty"`
 	// RequirePermissions overrides the system default when set.
 	// nil = use system default (true). false = opt out (--dangerously-skip-permissions).
 	RequirePermissions *bool               `yaml:"require_permissions,omitempty" json:"requirePermissions,omitempty"`

--- a/internal/task/model_test.go
+++ b/internal/task/model_test.go
@@ -28,8 +28,8 @@ func TestValidateStatus_Invalid(t *testing.T) {
 func TestAllStatuses(t *testing.T) {
 	t.Parallel()
 	statuses := AllStatuses()
-	if len(statuses) != 11 {
-		t.Errorf("got %d statuses, want 11", len(statuses))
+	if len(statuses) != 12 {
+		t.Errorf("got %d statuses, want 12", len(statuses))
 	}
 	seen := make(map[Status]bool)
 	for _, s := range statuses {
@@ -37,6 +37,9 @@ func TestAllStatuses(t *testing.T) {
 			t.Errorf("duplicate status %q", s)
 		}
 		seen[s] = true
+	}
+	if !seen[StatusBlocked] {
+		t.Errorf("StatusBlocked missing from AllStatuses()")
 	}
 }
 

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -290,6 +290,9 @@ func (s *Store) Update(id string, u Update) (Task, error) {
 	if u.StatusReason != nil {
 		t.StatusReason = *u.StatusReason
 	}
+	if u.BlockedByIssue != nil {
+		t.BlockedByIssue = *u.BlockedByIssue
+	}
 	if u.AgentMode != nil {
 		if _, err := ValidateAgentMode(*u.AgentMode); err != nil {
 			return Task{}, err

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -12,27 +12,28 @@ import (
 // A nil pointer means "leave unchanged"; a non-nil pointer applies the new value.
 // For Workflow: nil = unchanged; non-nil = overwrite (even if pointed-to value is nil).
 type Update struct {
-	Title        *string
-	Slug         *string
-	Status       *Status
-	StatusReason *string
-	AgentMode    *string
-	TaskType     *TaskType
-	Body         *string
-	Tags         *[]string
-	ProjectID    *string
-	Branch       *string
-	PRNumber     *int
-	Issue        *string
-	Reviewed     *bool
-	RunRole      *string
-	TodoistID    *string
-	Priority     *Priority
-	DueDate      **time.Time
-	Workflow     **workflow.Execution
-	Plan         *string
-	PlanCritique *string
-	CodeReview   *string
+	Title          *string
+	Slug           *string
+	Status         *Status
+	StatusReason   *string
+	BlockedByIssue *string
+	AgentMode      *string
+	TaskType       *TaskType
+	Body           *string
+	Tags           *[]string
+	ProjectID      *string
+	Branch         *string
+	PRNumber       *int
+	Issue          *string
+	Reviewed       *bool
+	RunRole        *string
+	TodoistID      *string
+	Priority       *Priority
+	DueDate        **time.Time
+	Workflow       **workflow.Execution
+	Plan           *string
+	PlanCritique   *string
+	CodeReview     *string
 }
 
 // Ptr returns a pointer to v. Convenience for building Update literals.
@@ -57,7 +58,7 @@ func UpdateFromMap(raw map[string]any) (Update, error) {
 
 func applyMapField(u *Update, k string, v any) error {
 	switch k {
-	case "title", "slug", "status_reason", "body",
+	case "title", "slug", "status_reason", "blocked_by_issue", "body",
 		"project_id", "branch", "issue", "run_role", "todoist_id", "plan", "plan_critique", "code_review":
 		return applyPlainStringField(u, k, v)
 	case "priority":
@@ -104,6 +105,8 @@ func applyPlainStringField(u *Update, k string, v any) error {
 		u.Slug = &s
 	case "status_reason":
 		u.StatusReason = &s
+	case "blocked_by_issue":
+		u.BlockedByIssue = &s
 	case "body":
 		u.Body = &s
 	case "project_id":

--- a/internal/workflow/condition.go
+++ b/internal/workflow/condition.go
@@ -67,8 +67,8 @@ var FieldAllowedValues = map[string]map[string]bool{
 	"task.status": {
 		"new": true, "todo": true, "in-progress": true, "in-review": true,
 		"planning": true, "plan-review": true, "testing": true,
-		"test-plan-review": true, "human-required": true, "done": true,
-		"cancelled": true,
+		"test-plan-review": true, "human-required": true, "blocked": true,
+		"done": true, "cancelled": true,
 	},
 	"task.task_type": {
 		"normal": true, "debug": true, "research": true, "chat": true,


### PR DESCRIPTION
## Motivation

Today, when a Sybra task lands in `human-required`, the only signal is a
desktop notification. Many of those transitions are not actually "user input
needed" — they're Sybra bugs (workflow misfire, agent mis-config, infra
flakiness) that the user has to manually triage. This change adds an
opt-in diagnostic that runs as soon as the transition fires.

## Implementation information

Status hook in `App.initStatusHook` spawns a headless Claude agent (role
`human-review`) inside the configured Sybra source tree. The agent
inspects task state, recent agent runs, audit/host logs and source code,
then emits a fenced ` ```sybra-verdict ` JSON block. The host parses the
verdict deterministically and applies one of two side-effects:

- `decision: human` → append a verdict note to the task body, leave
  status at `human-required`.
- `decision: sybra_bug` → file a deduplicated GitHub issue via
  `monitor.GHIssueSink.SubmitIssue` (extracted from the existing
  `Submit(Anomaly, body)` so the dedup-and-comment logic is reused), then
  flip the task to a new `blocked` status with a `BlockedByIssue` URL
  field that the UI surfaces as a clickable link.

Per-machine controls:
- `human_review.enabled` toggle (false on server, true on laptop).
- Rolling rate limiter (`max_per_hour`, default 6) and per-task in-flight
  guard so a flap doesn't spam reviews/issues.
- `sybra_repo_dir` must point at a Sybra source checkout — empty disables.

Workflow engine completion is bypassed for `human-review` runs so the
diagnostic verdict can't accidentally advance the user's workflow step.

Alternatives discarded: (a) running `gh issue create` directly from the
agent's allowed tools (lost deterministic dedup), (b) adding a poller
that scans `human-required` tasks (worse latency, harder to bound).

## Supporting documentation

- New status `blocked` added to `task.Status` enum, `validStatuses`,
  `AllStatuses`, and the workflow engine's `FieldAllowedValues` so YAML
  triggers can match it.
- Audit events: `human_review.{spawned, verdict, issue_filed, skipped}`.
- Tests: `internal/sybra/app_human_review_test.go` covers
  `parseVerdict` (5 cases), the rolling rate limiter, and four
  `onComplete` paths (human / sybra_bug / sink-error / malformed).

## Test plan

- [ ] `mise run lint` passes
- [ ] `go test ./...` passes
- [ ] `cd frontend && npm run check` passes
- [ ] On laptop with `human_review.enabled: true` and a real Sybra source
      dir, trigger a workflow that flips a task to human-required (e.g.
      `verify_commits` with no commits). Confirm a `human-review` agent
      run appears under the task and either a verdict note is appended
      or the task flips to `blocked` with a clickable issue link.
- [ ] Toggle `enabled: false`, repeat, confirm no spawn and the
      `app.automations` log line shows `human_review=false`.