### PR TITLE
fix(monitor): scan all runs for human verdict

### DIFF
--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"encoding/json"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -171,16 +172,12 @@ func detectStuckHumanBlocked(t *task.Task, now time.Time, budget time.Duration) 
 			ev["last_agent_role"] = last.Role
 		}
 		ev["last_agent_state"] = last.State
-		if last.Role == "human-review" && last.State == "stopped" {
-			verdict := last.Verdict
-			if verdict == "" && last.Result != "" {
-				// Fallback for runs persisted before the Verdict field was
-				// added: parse from the truncated Result text.
-				verdict = parseHumanReviewDecision(last.Result)
-			}
-			if verdict != "" {
-				ev["human_review_verdict"] = verdict
-			}
+		// Scan all runs newest-to-oldest for the first parseable human-review
+		// verdict. Checking only the last run misses earlier successful verdicts
+		// when the most recent human-review run failed (e.g. API 529 Overloaded)
+		// and left an empty result with no sybra-verdict block.
+		if verdict := lastHumanReviewVerdict(t.AgentRuns); verdict != "" {
+			ev["human_review_verdict"] = verdict
 		}
 	}
 	// plan-review is always deterministic: human must approve or reject the plan.
@@ -344,6 +341,26 @@ func projectAllowed(fn func(string) bool, projectID string) bool {
 		return true
 	}
 	return fn(projectID)
+}
+
+// lastHumanReviewVerdict returns the verdict from the most recent stopped
+// human-review run that produced a parseable sybra-verdict. It scans backward
+// so that a later failed/overloaded run (empty or unparseable result) does not
+// mask a successful verdict from an earlier run.
+func lastHumanReviewVerdict(runs []task.AgentRun) string {
+	for i := range slices.Backward(runs) {
+		r := &runs[i]
+		if r.Role != "human-review" || r.State != "stopped" {
+			continue
+		}
+		if r.Verdict != "" {
+			return r.Verdict
+		}
+		if v := parseHumanReviewDecision(r.Result); v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 var humanReviewVerdictRe = regexp.MustCompile("(?s)```\\s*sybra-verdict\\s*\\n(.*?)\\n```")

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -628,6 +628,37 @@ func TestDetectStuckHumanBlocked_HumanReviewVerdict(t *testing.T) {
 			t.Errorf("human_review_verdict = %q, want sybra_bug (Verdict field wins)", got)
 		}
 	})
+
+	t.Run("uses earlier verdict when last run has no parseable result", func(t *testing.T) {
+		// Simulates: human-review ran and returned "human", then a second
+		// human-review attempt was dispatched but failed with an API error
+		// (result has no sybra-verdict block). The earlier verdict must win.
+		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{
+				{
+					AgentID: "rev1", Role: "human-review", State: "stopped",
+					Result: "Analysis.\n\n```sybra-verdict\n{\"decision\":\"human\",\"summary\":\"project not registered\"}\n```",
+				},
+				{
+					AgentID: "rev2", Role: "human-review", State: "stopped",
+					Result: "API Error: 529 Overloaded. This is a server-side issue, usually temporary.",
+				},
+			}
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		got, ok := report.Anomalies[0].Evidence["human_review_verdict"]
+		if !ok {
+			t.Fatal("evidence missing human_review_verdict; failed last run should not mask earlier verdict")
+		}
+		if got != "human" {
+			t.Errorf("human_review_verdict = %q, want human", got)
+		}
+	})
 }
 
 func TestDetectStuckHumanBlocked_RequiresLLM(t *testing.T) {
@@ -711,6 +742,28 @@ func TestDetectStuckHumanBlocked_RequiresLLM(t *testing.T) {
 		// Verdict field on a running agent is not surfaced, so RequiresLLM stays true.
 		if !report.Anomalies[0].RequiresLLM {
 			t.Error("RequiresLLM must be true when human-review is still running")
+		}
+	})
+
+	t.Run("RequiresLLM=false when earlier run has human verdict and last run failed", func(t *testing.T) {
+		// Simulates the real-world case: first human-review returned "human",
+		// second attempt hit API 529 with no parseable result. The task is still
+		// genuinely human-required — should not spawn an LLM investigation.
+		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{
+				{AgentID: "rev1", Role: "human-review", State: "stopped", Verdict: "human"},
+				{AgentID: "rev2", Role: "human-review", State: "stopped",
+					Result: "API Error: 529 Overloaded."},
+			}
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		if report.Anomalies[0].RequiresLLM {
+			t.Error("RequiresLLM must be false: earlier human verdict must not be masked by a failed last run")
 		}
 	})
 }


### PR DESCRIPTION
## Motivation

When a human-review agent run fails mid-flight (e.g. API 529 Overloaded) and leaves an empty or unparseable result, the monitor's stuck-human-blocked detector was checking only the last run for a verdict. This caused it to miss a successful verdict from an earlier run, incorrectly treating the task as unresolved and triggering unnecessary LLM investigation.

## Implementation information

Extracted a `lastHumanReviewVerdict` helper that scans `AgentRuns` backward (newest-to-oldest) and returns the first parseable `sybra-verdict` from any stopped human-review run. The existing inline check, which only looked at the final run, is replaced with a call to this helper.

Two new test cases cover the regression:
- evidence carries the earlier verdict when the last run has no parseable result
- `RequiresLLM` stays false when an earlier run holds a human verdict and the last run failed

> Changelog: fix(monitor): scan all runs for human verdict