### PR TITLE
fix(project): fork-only push guard

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -398,6 +398,32 @@ func PushRemote(repoPath string) string {
 	return "origin"
 }
 
+// forkOnlyDisabledPushURL is the sentinel pushURL written to origin when a
+// fork remote exists. Agents using `git push origin <branch>` (with or
+// without --no-verify) hit a transport-level failure naming this sentinel,
+// so the error message itself documents the policy.
+const forkOnlyDisabledPushURL = "sybra-disabled-do-not-push-to-upstream-use-fork"
+
+// EnforceForkOnlyPush configures a worktree so pushes never reach origin
+// when a "fork" remote exists. It overrides remote.origin.pushurl with a
+// deliberately invalid value; git push fails before any network call, which
+// also means --no-verify cannot bypass this guard (unlike a pre-push hook).
+//
+// When no fork remote exists, any previously written sentinel pushurl is
+// cleared so single-remote workflows (pet projects without a fork) keep
+// pushing to origin normally. Foreign pushurl values (set by the user) are
+// left untouched.
+func EnforceForkOnlyPush(worktreePath string) error {
+	if _, err := executil.Output(worktreePath, "git", "config", "--get", "remote.fork.url"); err != nil {
+		current, getErr := executil.Output(worktreePath, "git", "config", "--get", "remote.origin.pushurl")
+		if getErr == nil && strings.TrimSpace(current) == forkOnlyDisabledPushURL {
+			_ = executil.Run(worktreePath, "git", "config", "--unset", "remote.origin.pushurl")
+		}
+		return nil
+	}
+	return executil.Run(worktreePath, "git", "remote", "set-url", "--push", "origin", forkOnlyDisabledPushURL)
+}
+
 // PushUpstream pushes branch to the fork remote if present, else origin,
 // with -u to set remote tracking.
 func PushUpstream(worktreePath, branch string) error {

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -1107,6 +1107,178 @@ func TestPushUpstream_RoutesToFork(t *testing.T) {
 	}
 }
 
