### PR TITLE
fix(agent): make task context opt-in

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/app.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/app.ts
@@ -96,8 +96,8 @@ export function Shutdown(): $CancellablePromise<void> {
  * User-triggered starts are never one-shot — that flag is reserved for workflow
  * steps that expect a single turn.
  */
-export function StartAgent(taskID: string, mode: string, prompt: string): $CancellablePromise<agent$0.Agent | null> {
-    return $Call.ByID(2345014098, taskID, mode, prompt).then(($result: any) => {
+export function StartAgent(taskID: string, mode: string, prompt: string, includeTaskDescription: boolean): $CancellablePromise<agent$0.Agent | null> {
+    return $Call.ByID(2345014098, taskID, mode, prompt, includeTaskDescription).then(($result: any) => {
         return $$createType7($result);
     });
 }

--- a/frontend/src/components/task-detail/AgentLauncher.svelte
+++ b/frontend/src/components/task-detail/AgentLauncher.svelte
@@ -19,6 +19,7 @@
   let runningAgent = $state<Agent | null>(null)
   let prompt = $state('')
   let agentMode = $state('interactive')
+  let includeTaskDescription = $state(false)
   let starting = $state(false)
   let error = $state('')
   let modeInit = false
@@ -52,7 +53,7 @@
     starting = true
     error = ''
     try {
-      runningAgent = await agentStore.start(task.id, agentMode, prompt.trim())
+      runningAgent = await agentStore.start(task.id, agentMode, prompt.trim(), includeTaskDescription)
       prompt = ''
     } catch (e) {
       error = String(e)
@@ -131,6 +132,15 @@
           class="rounded border-surface-300 dark:border-surface-600"
         />
         <span class="text-sm">Headless</span>
+      </label>
+      <label class="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={includeTaskDescription}
+          onchange={(e) => { includeTaskDescription = e.currentTarget.checked }}
+          class="rounded border-surface-300 dark:border-surface-600"
+        />
+        <span class="text-sm">Include task description</span>
       </label>
     </div>
     <textarea

--- a/frontend/src/components/task-detail/AgentLauncher.svelte.test.ts
+++ b/frontend/src/components/task-detail/AgentLauncher.svelte.test.ts
@@ -80,7 +80,20 @@ describe('AgentLauncher', () => {
     await fireEvent.input(ta, { target: { value: 'do the thing' } })
     await fireEvent.click(screen.getByText('Start agent'))
     await waitFor(() => {
-      expect(mockStart).toHaveBeenCalledWith('t1', 'headless', 'do the thing')
+      expect(mockStart).toHaveBeenCalledWith('t1', 'headless', 'do the thing', false)
+    })
+  })
+
+  it('includes task description when opted in', async () => {
+    mockStart.mockResolvedValue({ id: 'a1', state: 'running', mode: 'headless' })
+    render(AgentLauncher, { props: { task: baseTask as never, onviewagent: vi.fn() } })
+    const ta = screen.getByPlaceholderText('Enter prompt for the agent...') as HTMLTextAreaElement
+    await fireEvent.input(ta, { target: { value: 'do the thing' } })
+    const include = screen.getByLabelText('Include task description') as HTMLInputElement
+    await fireEvent.click(include)
+    await fireEvent.click(screen.getByText('Start agent'))
+    await waitFor(() => {
+      expect(mockStart).toHaveBeenCalledWith('t1', 'headless', 'do the thing', true)
     })
   })
 

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -47,7 +47,7 @@ export function ListBackgroundOps(): Promise<Array<any>> { return call('App', 'L
 export function ListNotifications(): Promise<Array<Notification>> { return call('App', 'ListNotifications') }
 export function RegisterSpotlightHotkey(): Promise<void> { return call('App', 'RegisterSpotlightHotkey') }
 export function SetDesktopNotifications(arg1: boolean): Promise<void> { return call('App', 'SetDesktopNotifications', arg1) }
-export function StartAgent(arg1: string, arg2: string, arg3: string): Promise<Agent> { return call('App', 'StartAgent', arg1, arg2, arg3) }
+export function StartAgent(arg1: string, arg2: string, arg3: string, arg4: boolean): Promise<Agent> { return call('App', 'StartAgent', arg1, arg2, arg3, arg4) }
 export function StartChat(arg1: string, arg2: string, arg3: string): Promise<Agent> { return call('App', 'StartChat', arg1, arg2, arg3) }
 export function StopChat(arg1: string): Promise<void> { return call('App', 'StopChat', arg1) }
 

--- a/frontend/src/stores/agents.svelte.test.ts
+++ b/frontend/src/stores/agents.svelte.test.ts
@@ -99,9 +99,9 @@ describe('AgentStore', () => {
       const agent = makeAgent({ id: 'new-1' })
       mockStartAgent.mockResolvedValue(agent)
 
-      const result = await agentStore.start('task-1', 'headless', 'do stuff')
+      const result = await agentStore.start('task-1', 'headless', 'do stuff', false)
 
-      expect(mockStartAgent).toHaveBeenCalledWith('task-1', 'headless', 'do stuff')
+      expect(mockStartAgent).toHaveBeenCalledWith('task-1', 'headless', 'do stuff', false)
       expect(result.id).toBe('new-1')
       expect(agentStore.agents.get('new-1')).toBeDefined()
       expect(agentStore.outputs.get('new-1')).toEqual([])

--- a/frontend/src/stores/agents.svelte.ts
+++ b/frontend/src/stores/agents.svelte.ts
@@ -47,8 +47,8 @@ class AgentStore extends EntityStore<Agent> {
     return this.list.filter((a) => a.state === state)
   }
 
-  async start(taskID: string, mode: string, prompt: string): Promise<Agent> {
-    const result = await StartAgent(taskID, mode, prompt)
+  async start(taskID: string, mode: string, prompt: string, includeTaskDescription: boolean): Promise<Agent> {
+    const result = await StartAgent(taskID, mode, prompt, includeTaskDescription)
     this.set(result.id, result)
     this.outputs.set(result.id, [])
     return result

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -21,7 +21,7 @@ import (
 // uses. Defined here so the package does not import internal/sybra (which
 // would form a cycle: sybra → recovery → sybra).
 type Orchestrator interface {
-	StartAgent(taskID, mode, prompt string, oneShot bool) (*agent.Agent, error)
+	StartAgent(taskID, mode, prompt string, includeTaskDescription, oneShot bool) (*agent.Agent, error)
 	StartPRFixAgent(taskID string) error
 }
 

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -125,7 +125,7 @@ type stubOrchestrator struct {
 	startReturned *agent.Agent
 }
 
-func (s *stubOrchestrator) StartAgent(_, _, _ string, _ bool) (*agent.Agent, error) {
+func (s *stubOrchestrator) StartAgent(_, _, _ string, _, _ bool) (*agent.Agent, error) {
 	s.startCalls++
 	return s.startReturned, s.startErr
 }

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -115,7 +115,7 @@ func (r *Recovery) RestartStaleInProgress() {
 			// Restart-stale only ever reaches this branch for headless
 			// mode (interactive tasks are handled by recoverStaleInteractive
 			// above), so OneShot is irrelevant — pass false.
-			_, err := r.Orchestrator.StartAgent(taskID, mode, prompt, false)
+			_, err := r.Orchestrator.StartAgent(taskID, mode, prompt, false, false)
 			metrics.OrchestratorStaleRestart(err == nil)
 			r.Throttle.Log(r.Logger, "restart-stale.failed", "stale:"+taskID, err, "task_id", taskID)
 			if err != nil {

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -301,8 +301,8 @@ func (a *App) Shutdown(_ context.Context) {
 // StartAgent delegates to AgentOrchestrator and is exposed as a Wails-bound method.
 // User-triggered starts are never one-shot — that flag is reserved for workflow
 // steps that expect a single turn.
-func (a *App) StartAgent(taskID, mode, prompt string) (*agent.Agent, error) {
-	return a.agentOrch.StartAgent(taskID, mode, prompt, false)
+func (a *App) StartAgent(taskID, mode, prompt string, includeTaskDescription bool) (*agent.Agent, error) {
+	return a.agentOrch.StartAgent(taskID, mode, prompt, includeTaskDescription, false)
 }
 
 // StartChat creates a new interactive chat bound to projectID using the

--- a/internal/sybra/app_agents.go
+++ b/internal/sybra/app_agents.go
@@ -115,7 +115,7 @@ func newAgentOrchestrator(
 	}
 }
 
-func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, oneShot bool) (*agent.Agent, error) {
+func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, includeTaskDescription, oneShot bool) (*agent.Agent, error) {
 	t, err := o.tasks.Get(taskID)
 	if err != nil {
 		return nil, err
@@ -166,7 +166,7 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, oneShot bool
 		}
 	}
 
-	fullPrompt := fmt.Sprintf("# Task: %s\n\n%s\n\n---\n\n%s", t.Title, t.Body, prompt)
+	fullPrompt := buildTaskStartPrompt(t, prompt, includeTaskDescription)
 	ag, err := o.agents.Run(agent.RunConfig{
 		TaskID:             taskID,
 		Name:               t.Title,
@@ -215,6 +215,18 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, oneShot bool
 		o.logger.Error("task.add-run", "task_id", taskID, "err", err)
 	}
 	return ag, nil
+}
+
+func buildTaskStartPrompt(t task.Task, prompt string, includeTaskDescription bool) string {
+	prompt = strings.TrimSpace(prompt)
+	if !includeTaskDescription {
+		return prompt
+	}
+	base := fmt.Sprintf("# Task: %s\n\n%s", t.Title, t.Body)
+	if prompt == "" {
+		return base
+	}
+	return base + "\n\n---\n\n" + prompt
 }
 
 // StartChat creates a synthetic chat task bound to projectID, prepares a

--- a/internal/sybra/app_agents_test.go
+++ b/internal/sybra/app_agents_test.go
@@ -1,6 +1,7 @@
 package sybra
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -155,5 +156,27 @@ func TestPickImplementationResumeSession(t *testing.T) {
 				t.Errorf("pickImplementationResumeSession() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestBuildTaskStartPrompt(t *testing.T) {
+	t.Parallel()
+
+	taskData := task.Task{Title: "My task", Body: "Task body"}
+
+	got := buildTaskStartPrompt(taskData, "do the thing", false)
+	if got != "do the thing" {
+		t.Fatalf("buildTaskStartPrompt(include=false) = %q, want %q", got, "do the thing")
+	}
+
+	got = buildTaskStartPrompt(taskData, "do the thing", true)
+	want := "# Task: My task\n\nTask body\n\n---\n\ndo the thing"
+	if got != want {
+		t.Fatalf("buildTaskStartPrompt(include=true) = %q, want %q", got, want)
+	}
+
+	got = buildTaskStartPrompt(taskData, "   \n\t", true)
+	if !strings.Contains(got, "# Task: My task") {
+		t.Fatalf("buildTaskStartPrompt(include=true, empty prompt) = %q, want task context", got)
 	}
 }

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -275,7 +275,7 @@ func TestStartAgentRejectsMissingProject(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = a.StartAgent(created.ID, "headless", "test prompt")
+	_, err = a.StartAgent(created.ID, "headless", "test prompt", false)
 	if err == nil {
 		t.Fatal("expected error: task without project_id must be rejected")
 	}
@@ -286,7 +286,7 @@ func TestStartAgentRejectsMissingProject(t *testing.T) {
 
 func TestStartAgentTaskNotFound(t *testing.T) {
 	a := setupApp(t)
-	_, err := a.StartAgent("nonexistent", "headless", "prompt")
+	_, err := a.StartAgent("nonexistent", "headless", "prompt", false)
 	if err == nil {
 		t.Fatal("expected error for nonexistent task")
 	}

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -176,7 +176,7 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 	// PrepareForFix) bypasses the orchestrator's worktree path and uses the
 	// caller-provided dir directly.
 	if (role == "" || role == string(agent.RoleImplementation)) && dir == "" {
-		ag, err := a.agentOrch.StartAgent(taskID, mode, prompt, oneShot)
+		ag, err := a.agentOrch.StartAgent(taskID, mode, prompt, false, oneShot)
 		if err != nil {
 			return "", err
 		}

--- a/internal/sybra/e2e_bootstrap_test.go
+++ b/internal/sybra/e2e_bootstrap_test.go
@@ -200,7 +200,7 @@ func TestE2E_BootstrapRunsBeforeAgent_MergedRepoAndApp(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ag, err := env.agentOrch.StartAgent(tk.ID, "headless", "any prompt", false)
+	ag, err := env.agentOrch.StartAgent(tk.ID, "headless", "any prompt", false, false)
 	if err != nil {
 		t.Fatalf("StartAgent: %v", err)
 	}
@@ -274,7 +274,7 @@ func TestE2E_BootstrapFailure_AbortsAgentStart(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ag, err := env.agentOrch.StartAgent(tk.ID, "headless", "any prompt", false)
+	ag, err := env.agentOrch.StartAgent(tk.ID, "headless", "any prompt", false, false)
 	if err == nil {
 		t.Fatalf("expected StartAgent to fail, got agent %s", ag.ID)
 	}

--- a/internal/sybra/orchestrator_resume_test.go
+++ b/internal/sybra/orchestrator_resume_test.go
@@ -172,7 +172,7 @@ updated_at: 2025-01-01T00:00:00Z
 		t.Fatal(err)
 	}
 
-	if _, err := orch.StartAgent(created.ID, "interactive", "Implement the feature.", true); err != nil {
+	if _, err := orch.StartAgent(created.ID, "interactive", "Implement the feature.", false, true); err != nil {
 		t.Fatalf("orchestrator StartAgent: %v", err)
 	}
 


### PR DESCRIPTION
## Motivation

Task title/body were injected into every manual agent start by default. Make that explicit opt-in.

## Implementation information

Added an include-task-description flag through the agent start path, defaulting it off in the task launcher UI. Updated the backend prompt builder, recovery calls, generated frontend bindings, and tests.

> Changelog: fix(agent): make task context opt-in

## Supporting documentation

- `go test ./...`
- `npm test -- src/components/task-detail/AgentLauncher.svelte.test.ts src/stores/agents.svelte.test.ts`