### PR TITLE
fix(monitor): store and surface human-review verdict

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -26,6 +26,13 @@ export class AgentRun {
     "costUsd": number;
     "prompt"?: string;
     "result": string;
+
+    /**
+     * Verdict holds the parsed decision for human-review runs ("human" or
+     * "sybra_bug"). Extracted from live agent output at completion time so
+     * it survives Result truncation.
+     */
+    "verdict"?: string;
     "logFile": string;
     "sessionId"?: string;
 

--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -171,9 +171,15 @@ func detectStuckHumanBlocked(t *task.Task, now time.Time, budget time.Duration) 
 			ev["last_agent_role"] = last.Role
 		}
 		ev["last_agent_state"] = last.State
-		if last.Role == "human-review" && last.State == "stopped" && last.Result != "" {
-			if d := parseHumanReviewDecision(last.Result); d != "" {
-				ev["human_review_verdict"] = d
+		if last.Role == "human-review" && last.State == "stopped" {
+			if last.Verdict != "" {
+				ev["human_review_verdict"] = last.Verdict
+			} else if last.Result != "" {
+				// Fallback for runs persisted before the Verdict field was
+				// added: parse from the truncated Result text.
+				if d := parseHumanReviewDecision(last.Result); d != "" {
+					ev["human_review_verdict"] = d
+				}
 			}
 		}
 	}

--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -1,6 +1,8 @@
 package monitor
 
 import (
+	"encoding/json"
+	"regexp"
 	"strings"
 	"time"
 
@@ -169,6 +171,11 @@ func detectStuckHumanBlocked(t *task.Task, now time.Time, budget time.Duration) 
 			ev["last_agent_role"] = last.Role
 		}
 		ev["last_agent_state"] = last.State
+		if last.Role == "human-review" && last.State == "stopped" && last.Result != "" {
+			if d := parseHumanReviewDecision(last.Result); d != "" {
+				ev["human_review_verdict"] = d
+			}
+		}
 	}
 	return &Anomaly{
 		Kind:        KindStuckHumanBlocked,
@@ -328,4 +335,27 @@ func projectAllowed(fn func(string) bool, projectID string) bool {
 		return true
 	}
 	return fn(projectID)
+}
+
+var humanReviewVerdictRe = regexp.MustCompile("(?s)```\\s*sybra-verdict\\s*\\n(.*?)\\n```")
+
+// parseHumanReviewDecision extracts the "decision" field from a sybra-verdict
+// fenced block embedded in the human-review agent result text. Returns "human"
+// or "sybra_bug" on success, empty string on any parse failure.
+func parseHumanReviewDecision(result string) string {
+	m := humanReviewVerdictRe.FindStringSubmatch(result)
+	if len(m) < 2 {
+		return ""
+	}
+	var v struct {
+		Decision string `json:"decision"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(m[1])), &v); err != nil {
+		return ""
+	}
+	d := strings.ToLower(strings.TrimSpace(v.Decision))
+	if d != "human" && d != "sybra_bug" {
+		return ""
+	}
+	return d
 }

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -536,6 +536,60 @@ func TestDetectStuckHumanBlocked_HumanReviewVerdict(t *testing.T) {
 			t.Error("evidence should not contain human_review_verdict when role is not human-review")
 		}
 	})
+
+	t.Run("uses Verdict field when set, even with truncated Result", func(t *testing.T) {
+		// Simulates a long review response where the sybra-verdict block was
+		// cut off during Result truncation but the Verdict field was populated
+		// from the live agent output at completion time.
+		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{
+				{
+					AgentID: "rev1", Role: "human-review", State: "stopped",
+					Result:  "Very long diagnostic writeup... (truncated)",
+					Verdict: "sybra_bug",
+				},
+			}
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		got, ok := report.Anomalies[0].Evidence["human_review_verdict"]
+		if !ok {
+			t.Fatal("evidence missing human_review_verdict")
+		}
+		if got != "sybra_bug" {
+			t.Errorf("human_review_verdict = %q, want %q", got, "sybra_bug")
+		}
+	})
+
+	t.Run("Verdict field takes priority over Result parsing", func(t *testing.T) {
+		// Verdict field wins even when Result also contains a parseable block.
+		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{
+				{
+					AgentID: "rev1", Role: "human-review", State: "stopped",
+					Result:  "```sybra-verdict\n{\"decision\":\"human\"}\n```",
+					Verdict: "sybra_bug",
+				},
+			}
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		got, ok := report.Anomalies[0].Evidence["human_review_verdict"]
+		if !ok {
+			t.Fatal("evidence missing human_review_verdict")
+		}
+		if got != "sybra_bug" {
+			t.Errorf("human_review_verdict = %q, want sybra_bug (Verdict field wins)", got)
+		}
+	})
 }
 
 func TestCounts(t *testing.T) {

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -400,6 +400,144 @@ func TestDetectStuckHumanBlocked_Evidence(t *testing.T) {
 	})
 }
 
