### PR TITLE
refactor(ui): single date/time formatting utility

### DIFF
--- a/frontend/src/components/AgentCard.svelte
+++ b/frontend/src/components/AgentCard.svelte
@@ -6,6 +6,7 @@
   import AgentStateBadge from './AgentStateBadge.svelte'
   import { clock } from '$lib/clock.svelte.js'
   import { formatElapsed } from '$lib/elapsed.js'
+  import { timeAgo } from '$lib/dates.js'
 
   interface Props {
     agent: Agent
@@ -29,17 +30,6 @@
   const isActivePhase = $derived(
     phase === 'running' || phase === 'blocked' || phase === 'waiting' || phase === 'human-required',
   )
-
-  function timeAgo(date: any): string {
-    if (!date) return ''
-    const now = Date.now()
-    const then = new Date(date).getTime()
-    const diff = Math.floor((now - then) / 1000)
-    if (diff < 60) return 'just now'
-    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
-    if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
-    return `${Math.floor(diff / 86400)}d ago`
-  }
 </script>
 
 <button

--- a/frontend/src/components/IssueCard.svelte
+++ b/frontend/src/components/IssueCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { timeAgo } from '$lib/dates.js'
   import type { Issue } from '../../bindings/github.com/Automaat/sybra/internal/github/models.js'
   import { BrowserOpenURL } from '$lib/api'
 
@@ -8,16 +9,6 @@
 
   const { issue }: Props = $props()
 
-  function timeAgo(date: string): string {
-    if (!date) return ''
-    const now = Date.now()
-    const then = new Date(date).getTime()
-    const diff = Math.floor((now - then) / 1000)
-    if (diff < 60) return 'just now'
-    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
-    if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
-    return `${Math.floor(diff / 86400)}d ago`
-  }
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/frontend/src/components/PRCard.svelte
+++ b/frontend/src/components/PRCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { timeAgo } from '$lib/dates.js'
   import type { PullRequest } from '../../bindings/github.com/Automaat/sybra/internal/github/models.js'
 
   interface Props {
@@ -10,16 +11,6 @@
 
   const { pr, actionLabel, onaction, onselect }: Props = $props()
 
-  function timeAgo(date: string): string {
-    if (!date) return ''
-    const now = Date.now()
-    const then = new Date(date).getTime()
-    const diff = Math.floor((now - then) / 1000)
-    if (diff < 60) return 'just now'
-    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
-    if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
-    return `${Math.floor(diff / 86400)}d ago`
-  }
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/frontend/src/components/PRDetailView.svelte
+++ b/frontend/src/components/PRDetailView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { timeAgo } from '$lib/dates.js'
   import type { CheckRunInfo, PullRequest } from '../../bindings/github.com/Automaat/sybra/internal/github/models.js'
   import { BrowserOpenURL } from '$lib/api'
 
@@ -14,16 +15,6 @@
 
   const { pr, checkRuns, onback, onapprove, onmerge, onrerun, onfix }: Props = $props()
 
-  function timeAgo(date: string): string {
-    if (!date) return ''
-    const now = Date.now()
-    const then = new Date(date).getTime()
-    const diff = Math.floor((now - then) / 1000)
-    if (diff < 60) return 'just now'
-    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
-    if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
-    return `${Math.floor(diff / 86400)}d ago`
-  }
 
   const isEligible = $derived(
     !pr.isDraft &&

--- a/frontend/src/components/PlanFileView.svelte
+++ b/frontend/src/components/PlanFileView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { commentStore } from '../stores/comments.svelte.js'
+  import { formatDateTime } from '$lib/dates.js'
 
 
   let { taskId, planBody } = $props<{ taskId: string; planBody: string }>()
@@ -40,10 +41,6 @@
     await commentStore.remove(taskId, commentId)
   }
 
-  function formatTime(ts: any): string {
-    if (!ts) return ''
-    return new Date(ts).toLocaleString()
-  }
 </script>
 
 <div class="font-mono text-sm">
@@ -83,7 +80,7 @@
               >Delete</button>
             </div>
           </div>
-          <div class="mt-1 text-xs text-surface-400">{formatTime(comment.createdAt)}</div>
+          <div class="mt-1 text-xs text-surface-400">{formatDateTime(comment.createdAt)}</div>
         </div>
       {/each}
 

--- a/frontend/src/components/RenovatePRCard.svelte
+++ b/frontend/src/components/RenovatePRCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { timeAgo } from '$lib/dates.js'
   import type { RenovatePR } from '../../bindings/github.com/Automaat/sybra/internal/github/models.js'
   import {
     MergeRenovatePR,
@@ -16,16 +17,6 @@
   const { pr, onselect }: Props = $props()
   let busy = $state('')
 
-  function timeAgo(date: string): string {
-    if (!date) return ''
-    const now = Date.now()
-    const then = new Date(date).getTime()
-    const diff = Math.floor((now - then) / 1000)
-    if (diff < 60) return 'just now'
-    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
-    if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
-    return `${Math.floor(diff / 86400)}d ago`
-  }
 
   const isEligible = $derived(
     !pr.isDraft &&

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { timeAgo } from '$lib/dates.js'
   import { CheckCircle, XCircle, Clock, GitPullRequest, CircleDot, Copy, AlertTriangle } from '@lucide/svelte'
   import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { agentStore } from '../stores/agents.svelte.js'
@@ -74,16 +75,6 @@
     return PRIORITY_OPTIONS.find(o => o.value === (p ?? '')) ?? PRIORITY_OPTIONS[0]
   }
 
-  function timeAgo(date: any): string {
-    if (!date) return ''
-    const now = Date.now()
-    const then = new Date(date).getTime()
-    const diff = Math.floor((now - then) / 1000)
-    if (diff < 60) return 'just now'
-    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
-    if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
-    return `${Math.floor(diff / 86400)}d ago`
-  }
 </script>
 
 <div

--- a/frontend/src/components/TaskListView.svelte
+++ b/frontend/src/components/TaskListView.svelte
@@ -2,6 +2,7 @@
   import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { PRIORITY_OPTIONS } from '../lib/priorities.js'
   import StatusBadge from './StatusBadge.svelte'
+  import { formatShortDate } from '../lib/dates.js'
 
   interface Props {
     tasks: Task[]
@@ -54,7 +55,7 @@
           </td>
           <td class="hidden px-4 py-2 text-surface-500 md:table-cell">{t.projectId || '—'}</td>
           <td class="hidden px-4 py-2 text-surface-400 text-xs lg:table-cell">
-            {t.updatedAt ? new Date(t.updatedAt).toLocaleDateString() : '—'}
+            {formatShortDate(t.updatedAt)}
           </td>
         </tr>
       {/each}

--- a/frontend/src/components/TaskTimeline.svelte
+++ b/frontend/src/components/TaskTimeline.svelte
@@ -9,6 +9,7 @@
   } from '../lib/timeline-gantt.js'
   import { STATUS_MAP } from '../lib/statuses.js'
   import { PRIORITY_OPTIONS } from '../lib/priorities.js'
+  import { formatShortDate } from '../lib/dates.js'
 
   interface Props {
     tasks: Task[]
@@ -55,10 +56,6 @@
     return PRIORITY_OPTIONS.find((o) => o.value === (p ?? ''))?.classes ?? 'text-surface-400'
   }
 
-  function formatDate(d: string | undefined): string {
-    if (!d) return '—'
-    return new Date(d).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-  }
 </script>
 
 <div class="flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -146,7 +143,7 @@
               </span>
               <span class="truncate text-sm font-medium">{t.title}</span>
               <span class="ml-auto shrink-0 text-xs text-surface-400">
-                {formatDate(t.createdAt)}
+                {formatShortDate(t.createdAt)}
               </span>
             </div>
 
@@ -172,7 +169,7 @@
                 <span
                   class="pointer-events-none absolute text-warning-500 dark:text-warning-400"
                   style="left: calc({duePct}% - 5px); top: 50%; transform: translateY(-50%); font-size: 10px"
-                  title="Due {formatDate(t.dueDate)}"
+                  title="Due {formatShortDate(t.dueDate)}"
                 >◆</span>
               {/if}
             </div>

--- a/frontend/src/components/agent-view/AgentHeader.svelte
+++ b/frontend/src/components/agent-view/AgentHeader.svelte
@@ -3,6 +3,7 @@
   import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import type { AgentPhase } from '$lib/agent-phases.js'
   import AgentStateBadge from '../AgentStateBadge.svelte'
+  import { formatDateTime } from '$lib/dates.js'
 
   interface Props {
     a: Agent
@@ -16,11 +17,6 @@
   const { a, phase, stepText, linkedTask, onstop, onviewtask }: Props = $props()
 
   const isRunning = $derived(a.state === 'running')
-
-  function formatDate(date: any): string {
-    if (!date) return '-'
-    return new Date(date).toLocaleString()
-  }
 </script>
 
 <div class="flex flex-col gap-6">
@@ -131,7 +127,7 @@
     {/if}
     <div class="flex flex-col gap-1">
       <span class="font-medium text-surface-500">Started</span>
-      <span>{formatDate(a.startedAt)}</span>
+      <span>{formatDateTime(a.startedAt)}</span>
     </div>
   </div>
 </div>

--- a/frontend/src/components/task-detail/AgentHistoryList.svelte
+++ b/frontend/src/components/task-detail/AgentHistoryList.svelte
@@ -3,7 +3,7 @@
   import type { ConvoEvent, StreamEvent } from '../../../bindings/github.com/Automaat/sybra/internal/agent/models.js'
   import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { GetAgentRunLog, GetAgentRunConvoLog } from '$lib/api'
-  import { formatDate } from '../../lib/dates.js'
+  import { formatDateTime } from '../../lib/dates.js'
   import StreamOutput from '../StreamOutput.svelte'
   import MessageBubble from '../MessageBubble.svelte'
   import ProviderLogo from '../ProviderLogo.svelte'
@@ -95,7 +95,7 @@
             {#if run.costUsd > 0}
               <span>${run.costUsd.toFixed(4)}</span>
             {/if}
-            <span>{formatDate(run.startedAt)}</span>
+            <span>{formatDateTime(run.startedAt)}</span>
             <ChevronDown size={16} class="transition-transform {expandedRun === run.agentId ? 'rotate-180' : ''}" />
           </div>
         </button>

--- a/frontend/src/components/task-detail/TaskMetadataRow.svelte
+++ b/frontend/src/components/task-detail/TaskMetadataRow.svelte
@@ -4,7 +4,7 @@
   import { taskStore } from '../../stores/tasks.svelte.js'
   import { notificationStore } from '../../stores/notifications.svelte.js'
   import { BrowserOpenURL } from '$lib/api'
-  import { formatDate } from '../../lib/dates.js'
+  import { formatDateTime } from '../../lib/dates.js'
   import AssignProjectDialog from '../AssignProjectDialog.svelte'
   import TaskTagEditor from './TaskTagEditor.svelte'
   import TaskDueDateEditor from './TaskDueDateEditor.svelte'
@@ -164,8 +164,8 @@
 </div>
 
 <div class="flex flex-wrap items-center gap-4 text-xs text-surface-400">
-  <span>Created: {formatDate(task.createdAt)}</span>
-  <span>Updated: {formatDate(task.updatedAt)}</span>
+  <span>Created: {formatDateTime(task.createdAt)}</span>
+  <span>Updated: {formatDateTime(task.updatedAt)}</span>
   <div class="flex items-center gap-1">
     <span>Due:</span>
     <TaskDueDateEditor bind:this={dueDateEditor} {task} onerror={handleError} />

--- a/frontend/src/lib/dates.test.ts
+++ b/frontend/src/lib/dates.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   parseNaturalDate,
   formatDueDateDisplay,
-  formatDate,
+  formatDateTime,
+  formatShortDate,
+  timeAgo,
   toUtcDayStart,
   toUtcDayEnd,
 } from './dates.js'
@@ -87,13 +89,53 @@ describe('formatDueDateDisplay', () => {
   })
 })
 
-describe('formatDate', () => {
+describe('formatDateTime', () => {
   it('returns "-" for falsy', () => {
-    expect(formatDate(null)).toBe('-')
-    expect(formatDate(undefined)).toBe('-')
+    expect(formatDateTime(null)).toBe('-')
+    expect(formatDateTime(undefined)).toBe('-')
+  })
+  it('returns "-" for an invalid date', () => {
+    expect(formatDateTime('not-a-date')).toBe('-')
   })
   it('returns localized string for valid date', () => {
-    expect(formatDate('2026-01-01T00:00:00Z')).not.toBe('-')
+    expect(formatDateTime('2026-01-01T00:00:00Z')).not.toBe('-')
+  })
+})
+
+describe('formatShortDate', () => {
+  it('returns em dash for falsy or invalid', () => {
+    expect(formatShortDate(null)).toBe('—')
+    expect(formatShortDate('nope')).toBe('—')
+  })
+  it('omits the year for the current year', () => {
+    const thisYear = new Date().getFullYear()
+    const out = formatShortDate(`${thisYear}-06-23T12:00:00`)
+    expect(out).not.toMatch(/\d{4}/)
+  })
+  it('includes the year for other years', () => {
+    expect(formatShortDate('2020-06-23T12:00:00')).toMatch(/2020/)
+  })
+})
+
+describe('timeAgo', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-01T12:00:00Z'))
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+  it('returns empty string for falsy or invalid', () => {
+    expect(timeAgo(null)).toBe('')
+    expect(timeAgo('nope')).toBe('')
+  })
+  it('returns "just now" under a minute', () => {
+    expect(timeAgo('2026-04-01T11:59:30Z')).toBe('just now')
+  })
+  it('returns minutes, hours, and days', () => {
+    expect(timeAgo('2026-04-01T11:55:00Z')).toBe('5m ago')
+    expect(timeAgo('2026-04-01T09:00:00Z')).toBe('3h ago')
+    expect(timeAgo('2026-03-30T12:00:00Z')).toBe('2d ago')
   })
 })
 

--- a/frontend/src/lib/dates.test.ts
+++ b/frontend/src/lib/dates.test.ts
@@ -107,13 +107,16 @@ describe('formatShortDate', () => {
     expect(formatShortDate(null)).toBe('—')
     expect(formatShortDate('nope')).toBe('—')
   })
+  // Derive the locale's own year token so assertions hold regardless of locale/numerals.
+  const yearToken = (d: Date) => new Intl.DateTimeFormat(undefined, { year: 'numeric' }).format(d)
   it('omits the year for the current year', () => {
-    const thisYear = new Date().getFullYear()
-    const out = formatShortDate(`${thisYear}-06-23T12:00:00`)
-    expect(out).not.toMatch(/\d{4}/)
+    const now = new Date()
+    const out = formatShortDate(new Date(now.getFullYear(), 5, 23, 12))
+    expect(out).not.toContain(yearToken(now))
   })
   it('includes the year for other years', () => {
-    expect(formatShortDate('2020-06-23T12:00:00')).toMatch(/2020/)
+    const other = new Date(2020, 5, 23, 12)
+    expect(formatShortDate(other)).toContain(yearToken(other))
   })
 })
 

--- a/frontend/src/lib/dates.ts
+++ b/frontend/src/lib/dates.ts
@@ -67,9 +67,35 @@ export function formatDueDateDisplay(date: unknown): string {
   })
 }
 
