### PR TITLE
fix(httpapi): sanitize and structure API error responses

### DIFF
--- a/cmd/sybra-perf/main.go
+++ b/cmd/sybra-perf/main.go
@@ -458,6 +458,23 @@ func waitHealthy(ctx context.Context, baseURL string, timeout time.Duration) err
 
 // ==================== API client ====================
 
+// formatAPIError decodes a JSON error envelope from the httpapi server.
+// Falls back to trimmed raw body text when the body is not a valid envelope.
+func formatAPIError(status int, body []byte) string {
+	var env struct {
+		Error string `json:"error"`
+		Code  string `json:"code"`
+	}
+	if err := json.Unmarshal(body, &env); err == nil && env.Error != "" {
+		return fmt.Sprintf("%s [%s] (HTTP %d)", env.Error, env.Code, status)
+	}
+	text := strings.TrimSpace(string(body))
+	if text == "" {
+		text = http.StatusText(status)
+	}
+	return fmt.Sprintf("%s (HTTP %d)", text, status)
+}
+
 type apiClient struct {
 	baseURL string
 	http    *http.Client
@@ -497,7 +514,7 @@ func (c *apiClient) call(service, method string, args []any, out any) error {
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		msg, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("%s.%s: %s (%d)", service, method, strings.TrimSpace(string(msg)), resp.StatusCode)
+		return fmt.Errorf("%s.%s: %s", service, method, formatAPIError(resp.StatusCode, msg))
 	}
 	if out == nil {
 		_, _ = io.Copy(io.Discard, resp.Body)

--- a/cmd/sybra-perf/main_test.go
+++ b/cmd/sybra-perf/main_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestFormatAPIError(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   []byte
+		want   string
+	}{
+		{
+			name:   "valid envelope",
+			status: http.StatusNotFound,
+			body:   []byte(`{"error":"unknown service: NoSvc","code":"not_found"}`),
+			want:   "unknown service: NoSvc [not_found] (HTTP 404)",
+		},
+		{
+			name:   "valid envelope internal error",
+			status: http.StatusInternalServerError,
+			body:   []byte(`{"error":"internal error","code":"internal_error"}`),
+			want:   "internal error [internal_error] (HTTP 500)",
+		},
+		{
+			name:   "malformed JSON",
+			status: http.StatusBadRequest,
+			body:   []byte(`not json`),
+			want:   "not json (HTTP 400)",
+		},
+		{
+			name:   "empty body",
+			status: http.StatusServiceUnavailable,
+			body:   []byte{},
+			want:   "Service Unavailable (HTTP 503)",
+		},
+		{
+			name:   "non-JSON text",
+			status: http.StatusInternalServerError,
+			body:   []byte("something went wrong"),
+			want:   "something went wrong (HTTP 500)",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatAPIError(tc.status, tc.body)
+			if got != tc.want {
+				t.Fatalf("formatAPIError(%d, %q) = %q; want %q", tc.status, tc.body, got, tc.want)
+			}
+		})
+	}
+}

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -21,7 +21,17 @@ async function call<T>(service: string, method: string, ...args: unknown[]): Pro
     headers: { 'Content-Type': 'application/json' },
     body: args.length > 0 ? JSON.stringify(args) : undefined,
   })
-  if (!res.ok) throw new Error(await res.text())
+  if (!res.ok) {
+    const rawText = await res.text()
+    // web-mode only: desktop Wails IPC errors never reach this path
+    let parsed: unknown = null
+    try { parsed = JSON.parse(rawText) } catch { /* fall through to rawText */ }
+    if (parsed && typeof parsed === 'object' && 'error' in parsed && typeof (parsed as Record<string, unknown>).error === 'string') {
+      const p = parsed as { error: string; code?: string }
+      throw Object.assign(new Error(p.error), { code: p.code })
+    }
+    throw new Error(rawText)
+  }
   const text = await res.text()
   return (text ? JSON.parse(text) : undefined) as T
 }

--- a/internal/httpapi/errors.go
+++ b/internal/httpapi/errors.go
@@ -12,9 +12,19 @@ type ErrorCode string
 const (
 	ErrCodeNotFound   ErrorCode = "not_found"
 	ErrCodeValidation ErrorCode = "validation_error"
+	ErrCodeConflict   ErrorCode = "conflict"
 	ErrCodeTooLarge   ErrorCode = "payload_too_large"
 	ErrCodeInternal   ErrorCode = "internal_error"
 )
