### PR TITLE
fix(github): retry merge on base modified

### DIFF
--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -4,7 +4,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 )
+
+// mergeRetryDelays controls the backoff between merge retries when GitHub
+// reports the base branch was modified mid-merge. Overridable from tests.
+var mergeRetryDelays = []time.Duration{
+	2 * time.Second,
+	4 * time.Second,
+	8 * time.Second,
+}
 
 // PRStats holds size metrics for a pull request.
 type PRStats struct {
@@ -325,12 +334,27 @@ func MergePR(repo string, number int) error {
 }
 
 func mergePRWith(e execer, repo string, number int) error {
-	out, err := e.run("pr", "merge", fmt.Sprintf("%d", number),
-		"--repo", repo, "--squash")
-	if err != nil {
-		return fmt.Errorf("gh pr merge %d: %s: %w", number, strings.TrimSpace(string(out)), err)
+	var lastOut []byte
+	var lastErr error
+	for attempt := 0; attempt <= len(mergeRetryDelays); attempt++ {
+		out, err := e.run("pr", "merge", fmt.Sprintf("%d", number),
+			"--repo", repo, "--squash")
+		if err == nil {
+			return nil
+		}
+		lastOut, lastErr = out, err
+		if !isBaseBranchModifiedErr(out) || attempt == len(mergeRetryDelays) {
+			break
+		}
+		time.Sleep(mergeRetryDelays[attempt])
 	}
-	return nil
+	return fmt.Errorf("gh pr merge %d: %s: %w", number, strings.TrimSpace(string(lastOut)), lastErr)
+}
+
+// isBaseBranchModifiedErr reports whether gh's output indicates a transient
+// base-branch race that GitHub asks the caller to retry.
+func isBaseBranchModifiedErr(out []byte) bool {
+	return strings.Contains(string(out), "Base branch was modified")
 }
 
 // MarkReady marks a draft pull request as ready for review.

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"fmt"
 	"testing"
+	"time"
 )
 
 func TestFetchPRStateWith(t *testing.T) {
@@ -371,4 +372,72 @@ func TestMergePRWith(t *testing.T) {
 			}
 		})
 	}
+}
+
+// scriptedExecer returns a different (output, err) for each call.
+type scriptedExecer struct {
+	calls    int
+	results  []scriptedResult
+	lastArgs []string
+}
+
+type scriptedResult struct {
+	output []byte
+	err    error
+}
+
+func (s *scriptedExecer) run(args ...string) ([]byte, error) {
+	s.lastArgs = args
+	i := s.calls
+	s.calls++
+	if i >= len(s.results) {
+		i = len(s.results) - 1
+	}
+	return s.results[i].output, s.results[i].err
+}
+
+func TestMergePRWith_RetriesBaseBranchModified(t *testing.T) {
+	prev := mergeRetryDelays
+	mergeRetryDelays = []time.Duration{0, 0, 0}
+	t.Cleanup(func() { mergeRetryDelays = prev })
+
+	t.Run("retries then succeeds", func(t *testing.T) {
+		baseModified := []byte("GraphQL: Base branch was modified. Review and try the merge again. (mergePullRequest)")
+		se := &scriptedExecer{results: []scriptedResult{
+			{output: baseModified, err: fmt.Errorf("exit 1")},
+			{output: baseModified, err: fmt.Errorf("exit 1")},
+			{output: nil, err: nil},
+		}}
+		if err := mergePRWith(se, "owner/repo", 42); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if se.calls != 3 {
+			t.Fatalf("calls = %d, want 3", se.calls)
+		}
+	})
+
+	t.Run("gives up after max retries", func(t *testing.T) {
+		baseModified := []byte("GraphQL: Base branch was modified. Review and try the merge again.")
+		se := &scriptedExecer{results: []scriptedResult{
+			{output: baseModified, err: fmt.Errorf("exit 1")},
+		}}
+		if err := mergePRWith(se, "owner/repo", 42); err == nil {
+			t.Fatal("expected error")
+		}
+		if se.calls != len(mergeRetryDelays)+1 {
+			t.Fatalf("calls = %d, want %d", se.calls, len(mergeRetryDelays)+1)
+		}
+	})
+
+	t.Run("non-retryable error fails fast", func(t *testing.T) {
+		se := &scriptedExecer{results: []scriptedResult{
+			{output: []byte("some other error"), err: fmt.Errorf("exit 1")},
+		}}
+		if err := mergePRWith(se, "owner/repo", 42); err == nil {
+			t.Fatal("expected error")
+		}
+		if se.calls != 1 {
+			t.Fatalf("calls = %d, want 1 (no retry)", se.calls)
+		}
+	})
 }


### PR DESCRIPTION
## Motivation

`gh pr merge` intermittently fails with:

```
GraphQL: Base branch was modified. Review and try the merge again. (mergePullRequest)
```

This is a known transient race when the PR base branch advances between GitHub computing the merge state and the merge attempt landing. Seen repeatedly in app logs across PRs 125/126/129/132/287/295.

## Implementation information

`internal/github.mergePRWith` now retries up to 3 times (2s/4s/8s backoff) when gh's output contains `"Base branch was modified"`. Non-retryable errors fail fast. Backoff is a package-level var so tests can override it.

Considered alternatives:
- `--match-head-commit`: would require an extra fetch to learn the head SHA and still races with base updates; doesn't address the actual error.
- Surface to the UI for manual retry: this error is purely transient — autoretry is the right default.

Tests cover: retry-then-success, give-up after max retries, non-retryable error fails fast (no retry).

## Supporting documentation

n/a