### PR TITLE
test(frontend): expand page coverage

### DIFF
--- a/frontend/src/pages/AgentDetail.svelte.test.ts
+++ b/frontend/src/pages/AgentDetail.svelte.test.ts
@@ -1,10 +1,23 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { agentState } from '../lib/events.js'
-import { render, screen, cleanup } from '@testing-library/svelte'
+import {
+  agentState,
+  agentError,
+  agentEscalation,
+  agentPluginErrors,
+} from '../lib/events.js'
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
 
 const mockStop = vi.fn()
 const mockUpdateAgent = vi.fn()
-const mockEventsOn = vi.fn((..._args: any[]) => vi.fn())
+const mockRespondEscalation = vi.fn()
+
+type Handler = (data: unknown) => void
+const eventHandlers: Record<string, Handler> = {}
+
+const mockEventsOn = vi.fn((channel: string, cb: Handler) => {
+  eventHandlers[channel] = cb
+  return vi.fn()
+})
 
 const mockAgents = new Map()
 
@@ -19,13 +32,26 @@ vi.mock('../stores/agents.svelte.js', () => ({
   },
 }))
 
+vi.mock('../stores/tasks.svelte.js', () => ({
+  taskStore: {
+    tasks: new Map<string, unknown>(),
+  },
+}))
+
+vi.mock('../stores/convo.svelte.js', () => ({
+  convoStore: {
+    conversations: new Map<string, unknown[]>(),
+  },
+}))
+
 vi.mock('$lib/api', () => ({
-  EventsOn: (...args: any[]) => mockEventsOn(...args),
-  RespondEscalation: vi.fn(),
+  EventsOn: (...args: any[]) => mockEventsOn(...(args as [string, Handler])),
+  RespondEscalation: (...args: unknown[]) => mockRespondEscalation(...args),
 }))
 
 vi.mock('../components/StreamOutput.svelte', () => ({ default: () => {} }))
 vi.mock('../components/agent-view/SessionWorkspace.svelte', () => ({ default: () => {} }))
+vi.mock('../components/agent-view/AgentViewBody.svelte', () => ({ default: () => {} }))
 
 const AgentDetail = (await import('./AgentDetail.svelte')).default
 
@@ -48,6 +74,7 @@ describe('AgentDetail', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockAgents.clear()
+    for (const k of Object.keys(eventHandlers)) delete eventHandlers[k]
   })
 
   afterEach(() => {
@@ -82,13 +109,60 @@ describe('AgentDetail', () => {
     })
   })
 
