### PR TITLE
fix(monitor): skip LLM for stuck plan-review

### DIFF
--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -183,9 +183,9 @@ func detectStuckHumanBlocked(t *task.Task, now time.Time, budget time.Duration) 
 			}
 		}
 	}
-	// When human-review already confirmed the task needs direct human work,
-	// the deterministic hint is sufficient — no LLM investigation adds value.
-	requiresLLM := ev["human_review_verdict"] != "human"
+	// plan-review is always deterministic: human must approve or reject the plan.
+	// For human-required, skip LLM only when human-review confirmed verdict=human.
+	requiresLLM := t.Status != task.StatusPlanReview && ev["human_review_verdict"] != "human"
 	return &Anomaly{
 		Kind:        KindStuckHumanBlocked,
 		TaskID:      t.ID,

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -634,6 +634,20 @@ func TestDetectStuckHumanBlocked_RequiresLLM(t *testing.T) {
 	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
 	cfg := defaultCfg()
 
+	t.Run("RequiresLLM=false when status is plan-review", func(t *testing.T) {
+		tk := mkTask("a", task.StatusPlanReview, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		if report.Anomalies[0].RequiresLLM {
+			t.Error("RequiresLLM must be false for plan-review — action is deterministic")
+		}
+	})
+
 	t.Run("RequiresLLM=false when human-review verdict is human", func(t *testing.T) {
 		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
 			t.UpdatedAt = now.Add(-9 * time.Hour)

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -81,7 +81,15 @@ func (m *memTasks) GetTask(id string) (TaskInfo, error) {
 	if !ok {
 		return TaskInfo{}, fmt.Errorf("task %s not found", id)
 	}
-	return *t, nil
+	cp := *t
+	// Shallow-copy the Execution struct so concurrent callers each get their
+	// own State field — mirroring the file-backed store which always
+	// deserializes a fresh object.
+	if t.Workflow != nil {
+		wf := *t.Workflow
+		cp.Workflow = &wf
+	}
+	return cp, nil
 }
 
 func (m *memTasks) ListTasks() ([]TaskInfo, error) {
@@ -143,7 +151,10 @@ func (m *memTasks) SetWorkflow(id string, wf *Execution) error {
 	if !ok {
 		return fmt.Errorf("task %s not found", id)
 	}
-	t.Workflow = wf
+	// Store a copy so the engine's wfExec pointer is decoupled from the
+	// store — mirrors the file-backed store which always serializes/deserializes.
+	wfCopy := *wf
+	t.Workflow = &wfCopy
 	return nil
 }
 


### PR DESCRIPTION
## Motivation

Tasks stuck in `plan-review` status have a deterministic action: the human must approve or reject the plan. Invoking LLM investigation for these tasks adds no value and wastes tokens.

Previously, `requiresLLM` was only suppressed when `human_review_verdict == "human"`, leaving `plan-review` tasks incorrectly flagged as needing LLM analysis.

## Implementation information

Added `t.Status != task.StatusPlanReview` as an additional short-circuit in `detectStuckHumanBlocked` so that `plan-review` anomalies always set `RequiresLLM = false`.

Added a test case in `TestDetectStuckHumanBlocked_RequiresLLM` that asserts `RequiresLLM` is false for a task in `plan-review` status stuck for 9 hours.

> Changelog: fix(monitor): skip LLM for stuck plan-review