### PR TITLE
feat(workflow): bubble agent-start errors to UI

### DIFF
--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CheckCircle, XCircle, Clock, GitPullRequest, CircleDot, Copy } from '@lucide/svelte'
+  import { CheckCircle, XCircle, Clock, GitPullRequest, CircleDot, Copy, AlertTriangle } from '@lucide/svelte'
   import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { agentStore } from '../stores/agents.svelte.js'
   import { reviewStore } from '../stores/reviews.svelte.js'
@@ -114,7 +114,13 @@
   </div>
 
   {#if t.statusReason}
-    <p class="mb-1.5 line-clamp-2 text-xs text-warning-600 dark:text-warning-400">{t.statusReason}</p>
+    <p
+      class="mb-1.5 flex items-start gap-1 line-clamp-2 text-xs text-warning-700 dark:text-warning-300"
+      title={t.statusReason}
+    >
+      <AlertTriangle size={12} class="mt-0.5 shrink-0" />
+      <span class="line-clamp-2">{t.statusReason}</span>
+    </p>
   {/if}
 
   {#if t.blockedByIssue}

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ChevronLeft } from '@lucide/svelte'
+  import { ChevronLeft, AlertTriangle } from '@lucide/svelte'
   import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { taskStore } from '../stores/tasks.svelte.js'
   import TaskHeaderBar from '../components/task-detail/TaskHeaderBar.svelte'
@@ -96,6 +96,15 @@
   {#if t}
     <div class="flex flex-col gap-6">
       <TaskHeaderBar task={t} {ondelete} />
+      {#if t.statusReason}
+        <div
+          class="flex items-start gap-2 rounded-md border border-warning-300 bg-warning-50 px-3 py-2 text-sm text-warning-800 dark:border-warning-700 dark:bg-warning-900/40 dark:text-warning-200"
+          role="status"
+        >
+          <AlertTriangle size={16} class="mt-0.5 shrink-0" />
+          <span>{t.statusReason}</span>
+        </div>
+      {/if}
       <TaskMetadataRow task={t} />
       <TaskPullRequestsPanel task={t} />
       <TaskDescriptionEditor task={t} />

--- a/internal/project/store.go
+++ b/internal/project/store.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +11,13 @@ import (
 	"github.com/Automaat/sybra/internal/fsutil"
 	"gopkg.in/yaml.v3"
 )
+
+// ErrProjectNotRegistered indicates the requested project is not present in
+// the local project store. Callers can errors.Is() this to distinguish a
+// permanent misconfiguration ("user never ran Create") from transient I/O
+// failures, and surface it to the UI as human-required instead of looping
+// on retry.
+var ErrProjectNotRegistered = errors.New("project not registered locally")
 
 type Store struct {
 	dir       string
@@ -210,6 +218,9 @@ func (s *Store) filePath(id string) string {
 func (s *Store) readFile(path string) (Project, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Project{}, fmt.Errorf("read project %s: %w", path, ErrProjectNotRegistered)
+		}
 		return Project{}, fmt.Errorf("read project: %w", err)
 	}
 	var p Project

--- a/internal/project/store_test.go
+++ b/internal/project/store_test.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -91,6 +92,9 @@ func TestStoreGetNotFound(t *testing.T) {
 	_, err = store.Get("nonexistent/repo")
 	if err == nil {
 		t.Fatal("expected error for nonexistent project")
+	}
+	if !errors.Is(err, ErrProjectNotRegistered) {
+		t.Fatalf("missing project: got %v, want errors.Is(ErrProjectNotRegistered)", err)
 	}
 }
 

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -93,10 +93,14 @@ func (r *Recovery) RestartStaleInProgress() {
 		taskID := t.ID
 		runRole := t.RunRole
 		if runRole == "pr-fix" {
+			currentStatus := t.Status
 			r.WG.Go(func() {
 				err := r.Orchestrator.StartPRFixAgent(taskID)
 				metrics.OrchestratorStaleRestart(err == nil)
 				r.Throttle.Log(r.Logger, "restart.pr-fix.failed", "pr-fix:"+taskID, err, "task_id", taskID)
+				if err != nil {
+					r.surfaceStartFailure(taskID, currentStatus, err)
+				}
 			})
 			continue
 		}
@@ -106,6 +110,7 @@ func (r *Recovery) RestartStaleInProgress() {
 			prFlag = ""
 		}
 		prompt := "Continue implementing this task. When done, create a PR with `gh pr create" + prFlag + "`."
+		currentStatus := t.Status
 		r.WG.Go(func() {
 			// Restart-stale only ever reaches this branch for headless
 			// mode (interactive tasks are handled by recoverStaleInteractive
@@ -113,7 +118,31 @@ func (r *Recovery) RestartStaleInProgress() {
 			_, err := r.Orchestrator.StartAgent(taskID, mode, prompt, false)
 			metrics.OrchestratorStaleRestart(err == nil)
 			r.Throttle.Log(r.Logger, "restart-stale.failed", "stale:"+taskID, err, "task_id", taskID)
+			if err != nil {
+				r.surfaceStartFailure(taskID, currentStatus, err)
+			}
 		})
+	}
+}
+
+// surfaceStartFailure mirrors workflow.Engine.surfaceStartFailure for the
+// recovery path: write a UI-visible reason on every retry, and flip to
+// human-required when the error is permanent (e.g. project not registered)
+// so the periodic resume loop stops hammering it.
+func (r *Recovery) surfaceStartFailure(taskID string, currentStatus task.Status, err error) {
+	reason, permanent := workflow.ClassifyAgentStartError(err)
+	if reason == "" {
+		return
+	}
+	target := currentStatus
+	if permanent {
+		target = task.StatusHumanRequired
+	}
+	if _, uErr := r.Tasks.Update(taskID, task.Update{
+		Status:       task.Ptr(target),
+		StatusReason: task.Ptr(reason),
+	}); uErr != nil {
+		r.Logger.Error("restart-stale.surface", "task_id", taskID, "err", uErr)
 	}
 }
 

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -180,6 +180,13 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 		Provider: c.Provider,
 	}); err != nil {
 		e.logger.Error("workflow.agent-complete.advance", "task_id", taskID, "err", err)
+		// Same surfacing as ResumeStalled: AdvanceStep often fails because
+		// the *next* step couldn't spawn its agent (e.g. project missing).
+		// Without this, the task sits in-progress with the only signal in
+		// logs until ResumeStalled gets a chance to retry.
+		if t.Status != "" {
+			e.surfaceStartFailure(taskID, t.Status, err)
+		}
 	}
 	e.clearAgentStep(c.AgentID)
 }
@@ -310,5 +317,30 @@ func (e *Engine) ResumeStalled() {
 		delete(e.dispatching, t.ID)
 		e.mu.Unlock()
 		e.resumeError.Log(e.logger, "workflow.resume-stalled.exec", t.ID, rErr, "task_id", t.ID)
+		if rErr != nil {
+			e.surfaceStartFailure(t.ID, fresh.Status, rErr)
+		}
+	}
+}
+
+// surfaceStartFailure writes a human-readable reason to task.StatusReason
+// when ResumeStalled fails to (re-)dispatch a step's agent. Permanent errors
+// (e.g. project missing) also flip the task to human-required so the resume
+// loop stops retrying every minute and the UI surfaces the block.
+//
+// Idempotent: writing the same reason twice is a no-op for the user — the
+// task already shows it. The transient branch deliberately does not change
+// status, so retries continue.
+func (e *Engine) surfaceStartFailure(taskID, currentStatus string, err error) {
+	reason, permanent := ClassifyAgentStartError(err)
+	if reason == "" {
+		return
+	}
+	target := currentStatus
+	if permanent {
+		target = "human-required"
+	}
+	if uErr := e.tasks.UpdateTaskStatus(taskID, target, reason); uErr != nil {
+		e.logger.Error("workflow.resume-stalled.surface", "task_id", taskID, "err", uErr)
 	}
 }

