### PR TITLE
fix(cli): dedup create by project+issue+title

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -201,6 +201,7 @@ func cmdCreate(s *task.Manager, args []string, jsonOut bool) int {
 	branch := fs.String("branch", "", "Git branch name")
 	pr := fs.Int("pr", 0, "GitHub PR number")
 	issue := fs.String("issue", "", "GitHub issue URL")
+	allowDup := fs.Bool("allow-dup", false, "skip duplicate-dispatch check (project+issue+title)")
 	if err := fs.Parse(args); err != nil {
 		return fatal(jsonOut, "%v", err)
 	}
@@ -209,6 +210,20 @@ func cmdCreate(s *task.Manager, args []string, jsonOut bool) int {
 	}
 	if _, err := task.ValidateTaskType(*ttype); err != nil {
 		return fatal(jsonOut, "%v", err)
+	}
+
+	if !*allowDup {
+		if dup, ok, err := findActiveDuplicate(s, *proj, *issue, *title); err != nil {
+			return fatal(jsonOut, "dedup check: %v", err)
+		} else if ok {
+			fmt.Fprintf(os.Stderr, "warning: duplicate dispatch — returning existing task %s (status=%s) for project=%s issue=%s; pass --allow-dup to override\n",
+				dup.ID, dup.Status, *proj, *issue)
+			if jsonOut {
+				return printJSON(dup)
+			}
+			fmt.Printf("Existing task %s: %s\n", dup.ID, dup.Title)
+			return 0
+		}
 	}
 
 	t, err := s.Create(*title, *body, *mode)
@@ -257,6 +272,33 @@ func cmdCreate(s *task.Manager, args []string, jsonOut bool) int {
 	}
 	fmt.Printf("Created task %s: %s\n", t.ID, t.Title)
 	return 0
+}
+
+// findActiveDuplicate looks for an existing non-terminal task that matches
+// project + issue + title. Used to suppress double-dispatch from the
+// orchestrator brain (which calls `sybra-cli create` externally and has no
+// view of the in-flight task list when a previous dispatch is still running).
+//
+// Match requires all three fields to be non-empty and equal, so it cannot
+// collapse legitimate distinct subtasks of an umbrella issue (those have
+// different titles).
+func findActiveDuplicate(s *task.Manager, projectID, issue, title string) (task.Task, bool, error) {
+	if projectID == "" || issue == "" || title == "" {
+		return task.Task{}, false, nil
+	}
+	tasks, err := s.List()
+	if err != nil {
+		return task.Task{}, false, err
+	}
+	for i := range tasks {
+		if task.IsTerminalStatus(tasks[i].Status) {
+			continue
+		}
+		if tasks[i].ProjectID == projectID && tasks[i].Issue == issue && tasks[i].Title == title {
+			return tasks[i], true, nil
+		}
+	}
+	return task.Task{}, false, nil
 }
 
 func cmdUpdate(s *task.Manager, args []string, jsonOut bool) int {
@@ -909,7 +951,7 @@ Commands:
   list     [--status STATUS] [--tag TAG] [--project ID]
            STATUS: new|todo|planning|plan-review|in-progress|in-review|testing|test-plan-review|human-required|done|cancelled
   get      <id>
-  create   --title TITLE [--body BODY] [--plan PLAN] [--mode MODE] [--type TYPE] [--tags t1,t2] [--project ID] [--branch B] [--pr N] [--issue URL]
+  create   --title TITLE [--body BODY] [--plan PLAN] [--mode MODE] [--type TYPE] [--tags t1,t2] [--project ID] [--branch B] [--pr N] [--issue URL] [--allow-dup]
            TYPE: normal|debug|research
   update   <id> [--title T] [--status S] [--status-reason R] [--body B] [--plan PLAN] [--plan-file PATH] [--mode M] [--type TYPE] [--tags T] [--project ID] [--branch B] [--pr N] [--issue URL] [--max-turns N]
   delete   <id>

--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -360,6 +360,131 @@ func TestCreateWithProject(t *testing.T) {
 	}
 }
 
