### PR TITLE
fix(watchdog): skip dwell escalation for blocked tasks

### DIFF
--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -42,6 +42,9 @@ type ReviewHandler struct {
 	// re-dispatched to pr-fix when CI fails. nil = renovate disabled.
 	renovatePRsFn       func() []github.PullRequest
 	transientFetchFails int
+	// wtFailures tracks consecutive worktree-creation failures per task ID.
+	// Once a task hits wtFailureLimit, it is escalated to human-required.
+	wtFailures map[string]int
 }
 
 func newReviewHandler(
@@ -63,6 +66,7 @@ func newReviewHandler(
 		prTracker:     prTracker,
 		worktrees:     worktrees,
 		renovatePRsFn: renovatePRsFn,
+		wtFailures:    make(map[string]int),
 	}
 }
 

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -8,8 +8,11 @@ import (
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/workflow"
 )
+
+const wtFailureLimit = 5
 
 func (r *ReviewHandler) handleAutoMerge(issue github.PRIssue) {
 	t, err := r.tasks.Get(issue.TaskID)
@@ -72,20 +75,9 @@ func (r *ReviewHandler) handlePRIssue(issue github.PRIssue) {
 		return
 	}
 
-	dir := ""
-	if t.ProjectID != "" {
-		var d string
-		var wtErr error
-		if issue.Kind == github.PRIssueConflict {
-			d, wtErr = r.worktrees.PrepareForFix(t, issue.PR.Number)
-		} else {
-			d, wtErr = r.worktrees.PrepareForTask(t, nil)
-		}
-		if wtErr != nil {
-			r.logger.Error("pr-monitor.worktree", "task_id", t.ID, "err", wtErr)
-			return
-		}
-		dir = d
+	dir, ok := r.prepareWorktree(t, issue)
+	if !ok {
+		return
 	}
 
 	if r.workflowEngine == nil {
@@ -127,6 +119,46 @@ func (r *ReviewHandler) handlePRIssue(issue github.PRIssue) {
 		"task_id", t.ID, "issue", string(issue.Kind),
 		"pr", issue.PR.Number, "workflow", wfID,
 	)
+}
+
+// prepareWorktree sets up the fix worktree for the given task and PR issue.
+// Returns ("", false) on error, with circuit-breaker escalation after wtFailureLimit
+// consecutive failures. Returns ("", true) when no worktree is needed.
+func (r *ReviewHandler) prepareWorktree(t task.Task, issue github.PRIssue) (string, bool) {
+	if t.ProjectID == "" {
+		return "", true
+	}
+	var (
+		d     string
+		wtErr error
+	)
+	if issue.Kind == github.PRIssueConflict {
+		d, wtErr = r.worktrees.PrepareForFix(t, issue.PR.Number)
+	} else {
+		d, wtErr = r.worktrees.PrepareForTask(t, nil)
+	}
+	if wtErr != nil {
+		if r.wtFailures == nil {
+			r.wtFailures = make(map[string]int)
+		}
+		r.wtFailures[t.ID]++
+		if r.wtFailures[t.ID] >= wtFailureLimit {
+			delete(r.wtFailures, t.ID)
+			r.logger.Error("pr-monitor.worktree.circuit-open",
+				"task_id", t.ID, "failures", wtFailureLimit, "err", wtErr)
+			if _, uerr := r.tasks.Update(t.ID, task.Update{
+				Status:       task.Ptr(task.StatusHumanRequired),
+				StatusReason: task.Ptr(fmt.Sprintf("pr-monitor: worktree creation failed %d times", wtFailureLimit)),
+			}); uerr != nil {
+				r.logger.Error("pr-monitor.worktree.escalate", "task_id", t.ID, "err", uerr)
+			}
+			return "", false
+		}
+		r.logger.Error("pr-monitor.worktree", "task_id", t.ID, "err", wtErr)
+		return "", false
+	}
+	delete(r.wtFailures, t.ID)
+	return d, true
 }
 
 func conflictPrompt(pr github.PullRequest) string {

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/workflow"
+	"github.com/Automaat/sybra/internal/worktree"
 )
 
 // TestPRMonitorEligible exercises the scan predicate used by the PR monitor
@@ -494,6 +496,89 @@ func TestTriageReviewSmall(t *testing.T) {
 					tt.additions, tt.files, got, tt.wantSmall)
 			}
 		})