--- a/internal/workflow/start_error.go
+++ b/internal/workflow/start_error.go
@@ -1,0 +1,54 @@
+package workflow
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Automaat/sybra/internal/project"
+)
+
+// startReasonMaxLen caps the human-facing reason written to task.StatusReason.
+// Longer messages clutter the UI and rarely add value beyond the lead error.
+const startReasonMaxLen = 200
+
+// ClassifyAgentStartError translates an agent-start error into a UI-safe
+// status_reason and a "permanent" flag.
+//
+// permanent=true means retrying without human action will not help — the
+// caller should flip the task to human-required and stop the resume loop
+// from hammering it once a minute.
+//
+// Reason is a single line, capped at startReasonMaxLen. Empty err yields
+// ("", false) so callers don't have to guard.
+func ClassifyAgentStartError(err error) (reason string, permanent bool) {
+	if err == nil {
+		return "", false
+	}
+	switch {
+	case errors.Is(err, project.ErrProjectNotRegistered):
+		permanent = true
+		reason = "agent start blocked: project not registered locally — create the project to resume"
+	default:
+		reason = "agent start failed: " + err.Error()
+	}
+	return truncateReason(reason), permanent
+}
+
+// truncateReason caps a status_reason to startReasonMaxLen bytes with an
+// ASCII ellipsis so the UI banner stays one line. Byte (not rune) bound so
+// the caller can compare against len(reason) without surprises from
+// multi-byte runes.
+func truncateReason(s string) string {
+	if len(s) <= startReasonMaxLen {
+		return s
+	}
+	const tail = "..."
+	return s[:startReasonMaxLen-len(tail)] + tail
+}
+
+// FormatStartFailure is a tiny helper for callers that want to log the same
+// classified text. Keeps the log line and the on-task reason consistent.
+func FormatStartFailure(taskID string, err error) string {
+	reason, _ := ClassifyAgentStartError(err)
+	return fmt.Sprintf("task %s: %s", taskID, reason)
+}

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -1,0 +1,107 @@
+package workflow
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/project"
+)
+
+func TestClassifyAgentStartError(t *testing.T) {
+	cases := []struct {
+		name          string
+		err           error
+		wantPermanent bool
+		wantContains  string
+	}{
+		{
+			name: "nil yields empty",
+			err:  nil,
+		},
+		{
+			name:          "project not registered is permanent",
+			err:           fmt.Errorf("worktree required: %w", project.ErrProjectNotRegistered),
+			wantPermanent: true,
+			wantContains:  "project not registered",
+		},
+		{
+			name:         "generic error is transient",
+			err:          errors.New("fetch origin: connection refused"),
+			wantContains: "agent start failed: fetch origin: connection refused",
+		},
+		{
+			name:         "long error gets truncated",
+			err:          errors.New(strings.Repeat("x", startReasonMaxLen*2)),
+			wantContains: "...",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reason, permanent := ClassifyAgentStartError(tc.err)
+			if tc.err == nil {
+				if reason != "" || permanent {
+					t.Fatalf("nil err: got reason=%q permanent=%v, want empty/false", reason, permanent)
+				}
+				return
+			}
+			if permanent != tc.wantPermanent {
+				t.Errorf("permanent: got %v, want %v", permanent, tc.wantPermanent)
+			}
+			if !strings.Contains(reason, tc.wantContains) {
+				t.Errorf("reason %q missing %q", reason, tc.wantContains)
+			}
+			if len(reason) > startReasonMaxLen {
+				t.Errorf("reason length %d exceeds cap %d", len(reason), startReasonMaxLen)
+			}
+		})
+	}
+}
+
+func TestSurfaceStartFailure_TransientKeepsStatus(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+
+	engine.surfaceStartFailure("t1", "in-progress", errors.New("git fetch: timeout"))
+
+	got, _ := tasks.GetTask("t1")
+	if got.Status != "in-progress" {
+		t.Errorf("transient failure flipped status: got %q, want in-progress", got.Status)
+	}
+	reason := tasks.Reason("t1")
+	if !strings.Contains(reason, "git fetch: timeout") {
+		t.Errorf("reason %q missing transient error text", reason)
+	}
+}
+
+func TestSurfaceStartFailure_PermanentFlipsToHumanRequired(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+
+	wrapped := fmt.Errorf("worktree required: %w", project.ErrProjectNotRegistered)
+	engine.surfaceStartFailure("t1", "in-progress", wrapped)
+
+	got, _ := tasks.GetTask("t1")
+	if got.Status != "human-required" {
+		t.Errorf("permanent failure should flip to human-required, got %q", got.Status)
+	}
+	reason := tasks.Reason("t1")
+	if !strings.Contains(reason, "project not registered") {
+		t.Errorf("reason %q missing permanent classification", reason)
+	}
+}
+
+func TestSurfaceStartFailure_NilErrIsNoOp(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+
+	engine.surfaceStartFailure("t1", "in-progress", nil)
+
+	if reason := tasks.Reason("t1"); reason != "" {
+		t.Errorf("nil err wrote reason %q, want empty", reason)
+	}
+}


