### PR TITLE
feat(skills): persona-driven multi-provider plan

### DIFF
--- a/internal/skills/data/sybra-plan.md
+++ b/internal/skills/data/sybra-plan.md
@@ -1,6 +1,6 @@
 ---
 name: sybra-plan
-description: Plan Sybra tasks — analyze scope, explore codebase, produce implementation plan without writing code. Use when asked to plan a task.
+description: Plan Sybra tasks — analyze scope, spawn persona-driven multi-provider planners, synthesize one plan with tradeoffs. Use when asked to plan a task.
 allowed-tools: Bash, Read, Glob, WebFetch
 user-invocable: true
 ---
@@ -29,15 +29,113 @@ sybra-cli --json get <id>
 - If URLs are referenced, fetch context (GitHub PRs/issues via `gh`, or WebFetch)
 - Explore the codebase: find relevant files, understand existing patterns
 - Identify dependencies and potential risks
+- **Triviality check** — if the task is a typo / single-line / mechanical rename / single-file edit with no design choices, skip persona-driven planning and jump straight to Step 5 with the plan written directly.
 
-### 3. Produce a structured plan
+### 3. Auto-select 2-3 personas
 
-Output a markdown plan with these sections:
+Default: **2 personas**. Bump to **3** when:
+- Two-surface task (eng + UX), or
+- Refactor / cross-cutting / "complex" framing, or
+- Best-fit shortcut group has 3 distinct lenses.
+
+Always include one bias-correction persona (`antirez`, `tef`, `hebert`, `meadows`, `chin`, `norman`, `nielsen`, `watson`) unless the task is a narrow specialist audit. Avoid duplicate lenses — if two personas push for the same thing, keep the sharper domain fit.
+
+**Selection shortcuts:**
+- code-style / refactor: antirez + tef + muratori
+- reliability / failure / ops: hebert + meadows + tef
+- perf hot path: muratori + tef + antirez
+- types / parsing / data validation: king + tef + antirez
+- testing strategy: test-architect + hughes + chin
+- domain modeling / bounded contexts: evans + king + meadows
+- backend feature (default): antirez + hebert + tef
+- UI feature: norman + krug + nielsen
+- accessibility / WCAG: watson + norman + nielsen
+- two-surface (eng + UX): antirez + tef + norman
+
+**Persona roster:**
+
+| Persona | Lens | Pushes for | Refuses |
+|---|---|---|---|
+| antirez | simplicity, design sacrifice | smallest plan that works, sharp scope cuts | over-abstraction, bloat |
+| tef | deletability, anti-DRY, protocol over topology | code easy to throw away | premature shared abstractions |
+| muratori | semantic compression, perf-from-day-one | data layout, hot path | Clean Code-style fragmentation |
+| hebert | operability, supervision, controlled-burn | named failure modes, supervision boundaries | hidden coupling |
+| meadows | systems, leverage points, feedback loops | feedback loops surfaced, stocks/flows | local optimization |
+| chin | tacit knowledge, NDM | situational fit, empirical recipes | rigid frameworks |
+| king | parse don't validate, totality | illegal states unrepresentable | runtime checks for type problems |
+| evans | DDD, ubiquitous language, bounded contexts | clear context boundaries | cross-context bleed |
+| test-architect | FCIS, tests as design pressure | functional core boundaries | tests that lock implementation |
+| hughes | property-based testing, generators | properties + shrinking | example-only suites |
+| norman | affordances, mental models | discoverability, error modes | hidden state |
+| krug | trunk test, "don't make me think" | label clarity, scan-ability | clever interactions |
+| nielsen | 10 heuristics, severity rating | consistency, error prevention | unscored issues |
+| watson | a11y, screen reader, WCAG | semantic markup, focus order | visual-only signaling |
+
+Announce the selection in one short line before spawning:
+`Auto-selected <p1> + <p2> [+ <p3>] because <one-line evidence>.`
+
+### 4. Spawn N×2 planners in parallel (Claude + Codex per persona)
+
+For **each** selected persona, fire **two** Bash calls in parallel — one `claude -p` and one `codex exec`. All planners (personas × providers) launch in **one tool-use block** with `run_in_background: true`. Total: 4 calls (2 personas) or 6 calls (3 personas).
+
+**Output sink:**
+
+```bash
+PLAN_DIR=$(mktemp -d -t sybra-plan-XXXX)
+echo "$PLAN_DIR"
+```
+
+**Persona brief template** (substitute per persona before writing to file):
+
+```
+You are <persona-name> (<short identity>).
+Your lens: <one-line philosophy from roster above>.
+You push for: <2-3 specifics from roster>.
+You refuse: <1-2 specifics from roster>.
+
+Background:
+- Task: <verbatim body from sybra-cli get>
+- Files explored: <paths from Step 2>
+- Relevant patterns / utilities: <list with paths>
+
+Write a detailed implementation plan strictly through your lens.
+- List critical files to modify (paths).
+- Step-by-step implementation order.
+- Name what you would cut and what you would refuse.
+- No hedging. Disagree with the safe path if your lens says so.
+
+Output a self-contained plan. End with marker line: ---END-PLAN---.
+```
+
+Write each persona brief to `$PLAN_DIR/<persona>-prompt.txt`, then for each persona issue **two** Bash tool calls (both with `run_in_background: true`):
+
+**Claude wrapper:**
+```bash
+claude -p --output-format text < "$PLAN_DIR/<persona>-prompt.txt" \
+  > "$PLAN_DIR/<persona>-claude.md" 2>&1
+```
+
+**Codex wrapper:**
+```bash
+codex exec --sandbox read-only --skip-git-repo-check - \
+  < "$PLAN_DIR/<persona>-prompt.txt" \
+  > "$PLAN_DIR/<persona>-codex.md" 2>&1
+```
+
+`read-only` sandbox forbids file writes — Codex outputs only to stdout. If a planner fails (auth issue, timeout, empty output), skip it during synthesis rather than aborting; note the gap in Tradeoffs.
+
+Wait for all backgrounded calls to complete (tool-call notifications fire on completion). Do not synthesize until every spawn has settled.
+
+### 5. Synthesize one final plan
+
+Read all `$PLAN_DIR/*.md` outputs. For each, extract content up to the `---END-PLAN---` marker (strip CLI chatter / tool-use lines that may precede the plan body).
+
+Write the final plan with sections:
 
 ```markdown
 ## Approach
 
-Brief description of the chosen approach and why.
+Recommended path. Spine drawn from cross-provider, cross-persona convergence.
 
 ## Files to Change
 
@@ -50,13 +148,26 @@ Brief description of the chosen approach and why.
 2. Second step — details
 3. ...
 
+## Tradeoffs
+
+Persona axis:
+- <p1> wanted X, <p2> wanted Y. Chose X because <one-line reason>.
+
+Provider axis (only when notable):
+- On <persona>, claude proposed X while codex proposed Y. Chose X because <reason>.
+
 ## Risks
 
 - Risk 1 and mitigation
 - Risk 2 and mitigation
 ```
 
