### PR TITLE
fix(agent): unwrap envelope on headless log replay

### DIFF
--- a/internal/agent/logfile.go
+++ b/internal/agent/logfile.go
@@ -2,29 +2,55 @@ package agent
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 )
 
-// ParseLogFile reads an NDJSON agent log and returns up to maxEvents
-// StreamEvents (the last N if the file exceeds the cap).
-// Malformed lines are silently skipped.
-func ParseLogFile(path string, maxEvents int) ([]StreamEvent, error) {
+// ParseLogFile reads an NDJSON agent log written by the headless runner and
+// returns up to maxEvents StreamEvents (the last N if the file exceeds the
+// cap). Headless logs persist the raw provider stream-json envelope, so we
+// must run the same envelope→StreamEvent conversion the live runner uses;
+// a flat json.Unmarshal into StreamEvent silently drops the nested
+// `message.content[]` and the rendered UI shows labeled bubbles with empty
+// text (the bug fixed alongside the interactive history rewrite).
+//
+// `provider` selects the parser ("codex" → ParseCodexLine, anything else →
+// ParseClaudeLine). Pass the value from AgentRun.Provider.
+//
+// Malformed lines are skipped silently.
+func ParseLogFile(path string, maxEvents int, provider string) ([]StreamEvent, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = f.Close() }()
 
+	isCodex := provider == "codex"
 	var events []StreamEvent
 	sc := bufio.NewScanner(f)
 	sc.Buffer(make([]byte, 0, 256*1024), 1024*1024)
 	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
 		var ev StreamEvent
-		if json.Unmarshal(sc.Bytes(), &ev) != nil || ev.Type == "" {
+		if isCodex {
+			ce, parseErr := ParseCodexLine(line)
+			if parseErr != nil {
+				continue
+			}
+			ev = codexEventToStreamEvent(ce)
+		} else {
+			ce, parseErr := ParseClaudeLine(line)
+			if parseErr != nil {
+				continue
+			}
+			ev = claudeEventToStreamEvent(ce)
+		}
+		if ev.Type == "" {
 			continue
 		}
 		events = append(events, ev)

--- a/internal/agent/logfile_test.go
+++ b/internal/agent/logfile_test.go
@@ -9,33 +9,52 @@ import (
 	"testing"
 )
 
-func TestParseLogFile(t *testing.T) {
+// TestParseLogFile_UnwrapsClaudeEnvelope is the regression guard for the
+// empty-bubble bug on the Agent History panel: headless logs persist raw
+// Claude stream-json envelopes (`{"type":"assistant","message":{...}}`),
+// and a flat json.Unmarshal into StreamEvent silently dropped
+// `message.content[]` so the rendered UI showed labeled bubbles with no
+// text. ParseLogFile must run the same envelope→StreamEvent conversion
+// the live runner uses.
+func TestParseLogFile_UnwrapsClaudeEnvelope(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.ndjson")
 
-	lines := `{"type":"init","content":"session started"}
-{"type":"assistant","content":"hello world"}
-bad line
-{"type":"tool_use","content":"Read file.go"}
-{"type":"result","content":"done"}
-`
+	lines := strings.Join([]string{
+		`{"type":"system","subtype":"init","session_id":"sess-1"}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"hello world"}]}}`,
+		`bad line`,
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tu-1","name":"Read","input":{"description":"file.go"}}]}}`,
+		`{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu-1","content":"contents"}]}}`,
+		`{"type":"result","subtype":"success","result":"done","session_id":"sess-1","total_cost_usd":0.01}`,
+	}, "\n") + "\n"
 	if err := os.WriteFile(path, []byte(lines), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	events, err := ParseLogFile(path, 0)
+	events, err := ParseLogFile(path, 0, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(events) != 4 {
-		t.Fatalf("expected 4 events, got %d", len(events))
+	if len(events) != 5 {
+		t.Fatalf("expected 5 events, got %d: %+v", len(events), events)
 	}
-	if events[0].Type != "init" {
-		t.Errorf("expected init, got %s", events[0].Type)
+
+	if events[0].Type != "system" {
+		t.Errorf("events[0].Type = %s, want system", events[0].Type)
 	}
-	if events[3].Type != "result" {
-		t.Errorf("expected result, got %s", events[3].Type)
+	if events[1].Type != "assistant" || events[1].Content != "hello world" {
+		t.Errorf("assistant text dropped: type=%s content=%q", events[1].Type, events[1].Content)
+	}
+	if events[2].Type != "assistant" || !strings.Contains(events[2].Content, "[Read] file.go") {
+		t.Errorf("tool_use content dropped: type=%s content=%q", events[2].Type, events[2].Content)
+	}
+	if events[3].Type != "user" || events[3].Content != "contents" {
+		t.Errorf("tool_result content dropped: type=%s content=%q", events[3].Type, events[3].Content)
+	}
+	if events[4].Type != "result" || events[4].CostUSD != 0.01 {
+		t.Errorf("result event dropped: type=%s cost=%v", events[4].Type, events[4].CostUSD)
 	}
 }
 
@@ -44,16 +63,17 @@ func TestParseLogFile_MaxEvents(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.ndjson")
 
-	lines := `{"type":"assistant","content":"msg1"}
-{"type":"assistant","content":"msg2"}
-{"type":"assistant","content":"msg3"}
-{"type":"result","content":"done"}
-`
+	lines := strings.Join([]string{
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"msg1"}]}}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"msg2"}]}}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"msg3"}]}}`,
+		`{"type":"result","subtype":"success","result":"done"}`,
+	}, "\n") + "\n"
 	if err := os.WriteFile(path, []byte(lines), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	events, err := ParseLogFile(path, 2)
+	events, err := ParseLogFile(path, 2, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,6 +85,41 @@ func TestParseLogFile_MaxEvents(t *testing.T) {
 	}
 	if events[1].Content != "done" {
 		t.Errorf("expected done, got %s", events[1].Content)
+	}
+}
+
+// TestParseLogFile_CodexProvider confirms the codex stream-json envelope
+// (item.started / item.completed / turn.completed) round-trips through the
+// codex parser when the caller passes provider="codex".
+func TestParseLogFile_CodexProvider(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "codex.ndjson")
+
+	lines := strings.Join([]string{
+		`{"type":"thread.started","thread_id":"thr-1"}`,
+		`{"type":"item.completed","item":{"id":"it-1","type":"agent_message","text":"codex says hi"}}`,
+		`{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":5}}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(lines), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	events, err := ParseLogFile(path, 0, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("expected 3 events, got %d: %+v", len(events), events)
+	}
+	if events[0].Type != "init" || events[0].SessionID != "thr-1" {
+		t.Errorf("init event dropped: %+v", events[0])
+	}
+	if events[1].Type != "assistant" || events[1].Content != "codex says hi" {
+		t.Errorf("assistant content dropped: type=%s content=%q", events[1].Type, events[1].Content)
+	}
+	if events[2].Type != "result" || events[2].InputTokens != 10 {
+		t.Errorf("result tokens dropped: %+v", events[2])
 	}
 }
 

