### PR TITLE
feat(projects): enrich cards, fix dup header

### DIFF
--- a/frontend/src/lib/app-lifecycle.ts
+++ b/frontend/src/lib/app-lifecycle.ts
@@ -13,6 +13,7 @@ import { projectStore } from '../stores/projects.svelte.js'
 import { notificationStore } from '../stores/notifications.svelte.js'
 import { bgopStore } from '../stores/bgops.svelte.js'
 import { connectionStore } from '../stores/connection.svelte.js'
+import { reviewStore } from '../stores/reviews.svelte.js'
 
 export type DegradedWarning = { subsystem: string; reason: string }
 
@@ -71,6 +72,9 @@ export function startAppLifecycle(hooks: AppLifecycleHooks): () => void {
   agentStore.startPolling()
   projectStore.load()
   projectStore.startPolling()
+  // Seed PR data so project cards show open-PR counts before the GitHub page is
+  // ever opened. The GitHub page owns the live polling.
+  reviewStore.load()
 
   const reloadTasks = debounced(() => taskStore.load(), 150)
   const unsubTasks = onEvents([ev.TaskCreated, ev.TaskUpdated, ev.TaskDeleted], reloadTasks)

--- a/frontend/src/pages/ProjectDetail.svelte
+++ b/frontend/src/pages/ProjectDetail.svelte
@@ -131,6 +131,14 @@
     }))
   )
 
