### PR TITLE
fix(agent): use env vars for claude bash timeout

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -34,7 +34,9 @@ export class AgentDefaults {
 
     /**
      * BashTimeoutSeconds sets the per-bash-tool-call timeout passed to
-     * claude -p via --bashTimeoutMs. 0 means use DefaultBashTimeoutSeconds (300).
+     * claude -p via the BASH_DEFAULT_TIMEOUT_MS / BASH_MAX_TIMEOUT_MS env
+     * vars (claude has no equivalent CLI flag). 0 means use
+     * DefaultBashTimeoutSeconds (300).
      */
     "bashTimeoutSeconds": number;
 

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -371,8 +371,10 @@ type RunConfig struct {
 	// MaxTurns overrides the global guardrail for this specific agent run.
 	// Zero means "use the manager's global guardrail".
 	MaxTurns int
-	// BashTimeoutMs sets --bashTimeoutMs on the claude CLI for this run.
-	// Zero means "use the manager's default".
+	// BashTimeoutMs sets the Bash tool timeout for this run by exporting
+	// BASH_DEFAULT_TIMEOUT_MS and BASH_MAX_TIMEOUT_MS into the claude
+	// subprocess (claude exposes no equivalent CLI flag). Zero means "use
+	// the manager's default".
 	BashTimeoutMs int
 }
 

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -72,7 +73,7 @@ done:
 }
 
 func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File) (retry bool, err error) {
-	name, args, command, err := buildHeadlessInvocation(a, cfg)
+	name, args, invokeEnv, command, err := buildHeadlessInvocation(a, cfg)
 	if err != nil {
 		return false, err
 	}
@@ -82,8 +83,9 @@ func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfi
 	if a.sessionCWD != "" {
 		cmd.Dir = a.sessionCWD
 	}
-	if len(cfg.ExtraEnv) > 0 {
-		cmd.Env = append(os.Environ(), cfg.ExtraEnv...)
+	if len(cfg.ExtraEnv) > 0 || len(invokeEnv) > 0 {
+		cmd.Env = append(os.Environ(), invokeEnv...)
+		cmd.Env = append(cmd.Env, cfg.ExtraEnv...)
 	}
 	a.Command = command
 
@@ -457,7 +459,11 @@ func (m *Manager) effectiveMaxTurns(a *Agent) int {
 	return global
 }
 
-func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args []string, command string, err error) {
+// buildHeadlessInvocation builds the subprocess invocation for a headless
+// agent. The returned env slice contains "KEY=VALUE" entries the caller must
+// merge into cmd.Env (Bash tool timeout for claude is delivered this way —
+// claude has no CLI flag for it).
+func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args, env []string, command string, err error) {
 	if a.Provider != "claude" && a.Provider != "codex" {
 		err = fmt.Errorf("unsupported provider: %s", a.Provider)
 		return
@@ -503,7 +509,15 @@ func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args []strin
 		args = append(args, "--model", a.Model)
 	}
 	if cfg.BashTimeoutMs > 0 {
-		args = append(args, "--bashTimeoutMs", fmt.Sprintf("%d", cfg.BashTimeoutMs))
+		// Claude has no `--bashTimeoutMs` CLI flag — the supported channel is
+		// the BASH_DEFAULT_TIMEOUT_MS / BASH_MAX_TIMEOUT_MS env vars. Set both
+		// so the configured value is honored even when it exceeds claude's
+		// built-in max (600000 ms).
+		ms := strconv.Itoa(cfg.BashTimeoutMs)
+		env = append(env,
+			"BASH_DEFAULT_TIMEOUT_MS="+ms,
+			"BASH_MAX_TIMEOUT_MS="+ms,
+		)
 	}
 	command = "claude " + strings.Join(args, " ")
 	return

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -660,7 +660,7 @@ func TestBuildHeadlessInvocation_RejectsShellInjection(t *testing.T) {
 	for _, bad := range injections {
 		t.Run("tool_"+bad, func(t *testing.T) {
 			a := &Agent{ID: "a", Provider: "claude"}
-			_, _, _, err := buildHeadlessInvocation(a, RunConfig{
+			_, _, _, _, err := buildHeadlessInvocation(a, RunConfig{
 				Prompt:       "ok",
 				AllowedTools: []string{bad},
 			})
@@ -673,7 +673,7 @@ func TestBuildHeadlessInvocation_RejectsShellInjection(t *testing.T) {
 	for _, bad := range []string{"sonnet --extra-flag", "opus;id", "gpt-5 $(id)", "model\"inject"} {
 		t.Run("model_"+bad, func(t *testing.T) {
 			a := &Agent{ID: "a", Provider: "claude", Model: bad}
-			_, _, _, err := buildHeadlessInvocation(a, RunConfig{Prompt: "ok"})
+			_, _, _, _, err := buildHeadlessInvocation(a, RunConfig{Prompt: "ok"})
 			if err == nil {
 				t.Errorf("buildHeadlessInvocation accepted injection model %q; safeArgRe must reject", bad)
 			}
@@ -682,7 +682,7 @@ func TestBuildHeadlessInvocation_RejectsShellInjection(t *testing.T) {
 
 	// Sanity check: safe tool and model names are accepted.
 	a := &Agent{ID: "a", Provider: "claude", Model: "sonnet"}
-	_, _, _, err := buildHeadlessInvocation(a, RunConfig{
+	_, _, _, _, err := buildHeadlessInvocation(a, RunConfig{
 		Prompt:       "ok",
 		AllowedTools: []string{"Bash", "Read", "Write"},
 	})
@@ -762,44 +762,53 @@ func TestGuardrails_PerAgentOverrideLower(t *testing.T) {
 	}
 }
 
-// TestBuildHeadlessInvocation_BashTimeoutMs verifies that --bashTimeoutMs is
-// included when cfg.BashTimeoutMs > 0, and absent when it is zero.
-func TestBuildHeadlessInvocation_BashTimeoutMs(t *testing.T) {
-	t.Run("included_when_set", func(t *testing.T) {
+// TestBuildHeadlessInvocation_BashTimeout verifies that the Bash tool timeout
+// is delivered to claude via BASH_DEFAULT_TIMEOUT_MS / BASH_MAX_TIMEOUT_MS env
+// vars (claude has no `--bashTimeoutMs` CLI flag) when cfg.BashTimeoutMs > 0,
+// and that no timeout is injected when it is zero or for codex.
+func TestBuildHeadlessInvocation_BashTimeout(t *testing.T) {
+	t.Run("env_set_for_claude", func(t *testing.T) {
 		a := &Agent{ID: "a", Provider: "claude"}
-		_, args, _, err := buildHeadlessInvocation(a, RunConfig{
+		_, args, env, _, err := buildHeadlessInvocation(a, RunConfig{
 			Prompt:        "hi",
 			BashTimeoutMs: 300000,
 		})
 		if err != nil {
 			t.Fatalf("buildHeadlessInvocation: %v", err)
 		}
-		idx := slices.Index(args, "--bashTimeoutMs")
-		if idx == -1 {
-			t.Fatal("--bashTimeoutMs not found in args")
+		if slices.Contains(args, "--bashTimeoutMs") {
+			t.Fatal("--bashTimeoutMs is not a real claude CLI flag and must not appear in args")
 		}
-		if idx+1 >= len(args) || args[idx+1] != "300000" {
-			t.Fatalf("--bashTimeoutMs value = %q, want 300000", args[idx+1])
+		want := []string{
+			"BASH_DEFAULT_TIMEOUT_MS=300000",
+			"BASH_MAX_TIMEOUT_MS=300000",
+		}
+		for _, w := range want {
+			if !slices.Contains(env, w) {
+				t.Errorf("env missing %q; got %v", w, env)
+			}
 		}
 	})
 
-	t.Run("absent_when_zero", func(t *testing.T) {
+	t.Run("env_absent_when_zero", func(t *testing.T) {
 		a := &Agent{ID: "a", Provider: "claude"}
-		_, args, _, err := buildHeadlessInvocation(a, RunConfig{
+		_, _, env, _, err := buildHeadlessInvocation(a, RunConfig{
 			Prompt:        "hi",
 			BashTimeoutMs: 0,
 		})
 		if err != nil {
 			t.Fatalf("buildHeadlessInvocation: %v", err)
 		}
-		if slices.Contains(args, "--bashTimeoutMs") {
-			t.Fatal("--bashTimeoutMs must be absent when BashTimeoutMs == 0")
+		for _, e := range env {
+			if strings.HasPrefix(e, "BASH_DEFAULT_TIMEOUT_MS=") || strings.HasPrefix(e, "BASH_MAX_TIMEOUT_MS=") {
+				t.Fatalf("bash timeout env must be absent when BashTimeoutMs == 0; got %q", e)
+			}
 		}
 	})
 
-	t.Run("not_passed_to_codex", func(t *testing.T) {
+	t.Run("not_set_for_codex", func(t *testing.T) {
 		a := &Agent{ID: "a", Provider: "codex"}
-		_, args, _, err := buildHeadlessInvocation(a, RunConfig{
+		_, args, env, _, err := buildHeadlessInvocation(a, RunConfig{
 			Prompt:        "hi",
 			BashTimeoutMs: 300000,
 		})
@@ -808,6 +817,11 @@ func TestBuildHeadlessInvocation_BashTimeoutMs(t *testing.T) {
 		}
 		if slices.Contains(args, "--bashTimeoutMs") {
 			t.Fatal("--bashTimeoutMs must not be passed to codex")
+		}
+		for _, e := range env {
+			if strings.HasPrefix(e, "BASH_DEFAULT_TIMEOUT_MS=") || strings.HasPrefix(e, "BASH_MAX_TIMEOUT_MS=") {
+				t.Fatalf("bash timeout env must not be set for codex; got %q", e)
+			}
 		}
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,7 +73,9 @@ type AgentDefaults struct {
 	// Set to false in config to opt all tasks into skip-permissions mode.
 	RequirePermissions *bool `yaml:"require_permissions" json:"requirePermissions"`
 	// BashTimeoutSeconds sets the per-bash-tool-call timeout passed to
-	// claude -p via --bashTimeoutMs. 0 means use DefaultBashTimeoutSeconds (300).
+	// claude -p via the BASH_DEFAULT_TIMEOUT_MS / BASH_MAX_TIMEOUT_MS env
+	// vars (claude has no equivalent CLI flag). 0 means use
+	// DefaultBashTimeoutSeconds (300).
 	BashTimeoutSeconds int `yaml:"bash_timeout_seconds" json:"bashTimeoutSeconds"`
 	// MaxLogEvents caps how many NDJSON events are returned when replaying
 	// a completed agent's log file. 0 means use DefaultMaxLogEvents (500).
@@ -89,8 +91,8 @@ type AgentDefaults struct {
 // BashTimeoutSeconds is not set in config.
 const DefaultBashTimeoutSeconds = 300
 
-// BashTimeoutMs returns the bash tool timeout in milliseconds, ready for
-// passing to claude -p --bashTimeoutMs.
+// BashTimeoutMs returns the bash tool timeout in milliseconds, exported into
+// the claude subprocess as BASH_DEFAULT_TIMEOUT_MS / BASH_MAX_TIMEOUT_MS.
 func (c *Config) BashTimeoutMs() int {
 	if c != nil && c.Agent.BashTimeoutSeconds > 0 {
 		return c.Agent.BashTimeoutSeconds * 1000


### PR DESCRIPTION
## Motivation

Headless tasks were getting stuck in `human-required` immediately after
being moved to `in-progress`. Root cause: Sybra was passing
`--bashTimeoutMs <ms>` to `claude -p`, but **that flag does not exist**.
Claude exits 1 with `error: unknown option '--bashTimeoutMs'`, the
implement step records zero commits, and `verify_commits` flips the
task back to `human-required` with `status_reason: no commits pushed to branch`.

The supported channel for the Bash-tool timeout is the
`BASH_DEFAULT_TIMEOUT_MS` / `BASH_MAX_TIMEOUT_MS` env vars (per
docs.claude.com/en/docs/claude-code/settings).

## Implementation information

- `buildHeadlessInvocation` now also returns an env slice; the claude
  branch populates `BASH_DEFAULT_TIMEOUT_MS` and `BASH_MAX_TIMEOUT_MS`
  (both, so values above claude's built-in 600 000 ms cap still apply)
  when `cfg.BashTimeoutMs > 0`. The bogus CLI flag is gone.
- `runHeadlessAttempt` merges that env with `cfg.ExtraEnv` onto
  `cmd.Env`. Order: `os.Environ()` first, then invocation env, then
  caller `ExtraEnv` (so caller overrides win).
- Codex path unchanged — no env injection, no flag.
- `RunConfig.BashTimeoutMs` and `Config.BashTimeoutMs()` doc comments
  updated to reflect the new mechanism.
- `TestBuildHeadlessInvocation_BashTimeout` rewritten to assert env vars
  are present for claude, absent at zero, and never set for codex; also
  asserts the fake flag never appears in args.

Considered probing `claude --help` for flag support and toggling — rejected:
adds startup cost and a new failure mode for a flag that simply isn't
real, while the env-var route already works on every supported claude
version.

## Supporting documentation

- [Claude Code settings (BASH_DEFAULT_TIMEOUT_MS)](https://docs.claude.com/en/docs/claude-code/settings)
- [Issue #5615 — timeout configuration guide](https://github.com/anthropics/claude-code/issues/5615)

> Changelog: fix(agent): use env vars for claude bash timeout