### PR TITLE
fix(reviews): lower reviewSmallAdditions to 40

### DIFF
--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -21,7 +21,7 @@ const (
 )
 
 const (
-	reviewSmallAdditions = 200
+	reviewSmallAdditions = 40
 	reviewSmallFiles     = 5
 )
 

--- a/internal/sybra/app_reviews_inbound.go
+++ b/internal/sybra/app_reviews_inbound.go
@@ -41,6 +41,12 @@ func (r *ReviewHandler) createReviewTaskWithTriage(pr github.PullRequest, projec
 	go triage(t)
 }
 
+// triageReviewSmall returns true when the PR is below both size thresholds and
+// should be routed to human-required rather than dispatched to a review agent.
+func triageReviewSmall(additions, changedFiles int) bool {
+	return additions < reviewSmallAdditions && changedFiles < reviewSmallFiles
+}
+
 func (r *ReviewHandler) triageReview(t task.Task) {
 	stats, err := github.FetchPRStats(t.ProjectID, t.PRNumber)
 	if err != nil {
@@ -57,7 +63,7 @@ func (r *ReviewHandler) triageReview(t task.Task) {
 
 	r.logger.Info("review.triage", "task_id", t.ID, "additions", stats.Additions, "files", stats.ChangedFiles)
 
-	if stats.Additions < reviewSmallAdditions && stats.ChangedFiles < reviewSmallFiles {
+	if triageReviewSmall(stats.Additions, stats.ChangedFiles) {
 		reason := fmt.Sprintf("PR too small for agent review (%d additions, %d files)", stats.Additions, stats.ChangedFiles)
 		if _, err := r.tasks.Update(t.ID, task.Update{
 			Status:       task.Ptr(task.StatusHumanRequired),

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -457,6 +457,46 @@ func TestMonitoredPRs(t *testing.T) {
 	}
 }
 
+// TestTriageReviewSmall guards the reviewSmallAdditions (40) and
+// reviewSmallFiles (5) thresholds. Both conditions must hold for the PR to be
+// routed to human-required; if either meets or exceeds its limit the review
+// agent should be dispatched.
+func TestTriageReviewSmall(t *testing.T) {
+	tests := []struct {
+		name      string
+		additions int
+		files     int
+		wantSmall bool
+	}{
+		// Both strictly below threshold → too small for agent
+		{"39 additions, 4 files — below both limits", 39, 4, true},
+		{"0 additions, 0 files — zero-sized PR", 0, 0, true},
+		{"1 addition, 1 file — minimal PR", 1, 1, true},
+
+		// additions at exact threshold → no longer small (dispatch agent)
+		{"40 additions, 4 files — additions at limit", 40, 4, false},
+		// files at exact threshold → no longer small (dispatch agent)
+		{"39 additions, 5 files — files at limit", 39, 5, false},
+		// both at threshold
+		{"40 additions, 5 files — both at limit", 40, 5, false},
+		// both above threshold
+		{"200 additions, 20 files — large PR", 200, 20, false},
+		// one well above, one below
+		{"100 additions, 1 file — additions above, files below", 100, 1, false},
+		{"1 addition, 10 files — additions below, files above", 1, 10, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := triageReviewSmall(tt.additions, tt.files)
+			if got != tt.wantSmall {
+				t.Errorf("triageReviewSmall(%d, %d) = %v, want %v",
+					tt.additions, tt.files, got, tt.wantSmall)
+			}
+		})
+	}
+}
+
 func TestHasReviewTask_ScopedByProject(t *testing.T) {
 	r := &ReviewHandler{}
 	existing := []task.Task{


### PR DESCRIPTION
## Motivation

`reviewSmallAdditions` was set to 200, causing PRs with up to 199 additions to be silently routed to `human-required` instead of dispatching a review agent. This made the \"small PR\" fast-path nearly useless in practice — most real PRs exceed 40 additions but are nowhere near 200.

Lowering to 40 aligns the threshold with truly trivial PRs (typos, single-line fixes, dep bumps).

## Implementation information

- `internal/sybra/app_reviews.go`: change constant from 200 → 40
- Extract `triageReviewSmall` predicate into `internal/sybra/app_reviews_inbound.go` to make it testable
- Add table-driven unit tests covering boundary conditions at `reviewSmallAdditions=40` and `reviewSmallFiles=5`