### PR TITLE
test(e2e): add e2e build tag and dedicated CI job

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,29 @@
 # Contributing
 
+## Dev Workflow
+
+### Hot Module Replacement (HMR)
+
+`mise run dev` starts `wails dev`, which launches a Vite dev server with Svelte HMR and opens the Wails window proxied to that server. Svelte file saves trigger HMR — typically < 500 ms — not a full rebuild.
+
+### `.env.development` for local dev overrides
+
+Vite loads `frontend/.env.development` automatically in dev mode (`vite dev`). The file is committed and holds shared dev defaults. Use `frontend/.env.local` for machine-local values that must not be committed (Vite gitignores `*.local` automatically).
+
+Example `frontend/.env.development`:
+
+```
+# Explicit desktop mode (default). Switch to "web" for browser-only iteration.
+VITE_MODE=desktop
+```
+
+### Profiling build performance
+
+```bash
+cd frontend && npx vite build --profile
+# Generates vite-profile-<timestamp>.json — open in speedscope.app
+```
+
 ## Frontend Dependency Pin Strategy
 
 ### Caret (`^`) — public UI libraries

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,3 @@
+# Vite dev-mode defaults — committed, machine-shared.
+# For machine-local overrides use .env.local (gitignored by Vite).
+VITE_MODE=desktop

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,51 +1,55 @@
 import { defineConfig } from 'vitest/config'
+import { loadEnv } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import tailwindcss from '@tailwindcss/vite'
 import { fileURLToPath, URL } from 'url'
 
-const mode = process.env.VITE_MODE ?? 'desktop'
-const outDir = mode === 'web' ? 'dist-web' : 'dist'
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const viteMode = env.VITE_MODE ?? 'desktop'
+  const outDir = viteMode === 'web' ? 'dist-web' : 'dist'
 
-export default defineConfig({
-  plugins: [
-    tailwindcss(),
-    svelte(),
-  ],
-  build: {
-    outDir,
-    target: 'esnext',
-    chunkSizeWarningLimit: 1000,
-    rollupOptions: {
-      output: {
-        manualChunks(id) {
-          if (id.includes('@xyflow')) return 'vendor-flow'
-          if (id.includes('highlight.js')) return 'vendor-highlight'
-          if (id.includes('/marked')) return 'vendor-markdown'
+  return {
+    plugins: [
+      tailwindcss(),
+      svelte(),
+    ],
+    build: {
+      outDir,
+      target: 'esnext',
+      chunkSizeWarningLimit: 1000,
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes('@xyflow')) return 'vendor-flow'
+            if (id.includes('highlight.js')) return 'vendor-highlight'
+            if (id.includes('/marked')) return 'vendor-markdown'
+          },
         },
       },
     },
-  },
-  optimizeDeps: {
-    include: ['highlight.js', 'marked', 'marked-highlight', 'js-yaml', 'snarkdown'],
-  },
-  define: {
-    'import.meta.env.VITE_MODE': JSON.stringify(mode),
-  },
-  resolve: {
-    conditions: ['browser'],
-    alias: {
-      '$lib': fileURLToPath(new URL('./src/lib', import.meta.url)),
+    optimizeDeps: {
+      include: ['highlight.js', 'marked', 'marked-highlight', 'js-yaml', 'snarkdown'],
     },
-  },
-  test: {
-    environment: 'jsdom',
-    include: ['src/**/*.test.ts'],
-    exclude: ['e2e/**', 'node_modules/**'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json'],
-      include: ['src/**/*.ts', 'src/**/*.svelte'],
-      exclude: ['src/main.ts'],
+    define: {
+      'import.meta.env.VITE_MODE': JSON.stringify(viteMode),
     },
-  },
+    resolve: {
+      conditions: ['browser'],
+      alias: {
+        '$lib': fileURLToPath(new URL('./src/lib', import.meta.url)),
+      },
+    },
+    test: {
+      environment: 'jsdom',
+      include: ['src/**/*.test.ts'],
+      exclude: ['e2e/**', 'node_modules/**'],
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'json'],
+        include: ['src/**/*.ts', 'src/**/*.svelte'],
+        exclude: ['src/main.ts'],
+      },
+    },
+  }
 })

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,6 +13,20 @@ export default defineConfig({
   ],
   build: {
     outDir,
+    target: 'esnext',
+    chunkSizeWarningLimit: 1000,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('@xyflow')) return 'vendor-flow'
+          if (id.includes('highlight.js')) return 'vendor-highlight'
+          if (id.includes('/marked')) return 'vendor-markdown'
+        },
+      },
+    },
+  },
+  optimizeDeps: {
+    include: ['highlight.js', 'marked', 'marked-highlight', 'js-yaml', 'snarkdown'],
   },
   define: {
     'import.meta.env.VITE_MODE': JSON.stringify(mode),


### PR DESCRIPTION
## Motivation

E2e tests were gated by `//go:build !short` — they ran whenever regular unit tests ran unless `-short` was passed, with no clean way to opt in/out of just the e2e suite. There was no dedicated CI job, so e2e coverage was either bundled with unit runs (slow) or skipped entirely.

## Implementation information

- Switched all e2e test files from `//go:build !short` to `//go:build e2e`, giving the suite its own explicit tag
- Added `test-go-e2e` CI job: builds frontend (required for `//go:embed`) then runs `go test -tags e2e -timeout 10m ./internal/sybra/...`
- Added `TestE2E_CrossProvider_DualPlan` — exercises dual-provider parallel planning end-to-end (triage → plan_claude + plan_codex → converge → review_plan)
- Moved `TestPRIssueKindConstants_MatchBuiltinWorkflowTriggers` and `TestPRMonitorEligible` out of e2e scope into unit tests (no fake-claude needed)
- Bundled: App struct decomposition (#599), `errors.AsType[T]` migration (#597), frontend store coverage to 93% (#595), Vite HMR optimization (#594), CI tool-version and npm-lockfile integrity checks (#598, #596)

Closes https://github.com/Automaat/sybra/issues/593