### PR TITLE
feat(ui): unify status & agent-state badges

### DIFF
--- a/frontend/src/components/AgentCard.svelte
+++ b/frontend/src/components/AgentCard.svelte
@@ -2,8 +2,8 @@
   import type { Agent } from '../../bindings/github.com/Automaat/sybra/internal/agent/models.js'
   import { agentStore } from '../stores/agents.svelte.js'
   import { taskStore } from '../stores/tasks.svelte.js'
-  import { fade } from 'svelte/transition'
   import { getAgentPhase, PHASE_CONFIG } from '$lib/agent-phases.js'
+  import AgentStateBadge from './AgentStateBadge.svelte'
   import { clock } from '$lib/clock.svelte.js'
   import { formatElapsed } from '$lib/elapsed.js'
 
@@ -71,14 +71,7 @@
         </span>
       {/if}
     </div>
-    <span class="inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-medium transition-all duration-150 {config.badgeClasses}">
-      {#if config.animate}
-        <span transition:fade={{ duration: 150 }} class="h-1.5 w-1.5 animate-pulse-subtle rounded-full {config.dotClasses}"></span>
-      {:else if phase !== 'queued' && phase !== 'done'}
-        <span transition:fade={{ duration: 150 }} class="h-1.5 w-1.5 rounded-full {config.dotClasses}"></span>
-      {/if}
-      {config.label}
-    </span>
+    <AgentStateBadge {phase} />
   </div>
 
   {#if phase === 'human-required'}

--- a/frontend/src/components/AgentStateBadge.svelte
+++ b/frontend/src/components/AgentStateBadge.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { fade } from 'svelte/transition'
   import { PHASE_CONFIG, type AgentPhase } from '$lib/agent-phases.js'
 
   interface Props {
@@ -19,9 +18,9 @@
 
 <span class="inline-flex items-center gap-1 rounded-full font-medium transition-all duration-150 {pillSize} {config.badgeClasses}">
   {#if config.animate}
-    <span transition:fade={{ duration: 150 }} class="animate-pulse-subtle rounded-full {dotSize} {config.dotClasses}"></span>
+    <span class="animate-pulse-subtle rounded-full {dotSize} {config.dotClasses}"></span>
   {:else if showDot}
-    <span transition:fade={{ duration: 150 }} class="rounded-full {dotSize} {config.dotClasses}"></span>
+    <span class="rounded-full {dotSize} {config.dotClasses}"></span>
   {/if}
   {config.label}
 </span>

--- a/frontend/src/components/AgentStateBadge.svelte
+++ b/frontend/src/components/AgentStateBadge.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { fade } from 'svelte/transition'
+  import { PHASE_CONFIG, type AgentPhase } from '$lib/agent-phases.js'
+
+  interface Props {
+    phase: AgentPhase
+    /** sm = list/card pill, md = detail header pill */
+    size?: 'sm' | 'md'
+  }
+
+  const { phase, size = 'sm' }: Props = $props()
+
+  const config = $derived(PHASE_CONFIG[phase])
+  const pillSize = $derived(size === 'md' ? 'px-3 py-1 text-sm' : 'px-2.5 py-0.5 text-xs')
+  const dotSize = $derived(size === 'md' ? 'h-2 w-2' : 'h-1.5 w-1.5')
+  // Queued and done are resting states — no leading dot, just the label.
+  const showDot = $derived(phase !== 'queued' && phase !== 'done')
+</script>
+
+<span class="inline-flex items-center gap-1 rounded-full font-medium transition-all duration-150 {pillSize} {config.badgeClasses}">
+  {#if config.animate}
+    <span transition:fade={{ duration: 150 }} class="animate-pulse-subtle rounded-full {dotSize} {config.dotClasses}"></span>
+  {:else if showDot}
+    <span transition:fade={{ duration: 150 }} class="rounded-full {dotSize} {config.dotClasses}"></span>
+  {/if}
+  {config.label}
+</span>

--- a/frontend/src/components/AgentStateBadge.svelte.test.ts
+++ b/frontend/src/components/AgentStateBadge.svelte.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/svelte'
+import AgentStateBadge from './AgentStateBadge.svelte'
+import { PHASE_CONFIG } from '$lib/agent-phases.js'
+
+describe('AgentStateBadge', () => {
+  afterEach(cleanup)
+
+  it('renders the phase label', () => {
+    render(AgentStateBadge, { props: { phase: 'running' } })
+    expect(screen.getByText('Running')).toBeDefined()
+  })
+
+  it('applies the shared phase badge classes', () => {
+    const { container } = render(AgentStateBadge, { props: { phase: 'human-required' } })
+    const pill = container.querySelector('span')
+    expect(pill?.className).toContain(PHASE_CONFIG['human-required'].badgeClasses.split(' ')[0])
+  })
+
+  it('renders a leading dot for active phases', () => {
+    const { container } = render(AgentStateBadge, { props: { phase: 'running' } })
+    expect(container.querySelectorAll('span').length).toBe(2)
+  })
+
+  it('omits the dot for resting phases (queued, done)', () => {
+    const { container } = render(AgentStateBadge, { props: { phase: 'queued' } })
+    expect(container.querySelectorAll('span').length).toBe(1)
+  })
+
+  it('uses larger sizing for the md variant', () => {
+    const { container } = render(AgentStateBadge, { props: { phase: 'reviewing', size: 'md' } })
+    expect(container.querySelector('span')?.className).toContain('text-sm')
+  })
+})

--- a/frontend/src/components/StatusBadge.svelte
+++ b/frontend/src/components/StatusBadge.svelte
@@ -7,7 +7,12 @@
 
   const { status }: Props = $props()
 
-  const resolved = $derived(STATUS_MAP[status] ?? { label: status, badgeClasses: 'bg-surface-200 text-surface-800' })
+  const resolved = $derived(
+    STATUS_MAP[status] ?? {
+      label: status,
+      badgeClasses: 'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200',
+    },
+  )
 </script>
 
 <span class="inline-block rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors duration-100 {resolved.badgeClasses}">

--- a/frontend/src/components/TaskListView.svelte
+++ b/frontend/src/components/TaskListView.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { PRIORITY_OPTIONS } from '../lib/priorities.js'
+  import StatusBadge from './StatusBadge.svelte'
 
   interface Props {
     tasks: Task[]
@@ -49,7 +50,7 @@
           </td>
           <td class="px-4 py-2 font-medium">{t.title}</td>
           <td class="px-4 py-2">
-            <span class="rounded-full px-2 py-0.5 text-xs font-semibold bg-surface-200 dark:bg-surface-700">{t.status}</span>
+            <StatusBadge status={t.status} />
           </td>
           <td class="hidden px-4 py-2 text-surface-500 md:table-cell">{t.projectId || '—'}</td>
           <td class="hidden px-4 py-2 text-surface-400 text-xs lg:table-cell">

--- a/frontend/src/components/agent-view/AgentHeader.svelte
+++ b/frontend/src/components/agent-view/AgentHeader.svelte
@@ -1,19 +1,19 @@
 <script lang="ts">
   import type { Agent } from '../../../bindings/github.com/Automaat/sybra/internal/agent/models.js'
   import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
-  import type { PhaseConfig, AgentPhase } from '$lib/agent-phases.js'
+  import type { AgentPhase } from '$lib/agent-phases.js'
+  import AgentStateBadge from '../AgentStateBadge.svelte'
 
   interface Props {
     a: Agent
     phase: AgentPhase
-    phaseConfig: PhaseConfig
     stepText?: string
     linkedTask?: Task | null
     onstop: () => void
     onviewtask: (taskId: string) => void
   }
 
-  const { a, phase, phaseConfig, stepText, linkedTask, onstop, onviewtask }: Props = $props()
+  const { a, phase, stepText, linkedTask, onstop, onviewtask }: Props = $props()
 
   const isRunning = $derived(a.state === 'running')
 
@@ -51,14 +51,7 @@
       {/if}
     </div>
     <div class="flex items-center gap-2">
-      <span class="inline-flex items-center gap-1 rounded-full px-3 py-1 text-sm font-medium {phaseConfig.badgeClasses}">
-        {#if phaseConfig.animate}
-          <span class="h-2 w-2 animate-pulse-subtle rounded-full {phaseConfig.dotClasses}"></span>
-        {:else if phase !== 'queued' && phase !== 'done'}
-          <span class="h-2 w-2 rounded-full {phaseConfig.dotClasses}"></span>
-        {/if}
-        {phaseConfig.label}
-      </span>
+      <AgentStateBadge {phase} size="md" />
       {#if isRunning}
         <button
           type="button"

--- a/frontend/src/pages/AgentDetail.svelte
+++ b/frontend/src/pages/AgentDetail.svelte
@@ -7,7 +7,7 @@
   import { taskStore } from '../stores/tasks.svelte.js'
   import { agentState, agentEscalation, agentError, agentPluginErrors } from '../lib/events.js'
   import AgentErrorBanner from '../components/AgentErrorBanner.svelte'
-  import { getAgentPhase, PHASE_CONFIG } from '$lib/agent-phases.js'
+  import { getAgentPhase } from '$lib/agent-phases.js'
   import { buildStreamTimeline, buildConvoTimeline } from '$lib/timeline.js'
   import { extractLatestPlanSteps, extractLatestPlanStepsFromConvo } from '$lib/plan-steps.js'
   import AgentHeader from '../components/agent-view/AgentHeader.svelte'
@@ -67,7 +67,6 @@
         )
       : 'done',
   )
-  const phaseConfig = $derived(PHASE_CONFIG[phase])
 
   // Timeline entries — reactive to store changes
   const streamOutputs = $derived(agentStore.outputs.get(agentId) ?? [])
@@ -299,7 +298,6 @@
       <AgentHeader
         {a}
         {phase}
-        {phaseConfig}
         stepText={agentStore.stepTexts.get(agentId)}
         {linkedTask}
         onstop={handleStop}

--- a/frontend/src/pages/Logbook.svelte
+++ b/frontend/src/pages/Logbook.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { taskStore } from '../stores/tasks.svelte.js'
-  import { STATUS_MAP } from '../lib/statuses.js'
   import { matchesQuery, matchesProject, matchesTags, matchesDateRange } from '../lib/task-filters.js'
   import { toUtcDayStart, toUtcDayEnd } from '../lib/dates.js'
   import TaskFilterPanel from '../components/TaskFilterPanel.svelte'
+  import StatusBadge from '../components/StatusBadge.svelte'
 
   interface Props {
     onviewtask: (id: string) => void
@@ -167,18 +167,13 @@
         </thead>
         <tbody>
           {#each filteredTasks as t (t.id)}
-            {@const meta = STATUS_MAP[t.status]}
             <tr
               class="cursor-pointer border-b border-surface-100 transition-colors hover:bg-surface-100 dark:border-surface-800 dark:hover:bg-surface-800"
               onclick={() => onviewtask(t.id)}
             >
               <td class="px-4 py-2 font-medium">{t.title}</td>
               <td class="px-4 py-2">
-                {#if meta}
-                  <span class="rounded-full px-2 py-0.5 text-xs font-semibold {meta.badgeClasses}">{meta.label}</span>
-                {:else}
-                  <span class="rounded-full px-2 py-0.5 text-xs font-semibold bg-surface-200 dark:bg-surface-700">{t.status}</span>
-                {/if}
+                <StatusBadge status={t.status} />
               </td>
               <td class="hidden px-4 py-2 text-surface-500 md:table-cell">{t.projectId || '—'}</td>
               <td class="hidden px-4 py-2 lg:table-cell">


### PR DESCRIPTION
## Motivation

Task status and agent state rendered inconsistently across screens (issue #904). The List and Logbook views used a gray pill with the raw lowercase status, while Board/Dashboard used semantic colored pills. Agent-state colors were re-derived ad hoc in `AgentCard` and `AgentHeader`, so distinct states could look identical.

## Implementation information

- New `AgentStateBadge.svelte` renders the agent-state pill from the shared `PHASE_CONFIG` map (single source of truth), with `sm`/`md` sizing for card vs detail-header use.
- `AgentCard` and `AgentHeader` drop their duplicated inline pill markup and use `<AgentStateBadge>`. `AgentHeader` no longer needs the `phaseConfig` prop, so the now-dead derivation/prop is removed from `AgentDetail`.
- `TaskListView` and `Logbook` now use the existing `<StatusBadge>` (driven by `STATUS_MAP`) instead of hand-rolled status pills.
- `AgentSidebarList` already pulls from `PHASE_CONFIG` (dot-only indicator) — left as-is.
- Added unit tests for `AgentStateBadge`; existing badge/agent/logbook suites still pass.

Closes #904

> Changelog: feat(ui): unify status & agent-state badges