### PR TITLE
test(monitor): result-fallback human-required path

### DIFF
--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -716,6 +716,33 @@ func TestDetectStuckHumanBlocked_RequiresLLM(t *testing.T) {
 		}
 	})
 
+	t.Run("RequiresLLM=false when Verdict field empty but Result has human verdict", func(t *testing.T) {
+		// Simulates the real-world case for task af1213a4: budget-exhausted task
+		// escalated to human-required, single human-review run completed with the
+		// decision embedded in the Result text (Verdict field was not yet
+		// populated in this era). Detector must fall back to parsing Result.
+		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{
+				{
+					AgentID: "rev1", Role: "human-review", State: "stopped",
+					Result: "Analysis.\n\n```sybra-verdict\n{\"decision\":\"human\",\"summary\":\"budget exhausted\"}\n```",
+				},
+			}
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		if report.Anomalies[0].RequiresLLM {
+			t.Error("RequiresLLM must be false when Result contains a human verdict (Verdict field fallback)")
+		}
+		if v, _ := report.Anomalies[0].Evidence["human_review_verdict"].(string); v != "human" {
+			t.Errorf("human_review_verdict = %q, want human", v)
+		}
+	})
+
 	t.Run("RequiresLLM=true when human-review verdict is sybra_bug", func(t *testing.T) {
 		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
 			t.UpdatedAt = now.Add(-9 * time.Hour)

--- a/internal/monitor/service_test.go
+++ b/internal/monitor/service_test.go
@@ -529,6 +529,75 @@ func TestServiceTick_HumanRequiredStuck_DowngradedLLM_RemediatesDirectly(t *test
 	}
 }
 
+// TestServiceTick_HumanRequiredStuck_ResultFallback covers the scenario that
+// produced a spurious meta-task for task af1213a4: single human-review run
+// completed with the verdict embedded in the Result text, Verdict field empty
+// (pre-Verdict-field era). The remediator must handle it in-process — no
+// meta-task, no dispatcher call.
+func TestServiceTick_HumanRequiredStuck_ResultFallback(t *testing.T) {
+	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
+	cfg := defaultCfg()
+	tasks := &fakeTasks{tasks: []task.Task{
+		mkTask("hr-result-fallback", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{{
+				Role:  "human-review",
+				State: "stopped",
+				// Verdict field empty — decision must be parsed from Result.
+				Result: "Analysis.\n\n```sybra-verdict\n{\"decision\":\"human\",\"summary\":\"budget exhausted\"}\n```",
+			}}
+		}),
+	}}
+	disp := &fakeDispatcher{}
+	sink := &fakeSink{createNext: true}
+	svc := NewService(Deps{
+		Cfg:        cfg,
+		Tasks:      tasks,
+		Audit:      fakeAudit{},
+		Agents:     nilAgentLister{},
+		Dispatcher: disp,
+		Sink:       sink,
+		Logger:     slog.Default(),
+		Now:        func() time.Time { return now },
+	})
+
+	report, err := svc.tick(context.Background())
+	if err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+
+	if len(report.Anomalies) != 1 || report.Anomalies[0].Kind != KindStuckHumanBlocked {
+		t.Fatalf("want 1 stuck_human_blocked anomaly, got %v", report.Anomalies)
+	}
+	if report.Anomalies[0].RequiresLLM {
+		t.Error("RequiresLLM must be false when Result contains a human verdict")
+	}
+
+	// Remediator must have stamped UpdatedAt (empty update, no status change).
+	if len(tasks.updates) != 1 {
+		t.Fatalf("want 1 task update (dwell reset), got %d", len(tasks.updates))
+	}
+	u := tasks.updates[0]
+	if u.id != "hr-result-fallback" {
+		t.Errorf("updated wrong task: %q", u.id)
+	}
+	if u.u.Status != nil {
+		t.Errorf("status must not change, got %v", u.u.Status)
+	}
+
+	// Sink and dispatcher must not fire — no meta-task.
+	if len(sink.submissions) != 0 {
+		t.Fatalf("sink must not see human-required anomaly, got %d submissions", len(sink.submissions))
+	}
+	if len(disp.calls) != 0 {
+		t.Fatalf("dispatcher must not be called, got %d calls", len(disp.calls))
+	}
+
+	if len(report.Remediated) != 1 {
+		t.Fatalf("want 1 remediated, got %d", len(report.Remediated))
+	}
+}
+
 func TestParseFirstMatchingIssue(t *testing.T) {
 	out := []byte(`[{"number":42,"title":"unrelated","url":"https://github.com/o/r/issues/42"},{"number":87,"title":"[monitor] failure_spike","url":"https://github.com/o/r/issues/87"}]`)
 	num, url := parseFirstMatchingIssue(out, "[monitor] failure_spike")

--- a/internal/monitor/service_test.go
+++ b/internal/monitor/service_test.go
@@ -405,17 +405,18 @@ func TestServiceTick_HumanRequiredStuck_RemediatesDirectly(t *testing.T) {
 	}
 }
 