--- a/internal/sybra/svc_agents.go
+++ b/internal/sybra/svc_agents.go
@@ -78,15 +78,17 @@ func (s *AgentService) GetConvoOutput(agentID string) ([]agent.ConvoEvent, error
 // log format (raw Claude stream-json envelope); route those through
 // GetAgentRunConvoLog so the nested message content is preserved.
 func (s *AgentService) GetAgentRunLog(taskID, agentID string) ([]agent.StreamEvent, error) {
-	if ag, err := s.agents.GetAgent(agentID); err == nil {
-		return ag.Output(), nil
+	if s.agents != nil {
+		if ag, err := s.agents.GetAgent(agentID); err == nil {
+			return ag.Output(), nil
+		}
 	}
 
-	logFile, err := s.findAgentLogFile(taskID, agentID)
+	logFile, provider, err := s.findAgentLogFile(taskID, agentID)
 	if err != nil {
 		return nil, err
 	}
-	return agent.ParseLogFile(logFile, s.cfg.DefaultMaxLogEvents())
+	return agent.ParseLogFile(logFile, s.cfg.DefaultMaxLogEvents(), provider)
 }
 
 // GetAgentRunConvoLog returns conversation events for a past or running
@@ -104,7 +106,7 @@ func (s *AgentService) GetAgentRunConvoLog(taskID, agentID string) ([]agent.Conv
 		}
 	}
 
-	logFile, err := s.findAgentLogFile(taskID, agentID)
+	logFile, _, err := s.findAgentLogFile(taskID, agentID)
 	if err != nil {
 		s.logger.Warn("agent.convo-log.not-found",
 			"task_id", taskID, "agent_id", agentID, "err", err)
@@ -124,20 +126,32 @@ func (s *AgentService) GetAgentRunConvoLog(taskID, agentID string) ([]agent.Conv
 
 // findAgentLogFile resolves the NDJSON log path for an agent run, first
 // consulting the task's agent_runs history then falling back to filesystem
-// globbing by agent ID. Shared by GetAgentRunLog / GetAgentRunConvoLog.
-func (s *AgentService) findAgentLogFile(taskID, agentID string) (string, error) {
+// globbing by agent ID. Also returns the provider recorded on the run (or
+// "" if the run could not be located on the task) so callers can pick the
+// matching stream-json parser. Shared by GetAgentRunLog /
+// GetAgentRunConvoLog.
+func (s *AgentService) findAgentLogFile(taskID, agentID string) (logFile, provider string, err error) {
 	t, err := s.tasks.Get(taskID)
 	if err != nil {
-		return "", fmt.Errorf("task %s: %w", taskID, err)
+		return "", "", fmt.Errorf("task %s: %w", taskID, err)
 	}
 
 	for i := range t.AgentRuns {
-		if t.AgentRuns[i].AgentID == agentID && t.AgentRuns[i].LogFile != "" {
-			return t.AgentRuns[i].LogFile, nil
+		if t.AgentRuns[i].AgentID != agentID {
+			continue
 		}
+		provider = t.AgentRuns[i].Provider
+		if t.AgentRuns[i].LogFile != "" {
+			return t.AgentRuns[i].LogFile, provider, nil
+		}
+		break
 	}
 
-	return agent.FindLogFile(s.logsDir, agentID)
+	path, err := agent.FindLogFile(s.logsDir, agentID)
+	if err != nil {
+		return "", provider, err
+	}
+	return path, provider, nil
 }
 
 // RespondEscalation sends a human decision to a guardrail-paused agent.

--- a/internal/sybra/svc_agents_test.go
+++ b/internal/sybra/svc_agents_test.go
@@ -190,3 +190,86 @@ func TestGetAgentRunConvoLog_UsesTaskLogFile(t *testing.T) {
 		t.Errorf("events = %+v, want single event with custom text", events)
 	}
 }
+
+// TestGetAgentRunLog_ReplaysHeadlessFromDisk is the headless counterpart to
+// TestGetAgentRunConvoLog_ReplaysFromDisk: regression guard for the
+// Agent History panel rendering empty bubbles. Headless logs persist raw
+// Claude stream-json envelopes, and a flat StreamEvent unmarshal dropped
+// nested message.content[]. Ensures the service replays headless logs
+// through the same envelope→StreamEvent path the live runner uses.
+func TestGetAgentRunLog_ReplaysHeadlessFromDisk(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	logsDir := filepath.Join(home, "logs")
+	tasksDir := filepath.Join(home, "tasks")
+	agentsLogDir := filepath.Join(logsDir, "agents")
+	if err := os.MkdirAll(agentsLogDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	agentID := "headless-replay-1"
+	logName := agentID + "-2026-05-08T12-00-00.ndjson"
+	logPath := filepath.Join(agentsLogDir, logName)
+	ndjson := strings.Join([]string{
+		`{"type":"system","subtype":"init","session_id":"sess-h1"}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"replayed text"}]}}`,
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tu-x","name":"Bash","input":{"command":"ls"}}]}}`,
+		`{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"tu-x","content":"a\nb"}]}}`,
+		`{"type":"result","subtype":"success","result":"done","session_id":"sess-h1","total_cost_usd":0.42}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(logPath, []byte(ndjson), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskMgr := task.NewManager(store, nil)
+
+	tk, err := store.Create("headless replay", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := task.AgentRun{
+		AgentID: agentID,
+		Mode:    "headless",
+		State:   "stopped",
+		LogFile: logPath,
+	}
+	if err := store.AddRun(tk.ID, run); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := &AgentService{
+		tasks:   taskMgr,
+		logger:  quietLogger(),
+		cfg:     &config.Config{},
+		logsDir: logsDir,
+	}
+
+	events, err := svc.GetAgentRunLog(tk.ID, agentID)
+	if err != nil {
+		t.Fatalf("GetAgentRunLog: %v", err)
+	}
+
+	if len(events) != 5 {
+		t.Fatalf("want 5 events, got %d: %+v", len(events), events)
+	}
+
+	// Regression assertion: with the old flat-Unmarshal path these would all
+	// be empty strings, producing the labeled-but-blank bubbles users saw.
+	if events[1].Type != "assistant" || events[1].Content != "replayed text" {
+		t.Errorf("assistant text dropped: type=%s content=%q", events[1].Type, events[1].Content)
+	}
+	if events[2].Type != "assistant" || !strings.Contains(events[2].Content, "[Bash] ls") {
+		t.Errorf("tool_use content dropped: type=%s content=%q", events[2].Type, events[2].Content)
+	}
+	if events[3].Type != "user" || events[3].Content != "a\nb" {
+		t.Errorf("tool_result content dropped: type=%s content=%q", events[3].Type, events[3].Content)
+	}
+	if events[4].Type != "result" || events[4].CostUSD != 0.42 {
+		t.Errorf("result metadata dropped: type=%s cost=%v", events[4].Type, events[4].CostUSD)
+	}
+}


### PR DESCRIPTION
## Motivation

Agent History on stopped headless agents rendered labeled-but-blank bubbles (ASST/USER/SYSTEM with empty content) — see screenshot from home-nas instance. Live agents looked fine because `Output()` returns parsed events from the in-memory buffer; only history replay (after the agent is purged) hit the broken path.

## Implementation information

`ParseLogFile` was doing `json.Unmarshal(line, &StreamEvent{})` directly on raw Claude/Codex stream-json envelopes. Flat `StreamEvent` has no `message` field, so `message.content[]` was silently dropped — same bug bdb9035 (#527) fixed for interactive via `ParseConvoLogFile`, missed for headless.

Now mirrors the live `streamHeadlessOutput` pipeline: dispatch via `ParseClaudeLine` / `ParseCodexLine` on `AgentRun.Provider`, then `claudeEventToStreamEvent` / `codexEventToStreamEvent`. `GetAgentRunLog` plumbs the provider through `findAgentLogFile`; also gained the same `s.agents != nil` guard `GetAgentRunConvoLog` already has.

Tests:
- `TestParseLogFile_UnwrapsClaudeEnvelope` — regression on the unit boundary.
- `TestParseLogFile_CodexProvider` — codex envelope round-trip.
- `TestGetAgentRunLog_ReplaysHeadlessFromDisk` — integration regression mirroring the existing ConvoLog test.

## Supporting documentation

Sibling fix to #527 (interactive-mode bubble fix).

> Changelog: fix(agent): unwrap envelope on headless log replay