### PR TITLE
fix(monitor): start routed tasks

### DIFF
--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -189,7 +189,21 @@ func (lm *LifecycleManager) startMonitorService(ctx context.Context, emit func(s
 	// deterministic path so they hit this sink (and get scrubbed) rather than
 	// being dispatched to an agent that would file an issue itself.
 	innerSink := monitor.NewGHIssueSink(a.cfg.Monitor.IssueLabel, a.cfg.Monitor.IssueRepo)
-	routingSink := newMonitorRoutingSink(innerSink, a.tasks, a.workScrubContextForTask, a.cfg.Monitor.IssueRepo, a.logger)
+	routingSink := newMonitorRoutingSink(innerSink, a.tasks, a.workScrubContextForTask, a.cfg.Monitor.IssueRepo, func(taskID string) {
+		if a.workflowEngine == nil {
+			return
+		}
+		a.wg.Go(func() {
+			dispatched, err := a.workflowEngine.DispatchEvent(taskID, "task.created", nil, nil)
+			if err != nil {
+				a.logger.Error("monitor.routing.workflow.failed", "task_id", taskID, "err", err)
+				return
+			}
+			if dispatched == "" {
+				a.logger.Warn("monitor.routing.workflow.no-match", "task_id", taskID)
+			}
+		})
+	}, a.logger)
 	svc := monitor.NewService(monitor.Deps{
 		Cfg:        a.cfg.Monitor,
 		Tasks:      a.tasks,

--- a/internal/sybra/monitor_sink.go
+++ b/internal/sybra/monitor_sink.go
@@ -26,25 +26,34 @@ import (
 // Terminal tasks (done, cancelled) are ignored so a recurrence after closure
 // opens a fresh task.
 type monitorRoutingSink struct {
-	inner     monitor.IssueSink
-	tasks     *task.Manager
-	workCtx   func(projectID string) *WorkScrubContext
-	projectID string
-	logger    *slog.Logger
-	now       func() time.Time
+	inner           monitor.IssueSink
+	tasks           *task.Manager
+	workCtx         func(projectID string) *WorkScrubContext
+	projectID       string
+	dispatchCreated func(taskID string)
+	logger          *slog.Logger
+	now             func() time.Time
 }
 
-func newMonitorRoutingSink(inner monitor.IssueSink, tasks *task.Manager, workCtx func(string) *WorkScrubContext, projectID string, logger *slog.Logger) *monitorRoutingSink {
+func newMonitorRoutingSink(
+	inner monitor.IssueSink,
+	tasks *task.Manager,
+	workCtx func(string) *WorkScrubContext,
+	projectID string,
+	dispatchCreated func(taskID string),
+	logger *slog.Logger,
+) *monitorRoutingSink {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	return &monitorRoutingSink{
-		inner:     inner,
-		tasks:     tasks,
-		workCtx:   workCtx,
-		projectID: projectID,
-		logger:    logger,
-		now:       time.Now,
+		inner:           inner,
+		tasks:           tasks,
+		workCtx:         workCtx,
+		projectID:       projectID,
+		dispatchCreated: dispatchCreated,
+		logger:          logger,
+		now:             time.Now,
 	}
 }
 
@@ -84,10 +93,18 @@ func (s *monitorRoutingSink) Submit(ctx context.Context, a monitor.Anomaly, body
 	if _, err := s.tasks.Update(newTask.ID, update); err != nil {
 		s.logger.Warn("monitor.routing.local.tag", "new_task_id", newTask.ID, "err", err)
 	}
+	s.dispatchCreatedWorkflow(newTask.ID)
 	s.logger.Info("monitor.routing.local",
 		"kind", a.Kind, "src_task_id", a.TaskID,
 		"new_task_id", newTask.ID, "project_id", s.projectID, "redactions", redactions)
 	return true, nil
+}
+
+func (s *monitorRoutingSink) dispatchCreatedWorkflow(taskID string) {
+	if s.dispatchCreated == nil {
+		return
+	}
+	s.dispatchCreated(taskID)
 }
 
 // findOpenByTitle returns the first non-terminal task whose Title equals the

--- a/internal/sybra/monitor_sink_test.go
+++ b/internal/sybra/monitor_sink_test.go
@@ -40,7 +40,7 @@ func newSinkTestEnv(t *testing.T) (*monitorRoutingSink, *task.Manager, *fakeInne
 		}
 		return &WorkScrubContext{ProjectID: projectID, Blocklist: []string{"kumahq/kuma"}}
 	}
-	sink := newMonitorRoutingSink(inner, tasks, workCtx, "Automaat/sybra", slog.New(slog.DiscardHandler))
+	sink := newMonitorRoutingSink(inner, tasks, workCtx, "Automaat/sybra", nil, slog.New(slog.DiscardHandler))
 	sink.now = func() time.Time { return time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC) }
 	return sink, tasks, inner
 }
@@ -96,6 +96,45 @@ func TestMonitorRoutingSink_WorkAnomaly_CreatesLocalTaskWithProject(t *testing.T
 	}
 	if strings.Contains(routed.Body, "kumahq/kuma") {
 		t.Errorf("body leaked work identifier: %q", routed.Body)
+	}
+}
+
+func TestMonitorRoutingSink_WorkAnomaly_DispatchesCreatedWorkflow(t *testing.T) {
+	t.Parallel()
+	sink, tasks, _ := newSinkTestEnv(t)
+	var dispatched []string
+	sink.dispatchCreated = func(taskID string) {
+		dispatched = append(dispatched, taskID)
+	}
+	src, err := tasks.Create("source", "src body", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	pid := "kumahq/kuma"
+	if _, err := tasks.Update(src.ID, task.Update{ProjectID: &pid}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	a := monitor.Anomaly{
+		Kind:        monitor.KindStuckHumanBlocked,
+		TaskID:      src.ID,
+		Fingerprint: "stuck_human_blocked:" + src.ID,
+	}
+	if _, err := sink.Submit(context.Background(), a, "evidence"); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if len(dispatched) != 1 {
+		t.Fatalf("dispatch calls = %d, want 1", len(dispatched))
+	}
+	routed, err := tasks.Get(dispatched[0])
+	if err != nil {
+		t.Fatalf("Get dispatched task: %v", err)
+	}
+	if routed.ProjectID != "Automaat/sybra" {
+		t.Fatalf("dispatch happened before project route update: project_id=%q", routed.ProjectID)
+	}
+	if !slices.Contains(routed.Tags, "sybra-bug") {
+		t.Fatalf("dispatch happened before tag route update: tags=%v", routed.Tags)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Monitor-created scrubbed tasks were written through task.Manager.Create, bypassing TaskService.CreateTask workflow auto-start. They stayed todo with no workflow or agent runs.

> Changelog: fix(monitor): start routed tasks

## Implementation information

Thread a task-created dispatcher into monitorRoutingSink. After creating a local scrubbed task and applying route metadata, dispatch task.created through the workflow engine. Log dispatch failures without failing task creation.

Added coverage that routed tasks dispatch after project/tags are set.

## Supporting documentation

Task 448f735a investigation.