### PR TITLE
fix(monitor): skip workflow and set human-required for plan-review stuck

### DIFF
--- a/internal/sybra/monitor_sink.go
+++ b/internal/sybra/monitor_sink.go
@@ -100,6 +100,12 @@ func (s *monitorRoutingSink) Submit(ctx context.Context, a monitor.Anomaly, body
 	}
 	if _, err := s.tasks.Update(newTask.ID, update); err != nil {
 		s.logger.Warn("monitor.routing.local.tag", "new_task_id", newTask.ID, "err", err)
+		if isPlanReviewAnomaly(a) {
+			// Update failed: task is stuck in todo with no workflow dispatched
+			// and human-required status not applied. Fail Submit so the anomaly
+			// is not silently dropped and can be retried on the next cycle.
+			return false, err
+		}
 	}
 	if !isPlanReviewAnomaly(a) {
 		s.dispatchCreatedWorkflow(newTask.ID)

--- a/internal/sybra/monitor_sink.go
+++ b/internal/sybra/monitor_sink.go
@@ -91,14 +91,34 @@ func (s *monitorRoutingSink) Submit(ctx context.Context, a monitor.Anomaly, body
 		pid := s.projectID
 		update.ProjectID = &pid
 	}
+	// plan-review stuck tasks require a human to approve or reject the plan —
+	// no agent work is actionable. Set human-required immediately and skip the
+	// triage→implement workflow so no agent is dispatched.
+	if isPlanReviewAnomaly(a) {
+		st := task.StatusHumanRequired
+		update.Status = &st
+	}
 	if _, err := s.tasks.Update(newTask.ID, update); err != nil {
 		s.logger.Warn("monitor.routing.local.tag", "new_task_id", newTask.ID, "err", err)
 	}
-	s.dispatchCreatedWorkflow(newTask.ID)
+	if !isPlanReviewAnomaly(a) {
+		s.dispatchCreatedWorkflow(newTask.ID)
+	}
 	s.logger.Info("monitor.routing.local",
 		"kind", a.Kind, "src_task_id", a.TaskID,
 		"new_task_id", newTask.ID, "project_id", s.projectID, "redactions", redactions)
 	return true, nil
+}
+
+// isPlanReviewAnomaly reports whether the anomaly is a stuck_human_blocked
+// detection for a task in plan-review status. Resolution is always deterministic
+// (approve or reject the plan) — no LLM or agent work adds value.
+func isPlanReviewAnomaly(a monitor.Anomaly) bool {
+	if a.Kind != monitor.KindStuckHumanBlocked {
+		return false
+	}
+	status, _ := a.Evidence["status"].(string)
+	return status == string(task.StatusPlanReview)
 }
 
 func (s *monitorRoutingSink) dispatchCreatedWorkflow(taskID string) {

--- a/internal/sybra/monitor_sink_test.go
+++ b/internal/sybra/monitor_sink_test.go
@@ -138,6 +138,61 @@ func TestMonitorRoutingSink_WorkAnomaly_DispatchesCreatedWorkflow(t *testing.T) 
 	}
 }
 
+func TestMonitorRoutingSink_PlanReviewAnomaly_SkipsWorkflowSetsHumanRequired(t *testing.T) {
+	t.Parallel()
+	sink, tasks, _ := newSinkTestEnv(t)
+	var dispatched []string
+	sink.dispatchCreated = func(taskID string) {
+		dispatched = append(dispatched, taskID)
+	}
+	src, err := tasks.Create("source", "src body", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	pid := "kumahq/kuma"
+	if _, err := tasks.Update(src.ID, task.Update{ProjectID: &pid}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	a := monitor.Anomaly{
+		Kind:        monitor.KindStuckHumanBlocked,
+		TaskID:      src.ID,
+		Fingerprint: "stuck_human_blocked:" + src.ID,
+		Evidence: map[string]any{
+			"status":  "plan-review",
+			"task_id": src.ID,
+		},
+	}
+	created, err := sink.Submit(context.Background(), a, "evidence")
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if !created {
+		t.Fatalf("expected created=true")
+	}
+	if len(dispatched) != 0 {
+		t.Fatalf("workflow dispatch must be skipped for plan-review anomaly, got %d", len(dispatched))
+	}
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var routed *task.Task
+	for i := range all {
+		if strings.HasPrefix(all[i].Title, "[monitor] stuck_human_blocked") {
+			routed = &all[i]
+			break
+		}
+	}
+	if routed == nil {
+		t.Fatalf("no routed task created")
+	}
+	if routed.Status != task.StatusHumanRequired {
+		t.Errorf("status = %q, want human-required", routed.Status)
+	}
+}
+
 func TestMonitorRoutingSink_WorkAnomaly_DedupsByTitle(t *testing.T) {
 	t.Parallel()
 	sink, tasks, _ := newSinkTestEnv(t)


### PR DESCRIPTION
## Motivation

When the monitor detects a `stuck_human_blocked` anomaly for a task in `plan-review` status, the only resolution is human action (approve or reject the plan). Previously the routing sink would dispatch a created-workflow agent anyway, which added noise without value and could loop indefinitely.

Additionally, if the `human-required` status update failed after creating the routed task, the anomaly was silently swallowed — leaving the task stuck in `todo` with no agent and no visible signal.

## Implementation information

- `isPlanReviewAnomaly` detects `stuck_human_blocked` anomalies where `evidence["status"] == "plan-review"`.
- On match: set `status = human-required` on the routed task and skip `dispatchCreatedWorkflow`.
- On update failure for a plan-review anomaly: return `(false, err)` so the anomaly is not silently dropped and can be retried next cycle.
- Added `TestMonitorRoutingSink_PlanReviewAnomaly_SkipsWorkflowSetsHumanRequired` covering the full path: no workflow dispatched, routed task status is `human-required`.