-export function formatDate(date: unknown): string {
+/** Absolute date + time in the user's locale (e.g. "4/2/2026, 10:00:00 AM"). */
+export function formatDateTime(date: unknown): string {
   if (!date) return '-'
-  return new Date(date as string | number | Date).toLocaleString()
+  const d = new Date(date as string | number | Date)
+  return isNaN(d.getTime()) ? '-' : d.toLocaleString()
+}
+
+/** Compact date: "Jun 23" in the current year, "Jun 23, 2025" otherwise. */
+export function formatShortDate(date: unknown): string {
+  if (!date) return '—'
+  const d = new Date(date as string | number | Date)
+  if (isNaN(d.getTime())) return '—'
+  return d.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: d.getFullYear() !== new Date().getFullYear() ? 'numeric' : undefined,
+  })
+}
+
+/** Relative "time ago": empty string when absent, else just now / Nm / Nh / Nd ago. */
+export function timeAgo(date: unknown): string {
+  if (!date) return ''
+  const then = new Date(date as string | number | Date).getTime()
+  if (isNaN(then)) return ''
+  const diff = Math.floor((Date.now() - then) / 1000)
+  if (diff < 60) return 'just now'
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  return `${Math.floor(diff / 86400)}d ago`
 }
 
 // UTC-anchored day boundaries for date-range filtering. Used by Logbook.

