### PR TITLE
fix(agent): fail closed on unknown/canceled approvals

### DIFF
--- a/internal/agent/approval_server.go
+++ b/internal/agent/approval_server.go
@@ -110,18 +110,17 @@ func (s *ApprovalServer) handlePreToolUse(w http.ResponseWriter, r *http.Request
 
 	s.logger.Info("approval-server.request", "tool", input.ToolName, "tool_use_id", input.ToolUseID)
 
-	// Find the agent by session_id.
-	agentID := s.findAgentBySession(input.SessionID)
-	if agentID == "" {
-		s.logger.Warn("approval-server.no-agent", "session_id", input.SessionID)
-		// No agent found — auto-allow to avoid blocking.
+	// Auto-approve safe read-only tools regardless of session.
+	if isSafeTool(input.ToolName) {
 		s.respondAllow(w, input.ToolInput)
 		return
 	}
 
-	// Auto-approve safe read-only tools.
-	if isSafeTool(input.ToolName) {
-		s.respondAllow(w, input.ToolInput)
+	// Find the agent by session_id; deny if unknown.
+	agentID := s.findAgentBySession(input.SessionID)
+	if agentID == "" {
+		s.logger.Warn("approval-server.no-agent", "session_id", input.SessionID)
+		s.respondDeny(w, "Unknown session")
 		return
 	}
 
@@ -170,7 +169,7 @@ func (s *ApprovalServer) handlePreToolUse(w http.ResponseWriter, r *http.Request
 			s.respondDeny(w, "User denied this action")
 		}
 	case <-r.Context().Done():
-		s.respondAllow(w, input.ToolInput) // timeout → allow to avoid deadlock
+		s.respondDeny(w, "Request canceled")
 	case <-time.After(5 * time.Minute):
 		s.respondDeny(w, "Approval timed out")
 	}

--- a/internal/agent/approval_server.go
+++ b/internal/agent/approval_server.go
@@ -153,9 +153,8 @@ func (s *ApprovalServer) handlePreToolUse(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	// Block until user responds or context is cancelled.
-	select {
-	case resp := <-ch:
+	// Restore agent state on all exit paths (approve, deny, canceled, timeout).
+	defer func() {
 		if s.agents != nil {
 			if a, err := s.agents.GetAgent(agentID); err == nil {
 				a.SetAwaitingApproval(false)
@@ -163,6 +162,11 @@ func (s *ApprovalServer) handlePreToolUse(w http.ResponseWriter, r *http.Request
 				s.emit(events.AgentState(agentID), a)
 			}
 		}
+	}()
+
+	// Block until user responds or context is cancelled.
+	select {
+	case resp := <-ch:
 		if resp.Approved {
 			s.respondAllow(w, input.ToolInput)
 		} else {

--- a/internal/agent/approval_server_test.go
+++ b/internal/agent/approval_server_test.go
@@ -156,6 +156,17 @@ func TestApprovalServer_CanceledContext(t *testing.T) {
 	if out.HookSpecificOutput.PermissionDecision != "deny" {
 		t.Errorf("expected deny on canceled context, got %q", out.HookSpecificOutput.PermissionDecision)
 	}
+
+	// Agent state must be restored after cancellation.
+	if fakeAgent.GetState() != StateRunning {
+		t.Errorf("expected state %q after cancel, got %q", StateRunning, fakeAgent.GetState())
+	}
+	fakeAgent.mu.RLock()
+	awaitingApproval := fakeAgent.AwaitingApproval
+	fakeAgent.mu.RUnlock()
+	if awaitingApproval {
+		t.Error("expected AwaitingApproval=false after canceled context")
+	}
 }
 
 func TestApprovalServer_ApprovalFlow_Approve(t *testing.T) {

--- a/internal/agent/approval_server_test.go
+++ b/internal/agent/approval_server_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -86,15 +87,74 @@ func TestApprovalServer_UnknownSession(t *testing.T) {
 	t.Parallel()
 	srv := newTestApprovalServer(t)
 
-	// No manager set → unknown session → auto-allow.
+	// No manager set → unknown session → deny (fail-closed).
 	resp := postHook(t, srv.Addr(), map[string]any{
 		"session_id":  "unknown-session",
 		"tool_name":   "Bash",
 		"tool_use_id": "tuid-unknown",
 		"tool_input":  map[string]any{},
 	})
-	if resp.HookSpecificOutput.PermissionDecision != "allow" {
-		t.Errorf("expected allow for unknown session, got %q", resp.HookSpecificOutput.PermissionDecision)
+	if resp.HookSpecificOutput.PermissionDecision != "deny" {
+		t.Errorf("expected deny for unknown session, got %q", resp.HookSpecificOutput.PermissionDecision)
+	}
+}
+
+func TestApprovalServer_CanceledContext(t *testing.T) {
+	t.Parallel()
+
+	mgr, _ := newTestManager(t)
+	fakeAgent := &Agent{
+		ID:        "fake-ag-cancel",
+		Mode:      "interactive",
+		SessionID: "session-cancel",
+		State:     StateRunning,
+	}
+	mgr.mu.Lock()
+	mgr.agents["fake-ag-cancel"] = fakeAgent
+	mgr.mu.Unlock()
+
+	srv, err := NewApprovalServer(func(_ string, _ any) {}, discardLogger())
+	if err != nil {
+		t.Fatalf("NewApprovalServer: %v", err)
+	}
+	srv.SetManager(mgr)
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	body, _ := json.Marshal(map[string]any{
+		"session_id":  "session-cancel",
+		"tool_name":   "Bash",
+		"tool_use_id": "tuid-cancel",
+		"tool_input":  map[string]any{},
+	})
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "/hooks/pre-tool-use", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Cancel context shortly after handler starts waiting for approval.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	rr := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		srv.handlePreToolUse(rr, req)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler blocked after context cancellation")
+	}
+
+	var out hookResponse
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.HookSpecificOutput.PermissionDecision != "deny" {
+		t.Errorf("expected deny on canceled context, got %q", out.HookSpecificOutput.PermissionDecision)
 	}
 }
 


### PR DESCRIPTION
## Motivation

The approval server had two safety gaps: unknown sessions and canceled contexts were silently treated as allowed, meaning tool calls could proceed without a valid approval. This is a security-correctness issue — the approval server should deny by default when it cannot confirm authorization.

Additionally, agent state (`AwaitingApproval`) was not reliably cleared on all exit paths (canceled context, timeout), leaving the agent stuck in the wrong state.

## Implementation information

- `approval_server.go`: deny tool calls when the session is unknown or the request context is canceled; safe tools bypass the session check as before (fail-open only for safe tools is intentional)
- `approval_server.go`: moved state cleanup into a `defer` so `AwaitingApproval` is cleared and `StateRunning` restored on all exit paths — including context cancellation and timeout
- `approval_server_test.go`: added test coverage for canceled-context path with state assertions, and for unknown-session denial

Closes https://github.com/Automaat/sybra/issues/760

> Changelog: fix(agent): fail closed on unknown/canceled approvals