### PR TITLE
feat(workflow): plan via the council skill

### DIFF
--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -75,14 +75,13 @@ steps:
     next:
       - goto: ""
 
-  # Single plan step: one opus agent runs /sybra-plan to produce the canonical
-  # plan sidecar. /sybra-plan does its own persona-driven planning + synthesis
-  # internally, so this one step replaces the prior THREE: two parallel plan
-  # agents (each writing a draft) plus a separate /plan-fork converge pass.
-  # That converge re-critiqued the plan (it nests /plan-critic, duplicating the
-  # codex critique_plan step below), and the two parallel planners could
-  # confabulate each other's task identity into the synthesized plan. The
-  # adversarial review is now solely the codex critique_plan step below.
+  # Single plan step: one opus agent convenes the council of experts
+  # (/council core-eng) to debate the implementation approach, then synthesizes
+  # that debate into the canonical plan sidecar. core-eng is pinned so the
+  # skill never reaches its interactive profile-selection (this runs headless).
+  # This one step replaces the prior THREE (two parallel plan agents + a
+  # /plan-fork converge that re-critiqued the plan); the adversarial review is
+  # now solely the codex critique_plan step below.
   - id: plan
     name: Plan
     type: run_agent
@@ -94,7 +93,7 @@ steps:
       needs_worktree: true
       max_retries: 1
       prompt: >-
-        Plan task {{.Task.ID}} using the /sybra-plan skill.
+        Plan task {{.Task.ID}} by convening the expert council.
 
         IDENTITY (read first, before anything else):
           - Your task ID is {{.Task.ID}}.
@@ -112,10 +111,19 @@ steps:
 
         Steps:
           1. Run: sybra-cli --json get {{.Task.ID}}
-          2. Read the codebase and produce a detailed implementation plan
-             that names files, symbols (with `path:line` references), the
-             ordered steps, and per-step verification criteria.
-          3. Write the full plan markdown to /tmp/sybra-plan-{{.Task.ID}}.md
+          2. Read the relevant source files so the plan is grounded in the
+             real code (name files and symbols you will touch).
+          3. Convene the council on the implementation approach:
+             `/council core-eng <concise task summary + the approach options
+             you are weighing, grounded in the files you read>`. The personas
+             will debate tradeoffs and surface risks from opposed engineering
+             lenses. If /council is unavailable in this environment, plan
+             directly using the same multi-lens scrutiny.
+          4. Synthesize the council's debate into a single detailed
+             implementation plan that names files, symbols (with `path:line`
+             references), the ordered steps, and per-step verification
+             criteria.
+          5. Write the full plan markdown to /tmp/sybra-plan-{{.Task.ID}}.md
 
         Do NOT call sybra-cli update — Sybra will ingest your file as the
         plan sidecar after you exit. Do NOT modify the task plan field

--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -113,12 +113,12 @@ steps:
           1. Run: sybra-cli --json get {{.Task.ID}}
           2. Read the relevant source files so the plan is grounded in the
              real code (name files and symbols you will touch).
-          3. Convene the council on the implementation approach:
-             `/council core-eng <concise task summary + the approach options
-             you are weighing, grounded in the files you read>`. The personas
-             will debate tradeoffs and surface risks from opposed engineering
-             lenses. If /council is unavailable in this environment, plan
-             directly using the same multi-lens scrutiny.
+          3. Convene the council on the implementation approach: run
+             `/council core-eng` and pass it a concise task summary plus the
+             approach options you are weighing, grounded in the files you read.
+             The personas will debate tradeoffs and surface risks from opposed
+             engineering lenses. If /council is unavailable in this
+             environment, plan directly using the same multi-lens scrutiny.
           4. Synthesize the council's debate into a single detailed
              implementation plan that names files, symbols (with `path:line`
              references), the ordered steps, and per-step verification

--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -142,8 +142,8 @@ steps:
     next:
       - goto: require_plan
 
-  # Guard: the plan agent can exit cleanly without producing a plan (e.g.
-  # /sybra-plan failed or the agent skipped the write). Mirrors
+  # Guard: the plan agent can exit cleanly without producing a plan (e.g. the
+  # council/plan flow failed or the agent skipped the write). Mirrors
   # require_plan_critique below: flips to human-required so the failure is
   # visible instead of silently advancing into critique_plan with an empty plan.
   - id: require_plan


### PR DESCRIPTION
## Motivation

We want opus planning to convene the **council of experts** (`/council`) so the implementation approach is debated through opposed engineering lenses before the plan is written, rather than via `/sybra-plan`.

## Implementation information

- `simple-task-plan.yaml` `plan` step prompt: the opus agent reads the relevant source, runs `/council core-eng` on the approach, then synthesizes the council's debate into the structured plan (files, `path:line`, ordered steps, per-step verification) written to the same `/tmp/sybra-plan-<id>.md` sidecar. `core-eng` is pinned so the skill never reaches its interactive profile-selection (verified: the only AskUserQuestion call sites are in the `auto` and `debate` paths, not `core-eng`). Spawning is bounded — 6 personas + 1 synthesis, one level deep (persona agents are leaf, read-only).
- Resilient fallback: if `/council` is unavailable, the agent plans directly with the same multi-lens scrutiny — a missing plugin can't hard-fail planning.

Prompt-only change; structure, sidecar path, and routing are unchanged, so the plan-flow e2e tests (fakes only read the sidecar path) still hold. Builtin validation + plan-flow e2e pass.

## Notes

- The `council` skill (sai plugin) must be installed wherever the plan agent runs (laptop + server container); the fallback covers absence.
- `core-eng` convenes engineering lenses only — a deliberate tradeoff to stay non-interactive; the downstream codex `critique_plan` still adds cross-provider adversarial review.

Closes #898

> Changelog: feat(workflow): plan via the council skill