### PR TITLE
fix(github): trim reviewSummaryQuery complexity

### DIFF
--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -7,9 +7,18 @@ import (
 	"time"
 )
 
+// reviewSummaryQuery fans out two PR searches in one request.
+//
+// Caps were tightened after GitHub's GraphQL edge consistently 502'd this
+// query for accounts with non-trivial PR sets. The original `first:100`
+// search × deep `reviewThreads(first:100) + latestReviews(first:20) +
+// contexts(first:50) + labels(first:10)` blew through ~36K complexity
+// points before the doubling, sitting near GitHub's ~50K cutoff. The caps
+// below preserve every consumer (UnresolvedCount, ViewerHasApproved,
+// HasPendingChecks, Labels) but slash complexity ~85%.
 const reviewSummaryQuery = `query($createdQ: String!, $requestedQ: String!) {
   viewer { login }
-  created: search(query: $createdQ, type: ISSUE, first: 100) {
+  created: search(query: $createdQ, type: ISSUE, first: 50) {
     nodes {
       ... on PullRequest {
         number
@@ -23,13 +32,13 @@ const reviewSummaryQuery = `query($createdQ: String!, $requestedQ: String!) {
         reviewDecision
         author { login type: __typename }
         repository { name nameWithOwner }
-        labels(first: 10) { nodes { name } }
+        labels(first: 5) { nodes { name } }
         commits(last: 1) {
           nodes {
             commit {
               statusCheckRollup {
                 state
-                contexts(first: 50) {
+                contexts(first: 20) {
                   nodes {
                     ... on CheckRun { status }
                   }
@@ -38,16 +47,16 @@ const reviewSummaryQuery = `query($createdQ: String!, $requestedQ: String!) {
             }
           }
         }
-        reviewThreads(first: 100) {
+        reviewThreads(first: 20) {
           nodes { isResolved }
         }
-        latestReviews(first: 20) {
+        latestReviews(first: 10) {
           nodes { state author { login } }
         }
       }
     }
   }
-  requested: search(query: $requestedQ, type: ISSUE, first: 100) {
+  requested: search(query: $requestedQ, type: ISSUE, first: 50) {
     nodes {
       ... on PullRequest {
         number
@@ -61,13 +70,13 @@ const reviewSummaryQuery = `query($createdQ: String!, $requestedQ: String!) {
         reviewDecision
         author { login type: __typename }
         repository { name nameWithOwner }
-        labels(first: 10) { nodes { name } }
+        labels(first: 5) { nodes { name } }
         commits(last: 1) {
           nodes {
             commit {
               statusCheckRollup {
                 state
-                contexts(first: 50) {
+                contexts(first: 20) {
                   nodes {
                     ... on CheckRun { status }
                   }
@@ -76,10 +85,10 @@ const reviewSummaryQuery = `query($createdQ: String!, $requestedQ: String!) {
             }
           }
         }
-        reviewThreads(first: 100) {
+        reviewThreads(first: 20) {
           nodes { isResolved }
         }
-        latestReviews(first: 20) {
+        latestReviews(first: 10) {
           nodes { state author { login } }
         }
       }


### PR DESCRIPTION
## Motivation

GitHub's GraphQL edge consistently returns `HTTP 502` for `reviewSummaryQuery` on accounts with a non-trivial PR set. Reproduced from a clean shell with the exact query bytes — fails 100% of the time. Effect: `pollAndMonitorPRs` warns every 5 min, `reviews:updated` is never emitted, `reviewStore` stays empty, and the kanban PR badge (`TaskCard.svelte:185-203`) silently never renders. `ReviewService.FetchReviews` from the frontend surfaces the same failure as a `Bound method returned an error` toast.

## Implementation information

The query carried 2× `search(first:100)` × per-PR `reviewThreads(first:100) + latestReviews(first:20) + contexts(first:50) + labels(first:10)` — roughly 36K complexity points before doubling, sitting against GitHub's ~50K cutoff. Trimmed only the collection caps; struct shape, consumers, and tests are unchanged:

| Field | Before | After |
|---|---|---|
| `search(first:N)` (created/requested) | 100 | 50 |
| `reviewThreads(first:N)` | 100 | 20 |
| `latestReviews(first:N)` | 20 | 10 |
| `contexts(first:N)` | 50 | 20 |
| `labels(first:N)` | 10 | 5 |

All downstream consumers stay correct: `UnresolvedCount`, `ViewerHasApproved`, `HasPendingChecks`, `Labels` are populated as before — caps remain comfortably above realistic per-PR counts.

Validated:
- Identical-shape new query returns `HTTP/2.0 200 OK` from `gh api graphql` against the failing account.
- `go test ./internal/github/...` passes.
- `golangci-lint run ./internal/github/...` clean.

Alternatives considered and discarded:
- **Two-pass split** (thin list + lazy enrichment): bigger blast radius, breaks existing call sites.
- **Drop fields entirely**: would zero `HasPendingChecks` and risk wrong pr-fix dispatch.
- **Fallback REST search on 502**: doesn't fix the root cause; query is just too heavy.

## Supporting documentation

Diagnosed from local logs — `~/.sybra/logs/sybra.log` showed 100% `pr-monitor.fetch HTTP 502/504` since restart.

> Changelog: fix(github): trim reviewSummaryQuery complexity