### PR TITLE
feat(stats): capture and persist reasoning tokens from codex

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/agent/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/agent/models.ts
@@ -21,6 +21,7 @@ export class Agent {
     "costUsd": number;
     "inputTokens"?: number;
     "outputTokens"?: number;
+    "reasoningTokens"?: number;
     "startedAt": time$0.Time;
     "lastEventAt": time$0.Time;
     "logPath"?: string;
@@ -47,6 +48,13 @@ export class Agent {
     "errorKind"?: string;
     "errorMsg"?: string;
     "awaitingApproval"?: boolean;
+
+    /**
+     * Resumable is set when the agent was stopped intentionally via StopAgent
+     * and CC exited with a valid session_id, meaning the next run can pass
+     * --resume to continue the conversation.
+     */
+    "resumable"?: boolean;
 
     /** Creates a new Agent instance. */
     constructor($$source: Partial<Agent> = {}) {
@@ -85,10 +93,10 @@ export class Agent {
      * Creates a new Agent instance from a string or object.
      */
     static createFrom($$source: any = {}): Agent {
-        const $$createField21_0 = $$createType0;
+        const $$createField22_0 = $$createType0;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("pluginErrors" in $$parsedSource) {
-            $$parsedSource["pluginErrors"] = $$createField21_0($$parsedSource["pluginErrors"]);
+            $$parsedSource["pluginErrors"] = $$createField22_0($$parsedSource["pluginErrors"]);
         }
         return new Agent($$parsedSource as Partial<Agent>);
     }
@@ -108,6 +116,7 @@ export class ConvoEvent {
     "costUsd"?: number;
     "inputTokens"?: number;
     "outputTokens"?: number;
+    "reasoningTokens"?: number;
     "isPartial"?: boolean;
     "timestamp": time$0.Time;
     "raw"?: json$0.RawMessage;
@@ -199,6 +208,7 @@ export class StreamEvent {
     "cost_usd"?: number;
     "input_tokens"?: number;
     "output_tokens"?: number;
+    "reasoning_tokens"?: number;
     "subtype"?: string;
     "timestamp": time$0.Time;
 
@@ -236,14 +246,14 @@ export class StreamEvent {
      * Creates a new StreamEvent instance from a string or object.
      */
     static createFrom($$source: any = {}): StreamEvent {
-        const $$createField10_0 = $$createType6;
-        const $$createField11_0 = $$createType0;
+        const $$createField11_0 = $$createType6;
+        const $$createField12_0 = $$createType0;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("plan_steps" in $$parsedSource) {
-            $$parsedSource["plan_steps"] = $$createField10_0($$parsedSource["plan_steps"]);
+            $$parsedSource["plan_steps"] = $$createField11_0($$parsedSource["plan_steps"]);
         }
         if ("plugin_errors" in $$parsedSource) {
-            $$parsedSource["plugin_errors"] = $$createField11_0($$parsedSource["plugin_errors"]);
+            $$parsedSource["plugin_errors"] = $$createField12_0($$parsedSource["plugin_errors"]);
         }
         return new StreamEvent($$parsedSource as Partial<StreamEvent>);
     }

--- a/frontend/bindings/github.com/Automaat/sybra/internal/stats/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/stats/models.ts
@@ -56,6 +56,7 @@ export class RunRecord {
     "durationS": number;
     "inputTokens"?: number;
     "outputTokens"?: number;
+    "reasoningTokens"?: number;
     "outcome": string;
     "timestamp": time$0.Time;
 
@@ -217,6 +218,7 @@ export class Summary {
     "totalDurationS": number;
     "totalInputTokens": number;
     "totalOutputTokens": number;
+    "totalReasoningTokens"?: number;
 
     /** Creates a new Summary instance. */
     constructor($$source: Partial<Summary> = {}) {

--- a/frontend/src/pages/Stats.svelte
+++ b/frontend/src/pages/Stats.svelte
@@ -106,6 +106,9 @@
         <p class="mt-1 text-2xl font-bold">
           {formatTokens(summary.totalInputTokens)} / {formatTokens(summary.totalOutputTokens)}
         </p>
+        {#if summary.totalReasoningTokens}
+          <p class="mt-0.5 text-xs text-surface-400">{formatTokens(summary.totalReasoningTokens)} reasoning</p>
+        {/if}
       </div>
     </div>
   {/if}
@@ -130,6 +133,7 @@
                   <th class="pb-2 text-right">Runs</th>
                   <th class="pb-2 text-right">Cost</th>
                   <th class="pb-2 text-right">Duration</th>
+                  <th class="pb-2 text-right">Reasoning</th>
                 </tr>
               </thead>
               <tbody>
@@ -139,6 +143,7 @@
                     <td class="py-1.5 text-right">{row.stats.totalRuns}</td>
                     <td class="py-1.5 text-right">${row.stats.totalCostUsd.toFixed(2)}</td>
                     <td class="py-1.5 text-right">{formatDuration(row.stats.totalDurationS)}</td>
+                    <td class="py-1.5 text-right text-surface-400">{row.stats.totalReasoningTokens ? formatTokens(row.stats.totalReasoningTokens) : '—'}</td>
                   </tr>
                 {/each}
               </tbody>
@@ -165,6 +170,7 @@
                 <th class="pb-2">Model</th>
                 <th class="pb-2 text-right">Cost</th>
                 <th class="pb-2 text-right">Duration</th>
+                <th class="pb-2 text-right">Reasoning</th>
                 <th class="pb-2">Outcome</th>
               </tr>
             </thead>
@@ -180,6 +186,7 @@
                   <td class="py-1.5 text-xs">{run.model || '—'}</td>
                   <td class="py-1.5 text-right text-xs">${run.costUsd.toFixed(4)}</td>
                   <td class="py-1.5 text-right text-xs">{formatDuration(run.durationS)}</td>
+                  <td class="py-1.5 text-right text-xs text-surface-400">{run.reasoningTokens ? formatTokens(run.reasoningTokens) : '—'}</td>
                   <td class="py-1.5">
                     <span class="rounded px-1.5 py-0.5 text-xs {run.outcome === 'completed'
                       ? 'bg-success-200 text-success-800 dark:bg-success-800 dark:text-success-200'

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -30,25 +30,26 @@ const (
 )
 
 type Agent struct {
-	ID           string    `json:"id"`
-	TaskID       string    `json:"taskId"`
-	Mode         string    `json:"mode"`
-	State        State     `json:"state"`
-	SessionID    string    `json:"sessionId"`
-	CostUSD      float64   `json:"costUsd"`
-	InputTokens  int       `json:"inputTokens,omitempty"`
-	OutputTokens int       `json:"outputTokens,omitempty"`
-	StartedAt    time.Time `json:"startedAt"`
-	LastEventAt  time.Time `json:"lastEventAt"`
-	LogPath      string    `json:"logPath,omitempty"`
-	External     bool      `json:"external"`
-	PID          int       `json:"pid,omitempty"`
-	Command      string    `json:"command,omitempty"`
-	Name         string    `json:"name,omitempty"`
-	Project      string    `json:"project,omitempty"`
-	Provider     string    `json:"provider,omitempty"`
-	Model        string    `json:"model,omitempty"`
-	Prompt       string    `json:"prompt,omitempty"`
+	ID              string    `json:"id"`
+	TaskID          string    `json:"taskId"`
+	Mode            string    `json:"mode"`
+	State           State     `json:"state"`
+	SessionID       string    `json:"sessionId"`
+	CostUSD         float64   `json:"costUsd"`
+	InputTokens     int       `json:"inputTokens,omitempty"`
+	OutputTokens    int       `json:"outputTokens,omitempty"`
+	ReasoningTokens int       `json:"reasoningTokens,omitempty"`
+	StartedAt       time.Time `json:"startedAt"`
+	LastEventAt     time.Time `json:"lastEventAt"`
+	LogPath         string    `json:"logPath,omitempty"`
+	External        bool      `json:"external"`
+	PID             int       `json:"pid,omitempty"`
+	Command         string    `json:"command,omitempty"`
+	Name            string    `json:"name,omitempty"`
+	Project         string    `json:"project,omitempty"`
+	Provider        string    `json:"provider,omitempty"`
+	Model           string    `json:"model,omitempty"`
+	Prompt          string    `json:"prompt,omitempty"`
 
 	TurnCount int `json:"turnCount,omitempty"`
 	// MaxTurns is the per-agent turn limit override; zero means use global guardrail.
@@ -243,7 +244,7 @@ func (a *Agent) GetSessionFilePath() string {
 
 // AddResultStats merges a result-event's stats into the running totals
 // and returns the new cumulative CostUSD.
-func (a *Agent) AddResultStats(sessionID string, cost float64, in, out int) float64 {
+func (a *Agent) AddResultStats(sessionID string, cost float64, in, out, reasoning int) float64 {
 	a.mu.Lock()
 	if sessionID != "" {
 		a.SessionID = sessionID
@@ -251,6 +252,7 @@ func (a *Agent) AddResultStats(sessionID string, cost float64, in, out int) floa
 	a.CostUSD += cost
 	a.InputTokens += in
 	a.OutputTokens += out
+	a.ReasoningTokens += reasoning
 	result := a.CostUSD
 	a.mu.Unlock()
 	return result
@@ -348,6 +350,13 @@ func (a *Agent) GetOutputTokens() int {
 	return a.OutputTokens
 }
 
+// GetReasoningTokens returns the cumulative reasoning token count.
+func (a *Agent) GetReasoningTokens() int {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.ReasoningTokens
+}
+
 // GetLogPath returns the current output log path.
 func (a *Agent) GetLogPath() string {
 	a.mu.RLock()
@@ -433,14 +442,15 @@ type PlanStep struct {
 }
 
 type StreamEvent struct {
-	Type         string    `json:"type"`
-	Content      string    `json:"content,omitempty"`
-	SessionID    string    `json:"session_id,omitempty"`
-	CostUSD      float64   `json:"cost_usd,omitempty"`
-	InputTokens  int       `json:"input_tokens,omitempty"`
-	OutputTokens int       `json:"output_tokens,omitempty"`
-	Subtype      string    `json:"subtype,omitempty"`
-	Timestamp    time.Time `json:"timestamp"`
+	Type            string    `json:"type"`
+	Content         string    `json:"content,omitempty"`
+	SessionID       string    `json:"session_id,omitempty"`
+	CostUSD         float64   `json:"cost_usd,omitempty"`
+	InputTokens     int       `json:"input_tokens,omitempty"`
+	OutputTokens    int       `json:"output_tokens,omitempty"`
+	ReasoningTokens int       `json:"reasoning_tokens,omitempty"`
+	Subtype         string    `json:"subtype,omitempty"`
+	Timestamp       time.Time `json:"timestamp"`
 	// ErrorType and ErrorStatus carry structured fields from the Anthropic error
 	// envelope (e.g. "overloaded_error", 529) when subtype == "error".
 	ErrorType   string `json:"error_type,omitempty"`
@@ -455,18 +465,19 @@ type StreamEvent struct {
 // ConvoEvent is a rich event for conversational mode, preserving full tool
 // call structure for the chat UI.
 type ConvoEvent struct {
-	Type         string            `json:"type"`
-	Subtype      string            `json:"subtype,omitempty"`
-	SessionID    string            `json:"sessionId,omitempty"`
-	Text         string            `json:"text,omitempty"`
-	ToolUses     []ToolUseBlock    `json:"toolUses,omitempty"`
-	ToolResults  []ToolResultBlock `json:"toolResults,omitempty"`
-	CostUSD      float64           `json:"costUsd,omitempty"`
-	InputTokens  int               `json:"inputTokens,omitempty"`
-	OutputTokens int               `json:"outputTokens,omitempty"`
-	IsPartial    bool              `json:"isPartial,omitempty"`
-	Timestamp    time.Time         `json:"timestamp"`
-	Raw          json.RawMessage   `json:"raw,omitempty"`
+	Type            string            `json:"type"`
+	Subtype         string            `json:"subtype,omitempty"`
+	SessionID       string            `json:"sessionId,omitempty"`
+	Text            string            `json:"text,omitempty"`
+	ToolUses        []ToolUseBlock    `json:"toolUses,omitempty"`
+	ToolResults     []ToolResultBlock `json:"toolResults,omitempty"`
+	CostUSD         float64           `json:"costUsd,omitempty"`
+	InputTokens     int               `json:"inputTokens,omitempty"`
+	OutputTokens    int               `json:"outputTokens,omitempty"`
+	ReasoningTokens int               `json:"reasoningTokens,omitempty"`
+	IsPartial       bool              `json:"isPartial,omitempty"`
+	Timestamp       time.Time         `json:"timestamp"`
+	Raw             json.RawMessage   `json:"raw,omitempty"`
 	// ErrorType and ErrorStatus carry structured fields from the Anthropic error
 	// envelope (e.g. "overloaded_error", 529) when subtype == "error".
 	ErrorType   string `json:"errorType,omitempty"`

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -56,6 +56,7 @@ func codexEventToConvoEvent(e CodexEvent) ConvoEvent {
 			ev.CostUSD = e.Result.CostUSD
 			ev.InputTokens = e.Result.InputTokens
 			ev.OutputTokens = e.Result.OutputTokens
+			ev.ReasoningTokens = e.Result.ReasoningTokens
 			ev.ErrorType = e.Result.ErrorType
 			ev.ErrorStatus = e.Result.ErrorStatus
 		}
@@ -240,7 +241,7 @@ func (m *Manager) streamCodexConvoOutput(a *Agent, stdout io.Reader, outFile io.
 				}
 			}
 		case "result":
-			costNow := a.AddResultStats(event.SessionID, event.CostUSD, event.InputTokens, event.OutputTokens)
+			costNow := a.AddResultStats(event.SessionID, event.CostUSD, event.InputTokens, event.OutputTokens, event.ReasoningTokens)
 			m.logger.Info("agent.codex.convo.result", "id", a.ID, "cost", costNow)
 			gotResult = true
 		}

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -50,6 +50,7 @@ func claudeEventToConvoEvent(e ClaudeEvent) ConvoEvent {
 			ev.CostUSD = e.Result.CostUSD
 			ev.InputTokens = e.Result.InputTokens
 			ev.OutputTokens = e.Result.OutputTokens
+			ev.ReasoningTokens = e.Result.ReasoningTokens
 		}
 	}
 	return ev
@@ -288,7 +289,7 @@ func (m *Manager) streamConvoOutput(a *Agent, stdout io.Reader, outFile io.Write
 				a.SetSessionID(event.SessionID)
 			}
 		case "result":
-			costNow := a.AddResultStats(event.SessionID, event.CostUSD, event.InputTokens, event.OutputTokens)
+			costNow := a.AddResultStats(event.SessionID, event.CostUSD, event.InputTokens, event.OutputTokens, event.ReasoningTokens)
 			m.logger.Info("agent.convo.result", "id", a.ID, "session_id", event.SessionID, "cost", costNow)
 			// Drain any prompts queued mid-turn before flipping to paused.
 			// Each queued prompt fires the next turn back-to-back so the

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -390,7 +390,7 @@ func (m *Manager) streamHeadlessOutput(ctx context.Context, a *Agent, stdout io.
 		}
 
 		if event.Type == "result" {
-			costNow := a.AddResultStats(event.SessionID, event.CostUSD, event.InputTokens, event.OutputTokens)
+			costNow := a.AddResultStats(event.SessionID, event.CostUSD, event.InputTokens, event.OutputTokens, event.ReasoningTokens)
 			m.logger.Info("agent.headless.result", "id", a.ID, "session_id", event.SessionID, "cost", costNow)
 			m.mu.RLock()
 			maxCost := m.guardrails.MaxCostUSD
@@ -566,6 +566,7 @@ func claudeEventToStreamEvent(e ClaudeEvent) StreamEvent {
 			ev.CostUSD = e.Result.CostUSD
 			ev.InputTokens = e.Result.InputTokens
 			ev.OutputTokens = e.Result.OutputTokens
+			ev.ReasoningTokens = e.Result.ReasoningTokens
 		}
 
 	}
@@ -630,6 +631,7 @@ func codexEventToStreamEvent(e CodexEvent) StreamEvent {
 			ev.CostUSD = e.Result.CostUSD
 			ev.InputTokens = e.Result.InputTokens
 			ev.OutputTokens = e.Result.OutputTokens
+			ev.ReasoningTokens = e.Result.ReasoningTokens
 			ev.ErrorType = e.Result.ErrorType
 			ev.ErrorStatus = e.Result.ErrorStatus
 		}

--- a/internal/agent/stream.go
+++ b/internal/agent/stream.go
@@ -17,12 +17,13 @@ type ClaudeMessage struct {
 
 // ClaudeResult holds fields from "result" events.
 type ClaudeResult struct {
-	Subtype      string
-	Text         string
-	SessionID    string
-	CostUSD      float64
-	InputTokens  int
-	OutputTokens int
+	Subtype         string
+	Text            string
+	SessionID       string
+	CostUSD         float64
+	InputTokens     int
+	OutputTokens    int
+	ReasoningTokens int
 	// ErrorType and ErrorStatus carry structured error info when Subtype == "error".
 	// Codex: mapped from the "code" field. Claude: reserved for future extraction.
 	ErrorType   string
@@ -101,8 +102,9 @@ type codexItem struct {
 }
 
 type codexUsage struct {
-	InputTokens  int `json:"input_tokens"`
-	OutputTokens int `json:"output_tokens"`
+	InputTokens     int `json:"input_tokens"`
+	OutputTokens    int `json:"output_tokens"`
+	ReasoningTokens int `json:"reasoning_tokens"`
 }
 
 // ParseClaudeLine parses one line of Claude stream-json output.
@@ -186,6 +188,7 @@ func ParseCodexLine(line []byte) (CodexEvent, error) {
 		if raw.Usage != nil {
 			r.InputTokens = raw.Usage.InputTokens
 			r.OutputTokens = raw.Usage.OutputTokens
+			r.ReasoningTokens = raw.Usage.ReasoningTokens
 		}
 		return CodexEvent{Type: "result", Raw: rawCopy, Result: &r}, nil
 

--- a/internal/agent/stream_test.go
+++ b/internal/agent/stream_test.go
@@ -658,6 +658,11 @@ func TestCodexEventToStreamEvent(t *testing.T) {
 			line: `{"type":"turn.completed","usage":{"input_tokens":16012,"output_tokens":18}}`,
 			want: StreamEvent{Type: "result", InputTokens: 16012, OutputTokens: 18},
 		},
+		{
+			name: "turn.completed with reasoning tokens",
+			line: `{"type":"turn.completed","usage":{"input_tokens":100,"output_tokens":50,"reasoning_tokens":200}}`,
+			want: StreamEvent{Type: "result", InputTokens: 100, OutputTokens: 50, ReasoningTokens: 200},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -678,6 +683,9 @@ func TestCodexEventToStreamEvent(t *testing.T) {
 			}
 			if got.OutputTokens != tt.want.OutputTokens {
 				t.Errorf("OutputTokens = %d, want %d", got.OutputTokens, tt.want.OutputTokens)
+			}
+			if got.ReasoningTokens != tt.want.ReasoningTokens {
+				t.Errorf("ReasoningTokens = %d, want %d", got.ReasoningTokens, tt.want.ReasoningTokens)
 			}
 		})
 	}

--- a/internal/loopagent/scheduler_test.go
+++ b/internal/loopagent/scheduler_test.go
@@ -165,7 +165,7 @@ func TestSchedulerOnAgentCompleteUpdatesCost(t *testing.T) {
 	}
 
 	ag := &agent.Agent{ID: "ag-cost", Name: "loop:self"}
-	ag.AddResultStats("sess", 0.42, 100, 50)
+	ag.AddResultStats("sess", 0.42, 100, 50, 0)
 	sched.OnAgentComplete(ag)
 
 	stored, _ := store.Get(la.ID)

--- a/internal/stats/backfill.go
+++ b/internal/stats/backfill.go
@@ -53,6 +53,9 @@ func (s *Store) Backfill(auditDir string) error {
 		if v, ok := ev.Data["provider"].(string); ok {
 			r.Provider = v
 		}
+		if v, ok := ev.Data["reasoning_tokens"].(float64); ok {
+			r.ReasoningTokens = int(v)
+		}
 
 		s.runs = append(s.runs, r)
 	}

--- a/internal/stats/backfill_test.go
+++ b/internal/stats/backfill_test.go
@@ -269,6 +269,37 @@ func TestBackfillFieldExtraction(t *testing.T) {
 	}
 }
 
+func TestBackfillReasoningTokens(t *testing.T) {
+	s, _ := newTestStore(t)
+	auditDir := newAuditDir(t)
+
+	ts := time.Date(2024, 7, 1, 9, 0, 0, 0, time.UTC)
+	writeAuditFile(t, auditDir, "2024-07-01.ndjson", []audit.Event{
+		{
+			Timestamp: ts,
+			Type:      audit.EventAgentCompleted,
+			TaskID:    "t1",
+			AgentID:   "a1",
+			Data: map[string]any{
+				"state":            "stopped",
+				"reasoning_tokens": float64(450),
+			},
+		},
+	})
+
+	if err := s.Backfill(auditDir); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := s.Query()
+	if len(resp.RecentRuns) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(resp.RecentRuns))
+	}
+	if resp.RecentRuns[0].ReasoningTokens != 450 {
+		t.Errorf("ReasoningTokens: got %d, want 450", resp.RecentRuns[0].ReasoningTokens)
+	}
+}
+
 func TestBackfillMultipleFiles(t *testing.T) {
 	s, _ := newTestStore(t)
 	auditDir := newAuditDir(t)

--- a/internal/stats/model.go
+++ b/internal/stats/model.go
@@ -4,30 +4,32 @@ import "time"
 
 // RunRecord captures a single agent execution for analytics.
 type RunRecord struct {
-	ID           string    `json:"id"`
-	TaskID       string    `json:"taskId"`
-	ProjectID    string    `json:"projectId,omitempty"`
-	Mode         string    `json:"mode"`
-	Role         string    `json:"role"`
-	Model        string    `json:"model,omitempty"`
-	Provider     string    `json:"provider,omitempty"`
-	CostUSD      float64   `json:"costUsd"`
-	DurationS    float64   `json:"durationS"`
-	InputTokens  int       `json:"inputTokens,omitempty"`
-	OutputTokens int       `json:"outputTokens,omitempty"`
-	Outcome      string    `json:"outcome"`
-	Timestamp    time.Time `json:"timestamp"`
+	ID              string    `json:"id"`
+	TaskID          string    `json:"taskId"`
+	ProjectID       string    `json:"projectId,omitempty"`
+	Mode            string    `json:"mode"`
+	Role            string    `json:"role"`
+	Model           string    `json:"model,omitempty"`
+	Provider        string    `json:"provider,omitempty"`
+	CostUSD         float64   `json:"costUsd"`
+	DurationS       float64   `json:"durationS"`
+	InputTokens     int       `json:"inputTokens,omitempty"`
+	OutputTokens    int       `json:"outputTokens,omitempty"`
+	ReasoningTokens int       `json:"reasoningTokens,omitempty"`
+	Outcome         string    `json:"outcome"`
+	Timestamp       time.Time `json:"timestamp"`
 }
 
 // Summary holds aggregate metrics over a set of runs.
 type Summary struct {
-	TotalCostUSD      float64 `json:"totalCostUsd"`
-	TotalRuns         int     `json:"totalRuns"`
-	AvgCostPerRun     float64 `json:"avgCostPerRun"`
-	AvgDurationS      float64 `json:"avgDurationS"`
-	TotalDurationS    float64 `json:"totalDurationS"`
-	TotalInputTokens  int     `json:"totalInputTokens"`
-	TotalOutputTokens int     `json:"totalOutputTokens"`
+	TotalCostUSD         float64 `json:"totalCostUsd"`
+	TotalRuns            int     `json:"totalRuns"`
+	AvgCostPerRun        float64 `json:"avgCostPerRun"`
+	AvgDurationS         float64 `json:"avgDurationS"`
+	TotalDurationS       float64 `json:"totalDurationS"`
+	TotalInputTokens     int     `json:"totalInputTokens"`
+	TotalOutputTokens    int     `json:"totalOutputTokens"`
+	TotalReasoningTokens int     `json:"totalReasoningTokens,omitempty"`
 }
 
 // GroupedStat is an aggregate keyed by a dimension (project, mode, etc).

--- a/internal/stats/store.go
+++ b/internal/stats/store.go
@@ -151,6 +151,7 @@ func summarize(runs []RunRecord) Summary {
 		s.TotalDurationS += runs[i].DurationS
 		s.TotalInputTokens += runs[i].InputTokens
 		s.TotalOutputTokens += runs[i].OutputTokens
+		s.TotalReasoningTokens += runs[i].ReasoningTokens
 	}
 	s.AvgCostPerRun = s.TotalCostUSD / float64(s.TotalRuns)
 	s.AvgDurationS = s.TotalDurationS / float64(s.TotalRuns)

--- a/internal/stats/store_test.go
+++ b/internal/stats/store_test.go
@@ -135,6 +135,39 @@ func TestPersistence(t *testing.T) {
 	}
 }
 
+func TestReasoningTokensPersistence(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stats.json")
+
+	s, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.Record(RunRecord{
+		ID: "r1", TaskID: "t1", Mode: "headless", Role: "implementation",
+		ReasoningTokens: 300, Outcome: "completed", Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reload and verify field survives the round-trip.
+	s2, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp := s2.Query()
+	if len(resp.RecentRuns) != 1 {
+		t.Fatalf("expected 1 run after reload, got %d", len(resp.RecentRuns))
+	}
+	if resp.RecentRuns[0].ReasoningTokens != 300 {
+		t.Errorf("ReasoningTokens after reload: got %d, want 300", resp.RecentRuns[0].ReasoningTokens)
+	}
+	if resp.AllTime.TotalReasoningTokens != 300 {
+		t.Errorf("TotalReasoningTokens: got %d, want 300", resp.AllTime.TotalReasoningTokens)
+	}
+}
+
 func TestQueryEmptyStore(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "stats.json")

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -180,6 +180,7 @@ func (h *AgentCompletionHandler) recordRunStats(ag *agent.Agent, cost, duration 
 	}
 	in := ag.GetInputTokens()
 	out := ag.GetOutputTokens()
+	reasoning := ag.GetReasoningTokens()
 	agCost := cost
 	if agCost == 0 && ag.Provider == "codex" {
 		agCost = stats.EstimateCost(ag.Model, in, out)
@@ -195,19 +196,20 @@ func (h *AgentCompletionHandler) recordRunStats(ag *agent.Agent, cost, duration 
 		}
 	}
 	_ = h.stats.Record(stats.RunRecord{
-		ID:           ag.ID,
-		TaskID:       ag.TaskID,
-		ProjectID:    projectID,
-		Mode:         ag.Mode,
-		Role:         string(agent.RoleFromName(ag.Name)),
-		Model:        ag.Model,
-		Provider:     ag.Provider,
-		CostUSD:      agCost,
-		DurationS:    duration,
-		InputTokens:  in,
-		OutputTokens: out,
-		Outcome:      outcome,
-		Timestamp:    time.Now(),
+		ID:              ag.ID,
+		TaskID:          ag.TaskID,
+		ProjectID:       projectID,
+		Mode:            ag.Mode,
+		Role:            string(agent.RoleFromName(ag.Name)),
+		Model:           ag.Model,
+		Provider:        ag.Provider,
+		CostUSD:         agCost,
+		DurationS:       duration,
+		InputTokens:     in,
+		OutputTokens:    out,
+		ReasoningTokens: reasoning,
+		Outcome:         outcome,
+		Timestamp:       time.Now(),
 	})
 }
 

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -84,12 +84,13 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 	state := ag.GetState()
 	cost := ag.GetCostUSD()
 	exitErr := ag.GetExitErr()
+	reasoning := ag.GetReasoningTokens()
 
 	// Audit logging always fires — orchestrator brain agents have no
 	// parent task and skip the storage paths below, but their lifecycle
 	// still belongs in the audit trail.
 	duration := time.Since(ag.StartedAt).Seconds()
-	h.logAudit(audit.EventAgentCompleted, ag.TaskID, ag.ID, map[string]any{
+	auditData := map[string]any{
 		"mode":       ag.Mode,
 		"cost_usd":   cost,
 		"duration_s": duration,
@@ -98,7 +99,11 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 		"provider":   ag.Provider,
 		"name":       ag.Name,
 		"log_file":   ag.LogPath,
-	})
+	}
+	if reasoning > 0 {
+		auditData["reasoning_tokens"] = reasoning
+	}
+	h.logAudit(audit.EventAgentCompleted, ag.TaskID, ag.ID, auditData)
 
 	h.recordRunStats(ag, cost, duration, exitErr)
 

--- a/internal/sybra/svc_stats.go
+++ b/internal/sybra/svc_stats.go
@@ -71,10 +71,11 @@ func aggregateByProjectType(byProject []stats.GroupedStat, types map[string]stri
 
 func addSummary(a, b stats.Summary) stats.Summary {
 	return stats.Summary{
-		TotalCostUSD:      a.TotalCostUSD + b.TotalCostUSD,
-		TotalRuns:         a.TotalRuns + b.TotalRuns,
-		TotalDurationS:    a.TotalDurationS + b.TotalDurationS,
-		TotalInputTokens:  a.TotalInputTokens + b.TotalInputTokens,
-		TotalOutputTokens: a.TotalOutputTokens + b.TotalOutputTokens,
+		TotalCostUSD:         a.TotalCostUSD + b.TotalCostUSD,
+		TotalRuns:            a.TotalRuns + b.TotalRuns,
+		TotalDurationS:       a.TotalDurationS + b.TotalDurationS,
+		TotalInputTokens:     a.TotalInputTokens + b.TotalInputTokens,
+		TotalOutputTokens:    a.TotalOutputTokens + b.TotalOutputTokens,
+		TotalReasoningTokens: a.TotalReasoningTokens + b.TotalReasoningTokens,
 	}
 }


### PR DESCRIPTION
## Motivation

Codex agents emit reasoning token counts in their `--json` output but Sybra was discarding them, leaving a gap in cost and usage statistics. Issue #703 tracks this as a missing data point in the stats dashboard.

## Implementation information

- Parse `reasoning_tokens` from the `usage` field in codex exec `--json` stream events (`runner_headless.go`)
- Accumulate reasoning tokens alongside input/output tokens in the agent stats model
- Backfill missing reasoning token counts into audit log entries so historical data stays consistent

Closes https://github.com/Automaat/sybra/issues/703