### PR TITLE
feat(logbook): tag popover & consolidate taxonomy

### DIFF
--- a/frontend/src/components/TagFilterPopover.svelte
+++ b/frontend/src/components/TagFilterPopover.svelte
@@ -42,6 +42,8 @@
 <div class="relative">
   <button
     type="button"
+    aria-haspopup="listbox"
+    aria-expanded={open}
     class="flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium transition-colors {selected.length > 0
       ? 'border-primary-500 bg-primary-500/10 text-primary-700 dark:text-primary-300'
       : 'border-surface-300 bg-surface-50 hover:bg-surface-200 dark:border-surface-700 dark:bg-surface-800'}"
@@ -74,6 +76,7 @@
           <li>
             <button
               type="button"
+              aria-pressed={selected.includes(tag)}
               class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors hover:bg-surface-200 dark:hover:bg-surface-700"
               onclick={() => toggle(tag)}
             >

--- a/frontend/src/components/TagFilterPopover.svelte
+++ b/frontend/src/components/TagFilterPopover.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import { Tag, Check } from '@lucide/svelte'
+
+  interface Props {
+    tags: string[]
+    selected: string[]
+    onchange: (selected: string[]) => void
+  }
+
+  const { tags, selected, onchange }: Props = $props()
+
+  let open = $state(false)
+  let query = $state('')
+
+  const filtered = $derived(
+    query.trim() ? tags.filter((t) => t.toLowerCase().includes(query.trim().toLowerCase())) : tags,
+  )
+
+  function toggle(tag: string) {
+    onchange(selected.includes(tag) ? selected.filter((t) => t !== tag) : [...selected, tag])
+  }
+
+  function close() {
+    open = false
+    query = ''
+  }
+
+  $effect(() => {
+    if (!open) return
+    function onKeydown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        e.stopImmediatePropagation()
+        close()
+      }
+    }
+    window.addEventListener('keydown', onKeydown, { capture: true })
+    return () => window.removeEventListener('keydown', onKeydown, { capture: true })
+  })
+</script>
+
+<div class="relative">
+  <button
+    type="button"
+    class="flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium transition-colors {selected.length > 0
+      ? 'border-primary-500 bg-primary-500/10 text-primary-700 dark:text-primary-300'
+      : 'border-surface-300 bg-surface-50 hover:bg-surface-200 dark:border-surface-700 dark:bg-surface-800'}"
+    onclick={() => (open = !open)}
+  >
+    <Tag size={14} />
+    Filter by tag
+    {#if selected.length > 0}
+      <span class="rounded-full bg-primary-500 px-1.5 text-[10px] font-bold text-white">{selected.length}</span>
+    {/if}
+  </button>
+
+  {#if open}
+    <!-- Outside-click catcher -->
+    <button type="button" class="fixed inset-0 z-40 cursor-default" aria-label="Close tag filter" onclick={close}></button>
+
+    <div class="absolute left-0 z-50 mt-1 w-64 rounded-lg elevation-popover">
+      <div class="border-b border-surface-200 p-2 dark:border-surface-700">
+        <!-- svelte-ignore a11y_autofocus -->
+        <input
+          bind:value={query}
+          type="text"
+          placeholder="Search tags…"
+          autofocus
+          class="w-full rounded border border-surface-300 bg-surface-50 px-2 py-1 text-xs focus:border-primary-500 focus:outline-none dark:border-surface-700 dark:bg-surface-900"
+        />
+      </div>
+      <ul class="max-h-64 overflow-y-auto py-1">
+        {#each filtered as tag (tag)}
+          <li>
+            <button
+              type="button"
+              class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors hover:bg-surface-200 dark:hover:bg-surface-700"
+              onclick={() => toggle(tag)}
+            >
+              <span class="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded border {selected.includes(tag)
+                ? 'border-primary-500 bg-primary-500 text-white'
+                : 'border-surface-400'}">
+                {#if selected.includes(tag)}<Check size={10} strokeWidth={3} />{/if}
+              </span>
+              <span class="truncate">{tag}</span>
+            </button>
+          </li>
+        {:else}
+          <li class="px-3 py-2 text-xs text-surface-400">No matching tags</li>
+        {/each}
+      </ul>
+      {#if selected.length > 0}
+        <div class="border-t border-surface-200 p-2 dark:border-surface-700">
+          <button
+            type="button"
+            class="w-full rounded px-2 py-1 text-xs text-surface-500 hover:bg-surface-200 dark:hover:bg-surface-700"
+            onclick={() => onchange([])}
+          >
+            Clear {selected.length} tag{selected.length === 1 ? '' : 's'}
+          </button>
+        </div>
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/frontend/src/lib/tags.test.ts
+++ b/frontend/src/lib/tags.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeTag, canonicalTags, matchesCanonicalTags } from './tags.js'
+
+describe('normalizeTag', () => {
+  it('strips known grouping prefixes', () => {
+    expect(normalizeTag('kind/bug')).toBe('bug')
+    expect(normalizeTag('type/refactor')).toBe('refactor')
+    expect(normalizeTag('size/medium')).toBe('medium')
+    expect(normalizeTag('priority/normal')).toBe('normal')
+  })
+
+  it('collapses synonyms', () => {
+    expect(normalizeTag('performance')).toBe('perf')
+    expect(normalizeTag('testing')).toBe('test')
+    expect(normalizeTag('type/test')).toBe('test')
+    expect(normalizeTag('enhancement')).toBe('feature')
+  })
+
+  it('lowercases and trims', () => {
+    expect(normalizeTag('  Bug ')).toBe('bug')
+  })
+
+  it('leaves unknown prefixes intact', () => {
+    expect(normalizeTag('frontend/login')).toBe('frontend/login')
+  })
+
+  it('does not strip location namespaces (area/scope) — they carry meaning', () => {
+    // area/test must NOT collapse to the same canonical as type/test.
+    expect(normalizeTag('area/test')).toBe('area/test')
+    expect(normalizeTag('type/test')).toBe('test')
+    expect(normalizeTag('area/test')).not.toBe(normalizeTag('type/test'))
+  })
+
+  it('reduces stray-slash tags to empty', () => {
+    expect(normalizeTag('/')).toBe('')
+    expect(normalizeTag('kind/')).toBe('')
+  })
+
+  it('passes unknown bare tags through', () => {
+    expect(normalizeTag('backend')).toBe('backend')
+  })
+})
+
+describe('canonicalTags', () => {
+  it('dedupes variants to one sorted set', () => {
+    expect(canonicalTags(['bug', 'kind/bug', 'feature', 'enhancement', 'perf', 'performance'])).toEqual([
+      'bug',
+      'feature',
+      'perf',
+    ])
+  })
+
+  it('drops empties', () => {
+    expect(canonicalTags(['', '  ', 'bug'])).toEqual(['bug'])
+  })
+})
+
+describe('matchesCanonicalTags', () => {
+  it('matches a canonical selection against any variant', () => {
+    expect(matchesCanonicalTags(['kind/bug'], ['bug'])).toBe(true)
+    expect(matchesCanonicalTags(['bug'], ['bug'])).toBe(true)
+    expect(matchesCanonicalTags(['feature'], ['bug'])).toBe(false)
+  })
+
+  it('requires every selected tag (AND)', () => {
+    expect(matchesCanonicalTags(['bug', 'perf'], ['bug', 'perf'])).toBe(true)
+    expect(matchesCanonicalTags(['bug'], ['bug', 'perf'])).toBe(false)
+  })
+
+  it('empty selection matches everything', () => {
+    expect(matchesCanonicalTags(['bug'], [])).toBe(true)
+    expect(matchesCanonicalTags(undefined, [])).toBe(true)
+  })
+})

--- a/frontend/src/lib/tags.ts
+++ b/frontend/src/lib/tags.ts
@@ -1,0 +1,75 @@
+// Tag taxonomy normalization for the logbook.
+//
+// Tasks accumulate tags from several sources (manual, GitHub issue labels,
+// auto-sources), which produces heavy duplication: a grouping prefix
+// (`kind/bug`, `type/refactor`, `size/medium`, `priority/normal`) alongside the
+// bare term, plus synonyms (`performance`/`perf`, `testing`/`test`).
+//
+// `normalizeTag` collapses every variant to ONE canonical term so the logbook
+// shows a small, de-duplicated tag set. The canonical convention is the bare,
+// lowercase term (no grouping prefix); the documented vocabulary below is the
+// target set.
+
+// Grouping prefixes stripped from `<prefix>/<term>` tags. Deliberately excludes
+// location namespaces like `area/`/`scope/` — those carry meaning (an
+// `area/test` code-area is not a `type/test`), so stripping them would merge
+// semantically distinct tags.
+const GROUP_PREFIXES = new Set(['kind', 'type', 'size', 'priority'])
+
+/** Synonyms that don't reduce to a simple prefix strip. */
+const SYNONYMS: Record<string, string> = {
+  performance: 'perf',
+  testing: 'test',
+  tests: 'test',
+  enhancement: 'feature',
+  feat: 'feature',
+  docs: 'documentation',
+  doc: 'documentation',
+}
+
+/**
+ * Canonical, documented vocabulary the logbook normalizes toward. Not
+ * exhaustive (unknown tags pass through normalized), but records the intended
+ * de-duplicated set.
+ */
+export const CANONICAL_TAGS = [
+  'bug',
+  'feature',
+  'refactor',
+  'perf',
+  'test',
+  'documentation',
+  'chore',
+  'small',
+  'medium',
+  'large',
+  'low',
+  'normal',
+  'high',
+] as const
+
+/** Reduce a raw tag to its canonical form (empty for meaningless tags). */
+export function normalizeTag(tag: string): string {
+  const lower = tag.trim().toLowerCase()
+  const slash = lower.indexOf('/')
+  const stripped = slash > 0 && GROUP_PREFIXES.has(lower.slice(0, slash)) ? lower.slice(slash + 1) : lower
+  // Drop stray slashes/whitespace (e.g. `/`, `kind/`) so they never become chips.
+  const base = stripped.replace(/^\/+|\/+$/g, '').trim()
+  return SYNONYMS[base] ?? base
+}
+
+/** Distinct, sorted canonical tags from a raw tag list. */
+export function canonicalTags(tags: string[]): string[] {
+  return [...new Set(tags.map(normalizeTag))].filter(Boolean).sort()
+}
+
+/**
+ * True when a task's tags satisfy every selected canonical tag (a task matches
+ * canonical `bug` whether tagged `bug`, `kind/bug`, etc.). Empty selection
+ * matches everything.
+ */
+export function matchesCanonicalTags(taskTags: string[] | undefined, selected: string[]): boolean {
+  if (selected.length === 0) return true
+  const normalized = new Set((taskTags ?? []).map(normalizeTag))
+  return selected.every((t) => normalized.has(t))
+}

--- a/frontend/src/pages/Logbook.svelte
+++ b/frontend/src/pages/Logbook.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { taskStore } from '../stores/tasks.svelte.js'
-  import { matchesQuery, matchesProject, matchesTags, matchesDateRange } from '../lib/task-filters.js'
+  import { matchesQuery, matchesProject, matchesDateRange } from '../lib/task-filters.js'
+  import { canonicalTags, matchesCanonicalTags } from '../lib/tags.js'
   import { toUtcDayStart, toUtcDayEnd, formatShortDate } from '../lib/dates.js'
   import TaskFilterPanel from '../components/TaskFilterPanel.svelte'
+  import TagFilterPopover from '../components/TagFilterPopover.svelte'
   import StatusBadge from '../components/StatusBadge.svelte'
 
   interface Props {
@@ -32,7 +34,7 @@
   )
 
   const allTags = $derived(
-    [...new Set(logbookTasks.flatMap((t: Task) => t.tags ?? []))].sort(),
+    canonicalTags(logbookTasks.flatMap((t: Task) => t.tags ?? [])),
   )
 
   const filteredTasks = $derived.by(() => {
@@ -44,7 +46,7 @@
         if (selectedStatus !== 'all' && t.status !== selectedStatus) return false
         if (!matchesQuery(t, searchQuery)) return false
         if (!matchesProject(t, selectedProjectId)) return false
-        if (!matchesTags(t, selectedTags)) return false
+        if (!matchesCanonicalTags(t.tags, selectedTags)) return false
         if (!matchesDateRange(t, from, to, 'closedAt')) return false
         return true
       })
@@ -102,6 +104,10 @@
       hasActive={hasActiveFilters}
     />
 
+    {#if allTags.length > 0}
+      <TagFilterPopover tags={allTags} selected={selectedTags} onchange={(s) => (selectedTags = s)} />
+    {/if}
+
     <!-- Sort toggle (page-specific, kept inline) -->
     <button
       type="button"
@@ -112,26 +118,6 @@
       {sortAsc ? '↑ Oldest' : '↓ Newest'}
     </button>
   </div>
-
-  <!-- Tag filter row -->
-  {#if allTags.length > 0}
-    <div class="flex flex-wrap gap-1.5 border-b border-surface-200 px-4 py-2 dark:border-surface-700">
-      {#each allTags as tag}
-        <button
-          type="button"
-          class="rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors {selectedTags.includes(tag)
-            ? 'border-primary-500 bg-primary-500 text-white'
-            : 'border-surface-300 bg-surface-100 text-surface-600 hover:bg-surface-200 dark:border-surface-600 dark:bg-surface-800 dark:text-surface-300}'}"
-          onclick={() =>
-            selectedTags.includes(tag)
-              ? (selectedTags = selectedTags.filter((t) => t !== tag))
-              : (selectedTags = [...selectedTags, tag])}
-        >
-          {tag}
-        </button>
-      {/each}
-    </div>
-  {/if}
 
   <!-- Task list -->
   <div class="min-h-0 flex-1 overflow-y-auto">
@@ -171,7 +157,7 @@
               <td class="hidden px-4 py-2 text-surface-500 md:table-cell">{t.projectId || '—'}</td>
               <td class="hidden px-4 py-2 lg:table-cell">
                 <div class="flex flex-wrap gap-1">
-                  {#each t.tags ?? [] as tag}
+                  {#each canonicalTags(t.tags ?? []) as tag}
                     <span class="rounded-full bg-surface-200 px-1.5 py-0.5 text-xs dark:bg-surface-700">{tag}</span>
                   {/each}
                 </div>

--- a/frontend/src/pages/Logbook.svelte.test.ts
+++ b/frontend/src/pages/Logbook.svelte.test.ts
@@ -238,13 +238,13 @@ describe('Logbook', () => {
   })
 
   describe('tag filtering', () => {
-    it('renders tag pills from logbook tasks', () => {
+    it('lists tags in the filter popover', async () => {
       Object.assign(taskStore, {
         list: [makeTask({ id: 't1', status: 'done', tags: ['backend', 'api'] })],
       })
       render(Logbook, { props: { onviewtask: vi.fn() } })
-      const tagButtons = screen.getAllByText('backend')
-      expect(tagButtons.length).toBeGreaterThan(0)
+      await fireEvent.click(screen.getByText('Filter by tag'))
+      expect(screen.getAllByText('backend').length).toBeGreaterThan(0)
     })
 
     it('filters tasks by selected tag', async () => {
@@ -255,13 +255,31 @@ describe('Logbook', () => {
         ],
       })
       render(Logbook, { props: { onviewtask: vi.fn() } })
-      const tagPills = screen.getAllByText('backend')
-      await fireEvent.click(tagPills[0])
+      await fireEvent.click(screen.getByText('Filter by tag'))
+      // First 'backend' in DOM order is the popover option (filter bar precedes the table).
+      await fireEvent.click(screen.getAllByText('backend')[0].closest('button')!)
       expect(screen.getByText('Backend task')).toBeDefined()
       expect(screen.queryByText('Frontend task')).toBeNull()
     })
 
-    it('does not show tag pills from non-logbook tasks', () => {
+    it('normalizes duplicate tag variants to one canonical option', async () => {
+      Object.assign(taskStore, {
+        list: [
+          makeTask({ id: 't1', title: 'Bug A', status: 'done', tags: ['kind/bug'] }),
+          makeTask({ id: 't2', title: 'Bug B', status: 'done', tags: ['bug'] }),
+        ],
+      })
+      render(Logbook, { props: { onviewtask: vi.fn() } })
+      await fireEvent.click(screen.getByText('Filter by tag'))
+      // Both variants collapse to a single canonical 'bug' option in the popover.
+      const bugOptions = screen.getAllByText('bug').filter((el) => el.closest('button'))
+      await fireEvent.click(bugOptions[0].closest('button')!)
+      // Selecting canonical 'bug' matches both the 'bug' and 'kind/bug' tasks.
+      expect(screen.getByText('Bug A')).toBeDefined()
+      expect(screen.getByText('Bug B')).toBeDefined()
+    })
+
+    it('does not list tags from non-logbook tasks in the popover', async () => {
       Object.assign(taskStore, {
         list: [
           makeTask({ id: 't1', status: 'done', tags: ['done-tag'] }),
@@ -269,6 +287,8 @@ describe('Logbook', () => {
         ],
       })
       render(Logbook, { props: { onviewtask: vi.fn() } })
+      await fireEvent.click(screen.getByText('Filter by tag'))
+      expect(screen.getAllByText('done-tag').length).toBeGreaterThan(0)
       expect(screen.queryByText('todo-tag')).toBeNull()
     })
   })


### PR DESCRIPTION
## Motivation

The Logbook rendered a ~49-chip always-on tag cloud across three rows, and the vocabulary had heavy duplication (`bug` vs `kind/bug`, `refactor` vs `type/refactor`, `medium` vs `size/medium`, `perf` vs `performance`, `test` vs `testing`, …) — issue #918.

## Implementation information

- **Compact popover**: a new searchable `TagFilterPopover` (trigger button with a selected-count badge, search input, checkbox list, clear-all) replaces the always-on cloud.
- **Canonical taxonomy** in `lib/tags.ts`: `normalizeTag` strips the `kind/`/`type/`/`size/`/`priority/` grouping prefixes and maps synonyms (performance→perf, testing→test, enhancement→feature, …) to one documented `CANONICAL_TAGS` set; `matchesCanonicalTags` makes a canonical selection match every raw variant. The Logbook shows canonical tags in both the popover and the row chips.

A pre-PR adversarial review caught three real issues, all fixed: (1) `area/`/`scope/` were initially stripped too, collapsing semantically distinct location tags (`area/test` ≡ `type/test`) — they're now preserved; (2) the row Tags column showed raw tags while the popover showed canonical — now both canonical; (3) a stray `/` tag leaked a meaningless chip — `normalizeTag` now reduces stray slashes to empty. Also added Escape-to-close on the popover to match the house picker pattern.

Closes #918

> Changelog: feat(logbook): tag popover & consolidate taxonomy