### PR TITLE
feat(workflow): noplan tag skips the plan pipeline

### DIFF
--- a/cmd/fake-claude/main.go
+++ b/cmd/fake-claude/main.go
@@ -14,6 +14,7 @@
 //   - triage: runs sybra-cli to set status=todo, tags=small, emits result
 //   - triage_to_planning: runs sybra-cli to set status=planning, tags=large
 //   - triage_to_planning_nocritic: like triage_to_planning but adds nocritic tag
+//   - triage_to_planning_noplan: like triage_to_planning but adds noplan tag
 //   - triage_to_done: runs sybra-cli to set status=done
 //   - triage_to_in_review: runs sybra-cli to set status=in-review
 //   - triage_to_human_required: runs sybra-cli to set status=human-required
@@ -118,6 +119,8 @@ func runScenario(scenario, taskID string) bool {
 		runTriage(taskID, "planning", "large")
 	case "triage_to_planning_nocritic":
 		runTriage(taskID, "planning", "large,nocritic")
+	case "triage_to_planning_noplan":
+		runTriage(taskID, "planning", "large,noplan")
 	case "plan_critic_success":
 		runPlanCriticSuccess(taskID)
 	case "plan_critic_no_save":
@@ -144,9 +147,7 @@ func runScenario(scenario, taskID string) bool {
 		}
 		emitResult("Evaluation complete. Status set to in-review.")
 	case "pr_created":
-		emitSystem()
-		emitAssistant("Implementing and pushing PR...")
-		emitResult("Implementation done. Created PR https://github.com/test-org/test-repo/pull/42")
+		runPRCreated()
 	case "signal_kill":
 		runSignalKill()
 	case "block_silent":
@@ -183,6 +184,14 @@ func runInteractiveImplement() {
 	emitAssistant("Implementing interactively...")
 	emitResult("Implementation done. PR created")
 	_, _ = io.Copy(io.Discard, os.Stdin)
+}
+
+// runPRCreated emits an implement result whose text carries a PR URL, so the
+// mechanical link-PR step can extract the number via regex.
+func runPRCreated() {
+	emitSystem()
+	emitAssistant("Implementing and pushing PR...")
+	emitResult("Implementation done. Created PR https://github.com/test-org/test-repo/pull/42")
 }
 
 // runSignalKill emits a start event then kills itself with SIGTERM, simulating

--- a/cmd/fake-codex/main.go
+++ b/cmd/fake-codex/main.go
@@ -74,6 +74,10 @@ func runExec() {
 		emitAgentMessage("Triaging task...")
 		runCLI(taskID, "update", taskID, "--status", "planning", "--tags", "large,nocritic")
 		emitTurnCompleted(100, 20)
+	case "triage_to_planning_noplan":
+		emitAgentMessage("Triaging task...")
+		runCLI(taskID, "update", taskID, "--status", "planning", "--tags", "large,noplan")
+		emitTurnCompleted(100, 20)
 	case "plan_critic_success":
 		runCodexPlanCriticSuccess(taskID)
 	case "plan_critic_no_save":

--- a/cmd/fake-codex/main.go
+++ b/cmd/fake-codex/main.go
@@ -63,21 +63,13 @@ func runExec() {
 		emitAgentMessage("Working on it...")
 		os.Exit(0)
 	case "triage":
-		emitAgentMessage("Triaging task...")
-		runCLI(taskID, "update", taskID, "--status", "todo", "--tags", "small")
-		emitTurnCompleted(100, 20)
+		codexTriage(taskID, "--status", "todo", "--tags", "small")
 	case "triage_to_planning":
-		emitAgentMessage("Triaging task...")
-		runCLI(taskID, "update", taskID, "--status", "planning", "--tags", "large")
-		emitTurnCompleted(100, 20)
+		codexTriage(taskID, "--status", "planning", "--tags", "large")
 	case "triage_to_planning_nocritic":
-		emitAgentMessage("Triaging task...")
-		runCLI(taskID, "update", taskID, "--status", "planning", "--tags", "large,nocritic")
-		emitTurnCompleted(100, 20)
+		codexTriage(taskID, "--status", "planning", "--tags", "large,nocritic")
 	case "triage_to_planning_noplan":
-		emitAgentMessage("Triaging task...")
-		runCLI(taskID, "update", taskID, "--status", "planning", "--tags", "large,noplan")
-		emitTurnCompleted(100, 20)
+		codexTriage(taskID, "--status", "planning", "--tags", "large,noplan")
 	case "plan_critic_success":
 		runCodexPlanCriticSuccess(taskID)
 	case "plan_critic_no_save":
@@ -85,17 +77,11 @@ func runExec() {
 	case "code_review_success":
 		runCodexCodeReviewSuccess(taskID)
 	case "triage_to_done":
-		emitAgentMessage("Triaging task...")
-		runCLI(taskID, "update", taskID, "--status", "done")
-		emitTurnCompleted(100, 20)
+		codexTriage(taskID, "--status", "done")
 	case "triage_to_in_review":
-		emitAgentMessage("Triaging task...")
-		runCLI(taskID, "update", taskID, "--status", "in-review")
-		emitTurnCompleted(100, 20)
+		codexTriage(taskID, "--status", "in-review")
 	case "triage_to_human_required":
-		emitAgentMessage("Triaging task...")
-		runCLI(taskID, "update", taskID, "--status", "human-required")
-		emitTurnCompleted(100, 20)
+		codexTriage(taskID, "--status", "human-required")
 	case "overloaded_error":
 		emitError("Service overloaded (529)")
 		os.Exit(1)
@@ -259,6 +245,14 @@ func popScenario() string {
 		return s
 	}
 	return "success"
+}
+
+// codexTriage emits a triage turn that updates the task via sybra-cli with the
+// given fields (e.g. --status/--tags), mirroring the real codex triage step.
+func codexTriage(taskID string, updateArgs ...string) {
+	emitAgentMessage("Triaging task...")
+	runCLI(taskID, "update", append([]string{taskID}, updateArgs...)...)
+	emitTurnCompleted(100, 20)
 }
 
 func runCLI(taskID, subcmd string, args ...string) {

--- a/internal/skills/data/sybra-triage.md
+++ b/internal/skills/data/sybra-triage.md
@@ -30,7 +30,7 @@ Classify pending tasks via the Go classifier. Go owns routing rules, tag validat
    - Picks size (small|medium|large), type (bug|feature|refactor|review|chore|docs), and mode (headless|interactive)
    - Auto-matches a registered project if a github.com URL is in the title or body
    - Applies routing rules (work non-reviews → planning; medium/large features → planning; everything else → todo)
-   - Escape-hatch tags on a task override the plan pipeline: `noplan` skips planning entirely (triage → implement) for trivial/well-specified tasks; `nocritic` keeps planning but skips the plan critique
+   - The plan workflow honors two escape-hatch tags **when already present** on a task — `noplan` skips planning entirely (triage → implement), `nocritic` keeps planning but skips the plan critique. The classifier does not assign these itself (they're outside its tag vocabulary and would be stripped); set them manually or via the orchestrator on trivial/well-specified tasks.
    - Forces `interactive` mode for `work` projects unless it's a PR review
    - Writes a `triage.classified` audit event
 

--- a/internal/skills/data/sybra-triage.md
+++ b/internal/skills/data/sybra-triage.md
@@ -30,6 +30,7 @@ Classify pending tasks via the Go classifier. Go owns routing rules, tag validat
    - Picks size (small|medium|large), type (bug|feature|refactor|review|chore|docs), and mode (headless|interactive)
    - Auto-matches a registered project if a github.com URL is in the title or body
    - Applies routing rules (work non-reviews → planning; medium/large features → planning; everything else → todo)
+   - Escape-hatch tags on a task override the plan pipeline: `noplan` skips planning entirely (triage → implement) for trivial/well-specified tasks; `nocritic` keeps planning but skips the plan critique
    - Forces `interactive` mode for `work` projects unless it's a PR review
    - Writes a `triage.classified` audit event
 

--- a/internal/skills/data/sybra-triage.md
+++ b/internal/skills/data/sybra-triage.md
@@ -30,7 +30,7 @@ Classify pending tasks via the Go classifier. Go owns routing rules, tag validat
    - Picks size (small|medium|large), type (bug|feature|refactor|review|chore|docs), and mode (headless|interactive)
    - Auto-matches a registered project if a github.com URL is in the title or body
    - Applies routing rules (work non-reviews → planning; medium/large features → planning; everything else → todo)
-   - The plan workflow honors two escape-hatch tags **when already present** on a task — `noplan` skips planning entirely (triage → implement), `nocritic` keeps planning but skips the plan critique. The classifier does not assign these itself (they're outside its tag vocabulary and would be stripped); set them manually or via the orchestrator on trivial/well-specified tasks.
+   - The plan workflow honors two escape-hatch tags on a task — `noplan` skips planning entirely (triage → implement), `nocritic` keeps planning but skips the plan critique. The classifier does not assign these itself, but it **preserves** them when already set, so a human/orchestrator can tag a trivial/well-specified task before triage and the opt-out survives.
    - Forces `interactive` mode for `work` projects unless it's a PR review
    - Writes a `triage.classified` audit event
 

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -2597,6 +2597,47 @@ func TestE2E_BuiltinSimpleTask_NocriticTagSkipsCritique(t *testing.T) {
 	}
 }
 
+// TestE2E_BuiltinSimpleTask_NoplanTagSkipsPlanning verifies the noplan escape
+// hatch: a task triage tags `noplan` skips the entire plan/critique/review
+// pipeline and hands straight off to implementation, even though triage set
+// status=planning.
+func TestE2E_BuiltinSimpleTask_NoplanTagSkipsPlanning(t *testing.T) {
+	env := setupE2EMulti(t, []string{
+		"triage_to_planning_noplan", // triage: status=planning, tags=large,noplan
+	})
+	loadBuiltinWorkflow(t, env, "simple-task-plan")
+
+	created, err := env.tasks.Create("noplan fast-path", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := env.startWorkflow(created.ID, "simple-task-plan"); err != nil {
+		t.Fatal(err)
+	}
+
+	waitFor(t, 30*time.Second, "simple-task-plan completes via the noplan fast-path", func() bool {
+		tk, gErr := env.tasks.Get(created.ID)
+		return gErr == nil && tk.Workflow != nil && tk.Workflow.State == workflow.ExecCompleted
+	})
+
+	tk, err := env.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stepIDs := stepIDsFromHistory(tk.Workflow)
+	for _, banned := range []string{"plan", "critique_plan", "review_plan"} {
+		if slices.Contains(stepIDs, banned) {
+			t.Errorf("noplan task ran the %q step; expected it skipped\nhistory: %v", banned, stepIDs)
+		}
+	}
+	if !slices.Contains(stepIDs, "set_in_progress_and_end") {
+		t.Errorf("expected hand-off to implement (set_in_progress_and_end)\nhistory: %v", stepIDs)
+	}
+	if tk.Status != task.StatusInProgress {
+		t.Errorf("status = %q, want in-progress", tk.Status)
+	}
+}
+
 // TestE2E_BuiltinSimpleTask_TriageTerminalShortCircuits verifies triage can
 // terminate simple-task directly on terminal statuses without running plan or
 // implementation.

--- a/internal/triage/apply.go
+++ b/internal/triage/apply.go
@@ -2,6 +2,7 @@ package triage
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/Automaat/sybra/internal/project"
@@ -50,7 +51,16 @@ func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project
 	}
 
 	if len(v.Tags) > 0 {
-		updates["tags"] = v.Tags
+		// Preserve escape-hatch routing tags (noplan/nocritic) already on the
+		// task — the classifier vocabulary excludes them, so replacing tags
+		// wholesale would silently drop a manually-set opt-out.
+		tags := v.Tags
+		for _, hatch := range escapeHatchTags {
+			if slices.Contains(t.Tags, hatch) && !slices.Contains(tags, hatch) {
+				tags = append(tags, hatch)
+			}
+		}
+		updates["tags"] = tags
 	}
 
 	mode := RouteMode(v.Mode, v.Type, projectType)

--- a/internal/triage/apply_test.go
+++ b/internal/triage/apply_test.go
@@ -1,6 +1,7 @@
 package triage
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -53,6 +54,32 @@ func TestApplyRewritesTitleAndPreservesOriginal(t *testing.T) {
 	}
 	if len(updated.Tags) != 3 {
 		t.Errorf("tags: got %v", updated.Tags)
+	}
+}
+
+func TestApplyPreservesEscapeHatchTags(t *testing.T) {
+	mgr := newTestManager(t)
+	created, err := mgr.Create("trivial typo fix", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// A human/orchestrator set noplan on the task before triage runs.
+	created.Tags = []string{"noplan"}
+
+	// Classifier verdict does not include noplan (it's outside the vocabulary).
+	v := Verdict{
+		Title: "fix(docs): typo",
+		Tags:  []string{"docs", "small", "docs"},
+		Size:  "small",
+		Type:  "docs",
+		Mode:  "headless",
+	}
+	updated, err := Apply(mgr, created, v, nil)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !slices.Contains(updated.Tags, "noplan") {
+		t.Errorf("noplan escape-hatch tag dropped by triage; got %v", updated.Tags)
 	}
 }
 

--- a/internal/triage/model.go
+++ b/internal/triage/model.go
@@ -30,6 +30,13 @@ var (
 	// this set and the size/type sets are rejected.
 	domainTags = []string{"backend", "frontend", "infra", "docs", "ci", "auth", "db", "test"}
 
+	// escapeHatchTags are workflow-routing opt-outs, not part of the
+	// classifier's assignable vocabulary. They are accepted by NormalizeTags
+	// (so they aren't stripped) and preserved through triage (see Apply) so a
+	// human/orchestrator can set them on a task without triage dropping them.
+	// `noplan` skips the plan pipeline; `nocritic` skips the plan critique.
+	escapeHatchTags = []string{"noplan", "nocritic"}
+
 	// tagAliases normalize common abbreviations into the canonical tag.
 	tagAliases = map[string]string{
 		"be":        "backend",
@@ -83,7 +90,8 @@ func NormalizeTags(raw []string) ([]string, error) {
 func isKnownTag(t string) bool {
 	return slices.Contains(domainTags, t) ||
 		slices.Contains(validSizes, t) ||
-		slices.Contains(validTypes, t)
+		slices.Contains(validTypes, t) ||
+		slices.Contains(escapeHatchTags, t)
 }
 
 // ValidateVerdict ensures all enumerated fields are in their allowed set and

--- a/internal/triage/model_test.go
+++ b/internal/triage/model_test.go
@@ -18,6 +18,7 @@ func TestNormalizeTags(t *testing.T) {
 		{"dedupe", []string{"backend", "backend", "BE"}, []string{"backend"}, false},
 		{"whitespace+case", []string{" Backend ", "SMALL"}, []string{"backend", "small"}, false},
 		{"empty", []string{}, []string{}, false},
+		{"escape-hatch kept", []string{"backend", "noplan", "nocritic"}, []string{"backend", "noplan", "nocritic"}, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -47,6 +47,16 @@ steps:
           operator: equals
           value: done
         goto: ""
+      # noplan escape hatch: skip the plan/critique/human-review pipeline and
+      # hand straight to implementation. Checked before the planning route so
+      # it wins even if triage set status=planning. The terminal guards above
+      # still take precedence, so a noplan task triage finished is not forced
+      # into implement.
+      - when:
+          field: task.tags
+          operator: contains
+          value: noplan
+        goto: set_in_progress_and_end
       - when:
           field: task.status
           operator: equals

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -76,6 +76,72 @@ func TestBuiltinSimpleTask_MaybeCritiqueReplanSkip(t *testing.T) {
 	}
 }
 
+// TestBuiltinSimpleTask_TriageNoplanRouting locks the noplan escape hatch in
+// the triage step's transition table: a noplan tag routes straight to
+// implement (winning over a planning status), terminal statuses still win over
+// noplan, and the absence of noplan preserves the normal plan/implement split.
+func TestBuiltinSimpleTask_TriageNoplanRouting(t *testing.T) {
+	t.Parallel()
+
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var simple *Definition
+	for i := range defs {
+		if defs[i].ID == "simple-task-plan" {
+			simple = &defs[i]
+			break
+		}
+	}
+	if simple == nil {
+		t.Fatal("simple-task-plan builtin definition not found")
+	}
+	step := simple.StepByID("triage")
+	if step == nil {
+		t.Fatal("triage step not found in simple-task-plan")
+	}
+
+	cases := []struct {
+		name   string
+		fields map[string]string
+		want   string
+	}{
+		{
+			name:   "planning_without_noplan_goes_to_plan",
+			fields: map[string]string{"task.status": "planning", "task.tags": "backend,feature"},
+			want:   "plan",
+		},
+		{
+			name:   "noplan_skips_planning_even_when_status_planning",
+			fields: map[string]string{"task.status": "planning", "task.tags": "backend,noplan"},
+			want:   "set_in_progress_and_end",
+		},
+		{
+			name:   "todo_without_noplan_hands_off_to_implement",
+			fields: map[string]string{"task.status": "todo", "task.tags": "backend"},
+			want:   "set_in_progress_and_end",
+		},
+		{
+			name:   "terminal_status_wins_over_noplan",
+			fields: map[string]string{"task.status": "done", "task.tags": "backend,noplan"},
+			want:   "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveTransition(step.Next, tc.fields)
+			if err != nil {
+				t.Fatalf("ResolveTransition: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("goto = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestBuiltinTestingTask_MaybeCritiqueReplanSkip is the testing-task
 // mirror of the simple-task replan-skip guarantee above.
 func TestBuiltinTestingTask_MaybeCritiqueReplanSkip(t *testing.T) {


### PR DESCRIPTION
## Motivation

Forced planning sends every non-review work task through plan → critique → human review before implementation. For a trivial / already-well-specified task that is wasted latency and cost (even after #887 trimmed planning to one step). There's already a `nocritic` escape hatch; this adds the heavier-hitting `noplan` one.

## Implementation information

- `simple-task-plan.yaml`: the `triage` step's `next` routing gets a `task.tags contains noplan → set_in_progress_and_end` branch **before** the `status==planning → plan` branch, so a `noplan` task hands straight to implement even if triage set planning. The terminal in-review/human-required/done guards still precede it (a noplan task triage finished isn't forced into implement).
- `noplan` is set the same way `nocritic` is — manually or by the orchestrator. The classifier strips unknown tags, so it does **not** assign these; `/sybra-triage` doc reworded to say they're *honored when present*. Teaching the classifier to auto-apply `noplan` is a follow-up.
- Tests: a `ResolveTransition` unit test locking noplan-vs-planning and terminal-guard precedence; an e2e test (noplan task skips plan/critique/review, hands to implement); `triage_to_planning_noplan` scenarios in both fake providers.

Verified: unit + e2e (`-race`) pass, full `-race -tags e2e` suite green, golangci-lint 0.

Closes #896

> Changelog: feat(workflow): noplan tag skips the plan pipeline