### PR TITLE
fix(ui): resolve "Reviews" naming collision

### DIFF
--- a/frontend/e2e/screenshots.spec.ts
+++ b/frontend/e2e/screenshots.spec.ts
@@ -319,7 +319,7 @@ for (const theme of ['light', 'dark'] as const) {
 
     test('github-reviews', async ({ page }) => {
       await goToGitHub(page)
-      await page.getByRole('button', { name: /^Reviews/ }).click()
+      await page.getByRole('button', { name: /^PR Reviews/ }).click()
       await page.getByText('feat(orchestrator): multi-agent task routing').waitFor()
       await shot(page, theme, 'github-reviews')
     })

--- a/frontend/src/pages/GitHub.svelte
+++ b/frontend/src/pages/GitHub.svelte
@@ -77,7 +77,7 @@
 
   const tabs: { id: Tab; label: string; count: () => number }[] = [
     { id: 'my-prs', label: 'My PRs', count: () => reviewStore.createdByMe.length },
-    { id: 'reviews', label: 'Reviews', count: () => reviewStore.reviewRequested.length },
+    { id: 'reviews', label: 'PR Reviews', count: () => reviewStore.reviewRequested.length },
     { id: 'renovate', label: 'Renovate', count: () => renovateStore.count },
     { id: 'issues', label: 'Issues', count: () => issueStore.count },
   ]

--- a/frontend/src/pages/GitHub.svelte.test.ts
+++ b/frontend/src/pages/GitHub.svelte.test.ts
@@ -98,10 +98,10 @@ describe('GitHub', () => {
     cleanup()
   })
 
-  it('renders tab bar with My PRs, Reviews, Renovate, Issues', () => {
+  it('renders tab bar with My PRs, PR Reviews, Renovate, Issues', () => {
     render(GitHub, { props: {} })
     expect(screen.getByText('My PRs')).toBeDefined()
-    expect(screen.getByText('Reviews')).toBeDefined()
+    expect(screen.getByText('PR Reviews')).toBeDefined()
     expect(screen.getByText('Renovate')).toBeDefined()
     expect(screen.getByText('Issues')).toBeDefined()
   })
@@ -122,9 +122,9 @@ describe('GitHub', () => {
     expect(mockRenovateLoad).toHaveBeenCalled()
   })
 
-  it('switches to Reviews tab', async () => {
+  it('switches to PR Reviews tab', async () => {
     render(GitHub, { props: {} })
-    await fireEvent.click(screen.getByText('Reviews'))
+    await fireEvent.click(screen.getByText('PR Reviews'))
     expect(screen.getByText('No pending review requests')).toBeDefined()
   })
 


### PR DESCRIPTION
## Motivation

Two distinct surfaces were both labelled "Reviews" (issue #911): the top-level nav "Reviews" (plan / test-plan review queue) and the GitHub page's "Reviews" tab (PR review requests). Same word, unrelated features.

## Implementation information

- Renamed the GitHub page's tab label "Reviews" → **"PR Reviews"** (the tab id stays `reviews`, so active-state, deep-links, and the count badge are unaffected — the label is render-only). This is the maintainer's own suggested option and the most surgical fix.
- Updated the GitHub unit tests (tab assertion + click target) and the `github-reviews` Playwright screenshot spec's anchored selector (`/^Reviews/` → `/^PR Reviews/`).

The remaining "Reviews" strings (side rail, bottom tab, more-sheet, command palette, keyboard help, page title, and the plan-review page's own `<h3>`) all refer to the **single** `kind: 'reviews'` plan-review surface, so no two *distinct* surfaces share the bare label anymore.

Closes #911

> Changelog: fix(ui): resolve "Reviews" naming collision