### PR TITLE
feat(project): route pushes to fork remote

### DIFF
--- a/internal/monitor/dispatcher.go
+++ b/internal/monitor/dispatcher.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -110,7 +111,7 @@ func (d *agentDispatcher) Dispatch(_ context.Context, a Anomaly) (string, error)
 		TaskID:                 taskID,
 		Name:                   name,
 		Mode:                   "headless",
-		Prompt:                 DispatchPrompt(a, d.issueRepo),
+		Prompt:                 DispatchPrompt(a, d.issueRepo, project.PushRemote(dir)),
 		AllowedTools:           []string{"Bash", "Read"},
 		Dir:                    dir,
 		Model:                  d.model,

--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -35,10 +35,12 @@ func DeterministicIssueBody(a Anomaly) string {
 // issueRepo is the "owner/name" repository where GitHub issues must be filed;
 // it is injected explicitly so agents are independent of their working
 // directory (which may be a task worktree for an unrelated project).
-func DispatchPrompt(a Anomaly, issueRepo string) string {
+// pushRemote names the git remote agents should push branches to ("fork"
+// when the worktree's repo has a user-fork remote configured, else "origin").
+func DispatchPrompt(a Anomaly, issueRepo, pushRemote string) string {
 	switch a.Kind {
 	case KindPRGap:
-		return prGapPrompt(a)
+		return prGapPrompt(a, pushRemote)
 	case KindStuckHumanBlocked:
 		return stuckPrompt(a, issueRepo)
 	case KindFailureSpike:
@@ -50,9 +52,12 @@ func DispatchPrompt(a Anomaly, issueRepo string) string {
 	}
 }
 
-func prGapPrompt(a Anomaly) string {
+func prGapPrompt(a Anomaly, pushRemote string) string {
 	taskID, _ := a.Evidence["task_id"].(string)
 	title, _ := a.Evidence["title"].(string)
+	if pushRemote == "" {
+		pushRemote = "origin"
+	}
 	return fmt.Sprintf(`You are the sybra monitor PR-gap remediator.
 
 Task: %s — %q
@@ -66,13 +71,14 @@ Run, in order:
    `+"`sybra-cli update %s --status human-required --status-reason \"monitor: in-review with no commits\"`"+`
    then exit.
 3. Otherwise:
-   `+"`git push -u origin HEAD`"+`
+   `+"`git push -u %s HEAD`"+`
    `+"`gh pr create --base main --title %q --body \"<two-sentence summary from the latest commits>\"`"+`
+   When pushing to a fork remote, gh detects the cross-repo head automatically; no extra flags needed.
 4. On success, run `+"`sybra-cli update %s --pr <number> --status-reason \"monitor: created missing PR\"`"+`.
 
 Output exactly one final JSON line:
 {"action":"created"|"escalated"|"failed","prNumber":N,"reason":"..."}`,
-		taskID, title, taskID, title, taskID,
+		taskID, title, taskID, pushRemote, title, taskID,
 	)
 }
 

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -331,9 +331,23 @@ func parseWorktreePorcelain(raw string) []Worktree {
 	return result
 }
 
-// PushUpstream pushes branch to origin with -u to set remote tracking.
+// PushRemote returns the remote that branch pushes should target. If the
+// repository has a remote named "fork" (the user's fork of the upstream,
+// typically configured manually or by `gh repo fork --remote`), returns
+// "fork"; otherwise returns "origin". This lets sybra push agent branches to
+// the fork — and `gh pr create` therefore open cross-repo PRs — without a
+// project-level setting.
+func PushRemote(repoPath string) string {
+	if _, err := executil.Output(repoPath, "git", "config", "--get", "remote.fork.url"); err == nil {
+		return "fork"
+	}
+	return "origin"
+}
+
+// PushUpstream pushes branch to the fork remote if present, else origin,
+// with -u to set remote tracking.
 func PushUpstream(worktreePath, branch string) error {
-	return executil.Run(worktreePath, "git", "push", "-u", "origin", branch)
+	return executil.Run(worktreePath, "git", "push", "-u", PushRemote(worktreePath), branch)
 }
 
 // CurrentBranch returns the checked-out branch name for a worktree.
@@ -345,10 +359,10 @@ func CurrentBranch(worktreePath string) (string, error) {
 	return strings.TrimSpace(branch), nil
 }
 
-// PushForce force-pushes the branch to origin using --force-with-lease.
-// Used after a local rebase to sync the remote without overwriting commits
-// from other authors (--force-with-lease fails if remote has unknown commits).
-// Returns ErrBranchMissing if the local branch ref does not exist.
+// PushForce force-pushes the branch to the fork remote if present, else
+// origin, using --force-with-lease. Used after a local rebase to sync the
+// remote without overwriting commits from other authors. Returns
+// ErrBranchMissing if the local branch ref does not exist.
 func PushForce(worktreePath, branch string) error {
 	if err := executil.Run(worktreePath, "git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch); err != nil {
 		var exitErr *exec.ExitError
@@ -357,7 +371,7 @@ func PushForce(worktreePath, branch string) error {
 		}
 		return err
 	}
-	return executil.Run(worktreePath, "git", "push", "--force-with-lease", "-u", "origin", branch)
+	return executil.Run(worktreePath, "git", "push", "--force-with-lease", "-u", PushRemote(worktreePath), branch)
 }
 
 func RemoveWorktree(barePath, worktreePath string) error {

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -1002,6 +1002,83 @@ func TestCreateWorktree_DuplicatePathRejected(t *testing.T) {
 	}
 }
 
+func TestPushRemote_DefaultOrigin(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	_, wtPath := initWorktree(t)
+	if got := PushRemote(wtPath); got != "origin" {
+		t.Errorf("PushRemote without fork = %q, want %q", got, "origin")
+	}
+}
+
+func TestPushRemote_DetectsFork(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	_, wtPath := initWorktree(t)
+
+	forkBare := filepath.Join(t.TempDir(), "fork.git")
+	if out, err := exec.Command("git", "init", "--bare", forkBare).CombinedOutput(); err != nil {
+		t.Fatalf("init fork bare: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", wtPath, "remote", "add", "fork", forkBare).CombinedOutput(); err != nil {
+		t.Fatalf("add fork remote: %v: %s", err, out)
+	}
+
+	if got := PushRemote(wtPath); got != "fork" {
+		t.Errorf("PushRemote with fork = %q, want %q", got, "fork")
+	}
+}
+
+// TestPushUpstream_RoutesToFork verifies that PushUpstream targets the fork
+// remote when one is configured — this is the core kuma-PR-from-fork fix.
+// Without this routing, sybra's initial branch push lands on the upstream
+// repo and gh pr create then opens a same-repo PR.
+func TestPushUpstream_RoutesToFork(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	_, wtPath := initWorktree(t)
+
+	originBare := filepath.Join(t.TempDir(), "origin.git")
+	if out, err := exec.Command("git", "init", "--bare", originBare).CombinedOutput(); err != nil {
+		t.Fatalf("init origin bare: %v: %s", err, out)
+	}
+	forkBare := filepath.Join(t.TempDir(), "fork.git")
+	if out, err := exec.Command("git", "init", "--bare", forkBare).CombinedOutput(); err != nil {
+		t.Fatalf("init fork bare: %v: %s", err, out)
+	}
+	for _, args := range [][]string{
+		{"remote", "set-url", "origin", originBare},
+		{"remote", "add", "fork", forkBare},
+		{"checkout", "-b", "sybra/route-test"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = wtPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+
+	if err := PushUpstream(wtPath, "sybra/route-test"); err != nil {
+		t.Fatalf("PushUpstream: %v", err)
+	}
+
+	// Branch should exist on fork, not origin.
+	forkOut, _ := exec.Command("git", "-C", forkBare, "branch", "--list", "sybra/route-test").Output()
+	if strings.TrimSpace(string(forkOut)) == "" {
+		t.Error("branch missing on fork after PushUpstream")
+	}
+	originOut, _ := exec.Command("git", "-C", originBare, "branch", "--list", "sybra/route-test").Output()
+	if strings.TrimSpace(string(originOut)) != "" {
+		t.Errorf("branch should not exist on origin; got %q", originOut)
+	}
+}
+
 // TestListWorktrees_OrphanedAdminDir covers the recovery mismatch where a
 // user manually rm -rfs the working tree directory but leaves the
 // `.git/worktrees/<name>/` admin entry. `git worktree list` still reports the


### PR DESCRIPTION
## Motivation

Two kuma tasks opened PRs filed against the upstream repo (`kumahq/kuma`) rather than my fork (`Automaat/kuma`). Sybra's worktree-init push hardcoded `origin`, so the agent branch landed on upstream and `gh pr create` made same-repo PRs.

## Implementation information

- `internal/project/git.go`: new `PushRemote(repoPath)` returns `fork` if that remote is configured on the repo, else `origin`. `PushUpstream` and `PushForce` route through it. No project-model change — auto-detected from existing git config so users who manually added a `fork` remote (or `gh repo fork --remote`) are picked up automatically.
- `internal/monitor/prompts.go` + `dispatcher.go`: `prGapPrompt` now takes the resolved push remote so its `git push -u <remote> HEAD` step matches. Dispatcher computes it from the anomaly's worktree dir.
- Three new tests cover default-to-origin, fork detection, and end-to-end routing (verifies branch lands on fork bare, not origin bare).
- Subsequent agent commits use branch tracking, so they continue pushing to fork; `gh pr create` auto-detects cross-repo head from the fork remote.

Alternative considered: explicit `ForkOwner` field on `Project` + UI control. Rejected — fork remote is already a standard git convention and the user had it manually configured for kuma. Adds no model/UI surface.

## Supporting documentation

The two existing upstream-filed kuma PRs were closed and reopened from fork (`#16550`→`#16551`, `#16549`→`#16552`).

> Changelog: feat(project): route pushes to fork remote