### PR TITLE
fix(monitor): dispatch hint for fix-review stopped

### DIFF
--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -116,6 +116,20 @@ func stuckPrompt(a Anomaly, issueRepo string) string {
 - If the verdict says "awaiting PR reviewer": confirm the PR is still open and unreviewed, then report that as the blocker with "request review / wait for reviewer" as the next step.
 - If the verdict note contains "sybra_bug (no issue payload)", "sybra_bug (local task creation failed)", or "sybra_bug (issue submission failed)": issue filing failed on a transient or empty-payload error — the task is correctly in human-required. Report the specific failure text as the blocker with "retry issue filing or investigate the filing error" as the next step.
 - If the verdict note says "sybra_bug" without a failure qualifier in parentheses: the task should be in blocked status, not human-required; report that as the blocker.`
+	} else if lastRole == "fix-review" && lastState == "stopped" {
+		prRef := "the PR"
+		if prNumber > 0 {
+			prRef = fmt.Sprintf("PR #%d", prNumber)
+		}
+		doneCmd := ""
+		if taskID != "" {
+			doneCmd = "\n- Once " + prRef + " merges, mark task done: `sybra-cli update " + taskID + " --status done`."
+		}
+		investigationHint = "- A fix-review agent already ran — skip the agent log and check " + prRef + " review state with `gh pr view --json reviewDecision,statusCheckRollup`.\n" +
+			"- If CHANGES_REQUESTED: new review comments arrived — report that as the blocker with \"run another fix-review agent\" as the next step.\n" +
+			"- If REVIEW_REQUIRED: fixes were pushed but review was not re-requested — report \"awaiting re-review\" with \"re-request review\" as the next step.\n" +
+			"- If APPROVED and CI passes: report \"ready to merge\" with \"merge the PR\" as the next step." +
+			doneCmd
 	}
 
 	return fmt.Sprintf(`You are the sybra monitor stuck-task investigator.

--- a/internal/monitor/prompts_test.go
+++ b/internal/monitor/prompts_test.go
@@ -460,6 +460,63 @@ func TestDispatchPrompt_StuckHumanBlocked_ExtraEvidence(t *testing.T) {
 		}
 	})
 
+	t.Run("fix-review hint when last agent is fix-review stopped", func(t *testing.T) {
+		a := Anomaly{Kind: KindStuckHumanBlocked, Evidence: copyEv(map[string]any{
+			"last_agent_role":  "fix-review",
+			"last_agent_state": "stopped",
+		})}
+		prompt := DispatchPrompt(a, "owner/repo", "")
+		if strings.Contains(prompt, "most recent agent log") {
+			t.Error("prompt must not ask agent to re-read agent log when fix-review already ran")
+		}
+		if !strings.Contains(prompt, "reviewDecision") {
+			t.Error("prompt should direct agent to check PR review state")
+		}
+		if !strings.Contains(prompt, "CHANGES_REQUESTED") {
+			t.Error("prompt should mention CHANGES_REQUESTED case")
+		}
+		if !strings.Contains(prompt, "REVIEW_REQUIRED") {
+			t.Error("prompt should mention REVIEW_REQUIRED case")
+		}
+	})
+
+	t.Run("fix-review hint includes task done command", func(t *testing.T) {
+		a := Anomaly{Kind: KindStuckHumanBlocked, Evidence: copyEv(map[string]any{
+			"last_agent_role":  "fix-review",
+			"last_agent_state": "stopped",
+		})}
+		prompt := DispatchPrompt(a, "owner/repo", "")
+		if !strings.Contains(prompt, "sybra-cli update abc --status done") {
+			t.Error("prompt should include done command for task id")
+		}
+	})
+
+	t.Run("fix-review hint includes PR number when available", func(t *testing.T) {
+		a := Anomaly{Kind: KindStuckHumanBlocked, Evidence: copyEv(map[string]any{
+			"last_agent_role":  "fix-review",
+			"last_agent_state": "stopped",
+			"pr_number":        16601,
+		})}
+		prompt := DispatchPrompt(a, "owner/repo", "")
+		if !strings.Contains(prompt, "PR #16601") {
+			t.Error("prompt should mention specific PR number when available")
+		}
+	})
+
+	t.Run("no fix-review hint when agent still running", func(t *testing.T) {
+		a := Anomaly{Kind: KindStuckHumanBlocked, Evidence: copyEv(map[string]any{
+			"last_agent_role":  "fix-review",
+			"last_agent_state": "running",
+		})}
+		prompt := DispatchPrompt(a, "owner/repo", "")
+		if strings.Contains(prompt, "reviewDecision") {
+			t.Error("prompt must not reference PR review state while fix-review is still running")
+		}
+		if !strings.Contains(prompt, "most recent agent log") {
+			t.Error("prompt should use standard investigation hint when fix-review agent is still running")
+		}
+	})
+
 	t.Run("omits linked PR when pr_number absent", func(t *testing.T) {
 		a := Anomaly{Kind: KindStuckHumanBlocked, Evidence: copyEv(nil)}
 		prompt := DispatchPrompt(a, "owner/repo", "")


### PR DESCRIPTION
## Motivation

When a `fix-review` agent finishes (state=stopped) and the task lands in `human-required`, the monitor's dispatch prompt was using the generic investigation path — which asks the investigator to re-read the agent log. That's wasted work: the agent already ran, the log is not the signal. The PR review state is.

## Implementation information

Added a new branch in `stuckPrompt` that fires when `last_agent_role == "fix-review"` and `last_agent_state == "stopped"`. The hint:

- Skips the agent log and directs straight to `gh pr view --json reviewDecision,statusCheckRollup`.
- Handles all three terminal review states: `CHANGES_REQUESTED`, `REVIEW_REQUIRED` (fixes pushed, re-review not requested), and `APPROVED + CI green` (merge).
- Injects a `sybra-cli update <id> --status done` command when PR merges if a task ID is present.
- References the specific PR number (`PR #N`) when `pr_number` evidence is available.

Tests cover: hint triggered for stopped fix-review, not triggered for running fix-review, PR number interpolation, done command inclusion.

> Changelog: fix(monitor): dispatch hint for fix-review stopped