### PR TITLE
feat(headless): enable CLAUDE_CODE_FORK_SUBAGENT per-task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,8 @@ claude -p "prompt" --output-format stream-json [--resume <id>] [--allowedTools "
 - StreamEvent types: `init`, `assistant`, `tool_use`, `tool_result`, `result`
 - Empty `allowed_tools` → `--dangerously-skip-permissions`
 
+**Fork subagents** (`fork_subagent: true`): sets `CLAUDE_CODE_FORK_SUBAGENT=1` in the subprocess environment (CC v2.1.121+, claude provider only). Allows a single prompt to spawn parallel subagent runs, reducing wall-clock time for multi-part work. Tradeoff: each forked subagent incurs its own token usage — total cost multiplies with parallelism. Enable per-task from the metadata panel or task creation dialog. Not propagated to interactive or codex agents.
+
 **Interactive** (tmux):
 ```bash
 tmux new-session -d -s sybra-<id> -x 200 -y 50 "claude"

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -189,6 +189,12 @@ export class Task {
      * nil = use system default (true). false = opt out (--dangerously-skip-permissions).
      */
     "requirePermissions"?: boolean | null;
+
+    /**
+     * ForkSubagent enables CLAUDE_CODE_FORK_SUBAGENT=1 for this task's headless
+     * agent, allowing a single prompt to spawn parallel subagent runs.
+     */
+    "forkSubagent"?: boolean;
     "agentRuns": AgentRun[];
     "workflow": workflow$0.Execution | null;
     "createdAt": time$0.Time;

--- a/frontend/src/components/CreateTaskDialog.svelte
+++ b/frontend/src/components/CreateTaskDialog.svelte
@@ -79,7 +79,7 @@
       const updates: Record<string, unknown> = {}
       if (taskType !== 'normal') updates.task_type = taskType
       if (selectedProject) updates.project_id = selectedProject
-      if (forkSubagent) updates.fork_subagent = true
+      if (forkSubagent && effectiveMode === 'headless') updates.fork_subagent = true
       if (Object.keys(updates).length > 0) {
         t = await taskStore.update(t.id, updates)
       }

--- a/frontend/src/components/CreateTaskDialog.svelte
+++ b/frontend/src/components/CreateTaskDialog.svelte
@@ -15,6 +15,7 @@
   let title = $state('')
   let body = $state('')
   let headless = $state(false)
+  let forkSubagent = $state(false)
   let taskType = $state('normal')
   let selectedProject = $state('')
   let projectSearch = $state('')
@@ -50,6 +51,7 @@
     title = ''
     body = ''
     headless = false
+    forkSubagent = false
     taskType = 'normal'
     selectedProject = ''
     projectSearch = ''
@@ -77,6 +79,7 @@
       const updates: Record<string, unknown> = {}
       if (taskType !== 'normal') updates.task_type = taskType
       if (selectedProject) updates.project_id = selectedProject
+      if (forkSubagent) updates.fork_subagent = true
       if (Object.keys(updates).length > 0) {
         t = await taskStore.update(t.id, updates)
       }
@@ -189,6 +192,17 @@
             />
             <span class="text-sm font-medium">Headless</span>
           </label>
+          {#if headless}
+            <label class="flex items-center gap-2">
+              <input
+                type="checkbox"
+                bind:checked={forkSubagent}
+                class="rounded border-surface-300 dark:border-surface-600"
+              />
+              <span class="text-sm font-medium">Fork subagents</span>
+              <span class="text-xs text-surface-400">(parallel, higher token cost)</span>
+            </label>
+          {/if}
         {/if}
 
         <label class="flex flex-col gap-1">

--- a/frontend/src/components/task-detail/TaskMetadataRow.svelte
+++ b/frontend/src/components/task-detail/TaskMetadataRow.svelte
@@ -295,6 +295,7 @@
     </div>
   {/if}
 
+  {#if task.agentMode === 'headless'}
   <div class="flex flex-col gap-1">
     <span class="font-medium text-surface-500">Fork Subagents</span>
     <button
@@ -316,6 +317,7 @@
       {/if}
     </button>
   </div>
+  {/if}
 
   <div class="flex flex-col gap-1">
     <span class="font-medium text-surface-500">Max Turns</span>

--- a/frontend/src/components/task-detail/TaskMetadataRow.svelte
+++ b/frontend/src/components/task-detail/TaskMetadataRow.svelte
@@ -296,6 +296,28 @@
   {/if}
 
   <div class="flex flex-col gap-1">
+    <span class="font-medium text-surface-500">Fork Subagents</span>
+    <button
+      type="button"
+      class="w-fit rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-200 hover:text-surface-700 dark:hover:bg-surface-700 dark:hover:text-surface-300"
+      onclick={async () => {
+        try {
+          await taskStore.update(task.id, { fork_subagent: !task.forkSubagent })
+        } catch (e) {
+          error = String(e)
+        }
+      }}
+      title="Enable CLAUDE_CODE_FORK_SUBAGENT=1 — parallel subagents, higher token cost"
+    >
+      {#if task.forkSubagent}
+        <span class="text-primary-600 dark:text-primary-400">enabled</span>
+      {:else}
+        <span class="italic text-surface-400">disabled</span>
+      {/if}
+    </button>
+  </div>
+
+  <div class="flex flex-col gap-1">
     <span class="font-medium text-surface-500">Max Turns</span>
     {#if editingMaxTurns}
       <input

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -433,6 +433,10 @@ type RunConfig struct {
 	// subprocess (claude exposes no equivalent CLI flag). Zero means "use
 	// the manager's default".
 	BashTimeoutMs int
+	// ForkSubagent, when true, sets CLAUDE_CODE_FORK_SUBAGENT=1 in the claude
+	// subprocess environment (claude provider only). Enables parallel subagent
+	// spawning from a single prompt at the cost of higher token usage.
+	ForkSubagent bool
 }
 
 // PlanStep represents a single item from a TodoWrite tool call.

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -538,6 +538,9 @@ func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args, env []
 			"BASH_MAX_TIMEOUT_MS="+ms,
 		)
 	}
+	if cfg.ForkSubagent {
+		env = append(env, "CLAUDE_CODE_FORK_SUBAGENT=1")
+	}
 	command = "claude " + strings.Join(args, " ")
 	return
 }

--- a/internal/sybra/app_agents.go
+++ b/internal/sybra/app_agents.go
@@ -180,6 +180,7 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, oneShot bool
 		ResumeSessionID:    resumeSessionID,
 		ExtraEnv:           extraEnv,
 		MaxTurns:           t.MaxTurns,
+		ForkSubagent:       t.ForkSubagent,
 	})
 	if err != nil {
 		// Gate block leaves no running agent. Flip the task back to todo so

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -175,7 +175,11 @@ type Task struct {
 	MaxTurns int `yaml:"max_turns,omitempty" json:"maxTurns,omitempty"`
 	// RequirePermissions overrides the system default when set.
 	// nil = use system default (true). false = opt out (--dangerously-skip-permissions).
-	RequirePermissions *bool               `yaml:"require_permissions,omitempty" json:"requirePermissions,omitempty"`
+	RequirePermissions *bool `yaml:"require_permissions,omitempty" json:"requirePermissions,omitempty"`
+	// ForkSubagent enables CLAUDE_CODE_FORK_SUBAGENT=1 for this task's headless
+	// agent, allowing a single prompt to spawn parallel subagent runs. Trades
+	// higher token cost for reduced wall-clock time on multi-part prompts.
+	ForkSubagent bool `yaml:"fork_subagent,omitempty" json:"forkSubagent,omitempty"`
 	AgentRuns          []AgentRun          `yaml:"agent_runs,omitempty" json:"agentRuns"`
 	Workflow           *workflow.Execution `yaml:"workflow,omitempty" json:"workflow"`
 	CreatedAt          time.Time           `yaml:"created_at" json:"createdAt"`

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -341,6 +341,9 @@ func (s *Store) Update(id string, u Update) (Task, error) {
 	if u.MaxTurns != nil {
 		t.MaxTurns = *u.MaxTurns
 	}
+	if u.ForkSubagent != nil {
+		t.ForkSubagent = *u.ForkSubagent
+	}
 	if err := s.writeSidecars(id, u, &t); err != nil {
 		return Task{}, err
 	}

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -35,6 +35,7 @@ type Update struct {
 	PlanCritique   *string
 	CodeReview     *string
 	MaxTurns       *int
+	ForkSubagent   *bool
 }
 
 // Ptr returns a pointer to v. Convenience for building Update literals.
@@ -76,6 +77,12 @@ func applyMapField(u *Update, k string, v any) error {
 		return applyPRNumberField(u, k, v)
 	case "max_turns":
 		return applyMaxTurnsField(u, v)
+	case "fork_subagent":
+		b, ok := v.(bool)
+		if !ok {
+			return fmt.Errorf("field %q: want bool, got %T", k, v)
+		}
+		u.ForkSubagent = &b
 	case "due_date":
 		return applyDueDateField(u, v)
 	case "reviewed":


### PR DESCRIPTION
## Motivation

CC v2.1.121 enabled `CLAUDE_CODE_FORK_SUBAGENT=1` in non-interactive (`claude -p`) sessions, allowing a single Sybra task to spawn parallel subagent runs from one prompt. Without this toggle, users cannot take advantage of the parallelism.

## Implementation information

- Added `ForkSubagent bool` field to the task model with YAML frontmatter support
- When enabled, headless runner sets `CLAUDE_CODE_FORK_SUBAGENT=1` in the subprocess environment
- Guarded the env var injection behind a headless-mode check so interactive/codex agents are unaffected
- Toggle exposed in task creation dialog and metadata panel
- CLAUDE.md updated with tradeoff note (parallelism vs token cost multiplication)

Closes https://github.com/Automaat/sybra/issues/691