### PR TITLE
test(frontend): expand mid-size page coverage

### DIFF
--- a/frontend/src/pages/GitHub.svelte.test.ts
+++ b/frontend/src/pages/GitHub.svelte.test.ts
@@ -133,4 +133,150 @@ describe('GitHub', () => {
     await fireEvent.click(screen.getByText('Renovate'))
     expect(screen.getByText('No Renovate PRs')).toBeDefined()
   })
+
+  it('switches to Issues tab', async () => {
+    render(GitHub, { props: {} })
+    await fireEvent.click(screen.getByText('Issues'))
+    expect(screen.getByText('No assigned issues')).toBeDefined()
+  })
+
+  it('shows Loading state on My PRs while loading', () => {
+    mockReviewStore.loading = true
+    render(GitHub, { props: {} })
+    expect(screen.getByText('Loading...')).toBeDefined()
+  })
+
+  it('shows Loading state on Renovate tab while loading', async () => {
+    mockRenovateStore.loading = true
+    render(GitHub, { props: {} })
+    await fireEvent.click(screen.getByText('Renovate'))
+    expect(screen.getByText('Loading...')).toBeDefined()
+  })
+
+  it('shows error and Retry button when Renovate fails', async () => {
+    mockRenovateStore.error = 'rate-limited'
+    render(GitHub, { props: {} })
+    await fireEvent.click(screen.getByText('Renovate'))
+    expect(screen.getByText('Failed to load Renovate PRs')).toBeDefined()
+    expect(screen.getByText('rate-limited')).toBeDefined()
+    expect(screen.getByText('Retry')).toBeDefined()
+  })
+
+  it('clicking Retry on Renovate calls renovateStore.load', async () => {
+    mockRenovateStore.error = 'rate-limited'
+    render(GitHub, { props: {} })
+    await fireEvent.click(screen.getByText('Renovate'))
+    mockRenovateLoad.mockClear()
+    await fireEvent.click(screen.getByText('Retry'))
+    expect(mockRenovateLoad).toHaveBeenCalled()
+  })
+
+  it('shows issue store error on Issues tab', async () => {
+    mockIssueStore.error = 'github 401'
+    render(GitHub, { props: {} })
+    await fireEvent.click(screen.getByText('Issues'))
+    expect(screen.getByText('github 401')).toBeDefined()
+  })
+
+  it('clicking Refresh on My PRs calls reviewStore.load', async () => {
+    render(GitHub, { props: {} })
+    mockLoad.mockClear()
+    await fireEvent.click(screen.getByText('Refresh'))
+    expect(mockLoad).toHaveBeenCalled()
+  })
+
+  it('clicking Refresh on Renovate tab calls renovateStore.load', async () => {
+    render(GitHub, { props: {} })
+    await fireEvent.click(screen.getByText('Renovate'))
+    mockRenovateLoad.mockClear()
+    await fireEvent.click(screen.getByText('Refresh'))
+    expect(mockRenovateLoad).toHaveBeenCalled()
+  })
+
+  it('clicking Refresh on Issues tab calls issueStore.load', async () => {
+    render(GitHub, { props: {} })
+    await fireEvent.click(screen.getByText('Issues'))
+    vi.mocked(mockIssueStore.load).mockClear()
+    await fireEvent.click(screen.getByText('Refresh'))
+    expect(mockIssueStore.load).toHaveBeenCalled()
+  })
+
+  it('shows tab badge count when PRs are present', () => {
+    mockReviewStore.createdByMe = [
+      { url: 'u1', repository: 'owner/repo', number: 1, title: 'PR1' } as unknown as PullRequest,
+      { url: 'u2', repository: 'owner/repo', number: 2, title: 'PR2' } as unknown as PullRequest,
+    ]
+    render(GitHub, { props: {} })
+    expect(screen.getByText('2')).toBeDefined()
+  })
+
+  it('groups My PRs by repository', () => {
+    mockReviewStore.createdByMe = [
+      { url: 'u1', repository: 'org/a', number: 1, title: 'A1', isDraft: false, mergeable: 'MERGEABLE', ciStatus: 'SUCCESS', reviewDecision: 'APPROVED' } as unknown as PullRequest,
+      { url: 'u2', repository: 'org/b', number: 2, title: 'B1', isDraft: false, mergeable: 'MERGEABLE', ciStatus: 'SUCCESS', reviewDecision: 'APPROVED' } as unknown as PullRequest,
+    ]
+    render(GitHub, { props: {} })
+    expect(screen.getByText('org/a')).toBeDefined()
+    expect(screen.getByText('org/b')).toBeDefined()
+  })
+
+  it('shows Renovate search input on Renovate tab', async () => {
+    render(GitHub, { props: {} })
+    await fireEvent.click(screen.getByText('Renovate'))
+    expect(screen.getByPlaceholderText(/Search by repo/)).toBeDefined()
+  })
+
+  it('filters Renovate PRs by search query', async () => {
+    mockRenovateStore.prs = [
+      { url: 'u1', repository: 'org/match', number: 1, title: 'Update foo', labels: ['deps'] } as unknown as RenovatePR,
+      { url: 'u2', repository: 'org/other', number: 2, title: 'Update bar', labels: ['deps'] } as unknown as RenovatePR,
+    ]
+    render(GitHub, { props: {} })
+    await fireEvent.click(screen.getByText('Renovate'))
+    const input = screen.getByPlaceholderText(/Search by repo/)
+    await fireEvent.input(input, { target: { value: 'match' } })
+    await vi.waitFor(() => {
+      expect(screen.getByText('org/match')).toBeDefined()
+      expect(screen.queryByText('org/other')).toBeNull()
+    })
+  })
+
+  it('shows no-match message when Renovate search has no results', async () => {
+    mockRenovateStore.prs = [
+      { url: 'u1', repository: 'org/foo', number: 1, title: 'Update foo', labels: [] } as unknown as RenovatePR,
+    ]
+    render(GitHub, { props: {} })
+    await fireEvent.click(screen.getByText('Renovate'))
+    const input = screen.getByPlaceholderText(/Search by repo/)
+    await fireEvent.input(input, { target: { value: 'nomatchatall' } })
+    await vi.waitFor(() => {
+      expect(screen.getByText(/No matches for "nomatchatall"/)).toBeDefined()
+    })
+  })
+
+  it('Escape in Renovate search clears query', async () => {
+    render(GitHub, { props: {} })
+    await fireEvent.click(screen.getByText('Renovate'))
+    const input = screen.getByPlaceholderText(/Search by repo/) as HTMLInputElement
+    await fireEvent.input(input, { target: { value: 'query' } })
+    expect(input.value).toBe('query')
+    await fireEvent.keyDown(input, { key: 'Escape' })
+    await vi.waitFor(() => {
+      expect(input.value).toBe('')
+    })
+  })
+
+  it('stops polling on unmount', () => {
+    const { unmount } = render(GitHub, { props: {} })
+    unmount()
+    expect(mockStopPolling).toHaveBeenCalled()
+  })
+
+  it('responds to focus-renovate-search window event by switching to Renovate tab', async () => {
+    render(GitHub, { props: {} })
+    window.dispatchEvent(new CustomEvent('focus-renovate-search'))
+    await vi.waitFor(() => {
+      expect(screen.getByPlaceholderText(/Search by repo/)).toBeDefined()
+    })
+  })
 })