-### 4. Publish the plan + hand off for review
+**Convergence priority:**
+- Same persona, different providers agreeing = strong signal (use as spine).
+- Different personas, same provider agreeing = weaker signal.
+- Disagreements surface in Tradeoffs with a one-line rationale for the chosen side.
+
+### 6. Publish the plan + hand off for review
 
 ```bash
 sybra-cli --json update <id> --plan "<full plan markdown>"
@@ -65,12 +176,12 @@ sybra-cli --json update <id> --status plan-review
 
 Then STOP and wait at the chat prompt. Do NOT exit. Do NOT implement.
 
-### 5. Respond to feedback
+### 7. Respond to feedback
 
 The user may send feedback in the same chat session. When feedback arrives:
 
 1. Read it carefully
-2. Revise the plan (use prior context — do not re-analyze files you already read)
+2. Revise the plan in-place (do NOT re-spawn personas unless feedback substantially shifts scope)
 3. `sybra-cli --json update <id> --plan "<revised plan>"`
 4. `sybra-cli --json update <id> --status plan-review`
 5. Wait again
@@ -87,10 +198,14 @@ The user may send feedback in the same chat session. When feedback arrives:
 <example>
 Input: Task `task-abc` body: "Add rate limiting to /api/login endpoint, 5 req/min per IP".
 
-Output plan:
+Step 3 announce: `Auto-selected antirez + hebert because backend feature with reliability concerns.`
+
+Step 4: 4 parallel Bash calls (antirez+claude, antirez+codex, hebert+claude, hebert+codex), `run_in_background: true`, outputs to a temp dir.
+
+Step 5 synthesized plan:
 ```markdown
 ## Approach
