### PR TITLE
fix(monitor): dedup routed work tasks by title

### DIFF
--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -189,7 +189,7 @@ func (lm *LifecycleManager) startMonitorService(ctx context.Context, emit func(s
 	// deterministic path so they hit this sink (and get scrubbed) rather than
 	// being dispatched to an agent that would file an issue itself.
 	innerSink := monitor.NewGHIssueSink(a.cfg.Monitor.IssueLabel, a.cfg.Monitor.IssueRepo)
-	routingSink := newMonitorRoutingSink(innerSink, a.tasks, a.workScrubContextForTask, a.logger)
+	routingSink := newMonitorRoutingSink(innerSink, a.tasks, a.workScrubContextForTask, a.cfg.Monitor.IssueRepo, a.logger)
 	svc := monitor.NewService(monitor.Deps{
 		Cfg:        a.cfg.Monitor,
 		Tasks:      a.tasks,

--- a/internal/sybra/monitor_sink.go
+++ b/internal/sybra/monitor_sink.go
@@ -2,7 +2,9 @@ package sybra
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/Automaat/sybra/internal/monitor"
 	"github.com/Automaat/sybra/internal/scrub"
@@ -17,18 +19,33 @@ import (
 //
 // Non-work anomalies (and board-wide anomalies with no TaskID) pass through
 // to the inner sink unchanged.
+//
+// Dedup: an open local task whose title matches the anomaly's IssueTitle is
+// reused — the scrubbed body is appended as a "re-detected" note and Submit
+// returns (false, nil), mirroring the GH sink's comment-on-hit contract.
+// Terminal tasks (done, cancelled) are ignored so a recurrence after closure
+// opens a fresh task.
 type monitorRoutingSink struct {
-	inner   monitor.IssueSink
-	tasks   *task.Manager
-	workCtx func(projectID string) *WorkScrubContext
-	logger  *slog.Logger
+	inner     monitor.IssueSink
+	tasks     *task.Manager
+	workCtx   func(projectID string) *WorkScrubContext
+	projectID string
+	logger    *slog.Logger
+	now       func() time.Time
 }
 
-func newMonitorRoutingSink(inner monitor.IssueSink, tasks *task.Manager, workCtx func(string) *WorkScrubContext, logger *slog.Logger) *monitorRoutingSink {
+func newMonitorRoutingSink(inner monitor.IssueSink, tasks *task.Manager, workCtx func(string) *WorkScrubContext, projectID string, logger *slog.Logger) *monitorRoutingSink {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &monitorRoutingSink{inner: inner, tasks: tasks, workCtx: workCtx, logger: logger}
+	return &monitorRoutingSink{
+		inner:     inner,
+		tasks:     tasks,
+		workCtx:   workCtx,
+		projectID: projectID,
+		logger:    logger,
+		now:       time.Now,
+	}
 }
 
 // Submit implements monitor.IssueSink. Routes to a local scrubbed sybra task
@@ -40,19 +57,69 @@ func (s *monitorRoutingSink) Submit(ctx context.Context, a monitor.Anomaly, body
 	}
 	title, _ := scrub.Scrub(monitor.IssueTitle(a.Kind, a.Fingerprint), wctx.Blocklist)
 	scrubbedBody, redactions := scrub.Scrub(body, wctx.Blocklist)
+
+	if existing, ok := s.findOpenByTitle(title); ok {
+		appended := appendRedetectedNote(existing.Body, scrubbedBody, s.now())
+		if _, err := s.tasks.Update(existing.ID, task.Update{Body: &appended}); err != nil {
+			s.logger.Warn("monitor.routing.local.append", "task_id", existing.ID, "err", err)
+			return false, err
+		}
+		s.logger.Info("monitor.routing.local.dedup",
+			"kind", a.Kind, "src_task_id", a.TaskID,
+			"task_id", existing.ID, "redactions", redactions)
+		return false, nil
+	}
+
 	newTask, err := s.tasks.Create(title, scrubbedBody, task.AgentModeHeadless)
 	if err != nil {
 		s.logger.Error("monitor.routing.local.create", "src_task_id", a.TaskID, "kind", a.Kind, "err", err)
 		return false, err
 	}
 	tags := []string{"sybra-bug", "scrubbed", "monitor:" + string(a.Kind)}
-	if _, err := s.tasks.Update(newTask.ID, task.Update{Tags: &tags}); err != nil {
+	update := task.Update{Tags: &tags}
+	if s.projectID != "" {
+		pid := s.projectID
+		update.ProjectID = &pid
+	}
+	if _, err := s.tasks.Update(newTask.ID, update); err != nil {
 		s.logger.Warn("monitor.routing.local.tag", "new_task_id", newTask.ID, "err", err)
 	}
 	s.logger.Info("monitor.routing.local",
 		"kind", a.Kind, "src_task_id", a.TaskID,
-		"new_task_id", newTask.ID, "redactions", redactions)
+		"new_task_id", newTask.ID, "project_id", s.projectID, "redactions", redactions)
 	return true, nil
+}
+
+// findOpenByTitle returns the first non-terminal task whose Title equals the
+// fingerprint-stable issue title. Ok is false when no match exists or the
+// task list cannot be read.
+func (s *monitorRoutingSink) findOpenByTitle(title string) (task.Task, bool) {
+	all, err := s.tasks.List()
+	if err != nil {
+		s.logger.Warn("monitor.routing.local.list", "err", err)
+		return task.Task{}, false
+	}
+	for i := range all {
+		t := &all[i]
+		if t.Title != title {
+			continue
+		}
+		if task.IsTerminalStatus(t.Status) {
+			continue
+		}
+		return *t, true
+	}
+	return task.Task{}, false
+}
+
+// appendRedetectedNote appends a timestamped "re-detected" block carrying the
+// latest scrubbed body so each cycle's evidence is preserved without spawning
+// a new task. Idempotent enough: every cycle gets one block; the source task
+// id stays in the original title.
+func appendRedetectedNote(existing, body string, now time.Time) string {
+	stamp := now.UTC().Format(time.RFC3339)
+	note := fmt.Sprintf("\n\n## Re-detected at %s\n%s\n", stamp, body)
+	return existing + note
 }
 
 // lookupWorkContext returns a WorkScrubContext if the anomaly's task belongs

--- a/internal/sybra/monitor_sink_test.go
+++ b/internal/sybra/monitor_sink_test.go
@@ -1,0 +1,222 @@
+package sybra
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/monitor"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+type fakeInnerSink struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (f *fakeInnerSink) Submit(_ context.Context, _ monitor.Anomaly, _ string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return true, nil
+}
+
+func newSinkTestEnv(t *testing.T) (*monitorRoutingSink, *task.Manager, *fakeInnerSink) {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatalf("task.NewStore: %v", err)
+	}
+	tasks := task.NewManager(store, task.EmitterFunc(func(string, any) {}))
+	inner := &fakeInnerSink{}
+	workCtx := func(projectID string) *WorkScrubContext {
+		if projectID == "" {
+			return nil
+		}
+		return &WorkScrubContext{ProjectID: projectID, Blocklist: []string{"kumahq/kuma"}}
+	}
+	sink := newMonitorRoutingSink(inner, tasks, workCtx, "Automaat/sybra", slog.New(slog.DiscardHandler))
+	sink.now = func() time.Time { return time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC) }
+	return sink, tasks, inner
+}
+
+func TestMonitorRoutingSink_WorkAnomaly_CreatesLocalTaskWithProject(t *testing.T) {
+	t.Parallel()
+	sink, tasks, inner := newSinkTestEnv(t)
+	src, err := tasks.Create("source", "src body", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	pid := "kumahq/kuma"
+	if _, err := tasks.Update(src.ID, task.Update{ProjectID: &pid}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	a := monitor.Anomaly{
+		Kind:        monitor.KindStuckHumanBlocked,
+		TaskID:      src.ID,
+		Fingerprint: "stuck_human_blocked:" + src.ID,
+	}
+	created, err := sink.Submit(context.Background(), a, "evidence with kumahq/kuma leak")
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if !created {
+		t.Fatalf("expected created=true on first call")
+	}
+	if inner.calls != 0 {
+		t.Fatalf("inner sink should not be called for work anomaly, got calls=%d", inner.calls)
+	}
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var routed *task.Task
+	for i := range all {
+		if strings.HasPrefix(all[i].Title, "[monitor] stuck_human_blocked") {
+			routed = &all[i]
+			break
+		}
+	}
+	if routed == nil {
+		t.Fatalf("no routed task created; tasks=%+v", all)
+	}
+	if routed.ProjectID != "Automaat/sybra" {
+		t.Errorf("ProjectID = %q, want %q", routed.ProjectID, "Automaat/sybra")
+	}
+	if !slices.Contains(routed.Tags, "sybra-bug") || !slices.Contains(routed.Tags, "scrubbed") ||
+		!slices.Contains(routed.Tags, "monitor:stuck_human_blocked") {
+		t.Errorf("tags missing required values: %v", routed.Tags)
+	}
+	if strings.Contains(routed.Body, "kumahq/kuma") {
+		t.Errorf("body leaked work identifier: %q", routed.Body)
+	}
+}
+
+func TestMonitorRoutingSink_WorkAnomaly_DedupsByTitle(t *testing.T) {
+	t.Parallel()
+	sink, tasks, _ := newSinkTestEnv(t)
+	src, err := tasks.Create("source", "src body", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	pid := "kumahq/kuma"
+	if _, err := tasks.Update(src.ID, task.Update{ProjectID: &pid}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	a := monitor.Anomaly{
+		Kind:        monitor.KindStuckHumanBlocked,
+		TaskID:      src.ID,
+		Fingerprint: "stuck_human_blocked:" + src.ID,
+	}
+	if _, err := sink.Submit(context.Background(), a, "first evidence"); err != nil {
+		t.Fatalf("first Submit: %v", err)
+	}
+	created, err := sink.Submit(context.Background(), a, "second evidence")
+	if err != nil {
+		t.Fatalf("second Submit: %v", err)
+	}
+	if created {
+		t.Fatalf("expected created=false on dedup hit")
+	}
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var routed []task.Task
+	for _, tk := range all {
+		if strings.HasPrefix(tk.Title, "[monitor] stuck_human_blocked") {
+			routed = append(routed, tk)
+		}
+	}
+	if len(routed) != 1 {
+		t.Fatalf("want 1 routed task after dedup, got %d", len(routed))
+	}
+	if !strings.Contains(routed[0].Body, "## Re-detected at 2026-05-11T12:00:00Z") {
+		t.Errorf("body missing re-detected note: %q", routed[0].Body)
+	}
+	if !strings.Contains(routed[0].Body, "second evidence") {
+		t.Errorf("body missing appended evidence: %q", routed[0].Body)
+	}
+}
+
+func TestMonitorRoutingSink_TerminalTaskReopensNew(t *testing.T) {
+	t.Parallel()
+	sink, tasks, _ := newSinkTestEnv(t)
+	src, err := tasks.Create("source", "src body", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	pid := "kumahq/kuma"
+	if _, err := tasks.Update(src.ID, task.Update{ProjectID: &pid}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	a := monitor.Anomaly{
+		Kind:        monitor.KindStuckHumanBlocked,
+		TaskID:      src.ID,
+		Fingerprint: "stuck_human_blocked:" + src.ID,
+	}
+	if _, err := sink.Submit(context.Background(), a, "first"); err != nil {
+		t.Fatalf("first Submit: %v", err)
+	}
+
+	all, _ := tasks.List()
+	for _, tk := range all {
+		if strings.HasPrefix(tk.Title, "[monitor] stuck_human_blocked") {
+			done := task.StatusDone
+			if _, err := tasks.Update(tk.ID, task.Update{Status: &done}); err != nil {
+				t.Fatalf("close task: %v", err)
+			}
+		}
+	}
+
+	created, err := sink.Submit(context.Background(), a, "second")
+	if err != nil {
+		t.Fatalf("second Submit: %v", err)
+	}
+	if !created {
+		t.Fatalf("expected created=true after prior closed")
+	}
+	all, _ = tasks.List()
+	var open int
+	for _, tk := range all {
+		if strings.HasPrefix(tk.Title, "[monitor] stuck_human_blocked") && !task.IsTerminalStatus(tk.Status) {
+			open++
+		}
+	}
+	if open != 1 {
+		t.Fatalf("want exactly 1 open routed task, got %d", open)
+	}
+}
+
+func TestMonitorRoutingSink_NonWorkPassesThrough(t *testing.T) {
+	t.Parallel()
+	sink, tasks, inner := newSinkTestEnv(t)
+	// Source task with no project_id → workCtx returns nil → inner sink path.
+	src, err := tasks.Create("source", "body", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	a := monitor.Anomaly{
+		Kind:        monitor.KindStuckHumanBlocked,
+		TaskID:      src.ID,
+		Fingerprint: "stuck_human_blocked:" + src.ID,
+	}
+	created, err := sink.Submit(context.Background(), a, "body")
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if !created {
+		t.Fatalf("inner returns created=true; got false")
+	}
+	if inner.calls != 1 {
+		t.Fatalf("inner.calls = %d, want 1", inner.calls)
+	}
+}


### PR DESCRIPTION
## Motivation

`monitorRoutingSink.Submit` unconditionally created a new local sybra task every time a work-typed anomaly fired. With a 30-minute issue cooldown and a long-stuck `human-required` task, the inbox accumulated five duplicate `[monitor] stuck_human_blocked: <id>` tasks in under three hours. The GH sink dedups by exact title (`findOpenIssue` → comment on hit); the local routing path had no equivalent.

Routed tasks also never got `project_id` set, so they didn't appear under the registered `Automaat/sybra` project view.

## Implementation information

- `monitor_sink.go`: before `Create`, scan `tasks.List()` for the first non-terminal task whose `Title` matches the scrubbed `IssueTitle(kind, fingerprint)`. On hit, append a timestamped `## Re-detected at <RFC3339>` block with the latest scrubbed body and return `(false, nil)` — mirrors the GH sink's comment-on-hit contract. Terminal statuses (`done`, `cancelled`) are skipped so a recurrence after closure opens fresh.
- On create-path, set `ProjectID = cfg.Monitor.IssueRepo` (defaults to `Automaat/sybra`). Wired through `newMonitorRoutingSink(..., projectID, ...)` from `lifecycle.go`.
- Injectable `now` clock for deterministic test timestamps.

Alternatives considered: matching by tag (`monitor:<kind>`) instead of title — rejected because multiple distinct fingerprints share a kind and would collapse together. Storing fingerprint in task metadata — rejected, too invasive for a leaf sink.

## Supporting documentation

New tests in `monitor_sink_test.go`: create-with-project, dedup-by-title, terminal-task-reopens-new, non-work-passes-through. All existing tests still pass; `golangci-lint run ./...` clean.