### PR TITLE
fix(agent): fix codex flag handling and RequirePermissions bypass

### DIFF
--- a/docs/codex-setup.md
+++ b/docs/codex-setup.md
@@ -74,10 +74,10 @@ Sybra maps generic aliases to provider-specific model IDs at runtime:
 Sybra spawns a `codex exec` subprocess per task:
 
 ```bash
-# Default (no permission restrictions)
-codex exec --json --skip-git-repo-check --sandbox workspace-write --model gpt-5.4 -C <worktree> "<prompt>"
+# RequirePermissions=false (skip-permissions / bypass mode)
+codex exec --json --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox --model gpt-5.4 -C <worktree> "<prompt>"
 
-# With RequirePermissions=true
+# RequirePermissions=true (sandboxed, file-write only)
 codex exec --json --skip-git-repo-check --sandbox workspace-write --model gpt-5.4 -C <worktree> "<prompt>"
 ```
 
@@ -93,7 +93,7 @@ Sybra spawns a new `codex exec --json` process for each user turn. Unlike Claude
 |---------|-------------|-------|
 | Session resume | `--resume <session-id>` | Not supported — each run is independent |
 | Tool allowlist | `--allowedTools tool1,tool2` | Not supported; use `--sandbox workspace-write` for file-write-only mode |
-| Permissions bypass | `--dangerously-skip-permissions` | `--sandbox workspace-write` |
+| Permissions bypass | `--dangerously-skip-permissions` | `--dangerously-bypass-approvals-and-sandbox` |
 | Session files | `~/.claude/projects/<key>/<id>.jsonl` | `~/.codex/sessions/rollout-<id>.jsonl` |
 | External discovery | Claude process detection via session files | Codex process detection via `pgrep -f codex` + session JSONL |
 | Cost reporting | Reported in `result` event (`cost_usd`) | Not reported in stream; billed on OpenAI dashboard |

