### PR TITLE
feat(tasks): link issue imports to PRs

### DIFF
--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -65,6 +65,31 @@ const issueSnapshotQuery = `query($assignedQ: String!, $labeledQ: String!) {
   }
 }`
 
+const issueLinkedPRsQuery = `query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      timelineItems(first: 100, itemTypes: CROSS_REFERENCED_EVENT) {
+        nodes {
+          ... on CrossReferencedEvent {
+            willCloseTarget
+            source {
+              ... on PullRequest {
+                number
+                title
+                url
+                state
+                headRefName
+                author { login type: __typename }
+                repository { name nameWithOwner }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`
+
 type gqlIssueResponse struct {
 	Data struct {
 		Search struct {
@@ -114,6 +139,40 @@ type gqlIssue struct {
 			Name string `json:"name"`
 		} `json:"nodes"`
 	} `json:"labels"`
+}
+
+type gqlIssueLinkedPRsResponse struct {
+	Data struct {
+		Repository struct {
+			Issue struct {
+				TimelineItems struct {
+					Nodes []gqlCrossReferencedEvent `json:"nodes"`
+				} `json:"timelineItems"`
+			} `json:"issue"`
+		} `json:"repository"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+type gqlCrossReferencedEvent struct {
+	WillCloseTarget bool `json:"willCloseTarget"`
+	Source          struct {
+		Number      int    `json:"number"`
+		Title       string `json:"title"`
+		URL         string `json:"url"`
+		State       string `json:"state"`
+		HeadRefName string `json:"headRefName"`
+		Author      struct {
+			Login string `json:"login"`
+			Type  string `json:"type"`
+		} `json:"author"`
+		Repository struct {
+			Name          string `json:"name"`
+			NameWithOwner string `json:"nameWithOwner"`
+		} `json:"repository"`
+	} `json:"source"`
 }
 
 type IssueSnapshot struct {
@@ -372,4 +431,58 @@ func fetchIssueWith(e execer, repo string, number int) (Issue, error) {
 		issueCache.Set(key, issue, 2*time.Minute)
 	}
 	return issue, nil
+}
+
+// FetchIssueLinkedPRs returns same-repo open PRs that GitHub links as closing
+// the issue through cross-reference timeline events.
+func FetchIssueLinkedPRs(repo string, issueNumber int) ([]PullRequest, error) {
+	return fetchIssueLinkedPRsWith(defaultExecer, repo, issueNumber)
+}
+
+func fetchIssueLinkedPRsWith(e execer, repo string, issueNumber int) ([]PullRequest, error) {
+	owner, name, ok := strings.Cut(repo, "/")
+	if !ok || owner == "" || name == "" {
+		return nil, fmt.Errorf("invalid repo %q", repo)
+	}
+	httpResp, err := runGHAPIWith(e, "", "graphql",
+		"-f", "query="+issueLinkedPRsQuery,
+		"-f", "owner="+owner,
+		"-f", "name="+name,
+		"-F", fmt.Sprintf("number=%d", issueNumber))
+	if err != nil {
+		return nil, fmt.Errorf("gh api graphql: %s: %w", sanitizeGHOutput(httpResp.body), err)
+	}
+
+	var gqlResp gqlIssueLinkedPRsResponse
+	if err := json.Unmarshal(httpResp.body, &gqlResp); err != nil {
+		return nil, fmt.Errorf("parse graphql response: %w", err)
+	}
+	if len(gqlResp.Errors) > 0 {
+		return nil, fmt.Errorf("graphql: %s", gqlResp.Errors[0].Message)
+	}
+
+	events := gqlResp.Data.Repository.Issue.TimelineItems.Nodes
+	prs := make([]PullRequest, 0, len(events))
+	seen := make(map[int]struct{}, len(events))
+	for i := range events {
+		ev := &events[i]
+		src := &ev.Source
+		if !ev.WillCloseTarget || src.Number == 0 || src.State != "OPEN" || src.Repository.NameWithOwner != repo {
+			continue
+		}
+		if _, ok := seen[src.Number]; ok {
+			continue
+		}
+		seen[src.Number] = struct{}{}
+		prs = append(prs, PullRequest{
+			Number:      src.Number,
+			Title:       src.Title,
+			URL:         src.URL,
+			HeadRefName: src.HeadRefName,
+			Repository:  src.Repository.NameWithOwner,
+			RepoName:    src.Repository.Name,
+			Author:      src.Author.Login,
+		})
+	}
+	return prs, nil
 }

--- a/internal/github/issues_test.go
+++ b/internal/github/issues_test.go
@@ -1,0 +1,105 @@
+package github
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestFetchIssueLinkedPRsWith(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		output  string
+		execErr error
+		want    []PullRequest
+		wantErr string
+	}{
+		{
+			name: "one same-repo open PR",
+			output: linkedPRsResponse(`[
+				{"willCloseTarget":true,"source":{"number":7,"title":"fix bug","url":"https://github.com/owner/repo/pull/7","state":"OPEN","headRefName":"fix/bug","author":{"login":"me","type":"User"},"repository":{"name":"repo","nameWithOwner":"owner/repo"}}}
+			]`),
+			want: []PullRequest{{
+				Number:      7,
+				Title:       "fix bug",
+				URL:         "https://github.com/owner/repo/pull/7",
+				HeadRefName: "fix/bug",
+				Repository:  "owner/repo",
+				RepoName:    "repo",
+				Author:      "me",
+			}},
+		},
+		{
+			name: "cross-repo ignored",
+			output: linkedPRsResponse(`[
+				{"willCloseTarget":true,"source":{"number":8,"title":"x","url":"https://github.com/else/repo/pull/8","state":"OPEN","headRefName":"x","author":{"login":"me","type":"User"},"repository":{"name":"repo","nameWithOwner":"else/repo"}}}
+			]`),
+			want: []PullRequest{},
+		},
+		{
+			name: "closed PR ignored",
+			output: linkedPRsResponse(`[
+				{"willCloseTarget":true,"source":{"number":9,"title":"closed","url":"https://github.com/owner/repo/pull/9","state":"CLOSED","headRefName":"closed","author":{"login":"me","type":"User"},"repository":{"name":"repo","nameWithOwner":"owner/repo"}}}
+			]`),
+			want: []PullRequest{},
+		},
+		{
+			name: "multiple PRs returned",
+			output: linkedPRsResponse(`[
+				{"willCloseTarget":true,"source":{"number":10,"title":"one","url":"https://github.com/owner/repo/pull/10","state":"OPEN","headRefName":"one","author":{"login":"me","type":"User"},"repository":{"name":"repo","nameWithOwner":"owner/repo"}}},
+				{"willCloseTarget":true,"source":{"number":11,"title":"two","url":"https://github.com/owner/repo/pull/11","state":"OPEN","headRefName":"two","author":{"login":"me","type":"User"},"repository":{"name":"repo","nameWithOwner":"owner/repo"}}}
+			]`),
+			want: []PullRequest{
+				{Number: 10, Title: "one", URL: "https://github.com/owner/repo/pull/10", HeadRefName: "one", Repository: "owner/repo", RepoName: "repo", Author: "me"},
+				{Number: 11, Title: "two", URL: "https://github.com/owner/repo/pull/11", HeadRefName: "two", Repository: "owner/repo", RepoName: "repo", Author: "me"},
+			},
+		},
+		{
+			name:    "malformed JSON",
+			output:  "not json",
+			wantErr: "parse graphql response",
+		},
+		{
+			name:    "graphql error",
+			output:  `{"errors":[{"message":"bad query"}]}`,
+			wantErr: "graphql: bad query",
+		},
+		{
+			name:    "exec error",
+			output:  "gh: bad credentials",
+			execErr: fmt.Errorf("exit 1"),
+			wantErr: "gh api graphql",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fe := &fakeExecer{output: []byte(tt.output), err: tt.execErr}
+			got, err := fetchIssueLinkedPRsWith(fe, "owner/repo", 3)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("len = %d, want %d: %+v", len(got), len(tt.want), got)
+			}
+			for i := range got {
+				if !reflect.DeepEqual(got[i], tt.want[i]) {
+					t.Fatalf("pr[%d] = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func linkedPRsResponse(nodes string) string {
+	return `{"data":{"repository":{"issue":{"timelineItems":{"nodes":` + nodes + `}}}}}`
+}

--- a/internal/poll/issues.go
+++ b/internal/poll/issues.go
@@ -29,6 +29,8 @@ type IssuesFetcher struct {
 	fetchAssigned         func() ([]github.Issue, error)
 	fetchLabeled          func(repos []string, label string) ([]github.Issue, error)
 	fetchSnapshot         func(repos []string, label string) (github.IssueSnapshot, error)
+	fetchIssueLinkedPRs   func(repo string, issueNumber int) ([]github.PullRequest, error)
+	viewerLogin           func() string
 	transientFetchFails   int
 	transientLabeledFails int
 }
@@ -47,14 +49,16 @@ func NewIssuesFetcher(
 		allowsType = func(project.ProjectType) bool { return true }
 	}
 	return &IssuesFetcher{
-		tasks:         tasks,
-		projects:      projects,
-		emit:          emit,
-		logger:        logger,
-		allowsType:    allowsType,
-		fetchAssigned: github.FetchAssignedIssues,
-		fetchLabeled:  github.FetchLabeledIssuesForRepos,
-		fetchSnapshot: github.FetchIssueSnapshot,
+		tasks:               tasks,
+		projects:            projects,
+		emit:                emit,
+		logger:              logger,
+		allowsType:          allowsType,
+		fetchAssigned:       github.FetchAssignedIssues,
+		fetchLabeled:        github.FetchLabeledIssuesForRepos,
+		fetchSnapshot:       github.FetchIssueSnapshot,
+		fetchIssueLinkedPRs: github.FetchIssueLinkedPRs,
+		viewerLogin:         github.ViewerLogin,
 	}
 }
 
@@ -217,6 +221,7 @@ func (f *IssuesFetcher) syncIssuesToTasks(issues []github.Issue) {
 				Issue:     task.Ptr(issue.URL),
 				ProjectID: task.Ptr(issue.Repository),
 			}
+			f.enrichLinkedViewerPR(issue, &u)
 			if issue.Body != "" {
 				u.Body = task.Ptr(issue.Body)
 			}
@@ -239,6 +244,7 @@ func (f *IssuesFetcher) syncIssuesToTasks(issues []github.Issue) {
 			Status:    task.Ptr(task.StatusTodo),
 			ProjectID: task.Ptr(issue.Repository),
 		}
+		f.enrichLinkedViewerPR(issue, &u)
 
 		if len(issue.Labels) > 0 {
 			labels := issue.Labels
@@ -251,4 +257,37 @@ func (f *IssuesFetcher) syncIssuesToTasks(issues []github.Issue) {
 
 		f.logger.Info("issue-sync.created", "task_id", t.ID, "issue", issue.URL)
 	}
+}
+
+func (f *IssuesFetcher) enrichLinkedViewerPR(issue *github.Issue, u *task.Update) {
+	if f.fetchIssueLinkedPRs == nil || f.viewerLogin == nil {
+		return
+	}
+	prs, err := f.fetchIssueLinkedPRs(issue.Repository, issue.Number)
+	if err != nil {
+		f.logger.Warn("issue-sync.linked-prs", "issue", issue.URL, "err", err)
+		return
+	}
+	if len(prs) == 0 {
+		return
+	}
+	viewer := f.viewerLogin()
+	if viewer == "" {
+		return
+	}
+	var mine []github.PullRequest
+	for i := range prs {
+		if strings.EqualFold(prs[i].Author, viewer) {
+			mine = append(mine, prs[i])
+		}
+	}
+	if len(mine) != 1 {
+		if len(mine) > 1 {
+			f.logger.Warn("issue-sync.linked-prs.ambiguous", "issue", issue.URL, "count", len(mine))
+		}
+		return
+	}
+	u.PRNumber = task.Ptr(mine[0].Number)
+	u.Branch = task.Ptr(mine[0].HeadRefName)
+	u.Status = task.Ptr(task.StatusInReview)
 }

--- a/internal/poll/issues_test.go
+++ b/internal/poll/issues_test.go
@@ -53,6 +53,8 @@ func newIssuesFetcherForTest(
 	}
 	// Assigned path is exercised separately; default to empty to avoid gh.
 	f.fetchAssigned = func() ([]github.Issue, error) { return nil, nil }
+	f.fetchIssueLinkedPRs = func(string, int) ([]github.PullRequest, error) { return nil, nil }
+	f.viewerLogin = func() string { return "me" }
 
 	return &issuesFetcherEnv{
 		fetcher:     f,
@@ -280,6 +282,127 @@ func TestIssuesFetcher_SyncIssuesToTasks_EnrichesURLTitledTasks(t *testing.T) {
 	}
 }
 
+func TestIssuesFetcher_SyncIssuesToTasks_LinkedViewerPR(t *testing.T) {
+	t.Parallel()
+
+	env := newIssuesFetcherForTest(t, nil, nil)
+	writeProject(t, env.projectsDir, "acme--pet1.yaml", "acme/pet1", "acme", "pet1", project.ProjectTypePet)
+	env.fetcher.fetchIssueLinkedPRs = func(repo string, issueNumber int) ([]github.PullRequest, error) {
+		if repo != "acme/pet1" || issueNumber != 6 {
+			t.Fatalf("linked PR fetch = %s#%d, want acme/pet1#6", repo, issueNumber)
+		}
+		return []github.PullRequest{{
+			Number:      42,
+			HeadRefName: "fix/issue-6",
+			Author:      "me",
+		}}, nil
+	}
+
+	env.fetcher.syncIssuesToTasks([]github.Issue{{
+		Number:     6,
+		Title:      "linked issue",
+		URL:        "https://github.com/acme/pet1/issues/6",
+		Repository: "acme/pet1",
+	}})
+
+	got := onlyTask(t, env.tasks)
+	if got.Status != task.StatusInReview {
+		t.Fatalf("Status = %q, want %q", got.Status, task.StatusInReview)
+	}
+	if got.PRNumber != 42 {
+		t.Fatalf("PRNumber = %d, want 42", got.PRNumber)
+	}
+	if got.Branch != "fix/issue-6" {
+		t.Fatalf("Branch = %q, want fix/issue-6", got.Branch)
+	}
+}
+
+func TestIssuesFetcher_SyncIssuesToTasks_URLTitleLinkedViewerPR(t *testing.T) {
+	t.Parallel()
+
+	env := newIssuesFetcherForTest(t, nil, nil)
+	writeProject(t, env.projectsDir, "acme--pet1.yaml", "acme/pet1", "acme", "pet1", project.ProjectTypePet)
+	stub, err := env.tasks.Create("https://github.com/acme/pet1/issues/7", "", "headless")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	env.fetcher.fetchIssueLinkedPRs = func(string, int) ([]github.PullRequest, error) {
+		return []github.PullRequest{{Number: 43, HeadRefName: "fix/issue-7", Author: "me"}}, nil
+	}
+
+	env.fetcher.syncIssuesToTasks([]github.Issue{{
+		Number:     7,
+		Title:      "real title",
+		URL:        "https://github.com/acme/pet1/issues/7",
+		Repository: "acme/pet1",
+	}})
+
+	tasks, err := env.tasks.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("task count = %d, want 1", len(tasks))
+	}
+	got, err := env.tasks.Get(stub.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Title != "real title" || got.PRNumber != 43 || got.Status != task.StatusInReview {
+		t.Fatalf("task = %+v, want enriched linked viewer PR", got)
+	}
+}
+
+func TestIssuesFetcher_SyncIssuesToTasks_NoLinkedPRKeepsTodo(t *testing.T) {
+	t.Parallel()
+
+	env := newIssuesFetcherForTest(t, nil, nil)
+	writeProject(t, env.projectsDir, "acme--pet1.yaml", "acme/pet1", "acme", "pet1", project.ProjectTypePet)
+
+	env.fetcher.syncIssuesToTasks([]github.Issue{{
+		Number:     8,
+		Title:      "plain issue",
+		URL:        "https://github.com/acme/pet1/issues/8",
+		Repository: "acme/pet1",
+	}})
+
+	got := onlyTask(t, env.tasks)
+	if got.Status != task.StatusTodo {
+		t.Fatalf("Status = %q, want %q", got.Status, task.StatusTodo)
+	}
+	if got.PRNumber != 0 || got.Branch != "" {
+		t.Fatalf("linked PR fields = %d/%q, want empty", got.PRNumber, got.Branch)
+	}
+}
+
+func TestIssuesFetcher_SyncIssuesToTasks_AmbiguousViewerPRsKeepTodo(t *testing.T) {
+	t.Parallel()
+
+	env := newIssuesFetcherForTest(t, nil, nil)
+	writeProject(t, env.projectsDir, "acme--pet1.yaml", "acme/pet1", "acme", "pet1", project.ProjectTypePet)
+	env.fetcher.fetchIssueLinkedPRs = func(string, int) ([]github.PullRequest, error) {
+		return []github.PullRequest{
+			{Number: 44, HeadRefName: "one", Author: "me"},
+			{Number: 45, HeadRefName: "two", Author: "me"},
+		}, nil
+	}
+
+	env.fetcher.syncIssuesToTasks([]github.Issue{{
+		Number:     9,
+		Title:      "ambiguous issue",
+		URL:        "https://github.com/acme/pet1/issues/9",
+		Repository: "acme/pet1",
+	}})
+
+	got := onlyTask(t, env.tasks)
+	if got.Status != task.StatusTodo {
+		t.Fatalf("Status = %q, want %q", got.Status, task.StatusTodo)
+	}
+	if got.PRNumber != 0 || got.Branch != "" {
+		t.Fatalf("linked PR fields = %d/%q, want empty", got.PRNumber, got.Branch)
+	}
+}
+
 // TestIssuesFetcher_CrossMachineRouting_PetAndWorkSplit verifies the
 // end-to-end routing story: two machines (pet-only and work-only) point at
 // the same shared project universe, and each machine's fetcher only creates
@@ -337,6 +460,18 @@ func taskIssueURLs(t *testing.T, tm *task.Manager) []string {
 		}
 	}
 	return out
+}
+
+func onlyTask(t *testing.T, tm *task.Manager) task.Task {
+	t.Helper()
+	tasks, err := tm.List()
+	if err != nil {
+		t.Fatalf("tasks.List: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("task count = %d, want 1", len(tasks))
+	}
+	return tasks[0]
 }
 
 func assertStringSetEqual(t *testing.T, got, want []string) {

--- a/internal/sybra/svc_planning_test.go
+++ b/internal/sybra/svc_planning_test.go
@@ -2,6 +2,7 @@ package sybra
 
 import (
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -171,21 +172,20 @@ func TestTaskService_CreateTask_AutoStartsWorkflow(t *testing.T) {
 }
 
 func TestTaskService_UpdateTask_CleansWorktreeOnDone(t *testing.T) {
-	svc, _ := setupTaskService(t)
+	a := setupApp(t)
+	var wg sync.WaitGroup
+	svc := &TaskService{
+		tasks:     a.tasks,
+		agents:    a.agents,
+		worktrees: a.worktrees,
+		wg:        &wg,
+		logger:    a.logger,
+	}
 
 	created, err := svc.CreateTask("cleanup task", "", "headless")
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	// CreateTask auto-dispatches the task.created workflow in a goroutine,
-	// which briefly registers a triage agent that fails (no real `claude`
-	// binary on PATH in unit tests). UpdateTask's status guard refuses
-	// "done" while HasRunningAgentForTask is true, so wait for the agent
-	// goroutine to finish cleanup before exercising the guard. Without
-	// this, the test races the agent.Manager cleanup goroutine and flakes
-	// under CI load.
-	waitForNoAgent(t, svc, created.ID, 5*time.Second)
 
 	updated, err := svc.UpdateTask(created.ID, map[string]any{"status": "done"})
 	if err != nil {
@@ -194,24 +194,6 @@ func TestTaskService_UpdateTask_CleansWorktreeOnDone(t *testing.T) {
 	if updated.Status != task.StatusDone {
 		t.Fatalf("expected done, got %q", updated.Status)
 	}
-}
-
-// waitForNoAgent polls until no live agent is registered for the task or
-// the deadline expires. Use after CreateTask in tests that exercise
-// status-change guards: setupTaskService loads builtin workflows whose
-// task.created trigger spawns an async triage agent that fails fast (no
-// real provider on PATH). The race window between agent registration and
-// markAgentDone is what flakes under CI load.
-func waitForNoAgent(t *testing.T, svc *TaskService, taskID string, timeout time.Duration) {
-	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		if !svc.agents.HasRunningAgentForTask(taskID) {
-			return
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	t.Fatalf("timeout waiting for agent cleanup on task %s", taskID)
 }
 
 // --- assembleFeedback: merges free text + unresolved inline comments ---

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -19,14 +19,18 @@ import (
 
 // TaskService exposes task CRUD operations as Wails-bound methods.
 type TaskService struct {
-	tasks          *task.Manager
-	agents         *agent.Manager
-	workflowEngine *workflow.Engine
-	worktrees      *worktree.Manager
-	sandboxes      *sandbox.Manager
-	wg             *sync.WaitGroup
-	logger         *slog.Logger
-	audit          *audit.Logger
+	tasks               *task.Manager
+	agents              *agent.Manager
+	workflowEngine      *workflow.Engine
+	worktrees           *worktree.Manager
+	sandboxes           *sandbox.Manager
+	wg                  *sync.WaitGroup
+	logger              *slog.Logger
+	audit               *audit.Logger
+	fetchPR             func(repo string, number int) (github.PullRequest, error)
+	fetchIssue          func(repo string, number int) (github.Issue, error)
+	fetchIssueLinkedPRs func(repo string, issueNumber int) ([]github.PullRequest, error)
+	viewerLogin         func() string
 }
 
 // ListTasks returns all tasks from the store, excluding ephemeral chat tasks.
@@ -58,12 +62,14 @@ func (s *TaskService) CreateTask(title, body, mode string) (task.Task, error) {
 	if err != nil {
 		return t, err
 	}
+	isIssueURL := false
 	// Enrich from GitHub PR URL if title looks like one.
 	if repo, number := github.ParsePRURL(title); repo != "" {
 		s.wg.Go(func() {
 			s.enrichFromPR(t.ID, repo, number)
 		})
 	} else if repo, number := github.ParseIssueURL(title); repo != "" {
+		isIssueURL = true
 		// Enrich from GitHub issue URL if title looks like one.
 		s.wg.Go(func() {
 			s.enrichFromIssue(t.ID, repo, number)
@@ -77,18 +83,25 @@ func (s *TaskService) CreateTask(title, body, mode string) (task.Task, error) {
 		})
 	}
 	// Match and start a workflow for the new task.
-	if s.workflowEngine != nil && t.Status == task.StatusTodo {
-		info := taskToInfo(t)
-		if def := s.workflowEngine.MatchWorkflow(info, "task.created"); def != nil {
-			s.logger.Info("workflow.auto-start", "task_id", t.ID, "workflow", def.ID)
-			s.wg.Go(func() {
-				if wfErr := s.workflowEngine.StartWorkflow(t.ID, def.ID); wfErr != nil {
-					s.logger.Error("workflow.auto-start.failed", "task_id", t.ID, "err", wfErr)
-				}
-			})
-		}
+	if !isIssueURL {
+		s.startCreatedWorkflow(t)
 	}
 	return t, nil
+}
+
+func (s *TaskService) startCreatedWorkflow(t task.Task) {
+	if s.workflowEngine == nil || t.Status != task.StatusTodo {
+		return
+	}
+	info := taskToInfo(t)
+	if def := s.workflowEngine.MatchWorkflow(info, "task.created"); def != nil {
+		s.logger.Info("workflow.auto-start", "task_id", t.ID, "workflow", def.ID)
+		s.wg.Go(func() {
+			if wfErr := s.workflowEngine.StartWorkflow(t.ID, def.ID); wfErr != nil {
+				s.logger.Error("workflow.auto-start.failed", "task_id", t.ID, "err", wfErr)
+			}
+		})
+	}
 }
 
 // UpdateTask applies field updates to a task. The workflow engine drives
@@ -200,12 +213,12 @@ func (s *TaskService) DeleteTask(id string) error {
 // If the PR was authored by the current viewer, moves to in-review for PR monitoring.
 // Otherwise, starts a headless review agent with /staff-code-review.
 func (s *TaskService) enrichFromPR(taskID, repo string, number int) {
-	pr, err := github.FetchPR(repo, number)
+	pr, err := s.fetchPRFunc()(repo, number)
 	if err != nil {
 		s.logger.Error("enrich-pr.fetch", "task_id", taskID, "repo", repo, "number", number, "err", err)
 		return
 	}
-	viewer := github.ViewerLogin()
+	viewer := s.viewerLoginFunc()()
 
 	slug := task.Slugify(pr.Title)
 	u := task.Update{
@@ -294,7 +307,7 @@ func (s *TaskService) startPRReviewAgent(t task.Task) error {
 
 // enrichFromIssue fetches a GitHub issue and updates the task with real title/body.
 func (s *TaskService) enrichFromIssue(taskID, repo string, number int) {
-	issue, err := github.FetchIssue(repo, number)
+	issue, err := s.fetchIssueFunc()(repo, number)
 	if err != nil {
 		s.logger.Error("enrich-issue.fetch", "task_id", taskID, "repo", repo, "number", number, "err", err)
 		return
@@ -313,9 +326,84 @@ func (s *TaskService) enrichFromIssue(taskID, repo string, number int) {
 		labels := issue.Labels
 		u.Tags = &labels
 	}
-	if _, err := s.tasks.Update(taskID, u); err != nil {
+	linkedPRs, linkedErr := s.fetchIssueLinkedPRsFunc()(repo, number)
+	if linkedErr != nil {
+		s.logger.Warn("enrich-issue.linked-prs", "task_id", taskID, "repo", repo, "number", number, "err", linkedErr)
+	} else if linked, ok := s.singleViewerLinkedPR(linkedPRs); ok {
+		u.PRNumber = task.Ptr(linked.Number)
+		u.Branch = task.Ptr(linked.HeadRefName)
+		u.Status = task.Ptr(task.StatusInReview)
+	} else if len(linkedPRs) > 0 {
+		if viewerPRs := s.viewerLinkedPRCount(linkedPRs); viewerPRs > 1 {
+			s.logger.Warn("enrich-issue.linked-prs.ambiguous", "task_id", taskID, "count", viewerPRs)
+		}
+	}
+	updated, err := s.tasks.Update(taskID, u)
+	if err != nil {
 		s.logger.Error("enrich-issue.update", "task_id", taskID, "err", err)
 		return
 	}
+	if linkedErr == nil && len(linkedPRs) == 0 {
+		s.startCreatedWorkflow(updated)
+	}
 	s.logger.Info("enrich-issue.done", "task_id", taskID, "title", issue.Title)
+}
+
+func (s *TaskService) fetchPRFunc() func(string, int) (github.PullRequest, error) {
+	if s.fetchPR != nil {
+		return s.fetchPR
+	}
+	return github.FetchPR
+}
+
+func (s *TaskService) fetchIssueFunc() func(string, int) (github.Issue, error) {
+	if s.fetchIssue != nil {
+		return s.fetchIssue
+	}
+	return github.FetchIssue
+}
+
+func (s *TaskService) fetchIssueLinkedPRsFunc() func(string, int) ([]github.PullRequest, error) {
+	if s.fetchIssueLinkedPRs != nil {
+		return s.fetchIssueLinkedPRs
+	}
+	return github.FetchIssueLinkedPRs
+}
+
+func (s *TaskService) viewerLoginFunc() func() string {
+	if s.viewerLogin != nil {
+		return s.viewerLogin
+	}
+	return github.ViewerLogin
+}
+
+func (s *TaskService) singleViewerLinkedPR(prs []github.PullRequest) (github.PullRequest, bool) {
+	viewer := s.viewerLoginFunc()()
+	if viewer == "" {
+		return github.PullRequest{}, false
+	}
+	var mine []github.PullRequest
+	for i := range prs {
+		if strings.EqualFold(prs[i].Author, viewer) {
+			mine = append(mine, prs[i])
+		}
+	}
+	if len(mine) != 1 {
+		return github.PullRequest{}, false
+	}
+	return mine[0], true
+}
+
+func (s *TaskService) viewerLinkedPRCount(prs []github.PullRequest) int {
+	viewer := s.viewerLoginFunc()()
+	if viewer == "" {
+		return 0
+	}
+	var count int
+	for i := range prs {
+		if strings.EqualFold(prs[i].Author, viewer) {
+			count++
+		}
+	}
+	return count
 }

--- a/internal/sybra/svc_tasks_test.go
+++ b/internal/sybra/svc_tasks_test.go
@@ -1,0 +1,101 @@
+package sybra
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func TestTaskService_CreateTask_IssueURLWaitsForEnrichment(t *testing.T) {
+	svc, _ := setupTaskService(t)
+
+	fetchEntered := make(chan struct{})
+	releaseFetch := make(chan struct{})
+	svc.fetchIssue = func(repo string, number int) (github.Issue, error) {
+		if repo != "owner/repo" || number != 12 {
+			t.Fatalf("fetchIssue = %s#%d, want owner/repo#12", repo, number)
+		}
+		close(fetchEntered)
+		<-releaseFetch
+		return github.Issue{
+			Number:     12,
+			Title:      "real issue",
+			URL:        "https://github.com/owner/repo/issues/12",
+			Repository: "owner/repo",
+		}, nil
+	}
+	svc.fetchIssueLinkedPRs = func(string, int) ([]github.PullRequest, error) {
+		return []github.PullRequest{{
+			Number:      34,
+			HeadRefName: "fix/issue-12",
+			Author:      "me",
+		}}, nil
+	}
+	svc.viewerLogin = func() string { return "me" }
+
+	created, err := svc.CreateTask("https://github.com/owner/repo/issues/12", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-fetchEntered:
+	case <-time.After(time.Second):
+		t.Fatal("fetchIssue was not called")
+	}
+
+	got, err := svc.GetTask(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow != nil {
+		t.Fatalf("workflow = %+v, want nil before issue enrichment", got.Workflow)
+	}
+
+	close(releaseFetch)
+	svc.wg.Wait()
+
+	got, err = svc.GetTask(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusInReview {
+		t.Fatalf("Status = %q, want %q", got.Status, task.StatusInReview)
+	}
+	if got.PRNumber != 34 || got.Branch != "fix/issue-12" {
+		t.Fatalf("linked PR = %d/%q, want 34/fix/issue-12", got.PRNumber, got.Branch)
+	}
+	if got.Workflow != nil {
+		t.Fatalf("workflow = %+v, want nil for linked viewer PR", got.Workflow)
+	}
+}
+
+func TestTaskService_CreateTask_IssueURLNoPRStartsWorkflowAfterEnrichment(t *testing.T) {
+	svc, _ := setupTaskService(t)
+	svc.fetchIssue = func(string, int) (github.Issue, error) {
+		return github.Issue{
+			Number:     13,
+			Title:      "plain issue",
+			URL:        "https://github.com/owner/repo/issues/13",
+			Repository: "owner/repo",
+		}, nil
+	}
+	svc.fetchIssueLinkedPRs = func(string, int) ([]github.PullRequest, error) { return nil, nil }
+	svc.viewerLogin = func() string { return "me" }
+
+	created, err := svc.CreateTask("https://github.com/owner/repo/issues/13", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.wg.Wait()
+
+	got := waitForWorkflow(t, svc, created.ID)
+	if got.Title != "plain issue" {
+		t.Fatalf("Title = %q, want plain issue", got.Title)
+	}
+	if got.Status != task.StatusTodo && got.Status != task.StatusPlanning && got.Status != task.StatusInProgress {
+		t.Fatalf("Status = %q, want workflow-owned issue status", got.Status)
+	}
+}


### PR DESCRIPTION
## Motivation

Issue imports that already have one open viewer-authored PR should enter PR monitoring directly.

> Changelog: feat(tasks): link issue imports to PRs

## Implementation information

Adds linked PR lookup via GitHub GraphQL cross-reference timeline events. Issue import and manual issue URL creation now attach a single viewer-authored PR and set the task to in-review. Manual issue URLs defer workflow start until issue enrichment decides whether normal task flow is needed.

## Supporting documentation

None.