### PR TITLE
feat(workflow): triage review depth by diff size

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -625,6 +625,7 @@ export enum StepType {
     StepLinkPRAndReview = "link_pr_and_review",
     StepEvaluate = "evaluate",
     StepRequireSidecar = "require_sidecar",
+    StepTriageReview = "triage_review",
 
     /**
      * StepParallel runs its `Parallel` children concurrently as run_agent

--- a/internal/workflow/builtin/pr-review.yaml
+++ b/internal/workflow/builtin/pr-review.yaml
@@ -9,8 +9,45 @@ trigger:
       operator: contains
       value: review
 steps:
-  - id: review
-    name: Review PR
+  # Mechanical heuristic: pick simple vs staff review based on PR diff size.
+  # Same step type used by simple-task; here it falls back to `gh pr diff`
+  # since this workflow has no worktree.
+  - id: triage_review
+    name: Triage Review
+    type: triage_review
+    next:
+      - goto: pick_review_method
+
+  - id: pick_review_method
+    name: Pick Review Method
+    type: condition
+    next:
+      - when:
+          field: task.tags
+          operator: contains
+          value: force-staff-review
+        goto: review_staff
+      - when:
+          field: vars.step.triage_review.output
+          operator: equals
+          value: simple
+        goto: review_simple
+      - goto: review_staff
+
+  - id: review_simple
+    name: Review PR (simple)
+    type: run_agent
+    config:
+      role: review
+      mode: headless
+      model: sonnet
+      prompt: >-
+        Run /pr-review on https://github.com/{{.Task.ProjectID}}/pull/{{.Task.PRNumber}}
+    next:
+      - goto: set_in_review
+
+  - id: review_staff
+    name: Review PR (staff)
     type: run_agent
     config:
       role: review

--- a/internal/workflow/builtin/simple-task.yaml
+++ b/internal/workflow/builtin/simple-task.yaml
@@ -412,14 +412,77 @@ steps:
           field: task.tags
           operator: not_contains
           value: noreview
-        goto: code_review
+        goto: triage_review
       - goto: create_pr
 
-  # Review runs locally on the worktree before the PR is created, so fixes
-  # are committed to the branch first. No PR URL needed — diff against
-  # origin/main captures everything the agent just implemented.
-  - id: code_review
-    name: Code Review
+  # Mechanical heuristic (no LLM): inspects diff size + file shape and emits
+  # "simple" or "staff" so pick_review_method below can pick between the
+  # lightweight /pr-review skill and the deeper /staff-code-review skill.
+  # Force-staff-review tag is checked by the picker, not here, so the
+  # decision rationale is still logged for tagged tasks.
+  - id: triage_review
+    name: Triage Review
+    type: triage_review
+    next:
+      - goto: pick_review_method
+
+  # Routes to the simple or staff review based on:
+  #   - task.tags contains force-staff-review → always staff (escape hatch)
+  #   - vars.step.triage_review.output equals simple → /pr-review
+  #   - otherwise → /staff-code-review (covers "staff", error fallbacks)
+  - id: pick_review_method
+    name: Pick Review Method
+    type: condition
+    next:
+      - when:
+          field: task.tags
+          operator: contains
+          value: force-staff-review
+        goto: code_review_staff
+      - when:
+          field: vars.step.triage_review.output
+          operator: equals
+          value: simple
+        goto: code_review_simple
+      - goto: code_review_staff
+
+  # Lightweight review for small, low-risk diffs. Writes to the same
+  # sidecar path as code_review_staff so fix_review reads either one
+  # transparently.
+  - id: code_review_simple
+    name: Code Review (simple)
+    type: run_agent
+    config:
+      role: review
+      mode: headless
+      provider: cross
+      needs_worktree: true
+      max_retries: 2
+      prompt: >-
+        Review the changes on the current branch vs origin/main.
+        The PR has not been created yet — review the local diff.
+
+        Steps:
+          1. git diff origin/main..HEAD > /tmp/sybra-diff-{{.Task.ID}}.patch
+          2. Run /pr-review against that patch and the worktree source
+          3. Save the full review to /tmp/sybra-review-{{.Task.ID}}.md
+
+        Do NOT submit anything to GitHub. Sybra will ingest
+        /tmp/sybra-review-{{.Task.ID}}.md as the code_review sidecar
+        after you exit — you do not need to call sybra-cli yourself.
+        The /tmp file also remains for the next step (fix_review) to
+        read directly.
+      import_sidecar:
+        kind: code_review
+        from: /tmp/sybra-review-{{.Task.ID}}.md
+    next:
+      - goto: require_code_review
+
+  # Deep review for non-trivial diffs. Same sidecar contract as
+  # code_review_simple. Used by default whenever triage cannot prove a
+  # diff is small + low-risk.
+  - id: code_review_staff
+    name: Code Review (staff)
     type: run_agent
     config:
       role: review

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -286,7 +286,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			return e.execParallel(taskID, step, wfExec, ctx)
 		case StepWaitHuman:
 			return e.execWaitHuman(taskID, step, wfExec)
-		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar:
+		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepTriageReview:
 			// handled below as sync steps
 		default:
 			return fmt.Errorf("unknown step type %q", step.Type)
@@ -358,6 +358,8 @@ func (e *Engine) execSyncStep(taskID string, step *Step, wfExec *Execution, ctx 
 		return e.execEvaluate(taskID, step, wfExec, t)
 	case StepRequireSidecar:
 		return e.execRequireSidecar(taskID, step, t)
+	case StepTriageReview:
+		return e.execTriageReview(taskID, step, t)
 	default:
 		return StepOutput{}, fmt.Errorf("unknown step type %q", step.Type)
 	}

--- a/internal/workflow/engine_steps.go
+++ b/internal/workflow/engine_steps.go
@@ -679,6 +679,233 @@ func (e *Engine) execVerifyCommits(taskID string, step *Step, t TaskInfo) (StepO
 	return StepOutput{StepID: step.ID, Status: "completed", Output: "commits verified"}, nil
 }
 
+// triageReviewLineLimit and triageReviewFileLimit are the hard ceilings under
+// which a diff is eligible for the lightweight `/pr-review` skill. Anything
+// larger gets the deeper `/staff-code-review`. Tuned by gut; revisit after a
+// week of real use.
+const (
+	triageReviewLineLimit = 50
+	triageReviewFileLimit = 3
+)
+
+// triageReviewRiskyPathRe matches paths whose changes warrant staff-level
+// review regardless of size: workflow/agent core, entrypoints, tests, CI,
+// container build. A 5-line tweak inside internal/workflow can break the
+// engine for every task — exactly what staff review is for.
+var triageReviewRiskyPathRe = regexp.MustCompile(
+	`(^|/)(internal/(workflow|agent|sybra)/|cmd/|main\.go$|.*_test\.go$|Dockerfile|\.github/workflows/)`,
+)
+
+// triageReviewSimpleExts lists the file extensions a "simple" review can
+// safely cover. Anything outside this set (e.g. binary, .sql, .proto) is
+// unfamiliar enough to warrant the deeper review.
+var triageReviewSimpleExts = map[string]bool{
+	".go": true, ".ts": true, ".tsx": true, ".svelte": true,
+	".md": true, ".yaml": true, ".yml": true, ".json": true,
+	".css": true, ".html": true, ".txt": true,
+}
+
+// triageReviewShortStatRe parses the trailing summary of `git diff --shortstat`,
+// e.g. ` 5 files changed, 23 insertions(+), 12 deletions(-)`.
+var triageReviewShortStatRe = regexp.MustCompile(
+	`(\d+)\s+files?\s+changed(?:,\s+(\d+)\s+insertions?\(\+\))?(?:,\s+(\d+)\s+deletions?\(-\))?`,
+)
+
+// triageVerdict applies the heuristic and returns "simple" or "staff" with a
+// short rationale. Pure function — easy to unit-test without git.
+func triageVerdict(files []string, insertions, deletions int) (verdict, reason string) {
+	total := insertions + deletions
+	if len(files) == 0 {
+		return "staff", "no files reported"
+	}
+	if total > triageReviewLineLimit {
+		return "staff", fmt.Sprintf("%d lines > %d", total, triageReviewLineLimit)
+	}
+	if len(files) > triageReviewFileLimit {
+		return "staff", fmt.Sprintf("%d files > %d", len(files), triageReviewFileLimit)
+	}
+	for _, f := range files {
+		if triageReviewRiskyPathRe.MatchString(f) {
+			return "staff", "risky path: " + f
+		}
+		ext := strings.ToLower(filepathExt(f))
+		if !triageReviewSimpleExts[ext] {
+			label := ext
+			if label == "" {
+				label = "(no extension)"
+			}
+			return "staff", "unsupported extension: " + label + " (" + f + ")"
+		}
+	}
+	return "simple", fmt.Sprintf("%d lines, %d files, low risk", total, len(files))
+}
+
+// filepathExt returns the file extension including the dot, or "" when none.
+// Inlined to avoid pulling path/filepath into this file just for one call.
+func filepathExt(name string) string {
+	for i := len(name) - 1; i >= 0 && name[i] != '/'; i-- {
+		if name[i] == '.' {
+			return name[i:]
+		}
+	}
+	return ""
+}
+
+// execTriageReview decides between the lightweight `/pr-review` skill and the
+// deeper `/staff-code-review` skill based on the diff's size and shape. Pure
+// mechanical — no LLM call. Returns Output set to "simple" or "staff" so a
+// downstream condition step can route via vars.step.<id>.output.
+//
+// Two diff sources, in order:
+//  1. Worktree (preferred): git diff <base>...HEAD against the resolved
+//     origin base. Used by simple-task after verify_commits.
+//  2. GitHub PR: gh pr diff --name-only + gh pr diff. Used by pr-review
+//     when the task is tagged `review` on an existing PR.
+//
+// Fail-safe: any unrecoverable error (no worktree, no PR, git/gh failure)
+// returns "staff" so we err toward the deeper review rather than silently
+// shipping a thin one.
+func (e *Engine) execTriageReview(taskID string, step *Step, t TaskInfo) (StepOutput, error) {
+	files, ins, del, src, err := e.collectTriageDiff(taskID, t)
+	if err != nil {
+		e.logger.Warn("workflow.triage-review.diff-error", "task_id", taskID, "src", src, "err", err)
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "staff"}, nil
+	}
+	verdict, reason := triageVerdict(files, ins, del)
+	e.logger.Info("workflow.triage-review",
+		"task_id", taskID,
+		"verdict", verdict,
+		"src", src,
+		"files", len(files),
+		"insertions", ins,
+		"deletions", del,
+		"reason", reason,
+	)
+	return StepOutput{StepID: step.ID, Status: "completed", Output: verdict}, nil
+}
+
+// collectTriageDiff gathers (files, insertions, deletions, source) for the
+// triage heuristic. Tries the worktree first, falls back to gh pr diff when
+// the task has a PR but no worktree (e.g. the standalone pr-review workflow).
+func (e *Engine) collectTriageDiff(taskID string, t TaskInfo) (files []string, insertions, deletions int, source string, err error) {
+	if e.worktrees != nil {
+		if wtPath, ok := e.worktrees.GetWorktreePath(taskID); ok {
+			files, insertions, deletions, err = e.gitTriageDiff(wtPath)
+			if err == nil {
+				return files, insertions, deletions, "worktree", nil
+			}
+			// Worktree present but git failed — surface the error. Don't fall
+			// through to gh: a broken worktree shouldn't silently flip to PR
+			// mode and mask the real problem.
+			return nil, 0, 0, "worktree", err
+		}
+	}
+	if t.PRNumber > 0 && t.ProjectID != "" {
+		files, insertions, deletions, err = e.ghTriageDiff(t.ProjectID, t.PRNumber)
+		return files, insertions, deletions, "pr", err
+	}
+	return nil, 0, 0, "none", fmt.Errorf("no worktree and no pr to inspect")
+}
+
+// gitTriageDiff runs `git diff <base>...HEAD` against the worktree to extract
+// changed files and the insertion/deletion counts.
+func (e *Engine) gitTriageDiff(wtPath string) (files []string, insertions, deletions int, err error) {
+	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
+	defer cancel()
+	base := resolveOriginBase(ctx, wtPath)
+	rangeSpec := base + "...HEAD"
+
+	nameCmd := exec.CommandContext(ctx, "git", "diff", "--name-only", rangeSpec)
+	nameCmd.Dir = wtPath
+	nameOut, err := nameCmd.Output()
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("git diff --name-only: %w", err)
+	}
+
+	statCmd := exec.CommandContext(ctx, "git", "diff", "--shortstat", rangeSpec)
+	statCmd.Dir = wtPath
+	statOut, err := statCmd.Output()
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("git diff --shortstat: %w", err)
+	}
+
+	files = splitNonEmptyLines(string(nameOut))
+	insertions, deletions = parseShortStat(string(statOut))
+	return files, insertions, deletions, nil
+}
+
+// ghTriageDiff queries GitHub for the PR diff when there's no worktree.
+// Uses `gh pr diff --name-only` for the file list and `gh pr diff --patch` to
+// count insertions/deletions from the unified diff body.
+func (e *Engine) ghTriageDiff(repo string, pr int) (files []string, insertions, deletions int, err error) {
+	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
+	defer cancel()
+
+	nameCmd := exec.CommandContext(ctx, "bash", "-c",
+		"gh pr diff \"$_PR\" --repo \"$_REPO\" --name-only")
+	nameCmd.Env = append(nameCmd.Environ(),
+		"_REPO="+repo,
+		fmt.Sprintf("_PR=%d", pr),
+	)
+	nameOut, err := nameCmd.Output()
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("gh pr diff --name-only: %w", err)
+	}
+
+	patchCmd := exec.CommandContext(ctx, "bash", "-c",
+		"gh pr diff \"$_PR\" --repo \"$_REPO\" --patch")
+	patchCmd.Env = append(patchCmd.Environ(),
+		"_REPO="+repo,
+		fmt.Sprintf("_PR=%d", pr),
+	)
+	patchOut, err := patchCmd.Output()
+	if err != nil {
+		return nil, 0, 0, fmt.Errorf("gh pr diff --patch: %w", err)
+	}
+
+	files = splitNonEmptyLines(string(nameOut))
+	insertions, deletions = countPatchLines(string(patchOut))
+	return files, insertions, deletions, nil
+}
+
+func splitNonEmptyLines(s string) []string {
+	out := make([]string, 0)
+	for line := range strings.SplitSeq(s, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+// parseShortStat extracts insertion and deletion counts from
+// `git diff --shortstat` summary lines.
+func parseShortStat(s string) (insertions, deletions int) {
+	m := triageReviewShortStatRe.FindStringSubmatch(s)
+	if m == nil {
+		return 0, 0
+	}
+	insertions, _ = strconv.Atoi(m[2])
+	deletions, _ = strconv.Atoi(m[3])
+	return insertions, deletions
+}
+
+// countPatchLines walks a unified diff body and counts insertion / deletion
+// lines, ignoring the `+++`/`---` file headers.
+func countPatchLines(patch string) (insertions, deletions int) {
+	for line := range strings.SplitSeq(patch, "\n") {
+		switch {
+		case strings.HasPrefix(line, "+++ "), strings.HasPrefix(line, "--- "):
+			continue
+		case strings.HasPrefix(line, "+"):
+			insertions++
+		case strings.HasPrefix(line, "-"):
+			deletions++
+		}
+	}
+	return insertions, deletions
+}
+
 func (e *Engine) gitLogAheadOfBase(wtPath string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
 	defer cancel()

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -85,6 +85,7 @@ const (
 	StepLinkPRAndReview     StepType = "link_pr_and_review"
 	StepEvaluate            StepType = "evaluate"
 	StepRequireSidecar      StepType = "require_sidecar"
+	StepTriageReview        StepType = "triage_review"
 	// StepParallel runs its `Parallel` children concurrently as run_agent
 	// steps. The parent step advances only after every child has terminated;
 	// parent-level Next is evaluated against the parent step record (with the

--- a/internal/workflow/triage_review_test.go
+++ b/internal/workflow/triage_review_test.go
@@ -1,0 +1,491 @@
+package workflow
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTriageVerdict(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		files      []string
+		insertions int
+		deletions  int
+		want       string
+	}{
+		{
+			name:       "tiny_doc_change_is_simple",
+			files:      []string{"README.md"},
+			insertions: 3,
+			deletions:  1,
+			want:       "simple",
+		},
+		{
+			name:       "small_frontend_tweak_is_simple",
+			files:      []string{"frontend/src/App.svelte", "frontend/src/style.css"},
+			insertions: 12,
+			deletions:  4,
+			want:       "simple",
+		},
+		{
+			name:       "single_line_workflow_change_still_staff",
+			files:      []string{"internal/workflow/engine.go"},
+			insertions: 1,
+			deletions:  0,
+			want:       "staff",
+		},
+		{
+			name:       "single_line_agent_change_still_staff",
+			files:      []string{"internal/agent/manager.go"},
+			insertions: 5,
+			deletions:  0,
+			want:       "staff",
+		},
+		{
+			name:       "test_file_always_staff",
+			files:      []string{"internal/task/parser_test.go"},
+			insertions: 8,
+			deletions:  2,
+			want:       "staff",
+		},
+		{
+			name:       "ci_workflow_always_staff",
+			files:      []string{".github/workflows/ci.yml"},
+			insertions: 4,
+			deletions:  0,
+			want:       "staff",
+		},
+		{
+			name:       "dockerfile_always_staff",
+			files:      []string{"Dockerfile"},
+			insertions: 3,
+			deletions:  1,
+			want:       "staff",
+		},
+		{
+			name:       "main_go_always_staff",
+			files:      []string{"main.go"},
+			insertions: 2,
+			deletions:  1,
+			want:       "staff",
+		},
+		{
+			name:       "many_lines_is_staff",
+			files:      []string{"frontend/src/App.svelte"},
+			insertions: 100,
+			deletions:  0,
+			want:       "staff",
+		},
+		{
+			name:       "many_files_is_staff",
+			files:      []string{"a.md", "b.md", "c.md", "d.md"},
+			insertions: 4,
+			deletions:  0,
+			want:       "staff",
+		},
+		{
+			name:       "unknown_extension_is_staff",
+			files:      []string{"schema.sql"},
+			insertions: 5,
+			deletions:  0,
+			want:       "staff",
+		},
+		{
+			name:       "binary_or_no_extension_is_staff",
+			files:      []string{"bin/runner"},
+			insertions: 1,
+			deletions:  0,
+			want:       "staff",
+		},
+		{
+			name:       "no_files_is_staff",
+			files:      nil,
+			insertions: 0,
+			deletions:  0,
+			want:       "staff",
+		},
+		{
+			name:       "right_at_line_limit_still_simple",
+			files:      []string{"docs.md"},
+			insertions: triageReviewLineLimit,
+			deletions:  0,
+			want:       "simple",
+		},
+		{
+			name:       "right_at_file_limit_still_simple",
+			files:      []string{"a.md", "b.md", "c.md"},
+			insertions: 3,
+			deletions:  0,
+			want:       "simple",
+		},
+		{
+			name:       "non_internal_go_outside_risky_paths_simple",
+			files:      []string{"pkg/util/strings.go"},
+			insertions: 10,
+			deletions:  2,
+			want:       "simple",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, reason := triageVerdict(tc.files, tc.insertions, tc.deletions)
+			if got != tc.want {
+				t.Errorf("verdict = %q, want %q (reason: %s)", got, tc.want, reason)
+			}
+		})
+	}
+}
+
+func TestParseShortStat(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in    string
+		wantI int
+		wantD int
+	}{
+		{" 5 files changed, 23 insertions(+), 12 deletions(-)\n", 23, 12},
+		{" 1 file changed, 1 insertion(+)\n", 1, 0},
+		{" 1 file changed, 4 deletions(-)\n", 0, 4},
+		{" 2 files changed, 0 insertions(+), 0 deletions(-)\n", 0, 0},
+		{"", 0, 0},
+		{"garbage", 0, 0},
+	}
+	for _, tc := range cases {
+		i, d := parseShortStat(tc.in)
+		if i != tc.wantI || d != tc.wantD {
+			t.Errorf("parseShortStat(%q) = (%d, %d), want (%d, %d)", tc.in, i, d, tc.wantI, tc.wantD)
+		}
+	}
+}
+
+func TestCountPatchLines(t *testing.T) {
+	t.Parallel()
+	patch := `diff --git a/foo b/foo
+--- a/foo
++++ b/foo
+@@ -1,2 +1,3 @@
+ unchanged
+-removed
++added
++another
+`
+	ins, del := countPatchLines(patch)
+	if ins != 2 || del != 1 {
+		t.Errorf("countPatchLines = (%d, %d), want (2, 1)", ins, del)
+	}
+}
+
+func TestSplitNonEmptyLines(t *testing.T) {
+	t.Parallel()
+	got := splitNonEmptyLines("a\n\nb\n  \nc\n")
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestFilepathExt(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"foo.go":             ".go",
+		"x/y/foo.tsx":        ".tsx",
+		"Dockerfile":         "",
+		"a.b.c":              ".c",
+		"":                   "",
+		"foo/bar":            "",
+		".github/workflows/": "",
+	}
+	for in, want := range cases {
+		if got := filepathExt(in); got != want {
+			t.Errorf("filepathExt(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func newTriageStep() *Step { return &Step{ID: "triage_review", Type: StepTriageReview} }
+
+func TestExecTriageReview_NoWorktreeNoPRReturnsStaff(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	out, err := engine.execTriageReview("t1", newTriageStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "staff" {
+		t.Errorf("Output = %q, want staff (fail-safe)", out.Output)
+	}
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed", out.Status)
+	}
+}
+
+func TestExecTriageReview_BrokenWorktreeReturnsStaff(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	// Path exists but is not a git repo.
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: t.TempDir(), ok: true})
+
+	out, err := engine.execTriageReview("t1", newTriageStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "staff" {
+		t.Errorf("Output = %q, want staff (git error fail-safe)", out.Output)
+	}
+}
+
+func TestExecTriageReview_TinyDocChangeReturnsSimple(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	wt := makeGitRepo(t, false /* extra commit added below */)
+	// Add one tiny doc change.
+	if err := os.WriteFile(filepath.Join(wt, "NOTES.md"), []byte("note\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, wt, "add", "NOTES.md")
+	gitRun(t, wt, "commit", "-m", "docs: note")
+
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wt, ok: true})
+
+	out, err := engine.execTriageReview("t1", newTriageStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "simple" {
+		t.Errorf("Output = %q, want simple", out.Output)
+	}
+}
+
+func TestExecTriageReview_RiskyPathReturnsStaff(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	wt := makeGitRepo(t, false)
+	// Touch a workflow-internal file — only one line, but risky path.
+	risky := filepath.Join(wt, "internal", "workflow")
+	if err := os.MkdirAll(risky, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(risky, "engine.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, wt, "add", "internal/workflow/engine.go")
+	gitRun(t, wt, "commit", "-m", "feat: tweak engine")
+
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wt, ok: true})
+
+	out, err := engine.execTriageReview("t1", newTriageStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "staff" {
+		t.Errorf("Output = %q, want staff (risky path)", out.Output)
+	}
+}
+
+func TestExecTriageReview_LargeChangeReturnsStaff(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	wt := makeGitRepo(t, false)
+	// Write a single non-risky file but with > line limit insertions.
+	var big strings.Builder
+	for range triageReviewLineLimit + 5 {
+		big.WriteString("line\n")
+	}
+	if err := os.WriteFile(filepath.Join(wt, "big.md"), []byte(big.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, wt, "add", "big.md")
+	gitRun(t, wt, "commit", "-m", "docs: big")
+
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wt, ok: true})
+
+	out, err := engine.execTriageReview("t1", newTriageStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "staff" {
+		t.Errorf("Output = %q, want staff (over line limit)", out.Output)
+	}
+}
+
+// gitRun is a tiny git-exec helper for tests in this file. Mirrors the
+// closure inside makeGitRepo so callers can stage post-init commits without
+// cracking that helper open.
+func gitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// --- Builtin pick_review_method routing tests ---
+
+func TestBuiltinSimpleTask_PickReviewMethod(t *testing.T) {
+	t.Parallel()
+
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var simple *Definition
+	for i := range defs {
+		if defs[i].ID == "simple-task" {
+			simple = &defs[i]
+			break
+		}
+	}
+	if simple == nil {
+		t.Fatal("simple-task builtin definition not found")
+	}
+	step := simple.StepByID("pick_review_method")
+	if step == nil {
+		t.Fatal("pick_review_method step not found in simple-task")
+	}
+
+	cases := []struct {
+		name   string
+		fields map[string]string
+		want   string
+	}{
+		{
+			name: "simple_verdict_routes_to_simple",
+			fields: map[string]string{
+				"task.tags":                      "backend",
+				"vars.step.triage_review.output": "simple",
+			},
+			want: "code_review_simple",
+		},
+		{
+			name: "staff_verdict_routes_to_staff",
+			fields: map[string]string{
+				"task.tags":                      "backend",
+				"vars.step.triage_review.output": "staff",
+			},
+			want: "code_review_staff",
+		},
+		{
+			name: "force_staff_tag_overrides_simple_verdict",
+			fields: map[string]string{
+				"task.tags":                      "backend,force-staff-review",
+				"vars.step.triage_review.output": "simple",
+			},
+			want: "code_review_staff",
+		},
+		{
+			name: "missing_verdict_falls_back_to_staff",
+			fields: map[string]string{
+				"task.tags": "backend",
+			},
+			want: "code_review_staff",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveTransition(step.Next, tc.fields)
+			if err != nil {
+				t.Fatalf("ResolveTransition: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("goto = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuiltinPRReview_PickReviewMethod(t *testing.T) {
+	t.Parallel()
+
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var pr *Definition
+	for i := range defs {
+		if defs[i].ID == "pr-review" {
+			pr = &defs[i]
+			break
+		}
+	}
+	if pr == nil {
+		t.Fatal("pr-review builtin definition not found")
+	}
+	step := pr.StepByID("pick_review_method")
+	if step == nil {
+		t.Fatal("pick_review_method step not found in pr-review")
+	}
+
+	cases := []struct {
+		name   string
+		fields map[string]string
+		want   string
+	}{
+		{
+			name: "simple_verdict_routes_to_simple",
+			fields: map[string]string{
+				"task.tags":                      "review",
+				"vars.step.triage_review.output": "simple",
+			},
+			want: "review_simple",
+		},
+		{
+			name: "staff_verdict_routes_to_staff",
+			fields: map[string]string{
+				"task.tags":                      "review",
+				"vars.step.triage_review.output": "staff",
+			},
+			want: "review_staff",
+		},
+		{
+			name: "force_staff_tag_overrides_simple_verdict",
+			fields: map[string]string{
+				"task.tags":                      "review,force-staff-review",
+				"vars.step.triage_review.output": "simple",
+			},
+			want: "review_staff",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveTransition(step.Next, tc.fields)
+			if err != nil {
+				t.Fatalf("ResolveTransition: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("goto = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Every Sybra-driven task currently runs `/staff-code-review` regardless of how trivial the diff is. A typo fix or a one-line config tweak gets the same architectural deep-dive as a 500-line refactor — wasted tokens, slower loop, noise the reviewer dismisses.

## Implementation information

New mechanical step type `triage_review` (no LLM) inspects the diff before review and routes to either `/pr-review` (light) or `/staff-code-review` (deep) via a follow-up `pick_review_method` condition step. Both review variants write to the same `code_review` sidecar, so `fix_review` consumes either output without changes.

**Heuristic** (`triageVerdict`): all must hold for `simple` — else `staff`:
- insertions + deletions ≤ 50
- files changed ≤ 3
- no risky path (`internal/{workflow,agent,sybra}/`, `cmd/`, `main.go`, `*_test.go`, `Dockerfile`, `.github/workflows/`)
- every file extension in the simple-review allowlist (`.go .ts .tsx .svelte .md .yaml .yml .json .css .html .txt`)

**Diff sources**, in order:
1. Worktree (`git diff origin/main...HEAD`) — used by simple-task post-implementation
2. GitHub PR (`gh pr diff`) — used by the standalone pr-review workflow
3. Neither → fail-safe to `staff`

**Escape hatch**: `force-staff-review` tag bypasses the triage and forces deep review.

**Wiring**:
- `simple-task.yaml`: `verify_commits → maybe_review → triage_review → pick_review_method → code_review_simple` OR `code_review_staff` → `require_code_review` (existing)
- `pr-review.yaml`: `triage_review → pick_review_method → review_simple` OR `review_staff` → `set_in_review`

**Tests**: `internal/workflow/triage_review_test.go` covers the pure heuristic (16 cases), the parsers, the end-to-end exec (worktree present / broken / missing, PR-only fallback), and the new transition routing for both builtin workflows.

## Supporting documentation

Plan: `~/.claude/plans/we-now-run-staff-review-bubbly-wigderson.md`