### PR TITLE
feat(review): automate PR review cleanup

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -621,6 +621,7 @@ export enum StepType {
     StepCondition = "condition",
     StepShell = "shell",
     StepEnsurePRClosesIssue = "ensure_pr_closes_issue",
+    StepRerequestReview = "rerequest_review",
     StepVerifyCommits = "verify_commits",
     StepLinkPRAndReview = "link_pr_and_review",
     StepEvaluate = "evaluate",

--- a/frontend/src/components/workflow/StepConfigPanel.svelte
+++ b/frontend/src/components/workflow/StepConfigPanel.svelte
@@ -147,6 +147,14 @@
         <option value="set_status">Set Status</option>
         <option value="condition">Condition</option>
         <option value="shell">Shell</option>
+        <option value="ensure_pr_closes_issue">Ensure PR Closes Issue</option>
+        <option value="rerequest_review">Re-request Review</option>
+        <option value="verify_commits">Verify Commits</option>
+        <option value="link_pr_and_review">Link PR and Review</option>
+        <option value="evaluate">Evaluate</option>
+        <option value="require_sidecar">Require Sidecar</option>
+        <option value="validate_plan">Validate Plan</option>
+        <option value="triage_review">Triage Review</option>
         <option value="parallel">Parallel</option>
       </select>
     </label>

--- a/internal/github/monitor.go
+++ b/internal/github/monitor.go
@@ -1,5 +1,7 @@
 package github
 
+import "strconv"
+
 // PRIssueKind identifies what's wrong with a PR.
 type PRIssueKind string
 
@@ -36,14 +38,22 @@ type ClosedPR struct {
 // It skips tasks whose PR still appears in openPRs.
 func DetectClosedTaskPRs(openPRs []PullRequest, tasks []TaskMatcher, fetchState func(repo string, number int) (PRState, error)) []ClosedPR {
 	openByNumber := make(map[int]struct{}, len(openPRs))
+	openByRepoNumber := make(map[string]struct{}, len(openPRs))
 	for i := range openPRs {
-		openByNumber[openPRs[i].Number] = struct{}{}
+		if openPRs[i].Repository == "" {
+			openByNumber[openPRs[i].Number] = struct{}{}
+			continue
+		}
+		openByRepoNumber[prRepoNumberKey(openPRs[i].Repository, openPRs[i].Number)] = struct{}{}
 	}
 
 	var closed []ClosedPR
 	for i := range tasks {
 		t := &tasks[i]
 		if t.PRNumber == 0 || t.ProjectID == "" {
+			continue
+		}
+		if _, isOpen := openByRepoNumber[prRepoNumberKey(t.ProjectID, t.PRNumber)]; isOpen {
 			continue
 		}
 		if _, isOpen := openByNumber[t.PRNumber]; isOpen {
@@ -58,6 +68,10 @@ func DetectClosedTaskPRs(openPRs []PullRequest, tasks []TaskMatcher, fetchState 
 		}
 	}
 	return closed
+}
+
+func prRepoNumberKey(repo string, number int) string {
+	return repo + "#" + strconv.Itoa(number)
 }
 
 // MatchTaskPRs finds issues on PRs that are linked to tasks.

--- a/internal/github/monitor_test.go
+++ b/internal/github/monitor_test.go
@@ -169,10 +169,17 @@ func TestDetectClosedTaskPRs(t *testing.T) {
 		},
 		{
 			name:    "PR still open – skipped",
-			openPRs: []PullRequest{{Number: 42}},
+			openPRs: []PullRequest{{Number: 42, Repository: "o/r"}},
 			tasks:   []TaskMatcher{{ID: "t1", PRNumber: 42, ProjectID: "o/r"}},
 			states:  map[int]PRState{42: open},
 			want:    nil,
+		},
+		{
+			name:    "same PR number in another repo does not mask closed task PR",
+			openPRs: []PullRequest{{Number: 42, Repository: "other/repo"}},
+			tasks:   []TaskMatcher{{ID: "t1", PRNumber: 42, ProjectID: "o/r"}},
+			states:  map[int]PRState{42: closed},
+			want:    []ClosedPR{{TaskID: "t1", PRNumber: 42, State: "CLOSED"}},
 		},
 		{
 			name:    "PR merged → done",

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -76,6 +76,7 @@ type PRBranch struct {
 type PRContext struct {
 	URL      string
 	Branch   string
+	Author   string
 	Comments []PRReviewComment
 }
 
@@ -276,14 +277,17 @@ func fetchPRContextWith(e execer, repo string, number int) (PRContext, error) {
 
 	// Fetch PR metadata: url, branch, and review bodies
 	out, err := e.run("pr", "view", fmt.Sprintf("%d", number),
-		"--repo", repo, "--json", "url,headRefName,reviews")
+		"--repo", repo, "--json", "url,headRefName,author,reviews")
 	if err != nil {
 		return PRContext{}, fmt.Errorf("gh pr view %d context: %s: %w", number, strings.TrimSpace(string(out)), err)
 	}
 	var meta struct {
 		URL         string `json:"url"`
 		HeadRefName string `json:"headRefName"`
-		Reviews     []struct {
+		Author      struct {
+			Login string `json:"login"`
+		} `json:"author"`
+		Reviews []struct {
 			Author struct {
 				Login string `json:"login"`
 			} `json:"author"`
@@ -295,7 +299,7 @@ func fetchPRContextWith(e execer, repo string, number int) (PRContext, error) {
 		return PRContext{}, fmt.Errorf("parse pr context: %w", err)
 	}
 
-	ctx := PRContext{URL: meta.URL, Branch: meta.HeadRefName}
+	ctx := PRContext{URL: meta.URL, Branch: meta.HeadRefName, Author: meta.Author.Login}
 
 	// Include only CHANGES_REQUESTED review bodies.
 	for _, r := range meta.Reviews {
@@ -460,6 +464,38 @@ func editPRBodyWith(e execer, repo string, number int, body string) error {
 		"--repo", repo, "--body", body)
 	if err != nil {
 		return fmt.Errorf("gh pr edit %d: %s: %w", number, strings.TrimSpace(string(out)), err)
+	}
+	if runtimeCacheEnabled(e) {
+		invalidatePRCaches(repo, number)
+	}
+	return nil
+}
+
+// RequestReviewers requests a review from the given GitHub user logins.
+func RequestReviewers(repo string, number int, reviewers []string) error {
+	return requestReviewersWith(defaultExecer, repo, number, reviewers)
+}
+
+func requestReviewersWith(e execer, repo string, number int, reviewers []string) error {
+	if len(reviewers) == 0 {
+		return nil
+	}
+	args := []string{
+		"--method", "POST",
+		fmt.Sprintf("repos/%s/pulls/%d/requested_reviewers", repo, number),
+	}
+	for _, reviewer := range reviewers {
+		if strings.TrimSpace(reviewer) == "" {
+			continue
+		}
+		args = append(args, "-f", "reviewers[]="+reviewer)
+	}
+	if len(args) == 3 {
+		return nil
+	}
+	resp, err := runGHAPIWith(e, "", args...)
+	if err != nil {
+		return fmt.Errorf("gh request reviewers %d: %s: %w", number, sanitizeGHOutput(resp.body), err)
 	}
 	if runtimeCacheEnabled(e) {
 		invalidatePRCaches(repo, number)

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -342,6 +342,78 @@ func TestEditPRBodyWith_execError(t *testing.T) {
 	}
 }
 
+func TestRequestReviewersWith_passesArgs(t *testing.T) {
+	t.Parallel()
+	fe := &recordingExecer{output: []byte("HTTP/2.0 201 Created\n\n{}")}
+	if err := requestReviewersWith(fe, "owner/repo", 42, []string{"alice", "bob"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{
+		"api", "--include", "--method", "POST",
+		"repos/owner/repo/pulls/42/requested_reviewers",
+		"-f", "reviewers[]=alice",
+		"-f", "reviewers[]=bob",
+	}
+	if len(fe.lastArgs) != len(want) {
+		t.Fatalf("args = %v, want %v", fe.lastArgs, want)
+	}
+	for i, a := range fe.lastArgs {
+		if a != want[i] {
+			t.Errorf("arg[%d] = %q, want %q", i, a, want[i])
+		}
+	}
+}
+
+func TestRequestReviewersWith_emptySkips(t *testing.T) {
+	t.Parallel()
+	fe := &recordingExecer{}
+	if err := requestReviewersWith(fe, "owner/repo", 42, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fe.calls != 0 {
+		t.Fatalf("calls = %d, want 0", fe.calls)
+	}
+}
+
+func TestRequestReviewersWith_execError(t *testing.T) {
+	t.Parallel()
+	fe := &fakeExecer{output: []byte("HTTP/2.0 422 Unprocessable Entity\n\nreviewer is not a collaborator"), err: fmt.Errorf("exit 1")}
+	if err := requestReviewersWith(fe, "owner/repo", 42, []string{"alice"}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestFetchPRContextWith_includesAuthorAndCommentAuthors(t *testing.T) {
+	t.Parallel()
+	fe := &scriptedExecer{results: []scriptedResult{
+		{output: []byte(`{
+			"url":"https://github.com/owner/repo/pull/42",
+			"headRefName":"feature/x",
+			"author":{"login":"author"},
+			"reviews":[
+				{"author":{"login":"alice"},"body":"top level","state":"CHANGES_REQUESTED"},
+				{"author":{"login":"ignored"},"body":"approved","state":"APPROVED"}
+			]
+		}`)},
+		{output: []byte("HTTP/2.0 200 OK\n\n" +
+			"{\"author\":\"bob\",\"body\":\"inline\",\"path\":\"main.go\"}\n")},
+	}}
+
+	got, err := fetchPRContextWith(fe, "owner/repo", 42)
+	if err != nil {
+		t.Fatalf("fetchPRContextWith: %v", err)
+	}
+	if got.Author != "author" {
+		t.Errorf("Author = %q, want author", got.Author)
+	}
+	if len(got.Comments) != 2 {
+		t.Fatalf("comments len = %d, want 2: %+v", len(got.Comments), got.Comments)
+	}
+	if got.Comments[0].Author != "alice" || got.Comments[1].Author != "bob" {
+		t.Fatalf("comment authors = %+v, want alice,bob", got.Comments)
+	}
+}
+
 func TestMergePRWith(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -234,6 +234,7 @@ func (a *App) initWorkflowEngine() {
 		a.logger,
 	)
 	a.workflowEngine.SetPRLinker(prLinkerAdapter{})
+	a.workflowEngine.SetPRReviewRequester(prReviewRequesterAdapter{})
 	a.workflowEngine.SetWorktreeGetter(&worktreeGetterAdapter{tasks: a.tasks, mgr: a.worktrees})
 	a.workflowEngine.SetContext(a.ctx)
 	// SetOnComplete moves to wireServices so the callback closure binds

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
@@ -274,6 +275,29 @@ func (r *ReviewHandler) detectPublishedReviews(tasks []task.Task) {
 	}
 }
 
+func reviewClosedPREligible(t *task.Task) bool {
+	return t.TaskType != task.TaskTypeChat &&
+		!task.IsTerminalStatus(t.Status) &&
+		slices.Contains(t.Tags, "review") &&
+		t.ProjectID != "" &&
+		t.PRNumber != 0
+}
+
+func reviewTaskMatchers(tasks []task.Task) []github.TaskMatcher {
+	matchers := make([]github.TaskMatcher, 0, len(tasks))
+	for i := range tasks {
+		if !reviewClosedPREligible(&tasks[i]) {
+			continue
+		}
+		matchers = append(matchers, github.TaskMatcher{
+			ID:        tasks[i].ID,
+			PRNumber:  tasks[i].PRNumber,
+			ProjectID: tasks[i].ProjectID,
+		})
+	}
+	return matchers
+}
+
 // prMonitorEligible decides whether the PR monitor should consider a task
 // when scanning for CI failures, conflicts, and ready-to-merge state.
 //
@@ -405,11 +429,40 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 
 	r.maybeCreateReviewTasks(tasks, summary.ReviewRequested)
 	r.detectPublishedReviews(tasks)
+	r.closeFinishedReviewTasks(tasks, summary.ReviewRequested)
 
 	if prNeedsAttention(monitoredPRs) {
 		return prPollFast
 	}
 	return prPollSlow
+}
+
+func (r *ReviewHandler) closeFinishedReviewTasks(tasks []task.Task, openReviewPRs []github.PullRequest) {
+	matchers := reviewTaskMatchers(tasks)
+	if len(matchers) == 0 {
+		return
+	}
+	closedPRs := github.DetectClosedTaskPRs(openReviewPRs, matchers, github.FetchPRState)
+	for _, c := range closedPRs {
+		if r.agents.HasRunningAgentForTask(c.TaskID) {
+			r.logger.Info("review.closed-skip-running-agent", "task_id", c.TaskID, "pr", c.PRNumber)
+			continue
+		}
+		reason := fmt.Sprintf("review PR %s", strings.ToLower(c.State))
+		if _, err := r.tasks.Update(c.TaskID, task.Update{
+			Status:       task.Ptr(task.StatusDone),
+			StatusReason: &reason,
+		}); err != nil {
+			r.logger.Error("review.closed-update", "task_id", c.TaskID, "err", err)
+			continue
+		}
+		eventType := audit.EventPRMerged
+		if c.State == "CLOSED" {
+			eventType = audit.EventPRClosed
+		}
+		r.logAudit(eventType, c.TaskID, "", map[string]any{"pr": c.PRNumber, "state": c.State, "review_task": true})
+		r.logger.Info("review.auto-done", "task_id", c.TaskID, "pr", c.PRNumber, "state", c.State)
+	}
 }
 
 // monitoredPRs returns the union of user-authored PRs (from FetchReviews) and

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -80,6 +80,98 @@ func TestPRMonitorEligible(t *testing.T) {
 	}
 }
 
+func TestReviewClosedPREligible(t *testing.T) {
+	tests := []struct {
+		name string
+		tk   task.Task
+		want bool
+	}{
+		{
+			name: "in-review review task with PR",
+			tk: task.Task{
+				Status:    task.StatusInReview,
+				Tags:      []string{"review"},
+				ProjectID: "o/r",
+				PRNumber:  42,
+			},
+			want: true,
+		},
+		{
+			name: "human-required review task with PR",
+			tk: task.Task{
+				Status:    task.StatusHumanRequired,
+				Tags:      []string{"review"},
+				ProjectID: "o/r",
+				PRNumber:  42,
+			},
+			want: true,
+		},
+		{
+			name: "done review task skipped",
+			tk: task.Task{
+				Status:    task.StatusDone,
+				Tags:      []string{"review"},
+				ProjectID: "o/r",
+				PRNumber:  42,
+			},
+			want: false,
+		},
+		{
+			name: "non-review task skipped",
+			tk: task.Task{
+				Status:    task.StatusInReview,
+				ProjectID: "o/r",
+				PRNumber:  42,
+			},
+			want: false,
+		},
+		{
+			name: "review task without PR skipped",
+			tk: task.Task{
+				Status:    task.StatusInReview,
+				Tags:      []string{"review"},
+				ProjectID: "o/r",
+			},
+			want: false,
+		},
+		{
+			name: "chat task skipped",
+			tk: task.Task{
+				Status:    task.StatusInReview,
+				TaskType:  task.TaskTypeChat,
+				Tags:      []string{"review"},
+				ProjectID: "o/r",
+				PRNumber:  42,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reviewClosedPREligible(&tt.tk); got != tt.want {
+				t.Errorf("reviewClosedPREligible(%+v) = %v, want %v", tt.tk, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReviewTaskMatchers(t *testing.T) {
+	tasks := []task.Task{
+		{ID: "review", Status: task.StatusInReview, Tags: []string{"review"}, ProjectID: "o/r", PRNumber: 42},
+		{ID: "done", Status: task.StatusDone, Tags: []string{"review"}, ProjectID: "o/r", PRNumber: 43},
+		{ID: "mine", Status: task.StatusInReview, ProjectID: "o/r", PRNumber: 44},
+	}
+
+	got := reviewTaskMatchers(tasks)
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1: %+v", len(got), got)
+	}
+	if got[0].ID != "review" || got[0].ProjectID != "o/r" || got[0].PRNumber != 42 {
+		t.Fatalf("matcher = %+v, want review o/r#42", got[0])
+	}
+}
+
 // TestMonitoredPRs covers the regression where Renovate-bot PRs linked to a
 // task by pr_number were silently skipped by the pr-monitor because
 // FetchReviews uses author:@me. monitoredPRs folds renovatePRsFn output into

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -18,10 +18,11 @@ import (
 
 // Compile-time interface checks.
 var (
-	_ workflow.TaskProvider   = (*taskAdapter)(nil)
-	_ workflow.AgentLauncher  = (*agentAdapter)(nil)
-	_ workflow.PRLinker       = (*prLinkerAdapter)(nil)
-	_ workflow.WorktreeGetter = (*worktreeGetterAdapter)(nil)
+	_ workflow.TaskProvider      = (*taskAdapter)(nil)
+	_ workflow.AgentLauncher     = (*agentAdapter)(nil)
+	_ workflow.PRLinker          = (*prLinkerAdapter)(nil)
+	_ workflow.PRReviewRequester = (*prReviewRequesterAdapter)(nil)
+	_ workflow.WorktreeGetter    = (*worktreeGetterAdapter)(nil)
 )
 
 // taskAdapter bridges task.Manager → workflow.TaskProvider.
@@ -141,6 +142,49 @@ func (prLinkerAdapter) GetClosingIssues(repo string, prNumber int) (issues []int
 
 func (prLinkerAdapter) EditBody(repo string, prNumber int, body string) error {
 	return github.EditPRBody(repo, prNumber, body)
+}
+
+// prReviewRequesterAdapter asks users who left actionable PR feedback to
+// review again after the fix-review workflow pushes updated commits.
+type prReviewRequesterAdapter struct{}
+
+func (prReviewRequesterAdapter) RerequestReview(repo string, prNumber int) ([]string, error) {
+	ctx, err := github.FetchPRContext(repo, prNumber)
+	if err != nil {
+		return nil, err
+	}
+	viewer := github.ViewerLogin()
+	seen := map[string]struct{}{}
+	reviewers := make([]string, 0, len(ctx.Comments))
+	for _, c := range ctx.Comments {
+		login := strings.TrimSpace(c.Author)
+		if !eligibleRerequestReviewer(login, viewer, ctx.Author) {
+			continue
+		}
+		key := strings.ToLower(login)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		reviewers = append(reviewers, login)
+	}
+	if len(reviewers) == 0 {
+		return nil, nil
+	}
+	if err := github.RequestReviewers(repo, prNumber, reviewers); err != nil {
+		return nil, err
+	}
+	return reviewers, nil
+}
+
+func eligibleRerequestReviewer(login, viewer, prAuthor string) bool {
+	if login == "" {
+		return false
+	}
+	if strings.EqualFold(login, viewer) || strings.EqualFold(login, prAuthor) {
+		return false
+	}
+	return !strings.HasSuffix(strings.ToLower(login), "[bot]")
 }
 
 // worktreeGetterAdapter bridges worktree.Manager + task.Manager → workflow.WorktreeGetter.

--- a/internal/sybra/app_workflow_test.go
+++ b/internal/sybra/app_workflow_test.go
@@ -1,0 +1,31 @@
+package sybra
+
+import "testing"
+
+func TestEligibleRerequestReviewer(t *testing.T) {
+	tests := []struct {
+		name     string
+		login    string
+		viewer   string
+		author   string
+		expected bool
+	}{
+		{name: "comment author", login: "alice", viewer: "me", author: "author", expected: true},
+		{name: "empty", login: "", viewer: "me", author: "author", expected: false},
+		{name: "viewer", login: "me", viewer: "me", author: "author", expected: false},
+		{name: "pr author", login: "author", viewer: "me", author: "author", expected: false},
+		{name: "bot", login: "renovate[bot]", viewer: "me", author: "author", expected: false},
+		{name: "case-insensitive viewer", login: "Me", viewer: "me", author: "author", expected: false},
+		{name: "case-insensitive author", login: "Author", viewer: "me", author: "author", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := eligibleRerequestReviewer(tt.login, tt.viewer, tt.author)
+			if got != tt.expected {
+				t.Fatalf("eligibleRerequestReviewer(%q, %q, %q) = %v, want %v",
+					tt.login, tt.viewer, tt.author, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -472,17 +472,39 @@ func TestE2E_HeadlessAgent_ArgsVerification(t *testing.T) {
 func TestE2E_HeadlessAgent_FailExit(t *testing.T) {
 	forEachProvider(t, func(t *testing.T, p providerSpec) {
 		env := setupE2EProvider(t, p.provider, "fail_exit")
+		writeWorkflowFixture(t, env, "test-fail-exit", `id: test-fail-exit
+name: Test Fail Exit
+steps:
+  - id: triage
+    name: Triage
+    type: run_agent
+    config:
+      role: triage
+      mode: headless
+      model: sonnet
+      max_retries: 0
+      prompt: "Triage {{.Task.ID}}"
+    next:
+      - goto: set_done
+  - id: set_done
+    name: Mark Done
+    type: set_status
+    config:
+      status: done
+    next:
+      - goto: ""
+`)
 
 		created, err := env.tasks.Create("test task", "", "headless")
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if err := env.startWorkflow(created.ID, "test-simple"); err != nil {
+		if err := env.startWorkflow(created.ID, "test-fail-exit"); err != nil {
 			t.Fatal(err)
 		}
 
-		waitFor(t, 30*time.Second, "workflow moves past triage retries", func() bool {
+		waitFor(t, 30*time.Second, "workflow moves past failed triage", func() bool {
 			tk, err := env.tasks.Get(created.ID)
 			if err != nil {
 				return false

--- a/internal/workflow/builtin/pr-fix.yaml
+++ b/internal/workflow/builtin/pr-fix.yaml
@@ -87,4 +87,12 @@ steps:
     name: Ensure PR Closes Issue
     type: ensure_pr_closes_issue
     next:
+      - goto: rerequest_review
+
+  # Mechanical check (no LLM): after a PR-fix agent has pushed updated commits,
+  # request another review from users whose comments/reviews were addressed.
+  - id: rerequest_review
+    name: Re-request Review
+    type: rerequest_review
+    next:
       - goto: ""

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -81,6 +81,12 @@ type PRLinker interface {
 	EditBody(repo string, prNumber int, body string) error
 }
 
+// PRReviewRequester re-requests review from prior PR commenters after a
+// workflow fixes review comments and pushes updated commits.
+type PRReviewRequester interface {
+	RerequestReview(repo string, prNumber int) (reviewers []string, err error)
+}
+
 // CompletionInfo is passed to the OnComplete callback when a workflow finishes.
 type CompletionInfo struct {
 	TaskID     string
@@ -100,6 +106,7 @@ type Engine struct {
 	tasks           TaskProvider
 	agents          AgentLauncher
 	prLinker        PRLinker
+	prReviewers     PRReviewRequester
 	worktrees       WorktreeGetter
 	onComplete      func(CompletionInfo)
 	logger          *slog.Logger
@@ -141,6 +148,9 @@ func (e *Engine) Defs() *Store { return e.store }
 // SetPRLinker wires an implementation of PRLinker used by the
 // `ensure_pr_closes_issue` step. Leaving it unset makes the step a no-op.
 func (e *Engine) SetPRLinker(l PRLinker) { e.prLinker = l }
+
+// SetPRReviewRequester wires an implementation used by rerequest_review.
+func (e *Engine) SetPRReviewRequester(r PRReviewRequester) { e.prReviewers = r }
 
 // SetWorktreeGetter wires a WorktreeGetter used by the `verify_commits` step.
 // Leaving it unset makes the step a no-op.

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -286,7 +286,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			return e.execParallel(taskID, step, wfExec, ctx)
 		case StepWaitHuman:
 			return e.execWaitHuman(taskID, step, wfExec)
-		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepTriageReview:
+		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepRerequestReview, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepTriageReview:
 			// handled below as sync steps
 		default:
 			return fmt.Errorf("unknown step type %q", step.Type)
@@ -350,6 +350,8 @@ func (e *Engine) execSyncStep(taskID string, step *Step, wfExec *Execution, ctx 
 		return e.execShell(step, ctx)
 	case StepEnsurePRClosesIssue:
 		return e.execEnsurePRClosesIssue(taskID, step, t)
+	case StepRerequestReview:
+		return e.execRerequestReview(taskID, step, t)
 	case StepVerifyCommits:
 		return e.execVerifyCommits(taskID, step, t)
 	case StepLinkPRAndReview:

--- a/internal/workflow/engine_steps.go
+++ b/internal/workflow/engine_steps.go
@@ -572,6 +572,27 @@ func (e *Engine) execEnsurePRClosesIssue(taskID string, step *Step, t TaskInfo) 
 	return StepOutput{StepID: step.ID, Status: "completed", Output: msg}, nil
 }
 
+func (e *Engine) execRerequestReview(taskID string, step *Step, t TaskInfo) (StepOutput, error) {
+	if e.prReviewers == nil {
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no pr review requester configured"}, nil
+	}
+	if t.PRNumber == 0 || t.ProjectID == "" {
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: missing pr or project"}, nil
+	}
+
+	reviewers, err := e.prReviewers.RerequestReview(t.ProjectID, t.PRNumber)
+	if err != nil {
+		e.logger.Warn("workflow.rerequest-review.failed", "task_id", taskID, "pr", t.PRNumber, "err", err)
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "request failed: " + err.Error()}, nil
+	}
+	if len(reviewers) == 0 {
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no eligible reviewers"}, nil
+	}
+	msg := "requested review from @" + strings.Join(reviewers, ", @")
+	e.logger.Info("workflow.rerequest-review.requested", "task_id", taskID, "pr", t.PRNumber, "reviewers", reviewers)
+	return StepOutput{StepID: step.ID, Status: "completed", Output: msg}, nil
+}
+
 // execVerifyCommits checks that the task's branch has at least one commit
 // ahead of origin/main. This is a non-LLM mechanical gate that runs before
 // the eval agent to detect incomplete work without giving eval git access.

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1787,6 +1787,99 @@ func newEnsurePRStep() *Step {
 	return &Step{ID: "ensure", Type: StepEnsurePRClosesIssue}
 }
 
+type fakePRReviewRequester struct {
+	reviewers []string
+	err       error
+	calls     int
+	repo      string
+	prNumber  int
+}
+
+func (f *fakePRReviewRequester) RerequestReview(repo string, prNumber int) ([]string, error) {
+	f.calls++
+	f.repo = repo
+	f.prNumber = prNumber
+	return f.reviewers, f.err
+}
+
+func newRerequestReviewStep() *Step {
+	return &Step{ID: "rerequest", Type: StepRerequestReview}
+}
+
+func TestExecRerequestReview_NoRequesterSkips(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	ti := TaskInfo{ID: "t1", ProjectID: "owner/repo", PRNumber: 5}
+	out, err := engine.execRerequestReview("t1", newRerequestReviewStep(), ti)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.Output, "no pr review requester") {
+		t.Errorf("Output = %q, want no requester skip", out.Output)
+	}
+}
+
+func TestExecRerequestReview_MissingFieldsSkip(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	requester := &fakePRReviewRequester{}
+	engine.SetPRReviewRequester(requester)
+
+	out, err := engine.execRerequestReview("t1", newRerequestReviewStep(), TaskInfo{ID: "t1", ProjectID: "owner/repo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requester.calls != 0 {
+		t.Fatalf("requester calls = %d, want 0", requester.calls)
+	}
+	if !strings.Contains(out.Output, "missing pr or project") {
+		t.Errorf("Output = %q, want missing fields skip", out.Output)
+	}
+}
+
+func TestExecRerequestReview_RequestsReviewers(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	requester := &fakePRReviewRequester{reviewers: []string{"alice", "bob"}}
+	engine.SetPRReviewRequester(requester)
+
+	ti := TaskInfo{ID: "t1", ProjectID: "owner/repo", PRNumber: 5}
+	out, err := engine.execRerequestReview("t1", newRerequestReviewStep(), ti)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requester.calls != 1 || requester.repo != "owner/repo" || requester.prNumber != 5 {
+		t.Fatalf("requester = calls:%d repo:%q pr:%d", requester.calls, requester.repo, requester.prNumber)
+	}
+	if !strings.Contains(out.Output, "@alice") || !strings.Contains(out.Output, "@bob") {
+		t.Errorf("Output = %q, want requested reviewers", out.Output)
+	}
+}
+
+func TestExecRerequestReview_ErrorIsNonFatal(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine.SetPRReviewRequester(&fakePRReviewRequester{err: fmt.Errorf("boom")})
+
+	ti := TaskInfo{ID: "t1", ProjectID: "owner/repo", PRNumber: 5}
+	out, err := engine.execRerequestReview("t1", newRerequestReviewStep(), ti)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" || !strings.Contains(out.Output, "request failed") {
+		t.Errorf("output = %+v, want completed failure note", out)
+	}
+}
+
 func TestExecEnsurePRClosesIssue_NoLinkerSkips(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -81,6 +81,7 @@ const (
 	StepCondition           StepType = "condition"
 	StepShell               StepType = "shell"
 	StepEnsurePRClosesIssue StepType = "ensure_pr_closes_issue"
+	StepRerequestReview     StepType = "rerequest_review"
 	StepVerifyCommits       StepType = "verify_commits"
 	StepLinkPRAndReview     StepType = "link_pr_and_review"
 	StepEvaluate            StepType = "evaluate"


### PR DESCRIPTION
## Motivation

Review tasks can stay open after the reviewed PR is closed or merged by its creator. PR-fix runs also need to notify the users whose comments were addressed after new commits are pushed.

> Changelog: feat(review): automate PR review cleanup

## Implementation information

Track non-terminal review tasks with linked PRs during the review poll. When a linked review PR disappears from open review requests, fetch its state and mark the task done if GitHub reports CLOSED or MERGED.

Add a mechanical rerequest_review workflow step after PR-fix commit verification and PR body cleanup. It gathers users who left actionable review feedback, filters out self, PR author, and bots, then requests another review through GitHub's review request API.

Also key open PR detection by repository and number so matching PR numbers in different repos do not hide a closed task PR.

## Supporting documentation

Task example: b58e92d6