### PR TITLE
chore(docker): lint layer cache invariants

### DIFF
--- a/.github/workflows/dockerfile-layers.yml
+++ b/.github/workflows/dockerfile-layers.yml
@@ -1,0 +1,47 @@
+name: Dockerfile Layers
+
+# Enforces the layer cache strategy documented at the top of the runtime
+# stage in Dockerfile. Hadolint lints individual instructions but cannot
+# detect *position* — e.g. a `RUN apt-get install ...` added to Layer F+G
+# would silently invalidate the apt cache on every sybra commit. This
+# workflow catches that and a handful of related invariants:
+#
+#   - Layer markers (A..F+G) appear in order, exactly once each
+#   - Heavy operations (apt, npm globals, COPY --from=<builder>) stay
+#     confined to the layer that owns them
+#   - HEALTHCHECK uses curl (portable) not node -e (fragile)
+#   - Every FROM is sha256-pinned (digest staleness handled by Renovate)
+#
+# Runs only when the Dockerfile or the checker script changes — same
+# narrow scope as docker-build.yml.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - 'scripts/check-dockerfile-layers.sh'
+      - '.github/workflows/dockerfile-layers.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - 'scripts/check-dockerfile-layers.sh'
+      - '.github/workflows/dockerfile-layers.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dockerfile-layers-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-layers:
+    name: Layer Order & Digest Pins
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run layer linter
+        run: bash scripts/check-dockerfile-layers.sh Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,29 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /bin/sybra-server ./cmd/sybra
 
 # Stage 3: Runtime — node:24-slim for claude CLI (Node.js-based)
 #
-# Layer ordering targets pull-time on re-deploys: the heavy, version-pinned
-# tool layers sit above the thin sybra-binary + web-assets layers. Bumping
-# sybra invalidates only the last two COPY layers (~20MB); bumping a tool
-# ARG invalidates just that tool's layer. Pinned versions keep layer digests
-# stable across rebuilds (unpinned `apt-get` / `npm install` would otherwise
-# regenerate the blob on every build even when inputs are unchanged).
+# Layer cache strategy (DO NOT REORDER without updating
+# scripts/check-dockerfile-layers.sh):
+#
+#   A. apt system packages + gh repo   — heaviest, rare changes
+#   B. klaudiush binary                — pinned via ARG, rare
+#   C. node CLIs (claude, codex)       — pinned via ARG, monthly bumps
+#   D. mise binary                     — pinned via ARG, rare
+#   E. non-root user + static config   — never changes
+#   F+G. sybra binaries + web assets   — per-commit, thin (~20MB)
+#
+# Invariants enforced by scripts/check-dockerfile-layers.sh in CI:
+#   - Each "# --- Layer X:" marker appears exactly once, in order
+#   - `apt-get install` only inside Layer A
+#   - `npm install -g` only inside Layer C
+#   - `COPY --from=<builder>` only inside Layer F+G
+#   - HEALTHCHECK uses curl (not node -e)
+#   - Every FROM is sha256-pinned
+#
+# Why it matters: bumping sybra invalidates only the last COPY layers;
+# bumping a tool ARG invalidates just that tool's layer. If `apt-get
+# install` ever lands in Layer F+G, the apt cache silently regenerates
+# on every sybra commit and image size balloons. The linter catches that
+# before it reaches main.
 FROM node:24-slim@sha256:24dc26ef1e3c3690f27ebc4136c9c186c3133b25563ae4d7f0692e4d1fe5db0e AS runtime
 
 # Pipe failures in subsequent RUN blocks should fail the build.
@@ -139,7 +156,7 @@ WORKDIR /home/sybra
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD node -e "require('http').get('http://localhost:'+process.env.SYBRA_PORT+'/health',r=>{process.exit(r.statusCode===200?0:1)}).on('error',()=>process.exit(1))"
+    CMD curl -sf "http://localhost:${SYBRA_PORT}/health" || exit 1
 
 # Mounts expected (host dirs must be chowned to uid:gid 1000:1000):
 #   ~/.sybra  → /home/sybra/.sybra  (task store, config, projects)

