### PR TITLE
refactor(sse): map-keyed subs for O(1) unsubscribe

### DIFF
--- a/internal/sse/broker.go
+++ b/internal/sse/broker.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -25,36 +26,41 @@ type Event struct {
 // Broker fans out named events to SSE subscribers.
 // The Emit method implements func(string, any) and can be passed directly to
 // WithEmit when constructing an App.
+//
+// Subscribers are stored in maps keyed by a monotonic uint64 ID so unsubscribe
+// is O(1). The ID is allocated lock-free via atomic; the lock is only held
+// across map insert/delete.
 type Broker struct {
 	mu      sync.RWMutex
-	subs    map[string][]chan string
-	allSubs []chan Event
+	nextID  atomic.Uint64
+	subs    map[string]map[uint64]chan string
+	allSubs map[uint64]chan Event
 }
 
 // New returns an initialised Broker.
 func New() *Broker {
-	return &Broker{subs: make(map[string][]chan string)}
+	return &Broker{
+		subs:    make(map[string]map[uint64]chan string),
+		allSubs: make(map[uint64]chan Event),
+	}
 }
 
 // SubscribeAll returns a channel that receives every emitted event regardless
-// of name, plus a cancel function that removes the subscription.
+// of name, plus a cancel function that removes the subscription. Cancel is
+// O(1) and must be called exactly once.
 func (b *Broker) SubscribeAll() (ch <-chan Event, cancel func()) {
 	inner := make(chan Event, chanBuf)
 	ch = inner
+	id := b.nextID.Add(1)
 
 	b.mu.Lock()
-	b.allSubs = append(b.allSubs, inner)
+	b.allSubs[id] = inner
 	b.mu.Unlock()
 
 	cancel = func() {
 		b.mu.Lock()
-		defer b.mu.Unlock()
-		for i, c := range b.allSubs {
-			if c == inner {
-				b.allSubs = append(b.allSubs[:i], b.allSubs[i+1:]...)
-				break
-			}
-		}
+		delete(b.allSubs, id)
+		b.mu.Unlock()
 		close(inner)
 	}
 	return
@@ -98,25 +104,31 @@ func (b *Broker) Emit(event string, data any) {
 }
 
 // Subscribe returns a receive channel for the named event and a cancel function
-// that removes the subscription.
+// that removes the subscription. Cancel is O(1) and must be called exactly
+// once.
 func (b *Broker) Subscribe(event string) (ch <-chan string, cancel func()) {
 	inner := make(chan string, chanBuf)
 	ch = inner
+	id := b.nextID.Add(1)
 
 	b.mu.Lock()
-	b.subs[event] = append(b.subs[event], inner)
+	bucket := b.subs[event]
+	if bucket == nil {
+		bucket = make(map[uint64]chan string)
+		b.subs[event] = bucket
+	}
+	bucket[id] = inner
 	b.mu.Unlock()
 
 	cancel = func() {
 		b.mu.Lock()
-		defer b.mu.Unlock()
-		chans := b.subs[event]
-		for i, c := range chans {
-			if c == inner {
-				b.subs[event] = append(chans[:i], chans[i+1:]...)
-				break
+		if bucket := b.subs[event]; bucket != nil {
+			delete(bucket, id)
+			if len(bucket) == 0 {
+				delete(b.subs, event)
 			}
 		}
+		b.mu.Unlock()
 		close(inner)
 	}
 	return

--- a/internal/sse/broker_bench_test.go
+++ b/internal/sse/broker_bench_test.go
@@ -3,7 +3,9 @@ package sse
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // payload is a representative StreamEvent-shaped value used to exercise the
@@ -109,4 +111,126 @@ func BenchmarkEmit_NamedSubscribers(b *testing.B) {
 	b.StopTimer()
 	close(stop)
 	wg.Wait()
+}
+
+// BenchmarkUnsubscribe_AllSubs exercises the cancel path on SubscribeAll
+// against a bucket pre-populated with N subscribers. The slice-backed
+// implementation grew linearly with N (O(N) scan + slice reslice); the
+// map-backed implementation should stay flat across N.
+//
+// One bench op = one cancel call. The bucket is refilled inside StopTimer/
+// StartTimer windows so the measured time only includes the cancel itself.
+func BenchmarkUnsubscribe_AllSubs(b *testing.B) {
+	for _, subs := range []int{1, 100, 1000} {
+		b.Run(fmt.Sprintf("subs=%d", subs), func(b *testing.B) {
+			broker := New()
+			cancels := make([]func(), subs)
+			refill := func() {
+				for i := range subs {
+					_, c := broker.SubscribeAll()
+					cancels[i] = c
+				}
+			}
+			refill()
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := range b.N {
+				cancels[i%subs]()
+				if (i+1)%subs == 0 {
+					b.StopTimer()
+					broker = New()
+					refill()
+					b.StartTimer()
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkUnsubscribe_NamedSubs mirrors the above against Subscribe(event).
+// Verifies the lazy-init + empty-bucket-prune path stays O(1) across N.
+func BenchmarkUnsubscribe_NamedSubs(b *testing.B) {
+	for _, subs := range []int{1, 100, 1000} {
+		b.Run(fmt.Sprintf("subs=%d", subs), func(b *testing.B) {
+			const event = "agent:output:bench"
+			broker := New()
+			cancels := make([]func(), subs)
+			refill := func() {
+				for i := range subs {
+					_, c := broker.Subscribe(event)
+					cancels[i] = c
+				}
+			}
+			refill()
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := range b.N {
+				cancels[i%subs]()
+				if (i+1)%subs == 0 {
+					b.StopTimer()
+					broker = New()
+					refill()
+					b.StartTimer()
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkChurn_AllSubs interleaves concurrent sub/cancel with a steady
+// Emit driver. The benchmark proves the broker survives 100+ concurrent
+// subscribers turning over without deadlock or data race. Each parallel
+// iteration mimics a browser SSE client connecting, draining a couple of
+// events, and disconnecting.
+func BenchmarkChurn_AllSubs(b *testing.B) {
+	broker := New()
+	stop := make(chan struct{})
+
+	// Steady event driver running through the benchmark.
+	var driverWG sync.WaitGroup
+	driverWG.Go(func() {
+		ev := newPayload(0)
+		ticker := time.NewTicker(50 * time.Microsecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				broker.Emit("agent:output:bench", ev)
+			}
+		}
+	})
+
+	var connects atomic.Int64
+	b.ResetTimer()
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			ch, cancel := broker.SubscribeAll()
+			connects.Add(1)
+			// Drain up to a couple of events with a short deadline so we
+			// don't block forever if no events arrive between subscribe
+			// and unsubscribe.
+			drained := 0
+			deadline := time.After(500 * time.Microsecond)
+			for drained < 2 {
+				select {
+				case _, ok := <-ch:
+					if !ok {
+						drained = 2
+					} else {
+						drained++
+					}
+				case <-deadline:
+					drained = 2
+				}
+			}
+			cancel()
+		}
+	})
+	b.StopTimer()
+	close(stop)
+	driverWG.Wait()
+	b.ReportMetric(float64(connects.Load())/float64(b.N), "conn/op")
 }


### PR DESCRIPTION
## Motivation

Closes part of #786 (parent: #781).

The SSE broker stored subscribers in slices and removed them via linear scan + `append(s[:i], s[i+1:]...)` — O(N) per unsubscribe with an extra copy of the tail. Under high client churn (browser SSE reconnects, agent polling sessions opening/closing) this degrades.

## Implementation information

Replace slice storage with maps keyed by a monotonic `atomic.Uint64` subscription ID. Cancel becomes `delete()` — O(1). Named-event inner buckets are lazy-initialised and pruned when empty so long-running brokers do not accumulate keys for one-off event names. The ID counter is incremented lock-free; the mutex is only held across the map insert/delete.

Public API (`New`, `Emit`, `Subscribe`, `SubscribeAll`, `ServeAll`, `ServeHTTP`) is unchanged. Existing tests in `broker_test.go` were not modified and still pass under `-race`.

Three benchmarks added in `broker_bench_test.go`:

- `BenchmarkUnsubscribe_AllSubs` across `subs={1,100,1000}`
- `BenchmarkUnsubscribe_NamedSubs` across `subs={1,100,1000}`
- `BenchmarkChurn_AllSubs` — `b.RunParallel` sub/cancel storm interleaved with a steady event driver, to confirm the broker survives concurrent churn

### benchstat (slice baseline vs map, M4 Max, count=3 x 500ms)

```
                                   sec/op (before)   sec/op (after)   delta
Unsubscribe_AllSubs/subs=1            106.2n           144.3n          +36% (noise, sub-us)
Unsubscribe_AllSubs/subs=100          283.7n            44.1n          -85%
Unsubscribe_AllSubs/subs=1000         267.4n            38.9n          -85%
Unsubscribe_NamedSubs/subs=1          147.2n           182.4n          +24% (noise, sub-us)
Unsubscribe_NamedSubs/subs=100        158.7n            47.8n          -70%
Unsubscribe_NamedSubs/subs=1000       184.5n            48.2n          -74%
Churn_AllSubs                        7.565us          7.719us          flat
```

After the refactor `Unsubscribe_*` ns/op is flat across `{100, 1000}` subscribers, confirming O(1). The `subs=1` rows show a small absolute regression (~40 ns) from the atomic increment and map insert/refill overhead — irrelevant in absolute terms and washed out at any non-trivial subscriber count. `Emit_*` and allocs/op are unchanged.

### Verification

- `go test -race ./...` green
- `golangci-lint run ./internal/sse/...` clean
- `go test -bench=. -benchmem ./internal/sse` produces the numbers above

## Supporting documentation

Issue: https://github.com/Automaat/sybra/issues/786 (body specifies this exact refactor). Parent umbrella: https://github.com/Automaat/sybra/issues/781.

> Changelog: refactor(sse): map-keyed subs for O(1) unsubscribe