### PR TITLE
fix(workflow): advance parent on all-spawn-fail

### DIFF
--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -283,7 +283,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 		case StepRunAgent:
 			return e.execRunAgent(taskID, step, wfExec, ctx)
 		case StepParallel:
-			return e.execParallel(taskID, step, wfExec, ctx)
+			return e.execParallel(taskID, def, step, wfExec, ctx)
 		case StepWaitHuman:
 			return e.execWaitHuman(taskID, step, wfExec)
 		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepRerequestReview, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepTriageReview:

--- a/internal/workflow/engine_parallel_test.go
+++ b/internal/workflow/engine_parallel_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"errors"
 	"os"
 	"slices"
 	"strings"
@@ -324,6 +325,43 @@ func TestParallel_ChildFailExhaustedFailsParent(t *testing.T) {
 	rec := findStepRecord(wf, "plan")
 	if rec == nil || rec.Status != "failed" {
 		t.Errorf("parent record after exhausted retries: %+v (want failed)", rec)
+	}
+}
+
+// TestParallel_AllSpawnsFail_AdvancesParent regresses a deadlock: when every
+// child in a parallel block fails at spawn time (e.g. missing project), no
+// agent ever runs, so HandleAgentComplete never fires. The engine must
+// advance the parent synchronously to status=failed instead of leaving the
+// workflow stuck in state=waiting forever.
+func TestParallel_AllSpawnsFail_AdvancesParent(t *testing.T) {
+	store := newTestStoreWith(t, "test-parallel-terminal.yaml")
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
+
+	agents.SetFailSpawn(errors.New("project not registered locally"))
+
+	if err := engine.StartWorkflow("t1", "test-parallel-terminal"); err != nil {
+		t.Fatalf("StartWorkflow returned err = %v; engine must surface a failed parent record instead of bubbling the spawn error", err)
+	}
+
+	wf := mustWorkflow(t, tasks, "t1")
+	if _, still := wf.ParallelInflight["plan"]; still {
+		t.Errorf("ParallelInflight[plan] should be cleared after all spawns failed")
+	}
+	rec := findStepRecord(wf, "plan")
+	if rec == nil {
+		t.Fatal("parent step record missing — workflow deadlocked in state=waiting")
+	}
+	if rec.Status != "failed" {
+		t.Errorf("parent status = %q, want failed", rec.Status)
+	}
+	if wf.State == ExecWaiting {
+		t.Errorf("workflow state = %q, want terminal (not waiting)", wf.State)
+	}
+	if got := agents.CallCount(); got != 0 {
+		t.Errorf("recorded successful StartAgent calls = %d, want 0 (spawn was armed to fail)", got)
 	}
 }
 

--- a/internal/workflow/engine_steps.go
+++ b/internal/workflow/engine_steps.go
@@ -142,7 +142,7 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 // on the worktree is benign. The parent step advances to its `next` only
 // after every child has terminated; per-child completions are routed
 // through AdvanceStep via the existing agentSteps mapping.
