### PR TITLE
fix(monitor): improve stuck-human-blocked hints and evidence

### DIFF
--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -234,7 +234,7 @@ func suggestedInvestigation(a Anomaly) string {
 			}
 			hint += "- Note shows unparseable or failed verdict: review the raw agent output in the note and act accordingly.\n"
 		} else if lastRole == "fix-review" && lastState == "stopped" {
-			hint += "- Fix-review agent pushed review fixes to the PR — re-check the PR for updated review status and approve or request further changes.\n"
+			hint += "- Fix-review agent finished — check the PR and agent log for the outcome, then approve or request further changes.\n"
 		}
 		return hint
 	default:

--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -224,15 +224,17 @@ func suggestedInvestigation(a Anomaly) string {
 		if reason, _ := a.Evidence["status_reason"].(string); reason != "" {
 			hint += "- Blocking reason: " + reason + "\n"
 		}
-		if lastRole, _ := a.Evidence["last_agent_role"].(string); lastRole == "human-review" {
-			if lastState, _ := a.Evidence["last_agent_state"].(string); lastState == "stopped" {
-				taskID, _ := a.Evidence["task_id"].(string)
-				hint += "- Human-review agent assessed this task — check the latest auto-review note in the task body.\n"
-				if taskID != "" {
-					hint += "- Note confirms 'needs human': provide the required input, then retry via `sybra-cli update " + taskID + " --status todo`.\n"
-				}
-				hint += "- Note shows unparseable or failed verdict: review the raw agent output in the note and act accordingly.\n"
+		lastRole, _ := a.Evidence["last_agent_role"].(string)
+		lastState, _ := a.Evidence["last_agent_state"].(string)
+		if lastRole == "human-review" && lastState == "stopped" {
+			taskID, _ := a.Evidence["task_id"].(string)
+			hint += "- Human-review agent assessed this task — check the latest auto-review note in the task body.\n"
+			if taskID != "" {
+				hint += "- Note confirms 'needs human': provide the required input, then retry via `sybra-cli update " + taskID + " --status todo`.\n"
 			}
+			hint += "- Note shows unparseable or failed verdict: review the raw agent output in the note and act accordingly.\n"
+		} else if lastRole == "fix-review" && lastState == "stopped" {
+			hint += "- Fix-review agent pushed review fixes to the PR — re-check the PR for updated review status and approve or request further changes.\n"
 		}
 		return hint
 	default:

--- a/internal/monitor/prompts_test.go
+++ b/internal/monitor/prompts_test.go
@@ -158,7 +158,10 @@ func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_AfterFixReview(t
 		t.Error("hint must not mention human-review when role is fix-review")
 	}
 	if !strings.Contains(body, "Fix-review agent") {
-		t.Error("hint should mention fix-review agent pushed fixes")
+		t.Error("hint should mention fix-review agent finished")
+	}
+	if strings.Contains(body, "pushed") {
+		t.Error("hint must not claim fixes were pushed — outcome is unknown")
 	}
 	if !strings.Contains(body, "PR") {
 		t.Error("hint should reference PR for fix-review case")

--- a/internal/monitor/prompts_test.go
+++ b/internal/monitor/prompts_test.go
@@ -133,6 +133,61 @@ func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_AfterHumanReview
 	}
 }
 
+func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_AfterFixReview(t *testing.T) {
+	a := Anomaly{
+		Kind:        KindStuckHumanBlocked,
+		TaskID:      "pqr678",
+		Severity:    SeverityWarn,
+		Fingerprint: "stuck_human_blocked:pqr678",
+		DetectedAt:  time.Date(2026, 5, 14, 9, 0, 0, 0, time.UTC),
+		Evidence: map[string]any{
+			"task_id":          "pqr678",
+			"status":           "human-required",
+			"dwell_h":          10.0,
+			"last_agent_role":  "fix-review",
+			"last_agent_state": "stopped",
+		},
+	}
+
+	body := DeterministicIssueBody(a)
+
+	if strings.Contains(body, "Approve or reject the plan") {
+		t.Error("human-required hint must not reference plan approval")
+	}
+	if strings.Contains(body, "Human-review agent") {
+		t.Error("hint must not mention human-review when role is fix-review")
+	}
+	if !strings.Contains(body, "Fix-review agent") {
+		t.Error("hint should mention fix-review agent pushed fixes")
+	}
+	if !strings.Contains(body, "PR") {
+		t.Error("hint should reference PR for fix-review case")
+	}
+}
+
+func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_FixReviewStillRunning(t *testing.T) {
+	a := Anomaly{
+		Kind:        KindStuckHumanBlocked,
+		TaskID:      "stu901",
+		Severity:    SeverityWarn,
+		Fingerprint: "stuck_human_blocked:stu901",
+		DetectedAt:  time.Date(2026, 5, 14, 9, 0, 0, 0, time.UTC),
+		Evidence: map[string]any{
+			"task_id":          "stu901",
+			"status":           "human-required",
+			"dwell_h":          3.0,
+			"last_agent_role":  "fix-review",
+			"last_agent_state": "running",
+		},
+	}
+
+	body := DeterministicIssueBody(a)
+
+	if strings.Contains(body, "Fix-review agent") {
+		t.Error("hint must not claim fix-review completed when agent is still running")
+	}
+}
+
 func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_HumanReviewStillRunning(t *testing.T) {
 	a := Anomaly{
 		Kind:        KindStuckHumanBlocked,


### PR DESCRIPTION
## Motivation

The `stuck_human_blocked` monitor anomaly lacked enough context for the
orchestrator to act on it. The generated hint was generic and did not
surface the blocking reason, agent role, or agent state — making it hard
to know what action to take without opening the task manually.

## Implementation information

- Added `status_reason` and last-agent evidence fields to the
  `stuck_human_blocked` anomaly.
- Split the hint by blocking status: surfaces the blocking reason when
  present.
- Added branch for `fix-review` agent state: when a fix-review agent
  stopped, the hint now tells the orchestrator to check the PR/log and
  approve or request further changes (softened wording from a harder
  imperative).
- Added branch for `human-review` agent state: points to the task body
  for the latest auto-review note.
- Fixed fingerprint dedup after an evidence field rename so anomalies are
  not re-filed on every cycle.

> Changelog: fix(monitor): improve stuck-human-blocked hints and evidence