### PR TITLE
fix(monitor): skip and warn on undispatchable anomalies

### DIFF
--- a/internal/monitor/dispatcher.go
+++ b/internal/monitor/dispatcher.go
@@ -14,10 +14,12 @@ import (
 // does not block on agent completion.
 type Dispatcher interface {
 	// Dispatchable reports whether the anomaly can be dispatched to an agent.
-	// Callers must check this before Dispatch to avoid spurious WARN logs for
-	// anomalies whose working directory can never be resolved (e.g. external
-	// GitHub-issue tasks with no worktree and an empty repoDir).
-	Dispatchable(a Anomaly) bool
+	// Returns (true, "") when dispatchable.
+	// Returns (false, "") when undispatchable for an expected reason (e.g. an
+	// external GitHub-issue task with no worktree and empty repoDir).
+	// Returns (false, reason) for unexpected conditions (task store not
+	// configured, transient task lookup failure) — callers should WARN.
+	Dispatchable(a Anomaly) (ok bool, skipReason string)
 	Dispatch(ctx context.Context, a Anomaly) (agentID string, err error)
 }
 
@@ -67,12 +69,31 @@ func NewAgentDispatcher(d AgentDispatcherDeps) *agentDispatcher {
 	}
 }
 
-// Dispatchable returns true if resolveTarget can produce a non-empty working
-// directory for a. When false, the Service skips dispatch entirely rather than
-// attempting and logging a WARN for every monitor tick.
-func (d *agentDispatcher) Dispatchable(a Anomaly) bool {
+// Dispatchable implements Dispatcher. It calls resolveTarget for the fast path
+// (dir non-empty → dispatchable). When dir is empty it classifies the reason:
+// expected cases (external task with no worktree) return (false, ""); unexpected
+// cases (missing task store, transient lookup failure) return (false, reason) so
+// the caller can emit a WARN instead of silently swallowing the anomaly.
+func (d *agentDispatcher) Dispatchable(a Anomaly) (ok bool, skipReason string) {
 	dir, _, _ := d.resolveTarget(a)
-	return dir != ""
+	if dir != "" {
+		return true, ""
+	}
+	// dir is empty — classify the root cause so the caller can distinguish
+	// expected external-task skips from unexpected resolution failures.
+	if a.TaskID == "" {
+		return false, "board-wide anomaly: repoDir not configured"
+	}
+	if d.tasks == nil {
+		return false, "task store not configured"
+	}
+	if _, err := d.tasks.Get(a.TaskID); err != nil {
+		return false, "task lookup failed: " + err.Error()
+	}
+	// Task exists but has no worktree and repoDir is empty — this is the
+	// known external-task case (e.g. GitHub-issue task on a machine with no
+	// local clone). Skip silently.
+	return false, ""
 }
 
 // Dispatch resolves a working directory and a task title for the anomaly,
@@ -128,7 +149,7 @@ func (d *agentDispatcher) resolveTarget(a Anomaly) (dir, taskID, name string) {
 // Dispatcher without spawning real agents.
 type noopDispatcher struct{}
 
-func (noopDispatcher) Dispatchable(Anomaly) bool                         { return true }
+func (noopDispatcher) Dispatchable(Anomaly) (ok bool, skipReason string) { return true, "" }
 func (noopDispatcher) Dispatch(context.Context, Anomaly) (string, error) { return "", nil }
 
 // NoopDispatcher returns a Dispatcher that never spawns a process. Exported

--- a/internal/monitor/dispatcher.go
+++ b/internal/monitor/dispatcher.go
@@ -13,6 +13,11 @@ import (
 // commenting its own GitHub issue. Dispatch is fire-and-forget — the Service
 // does not block on agent completion.
 type Dispatcher interface {
+	// Dispatchable reports whether the anomaly can be dispatched to an agent.
+	// Callers must check this before Dispatch to avoid spurious WARN logs for
+	// anomalies whose working directory can never be resolved (e.g. external
+	// GitHub-issue tasks with no worktree and an empty repoDir).
+	Dispatchable(a Anomaly) bool
 	Dispatch(ctx context.Context, a Anomaly) (agentID string, err error)
 }
 
@@ -60,6 +65,14 @@ func NewAgentDispatcher(d AgentDispatcherDeps) *agentDispatcher {
 		model:        d.Model,
 		issueRepo:    d.IssueRepo,
 	}
+}
+
+// Dispatchable returns true if resolveTarget can produce a non-empty working
+// directory for a. When false, the Service skips dispatch entirely rather than
+// attempting and logging a WARN for every monitor tick.
+func (d *agentDispatcher) Dispatchable(a Anomaly) bool {
+	dir, _, _ := d.resolveTarget(a)
+	return dir != ""
 }
 
 // Dispatch resolves a working directory and a task title for the anomaly,
@@ -115,6 +128,7 @@ func (d *agentDispatcher) resolveTarget(a Anomaly) (dir, taskID, name string) {
 // Dispatcher without spawning real agents.
 type noopDispatcher struct{}
 
+func (noopDispatcher) Dispatchable(Anomaly) bool                         { return true }
 func (noopDispatcher) Dispatch(context.Context, Anomaly) (string, error) { return "", nil }
 
 // NoopDispatcher returns a Dispatcher that never spawns a process. Exported

--- a/internal/monitor/dispatcher_test.go
+++ b/internal/monitor/dispatcher_test.go
@@ -223,7 +223,8 @@ func TestDispatcher_EmptyRepoDirRejected(t *testing.T) {
 func TestDispatcher_DispatchableEmptyRepoDirNoWorktree(t *testing.T) {
 	d := &agentDispatcher{repoDir: ""}
 	a := Anomaly{Kind: KindStuckHumanBlocked, TaskID: "abc", Fingerprint: "stuck:abc"}
-	if d.Dispatchable(a) {
+	ok, _ := d.Dispatchable(a)
+	if ok {
 		t.Error("want false when repoDir empty and no worktree")
 	}
 }
@@ -231,7 +232,8 @@ func TestDispatcher_DispatchableEmptyRepoDirNoWorktree(t *testing.T) {
 func TestDispatcher_DispatchableWithRepoDir(t *testing.T) {
 	d := &agentDispatcher{repoDir: "/repo"}
 	a := Anomaly{Kind: KindFailureSpike, Fingerprint: "failure_spike"}
-	if !d.Dispatchable(a) {
+	ok, _ := d.Dispatchable(a)
+	if !ok {
 		t.Error("want true when repoDir non-empty")
 	}
 }
@@ -244,16 +246,62 @@ func TestDispatcher_DispatchableWithWorktree(t *testing.T) {
 	}
 	d := &agentDispatcher{repoDir: "", tasks: tasks, worktreePath: worktreeFn}
 	a := Anomaly{Kind: KindStuckHumanBlocked, TaskID: "abc123", Fingerprint: "stuck:abc123"}
-	if !d.Dispatchable(a) {
+	ok, _ := d.Dispatchable(a)
+	if !ok {
 		t.Error("want true when worktree resolves")
+	}
+}
+
+func TestDispatcher_DispatchableMissingTaskStore_ReturnsReason(t *testing.T) {
+	// tasks==nil with a TaskID is unexpected — must return a non-empty reason.
+	d := &agentDispatcher{repoDir: "", tasks: nil, worktreePath: nil}
+	a := Anomaly{Kind: KindStuckHumanBlocked, TaskID: "abc", Fingerprint: "stuck:abc"}
+	ok, reason := d.Dispatchable(a)
+	if ok {
+		t.Fatal("want false")
+	}
+	if reason == "" {
+		t.Error("want non-empty skip reason for missing task store")
+	}
+}
+
+func TestDispatcher_DispatchableTransientLookupFailure_ReturnsReason(t *testing.T) {
+	// tasks.Get failure with empty repoDir is unexpected — must return a reason.
+	tasks := dispatcherTasksStub{err: errors.New("db timeout")}
+	d := &agentDispatcher{repoDir: "", tasks: tasks, worktreePath: nil}
+	a := Anomaly{Kind: KindStuckHumanBlocked, TaskID: "abc", Fingerprint: "stuck:abc"}
+	ok, reason := d.Dispatchable(a)
+	if ok {
+		t.Fatal("want false")
+	}
+	if reason == "" {
+		t.Error("want non-empty skip reason for transient task lookup failure")
+	}
+}
+
+func TestDispatcher_DispatchableExternalTask_SilentSkip(t *testing.T) {
+	// Task exists, worktree returns false, repoDir empty → external task.
+	// This is an expected/known case — skip reason must be empty.
+	theTask := task.Task{ID: "abc123"}
+	tasks := dispatcherTasksStub{task: theTask}
+	worktreeFn := func(task.Task) (string, bool) { return "", false }
+	d := &agentDispatcher{repoDir: "", tasks: tasks, worktreePath: worktreeFn}
+	a := Anomaly{Kind: KindStuckHumanBlocked, TaskID: "abc123", Fingerprint: "stuck:abc123"}
+	ok, reason := d.Dispatchable(a)
+	if ok {
+		t.Fatal("want false for external task with no worktree")
+	}
+	if reason != "" {
+		t.Errorf("want empty reason for known external-task skip, got %q", reason)
 	}
 }
 
 func TestDispatcher_UndispatchableSkippedInService(t *testing.T) {
 	// Verifies that when Dispatchable returns false the dispatcher is never
-	// called, no cooldown slot is consumed, and no WARN is produced.
+	// called and no cooldown slot is consumed. (A WARN is expected here because
+	// tasks==nil with a non-empty TaskID is an unexpected configuration.)
 	rr := &recordingRunner{}
-	// Empty repoDir + no worktree → Dispatchable returns false.
+	// Empty repoDir + no task store → Dispatchable returns (false, reason).
 	d := &agentDispatcher{agents: rr, repoDir: "", tasks: nil, worktreePath: nil}
 
 	svc := &Service{

--- a/internal/monitor/dispatcher_test.go
+++ b/internal/monitor/dispatcher_test.go
@@ -3,11 +3,14 @@ package monitor
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -214,6 +217,68 @@ func TestDispatcher_EmptyRepoDirRejected(t *testing.T) {
 	}
 	if len(rr.calls) != 0 {
 		t.Error("runner must not be called when dir unresolved")
+	}
+}
+
+func TestDispatcher_DispatchableEmptyRepoDirNoWorktree(t *testing.T) {
+	d := &agentDispatcher{repoDir: ""}
+	a := Anomaly{Kind: KindStuckHumanBlocked, TaskID: "abc", Fingerprint: "stuck:abc"}
+	if d.Dispatchable(a) {
+		t.Error("want false when repoDir empty and no worktree")
+	}
+}
+
+func TestDispatcher_DispatchableWithRepoDir(t *testing.T) {
+	d := &agentDispatcher{repoDir: "/repo"}
+	a := Anomaly{Kind: KindFailureSpike, Fingerprint: "failure_spike"}
+	if !d.Dispatchable(a) {
+		t.Error("want true when repoDir non-empty")
+	}
+}
+
+func TestDispatcher_DispatchableWithWorktree(t *testing.T) {
+	theTask := task.Task{ID: "abc123"}
+	tasks := dispatcherTasksStub{task: theTask}
+	worktreeFn := func(t task.Task) (string, bool) {
+		return "/worktrees/abc123", t.ID == "abc123"
+	}
+	d := &agentDispatcher{repoDir: "", tasks: tasks, worktreePath: worktreeFn}
+	a := Anomaly{Kind: KindStuckHumanBlocked, TaskID: "abc123", Fingerprint: "stuck:abc123"}
+	if !d.Dispatchable(a) {
+		t.Error("want true when worktree resolves")
+	}
+}
+
+func TestDispatcher_UndispatchableSkippedInService(t *testing.T) {
+	// Verifies that when Dispatchable returns false the dispatcher is never
+	// called, no cooldown slot is consumed, and no WARN is produced.
+	rr := &recordingRunner{}
+	// Empty repoDir + no worktree → Dispatchable returns false.
+	d := &agentDispatcher{agents: rr, repoDir: "", tasks: nil, worktreePath: nil}
+
+	svc := &Service{
+		dispatcher: d,
+		state:      newRunState(),
+		logger:     slog.Default(),
+		cfg:        config.MonitorConfig{IssueCooldownMinutes: 30},
+	}
+
+	now := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	anoms := []Anomaly{
+		{Kind: KindStuckHumanBlocked, TaskID: "abc", RequiresLLM: true, Fingerprint: "stuck:abc"},
+	}
+	dispatched := svc.dispatchLLMAnomalies(context.Background(), now, anoms)
+	if len(dispatched) != 0 {
+		t.Errorf("want 0 dispatched, got %d", len(dispatched))
+	}
+	if len(rr.calls) != 0 {
+		t.Errorf("runner must not be called for undispatchable anomaly")
+	}
+	// Cooldown must not be consumed — a second call at the same time should
+	// also skip (not because of cooldown but because still undispatchable).
+	dispatched2 := svc.dispatchLLMAnomalies(context.Background(), now, anoms)
+	if len(dispatched2) != 0 {
+		t.Errorf("want 0 dispatched on second call, got %d", len(dispatched2))
 	}
 }
 

--- a/internal/monitor/service.go
+++ b/internal/monitor/service.go
@@ -248,6 +248,9 @@ func (s *Service) dispatchLLMAnomalies(ctx context.Context, now time.Time, anoms
 		if !a.RequiresLLM {
 			continue
 		}
+		if !s.dispatcher.Dispatchable(a) {
+			continue
+		}
 		if !s.state.canDispatch(a.Fingerprint, now, cooldown) {
 			continue
 		}

--- a/internal/monitor/service.go
+++ b/internal/monitor/service.go
@@ -248,7 +248,11 @@ func (s *Service) dispatchLLMAnomalies(ctx context.Context, now time.Time, anoms
 		if !a.RequiresLLM {
 			continue
 		}
-		if !s.dispatcher.Dispatchable(a) {
+		ok, skipReason := s.dispatcher.Dispatchable(a)
+		if !ok {
+			if skipReason != "" {
+				s.logger.Warn("monitor.dispatch.undispatchable", "kind", a.Kind, "task_id", a.TaskID, "reason", skipReason)
+			}
 			continue
 		}
 		if !s.state.canDispatch(a.Fingerprint, now, cooldown) {

--- a/internal/monitor/service_test.go
+++ b/internal/monitor/service_test.go
@@ -100,7 +100,7 @@ type fakeDispatcher struct {
 	nextID int
 }
 
-func (f *fakeDispatcher) Dispatchable(Anomaly) bool { return true }
+func (f *fakeDispatcher) Dispatchable(Anomaly) (ok bool, skipReason string) { return true, "" }
 
 func (f *fakeDispatcher) Dispatch(_ context.Context, a Anomaly) (string, error) {
 	f.mu.Lock()

--- a/internal/monitor/service_test.go
+++ b/internal/monitor/service_test.go
@@ -100,6 +100,8 @@ type fakeDispatcher struct {
 	nextID int
 }
 
+func (f *fakeDispatcher) Dispatchable(Anomaly) bool { return true }
+
 func (f *fakeDispatcher) Dispatch(_ context.Context, a Anomaly) (string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()


### PR DESCRIPTION
## Motivation

Anomalies that cannot be dispatched (e.g. GitHub-issue tasks with no local worktree and no repoDir configured) were silently consuming cooldown slots, preventing the same anomaly from being retried once conditions changed. Unexpected configuration failures (missing task store, transient lookup errors) were swallowed without any log signal.

Closes https://github.com/Automaat/sybra/issues/679

## Implementation information

- Added `Dispatchable(Anomaly) (ok bool, skipReason string)` to the `Dispatcher` interface.
- `agentDispatcher.Dispatchable` calls the existing `resolveTarget` fast path: non-empty dir → dispatchable. Empty dir is then classified: empty TaskID or nil task store or lookup failure → returns non-empty `skipReason` so callers emit a WARN; task exists with no worktree and empty repoDir (known external-task case) → returns `(false, "")` for a silent skip.
- `Service.dispatchLLMAnomalies` calls `Dispatchable` before the cooldown check; undispatchable anomalies skip without consuming a cooldown slot. Non-empty `skipReason` triggers a `slog.Warn`.
- `noopDispatcher` and `fakeDispatcher` implement the new method (always returns `true, ""`).
- Tests cover all four Dispatchable paths plus end-to-end verification that the runner is never called and no cooldown is consumed for undispatchable anomalies.