### PR TITLE
ci(actions): fix screenshots PR lookup

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -108,8 +108,14 @@ jobs:
           git commit -m "chore(screenshots): sync from sybra@${SYBRA_SHA}"
           git push --force-with-lease origin "$BRANCH"
 
-          if gh pr view "$BRANCH" --repo Automaat/sybra-website >/dev/null 2>&1; then
-            gh pr edit "$BRANCH" \
+          PR_URL=$(gh pr list \
+            --repo Automaat/sybra-website \
+            --head "$BRANCH" \
+            --state open \
+            --json url \
+            --jq '.[0].url // ""')
+          if [ -n "$PR_URL" ]; then
+            gh pr edit "$PR_URL" \
               --repo Automaat/sybra-website \
               --title "chore(screenshots): sync from sybra@${SYBRA_SHA}" \
               --body "Automated screenshot sync from automaat/sybra@${SYBRA_SHA}."


### PR DESCRIPTION
## Motivation

Screenshots workflow on main fails when the `screenshots/sync` PR already exists in `Automaat/sybra-website`. `gh pr view "screenshots/sync" --repo ...` does not reliably resolve a branch with a slash, so the script falls into the `else` branch and `gh pr create` errors out with: `a pull request for branch "screenshots/sync" into branch "main" already exists`.

## Implementation information

Replace the `gh pr view` existence probe with `gh pr list --head "$BRANCH" --state open --json url --jq '.[0].url // ""'`, which is the documented way to look up a PR by head branch in another repo. Pass the resulting URL to `gh pr edit`.

## Supporting documentation

Failing run: https://github.com/Automaat/sybra/actions/runs/25625840547