### PR TITLE
fix(skills): ship plan skills

### DIFF
--- a/.claude/skills/plan-critic/SKILL.md
+++ b/.claude/skills/plan-critic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan-critic
-description: Critique a Claude implementation plan before approving execution. Spawns parallel persona subagents (Skeptic, Architect, Verifier) to evaluate the plan against the codebase, auto-applies refinements on REFINE verdict, and saves every review to ~/.claude/plan-reviews/ for future reference. Use when a plan has been generated (Plan Mode output, ExitPlanMode, pasted plan text, or plan file path) and needs review before code is written. Triggers on "critique this plan", "review this plan", "is this plan good", "poke holes in this plan", "should I approve this plan", or sharing a plan for evaluation.
+description: Critique an implementation plan before approving execution. Spawns persona subagents when available, falls back to local review, auto-applies refinements on REFINE verdict, and saves every review to ~/.claude/plan-reviews/. Use when a plan has been generated (Plan Mode output, ExitPlanMode, pasted plan text, or plan file path) and needs review before code is written.
 argument-hint: "[plan file path | paste plan inline | --from-conversation]"
 user-invocable: true
 allowed-tools:
@@ -10,12 +10,11 @@ allowed-tools:
   - Bash
   - Edit
   - Write
-  - AskUserQuestion
 ---
 
 # Plan Critic
 
-Critique a Claude implementation plan **before** any code is written. The cost of revising a plan is near-zero; the cost of revising executed code is hours of rework. This skill applies the plan-then-execute discipline rigorously: nothing gets approved until three independent personas have inspected it.
+Critique an implementation plan **before** any code is written. The cost of revising a plan is near-zero; the cost of revising executed code is hours of rework. This skill applies the plan-then-execute discipline rigorously: nothing gets approved until three independent lenses have inspected it.
 
 **Core principle:** A plan that names files generically has not been read. A plan that references `verify_jwt_token` at `auth/middleware.go:42` has been read. The job of this skill is to tell those apart and force the second.
 
@@ -27,7 +26,7 @@ Critique a Claude implementation plan **before** any code is written. The cost o
 | `[paste plan inline]` | positional | Plan text pasted directly in the user's message. Use as-is. |
 | `--from-conversation` | flag | Use the plan most recently produced in the current conversation (e.g., from ExitPlanMode or a planning response). |
 
-If input is ambiguous (multiple candidates, unclear which plan), use AskUserQuestion to disambiguate before proceeding. Present these options:
+If input is ambiguous (multiple candidates, unclear which plan), ask the user to disambiguate before proceeding. Present these options:
 
 - **File path** — the user types a path to a plan markdown file
 - **Paste inline** — the user pastes the plan text in the next message
@@ -59,9 +58,9 @@ Input: A plan touching 14 files across 4 packages with no symbol-level reference
 Triage result: Scope warning (7+ files) AND surface-level reading risk. Recommend splitting into sub-plans before review continues.
 </example>
 
-### Phase 2: Codebase Grounding (single Explore agent, 30-60s)
+### Phase 2: Codebase Grounding (single explorer when available, 30-60s)
 
-Spawn one `Agent` (subagent_type: `Explore`, thoroughness: `medium`) to build a **Grounding Brief**. All three review personas will share this brief — no redundant exploration.
+Spawn one explorer subagent to build a **Grounding Brief** when the runtime supports subagents. In Claude, use `Agent` with an explore/general-purpose subagent. In Codex, use the available subagent tool. If subagents are unavailable, build the brief locally with `Read`, `Grep`, and `Bash`. All three review lenses share this brief — no redundant exploration.
 
 The Grounding agent must:
 
