### PR TITLE
refactor(sybra): split init and completion

### DIFF
--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -1,0 +1,211 @@
+package sybra
+
+import (
+	"time"
+
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/loopagent"
+	"github.com/Automaat/sybra/internal/sandbox"
+	"github.com/Automaat/sybra/internal/stats"
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
+	"github.com/Automaat/sybra/internal/worktree"
+)
+
+// maxResultLen bounds how much of the agent's last result message we
+// persist into the task file. Larger values bloat task files (and the
+// cross-process diff stream); smaller values truncate enough context
+// that humans can't read past failures from the UI.
+const maxResultLen = 2000
+
+// newAgentCompletionHandler constructs the handler with every dependency
+// the App holds. Called from wireServices once all subsystems are
+// initialized — by then loopSched, humanReview, workflowEngine, and stats
+// are either populated or intentionally nil (degraded init), and the
+// handler's nil-checks at call time handle the latter.
+func (a *App) newAgentCompletionHandler(emit func(string, any)) *AgentCompletionHandler {
+	return &AgentCompletionHandler{
+		DomainHandler: DomainHandler{
+			logger: a.logger,
+			audit:  a.audit,
+			emit:   emit,
+		},
+		tasks:          a.tasks,
+		worktrees:      a.worktrees,
+		sandboxes:      a.sandboxes,
+		workflowEngine: a.workflowEngine,
+		stats:          a.stats,
+		loopSched:      a.loopSched,
+		humanReview:    a.humanReview,
+		prTracker:      a.prTracker,
+	}
+}
+
+// AgentCompletionHandler reacts to agent.Manager and workflow.Engine
+// terminal-state callbacks: persists the result, records stats, advances
+// workflow, triggers worktree/sandbox cleanup. Mirrors the previous
+// (a *App) onAgentComplete + recordAgentRunStats + onWorkflowComplete
+// trio that lived inline in app.go.
+//
+// All optional dependencies (workflowEngine, stats, loopSched, humanReview,
+// sandboxes) are nil-safe — the test harness wires only the deps the
+// scenario exercises.
+type AgentCompletionHandler struct {
+	DomainHandler // logger + audit + emit
+
+	tasks          *task.Manager
+	worktrees      *worktree.Manager
+	sandboxes      *sandbox.Manager
+	workflowEngine *workflow.Engine
+	stats          *stats.Store
+	loopSched      *loopagent.Scheduler
+	humanReview    *humanReviewHandler
+	prTracker      *github.IssueTracker
+}
+
+// OnComplete is the callback installed via agents.SetOnComplete. Called
+// once per terminal agent state transition.
+func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
+	var resultContent string
+	outputs := ag.Output()
+	for i := range outputs {
+		if outputs[i].Type == "result" {
+			resultContent = outputs[i].Content
+		}
+	}
+
+	// Snapshot mutable fields once under the agent's lock so both the
+	// persistence write and the audit entry see a consistent view.
+	state := ag.GetState()
+	cost := ag.GetCostUSD()
+	exitErr := ag.GetExitErr()
+
+	// Audit logging always fires — orchestrator brain agents have no
+	// parent task and skip the storage paths below, but their lifecycle
+	// still belongs in the audit trail.
+	duration := time.Since(ag.StartedAt).Seconds()
+	h.logAudit(audit.EventAgentCompleted, ag.TaskID, ag.ID, map[string]any{
+		"mode":       ag.Mode,
+		"cost_usd":   cost,
+		"duration_s": duration,
+		"state":      string(state),
+		"role":       agent.RoleFromName(ag.Name),
+		"provider":   ag.Provider,
+		"name":       ag.Name,
+		"log_file":   ag.LogPath,
+	})
+
+	h.recordRunStats(ag, cost, duration, exitErr)
+
+	// Loop agents run without a TaskID — let the scheduler record cost
+	// before the early return below kicks in.
+	if h.loopSched != nil {
+		h.loopSched.OnAgentComplete(ag)
+	}
+
+	// Orchestrator brain agents run with TaskID="" (rooted at ~/.sybra,
+	// no parent task). Calling UpdateRun / HandleAgentComplete / Get with
+	// an empty ID joins to ".sybra/tasks/.md" and crashes the handler.
+	if ag.TaskID == "" {
+		return
+	}
+
+	truncated := resultContent
+	if len(truncated) > maxResultLen {
+		truncated = truncated[:maxResultLen] + "\n... (truncated)"
+	}
+	if err := h.tasks.UpdateRun(ag.TaskID, ag.ID, map[string]any{
+		"state":      string(state),
+		"cost_usd":   cost,
+		"result":     truncated,
+		"log_file":   ag.LogPath,
+		"session_id": ag.GetSessionID(),
+	}); err != nil {
+		h.logger.Error("task.update-run", "task_id", ag.TaskID, "agent_id", ag.ID, "err", err)
+	}
+
+	// Human-review agents are out-of-band diagnostics — they must not
+	// feed into the workflow engine (which would advance the step that
+	// originally caused the human-required transition based on the
+	// diagnostic verdict).
+	if agent.RoleFromName(ag.Name) == agent.RoleHumanReview {
+		if h.humanReview != nil {
+			h.humanReview.onComplete(ag)
+		}
+		return
+	}
+
+	if h.workflowEngine != nil {
+		h.workflowEngine.HandleAgentComplete(ag.TaskID, workflow.AgentCompletion{
+			AgentID:  ag.ID,
+			Result:   resultContent,
+			Provider: ag.Provider,
+			Success:  exitErr == nil,
+		})
+	}
+
+	// Worktree and sandbox cleanup for terminal tasks (after engine
+	// advances, so status is final).
+	if t, err := h.tasks.Get(ag.TaskID); err == nil && task.IsTerminalStatus(t.Status) {
+		go h.worktrees.Remove(ag.TaskID)
+		if h.sandboxes != nil {
+			go h.sandboxes.Stop(ag.TaskID)
+		}
+	}
+}
+
+// recordRunStats persists a stats.RunRecord for the completed agent.
+// No-op when the stats store failed to initialize at startup.
+func (h *AgentCompletionHandler) recordRunStats(ag *agent.Agent, cost, duration float64, exitErr error) {
+	if h.stats == nil {
+		return
+	}
+	in := ag.GetInputTokens()
+	out := ag.GetOutputTokens()
+	agCost := cost
+	if agCost == 0 && ag.Provider == "codex" {
+		agCost = stats.EstimateCost(ag.Model, in, out)
+	}
+	outcome := "failed"
+	if exitErr == nil {
+		outcome = "completed"
+	}
+	var projectID string
+	if ag.TaskID != "" {
+		if t, err := h.tasks.Get(ag.TaskID); err == nil {
+			projectID = t.ProjectID
+		}
+	}
+	_ = h.stats.Record(stats.RunRecord{
+		ID:           ag.ID,
+		TaskID:       ag.TaskID,
+		ProjectID:    projectID,
+		Mode:         ag.Mode,
+		Role:         string(agent.RoleFromName(ag.Name)),
+		Model:        ag.Model,
+		Provider:     ag.Provider,
+		CostUSD:      agCost,
+		DurationS:    duration,
+		InputTokens:  in,
+		OutputTokens: out,
+		Outcome:      outcome,
+		Timestamp:    time.Now(),
+	})
+}
+
+// OnWorkflowComplete is the callback installed via
+// workflowEngine.SetOnComplete. Clears the PR-tracker cooldown for the
+// resolved (issue, kind) pair so a future failure of the same kind is
+// retried fresh.
+func (h *AgentCompletionHandler) OnWorkflowComplete(info workflow.CompletionInfo) {
+	kind := github.PRIssueKind(info.Variables["pr_issue_kind"])
+	if kind == "" {
+		return
+	}
+	h.prTracker.ClearCooldown(info.TaskID, kind)
+	h.logger.Info("pr-tracker.cooldown-cleared",
+		"task_id", info.TaskID, "kind", string(kind),
+		"retries", h.prTracker.Retries(info.TaskID, kind))
+}

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
-	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -35,7 +34,6 @@ import (
 	"github.com/Automaat/sybra/internal/recovery"
 	"github.com/Automaat/sybra/internal/sandbox"
 	"github.com/Automaat/sybra/internal/selfmonitor"
-	"github.com/Automaat/sybra/internal/skillsync"
 	"github.com/Automaat/sybra/internal/spotlight"
 	"github.com/Automaat/sybra/internal/stats"
 	"github.com/Automaat/sybra/internal/task"
@@ -43,8 +41,6 @@ import (
 	"github.com/Automaat/sybra/internal/workflow"
 	"github.com/Automaat/sybra/internal/worktree"
 )
-
-const maxResultLen = 2000
 
 type App struct {
 	ctx             context.Context
@@ -88,6 +84,7 @@ type App struct {
 	emitFactory     func(context.Context) func(string, any)
 	restartStaleErr *logging.ErrorThrottle
 	recovery        *recovery.Recovery
+	agentCompletion *AgentCompletionHandler
 
 	bgops *bgop.Tracker
 
@@ -254,7 +251,6 @@ func (a *App) Startup(ctx context.Context) error {
 		MaxTurns:   a.cfg.Agent.MaxTurns,
 	})
 	a.initApprovalServer(emit)
-	a.agents.SetOnComplete(a.onAgentComplete)
 
 	a.initLoopScheduler(ctx, emit)
 	a.initFileWatcher(ctx, emit)
@@ -277,19 +273,6 @@ func (a *App) Startup(ctx context.Context) error {
 	return nil
 }
 
-func (a *App) initBgops(emit func(string, any)) {
-	a.bgops = bgop.NewTracker(emit, filepath.Join(config.HomeDir(), "bgops.json"))
-	a.bgops.LoadFromDisk()
-}
-
-func (a *App) initFileWatcher(ctx context.Context, emit func(string, any)) {
-	w := watcher.New(a.tasksDir, emit, a.logger)
-	a.watcher = w
-	if err := w.Start(ctx); err != nil {
-		a.logger.Error("watcher.start", "err", err)
-	}
-}
-
 // GetMonitorReport returns the most recent finished report from the
 // in-process monitor service. Ready is false until the first tick completes;
 // the frontend should show an empty state in that window. Enabled mirrors
@@ -300,357 +283,6 @@ func (a *App) GetMonitorReport() MonitorReportBinding {
 	}
 	r, ok := a.monitorSvc.LastReport()
 	return MonitorReportBinding{Enabled: true, Ready: ok, Report: r}
-}
-
-// MonitorReportBinding is the Wails-friendly envelope for the latest
-// monitor report. Keeping the struct here (rather than in internal/monitor)
-// avoids the frontend bindings needing to handle a `monitor.Report | null`
-// union — Enabled/Ready flags say whether Report is populated.
-type MonitorReportBinding struct {
-	Enabled bool           `json:"enabled"`
-	Ready   bool           `json:"ready"`
-	Report  monitor.Report `json:"report"`
-}
-
-// allowsProjectType reports whether project-scoped automations on this machine
-// should act on the given project type. Used to route automation work between
-// instances (e.g., pet projects on the server, work projects on the laptop).
-func (a *App) allowsProjectType(t project.ProjectType) bool {
-	return a.cfg.AllowsProjectType(string(t))
-}
-
-// initIssuesFetcher constructs the GitHub Issues fetcher if enabled, returning
-// nil otherwise. Kept separate so Startup stays under the funlen limit.
-func (a *App) initIssuesFetcher(emit func(string, any)) *poll.IssuesFetcher {
-	if !a.cfg.GitHub.Enabled {
-		a.logger.Info("github.disabled")
-		return nil
-	}
-	return poll.NewIssuesFetcher(a.tasks, a.projects, emit, a.logger, a.allowsProjectType)
-}
-
-// logAutomationsSummary logs a one-line snapshot of which automations this
-// machine runs. Useful when comparing two instances side by side.
-func (a *App) logAutomationsSummary() {
-	loopAgentsEnabled := 0
-	if a.loopAgents != nil {
-		if las, err := a.loopAgents.List(); err == nil {
-			for i := range las {
-				if las[i].Enabled {
-					loopAgentsEnabled++
-				}
-			}
-		}
-	}
-	projectTypes := a.cfg.ProjectTypes
-	if len(projectTypes) == 0 {
-		projectTypes = []string{"*"}
-	}
-	a.logger.Info("app.automations",
-		"todoist", a.cfg.Todoist.Enabled && a.cfg.Todoist.APIToken != "",
-		"github", a.cfg.GitHub.Enabled,
-		"renovate", a.cfg.Renovate.Enabled,
-		"triage", a.cfg.Triage.Enabled,
-		"human_review", a.humanReview != nil,
-		"project_types", projectTypes,
-		"loop_agents_enabled", loopAgentsEnabled,
-	)
-}
-
-func (a *App) initStats() {
-	statsStore, err := stats.NewStore(config.StatsFile())
-	if err != nil {
-		a.logger.Warn("stats.init.degraded", "err", err)
-		// a.stats remains nil; StatsService.GetStats() guards against nil.
-		return
-	}
-	a.stats = statsStore
-	if err := statsStore.Backfill(a.auditDir); err != nil {
-		a.logger.Warn("stats.backfill", "err", err)
-	}
-}
-
-func (a *App) initStatusHook() {
-	a.tasks.SetStatusChangeHook(func(taskID, from, to string) {
-		a.logAudit(audit.EventTaskStatusChanged, taskID, "", map[string]any{"from": from, "to": to})
-
-		// Advance workflows whose current run_agent step declares a
-		// matching wait_for_status. This is how interactive agents (which
-		// never exit between turns) signal step completion.
-		if a.workflowEngine != nil {
-			a.workflowEngine.HandleStatusChange(taskID, to)
-		}
-
-		switch to {
-		case string(task.StatusInReview):
-			msg := taskID
-			if t, err := a.tasks.Get(taskID); err == nil {
-				msg = t.Title
-			}
-			a.notifier.Send(notification.LevelInfo, "Ready for review", msg, taskID, "")
-		case string(task.StatusHumanRequired):
-			msg := taskID
-			if t, err := a.tasks.Get(taskID); err == nil {
-				msg = t.Title
-			}
-			a.notifier.Send(notification.LevelWarning, "Needs human", msg, taskID, "")
-			if a.humanReview != nil {
-				go a.humanReview.maybeSpawn(taskID, from)
-			}
-		case string(task.StatusTesting):
-			if a.workflowEngine != nil {
-				if _, err := a.workflowEngine.DispatchEvent(
-					taskID,
-					"task.status_changed",
-					map[string]string{"task.status": string(task.StatusTesting)},
-					nil,
-				); err != nil {
-					a.logger.Error("workflow.dispatch.testing", "task_id", taskID, "err", err)
-				}
-			}
-		}
-	})
-}
-
-func (a *App) initAudit() {
-	al, err := audit.NewLogger(a.auditDir)
-	if err != nil {
-		a.logger.Warn("audit.init.degraded", "err", err)
-		// a.audit remains nil; logAudit() is a no-op when audit is nil.
-		return
-	}
-	a.audit = al
-	retentionDays := a.cfg.Audit.RetentionDays
-	if retentionDays <= 0 {
-		retentionDays = 30
-	}
-	if err := audit.Cleanup(a.auditDir, retentionDays); err != nil {
-		a.logger.Warn("audit.cleanup", "err", err)
-	}
-}
-
-// initProviderHealth constructs the provider health checker, wires it into
-// the agent manager as a gate, and starts its background probe loop. When
-// providers.health_check.enabled=false the checker is skipped entirely and
-// the manager runs with a nil gate (no blocking).
-func (a *App) initProviderHealth(ctx context.Context, emit func(string, any)) {
-	if !a.cfg.Providers.HealthCheck.Enabled {
-		a.logger.Info("provider.health.disabled")
-		return
-	}
-	pc := provider.New(provider.Config{
-		Interval:         time.Duration(a.cfg.Providers.HealthCheck.IntervalSeconds) * time.Second,
-		ClaudeEnabled:    a.cfg.Providers.Claude.Enabled,
-		CodexEnabled:     a.cfg.Providers.Codex.Enabled,
-		AutoFailover:     a.cfg.Providers.AutoFailover,
-		ClaudeRLCooldown: time.Duration(a.cfg.Providers.Claude.RateLimitCooldownSeconds) * time.Second,
-		CodexRLCooldown:  time.Duration(a.cfg.Providers.Codex.RateLimitCooldownSeconds) * time.Second,
-	}, emit, a.logger)
-	a.providerHealth = pc
-	a.agents.SetHealthGate(pc)
-	a.wg.Go(func() { pc.Run(ctx) })
-}
-
-// emitDegradedWarnings fires startup:degraded for any subsystem that failed
-// to initialize. Called after emit is configured so the frontend receives the events.
-func (a *App) emitDegradedWarnings(emit func(string, any)) {
-	type degraded struct {
-		Subsystem string `json:"subsystem"`
-		Reason    string `json:"reason"`
-	}
-	if a.audit == nil {
-		emit(events.StartupDegraded, degraded{"audit", "audit logger failed to initialize; audit trail unavailable"})
-	}
-	if a.stats == nil {
-		emit(events.StartupDegraded, degraded{"stats", "stats store failed to initialize; metrics unavailable"})
-	}
-}
-
-func (a *App) onAgentComplete(ag *agent.Agent) {
-	var resultContent string
-	outputs := ag.Output()
-	for i := range outputs {
-		if outputs[i].Type == "result" {
-			resultContent = outputs[i].Content
-		}
-	}
-
-	// Snapshot mutable fields once under the agent's lock so both the
-	// persistence write and the audit entry see a consistent view.
-	state := ag.GetState()
-	cost := ag.GetCostUSD()
-	exitErr := ag.GetExitErr()
-
-	// Audit logging always fires — orchestrator brain agents have no parent
-	// task and skip the storage paths below, but their lifecycle still
-	// belongs in the audit trail.
-	duration := time.Since(ag.StartedAt).Seconds()
-	a.logAudit(audit.EventAgentCompleted, ag.TaskID, ag.ID, map[string]any{
-		"mode":       ag.Mode,
-		"cost_usd":   cost,
-		"duration_s": duration,
-		"state":      string(state),
-		"role":       agent.RoleFromName(ag.Name),
-		"provider":   ag.Provider,
-		"name":       ag.Name,
-		"log_file":   ag.LogPath,
-	})
-
-	a.recordAgentRunStats(ag, cost, duration, exitErr)
-
-	// Loop agents run without a TaskID — let the scheduler record cost
-	// before the early return below kicks in.
-	if a.loopSched != nil {
-		a.loopSched.OnAgentComplete(ag)
-	}
-
-	// Orchestrator brain agents run with TaskID="" (rooted at ~/.sybra,
-	// no parent task). Calling UpdateRun / HandleAgentComplete / Get with
-	// an empty ID joins to ".sybra/tasks/.md" and crashes the handler.
-	if ag.TaskID == "" {
-		return
-	}
-
-	// Persist run result to task file.
-	truncated := resultContent
-	if len(truncated) > maxResultLen {
-		truncated = truncated[:maxResultLen] + "\n... (truncated)"
-	}
-	if err := a.tasks.UpdateRun(ag.TaskID, ag.ID, map[string]any{
-		"state":      string(state),
-		"cost_usd":   cost,
-		"result":     truncated,
-		"log_file":   ag.LogPath,
-		"session_id": ag.GetSessionID(),
-	}); err != nil {
-		a.logger.Error("task.update-run", "task_id", ag.TaskID, "agent_id", ag.ID, "err", err)
-	}
-
-	// Human-review agents are out-of-band diagnostics — they must not feed
-	// into the workflow engine (which would advance the step that originally
-	// caused the human-required transition based on the diagnostic verdict).
-	if agent.RoleFromName(ag.Name) == agent.RoleHumanReview {
-		if a.humanReview != nil {
-			a.humanReview.onComplete(ag)
-		}
-		return
-	}
-
-	// Advance workflow.
-	if a.workflowEngine != nil {
-		a.workflowEngine.HandleAgentComplete(ag.TaskID, workflow.AgentCompletion{
-			AgentID:  ag.ID,
-			Result:   resultContent,
-			Provider: ag.Provider,
-			Success:  exitErr == nil,
-		})
-	}
-
-	// Worktree and sandbox cleanup for terminal tasks (after engine advances, so status is final).
-	if t, err := a.tasks.Get(ag.TaskID); err == nil && task.IsTerminalStatus(t.Status) {
-		go a.worktrees.Remove(ag.TaskID)
-		if a.sandboxes != nil {
-			go a.sandboxes.Stop(ag.TaskID)
-		}
-	}
-}
-
-// initAutomations starts every per-machine task source in dependency order
-// and returns the GitHub issues fetcher (still consumed by
-// startBackgroundServices). Extracted so Startup stays under funlen.
-func (a *App) initAutomations(emit func(string, any)) *poll.IssuesFetcher {
-	a.initTodoist(emit)
-	a.initRenovate(emit)
-	a.initTriage()
-	a.initHumanReview()
-	return a.initIssuesFetcher(emit)
-}
-
-// recordAgentRunStats persists a stats.RunRecord for the completed agent.
-// Extracted from onAgentComplete to keep that function within funlen.
-func (a *App) recordAgentRunStats(ag *agent.Agent, cost, duration float64, exitErr error) {
-	if a.stats == nil {
-		return
-	}
-	in := ag.GetInputTokens()
-	out := ag.GetOutputTokens()
-	agCost := cost
-	if agCost == 0 && ag.Provider == "codex" {
-		agCost = stats.EstimateCost(ag.Model, in, out)
-	}
-	outcome := "failed"
-	if exitErr == nil {
-		outcome = "completed"
-	}
-	var projectID string
-	if ag.TaskID != "" {
-		if t, err := a.tasks.Get(ag.TaskID); err == nil {
-			projectID = t.ProjectID
-		}
-	}
-	_ = a.stats.Record(stats.RunRecord{
-		ID:           ag.ID,
-		TaskID:       ag.TaskID,
-		ProjectID:    projectID,
-		Mode:         ag.Mode,
-		Role:         string(agent.RoleFromName(ag.Name)),
-		Model:        ag.Model,
-		Provider:     ag.Provider,
-		CostUSD:      agCost,
-		DurationS:    duration,
-		InputTokens:  in,
-		OutputTokens: out,
-		Outcome:      outcome,
-		Timestamp:    time.Now(),
-	})
-}
-
-func (a *App) onWorkflowComplete(info workflow.CompletionInfo) {
-	kind := github.PRIssueKind(info.Variables["pr_issue_kind"])
-	if kind == "" {
-		return
-	}
-	a.prTracker.ClearCooldown(info.TaskID, kind)
-	a.logger.Info("pr-tracker.cooldown-cleared",
-		"task_id", info.TaskID, "kind", string(kind),
-		"retries", a.prTracker.Retries(info.TaskID, kind))
-}
-
-func (a *App) initWorkflowEngine() {
-	if os.Getenv("SYBRA_DISABLE_WORKFLOWS") == "1" {
-		a.logger.Info("workflow.disabled")
-		return
-	}
-	wfStore, err := workflow.NewStore(config.WorkflowsDir())
-	if err != nil {
-		a.logger.Error("workflow.store.init", "err", err)
-		return
-	}
-	a.workflowStore = wfStore
-	if syncErr := workflow.SyncBuiltins(wfStore); syncErr != nil {
-		a.logger.Error("workflow.sync-builtins", "err", syncErr)
-	}
-	a.workflowEngine = workflow.NewEngine(
-		wfStore,
-		&taskAdapter{tasks: a.tasks, projects: a.projects},
-		&agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks, sandboxes: a.sandboxes},
-		a.logger,
-	)
-	a.workflowEngine.SetPRLinker(prLinkerAdapter{})
-	a.workflowEngine.SetWorktreeGetter(&worktreeGetterAdapter{tasks: a.tasks, mgr: a.worktrees})
-	a.workflowEngine.SetOnComplete(a.onWorkflowComplete)
-	a.workflowEngine.SetContext(a.ctx)
-}
-
-func (a *App) initApprovalServer(emit func(string, any)) {
-	srv, err := agent.NewApprovalServer(emit, a.logger)
-	if err != nil {
-		a.logger.Error("approval-server.init", "err", err)
-		return
-	}
-	srv.SetManager(a.agents)
-	a.agents.SetApprovalAddr(srv.Addr())
-	a.agentSvc.approval = srv
 }
 
 func (a *App) Shutdown(_ context.Context) {
@@ -667,20 +299,6 @@ func (a *App) Shutdown(_ context.Context) {
 		_ = a.audit.Close()
 	}
 	a.logger.Info("app.stopped")
-}
-
-func (a *App) logAudit(eventType, taskID, agentID string, data map[string]any) {
-	if a.audit == nil {
-		return
-	}
-	if err := a.audit.Log(audit.Event{
-		Type:    eventType,
-		TaskID:  taskID,
-		AgentID: agentID,
-		Data:    data,
-	}); err != nil {
-		a.logger.Error("audit.log", "type", eventType, "err", err)
-	}
 }
 
 // StartAgent delegates to AgentOrchestrator and is exposed as a Wails-bound method.
