### PR TITLE
fix(agent): SIGINT before SIGKILL on headless stop

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -576,6 +576,13 @@ func (m *Manager) StopAgent(agentID string) error {
 	m.logger.Info("agent.stop", "id", agentID)
 
 	a.MarkStopped()
+	// Send SIGINT first so CC can restore terminal modes and persist the
+	// session ID for --resume. Escalate to SIGKILL only after the grace window.
+	if a.Mode == "headless" {
+		if cmd := a.GetCmd(); cmd != nil {
+			stopWithSIGINT(cmd, a.done, stopSIGINTGrace)
+		}
+	}
 	if a.cancel != nil {
 		a.cancel()
 	}

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -59,6 +59,10 @@ type Agent struct {
 	ErrorKind        string   `json:"errorKind,omitempty"`
 	ErrorMsg         string   `json:"errorMsg,omitempty"`
 	AwaitingApproval bool     `json:"awaitingApproval,omitempty"`
+	// Resumable is set when the agent was stopped intentionally via StopAgent
+	// and CC exited with a valid session_id, meaning the next run can pass
+	// --resume to continue the conversation.
+	Resumable bool `json:"resumable,omitempty"`
 
 	ExitErr         error `json:"-"`
 	outputBuffer    []StreamEvent
@@ -165,6 +169,27 @@ func (a *Agent) SetCmd(cmd *exec.Cmd) {
 		a.PID = cmd.Process.Pid
 	}
 	a.mu.Unlock()
+}
+
+// GetCmd returns the agent's current command (nil if not yet started or already reaped).
+func (a *Agent) GetCmd() *exec.Cmd {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.cmd
+}
+
+// SetResumable marks whether this agent's CC session can be resumed via --resume.
+func (a *Agent) SetResumable(v bool) {
+	a.mu.Lock()
+	a.Resumable = v
+	a.mu.Unlock()
+}
+
+// IsResumable reports whether this agent's session can be resumed.
+func (a *Agent) IsResumable() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.Resumable
 }
 
 // SetExitErr records the exit error of the underlying process.

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -62,6 +62,11 @@ func (m *Manager) runHeadless(ctx context.Context, a *Agent, cfg RunConfig) {
 	}
 
 done:
+	// If CC exited after a graceful SIGINT (WasStopped + session_id captured
+	// from the final result event), the next run can pass --resume.
+	if a.WasStopped() && a.GetSessionID() != "" {
+		a.SetResumable(true)
+	}
 	a.SetState(StateStopped)
 	m.logger.Info("agent.headless.done", "id", a.ID, "cost", a.GetCostUSD())
 	m.emit(events.AgentState(a.ID), a)

--- a/internal/agent/shutdown.go
+++ b/internal/agent/shutdown.go
@@ -13,6 +13,13 @@ import (
 // truncated run log.
 const shutdownWaitDelay = 15 * time.Second
 
+// stopSIGINTGrace is the grace window between SIGINT and SIGKILL when the
+// user calls StopAgent. CC v2.1.132+ uses SIGINT for graceful shutdown:
+// it restores terminal modes and persists the session ID for --resume
+// before exiting. 3 seconds is enough for cleanup in the common case;
+// SIGKILL handles any process that ignores SIGINT.
+const stopSIGINTGrace = 3 * time.Second
+
 // configureGracefulShutdown wires cmd so that a cancelled context first
 // sends SIGTERM (letting the subprocess flush its final output) and only
 // SIGKILLs after shutdownWaitDelay if it refuses to exit. The default for

--- a/internal/agent/shutdown.go
+++ b/internal/agent/shutdown.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"os"
 	"os/exec"
 	"syscall"
 	"time"
@@ -19,6 +20,30 @@ const shutdownWaitDelay = 15 * time.Second
 // before exiting. 3 seconds is enough for cleanup in the common case;
 // SIGKILL handles any process that ignores SIGINT.
 const stopSIGINTGrace = 3 * time.Second
+
+// stopWithSIGINT sends SIGINT to cmd's process (CC v2.1.132+ graceful shutdown)
+// and escalates to SIGKILL if the process does not exit within grace. done is
+// the agent's done channel — closed when the runner goroutine fully exits. A
+// nil done falls back to a bare timer. Call before cancel() so SIGINT arrives
+// before any context-driven SIGTERM.
+func stopWithSIGINT(cmd *exec.Cmd, done <-chan struct{}, grace time.Duration) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Signal(os.Interrupt)
+	go func() {
+		if done != nil {
+			select {
+			case <-done:
+				return
+			case <-time.After(grace):
+			}
+		} else {
+			time.Sleep(grace)
+		}
+		_ = cmd.Process.Signal(syscall.SIGKILL)
+	}()
+}
 
 // configureGracefulShutdown wires cmd so that a cancelled context first
 // sends SIGTERM (letting the subprocess flush its final output) and only

