### PR TITLE
feat(agents): simplify agent detail layout

### DIFF
--- a/frontend/src/components/StreamOutput.svelte
+++ b/frontend/src/components/StreamOutput.svelte
@@ -19,6 +19,14 @@
   let autoScroll = $state(true)
   let flashIndex = $state<number | null>(null)
 
+  // `system` rows (system-reminders) and empty-content rows are low signal, but
+  // we de-emphasise rather than hide them: the timeline indexes the full event
+  // array (so removal would break click/scroll sync) and Claude tool results
+  // arrive as `user` rows that must stay readable.
+  function isQuiet(e: StreamEvent): boolean {
+    return e.type === 'system' || (e.content ?? '').trim().length === 0
+  }
+
   const typeStyles: Record<string, { label: string; classes: string }> = {
     init: { label: 'INIT', classes: 'bg-surface-300 text-surface-800 dark:bg-surface-600 dark:text-surface-200' },
     assistant: { label: 'ASST', classes: 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200' },
@@ -113,7 +121,7 @@
         {@const style = typeStyles[event.type] ?? { label: event.type.toUpperCase(), classes: 'bg-surface-300 text-surface-800 dark:bg-surface-700 dark:text-surface-200' }}
         <div
           data-event-index={i}
-          class="flex items-start gap-2 rounded transition-colors duration-300
+          class="flex items-start gap-2 rounded transition-colors duration-300 {isQuiet(event) ? 'opacity-50' : ''}
             {flashIndex === i ? 'bg-warning-900/40' : ''}"
         >
           <span class="mt-0.5 inline-block shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold {style.classes}">

--- a/frontend/src/components/StreamOutput.svelte.test.ts
+++ b/frontend/src/components/StreamOutput.svelte.test.ts
@@ -59,6 +59,39 @@ describe('StreamOutput', () => {
     })
   })
 
