### PR TITLE
feat(ui): populate model picker via codex debug models

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/index.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/index.ts
@@ -32,6 +32,7 @@ export {
 
 export {
     AppSettings,
+    CodexModel,
     LoggingSettings,
     LoopAgentRun,
     MonitorReportBinding,

--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/infoservice.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/infoservice.ts
@@ -15,13 +15,26 @@ import { Call as $Call, CancellablePromise as $CancellablePromise, Create as $Cr
 import * as $models from "./models.js";
 
 /**
+ * GetCodexModels runs `codex debug models` once per session and returns the
+ * parsed model catalog. Returns an empty slice when codex is unavailable or
+ * the output cannot be parsed — callers should fall back to a built-in list.
+ */
+export function GetCodexModels(): $CancellablePromise<$models.CodexModel[]> {
+    return $Call.ByID(2281056322).then(($result: any) => {
+        return $$createType1($result);
+    });
+}
+
+/**
  * GetVersion returns version information for the running server binary.
  */
 export function GetVersion(): $CancellablePromise<$models.VersionInfo> {
     return $Call.ByID(2557760771).then(($result: any) => {
-        return $$createType0($result);
+        return $$createType2($result);
     });
 }
 
 // Private type creation functions
-const $$createType0 = $models.VersionInfo.createFrom;
+const $$createType0 = $models.CodexModel.createFrom;
+const $$createType1 = $Create.Array($$createType0);
+const $$createType2 = $models.VersionInfo.createFrom;

--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/models.ts
@@ -108,6 +108,34 @@ export class AppSettings {
 }
 
 /**
+ * CodexModel is a single entry from `codex debug models`.
+ */
+export class CodexModel {
+    "slug": string;
+    "display_name": string;
+
+    /** Creates a new CodexModel instance. */
+    constructor($$source: Partial<CodexModel> = {}) {
+        if (!("slug" in $$source)) {
+            this["slug"] = "";
+        }
+        if (!("display_name" in $$source)) {
+            this["display_name"] = "";
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new CodexModel instance from a string or object.
+     */
+    static createFrom($$source: any = {}): CodexModel {
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        return new CodexModel($$parsedSource as Partial<CodexModel>);
+    }
+}
+
+/**
  * LoggingSettings holds the editable subset of LoggingConfig (Dir is read-only).
  */
 export class LoggingSettings {

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -6,7 +6,7 @@ import type { ReviewComment, Task } from '../../bindings/github.com/Automaat/syb
 import type { Project, Worktree } from '../../bindings/github.com/Automaat/sybra/internal/project/models.js'
 import type { Issue, RenovatePR, ReviewSummary } from '../../bindings/github.com/Automaat/sybra/internal/github/models.js'
 import type { LoopAgent } from '../../bindings/github.com/Automaat/sybra/internal/loopagent/models.js'
-import type { AppSettings, LoopAgentRun, MonitorReportBinding, VersionInfo } from '../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
+import type { AppSettings, CodexModel, LoopAgentRun, MonitorReportBinding, VersionInfo } from '../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
 import type { Notification } from '../../bindings/github.com/Automaat/sybra/internal/notification/models.js'
 import type { StatsResponse } from '../../bindings/github.com/Automaat/sybra/internal/stats/models.js'
 import type { Definition } from '../../bindings/github.com/Automaat/sybra/internal/workflow/models.js'
@@ -55,6 +55,7 @@ export function GetSettings(): Promise<AppSettings> { return call('ConfigService
 export function UpdateSettings(arg1: AppSettings): Promise<void> { return call('ConfigService', 'UpdateSettings', arg1) }
 
 // InfoService
+export function GetCodexModels(): Promise<CodexModel[]> { return call('InfoService', 'GetCodexModels') }
 export function GetVersion(): Promise<VersionInfo> { return call('InfoService', 'GetVersion') }
 
 // IntegrationService

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -62,6 +62,7 @@ export const GetSettings = pick(ConfigSvc.GetSettings, http.GetSettings)
 export const UpdateSettings = pick(ConfigSvc.UpdateSettings, http.UpdateSettings)
 
 // InfoService
+export const GetCodexModels = pick(InfoSvc.GetCodexModels, http.GetCodexModels)
 export const GetVersion = pick(InfoSvc.GetVersion, http.GetVersion)
 
 // IntegrationService

--- a/frontend/src/pages/Settings.svelte
+++ b/frontend/src/pages/Settings.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { GetSettings, UpdateSettings, GetVersion } from '$lib/api'
+  import { GetSettings, UpdateSettings, GetVersion, GetCodexModels } from '$lib/api'
   import type { AppSettings } from '../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
   import {
     GetProviderHealth,
@@ -41,12 +41,29 @@
   let serverVersion = $state<string | null>(null)
   const clientVersion = String(import.meta.env.VITE_APP_VERSION || 'dev')
 
+  type ModelOption = { value: string; label: string }
+  const codexFallbackModels: ModelOption[] = [
+    { value: '', label: 'Default (gpt-5.4)' },
+    { value: 'gpt-5.4', label: 'GPT-5.4' },
+    { value: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
+    { value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' },
+  ]
+  let codexDynamicModels = $state<ModelOption[]>([])
+
   $effect(() => {
     load()
   })
 
   onMount(() => {
     GetVersion().then(v => { serverVersion = v.server }).catch(() => { serverVersion = 'unavailable' })
+    GetCodexModels().then(models => {
+      if (models && models.length > 0) {
+        codexDynamicModels = [
+          { value: '', label: `Default (${models[0].slug})` },
+          ...models.map(m => ({ value: m.slug, label: m.display_name })),
+        ]
+      }
+    }).catch(() => {})
   })
 
   async function load() {
@@ -149,12 +166,7 @@
   const modelOptions = $derived.by(() => {
     if (!settings) return []
     if (settings.agent.provider === 'codex') {
-      return [
-        { value: '', label: 'Default (gpt-5.4)' },
-        { value: 'gpt-5.4', label: 'GPT-5.4' },
-        { value: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
-        { value: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' },
-      ]
+      return codexDynamicModels.length > 0 ? codexDynamicModels : codexFallbackModels
     }
     return [
       { value: '', label: 'Default (Sonnet)' },

--- a/frontend/src/pages/Settings.svelte
+++ b/frontend/src/pages/Settings.svelte
@@ -59,7 +59,7 @@
     GetCodexModels().then(models => {
       if (models && models.length > 0) {
         codexDynamicModels = [
-          { value: '', label: `Default (${models[0].slug})` },
+          { value: '', label: codexFallbackModels[0].label },
           ...models.map(m => ({ value: m.slug, label: m.display_name })),
         ]
       }

--- a/frontend/src/pages/Settings.svelte.test.ts
+++ b/frontend/src/pages/Settings.svelte.test.ts
@@ -4,6 +4,7 @@ import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
 const mockGetSettings = vi.fn()
 const mockUpdateSettings = vi.fn()
 const mockGetVersion = vi.fn()
+const mockGetCodexModels = vi.fn()
 const mockProviderHealthEnabled = vi.fn()
 const mockGetProviderHealth = vi.fn()
 const mockSetProviderAutoFailover = vi.fn()
@@ -14,6 +15,7 @@ vi.mock('$lib/api', () => ({
   GetSettings: (...args: unknown[]) => mockGetSettings(...args),
   UpdateSettings: (...args: unknown[]) => mockUpdateSettings(...args),
   GetVersion: (...args: unknown[]) => mockGetVersion(...args),
+  GetCodexModels: (...args: unknown[]) => mockGetCodexModels(...args),
   EventsOn: (...args: any[]) => mockEventsOn(...args),
 }))
 
@@ -51,6 +53,7 @@ describe('Settings', () => {
     mockGetSettings.mockReset()
     mockUpdateSettings.mockReset()
     mockGetVersion.mockResolvedValue({ server: 'v1.0.0', client: 'v1.0.0' })
+    mockGetCodexModels.mockResolvedValue([])
     mockProviderHealthEnabled.mockResolvedValue(false)
     mockGetProviderHealth.mockResolvedValue([])
     mockEventsOn.mockReturnValue(vi.fn())

--- a/internal/sybra/svc_info.go
+++ b/internal/sybra/svc_info.go
@@ -1,16 +1,55 @@
 package sybra
 
-import "github.com/Automaat/sybra/internal/version"
+import (
+	"encoding/json"
+	"os/exec"
+	"sync"
+
+	"github.com/Automaat/sybra/internal/version"
+)
 
 // VersionInfo holds version strings for the server and client.
 type VersionInfo struct {
 	Server string `json:"server"`
 }
 
+// CodexModel is a single entry from `codex debug models`.
+type CodexModel struct {
+	Slug        string `json:"slug"`
+	DisplayName string `json:"display_name"`
+}
+
 // InfoService exposes build metadata to the frontend.
-type InfoService struct{}
+type InfoService struct {
+	once        sync.Once
+	codexModels []CodexModel
+}
 
 // GetVersion returns version information for the running server binary.
 func (s *InfoService) GetVersion() VersionInfo {
 	return VersionInfo{Server: version.Version}
+}
+
+// GetCodexModels runs `codex debug models` once per session and returns the
+// parsed model catalog. Returns an empty slice when codex is unavailable or
+// the output cannot be parsed — callers should fall back to a built-in list.
+func (s *InfoService) GetCodexModels() []CodexModel {
+	s.once.Do(func() {
+		s.codexModels = fetchCodexModels()
+	})
+	return s.codexModels
+}
+
+func fetchCodexModels() []CodexModel {
+	out, err := exec.Command("codex", "debug", "models").Output()
+	if err != nil {
+		return nil
+	}
+	var payload struct {
+		Models []CodexModel `json:"models"`
+	}
+	if err := json.Unmarshal(out, &payload); err != nil {
+		return nil
+	}
+	return payload.Models
 }


### PR DESCRIPTION
## Motivation

Model picker in the UI was static/hardcoded, giving users no visibility into which Codex models are actually available. This surfaced as issue #705.

## Implementation information

- Added `GetCodexModels` backend binding that queries the Codex debug endpoint for available models
- Frontend model picker now fetches and displays live model list on mount
- Fixed default label to show correctly when no model is selected
- Added `GetCodexModels` mock for test environments to avoid real network calls

Closes https://github.com/Automaat/sybra/issues/705