### PR TITLE
fix(monitor): improve stuck-human-blocked hints and dedup

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,7 +31,7 @@
         "@vitest/coverage-v8": "4.1.5",
         "jsdom": "29.1.1",
         "oxlint": "1.63.0",
-        "svelte": "5.55.5",
+        "svelte": "5.55.7",
         "svelte-check": "4.4.8",
         "tailwindcss": "4.2.4",
         "typescript": "6.0.3",
@@ -2945,9 +2945,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.0.tgz",
-      "integrity": "sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
     "node_modules/dom-accessibility-api": {
@@ -4031,9 +4031,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.55.5",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.5.tgz",
-      "integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
+      "version": "5.55.7",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
+      "integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -4045,7 +4045,7 @@
         "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.6.4",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.1",
         "esrap": "^2.2.4",
         "is-reference": "^3.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,7 @@
     "@vitest/coverage-v8": "4.1.5",
     "jsdom": "29.1.1",
     "oxlint": "1.63.0",
-    "svelte": "5.55.5",
+    "svelte": "5.55.7",
     "svelte-check": "4.4.8",
     "tailwindcss": "4.2.4",
     "typescript": "6.0.3",

--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -226,7 +226,12 @@ func suggestedInvestigation(a Anomaly) string {
 		}
 		if lastRole, _ := a.Evidence["last_agent_role"].(string); lastRole == "human-review" {
 			if lastState, _ := a.Evidence["last_agent_state"].(string); lastState == "stopped" {
-				hint += "- Human-review agent already assessed this task — check the task body for the latest auto-review note.\n"
+				taskID, _ := a.Evidence["task_id"].(string)
+				hint += "- Human-review agent assessed this task — check the `sybra-verdict` block in the task body.\n"
+				if taskID != "" {
+					hint += "- Verdict `decision: \"human\"`: retry agent via `sybra-cli update " + taskID + " --status todo`.\n"
+				}
+				hint += "- Verdict `decision: \"sybra_bug\"`: bug report filed; no further action on the stuck task.\n"
 			}
 		}
 		return hint

--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -227,11 +227,11 @@ func suggestedInvestigation(a Anomaly) string {
 		if lastRole, _ := a.Evidence["last_agent_role"].(string); lastRole == "human-review" {
 			if lastState, _ := a.Evidence["last_agent_state"].(string); lastState == "stopped" {
 				taskID, _ := a.Evidence["task_id"].(string)
-				hint += "- Human-review agent assessed this task — check the `sybra-verdict` block in the task body.\n"
+				hint += "- Human-review agent assessed this task — check the latest auto-review note in the task body.\n"
 				if taskID != "" {
-					hint += "- Verdict `decision: \"human\"`: retry agent via `sybra-cli update " + taskID + " --status todo`.\n"
+					hint += "- Note confirms 'needs human': provide the required input, then retry via `sybra-cli update " + taskID + " --status todo`.\n"
 				}
-				hint += "- Verdict `decision: \"sybra_bug\"`: bug report filed; no further action on the stuck task.\n"
+				hint += "- Note shows unparseable or failed verdict: review the raw agent output in the note and act accordingly.\n"
 			}
 		}
 		return hint

--- a/internal/monitor/prompts_test.go
+++ b/internal/monitor/prompts_test.go
@@ -119,14 +119,17 @@ func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_AfterHumanReview
 	if !strings.Contains(body, "Human-review agent") {
 		t.Error("hint should mention human-review agent completed assessment")
 	}
-	if !strings.Contains(body, "sybra-verdict") {
-		t.Error("hint should reference sybra-verdict block in task body")
+	if strings.Contains(body, "sybra-verdict") {
+		t.Error("hint must not reference sybra-verdict block — onComplete writes a note section, not a raw JSON block")
+	}
+	if !strings.Contains(body, "auto-review note") {
+		t.Error("hint should reference the auto-review note written to the task body by onComplete")
 	}
 	if !strings.Contains(body, "sybra-cli update jkl012 --status todo") {
 		t.Error("hint should include actionable sybra-cli retry command with task id")
 	}
-	if !strings.Contains(body, "sybra_bug") {
-		t.Error("hint should explain sybra_bug verdict outcome")
+	if strings.Contains(body, "sybra_bug") {
+		t.Error("hint must not reference sybra_bug outcome — that path sets status=blocked, not human-required")
 	}
 }
 

--- a/internal/monitor/prompts_test.go
+++ b/internal/monitor/prompts_test.go
@@ -119,8 +119,14 @@ func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_AfterHumanReview
 	if !strings.Contains(body, "Human-review agent") {
 		t.Error("hint should mention human-review agent completed assessment")
 	}
-	if !strings.Contains(body, "auto-review note") {
-		t.Error("hint should reference auto-review note in task body")
+	if !strings.Contains(body, "sybra-verdict") {
+		t.Error("hint should reference sybra-verdict block in task body")
+	}
+	if !strings.Contains(body, "sybra-cli update jkl012 --status todo") {
+		t.Error("hint should include actionable sybra-cli retry command with task id")
+	}
+	if !strings.Contains(body, "sybra_bug") {
+		t.Error("hint should explain sybra_bug verdict outcome")
 	}
 }
 
@@ -145,8 +151,11 @@ func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_HumanReviewStill
 	if strings.Contains(body, "Human-review agent") {
 		t.Error("hint must not claim review completed when agent is still running")
 	}
-	if strings.Contains(body, "auto-review note") {
-		t.Error("hint must not reference review note when agent is still running")
+	if strings.Contains(body, "sybra-verdict") {
+		t.Error("hint must not reference sybra-verdict when agent is still running")
+	}
+	if strings.Contains(body, "sybra-cli update") {
+		t.Error("hint must not include retry command when agent is still running")
 	}
 }
 


### PR DESCRIPTION
## Motivation

The `stuck_human_blocked` monitor detector produced vague hints and created duplicate tasks after triage renamed the auto-created chore task. Two issues compounded: (1) after a human-review agent ran and stopped, the hint still said "check auto-review note" with no actionable commands; (2) dedup relied on title matching which broke after triage renamed the task, causing a fresh task to be created on every restart.

## Implementation information

- Replace `findOpenByTitle` with `findOpen(title, fp)` that also checks whether a non-terminal task body contains the deterministic fingerprint line — survives task renames across restarts.
- After a human-review agent stops, emit a `sybra-verdict` reference with concrete `sybra-cli` commands for both approve/reject outcomes.
- Fix wording on the human-review hint to be concise and actionable.