### PR TITLE
fix(agent): close done after onComplete

### DIFF
--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -70,13 +70,13 @@ func codexEventToConvoEvent(e CodexEvent) ConvoEvent {
 func (m *Manager) runCodexConversational(ctx context.Context, a *Agent, cfg RunConfig) {
 	defer func() {
 		a.SetState(StateStopped)
-		m.markAgentDone(a)
 		m.logger.Info("agent.codex.convo.done", "id", a.ID, "cost", a.GetCostUSD())
 		m.emit(events.AgentState(a.ID), a)
 		m.recordCompletion(a, a.GetExitErr() == nil)
 		if m.onComplete != nil {
 			m.onComplete(a)
 		}
+		m.markAgentDone(a)
 	}()
 
 	outFile, fileErr := logging.NewAgentOutputFile(m.logDir, a.ID)

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -162,13 +162,13 @@ func (m *Manager) runConversational(ctx context.Context, a *Agent, cfg RunConfig
 
 done:
 	a.SetState(StateStopped)
-	m.markAgentDone(a)
 	m.logger.Info("agent.convo.done", "id", a.ID, "cost", a.GetCostUSD())
 	m.emit(events.AgentState(a.ID), a)
 	m.recordCompletion(a, a.GetExitErr() == nil)
 	if m.onComplete != nil {
 		m.onComplete(a)
 	}
+	m.markAgentDone(a)
 }
 
 func (m *Manager) runConvoAttempt(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File) (retry bool, err error) {

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -63,13 +63,16 @@ func (m *Manager) runHeadless(ctx context.Context, a *Agent, cfg RunConfig) {
 
 done:
 	a.SetState(StateStopped)
-	m.markAgentDone(a)
 	m.logger.Info("agent.headless.done", "id", a.ID, "cost", a.GetCostUSD())
 	m.emit(events.AgentState(a.ID), a)
 	m.recordCompletion(a, a.GetExitErr() == nil)
 	if m.onComplete != nil {
 		m.onComplete(a)
 	}
+	// Close `done` only after onComplete returns. HasRunningAgentForTask
+	// gates ResumeStalled; releasing it before the workflow advance handler
+	// runs lets a tight ResumeStalled loop dispatch a duplicate agent.
+	m.markAgentDone(a)
 }
 
 func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File) (retry bool, err error) {
@@ -661,7 +664,6 @@ func (m *Manager) handleError(a *Agent, err error) {
 	kind := classifyAgentError(err)
 	a.SetError(kind, err.Error())
 	a.SetState(StateStopped)
-	m.markAgentDone(a)
 	m.logger.Error("agent.error", "id", a.ID, "kind", kind, "err", err)
 	m.emit(events.AgentError(a.ID), ErrorEvent{Kind: kind, Msg: err.Error()})
 	m.emit(events.AgentState(a.ID), a)
@@ -669,6 +671,7 @@ func (m *Manager) handleError(a *Agent, err error) {
 	if m.onComplete != nil {
 		m.onComplete(a)
 	}
+	m.markAgentDone(a)
 }
 
 // classifyAgentError maps a fatal agent error to a canonical kind string.


### PR DESCRIPTION
## Motivation

`TestE2E_ResumeStalled_TightLoopIdempotent` is intermittently failing on CI (e.g. PR #672 and a recent main run). Two consecutive failures while debugging PR #672 confirmed it's not pure flake — it's a real race that the tight loop reliably exposes when the test agent fixture finishes near-instantly.

Race window:

1. Headless runner finishes the agent.
2. `markAgentDone(a)` closes `done` → `HasRunningAgentForTask` returns false.
3. (gap) `onComplete(a)` not yet called → `HandleAgentComplete` not yet entered → `AdvanceStep` has not acquired the inflight mutex → workflow still on `implement`.
4. `ResumeStalled` enters: no running agent + same `CurrentStep` + no `dispatching` marker + `TryLock` succeeds. It dispatches a duplicate agent → `AgentRuns` becomes 2.

## Implementation information

Move `markAgentDone(a)` to after `onComplete(a)` in all four runner exits:

- `runner_headless.go` — main `done:` block + `handleError`
- `runner_convo.go` — `done:` block
- `runner_codex_convo.go` — deferred shutdown

Now `HasRunningAgent` stays true for the entire completion handler. `KillAgentsForTask` / `Shutdown` keep waiting on `done` correctly — they were already guarded for "goroutine truly exited" semantics, which now includes the completion handler.

Verified with `go test -tags e2e -count=10 -run TestE2E_ResumeStalled_TightLoopIdempotent` (10/10 pass) and full `internal/sybra` e2e suite.

## Supporting documentation

Discovered while debugging CI on #672.