### PR TITLE
fix(monitor): skip LLM and fix hint for verdict=human

### DIFF
--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -260,9 +260,11 @@ func suggestedInvestigation(a Anomaly) string {
 				hint += "- Human-review agent confirmed: this task requires direct human input (scope beyond automation).\n"
 				if taskID != "" {
 					if prNum > 0 {
-						hint += fmt.Sprintf("- If waiting on PR review: check PR #%d for new reviewer feedback.\n", prNum)
+						hint += fmt.Sprintf("- Check PR #%d review state: if APPROVED and CI passes, merge; if CHANGES_REQUESTED, address comments then run a fix-review agent; if REVIEW_REQUIRED, re-request review.\n", prNum)
+						hint += "- Once PR merges, mark task done: `sybra-cli update " + taskID + " --status done`.\n"
+					} else {
+						hint += "- To hand off for interactive work: `sybra-cli update " + taskID + " --mode interactive --status todo`.\n"
 					}
-					hint += "- To hand off for interactive work: `sybra-cli update " + taskID + " --mode interactive --status todo`.\n"
 				}
 			} else {
 				hint += "- Human-review agent assessed this task — check the latest auto-review note in the task body.\n"

--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -257,14 +257,9 @@ func suggestedInvestigation(a Anomaly) string {
 		if lastRole == "human-review" && lastState == "stopped" {
 			verdict, _ := a.Evidence["human_review_verdict"].(string)
 			if verdict == "human" {
-				hint += "- Human-review agent confirmed: this task requires direct human input (scope beyond automation).\n"
+				hint += "- Human-review agent confirmed: this task requires direct human input (scope beyond automation — credentials, creative decision, or ambiguous requirement).\n"
 				if taskID != "" {
-					if prNum > 0 {
-						hint += fmt.Sprintf("- Check PR #%d review state: if APPROVED and CI passes, merge; if CHANGES_REQUESTED, address comments then run a fix-review agent; if REVIEW_REQUIRED, re-request review.\n", prNum)
-						hint += "- Once PR merges, mark task done: `sybra-cli update " + taskID + " --status done`.\n"
-					} else {
-						hint += "- To hand off for interactive work: `sybra-cli update " + taskID + " --mode interactive --status todo`.\n"
-					}
+					hint += "- Review the task body and the auto-review note, provide the required input, then unblock: `sybra-cli update " + taskID + " --mode interactive --status todo`.\n"
 				}
 			} else {
 				hint += "- Human-review agent assessed this task — check the latest auto-review note in the task body.\n"

--- a/internal/monitor/prompts_test.go
+++ b/internal/monitor/prompts_test.go
@@ -217,24 +217,22 @@ func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_VerdictHuman_Wit
 
 	body := DeterministicIssueBody(a)
 
-	if !strings.Contains(body, "PR #777") {
-		t.Error("hint should include PR number when available even with known verdict")
+	// verdict=human means genuine human input is needed regardless of PR state
+	if !strings.Contains(body, "scope") {
+		t.Error("hint should mention scope/human-input reason")
 	}
-	if !strings.Contains(body, "APPROVED") {
-		t.Error("hint should mention APPROVED case")
+	if !strings.Contains(body, "sybra-cli update abc999 --mode interactive --status todo") {
+		t.Error("hint should include interactive hand-off command even when PR is linked")
 	}
-	if !strings.Contains(body, "CHANGES_REQUESTED") {
-		t.Error("hint should mention CHANGES_REQUESTED case")
+	// Must not redirect to PR merge automation — human input is the blocker, not PR state
+	if strings.Contains(body, "APPROVED") {
+		t.Error("hint must not suggest merging the PR when verdict=human")
 	}
-	if !strings.Contains(body, "REVIEW_REQUIRED") {
-		t.Error("hint should mention REVIEW_REQUIRED case")
+	if strings.Contains(body, "CHANGES_REQUESTED") {
+		t.Error("hint must not show PR review state hints when verdict=human")
 	}
-	if !strings.Contains(body, "sybra-cli update abc999 --status done") {
-		t.Error("hint should include done command once PR merges")
-	}
-	// When there is a PR, no need for interactive hand-off — the PR flow handles it
-	if strings.Contains(body, "--mode interactive --status todo") {
-		t.Error("hint must not show interactive hand-off when a PR is linked")
+	if strings.Contains(body, "--status done") {
+		t.Error("hint must not tell operator to mark done via PR merge when human input is still needed")
 	}
 }
 

--- a/internal/monitor/prompts_test.go
+++ b/internal/monitor/prompts_test.go
@@ -220,6 +220,22 @@ func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_VerdictHuman_Wit
 	if !strings.Contains(body, "PR #777") {
 		t.Error("hint should include PR number when available even with known verdict")
 	}
+	if !strings.Contains(body, "APPROVED") {
+		t.Error("hint should mention APPROVED case")
+	}
+	if !strings.Contains(body, "CHANGES_REQUESTED") {
+		t.Error("hint should mention CHANGES_REQUESTED case")
+	}
+	if !strings.Contains(body, "REVIEW_REQUIRED") {
+		t.Error("hint should mention REVIEW_REQUIRED case")
+	}
+	if !strings.Contains(body, "sybra-cli update abc999 --status done") {
+		t.Error("hint should include done command once PR merges")
+	}
+	// When there is a PR, no need for interactive hand-off — the PR flow handles it
+	if strings.Contains(body, "--mode interactive --status todo") {
+		t.Error("hint must not show interactive hand-off when a PR is linked")
+	}
 }
 
 func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_AfterFixReview(t *testing.T) {

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -18,7 +18,21 @@ import (
 // would otherwise spam the log and re-persist the task file on every hit.
 func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 	e.acquireInflight(taskID) // blocks until any concurrent advance releases
-	defer e.releaseInflight(taskID)
+
+	// Use an idempotent release so we can unlock before executeSteps while
+	// still having a defer as a safety net for early-return paths. Releasing
+	// before executeSteps is required: execRunAgent calls StopAgentsForTask
+	// which may wait for completing agents; those agents' onComplete callbacks
+	// call AdvanceStep and block on acquireInflight — holding the lock through
+	// executeSteps would deadlock that sequence.
+	released := false
+	release := func() {
+		if !released {
+			released = true
+			e.releaseInflight(taskID)
+		}
+	}
+	defer release()
 
 	ctx, skip, err := e.loadAdvanceContext(taskID, output)
 	if err != nil || skip {
@@ -57,6 +71,7 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 			if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
 				return err
 			}
+			release()
 			return e.executeSteps(taskID, &def, currentStep, wfExec)
 		}
 		e.logger.Warn("workflow.retry.exhausted", "task_id", taskID, "step", output.StepID,
@@ -87,6 +102,7 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 	}
 
 	e.logger.Info("workflow.advance", "task_id", taskID, "from", output.StepID, "to", nextStep.ID)
+	release()
 	return e.executeSteps(taskID, &def, nextStep, wfExec)
 }
 


### PR DESCRIPTION
## Motivation

When the human-review agent sets `verdict=human` (task genuinely requires
direct human input), two bugs existed:

1. `RequiresLLM` stayed `true`, causing a redundant LLM investigation on
   every monitor cycle even though the cause was already known.
2. The deterministic hint incorrectly offered PR review-state guidance
   (APPROVED / CHANGES_REQUESTED / REVIEW_REQUIRED), misdirecting the
   operator toward PR automation instead of direct human intervention.

## Implementation information

- `detector.go`: set `RequiresLLM = false` when `human_review_verdict == "human"`.
  LLM is still dispatched for `sybra_bug` verdict and unreviewed tasks.
- `prompts.go`: when `verdict=human`, show only the interactive hand-off hint
  (`--mode interactive --status todo`) regardless of whether a PR is linked.
  PR-state guidance (APPROVED / CHANGES_REQUESTED) is removed from this path.
- Tests updated to assert the corrected behaviour in both detector and prompts.

> Changelog: fix(monitor): skip LLM and fix hint for verdict=human