### PR TITLE
feat(ui): dark-theme elevation & modal treatment

### DIFF
--- a/frontend/src/components/AssignProjectDialog.svelte
+++ b/frontend/src/components/AssignProjectDialog.svelte
@@ -43,13 +43,13 @@
 {#if open}
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-  class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm"
+  class="fixed inset-0 z-50 flex items-center justify-center modal-backdrop"
   onclick={() => onOpenChange(false)}
   onkeydown={(e) => e.key === 'Escape' && onOpenChange(false)}
 >
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
-    class="min-w-[260px] rounded-xl border border-surface-300 bg-surface-50 shadow-2xl dark:border-surface-700 dark:bg-surface-900"
+    class="min-w-[260px] rounded-xl elevation-popover"
     onclick={(e) => e.stopPropagation()}
     onkeydown={(e) => e.stopPropagation()}
   >

--- a/frontend/src/components/CommandPalette.svelte
+++ b/frontend/src/components/CommandPalette.svelte
@@ -107,7 +107,7 @@
   }
 </script>
 
-<MobileSheet {open} onOpenChange={(o) => { if (!o) onclose() }} variant="top" backdropClass="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm">
+<MobileSheet {open} onOpenChange={(o) => { if (!o) onclose() }} variant="top">
   <div class="flex flex-col">
     <!-- Search bar -->
     <div class="flex items-center gap-3 border-b border-surface-200 px-4 dark:border-surface-700">

--- a/frontend/src/components/CreateProjectDialog.svelte
+++ b/frontend/src/components/CreateProjectDialog.svelte
@@ -92,7 +92,7 @@
           <p class="text-sm text-surface-500">Starting clone…</p>
         {/if}
 
-        <div class="sticky bottom-0 -mx-5 -mb-5 flex justify-end gap-2 border-t border-surface-200 bg-surface-50/95 px-5 pt-3 pb-safe backdrop-blur dark:border-surface-800 dark:bg-surface-950/95 md:-mx-6 md:-mb-6 md:px-6 md:pb-4">
+        <div class="sticky bottom-0 -mx-5 -mb-5 flex justify-end gap-2 border-t border-surface-200 bg-surface-50/95 px-5 pt-3 pb-safe backdrop-blur dark:border-surface-800 dark:bg-surface-900/95 md:-mx-6 md:-mb-6 md:px-6 md:pb-4">
           <button
             type="button"
             onclick={() => { onOpenChange(false); reset() }}

--- a/frontend/src/components/CreateTaskDialog.svelte
+++ b/frontend/src/components/CreateTaskDialog.svelte
@@ -219,7 +219,7 @@
           <p class="text-sm text-error-500">{error}</p>
         {/if}
 
-        <div class="sticky bottom-0 -mx-5 -mb-5 flex justify-end gap-2 border-t border-surface-200 bg-surface-50/95 px-5 pt-3 pb-safe backdrop-blur dark:border-surface-800 dark:bg-surface-950/95 md:-mx-6 md:-mb-6 md:px-6 md:pb-4">
+        <div class="sticky bottom-0 -mx-5 -mb-5 flex justify-end gap-2 border-t border-surface-200 bg-surface-50/95 px-5 pt-3 pb-safe backdrop-blur dark:border-surface-800 dark:bg-surface-900/95 md:-mx-6 md:-mb-6 md:px-6 md:pb-4">
           <button
             type="button"
             onclick={() => { onOpenChange(false); reset() }}

--- a/frontend/src/components/NewChatDialog.svelte
+++ b/frontend/src/components/NewChatDialog.svelte
@@ -178,7 +178,7 @@
           <p class="text-sm text-error-500">{error}</p>
         {/if}
 
-        <div class="sticky bottom-0 -mx-5 -mb-5 flex justify-end gap-2 border-t border-surface-200 bg-surface-50/95 px-5 pt-3 pb-safe backdrop-blur dark:border-surface-800 dark:bg-surface-950/95 md:-mx-6 md:-mb-6 md:px-6 md:pb-4">
+        <div class="sticky bottom-0 -mx-5 -mb-5 flex justify-end gap-2 border-t border-surface-200 bg-surface-50/95 px-5 pt-3 pb-safe backdrop-blur dark:border-surface-800 dark:bg-surface-900/95 md:-mx-6 md:-mb-6 md:px-6 md:pb-4">
           <button
             type="button"
             onclick={() => { onOpenChange(false); reset() }}

