### PR TITLE
fix(monitor): scan all runs for human verdict

### DIFF
--- a/frontend/e2e/tasks.spec.ts
+++ b/frontend/e2e/tasks.spec.ts
@@ -251,14 +251,15 @@ test.describe('Navigation Rail', () => {
 })
 
 test.describe('Task watcher', () => {
-  test('board updates when task file is created externally', { tag: '@flaky' }, async ({ page }) => {
-    test.setTimeout(35_000)
+  test('board updates when task file is created externally', async ({ page }) => {
     await goToTaskList(page)
     await waitForTasks(page)
 
     const title = `E2E External Task ${Date.now()}`
     await createExternalTaskFile(title)
 
-    await expect(page.getByRole('heading', { name: title })).toBeVisible({ timeout: 30_000 })
+    // Watcher debounce (200ms) + SSE delivery + store trailing fetch (≤500ms)
+    // settle well under a second; 10s is generous headroom for CI.
+    await expect(page.getByRole('heading', { name: title })).toBeVisible({ timeout: 10_000 })
   })
 })

--- a/frontend/src/stores/entity-store.svelte.ts
+++ b/frontend/src/stores/entity-store.svelte.ts
@@ -1,8 +1,14 @@
+// Minimum gap between backend fetches. A burst of load() calls inside this
+// window collapses to one leading fetch plus one trailing fetch.
+const MIN_LOAD_INTERVAL_MS = 500
+
 export class EntityStore<T extends { id: string }> {
   items = $state<Map<string, T>>(new Map())
   loading = $state(false)
   error = $state('')
   private pollTimer: ReturnType<typeof setInterval> | null = null
+  private trailingTimer: ReturnType<typeof setTimeout> | null = null
+  private trailingPending = false
   private inFlight: Promise<void> | null = null
   private lastLoadAt = 0
 
@@ -26,14 +32,38 @@ export class EntityStore<T extends { id: string }> {
   }
 
   async load(): Promise<void> {
-    // Coalesce concurrent callers and throttle to at most one fetch per 500ms.
-    // Initial loads (empty items) bypass the throttle so first render always fetches.
-    if (this.inFlight) return this.inFlight
+    // A fetch already in flight absorbs this caller, but flags a trailing
+    // fetch: the running request may have read the backend before the change
+    // that triggered this call landed.
+    if (this.inFlight) {
+      this.trailingPending = true
+      return this.inFlight
+    }
+    // Throttle to one fetch per MIN_LOAD_INTERVAL_MS. Initial loads (empty
+    // items) always fetch so first render is never delayed. A throttled call
+    // is never dropped — it schedules a trailing fetch, otherwise a live
+    // event (task:created/updated/deleted) arriving just after a load would
+    // be invisible until the next poll, up to 30s later.
     const isInitial = this.items.size === 0
     if (!isInitial) {
       const sinceLast = Date.now() - this.lastLoadAt
-      if (sinceLast < 500) return
+      if (sinceLast < MIN_LOAD_INTERVAL_MS) {
+        this.scheduleTrailingLoad(MIN_LOAD_INTERVAL_MS - sinceLast)
+        return
+      }
     }
+    return this.runLoad(isInitial)
+  }
+
+  private scheduleTrailingLoad(delayMs: number): void {
+    if (this.trailingTimer !== null) return
+    this.trailingTimer = setTimeout(() => {
+      this.trailingTimer = null
+      void this.load()
+    }, delayMs)
+  }
+
+  private runLoad(isInitial: boolean): Promise<void> {
     if (isInitial) this.loading = true
     this.error = ''
     this.inFlight = (async () => {
@@ -48,6 +78,10 @@ export class EntityStore<T extends { id: string }> {
         if (isInitial) this.loading = false
         this.lastLoadAt = Date.now()
         this.inFlight = null
+        if (this.trailingPending) {
+          this.trailingPending = false
+          this.scheduleTrailingLoad(MIN_LOAD_INTERVAL_MS)
+        }
       }
     })()
     return this.inFlight
@@ -63,5 +97,10 @@ export class EntityStore<T extends { id: string }> {
       clearInterval(this.pollTimer)
       this.pollTimer = null
     }
+    if (this.trailingTimer) {
+      clearTimeout(this.trailingTimer)
+      this.trailingTimer = null
+    }
+    this.trailingPending = false
   }
 }

--- a/frontend/src/stores/tasks.svelte.test.ts
+++ b/frontend/src/stores/tasks.svelte.test.ts
@@ -114,6 +114,46 @@ describe('TaskStore', () => {
 
       expect(taskStore.loading).toBe(false)
     })
+
+    it('runs a trailing fetch when throttled instead of dropping the load', async () => {
+      vi.useFakeTimers()
+      try {
+        mockListTasks.mockResolvedValue([makeTask({ id: 't1' })])
+        await taskStore.load()
+        expect(mockListTasks).toHaveBeenCalledTimes(1)
+
+        // A load within the 500ms window is throttled — but a live event
+        // (task:created/updated/deleted) must not be lost. The throttled call
+        // schedules a trailing fetch rather than returning empty-handed.
+        mockListTasks.mockResolvedValue([makeTask({ id: 't1' }), makeTask({ id: 't2' })])
+        await taskStore.load()
+        expect(mockListTasks).toHaveBeenCalledTimes(1)
+
+        await vi.advanceTimersByTimeAsync(500)
+        expect(mockListTasks).toHaveBeenCalledTimes(2)
+        expect(taskStore.tasks.size).toBe(2)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('coalesces a burst of throttled loads into one trailing fetch', async () => {
+      vi.useFakeTimers()
+      try {
+        mockListTasks.mockResolvedValue([makeTask({ id: 't1' })])
+        await taskStore.load()
+        expect(mockListTasks).toHaveBeenCalledTimes(1)
+
+        await taskStore.load()
+        await taskStore.load()
+        await taskStore.load()
+
+        await vi.advanceTimersByTimeAsync(500)
+        expect(mockListTasks).toHaveBeenCalledTimes(2)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
   })
 
   describe('get', () => {

--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -344,7 +344,15 @@ func projectAllowed(fn func(string) bool, projectID string) bool {
 // runs. "human" is treated as final and returned immediately so a failed
 // later run (e.g. API 529 with no parseable result) cannot override an
 // earlier confirmed-human conclusion.
+// A running human-review supersedes any older stopped verdict — the in-flight
+// run may produce a different decision, so we must wait for it to finish.
 func humanReviewVerdict(runs []task.AgentRun) string {
+	for i := range runs {
+		r := &runs[i]
+		if r.Role == "human-review" && r.State == "running" {
+			return ""
+		}
+	}
 	var last string
 	for i := range runs {
 		r := &runs[i]

--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -171,17 +171,11 @@ func detectStuckHumanBlocked(t *task.Task, now time.Time, budget time.Duration) 
 			ev["last_agent_role"] = last.Role
 		}
 		ev["last_agent_state"] = last.State
-		if last.Role == "human-review" && last.State == "stopped" {
-			verdict := last.Verdict
-			if verdict == "" && last.Result != "" {
-				// Fallback for runs persisted before the Verdict field was
-				// added: parse from the truncated Result text.
-				verdict = parseHumanReviewDecision(last.Result)
-			}
-			if verdict != "" {
-				ev["human_review_verdict"] = verdict
-			}
-		}
+	}
+	// Scan all runs so a failed later run cannot override an earlier
+	// confirmed-human verdict (the condition that produced task 47676b42).
+	if v := humanReviewVerdict(t.AgentRuns); v != "" {
+		ev["human_review_verdict"] = v
 	}
 	// plan-review is always deterministic: human must approve or reject the plan.
 	// For human-required, skip LLM only when human-review confirmed verdict=human.
@@ -344,6 +338,31 @@ func projectAllowed(fn func(string) bool, projectID string) bool {
 		return true
 	}
 	return fn(projectID)
+}
+
+// humanReviewVerdict returns the effective verdict across all human-review
+// runs. "human" is treated as final and returned immediately so a failed
+// later run (e.g. API 529 with no parseable result) cannot override an
+// earlier confirmed-human conclusion.
+func humanReviewVerdict(runs []task.AgentRun) string {
+	var last string
+	for i := range runs {
+		r := &runs[i]
+		if r.Role != "human-review" || r.State != "stopped" {
+			continue
+		}
+		v := r.Verdict
+		if v == "" && r.Result != "" {
+			v = parseHumanReviewDecision(r.Result)
+		}
+		if v == "human" {
+			return "human"
+		}
+		if v != "" {
+			last = v
+		}
+	}
+	return last
 }
 
 var humanReviewVerdictRe = regexp.MustCompile("(?s)```\\s*sybra-verdict\\s*\\n(.*?)\\n```")

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -713,6 +713,30 @@ func TestDetectStuckHumanBlocked_RequiresLLM(t *testing.T) {
 			t.Error("RequiresLLM must be true when human-review is still running")
 		}
 	})
+
+	t.Run("RequiresLLM=true when running human-review follows stopped verdict=human", func(t *testing.T) {
+		// History: [stopped verdict=human, running human-review]. The newer
+		// in-flight run must block reuse of the older verdict — the running
+		// review may reach a different conclusion.
+		tk := mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{
+				{AgentID: "rev1", Role: "human-review", State: "stopped", Verdict: "human"},
+				{AgentID: "rev2", Role: "human-review", State: "running"},
+			}
+		})
+		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
+		report := Detect(in)
+		if len(report.Anomalies) != 1 {
+			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+		}
+		if _, ok := report.Anomalies[0].Evidence["human_review_verdict"]; ok {
+			t.Error("human_review_verdict must not be set while a newer review is running")
+		}
+		if !report.Anomalies[0].RequiresLLM {
+			t.Error("RequiresLLM must be true when newer human-review is still running")
+		}
+	})
 }
 
 func TestCounts(t *testing.T) {

--- a/internal/monitor/service_test.go
+++ b/internal/monitor/service_test.go
@@ -479,6 +479,76 @@ func TestServiceTick_HumanRequiredStuck_DowngradedLLM(t *testing.T) {
 	}
 }
 
+// TestServiceTick_HumanRequiredStuck_EarlierRunHuman covers the PR #840 fix:
+// when a prior human-review run concluded "human" and a later run failed
+// (no verdict), the detector emits RequiresLLM=false without requiring
+// DowngradeLLMForTask. The remediator stamps UpdatedAt and neither sink
+// nor dispatcher fires.
+func TestServiceTick_HumanRequiredStuck_EarlierRunHuman(t *testing.T) {
+	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
+	cfg := defaultCfg()
+	tasks := &fakeTasks{tasks: []task.Task{
+		mkTask("hr-multi-run", task.StatusHumanRequired, func(t *task.Task) {
+			t.UpdatedAt = now.Add(-9 * time.Hour)
+			t.AgentRuns = []task.AgentRun{
+				{Role: "human-review", State: "stopped", Verdict: "human"},
+				// Second run failed: API overloaded, no verdict.
+				{Role: "human-review", State: "stopped", Result: "API Error: 529 Overloaded."},
+			}
+		}),
+	}}
+	disp := &fakeDispatcher{}
+	sink := &fakeSink{createNext: true}
+	svc := NewService(Deps{
+		Cfg:    cfg,
+		Tasks:  tasks,
+		Audit:  fakeAudit{},
+		Agents: nilAgentLister{},
+		// No DowngradeLLMForTask: the "human" verdict from run 1 alone must
+		// suppress RequiresLLM.
+		Dispatcher: disp,
+		Sink:       sink,
+		Logger:     slog.Default(),
+		Now:        func() time.Time { return now },
+	})
+
+	report, err := svc.tick(context.Background())
+	if err != nil {
+		t.Fatalf("tick: %v", err)
+	}
+
+	if len(report.Anomalies) != 1 || report.Anomalies[0].Kind != KindStuckHumanBlocked {
+		t.Fatalf("want 1 stuck_human_blocked anomaly, got %v", report.Anomalies)
+	}
+	if report.Anomalies[0].RequiresLLM {
+		t.Error("RequiresLLM must be false: earlier run concluded 'human'")
+	}
+	if report.Anomalies[0].Evidence["human_review_verdict"] != "human" {
+		t.Errorf("evidence human_review_verdict must be 'human', got %v",
+			report.Anomalies[0].Evidence["human_review_verdict"])
+	}
+
+	if len(tasks.updates) != 1 {
+		t.Fatalf("want 1 task update (dwell reset), got %d", len(tasks.updates))
+	}
+	if tasks.updates[0].id != "hr-multi-run" {
+		t.Errorf("updated wrong task: %q", tasks.updates[0].id)
+	}
+	if tasks.updates[0].u.Status != nil {
+		t.Errorf("status must not change, got %v", tasks.updates[0].u.Status)
+	}
+
+	if len(sink.submissions) != 0 {
+		t.Fatalf("sink must not see anomaly, got %d submissions", len(sink.submissions))
+	}
+	if len(disp.calls) != 0 {
+		t.Fatalf("dispatcher must not fire, got %d calls", len(disp.calls))
+	}
+	if len(report.Remediated) != 1 {
+		t.Fatalf("want 1 remediated, got %d", len(report.Remediated))
+	}
+}
+
 func TestParseFirstMatchingIssue(t *testing.T) {
 	out := []byte(`[{"number":42,"title":"unrelated","url":"https://github.com/o/r/issues/42"},{"number":87,"title":"[monitor] failure_spike","url":"https://github.com/o/r/issues/87"}]`)
 	num, url := parseFirstMatchingIssue(out, "[monitor] failure_spike")


### PR DESCRIPTION
## Motivation

A failed later run (e.g. API 529, no verdict) could override an earlier confirmed-human conclusion, setting `RequiresLLM=true` and producing spurious meta-tasks. A running human-review could also be ignored in favor of a stopped verdict from an older run.

## Implementation information

- Extract `humanReviewVerdict` helper in `internal/monitor/detector.go` that scans **all** agent runs and returns `"human"` immediately on first match — a failed run cannot override a confirmed verdict.
- Guard: a running human-review blocks any older stopped verdict to prevent premature escalation while review is in flight.
- Fix `EntityStore.load` trailing fetch for throttled reloads (frontend store was dropping the post-throttle reload).
- Add service-level test covering the downgraded-LLM + confirmed-human path and the running-review guard.
- e2e watcher: drop `@flaky` tag, reduce timeout 30 s → 10 s.

> Changelog: fix(monitor): scan all runs for human verdict