### PR TITLE
fix(github): reduce gh api pressure

### DIFF
--- a/internal/github/checks.go
+++ b/internal/github/checks.go
@@ -21,5 +21,8 @@ func rerunFailedChecksWith(e execer, repo string, number int) error {
 	if err != nil {
 		return fmt.Errorf("gh run rerun --failed: %s: %w", strings.TrimSpace(string(out)), err)
 	}
+	if runtimeCacheEnabled(e) {
+		invalidatePRCaches(repo, number)
+	}
 	return nil
 }

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -17,8 +17,10 @@ type execer interface {
 type ghExecer struct{}
 
 func (ghExecer) run(args ...string) ([]byte, error) {
-	cmd := exec.Command("gh", args...)
-	return cmd.CombinedOutput()
+	return ghGate.execute(func() ([]byte, error) {
+		cmd := exec.Command("gh", args...)
+		return cmd.CombinedOutput()
+	})
 }
 
 var defaultExecer execer = ghExecer{}
@@ -50,14 +52,6 @@ func viewerLogin(e execer) string {
 	return result
 }
 
-// resetCachedViewerForTest clears the package-level viewer cache. Exported
-// only for use from tests in the same package.
-func resetCachedViewerForTest() {
-	viewerMu.Lock()
-	cachedViewer = ""
-	viewerMu.Unlock()
-}
-
 // sanitizeGHOutput trims the `gh` CLI's combined output for use in error
 // messages. When GitHub returns a 5xx with an HTML error page (e.g. the
 // "Unicorn!" 504 page), gh prints the entire HTML body followed by a
@@ -80,7 +74,12 @@ func sanitizeGHOutput(out []byte) string {
 }
 
 const prQuery = `query($q: String!) {
-  search(query: $q, type: ISSUE, first: 50) {
+  viewer { login }
+  search(query: $q, type: ISSUE, first: 100) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
     nodes {
       ... on PullRequest {
         number
@@ -135,8 +134,15 @@ type gqlStatusCheckRollup struct {
 
 type gqlResponse struct {
 	Data struct {
+		Viewer struct {
+			Login string `json:"login"`
+		} `json:"viewer"`
 		Search struct {
-			Nodes []gqlPR `json:"nodes"`
+			Nodes    []gqlPR `json:"nodes"`
+			PageInfo struct {
+				HasNextPage bool   `json:"hasNextPage"`
+				EndCursor   string `json:"endCursor"`
+			} `json:"pageInfo"`
 		} `json:"search"`
 	} `json:"data"`
 	Errors []struct {
@@ -190,22 +196,22 @@ type gqlPR struct {
 }
 
 func searchPRsWith(e execer, query string) ([]PullRequest, error) {
-	out, err := e.run("api", "graphql",
+	resp, err := runGHAPIWith(e, "", "graphql",
 		"-f", "query="+prQuery,
 		"-f", "q="+query)
 	if err != nil {
-		return nil, fmt.Errorf("gh api graphql: %s: %w", sanitizeGHOutput(out), err)
+		return nil, fmt.Errorf("gh api graphql: %s: %w", sanitizeGHOutput(resp.body), err)
 	}
 
-	var resp gqlResponse
-	if err := json.Unmarshal(out, &resp); err != nil {
+	var gqlResp gqlResponse
+	if err := json.Unmarshal(resp.body, &gqlResp); err != nil {
 		return nil, fmt.Errorf("parse graphql response: %w", err)
 	}
-	if len(resp.Errors) > 0 {
-		return nil, fmt.Errorf("graphql: %s", resp.Errors[0].Message)
+	if len(gqlResp.Errors) > 0 {
+		return nil, fmt.Errorf("graphql: %s", gqlResp.Errors[0].Message)
 	}
 
-	return convertPRs(resp.Data.Search.Nodes, viewerLogin(e)), nil
+	return convertPRs(gqlResp.Data.Search.Nodes, gqlResp.Data.Viewer.Login), nil
 }
 
 // convertCommonPR converts shared gqlPR fields into a PullRequest.

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 )
 
-func resetViewerCache() { resetCachedViewerForTest() }
-
 // fakeExecer is a test double that returns fixed output and error.
 type fakeExecer struct {
 	output []byte

--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -4,10 +4,50 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 )
 
 const issueQuery = `query($q: String!) {
-  search(query: $q, type: ISSUE, first: 50) {
+  search(query: $q, type: ISSUE, first: 100) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      ... on Issue {
+        number
+        title
+        body
+        url
+        state
+        createdAt
+        updatedAt
+        author { login }
+        repository { name nameWithOwner }
+        labels(first: 10) { nodes { name } }
+      }
+    }
+  }
+}`
+
+const issueSnapshotQuery = `query($assignedQ: String!, $labeledQ: String!) {
+  assigned: search(query: $assignedQ, type: ISSUE, first: 100) {
+    nodes {
+      ... on Issue {
+        number
+        title
+        body
+        url
+        state
+        createdAt
+        updatedAt
+        author { login }
+        repository { name nameWithOwner }
+        labels(first: 10) { nodes { name } }
+      }
+    }
+  }
+  labeled: search(query: $labeledQ, type: ISSUE, first: 100) {
     nodes {
       ... on Issue {
         number
@@ -28,8 +68,26 @@ const issueQuery = `query($q: String!) {
 type gqlIssueResponse struct {
 	Data struct {
 		Search struct {
-			Nodes []gqlIssue `json:"nodes"`
+			Nodes    []gqlIssue `json:"nodes"`
+			PageInfo struct {
+				HasNextPage bool   `json:"hasNextPage"`
+				EndCursor   string `json:"endCursor"`
+			} `json:"pageInfo"`
 		} `json:"search"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+type gqlIssueSnapshotResponse struct {
+	Data struct {
+		Assigned struct {
+			Nodes []gqlIssue `json:"nodes"`
+		} `json:"assigned"`
+		Labeled struct {
+			Nodes []gqlIssue `json:"nodes"`
+		} `json:"labeled"`
 	} `json:"data"`
 	Errors []struct {
 		Message string `json:"message"`
@@ -58,13 +116,42 @@ type gqlIssue struct {
 	} `json:"labels"`
 }
 
+type IssueSnapshot struct {
+	Assigned []Issue
+	Labeled  []Issue
+}
+
 // FetchAssignedIssues returns open issues assigned to the authenticated user.
 func FetchAssignedIssues() ([]Issue, error) {
 	return fetchAssignedIssuesWith(defaultExecer)
 }
 
 func fetchAssignedIssuesWith(e execer) ([]Issue, error) {
-	return searchIssuesWith(e, "is:issue is:open assignee:@me sort:updated-desc")
+	const query = "is:issue is:open assignee:@me sort:updated-desc"
+	if runtimeCacheEnabled(e) {
+		if cached, ok := assignedIssuesCache.Get(query); ok {
+			return cached, nil
+		}
+		if ghGate.shouldSkipOptional("graphql") {
+			if stale, ok := assignedIssuesCache.GetStale(query); ok {
+				return stale, nil
+			}
+		}
+	}
+
+	issues, err := searchIssuesWith(e, query)
+	if err != nil {
+		if runtimeCacheEnabled(e) {
+			if stale, ok := assignedIssuesCache.GetStale(query); ok {
+				return stale, nil
+			}
+		}
+		return nil, err
+	}
+	if runtimeCacheEnabled(e) {
+		assignedIssuesCache.Set(query, issues, 30*time.Second)
+	}
+	return issues, nil
 }
 
 // FetchLabeledIssuesForRepos returns open issues with the given label across the specified repos.
@@ -81,26 +168,122 @@ func fetchLabeledIssuesForReposWith(e execer, repos []string, label string) ([]I
 		parts[i] = "repo:" + r
 	}
 	query := fmt.Sprintf("is:issue is:open label:%s %s sort:updated-desc", label, strings.Join(parts, " "))
-	return searchIssuesWith(e, query)
+	if runtimeCacheEnabled(e) {
+		if cached, ok := labeledIssuesCache.Get(query); ok {
+			return cached, nil
+		}
+		if ghGate.shouldSkipOptional("graphql") {
+			if stale, ok := labeledIssuesCache.GetStale(query); ok {
+				return stale, nil
+			}
+		}
+	}
+
+	issues, err := searchIssuesWith(e, query)
+	if err != nil {
+		if runtimeCacheEnabled(e) {
+			if stale, ok := labeledIssuesCache.GetStale(query); ok {
+				return stale, nil
+			}
+		}
+		return nil, err
+	}
+	if runtimeCacheEnabled(e) {
+		labeledIssuesCache.Set(query, issues, 30*time.Second)
+	}
+	return issues, nil
 }
 
 func searchIssuesWith(e execer, query string) ([]Issue, error) {
-	out, err := e.run("api", "graphql",
+	httpResp, err := runGHAPIWith(e, "", "graphql",
 		"-f", "query="+issueQuery,
 		"-f", "q="+query)
 	if err != nil {
-		return nil, fmt.Errorf("gh api graphql: %s: %w", sanitizeGHOutput(out), err)
+		return nil, fmt.Errorf("gh api graphql: %s: %w", sanitizeGHOutput(httpResp.body), err)
 	}
 
-	var resp gqlIssueResponse
-	if err := json.Unmarshal(out, &resp); err != nil {
+	var gqlResp gqlIssueResponse
+	if err := json.Unmarshal(httpResp.body, &gqlResp); err != nil {
 		return nil, fmt.Errorf("parse graphql response: %w", err)
 	}
-	if len(resp.Errors) > 0 {
-		return nil, fmt.Errorf("graphql: %s", resp.Errors[0].Message)
+	if len(gqlResp.Errors) > 0 {
+		return nil, fmt.Errorf("graphql: %s", gqlResp.Errors[0].Message)
 	}
 
-	return convertIssues(resp.Data.Search.Nodes), nil
+	return convertIssues(gqlResp.Data.Search.Nodes), nil
+}
+
+// FetchIssueSnapshot returns assigned issues and labeled issues in one GraphQL call.
+func FetchIssueSnapshot(repos []string, label string) (IssueSnapshot, error) {
+	return fetchIssueSnapshotWith(defaultExecer, repos, label)
+}
+
+func fetchIssueSnapshotWith(e execer, repos []string, label string) (IssueSnapshot, error) {
+	snapshot := IssueSnapshot{}
+	if len(repos) == 0 {
+		assigned, err := fetchAssignedIssuesWith(e)
+		if err != nil {
+			return snapshot, err
+		}
+		snapshot.Assigned = assigned
+		return snapshot, nil
+	}
+
+	labeledParts := make([]string, len(repos))
+	for i, repo := range repos {
+		labeledParts[i] = "repo:" + repo
+	}
+	assignedQuery := "is:issue is:open assignee:@me sort:updated-desc"
+	labeledQuery := fmt.Sprintf("is:issue is:open label:%s %s sort:updated-desc", label, strings.Join(labeledParts, " "))
+
+	if runtimeCacheEnabled(e) {
+		if ghGate.shouldSkipOptional("graphql") {
+			if assigned, ok := assignedIssuesCache.GetStale(assignedQuery); ok {
+				snapshot.Assigned = assigned
+			}
+			if labeled, ok := labeledIssuesCache.GetStale(labeledQuery); ok {
+				snapshot.Labeled = labeled
+			}
+			if snapshot.Assigned != nil || snapshot.Labeled != nil {
+				return snapshot, nil
+			}
+		}
+	}
+
+	httpResp, err := runGHAPIWith(e, "", "graphql",
+		"-f", "query="+issueSnapshotQuery,
+		"-f", "assignedQ="+assignedQuery,
+		"-f", "labeledQ="+labeledQuery)
+	if err != nil {
+		if runtimeCacheEnabled(e) {
+			if assigned, ok := assignedIssuesCache.GetStale(assignedQuery); ok {
+				snapshot.Assigned = assigned
+			}
+			if labeled, ok := labeledIssuesCache.GetStale(labeledQuery); ok {
+				snapshot.Labeled = labeled
+			}
+			if snapshot.Assigned != nil || snapshot.Labeled != nil {
+				return snapshot, nil
+			}
+		}
+		return snapshot, fmt.Errorf("gh api graphql: %s: %w", sanitizeGHOutput(httpResp.body), err)
+	}
+
+	var gqlResp gqlIssueSnapshotResponse
+	if err := json.Unmarshal(httpResp.body, &gqlResp); err != nil {
+		return snapshot, fmt.Errorf("parse graphql response: %w", err)
+	}
+	if len(gqlResp.Errors) > 0 {
+		return snapshot, fmt.Errorf("graphql: %s", gqlResp.Errors[0].Message)
+	}
+
+	snapshot.Assigned = convertIssues(gqlResp.Data.Assigned.Nodes)
+	snapshot.Labeled = convertIssues(gqlResp.Data.Labeled.Nodes)
+	if runtimeCacheEnabled(e) {
+		assignedIssuesCache.Set(assignedQuery, snapshot.Assigned, 30*time.Second)
+		labeledIssuesCache.Set(labeledQuery, snapshot.Labeled, 30*time.Second)
+	}
+	return snapshot, nil
 }
 
 func convertIssues(nodes []gqlIssue) []Issue {
@@ -139,6 +322,13 @@ func FetchIssue(repo string, number int) (Issue, error) {
 }
 
 func fetchIssueWith(e execer, repo string, number int) (Issue, error) {
+	key := prCacheKey(repo, number)
+	if runtimeCacheEnabled(e) {
+		if cached, ok := issueCache.Get(key); ok {
+			return cached, nil
+		}
+	}
+
 	out, err := e.run("issue", "view", fmt.Sprintf("%d", number),
 		"--repo", repo, "--json", "number,title,body,url,labels,author")
 	if err != nil {
@@ -168,7 +358,7 @@ func fetchIssueWith(e execer, repo string, number int) (Issue, error) {
 	if len(parts) == 2 {
 		repoName = parts[1]
 	}
-	return Issue{
+	issue := Issue{
 		Number:     raw.Number,
 		Title:      raw.Title,
 		Body:       raw.Body,
@@ -177,5 +367,9 @@ func fetchIssueWith(e execer, repo string, number int) (Issue, error) {
 		RepoName:   repoName,
 		Labels:     labels,
 		Author:     raw.Author.Login,
-	}, nil
+	}
+	if runtimeCacheEnabled(e) {
+		issueCache.Set(key, issue, 2*time.Minute)
+	}
+	return issue, nil
 }

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -92,6 +92,13 @@ func FetchPR(repo string, number int) (PullRequest, error) {
 }
 
 func fetchPRWith(e execer, repo string, number int) (PullRequest, error) {
+	key := prCacheKey(repo, number)
+	if runtimeCacheEnabled(e) {
+		if cached, ok := prCache.Get(key); ok {
+			return cached, nil
+		}
+	}
+
 	out, err := e.run("pr", "view", fmt.Sprintf("%d", number),
 		"--repo", repo, "--json", "number,title,body,url,headRefName,author,labels")
 	if err != nil {
@@ -122,7 +129,7 @@ func fetchPRWith(e execer, repo string, number int) (PullRequest, error) {
 	if len(parts) == 2 {
 		repoName = parts[1]
 	}
-	return PullRequest{
+	pr := PullRequest{
 		Number:      raw.Number,
 		Title:       raw.Title,
 		URL:         raw.URL,
@@ -131,7 +138,11 @@ func fetchPRWith(e execer, repo string, number int) (PullRequest, error) {
 		RepoName:    repoName,
 		Author:      raw.Author.Login,
 		Labels:      labels,
-	}, nil
+	}
+	if runtimeCacheEnabled(e) {
+		prCache.Set(key, pr, 2*time.Minute)
+	}
+	return pr, nil
 }
 
 // FetchPRStats returns additions, deletions, and changed file count for a PR.
@@ -140,6 +151,13 @@ func FetchPRStats(repo string, number int) (PRStats, error) {
 }
 
 func fetchPRStatsWith(e execer, repo string, number int) (PRStats, error) {
+	key := prCacheKey(repo, number)
+	if runtimeCacheEnabled(e) {
+		if cached, ok := prStatsCache.Get(key); ok {
+			return cached, nil
+		}
+	}
+
 	out, err := e.run("pr", "view", fmt.Sprintf("%d", number),
 		"--repo", repo, "--json", "additions,deletions,changedFiles")
 	if err != nil {
@@ -148,6 +166,9 @@ func fetchPRStatsWith(e execer, repo string, number int) (PRStats, error) {
 	var s PRStats
 	if err := json.Unmarshal(out, &s); err != nil {
 		return PRStats{}, fmt.Errorf("parse pr stats: %w", err)
+	}
+	if runtimeCacheEnabled(e) {
+		prStatsCache.Set(key, s, 5*time.Minute)
 	}
 	return s, nil
 }
@@ -158,6 +179,13 @@ func FetchPRState(repo string, number int) (PRState, error) {
 }
 
 func fetchPRStateWith(e execer, repo string, number int) (PRState, error) {
+	key := prCacheKey(repo, number)
+	if runtimeCacheEnabled(e) {
+		if cached, ok := prStateCache.Get(key); ok {
+			return cached, nil
+		}
+	}
+
 	out, err := e.run("pr", "view", fmt.Sprintf("%d", number),
 		"--repo", repo, "--json", "state,mergedAt,mergeable,statusCheckRollup")
 	if err != nil {
@@ -166,6 +194,9 @@ func fetchPRStateWith(e execer, repo string, number int) (PRState, error) {
 	var s PRState
 	if err := json.Unmarshal(out, &s); err != nil {
 		return PRState{}, fmt.Errorf("parse pr state: %w", err)
+	}
+	if runtimeCacheEnabled(e) {
+		prStateCache.Set(key, s, 30*time.Second)
 	}
 	return s, nil
 }
@@ -176,6 +207,13 @@ func FetchPRFiles(repo string, number int) ([]string, error) {
 }
 
 func fetchPRFilesWith(e execer, repo string, number int) ([]string, error) {
+	key := prCacheKey(repo, number)
+	if runtimeCacheEnabled(e) {
+		if cached, ok := prFilesCache.Get(key); ok {
+			return append([]string(nil), cached...), nil
+		}
+	}
+
 	out, err := e.run("pr", "view", fmt.Sprintf("%d", number),
 		"--repo", repo, "--json", "files")
 	if err != nil {
@@ -189,6 +227,9 @@ func fetchPRFilesWith(e execer, repo string, number int) ([]string, error) {
 	for i := range f.Files {
 		paths[i] = f.Files[i].Path
 	}
+	if runtimeCacheEnabled(e) {
+		prFilesCache.Set(key, append([]string(nil), paths...), 2*time.Minute)
+	}
 	return paths, nil
 }
 
@@ -198,6 +239,13 @@ func FetchPRBranch(repo string, number int) (string, error) {
 }
 
 func fetchPRBranchWith(e execer, repo string, number int) (string, error) {
+	key := prCacheKey(repo, number)
+	if runtimeCacheEnabled(e) {
+		if cached, ok := prBranchCache.Get(key); ok {
+			return cached, nil
+		}
+	}
+
 	out, err := e.run("pr", "view", fmt.Sprintf("%d", number),
 		"--repo", repo, "--json", "headRefName")
 	if err != nil {
@@ -206,6 +254,9 @@ func fetchPRBranchWith(e execer, repo string, number int) (string, error) {
 	var b PRBranch
 	if err := json.Unmarshal(out, &b); err != nil {
 		return "", fmt.Errorf("parse pr branch: %w", err)
+	}
+	if runtimeCacheEnabled(e) {
+		prBranchCache.Set(key, b.HeadRefName, 2*time.Minute)
 	}
 	return b.HeadRefName, nil
 }
@@ -216,6 +267,13 @@ func FetchPRContext(repo string, number int) (PRContext, error) {
 }
 
 func fetchPRContextWith(e execer, repo string, number int) (PRContext, error) {
+	key := prCacheKey(repo, number)
+	if runtimeCacheEnabled(e) {
+		if cached, ok := prContextCache.Get(key); ok {
+			return cached, nil
+		}
+	}
+
 	// Fetch PR metadata: url, branch, and review bodies
 	out, err := e.run("pr", "view", fmt.Sprintf("%d", number),
 		"--repo", repo, "--json", "url,headRefName,reviews")
@@ -251,11 +309,11 @@ func fetchPRContextWith(e execer, repo string, number int) (PRContext, error) {
 	}
 
 	// Fetch inline diff comments (unresolved review thread comments).
-	inlineOut, err := e.run("api",
+	inlineResp, err := runGHAPIWith(e, "30s",
 		fmt.Sprintf("repos/%s/pulls/%d/comments", repo, number),
 		"-q", `.[] | select(.position != null) | {author: .user.login, body: .body, path: .path}`)
-	if err == nil && len(inlineOut) > 0 {
-		for line := range strings.SplitSeq(strings.TrimSpace(string(inlineOut)), "\n") {
+	if err == nil && len(inlineResp.body) > 0 {
+		for line := range strings.SplitSeq(strings.TrimSpace(string(inlineResp.body)), "\n") {
 			if line == "" {
 				continue
 			}
@@ -278,6 +336,9 @@ func fetchPRContextWith(e execer, repo string, number int) (PRContext, error) {
 		}
 	}
 
+	if runtimeCacheEnabled(e) {
+		prContextCache.Set(key, ctx, 30*time.Second)
+	}
 	return ctx, nil
 }
 
@@ -291,6 +352,13 @@ func FetchPRClosingIssues(repo string, number int) (issues []int, body string, e
 }
 
 func fetchPRClosingIssuesWith(e execer, repo string, number int) (issues []int, body string, err error) {
+	key := prCacheKey(repo, number)
+	if runtimeCacheEnabled(e) {
+		if cached, ok := prClosingIssuesCache.Get(key); ok {
+			return append([]int(nil), cached.issues...), cached.body, nil
+		}
+	}
+
 	out, runErr := e.run("pr", "view", fmt.Sprintf("%d", number),
 		"--repo", repo, "--json", "closingIssuesReferences,body")
 	if runErr != nil {
@@ -325,6 +393,12 @@ func fetchPRClosingIssuesWith(e execer, repo string, number int) (issues []int, 
 			issues = append(issues, ref.Number)
 		}
 	}
+	if runtimeCacheEnabled(e) {
+		prClosingIssuesCache.Set(key, prClosingIssuesResult{
+			issues: append([]int(nil), issues...),
+			body:   raw.Body,
+		}, 2*time.Minute)
+	}
 	return issues, raw.Body, nil
 }
 
@@ -340,6 +414,9 @@ func mergePRWith(e execer, repo string, number int) error {
 		out, err := e.run("pr", "merge", fmt.Sprintf("%d", number),
 			"--repo", repo, "--squash")
 		if err == nil {
+			if runtimeCacheEnabled(e) {
+				invalidatePRCaches(repo, number)
+			}
 			return nil
 		}
 		lastOut, lastErr = out, err
@@ -367,6 +444,9 @@ func markReadyWith(e execer, repo string, number int) error {
 	if err != nil {
 		return fmt.Errorf("gh pr ready: %s: %w", strings.TrimSpace(string(out)), err)
 	}
+	if runtimeCacheEnabled(e) {
+		invalidatePRCaches(repo, number)
+	}
 	return nil
 }
 
@@ -380,6 +460,9 @@ func editPRBodyWith(e execer, repo string, number int, body string) error {
 		"--repo", repo, "--body", body)
 	if err != nil {
 		return fmt.Errorf("gh pr edit %d: %s: %w", number, strings.TrimSpace(string(out)), err)
+	}
+	if runtimeCacheEnabled(e) {
+		invalidatePRCaches(repo, number)
 	}
 	return nil
 }

--- a/internal/github/renovate.go
+++ b/internal/github/renovate.go
@@ -3,11 +3,20 @@ package github
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
 )
+
+const renovateSearchChunkSize = 20
 
 // renovatePRQuery includes individual check run contexts for rerun support.
 const renovatePRQuery = `query($q: String!) {
-  search(query: $q, type: ISSUE, first: 50) {
+  viewer { login }
+  search(query: $q, type: ISSUE, first: 100) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
     nodes {
       ... on PullRequest {
         number
@@ -61,50 +70,92 @@ func fetchRenovatePRsWith(e execer, author string, repos []string) ([]RenovatePR
 		return nil, nil
 	}
 
-	seen := make(map[string]struct{})
-	var all []RenovatePR
-
 	authors := []string{author}
 	if author == "app/renovate" {
 		authors = append(authors, "renovate[bot]")
 	}
-
-	for _, repo := range repos {
-		for _, a := range authors {
-			query := fmt.Sprintf("is:pr is:open author:%s repo:%s", a, repo)
-			prs, err := searchRenovatePRsWith(e, query)
-			if err != nil {
-				return nil, fmt.Errorf("fetch renovate PRs for %s: %w", repo, err)
-			}
-			for i := range prs {
-				key := fmt.Sprintf("%s#%d", prs[i].Repository, prs[i].Number)
-				if _, dup := seen[key]; !dup {
-					seen[key] = struct{}{}
-					all = append(all, prs[i])
-				}
+	cacheKey := strings.Join(authors, ",") + "||" + strings.Join(repos, ",")
+	if runtimeCacheEnabled(e) {
+		if cached, ok := renovatePRsCache.Get(cacheKey); ok {
+			return cached, nil
+		}
+		if ghGate.shouldSkipOptional("graphql") {
+			if stale, ok := renovatePRsCache.GetStale(cacheKey); ok {
+				return stale, nil
 			}
 		}
+	}
+
+	seen := make(map[string]struct{})
+	var all []RenovatePR
+
+	for start := 0; start < len(repos); start += renovateSearchChunkSize {
+		end := min(start+renovateSearchChunkSize, len(repos))
+		query := buildRenovateSearchQuery(authors, repos[start:end])
+		prs, err := searchRenovatePRsWith(e, query)
+		if err != nil {
+			if runtimeCacheEnabled(e) {
+				if stale, ok := renovatePRsCache.GetStale(cacheKey); ok {
+					return stale, nil
+				}
+			}
+			return nil, fmt.Errorf("fetch renovate PRs: %w", err)
+		}
+		for i := range prs {
+			key := fmt.Sprintf("%s#%d", prs[i].Repository, prs[i].Number)
+			if _, dup := seen[key]; !dup {
+				seen[key] = struct{}{}
+				all = append(all, prs[i])
+			}
+		}
+	}
+	if runtimeCacheEnabled(e) {
+		renovatePRsCache.Set(cacheKey, all, 30*time.Second)
 	}
 	return all, nil
 }
 
 func searchRenovatePRsWith(e execer, query string) ([]RenovatePR, error) {
-	out, err := e.run("api", "graphql",
+	resp, err := runGHAPIWith(e, "", "graphql",
 		"-f", "query="+renovatePRQuery,
 		"-f", "q="+query)
 	if err != nil {
-		return nil, fmt.Errorf("gh api graphql: %s: %w", sanitizeGHOutput(out), err)
+		return nil, fmt.Errorf("gh api graphql: %s: %w", sanitizeGHOutput(resp.body), err)
 	}
 
-	var resp gqlResponse
-	if err := json.Unmarshal(out, &resp); err != nil {
+	var gqlResp gqlResponse
+	if err := json.Unmarshal(resp.body, &gqlResp); err != nil {
 		return nil, fmt.Errorf("parse graphql response: %w", err)
 	}
-	if len(resp.Errors) > 0 {
-		return nil, fmt.Errorf("graphql: %s", resp.Errors[0].Message)
+	if len(gqlResp.Errors) > 0 {
+		return nil, fmt.Errorf("graphql: %s", gqlResp.Errors[0].Message)
 	}
 
-	return convertRenovatePRs(resp.Data.Search.Nodes, viewerLogin(e)), nil
+	return convertRenovatePRs(gqlResp.Data.Search.Nodes, gqlResp.Data.Viewer.Login), nil
+}
+
+func buildRenovateSearchQuery(authors, repos []string) string {
+	var authorParts []string
+	for _, author := range authors {
+		if strings.TrimSpace(author) == "" {
+			continue
+		}
+		authorParts = append(authorParts, "author:"+author)
+	}
+
+	var repoParts []string
+	for _, repo := range repos {
+		if strings.TrimSpace(repo) == "" {
+			continue
+		}
+		repoParts = append(repoParts, "repo:"+repo)
+	}
+
+	return fmt.Sprintf(
+		"is:pr is:open (%s) (%s)",
+		strings.Join(authorParts, " OR "),
+		strings.Join(repoParts, " OR "),
+	)
 }
 
 func convertRenovatePRs(nodes []gqlPR, viewer string) []RenovatePR {

--- a/internal/github/renovate_test.go
+++ b/internal/github/renovate_test.go
@@ -61,3 +61,16 @@ func TestConvertRenovatePRs(t *testing.T) {
 		}
 	})
 }
+
+func TestBuildRenovateSearchQuery(t *testing.T) {
+	t.Parallel()
+
+	got := buildRenovateSearchQuery(
+		[]string{"app/renovate", "renovate[bot]"},
+		[]string{"acme/api", "acme/web"},
+	)
+	want := "is:pr is:open (author:app/renovate OR author:renovate[bot]) (repo:acme/api OR repo:acme/web)"
+	if got != want {
+		t.Fatalf("query = %q, want %q", got, want)
+	}
+}

--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -4,7 +4,105 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 )
+
+const reviewSummaryQuery = `query($createdQ: String!, $requestedQ: String!) {
+  viewer { login }
+  created: search(query: $createdQ, type: ISSUE, first: 100) {
+    nodes {
+      ... on PullRequest {
+        number
+        title
+        url
+        headRefName
+        isDraft
+        mergeable
+        createdAt
+        updatedAt
+        reviewDecision
+        author { login type: __typename }
+        repository { name nameWithOwner }
+        labels(first: 10) { nodes { name } }
+        commits(last: 1) {
+          nodes {
+            commit {
+              statusCheckRollup {
+                state
+                contexts(first: 50) {
+                  nodes {
+                    ... on CheckRun { status }
+                  }
+                }
+              }
+            }
+          }
+        }
+        reviewThreads(first: 100) {
+          nodes { isResolved }
+        }
+        latestReviews(first: 20) {
+          nodes { state author { login } }
+        }
+      }
+    }
+  }
+  requested: search(query: $requestedQ, type: ISSUE, first: 100) {
+    nodes {
+      ... on PullRequest {
+        number
+        title
+        url
+        headRefName
+        isDraft
+        mergeable
+        createdAt
+        updatedAt
+        reviewDecision
+        author { login type: __typename }
+        repository { name nameWithOwner }
+        labels(first: 10) { nodes { name } }
+        commits(last: 1) {
+          nodes {
+            commit {
+              statusCheckRollup {
+                state
+                contexts(first: 50) {
+                  nodes {
+                    ... on CheckRun { status }
+                  }
+                }
+              }
+            }
+          }
+        }
+        reviewThreads(first: 100) {
+          nodes { isResolved }
+        }
+        latestReviews(first: 20) {
+          nodes { state author { login } }
+        }
+      }
+    }
+  }
+}`
+
+type gqlReviewSummaryResponse struct {
+	Data struct {
+		Viewer struct {
+			Login string `json:"login"`
+		} `json:"viewer"`
+		Created struct {
+			Nodes []gqlPR `json:"nodes"`
+		} `json:"created"`
+		Requested struct {
+			Nodes []gqlPR `json:"nodes"`
+		} `json:"requested"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
 
 // FetchReviews returns open PRs created by the user and review requests, excluding bots.
 func FetchReviews() (ReviewSummary, error) {
@@ -12,21 +110,49 @@ func FetchReviews() (ReviewSummary, error) {
 }
 
 func fetchReviewsWith(e execer) (ReviewSummary, error) {
-	var summary ReviewSummary
-
-	created, err := searchPRsWith(e, "is:pr is:open author:@me")
-	if err != nil {
-		return summary, fmt.Errorf("fetch created PRs: %w", err)
+	const (
+		createdQuery   = "is:pr is:open author:@me"
+		requestedQuery = "is:pr is:open review-requested:@me"
+	)
+	cacheKey := createdQuery + "||" + requestedQuery
+	if runtimeCacheEnabled(e) {
+		if cached, ok := reviewSummaryCache.Get(cacheKey); ok {
+			return cached, nil
+		}
+		if ghGate.shouldSkipOptional("graphql") {
+			if stale, ok := reviewSummaryCache.GetStale(cacheKey); ok {
+				return stale, nil
+			}
+		}
 	}
-	summary.CreatedByMe = created
 
-	// review-requested may fail on server deployments with scoped tokens or
-	// rate limits. Log and continue rather than discarding createdByMe data.
-	requested, err := searchPRsWith(e, "is:pr is:open review-requested:@me")
+	resp, err := runGHAPIWith(e, "", "graphql",
+		"-f", "query="+reviewSummaryQuery,
+		"-f", "createdQ="+createdQuery,
+		"-f", "requestedQ="+requestedQuery)
 	if err != nil {
-		summary.ReviewRequested = nil
-	} else {
-		summary.ReviewRequested = requested
+		if runtimeCacheEnabled(e) {
+			if stale, ok := reviewSummaryCache.GetStale(cacheKey); ok {
+				return stale, nil
+			}
+		}
+		return ReviewSummary{}, fmt.Errorf("gh api graphql: %s: %w", sanitizeGHOutput(resp.body), err)
+	}
+
+	var gqlResp gqlReviewSummaryResponse
+	if err := json.Unmarshal(resp.body, &gqlResp); err != nil {
+		return ReviewSummary{}, fmt.Errorf("parse graphql response: %w", err)
+	}
+	if len(gqlResp.Errors) > 0 {
+		return ReviewSummary{}, fmt.Errorf("graphql: %s", gqlResp.Errors[0].Message)
+	}
+
+	summary := ReviewSummary{
+		CreatedByMe:     convertPRs(gqlResp.Data.Created.Nodes, gqlResp.Data.Viewer.Login),
+		ReviewRequested: convertPRs(gqlResp.Data.Requested.Nodes, gqlResp.Data.Viewer.Login),
+	}
+	if runtimeCacheEnabled(e) {
+		reviewSummaryCache.Set(cacheKey, summary, 20*time.Second)
 	}
 
 	return summary, nil
@@ -39,20 +165,38 @@ func HasPendingReview(repo string, number int) (bool, error) {
 }
 
 func hasPendingReviewWith(e execer, repo string, number int) (bool, error) {
-	out, err := e.run("api", fmt.Sprintf("repos/%s/pulls/%d/reviews", repo, number))
+	key := prCacheKey(repo, number)
+	if runtimeCacheEnabled(e) {
+		if cached, ok := pendingReviewCache.Get(key); ok {
+			return cached, nil
+		}
+	}
+
+	resp, err := runGHAPIWith(e, "30s", fmt.Sprintf("repos/%s/pulls/%d/reviews", repo, number))
 	if err != nil {
-		return false, fmt.Errorf("fetch reviews for %s#%d: %s: %w", repo, number, strings.TrimSpace(string(out)), err)
+		if runtimeCacheEnabled(e) {
+			if stale, ok := pendingReviewCache.GetStale(key); ok {
+				return stale, nil
+			}
+		}
+		return false, fmt.Errorf("fetch reviews for %s#%d: %s: %w", repo, number, strings.TrimSpace(string(resp.body)), err)
 	}
 	var reviews []struct {
 		State string `json:"state"`
 	}
-	if err := json.Unmarshal(out, &reviews); err != nil {
+	if err := json.Unmarshal(resp.body, &reviews); err != nil {
 		return false, fmt.Errorf("parse reviews: %w", err)
 	}
 	for i := range reviews {
 		if reviews[i].State == "PENDING" {
+			if runtimeCacheEnabled(e) {
+				pendingReviewCache.Set(key, true, 30*time.Second)
+			}
 			return true, nil
 		}
+	}
+	if runtimeCacheEnabled(e) {
+		pendingReviewCache.Set(key, false, 30*time.Second)
 	}
 	return false, nil
 }
@@ -67,6 +211,9 @@ func approvePRWith(e execer, repo string, number int) error {
 		fmt.Sprintf("%d", number), "-R", repo)
 	if err != nil {
 		return fmt.Errorf("gh pr review --approve %d: %s: %w", number, strings.TrimSpace(string(out)), err)
+	}
+	if runtimeCacheEnabled(e) {
+		invalidatePRCaches(repo, number)
 	}
 	return nil
 }

--- a/internal/github/review_test.go
+++ b/internal/github/review_test.go
@@ -5,31 +5,12 @@ import (
 	"testing"
 )
 
-// seqExecer returns successive output/error pairs per call, cycling the last
-// entry if calls exceed the slice length. Used to simulate partial failures
-// (e.g. first query succeeds, second fails).
-type seqExecer struct {
-	responses []struct {
-		output []byte
-		err    error
-	}
-	i int
-}
-
-func (s *seqExecer) run(_ ...string) ([]byte, error) {
-	idx := s.i
-	if idx >= len(s.responses) {
-		idx = len(s.responses) - 1
-	}
-	s.i++
-	return s.responses[idx].output, s.responses[idx].err
-}
-
 func TestFetchReviewsWith_success(t *testing.T) {
 	t.Parallel()
 	response := `{
 		"data": {
-			"search": {
+			"viewer": {"login": "me"},
+			"created": {
 				"nodes": [
 					{
 						"number": 1,
@@ -42,18 +23,32 @@ func TestFetchReviewsWith_success(t *testing.T) {
 						"reviewThreads": {"nodes": []}
 					}
 				]
+			},
+			"requested": {
+				"nodes": [
+					{
+						"number": 2,
+						"title": "review me",
+						"url": "https://github.com/o/r/pull/2",
+						"author": {"login": "peer", "type": "User"},
+						"repository": {"name": "r", "nameWithOwner": "o/r"},
+						"labels": {"nodes": []},
+						"commits": {"nodes": []},
+						"reviewThreads": {"nodes": []},
+						"latestReviews": {"nodes": []}
+					}
+				]
 			}
 		}
 	}`
 
-	resetViewerCache()
 	fe := &fakeExecer{output: []byte(response)}
 	summary, err := fetchReviewsWith(fe)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if fe.calls < 2 {
-		t.Errorf("expected at least 2 calls (created + requested), got %d", fe.calls)
+	if fe.calls != 1 {
+		t.Errorf("calls = %d, want 1", fe.calls)
 	}
 	if len(summary.CreatedByMe) != 1 {
 		t.Errorf("CreatedByMe len = %d, want 1", len(summary.CreatedByMe))
@@ -63,35 +58,12 @@ func TestFetchReviewsWith_success(t *testing.T) {
 	}
 }
 
-func TestFetchReviewsWith_reviewRequestedFailsReturnsCreatedByMe(t *testing.T) {
-	// Simulates a server where review-requested query fails (scoped token,
-	// rate limit, etc.). Must return createdByMe without error.
+func TestFetchReviewsWith_graphqlError(t *testing.T) {
 	t.Parallel()
-	response := `{"data":{"search":{"nodes":[{"number":7,"title":"my pr",` +
-		`"url":"https://github.com/o/r/pull/7","author":{"login":"me","type":"User"},` +
-		`"repository":{"name":"r","nameWithOwner":"o/r"},` +
-		`"labels":{"nodes":[]},"commits":{"nodes":[]},"reviewThreads":{"nodes":[]}}]}}}`
-
-	resetViewerCache()
-	type entry = struct {
-		output []byte
-		err    error
-	}
-	fe := &seqExecer{responses: []entry{
-		{output: []byte(response)},                              // createdByMe graphql
-		{output: []byte("me\n")},                                // viewerLogin user API
-		{output: []byte("gh error"), err: fmt.Errorf("exit 1")}, // review-requested graphql → fail
-	}}
-
-	summary, err := fetchReviewsWith(fe)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(summary.CreatedByMe) != 1 {
-		t.Errorf("CreatedByMe len = %d, want 1", len(summary.CreatedByMe))
-	}
-	if summary.ReviewRequested != nil {
-		t.Errorf("ReviewRequested = %v, want nil", summary.ReviewRequested)
+	fe := &fakeExecer{output: []byte(`{"errors":[{"message":"rate limited"}]}`)}
+	_, err := fetchReviewsWith(fe)
+	if err == nil {
+		t.Fatal("expected error")
 	}
 }
 

--- a/internal/github/runtime.go
+++ b/internal/github/runtime.go
@@ -1,0 +1,277 @@
+package github
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	ghRequestSpacing      = 150 * time.Millisecond
+	ghLowBudgetThreshold  = 150
+	ghOptionalCooldown    = 30 * time.Second
+	ghFallbackRateBackoff = 1 * time.Minute
+)
+
+type ttlCache[T any] struct {
+	mu    sync.RWMutex
+	items map[string]ttlCacheEntry[T]
+}
+
+type ttlCacheEntry[T any] struct {
+	value     T
+	expiresAt time.Time
+}
+
+func newTTLCache[T any]() *ttlCache[T] {
+	return &ttlCache[T]{items: make(map[string]ttlCacheEntry[T])}
+}
+
+func (c *ttlCache[T]) Get(key string) (T, bool) {
+	var zero T
+	c.mu.RLock()
+	entry, ok := c.items[key]
+	c.mu.RUnlock()
+	if !ok {
+		return zero, false
+	}
+	if !entry.expiresAt.IsZero() && time.Now().After(entry.expiresAt) {
+		c.mu.Lock()
+		delete(c.items, key)
+		c.mu.Unlock()
+		return zero, false
+	}
+	return entry.value, true
+}
+
+func (c *ttlCache[T]) GetStale(key string) (T, bool) {
+	var zero T
+	c.mu.RLock()
+	entry, ok := c.items[key]
+	c.mu.RUnlock()
+	if !ok {
+		return zero, false
+	}
+	return entry.value, true
+}
+
+func (c *ttlCache[T]) Set(key string, value T, ttl time.Duration) {
+	c.mu.Lock()
+	c.items[key] = ttlCacheEntry[T]{
+		value:     value,
+		expiresAt: time.Now().Add(ttl),
+	}
+	c.mu.Unlock()
+}
+
+func (c *ttlCache[T]) Delete(key string) {
+	c.mu.Lock()
+	delete(c.items, key)
+	c.mu.Unlock()
+}
+
+type ghHTTPResponse struct {
+	body       []byte
+	headers    map[string]string
+	statusCode int
+}
+
+func parseGHHTTPResponse(out []byte) ghHTTPResponse {
+	raw := strings.ReplaceAll(string(out), "\r\n", "\n")
+	if !strings.HasPrefix(raw, "HTTP/") {
+		return ghHTTPResponse{body: out}
+	}
+
+	head, body, ok := strings.Cut(raw, "\n\n")
+	if !ok {
+		return ghHTTPResponse{body: out}
+	}
+	lines := strings.Split(head, "\n")
+	resp := ghHTTPResponse{
+		body:    []byte(body),
+		headers: make(map[string]string),
+	}
+
+	if len(lines) > 0 {
+		parts := strings.Fields(lines[0])
+		if len(parts) >= 2 {
+			if code, err := strconv.Atoi(parts[1]); err == nil {
+				resp.statusCode = code
+			}
+		}
+	}
+
+	for _, line := range lines[1:] {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		resp.headers[strings.ToLower(strings.TrimSpace(key))] = strings.TrimSpace(value)
+	}
+
+	return resp
+}
+
+type ghRateWindow struct {
+	remaining int
+	resetAt   time.Time
+}
+
+type ghRequestGate struct {
+	mu        sync.Mutex
+	notBefore time.Time
+	lastRun   time.Time
+	resources map[string]ghRateWindow
+}
+
+func newGHRequestGate() *ghRequestGate {
+	return &ghRequestGate{
+		resources: make(map[string]ghRateWindow),
+	}
+}
+
+func (g *ghRequestGate) execute(run func() ([]byte, error)) ([]byte, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	waitUntil := g.notBefore
+	if next := g.lastRun.Add(ghRequestSpacing); next.After(waitUntil) {
+		waitUntil = next
+	}
+	if sleep := time.Until(waitUntil); sleep > 0 {
+		time.Sleep(sleep)
+	}
+
+	out, err := run()
+	g.lastRun = time.Now()
+	if err != nil && isRateLimitedMessage(string(out)) {
+		g.bumpLocked(g.lastRun.Add(ghFallbackRateBackoff))
+	}
+	return out, err
+}
+
+func (g *ghRequestGate) observe(resp ghHTTPResponse, err error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	now := time.Now()
+	if retryAfter, ok := resp.headers["retry-after"]; ok {
+		if seconds, convErr := strconv.Atoi(strings.TrimSpace(retryAfter)); convErr == nil && seconds > 0 {
+			g.bumpLocked(now.Add(time.Duration(seconds) * time.Second))
+		}
+	}
+
+	resource := strings.ToLower(strings.TrimSpace(resp.headers["x-ratelimit-resource"]))
+	if resource != "" {
+		window := ghRateWindow{remaining: -1}
+		if remaining, ok := resp.headers["x-ratelimit-remaining"]; ok {
+			if n, convErr := strconv.Atoi(strings.TrimSpace(remaining)); convErr == nil {
+				window.remaining = n
+			}
+		}
+		if reset, ok := resp.headers["x-ratelimit-reset"]; ok {
+			if ts, convErr := strconv.ParseInt(strings.TrimSpace(reset), 10, 64); convErr == nil && ts > 0 {
+				window.resetAt = time.Unix(ts, 0)
+			}
+		}
+		g.resources[resource] = window
+		if window.remaining == 0 && !window.resetAt.IsZero() {
+			g.bumpLocked(window.resetAt)
+		}
+	}
+
+	if err != nil && isRateLimitedMessage(string(resp.body)) {
+		g.bumpLocked(now.Add(ghFallbackRateBackoff))
+	}
+}
+
+func (g *ghRequestGate) shouldSkipOptional(resource string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if time.Until(g.notBefore) > 0 {
+		return true
+	}
+
+	window, ok := g.resources[strings.ToLower(resource)]
+	if !ok || window.remaining < 0 || window.resetAt.IsZero() {
+		return false
+	}
+	if window.remaining > ghLowBudgetThreshold {
+		return false
+	}
+	return time.Until(window.resetAt) > ghOptionalCooldown
+}
+
+func (g *ghRequestGate) bumpLocked(until time.Time) {
+	if until.After(g.notBefore) {
+		g.notBefore = until
+	}
+}
+
+func isRateLimitedMessage(msg string) bool {
+	lower := strings.ToLower(msg)
+	return strings.Contains(lower, "secondary rate limit") ||
+		strings.Contains(lower, "api rate limit exceeded") ||
+		strings.Contains(lower, "rate limit exceeded") ||
+		strings.Contains(lower, "retry after")
+}
+
+func runGHAPIWith(e execer, cacheTTL string, args ...string) (ghHTTPResponse, error) {
+	cmdArgs := make([]string, 0, len(args)+4)
+	cmdArgs = append(cmdArgs, "api")
+	if cacheTTL != "" {
+		cmdArgs = append(cmdArgs, "--cache", cacheTTL)
+	}
+	cmdArgs = append(cmdArgs, "--include")
+	cmdArgs = append(cmdArgs, args...)
+
+	out, err := e.run(cmdArgs...)
+	resp := parseGHHTTPResponse(out)
+	ghGate.observe(resp, err)
+	return resp, err
+}
+
+func runtimeCacheEnabled(e execer) bool {
+	return e == defaultExecer
+}
+
+func prCacheKey(repo string, number int) string {
+	return repo + "#" + strconv.Itoa(number)
+}
+
+func invalidatePRCaches(repo string, number int) {
+	key := prCacheKey(repo, number)
+	prCache.Delete(key)
+	prStatsCache.Delete(key)
+	prStateCache.Delete(key)
+	prFilesCache.Delete(key)
+	prBranchCache.Delete(key)
+	prContextCache.Delete(key)
+	prClosingIssuesCache.Delete(key)
+	pendingReviewCache.Delete(key)
+}
+
+var (
+	ghGate = newGHRequestGate()
+
+	reviewSummaryCache   = newTTLCache[ReviewSummary]()
+	assignedIssuesCache  = newTTLCache[[]Issue]()
+	labeledIssuesCache   = newTTLCache[[]Issue]()
+	renovatePRsCache     = newTTLCache[[]RenovatePR]()
+	prCache              = newTTLCache[PullRequest]()
+	prStatsCache         = newTTLCache[PRStats]()
+	prStateCache         = newTTLCache[PRState]()
+	prFilesCache         = newTTLCache[[]string]()
+	prBranchCache        = newTTLCache[string]()
+	prContextCache       = newTTLCache[PRContext]()
+	prClosingIssuesCache = newTTLCache[prClosingIssuesResult]()
+	pendingReviewCache   = newTTLCache[bool]()
+	issueCache           = newTTLCache[Issue]()
+)
+
+type prClosingIssuesResult struct {
+	issues []int
+	body   string
+}

--- a/internal/poll/issues.go
+++ b/internal/poll/issues.go
@@ -26,6 +26,7 @@ type IssuesFetcher struct {
 	allowsType    func(project.ProjectType) bool
 	fetchAssigned func() ([]github.Issue, error)
 	fetchLabeled  func(repos []string, label string) ([]github.Issue, error)
+	fetchSnapshot func(repos []string, label string) (github.IssueSnapshot, error)
 }
 
 // NewIssuesFetcher creates an IssuesFetcher. allowsType filters issues whose
@@ -49,12 +50,18 @@ func NewIssuesFetcher(
 		allowsType:    allowsType,
 		fetchAssigned: github.FetchAssignedIssues,
 		fetchLabeled:  github.FetchLabeledIssuesForRepos,
+		fetchSnapshot: github.FetchIssueSnapshot,
 	}
 }
 
 func (f *IssuesFetcher) Name() string { return "issues" }
 
 func (f *IssuesFetcher) Poll(_ context.Context) time.Duration {
+	if f.fetchSnapshot != nil {
+		f.pollSnapshot()
+		return IssuesPollInterval
+	}
+
 	issues, err := f.fetchAssigned()
 	metrics.GitHubFetch(err == nil)
 	if err != nil {
@@ -69,6 +76,24 @@ func (f *IssuesFetcher) Poll(_ context.Context) time.Duration {
 	return IssuesPollInterval
 }
 
+func (f *IssuesFetcher) pollSnapshot() {
+	repos := f.allowedRepos()
+	snapshot, err := f.fetchSnapshot(repos, synapseIssueLabel)
+	metrics.GitHubFetch(err == nil)
+	if err != nil {
+		f.logger.Warn("issues.fetch", "err", err)
+		return
+	}
+
+	f.emit("issues:updated", snapshot.Assigned)
+	f.logger.Debug("issues.poll", "count", len(snapshot.Assigned))
+	metrics.GitHubIssuesImported(len(snapshot.Assigned))
+	f.syncIssuesToTasks(snapshot.Assigned)
+
+	f.logger.Debug("labeled-issues.poll", "count", len(snapshot.Labeled))
+	f.syncIssuesToTasks(snapshot.Labeled)
+}
+
 // syncLabeledIssuesToTasks fetches issues labeled 'sybra' across all registered
 // pet projects and creates tasks for any not yet tracked.
 func (f *IssuesFetcher) syncLabeledIssuesToTasks() {
@@ -78,12 +103,7 @@ func (f *IssuesFetcher) syncLabeledIssuesToTasks() {
 		return
 	}
 
-	var repos []string
-	for i := range projects {
-		if f.allowsType(projects[i].Type) {
-			repos = append(repos, projects[i].ID)
-		}
-	}
+	repos := f.allowedReposFrom(projects)
 	if len(repos) == 0 {
 		return
 	}
@@ -95,6 +115,25 @@ func (f *IssuesFetcher) syncLabeledIssuesToTasks() {
 	}
 	f.logger.Debug("labeled-issues.poll", "count", len(labeled))
 	f.syncIssuesToTasks(labeled)
+}
+
+func (f *IssuesFetcher) allowedRepos() []string {
+	projects, err := f.projects.List()
+	if err != nil {
+		f.logger.Error("labeled-issues.list-projects", "err", err)
+		return nil
+	}
+	return f.allowedReposFrom(projects)
+}
+
+func (f *IssuesFetcher) allowedReposFrom(projects []project.Project) []string {
+	var repos []string
+	for i := range projects {
+		if f.allowsType(projects[i].Type) {
+			repos = append(repos, projects[i].ID)
+		}
+	}
+	return repos
 }
 
 func (f *IssuesFetcher) syncIssuesToTasks(issues []github.Issue) {


### PR DESCRIPTION
## Motivation

Reduce GitHub API pressure from polling and repeated PR reads.

> Changelog: fix(github): reduce gh api pressure

## Implementation information

Batch issue, review, and Renovate poll queries. Serialize Work seamlessly with GitHub from the command line.

USAGE
  gh <command> <subcommand> [flags]

CORE COMMANDS
  auth:          Authenticate gh and git with GitHub
  browse:        Open repositories, issues, pull requests, and more in the browser
  codespace:     Connect to and manage codespaces
  gist:          Manage gists
  issue:         Manage issues
  org:           Manage organizations
  pr:            Manage pull requests
  project:       Work with GitHub Projects.
  release:       Manage releases
  repo:          Manage repositories

GITHUB ACTIONS COMMANDS
  cache:         Manage GitHub Actions caches
  run:           View details about workflow runs
  workflow:      View details about GitHub Actions workflows

ALIAS COMMANDS
  co:            Alias for "pr checkout"

ADDITIONAL COMMANDS
  agent-task:    Work with agent tasks (preview)
  alias:         Create command shortcuts
  api:           Make an authenticated GitHub API request
  attestation:   Work with artifact attestations
  completion:    Generate shell completion scripts
  config:        Manage configuration for gh
  extension:     Manage gh extensions
  gpg-key:       Manage GPG keys
  label:         Manage labels
  preview:       Execute previews for gh features
  ruleset:       View info about repo rulesets
  search:        Search for repositories, issues, and pull requests
  secret:        Manage GitHub secrets
  ssh-key:       Manage SSH keys
  status:        Print information about relevant issues, pull requests, and notifications across repositories
  variable:      Manage GitHub Actions variables

HELP TOPICS
  accessibility: Learn about GitHub CLI's accessibility experiences
  actions:       Learn about working with GitHub Actions
  environment:   Environment variables that can be used with gh
  exit-codes:    Exit codes used by gh
  formatting:    Formatting options for JSON data exported from gh
  mintty:        Information about using gh with MinTTY
  reference:     A comprehensive reference of all gh commands

FLAGS
  --help      Show help for command
  --version   Show gh version

EXAMPLES
  $ gh issue create
  $ gh repo clone cli/cli
  $ gh pr checkout 321

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`
  Learn about accessibility experiences using `gh help accessibility` calls, parse rate-limit headers, and cache hot read paths with stale fallback under pressure.

## Supporting documentation

N/A