### PR TITLE
fix(monitor): add pr_number to stuck evidence

### DIFF
--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -160,6 +160,9 @@ func detectStuckHumanBlocked(t *task.Task, now time.Time, budget time.Duration) 
 	if t.StatusReason != "" {
 		ev["status_reason"] = t.StatusReason
 	}
+	if t.PRNumber > 0 {
+		ev["pr_number"] = t.PRNumber
+	}
 	if n := len(t.AgentRuns); n > 0 {
 		last := t.AgentRuns[n-1]
 		if last.Role != "" {

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -365,6 +365,39 @@ func TestDetectStuckHumanBlocked_Evidence(t *testing.T) {
 			t.Error("last_agent_state should be absent when no runs")
 		}
 	})
+
+	t.Run("includes pr_number when set", func(t *testing.T) {
+		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.PRNumber = 42
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		got, ok := report.Anomalies[0].Evidence["pr_number"]
+		if !ok {
+			t.Fatal("evidence missing pr_number")
+		}
+		if got != 42 {
+			t.Errorf("pr_number = %v, want 42", got)
+		}
+	})
+
+	t.Run("omits pr_number when zero", func(t *testing.T) {
+		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		if _, ok := report.Anomalies[0].Evidence["pr_number"]; ok {
+			t.Error("evidence should not contain pr_number when zero")
+		}
+	})
 }
 
 func TestCounts(t *testing.T) {

--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -93,6 +93,7 @@ func stuckPrompt(a Anomaly, issueRepo string) string {
 	statusReason, _ := a.Evidence["status_reason"].(string)
 	lastRole, _ := a.Evidence["last_agent_role"].(string)
 	lastState, _ := a.Evidence["last_agent_state"].(string)
+	prNumber, _ := a.Evidence["pr_number"].(int)
 
 	var extra strings.Builder
 	if statusReason != "" {
@@ -102,6 +103,9 @@ func stuckPrompt(a Anomaly, issueRepo string) string {
 		fmt.Fprintf(&extra, "Last agent: role=%s state=%s\n", lastRole, lastState)
 	} else if lastState != "" {
 		fmt.Fprintf(&extra, "Last agent: state=%s\n", lastState)
+	}
+	if prNumber > 0 {
+		fmt.Fprintf(&extra, "Linked PR: #%d\n", prNumber)
 	}
 	extraStr := extra.String()
 
@@ -228,8 +232,12 @@ func suggestedInvestigation(a Anomaly) string {
 		lastState, _ := a.Evidence["last_agent_state"].(string)
 		if lastRole == "human-review" && lastState == "stopped" {
 			taskID, _ := a.Evidence["task_id"].(string)
+			prNum, _ := a.Evidence["pr_number"].(int)
 			hint += "- Human-review agent assessed this task — check the latest auto-review note in the task body.\n"
 			if taskID != "" {
+				if prNum > 0 {
+					hint += fmt.Sprintf("- If note says awaiting PR review: check PR #%d for new reviewer feedback.\n", prNum)
+				}
 				hint += "- Note confirms human input needed: provide it, then `sybra-cli update " + taskID + " --status todo`.\n"
 				hint += "- If the note says scope exceeds automation, switch to interactive mode: `sybra-cli update " + taskID + " --mode interactive --status todo`.\n"
 			}

--- a/internal/monitor/prompts_test.go
+++ b/internal/monitor/prompts_test.go
@@ -136,6 +136,30 @@ func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_AfterHumanReview
 	}
 }
 
+func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_AfterHumanReview_WithPR(t *testing.T) {
+	a := Anomaly{
+		Kind:        KindStuckHumanBlocked,
+		TaskID:      "jkl012",
+		Severity:    SeverityWarn,
+		Fingerprint: "stuck_human_blocked:jkl012",
+		DetectedAt:  time.Date(2026, 5, 14, 9, 0, 0, 0, time.UTC),
+		Evidence: map[string]any{
+			"task_id":          "jkl012",
+			"status":           "human-required",
+			"dwell_h":          10.0,
+			"last_agent_role":  "human-review",
+			"last_agent_state": "stopped",
+			"pr_number":        16601,
+		},
+	}
+
+	body := DeterministicIssueBody(a)
+
+	if !strings.Contains(body, "PR #16601") {
+		t.Error("hint should include PR number when available")
+	}
+}
+
 func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_AfterFixReview(t *testing.T) {
 	a := Anomaly{
 		Kind:        KindStuckHumanBlocked,
@@ -280,6 +304,24 @@ func TestDispatchPrompt_StuckHumanBlocked_ExtraEvidence(t *testing.T) {
 		}
 		if strings.Contains(prompt, "Last agent:") {
 			t.Error("prompt should not contain Last agent when absent")
+		}
+	})
+
+	t.Run("includes linked PR when pr_number set", func(t *testing.T) {
+		a := Anomaly{Kind: KindStuckHumanBlocked, Evidence: copyEv(map[string]any{
+			"pr_number": 16601,
+		})}
+		prompt := DispatchPrompt(a, "owner/repo", "")
+		if !strings.Contains(prompt, "Linked PR: #16601") {
+			t.Error("prompt missing Linked PR line")
+		}
+	})
+
+	t.Run("omits linked PR when pr_number absent", func(t *testing.T) {
+		a := Anomaly{Kind: KindStuckHumanBlocked, Evidence: copyEv(nil)}
+		prompt := DispatchPrompt(a, "owner/repo", "")
+		if strings.Contains(prompt, "Linked PR:") {
+			t.Error("prompt should not contain Linked PR when pr_number absent")
 		}
 	})
 }


### PR DESCRIPTION
## Motivation

When a `human-required` task has a linked PR, the stuck-task investigator
prompt and the deterministic issue body had no way to surface that PR number.
Operators had to manually look up the task to find which PR needed attention.

## Implementation information

- `detectStuckHumanBlocked`: adds `pr_number` to evidence map when
  `task.PRNumber > 0`; omits the key entirely when zero so downstream
  callers can check presence rather than comparing against zero
- `stuckPrompt`: extracts `pr_number` from evidence and appends
  `Linked PR: #N` line to the extra-context block fed to the LLM
- `suggestedInvestigation`: when the last agent was a `human-review`
  agent in `stopped` state and a PR number is present, inserts an
  actionable hint (`check PR #N for new reviewer feedback`) before
  the generic re-queue instructions
- Tests cover: evidence present/absent in detector, prompt
  includes/omits the line, deterministic body includes PR number

> Changelog: fix(monitor): add pr_number to stuck evidence