### PR TITLE
feat(sybra): scrub + local task for work data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,9 @@
 # Agent Instructions
 
 Codex: read [CLAUDE.md](./CLAUDE.md) before making changes in this repository. Follow the guidance there as the primary repo-specific instruction set.
+
+## Hard Rule: No Work-Data Leak
+
+Sybra is a public personal project. Never link, embed, paraphrase, or otherwise leak content from work repos (e.g. Kong / `konghq.*`) into the sybra repo or any artifact it produces — issues, PRs, task bodies, plan sidecars, commit messages, logs, screenshots. Applies to manual work AND every sybra automation (Todoist, GitHub Issues fetcher, Renovate fixer, orchestrator, reviews).
+
+Forbidden: work-org repo URLs, branch names, commit SHAs from work repos, ticket IDs (Jira keys), internal hostnames, customer names, snippets from work repos. Filter at the source (project-type/source-config), not in post-processing. See **Work-Data Confidentiality** in CLAUDE.md.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,21 @@
 
 Local desktop app to orchestrate a swarm of Claude Code agents. Markdown-based task management, two execution modes (interactive tmux + headless `claude -p`), Wails v3 alpha GUI (darwin-only).
 
+## Work-Data Confidentiality (HARD RULE)
+
+Sybra is a public personal project. **Never** link, embed, paraphrase, or otherwise leak content from work repos (e.g. Kong / `konghq.*`) into the sybra repo or any artifact it produces.
+
+Applies to:
+
+- Issues and PRs opened against `Automaat/sybra` — manually, via Claude Code, or via any sybra automation
+- Task bodies, decision logs, plan sidecars, commit messages, audit logs that may end up in PRs
+- Auto-sources that ingest external content into tasks: Todoist polling, GitHub Issues fetcher, Renovate fixer, orchestrator brain, review automations
+- Logs, screenshots, and pasted snippets uploaded to issues/PRs
+
+Forbidden content: work-org repo URLs, branch names, commit SHAs from work repos, ticket IDs (e.g. Jira keys), internal hostnames, customer names, code snippets from work repos.
+
+When an automation could surface external content into sybra, filter at the source (project-type / source-config), not just at the final artifact. See "Per-Machine Automations" — work projects must be routed to a different sybra instance, not authored into the public repo.
+
 ## Project Structure
 
 ```
@@ -358,3 +373,4 @@ Frontend must build before Go compilation due to `//go:embed all:frontend/dist`:
 - ❌ Adding a new auto-task source without (a) an `Enabled bool` toggle in its config block and (b) `cfg.AllowsProjectType(...)` filtering if the source is project-scoped — both are required so users running Sybra on multiple machines can route work without duplication
 - ❌ Baking project toolchains into the prod `Dockerfile` — the image ships `mise` only. Language-specific tools belong in each project's **Setup commands** (see Server Deployment section). New projects in new languages never require a container rebuild.
 - ❌ Treating `go build .` (desktop) as a server-context commit gate — Wails v3 needs GTK/webkit on Linux (not installed server-side) and desktop is darwin-only/CI-owned. Use `mise run build:server` for server-side verification.
+- ❌ Pasting, linking, or paraphrasing work-repo content (URLs, branches, SHAs, ticket IDs, snippets, logs, customer names) into sybra issues/PRs/tasks/commits — see **Work-Data Confidentiality** at the top. Any new auto-source that ingests external content must filter work-repo content at the source, not in post-processing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,22 @@ Applies to:
 
 Forbidden content: work-org repo URLs, branch names, commit SHAs from work repos, ticket IDs (e.g. Jira keys), internal hostnames, customer names, code snippets from work repos.
 
-When an automation could surface external content into sybra, filter at the source (project-type / source-config), not just at the final artifact. See "Per-Machine Automations" — work projects must be routed to a different sybra instance, not authored into the public repo.
+### Enforcement mechanism
+
+Two-layer defense applied to every automation that authors a sybra artifact for a work-typed task (`project.Type == work`):
+
+1. **Semantic ceiling (prompt-level)** — review-agent prompts include explicit redaction rules naming the project's identifiers; agents are told to describe sybra bugs abstractly without quoting work content.
+2. **Regex floor (`internal/scrub`)** — every agent- or detector-authored title/body is run through `scrub.Scrub(text, blocklist)` before persistence. Blocklist is derived from the project record (id, owner, repo, URL). Static patterns redact GitHub URLs, Jira-shaped keys, emails. Replacement is `[redacted]`.
+
+Filing routes for work-typed tasks:
+
+| Source | Public path (non-work) | Work-typed path |
+|--------|------------------------|-----------------|
+| Human review (`internal/sybra/app_human_review.go`) | GH issue on `Automaat/sybra` | Scrubbed local sybra task tagged `sybra-bug,scrubbed` (`fileLocalScrubbed`); origin task flipped to `blocked` with pointer to the local task |
+| Monitor anomalies (`internal/sybra/monitor_sink.go`) | GH issue on `Monitor.IssueRepo` | Scrubbed local sybra task tagged `sybra-bug,scrubbed,monitor:<kind>` via `monitorRoutingSink` |
+| LLM-dispatched anomalies | Agent files its own GH issue | Downgraded to deterministic path via `DowngradeLLMForTask` → goes through `monitorRoutingSink` (no agent invocation, no agent-authored content to leak) |
+
+When adding a new auto-source that ingests external content or files artifacts on a public destination, route work-typed tasks through `App.workScrubContextForTask` + `scrub.Scrub` and create a local sybra task instead. Never paraphrase, summarise, or build a "lite" issue body that retains identifiers — the scrubber is the only sanctioned reduction.
 
 ## Project Structure
 

--- a/internal/monitor/service.go
+++ b/internal/monitor/service.go
@@ -48,23 +48,32 @@ type Deps struct {
 	Logger        *slog.Logger
 	Now           func() time.Time
 	AllowsProject func(projectID string) bool
+	// DowngradeLLMForTask, when non-nil, is consulted for every anomaly with
+	// RequiresLLM=true after detection. Returning true for an anomaly's
+	// TaskID forces its RequiresLLM flag to false, routing it through the
+	// deterministic-body path instead of the agent-driven path. Used by
+	// callers (e.g. internal/sybra) to keep work-typed anomalies away from
+	// LLM-generated issue content that is hard to scrub. See CLAUDE.md —
+	// Work-Data Confidentiality.
+	DowngradeLLMForTask func(taskID string) bool
 }
 
 // Service runs the monitor loop. It is constructed once at app startup and
 // runs until its context is cancelled.
 type Service struct {
-	cfg           config.MonitorConfig
-	tasks         taskAPI
-	audit         auditAPI
-	agents        agentLister
-	dispatcher    Dispatcher
-	sink          IssueSink
-	emit          EmitFunc
-	logger        *slog.Logger
-	now           func() time.Time
-	allowsProject func(string) bool
-	state         *runState
-	rem           *remediator
+	cfg                 config.MonitorConfig
+	tasks               taskAPI
+	audit               auditAPI
+	agents              agentLister
+	dispatcher          Dispatcher
+	sink                IssueSink
+	emit                EmitFunc
+	logger              *slog.Logger
+	now                 func() time.Time
+	allowsProject       func(string) bool
+	downgradeLLMForTask func(taskID string) bool
+	state               *runState
+	rem                 *remediator
 }
 
 // NewService validates dependencies and returns a Service ready for Run.
