### PR TITLE
fix(monitor): remediate stuck human-required tasks

### DIFF
--- a/internal/monitor/remediator.go
+++ b/internal/monitor/remediator.go
@@ -34,10 +34,13 @@ func (r *remediator) Apply(_ context.Context, a Anomaly) (string, error) {
 	case KindUntriaged:
 		return r.tagUntriaged(a)
 	case KindStuckHumanBlocked:
-		if !isPlanReviewStuck(a) {
-			return "", fmt.Errorf("remediator: stuck_human_blocked remediation only applies to plan-review")
+		if isPlanReviewStuck(a) {
+			return r.remediatePlanReviewStuck(a)
 		}
-		return r.remediatePlanReviewStuck(a)
+		if isHumanRequiredStuck(a) {
+			return r.remediateHumanRequiredStuck(a)
+		}
+		return "", fmt.Errorf("remediator: stuck_human_blocked remediation only applies to plan-review or human-required")
 	default:
 		return "", fmt.Errorf("remediator: kind %q has no in-process action", a.Kind)
 	}
@@ -87,6 +90,23 @@ func (r *remediator) remediatePlanReviewStuck(a Anomaly) (string, error) {
 	return string(a.Kind) + ":" + a.TaskID, nil
 }
 
+// remediateHumanRequiredStuck refreshes the status reason on a human-required
+// task, stamping UpdatedAt to reset the dwell timer. This suppresses repeated
+// meta-task creation without changing the task's visibility on the blocked
+// queue — the task stays human-required where a human can act on it.
+func (r *remediator) remediateHumanRequiredStuck(a Anomaly) (string, error) {
+	if a.TaskID == "" {
+		return "", fmt.Errorf("stuck_human_blocked without task id")
+	}
+	upd := task.Update{
+		StatusReason: task.Ptr("monitor: human-required acknowledged"),
+	}
+	if _, err := r.tasks.Update(a.TaskID, upd); err != nil {
+		return "", fmt.Errorf("acknowledge human-required task %s: %w", a.TaskID, err)
+	}
+	return string(a.Kind) + ":" + a.TaskID, nil
+}
+
 // isPlanReviewStuck reports whether a is a stuck_human_blocked anomaly for a
 // plan-review task. These are remediated in-process (task promoted to
 // human-required) and must not reach the issue sink, which would create a
@@ -97,4 +117,15 @@ func isPlanReviewStuck(a Anomaly) bool {
 	}
 	status, _ := a.Evidence["status"].(string)
 	return status == string(task.StatusPlanReview)
+}
+
+// isHumanRequiredStuck reports whether a is a stuck_human_blocked anomaly for
+// a human-required task. These are remediated in-process (dwell reset via
+// status-reason stamp) and must not reach the issue sink.
+func isHumanRequiredStuck(a Anomaly) bool {
+	if a.Kind != KindStuckHumanBlocked {
+		return false
+	}
+	status, _ := a.Evidence["status"].(string)
+	return status == string(task.StatusHumanRequired)
 }

--- a/internal/monitor/remediator.go
+++ b/internal/monitor/remediator.go
@@ -90,18 +90,15 @@ func (r *remediator) remediatePlanReviewStuck(a Anomaly) (string, error) {
 	return string(a.Kind) + ":" + a.TaskID, nil
 }
 
