### PR TITLE
fix(review): push fix-review branch

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -336,6 +336,15 @@ func PushUpstream(worktreePath, branch string) error {
 	return executil.Run(worktreePath, "git", "push", "-u", "origin", branch)
 }
 
+// CurrentBranch returns the checked-out branch name for a worktree.
+func CurrentBranch(worktreePath string) (string, error) {
+	branch, err := executil.Output(worktreePath, "git", "branch", "--show-current")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(branch), nil
+}
+
 // PushForce force-pushes the branch to origin using --force-with-lease.
 // Used after a local rebase to sync the remote without overwriting commits
 // from other authors (--force-with-lease fails if remote has unknown commits).

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -2,6 +2,7 @@ package sybra
 
 import (
 	"errors"
+	"os"
 	"os/exec"
 	"syscall"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/loopagent"
+	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/sandbox"
 	"github.com/Automaat/sybra/internal/stats"
 	"github.com/Automaat/sybra/internal/task"
@@ -145,6 +147,10 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 		return
 	}
 
+	if agent.RoleFromName(ag.Name) == agent.RoleFixReview && exitErr == nil {
+		h.pushFixReviewBranch(ag)
+	}
+
 	if h.workflowEngine != nil {
 		// Stall when (a) the kernel killed the process via signal (OS/container
 		// SIGTERM, SIGKILL escalation), or (b) Sybra's own StopAgent set the
@@ -178,6 +184,46 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 			go h.sandboxes.Stop(ag.TaskID)
 		}
 	}
+}
+
+func (h *AgentCompletionHandler) pushFixReviewBranch(ag *agent.Agent) {
+	if h.worktrees == nil || h.tasks == nil {
+		return
+	}
+
+	t, err := h.tasks.Get(ag.TaskID)
+	if err != nil {
+		h.logger.Warn("fix-review.push.task", "task_id", ag.TaskID, "agent_id", ag.ID, "err", err)
+		return
+	}
+	if t.ProjectID == "" {
+		return
+	}
+
+	wtPath := h.worktrees.PathFor(t)
+	if _, err := os.Stat(wtPath); err != nil {
+		h.logger.Warn("fix-review.push.worktree", "task_id", ag.TaskID, "agent_id", ag.ID, "path", wtPath, "err", err)
+		return
+	}
+
+	branch := t.Branch
+	if branch == "" {
+		branch, err = project.CurrentBranch(wtPath)
+		if err != nil {
+			h.logger.Warn("fix-review.push.branch", "task_id", ag.TaskID, "agent_id", ag.ID, "path", wtPath, "err", err)
+			return
+		}
+	}
+
+	if err := project.PushForce(wtPath, branch); err != nil {
+		if errors.Is(err, project.ErrBranchMissing) {
+			h.logger.Info("fix-review.push-skipped", "task_id", ag.TaskID, "agent_id", ag.ID, "branch", branch, "reason", "local branch ref missing")
+			return
+		}
+		h.logger.Warn("fix-review.push", "task_id", ag.TaskID, "agent_id", ag.ID, "branch", branch, "err", err)
+		return
+	}
+	h.logger.Info("fix-review.pushed", "task_id", ag.TaskID, "agent_id", ag.ID, "branch", branch)
 }
 
 // recordRunStats persists a stats.RunRecord for the completed agent.

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -144,7 +144,7 @@ func (r *ReviewHandler) startFixReviewAgent(t task.Task) error {
 		"Run /fix-review https://github.com/%s/pull/%d --auto\n\n"+
 			"IMPORTANT: when committing, use conventional commit format "+
 			"`fix(review): address PR review comments` (type(scope) required by repo hooks). "+
-			"Sign the commit with `git commit -s -S`.",
+			"Sign the commit with `git commit -s -S`. Push the branch when done.",
 		t.ProjectID, t.PRNumber,
 	)
 

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -4,13 +4,16 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 
 	"github.com/Automaat/sybra/internal/workflow"
