### PR TITLE
ci(ci): extend version sync checks and e2e telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,10 @@ jobs:
           echo "### Fast Tests (${{ matrix.provider }})" >> "$GITHUB_STEP_SUMMARY"
           test -f test-results/results.json && node e2e/timing-summary.mjs >> "$GITHUB_STEP_SUMMARY" || true
 
+      - name: Clear results before integration phase
+        if: always()
+        run: rm -f frontend/test-results/results.json
+
       - name: Run integration e2e tests (target ≤10 min)
         run: cd frontend && npx playwright test --grep "@integration"
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
   e2e:
     name: E2E Tests (${{ matrix.provider }})
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -245,11 +245,31 @@ jobs:
             sleep 1
           done
 
-      - name: Run e2e tests
-        run: cd frontend && npx playwright test --reporter=github
+      - name: Run fast e2e tests (target ≤5 min)
+        run: cd frontend && npx playwright test --grep-invert "@integration|@flaky"
         env:
           SYBRA_HOME: /tmp/sybra-e2e
           SYBRA_E2E_PROVIDER: ${{ matrix.provider }}
+
+      - name: Write fast test timing summary
+        if: always()
+        working-directory: frontend
+        run: |
+          echo "### Fast Tests (${{ matrix.provider }})" >> "$GITHUB_STEP_SUMMARY"
+          test -f test-results/results.json && node e2e/timing-summary.mjs >> "$GITHUB_STEP_SUMMARY" || true
+
+      - name: Run integration e2e tests (target ≤10 min)
+        run: cd frontend && npx playwright test --grep "@integration"
+        env:
+          SYBRA_HOME: /tmp/sybra-e2e
+          SYBRA_E2E_PROVIDER: ${{ matrix.provider }}
+
+      - name: Write integration test timing summary
+        if: always()
+        working-directory: frontend
+        run: |
+          echo "### Integration Tests (${{ matrix.provider }})" >> "$GITHUB_STEP_SUMMARY"
+          test -f test-results/results.json && node e2e/timing-summary.mjs >> "$GITHUB_STEP_SUMMARY" || true
 
       - name: Dump server log
         if: failure()
@@ -259,5 +279,80 @@ jobs:
         if: failure()
         with:
           name: playwright-report-${{ matrix.provider }}