+
+// ClientError is implemented by service errors that are safe to surface to
+// HTTP clients (validation failures, precondition/state errors). The handler
+// passes the message and status through instead of sanitizing to 500.
+// Service packages implement this locally — no import of httpapi required.
+type ClientError interface {
+	error
+	HTTPStatus() int
+}
 
 type errorEnvelope struct {
 	Error string    `json:"error"`

--- a/internal/httpapi/errors.go
+++ b/internal/httpapi/errors.go
@@ -1,0 +1,35 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+// ErrorCode identifies the failure class in a JSON error response.
+type ErrorCode string
+
+const (
+	ErrCodeNotFound   ErrorCode = "not_found"
+	ErrCodeValidation ErrorCode = "validation_error"
+	ErrCodeTooLarge   ErrorCode = "payload_too_large"
+	ErrCodeInternal   ErrorCode = "internal_error"
+)
+
+type errorEnvelope struct {
+	Error string    `json:"error"`
+	Code  ErrorCode `json:"code"`
+}
+
+func respondError(w http.ResponseWriter, logger *slog.Logger, status int, code ErrorCode, clientMsg string) {
+	if status >= 500 {
+		logger.Error("httpapi.error", "status", status, "code", code)
+	} else {
+		logger.Warn("httpapi.error", "status", status, "code", code)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(errorEnvelope{Error: clientMsg, Code: code}); err != nil {
+		logger.Error("httpapi.error.encode", "status", status, "code", code, "err", err)
+	}
+}

--- a/internal/httpapi/handler.go
+++ b/internal/httpapi/handler.go
@@ -123,9 +123,14 @@ func Mount(mux *http.ServeMux, services map[string]Service, logger *slog.Logger)
 			if last.Type().Implements(errType) {
 				if !last.IsNil() {
 					callErr, _ := last.Interface().(error)
-					logger.Warn("httpapi.call.error",
-						"service", svcName, "method", methodName, "err", callErr)
-					respondError(w, logger, http.StatusInternalServerError, ErrCodeInternal, "internal error")
+					var ce ClientError
+					if errors.As(callErr, &ce) {
+						respondError(w, logger, ce.HTTPStatus(), codeForStatus(ce.HTTPStatus()), ce.Error())
+					} else {
+						logger.Warn("httpapi.call.error",
+							"service", svcName, "method", methodName, "err", callErr)
+						respondError(w, logger, http.StatusInternalServerError, ErrCodeInternal, "internal error")
+					}
 					return
 				}
 				out = out[:len(out)-1]
@@ -146,3 +151,14 @@ func Mount(mux *http.ServeMux, services map[string]Service, logger *slog.Logger)
 }
 
 var errType = reflect.TypeFor[error]()
+
+// codeForStatus maps an HTTP status returned by a ClientError to the
+// structured error code included in the JSON response envelope.
+func codeForStatus(status int) ErrorCode {
+	switch status {
+	case http.StatusConflict:
+		return ErrCodeConflict
+	default:
+		return ErrCodeValidation
+	}
+}

--- a/internal/httpapi/handler.go
+++ b/internal/httpapi/handler.go
@@ -4,11 +4,13 @@
 //
 // Request body: JSON array of positional arguments (omit body for zero-arg calls).
 // Response body: JSON-encoded return value (empty body for void returns).
-// Errors: HTTP 500 with plain-text error message.
+// Errors: JSON {"error","code"} envelope; HTTP status reflects the failure class;
+// internal (5xx) errors are sanitized — the raw error appears only in server logs.
 package httpapi
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -50,19 +52,19 @@ func Mount(mux *http.ServeMux, services map[string]Service, logger *slog.Logger)
 
 		svc, ok := services[svcName]
 		if !ok {
-			http.Error(w, fmt.Sprintf("unknown service: %s", svcName), http.StatusNotFound)
+			respondError(w, logger, http.StatusNotFound, ErrCodeNotFound, fmt.Sprintf("unknown service: %s", svcName))
 			return
 		}
 
 		if _, allowed := svc.methods[methodName]; !allowed {
-			http.Error(w, fmt.Sprintf("unknown method: %s.%s", svcName, methodName), http.StatusNotFound)
+			respondError(w, logger, http.StatusNotFound, ErrCodeNotFound, fmt.Sprintf("unknown method: %s.%s", svcName, methodName))
 			return
 		}
 
 		rv := reflect.ValueOf(svc.Impl)
 		m := rv.MethodByName(methodName)
 		if !m.IsValid() {
-			http.Error(w, fmt.Sprintf("unknown method: %s.%s", svcName, methodName), http.StatusNotFound)
+			respondError(w, logger, http.StatusNotFound, ErrCodeNotFound, fmt.Sprintf("unknown method: %s.%s", svcName, methodName))
 			return
 		}
 
@@ -75,7 +77,12 @@ func Mount(mux *http.ServeMux, services map[string]Service, logger *slog.Logger)
 		// Read body once.
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			http.Error(w, "read body: "+err.Error(), http.StatusBadRequest)
+			var maxErr *http.MaxBytesError
+			if errors.As(err, &maxErr) {
+				respondError(w, logger, http.StatusRequestEntityTooLarge, ErrCodeTooLarge, "request body too large")
+			} else {
+				respondError(w, logger, http.StatusBadRequest, ErrCodeValidation, "failed to read request body")
+			}
 			return
 		}
 
@@ -83,14 +90,14 @@ func Mount(mux *http.ServeMux, services map[string]Service, logger *slog.Logger)
 		var rawArgs []json.RawMessage
 		if len(body) > 0 {
 			if err := json.Unmarshal(body, &rawArgs); err != nil {
-				http.Error(w, "decode args: "+err.Error(), http.StatusBadRequest)
+				respondError(w, logger, http.StatusBadRequest, ErrCodeValidation, "invalid JSON in args")
 				return
 			}
 		}
 
 		numIn := mt.NumIn()
 		if len(rawArgs) != numIn {
-			http.Error(w, fmt.Sprintf("%s.%s expects %d args, got %d", svcName, methodName, numIn, len(rawArgs)), http.StatusBadRequest)
+			respondError(w, logger, http.StatusBadRequest, ErrCodeValidation, fmt.Sprintf("%s.%s expects %d args, got %d", svcName, methodName, numIn, len(rawArgs)))
 			return
 		}
 
@@ -101,7 +108,7 @@ func Mount(mux *http.ServeMux, services map[string]Service, logger *slog.Logger)
 			// Allocate a pointer to the param type so json.Unmarshal can fill it.
 			ptr := reflect.New(paramType)
 			if err := json.Unmarshal(rawArgs[i], ptr.Interface()); err != nil {
-				http.Error(w, fmt.Sprintf("arg %d: %s", i, err.Error()), http.StatusBadRequest)
+				respondError(w, logger, http.StatusBadRequest, ErrCodeValidation, fmt.Sprintf("arg %d: invalid argument type", i))
 				return
 			}
 			in[i] = ptr.Elem()
@@ -118,7 +125,7 @@ func Mount(mux *http.ServeMux, services map[string]Service, logger *slog.Logger)
 					callErr, _ := last.Interface().(error)
 					logger.Warn("httpapi.call.error",
 						"service", svcName, "method", methodName, "err", callErr)
-					http.Error(w, callErr.Error(), http.StatusInternalServerError)
+					respondError(w, logger, http.StatusInternalServerError, ErrCodeInternal, "internal error")
 					return
 				}
 				out = out[:len(out)-1]