@@ -165,6 +168,180 @@ func TestOnAgentComplete_EmptyTaskID_NoCrash(t *testing.T) {
 	}
 	if !otherStat.ModTime().Equal(otherStat2.ModTime()) {
 		t.Errorf("unrelated task file was rewritten: mtime %v -> %v", otherStat.ModTime(), otherStat2.ModTime())
+	}
+}
+
+func setupFixReviewPushTest(t *testing.T) (*AgentCompletionHandler, *task.Manager, string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	home, err := os.MkdirTemp("", "sybra-fix-review-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(home) })
+
+	tasksDir := filepath.Join(home, "tasks")
+	taskStore, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskMgr := task.NewManager(taskStore, nil)
+
+	projStore, err := project.NewStore(filepath.Join(home, "projects"), filepath.Join(home, "clones"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	src := initFixReviewSourceRepo(t)
+	barePath := filepath.Join(home, "clones", "testowner", "testrepo.git")
+	if err := os.MkdirAll(filepath.Dir(barePath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := project.CloneBare(src, barePath); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+
+	projYAML := `id: testowner/testrepo
+name: testrepo
+owner: testowner
+repo: testrepo
+url: ` + src + `
+clone_path: ` + barePath + `
+type: pet
+created_at: 2025-01-01T00:00:00Z
+updated_at: 2025-01-01T00:00:00Z
+`
+	projFile := filepath.Join(home, "projects", "testowner--testrepo.yaml")
+	if err := os.WriteFile(projFile, []byte(projYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := discardLogger()
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: filepath.Join(home, "worktrees"),
+		Projects:     projStore,
+		Tasks:        taskMgr,
+		Logger:       logger,
+		PRBranchResolver: func(repo string, prNumber int) (string, error) {
+			return project.DefaultBranch(barePath)
+		},
+	})
+
+	h := &AgentCompletionHandler{
+		DomainHandler: DomainHandler{logger: logger},
+		tasks:         taskMgr,
+		worktrees:     wm,
+	}
+	return h, taskMgr, barePath
+}
+
+func initFixReviewSourceRepo(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "src")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"init", dir},
+		{"-C", dir, "config", "user.email", "test@test.com"},
+		{"-C", dir, "config", "user.name", "Test"},
+		{"-C", dir, "config", "commit.gpgsign", "false"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"-C", dir, "add", "."},
+		{"-C", dir, "commit", "-m", "init"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	return dir
+}
+
+func TestOnAgentComplete_FixReviewPushesBranch(t *testing.T) {
+	h, taskMgr, barePath := setupFixReviewPushTest(t)
+	branch, err := project.DefaultBranch(barePath)
+	if err != nil {
+		t.Fatalf("default branch: %v", err)
+	}
+
+	tk, err := taskMgr.Create("fix pr", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, err := taskMgr.Update(tk.ID, task.Update{
+		ProjectID: task.Ptr("testowner/testrepo"),
+		PRNumber:  task.Ptr(42),
+		Status:    task.Ptr(task.StatusInReview),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tk = updated
+
+	wtPath, err := h.worktrees.PrepareForFix(tk, 42)
+	if err != nil {
+		t.Fatalf("PrepareForFix: %v", err)
+	}
+
+	for _, args := range [][]string{
+		{"-C", wtPath, "config", "user.email", "test@test.com"},
+		{"-C", wtPath, "config", "user.name", "Test"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), []byte("# updated\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"-C", wtPath, "add", "."},
+		{"-C", wtPath, "commit", "-m", "fix(review): update pr"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	localHead, err := exec.Command("git", "-C", wtPath, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("local head: %v", err)
+	}
+
+	if err := taskMgr.AddRun(tk.ID, task.AgentRun{
+		AgentID:   "agent-1",
+		Role:      string(agent.RoleFixReview),
+		Mode:      "headless",
+		State:     string(agent.StateRunning),
+		StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	h.OnComplete(&agent.Agent{
+		ID:        "agent-1",
+		TaskID:    tk.ID,
+		Mode:      "headless",
+		Name:      agent.RoleFixReview.AgentName(tk.Title),
+		StartedAt: time.Now(),
+	})
+
+	remoteHead, err := exec.Command("git", "-C", barePath, "rev-parse", "refs/heads/"+branch).Output()
+	if err != nil {
+		t.Fatalf("remote head: %v", err)
+	}
+	if got, want := strings.TrimSpace(string(remoteHead)), strings.TrimSpace(string(localHead)); got != want {
+		t.Fatalf("remote head = %s, want %s", got, want)
 	}
 }
 

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -369,6 +369,7 @@ func (m *Manager) PrepareForFix(t task.Task, prNumber int) (string, error) {
 	if err := project.SanitizeWorktree(wtPath); err != nil {
 		m.logger.Warn("fix.worktree.sanitize", "task_id", t.ID, "err", err)
 	}
+	m.ensureBranch(t, branch)
 	m.logger.Info("fix.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
 	if err := m.runSetup(t.ID, wtPath, m.resolveSetupCommands(wtPath, proj)); err != nil {
 		return "", fmt.Errorf("fix setup: %w", err)


### PR DESCRIPTION
## Motivation

fix-review agents were completing locally without updating the PR branch on GitHub, so review fixes stayed invisible upstream.

## Implementation information

- OnComplete now force-pushes the fix-review branch after a successful run.
- PrepareForFix persists the branch on the task and the worktree helper keeps that branch stable.
- Added regression coverage for fix-review push behavior.

> Changelog: fix(review): push fix-review branch