### PR TITLE
refactor(frontend): split Settings into panels

### DIFF
--- a/frontend/src/components/settings/LoggingPanel.svelte
+++ b/frontend/src/components/settings/LoggingPanel.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import type { AppSettings } from '../../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
+
+  interface Props {
+    settings: AppSettings
+  }
+
+  const { settings }: Props = $props()
+</script>
+
+<div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
+  <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Logging & Audit</h2>
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <div class="flex flex-col gap-1">
+      <label class="text-sm font-medium" for="log-level">Log Level</label>
+      <select
+        id="log-level"
+        class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
+        bind:value={settings.logging.level}
+      >
+        <option value="debug">Debug</option>
+        <option value="info">Info</option>
+        <option value="warn">Warn</option>
+        <option value="error">Error</option>
+      </select>
+    </div>
+    <div class="flex flex-col gap-1">
+      <label class="text-sm font-medium" for="log-max-size">Max Log Size (MB)</label>
+      <input
+        id="log-max-size"
+        type="number"
+        min="1"
+        max="500"
+        class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
+        bind:value={settings.logging.maxSizeMB}
+      />
+      <span class="text-xs text-surface-400">1–500 MB</span>
+    </div>
+    <div class="flex flex-col gap-1">
+      <label class="text-sm font-medium" for="log-max-files">Max Log Files</label>
+      <input
+        id="log-max-files"
+        type="number"
+        min="1"
+        max="50"
+        class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
+        bind:value={settings.logging.maxFiles}
+      />
+      <span class="text-xs text-surface-400">1–50 files</span>
+    </div>
+    <div class="flex flex-col gap-1">
+      <label class="text-sm font-medium" for="audit-retention">Audit Retention (days)</label>
+      <input
+        id="audit-retention"
+        type="number"
+        min="1"
+        max="365"
+        class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
+        bind:value={settings.audit.retentionDays}
+      />
+      <span class="text-xs text-surface-400">1–365 days</span>
+    </div>
+  </div>
+  <div class="mt-4">
+    <label class="flex cursor-pointer items-center gap-3">
+      <input
+        type="checkbox"
+        class="h-4 w-4 cursor-pointer rounded border-surface-300"
+        bind:checked={settings.audit.enabled}
+      />
+      <span class="text-sm">Enable audit logging</span>
+    </label>
+  </div>
+</div>

--- a/frontend/src/components/settings/LoggingPanel.svelte.test.ts
+++ b/frontend/src/components/settings/LoggingPanel.svelte.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
+
+const LoggingPanel = (await import('./LoggingPanel.svelte')).default
+
+function buildSettings() {
+  return {
+    logging: { level: 'info', maxSizeMB: 50, maxFiles: 5 },
+    audit: { enabled: true, retentionDays: 30 },
+  } as never
+}
+
+describe('LoggingPanel', () => {
+  afterEach(cleanup)
+
+  it('renders the four numeric/select inputs', () => {
+    render(LoggingPanel, { props: { settings: buildSettings() } })
+    expect(screen.getByLabelText('Log Level')).toBeDefined()
+    expect(screen.getByLabelText('Max Log Size (MB)')).toBeDefined()
+    expect(screen.getByLabelText('Max Log Files')).toBeDefined()
+    expect(screen.getByLabelText('Audit Retention (days)')).toBeDefined()
+  })
+
+  it('renders audit toggle reflecting settings', () => {
+    render(LoggingPanel, { props: { settings: buildSettings() } })
+    const cb = screen.getByLabelText('Enable audit logging') as HTMLInputElement
+    expect(cb.checked).toBe(true)
+  })
+
+  it('changing log level updates two-way bound value', async () => {
+    const s = buildSettings()
+    render(LoggingPanel, { props: { settings: s } })
+    const select = screen.getByLabelText('Log Level') as HTMLSelectElement
+    await fireEvent.change(select, { target: { value: 'debug' } })
+    expect(select.value).toBe('debug')
+  })
+})

