### PR TITLE
build(frontend): enable TS6 strict defaults

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,18 +1,18 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES2025",
     "useDefineForClassFields": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
-    "baseUrl": ".",
     "paths": {
-      "$lib/*": ["src/lib/*"]
+      "$lib/*": ["./src/lib/*"]
     },
     "allowJs": true,
     "checkJs": true,
     "isolatedModules": true,
     "strict": true,
+    "libReplacement": false,
     "skipLibCheck": true
   },
   "include": [


### PR DESCRIPTION
## Motivation

TypeScript 6 introduced stricter defaults and deprecation warnings that surfaced on upgrade. The `baseUrl` option is deprecated in TS6, causing build warnings. Aligning the config to TS6 idioms cleans these up and ensures incremental builds stay fast.

## Implementation information

- Changed `target` from `ESNext` to `ES2025` for an explicit, stable target
- Removed deprecated `baseUrl` (TS6 deprecation warning eliminated)
- Added `libReplacement: false` to opt out of the new lib replacement behavior and speed up incremental builds
- Updated `paths` to be relative to `tsconfig.json` location (no longer requires `baseUrl`)

Single file change: `frontend/tsconfig.json`.

Closes https://github.com/Automaat/sybra/issues/607

> Changelog: build(frontend): enable TS6 strict defaults