@@ -97,13 +96,13 @@ The Grounding agent must:
 - No tests exist for the package the plan modifies most heavily
 ```
 
-### Phase 3: Persona Review (parallel subagents)
+### Phase 3: Persona Review (parallel subagents when available)
 
 Read [references/personas.md](references/personas.md) in full before spawning Phase 3 agents — it contains the exact instruction blocks for each persona.
 
-Spawn three `Agent` subagents **in parallel** (single message, multiple Agent tool calls) using the prompts in personas.md. Parallelize because the personas are independent perspectives on the same inputs, so sequential spawning wastes wall time without improving quality:
+Spawn three subagents **in parallel** when the runtime supports it, using the prompts in personas.md. Claude uses `Agent`; Codex uses its available subagent tool. If subagents are unavailable, run the three reviews locally as separate sections:
 
-- **Verifier** — Did Claude actually read the code, or skim file names?
+- **Verifier** — Did the planner actually read the code, or skim file names?
 - **Architect** — Is the structure sound? File selection, order, conventions, scope?
 - **Skeptic** — What's missing? Edge cases, failure modes, verification criteria?
 
@@ -198,7 +197,7 @@ Produce the final report in this exact structure:
 
 ## Rejection Rationale
 
-[Only if verdict is REJECT. What's fundamentally wrong and what Claude must do before re-planning.]
+[Only if verdict is REJECT. What's fundamentally wrong and what the planner must do before re-planning.]
 
 ## Refined Plan
 
@@ -214,11 +213,11 @@ Saved to: `~/.claude/plan-reviews/<filename>.md`
 - "Approved — proceed with execution."
 - "Refined — plan file updated in place at `<path>`. Review.": when REFINE + file path
 - "Refined — refined plan in the Refined Plan section above. Copy into your plan source.": when REFINE + inline/from-conversation
-- "Rejected — Claude should read [specific files] and re-plan from scratch."]
+- "Rejected — planner should read [specific files] and re-plan from scratch."]
 ```
 
 <example>
-Plan claims to update `UserStore.Save` callers. Grounding Brief reports `UserStore.Save` not found; closest is `UserRepository.Persist`. Verifier flags surface reading. Verdict: **REJECT**. Next action: Claude must read `store/user.go` and re-plan against the real symbol.
+Plan claims to update `UserStore.Save` callers. Grounding Brief reports `UserStore.Save` not found; closest is `UserRepository.Persist`. Verifier flags surface reading. Verdict: **REJECT**. Next action: planner must read `store/user.go` and re-plan against the real symbol.
 </example>
 
 <example>
@@ -249,7 +248,7 @@ Common failure modes and recovery:
 
 - **Grounding agent times out or returns empty brief.** Re-spawn with a narrower scope (focus on the top 3 files the plan names). If still empty, fall back to running grep directly from the main context for the named symbols and proceed without the full brief — note the degraded confidence in the verdict.
 - **Personas disagree (one APPROVE, one REJECT).** Trust the more conservative verdict. Surface the disagreement explicitly in the Cross-Cutting Issues section and let the user adjudicate.
-- **Plan input is ambiguous or missing.** Use AskUserQuestion with concrete options (file path, paste inline, use last-conversation plan). Do not guess.
+- **Plan input is ambiguous or missing.** Ask with concrete options (file path, paste inline, use last-conversation plan). Do not guess.
 - **Plan references files in a different repo or path the agent can't access.** Stop and ask the user to either provide the files or scope the review to what is reachable.
 - **All three personas return identical findings.** This usually means the plan is so vague that any reviewer surfaces the same gaps — flag as REJECT and request specifics before re-review.
 

--- a/.claude/skills/plan-critic/references/personas.md
+++ b/.claude/skills/plan-critic/references/personas.md
@@ -6,11 +6,11 @@ Full review prompts for the three Phase 3 personas. Spawn each as a parallel `Ag
 
 **Subagent type:** `general-purpose`
 
-**Role:** Did Claude actually read the code, or did it skim file names?
+**Role:** Did the planner actually read the code, or did it skim file names?
 
 **Instructions to pass:**
 
-> You are reviewing a Claude implementation plan with one job: determine whether the plan demonstrates that Claude actually read the relevant code, or whether it is operating on surface-level guesses.
+> You are reviewing an implementation plan with one job: determine whether the plan demonstrates that the planner actually read the relevant code, or whether it is operating on surface-level guesses.
 >
 > **Inputs:** the plan text, the Grounding Brief.
 >
@@ -24,7 +24,7 @@ Full review prompts for the three Phase 3 personas. Spawn each as a parallel `Ag
 > - **Depth score:** Deep / Surface / Shallow
 > - **Evidence of reading:** specific quotes from the plan that prove (or fail to prove) Claude read the code
 > - **Hidden assumptions:** list of unverified assumptions the plan makes