+          path: frontend/test-results/
+          retention-days: 7
+
+  e2e-flaky:
+    name: E2E Flaky (non-blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+
+      - name: Install frontend deps
+        run: cd frontend && npm ci
+
+      - name: Install Playwright browsers
+        run: cd frontend && npx playwright install chromium
+
+      - name: Seed e2e fixtures
+        run: |
+          mkdir -p "$SYBRA_HOME/tasks"
+          cp frontend/e2e/fixtures/*.md "$SYBRA_HOME/tasks/"
+          cat > "$SYBRA_HOME/config.yaml" <<EOF
+          agent:
+            provider: claude
+          EOF
+        env:
+          SYBRA_HOME: /tmp/sybra-e2e
+
+      - name: Build web frontend
+        run: cd frontend && npm run build:web
+
+      - name: Build sybra-server
+        run: go build -o bin/sybra-server ./cmd/sybra-server
+
+      - name: Start sybra-server
+        run: |
+          SYBRA_HOME=/tmp/sybra-e2e \
+          SYBRA_STATIC_DIR=frontend/dist-web \
+          ./bin/sybra-server > /tmp/sybra-server.log 2>&1 &
+          echo "Waiting for sybra-server..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/health > /dev/null 2>&1; then
+              echo "Ready after ${i}s"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "::error::sybra-server timed out"
+              cat /tmp/sybra-server.log
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Run flaky e2e tests
+        run: cd frontend && npx playwright test --grep "@flaky" --retries=5
+        env:
+          SYBRA_HOME: /tmp/sybra-e2e
+
+      - name: Write flaky test timing summary
+        if: always()
+        working-directory: frontend
+        run: |
+          echo "### Flaky Tests" >> "$GITHUB_STEP_SUMMARY"
+          test -f test-results/results.json && node e2e/timing-summary.mjs >> "$GITHUB_STEP_SUMMARY" || true
+
+      - name: Dump server log
+        if: always()
+        run: cat /tmp/sybra-server.log || true
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: playwright-report-flaky
           path: frontend/test-results/
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
         working-directory: frontend
         run: |
           echo "### Fast Tests (${{ matrix.provider }})" >> "$GITHUB_STEP_SUMMARY"
-          test -f test-results/results.json && node e2e/timing-summary.mjs >> "$GITHUB_STEP_SUMMARY" || true
+          if test -f test-results/results.json; then node e2e/timing-summary.mjs >> "$GITHUB_STEP_SUMMARY"; fi
 
       - name: Clear results before integration phase
         if: always()
@@ -273,7 +273,7 @@ jobs:
         working-directory: frontend
         run: |
           echo "### Integration Tests (${{ matrix.provider }})" >> "$GITHUB_STEP_SUMMARY"
-          test -f test-results/results.json && node e2e/timing-summary.mjs >> "$GITHUB_STEP_SUMMARY" || true
+          if test -f test-results/results.json; then node e2e/timing-summary.mjs >> "$GITHUB_STEP_SUMMARY"; fi
 
       - name: Dump server log
         if: failure()
@@ -348,7 +348,7 @@ jobs:
         working-directory: frontend
         run: |
           echo "### Flaky Tests" >> "$GITHUB_STEP_SUMMARY"
-          test -f test-results/results.json && node e2e/timing-summary.mjs >> "$GITHUB_STEP_SUMMARY" || true
+          if test -f test-results/results.json; then node e2e/timing-summary.mjs >> "$GITHUB_STEP_SUMMARY"; fi
 
       - name: Dump server log
         if: always()

--- a/frontend/e2e/provider-smoke.spec.ts
+++ b/frontend/e2e/provider-smoke.spec.ts
@@ -23,7 +23,7 @@ test.describe.configure({ mode: 'serial' })
 // Smoke: core pages render for each provider in the matrix.
 // When SYNAPSE_E2E_PROVIDER is set (CI), only the matching spec runs.
 // ---------------------------------------------------------------------------
-test.describe('Provider smoke: board', () => {
+test.describe('Provider smoke: board', { tag: '@integration' }, () => {
   for (const spec of selectedProviders()) {
     test(`board loads [${spec.provider}]`, async ({ page }) => {
       await page.goto('/')
@@ -48,7 +48,7 @@ test.describe('Provider smoke: board', () => {
 // run is reflected in the Settings UI.  Only meaningful in CI where
 // SYNAPSE_E2E_PROVIDER is set and config.yaml is pre-seeded.
 // ---------------------------------------------------------------------------
-test.describe('Provider config reflected in Settings', () => {
+test.describe('Provider config reflected in Settings', { tag: '@integration' }, () => {
   test('active provider matches SYNAPSE_E2E_PROVIDER', async ({ page }) => {
     const envProvider = process.env.SYNAPSE_E2E_PROVIDER?.trim()
     test.skip(!envProvider, 'SYNAPSE_E2E_PROVIDER not set — skipped on local runs')

--- a/frontend/e2e/settings-provider.spec.ts
+++ b/frontend/e2e/settings-provider.spec.ts
@@ -37,7 +37,7 @@ async function restoreAgentSettings(page: Page, original: { provider: string; mo
 
 test.describe.configure({ mode: 'serial' })
 
-test.describe('Settings provider matrix', () => {
+test.describe('Settings provider matrix', { tag: '@integration' }, () => {
   for (const spec of selectedProviders()) {
     test(`switches model options for ${spec.provider}`, async ({ page }) => {
       await goToSettings(page)

--- a/frontend/e2e/tasks.spec.ts
+++ b/frontend/e2e/tasks.spec.ts
@@ -251,12 +251,7 @@ test.describe('Navigation Rail', () => {
 })
 
 test.describe('Task watcher', () => {
-  test('board updates when task file is created externally', async ({ page }) => {
-    test.fixme(
-      process.env.CI === 'true',
-      'External fs watcher create events are unreliable on GitHub macOS Wails runs',
-    )
-
+  test('board updates when task file is created externally', { tag: '@flaky', timeout: 35_000 }, async ({ page }) => {
     await goToTaskList(page)
     await waitForTasks(page)
 

--- a/frontend/e2e/tasks.spec.ts
+++ b/frontend/e2e/tasks.spec.ts
@@ -251,7 +251,8 @@ test.describe('Navigation Rail', () => {
 })
 
 test.describe('Task watcher', () => {
-  test('board updates when task file is created externally', { tag: '@flaky', timeout: 35_000 }, async ({ page }) => {
+  test('board updates when task file is created externally', { tag: '@flaky' }, async ({ page }) => {
+    test.setTimeout(35_000)
     await goToTaskList(page)
     await waitForTasks(page)
 

--- a/frontend/e2e/timing-summary.mjs
+++ b/frontend/e2e/timing-summary.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// Parses test-results/results.json (Playwright JSON reporter) and writes
+// a Markdown timing table to stdout for appending to $GITHUB_STEP_SUMMARY.
+// Run from the frontend/ directory: node e2e/timing-summary.mjs
+import { readFileSync } from 'node:fs'
+
+const data = JSON.parse(readFileSync('test-results/results.json', 'utf8'))
+const rows = []
+
+function extractSpecs(suite) {
+  for (const spec of suite.specs ?? []) {
+    const results = spec.tests?.[0]?.results ?? []
+    if (results.length > 0) {
+      const last = results.at(-1)
+      rows.push({
+        title: spec.fullTitle ?? spec.title,
+        duration: last.duration,
+        status: last.status,
+        retry: last.retry,
+      })
+    }
+  }
+  for (const child of suite.suites ?? []) {
+    extractSpecs(child)
+  }
+}
+
+for (const suite of data.suites ?? []) {
+  extractSpecs(suite)
+}
+
+rows.sort((a, b) => b.duration - a.duration)
+
+const totalMs = data.stats?.duration ?? 0
+
+function statusIcon(status, retry) {
+  if (status === 'passed' && retry > 0) return '⚠️ flaky'
+  if (status === 'passed') return '✅'
+  if (status === 'skipped') return '⏭️'
+  return '❌'
+}
+
+const lines = [
+  `**Total:** ${rows.length} tests · ${Math.round(totalMs / 1000)}s`,
+  '',
+  '| Test | Duration | Status |',
+  '|------|----------|--------|',
+  ...rows.map((r) => `| ${r.title} | ${r.duration}ms | ${statusIcon(r.status, r.retry)} |`),
+  '',
+]
+
+process.stdout.write(lines.join('\n'))

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -5,7 +5,9 @@ export default defineConfig({
   testIgnore: process.env.PLAYWRIGHT_SCREENSHOTS ? [] : ['**/screenshots.spec.ts'],
   timeout: 10_000,
   retries: process.env.CI ? 2 : 0,
-  reporter: process.env.CI ? 'github' : 'list',
+  reporter: process.env.CI
+    ? [['github'], ['json', { outputFile: 'test-results/results.json' }]]
+    : [['list']],
   use: {
     baseURL: 'http://localhost:8080',
     screenshot: 'only-on-failure',


### PR DESCRIPTION
## Motivation

Version sync checks in CI only covered README.md and CLAUDE.md against go.mod. This left mise.toml and frontend/package.json `engines.node` silently stale after toolchain bumps — caught only at runtime. npm lockfile drift was similarly undetected. E2E tests had no SLA visibility and no structured handling for flaky tests, making CI diagnosis slow.

Closes https://github.com/Automaat/sybra/issues/592

## Implementation information

- **Version sync** (`version-sync` job): added checks that `mise.toml` Go version matches `go.mod`, and `frontend/package.json` `engines.node` matches `mise.toml` node version
- **npm lockfile integrity**: new `npm-lockfile-integrity` CI job + `.githooks/pre-commit` hook that both run `npm install --package-lock-only` and diff-check the result
- **Go E2E job** (`test-go-e2e`): runs `go test -tags e2e ./internal/sybra/...` with frontend pre-built for `//go:embed`
- **E2E split**: fast tests (no `@integration`/`@flaky` tag), integration tests (`@integration`), and non-blocking flaky job (`@flaky`, `continue-on-error: true`, 5 retries); results.json cleared between phases to avoid stale telemetry
- **Timing telemetry**: each phase writes a `timing-summary.mjs` summary to `$GITHUB_STEP_SUMMARY` so slow tests are visible without digging through logs; e2e timeout bumped from 10 → 15 min to accommodate the integration phase