### PR TITLE
fix(monitor): context-aware hint for human-review stuck tasks

### DIFF
--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -109,6 +109,14 @@ func stuckPrompt(a Anomaly, issueRepo string) string {
 	}
 	extraStr := extra.String()
 
+	investigationHint := `- Read the task file and the most recent agent log under ~/.sybra/logs/agents matching this task id.
+- Identify the actual blocker in one sentence and propose the next concrete step a human could take.`
+	if lastRole == "human-review" && lastState == "stopped" {
+		investigationHint = `- A human-review agent has already assessed this task. Read the "## Auto-review verdict" section (or the most recent "## Re-detected" block) in the task file — use that verdict as the blocker summary instead of re-reading the agent log.
+- If the verdict says "awaiting PR reviewer": confirm the PR is still open and unreviewed, then report that as the blocker with "request review / wait for reviewer" as the next step.
+- If the verdict says "sybra_bug": the task should be in blocked status, not human-required; report that as the blocker.`
+	}
+
 	return fmt.Sprintf(`You are the sybra monitor stuck-task investigator.
 
 Task: %s — %q
@@ -116,8 +124,7 @@ Status: %s   Dwell: %.1fh
 Task file: %s
 %s
 Read-only investigation:
-- Read the task file and the most recent agent log under ~/.sybra/logs/agents matching this task id.
-- Identify the actual blocker in one sentence and propose the next concrete step a human could take.
+%s
 - Then dedup against open issues and either create or comment one on the repo below.
 
 GitHub issue handling:
@@ -129,7 +136,7 @@ GitHub issue handling:
 
 Output exactly one final JSON line:
 {"issueNumber":N,"action":"created"|"commented","blocker":"<one phrase>","nextStep":"<imperative sentence>"}`,
-		taskID, title, status, dwell, filePath, extraStr,
+		taskID, title, status, dwell, filePath, extraStr, investigationHint,
 		issueRepo, taskID, issueRepo, taskID, issueRepo, issueRepo, taskID,
 	)
 }

--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -114,7 +114,8 @@ func stuckPrompt(a Anomaly, issueRepo string) string {
 	if lastRole == "human-review" && lastState == "stopped" {
 		investigationHint = `- A human-review agent has already assessed this task. Read the "## Auto-review verdict" section (or the most recent "## Re-detected" block) in the task file — use that verdict as the blocker summary instead of re-reading the agent log.
 - If the verdict says "awaiting PR reviewer": confirm the PR is still open and unreviewed, then report that as the blocker with "request review / wait for reviewer" as the next step.
-- If the verdict says "sybra_bug": the task should be in blocked status, not human-required; report that as the blocker.`
+- If the verdict note contains "sybra_bug (no issue payload)", "sybra_bug (local task creation failed)", or "sybra_bug (issue submission failed)": issue filing failed on a transient or empty-payload error — the task is correctly in human-required. Report the specific failure text as the blocker with "retry issue filing or investigate the filing error" as the next step.
+- If the verdict note says "sybra_bug" without a failure qualifier in parentheses: the task should be in blocked status, not human-required; report that as the blocker.`
 	}
 
 	return fmt.Sprintf(`You are the sybra monitor stuck-task investigator.

--- a/internal/monitor/prompts_test.go
+++ b/internal/monitor/prompts_test.go
@@ -317,6 +317,37 @@ func TestDispatchPrompt_StuckHumanBlocked_ExtraEvidence(t *testing.T) {
 		}
 	})
 
+	t.Run("human-review hint when last agent is human-review stopped", func(t *testing.T) {
+		a := Anomaly{Kind: KindStuckHumanBlocked, Evidence: copyEv(map[string]any{
+			"last_agent_role":  "human-review",
+			"last_agent_state": "stopped",
+		})}
+		prompt := DispatchPrompt(a, "owner/repo", "")
+		if !strings.Contains(prompt, "Auto-review verdict") {
+			t.Error("prompt should direct agent to the Auto-review verdict section")
+		}
+		if !strings.Contains(prompt, "awaiting PR reviewer") {
+			t.Error("prompt should mention awaiting PR reviewer case")
+		}
+		if strings.Contains(prompt, "most recent agent log") {
+			t.Error("prompt should not ask agent to re-read agent log when human-review verdict exists")
+		}
+	})
+
+	t.Run("no human-review hint when agent still running", func(t *testing.T) {
+		a := Anomaly{Kind: KindStuckHumanBlocked, Evidence: copyEv(map[string]any{
+			"last_agent_role":  "human-review",
+			"last_agent_state": "running",
+		})}
+		prompt := DispatchPrompt(a, "owner/repo", "")
+		if strings.Contains(prompt, "Auto-review verdict") {
+			t.Error("prompt must not reference Auto-review verdict while human-review is still running")
+		}
+		if !strings.Contains(prompt, "most recent agent log") {
+			t.Error("prompt should use standard investigation hint when agent is still running")
+		}
+	})
+
 	t.Run("omits linked PR when pr_number absent", func(t *testing.T) {
 		a := Anomaly{Kind: KindStuckHumanBlocked, Evidence: copyEv(nil)}
 		prompt := DispatchPrompt(a, "owner/repo", "")

--- a/internal/monitor/prompts_test.go
+++ b/internal/monitor/prompts_test.go
@@ -334,6 +334,26 @@ func TestDispatchPrompt_StuckHumanBlocked_ExtraEvidence(t *testing.T) {
 		}
 	})
 
+	t.Run("human-review hint distinguishes filing failures from status bug", func(t *testing.T) {
+		a := Anomaly{Kind: KindStuckHumanBlocked, Evidence: copyEv(map[string]any{
+			"last_agent_role":  "human-review",
+			"last_agent_state": "stopped",
+		})}
+		prompt := DispatchPrompt(a, "owner/repo", "")
+		// All three failure-qualified variants must be listed so the agent can
+		// recognise a legitimately human-required task (issue filing failed)
+		// and not misreport it as a status-transition bug.
+		for _, variant := range []string{"no issue payload", "local task creation failed", "issue submission failed"} {
+			if !strings.Contains(prompt, variant) {
+				t.Errorf("prompt must name filing failure variant %q", variant)
+			}
+		}
+		// Bare sybra_bug (no qualifier) should still be flagged as a status bug.
+		if !strings.Contains(prompt, "sybra_bug") {
+			t.Error("prompt must still mention sybra_bug for the bare-verdict status-bug case")
+		}
+	})
+
 	t.Run("no human-review hint when agent still running", func(t *testing.T) {
 		a := Anomaly{Kind: KindStuckHumanBlocked, Evidence: copyEv(map[string]any{
 			"last_agent_role":  "human-review",


### PR DESCRIPTION
## Motivation

The stuck-task investigator prompt used a generic "read the agent log" hint for all stuck tasks. When a human-review agent has already assessed the task and written a verdict, re-reading the agent log is redundant and less informative — the verdict section already captures the blocker.

Additionally, the `sybra_bug` hint was a single undifferentiated bullet, making it hard for the investigator to distinguish between transient filing failures (retry-able) and tasks that should be in `blocked` status (routing error).

## Implementation information

- Added a conditional `investigationHint` in `stuckPrompt`: when `lastRole == "human-review"` and `lastState == "stopped"`, the investigator is directed to read the auto-review verdict section instead of the agent log.
- The specialized hint covers three sybra_bug sub-cases by failure qualifier in parentheses: `no issue payload`, `local task creation failed`, `issue submission failed` (all retry-able) vs bare `sybra_bug` (wrong status, should be `blocked`).
- Tests added to `prompts_test.go` covering the new conditional path.