### PR TITLE
fix(skillsync): only prune sybra- orphans

### DIFF
--- a/internal/skillsync/syncer.go
+++ b/internal/skillsync/syncer.go
@@ -280,8 +280,13 @@ func (s *Syncer) syncFS(fsys fs.FS, srcDir, dst string, prune bool) map[string]s
 }
 
 // removeOrphans deletes dst/<name>/ subdirs whose names are absent from
-// srcNames, but only when the subdir holds a SKILL.md (so we never touch
-// unrelated content the user dropped there).
+// srcNames, but only when:
+//   - the subdir name starts with "sybra-" (sybra owns that namespace), and
+//   - the subdir holds a SKILL.md (so we never touch unrelated content the
+//     user dropped there).
+//
+// Restricting to the sybra- prefix protects user-authored skills that
+// happen to live in a shared destination like ~/.claude/skills.
 func (s *Syncer) removeOrphans(dst, cleanDst string, srcNames map[string]struct{}) {
 	dstEntries, err := os.ReadDir(dst)
 	if err != nil {
@@ -289,6 +294,9 @@ func (s *Syncer) removeOrphans(dst, cleanDst string, srcNames map[string]struct{
 	}
 	for _, e := range dstEntries {
 		if !e.IsDir() {
+			continue
+		}
+		if !strings.HasPrefix(e.Name(), "sybra-") {
 			continue
 		}
 		if _, ok := srcNames[e.Name()]; ok {

--- a/internal/skillsync/syncer_test.go
+++ b/internal/skillsync/syncer_test.go
@@ -89,27 +89,38 @@ func TestSyncDirRemovesOrphans(t *testing.T) {
 	if err := os.MkdirAll(srcDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	keep := []byte("---\nname: keep\ndescription: test\n---\n\n# keep")
-	if err := os.WriteFile(filepath.Join(srcDir, "keep.md"), keep, 0o644); err != nil {
+	keep := []byte("---\nname: sybra-keep\ndescription: test\n---\n\n# sybra-keep")
+	if err := os.WriteFile(filepath.Join(srcDir, "sybra-keep.md"), keep, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	dstDir := filepath.Join(t.TempDir(), "dst-skills")
-	orphan := filepath.Join(dstDir, "orphan")
-	if err := os.MkdirAll(orphan, 0o755); err != nil {
+	sybraOrphan := filepath.Join(dstDir, "sybra-orphan")
+	if err := os.MkdirAll(sybraOrphan, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(orphan, "SKILL.md"), []byte("---\nname: orphan\n---\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(sybraOrphan, "SKILL.md"), []byte("---\nname: sybra-orphan\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	userSkill := filepath.Join(dstDir, "ship-issue")
+	if err := os.MkdirAll(userSkill, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(userSkill, "SKILL.md"), []byte("---\nname: ship-issue\n---\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	newSyncer().SyncDir(srcDir, dstDir)
 
-	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
-		t.Errorf("orphan skill dir should be removed: stat err=%v", err)
+	if _, err := os.Stat(sybraOrphan); !os.IsNotExist(err) {
+		t.Errorf("sybra- orphan skill dir should be removed: stat err=%v", err)
 	}
-	if _, err := os.Stat(filepath.Join(dstDir, "keep", "SKILL.md")); err != nil {
-		t.Errorf("keep/SKILL.md missing: %v", err)
+	if _, err := os.Stat(filepath.Join(userSkill, "SKILL.md")); err != nil {
+		t.Errorf("user skill without sybra- prefix must be preserved: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dstDir, "sybra-keep", "SKILL.md")); err != nil {
+		t.Errorf("sybra-keep/SKILL.md missing: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Motivation

`removeOrphans` previously deleted any subdir under the destination skills
dir that wasn't in the source set and happened to hold a `SKILL.md`. When
the destination is shared (e.g. `~/.claude/skills`), that wipes
user-authored skills that have nothing to do with sybra.

## Implementation information

Restrict pruning to subdirs whose name starts with `sybra-` — sybra owns
that namespace, so anything else is treated as user content and left
alone. The SKILL.md guard is kept as a second floor.

Test updated to assert both:
- a `sybra-` orphan is still removed
- a non-prefixed user skill (`ship-issue/SKILL.md`) is preserved

## Supporting documentation

n/a