### PR TITLE
fix(watchdog): avoid false human-required

### DIFF
--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -59,6 +59,9 @@ type Watchdog struct {
 	logger *slog.Logger
 	emit   func(string, any)
 	wg     *sync.WaitGroup
+
+	inspectAgent func(context.Context, *slog.Logger, agent.InspectInput) (agent.InspectorVerdict, error)
+	stopAgent    func(string) error
 }
 
 // New creates a Watchdog.
@@ -70,11 +73,13 @@ func New(
 	wg *sync.WaitGroup,
 ) *Watchdog {
 	return &Watchdog{
-		agents: agents,
-		tasks:  tasks,
-		logger: logger,
-		emit:   emit,
-		wg:     wg,
+		agents:       agents,
+		tasks:        tasks,
+		logger:       logger,
+		emit:         emit,
+		wg:           wg,
+		inspectAgent: agent.Inspect,
+		stopAgent:    agents.StopAgent,
 	}
 }
 
@@ -145,7 +150,7 @@ func (w *Watchdog) inspect(ctx context.Context, ag *agent.Agent, t task.Task, st
 	ictx, cancel := context.WithTimeout(ctx, InspectTimeout)
 	defer cancel()
 
-	verdict, err := agent.Inspect(ictx, w.logger, agent.InspectInput{
+	verdict, err := w.inspectAgent(ictx, w.logger, agent.InspectInput{
 		AgentID:   ag.ID,
 		TaskTitle: t.Title,
 		LogPath:   ag.GetLogPath(),
@@ -162,26 +167,34 @@ func (w *Watchdog) inspect(ctx context.Context, ag *agent.Agent, t task.Task, st
 		"recommendation", verdict.Recommendation, "reason", verdict.Reason)
 
 	w.emit(events.AgentStuck(ag.ID), verdict)
+	w.applyVerdict(ag, verdict)
+}
 
+func (w *Watchdog) applyVerdict(ag *agent.Agent, verdict agent.InspectorVerdict) {
 	switch verdict.Recommendation {
 	case "stop":
 		// Set human-required before stopping so the AdvanceStep callback
 		// (fired via onComplete after the agent exits) sees the escalated
 		// status and the workflow stops instead of advancing to the next step.
 		if ag.TaskID != "" {
-			if _, err := w.tasks.Update(ag.TaskID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+			reason := "watchdog stop"
+			if verdict.Reason != "" {
+				reason = "watchdog: " + verdict.Reason
+			}
+			if _, err := w.tasks.Update(ag.TaskID, task.Update{
+				Status:       task.Ptr(task.StatusHumanRequired),
+				StatusReason: task.Ptr(reason),
+			}); err != nil {
 				w.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
 			}
 		}
-		if err := w.agents.StopAgent(ag.ID); err != nil {
+		if err := w.stopAgent(ag.ID); err != nil {
 			w.logger.Error("agent.watchdog.stop.failed", "id", ag.ID, "err", err)
 		}
 	case "escalate":
-		if ag.TaskID != "" {
-			if _, err := w.tasks.Update(ag.TaskID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
-				w.logger.Error("agent.watchdog.task.update", "task_id", ag.TaskID, "err", err)
-			}
-		}
+		// Ambiguous verdicts are advisory only. Flipping the task to
+		// human-required while the agent keeps running leaves task status
+		// inconsistent and can strand successfully completing work.
 	case "continue":
 		// intentional no-op; debounce suppresses re-check
 	}

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -1,0 +1,91 @@
+package watchdog
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func TestApplyVerdict_EscalateLeavesTaskRunning(t *testing.T) {
+	tasks, tk := newTestTasks(t)
+
+	stopped := false
+	w := &Watchdog{
+		tasks:     tasks,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		stopAgent: func(string) error { stopped = true; return nil },
+	}
+
+	w.applyVerdict(&agent.Agent{ID: "a1", TaskID: tk.ID}, agent.InspectorVerdict{
+		Stuck:          true,
+		Reason:         "ambiguous environment churn",
+		Recommendation: "escalate",
+	})
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusInProgress)
+	}
+	if got.StatusReason != "" {
+		t.Fatalf("status_reason = %q, want empty", got.StatusReason)
+	}
+	if stopped {
+		t.Fatal("stopAgent called on escalate verdict")
+	}
+}
+
+func TestApplyVerdict_StopSetsReasonAndStopsAgent(t *testing.T) {
+	tasks, tk := newTestTasks(t)
+
+	stopped := false
+	w := &Watchdog{
+		tasks:     tasks,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		stopAgent: func(string) error { stopped = true; return nil },
+	}
+
+	w.applyVerdict(&agent.Agent{ID: "a1", TaskID: tk.ID}, agent.InspectorVerdict{
+		Stuck:          true,
+		Reason:         "looping on toolchain setup",
+		Recommendation: "stop",
+	})
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusHumanRequired)
+	}
+	if got.StatusReason != "watchdog: looping on toolchain setup" {
+		t.Fatalf("status_reason = %q, want watchdog reason", got.StatusReason)
+	}
+	if !stopped {
+		t.Fatal("stopAgent not called on stop verdict")
+	}
+}
+
+func newTestTasks(t *testing.T) (*task.Manager, task.Task) {
+	t.Helper()
+
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	tasks := task.NewManager(store, nil)
+	tk, err := tasks.Create("watchdog test", "", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusInProgress)})
+	if err != nil {
+		t.Fatalf("set in-progress: %v", err)
+	}
+	return tasks, tk
+}


### PR DESCRIPTION
## Motivation

Watchdog escalate verdicts were flipping tasks to human-required while the implementation agent kept running. That left tasks in the wrong terminal state even when the agent finished successfully.

> Changelog: fix(watchdog): avoid false human-required

## Implementation information

Moved watchdog verdict handling behind a dedicated helper. Escalate is now advisory-only and no longer mutates task status. Stop still flips to human-required, but now also persists a status_reason with the watchdog diagnosis.

Added regression tests for both paths so ambiguous verdicts keep the task in progress, while stop verdicts still stop the agent and record context.

## Supporting documentation

Task 2429b764 on remote sybra reproduced the bug: watchdog escalated a running agent at 2026-05-08 10:46:56Z, but the same agent finished successfully at 2026-05-08 10:48:26Z.