### PR TITLE
fix(workflow): handle signal-killed agents correctly

### DIFF
--- a/cmd/fake-claude/main.go
+++ b/cmd/fake-claude/main.go
@@ -27,6 +27,7 @@
 //     mechanical link_pr_and_review step can extract the PR number via regex
 //   - auth_error: emits auth-failure text then exits 1
 //   - malformed_pr_output: emits large malformed PR-ish text (no valid URL)
+//   - signal_kill: emits system+assistant then kills self with SIGTERM
 //
 // Perf scenarios (zero token cost, drive backend load):
 //   - perf_stream: emit FAKE_CLAUDE_EVENT_COUNT assistant events spaced
@@ -50,6 +51,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -137,6 +139,8 @@ func runScenario(scenario, taskID string) bool {
 		emitSystem()
 		emitAssistant("Implementing and pushing PR...")
 		emitResult("Implementation done. Created PR https://github.com/test-org/test-repo/pull/42")
+	case "signal_kill":
+		runSignalKill()
 	case "auth_error":
 		emitSystem()
 		emitAssistant("Authentication failed. Please re-auth.")
@@ -153,6 +157,15 @@ func runScenario(scenario, taskID string) bool {
 		return false
 	}
 	return true
+}
+
+// runSignalKill emits a start event then kills itself with SIGTERM, simulating
+// a container/OS shutdown mid-run.
+func runSignalKill() {
+	emitSystem()
+	emitAssistant("Starting work...")
+	_ = syscall.Kill(os.Getpid(), syscall.SIGTERM)
+	select {} // block until signal arrives
 }
 
 // runMalformedPROutput emits a long stream of malformed PR-URL fragments

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -514,6 +514,7 @@ func (m *Manager) StopAgent(agentID string) error {
 
 	m.logger.Info("agent.stop", "id", agentID)
 
+	a.MarkStopped()
 	if a.cancel != nil {
 		a.cancel()
 	}

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -227,7 +227,17 @@ func TestStopHeadlessDoesNotCallOnComplete(t *testing.T) {
 		mu            sync.Mutex
 		completeCalls int
 	)
+
+	// holdOpen blocks the onComplete callback from completing until we have
+	// checked completeCalls. Without this, in environments where the claude
+	// binary is absent the runner goroutine fails immediately and races to
+	// call onComplete before StopAgent returns. t.Cleanup closes it so the
+	// goroutine can eventually finish without leaking.
+	holdOpen := make(chan struct{})
+	t.Cleanup(func() { close(holdOpen) })
+
 	m.SetOnComplete(func(_ *Agent) {
+		<-holdOpen
 		mu.Lock()
 		completeCalls++
 		mu.Unlock()

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -89,6 +89,13 @@ type Agent struct {
 	// prompt without a stdin pipe. Guarded by mu.
 	promptCh chan string
 
+	// stopped is set by StopAgent before cancelling the context so
+	// OnComplete can distinguish an intentional user stop (SIGTERM via
+	// cancel) from an infra-level kill (OS/container SIGTERM). Both exit
+	// with a signal, but only intentional stops should advance the
+	// workflow step to "failed".
+	stopped bool
+
 	// mu guards mutable fields touched from multiple goroutines. See the
 	// package-level note above the Agent type.
 	mu sync.RWMutex
@@ -113,6 +120,20 @@ func (a *Agent) GetState() State {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.State
+}
+
+// MarkStopped records that the agent was stopped intentionally via StopAgent.
+func (a *Agent) MarkStopped() {
+	a.mu.Lock()
+	a.stopped = true
+	a.mu.Unlock()
+}
+
+// WasStopped reports whether StopAgent was called on this agent.
+func (a *Agent) WasStopped() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.stopped
 }
 
 // AppendOutput appends a stream event to the headless output buffer and

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -1,6 +1,9 @@
 package sybra
 
 import (
+	"errors"
+	"os/exec"
+	"syscall"
 	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
@@ -138,6 +141,14 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 	}
 
 	if h.workflowEngine != nil {
+		if isSignalKill(exitErr) {
+			// Agent was killed by a signal (e.g. SIGTERM on container/OS shutdown),
+			// not a logical failure. Leave the workflow step stalled so
+			// ResumeStalled re-dispatches the agent on the next tick.
+			h.logger.Warn("agent.completion.signal-kill",
+				"task_id", ag.TaskID, "agent_id", ag.ID)
+			return
+		}
 		h.workflowEngine.HandleAgentComplete(ag.TaskID, workflow.AgentCompletion{
 			AgentID:  ag.ID,
 			Result:   resultContent,
@@ -193,6 +204,21 @@ func (h *AgentCompletionHandler) recordRunStats(ag *agent.Agent, cost, duration 
 		Outcome:      outcome,
 		Timestamp:    time.Now(),
 	})
+}
+
+// isSignalKill reports whether err represents a process killed by an OS signal.
+// Signal kills (e.g. SIGTERM from container/OS shutdown) are infrastructure
+// interruptions, not logical agent failures — the workflow should not advance.
+func isSignalKill(err error) bool {
+	if err == nil {
+		return false
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	ws, ok := exitErr.Sys().(syscall.WaitStatus)
+	return ok && ws.Signaled()
 }
 
 // OnWorkflowComplete is the callback installed via

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -141,12 +141,14 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 	}
 
 	if h.workflowEngine != nil {
-		if isSignalKill(exitErr) {
-			// Agent was killed by a signal (e.g. SIGTERM on container/OS shutdown),
-			// not a logical failure. Leave the workflow step stalled so
-			// ResumeStalled re-dispatches the agent on the next tick.
+		if isSignalKill(exitErr) && !ag.WasStopped() {
+			// Infrastructure-level kill (e.g. OS/container SIGTERM): leave the
+			// workflow step stalled so ResumeStalled re-dispatches the agent on
+			// the next tick. Clear the agent→step mapping so agentSteps does not
+			// leak and hasTrackedAgentForTaskStep does not suppress the retry.
 			h.logger.Warn("agent.completion.signal-kill",
 				"task_id", ag.TaskID, "agent_id", ag.ID)
+			h.workflowEngine.ClearAgentStep(ag.ID)
 			return
 		}
 		h.workflowEngine.HandleAgentComplete(ag.TaskID, workflow.AgentCompletion{

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -433,6 +433,64 @@ func TestE2E_HeadlessAgent_FailExit(t *testing.T) {
 	})
 }
 
+// TestE2E_HeadlessAgent_SignalKill_DoesNotAdvanceWorkflow verifies that when an
+// agent is killed by a signal (SIGTERM), the workflow step does NOT advance.
+// The workflow should stay stalled at the current step so ResumeStalled can
+// re-dispatch the agent. Regression test for #615.
+func TestE2E_HeadlessAgent_SignalKill_DoesNotAdvanceWorkflow(t *testing.T) {
+	// First call: agent dies with SIGTERM. Second call (via ResumeStalled): success.
+	env := setupE2EMulti(t, []string{"signal_kill", "triage"})
+
+	// Wire production AgentCompletionHandler so the signal kill guard fires.
+	h := &AgentCompletionHandler{
+		DomainHandler:  DomainHandler{logger: e2eLogger()},
+		tasks:          env.tasks,
+		worktrees:      worktree.New(worktree.Config{WorktreesDir: env.worktreesDir, Tasks: env.tasks, Logger: e2eLogger(), AgentChecker: env.agents.HasRunningAgentForTask}),
+		workflowEngine: env.engine,
+	}
+	env.agents.SetOnComplete(func(ag *agent.Agent) {
+		env.pendingCompletions.Add(1)
+		defer env.pendingCompletions.Add(-1)
+		h.OnComplete(ag)
+	})
+
+	created, err := env.tasks.Create("signal kill task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := env.startWorkflow(created.ID, "test-simple"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the signal-killed agent to finish and completion callback to return.
+	waitFor(t, 10*time.Second, "signal-killed agent completes", func() bool {
+		return !env.agents.HasRunningAgentForTask(created.ID) && env.pendingCompletions.Load() == 0
+	})
+
+	// The workflow must NOT have advanced past triage.
+	tk, err := env.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tk.Workflow == nil {
+		t.Fatal("no workflow on task")
+	}
+	if tk.Workflow.CurrentStep != "triage" {
+		t.Errorf("workflow advanced to %q on signal kill; want to stay at triage", tk.Workflow.CurrentStep)
+	}
+
+	// ResumeStalled re-dispatches the agent with the next scenario (triage success).
+	env.engine.ResumeStalled()
+
+	waitFor(t, 10*time.Second, "workflow advances past triage after retry", func() bool {
+		tk2, err := env.tasks.Get(created.ID)
+		if err != nil {
+			return false
+		}
+		return tk2.Workflow != nil && tk2.Workflow.CurrentStep != "triage"
+	})
+}
+
 func TestE2E_WorkflowWithSynapseCLI(t *testing.T) {
 	forEachProvider(t, func(t *testing.T, p providerSpec) {
 		env := setupE2EProvider(t, p.provider, "triage")

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -217,6 +217,14 @@ func (e *Engine) clearAgentStep(agentID string) {
 	e.mu.Unlock()
 }
 
+// ClearAgentStep removes the agent→step mapping without advancing the workflow.
+// Used when an agent exits due to an infrastructure-level signal kill so the
+// tracked-agent entry is released while the workflow step stays stalled for
+// ResumeStalled to re-dispatch.
+func (e *Engine) ClearAgentStep(agentID string) {
+	e.clearAgentStep(agentID)
+}
+
 // ResumeStalled finds tasks with running/waiting workflows where no agent
 // is active, and attempts to re-execute the current step.
 func (e *Engine) ResumeStalled() {


### PR DESCRIPTION
## Motivation

Agents killed by SIGTERM/SIGKILL (OS/container shutdown) were incorrectly
advancing workflow steps. Any non-zero exit flipped the step to `failed` and
continued — e.g. into `verify_commits` — setting tasks to `human-required`
spuriously.

A second bug: `isSignalKill` was too broad and caught intentional `StopAgent`
cancels (SIGTERM via context cancellation), causing `ResumeStalled` to
re-dispatch already-stopped workflow agents. The early return also leaked
`agentSteps` entries, leaving `hasTrackedAgentForTaskStep` seeing phantom
agents.

## Implementation information

Two commits:

1. **skip advance on signal-killed agent** — added `isSignalKill` helper
   detecting `syscall.WaitStatus.Signaled()`. When fired, `OnComplete` logs
   and returns early; `ResumeStalled` re-dispatches on the next tick. Added
   `signal_kill` scenario to `fake-claude` and an e2e test verifying the
   workflow stays stalled then advances correctly after re-dispatch.

2. **narrow signal-kill guard; clear agentSteps on infra kill** — added
   `Agent.MarkStopped`/`WasStopped` so `StopAgent` stamps the agent before
   cancelling. Guard becomes `isSignalKill && !WasStopped` so intentional
   stops fall through to `HandleAgentComplete`. Also added
   `Engine.ClearAgentStep` called in the infra-kill path to prevent
   `agentSteps` leaks.