### PR TITLE
feat(agents): unify chats & agents list layout

### DIFF
--- a/frontend/src/components/AgentListRow.svelte
+++ b/frontend/src/components/AgentListRow.svelte
@@ -29,19 +29,20 @@
 
   // Single-line intent under the name: live step text while running, the
   // pending action otherwise, falling back to a distinct session name.
-  const intent = $derived(
-    phase === 'running'
-      ? (agentStore.stepTexts.get(a.id) ?? 'Working...')
-      : phase === 'human-required'
-        ? 'Waiting for human input'
-        : phase === 'waiting'
-          ? 'Waiting for reply'
-          : phase === 'blocked'
-            ? 'Awaiting tool approval'
-            : subtitle && subtitle !== heading
-              ? subtitle
-              : '',
-  )
+  const intent = $derived.by(() => {
+    switch (phase) {
+      case 'running':
+        return agentStore.stepTexts.get(a.id) ?? 'Working...'
+      case 'human-required':
+        return 'Waiting for human input'
+      case 'waiting':
+        return 'Waiting for reply'
+      case 'blocked':
+        return 'Awaiting tool approval'
+      default:
+        return subtitle && subtitle !== heading ? subtitle : ''
+    }
+  })
 </script>
 
 <button

--- a/frontend/src/components/AgentListRow.svelte
+++ b/frontend/src/components/AgentListRow.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  import type { Agent } from '../../bindings/github.com/Automaat/sybra/internal/agent/models.js'
+  import { agentStore } from '../stores/agents.svelte.js'
+  import { taskStore } from '../stores/tasks.svelte.js'
+  import { getAgentPhase, PHASE_CONFIG } from '$lib/agent-phases.js'
+  import AgentStateBadge from './AgentStateBadge.svelte'
+  import { clock } from '$lib/clock.svelte.js'
+  import { formatElapsed } from '$lib/elapsed.js'
+  import { timeAgo } from '$lib/dates.js'
+  import { agentDisplayName, cleanAgentName } from '$lib/agent-name.js'
+
+  interface Props {
+    agent: Agent
+    onclick: () => void
+  }
+
+  const { agent: a, onclick }: Props = $props()
+
+  const linkedTask = $derived(a.taskId ? taskStore.tasks.get(a.taskId) : null)
+  const heading = $derived(agentDisplayName(a, linkedTask?.title))
+  const subtitle = $derived(cleanAgentName(a.name))
+
+  const phase = $derived(getAgentPhase(a.state, a.escalationReason, linkedTask?.status, a.awaitingApproval))
+  const config = $derived(PHASE_CONFIG[phase])
+
+  const isActivePhase = $derived(
+    phase === 'running' || phase === 'blocked' || phase === 'waiting' || phase === 'human-required',
+  )
+
+  // Single-line intent under the name: live step text while running, the
+  // pending action otherwise, falling back to a distinct session name.
+  const intent = $derived(
+    phase === 'running'
+      ? (agentStore.stepTexts.get(a.id) ?? 'Working...')
+      : phase === 'human-required'
+        ? 'Waiting for human input'
+        : phase === 'waiting'
+          ? 'Waiting for reply'
+          : phase === 'blocked'
+            ? 'Awaiting tool approval'
+            : subtitle && subtitle !== heading
+              ? subtitle
+              : '',
+  )
+</script>
+
+<button
+  type="button"
+  class="flex w-full items-center gap-3 rounded-lg border border-surface-200 bg-white px-3 py-2 text-left transition-colors hover:bg-surface-50 dark:border-surface-700 dark:bg-surface-800 dark:hover:bg-surface-700 {config.faded ? 'opacity-60' : ''}"
+  onclick={onclick}
+>
+  <div class="min-w-0 flex-1">
+    <div class="flex items-center gap-2">
+      <span class="truncate text-sm font-medium text-surface-900 dark:text-surface-100">{heading}</span>
+      {#if a.external}
+        <span class="shrink-0 rounded bg-warning-100 px-1.5 py-0.5 text-[10px] text-warning-700 dark:bg-warning-900 dark:text-warning-300">external</span>
+      {/if}
+      {#if a.project}
+        <span class="shrink-0 truncate rounded bg-surface-100 px-1.5 py-0.5 text-[10px] text-surface-500 dark:bg-surface-700">{a.project}</span>
+      {/if}
+    </div>
+    {#if intent}
+      <p class="truncate text-xs {phase === 'human-required' ? 'font-medium text-error-600 dark:text-error-400' : 'text-surface-500'}">{intent}</p>
+    {/if}
+  </div>
+
+  <AgentStateBadge {phase} />
+
+  <div class="flex shrink-0 flex-col items-end gap-0.5">
+    {#if a.costUsd > 0}
+      <span class="text-xs text-surface-500">${a.costUsd.toFixed(2)}</span>
+    {/if}
+    <span class="text-[10px] text-surface-400">
+      {isActivePhase ? formatElapsed(a.startedAt, clock.now) : timeAgo(a.startedAt)}
+    </span>
+  </div>
+</button>

--- a/frontend/src/components/AgentListRow.svelte.test.ts
+++ b/frontend/src/components/AgentListRow.svelte.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/svelte'
+import AgentListRow from './AgentListRow.svelte'
+import { taskStore } from '../stores/tasks.svelte.js'
+import type { Agent } from '../../bindings/github.com/Automaat/sybra/internal/agent/models.js'
+import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
+
+const clockMock = vi.hoisted(() => ({ now: Date.now() }))
+vi.mock('$lib/clock.svelte.js', () => ({ clock: clockMock }))
+
+function makeAgent(overrides: Record<string, unknown> = {}): Agent {
+  return {
+    id: 'agent-1',
+    taskId: 'task-1',
+    mode: 'interactive',
+    state: 'paused',
+    sessionId: '',
+    costUsd: 0.42,
+    startedAt: '2026-04-01T00:00:00Z',
+    external: false,
+    pid: 0,
+    command: '',
+    name: 'review:Fix the bug',
+    project: 'sybra',
+    lastEventAt: '',
+    convertValues: () => {},
+    ...overrides,
+  } as unknown as Agent
+}
+
+function makeTask(overrides: Record<string, unknown> = {}): Task {
+  return {
+    id: 'task-1',
+    title: 'Test task',
+    status: 'todo',
+    convertValues: () => {},
+    ...overrides,
+  } as unknown as Task
+}
+
+describe('AgentListRow', () => {
+  afterEach(() => {
+    cleanup()
+    taskStore.tasks = new Map()
+  })
+
+  it('renders the friendly task title and the state badge', () => {
+    taskStore.tasks = new Map([['task-1', makeTask({ title: 'Implement auth', status: 'todo' })]])
+    render(AgentListRow, { props: { agent: makeAgent({ state: 'paused' }), onclick: () => {} } })
+    expect(screen.getByText('Implement auth')).toBeDefined()
+    // The shared AgentStateBadge renders the phase label (paused → Waiting).
+    expect(screen.getByText('Waiting')).toBeDefined()
+  })
+
+  it('renders the project chip and cost', () => {
+    render(AgentListRow, { props: { agent: makeAgent(), onclick: () => {} } })
+    expect(screen.getByText('sybra')).toBeDefined()
+    expect(screen.getByText('$0.42')).toBeDefined()
+  })
+
+  it('strips the role prefix when there is no linked task', () => {
+    render(AgentListRow, { props: { agent: makeAgent({ taskId: '' }), onclick: () => {} } })
+    expect(screen.getByText('Fix the bug')).toBeDefined()
+  })
+
+  it('fires onclick when the row is clicked', async () => {
+    const onclick = vi.fn()
+    render(AgentListRow, { props: { agent: makeAgent(), onclick } })
+    await fireEvent.click(screen.getByRole('button'))
+    expect(onclick).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/lib/agent-phases.ts
+++ b/frontend/src/lib/agent-phases.ts
@@ -36,8 +36,9 @@ export const PHASE_CONFIG: Record<AgentPhase, PhaseConfig> = {
     phase: 'waiting',
     label: 'Waiting',
     body: 'Agent has paused and is waiting for your reply.',
-    dotClasses: 'bg-surface-400 dark:bg-surface-500',
-    badgeClasses: 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-300',
+    // Distinct from the gray "Queued" — "Waiting" means it's your turn.
+    dotClasses: 'bg-secondary-500',
+    badgeClasses: 'bg-secondary-200 text-secondary-800 dark:bg-secondary-700 dark:text-secondary-200',
     animate: false,
     faded: false,
   },

--- a/frontend/src/pages/AgentList.svelte
+++ b/frontend/src/pages/AgentList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { SegmentedControl } from '@skeletonlabs/skeleton-svelte'
   import { agentStore } from '../stores/agents.svelte.js'
-  import AgentCard from '../components/AgentCard.svelte'
+  import AgentListRow from '../components/AgentListRow.svelte'
   import { EventsOn } from '$lib/api'
   import { agentOutput } from '../lib/events.js'
   import { extractStepText } from '$lib/step-text.js'
@@ -64,9 +64,9 @@
       <p class="text-sm">Start an agent from a task to see it here</p>
     </div>
   {:else}
-    <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+    <div class="flex flex-col gap-1.5">
       {#each filtered as a (a.id)}
-        <AgentCard agent={a} onclick={() => onselect(a.id)} />
+        <AgentListRow agent={a} onclick={() => onselect(a.id)} />
       {/each}
     </div>
   {/if}

--- a/frontend/src/pages/AgentList.svelte.test.ts
+++ b/frontend/src/pages/AgentList.svelte.test.ts
@@ -77,14 +77,17 @@ describe('AgentList', () => {
     expect(screen.getByText('Start an agent from a task to see it here')).toBeDefined()
   })
 
-  it('renders agent cards when agents exist', () => {
+  it('renders agents in a dense list (not a card grid)', () => {
     const agents = [
       makeAgent({ id: 'a1', state: 'running' }),
       makeAgent({ id: 'a2', state: 'idle' }),
     ]
     mockByState.mockReturnValue(agents)
-    render(AgentList, { props: { onselect: vi.fn() } })
+    const { container } = render(AgentList, { props: { onselect: vi.fn() } })
     expect(screen.queryByText('No agents')).toBeNull()
     expect(mockByState).toHaveBeenCalledWith('all')
+    // Shared list layout: a vertical flex stack of rows, not a 3-col grid.
+    expect(container.querySelector('.flex.flex-col.gap-1\\.5')).not.toBeNull()
+    expect(container.querySelector('.grid')).toBeNull()
   })
 })

--- a/frontend/src/pages/ChatList.svelte
+++ b/frontend/src/pages/ChatList.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
-  import { timeAgo } from '$lib/dates.js'
-  import { agentDisplayName } from '$lib/agent-name.js'
   import type { Agent } from '../../bindings/github.com/Automaat/sybra/internal/agent/models.js'
   import { agentStore } from '../stores/agents.svelte.js'
   import { projectStore } from '../stores/projects.svelte.js'
-  import { getAgentPhase, PHASE_CONFIG } from '$lib/agent-phases.js'
+  import AgentListRow from '../components/AgentListRow.svelte'
   import NewChatDialog from '../components/NewChatDialog.svelte'
   import { MessageCircle } from '@lucide/svelte'
 
@@ -29,11 +27,6 @@
   const interactiveAgents = $derived(
     agentStore.list.filter((a: Agent) => a.mode === 'interactive'),
   )
-
-  function agentPhaseConfig(a: Agent) {
-    return PHASE_CONFIG[getAgentPhase(a.state, a.escalationReason, undefined, a.awaitingApproval)]
-  }
-
 </script>
 
 <div class="flex flex-col gap-3 p-4 md:gap-4 md:p-6">
@@ -60,43 +53,9 @@
       </button>
     </div>
   {:else}
-    <div class="flex flex-col gap-2">
+    <div class="flex flex-col gap-1.5">
       {#each interactiveAgents as a (a.id)}
-        <button
-          type="button"
-          class="flex items-center gap-3 rounded-lg border border-surface-200 bg-white p-4 text-left transition-colors
-            hover:bg-surface-50 dark:border-surface-700 dark:bg-surface-800 dark:hover:bg-surface-750"
-          onclick={() => onselect(a.id)}
-        >
-          <!-- Status dot -->
-          <span class="h-2.5 w-2.5 shrink-0 rounded-full {agentPhaseConfig(a).dotClasses}
-            {agentPhaseConfig(a).animate ? 'animate-pulse' : ''}"></span>
-
-          <!-- Content -->
-          <div class="min-w-0 flex-1">
-            <div class="flex items-center gap-2">
-              <span class="truncate text-sm font-medium text-surface-900 dark:text-surface-100">
-                {agentDisplayName(a)}
-              </span>
-              {#if a.project}
-                <span class="shrink-0 rounded bg-surface-100 px-1.5 py-0.5 text-[10px] text-surface-500 dark:bg-surface-700">
-                  {a.project}
-                </span>
-              {/if}
-            </div>
-            <p class="mt-0.5 text-xs text-surface-500">
-              {agentPhaseConfig(a).label}
-            </p>
-          </div>
-
-          <!-- Meta -->
-          <div class="flex shrink-0 flex-col items-end gap-1">
-            {#if a.costUsd > 0}
-              <span class="text-xs text-surface-500">${a.costUsd.toFixed(2)}</span>
-            {/if}
-            <span class="text-[10px] text-surface-400">{timeAgo(a.startedAt)}</span>
-          </div>
-        </button>
+        <AgentListRow agent={a} onclick={() => onselect(a.id)} />
       {/each}
     </div>
   {/if}

--- a/frontend/src/pages/ChatList.svelte.test.ts
+++ b/frontend/src/pages/ChatList.svelte.test.ts
@@ -8,6 +8,7 @@ vi.mock('../stores/agents.svelte.js', () => ({
   agentStore: {
     get list() { return mockAgentList },
     get agents() { return new Map() },
+    stepTexts: new Map(),
   },
 }))
 
@@ -19,15 +20,6 @@ vi.mock('../stores/projects.svelte.js', () => ({
 }))
 
 vi.mock('../components/NewChatDialog.svelte', () => ({ default: () => {} }))
-
-vi.mock('$lib/agent-phases.js', () => ({
-  getAgentPhase: vi.fn(() => 'active'),
-  PHASE_CONFIG: {
-    active: { label: 'Running', dotClasses: 'bg-green-500', animate: true },
-    done: { label: 'Done', dotClasses: 'bg-gray-500', animate: false },
-    blocked: { label: 'Blocked', dotClasses: 'bg-red-500', animate: false },
-  },
-}))
 
 const ChatList = (await import('./ChatList.svelte')).default
 
@@ -119,5 +111,12 @@ describe('ChatList', () => {
     render(ChatList, { props: { onselect: vi.fn() } })
     expect(screen.getByText('interactive')).toBeDefined()
     expect(screen.queryByText('headless-agent')).toBeNull()
+  })
+
+  it('renders a paused chat with the distinct Waiting badge (not gray)', () => {
+    mockAgentList.push(makeAgent({ state: 'paused' }))
+    render(ChatList, { props: { onselect: vi.fn() } })
+    // The shared badge uses the secondary palette for Waiting, not surface gray.
+    expect(screen.getByText('Waiting').className).toContain('secondary')
   })
 })


### PR DESCRIPTION
## Motivation

Chats (tall full-width rows) and Agents (3-col card grid) used different layouts for the same kind of entity, and the state dots weren't color-distinct ("Queued" and "Waiting" both gray) — issue #917.

## Implementation information

- New shared **`AgentListRow`**: a dense, full-width row using the shared `AgentStateBadge` and the friendly `agentDisplayName`, with a single intent line (live step text while running, pending action otherwise), project/external chips, cost and elapsed/timeAgo.
- `AgentList` swaps its `grid-cols-3` card grid for a `flex flex-col` stack of `AgentListRow`; `ChatList` drops its bespoke rows for the same component. `AgentCard` stays for the Dashboard summary.
- `agent-phases.ts`: "Waiting" now uses the secondary (teal) dot + badge, distinct from gray "Queued".

A pre-PR adversarial review cleared the scary hypotheses (phase divergence from `linkedTask.status` — chat tasks are filtered out of the store; invisible `secondary-*` — it's a defined theme color; broken step-text subscription — intact). It flagged three nits, all fixed: an undefined `dark:hover:bg-surface-750` (now `surface-700`, restoring AgentList's dark hover), a stale `agent-phases` mock with a phantom phase in the ChatList test (removed; added a page-level assertion that Waiting renders with the secondary palette), and a weak AgentList test (now asserts a dense flex list, not a grid).

Closes #917

> Changelog: feat(agents): unify chats & agents list layout