### PR TITLE
refactor(errors): adopt errors.AsType[T] from Go 1.26

### DIFF
--- a/internal/agent/manager_gate_test.go
+++ b/internal/agent/manager_gate_test.go
@@ -70,8 +70,8 @@ func TestGateProvider_BothUnhealthyReturnsTypedError(t *testing.T) {
 	if !errors.Is(err, provider.ErrProviderUnhealthy) {
 		t.Fatalf("error should match ErrProviderUnhealthy: %v", err)
 	}
-	var ue *provider.UnhealthyError
-	if !errors.As(err, &ue) {
+	ue, ok := errors.AsType[*provider.UnhealthyError](err)
+	if !ok {
 		t.Fatalf("error should unwrap to UnhealthyError")
 	}
 	if ue.Provider != "claude" || ue.Reason != "rate_limited" {

--- a/internal/agent/shutdown_test.go
+++ b/internal/agent/shutdown_test.go
@@ -53,8 +53,8 @@ func TestConfigureGracefulShutdown_CancelSendsSIGTERM(t *testing.T) {
 	if waitErr == nil {
 		t.Fatal("expected exit error after cancel, got nil")
 	}
-	var exitErr *exec.ExitError
-	if !errors.As(waitErr, &exitErr) {
+	exitErr, ok := errors.AsType[*exec.ExitError](waitErr)
+	if !ok {
 		t.Fatalf("expected *exec.ExitError, got %T: %v", waitErr, waitErr)
 	}
 	status, ok := exitErr.Sys().(syscall.WaitStatus)

--- a/internal/provider/probes.go
+++ b/internal/provider/probes.go
@@ -28,12 +28,10 @@ func ProbeClaude(ctx context.Context) (Status, error) {
 		if isLoggedOutStderr(stderr.String()) {
 			return Status{Provider: "claude", Healthy: false, Reason: "logged_out", LastCheck: time.Now()}, nil
 		}
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			// Fall through: claude may have printed JSON on stdout even with non-zero exit.
-		} else {
+		if _, ok := errors.AsType[*exec.ExitError](err); !ok {
 			return Status{Provider: "claude", Healthy: false, Reason: "probe_error", Detail: err.Error(), LastCheck: time.Now()}, err
 		}
+		// Fall through: claude may have printed JSON on stdout even with non-zero exit.
 	}
 	return parseClaudeAuthStatus(stdout.Bytes())
 }
@@ -55,8 +53,7 @@ func ProbeCodex(ctx context.Context) (Status, error) {
 		if isLoggedOutStderr(stderr.String()) || isLoggedOutStderr(stdout.String()) {
 			return Status{Provider: "codex", Healthy: false, Reason: "logged_out", LastCheck: time.Now()}, nil
 		}
-		var exitErr *exec.ExitError
-		if !errors.As(err, &exitErr) {
+		if _, ok := errors.AsType[*exec.ExitError](err); !ok {
 			return Status{Provider: "codex", Healthy: false, Reason: "probe_error", Detail: err.Error(), LastCheck: time.Now()}, err
 		}
 	}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2344,8 +2344,8 @@ func TestExecuteSteps_CycleDetection(t *testing.T) {
 		t.Fatal("expected error for cyclic workflow, got nil")
 	}
 
-	var cycleErr *CycleError
-	if !errors.As(err, &cycleErr) {
+	cycleErr, ok := errors.AsType[*CycleError](err)
+	if !ok {
 		t.Fatalf("expected *CycleError, got %T: %v", err, err)
 	}
 	if cycleErr.StepID == "" {


### PR DESCRIPTION
## Motivation

Go 1.26 introduced `errors.AsType[T](err)` to reduce boilerplate in the common pattern of checking for a specific error type. The codebase used `var target T; errors.As(err, &target)` throughout hot paths in `internal/agent`, `internal/provider`, and `internal/workflow`, which is more verbose and less type-safe than the new generic helper.

Closes https://github.com/Automaat/sybra/issues/589

## Implementation information

- Replaced `errors.As` + local variable declarations with `errors.AsType[T]` at all applicable call sites
- Where only the presence check mattered (not the value), used `_, ok := errors.AsType[T](err)` idiom
- No behaviour changes — purely mechanical substitution, verified by existing test suite