--- a/frontend/src/components/PriorityPicker.svelte
+++ b/frontend/src/components/PriorityPicker.svelte
@@ -37,13 +37,13 @@
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-  class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm"
+  class="fixed inset-0 z-50 flex items-center justify-center modal-backdrop"
   onclick={onclose}
   onkeydown={(e) => e.key === 'Escape' && onclose()}
 >
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
-    class="min-w-[180px] rounded-xl border border-surface-300 bg-surface-50 shadow-2xl dark:border-surface-700 dark:bg-surface-900"
+    class="min-w-[180px] rounded-xl elevation-popover"
     onclick={(e) => e.stopPropagation()}
     onkeydown={(e) => e.stopPropagation()}
   >

--- a/frontend/src/components/StatusPicker.svelte
+++ b/frontend/src/components/StatusPicker.svelte
@@ -37,13 +37,13 @@
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-  class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm"
+  class="fixed inset-0 z-50 flex items-center justify-center modal-backdrop"
   onclick={onclose}
   onkeydown={(e) => e.key === 'Escape' && onclose()}
 >
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
-    class="min-w-[200px] rounded-xl border border-surface-300 bg-surface-50 shadow-2xl dark:border-surface-700 dark:bg-surface-900"
+    class="min-w-[200px] rounded-xl elevation-popover"
     onclick={(e) => e.stopPropagation()}
     onkeydown={(e) => e.stopPropagation()}
   >

--- a/frontend/src/components/shell/MobileSheet.svelte
+++ b/frontend/src/components/shell/MobileSheet.svelte
@@ -23,10 +23,10 @@
 
   const contentClass = $derived(
     variant === 'bottom'
-      ? 'flex max-h-[92dvh] w-full flex-col overflow-y-auto rounded-t-2xl bg-surface-50 pb-safe shadow-2xl dark:bg-surface-950 md:max-h-[85dvh] md:max-w-lg md:rounded-2xl md:pb-0'
+      ? 'elevation-modal flex max-h-[92dvh] w-full flex-col overflow-y-auto rounded-t-2xl pb-safe md:max-h-[85dvh] md:max-w-lg md:rounded-2xl md:pb-0'
       : variant === 'top'
-        ? 'flex max-h-[92dvh] w-full flex-col overflow-y-auto rounded-b-2xl bg-surface-50 pt-safe shadow-2xl dark:bg-surface-950 md:max-h-[80dvh] md:max-w-lg md:rounded-2xl md:pt-0'
-        : 'flex max-h-[92dvh] w-full max-w-lg flex-col overflow-y-auto rounded-2xl bg-surface-50 shadow-2xl dark:bg-surface-950'
+        ? 'elevation-modal flex max-h-[92dvh] w-full flex-col overflow-y-auto rounded-b-2xl pt-safe md:max-h-[80dvh] md:max-w-lg md:rounded-2xl md:pt-0'
+        : 'elevation-modal flex max-h-[92dvh] w-full max-w-lg flex-col overflow-y-auto rounded-2xl'
   )
 </script>
 
@@ -34,7 +34,7 @@
   {open}
   onOpenChange={(d) => onOpenChange(d.open)}
 >