-> - **Required pre-execution reads:** files/functions Claude must read before this plan can be trusted
+> - **Required pre-execution reads:** files/functions the planner must read before this plan can be trusted
 
 ## Persona 2: The Architect
 
@@ -34,7 +34,7 @@ Full review prompts for the three Phase 3 personas. Spawn each as a parallel `Ag
 
 **Instructions to pass:**
 
-> You are reviewing a Claude implementation plan from an architect's perspective. Your job is to evaluate the structural soundness of the plan, not whether Claude read the code (that's the Verifier's job).
+> You are reviewing an implementation plan from an architect's perspective. Your job is to evaluate the structural soundness of the plan, not whether the planner read the code (that's the Verifier's job).
 >
 > **Inputs:** the plan text, the Grounding Brief.
 >
@@ -60,7 +60,7 @@ Full review prompts for the three Phase 3 personas. Spawn each as a parallel `Ag
 
 **Instructions to pass:**
 
-> You are reviewing a Claude implementation plan as an adversarial skeptic. Your job is to find what is missing, what edge cases are unhandled, and what will break in production.
+> You are reviewing an implementation plan as an adversarial skeptic. Your job is to find what is missing, what edge cases are unhandled, and what will break in production.
 >
 > **Inputs:** the plan text, the Grounding Brief.
 >

--- a/.claude/skills/plan-fork/SKILL.md
+++ b/.claude/skills/plan-fork/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: plan-fork
+description: Merge two independent implementation plan drafts into one clean Sybra plan. Use when given two plan file paths and an optional --task/--out.
+allowed-tools: Read, Write, Bash, Skill
+user-invocable: true
+---
+
+# Plan Fork
+
+Synthesize two independent plan drafts into one canonical implementation plan.
+
+You are a convergence step. Do not implement code. Do not modify task status.
+
+## Inputs
+
+Invocation shape:
+
+```bash
+/plan-fork <plan-a-path> <plan-b-path> --task <task-id> --out <output-path>
+$plan-fork <plan-a-path> <plan-b-path> --task <task-id> --out <output-path>
+```
+
+- First two positional arguments are draft markdown files.
+- `--task` is the canonical Sybra task ID.
+- `--out` is where to write the synthesized plan. If omitted, print the plan.
+
+## Process
+
+1. Read both draft files fully.
+2. Verify both drafts target the `--task` ID when a task ID is provided.
+3. Detect contamination:
+   - other Sybra task IDs
+   - unrelated branch names
+   - unrelated worktree paths
+   - stale PR, issue, ticket, or repo references not present in both drafts or task context
+4. Drop contaminated details. Keep only evidence-backed implementation content.
+5. Merge the strongest parts into one plan:
+   - scope and goal
+   - touched files and symbols
+   - ordered implementation steps
+   - verification commands and expected outcomes
+   - risks and rollback notes when relevant
+6. Resolve conflicts explicitly by choosing the simpler, safer path. Do not preserve both alternatives unless the human must decide.
+7. Critique the synthesized draft:
+   - Claude: invoke `/plan-critic` if available.
+   - Codex: invoke `$plan-critic` if available.
+   - If unavailable, do a local critique pass with the same standard.
+   Address concrete defects in the final plan.
+8. Write only the final plan markdown to `--out` when provided.
+
+## Output Format
+
+```markdown
+## Goal
+
+<one concise paragraph>
+
+## Scope
+
+- <included work>
+- <excluded work if important>
+
+## Implementation
+
+1. <step>
+   - Files: `<path>`
+   - Details: <specific symbols/changes>
+   - Verify: `<command>` -> <expected result>
+
+## Risks
+
+- <risk or "None">
+
+## Open Questions
+
+- <question or "None">
+```
+
+## Rules
+
+- No placeholders.
+- No TODOs.
+- No unrelated refactors.
+- No task status changes.
+- No direct `sybra-cli update`.
+- No branch/worktree/task IDs except the canonical `--task` value.