--- a/frontend/src/pages/ChatList.svelte
+++ b/frontend/src/pages/ChatList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { timeAgo } from '$lib/dates.js'
   import type { Agent } from '../../bindings/github.com/Automaat/sybra/internal/agent/models.js'
   import { agentStore } from '../stores/agents.svelte.js'
   import { projectStore } from '../stores/projects.svelte.js'
@@ -32,16 +33,6 @@
     return PHASE_CONFIG[getAgentPhase(a.state, a.escalationReason, undefined, a.awaitingApproval)]
   }
 
-  function timeAgo(date: string | undefined): string {
-    if (!date) return ''
-    const ms = Date.now() - new Date(date).getTime()
-    const mins = Math.floor(ms / 60000)
-    if (mins < 1) return 'just now'
-    if (mins < 60) return `${mins}m ago`
-    const hrs = Math.floor(mins / 60)
-    if (hrs < 24) return `${hrs}h ago`
-    return `${Math.floor(hrs / 24)}d ago`
-  }
 </script>
 
 <div class="flex flex-col gap-3 p-4 md:gap-4 md:p-6">

--- a/frontend/src/pages/Logbook.svelte
+++ b/frontend/src/pages/Logbook.svelte
@@ -2,7 +2,7 @@
   import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { taskStore } from '../stores/tasks.svelte.js'
   import { matchesQuery, matchesProject, matchesTags, matchesDateRange } from '../lib/task-filters.js'
