### PR TITLE
feat(agents): clean identity & header redundancy

### DIFF
--- a/frontend/src/components/AgentCard.svelte
+++ b/frontend/src/components/AgentCard.svelte
@@ -7,6 +7,7 @@
   import { clock } from '$lib/clock.svelte.js'
   import { formatElapsed } from '$lib/elapsed.js'
   import { timeAgo } from '$lib/dates.js'
+  import { agentDisplayName, cleanAgentName } from '$lib/agent-name.js'
 
   interface Props {
     agent: Agent
@@ -16,6 +17,9 @@
   const { agent: a, onclick }: Props = $props()
 
   const linkedTask = $derived(a.taskId ? taskStore.tasks.get(a.taskId) : null)
+
+  const heading = $derived(agentDisplayName(a, linkedTask?.title))
+  const subtitle = $derived(cleanAgentName(a.name))
 
   const phase = $derived(
     getAgentPhase(
@@ -39,9 +43,9 @@
 >
   <div class="mb-2 flex items-start justify-between gap-2">
     <div class="flex flex-col gap-0.5">
-      <h3 class="text-sm font-semibold leading-tight {config.faded ? 'text-surface-400 dark:text-surface-500' : ''}">{linkedTask?.title ?? (a.project || a.id)}</h3>
-      {#if a.name}
-        <span class="text-xs text-surface-400">{a.name}</span>
+      <h3 class="text-sm font-semibold leading-tight {config.faded ? 'text-surface-400 dark:text-surface-500' : ''}">{heading}</h3>
+      {#if subtitle && subtitle !== heading}
+        <span class="text-xs text-surface-400">{subtitle}</span>
       {/if}
       {#if phase === 'running'}
         <span class="text-xs italic text-surface-400">

--- a/frontend/src/components/AgentCard.svelte.test.ts
+++ b/frontend/src/components/AgentCard.svelte.test.ts
@@ -67,14 +67,14 @@ describe('AgentCard', () => {
     expect(screen.getByRole('heading', { level: 3 }).textContent).toBe('Implement auth')
   })
 
-  it('renders agent project name in heading when no linked task', () => {
-    render(AgentCard, { props: { agent: makeAgent(), onclick: () => {} } })
+  it('renders the project in the heading when there is no task or name', () => {
+    render(AgentCard, { props: { agent: makeAgent({ name: '' }), onclick: () => {} } })
     expect(screen.getByRole('heading', { level: 3 }).textContent).toBe('sybra')
   })
 
-  it('renders agent id as fallback when project is empty and no linked task', () => {
-    render(AgentCard, { props: { agent: makeAgent({ project: '' }), onclick: () => {} } })
-    expect(screen.getByRole('heading', { level: 3 }).textContent).toBe('agent-1')
+  it('renders a labelled session id when project, name and task are empty', () => {
+    render(AgentCard, { props: { agent: makeAgent({ project: '', name: '', taskId: '' }), onclick: () => {} } })
+    expect(screen.getByRole('heading', { level: 3 }).textContent).toBe('Session agent-1')
   })
 
   it('renders agent name when present', () => {

--- a/frontend/src/components/agent-view/AgentHeader.svelte
+++ b/frontend/src/components/agent-view/AgentHeader.svelte
@@ -4,6 +4,7 @@
   import type { AgentPhase } from '$lib/agent-phases.js'
   import AgentStateBadge from '../AgentStateBadge.svelte'
   import { formatDateTime } from '$lib/dates.js'
+  import { agentDisplayName, cleanAgentName, shortId } from '$lib/agent-name.js'
 
   interface Props {
     a: Agent
@@ -17,14 +18,21 @@
   const { a, phase, stepText, linkedTask, onstop, onviewtask }: Props = $props()
 
   const isRunning = $derived(a.state === 'running')
+  const heading = $derived(agentDisplayName(a, linkedTask?.title))
+  // Show the session name only when it adds something beyond the heading.
+  const subtitle = $derived(cleanAgentName(a.name))
+  const showSubtitle = $derived(subtitle.length > 0 && subtitle !== heading)
 </script>
 
 <div class="flex flex-col gap-6">
   <div class="flex items-start justify-between gap-4">
     <div class="min-w-0">
-      <h1 class="break-words text-2xl font-bold">{a.project || a.id}</h1>
-      {#if a.name}
-        <span class="text-sm text-surface-400">{a.name}</span>
+      <div class="flex flex-wrap items-center gap-2">
+        <h1 class="break-words text-2xl font-bold">{heading}</h1>
+        <span class="rounded bg-surface-200 px-1.5 py-0.5 font-mono text-[10px] text-surface-500 dark:bg-surface-700 dark:text-surface-400" title="Agent ID: {a.id}">{shortId(a.id)}</span>
+      </div>
+      {#if showSubtitle}
+        <span class="text-sm text-surface-400">{subtitle}</span>
       {/if}
       {#if phase === 'running'}
         <p class="mt-0.5 text-sm italic text-surface-400">
@@ -69,7 +77,7 @@
           class="text-left text-primary-500 hover:underline"
           onclick={() => onviewtask(a.taskId)}
         >
-          {linkedTask?.title ?? a.taskId}
+          View task →
         </button>
       </div>
     {/if}
@@ -87,12 +95,6 @@
       <div class="flex flex-col gap-1">
         <span class="font-medium text-surface-500">Project</span>
         <span class="rounded bg-surface-200 px-2 py-0.5 dark:bg-surface-700">{a.project}</span>
-      </div>
-    {/if}
-    {#if a.name}
-      <div class="flex flex-col gap-1">
-        <span class="font-medium text-surface-500">Session Name</span>
-        <span class="rounded bg-surface-200 px-2 py-0.5 dark:bg-surface-700">{a.name}</span>
       </div>
     {/if}
     {#if a.external}

--- a/frontend/src/components/agent-view/AgentSidebarList.svelte
+++ b/frontend/src/components/agent-view/AgentSidebarList.svelte
@@ -3,6 +3,7 @@
   import { getAgentPhase, PHASE_CONFIG } from '$lib/agent-phases.js'
   import { taskStore } from '../../stores/tasks.svelte.js'
   import { agentStore } from '../../stores/agents.svelte.js'
+  import { agentDisplayName } from '$lib/agent-name.js'
 
   interface Props {
     agents: Agent[]
@@ -35,6 +36,7 @@
       {@const linkedTask = a.taskId ? taskStore.tasks.get(a.taskId) : null}
       {@const phase = getAgentPhase(a.state, a.escalationReason, linkedTask?.status, a.awaitingApproval)}
       {@const config = PHASE_CONFIG[phase]}
+      {@const label = agentDisplayName(a, linkedTask?.title)}
       <button
         type="button"
         onclick={() => { onnavigate(a.id) }}
@@ -44,8 +46,8 @@
             : 'hover:bg-surface-100 dark:hover:bg-surface-800'}"
       >
         <span class="h-2 w-2 shrink-0 rounded-full {config.dotClasses} {config.animate ? 'animate-pulse-subtle' : ''}"></span>
-        <span class="min-w-0 flex-1 truncate leading-snug" title={linkedTask?.title ?? a.name ?? a.id}>
-          {linkedTask?.title ?? a.name ?? a.id}
+        <span class="min-w-0 flex-1 truncate leading-snug" title={label}>
+          {label}
         </span>
         {#if agentStore.stepTexts.get(a.id)}
           <span class="truncate text-[9px] italic text-surface-400 max-w-[80px]" title={agentStore.stepTexts.get(a.id)}>

--- a/frontend/src/lib/agent-name.test.ts
+++ b/frontend/src/lib/agent-name.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { cleanAgentName, shortId, agentDisplayName } from './agent-name.js'
+
+describe('cleanAgentName', () => {
+  it('strips a role prefix, fixing the review:Review doubling', () => {
+    expect(cleanAgentName('review:Review the PR #42')).toBe('Review the PR #42')
+  })
+
+  it('strips other known role prefixes', () => {
+    expect(cleanAgentName('plan:Design auth')).toBe('Design auth')
+    expect(cleanAgentName('triage:Investigate flaky test')).toBe('Investigate flaky test')
+    expect(cleanAgentName('fix-review:Address feedback')).toBe('Address feedback')
+  })
+
+  it('leaves names without a known role prefix untouched', () => {
+    expect(cleanAgentName('my-chat-session')).toBe('my-chat-session')
+    expect(cleanAgentName('ext-12345')).toBe('ext-12345')
+    // Human-typed "Review:" (capitalised) is not a technical role prefix.
+    expect(cleanAgentName('Review: my notes')).toBe('Review: my notes')
+  })
+
+  it('returns empty for nullish', () => {
+    expect(cleanAgentName(undefined)).toBe('')
+    expect(cleanAgentName(null)).toBe('')
+  })
+})
+
+describe('shortId', () => {
+  it('keeps the trailing entropy of a long structured id (no prefix collision)', () => {
+    // Two Codex sessions sharing the `ext-codex-` prefix stay distinct.
+    expect(shortId('ext-codex-abc12345')).toBe('abc12345')
+    expect(shortId('ext-codex-def67890')).toBe('def67890')
+  })
+
+  it('keeps short ids whole', () => {
+    expect(shortId('ext-12')).toBe('ext-12')
+    expect(shortId('agent-1')).toBe('agent-1')
+  })
+})
+
+describe('agentDisplayName', () => {
+  it('prefers the linked task title', () => {
+    expect(agentDisplayName({ id: 'x', name: 'review:Fix the bug' }, 'Fix the bug')).toBe('Fix the bug')
+  })
+
+  it('falls back to the cleaned name', () => {
+    expect(agentDisplayName({ id: 'x', name: 'review:Fix the bug' })).toBe('Fix the bug')
+  })
+
+  it('falls back to the project', () => {
+    expect(agentDisplayName({ id: 'x', project: 'owner/repo' })).toBe('owner/repo')
+  })
+
+  it('falls back to the task id before a bare session label', () => {
+    expect(agentDisplayName({ id: 'x', taskId: 'task-1' })).toBe('task-1')
+  })
+
+  it('labels a bare-id session instead of showing a raw hash', () => {
+    expect(agentDisplayName({ id: 'ext-codex-9f8e7d6c' })).toBe('Session 9f8e7d6c')
+  })
+})

--- a/frontend/src/lib/agent-name.ts
+++ b/frontend/src/lib/agent-name.ts
@@ -1,0 +1,64 @@
+// Friendly display names for agents and interactive sessions, so the UI shows
+// readable labels instead of opaque hashes or technical role prefixes.
+
+interface NamedAgent {
+  id: string
+  name?: string
+  project?: string
+  taskId?: string
+}
+
+// Agents are launched as `<role>:<title>` (see internal/agent/role.go). When
+// the title itself starts with a word like "Review", the raw name reads as a
+// doubled "review:Review …" prefix — stripping the role prefix fixes that.
+const ROLE_PREFIXES = new Set([
+  'triage',
+  'plan',
+  'plan-critic',
+  'eval',
+  'pr-fix',
+  'review',
+  'fix-review',
+  'test-plan',
+  'test-plan-critic',
+  'test-runner',
+  'implementation',
+  'human-review',
+])
+
+/**
+ * Strip a leading technical role prefix (`review:`, `plan:`, …) from an agent
+ * name so the human-readable title is shown on its own. Roles are lowercase
+ * (matched case-sensitively); names without a known role prefix are untouched.
+ */
+export function cleanAgentName(name: string | undefined | null): string {
+  if (!name) return ''
+  const idx = name.indexOf(':')
+  if (idx > 0 && ROLE_PREFIXES.has(name.slice(0, idx))) {
+    return name.slice(idx + 1).trim()
+  }
+  return name.trim()
+}
+
+/**
+ * Compact form of an opaque id for an ID chip / fallback label. Opaque ids
+ * often share a long structured prefix (e.g. `ext-codex-<sid>`), so the
+ * trailing, high-entropy portion is kept — truncating the front would collide.
+ */
+export function shortId(id: string): string {
+  return id.length > 12 ? id.slice(-8) : id
+}
+
+/**
+ * Best human-readable name for an agent/session: the linked task title, else
+ * the cleaned session name, else the project, else the task id — never a bare
+ * hash (an id-only fallback is labelled "Session <shortId>").
+ */
+export function agentDisplayName(a: NamedAgent, taskTitle?: string | null): string {
+  if (taskTitle) return taskTitle
+  const name = cleanAgentName(a.name)
+  if (name) return name
+  if (a.project) return a.project
+  if (a.taskId) return a.taskId
+  return `Session ${shortId(a.id)}`
+}

--- a/frontend/src/pages/AgentDetail.svelte.test.ts
+++ b/frontend/src/pages/AgentDetail.svelte.test.ts
@@ -6,6 +6,9 @@ import {
   agentPluginErrors,
 } from '../lib/events.js'
 import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
+import { taskStore } from '../stores/tasks.svelte.js'
+
+const mockTasks = taskStore.tasks as Map<string, unknown>
 
 const mockStop = vi.fn()
 const mockUpdateAgent = vi.fn()
@@ -74,6 +77,7 @@ describe('AgentDetail', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockAgents.clear()
+    mockTasks.clear()
     for (const k of Object.keys(eventHandlers)) delete eventHandlers[k]
   })
 
@@ -98,8 +102,19 @@ describe('AgentDetail', () => {
     })
   })
 
-  it('shows project name as title', async () => {
+  it('shows the session name as the title', async () => {
     mockAgents.set('agent-1', { ...mockAgent })
+    render(AgentDetail, {
+      props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => {
+      const heading = screen.getByRole('heading', { level: 1 })
+      expect(heading.textContent).toBe('test-session')
+    })
+  })
+
+  it('shows the project as the title when there is no name', async () => {
+    mockAgents.set('agent-1', { ...mockAgent, name: '' })
     render(AgentDetail, {
       props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
     })
@@ -109,15 +124,31 @@ describe('AgentDetail', () => {
     })
   })
 
-  it('falls back to agent id when project is empty', async () => {
-    mockAgents.set('agent-1', { ...mockAgent, project: '' })
+  it('shows a labelled session id when name, project and task are empty', async () => {
+    mockAgents.set('agent-1', { ...mockAgent, name: '', project: '', taskId: '' })
     render(AgentDetail, {
       props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
     })
     await vi.waitFor(() => {
       const heading = screen.getByRole('heading', { level: 1 })
-      expect(heading.textContent).toBe('agent-1')
+      expect(heading.textContent).toBe('Session agent-1')
     })
+  })
+
+  it('shows the task name once for a role-prefixed agent with a linked task', async () => {
+    // Review agent: name is `review:<task title>`, task linked. The heading is
+    // the task title; the role-stripped subtitle must not repeat it.
+    mockTasks.set('task-1', { id: 'task-1', title: 'Fix the auth bug' })
+    mockAgents.set('agent-1', { ...mockAgent, name: 'review:Fix the auth bug' })
+    render(AgentDetail, {
+      props: { agentId: 'agent-1', onback: vi.fn(), onviewtask: vi.fn() },
+    })
+    await vi.waitFor(() => {
+      expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Fix the auth bug')
+    })
+    // Appears exactly once — no duplicate subtitle, no `review:` prefix anywhere.
+    expect(screen.getAllByText('Fix the auth bug')).toHaveLength(1)
+    expect(screen.queryByText('review:Fix the auth bug')).toBeNull()
   })
 
   it('shows Stop button when agent is running', async () => {
@@ -174,7 +205,7 @@ describe('AgentDetail', () => {
     await vi.waitFor(() => {
       expect(screen.getByText('headless')).toBeDefined()
       expect(screen.getByText('external')).toBeDefined()
-      expect(screen.getByText('task-1')).toBeDefined()
+      expect(screen.getByText('View task →')).toBeDefined()
       expect(screen.getByText('$0.57')).toBeDefined()
       expect(screen.getByText('12345')).toBeDefined()
       expect(screen.getByText('sess-123')).toBeDefined()

--- a/frontend/src/pages/ChatList.svelte
+++ b/frontend/src/pages/ChatList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { timeAgo } from '$lib/dates.js'
+  import { agentDisplayName } from '$lib/agent-name.js'
   import type { Agent } from '../../bindings/github.com/Automaat/sybra/internal/agent/models.js'
   import { agentStore } from '../stores/agents.svelte.js'
   import { projectStore } from '../stores/projects.svelte.js'
@@ -75,7 +76,7 @@
           <div class="min-w-0 flex-1">
             <div class="flex items-center gap-2">
               <span class="truncate text-sm font-medium text-surface-900 dark:text-surface-100">
-                {a.name || a.taskId || a.id}
+                {agentDisplayName(a)}
               </span>
               {#if a.project}
                 <span class="shrink-0 rounded bg-surface-100 px-1.5 py-0.5 text-[10px] text-surface-500 dark:bg-surface-700">

--- a/frontend/src/pages/ChatList.svelte.test.ts
+++ b/frontend/src/pages/ChatList.svelte.test.ts
@@ -106,10 +106,11 @@ describe('ChatList', () => {
     expect(screen.getByText('org/myrepo')).toBeDefined()
   })
 
-  it('shows agent id when name and taskId are empty', () => {
-    mockAgentList.push(makeAgent({ name: '', taskId: '', id: 'agent-abc123' }))
+  it('shows a friendly session label instead of a bare id', () => {
+    mockAgentList.push(makeAgent({ name: '', taskId: '', project: '', id: 'ext-codex-abcdef12' }))
     render(ChatList, { props: { onselect: vi.fn() } })
-    expect(screen.getByText('agent-abc123')).toBeDefined()
+    // Trailing entropy kept so distinct ext-codex- sessions don't collide.
+    expect(screen.getByText('Session abcdef12')).toBeDefined()
   })
 
   it('only shows interactive agents (not headless)', () => {


### PR DESCRIPTION
## Motivation

Agent Detail's heading was an opaque hash, the task name repeated up to three times (subtitle, Task field, an overflowing "Session Name" box), a doubled `review:Review …` prefix showed across Agents/Chats/Dashboard, and sessions/chats read as raw `ext-…` ids (issue #916).

## Implementation information

- New `lib/agent-name.ts` with `agentDisplayName` / `cleanAgentName` / `shortId`, used by AgentHeader, AgentCard, AgentSidebarList and ChatList.
- **Friendly name once**: the detail heading is `task title > cleaned session name > project > task id > Session <shortId>`; the opaque id is demoted to a small chip; the duplicate "Session Name" field is removed; the "Task" field becomes a "View task →" link (no title repeat). The subtitle is shown only when it differs from the heading.
- **`cleanAgentName`** strips the technical role prefix that `internal/agent/role.go` prepends (`review:`, `plan:`, `fix-review:`, …). A review agent named `review:Review the PR` now reads as `Review the PR` — killing the `review:Review …` doubling at the display layer (matched against the real role set, case-sensitive, so human-typed `Review:` labels are untouched).
- **`shortId`** keeps an id's trailing entropy rather than the front, so Codex sessions sharing the 10-char `ext-codex-` prefix stay distinguishable.

A pre-PR adversarial review (which read the Go source) caught that my first attempt targeted the wrong name shape (`review:Review:` double-colon, which is never produced) and that front-truncation collided on `ext-codex-`. Both are fixed here; the role-prefix + trailing-entropy approach is grounded in `role.go` / `discovery.go`. Added a test that exercises the real `review:<title>` + linked-task path to prove the name renders once.

Closes #916

> Changelog: feat(agents): clean identity & header redundancy