### PR TITLE
fix(renovate): drop parens in PR search query

### DIFF
--- a/internal/github/renovate.go
+++ b/internal/github/renovate.go
@@ -134,28 +134,28 @@ func searchRenovatePRsWith(e execer, query string) ([]RenovatePR, error) {
 	return convertRenovatePRs(gqlResp.Data.Search.Nodes, gqlResp.Data.Viewer.Login), nil
 }
 
+// buildRenovateSearchQuery composes a GitHub issue-search query string.
+//
+// GitHub search treats parentheses and the `OR` keyword as text matches
+// rather than boolean grouping, so wrapping qualifiers in `(a OR b)`
+// silently returns zero results. Repeated same-name qualifiers act as an
+// implicit OR — `author:a author:b repo:x repo:y` is the only form that
+// works.
 func buildRenovateSearchQuery(authors, repos []string) string {
-	var authorParts []string
+	parts := []string{"is:pr", "is:open"}
 	for _, author := range authors {
 		if strings.TrimSpace(author) == "" {
 			continue
 		}
-		authorParts = append(authorParts, "author:"+author)
+		parts = append(parts, "author:"+author)
 	}
-
-	var repoParts []string
 	for _, repo := range repos {
 		if strings.TrimSpace(repo) == "" {
 			continue
 		}
-		repoParts = append(repoParts, "repo:"+repo)
+		parts = append(parts, "repo:"+repo)
 	}
-
-	return fmt.Sprintf(
-		"is:pr is:open (%s) (%s)",
-		strings.Join(authorParts, " OR "),
-		strings.Join(repoParts, " OR "),
-	)
+	return strings.Join(parts, " ")
 }
 
 func convertRenovatePRs(nodes []gqlPR, viewer string) []RenovatePR {

--- a/internal/github/renovate_test.go
+++ b/internal/github/renovate_test.go
@@ -69,7 +69,7 @@ func TestBuildRenovateSearchQuery(t *testing.T) {
 		[]string{"app/renovate", "renovate[bot]"},
 		[]string{"acme/api", "acme/web"},
 	)
-	want := "is:pr is:open (author:app/renovate OR author:renovate[bot]) (repo:acme/api OR repo:acme/web)"
+	want := "is:pr is:open author:app/renovate author:renovate[bot] repo:acme/api repo:acme/web"
 	if got != want {
 		t.Fatalf("query = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Motivation

The Renovate tab in the GitHub view was empty even when open
Renovate PRs existed across registered projects. Root cause:
`buildRenovateSearchQuery` produced
`is:pr is:open (author:a OR author:b) (repo:x OR repo:y)`. GitHub
issue search treats parentheses and the `OR` keyword as plain
text, not boolean grouping, so the entire query matched zero
results. Verified with a live `gh api graphql` repro: the
parenthesized form returns `[]`, the space-separated form
returns 47 PRs across the user's repos.

## Implementation information

Replaced the parenthesized `OR`-joined fmt.Sprintf with a
space-joined qualifier list. Multiple same-name qualifiers
(`author:a author:b`, `repo:x repo:y`) act as implicit OR — the
syntax GitHub search actually supports. Updated the unit test
to assert the new query string and added a doc comment that
explains why the obvious-looking grouping breaks.

Considered and rejected: keeping per-author OR via separate
search calls (extra rate-limit cost, more complex chunking).

> Changelog: fix(renovate): drop parens in PR search query

## Supporting documentation

GitHub Search syntax docs:
https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests