### PR TITLE
fix(monitor): improve fix-review stuck hint with PR state

### DIFF
--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -264,7 +264,7 @@ func suggestedInvestigation(a Anomaly) string {
 		} else if lastRole == "fix-review" && lastState == "stopped" {
 			hint += "- Fix-review agent finished — check the PR and agent log for the outcome.\n"
 			if prNum > 0 {
-				hint += fmt.Sprintf("- Check PR #%d review state: if CHANGES_REQUESTED run another fix-review agent; if REVIEW_REQUIRED re-request review; if APPROVED merge.\n", prNum)
+				hint += fmt.Sprintf("- Check PR #%d review state: if CHANGES_REQUESTED run another fix-review agent; if REVIEW_REQUIRED re-request review; if APPROVED and CI passes and no conflicts, merge.\n", prNum)
 			} else {
 				hint += "- Check the PR state: address remaining comments, re-request review, or merge if approved.\n"
 			}

--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -236,11 +236,11 @@ func suggestedInvestigation(a Anomaly) string {
 		if reason, _ := a.Evidence["status_reason"].(string); reason != "" {
 			hint += "- Blocking reason: " + reason + "\n"
 		}
+		taskID, _ := a.Evidence["task_id"].(string)
+		prNum, _ := a.Evidence["pr_number"].(int)
 		lastRole, _ := a.Evidence["last_agent_role"].(string)
 		lastState, _ := a.Evidence["last_agent_state"].(string)
 		if lastRole == "human-review" && lastState == "stopped" {
-			taskID, _ := a.Evidence["task_id"].(string)
-			prNum, _ := a.Evidence["pr_number"].(int)
 			verdict, _ := a.Evidence["human_review_verdict"].(string)
 			if verdict == "human" {
 				hint += "- Human-review agent confirmed: this task requires direct human input (scope beyond automation).\n"
@@ -262,7 +262,15 @@ func suggestedInvestigation(a Anomaly) string {
 				hint += "- Note shows unparseable or failed verdict: review the raw agent output in the note and act accordingly.\n"
 			}
 		} else if lastRole == "fix-review" && lastState == "stopped" {
-			hint += "- Fix-review agent finished — check the PR and agent log for the outcome, then approve or request further changes.\n"
+			hint += "- Fix-review agent finished — check the PR and agent log for the outcome.\n"
+			if prNum > 0 {
+				hint += fmt.Sprintf("- Check PR #%d review state: if CHANGES_REQUESTED run another fix-review agent; if REVIEW_REQUIRED re-request review; if APPROVED merge.\n", prNum)
+			} else {
+				hint += "- Check the PR state: address remaining comments, re-request review, or merge if approved.\n"
+			}
+			if taskID != "" {
+				hint += "- Once PR merges, mark task done: `sybra-cli update " + taskID + " --status done`.\n"
+			}
 		}
 		return hint
 	default:

--- a/internal/monitor/prompts_test.go
+++ b/internal/monitor/prompts_test.go
@@ -257,6 +257,36 @@ func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_AfterFixReview(t
 	}
 }
 
+func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_AfterFixReview_WithPR(t *testing.T) {
+	a := Anomaly{
+		Kind:        KindStuckHumanBlocked,
+		TaskID:      "pqr678",
+		Severity:    SeverityWarn,
+		Fingerprint: "stuck_human_blocked:pqr678",
+		DetectedAt:  time.Date(2026, 5, 14, 9, 0, 0, 0, time.UTC),
+		Evidence: map[string]any{
+			"task_id":          "pqr678",
+			"status":           "human-required",
+			"dwell_h":          10.0,
+			"last_agent_role":  "fix-review",
+			"last_agent_state": "stopped",
+			"pr_number":        16601,
+		},
+	}
+
+	body := DeterministicIssueBody(a)
+
+	if !strings.Contains(body, "PR #16601") {
+		t.Error("hint should include PR number when available")
+	}
+	if !strings.Contains(body, "CHANGES_REQUESTED") {
+		t.Error("hint should mention CHANGES_REQUESTED action")
+	}
+	if !strings.Contains(body, "sybra-cli update pqr678 --status done") {
+		t.Error("hint should include done command once PR merges")
+	}
+}
+
 func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_FixReviewStillRunning(t *testing.T) {
 	a := Anomaly{
 		Kind:        KindStuckHumanBlocked,


### PR DESCRIPTION
## Motivation

When a fix-review agent finishes and a task becomes stuck in human-required,
the monitor hint was generic. Operators had no actionable PR-specific guidance
— they had to manually look up the PR number and figure out next steps.

## Implementation information

- Hoist `task_id` and `pr_number` extraction before the `lastRole` branches
  so both are available to all hint paths.
- When `lastRole == "fix-review"` and a PR number is known, emit a
  targeted hint with the PR number and concrete next actions keyed by review
  state (`CHANGES_REQUESTED`, `REVIEW_REQUIRED`, `APPROVED`).
- Refine the APPROVED branch to include CI/conflict readiness: "if APPROVED
  and CI passes and no conflicts, merge."
- Add a `sybra-cli update <id> --status done` reminder once the PR merges.
- Add `TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_AfterFixReview_WithPR`
  covering the PR-number path.

> Changelog: fix(monitor): improve fix-review stuck hint with PR state