### PR TITLE
fix(frontend): add error boundaries for Svelte 5 callbacks

### DIFF
--- a/frontend/src/components/ErrorBoundary.svelte
+++ b/frontend/src/components/ErrorBoundary.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+  import { notificationStore } from '../stores/notifications.svelte.js'
+
+  interface Props {
+    children?: Snippet
+    fallback?: Snippet<[unknown, () => void]>
+    onerror?: (error: unknown, reset: () => void) => void
+  }
+
+  const { children, fallback, onerror }: Props = $props()
+
+  function handleError(error: unknown, reset: () => void) {
+    const message = error instanceof Error ? error.message : String(error)
+    notificationStore.pushLocal('error', 'Component error', message)
+    onerror?.(error, reset)
+  }
+</script>
+
+<svelte:boundary onerror={handleError}>
+  {#if children}{@render children()}{/if}
+  {#snippet failed(error, reset)}
+    {#if fallback}
+      {@render fallback(error, reset)}
+    {:else}
+      <div class="rounded-lg border border-error-300 bg-error-50 p-4 text-error-700 dark:border-error-700 dark:bg-error-900/20 dark:text-error-400">
+        <p class="text-sm font-medium">Something went wrong</p>
+        <p class="mt-1 text-xs opacity-75">{error instanceof Error ? error.message : String(error)}</p>
+        <button
+          type="button"
+          class="mt-2 text-xs underline hover:no-underline"
+          onclick={reset}
+        >
+          Try again
+        </button>
+      </div>
+    {/if}
+  {/snippet}
+</svelte:boundary>

--- a/frontend/src/components/ErrorBoundary.svelte.test.ts
+++ b/frontend/src/components/ErrorBoundary.svelte.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/svelte'
+import ErrorBoundary from './ErrorBoundary.svelte'
+
+vi.mock('../stores/notifications.svelte.js', () => ({
+  notificationStore: {
+    pushLocal: vi.fn(),
+  },
+}))
+
+describe('ErrorBoundary', () => {
+  afterEach(cleanup)
+
+  it('renders without errors', () => {
+    const { container } = render(ErrorBoundary, {
+      props: {},
+    })
+    expect(container).toBeDefined()
+  })
+})

--- a/frontend/src/components/ErrorBoundary.svelte.test.ts
+++ b/frontend/src/components/ErrorBoundary.svelte.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, cleanup } from '@testing-library/svelte'
+import { render, screen, fireEvent, cleanup } from '@testing-library/svelte'
 import ErrorBoundary from './ErrorBoundary.svelte'
 
 vi.mock('../stores/notifications.svelte.js', () => ({
@@ -8,13 +8,72 @@ vi.mock('../stores/notifications.svelte.js', () => ({
   },
 }))
 
-describe('ErrorBoundary', () => {
-  afterEach(cleanup)
+const { notificationStore } = await import('../stores/notifications.svelte.js')
 
-  it('renders without errors', () => {
-    const { container } = render(ErrorBoundary, {
-      props: {},
-    })
+// In Svelte 5, snippets are plain functions; passing a throwing function as
+// children exercises the <svelte:boundary> path without needing a fixture component.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyProps = any
+
+describe('ErrorBoundary', () => {
+  afterEach(() => {
+    cleanup()
+    vi.mocked(notificationStore.pushLocal).mockClear()
+  })
+
+  it('renders without errors when empty', () => {
+    const { container } = render(ErrorBoundary, { props: {} })
     expect(container).toBeDefined()
+    expect(container.textContent).not.toContain('Something went wrong')
+  })
+
+  it('shows default fallback and pushes notification when child throws', async () => {
+    const throwingSnippet = () => { throw new Error('render error') }
+
+    render(ErrorBoundary, { props: { children: throwingSnippet } as AnyProps })
+
+    await vi.waitFor(() => {
+      expect(vi.mocked(notificationStore.pushLocal)).toHaveBeenCalledWith(
+        'error',
+        'Component error',
+        'render error',
+      )
+    })
+    expect(screen.getByText('Something went wrong')).toBeDefined()
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeDefined()
+  })
+
+  it('calls onerror prop with error and reset when child throws', async () => {
+    const throwingSnippet = () => { throw new Error('onerror test') }
+    const onerror = vi.fn()
+
+    render(ErrorBoundary, { props: { children: throwingSnippet, onerror } } as AnyProps)
+
+    await vi.waitFor(() => {
+      expect(onerror).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'onerror test' }),
+        expect.any(Function),
+      )
+    })
+  })
+
+  it('reset button re-renders children after error clears', async () => {
+    let shouldThrow = true
+    const conditionalSnippet = () => {
+      if (shouldThrow) throw new Error('conditional error')
+    }
+
+    render(ErrorBoundary, { props: { children: conditionalSnippet } } as AnyProps)
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Something went wrong')).toBeDefined()
+    })
+
+    shouldThrow = false
+    await fireEvent.click(screen.getByRole('button', { name: 'Try again' }))
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText('Something went wrong')).toBeNull()
+    })
   })
 })

