### PR TITLE
fix(agent): enforce per-bash-tool timeout

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -33,6 +33,12 @@ export class AgentDefaults {
     "requirePermissions": boolean | null;
 
     /**
+     * BashTimeoutSeconds sets the per-bash-tool-call timeout passed to
+     * claude -p via --bashTimeoutMs. 0 means use DefaultBashTimeoutSeconds (300).
+     */
+    "bashTimeoutSeconds": number;
+
+    /**
      * MaxLogEvents caps how many NDJSON events are returned when replaying
      * a completed agent's log file. 0 means use DefaultMaxLogEvents (500).
      */
@@ -77,6 +83,9 @@ export class AgentDefaults {
         }
         if (!("requirePermissions" in $$source)) {
             this["requirePermissions"] = null;
+        }
+        if (!("bashTimeoutSeconds" in $$source)) {
+            this["bashTimeoutSeconds"] = 0;
         }
         if (!("maxLogEvents" in $$source)) {
             this["maxLogEvents"] = 0;

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -40,12 +40,12 @@ type Manager struct {
 	onComplete    func(ag *Agent)
 	logger        *slog.Logger
 	logDir        string
-	maxConcurrent  int
-	defaultProv    string
-	approvalAddr   string // localhost:port for the HTTP tool approval server
-	guardrails     Guardrails
-	bashTimeoutMs  int
-	gate           provider.HealthGate
+	maxConcurrent int
+	defaultProv   string
+	approvalAddr  string // localhost:port for the HTTP tool approval server
+	guardrails    Guardrails
+	bashTimeoutMs int
+	gate          provider.HealthGate
 }
 
 func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir string) *Manager {

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -40,11 +40,12 @@ type Manager struct {
 	onComplete    func(ag *Agent)
 	logger        *slog.Logger
 	logDir        string
-	maxConcurrent int
-	defaultProv   string
-	approvalAddr  string // localhost:port for the HTTP tool approval server
-	guardrails    Guardrails
-	gate          provider.HealthGate
+	maxConcurrent  int
+	defaultProv    string
+	approvalAddr   string // localhost:port for the HTTP tool approval server
+	guardrails     Guardrails
+	bashTimeoutMs  int
+	gate           provider.HealthGate
 }
 
 func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir string) *Manager {
@@ -114,6 +115,14 @@ func (m *Manager) DefaultProvider() string {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.defaultProv
+}
+
+// SetBashTimeoutMs sets the default --bashTimeoutMs passed to claude -p.
+// Zero disables the flag (no per-call timeout).
+func (m *Manager) SetBashTimeoutMs(ms int) {
+	m.mu.Lock()
+	m.bashTimeoutMs = ms
+	m.mu.Unlock()
 }
 
 // SetGuardrails configures cost and turn limits applied to all agents.
@@ -216,6 +225,12 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 	resolvedProvider, gateErr := m.gateProvider(cfg)
 	if gateErr != nil {
 		return nil, gateErr
+	}
+
+	if cfg.BashTimeoutMs == 0 {
+		m.mu.RLock()
+		cfg.BashTimeoutMs = m.bashTimeoutMs
+		m.mu.RUnlock()
 	}
 
 	id := uuid.NewString()[:8]

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -371,6 +371,9 @@ type RunConfig struct {
 	// MaxTurns overrides the global guardrail for this specific agent run.
 	// Zero means "use the manager's global guardrail".
 	MaxTurns int
+	// BashTimeoutMs sets --bashTimeoutMs on the claude CLI for this run.
+	// Zero means "use the manager's default".
+	BashTimeoutMs int
 }
 
 // PlanStep represents a single item from a TodoWrite tool call.

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -502,6 +502,9 @@ func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args []strin
 	if a.Model != "" {
 		args = append(args, "--model", a.Model)
 	}
+	if cfg.BashTimeoutMs > 0 {
+		args = append(args, "--bashTimeoutMs", fmt.Sprintf("%d", cfg.BashTimeoutMs))
+	}
 	command = "claude " + strings.Join(args, " ")
 	return
 }

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -761,3 +761,53 @@ func TestGuardrails_PerAgentOverrideLower(t *testing.T) {
 		t.Errorf("per-agent MaxTurns=5 should escalate before global=20; got %d escalation events", escalations)
 	}
 }
