### PR TITLE
fix(worktree): fetch PR head for fork-PR reviews

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -160,7 +160,10 @@ func FetchOrigin(barePath string) error {
 // lands under refs/remotes/origin/*. Checking out the returned ref therefore
 // works where refs/remotes/origin/<branch> does not.
 func FetchPRHead(barePath string, prNumber int) (string, error) {
-	localRef := fmt.Sprintf("refs/remotes/origin/pr/%d", prNumber)
+	// Store under refs/sybra/* rather than refs/remotes/origin/* so a real
+	// upstream branch named pr/<N> (which FetchOrigin maps to
+	// refs/remotes/origin/pr/<N>) cannot collide with the fetched PR head.
+	localRef := fmt.Sprintf("refs/sybra/pr/%d", prNumber)
 	refspec := fmt.Sprintf("+refs/pull/%d/head:%s", prNumber, localRef)
 	if err := executil.Run(barePath, "git", "fetch", "origin", refspec); err != nil {
 		return "", err

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -154,6 +154,20 @@ func FetchOrigin(barePath string) error {
 	return executil.Run(barePath, "git", "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*")
 }
 
+// FetchPRHead fetches a pull request's head commit into a stable local ref and
+// returns that ref. GitHub exposes every PR's head at refs/pull/<N>/head on the
+// upstream remote — including PRs opened from forks, whose head branch never
+// lands under refs/remotes/origin/*. Checking out the returned ref therefore
+// works where refs/remotes/origin/<branch> does not.
+func FetchPRHead(barePath string, prNumber int) (string, error) {
+	localRef := fmt.Sprintf("refs/remotes/origin/pr/%d", prNumber)
+	refspec := fmt.Sprintf("+refs/pull/%d/head:%s", prNumber, localRef)
+	if err := executil.Run(barePath, "git", "fetch", "origin", refspec); err != nil {
+		return "", err
+	}
+	return localRef, nil
+}
+
 // SyncLocalBranch fast-forwards refs/heads/<branch> in the bare clone to match
 // refs/remotes/origin/<branch> if the local branch is strictly behind the remote.
 // If the local branch has commits ahead of (or diverged from) origin, it is left

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -1601,8 +1601,8 @@ func TestFetchPRHead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FetchPRHead: %v", err)
 	}
-	if ref != "refs/remotes/origin/pr/42" {
-		t.Errorf("ref = %q, want refs/remotes/origin/pr/42", ref)
+	if ref != "refs/sybra/pr/42" {
+		t.Errorf("ref = %q, want refs/sybra/pr/42", ref)
 	}
 	got, err := exec.Command("git", "-C", bare, "rev-parse", ref).CombinedOutput()
 	if err != nil {

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -1552,3 +1552,70 @@ func TestPushSync_DivergenceForcePushes(t *testing.T) {
 		t.Fatalf("remote SHA after force-with-lease = %q, want %q", got, divergedSHA)
 	}
 }
+
+func TestFetchPRHead(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+
+	// Build an upstream whose PR-42 head commit is reachable ONLY via
+	// refs/pull/42/head — never as a normal branch head. This mirrors a fork
+	// PR: the head branch lives in the fork, but GitHub still publishes the
+	// head at refs/pull/<N>/head on the upstream.
+	upstream := initRepoWithCommit(t)
+	run := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", upstream}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	defBranch, err := exec.Command("git", "-C", upstream, "rev-parse", "--abbrev-ref", "HEAD").CombinedOutput()
+	if err != nil {
+		t.Fatalf("default branch: %v: %s", err, defBranch)
+	}
+	run("checkout", "-b", "fork-feature")
+	if err := os.WriteFile(filepath.Join(upstream, "feature.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "fork feature")
+	shaOut, err := exec.Command("git", "-C", upstream, "rev-parse", "HEAD").CombinedOutput()
+	if err != nil {
+		t.Fatalf("rev-parse: %v: %s", err, shaOut)
+	}
+	prSHA := strings.TrimSpace(string(shaOut))
+	run("update-ref", "refs/pull/42/head", prSHA)
+	run("checkout", strings.TrimSpace(string(defBranch)))
+	run("branch", "-D", "fork-feature")
+
+	// A plain bare clone copies heads only — not refs/pull/* — so the PR
+	// commit is absent until FetchPRHead pulls it on demand.
+	bare := filepath.Join(t.TempDir(), "clone.git")
+	if err := CloneBare(upstream, bare); err != nil {
+		t.Fatalf("CloneBare: %v", err)
+	}
+
+	ref, err := FetchPRHead(bare, 42)
+	if err != nil {
+		t.Fatalf("FetchPRHead: %v", err)
+	}
+	if ref != "refs/remotes/origin/pr/42" {
+		t.Errorf("ref = %q, want refs/remotes/origin/pr/42", ref)
+	}
+	got, err := exec.Command("git", "-C", bare, "rev-parse", ref).CombinedOutput()
+	if err != nil {
+		t.Fatalf("rev-parse %s: %v: %s", ref, err, got)
+	}
+	if strings.TrimSpace(string(got)) != prSHA {
+		t.Errorf("fetched ref at %q, want %q", strings.TrimSpace(string(got)), prSHA)
+	}
+
+	// The detached worktree that PrepareForReview creates must succeed from
+	// the fetched PR head — the original failure mode.
+	wtPath := filepath.Join(t.TempDir(), "wt")
+	if err := CreateWorktreeDetached(bare, wtPath, ref); err != nil {
+		t.Fatalf("CreateWorktreeDetached from PR head: %v", err)
+	}
+}

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -227,7 +227,13 @@ func (m *Manager) PrepareForReview(t task.Task) (string, error) {
 		return wtPath, nil
 	}
 
-	ref := "refs/remotes/origin/" + branch
+	// Check out the PR head via refs/pull/<N>/head rather than
+	// refs/remotes/origin/<branch>: a fork PR's head branch never lands under
+	// origin, so the latter fails with "invalid reference".
+	ref, err := project.FetchPRHead(proj.ClonePath, t.PRNumber)
+	if err != nil {
+		return "", fmt.Errorf("fetch pr head: %w", err)
+	}
 	if err := project.CreateWorktreeDetached(proj.ClonePath, wtPath, ref); err != nil {
 		return "", fmt.Errorf("create review worktree: %w", err)
 	}

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -217,14 +217,18 @@ func (m *Manager) PrepareForReview(t task.Task) (string, error) {
 		m.logger.Warn("review.worktree.fetch", "project", proj.ID, "err", err)
 	}
 
-	branch, err := m.prBranch(t.ProjectID, t.PRNumber)
-	if err != nil {
-		return "", fmt.Errorf("fetch pr branch: %w", err)
-	}
-
 	wtPath := m.PathFor(t)
 	if _, statErr := os.Stat(wtPath); statErr == nil {
 		return wtPath, nil
+	}
+
+	// The branch name is only a log annotation now (the checkout uses the PR
+	// head ref below), so a transient gh failure must not block worktree
+	// creation.
+	branch, err := m.prBranch(t.ProjectID, t.PRNumber)
+	if err != nil {
+		m.logger.Warn("review.worktree.pr-branch", "project", proj.ID, "pr", t.PRNumber, "err", err)
+		branch = ""
 	}
 
 	// Check out the PR head via refs/pull/<N>/head rather than


### PR DESCRIPTION
## Motivation

Inbound PR review failed to create a worktree for **fork PRs** (#889): `PrepareForReview` checked out `refs/remotes/origin/<pr-branch>`, which doesn't exist for a fork PR (its head branch lives in the fork). The worktree-add failed (non-fatal — it fell back to `~/.sybra` and the review skill re-cloned to /tmp), wasting the prep and spamming the log.

## Implementation information

- Add `project.FetchPRHead(barePath, prNumber)` — `git fetch origin +refs/pull/<N>/head:refs/remotes/origin/pr/<N>` (GitHub exposes `pull/<N>/head` for every PR, forks included) and returns the local ref.
- `PrepareForReview` checks out that ref instead of `origin/<branch>`. The `prBranch` lookup is now only a log annotation, so it moved after the existing-worktree fast path and is non-fatal.
- Unit test simulates a fork PR (head reachable only via `refs/pull/42/head`, source branch deleted), bare-clones, and asserts `FetchPRHead` materializes the ref and a detached worktree can be created from it.

Same-repo PRs are unaffected (`pull/<N>/head` exists for them too). The identical bug in `PrepareForFix` is tracked as a follow-up (it needs writable-branch + fork-push handling).

Closes #889

> Changelog: fix(worktree): fetch PR head for fork-PR reviews