### PR TITLE
fix(monitor): fix human verdict detection in stuck-human-blocked

### DIFF
--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"encoding/json"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -171,16 +172,12 @@ func detectStuckHumanBlocked(t *task.Task, now time.Time, budget time.Duration) 
 			ev["last_agent_role"] = last.Role
 		}
 		ev["last_agent_state"] = last.State
-		if last.Role == "human-review" && last.State == "stopped" {
-			verdict := last.Verdict
-			if verdict == "" && last.Result != "" {
-				// Fallback for runs persisted before the Verdict field was
-				// added: parse from the truncated Result text.
-				verdict = parseHumanReviewDecision(last.Result)
-			}
-			if verdict != "" {
-				ev["human_review_verdict"] = verdict
-			}
+		// Scan all runs newest-to-oldest for the first parseable human-review
+		// verdict. Checking only the last run misses earlier successful verdicts
+		// when the most recent human-review run failed (e.g. API 529 Overloaded)
+		// and left an empty result with no sybra-verdict block.
+		if verdict := lastHumanReviewVerdict(t.AgentRuns); verdict != "" {
+			ev["human_review_verdict"] = verdict
 		}
 	}
 	// plan-review is always deterministic: human must approve or reject the plan.
@@ -344,6 +341,26 @@ func projectAllowed(fn func(string) bool, projectID string) bool {
 		return true
 	}
 	return fn(projectID)
