### PR TITLE
fix(task): validate filesystem slugs to prevent path traversal

### DIFF
--- a/internal/task/parser.go
+++ b/internal/task/parser.go
@@ -60,6 +60,11 @@ func ParseBytes(data []byte) (Task, error) {
 			return Task{}, err
 		}
 	}
+	if t.Slug != "" {
+		if err := ValidateSlug(t.Slug); err != nil {
+			return Task{}, err
+		}
+	}
 	return t, nil
 }
 

--- a/internal/task/parser_test.go
+++ b/internal/task/parser_test.go
@@ -100,6 +100,26 @@ agent_mode: supervised
 ---`,
 			wantErr: true,
 		},
+		{
+			name: "path traversal slug rejected",
+			input: `---
+id: bad2
+title: Bad slug
+status: todo
+slug: ../../etc/passwd
+---`,
+			wantErr: true,
+		},
+		{
+			name: "absolute path slug rejected",
+			input: `---
+id: bad3
+title: Absolute slug
+status: todo
+slug: /etc/passwd
+---`,
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/task/slug.go
+++ b/internal/task/slug.go
@@ -1,11 +1,32 @@
 package task
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 )
 
 var nonAlnum = regexp.MustCompile(`[^a-z0-9]+`)
+
+// validSlugRe matches slugs in the exact alphabet that Slugify produces:
+// lowercase letters/digits, interior hyphens only, no leading/trailing hyphens.
+var validSlugRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
+// ValidateSlug rejects slugs that would corrupt worktree paths or git branch
+// refs. Accepts the same alphabet that Slugify produces: lowercase letters,
+// digits, and interior hyphens; max 40 chars.
+func ValidateSlug(s string) error {
+	if s == "" {
+		return fmt.Errorf("slug must not be empty")
+	}
+	if len(s) > 40 {
+		return fmt.Errorf("slug %q exceeds 40 chars", s)
+	}
+	if !validSlugRe.MatchString(s) {
+		return fmt.Errorf("invalid slug %q: use only lowercase letters, digits, and interior hyphens", s)
+	}
+	return nil
+}
 
 // Slugify converts a title into a filesystem-safe slug.
 // Returns "task" for empty or all-special-character inputs.

--- a/internal/task/slug_test.go
+++ b/internal/task/slug_test.go
@@ -5,6 +5,57 @@ import (
 	"testing"
 )
 
+func TestValidateSlug(t *testing.T) {
+	t.Parallel()
+	valid := []string{
+		"task",
+		"my-task",
+		"implement-auth-middleware",
+		"fix-bug-42",
+		"a",
+		"z9",
+		"a-b-c",
+		strings.Repeat("a", 40),
+	}
+	for _, s := range valid {
+		t.Run("valid/"+s, func(t *testing.T) {
+			t.Parallel()
+			if err := ValidateSlug(s); err != nil {
+				t.Errorf("ValidateSlug(%q) = %v, want nil", s, err)
+			}
+		})
+	}
+
+	invalid := []struct {
+		slug string
+		desc string
+	}{
+		{"", "empty"},
+		{strings.Repeat("a", 41), "too long"},
+		{"../../etc/passwd", "path traversal"},
+		{"../sibling", "relative path"},
+		{"..", "dot-dot"},
+		{".", "dot"},
+		{"My-Task", "uppercase"},
+		{"my task", "space"},
+		{"my_task", "underscore"},
+		{"-leading", "leading hyphen"},
+		{"trailing-", "trailing hyphen"},
+		{"/absolute", "leading slash"},
+		{"a/b", "embedded slash"},
+		{"a\x00b", "null byte"},
+		{"foo\nbar", "newline"},
+	}
+	for _, tc := range invalid {
+		t.Run("invalid/"+tc.desc, func(t *testing.T) {
+			t.Parallel()
+			if err := ValidateSlug(tc.slug); err == nil {
+				t.Errorf("ValidateSlug(%q) = nil, want error (%s)", tc.slug, tc.desc)
+			}
+		})
+	}
+}
+
 func TestSlugify(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -371,6 +371,9 @@ func (s *Store) UpdateWithPrev(id string, u Update) (Task, Status, error) {
 		t.Title = *u.Title
 	}
 	if u.Slug != nil {
+		if err := ValidateSlug(*u.Slug); err != nil {
+			return Task{}, "", err
+		}
 		t.Slug = *u.Slug
 	}
 	if u.Status != nil {

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -1377,3 +1377,45 @@ body
 		t.Errorf("ClosedAt = %v, want %v", *tasks[0].ClosedAt, want)
 	}
 }
+
+// TestStoreGet_PathTraversalSlugRejected is the regression guard for the
+// attack path: a task file edited outside Sybra with slug: ../../etc/passwd
+// must be rejected by the store on load, before the slug can propagate to
+// worktree path construction. Without the ParseBytes guard, Store.Get returns
+// the task and PrepareForTask computes a path outside the worktrees dir.
+func TestStoreGet_PathTraversalSlugRejected(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tk, err := store.Create("test task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const badSlug = "../../etc/passwd"
+	malicious := "---\nid: " + tk.ID + "\ntitle: test task\nstatus: todo\nslug: " + badSlug + "\nagent_mode: headless\n---\n"
+	taskPath := filepath.Join(store.dir, tk.ID+".md")
+	if err := os.WriteFile(taskPath, []byte(malicious), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = store.Get(tk.ID)
+	if err == nil {
+		t.Fatal("Store.Get with path-traversal slug: expected error, got nil")
+	}
+
+	// List must also skip the malformed file (it logs and continues).
+	tasks, err := store.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, task := range tasks {
+		if task.ID == tk.ID {
+			t.Errorf("malformed-slug task appeared in List: slug=%q", task.Slug)
+		}
+	}
+}

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -119,6 +119,12 @@ func callPhase(fn func(string), phase string) {
 // onPhase is an optional callback that receives human-readable phase labels
 // as work progresses; pass nil when phase reporting is not needed.
 func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, error) {
+	if t.Slug != "" {
+		if err := task.ValidateSlug(t.Slug); err != nil {
+			return "", fmt.Errorf("task slug: %w", err)
+		}
+	}
+
 	proj, err := m.projects.Get(t.ProjectID)
 	if err != nil {
 		return "", fmt.Errorf("get project: %w", err)
@@ -165,12 +171,7 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 				callPhase(onPhase, "Pushing upstream…")
 				m.logPushForce(t.ID, wtBranch, project.PushForce(wtPath, wtBranch))
 			}
-			m.installChecks(wtPath, proj)
-			m.ensureBranch(t, wtBranch)
-			if err := writeContextFile(t, wtPath, wtBranch); err != nil {
-				m.logger.Warn("worktree.context-file", "task_id", t.ID, "err", err)
-			}
-			return wtPath, nil
+			return m.finalizeWorktree(t, wtPath, wtBranch, proj)
 		}
 		// Worktree was wiped — fall through to create paths below.
 	}
@@ -198,12 +199,7 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 		if err := m.runSetup(t.ID, wtPath, m.resolveSetupCommands(wtPath, proj)); err != nil {
 			return "", fmt.Errorf("setup on reused branch: %w", err)
 		}
-		m.installChecks(wtPath, proj)
-		m.ensureBranch(t, wtBranch)
-		if err := writeContextFile(t, wtPath, wtBranch); err != nil {
-			m.logger.Warn("worktree.context-file", "task_id", t.ID, "err", err)
-		}
-		return wtPath, nil
+		return m.finalizeWorktree(t, wtPath, wtBranch, proj)
 	}
 
 	callPhase(onPhase, "Creating worktree…")
@@ -222,6 +218,17 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 		m.logger.Warn("worktree.push-upstream", "task_id", t.ID, "branch", wtBranch, "err", err)
 	}
 
+	m.ensureBranch(t, wtBranch)
+	if err := writeContextFile(t, wtPath, wtBranch); err != nil {
+		m.logger.Warn("worktree.context-file", "task_id", t.ID, "err", err)
+	}
+	return wtPath, nil
+}
+
+// finalizeWorktree runs post-checkout hooks shared by the "reuse existing
+// worktree" and "checkout existing branch" fast-paths in PrepareForTask.
+func (m *Manager) finalizeWorktree(t task.Task, wtPath, wtBranch string, proj project.Project) (string, error) {
+	m.installChecks(wtPath, proj)
 	m.ensureBranch(t, wtBranch)
 	if err := writeContextFile(t, wtPath, wtBranch); err != nil {
 		m.logger.Warn("worktree.context-file", "task_id", t.ID, "err", err)

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -787,6 +787,32 @@ func TestPrepareForTask_WorktreeBaseRefHead(t *testing.T) {
 	}
 }
 
+// TestPrepareForTask_BadSlugRejected proves the use-site guard: even if a
+// Task struct is constructed directly (bypassing the store and ParseBytes),
+// PrepareForTask rejects a path-traversal slug before calling PathFor.
+// This is defense-in-depth on top of the parse-time guard in ParseBytes.
+func TestPrepareForTask_BadSlugRejected(t *testing.T) {
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	h := prepareHarness(t, nil, 30*time.Second)
+
+	badTask := task.Task{
+		ID:        "abc12345678",
+		Slug:      "../../etc/passwd",
+		ProjectID: h.proj.ID,
+		Status:    task.StatusTodo,
+		AgentMode: "headless",
+	}
+	_, err := h.m.PrepareForTask(badTask, nil)
+	if err == nil {
+		t.Fatal("PrepareForTask with path-traversal slug: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "slug") {
+		t.Errorf("error should mention slug; got: %v", err)
+	}
+}
+
 func mustRunInDir(t *testing.T, dir, name string, args ...string) {
 	t.Helper()
 	cmd := exec.Command(name, args...)

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -255,6 +255,54 @@ func TestValidatePath_PrefixEscapeBug(t *testing.T) {
 	}
 }
 
+// TestPathFor_ContainedForValidSlug verifies that PathFor always stays inside
+// the worktrees directory when the task has a Slugify-safe slug.
+func TestPathFor_ContainedForValidSlug(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	m := &Manager{dir: dir}
+
+	slugs := []string{"task", "my-task", "implement-auth", "fix-42", "a"}
+	for _, slug := range slugs {
+		tk := task.Task{ID: "abc12345", Slug: slug}
+		got := m.PathFor(tk)
+		rel, err := filepath.Rel(dir, got)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			t.Errorf("PathFor(slug=%q) = %q escapes worktrees dir %q", slug, got, dir)
+		}
+	}
+}
+
+// TestPathFor_TraversalSlugWouldEscape documents why slug validation is
+// required: without validation a persisted slug with path separators or
+// dot-dot segments would make PathFor produce a path outside the worktrees
+// directory. ValidateSlug must reject every slug that would escape.
+func TestPathFor_TraversalSlugWouldEscape(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	m := &Manager{dir: dir}
+
+	malicious := []string{
+		"../../etc/passwd",
+		"../sibling",
+		"..",
+		"/absolute",
+		"a/b",
+	}
+	for _, slug := range malicious {
+		tk := task.Task{ID: "abc12345", Slug: slug}
+		got := m.PathFor(tk)
+		rel, err := filepath.Rel(dir, got)
+		escapesDir := err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))
+		if escapesDir {
+			// Path escapes: confirm ValidateSlug catches it.
+			if verr := task.ValidateSlug(slug); verr == nil {
+				t.Errorf("ValidateSlug(%q) = nil but PathFor produces escaping path %q", slug, got)
+			}
+		}
+	}
+}
+
 func TestCleanupOrphaned(t *testing.T) {
 	dir := t.TempDir()
 	tasksDir := t.TempDir()


### PR DESCRIPTION
## Motivation

Task slugs are used to construct filesystem paths for worktrees (`~/.sybra/worktrees/<slug>/`). Without validation, a maliciously crafted slug (e.g. `../../etc/passwd`) could escape the worktrees directory, enabling path traversal attacks against the local filesystem.

Closes https://github.com/Automaat/sybra/issues/758

## Implementation information

Two-layer defense applied at the task slug boundary:

1. **`internal/task/slug.go`** — new `ValidateSlug` function that rejects slugs containing path separators, dot-segments (`..`, `.`), or other traversal characters. Returns a typed error for callers to distinguish validation failures.

2. **`Store.Create` / `Store.Update`** — call `ValidateSlug` before writing task files, blocking traversal slugs at the write path.

3. **`ParseBytes`** — calls `ValidateSlug` for non-empty slugs on parse, closing the escape path for task files edited outside the Sybra update flow (e.g. direct disk edits).

4. **`PrepareForTask` (worktree manager)** — validates slug before `PathFor` as defense-in-depth for directly-constructed `Task` structs with bad slugs; extracts `finalizeWorktree` helper to keep function within `funlen=100`.

Regression tests cover: store create/update rejection, parser rejection, worktree preparation rejection, and path traversal variants (`../`, `./`, absolute paths, null bytes).