### PR TITLE
test(monitor): freshen e2e fixture + fix tests

### DIFF
--- a/frontend/e2e/workflow.spec.ts
+++ b/frontend/e2e/workflow.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test'
-import { readdir, unlink, copyFile } from 'node:fs/promises'
+import { readdir, unlink, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 
@@ -25,7 +25,12 @@ async function cleanupCreatedTasks() {
 async function ensurePlanFixture() {
   const src = join(import.meta.dirname, 'fixtures', 'plan0001.md')
   const dst = join(TASKS_DIR, 'plan0001.md')
-  await copyFile(src, dst)
+  // Rewrite timestamps to now so the monitor does not flag the task as stuck
+  const now = new Date().toISOString()
+  let content = await readFile(src, 'utf8')
+  content = content.replace(/created_at: .+/, `created_at: ${now}`)
+  content = content.replace(/updated_at: .+/, `updated_at: ${now}`)
+  await writeFile(dst, content)
 }
 
 async function goToTaskList(page: Page) {
@@ -46,6 +51,7 @@ async function goToPlanReviews(page: Page) {
 }
 
 test.beforeAll(async () => {
+  await cleanupCreatedTasks()
   await ensurePlanFixture()
 })
 

--- a/internal/monitor/service_test.go
+++ b/internal/monitor/service_test.go
@@ -341,6 +341,55 @@ func TestServiceTick_PlanReviewStuck_RemediatesDirectly(t *testing.T) {
 	}
 }
 
+func TestServiceTick_DowngradeLLM_HumanRequired_GoesToSink(t *testing.T) {
+	// Regression: work-typed human-required tasks have RequiresLLM downgraded
+	// to false. They must reach the sink (not the dispatcher) so the routing
+	// sink can dedup against the existing meta-task instead of spawning a new
+	// LLM agent that would leak work-project identifiers.
+	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
+	cfg := defaultCfg()
+	tasks := &fakeTasks{tasks: []task.Task{
+		mkTask("hr-work", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour) // past 8h budget
+		}),
+	}}
+	disp := &fakeDispatcher{}
+	sink := &fakeSink{createNext: true}
+	svc := NewService(Deps{
+		Cfg:    cfg,
+		Tasks:  tasks,
+		Audit:  fakeAudit{},
+		Agents: nilAgentLister{},
+		// Downgrade LLM for the work-typed task — mirrors what App does for
+		// kumahq/kuma and other work-typed projects.
+		DowngradeLLMForTask: func(id string) bool { return id == "hr-work" },
+		Dispatcher:          disp,
+		Sink:                sink,
+		Logger:              slog.Default(),
+		Now:                 func() time.Time { return now },
+	})
+
+	report, err := svc.tick(context.Background())
+	if err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+	if len(report.Anomalies) != 1 || report.Anomalies[0].Kind != KindStuckHumanBlocked {
+		t.Fatalf("want 1 stuck_human_blocked anomaly, got %v", report.Anomalies)
+	}
+	// Downgrade must have cleared RequiresLLM.
+	if report.Anomalies[0].RequiresLLM {
+		t.Errorf("RequiresLLM must be false after downgrade")
+	}
+	// Dispatcher must not be called — the anomaly is deterministic after downgrade.
+	if len(disp.calls) != 0 {
+		t.Errorf("dispatcher must not be called for downgraded anomaly, got %d calls", len(disp.calls))
+	}
+	// Sink must receive the anomaly for dedup/routing.
+	if len(sink.submissions) != 1 {
+		t.Errorf("sink must receive 1 submission, got %d", len(sink.submissions))
+	}
+}
+
 func TestParseFirstMatchingIssue(t *testing.T) {
 	out := []byte(`[{"number":42,"title":"unrelated","url":"https://github.com/o/r/issues/42"},{"number":87,"title":"[monitor] failure_spike","url":"https://github.com/o/r/issues/87"}]`)
 	num, url := parseFirstMatchingIssue(out, "[monitor] failure_spike")


### PR DESCRIPTION
## Motivation

The original `DowngradeLLM` coverage in this PR predated #838/#842, which
changed downgraded human-required tasks to remediate directly instead of
routing to the sink. That test now asserts dead behavior. Meanwhile `main`
HEAD was red: #844 changed verdict detection but left #843's contradictory
`StaleVerdictIgnored` test in place.

## Implementation information

- Merge `origin/main`; resolve the `service_test.go` conflict.
- Drop `TestServiceTick_DowngradeLLM_HumanRequired_GoesToSink` — superseded
  by `TestServiceTick_HumanRequiredStuck_DowngradedLLM_RemediatesDirectly`
  (#842).
- Rename `StaleVerdictIgnored` → `FailedRunKeepsVerdict` and invert it to
  match #844: a failed last human-review run must not mask an earlier
  stopped verdict.
- Keep the e2e change: `ensurePlanFixture` rewrites the plan fixture
  timestamps to now so the monitor does not flag it as stuck, and
  `cleanupCreatedTasks` runs in `beforeAll`.

> Changelog: skip