### PR TITLE
fix(pr-monitor): gate retry on head SHA change

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/github/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/github/models.ts
@@ -122,6 +122,7 @@ export class PullRequest {
     "isDraft": boolean;
     "labels": string[];
     "headRefName": string;
+    "headSha": string;
 
     /**
      * SUCCESS, FAILURE, PENDING, or ""
@@ -175,6 +176,9 @@ export class PullRequest {
         }
         if (!("headRefName" in $$source)) {
             this["headRefName"] = "";
+        }
+        if (!("headSha" in $$source)) {
+            this["headSha"] = "";
         }
         if (!("ciStatus" in $$source)) {
             this["ciStatus"] = "";
@@ -230,6 +234,7 @@ export class RenovatePR {
     "isDraft": boolean;
     "labels": string[];
     "headRefName": string;
+    "headSha": string;
 
     /**
      * SUCCESS, FAILURE, PENDING, or ""
@@ -285,6 +290,9 @@ export class RenovatePR {
         if (!("headRefName" in $$source)) {
             this["headRefName"] = "";
         }
+        if (!("headSha" in $$source)) {
+            this["headSha"] = "";
+        }
         if (!("ciStatus" in $$source)) {
             this["ciStatus"] = "";
         }
@@ -321,13 +329,13 @@ export class RenovatePR {
      */
     static createFrom($$source: any = {}): RenovatePR {
         const $$createField7_0 = $$createType0;
-        const $$createField17_0 = $$createType2;
+        const $$createField18_0 = $$createType2;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("labels" in $$parsedSource) {
             $$parsedSource["labels"] = $$createField7_0($$parsedSource["labels"]);
         }
         if ("checkRuns" in $$parsedSource) {
-            $$parsedSource["checkRuns"] = $$createField17_0($$parsedSource["checkRuns"]);
+            $$parsedSource["checkRuns"] = $$createField18_0($$parsedSource["checkRuns"]);
         }
         return new RenovatePR($$parsedSource as Partial<RenovatePR>);
     }

--- a/frontend/src/components/PRCard.svelte.test.ts
+++ b/frontend/src/components/PRCard.svelte.test.ts
@@ -13,6 +13,7 @@ function makePR(overrides: Record<string, unknown> = {}) {
     isDraft: false,
     labels: [],
     headRefName: 'feature/test',
+    headSha: 'abc1234',
     ciStatus: '',
     hasPendingChecks: false,
     reviewDecision: '',

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -97,6 +97,7 @@ const prQuery = `query($q: String!) {
         commits(last: 1) {
           nodes {
             commit {
+              oid
               statusCheckRollup {
                 state
                 contexts(first: 50) {
@@ -176,6 +177,7 @@ type gqlPR struct {
 	Commits struct {
 		Nodes []struct {
 			Commit struct {
+				OID               string                `json:"oid"`
 				StatusCheckRollup *gqlStatusCheckRollup `json:"statusCheckRollup"`
 			} `json:"commit"`
 		} `json:"nodes"`
@@ -224,7 +226,9 @@ func convertCommonPR(n *gqlPR, viewer string) PullRequest {
 
 	var ciStatus string
 	var hasPendingChecks bool
+	var headSHA string
 	if len(n.Commits.Nodes) > 0 {
+		headSHA = n.Commits.Nodes[0].Commit.OID
 		if rollup := n.Commits.Nodes[0].Commit.StatusCheckRollup; rollup != nil {
 			ciStatus = rollup.State
 			for _, ctx := range rollup.Contexts.Nodes {
@@ -258,6 +262,7 @@ func convertCommonPR(n *gqlPR, viewer string) PullRequest {
 		Title:             n.Title,
 		URL:               n.URL,
 		HeadRefName:       n.HeadRefName,
+		HeadSHA:           headSHA,
 		Repository:        n.Repository.NameWithOwner,
 		RepoName:          n.Repository.Name,
 		Author:            n.Author.Login,

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -216,10 +216,12 @@ func TestConvertPRs_ciStatus(t *testing.T) {
 			if tt.hasCI {
 				node.Commits.Nodes = []struct {
 					Commit struct {
+						OID               string                `json:"oid"`
 						StatusCheckRollup *gqlStatusCheckRollup `json:"statusCheckRollup"`
 					} `json:"commit"`
 				}{
 					{Commit: struct {
+						OID               string                `json:"oid"`
 						StatusCheckRollup *gqlStatusCheckRollup `json:"statusCheckRollup"`
 					}{StatusCheckRollup: &gqlStatusCheckRollup{State: tt.state}}},
 				}

--- a/internal/github/debounce.go
+++ b/internal/github/debounce.go
@@ -13,6 +13,7 @@ type IssueTracker struct {
 	mu       sync.Mutex
 	handled  map[string]time.Time
 	retries  map[string]int
+	lastSHA  map[string]string
 	cooldown time.Duration
 	now      func() time.Time // injectable for testing
 }
@@ -22,6 +23,7 @@ func NewIssueTracker(cooldown time.Duration) *IssueTracker {
 	return &IssueTracker{
 		handled:  make(map[string]time.Time),
 		retries:  make(map[string]int),
+		lastSHA:  make(map[string]string),
 		cooldown: cooldown,
 		now:      time.Now,
 	}
@@ -31,13 +33,19 @@ func issueKey(taskID string, kind PRIssueKind) string {
 	return taskID + ":" + string(kind)
 }
 
-// ShouldHandle returns true if this issue hasn't been handled within the
-// cooldown and hasn't exceeded max retries.
-func (t *IssueTracker) ShouldHandle(taskID string, kind PRIssueKind) bool {
+// ShouldHandle returns true if this issue should be retried.
+// Blocks when: max retries reached, same SHA as last attempt (no new commit),
+// or within cooldown window (first attempt or SHA unknown).
+func (t *IssueTracker) ShouldHandle(taskID string, kind PRIssueKind, sha string) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	key := issueKey(taskID, kind)
 	if t.retries[key] >= maxRetries {
+		return false
+	}
+	// If SHA is known and unchanged, the fix attempt ran against this exact
+	// commit with no new push since — skip until a new commit arrives.
+	if sha != "" && t.lastSHA[key] == sha {
 		return false
 	}
 	last, ok := t.handled[key]
@@ -48,16 +56,20 @@ func (t *IssueTracker) ShouldHandle(taskID string, kind PRIssueKind) bool {
 }
 
 // MarkHandled records that an agent was spawned for this issue.
-func (t *IssueTracker) MarkHandled(taskID string, kind PRIssueKind) {
+func (t *IssueTracker) MarkHandled(taskID string, kind PRIssueKind, sha string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	key := issueKey(taskID, kind)
 	t.handled[key] = t.now()
 	t.retries[key]++
+	if sha != "" {
+		t.lastSHA[key] = sha
+	}
 }
 
-// ClearCooldown removes the cooldown for a task+issue so the next poll
-// can retry immediately. The retry counter is preserved.
+// ClearCooldown removes the time-based cooldown for a task+issue so the next
+// poll can retry immediately if the SHA has changed. The retry counter and
+// last-attempt SHA are preserved.
 func (t *IssueTracker) ClearCooldown(taskID string, kind PRIssueKind) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -71,6 +83,7 @@ func (t *IssueTracker) Clear(taskID string, kind PRIssueKind) {
 	key := issueKey(taskID, kind)
 	delete(t.handled, key)
 	delete(t.retries, key)
+	delete(t.lastSHA, key)
 }
 
 // Retries returns the current retry count for a task+issue.
@@ -89,6 +102,7 @@ func (t *IssueTracker) Cleanup() {
 		if v.Before(cutoff) {
 			delete(t.handled, k)
 			delete(t.retries, k)
+			delete(t.lastSHA, k)
 		}
 	}
 }

--- a/internal/github/debounce_test.go
+++ b/internal/github/debounce_test.go
@@ -12,42 +12,63 @@ func TestIssueTracker(t *testing.T) {
 	tracker.now = func() time.Time { return now }
 
 	t.Run("first occurrence is handleable", func(t *testing.T) {
-		if !tracker.ShouldHandle("t1", PRIssueConflict) {
+		if !tracker.ShouldHandle("t1", PRIssueConflict, "") {
 			t.Fatal("expected ShouldHandle=true for new issue")
 		}
 	})
 
 	t.Run("within cooldown is not handleable", func(t *testing.T) {
-		tracker.MarkHandled("t1", PRIssueConflict)
+		tracker.MarkHandled("t1", PRIssueConflict, "sha1")
 
 		now = now.Add(10 * time.Minute)
-		if tracker.ShouldHandle("t1", PRIssueConflict) {
+		if tracker.ShouldHandle("t1", PRIssueConflict, "sha1") {
 			t.Fatal("expected ShouldHandle=false within cooldown")
 		}
 	})
 
-	t.Run("after cooldown is handleable again", func(t *testing.T) {
-		now = now.Add(25 * time.Minute) // 35 min total since mark
-		if !tracker.ShouldHandle("t1", PRIssueConflict) {
-			t.Fatal("expected ShouldHandle=true after cooldown")
+	t.Run("same sha blocks regardless of cooldown", func(t *testing.T) {
+		now = now.Add(25 * time.Minute) // 35 min total since mark — past cooldown
+		if tracker.ShouldHandle("t1", PRIssueConflict, "sha1") {
+			t.Fatal("expected ShouldHandle=false: same SHA as last attempt")
+		}
+	})
+
+	t.Run("new sha allows retry after cooldown", func(t *testing.T) {
+		if !tracker.ShouldHandle("t1", PRIssueConflict, "sha2") {
+			t.Fatal("expected ShouldHandle=true: new SHA after cooldown")
+		}
+	})
+
+	t.Run("new sha within cooldown is still blocked", func(t *testing.T) {
+		tracker.MarkHandled("t6", PRIssueCIFailure, "sha-a")
+		now = now.Add(5 * time.Minute) // within cooldown
+		if tracker.ShouldHandle("t6", PRIssueCIFailure, "sha-b") {
+			t.Fatal("expected ShouldHandle=false: new SHA but within cooldown")
+		}
+	})
+
+	t.Run("empty sha skips sha gate", func(t *testing.T) {
+		now = now.Add(31 * time.Minute) // past cooldown for t6
+		if !tracker.ShouldHandle("t6", PRIssueCIFailure, "") {
+			t.Fatal("expected ShouldHandle=true: empty SHA skips SHA gate")
 		}
 	})
 
 	t.Run("different issue kinds are independent", func(t *testing.T) {
 		now = time.Date(2026, 4, 3, 13, 0, 0, 0, time.UTC)
-		tracker.MarkHandled("t2", PRIssueCIFailure)
+		tracker.MarkHandled("t2", PRIssueCIFailure, "sha-x")
 
-		if !tracker.ShouldHandle("t2", PRIssueConflict) {
+		if !tracker.ShouldHandle("t2", PRIssueConflict, "sha-x") {
 			t.Fatal("expected ShouldHandle=true for different kind")
 		}
-		if tracker.ShouldHandle("t2", PRIssueCIFailure) {
-			t.Fatal("expected ShouldHandle=false for same kind")
+		if tracker.ShouldHandle("t2", PRIssueCIFailure, "sha-x") {
+			t.Fatal("expected ShouldHandle=false for same kind + same SHA")
 		}
 	})
 
 	t.Run("clear removes tracking and retries", func(t *testing.T) {
 		tracker.Clear("t2", PRIssueCIFailure)
-		if !tracker.ShouldHandle("t2", PRIssueCIFailure) {
+		if !tracker.ShouldHandle("t2", PRIssueCIFailure, "sha-x") {
 			t.Fatal("expected ShouldHandle=true after Clear")
 		}
 		if tracker.Retries("t2", PRIssueCIFailure) != 0 {
@@ -55,15 +76,20 @@ func TestIssueTracker(t *testing.T) {
 		}
 	})
 
-	t.Run("clear cooldown preserves retry count", func(t *testing.T) {
-		tracker.MarkHandled("t4", PRIssueCIFailure)
+	t.Run("clear cooldown preserves retry count and sha", func(t *testing.T) {
+		tracker.MarkHandled("t4", PRIssueCIFailure, "sha-old")
 		if tracker.Retries("t4", PRIssueCIFailure) != 1 {
 			t.Fatalf("retries = %d, want 1", tracker.Retries("t4", PRIssueCIFailure))
 		}
 
 		tracker.ClearCooldown("t4", PRIssueCIFailure)
-		if !tracker.ShouldHandle("t4", PRIssueCIFailure) {
-			t.Fatal("expected ShouldHandle=true after ClearCooldown")
+		// same SHA still blocked even after ClearCooldown
+		if tracker.ShouldHandle("t4", PRIssueCIFailure, "sha-old") {
+			t.Fatal("expected ShouldHandle=false: same SHA blocks even after ClearCooldown")
+		}
+		// new SHA allowed since time gate is cleared
+		if !tracker.ShouldHandle("t4", PRIssueCIFailure, "sha-new") {
+			t.Fatal("expected ShouldHandle=true: new SHA after ClearCooldown")
 		}
 		if tracker.Retries("t4", PRIssueCIFailure) != 1 {
 			t.Fatal("expected retries preserved after ClearCooldown")
@@ -72,35 +98,37 @@ func TestIssueTracker(t *testing.T) {
 
 	t.Run("max retries blocks handling", func(t *testing.T) {
 		now = time.Date(2026, 4, 3, 14, 0, 0, 0, time.UTC)
+		sha := "sha-0"
 		for i := range maxRetries {
-			tracker.MarkHandled("t5", PRIssueConflict)
+			tracker.MarkHandled("t5", PRIssueConflict, sha)
+			sha = "sha-" + string(rune('1'+i)) // new SHA each iteration
 			now = now.Add(31 * time.Minute)
 			if i < maxRetries-1 {
-				if !tracker.ShouldHandle("t5", PRIssueConflict) {
+				if !tracker.ShouldHandle("t5", PRIssueConflict, sha) {
 					t.Fatalf("expected ShouldHandle=true on retry %d", i+1)
 				}
 			}
 		}
-		// Even after cooldown, max retries should block.
-		if tracker.ShouldHandle("t5", PRIssueConflict) {
+		// Even after cooldown with new SHA, max retries should block.
+		if tracker.ShouldHandle("t5", PRIssueConflict, sha) {
 			t.Fatal("expected ShouldHandle=false after max retries")
 		}
 	})
 
 	t.Run("clear resets retry cap", func(t *testing.T) {
 		tracker.Clear("t5", PRIssueConflict)
-		if !tracker.ShouldHandle("t5", PRIssueConflict) {
+		if !tracker.ShouldHandle("t5", PRIssueConflict, "") {
 			t.Fatal("expected ShouldHandle=true after Clear resets retries")
 		}
 	})
 
 	t.Run("cleanup removes old entries", func(t *testing.T) {
-		tracker.MarkHandled("t3", PRIssueConflict)
+		tracker.MarkHandled("t3", PRIssueConflict, "sha-old")
 		now = now.Add(61 * time.Minute) // past 2x cooldown
 		tracker.Cleanup()
 
-		// t3 should be cleaned up
-		if !tracker.ShouldHandle("t3", PRIssueConflict) {
+		// t3 should be cleaned up — new SHA allowed
+		if !tracker.ShouldHandle("t3", PRIssueConflict, "sha-old") {
 			t.Fatal("expected ShouldHandle=true after cleanup")
 		}
 		if tracker.Retries("t3", PRIssueConflict) != 0 {

--- a/internal/github/model.go
+++ b/internal/github/model.go
@@ -11,6 +11,7 @@ type PullRequest struct {
 	IsDraft           bool     `json:"isDraft"`
 	Labels            []string `json:"labels"`
 	HeadRefName       string   `json:"headRefName"`
+	HeadSHA           string   `json:"headSha"`
 	CIStatus          string   `json:"ciStatus"`         // SUCCESS, FAILURE, PENDING, or ""
 	HasPendingChecks  bool     `json:"hasPendingChecks"` // true when any check is still in-progress/queued
 	ReviewDecision    string   `json:"reviewDecision"`   // APPROVED, CHANGES_REQUESTED, REVIEW_REQUIRED, or ""

--- a/internal/github/renovate.go
+++ b/internal/github/renovate.go
@@ -34,6 +34,7 @@ const renovatePRQuery = `query($q: String!) {
         commits(last: 1) {
           nodes {
             commit {
+              oid
               statusCheckRollup {
                 state
                 contexts(first: 50) {

--- a/internal/github/renovate_test.go
+++ b/internal/github/renovate_test.go
@@ -33,9 +33,11 @@ func TestConvertRenovatePRs(t *testing.T) {
 		node := makeNode("renovate[bot]", "Bot")
 		node.Commits.Nodes = []struct {
 			Commit struct {
+				OID               string                `json:"oid"`
 				StatusCheckRollup *gqlStatusCheckRollup `json:"statusCheckRollup"`
 			} `json:"commit"`
 		}{{Commit: struct {
+			OID               string                `json:"oid"`
 			StatusCheckRollup *gqlStatusCheckRollup `json:"statusCheckRollup"`
 		}{StatusCheckRollup: &gqlStatusCheckRollup{
 			State: "FAILURE",

--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -36,6 +36,7 @@ const reviewSummaryQuery = `query($createdQ: String!, $requestedQ: String!) {
         commits(last: 1) {
           nodes {
             commit {
+              oid
               statusCheckRollup {
                 state
                 contexts(first: 20) {
@@ -74,6 +75,7 @@ const reviewSummaryQuery = `query($createdQ: String!, $requestedQ: String!) {
         commits(last: 1) {
           nodes {
             commit {
+              oid
               statusCheckRollup {
                 state
                 contexts(first: 20) {

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -242,13 +242,6 @@ func isSignalKill(err error) bool {
 //     (done/cancelled/in-review/human-required/blocked) match no triggers,
 //     so DispatchEvent returns "" without starting anything.
 func (h *AgentCompletionHandler) OnWorkflowComplete(info workflow.CompletionInfo) {
-	if kind := github.PRIssueKind(info.Variables["pr_issue_kind"]); kind != "" {
-		h.prTracker.ClearCooldown(info.TaskID, kind)
-		h.logger.Info("pr-tracker.cooldown-cleared",
-			"task_id", info.TaskID, "kind", string(kind),
-			"retries", h.prTracker.Retries(info.TaskID, kind))
-	}
-
 	if h.workflowEngine == nil {
 		return
 	}

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -349,7 +349,7 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 			if r.agents.HasRunningAgentForTask(issues[i].TaskID) {
 				continue
 			}
-			if !r.prTracker.ShouldHandle(issues[i].TaskID, issues[i].Kind) {
+			if !r.prTracker.ShouldHandle(issues[i].TaskID, issues[i].Kind, issues[i].PR.HeadSHA) {
 				continue
 			}
 			if issues[i].Kind == github.PRIssueReadyToMerge {
@@ -421,7 +421,7 @@ func (r *ReviewHandler) handleAutoMerge(issue github.PRIssue) {
 		return
 	}
 
-	r.prTracker.MarkHandled(t.ID, issue.Kind)
+	r.prTracker.MarkHandled(t.ID, issue.Kind, issue.PR.HeadSHA)
 	r.logAudit(audit.EventPRAutoMerged, t.ID, "", map[string]any{
 		"pr": issue.PR.Number, "repo": issue.PR.Repository,
 	})
@@ -504,7 +504,7 @@ func (r *ReviewHandler) handlePRIssue(issue github.PRIssue) {
 		return
 	}
 
-	r.prTracker.MarkHandled(t.ID, issue.Kind)
+	r.prTracker.MarkHandled(t.ID, issue.Kind, issue.PR.HeadSHA)
 	r.logAudit(audit.EventPRFixAgentStarted, t.ID, "", map[string]any{
 		"issue": string(issue.Kind), "pr": issue.PR.Number, "workflow": wfID,
 	})


### PR DESCRIPTION
## Motivation

The PR monitor was re-dispatching fix agents on every workflow completion
for the same commit, burning retry budget without making progress. The
cooldown throttle only applied to the first attempt — once cleared via
`OnWorkflowComplete`, subsequent monitor cycles could re-fire immediately
against the same HEAD SHA.

Closes https://github.com/Automaat/sybra/issues/680

## Implementation information

Track `HeadSHA` from the GraphQL `oid` field (added to all three PR
queries: `prQuery`, `renovatePRQuery`, `reviewSummaryQuery`) and store it
in `IssueTracker.lastSHA` per task+kind key.

`ShouldHandle` now blocks re-dispatch when the incoming SHA matches the
last attempted SHA — the monitor can only re-fire after a new commit is
pushed. Cooldown remains as an initial throttle for the very first attempt.

`OnWorkflowComplete` no longer calls `ClearCooldown` unconditionally; SHA
gating is the primary signal, so clearing the time gate on completion
would bypass the fix entirely.

`Clear` and `Cleanup` were updated to evict `lastSHA` alongside the other
per-key state so stale entries don't accumulate.

Tests were rewritten to cover the new SHA-gating invariants: same SHA
blocks even past cooldown, new SHA allows retry after cooldown, empty SHA
skips the SHA gate (backward compat), and `ClearCooldown` no longer
unlocks same-SHA re-dispatch.