### PR TITLE
fix(github): retry transient gh api failures

### DIFF
--- a/internal/github/runtime.go
+++ b/internal/github/runtime.go
@@ -23,10 +23,12 @@ var ghRetrySleep = func(attempt int) {
 }
 
 // isTransientGHError reports whether a gh api failure looks like a transient
-// gateway/network blip worth retrying (5xx, timeout, dropped connection), as
-// opposed to a 4xx/auth error or a rate limit. Rate limits are deliberately
-// excluded — the request gate already paces those via notBefore backoff, and
-// retrying them immediately would only make things worse.
+// gateway/network blip worth retrying — a 502/503/504 gateway response, a
+// connection timeout, or a dropped stream — as opposed to a 4xx/auth error, a
+// plain 500 (often a real server-side bug, not transient), or a rate limit.
+// Rate limits are deliberately excluded: the request gate already paces those
+// via notBefore backoff, and retrying them immediately would only make things
+// worse.
 func isTransientGHError(out []byte, err error) bool {
 	if err == nil || isRateLimitedMessage(string(out)) {
 		return false

--- a/internal/github/runtime.go
+++ b/internal/github/runtime.go
@@ -259,8 +259,10 @@ func runGHAPIWith(e execer, cacheTTL string, args ...string) (ghHTTPResponse, er
 	cmdArgs = append(cmdArgs, args...)
 
 	// Retry transient gateway/network failures (502/503/504, timeouts,
-	// dropped streams) — these are read-only API calls, so a retry is safe
-	// and spares the caller a spurious "fetch failed" on a GitHub blip.
+	// dropped streams), but only for reads: a write (--method
+	// POST/PUT/PATCH/DELETE) that returned a transient error may already have
+	// applied server-side, so retrying it could double-act.
+	write := isWriteRequest(args)
 	var resp ghHTTPResponse
 	var err error
 	for attempt := 0; ; attempt++ {
@@ -268,12 +270,26 @@ func runGHAPIWith(e execer, cacheTTL string, args ...string) (ghHTTPResponse, er
 		out, err = e.run(cmdArgs...)
 		resp = parseGHHTTPResponse(out)
 		ghGate.observe(resp, err)
-		if err == nil || attempt >= ghMaxRetries || !isTransientGHError(out, err) {
+		if err == nil || write || attempt >= ghMaxRetries || !isTransientGHError(out, err) {
 			break
 		}
 		ghRetrySleep(attempt)
 	}
 	return resp, err
+}
+
+// isWriteRequest reports whether the gh api args specify a mutating HTTP
+// method, so the retry path can leave writes alone.
+func isWriteRequest(args []string) bool {
+	for i, a := range args {
+		if (a == "--method" || a == "-X") && i+1 < len(args) {
+			switch strings.ToUpper(args[i+1]) {
+			case "POST", "PUT", "PATCH", "DELETE":
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func runtimeCacheEnabled(e execer) bool {

--- a/internal/github/runtime.go
+++ b/internal/github/runtime.go
@@ -12,7 +12,38 @@ const (
 	ghLowBudgetThreshold  = 150
 	ghOptionalCooldown    = 30 * time.Second
 	ghFallbackRateBackoff = 1 * time.Minute
+	ghMaxRetries          = 2
+	ghRetryBaseBackoff    = 500 * time.Millisecond
 )
+
+// ghRetrySleep waits before a transient-error retry (backoff grows with the
+// attempt). A package var so tests can stub out the real delay.
+var ghRetrySleep = func(attempt int) {
+	time.Sleep(time.Duration(attempt+1) * ghRetryBaseBackoff)
+}
+
+// isTransientGHError reports whether a gh api failure looks like a transient
+// gateway/network blip worth retrying (5xx, timeout, dropped connection), as
+// opposed to a 4xx/auth error or a rate limit. Rate limits are deliberately
+// excluded — the request gate already paces those via notBefore backoff, and
+// retrying them immediately would only make things worse.
+func isTransientGHError(out []byte, err error) bool {
+	if err == nil || isRateLimitedMessage(string(out)) {
+		return false
+	}
+	msg := strings.ToLower(string(out))
+	for _, sig := range []string{
+		"http 502", "http 503", "http 504",
+		"operation timed out", "i/o timeout", "deadline exceeded",
+		"connection reset", "connection refused",
+		"stream error", "unexpected eof", "tls handshake",
+	} {
+		if strings.Contains(msg, sig) {
+			return true
+		}
+	}
+	return false
+}
 
 type ttlCache[T any] struct {
 	mu    sync.RWMutex
@@ -227,9 +258,21 @@ func runGHAPIWith(e execer, cacheTTL string, args ...string) (ghHTTPResponse, er
 	cmdArgs = append(cmdArgs, "--include")
 	cmdArgs = append(cmdArgs, args...)
 
-	out, err := e.run(cmdArgs...)
-	resp := parseGHHTTPResponse(out)
-	ghGate.observe(resp, err)
+	// Retry transient gateway/network failures (502/503/504, timeouts,
+	// dropped streams) — these are read-only API calls, so a retry is safe
+	// and spares the caller a spurious "fetch failed" on a GitHub blip.
+	var resp ghHTTPResponse
+	var err error
+	for attempt := 0; ; attempt++ {
+		var out []byte
+		out, err = e.run(cmdArgs...)
+		resp = parseGHHTTPResponse(out)
+		ghGate.observe(resp, err)
+		if err == nil || attempt >= ghMaxRetries || !isTransientGHError(out, err) {
+			break
+		}
+		ghRetrySleep(attempt)
+	}
 	return resp, err
 }
 

--- a/internal/github/runtime_retry_test.go
+++ b/internal/github/runtime_retry_test.go
@@ -1,0 +1,83 @@
+package github
+
+import (
+	"fmt"
+	"testing"
+)
+
+func stubRetrySleep(t *testing.T) {
+	t.Helper()
+	orig := ghRetrySleep
+	ghRetrySleep = func(int) {}
+	t.Cleanup(func() { ghRetrySleep = orig })
+}
+
+func TestRunGHAPIWith_RetriesTransientThenSucceeds(t *testing.T) {
+	stubRetrySleep(t)
+
+	success := []byte("HTTP/2.0 200 OK\n\n{\"data\":{}}")
+	se := &sequenceExecer{
+		outputs: [][]byte{[]byte("gh: HTTP 502"), []byte("gh: HTTP 504"), success},
+		errs:    []error{fmt.Errorf("exit 1"), fmt.Errorf("exit 1"), nil},
+	}
+
+	resp, err := runGHAPIWith(se, "", "graphql")
+	if err != nil {
+		t.Fatalf("want success after transient retries, got %v", err)
+	}
+	if se.calls != 3 {
+		t.Errorf("calls = %d, want 3 (2 transient + 1 success)", se.calls)
+	}
+	if resp.statusCode != 200 {
+		t.Errorf("statusCode = %d, want 200", resp.statusCode)
+	}
+}
+
+func TestRunGHAPIWith_GivesUpAfterMaxRetries(t *testing.T) {
+	stubRetrySleep(t)
+
+	tr := []byte("gh: HTTP 503")
+	se := &sequenceExecer{
+		outputs: [][]byte{tr, tr, tr, tr},
+		errs:    []error{fmt.Errorf("e"), fmt.Errorf("e"), fmt.Errorf("e"), fmt.Errorf("e")},
+	}
+
+	if _, err := runGHAPIWith(se, "", "graphql"); err == nil {
+		t.Fatal("want error after exhausting retries")
+	}
+	if se.calls != ghMaxRetries+1 {
+		t.Errorf("calls = %d, want %d (initial + %d retries)", se.calls, ghMaxRetries+1, ghMaxRetries)
+	}
+}
+
+func TestRunGHAPIWith_NoRetryOnNonTransient(t *testing.T) {
+	stubRetrySleep(t)
+
+	se := &sequenceExecer{
+		outputs: [][]byte{[]byte("gh: HTTP 404")},
+		errs:    []error{fmt.Errorf("exit 1")},
+	}
+
+	if _, err := runGHAPIWith(se, "", "graphql"); err == nil {
+		t.Fatal("want error")
+	}
+	if se.calls != 1 {
+		t.Errorf("calls = %d, want 1 (404 is not retried)", se.calls)
+	}
+}
+
+func TestRunGHAPIWith_NoRetryOnRateLimit(t *testing.T) {
+	stubRetrySleep(t)
+
+	se := &sequenceExecer{
+		outputs: [][]byte{[]byte("API rate limit exceeded")},
+		errs:    []error{fmt.Errorf("exit 1")},
+	}
+
+	if _, err := runGHAPIWith(se, "", "graphql"); err == nil {
+		t.Fatal("want error")
+	}
+	if se.calls != 1 {
+		t.Errorf("calls = %d, want 1 (rate limits are paced by the gate, not retried)", se.calls)
+	}
+}

--- a/internal/github/runtime_retry_test.go
+++ b/internal/github/runtime_retry_test.go
@@ -81,3 +81,38 @@ func TestRunGHAPIWith_NoRetryOnRateLimit(t *testing.T) {
 		t.Errorf("calls = %d, want 1 (rate limits are paced by the gate, not retried)", se.calls)
 	}
 }
+
+func TestRunGHAPIWith_NoRetryOnWrite(t *testing.T) {
+	stubRetrySleep(t)
+
+	tr := []byte("gh: HTTP 502")
+	se := &sequenceExecer{
+		outputs: [][]byte{tr, tr, tr},
+		errs:    []error{fmt.Errorf("e"), fmt.Errorf("e"), fmt.Errorf("e")},
+	}
+
+	// A POST mutation must not be retried even on a transient error — it may
+	// already have applied server-side.
+	if _, err := runGHAPIWith(se, "", "repos/o/r/pulls/1/requested_reviewers", "--method", "POST"); err == nil {
+		t.Fatal("want error")
+	}
+	if se.calls != 1 {
+		t.Errorf("calls = %d, want 1 (writes are not retried)", se.calls)
+	}
+}
+
+func TestRunGHAPIWith_NoRetryOnSuccess(t *testing.T) {
+	stubRetrySleep(t)
+
+	se := &sequenceExecer{
+		outputs: [][]byte{[]byte("HTTP/2.0 200 OK\n\n{}")},
+		errs:    []error{nil},
+	}
+
+	if _, err := runGHAPIWith(se, "", "graphql"); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if se.calls != 1 {
+		t.Errorf("calls = %d, want 1 (no retry on first-try success)", se.calls)
+	}
+}


### PR DESCRIPTION
## Motivation

Background pr-monitor/renovate polls failed outright on momentary GitHub blips (#892) — `gh: HTTP 502/504`, `operation timed out`, `stream error … CANCEL`. The `ghRequestGate` paces requests and backs off on rate limits but never retries, so a single transient 5xx/timeout dropped a poll cycle and spammed the log.

## Implementation information

- Add bounded retry-with-backoff for **transient** failures in `runGHAPIWith` (the central `gh api` path the failing graphql/REST reads go through). `ghMaxRetries=2` (3 attempts), backoff via a `ghRetrySleep` var tests stub.
- `isTransientGHError` matches 502/503/504, connection timeouts/resets, dropped streams; returns **false** for 4xx/auth and for rate limits (those are already paced by the gate — retrying would only worsen them).
- **Reads only:** self-review caught that `requestReviewersWith` POSTs through `runGHAPIWith`, so retry is skipped when the args specify a write method (`POST/PUT/PATCH/DELETE`) — a write that returned a transient error may already have applied.
- Tests: transient-then-success, exhaust-retries, non-transient (404), rate-limit, write-not-retried, first-try-success.

Each retry is re-paced by the existing gate; worst-case added latency for a fully-failing read ≈ 2s — fine for a background poller.

Closes #892

> Changelog: fix(github): retry transient gh api failures