### PR TITLE
fix(agent): codex sandbox & stdin errors in headless mode

### DIFF
--- a/docs/codex-setup.md
+++ b/docs/codex-setup.md
@@ -74,12 +74,13 @@ Sybra maps generic aliases to provider-specific model IDs at runtime:
 Sybra spawns a `codex exec` subprocess per task:
 
 ```bash
-# RequirePermissions=false (skip-permissions / bypass mode)
+# Headless mode always uses bypass (regardless of RequirePermissions)
 codex exec --json --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox --model gpt-5.4 -C <worktree> "<prompt>"
-
-# RequirePermissions=true (sandboxed, file-write only)
-codex exec --json --skip-git-repo-check --sandbox workspace-write --model gpt-5.4 -C <worktree> "<prompt>"
 ```
+
+`--sandbox workspace-write` is intentionally not used in headless mode. That mode requests user approval for writes outside the workspace; in a headless run there is no TTY or UI to serve the approval prompt, so every such request is auto-rejected and the agent run fails. The worktree directory itself provides task isolation.
+
+`RequirePermissions=true` only affects sandbox selection in **interactive (conversational)** mode, where a human can approve sandbox prompts.
 
 Stdout is read as NDJSON. Sybra parses Codex event types (`agent_message`, `command_execution`, `task_complete`, etc.) and maps them to its unified `StreamEvent` format for display.
 

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -324,7 +324,7 @@ func (m *Manager) buildCommand(cfg RunConfig) (string, error) {
 	model := normalizeModel(prov, cfg.Model)
 	switch prov {
 	case "codex":
-		return buildCodexCommand(model, cfg.RequirePermissions), nil
+		return buildCodexCommand(model, cfg.RequirePermissions, cfg.Mode == "headless"), nil
 	default:
 		return buildClaudeCommand(model, cfg.AllowedTools, cfg.RequirePermissions), nil
 	}
@@ -345,9 +345,9 @@ func buildClaudeCommand(model string, allowedTools []string, requirePerms bool) 
 }
 
 // buildCodexCommand builds the display command string for a Codex agent.
