### PR TITLE
feat(project): expose worktree.baseRef setting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,8 @@ Projects mirror GitHub repos. Created from a GitHub URL, cloned as bare repos.
 
 **Flow:** Create project from URL → bare clone → assign `project_id` to tasks → agent start auto-creates worktree → worktree cleaned up on agent completion.
 
+**Worktree base ref** (`worktree_base_ref`): controls the starting point for new worktree branches. `fresh` (default) branches off `origin/<default>` so worktrees always start from pushed remote state. `head` branches off the local HEAD of the default branch, picking up commits that exist locally but haven't been pushed yet. Empty value treated as `fresh` — existing projects require no migration. Configurable per-project from the Project → Setup tab.
+
 **CLI:**
 ```bash
 sybra-cli project list|get|create|delete

--- a/frontend/bindings/github.com/Automaat/sybra/internal/project/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/project/models.ts
@@ -57,6 +57,13 @@ export class Project {
     "setupCommands"?: string[];
     "sandbox"?: SandboxConfig | null;
     "checks"?: ChecksConfig | null;
+
+    /**
+     * WorktreeBaseRef controls the starting point for new worktree branches.
+     * "fresh" (default) branches off origin/<default>; "head" branches off the
+     * local HEAD so unpushed commits are included. Empty value treated as "fresh".
+     */
+    "worktreeBaseRef"?: string;
     "createdAt": time$0.Time;
     "updatedAt": time$0.Time;
 

--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/projectservice.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/projectservice.ts
@@ -91,6 +91,16 @@ export function SetProjectSetupCommands(id: string, cmds: string[]): $Cancellabl
 }
 
 /**
+ * SetProjectWorktreeBaseRef sets the worktree branching base for a project.
+ * ref must be "fresh" (branch off origin/<default>) or "head" (branch off local HEAD).
+ */
+export function SetProjectWorktreeBaseRef(id: string, ref: string): $CancellablePromise<project$0.Project> {
+    return $Call.ByID(1094675552, id, ref).then(($result: any) => {
+        return $$createType0($result);
+    });
+}
+
+/**
  * UpdateProject changes the type (pet/work) of a registered project.
  */
 export function UpdateProject(id: string, ptype: string): $CancellablePromise<project$0.Project> {

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -105,6 +105,7 @@ export function ListProjects(): Promise<Array<Project>> { return call('ProjectSe
 export function ListWorktrees(arg1: string): Promise<Array<Worktree>> { return call('ProjectService', 'ListWorktrees', arg1) }
 export function OpenInEditor(arg1: string): Promise<void> { return call('ProjectService', 'OpenInEditor', arg1) }
 export function OpenInTerminal(arg1: string): Promise<void> { return call('ProjectService', 'OpenInTerminal', arg1) }
+export function SetProjectWorktreeBaseRef(arg1: string, arg2: string): Promise<Project> { return call('ProjectService', 'SetProjectWorktreeBaseRef', arg1, arg2) }
 export function UpdateProject(arg1: string, arg2: string): Promise<Project> { return call('ProjectService', 'UpdateProject', arg1, arg2) }
 
 // ReviewService

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -112,6 +112,7 @@ export const ListProjects = pick(ProjectSvc.ListProjects, http.ListProjects)
 export const ListWorktrees = pick(ProjectSvc.ListWorktrees, http.ListWorktrees)
 export const OpenInEditor = pick(ProjectSvc.OpenInEditor, http.OpenInEditor)
 export const OpenInTerminal = pick(ProjectSvc.OpenInTerminal, http.OpenInTerminal)
+export const SetProjectWorktreeBaseRef = pick(ProjectSvc.SetProjectWorktreeBaseRef, http.SetProjectWorktreeBaseRef)
 export const UpdateProject = pick(ProjectSvc.UpdateProject, http.UpdateProject)
 
 // ReviewService

--- a/frontend/src/pages/ProjectDetail.svelte
+++ b/frontend/src/pages/ProjectDetail.svelte
@@ -4,6 +4,7 @@
   import * as yaml from 'js-yaml'
   import type { Project, SandboxConfig } from '../../bindings/github.com/Automaat/sybra/internal/project/models.js'
   import { SetProjectSandboxConfig, SetProjectSetupCommands } from '../../bindings/github.com/Automaat/sybra/internal/sybra/projectservice.js'
+  import { SetProjectWorktreeBaseRef } from '../lib/api.js'
   import { projectStore } from '../stores/projects.svelte.js'
   import { taskStore } from '../stores/tasks.svelte.js'
   import { BOARD_COLUMNS } from '../lib/statuses.js'
@@ -31,6 +32,9 @@
   let setupSaving = $state(false)
   let setupError = $state('')
   let setupSaved = $state(false)
+  let baseRefSaving = $state(false)
+  let baseRefError = $state('')
+  let baseRefSaved = $state(false)
 
   const tabs = [
     { value: 'tasks', label: 'Tasks' },
@@ -75,6 +79,22 @@
       setupError = String(e)
     } finally {
       setupSaving = false
+    }
+  }
+
+  async function saveWorktreeBaseRef(ref: string) {
+    if (!p) return
+    baseRefSaving = true
+    baseRefError = ''
+    baseRefSaved = false
+    try {
+      p = await SetProjectWorktreeBaseRef(projectId, ref)
+      baseRefSaved = true
+      setTimeout(() => { baseRefSaved = false }, 2000)
+    } catch (e) {
+      baseRefError = String(e)
+    } finally {
+      baseRefSaving = false
     }
   }
 
@@ -250,6 +270,36 @@
         <WorktreeList projectId={projectId} />
       {:else if activeTab === 'setup'}
         <div class="flex flex-col gap-3">
+          <div class="flex flex-col gap-2 rounded border border-surface-300 p-3 dark:border-surface-600">
+            <div class="flex items-center justify-between">
+              <div class="flex flex-col gap-0.5">
+                <span class="text-sm font-medium">Worktree base</span>
+                <span class="text-xs text-surface-500">
+                  Starting point for new worktree branches.
+                  <strong>fresh</strong> = <code>origin/&lt;default&gt;</code> (always pushed state);
+                  <strong>head</strong> = local HEAD (includes unpushed commits).
+                </span>
+              </div>
+              <div class="flex items-center gap-2">
+                {#if baseRefSaved}
+                  <span class="text-xs text-success-500">Saved</span>
+                {/if}
+                {#if baseRefError}
+                  <span class="text-xs text-error-500">{baseRefError}</span>
+                {/if}
+                <select
+                  class="rounded border border-surface-300 bg-surface-50 px-2 py-1 text-sm dark:border-surface-600 dark:bg-surface-900 disabled:opacity-50"
+                  value={p.worktreeBaseRef ?? 'fresh'}
+                  onchange={(e) => saveWorktreeBaseRef((e.target as HTMLSelectElement).value)}
+                  disabled={baseRefSaving}
+                >
+                  <option value="fresh">fresh</option>
+                  <option value="head">head</option>
+                </select>
+              </div>
+            </div>
+          </div>
+
           <p class="text-sm text-surface-500">
             Machine-local shell commands run inside every newly created worktree for this project, <em>after</em>
             the <code>setup:</code> block in the repo's <code>.sybra.yaml</code>. Use this only for host-specific extras

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -136,6 +136,50 @@ func FetchOrigin(barePath string) error {
 	return executil.Run(barePath, "git", "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*")
 }
 
+// SyncLocalBranch fast-forwards refs/heads/<branch> in the bare clone to match
+// refs/remotes/origin/<branch> if the local branch is strictly behind the remote.
+// If the local branch has commits ahead of (or diverged from) origin, it is left
+// unchanged so those local-only commits are preserved. This keeps refs/heads/<branch>
+// usable as a base ref for WorktreeBaseRefHead mode — without this, a bare clone
+// never updates refs/heads/* after the initial clone, so FetchOrigin alone cannot
+// make head mode reflect current remote state.
+func SyncLocalBranch(barePath, branch string) error {
+	localRef := "refs/heads/" + branch
+	remoteRef := "refs/remotes/origin/" + branch
+
+	remoteSHA, remoteOK := resolveRef(barePath, remoteRef)
+	if !remoteOK {
+		return nil // remote ref absent, nothing to sync
+	}
+
+	localSHA, localOK := resolveRef(barePath, localRef)
+	if !localOK {
+		// local branch absent — create it at the remote SHA
+		return executil.Run(barePath, "git", "update-ref", localRef, remoteSHA)
+	}
+
+	if localSHA == remoteSHA {
+		return nil
+	}
+
+	// Fast-forward only: advance local if it is a strict ancestor of remote.
+	// merge-base --is-ancestor exits 0 when local IS an ancestor; exits 1 when not.
+	cmd := exec.Command("git", "merge-base", "--is-ancestor", localSHA, remoteSHA)
+	cmd.Dir = barePath
+	if cmd.Run() == nil {
+		return executil.Run(barePath, "git", "update-ref", localRef, remoteSHA)
+	}
+	// local is not an ancestor (has local-only or diverged commits) — preserve
+	return nil
+}
+
+// resolveRef resolves a git ref in the bare repo. Returns ("", false) if the
+// ref does not exist or cannot be resolved.
+func resolveRef(barePath, ref string) (string, bool) {
+	sha, err := executil.Output(barePath, "git", "rev-parse", "--verify", ref)
+	return sha, err == nil
+}
+
 // SanitizeWorktree cleans up worktree state that would confuse agents:
 //   - aborts any stuck rebase/merge/cherry-pick
 //   - deletes local branches that shadow remote refs (e.g. local "origin/main")

--- a/internal/project/model.go
+++ b/internal/project/model.go
@@ -110,6 +110,15 @@ const (
 	ProjectStatusError ProjectStatus = "error"
 )
 
+// WorktreeBaseRefFresh branches new worktrees off origin/<default> — always
+// starts from the latest pushed remote state.
+const WorktreeBaseRefFresh = "fresh"
+
+// WorktreeBaseRefHead branches new worktrees off the local HEAD of the
+// default branch — picks up commits that exist locally but haven't been
+// pushed yet.
+const WorktreeBaseRefHead = "head"
+
 type Project struct {
 	ID        string      `yaml:"id" json:"id"`
 	Name      string      `yaml:"name" json:"name"`
@@ -124,8 +133,12 @@ type Project struct {
 	SetupCommands []string       `yaml:"setup_commands,omitempty" json:"setupCommands,omitempty"`
 	Sandbox       *SandboxConfig `yaml:"sandbox,omitempty" json:"sandbox,omitempty"`
 	Checks        *ChecksConfig  `yaml:"checks,omitempty"  json:"checks,omitempty"`
-	CreatedAt     time.Time      `yaml:"created_at" json:"createdAt"`
-	UpdatedAt     time.Time      `yaml:"updated_at" json:"updatedAt"`
+	// WorktreeBaseRef controls the starting point for new worktree branches.
+	// "fresh" (default) branches off origin/<default>; "head" branches off the
+	// local HEAD so unpushed commits are included. Empty value treated as "fresh".
+	WorktreeBaseRef string    `yaml:"worktree_base_ref,omitempty" json:"worktreeBaseRef,omitempty"`
+	CreatedAt       time.Time `yaml:"created_at" json:"createdAt"`
+	UpdatedAt       time.Time `yaml:"updated_at" json:"updatedAt"`
 }
 
 type Worktree struct {

--- a/internal/project/store.go
+++ b/internal/project/store.go
@@ -192,6 +192,21 @@ func (s *Store) SetSetupCommands(id string, cmds []string) (Project, error) {
 	return p, s.writeFile(p)
 }
 
+// SetWorktreeBaseRef sets the worktree branching base for a project.
+// ref must be WorktreeBaseRefFresh or WorktreeBaseRefHead.
+func (s *Store) SetWorktreeBaseRef(id, ref string) (Project, error) {
+	if ref != WorktreeBaseRefFresh && ref != WorktreeBaseRefHead {
+		return Project{}, fmt.Errorf("invalid worktree_base_ref %q (must be %q or %q)", ref, WorktreeBaseRefFresh, WorktreeBaseRefHead)
+	}
+	p, err := s.Get(id)
+	if err != nil {
+		return p, err
+	}
+	p.WorktreeBaseRef = ref
+	p.UpdatedAt = time.Now().UTC()
+	return p, s.writeFile(p)
+}
+
 func (s *Store) Delete(id string) error {
 	p, err := s.Get(id)
 	if err != nil {
@@ -232,6 +247,9 @@ func (s *Store) readFile(path string) (Project, error) {
 	}
 	if p.Status == "" {
 		p.Status = ProjectStatusReady
+	}
+	if p.WorktreeBaseRef == "" {
+		p.WorktreeBaseRef = WorktreeBaseRefFresh
 	}
 	return p, nil
 }

--- a/internal/sybra/svc_projects.go
+++ b/internal/sybra/svc_projects.go
@@ -110,6 +110,17 @@ func (s *ProjectService) SetProjectSetupCommands(id string, cmds []string) (proj
 	return p, nil
 }
 
+// SetProjectWorktreeBaseRef sets the worktree branching base for a project.
+// ref must be "fresh" (branch off origin/<default>) or "head" (branch off local HEAD).
+func (s *ProjectService) SetProjectWorktreeBaseRef(id, ref string) (project.Project, error) {
+	s.logger.Info("project.set-worktree-base-ref", "id", id, "ref", ref)
+	p, err := s.projects.SetWorktreeBaseRef(id, ref)
+	if err != nil {
+		s.logger.Error("project.set-worktree-base-ref.failed", "id", id, "err", err)
+	}
+	return p, err
+}
+
 // DeleteProject removes a project and its bare clone from disk.
 func (s *ProjectService) DeleteProject(id string) error {
 	s.logger.Info("project.delete", "id", id)

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -133,6 +133,12 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 		return "", fmt.Errorf("default branch: %w", err)
 	}
 
+	if proj.WorktreeBaseRef == project.WorktreeBaseRefHead {
+		if err := project.SyncLocalBranch(proj.ClonePath, branch); err != nil {
+			m.logger.Warn("worktree.sync-local-branch", "task_id", t.ID, "branch", branch, "err", err)
+		}
+	}
+
 	wtPath := m.PathFor(t)
 	wtBranch := "sybra/" + t.DirName()
 	baseRef := worktreeBaseRef(proj.WorktreeBaseRef, branch)
@@ -240,6 +246,12 @@ func (m *Manager) PrepareForChat(t task.Task, onPhase func(string)) (string, err
 	branch, err := project.DefaultBranch(proj.ClonePath)
 	if err != nil {
 		return "", fmt.Errorf("default branch: %w", err)
+	}
+
+	if proj.WorktreeBaseRef == project.WorktreeBaseRefHead {
+		if err := project.SyncLocalBranch(proj.ClonePath, branch); err != nil {
+			m.logger.Warn("worktree.sync-local-branch", "task_id", t.ID, "branch", branch, "err", err)
+		}
 	}
 
 	wtPath := m.PathFor(t)

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -135,7 +135,7 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 
 	wtPath := m.PathFor(t)
 	wtBranch := "sybra/" + t.DirName()
-	baseRef := "refs/remotes/origin/" + branch
+	baseRef := worktreeBaseRef(proj.WorktreeBaseRef, branch)
 
 	if _, statErr := os.Stat(wtPath); statErr == nil {
 		callPhase(onPhase, "Checking worktree…")
@@ -244,7 +244,7 @@ func (m *Manager) PrepareForChat(t task.Task, onPhase func(string)) (string, err
 
 	wtPath := m.PathFor(t)
 	wtBranch := "sybra/" + t.DirName()
-	baseRef := "refs/remotes/origin/" + branch
+	baseRef := worktreeBaseRef(proj.WorktreeBaseRef, branch)
 
 	if _, statErr := os.Stat(wtPath); statErr == nil {
 		usable, err := m.healOrRecreate(t.ID, proj.ClonePath, wtPath)
@@ -714,4 +714,15 @@ func (m *Manager) logPushForce(taskID, branch string, err error) {
 	} else {
 		m.logger.Warn("worktree.push-force", "task_id", taskID, "branch", branch, "err", err)
 	}
+}
+
+// worktreeBaseRef returns the git ref used as the starting point for new
+// worktree branches. "head" uses the local branch tip (picks up unpushed
+// commits); anything else (including "fresh" and the zero value) uses the
+// remote tracking ref so the worktree always starts from pushed state.
+func worktreeBaseRef(setting, branch string) string {
+	if setting == project.WorktreeBaseRefHead {
+		return "refs/heads/" + branch
+	}
+	return "refs/remotes/origin/" + branch
 }

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -681,6 +681,64 @@ func TestPrepareForTask_MergesRepoAndAppSetup(t *testing.T) {
 	}
 }
 
+// TestPrepareForTask_WorktreeBaseRefHead asserts that "head" mode branches from
+// the current remote state, not the stale clone-time commit. Before the fix,
+// refs/heads/<branch> in a bare clone was never updated after FetchOrigin, so
+// selecting "head" silently produced worktrees rooted at the original clone SHA.
+func TestPrepareForTask_WorktreeBaseRefHead(t *testing.T) {
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	h := prepareHarness(t, nil, 30*time.Second)
+
+	// Switch the project to head mode.
+	if _, err := h.store.SetWorktreeBaseRef(h.proj.ID, project.WorktreeBaseRefHead); err != nil {
+		t.Fatalf("SetWorktreeBaseRef: %v", err)
+	}
+
+	// Add a commit to the upstream src after the bare was cloned.
+	if err := os.WriteFile(filepath.Join(h.src, "upstream.txt"), []byte("upstream\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunInDir(t, h.src, "git", "add", "upstream.txt")
+	mustRunInDir(t, h.src, "git", "commit", "-m", "upstream progress")
+
+	// Capture the new upstream SHA.
+	rawSHA, err := exec.Command("git", "-C", h.src, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("rev-parse src HEAD: %v", err)
+	}
+	wantSHA := strings.TrimSpace(string(rawSHA))
+
+	tk, err := h.tasks.Store().Create("head-mode task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.tasks.Update(tk.ID, task.Update{ProjectID: task.Ptr(h.proj.ID)}); err != nil {
+		t.Fatal(err)
+	}
+	tk, err = h.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wtPath, err := h.m.PrepareForTask(tk, nil)
+	if err != nil {
+		t.Fatalf("PrepareForTask: %v", err)
+	}
+
+	// The upstream commit must be an ancestor of the worktree HEAD — confirming
+	// that SyncLocalBranch carried the new commit into refs/heads/main before
+	// the worktree branch was created.
+	out, err := exec.Command("git", "-C", wtPath, "merge-base", wantSHA, "HEAD").Output()
+	if err != nil {
+		t.Fatalf("merge-base: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != wantSHA {
+		t.Errorf("worktree does not contain upstream commit %s; merge-base=%s", wantSHA, got)
+	}
+}
+
 func mustRunInDir(t *testing.T, dir, name string, args ...string) {
 	t.Helper()
 	cmd := exec.Command(name, args...)


### PR DESCRIPTION
## Motivation

Worktrees always branched from `origin/<default>` (pushed remote state). This made it impossible to test local-only commits in an agent worktree without pushing first. Issue #689 requested a per-project setting to control the branch base.

Closes https://github.com/Automaat/sybra/issues/689

## Implementation information

- Added `WorktreeBaseRef` field (`fresh`|`head`) to the `Project` struct; default `fresh` keeps existing behaviour — no migration needed.
- `store.SetWorktreeBaseRef` validates and persists the setting.
- `worktree.Manager` uses the setting when creating new branches:
  - `fresh` → `refs/remotes/origin/<default>` (previous behaviour)
  - `head`  → `refs/heads/<default>` (picks up unpushed local commits)
- `project.SyncLocalBranch` fast-forwards `refs/heads/<branch>` to its remote tracking ref after each `FetchOrigin`, so `head` mode always reflects the current remote state rather than the stale clone-time commit. The fast-forward is skipped when the local branch is ahead of or diverged from origin, preserving local-only commits.
- `SyncLocalBranch` is called in `PrepareForTask` and `PrepareForChat` after `DefaultBranch`.
- `ProjectService.SetProjectWorktreeBaseRef` is a Wails-bound method with shim entries in `api.ts` and `api-http.ts`.
- Setup tab UI: inline select that saves on change.
- `TestPrepareForTask_WorktreeBaseRefHead` covers the key regression: upstream advances after clone, head mode must produce a worktree at the new commit.