+func TestParseHumanReviewDecision(t *testing.T) {
+	cases := []struct {
+		name   string
+		result string
+		want   string
+	}{
+		{
+			name:   "human verdict",
+			result: "Analysis complete.\n\n```sybra-verdict\n{\"decision\":\"human\",\"summary\":\"needs human\"}\n```",
+			want:   "human",
+		},
+		{
+			name:   "sybra_bug verdict",
+			result: "```sybra-verdict\n{\"decision\":\"sybra_bug\",\"summary\":\"workflow misfire\"}\n```",
+			want:   "sybra_bug",
+		},
+		{
+			name:   "case insensitive decision",
+			result: "```sybra-verdict\n{\"decision\":\"HUMAN\"}\n```",
+			want:   "human",
+		},
+		{
+			name:   "no verdict block",
+			result: "No structured verdict here.",
+			want:   "",
+		},
+		{
+			name:   "invalid decision value",
+			result: "```sybra-verdict\n{\"decision\":\"maybe\"}\n```",
+			want:   "",
+		},
+		{
+			name:   "malformed json",
+			result: "```sybra-verdict\n{broken\n```",
+			want:   "",
+		},
+		{
+			name:   "empty result",
+			result: "",
+			want:   "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseHumanReviewDecision(tc.result)
+			if got != tc.want {
+				t.Errorf("parseHumanReviewDecision = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDetectStuckHumanBlocked_HumanReviewVerdict(t *testing.T) {
+	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
+	cfg := defaultCfg()
+
+	t.Run("includes human_review_verdict when result has human decision", func(t *testing.T) {
+		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{
+				{
+					AgentID: "rev1", Role: "human-review", State: "stopped",
+					Result: "Analysis.\n\n```sybra-verdict\n{\"decision\":\"human\",\"summary\":\"needs direct work\"}\n```",
+				},
+			}
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		got, ok := report.Anomalies[0].Evidence["human_review_verdict"]
+		if !ok {
+			t.Fatal("evidence missing human_review_verdict")
+		}
+		if got != "human" {
+			t.Errorf("human_review_verdict = %q, want %q", got, "human")
+		}
+	})
+
+	t.Run("omits human_review_verdict when result is empty", func(t *testing.T) {
+		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{
+				{AgentID: "rev1", Role: "human-review", State: "stopped", Result: ""},
+			}
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		if _, ok := report.Anomalies[0].Evidence["human_review_verdict"]; ok {
+			t.Error("evidence should not contain human_review_verdict when result is empty")
+		}
+	})
+
+	t.Run("omits human_review_verdict when agent still running", func(t *testing.T) {
+		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{
+				{
+					AgentID: "rev1", Role: "human-review", State: "running",
+					Result: "```sybra-verdict\n{\"decision\":\"human\"}\n```",
+				},
+			}
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		if _, ok := report.Anomalies[0].Evidence["human_review_verdict"]; ok {
+			t.Error("evidence should not contain human_review_verdict when agent is still running")
+		}
+	})
+
+	t.Run("omits human_review_verdict when role is not human-review", func(t *testing.T) {
+		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{
+				{
+					AgentID: "fix1", Role: "fix-review", State: "stopped",
+					Result: "```sybra-verdict\n{\"decision\":\"human\"}\n```",
+				},
+			}
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		if _, ok := report.Anomalies[0].Evidence["human_review_verdict"]; ok {
+			t.Error("evidence should not contain human_review_verdict when role is not human-review")
+		}
+	})
+}
+
 func TestCounts(t *testing.T) {
 	tasks := []task.Task{
 		mkTask("a", task.StatusTodo),

--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -233,15 +233,26 @@ func suggestedInvestigation(a Anomaly) string {
 		if lastRole == "human-review" && lastState == "stopped" {
 			taskID, _ := a.Evidence["task_id"].(string)
 			prNum, _ := a.Evidence["pr_number"].(int)
-			hint += "- Human-review agent assessed this task — check the latest auto-review note in the task body.\n"
-			if taskID != "" {
-				if prNum > 0 {
-					hint += fmt.Sprintf("- If note says awaiting PR review: check PR #%d for new reviewer feedback.\n", prNum)
+			verdict, _ := a.Evidence["human_review_verdict"].(string)
+			if verdict == "human" {
+				hint += "- Human-review agent confirmed: this task requires direct human input (scope beyond automation).\n"
+				if taskID != "" {
+					if prNum > 0 {
+						hint += fmt.Sprintf("- If waiting on PR review: check PR #%d for new reviewer feedback.\n", prNum)
+					}
+					hint += "- To hand off for interactive work: `sybra-cli update " + taskID + " --mode interactive --status todo`.\n"
 				}
-				hint += "- Note confirms human input needed: provide it, then `sybra-cli update " + taskID + " --status todo`.\n"
-				hint += "- If the note says scope exceeds automation, switch to interactive mode: `sybra-cli update " + taskID + " --mode interactive --status todo`.\n"
+			} else {
+				hint += "- Human-review agent assessed this task — check the latest auto-review note in the task body.\n"
+				if taskID != "" {
+					if prNum > 0 {
+						hint += fmt.Sprintf("- If note says awaiting PR review: check PR #%d for new reviewer feedback.\n", prNum)
+					}
+					hint += "- Note confirms human input needed: provide it, then `sybra-cli update " + taskID + " --status todo`.\n"
+					hint += "- If the note says scope exceeds automation, switch to interactive mode: `sybra-cli update " + taskID + " --mode interactive --status todo`.\n"
+				}
+				hint += "- Note shows unparseable or failed verdict: review the raw agent output in the note and act accordingly.\n"
 			}
-			hint += "- Note shows unparseable or failed verdict: review the raw agent output in the note and act accordingly.\n"
 		} else if lastRole == "fix-review" && lastState == "stopped" {
 			hint += "- Fix-review agent finished — check the PR and agent log for the outcome, then approve or request further changes.\n"
 		}

--- a/internal/monitor/prompts_test.go
+++ b/internal/monitor/prompts_test.go
@@ -160,6 +160,68 @@ func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_AfterHumanReview
 	}
 }
 
+func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_VerdictHuman(t *testing.T) {
+	a := Anomaly{
+		Kind:        KindStuckHumanBlocked,
+		TaskID:      "abc999",
+		Severity:    SeverityWarn,
+		Fingerprint: "stuck_human_blocked:abc999",
+		DetectedAt:  time.Date(2026, 5, 14, 9, 0, 0, 0, time.UTC),
+		Evidence: map[string]any{
+			"task_id":              "abc999",
+			"status":               "human-required",
+			"dwell_h":              10.0,
+			"last_agent_role":      "human-review",
+			"last_agent_state":     "stopped",
+			"human_review_verdict": "human",
+		},
+	}
+
+	body := DeterministicIssueBody(a)
+
+	if !strings.Contains(body, "confirmed") {
+		t.Error("hint should say verdict was confirmed")
+	}
+	if !strings.Contains(body, "scope beyond automation") {
+		t.Error("hint should mention scope beyond automation")
+	}
+	if !strings.Contains(body, "sybra-cli update abc999 --mode interactive --status todo") {
+		t.Error("hint should include interactive hand-off command")
+	}
+	// When verdict is known-human, the conditional phrasing is no longer needed
+	if strings.Contains(body, "If the note says scope exceeds automation") {
+		t.Error("hint must not show conditional scope hint when verdict is already known")
+	}
+	if strings.Contains(body, "Note confirms human input needed") {
+		t.Error("hint must not show generic note-check when verdict is already known")
+	}
+}
+
+func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_VerdictHuman_WithPR(t *testing.T) {
+	a := Anomaly{
+		Kind:        KindStuckHumanBlocked,
+		TaskID:      "abc999",
+		Severity:    SeverityWarn,
+		Fingerprint: "stuck_human_blocked:abc999",
+		DetectedAt:  time.Date(2026, 5, 14, 9, 0, 0, 0, time.UTC),
+		Evidence: map[string]any{
+			"task_id":              "abc999",
+			"status":               "human-required",
+			"dwell_h":              10.0,
+			"last_agent_role":      "human-review",
+			"last_agent_state":     "stopped",
+			"human_review_verdict": "human",
+			"pr_number":            777,
+		},
+	}
+
+	body := DeterministicIssueBody(a)
+
+	if !strings.Contains(body, "PR #777") {
+		t.Error("hint should include PR number when available even with known verdict")
+	}
+}
+
 func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_AfterFixReview(t *testing.T) {
 	a := Anomaly{
 		Kind:        KindStuckHumanBlocked,

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -126,13 +126,22 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 	if len(truncated) > maxResultLen {
 		truncated = truncated[:maxResultLen] + "\n... (truncated)"
 	}
-	if err := h.tasks.UpdateRun(ag.TaskID, ag.ID, map[string]any{
+	runUpdates := map[string]any{
 		"state":      string(state),
 		"cost_usd":   cost,
 		"result":     truncated,
 		"log_file":   ag.LogPath,
 		"session_id": ag.GetSessionID(),
-	}); err != nil {
+	}
+	// For human-review agents, parse the verdict from the live (untruncated)
+	// output and persist it in its own field so detector.go can read it even
+	// when the full result text is longer than maxResultLen.
+	if agent.RoleFromName(ag.Name) == agent.RoleHumanReview {
+		if v, err := parseVerdict(finalAssistantText(ag)); err == nil {
+			runUpdates["verdict"] = v.Decision
+		}
+	}
+	if err := h.tasks.UpdateRun(ag.TaskID, ag.ID, runUpdates); err != nil {
 		h.logger.Error("task.update-run", "task_id", ag.TaskID, "agent_id", ag.ID, "err", err)
 	}
 

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -142,8 +142,12 @@ type AgentRun struct {
 	CostUSD   float64   `yaml:"cost_usd,omitempty" json:"costUsd"`
 	Prompt    string    `yaml:"prompt,omitempty" json:"prompt,omitempty"`
 	Result    string    `yaml:"result,omitempty" json:"result"`
-	LogFile   string    `yaml:"log_file,omitempty" json:"logFile"`
-	SessionID string    `yaml:"session_id,omitempty" json:"sessionId,omitempty"`
+	// Verdict holds the parsed decision for human-review runs ("human" or
+	// "sybra_bug"). Extracted from live agent output at completion time so
+	// it survives Result truncation.
+	Verdict   string `yaml:"verdict,omitempty" json:"verdict,omitempty"`
+	LogFile   string `yaml:"log_file,omitempty" json:"logFile"`
+	SessionID string `yaml:"session_id,omitempty" json:"sessionId,omitempty"`
 }
 
 type Task struct {

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -674,6 +674,9 @@ func (s *Store) UpdateRun(taskID, agentID string, updates map[string]any) error 
 		if v, ok := updates["result"].(string); ok {
 			t.AgentRuns[i].Result = v
 		}
+		if v, ok := updates["verdict"].(string); ok && v != "" {
+			t.AgentRuns[i].Verdict = v
+		}
 		if v, ok := updates["log_file"].(string); ok {
 			t.AgentRuns[i].LogFile = v
 		}


### PR DESCRIPTION
## Motivation

When a human-review agent produces a long response, the result text gets truncated before persisting. The `sybra-verdict` fenced block — which contains the structured decision — can be cut off, leaving the monitor detector unable to determine the verdict. This caused stuck-human-blocked hints to show generic, non-actionable guidance even when the review agent had already issued a clear decision.

## Implementation information

- Added `Verdict` field to `AgentRun` (model + store) — a dedicated slot for the parsed decision that survives result truncation.
- On human-review agent completion, `agent_completion.go` parses the verdict from the live (untruncated) assistant output and stores it in `Verdict` before the result is capped at `maxResultLen`.
- `detector.go` reads `Verdict` first; falls back to regex-parsing `Result` for runs persisted before this field existed (`parseHumanReviewDecision`).
- `prompts.go` branches on `human_review_verdict` evidence: when the verdict is `"human"`, the hint is direct and actionable (skip the conditional phrasing); when absent or unparseable, the previous generic hint is preserved.

> Changelog: fix(monitor): store and surface human-review verdict