### PR TITLE
feat(nav): group & reduce sidebar items

### DIFF
--- a/frontend/src/components/shell/SideRail.svelte
+++ b/frontend/src/components/shell/SideRail.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { LayoutGrid, ClipboardList, Folder, MessageCircle, UserCircle, GitBranch, ClipboardCheck, LayoutDashboard, BarChart3, Settings, Archive } from '@lucide/svelte'
+  import type { Component } from 'svelte'
   import { navStore } from '../../lib/navigation.svelte.js'
   import { taskStore } from '../../stores/tasks.svelte.js'
   import { agentStore } from '../../stores/agents.svelte.js'
@@ -19,78 +20,104 @@
   interface NavItem {
     kind: string[]
     label: string
+    icon: Component
     title?: string
     onclick: () => void
   }
 
-  const items: NavItem[] = [
-    { kind: ['dashboard'], label: 'Dashboard', onclick: () => navStore.reset({ kind: 'dashboard' }) },
-    { kind: ['task-list', 'task-detail'], label: 'Board', onclick: () => navStore.reset({ kind: 'task-list' }) },
-    { kind: ['project-list', 'project-detail'], label: 'Projects', onclick: () => navStore.reset({ kind: 'project-list' }) },
-    { kind: ['chats', 'chat-detail'], label: 'Chats', onclick: () => navStore.reset({ kind: 'chats' }) },
-    { kind: ['agents', 'agent-detail'], label: 'Agents', onclick: () => navStore.reset({ kind: 'agents' }) },
-    { kind: ['github'], label: 'GitHub', onclick: () => navStore.reset({ kind: 'github' }) },
-    { kind: ['reviews'], label: 'Reviews', onclick: () => navStore.reset({ kind: 'reviews' }) },
-    { kind: ['logbook'], label: 'Logbook', onclick: () => navStore.reset({ kind: 'logbook' }) },
-    { kind: ['workflows', 'workflow-detail'], label: 'Workflows', onclick: () => navStore.reset({ kind: 'workflows' }) },
-    { kind: ['stats'], label: 'Stats', onclick: () => navStore.reset({ kind: 'stats' }) },
-    { kind: ['settings'], label: 'Settings', title: 'Settings (Cmd+,)', onclick: () => navStore.reset({ kind: 'settings' }) },
+  interface NavGroup {
+    label: string
+    items: NavItem[]
+  }
+
+  // Grouped so 11 destinations read as ~4 scannable sections instead of a flat
+  // wall. Group labels avoid colliding with any item label. Settings is pinned
+  // to the bottom. Every destination stays one click away.
+  const groups: NavGroup[] = [
+    {
+      label: 'Work',
+      items: [
+        { kind: ['dashboard'], label: 'Dashboard', icon: LayoutGrid, onclick: () => navStore.reset({ kind: 'dashboard' }) },
+        { kind: ['task-list', 'task-detail'], label: 'Board', icon: ClipboardList, onclick: () => navStore.reset({ kind: 'task-list' }) },
+        { kind: ['reviews'], label: 'Reviews', icon: ClipboardCheck, onclick: () => navStore.reset({ kind: 'reviews' }) },
+        { kind: ['logbook'], label: 'Logbook', icon: Archive, onclick: () => navStore.reset({ kind: 'logbook' }) },
+      ],
+    },
+    {
+      label: 'Sessions',
+      items: [
+        { kind: ['chats', 'chat-detail'], label: 'Chats', icon: MessageCircle, onclick: () => navStore.reset({ kind: 'chats' }) },
+        { kind: ['agents', 'agent-detail'], label: 'Agents', icon: UserCircle, onclick: () => navStore.reset({ kind: 'agents' }) },
+      ],
+    },
+    {
+      label: 'Build',
+      items: [
+        { kind: ['project-list', 'project-detail'], label: 'Projects', icon: Folder, onclick: () => navStore.reset({ kind: 'project-list' }) },
+        { kind: ['workflows', 'workflow-detail'], label: 'Workflows', icon: LayoutDashboard, onclick: () => navStore.reset({ kind: 'workflows' }) },
+      ],
+    },
+    {
+      label: 'Data',
+      items: [
+        { kind: ['github'], label: 'GitHub', icon: GitBranch, onclick: () => navStore.reset({ kind: 'github' }) },
+        { kind: ['stats'], label: 'Stats', icon: BarChart3, onclick: () => navStore.reset({ kind: 'stats' }) },
+      ],
+    },
   ]
+
+  const settingsItem: NavItem = {
+    kind: ['settings'],
+    label: 'Settings',
+    icon: Settings,
+    title: 'Settings (Cmd+,)',
+    onclick: () => navStore.reset({ kind: 'settings' }),
+  }
 </script>
+
+{#snippet navButton(item: NavItem)}
+  {@const active = item.kind.includes(navStore.page.kind)}
+  {@const Icon = item.icon}
+  <button
+    type="button"
+    data-part="trigger"
+    onclick={item.onclick}
+    title={item.title ?? item.label}
+    class="flex flex-col items-center gap-0.5 rounded-md px-1 py-1.5 text-[10px] font-medium transition-colors
+      {active
+        ? 'bg-primary-100 text-primary-700 dark:bg-primary-900/40 dark:text-primary-300'
+        : 'text-surface-600 hover:bg-surface-200 dark:text-surface-400 dark:hover:bg-surface-700'}"
+  >
+    <div class="relative">
+      <Icon size={18} />
+      {#if item.label === 'Chats' && interactiveAgentCount > 0}
+        <span class="absolute -right-1 -top-1 flex h-3 w-3 items-center justify-center rounded-full bg-primary-500 text-[8px] font-bold text-white">{interactiveAgentCount}</span>
+      {:else if item.label === 'Agents' && runningAgentCount > 0}
+        <span class="absolute -right-1 -top-1 flex h-3 w-3 items-center justify-center rounded-full bg-success-500 text-[8px] font-bold text-white">{runningAgentCount}</span>
+      {:else if item.label === 'Reviews' && reviewCount > 0}
+        <span class="absolute -right-1 -top-1 flex h-3 w-3 items-center justify-center rounded-full bg-warning-500 text-[8px] font-bold text-white">{reviewCount}</span>
+      {/if}
+    </div>
+    <span class="leading-tight">{item.label}</span>
+  </button>
+{/snippet}
 
 <nav class="flex h-full w-16 flex-col border-r border-surface-200 bg-surface-50 dark:border-surface-700 dark:bg-surface-900">
   <div class="flex shrink-0 items-center justify-center py-3">
     <span class="text-lg font-bold">S</span>
   </div>
   <div class="flex flex-1 flex-col gap-0.5 overflow-y-auto px-1 py-1">
-    {#each items as item}
-      {@const active = item.kind.includes(navStore.page.kind)}
-      <button
-        type="button"
-        data-part="trigger"
-        onclick={item.onclick}
-        title={item.title ?? item.label}
-        class="flex flex-col items-center gap-0.5 rounded-md px-1 py-1.5 text-[10px] font-medium transition-colors
-          {active
-            ? 'bg-primary-100 text-primary-700 dark:bg-primary-900/40 dark:text-primary-300'
-            : 'text-surface-600 hover:bg-surface-200 dark:text-surface-400 dark:hover:bg-surface-700'}"
-      >
-        <div class="relative">
-          {#if item.label === 'Dashboard'}
-            <LayoutGrid size={18} />
-          {:else if item.label === 'Board'}
-            <ClipboardList size={18} />
-          {:else if item.label === 'Projects'}
-            <Folder size={18} />
-          {:else if item.label === 'Chats'}
-            <MessageCircle size={18} />
-            {#if interactiveAgentCount > 0}
-              <span class="absolute -right-1 -top-1 flex h-3 w-3 items-center justify-center rounded-full bg-primary-500 text-[8px] font-bold text-white">{interactiveAgentCount}</span>
-            {/if}
-          {:else if item.label === 'Agents'}
-            <UserCircle size={18} />
-            {#if runningAgentCount > 0}
-              <span class="absolute -right-1 -top-1 flex h-3 w-3 items-center justify-center rounded-full bg-success-500 text-[8px] font-bold text-white">{runningAgentCount}</span>
-            {/if}
-          {:else if item.label === 'GitHub'}
-            <GitBranch size={18} />
-          {:else if item.label === 'Reviews'}
-            <ClipboardCheck size={18} />
-            {#if reviewCount > 0}
-              <span class="absolute -right-1 -top-1 flex h-3 w-3 items-center justify-center rounded-full bg-warning-500 text-[8px] font-bold text-white">{reviewCount}</span>
-            {/if}
-          {:else if item.label === 'Logbook'}
-            <Archive size={18} />
-          {:else if item.label === 'Workflows'}
-            <LayoutDashboard size={18} />
-          {:else if item.label === 'Stats'}
-            <BarChart3 size={18} />
-          {:else if item.label === 'Settings'}
-            <Settings size={18} />
-          {/if}
-        </div>
-        <span class="leading-tight">{item.label}</span>
-      </button>
+    {#each groups as group, gi}
+      {#if gi > 0}
+        <div class="mx-2 mb-0.5 mt-1.5 border-t border-surface-200 dark:border-surface-700"></div>
+      {/if}
+      <span class="px-1 pb-0.5 text-center text-[8px] font-semibold uppercase tracking-wider text-surface-400">{group.label}</span>
+      {#each group.items as item}
+        {@render navButton(item)}
+      {/each}
     {/each}
+  </div>
+  <div class="shrink-0 border-t border-surface-200 px-1 py-1 dark:border-surface-700">
+    {@render navButton(settingsItem)}
   </div>
 </nav>

--- a/frontend/src/components/shell/SideRail.svelte
+++ b/frontend/src/components/shell/SideRail.svelte
@@ -20,7 +20,7 @@
   interface NavItem {
     kind: string[]
     label: string
-    icon: Component
+    icon: Component<{ size?: number }>
     title?: string
     onclick: () => void
   }

--- a/frontend/src/components/shell/SideRail.svelte.test.ts
+++ b/frontend/src/components/shell/SideRail.svelte.test.ts
@@ -50,6 +50,13 @@ describe('SideRail', () => {
     expect(screen.getByText('S')).toBeDefined()
   })
 
+  it('renders the nav group headers', () => {
+    render(SideRail)
+    for (const group of ['Work', 'Sessions', 'Build', 'Data']) {
+      expect(screen.getByText(group)).toBeDefined()
+    }
+  })
+
   it('calls navStore.reset when Board clicked', async () => {
     const { navStore } = await import('../../lib/navigation.svelte.js')
     render(SideRail)


### PR DESCRIPTION
## Motivation

The desktop side rail crammed 11 flat destinations into a 64px column (issue #909), giving no visual structure to scan.

## Implementation information

- Grouped the destinations into four labelled, divider-separated sections — **Work** (Dashboard, Board, Reviews, Logbook), **Sessions** (Chats, Agents), **Build** (Projects, Workflows), **Data** (GitHub, Stats) — and pinned **Settings** to the bottom. Every destination stays reachable in one click (no collapsing).
- Group headers are named to avoid colliding with any item label.
- Refactored icon rendering from a per-label `if/else` chain to a dynamic `{@const Icon = item.icon}` inside a shared `{#snippet navButton}`; the Chats/Agents/Reviews count badges and active-highlight logic are unchanged.
- Added a test asserting the group headers render; existing label/click/badge tests still pass.

Mobile bottom-tab + More structure is untouched (out of scope).

Closes #909

> Changelog: feat(nav): group & reduce sidebar items