### PR TITLE
feat(stats): add by-project-type breakdown

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/stats/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/stats/models.ts
@@ -107,6 +107,7 @@ export class StatsResponse {
     "thisMonth": Summary;
     "allTime": Summary;
     "byProject": GroupedStat[];
+    "byProjectType": GroupedStat[];
     "byMode": GroupedStat[];
     "byRole": GroupedStat[];
     "byModel": GroupedStat[];
@@ -129,6 +130,9 @@ export class StatsResponse {
         }
         if (!("byProject" in $$source)) {
             this["byProject"] = [];
+        }
+        if (!("byProjectType" in $$source)) {
+            this["byProjectType"] = [];
         }
         if (!("byMode" in $$source)) {
             this["byMode"] = [];
@@ -162,7 +166,8 @@ export class StatsResponse {
         const $$createField6_0 = $$createType2;
         const $$createField7_0 = $$createType2;
         const $$createField8_0 = $$createType2;
-        const $$createField9_0 = $$createType4;
+        const $$createField9_0 = $$createType2;
+        const $$createField10_0 = $$createType4;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("today" in $$parsedSource) {
             $$parsedSource["today"] = $$createField0_0($$parsedSource["today"]);
@@ -179,20 +184,23 @@ export class StatsResponse {
         if ("byProject" in $$parsedSource) {
             $$parsedSource["byProject"] = $$createField4_0($$parsedSource["byProject"]);
         }
+        if ("byProjectType" in $$parsedSource) {
+            $$parsedSource["byProjectType"] = $$createField5_0($$parsedSource["byProjectType"]);
+        }
         if ("byMode" in $$parsedSource) {
-            $$parsedSource["byMode"] = $$createField5_0($$parsedSource["byMode"]);
+            $$parsedSource["byMode"] = $$createField6_0($$parsedSource["byMode"]);
         }
         if ("byRole" in $$parsedSource) {
-            $$parsedSource["byRole"] = $$createField6_0($$parsedSource["byRole"]);
+            $$parsedSource["byRole"] = $$createField7_0($$parsedSource["byRole"]);
         }
         if ("byModel" in $$parsedSource) {
-            $$parsedSource["byModel"] = $$createField7_0($$parsedSource["byModel"]);
+            $$parsedSource["byModel"] = $$createField8_0($$parsedSource["byModel"]);
         }
         if ("byProvider" in $$parsedSource) {
-            $$parsedSource["byProvider"] = $$createField8_0($$parsedSource["byProvider"]);
+            $$parsedSource["byProvider"] = $$createField9_0($$parsedSource["byProvider"]);
         }
         if ("recentRuns" in $$parsedSource) {
-            $$parsedSource["recentRuns"] = $$createField9_0($$parsedSource["recentRuns"]);
+            $$parsedSource["recentRuns"] = $$createField10_0($$parsedSource["recentRuns"]);
         }
         return new StatsResponse($$parsedSource as Partial<StatsResponse>);
     }

--- a/frontend/src/pages/Stats.svelte
+++ b/frontend/src/pages/Stats.svelte
@@ -114,6 +114,7 @@
   {#if statsStore.data}
     <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
       {#each [
+        { title: 'By Project Type', data: statsStore.data.byProjectType },
         { title: 'By Project', data: statsStore.data.byProject },
         { title: 'By Role', data: statsStore.data.byRole },
         { title: 'By Mode', data: statsStore.data.byMode },

--- a/frontend/src/pages/Stats.svelte.test.ts
+++ b/frontend/src/pages/Stats.svelte.test.ts
@@ -38,6 +38,7 @@ function makeStatsData(): StatsResponse {
     thisMonth: s,
     allTime: s,
     byProject: [],
+    byProjectType: [],
     byRole: [],
     byMode: [],
     byModel: [],
@@ -111,6 +112,7 @@ describe('Stats', () => {
   it('shows breakdown sections', () => {
     mockStatsStore.data = makeStatsData()
     render(Stats, { props: {} })
+    expect(screen.getByText('By Project Type')).toBeDefined()
     expect(screen.getByText('By Project')).toBeDefined()
     expect(screen.getByText('By Role')).toBeDefined()
     expect(screen.getByText('By Mode')).toBeDefined()

--- a/internal/stats/model.go
+++ b/internal/stats/model.go
@@ -38,14 +38,15 @@ type GroupedStat struct {
 
 // StatsResponse is the full analytics payload returned to the frontend.
 type StatsResponse struct {
-	Today      Summary       `json:"today"`
-	ThisWeek   Summary       `json:"thisWeek"`
-	ThisMonth  Summary       `json:"thisMonth"`
-	AllTime    Summary       `json:"allTime"`
-	ByProject  []GroupedStat `json:"byProject"`
-	ByMode     []GroupedStat `json:"byMode"`
-	ByRole     []GroupedStat `json:"byRole"`
-	ByModel    []GroupedStat `json:"byModel"`
-	ByProvider []GroupedStat `json:"byProvider"`
-	RecentRuns []RunRecord   `json:"recentRuns"`
+	Today         Summary       `json:"today"`
+	ThisWeek      Summary       `json:"thisWeek"`
+	ThisMonth     Summary       `json:"thisMonth"`
+	AllTime       Summary       `json:"allTime"`
+	ByProject     []GroupedStat `json:"byProject"`
+	ByProjectType []GroupedStat `json:"byProjectType"`
+	ByMode        []GroupedStat `json:"byMode"`
+	ByRole        []GroupedStat `json:"byRole"`
+	ByModel       []GroupedStat `json:"byModel"`
+	ByProvider    []GroupedStat `json:"byProvider"`
+	RecentRuns    []RunRecord   `json:"recentRuns"`
 }

--- a/internal/sybra/services.go
+++ b/internal/sybra/services.go
@@ -58,6 +58,7 @@ func (a *App) wireServices(emit func(string, any)) {
 	a.intgSvc.providerHealth = a.providerHealth
 	a.intgSvc.saveConfig = func() error { return a.cfg.Save() }
 	a.statsSvc.stats = a.stats
+	a.statsSvc.projects = a.projects
 	a.workflowSvc.engine = a.workflowEngine
 	a.workflowSvc.store = a.workflowStore
 

--- a/internal/sybra/svc_stats.go
+++ b/internal/sybra/svc_stats.go
@@ -1,10 +1,17 @@
 package sybra
 
-import "github.com/Automaat/sybra/internal/stats"
+import (
+	"cmp"
+	"slices"
+
+	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/stats"
+)
 
 // StatsService exposes statistics as Wails-bound methods.
 type StatsService struct {
-	stats *stats.Store
+	stats    *stats.Store
+	projects *project.Store
 }
 
 // GetStats returns aggregated agent run statistics.
@@ -12,5 +19,62 @@ func (s *StatsService) GetStats() stats.StatsResponse {
 	if s.stats == nil {
 		return stats.StatsResponse{}
 	}
-	return s.stats.Query()
+	resp := s.stats.Query()
+	resp.ByProjectType = aggregateByProjectType(resp.ByProject, s.projectTypes())
+	return resp
+}
+
+// projectTypes returns a map of project ID -> type ("pet"/"work"). An empty
+// map is returned if the project store is unavailable or the listing fails;
+// callers fold unknowns into the "(unknown)" bucket.
+func (s *StatsService) projectTypes() map[string]string {
+	if s.projects == nil {
+		return map[string]string{}
+	}
+	list, err := s.projects.List()
+	if err != nil {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(list))
+	for i := range list {
+		out[list[i].ID] = string(list[i].Type)
+	}
+	return out
+}
+
+// aggregateByProjectType folds per-project stats into per-type buckets using
+// the supplied projectID -> type map. Projects absent from the map land in
+// "(unknown)". Result is sorted by total cost desc to match the other groups.
+func aggregateByProjectType(byProject []stats.GroupedStat, types map[string]string) []stats.GroupedStat {
+	buckets := map[string]stats.Summary{}
+	for _, g := range byProject {
+		key, ok := types[g.Key]
+		if !ok || key == "" {
+			key = "(unknown)"
+		}
+		buckets[key] = addSummary(buckets[key], g.Stats)
+	}
+
+	out := make([]stats.GroupedStat, 0, len(buckets))
+	for k, v := range buckets {
+		if v.TotalRuns > 0 {
+			v.AvgCostPerRun = v.TotalCostUSD / float64(v.TotalRuns)
+			v.AvgDurationS = v.TotalDurationS / float64(v.TotalRuns)
+		}
+		out = append(out, stats.GroupedStat{Key: k, Stats: v})
+	}
+	slices.SortFunc(out, func(a, b stats.GroupedStat) int {
+		return cmp.Compare(b.Stats.TotalCostUSD, a.Stats.TotalCostUSD)
+	})
+	return out
+}
+
+func addSummary(a, b stats.Summary) stats.Summary {
+	return stats.Summary{
+		TotalCostUSD:      a.TotalCostUSD + b.TotalCostUSD,
+		TotalRuns:         a.TotalRuns + b.TotalRuns,
+		TotalDurationS:    a.TotalDurationS + b.TotalDurationS,
+		TotalInputTokens:  a.TotalInputTokens + b.TotalInputTokens,
+		TotalOutputTokens: a.TotalOutputTokens + b.TotalOutputTokens,
+	}
 }

--- a/internal/sybra/svc_stats_test.go
+++ b/internal/sybra/svc_stats_test.go
@@ -1,0 +1,103 @@
+package sybra
+
+import (
+	"math"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/stats"
+)
+
+func TestAggregateByProjectType(t *testing.T) {
+	byProject := []stats.GroupedStat{
+		{Key: "Automaat/sybra", Stats: stats.Summary{
+			TotalCostUSD: 1.0, TotalRuns: 4, TotalDurationS: 200,
+			TotalInputTokens: 1000, TotalOutputTokens: 500,
+			AvgCostPerRun: 0.25, AvgDurationS: 50,
+		}},
+		{Key: "Automaat/zsh-clean-history", Stats: stats.Summary{
+			TotalCostUSD: 0.5, TotalRuns: 2, TotalDurationS: 100,
+			AvgCostPerRun: 0.25, AvgDurationS: 50,
+		}},
+		{Key: "kumahq/kuma", Stats: stats.Summary{
+			TotalCostUSD: 3.0, TotalRuns: 6, TotalDurationS: 600,
+			AvgCostPerRun: 0.5, AvgDurationS: 100,
+		}},
+		{Key: "no/such-project", Stats: stats.Summary{
+			TotalCostUSD: 0.1, TotalRuns: 1, TotalDurationS: 10,
+			AvgCostPerRun: 0.1, AvgDurationS: 10,
+		}},
+	}
+	types := map[string]string{
+		"Automaat/sybra":             "pet",
+		"Automaat/zsh-clean-history": "pet",
+		"kumahq/kuma":                "work",
+	}
+
+	out := aggregateByProjectType(byProject, types)
+
+	if len(out) != 3 {
+		t.Fatalf("want 3 buckets (pet, work, (unknown)); got %d: %+v", len(out), out)
+	}
+
+	// Sorted by cost desc: work (3.0) > pet (1.5) > (unknown) (0.1)
+	if out[0].Key != "work" || out[1].Key != "pet" || out[2].Key != "(unknown)" {
+		t.Errorf("ordering: got %s,%s,%s; want work,pet,(unknown)", out[0].Key, out[1].Key, out[2].Key)
+	}
+
+	pet := find(t, out, "pet")
+	if pet.TotalRuns != 6 {
+		t.Errorf("pet.totalRuns: got %d, want 6", pet.TotalRuns)
+	}
+	if !nearly(pet.TotalCostUSD, 1.5) {
+		t.Errorf("pet.totalCost: got %f, want 1.5", pet.TotalCostUSD)
+	}
+	if !nearly(pet.AvgCostPerRun, 1.5/6) {
+		t.Errorf("pet.avgCostPerRun: got %f, want %f", pet.AvgCostPerRun, 1.5/6)
+	}
+	if !nearly(pet.AvgDurationS, 300.0/6) {
+		t.Errorf("pet.avgDurationS: got %f, want 50", pet.AvgDurationS)
+	}
+	if pet.TotalInputTokens != 1000 || pet.TotalOutputTokens != 500 {
+		t.Errorf("pet tokens: got in=%d out=%d, want 1000/500", pet.TotalInputTokens, pet.TotalOutputTokens)
+	}
+
+	work := find(t, out, "work")
+	if work.TotalRuns != 6 || !nearly(work.TotalCostUSD, 3.0) {
+		t.Errorf("work bucket wrong: %+v", work)
+	}
+
+	unknown := find(t, out, "(unknown)")
+	if unknown.TotalRuns != 1 {
+		t.Errorf("unknown.totalRuns: got %d, want 1", unknown.TotalRuns)
+	}
+}
+
+func TestAggregateByProjectType_EmptyMap(t *testing.T) {
+	byProject := []stats.GroupedStat{
+		{Key: "a/b", Stats: stats.Summary{TotalCostUSD: 1, TotalRuns: 1, TotalDurationS: 10}},
+	}
+	out := aggregateByProjectType(byProject, map[string]string{})
+	if len(out) != 1 || out[0].Key != "(unknown)" {
+		t.Fatalf("expected single (unknown) bucket; got %+v", out)
+	}
+}
+
+func TestAggregateByProjectType_SkipsZeroBuckets(t *testing.T) {
+	out := aggregateByProjectType(nil, map[string]string{"a/b": "pet"})
+	if len(out) != 0 {
+		t.Errorf("empty input → empty output; got %+v", out)
+	}
+}
+
+func find(t *testing.T, gs []stats.GroupedStat, key string) stats.Summary {
+	t.Helper()
+	for _, g := range gs {
+		if g.Key == key {
+			return g.Stats
+		}
+	}
+	t.Fatalf("no bucket with key %q in %+v", key, gs)
+	return stats.Summary{}
+}
+
+func nearly(a, b float64) bool { return math.Abs(a-b) < 1e-9 }


### PR DESCRIPTION
## Motivation

Stats page lacked a pet/work split. After the synapse → sybra rename
the lifetime numbers got fragmented, and the existing By Project view
makes it tedious to mentally roll up per-repo rows into "how much
have I shipped on hobby projects vs. work this month".

## Implementation information

- New `ByProjectType []GroupedStat` on `stats.StatsResponse`.
- Aggregation lives in `StatsService` (not `internal/stats`) — the
  stats package stays unaware of project metadata. Service folds the
  existing `ByProject` summaries via a projectID → type map fetched
  from `*project.Store`. Avg fields are recomputed after summing.
- Projects without metadata land in `(unknown)`; sorted by total
  cost desc to match other groups.
- Stats.svelte renders a new "By Project Type" card alongside the
  existing breakdowns.
- Bindings regenerated.

## Supporting documentation

None.