@@ -85,18 +94,19 @@ func NewService(d Deps) *Service {
 		d.Emit = func(string, any) {}
 	}
 	return &Service{
-		cfg:           d.Cfg,
-		tasks:         d.Tasks,
-		audit:         d.Audit,
-		agents:        d.Agents,
-		dispatcher:    d.Dispatcher,
-		sink:          d.Sink,
-		emit:          d.Emit,
-		logger:        d.Logger,
-		now:           d.Now,
-		allowsProject: d.AllowsProject,
-		state:         newRunState(),
-		rem:           newRemediator(d.Tasks),
+		cfg:                 d.Cfg,
+		tasks:               d.Tasks,
+		audit:               d.Audit,
+		agents:              d.Agents,
+		dispatcher:          d.Dispatcher,
+		sink:                d.Sink,
+		emit:                d.Emit,
+		logger:              d.Logger,
+		now:                 d.Now,
+		allowsProject:       d.AllowsProject,
+		downgradeLLMForTask: d.DowngradeLLMForTask,
+		state:               newRunState(),
+		rem:                 newRemediator(d.Tasks),
 	}
 }
 
@@ -170,6 +180,7 @@ func (s *Service) tick(ctx context.Context) (Report, error) {
 		AllowsProject: s.allowsProject,
 	})
 	report.Anomalies = SortAnomalies(report.Anomalies)
+	s.applyDowngradeLLM(report.Anomalies)
 
 	report.Remediated = s.applyRemediations(ctx, report.Anomalies)
 	report.Dispatched = s.dispatchLLMAnomalies(ctx, now, report.Anomalies)