--- a/frontend/src/pages/Loops.svelte.test.ts
+++ b/frontend/src/pages/Loops.svelte.test.ts
@@ -168,4 +168,125 @@ describe('Loops', () => {
     render(Loops)
     expect(screen.getByText('last: never')).toBeDefined()
   })
+
+  it('formats interval in days for >=86400 seconds', () => {
+    Object.assign(loopStore, { list: [makeLoop({ intervalSec: 86400 })] })
+    render(Loops)
+    expect(screen.getByText('every 1d')).toBeDefined()
+  })
+
+  it('formats interval in minutes for sub-hour values', () => {
+    Object.assign(loopStore, { list: [makeLoop({ intervalSec: 300 })] })
+    render(Loops)
+    expect(screen.getByText('every 5m')).toBeDefined()
+  })
+
+  it('formats interval in seconds for sub-minute values', () => {
+    Object.assign(loopStore, { list: [makeLoop({ intervalSec: 30 })] })
+    render(Loops)
+    expect(screen.getByText('every 30s')).toBeDefined()
+  })
+
+  it('shows "just now" for very recent lastRunAt', () => {
+    Object.assign(loopStore, {
+      list: [makeLoop({ lastRunAt: new Date(Date.now() - 5_000).toISOString() })],
+    })
+    render(Loops)
+    expect(screen.getByText('last: just now')).toBeDefined()
+  })
+
+  it('shows minutes-ago for recent lastRunAt', () => {
+    Object.assign(loopStore, {
+      list: [makeLoop({ lastRunAt: new Date(Date.now() - 5 * 60_000).toISOString() })],
+    })
+    render(Loops)
+    expect(screen.getByText('last: 5m ago')).toBeDefined()
+  })
+
+  it('shows hours-ago for older lastRunAt', () => {
+    Object.assign(loopStore, {
+      list: [makeLoop({ lastRunAt: new Date(Date.now() - 3 * 3600_000).toISOString() })],
+    })
+    render(Loops)
+    expect(screen.getByText('last: 3h ago')).toBeDefined()
+  })
+
+  it('shows days-ago for much older lastRunAt', () => {
+    Object.assign(loopStore, {
+      list: [makeLoop({ lastRunAt: new Date(Date.now() - 2 * 86400_000).toISOString() })],
+    })
+    render(Loops)
+    expect(screen.getByText('last: 2d ago')).toBeDefined()
+  })
+
+  it('calls loopStore.update with toggled enabled when Pause clicked', async () => {
+    mockUpdate.mockResolvedValue(undefined)
+    Object.assign(loopStore, { list: [makeLoop({ id: 'lp', enabled: true })] })
+    render(Loops)
+    await fireEvent.click(screen.getByText('Pause'))
+    expect(mockUpdate).toHaveBeenCalled()
+    const arg = mockUpdate.mock.calls[0][0]
+    expect(arg.enabled).toBe(false)
+  })
+
+  it('calls loopStore.update with enabled=true when Enable clicked', async () => {
+    mockUpdate.mockResolvedValue(undefined)
+    Object.assign(loopStore, { list: [makeLoop({ id: 'lp', enabled: false })] })
+    render(Loops)
+    await fireEvent.click(screen.getByText('Enable'))
+    expect(mockUpdate).toHaveBeenCalled()
+    const arg = mockUpdate.mock.calls[0][0]
+    expect(arg.enabled).toBe(true)
+  })
+
+  it('sets store error when runNow rejects', async () => {
+    mockRunNow.mockRejectedValue(new Error('run failed'))
+    Object.assign(loopStore, { list: [makeLoop({ id: 'lp' })] })
+    render(Loops)
+    await fireEvent.click(screen.getByText('Run now'))
+    await vi.waitFor(() => {
+      expect(loopStore.error).toContain('run failed')
+    })
+  })
+
+  it('sets store error when remove rejects', async () => {
+    mockRemove.mockRejectedValue(new Error('delete failed'))
+    Object.assign(loopStore, { list: [makeLoop({ id: 'lp' })] })
+    render(Loops)
+    await fireEvent.click(screen.getByText('Delete'))
+    await vi.waitFor(() => {
+      expect(loopStore.error).toContain('delete failed')
+    })
+  })
+
+  it('subscribes to LoopAgentUpdated event on mount', () => {
+    render(Loops)
+    expect(mockEventsOn).toHaveBeenCalledWith('loopagent:updated', expect.any(Function))
+  })
+
+  it('shows model badge when set', () => {
+    Object.assign(loopStore, { list: [makeLoop({ model: 'opus' })] })
+    render(Loops)
+    expect(screen.getByText('opus')).toBeDefined()
+  })
+
+  it('shows prompt text', () => {
+    Object.assign(loopStore, { list: [makeLoop({ prompt: '/check-deploys' })] })
+    render(Loops)
+    expect(screen.getByText('/check-deploys')).toBeDefined()
+  })
+
+  it('renders multiple loops independently', () => {
+    Object.assign(loopStore, {
+      list: [
+        makeLoop({ id: 'l1', name: 'one' }),
+        makeLoop({ id: 'l2', name: 'two', enabled: false }),
+      ],
+    })
+    render(Loops)
+    expect(screen.getByText('one')).toBeDefined()
+    expect(screen.getByText('two')).toBeDefined()
+    expect(screen.getByText('active')).toBeDefined()
+    expect(screen.getByText('paused')).toBeDefined()
+  })
 })