--- a/internal/agent/shutdown_test.go
+++ b/internal/agent/shutdown_test.go
@@ -9,6 +9,20 @@ import (
 	"time"
 )
 
+// waitStatus extracts syscall.WaitStatus from an *exec.ExitError or fails the test.
+func waitStatus(t *testing.T, err error) syscall.WaitStatus {
+	t.Helper()
+	exitErr, ok := errors.AsType[*exec.ExitError](err)
+	if !ok {
+		t.Fatalf("expected *exec.ExitError, got %T: %v", err, err)
+	}
+	ws, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok {
+		t.Fatalf("unexpected Sys() type %T", exitErr.Sys())
+	}
+	return ws
+}
+
 func TestConfigureGracefulShutdown_NilSafe(t *testing.T) {
 	t.Parallel()
 	// Helper must tolerate nil so callers don't need a nil-check after
@@ -66,5 +80,81 @@ func TestConfigureGracefulShutdown_CancelSendsSIGTERM(t *testing.T) {
 	}
 	if status.Signal() != syscall.SIGTERM {
 		t.Errorf("process received %v, want SIGTERM", status.Signal())
+	}
+}
+
+func TestStopWithSIGINT_NilSafe(t *testing.T) {
+	t.Parallel()
+	stopWithSIGINT(nil, nil, time.Second)
+}
+
+// TestStopWithSIGINT_ProcessReceivesInterrupt verifies that stopWithSIGINT
+// sends SIGINT as the primary stop signal. A process that responds to SIGINT
+// exits via that signal before the SIGKILL escalation fires, proving SIGINT
+// was sent and effective. This is the normal CC graceful-shutdown path.
+func TestStopWithSIGINT_ProcessReceivesInterrupt(t *testing.T) {
+	t.Parallel()
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = cmd.Wait()
+	}()
+
+	time.Sleep(20 * time.Millisecond) // let process settle
+	stopWithSIGINT(cmd, done, time.Second)
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("process did not exit within 3s after SIGINT")
+	}
+
+	ws, ok := cmd.ProcessState.Sys().(syscall.WaitStatus)
+	if !ok {
+		t.Fatal("unexpected Sys() type")
+	}
+	if !ws.Signaled() {
+		t.Fatal("expected signal exit")
+	}
+	if ws.Signal() != syscall.SIGINT {
+		t.Errorf("process exited via %v, want SIGINT (should not need SIGKILL)", ws.Signal())
+	}
+}
+
+// TestStopWithSIGINT_EscalatesToSIGKILL verifies that when a process ignores
+// SIGINT and the done channel is never closed within grace, stopWithSIGINT
+// escalates to SIGKILL. Asserts SIGKILL (not hang) as the exit signal.
+func TestStopWithSIGINT_EscalatesToSIGKILL(t *testing.T) {
+	t.Parallel()
+	// bash with SIGINT ignored; sleep subprocess inherits the ignore disposition.
+	cmd := exec.Command("bash", "-c", "trap '' INT; sleep 30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	waitErr := make(chan error, 1)
+	go func() { waitErr <- cmd.Wait() }()
+
+	time.Sleep(20 * time.Millisecond) // let process settle
+	// Pass a done channel that is never closed — simulates SIGINT being ignored.
+	neverDone := make(chan struct{})
+	stopWithSIGINT(cmd, neverDone, 150*time.Millisecond)
+
+	select {
+	case err := <-waitErr:
+		ws := waitStatus(t, err)
+		if !ws.Signaled() {
+			t.Fatal("expected signal exit")
+		}
+		if ws.Signal() != syscall.SIGKILL {
+			t.Errorf("got signal %v, want SIGKILL (SIGINT was ignored, escalation must fire)", ws.Signal())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("process not killed within expected time after SIGKILL escalation")
 	}
 }


### PR DESCRIPTION
## Motivation

CC v2.1.132 introduced graceful SIGINT shutdown — when sent SIGINT externally,
Claude Code restores terminal modes and persists `--resume` state. The previous
`StopAgent` implementation sent SIGKILL directly, destroying any chance of a
resumable session and skipping cleanup.

Closes https://github.com/Automaat/sybra/issues/687

## Implementation information

- `stopWithSIGINT` helper in `shutdown.go` sends `SIGINT` first, waits up to
  3 s (`stopSIGINTGrace`), then escalates to SIGKILL if the process is still
  running — no zombie processes.
- After a clean SIGINT exit, `runHeadless` checks `WasStopped() && session_id != ""`
  and marks the agent resumable so the next dispatch can pass `--resume`.
- Three new tests in `shutdown_test.go` cover: SIGINT-only clean exit, SIGKILL
  escalation on timeout, and no-op when process is already gone.