### PR TITLE
fix(ui): dedupe page titles & header labels

### DIFF
--- a/frontend/e2e/chat.spec.ts
+++ b/frontend/e2e/chat.spec.ts
@@ -18,8 +18,7 @@ import { test, expect, type Page } from '@playwright/test'
 async function goToChats(page: Page) {
   await page.goto('/')
   await page.locator('[data-part="trigger"]', { hasText: /Chats/ }).click()
-  // Sidebar nav also has an "h2 Chats" heading, so scope to the main region.
-  await expect(page.getByRole('main').getByRole('heading', { name: 'Chats' })).toBeVisible()
+  await expect(page.locator('h2', { hasText: 'Chats' })).toBeVisible()
 }
 
 test.describe('Chat list', () => {

--- a/frontend/e2e/provider-smoke.spec.ts
+++ b/frontend/e2e/provider-smoke.spec.ts
@@ -13,7 +13,7 @@ import { providerMatrix, selectedProviders } from './lib/providers.js'
 async function goToSettings(page: Page) {
   await page.goto('/')
   await page.locator('[data-part="trigger"]', { hasText: /Settings/ }).click()
-  await expect(page.locator('h1', { hasText: 'Settings' })).toBeVisible()
+  await expect(page.locator('h2', { hasText: 'Settings' })).toBeVisible()
   await expect(page.locator('#agent-provider')).toBeVisible()
 }
 

--- a/frontend/e2e/screenshots.spec.ts
+++ b/frontend/e2e/screenshots.spec.ts
@@ -78,7 +78,7 @@ for (const theme of ['light', 'dark'] as const) {
     test('dashboard', async ({ page }) => {
       await page.goto('/')
       await page.locator('[data-part="trigger"]', { hasText: /Dashboard/ }).click()
-      await page.locator('h1', { hasText: 'Dashboard' }).waitFor()
+      await page.locator('h2', { hasText: 'Dashboard' }).waitFor()
       await shot(page, theme, 'dashboard')
     })
 
@@ -176,14 +176,14 @@ for (const theme of ['light', 'dark'] as const) {
     test('chats', async ({ page }) => {
       await page.goto('/')
       await page.locator('[data-part="trigger"]', { hasText: /Chats/ }).click()
-      await page.getByRole('main').getByRole('heading', { name: 'Chats' }).waitFor()
+      await page.locator('h2', { hasText: 'Chats' }).waitFor()
       await shot(page, theme, 'chats')
     })
 
     test('chats-new-chat-dialog', async ({ page }) => {
       await page.goto('/')
       await page.locator('[data-part="trigger"]', { hasText: /Chats/ }).click()
-      await page.getByRole('main').getByRole('heading', { name: 'Chats' }).waitFor()
+      await page.locator('h2', { hasText: 'Chats' }).waitFor()
       await page.getByRole('main').getByRole('button', { name: /New Chat/ }).first().click()
       await page.getByRole('dialog').waitFor()
       await shot(page, theme, 'chats-new-chat-dialog')
@@ -192,7 +192,7 @@ for (const theme of ['light', 'dark'] as const) {
     test('chat-detail', async ({ page }) => {
       await page.goto('/')
       await page.locator('[data-part="trigger"]', { hasText: /Chats/ }).click()
-      await page.getByRole('main').getByRole('heading', { name: 'Chats' }).waitFor()
+      await page.locator('h2', { hasText: 'Chats' }).waitFor()
       // Open the first existing chat session if present
       const firstChat = page.getByRole('main').getByRole('listitem').first()
       if (await firstChat.count() > 0 && await firstChat.isVisible()) {
@@ -397,7 +397,7 @@ for (const theme of ['light', 'dark'] as const) {
     test('settings', async ({ page }) => {
       await page.goto('/')
       await page.locator('[data-part="trigger"]', { hasText: /Settings/ }).click()
-      await page.locator('h1', { hasText: 'Settings' }).waitFor()
+      await page.locator('h2', { hasText: 'Settings' }).waitFor()
       await shot(page, theme, 'settings')
     })
   })

--- a/frontend/e2e/settings-provider.spec.ts
+++ b/frontend/e2e/settings-provider.spec.ts
@@ -4,7 +4,7 @@ import { selectedProviders } from './lib/providers.js'
 async function goToSettings(page: Page) {
   await page.goto('/')
   await page.locator('[data-part="trigger"]', { hasText: /Settings/ }).click()
-  await expect(page.locator('h1', { hasText: 'Settings' })).toBeVisible()
+  await expect(page.locator('h2', { hasText: 'Settings' })).toBeVisible()
   await expect(page.locator('#agent-provider')).toBeVisible()
 }
 

--- a/frontend/e2e/tasks.spec.ts
+++ b/frontend/e2e/tasks.spec.ts
@@ -77,7 +77,7 @@ test.describe('Task List', () => {
   test('shows app bar with Tasks title and New Task button', async ({ page }) => {
     await goToTaskList(page)
 
-    await expect(page.locator('h2', { hasText: 'Tasks' })).toBeVisible()
+    await expect(page.locator('h2', { hasText: 'Board' })).toBeVisible()
     await expect(page.getByText('+ New Task')).toBeVisible()
   })
 
@@ -142,7 +142,7 @@ test.describe('Task Detail', () => {
 
     await page.getByText('Back to tasks').click()
 
-    await expect(page.locator('h2', { hasText: 'Tasks' })).toBeVisible()
+    await expect(page.locator('h2', { hasText: 'Board' })).toBeVisible()
     await expect(page.getByText('Implement auth middleware')).toBeVisible()
   })
 
@@ -246,7 +246,7 @@ test.describe('Navigation Rail', () => {
     const navTrigger = page.locator('[data-part="trigger"]', { hasText: /Board/ })
     await navTrigger.click()
 
-    await expect(page.locator('h2', { hasText: 'Tasks' })).toBeVisible()
+    await expect(page.locator('h2', { hasText: 'Board' })).toBeVisible()
   })
 })
 

--- a/frontend/e2e/tasks.spec.ts
+++ b/frontend/e2e/tasks.spec.ts
@@ -74,7 +74,7 @@ test.describe('Task List', () => {
     await expect(page.getByRole('heading', { name: 'Done' })).not.toBeVisible()
   })
 
-  test('shows app bar with Tasks title and New Task button', async ({ page }) => {
+  test('shows app bar with Board title and New Task button', async ({ page }) => {
     await goToTaskList(page)
 
     await expect(page.locator('h2', { hasText: 'Board' })).toBeVisible()

--- a/frontend/src/lib/keyboard.svelte.ts
+++ b/frontend/src/lib/keyboard.svelte.ts
@@ -22,7 +22,7 @@ export const SHORTCUTS: { scope: string; label: string; shortcuts: Shortcut[] }[
   },
   {
     scope: 'task-list',
-    label: 'Task Board',
+    label: 'Board',
     shortcuts: [
       { keys: 'J  /  ↓', description: 'Move focus down' },
       { keys: 'K  /  ↑', description: 'Move focus up' },
@@ -65,7 +65,7 @@ export const SHORTCUTS: { scope: string; label: string; shortcuts: Shortcut[] }[
     scope: 'global',
     label: 'Quick Navigation',
     shortcuts: [
-      { keys: 'G  I', description: 'All Tasks' },
+      { keys: 'G  I', description: 'Board' },
       { keys: 'G  A', description: 'Active (In Progress)' },
       { keys: 'G  P', description: 'Projects' },
       { keys: 'G  S', description: 'Settings' },

--- a/frontend/src/lib/navigation.svelte.test.ts
+++ b/frontend/src/lib/navigation.svelte.test.ts
@@ -132,7 +132,7 @@ describe('NavStore', () => {
   describe('pageTitle', () => {
     it.each([
       [{ kind: 'dashboard' }, 'Dashboard'],
-      [{ kind: 'task-list' }, 'Tasks'],
+      [{ kind: 'task-list' }, 'Board'],
       [{ kind: 'task-detail', taskId: 't1' }, 'Task Detail'],
       [{ kind: 'project-list' }, 'Projects'],
       [{ kind: 'project-detail', projectId: 'p1' }, 'Project Detail'],

--- a/frontend/src/lib/navigation.svelte.ts
+++ b/frontend/src/lib/navigation.svelte.ts
@@ -60,7 +60,7 @@ class NavStore {
     const p = this.page
     switch (p.kind) {
       case 'dashboard': return 'Dashboard'
-      case 'task-list': return 'Tasks'
+      case 'task-list': return 'Board'
       case 'task-detail': return 'Task Detail'
       case 'project-list': return 'Projects'
       case 'project-detail': return 'Project Detail'

--- a/frontend/src/lib/palette-commands.ts
+++ b/frontend/src/lib/palette-commands.ts
@@ -75,7 +75,7 @@ export function buildCommands(ctx: PaletteCtx): Command[] {
   // --- PAGES ---
   const pageEntries: { id: string; title: string; shortcut?: string; page: Page }[] = [
     { id: 'page:dashboard', title: 'Dashboard', shortcut: '⌘1', page: { kind: 'dashboard' } },
-    { id: 'page:task-list', title: 'Tasks', shortcut: '⌘2', page: { kind: 'task-list' } },
+    { id: 'page:task-list', title: 'Board', shortcut: '⌘2', page: { kind: 'task-list' } },
     { id: 'page:project-list', title: 'Projects', shortcut: '⌘3', page: { kind: 'project-list' } },
     { id: 'page:agents', title: 'Agents', shortcut: '⌘4', page: { kind: 'agents' } },
     { id: 'page:github', title: 'GitHub', shortcut: '⌘5', page: { kind: 'github' } },

--- a/frontend/src/pages/ChatList.svelte
+++ b/frontend/src/pages/ChatList.svelte
@@ -36,8 +36,7 @@
 </script>
 
 <div class="flex flex-col gap-3 p-4 md:gap-4 md:p-6">
-  <div class="flex items-center justify-between">
-    <h2 class="text-lg font-semibold text-surface-900 dark:text-surface-100">Chats</h2>
+  <div class="flex items-center justify-end">
     <button
       type="button"
       class="rounded-lg bg-primary-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-600"

--- a/frontend/src/pages/ChatList.svelte.test.ts
+++ b/frontend/src/pages/ChatList.svelte.test.ts
@@ -60,9 +60,9 @@ describe('ChatList', () => {
     vi.restoreAllMocks()
   })
 
-  it('renders Chats heading', () => {
+  it('renders the new-chat action', () => {
     render(ChatList, { props: { onselect: vi.fn() } })
-    expect(screen.getByText('Chats')).toBeDefined()
+    expect(screen.getByText('+ New Chat')).toBeDefined()
   })
 
   it('shows + New Chat button', () => {

--- a/frontend/src/pages/Dashboard.svelte
+++ b/frontend/src/pages/Dashboard.svelte
@@ -58,8 +58,6 @@
 </script>
 
 <div class="flex flex-col gap-4 p-4 md:gap-6 md:p-6">
-  <h1 class="text-2xl font-bold">Dashboard</h1>
-
   <!-- Stats row -->
   <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
     <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">

--- a/frontend/src/pages/Dashboard.test.ts
+++ b/frontend/src/pages/Dashboard.test.ts
@@ -88,9 +88,9 @@ describe('Dashboard', () => {
     cleanup()
   })
 
-  it('renders dashboard heading', () => {
+  it('renders the task status breakdown', () => {
     render(Dashboard, { props: { onviewagent: vi.fn() } })
-    expect(screen.getByText('Dashboard')).toBeTruthy()
+    expect(screen.getByText('Task Status')).toBeTruthy()
   })
 
   it('shows stat cards with correct counts', () => {

--- a/frontend/src/pages/Logbook.svelte
+++ b/frontend/src/pages/Logbook.svelte
@@ -80,7 +80,6 @@
 <div class="flex min-h-0 flex-1 flex-col overflow-hidden">
   <!-- Header -->
   <div class="flex items-center gap-3 border-b border-surface-200 px-4 py-3 dark:border-surface-700">
-    <h1 class="text-lg font-semibold">Logbook</h1>
     <span class="text-sm text-surface-400">{logbookTasks.length} closed</span>
   </div>
 

--- a/frontend/src/pages/Settings.svelte
+++ b/frontend/src/pages/Settings.svelte
@@ -131,8 +131,7 @@
 </script>
 
 <div class="flex flex-col gap-4 p-4 md:gap-6 md:p-6">
-  <div class="flex items-center justify-between">
-    <h1 class="text-2xl font-bold">Settings</h1>
+  <div class="flex items-center justify-end">
     <div class="flex items-center gap-2">
       {#if successMsg}
         <span class="text-sm text-success-500">{successMsg}</span>

--- a/frontend/src/pages/Settings.svelte.test.ts
+++ b/frontend/src/pages/Settings.svelte.test.ts
@@ -93,10 +93,10 @@ describe('Settings', () => {
     })
   })
 
-  it('renders Settings heading', () => {
+  it('renders the appearance section', () => {
     mockGetSettings.mockReturnValue(new Promise(() => {}))
     render(Settings)
-    expect(screen.getByText('Settings')).toBeDefined()
+    expect(screen.getByText('Appearance')).toBeDefined()
   })
 
   it('renders Agent Defaults section after load', async () => {

--- a/frontend/src/pages/Stats.svelte
+++ b/frontend/src/pages/Stats.svelte
@@ -52,8 +52,7 @@
 </script>
 
 <div class="flex flex-col gap-4 p-4 md:gap-6 md:p-6">
-  <div class="flex items-center justify-between">
-    <h1 class="text-2xl font-bold">Stats</h1>
+  <div class="flex items-center justify-end">
     <button
       type="button"
       class="rounded-lg bg-surface-200 px-3 py-1.5 text-sm font-medium hover:bg-surface-300 dark:bg-surface-700 dark:hover:bg-surface-600"

--- a/frontend/src/pages/Stats.svelte.test.ts
+++ b/frontend/src/pages/Stats.svelte.test.ts
@@ -58,9 +58,9 @@ describe('Stats', () => {
     cleanup()
   })
 
-  it('renders Stats heading', () => {
+  it('renders the page with a refresh control', () => {
     render(Stats, { props: {} })
-    expect(screen.getByText('Stats')).toBeDefined()
+    expect(screen.getByText('Refresh')).toBeDefined()
   })
 
   it('shows period tabs', () => {

--- a/frontend/src/pages/WorkflowList.svelte
+++ b/frontend/src/pages/WorkflowList.svelte
@@ -15,10 +15,6 @@
 </script>
 
 <div class="flex flex-col gap-3 p-4 md:gap-4 md:p-6">
-  <div class="flex items-center justify-between">
-    <h2 class="text-lg font-semibold">Workflows</h2>
-  </div>
-
   {#if workflowStore.loading && workflowStore.list.length === 0}
     <p class="text-sm opacity-60">Loading workflows...</p>
   {:else if workflowStore.error}

--- a/frontend/src/pages/WorkflowList.svelte.test.ts
+++ b/frontend/src/pages/WorkflowList.svelte.test.ts
@@ -38,9 +38,9 @@ describe('WorkflowList', () => {
     vi.restoreAllMocks()
   })
 
-  it('renders Workflows heading', () => {
+  it('renders the empty state when there are no workflows', () => {
     render(WorkflowList, { props: { onselect: vi.fn() } })
-    expect(screen.getByText('Workflows')).toBeDefined()
+    expect(screen.getByText('No workflows found')).toBeDefined()
   })
 
   it('shows loading message when loading with empty list', () => {

--- a/frontend/src/pages/WorkflowList.svelte.test.ts
+++ b/frontend/src/pages/WorkflowList.svelte.test.ts
@@ -38,9 +38,9 @@ describe('WorkflowList', () => {
     vi.restoreAllMocks()
   })
 
-  it('renders the empty state when there are no workflows', () => {
+  it('loads workflows on mount', () => {
     render(WorkflowList, { props: { onselect: vi.fn() } })
-    expect(screen.getByText('No workflows found')).toBeDefined()
+    expect(workflowStore.load).toHaveBeenCalled()
   })
 
   it('shows loading message when loading with empty list', () => {


### PR DESCRIPTION
## Motivation

Most pages rendered their name twice — once in the top bar (`navStore.pageTitle`) and again as an in-content heading (issue #910). Separately, the sidebar/tab labelled the task board "Board" while its header said "Tasks".

## Implementation information

- Removed the redundant in-body title headings on **Dashboard, Chats, Stats, Settings, Workflows, and Logbook** — the desktop top bar (`AppShell` `<h2>`) and mobile bar (`MobileAppBar` `<h1>`) already render the title for every page. Header rows that kept an action button switched `justify-between → justify-end`; WorkflowList's now-empty wrapper was dropped entirely.
- Reconciled **"Board" vs "Tasks"**: `pageTitle` for `task-list` is now "Board", matching the rail label, bottom tab, and `activeTab`. Updated the command-palette page command and the keyboard-help scope/shortcut labels to "Board" too.
- Updated the page unit tests to assert a stable in-page element instead of the removed title, and the e2e specs (`tasks`, `chat`, `screenshots`, `settings-provider`, `provider-smoke`) to target the top-bar `<h2>` title.

A pre-PR adversarial review caught that several e2e specs still waited on the removed in-body headings and that the Logbook page title was missed — both fixed here.

## Open questions / scope

- **Projects** page (duplicate title + "+ New Project" button vs the top-bar primary action) is intentionally left to #914, which owns "fix duplicate header" for projects.
- **Reviews** page's `<h3>Reviews</h3>` pane label is left to #911 ("resolve Reviews naming collision"), which owns that surface.

Closes #910

> Changelog: fix(ui): dedupe page titles & header labels