### PR TITLE
fix(api): restrict HTTP dispatch to allowlist

### DIFF
--- a/cmd/sybra-server/main.go
+++ b/cmd/sybra-server/main.go
@@ -167,7 +167,7 @@ func buildMux(logger *slog.Logger, broker *sse.Broker, app *sybra.App) *http.Ser
 	mux.HandleFunc("GET /api/events/{eventName}", broker.ServeHTTP)
 
 	// API dispatch: POST /api/{service}/{method}
-	httpapi.Mount(mux, app.ServiceRegistry(), logger)
+	httpapi.Mount(mux, sybra.ServiceRegistry(app), logger)
 
 	// Optional SPA static files.
 	if staticDir := os.Getenv("SYBRA_STATIC_DIR"); staticDir != "" {

--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/app.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/app.ts
@@ -70,17 +70,6 @@ export function RegisterSpotlightHotkey(): $CancellablePromise<void> {
 }
 
 /**
- * ServiceRegistry returns the named service instances for HTTP dispatch.
- * All values are the concrete pointers Wails binds; the HTTP handler uses
- * reflection to call their exported methods.
- */
-export function ServiceRegistry(): $CancellablePromise<{ [_ in string]?: any }> {
-    return $Call.ByID(3128777629).then(($result: any) => {
-        return $$createType5($result);
-    });
-}
-
-/**
  * SetDesktopNotifications enables or disables macOS desktop notifications.
  */
 export function SetDesktopNotifications(enabled: boolean): $CancellablePromise<void> {
@@ -98,7 +87,7 @@ export function Shutdown(): $CancellablePromise<void> {
  */
 export function StartAgent(taskID: string, mode: string, prompt: string, includeTaskDescription: boolean): $CancellablePromise<agent$0.Agent | null> {
     return $Call.ByID(2345014098, taskID, mode, prompt, includeTaskDescription).then(($result: any) => {
-        return $$createType7($result);
+        return $$createType6($result);
     });
 }
 
@@ -109,7 +98,7 @@ export function StartAgent(taskID: string, mode: string, prompt: string, include
  */
 export function StartChat(projectID: string, providerName: string, prompt: string): $CancellablePromise<agent$0.Agent | null> {
     return $Call.ByID(4013768999, projectID, providerName, prompt).then(($result: any) => {
-        return $$createType7($result);
+        return $$createType6($result);
     });
 }
 
@@ -137,7 +126,7 @@ export function StopChat(agentID: string): $CancellablePromise<void> {
  */
 export function V3Services(): $CancellablePromise<application$0.Service[]> {
     return $Call.ByID(1114222916).then(($result: any) => {
-        return $$createType9($result);
+        return $$createType8($result);
     });
 }
 
@@ -147,8 +136,7 @@ const $$createType1 = bgop$0.Operation.createFrom;
 const $$createType2 = $Create.Array($$createType1);
 const $$createType3 = notification$0.Notification.createFrom;
 const $$createType4 = $Create.Array($$createType3);
-const $$createType5 = $Create.Map($Create.Any, $Create.Any);
-const $$createType6 = agent$0.Agent.createFrom;
-const $$createType7 = $Create.Nullable($$createType6);
-const $$createType8 = application$0.Service.createFrom;
-const $$createType9 = $Create.Array($$createType8);
+const $$createType5 = agent$0.Agent.createFrom;
+const $$createType6 = $Create.Nullable($$createType5);
+const $$createType7 = application$0.Service.createFrom;
+const $$createType8 = $Create.Array($$createType7);

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -38,14 +38,14 @@ export function RespondApproval(arg1: string, arg2: boolean): Promise<void> { re
 export function RespondEscalation(arg1: string, arg2: boolean): Promise<void> { return call('AgentService', 'RespondEscalation', arg1, arg2) }
 export function SendMessage(arg1: string, arg2: string): Promise<void> { return call('AgentService', 'SendMessage', arg1, arg2) }
 export function StopAgent(arg1: string): Promise<void> { return call('AgentService', 'StopAgent', arg1) }
-export function OpenWorktree(arg1: string): Promise<void> { return call('AgentService', 'OpenWorktree', arg1) }
-export function ResumeInClaudeCode(arg1: string): Promise<void> { return call('AgentService', 'ResumeInClaudeCode', arg1) }
+export function OpenWorktree(_arg1: string): Promise<void> { return Promise.reject(new Error('not available in web mode')) }
+export function ResumeInClaudeCode(_arg1: string): Promise<void> { return Promise.reject(new Error('not available in web mode')) }
 
 // App
 export function GetMonitorReport(): Promise<MonitorReportBinding> { return call('App', 'GetMonitorReport') }
 export function ListBackgroundOps(): Promise<Array<any>> { return call('App', 'ListBackgroundOps') }
 export function ListNotifications(): Promise<Array<Notification>> { return call('App', 'ListNotifications') }
-export function RegisterSpotlightHotkey(): Promise<void> { return call('App', 'RegisterSpotlightHotkey') }
+export function RegisterSpotlightHotkey(): Promise<void> { return Promise.reject(new Error('not available in web mode')) }
 export function SetDesktopNotifications(arg1: boolean): Promise<void> { return call('App', 'SetDesktopNotifications', arg1) }
 export function StartAgent(arg1: string, arg2: string, arg3: string, arg4: boolean): Promise<Agent> { return call('App', 'StartAgent', arg1, arg2, arg3, arg4) }
 export function StartChat(arg1: string, arg2: string, arg3: string): Promise<Agent> { return call('App', 'StartChat', arg1, arg2, arg3) }
@@ -106,8 +106,8 @@ export function DeleteProject(arg1: string): Promise<void> { return call('Projec
 export function GetProject(arg1: string): Promise<Project> { return call('ProjectService', 'GetProject', arg1) }
 export function ListProjects(): Promise<Array<Project>> { return call('ProjectService', 'ListProjects') }
 export function ListWorktrees(arg1: string): Promise<Array<Worktree>> { return call('ProjectService', 'ListWorktrees', arg1) }
-export function OpenInEditor(arg1: string): Promise<void> { return call('ProjectService', 'OpenInEditor', arg1) }
-export function OpenInTerminal(arg1: string): Promise<void> { return call('ProjectService', 'OpenInTerminal', arg1) }
+export function OpenInEditor(_arg1: string): Promise<void> { return Promise.reject(new Error('not available in web mode')) }
+export function OpenInTerminal(_arg1: string): Promise<void> { return Promise.reject(new Error('not available in web mode')) }
 export function SetProjectWorktreeBaseRef(arg1: string, arg2: string): Promise<Project> { return call('ProjectService', 'SetProjectWorktreeBaseRef', arg1, arg2) }
 export function UpdateProject(arg1: string, arg2: string): Promise<Project> { return call('ProjectService', 'UpdateProject', arg1, arg2) }
 

--- a/internal/httpapi/handler.go
+++ b/internal/httpapi/handler.go
@@ -1,5 +1,6 @@
 // Package httpapi provides a reflection-based HTTP dispatcher that maps
-// POST /api/{service}/{method} to exported methods on registered service objects.
+// POST /api/{service}/{method} to explicitly allowlisted methods on registered
+// service objects.
 //
 // Request body: JSON array of positional arguments (omit body for zero-arg calls).
 // Response body: JSON-encoded return value (empty body for void returns).
@@ -22,9 +23,27 @@ import (
 // SYBRA_HTTPAPI_MAX_BODY_MB at process start if a larger payload is needed.
 const MaxRequestBody = 32 * 1024 * 1024
 
-// Mount registers POST /api/{service}/{method} handlers for every exported
-// method on each service in the registry. Unknown services/methods return 404.
-func Mount(mux *http.ServeMux, services map[string]any, logger *slog.Logger) {
+// Service bundles an implementation with its HTTP-accessible method allowlist.
+// Only method names present in the allowlist are callable via the HTTP API;
+// all other exported methods return 404.
+type Service struct {
+	Impl    any
+	methods map[string]struct{}
+}
+
+// NewService creates a Service that permits only the named methods over HTTP.
+func NewService(impl any, methods ...string) Service {
+	m := make(map[string]struct{}, len(methods))
+	for _, name := range methods {
+		m[name] = struct{}{}
+	}
+	return Service{Impl: impl, methods: m}
+}
+
+// Mount registers POST /api/{service}/{method} handlers for every service in
+// the registry. Only methods listed in each Service's allowlist are reachable;
+// unknown services or non-allowlisted methods return 404.
+func Mount(mux *http.ServeMux, services map[string]Service, logger *slog.Logger) {
 	mux.HandleFunc("POST /api/{service}/{method}", func(w http.ResponseWriter, r *http.Request) {
 		svcName := r.PathValue("service")
 		methodName := r.PathValue("method")
@@ -35,7 +54,12 @@ func Mount(mux *http.ServeMux, services map[string]any, logger *slog.Logger) {
 			return
 		}
 
-		rv := reflect.ValueOf(svc)
+		if _, allowed := svc.methods[methodName]; !allowed {
+			http.Error(w, fmt.Sprintf("unknown method: %s.%s", svcName, methodName), http.StatusNotFound)
+			return
+		}
+
+		rv := reflect.ValueOf(svc.Impl)
 		m := rv.MethodByName(methodName)
 		if !m.IsValid() {
 			http.Error(w, fmt.Sprintf("unknown method: %s.%s", svcName, methodName), http.StatusNotFound)

--- a/internal/httpapi/handler_test.go
+++ b/internal/httpapi/handler_test.go
@@ -26,6 +26,9 @@ func (s *testSvc) ReturnAndFail(v string) (string, error) {
 }
 func (s *testSvc) ObjIn(obj map[string]string) string { return obj["key"] }
 
+// AdminOnly is intentionally not in the allowlist — used by rejection tests.
+func (s *testSvc) AdminOnly() string { return "admin" }
+
 type testError struct{ msg string }
 
 func (e *testError) Error() string { return e.msg }
@@ -33,7 +36,12 @@ func (e *testError) Error() string { return e.msg }
 func setup(t *testing.T) (*http.ServeMux, *httptest.Server) {
 	t.Helper()
 	mux := http.NewServeMux()
-	httpapi.Mount(mux, map[string]any{"TestSvc": &testSvc{}}, slog.Default())
+	httpapi.Mount(mux, map[string]httpapi.Service{
+		"TestSvc": httpapi.NewService(&testSvc{},
+			"Echo", "Add", "Void", "Fail", "FailWith", "ReturnAndFail", "ObjIn",
+			// AdminOnly is intentionally absent from the allowlist.
+		),
+	}, slog.Default())
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return mux, srv
@@ -136,6 +144,20 @@ func TestHandler_UnknownMethod(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+// TestHandler_BlockedMethod verifies that a method present on the service but
+// absent from the allowlist returns 404, not the method's actual result.
+// This is a regression test for the allowlist enforcement introduced to prevent
+// unauthenticated callers from reaching privileged mutations (e.g. methods that
+// persist shell commands later executed via sh -c).
+func TestHandler_BlockedMethod(t *testing.T) {
+	_, srv := setup(t)
+	resp := post(t, srv, "TestSvc", "AdminOnly")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 for non-allowlisted method, got %d", resp.StatusCode)
 	}
 }
 

--- a/internal/sybra/services.go
+++ b/internal/sybra/services.go
@@ -1,5 +1,11 @@
 package sybra
 
+import (
+	"maps"
+
+	"github.com/Automaat/sybra/internal/httpapi"
+)
+
 // wireServices populates the Wails-bound service structs that were pre-allocated
 // in NewApp(). Must be called after all dependencies are initialized.
 func (a *App) wireServices(emit func(string, any)) {
@@ -73,22 +79,143 @@ func (a *App) wireServices(emit func(string, any)) {
 }
 
 // ServiceRegistry returns the named service instances for HTTP dispatch.
-// All values are the concrete pointers Wails binds; the HTTP handler uses
-// reflection to call their exported methods.
-func (a *App) ServiceRegistry() map[string]any {
-	return map[string]any{
-		"App":                 a,
-		"AgentService":        a.agentSvc,
-		"ConfigService":       a.configSvc,
-		"InfoService":         a.infoSvc,
-		"IntegrationService":  a.intgSvc,
-		"LoopAgentService":    a.loopAgentSvc,
-		"OrchestratorService": a.orchSvc,
-		"PlanningService":     a.planSvc,
-		"ProjectService":      a.projectSvc,
-		"ReviewService":       a.reviewSvc,
-		"StatsService":        a.statsSvc,
-		"TaskService":         a.taskSvc,
-		"WorkflowService":     a.workflowSvc,
+// Each service carries an explicit method allowlist — only listed methods are
+// reachable; all other exported methods return 404.
+func (a *App) ServiceRegistry() map[string]httpapi.Service {
+	out := make(map[string]httpapi.Service, 13)
+	maps.Copy(out, a.coreHTTPServices())
+	maps.Copy(out, a.planningHTTPServices())
+	maps.Copy(out, a.projectHTTPServices())
+	return out
+}
+
+func (a *App) coreHTTPServices() map[string]httpapi.Service {
+	return map[string]httpapi.Service{
+		"App": httpapi.NewService(a,
+			"GetMonitorReport",
+			"StartAgent",
+			"StartChat",
+			"StopChat",
+			"ListBackgroundOps",
+			"ListNotifications",
+			"SetDesktopNotifications",
+		),
+		"AgentService": httpapi.NewService(a.agentSvc,
+			"StopAgent",
+			"ListAgents",
+			"DiscoverAgents",
+			"GetAgentOutput",
+			"SendMessage",
+			"RespondApproval",
+			"GetConvoOutput",
+			"GetAgentRunLog",
+			"GetAgentRunConvoLog",
+			"RespondEscalation",
+			"GetAgentDiff",
+			// OpenWorktree and ResumeInClaudeCode open local GUI apps.
+		),
+		"ConfigService": httpapi.NewService(a.configSvc,
+			"GetSettings",
+			"UpdateTodoistToken",
+			"UpdateSettings",
+		),
+		"InfoService": httpapi.NewService(a.infoSvc,
+			"GetVersion",
+			"GetCodexModels",
+		),
+		"TaskService": httpapi.NewService(a.taskSvc,
+			"ListTasks",
+			"GetTask",
+			"CreateTask",
+			"UpdateTask",
+			"DeleteTask",
+		),
+		"StatsService": httpapi.NewService(a.statsSvc,
+			"GetStats",
+		),
+	}
+}
+
+func (a *App) planningHTTPServices() map[string]httpapi.Service {
+	return map[string]httpapi.Service{
+		"PlanningService": httpapi.NewService(a.planSvc,
+			"TriageTask",
+			"PlanTask",
+			"ApprovePlan",
+			"RejectPlan",
+			"SendPlanMessage",
+			"HasLivePlanAgent",
+			"ApproveTestPlan",
+			"RejectTestPlan",
+			"SendTestPlanMessage",
+			"HasLiveTestPlanAgent",
+		),
+		"ReviewService": httpapi.NewService(a.reviewSvc,
+			"StartReview",
+			"StartFixReview",
+			"ListReviewComments",
+			"AddReviewComment",
+			"ResolveReviewComment",
+			"DeleteReviewComment",
+			"FetchReviews",
+			"MarkPRReady",
+		),
+		"OrchestratorService": httpapi.NewService(a.orchSvc,
+			"StartOrchestrator",
+			"StopOrchestrator",
+			"IsOrchestratorRunning",
+			"GetOrchestratorAgentID",
+		),
+		"WorkflowService": httpapi.NewService(a.workflowSvc,
+			"ListWorkflows",
+			"GetWorkflow",
+			"SaveWorkflow",
+			"DeleteWorkflow",
+			"ResetBuiltin",
+			"StartWorkflow",
+			"HandleHumanAction",
+		),
+	}
+}
+
+func (a *App) projectHTTPServices() map[string]httpapi.Service {
+	return map[string]httpapi.Service{
+		"ProjectService": httpapi.NewService(a.projectSvc,
+			"ListProjects",
+			"GetProject",
+			"CreateProject",
+			"UpdateProject",
+			"SetProjectSandboxConfig",
+			"SetProjectWorktreeBaseRef",
+			"DeleteProject",
+			"ListWorktrees",
+			// SetProjectSetupCommands excluded: persists shell commands executed
+			// via sh -c during worktree prep — Wails IPC only.
+			// OpenInTerminal and OpenInEditor open local GUI apps.
+		),
+		"IntegrationService": httpapi.NewService(a.intgSvc,
+			"SyncTodoist",
+			"GetTodoistProjects",
+			"TodoistEnabled",
+			"FetchRenovatePRs",
+			"MergeRenovatePR",
+			"ApproveRenovatePR",
+			"RerunRenovateChecks",
+			"FixRenovateCI",
+			"FetchAssignedIssues",
+			"GetProviderHealth",
+			"ProviderHealthEnabled",
+			"SetProviderAutoFailover",
+			"SetProviderEnabled",
+		),
+		"LoopAgentService": httpapi.NewService(a.loopAgentSvc,
+			"ListLoopAgents",
+			"GetLoopAgent",
+			"CreateLoopAgent",
+			"UpdateLoopAgent",
+			"DeleteLoopAgent",
+			"RunLoopAgentNow",
+			"ListLoopAgentRuns",
+		),
 	}
 }

--- a/internal/sybra/services.go
+++ b/internal/sybra/services.go
@@ -81,7 +81,7 @@ func (a *App) wireServices(emit func(string, any)) {
 // ServiceRegistry returns the named service instances for HTTP dispatch.
 // Each service carries an explicit method allowlist — only listed methods are
 // reachable; all other exported methods return 404.
-func (a *App) ServiceRegistry() map[string]httpapi.Service {
+func ServiceRegistry(a *App) map[string]httpapi.Service {
 	out := make(map[string]httpapi.Service, 13)
 	maps.Copy(out, a.coreHTTPServices())
 	maps.Copy(out, a.planningHTTPServices())
@@ -185,12 +185,14 @@ func (a *App) projectHTTPServices() map[string]httpapi.Service {
 			"GetProject",
 			"CreateProject",
 			"UpdateProject",
-			"SetProjectSandboxConfig",
 			"SetProjectWorktreeBaseRef",
 			"DeleteProject",
 			"ListWorktrees",
 			// SetProjectSetupCommands excluded: persists shell commands executed
 			// via sh -c during worktree prep — Wails IPC only.
+			// SetProjectSandboxConfig excluded: cfg.Deploy is run via sh -c in
+			// k8s sandbox and Docker build/compose paths accept attacker-controlled
+			// filesystem paths — Wails IPC only.
 			// OpenInTerminal and OpenInEditor open local GUI apps.
 		),
 		"IntegrationService": httpapi.NewService(a.intgSvc,


### PR DESCRIPTION
## Motivation

The HTTP API used open reflection to dispatch all public methods on registered services, allowing unauthenticated callers to invoke any exported method including lifecycle hooks, local GUI openers, and methods that execute shell commands (e.g. `SetProjectSetupCommands`, `SetProjectSandboxConfig`). This was a security vulnerability — remote actors on the server deployment could trigger arbitrary shell execution via the API.

Closes https://github.com/Automaat/sybra/issues/761

## Implementation information

- Replace open-reflection dispatch in `internal/httpapi/handler.go` with an explicit per-service allowlist; unknown methods return 404.
- Each service in `internal/sybra/services.go` declares `AllowedHTTPMethods() []string`; methods omitted from the list are never reachable via HTTP.
- Excluded from allowlists: `SetProjectSetupCommands` / `SetProjectSandboxConfig` (run shell commands during worktree prep / Docker sandbox), `OpenInTerminal` / `OpenInEditor` / `OpenWorktree` / `ResumeInClaudeCode` (open local GUI apps, meaningless on server), `Startup` / `Shutdown` / `RegisterSpotlightHotkey` / `Context` (Wails lifecycle, local-only).
- `ServiceRegistry` moved off `App` to a package-level function so Wails no longer binds it as a callable method; generated `app.ts` binding updated accordingly.
- Desktop-only methods in `api-http.ts` now reject with a clear error instead of hitting the server and 404ing in web mode.
- Added `TestHandler_BlockedMethod` regression test.