+// TestEnforceForkOnlyPush_BlocksOriginPush proves the transport-level guard:
+// when a fork remote exists, an agent's `git push origin <branch>` fails
+// before the network call, regardless of --no-verify. This is the deterministic
+// floor that backs up the prompt-level guidance pointing agents at fork.
+func TestEnforceForkOnlyPush_BlocksOriginPush(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	_, wtPath := initWorktree(t)
+
+	originBare := filepath.Join(t.TempDir(), "origin.git")
+	if out, err := exec.Command("git", "init", "--bare", originBare).CombinedOutput(); err != nil {
+		t.Fatalf("init origin bare: %v: %s", err, out)
+	}
+	forkBare := filepath.Join(t.TempDir(), "fork.git")
+	if out, err := exec.Command("git", "init", "--bare", forkBare).CombinedOutput(); err != nil {
+		t.Fatalf("init fork bare: %v: %s", err, out)
+	}
+	for _, args := range [][]string{
+		{"remote", "set-url", "origin", originBare},
+		{"remote", "add", "fork", forkBare},
+		{"checkout", "-b", "fix/route-test"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = wtPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+
+	if err := EnforceForkOnlyPush(wtPath); err != nil {
+		t.Fatalf("EnforceForkOnlyPush: %v", err)
+	}
+
+	// Push to origin must fail. --no-verify ensures we're testing the
+	// transport-level guard, not a pre-push hook.
+	pushCmd := exec.Command("git", "push", "--no-verify", "origin", "fix/route-test")
+	pushCmd.Dir = wtPath
+	out, err := pushCmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("push to origin should fail when fork remote exists; got success: %s", out)
+	}
+	if !strings.Contains(string(out), forkOnlyDisabledPushURL) {
+		t.Errorf("push error should reference sentinel pushurl so the cause is obvious; got: %s", out)
+	}
+
+	// Push to fork must still work.
+	pushFork := exec.Command("git", "push", "fork", "fix/route-test")
+	pushFork.Dir = wtPath
+	if out, err := pushFork.CombinedOutput(); err != nil {
+		t.Fatalf("push to fork should succeed: %v: %s", err, out)
+	}
+}
+
+// TestEnforceForkOnlyPush_NoForkLeavesOriginPushable confirms the guard is
+// dormant on single-remote repos (pet projects without a fork) — pushing to
+// origin must keep working.
+func TestEnforceForkOnlyPush_NoForkLeavesOriginPushable(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	_, wtPath := initWorktree(t)
+
+	originBare := filepath.Join(t.TempDir(), "origin.git")
+	if out, err := exec.Command("git", "init", "--bare", originBare).CombinedOutput(); err != nil {
+		t.Fatalf("init origin bare: %v: %s", err, out)
+	}
+	for _, args := range [][]string{
+		{"remote", "set-url", "origin", originBare},
+		{"checkout", "-b", "feat/route-test"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = wtPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+
+	if err := EnforceForkOnlyPush(wtPath); err != nil {
+		t.Fatalf("EnforceForkOnlyPush: %v", err)
+	}
+
+	pushCmd := exec.Command("git", "push", "origin", "feat/route-test")
+	pushCmd.Dir = wtPath
+	if out, err := pushCmd.CombinedOutput(); err != nil {
+		t.Fatalf("push to origin should succeed without a fork remote: %v: %s", err, out)
+	}
+}
+
+// TestEnforceForkOnlyPush_RestoresAfterForkRemoved verifies the sentinel
+// pushurl is cleared when the fork remote disappears, so removing the fork
+// reverts the worktree to normal origin pushes. Foreign pushurl values set
+// by the user are left untouched.
+func TestEnforceForkOnlyPush_RestoresAfterForkRemoved(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	_, wtPath := initWorktree(t)
+
+	originBare := filepath.Join(t.TempDir(), "origin.git")
+	if out, err := exec.Command("git", "init", "--bare", originBare).CombinedOutput(); err != nil {
+		t.Fatalf("init origin bare: %v: %s", err, out)
+	}
+	forkBare := filepath.Join(t.TempDir(), "fork.git")
+	if out, err := exec.Command("git", "init", "--bare", forkBare).CombinedOutput(); err != nil {
+		t.Fatalf("init fork bare: %v: %s", err, out)
+	}
+	for _, args := range [][]string{
+		{"remote", "set-url", "origin", originBare},
+		{"remote", "add", "fork", forkBare},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = wtPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+
+	if err := EnforceForkOnlyPush(wtPath); err != nil {
+		t.Fatalf("EnforceForkOnlyPush (with fork): %v", err)
+	}
+
+	rm := exec.Command("git", "remote", "remove", "fork")
+	rm.Dir = wtPath
+	if out, err := rm.CombinedOutput(); err != nil {
+		t.Fatalf("remove fork: %v: %s", err, out)
+	}
+
+	if err := EnforceForkOnlyPush(wtPath); err != nil {
+		t.Fatalf("EnforceForkOnlyPush (after fork removed): %v", err)
+	}
+
+	got, _ := exec.Command("git", "-C", wtPath, "config", "--get", "remote.origin.pushurl").Output()
+	if trimmed := strings.TrimSpace(string(got)); trimmed != "" {
+		t.Errorf("pushurl should be cleared after fork remote removed; got %q", trimmed)
+	}
+}
+
+// TestEnforceForkOnlyPush_PreservesForeignPushURL ensures the guard does not
+// trample a user-set pushurl when no fork remote exists. We only own the
+// sentinel value.
+func TestEnforceForkOnlyPush_PreservesForeignPushURL(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	_, wtPath := initWorktree(t)
+
+	foreignURL := "https://user.example.com/custom-push-url.git"
+	for _, args := range [][]string{
+		{"remote", "set-url", "--push", "origin", foreignURL},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = wtPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+
+	if err := EnforceForkOnlyPush(wtPath); err != nil {
+		t.Fatalf("EnforceForkOnlyPush: %v", err)
+	}
+
+	got, _ := exec.Command("git", "-C", wtPath, "config", "--get", "remote.origin.pushurl").Output()
+	if trimmed := strings.TrimSpace(string(got)); trimmed != foreignURL {
+		t.Errorf("user pushurl clobbered; got %q want %q", trimmed, foreignURL)
+	}
+}
+
 // TestListWorktrees_OrphanedAdminDir covers the recovery mismatch where a
 // user manually rm -rfs the working tree directory but leaves the
 // `.git/worktrees/<name>/` admin entry. `git worktree list` still reports the

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -543,8 +543,16 @@ func (r *ReviewHandler) handlePRIssue(issue github.PRIssue) {
 		prompt = fmt.Sprintf(
 			"Fix failing CI on branch `%s` (PR #%d). "+
 				"Check the failing run with `gh run view --log-failed`, "+
-				"fix the code, commit and push. No unrelated changes.",
-			issue.PR.HeadRefName, issue.PR.Number,
+				"fix the code, commit and push. No unrelated changes.\n\n"+
+				"Push to the same remote the PR was opened from — never "+
+				"to `origin` when a `fork` remote exists:\n"+
+				"```sh\n"+
+				"PUSH_REMOTE=origin\n"+
+				"if git config --get remote.fork.url >/dev/null; then "+
+				"PUSH_REMOTE=fork; fi\n"+
+				"git push \"$PUSH_REMOTE\" HEAD:%s\n"+
+				"```",
+			issue.PR.HeadRefName, issue.PR.Number, issue.PR.HeadRefName,
 		)
 		r.logAudit(audit.EventPRCIFailureDetected, t.ID, "", map[string]any{
 			"pr": issue.PR.Number, "repo": issue.PR.Repository,
@@ -629,15 +637,18 @@ func conflictPrompt(pr github.PullRequest) string {
 			"git fetch origin\n"+
 			"git rebase refs/remotes/origin/main\n"+
 			"# resolve each conflict, git add, git rebase --continue\n"+
-			"git push --force-with-lease\n"+
+			"PUSH_REMOTE=origin\n"+
+			"if git config --get remote.fork.url >/dev/null; then PUSH_REMOTE=fork; fi\n"+
+			"git push --force-with-lease \"$PUSH_REMOTE\" HEAD:%s\n"+
 			"```\n\n"+
 			"Rules:\n"+
 			"- Use `refs/remotes/origin/main` (not `origin/main`) to avoid ambiguous refs\n"+
+			"- Push to `fork` (not `origin`) when a `fork` remote exists — the PR was opened from the fork\n"+
 			"- Resolve conflicts keeping BOTH sides' intent\n"+
 			"- If rebase produces more than 3 conflicting files, run `git rebase --abort` and stop — the task needs human review\n"+
 			"- No investigation, no extra commits, no unrelated changes"+
 			"%s",
-		pr.HeadRefName, pr.Number, filesCtx,
+		pr.HeadRefName, pr.Number, pr.HeadRefName, filesCtx,
 	)
 }
 

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -382,6 +382,9 @@ func (m *Manager) PrepareForFix(t task.Task, prNumber int) (string, error) {
 	if err := m.runSetup(t.ID, wtPath, m.resolveSetupCommands(wtPath, proj)); err != nil {
 		return "", fmt.Errorf("fix setup: %w", err)
 	}
+	if err := project.EnforceForkOnlyPush(wtPath); err != nil {
+		m.logger.Warn("fix.worktree.fork-only-push", "task_id", t.ID, "err", err)
+	}
 	return wtPath, nil
 }
 
@@ -718,6 +721,9 @@ func (m *Manager) installChecks(wtPath string, proj project.Project) {
 	checks := project.MergeChecks(repoChecks, proj.Checks)
 	if err := project.InstallHooks(wtPath, checks); err != nil {
 		m.logger.Warn("worktree.hooks", "path", wtPath, "err", err)
+	}
+	if err := project.EnforceForkOnlyPush(wtPath); err != nil {
+		m.logger.Warn("worktree.fork-only-push", "path", wtPath, "err", err)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Task `03660712` (kuma fork-based PR #16606) hit a real failure mode of the
pr-fix flow: the CI-failure agent ran `git push --no-verify origin <branch>`,
landing the gci import fix on upstream `kumahq/kuma` instead of the fork
`Automaat/kuma` the PR was opened from. The PR head never picked up the
fix; meanwhile the upstream repo got an unwanted branch write. Pre-push
hooks can't save this case because `--no-verify` bypasses them.

## Implementation information

Two layers, mirroring the scrub semantic-ceiling + regex-floor pattern.

**Transport-level floor — `project.EnforceForkOnlyPush`.** When a `fork`
remote exists in a worktree, overrides `remote.origin.pushurl` with the
sentinel `sybra-disabled-do-not-push-to-upstream-use-fork`. `git push origin
<branch>` then fails before the network call with the sentinel in the error
message — `--no-verify` cannot bypass this. Idempotent restore when the fork
remote is removed; user-set foreign pushurls are left untouched (we only own
the sentinel). Wired into `worktree.Manager.installChecks` (covers both
`PrepareForTask` paths) and into `PrepareForFix` (which previously didn't
install checks at all).

**Prompt-level ceiling.** Both `conflictPrompt` and the inline CI-failure
prompt in `internal/sybra/app_reviews.go` now emit the same
`PUSH_REMOTE=origin; if git config --get remote.fork.url …; then PUSH_REMOTE=fork; fi`
snippet that `simple-task-review.yaml`'s create-pr step already uses, so
agents pick the right remote up front instead of relying on the guard to
catch a mistake.

Alternatives considered: a pre-push hook only — rejected because `--no-verify`
silently bypasses hooks and the offending command in `03660712` used exactly
that flag.

Coverage: 4 new tests in `internal/project/git_test.go` —
blocks-origin-push (with `--no-verify`), no-fork-leaves-origin-pushable,
restores-after-fork-removed, preserves-foreign-pushurl. `go test ./...`
and `golangci-lint run ./...` clean.

## Supporting documentation

- Failing task: `~/.sybra/tasks/03660712.md`
- Upstream PR that landed on the wrong remote: kumahq/kuma#16606