--- a/scripts/check-dockerfile-layers.sh
+++ b/scripts/check-dockerfile-layers.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Enforces the Dockerfile cache strategy documented at the top of the
+# runtime stage. Heavy, version-pinned tool layers (apt, npm globals,
+# klaudiush, mise) MUST appear before the thin per-commit layers (sybra
+# binaries + web assets). Re-ordering these silently invalidates the
+# cache on every sybra bump and bloats pull-time on re-deploys.
+#
+# Hadolint cannot detect this — it lints individual instructions, not
+# the *position* of heavy work relative to thin work. This script does.
+
+set -euo pipefail
+
+DOCKERFILE="${1:-Dockerfile}"
+
+if [[ ! -f "${DOCKERFILE}" ]]; then
+  echo "::error::${DOCKERFILE} not found" >&2
+  exit 1
+fi
+
+fail=0
+
+note() {
+  echo "  - $*" >&2
+}
+
+err() {
+  echo "::error file=${DOCKERFILE}::$*" >&2
+  fail=1
+}
+
+# --- 1. FROM pins ---------------------------------------------------------
+# Every FROM must use @sha256:<digest>. Tag-only FROMs let a base-image
+# republish silently shift the runtime out from under us.
+while IFS= read -r line; do
+  if [[ ! "${line}" =~ @sha256:[a-f0-9]{64} ]]; then
+    err "FROM without sha256 digest pin: ${line}"
+  fi
+done < <(grep -E '^FROM ' "${DOCKERFILE}")
+
+# --- 2. Layer marker ordering --------------------------------------------
+# The runtime stage uses ordered markers (Layer A, B, C, D, E, F+G) so a
+# human reviewer can spot reorderings in a diff. Enforce that they appear
+# in alphabetical order and each appears exactly once.
+expected=(A B C D E "F\\+G")
+prev_line=0
+for marker in "${expected[@]}"; do
+  count=$(grep -cE "^# --- Layer ${marker}:" "${DOCKERFILE}" || true)
+  if [[ "${count}" -ne 1 ]]; then
+    err "expected exactly one '# --- Layer ${marker}:' marker, found ${count}"
+    continue
+  fi
+  this_line=$(grep -nE "^# --- Layer ${marker}:" "${DOCKERFILE}" | head -1 | cut -d: -f1)
+  if (( this_line <= prev_line )); then
+    err "Layer ${marker} (line ${this_line}) appears before previous marker (line ${prev_line})"
+  fi
+  prev_line="${this_line}"
+done
+
+# --- 3. Heavy operations confined to their layers ------------------------
+# The whole point of the layer order is that heavy/unpinned operations
+# never appear in the thin per-commit zone. If someone adds `RUN apt-get
+# install` to Layer F+G, the apt cache is invalidated on every sybra
+# bump and the image regrows by ~150MB silently. Catch that here.
+#
+# Strategy: read the file, track which layer marker we're under, and
+# flag rule violations per layer.
+awk -v dockerfile="${DOCKERFILE}" '
+  /^# --- Layer A:/   { layer="A"; next }
+  /^# --- Layer B:/   { layer="B"; next }
+  /^# --- Layer C:/   { layer="C"; next }
+  /^# --- Layer D:/   { layer="D"; next }
+  /^# --- Layer E:/   { layer="E"; next }
+  /^# --- Layer F\+G:/{ layer="FG"; next }
+
+  # apt-get install only allowed in Layer A.
+  /^[[:space:]]*&&[[:space:]]*apt-get[[:space:]]+install/ || /apt-get[[:space:]]+install/ {
+    if (layer != "" && layer != "A") {
+      printf("::error file=%s,line=%d::apt-get install outside Layer A (in Layer %s): %s\n",
+             dockerfile, NR, layer, $0) > "/dev/stderr"
+      bad=1
+    }
+  }
+
+  # npm install -g only allowed in Layer C.
+  /npm[[:space:]]+install[[:space:]]+-g/ {
+    if (layer != "" && layer != "C") {
+      printf("::error file=%s,line=%d::npm install -g outside Layer C (in Layer %s): %s\n",
+             dockerfile, NR, layer, $0) > "/dev/stderr"
+      bad=1
+    }
+  }
+
+  # COPY --from=<builder> only allowed in Layer F+G (the thin per-commit zone).
+  /^COPY[[:space:]]+--from=/ {
+    if (layer != "" && layer != "FG") {
+      printf("::error file=%s,line=%d::COPY --from=<builder> outside Layer F+G (in Layer %s): %s\n",
+             dockerfile, NR, layer, $0) > "/dev/stderr"
+      bad=1
+    }
+  }
+
+  END { exit bad ? 1 : 0 }
+' "${DOCKERFILE}" || fail=1
+
+# --- 4. Healthcheck uses curl, not node ----------------------------------
+# Node-based healthchecks are fragile: they depend on the node runtime
+# being on PATH inside the runtime stage. curl is installed in Layer A
+# and is the portable choice. HEALTHCHECK spans line-continuations, so
+# grep -A1 picks up the CMD line that follows.
+hc=$(grep -A1 -E "^HEALTHCHECK" "${DOCKERFILE}" || true)
+if printf "%s" "${hc}" | grep -q "node -e"; then
+  err "HEALTHCHECK still uses node -e, prefer curl for portability"
+fi
+
+if [[ "${fail}" -ne 0 ]]; then
+  echo "" >&2
+  echo "Dockerfile layer check FAILED. See errors above." >&2
+  exit 1
+fi
+
+echo "Dockerfile layer check passed."


### PR DESCRIPTION
## Motivation

Closes #790.

The Dockerfile is well-structured with explicit `# --- Layer A:` … `# --- Layer F+G:` markers, but nothing prevents a contributor from re-ordering the layers or — worse — adding `RUN apt-get install ...` to the thin per-commit zone. Hadolint lints individual instructions but cannot detect *position*, so the invariants the runtime stage relies on for cache stability go unenforced.

## Implementation information

`scripts/check-dockerfile-layers.sh` parses the Dockerfile and asserts:

- Each `# --- Layer X:` marker appears exactly once, in alphabetical order (A..F+G)
- `apt-get install` only inside Layer A
- `npm install -g` only inside Layer C
- `COPY --from=<builder>` only inside Layer F+G (the thin per-commit zone)
- `HEALTHCHECK` uses curl, not `node -e`
- Every `FROM` is sha256-pinned

A new `.github/workflows/dockerfile-layers.yml` runs it on PRs that touch the Dockerfile or the script itself — narrow scope, same pattern as `docker-build.yml`.

Companion Dockerfile changes:
- Swapped the `node -e` HEALTHCHECK for `curl -sf` (portable, lighter, no dependency on the node runtime being on PATH).
- Expanded the runtime-stage header comment to enumerate the invariants and reference the linter, so a reviewer sees the rules in the diff context, not just in CI output.

Alternatives considered:
- **Inline the check into `lint-dockerfile` in `ci.yml`** — rejected; the issue explicitly asks for a dedicated workflow file, and a separate workflow keeps the trigger path-scoped.
- **Two-pass docker build + digest comparison** — rejected as over-engineered; the realistic regression is human reordering, which the marker linter catches with no Docker daemon required.

## Supporting documentation

- Parent: #781