-  import { toUtcDayStart, toUtcDayEnd } from '../lib/dates.js'
+  import { toUtcDayStart, toUtcDayEnd, formatShortDate } from '../lib/dates.js'
   import TaskFilterPanel from '../components/TaskFilterPanel.svelte'
   import StatusBadge from '../components/StatusBadge.svelte'
 
@@ -75,12 +75,6 @@
     dateTo = ''
   }
 
-  function formatClosed(val: unknown): string {
-    if (!val) return '—'
-    const d = new Date(val as string | number | Date)
-    if (isNaN(d.getTime())) return '—'
-    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
-  }
 </script>
 
 <div class="flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -183,7 +177,7 @@
                   {/each}
                 </div>
               </td>
-              <td class="px-4 py-2 text-xs text-surface-400">{formatClosed(t.closedAt)}</td>
+              <td class="px-4 py-2 text-xs text-surface-400">{formatShortDate(t.closedAt)}</td>
             </tr>
           {/each}
         </tbody>

--- a/frontend/src/pages/Loops.svelte
+++ b/frontend/src/pages/Loops.svelte
@@ -4,6 +4,7 @@
   import { LoopAgent } from '../../bindings/github.com/Automaat/sybra/internal/loopagent/models.js'
   import { EventsOn } from '$lib/api'
   import { LoopAgentUpdated } from '../lib/events.js'
