### PR TITLE
fix(pr-monitor): scan renovate PRs too

### DIFF
--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -241,7 +241,7 @@ func (a *App) Startup(ctx context.Context) error {
 	})
 	a.sandboxes = sandbox.NewManager(filepath.Join(config.HomeDir(), "sandboxes"), a.logger)
 	a.agentOrch = newAgentOrchestrator(a.tasks, a.projects, a.agents, a.audit, a.logger, a.worktrees, a.cfg)
-	a.reviewer = newReviewHandler(a.tasks, a.projects, a.agents, a.audit, a.logger, a.prTracker, emit, a.worktrees)
+	a.reviewer = newReviewHandler(a.tasks, a.projects, a.agents, a.audit, a.logger, a.prTracker, emit, a.worktrees, a.renovatePRsForMonitor)
 
 	a.initWorkflowEngine()
 

--- a/internal/sybra/app_renovate.go
+++ b/internal/sybra/app_renovate.go
@@ -1,6 +1,9 @@
 package sybra
 
-import "github.com/Automaat/sybra/internal/poll"
+import (
+	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/poll"
+)
 
 func (a *App) initRenovate(emit func(string, any)) {
 	if !a.cfg.Renovate.Enabled {
@@ -8,4 +11,29 @@ func (a *App) initRenovate(emit func(string, any)) {
 	}
 	a.renovateHandler = poll.NewRenovateHandler(a.projects, a.logger, emit, &a.cfg.Renovate, a.allowsProjectType)
 	a.logger.Info("renovate.enabled", "author", a.cfg.Renovate.Author)
+}
+
+// renovatePRsForMonitor returns Renovate-bot PRs flattened to PullRequest for
+// the pr-monitor's match pass. FetchReviews uses author:@me which excludes
+// bots, so without this hook a Renovate PR linked to a task by pr_number
+// never gets re-dispatched to pr-fix when CI keeps failing. Returns nil when
+// renovate is disabled or no projects are registered for this machine.
+func (a *App) renovatePRsForMonitor() []github.PullRequest {
+	if a.renovateHandler == nil {
+		return nil
+	}
+	repos := a.renovateHandler.Repos()
+	if len(repos) == 0 {
+		return nil
+	}
+	rps, err := github.FetchRenovatePRs(a.cfg.Renovate.Author, repos)
+	if err != nil {
+		a.logger.Warn("pr-monitor.renovate-fetch", "err", err)
+		return nil
+	}
+	prs := make([]github.PullRequest, len(rps))
+	for i := range rps {
+		prs[i] = rps[i].PullRequest
+	}
+	return prs
 }

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -37,6 +37,11 @@ type ReviewHandler struct {
 	prTracker      *github.IssueTracker
 	worktrees      *worktree.Manager
 	workflowEngine *workflow.Engine
+	// renovatePRsFn returns Renovate-bot PRs to fold into the monitor pass.
+	// FetchReviews uses author:@me which excludes bot-authored PRs, so without
+	// this hook a Renovate PR linked to a task by pr_number/branch never gets
+	// re-dispatched to pr-fix when CI fails. nil = renovate disabled.
+	renovatePRsFn func() []github.PullRequest
 }
 
 func newReviewHandler(
@@ -48,6 +53,7 @@ func newReviewHandler(
 	prTracker *github.IssueTracker,
 	emit func(string, any),
 	worktrees *worktree.Manager,
+	renovatePRsFn func() []github.PullRequest,
 ) *ReviewHandler {
 	return &ReviewHandler{
 		DomainHandler: DomainHandler{audit: al, logger: logger, emit: emit},
@@ -56,6 +62,7 @@ func newReviewHandler(
 		agents:        agents,
 		prTracker:     prTracker,
 		worktrees:     worktrees,
+		renovatePRsFn: renovatePRsFn,
 	}
 }
 
@@ -332,8 +339,10 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 		})
 	}
 
