### PR TITLE
fix(frontend): avoid vitest config import

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,6 @@
-import { defineConfig } from 'vitest/config'
-import { loadEnv } from 'vite'
+/// <reference types="vitest/config" />
+
+import { defineConfig, loadEnv } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import tailwindcss from '@tailwindcss/vite'
 import { fileURLToPath, URL } from 'url'


### PR DESCRIPTION
Import defineConfig from vite and keep Vitest typing support via a reference directive

That keeps Vite config loading independent from the vitest runtime package during external build entrypoints.

Signed-off-by: slonka <slonka@users.noreply.github.com>

otherwise getting:

```
failed to load config from /Users/krzysztof.slonka/projects/sybra/frontend/vite.config.ts
error during build:
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'vitest' imported from /Users/krzysztof.slonka/projects/sybra/frontend/vite.config.ts.timestamp-1778758168316-22a575a0db1fe8.mjs
    at Object.getPackageJSONURL (node:internal/modules/package_json_reader:301:9)
    at packageResolve (node:internal/modules/esm/resolve:764:81)
    at moduleResolve (node:internal/modules/esm/resolve:855:18)
    at defaultResolve (node:internal/modules/esm/resolve:988:11)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:697:20)
    at #resolveAndMaybeBlockOnLoaderThread (node:internal/modules/esm/loader:714:38)
    at ModuleLoader.resolveSync (node:internal/modules/esm/loader:746:52)
    at #resolve (node:internal/modules/esm/loader:679:17)
    at ModuleLoader.getOrCreateModuleJob (node:internal/modules/esm/loader:599:35)
    at ModuleJob.syncLink (node:internal/modules/esm/module_job:162:33) {
  code: 'ERR_MODULE_NOT_FOUND'
}

pid 87160 exit 1
Build with Vite failed! ❌
[dev] ERROR task failed
```