### PR TITLE
fix(workflow): verify_commits done at base

### DIFF
--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -3283,14 +3283,18 @@ func TestE2E_ProviderCrossUnavailable_FallsBackToDefault(t *testing.T) {
 	}
 }
 
-func TestE2E_VerifyCommits_NoAheadFlipsHumanRequired(t *testing.T) {
+// TestE2E_VerifyCommits_BranchAtBaseMarksDone covers verify_commits when the
+// worktree HEAD matches origin/main (rebased branch with no commits ahead).
+// The implementation is already on origin from a prior merge, so the step
+// marks the task done and ends the workflow instead of routing to
+// set_ready_review (which would otherwise loop forever via the auto-restart
+// in svc_tasks.UpdateTask).
+func TestE2E_VerifyCommits_BranchAtBaseMarksDone(t *testing.T) {
 	env := setupE2EMultiProvider(t, "claude", []string{"triage", "success"})
-	// verify_commits lives in simple-task-implement; the cascade in
-	// setupE2EMultiProvider hands off plan → implement on status=in-progress.
 	loadBuiltinWorkflow(t, env, "simple-task-plan")
 	loadBuiltinWorkflow(t, env, "simple-task-implement")
 
-	created, err := env.tasks.Create("verify commits no ahead", "", "headless")
+	created, err := env.tasks.Create("verify commits branch at base", "", "headless")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3303,7 +3307,6 @@ func TestE2E_VerifyCommits_NoAheadFlipsHumanRequired(t *testing.T) {
 		t.Fatal(err)
 	}
 	initRepoWithOriginMain(t, worktreePath)
-	runCmd(t, worktreePath, "git", "log", "origin/main..HEAD", "--oneline")
 
 	if err := env.startWorkflow(created.ID, "simple-task-plan"); err != nil {
 		t.Fatal(err)
@@ -3317,24 +3320,24 @@ func TestE2E_VerifyCommits_NoAheadFlipsHumanRequired(t *testing.T) {
 	})
 
 	tk, _ := env.tasks.Get(created.ID)
-	if tk.Status != task.StatusHumanRequired {
-		t.Fatalf("status = %q, want human-required", tk.Status)
+	if tk.Status != task.StatusDone {
+		t.Fatalf("status = %q, want done", tk.Status)
 	}
-	if tk.StatusReason != "no commits pushed to branch" {
+	if !strings.Contains(tk.StatusReason, "branch identical to base") {
 		var verifyOut string
 		for i := range tk.Workflow.StepHistory {
 			if tk.Workflow.StepHistory[i].StepID == "verify_commits" {
 				verifyOut = tk.Workflow.StepHistory[i].Output
 			}
 		}
-		t.Fatalf("status_reason = %q, want no commits pushed to branch (verify_commits output=%q)", tk.StatusReason, verifyOut)
+		t.Fatalf("status_reason = %q, want 'branch identical to base' (verify_commits output=%q)", tk.StatusReason, verifyOut)
 	}
 	stepIDs := stepIDsFromHistory(tk.Workflow)
 	if !slices.Contains(stepIDs, "verify_commits") {
 		t.Fatalf("verify_commits missing from history: %v", stepIDs)
 	}
-	if slices.Contains(stepIDs, "link_pr_and_review") || slices.Contains(stepIDs, "evaluate") {
-		t.Fatalf("unexpected fallback steps executed after verify_commits gate: %v", stepIDs)
+	if slices.Contains(stepIDs, "set_ready_review") {
+		t.Fatalf("unexpected set_ready_review executed after verify_commits done-gate: %v", stepIDs)
 	}
 }
 

--- a/internal/workflow/builtin/pr-fix.yaml
+++ b/internal/workflow/builtin/pr-fix.yaml
@@ -42,6 +42,13 @@ steps:
           operator: equals
           value: human-required
         goto: ""
+      # Branch identical to base after fix attempt → fix landed via a different
+      # branch; verify_commits set status=done and we end the workflow.
+      - when:
+          field: task.status
+          operator: equals
+          value: done
+        goto: ""
       - goto: link_pr_and_review
 
   # Non-LLM step: recover PR number from task, agent result history, or

--- a/internal/workflow/builtin/simple-task-implement.yaml
+++ b/internal/workflow/builtin/simple-task-implement.yaml
@@ -54,6 +54,14 @@ steps:
           operator: equals
           value: human-required
         goto: ""
+      # Branch identical to base after rebase → fix already on origin from a
+      # prior merge; verify_commits set status=done and we end the workflow
+      # instead of re-flipping to ready-review.
+      - when:
+          field: task.status
+          operator: equals
+          value: done
+        goto: ""
       - goto: set_ready_review
 
   # Terminal hand-off to simple-task-review: flip status to ready-review

--- a/internal/workflow/engine_steps.go
+++ b/internal/workflow/engine_steps.go
@@ -669,6 +669,22 @@ func (e *Engine) execVerifyCommits(taskID string, step *Step, t TaskInfo) (StepO
 	}
 
 	if strings.TrimSpace(string(output)) == "" {
+		// Disambiguate "no commits ahead" between two cases:
+		//   (a) HEAD == base ref tip → branch is identical to base. Implementation
+		//       was already on origin (e.g. merged via a different branch before
+		//       this task ran). Re-running implement would loop forever because
+		//       there is nothing left to do. Mark done so the auto-restart in
+		//       svc_tasks.UpdateTask doesn't bounce the task back to in-progress.
+		//   (b) HEAD != base → branch diverged but has zero fast-forward commits.
+		//       Genuine "agent did nothing"; flip to human-required as before.
+		if branchAtBase(e.ctx, wtPath) {
+			reason := "branch identical to base — implementation already on origin"
+			if statusErr := e.tasks.UpdateTaskStatus(taskID, "done", reason); statusErr != nil {
+				e.logger.Error("workflow.verify-commits.status", "task_id", taskID, "err", statusErr)
+			}
+			e.logger.Info("workflow.verify-commits.branch-at-base", "task_id", taskID)
+			return StepOutput{StepID: step.ID, Status: "completed", Output: "branch at base: marked done"}, nil
+		}
 		reason := "no commits pushed to branch"
 		if statusErr := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); statusErr != nil {
 			e.logger.Error("workflow.verify-commits.status", "task_id", taskID, "err", statusErr)
@@ -677,6 +693,34 @@ func (e *Engine) execVerifyCommits(taskID string, step *Step, t TaskInfo) (StepO
 	}
 
 	return StepOutput{StepID: step.ID, Status: "completed", Output: "commits verified"}, nil
+}
+
+// branchAtBase reports whether the worktree's HEAD points at the same commit
+// as the resolved origin base ref. Used by execVerifyCommits to distinguish
+// "fix already merged elsewhere" from "agent did nothing".
+func branchAtBase(parentCtx context.Context, wtPath string) bool {
+	ctx, cancel := context.WithTimeout(parentCtx, shellTimeout)
+	defer cancel()
+	baseRef := resolveOriginBase(ctx, wtPath)
+	headSHA, err := gitRevParse(ctx, wtPath, "HEAD")
+	if err != nil || headSHA == "" {
+		return false
+	}
+	baseSHA, err := gitRevParse(ctx, wtPath, baseRef)
+	if err != nil || baseSHA == "" {
+		return false
+	}
+	return headSHA == baseSHA
+}
+
+func gitRevParse(ctx context.Context, wtPath, ref string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--verify", ref)
+	cmd.Dir = wtPath
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 // triageReviewLineLimit and triageReviewFileLimit are the hard ceilings under

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2616,14 +2616,52 @@ func TestExecVerifyCommits_RetriesAfterTransientFailure(t *testing.T) {
 	}
 }
 
-func TestExecVerifyCommits_NoCommitsFlipsHumanRequired(t *testing.T) {
+// TestExecVerifyCommits_BranchAtBaseMarksDone covers the case where the
+// agent committed nothing because the implementation was already on
+// origin/main (e.g. merged via a different branch). HEAD == origin/main, so
+// the task is marked done instead of human-required to avoid an infinite
+// auto-restart loop in svc_tasks.UpdateTask.
+func TestExecVerifyCommits_BranchAtBaseMarksDone(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	agents := newMockAgents()
 	engine := NewEngine(store, tasks, agents, discardLogger())
 
-	wtDir := makeGitRepo(t, false /* no extra commit */)
+	wtDir := makeGitRepo(t, false /* no extra commit; HEAD == origin/main */)
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
+
+	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed", out.Status)
+	}
+	if !strings.Contains(out.Output, "branch at base") {
+		t.Errorf("Output = %q, want 'branch at base'", out.Output)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "done" {
+		t.Errorf("task status = %q, want done", ti.Status)
+	}
+	if reason := tasks.Reason("t1"); !strings.Contains(reason, "branch identical to base") {
+		t.Errorf("status reason = %q, want 'branch identical to base'", reason)
+	}
+}
+
+// TestExecVerifyCommits_DivergentNoCommitsFlipsHumanRequired covers the
+// genuine "agent did nothing" path: HEAD is behind origin/main (not at base
+// tip) and no commits exist ahead. We can't conclude the work is on origin,
+// so flip to human-required as before.
+func TestExecVerifyCommits_DivergentNoCommitsFlipsHumanRequired(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	wtDir := makeGitRepoBehindOrigin(t)
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
 
 	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), TaskInfo{ID: "t1"})
@@ -2640,6 +2678,47 @@ func TestExecVerifyCommits_NoCommitsFlipsHumanRequired(t *testing.T) {
 	if ti.Status != "human-required" {
 		t.Errorf("task status = %q, want human-required", ti.Status)
 	}
+}
+
+// makeGitRepoBehindOrigin builds a worktree where HEAD is behind origin/main:
+// origin/main points at commit B, HEAD is reset back to commit A. Used to
+// exercise the "no commits ahead, HEAD != base" branch of execVerifyCommits.
+func makeGitRepoBehindOrigin(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	run("init", "-b", "main")
+	run("config", "user.email", "test@test.com")
+	run("config", "user.name", "Test")
+
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "a.txt")
+	run("commit", "-m", "A")
+	if err := os.WriteFile(filepath.Join(dir, "b.txt"), []byte("b\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "b.txt")
+	run("commit", "-m", "B")
+
+	// origin tracks current HEAD (commit B).
+	run("remote", "add", "origin", dir)
+	run("fetch", "origin")
+
+	// Rewind HEAD to commit A — now origin/main is ahead of HEAD.
+	run("reset", "--hard", "HEAD~1")
+
+	return dir
 }
 
 // --- require_sidecar step ---


### PR DESCRIPTION
## Motivation

User couldn't move task `6b81bb07` from `human-required` → `in-progress`: the move succeeded, but the workflow auto-restart in `svc_tasks.UpdateTask` immediately re-ran `simple-task-implement`, which advanced through `implement` (agent: "nothing to do, fix already on main") into `verify_commits`, which saw zero commits ahead of `origin/main` and flipped the status straight back. Infinite loop.

Root cause: `execVerifyCommits` treats *empty `git log origin/main..HEAD`* as "agent didn't push commits" without considering the case where the worktree HEAD is identical to `origin/main` — i.e. the fix was already merged via a different branch (here, the Rust rewrite at `ee5c5c9` had already landed `File::open(parent)?.sync_all()?`).

## Implementation information

`execVerifyCommits` now disambiguates the empty-diff case with a HEAD-vs-base SHA comparison (`branchAtBase` helper):

- HEAD == base → mark task `done` with reason `branch identical to base — implementation already on origin`. Breaks the auto-restart loop because `done` is terminal in `svc_tasks.UpdateTask`.
- HEAD != base, no commits ahead → still flips to `human-required` (genuine "agent did nothing").

Workflow yamls (`simple-task-implement`, `pr-fix`) get an extra `task.status == done → goto ""` route on the `verify_commits` step, so the workflow ends instead of falling through to `set_ready_review` / `link_pr_and_review` (which would override the `done` status).

Tests: 2 unit tests (branch-at-base → done; divergent-no-commits → human-required), 1 e2e test renamed/reframed (`TestE2E_VerifyCommits_BranchAtBaseMarksDone`). Full e2e suite green.

Alternatives considered:
- Disabling the auto-restart in `svc_tasks.UpdateTask` for the `human-required → in-progress` path: too broad, would break the legitimate "transient failure, retry implementation" case.
- Marking `done` only when an associated PR is found via `gh pr list --merged`: requires GitHub API per check + missed the case here (fix landed on a different branch with a different issue link).

## Supporting documentation

> Changelog: fix(workflow): verify_commits done at base