-func buildCodexCommand(model string, requirePerms bool) string {
+func buildCodexCommand(model string, requirePerms, headless bool) string {
 	parts := []string{"codex", "exec", "--json", "--skip-git-repo-check"}
-	parts = append(parts, codexSandboxArgs(requirePerms)...)
+	parts = append(parts, codexSandboxArgs(requirePerms, headless)...)
 	if model != "" {
 		parts = append(parts, "--model", model)
 	}
@@ -360,13 +360,20 @@ func buildCodexCommand(model string, requirePerms bool) string {
 // inside a Docker/LXC container whose kernel blocks unprivileged user
 // namespaces (kernel.unprivileged_userns_clone=0), where bwrap crashes
 // before the agent can execute any command.
-func codexSandboxArgs(requirePerms bool) []string {
+//
+// headless must be true for headless runs. --sandbox workspace-write asks
+// for user approval on writes outside the workspace; in headless mode there
+// is no UI to serve those approval prompts, so they auto-reject and the run
+// fails. Bypass mode is used instead.
+func codexSandboxArgs(requirePerms, headless bool) []string {
 	if os.Getenv("SYBRA_DISABLE_CODEX_SANDBOX") == "1" {
 		return []string{"--sandbox", "danger-full-access"}
 	}
-	if !requirePerms {
-		// Mirror Claude's --dangerously-skip-permissions: bypass all approval
-		// prompts and sandbox restrictions.
+	if !requirePerms || headless {
+		// Bypass all approval prompts and sandbox restrictions.
+		// For headless runs this is required regardless of RequirePermissions:
+		// --sandbox workspace-write auto-rejects approval requests since there
+		// is no TTY/UI to serve them, which silently breaks the agent run.
 		return []string{"--dangerously-bypass-approvals-and-sandbox"}
 	}
 	return []string{"--sandbox", "workspace-write"}

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -174,7 +174,9 @@ func (m *Manager) runCodexTurn(ctx context.Context, a *Agent, cfg RunConfig, pro
 
 func buildCodexConvoArgs(a *Agent, cfg RunConfig, prompt string) []string {
 	args := []string{"exec", "--json", "--skip-git-repo-check"}
-	args = append(args, codexSandboxArgs(cfg.RequirePermissions)...)
+	// headless=false: interactive (conversational) mode has a human present
+	// who can approve sandbox prompts via the UI.
+	args = append(args, codexSandboxArgs(cfg.RequirePermissions, false)...)
 	if a.Model != "" {
 		args = append(args, "--model", a.Model)
 	}

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -90,13 +90,6 @@ func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfi
 		cmd.Env = append(os.Environ(), invokeEnv...)
 		cmd.Env = append(cmd.Env, cfg.ExtraEnv...)
 	}
-	// Signal EOF on stdin for codex: /dev/null (the nil default) reads as
-	// infinite zero bytes and never signals EOF, which may leave codex
-	// thinking stdin is open and cause write_stdin attempts on subprocesses.
-	// An empty reader returns EOF immediately so codex detects a closed stdin.
-	if a.Provider == "codex" {
-		cmd.Stdin = bytes.NewReader(nil)
-	}
 	a.Command = command
 
 	stdout, pipeErr := cmd.StdoutPipe()

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -90,6 +90,13 @@ func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfi
 		cmd.Env = append(os.Environ(), invokeEnv...)
 		cmd.Env = append(cmd.Env, cfg.ExtraEnv...)
 	}
+	// Signal EOF on stdin for codex: /dev/null (the nil default) reads as
+	// infinite zero bytes and never signals EOF, which may leave codex
+	// thinking stdin is open and cause write_stdin attempts on subprocesses.
+	// An empty reader returns EOF immediately so codex detects a closed stdin.
+	if a.Provider == "codex" {
+		cmd.Stdin = bytes.NewReader(nil)
+	}
 	a.Command = command
 
 	stdout, pipeErr := cmd.StdoutPipe()
@@ -485,7 +492,9 @@ func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args, env []
 	if a.Provider == "codex" {
 		name = "codex"
 		args = []string{"exec", "--json", "--skip-git-repo-check"}
-		args = append(args, codexSandboxArgs(cfg.RequirePermissions)...)
+		// headless=true: --sandbox workspace-write requires approval prompts
+		// which auto-reject in headless mode (no TTY/UI). Always bypass.
+		args = append(args, codexSandboxArgs(cfg.RequirePermissions, true)...)
 		if a.Model != "" {
 			args = append(args, "--model", a.Model)
 		}

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -825,3 +825,96 @@ func TestBuildHeadlessInvocation_BashTimeout(t *testing.T) {
 		}
 	})
 }
+
+// TestBuildHeadlessInvocation_CodexAlwaysBypassesSandbox verifies that headless
+// codex invocations always use --dangerously-bypass-approvals-and-sandbox,
+// even when RequirePermissions=true. In headless mode there is no UI to serve
+// --sandbox workspace-write approval prompts; auto-rejection silently breaks
+// the agent run.
+func TestBuildHeadlessInvocation_CodexAlwaysBypassesSandbox(t *testing.T) {
+	cases := []struct {
+		name           string
+		requirePerms   bool
+		disableSandbox string // SYBRA_DISABLE_CODEX_SANDBOX value
+		wantBypass     bool
+		wantDangerFull bool
+	}{
+		{
+			name:         "require_perms_false_bypasses",
+			requirePerms: false,
+			wantBypass:   true,
+		},
+		{
+			name:         "require_perms_true_still_bypasses_in_headless",
+			requirePerms: true,
+			wantBypass:   true,
+		},
+		{
+			name:           "disable_sandbox_env_overrides_all",
+			requirePerms:   true,
+			disableSandbox: "1",
+			wantDangerFull: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.disableSandbox != "" {
+				t.Setenv("SYBRA_DISABLE_CODEX_SANDBOX", tc.disableSandbox)
+			}
+
+			a := &Agent{ID: "a", Provider: "codex"}
+			_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{
+				Prompt:             "hi",
+				RequirePermissions: tc.requirePerms,
+			})
+			if err != nil {
+				t.Fatalf("buildHeadlessInvocation: %v", err)
+			}
+
+			if tc.wantBypass {
+				if !slices.Contains(args, "--dangerously-bypass-approvals-and-sandbox") {
+					t.Errorf("args missing --dangerously-bypass-approvals-and-sandbox; got %v", args)
+				}
+				if slices.Contains(args, "--sandbox") {
+					t.Errorf("--sandbox must not appear when bypassing; got %v", args)
+				}
+			}
+			if tc.wantDangerFull {
+				if !slices.Contains(args, "danger-full-access") {
+					t.Errorf("args missing danger-full-access; got %v", args)
+				}
+			}
+		})
+	}
+}
+
+// TestCodexSandboxArgs_HeadlessAlwaysBypasses pins the invariant that headless
+// codex always bypasses approvals even when RequirePermissions=true. Interactive
+// mode with RequirePermissions=true must use --sandbox workspace-write.
+func TestCodexSandboxArgs_HeadlessAlwaysBypasses(t *testing.T) {
+	t.Run("headless_requirePerms_false", func(t *testing.T) {
+		args := codexSandboxArgs(false, true)
+		if !slices.Contains(args, "--dangerously-bypass-approvals-and-sandbox") {
+			t.Errorf("expected bypass; got %v", args)
+		}
+	})
+	t.Run("headless_requirePerms_true", func(t *testing.T) {
+		args := codexSandboxArgs(true, true)
+		if !slices.Contains(args, "--dangerously-bypass-approvals-and-sandbox") {
+			t.Errorf("requirePerms=true headless must bypass; got %v", args)
+		}
+	})
+	t.Run("interactive_requirePerms_true", func(t *testing.T) {
+		args := codexSandboxArgs(true, false)
+		if !slices.Contains(args, "--sandbox") || !slices.Contains(args, "workspace-write") {
+			t.Errorf("interactive+requirePerms should use workspace-write; got %v", args)
+		}
+	})
+	t.Run("interactive_requirePerms_false", func(t *testing.T) {
+		args := codexSandboxArgs(false, false)
+		if !slices.Contains(args, "--dangerously-bypass-approvals-and-sandbox") {
+			t.Errorf("interactive+!requirePerms should bypass; got %v", args)
+		}
+	})
+}

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -403,8 +403,7 @@ func TestE2E_HeadlessAgent_ArgsVerification(t *testing.T) {
 				"exec",
 				"--json",
 				"--skip-git-repo-check",
-				"--sandbox",
-				"workspace-write",
+				"--dangerously-bypass-approvals-and-sandbox",
 				"--model\ngpt-5.4",
 			} {
 				if !strings.Contains(args, want) {


### PR DESCRIPTION
## Motivation

Headless codex runs hit two recurring failures:

1. `--sandbox workspace-write` auto-rejects approval requests in headless mode (no TTY/UI), causing "patch rejected: writing outside of the project" errors during review steps.
2. `stdin` defaults to `/dev/null` (infinite zero reads, never EOF), leaving codex thinking stdin is open and triggering `write_stdin` failures on subprocesses that have no TTY.

Closes https://github.com/Automaat/sybra/issues/682

## Implementation information

**Sandbox fix:** `codexSandboxArgs` gains a `headless bool`. When `headless=true`, always emit `--dangerously-bypass-approvals-and-sandbox` regardless of `RequirePermissions` — there is no mechanism to serve approvals headlessly. Interactive (conversational) mode keeps the existing `--sandbox workspace-write` behaviour when `RequirePermissions=true`.

**Stdin fix:** Initial attempt set `cmd.Stdin = bytes.NewReader(nil)` for codex in `runHeadlessAttempt`, but this is a no-op — `bytes.NewReader(nil)` behaves identically to `nil` Cmd.Stdin (both give the child `/dev/null`). That block was dropped in a follow-up commit. The real fix is the sandbox bypass which prevents codex from attempting interactive stdin features altogether.

`buildCodexConvoArgs` updated to pass `headless=false` so interactive mode sandbox selection is unchanged. `docs/codex-setup.md` updated to reflect the new headless behaviour. New tests pin both invariants.