--- a/internal/skills/data/plan-critic.md
+++ b/internal/skills/data/plan-critic.md
@@ -1,0 +1,84 @@
+---
+name: plan-critic
+description: Critique an implementation plan before execution. Works with Claude or Codex; uses subagents when available and falls back to local review.
+argument-hint: "[plan file path | pasted plan text | --from-conversation]"
+user-invocable: true
+allowed-tools: Read, Grep, Bash, Write, Edit, Agent
+---
+
+# Plan Critic
+
+Review an implementation plan before code is written. Reject plans that are vague, ungrounded, risky, or missing verification.
+
+## Inputs
+
+- File path: read the markdown file.
+- Inline text: review the pasted plan.
+- `--from-conversation`: review the latest plan in the conversation.
+
+If the input is ambiguous, ask for the plan source.
+
+## Process
+
+1. Resolve the plan input.
+2. Fast triage:
+   - Is it actually a plan?
+   - Does it name concrete files, symbols, commands, and ordered steps?
+   - Is the scope small enough to execute safely?
+3. Ground the plan in the repo:
+   - Verify named files exist.
+   - Verify named symbols exist.
+   - Find relevant callers and established local patterns.
+   - Check whether verification commands match the project.
+4. Review from three lenses:
+   - Verifier: did the planner read the code?
+   - Architect: is the sequence and boundary choice sound?
+   - Skeptic: what breaks, what is missing, what is untested?
+5. Use subagents in parallel when the runtime supports them. If not, perform the three lenses locally and keep the sections separate.
+6. Decide:
+   - `APPROVE`: plan is executable as-is.
+   - `REFINE`: plan is sound but needs specific edits.
+   - `REJECT`: plan is wrong, vague, or ungrounded.
+7. For `REFINE`, if reviewing a file and edits are allowed, update the plan file directly. Otherwise include a refined plan section.
+8. Save the review when possible:
+
+```bash
+mkdir -p ~/.claude/plan-reviews
+```
+
+Use a timestamped markdown file. If that path is unavailable, print the review only.
+
+## Output Format
+
+```markdown
+# Plan Review: <APPROVE|REFINE|REJECT>
+
+## Verdict
+
+<one concise paragraph>
+
+## Findings
+
+- [severity] <file/symbol/step>: <issue and consequence>
+
+## Required Changes
+
+- <change or "None">
+
+## Refined Plan
+
+<only when verdict is REFINE and the source plan was not edited directly>
+
+## Verification
+
+- <command> -> <expected result>
+```
+
+## Rules
+
+- Findings first.
+- Cite files and symbols precisely.
+- Do not approve plans with hallucinated files or symbols.
+- Do not implement code.
+- Do not change task status.
+- Do not use placeholders.