### PR DESCRIPTION
## Motivation

Tasks whose retry loop kept failing (e.g. project YAML missing) sat
at `in-progress` indefinitely with the only signal in throttled logs.
The watchdog/restart-stale ticker hammered them once a minute, the
UI showed nothing.

Concrete trigger: task `8de4e8ab` referenced `project_id:
Automaat/zsh-clean-history` that was never registered locally.
Workflow advanced to `implement`, agent start kept erroring with
`worktree required: ... no such file or directory`, task looked
healthy in the dashboard.

> Changelog: feat(workflow): bubble agent-start errors to UI

## Implementation information

Three layers:

1. **Sentinel** — `project.ErrProjectNotRegistered` returned (wrapped)
   from `Store.readFile` when the yaml is missing. Lets callers
   `errors.Is` instead of string-matching.
2. **Classifier + writer** — new `workflow.ClassifyAgentStartError`
   returns `(reason, permanent)`. New `Engine.surfaceStartFailure`
   writes the reason to `task.status_reason` and flips the task to
   `human-required` when permanent. Called from `ResumeStalled` and
   from the `AdvanceStep`-on-agent-complete path. `recovery/stale.go`
   does the same in `RestartStaleInProgress` (default + pr-fix
   branches).
3. **UI** — `TaskCard.svelte` adds an `AlertTriangle` icon and tooltip
   to the existing `statusReason` line. `TaskDetail.svelte` renders a
   warning banner above the metadata row when set.

Permanent errors (project missing) flip status, breaking the retry
loop and surfacing the block prominently. Transient errors (network,
fetch failures) only write the reason and keep retrying — UI sees
the cause, recovery still attempts.

Reason text capped at 200 bytes for one-line UI display.

Alternatives considered:
- Counting consecutive identical failures and flipping after N retries
  (rejected: in-memory counter complicates restart, sentinel-based
  classification is sufficient for the known permanent class).
- Adding a separate `last_error` field on Task (rejected: existing
  `status_reason` already has the right semantics and a UI surface).

## Supporting documentation

None.