### PR TITLE
fix(monitor): no LLM when verdict=human

### DIFF
--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -183,11 +183,14 @@ func detectStuckHumanBlocked(t *task.Task, now time.Time, budget time.Duration) 
 			}
 		}
 	}
+	// When human-review already confirmed the task needs direct human work,
+	// the deterministic hint is sufficient — no LLM investigation adds value.
+	requiresLLM := ev["human_review_verdict"] != "human"
 	return &Anomaly{
 		Kind:        KindStuckHumanBlocked,
 		TaskID:      t.ID,
 		Severity:    SeverityWarn,
-		RequiresLLM: true,
+		RequiresLLM: requiresLLM,
 		Fingerprint: Fingerprint(KindStuckHumanBlocked, t.ID, ev),
 		Evidence:    ev,
 		DetectedAt:  now,

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -630,6 +630,77 @@ func TestDetectStuckHumanBlocked_HumanReviewVerdict(t *testing.T) {
 	})
 }
 
+func TestDetectStuckHumanBlocked_RequiresLLM(t *testing.T) {
+	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
+	cfg := defaultCfg()
+
+	t.Run("RequiresLLM=false when human-review verdict is human", func(t *testing.T) {
+		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{
+				{AgentID: "rev1", Role: "human-review", State: "stopped", Verdict: "human"},
+			}
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		if report.Anomalies[0].RequiresLLM {
+			t.Error("RequiresLLM must be false when human-review confirmed verdict=human")
+		}
+	})
+
+	t.Run("RequiresLLM=true when human-review verdict is sybra_bug", func(t *testing.T) {
+		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{
+				{AgentID: "rev1", Role: "human-review", State: "stopped", Verdict: "sybra_bug"},
+			}
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		if !report.Anomalies[0].RequiresLLM {
+			t.Error("RequiresLLM must be true when verdict is sybra_bug")
+		}
+	})
+
+	t.Run("RequiresLLM=true when no human-review ran", func(t *testing.T) {
+		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		if !report.Anomalies[0].RequiresLLM {
+			t.Error("RequiresLLM must be true when no human-review verdict is known")
+		}
+	})
+
+	t.Run("RequiresLLM=true when human-review still running", func(t *testing.T) {
+		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{
+				{AgentID: "rev1", Role: "human-review", State: "running", Verdict: "human"},
+			}
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		// Verdict field on a running agent is not surfaced, so RequiresLLM stays true.
+		if !report.Anomalies[0].RequiresLLM {
+			t.Error("RequiresLLM must be true when human-review is still running")
+		}
+	})
+}
+
 func TestCounts(t *testing.T) {
 	tasks := []task.Task{
 		mkTask("a", task.StatusTodo),


### PR DESCRIPTION
## Motivation

When a task already has a human-review verdict set, the monitor was unnecessarily invoking an LLM to analyze the stuck state. This wasted tokens and added latency for a case that can be handled deterministically.

## Implementation information

- Skip LLM invocation in the stuck-human-blocked path when `verdict=human` is already set on the task
- Build on previous improvements to stuck-human-blocked detection: richer evidence, PR state in hints, context-aware hint generation, human-review verdict storage and surfacing, deduplication by fingerprint
- The verdict is stored on the task and surfaced in the monitor so downstream logic can branch without re-querying the LLM

> Changelog: fix(monitor): no LLM when verdict=human