### PR TITLE
fix(worktree): pre-check branch on push-force

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -298,7 +298,11 @@ func PushUpstream(worktreePath, branch string) error {
 // Returns ErrBranchMissing if the local branch ref does not exist.
 func PushForce(worktreePath, branch string) error {
 	if err := executil.Run(worktreePath, "git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch); err != nil {
-		return ErrBranchMissing
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return ErrBranchMissing
+		}
+		return err
 	}
 	return executil.Run(worktreePath, "git", "push", "--force-with-lease", "-u", "origin", branch)
 }

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -11,6 +12,9 @@ import (
 	"github.com/Automaat/sybra/internal/executil"
 	"gopkg.in/yaml.v3"
 )
+
+// ErrBranchMissing is returned by PushForce when the local branch ref does not exist.
+var ErrBranchMissing = errors.New("local branch ref does not exist")
 
 // LoadRepoConfig reads .sybra.yaml from the worktree root. Returns an empty
 // RepoConfig (not an error) if the file does not exist.
@@ -291,7 +295,11 @@ func PushUpstream(worktreePath, branch string) error {
 // PushForce force-pushes the branch to origin using --force-with-lease.
 // Used after a local rebase to sync the remote without overwriting commits
 // from other authors (--force-with-lease fails if remote has unknown commits).
+// Returns ErrBranchMissing if the local branch ref does not exist.
 func PushForce(worktreePath, branch string) error {
+	if err := executil.Run(worktreePath, "git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch); err != nil {
+		return ErrBranchMissing
+	}
 	return executil.Run(worktreePath, "git", "push", "--force-with-lease", "-u", "origin", branch)
 }
 

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -2,6 +2,7 @@ package worktree
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -156,9 +157,7 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 				// Sync remote after rebase — local SHAs changed, remote still has
 				// old commits. create_pr push would fail with "diverged" otherwise.
 				callPhase(onPhase, "Pushing upstream…")
-				if err := project.PushForce(wtPath, wtBranch); err != nil {
-					m.logger.Warn("worktree.push-force", "task_id", t.ID, "branch", wtBranch, "err", err)
-				}
+				m.logPushForce(t.ID, wtBranch, project.PushForce(wtPath, wtBranch))
 			}
 			m.installChecks(wtPath, proj)
 			m.ensureBranch(t, wtBranch)
@@ -186,9 +185,7 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 		} else {
 			// Sync remote after rebase.
 			callPhase(onPhase, "Pushing upstream…")
-			if err := project.PushForce(wtPath, wtBranch); err != nil {
-				m.logger.Warn("worktree.push-force", "task_id", t.ID, "branch", wtBranch, "err", err)
-			}
+			m.logPushForce(t.ID, wtBranch, project.PushForce(wtPath, wtBranch))
 		}
 		m.logger.Info("worktree.reused-branch", "task_id", t.ID, "path", wtPath, "branch", wtBranch)
 		callPhase(onPhase, "Running setup…")
@@ -705,5 +702,16 @@ func (m *Manager) ensureBranch(t task.Task, branch string) {
 	}
 	if _, err := m.tasks.Update(t.ID, task.Update{Branch: task.Ptr(branch)}); err != nil {
 		m.logger.Error("worktree.set-branch", "task_id", t.ID, "err", err)
+	}
+}
+
+func (m *Manager) logPushForce(taskID, branch string, err error) {
+	if err == nil {
+		return
+	}
+	if errors.Is(err, project.ErrBranchMissing) {
+		m.logger.Info("worktree.push-force-skipped", "task_id", taskID, "branch", branch, "reason", "local branch ref missing")
+	} else {
+		m.logger.Warn("worktree.push-force", "task_id", taskID, "branch", branch, "err", err)
 	}
 }


### PR DESCRIPTION
## Motivation

`PushForce` was calling `git push --force-with-lease` without verifying the local branch ref exists first, producing noisy WARN logs when a worktree branch was deleted or never created:

```
worktree.push-force WARN err="git push --force-with-lease -u origin sybra/...: exit status 1: error: src refspec ... does not match any"
```

Closes https://github.com/Automaat/sybra/issues/683

## Implementation information

Two commits:

1. `fix(worktree): pre-check branch on push-force` — adds a `git show-ref --verify` call before the push in `PushForce`. Returns early with `ErrBranchMissing` (a typed sentinel) if the ref doesn't exist, avoiding the misleading push error.

2. `fix(project): distinguish missing ref from other show-ref errors in PushForce` — tightens the error check to only treat exit code 1 as `ErrBranchMissing`; other non-zero exit codes propagate as real errors.

The caller (`internal/worktree/manager.go`) already logs WARN on error — with the sentinel, it can now distinguish a missing-branch (expected/benign) from a genuine push failure.

> Changelog: fix(worktree): pre-check branch on push-force