### PR TITLE
fix(pr-monitor): auto-done human-required on merge

### DIFF
--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -97,17 +97,25 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 		return prPollSlow
 	}
 
-	var matchers []github.TaskMatcher
+	var (
+		matchers       []github.TaskMatcher
+		closedMatchers []github.TaskMatcher
+	)
 	for i := range tasks {
-		if !prMonitorEligible(&tasks[i]) {
-			continue
-		}
-		matchers = append(matchers, github.TaskMatcher{
+		m := github.TaskMatcher{
 			ID:        tasks[i].ID,
 			PRNumber:  tasks[i].PRNumber,
 			Branch:    tasks[i].Branch,
 			ProjectID: tasks[i].ProjectID,
-		})
+		}
+		if prMonitorEligible(&tasks[i]) {
+			matchers = append(matchers, m)
+			closedMatchers = append(closedMatchers, m)
+		} else if prClosedEligible(&tasks[i]) {
+			// human-required tasks are excluded from pr-fix dispatch but still
+			// advance to done when their PR is merged.
+			closedMatchers = append(closedMatchers, m)
+		}
 	}
 
 	monitoredPRs := r.monitoredPRs(summary)
@@ -141,8 +149,10 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 			}
 			r.handlePRIssue(issues[i])
 		}
+	}
 
-		closedPRs := github.DetectClosedTaskPRs(monitoredPRs, matchers, github.FetchPRState)
+	if len(closedMatchers) > 0 {
+		closedPRs := github.DetectClosedTaskPRs(monitoredPRs, closedMatchers, github.FetchPRState)
 		for _, c := range closedPRs {
 			if r.agents.HasRunningAgentForTask(c.TaskID) {
 				r.logger.Info("pr-monitor.closed-skip-running-agent", "task_id", c.TaskID, "pr", c.PRNumber)
@@ -279,6 +289,20 @@ func prMonitorEligible(t *task.Task) bool {
 	default:
 		return false
 	}
+}
+
+// prClosedEligible is a superset of prMonitorEligible: it additionally includes
+// human-required tasks that carry a PR number. Those tasks are excluded from
+// pr-fix dispatch and auto-merge (they need operator attention) but should
+// still advance to done when their PR is merged or closed.
+func prClosedEligible(t *task.Task) bool {
+	if prMonitorEligible(t) {
+		return true
+	}
+	if t.TaskType == task.TaskTypeChat || slices.Contains(t.Tags, "review") {
+		return false
+	}
+	return t.Status == task.StatusHumanRequired && t.PRNumber != 0
 }
 
 func prNeedsAttention(prs []github.PullRequest) bool {

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -71,7 +71,7 @@ func TestPRMonitorEligible(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "human-required with PR — not eligible, needs operator action first",
+			name: "human-required with PR — excluded from pr-fix dispatch (see prClosedEligible for auto-done)",
 			tk:   task.Task{Status: task.StatusHumanRequired, PRNumber: 42},
 			want: false,
 		},
@@ -81,6 +81,63 @@ func TestPRMonitorEligible(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := prMonitorEligible(&tt.tk); got != tt.want {
 				t.Errorf("prMonitorEligible(%+v) = %v, want %v", tt.tk, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrClosedEligible(t *testing.T) {
+	tests := []struct {
+		name string
+		tk   task.Task
+		want bool
+	}{
+		{
+			name: "in-review with PR — eligible (via prMonitorEligible)",
+			tk:   task.Task{Status: task.StatusInReview, PRNumber: 42},
+			want: true,
+		},
+		{
+			name: "in-progress with PR — eligible (via prMonitorEligible)",
+			tk:   task.Task{Status: task.StatusInProgress, PRNumber: 42},
+			want: true,
+		},
+		{
+			name: "human-required with PR — eligible for auto-done when merged",
+			tk:   task.Task{Status: task.StatusHumanRequired, PRNumber: 42},
+			want: true,
+		},
+		{
+			name: "human-required with branch only — not eligible (no PR to detect)",
+			tk:   task.Task{Status: task.StatusHumanRequired, Branch: "feat"},
+			want: false,
+		},
+		{
+			name: "human-required review tag — excluded (inbound review, handled separately)",
+			tk:   task.Task{Status: task.StatusHumanRequired, PRNumber: 42, Tags: []string{"review"}},
+			want: false,
+		},
+		{
+			name: "human-required chat task — excluded",
+			tk:   task.Task{TaskType: task.TaskTypeChat, Status: task.StatusHumanRequired, PRNumber: 42},
+			want: false,
+		},
+		{
+			name: "todo with PR — not eligible",
+			tk:   task.Task{Status: task.StatusTodo, PRNumber: 42},
+			want: false,
+		},
+		{
+			name: "done with PR — not eligible (terminal)",
+			tk:   task.Task{Status: task.StatusDone, PRNumber: 42},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := prClosedEligible(&tt.tk); got != tt.want {
+				t.Errorf("prClosedEligible(%+v) = %v, want %v", tt.tk, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Motivation

`human-required` tasks with a linked PR were never advancing to `done` when
their PR was merged. The PR-monitor skipped them entirely — they passed
`prMonitorEligible` (which excludes human-required) and never reached the
closed-PR detection path, leaving tasks permanently stuck at
`human-required` even after the underlying work landed.

## Implementation information

Introduced `prClosedEligible` as a superset of `prMonitorEligible`. It
returns `true` for `human-required` tasks that carry a PR number (excluding
chat tasks and review-tagged tasks). A separate `closedMatchers` slice is
built from both eligible sets and fed to `DetectClosedTaskPRs`, which now
runs even when the main pr-fix dispatch loop has nothing to act on.

Human-required tasks remain excluded from the pr-fix dispatch and auto-merge
logic — they only participate in the closed/merged transition.

Tests added in `app_reviews_unit_test.go` covering the new eligibility path.

> Changelog: fix(pr-monitor): auto-done human-required on merge