+  it('de-emphasises system rows but keeps user (tool-result) content readable', async () => {
+    mockGetOutput.mockResolvedValue([
+      makeTSE('assistant', 'Real output'),
+      makeTSE('user', 'tool result body'), // Claude tool results — must stay visible
+      makeTSE('system', 'system reminder'),
+    ])
+
+    render(StreamOutput, { props: { agentId: 'test-1' } })
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('Real output')).toBeDefined()
+    })
+    // Tool-result content stays at full prominence; the system row is dimmed.
+    const toolRow = screen.getByText('tool result body').closest('[data-event-index]')
+    expect(toolRow?.className).not.toContain('opacity-50')
+    const systemRow = screen.getByText('system reminder').closest('[data-event-index]')
+    expect(systemRow?.className).toContain('opacity-50')
+  })
+
+  it('keeps full-array indices so timeline sync is not broken', async () => {
+    mockGetOutput.mockResolvedValue([
+      makeTSE('assistant', 'first'),
+      makeTSE('system', 'noise'),
+      makeTSE('assistant', 'third'),
+    ])
+
+    render(StreamOutput, { props: { agentId: 'test-1' } })
+
+    await vi.waitFor(() => {
+      expect(screen.getByText('third').closest('[data-event-index]')?.getAttribute('data-event-index')).toBe('2')
+    })
+  })
+
   it('renders unknown event type label as uppercase', async () => {
     mockGetOutput.mockResolvedValue([makeTSE('custom', 'data')])
 

--- a/frontend/src/components/agent-view/AgentHeader.svelte
+++ b/frontend/src/components/agent-view/AgentHeader.svelte
@@ -21,8 +21,8 @@
 
 <div class="flex flex-col gap-6">
   <div class="flex items-start justify-between gap-4">
-    <div>
-      <h1 class="text-2xl font-bold">{a.project || a.id}</h1>
+    <div class="min-w-0">
+      <h1 class="break-words text-2xl font-bold">{a.project || a.id}</h1>
       {#if a.name}
         <span class="text-sm text-surface-400">{a.name}</span>
       {/if}

--- a/frontend/src/components/agent-view/ThreePanelLayout.svelte
+++ b/frontend/src/components/agent-view/ThreePanelLayout.svelte
@@ -16,18 +16,40 @@
     return val === null ? fallback : val === 'true'
   }
 
-  let workspaceCollapsed = $state(getStorageBool('sybra.workspace.rightCollapsed', false))
+  // Default to two panes (the center step-list + output); the agents sidebar and
+  // the session workspace are collapsed behind toggles to avoid cramping.
+  let sidebarCollapsed = $state(getStorageBool('sybra.workspace.leftCollapsed', true))
+  let workspaceCollapsed = $state(getStorageBool('sybra.workspace.rightCollapsed', true))
 
+  $effect(() => {
+    localStorage.setItem('sybra.workspace.leftCollapsed', String(sidebarCollapsed))
+  })
   $effect(() => {
     localStorage.setItem('sybra.workspace.rightCollapsed', String(workspaceCollapsed))
   })
 </script>
 
 <div class="flex min-h-0 items-start gap-3">
-  <!-- Left sidebar: hidden below md -->
-  <div class="hidden w-48 shrink-0 flex-col md:flex">
-    {@render sidebar()}
-  </div>
+  <!-- Left sidebar toggle — only at md+ -->
+  <button
+    type="button"
+    onclick={() => { sidebarCollapsed = !sidebarCollapsed }}
+    title={sidebarCollapsed ? 'Show agents' : 'Hide agents'}
+    class="hidden shrink-0 rounded p-1 text-surface-400 hover:bg-surface-200 hover:text-surface-700 dark:hover:bg-surface-700 dark:hover:text-surface-200 md:flex"
+  >
+    {#if sidebarCollapsed}
+      <ChevronRight size={14} />
+    {:else}
+      <ChevronLeft size={14} />
+    {/if}
+  </button>
+
+  <!-- Left sidebar: hidden below md, collapsible -->
+  {#if !sidebarCollapsed}
+    <div class="hidden w-48 shrink-0 flex-col md:flex">
+      {@render sidebar()}
+    </div>
+  {/if}
 
   <!-- Center: always visible -->
   <div class="min-w-0 flex-1">
@@ -41,7 +63,7 @@
     </div>
   {/if}
 
-  <!-- Collapse/expand toggle — only visible at lg+ -->
+  <!-- Workspace toggle — only visible at lg+ -->
   <button
     type="button"
     onclick={() => { workspaceCollapsed = !workspaceCollapsed }}

--- a/frontend/src/components/agent-view/ThreePanelLayout.svelte
+++ b/frontend/src/components/agent-view/ThreePanelLayout.svelte
@@ -16,16 +16,24 @@
     return val === null ? fallback : val === 'true'
   }
 
+  function setStorageBool(key: string, val: boolean): void {
+    try {
+      localStorage.setItem(key, String(val))
+    } catch {
+      // storage disabled / quota exceeded — preference just won't persist
+    }
+  }
+
   // Default to two panes (the center step-list + output); the agents sidebar and
   // the session workspace are collapsed behind toggles to avoid cramping.
   let sidebarCollapsed = $state(getStorageBool('sybra.workspace.leftCollapsed', true))
   let workspaceCollapsed = $state(getStorageBool('sybra.workspace.rightCollapsed', true))
 
   $effect(() => {
-    localStorage.setItem('sybra.workspace.leftCollapsed', String(sidebarCollapsed))
+    setStorageBool('sybra.workspace.leftCollapsed', sidebarCollapsed)
   })
   $effect(() => {
-    localStorage.setItem('sybra.workspace.rightCollapsed', String(workspaceCollapsed))
+    setStorageBool('sybra.workspace.rightCollapsed', workspaceCollapsed)
   })
 </script>
 
@@ -35,6 +43,7 @@
     type="button"
     onclick={() => { sidebarCollapsed = !sidebarCollapsed }}
     title={sidebarCollapsed ? 'Show agents' : 'Hide agents'}
+    aria-label={sidebarCollapsed ? 'Show agents' : 'Hide agents'}
     class="hidden shrink-0 rounded p-1 text-surface-400 hover:bg-surface-200 hover:text-surface-700 dark:hover:bg-surface-700 dark:hover:text-surface-200 md:flex"
   >
     {#if sidebarCollapsed}
@@ -68,6 +77,7 @@
     type="button"
     onclick={() => { workspaceCollapsed = !workspaceCollapsed }}
     title={workspaceCollapsed ? 'Show workspace' : 'Hide workspace'}
+    aria-label={workspaceCollapsed ? 'Show workspace' : 'Hide workspace'}
     class="hidden shrink-0 rounded p-1 text-surface-400 hover:bg-surface-200 hover:text-surface-700 dark:hover:bg-surface-700 dark:hover:text-surface-200 lg:flex"
   >
     {#if workspaceCollapsed}

--- a/frontend/src/components/agent-view/ThreePanelLayout.svelte.test.ts
+++ b/frontend/src/components/agent-view/ThreePanelLayout.svelte.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
+import { createRawSnippet } from 'svelte'
+import ThreePanelLayout from './ThreePanelLayout.svelte'
+
+const snip = (text: string) =>
+  createRawSnippet(() => ({ render: () => `<div>${text}</div>` }))
+
+function renderLayout() {
+  return render(ThreePanelLayout, {
+    props: {
+      sidebar: snip('SIDEBAR') as never,
+      workspace: snip('WORKSPACE') as never,
+      children: snip('CENTER') as never,
+    },
+  })
+}
+
+describe('ThreePanelLayout', () => {
+  beforeEach(() => localStorage.clear())
+  afterEach(() => {
+    cleanup()
+    localStorage.clear()
+  })
+
+  it('defaults to the two center panes — sidebar and workspace collapsed', () => {
+    renderLayout()
+    expect(screen.getByText('CENTER')).toBeDefined()
+    expect(screen.queryByText('SIDEBAR')).toBeNull()
+    expect(screen.queryByText('WORKSPACE')).toBeNull()
+  })
+
+  it('reveals the agents sidebar when its toggle is clicked', async () => {
+    renderLayout()
+    await fireEvent.click(screen.getByTitle('Show agents'))
+    expect(screen.getByText('SIDEBAR')).toBeDefined()
+  })
+
+  it('reveals the workspace when its toggle is clicked', async () => {
+    renderLayout()
+    await fireEvent.click(screen.getByTitle('Show workspace'))
+    expect(screen.getByText('WORKSPACE')).toBeDefined()
+  })
+
+  it('respects a persisted expanded workspace preference', () => {
+    localStorage.setItem('sybra.workspace.rightCollapsed', 'false')
+    renderLayout()
+    expect(screen.getByText('WORKSPACE')).toBeDefined()
+  })
+
+  it('respects a persisted expanded sidebar preference', () => {
+    localStorage.setItem('sybra.workspace.leftCollapsed', 'false')
+    renderLayout()
+    expect(screen.getByText('SIDEBAR')).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Motivation

Agent Detail showed four simultaneous scroll panes (agents sidebar · output log · workspace tabs), cramped even on wide screens, with a low-signal output event log (issue #915).

## Implementation information

- **Two panes by default**: `ThreePanelLayout` now collapses both the agents sidebar (new `sybra.workspace.leftCollapsed`, default true) and the session workspace (`rightCollapsed`, now default true) behind toggle buttons, leaving the center step-list + output as the default. Persisted prefs are respected.
- **Quieter output log**: `StreamOutput` de-emphasises `system` and empty-content rows (`opacity-50`) so the meaningful assistant/tool rows stand out.
- **Header containment**: the title row gets `min-w-0` + `break-words` so a long agent id/project can't overflow and push the badge/Stop controls off-screen.

### Why de-emphasise the log instead of hiding rows
A pre-PR adversarial review caught two traps with hiding `user`/`system` rows: (1) `buildStreamTimeline` indexes the **full** event array, so removing rows breaks the timeline↔output click/scroll sync (dead clicks); (2) in Claude (the primary provider) tool results arrive as `user`-typed events, so hiding `user` would strip all tool output from the log. De-emphasis keeps every row rendered with its original index and keeps tool results readable while cutting visual noise.

## Open questions / scope

- The agent header **content** redundancy (opaque-hash title, repeated task name) is owned by #916; this PR only contains the layout + the intra-row overflow fix. I could not find a `sticky`/positioned element for the title to literally overlap, so the header fix is the intra-row containment — visual confirmation on the desktop app is welcome.

Closes #915

> Changelog: feat(agents): simplify agent detail layout