### PR TITLE
fix(tasks): dispatch CLI-created tasks + grace

### DIFF
--- a/cmd/sybra-cli/monitor_test.go
+++ b/cmd/sybra-cli/monitor_test.go
@@ -1,12 +1,35 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/monitor"
 	"github.com/Automaat/sybra/internal/task"
 )
+
+// backdateCreatedAt rewrites a task file's created_at so detectUntriaged's
+// creation grace period does not exempt it — used by tests that assert
+// untriaged detection rather than the grace window itself.
+func backdateCreatedAt(t *testing.T, home, id string, age time.Duration) {
+	t.Helper()
+	p := filepath.Join(home, "tasks", id+".md")
+	tk, err := task.Parse(p)
+	if err != nil {
+		t.Fatalf("parse %s: %v", id, err)
+	}
+	tk.CreatedAt = time.Now().Add(-age).UTC()
+	data, err := task.Marshal(tk)
+	if err != nil {
+		t.Fatalf("marshal %s: %v", id, err)
+	}
+	if err := os.WriteFile(p, data, 0o600); err != nil {
+		t.Fatalf("write %s: %v", id, err)
+	}
+}
 
 func TestMonitorScanEmptyBoard(t *testing.T) {
 	setupStore(t)
@@ -26,7 +49,7 @@ func TestMonitorScanEmptyBoard(t *testing.T) {
 }
 
 func TestMonitorScanDetectsUntriagedAndOverDispatch(t *testing.T) {
-	setupStore(t)
+	dir := setupStore(t)
 
 	// Plant 4 in-progress tasks (over the default DispatchLimit of 3) plus
 	// an untriaged todo task. Tags are empty on one; a second has a full
@@ -57,8 +80,12 @@ func TestMonitorScanDetectsUntriagedAndOverDispatch(t *testing.T) {
 	createHeadless("in-progress b", task.StatusInProgress, []string{"medium"})
 	createHeadless("in-progress c", task.StatusInProgress, []string{"medium"})
 	createHeadless("in-progress d", task.StatusInProgress, []string{"medium"})
-	createHeadless("untriaged todo", task.StatusTodo, nil)
+	untriagedID := createHeadless("untriaged todo", task.StatusTodo, nil)
 	createHeadless("triaged todo", task.StatusTodo, []string{"medium"})
+
+	// detectUntriaged exempts freshly created tasks; backdate this one past
+	// the grace window so it is still flagged (this test asserts detection).
+	backdateCreatedAt(t, dir, untriagedID, 30*time.Minute)
 
 	code, out := runCLI(t, "--json", "monitor", "scan")
 	if code != 0 {

--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -120,11 +120,21 @@ func detectPerTask(in DetectInput) []Anomaly {
 	return out
 }
 
+// untriagedGracePeriod is how long a freshly created task is left alone before
+// it can be flagged as untriaged. A new task.created workflow (triage) needs a
+// moment to pick the task up and assign tags/mode; flagging immediately
+// produces spurious "untriaged" anomalies — and, for work-typed tasks, a
+// scrubbed sybra-bug — for perfectly normal new tasks.
+const untriagedGracePeriod = 15 * time.Minute
+
 func detectUntriaged(t *task.Task, now time.Time) *Anomaly {
 	if t.Status != task.StatusTodo {
 		return nil
 	}
 	if len(t.Tags) > 0 && t.AgentMode != "" {
+		return nil
+	}
+	if !t.CreatedAt.IsZero() && now.Sub(t.CreatedAt) < untriagedGracePeriod {
 		return nil
 	}
 	ev := map[string]any{

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -116,6 +116,30 @@ func TestDetect(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "untriaged not flagged within grace period",
+			in: DetectInput{
+				Now: now,
+				Tasks: []task.Task{mkTask("a", task.StatusTodo, func(t *task.Task) {
+					t.Tags = nil
+					t.CreatedAt = now
+				})},
+				Cfg: cfg,
+			},
+			want: nil,
+		},
+		{
+			name: "untriaged flagged after grace period",
+			in: DetectInput{
+				Now: now,
+				Tasks: []task.Task{mkTask("a", task.StatusTodo, func(t *task.Task) {
+					t.Tags = nil
+					t.CreatedAt = now.Add(-20 * time.Minute)
+				})},
+				Cfg: cfg,
+			},
+			want: []AnomalyKind{KindUntriaged},
+		},
+		{
 			name: "stuck_human_blocked on plan-review past budget",
 			in: DetectInput{
 				Now: now,

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -213,6 +213,12 @@ func (a *App) Startup(ctx context.Context) error {
 				} else {
 					store.InvalidatePath(path)
 				}
+				// A task file appearing outside GUI CreateTask (e.g. via
+				// sybra-cli) must still get its task.created workflow, or it
+				// sits inert in todo with nothing to dispatch it.
+				if event == events.TaskCreated {
+					a.maybeStartWorkflowForExternalTask(path)
+				}
 			}
 		}
 		a.emit(event, data)

--- a/internal/sybra/app_external_task_test.go
+++ b/internal/sybra/app_external_task_test.go
@@ -1,0 +1,62 @@
+package sybra
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/fsutil"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// TestApp_MaybeStartWorkflowForExternalTask covers the dispatch path for tasks
+// created outside the GUI (e.g. via sybra-cli, which writes the file directly).
+// The matching task.created workflow must attach for a fresh todo task, and the
+// status guard must prevent re-dispatch onto non-fresh tasks.
+func TestApp_MaybeStartWorkflowForExternalTask(t *testing.T) {
+	taskSvc, app := setupTaskService(t)
+	app.workflowEngine = taskSvc.workflowEngine
+
+	// write simulates the cross-process file write sybra-cli performs: it
+	// bypasses the in-process task.Manager (AtomicWrite straight to disk),
+	// then primes the Manager cache the way app.go's emit callback does.
+	write := func(id string, status task.Status) string {
+		tk := task.Task{
+			ID: id, Title: "ext " + id, Status: status,
+			AgentMode: task.AgentModeHeadless, CreatedAt: time.Now().UTC(),
+		}
+		data, err := task.Marshal(tk)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p := filepath.Join(app.tasksDir, id+".md")
+		if err := fsutil.AtomicWrite(p, data); err != nil {
+			t.Fatal(err)
+		}
+		app.tasks.OnExternalUpdate(p)
+		return p
+	}
+
+	// Fresh todo task → the task.created workflow (simple-task-plan) attaches.
+	todoPath := write("ext-todo", task.StatusTodo)
+	app.maybeStartWorkflowForExternalTask(todoPath)
+	app.wg.Wait()
+	if tk, _ := app.tasks.Get("ext-todo"); tk.Workflow == nil || tk.Workflow.WorkflowID != "simple-task-plan" {
+		t.Fatalf("fresh todo task: expected simple-task-plan workflow attached, got %+v", tk.Workflow)
+	}
+
+	// Done task → the status guard prevents re-dispatch (simple-task-plan's
+	// trigger has no status condition, so without the guard this would restart
+	// planning on a finished task).
+	donePath := write("ext-done", task.StatusDone)
+	app.maybeStartWorkflowForExternalTask(donePath)
+	app.wg.Wait()
+	if tk, _ := app.tasks.Get("ext-done"); tk.Workflow != nil {
+		t.Errorf("done task: expected no workflow, got %+v", tk.Workflow)
+	}
+
+	// Sidecar files share the tasks dir and also fire TaskCreated — must be a
+	// no-op (and must not panic).
+	app.maybeStartWorkflowForExternalTask(filepath.Join(app.tasksDir, "ext-todo.plan.md"))
+	app.wg.Wait()
+}

--- a/internal/sybra/app_external_task_test.go
+++ b/internal/sybra/app_external_task_test.go
@@ -7,12 +7,14 @@ import (
 
 	"github.com/Automaat/sybra/internal/fsutil"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
 )
 
 // TestApp_MaybeStartWorkflowForExternalTask covers the dispatch path for tasks
 // created outside the GUI (e.g. via sybra-cli, which writes the file directly).
-// The matching task.created workflow must attach for a fresh todo task, and the
-// status guard must prevent re-dispatch onto non-fresh tasks.
+// The matching task.created workflow must attach for a fresh todo task, the
+// status guard must prevent re-dispatch onto non-fresh tasks, and re-firing
+// onto a task that already owns an active workflow must be a no-op.
 func TestApp_MaybeStartWorkflowForExternalTask(t *testing.T) {
 	taskSvc, app := setupTaskService(t)
 	app.workflowEngine = taskSvc.workflowEngine
@@ -41,8 +43,37 @@ func TestApp_MaybeStartWorkflowForExternalTask(t *testing.T) {
 	todoPath := write("ext-todo", task.StatusTodo)
 	app.maybeStartWorkflowForExternalTask(todoPath)
 	app.wg.Wait()
-	if tk, _ := app.tasks.Get("ext-todo"); tk.Workflow == nil || tk.Workflow.WorkflowID != "simple-task-plan" {
+	tk, err := app.tasks.Get("ext-todo")
+	if err != nil {
+		t.Fatalf("get ext-todo: %v", err)
+	}
+	if tk.Workflow == nil || tk.Workflow.WorkflowID != "simple-task-plan" {
 		t.Fatalf("fresh todo task: expected simple-task-plan workflow attached, got %+v", tk.Workflow)
+	}
+
+	// Idempotency: re-firing onto a task that already owns an active workflow
+	// must not restart it. Pin a known active workflow, fire again, and assert
+	// the step is untouched (DispatchEvent rejects the active workflow and the
+	// helper swallows ErrWorkflowAlreadyActive — no double-start, no error).
+	activePath := write("ext-active", task.StatusTodo)
+	if _, err := app.tasks.UpdateMap("ext-active", map[string]any{
+		"workflow": &workflow.Execution{
+			WorkflowID:  "simple-task-plan",
+			CurrentStep: "triage",
+			State:       workflow.ExecWaiting,
+			Variables:   map[string]string{},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	app.maybeStartWorkflowForExternalTask(activePath)
+	app.wg.Wait()
+	ak, err := app.tasks.Get("ext-active")
+	if err != nil {
+		t.Fatalf("get ext-active: %v", err)
+	}
+	if ak.Workflow == nil || ak.Workflow.CurrentStep != "triage" {
+		t.Errorf("re-fire onto active workflow should be a no-op, got %+v", ak.Workflow)
 	}
 
 	// Done task → the status guard prevents re-dispatch (simple-task-plan's
@@ -51,8 +82,12 @@ func TestApp_MaybeStartWorkflowForExternalTask(t *testing.T) {
 	donePath := write("ext-done", task.StatusDone)
 	app.maybeStartWorkflowForExternalTask(donePath)
 	app.wg.Wait()
-	if tk, _ := app.tasks.Get("ext-done"); tk.Workflow != nil {
-		t.Errorf("done task: expected no workflow, got %+v", tk.Workflow)
+	dk, err := app.tasks.Get("ext-done")
+	if err != nil {
+		t.Fatalf("get ext-done: %v", err)
+	}
+	if dk.Workflow != nil {
+		t.Errorf("done task: expected no workflow, got %+v", dk.Workflow)
 	}
 
 	// Sidecar files share the tasks dir and also fire TaskCreated — must be a

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -2,8 +2,10 @@ package sybra
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
@@ -186,6 +188,49 @@ func (a *App) initStatusHook() {
 					a.logger.Error("workflow.dispatch.testing", "task_id", taskID, "err", err)
 				}
 			}
+		}
+	})
+}
+
+// maybeStartWorkflowForExternalTask starts the matching task.created workflow
+// for a task that appeared on disk outside the GUI CreateTask path — most
+// importantly via sybra-cli, the documented primary task interface. Without
+// this, CLI-created tasks never get a workflow and sit inert in todo: the
+// orchestrator can triage them but no implementation ever starts. Mirrors
+// TaskService.startCreatedWorkflow. Idempotent: DispatchEvent serializes per
+// task and rejects a task that already owns a non-terminal workflow, so the
+// watcher firing TaskCreated several times for one file is harmless.
+func (a *App) maybeStartWorkflowForExternalTask(path string) {
+	if a.workflowEngine == nil || a.tasks == nil {
+		return
+	}
+	id := strings.TrimSuffix(filepath.Base(path), ".md")
+	if id == "" {
+		return
+	}
+	a.wg.Go(func() {
+		t, err := a.tasks.Get(id)
+		if err != nil {
+			return
+		}
+		// Only fresh, pre-implementation tasks. simple-task-plan's trigger has
+		// no status condition, so without this guard a task.created dispatch
+		// could restart planning on an in-review/done task.
+		if t.Status != task.StatusNew && t.Status != task.StatusTodo {
+			return
+		}
+		if t.Workflow != nil &&
+			t.Workflow.State != "" &&
+			t.Workflow.State != workflow.ExecCompleted &&
+			t.Workflow.State != workflow.ExecFailed {
+			return
+		}
+		if a.agents.HasRunningAgentForTask(id) {
+			return
+		}
+		if _, err := a.workflowEngine.DispatchEvent(id, "task.created", nil, nil); err != nil &&
+			!errors.Is(err, workflow.ErrWorkflowAlreadyActive) {
+			a.logger.Error("workflow.external-create.failed", "task_id", id, "err", err)
 		}
 	})
 }

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -201,10 +201,17 @@ func (a *App) initStatusHook() {
 // task and rejects a task that already owns a non-terminal workflow, so the
 // watcher firing TaskCreated several times for one file is harmless.
 func (a *App) maybeStartWorkflowForExternalTask(path string) {
-	if a.workflowEngine == nil || a.tasks == nil {
+	if a.workflowEngine == nil || a.tasks == nil || a.agents == nil {
 		return
 	}
-	id := strings.TrimSuffix(filepath.Base(path), ".md")
+	base := filepath.Base(path)
+	// Sidecar files (plan/critique/review) share the tasks dir and also fire
+	// TaskCreated; they are not tasks, so skip them up front rather than
+	// spending a goroutine + Get that would fail anyway.
+	if task.IsSidecarFile(base) {
+		return
+	}
+	id := strings.TrimSuffix(base, ".md")
 	if id == "" {
 		return
 	}


### PR DESCRIPTION
## Motivation

Two related gaps surfaced while watching a `sybra-cli`-created task (#884): it sat inert in `todo` (no workflow ever dispatched), and was immediately flagged as untriaged — filing a spurious local bug.

## Implementation information

- **Dispatch:** on the file watcher's `TaskCreated` event, `maybeStartWorkflowForExternalTask` dispatches the matching `task.created` workflow for a fresh (`new`/`todo`), workflow-less task with no running agent — mirroring the GUI's `startCreatedWorkflow`. Idempotent via `DispatchEvent`'s per-task serialization. Skips sidecar files and non-fresh tasks; the status guard is load-bearing because `simple-task-plan`'s trigger has no status condition (without it, an external write to a finished task could restart planning).
- **Untriaged grace:** `detectUntriaged` skips tasks created within the last 15 min, so a brand-new task is not flagged before its triage workflow has a chance to run.
- **Tests:** dispatch (fresh todo → workflow attaches; done → skipped by the guard; sidecar → no-op); grace period (within → no anomaly; past → `KindUntriaged`).

Closes #884

> Changelog: fix(tasks): dispatch CLI-created tasks + untriaged grace