### PR TITLE
fix(monitor): improve stuck-human-blocked detection and hints

### DIFF
--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -130,7 +130,7 @@ func stuckPrompt(a Anomaly, issueRepo string) string {
 			mergedCmd = "`sybra-cli update " + taskID + " --status done`"
 		}
 		investigationHint = "- A fix-review agent already ran — skip the agent log and check " + prRef + " state with `gh pr view --json state,reviewDecision,statusCheckRollup`.\n" +
-			"- If state=MERGED: the PR has already been merged — run " + mergedCmd + " and exit immediately.\n" +
+			"- If state=MERGED: the PR has already been merged. Run " + mergedCmd + ". Skip issue filing and output: {\"issueNumber\":null,\"action\":\"remediated\",\"blocker\":\"PR already merged\",\"nextStep\":\"none\"}.\n" +
 			"- If CHANGES_REQUESTED: new review comments arrived — report that as the blocker with \"run another fix-review agent\" as the next step.\n" +
 			"- If REVIEW_REQUIRED: fixes were pushed but review was not re-requested — report \"awaiting re-review\" with \"re-request review\" as the next step.\n" +
 			"- If APPROVED and CI passes: report \"ready to merge\" with \"merge the PR\" as the next step." +
@@ -155,7 +155,7 @@ GitHub issue handling:
 - On miss: gh issue create --repo %s --title "[monitor] stuck_human_blocked: %s" --body "..." --label monitor,bug
 
 Output exactly one final JSON line:
-{"issueNumber":N,"action":"created"|"commented","blocker":"<one phrase>","nextStep":"<imperative sentence>"}`,
+{"issueNumber":N,"action":"created"|"commented"|"remediated","blocker":"<one phrase>","nextStep":"<imperative sentence>"}`,
 		taskID, title, status, dwell, filePath, extraStr, investigationHint,
 		issueRepo, taskID, issueRepo, taskID, issueRepo, issueRepo, taskID,
 	)

--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -125,7 +125,12 @@ func stuckPrompt(a Anomaly, issueRepo string) string {
 		if taskID != "" {
 			doneCmd = "\n- Once " + prRef + " merges, mark task done: `sybra-cli update " + taskID + " --status done`."
 		}
-		investigationHint = "- A fix-review agent already ran — skip the agent log and check " + prRef + " review state with `gh pr view --json reviewDecision,statusCheckRollup`.\n" +
+		mergedCmd := ""
+		if taskID != "" {
+			mergedCmd = "`sybra-cli update " + taskID + " --status done`"
+		}
+		investigationHint = "- A fix-review agent already ran — skip the agent log and check " + prRef + " state with `gh pr view --json state,reviewDecision,statusCheckRollup`.\n" +
+			"- If state=MERGED: the PR has already been merged — run " + mergedCmd + " and exit immediately.\n" +
 			"- If CHANGES_REQUESTED: new review comments arrived — report that as the blocker with \"run another fix-review agent\" as the next step.\n" +
 			"- If REVIEW_REQUIRED: fixes were pushed but review was not re-requested — report \"awaiting re-review\" with \"re-request review\" as the next step.\n" +
 			"- If APPROVED and CI passes: report \"ready to merge\" with \"merge the PR\" as the next step." +
@@ -278,9 +283,9 @@ func suggestedInvestigation(a Anomaly) string {
 		} else if lastRole == "fix-review" && lastState == "stopped" {
 			hint += "- Fix-review agent finished — check the PR and agent log for the outcome.\n"
 			if prNum > 0 {
-				hint += fmt.Sprintf("- Check PR #%d review state: if CHANGES_REQUESTED run another fix-review agent; if REVIEW_REQUIRED re-request review; if APPROVED and CI passes and no conflicts, merge.\n", prNum)
+				hint += fmt.Sprintf("- Check PR #%d state: if MERGED mark task done immediately (`sybra-cli update %s --status done`); if CHANGES_REQUESTED run another fix-review agent; if REVIEW_REQUIRED re-request review; if APPROVED and CI passes merge.\n", prNum, taskID)
 			} else {
-				hint += "- Check the PR state: address remaining comments, re-request review, or merge if approved.\n"
+				hint += "- Check the PR state: if already merged mark task done; address remaining comments, re-request review, or merge if approved.\n"
 			}
 			if taskID != "" {
 				hint += "- Once PR merges, mark task done: `sybra-cli update " + taskID + " --status done`.\n"

--- a/internal/monitor/prompts_test.go
+++ b/internal/monitor/prompts_test.go
@@ -287,6 +287,33 @@ func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_AfterFixReview_W
 	}
 }
 
+func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_AfterFixReview_WithPR_MergedCase(t *testing.T) {
+	a := Anomaly{
+		Kind:        KindStuckHumanBlocked,
+		TaskID:      "pqr678",
+		Severity:    SeverityWarn,
+		Fingerprint: "stuck_human_blocked:pqr678",
+		DetectedAt:  time.Date(2026, 5, 14, 9, 0, 0, 0, time.UTC),
+		Evidence: map[string]any{
+			"task_id":          "pqr678",
+			"status":           "human-required",
+			"dwell_h":          10.0,
+			"last_agent_role":  "fix-review",
+			"last_agent_state": "stopped",
+			"pr_number":        16601,
+		},
+	}
+
+	body := DeterministicIssueBody(a)
+
+	if !strings.Contains(body, "MERGED") {
+		t.Error("hint should mention MERGED case for already-merged PRs")
+	}
+	if !strings.Contains(body, "sybra-cli update pqr678 --status done") {
+		t.Error("hint should include done command for merged PR case")
+	}
+}
+
 func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired_FixReviewStillRunning(t *testing.T) {
 	a := Anomaly{
 		Kind:        KindStuckHumanBlocked,
@@ -500,6 +527,20 @@ func TestDispatchPrompt_StuckHumanBlocked_ExtraEvidence(t *testing.T) {
 		prompt := DispatchPrompt(a, "owner/repo", "")
 		if !strings.Contains(prompt, "PR #16601") {
 			t.Error("prompt should mention specific PR number when available")
+		}
+	})
+
+	t.Run("fix-review hint includes MERGED case", func(t *testing.T) {
+		a := Anomaly{Kind: KindStuckHumanBlocked, Evidence: copyEv(map[string]any{
+			"last_agent_role":  "fix-review",
+			"last_agent_state": "stopped",
+		})}
+		prompt := DispatchPrompt(a, "owner/repo", "")
+		if !strings.Contains(prompt, "state=MERGED") {
+			t.Error("prompt should mention MERGED case for fix-review")
+		}
+		if !strings.Contains(prompt, "state,reviewDecision") {
+			t.Error("prompt should include state field in gh pr view command")
 		}
 	})
 


### PR DESCRIPTION
## Motivation

The monitor's stuck-human-blocked anomaly detector produced vague, low-signal hints that made it hard to understand why a task was blocked and what action to take. Human-review verdict was not stored or surfaced, fix-review state was ignored in hint generation, and deduplication was fragile.

## Implementation information

- Added `stuck_human_blocked` hint split by blocking status (interactive vs. human-required)
- Surface PR number in stuck evidence so hints can reference the open PR
- Store and surface human-review verdict; skip LLM invocation when verdict is already `human`
- Context-aware hint for human-review stuck tasks using stored verdict
- Richer evidence bundle: PR state, review verdict, blocking reason
- Dedup anomalies by fingerprint (survives task renames)
- Fix-review hint includes PR state (open/merged/closed) and handles MERGED as unambiguous terminal path
- Dispatch hint for fix-review stopped agents