### PR TITLE
fix(monitor): split hint by blocking status

### DIFF
--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/Automaat/sybra/internal/task"
 )
 
 // DeterministicIssueBody renders the issue body the IssueSink files for
@@ -26,7 +28,7 @@ func DeterministicIssueBody(a Anomaly) string {
 	if len(a.Evidence) > 0 {
 		fmt.Fprintf(&b, "## Evidence\n```json\n%s\n```\n\n", evidenceJSON(a.Evidence))
 	}
-	fmt.Fprintf(&b, "## Suggested investigation\n%s\n", suggestedInvestigation(a.Kind))
+	fmt.Fprintf(&b, "## Suggested investigation\n%s\n", suggestedInvestigation(a))
 	return b.String()
 }
 
@@ -191,8 +193,8 @@ func evidenceJSON(ev map[string]any) string {
 	return string(b)
 }
 
-func suggestedInvestigation(kind AnomalyKind) string {
-	switch kind {
+func suggestedInvestigation(a Anomaly) string {
+	switch a.Kind {
 	case KindOverDispatchLimit:
 		return "- Cap concurrent agents in `agent.MaxConcurrent` or stop in-progress runs that have been live longer than expected.\n"
 	case KindLostAgent:
@@ -200,7 +202,14 @@ func suggestedInvestigation(kind AnomalyKind) string {
 	case KindUntriaged:
 		return "- Run `/sybra-triage` against the affected task to fill `agent_mode` and `tags`.\n"
 	case KindStuckHumanBlocked:
-		return "- Review the blocking task: approve or reject the plan, or provide the context needed to unblock progress.\n"
+		if status, _ := a.Evidence["status"].(string); status == string(task.StatusPlanReview) {
+			return "- Approve or reject the plan to advance the task.\n"
+		}
+		hint := "- Review the task file and `status_reason`, then provide the required human input to unblock progress.\n"
+		if reason, _ := a.Evidence["status_reason"].(string); reason != "" {
+			hint += "- Blocking reason: " + reason + "\n"
+		}
+		return hint
 	default:
 		return "- See the dispatched agent's issue comment for proximate cause and next step.\n"
 	}

--- a/internal/monitor/prompts_test.go
+++ b/internal/monitor/prompts_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func TestDeterministicIssueBody_StuckHumanBlocked(t *testing.T) {
+func TestDeterministicIssueBody_StuckHumanBlocked_PlanReview(t *testing.T) {
 	a := Anomaly{
 		Kind:        KindStuckHumanBlocked,
 		TaskID:      "abc123",
@@ -33,8 +33,64 @@ func TestDeterministicIssueBody_StuckHumanBlocked(t *testing.T) {
 	if strings.Contains(body, "dispatched agent") {
 		t.Error("body must not mention dispatched agent for stuck_human_blocked")
 	}
-	if !strings.Contains(body, "approve or reject the plan") {
-		t.Error("body missing actionable review guidance")
+	if !strings.Contains(body, "Approve or reject the plan") {
+		t.Error("plan-review hint missing")
+	}
+}
+
+func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired(t *testing.T) {
+	a := Anomaly{
+		Kind:        KindStuckHumanBlocked,
+		TaskID:      "def456",
+		Severity:    SeverityWarn,
+		Fingerprint: "stuck_human_blocked:def456",
+		DetectedAt:  time.Date(2026, 5, 14, 9, 0, 0, 0, time.UTC),
+		Evidence: map[string]any{
+			"task_id":       "def456",
+			"status":        "human-required",
+			"dwell_h":       9.0,
+			"status_reason": "waiting for API key rotation approval",
+		},
+	}
+
+	body := DeterministicIssueBody(a)
+
+	if strings.Contains(body, "dispatched agent") {
+		t.Error("body must not mention dispatched agent for stuck_human_blocked")
+	}
+	// human-required should NOT suggest plan approval
+	if strings.Contains(body, "Approve or reject the plan") {
+		t.Error("human-required hint must not reference plan approval")
+	}
+	if !strings.Contains(body, "status_reason") {
+		t.Error("human-required hint missing status_reason reference")
+	}
+	if !strings.Contains(body, "waiting for API key rotation approval") {
+		t.Error("status_reason content not surfaced in hint")
+	}
+}
+
+func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_NoReason(t *testing.T) {
+	a := Anomaly{
+		Kind:        KindStuckHumanBlocked,
+		TaskID:      "ghi789",
+		Severity:    SeverityWarn,
+		Fingerprint: "stuck_human_blocked:ghi789",
+		DetectedAt:  time.Date(2026, 5, 14, 9, 0, 0, 0, time.UTC),
+		Evidence: map[string]any{
+			"task_id": "ghi789",
+			"status":  "human-required",
+			"dwell_h": 10.0,
+		},
+	}
+
+	body := DeterministicIssueBody(a)
+
+	if strings.Contains(body, "Approve or reject the plan") {
+		t.Error("human-required hint must not reference plan approval")
+	}
+	if !strings.Contains(body, "status_reason") {
+		t.Error("human-required hint missing status_reason reference")
 	}
 }
 


### PR DESCRIPTION
## Motivation

`suggestedInvestigation` gave identical advice for both `plan-review` and
`human-required` stuck tasks: "approve or reject the plan" is meaningless
for a task blocked on unrelated human input (e.g. credentials, decisions).

## Implementation information

- Split `suggestedInvestigation` to accept the full `Anomaly` and branch on
  `evidence["status"]`: `plan-review` gets the plan-approval nudge;
  `human-required` gets a hint to check `status_reason`.
- Surface `status_reason` in anomaly evidence when set, so the filed issue
  shows the blocking reason without opening the task file.
- Added three new test cases covering plan-review hint, human-required with
  reason, and human-required without reason.

> Changelog: fix(monitor): split hint by blocking status