### PR TITLE
feat(gui): show review task state

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/github/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/github/models.ts
@@ -347,6 +347,7 @@ export class RenovatePR {
 export class ReviewSummary {
     "createdByMe": PullRequest[];
     "reviewRequested": PullRequest[];
+    "reviewedByMe": PullRequest[];
 
     /** Creates a new ReviewSummary instance. */
     constructor($$source: Partial<ReviewSummary> = {}) {
@@ -355,6 +356,9 @@ export class ReviewSummary {
         }
         if (!("reviewRequested" in $$source)) {
             this["reviewRequested"] = [];
+        }
+        if (!("reviewedByMe" in $$source)) {
+            this["reviewedByMe"] = [];
         }
 
         Object.assign(this, $$source);
@@ -366,12 +370,16 @@ export class ReviewSummary {
     static createFrom($$source: any = {}): ReviewSummary {
         const $$createField0_0 = $$createType4;
         const $$createField1_0 = $$createType4;
+        const $$createField2_0 = $$createType4;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("createdByMe" in $$parsedSource) {
             $$parsedSource["createdByMe"] = $$createField0_0($$parsedSource["createdByMe"]);
         }
         if ("reviewRequested" in $$parsedSource) {
             $$parsedSource["reviewRequested"] = $$createField1_0($$parsedSource["reviewRequested"]);
+        }
+        if ("reviewedByMe" in $$parsedSource) {
+            $$parsedSource["reviewedByMe"] = $$createField2_0($$parsedSource["reviewedByMe"]);
         }
         return new ReviewSummary($$parsedSource as Partial<ReviewSummary>);
     }

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -65,6 +65,7 @@
 
   const linkedPRs = $derived(reviewStore.byTask(t))
   const topPR = $derived(linkedPRs.length > 0 ? linkedPRs[0] : null)
+  const isReviewTask = $derived(t.tags?.includes('review') ?? false)
 
   function priorityMeta(p: string | undefined) {
     return PRIORITY_OPTIONS.find(o => o.value === (p ?? '')) ?? PRIORITY_OPTIONS[0]
@@ -188,7 +189,19 @@
       </span>
     {/if}
 
-    {#if topPR}
+    {#if topPR && isReviewTask}
+      {#if topPR.viewerHasApproved}
+        <span class="inline-flex items-center gap-1 rounded bg-success-500/15 px-1.5 py-0.5 font-medium text-success-700 dark:text-success-400" title="Approved; waiting for PR to merge">
+          <GitPullRequest size={12} />
+          #{topPR.number} Approved, waiting merge
+        </span>
+      {:else}
+        <span class="inline-flex items-center gap-1 rounded bg-warning-500/15 px-1.5 py-0.5 font-medium text-warning-700 dark:text-warning-400" title="Review requested">
+          <GitPullRequest size={12} />
+          #{topPR.number} Review needed
+        </span>
+      {/if}
+    {:else if topPR}
       <span class="inline-flex items-center gap-1 rounded bg-warning-500/15 px-1.5 py-0.5 font-medium text-warning-700 dark:text-warning-400" title={topPR.title}>
         <GitPullRequest size={12} />
         #{topPR.number}

--- a/frontend/src/components/TaskCard.svelte.test.ts
+++ b/frontend/src/components/TaskCard.svelte.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/svelte'
 import TaskCard from './TaskCard.svelte'
 import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
+import { PullRequest } from '../../bindings/github.com/Automaat/sybra/internal/github/models.js'
 
 vi.mock('../stores/notifications.svelte.js', () => ({
   notificationStore: {
@@ -10,6 +11,7 @@ vi.mock('../stores/notifications.svelte.js', () => ({
 }))
 
 const { notificationStore } = await import('../stores/notifications.svelte.js')
+const { reviewStore } = await import('../stores/reviews.svelte.js')
 
 const mockTask = {
   id: 'task-1',
@@ -39,7 +41,35 @@ const mockTask = {
   convertValues: () => {},
 } as unknown as Task
 
+function makePR(overrides: Record<string, unknown> = {}) {
+  return PullRequest.createFrom({
+    number: 42,
+    title: 'Review PR',
+    url: 'https://github.com/owner/repo/pull/42',
+    repository: 'owner/repo',
+    repoName: 'repo',
+    author: 'peer',
+    isDraft: false,
+    labels: [],
+    headRefName: '',
+    ciStatus: '',
+    reviewDecision: '',
+    mergeable: '',
+    unresolvedCount: 0,
+    viewerHasApproved: false,
+    createdAt: '2026-04-01T00:00:00Z',
+    updatedAt: '2026-04-01T00:00:00Z',
+    ...overrides,
+  })
+}
+
 describe('TaskCard', () => {
+  beforeEach(() => {
+    reviewStore.createdByMe = []
+    reviewStore.reviewRequested = []
+    reviewStore.reviewedByMe = []
+  })
+
   afterEach(() => {
     cleanup()
   })
@@ -118,6 +148,30 @@ describe('TaskCard', () => {
   it('does not show Needs Review badge for other statuses', () => {
     render(TaskCard, { props: { task: mockTask, onclick: () => {} } })
     expect(screen.queryByText('Needs Review')).toBeNull()
+  })
+
+  it('shows review-needed badge for review-requested PR tasks', () => {
+    reviewStore.reviewRequested = [makePR()]
+    render(TaskCard, {
+      props: {
+        task: { ...mockTask, tags: ['review'], projectId: 'owner/repo', prNumber: 42 } as Task,
+        onclick: () => {},
+      },
+    })
+
+    expect(screen.getByText(/Review needed/)).toBeDefined()
+  })
+
+  it('shows approved waiting-merge badge for approved review tasks', () => {
+    reviewStore.reviewedByMe = [makePR({ viewerHasApproved: true })]
+    render(TaskCard, {
+      props: {
+        task: { ...mockTask, tags: ['review'], projectId: 'owner/repo', prNumber: 42 } as Task,
+        onclick: () => {},
+      },
+    })
+
+    expect(screen.getByText(/Approved, waiting merge/)).toBeDefined()
   })
 
   describe('timeAgo', () => {

--- a/frontend/src/stores/reviews.svelte.test.ts
+++ b/frontend/src/stores/reviews.svelte.test.ts
@@ -43,6 +43,7 @@ describe('ReviewStore', () => {
     eventCallbacks = {}
     reviewStore.createdByMe = []
     reviewStore.reviewRequested = []
+    reviewStore.reviewedByMe = []
     reviewStore.error = ''
     reviewStore.loading = false
     reviewStore.stopListening()
@@ -52,22 +53,25 @@ describe('ReviewStore', () => {
     it('fetches reviews from backend', async () => {
       const created = [makePR({ number: 1 })]
       const requested = [makePR({ number: 2 })]
-      mockFetchReviews.mockResolvedValue({ createdByMe: created, reviewRequested: requested })
+      const reviewed = [makePR({ number: 3, viewerHasApproved: true })]
+      mockFetchReviews.mockResolvedValue({ createdByMe: created, reviewRequested: requested, reviewedByMe: reviewed })
 
       await reviewStore.load()
 
       expect(mockFetchReviews).toHaveBeenCalled()
       expect(reviewStore.createdByMe).toHaveLength(1)
       expect(reviewStore.reviewRequested).toHaveLength(1)
+      expect(reviewStore.reviewedByMe).toHaveLength(1)
     })
 
     it('handles null arrays', async () => {
-      mockFetchReviews.mockResolvedValue({ createdByMe: null, reviewRequested: null })
+      mockFetchReviews.mockResolvedValue({ createdByMe: null, reviewRequested: null, reviewedByMe: null })
 
       await reviewStore.load()
 
       expect(reviewStore.createdByMe).toHaveLength(0)
       expect(reviewStore.reviewRequested).toHaveLength(0)
+      expect(reviewStore.reviewedByMe).toHaveLength(0)
       expect(reviewStore.error).toBe('')
     })
 
@@ -102,6 +106,7 @@ describe('ReviewStore', () => {
     it('sums both lists', () => {
       reviewStore.createdByMe = [makePR({ number: 1 }), makePR({ number: 2 })]
       reviewStore.reviewRequested = [makePR({ number: 3 })]
+      reviewStore.reviewedByMe = [makePR({ number: 4 })]
 
       expect(reviewStore.totalCount).toBe(3)
     })
@@ -119,6 +124,7 @@ describe('ReviewStore', () => {
       const shared = makePR({ number: 1, repository: 'org/repo' })
       reviewStore.createdByMe = [pr1, pr2]
       reviewStore.reviewRequested = [shared]
+      reviewStore.reviewedByMe = [makePR({ number: 2, repository: 'org/repo' })]
 
       const all = reviewStore.allPRs
       expect(all).toHaveLength(2)
@@ -129,13 +135,15 @@ describe('ReviewStore', () => {
       expect(reviewStore.allPRs).toHaveLength(0)
     })
 
-    it('preserves order: createdByMe first, then reviewRequested', () => {
+    it('preserves order: createdByMe first, then reviewRequested, then reviewedByMe', () => {
       reviewStore.createdByMe = [makePR({ number: 10, repository: 'org/a' })]
       reviewStore.reviewRequested = [makePR({ number: 20, repository: 'org/b' })]
+      reviewStore.reviewedByMe = [makePR({ number: 30, repository: 'org/c' })]
 
       const all = reviewStore.allPRs
       expect(all[0].number).toBe(10)
       expect(all[1].number).toBe(20)
+      expect(all[2].number).toBe(30)
     })
   })
 
@@ -209,20 +217,23 @@ describe('ReviewStore', () => {
       const cb = eventCallbacks[ReviewsUpdated]
       expect(cb).toBeDefined()
 
-      cb({ createdByMe: [makePR({ number: 10 })], reviewRequested: [makePR({ number: 20 })] })
+      cb({ createdByMe: [makePR({ number: 10 })], reviewRequested: [makePR({ number: 20 })], reviewedByMe: [makePR({ number: 30 })] })
 
       expect(reviewStore.createdByMe).toHaveLength(1)
       expect(reviewStore.createdByMe[0].number).toBe(10)
       expect(reviewStore.reviewRequested).toHaveLength(1)
       expect(reviewStore.reviewRequested[0].number).toBe(20)
+      expect(reviewStore.reviewedByMe).toHaveLength(1)
+      expect(reviewStore.reviewedByMe[0].number).toBe(30)
     })
 
     it('handles null in event data', () => {
       reviewStore.listen()
-      eventCallbacks[ReviewsUpdated]({ createdByMe: null, reviewRequested: null })
+      eventCallbacks[ReviewsUpdated]({ createdByMe: null, reviewRequested: null, reviewedByMe: null })
 
       expect(reviewStore.createdByMe).toHaveLength(0)
       expect(reviewStore.reviewRequested).toHaveLength(0)
+      expect(reviewStore.reviewedByMe).toHaveLength(0)
     })
 
     it('stopListening removes callback', () => {

--- a/frontend/src/stores/reviews.svelte.ts
+++ b/frontend/src/stores/reviews.svelte.ts
@@ -5,6 +5,7 @@ import type { PullRequest, ReviewSummary } from '../../bindings/github.com/Autom
 class ReviewStore {
   createdByMe = $state<PullRequest[]>([])
   reviewRequested = $state<PullRequest[]>([])
+  reviewedByMe = $state<PullRequest[]>([])
   loading = $state(false)
   error = $state('')
   private cancelListener: (() => void) | null = null
@@ -16,7 +17,7 @@ class ReviewStore {
   get allPRs(): PullRequest[] {
     const seen = new Set<string>()
     const result: PullRequest[] = []
-    for (const pr of [...this.createdByMe, ...this.reviewRequested]) {
+    for (const pr of [...this.createdByMe, ...this.reviewRequested, ...this.reviewedByMe]) {
       const key = `${pr.repository}#${pr.number}`
       if (!seen.has(key)) {
         seen.add(key)
@@ -51,6 +52,7 @@ class ReviewStore {
       const result = await FetchReviews()
       this.createdByMe = result.createdByMe ?? []
       this.reviewRequested = result.reviewRequested ?? []
+      this.reviewedByMe = result.reviewedByMe ?? []
     } catch (e) {
       this.error = String(e)
     } finally {
@@ -63,6 +65,7 @@ class ReviewStore {
     this.cancelListener = EventsOn(ReviewsUpdated, (summary: ReviewSummary) => {
       this.createdByMe = summary.createdByMe ?? []
       this.reviewRequested = summary.reviewRequested ?? []
+      this.reviewedByMe = summary.reviewedByMe ?? []
     })
   }
 

--- a/internal/github/model.go
+++ b/internal/github/model.go
@@ -26,6 +26,7 @@ type PullRequest struct {
 type ReviewSummary struct {
 	CreatedByMe     []PullRequest `json:"createdByMe"`
 	ReviewRequested []PullRequest `json:"reviewRequested"`
+	ReviewedByMe    []PullRequest `json:"reviewedByMe"`
 }
 
 // CheckRunInfo represents a single CI check run.

--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -16,7 +16,7 @@ import (
 // points before the doubling, sitting near GitHub's ~50K cutoff. The caps
 // below preserve every consumer (UnresolvedCount, ViewerHasApproved,
 // HasPendingChecks, Labels) but slash complexity ~85%.
-const reviewSummaryQuery = `query($createdQ: String!, $requestedQ: String!) {
+const reviewSummaryQuery = `query($createdQ: String!, $requestedQ: String!, $reviewedQ: String!) {
   viewer { login }
   created: search(query: $createdQ, type: ISSUE, first: 50) {
     nodes {
@@ -114,6 +114,54 @@ const reviewSummaryQuery = `query($createdQ: String!, $requestedQ: String!) {
       }
     }
   }
+  reviewed: search(query: $reviewedQ, type: ISSUE, first: 50) {
+    nodes {
+      ... on PullRequest {
+        number
+        title
+        url
+        headRefName
+        isDraft
+        mergeable
+        createdAt
+        updatedAt
+        reviewDecision
+        author { login type: __typename }
+        repository { name nameWithOwner }
+        labels(first: 5) { nodes { name } }
+        commits(last: 1) {
+          nodes {
+            commit {
+              oid
+              statusCheckRollup {
+                state
+                contexts(first: 20) {
+                  nodes {
+                    __typename
+                    ... on CheckRun {
+                      name
+                      status
+                      conclusion
+                    }
+                    ... on StatusContext {
+                      name: context
+                      state
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        reviewThreads(first: 20) {
+          nodes { isResolved }
+        }
+        latestReviews(first: 10) {
+          nodes { state author { login } }
+        }
+      }
+    }
+  }
 }`
 
 type gqlReviewSummaryResponse struct {
@@ -127,6 +175,9 @@ type gqlReviewSummaryResponse struct {
 		Requested struct {
 			Nodes []gqlPR `json:"nodes"`
 		} `json:"requested"`
+		Reviewed struct {
+			Nodes []gqlPR `json:"nodes"`
+		} `json:"reviewed"`
 	} `json:"data"`
 	Errors []struct {
 		Message string `json:"message"`
@@ -142,8 +193,9 @@ func fetchReviewsWith(e execer) (ReviewSummary, error) {
 	const (
 		createdQuery   = "is:pr is:open author:@me"
 		requestedQuery = "is:pr is:open review-requested:@me"
+		reviewedQuery  = "is:pr is:open reviewed-by:@me"
 	)
-	cacheKey := createdQuery + "||" + requestedQuery
+	cacheKey := createdQuery + "||" + requestedQuery + "||" + reviewedQuery
 	if runtimeCacheEnabled(e) {
 		if cached, ok := reviewSummaryCache.Get(cacheKey); ok {
 			return cached, nil
@@ -158,7 +210,8 @@ func fetchReviewsWith(e execer) (ReviewSummary, error) {
 	resp, err := runGHAPIWith(e, "", "graphql",
 		"-f", "query="+reviewSummaryQuery,
 		"-f", "createdQ="+createdQuery,
-		"-f", "requestedQ="+requestedQuery)
+		"-f", "requestedQ="+requestedQuery,
+		"-f", "reviewedQ="+reviewedQuery)
 	if err != nil {
 		if runtimeCacheEnabled(e) {
 			if stale, ok := reviewSummaryCache.GetStale(cacheKey); ok {
@@ -179,12 +232,23 @@ func fetchReviewsWith(e execer) (ReviewSummary, error) {
 	summary := ReviewSummary{
 		CreatedByMe:     convertPRs(gqlResp.Data.Created.Nodes, gqlResp.Data.Viewer.Login),
 		ReviewRequested: convertPRs(gqlResp.Data.Requested.Nodes, gqlResp.Data.Viewer.Login),
+		ReviewedByMe:    approvedOnly(convertPRs(gqlResp.Data.Reviewed.Nodes, gqlResp.Data.Viewer.Login)),
 	}
 	if runtimeCacheEnabled(e) {
 		reviewSummaryCache.Set(cacheKey, summary, 20*time.Second)
 	}
 
 	return summary, nil
+}
+
+func approvedOnly(prs []PullRequest) []PullRequest {
+	out := prs[:0]
+	for i := range prs {
+		if prs[i].ViewerHasApproved {
+			out = append(out, prs[i])
+		}
+	}
+	return out
 }
 
 // HasPendingReview checks if the authenticated user has a pending (draft) review on a PR.

--- a/internal/github/review_test.go
+++ b/internal/github/review_test.go
@@ -38,6 +38,32 @@ func TestFetchReviewsWith_success(t *testing.T) {
 						"latestReviews": {"nodes": []}
 					}
 				]
+			},
+			"reviewed": {
+				"nodes": [
+					{
+						"number": 3,
+						"title": "approved by me",
+						"url": "https://github.com/o/r/pull/3",
+						"author": {"login": "peer", "type": "User"},
+						"repository": {"name": "r", "nameWithOwner": "o/r"},
+						"labels": {"nodes": []},
+						"commits": {"nodes": []},
+						"reviewThreads": {"nodes": []},
+						"latestReviews": {"nodes": [{"state": "APPROVED", "author": {"login": "me"}}]}
+					},
+					{
+						"number": 4,
+						"title": "commented by me",
+						"url": "https://github.com/o/r/pull/4",
+						"author": {"login": "peer", "type": "User"},
+						"repository": {"name": "r", "nameWithOwner": "o/r"},
+						"labels": {"nodes": []},
+						"commits": {"nodes": []},
+						"reviewThreads": {"nodes": []},
+						"latestReviews": {"nodes": [{"state": "COMMENTED", "author": {"login": "me"}}]}
+					}
+				]
 			}
 		}
 	}`
@@ -55,6 +81,12 @@ func TestFetchReviewsWith_success(t *testing.T) {
 	}
 	if len(summary.ReviewRequested) != 1 {
 		t.Errorf("ReviewRequested len = %d, want 1", len(summary.ReviewRequested))
+	}
+	if len(summary.ReviewedByMe) != 1 {
+		t.Fatalf("ReviewedByMe len = %d, want 1", len(summary.ReviewedByMe))
+	}
+	if summary.ReviewedByMe[0].Number != 3 {
+		t.Errorf("ReviewedByMe[0].Number = %d, want 3", summary.ReviewedByMe[0].Number)
 	}
 }
 
@@ -88,7 +120,8 @@ func TestFetchReviewsWith_failedCheckRunConclusion(t *testing.T) {
 					}
 				]
 			},
-			"requested": {"nodes": []}
+			"requested": {"nodes": []},
+			"reviewed": {"nodes": []}
 		}
 	}`
 

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -438,12 +438,22 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 
 	r.maybeCreateReviewTasks(tasks, summary.ReviewRequested)
 	r.detectPublishedReviews(tasks)
-	r.closeFinishedReviewTasks(tasks, summary.ReviewRequested)
+	r.closeFinishedReviewTasks(tasks, openReviewPRs(summary))
 
 	if prNeedsAttention(monitoredPRs) {
 		return prPollFast
 	}
 	return prPollSlow
+}
+
+func openReviewPRs(summary github.ReviewSummary) []github.PullRequest {
+	if len(summary.ReviewedByMe) == 0 {
+		return summary.ReviewRequested
+	}
+	prs := make([]github.PullRequest, 0, len(summary.ReviewRequested)+len(summary.ReviewedByMe))
+	prs = append(prs, summary.ReviewRequested...)
+	prs = append(prs, summary.ReviewedByMe...)
+	return prs
 }
 
 func (r *ReviewHandler) closeFinishedReviewTasks(tasks []task.Task, openReviewPRs []github.PullRequest) {

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -177,6 +177,23 @@ func TestReviewTaskMatchers(t *testing.T) {
 	}
 }
 
+func TestOpenReviewPRsIncludesApprovedReviews(t *testing.T) {
+	requested := github.PullRequest{Number: 1, Repository: "o/r"}
+	approved := github.PullRequest{Number: 2, Repository: "o/r", ViewerHasApproved: true}
+
+	got := openReviewPRs(github.ReviewSummary{
+		ReviewRequested: []github.PullRequest{requested},
+		ReviewedByMe:    []github.PullRequest{approved},
+	})
+
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Number != 1 || got[1].Number != 2 {
+		t.Fatalf("numbers = [%d %d], want [1 2]", got[0].Number, got[1].Number)
+	}
+}
+
 func TestCreateReviewTaskPassesUpdatedTaskToTriage(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "tasks")
 	store, err := task.NewStore(dir)


### PR DESCRIPTION
## Motivation

Review tasks stay on the board until their PR merges, but approved reviews did not show that no action remained.

> Changelog: feat(gui): show review task state

## Implementation information

- Add reviewed-by-me PRs to the review summary.
- Keep approved review PRs in board matching and close tasks only after PR closed or merged.
- Show review task badges for pending review and approved waiting merge states.

## Supporting documentation

None.