### PR TITLE
fix(monitor): improve stuck-human-blocked hints and evidence

### DIFF
--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -224,6 +224,9 @@ func suggestedInvestigation(a Anomaly) string {
 		if reason, _ := a.Evidence["status_reason"].(string); reason != "" {
 			hint += "- Blocking reason: " + reason + "\n"
 		}
+		if lastRole, _ := a.Evidence["last_agent_role"].(string); lastRole == "human-review" {
+			hint += "- Human-review agent already assessed this task — check the task body for the auto-review verdict.\n"
+		}
 		return hint
 	default:
 		return "- See the dispatched agent's issue comment for proximate cause and next step.\n"

--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -225,7 +225,9 @@ func suggestedInvestigation(a Anomaly) string {
 			hint += "- Blocking reason: " + reason + "\n"
 		}
 		if lastRole, _ := a.Evidence["last_agent_role"].(string); lastRole == "human-review" {
-			hint += "- Human-review agent already assessed this task — check the task body for the auto-review verdict.\n"
+			if lastState, _ := a.Evidence["last_agent_state"].(string); lastState == "stopped" {
+				hint += "- Human-review agent already assessed this task — check the task body for the latest auto-review note.\n"
+			}
 		}
 		return hint
 	default:

--- a/internal/monitor/prompts_test.go
+++ b/internal/monitor/prompts_test.go
@@ -95,6 +95,35 @@ func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_NoReason(t *test
 	}
 }
 
+func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_AfterHumanReview(t *testing.T) {
+	a := Anomaly{
+		Kind:        KindStuckHumanBlocked,
+		TaskID:      "jkl012",
+		Severity:    SeverityWarn,
+		Fingerprint: "stuck_human_blocked:jkl012",
+		DetectedAt:  time.Date(2026, 5, 14, 9, 0, 0, 0, time.UTC),
+		Evidence: map[string]any{
+			"task_id":          "jkl012",
+			"status":           "human-required",
+			"dwell_h":          10.0,
+			"last_agent_role":  "human-review",
+			"last_agent_state": "stopped",
+		},
+	}
+
+	body := DeterministicIssueBody(a)
+
+	if strings.Contains(body, "Approve or reject the plan") {
+		t.Error("human-required hint must not reference plan approval")
+	}
+	if !strings.Contains(body, "Human-review agent") {
+		t.Error("hint should mention human-review agent completed assessment")
+	}
+	if !strings.Contains(body, "auto-review verdict") {
+		t.Error("hint should reference auto-review verdict in task body")
+	}
+}
+
 func TestDispatchPrompt_StuckHumanBlocked_ExtraEvidence(t *testing.T) {
 	base := map[string]any{
 		"task_id":   "abc",

--- a/internal/monitor/prompts_test.go
+++ b/internal/monitor/prompts_test.go
@@ -119,8 +119,34 @@ func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_AfterHumanReview
 	if !strings.Contains(body, "Human-review agent") {
 		t.Error("hint should mention human-review agent completed assessment")
 	}
-	if !strings.Contains(body, "auto-review verdict") {
-		t.Error("hint should reference auto-review verdict in task body")
+	if !strings.Contains(body, "auto-review note") {
+		t.Error("hint should reference auto-review note in task body")
+	}
+}
+
+func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_HumanReviewStillRunning(t *testing.T) {
+	a := Anomaly{
+		Kind:        KindStuckHumanBlocked,
+		TaskID:      "mno345",
+		Severity:    SeverityWarn,
+		Fingerprint: "stuck_human_blocked:mno345",
+		DetectedAt:  time.Date(2026, 5, 14, 9, 0, 0, 0, time.UTC),
+		Evidence: map[string]any{
+			"task_id":          "mno345",
+			"status":           "human-required",
+			"dwell_h":          3.0,
+			"last_agent_role":  "human-review",
+			"last_agent_state": "running",
+		},
+	}
+
+	body := DeterministicIssueBody(a)
+
+	if strings.Contains(body, "Human-review agent") {
+		t.Error("hint must not claim review completed when agent is still running")
+	}
+	if strings.Contains(body, "auto-review note") {
+		t.Error("hint must not reference review note when agent is still running")
 	}
 }
 


### PR DESCRIPTION
## Motivation

The monitor's stuck-human-blocked anomaly lacked actionable context: the
investigation prompt omitted evidence fields (status_reason, last agent
role/state) and the deterministic issue body gave a generic hint regardless of
why the task was blocked.

## Implementation information

- `stuckPrompt`: injects `status_reason`, `last_agent_role`, and
  `last_agent_state` from the anomaly evidence so the investigator agent has
  concrete context without reading extra files.
- `suggestedInvestigation`: adds a `KindStuckHumanBlocked` case that branches
  on task status — plan-review tasks get a plan-approval nudge, others get a
  status-reason-aware hint.
- Gates the "human-review agent already assessed" hint on `last_agent_state ==
  stopped` to avoid showing it while a review agent is still running.
- `DispatchPrompt` / `prGapPrompt`: threads `pushRemote` through so PR-gap
  agents push to the correct remote (fork vs origin).
- All new branches are covered by extended `prompts_test.go` cases.

> Changelog: fix(monitor): improve stuck-human-blocked hints and evidence