### PR TITLE
ci(renovate): wrap Dockerfile pattern as regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -70,7 +70,7 @@
     {
       "customType": "regex",
       "description": "Update ARGs annotated with `# renovate: datasource=… depName=…` in Dockerfiles",
-      "managerFilePatterns": ["(^|/)Dockerfile$"],
+      "managerFilePatterns": ["/(^|/)Dockerfile$/"],
       "matchStrings": [
         "#\\s*renovate:\\s*datasource=(?<datasource>[a-z-]+?)\\s+depName=(?<depName>[^\\s]+?)(\\s+versioning=(?<versioning>[a-z-]+?))?\\s*\\nARG\\s+[A-Z0-9_]+=(?<currentValue>[^\\s]+)"
       ]


### PR DESCRIPTION
## Motivation

PR #650 added a customManager to bump `CLAUDE_CODE_VERSION`, `CODEX_VERSION`, `KLAUDIUSH_VERSION`, `MISE_VERSION` ARGs in the Dockerfile, but no PRs ever opened and the Dependency Dashboard never listed those deps.

Root cause: `managerFilePatterns` entries are minimatch globs by default; regex patterns must be wrapped in `/.../`. The unwrapped `(^|/)Dockerfile$` was parsed as a glob, matched zero files, and the customManager was silently dropped. Renovate config validation passed, regex itself was correct, only the file-pattern syntax was wrong.

This is the reason synapse is currently bricked — claude CLI 2.1.104 in the deployed image does not recognize `--bashTimeoutMs` (added in v0.36.0 / PR #648), so every headless claude agent exits in 200ms with `unknown option '--bashTimeoutMs'`. With the fix in this PR, Renovate will open a bump PR for `@anthropic-ai/claude-code` and unblock the fleet.

## Implementation information

```diff
- "managerFilePatterns": ["(^|/)Dockerfile$"],
+ "managerFilePatterns": ["/(^|/)Dockerfile$/"],
```

Verified locally with `renovate --platform=local --dry-run=full`:

- before: `Matched 1 file(s) for manager regex: <none>`
- after: `Matched 1 file(s) for manager regex: Dockerfile` and 4 deps surface (`@anthropic-ai/claude-code`, `@openai/codex`, `smykla-skalski/klaudiush`, `jdx/mise`).

## Supporting documentation

- PR #650 — original customManager (introduced the bug)
- PR #648 — `--bashTimeoutMs` flag that requires the bump
- Renovate docs: <https://docs.renovatebot.com/configuration-options/#managerfilepatterns>

> Changelog: ci(renovate): wrap Dockerfile pattern as regex