### PR TITLE
fix(workflow): cancel pr-fix when issue resolved

### DIFF
--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -391,6 +391,7 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 	if len(matchers) > 0 {
 		issues := github.MatchTaskPRs(monitoredPRs, matchers)
 		r.prTracker.Cleanup()
+		r.cancelResolvedPRFixWorkflows(tasks, issues)
 
 		for i := range issues {
 			if r.agents.HasRunningAgentForTask(issues[i].TaskID) {
@@ -444,6 +445,63 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 		return prPollFast
 	}
 	return prPollSlow
+}
+
+// cancelResolvedPRFixWorkflows terminates any in-flight pr-fix workflow
+// whose originating PR issue (`pr_issue_kind` in workflow vars) is no
+// longer present on the live PR. Prevents ResumeStalled from re-spawning
+// fix agents forever when the underlying CI failure or conflict has
+// since been resolved on a newer push.
+//
+// Without this, a pr-fix workflow remains in state=waiting on the `fix`
+// step until its agent succeeds or the task is deleted — there is no
+// trigger-re-evaluation between dispatch and completion. The orchestrator
+// loop then re-dispatches the step every minute, spawning a fresh agent
+// each time even though the PR is now green.
+func (r *ReviewHandler) cancelResolvedPRFixWorkflows(tasks []task.Task, issues []github.PRIssue) {
+	if r.workflowEngine == nil {
+		return
+	}
+	// Index live issues per task so we can answer "kind K still present
+	// for task T?" in O(1).
+	liveByTask := make(map[string]map[string]bool, len(tasks))
+	for i := range issues {
+		set := liveByTask[issues[i].TaskID]
+		if set == nil {
+			set = make(map[string]bool, 2)
+			liveByTask[issues[i].TaskID] = set
+		}
+		set[string(issues[i].Kind)] = true
+	}
+
+	for i := range tasks {
+		t := &tasks[i]
+		if t.Workflow == nil || t.Workflow.WorkflowID != "pr-fix" {
+			continue
+		}
+		if t.Workflow.State == workflow.ExecCompleted || t.Workflow.State == workflow.ExecFailed {
+			continue
+		}
+		kind := t.Workflow.Variables["pr_issue_kind"]
+		if kind == "" {
+			continue
+		}
+		if liveByTask[t.ID][kind] {
+			continue // condition still holds — let the workflow proceed
+		}
+		step, err := r.workflowEngine.CancelWorkflow(t.ID, "pr-monitor: "+kind+" resolved")
+		if err != nil {
+			r.logger.Error("pr-monitor.cancel-resolved", "task_id", t.ID, "kind", kind, "err", err)
+			continue
+		}
+		// Clear cooldown so a future failure of the same kind on a new
+		// SHA re-triggers fresh (the closed-PR path does the same via
+		// prTracker.Cleanup; we need the explicit clear here because
+		// the PR is still open).
+		r.prTracker.Clear(t.ID, github.PRIssueKind(kind))
+		r.logger.Info("pr-monitor.cancel-resolved",
+			"task_id", t.ID, "kind", kind, "step", step, "pr", t.PRNumber)
+	}
 }
 
 func openReviewPRs(summary github.ReviewSummary) []github.PullRequest {

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
 )
 
 // TestPRMonitorEligible exercises the scan predicate used by the PR monitor
@@ -237,6 +239,109 @@ func TestCreateReviewTaskPassesUpdatedTaskToTriage(t *testing.T) {
 	}
 	if len(files) != 1 {
 		t.Fatalf("created files = %d, want 1", len(files))
+	}
+}
+
+// TestCancelResolvedPRFixWorkflows covers the loop where pr-fix kept
+// re-spawning agents long after the underlying CI failure was resolved.
+// The fix: cancel any in-flight pr-fix workflow whose pr_issue_kind is no
+// longer present in the current MatchTaskPRs output.
+func TestCancelResolvedPRFixWorkflows(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := task.NewStore(filepath.Join(tmp, "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	wfStore, err := workflow.NewStore(filepath.Join(tmp, "workflows"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := workflow.SyncBuiltins(wfStore); err != nil {
+		t.Fatal(err)
+	}
+	agentMgr := agent.NewManager(t.Context(), func(string, any) {}, logger, t.TempDir())
+	engine := workflow.NewEngine(wfStore,
+		&taskAdapter{tasks: tasks},
+		&agentAdapter{agents: agentMgr, tasks: tasks},
+		logger,
+	)
+
+	// Seed three tasks. task.Create assigns IDs, so map fixture labels
+	// to the real generated IDs for the assertions below:
+	//   resolved — pr-fix active for ci_failure, no longer in issues → cancel
+	//   live     — pr-fix active for conflict, conflict still in issues → leave
+	//   other    — no workflow → nothing to do
+	ids := map[string]string{}
+	mkTask := func(label, kind string, hasWF bool, wfState workflow.ExecState) {
+		t.Helper()
+		created, err := tasks.Create(label, "", string(task.AgentModeHeadless))
+		if err != nil {
+			t.Fatalf("create %s: %v", label, err)
+		}
+		ids[label] = created.ID
+		pr := 100
+		upd := task.Update{PRNumber: &pr}
+		if hasWF {
+			wf := &workflow.Execution{
+				WorkflowID:  "pr-fix",
+				CurrentStep: "fix",
+				State:       wfState,
+				Variables:   map[string]string{"pr_issue_kind": kind},
+			}
+			upd.Workflow = &wf
+		}
+		if _, err := tasks.Update(created.ID, upd); err != nil {
+			t.Fatalf("update %s: %v", label, err)
+		}
+	}
+	mkTask("resolved", "ci_failure", true, workflow.ExecWaiting)
+	mkTask("live", "conflict", true, workflow.ExecWaiting)
+	mkTask("other", "", false, "")
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := &ReviewHandler{
+		DomainHandler:  DomainHandler{logger: logger},
+		tasks:          tasks,
+		prTracker:      github.NewIssueTracker(time.Minute),
+		workflowEngine: engine,
+	}
+	// "live" task's conflict is still detected. "resolved" task has no
+	// matching live issue — that's the case we want to cancel.
+	issues := []github.PRIssue{
+		{Kind: github.PRIssueConflict, TaskID: ids["live"]},
+	}
+	// Seed a handled marker so we can check Clear() was called.
+	r.prTracker.MarkHandled(ids["resolved"], github.PRIssueCIFailure, "sha-old")
+
+	r.cancelResolvedPRFixWorkflows(all, issues)
+
+	got, err := tasks.Get(ids["resolved"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow == nil || got.Workflow.State != workflow.ExecCompleted {
+		t.Errorf("resolved workflow state = %+v, want completed", got.Workflow)
+	}
+	if got.Workflow != nil && got.Workflow.CurrentStep != "" {
+		t.Errorf("resolved CurrentStep = %q, want empty", got.Workflow.CurrentStep)
+	}
+	// Cooldown was cleared, so a future ci_failure on a new SHA can re-trigger.
+	if !r.prTracker.ShouldHandle(ids["resolved"], github.PRIssueCIFailure, "sha-new") {
+		t.Error("prTracker.Clear was not called for resolved task")
+	}
+
+	got, err = tasks.Get(ids["live"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow == nil || got.Workflow.State != workflow.ExecWaiting {
+		t.Errorf("live workflow state = %+v, want still waiting", got.Workflow)
 	}
 }
 

--- a/internal/workflow/engine_dispatch.go
+++ b/internal/workflow/engine_dispatch.go
@@ -194,3 +194,51 @@ func (e *Engine) HasActiveWorkflow(taskID string) bool {
 	}
 	return t.Workflow.State != ExecCompleted && t.Workflow.State != ExecFailed
 }
+
+// CancelWorkflow terminates a task's active workflow without running any
+// remaining steps. Stops in-flight agents for the task, marks the workflow
+// ExecCompleted with the cancellation reason recorded in variables, and
+// clears CurrentStep so ResumeStalled stops re-dispatching.
+//
+// No-op when the task has no workflow or its workflow already terminated.
+// Returns the prior current step ID for the caller's log line; empty when
+// the workflow had already ended.
+//
+// Does NOT fire OnComplete — cascading the cancel into the next workflow
+// (e.g. simple-task-review on ready-review) is rarely what the caller
+// wants, and pr-monitor wants the task to fall back to its prior state.
+func (e *Engine) CancelWorkflow(taskID, reason string) (string, error) {
+	t, err := e.tasks.GetTask(taskID)
+	if err != nil {
+		return "", err
+	}
+	if t.Workflow == nil {
+		return "", nil
+	}
+	if t.Workflow.State == ExecCompleted || t.Workflow.State == ExecFailed {
+		return "", nil
+	}
+
+	priorStep := t.Workflow.CurrentStep
+
+	// Stop any in-flight agents first so their completion callback runs
+	// against the about-to-be-terminal workflow (HandleAgentComplete's
+	// terminal guard at engine_events.go:128 turns it into a no-op).
+	e.agents.StopAgentsForTask(taskID, "")
+
+	now := time.Now().UTC()
+	wfExec := t.Workflow
+	wfExec.State = ExecCompleted
+	wfExec.CompletedAt = &now
+	wfExec.CurrentStep = ""
+	if reason != "" {
+		wfExec.SetVar("cancel_reason", reason)
+	}
+	if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
+		return priorStep, err
+	}
+	e.logger.Info("workflow.cancelled",
+		"task_id", taskID, "workflow", wfExec.WorkflowID,
+		"step", priorStep, "reason", reason)
+	return priorStep, nil
+}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -835,6 +835,67 @@ func TestHasActiveWorkflow(t *testing.T) {
 	}
 }
 
+func TestCancelWorkflow(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{ID: "active", Status: "in-progress",
+		Workflow: &Execution{
+			WorkflowID:  "pr-fix",
+			CurrentStep: "fix",
+			State:       ExecWaiting,
+			Variables:   map[string]string{"pr_issue_kind": "ci_failure"},
+		}})
+	tasks.Put(TaskInfo{ID: "completed", Status: "done",
+		Workflow: &Execution{WorkflowID: "pr-fix", State: ExecCompleted}})
+	tasks.Put(TaskInfo{ID: "no-wf", Status: "todo"})
+
+	// Pretend an agent is running for "active" so we can verify it's stopped.
+	if _, err := agents.StartAgent("active", "pr-fix", "headless", "sonnet", "claude", "p", "", nil, false, false); err != nil {
+		t.Fatalf("seed agent: %v", err)
+	}
+
+	step, err := engine.CancelWorkflow("active", "ci_failure resolved")
+	if err != nil {
+		t.Fatalf("CancelWorkflow active: %v", err)
+	}
+	if step != "fix" {
+		t.Errorf("returned step = %q, want %q", step, "fix")
+	}
+	got, err := tasks.GetTask("active")
+	if err != nil {
+		t.Fatalf("get active: %v", err)
+	}
+	if got.Workflow.State != ExecCompleted {
+		t.Errorf("State = %s, want %s", got.Workflow.State, ExecCompleted)
+	}
+	if got.Workflow.CurrentStep != "" {
+		t.Errorf("CurrentStep = %q, want empty", got.Workflow.CurrentStep)
+	}
+	if got.Workflow.CompletedAt == nil {
+		t.Error("CompletedAt not set")
+	}
+	if got.Workflow.Variables["cancel_reason"] != "ci_failure resolved" {
+		t.Errorf("cancel_reason = %q", got.Workflow.Variables["cancel_reason"])
+	}
+	if agents.HasRunningAgent("active") {
+		t.Error("agent still running after cancel")
+	}
+
+	// Already-terminal workflow → no-op, no error.
+	if step, err := engine.CancelWorkflow("completed", "x"); err != nil || step != "" {
+		t.Errorf("cancel completed: step=%q err=%v", step, err)
+	}
+
+	// No workflow attached → no-op, no error.
+	if step, err := engine.CancelWorkflow("no-wf", "x"); err != nil || step != "" {
+		t.Errorf("cancel no-wf: step=%q err=%v", step, err)
+	}
+}
+
 func TestMatchWorkflow_PriorityTieBreak(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()


### PR DESCRIPTION
## Motivation

When pr-monitor dispatches `pr-fix` for a CI failure or merge conflict, the workflow lands on the `fix` step (state=waiting) and a headless agent runs. If that agent is killed before completing (manual stop, watchdog, container restart, etc.), the orchestrator's `ResumeStalled` tick (1 min) re-dispatches the same step, spawning a fresh agent each cycle. There is no re-evaluation of the originating trigger between dispatches — so when a newer push fixes CI on the branch, the workflow keeps trying to "fix" a failure that no longer exists, burning credits and tying up the worktree.

Observed on task 8f54ac4a (PR kumahq/kuma#16601): pr-fix dispatched 10 fix agents over 20 minutes after CI had already gone IN_PROGRESS/SUCCESS.

## Implementation information

Add `Engine.CancelWorkflow(taskID, reason) (priorStep string, err error)`:
- Stops in-flight agents for the task
- Marks workflow ExecCompleted with CompletedAt set, records `cancel_reason` in vars, clears CurrentStep
- Does NOT fire OnComplete (no cascade — task falls back to its prior state)
- No-op on terminal / missing workflows

Wire `ReviewHandler.cancelResolvedPRFixWorkflows` into `pollAndMonitorPRs`. On each poll, after `MatchTaskPRs`, walk tasks with active pr-fix workflows and cancel any whose `pr_issue_kind` (set at dispatch time in `handlePRIssue`) is no longer present among live issues for the task. Also calls `prTracker.Clear` so a future failure of the same kind on a new SHA re-triggers fresh — without that, the cooldown debounce blocks the next legitimate dispatch.

Alternative considered: adding a `verify_pr_issue` sync step at the front of pr-fix.yaml. Rejected — it would need a new step type and only run on workflow advance, not on the ResumeStalled retry tick, so an in-flight stuck workflow could still loop for a minute between re-evaluations. Cancelling from the poller is closer to the existing pr-monitor → workflow boundary.

Tests:
- `TestCancelWorkflow` — active workflow gets terminated + agent stopped; terminal/missing workflows are no-ops
- `TestCancelResolvedPRFixWorkflows` — resolved task is cancelled and cooldown cleared, live task is left alone

## Supporting documentation

Triggered by debugging session on task 8f54ac4a where a real CI failure dispatched pr-fix, the user killed an early agent attempt, then a later push fixed CI — but pr-fix kept respawning because nothing told it the failure was gone.