### PR TITLE
fix(stores): trailing fetch for throttled reload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,7 +306,7 @@ jobs:
           done
 
       - name: Run fast e2e tests (target ≤5 min)
-        run: cd frontend && npx playwright test --grep-invert "@integration|@flaky"
+        run: cd frontend && npx playwright test --grep-invert "@integration"
         env:
           SYBRA_HOME: /tmp/sybra-e2e
           SYBRA_E2E_PROVIDER: ${{ matrix.provider }}
@@ -343,82 +343,5 @@ jobs:
         if: failure()
         with:
           name: playwright-report-${{ matrix.provider }}
-          path: frontend/test-results/
-          retention-days: 7
-
-  e2e-flaky:
-    name: E2E Flaky (non-blocking)
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-
-      - name: Install frontend deps
-        run: cd frontend && npm ci
-
-      - name: Install Playwright browsers
-        run: cd frontend && npx playwright install chromium
-
-      - name: Seed e2e fixtures
-        run: |
-          mkdir -p "$SYBRA_HOME/tasks"
-          cp frontend/e2e/fixtures/*.md "$SYBRA_HOME/tasks/"
-          cat > "$SYBRA_HOME/config.yaml" <<EOF
-          agent:
-            provider: claude
-          monitor:
-            stuck_human_hours: 99999
-          EOF
-        env:
-          SYBRA_HOME: /tmp/sybra-e2e
-
-      - name: Build web frontend
-        run: cd frontend && npm run build:web
-
-      - name: Build sybra-server
-        run: go build -o bin/sybra-server ./cmd/sybra-server
-
-      - name: Start sybra-server
-        run: |
-          SYBRA_HOME=/tmp/sybra-e2e \
-          SYBRA_STATIC_DIR=frontend/dist-web \
-          ./bin/sybra-server > /tmp/sybra-server.log 2>&1 &
-          echo "Waiting for sybra-server..."
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:8080/health > /dev/null 2>&1; then
-              echo "Ready after ${i}s"
-              break
-            fi
-            if [ "$i" -eq 30 ]; then
-              echo "::error::sybra-server timed out"
-              cat /tmp/sybra-server.log
-              exit 1
-            fi
-            sleep 1
-          done
-
-      - name: Run flaky e2e tests
-        run: cd frontend && npx playwright test --grep "@flaky" --retries=5
-        env:
-          SYBRA_HOME: /tmp/sybra-e2e
-
-      - name: Write flaky test timing summary
-        if: always()
-        working-directory: frontend
-        run: |
-          echo "### Flaky Tests" >> "$GITHUB_STEP_SUMMARY"
-          if test -f test-results/results.json; then node e2e/timing-summary.mjs >> "$GITHUB_STEP_SUMMARY"; fi
-
-      - name: Dump server log
-        if: always()
-        run: cat /tmp/sybra-server.log || true
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: always()
-        with:
-          name: playwright-report-flaky
           path: frontend/test-results/
           retention-days: 7

--- a/frontend/e2e/tasks.spec.ts
+++ b/frontend/e2e/tasks.spec.ts
@@ -251,14 +251,15 @@ test.describe('Navigation Rail', () => {
 })
 
 test.describe('Task watcher', () => {
-  test('board updates when task file is created externally', { tag: '@flaky' }, async ({ page }) => {
-    test.setTimeout(35_000)
+  test('board updates when task file is created externally', async ({ page }) => {
     await goToTaskList(page)
     await waitForTasks(page)
 
     const title = `E2E External Task ${Date.now()}`
     await createExternalTaskFile(title)
 
-    await expect(page.getByRole('heading', { name: title })).toBeVisible({ timeout: 30_000 })
+    // Watcher debounce (200ms) + SSE delivery + store trailing fetch (≤500ms)
+    // settle well under a second; 10s is generous headroom for CI.
+    await expect(page.getByRole('heading', { name: title })).toBeVisible({ timeout: 10_000 })
   })
 })

--- a/frontend/src/stores/entity-store.svelte.ts
+++ b/frontend/src/stores/entity-store.svelte.ts
@@ -1,8 +1,14 @@
+// Minimum gap between backend fetches. A burst of load() calls inside this
+// window collapses to one leading fetch plus one trailing fetch.
+const MIN_LOAD_INTERVAL_MS = 500
+
 export class EntityStore<T extends { id: string }> {
   items = $state<Map<string, T>>(new Map())
   loading = $state(false)
   error = $state('')
   private pollTimer: ReturnType<typeof setInterval> | null = null
+  private trailingTimer: ReturnType<typeof setTimeout> | null = null
+  private trailingPending = false
   private inFlight: Promise<void> | null = null
   private lastLoadAt = 0
 
@@ -26,14 +32,38 @@ export class EntityStore<T extends { id: string }> {
   }
 
   async load(): Promise<void> {
-    // Coalesce concurrent callers and throttle to at most one fetch per 500ms.
-    // Initial loads (empty items) bypass the throttle so first render always fetches.
-    if (this.inFlight) return this.inFlight
+    // A fetch already in flight absorbs this caller, but flags a trailing
+    // fetch: the running request may have read the backend before the change
+    // that triggered this call landed.
+    if (this.inFlight) {
+      this.trailingPending = true
+      return this.inFlight
+    }
+    // Throttle to one fetch per MIN_LOAD_INTERVAL_MS. Initial loads (empty
+    // items) always fetch so first render is never delayed. A throttled call
+    // is never dropped — it schedules a trailing fetch, otherwise a live
+    // event (task:created/updated/deleted) arriving just after a load would
+    // be invisible until the next poll, up to 30s later.
     const isInitial = this.items.size === 0
     if (!isInitial) {
       const sinceLast = Date.now() - this.lastLoadAt
-      if (sinceLast < 500) return
+      if (sinceLast < MIN_LOAD_INTERVAL_MS) {
+        this.scheduleTrailingLoad(MIN_LOAD_INTERVAL_MS - sinceLast)
+        return
+      }
     }
+    return this.runLoad(isInitial)
+  }
+
+  private scheduleTrailingLoad(delayMs: number): void {
+    if (this.trailingTimer !== null) return
+    this.trailingTimer = setTimeout(() => {
+      this.trailingTimer = null
+      void this.load()
+    }, delayMs)
+  }
+
+  private runLoad(isInitial: boolean): Promise<void> {
     if (isInitial) this.loading = true
     this.error = ''
     this.inFlight = (async () => {
@@ -48,6 +78,10 @@ export class EntityStore<T extends { id: string }> {
         if (isInitial) this.loading = false
         this.lastLoadAt = Date.now()
         this.inFlight = null
+        if (this.trailingPending) {
+          this.trailingPending = false
+          this.scheduleTrailingLoad(MIN_LOAD_INTERVAL_MS)
+        }
       }
     })()
     return this.inFlight
@@ -63,5 +97,10 @@ export class EntityStore<T extends { id: string }> {
       clearInterval(this.pollTimer)
       this.pollTimer = null
     }
+    if (this.trailingTimer) {
+      clearTimeout(this.trailingTimer)
+      this.trailingTimer = null
+    }
+    this.trailingPending = false
   }
 }

--- a/frontend/src/stores/tasks.svelte.test.ts
+++ b/frontend/src/stores/tasks.svelte.test.ts
@@ -114,6 +114,46 @@ describe('TaskStore', () => {
 
       expect(taskStore.loading).toBe(false)
     })
+
+    it('runs a trailing fetch when throttled instead of dropping the load', async () => {
+      vi.useFakeTimers()
+      try {
+        mockListTasks.mockResolvedValue([makeTask({ id: 't1' })])
+        await taskStore.load()
+        expect(mockListTasks).toHaveBeenCalledTimes(1)
+
+        // A load within the 500ms window is throttled — but a live event
+        // (task:created/updated/deleted) must not be lost. The throttled call
+        // schedules a trailing fetch rather than returning empty-handed.
+        mockListTasks.mockResolvedValue([makeTask({ id: 't1' }), makeTask({ id: 't2' })])
+        await taskStore.load()
+        expect(mockListTasks).toHaveBeenCalledTimes(1)
+
+        await vi.advanceTimersByTimeAsync(500)
+        expect(mockListTasks).toHaveBeenCalledTimes(2)
+        expect(taskStore.tasks.size).toBe(2)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('coalesces a burst of throttled loads into one trailing fetch', async () => {
+      vi.useFakeTimers()
+      try {
+        mockListTasks.mockResolvedValue([makeTask({ id: 't1' })])
+        await taskStore.load()
+        expect(mockListTasks).toHaveBeenCalledTimes(1)
+
+        await taskStore.load()
+        await taskStore.load()
+        await taskStore.load()
+
+        await vi.advanceTimersByTimeAsync(500)
+        expect(mockListTasks).toHaveBeenCalledTimes(2)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
   })
 
   describe('get', () => {


### PR DESCRIPTION
## Motivation

The `E2E Flaky (non-blocking)` CI job exists to quarantine one test —
`board updates when task file is created externally`. It was never a
genuine flake: commit history shows it went `test.fixme` → `@flaky`
without anyone diagnosing the cause.

Reproduced locally: 4 pass / 4 fail out of 8 runs. Every *passing* run
took 30–35s — the tell. A working live update lands in ~1s; 30s is the
`taskStore` poll interval. The test's 30s assertion timeout was racing
the 30s poll.

> Changelog: fix(stores): trailing fetch for throttled live reloads

Root cause is a real product bug, not a test issue. Instrumenting the
browser showed the `task:created` SSE event always arrives (~200ms
after the file write), but no `ListTasks` fetch follows when the event
lands within 500ms of the initial load — exactly this test's timing.

`EntityStore.load()` throttled to one fetch per 500ms and silently
dropped any throttled call with no trailing re-fetch. So a task file
change within 500ms of a load (page load, or rapid agent churn) stayed
invisible in the live UI for up to 30s.

## Implementation information

- `EntityStore.load()` now uses a trailing-edge throttle: a throttled
  call schedules a trailing fetch instead of being dropped. An
  in-flight-coalesced call flags a trailing fetch too, since the
  running request may have read the backend before the change landed.
  `stopPolling()` clears the trailing timer. Fix benefits all stores
  (tasks, agents, projects).
- `tasks.spec.ts`: dropped the `@flaky` tag and the 35s/30s timeouts
  (live path settles well under 1s — 10s is generous CI headroom).
- `ci.yml`: removed the non-blocking `e2e-flaky` job; the test now runs
  in the fast suite.
- Added two regression tests covering throttled trailing fetch and
  burst coalescing.

Verified: the un-tagged test passes 12/12 locally (~1.5s each, was
30–35s or failing). oxlint, svelte-check, 187 store unit tests, and
actionlint all green.

## Supporting documentation

None.