+	}
+}
+
+// TestPrepareWorktree_CircuitBreaker verifies the stateful failure counter:
+// each call that fails worktree creation increments a per-task counter, and
+// once that counter reaches wtFailureLimit the task is escalated to
+// human-required and the counter is reset.
+func TestPrepareWorktree_CircuitBreaker(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := task.NewStore(filepath.Join(tmp, "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	// Create a task with a project_id; PrepareForTask will fail immediately
+	// because "owner/repo" is not registered in the project store.
+	tk, err := tasks.Create("test task", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	projID := "owner/repo"
+	tk, err = tasks.Update(tk.ID, task.Update{ProjectID: task.Ptr(projID)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	projStore, err := project.NewStore(filepath.Join(tmp, "projects"), filepath.Join(tmp, "clones"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wt := worktree.New(worktree.Config{
+		WorktreesDir: filepath.Join(tmp, "worktrees"),
+		Projects:     projStore,
+		Tasks:        tasks,
+		Logger:       slog.New(slog.DiscardHandler),
+		LogsDir:      filepath.Join(tmp, "logs"),
+	})
+
+	r := &ReviewHandler{
+		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
+		tasks:         tasks,
+		worktrees:     wt,
+		wtFailures:    make(map[string]int),
+	}
+
+	issue := github.PRIssue{
+		Kind:   github.PRIssueCIFailure,
+		TaskID: tk.ID,
+		PR:     github.PullRequest{Number: 1, HeadRefName: "feat/x"},
+	}
+
+	// Failures 1–(wtFailureLimit-1): return ("", false) without escalating.
+	for i := range wtFailureLimit - 1 {
+		_, ok := r.prepareWorktree(tk, issue)
+		if ok {
+			t.Fatalf("call %d: want ok=false on worktree error", i+1)
+		}
+		got, err := tasks.Get(tk.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status == task.StatusHumanRequired {
+			t.Fatalf("call %d: task escalated too early (want %d failures before trip)", i+1, wtFailureLimit)
+		}
+	}
+
+	// wtFailureLimit-th failure opens the circuit and escalates the task.
+	_, ok := r.prepareWorktree(tk, issue)
+	if ok {
+		t.Fatal("circuit-open call: want ok=false")
+	}
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q after circuit break, want human-required", got.Status)
+	}
+	// Counter must be deleted so the next task start doesn't carry stale state.
+	if n := r.wtFailures[tk.ID]; n != 0 {
+		t.Fatalf("wtFailures[%s] = %d after circuit trip, want 0", tk.ID, n)
 	}
 }
 

--- a/internal/watchdog/dwell.go
+++ b/internal/watchdog/dwell.go
@@ -1,7 +1,9 @@
 package watchdog
 
 import (
+	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/Automaat/sybra/internal/task"
@@ -30,6 +32,16 @@ func dwellBudget(tags []string) time.Duration {
 	}
 }
 
+// hasBlocker reports whether the task body declares an upstream blocker via a
+// "## Blocked by" heading or an inline "Blocked by #NNN" reference. Tasks with
+// a recognised blocker are skipped by the dwell watchdog — they are
+// intentionally idle and should not be escalated until the blocker clears.
+func hasBlocker(body string) bool {
+	lower := strings.ToLower(body)
+	return strings.Contains(lower, "## blocked by") ||
+		strings.Contains(lower, "blocked by #")
+}
+
 func (w *Watchdog) checkDwell(now time.Time) {
 	tasks, err := w.tasks.List()
 	if err != nil {
@@ -44,11 +56,14 @@ func (w *Watchdog) checkDwell(now time.Time) {
 		if t.Status != task.StatusTodo && t.Status != task.StatusInProgress {
 			continue
 		}
+		if hasBlocker(t.Body) {
+			continue
+		}
 		budget := dwellBudget(t.Tags)
 		if now.Sub(t.UpdatedAt) <= budget {
 			continue
 		}
-		reason := "dwell exceeded size tag budget"
+		reason := fmt.Sprintf("dwell: exceeded %v budget", budget)
 		w.logger.Info("watchdog.dwell.escalate",
 			"task_id", t.ID, "status", string(t.Status),
 			"dwell_h", now.Sub(t.UpdatedAt).Hours(), "budget_h", budget.Hours())

--- a/internal/watchdog/dwell.go
+++ b/internal/watchdog/dwell.go
@@ -33,13 +33,20 @@ func dwellBudget(tags []string) time.Duration {
 }
 
 // hasBlocker reports whether the task body declares an upstream blocker via a
-// "## Blocked by" heading or an inline "Blocked by #NNN" reference. Tasks with
+// "## Blocked by" heading or a standalone "Blocked by #NNN" line. Tasks with
 // a recognised blocker are skipped by the dwell watchdog — they are
 // intentionally idle and should not be escalated until the blocker clears.
+//
+// Matching is line-anchored to avoid false positives from prose that contains
+// the phrase mid-sentence (e.g. "it depends on Blocked by #123").
 func hasBlocker(body string) bool {
-	lower := strings.ToLower(body)
-	return strings.Contains(lower, "## blocked by") ||
-		strings.Contains(lower, "blocked by #")
+	for line := range strings.SplitSeq(body, "\n") {
+		trimmed := strings.TrimSpace(strings.ToLower(line))
+		if strings.HasPrefix(trimmed, "## blocked by") || strings.HasPrefix(trimmed, "blocked by #") {
+			return true
+		}
+	}
+	return false
 }
 
 func (w *Watchdog) checkDwell(now time.Time) {

--- a/internal/watchdog/dwell_test.go
+++ b/internal/watchdog/dwell_test.go
@@ -1,0 +1,111 @@
+package watchdog
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func TestHasBlocker(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"empty", "", false},
+		{"no blocker", "## Description\nDo the thing.", false},
+		{"h2 blocked by", "## Blocked by\n\nhttps://github.com/org/repo/issues/42", true},
+		{"h2 blocked by lowercase", "## blocked by\n\nsome text", true},
+		{"inline blocked by issue ref", "depends on Blocked by #123", true},
+		{"partial match no hash", "## Description\nblocked by upstream change", false},
+		{"mid-body heading", "## Summary\nsome work\n\n## Blocked by\n\n#99", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasBlocker(tc.body); got != tc.want {
+				t.Fatalf("hasBlocker(%q) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckDwell_SkipsBlockedTasks(t *testing.T) {
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	mgr := task.NewManager(store, nil)
+
+	blockedTask, err := mgr.Create("blocked task", "## Blocked by\n\nhttps://github.com/org/repo/issues/1", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	// Push UpdatedAt far into the past to exceed any budget.
+	past := time.Now().UTC().Add(-24 * time.Hour)
+	blockedTask, err = mgr.Update(blockedTask.ID, task.Update{
+		Status: task.Ptr(task.StatusTodo),
+	})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+	// Manually set UpdatedAt via a second Update with a body touch to keep past time.
+	// We can't set UpdatedAt directly — use a workaround: set the task's body again so
+	// the store re-marshals. Then verify the watchdog skips it regardless.
+	_ = past // UpdatedAt is set by the store on each Update call.
+	// Use a real old task by setting updatedAt via internal store if needed.
+	// Since we cannot set UpdatedAt, we verify the skip via status after checkDwell.
+
+	w := &Watchdog{
+		tasks:  mgr,
+		logger: slog.New(slog.DiscardHandler),
+	}
+
+	// Run checkDwell with a "now" that is far ahead so any non-blocked task would fire.
+	w.checkDwell(time.Now().Add(48 * time.Hour))
+
+	got, err := mgr.Get(blockedTask.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusTodo {
+		t.Fatalf("blocked task status = %q, want todo (should be skipped by dwell)", got.Status)
+	}
+}
+
+func TestCheckDwell_EscalatesUnblockedTask(t *testing.T) {
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	mgr := task.NewManager(store, nil)
+
+	tk, err := mgr.Create("normal task", "## Description\nsome work", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = mgr.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusTodo)})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	w := &Watchdog{
+		tasks:  mgr,
+		logger: slog.New(slog.DiscardHandler),
+	}
+
+	// checkDwell with "now" 48h ahead so the default 12h budget is exceeded.
+	w.checkDwell(tk.UpdatedAt.Add(48 * time.Hour))
+
+	got, err := mgr.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want human-required", got.Status)
+	}
+	if got.StatusReason == "dwell exceeded size tag budget" {
+		t.Fatalf("status reason still has hardcoded string; want budget-specific reason")
+	}
+}

--- a/internal/watchdog/dwell_test.go
+++ b/internal/watchdog/dwell_test.go
@@ -18,7 +18,8 @@ func TestHasBlocker(t *testing.T) {
 		{"no blocker", "## Description\nDo the thing.", false},
 		{"h2 blocked by", "## Blocked by\n\nhttps://github.com/org/repo/issues/42", true},
 		{"h2 blocked by lowercase", "## blocked by\n\nsome text", true},
-		{"inline blocked by issue ref", "depends on Blocked by #123", true},
+		{"inline blocked by standalone line", "Blocked by #123\nsome other text", true},
+		{"inline blocked by prose — not a blocker", "depends on Blocked by #123", false},
 		{"partial match no hash", "## Description\nblocked by upstream change", false},
 		{"mid-body heading", "## Summary\nsome work\n\n## Blocked by\n\n#99", true},
 	}


### PR DESCRIPTION
## Motivation

Dwell escalation was firing on tasks that had explicit blockers recorded in their body (e.g. `## Blocked by` heading or `Blocked by #NNN` references). These tasks are legitimately stalled waiting on an external dependency, so triggering an inspection — and potentially stopping the agent — was incorrect.

## Implementation information

- `hasBlocker()` in `internal/watchdog/dwell.go` detects blocker markers using line-anchored regex to avoid false positives from mid-sentence mentions; uses `strings.SplitSeq` for efficiency.
- `checkDwell` skips escalation when `hasBlocker()` returns true.
- Fixed hardcoded status reason to include the actual budget value.
- `prepareWorktree()` circuit-breaks after 5 consecutive failures and escalates the task to `human-required` instead of looping forever.
- Added `dwell_test.go` cases covering blocked/unblocked detection and the prose-blocker false-positive edge case.
- Added `app_reviews_unit_test.go` covering the circuit-breaker path in `prepareWorktree`.

> Changelog: fix(watchdog): skip dwell escalation for blocked tasks