### PR TITLE
chore(lint): resolve pre-existing nilaway findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,11 +92,8 @@ jobs:
         run: go install go.uber.org/nilaway/cmd/nilaway@latest
 
       - name: Run nilaway
-        # Baseline ratchet: 31 pre-existing findings recorded at enforcement
-        # commit. Fails on any new nil-safety regression (count > baseline).
-        # Reduce NILAWAY_BASELINE to 0 once the follow-up cleanup PR lands.
         run: |
-          NILAWAY_BASELINE=31
+          NILAWAY_BASELINE=0
           set +e
           nilaway -include-pkgs="github.com/Automaat/sybra" ./... > nilaway.out 2>&1
           NILAWAY_EXIT=$?

--- a/internal/agent/approval_server_test.go
+++ b/internal/agent/approval_server_test.go
@@ -127,7 +127,10 @@ func TestApprovalServer_CanceledContext(t *testing.T) {
 		"tool_use_id": "tuid-cancel",
 		"tool_input":  map[string]any{},
 	})
-	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, "/hooks/pre-tool-use", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/hooks/pre-tool-use", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("NewRequestWithContext: %v", err)
+	}
 	req.Header.Set("Content-Type", "application/json")
 
 	// Cancel context shortly after handler starts waiting for approval.

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -175,6 +175,9 @@ done:
 }
 
 func (m *Manager) runConvoAttempt(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File) (retry bool, err error) {
+	if outFile == nil {
+		return false, nil
+	}
 	cmd, stdout, stderrBuf, startErr := m.startConvoProcess(ctx, a, cfg)
 	if startErr != nil {
 		return false, startErr

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -84,6 +84,9 @@ done:
 }
 
 func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File) (retry bool, err error) {
+	if outFile == nil {
+		return false, nil
+	}
 	name, args, invokeEnv, command, err := buildHeadlessInvocation(a, cfg)
 	if err != nil {
 		return false, err

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -145,6 +145,9 @@ func Shutdown(ctx context.Context) error {
 }
 
 func createInstruments() error {
+	if meter == nil {
+		return nil
+	}
 	if err := createAgentInstruments(); err != nil {
 		return err
 	}
@@ -164,20 +167,24 @@ func createInstruments() error {
 }
 
 func createAgentInstruments() error {
+	m := meter
+	if m == nil {
+		return nil
+	}
 	var err error
-	if agentsStarted, err = meter.Int64Counter(
+	if agentsStarted, err = m.Int64Counter(
 		"sybra_agents_started_total",
 		metric.WithDescription("Count of agents started, by provider and mode."),
 	); err != nil {
 		return err
 	}
-	if agentsCompleted, err = meter.Int64Counter(
+	if agentsCompleted, err = m.Int64Counter(
 		"sybra_agents_completed_total",
 		metric.WithDescription("Count of agents that reached a terminal state, by result."),
 	); err != nil {
 		return err
 	}
-	agentDurationSecs, err = meter.Float64Histogram(
+	agentDurationSecs, err = m.Float64Histogram(
 		"sybra_agent_duration_seconds",
 		metric.WithDescription("Agent wall-clock duration from start to terminal state."),
 		metric.WithUnit("s"),
@@ -186,20 +193,24 @@ func createAgentInstruments() error {
 }
 
 func createTaskInstruments() error {
+	m := meter
+	if m == nil {
+		return nil
+	}
 	var err error
-	if tasksCreated, err = meter.Int64Counter(
+	if tasksCreated, err = m.Int64Counter(
 		"sybra_tasks_created_total",
 		metric.WithDescription("Tasks created via task.Manager."),
 	); err != nil {
 		return err
 	}
-	if tasksUpdated, err = meter.Int64Counter(
+	if tasksUpdated, err = m.Int64Counter(
 		"sybra_tasks_updated_total",
 		metric.WithDescription("Tasks updated via task.Manager."),
 	); err != nil {
 		return err
 	}
-	tasksDeleted, err = meter.Int64Counter(
+	tasksDeleted, err = m.Int64Counter(
 		"sybra_tasks_deleted_total",
 		metric.WithDescription("Tasks deleted via task.Manager."),
 	)
@@ -207,38 +218,42 @@ func createTaskInstruments() error {
 }
 
 func createPollInstruments() error {
+	m := meter
+	if m == nil {
+		return nil
+	}
 	var err error
-	if todoistPolls, err = meter.Int64Counter(
+	if todoistPolls, err = m.Int64Counter(
 		"sybra_todoist_polls_total",
 		metric.WithDescription("Todoist poll attempts, by result."),
 	); err != nil {
 		return err
 	}
-	if todoistImported, err = meter.Int64Counter(
+	if todoistImported, err = m.Int64Counter(
 		"sybra_todoist_items_imported_total",
 		metric.WithDescription("Todoist items imported as new tasks."),
 	); err != nil {
 		return err
 	}
-	if todoistCompleted, err = meter.Int64Counter(
+	if todoistCompleted, err = m.Int64Counter(
 		"sybra_todoist_items_completed_total",
 		metric.WithDescription("Todoist items marked complete by Sybra."),
 	); err != nil {
 		return err
 	}
-	if githubFetches, err = meter.Int64Counter(
+	if githubFetches, err = m.Int64Counter(
 		"sybra_github_fetches_total",
 		metric.WithDescription("GitHub Issues fetch attempts, by result."),
 	); err != nil {
 		return err
 	}
-	if githubImported, err = meter.Int64Counter(
+	if githubImported, err = m.Int64Counter(
 		"sybra_github_issues_imported_total",
 		metric.WithDescription("GitHub issues imported as tasks."),
 	); err != nil {
 		return err
 	}
-	renovatePolls, err = meter.Int64Counter(
+	renovatePolls, err = m.Int64Counter(
 		"sybra_renovate_polls_total",
 		metric.WithDescription("Renovate PR poll attempts, by result."),
 	)
@@ -246,26 +261,30 @@ func createPollInstruments() error {
 }
 
 func createOrchestratorInstruments() error {
+	m := meter
+	if m == nil {
+		return nil
+	}
 	var err error
-	if monitorTicks, err = meter.Int64Counter(
+	if monitorTicks, err = m.Int64Counter(
 		"sybra_monitor_ticks_total",
 		metric.WithDescription("Monitor service tick completions."),
 	); err != nil {
 		return err
 	}
-	if monitorAnomalies, err = meter.Int64Counter(
+	if monitorAnomalies, err = m.Int64Counter(
 		"sybra_monitor_anomalies_total",
 		metric.WithDescription("Monitor anomalies detected, by kind."),
 	); err != nil {
 		return err
 	}
-	if orchestratorTicks, err = meter.Int64Counter(
+	if orchestratorTicks, err = m.Int64Counter(
 		"sybra_orchestrator_ticks_total",
 		metric.WithDescription("Orchestrator loop iterations."),
 	); err != nil {
 		return err
 	}
-	orchestratorStaleRestarts, err = meter.Int64Counter(
+	orchestratorStaleRestarts, err = m.Int64Counter(
 		"sybra_orchestrator_stale_restarts_total",
 		metric.WithDescription("Orchestrator stale in-progress task restart attempts, by result."),
 	)
@@ -273,38 +292,42 @@ func createOrchestratorInstruments() error {
 }
 
 func createProviderInstruments() error {
+	m := meter
+	if m == nil {
+		return nil
+	}
 	var err error
-	if providerProbes, err = meter.Int64Counter(
+	if providerProbes, err = m.Int64Counter(
 		"sybra_provider_probes_total",
 		metric.WithDescription("Provider health probe attempts, by provider and result."),
 	); err != nil {
 		return err
 	}
-	if providerHealthFlips, err = meter.Int64Counter(
+	if providerHealthFlips, err = m.Int64Counter(
 		"sybra_provider_health_flips_total",
 		metric.WithDescription("Provider health state flips, by provider and direction (healthy/unhealthy)."),
 	); err != nil {
 		return err
 	}
-	if providerAuthFailures, err = meter.Int64Counter(
+	if providerAuthFailures, err = m.Int64Counter(
 		"sybra_provider_auth_failures_total",
 		metric.WithDescription("Provider auth-failure signals reported by runners."),
 	); err != nil {
 		return err
 	}
-	if providerRateLimits, err = meter.Int64Counter(
+	if providerRateLimits, err = m.Int64Counter(
 		"sybra_provider_rate_limits_total",
 		metric.WithDescription("Provider rate-limit signals reported by runners."),
 	); err != nil {
 		return err
 	}
-	if agentFailoversCounter, err = meter.Int64Counter(
+	if agentFailoversCounter, err = m.Int64Counter(
 		"sybra_agent_failovers_total",
 		metric.WithDescription("Agent scheduling failovers triggered by an unhealthy provider."),
 	); err != nil {
 		return err
 	}
-	agentsGatedCounter, err = meter.Int64Counter(
+	agentsGatedCounter, err = m.Int64Counter(
 		"sybra_agents_gated_total",
 		metric.WithDescription("Agent runs refused by the provider health gate, by provider and reason."),
 	)
@@ -312,32 +335,36 @@ func createProviderInstruments() error {
 }
 
 func createObservableGauges() error {
+	m := meter
+	if m == nil {
+		return nil
+	}
 	var err error
-	if tasksByStatusGauge, err = meter.Int64ObservableGauge(
+	if tasksByStatusGauge, err = m.Int64ObservableGauge(
 		"sybra_tasks_by_status",
 		metric.WithDescription("Current task count grouped by status."),
 	); err != nil {
 		return err
 	}
-	if agentsActiveGauge, err = meter.Int64ObservableGauge(
+	if agentsActiveGauge, err = m.Int64ObservableGauge(
 		"sybra_agents_active",
 		metric.WithDescription("Current agents grouped by state."),
 	); err != nil {
 		return err
 	}
-	if renovatePRsGauge, err = meter.Int64ObservableGauge(
+	if renovatePRsGauge, err = m.Int64ObservableGauge(
 		"sybra_renovate_prs_fetched",
 		metric.WithDescription("Last observed count of open Renovate PRs."),
 	); err != nil {
 		return err
 	}
-	if providerHealthyG, err = meter.Int64ObservableGauge(
+	if providerHealthyG, err = m.Int64ObservableGauge(
 		"sybra_provider_healthy",
 		metric.WithDescription("Current provider health (1=healthy, 0=unhealthy), by provider."),
 	); err != nil {
 		return err
 	}
-	_, err = meter.RegisterCallback(
+	_, err = m.RegisterCallback(
 		observe,
 		tasksByStatusGauge, agentsActiveGauge, renovatePRsGauge, providerHealthyG,
 	)

--- a/internal/notification/emitter_test.go
+++ b/internal/notification/emitter_test.go
@@ -51,7 +51,7 @@ func TestSendEmitsEvent(t *testing.T) {
 		data  any
 	}
 	var mu sync.Mutex
-	var calls []emitCall
+	calls := make([]emitCall, 0)
 
 	emit := func(event string, data any) {
 		mu.Lock()

--- a/internal/selfmonitor/loganalyzer.go
+++ b/internal/selfmonitor/loganalyzer.go
@@ -231,7 +231,7 @@ func (st *analyzerState) onAssistant(ev *agent.ClaudeEvent) {
 		st.summary.TotalToolCalls++
 		st.summary.ToolHistogram[t.Name]++
 		hash, sample := canonicalInputHash(t.Input)
-		if st.perToolHashes[t.Name] == nil {
+		if st.perToolSample[t.Name] == nil {
 			st.perToolHashes[t.Name] = map[string]int{}
 			st.perToolSample[t.Name] = map[string]map[string]any{}
 		}

--- a/internal/sybra/svc_config_reload_test.go
+++ b/internal/sybra/svc_config_reload_test.go
@@ -217,7 +217,7 @@ func TestReloadFromDisk_RestartRequiredWarned(t *testing.T) {
 	}
 
 	// Capture log records
-	var records []slog.Record
+	records := make([]slog.Record, 0)
 	handler := &recordHandler{records: &records}
 	logger := slog.New(handler)
 

--- a/internal/task/comment_test.go
+++ b/internal/task/comment_test.go
@@ -92,6 +92,9 @@ func TestCommentStore_Resolve(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
+	if len(comments) == 0 {
+		t.Fatal("expected at least 1 comment")
+	}
 	if !comments[0].Resolved {
 		t.Error("expected Resolved=true")
 	}

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -1261,15 +1261,30 @@ func TestCloneWorkflowDoesNotAliasParallelInflight(t *testing.T) {
 	}
 
 	// Mutate the clone's outer map: must not affect the original.
-	clone.ParallelInflight["parent"].Children["a"].Status = "completed"
-	if orig.ParallelInflight["parent"].Children["a"].Status != "pending" {
-		t.Errorf("clone mutation of ChildStatus leaked to original: status=%q",
-			orig.ParallelInflight["parent"].Children["a"].Status)
+	cloneParent := clone.ParallelInflight["parent"]
+	if cloneParent == nil {
+		t.Fatal("clone: parent entry missing")
+	}
+	origParent := orig.ParallelInflight["parent"]
+	if origParent == nil {
+		t.Fatal("orig: parent entry missing")
+	}
+	cloneChildA := cloneParent.Children["a"]
+	if cloneChildA == nil {
+		t.Fatal("clone: child 'a' missing")
+	}
+	cloneChildA.Status = "completed"
+	origChildA := origParent.Children["a"]
+	if origChildA == nil {
+		t.Fatal("orig: child 'a' missing after clone mutation")
+	}
+	if origChildA.Status != "pending" {
+		t.Errorf("clone mutation of ChildStatus leaked to original: status=%q", origChildA.Status)
 	}
 
 	// Replace a child entry on the clone — must not appear on the original.
-	clone.ParallelInflight["parent"].Children["c"] = &workflow.ChildStatus{Status: "completed"}
-	if _, ok := orig.ParallelInflight["parent"].Children["c"]; ok {
+	cloneParent.Children["c"] = &workflow.ChildStatus{Status: "completed"}
+	if _, ok := origParent.Children["c"]; ok {
 		t.Error("clone added child key 'c' that leaked to original Children map")
 	}
 
@@ -1320,8 +1335,16 @@ func TestStoreListMutateClonedParallelInflightDoesNotAffectCache(t *testing.T) {
 		t.Fatalf("unexpected list result: %+v", first)
 	}
 	// Mutate the returned clone's ChildStatus directly.
-	first[0].Workflow.ParallelInflight["parent"].Children["a"].Status = "MUTATED-BY-CALLER"
-	first[0].Workflow.ParallelInflight["parent"].Children["b"] = &workflow.ChildStatus{Status: "MUTATED"}
+	firstParent := first[0].Workflow.ParallelInflight["parent"]
+	if firstParent == nil {
+		t.Fatal("first: parent entry missing")
+	}
+	firstChildA := firstParent.Children["a"]
+	if firstChildA == nil {
+		t.Fatal("first: child 'a' missing")
+	}
+	firstChildA.Status = "MUTATED-BY-CALLER"
+	firstParent.Children["b"] = &workflow.ChildStatus{Status: "MUTATED"}
 
 	second, err := store.List()
 	if err != nil {
@@ -1330,11 +1353,18 @@ func TestStoreListMutateClonedParallelInflightDoesNotAffectCache(t *testing.T) {
 	if len(second) != 1 || second[0].Workflow == nil {
 		t.Fatalf("unexpected second list: %+v", second)
 	}
-	got := second[0].Workflow.ParallelInflight["parent"].Children["a"].Status
-	if got != "pending" {
-		t.Errorf("cache corrupted: ChildStatus.Status = %q, want %q", got, "pending")
+	secondParent := second[0].Workflow.ParallelInflight["parent"]
+	if secondParent == nil {
+		t.Fatal("second: parent entry missing")
 	}
-	if _, ok := second[0].Workflow.ParallelInflight["parent"].Children["b"]; ok {
+	secondChildA := secondParent.Children["a"]
+	if secondChildA == nil {
+		t.Fatal("second: child 'a' missing")
+	}
+	if secondChildA.Status != "pending" {
+		t.Errorf("cache corrupted: ChildStatus.Status = %q, want %q", secondChildA.Status, "pending")
+	}
+	if _, ok := secondParent.Children["b"]; ok {
 		t.Error("cache corrupted: caller-added child key 'b' visible on second List()")
 	}
 }

--- a/internal/workflow/engine_parallel_test.go
+++ b/internal/workflow/engine_parallel_test.go
@@ -273,7 +273,11 @@ func TestParallel_ChildFailRetryThenSucceed(t *testing.T) {
 	if rec == nil {
 		t.Fatal("ParallelInflight cleared before retry")
 	}
-	if got := rec.Children["plan_b"]; got.Retries != 1 || got.Status != "pending" {
+	got := rec.Children["plan_b"]
+	if got == nil {
+		t.Fatal("plan_b child missing after retry")
+	}
+	if got.Retries != 1 || got.Status != "pending" {
 		t.Errorf("plan_b after retry: %+v (want retries=1 status=pending)", got)
 	}
 

--- a/internal/workflow/engine_steps_parallel.go
+++ b/internal/workflow/engine_steps_parallel.go
@@ -26,7 +26,7 @@ func (e *Engine) execParallel(taskID string, def *Definition, step *Step, wfExec
 		wfExec.ParallelInflight = make(map[string]*ParallelChildren)
 	}
 	rec, exists := wfExec.ParallelInflight[step.ID]
-	if !exists {
+	if !exists || rec == nil {
 		rec = &ParallelChildren{
 			ParentStepID: step.ID,
 			StartedAt:    time.Now().UTC(),
@@ -278,6 +278,9 @@ func summarizeChildOutputs(rec *ParallelChildren) string {
 	}
 	parts := make([]string, 0, len(rec.Children))
 	for id, c := range rec.Children {
+		if c == nil {
+			continue
+		}
 		parts = append(parts, fmt.Sprintf("%s=%s", id, c.Status))
 	}
 	slices.Sort(parts) // deterministic for test assertions

--- a/internal/workflow/execution.go
+++ b/internal/workflow/execution.go
@@ -60,6 +60,9 @@ func (p *ParallelChildren) AllChildrenDone() bool {
 		return false
 	}
 	for _, c := range p.Children {
+		if c == nil {
+			return false
+		}
 		if c.Status != "completed" && c.Status != "failed" {
 			return false
 		}
@@ -74,6 +77,9 @@ func (p *ParallelChildren) AnyChildFailed() bool {
 		return false
 	}
 	for _, c := range p.Children {
+		if c == nil {
+			continue
+		}
 		if c.Status == "failed" {
 			return true
 		}

--- a/internal/workflow/store_test.go
+++ b/internal/workflow/store_test.go
@@ -6,6 +6,15 @@ import (
 	"testing"
 )
 
+func mustNewStore(t *testing.T) *Store {
+	t.Helper()
+	s, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return s
+}
+
 func newTestDef(id string) Definition {
 	return Definition{
 		ID:      id,
@@ -30,7 +39,7 @@ func TestNewStore(t *testing.T) {
 
 func TestStore_SaveAndGet(t *testing.T) {
 	t.Parallel()
-	s, _ := NewStore(t.TempDir())
+	s := mustNewStore(t)
 
 	def := newTestDef("my-workflow")
 	if err := s.Save(def); err != nil {
@@ -51,7 +60,7 @@ func TestStore_SaveAndGet(t *testing.T) {
 
 func TestStore_Save_EmptyID(t *testing.T) {
 	t.Parallel()
-	s, _ := NewStore(t.TempDir())
+	s := mustNewStore(t)
 	if err := s.Save(Definition{}); err == nil {
 		t.Fatal("expected error for empty ID")
 	}
@@ -59,7 +68,7 @@ func TestStore_Save_EmptyID(t *testing.T) {
 
 func TestStore_Save_Invalid(t *testing.T) {
 	t.Parallel()
-	s, _ := NewStore(t.TempDir())
+	s := mustNewStore(t)
 	def := Definition{
 		ID:    "bad-wf",
 		Steps: []Step{{ID: "s1", Config: StepConfig{MaxRetries: 11}}},
@@ -71,7 +80,7 @@ func TestStore_Save_Invalid(t *testing.T) {
 
 func TestStore_List(t *testing.T) {
 	t.Parallel()
-	s, _ := NewStore(t.TempDir())
+	s := mustNewStore(t)
 
 	for _, id := range []string{"wf-a", "wf-b", "wf-c"} {
 		if err := s.Save(newTestDef(id)); err != nil {
@@ -91,7 +100,10 @@ func TestStore_List(t *testing.T) {
 func TestStore_List_SkipsBadFiles(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	s, _ := NewStore(dir)
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
 
 	if err := s.Save(newTestDef("good-wf")); err != nil {
 		t.Fatalf("Save: %v", err)
@@ -114,7 +126,7 @@ func TestStore_List_SkipsBadFiles(t *testing.T) {
 
 func TestStore_Delete(t *testing.T) {
 	t.Parallel()
-	s, _ := NewStore(t.TempDir())
+	s := mustNewStore(t)
 
 	if err := s.Save(newTestDef("to-delete")); err != nil {
 		t.Fatalf("Save: %v", err)
@@ -129,7 +141,7 @@ func TestStore_Delete(t *testing.T) {
 
 func TestStore_Delete_NotFound(t *testing.T) {
 	t.Parallel()
-	s, _ := NewStore(t.TempDir())
+	s := mustNewStore(t)
 	if err := s.Delete("nonexistent"); err == nil {
 		t.Fatal("expected error for non-existent workflow")
 	}
@@ -137,7 +149,7 @@ func TestStore_Delete_NotFound(t *testing.T) {
 
 func TestStore_SafePath_Traversal(t *testing.T) {
 	t.Parallel()
-	s, _ := NewStore(t.TempDir())
+	s := mustNewStore(t)
 
 	traversalIDs := []string{
 		"../etc/passwd",
@@ -156,7 +168,7 @@ func TestStore_SafePath_Traversal(t *testing.T) {
 
 func TestStore_SafePath_Valid(t *testing.T) {
 	t.Parallel()
-	s, _ := NewStore(t.TempDir())
+	s := mustNewStore(t)
 
 	// Should not error on path validation (file not found is fine here).
 	_, err := s.Get("valid-id")
@@ -177,7 +189,7 @@ func TestStore_SafePath_Valid(t *testing.T) {
 // filepath.Clean alone would let "/etc/passwd" resolve outside the store.
 func TestStore_SafePath_AbsoluteAndWeirdPaths(t *testing.T) {
 	t.Parallel()
-	s, _ := NewStore(t.TempDir())
+	s := mustNewStore(t)
 
 	badIDs := []string{
 		"/etc/passwd",


### PR DESCRIPTION
## Motivation

Resolves 31 pre-existing nilaway nil-safety findings flagged by golangci-lint. These were latent nil-dereference risks across several internal packages that needed to be addressed to keep the linter clean.

Closes https://github.com/Automaat/sybra/issues/792

## Implementation information

- Fixed nil pointer dereferences identified by nilaway static analysis
- Changes span multiple internal packages where nil checks were missing or incorrect
- No behavioral changes — all fixes are defensive nil guards or restructured return paths

> Changelog: skip