### PR TITLE
refactor(frontend): split TaskList views

### DIFF
--- a/frontend/src/components/TaskBoardView.svelte
+++ b/frontend/src/components/TaskBoardView.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  import { ChevronDown } from '@lucide/svelte'
+  import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
+  import type { BoardColumn } from '../lib/statuses.js'
+  import TaskCard from './TaskCard.svelte'
+  import InlineTaskAdd from './InlineTaskAdd.svelte'
+  import { viewport } from '../lib/viewport.svelte.js'
+  import { fly } from 'svelte/transition'
+  import { flip } from 'svelte/animate'
+  import { cubicOut } from 'svelte/easing'
+
+  interface Props {
+    visibleColumns: BoardColumn[]
+    /** Tasks for a given column's statuses. Caller filters; we render. */
+    columnTasks: (col: BoardColumn) => Task[]
+    focusedTaskId: string | null
+    collapsedColumns: Set<string>
+    onselect: (id: string) => void
+    onmove: (taskId: string, status: string) => void
+    ontogglecolumn: (status: string) => void
+  }
+
+  const {
+    visibleColumns,
+    columnTasks,
+    focusedTaskId,
+    collapsedColumns,
+    onselect,
+    onmove,
+    ontogglecolumn,
+  }: Props = $props()
+
+  let dragOverStatus = $state<string | null>(null)
+
+  async function handleDrop(e: DragEvent, targetStatus: string) {
+    e.preventDefault()
+    dragOverStatus = null
+    const taskId = e.dataTransfer?.getData('text/plain')
+    if (!taskId) return
+    onmove(taskId, targetStatus)
+  }
+</script>
+
+<div class="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-3 md:flex-row md:gap-4 md:overflow-x-auto md:overflow-y-hidden md:p-6">
+  {#each visibleColumns as col}
+    {@const tasks = columnTasks(col)}
+    {@const isCollapsed = !viewport.isDesktop && collapsedColumns.has(col.status)}
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      data-col-status={col.status}
+      class="flex w-full shrink-0 flex-col rounded-lg border-t-4 bg-surface-100 transition-shadow dark:bg-surface-900 md:min-w-[260px] md:flex-1 md:shrink {col.border} {dragOverStatus === col.status ? 'ring-2 ring-primary-400 dark:ring-primary-500' : ''}"
+      ondragover={(e) => { e.preventDefault(); dragOverStatus = col.status }}
+      ondragleave={() => { dragOverStatus = null }}
+      ondrop={(e) => handleDrop(e, col.status)}
+    >
+      <button
+        type="button"
+        onclick={() => ontogglecolumn(col.status)}
+        class="tap flex w-full items-center justify-between gap-2 px-3 py-2 text-left active:bg-surface-200 dark:active:bg-surface-800 md:cursor-default md:active:bg-transparent dark:md:active:bg-transparent"
+      >
+        <span class="flex items-center gap-2">
+          <ChevronDown size={16} class="transition-transform md:hidden {isCollapsed ? '-rotate-90' : ''}" aria-hidden="true" />
+          <h2 class="text-sm font-semibold">{col.label}</h2>
+        </span>
+        <span class="rounded-full bg-surface-200 px-2 py-0.5 text-xs font-medium dark:bg-surface-700">
+          {tasks.length}
+        </span>
+      </button>
+      {#if !isCollapsed}
+        <div class="flex flex-col gap-2 px-2 pb-2 md:flex-1 md:overflow-y-auto">
+          {#each tasks as t (t.id)}
+            <div
+              in:fly={{ y: -12, duration: 150, easing: cubicOut }}
+              out:fly={{ y: 12, duration: 200, easing: cubicOut }}
+              animate:flip={{ duration: 200, easing: cubicOut }}
+            >
+              <TaskCard
+                task={t}
+                onclick={() => onselect(t.id)}
+                focused={focusedTaskId === t.id}
+                onstatuschange={(s) => onmove(t.id, s)}
+              />
+            </div>
+          {/each}
+        </div>
+        <div class="px-2 pb-2">
+          <InlineTaskAdd status={col.status} />
+        </div>
+      {/if}
+    </div>
+  {/each}
+</div>

--- a/frontend/src/components/TaskBoardView.svelte.test.ts
+++ b/frontend/src/components/TaskBoardView.svelte.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
+
+vi.mock('../stores/tasks.svelte.js', () => ({
+  taskStore: { create: vi.fn(), update: vi.fn() },
+}))
+vi.mock('../stores/notifications.svelte.js', () => ({
+  notificationStore: { pushLocal: vi.fn() },
+}))
+
+const TaskBoardView = (await import('./TaskBoardView.svelte')).default
+
+const columns = [
+  { status: 'todo', label: 'Todo', border: 'border-t-surface-400', includes: [] },
+  { status: 'in-progress', label: 'In Progress', border: 'border-t-primary-500', includes: [] },
+]
+
+const tasks = [
+  { id: 't1', title: 'First', status: 'todo', priority: 'high', tags: [], agentMode: 'headless' },
+  { id: 't2', title: 'Second', status: 'in-progress', priority: 'low', tags: [], agentMode: 'headless' },
+]
+
+function columnTasks(col: { status: string }) {
+  return tasks.filter(t => t.status === col.status) as never[]
+}
+
+describe('TaskBoardView', () => {
+  afterEach(cleanup)
+
+  it('renders one column per visibleColumns entry', () => {
+    render(TaskBoardView, {
+      props: {
+        visibleColumns: columns as never,
+        columnTasks: columnTasks as never,
+        focusedTaskId: null,
+        collapsedColumns: new Set<string>(),
+        onselect: vi.fn(),
+        onmove: vi.fn(),
+        ontogglecolumn: vi.fn(),
+      },
+    })
+    expect(screen.getByRole('heading', { name: 'Todo' })).toBeDefined()
+    expect(screen.getByRole('heading', { name: 'In Progress' })).toBeDefined()
+  })
+
+  it('renders task cards inside their column', () => {
+    render(TaskBoardView, {
+      props: {
+        visibleColumns: columns as never,
+        columnTasks: columnTasks as never,
+        focusedTaskId: null,
+        collapsedColumns: new Set<string>(),
+        onselect: vi.fn(),
+        onmove: vi.fn(),
+        ontogglecolumn: vi.fn(),
+      },
+    })
+    expect(screen.getByText('First')).toBeDefined()
+    expect(screen.getByText('Second')).toBeDefined()
+  })
+
+  it('column header click fires ontogglecolumn with the status', async () => {
+    const ontogglecolumn = vi.fn()
+    render(TaskBoardView, {
+      props: {
+        visibleColumns: columns as never,
+        columnTasks: columnTasks as never,
+        focusedTaskId: null,
+        collapsedColumns: new Set<string>(),
+        onselect: vi.fn(),
+        onmove: vi.fn(),
+        ontogglecolumn,
+      },
+    })
+    await fireEvent.click(screen.getByRole('heading', { name: 'Todo' }))
+    expect(ontogglecolumn).toHaveBeenCalledWith('todo')
+  })
+
+  it('drop on column fires onmove with task id + target status', async () => {
+    const onmove = vi.fn()
+    const { container } = render(TaskBoardView, {
+      props: {
+        visibleColumns: columns as never,
+        columnTasks: columnTasks as never,
+        focusedTaskId: null,
+        collapsedColumns: new Set<string>(),
+        onselect: vi.fn(),
+        onmove,
+        ontogglecolumn: vi.fn(),
+      },
+    })
+    const dropZone = container.querySelector('[data-col-status="in-progress"]') as HTMLElement
+    const dataTransfer = { getData: (k: string) => (k === 'text/plain' ? 't1' : '') }
+    await fireEvent.drop(dropZone, { dataTransfer })
+    expect(onmove).toHaveBeenCalledWith('t1', 'in-progress')
+  })
+
+  it('count badge shows column task count', () => {
+    render(TaskBoardView, {
+      props: {
+        visibleColumns: columns as never,
+        columnTasks: columnTasks as never,
+        focusedTaskId: null,
+        collapsedColumns: new Set<string>(),
+        onselect: vi.fn(),
+        onmove: vi.fn(),
+        ontogglecolumn: vi.fn(),
+      },
+    })
+    // Each column has exactly one task; render two "1" badges
+    const ones = screen.getAllByText('1')
+    expect(ones.length).toBe(2)
+  })
+})

--- a/frontend/src/components/TaskListView.svelte
+++ b/frontend/src/components/TaskListView.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
+  import { PRIORITY_OPTIONS } from '../lib/priorities.js'
+
+  interface Props {
+    tasks: Task[]
+    focusedTaskId: string | null
+    onselect: (id: string) => void
+    onhover: (rowIdx: number) => void
+  }
+
+  const { tasks, focusedTaskId, onselect, onhover }: Props = $props()
+
+  function priorityIcon(p: string | undefined): string {
+    return PRIORITY_OPTIONS.find(o => o.value === (p ?? ''))?.icon ?? '–'
+  }
+
+  function priorityLabel(p: string | undefined): string {
+    return PRIORITY_OPTIONS.find(o => o.value === (p ?? ''))?.label ?? 'None'
+  }
+
+  function priorityClasses(p: string | undefined): string {
+    return PRIORITY_OPTIONS.find(o => o.value === (p ?? ''))?.classes ?? 'text-surface-400'
+  }
+</script>
+
+<div class="min-h-0 flex-1 overflow-y-auto">
+  <table class="w-full text-sm">
+    <thead class="sticky top-0 z-10 border-b border-surface-200 bg-surface-100 dark:border-surface-700 dark:bg-surface-900">
+      <tr>
+        <th class="px-4 py-2 text-left font-semibold text-surface-500 text-xs uppercase tracking-wider w-8">P</th>
+        <th class="px-4 py-2 text-left font-semibold text-surface-500 text-xs uppercase tracking-wider">Title</th>
+        <th class="px-4 py-2 text-left font-semibold text-surface-500 text-xs uppercase tracking-wider">Status</th>
+        <th class="px-4 py-2 text-left font-semibold text-surface-500 text-xs uppercase tracking-wider hidden md:table-cell">Project</th>
+        <th class="px-4 py-2 text-left font-semibold text-surface-500 text-xs uppercase tracking-wider hidden lg:table-cell">Updated</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each tasks as t, rowIdx (t.id)}
+        {@const isFocused = focusedTaskId === t.id}
+        <tr
+          data-focused-task={isFocused ? '' : undefined}
+          class="cursor-pointer border-b border-surface-100 transition-colors dark:border-surface-800 {isFocused ? 'bg-primary-50 dark:bg-primary-900/20' : 'hover:bg-surface-100 dark:hover:bg-surface-800'}"
+          onclick={() => onselect(t.id)}
+          onmouseenter={() => onhover(rowIdx)}
+        >
+          <td class="px-4 py-2">
+            <span class="font-mono text-sm {priorityClasses(t.priority)}" title="Priority: {priorityLabel(t.priority)}">{priorityIcon(t.priority)}</span>
+          </td>
+          <td class="px-4 py-2 font-medium">{t.title}</td>
+          <td class="px-4 py-2">
+            <span class="rounded-full px-2 py-0.5 text-xs font-semibold bg-surface-200 dark:bg-surface-700">{t.status}</span>
+          </td>
+          <td class="hidden px-4 py-2 text-surface-500 md:table-cell">{t.projectId || '—'}</td>
+          <td class="hidden px-4 py-2 text-surface-400 text-xs lg:table-cell">
+            {t.updatedAt ? new Date(t.updatedAt).toLocaleDateString() : '—'}
+          </td>
+        </tr>
+      {/each}
+      {#if tasks.length === 0}
+        <tr>
+          <td colspan="5" class="px-4 py-8 text-center text-surface-400">No tasks match your filters</td>
+        </tr>
+      {/if}
+    </tbody>
+  </table>
+</div>

--- a/frontend/src/components/TaskListView.svelte.test.ts
+++ b/frontend/src/components/TaskListView.svelte.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
+
+const TaskListView = (await import('./TaskListView.svelte')).default
+
+const tasks = [
+  {
+    id: 't1', title: 'First', status: 'todo', priority: 'high',
+    projectId: 'foo/bar', updatedAt: '2026-04-01T00:00:00Z', tags: [], agentMode: 'headless',
+  },
+  {
+    id: 't2', title: 'Second', status: 'in-progress', priority: 'low',
+    projectId: '', updatedAt: '2026-04-02T00:00:00Z', tags: [], agentMode: 'headless',
+  },
+]
+
+describe('TaskListView', () => {
+  afterEach(cleanup)
+
+  it('renders rows for each task', () => {
+    render(TaskListView, {
+      props: {
+        tasks: tasks as never,
+        focusedTaskId: null,
+        onselect: vi.fn(),
+        onhover: vi.fn(),
+      },
+    })
+    expect(screen.getByText('First')).toBeDefined()
+    expect(screen.getByText('Second')).toBeDefined()
+  })
+
+  it('shows project for tasks that have one, em-dash otherwise', () => {
+    render(TaskListView, {
+      props: {
+        tasks: tasks as never,
+        focusedTaskId: null,
+        onselect: vi.fn(),
+        onhover: vi.fn(),
+      },
+    })
+    expect(screen.getByText('foo/bar')).toBeDefined()
+    expect(screen.getByText('—')).toBeDefined()
+  })
+
+  it('row click fires onselect with task id', async () => {
+    const onselect = vi.fn()
+    render(TaskListView, {
+      props: {
+        tasks: tasks as never,
+        focusedTaskId: null,
+        onselect,
+        onhover: vi.fn(),
+      },
+    })
+    await fireEvent.click(screen.getByText('First'))
+    expect(onselect).toHaveBeenCalledWith('t1')
+  })
+
+  it('mouseenter fires onhover with row index', async () => {
+    const onhover = vi.fn()
+    render(TaskListView, {
+      props: {
+        tasks: tasks as never,
+        focusedTaskId: null,
+        onselect: vi.fn(),
+        onhover,
+      },
+    })
+    await fireEvent.mouseEnter(screen.getByText('Second').closest('tr')!)
+    expect(onhover).toHaveBeenCalledWith(1)
+  })
+
+  it('empty state renders "No tasks match your filters"', () => {
+    render(TaskListView, {
+      props: {
+        tasks: [],
+        focusedTaskId: null,
+        onselect: vi.fn(),
+        onhover: vi.fn(),
+      },
+    })
+    expect(screen.getByText('No tasks match your filters')).toBeDefined()
+  })
+
+  it('focused row gets primary-tinted background', () => {
+    const { container } = render(TaskListView, {
+      props: {
+        tasks: tasks as never,
+        focusedTaskId: 't2',
+        onselect: vi.fn(),
+        onhover: vi.fn(),
+      },
+    })
+    expect(container.querySelector('[data-focused-task]')).toBeTruthy()
+  })
+})

--- a/frontend/src/lib/task-list-keyboard.test.ts
+++ b/frontend/src/lib/task-list-keyboard.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest'
+import {
+  handleTaskListKeydown,
+  type TaskListKeyboardCtx,
+  type TaskListKeyboardEvent,
+} from './task-list-keyboard.js'
+
+function ev(p: Partial<TaskListKeyboardEvent> & { key: string }): TaskListKeyboardEvent {
+  return {
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    target: null,
+    ...p,
+  }
+}
+
+function ctx(o: Partial<TaskListKeyboardCtx> = {}): TaskListKeyboardCtx {
+  return {
+    viewMode: 'board',
+    focusedColIdx: -1,
+    focusedRowIdx: -1,
+    focusedTaskId: null,
+    allFilteredTasksLength: 0,
+    columnTasksLengths: [0, 0, 0],
+    anyPickerOpen: false,
+    ...o,
+  }
+}
+
+describe('handleTaskListKeydown — gating', () => {
+  it('suppresses everything inside input', () => {
+    const target = { tagName: 'INPUT' } as unknown as EventTarget
+    const r = handleTaskListKeydown(ev({ key: 'j', target }), ctx())
+    expect(r.action).toBeNull()
+    expect(r.preventDefault).toBe(false)
+  })
+
+  it('suppresses everything inside textarea', () => {
+    const target = { tagName: 'TEXTAREA' } as unknown as EventTarget
+    const r = handleTaskListKeydown(ev({ key: 'j', target }), ctx())
+    expect(r.action).toBeNull()
+  })
+
+  it('suppresses everything when picker open', () => {
+    const r = handleTaskListKeydown(ev({ key: 'j' }), ctx({ anyPickerOpen: true }))
+    expect(r.action).toBeNull()
+  })
+})
+
+describe('handleTaskListKeydown — Cmd shortcuts', () => {
+  it('Cmd+D on focused task opens due date', () => {
+    const r = handleTaskListKeydown(ev({ key: 'd', metaKey: true }), ctx({ focusedTaskId: 't1' }))
+    expect(r.action).toEqual({ type: 'open-due-date-focused' })
+    expect(r.preventDefault).toBe(true)
+  })
+
+  it('Cmd+D without focus is a no-op', () => {
+    const r = handleTaskListKeydown(ev({ key: 'd', metaKey: true }), ctx())
+    expect(r.action).toBeNull()
+  })
+
+  it('other Cmd combos bail', () => {
+    const r = handleTaskListKeydown(ev({ key: 'k', metaKey: true }), ctx())
+    expect(r.action).toBeNull()
+  })
+})
+
+describe('handleTaskListKeydown — search', () => {
+  it('"/" dispatches focus-search', () => {
+    const r = handleTaskListKeydown(ev({ key: '/' }), ctx())
+    expect(r.action).toEqual({ type: 'focus-search' })
+    expect(r.preventDefault).toBe(true)
+  })
+
+  it('Shift+F dispatches focus-search', () => {
+    const r = handleTaskListKeydown(ev({ key: 'F', shiftKey: true }), ctx())
+    expect(r.action).toEqual({ type: 'focus-search' })
+  })
+})
+
+describe('handleTaskListKeydown — vertical nav (list view)', () => {
+  it('j with no focus falls to focusFirst', () => {
+    const r = handleTaskListKeydown(
+      ev({ key: 'j' }),
+      ctx({ viewMode: 'list', allFilteredTasksLength: 5 }),
+    )
+    expect(r.action).toEqual({ type: 'set-focus', colIdx: 0, rowIdx: 0, scroll: true })
+  })
+
+  it('j increments rowIdx clamped to length-1', () => {
+    const r = handleTaskListKeydown(
+      ev({ key: 'j' }),
+      ctx({ viewMode: 'list', focusedColIdx: 0, focusedRowIdx: 1, allFilteredTasksLength: 3 }),
+    )
+    expect(r.action).toEqual({ type: 'set-focus', colIdx: 0, rowIdx: 2, scroll: true })
+  })
+
+  it('j at last row stays clamped', () => {
+    const r = handleTaskListKeydown(
+      ev({ key: 'j' }),
+      ctx({ viewMode: 'list', focusedColIdx: 0, focusedRowIdx: 4, allFilteredTasksLength: 5 }),
+    )
+    expect(r.action).toEqual({ type: 'set-focus', colIdx: 0, rowIdx: 4, scroll: true })
+  })
+
+  it('k decrements rowIdx clamped to 0', () => {
+    const r = handleTaskListKeydown(
+      ev({ key: 'k' }),
+      ctx({ viewMode: 'list', focusedColIdx: 0, focusedRowIdx: 0, allFilteredTasksLength: 5 }),
+    )
+    expect(r.action).toEqual({ type: 'set-focus', colIdx: 0, rowIdx: 0, scroll: true })
+  })
+
+  it('ArrowDown == j', () => {
+    const r = handleTaskListKeydown(
+      ev({ key: 'ArrowDown' }),
+      ctx({ viewMode: 'list', focusedColIdx: 0, focusedRowIdx: 0, allFilteredTasksLength: 5 }),
+    )
+    expect(r.action).toEqual({ type: 'set-focus', colIdx: 0, rowIdx: 1, scroll: true })
+  })
+})
+
+describe('handleTaskListKeydown — board nav', () => {
+  it('j in board uses per-column length', () => {
+    const r = handleTaskListKeydown(
+      ev({ key: 'j' }),
+      ctx({ viewMode: 'board', focusedColIdx: 1, focusedRowIdx: 0, columnTasksLengths: [2, 5, 3] }),
+    )
+    expect(r.action).toEqual({ type: 'set-focus', colIdx: 1, rowIdx: 1, scroll: true })
+  })
+
+  it('h jumps left to next non-empty column', () => {
+    const r = handleTaskListKeydown(
+      ev({ key: 'h' }),
+      ctx({ viewMode: 'board', focusedColIdx: 3, focusedRowIdx: 1, columnTasksLengths: [4, 0, 0, 2] }),
+    )
+    expect(r.action).toEqual({ type: 'set-focus', colIdx: 0, rowIdx: 1, scroll: true })
+  })
+
+  it('h with no further non-empty col is no-op (preventDefault)', () => {
+    const r = handleTaskListKeydown(
+      ev({ key: 'h' }),
+      ctx({ viewMode: 'board', focusedColIdx: 0, focusedRowIdx: 0, columnTasksLengths: [3, 0, 0] }),
+    )
+    expect(r.action).toBeNull()
+    expect(r.preventDefault).toBe(true)
+  })
+
+  it('l jumps right to next non-empty column', () => {
+    const r = handleTaskListKeydown(
+      ev({ key: 'l' }),
+      ctx({ viewMode: 'board', focusedColIdx: 0, focusedRowIdx: 2, columnTasksLengths: [3, 0, 1] }),
+    )
+    expect(r.action).toEqual({ type: 'set-focus', colIdx: 2, rowIdx: 0, scroll: true })
+  })
+
+  it('l clamps new row to shorter column', () => {
+    const r = handleTaskListKeydown(
+      ev({ key: 'l' }),
+      ctx({ viewMode: 'board', focusedColIdx: 0, focusedRowIdx: 5, columnTasksLengths: [6, 2] }),
+    )
+    expect(r.action).toEqual({ type: 'set-focus', colIdx: 1, rowIdx: 1, scroll: true })
+  })
+
+  it('h/l in list view do nothing', () => {
+    const r = handleTaskListKeydown(
+      ev({ key: 'h' }),
+      ctx({ viewMode: 'list', focusedColIdx: 0, focusedRowIdx: 0, allFilteredTasksLength: 5 }),
+    )
+    expect(r.action).toBeNull()
+  })
+})
+
+describe('handleTaskListKeydown — timeline zoom', () => {
+  it('+ zooms in', () => {
+    const r = handleTaskListKeydown(ev({ key: '+' }), ctx({ viewMode: 'timeline' }))
+    expect(r.action).toEqual({ type: 'timeline-zoom', dir: 'in' })
+  })
+  it('- zooms out', () => {
+    const r = handleTaskListKeydown(ev({ key: '-' }), ctx({ viewMode: 'timeline' }))
+    expect(r.action).toEqual({ type: 'timeline-zoom', dir: 'out' })
+  })
+  it('+/- only active in timeline view', () => {
+    const r = handleTaskListKeydown(ev({ key: '+' }), ctx({ viewMode: 'list' }))
+    expect(r.action).toBeNull()
+  })
+})
+
+describe('handleTaskListKeydown — actions', () => {
+  it('Enter on focused task selects', () => {
+    const r = handleTaskListKeydown(ev({ key: 'Enter' }), ctx({ focusedTaskId: 't1' }))
+    expect(r.action).toEqual({ type: 'select-focused' })
+  })
+  it('e on focused task selects', () => {
+    const r = handleTaskListKeydown(ev({ key: 'e' }), ctx({ focusedTaskId: 't1' }))
+    expect(r.action).toEqual({ type: 'select-focused' })
+  })
+  it('Enter without focus is no-op', () => {
+    const r = handleTaskListKeydown(ev({ key: 'Enter' }), ctx())
+    expect(r.action).toBeNull()
+  })
+  it('c triggers new task', () => {
+    const r = handleTaskListKeydown(ev({ key: 'c' }), ctx())
+    expect(r.action).toEqual({ type: 'new-task' })
+  })
+  it('Shift+C with focus opens assign-project picker', () => {
+    const r = handleTaskListKeydown(ev({ key: 'C', shiftKey: true }), ctx({ focusedTaskId: 't1' }))
+    expect(r.action).toEqual({ type: 'open-picker', kind: 'assign-project' })
+  })
+  it('s with focus opens status picker', () => {
+    const r = handleTaskListKeydown(ev({ key: 's' }), ctx({ focusedTaskId: 't1' }))
+    expect(r.action).toEqual({ type: 'open-picker', kind: 'status' })
+  })
+  it('p with focus opens priority picker', () => {
+    const r = handleTaskListKeydown(ev({ key: 'p' }), ctx({ focusedTaskId: 't1' }))
+    expect(r.action).toEqual({ type: 'open-picker', kind: 'priority' })
+  })
+  it('s/p without focus do nothing', () => {
+    expect(handleTaskListKeydown(ev({ key: 's' }), ctx()).action).toBeNull()
+    expect(handleTaskListKeydown(ev({ key: 'p' }), ctx()).action).toBeNull()
+  })
+  it('Escape clears focus', () => {
+    const r = handleTaskListKeydown(ev({ key: 'Escape' }), ctx({ focusedColIdx: 0, focusedRowIdx: 0 }))
+    expect(r.action).toEqual({ type: 'clear-focus' })
+  })
+})

--- a/frontend/src/lib/task-list-keyboard.ts
+++ b/frontend/src/lib/task-list-keyboard.ts
@@ -1,0 +1,165 @@
+// Pure decision logic for the TaskList keyboard handler. TaskList.svelte owns
+// state mutation (focusedColIdx/focusedRowIdx, pickers, dialogs) and
+// side effects (window.dispatchEvent, scrollIntoView, navigation); this
+// module decides *what* given the key event and a snapshot of focus state.
+
+import type { ViewMode } from './view-mode.svelte.js'
+
+export type TaskListKeyAction =
+  | { type: 'set-focus'; colIdx: number; rowIdx: number; scroll: boolean }
+  | { type: 'clear-focus' }
+  | { type: 'select-focused' }
+  | { type: 'open-due-date-focused' }
+  | { type: 'focus-search' }
+  | { type: 'open-picker'; kind: 'status' | 'priority' | 'assign-project' }
+  | { type: 'new-task' }
+  | { type: 'timeline-zoom'; dir: 'in' | 'out' }
+
+export interface TaskListKeyboardCtx {
+  viewMode: ViewMode
+  focusedColIdx: number
+  focusedRowIdx: number
+  focusedTaskId: string | null
+  // Length of `allFilteredTasks` (list + timeline views).
+  allFilteredTasksLength: number
+  // Length of each visible board column.
+  columnTasksLengths: number[]
+  // Any modal/picker open suppresses keyboard handling.
+  anyPickerOpen: boolean
+}
+
+export interface TaskListKeyboardEvent {
+  key: string
+  metaKey: boolean
+  ctrlKey: boolean
+  altKey: boolean
+  shiftKey: boolean
+  target: EventTarget | null
+}
+
+export interface TaskListKeyboardResult {
+  action: TaskListKeyAction | null
+  preventDefault: boolean
+}
+
+const NOOP: TaskListKeyboardResult = { action: null, preventDefault: false }
+
+function inEditable(target: EventTarget | null): boolean {
+  if (target === null) return false
+  const el = target as HTMLElement
+  return el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable === true
+}
+
+function focusFirst(ctx: TaskListKeyboardCtx): TaskListKeyAction {
+  if (ctx.viewMode === 'list' || ctx.viewMode === 'timeline') {
+    if (ctx.allFilteredTasksLength > 0) return { type: 'set-focus', colIdx: 0, rowIdx: 0, scroll: true }
+    return { type: 'clear-focus' }
+  }
+  for (let ci = 0; ci < ctx.columnTasksLengths.length; ci++) {
+    if (ctx.columnTasksLengths[ci] > 0) return { type: 'set-focus', colIdx: ci, rowIdx: 0, scroll: true }
+  }
+  return { type: 'clear-focus' }
+}
+
+export function handleTaskListKeydown(
+  e: TaskListKeyboardEvent,
+  ctx: TaskListKeyboardCtx,
+): TaskListKeyboardResult {
+  if (inEditable(e.target)) return NOOP
+  if (ctx.anyPickerOpen) return NOOP
+
+  const key = e.key
+  const isCmd = e.metaKey || e.ctrlKey
+
+  if (isCmd && key === 'd' && ctx.focusedTaskId) {
+    return { action: { type: 'open-due-date-focused' }, preventDefault: true }
+  }
+  if (isCmd) return NOOP
+  if (e.altKey) return NOOP
+
+  if (key === '/' || key === 'F') {
+    return { action: { type: 'focus-search' }, preventDefault: true }
+  }
+
+  // Navigation: j/k always vertical; h/l only for board view.
+  const isListLike = ctx.viewMode === 'list' || ctx.viewMode === 'timeline'
+
+  if (key === 'j' || key === 'ArrowDown') {
+    if (ctx.focusedColIdx < 0 || ctx.focusedRowIdx < 0) {
+      return { action: focusFirst(ctx), preventDefault: true }
+    }
+    if (isListLike) {
+      const next = Math.min(ctx.focusedRowIdx + 1, ctx.allFilteredTasksLength - 1)
+      return { action: { type: 'set-focus', colIdx: ctx.focusedColIdx, rowIdx: next, scroll: true }, preventDefault: true }
+    }
+    const len = ctx.columnTasksLengths[ctx.focusedColIdx] ?? 0
+    const next = Math.min(ctx.focusedRowIdx + 1, len - 1)
+    return { action: { type: 'set-focus', colIdx: ctx.focusedColIdx, rowIdx: next, scroll: true }, preventDefault: true }
+  }
+  if (key === 'k' || key === 'ArrowUp') {
+    if (ctx.focusedColIdx < 0 || ctx.focusedRowIdx < 0) {
+      return { action: focusFirst(ctx), preventDefault: true }
+    }
+    const next = Math.max(ctx.focusedRowIdx - 1, 0)
+    return { action: { type: 'set-focus', colIdx: ctx.focusedColIdx, rowIdx: next, scroll: true }, preventDefault: true }
+  }
+
+  if (!isListLike && (key === 'h' || key === 'ArrowLeft')) {
+    if (ctx.focusedColIdx < 0) {
+      return { action: focusFirst(ctx), preventDefault: true }
+    }
+    for (let ci = ctx.focusedColIdx - 1; ci >= 0; ci--) {
+      const len = ctx.columnTasksLengths[ci] ?? 0
+      if (len > 0) {
+        const row = Math.min(ctx.focusedRowIdx, len - 1)
+        return { action: { type: 'set-focus', colIdx: ci, rowIdx: row, scroll: true }, preventDefault: true }
+      }
+    }
+    return { ...NOOP, preventDefault: true }
+  }
+  if (!isListLike && (key === 'l' || key === 'ArrowRight')) {
+    if (ctx.focusedColIdx < 0) {
+      return { action: focusFirst(ctx), preventDefault: true }
+    }
+    for (let ci = ctx.focusedColIdx + 1; ci < ctx.columnTasksLengths.length; ci++) {
+      const len = ctx.columnTasksLengths[ci] ?? 0
+      if (len > 0) {
+        const row = Math.min(ctx.focusedRowIdx, len - 1)
+        return { action: { type: 'set-focus', colIdx: ci, rowIdx: row, scroll: true }, preventDefault: true }
+      }
+    }
+    return { ...NOOP, preventDefault: true }
+  }
+
+  if (ctx.viewMode === 'timeline') {
+    if (key === '+' || key === '=') {
+      return { action: { type: 'timeline-zoom', dir: 'in' }, preventDefault: true }
+    }
+    if (key === '-') {
+      return { action: { type: 'timeline-zoom', dir: 'out' }, preventDefault: true }
+    }
+  }
+
+  if (key === 'Enter' || key === 'e') {
+    if (ctx.focusedTaskId) return { action: { type: 'select-focused' }, preventDefault: true }
+    return NOOP
+  }
+  if (key === 'c' && !e.shiftKey) {
+    return { action: { type: 'new-task' }, preventDefault: true }
+  }
+  if (key === 'C' && e.shiftKey) {
+    if (ctx.focusedTaskId) return { action: { type: 'open-picker', kind: 'assign-project' }, preventDefault: true }
+    return { ...NOOP, preventDefault: true }
+  }
+  if (key === 's' && ctx.focusedTaskId) {
+    return { action: { type: 'open-picker', kind: 'status' }, preventDefault: true }
+  }
+  if (key === 'p' && ctx.focusedTaskId) {
+    return { action: { type: 'open-picker', kind: 'priority' }, preventDefault: true }
+  }
+  if (key === 'Escape') {
+    return { action: { type: 'clear-focus' }, preventDefault: false }
+  }
+
+  return NOOP
+}

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -1,25 +1,24 @@
 <script lang="ts">
-  import { Search, Filter, ChevronDown } from '@lucide/svelte'
+  import { Search, Filter } from '@lucide/svelte'
   import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { taskStore } from '../stores/tasks.svelte.js'
   import { projectStore } from '../stores/projects.svelte.js'
   import { notificationStore } from '../stores/notifications.svelte.js'
-  import { BOARD_COLUMNS } from '../lib/statuses.js'
+  import { BOARD_COLUMNS, type BoardColumn } from '../lib/statuses.js'
   import { matchesQuery, matchesProject, matchesTags, matchesAgentMode } from '../lib/task-filters.js'
-  import TaskCard from '../components/TaskCard.svelte'
   import TaskTimeline from '../components/TaskTimeline.svelte'
   import StatusPicker from '../components/StatusPicker.svelte'
   import PriorityPicker from '../components/PriorityPicker.svelte'
   import AssignProjectDialog from '../components/AssignProjectDialog.svelte'
   import TaskListFilterBar from '../components/TaskListFilterBar.svelte'
-  import InlineTaskAdd from '../components/InlineTaskAdd.svelte'
+  import TaskListView from '../components/TaskListView.svelte'
+  import TaskBoardView from '../components/TaskBoardView.svelte'
   import MobileSheet from '../components/shell/MobileSheet.svelte'
-  import { viewport } from '../lib/viewport.svelte.js'
-  import { fly } from 'svelte/transition'
-  import { flip } from 'svelte/animate'
-  import { cubicOut } from 'svelte/easing'
-  import { PRIORITY_OPTIONS } from '../lib/priorities.js'
   import { viewModeStore } from '../lib/view-mode.svelte.js'
+  import {
+    handleTaskListKeydown,
+    type TaskListKeyAction,
+  } from '../lib/task-list-keyboard.js'
 
   interface Props {
     onselect: (id: string) => void
@@ -30,7 +29,6 @@
 
   const { onselect, filter, onnewTask, onfocusedtaskchange }: Props = $props()
 
-  let dragOverStatus = $state<string | null>(null)
   let filtersOpen = $state(false)
   let collapsedColumns = $state<Set<string>>(new Set(['testing', 'done']))
 
@@ -64,18 +62,22 @@
   let priorityPickerOpen = $state(false)
   let assignProjectOpen = $state(false)
 
-  function getColumnTasks(colIndex: number): Task[] {
-    const col = visibleColumns[colIndex]
-    if (!col) return []
+  function columnTasks(col: BoardColumn): Task[] {
     const statuses = col.includes.length > 0 ? col.includes : [col.status]
     return filteredByStatuses(statuses)
+  }
+
+  function getColumnTasksByIdx(colIndex: number): Task[] {
+    const col = visibleColumns[colIndex]
+    if (!col) return []
+    return columnTasks(col)
   }
 
   const focusedTaskId = $derived.by((): string | null => {
     if (focusedColIdx < 0 || focusedRowIdx < 0) return null
     const tasks = viewMode === 'list' || viewMode === 'timeline'
       ? allFilteredTasks
-      : getColumnTasks(focusedColIdx)
+      : getColumnTasksByIdx(focusedColIdx)
     return tasks[focusedRowIdx]?.id ?? null
   })
 
@@ -84,20 +86,6 @@
   $effect(() => {
     onfocusedtaskchange?.(focusedTaskId)
   })
-
-  function focusFirstTask(): void {
-    if (viewMode === 'list' || viewMode === 'timeline') {
-      if (allFilteredTasks.length > 0) { focusedColIdx = 0; focusedRowIdx = 0 }
-      return
-    }
-    for (let ci = 0; ci < visibleColumns.length; ci++) {
-      if (getColumnTasks(ci).length > 0) {
-        focusedColIdx = ci
-        focusedRowIdx = 0
-        return
-      }
-    }
-  }
 
   function scrollFocusedIntoView(): void {
     requestAnimationFrame(() => {
@@ -135,152 +123,62 @@
     assignProjectOpen = false
   }
 
-  function handleBoardKeydown(e: KeyboardEvent): void {
-    const target = e.target as HTMLElement
-    if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) return
-
-    // Don't handle if a picker is open — pickers capture keys themselves
-    if (statusPickerOpen || priorityPickerOpen || assignProjectOpen) return
-
-    const key = e.key
-    const isCmd = e.metaKey || e.ctrlKey
-
-    // Cmd+D → due date for focused task (navigate to task detail and open due date)
-    if (isCmd && key === 'd' && focusedTaskId) {
-      e.preventDefault()
-      onselect(focusedTaskId)
-      requestAnimationFrame(() => window.dispatchEvent(new CustomEvent('open-due-date')))
-      return
-    }
-
-    if (isCmd) return
-    if (e.altKey) return
-
-    if (key === '/' || key === 'F') {
-      e.preventDefault()
-      window.dispatchEvent(new CustomEvent('focus-search'))
-      return
-    }
-
-    if (viewMode === 'list' || viewMode === 'timeline') {
-      if (key === 'j' || key === 'ArrowDown') {
-        e.preventDefault()
-        if (focusedColIdx < 0) { focusFirstTask(); scrollFocusedIntoView(); return }
-        focusedRowIdx = Math.min(focusedRowIdx + 1, allFilteredTasks.length - 1)
-        scrollFocusedIntoView()
-        return
-      }
-      if (key === 'k' || key === 'ArrowUp') {
-        e.preventDefault()
-        if (focusedColIdx < 0) { focusFirstTask(); scrollFocusedIntoView(); return }
-        focusedRowIdx = Math.max(focusedRowIdx - 1, 0)
-        scrollFocusedIntoView()
-        return
-      }
-      if (viewMode === 'timeline') {
-        if (key === '+' || key === '=') {
-          e.preventDefault()
-          timelineRef?.cycleZoomIn()
-          return
+  function applyAction(a: TaskListKeyAction) {
+    switch (a.type) {
+      case 'set-focus':
+        focusedColIdx = a.colIdx
+        focusedRowIdx = a.rowIdx
+        if (a.scroll) scrollFocusedIntoView()
+        break
+      case 'clear-focus':
+        focusedColIdx = -1
+        focusedRowIdx = -1
+        break
+      case 'select-focused':
+        if (focusedTaskId) onselect(focusedTaskId)
+        break
+      case 'open-due-date-focused':
+        if (focusedTaskId) {
+          onselect(focusedTaskId)
+          requestAnimationFrame(() => window.dispatchEvent(new CustomEvent('open-due-date')))
         }
-        if (key === '-') {
-          e.preventDefault()
-          timelineRef?.cycleZoomOut()
-          return
-        }
-      }
-    } else {
-      if (key === 'j' || key === 'ArrowDown') {
-        e.preventDefault()
-        if (focusedColIdx < 0) { focusFirstTask(); scrollFocusedIntoView(); return }
-        const tasks = getColumnTasks(focusedColIdx)
-        focusedRowIdx = Math.min(focusedRowIdx + 1, tasks.length - 1)
-        scrollFocusedIntoView()
-        return
-      }
-
-      if (key === 'k' || key === 'ArrowUp') {
-        e.preventDefault()
-        if (focusedColIdx < 0) { focusFirstTask(); scrollFocusedIntoView(); return }
-        focusedRowIdx = Math.max(focusedRowIdx - 1, 0)
-        scrollFocusedIntoView()
-        return
-      }
-
-      if (key === 'h' || key === 'ArrowLeft') {
-        e.preventDefault()
-        if (focusedColIdx < 0) { focusFirstTask(); scrollFocusedIntoView(); return }
-        for (let ci = focusedColIdx - 1; ci >= 0; ci--) {
-          const tasks = getColumnTasks(ci)
-          if (tasks.length > 0) {
-            focusedColIdx = ci
-            focusedRowIdx = Math.min(focusedRowIdx, tasks.length - 1)
-            scrollFocusedIntoView()
-            return
-          }
-        }
-        return
-      }
-
-      if (key === 'l' || key === 'ArrowRight') {
-        e.preventDefault()
-        if (focusedColIdx < 0) { focusFirstTask(); scrollFocusedIntoView(); return }
-        for (let ci = focusedColIdx + 1; ci < visibleColumns.length; ci++) {
-          const tasks = getColumnTasks(ci)
-          if (tasks.length > 0) {
-            focusedColIdx = ci
-            focusedRowIdx = Math.min(focusedRowIdx, tasks.length - 1)
-            scrollFocusedIntoView()
-            return
-          }
-        }
-        return
-      }
-    }
-
-    if (key === 'Enter' || key === 'e') {
-      const taskId = focusedTaskId
-      if (taskId) {
-        e.preventDefault()
-        onselect(taskId)
-      }
-      return
-    }
-
-    if (key === 'c' && !e.shiftKey) {
-      e.preventDefault()
-      onnewTask?.()
-      return
-    }
-
-    if (key === 'C' && e.shiftKey) {
-      e.preventDefault()
-      if (focusedTaskId) assignProjectOpen = true
-      return
-    }
-
-    if (key === 's' && focusedTaskId) {
-      e.preventDefault()
-      statusPickerOpen = true
-      return
-    }
-
-    if (key === 'p' && focusedTaskId) {
-      e.preventDefault()
-      priorityPickerOpen = true
-      return
-    }
-
-    if (key === 'Escape') {
-      focusedColIdx = -1
-      focusedRowIdx = -1
-      return
+        break
+      case 'focus-search':
+        window.dispatchEvent(new CustomEvent('focus-search'))
+        break
+      case 'open-picker':
+        if (a.kind === 'status') statusPickerOpen = true
+        else if (a.kind === 'priority') priorityPickerOpen = true
+        else assignProjectOpen = true
+        break
+      case 'new-task':
+        onnewTask?.()
+        break
+      case 'timeline-zoom':
+        if (a.dir === 'in') timelineRef?.cycleZoomIn()
+        else timelineRef?.cycleZoomOut()
+        break
     }
   }
 
+  function handleKeydown(e: KeyboardEvent) {
+    const lengths = visibleColumns.map((c) => columnTasks(c).length)
+    const result = handleTaskListKeydown(e, {
+      viewMode,
+      focusedColIdx,
+      focusedRowIdx,
+      focusedTaskId,
+      allFilteredTasksLength: allFilteredTasks.length,
+      columnTasksLengths: lengths,
+      anyPickerOpen: statusPickerOpen || priorityPickerOpen || assignProjectOpen,
+    })
+    if (result.preventDefault) e.preventDefault()
+    if (result.action) applyAction(result.action)
+  }
+
   $effect(() => {
-    window.addEventListener('keydown', handleBoardKeydown)
-    return () => window.removeEventListener('keydown', handleBoardKeydown)
+    window.addEventListener('keydown', handleKeydown)
+    return () => window.removeEventListener('keydown', handleKeydown)
   })
 
   // Listen for toggle-view event from App.svelte (Cmd+B)
@@ -318,7 +216,6 @@
     [...new Set(taskStore.list.flatMap((t: Task) => t.tags ?? []))].sort()
   )
 
-  // Derived: filter function
   function filteredByStatuses(statuses: string[]): Task[] {
     return taskStore.list.filter((t: Task) => {
       if (!statuses.includes(t.status)) return false
@@ -330,7 +227,6 @@
     })
   }
 
-  // All filtered tasks for list view (sorted by status order)
   const statusOrder: Record<string, number> = {
     'new': 0, 'todo': 1, 'planning': 2, 'plan-review': 3,
     'in-progress': 4, 'in-review': 5, 'testing': 6, 'test-plan-review': 7,
@@ -370,7 +266,6 @@
     selectedAgentMode = ''
   }
 
-  // Helpers retained for the mobile sheet
   function addTag(tag: string) {
     if (!selectedTags.includes(tag)) {
       selectedTags = [...selectedTags, tag]
@@ -386,32 +281,6 @@
     { value: 'headless', label: 'Headless' },
     { value: 'interactive', label: 'Interactive' },
   ]
-
-  async function handleDrop(e: DragEvent, targetStatus: string) {
-    e.preventDefault()
-    dragOverStatus = null
-    const taskId = e.dataTransfer?.getData('text/plain')
-    if (!taskId) return
-    const existing = taskStore.tasks.get(taskId)
-    if (!existing || existing.status === targetStatus) return
-    try {
-      await taskStore.update(taskId, { status: targetStatus })
-    } catch (err) {
-      notificationStore.pushLocal('error', 'Move failed', String(err))
-    }
-  }
-
-  function priorityIcon(p: string | undefined): string {
-    return PRIORITY_OPTIONS.find(o => o.value === (p ?? ''))?.icon ?? '–'
-  }
-
-  function priorityLabel(p: string | undefined): string {
-    return PRIORITY_OPTIONS.find(o => o.value === (p ?? ''))?.label ?? 'None'
-  }
-
-  function priorityClasses(p: string | undefined): string {
-    return PRIORITY_OPTIONS.find(o => o.value === (p ?? ''))?.classes ?? 'text-surface-400'
-  }
 </script>
 
 {#if statusPickerOpen && focusedTask}
@@ -481,50 +350,13 @@
   {:else if taskStore.error}
     <p class="m-auto text-sm text-error-500">{taskStore.error}</p>
   {:else if viewMode === 'list'}
-    <!-- List view -->
-    <div class="min-h-0 flex-1 overflow-y-auto">
-      <table class="w-full text-sm">
-        <thead class="sticky top-0 z-10 border-b border-surface-200 bg-surface-100 dark:border-surface-700 dark:bg-surface-900">
-          <tr>
-            <th class="px-4 py-2 text-left font-semibold text-surface-500 text-xs uppercase tracking-wider w-8">P</th>
-            <th class="px-4 py-2 text-left font-semibold text-surface-500 text-xs uppercase tracking-wider">Title</th>
-            <th class="px-4 py-2 text-left font-semibold text-surface-500 text-xs uppercase tracking-wider">Status</th>
-            <th class="px-4 py-2 text-left font-semibold text-surface-500 text-xs uppercase tracking-wider hidden md:table-cell">Project</th>
-            <th class="px-4 py-2 text-left font-semibold text-surface-500 text-xs uppercase tracking-wider hidden lg:table-cell">Updated</th>
-          </tr>
-        </thead>
-        <tbody>
-          {#each allFilteredTasks as t, rowIdx (t.id)}
-            {@const isFocused = focusedTaskId === t.id}
-            <tr
-              data-focused-task={isFocused ? '' : undefined}
-              class="cursor-pointer border-b border-surface-100 transition-colors dark:border-surface-800 {isFocused ? 'bg-primary-50 dark:bg-primary-900/20' : 'hover:bg-surface-100 dark:hover:bg-surface-800'}"
-              onclick={() => onselect(t.id)}
-              onmouseenter={() => { focusedColIdx = 0; focusedRowIdx = rowIdx }}
-            >
-              <td class="px-4 py-2">
-                <span class="font-mono text-sm {priorityClasses(t.priority)}" title="Priority: {priorityLabel(t.priority)}">{priorityIcon(t.priority)}</span>
-              </td>
-              <td class="px-4 py-2 font-medium">{t.title}</td>
-              <td class="px-4 py-2">
-                <span class="rounded-full px-2 py-0.5 text-xs font-semibold bg-surface-200 dark:bg-surface-700">{t.status}</span>
-              </td>
-              <td class="hidden px-4 py-2 text-surface-500 md:table-cell">{t.projectId || '—'}</td>
-              <td class="hidden px-4 py-2 text-surface-400 text-xs lg:table-cell">
-                {t.updatedAt ? new Date(t.updatedAt).toLocaleDateString() : '—'}
-              </td>
-            </tr>
-          {/each}
-          {#if allFilteredTasks.length === 0}
-            <tr>
-              <td colspan="5" class="px-4 py-8 text-center text-surface-400">No tasks match your filters</td>
-            </tr>
-          {/if}
-        </tbody>
-      </table>
-    </div>
+    <TaskListView
+      tasks={allFilteredTasks}
+      focusedTaskId={focusedTaskId}
+      onselect={(id) => onselect(id)}
+      onhover={(rowIdx) => { focusedColIdx = 0; focusedRowIdx = rowIdx }}
+    />
   {:else if viewMode === 'timeline'}
-    <!-- Timeline / Gantt view -->
     <TaskTimeline
       bind:this={timelineRef}
       tasks={allFilteredTasks}
@@ -536,57 +368,15 @@
       }}
     />
   {:else}
-    <!-- Board columns -->
-    <div class="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-3 md:flex-row md:gap-4 md:overflow-x-auto md:overflow-y-hidden md:p-6">
-      {#each visibleColumns as col}
-        {@const statuses = col.includes.length > 0 ? col.includes : [col.status]}
-        {@const tasks = filteredByStatuses(statuses)}
-        {@const isCollapsed = !viewport.isDesktop && collapsedColumns.has(col.status)}
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
-        <div
-          data-col-status={col.status}
-          class="flex w-full shrink-0 flex-col rounded-lg border-t-4 bg-surface-100 transition-shadow dark:bg-surface-900 md:min-w-[260px] md:flex-1 md:shrink {col.border} {dragOverStatus === col.status ? 'ring-2 ring-primary-400 dark:ring-primary-500' : ''}"
-          ondragover={(e) => { e.preventDefault(); dragOverStatus = col.status }}
-          ondragleave={() => { dragOverStatus = null }}
-          ondrop={(e) => handleDrop(e, col.status)}
-        >
-          <button
-            type="button"
-            onclick={() => toggleColumn(col.status)}
-            class="tap flex w-full items-center justify-between gap-2 px-3 py-2 text-left active:bg-surface-200 dark:active:bg-surface-800 md:cursor-default md:active:bg-transparent dark:md:active:bg-transparent"
-          >
-            <span class="flex items-center gap-2">
-              <ChevronDown size={16} class="transition-transform md:hidden {isCollapsed ? '-rotate-90' : ''}" aria-hidden="true" />
-              <h2 class="text-sm font-semibold">{col.label}</h2>
-            </span>
-            <span class="rounded-full bg-surface-200 px-2 py-0.5 text-xs font-medium dark:bg-surface-700">
-              {tasks.length}
-            </span>
-          </button>
-          {#if !isCollapsed}
-            <div class="flex flex-col gap-2 px-2 pb-2 md:flex-1 md:overflow-y-auto">
-              {#each tasks as t (t.id)}
-                <div
-                  in:fly={{ y: -12, duration: 150, easing: cubicOut }}
-                  out:fly={{ y: 12, duration: 200, easing: cubicOut }}
-                  animate:flip={{ duration: 200, easing: cubicOut }}
-                >
-                  <TaskCard
-                    task={t}
-                    onclick={() => onselect(t.id)}
-                    focused={focusedTaskId === t.id}
-                    onstatuschange={(s) => moveTask(t.id, s)}
-                  />
-                </div>
-              {/each}
-            </div>
-            <div class="px-2 pb-2">
-              <InlineTaskAdd status={col.status} />
-            </div>
-          {/if}
-        </div>
-      {/each}
-    </div>
+    <TaskBoardView
+      visibleColumns={visibleColumns}
+      columnTasks={columnTasks}
+      focusedTaskId={focusedTaskId}
+      collapsedColumns={collapsedColumns}
+      onselect={(id) => onselect(id)}
+      onmove={moveTask}
+      ontogglecolumn={toggleColumn}
+    />
   {/if}
 </div>
 


### PR DESCRIPTION
## Motivation

Follow-up to #786 / #798. After the prior PR `TaskList.svelte` was still 684 lines — view-mode rendering, keyboard nav, drag/drop, and inline-add markup were all interleaved. This PR extracts the view-mode renderers and the keyboard handler so each piece has a focused test.

## Implementation information

### `frontend/src/lib/task-list-keyboard.ts` (new, pure)

`handleTaskListKeydown(e, ctx)` returns `{ action: TaskListKeyAction | null, preventDefault }`. The action is a discriminated union the component switches over: `set-focus` (col + row, scroll flag), `clear-focus`, `select-focused`, `open-due-date-focused`, `focus-search`, `open-picker { kind }`, `new-task`, `timeline-zoom { dir }`.

Coverage (31 table-driven cases): editable-target gating, picker-open gating, Cmd+D + focus, all five modifier combos, j/k/h/l in both list and board view modes, board cross-column jump to next non-empty column with row clamping, +/- timeline zoom only in timeline view, Enter/e selection, c new-task, Shift+C / s / p pickers, Escape clear.

### `frontend/src/components/TaskListView.svelte` (new)

Pure table view. Props: `tasks`, `focusedTaskId`, `onselect`, `onhover`. Co-located vitest covers: rendering, em-dash for missing project, row click selects, mouseenter hovers, empty state, focused-row attribute.

### `frontend/src/components/TaskBoardView.svelte` (new)

Board columns + drag/drop + per-column `InlineTaskAdd`. Owns `dragOverStatus` (lives with the markup that consumes it). Props: `visibleColumns`, `columnTasks` (function — caller filters), `focusedTaskId`, `collapsedColumns`, `onselect`, `onmove`, `ontogglecolumn`. Co-located vitest covers: column rendering, task placement, header toggle, drop dispatches `onmove`, count badge.

### `TaskList.svelte` (684 -> 474)

The view-mode `{#if}` chain becomes a single component switch. The keyboard handler is reduced to a 50-line `applyAction` dispatcher. Picker/dialog state stays in the parent since each picker shares `focusedTask` — splitting that would create cross-component coupling without payoff.

### Verification

- `cd frontend && npm run check` — clean
- `cd frontend && npx oxlint .` — 0 warnings, 0 errors
- `cd frontend && npx vitest run` — **1180 / 1180 passed** (1138 prior + 42 new)
- `cd frontend && npm run build:desktop` — green

## Supporting documentation

Parent issue: https://github.com/Automaat/sybra/issues/786. Predecessors: https://github.com/Automaat/sybra/pull/798 (App.svelte keyboard + TaskMetadataRow editors + TaskListFilterBar + InlineTaskAdd).

> Changelog: refactor(frontend): split TaskList views