+  import { timeAgo } from '$lib/dates.js'
 
   let showForm = $state(false)
   let editing = $state<LoopAgent | null>(null)
@@ -34,14 +35,9 @@
   }
 
   function formatRelative(dateStr: string | any): string {
-    if (!dateStr) return 'never'
     const d = new Date(dateStr)
-    if (isNaN(d.getTime()) || d.getTime() === 0) return 'never'
-    const diff = Date.now() - d.getTime()
-    if (diff < 60_000) return 'just now'
-    if (diff < 3_600_000) return `${Math.round(diff / 60_000)}m ago`
-    if (diff < 86_400_000) return `${Math.round(diff / 3_600_000)}h ago`
-    return `${Math.round(diff / 86_400_000)}d ago`
+    if (!dateStr || isNaN(d.getTime()) || d.getTime() === 0) return 'never'
+    return timeAgo(d)
   }
 
   function formatCost(cost: number): string {

--- a/frontend/src/pages/ProjectDetail.svelte
+++ b/frontend/src/pages/ProjectDetail.svelte
@@ -8,6 +8,7 @@
   import { projectStore } from '../stores/projects.svelte.js'
   import { taskStore } from '../stores/tasks.svelte.js'
   import { BOARD_COLUMNS } from '../lib/statuses.js'
+  import { formatDateTime } from '../lib/dates.js'
   import TaskCard from '../components/TaskCard.svelte'
   import WorktreeList from '../components/WorktreeList.svelte'
 
@@ -155,10 +156,6 @@
     }
   }
 