+  // Tasks placed in the active board columns. Anything outside (done, cancelled,
+  // or an unknown/legacy status) is excluded so a project with no on-board tasks
+  // never renders as six empty buckets.
+  const boardCount = $derived(tasksByColumn.reduce((n, c) => n + c.tasks.length, 0))
+  const doneCount = $derived(projectTasks.filter(t => t.status === 'done').length)
+  const cancelledCount = $derived(projectTasks.filter(t => t.status === 'cancelled').length)
+  const otherCount = $derived(Math.max(0, projectTasks.length - boardCount - doneCount - cancelledCount))
+
   async function deleteProject() {
     if (!p) return
     deleting = true
@@ -239,12 +247,21 @@
 
       {#if activeTab === 'tasks'}
         <div class="flex flex-col gap-3">
-          <div class="flex items-center justify-between">
+          <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
             <span class="text-sm font-medium text-surface-500">Tasks ({projectTasks.length})</span>
+            {#if projectTasks.length > 0}
+              <span class="text-xs text-surface-400">
+                {boardCount} active · {doneCount} done{#if cancelledCount > 0} · {cancelledCount} cancelled{/if}{#if otherCount > 0} · {otherCount} other{/if}
+              </span>
+            {/if}
           </div>
 
           {#if projectTasks.length === 0}
             <p class="py-4 text-center text-sm text-surface-400">No tasks assigned to this project</p>
+          {:else if boardCount === 0}
+            <p class="py-4 text-center text-sm text-surface-400">
+              No active tasks — {doneCount} done{#if cancelledCount > 0}, {cancelledCount} cancelled{/if}{#if otherCount > 0}, {otherCount} other{/if}.
+            </p>
           {:else}
             <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
               {#each tasksByColumn as col (col.status)}

--- a/frontend/src/pages/ProjectDetail.svelte.test.ts
+++ b/frontend/src/pages/ProjectDetail.svelte.test.ts
@@ -135,6 +135,35 @@ describe('ProjectDetail', () => {
     })
   })
 
+  it('shows a summary instead of empty buckets when all tasks are terminal', async () => {
+    mockGet.mockResolvedValue(mockProject)
+    mockTaskList.push(
+      { id: 'a', projectId: 'owner/repo', status: 'done', updatedAt: '2026-04-01T00:00:00Z' },
+      { id: 'b', projectId: 'owner/repo', status: 'cancelled', updatedAt: '2026-04-01T00:00:00Z' },
+    )
+    render(ProjectDetail, {
+      props: { projectId: 'owner/repo', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => {
+      expect(screen.getByText(/No active tasks — 1 done, 1 cancelled/)).toBeDefined()
+    })
+    expect(screen.queryByRole('heading', { name: 'In Progress' })).toBeNull()
+  })
+
+  it('does not show empty buckets for a task with an unknown status', async () => {
+    mockGet.mockResolvedValue(mockProject)
+    // A status outside the board columns and not done/cancelled must not be
+    // counted as "active" and leave six all-zero columns.
+    mockTaskList.push({ id: 'x', projectId: 'owner/repo', status: 'mystery', updatedAt: '2026-04-01T00:00:00Z' })
+    render(ProjectDetail, {
+      props: { projectId: 'owner/repo', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => {
+      expect(screen.getByText(/No active tasks — 0 done, 1 other/)).toBeDefined()
+    })
+    expect(screen.queryByRole('heading', { name: 'In Progress' })).toBeNull()
+  })
+
   it('shows Delete button after loading', async () => {
     mockGet.mockResolvedValue(mockProject)
     render(ProjectDetail, {

--- a/frontend/src/pages/ProjectList.svelte
+++ b/frontend/src/pages/ProjectList.svelte
@@ -3,6 +3,7 @@
   import { projectStore } from '../stores/projects.svelte.js'
   import { taskStore } from '../stores/tasks.svelte.js'
   import { reviewStore } from '../stores/reviews.svelte.js'
+  import { BOARD_COLUMNS } from '../lib/statuses.js'
   import { formatShortDate, timeAgo } from '../lib/dates.js'
 
   interface Props {
@@ -12,10 +13,12 @@
 
   const { onselect, onadd }: Props = $props()
 
-  const TERMINAL = new Set(['done', 'cancelled'])
+  // "Active" = sits in an active board column (matches Project Detail's board
+  // count); terminal and unknown/legacy statuses are excluded.
+  const ACTIVE_STATUSES = new Set<string>(BOARD_COLUMNS.flatMap((c) => [c.status, ...c.includes]))
 
   function activeTaskCount(projectId: string): number {
-    return taskStore.list.filter((t) => t.projectId === projectId && !TERMINAL.has(t.status)).length
+    return taskStore.list.filter((t) => t.projectId === projectId && ACTIVE_STATUSES.has(t.status)).length
   }
 
   function openPRCount(owner: string, repo: string): number {
@@ -24,9 +27,15 @@
 
   /** Most recent task activity for a project, as a relative label (empty if none). */
   function lastActivity(projectId: string): string {
+    let latestMs = 0
     let latest = ''
     for (const t of taskStore.list) {
-      if (t.projectId === projectId && t.updatedAt && t.updatedAt > latest) latest = t.updatedAt
+      if (t.projectId !== projectId || !t.updatedAt) continue
+      const ms = Date.parse(t.updatedAt)
+      if (!Number.isNaN(ms) && ms > latestMs) {
+        latestMs = ms
+        latest = t.updatedAt
+      }
     }
     return latest ? timeAgo(latest) : ''
   }

--- a/frontend/src/pages/ProjectList.svelte
+++ b/frontend/src/pages/ProjectList.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-  import { Folder } from '@lucide/svelte'
+  import { Folder, GitPullRequest, ListChecks } from '@lucide/svelte'
   import { projectStore } from '../stores/projects.svelte.js'
-  import { formatShortDate } from '../lib/dates.js'
+  import { taskStore } from '../stores/tasks.svelte.js'
+  import { reviewStore } from '../stores/reviews.svelte.js'
+  import { formatShortDate, timeAgo } from '../lib/dates.js'
 
   interface Props {
     onselect: (id: string) => void
@@ -9,20 +11,28 @@
   }
 
   const { onselect, onadd }: Props = $props()
+
+  const TERMINAL = new Set(['done', 'cancelled'])
+
+  function activeTaskCount(projectId: string): number {
+    return taskStore.list.filter((t) => t.projectId === projectId && !TERMINAL.has(t.status)).length
+  }
+
+  function openPRCount(owner: string, repo: string): number {
+    return reviewStore.byRepo(`${owner}/${repo}`).length
+  }
+
+  /** Most recent task activity for a project, as a relative label (empty if none). */
+  function lastActivity(projectId: string): string {
+    let latest = ''
+    for (const t of taskStore.list) {
+      if (t.projectId === projectId && t.updatedAt && t.updatedAt > latest) latest = t.updatedAt
+    }
+    return latest ? timeAgo(latest) : ''
+  }
 </script>
 
 <div class="flex flex-col gap-3 p-4 md:gap-4 md:p-6">
-  <div class="flex items-center justify-between">
-    <h2 class="text-lg font-semibold">Projects</h2>
-    <button
-      type="button"
-      class="rounded-lg bg-primary-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-600"
-      onclick={onadd}
-    >
-      + Add Project
-    </button>
-  </div>
-
   {#if projectStore.loading && projectStore.list.length === 0}
     <p class="text-sm opacity-60">Loading projects...</p>
   {:else if projectStore.error}
@@ -42,6 +52,9 @@
   {:else}
     <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
       {#each projectStore.list as p (p.id)}
+        {@const active = activeTaskCount(p.id)}
+        {@const prs = openPRCount(p.owner, p.repo)}
+        {@const activity = lastActivity(p.id)}
         <button
           type="button"
           class="flex flex-col gap-2 rounded-lg border border-surface-300 bg-surface-50 p-4 text-left transition-colors hover:bg-surface-100 dark:border-surface-600 dark:bg-surface-800 dark:hover:bg-surface-700"
@@ -56,8 +69,21 @@
               <span class="rounded px-1.5 py-0.5 text-xs font-medium bg-surface-200 text-surface-500 dark:bg-surface-700 dark:text-surface-400">pet</span>
             {/if}
           </div>
-          <div class="flex items-center gap-2 text-xs text-surface-500">
-            <span>Added {formatShortDate(p.createdAt)}</span>
+          <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-surface-500">
+            <span class="inline-flex items-center gap-1" title="Active tasks">
+              <ListChecks size={13} class="shrink-0" />
+              {active} active
+            </span>
+            {#if prs > 0}
+              <span class="inline-flex items-center gap-1" title="Open pull requests">
+                <GitPullRequest size={13} class="shrink-0" />
+                {prs} PR{prs === 1 ? '' : 's'}
+              </span>
+            {/if}
+            {#if activity}
+              <span title="Last task activity">· {activity}</span>
+            {/if}
+            <span class="ml-auto opacity-70">Added {formatShortDate(p.createdAt)}</span>
           </div>
         </button>
       {/each}

--- a/frontend/src/pages/ProjectList.svelte.test.ts
+++ b/frontend/src/pages/ProjectList.svelte.test.ts
@@ -14,6 +14,16 @@ vi.mock('../stores/projects.svelte.js', () => ({
   projectStore: mockProjectStore,
 }))
 
+const mockTaskList: any[] = []
+vi.mock('../stores/tasks.svelte.js', () => ({
+  taskStore: { get list() { return mockTaskList } },
+}))
+
+let mockPRsByRepo: Record<string, any[]> = {}
+vi.mock('../stores/reviews.svelte.js', () => ({
+  reviewStore: { byRepo: (repo: string) => mockPRsByRepo[repo] ?? [] },
+}))
+
 const ProjectList = (await import('./ProjectList.svelte')).default
 
 const mockProject = {
@@ -31,6 +41,8 @@ describe('ProjectList', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockProjectList.length = 0
+    mockTaskList.length = 0
+    mockPRsByRepo = {}
     mockProjectStore.loading = false
     mockProjectStore.error = ''
   })
@@ -39,20 +51,18 @@ describe('ProjectList', () => {
     cleanup()
   })
 
-  it('renders Projects heading', () => {
+  it('does not render an in-body header or duplicate create button', () => {
+    mockProjectList.push(mockProject)
     render(ProjectList, { props: { onselect: vi.fn(), onadd: vi.fn() } })
-    expect(screen.getByText('Projects')).toBeDefined()
+    // The page title + create button live in the app top bar now.
+    expect(screen.queryByText('Projects')).toBeNull()
+    expect(screen.queryByText('+ Add Project')).toBeNull()
   })
 
-  it('shows Add Project button', () => {
-    render(ProjectList, { props: { onselect: vi.fn(), onadd: vi.fn() } })
-    expect(screen.getByText('+ Add Project')).toBeDefined()
-  })
-
-  it('calls onadd when Add Project clicked', async () => {
+  it('calls onadd from the empty-state button', async () => {
     const onadd = vi.fn()
     render(ProjectList, { props: { onselect: vi.fn(), onadd } })
-    await fireEvent.click(screen.getByText('+ Add Project'))
+    await fireEvent.click(screen.getByText('Add your first project'))
     expect(onadd).toHaveBeenCalledOnce()
   })
 
@@ -102,5 +112,18 @@ describe('ProjectList', () => {
     render(ProjectList, { props: { onselect, onadd: vi.fn() } })
     await fireEvent.click(screen.getByText('owner/repo'))
     expect(onselect).toHaveBeenCalledWith('owner/repo')
+  })
+
+  it('shows active-task and open-PR counts on the card', () => {
+    mockProjectList.push(mockProject)
+    mockTaskList.push(
+      { projectId: 'owner/repo', status: 'in-progress', updatedAt: '2026-04-02T00:00:00Z' },
+      { projectId: 'owner/repo', status: 'done', updatedAt: '2026-04-01T00:00:00Z' },
+      { projectId: 'other/repo', status: 'todo', updatedAt: '2026-04-03T00:00:00Z' },
+    )
+    mockPRsByRepo = { 'owner/repo': [{ number: 1 }, { number: 2 }] }
+    render(ProjectList, { props: { onselect: vi.fn(), onadd: vi.fn() } })
+    expect(screen.getByText('1 active')).toBeDefined() // done + other project excluded
+    expect(screen.getByText('2 PRs')).toBeDefined()
   })
 })

--- a/frontend/src/pages/ProjectList.svelte.test.ts
+++ b/frontend/src/pages/ProjectList.svelte.test.ts
@@ -119,11 +119,13 @@ describe('ProjectList', () => {
     mockTaskList.push(
       { projectId: 'owner/repo', status: 'in-progress', updatedAt: '2026-04-02T00:00:00Z' },
       { projectId: 'owner/repo', status: 'done', updatedAt: '2026-04-01T00:00:00Z' },
+      { projectId: 'owner/repo', status: 'mystery', updatedAt: '2026-04-01T00:00:00Z' },
       { projectId: 'other/repo', status: 'todo', updatedAt: '2026-04-03T00:00:00Z' },
     )
     mockPRsByRepo = { 'owner/repo': [{ number: 1 }, { number: 2 }] }
     render(ProjectList, { props: { onselect: vi.fn(), onadd: vi.fn() } })
-    expect(screen.getByText('1 active')).toBeDefined() // done + other project excluded
+    // done, unknown status, and the other project are all excluded from "active".
+    expect(screen.getByText('1 active')).toBeDefined()
     expect(screen.getByText('2 PRs')).toBeDefined()
   })
 })


### PR DESCRIPTION
## Motivation

The Projects page duplicated its title + primary button (top-bar "+ New Project" plus an in-body "Projects" heading and a second "+ Add Project"), cards were sparse, and Project Detail showed six all-zero status buckets for a project whose tasks were all done — looking broken (issue #914).

## Implementation information

- Removed the Projects page's in-body header + duplicate button. The page title and the single "New Project" create action live in the app top bar (the empty state keeps its onboarding CTA).
- **Enriched cards** with active-task and open-PR counts plus last-activity (`activeTaskCount`, `openPRCount` via `reviewStore.byRepo`, `lastActivity`). Seed `reviewStore.load()` at startup so counts are populated before the GitHub page is opened.
- **Project Detail**: an active/done/cancelled (+other) summary line, and when no task sits in an active board column it shows a summary instead of six empty columns. Active membership is derived from actual board placement, so a task with an unknown/legacy status can't reintroduce the all-zero buckets.

A pre-PR adversarial review caught the unknown-status edge case (the original `total − done − cancelled` math would have left six zeros) and the PR-count cold-start — both fixed here, with tests.

## Open questions / scope

- The empty state shows its own "Add your first project" CTA alongside the top-bar button — two create affordances, but that's the standard empty-state pattern (mutually exclusive with the populated list).

Closes #914

> Changelog: feat(projects): enrich cards, fix dup header