### PR TITLE
fix(worktree): keep pr fixes on branch

### DIFF
--- a/internal/sybra/svc_reviews_test.go
+++ b/internal/sybra/svc_reviews_test.go
@@ -207,6 +207,15 @@ func TestReviewService_StartFixReview_HappyPath(t *testing.T) {
 		t.Fatalf("StartFixReview: %v", err)
 	}
 
+	wtPath := filepath.Join(os.Getenv("SYBRA_HOME"), "worktrees", tk.DirName())
+	branchOut, err := exec.Command("git", "-C", wtPath, "branch", "--show-current").Output()
+	if err != nil {
+		t.Fatalf("show current branch: %v", err)
+	}
+	if branch := strings.TrimSpace(string(branchOut)); branch == "" {
+		t.Fatalf("fix-review worktree is detached HEAD")
+	}
+
 	waitFor(t, 5*time.Second, "fake-claude args log written", func() bool {
 		_, err := os.Stat(argsLog)
 		return err == nil

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -359,7 +359,11 @@ func (m *Manager) PrepareForFix(t task.Task, prNumber int) (string, error) {
 	}
 
 	ref := "refs/remotes/origin/" + branch
-	if err := project.CreateWorktreeExisting(proj.ClonePath, wtPath, ref); err != nil {
+	if project.BranchExists(proj.ClonePath, branch) {
+		if err := project.CreateWorktreeExisting(proj.ClonePath, wtPath, branch); err != nil {
+			return "", fmt.Errorf("checkout fix branch %s: %w", branch, err)
+		}
+	} else if err := project.CreateWorktree(proj.ClonePath, wtPath, branch, ref); err != nil {
 		return "", fmt.Errorf("create fix worktree: %w", err)
 	}
 	if err := project.SanitizeWorktree(wtPath); err != nil {


### PR DESCRIPTION
## Motivation

Fix-review agents committed review fixes on detached HEAD worktrees, so successful commits were not attached to a pushable branch.

> Changelog: fix(worktree): keep pr fixes on branch

## Implementation information

Create or reuse a local PR branch for fix-review worktrees instead of checking out the remote tracking ref directly. Add an e2e assertion that StartFixReview leaves the worktree on a branch.

## Supporting documentation

Task 18f5bdc6 exposed this: agent committed d66d8d4ec9 locally but no branch contained it.