-  function formatDate(date: any): string {
-    if (!date) return '-'
-    return new Date(date).toLocaleString()
-  }
 </script>
 
 <div class="flex flex-col gap-4 p-4 md:gap-6 md:p-6">
@@ -222,8 +219,8 @@
       </div>
 
       <div class="flex gap-6 text-xs text-surface-400">
-        <span>Created: {formatDate(p.createdAt)}</span>
-        <span>Updated: {formatDate(p.updatedAt)}</span>
+        <span>Created: {formatDateTime(p.createdAt)}</span>
+        <span>Updated: {formatDateTime(p.updatedAt)}</span>
       </div>
 
       <hr class="border-surface-300 dark:border-surface-600" />

--- a/frontend/src/pages/ProjectList.svelte
+++ b/frontend/src/pages/ProjectList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Folder } from '@lucide/svelte'
   import { projectStore } from '../stores/projects.svelte.js'
+  import { formatShortDate } from '../lib/dates.js'
 
   interface Props {
     onselect: (id: string) => void
@@ -8,11 +9,6 @@
   }
 
   const { onselect, onadd }: Props = $props()
-
-  function formatDate(date: any): string {
-    if (!date) return '-'
-    return new Date(date).toLocaleDateString()
-  }
 </script>
 
 <div class="flex flex-col gap-3 p-4 md:gap-4 md:p-6">
@@ -61,7 +57,7 @@
             {/if}
           </div>
           <div class="flex items-center gap-2 text-xs text-surface-500">
-            <span>Added {formatDate(p.createdAt)}</span>
+            <span>Added {formatShortDate(p.createdAt)}</span>
           </div>
         </button>
       {/each}


### PR DESCRIPTION
## Motivation

Date/time formatting was duplicated and inconsistent across the frontend (issue #905): ~8 hand-copied `timeAgo` relative-time ladders, three ad-hoc absolute `toLocaleString` formatters, and several differing short-date `toLocaleDateString` calls. Same concept, different output per screen.

## Implementation information

Centralized on `lib/dates.ts` as the single date/time utility:

- Renamed `formatDate` → `formatDateTime` (absolute date+time), added `isNaN` guard.
- Added `formatShortDate` (compact `Jun 23` / `Jun 23, 2025`) and a single `timeAgo` (`just now` / `Nm` / `Nh` / `Nd ago`, empty string when absent).
- Deleted the per-component `timeAgo` copies in AgentCard, IssueCard, PRCard, PRDetailView, RenovatePRCard, TaskCard, ChatList; Loops keeps a thin `formatRelative` wrapper that preserves its `never` sentinel and delegates the ladder.
- Routed absolute timestamps (AgentHeader, PlanFileView, ProjectDetail, TaskMetadataRow, AgentHistoryList) through `formatDateTime`, and short dates (TaskListView, ProjectList, Logbook, TaskTimeline) through `formatShortDate`.
- Added table-driven tests for the three exports.

Out of scope (intentionally left): `ActionTimeline`'s time-of-day formatter and the chart-axis formatters in `Stats.svelte` / `lib/timeline-gantt.ts`, plus token-count `toLocaleString` calls — none are calendar date/time display.

Behavior preserved: the shared `timeAgo` matches every old copy's output (`Math.floor`); Loops' switch from `Math.round` is consistent with all other consumers and changes no tested boundary.

Closes #905

> Changelog: refactor(ui): single date/time formatting utility