+// TestCreateDedupActiveDuplicate covers the orchestrator double-dispatch case:
+// two `sybra-cli create` calls with the same project+issue+title within seconds
+// must collapse onto the first task instead of forking a parallel one.
+func TestCreateDedupActiveDuplicate(t *testing.T) {
+	setupStore(t)
+
+	args := []string{
+		"--json", "create",
+		"--title", "refactor: extract styles",
+		"--project", "owner/repo",
+		"--issue", "https://github.com/owner/repo/issues/152",
+	}
+
+	code, out := runCLI(t, args...)
+	if code != 0 {
+		t.Fatalf("first create exit %d: %s", code, out)
+	}
+	var first task.Task
+	mustUnmarshal(t, out, &first)
+
+	code, out = runCLI(t, args...)
+	if code != 0 {
+		t.Fatalf("second create (dedup) exit %d: %s", code, out)
+	}
+	var second task.Task
+	mustUnmarshal(t, out, &second)
+
+	if second.ID != first.ID {
+		t.Fatalf("dedup failed: got new task %s, want existing %s", second.ID, first.ID)
+	}
+
+	code, out = runCLI(t, "--json", "list")
+	if code != 0 {
+		t.Fatalf("list exit %d", code)
+	}
+	var tasks []task.Task
+	mustUnmarshal(t, out, &tasks)
+	if len(tasks) != 1 {
+		t.Errorf("expected 1 task after dedup, got %d", len(tasks))
+	}
+}
+
+// TestCreateDedupAllowsDifferentTitle confirms the matcher is title-strict so
+// distinct subtasks of an umbrella issue (same project+issue, different title)
+// are not collapsed.
+func TestCreateDedupAllowsDifferentTitle(t *testing.T) {
+	setupStore(t)
+
+	common := []string{
+		"--project", "owner/repo",
+		"--issue", "https://github.com/owner/repo/issues/152",
+	}
+
+	code, _ := runCLI(t, append([]string{"--json", "create", "--title", "subtask A"}, common...)...)
+	if code != 0 {
+		t.Fatalf("first create exit %d", code)
+	}
+	code, _ = runCLI(t, append([]string{"--json", "create", "--title", "subtask B"}, common...)...)
+	if code != 0 {
+		t.Fatalf("second create exit %d", code)
+	}
+
+	_, out := runCLI(t, "--json", "list")
+	var tasks []task.Task
+	mustUnmarshal(t, out, &tasks)
+	if len(tasks) != 2 {
+		t.Errorf("expected 2 tasks (different titles), got %d", len(tasks))
+	}
+}
+
+// TestCreateDedupSkipsTerminalTask confirms a finished task does not block a
+// fresh dispatch on the same issue+title (e.g. operator wants a re-do).
+func TestCreateDedupSkipsTerminalTask(t *testing.T) {
+	setupStore(t)
+
+	args := []string{
+		"--json", "create",
+		"--title", "redo me",
+		"--project", "owner/repo",
+		"--issue", "https://github.com/owner/repo/issues/9",
+	}
+	_, out := runCLI(t, args...)
+	var first task.Task
+	mustUnmarshal(t, out, &first)
+
+	if code, msg := runCLI(t, "--json", "update", first.ID, "--status", "done"); code != 0 {
+		t.Fatalf("mark done exit %d: %s", code, msg)
+	}
+
+	code, out := runCLI(t, args...)
+	if code != 0 {
+		t.Fatalf("re-create exit %d: %s", code, out)
+	}
+	var second task.Task
+	mustUnmarshal(t, out, &second)
+	if second.ID == first.ID {
+		t.Fatalf("re-dispatch after done was deduped (got same id %s)", first.ID)
+	}
+}
+
+// TestCreateDedupAllowDupFlag confirms --allow-dup bypasses the check.
+func TestCreateDedupAllowDupFlag(t *testing.T) {
+	setupStore(t)
+
+	args := []string{
+		"--json", "create",
+		"--title", "force dup",
+		"--project", "owner/repo",
+		"--issue", "https://github.com/owner/repo/issues/1",
+	}
+	_, out := runCLI(t, args...)
+	var first task.Task
+	mustUnmarshal(t, out, &first)
+
+	code, out := runCLI(t, append(args, "--allow-dup")...)
+	if code != 0 {
+		t.Fatalf("forced create exit %d: %s", code, out)
+	}
+	var second task.Task
+	mustUnmarshal(t, out, &second)
+	if second.ID == first.ID {
+		t.Fatalf("--allow-dup did not bypass dedup")
+	}
+}
+
 func TestUpdateProject(t *testing.T) {
 	setupStore(t)
 


### PR DESCRIPTION
## Motivation

Orchestrator brain dispatched the same umbrella subtask twice within 2 minutes today (creatorops issue #152, tasks `18528f9c` and `32a1c565`). Both ran in parallel through to merged PRs doing the same `Projects.tsx` work — wasted compute, redundant review cycles, and the second PR mostly conflicted with the first on merge.

The CLI `create` path had no dedup: each `sybra-cli create` call from the external orchestrator allocates a fresh task even when an identical one is already in flight.

## Implementation information

`cmdCreate` in `cmd/sybra-cli/main.go` now calls `findActiveDuplicate` before `Manager.Create`. A duplicate is defined narrowly:

- `project_id`, `issue`, and `title` are all non-empty and exactly equal
- the existing task is not in a terminal status (`done`/`cancelled`)

On match: print a stderr warning, return the existing task as the create result (idempotent — same JSON shape so the orchestrator's downstream parsing keeps working), exit 0.

Escape hatches:

- `--allow-dup` flag — explicit override
- different titles (legit umbrella subtasks) are not collapsed — title-strict match
- terminal tasks don't block — operator can re-dispatch a finished task

### Why CLI, not `task.Manager.Create`

- The orchestrator brain runs externally and is the source of the duplicate dispatch.
- `IssuesFetcher` already has its own URL-based dedup (`internal/poll/issues.go:183`).
- Tests and other in-process callers create tasks with intentionally repeated titles; widening the dedup there would be a behavior change.

### Alternatives discarded

- Dedup by `(project_id, issue)` alone — too aggressive, would collapse legitimate umbrella subtasks.
- Hard error instead of idempotent return — orchestrator brain doesn't model error retries cleanly; idempotent is friendlier.
- Time window on terminal tasks — adds complexity without addressing the observed bug (both duplicates were active at second-dispatch time).

## Supporting documentation

Tests added:

- `TestCreateDedupActiveDuplicate` — second dispatch returns first task ID
- `TestCreateDedupAllowsDifferentTitle` — distinct subtasks coexist
- `TestCreateDedupSkipsTerminalTask` — done task does not block re-dispatch
- `TestCreateDedupAllowDupFlag` — `--allow-dup` bypasses

> Changelog: fix(cli): dedup create by project+issue+title