### PR TITLE
feat(ui): focus / simplified mode

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -14,6 +14,8 @@
   import AppWarningsBanner from './components/AppWarningsBanner.svelte'
   import PageRouter from './components/PageRouter.svelte'
   import { handleAppKeydown, type AppKeyAction } from './lib/app-keyboard.js'
+  import { focusModeStore } from './lib/focus-mode.svelte.js'
+  import { viewModeStore } from './lib/view-mode.svelte.js'
   import {
     startAppLifecycle,
     type ProviderHealth,
@@ -25,7 +27,16 @@
     openNewTask: () => { commandPaletteOpen = false; dialogOpen = true },
     openNewProject: () => { commandPaletteOpen = false; projectDialogOpen = true },
     openKeyboardHelp: () => { commandPaletteOpen = false; helpOpen = true },
+    toggleFocus: () => {
+      commandPaletteOpen = false
+      focusModeStore.toggle()
+      if (focusModeStore.enabled) viewModeStore.set('list')
+    },
   }
+
+  // Focus mode persists across sessions (localStorage) but the board view mode
+  // does not (sessionStorage), so re-apply the list default once on startup.
+  if (focusModeStore.enabled) viewModeStore.set('list')
 
   let degradedWarnings = $state<DegradedWarning[]>([])
   let providerHealth = $state<Record<string, ProviderHealth>>({})

--- a/frontend/src/components/shell/SideRail.svelte
+++ b/frontend/src/components/shell/SideRail.svelte
@@ -1,9 +1,15 @@
 <script lang="ts">
-  import { LayoutGrid, ClipboardList, Folder, MessageCircle, UserCircle, GitBranch, ClipboardCheck, LayoutDashboard, BarChart3, Settings, Archive } from '@lucide/svelte'
+  import { LayoutGrid, ClipboardList, Folder, MessageCircle, UserCircle, GitBranch, ClipboardCheck, LayoutDashboard, BarChart3, Settings, Archive, ChevronDown, ChevronUp } from '@lucide/svelte'
   import type { Component } from 'svelte'
   import { navStore } from '../../lib/navigation.svelte.js'
   import { taskStore } from '../../stores/tasks.svelte.js'
   import { agentStore } from '../../stores/agents.svelte.js'
+  import { focusModeStore } from '../../lib/focus-mode.svelte.js'
+
+  // Focus mode collapses the rail to the core destinations; "More" expands the
+  // full grouped nav so advanced views stay reachable.
+  const PRIMARY_LABELS = ['Board', 'Reviews', 'Chats', 'Agents']
+  let moreExpanded = $state(false)
 
   const interactiveAgentCount = $derived(
     agentStore.list.filter(a => a.mode === 'interactive' && (a.state === 'running' || a.state === 'paused')).length
@@ -73,6 +79,17 @@
     title: 'Settings (Cmd+,)',
     onclick: () => navStore.reset({ kind: 'settings' }),
   }
