### PR TITLE
fix(workflow): done when HEAD ancestor of base

### DIFF
--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -3323,14 +3323,14 @@ func TestE2E_VerifyCommits_BranchAtBaseMarksDone(t *testing.T) {
 	if tk.Status != task.StatusDone {
 		t.Fatalf("status = %q, want done", tk.Status)
 	}
-	if !strings.Contains(tk.StatusReason, "branch identical to base") {
+	if !strings.Contains(tk.StatusReason, "already merged into base") {
 		var verifyOut string
 		for i := range tk.Workflow.StepHistory {
 			if tk.Workflow.StepHistory[i].StepID == "verify_commits" {
 				verifyOut = tk.Workflow.StepHistory[i].Output
 			}
 		}
-		t.Fatalf("status_reason = %q, want 'branch identical to base' (verify_commits output=%q)", tk.StatusReason, verifyOut)
+		t.Fatalf("status_reason = %q, want 'already merged into base' (verify_commits output=%q)", tk.StatusReason, verifyOut)
 	}
 	stepIDs := stepIDsFromHistory(tk.Workflow)
 	if !slices.Contains(stepIDs, "verify_commits") {

--- a/internal/workflow/engine_steps.go
+++ b/internal/workflow/engine_steps.go
@@ -677,13 +677,13 @@ func (e *Engine) execVerifyCommits(taskID string, step *Step, t TaskInfo) (StepO
 		//       svc_tasks.UpdateTask doesn't bounce the task back to in-progress.
 		//   (b) HEAD != base → branch diverged but has zero fast-forward commits.
 		//       Genuine "agent did nothing"; flip to human-required as before.
-		if branchAtBase(e.ctx, wtPath) {
-			reason := "branch identical to base — implementation already on origin"
+		if branchMergedIntoBase(e.ctx, wtPath) {
+			reason := "branch already merged into base — implementation already on origin"
 			if statusErr := e.tasks.UpdateTaskStatus(taskID, "done", reason); statusErr != nil {
 				e.logger.Error("workflow.verify-commits.status", "task_id", taskID, "err", statusErr)
 			}
-			e.logger.Info("workflow.verify-commits.branch-at-base", "task_id", taskID)
-			return StepOutput{StepID: step.ID, Status: "completed", Output: "branch at base: marked done"}, nil
+			e.logger.Info("workflow.verify-commits.branch-merged", "task_id", taskID)
+			return StepOutput{StepID: step.ID, Status: "completed", Output: "branch merged into base: marked done"}, nil
 		}
 		reason := "no commits pushed to branch"
 		if statusErr := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); statusErr != nil {
@@ -695,32 +695,23 @@ func (e *Engine) execVerifyCommits(taskID string, step *Step, t TaskInfo) (StepO
 	return StepOutput{StepID: step.ID, Status: "completed", Output: "commits verified"}, nil
 }
 
-// branchAtBase reports whether the worktree's HEAD points at the same commit
-// as the resolved origin base ref. Used by execVerifyCommits to distinguish
-// "fix already merged elsewhere" from "agent did nothing".
-func branchAtBase(parentCtx context.Context, wtPath string) bool {
+// branchMergedIntoBase reports whether HEAD is reachable from the resolved
+// origin base ref (i.e. HEAD is an ancestor of, or equal to, base). Used by
+// execVerifyCommits to distinguish "fix already merged into origin" from
+// "agent did nothing".
+//
+// `git log origin/main..HEAD` empty ⟺ HEAD is reachable from origin/main, so
+// any time we land in the "no commits ahead" branch the answer here is true
+// in the common case. We still gate on an explicit `merge-base --is-ancestor`
+// check so an unrelated history (orphan branch, force-pushed elsewhere) does
+// not silently get marked done.
+func branchMergedIntoBase(parentCtx context.Context, wtPath string) bool {
 	ctx, cancel := context.WithTimeout(parentCtx, shellTimeout)
 	defer cancel()
 	baseRef := resolveOriginBase(ctx, wtPath)
-	headSHA, err := gitRevParse(ctx, wtPath, "HEAD")
-	if err != nil || headSHA == "" {
-		return false
-	}
-	baseSHA, err := gitRevParse(ctx, wtPath, baseRef)
-	if err != nil || baseSHA == "" {
-		return false
-	}
-	return headSHA == baseSHA
-}
-
-func gitRevParse(ctx context.Context, wtPath, ref string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--verify", ref)
+	cmd := exec.CommandContext(ctx, "git", "merge-base", "--is-ancestor", "HEAD", baseRef)
 	cmd.Dir = wtPath
-	out, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(out)), nil
+	return cmd.Run() == nil
 }
 
 // triageReviewLineLimit and triageReviewFileLimit are the hard ceilings under

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2638,23 +2638,25 @@ func TestExecVerifyCommits_BranchAtBaseMarksDone(t *testing.T) {
 	if out.Status != "completed" {
 		t.Errorf("Status = %q, want completed", out.Status)
 	}
-	if !strings.Contains(out.Output, "branch at base") {
-		t.Errorf("Output = %q, want 'branch at base'", out.Output)
+	if !strings.Contains(out.Output, "branch merged into base") {
+		t.Errorf("Output = %q, want 'branch merged into base'", out.Output)
 	}
 	ti, _ := tasks.GetTask("t1")
 	if ti.Status != "done" {
 		t.Errorf("task status = %q, want done", ti.Status)
 	}
-	if reason := tasks.Reason("t1"); !strings.Contains(reason, "branch identical to base") {
-		t.Errorf("status reason = %q, want 'branch identical to base'", reason)
+	if reason := tasks.Reason("t1"); !strings.Contains(reason, "already merged into base") {
+		t.Errorf("status reason = %q, want 'already merged into base'", reason)
 	}
 }
 
-// TestExecVerifyCommits_DivergentNoCommitsFlipsHumanRequired covers the
-// genuine "agent did nothing" path: HEAD is behind origin/main (not at base
-// tip) and no commits exist ahead. We can't conclude the work is on origin,
-// so flip to human-required as before.
-func TestExecVerifyCommits_DivergentNoCommitsFlipsHumanRequired(t *testing.T) {
+// TestExecVerifyCommits_BranchAncestorOfBaseMarksDone covers the regression
+// from issue #670: HEAD is an ancestor of origin/main (branch tip equals an
+// older commit on main, with newer commits on top — typical of squash-merge
+// followed by additional PRs). `git log origin/main..HEAD` is empty AND
+// HEAD != base.tip, but the work is still on origin. Must flip to done, not
+// human-required.
+func TestExecVerifyCommits_BranchAncestorOfBaseMarksDone(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
@@ -2671,18 +2673,18 @@ func TestExecVerifyCommits_DivergentNoCommitsFlipsHumanRequired(t *testing.T) {
 	if out.Status != "completed" {
 		t.Errorf("Status = %q, want completed", out.Status)
 	}
-	if !strings.Contains(out.Output, "no commits") {
-		t.Errorf("Output = %q, want 'no commits'", out.Output)
+	if !strings.Contains(out.Output, "branch merged into base") {
+		t.Errorf("Output = %q, want 'branch merged into base'", out.Output)
 	}
 	ti, _ := tasks.GetTask("t1")
-	if ti.Status != "human-required" {
-		t.Errorf("task status = %q, want human-required", ti.Status)
+	if ti.Status != "done" {
+		t.Errorf("task status = %q, want done", ti.Status)
 	}
 }
 
-// makeGitRepoBehindOrigin builds a worktree where HEAD is behind origin/main:
-// origin/main points at commit B, HEAD is reset back to commit A. Used to
-// exercise the "no commits ahead, HEAD != base" branch of execVerifyCommits.
+// makeGitRepoBehindOrigin builds a worktree where HEAD is an ancestor of
+// origin/main: origin/main points at commit B, HEAD is reset to commit A
+// (a parent of B). `git log origin/main..HEAD` is empty AND HEAD != base.tip.
 func makeGitRepoBehindOrigin(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()


### PR DESCRIPTION
## Motivation

Task `8f7bdd56` (BK-tree on per-base buckets, repo `Automaat/zsh-clean-history`) flipped to `human-required` with reason `no commits pushed to branch`, even though the implementation was already on `origin/main` via squash-merge of PR #56 (`feat(detector): add cross-base typo detection`, commit `b9687ec`).

The worktree branch tip was at `b9687ec`, an *ancestor* of `origin/main` (`ef7269c`, two follow-up commits ahead). `verify_commits` ran `git log origin/main..HEAD` → empty, then checked `branchAtBase()` (added in #670), which only short-circuits on strict SHA equality (`HEAD == base.tip`). Because HEAD ≠ tip but HEAD is reachable from tip, the code fell through to `human-required`. Auto-restart loop in `svc_tasks.UpdateTask` was avoided only because the operator manually unstuck the task.

> Changelog: fix(workflow): done when HEAD ancestor of base

## Implementation information

- `branchAtBase` → `branchMergedIntoBase` in `internal/workflow/engine_steps.go`. Now uses `git merge-base --is-ancestor HEAD <base>` instead of comparing SHAs.
  - Empty `git log origin/main..HEAD` ⟺ HEAD is reachable from origin/main ⟺ HEAD is ancestor of (or equal to) base. So `--is-ancestor` strictly subsumes the old equality check and handles the "merged via squash + follow-up commits on top" case.
- Removed unused `gitRevParse` helper.
- Status reason: `branch already merged into base — implementation already on origin`. Log key: `workflow.verify-commits.branch-merged`. Step output: `branch merged into base: marked done`.
- Tests:
  - Added `TestExecVerifyCommits_BranchAncestorOfBaseMarksDone` (regression: HEAD reset to `HEAD~1`, must mark done).
  - Updated `TestExecVerifyCommits_BranchAtBaseMarksDone` and `TestE2E_VerifyCommits_BranchAtBaseMarksDone` reason strings.
  - Removed the previous "DivergentNoCommits" test — its setup actually puts HEAD as an ancestor (now `done`), and a truly divergent case where `git log A..B` is empty but B is not an ancestor of A is logically impossible.

**Alternative considered:** unconditionally mark `done` whenever the log range is empty. Rejected — `merge-base --is-ancestor` is one extra git invocation but defensively guards against degenerate states (e.g. unresolvable refs), keeping behavior explicit.

## Supporting documentation

- Original short-circuit: commit 10d9971 (`fix(workflow): verify_commits done at base`)
- Live incident: task `8f7bdd56` in local sybra (status reason `no commits pushed to branch` despite work on origin)