--- a/frontend/src/components/settings/ProviderHealthPanel.svelte
+++ b/frontend/src/components/settings/ProviderHealthPanel.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+  import {
+    GetProviderHealth,
+    ProviderHealthEnabled,
+    SetProviderAutoFailover,
+    SetProviderEnabled,
+  } from '../../../bindings/github.com/Automaat/sybra/internal/sybra/integrationservice.js'
+  import { EventsOn } from '$lib/api'
+  import * as ev from '../../lib/events.js'
+  import type { AppSettings } from '../../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
+
+  interface Props {
+    settings: AppSettings
+    onsettingschange: () => void
+  }
+
+  const { settings, onsettingschange }: Props = $props()
+
+  type ProviderHealthEntry = {
+    provider: string
+    healthy: boolean
+    reason: string
+    detail?: string
+    lastCheck?: string
+    ratelimitedUntil?: string
+  }
+
+  let enabled = $state(false)
+  let map = $state<Record<string, ProviderHealthEntry>>({})
+  let error = $state('')
+
+  async function load() {
+    try {
+      enabled = await ProviderHealthEnabled()
+      if (!enabled) return
+      const list = (await GetProviderHealth()) ?? []
+      const next: Record<string, ProviderHealthEntry> = {}
+      for (const p of list) next[p.provider] = p as ProviderHealthEntry
+      map = next
+    } catch (e) {
+      error = String(e)
+    }
+  }
+
+  $effect(() => {
+    load()
+    const unsub = EventsOn(ev.ProviderHealth, (p: ProviderHealthEntry) => {
+      if (!p?.provider) return
+      map = { ...map, [p.provider]: p }
+    })
+    return () => unsub()
+  })
+
+  async function onAutoFailoverChange(e: Event) {
+    const value = (e.target as HTMLInputElement).checked
+    try {
+      await SetProviderAutoFailover(value)
+      settings.providers.autoFailover = value
+      onsettingschange()
+    } catch (err) {
+      error = String(err)
+    }
+  }
+
+  async function onProviderEnabledChange(name: 'claude' | 'codex', e: Event) {
+    const value = (e.target as HTMLInputElement).checked
+    try {
+      await SetProviderEnabled(name, value)
+      settings.providers[name].enabled = value
+      onsettingschange()
+      await load()
+    } catch (err) {
+      error = String(err)
+    }
+  }
+
+  function badgeClass(p: ProviderHealthEntry): string {
+    if (p.healthy) return 'bg-success-500/20 text-success-600 dark:text-success-300'
+    if (p.reason === 'disabled') return 'bg-surface-300 text-surface-600 dark:bg-surface-600 dark:text-surface-300'
+    return 'bg-error-500/20 text-error-600 dark:text-error-300'
+  }
+</script>
+
+{#if enabled}
+  <div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
+    <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Providers</h2>
+    {#if error}
+      <div class="mb-3 text-xs text-error-500">{error}</div>
+    {/if}
+    <div class="flex flex-col gap-3">
+      {#each ['claude', 'codex'] as name (name)}
+        {@const p = map[name]}
+        <div class="flex items-center justify-between gap-3 rounded border border-surface-200 bg-white px-3 py-2 dark:border-surface-700 dark:bg-surface-900">
+          <div class="flex flex-col">
+            <div class="flex items-center gap-2">
+              <span class="font-medium capitalize">{name}</span>
+              {#if p}
+                <span class="rounded px-1.5 py-0.5 text-xs {badgeClass(p)}">
+                  {p.healthy ? 'healthy' : p.reason}
+                </span>
+              {/if}
+            </div>
+            {#if p?.detail}
+              <span class="text-xs text-surface-400">{p.detail}</span>
+            {/if}
+            {#if p?.lastCheck}
+              <span class="text-xs text-surface-400">last check: {new Date(p.lastCheck).toLocaleTimeString()}</span>
+            {/if}
+          </div>
+          <label class="flex cursor-pointer items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              class="h-4 w-4 cursor-pointer rounded border-surface-300"
+              checked={name === 'claude' ? settings.providers.claude.enabled : settings.providers.codex.enabled}
+              onchange={(e) => onProviderEnabledChange(name as 'claude' | 'codex', e)}
+            />
+            <span>Enabled</span>
+          </label>
+        </div>
+      {/each}
+      <label class="flex cursor-pointer items-center gap-3 pt-2">
+        <input
+          type="checkbox"
+          class="h-4 w-4 cursor-pointer rounded border-surface-300"
+          checked={settings.providers.autoFailover}
+          onchange={onAutoFailoverChange}
+        />
+        <span class="text-sm">Auto-failover between providers when one is unhealthy</span>
+      </label>
+      <span class="text-xs text-surface-400">
+        Health check interval: {settings.providers.healthCheck.intervalSeconds}s. Edit config.yaml to change.
+      </span>
+    </div>
+  </div>
+{/if}

--- a/frontend/src/components/settings/ProviderHealthPanel.svelte.test.ts
+++ b/frontend/src/components/settings/ProviderHealthPanel.svelte.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte'
+
+const mockEnabled = vi.fn()
+const mockGetHealth = vi.fn()
+const mockSetEnabled = vi.fn()
+const mockSetAutoFailover = vi.fn()
+const mockEventsOn = vi.fn()
+
+vi.mock('../../../bindings/github.com/Automaat/sybra/internal/sybra/integrationservice.js', () => ({
+  ProviderHealthEnabled: () => mockEnabled(),
+  GetProviderHealth: () => mockGetHealth(),
+  SetProviderEnabled: (...args: unknown[]) => mockSetEnabled(...args),
+  SetProviderAutoFailover: (...args: unknown[]) => mockSetAutoFailover(...args),
+}))
+
+vi.mock('$lib/api', () => ({
+  EventsOn: (...args: unknown[]) => mockEventsOn(...args),
+}))
+
+const ProviderHealthPanel = (await import('./ProviderHealthPanel.svelte')).default
+
+function buildSettings() {
+  return {
+    providers: {
+      claude: { enabled: true },
+      codex: { enabled: false },
+      autoFailover: false,
+      healthCheck: { intervalSeconds: 30 },
+    },
+  } as never
+}
+
+describe('ProviderHealthPanel', () => {
+  beforeEach(() => {
+    mockEnabled.mockReset()
+    mockGetHealth.mockReset()
+    mockSetEnabled.mockReset()
+    mockSetAutoFailover.mockReset()
+    mockEventsOn.mockReset()
+    mockEventsOn.mockReturnValue(() => {})
+    mockEnabled.mockResolvedValue(true)
+    mockGetHealth.mockResolvedValue([
+      { provider: 'claude', healthy: true, reason: '' },
+      { provider: 'codex', healthy: false, reason: 'rate-limited' },
+    ])
+    mockSetEnabled.mockResolvedValue(undefined)
+    mockSetAutoFailover.mockResolvedValue(undefined)
+  })
+  afterEach(cleanup)
+
+  it('renders nothing when provider health is disabled at runtime', async () => {
+    mockEnabled.mockResolvedValue(false)
+    const { container } = render(ProviderHealthPanel, {
+      props: { settings: buildSettings(), onsettingschange: vi.fn() },
+    })
+    await waitFor(() => {
+      expect(container.querySelector('h2')).toBeNull()
+    })
+  })
+
+  it('renders Providers section with both rows when enabled', async () => {
+    render(ProviderHealthPanel, {
+      props: { settings: buildSettings(), onsettingschange: vi.fn() },
+    })
+    await waitFor(() => {
+      expect(screen.getByText('Providers')).toBeDefined()
+      expect(screen.getByText('claude')).toBeDefined()
+      expect(screen.getByText('codex')).toBeDefined()
+    })
+  })
+
+  it('shows healthy badge for claude and rate-limited reason for codex', async () => {
+    render(ProviderHealthPanel, {
+      props: { settings: buildSettings(), onsettingschange: vi.fn() },
+    })
+    await waitFor(() => {
+      expect(screen.getByText('healthy')).toBeDefined()
+      expect(screen.getByText('rate-limited')).toBeDefined()
+    })
+  })
+
+  it('toggling auto-failover calls SetProviderAutoFailover + onsettingschange', async () => {
+    const onsettingschange = vi.fn()
+    render(ProviderHealthPanel, {
+      props: { settings: buildSettings(), onsettingschange },
+    })
+    await waitFor(() => screen.getByText('Providers'))
+    const cb = screen.getByLabelText(/Auto-failover/) as HTMLInputElement
+    await fireEvent.click(cb)
+    await waitFor(() => {
+      expect(mockSetAutoFailover).toHaveBeenCalledWith(true)
+      expect(onsettingschange).toHaveBeenCalled()
+    })
+  })
+
+  it('subscribes to ProviderHealth events on mount', async () => {
+    render(ProviderHealthPanel, {
+      props: { settings: buildSettings(), onsettingschange: vi.fn() },
+    })
+    await waitFor(() => {
+      expect(mockEventsOn).toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/components/settings/RenovatePanel.svelte
+++ b/frontend/src/components/settings/RenovatePanel.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import type { AppSettings } from '../../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
+
+  interface Props {
+    settings: AppSettings
+  }
+
+  const { settings }: Props = $props()
+</script>
+
+<div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
+  <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Renovate</h2>
+  <div class="flex flex-col gap-4">
+    <label class="flex cursor-pointer items-center gap-3">
+      <input
+        type="checkbox"
+        class="h-4 w-4 cursor-pointer rounded border-surface-300"
+        bind:checked={settings.renovate.enabled}
+      />
+      <div>
+        <span class="text-sm font-medium">Enable Renovate PR tracking</span>
+        <p class="text-xs text-surface-400">Show Renovate bot PRs for registered projects</p>
+      </div>
+    </label>
+    {#if settings.renovate.enabled}
+      <div class="flex flex-col gap-1 sm:max-w-sm">
+        <label class="text-sm font-medium" for="renovate-author">PR Author</label>
+        <input
+          id="renovate-author"
+          type="text"
+          placeholder="app/renovate"
+          class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
+          bind:value={settings.renovate.author}
+        />
+        <span class="text-xs text-surface-400">GitHub author filter (default: app/renovate)</span>
+      </div>
+    {/if}
+  </div>
+</div>

--- a/frontend/src/components/settings/RenovatePanel.svelte.test.ts
+++ b/frontend/src/components/settings/RenovatePanel.svelte.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/svelte'
+
+const RenovatePanel = (await import('./RenovatePanel.svelte')).default
+
+function buildSettings(enabled: boolean) {
+  return {
+    renovate: { enabled, author: 'app/renovate' },
+  } as never
+}
+
+describe('RenovatePanel', () => {
+  afterEach(cleanup)
+
+  it('disabled hides author input', () => {
+    render(RenovatePanel, { props: { settings: buildSettings(false) } })
+    expect(screen.queryByLabelText('PR Author')).toBeNull()
+  })
+
+  it('enabled reveals author input pre-filled', () => {
+    render(RenovatePanel, { props: { settings: buildSettings(true) } })
+    const input = screen.getByLabelText('PR Author') as HTMLInputElement
+    expect(input.value).toBe('app/renovate')
+  })
+
+  it('enable toggle reflects current settings.enabled', () => {
+    render(RenovatePanel, { props: { settings: buildSettings(false) } })
+    expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(false)
+    cleanup()
+    render(RenovatePanel, { props: { settings: buildSettings(true) } })
+    expect((screen.getAllByRole('checkbox')[0] as HTMLInputElement).checked).toBe(true)
+  })
+})

--- a/frontend/src/components/settings/TodoistPanel.svelte
+++ b/frontend/src/components/settings/TodoistPanel.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import type { AppSettings } from '../../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
+
+  interface Props {
+    settings: AppSettings
+  }
+
+  const { settings }: Props = $props()
+</script>
+
+<div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
+  <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Todoist</h2>
+  <div class="flex flex-col gap-4">
+    <label class="flex cursor-pointer items-center gap-3">
+      <input
+        type="checkbox"
+        class="h-4 w-4 cursor-pointer rounded border-surface-300"
+        bind:checked={settings.todoist.enabled}
+      />
+      <div>
+        <span class="text-sm font-medium">Enable Todoist sync</span>
+        <p class="text-xs text-surface-400">Pull tasks from a Todoist project and close them when done</p>
+      </div>
+    </label>
+    {#if settings.todoist.enabled}
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div class="flex flex-col gap-1">
+          <label class="text-sm font-medium" for="todoist-token">API Token</label>
+          <input
+            id="todoist-token"
+            type="password"
+            placeholder="Your Todoist API token"
+            class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
+            bind:value={settings.todoist.apiToken}
+          />
+          <span class="text-xs text-surface-400">Settings → Integrations → API token</span>
+        </div>
+        <div class="flex flex-col gap-1">
+          <label class="text-sm font-medium" for="todoist-project">Project ID</label>
+          <input
+            id="todoist-project"
+            type="text"
+            placeholder="Todoist project ID"
+            class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
+            bind:value={settings.todoist.projectId}
+          />
+          <span class="text-xs text-surface-400">ID from project URL</span>
+        </div>
+        <div class="flex flex-col gap-1">
+          <label class="text-sm font-medium" for="todoist-poll">Poll Interval (seconds)</label>
+          <input
+            id="todoist-poll"
+            type="number"
+            min="30"
+            max="3600"
+            class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
+            bind:value={settings.todoist.pollSeconds}
+          />
+          <span class="text-xs text-surface-400">30–3600 seconds</span>
+        </div>
+      </div>
+    {/if}
+  </div>
+</div>

--- a/frontend/src/components/settings/TodoistPanel.svelte.test.ts
+++ b/frontend/src/components/settings/TodoistPanel.svelte.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/svelte'
+
+const TodoistPanel = (await import('./TodoistPanel.svelte')).default
+
+function buildSettings(enabled: boolean) {
+  return {
+    todoist: { enabled, apiToken: '', projectId: '', pollSeconds: 60 },
+  } as never
+}
+
+describe('TodoistPanel', () => {
+  afterEach(cleanup)
+
+  it('disabled hides credential inputs', () => {
+    render(TodoistPanel, { props: { settings: buildSettings(false) } })
+    expect(screen.queryByLabelText('API Token')).toBeNull()
+    expect(screen.queryByLabelText('Project ID')).toBeNull()
+  })
+
+  it('enabled reveals credential inputs', () => {
+    render(TodoistPanel, { props: { settings: buildSettings(true) } })
+    expect(screen.getByLabelText('API Token')).toBeDefined()
+    expect(screen.getByLabelText('Project ID')).toBeDefined()
+    expect(screen.getByLabelText('Poll Interval (seconds)')).toBeDefined()
+  })
+
+  it('enable toggle reflects current settings.enabled', () => {
+    render(TodoistPanel, { props: { settings: buildSettings(false) } })
+    expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(false)
+    cleanup()
+    render(TodoistPanel, { props: { settings: buildSettings(true) } })
+    expect((screen.getAllByRole('checkbox')[0] as HTMLInputElement).checked).toBe(true)
+  })
+})

--- a/frontend/src/pages/Settings.svelte
+++ b/frontend/src/pages/Settings.svelte
@@ -2,14 +2,10 @@
   import { onMount } from 'svelte'
   import { GetSettings, UpdateSettings, GetVersion, GetCodexModels } from '$lib/api'
   import type { AppSettings } from '../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
-  import {
-    GetProviderHealth,
-    ProviderHealthEnabled,
-    SetProviderAutoFailover,
-    SetProviderEnabled,
-  } from '../../bindings/github.com/Automaat/sybra/internal/sybra/integrationservice.js'
-  import { EventsOn } from '$lib/api'
-  import * as ev from '../lib/events.js'
+  import ProviderHealthPanel from '../components/settings/ProviderHealthPanel.svelte'
+  import LoggingPanel from '../components/settings/LoggingPanel.svelte'
+  import TodoistPanel from '../components/settings/TodoistPanel.svelte'
+  import RenovatePanel from '../components/settings/RenovatePanel.svelte'
 
   type ColorScheme = 'system' | 'light' | 'dark'
 
@@ -98,69 +94,8 @@
     settings = JSON.parse(original)
   }
 
-  type ProviderHealthEntry = {
-    provider: string
-    healthy: boolean
-    reason: string
-    detail?: string
-    lastCheck?: string
-    ratelimitedUntil?: string
-  }
-  let providerHealthEnabled = $state(false)
-  let providerHealthMap = $state<Record<string, ProviderHealthEntry>>({})
-  let providerError = $state('')
-
-  async function loadProviderHealth() {
-    try {
-      providerHealthEnabled = await ProviderHealthEnabled()
-      if (!providerHealthEnabled) return
-      const list = (await GetProviderHealth()) ?? []
-      const next: Record<string, ProviderHealthEntry> = {}
-      for (const p of list) next[p.provider] = p as ProviderHealthEntry
-      providerHealthMap = next
-    } catch (e) {
-      providerError = String(e)
-    }
-  }
-
-  $effect(() => {
-    loadProviderHealth()
-    const unsub = EventsOn(ev.ProviderHealth, (p: ProviderHealthEntry) => {
-      if (!p?.provider) return
-      providerHealthMap = { ...providerHealthMap, [p.provider]: p }
-    })
-    return () => unsub()
-  })
-
-  async function onAutoFailoverChange(e: Event) {
-    if (!settings) return
-    const value = (e.target as HTMLInputElement).checked
-    try {
-      await SetProviderAutoFailover(value)
-      settings.providers.autoFailover = value
-      original = JSON.stringify(settings)
-    } catch (err) {
-      providerError = String(err)
-    }
-  }
-
-  async function onProviderEnabledChange(name: 'claude' | 'codex', e: Event) {
-    if (!settings) return
-    const value = (e.target as HTMLInputElement).checked
-    try {
-      await SetProviderEnabled(name, value)
-      settings.providers[name].enabled = value
-      original = JSON.stringify(settings)
-      await loadProviderHealth()
-    } catch (err) {
-      providerError = String(err)
-    }
-  }
-
-  function healthBadgeClass(p: ProviderHealthEntry): string {
-    if (p.healthy) return 'bg-success-500/20 text-success-600 dark:text-success-300'
-    if (p.reason === 'disabled') return 'bg-surface-300 text-surface-600 dark:bg-surface-600 dark:text-surface-300'
-    return 'bg-error-500/20 text-error-600 dark:text-error-300'
+  function syncOriginal() {
+    if (settings) original = JSON.stringify(settings)
   }
 
   const modelOptions = $derived.by(() => {
@@ -290,59 +225,7 @@
       </div>
     </div>
 
-    <!-- Providers -->
-    {#if providerHealthEnabled}
-      <div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
-        <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Providers</h2>
-        {#if providerError}
-          <div class="mb-3 text-xs text-error-500">{providerError}</div>
-        {/if}
-        <div class="flex flex-col gap-3">
-          {#each ['claude', 'codex'] as name (name)}
-            {@const p = providerHealthMap[name]}
-            <div class="flex items-center justify-between gap-3 rounded border border-surface-200 bg-white px-3 py-2 dark:border-surface-700 dark:bg-surface-900">
-              <div class="flex flex-col">
-                <div class="flex items-center gap-2">
-                  <span class="font-medium capitalize">{name}</span>
-                  {#if p}
-                    <span class="rounded px-1.5 py-0.5 text-xs {healthBadgeClass(p)}">
-                      {p.healthy ? 'healthy' : p.reason}
-                    </span>
-                  {/if}
-                </div>
-                {#if p?.detail}
-                  <span class="text-xs text-surface-400">{p.detail}</span>
-                {/if}
-                {#if p?.lastCheck}
-                  <span class="text-xs text-surface-400">last check: {new Date(p.lastCheck).toLocaleTimeString()}</span>
-                {/if}
-              </div>
-              <label class="flex cursor-pointer items-center gap-2 text-sm">
-                <input
-                  type="checkbox"
-                  class="h-4 w-4 cursor-pointer rounded border-surface-300"
-                  checked={name === 'claude' ? settings.providers.claude.enabled : settings.providers.codex.enabled}
-                  onchange={(e) => onProviderEnabledChange(name as 'claude' | 'codex', e)}
-                />
-                <span>Enabled</span>
-              </label>
-            </div>
-          {/each}
-          <label class="flex cursor-pointer items-center gap-3 pt-2">
-            <input
-              type="checkbox"
-              class="h-4 w-4 cursor-pointer rounded border-surface-300"
-              checked={settings.providers.autoFailover}
-              onchange={onAutoFailoverChange}
-            />
-            <span class="text-sm">Auto-failover between providers when one is unhealthy</span>
-          </label>
-          <span class="text-xs text-surface-400">
-            Health check interval: {settings.providers.healthCheck.intervalSeconds}s. Edit config.yaml to change.
-          </span>
-        </div>
-      </div>
-    {/if}
+    <ProviderHealthPanel {settings} onsettingschange={syncOriginal} />
 
     <!-- Notifications -->
     <div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
@@ -386,158 +269,11 @@
       </div>
     </div>
 
-    <!-- Logging & Audit -->
-    <div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
-      <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Logging & Audit</h2>
-      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <div class="flex flex-col gap-1">
-          <label class="text-sm font-medium" for="log-level">Log Level</label>
-          <select
-            id="log-level"
-            class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
-            bind:value={settings.logging.level}
-          >
-            <option value="debug">Debug</option>
-            <option value="info">Info</option>
-            <option value="warn">Warn</option>
-            <option value="error">Error</option>
-          </select>
-        </div>
-        <div class="flex flex-col gap-1">
-          <label class="text-sm font-medium" for="log-max-size">Max Log Size (MB)</label>
-          <input
-            id="log-max-size"
-            type="number"
-            min="1"
-            max="500"
-            class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
-            bind:value={settings.logging.maxSizeMB}
-          />
-          <span class="text-xs text-surface-400">1–500 MB</span>
-        </div>
-        <div class="flex flex-col gap-1">
-          <label class="text-sm font-medium" for="log-max-files">Max Log Files</label>
-          <input
-            id="log-max-files"
-            type="number"
-            min="1"
-            max="50"
-            class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
-            bind:value={settings.logging.maxFiles}
-          />
-          <span class="text-xs text-surface-400">1–50 files</span>
-        </div>
-        <div class="flex flex-col gap-1">
-          <label class="text-sm font-medium" for="audit-retention">Audit Retention (days)</label>
-          <input
-            id="audit-retention"
-            type="number"
-            min="1"
-            max="365"
-            class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
-            bind:value={settings.audit.retentionDays}
-          />
-          <span class="text-xs text-surface-400">1–365 days</span>
-        </div>
-      </div>
-      <div class="mt-4">
-        <label class="flex cursor-pointer items-center gap-3">
-          <input
-            type="checkbox"
-            class="h-4 w-4 cursor-pointer rounded border-surface-300"
-            bind:checked={settings.audit.enabled}
-          />
-          <span class="text-sm">Enable audit logging</span>
-        </label>
-      </div>
-    </div>
+    <LoggingPanel settings={settings} />
 
-    <!-- Todoist -->
-    <div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
-      <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Todoist</h2>
-      <div class="flex flex-col gap-4">
-        <label class="flex cursor-pointer items-center gap-3">
-          <input
-            type="checkbox"
-            class="h-4 w-4 cursor-pointer rounded border-surface-300"
-            bind:checked={settings.todoist.enabled}
-          />
-          <div>
-            <span class="text-sm font-medium">Enable Todoist sync</span>
-            <p class="text-xs text-surface-400">Pull tasks from a Todoist project and close them when done</p>
-          </div>
-        </label>
-        {#if settings.todoist.enabled}
-          <div class="grid grid-cols-1 gap-4 sm:grid-cols-3">
-            <div class="flex flex-col gap-1">
-              <label class="text-sm font-medium" for="todoist-token">API Token</label>
-              <input
-                id="todoist-token"
-                type="password"
-                placeholder="Your Todoist API token"
-                class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
-                bind:value={settings.todoist.apiToken}
-              />
-              <span class="text-xs text-surface-400">Settings → Integrations → API token</span>
-            </div>
-            <div class="flex flex-col gap-1">
-              <label class="text-sm font-medium" for="todoist-project">Project ID</label>
-              <input
-                id="todoist-project"
-                type="text"
-                placeholder="Todoist project ID"
-                class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
-                bind:value={settings.todoist.projectId}
-              />
-              <span class="text-xs text-surface-400">ID from project URL</span>
-            </div>
-            <div class="flex flex-col gap-1">
-              <label class="text-sm font-medium" for="todoist-poll">Poll Interval (seconds)</label>
-              <input
-                id="todoist-poll"
-                type="number"
-                min="30"
-                max="3600"
-                class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
-                bind:value={settings.todoist.pollSeconds}
-              />
-              <span class="text-xs text-surface-400">30–3600 seconds</span>
-            </div>
-          </div>
-        {/if}
-      </div>
-    </div>
+    <TodoistPanel settings={settings} />
 
-    <!-- Renovate -->
-    <div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
-      <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Renovate</h2>
-      <div class="flex flex-col gap-4">
-        <label class="flex cursor-pointer items-center gap-3">
-          <input
-            type="checkbox"
-            class="h-4 w-4 cursor-pointer rounded border-surface-300"
-            bind:checked={settings.renovate.enabled}
-          />
-          <div>
-            <span class="text-sm font-medium">Enable Renovate PR tracking</span>
-            <p class="text-xs text-surface-400">Show Renovate bot PRs for registered projects</p>
-          </div>
-        </label>
-        {#if settings.renovate.enabled}
-          <div class="flex flex-col gap-1 sm:max-w-sm">
-            <label class="text-sm font-medium" for="renovate-author">PR Author</label>
-            <input
-              id="renovate-author"
-              type="text"
-              placeholder="app/renovate"
-              class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
-              bind:value={settings.renovate.author}
-            />
-            <span class="text-xs text-surface-400">GitHub author filter (default: app/renovate)</span>
-          </div>
-        {/if}
-      </div>
-    </div>
+    <RenovatePanel settings={settings} />
 
     <!-- Version (read-only) -->
     <div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">


### PR DESCRIPTION
## Motivation

Follow-up to issue 786. `Settings.svelte` was 581 lines mixing the load/save/reset lifecycle with 8 inline panels — provider health subscriptions sat next to localStorage color-scheme handling next to read-only directory listings. Pull the four heaviest panels into siblings so each owns its state and can be tested in isolation.

## Implementation information

### New panels under `frontend/src/components/settings/`

- **`ProviderHealthPanel.svelte`** — owns `ProviderHealthEnabled()`, the `EventsOn(ev.ProviderHealth)` subscription, and the per-provider enable + auto-failover toggles. Error/loading state lives with the data it represents. Co-located vitest mocks the `integrationservice` bindings + `EventsOn`; covers disabled-at-runtime hide, healthy/rate-limited badges, auto-failover toggle callback, event subscription wiring.
- **`LoggingPanel.svelte`** — log level + max-size + max-files + audit retention + audit toggle. Pure form, no async.
- **`TodoistPanel.svelte`** — enable toggle + credentials. Credentials reveal only when enabled.
- **`RenovatePanel.svelte`** — enable toggle + author filter.

### Reactivity note

The panels receive `settings` as a plain prop (no `bind:`, no `$bindable()`). Svelte 5 `$state` proxies propagate reactivity through prop pass-through for nested mutations — `$bindable()` is only needed when a child reassigns the whole prop, not when mutating its properties. This is cleaner than the cast-through-`bind:` pattern the prior iteration attempted.

### Settings.svelte (581 -> 317, -46%)

The page now focuses on `dirty`/`save`/`reset`, version + directories + appearance, and the agent defaults section. Each extracted panel is mounted inline where the inline markup used to be.

### Verification

- `cd frontend && npm run check` — 0 errors, 0 warnings
- `cd frontend && npx oxlint .` — 0 warnings, 0 errors
- `cd frontend && npx vitest run` — **1152 / 1152 passed** (1138 prior + 14 new)
- `cd frontend && npm run build:desktop` — green

## Supporting documentation

Parent issue: https://github.com/Automaat/sybra/issues/786. Continues the decomposition started in PRs 798 and 799.

> Changelog: refactor(frontend): split Settings into panels