-  <Dialog.Backdrop class={backdropClass ?? 'fixed inset-0 z-40 bg-black/50'} />
+  <Dialog.Backdrop class={backdropClass ?? 'modal-backdrop fixed inset-0 z-40'} />
   <Dialog.Positioner class={positionerClass}>
     <Dialog.Content class={contentClass}>
       {#if open}

--- a/frontend/src/pages/Loops.svelte
+++ b/frontend/src/pages/Loops.svelte
@@ -307,7 +307,7 @@
         </label>
       </div>
 
-      <div class="sticky bottom-0 -mx-5 -mb-5 mt-5 flex justify-end gap-2 border-t border-surface-200 bg-surface-50/95 px-5 pt-3 pb-safe backdrop-blur dark:border-surface-800 dark:bg-surface-950/95 md:-mx-6 md:-mb-6 md:px-6 md:pb-4">
+      <div class="sticky bottom-0 -mx-5 -mb-5 mt-5 flex justify-end gap-2 border-t border-surface-200 bg-surface-50/95 px-5 pt-3 pb-safe backdrop-blur dark:border-surface-800 dark:bg-surface-900/95 md:-mx-6 md:-mb-6 md:px-6 md:pb-4">
         <button
           type="button"
           class="tap rounded-lg bg-surface-200 px-4 py-2.5 text-sm font-medium active:bg-surface-300 dark:bg-surface-700 dark:active:bg-surface-600"

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -454,7 +454,7 @@
       <span class="text-sm font-medium">Show done</span>
     </label>
 
-    <div class="sticky bottom-0 -mx-5 -mb-5 flex gap-2 border-t border-surface-200 bg-surface-50/95 px-5 pt-3 pb-safe backdrop-blur dark:border-surface-800 dark:bg-surface-950/95">
+    <div class="sticky bottom-0 -mx-5 -mb-5 flex gap-2 border-t border-surface-200 bg-surface-50/95 px-5 pt-3 pb-safe backdrop-blur dark:border-surface-800 dark:bg-surface-900/95">
       <button
         type="button"
         onclick={() => { clearFilters(); filtersOpen = false }}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -76,3 +76,30 @@ html, body {
 @utility animate-pulse-subtle {
   animation: pulse-subtle 2s ease-in-out infinite;
 }
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Overlay elevation (dark theme): page (surface-950) < popover < modal.
+ * Both lift the surface to surface-900 off the near-black page and deepen the
+ * shadow so overlays read as distinct planes instead of a flat "sea of black";
+ * the modal goes further with a larger shadow and the blurred .modal-backdrop.
+ * Light theme keeps a near-white surface and leans on the shadow + border.
+ * Apply these instead of hand-rolling bg/border/shadow per overlay component.
+ * (On-page cards already sit on their own surface token, styled per-screen.)
+ * ────────────────────────────────────────────────────────────────────────── */
+.elevation-popover,
+.elevation-modal {
+  background-color: var(--color-surface-50);
+  border: 1px solid var(--color-surface-200);
+}
+.elevation-popover { box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.35), 0 4px 6px -4px rgb(0 0 0 / 0.35); }
+.elevation-modal   { box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.5); }
+
+.dark .elevation-popover { background-color: var(--color-surface-900); border-color: var(--color-surface-700); }
+.dark .elevation-modal   { background-color: var(--color-surface-900); border-color: var(--color-surface-700); }
+
+/* Shared overlay scrim: dim + blur whatever sits behind a modal/popover. */
+.modal-backdrop {
+  background-color: rgb(0 0 0 / 0.5);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -94,8 +94,11 @@ html, body {
 .elevation-popover { box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.35), 0 4px 6px -4px rgb(0 0 0 / 0.35); }
 .elevation-modal   { box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.5); }
 
-.dark .elevation-popover { background-color: var(--color-surface-900); border-color: var(--color-surface-700); }
-.dark .elevation-modal   { background-color: var(--color-surface-900); border-color: var(--color-surface-700); }
+.dark .elevation-popover,
+.dark .elevation-modal {
+  background-color: var(--color-surface-900);
+  border-color: var(--color-surface-700);
+}
 
 /* Shared overlay scrim: dim + blur whatever sits behind a modal/popover. */
 .modal-backdrop {


### PR DESCRIPTION
## Motivation

In dark mode the page, cards, and modals all sat at near-black `surface` tokens separated only by hairline borders (issue #906). Worst case: `MobileSheet` — the wrapper behind every form dialog and the command palette — used `dark:bg-surface-950`, the exact page background, so dialogs had no perceptible edge and their scrim neither dimmed nor blurred the page.

## Implementation information

- **Elevation scale** (`style.css`): reusable `.elevation-popover` / `.elevation-modal` classes that lift overlays to `surface-900` off the `surface-950` page and add progressively deeper shadows, plus a shared `.modal-backdrop` (dim + blur). Defined as unlayered CSS so they reliably win over Tailwind utilities in both themes.
- **MobileSheet** now renders on `.elevation-modal` and makes the blurred `.modal-backdrop` the default scrim, so all form dialogs + the command palette share one elevated, blurred treatment. CommandPalette drops its now-redundant custom backdrop.
- **Hand-rolled pickers** (Status / Priority / AssignProject) normalized onto `.modal-backdrop` + `.elevation-popover` (previously a lighter `bg-black/30` scrim and duplicated panel classes).
- **Sticky dialog footers** inside sheets (CreateTask, CreateProject, NewChat, Loops form, TaskList filters) re-tinted `surface-950→900` to match the elevated panel. Page-level chrome (ChatInput, BottomTabBar, MobileAppBar) intentionally keeps `surface-950` to match the page.

On-page card surfaces already sit above the page on their own tokens and are restyled per-screen (#912 / #914), so this PR scopes to overlays and does not touch them.

Closes #906

> Changelog: feat(ui): dark-theme elevation & modal treatment