### PR TITLE
fix(reviews): keep PR data for review tasks

### DIFF
--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -71,6 +71,10 @@ func newReviewHandler(
 }
 
 func (r *ReviewHandler) createReviewTask(pr github.PullRequest, projectID string) {
+	r.createReviewTaskWithTriage(pr, projectID, r.triageReview)
+}
+
+func (r *ReviewHandler) createReviewTaskWithTriage(pr github.PullRequest, projectID string, triage func(task.Task)) {
 	title := "Review: " + pr.Title
 	body := fmt.Sprintf("%s\n\nAuthor: @%s", pr.URL, pr.Author)
 
@@ -81,17 +85,18 @@ func (r *ReviewHandler) createReviewTask(pr github.PullRequest, projectID string
 	}
 
 	tags := []string{"review"}
-	if _, err := r.tasks.Update(t.ID, task.Update{
+	t, err = r.tasks.Update(t.ID, task.Update{
 		Tags:      &tags,
 		ProjectID: task.Ptr(projectID),
 		PRNumber:  task.Ptr(pr.Number),
 		Status:    task.Ptr(task.StatusTodo),
-	}); err != nil {
+	})
+	if err != nil {
 		r.logger.Error("review.update-task", "task_id", t.ID, "err", err)
 		return
 	}
 	r.logger.Info("review.task-created", "task_id", t.ID, "pr", pr.Number, "project", projectID)
-	go r.triageReview(t)
+	go triage(t)
 }
 
 func (r *ReviewHandler) triageReview(t task.Task) {
@@ -173,6 +178,10 @@ func (r *ReviewHandler) startFixReviewAgent(t task.Task) error {
 }
 
 func (r *ReviewHandler) startReviewAgent(t task.Task) error {
+	if t.ProjectID == "" || t.PRNumber == 0 {
+		return fmt.Errorf("task %s has no linked PR", t.ID)
+	}
+
 	dir := config.HomeDir()
 	if t.ProjectID != "" {
 		d, err := r.worktrees.PrepareForReview(t)

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -1,7 +1,12 @@
 package sybra
 
 import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/task"
@@ -169,6 +174,52 @@ func TestReviewTaskMatchers(t *testing.T) {
 	}
 	if got[0].ID != "review" || got[0].ProjectID != "o/r" || got[0].PRNumber != 42 {
 		t.Fatalf("matcher = %+v, want review o/r#42", got[0])
+	}
+}
+
+func TestCreateReviewTaskPassesUpdatedTaskToTriage(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "tasks")
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	got := make(chan task.Task, 1)
+
+	r := &ReviewHandler{
+		DomainHandler: DomainHandler{logger: slog.New(slog.NewTextHandler(io.Discard, nil))},
+		tasks:         tasks,
+	}
+	r.createReviewTaskWithTriage(github.PullRequest{
+		Number: 2708,
+		Title:  "docs: explain precedence",
+		URL:    "https://github.com/kumahq/kuma-website/pull/2708",
+		Author: "slonka",
+	}, "kumahq/kuma-website", func(t task.Task) {
+		got <- t
+	})
+
+	select {
+	case reviewTask := <-got:
+		if reviewTask.ProjectID != "kumahq/kuma-website" {
+			t.Fatalf("ProjectID = %q, want kumahq/kuma-website", reviewTask.ProjectID)
+		}
+		if reviewTask.PRNumber != 2708 {
+			t.Fatalf("PRNumber = %d, want 2708", reviewTask.PRNumber)
+		}
+		if reviewTask.Status != task.StatusTodo {
+			t.Fatalf("Status = %q, want %q", reviewTask.Status, task.StatusTodo)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("triage was not called")
+	}
+
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("created files = %d, want 1", len(files))
 	}
 }
 


### PR DESCRIPTION
## Motivation

Review tasks were created with PR metadata, but review dispatch used the pre-update task object. Agents received github.com//pull/0 and exited before running staff-code-review.

> Changelog: fix(reviews): keep PR data for review tasks

## Implementation information

Use the task returned by Update when handing off to review triage. Add a guard before review-agent startup when project or PR metadata is missing. Add regression coverage for the create-review handoff.

## Supporting documentation

Tested with go test ./...