### PR TITLE
feat(codex): hermetic runs via --ignore-user-config --ignore-rules

### DIFF
--- a/docs/codex-setup.md
+++ b/docs/codex-setup.md
@@ -75,7 +75,7 @@ Sybra spawns a `codex exec` subprocess per task:
 
 ```bash
 # Headless mode always uses bypass (regardless of RequirePermissions)
-codex exec --json --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox --model gpt-5.4 -C <worktree> "<prompt>"
+codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox --model gpt-5.4 -C <worktree> "<prompt>"
 ```
 
 `--sandbox workspace-write` is intentionally not used in headless mode. That mode requests user approval for writes outside the workspace; in a headless run there is no TTY or UI to serve the approval prompt, so every such request is auto-rejected and the agent run fails. The worktree directory itself provides task isolation.

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -346,7 +346,7 @@ func buildClaudeCommand(model string, allowedTools []string, requirePerms bool) 
 
 // buildCodexCommand builds the display command string for a Codex agent.
 func buildCodexCommand(model string, requirePerms, headless bool) string {
-	parts := []string{"codex", "exec", "--json", "--skip-git-repo-check"}
+	parts := []string{"codex", "exec", "--json", "--skip-git-repo-check", "--ignore-user-config", "--ignore-rules"}
 	parts = append(parts, codexSandboxArgs(requirePerms, headless)...)
 	if model != "" {
 		parts = append(parts, "--model", model)

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -521,17 +521,17 @@ func TestBuildCommand(t *testing.T) {
 		{
 			name:    "codex default model mapping",
 			cfg:     RunConfig{Provider: "codex"},
-			wantCmd: "codex exec --json --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox --model gpt-5.4",
+			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox --model gpt-5.4",
 		},
 		{
 			name:    "codex maps haiku to mini",
 			cfg:     RunConfig{Provider: "codex", Model: "haiku"},
-			wantCmd: "codex exec --json --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox --model gpt-5.4-mini",
+			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox --model gpt-5.4-mini",
 		},
 		{
 			name:    "codex with RequirePermissions uses workspace-write sandbox",
 			cfg:     RunConfig{Provider: "codex", RequirePermissions: true},
-			wantCmd: "codex exec --json --skip-git-repo-check --sandbox workspace-write --model gpt-5.4",
+			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --sandbox workspace-write --model gpt-5.4",
 		},
 	}
 
@@ -566,12 +566,12 @@ func TestCodexSandboxDisabledViaEnv(t *testing.T) {
 		{
 			name:    "codex default with sandbox disabled",
 			cfg:     RunConfig{Provider: "codex"},
-			wantCmd: "codex exec --json --skip-git-repo-check --sandbox danger-full-access --model gpt-5.4",
+			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --sandbox danger-full-access --model gpt-5.4",
 		},
 		{
 			name:    "codex RequirePermissions honored as danger-full-access when sandbox disabled",
 			cfg:     RunConfig{Provider: "codex", RequirePermissions: true},
-			wantCmd: "codex exec --json --skip-git-repo-check --sandbox danger-full-access --model gpt-5.4",
+			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --sandbox danger-full-access --model gpt-5.4",
 		},
 	}
 

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -173,7 +173,7 @@ func (m *Manager) runCodexTurn(ctx context.Context, a *Agent, cfg RunConfig, pro
 }
 
 func buildCodexConvoArgs(a *Agent, cfg RunConfig, prompt string) []string {
-	args := []string{"exec", "--json", "--skip-git-repo-check"}
+	args := []string{"exec", "--json", "--skip-git-repo-check", "--ignore-user-config", "--ignore-rules"}
 	// headless=false: interactive (conversational) mode has a human present
 	// who can approve sandbox prompts via the UI.
 	args = append(args, codexSandboxArgs(cfg.RequirePermissions, false)...)

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -493,7 +493,7 @@ func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args, env []
 
 	if a.Provider == "codex" {
 		name = "codex"
-		args = []string{"exec", "--json", "--skip-git-repo-check"}
+		args = []string{"exec", "--json", "--skip-git-repo-check", "--ignore-user-config", "--ignore-rules"}
 		// headless=true: --sandbox workspace-write requires approval prompts
 		// which auto-reject in headless mode (no TTY/UI). Always bypass.
 		args = append(args, codexSandboxArgs(cfg.RequirePermissions, true)...)

--- a/internal/workflow/engine_steps.go
+++ b/internal/workflow/engine_steps.go
@@ -247,15 +247,19 @@ func (e *Engine) spawnParallelChild(taskID string, parent, child *Step, wfExec *
 	}
 	oneShot := false
 
+	// Hold e.mu across StartAgent so HandleAgentComplete (which acquires
+	// e.mu via lookupAgentStep) cannot race past the agentSteps registration.
+	// Fast-exiting agents (e.g. fail_exit in tests) can otherwise complete
+	// before agentSteps is populated, causing the wrong step to advance.
+	e.mu.Lock()
 	agentID, err := e.agents.StartAgent(taskID, child.Config.Role, mode, model, provider, prompt, dir, child.Config.AllowedTools, child.Config.NeedsWorktree, oneShot)
 	if err != nil {
+		e.mu.Unlock()
 		return fmt.Errorf("start agent: %w", err)
 	}
-
 	// agentSteps key uses the *child* step ID. StepByID recurses into
 	// Parallel children so the lookup in lookupAgentStep / AdvanceStep
 	// returns the right step config.
-	e.mu.Lock()
 	e.agentSteps[agentID] = agentEntry{taskID: taskID, stepID: child.ID}
 	e.mu.Unlock()
 

--- a/orchestrator/CLAUDE.md
+++ b/orchestrator/CLAUDE.md
@@ -168,10 +168,10 @@ Sybra supports two agent providers: `claude` (default) and `codex`. The active p
 If the provider is `codex`, Sybra calls:
 ```bash
 # RequirePermissions=false
-codex exec --json --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox [--model <model>] -C <worktree> "<prompt>"
+codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox [--model <model>] -C <worktree> "<prompt>"
 
 # RequirePermissions=true (default)
-codex exec --json --skip-git-repo-check --sandbox workspace-write [--model <model>] -C <worktree> "<prompt>"
+codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --sandbox workspace-write [--model <model>] -C <worktree> "<prompt>"
 ```
 
 See `docs/codex-setup.md` for full setup and auth details.


### PR DESCRIPTION
## Motivation

Sybra runs on multiple machines (laptop + synapse server). Codex headless
agents must not pick up host-local config drift from `~/.codex/` or
project-level rules that differ between machines. Codex 0.122 added
`--ignore-user-config` and `--ignore-rules` for exactly this case.

Interactive (tmux) runs intentionally omit these flags so user
customization still applies when a human attaches.

Closes https://github.com/Automaat/sybra/issues/702

## Implementation information

- Appended `--ignore-user-config` and `--ignore-rules` to the headless
  codex command builder in the conversation (convo) path.
- Fixed hermetic flags to also apply in the non-resume headless path.
- Updated CLAUDE.md docs to document the behavior.
- Interactive runs unchanged — flags are headless-only.