--- a/frontend/src/components/QuickAddTask.svelte
+++ b/frontend/src/components/QuickAddTask.svelte
@@ -3,6 +3,7 @@
   import { Folder, X } from '@lucide/svelte'
   import { taskStore } from '../stores/tasks.svelte.js'
   import { projectStore } from '../stores/projects.svelte.js'
+  import { notificationStore } from '../stores/notifications.svelte.js'
   import { detectProject } from '../lib/detectProject.js'
 
   interface Props {
@@ -99,6 +100,8 @@
       value = ''
       onclose()
       oncreated?.(t.id)
+    } catch (err) {
+      notificationStore.pushLocal('error', 'Create failed', String(err))
     } finally {
       submitting = false
     }

--- a/frontend/src/components/QuickAddTask.svelte
+++ b/frontend/src/components/QuickAddTask.svelte
@@ -92,19 +92,27 @@
     if (!value.trim() || submitting) return
 
     submitting = true
+    let t
     try {
-      let t = await taskStore.create(value.trim(), '', 'interactive')
-      if (selectedProject) {
-        t = await taskStore.update(t.id, { project_id: selectedProject })
-      }
-      value = ''
-      onclose()
-      oncreated?.(t.id)
+      t = await taskStore.create(value.trim(), '', 'interactive')
     } catch (err) {
       notificationStore.pushLocal('error', 'Create failed', String(err))
-    } finally {
       submitting = false
+      return
     }
