### PR TITLE
fix(workflow): create prs from fork

### DIFF
--- a/internal/workflow/builtin/simple-task-review.yaml
+++ b/internal/workflow/builtin/simple-task-review.yaml
@@ -180,19 +180,33 @@ steps:
         Create a GitHub PR for the current branch if one does not exist yet.
 
         Steps:
-          1. Check: gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number'
+          1. Set branch/remote variables:
+             BRANCH="$(git branch --show-current)"
+             PUSH_REMOTE="origin"
+             if git config --get remote.fork.url >/dev/null; then PUSH_REMOTE="fork"; fi
+             REMOTE_URL="$(git config --get "remote.$PUSH_REMOTE.url")"
+             HEAD_OWNER="$(gh repo view "$REMOTE_URL" --json owner --jq .owner.login)"
+             HEAD_ARG="$BRANCH"
+             if [ "$PUSH_REMOTE" = "fork" ]; then HEAD_ARG="$HEAD_OWNER:$BRANCH"; fi
+          2. Check: gh pr list --head "$HEAD_ARG" --json number --jq '.[0].number'
              If a PR number is returned, skip creation — the PR already exists.
-          2. If no PR exists, push the branch and create one:
-             git push -u origin HEAD
+          3. If no PR exists, push the branch and create one:
+             git push -u "$PUSH_REMOTE" HEAD:"$BRANCH"
              If push is rejected because the remote has diverged (e.g. after a
              rebase), force-push without asking for confirmation:
-             git push --force-with-lease -u origin HEAD
+             git push --force-with-lease -u "$PUSH_REMOTE" HEAD:"$BRANCH"
              gh pr create{{if ne .Task.ProjectType "pet"}} --draft{{end}} \
+               --head "$HEAD_ARG" \
                --title "<conventional-commit title>" \
                --body "<PR body with ## Motivation and ## Implementation information>"
              {{- if .Task.Issue}}
              Include "Closes {{.Task.Issue}}" in the PR body.
              {{- end}}
+          4. Verify the created PR head matches local HEAD:
+             PR="$(gh pr list --head "$HEAD_ARG" --json number --jq '.[0].number')"
+             LOCAL_SHA="$(git rev-parse HEAD)"
+             PR_SHA="$(gh pr view "$PR" --json headRefOid --jq .headRefOid)"
+             test "$LOCAL_SHA" = "$PR_SHA"
 
         PR title must follow conventional commits format matching the task work.
         PR body must have ## Motivation and ## Implementation information sections.

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -169,6 +170,50 @@ func TestBuiltinDefinitions_Valid(t *testing.T) {
 				t.Errorf("Validate() error for %q: %v", d.ID, err)
 			}
 		})
+	}
+}
+
+func TestBuiltinSimpleTaskReview_CreatePRUsesForkRemote(t *testing.T) {
+	t.Parallel()
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var simple *Definition
+	for i := range defs {
+		if defs[i].ID == "simple-task-review" {
+			simple = &defs[i]
+			break
+		}
+	}
+	if simple == nil {
+		t.Fatal("simple-task-review builtin definition not found")
+	}
+	step := simple.StepByID("create_pr")
+	if step == nil {
+		t.Fatal("create_pr step not found in simple-task-review")
+	}
+	prompt := step.Config.Prompt
+	for _, want := range []string{
+		`remote.fork.url`,
+		`PUSH_REMOTE="fork"`,
+		`REMOTE_URL="$(git config --get "remote.$PUSH_REMOTE.url")"`,
+		`--head "$HEAD_ARG"`,
+		`git push -u "$PUSH_REMOTE" HEAD:"$BRANCH"`,
+		`headRefOid`,
+		`test "$LOCAL_SHA" = "$PR_SHA"`,
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("create_pr prompt missing %q", want)
+		}
+	}
+	for _, forbidden := range []string{
+		"git push -u origin HEAD",
+		"git push --force-with-lease -u origin HEAD",
+	} {
+		if strings.Contains(prompt, forbidden) {
+			t.Fatalf("create_pr prompt still hardcodes %q", forbidden)
+		}
 	}
 }
 


### PR DESCRIPTION
## Motivation

Prevent task PR creation from pushing branches to upstream when a fork remote exists.

## Implementation information

Updated simple-task-review create-pr prompt to detect fork remote, push there, create PR with explicit --head, and verify PR head SHA matches local HEAD.

Added regression coverage so the workflow keeps fork-aware push/head handling and does not return to hardcoded origin pushes.

## Supporting documentation

> Changelog: fix(workflow): create prs from fork