--- a/internal/skills/data/plan-fork.md
+++ b/internal/skills/data/plan-fork.md
@@ -1,0 +1,86 @@
+---
+name: plan-fork
+description: Merge two independent implementation plan drafts into one clean Sybra plan. Use when given two plan file paths and an optional --task/--out.
+allowed-tools: Read, Write, Bash, Skill
+user-invocable: true
+---
+
+# Plan Fork
+
+Synthesize two independent plan drafts into one canonical implementation plan.
+
+You are a convergence step. Do not implement code. Do not modify task status.
+
+## Inputs
+
+Invocation shape:
+
+```bash
+/plan-fork <plan-a-path> <plan-b-path> --task <task-id> --out <output-path>
+$plan-fork <plan-a-path> <plan-b-path> --task <task-id> --out <output-path>
+```
+
+- First two positional arguments are draft markdown files.
+- `--task` is the canonical Sybra task ID.
+- `--out` is where to write the synthesized plan. If omitted, print the plan.
+
+## Process
+
+1. Read both draft files fully.
+2. Verify both drafts target the `--task` ID when a task ID is provided.
+3. Detect contamination:
+   - other Sybra task IDs
+   - unrelated branch names
+   - unrelated worktree paths
+   - stale PR, issue, ticket, or repo references not present in both drafts or task context
+4. Drop contaminated details. Keep only evidence-backed implementation content.
+5. Merge the strongest parts into one plan:
+   - scope and goal
+   - touched files and symbols
+   - ordered implementation steps
+   - verification commands and expected outcomes
+   - risks and rollback notes when relevant
+6. Resolve conflicts explicitly by choosing the simpler, safer path. Do not preserve both alternatives unless the human must decide.
+7. Critique the synthesized draft:
+   - Claude: invoke `/plan-critic` if available.
+   - Codex: invoke `$plan-critic` if available.
+   - If unavailable, do a local critique pass with the same standard.
+   Address concrete defects in the final plan.
+8. Write only the final plan markdown to `--out` when provided.
+
+## Output Format
+
+```markdown
+## Goal
+
+<one concise paragraph>
+
+## Scope
+
+- <included work>
+- <excluded work if important>
+
+## Implementation
+
+1. <step>
+   - Files: `<path>`
+   - Details: <specific symbols/changes>
+   - Verify: `<command>` -> <expected result>
+
+## Risks
+
+- <risk or "None">
+
+## Open Questions
+
+- <question or "None">
+```
+
+## Rules
+
+- No placeholders.
+- No TODOs.
+- No unrelated refactors.
+- No task status changes.
+- No direct `sybra-cli update`.
+- No branch/worktree/task IDs except the canonical `--task` value.

--- a/internal/skills/data/sybra-plan.md
+++ b/internal/skills/data/sybra-plan.md
@@ -1,7 +1,7 @@
 ---
 name: sybra-plan
 description: Plan Sybra tasks — analyze scope, spawn persona-driven multi-provider planners, synthesize one plan with tradeoffs. Use when asked to plan a task.
-allowed-tools: Bash, Read, Glob, WebFetch
+allowed-tools: Bash, Read, Glob
 user-invocable: true
 ---
 
@@ -26,7 +26,7 @@ sybra-cli --json get <id>
 ### 2. Analyze scope
 
 - Read the task body, understand what's being asked
-- If URLs are referenced, fetch context (GitHub PRs/issues via `gh`, or WebFetch)
+- If URLs are referenced, fetch context with `gh` for GitHub or `curl` for public pages when available.
 - Explore the codebase: find relevant files, understand existing patterns
 - Identify dependencies and potential risks
 - **Triviality check** — if the task is a typo / single-line / mechanical rename / single-file edit with no design choices, skip persona-driven planning and jump straight to Step 5 with the plan written directly.

--- a/internal/skills/data/sybra-test-plan.md
+++ b/internal/skills/data/sybra-test-plan.md
@@ -57,7 +57,7 @@ For trivial changes see the "When not to use" section at the top — produce a o
 
 ### 3. Spawn three personas in parallel
 
-Invoke three `Agent` tool calls in a **single assistant message** — sequential spawning leaks context between personas and erodes the frame diversity that makes this skill work. Use `subagent_type: general-purpose`. Each prompt contains:
+Invoke three subagents in parallel when the runtime supports it — sequential spawning leaks context between personas and erodes the frame diversity that makes this skill work. Claude can use `Agent` with `subagent_type: general-purpose`; Codex can use its available subagent tool. If subagents are unavailable, write three local persona drafts as separate sections. Each prompt contains:
 
 1. The change under test (same for all three)
 2. The relevant domain checklist (same for all three)
@@ -318,7 +318,7 @@ sybra-cli --json update task-typo-7 --status test-plan-review
 - Plan manual verification only; automated tests belong in `test-writer`.
 - Don't execute cases — this skill produces the plan, a human runs it.
 - Stay at the prompt after publishing, so the human can send feedback.
-- Spawn personas in **parallel** (single message, three `Agent` calls). Sequential spawning leaks context and erodes frame diversity.
+- Spawn personas in **parallel** when supported. Sequential spawning leaks context and erodes frame diversity.
 - Skip personas for trivial changes (docs, typos, pure refactor) — publish a one-paragraph smoke plan instead.
 - Surface persona disagreements in Open questions; silently picking a winner hides real design ambiguity.
 - If the change is unidentifiable (no PR, no diff, vague body), ask the human before spawning personas.