--- a/docs/codex-setup.md
+++ b/docs/codex-setup.md
@@ -75,7 +75,7 @@ Sybra spawns a `codex exec` subprocess per task:
 
 ```bash
 # Default (no permission restrictions)
-codex exec --json --skip-git-repo-check --full-auto --model gpt-5.4 -C <worktree> "<prompt>"
+codex exec --json --skip-git-repo-check --sandbox workspace-write --model gpt-5.4 -C <worktree> "<prompt>"
 
 # With RequirePermissions=true
 codex exec --json --skip-git-repo-check --sandbox workspace-write --model gpt-5.4 -C <worktree> "<prompt>"
@@ -93,7 +93,7 @@ Sybra spawns a new `codex exec --json` process for each user turn. Unlike Claude
 |---------|-------------|-------|
 | Session resume | `--resume <session-id>` | Not supported — each run is independent |
 | Tool allowlist | `--allowedTools tool1,tool2` | Not supported; use `--sandbox workspace-write` for file-write-only mode |
-| Permissions bypass | `--dangerously-skip-permissions` | `--full-auto` |
+| Permissions bypass | `--dangerously-skip-permissions` | `--sandbox workspace-write` |
 | Session files | `~/.claude/projects/<key>/<id>.jsonl` | `~/.codex/sessions/rollout-<id>.jsonl` |
 | External discovery | Claude process detection via session files | Codex process detection via `pgrep -f codex` + session JSONL |
 | Cost reporting | Reported in `result` event (`cost_usd`) | Not reported in stream; billed on OpenAI dashboard |

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -365,7 +365,7 @@ func codexSandboxArgs(requirePerms bool) []string {
 		return []string{"--sandbox", "danger-full-access"}
 	}
 	if !requirePerms {
-		return []string{"--full-auto"}
+		return []string{"--sandbox", "workspace-write"}
 	}
 	return []string{"--sandbox", "workspace-write"}
 }

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -365,7 +365,9 @@ func codexSandboxArgs(requirePerms bool) []string {
 		return []string{"--sandbox", "danger-full-access"}
 	}
 	if !requirePerms {
-		return []string{"--sandbox", "workspace-write"}
+		// Mirror Claude's --dangerously-skip-permissions: bypass all approval
+		// prompts and sandbox restrictions.
+		return []string{"--dangerously-bypass-approvals-and-sandbox"}
 	}
 	return []string{"--sandbox", "workspace-write"}
 }

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -521,12 +521,12 @@ func TestBuildCommand(t *testing.T) {
 		{
 			name:    "codex default model mapping",
 			cfg:     RunConfig{Provider: "codex"},
-			wantCmd: "codex exec --json --skip-git-repo-check --sandbox workspace-write --model gpt-5.4",
+			wantCmd: "codex exec --json --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox --model gpt-5.4",
 		},
 		{
 			name:    "codex maps haiku to mini",
 			cfg:     RunConfig{Provider: "codex", Model: "haiku"},
-			wantCmd: "codex exec --json --skip-git-repo-check --sandbox workspace-write --model gpt-5.4-mini",
+			wantCmd: "codex exec --json --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox --model gpt-5.4-mini",
 		},
 		{
 			name:    "codex with RequirePermissions uses workspace-write sandbox",

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -521,12 +521,12 @@ func TestBuildCommand(t *testing.T) {
 		{
 			name:    "codex default model mapping",
 			cfg:     RunConfig{Provider: "codex"},
-			wantCmd: "codex exec --json --skip-git-repo-check --full-auto --model gpt-5.4",
+			wantCmd: "codex exec --json --skip-git-repo-check --sandbox workspace-write --model gpt-5.4",
 		},
 		{
 			name:    "codex maps haiku to mini",
 			cfg:     RunConfig{Provider: "codex", Model: "haiku"},
-			wantCmd: "codex exec --json --skip-git-repo-check --full-auto --model gpt-5.4-mini",
+			wantCmd: "codex exec --json --skip-git-repo-check --sandbox workspace-write --model gpt-5.4-mini",
 		},
 		{
 			name:    "codex with RequirePermissions uses workspace-write sandbox",

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -191,16 +191,17 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 	}
 
 	cfg := agent.RunConfig{
-		TaskID:       taskID,
-		Name:         r.AgentName(t.Title),
-		Mode:         mode,
-		Prompt:       prompt,
-		AllowedTools: allowedTools,
-		Model:        model,
-		Provider:     provider,
-		Dir:          dir,
-		OneShot:      oneShot,
-		MaxTurns:     t.MaxTurns,
+		TaskID:             taskID,
+		Name:               r.AgentName(t.Title),
+		Mode:               mode,
+		Prompt:             prompt,
+		AllowedTools:       allowedTools,
+		Model:              model,
+		Provider:           provider,
+		Dir:                dir,
+		OneShot:            oneShot,
+		MaxTurns:           t.MaxTurns,
+		RequirePermissions: resolvePermission(t, a.agentOrch.cfg),
 	}
 
 	// Caller-provided dir takes precedence (e.g. pr-fix flow pre-stages a

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -403,7 +403,8 @@ func TestE2E_HeadlessAgent_ArgsVerification(t *testing.T) {
 				"exec",
 				"--json",
 				"--skip-git-repo-check",
-				"--full-auto",
+				"--sandbox",
+				"workspace-write",
 				"--model\ngpt-5.4",
 			} {
 				if !strings.Contains(args, want) {

--- a/orchestrator/CLAUDE.md
+++ b/orchestrator/CLAUDE.md
@@ -156,18 +156,18 @@ Sybra supports two agent providers: `claude` (default) and `codex`. The active p
 | Task is a self-contained script or shell automation | Yes |
 | Task requires OpenAI-specific models or tooling | Yes |
 | Task needs session resume across runs | No — use Claude (`--resume` not supported in Codex) |
-| Task needs fine-grained tool allowlist | No — Codex only supports `--full-auto` or `--sandbox workspace-write` |
+| Task needs fine-grained tool allowlist | No — Codex only supports `--sandbox workspace-write` or `--sandbox danger-full-access` |
 
 **Codex limitations to keep in mind:**
 
 - No session resume — every headless run starts fresh; multi-turn recovery requires re-stating context in the prompt
-- No `--allowedTools` — use `RequirePermissions=true` to restrict to `workspace-write` sandbox, or accept `--full-auto`
+- No `--allowedTools` — use `RequirePermissions=true` to restrict to `workspace-write` sandbox, or accept `workspace-write` (default)
 - Cost not reported in stream — usage visible on OpenAI dashboard, not in Sybra UI
 - Interactive mode spawns a new process per turn (no persistent stdin)
 
 If the provider is `codex`, Sybra calls:
 ```bash
