### PR TITLE
feat(gui): collapsible plan sections

### DIFF
--- a/frontend/src/components/task-detail/TaskDescriptionEditor.svelte
+++ b/frontend/src/components/task-detail/TaskDescriptionEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { ChevronRight } from '@lucide/svelte'
   import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { taskStore } from '../../stores/tasks.svelte.js'
   import { renderMarkdown } from '../../lib/markdown.js'
@@ -9,9 +10,19 @@
 
   const { task }: Props = $props()
 
+  const PLAN_COLLAPSED_KEY = 'task-detail:plan-collapsed'
+
   let editing = $state(false)
   let draft = $state('')
   let error = $state('')
+  let planCollapsed = $state(typeof localStorage !== 'undefined' && localStorage.getItem(PLAN_COLLAPSED_KEY) === '1')
+
+  function togglePlan() {
+    planCollapsed = !planCollapsed
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(PLAN_COLLAPSED_KEY, planCollapsed ? '1' : '0')
+    }
+  }
 
   const renderedBody = $derived(renderMarkdown(task.body))
   const renderedPlan = $derived(renderMarkdown(task.plan))
@@ -89,13 +100,21 @@
 
 {#if task.plan}
   <div class="flex flex-col gap-1">
-    <div class="flex items-center gap-2">
+    <button
+      type="button"
+      class="flex w-fit items-center gap-2 text-left"
+      onclick={togglePlan}
+      aria-expanded={!planCollapsed}
+    >
+      <ChevronRight size={14} class="text-surface-400 transition-transform {planCollapsed ? '' : 'rotate-90'}" />
       <span class="text-sm font-medium text-surface-500">Plan</span>
       <span class="text-xs text-surface-400 italic">read-only · edit via sybra-cli --plan</span>
-    </div>
-    <div class="rounded-lg border border-surface-300 bg-surface-100 p-4 dark:border-surface-600 dark:bg-surface-900">
-      <div class="markdown-body text-sm text-surface-900 dark:text-surface-100">{@html renderedPlan}</div>
-    </div>
+    </button>
+    {#if !planCollapsed}
+      <div class="rounded-lg border border-surface-300 bg-surface-100 p-4 dark:border-surface-600 dark:bg-surface-900">
+        <div class="markdown-body text-sm text-surface-900 dark:text-surface-100">{@html renderedPlan}</div>
+      </div>
+    {/if}
   </div>
 {/if}
 

--- a/frontend/src/pages/Reviews.svelte
+++ b/frontend/src/pages/Reviews.svelte
@@ -263,7 +263,7 @@
       <!-- Plan content -->
       <div class="flex-1 overflow-y-auto px-6 py-4">
         {#if selectedTask.planCritique}
-          <details open class="mb-4 rounded-lg border border-warning-300 bg-warning-50 dark:border-warning-700 dark:bg-warning-900/20">
+          <details class="mb-4 rounded-lg border border-warning-300 bg-warning-50 dark:border-warning-700 dark:bg-warning-900/20">
             <summary class="cursor-pointer px-4 py-2 text-sm font-semibold text-warning-800 dark:text-warning-300">
               Plan Critique (auto-review)
             </summary>


### PR DESCRIPTION
## Motivation

Plan sections can be long. Users need to collapse them to navigate task and review pages efficiently.

## Implementation information

- Task detail: plan section gets a chevron toggle. Defaults to expanded; collapse state persisted to localStorage under `task-detail:plan-collapsed`.
- Review view: plan critique `<details>` no longer `open` by default — collapsed on load.

## Supporting documentation

n/a