### PR TITLE
ci(actions): promote nilaway to blocking mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,14 @@ jobs:
           NILAWAY_BASELINE=31
           set +e
           nilaway -include-pkgs="github.com/Automaat/sybra" ./... > nilaway.out 2>&1
-          FINDING_COUNT=$(grep -c '^/' nilaway.out || echo 0)
+          NILAWAY_EXIT=$?
+          FINDING_COUNT=$(grep -c '^/' nilaway.out)
+          set -e
+          if [ "$NILAWAY_EXIT" -ne 0 ] && [ "$FINDING_COUNT" -eq 0 ]; then
+            echo "::error::Nilaway exited ${NILAWAY_EXIT} with no parseable findings — crash or package-load failure."
+            cat nilaway.out >&2
+            exit "$NILAWAY_EXIT"
+          fi
           {
             echo "### Nilaway findings"
             echo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           version: latest
 
   lint-nilaway:
-    name: Nilaway (advisory)
+    name: Nilaway
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -91,21 +91,22 @@ jobs:
       - name: Install nilaway
         run: go install go.uber.org/nilaway/cmd/nilaway@latest
 
-      - name: Run nilaway (summary only, never fails)
-        # Findings are pre-existing; graduate to blocking after a dedicated
-        # cleanup PR fixes the baseline. Output is appended to the job
-        # summary so reviewers can see new regressions on each run.
+      - name: Run nilaway
+        # Baseline ratchet: 31 pre-existing findings recorded at enforcement
+        # commit. Fails on any new nil-safety regression (count > baseline).
+        # Reduce NILAWAY_BASELINE to 0 once the follow-up cleanup PR lands.
         run: |
+          NILAWAY_BASELINE=31
           set +e
           nilaway -include-pkgs="github.com/Automaat/sybra" ./... > nilaway.out 2>&1
-          rc=$?
+          FINDING_COUNT=$(grep -c '^/' nilaway.out || echo 0)
           {
             echo "### Nilaway findings"
             echo
-            if [ "$rc" -eq 0 ]; then
+            if [ "$FINDING_COUNT" -eq 0 ]; then
               echo "_No issues._"
             else
-              echo "<details><summary>$(grep -c '^/' nilaway.out || echo 0) findings</summary>"
+              echo "<details><summary>${FINDING_COUNT} findings (baseline: ${NILAWAY_BASELINE})</summary>"
               echo
               echo '```'
               cat nilaway.out
@@ -113,7 +114,11 @@ jobs:
               echo "</details>"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
-          exit 0
+          if [ "$FINDING_COUNT" -gt "$NILAWAY_BASELINE" ]; then
+            echo "::error::Nilaway: ${FINDING_COUNT} findings exceeds baseline of ${NILAWAY_BASELINE}. Fix new nil-safety regressions before merging."
+            exit 1
+          fi
+          echo "Nilaway: ${FINDING_COUNT}/${NILAWAY_BASELINE} findings — OK"
 
   lint-dockerfile:
     name: Dockerfile Lint

--- a/frontend/.oxlintrc.json
+++ b/frontend/.oxlintrc.json
@@ -1,0 +1,3 @@
+{
+  "ignorePatterns": ["bindings/**"]
+}

--- a/frontend/src/components/PlanSteps.svelte.test.ts
+++ b/frontend/src/components/PlanSteps.svelte.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/svelte'
 import PlanSteps from './PlanSteps.svelte'
 import type { PlanStep } from '$lib/plan-steps.js'

--- a/frontend/src/pages/Agents.svelte.test.ts
+++ b/frontend/src/pages/Agents.svelte.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
+import { render, cleanup } from '@testing-library/svelte'
 
 vi.mock('@skeletonlabs/skeleton-svelte', async (importOriginal) => {
   const mod = await importOriginal<typeof import('@skeletonlabs/skeleton-svelte')>()


### PR DESCRIPTION
## Motivation

Nilaway was running in non-blocking (advisory) mode — new nil-safety regressions could merge undetected. Promotes it to a hard CI gate to prevent that.

## Implementation information

- Runs nilaway, counts findings via `grep -c`, compares against a ratchet baseline of 31 pre-existing findings
- CI fails when the count exceeds baseline; passes when equal or lower
- Fixes `grep -c` fallback bug (`|| echo 0` produced `"0\n0"` and broke numeric comparisons)
- Captures nilaway exit code to fail fast on crash or package-load failure (exit != 0 with no findings)
- Ignores auto-generated `frontend/bindings/` in oxlint to reduce noise
- Drops unused imports in two test files that triggered lint warnings

Follow-up #792 will fix the 31 pre-existing findings and reduce the baseline to 0.

Closes https://github.com/Automaat/sybra/issues/791

> Changelog: ci(actions): promote nilaway to blocking mode