### PR TITLE
fix(agent): widen codex skill discovery

### DIFF
--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -186,7 +186,7 @@ func buildCodexConvoArgs(a *Agent, cfg RunConfig, prompt string) []string {
 	if a.sessionCWD != "" {
 		args = append(args, "-C", a.sessionCWD)
 	}
-	args = append(args, prompt)
+	args = append(args, rewriteSkillInvocations(prompt, discoverCodexSkills()))
 	return args
 }
 

--- a/internal/agent/skill_invoke.go
+++ b/internal/agent/skill_invoke.go
@@ -38,15 +38,46 @@ func rewriteSkillInvocations(prompt string, skillNames []string) string {
 	return prompt
 }
 
-// discoverCodexSkills returns the list of skill names installed under
-// ~/.codex/skills/. A skill name is a direct subdir containing a SKILL.md
-// file. Returns nil on any error — the caller treats that as "no rewrite".
+// discoverCodexSkills returns the union of skill names sybra knows about for
+// the codex skill rewriter. A "known" skill is one whose name shows up in
+// any of: ~/.codex/skills/, ~/.claude/skills/, ~/.codex/plugins/cache/*/*/*/skills/,
+// or ~/.claude/plugins/cache/*/*/*/skills/. Pulling from both providers and
+// their plugin caches matters because /staff-code-review can be installed
+// for claude via the sai plugin marketplace but absent from ~/.codex/skills/
+// — without that name in the set, the rewriter leaves /staff-code-review in
+// the prompt and codex tries to exec it as a shell path.
+//
+// Returns a deduped, deterministically-ordered slice. nil on any home-dir
+// error — caller treats that as "no rewrite".
 func discoverCodexSkills() []string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil
 	}