+}
+
+// lastHumanReviewVerdict returns the verdict from the most recent stopped
+// human-review run that produced a parseable sybra-verdict. It scans backward
+// so that a later failed/overloaded run (empty or unparseable result) does not
+// mask a successful verdict from an earlier run.
+func lastHumanReviewVerdict(runs []task.AgentRun) string {
+	for i := range slices.Backward(runs) {
+		r := &runs[i]
+		if r.Role != "human-review" || r.State != "stopped" {
+			continue
+		}
+		if r.Verdict != "" {
+			return r.Verdict
+		}
+		if v := parseHumanReviewDecision(r.Result); v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 var humanReviewVerdictRe = regexp.MustCompile("(?s)```\\s*sybra-verdict\\s*\\n(.*?)\\n```")

--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -350,8 +350,12 @@ func projectAllowed(fn func(string) bool, projectID string) bool {
 func lastHumanReviewVerdict(runs []task.AgentRun) string {
 	for i := range slices.Backward(runs) {
 		r := &runs[i]
-		if r.Role != "human-review" || r.State != "stopped" {
+		if r.Role != "human-review" {
 			continue
+		}
+		// A running human-review means a verdict is in flight; block any older verdict.
+		if r.State != "stopped" {
+			return ""
 		}
 		if r.Verdict != "" {
 			return r.Verdict

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -629,6 +629,26 @@ func TestDetectStuckHumanBlocked_HumanReviewVerdict(t *testing.T) {
 		}
 	})
 
+	t.Run("omits verdict when running human-review follows stopped human verdict", func(t *testing.T) {
+		// History: [stopped verdict=human, running human-review].
+		// Older verdict must not be surfaced while a newer review is still in flight.
+		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{
+				{AgentID: "rev1", Role: "human-review", State: "stopped", Verdict: "human"},
+				{AgentID: "rev2", Role: "human-review", State: "running"},
+			}
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		if _, ok := report.Anomalies[0].Evidence["human_review_verdict"]; ok {
+			t.Error("evidence must not contain human_review_verdict while a newer human-review is running")
+		}
+	})
+
 	t.Run("uses earlier verdict when last run has no parseable result", func(t *testing.T) {
 		// Simulates: human-review ran and returned "human", then a second
 		// human-review attempt was dispatched but failed with an API error
@@ -742,6 +762,26 @@ func TestDetectStuckHumanBlocked_RequiresLLM(t *testing.T) {
 		// Verdict field on a running agent is not surfaced, so RequiresLLM stays true.
 		if !report.Anomalies[0].RequiresLLM {
 			t.Error("RequiresLLM must be true when human-review is still running")
+		}
+	})
+
+	t.Run("RequiresLLM=true when running human-review follows stopped human verdict", func(t *testing.T) {
+		// History: [stopped verdict=human, running human-review].
+		// Running review blocks stale verdict — treat as unknown until it completes.
+		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{
+				{AgentID: "rev1", Role: "human-review", State: "stopped", Verdict: "human"},
+				{AgentID: "rev2", Role: "human-review", State: "running"},
+			}
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		if !report.Anomalies[0].RequiresLLM {
+			t.Error("RequiresLLM must be true while a newer human-review is still running")
 		}
 	})
 

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -628,6 +628,37 @@ func TestDetectStuckHumanBlocked_HumanReviewVerdict(t *testing.T) {
 			t.Errorf("human_review_verdict = %q, want sybra_bug (Verdict field wins)", got)
 		}
 	})
+
+	t.Run("uses earlier verdict when last run has no parseable result", func(t *testing.T) {
+		// Simulates: human-review ran and returned "human", then a second
+		// human-review attempt was dispatched but failed with an API error
+		// (result has no sybra-verdict block). The earlier verdict must win.
+		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{
+				{
+					AgentID: "rev1", Role: "human-review", State: "stopped",
+					Result: "Analysis.\n\n```sybra-verdict\n{\"decision\":\"human\",\"summary\":\"project not registered\"}\n```",
+				},
+				{
+					AgentID: "rev2", Role: "human-review", State: "stopped",
+					Result: "API Error: 529 Overloaded. This is a server-side issue, usually temporary.",
+				},
+			}
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		got, ok := report.Anomalies[0].Evidence["human_review_verdict"]
+		if !ok {
+			t.Fatal("evidence missing human_review_verdict; failed last run should not mask earlier verdict")
+		}
+		if got != "human" {
+			t.Errorf("human_review_verdict = %q, want human", got)
+		}
+	})
 }
 
 func TestDetectStuckHumanBlocked_RequiresLLM(t *testing.T) {
@@ -711,6 +742,28 @@ func TestDetectStuckHumanBlocked_RequiresLLM(t *testing.T) {
 		// Verdict field on a running agent is not surfaced, so RequiresLLM stays true.
 		if !report.Anomalies[0].RequiresLLM {
 			t.Error("RequiresLLM must be true when human-review is still running")
+		}
+	})
+
+	t.Run("RequiresLLM=false when earlier run has human verdict and last run failed", func(t *testing.T) {
+		// Simulates the real-world case: first human-review returned "human",
+		// second attempt hit API 529 with no parseable result. The task is still
+		// genuinely human-required — should not spawn an LLM investigation.
+		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{
+				{AgentID: "rev1", Role: "human-review", State: "stopped", Verdict: "human"},
+				{AgentID: "rev2", Role: "human-review", State: "stopped",
+					Result: "API Error: 529 Overloaded."},
+			}
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		if report.Anomalies[0].RequiresLLM {
+			t.Error("RequiresLLM must be false: earlier human verdict must not be masked by a failed last run")
 		}
 	})
 }


### PR DESCRIPTION
## Motivation

`detectStuckHumanBlocked` had two bugs that caused tasks requiring human review to be incorrectly routed to LLM investigation:

1. Only the last agent run was checked for a human-review verdict. A transient failure (e.g. API 529) on the most recent run masked earlier successful verdicts, triggering spurious LLM meta-tasks even when the task genuinely needed human input.

2. When scanning backward through runs, non-stopped (running) human-review runs were silently skipped, allowing an older stopped verdict to surface while a newer review was still in flight.

## Implementation information

- Extracted `lastHumanReviewVerdict` to scan runs newest-to-oldest, returning the first parseable stopped human-review verdict (fixes the masked-verdict bug).
- `lastHumanReviewVerdict` now returns empty immediately when it encounters a running human-review run, blocking stale verdicts from surfacing mid-review.
- Added regression tests covering: all-runs scan, API-error masking, running-review early-exit (both evidence omission and `RequiresLLM` correctness).

> Changelog: fix(monitor): fix human verdict detection in stuck-human-blocked