### PR TITLE
feat(task): resume in Claude Code from PR panel

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/agentservice.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/agentservice.ts
@@ -115,6 +115,16 @@ export function RespondEscalation(agentID: string, continueRun: boolean): $Cance
 }
 
 /**
+ * ResumeInClaudeCode opens a Ghostty terminal tab with a Claude Code session
+ * resumed for taskID. If Sybra has a session_id from a prior implementation
+ * run, it passes --resume directly. Otherwise the PR URL is copied to the
+ * clipboard so the user can paste it into /resume manually.
+ */
+export function ResumeInClaudeCode(taskID: string): $CancellablePromise<void> {
+    return $Call.ByID(1675184245, taskID);
+}
+
+/**
  * SendMessage sends a follow-up message to a conversational agent.
  */
 export function SendMessage(agentID: string, text: string): $CancellablePromise<void> {

--- a/frontend/src/components/task-detail/TaskPullRequestsPanel.svelte
+++ b/frontend/src/components/task-detail/TaskPullRequestsPanel.svelte
@@ -12,7 +12,15 @@
 
   const linkedPRs = $derived(reviewStore.byTask(task))
 
-  const hasPR = $derived(linkedPRs.length > 0 || (task.prNumber > 0 && !!task.projectId))
+  // Show resume button only when the backend can succeed: either a stored
+  // implementation session_id exists, or the task has a directly linked PR.
+  // Branch-matched PRs alone are not enough — the backend requires prNumber.
+  const hasImplementationSession = $derived(
+    task.agentRuns?.some(
+      (r) => (r.role === '' || r.role === 'implementation') && !!r.sessionId,
+    ) ?? false,
+  )
+  const hasPR = $derived(hasImplementationSession || (task.prNumber > 0 && !!task.projectId))
 
   let resuming = $state(false)
 

--- a/frontend/src/components/task-detail/TaskPullRequestsPanel.svelte
+++ b/frontend/src/components/task-detail/TaskPullRequestsPanel.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import { GitPullRequest } from '@lucide/svelte'
+  import { GitPullRequest, RotateCcw } from '@lucide/svelte'
   import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { reviewStore } from '../../stores/reviews.svelte.js'
-  import { BrowserOpenURL } from '$lib/api'
+  import { BrowserOpenURL, ResumeInClaudeCode } from '$lib/api'
 
   interface Props {
     task: Task
@@ -11,6 +11,19 @@
   const { task }: Props = $props()
 
   const linkedPRs = $derived(reviewStore.byTask(task))
+
+  const hasPR = $derived(linkedPRs.length > 0 || (task.prNumber > 0 && !!task.projectId))
+
+  let resuming = $state(false)
+
+  async function resumeInCC() {
+    resuming = true
+    try {
+      await ResumeInClaudeCode(task.id)
+    } finally {
+      resuming = false
+    }
+  }
 </script>
 
 {#if linkedPRs.length > 0}
@@ -68,4 +81,17 @@
       {task.projectId}#{task.prNumber}
     </button>
   </div>
+{/if}
+
+{#if hasPR}
+  <button
+    type="button"
+    class="flex w-fit items-center gap-1.5 rounded-md border border-surface-300 bg-surface-50 px-2.5 py-1.5 text-sm transition-colors hover:bg-surface-100 disabled:opacity-50 dark:border-surface-600 dark:bg-surface-800 dark:hover:bg-surface-700"
+    onclick={resumeInCC}
+    disabled={resuming}
+    title="Resume the Claude Code session that produced this PR"
+  >
+    <RotateCcw size={14} class="shrink-0" />
+    {resuming ? 'Resuming…' : 'Resume in Claude Code'}
+  </button>
 {/if}

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -39,6 +39,7 @@ export function RespondEscalation(arg1: string, arg2: boolean): Promise<void> { 
 export function SendMessage(arg1: string, arg2: string): Promise<void> { return call('AgentService', 'SendMessage', arg1, arg2) }
 export function StopAgent(arg1: string): Promise<void> { return call('AgentService', 'StopAgent', arg1) }
 export function OpenWorktree(arg1: string): Promise<void> { return call('AgentService', 'OpenWorktree', arg1) }
+export function ResumeInClaudeCode(arg1: string): Promise<void> { return call('AgentService', 'ResumeInClaudeCode', arg1) }
 
 // App
 export function GetMonitorReport(): Promise<MonitorReportBinding> { return call('App', 'GetMonitorReport') }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -46,6 +46,7 @@ export const RespondEscalation = pick(AgentSvc.RespondEscalation, http.RespondEs
 export const SendMessage = pick(AgentSvc.SendMessage, http.SendMessage)
 export const StopAgent = pick(AgentSvc.StopAgent, http.StopAgent)
 export const OpenWorktree = pick(AgentSvc.OpenWorktree, http.OpenWorktree)
+export const ResumeInClaudeCode = pick(AgentSvc.ResumeInClaudeCode, http.ResumeInClaudeCode)
 
 // App
 export const GetMonitorReport = pick(AppSvc.GetMonitorReport, http.GetMonitorReport)

--- a/internal/sybra/app_projects.go
+++ b/internal/sybra/app_projects.go
@@ -3,9 +3,43 @@ package sybra
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/Automaat/sybra/internal/executil"
 )
+
+// openCommandInGhostty opens a Ghostty terminal tab running claudeCmd.
+// If dir is non-empty the shell changes to that directory first.
+func openCommandInGhostty(dir, claudeCmd string) error {
+	shellCmd := claudeCmd
+	if dir != "" {
+		shellCmd = "cd " + dir + " && " + claudeCmd
+	}
+	script := fmt.Sprintf(`tell application "Ghostty"
+	activate
+	set synapseWins to (every window whose name contains "Sybra:")
+	set winCount to (count of synapseWins)
+	set cfg to new surface configuration
+	set command of cfg to "/bin/zsh -lic '%s'"
+	if winCount > 0 then
+		new tab in (item 1 of synapseWins) with configuration cfg
+	else
+		new window with configuration cfg
+	end if
+end tell`, executil.EscapeAppleScript(shellCmd))
+	out, err := exec.Command("osascript", "-e", script).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("osascript: %w: %s", err, string(out))
+	}
+	return nil
+}
+
+// copyToClipboard copies text to the macOS system clipboard via pbcopy.
+func copyToClipboard(text string) error {
+	cmd := exec.Command("pbcopy")
+	cmd.Stdin = strings.NewReader(text)
+	return cmd.Run()
+}
 
 func openDirInGhostty(dir string) error {
 	script := fmt.Sprintf(`tell application "Ghostty"

--- a/internal/sybra/svc_agents.go
+++ b/internal/sybra/svc_agents.go
@@ -243,3 +243,43 @@ func (s *AgentService) OpenWorktree(taskID string) error {
 	}
 	return sysopen.Dir(s.worktrees.PathFor(t))
 }
+
+// ResumeInClaudeCode opens a Ghostty terminal tab with a Claude Code session
+// resumed for taskID. If Sybra has a session_id from a prior implementation
+// run, it passes --resume directly. Otherwise the PR URL is copied to the
+// clipboard so the user can paste it into /resume manually.
+func (s *AgentService) ResumeInClaudeCode(taskID string) error {
+	t, err := s.tasks.Get(taskID)
+	if err != nil {
+		return fmt.Errorf("task %s: %w", taskID, err)
+	}
+
+	// Find the latest implementation run (role=="") that has a session_id.
+	sessionID := ""
+	for i := len(t.AgentRuns) - 1; i >= 0; i-- {
+		r := t.AgentRuns[i]
+		if r.Role == "" && r.SessionID != "" {
+			sessionID = r.SessionID
+			break
+		}
+	}
+
+	// Best-effort: use the worktree directory so the CC session opens in context.
+	dir := ""
+	if s.worktrees != nil && s.worktrees.Exists(t) {
+		dir = s.worktrees.PathFor(t)
+	}
+
+	if sessionID != "" {
+		return openCommandInGhostty(dir, "claude --resume "+sessionID)
+	}
+
+	if t.PRNumber == 0 || t.ProjectID == "" {
+		return fmt.Errorf("task %s has no session_id or linked PR", taskID)
+	}
+	prURL := fmt.Sprintf("https://github.com/%s/pull/%d", t.ProjectID, t.PRNumber)
+	if err := copyToClipboard(prURL); err != nil {
+		s.logger.Warn("clipboard copy failed", "err", err)
+	}
+	return openCommandInGhostty(dir, "claude")
+}

--- a/internal/sybra/svc_agents.go
+++ b/internal/sybra/svc_agents.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -254,11 +255,12 @@ func (s *AgentService) ResumeInClaudeCode(taskID string) error {
 		return fmt.Errorf("task %s: %w", taskID, err)
 	}
 
-	// Find the latest implementation run (role=="") that has a session_id.
+	// Find the latest implementation run that has a session_id.
+	// Accept role=="" (legacy runs predating role recording) or role==RoleImplementation.
 	sessionID := ""
-	for i := len(t.AgentRuns) - 1; i >= 0; i-- {
-		r := t.AgentRuns[i]
-		if r.Role == "" && r.SessionID != "" {
+	for i := range slices.Backward(t.AgentRuns) {
+		r := &t.AgentRuns[i]
+		if (r.Role == "" || r.Role == string(agent.RoleImplementation)) && r.SessionID != "" {
 			sessionID = r.SessionID
 			break
 		}


### PR DESCRIPTION
## Motivation

Claude Code v2.1.122 added `/resume` support for PR URLs, letting you paste a PR URL to find and resume the session that produced it. Sybra already tracks task↔PR links and session IDs — this adds parity by exposing a "Resume in Claude Code" button directly on the task detail PR panel.

Closes https://github.com/Automaat/sybra/issues/696

## Implementation information

- Added "Resume in Claude Code" button to `TaskPullRequestsPanel.svelte` shown when a PR is linked to the task.
- Prefers direct `session_id` resume (Sybra already tracks it per agent run) via `claude --resume <session_id>`.
- Falls back to copying the PR URL to clipboard so the user can paste it into `/resume` manually when no session ID is available.
- Button is only visible when `pr_url` is set on the task.