-func (e *Engine) execParallel(taskID string, step *Step, wfExec *Execution, ctx TemplateContext) error {
+func (e *Engine) execParallel(taskID string, def *Definition, step *Step, wfExec *Execution, ctx TemplateContext) error {
 	if len(step.Parallel) < 2 {
 		return fmt.Errorf("parallel step %q has fewer than 2 children", step.ID)
 	}
@@ -199,6 +199,14 @@ func (e *Engine) execParallel(taskID string, step *Step, wfExec *Execution, ctx 
 			status.Status = "failed"
 			status.Output = "spawn failed: " + err.Error()
 		}
+	}
+
+	// If every child terminated at spawn time (all failed, or a resume found
+	// every slot already terminal), no agent will fire HandleAgentComplete to
+	// drive advanceParallelChild. Advance the parent synchronously instead so
+	// the workflow doesn't deadlock in state=waiting.
+	if rec.AllChildrenDone() {
+		return e.finalizeParallelParent(taskID, def, step, wfExec)
 	}
 
 	return e.tasks.SetWorkflow(taskID, wfExec)
@@ -339,8 +347,20 @@ func (e *Engine) advanceParallelChild(taskID string, def *Definition, parent, ch
 		return e.tasks.SetWorkflow(taskID, wfExec)
 	}
 
-	// All children terminated — collapse into a single parent step record
-	// and advance via parent's Next.
+	return e.finalizeParallelParent(taskID, def, parent, wfExec)
+}
+
+// finalizeParallelParent collapses a parallel block whose children have all
+// reached terminal status into a single parent StepRecord and advances via
+// the parent's Next. Called from advanceParallelChild on the last
+// completion, and from execParallel when every child failed at spawn time
+// (no agent ever ran → no completion callback will fire).
+func (e *Engine) finalizeParallelParent(taskID string, def *Definition, parent *Step, wfExec *Execution) error {
+	rec := wfExec.ParallelInflight[parent.ID]
+	if rec == nil {
+		return nil
+	}
+
 	parentStatus := "completed"
 	if rec.AnyChildFailed() {
 		parentStatus = "failed"
@@ -363,7 +383,6 @@ func (e *Engine) advanceParallelChild(taskID string, def *Definition, parent, ch
 		wfExec.SetVar("step."+parent.ID+".output", truncate(parentOutput, 2000))
 	}
 
-	// Re-read task for latest state (children may have written sidecars).
 	t, err := e.tasks.GetTask(taskID)
 	if err != nil {
 		return err

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -198,12 +198,13 @@ type sentPrompt struct {
 }
 
 type mockAgents struct {
-	mu      sync.Mutex
-	calls   []startCall
-	prompts []sentPrompt
-	running map[string]string // taskID -> agentID
-	roles   map[string]string // taskID+"/"+role -> agentID
-	counter int
+	mu        sync.Mutex
+	calls     []startCall
+	prompts   []sentPrompt
+	running   map[string]string // taskID -> agentID
+	roles     map[string]string // taskID+"/"+role -> agentID
+	counter   int
+	failSpawn error // when non-nil, StartAgent returns this error and records nothing
 }
 
 func newMockAgents() *mockAgents {
@@ -216,6 +217,9 @@ func newMockAgents() *mockAgents {
 func (m *mockAgents) StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.failSpawn != nil {
+		return "", m.failSpawn
+	}
 	m.counter++
 	id := fmt.Sprintf("agent-%d", m.counter)
 	m.calls = append(m.calls, startCall{
@@ -226,6 +230,15 @@ func (m *mockAgents) StartAgent(taskID, role, mode, model, provider, prompt, dir
 	m.running[taskID] = id
 	m.roles[taskID+"/"+role] = id
 	return id, nil
+}
+
+// SetFailSpawn arms the mock so the next StartAgent calls return err. Pass
+// nil to disarm. Used to simulate spawn-time failures (e.g. unregistered
+// project) that the workflow engine must handle without deadlocking.
+func (m *mockAgents) SetFailSpawn(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.failSpawn = err
 }
 
 func (m *mockAgents) HasRunningAgent(taskID string) bool {

--- a/internal/workflow/testdata/test-parallel-terminal.yaml
+++ b/internal/workflow/testdata/test-parallel-terminal.yaml
@@ -1,0 +1,26 @@
+id: test-parallel-terminal
+name: Test Parallel Terminal
+description: Parallel block with no next step — exercises spawn-fail finalization
+trigger:
+  on: task.created
+steps:
+  - id: plan
+    name: Plan (parallel, terminal)
+    type: parallel
+    parallel:
+      - id: plan_a
+        type: run_agent
+        config:
+          role: plan
+          provider: claude
+          mode: headless
+          prompt: "Plan A {{.Task.ID}}"
+      - id: plan_b
+        type: run_agent
+        config:
+          role: plan
+          provider: codex
+          mode: headless
+          prompt: "Plan B {{.Task.ID}}"
+    next:
+      - goto: ""


### PR DESCRIPTION
## Motivation

A parallel workflow step could deadlock the engine: if every child agent failed at spawn time (e.g. project not registered locally), no agent ever ran, so `HandleAgentComplete` never fired and `advanceParallelChild` never ran. The workflow stayed in `state: waiting` forever with all children marked `failed`.

Repro: triage assigns a task to a project that isn't registered locally → plan step spawns parallel `plan_claude` + `plan_codex` → both fail with \`read project ...: project not registered locally\` → workflow frozen.

## Implementation information

- Extracted the \"all children terminal → record parent + advance\" tail of \`advanceParallelChild\` into a new \`finalizeParallelParent\` helper.
- \`execParallel\` now takes \`*Definition\` and, after the spawn loop, checks \`rec.AllChildrenDone()\`. If every child is already terminal (all spawn-failed, or a resume found every slot terminal), it calls \`finalizeParallelParent\` synchronously instead of returning to the caller and waiting for callbacks that will never arrive.
- The one synchronous caller in \`engine_advance.go\` was updated to pass \`def\`.

Alternative considered: surface the spawn errors and abort the whole workflow at the engine level. Rejected — partial spawn failures (one child fails, others succeed) still need the existing retry/aggregation logic, so the cleanest fix is to make the all-fail case drive the same finalization path as the all-complete case.

Test coverage:
- Added \`SetFailSpawn\` to the workflow test \`mockAgents\` so a test can arm \`StartAgent\` to return an error.
- New testdata workflow \`test-parallel-terminal.yaml\` (parallel block with no successor step) isolates the spawn-fail path from downstream side effects.
- New regression test \`TestParallel_AllSpawnsFail_AdvancesParent\` asserts: \`ParallelInflight\` is cleared, parent step record exists with \`status=failed\`, workflow is not left in \`state=waiting\`.

> Changelog: fix(workflow): advance parent on all-spawn-fail