--- a/internal/skillsync/syncer.go
+++ b/internal/skillsync/syncer.go
@@ -89,7 +89,16 @@ func (s *Syncer) Run(opts Options) {
 	skillsSrc := filepath.Join(repoDir, ".claude", "skills")
 	s.info("skills.sync.start", "src", repoDir, "dst", opts.PrimaryDst)
 	for _, dst := range dsts {
-		s.SyncDir(skillsSrc, dst)
+		if opts.SkillsFS == nil {
+			s.SyncDir(skillsSrc, dst)
+			continue
+		}
+		cleanDst := filepath.Clean(dst) + string(filepath.Separator)
+		srcNames := s.syncFS(opts.SkillsFS, "data", dst, false)
+		for name := range s.syncDir(skillsSrc, dst, false) {
+			srcNames[name] = struct{}{}
+		}
+		s.removeOrphans(dst, cleanDst, srcNames)
 	}
 
 	if opts.SybraHomeDir != "" {
@@ -143,14 +152,18 @@ func (s *Syncer) SyncFile(src, dst string) {
 // by Claude Code's skill loader, so this layout is mandatory. Orphan skill
 // subdirs (present in dst but absent from src) are removed.
 func (s *Syncer) SyncDir(src, dst string) {
+	s.syncDir(src, dst, true)
+}
+
+func (s *Syncer) syncDir(src, dst string, prune bool) map[string]struct{} {
 	entries, err := os.ReadDir(src)
 	if err != nil {
 		s.debug("sync.skill.skip", "src", src, "reason", err)
-		return
+		return map[string]struct{}{}
 	}
 	if err := os.MkdirAll(dst, 0o755); err != nil {
 		s.error("sync.skill.mkdir", "dst", dst, "err", err)
-		return
+		return map[string]struct{}{}
 	}
 	cleanSrc := filepath.Clean(src) + string(filepath.Separator)
 	cleanDst := filepath.Clean(dst) + string(filepath.Separator)
@@ -203,20 +216,27 @@ func (s *Syncer) SyncDir(src, dst string) {
 		srcNames[name] = struct{}{}
 	}
 
-	s.removeOrphans(dst, cleanDst, srcNames)
+	if prune {
+		s.removeOrphans(dst, cleanDst, srcNames)
+	}
+	return srcNames
 }
 
 // SyncFS mirrors SyncDir but reads source files from an fs.FS. Used for
 // the embedded skill bundle (internal/skills.FS).
 func (s *Syncer) SyncFS(fsys fs.FS, srcDir, dst string) {
+	s.syncFS(fsys, srcDir, dst, true)
+}
+
+func (s *Syncer) syncFS(fsys fs.FS, srcDir, dst string, prune bool) map[string]struct{} {
 	entries, err := fs.ReadDir(fsys, srcDir)
 	if err != nil {
 		s.debug("sync.skill.fs.skip", "src", srcDir, "reason", err)
-		return
+		return map[string]struct{}{}
 	}
 	if err := os.MkdirAll(dst, 0o755); err != nil {
 		s.error("sync.skill.mkdir", "dst", dst, "err", err)
-		return
+		return map[string]struct{}{}
 	}
 	cleanDst := filepath.Clean(dst) + string(filepath.Separator)
 
@@ -253,7 +273,10 @@ func (s *Syncer) SyncFS(fsys fs.FS, srcDir, dst string) {
 		srcNames[name] = struct{}{}
 	}
 
-	s.removeOrphans(dst, cleanDst, srcNames)
+	if prune {
+		s.removeOrphans(dst, cleanDst, srcNames)
+	}
+	return srcNames
 }
 
 // removeOrphans deletes dst/<name>/ subdirs whose names are absent from

--- a/internal/skillsync/syncer_test.go
+++ b/internal/skillsync/syncer_test.go
@@ -5,8 +5,10 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/Automaat/sybra/internal/skills"
 	"github.com/Automaat/sybra/internal/skillsync"
 )
 
@@ -237,7 +239,7 @@ func TestRunPrefersEmbeddedWhenNoGoMod(t *testing.T) {
 	}
 }
 
-func TestRunUsesRepoSourceWhenGoModPresent(t *testing.T) {
+func TestRunMergesRepoAndEmbeddedWhenGoModPresent(t *testing.T) {
 	repoDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(repoDir, "go.mod"), []byte("module x\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -250,6 +252,10 @@ func TestRunUsesRepoSourceWhenGoModPresent(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(skillsSrc, "repo-skill.md"), repoSkill, 0o644); err != nil {
 		t.Fatal(err)
 	}
+	repoOverride := []byte("---\nname: shared\ndescription: repo\n---\n")
+	if err := os.WriteFile(filepath.Join(skillsSrc, "shared.md"), repoOverride, 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	embeddedSrc := filepath.Join(t.TempDir(), "embedded")
 	dataDir := filepath.Join(embeddedSrc, "data")
@@ -257,6 +263,9 @@ func TestRunUsesRepoSourceWhenGoModPresent(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dataDir, "embed-only.md"), []byte("---\nname: embed-only\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "shared.md"), []byte("---\nname: shared\ndescription: embed\n---\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	primaryDst := filepath.Join(t.TempDir(), "app-skills")
@@ -270,8 +279,39 @@ func TestRunUsesRepoSourceWhenGoModPresent(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(primaryDst, "repo-skill", "SKILL.md")); err != nil {
 		t.Errorf("repo skill missing: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(primaryDst, "embed-only")); !os.IsNotExist(err) {
-		t.Errorf("embedded skill should not be written in repo-source mode")
+	if _, err := os.Stat(filepath.Join(primaryDst, "embed-only", "SKILL.md")); err != nil {
+		t.Errorf("embedded skill missing: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(primaryDst, "shared", "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "description: repo") {
+		t.Errorf("repo skill should override embedded duplicate, got %q", got)
+	}
+}
+
+func TestRunShipsWorkflowSkillsFromEmbeddedBundle(t *testing.T) {
+	repoDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repoDir, "go.mod"), []byte("module x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	skillsSrc := filepath.Join(repoDir, ".claude", "skills")
+	if err := os.MkdirAll(skillsSrc, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	primaryDst := filepath.Join(t.TempDir(), "app-skills")
+	newSyncer().Run(skillsync.Options{
+		RepoDir:    repoDir,
+		SkillsFS:   skills.FS,
+		PrimaryDst: primaryDst,
+	})
+
+	for _, name := range []string{"plan-critic", "plan-fork", "sybra-plan", "sybra-test-plan", "sybra-triage"} {
+		if _, err := os.Stat(filepath.Join(primaryDst, name, "SKILL.md")); err != nil {
+			t.Errorf("%s skill missing: %v", name, err)
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/logging"
+	"github.com/Automaat/sybra/internal/skills"
 	"github.com/Automaat/sybra/internal/sybra"
 )
 
@@ -59,6 +60,7 @@ func run() error {
 	v3emit := func(string, any) {}
 
 	sybraApp := sybra.NewApp(logger, levelVar, cfg,
+		sybra.WithSkillsFS(skills.FS),
 		sybra.WithEmitFactory(func(_ context.Context) func(string, any) {
 			return func(event string, data any) { v3emit(event, data) }
 		}),


### PR DESCRIPTION
## Motivation

Plan workflow invokes plan-fork and plan-critic, but shipped skill sync did not guarantee those skills were installed for Claude and Codex agents.

> Changelog: fix(skills): ship plan skills

## Implementation information

Added bundled plan-fork and plan-critic skills, wired embedded skills into desktop startup, and changed skill sync to merge embedded skills with repo-local skills. Repo-local skills override embedded duplicates. Updated skill wording to avoid Claude-only assumptions where Codex runs the same workflow.

## Supporting documentation

Verified with:

- go test . ./internal/skillsync ./internal/agent ./internal/sybra