### PR TITLE
feat(tasks): collapse status taxonomy to core set

### DIFF
--- a/frontend/src/components/StatusPicker.svelte
+++ b/frontend/src/components/StatusPicker.svelte
@@ -18,6 +18,14 @@
   }
   let selectedIdx = $state(initialIdx())
 
+  // Picking the bucket the task is already in is a no-op — don't overwrite a
+  // granular status (e.g. blocked) with its rolled-up core (human-required)
+  // just because the user confirmed the highlighted "current" option.
+  function pick(value: string) {
+    if (value === coreStatus(currentStatus)) { onclose(); return }
+    onpick(value)
+  }
+
   $effect(() => {
     function handleKeydown(e: KeyboardEvent) {
       if (e.key === 'Escape') { e.preventDefault(); e.stopImmediatePropagation(); onclose(); return }
@@ -33,7 +41,7 @@
       }
       if (e.key === 'Enter') {
         e.preventDefault()
-        onpick(options[selectedIdx].value)
+        pick(options[selectedIdx].value)
         return
       }
     }
@@ -63,7 +71,7 @@
           <button
             type="button"
             class="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left text-sm transition-colors {i === selectedIdx ? 'bg-primary-500/15 text-primary-700 dark:text-primary-300' : 'hover:bg-surface-200 dark:hover:bg-surface-700'}"
-            onclick={() => onpick(opt.value)}
+            onclick={() => pick(opt.value)}
           >
             <span>{opt.label}</span>
             {#if opt.value === coreStatus(currentStatus)}

--- a/frontend/src/components/StatusPicker.svelte
+++ b/frontend/src/components/StatusPicker.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { STATUS_OPTIONS } from '../lib/statuses.js'
+  import { statusOptionsFor, coreStatus } from '../lib/statuses.js'
 
   interface Props {
     currentStatus: string
@@ -9,14 +9,21 @@
 
   const { currentStatus, onpick, onclose }: Props = $props()
 
-  let selectedIdx = $state(STATUS_OPTIONS.findIndex(s => s.value === currentStatus))
+  const options = $derived(statusOptionsFor(currentStatus))
+
+  // Highlight the core status the current (possibly granular) status rolls up to.
+  function initialIdx(): number {
+    const opts = statusOptionsFor(currentStatus)
+    return Math.max(0, opts.findIndex((s) => s.value === coreStatus(currentStatus)))
+  }
+  let selectedIdx = $state(initialIdx())
 
   $effect(() => {
     function handleKeydown(e: KeyboardEvent) {
       if (e.key === 'Escape') { e.preventDefault(); e.stopImmediatePropagation(); onclose(); return }
       if (e.key === 'ArrowDown' || e.key === 'j') {
         e.preventDefault()
-        selectedIdx = Math.min(selectedIdx + 1, STATUS_OPTIONS.length - 1)
+        selectedIdx = Math.min(selectedIdx + 1, options.length - 1)
         return
       }
       if (e.key === 'ArrowUp' || e.key === 'k') {
@@ -26,7 +33,7 @@
       }
       if (e.key === 'Enter') {
         e.preventDefault()
-        onpick(STATUS_OPTIONS[selectedIdx].value)
+        onpick(options[selectedIdx].value)
         return
       }
     }
@@ -51,7 +58,7 @@
       <p class="text-xs font-semibold uppercase tracking-wider text-surface-400">Change Status <kbd class="ml-1 rounded bg-surface-200 px-1 py-0.5 font-mono text-xs dark:bg-surface-700">S</kbd></p>
     </div>
     <ul class="py-1">
-      {#each STATUS_OPTIONS as opt, i}
+      {#each options as opt, i}
         <li>
           <button
             type="button"
@@ -59,7 +66,7 @@
             onclick={() => onpick(opt.value)}
           >
             <span>{opt.label}</span>
-            {#if opt.value === currentStatus}
+            {#if opt.value === coreStatus(currentStatus)}
               <span class="text-xs text-surface-400">current</span>
             {/if}
           </button>

--- a/frontend/src/components/StatusPicker.svelte.test.ts
+++ b/frontend/src/components/StatusPicker.svelte.test.ts
@@ -1,16 +1,16 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
 import StatusPicker from './StatusPicker.svelte'
-import { STATUS_OPTIONS } from '../lib/statuses.js'
+import { CORE_STATUS_OPTIONS } from '../lib/statuses.js'
 
 afterEach(() => {
   cleanup()
 })
 
 describe('StatusPicker', () => {
-  it('renders all status options', () => {
+  it('renders the core status options', () => {
     render(StatusPicker, { props: { currentStatus: 'todo', onpick: vi.fn(), onclose: vi.fn() } })
-    for (const opt of STATUS_OPTIONS) {
+    for (const opt of CORE_STATUS_OPTIONS) {
       expect(screen.getByText(opt.label)).toBeDefined()
     }
   })
@@ -47,42 +47,42 @@ describe('StatusPicker', () => {
 
   it('navigates down with ArrowDown key from first option', async () => {
     const onpick = vi.fn()
-    // Start at index 0 ('new') so ArrowDown goes to index 1
-    render(StatusPicker, { props: { currentStatus: STATUS_OPTIONS[0].value, onpick, onclose: vi.fn() } })
+    // Start at index 0 ('todo') so ArrowDown goes to index 1
+    render(StatusPicker, { props: { currentStatus: CORE_STATUS_OPTIONS[0].value, onpick, onclose: vi.fn() } })
     await fireEvent.keyDown(window, { key: 'ArrowDown' })
     await fireEvent.keyDown(window, { key: 'Enter' })
-    expect(onpick).toHaveBeenCalledWith(STATUS_OPTIONS[1].value)
+    expect(onpick).toHaveBeenCalledWith(CORE_STATUS_OPTIONS[1].value)
   })
 
   it('navigates down with j key', async () => {
     const onpick = vi.fn()
-    // Start at index 0 ('new') so j goes to index 1
-    render(StatusPicker, { props: { currentStatus: STATUS_OPTIONS[0].value, onpick, onclose: vi.fn() } })
+    // Start at index 0 ('todo') so j goes to index 1
+    render(StatusPicker, { props: { currentStatus: CORE_STATUS_OPTIONS[0].value, onpick, onclose: vi.fn() } })
     await fireEvent.keyDown(window, { key: 'j' })
     await fireEvent.keyDown(window, { key: 'Enter' })
-    expect(onpick).toHaveBeenCalledWith(STATUS_OPTIONS[1].value)
+    expect(onpick).toHaveBeenCalledWith(CORE_STATUS_OPTIONS[1].value)
   })
 
   it('navigates up with ArrowUp key and does not go below 0', async () => {
     const onpick = vi.fn()
-    render(StatusPicker, { props: { currentStatus: STATUS_OPTIONS[0].value, onpick, onclose: vi.fn() } })
+    render(StatusPicker, { props: { currentStatus: CORE_STATUS_OPTIONS[0].value, onpick, onclose: vi.fn() } })
     await fireEvent.keyDown(window, { key: 'ArrowUp' })
     await fireEvent.keyDown(window, { key: 'Enter' })
-    expect(onpick).toHaveBeenCalledWith(STATUS_OPTIONS[0].value)
+    expect(onpick).toHaveBeenCalledWith(CORE_STATUS_OPTIONS[0].value)
   })
 
   it('navigates up with k key', async () => {
     const onpick = vi.fn()
     // Start at index 2 so k goes to index 1
-    render(StatusPicker, { props: { currentStatus: STATUS_OPTIONS[2].value, onpick, onclose: vi.fn() } })
+    render(StatusPicker, { props: { currentStatus: CORE_STATUS_OPTIONS[2].value, onpick, onclose: vi.fn() } })
     await fireEvent.keyDown(window, { key: 'k' })
     await fireEvent.keyDown(window, { key: 'Enter' })
-    expect(onpick).toHaveBeenCalledWith(STATUS_OPTIONS[1].value)
+    expect(onpick).toHaveBeenCalledWith(CORE_STATUS_OPTIONS[1].value)
   })
 
   it('does not navigate past last option with ArrowDown', async () => {
     const onpick = vi.fn()
-    const lastStatus = STATUS_OPTIONS[STATUS_OPTIONS.length - 1].value
+    const lastStatus = CORE_STATUS_OPTIONS[CORE_STATUS_OPTIONS.length - 1].value
     render(StatusPicker, { props: { currentStatus: lastStatus, onpick, onclose: vi.fn() } })
     for (let i = 0; i < 5; i++) {
       await fireEvent.keyDown(window, { key: 'ArrowDown' })
@@ -93,9 +93,9 @@ describe('StatusPicker', () => {
 
   it('selects current option with Enter key', async () => {
     const onpick = vi.fn()
-    // Start at first option ('new')
-    render(StatusPicker, { props: { currentStatus: STATUS_OPTIONS[0].value, onpick, onclose: vi.fn() } })
+    // Start at first option ('todo')
+    render(StatusPicker, { props: { currentStatus: CORE_STATUS_OPTIONS[0].value, onpick, onclose: vi.fn() } })
     await fireEvent.keyDown(window, { key: 'Enter' })
-    expect(onpick).toHaveBeenCalledWith(STATUS_OPTIONS[0].value)
+    expect(onpick).toHaveBeenCalledWith(CORE_STATUS_OPTIONS[0].value)
   })
 })

--- a/frontend/src/components/StatusPicker.svelte.test.ts
+++ b/frontend/src/components/StatusPicker.svelte.test.ts
@@ -65,8 +65,13 @@ describe('StatusPicker', () => {
 
   it('navigates up with ArrowUp key and does not go below 0', async () => {
     const onpick = vi.fn()
-    render(StatusPicker, { props: { currentStatus: CORE_STATUS_OPTIONS[0].value, onpick, onclose: vi.fn() } })
-    await fireEvent.keyDown(window, { key: 'ArrowUp' })
+    // Start at the last option, then ArrowUp past index 0; picking the first
+    // option is a real change vs the current status.
+    const lastStatus = CORE_STATUS_OPTIONS[CORE_STATUS_OPTIONS.length - 1].value
+    render(StatusPicker, { props: { currentStatus: lastStatus, onpick, onclose: vi.fn() } })
+    for (let i = 0; i < CORE_STATUS_OPTIONS.length + 2; i++) {
+      await fireEvent.keyDown(window, { key: 'ArrowUp' })
+    }
     await fireEvent.keyDown(window, { key: 'Enter' })
     expect(onpick).toHaveBeenCalledWith(CORE_STATUS_OPTIONS[0].value)
   })
@@ -83,19 +88,24 @@ describe('StatusPicker', () => {
   it('does not navigate past last option with ArrowDown', async () => {
     const onpick = vi.fn()
     const lastStatus = CORE_STATUS_OPTIONS[CORE_STATUS_OPTIONS.length - 1].value
-    render(StatusPicker, { props: { currentStatus: lastStatus, onpick, onclose: vi.fn() } })
-    for (let i = 0; i < 5; i++) {
+    // Start at the first option, ArrowDown past the end; picking the last
+    // option is a real change vs the current status.
+    render(StatusPicker, { props: { currentStatus: CORE_STATUS_OPTIONS[0].value, onpick, onclose: vi.fn() } })
+    for (let i = 0; i < CORE_STATUS_OPTIONS.length + 2; i++) {
       await fireEvent.keyDown(window, { key: 'ArrowDown' })
     }
     await fireEvent.keyDown(window, { key: 'Enter' })
     expect(onpick).toHaveBeenCalledWith(lastStatus)
   })
 
-  it('selects current option with Enter key', async () => {
+  it('treats Enter on the already-current option as a no-op', async () => {
     const onpick = vi.fn()
-    // Start at first option ('todo')
-    render(StatusPicker, { props: { currentStatus: CORE_STATUS_OPTIONS[0].value, onpick, onclose: vi.fn() } })
+    const onclose = vi.fn()
+    // The picker pre-highlights the current status; confirming it must not
+    // overwrite the (possibly granular) status with its rolled-up core.
+    render(StatusPicker, { props: { currentStatus: 'new', onpick, onclose } })
     await fireEvent.keyDown(window, { key: 'Enter' })
-    expect(onpick).toHaveBeenCalledWith(CORE_STATUS_OPTIONS[0].value)
+    expect(onpick).not.toHaveBeenCalled()
+    expect(onclose).toHaveBeenCalled()
   })
 })

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -5,7 +5,7 @@
   import { agentStore } from '../stores/agents.svelte.js'
   import { reviewStore } from '../stores/reviews.svelte.js'
   import { notificationStore } from '../stores/notifications.svelte.js'
-  import { STATUS_OPTIONS, awaitsHuman, awaitsHumanLabel } from '../lib/statuses.js'
+  import { statusOptionsFor, coreStatus, awaitsHuman, awaitsHumanLabel } from '../lib/statuses.js'
   import { PRIORITY_OPTIONS } from '../lib/priorities.js'
 
   interface Props {
@@ -260,13 +260,13 @@
   {#if onstatuschange}
     <div class="mt-2 flex justify-end">
       <select
-        value={t.status}
+        value={coreStatus(t.status)}
         onchange={handleStatusChange}
         onclick={(e) => e.stopPropagation()}
         class="tap rounded border border-surface-300 bg-surface-100 px-2 py-1 text-xs font-medium dark:border-surface-600 dark:bg-surface-700"
         aria-label="Change status"
       >
-        {#each STATUS_OPTIONS as opt}
+        {#each statusOptionsFor(t.status) as opt}
           <option value={opt.value} disabled={hasRunningAgent && AGENT_BLOCKED_STATUSES.has(opt.value)}>{opt.label}</option>
         {/each}
       </select>

--- a/frontend/src/components/task-detail/TaskHeaderBar.svelte
+++ b/frontend/src/components/task-detail/TaskHeaderBar.svelte
@@ -5,7 +5,7 @@
   import { agentStore } from '../../stores/agents.svelte.js'
   import { notificationStore } from '../../stores/notifications.svelte.js'
   import { StartReview, StartFixReview } from '$lib/api'
-  import { STATUS_OPTIONS, STATUS_MAP } from '../../lib/statuses.js'
+  import { statusOptionsFor, STATUS_MAP, coreStatus } from '../../lib/statuses.js'
 
   interface Props {
     task: Task
@@ -14,7 +14,7 @@
 
   const { task, ondelete }: Props = $props()
 
-  const statusOptions = STATUS_OPTIONS
+  const statusOptions = $derived(statusOptionsFor(task.status))
 
   // Statuses that conflict with a running agent
   const AGENT_BLOCKED_STATUSES = new Set(['new', 'todo', 'done'])
@@ -228,9 +228,9 @@
     <select
       bind:this={statusSelectRef}
       data-testid="task-status-select"
-      class="cursor-pointer rounded-full px-2.5 py-0.5 text-xs font-semibold transition-opacity hover:opacity-80 {STATUS_MAP[task.status]?.badgeClasses ?? 'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200'}"
+      class="cursor-pointer rounded-full px-2.5 py-0.5 text-xs font-semibold transition-opacity hover:opacity-80 {STATUS_MAP[coreStatus(task.status)]?.badgeClasses ?? 'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200'}"
       style="appearance: auto"
-      value={task.status}
+      value={coreStatus(task.status)}
       onchange={(e) => updateStatus((e.target as HTMLSelectElement).value)}
       title="Click to change status"
     >

--- a/frontend/src/lib/statuses.test.ts
+++ b/frontend/src/lib/statuses.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CORE_STATUSES,
+  CORE_STATUS_OPTIONS,
+  coreStatus,
+  statusOptionsFor,
+  BOARD_COLUMNS,
+  STATUS_MAP,
+} from './statuses.js'
+
+describe('CORE_STATUSES', () => {
+  it('is the active board columns plus the terminal states', () => {
+    expect(CORE_STATUSES).toEqual([...BOARD_COLUMNS.map((c) => c.status), 'done', 'cancelled'])
+  })
+
+  it('is a small set (<= 8) and excludes granular states', () => {
+    expect(CORE_STATUSES.length).toBeLessThanOrEqual(8)
+    for (const granular of ['new', 'plan-review', 'ready-review', 'test-plan-review', 'blocked']) {
+      expect(CORE_STATUSES).not.toContain(granular)
+    }
+  })
+
+  it('exposes options with labels from STATUS_MAP', () => {
+    for (const opt of CORE_STATUS_OPTIONS) {
+      expect(opt.label).toBe(STATUS_MAP[opt.value].label)
+    }
+  })
+})
+
+describe('coreStatus', () => {
+  it('rolls granular states up to their board column', () => {
+    expect(coreStatus('new')).toBe('todo')
+    expect(coreStatus('plan-review')).toBe('planning')
+    expect(coreStatus('ready-review')).toBe('in-review')
+    expect(coreStatus('test-plan-review')).toBe('testing')
+    expect(coreStatus('blocked')).toBe('human-required')
+  })
+
+  it('maps a column status to itself', () => {
+    for (const col of BOARD_COLUMNS) {
+      expect(coreStatus(col.status)).toBe(col.status)
+    }
+  })
+
+  it('passes terminal/unknown states through unchanged', () => {
+    expect(coreStatus('done')).toBe('done')
+    expect(coreStatus('cancelled')).toBe('cancelled')
+    expect(coreStatus('mystery')).toBe('mystery')
+  })
+
+  it('always lands on a core status for every folded state', () => {
+    for (const col of BOARD_COLUMNS) {
+      for (const folded of col.includes) {
+        expect(CORE_STATUSES).toContain(coreStatus(folded))
+      }
+    }
+  })
+})
+
+describe('statusOptionsFor', () => {
+  it('returns just the core options for a core status', () => {
+    expect(statusOptionsFor('in-progress')).toBe(CORE_STATUS_OPTIONS)
+  })
+
+  it('returns just the core options for a folded granular status', () => {
+    expect(statusOptionsFor('blocked')).toBe(CORE_STATUS_OPTIONS)
+    expect(statusOptionsFor('cancelled')).toBe(CORE_STATUS_OPTIONS)
+  })
+
+  it('appends an unknown current status so it stays selectable', () => {
+    const opts = statusOptionsFor('mystery')
+    expect(opts).toHaveLength(CORE_STATUS_OPTIONS.length + 1)
+    expect(opts.at(-1)).toEqual({ value: 'mystery', label: 'mystery' })
+  })
+})

--- a/frontend/src/lib/statuses.test.ts
+++ b/frontend/src/lib/statuses.test.ts
@@ -62,7 +62,7 @@ describe('statusOptionsFor', () => {
     expect(statusOptionsFor('in-progress')).toBe(CORE_STATUS_OPTIONS)
   })
 
-  it('returns just the core options for a folded granular status', () => {
+  it('returns just the core options for a folded or terminal status', () => {
     expect(statusOptionsFor('blocked')).toBe(CORE_STATUS_OPTIONS)
     expect(statusOptionsFor('cancelled')).toBe(CORE_STATUS_OPTIONS)
   })

--- a/frontend/src/lib/statuses.ts
+++ b/frontend/src/lib/statuses.ts
@@ -20,6 +20,11 @@ export interface StatusMeta {
   pillClasses: string
 }
 
+export type StatusOption<T extends string = string> = {
+  value: T
+  label: string
+}
+
 /** All valid statuses — mirrors Go internal/task/model.go */
 export const ALL_STATUSES: StatusMeta[] = [
   {
@@ -159,10 +164,11 @@ export const BOARD_COLUMNS: BoardColumn[] = [
 ]
 
 /**
- * Core user-facing status set: the active board columns plus `done`. Granular
- * states (new, plan-review, ready-review, test-plan-review, blocked, cancelled)
- * are internal/derived — set by automations, not picked by hand. Users choose
- * from this small set so a task's status always lines up with a board column.
+ * Core user-facing status set: the active board columns plus the terminal
+ * states (`done`, `cancelled`). Granular states (new, plan-review,
+ * ready-review, test-plan-review, blocked) are internal/derived — set by
+ * automations, not picked by hand. Users choose from this small set so a
+ * task's status always lines up with a board column.
  */
 export const CORE_STATUSES: TaskStatus[] = [
   ...BOARD_COLUMNS.map((c) => c.status),
@@ -170,10 +176,16 @@ export const CORE_STATUSES: TaskStatus[] = [
   'cancelled',
 ]
 
+const CORE_STATUS_SET: ReadonlySet<TaskStatus> = new Set(CORE_STATUSES)
+
 /** Core statuses as dropdown/picker options. */
-export const CORE_STATUS_OPTIONS: { value: TaskStatus; label: string }[] = CORE_STATUSES.map(
+export const CORE_STATUS_OPTIONS: StatusOption<TaskStatus>[] = CORE_STATUSES.map(
   (value) => ({ value, label: STATUS_MAP[value].label }),
 )
+
+function isCoreStatus(status: string): status is TaskStatus {
+  return CORE_STATUS_SET.has(status as TaskStatus)
+}
 
 /** Granular status → the core (column) status it rolls up to. */
 const STATUS_TO_CORE: Record<string, TaskStatus> = (() => {
@@ -186,8 +198,10 @@ const STATUS_TO_CORE: Record<string, TaskStatus> = (() => {
 })()
 
 /** Roll any status up to its core (column) status; terminal states map to self. */
-export function coreStatus(status: string): TaskStatus {
-  return STATUS_TO_CORE[status] ?? (status as TaskStatus)
+export function coreStatus(status: TaskStatus): TaskStatus
+export function coreStatus(status: string): string
+export function coreStatus(status: string): string {
+  return STATUS_TO_CORE[status] ?? status
 }
 
 /**
@@ -196,8 +210,10 @@ export function coreStatus(status: string): TaskStatus {
  * unknown/legacy status), its own value is appended so the control never
  * mislabels or silently reassigns it.
  */
-export function statusOptionsFor(current: string): { value: TaskStatus; label: string }[] {
+export function statusOptionsFor(current: TaskStatus): StatusOption<TaskStatus>[]
+export function statusOptionsFor(current: string): StatusOption<string>[]
+export function statusOptionsFor(current: string): StatusOption<string>[] {
   const core = coreStatus(current)
-  if (CORE_STATUSES.includes(core)) return CORE_STATUS_OPTIONS
+  if (isCoreStatus(core)) return CORE_STATUS_OPTIONS
   return [...CORE_STATUS_OPTIONS, { value: core, label: STATUS_MAP[core]?.label ?? core }]
 }

--- a/frontend/src/lib/statuses.ts
+++ b/frontend/src/lib/statuses.ts
@@ -140,11 +140,6 @@ export const STATUS_MAP: Record<string, StatusMeta> = Object.fromEntries(
   ALL_STATUSES.map((s) => [s.value, s]),
 )
 
-/** For dropdowns / segmented controls */
-export const STATUS_OPTIONS: { value: TaskStatus; label: string }[] = ALL_STATUSES.map(
-  ({ value, label }) => ({ value, label }),
-)
-
 export interface BoardColumn {
   status: TaskStatus
   label: string
@@ -162,3 +157,47 @@ export const BOARD_COLUMNS: BoardColumn[] = [
   { status: 'testing', label: 'Testing', border: 'border-t-secondary-500 dark:border-t-secondary-400', includes: ['testing', 'test-plan-review'] },
   { status: 'human-required', label: 'Human Required', border: 'border-t-error-500 dark:border-t-error-400', includes: ['human-required', 'blocked'] },
 ]
+
+/**
+ * Core user-facing status set: the active board columns plus `done`. Granular
+ * states (new, plan-review, ready-review, test-plan-review, blocked, cancelled)
+ * are internal/derived — set by automations, not picked by hand. Users choose
+ * from this small set so a task's status always lines up with a board column.
+ */
+export const CORE_STATUSES: TaskStatus[] = [
+  ...BOARD_COLUMNS.map((c) => c.status),
+  'done',
+  'cancelled',
+]
+
+/** Core statuses as dropdown/picker options. */
+export const CORE_STATUS_OPTIONS: { value: TaskStatus; label: string }[] = CORE_STATUSES.map(
+  (value) => ({ value, label: STATUS_MAP[value].label }),
+)
+
+/** Granular status → the core (column) status it rolls up to. */
+const STATUS_TO_CORE: Record<string, TaskStatus> = (() => {
+  const map: Record<string, TaskStatus> = {}
+  for (const col of BOARD_COLUMNS) {
+    map[col.status] = col.status
+    for (const folded of col.includes) map[folded] = col.status
+  }
+  return map
+})()
+
+/** Roll any status up to its core (column) status; terminal states map to self. */
+export function coreStatus(status: string): TaskStatus {
+  return STATUS_TO_CORE[status] ?? (status as TaskStatus)
+}
+
+/**
+ * Picker options for a task whose current status is `current`. Normally the
+ * core set, but if `current` rolls up to something outside the core set (an
+ * unknown/legacy status), its own value is appended so the control never
+ * mislabels or silently reassigns it.
+ */
+export function statusOptionsFor(current: string): { value: TaskStatus; label: string }[] {
+  const core = coreStatus(current)
+  if (CORE_STATUSES.includes(core)) return CORE_STATUS_OPTIONS
+  return [...CORE_STATUS_OPTIONS, { value: core, label: STATUS_MAP[core]?.label ?? core }]
+}

--- a/frontend/src/pages/Dashboard.svelte
+++ b/frontend/src/pages/Dashboard.svelte
@@ -23,6 +23,13 @@
   const tasksByStatus = $derived(
     Object.fromEntries(ALL_STATUSES.map(s => [s.value, taskStore.byStatus(s.value).length]))
   )
+
+  // Most statuses sit at 0; hide empty buckets behind a toggle to cut the noise.
+  let showAllStatuses = $state(false)
+  const visibleStatuses = $derived(
+    showAllStatuses ? ALL_STATUSES : ALL_STATUSES.filter(s => (tasksByStatus[s.value] ?? 0) > 0)
+  )
+  const emptyStatusCount = $derived(ALL_STATUSES.length - visibleStatuses.length)
   const totalTasks = $derived(taskStore.list.length)
 
   const totalCost = $derived(
@@ -75,13 +82,27 @@
 
   <!-- Task status breakdown -->
   <div class="flex flex-col gap-2">
-    <span class="text-sm font-medium text-surface-500">Task Status</span>
+    <div class="flex items-center gap-3">
+      <span class="text-sm font-medium text-surface-500">Task Status</span>
+      {#if totalTasks > 0 && (showAllStatuses || emptyStatusCount > 0)}
+        <button
+          type="button"
+          class="text-xs text-surface-400 hover:text-surface-600 dark:hover:text-surface-300"
+          onclick={() => (showAllStatuses = !showAllStatuses)}
+        >
+          {showAllStatuses ? 'Hide empty' : `Show all (${emptyStatusCount} empty)`}
+        </button>
+      {/if}
+    </div>
     <div class="flex flex-wrap gap-3">
-      {#each ALL_STATUSES as s (s.value)}
+      {#each visibleStatuses as s (s.value)}
         <span class="rounded px-2.5 py-1 text-xs {s.pillClasses}">
           {s.label} <strong>{tasksByStatus[s.value]}</strong>
         </span>
       {/each}
+      {#if visibleStatuses.length === 0}
+        <span class="text-xs text-surface-400">No tasks yet</span>
+      {/if}
     </div>
   </div>
 


### PR DESCRIPTION
## Motivation

`statuses.ts` defined 13 statuses folded into 6 board columns (issue #907). Effects: every board card and the task-detail header carried a full 13-option status `<select>`; the dashboard showed all 13 status chips even when most read `0`; and folded states (e.g. `blocked` in the "Human Required" column) let a card's pill disagree with its column.

## Implementation information

- **Core set** (`statuses.ts`): `CORE_STATUSES` = the 6 board columns + the two terminal states (`done`, `cancelled`); `coreStatus()` rolls any granular state up to its column. `statusOptionsFor(current)` returns the core options, appending the current status only if it falls outside the core set (defensive for unknown/legacy values) so a control never mislabels or silently reassigns it.
- The three status **pick** points — board card `<select>`, task-detail header `<select>`, and the `S`-key `StatusPicker` — now offer `statusOptionsFor(...)` and bind to `coreStatus(...)`. Granular states (`new`, `plan-review`, `ready-review`, `test-plan-review`, `blocked`) stay internal/derived, set by automations.
- **Dashboard**: zero-count status chips are hidden behind a `Show all (N empty)` toggle; the toggle only appears once there are tasks.
- Removed the now-unused `STATUS_OPTIONS` export so nothing re-imports the full 13-option list.
- Added `statuses.test.ts` for `coreStatus` / `statusOptionsFor` / `CORE_STATUSES`.

A pre-PR adversarial review caught that terminal `cancelled` tasks would render as "Todo" in the selects and the picker would silently reassign them — fixed by including `cancelled` in the core set and the `statusOptionsFor` fallback.

Closes #907

> Changelog: feat(tasks): collapse status taxonomy to core set