--- a/internal/httpapi/handler_test.go
+++ b/internal/httpapi/handler_test.go
@@ -25,6 +25,8 @@ func (s *testSvc) ReturnAndFail(v string) (string, error) {
 	return "", &testError{v}
 }
 func (s *testSvc) ObjIn(obj map[string]string) string { return obj["key"] }
+func (s *testSvc) ClientFail400() error               { return &testClientError{400, "bad input"} }
+func (s *testSvc) ClientFail409() error               { return &testClientError{409, "already running"} }
 
 // AdminOnly is intentionally not in the allowlist — used by rejection tests.
 func (s *testSvc) AdminOnly() string { return "admin" }
@@ -32,6 +34,15 @@ func (s *testSvc) AdminOnly() string { return "admin" }
 type testError struct{ msg string }
 
 func (e *testError) Error() string { return e.msg }
+
+// testClientError implements httpapi.ClientError without importing the package.
+type testClientError struct {
+	status int
+	msg    string
+}
+
+func (e *testClientError) Error() string   { return e.msg }
+func (e *testClientError) HTTPStatus() int { return e.status }
 
 func setup(t *testing.T) (*http.ServeMux, *httptest.Server, *bytes.Buffer) {
 	t.Helper()
@@ -41,6 +52,7 @@ func setup(t *testing.T) (*http.ServeMux, *httptest.Server, *bytes.Buffer) {
 	httpapi.Mount(mux, map[string]httpapi.Service{
 		"TestSvc": httpapi.NewService(&testSvc{},
 			"Echo", "Add", "Void", "Fail", "FailWith", "ReturnAndFail", "ObjIn",
+			"ClientFail400", "ClientFail409",
 			// AdminOnly is intentionally absent from the allowlist.
 		),
 	}, logger)
@@ -157,6 +169,41 @@ func TestHandler_ErrorReturn(t *testing.T) {
 	}
 	if !strings.Contains(logs, "boom") {
 		t.Fatalf("expected raw error 'boom' in logs; got: %s", logs)
+	}
+}
+
+func TestHandler_ClientErrorPassthrough(t *testing.T) {
+	_, srv, logBuf := setup(t)
+
+	cases := []struct {
+		method     string
+		wantStatus int
+		wantMsg    string
+		wantCode   string
+	}{
+		{"ClientFail400", http.StatusBadRequest, "bad input", string(httpapi.ErrCodeValidation)},
+		{"ClientFail409", http.StatusConflict, "already running", string(httpapi.ErrCodeConflict)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.method, func(t *testing.T) {
+			resp := post(t, srv, "TestSvc", tc.method)
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatus {
+				t.Fatalf("expected status %d, got %d", tc.wantStatus, resp.StatusCode)
+			}
+			msg, code := decodeErr(t, resp)
+			if msg != tc.wantMsg {
+				t.Fatalf("expected client message %q, got %q", tc.wantMsg, msg)
+			}
+			if code != tc.wantCode {
+				t.Fatalf("expected code %q, got %q", tc.wantCode, code)
+			}
+			// ClientErrors must NOT appear in server logs as internal errors.
+			if strings.Contains(logBuf.String(), "httpapi.call.error") {
+				t.Fatal("ClientError must not be logged as internal error")
+			}
+		})
 	}
 }
 

--- a/internal/httpapi/handler_test.go
+++ b/internal/httpapi/handler_test.go
@@ -33,18 +33,20 @@ type testError struct{ msg string }
 
 func (e *testError) Error() string { return e.msg }
 
-func setup(t *testing.T) (*http.ServeMux, *httptest.Server) {
+func setup(t *testing.T) (*http.ServeMux, *httptest.Server, *bytes.Buffer) {
 	t.Helper()
+	logBuf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(logBuf, nil))
 	mux := http.NewServeMux()
 	httpapi.Mount(mux, map[string]httpapi.Service{
 		"TestSvc": httpapi.NewService(&testSvc{},
 			"Echo", "Add", "Void", "Fail", "FailWith", "ReturnAndFail", "ObjIn",
 			// AdminOnly is intentionally absent from the allowlist.
 		),
-	}, slog.Default())
+	}, logger)
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
-	return mux, srv
+	return mux, srv, logBuf
 }
 
 func post(t *testing.T, srv *httptest.Server, service, method string, args ...any) *http.Response {
@@ -71,8 +73,25 @@ func post(t *testing.T, srv *httptest.Server, service, method string, args ...an
 	return resp
 }
 
+// decodeErr asserts Content-Type is application/json and decodes the error envelope.
+func decodeErr(t *testing.T, resp *http.Response) (message, code string) {
+	t.Helper()
+	ct := resp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "application/json") {
+		t.Fatalf("expected Content-Type application/json, got %q", ct)
+	}
+	var env struct {
+		Error string `json:"error"`
+		Code  string `json:"code"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode error envelope: %v", err)
+	}
+	return env.Error, env.Code
+}
+
 func TestHandler_Echo(t *testing.T) {
-	_, srv := setup(t)
+	_, srv, _ := setup(t)
 
 	resp := post(t, srv, "TestSvc", "Echo", "hello")
 	defer resp.Body.Close()
@@ -90,7 +109,7 @@ func TestHandler_Echo(t *testing.T) {
 }
 
 func TestHandler_Add(t *testing.T) {
-	_, srv := setup(t)
+	_, srv, _ := setup(t)
 
 	resp := post(t, srv, "TestSvc", "Add", 3, 4)
 	defer resp.Body.Close()
@@ -108,7 +127,7 @@ func TestHandler_Add(t *testing.T) {
 }
 
 func TestHandler_Void(t *testing.T) {
-	_, srv := setup(t)
+	_, srv, _ := setup(t)
 	resp := post(t, srv, "TestSvc", "Void")
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
@@ -117,20 +136,103 @@ func TestHandler_Void(t *testing.T) {
 }
 
 func TestHandler_ErrorReturn(t *testing.T) {
-	_, srv := setup(t)
+	_, srv, logBuf := setup(t)
 	resp := post(t, srv, "TestSvc", "FailWith")
 	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusInternalServerError {
 		t.Fatalf("expected 500, got %d", resp.StatusCode)
 	}
-	body, _ := io.ReadAll(resp.Body)
-	if !strings.Contains(string(body), "boom") {
-		t.Fatalf("expected error message, got: %s", body)
+	msg, code := decodeErr(t, resp)
+	if msg != "internal error" {
+		t.Fatalf("client must not see raw error; got %q", msg)
+	}
+	if code != string(httpapi.ErrCodeInternal) {
+		t.Fatalf("expected code %q, got %q", httpapi.ErrCodeInternal, code)
+	}
+	// Raw error must appear in server logs, not in client response.
+	logs := logBuf.String()
+	if !strings.Contains(logs, "httpapi.call.error") {
+		t.Fatalf("expected httpapi.call.error in logs; got: %s", logs)
+	}
+	if !strings.Contains(logs, "boom") {
+		t.Fatalf("expected raw error 'boom' in logs; got: %s", logs)
+	}
+}
+
+func TestHandler_ErrorEnvelope(t *testing.T) {
+	_, srv, _ := setup(t)
+
+	cases := []struct {
+		name       string
+		service    string
+		method     string
+		args       []any
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name: "unknown service", service: "NoSvc", method: "Foo",
+			wantStatus: http.StatusNotFound, wantCode: string(httpapi.ErrCodeNotFound),
+		},
+		{
+			name: "blocked method (not in allowlist)", service: "TestSvc", method: "AdminOnly",
+			wantStatus: http.StatusNotFound, wantCode: string(httpapi.ErrCodeNotFound),
+		},
+		{
+			name: "non-existent method", service: "TestSvc", method: "DoesNotExist",
+			wantStatus: http.StatusNotFound, wantCode: string(httpapi.ErrCodeNotFound),
+		},
+		{
+			name: "bad JSON args", service: "TestSvc", method: "Echo",
+			args:       []any{`not-valid-json-array`},
+			wantStatus: http.StatusBadRequest, wantCode: string(httpapi.ErrCodeValidation),
+		},
+		{
+			name: "arg count mismatch", service: "TestSvc", method: "Add",
+			args:       []any{1},
+			wantStatus: http.StatusBadRequest, wantCode: string(httpapi.ErrCodeValidation),
+		},
+		{
+			name: "arg type mismatch", service: "TestSvc", method: "Add",
+			args:       []any{"not-a-number", "also-not-a-number"},
+			wantStatus: http.StatusBadRequest, wantCode: string(httpapi.ErrCodeValidation),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var resp *http.Response
+			if tc.name == "bad JSON args" {
+				// Send a raw non-JSON body to trigger args decode failure.
+				req, err := http.NewRequest(http.MethodPost, srv.URL+"/api/"+tc.service+"/"+tc.method,
+					strings.NewReader("not-json-array"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				req.Header.Set("Content-Type", "application/json")
+				resp, err = http.DefaultClient.Do(req)
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				resp = post(t, srv, tc.service, tc.method, tc.args...)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatus {
+				t.Fatalf("expected status %d, got %d", tc.wantStatus, resp.StatusCode)
+			}
+			_, code := decodeErr(t, resp)
+			if code != tc.wantCode {
+				t.Fatalf("expected code %q, got %q", tc.wantCode, code)
+			}
+		})
 	}
 }
 
 func TestHandler_UnknownService(t *testing.T) {
-	_, srv := setup(t)
+	_, srv, _ := setup(t)
 	resp := post(t, srv, "NoSvc", "Foo")
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusNotFound {
@@ -139,7 +241,7 @@ func TestHandler_UnknownService(t *testing.T) {
 }
 
 func TestHandler_UnknownMethod(t *testing.T) {
-	_, srv := setup(t)
+	_, srv, _ := setup(t)
 	resp := post(t, srv, "TestSvc", "DoesNotExist")
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusNotFound {
@@ -153,7 +255,7 @@ func TestHandler_UnknownMethod(t *testing.T) {
 // unauthenticated callers from reaching privileged mutations (e.g. methods that
 // persist shell commands later executed via sh -c).
 func TestHandler_BlockedMethod(t *testing.T) {
-	_, srv := setup(t)
+	_, srv, _ := setup(t)
 	resp := post(t, srv, "TestSvc", "AdminOnly")
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusNotFound {
@@ -162,7 +264,7 @@ func TestHandler_BlockedMethod(t *testing.T) {
 }
 
 func TestHandler_ObjIn(t *testing.T) {
-	_, srv := setup(t)
+	_, srv, _ := setup(t)
 	resp := post(t, srv, "TestSvc", "ObjIn", map[string]string{"key": "val"})
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
@@ -183,7 +285,7 @@ func TestHandler_ObjIn(t *testing.T) {
 // server returns HTTP 4xx (413 Request Entity Too Large per
 // http.MaxBytesReader semantics) instead of crashing.
 func TestHandler_OversizedBodyRejected(t *testing.T) {
-	_, srv := setup(t)
+	_, srv, _ := setup(t)
 
 	// Body just over the cap. The framework triggers MaxBytesReader's error
 	// during io.ReadAll on the server side.
@@ -203,5 +305,11 @@ func TestHandler_OversizedBodyRejected(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusOK {
 		t.Errorf("oversized body was accepted (status %d); MaxBytesReader cap not enforced", resp.StatusCode)
+	}
+	if resp.StatusCode == http.StatusRequestEntityTooLarge {
+		_, code := decodeErr(t, resp)
+		if code != string(httpapi.ErrCodeTooLarge) {
+			t.Fatalf("expected code %q, got %q", httpapi.ErrCodeTooLarge, code)
+		}
 	}
 }

--- a/internal/sybra/client_errors.go
+++ b/internal/sybra/client_errors.go
@@ -1,0 +1,22 @@
+package sybra
+
+import "net/http"
+
+// clientError is a user-facing error that the HTTP API handler surfaces
+// directly (status + message) instead of sanitizing to 500 internal error.
+// Implements httpapi.ClientError without importing that package.
+type clientError struct {
+	status int
+	msg    string
+}
+
+func (e *clientError) Error() string   { return e.msg }
+func (e *clientError) HTTPStatus() int { return e.status }
+
+func validationError(msg string) error {
+	return &clientError{status: http.StatusBadRequest, msg: msg}
+}
+
+func conflictError(msg string) error {
+	return &clientError{status: http.StatusConflict, msg: msg}
+}

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -85,33 +85,33 @@ func (s *ConfigService) UpdateSettings(settings AppSettings) error {
 func (s *ConfigService) validateSettings(settings AppSettings) error {
 	validProviders := map[string]bool{"": true, "claude": true, "codex": true}
 	if !validProviders[settings.Agent.Provider] {
-		return fmt.Errorf("invalid provider: %q", settings.Agent.Provider)
+		return validationError(fmt.Sprintf("invalid provider: %q", settings.Agent.Provider))
 	}
 	if settings.Agent.Model != "" && !modelNameRe.MatchString(settings.Agent.Model) {
-		return fmt.Errorf("invalid model: %q", settings.Agent.Model)
+		return validationError(fmt.Sprintf("invalid model: %q", settings.Agent.Model))
 	}
 	validModes := map[string]bool{"": true, "headless": true, "interactive": true}
 	if !validModes[settings.Agent.Mode] {
-		return fmt.Errorf("invalid mode: %q", settings.Agent.Mode)
+		return validationError(fmt.Sprintf("invalid mode: %q", settings.Agent.Mode))
 	}
 	if settings.Agent.MaxConcurrent < 1 || settings.Agent.MaxConcurrent > 10 {
-		return fmt.Errorf("maxConcurrent must be 1–10")
+		return validationError("maxConcurrent must be 1–10")
 	}
 	validLevels := map[string]bool{"debug": true, "info": true, "warn": true, "error": true}
 	if !validLevels[settings.Logging.Level] {
-		return fmt.Errorf("invalid log level: %q", settings.Logging.Level)
+		return validationError(fmt.Sprintf("invalid log level: %q", settings.Logging.Level))
 	}
 	if settings.Logging.MaxSizeMB < 1 || settings.Logging.MaxSizeMB > 500 {
-		return fmt.Errorf("maxSizeMB must be 1–500")
+		return validationError("maxSizeMB must be 1–500")
 	}
 	if settings.Logging.MaxFiles < 1 || settings.Logging.MaxFiles > 50 {
-		return fmt.Errorf("maxFiles must be 1–50")
+		return validationError("maxFiles must be 1–50")
 	}
 	if settings.Audit.RetentionDays < 1 || settings.Audit.RetentionDays > 365 {
-		return fmt.Errorf("retentionDays must be 1–365")
+		return validationError("retentionDays must be 1–365")
 	}
 	if settings.Todoist.Enabled && settings.Todoist.APIToken == "" && s.cfg.Todoist.APIToken == "" {
-		return fmt.Errorf("todoist API token required when enabled")
+		return validationError("todoist API token required when enabled")
 	}
 	if settings.Todoist.PollSeconds < 30 || settings.Todoist.PollSeconds > 3600 {
 		settings.Todoist.PollSeconds = 120

--- a/internal/sybra/svc_orchestrator.go
+++ b/internal/sybra/svc_orchestrator.go
@@ -36,7 +36,7 @@ func (s *OrchestratorService) StartOrchestrator() error {
 	if id := s.agentID; id != "" {
 		if a, err := s.agents.GetAgent(id); err == nil && a.GetState() != agent.StateStopped {
 			s.mu.Unlock()
-			return fmt.Errorf("orchestrator already running")
+			return conflictError("orchestrator already running")
 		}
 		s.agentID = ""
 	}
@@ -74,7 +74,7 @@ func (s *OrchestratorService) StopOrchestrator() error {
 	s.mu.Unlock()
 
 	if id == "" {
-		return fmt.Errorf("orchestrator not running")
+		return conflictError("orchestrator not running")
 	}
 	if err := s.agents.StopAgent(id); err != nil {
 		return fmt.Errorf("stop orchestrator: %w", err)

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -127,15 +127,15 @@ func (s *TaskService) UpdateTask(id string, updates map[string]any) (task.Task, 
 			string(task.StatusCancelled): true,
 		}
 		if agentBlockedStatuses[status] && s.agents.HasRunningAgentForTask(id) {
-			return cur, fmt.Errorf("cannot move to %q: stop the running agent first", status)
+			return cur, conflictError(fmt.Sprintf("cannot move to %q: stop the running agent first", status))
 		}
 
 		if status == string(task.StatusTesting) {
 			if cur.Workflow != nil &&
 				cur.Workflow.State != workflow.ExecCompleted &&
 				cur.Workflow.State != workflow.ExecFailed {
-				return cur, fmt.Errorf("cannot move to testing: task has active workflow %q (state=%s)",
-					cur.Workflow.WorkflowID, cur.Workflow.State)
+				return cur, conflictError(fmt.Sprintf("cannot move to testing: task has active workflow %q (state=%s)",
+					cur.Workflow.WorkflowID, cur.Workflow.State))
 			}
 		}
 	}


### PR DESCRIPTION
## Motivation

Generic `http.Error` plain-text 500 responses were leaking raw internal
error messages to API consumers and hiding actionable validation errors
behind opaque 500s. Both the frontend and the perf client had no
structured way to surface error details.

## Implementation information

- Added typed JSON error envelope `{"error":"…","code":"…"}` replacing
  all plain-text `http.Error` calls in `internal/httpapi/handler.go`.
- Added `internal/httpapi/errors.go` with error code constants
  (`not_found`, `bad_request`, `conflict`, `internal_error`) and
  `writeError`/`writeClientError` helpers.
- Internal errors are sanitized to a static `"internal error"` message;
  the raw `error` stays in `slog` only — no leakage to callers.
- Added `ClientError` interface in `internal/sybra/client_errors.go`
  so services can return typed errors that map to 400/409 responses.
- Updated `svc_config.go` and `svc_orchestrator.go` to return typed
  client errors for validation and state-conflict cases.
- Updated `frontend/src/lib/api-http.ts` to parse the new envelope.
- Updated `cmd/sybra-perf` to decode the envelope with fallback to raw
  body text; added `TestFormatAPIError` unit tests.

Closes https://github.com/Automaat/sailor-buddy/issues/135

> Changelog: fix(httpapi): sanitize and structure API error responses