### PR TITLE
fix(monitor): remediate stuck plan-review direct

### DIFF
--- a/internal/monitor/remediator.go
+++ b/internal/monitor/remediator.go
@@ -33,6 +33,11 @@ func (r *remediator) Apply(_ context.Context, a Anomaly) (string, error) {
 		return r.resetLostAgent(a)
 	case KindUntriaged:
 		return r.tagUntriaged(a)
+	case KindStuckHumanBlocked:
+		if !isPlanReviewStuck(a) {
+			return "", fmt.Errorf("remediator: stuck_human_blocked remediation only applies to plan-review")
+		}
+		return r.remediatePlanReviewStuck(a)
 	default:
 		return "", fmt.Errorf("remediator: kind %q has no in-process action", a.Kind)
 	}
@@ -63,4 +68,33 @@ func (r *remediator) tagUntriaged(a Anomaly) (string, error) {
 		return "", fmt.Errorf("tag untriaged task %s: %w", a.TaskID, err)
 	}
 	return string(a.Kind) + ":" + a.TaskID, nil
+}
+
+// remediatePlanReviewStuck sets a plan-review stuck task to human-required
+// so it surfaces on the blocked queue without spawning a new meta-task.
+// Only called when isPlanReviewStuck(a) is true.
+func (r *remediator) remediatePlanReviewStuck(a Anomaly) (string, error) {
+	if a.TaskID == "" {
+		return "", fmt.Errorf("stuck_human_blocked without task id")
+	}
+	upd := task.Update{
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr("monitor: plan-review stalled"),
+	}
+	if _, err := r.tasks.Update(a.TaskID, upd); err != nil {
+		return "", fmt.Errorf("set plan-review task %s human-required: %w", a.TaskID, err)
+	}
+	return string(a.Kind) + ":" + a.TaskID, nil
+}
+
+// isPlanReviewStuck reports whether a is a stuck_human_blocked anomaly for a
+// plan-review task. These are remediated in-process (task promoted to
+// human-required) and must not reach the issue sink, which would create a
+// redundant meta-task.
+func isPlanReviewStuck(a Anomaly) bool {
+	if a.Kind != KindStuckHumanBlocked {
+		return false
+	}
+	status, _ := a.Evidence["status"].(string)
+	return status == string(task.StatusPlanReview)
 }

