### PR TITLE
fix(github): downgrade transient gh-api errors

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -328,3 +328,19 @@ func ParseIssueURL(rawURL string) (repo string, number int) {
 func ViewerLogin() string {
 	return viewerLogin(defaultExecer)
 }
+
+// IsTransientError reports whether err is a transient GitHub API failure
+// (HTTP 5xx or network timeout) that is expected to resolve on its own.
+func IsTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	// HTTP 5xx: sanitized gh output produces "gh: http 5xx"
+	if strings.Contains(msg, "http 5") {
+		return true
+	}
+	return strings.Contains(msg, "dial tcp") ||
+		strings.Contains(msg, "i/o timeout") ||
+		strings.Contains(msg, "context deadline exceeded")
+}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -637,6 +637,39 @@ func TestParseIssueURL(t *testing.T) {
 	}
 }
 
+func TestIsTransientError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		errMsg    string
+		transient bool
+	}{
+		{"nil error", "", false},
+		{"504 html page", "gh api graphql: gh: HTTP 504: exit status 1", true},
+		{"502 html page", "gh api graphql: gh: HTTP 502: exit status 1", true},
+		{"500 internal", "gh api graphql: gh: HTTP 500: exit status 1", true},
+		{"dial tcp timeout", "gh api graphql: dial tcp 1.2.3.4:443: i/o timeout: exit status 1", true},
+		{"i/o timeout bare", "i/o timeout", true},
+		{"context deadline exceeded", "context deadline exceeded", true},
+		{"401 auth", "gh api graphql: gh: HTTP 401: exit status 1", false},
+		{"404 not found", "gh api graphql: gh: HTTP 404: exit status 1", false},
+		{"graphql error", "graphql: Field 'foo' doesn't exist", false},
+		{"parse error", "parse graphql response: unexpected EOF", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var err error
+			if tt.errMsg != "" {
+				err = fmt.Errorf("%s", tt.errMsg)
+			}
+			if got := IsTransientError(err); got != tt.transient {
+				t.Errorf("IsTransientError(%q) = %v, want %v", tt.errMsg, got, tt.transient)
+			}
+		})
+	}
+}
+
 func TestSanitizeGHOutput(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/poll/issues.go
+++ b/internal/poll/issues.go
@@ -14,19 +14,23 @@ import (
 
 const IssuesPollInterval = 5 * time.Minute
 
+const issuesTransientWarnThreshold = 3
+
 // synapseIssueLabel is the GitHub label that triggers auto-creation of Sybra tasks.
 const synapseIssueLabel = "sybra"
 
 // IssuesFetcher polls GitHub for assigned and labeled issues and syncs them to tasks.
 type IssuesFetcher struct {
-	tasks         *task.Manager
-	projects      *project.Store
-	emit          func(string, any)
-	logger        *slog.Logger
-	allowsType    func(project.ProjectType) bool
-	fetchAssigned func() ([]github.Issue, error)
-	fetchLabeled  func(repos []string, label string) ([]github.Issue, error)
-	fetchSnapshot func(repos []string, label string) (github.IssueSnapshot, error)
+	tasks                 *task.Manager
+	projects              *project.Store
+	emit                  func(string, any)
+	logger                *slog.Logger
+	allowsType            func(project.ProjectType) bool
+	fetchAssigned         func() ([]github.Issue, error)
+	fetchLabeled          func(repos []string, label string) ([]github.Issue, error)
+	fetchSnapshot         func(repos []string, label string) (github.IssueSnapshot, error)
+	transientFetchFails   int
+	transientLabeledFails int
 }
 
 // NewIssuesFetcher creates an IssuesFetcher. allowsType filters issues whose
@@ -65,9 +69,20 @@ func (f *IssuesFetcher) Poll(_ context.Context) time.Duration {
 	issues, err := f.fetchAssigned()
 	metrics.GitHubFetch(err == nil)
 	if err != nil {
-		f.logger.Warn("issues.fetch", "err", err)
+		if github.IsTransientError(err) {
+			f.transientFetchFails++
+			if f.transientFetchFails < issuesTransientWarnThreshold {
+				f.logger.Info("issues.fetch", "err", err)
+			} else {
+				f.logger.Warn("issues.fetch", "err", err, "consecutive", f.transientFetchFails)
+			}
+		} else {
+			f.transientFetchFails = 0
+			f.logger.Warn("issues.fetch", "err", err)
+		}
 		return IssuesPollInterval
 	}
+	f.transientFetchFails = 0
 	f.emit("issues:updated", issues)
 	f.logger.Debug("issues.poll", "count", len(issues))
 	metrics.GitHubIssuesImported(len(issues))
@@ -81,9 +96,20 @@ func (f *IssuesFetcher) pollSnapshot() {
 	snapshot, err := f.fetchSnapshot(repos, synapseIssueLabel)
 	metrics.GitHubFetch(err == nil)
 	if err != nil {
-		f.logger.Warn("issues.fetch", "err", err)
+		if github.IsTransientError(err) {
+			f.transientFetchFails++
+			if f.transientFetchFails < issuesTransientWarnThreshold {
+				f.logger.Info("issues.fetch", "err", err)
+			} else {
+				f.logger.Warn("issues.fetch", "err", err, "consecutive", f.transientFetchFails)
+			}
+		} else {
+			f.transientFetchFails = 0
+			f.logger.Warn("issues.fetch", "err", err)
+		}
 		return
 	}
+	f.transientFetchFails = 0
 
 	f.emit("issues:updated", snapshot.Assigned)
 	f.logger.Debug("issues.poll", "count", len(snapshot.Assigned))
@@ -110,9 +136,20 @@ func (f *IssuesFetcher) syncLabeledIssuesToTasks() {
 
 	labeled, err := f.fetchLabeled(repos, synapseIssueLabel)
 	if err != nil {
-		f.logger.Warn("labeled-issues.fetch", "err", err)
+		if github.IsTransientError(err) {
+			f.transientLabeledFails++
+			if f.transientLabeledFails < issuesTransientWarnThreshold {
+				f.logger.Info("labeled-issues.fetch", "err", err)
+			} else {
+				f.logger.Warn("labeled-issues.fetch", "err", err, "consecutive", f.transientLabeledFails)
+			}
+		} else {
+			f.transientLabeledFails = 0
+			f.logger.Warn("labeled-issues.fetch", "err", err)
+		}
 		return
 	}
+	f.transientLabeledFails = 0
 	f.logger.Debug("labeled-issues.poll", "count", len(labeled))
 	f.syncIssuesToTasks(labeled)
 }

--- a/internal/poll/renovate.go
+++ b/internal/poll/renovate.go
@@ -18,14 +18,17 @@ const (
 	RenovatePollSlow = 5 * time.Minute
 )
 
+const renovateTransientWarnThreshold = 3
+
 // RenovateHandler manages Renovate PR polling and actions.
 type RenovateHandler struct {
-	projects     *project.Store
-	logger       *slog.Logger
-	emit         func(string, any)
-	cfg          *config.RenovateConfig
-	allowsType   func(project.ProjectType) bool
-	lastPRsCount atomic.Int64
+	projects            *project.Store
+	logger              *slog.Logger
+	emit                func(string, any)
+	cfg                 *config.RenovateConfig
+	allowsType          func(project.ProjectType) bool
+	lastPRsCount        atomic.Int64
+	transientFetchFails int
 }
 
 // NewRenovateHandler creates a RenovateHandler. allowsType filters which
@@ -88,9 +91,20 @@ func (h *RenovateHandler) pollRenovatePRs() time.Duration {
 	prs, err := github.FetchRenovatePRs(h.cfg.Author, repos)
 	metrics.RenovatePoll(err == nil)
 	if err != nil {
-		h.logger.Warn("renovate.fetch", "err", err)
+		if github.IsTransientError(err) {
+			h.transientFetchFails++
+			if h.transientFetchFails < renovateTransientWarnThreshold {
+				h.logger.Info("renovate.fetch", "err", err)
+			} else {
+				h.logger.Warn("renovate.fetch", "err", err, "consecutive", h.transientFetchFails)
+			}
+		} else {
+			h.transientFetchFails = 0
+			h.logger.Warn("renovate.fetch", "err", err)
+		}
 		return RenovatePollSlow
 	}
+	h.transientFetchFails = 0
 
 	h.lastPRsCount.Store(int64(len(prs)))
 	h.emit(events.RenovateUpdated, prs)

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -43,48 +43,49 @@ import (
 )
 
 type App struct {
-	ctx             context.Context
-	cancel          context.CancelFunc
-	wg              sync.WaitGroup
-	tasks           *task.Manager
-	projects        *project.Store
-	loopAgents      *loopagent.Store
-	loopSched       *loopagent.Scheduler
-	agents          *agent.Manager
-	watcher         *watcher.Watcher
-	configWatcher   *confighot.Watcher
-	notifier        *notification.Emitter
-	audit           *audit.Logger
-	stats           *stats.Store
-	tasksDir        string
-	skillsDir       string
-	repoDir         string
-	worktreesDir    string
-	logger          *slog.Logger
-	logDir          string
-	auditDir        string
-	prTracker       *github.IssueTracker
-	providerHealth  *provider.Checker
-	worktrees       *worktree.Manager
-	sandboxes       *sandbox.Manager
-	monitorSvc      *monitor.Service
-	selfMonitorSvc  *selfmonitor.Service
-	agentOrch       *AgentOrchestrator
-	reviewer        *ReviewHandler
-	workflowEngine  *workflow.Engine
-	workflowStore   *workflow.Store
-	todoistHandler  *poll.TodoistHandler
-	todoistCancel   context.CancelFunc
-	renovateHandler *poll.RenovateHandler
-	triageHandler   *poll.TriageHandler
-	humanReview     *humanReviewHandler
-	cfg             *config.Config
-	logLevel        *slog.LevelVar
-	emit            func(string, any)
-	emitFactory     func(context.Context) func(string, any)
-	restartStaleErr *logging.ErrorThrottle
-	recovery        *recovery.Recovery
-	agentCompletion *AgentCompletionHandler
+	ctx                           context.Context
+	cancel                        context.CancelFunc
+	wg                            sync.WaitGroup
+	tasks                         *task.Manager
+	projects                      *project.Store
+	loopAgents                    *loopagent.Store
+	loopSched                     *loopagent.Scheduler
+	agents                        *agent.Manager
+	watcher                       *watcher.Watcher
+	configWatcher                 *confighot.Watcher
+	notifier                      *notification.Emitter
+	audit                         *audit.Logger
+	stats                         *stats.Store
+	tasksDir                      string
+	skillsDir                     string
+	repoDir                       string
+	worktreesDir                  string
+	logger                        *slog.Logger
+	logDir                        string
+	auditDir                      string
+	prTracker                     *github.IssueTracker
+	providerHealth                *provider.Checker
+	worktrees                     *worktree.Manager
+	sandboxes                     *sandbox.Manager
+	monitorSvc                    *monitor.Service
+	selfMonitorSvc                *selfmonitor.Service
+	agentOrch                     *AgentOrchestrator
+	reviewer                      *ReviewHandler
+	workflowEngine                *workflow.Engine
+	workflowStore                 *workflow.Store
+	todoistHandler                *poll.TodoistHandler
+	todoistCancel                 context.CancelFunc
+	renovateHandler               *poll.RenovateHandler
+	renovateMonitorTransientFails int
+	triageHandler                 *poll.TriageHandler
+	humanReview                   *humanReviewHandler
+	cfg                           *config.Config
+	logLevel                      *slog.LevelVar
+	emit                          func(string, any)
+	emitFactory                   func(context.Context) func(string, any)
+	restartStaleErr               *logging.ErrorThrottle
+	recovery                      *recovery.Recovery
+	agentCompletion               *AgentCompletionHandler
 
 	bgops *bgop.Tracker
 

--- a/internal/sybra/app_renovate.go
+++ b/internal/sybra/app_renovate.go
@@ -28,9 +28,20 @@ func (a *App) renovatePRsForMonitor() []github.PullRequest {
 	}
 	rps, err := github.FetchRenovatePRs(a.cfg.Renovate.Author, repos)
 	if err != nil {
-		a.logger.Warn("pr-monitor.renovate-fetch", "err", err)
+		if github.IsTransientError(err) {
+			a.renovateMonitorTransientFails++
+			if a.renovateMonitorTransientFails < transientFetchWarnThreshold {
+				a.logger.Info("pr-monitor.renovate-fetch", "err", err)
+			} else {
+				a.logger.Warn("pr-monitor.renovate-fetch", "err", err, "consecutive", a.renovateMonitorTransientFails)
+			}
+		} else {
+			a.renovateMonitorTransientFails = 0
+			a.logger.Warn("pr-monitor.renovate-fetch", "err", err)
+		}
 		return nil
 	}
+	a.renovateMonitorTransientFails = 0
 	prs := make([]github.PullRequest, len(rps))
 	for i := range rps {
 		prs[i] = rps[i].PullRequest

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -28,6 +28,8 @@ const (
 	reviewSmallFiles     = 5
 )
 
+const transientFetchWarnThreshold = 3
+
 // ReviewHandler manages PR review task creation, agent dispatch, and status tracking.
 type ReviewHandler struct {
 	DomainHandler
@@ -41,7 +43,8 @@ type ReviewHandler struct {
 	// FetchReviews uses author:@me which excludes bot-authored PRs, so without
 	// this hook a Renovate PR linked to a task by pr_number/branch never gets
 	// re-dispatched to pr-fix when CI fails. nil = renovate disabled.
-	renovatePRsFn func() []github.PullRequest
+	renovatePRsFn       func() []github.PullRequest
+	transientFetchFails int
 }
 
 func newReviewHandler(
@@ -315,9 +318,20 @@ func (r *ReviewHandler) Poll(_ context.Context) time.Duration {
 func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 	summary, err := github.FetchReviews()
 	if err != nil {
-		r.logger.Warn("pr-monitor.fetch", "err", err)
+		if github.IsTransientError(err) {
+			r.transientFetchFails++
+			if r.transientFetchFails < transientFetchWarnThreshold {
+				r.logger.Info("pr-monitor.fetch", "err", err)
+			} else {
+				r.logger.Warn("pr-monitor.fetch", "err", err, "consecutive", r.transientFetchFails)
+			}
+		} else {
+			r.transientFetchFails = 0
+			r.logger.Warn("pr-monitor.fetch", "err", err)
+		}
 		return prPollSlow
 	}
+	r.transientFetchFails = 0
 
 	r.emit("reviews:updated", summary)
 


### PR DESCRIPTION
## Motivation

Transient GitHub API failures (5xx, network timeouts, context deadline exceeded)
were logged at `Warn` level unconditionally, creating noise that made it hard to
distinguish real problems from ephemeral blips. First two consecutive transient
failures should be silent (Info), escalating only on repeated errors.

Closes https://github.com/Automaat/sybra/issues/684

## Implementation information

- Added `IsTransientError(err)` helper in `internal/github/client.go` that
  classifies errors by HTTP status or network family: 5xx, dial tcp,
  i/o timeout, context deadline → transient; 4xx, auth, parse errors → permanent.
- Added `transientFetchFails` counter per-source in `ReviewHandler`
  (`app_reviews.go`) and `RenovateHandler` (`app_renovate.go`): first 2
  consecutive transient hits log at Info, 3rd+ escalates to Warn; counter resets
  on success.
- Extended the same pattern to all three fetch paths in `IssuesFetcher`
  (`fetchAssigned`, `fetchSnapshot`, `fetchLabeled` in `poll/issues.go`) and
  `renovatePRsForMonitor` in `app_renovate.go`.
- Added unit tests for `IsTransientError` covering all classified cases.