### PR TITLE
fix(orchestrator): kick off brain, reap if wedged

### DIFF
--- a/cmd/fake-claude/main.go
+++ b/cmd/fake-claude/main.go
@@ -28,6 +28,9 @@
 //   - auth_error: emits auth-failure text then exits 1
 //   - malformed_pr_output: emits large malformed PR-ish text (no valid URL)
 //   - signal_kill: emits system+assistant then kills self with SIGTERM
+//   - block_silent: emits nothing and blocks on stdin until EOF. Simulates the
+//     wedged orchestrator brain — a conversational agent started with no
+//     kickoff prompt that parks in StatePaused with no session id.
 //   - hang: emits system+assistant then blocks indefinitely. Used to simulate
 //     an agent that Sybra's StopAgent has to kill mid-run.
 //
@@ -132,10 +135,7 @@ func runScenario(scenario, taskID string) bool {
 		emitAssistant("Implementing...")
 		emitResult("Implementation done. PR created")
 	case "interactive_implement":
-		emitSystem()
-		emitAssistant("Implementing interactively...")
-		emitResult("Implementation done. PR created")
-		_, _ = io.Copy(io.Discard, os.Stdin)
+		runInteractiveImplement()
 	case "evaluate":
 		emitSystem()
 		emitAssistant("Evaluating...")
@@ -149,6 +149,12 @@ func runScenario(scenario, taskID string) bool {
 		emitResult("Implementation done. Created PR https://github.com/test-org/test-repo/pull/42")
 	case "signal_kill":
 		runSignalKill()
+	case "block_silent":
+		// Emit nothing and block on stdin until EOF. Reproduces the wedged
+		// orchestrator brain: a conversational agent started with no kickoff
+		// prompt parks in StatePaused with no session id (none is ever
+		// emitted) and idles on stdin forever.
+		_, _ = io.Copy(io.Discard, os.Stdin)
 	case "hang":
 		runHang()
 	case "auth_error":
@@ -167,6 +173,16 @@ func runScenario(scenario, taskID string) bool {
 		return false
 	}
 	return true
+}
+
+// runInteractiveImplement emits a full implement result then blocks on stdin
+// until EOF, simulating a real conversational claude agent that stays alive
+// between turns and exits when the parent closes stdin.
+func runInteractiveImplement() {
+	emitSystem()
+	emitAssistant("Implementing interactively...")
+	emitResult("Implementation done. PR created")
+	_, _ = io.Copy(io.Discard, os.Stdin)
 }
 
 // runSignalKill emits a start event then kills itself with SIGTERM, simulating

--- a/internal/sybra/svc_orchestrator.go
+++ b/internal/sybra/svc_orchestrator.go
@@ -60,21 +60,23 @@ type OrchestratorService struct {
 // turn, as instructed by orchestrator/CLAUDE.md. Provider is pinned to claude
 // because /sybra-monitor is a Claude-only skill.
 func (s *OrchestratorService) StartOrchestrator() error {
+	// Hold the lock across agents.Run so two concurrent callers (the 1-minute
+	// auto-start loop and the UI Start button) cannot both pass the replaceable
+	// guard and leak an orphan brain that takes a real turn. Start is rare and
+	// off any hot path, so holding the lock over the bounded process spawn is
+	// acceptable.
 	s.mu.Lock()
-	stale := ""
+	defer s.mu.Unlock()
+
 	if id := s.agentID; id != "" {
 		if a, err := s.agents.GetAgent(id); err == nil && !orchestratorReplaceable(a) {
-			s.mu.Unlock()
 			return conflictError("orchestrator already running")
 		}
 		// Existing agent is stopped, or wedged-paused with no session — reap
-		// it so a freshly kicked-off orchestrator can replace it.
-		stale = id
+		// it so a freshly kicked-off orchestrator can replace it. StopAgent is
+		// idempotent on an already-terminal agent.
+		_ = s.agents.StopAgent(id)
 		s.agentID = ""
-	}
-	s.mu.Unlock()
-	if stale != "" {
-		_ = s.agents.StopAgent(stale)
 	}
 
 	a, err := s.agents.Run(agent.RunConfig{
@@ -88,10 +90,7 @@ func (s *OrchestratorService) StartOrchestrator() error {
 	if err != nil {
 		return fmt.Errorf("start orchestrator agent: %w", err)
 	}
-
-	s.mu.Lock()
 	s.agentID = a.ID
-	s.mu.Unlock()
 
 	s.logger.Info("orchestrator.started", "agent_id", a.ID)
 	if s.audit != nil {

--- a/internal/sybra/svc_orchestrator.go
+++ b/internal/sybra/svc_orchestrator.go
@@ -15,6 +15,34 @@ import (
 // so the frontend and tests can identify it in agent listings.
 const orchestratorAgentName = "orchestrator"
 
+// orchestratorKickoffPrompt is the first user message delivered to the
+// orchestrator brain so it actually takes a turn. The conversational runner
+// only sends an initial message when RunConfig.Prompt is non-empty; without it
+// the agent is parked in StatePaused, idle on stdin, and never bootstraps its
+// monitor loop or dispatches work (it just sits silent forever).
+const orchestratorKickoffPrompt = "Start your orchestrator session now. Follow your " +
+	"operating instructions in CLAUDE.md: first ensure your recurring monitor loop is " +
+	"scheduled via CronCreate(schedule=\"*/5 * * * *\", prompt=\"/sybra-monitor\") if it is " +
+	"not already, then run one /sybra-monitor cycle to triage and dispatch ready work."
+
+// orchestratorReplaceable reports whether an existing orchestrator agent should
+// be reaped and replaced rather than treated as "already running". A crashed
+// agent is StateStopped. A conversational agent that was started without a
+// kickoff prompt parks in StatePaused with no session id and idles on stdin
+// forever — that is the wedged-brain failure mode, so it is replaceable. A
+// paused-between-turns agent that already established a session is healthy and
+// must be left alone (otherwise the 1-minute auto-start loop would churn it).
+func orchestratorReplaceable(a *agent.Agent) bool {
+	switch a.GetState() {
+	case agent.StateStopped:
+		return true
+	case agent.StatePaused:
+		return a.GetSessionID() == ""
+	default:
+		return false
+	}
+}
+
 // OrchestratorService exposes orchestrator session operations as Wails-bound methods.
 type OrchestratorService struct {
 	agents *agent.Manager
@@ -33,20 +61,28 @@ type OrchestratorService struct {
 // because /sybra-monitor is a Claude-only skill.
 func (s *OrchestratorService) StartOrchestrator() error {
 	s.mu.Lock()
+	stale := ""
 	if id := s.agentID; id != "" {
-		if a, err := s.agents.GetAgent(id); err == nil && a.GetState() != agent.StateStopped {
+		if a, err := s.agents.GetAgent(id); err == nil && !orchestratorReplaceable(a) {
 			s.mu.Unlock()
 			return conflictError("orchestrator already running")
 		}
+		// Existing agent is stopped, or wedged-paused with no session — reap
+		// it so a freshly kicked-off orchestrator can replace it.
+		stale = id
 		s.agentID = ""
 	}
 	s.mu.Unlock()
+	if stale != "" {
+		_ = s.agents.StopAgent(stale)
+	}
 
 	a, err := s.agents.Run(agent.RunConfig{
 		Name:                   orchestratorAgentName,
 		Mode:                   "interactive",
 		Dir:                    config.HomeDir(),
 		Provider:               "claude",
+		Prompt:                 orchestratorKickoffPrompt,
 		IgnoreConcurrencyLimit: true,
 	})
 	if err != nil {
@@ -99,7 +135,10 @@ func (s *OrchestratorService) IsOrchestratorRunning() bool {
 	if err != nil {
 		return false
 	}
-	return a.GetState() != agent.StateStopped
+	// A wedged-paused or stopped orchestrator is not actually doing work, so
+	// it does not count as running — this lets maybeStartOrchestrator replace
+	// it instead of trusting a stale in-memory state forever.
+	return !orchestratorReplaceable(a)
 }
 
 // GetOrchestratorAgentID returns the current orchestrator agent id, or empty

--- a/internal/sybra/svc_orchestrator_replaceable_test.go
+++ b/internal/sybra/svc_orchestrator_replaceable_test.go
@@ -1,0 +1,34 @@
+package sybra
+
+import (
+	"testing"
+
+	"github.com/Automaat/sybra/internal/agent"
+)
+
+func TestOrchestratorReplaceable(t *testing.T) {
+	tests := []struct {
+		name      string
+		state     agent.State
+		sessionID string
+		want      bool
+	}{
+		{"stopped is replaceable", agent.StateStopped, "", true},
+		{"stopped with session is replaceable", agent.StateStopped, "sess-1", true},
+		{"paused with no session is the wedged brain", agent.StatePaused, "", true},
+		{"paused with session is healthy between turns", agent.StatePaused, "sess-1", false},
+		{"running is healthy", agent.StateRunning, "", false},
+		{"idle is healthy", agent.StateIdle, "sess-1", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &agent.Agent{}
+			a.SetState(tt.state)
+			a.SetSessionID(tt.sessionID)
+			if got := orchestratorReplaceable(a); got != tt.want {
+				t.Errorf("orchestratorReplaceable(state=%s, session=%q) = %v, want %v",
+					tt.state, tt.sessionID, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sybra/svc_orchestrator_test.go
+++ b/internal/sybra/svc_orchestrator_test.go
@@ -105,16 +105,23 @@ func TestOrchestratorService_ReplacesWedgedBrain(t *testing.T) {
 	if err != nil {
 		t.Fatalf("seed wedged agent: %v", err)
 	}
-	deadline := time.Now().Add(5 * time.Second)
+	// The seed agent reaches StatePaused asynchronously once its runner
+	// spawns the (silent) process, so poll rather than assume. The ceiling is
+	// generous for loaded CI; the loop exits as soon as the state settles.
+	var lastState agent.State
+	var lastSession string
+	deadline := time.Now().Add(30 * time.Second)
 	for {
-		a, gerr := mgr.GetAgent(wedged.ID)
-		if gerr == nil && a.GetState() == agent.StatePaused && a.GetSessionID() == "" {
-			break
+		if a, gerr := mgr.GetAgent(wedged.ID); gerr == nil {
+			lastState, lastSession = a.GetState(), a.GetSessionID()
+			if lastState == agent.StatePaused && lastSession == "" {
+				break
+			}
 		}
 		if time.Now().After(deadline) {
-			t.Fatal("wedged agent never parked in paused-no-session")
+			t.Fatalf("wedged agent never parked in paused-no-session (last state=%q session=%q)", lastState, lastSession)
 		}
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(20 * time.Millisecond)
 	}
 	svc.agentID = wedged.ID
 

--- a/internal/sybra/svc_orchestrator_test.go
+++ b/internal/sybra/svc_orchestrator_test.go
@@ -85,6 +85,37 @@ func TestOrchestratorService_StopWhenNotRunning(t *testing.T) {
 	}
 }
 
+func TestOrchestratorService_ReplacesWedgedBrain(t *testing.T) {
+	binDir := buildTestBinaries(t)
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	t.Setenv("FAKE_CLAUDE_SCENARIO", "interactive_implement")
+	t.Setenv("SYBRA_HOME", t.TempDir())
+
+	svc, mgr := newOrchSvcForTest(t)
+	t.Cleanup(func() { _ = svc.StopOrchestrator() })
+
+	// Seed a stale/wedged orchestrator: a stopped agent the service still
+	// points at. Before the fix this was handled, but a paused-no-session
+	// agent (the real wedge) was treated as "running" and never replaced;
+	// orchestratorReplaceable now covers both, and StartOrchestrator must
+	// reap the stale agent and swap in a fresh one.
+	stale, err := mgr.Run(agent.RunConfig{TaskID: "stale", Name: "stale", Mode: "interactive", Prompt: "hi", Dir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("seed stale agent: %v", err)
+	}
+	if err := mgr.StopAgent(stale.ID); err != nil {
+		t.Fatalf("stop seed agent: %v", err)
+	}
+	svc.agentID = stale.ID
+
+	if err := svc.StartOrchestrator(); err != nil {
+		t.Fatalf("StartOrchestrator over a wedged brain should succeed: %v", err)
+	}
+	if got := svc.GetOrchestratorAgentID(); got == "" || got == stale.ID {
+		t.Errorf("expected a fresh orchestrator id, got %q (stale was %q)", got, stale.ID)
+	}
+}
+
 func TestOrchestratorService_IgnoreConcurrencyLimit(t *testing.T) {
 	binDir := buildTestBinaries(t)
 	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))

--- a/internal/sybra/svc_orchestrator_test.go
+++ b/internal/sybra/svc_orchestrator_test.go
@@ -98,9 +98,13 @@ func TestOrchestratorService_ReplacesWedgedBrain(t *testing.T) {
 	// Seed the exact production wedge: a conversational agent started with no
 	// kickoff prompt parks in StatePaused, and the block_silent fake emits
 	// nothing so it never gets a session id. Before the fix this paused-no-
-	// session state was treated as "running" and never replaced.
+	// session state was treated as "running" and never replaced. Pin the
+	// scenario via ExtraEnv (appended to the subprocess env, overriding the
+	// process-global FAKE_CLAUDE_SCENARIO) so a sibling e2e test cannot race
+	// the seed's async subprocess exec and hand it a session-emitting scenario.
 	wedged, err := mgr.Run(agent.RunConfig{
 		TaskID: "wedged", Name: "wedged", Mode: "interactive", Dir: t.TempDir(),
+		ExtraEnv: []string{"FAKE_CLAUDE_SCENARIO=block_silent"},
 	})
 	if err != nil {
 		t.Fatalf("seed wedged agent: %v", err)

--- a/internal/sybra/svc_orchestrator_test.go
+++ b/internal/sybra/svc_orchestrator_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
 )
@@ -94,25 +95,36 @@ func TestOrchestratorService_ReplacesWedgedBrain(t *testing.T) {
 	svc, mgr := newOrchSvcForTest(t)
 	t.Cleanup(func() { _ = svc.StopOrchestrator() })
 
-	// Seed a stale/wedged orchestrator: a stopped agent the service still
-	// points at. Before the fix this was handled, but a paused-no-session
-	// agent (the real wedge) was treated as "running" and never replaced;
-	// orchestratorReplaceable now covers both, and StartOrchestrator must
-	// reap the stale agent and swap in a fresh one.
-	stale, err := mgr.Run(agent.RunConfig{TaskID: "stale", Name: "stale", Mode: "interactive", Prompt: "hi", Dir: t.TempDir()})
+	// Seed the exact production wedge: a conversational agent started with no
+	// kickoff prompt parks in StatePaused, and the block_silent fake emits
+	// nothing so it never gets a session id. Before the fix this paused-no-
+	// session state was treated as "running" and never replaced.
+	wedged, err := mgr.Run(agent.RunConfig{
+		TaskID: "wedged", Name: "wedged", Mode: "interactive", Dir: t.TempDir(),
+	})
 	if err != nil {
-		t.Fatalf("seed stale agent: %v", err)
+		t.Fatalf("seed wedged agent: %v", err)
 	}
-	if err := mgr.StopAgent(stale.ID); err != nil {
-		t.Fatalf("stop seed agent: %v", err)
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		a, gerr := mgr.GetAgent(wedged.ID)
+		if gerr == nil && a.GetState() == agent.StatePaused && a.GetSessionID() == "" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("wedged agent never parked in paused-no-session")
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
-	svc.agentID = stale.ID
+	svc.agentID = wedged.ID
 
+	// orchestratorReplaceable must treat paused-no-session as replaceable, so
+	// StartOrchestrator reaps the wedged brain and swaps in a fresh one.
 	if err := svc.StartOrchestrator(); err != nil {
 		t.Fatalf("StartOrchestrator over a wedged brain should succeed: %v", err)
 	}
-	if got := svc.GetOrchestratorAgentID(); got == "" || got == stale.ID {
-		t.Errorf("expected a fresh orchestrator id, got %q (stale was %q)", got, stale.ID)
+	if got := svc.GetOrchestratorAgentID(); got == "" || got == wedged.ID {
+		t.Errorf("expected a fresh orchestrator id, got %q (wedged was %q)", got, wedged.ID)
 	}
 }
 


### PR DESCRIPTION
## Motivation

The in-app conversational orchestrator brain wedged on every start (#882): launched with no kickoff prompt, the conversational runner parks it in `StatePaused` idle on stdin, so it never bootstraps its monitor loop or dispatches work. `IsOrchestratorRunning` treated `StatePaused` as "running", so the 1-minute `maybeStartOrchestrator` loop never replaced it — observed wedged for 23h with a 0-byte agent log, leaving task dispatch dependent on the independent Go automations.

## Implementation information

- `StartOrchestrator` now passes a kickoff `Prompt` so the brain takes its first turn and ensures its `/sybra-monitor` cron is scheduled.
- New `orchestratorReplaceable(agent)`: true for `StateStopped`, or `StatePaused` **with an empty session id** (the wedged-no-kickoff case). Used in `IsOrchestratorRunning` and the `StartOrchestrator` guard so `maybeStartOrchestrator` reaps and replaces a wedged brain, while a healthy paused-between-turns agent (which already holds a session id) is left alone.
- `StartOrchestrator` holds the service lock across `agents.Run` to close a concurrent-start race that could otherwise leak an orphan brain.
- Tests: unit test for the `orchestratorReplaceable` predicate; e2e test asserting the reap-and-replace path swaps in a fresh agent id.

Closes #882

> Changelog: fix(orchestrator): kick off brain, reap if wedged