### PR TITLE
ci(renovate): detect Dockerfile ARG version pins

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -65,5 +65,15 @@
       "extractVersion": "^v(?<version>.*)$",
       "automerge": true
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update ARGs annotated with `# renovate: datasource=… depName=…` in Dockerfiles",
+      "managerFilePatterns": ["(^|/)Dockerfile$"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+?)\\s+depName=(?<depName>[^\\s]+?)(\\s+versioning=(?<versioning>[a-z-]+?))?\\s*\\nARG\\s+[A-Z0-9_]+=(?<currentValue>[^\\s]+)"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Motivation

No Renovate PRs were opened to bump `@anthropic-ai/claude-code`, `@openai/codex`, `klaudiush`, or `mise` despite the `# renovate: datasource=… depName=…` annotations in `Dockerfile`.

Root cause: Renovate's built-in Dockerfile manager only parses `FROM` lines. The annotated ARGs require a `customManagers` regex matcher to be picked up. None was configured, so the comments were decorative.

Drift caught by this fix:
- `@anthropic-ai/claude-code` `2.1.104` → `2.1.133`
- `@openai/codex` `0.120.0` → `0.129.0`
- `klaudiush`, `mise` also stale

Confirmed via Dependency Dashboard (#3) — Detected Dependencies for the Dockerfile lists only the 3 `FROM` images.

## Implementation information

Added a `customManagers` block with a single regex matcher targeting any Dockerfile. Pattern:

- captures `datasource`, `depName`, optional `versioning` from the `# renovate:` comment
- captures `currentValue` from the next-line `ARG NAME=value`

Validated with `renovate-config-validator`. Regex tested against the current `Dockerfile`; matches all four annotated ARGs:

```
{datasource: github-releases, depName: smykla-skalski/klaudiush, currentValue: v1.32.0}
{datasource: npm,             depName: @anthropic-ai/claude-code, currentValue: 2.1.104}
{datasource: npm,             depName: @openai/codex,             currentValue: 0.120.0}
{datasource: github-releases, depName: jdx/mise,                   currentValue: v2026.4.15}
```

The existing klaudiush packageRule (`extractVersion`, `automerge: true`) keeps applying — `matchPackageNames` is the only join.

## Supporting documentation

- Renovate customManagers: https://docs.renovatebot.com/configuration-options/#custommanagers
- Dependency Dashboard: #3

> Changelog: skip