### PR TITLE
build(docker): ship sybra source tree

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,6 +125,9 @@ RUN userdel -r node 2>/dev/null || true \
 COPY --from=go-builder /bin/sybra-server /usr/local/bin/sybra-server
 COPY --from=go-builder /bin/sybra-cli /usr/local/bin/sybra-cli
 COPY --from=frontend-builder /app/frontend/dist-web /app/web
+COPY internal /app/src/internal
+COPY orchestrator /app/src/orchestrator
+COPY go.mod go.sum README.md CLAUDE.md /app/src/
 
 ENV SYBRA_PORT=8080
 ENV SYBRA_STATIC_DIR=/app/web


### PR DESCRIPTION
## Motivation

Remote sybra needs a local sybra source checkout for the human-review agent. The server image only shipped the binary and web assets, so `human_review.sybra_repo_dir` had nowhere valid to point.

> Changelog: build(docker): ship sybra source tree

## Implementation information

Copied the sybra source files the review agent needs into `/app/src` in the runtime image: `internal/`, `orchestrator/`, and top-level metadata files used for repo context.

This keeps the existing runtime layout intact while making `human_review.sybra_repo_dir: /app/src` valid on the server.

## Supporting documentation

Pairs with the home-nas deploy change that enables `human_review` and points it at `/app/src`.