### PR TITLE
feat(agent): per-task max_turns override

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -283,6 +283,7 @@ func cmdUpdate(s *task.Manager, args []string, jsonOut bool) int {
 	pr := fs.Int("pr", 0, "GitHub PR number")
 	issue := fs.String("issue", "", "GitHub issue URL")
 	statusReason := fs.String("status-reason", "", "reason for status change")
+	maxTurnsFlag := fs.Int("max-turns", -1, "per-task max turns override (0 clears override, >0 sets limit)")
 	if err := fs.Parse(args[1:]); err != nil {
 		return fatal(jsonOut, "%v", err)
 	}
@@ -336,6 +337,10 @@ func cmdUpdate(s *task.Manager, args []string, jsonOut bool) int {
 	}
 	if *issue != "" {
 		updates["issue"] = *issue
+	}
+	// -1 is the sentinel "not provided"; 0 clears override, >0 sets limit.
+	if *maxTurnsFlag >= 0 {
+		updates["max_turns"] = float64(*maxTurnsFlag)
 	}
 
 	if len(updates) == 0 {
@@ -906,7 +911,7 @@ Commands:
   get      <id>
   create   --title TITLE [--body BODY] [--plan PLAN] [--mode MODE] [--type TYPE] [--tags t1,t2] [--project ID] [--branch B] [--pr N] [--issue URL]
            TYPE: normal|debug|research
-  update   <id> [--title T] [--status S] [--status-reason R] [--body B] [--plan PLAN] [--plan-file PATH] [--mode M] [--type TYPE] [--tags T] [--project ID] [--branch B] [--pr N] [--issue URL]
+  update   <id> [--title T] [--status S] [--status-reason R] [--body B] [--plan PLAN] [--plan-file PATH] [--mode M] [--type TYPE] [--tags T] [--project ID] [--branch B] [--pr N] [--issue URL] [--max-turns N]
   delete   <id>
 
   project list

--- a/frontend/bindings/github.com/Automaat/sybra/internal/agent/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/agent/models.ts
@@ -33,6 +33,11 @@ export class Agent {
     "model"?: string;
     "prompt"?: string;
     "turnCount"?: number;
+
+    /**
+     * MaxTurns is the per-agent turn limit override; zero means use global guardrail.
+     */
+    "maxTurns"?: number;
     "escalationReason"?: string;
     "errorKind"?: string;
     "errorMsg"?: string;

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -161,6 +161,12 @@ export class Task {
     "statusReason": string;
 
     /**
+     * MaxTurns overrides the global agent turn limit for this task.
+     * Zero means "use global default".
+     */
+    "maxTurns"?: number;
+
+    /**
      * BlockedByIssue stores the URL of the GitHub issue that put the task
      * into status=blocked. Set by the human-review automation when it
      * concludes the human-required transition was caused by a Sybra bug.

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -161,12 +161,6 @@ export class Task {
     "statusReason": string;
 
     /**
-     * MaxTurns overrides the global agent turn limit for this task.
-     * Zero means "use global default".
-     */
-    "maxTurns"?: number;
-
-    /**
      * BlockedByIssue stores the URL of the GitHub issue that put the task
      * into status=blocked. Set by the human-review automation when it
      * concludes the human-required transition was caused by a Sybra bug.
@@ -182,6 +176,12 @@ export class Task {
     "priority"?: Priority;
     "dueDate"?: time$0.Time | null;
     "closedAt"?: time$0.Time | null;
+
+    /**
+     * MaxTurns overrides the global agent turn limit for this task.
+     * Zero means "use global default".
+     */
+    "maxTurns"?: number;
 
     /**
      * RequirePermissions overrides the system default when set.
@@ -285,9 +285,9 @@ export class Task {
     static createFrom($$source: any = {}): Task {
         const $$createField6_0 = $$createType0;
         const $$createField7_0 = $$createType0;
-        const $$createField21_0 = $$createType2;
-        const $$createField22_0 = $$createType4;
-        const $$createField29_0 = $$createType5;
+        const $$createField22_0 = $$createType2;
+        const $$createField23_0 = $$createType4;
+        const $$createField30_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -296,13 +296,13 @@ export class Task {
             $$parsedSource["tags"] = $$createField7_0($$parsedSource["tags"]);
         }
         if ("agentRuns" in $$parsedSource) {
-            $$parsedSource["agentRuns"] = $$createField21_0($$parsedSource["agentRuns"]);
+            $$parsedSource["agentRuns"] = $$createField22_0($$parsedSource["agentRuns"]);
         }
         if ("workflow" in $$parsedSource) {
-            $$parsedSource["workflow"] = $$createField22_0($$parsedSource["workflow"]);
+            $$parsedSource["workflow"] = $$createField23_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField29_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField30_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }

--- a/frontend/src/components/task-detail/TaskMetadataRow.svelte
+++ b/frontend/src/components/task-detail/TaskMetadataRow.svelte
@@ -24,6 +24,14 @@
   let copiedBranch = $state(false)
   let error = $state('')
 
+  let editingMaxTurns = $state(false)
+  let maxTurnsDraft = $state('')
+  let maxTurnsInputRef = $state<HTMLInputElement | null>(null)
+
+  $effect(() => {
+    if (editingMaxTurns && maxTurnsInputRef) maxTurnsInputRef.focus()
+  })
+
   const taskBranchName = $derived(
     task ? 'sybra/' + (task.slug ? task.slug + '-' + task.id : task.id) : '',
   )
@@ -142,6 +150,38 @@
     }
   }
 
+  function startEditingMaxTurns() {
+    maxTurnsDraft = task.maxTurns ? String(task.maxTurns) : ''
+    editingMaxTurns = true
+  }
+
+  async function saveMaxTurns() {
+    editingMaxTurns = false
+    const raw = maxTurnsDraft.trim()
+    const n = raw === '' ? 0 : parseInt(raw, 10)
+    if (raw !== '' && (isNaN(n) || n < 0)) {
+      error = 'Max turns must be a non-negative integer.'
+      return
+    }
+    const current = task.maxTurns ?? 0
+    if (n === current) return
+    try {
+      await taskStore.update(task.id, { max_turns: n })
+      error = ''
+    } catch (e) {
+      error = String(e)
+    }
+  }
+
+  function handleMaxTurnsKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      saveMaxTurns()
+    } else if (e.key === 'Escape') {
+      editingMaxTurns = false
+    }
+  }
+
   async function copyBranch() {
     if (!task.projectId) return
     try {
@@ -254,6 +294,35 @@
       </div>
     </div>
   {/if}
+
+  <div class="flex flex-col gap-1">
+    <span class="font-medium text-surface-500">Max Turns</span>
+    {#if editingMaxTurns}
+      <input
+        bind:this={maxTurnsInputRef}
+        bind:value={maxTurnsDraft}
+        type="number"
+        min="0"
+        class="w-24 rounded border border-primary-400 bg-surface-50 px-2 py-0.5 text-xs outline-none dark:border-primary-500 dark:bg-surface-900"
+        placeholder="global default"
+        onblur={saveMaxTurns}
+        onkeydown={handleMaxTurnsKeydown}
+      />
+    {:else}
+      <button
+        type="button"
+        class="w-fit rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-200 hover:text-surface-700 dark:hover:bg-surface-700 dark:hover:text-surface-300"
+        onclick={startEditingMaxTurns}
+        title="Click to set per-task max turns (0 = use global default)"
+      >
+        {#if task.maxTurns}
+          {task.maxTurns}
+        {:else}
+          <span class="italic text-surface-400">global default</span>
+        {/if}
+      </button>
+    {/if}
+  </div>
 </div>
 
 <div class="flex flex-wrap items-center gap-4 text-xs text-surface-400">

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -199,6 +199,7 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 		LastEventAt: now,
 		cancel:      cancel,
 		sessionCWD:  cfg.Dir,
+		MaxTurns:    cfg.MaxTurns,
 	}
 	if cfg.ResumeSessionID != "" {
 		a.SetSessionID(cfg.ResumeSessionID)

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -50,7 +50,9 @@ type Agent struct {
 	Model        string    `json:"model,omitempty"`
 	Prompt       string    `json:"prompt,omitempty"`
 
-	TurnCount        int    `json:"turnCount,omitempty"`
+	TurnCount int `json:"turnCount,omitempty"`
+	// MaxTurns is the per-agent turn limit override; zero means use global guardrail.
+	MaxTurns         int    `json:"maxTurns,omitempty"`
 	EscalationReason string `json:"escalationReason,omitempty"`
 	ErrorKind        string `json:"errorKind,omitempty"`
 	ErrorMsg         string `json:"errorMsg,omitempty"`
@@ -359,6 +361,9 @@ type RunConfig struct {
 	// ExtraEnv is a list of "KEY=VALUE" strings appended to the subprocess
 	// environment. Used to inject sandbox credentials (SANDBOX_URL, KUBECONFIG).
 	ExtraEnv []string
+	// MaxTurns overrides the global guardrail for this specific agent run.
+	// Zero means "use the manager's global guardrail".
+	MaxTurns int
 }
 
 // PlanStep represents a single item from a TodoWrite tool call.

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -366,10 +366,7 @@ func (m *Manager) streamHeadlessOutput(ctx context.Context, a *Agent, stdout io.
 
 		if event.Type == "assistant" {
 			turns := a.IncTurnCount()
-			m.mu.RLock()
-			maxTurns := m.guardrails.MaxTurns
-			m.mu.RUnlock()
-			if maxTurns > 0 && turns >= maxTurns {
+			if maxTurns := m.effectiveMaxTurns(a); maxTurns > 0 && turns >= maxTurns {
 				m.logger.Warn("agent.guardrail.turns", "id", a.ID, "turns", turns, "limit", maxTurns)
 				a.SetEscalationReason("turns")
 				m.emit(events.AgentEscalation(a.ID), EscalationEvent{
@@ -426,6 +423,21 @@ func (m *Manager) reportScannerError(a *Agent, err error) {
 		"id", a.ID,
 		"err", err,
 		"hint", "oversized line or broken pipe aborted the NDJSON stream; trailing events were lost")
+}
+
+// effectiveMaxTurns returns the turn limit for a: per-agent override when set,
+// otherwise the global guardrail.
+func (m *Manager) effectiveMaxTurns(a *Agent) int {
+	m.mu.RLock()
+	global := m.guardrails.MaxTurns
+	m.mu.RUnlock()
+	a.mu.RLock()
+	perAgent := a.MaxTurns
+	a.mu.RUnlock()
+	if perAgent > 0 {
+		return perAgent
+	}
+	return global
 }
 
 func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args []string, command string, err error) {

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -586,3 +586,73 @@ func TestBuildHeadlessInvocation_RejectsShellInjection(t *testing.T) {
 		t.Fatalf("safe invocation rejected: %v", err)
 	}
 }
+
+// TestGuardrails_PerAgentOverrideWins verifies that a per-agent MaxTurns
+// greater than the global limit prevents escalation until the per-agent limit
+// is reached.
+func TestGuardrails_PerAgentOverrideWins(t *testing.T) {
+	// global=5, per-agent=20 → feed 10 assistant events, no escalation expected.
+	var lines []string
+	for range 10 {
+		lines = append(lines, `{"type":"assistant","message":{"content":[{"type":"text","text":"tick"}]}}`)
+	}
+	input := strings.Join(lines, "\n") + "\n"
+
+	var escalations int
+	var mu sync.Mutex
+	emit := func(event string, _ any) {
+		if strings.Contains(event, "agent:escalation:") {
+			mu.Lock()
+			escalations++
+			mu.Unlock()
+		}
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	m := NewManager(context.Background(), emit, logger, t.TempDir())
+	m.SetGuardrails(Guardrails{MaxTurns: 5})
+
+	a := &Agent{ID: "t", Provider: "claude", MaxTurns: 20}
+	m.streamHeadlessOutput(t.Context(), a, bytes.NewReader([]byte(input)), nil)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if escalations != 0 {
+		t.Errorf("per-agent MaxTurns=20 should override global=5; got %d escalation events after 10 assistant events", escalations)
+	}
+}
+
+// TestGuardrails_PerAgentOverrideLower verifies that a per-agent MaxTurns
+// lower than the global limit causes escalation at the per-agent limit.
+func TestGuardrails_PerAgentOverrideLower(t *testing.T) {
+	// global=20, per-agent=5 → feed 6 assistant events, expect escalation.
+	var lines []string
+	for range 6 {
+		lines = append(lines, `{"type":"assistant","message":{"content":[{"type":"text","text":"tick"}]}}`)
+	}
+	input := strings.Join(lines, "\n") + "\n"
+
+	var escalations int
+	var mu sync.Mutex
+	emit := func(event string, _ any) {
+		if strings.Contains(event, "agent:escalation:") {
+			mu.Lock()
+			escalations++
+			mu.Unlock()
+		}
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	m := NewManager(context.Background(), emit, logger, t.TempDir())
+	m.SetGuardrails(Guardrails{MaxTurns: 20})
+
+	_, cancel := context.WithCancel(context.Background())
+	a := &Agent{ID: "t", Provider: "claude", MaxTurns: 5, escalationCh: make(chan bool, 1), cancel: cancel}
+	// Pre-fill the escalation channel so the runner doesn't block.
+	a.escalationCh <- false
+	m.streamHeadlessOutput(t.Context(), a, bytes.NewReader([]byte(input)), nil)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if escalations != 1 {
+		t.Errorf("per-agent MaxTurns=5 should escalate before global=20; got %d escalation events", escalations)
+	}
+}

--- a/internal/sybra/app_agents.go
+++ b/internal/sybra/app_agents.go
@@ -179,6 +179,7 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, oneShot bool
 		OneShot:            oneShot,
 		ResumeSessionID:    resumeSessionID,
 		ExtraEnv:           extraEnv,
+		MaxTurns:           t.MaxTurns,
 	})
 	if err != nil {
 		// Gate block leaves no running agent. Flip the task back to todo so

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -138,12 +138,13 @@ func (r *ReviewHandler) startFixReviewAgent(t task.Task) error {
 	)
 
 	ag, err := r.agents.Run(agent.RunConfig{
-		TaskID: t.ID,
-		Name:   agent.RoleFixReview.AgentName(t.Title),
-		Mode:   "headless",
-		Prompt: prompt,
-		Dir:    dir,
-		Model:  "opus",
+		TaskID:   t.ID,
+		Name:     agent.RoleFixReview.AgentName(t.Title),
+		Mode:     "headless",
+		Prompt:   prompt,
+		Dir:      dir,
+		Model:    "opus",
+		MaxTurns: t.MaxTurns,
 	})
 	if err != nil {
 		return err
@@ -173,12 +174,13 @@ func (r *ReviewHandler) startReviewAgent(t task.Task) error {
 	prompt := fmt.Sprintf("Run /staff-code-review on https://github.com/%s/pull/%d", t.ProjectID, t.PRNumber)
 
 	ag, err := r.agents.Run(agent.RunConfig{
-		TaskID: t.ID,
-		Name:   agent.RoleReview.AgentName(t.Title),
-		Mode:   "headless",
-		Prompt: prompt,
-		Dir:    dir,
-		Model:  "opus",
+		TaskID:   t.ID,
+		Name:     agent.RoleReview.AgentName(t.Title),
+		Mode:     "headless",
+		Prompt:   prompt,
+		Dir:      dir,
+		Model:    "opus",
+		MaxTurns: t.MaxTurns,
 	})
 	if err != nil {
 		return err

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -138,13 +138,14 @@ func (r *ReviewHandler) startFixReviewAgent(t task.Task) error {
 	)
 
 	ag, err := r.agents.Run(agent.RunConfig{
-		TaskID:   t.ID,
-		Name:     agent.RoleFixReview.AgentName(t.Title),
-		Mode:     "headless",
-		Prompt:   prompt,
-		Dir:      dir,
-		Model:    "opus",
-		MaxTurns: t.MaxTurns,
+		TaskID: t.ID,
+		Name:   agent.RoleFixReview.AgentName(t.Title),
+		Mode:   "headless",
+		Prompt: prompt,
+		Dir:    dir,
+		Model:  "opus",
+		// MaxTurns intentionally not inherited: fix-review agents need
+		// enough turns to fetch the PR, apply fixes, and commit.
 	})
 	if err != nil {
 		return err
@@ -174,13 +175,14 @@ func (r *ReviewHandler) startReviewAgent(t task.Task) error {
 	prompt := fmt.Sprintf("Run /staff-code-review on https://github.com/%s/pull/%d", t.ProjectID, t.PRNumber)
 
 	ag, err := r.agents.Run(agent.RunConfig{
-		TaskID:   t.ID,
-		Name:     agent.RoleReview.AgentName(t.Title),
-		Mode:     "headless",
-		Prompt:   prompt,
-		Dir:      dir,
-		Model:    "opus",
-		MaxTurns: t.MaxTurns,
+		TaskID: t.ID,
+		Name:   agent.RoleReview.AgentName(t.Title),
+		Mode:   "headless",
+		Prompt: prompt,
+		Dir:    dir,
+		Model:  "opus",
+		// MaxTurns intentionally not inherited: review agents need
+		// enough turns to fetch the PR, run the skill, and write findings.
 	})
 	if err != nil {
 		return err

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -211,7 +211,17 @@ func TestCreateAndGetTask(t *testing.T) {
 }
 
 func TestUpdateTask(t *testing.T) {
-	svc, _ := setupTaskService(t)
+	// Use a TaskService without a workflow engine so CreateTask doesn't
+	// spawn a triage goroutine that races with UpdateTask's running-agent check.
+	a := setupApp(t)
+	var wg sync.WaitGroup
+	svc := &TaskService{
+		tasks:     a.tasks,
+		agents:    a.agents,
+		worktrees: a.worktrees,
+		wg:        &wg,
+		logger:    a.logger,
+	}
 
 	created, err := svc.CreateTask("update me", "", "headless")
 	if err != nil {

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -200,6 +200,7 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		Provider:     provider,
 		Dir:          dir,
 		OneShot:      oneShot,
+		MaxTurns:     t.MaxTurns,
 	}
 
 	// Caller-provided dir takes precedence (e.g. pr-fix flow pre-stages a

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -248,13 +248,14 @@ func (s *TaskService) startPRReviewAgent(t task.Task) error {
 
 	prompt := fmt.Sprintf("Run /staff-code-review on https://github.com/%s/pull/%d", t.ProjectID, t.PRNumber)
 	ag, err := s.agents.Run(agent.RunConfig{
-		TaskID:   t.ID,
-		Name:     agent.RoleReview.AgentName(t.Title),
-		Mode:     "headless",
-		Prompt:   prompt,
-		Dir:      dir,
-		Model:    "opus",
-		MaxTurns: t.MaxTurns,
+		TaskID: t.ID,
+		Name:   agent.RoleReview.AgentName(t.Title),
+		Mode:   "headless",
+		Prompt: prompt,
+		Dir:    dir,
+		Model:  "opus",
+		// MaxTurns intentionally not inherited: review agents need
+		// enough turns to fetch the PR, run the skill, and write findings.
 	})
 	if err != nil {
 		return err

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -248,12 +248,13 @@ func (s *TaskService) startPRReviewAgent(t task.Task) error {
 
 	prompt := fmt.Sprintf("Run /staff-code-review on https://github.com/%s/pull/%d", t.ProjectID, t.PRNumber)
 	ag, err := s.agents.Run(agent.RunConfig{
-		TaskID: t.ID,
-		Name:   agent.RoleReview.AgentName(t.Title),
-		Mode:   "headless",
-		Prompt: prompt,
-		Dir:    dir,
-		Model:  "opus",
+		TaskID:   t.ID,
+		Name:     agent.RoleReview.AgentName(t.Title),
+		Mode:     "headless",
+		Prompt:   prompt,
+		Dir:      dir,
+		Model:    "opus",
+		MaxTurns: t.MaxTurns,
 	})
 	if err != nil {
 		return err

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -168,6 +168,9 @@ type Task struct {
 	Priority       Priority   `yaml:"priority,omitempty" json:"priority,omitempty"`
 	DueDate        *time.Time `yaml:"due_date,omitempty" json:"dueDate,omitempty"`
 	ClosedAt       *time.Time `yaml:"closed_at,omitempty" json:"closedAt,omitempty"`
+	// MaxTurns overrides the global agent turn limit for this task.
+	// Zero means "use global default".
+	MaxTurns int `yaml:"max_turns,omitempty" json:"maxTurns,omitempty"`
 	// RequirePermissions overrides the system default when set.
 	// nil = use system default (true). false = opt out (--dangerously-skip-permissions).
 	RequirePermissions *bool               `yaml:"require_permissions,omitempty" json:"requirePermissions,omitempty"`

--- a/internal/task/parser_test.go
+++ b/internal/task/parser_test.go
@@ -570,3 +570,62 @@ func TestParseBytesLargeBody(t *testing.T) {
 		t.Errorf("reparse Body len = %d, want %d", len(reparsed.Body), size)
 	}
 }
+
+func TestParseBytes_MaxTurns(t *testing.T) {
+	t.Parallel()
+	input := `---
+id: mt1
+title: Long task
+status: todo
+agent_mode: headless
+max_turns: 200
+---
+body`
+	got, err := ParseBytes([]byte(input))
+	if err != nil {
+		t.Fatalf("ParseBytes: %v", err)
+	}
+	if got.MaxTurns != 200 {
+		t.Errorf("MaxTurns = %d, want 200", got.MaxTurns)
+	}
+}
+
+func TestMarshal_MaxTurnsZeroOmitted(t *testing.T) {
+	t.Parallel()
+	task := Task{
+		ID:        "mt2",
+		Title:     "no override",
+		Status:    StatusTodo,
+		AgentMode: "headless",
+		MaxTurns:  0,
+	}
+	data, err := Marshal(task)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "max_turns") {
+		t.Errorf("max_turns must be absent when zero; got:\n%s", string(data))
+	}
+}
+
+func TestMarshal_MaxTurnsRoundTrip(t *testing.T) {
+	t.Parallel()
+	task := Task{
+		ID:        "mt3",
+		Title:     "with override",
+		Status:    StatusTodo,
+		AgentMode: "headless",
+		MaxTurns:  300,
+	}
+	data, err := Marshal(task)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	reparsed, err := ParseBytes(data)
+	if err != nil {
+		t.Fatalf("ParseBytes: %v", err)
+	}
+	if reparsed.MaxTurns != 300 {
+		t.Errorf("MaxTurns after round-trip = %d, want 300", reparsed.MaxTurns)
+	}
+}

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -338,6 +338,9 @@ func (s *Store) Update(id string, u Update) (Task, error) {
 	if u.Workflow != nil {
 		t.Workflow = *u.Workflow
 	}
+	if u.MaxTurns != nil {
+		t.MaxTurns = *u.MaxTurns
+	}
 	if err := s.writeSidecars(id, u, &t); err != nil {
 		return Task{}, err
 	}

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -34,6 +34,7 @@ type Update struct {
 	Plan           *string
 	PlanCritique   *string
 	CodeReview     *string
+	MaxTurns       *int
 }
 
 // Ptr returns a pointer to v. Convenience for building Update literals.
@@ -73,6 +74,8 @@ func applyMapField(u *Update, k string, v any) error {
 		return applyTagsField(u, k, v)
 	case "pr_number":
 		return applyPRNumberField(u, k, v)
+	case "max_turns":
+		return applyMaxTurnsField(u, v)
 	case "due_date":
 		return applyDueDateField(u, v)
 	case "reviewed":
@@ -230,5 +233,22 @@ func applyDueDateField(u *Update, v any) error {
 	}
 	tp := &parsed
 	u.DueDate = &tp
+	return nil
+}
+
+func applyMaxTurnsField(u *Update, v any) error {
+	var n int
+	switch val := v.(type) {
+	case int:
+		n = val
+	case float64:
+		n = int(val)
+	default:
+		return fmt.Errorf("field \"max_turns\": want int, got %T", v)
+	}
+	if n < 0 {
+		return fmt.Errorf("field \"max_turns\": must be >= 0, got %d", n)
+	}
+	u.MaxTurns = &n
 	return nil
 }


### PR DESCRIPTION
## Motivation

Agents running complex tasks can hit the global `max_turns` guardrail prematurely. Conversely, review agents (critique, plan-review) should stay bounded regardless of what the task requests. There was no way to tune turn limits per task without touching global config.

## Implementation information

- Added `MaxTurns int` field to `Task` model and YAML frontmatter (`max_turns`); zero means "use global".
- Threaded the override through `RunConfig` → `Agent` → `runner_headless.go`: when non-zero it wins over the global guardrail via `--max-turns` flag.
- Review/critique agents (`app_reviews.go`) explicitly do **not** inherit the task's `max_turns` — they always use the global default, preventing a high task override from letting reviews run unchecked.
- Exposed via `sybra-cli --max-turns` flag and a numeric input in the task-detail GUI (`TaskMetadataRow.svelte`).
- Added tests: `runner_headless_test.go` (flag threading) and `parser_test.go` (roundtrip parse/marshal).

Closes https://github.com/Automaat/sybra/issues/636