-codex exec --json --skip-git-repo-check --full-auto [--model <model>] -C <worktree> "<prompt>"
+codex exec --json --skip-git-repo-check --sandbox workspace-write [--model <model>] -C <worktree> "<prompt>"
 ```
 
 See `docs/codex-setup.md` for full setup and auth details.

--- a/orchestrator/CLAUDE.md
+++ b/orchestrator/CLAUDE.md
@@ -156,17 +156,21 @@ Sybra supports two agent providers: `claude` (default) and `codex`. The active p
 | Task is a self-contained script or shell automation | Yes |
 | Task requires OpenAI-specific models or tooling | Yes |
 | Task needs session resume across runs | No — use Claude (`--resume` not supported in Codex) |
-| Task needs fine-grained tool allowlist | No — Codex only supports `--sandbox workspace-write` or `--sandbox danger-full-access` |
+| Task needs fine-grained tool allowlist | No — Codex only supports `--sandbox workspace-write` (RequirePermissions=true) or `--dangerously-bypass-approvals-and-sandbox` (RequirePermissions=false) |
 
 **Codex limitations to keep in mind:**
 
 - No session resume — every headless run starts fresh; multi-turn recovery requires re-stating context in the prompt
-- No `--allowedTools` — use `RequirePermissions=true` to restrict to `workspace-write` sandbox, or accept `workspace-write` (default)
+- No `--allowedTools` — use `RequirePermissions=true` to restrict to `workspace-write` sandbox, or `RequirePermissions=false` for full bypass (`--dangerously-bypass-approvals-and-sandbox`)
 - Cost not reported in stream — usage visible on OpenAI dashboard, not in Sybra UI
 - Interactive mode spawns a new process per turn (no persistent stdin)
 
 If the provider is `codex`, Sybra calls:
 ```bash
+# RequirePermissions=false
+codex exec --json --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox [--model <model>] -C <worktree> "<prompt>"
+
+# RequirePermissions=true (default)
 codex exec --json --skip-git-repo-check --sandbox workspace-write [--model <model>] -C <worktree> "<prompt>"
 ```
 


### PR DESCRIPTION
## Motivation

Two related bugs in Codex agent invocation:

1. `--full-auto` flag was removed from the Codex CLI but Sybra was still passing it, causing agent startup failures.
2. `codexSandboxArgs` returned `--sandbox workspace-write` for both `RequirePermissions=true` and `RequirePermissions=false`, making the permission bypass a no-op.

## Implementation information

- Replaced `--full-auto` with the current Codex flag (`--dangerously-bypass-approvals-and-sandbox` for no-permissions path, `--sandbox workspace-write` for restricted path).
- `RequirePermissions=false` now maps to `--dangerously-bypass-approvals-and-sandbox`, mirroring Claude's `--dangerously-skip-permissions` behaviour.
- `RequirePermissions=true` keeps `--sandbox workspace-write`.
- Updated `docs/codex-setup.md`, `orchestrator/CLAUDE.md`, and tests to match.

Closes https://github.com/Automaat/sybra/issues/681