### PR TITLE
fix(reviews): scope review-task dedup by project

### DIFF
--- a/internal/sybra/app_reviews_inbound.go
+++ b/internal/sybra/app_reviews_inbound.go
@@ -182,16 +182,20 @@ func (r *ReviewHandler) maybeCreateReviewTasks(tasks []task.Task, reviewPRs []gi
 		if matches[i].PR.ReviewDecision == "APPROVED" {
 			continue
 		}
-		if r.hasReviewTask(tasks, matches[i].PR.Number) {
+		if r.hasReviewTask(tasks, matches[i].ProjectID, matches[i].PR.Number) {
 			continue
 		}
 		r.createReviewTask(matches[i].PR, matches[i].ProjectID)
 	}
 }
 
-func (r *ReviewHandler) hasReviewTask(tasks []task.Task, prNumber int) bool {
+func (r *ReviewHandler) hasReviewTask(tasks []task.Task, projectID string, prNumber int) bool {
 	for i := range tasks {
-		if tasks[i].PRNumber == prNumber && slices.Contains(tasks[i].Tags, "review") {
+		// PR numbers are per-repo, so a review task only suppresses another
+		// PR with the same number when they belong to the same project.
+		if tasks[i].ProjectID == projectID &&
+			tasks[i].PRNumber == prNumber &&
+			slices.Contains(tasks[i].Tags, "review") {
 			return true
 		}
 	}

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -456,3 +456,29 @@ func TestMonitoredPRs(t *testing.T) {
 		})
 	}
 }
+
+func TestHasReviewTask_ScopedByProject(t *testing.T) {
+	r := &ReviewHandler{}
+	existing := []task.Task{
+		{ProjectID: "org/a", PRNumber: 42, Tags: []string{"review"}},
+		{ProjectID: "org/a", PRNumber: 7, Tags: []string{"backend"}}, // not a review task
+	}
+	tests := []struct {
+		name      string
+		projectID string
+		prNumber  int
+		want      bool
+	}{
+		{"same project + number is a duplicate", "org/a", 42, true},
+		{"same number, different project is not", "org/b", 42, false},
+		{"same project, different number is not", "org/a", 99, false},
+		{"matching number without review tag is not", "org/a", 7, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := r.hasReviewTask(existing, tt.projectID, tt.prNumber); got != tt.want {
+				t.Errorf("hasReviewTask(%q, %d) = %v, want %v", tt.projectID, tt.prNumber, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

`ReviewHandler.hasReviewTask` deduped inbound review tasks by PR **number** + the `review` tag only, ignoring the project (#894). PR numbers are per-repo, so an open review task for PR #42 in project A made the dispatch loop skip PR #42 in project B — silently dropping reviews whenever PR numbers collide across the registered projects.

## Implementation information

- `hasReviewTask(tasks, projectID, prNumber)` now also requires `tasks[i].ProjectID == projectID`. Caller passes `matches[i].ProjectID` (always non-empty — `MatchReviewPRs` only emits matches for a known project).
- Existing review tasks always carry `ProjectID` (set in the same update that adds the `review` tag), so the equality is reliable.
- Table test: same project+number (dup), cross-project same number (the bug), same project different number, matching number without the review tag.

## Supporting documentation

The renovate-fix dedup (`svc_integrations.go`) was already project-scoped; this was the sole project-blind PR-number comparison.

Closes #894

> Changelog: fix(reviews): scope review-task dedup by project