### PR TITLE
fix(monitor): align dispatch limit default

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -536,7 +536,7 @@ func applyMonitorDefaults(cfg *Config) {
 		cfg.Monitor.IssueCooldownMinutes = 30
 	}
 	if cfg.Monitor.DispatchLimit <= 0 {
-		cfg.Monitor.DispatchLimit = 3
+		cfg.Monitor.DispatchLimit = cfg.Agent.MaxConcurrent
 	}
 	if cfg.Monitor.StuckHumanHours <= 0 {
 		cfg.Monitor.StuckHumanHours = 8

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -78,6 +78,42 @@ func TestLoadProviderDefaultAndPersistedValue(t *testing.T) {
 	}
 }
 
+func TestLoadMonitorDispatchLimitDefaultsToAgentLimit(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+
+	yaml := []byte("agent:\n  max_concurrent: 10\n")
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), yaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Monitor.DispatchLimit != 10 {
+		t.Fatalf("dispatch limit = %d, want 10", cfg.Monitor.DispatchLimit)
+	}
+}
+
+func TestLoadMonitorDispatchLimitPreservesOverride(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+
+	yaml := []byte("agent:\n  max_concurrent: 10\nmonitor:\n  dispatch_limit: 4\n")
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), yaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Monitor.DispatchLimit != 4 {
+		t.Fatalf("dispatch limit = %d, want 4", cfg.Monitor.DispatchLimit)
+	}
+}
+
 func TestLoadEnvOverride(t *testing.T) {
 	t.Setenv("SYBRA_HOME", t.TempDir())
 	t.Setenv("SYBRA_LOG_LEVEL", "error")


### PR DESCRIPTION
## Motivation

Monitor reports over-dispatch when in-progress tasks exceed its dispatch limit. Live config can raise agent concurrency with agent.max_concurrent, but monitor.dispatch_limit stayed at default 3 when omitted. That produced false bug issues on valid boards.

Closes https://github.com/Automaat/sybra/issues/719

> Changelog: fix(monitor): align dispatch limit default

## Implementation information

Default monitor.dispatch_limit to agent.max_concurrent when no explicit monitor override exists. Preserve explicit monitor.dispatch_limit values.

Added config tests for both defaulting and override behavior.

## Supporting documentation

Issue: https://github.com/Automaat/sybra/issues/719