### PR TITLE
fix(project): avoid unnecessary force pushes

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -22,7 +22,7 @@ var (
 	repoRe = regexp.MustCompile(`^[a-zA-Z0-9_.-]{1,100}$`)
 )
 
-// ErrBranchMissing is returned by PushForce when the local branch ref does not exist.
+// ErrBranchMissing is returned by PushSync when the local branch ref does not exist.
 var ErrBranchMissing = errors.New("local branch ref does not exist")
 
 // LoadRepoConfig reads .sybra.yaml from the worktree root. Returns an empty
@@ -413,11 +413,17 @@ func CurrentBranch(worktreePath string) (string, error) {
 	return strings.TrimSpace(branch), nil
 }
 
-// PushForce force-pushes the branch to the fork remote if present, else
-// origin, using --force-with-lease. Used after a local rebase to sync the
-// remote without overwriting commits from other authors. Returns
-// ErrBranchMissing if the local branch ref does not exist.
-func PushForce(worktreePath, branch string) error {
+// PushSync syncs the branch to the fork remote (if present) or origin using
+// the minimum mode required:
+//   - first push (remote tracking ref absent): regular push with -u
+//   - local SHA == remote tracking SHA: no-op
+//   - remote tracking SHA is an ancestor of local (fast-forward): regular push
+//   - histories diverged: --force-with-lease
+//
+// Compared to an unconditional force push, this avoids gratuitous rewrites of
+// the remote when a rebase was a no-op or the agent produced no new commits.
+// Returns ErrBranchMissing if the local branch ref does not exist.
+func PushSync(worktreePath, branch string) error {
 	if err := executil.Run(worktreePath, "git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
@@ -425,7 +431,31 @@ func PushForce(worktreePath, branch string) error {
 		}
 		return err
 	}
-	return executil.Run(worktreePath, "git", "push", "--force-with-lease", "-u", PushRemote(worktreePath), branch)
+
+	remote := PushRemote(worktreePath)
+	localSHA, err := executil.Output(worktreePath, "git", "rev-parse", "--verify", "refs/heads/"+branch)
+	if err != nil {
+		return err
+	}
+
+	remoteSHA, remoteErr := executil.Output(worktreePath, "git", "rev-parse", "--verify", "refs/remotes/"+remote+"/"+branch)
+	if remoteErr != nil {
+		// Remote tracking ref unknown — first push, set upstream.
+		return executil.Run(worktreePath, "git", "push", "-u", remote, branch)
+	}
+
+	if localSHA == remoteSHA {
+		return nil
+	}
+
+	// Fast-forward when remote SHA is reachable from local SHA.
+	ffCmd := exec.Command("git", "merge-base", "--is-ancestor", remoteSHA, localSHA)
+	ffCmd.Dir = worktreePath
+	if ffCmd.Run() == nil {
+		return executil.Run(worktreePath, "git", "push", "-u", remote, branch)
+	}
+
+	return executil.Run(worktreePath, "git", "push", "--force-with-lease", "-u", remote, branch)
 }
 
 func RemoveWorktree(barePath, worktreePath string) error {

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1170,5 +1171,212 @@ func TestListWorktrees_OrphanedAdminDir(t *testing.T) {
 		if wt.Path == wtPath {
 			t.Errorf("orphan %s still listed after prune", wt.Path)
 		}
+	}
+}
+
+// setupPushSyncWorktree builds: bare "remote" ← bare sybra clone ← worktree.
+// The worktree pushes against the remote bare, which accepts force pushes
+// and lets us inspect ref state to verify PushSync's mode selection.
+func setupPushSyncWorktree(t *testing.T) (remoteBare, wtPath, wtBranch string) {
+	t.Helper()
+	src := initRepoWithCommit(t)
+	remoteBare = filepath.Join(t.TempDir(), "remote.git")
+	if out, err := exec.Command("git", "init", "--bare", remoteBare).CombinedOutput(); err != nil {
+		t.Fatalf("init remote bare: %v: %s", err, out)
+	}
+	// Enable reflog on the bare so we can count actual ref updates per branch.
+	if out, err := exec.Command("git", "-C", remoteBare, "config", "core.logAllRefUpdates", "true").CombinedOutput(); err != nil {
+		t.Fatalf("config logAllRefUpdates: %v: %s", err, out)
+	}
+	for _, args := range [][]string{
+		{"-C", src, "remote", "add", "rem", remoteBare},
+		{"-C", src, "push", "rem", "HEAD"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+
+	sybraBare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(remoteBare, sybraBare); err != nil {
+		t.Fatalf("clone bare: %v", err)
+	}
+	branch, err := DefaultBranch(sybraBare)
+	if err != nil {
+		t.Fatalf("default branch: %v", err)
+	}
+	wtPath = filepath.Join(t.TempDir(), "wt")
+	wtBranch = "sybra/push-test"
+	if err := CreateWorktree(sybraBare, wtPath, wtBranch, branch); err != nil {
+		t.Fatalf("create worktree: %v", err)
+	}
+	for _, args := range [][]string{
+		{"config", "user.email", "test@test.com"},
+		{"config", "user.name", "Test"},
+		{"config", "commit.gpgsign", "false"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = wtPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	return remoteBare, wtPath, wtBranch
+}
+
+// makeCommit writes a file and creates a commit in wtPath. Returns the new HEAD SHA.
+func makeCommit(t *testing.T, wtPath, content string) string {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(wtPath, "data.txt"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"add", "."},
+		{"commit", "-m", "change: " + content},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = wtPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = wtPath
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// remoteRefSHA returns the SHA the remote bare resolves for branch, or "" if absent.
+func remoteRefSHA(t *testing.T, remoteBare, branch string) string {
+	t.Helper()
+	cmd := exec.Command("git", "-C", remoteBare, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch)
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// remoteReflogCount returns the number of reflog entries for branch on the remote bare.
+func remoteReflogCount(t *testing.T, remoteBare, branch string) int {
+	t.Helper()
+	cmd := exec.Command("git", "-C", remoteBare, "reflog", "show", "refs/heads/"+branch)
+	out, _ := cmd.Output() // empty output is fine when the ref has no entries yet
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return 0
+	}
+	return strings.Count(trimmed, "\n") + 1
+}
+
+func TestPushSync_BranchMissing(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	_, wtPath, _ := setupPushSyncWorktree(t)
+	if err := PushSync(wtPath, "no-such-branch"); !errors.Is(err, ErrBranchMissing) {
+		t.Fatalf("PushSync missing branch: got %v, want ErrBranchMissing", err)
+	}
+}
+
+func TestPushSync_FirstPushSetsTracking(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
+	localSHA := makeCommit(t, wtPath, "first")
+
+	if err := PushSync(wtPath, branch); err != nil {
+		t.Fatalf("PushSync first push: %v", err)
+	}
+	if got := remoteRefSHA(t, remoteBare, branch); got != localSHA {
+		t.Fatalf("remote SHA after first push = %q, want %q", got, localSHA)
+	}
+}
+
+func TestPushSync_NoopWhenSynced(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
+	makeCommit(t, wtPath, "one")
+	if err := PushSync(wtPath, branch); err != nil {
+		t.Fatalf("PushSync first: %v", err)
+	}
+	entriesBefore := remoteReflogCount(t, remoteBare, branch)
+	if entriesBefore == 0 {
+		t.Fatalf("first push left no reflog entry (logAllRefUpdates may be off)")
+	}
+
+	// Second sync with no local changes must not touch the remote.
+	if err := PushSync(wtPath, branch); err != nil {
+		t.Fatalf("PushSync second (no-op): %v", err)
+	}
+	if got := remoteReflogCount(t, remoteBare, branch); got != entriesBefore {
+		t.Fatalf("remote reflog grew from %d to %d on a no-op sync (a push was issued)", entriesBefore, got)
+	}
+}
+
+func TestPushSync_FastForwardWithoutForce(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
+	makeCommit(t, wtPath, "one")
+	if err := PushSync(wtPath, branch); err != nil {
+		t.Fatalf("PushSync seed: %v", err)
+	}
+
+	// Reject force-pushes on the remote so a fast-forward must succeed without force.
+	if out, err := exec.Command("git", "-C", remoteBare, "config", "receive.denyNonFastForwards", "true").CombinedOutput(); err != nil {
+		t.Fatalf("denyNonFastForwards: %v: %s", err, out)
+	}
+
+	newSHA := makeCommit(t, wtPath, "two")
+	if err := PushSync(wtPath, branch); err != nil {
+		t.Fatalf("PushSync fast-forward: %v", err)
+	}
+	if got := remoteRefSHA(t, remoteBare, branch); got != newSHA {
+		t.Fatalf("remote SHA after fast-forward = %q, want %q", got, newSHA)
+	}
+}
+
+func TestPushSync_DivergenceForcePushes(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
+	makeCommit(t, wtPath, "one")
+	makeCommit(t, wtPath, "two")
+	if err := PushSync(wtPath, branch); err != nil {
+		t.Fatalf("PushSync seed: %v", err)
+	}
+
+	// Rewrite history locally so HEAD diverges from the remote tracking ref.
+	if out, err := exec.Command("git", "-C", wtPath, "reset", "--hard", "HEAD~1").CombinedOutput(); err != nil {
+		t.Fatalf("reset: %v: %s", err, out)
+	}
+	divergedSHA := makeCommit(t, wtPath, "two-prime")
+
+	// Prove a regular push would now be rejected — only force-with-lease should succeed.
+	rejectCmd := exec.Command("git", "push", "origin", branch)
+	rejectCmd.Dir = wtPath
+	if out, err := rejectCmd.CombinedOutput(); err == nil {
+		t.Fatalf("expected regular push to be rejected on divergence; succeeded: %s", out)
+	}
+
+	if err := PushSync(wtPath, branch); err != nil {
+		t.Fatalf("PushSync divergence: %v", err)
+	}
+	if got := remoteRefSHA(t, remoteBare, branch); got != divergedSHA {
+		t.Fatalf("remote SHA after force-with-lease = %q, want %q", got, divergedSHA)
 	}
 }

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -215,7 +215,7 @@ func (h *AgentCompletionHandler) pushFixReviewBranch(ag *agent.Agent) {
 		}
 	}
 
-	if err := project.PushForce(wtPath, branch); err != nil {
+	if err := project.PushSync(wtPath, branch); err != nil {
 		if errors.Is(err, project.ErrBranchMissing) {
 			h.logger.Info("fix-review.push-skipped", "task_id", ag.TaskID, "agent_id", ag.ID, "branch", branch, "reason", "local branch ref missing")
 			return

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -166,10 +166,11 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 				m.logger.Warn("worktree.rebase-skipped", "task_id", t.ID, "base", baseRef, "err", err)
 			} else {
 				m.logger.Info("worktree.rebased", "task_id", t.ID, "path", wtPath, "base", baseRef)
-				// Sync remote after rebase — local SHAs changed, remote still has
-				// old commits. create_pr push would fail with "diverged" otherwise.
-				callPhase(onPhase, "Pushing upstream…")
-				m.logPushForce(t.ID, wtBranch, project.PushForce(wtPath, wtBranch))
+				// Sync remote after rebase. PushSync picks the minimum mode —
+				// no-op when local matches remote, regular push for
+				// fast-forward, --force-with-lease only on divergence.
+				callPhase(onPhase, "Syncing upstream…")
+				m.logPushSync(t.ID, wtBranch, project.PushSync(wtPath, wtBranch))
 			}
 			return m.finalizeWorktree(t, wtPath, wtBranch, proj)
 		}
@@ -191,8 +192,8 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 			m.logger.Warn("worktree.rebase-skipped", "task_id", t.ID, "base", baseRef, "err", err)
 		} else {
 			// Sync remote after rebase.
-			callPhase(onPhase, "Pushing upstream…")
-			m.logPushForce(t.ID, wtBranch, project.PushForce(wtPath, wtBranch))
+			callPhase(onPhase, "Syncing upstream…")
+			m.logPushSync(t.ID, wtBranch, project.PushSync(wtPath, wtBranch))
 		}
 		m.logger.Info("worktree.reused-branch", "task_id", t.ID, "path", wtPath, "branch", wtBranch)
 		callPhase(onPhase, "Running setup…")
@@ -729,14 +730,14 @@ func (m *Manager) ensureBranch(t task.Task, branch string) {
 	}
 }
 
-func (m *Manager) logPushForce(taskID, branch string, err error) {
+func (m *Manager) logPushSync(taskID, branch string, err error) {
 	if err == nil {
 		return
 	}
 	if errors.Is(err, project.ErrBranchMissing) {
-		m.logger.Info("worktree.push-force-skipped", "task_id", taskID, "branch", branch, "reason", "local branch ref missing")
+		m.logger.Info("worktree.push-sync-skipped", "task_id", taskID, "branch", branch, "reason", "local branch ref missing")
 	} else {
-		m.logger.Warn("worktree.push-force", "task_id", taskID, "branch", branch, "err", err)
+		m.logger.Warn("worktree.push-sync", "task_id", taskID, "branch", branch, "err", err)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Sybra force-pushed on every task start and every fix-review completion, even when there was nothing to rewrite. `internal/worktree/manager.go` called `PushForce` after every rebase (including no-op rebases that left local SHAs untouched), and `pushFixReviewBranch` force-pushed after every fix-review agent regardless of whether new commits were produced. Result: noisy `--force-with-lease` traffic against fork/origin where a plain push (or no push at all) would have sufficed.

## Implementation information

Replaced `project.PushForce` with `project.PushSync`. `PushSync` resolves local SHA, then compares against the configured push remote's tracking ref (`fork` if present, else `origin`) and picks the minimum mode:

- remote tracking ref absent → `git push -u <remote> <branch>` (first push, sets upstream)
- local SHA == remote SHA → no-op, returns nil without invoking `git push`
- remote SHA is an ancestor of local (fast-forward) → `git push -u <remote> <branch>` (no force)
- histories diverged → `git push --force-with-lease -u <remote> <branch>`

`ErrBranchMissing` semantics preserved. Callers in `internal/worktree/manager.go` (two rebase post-push sites) and `internal/sybra/agent_completion.go` (`pushFixReviewBranch`) now go through `PushSync`. Manager log keys renamed `worktree.push-force*` → `worktree.push-sync*`. The merge-conflict-fix agent prompt in `internal/sybra/app_reviews.go` still tells the agent to `git push --force-with-lease` — that path is genuinely post-rebase and stays as-is.

Tests in `internal/project/git_test.go` cover all four branches: branch-missing returns the sentinel, first push sets the remote ref, repeated sync leaves the remote reflog count unchanged (proving no push ran), fast-forward succeeds with `receive.denyNonFastForwards=true` set on the remote (proving force wasn't used), and divergence succeeds only after a regular push is shown to be rejected (proving `--force-with-lease` was used).

Alternatives discarded:

- Skip the post-rebase push entirely when `git rebase` reported "already up to date" — requires parsing rebase output, doesn't cover the fix-review path, and still leaves divergent local branches unsynced when the rebase did rewrite SHAs.
- Always run `git push` and let the remote reject no-ops — still issues a network round-trip and keeps `--force-with-lease` semantics where they aren't needed.

## Supporting documentation

User report: "sybra is doing a lot of force pushes, I dont like it. We should do force pushes only when necessary."