### PR TITLE
feat(board): default to list, handle empty columns

### DIFF
--- a/frontend/e2e/history.spec.ts
+++ b/frontend/e2e/history.spec.ts
@@ -123,6 +123,7 @@ test.describe('TaskDetail agent history', () => {
     await page.goto('/')
     // Navigate into the fixture task via the Board → task card flow.
     await page.locator('[data-part="trigger"]', { hasText: /Board/ }).click()
+    await page.getByRole('button', { name: 'Board view' }).click()
     await page.locator('button:has(h3)', { hasText: 'history fixture task' }).first().click()
 
     // Agent history section must be present with the fixture agent.

--- a/frontend/e2e/provider-smoke.spec.ts
+++ b/frontend/e2e/provider-smoke.spec.ts
@@ -28,6 +28,7 @@ test.describe('Provider smoke: board', { tag: '@integration' }, () => {
     test(`board loads [${spec.provider}]`, async ({ page }) => {
       await page.goto('/')
       await page.locator('[data-part="trigger"]', { hasText: /Board/ }).click()
+      await page.getByRole('button', { name: 'Board view' }).click()
       await page.waitForSelector('button:has(h3), :text("No tasks")', { timeout: 10_000 })
       await expect(page.getByRole('heading', { name: 'Todo' })).toBeVisible()
       await expect(page.getByRole('heading', { name: 'In Progress' })).toBeVisible()

--- a/frontend/e2e/screenshots.spec.ts
+++ b/frontend/e2e/screenshots.spec.ts
@@ -39,6 +39,8 @@ async function applyTheme(context: BrowserContext, theme: 'light' | 'dark') {
 async function goToTaskList(page: Page) {
   await page.goto('/')
   await page.locator('[data-part="trigger"]', { hasText: /Board/ }).click()
+  // List is the default view now; switch to the board for these column-based shots.
+  await page.getByRole('button', { name: 'Board view' }).click()
   await page.waitForSelector('button:has(h3), :text("No tasks")', { timeout: 10_000 })
 }
 

--- a/frontend/e2e/tasks.spec.ts
+++ b/frontend/e2e/tasks.spec.ts
@@ -20,6 +20,8 @@ async function cleanupCreatedTasks() {
 async function goToTaskList(page: Page) {
   await page.goto('/')
   await page.locator('[data-part="trigger"]', { hasText: /Board/ }).click()
+  // List is the default view now; switch to the board for these column-based tests.
+  await page.getByRole('button', { name: 'Board view' }).click()
   await page.waitForSelector('button:has(h3), :text("No tasks")', { timeout: 10_000 })
 }
 

--- a/frontend/e2e/workflow.spec.ts
+++ b/frontend/e2e/workflow.spec.ts
@@ -36,6 +36,8 @@ async function ensurePlanFixture() {
 async function goToTaskList(page: Page) {
   await page.goto('/')
   await page.locator('[data-part="trigger"]', { hasText: /Board/ }).click()
+  // List is the default view now; switch to the board for these column-based tests.
+  await page.getByRole('button', { name: 'Board view' }).click()
   await page.waitForSelector('button:has(h3), :text("No tasks")', {
     timeout: 10_000,
   })

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -34,8 +34,8 @@
     },
   }
 
-  // Focus mode persists across sessions (localStorage) but the board view mode
-  // does not (sessionStorage), so re-apply the list default once on startup.
+  // Focus mode leads with the list view, so re-apply it on startup since the
+  // persisted view mode may be board.
   if (focusModeStore.enabled) viewModeStore.set('list')
 
   let degradedWarnings = $state<DegradedWarning[]>([])

--- a/frontend/src/components/TaskBoardView.svelte
+++ b/frontend/src/components/TaskBoardView.svelte
@@ -70,7 +70,6 @@
     {@const isThin = viewport.isDesktop && tasks.length === 0 && !expandedEmpty.has(col.status)}
     {#if isThin}
       <!-- Thin rail for an empty desktop column — stays a drop target; click to expand. -->
-      <!-- svelte-ignore a11y_no_static_element_interactions -->
       <button
         type="button"
         data-col-status={col.status}
@@ -82,7 +81,7 @@
         class="hidden shrink-0 flex-col items-center gap-2 rounded-lg border-t-4 bg-surface-100 py-3 transition-colors hover:bg-surface-200 dark:bg-surface-900 dark:hover:bg-surface-800 md:flex md:w-10 {col.border} {dragOverStatus === col.status ? 'ring-2 ring-primary-400 dark:ring-primary-500' : ''}"
       >
         <span class="rounded-full bg-surface-200 px-1.5 py-0.5 text-[10px] font-medium text-surface-400 dark:bg-surface-700">0</span>
-        <h2 class="text-xs font-medium text-surface-400 [writing-mode:vertical-rl]">{col.label}</h2>
+        <span role="heading" aria-level="2" class="text-xs font-medium text-surface-400 [writing-mode:vertical-rl]">{col.label}</span>
       </button>
     {:else}
     <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/frontend/src/components/TaskBoardView.svelte
+++ b/frontend/src/components/TaskBoardView.svelte
@@ -31,6 +31,28 @@
   }: Props = $props()
 
   let dragOverStatus = $state<string | null>(null)
+  // Empty desktop columns collapse to a thin rail; clicking one expands it so
+  // tasks can still be added there.
+  let expandedEmpty = $state<Set<string>>(new Set())
+
+  function expandEmpty(status: string) {
+    expandedEmpty = new Set(expandedEmpty).add(status)
+  }
+
+  // Drop the expand override once a column has tasks, so it re-collapses to a
+  // thin rail if it later empties out again (rather than staying expanded).
+  $effect(() => {
+    let changed = false
+    const next = new Set(expandedEmpty)
+    for (const status of expandedEmpty) {
+      const col = visibleColumns.find((c) => c.status === status)
+      if (col && columnTasks(col).length > 0) {
+        next.delete(status)
+        changed = true
+      }
+    }
+    if (changed) expandedEmpty = next
+  })
 
   async function handleDrop(e: DragEvent, targetStatus: string) {
     e.preventDefault()
@@ -45,6 +67,24 @@
   {#each visibleColumns as col}
     {@const tasks = columnTasks(col)}
     {@const isCollapsed = !viewport.isDesktop && collapsedColumns.has(col.status)}
+    {@const isThin = viewport.isDesktop && tasks.length === 0 && !expandedEmpty.has(col.status)}
+    {#if isThin}
+      <!-- Thin rail for an empty desktop column — stays a drop target; click to expand. -->
+      <!-- svelte-ignore a11y_no_static_element_interactions -->
+      <button
+        type="button"
+        data-col-status={col.status}
+        onclick={() => expandEmpty(col.status)}
+        ondragover={(e) => { e.preventDefault(); dragOverStatus = col.status }}
+        ondragleave={() => { dragOverStatus = null }}
+        ondrop={(e) => handleDrop(e, col.status)}
+        title="{col.label} (empty) — click to expand"
+        class="hidden shrink-0 flex-col items-center gap-2 rounded-lg border-t-4 bg-surface-100 py-3 transition-colors hover:bg-surface-200 dark:bg-surface-900 dark:hover:bg-surface-800 md:flex md:w-10 {col.border} {dragOverStatus === col.status ? 'ring-2 ring-primary-400 dark:ring-primary-500' : ''}"
+      >
+        <span class="rounded-full bg-surface-200 px-1.5 py-0.5 text-[10px] font-medium text-surface-400 dark:bg-surface-700">0</span>
+        <h2 class="text-xs font-medium text-surface-400 [writing-mode:vertical-rl]">{col.label}</h2>
+      </button>
+    {:else}
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       data-col-status={col.status}
@@ -88,5 +128,6 @@
         </div>
       {/if}
     </div>
+    {/if}
   {/each}
 </div>

--- a/frontend/src/components/TaskBoardView.svelte.test.ts
+++ b/frontend/src/components/TaskBoardView.svelte.test.ts
@@ -8,6 +8,11 @@ vi.mock('../stores/notifications.svelte.js', () => ({
   notificationStore: { pushLocal: vi.fn() },
 }))
 
+// Drives the empty-column thin-rail (desktop only); default off keeps the
+// existing populated-column tests on the normal layout.
+const vpMock = vi.hoisted(() => ({ isDesktop: false }))
+vi.mock('../lib/viewport.svelte.js', () => ({ viewport: vpMock }))
+
 const TaskBoardView = (await import('./TaskBoardView.svelte')).default
 
 const columns = [
@@ -25,7 +30,63 @@ function columnTasks(col: { status: string }) {
 }
 
 describe('TaskBoardView', () => {
-  afterEach(cleanup)
+  afterEach(() => {
+    cleanup()
+    vpMock.isDesktop = false
+  })
+
+  it('collapses an empty desktop column to a thin rail, expandable on click', async () => {
+    vpMock.isDesktop = true
+    const cols = [
+      { status: 'todo', label: 'Todo', border: '', includes: [] },
+      { status: 'testing', label: 'Testing', border: '', includes: [] },
+    ]
+    // todo has a task; testing is empty → thin rail.
+    const ct = (col: { status: string }) =>
+      (col.status === 'todo' ? [tasks[0]] : []) as never[]
+    render(TaskBoardView, {
+      props: {
+        visibleColumns: cols as never,
+        columnTasks: ct as never,
+        focusedTaskId: null,
+        collapsedColumns: new Set<string>(),
+        onselect: vi.fn(),
+        onmove: vi.fn(),
+        ontogglecolumn: vi.fn(),
+      },
+    })
+    const rail = screen.getByTitle(/Testing \(empty\)/)
+    expect(rail.textContent).toContain('0')
+    await fireEvent.click(rail)
+    // Expanding replaces the thin rail with the normal column.
+    expect(screen.queryByTitle(/Testing \(empty\)/)).toBeNull()
+  })
+
+  it('drops a task onto an empty thin rail and fires onmove', async () => {
+    vpMock.isDesktop = true
+    const onmove = vi.fn()
+    const cols = [
+      { status: 'todo', label: 'Todo', border: '', includes: [] },
+      { status: 'testing', label: 'Testing', border: '', includes: [] },
+    ]
+    const ct = (col: { status: string }) =>
+      (col.status === 'todo' ? [tasks[0]] : []) as never[]
+    render(TaskBoardView, {
+      props: {
+        visibleColumns: cols as never,
+        columnTasks: ct as never,
+        focusedTaskId: null,
+        collapsedColumns: new Set<string>(),
+        onselect: vi.fn(),
+        onmove,
+        ontogglecolumn: vi.fn(),
+      },
+    })
+    const rail = screen.getByTitle(/Testing \(empty\)/)
+    const dataTransfer = { getData: () => 't1' }
+    await fireEvent.drop(rail, { dataTransfer })
+    expect(onmove).toHaveBeenCalledWith('t1', 'testing')
+  })
 
   it('renders one column per visibleColumns entry', () => {
     render(TaskBoardView, {

--- a/frontend/src/components/TaskListFilterBar.svelte
+++ b/frontend/src/components/TaskListFilterBar.svelte
@@ -94,6 +94,7 @@
     <div class="flex rounded-md border border-surface-300 dark:border-surface-700" title="Switch view (⌘B)">
       <button
         type="button"
+        aria-label="List view"
         class="flex items-center gap-1 px-2 py-1 text-xs font-medium transition-colors first:rounded-l-md last:rounded-r-md {viewMode === 'list' ? 'bg-primary-500 text-white dark:bg-primary-600' : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
         onclick={() => pickViewMode('list')}
       >
@@ -102,6 +103,7 @@
       </button>
       <button
         type="button"
+        aria-label="Board view"
         class="flex items-center gap-1 border-x border-surface-300 px-2 py-1 text-xs font-medium transition-colors dark:border-surface-700 {viewMode === 'board' ? 'bg-primary-500 text-white dark:bg-primary-600' : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
         onclick={() => pickViewMode('board')}
       >
@@ -110,6 +112,7 @@
       </button>
       <button
         type="button"
+        aria-label="Timeline view"
         class="flex items-center gap-1 px-2 py-1 text-xs font-medium transition-colors first:rounded-l-md last:rounded-r-md {viewMode === 'timeline' ? 'bg-primary-500 text-white dark:bg-primary-600' : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
         onclick={() => pickViewMode('timeline')}
       >

--- a/frontend/src/lib/view-mode.svelte.ts
+++ b/frontend/src/lib/view-mode.svelte.ts
@@ -5,12 +5,14 @@ const STORAGE_KEY = 'taskViewMode'
 
 function loadStored(): ViewMode {
   try {
-    const v = sessionStorage.getItem(STORAGE_KEY)
+    const v = localStorage.getItem(STORAGE_KEY)
     if (v === 'list' || v === 'board' || v === 'timeline') return v
   } catch {
-    // sessionStorage unavailable (SSR / restricted context)
+    // localStorage unavailable (SSR / restricted context)
   }
-  return 'board'
+  // List is the most scannable surface and stays useful even when the board's
+  // columns are mostly empty, so it's the default first paint.
+  return 'list'
 }
 
 function createViewModeStore() {
@@ -23,7 +25,7 @@ function createViewModeStore() {
     set(v: ViewMode): void {
       mode = v
       try {
-        sessionStorage.setItem(STORAGE_KEY, v)
+        localStorage.setItem(STORAGE_KEY, v)
       } catch {
         // ignore
       }
@@ -32,7 +34,7 @@ function createViewModeStore() {
       const next = MODES[(MODES.indexOf(mode) + 1) % MODES.length]
       mode = next
       try {
-        sessionStorage.setItem(STORAGE_KEY, next)
+        localStorage.setItem(STORAGE_KEY, next)
       } catch {
         // ignore
       }


### PR DESCRIPTION
## Motivation

The board was the default landing and showed mostly-empty columns (e.g. 4 of 6 at 0), reading as void (issue #913). The List view is the most scannable surface but wasn't the default.

## Implementation information

- **Default view = List**, persisted to **localStorage** so it genuinely remembers the user's last choice across app restarts (it was sessionStorage, which reset every launch).
- **Empty board columns** collapse to a thin rail on desktop: a narrow drop-target showing the column's rotated `<h2>` label + a "0" badge, expandable on click. The expand override is pruned once a column has tasks, so it re-collapses if it empties again.
- Added `aria-label`s to the List / Board / Timeline view-switch buttons (a11y + stable selector).
- Updated every e2e helper/path that loads the board (`tasks`, `workflow`, `screenshots`, `provider-smoke`, `history`) to switch to Board view first, since the default is now List.

A pre-PR adversarial review caught that four e2e specs beyond `tasks.spec.ts` had their own board navigation that the default change would have broken, and that sessionStorage didn't satisfy "remember the user's choice" — both fixed here.

Closes #913

> Changelog: feat(board): default to list, handle empty columns