### PR TITLE
fix(monitor): hint for stuck_human_blocked

### DIFF
--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -199,6 +199,8 @@ func suggestedInvestigation(kind AnomalyKind) string {
 		return "- Confirm the agent process actually exited; the watchdog has reset the task to `todo`.\n"
 	case KindUntriaged:
 		return "- Run `/sybra-triage` against the affected task to fill `agent_mode` and `tags`.\n"
+	case KindStuckHumanBlocked:
+		return "- Review the blocking task: approve or reject the plan, or provide the context needed to unblock progress.\n"
 	default:
 		return "- See the dispatched agent's issue comment for proximate cause and next step.\n"
 	}

--- a/internal/monitor/prompts_test.go
+++ b/internal/monitor/prompts_test.go
@@ -1,0 +1,53 @@
+package monitor
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDeterministicIssueBody_StuckHumanBlocked(t *testing.T) {
+	a := Anomaly{
+		Kind:        KindStuckHumanBlocked,
+		TaskID:      "abc123",
+		Severity:    SeverityWarn,
+		Fingerprint: "stuck_human_blocked:abc123",
+		DetectedAt:  time.Date(2026, 5, 14, 9, 0, 0, 0, time.UTC),
+		Evidence: map[string]any{
+			"task_id": "abc123",
+			"status":  "plan-review",
+			"dwell_h": 8.5,
+		},
+	}
+
+	body := DeterministicIssueBody(a)
+
+	if !strings.Contains(body, "stuck_human_blocked") {
+		t.Error("body missing kind")
+	}
+	if !strings.Contains(body, "abc123") {
+		t.Error("body missing task id")
+	}
+	// Must NOT reference "dispatched agent's issue comment" — for work-typed
+	// downgraded anomalies no agent is dispatched and no GH issue is filed.
+	if strings.Contains(body, "dispatched agent") {
+		t.Error("body must not mention dispatched agent for stuck_human_blocked")
+	}
+	if !strings.Contains(body, "approve or reject the plan") {
+		t.Error("body missing actionable review guidance")
+	}
+}
+
+func TestDeterministicIssueBody_DefaultFallback(t *testing.T) {
+	a := Anomaly{
+		Kind:        KindFailureSpike,
+		Fingerprint: "failure_spike",
+		DetectedAt:  time.Now(),
+	}
+
+	body := DeterministicIssueBody(a)
+
+	if !strings.Contains(body, "dispatched agent") {
+		t.Error("non-stuck kinds should still reference the dispatched agent")
+	}
+}


### PR DESCRIPTION
## Motivation

`suggestedInvestigation` fell through to the default case for `KindStuckHumanBlocked`, pointing reviewers to "the dispatched agent's issue comment". For work-typed tasks this anomaly is downgraded from `RequiresLLM=true` before filing — no agent is dispatched and no GH issue is created — making the hint a dead-end.

## Implementation information

Added an explicit `case KindStuckHumanBlocked` in `suggestedInvestigation` that directs reviewers to approve/reject the plan or provide the context needed to unblock progress. Added `prompts_test.go` covering both the new case and the default fallback to prevent regression.

> Changelog: fix(monitor): hint for stuck_human_blocked