--- a/frontend/src/pages/Reviews.svelte.test.ts
+++ b/frontend/src/pages/Reviews.svelte.test.ts
@@ -248,4 +248,201 @@ describe('Reviews', () => {
     render(Reviews)
     expect(screen.getByText('3')).toBeDefined()
   })
+
+  it('shows projectId in sidebar when set', () => {
+    const task = makeTask({ id: 't1', title: 'Scoped task', projectId: 'owner/repo' })
+    mockByStatus.mockImplementation((status: string) => {
+      if (status === 'plan-review') return [task]
+      return []
+    })
+    render(Reviews)
+    expect(screen.getByText('owner/repo')).toBeDefined()
+  })
+
+  it('shows View Task button when onviewtask is passed', async () => {
+    const task = makeTask({ id: 't1', title: 'Linkable task' })
+    mockByStatus.mockImplementation((status: string) => {
+      if (status === 'plan-review') return [task]
+      return []
+    })
+    taskItemsMap.set('t1', task)
+    const onviewtask = vi.fn()
+    render(Reviews, { props: { onviewtask } })
+    await fireEvent.click(screen.getByText('Linkable task'))
+    await vi.waitFor(() => {
+      expect(screen.getByText('View Task →')).toBeDefined()
+    })
+    await fireEvent.click(screen.getByText('View Task →'))
+    expect(onviewtask).toHaveBeenCalledWith('t1')
+  })
+
+  it('renders Send Message button (disabled until feedback and live agent)', async () => {
+    const task = makeTask({ id: 't1', title: 'Send target' })
+    mockByStatus.mockImplementation((status: string) => {
+      if (status === 'plan-review') return [task]
+      return []
+    })
+    taskItemsMap.set('t1', task)
+    mockHasLivePlanAgent.mockResolvedValue(false)
+    render(Reviews)
+    await fireEvent.click(screen.getByText('Send target'))
+    await vi.waitFor(() => {
+      expect(screen.getByText('Send Message')).toBeDefined()
+    })
+  })
+
+  it('calls sendPlanMessage when Send Message clicked with live agent and feedback', async () => {
+    const task = makeTask({ id: 't1', title: 'Live agent task' })
+    mockByStatus.mockImplementation((status: string) => {
+      if (status === 'plan-review') return [task]
+      return []
+    })
+    taskItemsMap.set('t1', task)
+    mockHasLivePlanAgent.mockResolvedValue(true)
+    mockSendPlanMessage.mockResolvedValue(undefined)
+    render(Reviews)
+    await fireEvent.click(screen.getByText('Live agent task'))
+    await vi.waitFor(() => screen.getByPlaceholderText(/Rejection feedback/))
+    const textarea = screen.getByPlaceholderText(/Rejection feedback/)
+    await fireEvent.input(textarea, { target: { value: 'tighten section 3' } })
+    await fireEvent.click(screen.getByText('Send Message'))
+    await vi.waitFor(() => {
+      expect(mockSendPlanMessage).toHaveBeenCalledWith('t1', 'tighten section 3')
+    })
+  })
+
+  it('calls approveTestPlan for test-plan-review tasks', async () => {
+    const task = makeTask({ id: 't1', title: 'Test plan task', status: 'test-plan-review' })
+    mockByStatus.mockImplementation((status: string) => {
+      if (status === 'test-plan-review') return [task]
+      return []
+    })
+    taskItemsMap.set('t1', task)
+    mockApproveTestPlan.mockResolvedValue(undefined)
+    render(Reviews)
+    await fireEvent.click(screen.getByText('Test plan task'))
+    await vi.waitFor(() => screen.getByText('Approve'))
+    await fireEvent.click(screen.getByText('Approve'))
+    await vi.waitFor(() => {
+      expect(mockApproveTestPlan).toHaveBeenCalledWith('t1')
+    })
+  })
+
+  it('calls rejectTestPlan with feedback for test-plan-review tasks', async () => {
+    const task = makeTask({ id: 't1', title: 'Test reject', status: 'test-plan-review' })
+    mockByStatus.mockImplementation((status: string) => {
+      if (status === 'test-plan-review') return [task]
+      return []
+    })
+    taskItemsMap.set('t1', task)
+    mockRejectTestPlan.mockResolvedValue(undefined)
+    render(Reviews)
+    await fireEvent.click(screen.getByText('Test reject'))
+    await vi.waitFor(() => screen.getByPlaceholderText(/Rejection feedback/))
+    const textarea = screen.getByPlaceholderText(/Rejection feedback/)
+    await fireEvent.input(textarea, { target: { value: 'missing edge case' } })
+    await fireEvent.click(screen.getByText('Reject'))
+    await vi.waitFor(() => {
+      expect(mockRejectTestPlan).toHaveBeenCalledWith('t1', 'missing edge case')
+    })
+  })
+
+  it('renders Plan Critique section when planCritique is present', async () => {
+    const task = makeTask({
+      id: 't1',
+      title: 'Critiqued task',
+      planCritique: 'Plan needs more detail on auth',
+    })
+    mockByStatus.mockImplementation((status: string) => {
+      if (status === 'plan-review') return [task]
+      return []
+    })
+    taskItemsMap.set('t1', task)
+    render(Reviews)
+    await fireEvent.click(screen.getByText('Critiqued task'))
+    await vi.waitFor(() => {
+      expect(screen.getByText('Plan Critique (auto-review)')).toBeDefined()
+    })
+  })
+
+  it('shows error message when reject fails', async () => {
+    const task = makeTask({ id: 't1', title: 'Reject fails' })
+    mockByStatus.mockImplementation((status: string) => {
+      if (status === 'plan-review') return [task]
+      return []
+    })
+    taskItemsMap.set('t1', task)
+    mockRejectPlan.mockRejectedValue(new Error('reject error'))
+    render(Reviews)
+    await fireEvent.click(screen.getByText('Reject fails'))
+    await vi.waitFor(() => screen.getByText('Reject'))
+    await fireEvent.click(screen.getByText('Reject'))
+    await vi.waitFor(() => {
+      expect(screen.getByText(/reject error/)).toBeDefined()
+    })
+  })
+
+  it('shows unresolved comments banner in detail panel when count > 0', async () => {
+    const task = makeTask({ id: 't1', title: 'Commented' })
+    mockByStatus.mockImplementation((status: string) => {
+      if (status === 'plan-review') return [task]
+      return []
+    })
+    taskItemsMap.set('t1', task)
+    mockUnresolvedCount.mockReturnValue(2)
+    render(Reviews)
+    await fireEvent.click(screen.getByText('Commented'))
+    await vi.waitFor(() => {
+      expect(screen.getByText(/2 unresolved comments/)).toBeDefined()
+    })
+  })
+
+  it('uses singular comment label when only one unresolved', async () => {
+    const task = makeTask({ id: 't1', title: 'One comment' })
+    mockByStatus.mockImplementation((status: string) => {
+      if (status === 'plan-review') return [task]
+      return []
+    })
+    taskItemsMap.set('t1', task)
+    mockUnresolvedCount.mockReturnValue(1)
+    render(Reviews)
+    await fireEvent.click(screen.getByText('One comment'))
+    await vi.waitFor(() => {
+      expect(screen.getByText(/1 unresolved comment$/)).toBeDefined()
+    })
+  })
+
+  it('approve "a" keypress triggers plan approval', async () => {
+    const task = makeTask({ id: 't1', title: 'Keyboard task' })
+    mockByStatus.mockImplementation((status: string) => {
+      if (status === 'plan-review') return [task]
+      return []
+    })
+    taskItemsMap.set('t1', task)
+    mockApprovePlan.mockResolvedValue(undefined)
+    render(Reviews)
+    await fireEvent.click(screen.getByText('Keyboard task'))
+    await vi.waitFor(() => screen.getByText('Approve'))
+    await fireEvent.keyDown(window, { key: 'a' })
+    await vi.waitFor(() => {
+      expect(mockApprovePlan).toHaveBeenCalledWith('t1')
+    })
+  })
+
+  it('reject "r" keypress triggers plan rejection', async () => {
+    const task = makeTask({ id: 't1', title: 'Reject keyboard' })
+    mockByStatus.mockImplementation((status: string) => {
+      if (status === 'plan-review') return [task]
+      return []
+    })
+    taskItemsMap.set('t1', task)
+    mockRejectPlan.mockResolvedValue(undefined)
+    render(Reviews)
+    await fireEvent.click(screen.getByText('Reject keyboard'))
+    await vi.waitFor(() => screen.getByText('Reject'))
+    await fireEvent.keyDown(window, { key: 'r' })
+    await vi.waitFor(() => {
+      expect(mockRejectPlan).toHaveBeenCalledWith('t1', '')
+    })
+  })
 })