+
+  const primaryItems = $derived(
+    groups.flatMap((g) => g.items).filter((i) => PRIMARY_LABELS.includes(i.label)),
+  )
+  // Minimal rail only when focus mode is on and the user hasn't expanded "More".
+  const minimal = $derived(focusModeStore.enabled && !moreExpanded)
+
+  // Collapse "More" whenever focus mode turns off, so re-enabling starts minimal.
+  $effect(() => {
+    if (!focusModeStore.enabled) moreExpanded = false
+  })
 </script>
 
 {#snippet navButton(item: NavItem)}
@@ -107,15 +124,41 @@
     <span class="text-lg font-bold">S</span>
   </div>
   <div class="flex flex-1 flex-col gap-0.5 overflow-y-auto px-1 py-1">
-    {#each groups as group, gi}
-      {#if gi > 0}
-        <div class="mx-2 mb-0.5 mt-1.5 border-t border-surface-200 dark:border-surface-700"></div>
-      {/if}
-      <span class="px-1 pb-0.5 text-center text-[8px] font-semibold uppercase tracking-wider text-surface-400">{group.label}</span>
-      {#each group.items as item}
+    {#if minimal}
+      {#each primaryItems as item}
         {@render navButton(item)}
       {/each}
-    {/each}
+      <button
+        type="button"
+        onclick={() => (moreExpanded = true)}
+        title="More"
+        class="flex flex-col items-center gap-0.5 rounded-md px-1 py-1.5 text-[10px] font-medium text-surface-600 transition-colors hover:bg-surface-200 dark:text-surface-400 dark:hover:bg-surface-700"
+      >
+        <ChevronDown size={18} />
+        <span class="leading-tight">More</span>
+      </button>
+    {:else}
+      {#each groups as group, gi}
+        {#if gi > 0}
+          <div class="mx-2 mb-0.5 mt-1.5 border-t border-surface-200 dark:border-surface-700"></div>
+        {/if}
+        <span class="px-1 pb-0.5 text-center text-[8px] font-semibold uppercase tracking-wider text-surface-400">{group.label}</span>
+        {#each group.items as item}
+          {@render navButton(item)}
+        {/each}
+      {/each}
+      {#if focusModeStore.enabled}
+        <button
+          type="button"
+          onclick={() => (moreExpanded = false)}
+          title="Less"
+          class="mt-1.5 flex flex-col items-center gap-0.5 rounded-md px-1 py-1.5 text-[10px] font-medium text-surface-600 transition-colors hover:bg-surface-200 dark:text-surface-400 dark:hover:bg-surface-700"
+        >
+          <ChevronUp size={18} />
+          <span class="leading-tight">Less</span>
+        </button>
+      {/if}
+    {/if}
   </div>
   <div class="shrink-0 border-t border-surface-200 px-1 py-1 dark:border-surface-700">
     {@render navButton(settingsItem)}

--- a/frontend/src/components/shell/SideRail.svelte.test.ts
+++ b/frontend/src/components/shell/SideRail.svelte.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
+import { tick } from 'svelte'
 import { render, screen, fireEvent, cleanup } from '@testing-library/svelte'
 
 vi.mock('../../lib/navigation.svelte.js', () => ({
@@ -20,10 +21,17 @@ vi.mock('../../stores/agents.svelte.js', () => ({
   },
 }))
 
+// Use the real focus-mode store (a $state-backed singleton) so the tests
+// exercise genuine cross-component reactivity, not a frozen mock.
+const { focusModeStore } = await import('../../lib/focus-mode.svelte.js')
+
 const SideRail = (await import('./SideRail.svelte')).default
 
 describe('SideRail', () => {
-  afterEach(() => cleanup())
+  afterEach(() => {
+    cleanup()
+    focusModeStore.set(false)
+  })
 
   it('renders nav element', () => {
     render(SideRail)
@@ -55,6 +63,51 @@ describe('SideRail', () => {
     for (const group of ['Work', 'Sessions', 'Build', 'Data']) {
       expect(screen.getByText(group)).toBeDefined()
     }
+  })
+
+  it('in focus mode shows only primary items + More, hiding the rest', () => {
+    focusModeStore.set(true)
+    render(SideRail)
+    for (const label of ['Board', 'Reviews', 'Chats', 'Agents']) {
+      expect(screen.getByText(label)).toBeDefined()
+    }
+    expect(screen.getByText('More')).toBeDefined()
+    // Non-primary destinations and group headers are tucked away until expanded.
+    expect(screen.queryByText('Dashboard')).toBeNull()
+    expect(screen.queryByText('Stats')).toBeNull()
+    expect(screen.queryByText('Work')).toBeNull()
+  })
+
+  it('expands to the full grouped nav when More is clicked', async () => {
+    focusModeStore.set(true)
+    render(SideRail)
+    await fireEvent.click(screen.getByText('More'))
+    expect(screen.getByText('Dashboard')).toBeDefined()
+    expect(screen.getByText('Stats')).toBeDefined()
+    expect(screen.getByText('Less')).toBeDefined()
+  })
+
+  it('collapses to minimal reactively when focus mode is enabled after mount', async () => {
+    render(SideRail)
+    expect(screen.getByText('Dashboard')).toBeDefined() // full nav while off
+    focusModeStore.set(true)
+    await tick()
+    expect(screen.queryByText('Dashboard')).toBeNull() // collapsed without remount
+    expect(screen.getByText('More')).toBeDefined()
+  })
+
+  it('resets the More expansion when focus mode is turned off then on', async () => {
+    focusModeStore.set(true)
+    render(SideRail)
+    await fireEvent.click(screen.getByText('More')) // expand
+    expect(screen.getByText('Dashboard')).toBeDefined()
+    focusModeStore.set(false)
+    await tick()
+    focusModeStore.set(true)
+    await tick()
+    // Re-enabling starts minimal again, not stuck expanded.
+    expect(screen.queryByText('Dashboard')).toBeNull()
+    expect(screen.getByText('More')).toBeDefined()
   })
 
   it('calls navStore.reset when Board clicked', async () => {

--- a/frontend/src/lib/focus-mode.svelte.test.ts
+++ b/frontend/src/lib/focus-mode.svelte.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { focusModeStore } from './focus-mode.svelte.js'
 
 describe('focusModeStore', () => {
@@ -7,8 +7,18 @@ describe('focusModeStore', () => {
     focusModeStore.set(false)
   })
 
-  it('defaults to disabled', () => {
-    expect(focusModeStore.enabled).toBe(false)
+  it('initializes disabled when storage is empty', async () => {
+    vi.resetModules()
+    localStorage.removeItem('focusMode')
+    const { focusModeStore: fresh } = await import('./focus-mode.svelte.js')
+    expect(fresh.enabled).toBe(false)
+  })
+
+  it('initializes enabled when storage says so', async () => {
+    vi.resetModules()
+    localStorage.setItem('focusMode', 'true')
+    const { focusModeStore: fresh } = await import('./focus-mode.svelte.js')
+    expect(fresh.enabled).toBe(true)
   })
 
   it('set() updates the flag and persists', () => {

--- a/frontend/src/lib/focus-mode.svelte.test.ts
+++ b/frontend/src/lib/focus-mode.svelte.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { focusModeStore } from './focus-mode.svelte.js'
+
+describe('focusModeStore', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    focusModeStore.set(false)
+  })
+
+  it('defaults to disabled', () => {
+    expect(focusModeStore.enabled).toBe(false)
+  })
+
+  it('set() updates the flag and persists', () => {
+    focusModeStore.set(true)
+    expect(focusModeStore.enabled).toBe(true)
+    expect(localStorage.getItem('focusMode')).toBe('true')
+  })
+
+  it('toggle() flips the flag', () => {
+    expect(focusModeStore.enabled).toBe(false)
+    focusModeStore.toggle()
+    expect(focusModeStore.enabled).toBe(true)
+    focusModeStore.toggle()
+    expect(focusModeStore.enabled).toBe(false)
+  })
+})

--- a/frontend/src/lib/focus-mode.svelte.ts
+++ b/frontend/src/lib/focus-mode.svelte.ts
@@ -1,0 +1,40 @@
+// Focus mode — a persisted UI preference that trades power-user density for a
+// clean, first-time-friendly surface (minimal sidebar, list-first board).
+const STORAGE_KEY = 'focusMode'
+
+function loadStored(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true'
+  } catch {
+    // localStorage unavailable (SSR / restricted context)
+    return false
+  }
+}
+
+function createFocusModeStore() {
+  let enabled = $state<boolean>(loadStored())
+
+  function persist(): void {
+    try {
+      localStorage.setItem(STORAGE_KEY, String(enabled))
+    } catch {
+      // ignore
+    }
+  }
+
+  return {
+    get enabled(): boolean {
+      return enabled
+    },
+    set(v: boolean): void {
+      enabled = v
+      persist()
+    },
+    toggle(): void {
+      enabled = !enabled
+      persist()
+    },
+  }
+}
+
+export const focusModeStore = createFocusModeStore()

--- a/frontend/src/lib/palette-commands.test.ts
+++ b/frontend/src/lib/palette-commands.test.ts
@@ -33,6 +33,7 @@ function makeCtx(overrides: Partial<PaletteCtx> = {}): PaletteCtx {
     openNewTask: vi.fn(),
     openNewProject: vi.fn(),
     openKeyboardHelp: vi.fn(),
+    toggleFocus: vi.fn(),
     ...overrides,
   }
 }
@@ -90,6 +91,15 @@ describe('buildCommands', () => {
       expect(cmd.shortcut).toBe('⌘/')
       cmd.run()
       expect(openKeyboardHelp).toHaveBeenCalled()
+    })
+
+    it('includes toggle-focus action', () => {
+      const toggleFocus = vi.fn()
+      const cmds = buildCommands(makeCtx({ toggleFocus }))
+      const cmd = cmds.find(c => c.id === 'action:toggle-focus')!
+      expect(cmd.title).toBe('Toggle Focus Mode')
+      cmd.run()
+      expect(toggleFocus).toHaveBeenCalled()
     })
   })
 

--- a/frontend/src/lib/palette-commands.ts
+++ b/frontend/src/lib/palette-commands.ts
@@ -29,6 +29,7 @@ export interface PaletteCtx {
   openNewTask: () => void
   openNewProject: () => void
   openKeyboardHelp: () => void
+  toggleFocus: () => void
 }
 
 const ACTIVE_AGENT_STATES = new Set(['running', 'waiting', 'errored'])
@@ -62,6 +63,13 @@ export function buildCommands(ctx: PaletteCtx): Command[] {
     section: 'action',
     shortcut: '⌘/',
     run: ctx.openKeyboardHelp,
+  })
+  cmds.push({
+    id: 'action:toggle-focus',
+    title: 'Toggle Focus Mode',
+    section: 'action',
+    keywords: ['focus', 'simplify', 'simple', 'minimal'],
+    run: ctx.toggleFocus,
   })
 
   // --- PAGES ---

--- a/frontend/src/pages/Settings.svelte
+++ b/frontend/src/pages/Settings.svelte
@@ -6,6 +6,14 @@
   import LoggingPanel from '../components/settings/LoggingPanel.svelte'
   import TodoistPanel from '../components/settings/TodoistPanel.svelte'
   import RenovatePanel from '../components/settings/RenovatePanel.svelte'
+  import { focusModeStore } from '../lib/focus-mode.svelte.js'
+  import { viewModeStore } from '../lib/view-mode.svelte.js'
+
+  function setFocusMode(on: boolean) {
+    focusModeStore.set(on)
+    // Focus mode leads with the simpler list view.
+    if (on) viewModeStore.set('list')
+  }
 
   type ColorScheme = 'system' | 'light' | 'dark'
 
@@ -168,6 +176,18 @@
       </select>
       <span class="text-xs text-surface-400">Applied immediately, no save needed</span>
     </div>
+    <label class="mt-4 flex items-start gap-3">
+      <input
+        type="checkbox"
+        class="mt-0.5 h-4 w-4 accent-primary-500"
+        checked={focusModeStore.enabled}
+        onchange={(e) => setFocusMode((e.target as HTMLInputElement).checked)}
+      />
+      <span class="flex flex-col">
+        <span class="text-sm font-medium">Focus mode</span>
+        <span class="text-xs text-surface-400">Cleaner, minimal surface — collapses the sidebar and leads with the list view. Advanced views stay reachable via “More”.</span>
+      </span>
+    </label>
   </div>
 
   {#if settings}


### PR DESCRIPTION
## Motivation

The app reads as a power tool; a simpler, first-time-friendly surface was buried under dense chrome (issue #908). Depends on the now-merged status collapse (#907) and nav grouping (#909).

## Implementation information

- New persisted `focusModeStore` (`lib/focus-mode.svelte.ts`, localStorage-backed `$state` singleton).
- **(a) List-first board**: enabling Focus sets the board to the list view. Because focus persists in localStorage but the view mode lives in sessionStorage, `App.svelte` re-applies the list default once on startup so a returning focus-mode user still lands on the list.
- **(b) Core statuses**: already delivered by #907 — the board renders the six columns and pickers offer the core set; no further change needed.
- **(c) Minimal sidebar**: in Focus mode the side rail collapses to **Board · Reviews · Chats · Agents** plus a **More** expander that reveals the full grouped nav (and a **Less** to collapse). `More` resets whenever Focus is turned off, so re-enabling always starts minimal.
- Toggle from **Settings → Appearance** or the command palette (**Toggle Focus Mode**).
- Tests cover the store, the minimal/expand rail, post-mount reactivity, the More-reset, and the palette command.

## Open questions / scope

- **(d) Agent view leads with the Shell step-list** is intentionally deferred to #915 ("simplify agent detail layout"), which owns that surface. This PR delivers the toggle, list-first default, and minimal sidebar; advanced views stay reachable.

Closes #908

> Changelog: feat(ui): focus / simplified mode