### PR TITLE
fix(worktree): use branch type prefixes

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -314,14 +314,7 @@ func parseWorktreePorcelain(raw string) []Worktree {
 			} else if ref, ok := strings.CutPrefix(line, "branch "); ok {
 				branch, _ := strings.CutPrefix(ref, "refs/heads/")
 				wt.Branch = branch
-				if name, ok := strings.CutPrefix(wt.Branch, "sybra/"); ok {
-					// Task ID is always the last 8 chars (uuid[:8])
-					if len(name) >= 8 {
-						wt.TaskID = name[len(name)-8:]
-					} else {
-						wt.TaskID = name
-					}
-				}
+				wt.TaskID = taskIDFromBranch(wt.Branch)
 			}
 		}
 		if wt.Path != "" {
@@ -329,6 +322,49 @@ func parseWorktreePorcelain(raw string) []Worktree {
 		}
 	}
 	return result
+}
+
+func taskIDFromBranch(branch string) string {
+	if name, ok := strings.CutPrefix(branch, "sybra/"); ok {
+		return trailingTaskID(name)
+	}
+	prefix, name, ok := strings.Cut(branch, "/")
+	if !ok || !isSybraBranchPrefix(prefix) {
+		return ""
+	}
+	return trailingTaskID(name)
+}
+
+func trailingTaskID(name string) string {
+	if len(name) < 8 {
+		return ""
+	}
+	id := name[len(name)-8:]
+	if !isShortTaskID(id) {
+		return ""
+	}
+	return id
+}
+
+func isShortTaskID(id string) bool {
+	if len(id) != 8 {
+		return false
+	}
+	for _, r := range id {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func isSybraBranchPrefix(prefix string) bool {
+	switch prefix {
+	case "feat", "fix", "docs", "style", "refactor", "perf", "test", "build", "ci", "chore", "revert":
+		return true
+	default:
+		return false
+	}
 }
 
 // PushRemote returns the remote that branch pushes should target. If the

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -275,6 +275,16 @@ func TestParseWorktreePorcelain(t *testing.T) {
 			wantLen: 1, wantTaskID: "a1b2c3d4", wantBranch: "sybra/implement-auth-a1b2c3d4",
 		},
 		{
+			name:    "conventional format slug-id",
+			raw:     "worktree /tmp/wt\nHEAD abc1234567890\nbranch refs/heads/feat/implement-auth-a1b2c3d4\n",
+			wantLen: 1, wantTaskID: "a1b2c3d4", wantBranch: "feat/implement-auth-a1b2c3d4",
+		},
+		{
+			name:    "conventional non-sybra branch",
+			raw:     "worktree /tmp/wt\nHEAD abc1234567890\nbranch refs/heads/feat/foo\n",
+			wantLen: 1, wantTaskID: "", wantBranch: "feat/foo",
+		},
+		{
 			name:    "non-synapse branch",
 			raw:     "worktree /tmp/wt\nHEAD abc1234567890\nbranch refs/heads/feature/foo\n",
 			wantLen: 1, wantTaskID: "", wantBranch: "feature/foo",

--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -99,7 +99,7 @@ steps:
 
             DO NOT reference any other task ID, branch, or worktree path in
             your plan. If `git branch -a` reveals sibling branches like
-            `sybra/<other-slug>-<other-id>`, IGNORE them — they belong to
+            `<type>/<other-slug>-<other-id>`, IGNORE them — they belong to
             other concurrent tasks against the same project repo and have
             nothing to do with you.
 
@@ -146,7 +146,7 @@ steps:
 
             DO NOT reference any other task ID, branch, or worktree path in
             your plan. If `git branch -a` reveals sibling branches like
-            `sybra/<other-slug>-<other-id>`, IGNORE them — they belong to
+            `<type>/<other-slug>-<other-id>`, IGNORE them — they belong to
             other concurrent tasks against the same project repo and have
             nothing to do with you.
 

--- a/internal/workflow/engine_validate_plan.go
+++ b/internal/workflow/engine_validate_plan.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 )
 
-// foreignBranchRefRe matches Sybra branch refs of the form
-// `sybra/<slug>-<8hex>`. The trailing 8-hex group is the task ID; if it
-// differs from the current task's ID, the plan is referencing another
-// task's branch — likely cross-task LLM contamination during plan
-// synthesis (see fa6919fc / a9375bad incident).
-var foreignBranchRefRe = regexp.MustCompile(`sybra/[a-z0-9][a-z0-9-]*-([0-9a-f]{8})\b`)
+// foreignBranchRefRe matches Sybra-owned branch refs of the form
+// `<type>/<slug>-<8hex>` or legacy `sybra/<slug>-<8hex>`. The trailing
+// 8-hex group is the task ID; if it differs from the current task's ID,
+// the plan is referencing another task's branch — likely cross-task LLM
+// contamination during plan synthesis (see fa6919fc / a9375bad incident).
+var foreignBranchRefRe = regexp.MustCompile(`(?:sybra|feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)/[a-z0-9][a-z0-9-]*-([0-9a-f]{8})\b`)
 
 // foreignWorktreePathRe matches Sybra worktree paths of the form
 // `worktrees/<slug>-<8hex>`. Same contamination signal as branch refs.

--- a/internal/workflow/engine_validate_plan_test.go
+++ b/internal/workflow/engine_validate_plan_test.go
@@ -14,7 +14,7 @@ func TestExecValidatePlan_CleanPlanPasses(t *testing.T) {
 	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "planning"})
 	engine := newEngineForEval(t, tasks)
 
-	plan := "# Plan\n\nBranch: `sybra/bk-tree-on-per-base-buckets-fa6919fc`\nEdit src/cleaner.rs:60.\n"
+	plan := "# Plan\n\nBranch: `perf/bk-tree-on-per-base-buckets-fa6919fc`\nEdit src/cleaner.rs:60.\n"
 	out, err := engine.execValidatePlan("fa6919fc", newValidatePlanStep(),
 		TaskInfo{ID: "fa6919fc", Plan: plan})
 	if err != nil {
@@ -36,7 +36,7 @@ func TestExecValidatePlan_ForeignBranchRefFlipsHumanRequired(t *testing.T) {
 
 	// Reproduces the fa6919fc → a9375bad incident: plan body cites a sibling
 	// task's worktree path inside the same project.
-	plan := "# Plan\n\nBranch: `sybra/bk-tree-on-per-base-buckets-fa6919fc`\n" +
+	plan := "# Plan\n\nBranch: `perf/bk-tree-on-per-base-buckets-fa6919fc`\n" +
 		"Worktree: /home/sybra/.sybra/worktrees/cross-base-typo-detection-a9375bad\n"
 	out, err := engine.execValidatePlan("fa6919fc", newValidatePlanStep(),
 		TaskInfo{ID: "fa6919fc", Plan: plan})
@@ -65,7 +65,7 @@ func TestExecValidatePlan_ForeignBranchRefAlone(t *testing.T) {
 	engine := newEngineForEval(t, tasks)
 
 	// Branch ref alone (no worktree path) must still trip the validator.
-	plan := "Use branch sybra/cross-base-typo-detection-a9375bad as base."
+	plan := "Use branch fix/cross-base-typo-detection-a9375bad as base."
 	_, err := engine.execValidatePlan("fa6919fc", newValidatePlanStep(),
 		TaskInfo{ID: "fa6919fc", Plan: plan})
 	if err != nil {
@@ -101,7 +101,7 @@ func TestExecValidatePlan_EmptyPlanPasses(t *testing.T) {
 func TestExecValidatePlan_GitShortShaIgnored(t *testing.T) {
 	// 8-hex git short SHAs in code/commit references must NOT be flagged
 	// as foreign task IDs. The validator only matches structural patterns
-	// (sybra/<slug>-<id>, worktrees/<slug>-<id>).
+	// (<type>/<slug>-<id>, legacy sybra/<slug>-<id>, worktrees/<slug>-<id>).
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "fa6919fc", Status: "planning"})
 	engine := newEngineForEval(t, tasks)
@@ -119,7 +119,7 @@ func TestExecValidatePlan_GitShortShaIgnored(t *testing.T) {
 }
 
 func TestCollectForeignTaskIDs_DedupesAndSorts(t *testing.T) {
-	plan := "sybra/foo-aaaaaaaa and again sybra/bar-aaaaaaaa, plus worktrees/baz-bbbbbbbb."
+	plan := "fix/foo-aaaaaaaa and again sybra/bar-aaaaaaaa, plus worktrees/baz-bbbbbbbb."
 	got := collectForeignTaskIDs(plan, "fa6919fc")
 	want := []string{"aaaaaaaa", "bbbbbbbb"}
 	if len(got) != len(want) {
@@ -133,7 +133,7 @@ func TestCollectForeignTaskIDs_DedupesAndSorts(t *testing.T) {
 }
 
 func TestCollectForeignTaskIDs_OwnIDIgnored(t *testing.T) {
-	plan := "sybra/my-slug-fa6919fc and worktrees/my-slug-fa6919fc"
+	plan := "feat/my-slug-fa6919fc and worktrees/my-slug-fa6919fc"
 	got := collectForeignTaskIDs(plan, "fa6919fc")
 	if len(got) != 0 {
 		t.Errorf("got %v, want empty (own ID should be ignored)", got)

--- a/internal/worktree/branch.go
+++ b/internal/worktree/branch.go
@@ -1,0 +1,61 @@
+package worktree
+
+import (
+	"strings"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+var conventionalBranchTypes = map[string]struct{}{
+	"feat":     {},
+	"fix":      {},
+	"docs":     {},
+	"style":    {},
+	"refactor": {},
+	"perf":     {},
+	"test":     {},
+	"build":    {},
+	"ci":       {},
+	"chore":    {},
+	"revert":   {},
+}
+
+func branchNameForTask(t task.Task) string {
+	if t.Branch != "" {
+		return t.Branch
+	}
+	return branchPrefixForTask(t) + "/" + t.DirName()
+}
+
+func branchPrefixForTask(t task.Task) string {
+	if typ, ok := conventionalType(t.Title); ok {
+		return typ
+	}
+	switch t.TaskType {
+	case task.TaskTypeDebug:
+		return "fix"
+	case task.TaskTypeResearch, task.TaskTypeChat:
+		return "chore"
+	default:
+		return "chore"
+	}
+}
+
+func conventionalType(title string) (string, bool) {
+	idx := strings.IndexByte(title, ':')
+	if idx <= 0 {
+		return "", false
+	}
+	head := strings.TrimSpace(title[:idx])
+	head = strings.TrimSuffix(head, "!")
+	if open := strings.IndexByte(head, '('); open >= 0 {
+		if !strings.HasSuffix(head, ")") {
+			return "", false
+		}
+		head = head[:open]
+	}
+	if _, ok := conventionalBranchTypes[head]; !ok {
+		return "", false
+	}
+	return head, true
+}

--- a/internal/worktree/branch_test.go
+++ b/internal/worktree/branch_test.go
@@ -1,0 +1,72 @@
+package worktree
+
+import (
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func TestBranchNameForTask_UsesConventionalTitlePrefix(t *testing.T) {
+	t.Parallel()
+	tk := task.Task{
+		ID:    "fa6919fc",
+		Slug:  "add-auth",
+		Title: "feat(api): add auth endpoint",
+	}
+
+	got := branchNameForTask(tk)
+	want := "feat/add-auth-fa6919fc"
+	if got != want {
+		t.Fatalf("branchNameForTask = %q, want %q", got, want)
+	}
+}
+
+func TestBranchNameForTask_PreservesExistingBranch(t *testing.T) {
+	t.Parallel()
+	tk := task.Task{
+		ID:     "fa6919fc",
+		Slug:   "add-auth",
+		Title:  "feat(api): add auth endpoint",
+		Branch: "sybra/add-auth-fa6919fc",
+	}
+
+	got := branchNameForTask(tk)
+	want := "sybra/add-auth-fa6919fc"
+	if got != want {
+		t.Fatalf("branchNameForTask = %q, want %q", got, want)
+	}
+}
+
+func TestBranchPrefixForTask_Fallbacks(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		task task.Task
+		want string
+	}{
+		{
+			name: "debug",
+			task: task.Task{TaskType: task.TaskTypeDebug, Title: "crash on start"},
+			want: "fix",
+		},
+		{
+			name: "research",
+			task: task.Task{TaskType: task.TaskTypeResearch, Title: "compare providers"},
+			want: "chore",
+		},
+		{
+			name: "normal",
+			task: task.Task{TaskType: task.TaskTypeNormal, Title: "update copy"},
+			want: "chore",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := branchPrefixForTask(tt.task); got != tt.want {
+				t.Fatalf("branchPrefixForTask = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -114,7 +114,7 @@ func callPhase(fn func(string), phase string) {
 }
 
 // PrepareForTask creates (or reuses) a worktree for implementation work.
-// Fetches origin, creates branch sybra/{dirName} off default branch,
+// Fetches origin, creates a conventional-prefixed branch off default branch,
 // pushes upstream, and sets task.Branch.
 // onPhase is an optional callback that receives human-readable phase labels
 // as work progresses; pass nil when phase reporting is not needed.
@@ -140,7 +140,7 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 	}
 
 	wtPath := m.PathFor(t)
-	wtBranch := "sybra/" + t.DirName()
+	wtBranch := branchNameForTask(t)
 	baseRef := worktreeBaseRef(proj.WorktreeBaseRef, branch)
 
 	if _, statErr := os.Stat(wtPath); statErr == nil {
@@ -255,7 +255,7 @@ func (m *Manager) PrepareForChat(t task.Task, onPhase func(string)) (string, err
 	}
 
 	wtPath := m.PathFor(t)
-	wtBranch := "sybra/" + t.DirName()
+	wtBranch := branchNameForTask(t)
 	baseRef := worktreeBaseRef(proj.WorktreeBaseRef, branch)
 
 	if _, statErr := os.Stat(wtPath); statErr == nil {


### PR DESCRIPTION
## Motivation

Sybra-created task branches used the generic sybra/ prefix instead of conventional branch type prefixes.

> Changelog: fix(worktree): use branch type prefixes

## Implementation information

Derive new task branch prefixes from conventional task titles, falling back by task type. Preserve existing task branches for compatibility. Update worktree parsing and plan validation to recognize the new prefixes while keeping legacy sybra/ support.

## Supporting documentation

Tests: go test ./...