-Middleware using token bucket keyed by client IP. Reuse existing `internal/middleware` package.
+Token bucket middleware keyed by client IP, reusing existing `internal/middleware`.
 
 ## Files to Change
 - `internal/middleware/ratelimit.go` — new, token bucket implementation
@@ -100,24 +215,23 @@ Middleware using token bucket keyed by client IP. Reuse existing `internal/middl
 ## Steps
 1. Add `golang.org/x/time/rate` to go.mod
 2. Implement `NewIPLimiter(rps, burst)` returning `func(http.Handler) http.Handler`
-3. Write tests covering allow/deny/reset scenarios
+3. Write tests: allow / deny / reset scenarios
 4. Wire into login route in main.go
 
+## Tradeoffs
+Persona axis:
+- antirez wanted in-memory map (smallest), hebert wanted LRU eviction. Chose LRU because unbounded map is a documented failure mode under sustained scan traffic.
+
 ## Risks
-- Memory growth from IP map — mitigate with LRU eviction (cap 10k entries)
-- Behind proxy: read `X-Forwarded-For` header, trust only proxy range
+- Behind proxy: read `X-Forwarded-For`, trust only proxy CIDR range
+- Memory growth: LRU cap 10k entries
 ```
 
-Then:
-```bash
-sybra-cli --json update task-abc --plan "<plan above>"
-sybra-cli --json update task-abc --status plan-review
-```
-Stay at prompt, wait for feedback.
+Then publish + wait.
 </example>
 
 <example>
 Input: User feedback "also add metrics for blocked requests".
 
-Action: Revise Steps section to add prometheus counter, re-publish plan, set status plan-review, wait again. Do NOT re-read files already explored.
+Action: Revise Steps to add prometheus counter, re-publish plan, set status plan-review, wait. Do NOT re-spawn personas — feedback is additive, not scope-shifting.
 </example>


### PR DESCRIPTION
## Motivation

The `/sybra-plan` skill currently produces a single plan from one agent's
perspective. Output drifts toward safe, hedged, template-shaped plans —
the failure mode the council skill was built to fix.

## Implementation information

Restructure the skill so non-trivial tasks go through a persona-driven
multi-provider pipeline:

- Auto-select 2 council personas (3 for two-surface or cross-cutting
  tasks) using an inlined symptom-map shortcut list. Always include one
  bias-correction persona.
- For each persona, fire **two** Bash calls in parallel — one
  `claude -p` and one `codex exec --sandbox read-only` — all in a
  single tool-use block with `run_in_background: true`. Total: 4 or 6
  parallel planners.
- Synthesize one plan with sections Approach / Files to Change / Steps /
  Tradeoffs (persona-axis + provider-axis) / Risks. Convergence on the
  same persona across providers is strong signal; convergence across
  personas on the same provider is weaker signal.

Why two providers per persona: claude and codex draw different training
distributions and tool-use heuristics; their disagreement on the same
persona brief is signal, not noise. Codex runs read-only so it cannot
write files during planning.

Alternatives considered:
- Spawning council `Agent` subagents directly — rejected, the skill's
  allowed-tools list is `Bash, Read, Glob, WebFetch` (no Agent), and
  uniform Bash spawning across both providers is simpler.
- Putting the override in global `~/.claude/CLAUDE.md` — rejected per
  the rule that sybra-related artifacts live in the sybra repo and ride
  the existing skill-sync path to worktrees.

Trivial tasks (typo, rename, single-line, single-file mechanical edits)
keep the existing fast-path with no persona spawn. Failed planners
(auth issue, timeout, empty output) skip during synthesis rather than
aborting the whole plan.

The skill is embedded via `//go:embed data/*.md` in `internal/skills/`
and synced to worktrees through the existing skill-distribution path,
so no Go code changes are needed.

## Supporting documentation

- Council shortcut list and persona registry the inline roster is
  abridged from: `~/.claude/plugins/cache/sai/council/1.5.0/skills/council/`
- Plan-critic's parallel-spawn + shared-brief pattern modeled here:
  `~/.claude/plugins/cache/sai/plan-critic/1.0.0/skills/plan-critic/`

> Changelog: feat(skills): persona-driven multi-provider plan