### PR TITLE
feat(watchdog): scale StallLimit by size tag

### DIFF
--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -14,10 +14,21 @@ import (
 
 const (
 	TickInterval   = 30 * time.Second
-	StallLimit     = 15 * time.Minute
 	Debounce       = 5 * time.Minute
 	InspectTimeout = 2 * time.Minute
 )
+
+// stallLimit returns the max event-gap before triggering inspection.
+func stallLimit(tags []string) time.Duration {
+	switch {
+	case slices.Contains(tags, "large"):
+		return 45 * time.Minute
+	case slices.Contains(tags, "small"):
+		return 10 * time.Minute
+	default: // medium or unset
+		return 15 * time.Minute
+	}
+}
 
 // sizeBudget returns the maximum total runtime for a headless agent based on
 // its task's size tag. Trigger inspection once total runtime exceeds this.
@@ -117,16 +128,18 @@ func (w *Watchdog) tick(ctx context.Context, s *state, now time.Time) {
 		total := now.Sub(ag.StartedAt)
 
 		t, err := w.tasks.Get(ag.TaskID)
-		var budget time.Duration
+		var budget, sl time.Duration
 		if err == nil {
 			budget = sizeBudget(t.Tags)
+			sl = stallLimit(t.Tags)
 		} else {
 			budget = sizeBudget(nil)
+			sl = stallLimit(nil)
 		}
 
 		trigger := ""
 		switch {
-		case stall > StallLimit:
+		case stall > sl:
 			trigger = "stall"
 		case total > budget:
 			trigger = "budget"

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -4,10 +4,32 @@ import (
 	"io"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/task"
 )
+
+func TestStallLimit(t *testing.T) {
+	tests := []struct {
+		name string
+		tags []string
+		want time.Duration
+	}{
+		{"small", []string{"small"}, 10 * time.Minute},
+		{"medium", []string{"medium"}, 15 * time.Minute},
+		{"unset", nil, 15 * time.Minute},
+		{"large", []string{"large"}, 45 * time.Minute},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stallLimit(tc.tags)
+			if got != tc.want {
+				t.Fatalf("stallLimit(%v) = %v, want %v", tc.tags, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestApplyVerdict_EscalateLeavesTaskRunning(t *testing.T) {
 	tasks, tk := newTestTasks(t)


### PR DESCRIPTION
## Motivation

The watchdog used a single fixed `StallLimit` (15 min) for all tasks regardless of their size. Large tasks legitimately go quiet for long stretches while doing heavy analysis or multi-file edits, causing false-positive stall inspections. Small tasks should be caught faster.

Closes https://github.com/Automaat/sybra/issues/637

## Implementation information

Replaced the `StallLimit` constant with a `stallLimit(tags []string) time.Duration` function that maps the task's size tag to a duration:

- `large` → 45 min
- `small` → 10 min
- `medium` / unset → 15 min (previous default, no behaviour change)

The `tick` method now calls `stallLimit(t.Tags)` alongside the existing `sizeBudget(t.Tags)` call, using the same error fallback pattern. The constant is removed to prevent accidental direct use.

> Changelog: feat(watchdog): scale StallLimit by size tag