-	return listSkillDirs(filepath.Join(home, ".codex", "skills"))
+	seen := make(map[string]struct{}, 64)
+	for _, name := range listSkillDirs(filepath.Join(home, ".codex", "skills")) {
+		seen[name] = struct{}{}
+	}
+	for _, name := range listSkillDirs(filepath.Join(home, ".claude", "skills")) {
+		seen[name] = struct{}{}
+	}
+	for _, root := range []string{
+		filepath.Join(home, ".codex", "plugins", "cache"),
+		filepath.Join(home, ".claude", "plugins", "cache"),
+	} {
+		for _, name := range listPluginSkillDirs(root) {
+			seen[name] = struct{}{}
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+	slices.Sort(out)
+	return out
 }
 
 func listSkillDirs(root string) []string {
@@ -65,4 +96,50 @@ func listSkillDirs(root string) []string {
 		names = append(names, e.Name())
 	}
 	return names
+}
+
+// listPluginSkillDirs walks the plugin-cache layout used by both claude and
+// codex: <root>/<marketplace>/<plugin>/<version>/skills/<skill-name>/SKILL.md.
+// Returns every skill-name with a SKILL.md, deduping across versions.
+func listPluginSkillDirs(root string) []string {
+	marketplaces, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	for _, mp := range marketplaces {
+		if !mp.IsDir() || strings.HasPrefix(mp.Name(), ".") {
+			continue
+		}
+		plugins, err := os.ReadDir(filepath.Join(root, mp.Name()))
+		if err != nil {
+			continue
+		}
+		for _, pl := range plugins {
+			if !pl.IsDir() || strings.HasPrefix(pl.Name(), ".") {
+				continue
+			}
+			versions, err := os.ReadDir(filepath.Join(root, mp.Name(), pl.Name()))
+			if err != nil {
+				continue
+			}
+			for _, ver := range versions {
+				if !ver.IsDir() || strings.HasPrefix(ver.Name(), ".") {
+					continue
+				}
+				skillsDir := filepath.Join(root, mp.Name(), pl.Name(), ver.Name(), "skills")
+				for _, name := range listSkillDirs(skillsDir) {
+					seen[name] = struct{}{}
+				}
+			}
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+	return out
 }

--- a/internal/agent/skill_invoke_test.go
+++ b/internal/agent/skill_invoke_test.go
@@ -122,3 +122,56 @@ func TestListSkillDirsMissingRoot(t *testing.T) {
 		t.Errorf("got %v, want nil for missing root", got)
 	}
 }
+
+func TestListPluginSkillDirs(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	// Valid plugin layout: <root>/sai/staff-code-review/1.7.0/skills/staff-code-review/SKILL.md
+	mkSkill(t, root, "sai", "staff-code-review", "1.7.0", "staff-code-review")
+	// Older version of same skill — must dedupe.
+	mkSkill(t, root, "sai", "staff-code-review", "1.6.0", "staff-code-review")
+	// Different plugin under same marketplace.
+	mkSkill(t, root, "sai", "council", "1.5.0", "council")
+	// Different marketplace.
+	mkSkill(t, root, "anthropic-agent-skills", "document-skills", "f458cee31a75", "template")
+	// Hidden marketplace ignored.
+	mkSkill(t, root, ".hidden", "foo", "1.0.0", "foo")
+	// Skill dir missing SKILL.md is ignored.
+	if err := os.MkdirAll(filepath.Join(root, "sai", "no-skill", "1.0.0", "skills", "no-skill"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := listPluginSkillDirs(root)
+	want := map[string]bool{
+		"staff-code-review": true,
+		"council":           true,
+		"template":          true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want keys %v", got, want)
+	}
+	for _, name := range got {
+		if !want[name] {
+			t.Errorf("unexpected skill %q in %v", name, got)
+		}
+	}
+}
+
+func TestListPluginSkillDirsMissingRoot(t *testing.T) {
+	t.Parallel()
+	if got := listPluginSkillDirs("/nonexistent/plugins/cache"); got != nil {
+		t.Errorf("got %v, want nil for missing root", got)
+	}
+}
+
+func mkSkill(t *testing.T, root, marketplace, plugin, version, skill string) {
+	t.Helper()
+	skillDir := filepath.Join(root, marketplace, plugin, version, "skills", skill)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Motivation

Sybra dispatched a codex review agent with the prompt `Run /staff-code-review on https://github.com/.../pull/N`. Codex received the literal `/staff-code-review` and tried to exec it as a shell path:

```
/bin/zsh -lc 'command -v staff-code-review || command -v /staff-code-review || ls /staff-code-review'
ls: cannot access '/staff-code-review': No such file or directory
```

Two reasons the rewrite did not fire:

1. `discoverCodexSkills()` scanned `~/.codex/skills/` only. `staff-code-review` is installed for claude via the sai plugin marketplace at `~/.claude/plugins/cache/sai/staff-code-review/<ver>/skills/staff-code-review/`, never copied into `~/.codex/skills/`. Without that name in the known-skills set, `rewriteSkillInvocations` left `/staff-code-review` alone.
2. `buildCodexConvoArgs` (interactive codex path) never called `rewriteSkillInvocations` at all. Only the headless codex path did.

## Implementation information

`discoverCodexSkills()` now unions skill names from four locations:

- `~/.codex/skills/`
- `~/.claude/skills/`
- `~/.codex/plugins/cache/<marketplace>/<plugin>/<ver>/skills/`
- `~/.claude/plugins/cache/<marketplace>/<plugin>/<ver>/skills/`

New helper `listPluginSkillDirs` walks the marketplace/plugin/version layout used by both providers and dedupes across versions. Result is deterministically sorted so the regex sort in `rewriteSkillInvocations` stays stable.

`buildCodexConvoArgs` now runs the prompt through `rewriteSkillInvocations(prompt, discoverCodexSkills())` before passing it to `codex exec`, matching the headless path.

Verified locally that the widened discovery picks up `staff-code-review`, `council`, `humanize`, and the other sai-installed skills alongside the existing sybra-managed ones.

Alternatives considered:

- Rewrite any `/<word-name>` regardless of discovery — rejected, the discovery gate exists to keep typos and unrelated `/path-like-tokens` from being mangled.
- Install staff-code-review for codex on every machine — environmental fix, does not protect future users from the same class of failure.

## Supporting documentation

None.