@@ -716,93 +334,6 @@ func (a *App) StopChat(agentID string) error {
 		return fmt.Errorf("agent %s is not a chat (task_type=%s)", agentID, t.TaskType)
 	}
 	return a.taskSvc.DeleteTask(t.ID)
-}
-
-// seedDefaultLoopAgents creates the built-in sybra-self-monitor loop on
-// first boot only. It is disabled by default so the user can review the
-// configuration in the GUI before enabling. Idempotent: if a record with
-// the same Name already exists this is a no-op.
-func (a *App) initLoopAgents() error {
-	store, err := loopagent.NewStore(a.cfg.LoopAgentsDir)
-	if err != nil {
-		a.logger.Error("loopagent.store.init", "err", err)
-		return err
-	}
-	a.loopAgents = store
-	return nil
-}
-
-func (a *App) initLoopScheduler(ctx context.Context, emit func(string, any)) {
-	a.loopSched = loopagent.NewScheduler(ctx, a.loopAgents, a.agents, a.logger, emit, config.HomeDir())
-	a.seedDefaultLoopAgents()
-	a.loopSched.Sync()
-}
-
-func (a *App) seedDefaultLoopAgents() {
-	if a.loopAgents == nil {
-		return
-	}
-	const name = "sybra-self-monitor"
-	if _, ok := a.loopAgents.FindByName(name); ok {
-		return
-	}
-	created, err := a.loopAgents.Create(loopagent.LoopAgent{
-		Name:         name,
-		Prompt:       "/sybra-self-monitor",
-		IntervalSec:  21600, // 6 hours
-		AllowedTools: []string{"Bash", "Read", "Grep", "Glob"},
-		Provider:     "claude",
-		Model:        "sonnet",
-		Enabled:      false,
-	})
-	if err != nil {
-		a.logger.Warn("loopagent.seed.failed", "name", name, "err", err)
-		return
-	}
-	a.logger.Info("loopagent.seed.created", "id", created.ID, "name", name)
-}
-
-// newRecovery wires the App's deps into a recovery.Recovery used for
-// boot-time cleanup and the periodic restart-stale sweep called from the
-// orchestrator loop. Holds a pointer to a.restartStaleErr so the throttle
-// state is shared across both call sites.
-func (a *App) newRecovery() *recovery.Recovery {
-	var retention time.Duration
-	if days := a.cfg.DefaultLogRetentionDays(); days > 0 {
-		retention = time.Duration(days) * 24 * time.Hour
-	}
-	return &recovery.Recovery{
-		Tasks:          a.tasks,
-		Agents:         a.agents,
-		Worktrees:      a.worktrees,
-		WorkflowEngine: a.workflowEngine,
-		Orchestrator:   a.agentOrch,
-		Projects:       a.projects,
-		Logger:         a.logger,
-		Throttle:       a.restartStaleErr,
-		WG:             &a.wg,
-		LogDir:         a.logDir,
-		LogRetention:   retention,
-	}
-}
-
-// syncSkillsBundle drives the skillsync package with the App's source/dst
-// configuration. UserHomeDir is best-effort — when unavailable the user-home
-// destinations (~/.claude/skills, ~/.codex/skills) are silently skipped so
-// startup still succeeds in environments without a usable home dir.
-func (a *App) syncSkillsBundle() {
-	userHome, err := os.UserHomeDir()
-	if err != nil {
-		a.logger.Debug("skills.sync.no_user_home", "err", err)
-		userHome = ""
-	}
-	(&skillsync.Syncer{Logger: a.logger}).Run(skillsync.Options{
-		RepoDir:      a.repoDir,
-		SkillsFS:     a.skillsFS,
-		PrimaryDst:   a.skillsDir,
-		SybraHomeDir: config.HomeDir(),
-		UserHomeDir:  userHome,
-	})
 }
 
 // ListBackgroundOps returns active and recently-completed background operations.

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -1,0 +1,353 @@
+package sybra
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/bgop"
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/events"
+	"github.com/Automaat/sybra/internal/loopagent"
+	"github.com/Automaat/sybra/internal/monitor"
+	"github.com/Automaat/sybra/internal/notification"
+	"github.com/Automaat/sybra/internal/poll"
+	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/provider"
+	"github.com/Automaat/sybra/internal/recovery"
+	"github.com/Automaat/sybra/internal/skillsync"
+	"github.com/Automaat/sybra/internal/stats"
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/watcher"
+	"github.com/Automaat/sybra/internal/workflow"
+)
+
+func (a *App) initBgops(emit func(string, any)) {
+	a.bgops = bgop.NewTracker(emit, filepath.Join(config.HomeDir(), "bgops.json"))
+	a.bgops.LoadFromDisk()
+}
+
+func (a *App) initFileWatcher(ctx context.Context, emit func(string, any)) {
+	w := watcher.New(a.tasksDir, emit, a.logger)
+	a.watcher = w
+	if err := w.Start(ctx); err != nil {
+		a.logger.Error("watcher.start", "err", err)
+	}
+}
+
+// MonitorReportBinding is the Wails-friendly envelope for the latest
+// monitor report. Keeping the struct here (rather than in internal/monitor)
+// avoids the frontend bindings needing to handle a `monitor.Report | null`
+// union — Enabled/Ready flags say whether Report is populated.
+type MonitorReportBinding struct {
+	Enabled bool           `json:"enabled"`
+	Ready   bool           `json:"ready"`
+	Report  monitor.Report `json:"report"`
+}
+
+// allowsProjectType reports whether project-scoped automations on this machine
+// should act on the given project type. Used to route automation work between
+// instances (e.g., pet projects on the server, work projects on the laptop).
+func (a *App) allowsProjectType(t project.ProjectType) bool {
+	return a.cfg.AllowsProjectType(string(t))
+}
+
+// initIssuesFetcher constructs the GitHub Issues fetcher if enabled, returning
+// nil otherwise. Kept separate so Startup stays under the funlen limit.
+func (a *App) initIssuesFetcher(emit func(string, any)) *poll.IssuesFetcher {
+	if !a.cfg.GitHub.Enabled {
+		a.logger.Info("github.disabled")
+		return nil
+	}
+	return poll.NewIssuesFetcher(a.tasks, a.projects, emit, a.logger, a.allowsProjectType)
+}
+
+// logAutomationsSummary logs a one-line snapshot of which automations this
+// machine runs. Useful when comparing two instances side by side.
+func (a *App) logAutomationsSummary() {
+	loopAgentsEnabled := 0
+	if a.loopAgents != nil {
+		if las, err := a.loopAgents.List(); err == nil {
+			for i := range las {
+				if las[i].Enabled {
+					loopAgentsEnabled++
+				}
+			}
+		}
+	}
+	projectTypes := a.cfg.ProjectTypes
+	if len(projectTypes) == 0 {
+		projectTypes = []string{"*"}
+	}
+	a.logger.Info("app.automations",
+		"todoist", a.cfg.Todoist.Enabled && a.cfg.Todoist.APIToken != "",
+		"github", a.cfg.GitHub.Enabled,
+		"renovate", a.cfg.Renovate.Enabled,
+		"triage", a.cfg.Triage.Enabled,
+		"human_review", a.humanReview != nil,
+		"project_types", projectTypes,
+		"loop_agents_enabled", loopAgentsEnabled,
+	)
+}
+
+func (a *App) initStats() {
+	statsStore, err := stats.NewStore(config.StatsFile())
+	if err != nil {
+		a.logger.Warn("stats.init.degraded", "err", err)
+		// a.stats remains nil; StatsService.GetStats() guards against nil.
+		return
+	}
+	a.stats = statsStore
+	if err := statsStore.Backfill(a.auditDir); err != nil {
+		a.logger.Warn("stats.backfill", "err", err)
+	}
+}
+
+func (a *App) initStatusHook() {
+	a.tasks.SetStatusChangeHook(func(taskID, from, to string) {
+		a.logAudit(audit.EventTaskStatusChanged, taskID, "", map[string]any{"from": from, "to": to})
+
+		// Advance workflows whose current run_agent step declares a
+		// matching wait_for_status. This is how interactive agents (which
+		// never exit between turns) signal step completion.
+		if a.workflowEngine != nil {
+			a.workflowEngine.HandleStatusChange(taskID, to)
+		}
+
+		switch to {
+		case string(task.StatusInReview):
+			msg := taskID
+			if t, err := a.tasks.Get(taskID); err == nil {
+				msg = t.Title
+			}
+			a.notifier.Send(notification.LevelInfo, "Ready for review", msg, taskID, "")
+		case string(task.StatusHumanRequired):
+			msg := taskID
+			if t, err := a.tasks.Get(taskID); err == nil {
+				msg = t.Title
+			}
+			a.notifier.Send(notification.LevelWarning, "Needs human", msg, taskID, "")
+			if a.humanReview != nil {
+				go a.humanReview.maybeSpawn(taskID, from)
+			}
+		case string(task.StatusTesting):
+			if a.workflowEngine != nil {
+				if _, err := a.workflowEngine.DispatchEvent(
+					taskID,
+					"task.status_changed",
+					map[string]string{"task.status": string(task.StatusTesting)},
+					nil,
+				); err != nil {
+					a.logger.Error("workflow.dispatch.testing", "task_id", taskID, "err", err)
+				}
+			}
+		}
+	})
+}
+
+func (a *App) initAudit() {
+	al, err := audit.NewLogger(a.auditDir)
+	if err != nil {
+		a.logger.Warn("audit.init.degraded", "err", err)
+		// a.audit remains nil; logAudit() is a no-op when audit is nil.
+		return
+	}
+	a.audit = al
+	retentionDays := a.cfg.Audit.RetentionDays
+	if retentionDays <= 0 {
+		retentionDays = 30
+	}
+	if err := audit.Cleanup(a.auditDir, retentionDays); err != nil {
+		a.logger.Warn("audit.cleanup", "err", err)
+	}
+}
+
+// initProviderHealth constructs the provider health checker, wires it into
+// the agent manager as a gate, and starts its background probe loop. When
+// providers.health_check.enabled=false the checker is skipped entirely and
+// the manager runs with a nil gate (no blocking).
+func (a *App) initProviderHealth(ctx context.Context, emit func(string, any)) {
+	if !a.cfg.Providers.HealthCheck.Enabled {
+		a.logger.Info("provider.health.disabled")
+		return
+	}
+	pc := provider.New(provider.Config{
+		Interval:         time.Duration(a.cfg.Providers.HealthCheck.IntervalSeconds) * time.Second,
+		ClaudeEnabled:    a.cfg.Providers.Claude.Enabled,
+		CodexEnabled:     a.cfg.Providers.Codex.Enabled,
+		AutoFailover:     a.cfg.Providers.AutoFailover,
+		ClaudeRLCooldown: time.Duration(a.cfg.Providers.Claude.RateLimitCooldownSeconds) * time.Second,
+		CodexRLCooldown:  time.Duration(a.cfg.Providers.Codex.RateLimitCooldownSeconds) * time.Second,
+	}, emit, a.logger)
+	a.providerHealth = pc
+	a.agents.SetHealthGate(pc)
+	a.wg.Go(func() { pc.Run(ctx) })
+}
+
+// emitDegradedWarnings fires startup:degraded for any subsystem that failed
+// to initialize. Called after emit is configured so the frontend receives the events.
+func (a *App) emitDegradedWarnings(emit func(string, any)) {
+	type degraded struct {
+		Subsystem string `json:"subsystem"`
+		Reason    string `json:"reason"`
+	}
+	if a.audit == nil {
+		emit(events.StartupDegraded, degraded{"audit", "audit logger failed to initialize; audit trail unavailable"})
+	}
+	if a.stats == nil {
+		emit(events.StartupDegraded, degraded{"stats", "stats store failed to initialize; metrics unavailable"})
+	}
+}
+
+// initAutomations starts every per-machine task source in dependency order
+// and returns the GitHub issues fetcher (still consumed by
+// startBackgroundServices). Extracted so Startup stays under funlen.
+func (a *App) initAutomations(emit func(string, any)) *poll.IssuesFetcher {
+	a.initTodoist(emit)
+	a.initRenovate(emit)
+	a.initTriage()
+	a.initHumanReview()
+	return a.initIssuesFetcher(emit)
+}
+
+func (a *App) initWorkflowEngine() {
+	if os.Getenv("SYBRA_DISABLE_WORKFLOWS") == "1" {
+		a.logger.Info("workflow.disabled")
+		return
+	}
+	wfStore, err := workflow.NewStore(config.WorkflowsDir())
+	if err != nil {
+		a.logger.Error("workflow.store.init", "err", err)
+		return
+	}
+	a.workflowStore = wfStore
+	if syncErr := workflow.SyncBuiltins(wfStore); syncErr != nil {
+		a.logger.Error("workflow.sync-builtins", "err", syncErr)
+	}
+	a.workflowEngine = workflow.NewEngine(
+		wfStore,
+		&taskAdapter{tasks: a.tasks, projects: a.projects},
+		&agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks, sandboxes: a.sandboxes},
+		a.logger,
+	)
+	a.workflowEngine.SetPRLinker(prLinkerAdapter{})
+	a.workflowEngine.SetWorktreeGetter(&worktreeGetterAdapter{tasks: a.tasks, mgr: a.worktrees})
+	a.workflowEngine.SetContext(a.ctx)
+	// SetOnComplete moves to wireServices so the callback closure binds
+	// to the AgentCompletionHandler constructed there.
+}
+
+func (a *App) initApprovalServer(emit func(string, any)) {
+	srv, err := agent.NewApprovalServer(emit, a.logger)
+	if err != nil {
+		a.logger.Error("approval-server.init", "err", err)
+		return
+	}
+	srv.SetManager(a.agents)
+	a.agents.SetApprovalAddr(srv.Addr())
+	a.agentSvc.approval = srv
+}
+
+func (a *App) logAudit(eventType, taskID, agentID string, data map[string]any) {
+	if a.audit == nil {
+		return
+	}
+	if err := a.audit.Log(audit.Event{
+		Type:    eventType,
+		TaskID:  taskID,
+		AgentID: agentID,
+		Data:    data,
+	}); err != nil {
+		a.logger.Error("audit.log", "type", eventType, "err", err)
+	}
+}
+
+// seedDefaultLoopAgents creates the built-in sybra-self-monitor loop on
+// first boot only. It is disabled by default so the user can review the
+// configuration in the GUI before enabling. Idempotent: if a record with
+// the same Name already exists this is a no-op.
+func (a *App) initLoopAgents() error {
+	store, err := loopagent.NewStore(a.cfg.LoopAgentsDir)
+	if err != nil {
+		a.logger.Error("loopagent.store.init", "err", err)
+		return err
+	}
+	a.loopAgents = store
+	return nil
+}
+
+func (a *App) initLoopScheduler(ctx context.Context, emit func(string, any)) {
+	a.loopSched = loopagent.NewScheduler(ctx, a.loopAgents, a.agents, a.logger, emit, config.HomeDir())
+	a.seedDefaultLoopAgents()
+	a.loopSched.Sync()
+}
+
+func (a *App) seedDefaultLoopAgents() {
+	if a.loopAgents == nil {
+		return
+	}
+	const name = "sybra-self-monitor"
+	if _, ok := a.loopAgents.FindByName(name); ok {
+		return
+	}
+	created, err := a.loopAgents.Create(loopagent.LoopAgent{
+		Name:         name,
+		Prompt:       "/sybra-self-monitor",
+		IntervalSec:  21600, // 6 hours
+		AllowedTools: []string{"Bash", "Read", "Grep", "Glob"},
+		Provider:     "claude",
+		Model:        "sonnet",
+		Enabled:      false,
+	})
+	if err != nil {
+		a.logger.Warn("loopagent.seed.failed", "name", name, "err", err)
+		return
+	}
+	a.logger.Info("loopagent.seed.created", "id", created.ID, "name", name)
+}
+
+// newRecovery wires the App's deps into a recovery.Recovery used for
+// boot-time cleanup and the periodic restart-stale sweep called from the
+// orchestrator loop. Holds a pointer to a.restartStaleErr so the throttle
+// state is shared across both call sites.
+func (a *App) newRecovery() *recovery.Recovery {
+	var retention time.Duration
+	if days := a.cfg.DefaultLogRetentionDays(); days > 0 {
+		retention = time.Duration(days) * 24 * time.Hour
+	}
+	return &recovery.Recovery{
+		Tasks:          a.tasks,
+		Agents:         a.agents,
+		Worktrees:      a.worktrees,
+		WorkflowEngine: a.workflowEngine,
+		Orchestrator:   a.agentOrch,
+		Projects:       a.projects,
+		Logger:         a.logger,
+		Throttle:       a.restartStaleErr,
+		WG:             &a.wg,
+		LogDir:         a.logDir,
+		LogRetention:   retention,
+	}
+}
+
+// syncSkillsBundle drives the skillsync package with the App's source/dst
+// configuration. UserHomeDir is best-effort — when unavailable the user-home
+// destinations (~/.claude/skills, ~/.codex/skills) are silently skipped so
+// startup still succeeds in environments without a usable home dir.
+func (a *App) syncSkillsBundle() {
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		a.logger.Debug("skills.sync.no_user_home", "err", err)
+		userHome = ""
+	}
+	(&skillsync.Syncer{Logger: a.logger}).Run(skillsync.Options{
+		RepoDir:      a.repoDir,
+		SkillsFS:     a.skillsFS,
+		PrimaryDst:   a.skillsDir,
+		SybraHomeDir: config.HomeDir(),
+		UserHomeDir:  userHome,
+	})
+}

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -149,7 +149,12 @@ func TestOnAgentComplete_EmptyTaskID_NoCrash(t *testing.T) {
 
 	// Should not panic, and should not touch any task file. The historical
 	// bug created/touched ".md" in tasksDir; assert no such file exists.
-	a.onAgentComplete(ag)
+	h := &AgentCompletionHandler{
+		DomainHandler: DomainHandler{logger: a.logger},
+		tasks:         a.tasks,
+		worktrees:     a.worktrees,
+	}
+	h.OnComplete(ag)
 
 	if _, err := os.Stat(filepath.Join(a.tasksDir, ".md")); !os.IsNotExist(err) {
 		t.Errorf("expected no .md file in tasks dir, got err=%v", err)

--- a/internal/sybra/e2e_stats_test.go
+++ b/internal/sybra/e2e_stats_test.go
@@ -97,20 +97,15 @@ func TestE2E_Stats_RecordedOnAgentComplete(t *testing.T) {
 				Logger:       logger,
 				AgentChecker: agentMgr.HasRunningAgentForTask,
 			})
-			agentOrch := newAgentOrchestrator(taskMgr, nil, agentMgr, nil, logger, wm, nil)
-
-			app := &App{
-				tasks:     taskMgr,
-				agents:    agentMgr,
-				worktrees: wm,
-				agentOrch: agentOrch,
-				logger:    logger,
-				stats:     statsStore,
+			h := &AgentCompletionHandler{
+				DomainHandler: DomainHandler{logger: logger},
+				tasks:         taskMgr,
+				worktrees:     wm,
+				stats:         statsStore,
 			}
-
 			done := make(chan struct{})
 			agentMgr.SetOnComplete(func(ag *agent.Agent) {
-				app.onAgentComplete(ag)
+				h.OnComplete(ag)
 				close(done)
 			})
 

--- a/internal/sybra/services.go
+++ b/internal/sybra/services.go
@@ -60,6 +60,15 @@ func (a *App) wireServices(emit func(string, any)) {
 	a.statsSvc.stats = a.stats
 	a.workflowSvc.engine = a.workflowEngine
 	a.workflowSvc.store = a.workflowStore
+
+	// Subscribe handlers to manager callbacks last — by this point every
+	// dependency the handler reads is wired up, so the closures can't
+	// observe a partially-constructed App.
+	a.agentCompletion = a.newAgentCompletionHandler(emit)
+	a.agents.SetOnComplete(a.agentCompletion.OnComplete)
+	if a.workflowEngine != nil {
+		a.workflowEngine.SetOnComplete(a.agentCompletion.OnWorkflowComplete)
+	}
 }
 
 // ServiceRegistry returns the named service instances for HTTP dispatch.


### PR DESCRIPTION
## Motivation

Final step (3/3) of #604 — break up `internal/sybra/app.go`. Stacks on #620 (recovery) and #619 (skillsync).

After all three PRs land, `app.go` drops from **1382 → 391 lines**. The remaining file is exactly: struct definition, `NewApp`, `Options`, `Startup`, `Shutdown`, `Context()`, and the 8 Wails-bound entry-point methods (`StartAgent`, `StartChat`, `StopChat`, `GetMonitorReport`, `ListBackgroundOps`, `ListNotifications`, `SetDesktopNotifications`, `RegisterSpotlightHotkey`). Everything else moved.

## Implementation information

### `internal/sybra/agent_completion.go` (new)

`AgentCompletionHandler` embeds `DomainHandler` (matching the existing `ReviewHandler` pattern) and owns three callbacks that previously lived inline in `app.go`:

- `OnComplete(*agent.Agent)` — was `(a *App) onAgentComplete`
- `recordRunStats(...)` — was `(a *App) recordAgentRunStats`
- `OnWorkflowComplete(workflow.CompletionInfo)` — was `(a *App) onWorkflowComplete`

All optional deps (`workflowEngine`, `stats`, `loopSched`, `humanReview`, `sandboxes`) keep their nil-safety. `maxResultLen` constant moves with the handler — its only caller.

The handler is constructed inside `wireServices(emit)` rather than in `Startup` directly, because that's the point at which every dependency it reads is fully wired (`loopSched` is set in `initLoopScheduler`, `humanReview` in `initAutomations`, both of which run before `wireServices`). Both `agents.SetOnComplete` and `workflowEngine.SetOnComplete` registrations move into `wireServices` for the same reason — single subscribe point.

### `internal/sybra/app_init.go` (new)

20 init helpers move out of `app.go`. Methods stay on `*App` (no signature change) so existing callers and tests keep working without churn:

- `app_renovate.go:9` — `a.allowsProjectType` reference: still works.
- `lifecycle.go:188,224` — `a.allowsProjectType`: still works.
- `app_automation_routing_test.go` — `a.allowsProjectType`, `a.initIssuesFetcher`: still work.

Methods moved: `initBgops`, `initFileWatcher`, `initStats`, `initStatusHook`, `initAudit`, `initProviderHealth`, `initWorkflowEngine`, `initApprovalServer`, `initAutomations`, `initIssuesFetcher`, `initLoopAgents`, `initLoopScheduler`, `seedDefaultLoopAgents`, `emitDegradedWarnings`, `logAutomationsSummary`, `allowsProjectType`, `logAudit`, `newRecovery`, `syncSkillsBundle`. Plus the `MonitorReportBinding` type (Wails return-type envelope) — the bound method `GetMonitorReport` stays on `*App` in `app.go`.

### Test changes

`internal/sybra/app_test.go:152` (`TestOnAgentComplete_EmptyTaskID_NoCrash`) was the only test that called the moved code directly. Rewritten to instantiate `AgentCompletionHandler` directly:

```go
h := &AgentCompletionHandler{
    DomainHandler: DomainHandler{logger: a.logger},
    tasks:         a.tasks,
    worktrees:     a.worktrees,
}
h.OnComplete(ag)
```

The handler's nil-checks on `loopSched`, `workflowEngine`, `humanReview`, `sandboxes`, `stats` make this minimal fixture sufficient.

### Verification

- `go test ./...` — all green.
- `golangci-lint run ./...` — 0 issues.
- `gofmt` — clean.
- `mise run lint` — 0 errors.
- `go build .` (desktop) and `go build ./cmd/sybra-server/` — both succeed.

## Cumulative result of issue 604

| File              | Before | After |
|-------------------|-------:|------:|
| `internal/sybra/app.go` | 1382 | 391  |

New packages introduced across all three PRs: `internal/skillsync`, `internal/recovery`. New files inside `internal/sybra`: `agent_completion.go`, `app_init.go`. The 12 Wails-bound `*Service` structs in `svc_*.go` and `services.go` wiring are unchanged.

## Supporting documentation

Issue #604. Stacks on #620 (PR2 recovery) and #619 (PR1 skillsync).

> Changelog: refactor(sybra): split init and completion