### PR TITLE
refactor(sybra): decompose monolithic App struct

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,21 @@ jobs:
       - name: Run Go tests
         run: go test ./...
 
+  test-go-e2e:
+    name: Go E2E Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+      - name: Build frontend (needed for go:embed)
+        run: cd frontend && npm ci && npm run build:desktop
+
+      - name: Run Go e2e tests
+        run: go test -tags e2e -timeout 10m ./internal/sybra/...
+
   test-frontend:
     name: Frontend Tests
     runs-on: ubuntu-latest

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -1,0 +1,80 @@
+package sybra
+
+import (
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// TestPRMonitorEligible exercises the scan predicate used by the PR monitor
+// loop. The regression: tasks whose workflow exited to in-progress with a
+// live PR number (because an evaluate step crashed, or a manually-spawned
+// agent opened the PR outside the workflow) were silently dropped from the
+// scan because it only considered status=in-review. Result: failing CI on
+// those PRs was never fixed by pr-fix agents.
+func TestPRMonitorEligible(t *testing.T) {
+	tests := []struct {
+		name string
+		tk   task.Task
+		want bool
+	}{
+		{
+			name: "in-review with PR — original happy path",
+			tk:   task.Task{Status: task.StatusInReview, PRNumber: 42},
+			want: true,
+		},
+		{
+			name: "in-review with branch only — still eligible",
+			tk:   task.Task{Status: task.StatusInReview, Branch: "sybra/feat-x"},
+			want: true,
+		},
+		{
+			name: "in-review with neither PR nor branch — not eligible",
+			tk:   task.Task{Status: task.StatusInReview},
+			want: false,
+		},
+		{
+			name: "in-progress with PR — the regression case we're fixing",
+			tk:   task.Task{Status: task.StatusInProgress, PRNumber: 247},
+			want: true,
+		},
+		{
+			name: "in-progress with branch only — not eligible (avoid WIP false positives)",
+			tk:   task.Task{Status: task.StatusInProgress, Branch: "sybra/wip"},
+			want: false,
+		},
+		{
+			name: "in-progress with nothing — not eligible",
+			tk:   task.Task{Status: task.StatusInProgress},
+			want: false,
+		},
+		{
+			name: "review tag excluded (inbound review task, not ours)",
+			tk:   task.Task{Status: task.StatusInReview, PRNumber: 42, Tags: []string{"review"}},
+			want: false,
+		},
+		{
+			name: "todo with PR — not eligible, not in monitored states",
+			tk:   task.Task{Status: task.StatusTodo, PRNumber: 42},
+			want: false,
+		},
+		{
+			name: "done with PR — not eligible, already terminal",
+			tk:   task.Task{Status: task.StatusDone, PRNumber: 42},
+			want: false,
+		},
+		{
+			name: "human-required with PR — not eligible, needs operator action first",
+			tk:   task.Task{Status: task.StatusHumanRequired, PRNumber: 42},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := prMonitorEligible(&tt.tk); got != tt.want {
+				t.Errorf("prMonitorEligible(%+v) = %v, want %v", tt.tk, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sybra/e2e_bootstrap_test.go
+++ b/internal/sybra/e2e_bootstrap_test.go
@@ -1,4 +1,4 @@
-//go:build !short
+//go:build e2e
 
 package sybra
 

--- a/internal/sybra/e2e_chaos_test.go
+++ b/internal/sybra/e2e_chaos_test.go
@@ -1,4 +1,4 @@
-//go:build !short
+//go:build e2e
 
 package sybra
 

--- a/internal/sybra/e2e_crossprovider_test.go
+++ b/internal/sybra/e2e_crossprovider_test.go
@@ -1,4 +1,4 @@
-//go:build !short
+//go:build e2e
 
 package sybra
 

--- a/internal/sybra/e2e_stats_test.go
+++ b/internal/sybra/e2e_stats_test.go
@@ -1,4 +1,4 @@
-//go:build !short
+//go:build e2e
 
 package sybra
 

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -1,4 +1,4 @@
-//go:build !short
+//go:build e2e
 
 package sybra
 
@@ -1589,60 +1589,6 @@ func TestE2E_DispatchPREvent_ReadyToMerge(t *testing.T) {
 	}
 }
 
-// TestPRIssueKindConstants_MatchBuiltinWorkflowTriggers locks in the string
-// values of the PR issue kind constants against the real builtin workflow
-// YAMLs they must match. This is the narrowest possible regression guard
-// for the ci-failure vs ci_failure (and ready-to-merge vs ready_to_merge)
-// dispatch-mismatch bugs: if the constants drift from what the YAML triggers
-// expect, dispatch silently stops matching — exactly the bug this test
-// prevents.
-func TestPRIssueKindConstants_MatchBuiltinWorkflowTriggers(t *testing.T) {
-	cases := []struct {
-		kind     synapsegithub.PRIssueKind
-		wantStr  string
-		yamlFile string // empty when no builtin workflow triggers on this kind
-		needle   string
-	}{
-		{
-			kind:     synapsegithub.PRIssueCIFailure,
-			wantStr:  "ci_failure",
-			yamlFile: "../../internal/workflow/builtin/pr-fix.yaml",
-			needle:   "value: conflict,ci_failure",
-		},
-		{
-			kind:    synapsegithub.PRIssueReadyToMerge,
-			wantStr: "ready_to_merge",
-			// No builtin workflow: auto-merge.yaml was removed because
-			// ready_to_merge short-circuits to app_reviews.handleAutoMerge
-			// direct path and never reaches DispatchEvent. The constant is
-			// still locked here so frontend + any new workflow stays in sync.
-		},
-		{
-			kind:     synapsegithub.PRIssueConflict,
-			wantStr:  "conflict",
-			yamlFile: "../../internal/workflow/builtin/pr-fix.yaml",
-			needle:   "value: conflict,ci_failure",
-		},
-	}
-	for _, tc := range cases {
-		t.Run(string(tc.kind), func(t *testing.T) {
-			if got := string(tc.kind); got != tc.wantStr {
-				t.Errorf("constant = %q, want %q", got, tc.wantStr)
-			}
-			if tc.yamlFile == "" {
-				return
-			}
-			raw, err := os.ReadFile(tc.yamlFile)
-			if err != nil {
-				t.Fatalf("read %s: %v", tc.yamlFile, err)
-			}
-			if !strings.Contains(string(raw), tc.needle) {
-				t.Errorf("%s missing trigger %q — dispatch would not match", tc.yamlFile, tc.needle)
-			}
-		})
-	}
-}
-
 // testTestingTaskWorkflowYAML mirrors the real builtin testing-task.yaml
 // shape (id, trigger, step graph, transitions, human actions) but uses
 // headless agents so two consecutive run_agent steps are deterministic on CI.
@@ -2216,79 +2162,6 @@ func TestE2E_RestartStaleSkipsTerminalWorkflow(t *testing.T) {
 	}
 	if len(tkAfter.Workflow.StepHistory) != len(before.StepHistory) {
 		t.Errorf("step history mutated: %d → %d", len(before.StepHistory), len(tkAfter.Workflow.StepHistory))
-	}
-}
-
-// TestPRMonitorEligible exercises the scan predicate used by the PR monitor
-// loop. The regression: tasks whose workflow exited to in-progress with a
-// live PR number (because an evaluate step crashed, or a manually-spawned
-// agent opened the PR outside the workflow) were silently dropped from the
-// scan because it only considered status=in-review. Result: failing CI on
-// those PRs was never fixed by pr-fix agents.
-func TestPRMonitorEligible(t *testing.T) {
-	tests := []struct {
-		name string
-		tk   task.Task
-		want bool
-	}{
-		{
-			name: "in-review with PR — original happy path",
-			tk:   task.Task{Status: task.StatusInReview, PRNumber: 42},
-			want: true,
-		},
-		{
-			name: "in-review with branch only — still eligible",
-			tk:   task.Task{Status: task.StatusInReview, Branch: "sybra/feat-x"},
-			want: true,
-		},
-		{
-			name: "in-review with neither PR nor branch — not eligible",
-			tk:   task.Task{Status: task.StatusInReview},
-			want: false,
-		},
-		{
-			name: "in-progress with PR — the regression case we're fixing",
-			tk:   task.Task{Status: task.StatusInProgress, PRNumber: 247},
-			want: true,
-		},
-		{
-			name: "in-progress with branch only — not eligible (avoid WIP false positives)",
-			tk:   task.Task{Status: task.StatusInProgress, Branch: "sybra/wip"},
-			want: false,
-		},
-		{
-			name: "in-progress with nothing — not eligible",
-			tk:   task.Task{Status: task.StatusInProgress},
-			want: false,
-		},
-		{
-			name: "review tag excluded (inbound review task, not ours)",
-			tk:   task.Task{Status: task.StatusInReview, PRNumber: 42, Tags: []string{"review"}},
-			want: false,
-		},
-		{
-			name: "todo with PR — not eligible, not in monitored states",
-			tk:   task.Task{Status: task.StatusTodo, PRNumber: 42},
-			want: false,
-		},
-		{
-			name: "done with PR — not eligible, already terminal",
-			tk:   task.Task{Status: task.StatusDone, PRNumber: 42},
-			want: false,
-		},
-		{
-			name: "human-required with PR — not eligible, needs operator action first",
-			tk:   task.Task{Status: task.StatusHumanRequired, PRNumber: 42},
-			want: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := prMonitorEligible(&tt.tk); got != tt.want {
-				t.Errorf("prMonitorEligible(%+v) = %v, want %v", tt.tk, got, tt.want)
-			}
-		})
 	}
 }
 

--- a/internal/sybra/orchestrator_resume_test.go
+++ b/internal/sybra/orchestrator_resume_test.go
@@ -1,4 +1,4 @@
-//go:build !short
+//go:build e2e
 
 package sybra
 

--- a/internal/sybra/svc_orchestrator_test.go
+++ b/internal/sybra/svc_orchestrator_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package sybra
 
 import (

--- a/internal/sybra/svc_reviews_test.go
+++ b/internal/sybra/svc_reviews_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package sybra
 
 import (

--- a/internal/sybra/workflow_enum_crosscheck_test.go
+++ b/internal/sybra/workflow_enum_crosscheck_test.go
@@ -1,7 +1,9 @@
 package sybra
 
 import (
+	"os"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/Automaat/sybra/internal/github"
@@ -84,4 +86,58 @@ func diffSet(a, b map[string]bool) []string {
 		}
 	}
 	return out
+}
+
+// TestPRIssueKindConstants_MatchBuiltinWorkflowTriggers locks in the string
+// values of the PR issue kind constants against the real builtin workflow
+// YAMLs they must match. This is the narrowest possible regression guard
+// for the ci-failure vs ci_failure (and ready-to-merge vs ready_to_merge)
+// dispatch-mismatch bugs: if the constants drift from what the YAML triggers
+// expect, dispatch silently stops matching — exactly the bug this test
+// prevents.
+func TestPRIssueKindConstants_MatchBuiltinWorkflowTriggers(t *testing.T) {
+	cases := []struct {
+		kind     github.PRIssueKind
+		wantStr  string
+		yamlFile string // empty when no builtin workflow triggers on this kind
+		needle   string
+	}{
+		{
+			kind:     github.PRIssueCIFailure,
+			wantStr:  "ci_failure",
+			yamlFile: "../../internal/workflow/builtin/pr-fix.yaml",
+			needle:   "value: conflict,ci_failure",
+		},
+		{
+			kind:    github.PRIssueReadyToMerge,
+			wantStr: "ready_to_merge",
+			// No builtin workflow: auto-merge.yaml was removed because
+			// ready_to_merge short-circuits to app_reviews.handleAutoMerge
+			// direct path and never reaches DispatchEvent. The constant is
+			// still locked here so frontend + any new workflow stays in sync.
+		},
+		{
+			kind:     github.PRIssueConflict,
+			wantStr:  "conflict",
+			yamlFile: "../../internal/workflow/builtin/pr-fix.yaml",
+			needle:   "value: conflict,ci_failure",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.kind), func(t *testing.T) {
+			if got := string(tc.kind); got != tc.wantStr {
+				t.Errorf("constant = %q, want %q", got, tc.wantStr)
+			}
+			if tc.yamlFile == "" {
+				return
+			}
+			raw, err := os.ReadFile(tc.yamlFile)
+			if err != nil {
+				t.Fatalf("read %s: %v", tc.yamlFile, err)
+			}
+			if !strings.Contains(string(raw), tc.needle) {
+				t.Errorf("%s missing trigger %q — dispatch would not match", tc.yamlFile, tc.needle)
+			}
+		})
+	}
 }

--- a/internal/workflow/engine_bench_test.go
+++ b/internal/workflow/engine_bench_test.go
@@ -1,0 +1,152 @@
+package workflow
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newBenchStore creates a Store backed by a temp dir, copying test-simple.yaml.
+func newBenchStore(b *testing.B) *Store {
+	b.Helper()
+	dir := b.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		b.Fatal(err)
+	}
+	src, err := os.ReadFile(filepath.Join("testdata", "test-simple.yaml"))
+	if err != nil {
+		b.Fatalf("read test workflow: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "test-simple.yaml"), src, 0o644); err != nil {
+		b.Fatal(err)
+	}
+	return store
+}
+
+// BenchmarkStartWorkflow measures workflow initialization: store lookup,
+// trigger condition evaluation, and spawning the first agent.
+func BenchmarkStartWorkflow(b *testing.B) {
+	store := newBenchStore(b)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	b.ResetTimer()
+	for i := range b.N {
+		id := fmt.Sprintf("t%d", i)
+		tasks.Put(TaskInfo{ID: id, Status: "todo", AgentMode: "headless"})
+		if err := engine.StartWorkflow(id, "test-simple"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkAdvanceStep_ToImplement measures AdvanceStep driving
+// triage → set_in_progress (sync) → implement (async agent spawn).
+// One synchronous set_status step executes inline per iteration.
+func BenchmarkAdvanceStep_ToImplement(b *testing.B) {
+	store := newBenchStore(b)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	b.ResetTimer()
+	for i := range b.N {
+		id := fmt.Sprintf("t%d", i)
+		tasks.Put(TaskInfo{ID: id, Status: "todo", AgentMode: "headless"})
+		if err := engine.StartWorkflow(id, "test-simple"); err != nil {
+			b.Fatal(err)
+		}
+		agentID := agents.LastID()
+		agents.SimulateComplete(id)
+		if err := engine.AdvanceStep(id, StepOutput{
+			StepID: "triage", Status: "completed", AgentID: agentID,
+		}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkAdvanceStep_Retry measures the retry path: triage fails and the
+// engine re-executes the same step (max_retries=3 in test-simple.yaml).
+func BenchmarkAdvanceStep_Retry(b *testing.B) {
+	store := newBenchStore(b)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	b.ResetTimer()
+	for i := range b.N {
+		id := fmt.Sprintf("t%d", i)
+		tasks.Put(TaskInfo{ID: id, Status: "todo", AgentMode: "headless"})
+		if err := engine.StartWorkflow(id, "test-simple"); err != nil {
+			b.Fatal(err)
+		}
+		agentID := agents.LastID()
+		agents.SimulateComplete(id)
+		if err := engine.AdvanceStep(id, StepOutput{
+			StepID: "triage", Status: "failed", AgentID: agentID,
+		}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkResumeStalled measures scanning a pool of stalled tasks and
+// re-dispatching them. Exercises ListTasks, per-task state checks, and
+// the inflightMutex map under realistic task counts.
+func BenchmarkResumeStalled(b *testing.B) {
+	const taskCount = 20
+	store := newBenchStore(b)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	for i := range taskCount {
+		id := fmt.Sprintf("stalled-%d", i)
+		tasks.Put(TaskInfo{ID: id, Status: "todo", AgentMode: "headless"})
+		if err := engine.StartWorkflow(id, "test-simple"); err != nil {
+			b.Fatal(err)
+		}
+		agents.SimulateComplete(id)
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		engine.ResumeStalled()
+	}
+}
+
+// BenchmarkConcurrentAdvance_DistinctTasks measures concurrent AdvanceStep
+// calls across independent tasks, exercising the per-task inflightMutex map
+// under goroutine contention.
+func BenchmarkConcurrentAdvance_DistinctTasks(b *testing.B) {
+	const parallelism = 8
+	store := newBenchStore(b)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	ids := make([]string, parallelism)
+	for i := range parallelism {
+		ids[i] = fmt.Sprintf("par-t%d", i)
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			id := ids[i%parallelism]
+			tasks.Put(TaskInfo{ID: id, Status: "todo", AgentMode: "headless"})
+			_ = engine.StartWorkflow(id, "test-simple")
+			agentID := agents.LastID()
+			agents.SimulateComplete(id)
+			_ = engine.AdvanceStep(id, StepOutput{
+				StepID: "triage", Status: "completed", AgentID: agentID,
+			})
+			i++
+		}
+	})
+}

--- a/internal/workflow/engine_bench_test.go
+++ b/internal/workflow/engine_bench_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 )
 
@@ -121,32 +122,30 @@ func BenchmarkResumeStalled(b *testing.B) {
 
 // BenchmarkConcurrentAdvance_DistinctTasks measures concurrent AdvanceStep
 // calls across independent tasks, exercising the per-task inflightMutex map
-// under goroutine contention.
+// under goroutine contention without same-ID collisions.
 func BenchmarkConcurrentAdvance_DistinctTasks(b *testing.B) {
-	const parallelism = 8
 	store := newBenchStore(b)
 	tasks := newMemTasks()
 	agents := newMockAgents()
 	engine := NewEngine(store, tasks, agents, discardLogger())
 
-	ids := make([]string, parallelism)
-	for i := range parallelism {
-		ids[i] = fmt.Sprintf("par-t%d", i)
-	}
-
+	var counter atomic.Int64
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
-		i := 0
 		for pb.Next() {
-			id := ids[i%parallelism]
+			id := fmt.Sprintf("par-t%d", counter.Add(1))
 			tasks.Put(TaskInfo{ID: id, Status: "todo", AgentMode: "headless"})
-			_ = engine.StartWorkflow(id, "test-simple")
-			agentID := agents.LastID()
+			if err := engine.StartWorkflow(id, "test-simple"); err != nil {
+				b.Error(err)
+				continue
+			}
+			agentID := agents.RunningAgentID(id)
 			agents.SimulateComplete(id)
-			_ = engine.AdvanceStep(id, StepOutput{
+			if err := engine.AdvanceStep(id, StepOutput{
 				StepID: "triage", Status: "completed", AgentID: agentID,
-			})
-			i++
+			}); err != nil {
+				b.Error(err)
+			}
 		}
 	})
 }

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -281,6 +281,13 @@ func (m *mockAgents) LastID() string {
 	return fmt.Sprintf("agent-%d", m.counter)
 }
 
+// RunningAgentID returns the agent ID currently assigned to a task.
+func (m *mockAgents) RunningAgentID(taskID string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.running[taskID]
+}
+
 // CallCount returns total StartAgent calls.
 func (m *mockAgents) CallCount() int {
 	m.mu.Lock()


### PR DESCRIPTION
## Motivation

`app.go` and `engine.go` had grown into monolithic files (900+ and 1500+ lines respectively), making it hard to navigate, review, and extend. Human review logic was buried inside the general App struct alongside unrelated concerns. The workflow engine had no focused-file separation, and no benchmark or parallel-execution unit tests existed.

Closes https://github.com/Automaat/sybra/issues/587

## Implementation information

**App decomposition:**
- Extracted all human-review bound methods and logic from `app.go` → `app_human_review.go` (~479 lines)
- Added `services.go` to wire service dependencies cleanly, reducing `app.go` from 900 to ~444 lines
- Added `app_human_review_test.go` (330 lines) and `app_reviews_unit_test.go` for isolated unit coverage

**Workflow engine split:**
- `engine.go` reduced from ~1489 to a thin coordinator; logic extracted into:
  - `engine_advance.go` — state-advance logic
  - `engine_dispatch.go` — agent dispatch routing
  - `engine_events.go` — event emission
  - `engine_steps.go` — step execution (878 lines)
  - `engine_retry.go` — retry/backoff logic
- Added `engine_bench_test.go` (benchmarks for state transitions) and `engine_parallel_test.go` (403 lines, parallel execution coverage)

**Frontend unit tests:** Added Svelte store tests for bgops, comments, convo, issues, loops, notifications, projects, renovate, reviews, stats, tasks, workflows stores.

**Modernization (alongside):** `errors.AsType[T]` (Go 1.26), `slices.SortFunc`, `wg.Go`, `range int`, `strings.Seq` idioms; CI tool-version validation.