### PR TITLE
fix(workflow): stall on StopAgent kill

### DIFF
--- a/cmd/fake-claude/main.go
+++ b/cmd/fake-claude/main.go
@@ -28,6 +28,8 @@
 //   - auth_error: emits auth-failure text then exits 1
 //   - malformed_pr_output: emits large malformed PR-ish text (no valid URL)
 //   - signal_kill: emits system+assistant then kills self with SIGTERM
+//   - hang: emits system+assistant then blocks indefinitely. Used to simulate
+//     an agent that Sybra's StopAgent has to kill mid-run.
 //
 // Perf scenarios (zero token cost, drive backend load):
 //   - perf_stream: emit FAKE_CLAUDE_EVENT_COUNT assistant events spaced
@@ -141,6 +143,8 @@ func runScenario(scenario, taskID string) bool {
 		emitResult("Implementation done. Created PR https://github.com/test-org/test-repo/pull/42")
 	case "signal_kill":
 		runSignalKill()
+	case "hang":
+		runHang()
 	case "auth_error":
 		emitSystem()
 		emitAssistant("Authentication failed. Please re-auth.")
@@ -166,6 +170,15 @@ func runSignalKill() {
 	emitAssistant("Starting work...")
 	_ = syscall.Kill(os.Getpid(), syscall.SIGTERM)
 	select {} // block until signal arrives
+}
+
+// runHang emits a start event then blocks until the parent kills the process.
+// Used in tests where Sybra's StopAgent (cancel ctx → SIGTERM) is the killer,
+// distinguishing it from the self-kill in runSignalKill.
+func runHang() {
+	emitSystem()
+	emitAssistant("Hanging...")
+	select {} // block until SIGTERM/SIGKILL arrives
 }
 
 // runMalformedPROutput emits a long stream of malformed PR-URL fragments

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -141,13 +141,16 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 	}
 
 	if h.workflowEngine != nil {
-		if isSignalKill(exitErr) && !ag.WasStopped() {
-			// Infrastructure-level kill (e.g. OS/container SIGTERM): leave the
-			// workflow step stalled so ResumeStalled re-dispatches the agent on
-			// the next tick. Clear the agent→step mapping so agentSteps does not
-			// leak and hasTrackedAgentForTaskStep does not suppress the retry.
+		if isSignalKill(exitErr) {
+			// Signal kill (OS/container SIGTERM, Sybra's own StopAgent, or a
+			// stale-agent cleanup from execRunAgent/execParallel): work is
+			// incomplete, so leave the step stalled for ResumeStalled to
+			// re-dispatch. Advancing on a kill credits an unfinished run as
+			// a failed step, which transitions the workflow into verify_commits
+			// (or similar) with no commits — the failure mode reported in #641.
+			// WasStopped is logged for diagnostics but does not gate the stall.
 			h.logger.Warn("agent.completion.signal-kill",
-				"task_id", ag.TaskID, "agent_id", ag.ID)
+				"task_id", ag.TaskID, "agent_id", ag.ID, "stopped", ag.WasStopped())
 			h.workflowEngine.ClearAgentStep(ag.ID)
 			return
 		}
@@ -209,8 +212,9 @@ func (h *AgentCompletionHandler) recordRunStats(ag *agent.Agent, cost, duration 
 }
 
 // isSignalKill reports whether err represents a process killed by an OS signal.
-// Signal kills (e.g. SIGTERM from container/OS shutdown) are infrastructure
-// interruptions, not logical agent failures — the workflow should not advance.
+// Signal kills cover both infrastructure interruptions (SIGTERM from container/OS
+// shutdown) and Sybra's own StopAgent (cancel ctx → process killed). Neither
+// completes the agent's work, so the workflow should not advance.
 func isSignalKill(err error) bool {
 	if err == nil {
 		return false

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -491,6 +491,73 @@ func TestE2E_HeadlessAgent_SignalKill_DoesNotAdvanceWorkflow(t *testing.T) {
 	})
 }
 
+// TestE2E_HeadlessAgent_StopAgent_DoesNotAdvanceWorkflow verifies that when
+// Sybra's own StopAgent kills a running agent (cancel ctx → SIGTERM, with
+// WasStopped=true), the workflow step does NOT advance. Regression test for
+// #641: the prior guard `isSignalKill && !WasStopped` only stalled on
+// infrastructure SIGTERM, so a Sybra-initiated stop fell through to
+// HandleAgentComplete with Success=false and advanced the step (e.g.
+// implement → verify_commits with no commits).
+func TestE2E_HeadlessAgent_StopAgent_DoesNotAdvanceWorkflow(t *testing.T) {
+	// First scenario hangs so the test can call StopAgent mid-run; second
+	// is irrelevant — included only to prove the workflow could in
+	// principle advance if the guard didn't fire.
+	env := setupE2EMulti(t, []string{"hang", "triage"})
+
+	// Wire production AgentCompletionHandler so the signal kill guard fires.
+	h := &AgentCompletionHandler{
+		DomainHandler:  DomainHandler{logger: e2eLogger()},
+		tasks:          env.tasks,
+		worktrees:      worktree.New(worktree.Config{WorktreesDir: env.worktreesDir, Tasks: env.tasks, Logger: e2eLogger(), AgentChecker: env.agents.HasRunningAgentForTask}),
+		workflowEngine: env.engine,
+	}
+	env.agents.SetOnComplete(func(ag *agent.Agent) {
+		env.pendingCompletions.Add(1)
+		defer env.pendingCompletions.Add(-1)
+		h.OnComplete(ag)
+	})
+
+	created, err := env.tasks.Create("stop agent task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := env.startWorkflow(created.ID, "test-simple"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the triage agent to be live (running) so StopAgent has a
+	// real process to kill. Without this, StopAgent could race the
+	// startup path and leave WasStopped+exitErr in an unintended state.
+	var triageAgentID string
+	waitFor(t, 10*time.Second, "triage agent running", func() bool {
+		ag := env.agents.FindRunningAgentForTask(created.ID, agent.RoleTriage)
+		if ag == nil {
+			return false
+		}
+		triageAgentID = ag.ID
+		return ag.GetState() == agent.StateRunning
+	})
+
+	if err := env.agents.StopAgent(triageAgentID); err != nil {
+		t.Fatal(err)
+	}
+
+	waitFor(t, 10*time.Second, "stopped agent completion drains", func() bool {
+		return !env.agents.HasRunningAgentForTask(created.ID) && env.pendingCompletions.Load() == 0
+	})
+
+	tk, err := env.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tk.Workflow == nil {
+		t.Fatal("no workflow on task")
+	}
+	if tk.Workflow.CurrentStep != "triage" {
+		t.Errorf("workflow advanced to %q after StopAgent (WasStopped=true); want stalled at triage", tk.Workflow.CurrentStep)
+	}
+}
+
 func TestE2E_WorkflowWithSynapseCLI(t *testing.T) {
 	forEachProvider(t, func(t *testing.T, p providerSpec) {
 		env := setupE2EProvider(t, p.provider, "triage")


### PR DESCRIPTION
## Motivation

Closes #641. Stuck task `a4654f89` parked in `human-required` after Sybra's own `StopAgent` killed the implementation agent mid-run: workflow advanced `implement → verify_commits` with zero commits ahead of `main`.

Auto-review verdict on the task pinpointed the bug: `workflow advanced from implement→verify_commits after Sybra's own StopAgent killed the implementation agent mid-run (exit 143/SIGTERM, WasStopped=true), bypassing the signal-kill guard and landing in verify_commits with no commits`.

## Implementation information

Root cause in `internal/sybra/agent_completion.go:144`:

```go
if isSignalKill(exitErr) && !ag.WasStopped() {
```

Guard only stalled on infrastructure SIGTERM. When Sybra's own `StopAgent` cancels ctx (→ SIGTERM via `configureGracefulShutdown`), `WasStopped=true` AND `isSignalKill=true` — guard skipped, `HandleAgentComplete` ran with `Success=false`, step advanced as failed. Same hole hits stale-agent cleanup in `execRunAgent`/`execParallel` (lines 78, 114, 174 of `engine_steps.go`) and the user-facing Stop button.

Fix: drop `&& !ag.WasStopped()`. Any signal kill = work incomplete = stall. `WasStopped` is logged for diagnostics. ResumeStalled is the existing recovery path and works the same for both kill sources.

Alternative considered: add a separate `WasStopped` branch that fails the workflow. Rejected — stale-agent cleanup from the engine itself sets `WasStopped=true`, and failing the workflow on engine-initiated cleanup would be a regression. Stalling is the right semantics for all three callers.

Tests:
- New `TestE2E_HeadlessAgent_StopAgent_DoesNotAdvanceWorkflow` regression test (mirrors existing `SignalKill` test, but calls `StopAgent` instead of self-kill)
- New `hang` scenario in fake-claude (blocks until parent kills it)
- Existing `TestE2E_HeadlessAgent_SignalKill_DoesNotAdvanceWorkflow` still passes

## Supporting documentation

- Issue: #641
- Stuck task source: `~/.sybra/tasks/a4654f89.md`

> Changelog: fix(workflow): stall on StopAgent kill