### PR TITLE
feat(agent): surface init plugin_errors in GUI

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/agent/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/agent/models.ts
@@ -38,6 +38,11 @@ export class Agent {
      * MaxTurns is the per-agent turn limit override; zero means use global guardrail.
      */
     "maxTurns"?: number;
+
+    /**
+     * PluginErrors holds plugin load failures from the most recent init event.
+     */
+    "pluginErrors"?: string[];
     "escalationReason"?: string;
     "errorKind"?: string;
     "errorMsg"?: string;
@@ -80,7 +85,11 @@ export class Agent {
      * Creates a new Agent instance from a string or object.
      */
     static createFrom($$source: any = {}): Agent {
+        const $$createField21_0 = $$createType0;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        if ("pluginErrors" in $$parsedSource) {
+            $$parsedSource["pluginErrors"] = $$createField21_0($$parsedSource["pluginErrors"]);
+        }
         return new Agent($$parsedSource as Partial<Agent>);
     }
 }
@@ -126,8 +135,8 @@ export class ConvoEvent {
      * Creates a new ConvoEvent instance from a string or object.
      */
     static createFrom($$source: any = {}): ConvoEvent {
-        const $$createField4_0 = $$createType1;
-        const $$createField5_0 = $$createType3;
+        const $$createField4_0 = $$createType2;
+        const $$createField5_0 = $$createType4;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("toolUses" in $$parsedSource) {
             $$parsedSource["toolUses"] = $$createField4_0($$parsedSource["toolUses"]);
@@ -206,6 +215,11 @@ export class StreamEvent {
      */
     "plan_steps"?: PlanStep[];
 
+    /**
+     * PluginErrors carries plugin load failures surfaced by the init event.
+     */
+    "plugin_errors"?: string[];
+
     /** Creates a new StreamEvent instance. */
     constructor($$source: Partial<StreamEvent> = {}) {
         if (!("type" in $$source)) {
@@ -222,10 +236,14 @@ export class StreamEvent {
      * Creates a new StreamEvent instance from a string or object.
      */
     static createFrom($$source: any = {}): StreamEvent {
-        const $$createField10_0 = $$createType5;
+        const $$createField10_0 = $$createType6;
+        const $$createField11_0 = $$createType0;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("plan_steps" in $$parsedSource) {
             $$parsedSource["plan_steps"] = $$createField10_0($$parsedSource["plan_steps"]);
+        }
+        if ("plugin_errors" in $$parsedSource) {
+            $$parsedSource["plugin_errors"] = $$createField11_0($$parsedSource["plugin_errors"]);
         }
         return new StreamEvent($$parsedSource as Partial<StreamEvent>);
     }
@@ -287,7 +305,7 @@ export class ToolUseBlock {
      * Creates a new ToolUseBlock instance from a string or object.
      */
     static createFrom($$source: any = {}): ToolUseBlock {
-        const $$createField2_0 = $$createType6;
+        const $$createField2_0 = $$createType7;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("input" in $$parsedSource) {
             $$parsedSource["input"] = $$createField2_0($$parsedSource["input"]);
@@ -297,10 +315,11 @@ export class ToolUseBlock {
 }
 
 // Private type creation functions
-const $$createType0 = ToolUseBlock.createFrom;
-const $$createType1 = $Create.Array($$createType0);
-const $$createType2 = ToolResultBlock.createFrom;
-const $$createType3 = $Create.Array($$createType2);
-const $$createType4 = PlanStep.createFrom;
-const $$createType5 = $Create.Array($$createType4);
-const $$createType6 = $Create.Map($Create.Any, $Create.Any);
+const $$createType0 = $Create.Array($Create.Any);
+const $$createType1 = ToolUseBlock.createFrom;
+const $$createType2 = $Create.Array($$createType1);
+const $$createType3 = ToolResultBlock.createFrom;
+const $$createType4 = $Create.Array($$createType3);
+const $$createType5 = PlanStep.createFrom;
+const $$createType6 = $Create.Array($$createType5);
+const $$createType7 = $Create.Map($Create.Any, $Create.Any);

--- a/frontend/src/lib/events.ts
+++ b/frontend/src/lib/events.ts
@@ -14,6 +14,7 @@ export const AgentStuckPrefix = "agent:stuck:"
 export const AgentConvoPrefix = "agent:convo:"
 export const AgentApprovalPrefix = "agent:approval:"
 export const AgentEscalationPrefix = "agent:escalation:"
+export const AgentPluginErrorsPrefix = "agent:plugin_errors:"
 export const OrchestratorState = "orchestrator:state"
 export const MonitorReport = "monitor:report"
 export const SelfMonitorReport = "selfmonitor:report"
@@ -36,5 +37,6 @@ export const agentConvo = (id: string) => `${AgentConvoPrefix}${id}`
 export const agentError = (id: string) => `${AgentErrorPrefix}${id}`
 export const agentEscalation = (id: string) => `${AgentEscalationPrefix}${id}`
 export const agentOutput = (id: string) => `${AgentOutputPrefix}${id}`
+export const agentPluginErrors = (id: string) => `${AgentPluginErrorsPrefix}${id}`
 export const agentState = (id: string) => `${AgentStatePrefix}${id}`
 export const agentStuck = (id: string) => `${AgentStuckPrefix}${id}`

--- a/frontend/src/pages/AgentDetail.svelte
+++ b/frontend/src/pages/AgentDetail.svelte
@@ -113,17 +113,17 @@
   })
 
   $effect(() => {
+    pluginErrors = []
     const cached = agentStore.agents.get(agentId)
     if (cached) {
       a = cached
-      if (cached.pluginErrors?.length) {
-        pluginErrors = cached.pluginErrors
-      }
+      pluginErrors = cached.pluginErrors ?? []
     }
 
     const unsubState = EventsOn(agentState(agentId), (data: Agent) => {
       a = data
       agentStore.updateAgent(agentId, data)
+      pluginErrors = data.pluginErrors ?? []
     })
 
     const unsubError = EventsOn(agentError(agentId), (data: AgentErrorEvent) => {

--- a/frontend/src/pages/AgentDetail.svelte
+++ b/frontend/src/pages/AgentDetail.svelte
@@ -5,7 +5,7 @@
   import { agentStore } from '../stores/agents.svelte.js'
   import { convoStore } from '../stores/convo.svelte.js'
   import { taskStore } from '../stores/tasks.svelte.js'
-  import { agentState, agentEscalation, agentError } from '../lib/events.js'
+  import { agentState, agentEscalation, agentError, agentPluginErrors } from '../lib/events.js'
   import AgentErrorBanner from '../components/AgentErrorBanner.svelte'
   import { getAgentPhase, PHASE_CONFIG } from '$lib/agent-phases.js'
   import { buildStreamTimeline, buildConvoTimeline } from '$lib/timeline.js'
@@ -26,6 +26,10 @@
     msg: string
   }
 
+  interface PluginErrorsEvent {
+    errors: string[]
+  }
+
   interface Props {
     agentId: string
     onback: () => void
@@ -38,6 +42,8 @@
   let a = $state<Agent | null>(null)
   let error = $state('')
   let agentErr = $state<AgentErrorEvent | null>(null)
+  let pluginErrors = $state<string[]>([])
+  let pluginErrorsDismissed = $state(false)
   let escalation = $state<EscalationEvent | null>(null)
   let escalationResponding = $state(false)
   let errorDismissed = $state(false)
@@ -108,7 +114,12 @@
 
   $effect(() => {
     const cached = agentStore.agents.get(agentId)
-    if (cached) a = cached
+    if (cached) {
+      a = cached
+      if (cached.pluginErrors?.length) {
+        pluginErrors = cached.pluginErrors
+      }
+    }
 
     const unsubState = EventsOn(agentState(agentId), (data: Agent) => {
       a = data
@@ -125,10 +136,16 @@
       escalationResponding = false
     })
 
+    const unsubPluginErrors = EventsOn(agentPluginErrors(agentId), (data: PluginErrorsEvent) => {
+      pluginErrors = data.errors ?? []
+      pluginErrorsDismissed = false
+    })
+
     return () => {
       unsubState()
       unsubError()
       unsubEscalation()
+      unsubPluginErrors()
     }
   })
 
@@ -207,6 +224,35 @@
       onretry={a?.taskId ? () => onviewtask(a!.taskId) : undefined}
       ondismiss={() => { agentErr = null; errorDismissed = true }}
     />
+  {/if}
+
+  {#if pluginErrors.length > 0 && !pluginErrorsDismissed}
+    <div class="rounded-lg border-2 border-warning-400 bg-warning-50 p-4 dark:border-warning-600 dark:bg-warning-950">
+      <div class="flex items-start gap-3">
+        <div class="min-w-0 flex-1">
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="rounded bg-warning-200 px-2 py-0.5 text-xs font-bold text-warning-800 dark:bg-warning-700 dark:text-warning-200">
+              PLUGIN ERRORS
+            </span>
+            <span class="text-sm font-medium text-surface-800 dark:text-surface-200">
+              {pluginErrors.length} plugin{pluginErrors.length !== 1 ? 's' : ''} failed to load
+            </span>
+          </div>
+          <ul class="mt-2 space-y-1">
+            {#each pluginErrors as e}
+              <li class="font-mono text-xs text-surface-600 dark:text-surface-400">{e}</li>
+            {/each}
+          </ul>
+        </div>
+        <button
+          type="button"
+          class="shrink-0 text-sm text-surface-400 hover:text-surface-600 dark:hover:text-surface-200"
+          onclick={() => { pluginErrorsDismissed = true }}
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
   {/if}
 
   {#if escalation}

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -52,11 +52,13 @@ type Agent struct {
 
 	TurnCount int `json:"turnCount,omitempty"`
 	// MaxTurns is the per-agent turn limit override; zero means use global guardrail.
-	MaxTurns         int    `json:"maxTurns,omitempty"`
-	EscalationReason string `json:"escalationReason,omitempty"`
-	ErrorKind        string `json:"errorKind,omitempty"`
-	ErrorMsg         string `json:"errorMsg,omitempty"`
-	AwaitingApproval bool   `json:"awaitingApproval,omitempty"`
+	MaxTurns int `json:"maxTurns,omitempty"`
+	// PluginErrors holds plugin load failures from the most recent init event.
+	PluginErrors     []string `json:"pluginErrors,omitempty"`
+	EscalationReason string   `json:"escalationReason,omitempty"`
+	ErrorKind        string   `json:"errorKind,omitempty"`
+	ErrorMsg         string   `json:"errorMsg,omitempty"`
+	AwaitingApproval bool     `json:"awaitingApproval,omitempty"`
 
 	ExitErr         error `json:"-"`
 	outputBuffer    []StreamEvent
@@ -272,6 +274,27 @@ func (a *Agent) SetEscalationReason(reason string) {
 	a.mu.Unlock()
 }
 
+// SetPluginErrors records plugin load failures from the init event.
+func (a *Agent) SetPluginErrors(errs []string) {
+	a.mu.Lock()
+	cp := make([]string, len(errs))
+	copy(cp, errs)
+	a.PluginErrors = cp
+	a.mu.Unlock()
+}
+
+// GetPluginErrors returns a snapshot of the recorded plugin errors.
+func (a *Agent) GetPluginErrors() []string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if len(a.PluginErrors) == 0 {
+		return nil
+	}
+	cp := make([]string, len(a.PluginErrors))
+	copy(cp, a.PluginErrors)
+	return cp
+}
+
 // SetMaxTurns sets the per-agent turn limit override.
 func (a *Agent) SetMaxTurns(n int) {
 	a.mu.Lock()
@@ -400,6 +423,8 @@ type StreamEvent struct {
 	// PlanSteps is populated when the assistant calls TodoWrite; contains the
 	// latest snapshot of the agent's todo list at this point in the stream.
 	PlanSteps []PlanStep `json:"plan_steps,omitempty"`
+	// PluginErrors carries plugin load failures surfaced by the init event.
+	PluginErrors []string `json:"plugin_errors,omitempty"`
 }
 
 // ConvoEvent is a rich event for conversational mode, preserving full tool
@@ -471,6 +496,12 @@ func (a *Agent) SetError(kind, msg string) {
 type ErrorEvent struct {
 	Kind string `json:"kind"`
 	Msg  string `json:"msg"`
+}
+
+// PluginErrorsEvent is emitted on agent:plugin_errors:{id} when the init event
+// carries plugin load failures.
+type PluginErrorsEvent struct {
+	Errors []string `json:"errors"`
 }
 
 // EscalationEvent is emitted on agent:escalation:{id} when a guardrail fires.

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -375,6 +375,7 @@ func (m *Manager) streamHeadlessOutput(ctx context.Context, a *Agent, stdout io.
 			}
 			a.SetPluginErrors(event.PluginErrors)
 			m.emit(events.AgentPluginErrors(a.ID), PluginErrorsEvent{Errors: event.PluginErrors})
+			m.emit(events.AgentState(a.ID), a)
 		}
 
 		if event.Type == "assistant" {

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -369,6 +369,14 @@ func (m *Manager) streamHeadlessOutput(ctx context.Context, a *Agent, stdout io.
 			}
 		}
 
+		if (event.Type == "system" || event.Type == "init") && len(event.PluginErrors) > 0 {
+			for _, e := range event.PluginErrors {
+				m.logger.Warn("agent.plugin_error", "id", a.ID, "error", e)
+			}
+			a.SetPluginErrors(event.PluginErrors)
+			m.emit(events.AgentPluginErrors(a.ID), PluginErrorsEvent{Errors: event.PluginErrors})
+		}
+
 		if event.Type == "assistant" {
 			if keepGoing := m.checkTurnsGuardrail(ctx, a); !keepGoing {
 				return
@@ -534,6 +542,8 @@ func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args, env []
 func claudeEventToStreamEvent(e ClaudeEvent) StreamEvent {
 	ev := StreamEvent{Type: e.Type, Subtype: e.Subtype, SessionID: e.SessionID}
 	switch e.Type {
+	case "system", "init":
+		ev.PluginErrors = e.PluginErrors
 	case "assistant":
 		if e.Message != nil {
 			ev.Content = formatHeadlessAssistant(e.Message)

--- a/internal/agent/stream.go
+++ b/internal/agent/stream.go
@@ -31,12 +31,13 @@ type ClaudeResult struct {
 
 // ClaudeEvent is the shared envelope for all Claude stream-json events.
 type ClaudeEvent struct {
-	Type      string
-	Subtype   string
-	SessionID string
-	Raw       json.RawMessage // independent copy, never aliased to scanner buffer
-	Message   *ClaudeMessage
-	Result    *ClaudeResult
+	Type         string
+	Subtype      string
+	SessionID    string
+	PluginErrors []string
+	Raw          json.RawMessage // independent copy, never aliased to scanner buffer
+	Message      *ClaudeMessage
+	Result       *ClaudeResult
 }
 
 // CodexEvent is the shared envelope for all Codex stream-json events.
@@ -53,6 +54,7 @@ type claudeEnvelope struct {
 	Type              string                `json:"type"`
 	Subtype           string                `json:"subtype"`
 	SessionID         string                `json:"session_id"`
+	PluginErrors      []string              `json:"plugin_errors,omitempty"`
 	Message           *claudeMessagePayload `json:"message"`
 	Result            string                `json:"result"`
 	TotalCostUSD      float64               `json:"total_cost_usd"`
@@ -119,8 +121,9 @@ func ParseClaudeLine(line []byte) (ClaudeEvent, error) {
 	}
 
 	switch raw.Type {
-	case "system":
+	case "system", "init":
 		event.SessionID = raw.SessionID
+		event.PluginErrors = raw.PluginErrors
 
 	case "assistant":
 		if raw.Message != nil {

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -10,13 +10,14 @@ const (
 	TaskDeleted = "task:deleted"
 
 	// Agent events — prefix only; append ":"+agentID to form full event name.
-	AgentStatePrefix      = "agent:state:"
-	AgentOutputPrefix     = "agent:output:"
-	AgentErrorPrefix      = "agent:error:"
-	AgentStuckPrefix      = "agent:stuck:"
-	AgentConvoPrefix      = "agent:convo:"
-	AgentApprovalPrefix   = "agent:approval:"
-	AgentEscalationPrefix = "agent:escalation:"
+	AgentStatePrefix        = "agent:state:"
+	AgentOutputPrefix       = "agent:output:"
+	AgentErrorPrefix        = "agent:error:"
+	AgentStuckPrefix        = "agent:stuck:"
+	AgentConvoPrefix        = "agent:convo:"
+	AgentApprovalPrefix     = "agent:approval:"
+	AgentEscalationPrefix   = "agent:escalation:"
+	AgentPluginErrorsPrefix = "agent:plugin_errors:"
 
 	// Orchestrator events.
 	OrchestratorState = "orchestrator:state"
@@ -87,3 +88,6 @@ func AgentApproval(id string) string { return AgentApprovalPrefix + id }
 
 // AgentEscalation returns the escalation event name for the given agent ID.
 func AgentEscalation(id string) string { return AgentEscalationPrefix + id }
+
+// AgentPluginErrors returns the plugin errors event name for the given agent ID.
+func AgentPluginErrors(id string) string { return AgentPluginErrorsPrefix + id }


### PR DESCRIPTION
## Motivation

CC v2.1.128 extended the stream-json `init` event to include `plugin_errors`
covering dependency demotions and `--plugin-dir` load failures. These were
previously invisible to the user, making plugin misconfiguration hard to
diagnose.

Closes https://github.com/Automaat/sybra/issues/688

## Implementation information

- Extended `StreamEvent` parser in `runner_headless.go` to capture `plugin_errors` from `init` events
- Added `PluginErrors []string` field to the `Agent` model
- Emit Wails event `agent:plugin_errors:<id>` on the backend so the frontend subscribes and shows a non-blocking warning banner
- Fixed subsequent visibility bugs in the `AgentErrorBanner` component (state not clearing between agents, banner shown on empty error list)
- Errors logged to `~/.sybra/logs/` for diagnosability
- No UI noise on success path (no errors → banner hidden)