+
+    if (selectedProject) {
+      try {
+        t = await taskStore.update(t.id, { project_id: selectedProject })
+      } catch (err) {
+        notificationStore.pushLocal('error', 'Failed to assign project', String(err))
+      }
+    }
+
+    value = ''
+    onclose()
+    oncreated?.(t.id)
+    submitting = false
   }
 
   function dismissDetection() {

--- a/frontend/src/components/QuickAddTask.svelte.test.ts
+++ b/frontend/src/components/QuickAddTask.svelte.test.ts
@@ -21,6 +21,13 @@ vi.mock('../lib/detectProject.js', () => ({
   detectProject: vi.fn().mockReturnValue(null),
 }))
 
+vi.mock('../stores/notifications.svelte.js', () => ({
+  notificationStore: {
+    pushLocal: vi.fn(),
+  },
+}))
+
+const { notificationStore } = await import('../stores/notifications.svelte.js')
 const QuickAddTask = (await import('./QuickAddTask.svelte')).default
 
 describe('QuickAddTask', () => {
@@ -30,6 +37,7 @@ describe('QuickAddTask', () => {
 
   afterEach(() => {
     cleanup()
+    vi.restoreAllMocks()
   })
 
   it('renders nothing when closed', () => {
@@ -83,5 +91,42 @@ describe('QuickAddTask', () => {
       props: { open: true, onclose: vi.fn(), oncreated: vi.fn() },
     })
     expect(container).toBeDefined()
+  })
+
+  describe('partial-success: create succeeds but update fails', () => {
+    it('closes dialog and calls oncreated even when project update fails', async () => {
+      const onclose = vi.fn()
+      const oncreated = vi.fn()
+      const created = { id: 'task-new' }
+      mockCreate.mockResolvedValue(created)
+      mockUpdate.mockRejectedValue(new Error('update failed'))
+
+      render(QuickAddTask, { props: { open: true, onclose, oncreated } })
+      const input = screen.getByPlaceholderText('Task title, link, or note...')
+      await fireEvent.input(input, { target: { value: 'My task' } })
+      await fireEvent.submit(input.closest('form')!)
+
+      await vi.waitFor(() => {
+        expect(onclose).toHaveBeenCalledOnce()
+      })
+      expect(oncreated).toHaveBeenCalledWith('task-new')
+    })
+
+    it('shows create error and keeps dialog open when create fails', async () => {
+      const onclose = vi.fn()
+      mockCreate.mockRejectedValue(new Error('network error'))
+
+      render(QuickAddTask, { props: { open: true, onclose } })
+      const input = screen.getByPlaceholderText('Task title, link, or note...')
+      await fireEvent.input(input, { target: { value: 'My task' } })
+      await fireEvent.submit(input.closest('form')!)
+
+      await vi.waitFor(() => {
+        expect(notificationStore.pushLocal).toHaveBeenCalledWith(
+          'error', 'Create failed', 'Error: network error'
+        )
+      })
+      expect(onclose).not.toHaveBeenCalled()
+    })
   })
 })

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -3,6 +3,7 @@
   import type { task } from '../../wailsjs/go/models.js'
   import { agentStore } from '../stores/agents.svelte.js'
   import { reviewStore } from '../stores/reviews.svelte.js'
+  import { notificationStore } from '../stores/notifications.svelte.js'
   import { STATUS_OPTIONS } from '../lib/statuses.js'
   import { PRIORITY_OPTIONS } from '../lib/priorities.js'
 
@@ -30,9 +31,13 @@
 
   async function copyBranch(e: MouseEvent) {
     e.stopPropagation()
-    await navigator.clipboard.writeText(taskBranchName)
-    copiedBranch = true
-    setTimeout(() => { copiedBranch = false }, 1500)
+    try {
+      await navigator.clipboard.writeText(taskBranchName)
+      copiedBranch = true
+      setTimeout(() => { copiedBranch = false }, 1500)
+    } catch {
+      notificationStore.pushLocal('error', 'Copy failed', 'Could not copy branch name to clipboard')
+    }
   }
 
   const triaging = $derived(

--- a/frontend/src/components/TaskCard.svelte.test.ts
+++ b/frontend/src/components/TaskCard.svelte.test.ts
@@ -2,6 +2,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/svelte'
 import TaskCard from './TaskCard.svelte'
 
+vi.mock('../stores/notifications.svelte.js', () => ({
+  notificationStore: {
+    pushLocal: vi.fn(),
+  },
+}))
+
+const { notificationStore } = await import('../stores/notifications.svelte.js')
+
 const mockTask = {
   id: 'task-1',
   slug: 'test-task',
@@ -61,6 +69,44 @@ describe('TaskCard', () => {
     render(TaskCard, { props: { task: mockTask, onclick: handler } })
     await fireEvent.click(screen.getByRole('button'))
     expect(handler).toHaveBeenCalledOnce()
+  })
+
+  describe('copyBranch error handling', () => {
+    beforeEach(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText: vi.fn() },
+        configurable: true,
+        writable: true,
+      })
+      vi.mocked(notificationStore.pushLocal).mockClear()
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('shows notification when clipboard write fails', async () => {
+      vi.mocked(navigator.clipboard.writeText).mockRejectedValueOnce(new Error('Permission denied'))
+      const taskWithProject = { ...mockTask, projectId: 'owner/repo' }
+      render(TaskCard, { props: { task: taskWithProject, onclick: () => {} } })
+
+      const copyBtn = screen.getByTitle('Copy branch name (⇧⌘.)')
+      await fireEvent.click(copyBtn)
+
+      expect(notificationStore.pushLocal).toHaveBeenCalledWith('error', 'Copy failed', 'Could not copy branch name to clipboard')
+    })
+
+    it('copies branch name on success', async () => {
+      vi.mocked(navigator.clipboard.writeText).mockResolvedValueOnce(undefined)
+      const taskWithProject = { ...mockTask, projectId: 'owner/repo' }
+      render(TaskCard, { props: { task: taskWithProject, onclick: () => {} } })
+
+      const copyBtn = screen.getByTitle('Copy branch name (⇧⌘.)')
+      await fireEvent.click(copyBtn)
+
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining(mockTask.id))
+      expect(notificationStore.pushLocal).not.toHaveBeenCalled()
+    })
   })
 
   it('shows Needs Review badge for plan-review status', () => {

--- a/frontend/src/lib/callbacks.ts
+++ b/frontend/src/lib/callbacks.ts
@@ -1,0 +1,18 @@
+import { notificationStore } from '../stores/notifications.svelte.js'
+
+/**
+ * Wraps an async callback so errors are caught and shown as notifications
+ * instead of propagating and crashing the component.
+ */
+export function guard<Args extends unknown[]>(
+  fn: (...args: Args) => void | Promise<void>,
+  title = 'Action failed',
+): (...args: Args) => Promise<void> {
+  return async (...args: Args) => {
+    try {
+      await fn(...args)
+    } catch (err) {
+      notificationStore.pushLocal('error', title, String(err))
+    }
+  }
+}

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -5,6 +5,7 @@
   import { agentState } from '../lib/events.js'
   import { renderMarkdown } from '../lib/markdown.js'
   import { taskStore } from '../stores/tasks.svelte.js'
+  import { notificationStore } from '../stores/notifications.svelte.js'
   import { agentStore } from '../stores/agents.svelte.js'
   import { reviewStore } from '../stores/reviews.svelte.js'
   import { connectionStore } from '../stores/connection.svelte.js'
@@ -121,16 +122,24 @@
 
   async function copyId() {
     if (!t) return
-    await navigator.clipboard.writeText(t.id)
-    copied = true
-    setTimeout(() => { copied = false }, 1500)
+    try {
+      await navigator.clipboard.writeText(t.id)
+      copied = true
+      setTimeout(() => { copied = false }, 1500)
+    } catch (err) {
+      notificationStore.pushLocal('error', 'Copy failed', String(err))
+    }
   }
 
   async function copyBranch() {
     if (!t || !t.projectId) return
-    await navigator.clipboard.writeText(taskBranchName)
-    copiedBranch = true
-    setTimeout(() => { copiedBranch = false }, 1500)
+    try {
+      await navigator.clipboard.writeText(taskBranchName)
+      copiedBranch = true
+      setTimeout(() => { copiedBranch = false }, 1500)
+    } catch (err) {
+      notificationStore.pushLocal('error', 'Copy failed', String(err))
+    }
   }
 
   $effect(() => {

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -475,15 +475,21 @@
     const title = newTaskTitle.trim()
     if (!title) return
     newTaskTitle = ''
+    let created
     try {
-      const created = await taskStore.create(title, '', 'headless')
-      if (status !== 'new') {
-        await taskStore.update(created.id, { status })
-      }
-      requestAnimationFrame(() => inputRef?.focus())
+      created = await taskStore.create(title, '', 'headless')
     } catch (err) {
       notificationStore.pushLocal('error', 'Create failed', String(err))
+      return
     }
+    if (status !== 'new') {
+      try {
+        await taskStore.update(created.id, { status })
+      } catch (err) {
+        notificationStore.pushLocal('error', 'Failed to set status', String(err))
+      }
+    }
+    requestAnimationFrame(() => inputRef?.focus())
   }
 
   function handleInputKeydown(e: KeyboardEvent, status: string) {

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -475,11 +475,15 @@
     const title = newTaskTitle.trim()
     if (!title) return
     newTaskTitle = ''
-    const created = await taskStore.create(title, '', 'headless')
-    if (status !== 'new') {
-      await taskStore.update(created.id, { status })
+    try {
+      const created = await taskStore.create(title, '', 'headless')
+      if (status !== 'new') {
+        await taskStore.update(created.id, { status })
+      }
+      requestAnimationFrame(() => inputRef?.focus())
+    } catch (err) {
+      notificationStore.pushLocal('error', 'Create failed', String(err))
     }
-    requestAnimationFrame(() => inputRef?.focus())
   }
 
   function handleInputKeydown(e: KeyboardEvent, status: string) {

--- a/frontend/src/pages/TaskList.svelte.test.ts
+++ b/frontend/src/pages/TaskList.svelte.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/svelte'
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
 
 vi.mock('../stores/tasks.svelte.js', () => ({
   taskStore: {
     loading: false,
     error: '',
     list: [],
+    tasks: new Map(),
+    create: vi.fn(),
+    update: vi.fn(),
   },
 }))
 
@@ -15,7 +18,14 @@ vi.mock('../stores/projects.svelte.js', () => ({
   },
 }))
 
+vi.mock('../stores/notifications.svelte.js', () => ({
+  notificationStore: {
+    pushLocal: vi.fn(),
+  },
+}))
+
 const { taskStore } = await import('../stores/tasks.svelte.js')
+const { notificationStore } = await import('../stores/notifications.svelte.js')
 const TaskList = (await import('./TaskList.svelte')).default
 
 const mockTask = (id: string, title: string, status = 'todo') => ({
@@ -34,7 +44,8 @@ const mockTask = (id: string, title: string, status = 'todo') => ({
 
 describe('TaskList', () => {
   beforeEach(() => {
-    Object.assign(taskStore, { loading: false, error: '', list: [] })
+    Object.assign(taskStore, { loading: false, error: '', list: [], tasks: new Map(), create: vi.fn(), update: vi.fn() })
+    vi.mocked(notificationStore.pushLocal).mockClear()
   })
 
   afterEach(() => {
@@ -74,5 +85,23 @@ describe('TaskList', () => {
     render(TaskList, { props: { onselect: vi.fn() } })
     expect(screen.getByText('First Task')).toBeDefined()
     expect(screen.getByText('Second Task')).toBeDefined()
+  })
+
+  describe('submitInlineAdd error handling', () => {
+    it('shows notification when task creation fails', async () => {
+      vi.mocked(taskStore.create).mockRejectedValueOnce(new Error('Network error'))
+      render(TaskList, { props: { onselect: vi.fn() } })
+
+      const addBtn = screen.getAllByTitle('Add task (C)')[0]
+      await fireEvent.click(addBtn)
+
+      const input = screen.getByPlaceholderText('Task title')
+      await fireEvent.input(input, { target: { value: 'New task' } })
+      await fireEvent.keyDown(input, { key: 'Enter' })
+
+      await new Promise((r) => setTimeout(r, 0))
+
+      expect(notificationStore.pushLocal).toHaveBeenCalledWith('error', 'Create failed', 'Error: Network error')
+    })
   })
 })


### PR DESCRIPTION
## Motivation

Svelte 5 callback props replace the old `on:` directive but require explicit error handling — unhandled throws in callback props propagate silently or crash the component tree. Issue #588 identified that the frontend had no systematic pattern for this, leaving async operations like clipboard writes and task creation with missing or inconsistent `try-catch` coverage.

## Implementation information

- Added `guard()` helper in `frontend/src/lib/callbacks.ts` that wraps async callbacks with `try-catch` + `notificationStore.pushLocal` so all callback failures surface as toast notifications rather than silently propagating
- Added `ErrorBoundary.svelte` using `<svelte:boundary>` to catch render errors from children and display fallback UI with a reset button
- Fixed `copyBranch` in `TaskCard`: clipboard errors now show a notification
- Fixed `submitInlineAdd` in `TaskList` and `handleSubmit` in `QuickAddTask`: split `try-catch` blocks so create failure vs. post-create status update failure produce distinct messages; dialog closes and `oncreated` fires even when the follow-up update fails
- Fixed `copyId`/`copyBranch` in `TaskDetail`: clipboard writes now have error handling
- Added unit tests: `ErrorBoundary.svelte.test.ts`, `TaskCard.svelte.test.ts` (clipboard error), `TaskList.svelte.test.ts` (inline-add error), `QuickAddTask.svelte.test.ts` (partial-success path)

Closes https://github.com/Automaat/sybra/issues/588