-  it('shows state badge', async () => {
-    mockAgents.set('agent-1', { ...mockAgent })
+  it('falls back to agent id when project is empty', async () => {
+    mockAgents.set('agent-1', { ...mockAgent, project: '' })
     render(AgentDetail, {
       props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
     })
     await vi.waitFor(() => {
-      expect(screen.getByText(/running/i)).toBeDefined()
+      const heading = screen.getByRole('heading', { level: 1 })
+      expect(heading.textContent).toBe('agent-1')
+    })
+  })
+
+  it('shows Stop button when agent is running', async () => {
+    mockAgents.set('agent-1', { ...mockAgent, state: 'running' })
+    render(AgentDetail, {
+      props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => {
+      expect(screen.getByText('Stop')).toBeDefined()
+    })
+  })
+
+  it('does not show Stop button when agent is stopped', async () => {
+    mockAgents.set('agent-1', { ...mockAgent, state: 'stopped' })
+    render(AgentDetail, {
+      props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => {
+      expect(screen.queryByText('Stop')).toBeNull()
+    })
+  })
+
+  it('calls agentStore.stop when Stop button clicked', async () => {
+    mockAgents.set('agent-1', { ...mockAgent, state: 'running' })
+    mockStop.mockResolvedValue(undefined)
+    render(AgentDetail, {
+      props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => screen.getByText('Stop'))
+    await fireEvent.click(screen.getByText('Stop'))
+    await vi.waitFor(() => {
+      expect(mockStop).toHaveBeenCalledWith('agent-1')
+    })
+  })
+
+  it('shows error text when Stop call rejects', async () => {
+    mockAgents.set('agent-1', { ...mockAgent, state: 'running' })
+    mockStop.mockRejectedValue(new Error('stop failed'))
+    render(AgentDetail, {
+      props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => screen.getByText('Stop'))
+    await fireEvent.click(screen.getByText('Stop'))
+    await vi.waitFor(() => {
+      expect(screen.getByText(/stop failed/)).toBeDefined()
     })
   })
 
@@ -108,16 +182,215 @@ describe('AgentDetail', () => {
     })
   })
 
-  it('subscribes to EventsOn with correct channel', async () => {
+  it('subscribes to all four agent event channels', async () => {
     mockAgents.set('agent-1', { ...mockAgent })
     render(AgentDetail, {
       props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
     })
     await vi.waitFor(() => {
-      expect(mockEventsOn).toHaveBeenCalledWith(
-        agentState('agent-1'),
-        expect.any(Function),
-      )
+      expect(mockEventsOn).toHaveBeenCalledWith(agentState('agent-1'), expect.any(Function))
+      expect(mockEventsOn).toHaveBeenCalledWith(agentError('agent-1'), expect.any(Function))
+      expect(mockEventsOn).toHaveBeenCalledWith(agentEscalation('agent-1'), expect.any(Function))
+      expect(mockEventsOn).toHaveBeenCalledWith(agentPluginErrors('agent-1'), expect.any(Function))
+    })
+  })
+
+  it('shows turns escalation banner when agentEscalation fires with turns reason', async () => {
+    mockAgents.set('agent-1', { ...mockAgent })
+    render(AgentDetail, {
+      props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => eventHandlers[agentEscalation('agent-1')])
+    eventHandlers[agentEscalation('agent-1')]({
+      reason: 'turns',
+      turnCount: 50,
+      limit: 50,
+    })
+    await vi.waitFor(() => {
+      expect(screen.getByText('GUARDRAIL')).toBeDefined()
+      expect(screen.getByText(/Turn limit reached/)).toBeDefined()
+      expect(screen.getByText('Continue')).toBeDefined()
+      expect(screen.getByText('Kill')).toBeDefined()
+    })
+  })
+
+  it('shows cost escalation banner when agentEscalation fires with cost reason', async () => {
+    mockAgents.set('agent-1', { ...mockAgent })
+    render(AgentDetail, {
+      props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => eventHandlers[agentEscalation('agent-1')])
+    eventHandlers[agentEscalation('agent-1')]({
+      reason: 'cost',
+      costUsd: 5.5,
+      limit: 5,
+    })
+    await vi.waitFor(() => {
+      expect(screen.getByText('GUARDRAIL')).toBeDefined()
+      expect(screen.getByText(/Cost limit exceeded/)).toBeDefined()
+      expect(screen.queryByText('Continue')).toBeNull()
+      expect(screen.getByText('Dismiss')).toBeDefined()
+    })
+  })
+
+  it('calls RespondEscalation(true) on Continue click and clears banner', async () => {
+    mockAgents.set('agent-1', { ...mockAgent })
+    mockRespondEscalation.mockResolvedValue(undefined)
+    render(AgentDetail, {
+      props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => eventHandlers[agentEscalation('agent-1')])
+    eventHandlers[agentEscalation('agent-1')]({
+      reason: 'turns',
+      turnCount: 50,
+      limit: 50,
+    })
+    await vi.waitFor(() => screen.getByText('Continue'))
+    await fireEvent.click(screen.getByText('Continue'))
+    await vi.waitFor(() => {
+      expect(mockRespondEscalation).toHaveBeenCalledWith('agent-1', true)
+      expect(screen.queryByText('GUARDRAIL')).toBeNull()
+    })
+  })
+
+  it('calls RespondEscalation(false) on Kill click and clears banner', async () => {
+    mockAgents.set('agent-1', { ...mockAgent })
+    mockRespondEscalation.mockResolvedValue(undefined)
+    render(AgentDetail, {
+      props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => eventHandlers[agentEscalation('agent-1')])
+    eventHandlers[agentEscalation('agent-1')]({
+      reason: 'turns',
+      turnCount: 50,
+      limit: 50,
+    })
+    await vi.waitFor(() => screen.getByText('Kill'))
+    await fireEvent.click(screen.getByText('Kill'))
+    await vi.waitFor(() => {
+      expect(mockRespondEscalation).toHaveBeenCalledWith('agent-1', false)
+      expect(screen.queryByText('GUARDRAIL')).toBeNull()
+    })
+  })
+
+  it('dismisses cost escalation even when RespondEscalation rejects', async () => {
+    mockAgents.set('agent-1', { ...mockAgent })
+    mockRespondEscalation.mockRejectedValue(new Error('already stopped'))
+    render(AgentDetail, {
+      props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => eventHandlers[agentEscalation('agent-1')])
+    eventHandlers[agentEscalation('agent-1')]({
+      reason: 'cost',
+      costUsd: 5.5,
+      limit: 5,
+    })
+    await vi.waitFor(() => screen.getByText('Dismiss'))
+    await fireEvent.click(screen.getByText('Dismiss'))
+    await vi.waitFor(() => {
+      expect(screen.queryByText('GUARDRAIL')).toBeNull()
+    })
+  })
+
+  it('shows plugin errors banner when agentPluginErrors fires', async () => {
+    mockAgents.set('agent-1', { ...mockAgent })
+    render(AgentDetail, {
+      props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => eventHandlers[agentPluginErrors('agent-1')])
+    eventHandlers[agentPluginErrors('agent-1')]({
+      errors: ['plugin foo: failed to load', 'plugin bar: missing dep'],
+    })
+    await vi.waitFor(() => {
+      expect(screen.getByText('PLUGIN ERRORS')).toBeDefined()
+      expect(screen.getByText('2 plugins failed to load')).toBeDefined()
+      expect(screen.getByText('plugin foo: failed to load')).toBeDefined()
+      expect(screen.getByText('plugin bar: missing dep')).toBeDefined()
+    })
+  })
+
+  it('uses singular plugin label when only one plugin failed', async () => {
+    mockAgents.set('agent-1', { ...mockAgent })
+    render(AgentDetail, {
+      props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => eventHandlers[agentPluginErrors('agent-1')])
+    eventHandlers[agentPluginErrors('agent-1')]({
+      errors: ['plugin foo: failed'],
+    })
+    await vi.waitFor(() => {
+      expect(screen.getByText('1 plugin failed to load')).toBeDefined()
+    })
+  })
+
+  it('hides plugin errors banner when Dismiss is clicked', async () => {
+    mockAgents.set('agent-1', { ...mockAgent })
+    render(AgentDetail, {
+      props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => eventHandlers[agentPluginErrors('agent-1')])
+    eventHandlers[agentPluginErrors('agent-1')]({
+      errors: ['plugin foo: failed'],
+    })
+    await vi.waitFor(() => screen.getByText('Dismiss'))
+    await fireEvent.click(screen.getByText('Dismiss'))
+    await vi.waitFor(() => {
+      expect(screen.queryByText('PLUGIN ERRORS')).toBeNull()
+    })
+  })
+
+  it('seeds plugin errors from cached agent on mount', async () => {
+    mockAgents.set('agent-1', { ...mockAgent, pluginErrors: ['cached plugin err'] })
+    render(AgentDetail, {
+      props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => {
+      expect(screen.getByText('PLUGIN ERRORS')).toBeDefined()
+      expect(screen.getByText('cached plugin err')).toBeDefined()
+    })
+  })
+
+  it('shows error banner when agentError event fires', async () => {
+    mockAgents.set('agent-1', { ...mockAgent })
+    render(AgentDetail, {
+      props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => eventHandlers[agentError('agent-1')])
+    eventHandlers[agentError('agent-1')]({
+      kind: 'rate_limit',
+      msg: 'API rate limit hit',
+    })
+    await vi.waitFor(() => {
+      expect(screen.getByText('API rate limited')).toBeDefined()
+    })
+  })
+
+  it('seeds error banner from cached agent errorKind', async () => {
+    mockAgents.set('agent-1', {
+      ...mockAgent,
+      errorKind: 'worktree_conflict',
+      errorMsg: 'already checked out',
+    })
+    render(AgentDetail, {
+      props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => {
+      expect(screen.getByText('Worktree conflict')).toBeDefined()
+    })
+  })
+
+  it('updates state when agentState event fires', async () => {
+    mockAgents.set('agent-1', { ...mockAgent, state: 'running' })
+    mockUpdateAgent.mockImplementation((id: string, data: unknown) => {
+      mockAgents.set(id, data)
+    })
+    render(AgentDetail, {
+      props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => eventHandlers[agentState('agent-1')])
+    eventHandlers[agentState('agent-1')]({ ...mockAgent, state: 'stopped' })
+    await vi.waitFor(() => {
+      expect(mockUpdateAgent).toHaveBeenCalledWith('agent-1', expect.objectContaining({ state: 'stopped' }))
     })
   })
 
@@ -126,5 +399,14 @@ describe('AgentDetail', () => {
       props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
     })
     expect(screen.getByText('Back to agents')).toBeDefined()
+  })
+
+  it('calls onback when back button clicked', async () => {
+    const onback = vi.fn()
+    render(AgentDetail, {
+      props: { agentId: 'agent-1', onback, onviewtask: vi.fn() },
+    })
+    await fireEvent.click(screen.getByText('Back to agents'))
+    expect(onback).toHaveBeenCalled()
   })
 })

--- a/frontend/src/pages/Orchestrator.svelte.test.ts
+++ b/frontend/src/pages/Orchestrator.svelte.test.ts
@@ -1,11 +1,27 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/svelte'
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
 
 const mockIsOrchestratorRunning = vi.fn().mockResolvedValue(false)
 const mockStartOrchestrator = vi.fn().mockResolvedValue(undefined)
 const mockStopOrchestrator = vi.fn().mockResolvedValue(undefined)
 const mockGetOrchestratorAgentID = vi.fn().mockResolvedValue('')
-const mockGetMonitorReport = vi.fn().mockResolvedValue({
+const mockGetMonitorReport = vi.fn()
+
+const mockGetOutput = vi.fn().mockResolvedValue([])
+const mockSubscribe = vi.fn().mockReturnValue(() => {})
+
+type Handler = (data: unknown) => void
+const eventHandlers: Record<string, Handler> = {}
+
+const mockEventsOn = vi.fn((channel: string, cb: Handler) => {
+  eventHandlers[channel] = cb
+  return vi.fn()
+})
+
+const mockAgentList: any[] = []
+const mockConversations = new Map<string, unknown[]>()
+
+const emptyMonitorBinding = () => ({
   enabled: true,
   ready: false,
   report: {
@@ -27,9 +43,6 @@ const mockGetMonitorReport = vi.fn().mockResolvedValue({
     issuesUpdated: 0,
   },
 })
-const mockEventsOn = vi.fn().mockReturnValue(vi.fn())
-
-const mockAgentList: any[] = []
 
 vi.mock('$lib/api', () => ({
   IsOrchestratorRunning: (...args: unknown[]) => mockIsOrchestratorRunning(...args),
@@ -37,7 +50,7 @@ vi.mock('$lib/api', () => ({
   StopOrchestrator: (...args: unknown[]) => mockStopOrchestrator(...args),
   GetOrchestratorAgentID: (...args: unknown[]) => mockGetOrchestratorAgentID(...args),
   GetMonitorReport: (...args: unknown[]) => mockGetMonitorReport(...args),
-  EventsOn: (...args: any[]) => mockEventsOn(...args),
+  EventsOn: (...args: any[]) => mockEventsOn(...(args as [string, Handler])),
   BrowserOpenURL: vi.fn(),
 }))
 
@@ -51,9 +64,9 @@ vi.mock('../stores/agents.svelte.js', () => ({
 
 vi.mock('../stores/convo.svelte.js', () => ({
   convoStore: {
-    conversations: new Map(),
-    getOutput: vi.fn().mockResolvedValue([]),
-    subscribe: vi.fn().mockReturnValue(() => {}),
+    conversations: mockConversations,
+    getOutput: (...args: unknown[]) => mockGetOutput(...args),
+    subscribe: (...args: unknown[]) => mockSubscribe(...args),
   },
 }))
 
@@ -67,30 +80,16 @@ describe('Orchestrator', () => {
     vi.clearAllMocks()
     mockIsOrchestratorRunning.mockResolvedValue(false)
     mockGetOrchestratorAgentID.mockResolvedValue('')
-    mockGetMonitorReport.mockResolvedValue({
-      enabled: true,
-      ready: false,
-      report: {
-        generatedAt: '',
-        counts: {
-          new: 0,
-          todo: 0,
-          inProgress: 0,
-          inReview: 0,
-          planReview: 0,
-          humanRequired: 0,
-          done: 0,
-          byStatus: {},
-        },
-        anomalies: [],
-        remediated: [],
-        dispatched: [],
-        issuesOpened: 0,
-        issuesUpdated: 0,
-      },
+    mockGetMonitorReport.mockResolvedValue(emptyMonitorBinding())
+    mockEventsOn.mockImplementation((channel: string, cb: Handler) => {
+      eventHandlers[channel] = cb
+      return vi.fn()
     })
-    mockEventsOn.mockReturnValue(vi.fn())
+    mockGetOutput.mockResolvedValue([])
+    mockSubscribe.mockReturnValue(() => {})
     mockAgentList.length = 0
+    mockConversations.clear()
+    for (const k of Object.keys(eventHandlers)) delete eventHandlers[k]
   })
 
   afterEach(() => {
@@ -143,9 +142,180 @@ describe('Orchestrator', () => {
     })
   })
 
-  it('shows triage agent running badge when triage agent is running', () => {
+  it('subscribes to MonitorReport event', async () => {
+    render(Orchestrator, { props: {} })
+    await vi.waitFor(() => {
+      expect(mockEventsOn).toHaveBeenCalledWith('monitor:report', expect.any(Function))
+    })
+  })
+
+  it('shows Running status when orchestrator already running on mount', async () => {
+    mockIsOrchestratorRunning.mockResolvedValue(true)
+    mockGetOrchestratorAgentID.mockResolvedValue('orch-1')
+    render(Orchestrator, { props: {} })
+    await vi.waitFor(() => {
+      expect(screen.getByText('Running')).toBeDefined()
+      expect(screen.getByText('Stop')).toBeDefined()
+    })
+  })
+
+  it('calls StartOrchestrator when Start clicked', async () => {
+    mockStartOrchestrator.mockResolvedValue(undefined)
+    mockGetOrchestratorAgentID.mockResolvedValue('orch-1')
+    render(Orchestrator, { props: {} })
+    await vi.waitFor(() => screen.getByText('Start'))
+    await fireEvent.click(screen.getByText('Start'))
+    await vi.waitFor(() => {
+      expect(mockStartOrchestrator).toHaveBeenCalled()
+      expect(screen.getByText('Running')).toBeDefined()
+    })
+  })
+
+  it('shows error when Start fails', async () => {
+    mockStartOrchestrator.mockRejectedValue(new Error('start failed'))
+    render(Orchestrator, { props: {} })
+    await vi.waitFor(() => screen.getByText('Start'))
+    await fireEvent.click(screen.getByText('Start'))
+    await vi.waitFor(() => {
+      expect(screen.getByText(/start failed/)).toBeDefined()
+    })
+  })
+
+  it('calls StopOrchestrator when Stop clicked', async () => {
+    mockIsOrchestratorRunning.mockResolvedValue(true)
+    mockGetOrchestratorAgentID.mockResolvedValue('orch-1')
+    mockStopOrchestrator.mockResolvedValue(undefined)
+    render(Orchestrator, { props: {} })
+    await vi.waitFor(() => screen.getByText('Stop'))
+    await fireEvent.click(screen.getByText('Stop'))
+    await vi.waitFor(() => {
+      expect(mockStopOrchestrator).toHaveBeenCalled()
+      expect(screen.getByText('Stopped')).toBeDefined()
+    })
+  })
+
+  it('shows error when Stop fails', async () => {
+    mockIsOrchestratorRunning.mockResolvedValue(true)
+    mockGetOrchestratorAgentID.mockResolvedValue('orch-1')
+    mockStopOrchestrator.mockRejectedValue(new Error('stop failed'))
+    render(Orchestrator, { props: {} })
+    await vi.waitFor(() => screen.getByText('Stop'))
+    await fireEvent.click(screen.getByText('Stop'))
+    await vi.waitFor(() => {
+      expect(screen.getByText(/stop failed/)).toBeDefined()
+    })
+  })
+
+  it('toggles to Running when OrchestratorState event fires with running', async () => {
+    mockGetOrchestratorAgentID.mockResolvedValue('orch-1')
+    render(Orchestrator, { props: {} })
+    await vi.waitFor(() => eventHandlers['orchestrator:state'])
+    await eventHandlers['orchestrator:state']('running')
+    await vi.waitFor(() => {
+      expect(screen.getByText('Running')).toBeDefined()
+    })
+  })
+
+  it('toggles to Stopped when OrchestratorState event fires with stopped', async () => {
+    mockIsOrchestratorRunning.mockResolvedValue(true)
+    mockGetOrchestratorAgentID.mockResolvedValue('orch-1')
+    render(Orchestrator, { props: {} })
+    await vi.waitFor(() => eventHandlers['orchestrator:state'])
+    await eventHandlers['orchestrator:state']('stopped')
+    await vi.waitFor(() => {
+      expect(screen.getByText('Stopped')).toBeDefined()
+    })
+  })
+
+  it('shows monitor: waiting when monitor enabled but not ready', async () => {
+    render(Orchestrator, { props: {} })
+    await vi.waitFor(() => {
+      expect(screen.getByText('monitor: waiting')).toBeDefined()
+    })
+  })
+
+  it('does not show monitor status when monitor disabled', async () => {
+    mockGetMonitorReport.mockResolvedValue({ ...emptyMonitorBinding(), enabled: false })
+    render(Orchestrator, { props: {} })
+    await vi.waitFor(() => {
+      expect(screen.getByText('Stopped')).toBeDefined()
+      expect(screen.queryByText('monitor: waiting')).toBeNull()
+    })
+  })
+
+  it('shows monitor age and drift count when report ready with anomalies', async () => {
+    const generatedAt = new Date().toISOString()
+    mockGetMonitorReport.mockResolvedValue({
+      enabled: true,
+      ready: true,
+      report: {
+        ...emptyMonitorBinding().report,
+        generatedAt,
+        anomalies: [{ id: 'a1', kind: 'stale' }, { id: 'a2', kind: 'orphan' }],
+      },
+    })
+    render(Orchestrator, { props: {} })
+    await vi.waitFor(() => {
+      expect(screen.getByText(/monitor:.*ago/)).toBeDefined()
+      expect(screen.getByText(/drift=2/)).toBeDefined()
+    })
+  })
+
+  it('shows triage agent running badge', () => {
     mockAgentList.push({ id: 'a1', name: 'triage:task-1', taskId: 'task-1', state: 'running', costUsd: 0 })
     render(Orchestrator, { props: {} })
     expect(screen.getByText('1 running')).toBeDefined()
+  })
+
+  it('shows eval agent running badge', () => {
+    mockAgentList.push({ id: 'a1', name: 'eval:task-1', taskId: 'task-1', state: 'running', costUsd: 0 })
+    render(Orchestrator, { props: {} })
+    expect(screen.getByText('1 running')).toBeDefined()
+  })
+
+  it('renders triage agent cards', () => {
+    mockAgentList.push(
+      { id: 'a1', name: 'triage:task-1', taskId: 'task-1', state: 'running', costUsd: 0.0001 },
+      { id: 'a2', name: 'triage:task-2', taskId: 'task-2', state: 'stopped', costUsd: 0 },
+    )
+    render(Orchestrator, { props: {} })
+    expect(screen.getByText('task-1')).toBeDefined()
+    expect(screen.getByText('task-2')).toBeDefined()
+    expect(screen.getByText('running')).toBeDefined()
+    expect(screen.getByText('stopped')).toBeDefined()
+  })
+
+  it('renders eval agent cards', () => {
+    mockAgentList.push(
+      { id: 'a1', name: 'eval:task-1', taskId: 'task-1', state: 'running', costUsd: 0.05 },
+    )
+    render(Orchestrator, { props: {} })
+    expect(screen.getByText('task-1')).toBeDefined()
+    expect(screen.getByText('$0.0500')).toBeDefined()
+  })
+
+  it('only shows triage cost when above zero', () => {
+    mockAgentList.push(
+      { id: 'a1', name: 'triage:task-1', taskId: 'task-1', state: 'stopped', costUsd: 0 },
+    )
+    render(Orchestrator, { props: {} })
+    expect(screen.queryByText('$0.0000')).toBeNull()
+  })
+
+  it('updates monitor binding when MonitorReport event fires', async () => {
+    render(Orchestrator, { props: {} })
+    await vi.waitFor(() => eventHandlers['monitor:report'])
+    eventHandlers['monitor:report']({
+      generatedAt: new Date().toISOString(),
+      counts: emptyMonitorBinding().report.counts,
+      anomalies: [{ id: 'a1', kind: 'stale' }],
+      remediated: [],
+      dispatched: [],
+      issuesOpened: 0,
+      issuesUpdated: 0,
+    })
+    await vi.waitFor(() => {
+      expect(screen.getByText(/drift=1/)).toBeDefined()
+    })
   })
 })

--- a/frontend/src/pages/ProjectDetail.svelte.test.ts
+++ b/frontend/src/pages/ProjectDetail.svelte.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/svelte'
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
 
 const mockGet = vi.fn()
 const mockRemove = vi.fn()
@@ -158,5 +158,171 @@ describe('ProjectDetail', () => {
       expect(mockRemove).toHaveBeenCalledWith('owner/repo')
       expect(onback).toHaveBeenCalled()
     })
+  })
+
+  it('renders project URL as external link', async () => {
+    mockGet.mockResolvedValue(mockProject)
+    render(ProjectDetail, {
+      props: { projectId: 'owner/repo', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => {
+      const link = screen.getByText('https://github.com/owner/repo') as HTMLAnchorElement
+      expect(link).toBeDefined()
+      expect(link.getAttribute('href')).toBe('https://github.com/owner/repo')
+      expect(link.getAttribute('target')).toBe('_blank')
+      expect(link.getAttribute('rel')).toBe('noopener')
+    })
+  })
+
+  it('renders clone path', async () => {
+    mockGet.mockResolvedValue(mockProject)
+    render(ProjectDetail, {
+      props: { projectId: 'owner/repo', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => {
+      expect(screen.getByText('/path/to/clone')).toBeDefined()
+    })
+  })
+
+  it('renders Created and Updated timestamps', async () => {
+    mockGet.mockResolvedValue(mockProject)
+    render(ProjectDetail, {
+      props: { projectId: 'owner/repo', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => {
+      expect(screen.getByText(/Created:/)).toBeDefined()
+      expect(screen.getByText(/Updated:/)).toBeDefined()
+    })
+  })
+
+  it('shows Switch to Work button when type is pet', async () => {
+    mockGet.mockResolvedValue({ ...mockProject, type: 'pet' })
+    render(ProjectDetail, {
+      props: { projectId: 'owner/repo', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => {
+      expect(screen.getByText('Switch to Work')).toBeDefined()
+    })
+  })
+
+  it('shows Switch to Pet button when type is work', async () => {
+    mockGet.mockResolvedValue({ ...mockProject, type: 'work' })
+    render(ProjectDetail, {
+      props: { projectId: 'owner/repo', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => {
+      expect(screen.getByText('Switch to Pet')).toBeDefined()
+    })
+  })
+
+  it('calls projectStore.update with toggled type when toggle clicked', async () => {
+    mockGet.mockResolvedValue({ ...mockProject, type: 'pet' })
+    mockUpdate.mockResolvedValue({ ...mockProject, type: 'work' })
+    render(ProjectDetail, {
+      props: { projectId: 'owner/repo', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => screen.getByText('Switch to Work'))
+    await fireEvent.click(screen.getByText('Switch to Work'))
+    await vi.waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith('owner/repo', 'work')
+    })
+  })
+
+  it('toggles from work to pet', async () => {
+    mockGet.mockResolvedValue({ ...mockProject, type: 'work' })
+    mockUpdate.mockResolvedValue({ ...mockProject, type: 'pet' })
+    render(ProjectDetail, {
+      props: { projectId: 'owner/repo', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => screen.getByText('Switch to Pet'))
+    await fireEvent.click(screen.getByText('Switch to Pet'))
+    await vi.waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith('owner/repo', 'pet')
+    })
+  })
+
+  it('surfaces error when type toggle fails', async () => {
+    mockGet.mockResolvedValue({ ...mockProject, type: 'pet' })
+    mockUpdate.mockRejectedValue(new Error('update failed'))
+    render(ProjectDetail, {
+      props: { projectId: 'owner/repo', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => screen.getByText('Switch to Work'))
+    await fireEvent.click(screen.getByText('Switch to Work'))
+    await vi.waitFor(() => {
+      expect(screen.getByText(/update failed/)).toBeDefined()
+    })
+  })
+
+  it('surfaces error when delete fails and resets deleting flag', async () => {
+    mockGet.mockResolvedValue(mockProject)
+    mockRemove.mockRejectedValue(new Error('delete failed'))
+    render(ProjectDetail, {
+      props: { projectId: 'owner/repo', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => screen.getByText('Delete'))
+    await fireEvent.click(screen.getByText('Delete'))
+    await vi.waitFor(() => {
+      expect(screen.getByText(/delete failed/)).toBeDefined()
+      expect(screen.getByText('Delete')).toBeDefined()
+    })
+  })
+
+  it('shows task count when project has tasks', async () => {
+    mockGet.mockResolvedValue(mockProject)
+    mockTaskList.push(
+      { id: 't1', projectId: 'owner/repo', status: 'todo', title: 'Task 1' },
+      { id: 't2', projectId: 'owner/repo', status: 'in-progress', title: 'Task 2' },
+      { id: 't3', projectId: 'other/repo', status: 'todo', title: 'Other' },
+    )
+    render(ProjectDetail, {
+      props: { projectId: 'owner/repo', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => {
+      expect(screen.getByText('Tasks (2)')).toBeDefined()
+    })
+  })
+
+  it('renders board columns when project has tasks', async () => {
+    mockGet.mockResolvedValue(mockProject)
+    mockTaskList.push({ id: 't1', projectId: 'owner/repo', status: 'todo', title: 'Task 1' })
+    render(ProjectDetail, {
+      props: { projectId: 'owner/repo', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => {
+      expect(screen.getByText('Todo')).toBeDefined()
+      expect(screen.getByText('In Progress')).toBeDefined()
+      expect(screen.getByText('In Review')).toBeDefined()
+      expect(screen.getByText('Testing')).toBeDefined()
+      expect(screen.getByText('Human Required')).toBeDefined()
+    })
+  })
+
+  it('filters out tasks not assigned to current project', async () => {
+    mockGet.mockResolvedValue(mockProject)
+    mockTaskList.push(
+      { id: 't1', projectId: 'other/repo', status: 'todo', title: 'Other' },
+    )
+    render(ProjectDetail, {
+      props: { projectId: 'owner/repo', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => {
+      expect(screen.getByText('No tasks assigned to this project')).toBeDefined()
+    })
+  })
+
+  it('disables Delete button while deleting', async () => {
+    mockGet.mockResolvedValue(mockProject)
+    let resolveRemove: () => void = () => {}
+    mockRemove.mockReturnValue(new Promise<void>((res) => { resolveRemove = res }))
+    render(ProjectDetail, {
+      props: { projectId: 'owner/repo', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => screen.getByText('Delete'))
+    await fireEvent.click(screen.getByText('Delete'))
+    await vi.waitFor(() => {
+      expect(screen.getByText('Deleting...')).toBeDefined()
+    })
+    resolveRemove()
   })
 })

--- a/frontend/src/pages/TaskList.svelte.test.ts
+++ b/frontend/src/pages/TaskList.svelte.test.ts
@@ -33,6 +33,7 @@ vi.mock('../components/shell/MobileSheet.svelte', () => ({ default: () => {} }))
 const { taskStore } = await import('../stores/tasks.svelte.js')
 const { projectStore } = await import('../stores/projects.svelte.js')
 const { notificationStore } = await import('../stores/notifications.svelte.js')
+const { viewModeStore } = await import('../lib/view-mode.svelte.js')
 const TaskList = (await import('./TaskList.svelte')).default
 
 const mockTask = (id: string, title: string, status = 'todo') => ({
@@ -54,6 +55,7 @@ describe('TaskList', () => {
     Object.assign(taskStore, { loading: false, error: '', list: [], tasks: new Map(), create: vi.fn(), update: vi.fn() })
     Object.assign(projectStore, { list: [] })
     vi.mocked(notificationStore.pushLocal).mockClear()
+    viewModeStore.set('board')
   })
 
   afterEach(() => {
@@ -210,6 +212,68 @@ describe('TaskList', () => {
       Object.assign(projectStore, { list: [] })
       render(TaskList, { props: { onselect: vi.fn() } })
       expect(screen.queryByText('All projects')).toBeNull()
+    })
+  })
+
+  describe('agent mode filter chip', () => {
+    it('renders All, Headless, Interactive buttons', () => {
+      render(TaskList, { props: { onselect: vi.fn() } })
+      expect(screen.getByText('All')).toBeDefined()
+      expect(screen.getByText('Headless')).toBeDefined()
+      expect(screen.getByText('Interactive')).toBeDefined()
+    })
+  })
+
+  describe('clear filters', () => {
+    it('does not show Clear filters when no filters active', () => {
+      render(TaskList, { props: { onselect: vi.fn() } })
+      expect(screen.queryByText('Clear filters')).toBeNull()
+    })
+  })
+
+  describe('done column visibility', () => {
+    it('hides Done column by default', () => {
+      render(TaskList, { props: { onselect: vi.fn() } })
+      expect(screen.queryByText(/^Done$/)).toBeNull()
+    })
+  })
+
+  describe('mobile filter trigger', () => {
+    it('renders mobile filters button', () => {
+      render(TaskList, { props: { onselect: vi.fn() } })
+      expect(screen.getByLabelText('Filters')).toBeDefined()
+    })
+
+    it('renders mobile search input', () => {
+      render(TaskList, { props: { onselect: vi.fn() } })
+      const inputs = screen.getAllByPlaceholderText('Search tasks...')
+      expect(inputs.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('optional callbacks', () => {
+    it('does not crash when onnewTask is omitted', () => {
+      render(TaskList, { props: { onselect: vi.fn() } })
+      expect(screen.getByText('Todo')).toBeDefined()
+    })
+
+    it('does not crash when onfocusedtaskchange is omitted', () => {
+      render(TaskList, { props: { onselect: vi.fn() } })
+      expect(screen.getByText('Todo')).toBeDefined()
+    })
+  })
+
+  describe('hint bar', () => {
+    it('does not render hint bar when no task focused', () => {
+      render(TaskList, { props: { onselect: vi.fn() } })
+      expect(screen.queryByText('open')).toBeNull()
+    })
+  })
+
+  describe('filter prop', () => {
+    it('renders without error when filter=in-progress is passed', () => {
+      render(TaskList, { props: { onselect: vi.fn(), filter: 'in-progress' } })
+      expect(screen.getByText('Todo')).toBeDefined()
     })
   })
 })


### PR DESCRIPTION
## Motivation

Implements the body of issue #782 (frontend test coverage). The issue title was a
duplicate of #791 (nilaway — already CLOSED, #802 fixed the baseline) but the
body asked for deeper happy-path tests on ProjectDetail, AgentDetail,
Orchestrator, with TaskList refactor already landed in earlier PRs.

Closes #782.

## Implementation information

Targeted four page tests:

- **ProjectDetail** — 9 → 22 tests. Added type toggle (work↔pet), error
  paths for delete and update, URL/clone-path/dates rendering, task count
  + board columns when tasks are assigned, deleting-state flag.
- **AgentDetail** — 7 → 24 tests. Added stop button + error path, escalation
  banner for turns and cost, Continue/Kill flows (incl. error-on-Kill
  dismissal for cost), plugin errors banner with singular/plural label and
  Dismiss, cached error seed, agentError event-driven banner, agentState
  update propagation, back-button onback. Capture handlers from EventsOn
  so tests can drive event channels.
- **Orchestrator** — 9 → 25 tests. Added Start/Stop click flows + error
  paths, OrchestratorState event toggling, MonitorReport event +
  drift-count rendering, monitor disabled/waiting branches, triage/eval
  agent card rendering with cost gating.
- **TaskList** — 16 → 23 tests. Added agent-mode filter chips, Clear
  Filters absence, mobile filter trigger/search, hint-bar absence,
  filter=in-progress prop smoke test, optional-callback safety.

Reactivity-dependent tests (post-click filter, post-click view switch,
hover-driven focus) were dropped after they proved flaky against the
plain-object store mocks — coverage win wasn't worth the false negatives.
Two follow-up PRs will tackle the remaining mid-size pages (Reviews,
GitHub, Loops, WorkflowDetail, Settings, Stats) and bump the
\`vite.config.ts\` coverage thresholds toward 80% once the floor is high
enough to not break CI.

All 1255 frontend tests pass. svelte-check clean. oxlint clean (2 pre-existing warnings unchanged).

## Supporting documentation

- Issue: #782
- Umbrella: #781
- Plan: /Users/marcin.skalski/.claude/plans/implem-https-github-com-automaat-sybra-i-majestic-mochi.md

> Changelog: test(frontend): expand page coverage