@@ -218,6 +229,25 @@ func (s *Service) Scan(_ context.Context) (Report, error) {
 func (s *Service) LastReport() (Report, bool) {
 	r, _, ok := s.state.snapshot()
 	return r, ok
+}
+
+// applyDowngradeLLM forces RequiresLLM=false on any anomaly whose TaskID the
+// downgrade closure rejects. Used to route work-typed anomalies away from the
+// agent-driven filing path (which produces hard-to-scrub LLM output) into the
+// deterministic-body path where the issue sink applies redaction. No-op when
+// the closure is unset.
+func (s *Service) applyDowngradeLLM(anoms []Anomaly) {
+	if s.downgradeLLMForTask == nil {
+		return
+	}
+	for i := range anoms {
+		if !anoms[i].RequiresLLM || anoms[i].TaskID == "" {
+			continue
+		}
+		if s.downgradeLLMForTask(anoms[i].TaskID) {
+			anoms[i].RequiresLLM = false
+		}
+	}
 }
 
 func (s *Service) applyRemediations(ctx context.Context, anoms []Anomaly) []string {

--- a/internal/scrub/scrub.go
+++ b/internal/scrub/scrub.go
@@ -1,0 +1,101 @@
+// Package scrub redacts work-repo identifiers from agent- and detector-
+// authored text before it lands in a sybra artifact. It is the regex-floor
+// of the Work-Data Confidentiality invariant (see project CLAUDE.md): even
+// if a prompt instruction fails, the scrubber prevents known identifiers
+// from leaking.
+//
+// Two layers of patterns:
+//
+//  1. Dynamic — strings derived from a project record (owner, repo, full
+//     project ID, repo URL). These are the strongest signals that the text
+//     references a specific work source.
+//  2. Static — generic patterns common to corporate workflows: Jira-shaped
+//     ticket keys, full github.com URLs (path bodies redacted, the host kept
+//     so readers can tell the scrub ran), email addresses.
+//
+// Output uses a fixed `[redacted]` placeholder so scrubbed text remains
+// human-readable. The returned count lets callers log/test that something
+// was actually removed.
+package scrub
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Placeholder is the substitution used for every redacted match.
+const Placeholder = "[redacted]"
+
+// staticPatterns are content-shaped redactions applied regardless of the
+// blocklist. They aim for high precision over recall:
+//   - Jira-shaped keys (2+ uppercase letters, dash, digits) tend to be
+//     project-specific identifiers; matching short tokens like "A-1" would
+//     be noisy, so the lower bound is two letters.
+//   - github.com URLs are redacted in their entirety because the path
+//     usually reveals owner/repo/branch/SHA. The host word survives so the
+//     scrub is visible.
+//   - Email addresses are redacted to avoid leaking author identity from
+//     commit-author lines or @mentions.
+var staticPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\b[A-Z]{2,}-\d+\b`),
+	regexp.MustCompile(`https?://github\.com/[^\s)\]]+`),
+	regexp.MustCompile(`[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`),
+}
+
+// Scrub redacts every match of staticPatterns and every occurrence of any
+// blocklist literal (case-sensitive) from text. Empty or whitespace-only
+// entries in blocklist are ignored. Returns the redacted text and the total
+// number of substitutions performed.
+//
+// Static patterns run BEFORE blocklist substitution so URLs and emails are
+// redacted as whole tokens. Otherwise blocklist hits inside a URL would
+// fragment it (e.g. "https://github.com/[redacted]/repo/pull/9") and leave
+// path tails dangling. Blocklist matching then prefers longer strings first
+// so that "owner/repo" is redacted as one token rather than leaving "owner"
+// or "repo" naked.
+func Scrub(text string, blocklist []string) (scrubbed string, redactions int) {
+	if text == "" {
+		return text, 0
+	}
+	out := text
+	total := 0
+	for _, re := range staticPatterns {
+		matches := re.FindAllStringIndex(out, -1)
+		if len(matches) == 0 {
+			continue
+		}
+		out = re.ReplaceAllString(out, Placeholder)
+		total += len(matches)
+	}
+
+	cleaned := dedupNonEmpty(blocklist)
+	sort.Slice(cleaned, func(i, j int) bool {
+		return len(cleaned[i]) > len(cleaned[j])
+	})
+	for _, term := range cleaned {
+		count := strings.Count(out, term)
+		if count == 0 {
+			continue
+		}
+		out = strings.ReplaceAll(out, term, Placeholder)
+		total += count
+	}
+	return out, total
+}
+
+// dedupNonEmpty trims whitespace, drops empty entries, and removes
+// duplicates while preserving the first occurrence's spelling.
+func dedupNonEmpty(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		s = strings.TrimSpace(s)
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/scrub/scrub_test.go
+++ b/internal/scrub/scrub_test.go
@@ -1,0 +1,118 @@
+package scrub
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScrub(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		text       string
+		blocklist  []string
+		wantHas    []string
+		wantNotHas []string
+		wantCount  int
+	}{
+		{
+			name:       "empty input passes through",
+			text:       "",
+			blocklist:  []string{"work-org"},
+			wantCount:  0,
+			wantHas:    nil,
+			wantNotHas: []string{Placeholder},
+		},
+		{
+			name:       "no matches leaves text intact",
+			text:       "totally innocuous diagnostic note",
+			blocklist:  []string{"work-org"},
+			wantCount:  0,
+			wantHas:    []string{"totally innocuous"},
+			wantNotHas: []string{Placeholder},
+		},
+		{
+			name:       "blocklist literal redacted",
+			text:       "task came from work-org/secret-repo with details",
+			blocklist:  []string{"work-org/secret-repo", "work-org"},
+			wantCount:  1,
+			wantHas:    []string{Placeholder, "with details"},
+			wantNotHas: []string{"work-org", "secret-repo"},
+		},
+		{
+			name:       "longer blocklist entry wins",
+			text:       "owner/repo and also just owner alone",
+			blocklist:  []string{"owner", "owner/repo"},
+			wantCount:  2,
+			wantHas:    []string{Placeholder},
+			wantNotHas: []string{"owner/repo", "owner alone"},
+		},
+		{
+			name:       "github URL redacted",
+			text:       "see https://github.com/work-org/secret-repo/pull/42 for context",
+			blocklist:  nil,
+			wantCount:  1,
+			wantHas:    []string{Placeholder, "for context"},
+			wantNotHas: []string{"work-org", "secret-repo", "/pull/42"},
+		},
+		{
+			name:       "jira key redacted",
+			text:       "this is blocked by KAG-1234 over in tickets",
+			blocklist:  nil,
+			wantCount:  1,
+			wantHas:    []string{Placeholder, "over in tickets"},
+			wantNotHas: []string{"KAG-1234"},
+		},
+		{
+			name:       "single-letter prefix is NOT treated as jira",
+			text:       "version A-1 ships next week",
+			blocklist:  nil,
+			wantCount:  0,
+			wantHas:    []string{"A-1"},
+			wantNotHas: []string{Placeholder},
+		},
+		{
+			name:       "email redacted",
+			text:       "ping alice@konghq.com if blocked",
+			blocklist:  nil,
+			wantCount:  1,
+			wantHas:    []string{Placeholder, "if blocked"},
+			wantNotHas: []string{"alice@konghq.com"},
+		},
+		{
+			name:       "blocklist + static patterns combine",
+			text:       "PR https://github.com/work-org/repo/pull/9 from alice@work-org.com (ticket KAG-1)",
+			blocklist:  []string{"work-org"},
+			wantCount:  3,
+			wantHas:    []string{Placeholder},
+			wantNotHas: []string{"work-org", "alice@", "KAG-1"},
+		},
+		{
+			name:       "whitespace-only blocklist entries ignored",
+			text:       "innocent text",
+			blocklist:  []string{"", "   "},
+			wantCount:  0,
+			wantHas:    []string{"innocent text"},
+			wantNotHas: []string{Placeholder},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, count := Scrub(tc.text, tc.blocklist)
+			if count != tc.wantCount {
+				t.Errorf("redaction count = %d, want %d (got=%q)", count, tc.wantCount, got)
+			}
+			for _, needle := range tc.wantHas {
+				if !strings.Contains(got, needle) {
+					t.Errorf("output should contain %q; got=%q", needle, got)
+				}
+			}
+			for _, needle := range tc.wantNotHas {
+				if strings.Contains(got, needle) {
+					t.Errorf("output should NOT contain %q; got=%q", needle, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/sybra/app_automation_routing_test.go
+++ b/internal/sybra/app_automation_routing_test.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/Automaat/sybra/internal/config"
@@ -106,11 +107,12 @@ func TestAllowsProjectType_RoutingAcrossMachines(t *testing.T) {
 	}
 }
 
-// TestCanFilePublicForProject covers the Work-Data Confidentiality guard:
-// auto-filing on the public sybra repo must be blocked for work-typed
-// projects regardless of per-machine routing config. Pet/unknown projects
-// and tasks without a project_id remain allowed.
-func TestCanFilePublicForProject(t *testing.T) {
+// TestWorkScrubContextForTask covers the Work-Data Confidentiality guard:
+// work-typed projects must yield a non-nil scrub context (signalling the
+// caller to scrub + route to a local task) regardless of per-machine
+// routing config. Pet/unknown projects and tasks without a project_id
+// must yield nil so artifacts file normally on the public repo.
+func TestWorkScrubContextForTask(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -131,20 +133,35 @@ func TestCanFilePublicForProject(t *testing.T) {
 	}
 
 	cases := []struct {
-		name      string
-		projectID string
-		want      bool
+		name        string
+		projectID   string
+		wantNonNil  bool
+		wantInBlock []string // substrings the blocklist must contain when non-nil
 	}{
-		{"empty projectID is allowed", "", true},
-		{"pet project allowed", "pet-owner/pet-repo", true},
-		{"work project blocked", "work-owner/work-repo", false},
-		{"unknown project fails open", "ghost-owner/ghost-repo", true},
+		{name: "empty projectID is unscoped", projectID: "", wantNonNil: false},
+		{name: "pet project is unscoped", projectID: "pet-owner/pet-repo", wantNonNil: false},
+		{name: "unknown project fails open", projectID: "ghost-owner/ghost-repo", wantNonNil: false},
+		{
+			name:        "work project produces blocklist",
+			projectID:   "work-owner/work-repo",
+			wantNonNil:  true,
+			wantInBlock: []string{"work-owner/work-repo"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got := a.canFilePublicForProject(tc.projectID); got != tc.want {
-				t.Errorf("canFilePublicForProject(%q) = %v, want %v", tc.projectID, got, tc.want)
+			got := a.workScrubContextForTask(tc.projectID)
+			if (got != nil) != tc.wantNonNil {
+				t.Fatalf("workScrubContextForTask(%q) non-nil=%v, want %v", tc.projectID, got != nil, tc.wantNonNil)
+			}
+			if got == nil {
+				return
+			}
+			for _, needle := range tc.wantInBlock {
+				if !slices.Contains(got.Blocklist, needle) {
+					t.Errorf("blocklist missing %q; got %v", needle, got.Blocklist)
+				}
 			}
 		})
 	}

--- a/internal/sybra/app_automation_routing_test.go
+++ b/internal/sybra/app_automation_routing_test.go
@@ -2,6 +2,8 @@ package sybra
 
 import (
 	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/Automaat/sybra/internal/config"
@@ -101,5 +103,68 @@ func TestAllowsProjectType_RoutingAcrossMachines(t *testing.T) {
 				t.Errorf("allowsProjectType(other) = %v, want %v", got, tt.wantOther)
 			}
 		})
+	}
+}
+
+// TestCanFilePublicForProject covers the Work-Data Confidentiality guard:
+// auto-filing on the public sybra repo must be blocked for work-typed
+// projects regardless of per-machine routing config. Pet/unknown projects
+// and tasks without a project_id remain allowed.
+func TestCanFilePublicForProject(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	store, err := project.NewStore(dir, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	// Seed projects by writing YAML directly — Create() does a real git clone.
+	mustWriteProjectYAML(t, dir, "work-owner/work-repo", project.ProjectTypeWork)
+	mustWriteProjectYAML(t, dir, "pet-owner/pet-repo", project.ProjectTypePet)
+
+	// Even a machine routed to handle BOTH project types must still block
+	// public-repo filings for work-typed tasks.
+	a := &App{
+		cfg:      &config.Config{ProjectTypes: []string{"pet", "work"}},
+		projects: store,
+		logger:   slog.Default(),
+	}
+
+	cases := []struct {
+		name      string
+		projectID string
+		want      bool
+	}{
+		{"empty projectID is allowed", "", true},
+		{"pet project allowed", "pet-owner/pet-repo", true},
+		{"work project blocked", "work-owner/work-repo", false},
+		{"unknown project fails open", "ghost-owner/ghost-repo", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := a.canFilePublicForProject(tc.projectID); got != tc.want {
+				t.Errorf("canFilePublicForProject(%q) = %v, want %v", tc.projectID, got, tc.want)
+			}
+		})
+	}
+}
+
+// mustWriteProjectYAML writes a minimal project record straight to the
+// project.Store directory. Bypasses Store.Create (which performs a real git
+// clone) so the test can stage work/pet entries without network access.
+func mustWriteProjectYAML(t *testing.T, dir, id string, ptype project.ProjectType) {
+	t.Helper()
+	// project.Store.filePath maps "owner/repo" → "owner--repo.yaml".
+	safe := id
+	for i := 0; i < len(safe); i++ {
+		if safe[i] == '/' {
+			safe = safe[:i] + "--" + safe[i+1:]
+		}
+	}
+	path := filepath.Join(dir, safe+".yaml")
+	content := "id: " + id + "\ntype: " + string(ptype) + "\nowner: stub\nrepo: stub\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write project YAML: %v", err)
 	}
 }

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/monitor"
+	"github.com/Automaat/sybra/internal/scrub"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -55,12 +56,13 @@ type humanReviewHandler struct {
 	logFile string
 	now     func() time.Time
 
-	// canFilePublic reports whether human-review may run for a task with the
-	// given project ID. Work-typed projects are blocked to prevent leaking
-	// work-repo content into Automaat/sybra (see CLAUDE.md — Work-Data
-	// Confidentiality). Wired from App.canFilePublicForProject; nil during
-	// tests allows everything.
-	canFilePublic func(projectID string) bool
+	// workCtx returns a non-nil WorkScrubContext when the task's project is
+	// work-typed. When set, the handler still spawns the review agent but
+	// reroutes the sybra_bug verdict to a local sybra task with the body
+	// scrubbed through ctx.Blocklist — no GH issue on Automaat/sybra is
+	// filed. See CLAUDE.md — Work-Data Confidentiality. Nil during tests
+	// disables the work-project path.
+	workCtx func(projectID string) *WorkScrubContext
 
 	mu       sync.Mutex
 	inflight map[string]string // taskID -> agent ID
@@ -85,20 +87,20 @@ func newHumanReviewHandler(
 	logger *slog.Logger,
 	sink humanReviewIssueFiler,
 	homeDir, logFile string,
-	canFilePublic func(projectID string) bool,
+	workCtx func(projectID string) *WorkScrubContext,
 ) *humanReviewHandler {
 	return &humanReviewHandler{
-		cfg:           cfg,
-		tasks:         tasks,
-		agents:        agents,
-		audit:         al,
-		logger:        logger,
-		sink:          sink,
-		homeDir:       homeDir,
-		logFile:       logFile,
-		now:           time.Now,
-		canFilePublic: canFilePublic,
-		inflight:      make(map[string]string),
+		cfg:      cfg,
+		tasks:    tasks,
+		agents:   agents,
+		audit:    al,
+		logger:   logger,
+		sink:     sink,
+		homeDir:  homeDir,
+		logFile:  logFile,
+		now:      time.Now,
+		workCtx:  workCtx,
+		inflight: make(map[string]string),
 	}
 }
 
@@ -119,7 +121,7 @@ func (a *App) initHumanReview() {
 	}
 	sink := monitor.NewGHIssueSink(a.cfg.HumanReviewIssueLabel(), a.cfg.HumanReviewRepo())
 	logFile := filepath.Join(a.logDir, "sybra.log")
-	a.humanReview = newHumanReviewHandler(a.cfg, a.tasks, a.agents, a.audit, a.logger, sink, config.HomeDir(), logFile, a.canFilePublicForProject)
+	a.humanReview = newHumanReviewHandler(a.cfg, a.tasks, a.agents, a.audit, a.logger, sink, config.HomeDir(), logFile, a.workScrubContextForTask)
 	a.logger.Info("human-review.enabled", "dir", dir, "repo", a.cfg.HumanReviewRepo(), "model", a.cfg.HumanReviewModel())
 }
 
@@ -140,12 +142,13 @@ func (h *humanReviewHandler) maybeSpawn(taskID, prevStatus string) {
 		h.logger.Error("human-review.task.get", "task_id", taskID, "err", err)
 		return
 	}
-	// Work-Data Confidentiality: human-review files issues on Automaat/sybra
-	// (public) with task body + agent logs embedded. Work-typed projects must
-	// never reach that pipeline, regardless of per-machine routing.
-	if h.canFilePublic != nil && !h.canFilePublic(t.ProjectID) {
-		h.skip(taskID, "work_project_no_public_filing")
-		return
+	// Work-Data Confidentiality: if the task's project is work-typed, the
+	// review still runs (we want the diagnosis) but the prompt is augmented
+	// with redaction instructions and the verdict is routed to a local
+	// sybra task in onComplete rather than the public GH sink.
+	var wctx *WorkScrubContext
+	if h.workCtx != nil {
+		wctx = h.workCtx(t.ProjectID)
 	}
 
 	h.mu.Lock()
@@ -164,7 +167,7 @@ func (h *humanReviewHandler) maybeSpawn(taskID, prevStatus string) {
 	h.recent = append(h.recent, h.now())
 	h.mu.Unlock()
 
-	prompt := h.buildPrompt(t)
+	prompt := h.buildPrompt(t, wctx)
 	ag, err := h.agents.Run(agent.RunConfig{
 		TaskID:             taskID,
 		Name:               agent.RoleHumanReview.AgentName(t.Title),
@@ -233,10 +236,72 @@ func (h *humanReviewHandler) onComplete(ag *agent.Agent) {
 	case "human":
 		h.appendNote(taskID, "Auto-review verdict: needs human", v.Summary)
 	case "sybra_bug":
-		h.fileIssue(taskID, ag.ID, v)
+		// Re-check work context at completion time so a project re-typed
+		// during the review run still routes correctly.
+		var wctx *WorkScrubContext
+		if h.workCtx != nil {
+			if t, err := h.tasks.Get(taskID); err == nil {
+				wctx = h.workCtx(t.ProjectID)
+			}
+		}
+		if wctx != nil {
+			h.fileLocalScrubbed(taskID, ag.ID, v, wctx)
+		} else {
+			h.fileIssue(taskID, ag.ID, v)
+		}
 	default:
 		h.logger.Warn("human-review.verdict.unknown", "task_id", taskID, "decision", v.Decision)
 		h.appendNote(taskID, "Auto-review (unknown decision)", final)
+	}
+}
+
+// fileLocalScrubbed is the work-project fallback for the sybra_bug verdict.
+// Instead of opening a GitHub issue on Automaat/sybra, it scrubs the agent-
+// authored title and body through wctx.Blocklist and creates a local sybra
+// task tagged sybra-bug,scrubbed. The originating task is flipped to blocked
+// with a pointer to the new local task — same UX shape as the public path,
+// just routed away from the public repo.
+func (h *humanReviewHandler) fileLocalScrubbed(taskID, agentID string, v verdictDecision, wctx *WorkScrubContext) {
+	if strings.TrimSpace(v.IssueTitle) == "" || strings.TrimSpace(v.IssueBody) == "" {
+		h.logger.Warn("human-review.local.empty", "task_id", taskID, "agent_id", agentID)
+		h.appendNote(taskID, "Auto-review verdict: sybra_bug (no issue payload)", v.Summary)
+		return
+	}
+	title, titleRed := scrub.Scrub(v.IssueTitle, wctx.Blocklist)
+	body, bodyRed := scrub.Scrub(v.IssueBody, wctx.Blocklist)
+	summary, _ := scrub.Scrub(v.Summary, wctx.Blocklist)
+
+	newTask, err := h.tasks.Create(title, body, task.AgentModeHeadless)
+	if err != nil {
+		h.logger.Error("human-review.local.create", "task_id", taskID, "agent_id", agentID, "err", err)
+		h.appendNote(taskID, "Auto-review verdict: sybra_bug (local task creation failed)", summary+"\n\nError: "+err.Error())
+		return
+	}
+	tags := append([]string{"sybra-bug", "scrubbed"}, v.IssueLabels...)
+	if _, err := h.tasks.Update(newTask.ID, task.Update{Tags: &tags}); err != nil {
+		h.logger.Warn("human-review.local.tag", "new_task_id", newTask.ID, "err", err)
+	}
+	h.logAudit(audit.EventHumanReviewIssue, taskID, agentID, map[string]any{
+		"created": true, "url": "", "title": title,
+		"local_task_id": newTask.ID, "redactions_title": titleRed, "redactions_body": bodyRed,
+		"scrubbed": true,
+	})
+
+	statusReason := fmt.Sprintf("auto-review: %s (local task %s)", summary, newTask.ID)
+	noteBody := fmt.Sprintf("**Linked local sybra task:** %s\n\n%s", newTask.ID, summary)
+	origin, err := h.tasks.Get(taskID)
+	if err != nil {
+		h.logger.Error("human-review.local.origin-get", "task_id", taskID, "err", err)
+		return
+	}
+	newBody := appendSection(origin.Body, "Auto-review verdict: blocked by Sybra bug (scrubbed)", noteBody)
+	upd := task.Update{
+		Body:         &newBody,
+		Status:       task.Ptr(task.StatusBlocked),
+		StatusReason: task.Ptr(statusReason),
+	}
+	if _, err := h.tasks.Update(taskID, upd); err != nil {
+		h.logger.Error("human-review.local.origin-update", "task_id", taskID, "err", err)
 	}
 }
 
@@ -338,10 +403,23 @@ func (h *humanReviewHandler) logAudit(evt, taskID, agentID string, data map[stri
 // buildPrompt assembles the review agent's instructions and context. The
 // agent runs in the Sybra source tree with skip-permissions, so it can
 // freely grep the codebase + read host logs to diagnose the transition.
-func (h *humanReviewHandler) buildPrompt(t task.Task) string {
+//
+// When wctx is non-nil the task originates from a work-typed project; the
+// prompt is augmented with explicit redaction rules and the verdict will be
+// routed to a local sybra task instead of a public GH issue. The regex
+// scrubber is the floor — these instructions are the semantic ceiling.
+func (h *humanReviewHandler) buildPrompt(t task.Task, wctx *WorkScrubContext) string {
 	var b strings.Builder
 	b.WriteString("# Sybra auto-review of human-required transition\n\n")
-	b.WriteString("You are a diagnostic agent for Sybra (the desktop task orchestrator). A user task just transitioned to status=human-required. Decide whether this is genuinely a human-input situation or whether Sybra itself misbehaved (workflow misfire, agent mis-config, infrastructure flakiness, code bug). If it's a Sybra bug, prepare a GitHub issue payload — the host process will file it.\n\n")
+	if wctx != nil {
+		b.WriteString("## Work-Data Confidentiality (CRITICAL)\n")
+		b.WriteString("This task originated from a work-typed project. Your verdict will be persisted to a LOCAL sybra task, not a public GitHub issue, but you must still scrub work identifiers from your output:\n\n")
+		b.WriteString("- NEVER include the project_id, repo URL, owner, or repo name.\n")
+		b.WriteString("- NEVER quote code, branch names, commit SHAs, or ticket IDs from the task body.\n")
+		b.WriteString("- NEVER include author emails, customer names, or internal hostnames.\n")
+		b.WriteString("- DO describe the sybra bug abstractly: which workflow step misfired, which sybra subsystem is implicated, what state was inconsistent.\n\n")
+	}
+	b.WriteString("You are a diagnostic agent for Sybra (the desktop task orchestrator). A user task just transitioned to status=human-required. Decide whether this is genuinely a human-input situation or whether Sybra itself misbehaved (workflow misfire, agent mis-config, infrastructure flakiness, code bug). If it's a Sybra bug, prepare an issue payload — the host process will route it (local sybra task for work-typed projects, public GH issue otherwise).\n\n")
 	b.WriteString("## Task\n")
 	fmt.Fprintf(&b, "- ID: %s\n- Title: %s\n- Status: %s\n", t.ID, t.Title, t.Status)
 	if t.StatusReason != "" {

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -55,6 +55,13 @@ type humanReviewHandler struct {
 	logFile string
 	now     func() time.Time
 
+	// canFilePublic reports whether human-review may run for a task with the
+	// given project ID. Work-typed projects are blocked to prevent leaking
+	// work-repo content into Automaat/sybra (see CLAUDE.md — Work-Data
+	// Confidentiality). Wired from App.canFilePublicForProject; nil during
+	// tests allows everything.
+	canFilePublic func(projectID string) bool
+
 	mu       sync.Mutex
 	inflight map[string]string // taskID -> agent ID
 	recent   []time.Time       // spawn timestamps (rolling window)
@@ -78,18 +85,20 @@ func newHumanReviewHandler(
 	logger *slog.Logger,
 	sink humanReviewIssueFiler,
 	homeDir, logFile string,
+	canFilePublic func(projectID string) bool,
 ) *humanReviewHandler {
 	return &humanReviewHandler{
-		cfg:      cfg,
-		tasks:    tasks,
-		agents:   agents,
-		audit:    al,
-		logger:   logger,
-		sink:     sink,
-		homeDir:  homeDir,
-		logFile:  logFile,
-		now:      time.Now,
-		inflight: make(map[string]string),
+		cfg:           cfg,
+		tasks:         tasks,
+		agents:        agents,
+		audit:         al,
+		logger:        logger,
+		sink:          sink,
+		homeDir:       homeDir,
+		logFile:       logFile,
+		now:           time.Now,
+		canFilePublic: canFilePublic,
+		inflight:      make(map[string]string),
 	}
 }
 
@@ -110,7 +119,7 @@ func (a *App) initHumanReview() {
 	}
 	sink := monitor.NewGHIssueSink(a.cfg.HumanReviewIssueLabel(), a.cfg.HumanReviewRepo())
 	logFile := filepath.Join(a.logDir, "sybra.log")
-	a.humanReview = newHumanReviewHandler(a.cfg, a.tasks, a.agents, a.audit, a.logger, sink, config.HomeDir(), logFile)
+	a.humanReview = newHumanReviewHandler(a.cfg, a.tasks, a.agents, a.audit, a.logger, sink, config.HomeDir(), logFile, a.canFilePublicForProject)
 	a.logger.Info("human-review.enabled", "dir", dir, "repo", a.cfg.HumanReviewRepo(), "model", a.cfg.HumanReviewModel())
 }
 
@@ -129,6 +138,13 @@ func (h *humanReviewHandler) maybeSpawn(taskID, prevStatus string) {
 	t, err := h.tasks.Get(taskID)
 	if err != nil {
 		h.logger.Error("human-review.task.get", "task_id", taskID, "err", err)
+		return
+	}
+	// Work-Data Confidentiality: human-review files issues on Automaat/sybra
+	// (public) with task body + agent logs embedded. Work-typed projects must
+	// never reach that pipeline, regardless of per-machine routing.
+	if h.canFilePublic != nil && !h.canFilePublic(t.ProjectID) {
+		h.skip(taskID, "work_project_no_public_filing")
 		return
 	}
 

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -51,7 +51,7 @@ func newReviewTestEnv(t *testing.T) (*humanReviewHandler, *task.Manager, *fakeIs
 	cfg.HumanReview.MaxPerHour = 3
 	sink := &fakeIssueSink{created: true, url: "https://github.com/Automaat/sybra/issues/42"}
 	logger := slog.New(slog.DiscardHandler)
-	h := newHumanReviewHandler(cfg, tasks, nil, nil, logger, sink, dir, filepath.Join(dir, "missing.log"))
+	h := newHumanReviewHandler(cfg, tasks, nil, nil, logger, sink, dir, filepath.Join(dir, "missing.log"), nil)
 	return h, tasks, sink, func() {}
 }
 
@@ -294,6 +294,42 @@ func TestOnComplete_SinkError_LeavesHumanRequired(t *testing.T) {
 	}
 	if !strings.Contains(got.Body, "issue submission failed") {
 		t.Errorf("expected failure note in body; got:\n%s", got.Body)
+	}
+}
+
+func TestMaybeSpawn_WorkProject_SkippedNoAgent(t *testing.T) {
+	t.Parallel()
+	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	const workProject = "work-owner/work-repo"
+	h.canFilePublic = func(projectID string) bool {
+		return projectID != workProject
+	}
+
+	tk, err := tasks.Create("Has work content", "Body with work-repo refs.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{
+		ProjectID: task.Ptr(workProject),
+		Status:    task.Ptr(task.StatusHumanRequired),
+	}); err != nil {
+		t.Fatalf("assign work project: %v", err)
+	}
+
+	// agents and audit are nil in the test env; if maybeSpawn reaches the
+	// spawn path it would panic. The guard must short-circuit before that.
+	h.maybeSpawn(tk.ID, "in-progress")
+
+	if sink.calls != 0 {
+		t.Errorf("sink should not be called for work-typed project; calls=%d", sink.calls)
+	}
+	if _, busy := h.inflight[tk.ID]; busy {
+		t.Errorf("inflight should be empty when work project is skipped")
+	}
+	if len(h.recent) != 0 {
+		t.Errorf("rate-limit slot should not be consumed when work project is skipped; recent=%v", h.recent)
 	}
 }
 

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -297,17 +298,23 @@ func TestOnComplete_SinkError_LeavesHumanRequired(t *testing.T) {
 	}
 }
 
-func TestMaybeSpawn_WorkProject_SkippedNoAgent(t *testing.T) {
+func TestOnComplete_WorkProject_LocalTaskScrubbed(t *testing.T) {
 	t.Parallel()
 	h, tasks, sink, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
 	const workProject = "work-owner/work-repo"
-	h.canFilePublic = func(projectID string) bool {
-		return projectID != workProject
+	h.workCtx = func(projectID string) *WorkScrubContext {
+		if projectID != workProject {
+			return nil
+		}
+		return &WorkScrubContext{
+			ProjectID: workProject,
+			Blocklist: []string{workProject, "work-owner", "work-repo"},
+		}
 	}
 
-	tk, err := tasks.Create("Has work content", "Body with work-repo refs.", "headless")
+	tk, err := tasks.Create("Workflow misfire", "Body with KAG-1234 reference.", "headless")
 	if err != nil {
 		t.Fatalf("create task: %v", err)
 	}
@@ -318,19 +325,69 @@ func TestMaybeSpawn_WorkProject_SkippedNoAgent(t *testing.T) {
 		t.Fatalf("assign work project: %v", err)
 	}
 
-	// agents and audit are nil in the test env; if maybeSpawn reaches the
-	// spawn path it would panic. The guard must short-circuit before that.
-	h.maybeSpawn(tk.ID, "in-progress")
+	// Verdict body contains all three leak vectors: blocklist literal, GH
+	// URL, Jira key. After scrub, none must survive in the created task.
+	ag := &agent.Agent{TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
+	ag.AppendOutput(agent.StreamEvent{
+		Type: "assistant",
+		Content: "Diagnosis.\n\n```sybra-verdict\n" + `{
+  "decision": "sybra_bug",
+  "summary": "verify_commits never re-checked the branch in work-owner/work-repo",
+  "issue_title": "fix(workflow): verify_commits race for work-owner/work-repo",
+  "issue_body": "## What\nwork-owner referenced https://github.com/work-owner/work-repo/pull/9 (ticket KAG-1234)",
+  "issue_labels": ["workflow"]
+}` + "\n```\n",
+	})
+	h.inflight[tk.ID] = "agent-work"
+	h.onComplete(ag)
 
 	if sink.calls != 0 {
-		t.Errorf("sink should not be called for work-typed project; calls=%d", sink.calls)
+		t.Errorf("public sink must NOT be called for work-typed project; calls=%d", sink.calls)
 	}
-	if _, busy := h.inflight[tk.ID]; busy {
-		t.Errorf("inflight should be empty when work project is skipped")
+
+	// Original task: flipped to blocked with a pointer to the local task.
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("re-load origin: %v", err)
 	}
-	if len(h.recent) != 0 {
-		t.Errorf("rate-limit slot should not be consumed when work project is skipped; recent=%v", h.recent)
+	if got.Status != task.StatusBlocked {
+		t.Errorf("origin status: got %q want blocked", got.Status)
 	}
+	if !strings.Contains(got.Body, "blocked by Sybra bug (scrubbed)") {
+		t.Errorf("origin body missing scrubbed-blocked header; got:\n%s", got.Body)
+	}
+
+	// A new local task must exist with scrubbed content + sybra-bug tag.
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatalf("list tasks: %v", err)
+	}
+	var local *task.Task
+	for i := range all {
+		if all[i].ID == tk.ID {
+			continue
+		}
+		t := all[i]
+		local = &t
+	}
+	if local == nil {
+		t.Fatalf("expected a second (scrubbed) task to be created; got only origin")
+	}
+	body := local.Title + "\n" + local.Body
+	for _, leak := range []string{workProject, "work-owner", "work-repo", "github.com/work-owner", "KAG-1234"} {
+		if strings.Contains(body, leak) {
+			t.Errorf("local task leaks %q in title/body: %s", leak, body)
+		}
+	}
+	wantTag := func(needle string) {
+		t.Helper()
+		if !slices.Contains(local.Tags, needle) {
+			t.Errorf("local task missing tag %q; got tags=%v", needle, local.Tags)
+		}
+	}
+	wantTag("sybra-bug")
+	wantTag("scrubbed")
+	wantTag("workflow")
 }
 
 func TestOnComplete_MalformedVerdict_AppendsRaw(t *testing.T) {

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -55,24 +55,46 @@ func (a *App) allowsProjectType(t project.ProjectType) bool {
 	return a.cfg.AllowsProjectType(string(t))
 }
 
-// canFilePublicForProject reports whether sybra automations may file artifacts
-// (issues, PRs) on the public sybra repo on behalf of a task with the given
-// project ID. Work-typed projects are blocked unconditionally so work-repo
-// content (issue bodies, agent logs, diagnoses) never reaches Automaat/sybra
-// via any automation. See CLAUDE.md — Work-Data Confidentiality.
+// WorkScrubContext carries the redaction blocklist for a task whose project
+// is work-typed. Returned from App.workScrubContextForTask; a nil result
+// means "not a work-typed task — file artifacts normally". A non-nil result
+// signals automations to scrub their output through Blocklist and route to
+// a local sybra task instead of the public sybra repo. See CLAUDE.md —
+// Work-Data Confidentiality.
+type WorkScrubContext struct {
+	// ProjectID of the originating work task, retained for tagging and
+	// audit only — must not be echoed into any scrubbed artifact body.
+	ProjectID string
+	// Blocklist of literal strings to redact before persistence. Derived
+	// from the project record (owner, repo, full id, repo URL).
+	Blocklist []string
+}
+
+// workScrubContextForTask reports whether artifacts derived from a task
+// must be scrubbed and rerouted to a local sybra task. Returns nil when the
+// task is unscoped (no project_id), its project lookup misses, or the
+// project is not work-typed. Returns a populated context when the project
+// resolves to project.ProjectTypeWork.
 //
-// Returns true for tasks with no project_id (unscoped sybra-internal tasks)
-// and for tasks whose project lookup fails (fail-open is safe here because
-// the absence of a project record means no upstream work source).
-func (a *App) canFilePublicForProject(projectID string) bool {
+// Fail-open behaviour (unknown projects → nil) is intentional: the absence
+// of a project record means we have no upstream work source to leak, so
+// scrubbing would only hide signal without adding safety.
+func (a *App) workScrubContextForTask(projectID string) *WorkScrubContext {
 	if projectID == "" {
-		return true
+		return nil
 	}
 	p, err := a.projects.Get(projectID)
 	if err != nil {
-		return true
+		return nil
 	}
-	return p.Type != project.ProjectTypeWork
+	if p.Type != project.ProjectTypeWork {
+		return nil
+	}
+	bl := []string{p.ID, p.Owner, p.Repo}
+	if p.URL != "" {
+		bl = append(bl, p.URL)
+	}
+	return &WorkScrubContext{ProjectID: p.ID, Blocklist: bl}
 }
 
 // initIssuesFetcher constructs the GitHub Issues fetcher if enabled, returning

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -55,6 +55,26 @@ func (a *App) allowsProjectType(t project.ProjectType) bool {
 	return a.cfg.AllowsProjectType(string(t))
 }
 
+// canFilePublicForProject reports whether sybra automations may file artifacts
+// (issues, PRs) on the public sybra repo on behalf of a task with the given
+// project ID. Work-typed projects are blocked unconditionally so work-repo
+// content (issue bodies, agent logs, diagnoses) never reaches Automaat/sybra
+// via any automation. See CLAUDE.md — Work-Data Confidentiality.
+//
+// Returns true for tasks with no project_id (unscoped sybra-internal tasks)
+// and for tasks whose project lookup fails (fail-open is safe here because
+// the absence of a project record means no upstream work source).
+func (a *App) canFilePublicForProject(projectID string) bool {
+	if projectID == "" {
+		return true
+	}
+	p, err := a.projects.Get(projectID)
+	if err != nil {
+		return true
+	}
+	return p.Type != project.ProjectTypeWork
+}
+
 // initIssuesFetcher constructs the GitHub Issues fetcher if enabled, returning
 // nil otherwise. Kept separate so Startup stays under the funlen limit.
 func (a *App) initIssuesFetcher(emit func(string, any)) *poll.IssuesFetcher {

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Automaat/sybra/internal/metrics"
 	"github.com/Automaat/sybra/internal/monitor"
 	"github.com/Automaat/sybra/internal/poll"
+	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/selfmonitor"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/watchdog"
@@ -199,6 +200,14 @@ func (lm *LifecycleManager) startMonitorService(ctx context.Context, emit func(s
 			p, err := a.projects.Get(projectID)
 			if err != nil {
 				return true
+			}
+			// Monitor files anomaly issues on Monitor.IssueRepo (defaults to
+			// Automaat/sybra). Work-typed projects must never surface there —
+			// anomaly bodies carry task IDs and audit excerpts that may
+			// reference work-repo content. See CLAUDE.md — Work-Data
+			// Confidentiality.
+			if p.Type == project.ProjectTypeWork {
+				return false
 			}
 			return a.allowsProjectType(p.Type)
 		},

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Automaat/sybra/internal/metrics"
 	"github.com/Automaat/sybra/internal/monitor"
 	"github.com/Automaat/sybra/internal/poll"
-	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/selfmonitor"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/watchdog"
@@ -184,13 +183,20 @@ func (lm *LifecycleManager) startMonitorService(ctx context.Context, emit func(s
 		Model:     a.cfg.Monitor.Model,
 		IssueRepo: a.cfg.Monitor.IssueRepo,
 	})
+	// Work-Data Confidentiality: wrap the GH sink so anomalies on work-typed
+	// tasks become scrubbed local sybra tasks instead of public issues. The
+	// DowngradeLLMForTask closure forces work-typed LLM anomalies through the
+	// deterministic path so they hit this sink (and get scrubbed) rather than
+	// being dispatched to an agent that would file an issue itself.
+	innerSink := monitor.NewGHIssueSink(a.cfg.Monitor.IssueLabel, a.cfg.Monitor.IssueRepo)
+	routingSink := newMonitorRoutingSink(innerSink, a.tasks, a.workScrubContextForTask, a.logger)
 	svc := monitor.NewService(monitor.Deps{
 		Cfg:        a.cfg.Monitor,
 		Tasks:      a.tasks,
 		Audit:      monitor.AuditDirReader(a.cfg.AuditDir()),
 		Agents:     a.agents,
 		Dispatcher: disp,
-		Sink:       monitor.NewGHIssueSink(a.cfg.Monitor.IssueLabel, a.cfg.Monitor.IssueRepo),
+		Sink:       routingSink,
 		Emit:       emit,
 		Logger:     a.logger,
 		AllowsProject: func(projectID string) bool {
@@ -201,15 +207,14 @@ func (lm *LifecycleManager) startMonitorService(ctx context.Context, emit func(s
 			if err != nil {
 				return true
 			}
-			// Monitor files anomaly issues on Monitor.IssueRepo (defaults to
-			// Automaat/sybra). Work-typed projects must never surface there —
-			// anomaly bodies carry task IDs and audit excerpts that may
-			// reference work-repo content. See CLAUDE.md — Work-Data
-			// Confidentiality.
-			if p.Type == project.ProjectTypeWork {
+			return a.allowsProjectType(p.Type)
+		},
+		DowngradeLLMForTask: func(taskID string) bool {
+			t, err := a.tasks.Get(taskID)
+			if err != nil {
 				return false
 			}
-			return a.allowsProjectType(p.Type)
+			return a.workScrubContextForTask(t.ProjectID) != nil
 		},
 	})
 	a.monitorSvc = svc

--- a/internal/sybra/monitor_sink.go
+++ b/internal/sybra/monitor_sink.go
@@ -1,0 +1,71 @@
+package sybra
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/Automaat/sybra/internal/monitor"
+	"github.com/Automaat/sybra/internal/scrub"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// monitorRoutingSink wraps a monitor.IssueSink so anomalies on work-typed
+// tasks never reach the public sybra repo. When workCtx returns non-nil for
+// an anomaly's project, the sink scrubs the deterministic body through the
+// project's blocklist and creates a local sybra task tagged sybra-bug,
+// scrubbed instead of delegating to the wrapped sink.
+//
+// Non-work anomalies (and board-wide anomalies with no TaskID) pass through
+// to the inner sink unchanged.
+type monitorRoutingSink struct {
+	inner   monitor.IssueSink
+	tasks   *task.Manager
+	workCtx func(projectID string) *WorkScrubContext
+	logger  *slog.Logger
+}
+
+func newMonitorRoutingSink(inner monitor.IssueSink, tasks *task.Manager, workCtx func(string) *WorkScrubContext, logger *slog.Logger) *monitorRoutingSink {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &monitorRoutingSink{inner: inner, tasks: tasks, workCtx: workCtx, logger: logger}
+}
+
+// Submit implements monitor.IssueSink. Routes to a local scrubbed sybra task
+// for work-typed anomalies, otherwise delegates to the wrapped GH sink.
+func (s *monitorRoutingSink) Submit(ctx context.Context, a monitor.Anomaly, body string) (bool, error) {
+	wctx := s.lookupWorkContext(a.TaskID)
+	if wctx == nil {
+		return s.inner.Submit(ctx, a, body)
+	}
+	title, _ := scrub.Scrub(monitor.IssueTitle(a.Kind, a.Fingerprint), wctx.Blocklist)
+	scrubbedBody, redactions := scrub.Scrub(body, wctx.Blocklist)
+	newTask, err := s.tasks.Create(title, scrubbedBody, task.AgentModeHeadless)
+	if err != nil {
+		s.logger.Error("monitor.routing.local.create", "src_task_id", a.TaskID, "kind", a.Kind, "err", err)
+		return false, err
+	}
+	tags := []string{"sybra-bug", "scrubbed", "monitor:" + string(a.Kind)}
+	if _, err := s.tasks.Update(newTask.ID, task.Update{Tags: &tags}); err != nil {
+		s.logger.Warn("monitor.routing.local.tag", "new_task_id", newTask.ID, "err", err)
+	}
+	s.logger.Info("monitor.routing.local",
+		"kind", a.Kind, "src_task_id", a.TaskID,
+		"new_task_id", newTask.ID, "redactions", redactions)
+	return true, nil
+}
+
+// lookupWorkContext returns a WorkScrubContext if the anomaly's task belongs
+// to a work-typed project. Empty TaskID, missing task, missing project_id,
+// or non-work project all yield nil — anomaly should pass through to the
+// wrapped sink.
+func (s *monitorRoutingSink) lookupWorkContext(taskID string) *WorkScrubContext {
+	if s.workCtx == nil || taskID == "" {
+		return nil
+	}
+	t, err := s.tasks.Get(taskID)
+	if err != nil || t.ProjectID == "" {
+		return nil
+	}
+	return s.workCtx(t.ProjectID)
+}


### PR DESCRIPTION
## Motivation

Sybra is a public personal project, but two auto-sources file artifacts on `Automaat/sybra` for any task — including tasks ingested from work-repo GitHub issues. Their bodies carry external content verbatim, which would leak into the public repo on first `human-required` flip or monitor anomaly.

Earlier draft of this PR blocked work-typed tasks entirely. That kept things safe but lost the diagnostic value of the automations — the user wanted those tasks to land *somewhere*, just not in public.

## Implementation information

Two-layer defense applied to every automation that authors a sybra artifact for a work-typed task:

1. **Semantic ceiling (prompt-level)** — review-agent prompts include explicit redaction rules naming the project's identifiers; the agent is told to describe sybra bugs abstractly without quoting work content.
2. **Regex floor (`internal/scrub`)** — every agent- or detector-authored title/body runs through `scrub.Scrub(text, blocklist)` before persistence. Blocklist derives from the project record (id, owner, repo, URL). Static patterns redact GitHub URLs, Jira-shaped keys, emails. Replacement is `[redacted]`. Static patterns run before blocklist substitution so URLs/emails are redacted as whole tokens.

`App.workScrubContextForTask` centralises the check (nil = file normally; non-nil = scrub + route to local task).

### Filing routes

| Source | Public path (non-work) | Work-typed path |
|--------|------------------------|-----------------|
| Human review (`app_human_review.go`) | GH issue on `Automaat/sybra` | Scrubbed local sybra task tagged `sybra-bug,scrubbed` via `fileLocalScrubbed`; origin task flips to `blocked` with pointer to the local task |
| Monitor anomalies (`monitor_sink.go`) | GH issue on `Monitor.IssueRepo` | Scrubbed local sybra task tagged `sybra-bug,scrubbed,monitor:<kind>` via `monitorRoutingSink` |
| LLM-dispatched anomalies | Agent files its own GH issue | New `monitor.Deps.DowngradeLLMForTask` forces RequiresLLM=false so the anomaly takes the deterministic path → routingSink → local task. No agent invocation, no agent-authored content to leak |

### Tests

- `internal/scrub`: blocklist + static patterns combine, longer entry wins, single-letter prefix not treated as Jira, whitespace-only blocklist ignored.
- `internal/sybra`: `TestWorkScrubContextForTask` covers empty/pet/work/unknown; `TestOnComplete_WorkProject_LocalTaskScrubbed` runs the end-to-end review path with verdict body containing all three leak vectors (blocklist literal, GH URL, Jira key) and asserts none survive in the created local task plus the `sybra-bug` / `scrubbed` / verdict-label tags.

### Alternatives considered

- **Block-only** (earlier draft): simple, but loses the diagnostic — sybra bugs surfaced via work-typed tasks vanish silently.
- **Per-project-type private \`IssueRepo\`**: bigger refactor; punted.
- **Agent-instructed scrub only**: fragile — a single missed instruction leaks.
- **Regex-only scrub**: misses semantic context; combining both is cheap.

CLAUDE.md gains a **Work-Data Confidentiality** section + enforcement table; AGENTS.md surfaces the rule directly.

## Supporting documentation

> Changelog: feat(sybra): scrub + local task for work data