### PR TITLE
fix(github): split review summary fetch

### DIFF
--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -18,6 +18,25 @@ func (f *fakeExecer) run(_ ...string) ([]byte, error) {
 	return f.output, f.err
 }
 
+type sequenceExecer struct {
+	outputs [][]byte
+	errs    []error
+	calls   int
+}
+
+func (s *sequenceExecer) run(_ ...string) ([]byte, error) {
+	i := s.calls
+	s.calls++
+	if i >= len(s.outputs) {
+		return nil, fmt.Errorf("unexpected call %d", i+1)
+	}
+	var err error
+	if i < len(s.errs) {
+		err = s.errs[i]
+	}
+	return s.outputs[i], err
+}
+
 // recordingExecer captures the args of the most recent run() invocation
 // so tests can assert which command was dispatched.
 type recordingExecer struct {

--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -7,114 +7,13 @@ import (
 	"time"
 )
 
-// reviewSummaryQuery fans out two PR searches in one request.
-//
-// Caps were tightened after GitHub's GraphQL edge consistently 502'd this
-// query for accounts with non-trivial PR sets. The original `first:100`
-// search × deep `reviewThreads(first:100) + latestReviews(first:20) +
-// contexts(first:50) + labels(first:10)` blew through ~36K complexity
-// points before the doubling, sitting near GitHub's ~50K cutoff. The caps
-// below preserve every consumer (UnresolvedCount, ViewerHasApproved,
-// HasPendingChecks, Labels) but slash complexity ~85%.
-const reviewSummaryQuery = `query($createdQ: String!, $requestedQ: String!, $reviewedQ: String!) {
+// reviewSummaryQuery fetches one PR search leg. FetchReviews runs it once per
+// query instead of fanning out multiple search legs in one GraphQL request; the
+// combined form times out at GitHub's edge for accounts with many open review
+// requests.
+const reviewSummaryQuery = `query($q: String!) {
   viewer { login }
-  created: search(query: $createdQ, type: ISSUE, first: 50) {
-    nodes {
-      ... on PullRequest {
-        number
-        title
-        url
-        headRefName
-        isDraft
-        mergeable
-        createdAt
-        updatedAt
-        reviewDecision
-        author { login type: __typename }
-        repository { name nameWithOwner }
-        labels(first: 5) { nodes { name } }
-        commits(last: 1) {
-          nodes {
-            commit {
-              oid
-              statusCheckRollup {
-                state
-                contexts(first: 20) {
-                  nodes {
-                    __typename
-                    ... on CheckRun {
-                      name
-                      status
-                      conclusion
-                    }
-                    ... on StatusContext {
-                      name: context
-                      state
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-        reviewThreads(first: 20) {
-          nodes { isResolved }
-        }
-        latestReviews(first: 10) {
-          nodes { state author { login } }
-        }
-      }
-    }
-  }
-  requested: search(query: $requestedQ, type: ISSUE, first: 50) {
-    nodes {
-      ... on PullRequest {
-        number
-        title
-        url
-        headRefName
-        isDraft
-        mergeable
-        createdAt
-        updatedAt
-        reviewDecision
-        author { login type: __typename }
-        repository { name nameWithOwner }
-        labels(first: 5) { nodes { name } }
-        commits(last: 1) {
-          nodes {
-            commit {
-              oid
-              statusCheckRollup {
-                state
-                contexts(first: 20) {
-                  nodes {
-                    __typename
-                    ... on CheckRun {
-                      name
-                      status
-                      conclusion
-                    }
-                    ... on StatusContext {
-                      name: context
-                      state
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-        reviewThreads(first: 20) {
-          nodes { isResolved }
-        }
-        latestReviews(first: 10) {
-          nodes { state author { login } }
-        }
-      }
-    }
-  }
-  reviewed: search(query: $reviewedQ, type: ISSUE, first: 50) {
+  search(query: $q, type: ISSUE, first: 50) {
     nodes {
       ... on PullRequest {
         number
@@ -169,15 +68,9 @@ type gqlReviewSummaryResponse struct {
 		Viewer struct {
 			Login string `json:"login"`
 		} `json:"viewer"`
-		Created struct {
+		Search struct {
 			Nodes []gqlPR `json:"nodes"`
-		} `json:"created"`
-		Requested struct {
-			Nodes []gqlPR `json:"nodes"`
-		} `json:"requested"`
-		Reviewed struct {
-			Nodes []gqlPR `json:"nodes"`
-		} `json:"reviewed"`
+		} `json:"search"`
 	} `json:"data"`
 	Errors []struct {
 		Message string `json:"message"`
@@ -207,38 +100,57 @@ func fetchReviewsWith(e execer) (ReviewSummary, error) {
 		}
 	}
 
-	resp, err := runGHAPIWith(e, "", "graphql",
-		"-f", "query="+reviewSummaryQuery,
-		"-f", "createdQ="+createdQuery,
-		"-f", "requestedQ="+requestedQuery,
-		"-f", "reviewedQ="+reviewedQuery)
+	created, err := fetchReviewSearchWith(e, createdQuery)
 	if err != nil {
-		if runtimeCacheEnabled(e) {
-			if stale, ok := reviewSummaryCache.GetStale(cacheKey); ok {
-				return stale, nil
-			}
-		}
-		return ReviewSummary{}, fmt.Errorf("gh api graphql: %s: %w", sanitizeGHOutput(resp.body), err)
+		return staleReviewSummaryOrError(e, cacheKey, "created", err)
 	}
-
-	var gqlResp gqlReviewSummaryResponse
-	if err := json.Unmarshal(resp.body, &gqlResp); err != nil {
-		return ReviewSummary{}, fmt.Errorf("parse graphql response: %w", err)
+	requested, err := fetchReviewSearchWith(e, requestedQuery)
+	if err != nil {
+		return staleReviewSummaryOrError(e, cacheKey, "requested", err)
 	}
-	if len(gqlResp.Errors) > 0 {
-		return ReviewSummary{}, fmt.Errorf("graphql: %s", gqlResp.Errors[0].Message)
+	reviewed, err := fetchReviewSearchWith(e, reviewedQuery)
+	if err != nil {
+		return staleReviewSummaryOrError(e, cacheKey, "reviewed", err)
 	}
 
 	summary := ReviewSummary{
-		CreatedByMe:     convertPRs(gqlResp.Data.Created.Nodes, gqlResp.Data.Viewer.Login),
-		ReviewRequested: convertPRs(gqlResp.Data.Requested.Nodes, gqlResp.Data.Viewer.Login),
-		ReviewedByMe:    approvedOnly(convertPRs(gqlResp.Data.Reviewed.Nodes, gqlResp.Data.Viewer.Login)),
+		CreatedByMe:     created,
+		ReviewRequested: requested,
+		ReviewedByMe:    approvedOnly(reviewed),
 	}
 	if runtimeCacheEnabled(e) {
 		reviewSummaryCache.Set(cacheKey, summary, 20*time.Second)
 	}
 
 	return summary, nil
+}
+
+func staleReviewSummaryOrError(e execer, cacheKey, leg string, err error) (ReviewSummary, error) {
+	if runtimeCacheEnabled(e) {
+		if stale, ok := reviewSummaryCache.GetStale(cacheKey); ok {
+			return stale, nil
+		}
+	}
+	return ReviewSummary{}, fmt.Errorf("fetch %s reviews: %w", leg, err)
+}
+
+func fetchReviewSearchWith(e execer, query string) ([]PullRequest, error) {
+	resp, err := runGHAPIWith(e, "", "graphql",
+		"-f", "query="+reviewSummaryQuery,
+		"-f", "q="+query)
+	if err != nil {
+		return nil, fmt.Errorf("gh api graphql: %s: %w", sanitizeGHOutput(resp.body), err)
+	}
+
+	var gqlResp gqlReviewSummaryResponse
+	if err := json.Unmarshal(resp.body, &gqlResp); err != nil {
+		return nil, fmt.Errorf("parse graphql response: %w", err)
+	}
+	if len(gqlResp.Errors) > 0 {
+		return nil, fmt.Errorf("graphql: %s", gqlResp.Errors[0].Message)
+	}
+
+	return convertPRs(gqlResp.Data.Search.Nodes, gqlResp.Data.Viewer.Login), nil
 }
 
 func approvedOnly(prs []PullRequest) []PullRequest {

--- a/internal/github/review_test.go
+++ b/internal/github/review_test.go
@@ -7,10 +7,10 @@ import (
 
 func TestFetchReviewsWith_success(t *testing.T) {
 	t.Parallel()
-	response := `{
+	createdResponse := `{
 		"data": {
 			"viewer": {"login": "me"},
-			"created": {
+			"search": {
 				"nodes": [
 					{
 						"number": 1,
@@ -23,8 +23,13 @@ func TestFetchReviewsWith_success(t *testing.T) {
 						"reviewThreads": {"nodes": []}
 					}
 				]
-			},
-			"requested": {
+			}
+		}
+	}`
+	requestedResponse := `{
+		"data": {
+			"viewer": {"login": "me"},
+			"search": {
 				"nodes": [
 					{
 						"number": 2,
@@ -38,8 +43,13 @@ func TestFetchReviewsWith_success(t *testing.T) {
 						"latestReviews": {"nodes": []}
 					}
 				]
-			},
-			"reviewed": {
+			}
+		}
+	}`
+	reviewedResponse := `{
+		"data": {
+			"viewer": {"login": "me"},
+			"search": {
 				"nodes": [
 					{
 						"number": 3,
@@ -68,13 +78,17 @@ func TestFetchReviewsWith_success(t *testing.T) {
 		}
 	}`
 
-	fe := &fakeExecer{output: []byte(response)}
+	fe := &sequenceExecer{outputs: [][]byte{
+		[]byte(createdResponse),
+		[]byte(requestedResponse),
+		[]byte(reviewedResponse),
+	}}
 	summary, err := fetchReviewsWith(fe)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if fe.calls != 1 {
-		t.Errorf("calls = %d, want 1", fe.calls)
+	if fe.calls != 3 {
+		t.Errorf("calls = %d, want 3", fe.calls)
 	}
 	if len(summary.CreatedByMe) != 1 {
 		t.Errorf("CreatedByMe len = %d, want 1", len(summary.CreatedByMe))
@@ -92,10 +106,10 @@ func TestFetchReviewsWith_success(t *testing.T) {
 
 func TestFetchReviewsWith_failedCheckRunConclusion(t *testing.T) {
 	t.Parallel()
-	response := `{
+	createdResponse := `{
 		"data": {
 			"viewer": {"login": "me"},
-			"created": {
+			"search": {
 				"nodes": [
 					{
 						"number": 1,
@@ -119,13 +133,21 @@ func TestFetchReviewsWith_failedCheckRunConclusion(t *testing.T) {
 						"latestReviews": {"nodes": []}
 					}
 				]
-			},
-			"requested": {"nodes": []},
-			"reviewed": {"nodes": []}
+			}
+		}
+	}`
+	emptyResponse := `{
+		"data": {
+			"viewer": {"login": "me"},
+			"search": {"nodes": []}
 		}
 	}`
 
-	fe := &fakeExecer{output: []byte(response)}
+	fe := &sequenceExecer{outputs: [][]byte{
+		[]byte(createdResponse),
+		[]byte(emptyResponse),
+		[]byte(emptyResponse),
+	}}
 	summary, err := fetchReviewsWith(fe)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
## Motivation

PR monitor summary fetch can fail when one broad GraphQL request loads too many review-related PR details. That blocks CI-fix detection before workflow dispatch.

> Changelog: fix(github): split review summary fetch

## Implementation information

Split review summary loading into three smaller GraphQL calls for authored, requested, and reviewed PRs. Keep conversion, cache fallback, and approved-review filtering behavior unchanged. Added sequence test coverage for the new multi-call path.

## Supporting documentation

Live verification: each split query returns successfully while preserving existing fields.