### PR TITLE
fix(config): redact secrets from settings read API

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/configservice.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/configservice.ts
@@ -16,6 +16,8 @@ import * as $models from "./models.js";
 
 /**
  * GetSettings returns the current app settings for the config UI.
+ * Secret fields (e.g. Todoist.APIToken) are redacted — callers must use
+ * dedicated write-only methods (UpdateTodoistToken) to rotate them.
  */
 export function GetSettings(): $CancellablePromise<$models.AppSettings> {
     return $Call.ByID(1300186602).then(($result: any) => {
@@ -40,6 +42,15 @@ export function ReloadFromDisk(): $CancellablePromise<string[]> {
  */
 export function UpdateSettings(settings: $models.AppSettings): $CancellablePromise<void> {
     return $Call.ByID(659336121, settings);
+}
+
+/**
+ * UpdateTodoistToken sets or clears the Todoist API token and persists the config.
+ * Pass an empty string to remove the stored token.
+ * This is the only write path for the token — GetSettings never returns it.
+ */
+export function UpdateTodoistToken(token: string): $CancellablePromise<void> {
+    return $Call.ByID(1514278165, token);
 }
 
 // Private type creation functions

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -54,6 +54,7 @@ export function StopChat(arg1: string): Promise<void> { return call('App', 'Stop
 // ConfigService
 export function GetSettings(): Promise<AppSettings> { return call('ConfigService', 'GetSettings') }
 export function UpdateSettings(arg1: AppSettings): Promise<void> { return call('ConfigService', 'UpdateSettings', arg1) }
+export function UpdateTodoistToken(arg1: string): Promise<void> { return call('ConfigService', 'UpdateTodoistToken', arg1) }
 
 // InfoService
 export function GetCodexModels(): Promise<CodexModel[]> { return call('InfoService', 'GetCodexModels') }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -61,6 +61,7 @@ export const StopChat = pick(AppSvc.StopChat, http.StopChat)
 // ConfigService
 export const GetSettings = pick(ConfigSvc.GetSettings, http.GetSettings)
 export const UpdateSettings = pick(ConfigSvc.UpdateSettings, http.UpdateSettings)
+export const UpdateTodoistToken = pick(ConfigSvc.UpdateTodoistToken, http.UpdateTodoistToken)
 
 // InfoService
 export const GetCodexModels = pick(InfoSvc.GetCodexModels, http.GetCodexModels)

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -28,10 +28,14 @@ type ConfigService struct {
 }
 
 // GetSettings returns the current app settings for the config UI.
+// Secret fields (e.g. Todoist.APIToken) are redacted — callers must use
+// dedicated write-only methods (UpdateTodoistToken) to rotate them.
 func (s *ConfigService) GetSettings() AppSettings {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	c := s.cfg
+	todoist := c.Todoist
+	todoist.APIToken = "" // never leak the token over the read API
 	return AppSettings{
 		Agent:        c.Agent,
 		Notification: c.Notification,
@@ -42,11 +46,29 @@ func (s *ConfigService) GetSettings() AppSettings {
 			MaxFiles:  c.Logging.MaxFiles,
 		},
 		Audit:       c.Audit,
-		Todoist:     c.Todoist,
+		Todoist:     todoist,
 		Renovate:    c.Renovate,
 		Providers:   c.Providers,
 		Directories: c.Directories(),
 	}
+}
+
+// UpdateTodoistToken sets the Todoist API token and persists the config.
+// This is the only write path for the token — GetSettings never returns it.
+func (s *ConfigService) UpdateTodoistToken(token string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if token == "" {
+		return fmt.Errorf("token must not be empty")
+	}
+	s.cfg.Todoist.APIToken = token
+	if err := s.cfg.Save(); err != nil {
+		return err
+	}
+	if s.reloadHook != nil {
+		s.reloadHook()
+	}
+	return nil
 }
 
 // UpdateSettings validates, persists, and hot-reloads the provided settings.
@@ -90,7 +112,7 @@ func (s *ConfigService) validateSettings(settings AppSettings) error {
 	if settings.Audit.RetentionDays < 1 || settings.Audit.RetentionDays > 365 {
 		return fmt.Errorf("retentionDays must be 1–365")
 	}
-	if settings.Todoist.Enabled && settings.Todoist.APIToken == "" {
+	if settings.Todoist.Enabled && settings.Todoist.APIToken == "" && s.cfg.Todoist.APIToken == "" {
 		return fmt.Errorf("todoist API token required when enabled")
 	}
 	if settings.Todoist.PollSeconds < 30 || settings.Todoist.PollSeconds > 3600 {
@@ -150,6 +172,10 @@ func settingsToConfig(existing *config.Config, settings AppSettings) config.Conf
 	next.Logging.MaxFiles = settings.Logging.MaxFiles
 	next.Audit = settings.Audit
 	next.Todoist = settings.Todoist
+	// Preserve the stored token when the caller sends a blank (redacted) value.
+	if settings.Todoist.APIToken == "" {
+		next.Todoist.APIToken = existing.Todoist.APIToken
+	}
 	next.Renovate = settings.Renovate
 	next.Providers = settings.Providers
 	return next

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -53,14 +53,12 @@ func (s *ConfigService) GetSettings() AppSettings {
 	}
 }
 
-// UpdateTodoistToken sets the Todoist API token and persists the config.
+// UpdateTodoistToken sets or clears the Todoist API token and persists the config.
+// Pass an empty string to remove the stored token.
 // This is the only write path for the token — GetSettings never returns it.
 func (s *ConfigService) UpdateTodoistToken(token string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if token == "" {
-		return fmt.Errorf("token must not be empty")
-	}
 	s.cfg.Todoist.APIToken = token
 	if err := s.cfg.Save(); err != nil {
 		return err

--- a/internal/sybra/svc_config_settings_test.go
+++ b/internal/sybra/svc_config_settings_test.go
@@ -85,12 +85,23 @@ func TestUpdateTodoistToken(t *testing.T) {
 	}
 }
 
-func TestUpdateTodoistToken_RejectsEmpty(t *testing.T) {
+func TestUpdateTodoistToken_ClearsToken(t *testing.T) {
 	svc, cfgPath := setupConfigSvc(t)
+	svc.cfg.Todoist.APIToken = "existing-token"
 	writeConfigYAML(t, cfgPath, svc.cfg)
 
-	if err := svc.UpdateTodoistToken(""); err == nil {
-		t.Error("expected error for empty token, got nil")
+	if err := svc.UpdateTodoistToken(""); err != nil {
+		t.Fatalf("UpdateTodoistToken empty: %v", err)
+	}
+	if svc.cfg.Todoist.APIToken != "" {
+		t.Errorf("in-memory token = %q, want empty", svc.cfg.Todoist.APIToken)
+	}
+	saved, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(saved), "existing-token") {
+		t.Error("saved config still contains old token after clear")
 	}
 }
 

--- a/internal/sybra/svc_config_settings_test.go
+++ b/internal/sybra/svc_config_settings_test.go
@@ -1,0 +1,109 @@
+package sybra
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/config"
+)
+
+func TestGetSettings_RedactsAPIToken(t *testing.T) {
+	svc, cfgPath := setupConfigSvc(t)
+
+	svc.cfg.Todoist = config.TodoistConfig{
+		Enabled:     true,
+		APIToken:    "secret-token-abc123",
+		PollSeconds: 120,
+	}
+	writeConfigYAML(t, cfgPath, svc.cfg)
+
+	got := svc.GetSettings()
+	if got.Todoist.APIToken != "" {
+		t.Errorf("GetSettings returned APIToken %q, want empty string", got.Todoist.APIToken)
+	}
+	if !got.Todoist.Enabled {
+		t.Error("GetSettings should preserve Todoist.Enabled")
+	}
+}
+
+func TestUpdateSettings_PreservesTokenWhenBlank(t *testing.T) {
+	svc, cfgPath := setupConfigSvc(t)
+
+	svc.cfg.Todoist = config.TodoistConfig{
+		Enabled:     true,
+		APIToken:    "existing-token",
+		PollSeconds: 120,
+	}
+	writeConfigYAML(t, cfgPath, svc.cfg)
+
+	// Frontend sends back what GetSettings returns — token is blank.
+	settings := svc.GetSettings()
+	if settings.Todoist.APIToken != "" {
+		t.Fatalf("precondition: GetSettings returned non-empty token")
+	}
+	if err := svc.UpdateSettings(settings); err != nil {
+		t.Fatalf("UpdateSettings: %v", err)
+	}
+
+	if svc.cfg.Todoist.APIToken != "existing-token" {
+		t.Errorf("in-memory token = %q, want %q", svc.cfg.Todoist.APIToken, "existing-token")
+	}
+
+	saved, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(saved), "existing-token") {
+		t.Error("saved config does not contain the preserved token")
+	}
+}
+
+func TestUpdateTodoistToken(t *testing.T) {
+	svc, cfgPath := setupConfigSvc(t)
+	writeConfigYAML(t, cfgPath, svc.cfg)
+
+	if err := svc.UpdateTodoistToken("new-token-xyz"); err != nil {
+		t.Fatalf("UpdateTodoistToken: %v", err)
+	}
+
+	if svc.cfg.Todoist.APIToken != "new-token-xyz" {
+		t.Errorf("in-memory token = %q, want %q", svc.cfg.Todoist.APIToken, "new-token-xyz")
+	}
+
+	saved, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(saved), "new-token-xyz") {
+		t.Error("saved config does not contain the new token")
+	}
+
+	// GetSettings must still redact after UpdateTodoistToken.
+	if got := svc.GetSettings().Todoist.APIToken; got != "" {
+		t.Errorf("GetSettings returned token %q after UpdateTodoistToken, want empty", got)
+	}
+}
+
+func TestUpdateTodoistToken_RejectsEmpty(t *testing.T) {
+	svc, cfgPath := setupConfigSvc(t)
+	writeConfigYAML(t, cfgPath, svc.cfg)
+
+	if err := svc.UpdateTodoistToken(""); err == nil {
+		t.Error("expected error for empty token, got nil")
+	}
+}
+
+func TestUpdateSettings_ValidationRejectsEnabledWithNoToken(t *testing.T) {
+	svc, cfgPath := setupConfigSvc(t)
+	svc.cfg.Todoist.APIToken = ""
+	writeConfigYAML(t, cfgPath, svc.cfg)
+
+	settings := svc.GetSettings()
+	settings.Todoist.Enabled = true
+	settings.Todoist.APIToken = ""
+
+	if err := svc.UpdateSettings(settings); err == nil {
+		t.Error("expected validation error for enabled todoist with no token, got nil")
+	}
+}


### PR DESCRIPTION
## Motivation

The `GetSettings` API returned the raw `Todoist.APIToken` in the response, exposing secrets to any frontend consumer or log. A read API should never return credentials — callers that round-trip settings back via `UpdateSettings` would also accidentally clear the token unless special handling was added.

Closes https://github.com/Automaat/sybra/issues/759

## Implementation information

- `GetSettings` now clears `Todoist.APIToken` before returning, so the frontend always receives a blank token field.
- `settingsToConfig` preserves the in-memory token when the caller sends a blank value (safe round-trip: frontend reads blank, edits other fields, posts back blank → token unchanged).
- `UpdateTodoistToken` added as a dedicated write-only endpoint for explicit token updates; also accepts `""` to clear the stored token.
- Validation accepts a blank token when one is already stored in memory.
- Wails bindings regenerated to expose `UpdateTodoistToken`; re-exported via `api.ts` and `api-http.ts`.
- Tests cover redaction, round-trip preservation, and clear-token behavior.