### PR TITLE
refactor(workflow): split simple-task in 3 flows

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -134,6 +134,7 @@ export enum Status {
     StatusNew = "new",
     StatusTodo = "todo",
     StatusInProgress = "in-progress",
+    StatusReadyReview = "ready-review",
     StatusInReview = "in-review",
     StatusPlanning = "planning",
     StatusPlanReview = "plan-review",

--- a/frontend/src/lib/statuses.ts
+++ b/frontend/src/lib/statuses.ts
@@ -4,6 +4,7 @@ export type TaskStatus =
   | 'planning'
   | 'plan-review'
   | 'in-progress'
+  | 'ready-review'
   | 'in-review'
   | 'testing'
   | 'test-plan-review'
@@ -50,6 +51,12 @@ export const ALL_STATUSES: StatusMeta[] = [
     label: 'In Progress',
     badgeClasses: 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200',
     pillClasses: 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200',
+  },
+  {
+    value: 'ready-review',
+    label: 'Ready for Review',
+    badgeClasses: 'bg-warning-100 text-warning-700 dark:bg-warning-800 dark:text-warning-300',
+    pillClasses: 'bg-warning-100 text-warning-700 dark:bg-warning-800 dark:text-warning-300',
   },
   {
     value: 'in-review',
@@ -118,7 +125,7 @@ export const BOARD_COLUMNS: BoardColumn[] = [
   { status: 'todo', label: 'Todo', border: 'border-t-surface-400 dark:border-t-surface-500', includes: ['new', 'todo'] },
   { status: 'planning', label: 'Planning', border: 'border-t-tertiary-500 dark:border-t-tertiary-400', includes: ['planning', 'plan-review'] },
   { status: 'in-progress', label: 'In Progress', border: 'border-t-primary-500 dark:border-t-primary-400', includes: [] },
-  { status: 'in-review', label: 'In Review', border: 'border-t-warning-500 dark:border-t-warning-400', includes: [] },
+  { status: 'in-review', label: 'In Review', border: 'border-t-warning-500 dark:border-t-warning-400', includes: ['ready-review'] },
   { status: 'testing', label: 'Testing', border: 'border-t-secondary-500 dark:border-t-secondary-400', includes: ['testing', 'test-plan-review'] },
   { status: 'human-required', label: 'Human Required', border: 'border-t-error-500 dark:border-t-error-400', includes: ['human-required', 'blocked'] },
 ]

--- a/frontend/src/lib/statuses.ts
+++ b/frontend/src/lib/statuses.ts
@@ -125,7 +125,7 @@ export const BOARD_COLUMNS: BoardColumn[] = [
   { status: 'todo', label: 'Todo', border: 'border-t-surface-400 dark:border-t-surface-500', includes: ['new', 'todo'] },
   { status: 'planning', label: 'Planning', border: 'border-t-tertiary-500 dark:border-t-tertiary-400', includes: ['planning', 'plan-review'] },
   { status: 'in-progress', label: 'In Progress', border: 'border-t-primary-500 dark:border-t-primary-400', includes: [] },
-  { status: 'in-review', label: 'In Review', border: 'border-t-warning-500 dark:border-t-warning-400', includes: ['ready-review'] },
+  { status: 'in-review', label: 'In Review', border: 'border-t-warning-500 dark:border-t-warning-400', includes: ['in-review', 'ready-review'] },
   { status: 'testing', label: 'Testing', border: 'border-t-secondary-500 dark:border-t-secondary-400', includes: ['testing', 'test-plan-review'] },
   { status: 'human-required', label: 'Human Required', border: 'border-t-error-500 dark:border-t-error-400', includes: ['human-required', 'blocked'] },
 ]

--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -66,8 +66,8 @@ func countByStatus(tasks []task.Task) Counts {
 			c.HumanRequired++
 		case task.StatusDone:
 			c.Done++
-		case task.StatusPlanning, task.StatusTesting, task.StatusTestPlanReview,
-			task.StatusBlocked, task.StatusCancelled:
+		case task.StatusPlanning, task.StatusReadyReview, task.StatusTesting,
+			task.StatusTestPlanReview, task.StatusBlocked, task.StatusCancelled:
 			// Tracked in ByStatus only — not promoted to a top-level counter.
 		}
 	}

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -224,16 +224,56 @@ func isSignalKill(err error) bool {
 }
 
 // OnWorkflowComplete is the callback installed via
-// workflowEngine.SetOnComplete. Clears the PR-tracker cooldown for the
-// resolved (issue, kind) pair so a future failure of the same kind is
-// retried fresh.
+// workflowEngine.SetOnComplete. Two responsibilities:
+//
+//  1. Clear the PR-tracker cooldown for the resolved (issue, kind) pair so a
+//     future failure of the same kind is retried fresh.
+//  2. Bridge the workflow cascade: simple-task-plan flips status to
+//     in-progress, then ends; simple-task-implement flips status to
+//     ready-review, then ends. The status hook in initStatusHook fires
+//     DispatchEvent while *this* workflow is still active and gets rejected
+//     with ErrWorkflowAlreadyActive. By re-dispatching here — *after* the
+//     workflow has reached ExecCompleted — we let the next workflow in the
+//     chain pick up where this one left off. Idempotent: terminal statuses
+//     (done/cancelled/in-review/human-required/blocked) match no triggers,
+//     so DispatchEvent returns "" without starting anything.
 func (h *AgentCompletionHandler) OnWorkflowComplete(info workflow.CompletionInfo) {
-	kind := github.PRIssueKind(info.Variables["pr_issue_kind"])
-	if kind == "" {
+	if kind := github.PRIssueKind(info.Variables["pr_issue_kind"]); kind != "" {
+		h.prTracker.ClearCooldown(info.TaskID, kind)
+		h.logger.Info("pr-tracker.cooldown-cleared",
+			"task_id", info.TaskID, "kind", string(kind),
+			"retries", h.prTracker.Retries(info.TaskID, kind))
+	}
+
+	if h.workflowEngine == nil {
 		return
 	}
-	h.prTracker.ClearCooldown(info.TaskID, kind)
-	h.logger.Info("pr-tracker.cooldown-cleared",
-		"task_id", info.TaskID, "kind", string(kind),
-		"retries", h.prTracker.Retries(info.TaskID, kind))
+	t, err := h.tasks.Get(info.TaskID)
+	if err != nil {
+		return
+	}
+	if task.IsTerminalStatus(t.Status) {
+		return
+	}
+	dispatched, err := h.workflowEngine.DispatchEvent(
+		info.TaskID,
+		"task.status_changed",
+		map[string]string{"task.status": string(t.Status)},
+		nil,
+	)
+	if err != nil {
+		// ErrWorkflowAlreadyActive is benign here: a parallel start (e.g. the
+		// status hook race) has already won, so the cascade is in good hands.
+		if !errors.Is(err, workflow.ErrWorkflowAlreadyActive) {
+			h.logger.Error("workflow.cascade.dispatch",
+				"task_id", info.TaskID, "from_workflow", info.WorkflowID,
+				"status", string(t.Status), "err", err)
+		}
+		return
+	}
+	if dispatched != "" {
+		h.logger.Info("workflow.cascade.dispatched",
+			"task_id", info.TaskID, "from_workflow", info.WorkflowID,
+			"status", string(t.Status), "to_workflow", dispatched)
+	}
 }

--- a/internal/sybra/app_watcher_status_test.go
+++ b/internal/sybra/app_watcher_status_test.go
@@ -62,14 +62,14 @@ func TestApp_WatcherStatusHook_AdvancesWorkflow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Park the workflow at the simple-task `address_critique` step — the
-	// only run_agent step in simple-task that still uses
+	// Park the workflow at the simple-task-plan `address_critique` step —
+	// the only run_agent step in simple-task-plan that still uses
 	// wait_for_status: plan-review (the plan step is now a parallel block
 	// of headless one-shots that exit on their own).
 	if _, err := app.tasks.UpdateMap(created.ID, map[string]any{
 		"status": "planning",
 		"workflow": &workflow.Execution{
-			WorkflowID:  "simple-task",
+			WorkflowID:  "simple-task-plan",
 			CurrentStep: "address_critique",
 			State:       workflow.ExecWaiting,
 			Variables:   map[string]string{},

--- a/internal/sybra/e2e_crossprovider_test.go
+++ b/internal/sybra/e2e_crossprovider_test.go
@@ -365,13 +365,13 @@ func TestE2E_CrossProvider_DualPlan(t *testing.T) {
 			"write_sidecar_success", // plan_codex → plan-draft sidecar
 		},
 	)
-	loadBuiltinWorkflow(t, env, "simple-task")
+	loadBuiltinWorkflow(t, env, "simple-task-plan")
 
 	created, err := env.tasks.Create("dual-plan e2e", "", "headless")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := env.startWorkflow(created.ID, "simple-task"); err != nil {
+	if err := env.startWorkflow(created.ID, "simple-task-plan"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -464,13 +464,13 @@ func TestE2E_DualPlan_ChildRetryThenSucceed(t *testing.T) {
 			"write_sidecar_success", // plan_codex retry — writes the draft
 		},
 	)
-	loadBuiltinWorkflow(t, env, "simple-task")
+	loadBuiltinWorkflow(t, env, "simple-task-plan")
 
 	created, err := env.tasks.Create("dual-plan retry e2e", "", "headless")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := env.startWorkflow(created.ID, "simple-task"); err != nil {
+	if err := env.startWorkflow(created.ID, "simple-task-plan"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -541,13 +541,13 @@ func TestE2E_DualPlan_ChildExhaustedFailsParent(t *testing.T) {
 			"fail_exit", // plan_codex retry — also fails, exhausted
 		},
 	)
-	loadBuiltinWorkflow(t, env, "simple-task")
+	loadBuiltinWorkflow(t, env, "simple-task-plan")
 
 	created, err := env.tasks.Create("dual-plan exhausted e2e", "", "headless")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := env.startWorkflow(created.ID, "simple-task"); err != nil {
+	if err := env.startWorkflow(created.ID, "simple-task-plan"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -266,6 +266,24 @@ func setupE2EProvider(t *testing.T, provider, scenario string) *e2eEnv {
 		})
 	})
 
+	// Mirror production cascade wiring (sybra/services.go: SetOnComplete →
+	// AgentCompletionHandler.OnWorkflowComplete) so tests that span multiple
+	// chained workflows (simple-task-plan → simple-task-implement →
+	// simple-task-review) advance through the cascade exactly like the
+	// desktop app does.
+	engine.SetOnComplete(func(info workflow.CompletionInfo) {
+		t, gErr := taskMgr.Get(info.TaskID)
+		if gErr != nil || task.IsTerminalStatus(t.Status) {
+			return
+		}
+		_, _ = engine.DispatchEvent(
+			info.TaskID,
+			"task.status_changed",
+			map[string]string{"task.status": string(t.Status)},
+			map[string]string{workflow.WorkflowVarDir: env.agentDir},
+		)
+	})
+
 	return env
 }
 
@@ -2283,14 +2301,14 @@ func TestE2E_BuiltinSimpleTask_PlanCriticRunsBeforeReview(t *testing.T) {
 		"plan_critic_success",   // critique_plan — saves critique via sybra-cli
 		"success",               // address_critique
 	})
-	loadBuiltinWorkflow(t, env, "simple-task")
+	loadBuiltinWorkflow(t, env, "simple-task-plan")
 
 	created, err := env.tasks.Create("plan critic e2e", "", "headless")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := env.startWorkflow(created.ID, "simple-task"); err != nil {
+	if err := env.startWorkflow(created.ID, "simple-task-plan"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2357,14 +2375,14 @@ func TestE2E_BuiltinSimpleTask_MissingCritiqueFlipsHumanRequired(t *testing.T) {
 		"write_sidecar_success", // converge_plans
 		"plan_critic_no_save",   // critic exits without writing sidecar
 	})
-	loadBuiltinWorkflow(t, env, "simple-task")
+	loadBuiltinWorkflow(t, env, "simple-task-plan")
 
 	created, err := env.tasks.Create("missing critique e2e", "", "headless")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := env.startWorkflow(created.ID, "simple-task"); err != nil {
+	if err := env.startWorkflow(created.ID, "simple-task-plan"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2416,14 +2434,14 @@ func TestE2E_BuiltinSimpleTask_NocriticTagSkipsCritique(t *testing.T) {
 		"write_sidecar_success",       // plan child #2 writes its plan-draft
 		"write_sidecar_success",       // converge_plans writes the synthesized plan
 	})
-	loadBuiltinWorkflow(t, env, "simple-task")
+	loadBuiltinWorkflow(t, env, "simple-task-plan")
 
 	created, err := env.tasks.Create("nocritic e2e", "", "headless")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := env.startWorkflow(created.ID, "simple-task"); err != nil {
+	if err := env.startWorkflow(created.ID, "simple-task-plan"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2474,13 +2492,13 @@ func TestE2E_BuiltinSimpleTask_TriageTerminalShortCircuits(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			forEachProvider(t, func(t *testing.T, p providerSpec) {
 				env := setupE2EMultiProvider(t, p.provider, []string{tc.scenario})
-				loadBuiltinWorkflow(t, env, "simple-task")
+				loadBuiltinWorkflow(t, env, "simple-task-plan")
 
 				created, err := env.tasks.Create("terminal triage "+tc.name, "", "headless")
 				if err != nil {
 					t.Fatal(err)
 				}
-				if err := env.startWorkflow(created.ID, "simple-task"); err != nil {
+				if err := env.startWorkflow(created.ID, "simple-task-plan"); err != nil {
 					t.Fatal(err)
 				}
 
@@ -3200,7 +3218,10 @@ func TestE2E_ProviderCrossUnavailable_FallsBackToDefault(t *testing.T) {
 
 func TestE2E_VerifyCommits_NoAheadFlipsHumanRequired(t *testing.T) {
 	env := setupE2EMultiProvider(t, "claude", []string{"triage", "success"})
-	loadBuiltinWorkflow(t, env, "simple-task")
+	// verify_commits lives in simple-task-implement; the cascade in
+	// setupE2EMultiProvider hands off plan → implement on status=in-progress.
+	loadBuiltinWorkflow(t, env, "simple-task-plan")
+	loadBuiltinWorkflow(t, env, "simple-task-implement")
 
 	created, err := env.tasks.Create("verify commits no ahead", "", "headless")
 	if err != nil {
@@ -3217,13 +3238,15 @@ func TestE2E_VerifyCommits_NoAheadFlipsHumanRequired(t *testing.T) {
 	initRepoWithOriginMain(t, worktreePath)
 	runCmd(t, worktreePath, "git", "log", "origin/main..HEAD", "--oneline")
 
-	if err := env.startWorkflow(created.ID, "simple-task"); err != nil {
+	if err := env.startWorkflow(created.ID, "simple-task-plan"); err != nil {
 		t.Fatal(err)
 	}
 
-	waitFor(t, 30*time.Second, "workflow completes after verify_commits", func() bool {
+	waitFor(t, 30*time.Second, "implement workflow completes after verify_commits", func() bool {
 		tk, gErr := env.tasks.Get(created.ID)
-		return gErr == nil && tk.Workflow != nil && tk.Workflow.State == workflow.ExecCompleted
+		return gErr == nil && tk.Workflow != nil &&
+			tk.Workflow.WorkflowID == "simple-task-implement" &&
+			tk.Workflow.State == workflow.ExecCompleted
 	})
 
 	tk, _ := env.tasks.Get(created.ID)

--- a/internal/sybra/orchestrator_resume_test.go
+++ b/internal/sybra/orchestrator_resume_test.go
@@ -147,7 +147,7 @@ updated_at: 2025-01-01T00:00:00Z
 	workflowStart := time.Now()
 	if _, err := taskMgr.UpdateMap(created.ID, map[string]any{
 		"workflow": &workflow.Execution{
-			WorkflowID:  "simple-task",
+			WorkflowID:  "simple-task-implement",
 			CurrentStep: "implement",
 			State:       workflow.ExecRunning,
 			StartedAt:   workflowStart,

--- a/internal/sybra/svc_planning.go
+++ b/internal/sybra/svc_planning.go
@@ -21,7 +21,7 @@ type PlanningService struct {
 // returns nil if a workflow is already running or being started concurrently
 // (CreateTask spawns the same workflow in a goroutine).
 func (s *PlanningService) TriageTask(id string) error {
-	if err := s.engine.StartWorkflow(id, "simple-task"); err != nil {
+	if err := s.engine.StartWorkflow(id, "simple-task-plan"); err != nil {
 		if errors.Is(err, workflow.ErrWorkflowAlreadyActive) {
 			return nil
 		}
@@ -42,7 +42,7 @@ func (s *PlanningService) PlanTask(id string) error {
 	if t.Workflow != nil && t.Workflow.State != "" {
 		return nil
 	}
-	if err := s.engine.StartWorkflow(id, "simple-task"); err != nil {
+	if err := s.engine.StartWorkflow(id, "simple-task-plan"); err != nil {
 		// Concurrent auto-start (from CreateTask) holds the per-task start
 		// lock — that's also a no-op outcome from the user's perspective.
 		if errors.Is(err, workflow.ErrWorkflowAlreadyActive) {

--- a/internal/sybra/svc_planning_test.go
+++ b/internal/sybra/svc_planning_test.go
@@ -61,7 +61,7 @@ func TestPlanningService_PlanTask_NoopWithActiveWorkflow(t *testing.T) {
 	// Set up a workflow manually.
 	if _, err := taskSvc.tasks.UpdateMap(created.ID, map[string]any{
 		"workflow": &workflow.Execution{
-			WorkflowID: "simple-task",
+			WorkflowID: "simple-task-plan",
 			State:      workflow.ExecRunning,
 		},
 	}); err != nil {
@@ -296,13 +296,13 @@ type planCommentSpec struct {
 // stageWaitingPlanReview manually drops the task's workflow into an
 // ExecWaiting state at a human-action step so HandleHumanAction accepts
 // the action without going through the full agent pipeline. Uses the
-// builtin simple-task workflow because setupPlanningService syncs the
-// built-in definitions into the store.
+// builtin simple-task-plan workflow because setupPlanningService syncs
+// the built-in definitions into the store.
 func stageWaitingPlanReview(t *testing.T, taskSvc *TaskService, taskID string) {
 	t.Helper()
 	if _, err := taskSvc.tasks.UpdateMap(taskID, map[string]any{
 		"workflow": &workflow.Execution{
-			WorkflowID:  "simple-task",
+			WorkflowID:  "simple-task-plan",
 			CurrentStep: "review_plan",
 			State:       workflow.ExecWaiting,
 			// Seed _dir so the plan step the engine resumes after reject has a
@@ -438,12 +438,12 @@ func TestApp_StatusHook_AdvancesWorkflow(t *testing.T) {
 	}
 
 	// Park the workflow in address_critique — the only run_agent step in
-	// simple-task that still uses wait_for_status: plan-review (the plan
-	// step is now a parallel block of headless one-shots).
+	// simple-task-plan that still uses wait_for_status: plan-review (the
+	// plan step is now a parallel block of headless one-shots).
 	if _, err := app.tasks.UpdateMap(created.ID, map[string]any{
 		"status": "planning",
 		"workflow": &workflow.Execution{
-			WorkflowID:  "simple-task",
+			WorkflowID:  "simple-task-plan",
 			CurrentStep: "address_critique",
 			State:       workflow.ExecWaiting,
 			Variables:   map[string]string{},

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -13,6 +13,7 @@ const (
 	StatusNew            Status = "new"
 	StatusTodo           Status = "todo"
 	StatusInProgress     Status = "in-progress"
+	StatusReadyReview    Status = "ready-review"
 	StatusInReview       Status = "in-review"
 	StatusPlanning       Status = "planning"
 	StatusPlanReview     Status = "plan-review"
@@ -26,7 +27,8 @@ const (
 
 var validStatuses = map[Status]bool{
 	StatusNew: true, StatusTodo: true, StatusInProgress: true,
-	StatusInReview: true, StatusPlanning: true, StatusPlanReview: true,
+	StatusReadyReview: true, StatusInReview: true,
+	StatusPlanning: true, StatusPlanReview: true,
 	StatusTesting: true, StatusTestPlanReview: true,
 	StatusHumanRequired: true, StatusBlocked: true,
 	StatusDone: true, StatusCancelled: true,
@@ -36,7 +38,7 @@ var validStatuses = map[Status]bool{
 func AllStatuses() []Status {
 	return []Status{
 		StatusNew, StatusTodo, StatusPlanning, StatusPlanReview,
-		StatusInProgress, StatusInReview,
+		StatusInProgress, StatusReadyReview, StatusInReview,
 		StatusTesting, StatusTestPlanReview,
 		StatusHumanRequired, StatusBlocked, StatusDone, StatusCancelled,
 	}

--- a/internal/task/model_test.go
+++ b/internal/task/model_test.go
@@ -28,8 +28,8 @@ func TestValidateStatus_Invalid(t *testing.T) {
 func TestAllStatuses(t *testing.T) {
 	t.Parallel()
 	statuses := AllStatuses()
-	if len(statuses) != 12 {
-		t.Errorf("got %d statuses, want 12", len(statuses))
+	if len(statuses) != 13 {
+		t.Errorf("got %d statuses, want 13", len(statuses))
 	}
 	seen := make(map[Status]bool)
 	for _, s := range statuses {

--- a/internal/workflow/builtin/simple-task-implement.yaml
+++ b/internal/workflow/builtin/simple-task-implement.yaml
@@ -1,0 +1,68 @@
+id: simple-task-implement
+name: Simple Task — Implement
+description: Run the implementation agent and verify commits. Triggered by the cascade after simple-task-plan flips status to in-progress; hands off to simple-task-review via task.status=ready-review on completion.
+builtin: true
+trigger:
+  on: task.status_changed
+  conditions:
+    - field: task.status
+      operator: equals
+      value: in-progress
+    - field: task.tags
+      operator: not_contains
+      value: review
+steps:
+  - id: implement
+    name: Implement
+    type: run_agent
+    config:
+      role: implementation
+      mode: "{{.Task.AgentMode}}"
+      model: sonnet
+      prompt: >-
+        Implement this task. When done, commit your work and push the branch to
+        origin. Do NOT create a PR yet — the PR will be created after local code
+        review so that review fixes land in the same branch before it is opened.
+        {{- if .Task.Plan}}
+
+        ## Plan
+
+        {{.Task.Plan}}
+        {{- end}}
+    next:
+      # Watchdog stop (or any other pre-completion escalation) sets
+      # human-required before the agent exits; stop the workflow here
+      # instead of advancing into verify_commits on partial work.
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
+      - goto: verify_commits
+
+  # Mechanical check (no LLM): verifies the task's branch has at least one
+  # commit ahead of origin/main before handing off to review. Flips to
+  # human-required with reason "no commits pushed to branch" when the branch
+  # is empty. Skips gracefully when no worktree exists (e.g. task has no
+  # project).
+  - id: verify_commits
+    name: Verify Commits
+    type: verify_commits
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
+      - goto: set_ready_review
+
+  # Terminal hand-off to simple-task-review: flip status to ready-review
+  # and complete this workflow. The cascade in OnWorkflowComplete picks up
+  # the status_changed event and dispatches simple-task-review.
+  - id: set_ready_review
+    name: Hand Off to Review
+    type: set_status
+    config:
+      status: ready-review
+    next:
+      - goto: ""

--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -1,6 +1,6 @@
-id: simple-task
-name: Simple Task
-description: Triage, plan or implement, evaluate, review
+id: simple-task-plan
+name: Simple Task — Plan
+description: Triage a new task and (when planning is required) drive the plan / critique / human-review loop. Hands off to simple-task-implement via task.status=in-progress on completion.
 builtin: true
 trigger:
   on: task.created
@@ -30,8 +30,8 @@ steps:
     next:
       # Short-circuit when triage determined the task is already past
       # implementation (e.g. PR already open, escalated, or done). Without
-      # these guards the workflow would clobber the status in set_in_progress
-      # and dispatch a duplicate implement step.
+      # these guards the workflow would clobber the status in
+      # set_in_progress_and_end and dispatch a duplicate implement step.
       - when:
           field: task.status
           operator: equals
@@ -52,7 +52,18 @@ steps:
           operator: equals
           value: planning
         goto: plan
-      - goto: set_in_progress
+      - goto: set_in_progress_and_end
+
+  # Terminal hand-off to simple-task-implement: flip status to in-progress
+  # and complete this workflow. The cascade in OnWorkflowComplete picks up
+  # the status_changed event and dispatches simple-task-implement.
+  - id: set_in_progress_and_end
+    name: Hand Off to Implement
+    type: set_status
+    config:
+      status: in-progress
+    next:
+      - goto: ""
 
   # Dual-provider planning: Claude and Codex generate plans in parallel,
   # each as a headless one-shot writing its raw output to a per-child
@@ -322,7 +333,7 @@ steps:
           field: vars.human_action
           operator: equals
           value: approve
-        goto: set_in_progress
+        goto: set_in_progress_and_end
       - when:
           field: vars.human_action
           operator: equals
@@ -340,284 +351,3 @@ steps:
       status: planning
     next:
       - goto: plan
-
-  - id: set_in_progress
-    name: Start Implementation
-    type: set_status
-    config:
-      status: in-progress
-    next:
-      - goto: implement
-
-  - id: implement
-    name: Implement
-    type: run_agent
-    config:
-      role: implementation
-      mode: "{{.Task.AgentMode}}"
-      model: sonnet
-      prompt: >-
-        Implement this task. When done, commit your work and push the branch to
-        origin. Do NOT create a PR yet — the PR will be created after local code
-        review so that review fixes land in the same branch before it is opened.
-        {{- if .Task.Plan}}
-
-        ## Plan
-
-        {{.Task.Plan}}
-        {{- end}}
-    next:
-      # Watchdog stop (or any other pre-completion escalation) sets
-      # human-required before the agent exits; stop the workflow here
-      # instead of advancing into verify_commits on partial work.
-      - when:
-          field: task.status
-          operator: equals
-          value: human-required
-        goto: ""
-      - goto: verify_commits
-
-  # Mechanical check (no LLM): verifies the task's branch has at least one
-  # commit ahead of origin/main before running eval. Flips to human-required
-  # with reason "no commits pushed to branch" when the branch is empty.
-  # Skips gracefully when no worktree exists (e.g. task has no project).
-  - id: verify_commits
-    name: Verify Commits
-    type: verify_commits
-    next:
-      - when:
-          field: task.status
-          operator: equals
-          value: human-required
-        goto: ""
-      - goto: maybe_review
-
-  # Skip review when tagged noreview or already reviewed in a prior run.
-  # On skip, jump straight to create_pr so the PR is still opened.
-  - id: maybe_review
-    name: Review Decision
-    type: condition
-    config:
-      check:
-        field: task.tags
-        operator: not_contains
-        value: noreview
-    next:
-      - when:
-          field: task.reviewed
-          operator: equals
-          value: "true"
-        goto: create_pr
-      - when:
-          field: task.tags
-          operator: not_contains
-          value: noreview
-        goto: triage_review
-      - goto: create_pr
-
-  # Mechanical heuristic (no LLM): inspects diff size + file shape and emits
-  # "simple" or "staff" so pick_review_method below can pick between the
-  # lightweight /pr-review skill and the deeper /staff-code-review skill.
-  # Force-staff-review tag is checked by the picker, not here, so the
-  # decision rationale is still logged for tagged tasks.
-  - id: triage_review
-    name: Triage Review
-    type: triage_review
-    next:
-      - goto: pick_review_method
-
-  # Routes to the simple or staff review based on:
-  #   - task.tags contains force-staff-review → always staff (escape hatch)
-  #   - vars.step.triage_review.output equals simple → /pr-review
-  #   - otherwise → /staff-code-review (covers "staff", error fallbacks)
-  - id: pick_review_method
-    name: Pick Review Method
-    type: condition
-    next:
-      - when:
-          field: task.tags
-          operator: contains
-          value: force-staff-review
-        goto: code_review_staff
-      - when:
-          field: vars.step.triage_review.output
-          operator: equals
-          value: simple
-        goto: code_review_simple
-      - goto: code_review_staff
-
-  # Lightweight review for small, low-risk diffs. Writes to the same
-  # sidecar path as code_review_staff so fix_review reads either one
-  # transparently.
-  - id: code_review_simple
-    name: Code Review (simple)
-    type: run_agent
-    config:
-      role: review
-      mode: headless
-      provider: cross
-      needs_worktree: true
-      max_retries: 2
-      prompt: >-
-        Review the changes on the current branch vs origin/main.
-        The PR has not been created yet — review the local diff.
-
-        Steps:
-          1. git diff origin/main..HEAD > /tmp/sybra-diff-{{.Task.ID}}.patch
-          2. Run /pr-review against that patch and the worktree source
-          3. Save the full review to /tmp/sybra-review-{{.Task.ID}}.md
-
-        Do NOT submit anything to GitHub. Sybra will ingest
-        /tmp/sybra-review-{{.Task.ID}}.md as the code_review sidecar
-        after you exit — you do not need to call sybra-cli yourself.
-        The /tmp file also remains for the next step (fix_review) to
-        read directly.
-      import_sidecar:
-        kind: code_review
-        from: /tmp/sybra-review-{{.Task.ID}}.md
-    next:
-      - goto: require_code_review
-
-  # Deep review for non-trivial diffs. Same sidecar contract as
-  # code_review_simple. Used by default whenever triage cannot prove a
-  # diff is small + low-risk.
-  - id: code_review_staff
-    name: Code Review (staff)
-    type: run_agent
-    config:
-      role: review
-      mode: headless
-      provider: cross
-      needs_worktree: true
-      max_retries: 2
-      prompt: >-
-        Review the changes on the current branch vs origin/main.
-        The PR has not been created yet — review the local diff.
-
-        Steps:
-          1. git diff origin/main..HEAD > /tmp/sybra-diff-{{.Task.ID}}.patch
-          2. Run /staff-code-review against that patch and the worktree source
-          3. Save the full review to /tmp/sybra-review-{{.Task.ID}}.md
-
-        Do NOT submit anything to GitHub. Sybra will ingest
-        /tmp/sybra-review-{{.Task.ID}}.md as the code_review sidecar
-        after you exit — you do not need to call sybra-cli yourself.
-        The /tmp file also remains for the next step (fix_review) to
-        read directly.
-      import_sidecar:
-        kind: code_review
-        from: /tmp/sybra-review-{{.Task.ID}}.md
-    next:
-      - goto: require_code_review
-
-  # Guard: mirrors require_plan_critique above. Flips task to
-  # human-required when the review sidecar is empty (e.g. agent never
-  # wrote /tmp/sybra-review-…md, or its sandbox blocked the path).
-  # Without this, fix_review reads /tmp and the GUI never sees what
-  # the reviewer wrote.
-  - id: require_code_review
-    name: Require Code Review
-    type: require_sidecar
-    config:
-      sidecar: code_review
-    next:
-      - when:
-          field: task.status
-          operator: equals
-          value: human-required
-        goto: ""
-      - goto: fix_review
-
-  - id: fix_review
-    name: Fix Review Comments
-    type: run_agent
-    config:
-      role: fix-review
-      mode: headless
-      needs_worktree: true
-      max_retries: 2
-      prompt: >-
-        Read the code review at /tmp/sybra-review-{{.Task.ID}}.md
-
-        For each actionable finding (critical/high/medium severity), fix the code.
-        Skip low-severity nitpicks and style-only comments.
-
-        When done, commit your changes (do NOT push yet — push happens with PR
-        creation). Sign commits with `git commit -s -S`.
-        Use conventional commit format: `fix(review): address review comments`.
-    next:
-      - goto: create_pr
-
-  # Create the GitHub PR after review fixes are committed locally.
-  # Check for an existing PR first to stay idempotent on retries.
-  - id: create_pr
-    name: Create PR
-    type: run_agent
-    config:
-      role: create-pr
-      mode: headless
-      model: sonnet
-      needs_worktree: true
-      max_retries: 2
-      prompt: >-
-        Create a GitHub PR for the current branch if one does not exist yet.
-
-        Steps:
-          1. Check: gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number'
-             If a PR number is returned, skip creation — the PR already exists.
-          2. If no PR exists, push the branch and create one:
-             git push -u origin HEAD
-             If push is rejected because the remote has diverged (e.g. after a
-             rebase), force-push without asking for confirmation:
-             git push --force-with-lease -u origin HEAD
-             gh pr create{{if ne .Task.ProjectType "pet"}} --draft{{end}} \
-               --title "<conventional-commit title>" \
-               --body "<PR body with ## Motivation and ## Implementation information>"
-             {{- if .Task.Issue}}
-             Include "Closes {{.Task.Issue}}" in the PR body.
-             {{- end}}
-
-        PR title must follow conventional commits format matching the task work.
-        PR body must have ## Motivation and ## Implementation information sections.
-        Never ask for confirmation — this is a feature branch owned by this task.
-    next:
-      - goto: link_pr_and_review
-
-  # Non-LLM step: recover PR number from task, agent result history, or
-  # gh pr list. Sets task to in-review and skips the LLM eval when a PR
-  # is unambiguously found. Falls through to evaluate only when all three
-  # sources fail to find a PR.
-  - id: link_pr_and_review
-    name: Link PR and Review
-    type: link_pr_and_review
-    next:
-      - when:
-          field: task.status
-          operator: equals
-          value: in-review
-        goto: ensure_pr_closes_issue
-      - when:
-          field: task.status
-          operator: equals
-          value: human-required
-        goto: ""
-      - goto: evaluate
-
-  # Mechanical fallback (no LLM): reached only when link_pr_and_review failed
-  # to find a PR. Walks step history for the last run_agent record and flips
-  # the task to human-required with a truncated reason.
-  - id: evaluate
-    name: Evaluate
-    type: evaluate
-    next:
-      - goto: ""
-
-  # Mechanical check (no LLM): if the task is linked to a GitHub issue,
-  # make sure the PR's body carries a `Closes <issue-url>` reference so
-  # merging the PR auto-closes the issue. Auto-appends the reference if
-  # missing; flips to human-required if the edit/verification fails.
-  - id: ensure_pr_closes_issue
-    name: Ensure PR Closes Issue
-    type: ensure_pr_closes_issue
-    next:
-      - goto: ""

--- a/internal/workflow/builtin/simple-task-review.yaml
+++ b/internal/workflow/builtin/simple-task-review.yaml
@@ -1,0 +1,240 @@
+id: simple-task-review
+name: Simple Task — Review
+description: Triage the review depth, run code review (simple or staff), apply fixes, then create the GitHub PR and link it back to the task. Triggered by the cascade after simple-task-implement flips status to ready-review.
+builtin: true
+trigger:
+  on: task.status_changed
+  conditions:
+    - field: task.status
+      operator: equals
+      value: ready-review
+steps:
+  # Skip review when tagged noreview or already reviewed in a prior run.
+  # On skip, jump straight to create_pr so the PR is still opened.
+  - id: maybe_review
+    name: Review Decision
+    type: condition
+    config:
+      check:
+        field: task.tags
+        operator: not_contains
+        value: noreview
+    next:
+      - when:
+          field: task.reviewed
+          operator: equals
+          value: "true"
+        goto: create_pr
+      - when:
+          field: task.tags
+          operator: not_contains
+          value: noreview
+        goto: triage_review
+      - goto: create_pr
+
+  # Mechanical heuristic (no LLM): inspects diff size + file shape and emits
+  # "simple" or "staff" so pick_review_method below can pick between the
+  # lightweight /pr-review skill and the deeper /staff-code-review skill.
+  # Force-staff-review tag is checked by the picker, not here, so the
+  # decision rationale is still logged for tagged tasks.
+  - id: triage_review
+    name: Triage Review
+    type: triage_review
+    next:
+      - goto: pick_review_method
+
+  # Routes to the simple or staff review based on:
+  #   - task.tags contains force-staff-review → always staff (escape hatch)
+  #   - vars.step.triage_review.output equals simple → /pr-review
+  #   - otherwise → /staff-code-review (covers "staff", error fallbacks)
+  - id: pick_review_method
+    name: Pick Review Method
+    type: condition
+    next:
+      - when:
+          field: task.tags
+          operator: contains
+          value: force-staff-review
+        goto: code_review_staff
+      - when:
+          field: vars.step.triage_review.output
+          operator: equals
+          value: simple
+        goto: code_review_simple
+      - goto: code_review_staff
+
+  # Lightweight review for small, low-risk diffs. Writes to the same
+  # sidecar path as code_review_staff so fix_review reads either one
+  # transparently.
+  - id: code_review_simple
+    name: Code Review (simple)
+    type: run_agent
+    config:
+      role: review
+      mode: headless
+      provider: cross
+      needs_worktree: true
+      max_retries: 2
+      prompt: >-
+        Review the changes on the current branch vs origin/main.
+        The PR has not been created yet — review the local diff.
+
+        Steps:
+          1. git diff origin/main..HEAD > /tmp/sybra-diff-{{.Task.ID}}.patch
+          2. Run /pr-review against that patch and the worktree source
+          3. Save the full review to /tmp/sybra-review-{{.Task.ID}}.md
+
+        Do NOT submit anything to GitHub. Sybra will ingest
+        /tmp/sybra-review-{{.Task.ID}}.md as the code_review sidecar
+        after you exit — you do not need to call sybra-cli yourself.
+        The /tmp file also remains for the next step (fix_review) to
+        read directly.
+      import_sidecar:
+        kind: code_review
+        from: /tmp/sybra-review-{{.Task.ID}}.md
+    next:
+      - goto: require_code_review
+
+  # Deep review for non-trivial diffs. Same sidecar contract as
+  # code_review_simple. Used by default whenever triage cannot prove a
+  # diff is small + low-risk.
+  - id: code_review_staff
+    name: Code Review (staff)
+    type: run_agent
+    config:
+      role: review
+      mode: headless
+      provider: cross
+      needs_worktree: true
+      max_retries: 2
+      prompt: >-
+        Review the changes on the current branch vs origin/main.
+        The PR has not been created yet — review the local diff.
+
+        Steps:
+          1. git diff origin/main..HEAD > /tmp/sybra-diff-{{.Task.ID}}.patch
+          2. Run /staff-code-review against that patch and the worktree source
+          3. Save the full review to /tmp/sybra-review-{{.Task.ID}}.md
+
+        Do NOT submit anything to GitHub. Sybra will ingest
+        /tmp/sybra-review-{{.Task.ID}}.md as the code_review sidecar
+        after you exit — you do not need to call sybra-cli yourself.
+        The /tmp file also remains for the next step (fix_review) to
+        read directly.
+      import_sidecar:
+        kind: code_review
+        from: /tmp/sybra-review-{{.Task.ID}}.md
+    next:
+      - goto: require_code_review
+
+  # Guard: mirrors require_plan_critique in simple-task-plan. Flips task
+  # to human-required when the review sidecar is empty (e.g. agent never
+  # wrote /tmp/sybra-review-…md, or its sandbox blocked the path).
+  # Without this, fix_review reads /tmp and the GUI never sees what
+  # the reviewer wrote.
+  - id: require_code_review
+    name: Require Code Review
+    type: require_sidecar
+    config:
+      sidecar: code_review
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
+      - goto: fix_review
+
+  - id: fix_review
+    name: Fix Review Comments
+    type: run_agent
+    config:
+      role: fix-review
+      mode: headless
+      needs_worktree: true
+      max_retries: 2
+      prompt: >-
+        Read the code review at /tmp/sybra-review-{{.Task.ID}}.md
+
+        For each actionable finding (critical/high/medium severity), fix the code.
+        Skip low-severity nitpicks and style-only comments.
+
+        When done, commit your changes (do NOT push yet — push happens with PR
+        creation). Sign commits with `git commit -s -S`.
+        Use conventional commit format: `fix(review): address review comments`.
+    next:
+      - goto: create_pr
+
+  # Create the GitHub PR after review fixes are committed locally.
+  # Check for an existing PR first to stay idempotent on retries.
+  - id: create_pr
+    name: Create PR
+    type: run_agent
+    config:
+      role: create-pr
+      mode: headless
+      model: sonnet
+      needs_worktree: true
+      max_retries: 2
+      prompt: >-
+        Create a GitHub PR for the current branch if one does not exist yet.
+
+        Steps:
+          1. Check: gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number'
+             If a PR number is returned, skip creation — the PR already exists.
+          2. If no PR exists, push the branch and create one:
+             git push -u origin HEAD
+             If push is rejected because the remote has diverged (e.g. after a
+             rebase), force-push without asking for confirmation:
+             git push --force-with-lease -u origin HEAD
+             gh pr create{{if ne .Task.ProjectType "pet"}} --draft{{end}} \
+               --title "<conventional-commit title>" \
+               --body "<PR body with ## Motivation and ## Implementation information>"
+             {{- if .Task.Issue}}
+             Include "Closes {{.Task.Issue}}" in the PR body.
+             {{- end}}
+
+        PR title must follow conventional commits format matching the task work.
+        PR body must have ## Motivation and ## Implementation information sections.
+        Never ask for confirmation — this is a feature branch owned by this task.
+    next:
+      - goto: link_pr_and_review
+
+  # Non-LLM step: recover PR number from task, agent result history, or
+  # gh pr list. Sets task to in-review and skips the LLM eval when a PR
+  # is unambiguously found. Falls through to evaluate only when all three
+  # sources fail to find a PR.
+  - id: link_pr_and_review
+    name: Link PR and Review
+    type: link_pr_and_review
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: in-review
+        goto: ensure_pr_closes_issue
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
+      - goto: evaluate
+
+  # Mechanical fallback (no LLM): reached only when link_pr_and_review failed
+  # to find a PR. Walks step history for the last run_agent record and flips
+  # the task to human-required with a truncated reason.
+  - id: evaluate
+    name: Evaluate
+    type: evaluate
+    next:
+      - goto: ""
+
+  # Mechanical check (no LLM): if the task is linked to a GitHub issue,
+  # make sure the PR's body carries a `Closes <issue-url>` reference so
+  # merging the PR auto-closes the issue. Auto-appends the reference if
+  # missing; flips to human-required if the edit/verification fails.
+  - id: ensure_pr_closes_issue
+    name: Ensure PR Closes Issue
+    type: ensure_pr_closes_issue
+    next:
+      - goto: ""

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -19,17 +19,17 @@ func TestBuiltinSimpleTask_MaybeCritiqueReplanSkip(t *testing.T) {
 	}
 	var simple *Definition
 	for i := range defs {
-		if defs[i].ID == "simple-task" {
+		if defs[i].ID == "simple-task-plan" {
 			simple = &defs[i]
 			break
 		}
 	}
 	if simple == nil {
-		t.Fatal("simple-task builtin definition not found")
+		t.Fatal("simple-task-plan builtin definition not found")
 	}
 	step := simple.StepByID("maybe_critique")
 	if step == nil {
-		t.Fatal("maybe_critique step not found in simple-task")
+		t.Fatal("maybe_critique step not found in simple-task-plan")
 	}
 
 	cases := []struct {

--- a/internal/workflow/condition.go
+++ b/internal/workflow/condition.go
@@ -65,7 +65,8 @@ func isKnownField(field string) bool {
 // drift (adding a new Status, renaming a kind) fails CI immediately.
 var FieldAllowedValues = map[string]map[string]bool{
 	"task.status": {
-		"new": true, "todo": true, "in-progress": true, "in-review": true,
+		"new": true, "todo": true, "in-progress": true,
+		"ready-review": true, "in-review": true,
 		"planning": true, "plan-review": true, "testing": true,
 		"test-plan-review": true, "human-required": true, "blocked": true,
 		"done": true, "cancelled": true,

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -749,7 +749,7 @@ func TestDispatchEvent_AlreadyActiveRejected(t *testing.T) {
 		Status:    "in-progress",
 		AgentMode: "headless",
 		Workflow: &Execution{
-			WorkflowID:  "simple-task",
+			WorkflowID:  "simple-task-plan",
 			CurrentStep: "implement",
 			State:       ExecWaiting,
 		},
@@ -776,7 +776,7 @@ func TestDispatchEvent_TerminalWorkflowReplaced(t *testing.T) {
 		ID:     "t1",
 		Status: "in-review",
 		Workflow: &Execution{
-			WorkflowID:  "simple-task",
+			WorkflowID:  "simple-task-plan",
 			CurrentStep: "",
 			State:       ExecCompleted, // terminal — dispatch should replace
 		},

--- a/internal/workflow/triage_review_test.go
+++ b/internal/workflow/triage_review_test.go
@@ -360,17 +360,17 @@ func TestBuiltinSimpleTask_PickReviewMethod(t *testing.T) {
 	}
 	var simple *Definition
 	for i := range defs {
-		if defs[i].ID == "simple-task" {
+		if defs[i].ID == "simple-task-review" {
 			simple = &defs[i]
 			break
 		}
 	}
 	if simple == nil {
-		t.Fatal("simple-task builtin definition not found")
+		t.Fatal("simple-task-review builtin definition not found")
 	}
 	step := simple.StepByID("pick_review_method")
 	if step == nil {
-		t.Fatal("pick_review_method step not found in simple-task")
+		t.Fatal("pick_review_method step not found in simple-task-review")
 	}
 
 	cases := []struct {


### PR DESCRIPTION
## Motivation

The `simple-task` workflow had grown to 623 lines / 24 steps spanning five
distinct phases (triage → plan → implement → review → PR). The single file
was hard to scan, hard to modify one phase without re-reading the whole
file, and hard to reason about which phase a failing task was in.

## Implementation information

Split into three chained workflows that mirror the existing `pr-fix`,
`pr-review`, and `testing-task` pattern:

- `simple-task-plan` — triage + plan/critique/human-review loop. Trigger
  `task.created`. Ends by flipping status to `in-progress`.
- `simple-task-implement` — implement + verify_commits. Trigger
  `task.status_changed` → `in-progress`. Ends by flipping status to
  `ready-review` (new).
- `simple-task-review` — review-depth triage + simple/staff review +
  fix_review + create_pr + link/evaluate/closes-issue. Trigger
  `task.status_changed` → `ready-review`.

**Cascade.** `AgentCompletionHandler.OnWorkflowComplete` now dispatches a
`task.status_changed` event for the task's current status after a workflow
reaches `ExecCompleted`. This bridges mid-workflow `set_status` → next
workflow start, since `DispatchEvent` rejects with
`ErrWorkflowAlreadyActive` while the parent is mid-flight. The same
wiring is mirrored in the e2e test env so cascade-spanning tests behave
identically to production.

Considered (and rejected) adding an `invoke_workflow` step type to the
engine — it kept a single parent orchestrator but required engine work,
schema additions, and tests, with no operational gain over the
status-driven cascade that already exists for `testing-task`.

**Status enum.** Added `ready-review` to `task.Status`, `condition.go`
`FieldAllowedValues`, `monitor/detector.go` exhaustive switch, the
frontend `statuses.ts` type/labels/board mapping, and regenerated Wails
bindings.

> Changelog: refactor(workflow): split simple-task in 3 flows

## Supporting documentation

Plan: ~/.claude/plans/we-have-simple-task-goofy-adleman.md