### PR TITLE
feat(ui): mark awaits-you tasks on board tiles

### DIFF
--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -4,7 +4,7 @@
   import { agentStore } from '../stores/agents.svelte.js'
   import { reviewStore } from '../stores/reviews.svelte.js'
   import { notificationStore } from '../stores/notifications.svelte.js'
-  import { STATUS_OPTIONS } from '../lib/statuses.js'
+  import { STATUS_OPTIONS, awaitsHuman, awaitsHumanLabel } from '../lib/statuses.js'
   import { PRIORITY_OPTIONS } from '../lib/priorities.js'
 
   interface Props {
@@ -67,6 +67,9 @@
   const topPR = $derived(linkedPRs.length > 0 ? linkedPRs[0] : null)
   const isReviewTask = $derived(t.tags?.includes('review') ?? false)
 
+  // Task is waiting on the user (not an agent) — drives the red tile accent.
+  const needsYou = $derived(awaitsHuman(t.status))
+
   function priorityMeta(p: string | undefined) {
     return PRIORITY_OPTIONS.find(o => o.value === (p ?? '')) ?? PRIORITY_OPTIONS[0]
   }
@@ -85,7 +88,7 @@
 
 <div
   data-focused-task={focused ? '' : undefined}
-  class="group w-full select-none rounded-lg border bg-surface-50 p-3 text-left transition-all duration-100 active:bg-surface-100 dark:bg-surface-800 dark:active:bg-surface-700 md:hover:bg-surface-100 md:dark:hover:bg-surface-700 {focused ? 'border-primary-400 ring-2 ring-primary-400/50 dark:border-primary-500 dark:ring-primary-500/50' : 'border-surface-300 dark:border-surface-600'} {dragging ? 'opacity-40 shadow-lg' : ''}"
+  class="group w-full select-none rounded-lg border bg-surface-50 p-3 text-left transition-all duration-100 active:bg-surface-100 dark:bg-surface-800 dark:active:bg-surface-700 md:hover:bg-surface-100 md:dark:hover:bg-surface-700 {focused ? 'border-primary-400 ring-2 ring-primary-400/50 dark:border-primary-500 dark:ring-primary-500/50' : 'border-surface-300 dark:border-surface-600'} {needsYou ? 'border-l-4 border-l-error-500 dark:border-l-error-400' : ''} {needsYou && !focused ? 'ring-2 ring-error-400/40 dark:ring-error-500/40' : ''} {dragging ? 'opacity-40 shadow-lg' : ''}"
 >
   <button
     type="button"
@@ -169,9 +172,9 @@
       </span>
     {/if}
 
-    {#if t.status === 'plan-review'}
+    {#if needsYou}
       <span class="inline-flex items-center gap-1 rounded bg-error-200 px-1.5 py-0.5 font-semibold text-error-800 dark:bg-error-700 dark:text-error-200">
-        Needs Review
+        {awaitsHumanLabel(t.status)}
       </span>
     {/if}
 

--- a/frontend/src/components/TaskCard.svelte.test.ts
+++ b/frontend/src/components/TaskCard.svelte.test.ts
@@ -150,6 +150,30 @@ describe('TaskCard', () => {
     expect(screen.queryByText('Needs Review')).toBeNull()
   })
 
+  it('shows Needs You badge for human-required status', () => {
+    render(TaskCard, { props: { task: { ...mockTask, status: 'human-required' as Task['status'] }, onclick: () => {} } })
+    expect(screen.getByText('Needs You')).toBeDefined()
+  })
+
+  it('shows Blocked badge for blocked status', () => {
+    render(TaskCard, { props: { task: { ...mockTask, status: 'blocked' as Task['status'] }, onclick: () => {} } })
+    expect(screen.getByText('Blocked')).toBeDefined()
+  })
+
+  it('adds red left-border accent for awaits-human statuses', () => {
+    const { container } = render(TaskCard, {
+      props: { task: { ...mockTask, status: 'plan-review' as Task['status'] }, onclick: () => {} },
+    })
+    expect(container.querySelector('.border-l-error-500')).not.toBeNull()
+  })
+
+  it('omits the awaits-human accent for agent-driven statuses', () => {
+    const { container } = render(TaskCard, {
+      props: { task: { ...mockTask, status: 'in-review' as Task['status'] }, onclick: () => {} },
+    })
+    expect(container.querySelector('.border-l-error-500')).toBeNull()
+  })
+
   it('shows review-needed badge for review-requested PR tasks', () => {
     reviewStore.reviewRequested = [makePR()]
     render(TaskCard, {

--- a/frontend/src/lib/statuses.ts
+++ b/frontend/src/lib/statuses.ts
@@ -102,6 +102,39 @@ export const ALL_STATUSES: StatusMeta[] = [
   },
 ]
 
+/**
+ * Statuses that await the user's own action — distinct from agent-driven
+ * review states (`in-review`, `ready-review`) where an agent is working.
+ * Mirrors orchestrator/CLAUDE.md: plan-review/test-plan-review wait for the
+ * human to approve/reject; human-required/blocked need human input.
+ */
+export const AWAITS_HUMAN: ReadonlySet<TaskStatus> = new Set<TaskStatus>([
+  'human-required',
+  'plan-review',
+  'test-plan-review',
+  'blocked',
+])
+
+/** True when a task is waiting on the user (not on an agent). */
+export function awaitsHuman(status: string): boolean {
+  return AWAITS_HUMAN.has(status as TaskStatus)
+}
+
+/** Short pill label for an awaits-human task; empty when not awaiting. */
+export function awaitsHumanLabel(status: string): string {
+  switch (status) {
+    case 'plan-review':
+    case 'test-plan-review':
+      return 'Needs Review'
+    case 'blocked':
+      return 'Blocked'
+    case 'human-required':
+      return 'Needs You'
+    default:
+      return ''
+  }
+}
+
 /** O(1) lookup by status value */
 export const STATUS_MAP: Record<string, StatusMeta> = Object.fromEntries(
   ALL_STATUSES.map((s) => [s.value, s]),


### PR DESCRIPTION
## Motivation

The word "review" was overloaded on the board. Agent PR-review tasks
are titled `Review: <pr>` and sit in `in-review`, so they read like
they need the user's attention — but they are agent work. The tasks
that genuinely await the user (`human-required`, `plan-review`,
`test-plan-review`, `blocked`) were scattered across differently
colored columns with no shared signal.

> Changelog: feat(ui): mark awaits-you tasks on board tiles

## Implementation information

- New reusable `awaitsHuman(status)` predicate + `AWAITS_HUMAN` set +
  `awaitsHumanLabel()` in `lib/statuses.ts`. Mirrors the human-gated
  statuses defined in `orchestrator/CLAUDE.md`.
- `TaskCard.svelte`: a `needsYou` flag drives a red 4px left-border
  accent and a faint red ring (focus ring keeps priority), visible in
  any board column. The old `plan-review`-only "Needs Review" pill is
  generalized to a labeled pill (`Needs You` / `Needs Review` /
  `Blocked`).
- Agent-driven states (`in-review`, `ready-review`) are excluded by
  design, so `Review:` PR tasks no longer signal user action.

Alternatives considered: folding plan-review/test-plan-review into the
red Human Required column (rejected — loses the planning/testing stage
distinction); a separate inbox page (larger, deferred).

## Supporting documentation

Gates: svelte-check 0 errors, oxlint clean, 374 frontend tests pass
(4 new TaskCard cases).