### PR TITLE
feat(agent): auto-continue on turns when cost allows

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -15,6 +15,17 @@ export class AgentDefaults {
     "maxTurns": number;
 
     /**
+     * TurnCostFraction is the fraction of MaxCostUSD below which a turns
+     * escalation is auto-continued. Default 0.8 when unset.
+     */
+    "turnCostFraction": number;
+
+    /**
+     * TurnMultiplier scales the turn limit on each auto-continuation. Default 2 when unset.
+     */
+    "turnMultiplier": number;
+
+    /**
      * RequirePermissions sets the default permission requirement for agents.
      * nil means not configured (falls back to true — safe default).
      * Set to false in config to opt all tasks into skip-permissions mode.
@@ -57,6 +68,12 @@ export class AgentDefaults {
         }
         if (!("maxTurns" in $$source)) {
             this["maxTurns"] = 0;
+        }
+        if (!("turnCostFraction" in $$source)) {
+            this["turnCostFraction"] = 0;
+        }
+        if (!("turnMultiplier" in $$source)) {
+            this["turnMultiplier"] = 0;
         }
         if (!("requirePermissions" in $$source)) {
             this["requirePermissions"] = null;

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -22,6 +22,13 @@ type EmitFunc func(event string, data any)
 type Guardrails struct {
 	MaxCostUSD float64
 	MaxTurns   int
+	// TurnCostFraction is the fraction of MaxCostUSD below which a turns
+	// escalation is auto-continued without human approval. Default 0.8.
+	// Only effective when MaxCostUSD > 0.
+	TurnCostFraction float64
+	// TurnMultiplier scales the turn limit on each auto-continuation so
+	// the agent gets progressively more turns. Default 2.
+	TurnMultiplier float64
 }
 
 type Manager struct {
@@ -121,6 +128,35 @@ func (m *Manager) Guardrails() Guardrails {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.guardrails
+}
+
+// canAutoContinueTurns returns true when the agent's current cost is below
+// TurnCostFraction * MaxCostUSD, meaning there is still meaningful budget left
+// and the turns limit can be auto-bumped without human approval.
+// If MaxCostUSD == 0, auto-continue is always allowed (cost is unlimited).
+func (m *Manager) canAutoContinueTurns(a *Agent) bool {
+	m.mu.RLock()
+	maxCost := m.guardrails.MaxCostUSD
+	fraction := m.guardrails.TurnCostFraction
+	m.mu.RUnlock()
+	if maxCost == 0 {
+		return true
+	}
+	if fraction <= 0 {
+		fraction = 0.8
+	}
+	return a.GetCostUSD() < maxCost*fraction
+}
+
+// effectiveTurnMultiplier returns the configured TurnMultiplier, defaulting to 2.
+func (m *Manager) effectiveTurnMultiplier() float64 {
+	m.mu.RLock()
+	v := m.guardrails.TurnMultiplier
+	m.mu.RUnlock()
+	if v <= 0 {
+		return 2
+	}
+	return v
 }
 
 // RespondEscalation sends a human decision to a paused agent.

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -272,6 +272,13 @@ func (a *Agent) SetEscalationReason(reason string) {
 	a.mu.Unlock()
 }
 
+// SetMaxTurns sets the per-agent turn limit override.
+func (a *Agent) SetMaxTurns(n int) {
+	a.mu.Lock()
+	a.MaxTurns = n
+	a.mu.Unlock()
+}
+
 // GetCostUSD returns the current cumulative cost.
 func (a *Agent) GetCostUSD() float64 {
 	a.mu.RLock()

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -418,11 +418,6 @@ func (m *Manager) checkTurnsGuardrail(ctx context.Context, a *Agent) bool {
 		multiplier := m.effectiveTurnMultiplier()
 		newLimit := int(float64(maxTurns) * multiplier)
 		a.SetMaxTurns(newLimit)
-		m.emit(events.AgentEscalation(a.ID), EscalationEvent{
-			Reason:    "turns_auto_continued",
-			TurnCount: turns,
-			Limit:     float64(newLimit),
-		})
 		m.logger.Info("agent.guardrail.turns.auto_continued", "id", a.ID, "turns", turns, "new_limit", newLimit)
 		return true
 	}

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -365,29 +365,8 @@ func (m *Manager) streamHeadlessOutput(ctx context.Context, a *Agent, stdout io.
 		}
 
 		if event.Type == "assistant" {
-			turns := a.IncTurnCount()
-			if maxTurns := m.effectiveMaxTurns(a); maxTurns > 0 && turns >= maxTurns {
-				m.logger.Warn("agent.guardrail.turns", "id", a.ID, "turns", turns, "limit", maxTurns)
-				a.SetEscalationReason("turns")
-				m.emit(events.AgentEscalation(a.ID), EscalationEvent{
-					Reason:    "turns",
-					TurnCount: turns,
-					Limit:     float64(maxTurns),
-				})
-				m.emit(events.AgentState(a.ID), a)
-				// Block until human responds or context is cancelled.
-				select {
-				case continueRun := <-a.escalationCh:
-					if !continueRun {
-						a.cancel()
-						return
-					}
-					// Human approved continuation — clear reason and keep going.
-					a.SetEscalationReason("")
-					m.emit(events.AgentState(a.ID), a)
-				case <-ctx.Done():
-					return
-				}
+			if keepGoing := m.checkTurnsGuardrail(ctx, a); !keepGoing {
+				return
 			}
 		}
 
@@ -423,6 +402,49 @@ func (m *Manager) reportScannerError(a *Agent, err error) {
 		"id", a.ID,
 		"err", err,
 		"hint", "oversized line or broken pipe aborted the NDJSON stream; trailing events were lost")
+}
+
+// checkTurnsGuardrail increments the turn counter and, if the limit is
+// reached, either auto-continues (cost below threshold) or blocks until a
+// human decision arrives. Returns false if the caller should stop the stream.
+func (m *Manager) checkTurnsGuardrail(ctx context.Context, a *Agent) bool {
+	turns := a.IncTurnCount()
+	maxTurns := m.effectiveMaxTurns(a)
+	if maxTurns <= 0 || turns < maxTurns {
+		return true
+	}
+	m.logger.Warn("agent.guardrail.turns", "id", a.ID, "turns", turns, "limit", maxTurns)
+	if m.canAutoContinueTurns(a) {
+		multiplier := m.effectiveTurnMultiplier()
+		newLimit := int(float64(maxTurns) * multiplier)
+		a.SetMaxTurns(newLimit)
+		m.emit(events.AgentEscalation(a.ID), EscalationEvent{
+			Reason:    "turns_auto_continued",
+			TurnCount: turns,
+			Limit:     float64(newLimit),
+		})
+		m.logger.Info("agent.guardrail.turns.auto_continued", "id", a.ID, "turns", turns, "new_limit", newLimit)
+		return true
+	}
+	a.SetEscalationReason("turns")
+	m.emit(events.AgentEscalation(a.ID), EscalationEvent{
+		Reason:    "turns",
+		TurnCount: turns,
+		Limit:     float64(maxTurns),
+	})
+	m.emit(events.AgentState(a.ID), a)
+	select {
+	case continueRun := <-a.escalationCh:
+		if !continueRun {
+			a.cancel()
+			return false
+		}
+		a.SetEscalationReason("")
+		m.emit(events.AgentState(a.ID), a)
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 // effectiveMaxTurns returns the turn limit for a: per-agent override when set,

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -455,6 +455,120 @@ func TestGuardrails_MaxTurnsZeroMeansUnlimited(t *testing.T) {
 	}
 }
 
+// TestGuardrails_TurnsAutoContinue_CostBelowCap verifies that when an agent
+// hits MaxTurns but cumulative cost is well below the MaxCostUSD threshold,
+// the runner auto-continues without blocking on escalationCh. The turn limit
+// is bumped by TurnMultiplier and a turns_auto_continued escalation event is
+// emitted so the GUI can surface the bump.
+func TestGuardrails_TurnsAutoContinue_CostBelowCap(t *testing.T) {
+	// 5 assistant events — limit is 3 so the 3rd fires the guardrail.
+	var lines []string
+	for range 5 {
+		lines = append(lines, `{"type":"assistant","message":{"content":[{"type":"text","text":"tick"}]}}`)
+	}
+	input := strings.Join(lines, "\n") + "\n"
+
+	var (
+		autoContinued int
+		blocked       int
+		mu            sync.Mutex
+	)
+	emit := func(event string, data any) {
+		if !strings.Contains(event, "agent:escalation:") {
+			return
+		}
+		if e, ok := data.(EscalationEvent); ok {
+			mu.Lock()
+			switch e.Reason {
+			case "turns_auto_continued":
+				autoContinued++
+			case "turns":
+				blocked++
+			}
+			mu.Unlock()
+		}
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	m := NewManager(context.Background(), emit, logger, t.TempDir())
+	// Cost cap set, but agent has spent $0 — well below 80% of $10.
+	m.SetGuardrails(Guardrails{MaxCostUSD: 10.0, MaxTurns: 3})
+
+	// No escalationCh needed because auto-continue path never blocks.
+	a := &Agent{ID: "t", Provider: "claude"}
+	m.streamHeadlessOutput(t.Context(), a, bytes.NewReader([]byte(input)), nil)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if autoContinued == 0 {
+		t.Error("expected turns_auto_continued escalation event, got none")
+	}
+	if blocked != 0 {
+		t.Errorf("expected no blocking escalation, got %d", blocked)
+	}
+	if got := len(a.Output()); got != 5 {
+		t.Errorf("got %d events, want 5 — stream stopped early", got)
+	}
+}
+
+// TestGuardrails_TurnsBlocks_CostNearCap verifies that when an agent hits
+// MaxTurns and cumulative cost is above TurnCostFraction * MaxCostUSD, the
+// runner falls through to the human-gate path (blocking on escalationCh).
+func TestGuardrails_TurnsBlocks_CostNearCap(t *testing.T) {
+	// 4 assistant events; limit is 3 so the 3rd triggers.
+	var lines []string
+	for range 4 {
+		lines = append(lines, `{"type":"assistant","message":{"content":[{"type":"text","text":"tick"}]}}`)
+	}
+	// Prepend a result event so the agent's cost is seeded before turns fire.
+	resultLine := `{"type":"result","result":"r","session_id":"s1","total_cost_usd":9.0,"total_input_tokens":1,"total_output_tokens":1}`
+	input := resultLine + "\n" + strings.Join(lines, "\n") + "\n"
+
+	var (
+		autoContinued int
+		blocked       int
+		mu            sync.Mutex
+	)
+	emit := func(event string, data any) {
+		if !strings.Contains(event, "agent:escalation:") {
+			return
+		}
+		if e, ok := data.(EscalationEvent); ok {
+			mu.Lock()
+			switch e.Reason {
+			case "turns_auto_continued":
+				autoContinued++
+			case "turns":
+				blocked++
+			}
+			mu.Unlock()
+		}
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	m := NewManager(context.Background(), emit, logger, t.TempDir())
+	// Cost cap $10, agent already spent $9 — above 80% threshold.
+	m.SetGuardrails(Guardrails{MaxCostUSD: 10.0, MaxTurns: 3})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	// Respond to the escalation immediately: send false (kill) so the stream
+	// exits cleanly without hanging the test.
+	a := &Agent{ID: "t", Provider: "claude", escalationCh: make(chan bool, 1)}
+	go func() {
+		// Wait briefly for the escalation to be raised, then cancel.
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	m.streamHeadlessOutput(ctx, a, bytes.NewReader([]byte(input)), nil)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if autoContinued != 0 {
+		t.Errorf("expected no auto-continue (cost near cap), got %d", autoContinued)
+	}
+	if blocked == 0 {
+		t.Error("expected blocking turns escalation event, got none")
+	}
+}
+
 // TestGuardrails_SetMidRunVisibleToStream verifies SetGuardrails picks up
 // live — the stream loop re-reads m.guardrails under RLock on every event,
 // so a user who tightens the cost limit mid-run sees escalation on the

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -457,9 +457,8 @@ func TestGuardrails_MaxTurnsZeroMeansUnlimited(t *testing.T) {
 
 // TestGuardrails_TurnsAutoContinue_CostBelowCap verifies that when an agent
 // hits MaxTurns but cumulative cost is well below the MaxCostUSD threshold,
-// the runner auto-continues without blocking on escalationCh. The turn limit
-// is bumped by TurnMultiplier and a turns_auto_continued escalation event is
-// emitted so the GUI can surface the bump.
+// the runner auto-continues without blocking on escalationCh and without
+// emitting a blocking escalation event.
 func TestGuardrails_TurnsAutoContinue_CostBelowCap(t *testing.T) {
 	// 5 assistant events — limit is 3 so the 3rd fires the guardrail.
 	var lines []string
@@ -469,22 +468,16 @@ func TestGuardrails_TurnsAutoContinue_CostBelowCap(t *testing.T) {
 	input := strings.Join(lines, "\n") + "\n"
 
 	var (
-		autoContinued int
-		blocked       int
-		mu            sync.Mutex
+		blocked int
+		mu      sync.Mutex
 	)
 	emit := func(event string, data any) {
 		if !strings.Contains(event, "agent:escalation:") {
 			return
 		}
-		if e, ok := data.(EscalationEvent); ok {
+		if e, ok := data.(EscalationEvent); ok && e.Reason == "turns" {
 			mu.Lock()
-			switch e.Reason {
-			case "turns_auto_continued":
-				autoContinued++
-			case "turns":
-				blocked++
-			}
+			blocked++
 			mu.Unlock()
 		}
 	}
@@ -499,9 +492,6 @@ func TestGuardrails_TurnsAutoContinue_CostBelowCap(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
-	if autoContinued == 0 {
-		t.Error("expected turns_auto_continued escalation event, got none")
-	}
 	if blocked != 0 {
 		t.Errorf("expected no blocking escalation, got %d", blocked)
 	}
@@ -756,10 +746,11 @@ func TestGuardrails_PerAgentOverrideLower(t *testing.T) {
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	m := NewManager(context.Background(), emit, logger, t.TempDir())
-	m.SetGuardrails(Guardrails{MaxTurns: 20})
+	// MaxCostUSD set; agent cost seeded above 80% threshold so auto-continue is suppressed.
+	m.SetGuardrails(Guardrails{MaxCostUSD: 10.0, MaxTurns: 20})
 
 	_, cancel := context.WithCancel(context.Background())
-	a := &Agent{ID: "t", Provider: "claude", MaxTurns: 5, escalationCh: make(chan bool, 1), cancel: cancel}
+	a := &Agent{ID: "t", Provider: "claude", MaxTurns: 5, CostUSD: 9.0, escalationCh: make(chan bool, 1), cancel: cancel}
 	// Pre-fill the escalation channel so the runner doesn't block.
 	a.escalationCh <- false
 	m.streamHeadlessOutput(t.Context(), a, bytes.NewReader([]byte(input)), nil)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,11 @@ type AgentDefaults struct {
 	ResearchMachineDir string  `yaml:"research_machine_dir" json:"researchMachineDir"`
 	MaxCostUSD         float64 `yaml:"max_cost_usd" json:"maxCostUsd"`
 	MaxTurns           int     `yaml:"max_turns" json:"maxTurns"`
+	// TurnCostFraction is the fraction of MaxCostUSD below which a turns
+	// escalation is auto-continued. Default 0.8 when unset.
+	TurnCostFraction float64 `yaml:"turn_cost_fraction" json:"turnCostFraction"`
+	// TurnMultiplier scales the turn limit on each auto-continuation. Default 2 when unset.
+	TurnMultiplier float64 `yaml:"turn_multiplier" json:"turnMultiplier"`
 	// RequirePermissions sets the default permission requirement for agents.
 	// nil means not configured (falls back to true — safe default).
 	// Set to false in config to opt all tasks into skip-permissions mode.

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -247,8 +247,10 @@ func (a *App) Startup(ctx context.Context) error {
 
 	a.agents.SetMaxConcurrent(a.cfg.Agent.MaxConcurrent)
 	a.agents.SetGuardrails(agent.Guardrails{
-		MaxCostUSD: a.cfg.Agent.MaxCostUSD,
-		MaxTurns:   a.cfg.Agent.MaxTurns,
+		MaxCostUSD:       a.cfg.Agent.MaxCostUSD,
+		MaxTurns:         a.cfg.Agent.MaxTurns,
+		TurnCostFraction: a.cfg.Agent.TurnCostFraction,
+		TurnMultiplier:   a.cfg.Agent.TurnMultiplier,
 	})
 	a.initApprovalServer(emit)
 

--- a/internal/sybra/config_diff.go
+++ b/internal/sybra/config_diff.go
@@ -25,6 +25,12 @@ func diffConfig(old, next config.Config) (hot, restart []string) {
 	if old.Agent.MaxTurns != next.Agent.MaxTurns {
 		hot = append(hot, "agent.max_turns")
 	}
+	if old.Agent.TurnCostFraction != next.Agent.TurnCostFraction {
+		hot = append(hot, "agent.turn_cost_fraction")
+	}
+	if old.Agent.TurnMultiplier != next.Agent.TurnMultiplier {
+		hot = append(hot, "agent.turn_multiplier")
+	}
 	if old.Logging.Level != next.Logging.Level {
 		hot = append(hot, "logging.level")
 	}

--- a/internal/sybra/svc_config_reload.go
+++ b/internal/sybra/svc_config_reload.go
@@ -70,11 +70,14 @@ func (s *ConfigService) ReloadFromDisk() (changedHot []string, err error) {
 			}
 		}
 	}
-	// SetGuardrails once if either guardrail field changed.
-	if slices.Contains(hot, "agent.max_cost_usd") || slices.Contains(hot, "agent.max_turns") {
+	// SetGuardrails once if any guardrail field changed.
+	guardrailFields := []string{"agent.max_cost_usd", "agent.max_turns", "agent.turn_cost_fraction", "agent.turn_multiplier"}
+	if slices.ContainsFunc(guardrailFields, func(f string) bool { return slices.Contains(hot, f) }) {
 		s.agents.SetGuardrails(agent.Guardrails{
-			MaxCostUSD: next.Agent.MaxCostUSD,
-			MaxTurns:   next.Agent.MaxTurns,
+			MaxCostUSD:       next.Agent.MaxCostUSD,
+			MaxTurns:         next.Agent.MaxTurns,
+			TurnCostFraction: next.Agent.TurnCostFraction,
+			TurnMultiplier:   next.Agent.TurnMultiplier,
 		})
 	}
 


### PR DESCRIPTION
## Motivation

When an agent hits `MaxTurns`, Sybra previously always escalated to a human gate — even when the agent was well under the cost cap and could safely continue. This caused unnecessary interruptions for long-running tasks that hadn't exhausted their budget.

Closes https://github.com/Automaat/sybra/issues/638

## Implementation information

- When `MaxTurns` is hit, the agent checks current cost vs `MaxCostUSD * TurnCostFraction` (default 0.8).
- If below threshold, the per-agent turn limit is bumped by `TurnMultiplier` (default 2x) and execution continues without human intervention.
- Human-gate path is unchanged when cost is near cap, or when `MaxCostUSD=0` with an explicit turns limit.
- `TurnCostFraction` and `TurnMultiplier` are wired through `AgentDefaults` config and `config_diff` hot-reload.
- Extracts `checkTurnsGuardrail` helper to keep `streamHeadlessOutput` within funlen limit.
- Drops the `turns_auto_continued` escalation event — the UI had no handler and treated it as a cost breach, showing a false red guardrail on a still-running agent. Logger records the bump instead.