--- a/internal/monitor/remediator_test.go
+++ b/internal/monitor/remediator_test.go
@@ -1,0 +1,102 @@
+package monitor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func TestRemediator_PlanReviewStuck_SetsHumanRequired(t *testing.T) {
+	t.Parallel()
+	ft := &fakeTasks{tasks: []task.Task{
+		mkTask("pr1", task.StatusPlanReview),
+	}}
+	rem := newRemediator(ft)
+	a := Anomaly{
+		Kind:   KindStuckHumanBlocked,
+		TaskID: "pr1",
+		Evidence: map[string]any{
+			"status": "plan-review",
+		},
+	}
+	label, err := rem.Apply(context.Background(), a)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if label == "" {
+		t.Fatal("expected non-empty label")
+	}
+	if len(ft.updates) != 1 {
+		t.Fatalf("want 1 update, got %d", len(ft.updates))
+	}
+	u := ft.updates[0]
+	if u.id != "pr1" {
+		t.Errorf("updated wrong task: %q", u.id)
+	}
+	if u.u.Status == nil || *u.u.Status != task.StatusHumanRequired {
+		t.Errorf("status = %v, want human-required", u.u.Status)
+	}
+	if u.u.StatusReason == nil || *u.u.StatusReason == "" {
+		t.Error("status_reason should be set")
+	}
+}
+
+func TestRemediator_StuckHumanBlocked_NonPlanReview_Errors(t *testing.T) {
+	t.Parallel()
+	ft := &fakeTasks{tasks: []task.Task{
+		mkTask("hr1", task.StatusHumanRequired),
+	}}
+	rem := newRemediator(ft)
+	a := Anomaly{
+		Kind:   KindStuckHumanBlocked,
+		TaskID: "hr1",
+		Evidence: map[string]any{
+			"status": "human-required",
+		},
+	}
+	_, err := rem.Apply(context.Background(), a)
+	if err == nil {
+		t.Fatal("expected error for non-plan-review stuck_human_blocked")
+	}
+	if len(ft.updates) != 0 {
+		t.Fatalf("want 0 updates for non-plan-review, got %d", len(ft.updates))
+	}
+}
+
+func TestIsPlanReviewStuck(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		a    Anomaly
+		want bool
+	}{
+		{
+			name: "plan-review stuck",
+			a:    Anomaly{Kind: KindStuckHumanBlocked, Evidence: map[string]any{"status": "plan-review"}},
+			want: true,
+		},
+		{
+			name: "human-required stuck",
+			a:    Anomaly{Kind: KindStuckHumanBlocked, Evidence: map[string]any{"status": "human-required"}},
+			want: false,
+		},
+		{
+			name: "different kind",
+			a:    Anomaly{Kind: KindLostAgent, Evidence: map[string]any{"status": "plan-review"}},
+			want: false,
+		},
+		{
+			name: "no evidence",
+			a:    Anomaly{Kind: KindStuckHumanBlocked},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isPlanReviewStuck(tc.a); got != tc.want {
+				t.Errorf("isPlanReviewStuck = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/monitor/service.go
+++ b/internal/monitor/service.go
@@ -257,7 +257,7 @@ func (s *Service) applyRemediations(ctx context.Context, anoms []Anomaly) []stri
 		if a.RequiresLLM {
 			continue
 		}
-		if a.Kind != KindLostAgent && a.Kind != KindUntriaged {
+		if a.Kind != KindLostAgent && a.Kind != KindUntriaged && !isPlanReviewStuck(a) {
 			continue
 		}
 		label, err := s.rem.Apply(ctx, a)
@@ -309,7 +309,7 @@ func (s *Service) fileIssues(ctx context.Context, now time.Time, anoms []Anomaly
 	cooldown := time.Duration(s.cfg.IssueCooldownMinutes) * time.Minute
 	for i := range anoms {
 		a := anoms[i]
-		if a.RequiresLLM {
+		if a.RequiresLLM || isPlanReviewStuck(a) {
 			continue
 		}
 		if !s.state.canIssue(a.Fingerprint, now, cooldown) {

--- a/internal/monitor/service_test.go
+++ b/internal/monitor/service_test.go
@@ -285,6 +285,62 @@ func TestServiceScanHasNoSideEffects(t *testing.T) {
 	}
 }
 
+func TestServiceTick_PlanReviewStuck_RemediatesDirectly(t *testing.T) {
+	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
+	cfg := defaultCfg()
+	tasks := &fakeTasks{tasks: []task.Task{
+		// plan-review stuck: service must set it to human-required in-process.
+		mkTask("pr-stuck", task.StatusPlanReview, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+		}),
+	}}
+	disp := &fakeDispatcher{}
+	sink := &fakeSink{createNext: true}
+	svc := NewService(Deps{
+		Cfg:        cfg,
+		Tasks:      tasks,
+		Audit:      fakeAudit{},
+		Agents:     nilAgentLister{},
+		Dispatcher: disp,
+		Sink:       sink,
+		Logger:     slog.Default(),
+		Now:        func() time.Time { return now },
+	})
+
+	report, err := svc.tick(context.Background())
+	if err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+
+	if len(report.Anomalies) != 1 || report.Anomalies[0].Kind != KindStuckHumanBlocked {
+		t.Fatalf("want 1 stuck_human_blocked anomaly, got %v", report.Anomalies)
+	}
+
+	// Remediator must have set the task to human-required.
+	if len(tasks.updates) != 1 {
+		t.Fatalf("want 1 task update, got %d", len(tasks.updates))
+	}
+	u := tasks.updates[0]
+	if u.id != "pr-stuck" {
+		t.Errorf("updated wrong task: %q", u.id)
+	}
+	if u.u.Status == nil || *u.u.Status != task.StatusHumanRequired {
+		t.Errorf("status = %v, want human-required", u.u.Status)
+	}
+
+	// Sink must NOT receive the plan-review anomaly — no meta-task created.
+	if len(sink.submissions) != 0 {
+		t.Fatalf("sink must not see plan-review anomaly, got %d submissions", len(sink.submissions))
+	}
+	if len(disp.calls) != 0 {
+		t.Fatalf("dispatcher must not be called for plan-review anomaly, got %d calls", len(disp.calls))
+	}
+
+	if len(report.Remediated) != 1 {
+		t.Fatalf("want 1 remediated, got %d", len(report.Remediated))
+	}
+}
+
 func TestParseFirstMatchingIssue(t *testing.T) {
 	out := []byte(`[{"number":42,"title":"unrelated","url":"https://github.com/o/r/issues/42"},{"number":87,"title":"[monitor] failure_spike","url":"https://github.com/o/r/issues/87"}]`)
 	num, url := parseFirstMatchingIssue(out, "[monitor] failure_spike")

--- a/internal/sybra/monitor_sink.go
+++ b/internal/sybra/monitor_sink.go
@@ -91,40 +91,14 @@ func (s *monitorRoutingSink) Submit(ctx context.Context, a monitor.Anomaly, body
 		pid := s.projectID
 		update.ProjectID = &pid
 	}
-	// plan-review stuck tasks require a human to approve or reject the plan —
-	// no agent work is actionable. Set human-required immediately and skip the
-	// triage→implement workflow so no agent is dispatched.
-	if isPlanReviewAnomaly(a) {
-		st := task.StatusHumanRequired
-		update.Status = &st
-	}
 	if _, err := s.tasks.Update(newTask.ID, update); err != nil {
 		s.logger.Warn("monitor.routing.local.tag", "new_task_id", newTask.ID, "err", err)
-		if isPlanReviewAnomaly(a) {
-			// Update failed: task is stuck in todo with no workflow dispatched
-			// and human-required status not applied. Fail Submit so the anomaly
-			// is not silently dropped and can be retried on the next cycle.
-			return false, err
-		}
 	}
-	if !isPlanReviewAnomaly(a) {
-		s.dispatchCreatedWorkflow(newTask.ID)
-	}
+	s.dispatchCreatedWorkflow(newTask.ID)
 	s.logger.Info("monitor.routing.local",
 		"kind", a.Kind, "src_task_id", a.TaskID,
 		"new_task_id", newTask.ID, "project_id", s.projectID, "redactions", redactions)
 	return true, nil
-}
-
-// isPlanReviewAnomaly reports whether the anomaly is a stuck_human_blocked
-// detection for a task in plan-review status. Resolution is always deterministic
-// (approve or reject the plan) — no LLM or agent work adds value.
-func isPlanReviewAnomaly(a monitor.Anomaly) bool {
-	if a.Kind != monitor.KindStuckHumanBlocked {
-		return false
-	}
-	status, _ := a.Evidence["status"].(string)
-	return status == string(task.StatusPlanReview)
 }
 
 func (s *monitorRoutingSink) dispatchCreatedWorkflow(taskID string) {

--- a/internal/sybra/monitor_sink_test.go
+++ b/internal/sybra/monitor_sink_test.go
@@ -138,61 +138,6 @@ func TestMonitorRoutingSink_WorkAnomaly_DispatchesCreatedWorkflow(t *testing.T) 
 	}
 }
 
-func TestMonitorRoutingSink_PlanReviewAnomaly_SkipsWorkflowSetsHumanRequired(t *testing.T) {
-	t.Parallel()
-	sink, tasks, _ := newSinkTestEnv(t)
-	var dispatched []string
-	sink.dispatchCreated = func(taskID string) {
-		dispatched = append(dispatched, taskID)
-	}
-	src, err := tasks.Create("source", "src body", task.AgentModeHeadless)
-	if err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-	pid := "kumahq/kuma"
-	if _, err := tasks.Update(src.ID, task.Update{ProjectID: &pid}); err != nil {
-		t.Fatalf("Update: %v", err)
-	}
-
-	a := monitor.Anomaly{
-		Kind:        monitor.KindStuckHumanBlocked,
-		TaskID:      src.ID,
-		Fingerprint: "stuck_human_blocked:" + src.ID,
-		Evidence: map[string]any{
-			"status":  "plan-review",
-			"task_id": src.ID,
-		},
-	}
-	created, err := sink.Submit(context.Background(), a, "evidence")
-	if err != nil {
-		t.Fatalf("Submit: %v", err)
-	}
-	if !created {
-		t.Fatalf("expected created=true")
-	}
-	if len(dispatched) != 0 {
-		t.Fatalf("workflow dispatch must be skipped for plan-review anomaly, got %d", len(dispatched))
-	}
-
-	all, err := tasks.List()
-	if err != nil {
-		t.Fatalf("List: %v", err)
-	}
-	var routed *task.Task
-	for i := range all {
-		if strings.HasPrefix(all[i].Title, "[monitor] stuck_human_blocked") {
-			routed = &all[i]
-			break
-		}
-	}
-	if routed == nil {
-		t.Fatalf("no routed task created")
-	}
-	if routed.Status != task.StatusHumanRequired {
-		t.Errorf("status = %q, want human-required", routed.Status)
-	}
-}
-
 func TestMonitorRoutingSink_WorkAnomaly_DedupsByTitle(t *testing.T) {
 	t.Parallel()
 	sink, tasks, _ := newSinkTestEnv(t)


### PR DESCRIPTION
## Motivation

Stuck plan-review tasks were routed through the issue sink, which created new chore meta-tasks. Those meta-tasks then triggered triage → planning → got stuck themselves, producing an infinite cascade of monitor noise.

## Implementation information

The remediator now handles `KindStuckHumanBlocked` when evidence status is `plan-review`: it sets the original task to `human-required` directly so it surfaces on the blocked queue without spawning a meta-task.

`fileIssues` skips plan-review stuck anomalies (handled in-process). The routing sink's `isPlanReviewAnomaly` special-case is removed as dead code once `fileIssues` stops forwarding these anomalies.

> Changelog: fix(monitor): remediate stuck plan-review direct