+	monitoredPRs := r.monitoredPRs(summary)
+
 	if len(matchers) > 0 {
-		issues := github.MatchTaskPRs(summary.CreatedByMe, matchers)
+		issues := github.MatchTaskPRs(monitoredPRs, matchers)
 		r.prTracker.Cleanup()
 
 		for i := range issues {
@@ -350,7 +359,7 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 			r.handlePRIssue(issues[i])
 		}
 
-		closedPRs := github.DetectClosedTaskPRs(summary.CreatedByMe, matchers, github.FetchPRState)
+		closedPRs := github.DetectClosedTaskPRs(monitoredPRs, matchers, github.FetchPRState)
 		for _, c := range closedPRs {
 			if r.agents.HasRunningAgentForTask(c.TaskID) {
 				r.logger.Info("pr-monitor.closed-skip-running-agent", "task_id", c.TaskID, "pr", c.PRNumber)
@@ -372,10 +381,28 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 	r.maybeCreateReviewTasks(tasks, summary.ReviewRequested)
 	r.detectPublishedReviews(tasks)
 
-	if prNeedsAttention(summary.CreatedByMe) {
+	if prNeedsAttention(monitoredPRs) {
 		return prPollFast
 	}
 	return prPollSlow
+}
+
+// monitoredPRs returns the union of user-authored PRs (from FetchReviews) and
+// Renovate-bot PRs (from renovatePRsFn). Renovate's PRs aren't in author:@me,
+// so without folding them in here the pr-fix monitor would never re-spawn an
+// agent on a Renovate PR whose CI keeps failing.
+func (r *ReviewHandler) monitoredPRs(summary github.ReviewSummary) []github.PullRequest {
+	if r.renovatePRsFn == nil {
+		return summary.CreatedByMe
+	}
+	renovatePRs := r.renovatePRsFn()
+	if len(renovatePRs) == 0 {
+		return summary.CreatedByMe
+	}
+	prs := make([]github.PullRequest, 0, len(summary.CreatedByMe)+len(renovatePRs))
+	prs = append(prs, summary.CreatedByMe...)
+	prs = append(prs, renovatePRs...)
+	return prs
 }
 
 func (r *ReviewHandler) handleAutoMerge(issue github.PRIssue) {

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -3,6 +3,7 @@ package sybra
 import (
 	"testing"
 
+	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -74,6 +75,62 @@ func TestPRMonitorEligible(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := prMonitorEligible(&tt.tk); got != tt.want {
 				t.Errorf("prMonitorEligible(%+v) = %v, want %v", tt.tk, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMonitoredPRs covers the regression where Renovate-bot PRs linked to a
+// task by pr_number were silently skipped by the pr-monitor because
+// FetchReviews uses author:@me. monitoredPRs folds renovatePRsFn output into
+// the same slice that drives MatchTaskPRs and DetectClosedTaskPRs.
+func TestMonitoredPRs(t *testing.T) {
+	mine := github.PullRequest{Number: 1, Author: "me"}
+	bot := github.PullRequest{Number: 2, Author: "app/renovate"}
+	summary := github.ReviewSummary{CreatedByMe: []github.PullRequest{mine}}
+
+	tests := []struct {
+		name      string
+		fn        func() []github.PullRequest
+		wantNums  []int
+		wantAlloc bool // true when fn supplies extra PRs (forces a copy)
+	}{
+		{
+			name:     "nil fn returns CreatedByMe directly",
+			fn:       nil,
+			wantNums: []int{1},
+		},
+		{
+			name:     "empty fn result also returns CreatedByMe directly",
+			fn:       func() []github.PullRequest { return nil },
+			wantNums: []int{1},
+		},
+		{
+			name:      "fn returns renovate PRs — concatenated after CreatedByMe",
+			fn:        func() []github.PullRequest { return []github.PullRequest{bot} },
+			wantNums:  []int{1, 2},
+			wantAlloc: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &ReviewHandler{renovatePRsFn: tt.fn}
+			got := r.monitoredPRs(summary)
+			if len(got) != len(tt.wantNums) {
+				t.Fatalf("len = %d, want %d (got %+v)", len(got), len(tt.wantNums), got)
+			}
+			for i, n := range tt.wantNums {
+				if got[i].Number != n {
+					t.Errorf("got[%d].Number = %d, want %d", i, got[i].Number, n)
+				}
+			}
+			// When fn adds entries we must return a fresh slice — appending
+			// onto summary.CreatedByMe directly would mutate the caller's
+			// data on the next poll.
+			if tt.wantAlloc && len(got) > 0 && len(summary.CreatedByMe) > 0 &&
+				&got[0] == &summary.CreatedByMe[0] {
+				t.Error("monitoredPRs aliased summary.CreatedByMe; expected a copy")
 			}
 		})
 	}

--- a/internal/sybra/svc_reviews_test.go
+++ b/internal/sybra/svc_reviews_test.go
@@ -106,7 +106,7 @@ updated_at: 2025-01-01T00:00:00Z
 		AgentChecker: agentMgr.HasRunningAgentForTask,
 	})
 
-	handler := newReviewHandler(taskMgr, projStore, agentMgr, nil, logger, nil, func(string, any) {}, wm)
+	handler := newReviewHandler(taskMgr, projStore, agentMgr, nil, logger, nil, func(string, any) {}, wm, nil)
 	svc := &ReviewService{reviewer: handler, tasks: taskMgr}
 
 	return svc, taskMgr, barePath


### PR DESCRIPTION
## Motivation

Tasks linked to Renovate PRs (e.g. `1307f39b` → `Automaat/creatorops#124`)
get one fix attempt via the manual UI button and then go silent. Workflow
completes, CI keeps failing, no follow-up agent ever runs.

Root cause: `ReviewHandler.pollAndMonitorPRs` is the auto-monitor that
re-dispatches `pr.event` when CI fails on a tracked PR. Its input is
`github.FetchReviews` which queries `is:pr is:open author:@me`. Renovate
PRs are bot-authored (`app/renovate`), so they're never in
`summary.CreatedByMe`, never reach `MatchTaskPRs`, and the pr-fix
workflow never gets re-triggered.

## Implementation information

- New `renovatePRsFn func() []github.PullRequest` injected into
  `ReviewHandler`; nil = renovate disabled.
- Wired to `App.renovatePRsForMonitor`, which fetches via the existing
  `RenovateHandler.Repos()` (already filters by `allowsProjectType`).
- `monitoredPRs(summary)` concatenates `summary.CreatedByMe` and the
  renovate PR list and feeds the result to `MatchTaskPRs`,
  `DetectClosedTaskPRs`, and `prNeedsAttention`.
- Existing `prTracker.ShouldHandle` debounce (30 min) and pr-fix
  workflow stay authoritative.

Alternatives considered: extending `FetchReviews` GraphQL to also fetch
`author:app/renovate` for tracked repos. Rejected — author is
configurable per machine and the renovate poller already does this
fetch with the right filter.

Side effect: green Renovate PRs in `pet`-typed projects now also flow
through `handleAutoMerge` (was previously inaccessible for the same
reason). Matches existing intent — `RenovatePRCard` already exposes a
manual Merge button and the auto-merge guard is `project.Type==pet`.

## Supporting documentation

Test added: `TestMonitoredPRs` in
`internal/sybra/app_reviews_unit_test.go` covers nil-fn, empty-fn, and
populated-fn cases, plus a no-aliasing assertion.

> Changelog: fix(pr-monitor): scan renovate PRs too