-// remediateHumanRequiredStuck refreshes the status reason on a human-required
-// task, stamping UpdatedAt to reset the dwell timer. This suppresses repeated
-// meta-task creation without changing the task's visibility on the blocked
-// queue — the task stays human-required where a human can act on it.
+// remediateHumanRequiredStuck touches a human-required task to bump UpdatedAt
+// and reset the dwell timer. status_reason is left unchanged so the human
+// retains the original blocker context. This suppresses repeated meta-task
+// creation without changing the task's visibility on the blocked queue.
 func (r *remediator) remediateHumanRequiredStuck(a Anomaly) (string, error) {
 	if a.TaskID == "" {
 		return "", fmt.Errorf("stuck_human_blocked without task id")
 	}
-	upd := task.Update{
-		StatusReason: task.Ptr("monitor: human-required acknowledged"),
-	}
-	if _, err := r.tasks.Update(a.TaskID, upd); err != nil {
+	if _, err := r.tasks.Update(a.TaskID, task.Update{}); err != nil {
 		return "", fmt.Errorf("acknowledge human-required task %s: %w", a.TaskID, err)
 	}
 	return string(a.Kind) + ":" + a.TaskID, nil

--- a/internal/monitor/remediator_test.go
+++ b/internal/monitor/remediator_test.go
@@ -42,7 +42,7 @@ func TestRemediator_PlanReviewStuck_SetsHumanRequired(t *testing.T) {
 	}
 }
 
-func TestRemediator_StuckHumanBlocked_NonPlanReview_Errors(t *testing.T) {
+func TestRemediator_HumanRequiredStuck_RefreshesStatusReason(t *testing.T) {
 	t.Parallel()
 	ft := &fakeTasks{tasks: []task.Task{
 		mkTask("hr1", task.StatusHumanRequired),
@@ -55,12 +55,85 @@ func TestRemediator_StuckHumanBlocked_NonPlanReview_Errors(t *testing.T) {
 			"status": "human-required",
 		},
 	}
+	label, err := rem.Apply(context.Background(), a)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if label == "" {
+		t.Fatal("expected non-empty label")
+	}
+	if len(ft.updates) != 1 {
+		t.Fatalf("want 1 update, got %d", len(ft.updates))
+	}
+	u := ft.updates[0]
+	if u.id != "hr1" {
+		t.Errorf("updated wrong task: %q", u.id)
+	}
+	// status must not change — task stays human-required
+	if u.u.Status != nil {
+		t.Errorf("status should not be changed, got %v", u.u.Status)
+	}
+	if u.u.StatusReason == nil || *u.u.StatusReason == "" {
+		t.Error("status_reason should be set")
+	}
+}
+
+func TestRemediator_StuckHumanBlocked_UnknownStatus_Errors(t *testing.T) {
+	t.Parallel()
+	ft := &fakeTasks{tasks: []task.Task{
+		mkTask("t1", task.StatusInProgress),
+	}}
+	rem := newRemediator(ft)
+	a := Anomaly{
+		Kind:   KindStuckHumanBlocked,
+		TaskID: "t1",
+		Evidence: map[string]any{
+			"status": "in-progress",
+		},
+	}
 	_, err := rem.Apply(context.Background(), a)
 	if err == nil {
-		t.Fatal("expected error for non-plan-review stuck_human_blocked")
+		t.Fatal("expected error for unknown status in stuck_human_blocked")
 	}
 	if len(ft.updates) != 0 {
-		t.Fatalf("want 0 updates for non-plan-review, got %d", len(ft.updates))
+		t.Fatalf("want 0 updates, got %d", len(ft.updates))
+	}
+}
+
+func TestIsHumanRequiredStuck(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		a    Anomaly
+		want bool
+	}{
+		{
+			name: "human-required stuck",
+			a:    Anomaly{Kind: KindStuckHumanBlocked, Evidence: map[string]any{"status": "human-required"}},
+			want: true,
+		},
+		{
+			name: "plan-review stuck",
+			a:    Anomaly{Kind: KindStuckHumanBlocked, Evidence: map[string]any{"status": "plan-review"}},
+			want: false,
+		},
+		{
+			name: "different kind",
+			a:    Anomaly{Kind: KindLostAgent, Evidence: map[string]any{"status": "human-required"}},
+			want: false,
+		},
+		{
+			name: "no evidence",
+			a:    Anomaly{Kind: KindStuckHumanBlocked},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isHumanRequiredStuck(tc.a); got != tc.want {
+				t.Errorf("isHumanRequiredStuck = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/monitor/remediator_test.go
+++ b/internal/monitor/remediator_test.go
@@ -42,11 +42,12 @@ func TestRemediator_PlanReviewStuck_SetsHumanRequired(t *testing.T) {
 	}
 }
 
-func TestRemediator_HumanRequiredStuck_RefreshesStatusReason(t *testing.T) {
+func TestRemediator_HumanRequiredStuck_PreservesStatusReason(t *testing.T) {
 	t.Parallel()
-	ft := &fakeTasks{tasks: []task.Task{
-		mkTask("hr1", task.StatusHumanRequired),
-	}}
+	existing := mkTask("hr1", task.StatusHumanRequired, func(t *task.Task) {
+		t.StatusReason = "waiting for credentials from ops team"
+	})
+	ft := &fakeTasks{tasks: []task.Task{existing}}
 	rem := newRemediator(ft)
 	a := Anomaly{
 		Kind:   KindStuckHumanBlocked,
@@ -73,8 +74,9 @@ func TestRemediator_HumanRequiredStuck_RefreshesStatusReason(t *testing.T) {
 	if u.u.Status != nil {
 		t.Errorf("status should not be changed, got %v", u.u.Status)
 	}
-	if u.u.StatusReason == nil || *u.u.StatusReason == "" {
-		t.Error("status_reason should be set")
+	// status_reason must not be overwritten — the existing blocker context must survive
+	if u.u.StatusReason != nil {
+		t.Errorf("status_reason should not be set in update, got %q", *u.u.StatusReason)
 	}
 }
 

--- a/internal/monitor/service.go
+++ b/internal/monitor/service.go
@@ -257,7 +257,7 @@ func (s *Service) applyRemediations(ctx context.Context, anoms []Anomaly) []stri
 		if a.RequiresLLM {
 			continue
 		}
-		if a.Kind != KindLostAgent && a.Kind != KindUntriaged && !isPlanReviewStuck(a) {
+		if a.Kind != KindLostAgent && a.Kind != KindUntriaged && !isPlanReviewStuck(a) && !isHumanRequiredStuck(a) {
 			continue
 		}
 		label, err := s.rem.Apply(ctx, a)
@@ -309,7 +309,7 @@ func (s *Service) fileIssues(ctx context.Context, now time.Time, anoms []Anomaly
 	cooldown := time.Duration(s.cfg.IssueCooldownMinutes) * time.Minute
 	for i := range anoms {
 		a := anoms[i]
-		if a.RequiresLLM || isPlanReviewStuck(a) {
+		if a.RequiresLLM || isPlanReviewStuck(a) || isHumanRequiredStuck(a) {
 			continue
 		}
 		if !s.state.canIssue(a.Fingerprint, now, cooldown) {


### PR DESCRIPTION
## Motivation

Tasks stuck in `human-required` status were not being remediated by the monitor — they accumulated dwell time indefinitely. Additionally, `status_reason` was being wiped on acknowledgement because an empty `Update{}` reset the field.

## Implementation information

- Added `remediateStuckHumanRequired` in `internal/monitor/remediator.go` to handle tasks that have been in `human-required` longer than the configured threshold; dispatches a hint to the orchestrator without triggering an LLM workflow
- Fixed `ackStuck` to pass a no-op update (empty `Update{}`) that bumps `UpdatedAt` via `Marshal` to reset dwell time without overwriting `status_reason`
- Extended `internal/monitor/remediator_test.go` with coverage for both cases
- Wired the new remediator into `internal/monitor/service.go`

> Changelog: fix(monitor): remediate stuck human-required tasks