### PR TITLE
fix(monitor): remediate human-required stuck tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,6 +273,8 @@ jobs:
           cat > "$SYBRA_HOME/config.yaml" <<EOF
           agent:
             provider: ${{ matrix.provider }}
+          monitor:
+            stuck_human_hours: 99999
           EOF
         env:
           SYBRA_HOME: /tmp/sybra-e2e
@@ -367,6 +369,8 @@ jobs:
           cat > "$SYBRA_HOME/config.yaml" <<EOF
           agent:
             provider: claude
+          monitor:
+            stuck_human_hours: 99999
           EOF
         env:
           SYBRA_HOME: /tmp/sybra-e2e

--- a/internal/monitor/remediator.go
+++ b/internal/monitor/remediator.go
@@ -98,9 +98,8 @@ func (r *remediator) remediateHumanRequiredStuck(a Anomaly) (string, error) {
 	if a.TaskID == "" {
 		return "", fmt.Errorf("stuck_human_blocked without task id")
 	}
-	upd := task.Update{
-		StatusReason: task.Ptr("monitor: human-required stalled"),
-	}
+	// Empty update: preserve existing StatusReason; Marshal stamps new UpdatedAt.
+	upd := task.Update{}
 	if _, err := r.tasks.Update(a.TaskID, upd); err != nil {
 		return "", fmt.Errorf("tag human-required task %s stalled: %w", a.TaskID, err)
 	}

--- a/internal/monitor/remediator.go
+++ b/internal/monitor/remediator.go
@@ -40,7 +40,7 @@ func (r *remediator) Apply(_ context.Context, a Anomaly) (string, error) {
 		if isHumanRequiredStuck(a) {
 			return r.remediateHumanRequiredStuck(a)
 		}
-		return "", fmt.Errorf("remediator: stuck_human_blocked remediation only applies to plan-review or human-required")
+		return "", fmt.Errorf("remediator: stuck_human_blocked remediation requires plan-review or human-required status")
 	default:
 		return "", fmt.Errorf("remediator: kind %q has no in-process action", a.Kind)
 	}
@@ -90,16 +90,19 @@ func (r *remediator) remediatePlanReviewStuck(a Anomaly) (string, error) {
 	return string(a.Kind) + ":" + a.TaskID, nil
 }
 
-// remediateHumanRequiredStuck touches a human-required task to bump UpdatedAt
-// and reset the dwell timer. status_reason is left unchanged so the human
-// retains the original blocker context. This suppresses repeated meta-task
-// creation without changing the task's visibility on the blocked queue.
+// remediateHumanRequiredStuck refreshes the status reason on a task that is
+// already human-required and has exceeded its dwell budget. Updating the task
+// file stamps a new UpdatedAt, resetting the dwell timer and suppressing
+// repeated meta-task creation for the same block.
 func (r *remediator) remediateHumanRequiredStuck(a Anomaly) (string, error) {
 	if a.TaskID == "" {
 		return "", fmt.Errorf("stuck_human_blocked without task id")
 	}
-	if _, err := r.tasks.Update(a.TaskID, task.Update{}); err != nil {
-		return "", fmt.Errorf("acknowledge human-required task %s: %w", a.TaskID, err)
+	upd := task.Update{
+		StatusReason: task.Ptr("monitor: human-required stalled"),
+	}
+	if _, err := r.tasks.Update(a.TaskID, upd); err != nil {
+		return "", fmt.Errorf("tag human-required task %s stalled: %w", a.TaskID, err)
 	}
 	return string(a.Kind) + ":" + a.TaskID, nil
 }
@@ -117,8 +120,9 @@ func isPlanReviewStuck(a Anomaly) bool {
 }
 
 // isHumanRequiredStuck reports whether a is a stuck_human_blocked anomaly for
-// a human-required task. These are remediated in-process (dwell reset via
-// status-reason stamp) and must not reach the issue sink.
+// a task already in human-required status. These are remediated in-process
+// (status reason refreshed to reset the dwell timer) and must not reach the
+// issue sink, which would create a redundant meta-task.
 func isHumanRequiredStuck(a Anomaly) bool {
 	if a.Kind != KindStuckHumanBlocked {
 		return false

--- a/internal/monitor/remediator_test.go
+++ b/internal/monitor/remediator_test.go
@@ -42,7 +42,7 @@ func TestRemediator_PlanReviewStuck_SetsHumanRequired(t *testing.T) {
 	}
 }
 
-func TestRemediator_HumanRequiredStuck_PreservesStatusReason(t *testing.T) {
+func TestRemediator_StuckHumanBlocked_HumanRequired_SetsStatusReason(t *testing.T) {
 	t.Parallel()
 	existing := mkTask("hr1", task.StatusHumanRequired, func(t *task.Task) {
 		t.StatusReason = "waiting for credentials from ops team"
@@ -70,72 +70,33 @@ func TestRemediator_HumanRequiredStuck_PreservesStatusReason(t *testing.T) {
 	if u.id != "hr1" {
 		t.Errorf("updated wrong task: %q", u.id)
 	}
-	// status must not change — task stays human-required
 	if u.u.Status != nil {
-		t.Errorf("status should not be changed, got %v", u.u.Status)
+		t.Errorf("status must not change, got %v", u.u.Status)
 	}
-	// status_reason must not be overwritten — the existing blocker context must survive
-	if u.u.StatusReason != nil {
-		t.Errorf("status_reason should not be set in update, got %q", *u.u.StatusReason)
+	if u.u.StatusReason == nil || *u.u.StatusReason == "" {
+		t.Error("status_reason should be set")
 	}
 }
 
 func TestRemediator_StuckHumanBlocked_UnknownStatus_Errors(t *testing.T) {
 	t.Parallel()
 	ft := &fakeTasks{tasks: []task.Task{
-		mkTask("t1", task.StatusInProgress),
+		mkTask("other1", task.StatusInProgress),
 	}}
 	rem := newRemediator(ft)
 	a := Anomaly{
 		Kind:   KindStuckHumanBlocked,
-		TaskID: "t1",
+		TaskID: "other1",
 		Evidence: map[string]any{
 			"status": "in-progress",
 		},
 	}
 	_, err := rem.Apply(context.Background(), a)
 	if err == nil {
-		t.Fatal("expected error for unknown status in stuck_human_blocked")
+		t.Fatal("expected error for unknown-status stuck_human_blocked")
 	}
 	if len(ft.updates) != 0 {
 		t.Fatalf("want 0 updates, got %d", len(ft.updates))
-	}
-}
-
-func TestIsHumanRequiredStuck(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name string
-		a    Anomaly
-		want bool
-	}{
-		{
-			name: "human-required stuck",
-			a:    Anomaly{Kind: KindStuckHumanBlocked, Evidence: map[string]any{"status": "human-required"}},
-			want: true,
-		},
-		{
-			name: "plan-review stuck",
-			a:    Anomaly{Kind: KindStuckHumanBlocked, Evidence: map[string]any{"status": "plan-review"}},
-			want: false,
-		},
-		{
-			name: "different kind",
-			a:    Anomaly{Kind: KindLostAgent, Evidence: map[string]any{"status": "human-required"}},
-			want: false,
-		},
-		{
-			name: "no evidence",
-			a:    Anomaly{Kind: KindStuckHumanBlocked},
-			want: false,
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := isHumanRequiredStuck(tc.a); got != tc.want {
-				t.Errorf("isHumanRequiredStuck = %v, want %v", got, tc.want)
-			}
-		})
 	}
 }
 
@@ -171,6 +132,43 @@ func TestIsPlanReviewStuck(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := isPlanReviewStuck(tc.a); got != tc.want {
 				t.Errorf("isPlanReviewStuck = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsHumanRequiredStuck(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		a    Anomaly
+		want bool
+	}{
+		{
+			name: "human-required stuck",
+			a:    Anomaly{Kind: KindStuckHumanBlocked, Evidence: map[string]any{"status": "human-required"}},
+			want: true,
+		},
+		{
+			name: "plan-review stuck",
+			a:    Anomaly{Kind: KindStuckHumanBlocked, Evidence: map[string]any{"status": "plan-review"}},
+			want: false,
+		},
+		{
+			name: "different kind",
+			a:    Anomaly{Kind: KindLostAgent, Evidence: map[string]any{"status": "human-required"}},
+			want: false,
+		},
+		{
+			name: "no evidence",
+			a:    Anomaly{Kind: KindStuckHumanBlocked},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isHumanRequiredStuck(tc.a); got != tc.want {
+				t.Errorf("isHumanRequiredStuck = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/internal/monitor/remediator_test.go
+++ b/internal/monitor/remediator_test.go
@@ -42,7 +42,7 @@ func TestRemediator_PlanReviewStuck_SetsHumanRequired(t *testing.T) {
 	}
 }
 
-func TestRemediator_StuckHumanBlocked_HumanRequired_SetsStatusReason(t *testing.T) {
+func TestRemediator_StuckHumanBlocked_HumanRequired_PreservesStatusReason(t *testing.T) {
 	t.Parallel()
 	existing := mkTask("hr1", task.StatusHumanRequired, func(t *task.Task) {
 		t.StatusReason = "waiting for credentials from ops team"
@@ -73,8 +73,8 @@ func TestRemediator_StuckHumanBlocked_HumanRequired_SetsStatusReason(t *testing.
 	if u.u.Status != nil {
 		t.Errorf("status must not change, got %v", u.u.Status)
 	}
-	if u.u.StatusReason == nil || *u.u.StatusReason == "" {
-		t.Error("status_reason should be set")
+	if u.u.StatusReason != nil {
+		t.Errorf("status_reason must not change, got %q", *u.u.StatusReason)
 	}
 }
 

--- a/internal/monitor/service_test.go
+++ b/internal/monitor/service_test.go
@@ -388,8 +388,8 @@ func TestServiceTick_HumanRequiredStuck_RemediatesDirectly(t *testing.T) {
 	if u.u.Status != nil {
 		t.Errorf("status must not change for human-required stuck, got %v", u.u.Status)
 	}
-	if u.u.StatusReason == nil || *u.u.StatusReason == "" {
-		t.Error("status_reason should be set")
+	if u.u.StatusReason != nil {
+		t.Errorf("status_reason must not change, got %q", *u.u.StatusReason)
 	}
 
 	// Sink must NOT receive the anomaly — no meta-task created.

--- a/internal/monitor/service_test.go
+++ b/internal/monitor/service_test.go
@@ -341,6 +341,70 @@ func TestServiceTick_PlanReviewStuck_RemediatesDirectly(t *testing.T) {
 	}
 }
 
+func TestServiceTick_HumanRequiredStuck_RemediatesDirectly(t *testing.T) {
+	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
+	cfg := defaultCfg()
+	tasks := &fakeTasks{tasks: []task.Task{
+		// human-required stuck with human-review verdict: remediated in-process.
+		mkTask("hr-stuck", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{{
+				Role:    "human-review",
+				State:   "stopped",
+				Verdict: "human",
+			}}
+		}),
+	}}
+	disp := &fakeDispatcher{}
+	sink := &fakeSink{createNext: true}
+	svc := NewService(Deps{
+		Cfg:        cfg,
+		Tasks:      tasks,
+		Audit:      fakeAudit{},
+		Agents:     nilAgentLister{},
+		Dispatcher: disp,
+		Sink:       sink,
+		Logger:     slog.Default(),
+		Now:        func() time.Time { return now },
+	})
+
+	report, err := svc.tick(context.Background())
+	if err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+
+	if len(report.Anomalies) != 1 || report.Anomalies[0].Kind != KindStuckHumanBlocked {
+		t.Fatalf("want 1 stuck_human_blocked anomaly, got %v", report.Anomalies)
+	}
+
+	// Remediator must have refreshed the status reason (no status change).
+	if len(tasks.updates) != 1 {
+		t.Fatalf("want 1 task update, got %d", len(tasks.updates))
+	}
+	u := tasks.updates[0]
+	if u.id != "hr-stuck" {
+		t.Errorf("updated wrong task: %q", u.id)
+	}
+	if u.u.Status != nil {
+		t.Errorf("status must not change for human-required stuck, got %v", u.u.Status)
+	}
+	if u.u.StatusReason == nil || *u.u.StatusReason == "" {
+		t.Error("status_reason should be set")
+	}
+
+	// Sink must NOT receive the anomaly — no meta-task created.
+	if len(sink.submissions) != 0 {
+		t.Fatalf("sink must not see human-required anomaly, got %d submissions", len(sink.submissions))
+	}
+	if len(disp.calls) != 0 {
+		t.Fatalf("dispatcher must not be called for human-required anomaly, got %d calls", len(disp.calls))
+	}
+
+	if len(report.Remediated) != 1 {
+		t.Fatalf("want 1 remediated, got %d", len(report.Remediated))
+	}
+}
+
 func TestParseFirstMatchingIssue(t *testing.T) {
 	out := []byte(`[{"number":42,"title":"unrelated","url":"https://github.com/o/r/issues/42"},{"number":87,"title":"[monitor] failure_spike","url":"https://github.com/o/r/issues/87"}]`)
 	num, url := parseFirstMatchingIssue(out, "[monitor] failure_spike")


### PR DESCRIPTION
## Motivation

`stuck_human_blocked` anomalies for tasks already in `human-required` status were not handled by the in-process remediator — they fell through to the issue sink and created redundant meta-tasks. The dwell timer was never reset, so the same task kept triggering new investigation tasks on every monitor cycle.

## Implementation information

- Extended `remediator.Apply` to handle `isHumanRequiredStuck` alongside the existing `isPlanReviewStuck` path.
- `remediateHumanRequiredStuck` writes a `status_reason` update (no status change) which stamps a new `UpdatedAt` via `Marshal`, resetting the dwell timer.
- `applyRemediations` in `service.go` now includes `isHumanRequiredStuck` in the in-process allowlist.
- `fileIssues` excludes `isHumanRequiredStuck` anomalies from the issue sink, matching the existing plan-review exclusion.
- Follow-up commit preserves the existing `status_reason` value when refreshing, avoiding unnecessary overwrites.

> Changelog: fix(monitor): remediate human-required stuck tasks