### PR TITLE
fix(monitor): mark lost agent run stopped on reset

### DIFF
--- a/internal/monitor/dispatcher_test.go
+++ b/internal/monitor/dispatcher_test.go
@@ -61,6 +61,9 @@ func (d dispatcherTasksStub) Get(id string) (task.Task, error) {
 func (d dispatcherTasksStub) Update(string, task.Update) (task.Task, error) {
 	return task.Task{}, errors.New("not implemented")
 }
+func (d dispatcherTasksStub) UpdateRun(string, string, map[string]any) error {
+	return errors.New("not implemented")
+}
 
 func newTestDispatcher(runner agentRunner, tasks taskAPI, worktreeFn func(task.Task) (string, bool)) *agentDispatcher {
 	return &agentDispatcher{

--- a/internal/monitor/remediator.go
+++ b/internal/monitor/remediator.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/Automaat/sybra/internal/task"
 )
@@ -13,6 +14,7 @@ type taskAPI interface {
 	List() ([]task.Task, error)
 	Get(id string) (task.Task, error)
 	Update(id string, u task.Update) (task.Task, error)
+	UpdateRun(taskID, agentID string, updates map[string]any) error
 }
 
 // remediator runs the in-process actions for anomalies that don't need LLM
@@ -49,6 +51,16 @@ func (r *remediator) Apply(_ context.Context, a Anomaly) (string, error) {
 func (r *remediator) resetLostAgent(a Anomaly) (string, error) {
 	if a.TaskID == "" {
 		return "", fmt.Errorf("lost_agent without task id")
+	}
+	// Best-effort: mark the last running agent run as stopped so the UI does
+	// not continue to display it as active after the task is reset.
+	if t, err := r.tasks.Get(a.TaskID); err == nil {
+		for i := range slices.Backward(t.AgentRuns) {
+			if t.AgentRuns[i].State == "running" {
+				_ = r.tasks.UpdateRun(a.TaskID, t.AgentRuns[i].AgentID, map[string]any{"state": "stopped"})
+				break
+			}
+		}
 	}
 	upd := task.Update{
 		Status:       task.Ptr(task.StatusTodo),

--- a/internal/monitor/remediator_test.go
+++ b/internal/monitor/remediator_test.go
@@ -7,6 +7,70 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 )
 
+func TestRemediator_LostAgent_MarksRunningRunStopped(t *testing.T) {
+	t.Parallel()
+	withRun := func(t *task.Task) {
+		t.AgentRuns = []task.AgentRun{
+			{AgentID: "old-agent", State: "stopped"},
+			{AgentID: "lost-agent", State: "running"},
+		}
+	}
+	ft := &fakeTasks{tasks: []task.Task{
+		mkTask("task1", task.StatusInProgress, withRun),
+	}}
+	rem := newRemediator(ft)
+	a := Anomaly{Kind: KindLostAgent, TaskID: "task1"}
+
+	label, err := rem.Apply(context.Background(), a)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if label == "" {
+		t.Fatal("expected non-empty label")
+	}
+
+	// Task must be reset to todo.
+	if len(ft.updates) != 1 {
+		t.Fatalf("want 1 task update, got %d", len(ft.updates))
+	}
+	u := ft.updates[0]
+	if u.u.Status == nil || *u.u.Status != task.StatusTodo {
+		t.Errorf("status = %v, want todo", u.u.Status)
+	}
+
+	// Running agent run must be marked stopped before the task update.
+	if len(ft.runUpdates) != 1 {
+		t.Fatalf("want 1 run update, got %d", len(ft.runUpdates))
+	}
+	ru := ft.runUpdates[0]
+	if ru.taskID != "task1" {
+		t.Errorf("runUpdate taskID = %q, want task1", ru.taskID)
+	}
+	if ru.agentID != "lost-agent" {
+		t.Errorf("runUpdate agentID = %q, want lost-agent", ru.agentID)
+	}
+	if ru.updates["state"] != "stopped" {
+		t.Errorf("runUpdate state = %v, want stopped", ru.updates["state"])
+	}
+}
+
+func TestRemediator_LostAgent_NoRunningRun_SkipsRunUpdate(t *testing.T) {
+	t.Parallel()
+	ft := &fakeTasks{tasks: []task.Task{
+		mkTask("task2", task.StatusInProgress),
+	}}
+	rem := newRemediator(ft)
+	a := Anomaly{Kind: KindLostAgent, TaskID: "task2"}
+
+	_, err := rem.Apply(context.Background(), a)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(ft.runUpdates) != 0 {
+		t.Errorf("want 0 run updates when no running agent run, got %d", len(ft.runUpdates))
+	}
+}
+
 func TestRemediator_PlanReviewStuck_SetsHumanRequired(t *testing.T) {
 	t.Parallel()
 	ft := &fakeTasks{tasks: []task.Task{

--- a/internal/monitor/service_test.go
+++ b/internal/monitor/service_test.go
@@ -13,14 +13,21 @@ import (
 )
 
 type fakeTasks struct {
-	mu      sync.Mutex
-	tasks   []task.Task
-	updates []taskUpdate
+	mu         sync.Mutex
+	tasks      []task.Task
+	updates    []taskUpdate
+	runUpdates []runUpdate
 }
 
 type taskUpdate struct {
 	id string
 	u  task.Update
+}
+
+type runUpdate struct {
+	taskID  string
+	agentID string
+	updates map[string]any
 }
 
 func (f *fakeTasks) List() ([]task.Task, error) {
@@ -59,6 +66,28 @@ func (f *fakeTasks) Update(id string, u task.Update) (task.Task, error) {
 		return f.tasks[i], nil
 	}
 	return task.Task{}, errNotFound
+}
+
+func (f *fakeTasks) UpdateRun(taskID, agentID string, updates map[string]any) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.runUpdates = append(f.runUpdates, runUpdate{taskID: taskID, agentID: agentID, updates: updates})
+	for i := range f.tasks {
+		if f.tasks[i].ID != taskID {
+			continue
+		}
+		for j := range f.tasks[i].AgentRuns {
+			if f.tasks[i].AgentRuns[j].AgentID != agentID {
+				continue
+			}
+			if v, ok := updates["state"].(string); ok {
+				f.tasks[i].AgentRuns[j].State = v
+			}
+			return nil
+		}
+		return nil
+	}
+	return errNotFound
 }
 
 type fakeAudit struct {


### PR DESCRIPTION
## Motivation

When `resetLostAgent` reset an in-progress task back to `todo`, the last
`AgentRun` record kept `state=running`. This caused the UI to show a stale
active agent indefinitely even though the task was no longer being worked on.

## Implementation information

Added `UpdateRun` to the `taskAPI` interface in the monitor package.
`resetLostAgent` now iterates the agent runs in reverse, finds the last
`state=running` entry, and calls `UpdateRun` (best-effort, error ignored) to
flip it to `stopped` before performing the task status reset.

Two new tests cover the fix:
- `TestRemediator_LostAgent_MarksRunningRunStopped` — verifies the run update
  is issued with correct task/agent IDs and `state=stopped`.
- `TestRemediator_LostAgent_NoRunningRun_SkipsRunUpdate` — verifies no run
  update is issued when there is no running agent run.

> Changelog: fix(monitor): mark lost agent run stopped on reset