### PR TITLE
fix(monitor): improve stuck_human_blocked detection and hints

### DIFF
--- a/internal/sybra/monitor_sink.go
+++ b/internal/sybra/monitor_sink.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/Automaat/sybra/internal/monitor"
@@ -67,7 +68,7 @@ func (s *monitorRoutingSink) Submit(ctx context.Context, a monitor.Anomaly, body
 	title, _ := scrub.Scrub(monitor.IssueTitle(a.Kind, a.Fingerprint), wctx.Blocklist)
 	scrubbedBody, redactions := scrub.Scrub(body, wctx.Blocklist)
 
-	if existing, ok := s.findOpenByTitle(title); ok {
+	if existing, ok := s.findOpen(title, a.Fingerprint); ok {
 		appended := appendRedetectedNote(existing.Body, scrubbedBody, s.now())
 		if _, err := s.tasks.Update(existing.ID, task.Update{Body: &appended}); err != nil {
 			s.logger.Warn("monitor.routing.local.append", "task_id", existing.ID, "err", err)
@@ -107,24 +108,27 @@ func (s *monitorRoutingSink) dispatchCreatedWorkflow(taskID string) {
 	s.dispatchCreated(taskID)
 }
 
-// findOpenByTitle returns the first non-terminal task whose Title equals the
-// fingerprint-stable issue title. Ok is false when no match exists or the
-// task list cannot be read.
-func (s *monitorRoutingSink) findOpenByTitle(title string) (task.Task, bool) {
+// findOpen returns the first non-terminal task that matches the monitor chore
+// by title or by fingerprint embedded in the body. Title matching covers the
+// normal case; fingerprint matching covers tasks that were renamed by the
+// triage agent (the body is never modified by triage, so the fingerprint line
+// written by DeterministicIssueBody survives a rename). Ok is false when no
+// match exists or the task list cannot be read.
+func (s *monitorRoutingSink) findOpen(title, fp string) (task.Task, bool) {
 	all, err := s.tasks.List()
 	if err != nil {
 		s.logger.Warn("monitor.routing.local.list", "err", err)
 		return task.Task{}, false
 	}
+	marker := "- Fingerprint: `" + fp + "`"
 	for i := range all {
 		t := &all[i]
-		if t.Title != title {
-			continue
-		}
 		if task.IsTerminalStatus(t.Status) {
 			continue
 		}
-		return *t, true
+		if t.Title == title || strings.Contains(t.Body, marker) {
+			return *t, true
+		}
 	}
 	return task.Task{}, false
 }

--- a/internal/sybra/monitor_sink_test.go
+++ b/internal/sybra/monitor_sink_test.go
@@ -186,6 +186,69 @@ func TestMonitorRoutingSink_WorkAnomaly_DedupsByTitle(t *testing.T) {
 	}
 }
 
+func TestMonitorRoutingSink_WorkAnomaly_DedupsByFingerprintAfterRename(t *testing.T) {
+	t.Parallel()
+	sink, tasks, _ := newSinkTestEnv(t)
+	src, err := tasks.Create("source", "src body", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	pid := "kumahq/kuma"
+	if _, err := tasks.Update(src.ID, task.Update{ProjectID: &pid}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	a := monitor.Anomaly{
+		Kind:        monitor.KindStuckHumanBlocked,
+		TaskID:      src.ID,
+		Fingerprint: "stuck_human_blocked:" + src.ID,
+	}
+	// First submit creates the chore task.
+	body := "## Detection\n- Fingerprint: `stuck_human_blocked:" + src.ID + "`\n\n## Affected task\n- `" + src.ID + "`\n"
+	if _, err := sink.Submit(context.Background(), a, body); err != nil {
+		t.Fatalf("first Submit: %v", err)
+	}
+	// Simulate triage renaming the task (title changes, tags cleared).
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var chore *task.Task
+	for i := range all {
+		if strings.HasPrefix(all[i].Title, "[monitor]") {
+			chore = &all[i]
+			break
+		}
+	}
+	if chore == nil {
+		t.Fatalf("chore task not created")
+	}
+	renamed := "chore(sybra): unblock task " + src.ID + " stuck in human-required"
+	if _, err := tasks.Update(chore.ID, task.Update{Title: &renamed}); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	// Second submit must dedup via fingerprint in body, not title.
+	created, err := sink.Submit(context.Background(), a, "new cycle evidence")
+	if err != nil {
+		t.Fatalf("second Submit: %v", err)
+	}
+	if created {
+		t.Fatalf("expected created=false on fingerprint-dedup hit after rename")
+	}
+	all, err = tasks.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var open int
+	for _, tk := range all {
+		if strings.Contains(tk.Title, src.ID) && !task.IsTerminalStatus(tk.Status) {
+			open++
+		}
+	}
+	if open != 1 {
+		t.Fatalf("want 1 open chore task after dedup, got %d", open)
+	}
+}
+
 func TestMonitorRoutingSink_TerminalTaskReopensNew(t *testing.T) {
 	t.Parallel()
 	sink, tasks, _ := newSinkTestEnv(t)


### PR DESCRIPTION
## Motivation

Monitor anomalies for `human-required` tasks were giving unhelpful or
wrong guidance. The hint pointed to a non-existent agent issue comment
(work-typed tasks are downgraded — no agent is dispatched), dedup broke
after triage renamed the auto-created task, and the stuck prompt omitted
the status reason that explains *why* a task is blocked.

## Implementation information

- Add explicit `KindStuckHumanBlocked` case in `suggestedInvestigation`
  with status-aware branches: `plan-review` gets plan-approval nudge,
  `human-required` gets a hint to review `status_reason`.
- Surface `status_reason`, `last_agent_role`, and `last_agent_state` in
  both the anomaly evidence map and the `stuckPrompt` header so reviewers
  see the proximate cause without reading the log file.
- Replace `findOpenByTitle` with `findOpen(title, fp)` in `monitor_sink`:
  checks the fingerprint line in the task body so dedup survives a triage
  rename (title no longer matches `[monitor]` pattern after renaming).
- Add tests covering all new branches.

> Changelog: fix(monitor): improve stuck_human_blocked detection and hints