### PR TITLE
fix(workflow): block cross-task plan contamination

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -625,6 +625,7 @@ export enum StepType {
     StepLinkPRAndReview = "link_pr_and_review",
     StepEvaluate = "evaluate",
     StepRequireSidecar = "require_sidecar",
+    StepValidatePlan = "validate_plan",
     StepTriageReview = "triage_review",
 
     /**

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -140,18 +140,33 @@ func (s *TaskService) UpdateTask(id string, updates map[string]any) (task.Task, 
 	}
 
 	// When manually moved to in-progress with a terminal workflow and no live
-	// agent, restart the workflow so the user doesn't need to manually dispatch.
+	// agent, dispatch via task.status_changed so the trigger system picks the
+	// right workflow for the new status. Naively restarting cur.Workflow.WorkflowID
+	// would replay whatever flow ran before — for tasks created on the
+	// pre-split monolithic `simple-task` (commit 3764ed9) this re-ran triage
+	// and flipped status back to `planning` instead of running implement.
+	// DispatchEvent matches against current trigger conditions, which is what
+	// the user wants: in-progress → simple-task-implement.
 	if s.workflowEngine != nil {
 		if newStatus, ok := updates["status"].(string); ok &&
 			newStatus == string(task.StatusInProgress) &&
 			cur.Workflow != nil &&
 			(cur.Workflow.State == workflow.ExecCompleted || cur.Workflow.State == workflow.ExecFailed) &&
 			!s.agents.HasRunningAgentForTask(id) {
-			wfID := cur.Workflow.WorkflowID
-			s.logger.Info("workflow.restart", "task_id", id, "workflow", wfID)
+			s.logger.Info("workflow.restart", "task_id", id, "from_workflow", cur.Workflow.WorkflowID, "status", newStatus)
 			s.wg.Go(func() {
-				if wfErr := s.workflowEngine.StartWorkflow(id, wfID); wfErr != nil {
+				dispatched, wfErr := s.workflowEngine.DispatchEvent(
+					id,
+					"task.status_changed",
+					map[string]string{"task.status": newStatus},
+					nil,
+				)
+				if wfErr != nil {
 					s.logger.Error("workflow.restart.failed", "task_id", id, "err", wfErr)
+					return
+				}
+				if dispatched == "" {
+					s.logger.Warn("workflow.restart.no-match", "task_id", id, "status", newStatus)
 				}
 			})
 		}

--- a/internal/sybra/svc_tasks_restart_test.go
+++ b/internal/sybra/svc_tasks_restart_test.go
@@ -1,0 +1,95 @@
+package sybra
+
+import (
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
+)
+
+// TestUpdateTask_InProgressDispatchesByTrigger verifies that moving a task
+// to in-progress with a terminal workflow does NOT verbatim-restart the saved
+// workflow_id (the bug for tasks created on the pre-split monolithic
+// `simple-task`, which would re-run triage and flip status back to planning).
+// Instead the engine must dispatch via task.status_changed so trigger
+// conditions select the correct workflow — for in-progress this is
+// simple-task-implement.
+func TestUpdateTask_InProgressDispatchesByTrigger(t *testing.T) {
+	svc, a := setupTaskService(t)
+
+	// Create the task via the manager so CreateTask's auto-start workflow
+	// goroutine doesn't race with our setup.
+	tk, err := a.tasks.Create("retry me", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Attach a fake completed workflow with the OLD pre-split ID. The
+	// previous restart code would replay this verbatim; the fix dispatches
+	// via task.status_changed and matches the post-split implement workflow.
+	staleWf := &workflow.Execution{
+		WorkflowID:  "simple-task",
+		CurrentStep: "",
+		State:       workflow.ExecCompleted,
+	}
+	if _, err := a.tasks.Update(tk.ID, task.Update{Workflow: &staleWf}); err != nil {
+		t.Fatal(err)
+	}
+	// Plan must be present so simple-task-implement has something to feed
+	// the implement agent (matches the post-planning state of fa6919fc).
+	if _, err := a.tasks.Update(tk.ID, task.Update{
+		Plan:   task.Ptr("# Plan\n\nDo the thing.\n"),
+		Status: task.Ptr(task.StatusHumanRequired),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Move to in-progress. The restart goroutine fires DispatchEvent with
+	// task.status_changed. Agent start may fail in the test environment
+	// (no real claude binary), but the workflow_id is persisted on the
+	// task BEFORE agent start, so the assertion below is meaningful.
+	if _, err := svc.UpdateTask(tk.ID, map[string]any{"status": "in-progress"}); err != nil {
+		t.Fatal(err)
+	}
+	svc.wg.Wait()
+
+	got, err := a.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow == nil {
+		t.Fatal("workflow not set after restart")
+	}
+	if got.Workflow.WorkflowID == "simple-task" {
+		t.Errorf("workflow restarted as stale ID %q — restart should dispatch via trigger conditions, not replay the saved id",
+			got.Workflow.WorkflowID)
+	}
+	if got.Workflow.WorkflowID != "simple-task-implement" {
+		t.Errorf("workflow.WorkflowID = %q, want simple-task-implement", got.Workflow.WorkflowID)
+	}
+}
+
+// TestUpdateTask_InProgressNoWorkflowNoOp verifies the restart logic is
+// guarded by `cur.Workflow != nil`: moving a brand-new task to in-progress
+// (no prior workflow attached) must not blow up or dispatch anything.
+func TestUpdateTask_InProgressNoWorkflowNoOp(t *testing.T) {
+	svc, a := setupTaskService(t)
+
+	tk, err := a.tasks.Create("no prior wf", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := svc.UpdateTask(tk.ID, map[string]any{"status": "in-progress"}); err != nil {
+		t.Fatal(err)
+	}
+	svc.wg.Wait()
+
+	got, err := a.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusInProgress {
+		t.Errorf("status = %q, want in-progress", got.Status)
+	}
+}

--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -89,6 +89,20 @@ steps:
           prompt: >-
             Plan task {{.Task.ID}} using the /sybra-plan skill.
 
+            IDENTITY (read first, before anything else):
+              - Your task ID is {{.Task.ID}}.
+              - Your worktree is your current working directory (`pwd`).
+              - Your branch is the checked-out branch
+                (`git rev-parse --abbrev-ref HEAD`).
+              - For the canonical source of truth, read `./.sybra-context.md` —
+                this file is auto-written by Sybra into every task worktree.
+
+            DO NOT reference any other task ID, branch, or worktree path in
+            your plan. If `git branch -a` reveals sibling branches like
+            `sybra/<other-slug>-<other-id>`, IGNORE them — they belong to
+            other concurrent tasks against the same project repo and have
+            nothing to do with you.
+
             Steps:
               1. Run: sybra-cli --json get {{.Task.ID}}
               2. Read the codebase and produce a detailed implementation plan
@@ -121,6 +135,20 @@ steps:
           max_retries: 1
           prompt: >-
             Plan task {{.Task.ID}}.
+
+            IDENTITY (read first, before anything else):
+              - Your task ID is {{.Task.ID}}.
+              - Your worktree is your current working directory (`pwd`).
+              - Your branch is the checked-out branch
+                (`git rev-parse --abbrev-ref HEAD`).
+              - For the canonical source of truth, read `./.sybra-context.md` —
+                this file is auto-written by Sybra into every task worktree.
+
+            DO NOT reference any other task ID, branch, or worktree path in
+            your plan. If `git branch -a` reveals sibling branches like
+            `sybra/<other-slug>-<other-id>`, IGNORE them — they belong to
+            other concurrent tasks against the same project repo and have
+            nothing to do with you.
 
             Steps:
               1. Run: sybra-cli --json get {{.Task.ID}} — read the task
@@ -156,6 +184,15 @@ steps:
       prompt: >-
         Converge the parallel plan drafts for task {{.Task.ID}} into a
         single synthesized plan via /plan-fork.
+
+        IDENTITY (read first, before anything else):
+          - Your task ID is {{.Task.ID}}.
+          - Your worktree is `pwd`. Your branch is
+            `git rev-parse --abbrev-ref HEAD`.
+          - Read `./.sybra-context.md` for the canonical identity beacon.
+          - If a draft mentions a branch, worktree, or task ID that differs
+            from the identity above, that is contamination — strip it out
+            of the synthesized plan and substitute your own identity.
 
         Drafts (read each one before invoking the skill):
         {{- range $name, $content := .Task.PlanDrafts }}
@@ -198,6 +235,23 @@ steps:
     type: require_sidecar
     config:
       sidecar: plan
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
+      - goto: validate_plan_refs
+
+  # Cross-task contamination guard: rejects plans that reference branches or
+  # worktree paths belonging to OTHER tasks. The fa6919fc → a9375bad incident
+  # showed two parallel plan agents against the same project can confabulate a
+  # sibling task's identity into the synthesized plan; the impl agent then
+  # committed to the wrong branch and left fa6919fc's branch empty. Flipping
+  # to human-required keeps the failure visible.
+  - id: validate_plan_refs
+    name: Validate Plan References
+    type: validate_plan
     next:
       - when:
           field: task.status

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -286,7 +286,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			return e.execParallel(taskID, step, wfExec, ctx)
 		case StepWaitHuman:
 			return e.execWaitHuman(taskID, step, wfExec)
-		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepTriageReview:
+		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepTriageReview:
 			// handled below as sync steps
 		default:
 			return fmt.Errorf("unknown step type %q", step.Type)
@@ -358,6 +358,8 @@ func (e *Engine) execSyncStep(taskID string, step *Step, wfExec *Execution, ctx 
 		return e.execEvaluate(taskID, step, wfExec, t)
 	case StepRequireSidecar:
 		return e.execRequireSidecar(taskID, step, t)
+	case StepValidatePlan:
+		return e.execValidatePlan(taskID, step, t)
 	case StepTriageReview:
 		return e.execTriageReview(taskID, step, t)
 	default:

--- a/internal/workflow/engine_validate_plan.go
+++ b/internal/workflow/engine_validate_plan.go
@@ -1,0 +1,82 @@
+package workflow
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// foreignBranchRefRe matches Sybra branch refs of the form
+// `sybra/<slug>-<8hex>`. The trailing 8-hex group is the task ID; if it
+// differs from the current task's ID, the plan is referencing another
+// task's branch — likely cross-task LLM contamination during plan
+// synthesis (see fa6919fc / a9375bad incident).
+var foreignBranchRefRe = regexp.MustCompile(`sybra/[a-z0-9][a-z0-9-]*-([0-9a-f]{8})\b`)
+
+// foreignWorktreePathRe matches Sybra worktree paths of the form
+// `worktrees/<slug>-<8hex>`. Same contamination signal as branch refs.
+var foreignWorktreePathRe = regexp.MustCompile(`worktrees/[a-z0-9][a-z0-9-]*-([0-9a-f]{8})\b`)
+
+// execValidatePlan rejects synthesized plans that reference branches or
+// worktree paths belonging to OTHER tasks. The fa6919fc → a9375bad
+// incident showed that two parallel plan agents against the same project
+// can confabulate a sibling task's identity into the synthesized plan,
+// causing the implementation agent to commit to the wrong branch. Flips
+// the task to human-required so the failure is visible instead of
+// silently advancing into implementation on a contaminated plan.
+//
+// Designed to run AFTER require_plan so the plan field is guaranteed
+// non-empty when this step fires. A trimmed-empty plan is treated as
+// "nothing to validate" and the step passes — require_plan upstream
+// already flipped the task in that case.
+func (e *Engine) execValidatePlan(taskID string, step *Step, t TaskInfo) (StepOutput, error) {
+	plan := t.Plan
+	if strings.TrimSpace(plan) == "" {
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "plan empty (require_plan upstream should have flagged)"}, nil
+	}
+
+	foreign := collectForeignTaskIDs(plan, taskID)
+	if len(foreign) == 0 {
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "plan refs OK"}, nil
+	}
+
+	reason := fmt.Sprintf(
+		"plan references foreign task ID(s) %s — likely cross-task contamination during plan synthesis. Re-dispatch the task or edit the plan manually before approving.",
+		strings.Join(foreign, ", "),
+	)
+	if statusErr := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); statusErr != nil {
+		e.logger.Error("workflow.validate-plan.status", "task_id", taskID, "err", statusErr)
+	}
+	e.logger.Warn("workflow.validate-plan.foreign-refs",
+		"task_id", taskID, "foreign", strings.Join(foreign, ","))
+	return StepOutput{StepID: step.ID, Status: "completed", Output: reason}, nil
+}
+
+// collectForeignTaskIDs scans plan markdown for branch refs and worktree
+// paths whose trailing 8-hex task ID differs from currentID. Returns a
+// sorted, deduplicated slice. Restricted to the two structural patterns
+// (branch refs, worktree paths) so bare 8-hex strings — git short SHAs,
+// hex constants in code samples — never trip the validator.
+func collectForeignTaskIDs(plan, currentID string) []string {
+	seen := make(map[string]struct{})
+	for _, m := range foreignBranchRefRe.FindAllStringSubmatch(plan, -1) {
+		if id := m[1]; id != currentID {
+			seen[id] = struct{}{}
+		}
+	}
+	for _, m := range foreignWorktreePathRe.FindAllStringSubmatch(plan, -1) {
+		if id := m[1]; id != currentID {
+			seen[id] = struct{}{}
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(seen))
+	for id := range seen {
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/workflow/engine_validate_plan_test.go
+++ b/internal/workflow/engine_validate_plan_test.go
@@ -1,0 +1,141 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+)
+
+func newValidatePlanStep() *Step {
+	return &Step{ID: "validate_plan_refs", Type: StepValidatePlan}
+}
+
+func TestExecValidatePlan_CleanPlanPasses(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "planning"})
+	engine := newEngineForEval(t, tasks)
+
+	plan := "# Plan\n\nBranch: `sybra/bk-tree-on-per-base-buckets-fa6919fc`\nEdit src/cleaner.rs:60.\n"
+	out, err := engine.execValidatePlan("fa6919fc", newValidatePlanStep(),
+		TaskInfo{ID: "fa6919fc", Plan: plan})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed", out.Status)
+	}
+	ti, _ := tasks.GetTask("fa6919fc")
+	if ti.Status == "human-required" {
+		t.Errorf("clean plan flipped status to human-required: reason=%q", tasks.Reason("fa6919fc"))
+	}
+}
+
+func TestExecValidatePlan_ForeignBranchRefFlipsHumanRequired(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "planning"})
+	engine := newEngineForEval(t, tasks)
+
+	// Reproduces the fa6919fc → a9375bad incident: plan body cites a sibling
+	// task's worktree path inside the same project.
+	plan := "# Plan\n\nBranch: `sybra/bk-tree-on-per-base-buckets-fa6919fc`\n" +
+		"Worktree: /home/sybra/.sybra/worktrees/cross-base-typo-detection-a9375bad\n"
+	out, err := engine.execValidatePlan("fa6919fc", newValidatePlanStep(),
+		TaskInfo{ID: "fa6919fc", Plan: plan})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed (mechanical step)", out.Status)
+	}
+	ti, _ := tasks.GetTask("fa6919fc")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+	reason := tasks.Reason("fa6919fc")
+	if !strings.Contains(reason, "a9375bad") {
+		t.Errorf("reason = %q, want substring 'a9375bad'", reason)
+	}
+	if !strings.Contains(reason, "contamination") {
+		t.Errorf("reason = %q, want substring 'contamination'", reason)
+	}
+}
+
+func TestExecValidatePlan_ForeignBranchRefAlone(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "planning"})
+	engine := newEngineForEval(t, tasks)
+
+	// Branch ref alone (no worktree path) must still trip the validator.
+	plan := "Use branch sybra/cross-base-typo-detection-a9375bad as base."
+	_, err := engine.execValidatePlan("fa6919fc", newValidatePlanStep(),
+		TaskInfo{ID: "fa6919fc", Plan: plan})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ti, _ := tasks.GetTask("fa6919fc")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+}
+
+func TestExecValidatePlan_EmptyPlanPasses(t *testing.T) {
+	// require_plan upstream should have flagged this; validate_plan must not
+	// double-flip or error.
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "planning"})
+	engine := newEngineForEval(t, tasks)
+
+	out, err := engine.execValidatePlan("fa6919fc", newValidatePlanStep(),
+		TaskInfo{ID: "fa6919fc", Plan: "   \n\t\n"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed", out.Status)
+	}
+	ti, _ := tasks.GetTask("fa6919fc")
+	if ti.Status == "human-required" {
+		t.Errorf("empty plan should not flip status; reason=%q", tasks.Reason("fa6919fc"))
+	}
+}
+
+func TestExecValidatePlan_GitShortShaIgnored(t *testing.T) {
+	// 8-hex git short SHAs in code/commit references must NOT be flagged
+	// as foreign task IDs. The validator only matches structural patterns
+	// (sybra/<slug>-<id>, worktrees/<slug>-<id>).
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "planning"})
+	engine := newEngineForEval(t, tasks)
+
+	plan := "# Plan\n\nFix builds on commit 8e273bcd. Then cherry-pick a1b2c3d4.\n"
+	_, err := engine.execValidatePlan("fa6919fc", newValidatePlanStep(),
+		TaskInfo{ID: "fa6919fc", Plan: plan})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ti, _ := tasks.GetTask("fa6919fc")
+	if ti.Status == "human-required" {
+		t.Errorf("git short SHA tripped validator; reason=%q", tasks.Reason("fa6919fc"))
+	}
+}
+
+func TestCollectForeignTaskIDs_DedupesAndSorts(t *testing.T) {
+	plan := "sybra/foo-aaaaaaaa and again sybra/bar-aaaaaaaa, plus worktrees/baz-bbbbbbbb."
+	got := collectForeignTaskIDs(plan, "fa6919fc")
+	want := []string{"aaaaaaaa", "bbbbbbbb"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestCollectForeignTaskIDs_OwnIDIgnored(t *testing.T) {
+	plan := "sybra/my-slug-fa6919fc and worktrees/my-slug-fa6919fc"
+	got := collectForeignTaskIDs(plan, "fa6919fc")
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty (own ID should be ignored)", got)
+	}
+}

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -85,6 +85,7 @@ const (
 	StepLinkPRAndReview     StepType = "link_pr_and_review"
 	StepEvaluate            StepType = "evaluate"
 	StepRequireSidecar      StepType = "require_sidecar"
+	StepValidatePlan        StepType = "validate_plan"
 	StepTriageReview        StepType = "triage_review"
 	// StepParallel runs its `Parallel` children concurrently as run_agent
 	// steps. The parent step advances only after every child has terminated;

--- a/internal/worktree/context.go
+++ b/internal/worktree/context.go
@@ -1,0 +1,91 @@
+package worktree
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// contextFileName is the per-worktree identity beacon written into every
+// task worktree. Plan and implementation agents read it (or are prompted to)
+// to ground their work in the correct task — defending against LLM
+// confabulation when sibling worktrees in the same project expose unrelated
+// branches via shared bare-repo refs.
+const contextFileName = ".sybra-context.md"
+
+// writeContextFile drops a markdown identity beacon at the worktree root and
+// best-effort-excludes it from `git status` so agents don't accidentally
+// commit it. Errors are surfaced to the caller; the beacon is load-bearing
+// for the planner identity-pinning defense and a silent failure would let
+// the same cross-task contamination class recur.
+func writeContextFile(t task.Task, wtPath, branch string) error {
+	body := renderContextFile(t, wtPath, branch)
+	path := filepath.Join(wtPath, contextFileName)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", contextFileName, err)
+	}
+	addToInfoExclude(wtPath, contextFileName)
+	return nil
+}
+
+func renderContextFile(t task.Task, wtPath, branch string) string {
+	var sb strings.Builder
+	sb.WriteString("# Sybra Task Context\n\n")
+	sb.WriteString("This file is auto-written by Sybra into every task worktree as the\n")
+	sb.WriteString("authoritative identity beacon for agents. **You are working on the task\n")
+	sb.WriteString("described below — ignore any sibling branches you may observe via\n")
+	sb.WriteString("`git branch -a`. They belong to other concurrent tasks against the same\n")
+	sb.WriteString("project and have nothing to do with you.**\n\n")
+	fmt.Fprintf(&sb, "- Task ID: `%s`\n", t.ID)
+	if t.Title != "" {
+		fmt.Fprintf(&sb, "- Title: %s\n", t.Title)
+	}
+	fmt.Fprintf(&sb, "- Branch: `%s`\n", branch)
+	fmt.Fprintf(&sb, "- Worktree: `%s`\n", wtPath)
+	if t.ProjectID != "" {
+		fmt.Fprintf(&sb, "- Project: `%s`\n", t.ProjectID)
+	}
+	sb.WriteString("\nDo NOT commit this file. It is excluded via `.git/info/exclude`.\n")
+	return sb.String()
+}
+
+// addToInfoExclude appends entry to the worktree's per-worktree info/exclude
+// so `git status` and `git add -A` ignore it. Best-effort: a missing or
+// unwritable exclude file is logged elsewhere but not fatal — the beacon is
+// still usable, the agent just risks staging it.
+func addToInfoExclude(wtPath, entry string) {
+	cmd := exec.Command("git", "rev-parse", "--git-path", "info/exclude")
+	cmd.Dir = wtPath
+	out, err := cmd.Output()
+	if err != nil {
+		return
+	}
+	excludePath := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(excludePath) {
+		excludePath = filepath.Join(wtPath, excludePath)
+	}
+	if err := os.MkdirAll(filepath.Dir(excludePath), 0o755); err != nil {
+		return
+	}
+	existing, _ := os.ReadFile(excludePath)
+	line := "/" + entry
+	for raw := range strings.SplitSeq(string(existing), "\n") {
+		if strings.TrimSpace(raw) == line {
+			return
+		}
+	}
+	f, err := os.OpenFile(excludePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	prefix := ""
+	if len(existing) > 0 && !strings.HasSuffix(string(existing), "\n") {
+		prefix = "\n"
+	}
+	_, _ = f.WriteString(prefix + line + "\n")
+}

--- a/internal/worktree/context_test.go
+++ b/internal/worktree/context_test.go
@@ -1,0 +1,95 @@
+package worktree
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func TestWriteContextFile_WritesBeacon(t *testing.T) {
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	wt := t.TempDir()
+	mustRunInDir(t, wt, "git", "init", "-b", "main")
+
+	tk := task.Task{
+		ID:        "fa6919fc",
+		Slug:      "bk-tree-on-per-base-buckets",
+		Title:     "perf(history): implement BK-tree",
+		ProjectID: "Automaat/sybra",
+	}
+	branch := "sybra/bk-tree-on-per-base-buckets-fa6919fc"
+
+	if err := writeContextFile(tk, wt, branch); err != nil {
+		t.Fatalf("writeContextFile: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(wt, contextFileName))
+	if err != nil {
+		t.Fatalf("read beacon: %v", err)
+	}
+	body := string(content)
+	for _, want := range []string{tk.ID, branch, tk.Title, tk.ProjectID, wt} {
+		if !strings.Contains(body, want) {
+			t.Errorf("beacon missing %q. body:\n%s", want, body)
+		}
+	}
+}
+
+func TestWriteContextFile_AddsToInfoExclude(t *testing.T) {
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	wt := t.TempDir()
+	mustRunInDir(t, wt, "git", "init", "-b", "main")
+
+	tk := task.Task{ID: "fa6919fc", Slug: "x", ProjectID: "p/r"}
+	if err := writeContextFile(tk, wt, "sybra/x-fa6919fc"); err != nil {
+		t.Fatalf("writeContextFile: %v", err)
+	}
+
+	out, err := exec.Command("git", "-C", wt, "status", "--porcelain").Output()
+	if err != nil {
+		t.Fatalf("git status: %v", err)
+	}
+	if strings.Contains(string(out), contextFileName) {
+		t.Errorf("expected %s to be ignored by git, got status:\n%s", contextFileName, out)
+	}
+}
+
+func TestWriteContextFile_IdempotentExclude(t *testing.T) {
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	wt := t.TempDir()
+	mustRunInDir(t, wt, "git", "init", "-b", "main")
+
+	tk := task.Task{ID: "fa6919fc", Slug: "x", ProjectID: "p/r"}
+	for range 3 {
+		if err := writeContextFile(tk, wt, "sybra/x-fa6919fc"); err != nil {
+			t.Fatalf("writeContextFile: %v", err)
+		}
+	}
+
+	excludePathBytes, err := exec.Command("git", "-C", wt, "rev-parse", "--git-path", "info/exclude").Output()
+	if err != nil {
+		t.Fatalf("rev-parse: %v", err)
+	}
+	excludePath := strings.TrimSpace(string(excludePathBytes))
+	if !filepath.IsAbs(excludePath) {
+		excludePath = filepath.Join(wt, excludePath)
+	}
+	data, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("read exclude: %v", err)
+	}
+	count := strings.Count(string(data), "/"+contextFileName)
+	if count != 1 {
+		t.Errorf("expected exactly 1 exclude entry, got %d. exclude:\n%s", count, data)
+	}
+}

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -162,6 +162,9 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 			}
 			m.installChecks(wtPath, proj)
 			m.ensureBranch(t, wtBranch)
+			if err := writeContextFile(t, wtPath, wtBranch); err != nil {
+				m.logger.Warn("worktree.context-file", "task_id", t.ID, "err", err)
+			}
 			return wtPath, nil
 		}
 		// Worktree was wiped — fall through to create paths below.
@@ -194,6 +197,9 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 		}
 		m.installChecks(wtPath, proj)
 		m.ensureBranch(t, wtBranch)
+		if err := writeContextFile(t, wtPath, wtBranch); err != nil {
+			m.logger.Warn("worktree.context-file", "task_id", t.ID, "err", err)
+		}
 		return wtPath, nil
 	}
 
@@ -214,6 +220,9 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 	}
 
 	m.ensureBranch(t, wtBranch)
+	if err := writeContextFile(t, wtPath, wtBranch); err != nil {
+		m.logger.Warn("worktree.context-file", "task_id", t.ID, "err", err)
+	}
 	return wtPath, nil
 }
 
@@ -248,6 +257,9 @@ func (m *Manager) PrepareForChat(t task.Task, onPhase func(string)) (string, err
 		if usable {
 			m.logger.Info("chat.worktree.reused", "task_id", t.ID, "path", wtPath)
 			m.ensureBranch(t, wtBranch)
+			if err := writeContextFile(t, wtPath, wtBranch); err != nil {
+				m.logger.Warn("worktree.context-file", "task_id", t.ID, "err", err)
+			}
 			return wtPath, nil
 		}
 		// Worktree was wiped — fall through.
@@ -263,6 +275,9 @@ func (m *Manager) PrepareForChat(t task.Task, onPhase func(string)) (string, err
 			return "", fmt.Errorf("chat setup on reused branch: %w", err)
 		}
 		m.ensureBranch(t, wtBranch)
+		if err := writeContextFile(t, wtPath, wtBranch); err != nil {
+			m.logger.Warn("worktree.context-file", "task_id", t.ID, "err", err)
+		}
 		return wtPath, nil
 	}
 
@@ -274,6 +289,9 @@ func (m *Manager) PrepareForChat(t task.Task, onPhase func(string)) (string, err
 		return "", fmt.Errorf("chat setup on new worktree: %w", err)
 	}
 	m.ensureBranch(t, wtBranch)
+	if err := writeContextFile(t, wtPath, wtBranch); err != nil {
+		m.logger.Warn("worktree.context-file", "task_id", t.ID, "err", err)
+	}
 	return wtPath, nil
 }
 


### PR DESCRIPTION
## Motivation

Task fa6919fc was flagged sybra_bug after parallel plan agents
against the same project (Automaat/zsh-clean-history) produced a
synthesized plan that cited the sibling task a9375bad's worktree
path. The implementation agent then committed to the wrong branch,
leaving fa6919fc's branch empty.

Root cause: the bare-repo refs are shared across worktrees, so
`git branch -a` in fa6919fc's worktree exposes a9375bad's branch.
The planner LLM confabulated that branch name into the plan body.

A second issue surfaced when retrying: moving fa6919fc back to
in-progress dispatched the saved workflow_id `simple-task` (the
pre-split monolithic flow, commit 3764ed9), re-running triage and
flipping status back to planning instead of running implement.

## Implementation information

Three layered defenses for the contamination class plus a fix
for the restart routing.

1. `feat(worktree)` — write `.sybra-context.md` at the worktree
   root with task ID, branch, project. Best-effort added to the
   per-worktree `info/exclude` so it stays out of git status.
   Acts as a tamper-resistant identity beacon for agents.

2. `feat(workflow)` — pin planner identity in plan_claude /
   plan_codex / converge_plans prompts: an IDENTITY block tells
   the planner to use pwd / current branch and ignore sibling
   refs. Plus a new `validate_plan` step after `require_plan`
   that regex-scans the synthesized plan for foreign branch refs
   (`sybra/<slug>-<8hex>`) and worktree paths
   (`worktrees/<slug>-<8hex>`); foreign hits flip the task to
   human-required. Restricted to structural patterns so git short
   SHAs never false-positive.

3. `fix(sybra)` — UpdateTask in-progress restart now dispatches
   `task.status_changed` instead of replaying the saved
   workflow_id. Trigger conditions are authoritative: in-progress
   correctly routes to simple-task-implement regardless of what
   flow ran originally.

10 new unit tests cover the validator (incl. the live fa6919fc
plan body as a regression case), the beacon, and the restart
routing. Lint + full Go test suite green.

## Supporting documentation

Considered but rejected: hard ref isolation (separate clones
per task or git namespaces) — too invasive vs the marginal gain
over prompt pinning + validator.

> Changelog: feat(workflow): block cross-task plan contamination