### PR TITLE
fix(pr-monitor): skip codecov, gate workflow

### DIFF
--- a/internal/github/check_filter.go
+++ b/internal/github/check_filter.go
@@ -1,0 +1,139 @@
+package github
+
+import "strings"
+
+// informationalCheckPrefixes lists check-name prefixes that report on
+// codebase health (coverage, code-quality scans) but do not gate
+// mergeability. We exclude them from `CIStatus` so a failing
+// `codecov/patch` does not trigger the pr-fix loop — there is no code
+// change a fixer agent can make to bump coverage from a formatting
+// commit, so retrying just burns budget. Required-check enforcement
+// belongs to GitHub branch protection, not to this client.
+//
+// Match is by lowercase prefix: `codecov/patch`, `codecov/project`,
+// `sonarcloud/quality-gate`, etc. all match `codecov/` or `sonarcloud/`.
+// Override from tests via the package-level slice; production code
+// should not mutate it at runtime.
+var informationalCheckPrefixes = []string{
+	"codecov/",
+	"sonarcloud/",
+	"sonarsource/",
+	"deepsource/",
+}
+
+// isInformationalCheck reports whether the check name belongs to a
+// non-gating reporter (coverage, quality scan). Empty name returns
+// false so unparseable contexts still feed the rollup.
+func isInformationalCheck(name string) bool {
+	if name == "" {
+		return false
+	}
+	lower := strings.ToLower(name)
+	for _, p := range informationalCheckPrefixes {
+		if strings.HasPrefix(lower, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// effectiveCheckState normalizes a single context to one of
+// SUCCESS/FAILURE/PENDING. Returns "" when the context is malformed
+// (no usable typename and no state fields).
+//
+// CheckRun: status != COMPLETED → PENDING; conclusion is mapped to
+// SUCCESS for benign outcomes (NEUTRAL, SKIPPED, CANCELLED, STALE) and
+// FAILURE for blocking outcomes (FAILURE, TIMED_OUT, STARTUP_FAILURE,
+// ACTION_REQUIRED). Unknown conclusions on a completed CheckRun fall
+// through to SUCCESS — better to skip than to spam pr-fix on a check
+// state we don't recognize.
+//
+// StatusContext: PENDING/EXPECTED → PENDING; ERROR/FAILURE → FAILURE;
+// SUCCESS → SUCCESS.
+func effectiveCheckState(c gqlCheckContext) string {
+	switch c.Typename {
+	case "CheckRun":
+		if c.Status != "" && c.Status != "COMPLETED" {
+			return "PENDING"
+		}
+		switch strings.ToUpper(c.Conclusion) {
+		case "FAILURE", "TIMED_OUT", "STARTUP_FAILURE", "ACTION_REQUIRED":
+			return "FAILURE"
+		case "", "SUCCESS", "NEUTRAL", "SKIPPED", "CANCELLED", "STALE":
+			return "SUCCESS"
+		default:
+			return "SUCCESS"
+		}
+	case "StatusContext":
+		switch strings.ToUpper(c.State) {
+		case "FAILURE", "ERROR":
+			return "FAILURE"
+		case "PENDING", "EXPECTED":
+			return "PENDING"
+		case "SUCCESS":
+			return "SUCCESS"
+		default:
+			return ""
+		}
+	default:
+		// Older gh / GraphQL shapes that don't include __typename: best
+		// effort using whichever fields are populated.
+		if c.Status != "" || c.Conclusion != "" {
+			c.Typename = "CheckRun"
+			return effectiveCheckState(c)
+		}
+		if c.State != "" {
+			c.Typename = "StatusContext"
+			return effectiveCheckState(c)
+		}
+		return ""
+	}
+}
+
+// rollupFromContexts computes (ciStatus, hasPendingChecks) ignoring
+// informational reporters. Returns ("", false) when contexts is empty
+// so callers can fall back to the GitHub-supplied rollup state for
+// PRs whose checks GraphQL didn't return.
+//
+// Precedence: any FAILURE → FAILURE; else any PENDING → PENDING; else
+// SUCCESS. hasPendingChecks reflects pending state on the *filtered*
+// set so MatchTaskPRs does not stall on a still-running codecov check.
+func rollupFromContexts(contexts []gqlCheckContext) (ciStatus string, hasPendingChecks bool) {
+	if len(contexts) == 0 {
+		return "", false
+	}
+
+	var sawCounted, sawFailure, sawPending, sawSuccess bool
+	for i := range contexts {
+		if isInformationalCheck(contexts[i].Name) {
+			continue
+		}
+		state := effectiveCheckState(contexts[i])
+		if state == "" {
+			continue
+		}
+		sawCounted = true
+		switch state {
+		case "FAILURE":
+			sawFailure = true
+		case "PENDING":
+			sawPending = true
+		case "SUCCESS":
+			sawSuccess = true
+		}
+	}
+
+	if !sawCounted {
+		return "", false
+	}
+	switch {
+	case sawFailure:
+		return "FAILURE", sawPending
+	case sawPending:
+		return "PENDING", true
+	case sawSuccess:
+		return "SUCCESS", false
+	default:
+		return "", false
+	}
+}

--- a/internal/github/check_filter_test.go
+++ b/internal/github/check_filter_test.go
@@ -1,0 +1,339 @@
+package github
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestIsInformationalCheck(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"codecov/patch", true},
+		{"codecov/project", true},
+		{"Codecov/Patch", true}, // case-insensitive prefix match
+		{"sonarcloud/quality-gate", true},
+		{"sonarsource/quality-gate", true},
+		{"deepsource/test-coverage", true},
+		{"format-lint", false},
+		{"build", false},
+		{"test", false},
+		{"", false},
+		{"codecovious/foo", false}, // prefix only matches with trailing slash
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isInformationalCheck(tt.name); got != tt.want {
+				t.Errorf("isInformationalCheck(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveCheckState_CheckRun(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		status     string
+		conclusion string
+		want       string
+	}{
+		{"running", "IN_PROGRESS", "", "PENDING"},
+		{"queued", "QUEUED", "", "PENDING"},
+		{"completed success", "COMPLETED", "SUCCESS", "SUCCESS"},
+		{"completed failure", "COMPLETED", "FAILURE", "FAILURE"},
+		{"completed timed out", "COMPLETED", "TIMED_OUT", "FAILURE"},
+		{"completed startup failure", "COMPLETED", "STARTUP_FAILURE", "FAILURE"},
+		{"completed action required", "COMPLETED", "ACTION_REQUIRED", "FAILURE"},
+		{"completed neutral", "COMPLETED", "NEUTRAL", "SUCCESS"},
+		{"completed cancelled", "COMPLETED", "CANCELLED", "SUCCESS"},
+		{"completed skipped", "COMPLETED", "SKIPPED", "SUCCESS"},
+		{"completed stale", "COMPLETED", "STALE", "SUCCESS"},
+		{"completed unknown", "COMPLETED", "MARS_LANDING", "SUCCESS"},
+		{"empty status, success conclusion", "", "SUCCESS", "SUCCESS"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := gqlCheckContext{
+				Typename:   "CheckRun",
+				Status:     tt.status,
+				Conclusion: tt.conclusion,
+			}
+			if got := effectiveCheckState(ctx); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveCheckState_StatusContext(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		state string
+		want  string
+	}{
+		{"SUCCESS", "SUCCESS"},
+		{"FAILURE", "FAILURE"},
+		{"ERROR", "FAILURE"},
+		{"PENDING", "PENDING"},
+		{"EXPECTED", "PENDING"},
+		{"", ""},
+		{"NONSENSE", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.state, func(t *testing.T) {
+			t.Parallel()
+			ctx := gqlCheckContext{Typename: "StatusContext", State: tt.state}
+			if got := effectiveCheckState(ctx); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveCheckState_NoTypename(t *testing.T) {
+	t.Parallel()
+	// Older gh versions don't return __typename — fall back to whichever
+	// fields are populated.
+	t.Run("infers CheckRun from status", func(t *testing.T) {
+		t.Parallel()
+		ctx := gqlCheckContext{Status: "COMPLETED", Conclusion: "FAILURE"}
+		if got := effectiveCheckState(ctx); got != "FAILURE" {
+			t.Errorf("got %q, want FAILURE", got)
+		}
+	})
+	t.Run("infers StatusContext from state", func(t *testing.T) {
+		t.Parallel()
+		ctx := gqlCheckContext{State: "PENDING"}
+		if got := effectiveCheckState(ctx); got != "PENDING" {
+			t.Errorf("got %q, want PENDING", got)
+		}
+	})
+	t.Run("empty context returns empty", func(t *testing.T) {
+		t.Parallel()
+		if got := effectiveCheckState(gqlCheckContext{}); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}
+
+func TestRollupFromContexts(t *testing.T) {
+	t.Parallel()
+	checkRun := func(name, status, conclusion string) gqlCheckContext {
+		return gqlCheckContext{Typename: "CheckRun", Name: name, Status: status, Conclusion: conclusion}
+	}
+	statusCtx := func(name, state string) gqlCheckContext {
+		return gqlCheckContext{Typename: "StatusContext", Name: name, State: state}
+	}
+
+	tests := []struct {
+		name        string
+		contexts    []gqlCheckContext
+		wantStatus  string
+		wantPending bool
+	}{
+		{
+			name:       "empty falls back to caller",
+			contexts:   nil,
+			wantStatus: "",
+		},
+		{
+			name: "all real checks pass, codecov fails -> SUCCESS",
+			contexts: []gqlCheckContext{
+				checkRun("build", "COMPLETED", "SUCCESS"),
+				checkRun("test", "COMPLETED", "SUCCESS"),
+				checkRun("format-lint", "COMPLETED", "SUCCESS"),
+				checkRun("codecov/patch", "COMPLETED", "FAILURE"),
+				checkRun("codecov/project", "COMPLETED", "SUCCESS"),
+			},
+			wantStatus: "SUCCESS",
+		},
+		{
+			name: "real check fails alongside codecov -> FAILURE",
+			contexts: []gqlCheckContext{
+				checkRun("build", "COMPLETED", "FAILURE"),
+				checkRun("codecov/patch", "COMPLETED", "FAILURE"),
+			},
+			wantStatus: "FAILURE",
+		},
+		{
+			name: "real check pending while codecov pending -> PENDING from real",
+			contexts: []gqlCheckContext{
+				checkRun("build", "IN_PROGRESS", ""),
+				checkRun("codecov/patch", "IN_PROGRESS", ""),
+			},
+			wantStatus:  "PENDING",
+			wantPending: true,
+		},
+		{
+			name: "only codecov fails -> SUCCESS (no informational gating)",
+			contexts: []gqlCheckContext{
+				checkRun("codecov/patch", "COMPLETED", "FAILURE"),
+			},
+			// All filtered out -> "" so caller falls back to rollup.State
+			wantStatus: "",
+		},
+		{
+			name: "real failure with pending real -> FAILURE with hasPending",
+			contexts: []gqlCheckContext{
+				checkRun("build", "COMPLETED", "FAILURE"),
+				checkRun("test", "IN_PROGRESS", ""),
+			},
+			wantStatus:  "FAILURE",
+			wantPending: true,
+		},
+		{
+			name: "mix of CheckRun and StatusContext",
+			contexts: []gqlCheckContext{
+				checkRun("build", "COMPLETED", "SUCCESS"),
+				statusCtx("legacy-status", "FAILURE"),
+			},
+			wantStatus: "FAILURE",
+		},
+		{
+			name: "only StatusContext informational",
+			contexts: []gqlCheckContext{
+				statusCtx("codecov/patch", "FAILURE"),
+				statusCtx("codecov/project", "FAILURE"),
+			},
+			wantStatus: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, pending := rollupFromContexts(tt.contexts)
+			if got != tt.wantStatus {
+				t.Errorf("status = %q, want %q", got, tt.wantStatus)
+			}
+			if pending != tt.wantPending {
+				t.Errorf("pending = %v, want %v", pending, tt.wantPending)
+			}
+		})
+	}
+}
+
+func TestConvertPRs_filtersInformationalChecks(t *testing.T) {
+	t.Parallel()
+	// Mirrors the codecov-only failure on PR #186 that triggered the
+	// pr-fix retry loop. With the filter, ciStatus must roll up to
+	// SUCCESS so MatchTaskPRs does not raise a ci_failure issue.
+	raw := `{
+		"data": {
+			"search": {
+				"nodes": [
+					{
+						"number": 186,
+						"title": "refactor: replace console",
+						"url": "https://example.com/186",
+						"author": {"login": "dev", "type": "User"},
+						"repository": {"name": "creatorops", "nameWithOwner": "Automaat/creatorops"},
+						"labels": {"nodes": []},
+						"commits": {"nodes": [{"commit": {
+							"oid": "abc",
+							"statusCheckRollup": {
+								"state": "FAILURE",
+								"contexts": {"nodes": [
+									{"__typename": "CheckRun", "name": "format-lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+									{"__typename": "CheckRun", "name": "test", "status": "COMPLETED", "conclusion": "SUCCESS"},
+									{"__typename": "CheckRun", "name": "build", "status": "COMPLETED", "conclusion": "SUCCESS"},
+									{"__typename": "CheckRun", "name": "codecov/patch", "status": "COMPLETED", "conclusion": "FAILURE"},
+									{"__typename": "CheckRun", "name": "codecov/project", "status": "COMPLETED", "conclusion": "SUCCESS"}
+								]}
+							}
+						}}]},
+						"reviewThreads": {"nodes": []}
+					}
+				]
+			}
+		}
+	}`
+
+	var resp gqlResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	prs := convertPRs(resp.Data.Search.Nodes, "")
+	if len(prs) != 1 {
+		t.Fatalf("got %d PRs, want 1", len(prs))
+	}
+	if prs[0].CIStatus != "SUCCESS" {
+		t.Errorf("CIStatus = %q, want SUCCESS (codecov should be filtered)", prs[0].CIStatus)
+	}
+	if prs[0].HasPendingChecks {
+		t.Errorf("HasPendingChecks = true, want false")
+	}
+}
+
+func TestConvertPRs_realFailureBeatsCodecov(t *testing.T) {
+	t.Parallel()
+	// When a real CI check legitimately fails, the codecov filter must
+	// not mask it.
+	raw := `{
+		"data": {"search": {"nodes": [{
+			"number": 1,
+			"title": "x",
+			"url": "https://example.com/1",
+			"author": {"login": "dev", "type": "User"},
+			"repository": {"name": "r", "nameWithOwner": "o/r"},
+			"labels": {"nodes": []},
+			"commits": {"nodes": [{"commit": {
+				"oid": "abc",
+				"statusCheckRollup": {
+					"state": "FAILURE",
+					"contexts": {"nodes": [
+						{"__typename": "CheckRun", "name": "build", "status": "COMPLETED", "conclusion": "FAILURE"},
+						{"__typename": "CheckRun", "name": "codecov/patch", "status": "COMPLETED", "conclusion": "FAILURE"}
+					]}
+				}
+			}}]},
+			"reviewThreads": {"nodes": []}
+		}]}}
+	}`
+
+	var resp gqlResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	prs := convertPRs(resp.Data.Search.Nodes, "")
+	if len(prs) != 1 || prs[0].CIStatus != "FAILURE" {
+		t.Fatalf("CIStatus = %q, want FAILURE", prs[0].CIStatus)
+	}
+}
+
+func TestConvertPRs_emptyContextsFallsBackToRollupState(t *testing.T) {
+	t.Parallel()
+	// If GraphQL returns the rollup but no individual contexts (e.g.
+	// older gh, suppressed check API), keep the rollup.State so the
+	// new filter never silently zeros out CI status for legitimate PRs.
+	raw := `{
+		"data": {"search": {"nodes": [{
+			"number": 1,
+			"title": "x",
+			"url": "https://example.com/1",
+			"author": {"login": "dev", "type": "User"},
+			"repository": {"name": "r", "nameWithOwner": "o/r"},
+			"labels": {"nodes": []},
+			"commits": {"nodes": [{"commit": {
+				"oid": "abc",
+				"statusCheckRollup": {"state": "FAILURE", "contexts": {"nodes": []}}
+			}}]},
+			"reviewThreads": {"nodes": []}
+		}]}}
+	}`
+
+	var resp gqlResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	prs := convertPRs(resp.Data.Search.Nodes, "")
+	if len(prs) != 1 || prs[0].CIStatus != "FAILURE" {
+		t.Fatalf("CIStatus = %q, want FAILURE (fallback)", prs[0].CIStatus)
+	}
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -102,7 +102,9 @@ const prQuery = `query($q: String!) {
                 state
                 contexts(first: 50) {
                   nodes {
-                    ... on CheckRun { status }
+                    __typename
+                    ... on CheckRun { name status conclusion }
+                    ... on StatusContext { name: context state }
                   }
                 }
               }
@@ -120,10 +122,16 @@ const prQuery = `query($q: String!) {
   }
 }`
 
+// gqlCheckContext captures both `CheckRun` and `StatusContext` shapes from
+// the StatusCheckRollup contexts edge. The GraphQL query aliases
+// `StatusContext.context` → `name` and only `CheckRun` populates
+// status/conclusion, so callers must dispatch on Typename.
 type gqlCheckContext struct {
+	Typename   string `json:"__typename"`
 	Name       string `json:"name"`
-	Status     string `json:"status"`
-	Conclusion string `json:"conclusion"`
+	Status     string `json:"status"`     // CheckRun only: QUEUED|IN_PROGRESS|COMPLETED|...
+	Conclusion string `json:"conclusion"` // CheckRun only: SUCCESS|FAILURE|NEUTRAL|...
+	State      string `json:"state"`      // StatusContext only: PENDING|SUCCESS|FAILURE|ERROR|EXPECTED
 }
 
 type gqlStatusCheckRollup struct {
@@ -230,11 +238,21 @@ func convertCommonPR(n *gqlPR, viewer string) PullRequest {
 	if len(n.Commits.Nodes) > 0 {
 		headSHA = n.Commits.Nodes[0].Commit.OID
 		if rollup := n.Commits.Nodes[0].Commit.StatusCheckRollup; rollup != nil {
-			ciStatus = rollup.State
-			for _, ctx := range rollup.Contexts.Nodes {
-				if ctx.Status != "" && ctx.Status != "COMPLETED" {
-					hasPendingChecks = true
-					break
+			// Recompute rollup from contexts so non-gating reporters
+			// (codecov, sonarcloud) don't masquerade as CI failures and
+			// drive pr-fix loops. Fall back to the GitHub rollup state
+			// when no contexts came back (zero-checks PR or older gh).
+			filtered, filteredPending := rollupFromContexts(rollup.Contexts.Nodes)
+			if filtered != "" {
+				ciStatus = filtered
+				hasPendingChecks = filteredPending
+			} else {
+				ciStatus = rollup.State
+				for _, ctx := range rollup.Contexts.Nodes {
+					if ctx.Status != "" && ctx.Status != "COMPLETED" {
+						hasPendingChecks = true
+						break
+					}
 				}
 			}
 		}

--- a/internal/github/renovate.go
+++ b/internal/github/renovate.go
@@ -39,10 +39,15 @@ const renovatePRQuery = `query($q: String!) {
                 state
                 contexts(first: 50) {
                   nodes {
+                    __typename
                     ... on CheckRun {
                       name
                       status
                       conclusion
+                    }
+                    ... on StatusContext {
+                      name: context
+                      state
                     }
                   }
                 }
@@ -172,7 +177,11 @@ func convertRenovatePRs(nodes []gqlPR, viewer string) []RenovatePR {
 					if ctx.Name == "" {
 						continue
 					}
-					checks = append(checks, CheckRunInfo(ctx))
+					checks = append(checks, CheckRunInfo{
+						Name:       ctx.Name,
+						Status:     ctx.Status,
+						Conclusion: ctx.Conclusion,
+					})
 				}
 			}
 		}

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -363,6 +363,17 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 			if r.agents.HasRunningAgentForTask(issues[i].TaskID) {
 				continue
 			}
+			// Gate dispatch on workflow state too: an agent may have just
+			// exited while the workflow is still in verify_commits /
+			// link_pr_and_review. Without this, a fresh issue (e.g.
+			// kind=conflict appearing because main moved during the agent
+			// run) races the in-flight workflow's tail steps and triggers
+			// a layered re-dispatch that DispatchEvent later rejects, but
+			// only after we've prepped a worktree and emitted audit
+			// noise.
+			if r.workflowEngine != nil && r.workflowEngine.HasActiveWorkflow(issues[i].TaskID) {
+				continue
+			}
 			if !r.prTracker.ShouldHandle(issues[i].TaskID, issues[i].Kind, issues[i].PR.HeadSHA) {
 				continue
 			}

--- a/internal/workflow/engine_dispatch.go
+++ b/internal/workflow/engine_dispatch.go
@@ -171,3 +171,26 @@ func (e *Engine) DispatchEvent(taskID, event string, extraFields, vars map[strin
 	}
 	return def.ID, nil
 }
+
+// HasActiveWorkflow reports whether the task has a non-terminal workflow
+// execution attached. Returns false when the task is unknown, has no
+// workflow, or its workflow has reached ExecCompleted/ExecFailed.
+//
+// Pre-check for callers that want to bail out early (no worktree prep,
+// no audit emit) when DispatchEvent would otherwise reject with
+// ErrWorkflowAlreadyActive. This is racy by construction — a workflow
+// can complete or start between the check and the dispatch — so callers
+// must still treat ErrWorkflowAlreadyActive from DispatchEvent as
+// benign. Used by pr-monitor to suppress layered re-dispatches while a
+// pr-fix run is in flight, including the gap between an agent
+// finishing and the workflow's verify_commits/link_pr steps advancing.
+func (e *Engine) HasActiveWorkflow(taskID string) bool {
+	t, err := e.tasks.GetTask(taskID)
+	if err != nil {
+		return false
+	}
+	if t.Workflow == nil {
+		return false
+	}
+	return t.Workflow.State != ExecCompleted && t.Workflow.State != ExecFailed
+}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -797,6 +797,44 @@ func TestDispatchEvent_TerminalWorkflowReplaced(t *testing.T) {
 	}
 }
 
+func TestHasActiveWorkflow(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{ID: "no-wf", Status: "todo"})
+	tasks.Put(TaskInfo{ID: "running", Status: "in-progress",
+		Workflow: &Execution{WorkflowID: "x", State: ExecRunning}})
+	tasks.Put(TaskInfo{ID: "waiting", Status: "in-progress",
+		Workflow: &Execution{WorkflowID: "x", State: ExecWaiting}})
+	tasks.Put(TaskInfo{ID: "completed", Status: "done",
+		Workflow: &Execution{WorkflowID: "x", State: ExecCompleted}})
+	tasks.Put(TaskInfo{ID: "failed", Status: "human-required",
+		Workflow: &Execution{WorkflowID: "x", State: ExecFailed}})
+
+	cases := []struct {
+		id   string
+		want bool
+	}{
+		{"no-wf", false},
+		{"running", true},
+		{"waiting", true},
+		{"completed", false},
+		{"failed", false},
+		{"unknown-task", false},
+	}
+	for _, c := range cases {
+		t.Run(c.id, func(t *testing.T) {
+			t.Parallel()
+			if got := engine.HasActiveWorkflow(c.id); got != c.want {
+				t.Errorf("HasActiveWorkflow(%q) = %v, want %v", c.id, got, c.want)
+			}
+		})
+	}
+}
+
 func TestMatchWorkflow_PriorityTieBreak(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()


### PR DESCRIPTION
## Motivation

While investigating why two tasks (PRs #186 and #717) had been
chewing budget for over an hour, I found two distinct loop
classes in pr-monitor:

1. **PR #186** (`refactor(frontend): replace console`): all
   gating checks (`format-lint`, `test`, `build`) were
   `SUCCESS`; only `codecov/patch` was `FAILURE`. pr-monitor
   treated the rollup as a CI failure and dispatched pr-fix
   three times in a row. Each fix agent ran `prettier --write`
   and committed — none of which moves the codecov needle.
   Eventually capped at `maxRetries=3`, but that's wasted
   wall-time and budget per task.

2. **PR #717** (`feat(codex): hermetic runs`): a fresh
   `kind=conflict` issue appeared right after the previous
   pr-fix run completed (main moved during the agent's run).
   `HasRunningAgentForTask` returned false in the gap between
   agent exit and the workflow's `verify_commits` / `link_pr`
   tail steps, so `handlePRIssue` prepped a worktree and got
   to `DispatchEvent` only to be rejected with
   `ErrWorkflowAlreadyActive`. Wasted I/O and audit noise.

## Implementation information

**Fix 1 — filter informational checks**

`PRState.StatusCheckRollup` only carried `state`, not check
names. Extending the GraphQL query to fetch
`__typename`, `name`, `status`, `conclusion` for `CheckRun`
and `name: context, state` for `StatusContext`, then
recomputing `ciStatus` from the filtered set. The filter list
is a hardcoded prefix list (`codecov/`, `sonarcloud/`,
`sonarsource/`, `deepsource/`) — chosen over a config knob
because these are universally non-gating reporters and a knob
adds setup burden for zero observed benefit. If
`rollupFromContexts` returns empty (zero-checks PR or older
gh), fall back to the GitHub-supplied rollup state so we
don't silently zero out CI status for legitimate PRs.

The renovate query was extended in lockstep so renovate PRs
benefit from the same filter (and their `gqlCheckContext` →
`CheckRunInfo` conversion is now an explicit field map since
the struct gained `Typename` and `State`).

**Fix 2 — `HasActiveWorkflow` gate at polling**

New `Engine.HasActiveWorkflow(taskID) bool` returns true when
a non-terminal `Workflow.State` is attached. Used by
`pollAndMonitorPRs` after `HasRunningAgentForTask` to skip
issues whose task already has a workflow running — including
the gap between agent exit and tail steps. Race-prone by
construction (workflow can complete or start between check
and dispatch), but `DispatchEvent` still rejects with
`ErrWorkflowAlreadyActive` for correctness; this is just an
early-out to avoid worktree prep and audit emission.

**Tested**: `go test ./internal/github/... ./internal/workflow/...`
plus existing pr-event e2e tests
(`go test -tags e2e ./internal/sybra/ -run TestE2E_DispatchPREvent`).

## Supporting documentation

Diagnosis transcript in the conversation that produced this
patch — log evidence on the laptop install showed
`pr-tracker.cooldown-cleared retries=3` for the PR-186 loop
and a 58-min agent run on PR-717 that watchdog correctly
flagged as not-stuck (real test debugging) but burned through
the 300-turn auto-continue budget.