### PR TITLE
refactor(sybra): extract recovery package

### DIFF
--- a/internal/recovery/cleanup.go
+++ b/internal/recovery/cleanup.go
@@ -1,0 +1,60 @@
+package recovery
+
+import (
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// cleanStaleRuns marks agent_runs still showing "running" as "stopped" if
+// no matching in-memory agent exists. Fixes leftover state from
+// crashes/restarts.
+func (r *Recovery) cleanStaleRuns() {
+	tasks, err := r.Tasks.List()
+	if err != nil {
+		return
+	}
+	for i := range tasks {
+		if tasks[i].TaskType == task.TaskTypeChat {
+			continue
+		}
+		for j := range tasks[i].AgentRuns {
+			run := &tasks[i].AgentRuns[j]
+			if run.State != string(agent.StateRunning) {
+				continue
+			}
+			if r.Agents.HasRunningAgentForTask(tasks[i].ID) {
+				continue
+			}
+			r.Logger.Info("stale-run.cleanup", "task_id", tasks[i].ID, "agent_id", run.AgentID)
+			_ = r.Tasks.UpdateRun(tasks[i].ID, run.AgentID, map[string]any{
+				"state":  string(agent.StateStopped),
+				"result": "stale: marked stopped on startup",
+			})
+		}
+	}
+}
+
+// gcOrphanChats deletes any chat-task that no longer has a running agent.
+// Chats are ephemeral by design; a stale chat-task is always noise left
+// over from a crash or kill. Runs before worktree orphan cleanup so the
+// task file is gone by the time the worktree sweeper looks.
+func (r *Recovery) gcOrphanChats() {
+	tasks, err := r.Tasks.List()
+	if err != nil {
+		return
+	}
+	for i := range tasks {
+		t := tasks[i]
+		if t.TaskType != task.TaskTypeChat {
+			continue
+		}
+		if r.Agents.HasRunningAgentForTask(t.ID) {
+			continue
+		}
+		r.Logger.Info("chat.gc.orphan", "task_id", t.ID, "title", t.Title)
+		r.Worktrees.Remove(t.ID)
+		if err := r.Tasks.Delete(t.ID); err != nil {
+			r.Logger.Error("chat.gc.delete", "task_id", t.ID, "err", err)
+		}
+	}
+}

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -1,0 +1,70 @@
+// Package recovery handles boot-time and periodic recovery of tasks and
+// agents whose state survived a crash or restart. The startup pass runs
+// once from App.Startup; RestartStaleInProgress is also called from the
+// orchestrator loop every minute to catch agents that died after boot.
+package recovery
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/logging"
+	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
+	"github.com/Automaat/sybra/internal/worktree"
+)
+
+// Orchestrator is the subset of *sybra.AgentOrchestrator that recovery
+// uses. Defined here so the package does not import internal/sybra (which
+// would form a cycle: sybra → recovery → sybra).
+type Orchestrator interface {
+	StartAgent(taskID, mode, prompt string, oneShot bool) (*agent.Agent, error)
+	StartPRFixAgent(taskID string) error
+}
+
+// ProjectGetter is the subset of *project.Store needed to decide whether
+// a respawned agent should create a draft PR (work) or a regular PR (pet).
+type ProjectGetter interface {
+	Get(id string) (project.Project, error)
+}
+
+// Recovery owns the dependencies needed by the boot-time cleanup pass and
+// the periodic restart-stale sweep. Construct once during App.Startup,
+// reuse from the orchestrator loop.
+type Recovery struct {
+	Tasks          *task.Manager
+	Agents         *agent.Manager
+	Worktrees      *worktree.Manager
+	WorkflowEngine *workflow.Engine // optional; nil-safe
+	Orchestrator   Orchestrator
+	Projects       ProjectGetter
+	Logger         *slog.Logger
+	Throttle       *logging.ErrorThrottle
+	WG             *sync.WaitGroup
+
+	LogDir       string
+	LogRetention time.Duration // 0 disables age-based pruning
+}
+
+// RunStartupCleanup sequences boot-time maintenance in the order that lets
+// each step see the output of the previous one: chats first so their
+// worktrees show up as orphans to the subsequent sweep; stale run state
+// next so restart-stale sees a clean slate.
+func (r *Recovery) RunStartupCleanup() {
+	r.Worktrees.RepairAll()
+	r.gcOrphanChats()
+	r.Worktrees.CleanupOrphaned()
+	r.cleanStaleRuns()
+	r.pruneAgentLogs()
+	r.RestartStaleInProgress()
+}
+
+// pruneAgentLogs removes stale per-agent NDJSON files. Safe to call with
+// an empty LogDir (test setups) — the logging helper no-ops.
+func (r *Recovery) pruneAgentLogs() {
+	rep := logging.PruneAgentLogs(r.LogDir, r.LogRetention, time.Now())
+	logging.LogPruneReport(r.Logger, rep)
+}

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -1,0 +1,136 @@
+package recovery_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/logging"
+	"github.com/Automaat/sybra/internal/recovery"
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/worktree"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestRunStartupCleanupEmpty verifies the boot pass is idempotent on a
+// fresh, empty store — no panics, no error returns, no spurious task
+// mutations.
+func TestRunStartupCleanupEmpty(t *testing.T) {
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	logger := discardLogger()
+	agents := agent.NewManager(t.Context(), func(string, any) {}, logger, t.TempDir())
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Tasks:        tasks,
+		Logger:       logger,
+		AgentChecker: agents.HasRunningAgentForTask,
+	})
+
+	var wg sync.WaitGroup
+	r := &recovery.Recovery{
+		Tasks:     tasks,
+		Agents:    agents,
+		Worktrees: wm,
+		Logger:    logger,
+		Throttle:  logging.NewErrorThrottle(),
+		WG:        &wg,
+		LogDir:    t.TempDir(),
+	}
+	r.RunStartupCleanup()
+	wg.Wait()
+}
+
+// TestRestartStaleSkipsRecentRun verifies the dev-reload debounce: an
+// in-progress task whose latest agent run started seconds ago is left
+// alone (no respawn) so a hot-reloaded App doesn't race a still-living
+// subprocess from the prior lifecycle.
+func TestRestartStaleSkipsRecentRun(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := discardLogger()
+	agents := agent.NewManager(ctx, func(string, any) {}, logger, t.TempDir())
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Tasks:        tasks,
+		Logger:       logger,
+		AgentChecker: agents.HasRunningAgentForTask,
+	})
+
+	created, err := tasks.Create("stuck", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inProg := task.StatusInProgress
+	projID := "owner/repo"
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:    &inProg,
+		ProjectID: &projID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := tasks.AddRun(created.ID, task.AgentRun{
+		AgentID:   "ag-1",
+		Mode:      "headless",
+		State:     string(agent.StateRunning),
+		StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	stub := stubOrchestrator{}
+	r := &recovery.Recovery{
+		Tasks:        tasks,
+		Agents:       agents,
+		Worktrees:    wm,
+		Orchestrator: &stub,
+		Logger:       logger,
+		Throttle:     logging.NewErrorThrottle(),
+		WG:           &wg,
+		LogDir:       t.TempDir(),
+	}
+	r.RestartStaleInProgress()
+	wg.Wait()
+
+	if stub.startCalls != 0 {
+		t.Errorf("orchestrator was called %d times; want 0 (recent run debounce)", stub.startCalls)
+	}
+}
+
+type stubOrchestrator struct {
+	startCalls    int
+	prFixCalls    int
+	startErr      error
+	prFixErr      error
+	startReturned *agent.Agent
+}
+
+func (s *stubOrchestrator) StartAgent(_, _, _ string, _ bool) (*agent.Agent, error) {
+	s.startCalls++
+	return s.startReturned, s.startErr
+}
+
+func (s *stubOrchestrator) StartPRFixAgent(_ string) error {
+	s.prFixCalls++
+	return s.prFixErr
+}

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -1,0 +1,179 @@
+package recovery
+
+import (
+	"slices"
+	"time"
+
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/metrics"
+	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
+)
+
+// restartStaleMinAge is the minimum age of the latest agent run before a
+// stale in-progress task is eligible for respawn. Protects against
+// dev-mode hot-reload loops spawning parallel agents onto the same task.
+const restartStaleMinAge = 5 * time.Minute
+
+// RestartStaleInProgress recovers in-progress tasks that lost their agent
+// due to a crash or restart. Headless tasks are re-dispatched; interactive
+// tasks drive the workflow engine forward via recoverStaleInteractive.
+// Safe to call concurrently with the startup pass — each re-dispatch is
+// guarded by HasRunningAgentForTask + the recent-run debounce.
+func (r *Recovery) RestartStaleInProgress() {
+	tasks, err := r.Tasks.List()
+	if err != nil {
+		return
+	}
+	for i := range tasks {
+		t := tasks[i]
+		if t.TaskType == task.TaskTypeChat {
+			continue
+		}
+		if t.Status != task.StatusInProgress {
+			continue
+		}
+		if r.Agents.HasRunningAgentForTask(t.ID) {
+			continue
+		}
+		if slices.Contains(t.Tags, "review") {
+			continue
+		}
+		// Tasks with a terminal workflow stuck at in-progress: restart the
+		// workflow rather than spawning a bare agent. A bare agent spawn
+		// would loop forever (completion callback can't advance a terminal
+		// workflow), but restarting the workflow gives the callback a live
+		// execution to advance.
+		if r.WorkflowEngine != nil && t.Workflow != nil &&
+			(t.Workflow.State == workflow.ExecCompleted || t.Workflow.State == workflow.ExecFailed) {
+			wfID := t.Workflow.WorkflowID
+			taskID := t.ID
+			r.Logger.Info("restart-stale.restart-workflow", "task_id", taskID, "workflow", wfID)
+			r.WG.Go(func() {
+				if wfErr := r.WorkflowEngine.StartWorkflow(taskID, wfID); wfErr != nil {
+					r.Logger.Error("restart-stale.restart-workflow.failed", "task_id", taskID, "err", wfErr)
+				}
+			})
+			continue
+		}
+		// Debounce respawn when a previous run started recently. Covers
+		// the dev-reload case: app restarts every few seconds, but a
+		// headless subprocess from the prior lifecycle is still alive.
+		if lr := lastAgentRun(&t); lr != nil && time.Since(lr.StartedAt) < restartStaleMinAge {
+			r.Logger.Info("restart-stale.skip",
+				"task_id", t.ID, "reason", "recent_run",
+				"last_run_age_s", time.Since(lr.StartedAt).Seconds())
+			continue
+		}
+		// Tasks whose last agent was a pr-fix should not be re-implemented.
+		// Move them back to in-review so the reviews poller can re-detect
+		// and fix. handlePRIssue spawns pr-fix agents directly without
+		// registering a workflow, so onAgentComplete can't advance the task
+		// back to in-review itself.
+		if lastRun := lastAgentRun(&t); lastRun != nil && lastRun.Role == "pr-fix" {
+			r.Logger.Info("restart-stale.revert-to-review", "task_id", t.ID)
+			if _, updErr := r.Tasks.Update(t.ID, task.Update{Status: task.Ptr(task.StatusInReview)}); updErr != nil {
+				r.Logger.Error("restart-stale.revert", "task_id", t.ID, "err", updErr)
+			}
+			continue
+		}
+		// Interactive: drive the workflow engine to advance the current
+		// step using the stored agent run result — same mechanism as
+		// onAgentComplete.
+		if t.AgentMode != "headless" {
+			r.recoverStaleInteractive(&t)
+			continue
+		}
+		if t.ProjectID == "" {
+			r.Logger.Warn("restart-stale.skip", "task_id", t.ID, "reason", "no project_id")
+			continue
+		}
+		r.Logger.Info("restart.stale-in-progress", "task_id", t.ID, "run_role", t.RunRole)
+		taskID := t.ID
+		runRole := t.RunRole
+		if runRole == "pr-fix" {
+			r.WG.Go(func() {
+				err := r.Orchestrator.StartPRFixAgent(taskID)
+				metrics.OrchestratorStaleRestart(err == nil)
+				r.Throttle.Log(r.Logger, "restart.pr-fix.failed", "pr-fix:"+taskID, err, "task_id", taskID)
+			})
+			continue
+		}
+		mode := t.AgentMode
+		prFlag := " --draft"
+		if proj, pErr := r.Projects.Get(t.ProjectID); pErr == nil && proj.Type == project.ProjectTypePet {
+			prFlag = ""
+		}
+		prompt := "Continue implementing this task. When done, create a PR with `gh pr create" + prFlag + "`."
+		r.WG.Go(func() {
+			// Restart-stale only ever reaches this branch for headless
+			// mode (interactive tasks are handled by recoverStaleInteractive
+			// above), so OneShot is irrelevant — pass false.
+			_, err := r.Orchestrator.StartAgent(taskID, mode, prompt, false)
+			metrics.OrchestratorStaleRestart(err == nil)
+			r.Throttle.Log(r.Logger, "restart-stale.failed", "stale:"+taskID, err, "task_id", taskID)
+		})
+	}
+}
+
+// recoverStaleInteractive handles interactive in-progress tasks whose
+// agent died or disappeared across restarts. Marks the last agent run as
+// stopped (if still claiming running) and drives the workflow engine to
+// advance the current step using the stored result — mirroring the
+// normal onAgentComplete callback so evaluate/next steps fire.
+func (r *Recovery) recoverStaleInteractive(t *task.Task) {
+	lr := lastAgentRun(t)
+	if lr == nil {
+		r.Logger.Info("recover-stale.skip", "task_id", t.ID, "reason", "no_agent_runs")
+		return
+	}
+	// Only recover when the dead agent was interactive — headless
+	// stragglers (triage/eval) are managed by their own error paths, and
+	// we don't want to fake-complete a workflow step that needs real agent
+	// output.
+	if lr.Mode != "interactive" {
+		return
+	}
+	if lr.State == string(agent.StateRunning) {
+		if err := r.Tasks.UpdateRun(t.ID, lr.AgentID, map[string]any{
+			"state":  string(agent.StateStopped),
+			"result": "stale: agent gone, auto-recovered",
+		}); err != nil {
+			r.Logger.Error("recover-stale.update-run", "task_id", t.ID, "err", err)
+		}
+	}
+	if r.WorkflowEngine == nil || t.Workflow == nil {
+		r.Logger.Info("recover-stale.no-workflow", "task_id", t.ID)
+		return
+	}
+	if t.Workflow.State == workflow.ExecCompleted || t.Workflow.State == workflow.ExecFailed {
+		r.Logger.Info("recover-stale.workflow-terminal",
+			"task_id", t.ID, "state", string(t.Workflow.State))
+		return
+	}
+	// Mark the execution as recovered so the next step's template context
+	// knows not to trust .Prev.Output (use recoveredOrPrev instead).
+	// Persist before driving HandleAgentComplete so the engine reloads the
+	// flag.
+	t.Workflow.Recovered = true
+	wf := t.Workflow
+	if _, err := r.Tasks.Update(t.ID, task.Update{Workflow: &wf}); err != nil {
+		r.Logger.Error("recover-stale.set-recovered", "task_id", t.ID, "err", err)
+		return
+	}
+	r.Logger.Info("recover-stale.advance",
+		"task_id", t.ID, "agent_id", lr.AgentID, "step", t.Workflow.CurrentStep)
+	r.WorkflowEngine.HandleAgentComplete(t.ID, workflow.AgentCompletion{
+		AgentID:  lr.AgentID,
+		Provider: lr.Provider,
+		Success:  true,
+	})
+}
+
+func lastAgentRun(t *task.Task) *task.AgentRun {
+	if len(t.AgentRuns) == 0 {
+		return nil
+	}
+	return &t.AgentRuns[len(t.AgentRuns)-1]
+}

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -15,7 +15,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"slices"
 	"sync"
 	"time"
 
@@ -28,12 +27,12 @@ import (
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/logging"
 	"github.com/Automaat/sybra/internal/loopagent"
-	"github.com/Automaat/sybra/internal/metrics"
 	"github.com/Automaat/sybra/internal/monitor"
 	"github.com/Automaat/sybra/internal/notification"
 	"github.com/Automaat/sybra/internal/poll"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/provider"
+	"github.com/Automaat/sybra/internal/recovery"
 	"github.com/Automaat/sybra/internal/sandbox"
 	"github.com/Automaat/sybra/internal/selfmonitor"
 	"github.com/Automaat/sybra/internal/skillsync"
@@ -88,6 +87,7 @@ type App struct {
 	emit            func(string, any)
 	emitFactory     func(context.Context) func(string, any)
 	restartStaleErr *logging.ErrorThrottle
+	recovery        *recovery.Recovery
 
 	bgops *bgop.Tracker
 
@@ -263,7 +263,8 @@ func (a *App) Startup(ctx context.Context) error {
 	a.wireServices(emit)
 
 	a.syncSkillsBundle()
-	a.runStartupCleanup()
+	a.recovery = a.newRecovery()
+	a.recovery.RunStartupCleanup()
 	a.RegisterSpotlightHotkey()
 
 	lm := newLifecycleManager(a)
@@ -682,247 +683,6 @@ func (a *App) logAudit(eventType, taskID, agentID string, data map[string]any) {
 	}
 }
 
-// cleanStaleRuns marks agent_runs still showing "running" as "stopped" if no
-// matching in-memory agent exists. Fixes leftover state from crashes/restarts.
-func (a *App) cleanStaleRuns() {
-	tasks, err := a.tasks.List()
-	if err != nil {
-		return
-	}
-	for i := range tasks {
-		if tasks[i].TaskType == task.TaskTypeChat {
-			continue
-		}
-		for j := range tasks[i].AgentRuns {
-			run := &tasks[i].AgentRuns[j]
-			if run.State != string(agent.StateRunning) {
-				continue
-			}
-			if a.agents.HasRunningAgentForTask(tasks[i].ID) {
-				continue
-			}
-			a.logger.Info("stale-run.cleanup", "task_id", tasks[i].ID, "agent_id", run.AgentID)
-			_ = a.tasks.UpdateRun(tasks[i].ID, run.AgentID, map[string]any{
-				"state":  string(agent.StateStopped),
-				"result": "stale: marked stopped on startup",
-			})
-		}
-	}
-}
-
-// runStartupCleanup sequences boot-time maintenance in the order that lets
-// each step see the output of the previous one: chats first so their
-// worktrees show up as orphans to the subsequent sweep; stale run state
-// next so restart-stale sees a clean slate.
-func (a *App) runStartupCleanup() {
-	a.worktrees.RepairAll()
-	a.gcOrphanChats()
-	a.worktrees.CleanupOrphaned()
-	a.cleanStaleRuns()
-	a.pruneAgentLogs()
-	a.restartStaleInProgress()
-}
-
-// pruneAgentLogs removes stale per-agent NDJSON files at startup. Safe
-// to call with an empty logDir (test setups) — the logging helper no-ops.
-// The periodic counterpart lives in startAgentLogPruneLoop.
-func (a *App) pruneAgentLogs() {
-	days := a.cfg.DefaultLogRetentionDays()
-	var maxAge time.Duration
-	if days > 0 {
-		maxAge = time.Duration(days) * 24 * time.Hour
-	}
-	r := logging.PruneAgentLogs(a.logDir, maxAge, time.Now())
-	logging.LogPruneReport(a.logger, r)
-}
-
-// gcOrphanChats deletes any chat-task that no longer has a running agent.
-// Chats are ephemeral by design; a stale chat-task is always noise left over
-// from a crash or kill. Runs before worktree orphan cleanup so the task
-// file is gone by the time the worktree sweeper looks.
-func (a *App) gcOrphanChats() {
-	tasks, err := a.tasks.List()
-	if err != nil {
-		return
-	}
-	for i := range tasks {
-		t := tasks[i]
-		if t.TaskType != task.TaskTypeChat {
-			continue
-		}
-		if a.agents.HasRunningAgentForTask(t.ID) {
-			continue
-		}
-		a.logger.Info("chat.gc.orphan", "task_id", t.ID, "title", t.Title)
-		a.worktrees.Remove(t.ID)
-		if err := a.tasks.Delete(t.ID); err != nil {
-			a.logger.Error("chat.gc.delete", "task_id", t.ID, "err", err)
-		}
-	}
-}
-
-// restartStaleMinAge is the minimum age of the latest agent run before a
-// stale in-progress task is eligible for respawn. Protects against dev-mode
-// hot-reload loops spawning parallel agents onto the same task.
-const restartStaleMinAge = 5 * time.Minute
-
-// restartStaleInProgress recovers in-progress tasks that lost their agent
-// due to a crash or restart. Headless tasks are re-dispatched; interactive
-// tasks drive the workflow engine forward via recoverStaleInteractive.
-func (a *App) restartStaleInProgress() {
-	tasks, err := a.tasks.List()
-	if err != nil {
-		return
-	}
-	for i := range tasks {
-		t := tasks[i]
-		if t.TaskType == task.TaskTypeChat {
-			continue
-		}
-		if t.Status != task.StatusInProgress {
-			continue
-		}
-		if a.agents.HasRunningAgentForTask(t.ID) {
-			continue
-		}
-		if slices.Contains(t.Tags, "review") {
-			continue
-		}
-		// Tasks with a terminal workflow stuck at in-progress: restart the
-		// workflow rather than spawning a bare agent. A bare agent spawn would
-		// loop forever (completion callback can't advance a terminal workflow),
-		// but restarting the workflow gives the callback a live execution to
-		// advance. Skip the remaining stale-restart logic for these.
-		if a.workflowEngine != nil && t.Workflow != nil &&
-			(t.Workflow.State == workflow.ExecCompleted || t.Workflow.State == workflow.ExecFailed) {
-			wfID := t.Workflow.WorkflowID
-			taskID := t.ID
-			a.logger.Info("restart-stale.restart-workflow", "task_id", taskID, "workflow", wfID)
-			a.wg.Go(func() {
-				if wfErr := a.workflowEngine.StartWorkflow(taskID, wfID); wfErr != nil {
-					a.logger.Error("restart-stale.restart-workflow.failed", "task_id", taskID, "err", wfErr)
-				}
-			})
-			continue
-		}
-		// Debounce respawn when a previous run started recently. Covers the
-		// dev-reload case: app restarts every few seconds, but a headless
-		// subprocess from the prior lifecycle is still alive.
-		if lr := lastAgentRun(&t); lr != nil && time.Since(lr.StartedAt) < restartStaleMinAge {
-			a.logger.Info("restart-stale.skip",
-				"task_id", t.ID, "reason", "recent_run",
-				"last_run_age_s", time.Since(lr.StartedAt).Seconds())
-			continue
-		}
-		// Tasks whose last agent was a pr-fix should not be re-implemented.
-		// Move them back to in-review so the reviews poller can re-detect and fix.
-		// Applies to both headless and interactive modes — handlePRIssue
-		// spawns pr-fix agents directly without registering a workflow, so
-		// onAgentComplete can't advance the task back to in-review itself.
-		if lastRun := lastAgentRun(&t); lastRun != nil && lastRun.Role == "pr-fix" {
-			a.logger.Info("restart-stale.revert-to-review", "task_id", t.ID)
-			if _, err := a.tasks.Update(t.ID, task.Update{Status: task.Ptr(task.StatusInReview)}); err != nil {
-				a.logger.Error("restart-stale.revert", "task_id", t.ID, "err", err)
-			}
-			continue
-		}
-		// Interactive: drive the workflow engine to advance the current step
-		// using the stored agent run result — same mechanism as onAgentComplete.
-		if t.AgentMode != "headless" {
-			a.recoverStaleInteractive(&t)
-			continue
-		}
-		if t.ProjectID == "" {
-			a.logger.Warn("restart-stale.skip", "task_id", t.ID, "reason", "no project_id")
-			continue
-		}
-		a.logger.Info("restart.stale-in-progress", "task_id", t.ID, "run_role", t.RunRole)
-		taskID := t.ID
-		runRole := t.RunRole
-		if runRole == "pr-fix" {
-			a.wg.Go(func() {
-				err := a.agentOrch.StartPRFixAgent(taskID)
-				metrics.OrchestratorStaleRestart(err == nil)
-				a.restartStaleErr.Log(a.logger, "restart.pr-fix.failed", "pr-fix:"+taskID, err, "task_id", taskID)
-			})
-		} else {
-			mode := t.AgentMode
-			prFlag := " --draft"
-			if proj, pErr := a.projects.Get(t.ProjectID); pErr == nil && proj.Type == project.ProjectTypePet {
-				prFlag = ""
-			}
-			prompt := "Continue implementing this task. When done, create a PR with `gh pr create" + prFlag + "`."
-			a.wg.Go(func() {
-				// Restart-stale only ever reaches this branch for headless
-				// mode (interactive tasks are handled by recoverStaleInteractive
-				// above), so OneShot is irrelevant here — pass false.
-				_, err := a.agentOrch.StartAgent(taskID, mode, prompt, false)
-				metrics.OrchestratorStaleRestart(err == nil)
-				a.restartStaleErr.Log(a.logger, "restart-stale.failed", "stale:"+taskID, err, "task_id", taskID)
-			})
-		}
-	}
-}
-
-// recoverStaleInteractive handles interactive in-progress tasks whose agent
-// died or disappeared across restarts. Marks the last agent run as
-// stopped (if still claiming running) and drives the workflow engine to
-// advance the current step using the stored result — mirroring the normal
-// onAgentComplete callback so evaluate/next steps fire.
-func (a *App) recoverStaleInteractive(t *task.Task) {
-	lr := lastAgentRun(t)
-	if lr == nil {
-		a.logger.Info("recover-stale.skip", "task_id", t.ID, "reason", "no_agent_runs")
-		return
-	}
-	// Only recover when the dead agent was interactive — headless stragglers
-	// (triage/eval) are managed by their own error paths, and we don't want
-	// to fake-complete a workflow step that needs real agent output.
-	if lr.Mode != "interactive" {
-		return
-	}
-	if lr.State == string(agent.StateRunning) {
-		if err := a.tasks.UpdateRun(t.ID, lr.AgentID, map[string]any{
-			"state":  string(agent.StateStopped),
-			"result": "stale: agent gone, auto-recovered",
-		}); err != nil {
-			a.logger.Error("recover-stale.update-run", "task_id", t.ID, "err", err)
-		}
-	}
-	if a.workflowEngine == nil || t.Workflow == nil {
-		a.logger.Info("recover-stale.no-workflow", "task_id", t.ID)
-		return
-	}
-	if t.Workflow.State == workflow.ExecCompleted || t.Workflow.State == workflow.ExecFailed {
-		a.logger.Info("recover-stale.workflow-terminal",
-			"task_id", t.ID, "state", string(t.Workflow.State))
-		return
-	}
-	// Mark the execution as recovered so the next step's template context
-	// knows not to trust .Prev.Output (use recoveredOrPrev instead). Persist
-	// before driving HandleAgentComplete so the engine reloads the flag.
-	t.Workflow.Recovered = true
-	wf := t.Workflow
-	if _, err := a.tasks.Update(t.ID, task.Update{Workflow: &wf}); err != nil {
-		a.logger.Error("recover-stale.set-recovered", "task_id", t.ID, "err", err)
-		return
-	}
-	a.logger.Info("recover-stale.advance",
-		"task_id", t.ID, "agent_id", lr.AgentID, "step", t.Workflow.CurrentStep)
-	a.workflowEngine.HandleAgentComplete(t.ID, workflow.AgentCompletion{
-		AgentID:  lr.AgentID,
-		Provider: lr.Provider,
-		Success:  true,
-	})
-}
-
-func lastAgentRun(t *task.Task) *task.AgentRun {
-	if len(t.AgentRuns) == 0 {
-		return nil
-	}
-	return &t.AgentRuns[len(t.AgentRuns)-1]
-}
-
 // StartAgent delegates to AgentOrchestrator and is exposed as a Wails-bound method.
 // User-triggered starts are never one-shot — that flag is reserved for workflow
 // steps that expect a single turn.
@@ -1000,6 +760,30 @@ func (a *App) seedDefaultLoopAgents() {
 		return
 	}
 	a.logger.Info("loopagent.seed.created", "id", created.ID, "name", name)
+}
+
+// newRecovery wires the App's deps into a recovery.Recovery used for
+// boot-time cleanup and the periodic restart-stale sweep called from the
+// orchestrator loop. Holds a pointer to a.restartStaleErr so the throttle
+// state is shared across both call sites.
+func (a *App) newRecovery() *recovery.Recovery {
+	var retention time.Duration
+	if days := a.cfg.DefaultLogRetentionDays(); days > 0 {
+		retention = time.Duration(days) * 24 * time.Hour
+	}
+	return &recovery.Recovery{
+		Tasks:          a.tasks,
+		Agents:         a.agents,
+		Worktrees:      a.worktrees,
+		WorkflowEngine: a.workflowEngine,
+		Orchestrator:   a.agentOrch,
+		Projects:       a.projects,
+		Logger:         a.logger,
+		Throttle:       a.restartStaleErr,
+		WG:             &a.wg,
+		LogDir:         a.logDir,
+		LogRetention:   retention,
+	}
 }
 
 // syncSkillsBundle drives the skillsync package with the App's source/dst

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -25,7 +25,7 @@ func (a *App) orchestratorLoop(ctx context.Context) {
 			// Recover in-progress tasks whose agent died — runs continuously,
 			// not just at startup, to catch agents that finished without
 			// advancing the workflow.
-			a.restartStaleInProgress()
+			a.recovery.RestartStaleInProgress()
 			a.worktrees.CleanupOrphaned()
 		}
 	}

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/confighot"
 	"github.com/Automaat/sybra/internal/health"
+	"github.com/Automaat/sybra/internal/logging"
 	"github.com/Automaat/sybra/internal/metrics"
 	"github.com/Automaat/sybra/internal/monitor"
 	"github.com/Automaat/sybra/internal/poll"
@@ -79,8 +80,9 @@ func (lm *LifecycleManager) StartWatchers(ctx context.Context) {
 }
 
 // startAgentLogPruneLoop sweeps stale per-agent NDJSON files once a day.
-// The startup call in runStartupCleanup handles the first pass; this goroutine
-// keeps the directory bounded on long-lived server deployments.
+// The startup call inside Recovery.RunStartupCleanup handles the first
+// pass; this goroutine keeps the directory bounded on long-lived server
+// deployments.
 func (lm *LifecycleManager) startAgentLogPruneLoop(ctx context.Context) {
 	a := lm.app
 	a.wg.Go(func() {
@@ -91,10 +93,23 @@ func (lm *LifecycleManager) startAgentLogPruneLoop(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				a.pruneAgentLogs()
+				lm.prune()
 			}
 		}
 	})
+}
+
+// prune is the periodic body of startAgentLogPruneLoop. Mirrors the
+// retention computation Recovery does at startup so both passes use the
+// same maxAge.
+func (lm *LifecycleManager) prune() {
+	a := lm.app
+	var maxAge time.Duration
+	if days := a.cfg.DefaultLogRetentionDays(); days > 0 {
+		maxAge = time.Duration(days) * 24 * time.Hour
+	}
+	r := logging.PruneAgentLogs(a.logDir, maxAge, time.Now())
+	logging.LogPruneReport(a.logger, r)
 }
 
 // registerMetricsObservers wires OTel observable gauge callbacks to live


### PR DESCRIPTION
## Motivation

Step 2/3 of #604 — break up `internal/sybra/app.go`. This PR extracts startup cleanup and restart-stale logic (~250 LOC) into a new `internal/recovery` package. Stacked on top of #619 (skillsync). After PR2 `app.go` drops to 860 lines.

The recovery code was always non-IPC machinery — Wails never bound any of those methods. They are pure cleanup/recovery sweeps over `task.Manager` + `agent.Manager` + `worktree.Manager` state, plus optional workflow advancement via `workflow.Engine`. Lifting them out of `*App` makes them independently testable and removes ~25% of `app.go`.

## Implementation information

### New package: `internal/recovery`

- `Recovery` struct owns `Tasks`, `Agents`, `Worktrees`, `WorkflowEngine`, `Orchestrator`, `Projects`, `Logger`, `Throttle`, `WG`, `LogDir`, `LogRetention`.
- `RunStartupCleanup` is the boot pass: `RepairAll → gcOrphanChats → CleanupOrphaned → cleanStaleRuns → pruneAgentLogs → RestartStaleInProgress`. Same sequence as today.
- `RestartStaleInProgress` is the periodic sweep — exported so the orchestrator loop reuses it.
- `recoverStaleInteractive`, `cleanStaleRuns`, `gcOrphanChats`, `pruneAgentLogs`, `lastAgentRun`, `restartStaleMinAge` are package-private.
- Two narrow interfaces — `Orchestrator` and `ProjectGetter` — let `internal/recovery` avoid importing `internal/sybra`. `*sybra.AgentOrchestrator` and `*project.Store` satisfy them implicitly.

### App side

- New field `recovery *recovery.Recovery` on `*App`.
- `(a *App) newRecovery()` is a 20-line constructor that wires deps and computes `LogRetention` from `cfg.DefaultLogRetentionDays()`.
- `Startup`: `a.runStartupCleanup()` → `a.recovery = a.newRecovery(); a.recovery.RunStartupCleanup()`.
- `app_orchestrator.go`: `a.restartStaleInProgress()` → `a.recovery.RestartStaleInProgress()`.
- `lifecycle.go`: the daily prune loop now calls a tiny `lm.prune()` that drives `logging.PruneAgentLogs` directly with the same retention math (so `pruneAgentLogs` stays private to `recovery`).

### Tests

- `internal/recovery/recovery_test.go`: two smoke tests.
  - `TestRunStartupCleanupEmpty`: idempotent boot pass on a fresh empty store, no panics.
  - `TestRestartStaleSkipsRecentRun`: in-progress task with a fresh `StartedAt` triggers the dev-reload debounce — orchestrator stub asserts zero `StartAgent` calls.

### Verification

- `go test ./internal/recovery/... ./internal/sybra/... ./...` — all green.
- `golangci-lint run ./internal/recovery/... ./internal/sybra/...` — 0 issues.
- `mise run lint` — 0 errors.

## Supporting documentation

Issue #604. Stacks on #619 (PR1). PR3 (agent-completion + init helpers) follows.

> Changelog: refactor(sybra): extract recovery package