### PR TITLE
refactor(frontend): split large components

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -35,6 +35,7 @@
   import type { PaletteCtx } from './lib/palette-commands.js'
   import KeyboardHelp from './components/KeyboardHelp.svelte'
   import TaskSidebar from './components/TaskSidebar.svelte'
+  import { handleAppKeydown, type AppKeyAction } from './lib/app-keyboard.js'
   import { Cloud, AlertTriangle } from '@lucide/svelte'
 
   const paletteCtx: PaletteCtx = {
@@ -162,111 +163,41 @@
       let pendingG = false
       let gTimer: ReturnType<typeof setTimeout> | null = null
 
-      function handleKeydown(e: KeyboardEvent) {
-        // Clear G-chord when a modifier key combo fires
-        if ((e.metaKey || e.ctrlKey || e.altKey) && pendingG) {
-          pendingG = false
-          if (gTimer) { clearTimeout(gTimer); gTimer = null }
-        }
-
-        if (e.metaKey && e.key === 'n') {
-          e.preventDefault()
-          quickAddOpen = true
-        }
-        if (e.metaKey && e.key === 'k') {
-          e.preventDefault()
-          commandPaletteOpen = true
-        }
-        if (e.metaKey && e.key === '/') {
-          e.preventDefault()
-          helpOpen = true
-        }
-        if (e.metaKey && e.key === '1') {
-          e.preventDefault()
-          navStore.reset({ kind: 'dashboard' })
-        }
-        if (e.metaKey && e.key === '2') {
-          e.preventDefault()
-          navStore.reset({ kind: 'task-list' })
-        }
-        if (e.metaKey && e.key === '3') {
-          e.preventDefault()
-          navStore.reset({ kind: 'project-list' })
-        }
-        if (e.metaKey && e.key === '4') {
-          e.preventDefault()
-          navStore.reset({ kind: 'agents' })
-        }
-        if (e.metaKey && e.key === '5') {
-          e.preventDefault()
-          navStore.reset({ kind: 'github' })
-        }
-        if (e.metaKey && e.key === '6') {
-          e.preventDefault()
-          navStore.reset({ kind: 'reviews' })
-        }
-        if (e.metaKey && e.key === '7') {
-          e.preventDefault()
-          navStore.reset({ kind: 'stats' })
-        }
-        if (e.metaKey && e.key === ',') {
-          e.preventDefault()
-          navStore.reset({ kind: 'settings' })
-        }
-        if (e.metaKey && e.key === 'f') {
-          e.preventDefault()
-          if (navStore.page.kind === 'github') {
-            window.dispatchEvent(new CustomEvent('focus-renovate-search'))
-          } else {
-            navStore.reset({ kind: 'task-list' })
-            requestAnimationFrame(() => window.dispatchEvent(new CustomEvent('focus-search')))
-          }
-        }
-        if (e.metaKey && e.key === 'b') {
-          e.preventDefault()
-          window.dispatchEvent(new CustomEvent('toggle-view'))
-        }
-        if (e.metaKey && e.key === 'i') {
-          e.preventDefault()
-          if (navStore.page.kind === 'task-list') {
+      function applyAction(action: AppKeyAction) {
+        switch (action.type) {
+          case 'open-quickadd': quickAddOpen = true; break
+          case 'open-palette': commandPaletteOpen = true; break
+          case 'open-help': helpOpen = true; break
+          case 'nav-reset': navStore.reset(action.page); break
+          case 'toggle-view':
+            window.dispatchEvent(new CustomEvent('toggle-view'))
+            break
+          case 'focus-search':
+            if (action.target === 'renovate') {
+              window.dispatchEvent(new CustomEvent('focus-renovate-search'))
+            } else {
+              navStore.reset({ kind: 'task-list' })
+              requestAnimationFrame(() => window.dispatchEvent(new CustomEvent('focus-search')))
+            }
+            break
+          case 'toggle-sidebar':
             if (focusedTaskIdFromList) {
               sidebarTaskId = sidebarTaskId === focusedTaskIdFromList ? null : focusedTaskIdFromList
             } else {
               sidebarTaskId = null
             }
-          }
+            break
         }
+      }
 
-        // G-chord navigation and bare shortcuts: not in input/textarea/contenteditable
-        if (!e.metaKey && !e.ctrlKey && !e.altKey) {
-          const target = e.target as HTMLElement
-          const inInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable
-          if (!inInput && e.shiftKey && e.key === '?') {
-            e.preventDefault()
-            helpOpen = true
-          }
-        }
-        if (!e.metaKey && !e.ctrlKey && !e.altKey && !e.shiftKey) {
-          const target = e.target as HTMLElement
-          const inInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable
-          if (!inInput) {
-            if (pendingG) {
-              pendingG = false
-              if (gTimer) { clearTimeout(gTimer); gTimer = null }
-              if (e.key === 'i') { e.preventDefault(); navStore.reset({ kind: 'task-list' }) }
-              else if (e.key === 'a') { e.preventDefault(); navStore.reset({ kind: 'task-list', filter: 'in-progress' }) }
-              else if (e.key === 'p') { e.preventDefault(); navStore.reset({ kind: 'project-list' }) }
-              else if (e.key === 's') { e.preventDefault(); navStore.reset({ kind: 'settings' }) }
-              // unmapped letters: clear pendingG silently, no navigation
-              return
-            }
-            if (e.key === 'g') {
-              e.preventDefault()
-              pendingG = true
-              gTimer = setTimeout(() => { pendingG = false; gTimer = null }, 1500)
-              return
-            }
-          }
+      function handleKeydown(e: KeyboardEvent) {
+        const result = handleAppKeydown(e, { pendingG, currentPageKind: navStore.page.kind })
+        if (result.preventDefault) e.preventDefault()
+        if (result.action !== null) applyAction(result.action)
+        if (result.nextPendingG !== pendingG) {
+          if (gTimer) { clearTimeout(gTimer); gTimer = null }
+          pendingG = result.nextPendingG
+          if (pendingG) gTimer = setTimeout(() => { pendingG = false; gTimer = null }, 1500)
         }
       }
       window.addEventListener('keydown', handleKeydown)

--- a/frontend/src/components/InlineTaskAdd.svelte
+++ b/frontend/src/components/InlineTaskAdd.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  import { taskStore } from '../stores/tasks.svelte.js'
+  import { notificationStore } from '../stores/notifications.svelte.js'
+
+  interface Props {
+    status: string
+  }
+
+  const { status }: Props = $props()
+
+  let active = $state(false)
+  let title = $state('')
+  let inputRef = $state<HTMLInputElement | null>(null)
+
+  function open() {
+    active = true
+    title = ''
+    requestAnimationFrame(() => inputRef?.focus())
+  }
+
+  function dismiss() {
+    active = false
+    title = ''
+  }
+
+  async function submit() {
+    const t = title.trim()
+    if (!t) return
+    title = ''
+    let created
+    try {
+      created = await taskStore.create(t, '', 'headless')
+    } catch (err) {
+      notificationStore.pushLocal('error', 'Create failed', String(err))
+      return
+    }
+    if (status !== 'new') {
+      try {
+        await taskStore.update(created.id, { status })
+      } catch (err) {
+        notificationStore.pushLocal('error', 'Failed to set status', String(err))
+      }
+    }
+    requestAnimationFrame(() => inputRef?.focus())
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      submit()
+    } else if (e.key === 'Escape') {
+      dismiss()
+    }
+  }
+</script>
+
+{#if active}
+  <input
+    bind:this={inputRef}
+    bind:value={title}
+    type="text"
+    placeholder="Task title"
+    class="w-full rounded-md border border-surface-300 bg-surface-50 px-2 py-2.5 text-base outline-none focus:border-primary-400 focus:ring-1 focus:ring-primary-400 dark:border-surface-600 dark:bg-surface-800 md:py-1.5 md:text-sm"
+    onkeydown={handleKeydown}
+    onblur={dismiss}
+  />
+{:else}
+  <button
+    type="button"
+    class="tap flex w-full items-center gap-1 rounded-md px-2 py-2.5 text-sm opacity-60 transition-opacity active:bg-surface-200 active:opacity-100 dark:active:bg-surface-800 md:py-1.5 md:hover:bg-surface-200 md:hover:opacity-100 dark:md:hover:bg-surface-800"
+    onclick={open}
+    title="Add task (C)"
+  >
+    <span class="text-base leading-none">+</span> Add task
+  </button>
+{/if}

--- a/frontend/src/components/InlineTaskAdd.svelte.test.ts
+++ b/frontend/src/components/InlineTaskAdd.svelte.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte'
+
+const mockCreate = vi.fn()
+const mockUpdate = vi.fn()
+const mockPushLocal = vi.fn()
+
+vi.mock('../stores/tasks.svelte.js', () => ({
+  taskStore: {
+    create: (...args: unknown[]) => mockCreate(...args),
+    update: (...args: unknown[]) => mockUpdate(...args),
+  },
+}))
+vi.mock('../stores/notifications.svelte.js', () => ({
+  notificationStore: { pushLocal: (...args: unknown[]) => mockPushLocal(...args) },
+}))
+
+const InlineTaskAdd = (await import('./InlineTaskAdd.svelte')).default
+
+describe('InlineTaskAdd', () => {
+  beforeEach(() => {
+    mockCreate.mockReset()
+    mockUpdate.mockReset()
+    mockPushLocal.mockReset()
+    mockCreate.mockResolvedValue({ id: 'new1' })
+    mockUpdate.mockResolvedValue({})
+  })
+  afterEach(cleanup)
+
+  it('renders the trigger button', () => {
+    render(InlineTaskAdd, { props: { status: 'todo' } })
+    expect(screen.getByText('Add task')).toBeDefined()
+  })
+
+  it('click reveals the input', async () => {
+    render(InlineTaskAdd, { props: { status: 'todo' } })
+    await fireEvent.click(screen.getByRole('button'))
+    expect(await screen.findByPlaceholderText('Task title')).toBeDefined()
+  })
+
+  it('Enter creates task and applies status for non-"new" columns', async () => {
+    render(InlineTaskAdd, { props: { status: 'in-progress' } })
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('Task title')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'New widget' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalledWith('New widget', '', 'headless')
+    })
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith('new1', { status: 'in-progress' })
+    })
+  })
+
+  it('Enter on "new" column does not call update', async () => {
+    render(InlineTaskAdd, { props: { status: 'new' } })
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('Task title')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'Fresh idea' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => {
+      expect(mockCreate).toHaveBeenCalled()
+    })
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('Escape dismisses without creating', async () => {
+    render(InlineTaskAdd, { props: { status: 'todo' } })
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('Task title')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'Abandon' } })
+    await fireEvent.keyDown(input, { key: 'Escape' })
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('empty title on Enter is a no-op', async () => {
+    render(InlineTaskAdd, { props: { status: 'todo' } })
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('Task title')) as HTMLInputElement
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    expect(mockCreate).not.toHaveBeenCalled()
+  })
+
+  it('create error surfaces notification', async () => {
+    mockCreate.mockRejectedValue(new Error('boom'))
+    render(InlineTaskAdd, { props: { status: 'todo' } })
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('Task title')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'Will fail' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => {
+      expect(mockPushLocal).toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/components/TaskListFilterBar.svelte
+++ b/frontend/src/components/TaskListFilterBar.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  import { List, Columns, GanttChart } from '@lucide/svelte'
+  import TaskFilterPanel from './TaskFilterPanel.svelte'
+  import { navStore } from '../lib/navigation.svelte.js'
+  import { viewModeStore, type ViewMode } from '../lib/view-mode.svelte.js'
+
+  interface Props {
+    searchQuery: string
+    selectedProjectId: string
+    selectedTags: string[]
+    selectedAgentMode: string
+    allTags: string[]
+    showDone: boolean
+    hasActiveFilters: boolean
+    viewMode: ViewMode
+    onclear: () => void
+    onviewchange?: () => void
+  }
+
+  let {
+    searchQuery = $bindable(),
+    selectedProjectId = $bindable(),
+    selectedTags = $bindable(),
+    selectedAgentMode = $bindable(),
+    allTags,
+    showDone = $bindable(),
+    hasActiveFilters,
+    viewMode,
+    onclear,
+    onviewchange,
+  }: Props = $props()
+
+  const agentModes = [
+    { value: '', label: 'All' },
+    { value: 'headless', label: 'Headless' },
+    { value: 'interactive', label: 'Interactive' },
+  ]
+
+  function pickViewMode(m: ViewMode) {
+    viewModeStore.set(m)
+    onviewchange?.()
+  }
+</script>
+
+<div class="hidden flex-wrap items-center gap-3 border-b border-surface-200 px-6 py-3 dark:border-surface-800 md:flex">
+  <TaskFilterPanel
+    query={searchQuery}
+    onqueryChange={(q) => (searchQuery = q)}
+    focusEvent="focus-search"
+    showProject
+    selectedProjectId={selectedProjectId}
+    onprojectChange={(id) => (selectedProjectId = id)}
+    showTags
+    availableTags={allTags}
+    selectedTags={selectedTags}
+    ontagsChange={(tags) => (selectedTags = tags)}
+  />
+
+  <div class="flex h-8 rounded-md border border-surface-300 dark:border-surface-700">
+    {#each agentModes as mode}
+      <button
+        type="button"
+        class="px-2.5 text-xs font-medium transition-colors first:rounded-l-md last:rounded-r-md {selectedAgentMode === mode.value
+          ? 'bg-primary-500 text-white dark:bg-primary-600'
+          : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
+        onclick={() => (selectedAgentMode = mode.value)}
+      >
+        {mode.label}
+      </button>
+    {/each}
+  </div>
+
+  <div class="ml-auto flex items-center gap-3">
+    {#if hasActiveFilters}
+      <button
+        type="button"
+        class="text-xs text-surface-500 underline hover:text-surface-700 dark:hover:text-surface-300"
+        onclick={onclear}
+      >
+        Clear filters
+      </button>
+    {/if}
+    <button
+      type="button"
+      class="text-xs text-surface-500 underline hover:text-surface-700 dark:hover:text-surface-300"
+      onclick={() => navStore.reset({ kind: 'logbook' })}
+    >
+      Logbook →
+    </button>
+    <label class="flex items-center gap-1.5 text-xs text-surface-500">
+      <input type="checkbox" bind:checked={showDone} class="accent-primary-500" />
+      Show done
+    </label>
+    <div class="flex rounded-md border border-surface-300 dark:border-surface-700" title="Switch view (⌘B)">
+      <button
+        type="button"
+        class="flex items-center gap-1 px-2 py-1 text-xs font-medium transition-colors first:rounded-l-md last:rounded-r-md {viewMode === 'list' ? 'bg-primary-500 text-white dark:bg-primary-600' : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
+        onclick={() => pickViewMode('list')}
+      >
+        <List size={14} />
+        List
+      </button>
+      <button
+        type="button"
+        class="flex items-center gap-1 border-x border-surface-300 px-2 py-1 text-xs font-medium transition-colors dark:border-surface-700 {viewMode === 'board' ? 'bg-primary-500 text-white dark:bg-primary-600' : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
+        onclick={() => pickViewMode('board')}
+      >
+        <Columns size={14} />
+        Board
+      </button>
+      <button
+        type="button"
+        class="flex items-center gap-1 px-2 py-1 text-xs font-medium transition-colors first:rounded-l-md last:rounded-r-md {viewMode === 'timeline' ? 'bg-primary-500 text-white dark:bg-primary-600' : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
+        onclick={() => pickViewMode('timeline')}
+      >
+        <GanttChart size={14} />
+        Timeline
+      </button>
+    </div>
+  </div>
+</div>

--- a/frontend/src/components/task-detail/TaskDueDateEditor.svelte
+++ b/frontend/src/components/task-detail/TaskDueDateEditor.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
+  import { taskStore } from '../../stores/tasks.svelte.js'
+  import { formatDueDateDisplay, parseNaturalDate } from '../../lib/dates.js'
+
+  interface Props {
+    task: Task
+    onerror?: (msg: string) => void
+  }
+
+  const { task, onerror }: Props = $props()
+
+  let editing = $state(false)
+  let draft = $state('')
+  let inputRef = $state<HTMLInputElement | null>(null)
+
+  $effect(() => {
+    if (editing && inputRef) inputRef.focus()
+  })
+
+  export function start() {
+    if (editing) return
+    if (task.dueDate) {
+      const d = new Date(task.dueDate as unknown as string)
+      draft = isNaN(d.getTime()) ? '' : d.toISOString().split('T')[0]
+    } else {
+      draft = ''
+    }
+    editing = true
+  }
+
+  async function save() {
+    editing = false
+    const value = draft.trim()
+    let newVal: string | null = null
+    if (value && value.toLowerCase() !== 'none' && value.toLowerCase() !== 'clear') {
+      const parsed = parseNaturalDate(value)
+      if (!parsed) {
+        onerror?.(`Invalid date: "${value}". Try "today", "tomorrow", "next monday", "in 3 days", or YYYY-MM-DD.`)
+        return
+      }
+      newVal = parsed.toISOString()
+    }
+    const currentISO = task.dueDate ? new Date(task.dueDate as unknown as string).toISOString() : null
+    if (newVal === currentISO) return
+    try {
+      await taskStore.update(task.id, { due_date: newVal })
+      onerror?.('')
+    } catch (e) {
+      onerror?.(String(e))
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      save()
+    } else if (e.key === 'Escape') {
+      editing = false
+    }
+  }
+
+  const overdue = $derived(
+    task.dueDate ? new Date(task.dueDate as unknown as string) < new Date() : false,
+  )
+</script>
+
+{#if editing}
+  <input
+    bind:this={inputRef}
+    bind:value={draft}
+    class="rounded border border-primary-400 bg-surface-50 px-2 py-0.5 text-xs outline-none dark:border-primary-500 dark:bg-surface-900"
+    placeholder="today / tomorrow / YYYY-MM-DD"
+    onblur={save}
+    onkeydown={handleKeydown}
+  />
+  <span class="text-surface-300 dark:text-surface-600">Esc to cancel</span>
+{:else}
+  <button
+    type="button"
+    class="rounded px-1 py-0.5 transition-colors hover:bg-surface-200 hover:text-surface-700 dark:hover:bg-surface-700 dark:hover:text-surface-300 {overdue ? 'text-error-500 dark:text-error-400' : ''}"
+    onclick={start}
+    title="Click to set due date"
+  >
+    {formatDueDateDisplay(task.dueDate)}
+  </button>
+{/if}

--- a/frontend/src/components/task-detail/TaskDueDateEditor.svelte.test.ts
+++ b/frontend/src/components/task-detail/TaskDueDateEditor.svelte.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte'
+
+const mockUpdate = vi.fn()
+vi.mock('../../stores/tasks.svelte.js', () => ({
+  taskStore: { update: (...args: unknown[]) => mockUpdate(...args) },
+}))
+
+const TaskDueDateEditor = (await import('./TaskDueDateEditor.svelte')).default
+
+const baseTask = {
+  id: 't1',
+  slug: 'demo',
+  title: 'X',
+  status: 'todo',
+  body: '',
+  tags: [],
+  agentMode: 'headless',
+  allowedTools: [],
+  projectId: 'foo/bar',
+  createdAt: '2026-04-01T00:00:00Z',
+  updatedAt: '2026-04-01T00:00:00Z',
+  dueDate: null,
+}
+
+describe('TaskDueDateEditor', () => {
+  beforeEach(() => {
+    mockUpdate.mockReset()
+    mockUpdate.mockResolvedValue(baseTask)
+  })
+  afterEach(cleanup)
+
+  it('renders display state when no due date', () => {
+    render(TaskDueDateEditor, { props: { task: baseTask as never } })
+    // formatDueDateDisplay(null) returns the empty-state label
+    expect(screen.getByRole('button')).toBeDefined()
+  })
+
+  it('clicking display switches to edit input', async () => {
+    render(TaskDueDateEditor, { props: { task: baseTask as never } })
+    await fireEvent.click(screen.getByRole('button'))
+    expect(await screen.findByPlaceholderText('today / tomorrow / YYYY-MM-DD')).toBeDefined()
+  })
+
+  it('Enter with "today" saves an ISO date', async () => {
+    render(TaskDueDateEditor, { props: { task: baseTask as never } })
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('today / tomorrow / YYYY-MM-DD')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'today' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalled()
+      const args = mockUpdate.mock.calls[0]
+      expect(args[0]).toBe('t1')
+      expect(args[1].due_date).toBeTruthy()
+    })
+  })
+
+  it('invalid date reports via onerror, does not call update', async () => {
+    const errors: string[] = []
+    render(TaskDueDateEditor, {
+      props: {
+        task: baseTask as never,
+        onerror: (m: string) => { errors.push(m) },
+      },
+    })
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('today / tomorrow / YYYY-MM-DD')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'invalid garbage' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => {
+      expect(errors.some(e => /Invalid date/.test(e))).toBe(true)
+    })
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('Escape cancels without saving', async () => {
+    render(TaskDueDateEditor, { props: { task: baseTask as never } })
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('today / tomorrow / YYYY-MM-DD')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'today' } })
+    await fireEvent.keyDown(input, { key: 'Escape' })
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('"clear" sets due_date to null', async () => {
+    const taskWithDate = { ...baseTask, dueDate: '2026-12-01T00:00:00Z' }
+    render(TaskDueDateEditor, { props: { task: taskWithDate as never } })
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('today / tomorrow / YYYY-MM-DD')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'clear' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith('t1', { due_date: null })
+    })
+  })
+})

--- a/frontend/src/components/task-detail/TaskMaxTurnsEditor.svelte
+++ b/frontend/src/components/task-detail/TaskMaxTurnsEditor.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+  import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
+  import { taskStore } from '../../stores/tasks.svelte.js'
+
+  interface Props {
+    task: Task
+    onerror?: (msg: string) => void
+  }
+
+  const { task, onerror }: Props = $props()
+
+  let editing = $state(false)
+  let draft = $state('')
+  let inputRef = $state<HTMLInputElement | null>(null)
+
+  $effect(() => {
+    if (editing && inputRef) inputRef.focus()
+  })
+
+  export function start() {
+    if (editing) return
+    draft = task.maxTurns ? String(task.maxTurns) : ''
+    editing = true
+  }
+
+  async function save() {
+    editing = false
+    const raw = String(draft ?? '').trim()
+    const n = raw === '' ? 0 : parseInt(raw, 10)
+    if (raw !== '' && (isNaN(n) || n < 0)) {
+      onerror?.('Max turns must be a non-negative integer.')
+      return
+    }
+    const current = task.maxTurns ?? 0
+    if (n === current) return
+    try {
+      await taskStore.update(task.id, { max_turns: n })
+      onerror?.('')
+    } catch (e) {
+      onerror?.(String(e))
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      save()
+    } else if (e.key === 'Escape') {
+      editing = false
+    }
+  }
+</script>
+
+{#if editing}
+  <input
+    bind:this={inputRef}
+    bind:value={draft}
+    type="number"
+    min="0"
+    class="w-24 rounded border border-primary-400 bg-surface-50 px-2 py-0.5 text-xs outline-none dark:border-primary-500 dark:bg-surface-900"
+    placeholder="global default"
+    onblur={save}
+    onkeydown={handleKeydown}
+  />
+{:else}
+  <button
+    type="button"
+    class="w-fit rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-200 hover:text-surface-700 dark:hover:bg-surface-700 dark:hover:text-surface-300"
+    onclick={start}
+    title="Click to set per-task max turns (0 = use global default)"
+  >
+    {#if task.maxTurns}
+      {task.maxTurns}
+    {:else}
+      <span class="italic text-surface-400">global default</span>
+    {/if}
+  </button>
+{/if}

--- a/frontend/src/components/task-detail/TaskMaxTurnsEditor.svelte.test.ts
+++ b/frontend/src/components/task-detail/TaskMaxTurnsEditor.svelte.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte'
+
+const mockUpdate = vi.fn()
+vi.mock('../../stores/tasks.svelte.js', () => ({
+  taskStore: { update: (...args: unknown[]) => mockUpdate(...args) },
+}))
+
+const TaskMaxTurnsEditor = (await import('./TaskMaxTurnsEditor.svelte')).default
+
+const baseTask = {
+  id: 't1',
+  slug: 'demo',
+  title: 'X',
+  status: 'todo',
+  body: '',
+  tags: [],
+  agentMode: 'headless',
+  allowedTools: [],
+  projectId: 'foo/bar',
+  createdAt: '2026-04-01T00:00:00Z',
+  updatedAt: '2026-04-01T00:00:00Z',
+  dueDate: null,
+  maxTurns: 0,
+}
+
+describe('TaskMaxTurnsEditor', () => {
+  beforeEach(() => {
+    mockUpdate.mockReset()
+    mockUpdate.mockResolvedValue(baseTask)
+  })
+  afterEach(cleanup)
+
+  it('renders "global default" when maxTurns is 0', () => {
+    render(TaskMaxTurnsEditor, { props: { task: baseTask as never } })
+    expect(screen.getByText('global default')).toBeDefined()
+  })
+
+  it('renders explicit value when maxTurns is set', () => {
+    render(TaskMaxTurnsEditor, { props: { task: { ...baseTask, maxTurns: 25 } as never } })
+    expect(screen.getByText('25')).toBeDefined()
+  })
+
+  it('Enter on valid integer calls update', async () => {
+    render(TaskMaxTurnsEditor, { props: { task: baseTask as never } })
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('global default')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: '42' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith('t1', { max_turns: 42 })
+    })
+  })
+
+  it('negative input fires onerror, no update', async () => {
+    const errors: string[] = []
+    render(TaskMaxTurnsEditor, {
+      props: { task: baseTask as never, onerror: (m: string) => errors.push(m) },
+    })
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('global default')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: '-3' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => {
+      expect(errors.some(e => /non-negative/.test(e))).toBe(true)
+    })
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('Escape cancels without saving', async () => {
+    render(TaskMaxTurnsEditor, { props: { task: baseTask as never } })
+    await fireEvent.click(screen.getByRole('button'))
+    const input = (await screen.findByPlaceholderText('global default')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: '5' } })
+    await fireEvent.keyDown(input, { key: 'Escape' })
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('unchanged value is a no-op', async () => {
+    render(TaskMaxTurnsEditor, { props: { task: { ...baseTask, maxTurns: 10 } as never } })
+    await fireEvent.click(screen.getByText('10'))
+    const input = (await screen.findByPlaceholderText('global default')) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: '10' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    // Allow microtasks
+    await new Promise(r => setTimeout(r, 10))
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/task-detail/TaskMetadataRow.svelte
+++ b/frontend/src/components/task-detail/TaskMetadataRow.svelte
@@ -4,8 +4,11 @@
   import { taskStore } from '../../stores/tasks.svelte.js'
   import { notificationStore } from '../../stores/notifications.svelte.js'
   import { BrowserOpenURL } from '$lib/api'
-  import { formatDate, formatDueDateDisplay, parseNaturalDate } from '../../lib/dates.js'
+  import { formatDate } from '../../lib/dates.js'
   import AssignProjectDialog from '../AssignProjectDialog.svelte'
+  import TaskTagEditor from './TaskTagEditor.svelte'
+  import TaskDueDateEditor from './TaskDueDateEditor.svelte'
+  import TaskMaxTurnsEditor from './TaskMaxTurnsEditor.svelte'
 
   interface Props {
     task: Task
@@ -13,57 +16,20 @@
 
   const { task }: Props = $props()
 
-  let editingTags = $state(false)
-  let tagsDraft = $state<string[]>([])
-  let tagInput = $state('')
-  let tagInputRef = $state<HTMLInputElement | null>(null)
-
-  let editingDueDate = $state(false)
-  let dueDateDraft = $state('')
-  let dueDateInputRef = $state<HTMLInputElement | null>(null)
-
-  let copiedBranch = $state(false)
   let error = $state('')
-
-  let editingMaxTurns = $state(false)
-  let maxTurnsDraft = $state('')
-  let maxTurnsInputRef = $state<HTMLInputElement | null>(null)
-
+  let copiedBranch = $state(false)
   let projectDialogOpen = $state(false)
 
-  async function assignProject(projectId: string) {
-    if ((task.projectId ?? '') === projectId) return
-    try {
-      await taskStore.update(task.id, { project_id: projectId })
-      error = ''
-    } catch (e) {
-      error = String(e)
-    }
-  }
-
-  $effect(() => {
-    if (editingMaxTurns && maxTurnsInputRef) maxTurnsInputRef.focus()
-  })
+  let tagEditor = $state<TaskTagEditor | null>(null)
+  let dueDateEditor = $state<TaskDueDateEditor | null>(null)
 
   const taskBranchName = $derived(
     task ? 'sybra/' + (task.slug ? task.slug + '-' + task.id : task.id) : '',
   )
 
   $effect(() => {
-    if (editingTags && tagInputRef) tagInputRef.focus()
-  })
-
-  $effect(() => {
-    if (editingDueDate && dueDateInputRef) dueDateInputRef.focus()
-  })
-
-  $effect(() => {
-    function onEditTags() {
-      if (!editingTags) startEditingTags()
-    }
-    function onOpenDueDate() {
-      if (!editingDueDate) startEditingDueDate()
-    }
+    function onEditTags() { tagEditor?.start() }
+    function onOpenDueDate() { dueDateEditor?.start() }
     window.addEventListener('task-detail:edit-tags', onEditTags)
     window.addEventListener('open-due-date', onOpenDueDate)
     return () => {
@@ -72,126 +38,13 @@
     }
   })
 
-  function startEditingTags() {
-    tagsDraft = [...(task.tags ?? [])]
-    tagInput = ''
-    editingTags = true
-  }
-
-  function addTag() {
-    const tag = tagInput.trim().replace(/,/g, '')
-    if (tag && !tagsDraft.includes(tag)) tagsDraft = [...tagsDraft, tag]
-    tagInput = ''
-  }
-
-  function removeTag(tag: string) {
-    tagsDraft = tagsDraft.filter((x) => x !== tag)
-  }
-
-  async function saveTags() {
-    editingTags = false
-    const current = task.tags ?? []
-    const same =
-      current.length === tagsDraft.length && current.every((v, i) => v === tagsDraft[i])
-    if (same) return
+  async function assignProject(projectId: string) {
+    if ((task.projectId ?? '') === projectId) return
     try {
-      await taskStore.update(task.id, { tags: tagsDraft })
-    } catch (e) {
-      error = String(e)
-    }
-  }
-
-  function handleTagInputKeydown(e: KeyboardEvent) {
-    if (e.key === 'Enter') {
-      e.preventDefault()
-      if (tagInput.trim()) addTag()
-      else saveTags()
-    } else if (e.key === 'Escape') {
-      editingTags = false
-    } else if (e.key === 'Backspace' && !tagInput && tagsDraft.length > 0) {
-      tagsDraft = tagsDraft.slice(0, -1)
-    } else if (e.key === ',') {
-      e.preventDefault()
-      addTag()
-    }
-  }
-
-  function handleTagsContainerFocusout(e: FocusEvent) {
-    const related = e.relatedTarget as Node | null
-    const container = e.currentTarget as HTMLElement
-    if (!related || !container.contains(related)) saveTags()
-  }
-
-  function startEditingDueDate() {
-    if (task.dueDate) {
-      const d = new Date(task.dueDate as unknown as string)
-      dueDateDraft = isNaN(d.getTime()) ? '' : d.toISOString().split('T')[0]
-    } else {
-      dueDateDraft = ''
-    }
-    editingDueDate = true
-  }
-
-  async function saveDueDate() {
-    editingDueDate = false
-    const input = dueDateDraft.trim()
-    let newVal: string | null = null
-    if (input && input.toLowerCase() !== 'none' && input.toLowerCase() !== 'clear') {
-      const parsed = parseNaturalDate(input)
-      if (!parsed) {
-        error = `Invalid date: "${input}". Try "today", "tomorrow", "next monday", "in 3 days", or YYYY-MM-DD.`
-        return
-      }
-      newVal = parsed.toISOString()
-    }
-    const currentISO = task.dueDate ? new Date(task.dueDate as unknown as string).toISOString() : null
-    if (newVal === currentISO) return
-    try {
-      await taskStore.update(task.id, { due_date: newVal })
+      await taskStore.update(task.id, { project_id: projectId })
       error = ''
     } catch (e) {
       error = String(e)
-    }
-  }
-
-  function handleDueDateKeydown(e: KeyboardEvent) {
-    if (e.key === 'Enter') {
-      e.preventDefault()
-      saveDueDate()
-    } else if (e.key === 'Escape') {
-      editingDueDate = false
-    }
-  }
-
-  function startEditingMaxTurns() {
-    maxTurnsDraft = task.maxTurns ? String(task.maxTurns) : ''
-    editingMaxTurns = true
-  }
-
-  async function saveMaxTurns() {
-    editingMaxTurns = false
-    const raw = maxTurnsDraft.trim()
-    const n = raw === '' ? 0 : parseInt(raw, 10)
-    if (raw !== '' && (isNaN(n) || n < 0)) {
-      error = 'Max turns must be a non-negative integer.'
-      return
-    }
-    const current = task.maxTurns ?? 0
-    if (n === current) return
-    try {
-      await taskStore.update(task.id, { max_turns: n })
-      error = ''
-    } catch (e) {
-      error = String(e)
-    }
-  }
-
-  function handleMaxTurnsKeydown(e: KeyboardEvent) {
-    if (e.key === 'Enter') {
-      e.preventDefault()
-      saveMaxTurns()
-    } else if (e.key === 'Escape') {
-      editingMaxTurns = false
     }
   }
 
@@ -205,6 +58,8 @@
       notificationStore.pushLocal('error', 'Copy failed', String(e))
     }
   }
+
+  function handleError(msg: string) { error = msg }
 </script>
 
 {#if error}
@@ -219,48 +74,7 @@
 
   <div class="flex flex-col gap-1">
     <span class="font-medium text-surface-500">Tags</span>
-    {#if editingTags}
-      <!-- svelte-ignore a11y_no_static_element_interactions -->
-      <div
-        class="flex min-w-[8rem] flex-wrap items-center gap-1 rounded-lg border border-primary-400 bg-surface-50 px-2 py-1 dark:border-primary-500 dark:bg-surface-900"
-        onfocusout={handleTagsContainerFocusout}
-      >
-        {#each tagsDraft as tag}
-          <span class="inline-flex items-center gap-0.5 rounded bg-surface-200 px-1.5 py-0.5 text-xs dark:bg-surface-700">
-            {tag}
-            <button
-              type="button"
-              class="ml-0.5 text-surface-400 hover:text-error-500"
-              onclick={() => removeTag(tag)}
-              tabindex="-1"
-              aria-label="Remove tag {tag}"
-            >×</button>
-          </span>
-        {/each}
-        <input
-          bind:this={tagInputRef}
-          bind:value={tagInput}
-          class="min-w-[4rem] flex-1 bg-transparent text-xs outline-none"
-          placeholder={tagsDraft.length ? '' : 'add tags...'}
-          onkeydown={handleTagInputKeydown}
-        />
-      </div>
-    {:else}
-      <button
-        type="button"
-        class="flex flex-wrap items-center gap-1 rounded-lg border border-transparent px-1 py-0.5 text-left transition-colors hover:border-surface-300 hover:bg-surface-100 dark:hover:border-surface-600 dark:hover:bg-surface-800"
-        onclick={startEditingTags}
-        title="Click to edit tags"
-      >
-        {#if task.tags?.length}
-          {#each task.tags as tag}
-            <span class="rounded bg-surface-200 px-2 py-0.5 text-xs dark:bg-surface-700">{tag}</span>
-          {/each}
-        {:else}
-          <span class="text-xs italic text-surface-400">add tags</span>
-        {/if}
-      </button>
-    {/if}
+    <TaskTagEditor bind:this={tagEditor} {task} onerror={handleError} />
   </div>
 
   <div class="flex flex-col gap-1">
@@ -345,31 +159,7 @@
 
   <div class="flex flex-col gap-1">
     <span class="font-medium text-surface-500">Max Turns</span>
-    {#if editingMaxTurns}
-      <input
-        bind:this={maxTurnsInputRef}
-        bind:value={maxTurnsDraft}
-        type="number"
-        min="0"
-        class="w-24 rounded border border-primary-400 bg-surface-50 px-2 py-0.5 text-xs outline-none dark:border-primary-500 dark:bg-surface-900"
-        placeholder="global default"
-        onblur={saveMaxTurns}
-        onkeydown={handleMaxTurnsKeydown}
-      />
-    {:else}
-      <button
-        type="button"
-        class="w-fit rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-200 hover:text-surface-700 dark:hover:bg-surface-700 dark:hover:text-surface-300"
-        onclick={startEditingMaxTurns}
-        title="Click to set per-task max turns (0 = use global default)"
-      >
-        {#if task.maxTurns}
-          {task.maxTurns}
-        {:else}
-          <span class="italic text-surface-400">global default</span>
-        {/if}
-      </button>
-    {/if}
+    <TaskMaxTurnsEditor {task} onerror={handleError} />
   </div>
 </div>
 
@@ -378,26 +168,7 @@
   <span>Updated: {formatDate(task.updatedAt)}</span>
   <div class="flex items-center gap-1">
     <span>Due:</span>
-    {#if editingDueDate}
-      <input
-        bind:this={dueDateInputRef}
-        bind:value={dueDateDraft}
-        class="rounded border border-primary-400 bg-surface-50 px-2 py-0.5 text-xs outline-none dark:border-primary-500 dark:bg-surface-900"
-        placeholder="today / tomorrow / YYYY-MM-DD"
-        onblur={saveDueDate}
-        onkeydown={handleDueDateKeydown}
-      />
-      <span class="text-surface-300 dark:text-surface-600">Esc to cancel</span>
-    {:else}
-      <button
-        type="button"
-        class="rounded px-1 py-0.5 transition-colors hover:bg-surface-200 hover:text-surface-700 dark:hover:bg-surface-700 dark:hover:text-surface-300 {task.dueDate && new Date(task.dueDate as unknown as string) < new Date() ? 'text-error-500 dark:text-error-400' : ''}"
-        onclick={startEditingDueDate}
-        title="Click to set due date"
-      >
-        {formatDueDateDisplay(task.dueDate)}
-      </button>
-    {/if}
+    <TaskDueDateEditor bind:this={dueDateEditor} {task} onerror={handleError} />
   </div>
 </div>
 

--- a/frontend/src/components/task-detail/TaskTagEditor.svelte
+++ b/frontend/src/components/task-detail/TaskTagEditor.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+  import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
+  import { taskStore } from '../../stores/tasks.svelte.js'
+
+  interface Props {
+    task: Task
+    onerror?: (msg: string) => void
+  }
+
+  const { task, onerror }: Props = $props()
+
+  let editing = $state(false)
+  let draft = $state<string[]>([])
+  let input = $state('')
+  let inputRef = $state<HTMLInputElement | null>(null)
+
+  $effect(() => {
+    if (editing && inputRef) inputRef.focus()
+  })
+
+  export function start() {
+    if (editing) return
+    draft = [...(task.tags ?? [])]
+    input = ''
+    editing = true
+  }
+
+  function addTag() {
+    const tag = input.trim().replace(/,/g, '')
+    if (tag && !draft.includes(tag)) draft = [...draft, tag]
+    input = ''
+  }
+
+  function removeTag(tag: string) {
+    draft = draft.filter((x) => x !== tag)
+  }
+
+  async function save() {
+    editing = false
+    const current = task.tags ?? []
+    const same = current.length === draft.length && current.every((v, i) => v === draft[i])
+    if (same) return
+    try {
+      await taskStore.update(task.id, { tags: draft })
+    } catch (e) {
+      onerror?.(String(e))
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      if (input.trim()) addTag()
+      else save()
+    } else if (e.key === 'Escape') {
+      editing = false
+    } else if (e.key === 'Backspace' && !input && draft.length > 0) {
+      draft = draft.slice(0, -1)
+    } else if (e.key === ',') {
+      e.preventDefault()
+      addTag()
+    }
+  }
+
+  function handleFocusout(e: FocusEvent) {
+    const related = e.relatedTarget as Node | null
+    const container = e.currentTarget as HTMLElement
+    if (!related || !container.contains(related)) save()
+  }
+</script>
+
+{#if editing}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="flex min-w-[8rem] flex-wrap items-center gap-1 rounded-lg border border-primary-400 bg-surface-50 px-2 py-1 dark:border-primary-500 dark:bg-surface-900"
+    onfocusout={handleFocusout}
+  >
+    {#each draft as tag}
+      <span class="inline-flex items-center gap-0.5 rounded bg-surface-200 px-1.5 py-0.5 text-xs dark:bg-surface-700">
+        {tag}
+        <button
+          type="button"
+          class="ml-0.5 text-surface-400 hover:text-error-500"
+          onclick={() => removeTag(tag)}
+          tabindex="-1"
+          aria-label="Remove tag {tag}"
+        >×</button>
+      </span>
+    {/each}
+    <input
+      bind:this={inputRef}
+      bind:value={input}
+      class="min-w-[4rem] flex-1 bg-transparent text-xs outline-none"
+      placeholder={draft.length ? '' : 'add tags...'}
+      onkeydown={handleKeydown}
+    />
+  </div>
+{:else}
+  <button
+    type="button"
+    class="flex flex-wrap items-center gap-1 rounded-lg border border-transparent px-1 py-0.5 text-left transition-colors hover:border-surface-300 hover:bg-surface-100 dark:hover:border-surface-600 dark:hover:bg-surface-800"
+    onclick={start}
+    title="Click to edit tags"
+  >
+    {#if task.tags?.length}
+      {#each task.tags as tag}
+        <span class="rounded bg-surface-200 px-2 py-0.5 text-xs dark:bg-surface-700">{tag}</span>
+      {/each}
+    {:else}
+      <span class="text-xs italic text-surface-400">add tags</span>
+    {/if}
+  </button>
+{/if}

--- a/frontend/src/components/task-detail/TaskTagEditor.svelte.test.ts
+++ b/frontend/src/components/task-detail/TaskTagEditor.svelte.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte'
+
+const mockUpdate = vi.fn()
+vi.mock('../../stores/tasks.svelte.js', () => ({
+  taskStore: { update: (...args: unknown[]) => mockUpdate(...args) },
+}))
+
+const TaskTagEditor = (await import('./TaskTagEditor.svelte')).default
+
+const baseTask = {
+  id: 't1',
+  slug: 'demo',
+  title: 'X',
+  status: 'todo',
+  body: '',
+  tags: ['backend'],
+  agentMode: 'headless',
+  allowedTools: [],
+  projectId: 'foo/bar',
+  createdAt: '2026-04-01T00:00:00Z',
+  updatedAt: '2026-04-01T00:00:00Z',
+  dueDate: null,
+}
+
+describe('TaskTagEditor', () => {
+  beforeEach(() => {
+    mockUpdate.mockReset()
+    mockUpdate.mockResolvedValue(baseTask)
+  })
+  afterEach(cleanup)
+
+  it('renders existing tags in display mode', () => {
+    render(TaskTagEditor, { props: { task: baseTask as never } })
+    expect(screen.getByText('backend')).toBeDefined()
+  })
+
+  it('renders placeholder when no tags', () => {
+    render(TaskTagEditor, { props: { task: { ...baseTask, tags: [] } as never } })
+    expect(screen.getByText('add tags')).toBeDefined()
+  })
+
+  it('click switches to edit mode and shows input', async () => {
+    render(TaskTagEditor, { props: { task: baseTask as never } })
+    await fireEvent.click(screen.getByText('backend'))
+    await waitFor(() => {
+      expect(screen.getAllByRole('textbox').length).toBeGreaterThan(0)
+    })
+  })
+
+  it('Enter on non-empty input adds tag', async () => {
+    render(TaskTagEditor, { props: { task: baseTask as never } })
+    await fireEvent.click(screen.getByText('backend'))
+    const input = screen.getAllByRole('textbox')[0] as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'frontend' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => {
+      expect(screen.getByText('frontend')).toBeDefined()
+    })
+  })
+
+  it('Enter on empty input persists and exits edit mode', async () => {
+    render(TaskTagEditor, { props: { task: baseTask as never } })
+    await fireEvent.click(screen.getByText('backend'))
+    const input = screen.getAllByRole('textbox')[0] as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'frontend' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    // Now add a second tag and persist
+    await fireEvent.input(input, { target: { value: '' } })
+    await fireEvent.keyDown(input, { key: 'Enter' })
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith('t1', { tags: ['backend', 'frontend'] })
+    })
+  })
+
+  it('Escape cancels without calling update', async () => {
+    render(TaskTagEditor, { props: { task: baseTask as never } })
+    await fireEvent.click(screen.getByText('backend'))
+    const input = screen.getAllByRole('textbox')[0] as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'frontend' } })
+    await fireEvent.keyDown(input, { key: 'Escape' })
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('Backspace on empty input pops last tag', async () => {
+    const task = { ...baseTask, tags: ['a', 'b'] }
+    render(TaskTagEditor, { props: { task: task as never } })
+    await fireEvent.click(screen.getByText('a'))
+    const input = screen.getAllByRole('textbox')[0] as HTMLInputElement
+    await fireEvent.keyDown(input, { key: 'Backspace' })
+    // 'b' should be gone from the editor draft
+    await waitFor(() => {
+      expect(screen.queryByText('b')).toBeNull()
+    })
+  })
+
+  it('comma key adds tag without submitting', async () => {
+    render(TaskTagEditor, { props: { task: baseTask as never } })
+    await fireEvent.click(screen.getByText('backend'))
+    const input = screen.getAllByRole('textbox')[0] as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'devops' } })
+    await fireEvent.keyDown(input, { key: ',' })
+    await waitFor(() => {
+      expect(screen.getByText('devops')).toBeDefined()
+    })
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/app-keyboard.test.ts
+++ b/frontend/src/lib/app-keyboard.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest'
+import { handleAppKeydown, type AppKeyboardCtx, type AppKeyboardEvent } from './app-keyboard.js'
+
+function ev(partial: Partial<AppKeyboardEvent> & { key: string }): AppKeyboardEvent {
+  return {
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    target: null,
+    ...partial,
+  }
+}
+
+function ctx(overrides: Partial<AppKeyboardCtx> = {}): AppKeyboardCtx {
+  return {
+    pendingG: false,
+    currentPageKind: 'task-list',
+    ...overrides,
+  }
+}
+
+describe('handleAppKeydown — Cmd shortcuts', () => {
+  it.each([
+    ['n', { type: 'open-quickadd' }],
+    ['k', { type: 'open-palette' }],
+    ['/', { type: 'open-help' }],
+    ['b', { type: 'toggle-view' }],
+  ] as const)('Cmd+%s -> %j', (key, expected) => {
+    const r = handleAppKeydown(ev({ key, metaKey: true }), ctx())
+    expect(r.preventDefault).toBe(true)
+    expect(r.action).toEqual(expected)
+    expect(r.nextPendingG).toBe(false)
+  })
+
+  it.each([
+    ['1', 'dashboard'],
+    ['2', 'task-list'],
+    ['3', 'project-list'],
+    ['4', 'agents'],
+    ['5', 'github'],
+    ['6', 'reviews'],
+    ['7', 'stats'],
+    [',', 'settings'],
+  ] as const)('Cmd+%s navigates to %s', (key, kind) => {
+    const r = handleAppKeydown(ev({ key, metaKey: true }), ctx())
+    expect(r.preventDefault).toBe(true)
+    expect(r.action).toEqual({ type: 'nav-reset', page: { kind } })
+  })
+
+  it('Cmd+F on github focuses renovate search', () => {
+    const r = handleAppKeydown(ev({ key: 'f', metaKey: true }), ctx({ currentPageKind: 'github' }))
+    expect(r.action).toEqual({ type: 'focus-search', target: 'renovate' })
+  })
+
+  it('Cmd+F off github focuses task search', () => {
+    const r = handleAppKeydown(ev({ key: 'f', metaKey: true }), ctx({ currentPageKind: 'dashboard' }))
+    expect(r.action).toEqual({ type: 'focus-search', target: 'tasks' })
+  })
+
+  it('Cmd+I on task-list toggles sidebar', () => {
+    const r = handleAppKeydown(ev({ key: 'i', metaKey: true }), ctx({ currentPageKind: 'task-list' }))
+    expect(r.action).toEqual({ type: 'toggle-sidebar' })
+    expect(r.preventDefault).toBe(true)
+  })
+
+  it('Cmd+I off task-list is a no-op (preventDefault still claims the combo)', () => {
+    const r = handleAppKeydown(ev({ key: 'i', metaKey: true }), ctx({ currentPageKind: 'dashboard' }))
+    expect(r.action).toBeNull()
+    expect(r.preventDefault).toBe(true)
+  })
+})
+
+describe('handleAppKeydown — bare-key shortcuts', () => {
+  it('Shift+? opens help outside inputs', () => {
+    const r = handleAppKeydown(ev({ key: '?', shiftKey: true }), ctx())
+    expect(r.action).toEqual({ type: 'open-help' })
+    expect(r.preventDefault).toBe(true)
+  })
+
+  it('Shift+? inside an input is ignored', () => {
+    const target = { tagName: 'INPUT', isContentEditable: false } as unknown as EventTarget
+    const r = handleAppKeydown(ev({ key: '?', shiftKey: true, target }), ctx())
+    expect(r.action).toBeNull()
+    expect(r.preventDefault).toBe(false)
+  })
+
+  it('contenteditable target also blocks bare-key shortcuts', () => {
+    const target = { tagName: 'DIV', isContentEditable: true } as unknown as EventTarget
+    const r = handleAppKeydown(ev({ key: '?', shiftKey: true, target }), ctx())
+    expect(r.action).toBeNull()
+  })
+})
+
+describe('handleAppKeydown — G-chord', () => {
+  it('pressing g arms the chord', () => {
+    const r = handleAppKeydown(ev({ key: 'g' }), ctx())
+    expect(r.nextPendingG).toBe(true)
+    expect(r.preventDefault).toBe(true)
+    expect(r.action).toBeNull()
+  })
+
+  it('g then i navigates to task-list', () => {
+    const r = handleAppKeydown(ev({ key: 'i' }), ctx({ pendingG: true }))
+    expect(r.action).toEqual({ type: 'nav-reset', page: { kind: 'task-list' } })
+    expect(r.nextPendingG).toBe(false)
+  })
+
+  it('g then a navigates to filtered task-list', () => {
+    const r = handleAppKeydown(ev({ key: 'a' }), ctx({ pendingG: true }))
+    expect(r.action).toEqual({ type: 'nav-reset', page: { kind: 'task-list', filter: 'in-progress' } })
+  })
+
+  it('g then p navigates to project-list', () => {
+    const r = handleAppKeydown(ev({ key: 'p' }), ctx({ pendingG: true }))
+    expect(r.action).toEqual({ type: 'nav-reset', page: { kind: 'project-list' } })
+  })
+
+  it('g then s navigates to settings', () => {
+    const r = handleAppKeydown(ev({ key: 's' }), ctx({ pendingG: true }))
+    expect(r.action).toEqual({ type: 'nav-reset', page: { kind: 'settings' } })
+  })
+
+  it('g then unmapped letter swallows silently', () => {
+    const r = handleAppKeydown(ev({ key: 'z' }), ctx({ pendingG: true }))
+    expect(r.action).toBeNull()
+    expect(r.nextPendingG).toBe(false)
+  })
+
+  it('modifier press while G pending clears the chord', () => {
+    const r = handleAppKeydown(ev({ key: 'k', metaKey: true }), ctx({ pendingG: true }))
+    expect(r.action).toEqual({ type: 'open-palette' })
+    expect(r.nextPendingG).toBe(false)
+  })
+})
+
+describe('handleAppKeydown — unhandled', () => {
+  it('returns no-op for unmapped keys', () => {
+    const r = handleAppKeydown(ev({ key: 'x' }), ctx())
+    expect(r.action).toBeNull()
+    expect(r.preventDefault).toBe(false)
+    expect(r.nextPendingG).toBe(false)
+  })
+
+  it('Cmd+x is not a shortcut', () => {
+    const r = handleAppKeydown(ev({ key: 'x', metaKey: true }), ctx())
+    expect(r.action).toBeNull()
+    expect(r.preventDefault).toBe(false)
+  })
+})

--- a/frontend/src/lib/app-keyboard.ts
+++ b/frontend/src/lib/app-keyboard.ts
@@ -1,0 +1,133 @@
+// Pure decision logic for global App-level keyboard shortcuts.
+// App.svelte owns the side effects (preventDefault, window dispatchEvent,
+// state mutation, G-chord timer); this module decides *what* to do given
+// the key event and current context. Pure + sync so it can be unit-tested
+// without mounting Svelte or dispatching real KeyboardEvents.
+
+import type { Page } from './navigation.svelte.js'
+
+export type AppKeyAction =
+  | { type: 'open-quickadd' }
+  | { type: 'open-palette' }
+  | { type: 'open-help' }
+  | { type: 'nav-reset'; page: Page }
+  | { type: 'focus-search'; target: 'tasks' | 'renovate' }
+  | { type: 'toggle-view' }
+  | { type: 'toggle-sidebar' }
+
+export interface AppKeyboardCtx {
+  pendingG: boolean
+  currentPageKind: Page['kind']
+}
+
+export interface AppKeyboardResult {
+  action: AppKeyAction | null
+  preventDefault: boolean
+  // Next value for the caller's pendingG flag. Caller is responsible for
+  // (re)arming or clearing its 1.5s G-chord timeout when this transitions.
+  nextPendingG: boolean
+}
+
+// Subset of KeyboardEvent fields the handler actually reads. Lets tests pass
+// a plain object literal instead of constructing a real event.
+export interface AppKeyboardEvent {
+  key: string
+  metaKey: boolean
+  ctrlKey: boolean
+  altKey: boolean
+  shiftKey: boolean
+  target: EventTarget | null
+}
+
+const NOOP: AppKeyboardResult = { action: null, preventDefault: false, nextPendingG: false }
+
+function inEditable(target: EventTarget | null): boolean {
+  if (target === null) return false
+  const el = target as HTMLElement
+  return el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable === true
+}
+
+function metaNav(key: string): Page | null {
+  switch (key) {
+    case '1': return { kind: 'dashboard' }
+    case '2': return { kind: 'task-list' }
+    case '3': return { kind: 'project-list' }
+    case '4': return { kind: 'agents' }
+    case '5': return { kind: 'github' }
+    case '6': return { kind: 'reviews' }
+    case '7': return { kind: 'stats' }
+    case ',': return { kind: 'settings' }
+    default: return null
+  }
+}
+
+function gChordTarget(key: string): Page | null {
+  switch (key) {
+    case 'i': return { kind: 'task-list' }
+    case 'a': return { kind: 'task-list', filter: 'in-progress' }
+    case 'p': return { kind: 'project-list' }
+    case 's': return { kind: 'settings' }
+    default: return null
+  }
+}
+
+export function handleAppKeydown(e: AppKeyboardEvent, ctx: AppKeyboardCtx): AppKeyboardResult {
+  const hasMod = e.metaKey || e.ctrlKey || e.altKey
+
+  // A modifier press while a G-chord is pending cancels the chord.
+  if (hasMod && ctx.pendingG) {
+    // Fall through to handle the actual shortcut; just reset chord state.
+    // Build the rest of the result below with nextPendingG = false.
+  }
+
+  // Cmd-shortcuts (use metaKey only; ctrl variants are not bound today).
+  if (e.metaKey && !e.altKey) {
+    if (e.key === 'n') return { action: { type: 'open-quickadd' }, preventDefault: true, nextPendingG: false }
+    if (e.key === 'k') return { action: { type: 'open-palette' }, preventDefault: true, nextPendingG: false }
+    if (e.key === '/') return { action: { type: 'open-help' }, preventDefault: true, nextPendingG: false }
+
+    const navPage = metaNav(e.key)
+    if (navPage !== null) {
+      return { action: { type: 'nav-reset', page: navPage }, preventDefault: true, nextPendingG: false }
+    }
+
+    if (e.key === 'f') {
+      const target = ctx.currentPageKind === 'github' ? 'renovate' : 'tasks'
+      return { action: { type: 'focus-search', target }, preventDefault: true, nextPendingG: false }
+    }
+    if (e.key === 'b') {
+      return { action: { type: 'toggle-view' }, preventDefault: true, nextPendingG: false }
+    }
+    if (e.key === 'i') {
+      if (ctx.currentPageKind !== 'task-list') return { action: null, preventDefault: true, nextPendingG: false }
+      return { action: { type: 'toggle-sidebar' }, preventDefault: true, nextPendingG: false }
+    }
+  }
+
+  // Bare-key shortcuts only fire outside text inputs.
+  if (!hasMod && inEditable(e.target)) {
+    // Pending G-chord stays armed across input keystrokes — matches prior
+    // behavior. Caller's timer is responsible for eventual expiry.
+    return { ...NOOP, nextPendingG: ctx.pendingG }
+  }
+
+  if (!hasMod && e.shiftKey && e.key === '?') {
+    return { action: { type: 'open-help' }, preventDefault: true, nextPendingG: ctx.pendingG }
+  }
+
+  if (!hasMod && !e.shiftKey) {
+    if (ctx.pendingG) {
+      const target = gChordTarget(e.key)
+      if (target !== null) {
+        return { action: { type: 'nav-reset', page: target }, preventDefault: true, nextPendingG: false }
+      }
+      // Unmapped letter while chord is pending: swallow silently, clear chord.
+      return { action: null, preventDefault: false, nextPendingG: false }
+    }
+    if (e.key === 'g') {
+      return { action: null, preventDefault: true, nextPendingG: true }
+    }
+  }
+
+  return { ...NOOP, nextPendingG: ctx.pendingG && !hasMod }
+}

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
-  import { Search, Filter, ChevronDown, List, Columns, GanttChart } from '@lucide/svelte'
+  import { Search, Filter, ChevronDown } from '@lucide/svelte'
   import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { taskStore } from '../stores/tasks.svelte.js'
   import { projectStore } from '../stores/projects.svelte.js'
   import { notificationStore } from '../stores/notifications.svelte.js'
   import { BOARD_COLUMNS } from '../lib/statuses.js'
-  import { navStore } from '../lib/navigation.svelte.js'
   import { matchesQuery, matchesProject, matchesTags, matchesAgentMode } from '../lib/task-filters.js'
   import TaskCard from '../components/TaskCard.svelte'
   import TaskTimeline from '../components/TaskTimeline.svelte'
   import StatusPicker from '../components/StatusPicker.svelte'
   import PriorityPicker from '../components/PriorityPicker.svelte'
   import AssignProjectDialog from '../components/AssignProjectDialog.svelte'
-  import TaskFilterPanel from '../components/TaskFilterPanel.svelte'
+  import TaskListFilterBar from '../components/TaskListFilterBar.svelte'
+  import InlineTaskAdd from '../components/InlineTaskAdd.svelte'
   import MobileSheet from '../components/shell/MobileSheet.svelte'
   import { viewport } from '../lib/viewport.svelte.js'
   import { fly } from 'svelte/transition'
@@ -31,9 +31,6 @@
   const { onselect, filter, onnewTask, onfocusedtaskchange }: Props = $props()
 
   let dragOverStatus = $state<string | null>(null)
-  let addingToColumn = $state<string | null>(null)
-  let newTaskTitle = $state('')
-  let inputRef = $state<HTMLInputElement | null>(null)
   let filtersOpen = $state(false)
   let collapsedColumns = $state<Set<string>>(new Set(['testing', 'done']))
 
@@ -363,7 +360,7 @@
   )
 
   const hasActiveFilters = $derived(
-    searchQuery || selectedProjectId || selectedTags.length > 0 || selectedAgentMode
+    Boolean(searchQuery) || Boolean(selectedProjectId) || selectedTags.length > 0 || Boolean(selectedAgentMode)
   )
 
   function clearFilters() {
@@ -401,47 +398,6 @@
       await taskStore.update(taskId, { status: targetStatus })
     } catch (err) {
       notificationStore.pushLocal('error', 'Move failed', String(err))
-    }
-  }
-
-  function openInlineAdd(status: string) {
-    addingToColumn = status
-    newTaskTitle = ''
-    requestAnimationFrame(() => inputRef?.focus())
-  }
-
-  function dismissInlineAdd() {
-    addingToColumn = null
-    newTaskTitle = ''
-  }
-
-  async function submitInlineAdd(status: string) {
-    const title = newTaskTitle.trim()
-    if (!title) return
-    newTaskTitle = ''
-    let created
-    try {
-      created = await taskStore.create(title, '', 'headless')
-    } catch (err) {
-      notificationStore.pushLocal('error', 'Create failed', String(err))
-      return
-    }
-    if (status !== 'new') {
-      try {
-        await taskStore.update(created.id, { status })
-      } catch (err) {
-        notificationStore.pushLocal('error', 'Failed to set status', String(err))
-      }
-    }
-    requestAnimationFrame(() => inputRef?.focus())
-  }
-
-  function handleInputKeydown(e: KeyboardEvent, status: string) {
-    if (e.key === 'Enter') {
-      e.preventDefault()
-      submitInlineAdd(status)
-    } else if (e.key === 'Escape') {
-      dismissInlineAdd()
     }
   }
 
@@ -507,85 +463,18 @@
   </div>
 
   <!-- Desktop filter bar -->
-  <div class="hidden flex-wrap items-center gap-3 border-b border-surface-200 px-6 py-3 dark:border-surface-800 md:flex">
-    <TaskFilterPanel
-      query={searchQuery}
-      onqueryChange={(q) => (searchQuery = q)}
-      focusEvent="focus-search"
-      showProject
-      selectedProjectId={selectedProjectId}
-      onprojectChange={(id) => (selectedProjectId = id)}
-      showTags
-      availableTags={allTags}
-      selectedTags={selectedTags}
-      ontagsChange={(tags) => (selectedTags = tags)}
-    />
-
-    <!-- Agent mode pills (TaskList-specific) -->
-    <div class="flex h-8 rounded-md border border-surface-300 dark:border-surface-700">
-      {#each agentModes as mode}
-        <button
-          type="button"
-          class="px-2.5 text-xs font-medium transition-colors first:rounded-l-md last:rounded-r-md {selectedAgentMode === mode.value
-            ? 'bg-primary-500 text-white dark:bg-primary-600'
-            : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
-          onclick={() => (selectedAgentMode = mode.value)}
-        >
-          {mode.label}
-        </button>
-      {/each}
-    </div>
-
-    <!-- Right side: clear + show done + view toggle -->
-    <div class="ml-auto flex items-center gap-3">
-      {#if hasActiveFilters}
-        <button
-          type="button"
-          class="text-xs text-surface-500 underline hover:text-surface-700 dark:hover:text-surface-300"
-          onclick={clearFilters}
-        >
-          Clear filters
-        </button>
-      {/if}
-      <button
-        type="button"
-        class="text-xs text-surface-500 underline hover:text-surface-700 dark:hover:text-surface-300"
-        onclick={() => navStore.reset({ kind: 'logbook' })}
-      >
-        Logbook →
-      </button>
-      <label class="flex items-center gap-1.5 text-xs text-surface-500">
-        <input type="checkbox" bind:checked={showDone} class="accent-primary-500" />
-        Show done
-      </label>
-      <div class="flex rounded-md border border-surface-300 dark:border-surface-700" title="Switch view (⌘B)">
-        <button
-          type="button"
-          class="flex items-center gap-1 px-2 py-1 text-xs font-medium transition-colors first:rounded-l-md last:rounded-r-md {viewMode === 'list' ? 'bg-primary-500 text-white dark:bg-primary-600' : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
-          onclick={() => { viewModeStore.set('list'); focusedColIdx = -1; focusedRowIdx = -1 }}
-        >
-          <List size={14} />
-          List
-        </button>
-        <button
-          type="button"
-          class="flex items-center gap-1 border-x border-surface-300 px-2 py-1 text-xs font-medium transition-colors dark:border-surface-700 {viewMode === 'board' ? 'bg-primary-500 text-white dark:bg-primary-600' : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
-          onclick={() => { viewModeStore.set('board'); focusedColIdx = -1; focusedRowIdx = -1 }}
-        >
-          <Columns size={14} />
-          Board
-        </button>
-        <button
-          type="button"
-          class="flex items-center gap-1 px-2 py-1 text-xs font-medium transition-colors first:rounded-l-md last:rounded-r-md {viewMode === 'timeline' ? 'bg-primary-500 text-white dark:bg-primary-600' : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
-          onclick={() => { viewModeStore.set('timeline'); focusedColIdx = -1; focusedRowIdx = -1 }}
-        >
-          <GanttChart size={14} />
-          Timeline
-        </button>
-      </div>
-    </div>
-  </div>
+  <TaskListFilterBar
+    bind:searchQuery
+    bind:selectedProjectId
+    bind:selectedTags
+    bind:selectedAgentMode
+    bind:showDone
+    {allTags}
+    {hasActiveFilters}
+    {viewMode}
+    onclear={clearFilters}
+    onviewchange={() => { focusedColIdx = -1; focusedRowIdx = -1 }}
+  />
 
   {#if taskStore.loading}
     <p class="m-auto text-sm opacity-60">Loading tasks...</p>
@@ -692,26 +581,7 @@
               {/each}
             </div>
             <div class="px-2 pb-2">
-              {#if addingToColumn === col.status}
-                <input
-                  bind:this={inputRef}
-                  bind:value={newTaskTitle}
-                  type="text"
-                  placeholder="Task title"
-                  class="w-full rounded-md border border-surface-300 bg-surface-50 px-2 py-2.5 text-base outline-none focus:border-primary-400 focus:ring-1 focus:ring-primary-400 dark:border-surface-600 dark:bg-surface-800 md:py-1.5 md:text-sm"
-                  onkeydown={(e) => handleInputKeydown(e, col.status)}
-                  onblur={() => dismissInlineAdd()}
-                />
-              {:else}
-                <button
-                  type="button"
-                  class="tap flex w-full items-center gap-1 rounded-md px-2 py-2.5 text-sm opacity-60 transition-opacity active:bg-surface-200 active:opacity-100 dark:active:bg-surface-800 md:py-1.5 md:hover:bg-surface-200 md:hover:opacity-100 dark:md:hover:bg-surface-800"
-                  onclick={() => openInlineAdd(col.status)}
-                  title="Add task (C)"
-                >
-                  <span class="text-base leading-none">+</span> Add task
-                </button>
-              {/if}
+              <InlineTaskAdd status={col.status} />
             </div>
           {/if}
         </div>


### PR DESCRIPTION
## Motivation

Closes part of #786 (parent: #781).

Three of the four largest Svelte files in `frontend/src/` mixed render, IPC, keyboard, and dialog state — 400–800 lines each, all roads through `taskStore.update` or `window.dispatchEvent`. Adding tests meant mounting the whole component and faking the entire backend. Pull out the seams that don't need the DOM to be sensible.

## Implementation information

### `App.svelte` (462 -> 393)

- New `frontend/src/lib/app-keyboard.ts` — pure `handleAppKeydown(e, ctx)` returning `{ action: AppKeyAction | null, preventDefault, nextPendingG }`. The action is a discriminated union the component switches over to perform the side effect (open dialog, dispatch CustomEvent, etc.). The G-chord timer stays in the component because it's lifecycle-bound; the *decision* "is this G or J after G?" is now pure and unit-tested.
- 28 table-driven cases cover Cmd shortcuts, Cmd+1–7 page nav, Cmd+F search routing by current page, Cmd+I sidebar toggle, Shift+? help, G-chord arming + branches (`g i`, `g a`, `g p`, `g s`, unmapped letter), input-focus skip, and modifier-press chord cancel.

### `TaskMetadataRow.svelte` (408 -> 179)

- `TaskTagEditor.svelte`, `TaskDueDateEditor.svelte`, `TaskMaxTurnsEditor.svelte` — each owns its own draft/editing state and persists via `taskStore.update`. The parent calls `editor.start()` through `bind:this` so the existing `task-detail:edit-tags` / `open-due-date` window-event entry points still drive editing without rewriting the dispatch sites (those live in `TaskList.svelte` keyboard nav and `TaskDetail.svelte`).
- Each editor has a co-located `.svelte.test.ts` covering: display state, start->edit transition, save on Enter, Escape cancels without persisting, error paths.
- The existing `TaskMetadataRow.svelte.test.ts` was not modified and still passes — proves the external behavior is unchanged.

### `TaskList.svelte` (814 -> 684)

- `TaskListFilterBar.svelte` — desktop search/project/tags/agent-mode/view controls. Filter state is two-way bound via `$bindable()` so the parent keeps ownership of the search/tag arrays. `onclear` and `onviewchange` callbacks let the parent reset focus state on view switch.
- `InlineTaskAdd.svelte` — per-column quick-add. Each column instance owns its own `active`/`title`/`inputRef`, removing the shared `addingToColumn` / `newTaskTitle` / `inputRef` triple that lived on the parent.
- Coerced `hasActiveFilters` to `Boolean` (was `string | boolean` via short-circuit) so the new component's strict-boolean prop typechecks.

### Out of scope (per the plan, deferred to follow-ups)

- TaskList view-mode subcomponent extraction (List/Board/Timeline) and the 2D-focus keyboard handler — bigger refactor, DOM-measurement coupling.
- Settings.svelte panel extraction — lower ROI; Settings is already a scan-friendly form grid.
- App store-bootstrap + page-router extraction — bigger blast radius, lower test ROI.

### Numbers

| File | Before | After | Δ |
|------|-------:|------:|---:|
| App.svelte | 462 | 393 | -15% |
| TaskList.svelte | 814 | 684 | -16% |
| TaskMetadataRow.svelte | 408 | 179 | -56% |
| **Total** | **1684** | **1256** | **-25%** |

5 new components + 1 pure module, 6 new test files / 49 new tests.

### Verification

- `cd frontend && npm run check` (svelte-check) — 0 errors, 0 warnings
- `cd frontend && npx oxlint .` — 0 warnings, 0 errors
- `cd frontend && npx vitest run` — **1138 / 1138 passed** (existing 1089 + 49 new)
- `cd frontend && npm run build:desktop` — green
- `go build ./...` — green (desktop binary embeds `frontend/dist/`)

## Supporting documentation

Issue: https://github.com/Automaat/sybra/issues/786 (title specifies frontend decomposition; the body's SSE-broker work shipped separately).

> Changelog: refactor(frontend): split large components