### PR TITLE
fix(monitor): surface evidence in stuck-task prompt

### DIFF
--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -90,12 +90,27 @@ func stuckPrompt(a Anomaly, issueRepo string) string {
 	status, _ := a.Evidence["status"].(string)
 	dwell, _ := a.Evidence["dwell_h"].(float64)
 	filePath, _ := a.Evidence["file_path"].(string)
+	statusReason, _ := a.Evidence["status_reason"].(string)
+	lastRole, _ := a.Evidence["last_agent_role"].(string)
+	lastState, _ := a.Evidence["last_agent_state"].(string)
+
+	var extra strings.Builder
+	if statusReason != "" {
+		fmt.Fprintf(&extra, "Status reason: %s\n", statusReason)
+	}
+	if lastRole != "" {
+		fmt.Fprintf(&extra, "Last agent: role=%s state=%s\n", lastRole, lastState)
+	} else if lastState != "" {
+		fmt.Fprintf(&extra, "Last agent: state=%s\n", lastState)
+	}
+	extraStr := extra.String()
+
 	return fmt.Sprintf(`You are the sybra monitor stuck-task investigator.
 
 Task: %s — %q
 Status: %s   Dwell: %.1fh
 Task file: %s
-
+%s
 Read-only investigation:
 - Read the task file and the most recent agent log under ~/.sybra/logs/agents matching this task id.
 - Identify the actual blocker in one sentence and propose the next concrete step a human could take.
@@ -110,7 +125,7 @@ GitHub issue handling:
 
 Output exactly one final JSON line:
 {"issueNumber":N,"action":"created"|"commented","blocker":"<one phrase>","nextStep":"<imperative sentence>"}`,
-		taskID, title, status, dwell, filePath,
+		taskID, title, status, dwell, filePath, extraStr,
 		issueRepo, taskID, issueRepo, taskID, issueRepo, issueRepo, taskID,
 	)
 }

--- a/internal/monitor/prompts_test.go
+++ b/internal/monitor/prompts_test.go
@@ -1,6 +1,7 @@
 package monitor
 
 import (
+	"maps"
 	"strings"
 	"testing"
 	"time"
@@ -92,6 +93,67 @@ func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_NoReason(t *test
 	if !strings.Contains(body, "status_reason") {
 		t.Error("human-required hint missing status_reason reference")
 	}
+}
+
+func TestDispatchPrompt_StuckHumanBlocked_ExtraEvidence(t *testing.T) {
+	base := map[string]any{
+		"task_id":   "abc",
+		"title":     "some task",
+		"status":    "human-required",
+		"dwell_h":   9.0,
+		"file_path": "/path/abc.md",
+	}
+	copyEv := func(extra map[string]any) map[string]any {
+		m := make(map[string]any, len(base)+len(extra))
+		maps.Copy(m, base)
+		maps.Copy(m, extra)
+		return m
+	}
+
+	t.Run("includes status_reason", func(t *testing.T) {
+		a := Anomaly{Kind: KindStuckHumanBlocked, Evidence: copyEv(map[string]any{
+			"status_reason": "watchdog: turn limit exceeded",
+		})}
+		prompt := DispatchPrompt(a, "owner/repo", "")
+		if !strings.Contains(prompt, "watchdog: turn limit exceeded") {
+			t.Error("prompt missing status_reason")
+		}
+	})
+
+	t.Run("includes last_agent_role_and_state", func(t *testing.T) {
+		a := Anomaly{Kind: KindStuckHumanBlocked, Evidence: copyEv(map[string]any{
+			"last_agent_role":  "fix-review",
+			"last_agent_state": "stopped",
+		})}
+		prompt := DispatchPrompt(a, "owner/repo", "")
+		if !strings.Contains(prompt, "fix-review") {
+			t.Error("prompt missing last_agent_role")
+		}
+		if !strings.Contains(prompt, "stopped") {
+			t.Error("prompt missing last_agent_state")
+		}
+	})
+
+	t.Run("includes last_agent_state_without_role", func(t *testing.T) {
+		a := Anomaly{Kind: KindStuckHumanBlocked, Evidence: copyEv(map[string]any{
+			"last_agent_state": "running",
+		})}
+		prompt := DispatchPrompt(a, "owner/repo", "")
+		if !strings.Contains(prompt, "running") {
+			t.Error("prompt missing last_agent_state")
+		}
+	})
+
+	t.Run("omits extra lines when evidence absent", func(t *testing.T) {
+		a := Anomaly{Kind: KindStuckHumanBlocked, Evidence: copyEv(nil)}
+		prompt := DispatchPrompt(a, "owner/repo", "")
+		if strings.Contains(prompt, "Status reason:") {
+			t.Error("prompt should not contain Status reason when absent")
+		}
+		if strings.Contains(prompt, "Last agent:") {
+			t.Error("prompt should not contain Last agent when absent")
+		}
+	})
 }
 
 func TestDeterministicIssueBody_DefaultFallback(t *testing.T) {


### PR DESCRIPTION
## Motivation

The stuck-task investigator prompt included task id, title, status, dwell time, and file path — but omitted `status_reason`, `last_agent_role`, and `last_agent_state` that were added in #810/#811. Without these the dispatched agent had to read the log file to find the proximate cause.

## Implementation information

Extract the three new evidence fields in `stuckPrompt` and append them as a compact block between the status line and the read-only investigation instructions. Fields are omitted when absent so the prompt stays clean for anomalies that lack agent history.

Tests added in `prompts_test.go` cover: status_reason present, role+state present, state-only (no role), and all-absent (no extra lines rendered).

> Changelog: fix(monitor): surface evidence in stuck-task prompt