+
+// TestBuildHeadlessInvocation_BashTimeoutMs verifies that --bashTimeoutMs is
+// included when cfg.BashTimeoutMs > 0, and absent when it is zero.
+func TestBuildHeadlessInvocation_BashTimeoutMs(t *testing.T) {
+	t.Run("included_when_set", func(t *testing.T) {
+		a := &Agent{ID: "a", Provider: "claude"}
+		_, args, _, err := buildHeadlessInvocation(a, RunConfig{
+			Prompt:        "hi",
+			BashTimeoutMs: 300000,
+		})
+		if err != nil {
+			t.Fatalf("buildHeadlessInvocation: %v", err)
+		}
+		idx := slices.Index(args, "--bashTimeoutMs")
+		if idx == -1 {
+			t.Fatal("--bashTimeoutMs not found in args")
+		}
+		if idx+1 >= len(args) || args[idx+1] != "300000" {
+			t.Fatalf("--bashTimeoutMs value = %q, want 300000", args[idx+1])
+		}
+	})
+
+	t.Run("absent_when_zero", func(t *testing.T) {
+		a := &Agent{ID: "a", Provider: "claude"}
+		_, args, _, err := buildHeadlessInvocation(a, RunConfig{
+			Prompt:        "hi",
+			BashTimeoutMs: 0,
+		})
+		if err != nil {
+			t.Fatalf("buildHeadlessInvocation: %v", err)
+		}
+		if slices.Contains(args, "--bashTimeoutMs") {
+			t.Fatal("--bashTimeoutMs must be absent when BashTimeoutMs == 0")
+		}
+	})
+
+	t.Run("not_passed_to_codex", func(t *testing.T) {
+		a := &Agent{ID: "a", Provider: "codex"}
+		_, args, _, err := buildHeadlessInvocation(a, RunConfig{
+			Prompt:        "hi",
+			BashTimeoutMs: 300000,
+		})
+		if err != nil {
+			t.Fatalf("buildHeadlessInvocation codex: %v", err)
+		}
+		if slices.Contains(args, "--bashTimeoutMs") {
+			t.Fatal("--bashTimeoutMs must not be passed to codex")
+		}
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,6 +72,9 @@ type AgentDefaults struct {
 	// nil means not configured (falls back to true — safe default).
 	// Set to false in config to opt all tasks into skip-permissions mode.
 	RequirePermissions *bool `yaml:"require_permissions" json:"requirePermissions"`
+	// BashTimeoutSeconds sets the per-bash-tool-call timeout passed to
+	// claude -p via --bashTimeoutMs. 0 means use DefaultBashTimeoutSeconds (300).
+	BashTimeoutSeconds int `yaml:"bash_timeout_seconds" json:"bashTimeoutSeconds"`
 	// MaxLogEvents caps how many NDJSON events are returned when replaying
 	// a completed agent's log file. 0 means use DefaultMaxLogEvents (500).
 	MaxLogEvents int `yaml:"max_log_events" json:"maxLogEvents"`
@@ -80,6 +83,19 @@ type AgentDefaults struct {
 	// files, regardless of age) are swept on app startup and daily
 	// thereafter. 0 falls back to DefaultLogRetentionDays (14).
 	LogRetentionDays int `yaml:"log_retention_days" json:"logRetentionDays"`
+}
+
+// DefaultBashTimeoutSeconds is the per-bash-tool-call timeout used when
+// BashTimeoutSeconds is not set in config.
+const DefaultBashTimeoutSeconds = 300
+
+// BashTimeoutMs returns the bash tool timeout in milliseconds, ready for
+// passing to claude -p --bashTimeoutMs.
+func (c *Config) BashTimeoutMs() int {
+	if c != nil && c.Agent.BashTimeoutSeconds > 0 {
+		return c.Agent.BashTimeoutSeconds * 1000
+	}
+	return DefaultBashTimeoutSeconds * 1000
 }
 
 // DefaultMaxLogEvents returns the configured cap or 500 if unset.

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -245,14 +245,7 @@ func (a *App) Startup(ctx context.Context) error {
 
 	a.initWorkflowEngine()
 
-	a.agents.SetMaxConcurrent(a.cfg.Agent.MaxConcurrent)
-	a.agents.SetBashTimeoutMs(a.cfg.BashTimeoutMs())
-	a.agents.SetGuardrails(agent.Guardrails{
-		MaxCostUSD:       a.cfg.Agent.MaxCostUSD,
-		MaxTurns:         a.cfg.Agent.MaxTurns,
-		TurnCostFraction: a.cfg.Agent.TurnCostFraction,
-		TurnMultiplier:   a.cfg.Agent.TurnMultiplier,
-	})
+	a.initAgentConfig()
 	a.initApprovalServer(emit)
 
 	a.initLoopScheduler(ctx, emit)

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -246,6 +246,7 @@ func (a *App) Startup(ctx context.Context) error {
 	a.initWorkflowEngine()
 
 	a.agents.SetMaxConcurrent(a.cfg.Agent.MaxConcurrent)
+	a.agents.SetBashTimeoutMs(a.cfg.BashTimeoutMs())
 	a.agents.SetGuardrails(agent.Guardrails{
 		MaxCostUSD:       a.cfg.Agent.MaxCostUSD,
 		MaxTurns:         a.cfg.Agent.MaxTurns,

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -240,6 +240,17 @@ func (a *App) initWorkflowEngine() {
 	// to the AgentCompletionHandler constructed there.
 }
 
+func (a *App) initAgentConfig() {
+	a.agents.SetMaxConcurrent(a.cfg.Agent.MaxConcurrent)
+	a.agents.SetBashTimeoutMs(a.cfg.BashTimeoutMs())
+	a.agents.SetGuardrails(agent.Guardrails{
+		MaxCostUSD:       a.cfg.Agent.MaxCostUSD,
+		MaxTurns:         a.cfg.Agent.MaxTurns,
+		TurnCostFraction: a.cfg.Agent.TurnCostFraction,
+		TurnMultiplier:   a.cfg.Agent.TurnMultiplier,
+	})
+}
+
 func (a *App) initApprovalServer(emit func(string, any)) {
 	srv, err := agent.NewApprovalServer(emit, a.logger)
 	if err != nil {

--- a/internal/sybra/config_diff.go
+++ b/internal/sybra/config_diff.go
@@ -31,6 +31,9 @@ func diffConfig(old, next config.Config) (hot, restart []string) {
 	if old.Agent.TurnMultiplier != next.Agent.TurnMultiplier {
 		hot = append(hot, "agent.turn_multiplier")
 	}
+	if old.Agent.BashTimeoutSeconds != next.Agent.BashTimeoutSeconds {
+		hot = append(hot, "agent.bash_timeout_seconds")
+	}
 	if old.Logging.Level != next.Logging.Level {
 		hot = append(hot, "logging.level")
 	}

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -120,6 +120,7 @@ func (s *ConfigService) applyFromConfig(next config.Config) {
 	s.notifier.SetDesktop(next.Notification.Desktop)
 	s.agents.SetMaxConcurrent(next.Agent.MaxConcurrent)
 	s.agents.SetDefaultProvider(next.Agent.Provider)
+	s.agents.SetBashTimeoutMs(next.BashTimeoutMs())
 	s.agents.SetGuardrails(agent.Guardrails{
 		MaxCostUSD: next.Agent.MaxCostUSD,
 		MaxTurns:   next.Agent.MaxTurns,

--- a/internal/sybra/svc_config_reload.go
+++ b/internal/sybra/svc_config_reload.go
@@ -80,6 +80,9 @@ func (s *ConfigService) ReloadFromDisk() (changedHot []string, err error) {
 			TurnMultiplier:   next.Agent.TurnMultiplier,
 		})
 	}
+	if slices.Contains(hot, "agent.bash_timeout_seconds") {
+		s.agents.SetBashTimeoutMs(next.BashTimeoutMs())
+	}
 
 	if s.logger != nil {
 		for _, k := range restart {


### PR DESCRIPTION
## Motivation

Hung bash tool calls (e.g. `npm run test` with no TTY, or a blocking process) would stall the agent stream indefinitely. There was no per-tool-call timeout, so agents could be stuck waiting forever on a single bash invocation, wasting cost and compute.

Closes https://github.com/Automaat/sybra/issues/639

## Implementation information

Adds `--bashTimeoutMs` to the `claude -p` invocation in the headless runner. The timeout value defaults to 300s (5 min) and is configurable via `agent.bash_timeout_seconds` in `config.yaml`.

- `internal/config/config.go`: new `BashTimeoutSeconds` field in `AgentDefaults`
- `internal/agent/manager.go`: reads config and passes `--bashTimeoutMs` flag to claude CLI
- `internal/agent/runner_headless.go`: propagates the timeout value through `RunOptions`
- `internal/agent/model.go`: `BashTimeoutMs` field on `RunOptions`
- `internal/sybra/config_diff.go`: emits `agent.bash_timeout_seconds` in diff so hot-reload picks up live changes without restart
- `frontend/bindings/.../config/models.ts`: `bashTimeoutSeconds` added to `AgentDefaults` TS binding to match Go model
- Codex provider is unaffected (it handles its own sandboxing)

> Changelog: fix(agent): enforce per-bash-tool timeout