### PR TITLE
fix(github): read checkrun conclusions

### DIFF
--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -41,7 +41,16 @@ const reviewSummaryQuery = `query($createdQ: String!, $requestedQ: String!) {
                 state
                 contexts(first: 20) {
                   nodes {
-                    ... on CheckRun { status }
+                    __typename
+                    ... on CheckRun {
+                      name
+                      status
+                      conclusion
+                    }
+                    ... on StatusContext {
+                      name: context
+                      state
+                    }
                   }
                 }
               }
@@ -80,7 +89,16 @@ const reviewSummaryQuery = `query($createdQ: String!, $requestedQ: String!) {
                 state
                 contexts(first: 20) {
                   nodes {
-                    ... on CheckRun { status }
+                    __typename
+                    ... on CheckRun {
+                      name
+                      status
+                      conclusion
+                    }
+                    ... on StatusContext {
+                      name: context
+                      state
+                    }
                   }
                 }
               }

--- a/internal/github/review_test.go
+++ b/internal/github/review_test.go
@@ -58,6 +58,53 @@ func TestFetchReviewsWith_success(t *testing.T) {
 	}
 }
 
+func TestFetchReviewsWith_failedCheckRunConclusion(t *testing.T) {
+	t.Parallel()
+	response := `{
+		"data": {
+			"viewer": {"login": "me"},
+			"created": {
+				"nodes": [
+					{
+						"number": 1,
+						"title": "my PR",
+						"url": "https://github.com/o/r/pull/1",
+						"author": {"login": "me", "type": "User"},
+						"repository": {"name": "r", "nameWithOwner": "o/r"},
+						"labels": {"nodes": []},
+						"commits": {"nodes": [{
+							"commit": {
+								"oid": "abc123",
+								"statusCheckRollup": {
+									"state": "FAILURE",
+									"contexts": {"nodes": [
+										{"__typename": "CheckRun", "name": "check", "status": "COMPLETED", "conclusion": "FAILURE"}
+									]}
+								}
+							}
+						}]},
+						"reviewThreads": {"nodes": []},
+						"latestReviews": {"nodes": []}
+					}
+				]
+			},
+			"requested": {"nodes": []}
+		}
+	}`
+
+	fe := &fakeExecer{output: []byte(response)}
+	summary, err := fetchReviewsWith(fe)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := summary.CreatedByMe[0].CIStatus; got != "FAILURE" {
+		t.Errorf("CIStatus = %q, want FAILURE", got)
+	}
+	if summary.CreatedByMe[0].HasPendingChecks {
+		t.Error("HasPendingChecks = true, want false")
+	}
+}
+
 func TestFetchReviewsWith_graphqlError(t *testing.T) {
 	t.Parallel()
 	fe := &fakeExecer{output: []byte(`{"errors":[{"message":"rate limited"}]}`)}


### PR DESCRIPTION
## Motivation

Sybra skipped PR CI fixer dispatch when GitHub CheckRuns failed. Review polling queried CheckRun status only, so completed failed runs were treated as success.

> Changelog: fix(github): read checkrun conclusions

## Implementation information

Fetch CheckRun conclusion/name and StatusContext state/name in review polling. Add regression coverage for failed completed CheckRuns producing CIStatus=FAILURE.

