### PR TITLE
test(sybra): fix critique-guard race in waitFor

### DIFF
--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -2435,12 +2435,13 @@ func TestE2E_BuiltinSimpleTask_MissingCritiqueFlipsHumanRequired(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	waitFor(t, 30*time.Second, "task flips to human-required via require_plan_critique", func() bool {
+	// Wait for ExecCompleted, not just status: execRequireSidecar updates status before the engine records the step, so a status-only poll races the history append.
+	waitFor(t, 30*time.Second, "workflow completes via require_plan_critique guard", func() bool {
 		tk, gErr := env.tasks.Get(created.ID)
 		if gErr != nil {
 			return false
 		}
-		return tk.Status == task.StatusHumanRequired
+		return tk.Workflow != nil && tk.Workflow.State == workflow.ExecCompleted && tk.Status == task.StatusHumanRequired
 	})
 
 	tk, err := env.tasks.Get(created.ID)


### PR DESCRIPTION
## Motivation

`TestE2E_BuiltinSimpleTask_MissingCritiqueFlipsHumanRequired` flakes in
CI. Reproduced locally with `-count=20` (1 fail in 0.26s, vs 3.27s for a
passing run).

Failure surface:
```
require_plan_critique guard did not execute
history: [triage plan converge_plans require_plan maybe_critique critique_plan]
```

Status had flipped to human-required, but the guard step that flipped it
was missing from `tk.Workflow.StepHistory`.

## Implementation information

`execRequireSidecar` calls `UpdateTaskStatus(human-required)` before
returning the `StepOutput` that the engine appends to history. The two
writes are not atomic. A status-only poll can observe human-required in
the window between the status update and the history append.

The fix is in the test, not the engine: extend the `waitFor` predicate
to also require `tk.Workflow.State == workflow.ExecCompleted`. The
workflow only reaches the terminal state after the guard step has been
recorded and its `goto: ""` edge evaluated, so by the time
`ExecCompleted` is observed the history is consistent. This matches the
pattern already used by sibling tests at lines 551 and 777.

Alternatives considered:

- Reorder writes inside `execRequireSidecar` (history first, status
  second). Rejected — the current ordering is correct for production
  semantics (status visibility for downstream listeners shouldn't
  depend on workflow-history bookkeeping), and the race is a test-only
  concern.
- Make the engine atomic over status+history. Rejected — much larger
  change for one test's flakiness; the test-side fix is the right
  scope.

Validated with `-count=50` (0 fails) and full
`go test ./internal/sybra/ ./internal/workflow/` (both pass).

> Changelog: skip