### PR TITLE
fix(desktop): bound Wails event emission

### DIFF
--- a/desktop_emitter.go
+++ b/desktop_emitter.go
@@ -1,0 +1,123 @@
+//go:build darwin
+
+package main
+
+import (
+	"context"
+	"log/slog"
+	"runtime"
+	"sync"
+	"time"
+)
+
+const (
+	desktopEmitQueueSize     = 128
+	desktopEmitInterval      = 50 * time.Millisecond
+	desktopEmitMaxGoroutines = 256
+)
+
+type desktopEvent struct {
+	name string
+	data any
+}
+
+type desktopEmitter struct {
+	emit          func(string, any)
+	logger        *slog.Logger
+	queue         chan desktopEvent
+	interval      time.Duration
+	maxGoroutines int
+
+	mu            sync.Mutex
+	pending       map[string]desktopEvent
+	dropped       int
+	lastDropLog   time.Time
+	lastPausedLog time.Time
+}
+
+func newDesktopEmitter(ctx context.Context, logger *slog.Logger, emit func(string, any)) *desktopEmitter {
+	e := &desktopEmitter{
+		emit:          emit,
+		logger:        logger,
+		queue:         make(chan desktopEvent, desktopEmitQueueSize),
+		interval:      desktopEmitInterval,
+		maxGoroutines: desktopEmitMaxGoroutines,
+		pending:       map[string]desktopEvent{},
+	}
+	go e.run(ctx)
+	return e
+}
+
+func (e *desktopEmitter) Emit(name string, data any) {
+	ev := desktopEvent{name: name, data: data}
+	select {
+	case e.queue <- ev:
+	default:
+		e.coalesce(ev)
+	}
+}
+
+func (e *desktopEmitter) run(ctx context.Context) {
+	ticker := time.NewTicker(e.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			e.flushOne()
+		}
+	}
+}
+
+func (e *desktopEmitter) flushOne() {
+	if runtime.NumGoroutine() > e.maxGoroutines {
+		e.logPaused()
+		return
+	}
+
+	select {
+	case ev := <-e.queue:
+		e.emit(ev.name, ev.data)
+		return
+	default:
+	}
+
+	if ev, ok := e.takePending(); ok {
+		e.emit(ev.name, ev.data)
+	}
+}
+
+func (e *desktopEmitter) coalesce(ev desktopEvent) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.pending[ev.name] = ev
+	e.dropped++
+	now := time.Now()
+	if now.Sub(e.lastDropLog) >= time.Minute {
+		e.logger.Warn("desktop.emit.coalescing", "dropped", e.dropped, "pending", len(e.pending))
+		e.lastDropLog = now
+		e.dropped = 0
+	}
+}
+
+func (e *desktopEmitter) takePending() (desktopEvent, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for name, ev := range e.pending {
+		delete(e.pending, name)
+		return ev, true
+	}
+	return desktopEvent{}, false
+}
+
+func (e *desktopEmitter) logPaused() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	now := time.Now()
+	if now.Sub(e.lastPausedLog) < time.Minute {
+		return
+	}
+	e.logger.Warn("desktop.emit.paused", "goroutines", runtime.NumGoroutine(), "limit", e.maxGoroutines, "queued", len(e.queue), "pending", len(e.pending))
+	e.lastPausedLog = now
+}

--- a/desktop_emitter_test.go
+++ b/desktop_emitter_test.go
@@ -1,0 +1,78 @@
+//go:build darwin
+
+package main
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestDesktopEmitterCoalescesWhenQueueFull(t *testing.T) {
+	var emitted []desktopEvent
+	e := &desktopEmitter{
+		emit: func(name string, data any) {
+			emitted = append(emitted, desktopEvent{name: name, data: data})
+		},
+		logger:        slog.Default(),
+		queue:         make(chan desktopEvent, 1),
+		interval:      time.Hour,
+		maxGoroutines: 1_000_000,
+		pending:       map[string]desktopEvent{},
+	}
+
+	e.Emit("agent:output:1", "first")
+	e.Emit("agent:output:1", "second")
+	e.Emit("task:updated", "task-a")
+
+	e.flushOne()
+	e.flushOne()
+	e.flushOne()
+
+	if len(emitted) != 3 {
+		t.Fatalf("expected 3 emitted events, got %d", len(emitted))
+	}
+	if emitted[0].data != "first" {
+		t.Fatalf("expected queued event to emit first, got %v", emitted[0].data)
+	}
+	if emitted[1].data != "second" && emitted[2].data != "second" {
+		t.Fatalf("expected latest coalesced agent output to emit, got %#v", emitted)
+	}
+}
+
+func TestDesktopEmitterPausesWhenGoroutineLimitExceeded(t *testing.T) {
+	called := false
+	e := &desktopEmitter{
+		emit: func(string, any) {
+			called = true
+		},
+		logger:        slog.Default(),
+		queue:         make(chan desktopEvent, 1),
+		interval:      time.Hour,
+		maxGoroutines: 0,
+		pending:       map[string]desktopEvent{},
+	}
+
+	e.Emit("task:updated", "task-a")
+	e.flushOne()
+
+	if called {
+		t.Fatal("expected emit to pause when goroutine limit is exceeded")
+	}
+	if got := len(e.queue); got != 1 {
+		t.Fatalf("expected queued event to remain queued, got %d", got)
+	}
+}
+
+func TestNewDesktopEmitterStopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	e := newDesktopEmitter(ctx, slog.Default(), func(string, any) {})
+	cancel()
+
+	select {
+	case e.queue <- desktopEvent{name: "task:updated"}:
+	case <-time.After(time.Second):
+		t.Fatal("emitter queue blocked after context cancel")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -83,9 +83,10 @@ func run() error {
 		},
 	})
 
-	v3emit = func(event string, data any) {
+	desktopEvents := newDesktopEmitter(ctx, logger, func(event string, data any) {
 		v3app.Event.Emit(event, data)
-	}
+	})
+	v3emit = desktopEvents.Emit
 
 	v3app.Window.NewWithOptions(application.WebviewWindowOptions{
 		Title:            "Sybra",


### PR DESCRIPTION
## Motivation

Connecting a second monitor can wedge the Wails/WebView main thread. Sybra kept emitting desktop events, which let Wails pile up blocked ExecJS goroutines while agents kept running.

> Changelog: fix(desktop): bound Wails event emission

## Implementation information

Adds a bounded desktop event emitter in front of Wails. It sends events at a fixed pace, coalesces latest events when the queue fills, and pauses emits when goroutine count signals a stuck WebView dispatch path.

Adds unit tests for queue coalescing and the pause guard.

## Supporting documentation

Observed with pprof during local GUI hang after monitor attach.