### PR TITLE
fix(monitor): improve interactive hint for human-blocked tasks

### DIFF
--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -231,7 +231,7 @@ func suggestedInvestigation(a Anomaly) string {
 			hint += "- Human-review agent assessed this task — check the latest auto-review note in the task body.\n"
 			if taskID != "" {
 				hint += "- Note confirms human input needed: provide it, then `sybra-cli update " + taskID + " --status todo`.\n"
-				hint += "- Note confirms task scope exceeds automation: `sybra-cli update " + taskID + " --mode interactive --status todo`.\n"
+				hint += "- If the note says scope exceeds automation, switch to interactive mode: `sybra-cli update " + taskID + " --mode interactive --status todo`.\n"
 			}
 			hint += "- Note shows unparseable or failed verdict: review the raw agent output in the note and act accordingly.\n"
 		} else if lastRole == "fix-review" && lastState == "stopped" {

--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -230,7 +230,8 @@ func suggestedInvestigation(a Anomaly) string {
 			taskID, _ := a.Evidence["task_id"].(string)
 			hint += "- Human-review agent assessed this task — check the latest auto-review note in the task body.\n"
 			if taskID != "" {
-				hint += "- Note confirms 'needs human': provide the required input, then retry via `sybra-cli update " + taskID + " --status todo`.\n"
+				hint += "- Note confirms human input needed: provide it, then `sybra-cli update " + taskID + " --status todo`.\n"
+				hint += "- Note confirms task scope exceeds automation: `sybra-cli update " + taskID + " --mode interactive --status todo`.\n"
 			}
 			hint += "- Note shows unparseable or failed verdict: review the raw agent output in the note and act accordingly.\n"
 		} else if lastRole == "fix-review" && lastState == "stopped" {

--- a/internal/monitor/prompts_test.go
+++ b/internal/monitor/prompts_test.go
@@ -128,6 +128,9 @@ func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_AfterHumanReview
 	if !strings.Contains(body, "sybra-cli update jkl012 --status todo") {
 		t.Error("hint should include actionable sybra-cli retry command with task id")
 	}
+	if !strings.Contains(body, "sybra-cli update jkl012 --mode interactive --status todo") {
+		t.Error("hint should include interactive-mode option for tasks whose scope exceeds automation")
+	}
 	if strings.Contains(body, "sybra_bug") {
 		t.Error("hint must not reference sybra_bug outcome — that path sets status=blocked, not human-required")
 	}


### PR DESCRIPTION
## Motivation

The stuck-human-blocked hint only suggested retrying as headless. Tasks blocked because their scope exceeds automation needed a path to switch to interactive mode, which was missing from the hint.

## Implementation information

- Added a second hint line when task ID is present: suggests switching to interactive mode via `--mode interactive --status todo` for tasks where the human-review note says scope exceeds automation.
- Weakened the existing hint wording to be less prescriptive about what the note says.
- Extended the test to assert the new interactive-mode hint is present.

> Changelog: fix(monitor): add interactive-mode hint for scope-exceeds-automation tasks