-// TestServiceTick_HumanRequiredStuck_StaleVerdictIgnored verifies that when
-// the latest human-review run has an unparsable result (e.g. 529), the stale
-// "human" verdict from an older run is NOT used. The detector must derive
-// human_review_verdict from the last run only, so RequiresLLM=true and the
-// anomaly is dispatched rather than directly remediated.
-func TestServiceTick_HumanRequiredStuck_StaleVerdictIgnored(t *testing.T) {
+// TestServiceTick_HumanRequiredStuck_StaleVerdictPreserved verifies that when
+// the latest human-review run has an unparsable result (e.g. 529), the earlier
+// "human" verdict from an older run IS used. The detector scans runs newest-
+// to-oldest and surfaces the first parseable verdict, so RequiresLLM=false and
+// the anomaly is remediated in-process rather than dispatched.
+func TestServiceTick_HumanRequiredStuck_StaleVerdictPreserved(t *testing.T) {
 	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
 	cfg := defaultCfg()
 	tasks := &fakeTasks{tasks: []task.Task{
 		// Two human-review runs: older ended with Verdict="human", latest ended
-		// with unparsable 529 result. The detector must look at the last run only.
+		// with unparsable 529 result. Detector scans backward and finds the
+		// earlier verdict — task is genuinely human-required, no LLM needed.
 		mkTask("hr-stale", task.StatusHumanRequired, func(t *task.Task) {
 			t.UpdatedAt = now.Add(-9 * time.Hour)
 			t.AgentRuns = []task.AgentRun{
@@ -445,19 +446,19 @@ func TestServiceTick_HumanRequiredStuck_StaleVerdictIgnored(t *testing.T) {
 	if len(report.Anomalies) != 1 || report.Anomalies[0].Kind != KindStuckHumanBlocked {
 		t.Fatalf("want 1 stuck_human_blocked anomaly, got %v", report.Anomalies)
 	}
-	// Latest run has no parsable verdict → stale "human" must be ignored.
-	if !report.Anomalies[0].RequiresLLM {
-		t.Error("RequiresLLM must be true when latest run has unparsable result")
+	// Earlier "human" verdict is preserved — failed retry must not mask it.
+	if report.Anomalies[0].RequiresLLM {
+		t.Error("RequiresLLM must be false: earlier human verdict must not be masked by a failed retry")
 	}
 
-	// Dispatcher is invoked (RequiresLLM=true path).
-	if len(disp.calls) != 1 {
-		t.Fatalf("want 1 dispatcher call, got %d", len(disp.calls))
+	// Remediated in-process (dwell reset) — dispatcher must not fire.
+	if len(disp.calls) != 0 {
+		t.Fatalf("want 0 dispatcher calls, got %d", len(disp.calls))
 	}
 
-	// No direct remediation — task must NOT appear in Remediated.
-	if len(report.Remediated) != 0 {
-		t.Fatalf("want 0 remediated, got %d: %v", len(report.Remediated), report.Remediated)
+	// Task must appear in Remediated.
+	if len(report.Remediated) != 1 {
+		t.Fatalf("want 1 remediated, got %d: %v", len(report.Remediated), report.Remediated)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Spurious meta-task was created for task af1213a4: a single human-review run
completed with verdict embedded in the Result text only (Verdict field empty —
pre-Verdict-field era). The detector skipped RequiresLLM=false, so the service
dispatched a meta-task instead of remediating in-process.

## Implementation information

Adds regression coverage for the result-fallback path:

- `detector_test`: RequiresLLM=false subcase for empty Verdict + Result with
  sybra-verdict block
- `service_test`: `TestServiceTick_HumanRequiredStuck_ResultFallback` — verifies
  service remediates in-process with no meta-task or dispatcher call when Verdict
  is empty but Result carries the block

> Changelog: skip