--- a/frontend/src/pages/Settings.svelte.test.ts
+++ b/frontend/src/pages/Settings.svelte.test.ts
@@ -234,4 +234,156 @@ describe('Settings', () => {
       expect(screen.getByText('Providers')).toBeDefined()
     })
   })
+
+  it('renders Color Scheme options (system, light, dark)', () => {
+    mockGetSettings.mockReturnValue(new Promise(() => {}))
+    render(Settings)
+    expect(screen.getByText('System')).toBeDefined()
+    expect(screen.getByText('Light')).toBeDefined()
+    expect(screen.getByText('Dark')).toBeDefined()
+  })
+
+  it('persists colorScheme to localStorage when changed', async () => {
+    mockGetSettings.mockReturnValue(new Promise(() => {}))
+    render(Settings)
+    const select = screen.getByLabelText('Color Scheme') as HTMLSelectElement
+    await fireEvent.change(select, { target: { value: 'dark' } })
+    await vi.waitFor(() => {
+      expect(localStorage.getItem('colorScheme')).toBe('dark')
+    })
+  })
+
+  it('toggles dark class on html when dark selected', async () => {
+    mockGetSettings.mockReturnValue(new Promise(() => {}))
+    render(Settings)
+    const select = screen.getByLabelText('Color Scheme') as HTMLSelectElement
+    await fireEvent.change(select, { target: { value: 'dark' } })
+    await vi.waitFor(() => {
+      expect(document.documentElement.classList.contains('dark')).toBe(true)
+    })
+    await fireEvent.change(select, { target: { value: 'light' } })
+    await vi.waitFor(() => {
+      expect(document.documentElement.classList.contains('dark')).toBe(false)
+    })
+  })
+
+  it('Reset button appears when settings are dirty', async () => {
+    mockGetSettings.mockResolvedValue({ ...mockSettings })
+    render(Settings)
+    await vi.waitFor(() => screen.getByLabelText('Max Concurrent'))
+    const concurrencyInput = screen.getByLabelText('Max Concurrent') as HTMLInputElement
+    await fireEvent.input(concurrencyInput, { target: { value: '7' } })
+    await vi.waitFor(() => {
+      expect(screen.getByText('Reset')).toBeDefined()
+    })
+  })
+
+  it('Reset button reverts pending changes', async () => {
+    mockGetSettings.mockResolvedValue({ ...mockSettings })
+    render(Settings)
+    await vi.waitFor(() => screen.getByLabelText('Max Concurrent'))
+    const concurrencyInput = screen.getByLabelText('Max Concurrent') as HTMLInputElement
+    await fireEvent.input(concurrencyInput, { target: { value: '7' } })
+    await vi.waitFor(() => screen.getByText('Reset'))
+    await fireEvent.click(screen.getByText('Reset'))
+    await vi.waitFor(() => {
+      const after = screen.getByLabelText('Max Concurrent') as HTMLInputElement
+      expect(after.value).toBe('3')
+    })
+  })
+
+  it('renders Save and Reset only one button initially (Save)', async () => {
+    mockGetSettings.mockResolvedValue({ ...mockSettings })
+    render(Settings)
+    await vi.waitFor(() => screen.getByText('Agent Defaults'))
+    expect(screen.getByText('Save')).toBeDefined()
+    expect(screen.queryByText('Reset')).toBeNull()
+  })
+
+  it('shows server version after GetVersion resolves', async () => {
+    mockGetSettings.mockResolvedValue({ ...mockSettings })
+    mockGetVersion.mockResolvedValue({ server: 'v2.7.0', client: 'v2.7.0' })
+    render(Settings)
+    await vi.waitFor(() => {
+      expect(screen.getByText('v2.7.0')).toBeDefined()
+    })
+  })
+
+  it('shows unavailable when GetVersion rejects', async () => {
+    mockGetSettings.mockResolvedValue({ ...mockSettings })
+    mockGetVersion.mockRejectedValue(new Error('no version'))
+    render(Settings)
+    await vi.waitFor(() => {
+      expect(screen.getByText('unavailable')).toBeDefined()
+    })
+  })
+
+  it('renders directories list for known dir keys', async () => {
+    mockGetSettings.mockResolvedValue({ ...mockSettings })
+    render(Settings)
+    await vi.waitFor(() => {
+      expect(screen.getByText('Directories')).toBeDefined()
+      expect(screen.getByDisplayValue('/home/.sybra/tasks')).toBeDefined()
+      expect(screen.getByDisplayValue('/home/.sybra/skills')).toBeDefined()
+    })
+  })
+
+  it('toggles desktop notifications checkbox', async () => {
+    mockGetSettings.mockResolvedValue({ ...mockSettings })
+    render(Settings)
+    await vi.waitFor(() => screen.getByText('Notifications'))
+    const checkbox = screen.getByLabelText('Desktop notifications (macOS)') as HTMLInputElement
+    expect(checkbox.checked).toBe(false)
+    await fireEvent.click(checkbox)
+    await vi.waitFor(() => {
+      expect(checkbox.checked).toBe(true)
+    })
+  })
+
+  it('toggles autoTriage', async () => {
+    mockGetSettings.mockResolvedValue({ ...mockSettings })
+    render(Settings)
+    await vi.waitFor(() => screen.getByText('Auto-triage'))
+    const label = screen.getByText('Auto-triage').closest('label')
+    const checkbox = label?.querySelector('input[type="checkbox"]') as HTMLInputElement
+    expect(checkbox.checked).toBe(false)
+    await fireEvent.click(checkbox)
+    await vi.waitFor(() => {
+      expect(checkbox.checked).toBe(true)
+    })
+  })
+
+  it('switches model options when provider changes to codex', async () => {
+    mockGetSettings.mockResolvedValue({ ...mockSettings })
+    mockGetCodexModels.mockResolvedValue([
+      { slug: 'gpt-5.4', display_name: 'GPT-5.4' },
+    ])
+    render(Settings)
+    await vi.waitFor(() => screen.getByLabelText('Agent Type'))
+    const providerSelect = screen.getByLabelText('Agent Type') as HTMLSelectElement
+    await fireEvent.change(providerSelect, { target: { value: 'codex' } })
+    await vi.waitFor(() => {
+      expect(screen.getByText('GPT-5.4')).toBeDefined()
+    })
+  })
+
+  it('clears success message after save', async () => {
+    vi.useFakeTimers()
+    try {
+      mockGetSettings.mockResolvedValue({ ...mockSettings })
+      mockUpdateSettings.mockResolvedValue(undefined)
+      render(Settings)
+      await vi.waitFor(() => screen.getByLabelText('Max Concurrent'))
+      const concurrencyInput = screen.getByLabelText('Max Concurrent') as HTMLInputElement
+      await fireEvent.input(concurrencyInput, { target: { value: '5' } })
+      await fireEvent.click(screen.getByText('Save'))
+      await vi.waitFor(() => screen.getByText('Settings saved'))
+      vi.advanceTimersByTime(3001)
+      await vi.waitFor(() => {
+        expect(screen.queryByText('Settings saved')).toBeNull()
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/frontend/src/pages/Stats.svelte.test.ts
+++ b/frontend/src/pages/Stats.svelte.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/svelte'
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
 import { StatsResponse, Summary } from '../../bindings/github.com/Automaat/sybra/internal/stats/models.js'
 
 const mockLoad = vi.fn()
@@ -148,5 +148,168 @@ describe('Stats', () => {
     mockStatsStore.data = makeStatsData()
     render(Stats, { props: {} })
     expect(screen.getByText('5.0K / 2.0K')).toBeDefined()
+  })
+
+  it('formats tokens in millions for >=1M', () => {
+    const s = makeSummary({ totalInputTokens: 2_500_000, totalOutputTokens: 1_200_000 })
+    mockStatsStore.data = StatsResponse.createFrom({
+      today: s, thisWeek: s, thisMonth: s, allTime: s,
+      byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      recentRuns: [],
+    })
+    render(Stats, { props: {} })
+    expect(screen.getByText('2.5M / 1.2M')).toBeDefined()
+  })
+
+  it('formats tokens raw for <1K', () => {
+    const s = makeSummary({ totalInputTokens: 500, totalOutputTokens: 200 })
+    mockStatsStore.data = StatsResponse.createFrom({
+      today: s, thisWeek: s, thisMonth: s, allTime: s,
+      byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      recentRuns: [],
+    })
+    render(Stats, { props: {} })
+    expect(screen.getByText('500 / 200')).toBeDefined()
+  })
+
+  it('formats duration in seconds for <60s', () => {
+    const s = makeSummary({ totalDurationS: 45 })
+    mockStatsStore.data = StatsResponse.createFrom({
+      today: s, thisWeek: s, thisMonth: s, allTime: s,
+      byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      recentRuns: [],
+    })
+    render(Stats, { props: {} })
+    expect(screen.getByText('45s')).toBeDefined()
+  })
+
+  it('formats duration in minutes for <3600s', () => {
+    const s = makeSummary({ totalDurationS: 600 })
+    mockStatsStore.data = StatsResponse.createFrom({
+      today: s, thisWeek: s, thisMonth: s, allTime: s,
+      byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      recentRuns: [],
+    })
+    render(Stats, { props: {} })
+    expect(screen.getByText('10.0m')).toBeDefined()
+  })
+
+  it('shows reasoning tokens when set', () => {
+    const s = makeSummary({ totalReasoningTokens: 1500 })
+    mockStatsStore.data = StatsResponse.createFrom({
+      today: s, thisWeek: s, thisMonth: s, allTime: s,
+      byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      recentRuns: [],
+    })
+    render(Stats, { props: {} })
+    expect(screen.getByText('1.5K reasoning')).toBeDefined()
+  })
+
+  it('switches period when tab clicked', async () => {
+    const today = makeSummary({ totalCostUsd: 0.5, totalRuns: 2 })
+    const allTime = makeSummary({ totalCostUsd: 50, totalRuns: 200 })
+    mockStatsStore.data = StatsResponse.createFrom({
+      today, thisWeek: allTime, thisMonth: allTime, allTime,
+      byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      recentRuns: [],
+    })
+    render(Stats, { props: {} })
+    expect(screen.getByText('$50.00')).toBeDefined()
+    await fireEvent.click(screen.getByText('Today'))
+    await vi.waitFor(() => {
+      expect(screen.getByText('$0.50')).toBeDefined()
+    })
+  })
+
+  it('clicking Refresh calls statsStore.load', async () => {
+    render(Stats, { props: {} })
+    mockLoad.mockClear()
+    await fireEvent.click(screen.getByText('Refresh'))
+    expect(mockLoad).toHaveBeenCalled()
+  })
+
+  it('renders breakdown rows when data has entries', () => {
+    const s = makeSummary()
+    mockStatsStore.data = StatsResponse.createFrom({
+      today: s, thisWeek: s, thisMonth: s, allTime: s,
+      byProject: [],
+      byProjectType: [],
+      byRole: [
+        { key: 'triage', stats: makeSummary({ totalRuns: 5, totalCostUsd: 0.25, totalDurationS: 100 }) },
+        { key: 'plan', stats: makeSummary({ totalRuns: 3, totalCostUsd: 0.5, totalDurationS: 200 }) },
+      ],
+      byMode: [],
+      byModel: [],
+      recentRuns: [],
+    })
+    render(Stats, { props: {} })
+    expect(screen.getByText('triage')).toBeDefined()
+    expect(screen.getByText('plan')).toBeDefined()
+  })
+
+  it('renders recent runs rows', () => {
+    const s = makeSummary()
+    mockStatsStore.data = StatsResponse.createFrom({
+      today: s, thisWeek: s, thisMonth: s, allTime: s,
+      byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      recentRuns: [
+        {
+          id: 'r1',
+          taskId: 'task-1',
+          role: 'triage',
+          mode: 'headless',
+          model: 'sonnet',
+          costUsd: 0.05,
+          durationS: 60,
+          reasoningTokens: 100,
+          timestamp: '2026-05-01T10:00:00Z',
+          outcome: 'completed',
+        },
+        {
+          id: 'r2',
+          taskId: 'task-2',
+          role: 'eval',
+          mode: 'interactive',
+          model: '',
+          costUsd: 0.1,
+          durationS: 120,
+          reasoningTokens: 0,
+          timestamp: '2026-05-01T11:00:00Z',
+          outcome: 'failed',
+        },
+      ],
+    })
+    render(Stats, { props: {} })
+    expect(screen.getByText('task-1')).toBeDefined()
+    expect(screen.getByText('task-2')).toBeDefined()
+    expect(screen.getByText('triage')).toBeDefined()
+    expect(screen.getByText('eval')).toBeDefined()
+    expect(screen.getByText('completed')).toBeDefined()
+    expect(screen.getByText('failed')).toBeDefined()
+  })
+
+  it('shows dash for missing model in recent runs', () => {
+    const s = makeSummary()
+    mockStatsStore.data = StatsResponse.createFrom({
+      today: s, thisWeek: s, thisMonth: s, allTime: s,
+      byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      recentRuns: [
+        {
+          id: 'r1',
+          taskId: 'task-1',
+          role: 'triage',
+          mode: 'headless',
+          model: '',
+          costUsd: 0,
+          durationS: 0,
+          reasoningTokens: 0,
+          timestamp: '2026-05-01T10:00:00Z',
+          outcome: 'completed',
+        },
+      ],
+    })
+    render(Stats, { props: {} })
+    const dashes = screen.getAllByText('—')
+    expect(dashes.length).toBeGreaterThan(0)
   })
 })

--- a/frontend/src/pages/WorkflowDetail.svelte.test.ts
+++ b/frontend/src/pages/WorkflowDetail.svelte.test.ts
@@ -155,4 +155,38 @@ describe('WorkflowDetail', () => {
     await fireEvent.keyDown(window, { key: 'Escape' })
     expect(onback).toHaveBeenCalled()
   })
+
+  it('Cmd+S triggers save when dirty', async () => {
+    mockWorkflowGet.mockResolvedValue(makeDef())
+    mockWorkflowSave.mockResolvedValue(makeDef())
+    render(WorkflowDetail, { props: { workflowId: 'wf-1', onback: vi.fn() } })
+    await vi.waitFor(() => screen.getByText('my-workflow'))
+    await fireEvent.click(screen.getByText('+ Add step'))
+    await vi.waitFor(() => screen.getByText('unsaved'))
+    await fireEvent.keyDown(window, { key: 's', metaKey: true })
+    await vi.waitFor(() => {
+      expect(mockWorkflowSave).toHaveBeenCalled()
+    })
+  })
+
+  it('clears unsaved indicator after successful save', async () => {
+    mockWorkflowGet.mockResolvedValue(makeDef())
+    mockWorkflowSave.mockResolvedValue(makeDef())
+    render(WorkflowDetail, { props: { workflowId: 'wf-1', onback: vi.fn() } })
+    await vi.waitFor(() => screen.getByText('my-workflow'))
+    await fireEvent.click(screen.getByText('+ Add step'))
+    await vi.waitFor(() => screen.getByText('unsaved'))
+    await fireEvent.click(screen.getByText('Save'))
+    await vi.waitFor(() => {
+      expect(screen.queryByText('unsaved')).toBeNull()
+    })
+  })
+
+  it('+ Add step is enabled once definition loads', async () => {
+    mockWorkflowGet.mockResolvedValue(makeDef())
+    render(WorkflowDetail, { props: { workflowId: 'wf-1', onback: vi.fn() } })
+    await vi.waitFor(() => screen.getByText('my-workflow'))
+    const addBtn = screen.getByText('+ Add step') as HTMLButtonElement
+    expect(addBtn.disabled).toBe(false)
+  })
 })


### PR DESCRIPTION
## Motivation

PR 2 of the test-coverage push from issue #782. Follow-up to PR #805
(core pages). Targets the next tier of pages with the largest
test-to-source ratio gap.

## Implementation information

Test count deltas:

- **Reviews** — 15 → 26. Added test-plan-review approve/reject/send,
  Plan Critique section, View Task button, projectId in sidebar,
  unresolved comments banner with singular/plural, error path on
  reject, keyboard shortcuts (a, r).
- **GitHub** — 6 → 23. Added Issues tab, loading/error states for
  each tab, Renovate Retry button, Refresh per-tab, tab count
  badges, group-by-repository, Renovate search filter +
  no-match message + Escape-to-clear, focus-renovate-search window
  event handler, polling cleanup on unmount.
- **Loops** — 17 → 31. Added interval formatting branches (s/m/h/d),
  relative-time formatting (just now/m/h/d ago), toggleEnabled Pause
  and Enable flows, error paths for runNow and remove,
  LoopAgentUpdated event subscription, prompt + model display,
  multiple loops rendering.
- **WorkflowDetail** — 10 → 13. Added Cmd+S save, dirty clearing
  after save, add-step enabled-after-load.
- **Settings** — 18 → 30. Added Color Scheme localStorage
  persistence + dark-class toggle, Reset button appearance + revert,
  server-version display + unavailable fallback, directories list
  rendering, desktop-notifications toggle, autoTriage toggle,
  provider-to-codex model option swap, success-message timeout
  clearance.
- **Stats** — 14 → 24. Added token formatting in M and raw, duration
  in seconds and minutes, reasoning tokens, period switching, refresh
  click, breakdown rows, recent-runs rendering with role/outcome
  badges, dash for missing model.

Net: +70 frontend tests. All 1325 pass. svelte-check clean. oxlint
clean (2 pre-existing warnings unchanged).

Next: PR 3 — bump \`vite.config.ts\` coverage thresholds after CI
confirms global coverage clears the new floor.

## Supporting documentation

- Plan: /Users/marcin.skalski/.claude/plans/implem-https-github-com-automaat-sybra-i-majestic-mochi.md
- Prior PR: #805

> Changelog: test(frontend): expand mid-size page coverage