### PR TITLE
feat(workflows): layered graph layout & handles

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@dagrejs/dagre": "^3.0.0",
         "@lucide/svelte": "^1.8.0",
         "@wailsio/runtime": "3.0.0-alpha.79",
         "@xyflow/svelte": "^1.5.2",
@@ -338,6 +339,21 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@dagrejs/dagre": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
+      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "4.0.1"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
+      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
+      "license": "MIT"
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -638,9 +654,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -658,9 +671,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -678,9 +688,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -698,9 +705,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -718,9 +722,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -738,9 +739,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -758,9 +756,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -778,9 +773,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -967,9 +959,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -987,9 +976,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1007,9 +993,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1027,9 +1010,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1047,9 +1027,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1067,9 +1044,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1402,9 +1376,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1422,9 +1393,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1442,9 +1410,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1462,9 +1427,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3394,9 +3356,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3418,9 +3377,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3442,9 +3398,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3466,9 +3419,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "vitest": "4.1.8"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
     "@lucide/svelte": "^1.8.0",
     "@wailsio/runtime": "3.0.0-alpha.79",
     "@xyflow/svelte": "^1.5.2",

--- a/frontend/src/components/workflow/WorkflowGraph.svelte
+++ b/frontend/src/components/workflow/WorkflowGraph.svelte
@@ -29,7 +29,7 @@
   } as unknown as NodeTypes
 </script>
 
-<div class="h-full w-full">
+<div class="wf-graph h-full w-full">
   <SvelteFlow
     {nodes}
     {edges}
@@ -47,3 +47,24 @@
     <MiniMap />
   </SvelteFlow>
 </div>
+
+<style>
+  /* Restyle the default white handle stubs into intentional muted connectors.
+     Scoped under .wf-graph so other (future) xyflow graphs are unaffected. */
+  :global(.wf-graph .svelte-flow__handle) {
+    width: 8px;
+    height: 8px;
+    background: #94a3b8; /* slate-400 */
+    border: 2px solid #fff;
+    border-radius: 9999px;
+  }
+  :global(.dark .wf-graph .svelte-flow__handle) {
+    background: #64748b; /* slate-500 */
+    border-color: #1e293b; /* surface-800 */
+  }
+  :global(.wf-graph .svelte-flow__handle.connectingfrom),
+  :global(.wf-graph .svelte-flow__handle.connectionindicator),
+  :global(.wf-graph .svelte-flow__handle:hover) {
+    background: #3b82f6; /* primary — clearly a connector when interacting */
+  }
+</style>

--- a/frontend/src/lib/graph-layout.test.ts
+++ b/frontend/src/lib/graph-layout.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import type { Node, Edge } from '@xyflow/svelte'
+import { layoutGraph } from './graph-layout.js'
+
+function node(id: string): Node {
+  return { id, type: 'stepNode', position: { x: 0, y: 0 }, data: {} }
+}
+
+describe('layoutGraph', () => {
+  it('lays a chain out top-to-bottom by default', () => {
+    const nodes = [node('a'), node('b'), node('c')]
+    const edges: Edge[] = [
+      { id: 'a-b', source: 'a', target: 'b' },
+      { id: 'b-c', source: 'b', target: 'c' },
+    ]
+    const laid = layoutGraph(nodes, edges)
+    const y = (id: string) => laid.find((n) => n.id === id)!.position.y
+    expect(y('a')).toBeLessThan(y('b'))
+    expect(y('b')).toBeLessThan(y('c'))
+  })
+
+  it('lays out left-to-right when asked', () => {
+    const nodes = [node('a'), node('b')]
+    const edges: Edge[] = [{ id: 'a-b', source: 'a', target: 'b' }]
+    const laid = layoutGraph(nodes, edges, 'LR')
+    const x = (id: string) => laid.find((n) => n.id === id)!.position.x
+    expect(x('a')).toBeLessThan(x('b'))
+  })
+
+  it('preserves node data and type', () => {
+    const n = { ...node('a'), data: { label: 'keep' }, type: 'triggerNode' as const }
+    const [laid] = layoutGraph([n], [])
+    expect(laid.data).toEqual({ label: 'keep' })
+    expect(laid.type).toBe('triggerNode')
+  })
+
+  it('ignores edges referencing missing nodes', () => {
+    const nodes = [node('a')]
+    const edges: Edge[] = [{ id: 'a-x', source: 'a', target: 'ghost' }]
+    expect(() => layoutGraph(nodes, edges)).not.toThrow()
+  })
+})

--- a/frontend/src/lib/graph-layout.ts
+++ b/frontend/src/lib/graph-layout.ts
@@ -1,0 +1,39 @@
+import dagre from '@dagrejs/dagre'
+import type { Node, Edge } from '@xyflow/svelte'
+
+// Fallback node dimensions used before xyflow measures the real DOM nodes.
+const NODE_W = 180
+const NODE_H = 72
+
+export type LayoutDirection = 'TB' | 'LR'
+
+/**
+ * Assign layered DAG positions to graph nodes with dagre, so edges flow in one
+ * consistent direction instead of crisscrossing. Returns new node objects with
+ * updated `position`; node data/type are preserved. Default direction is
+ * top-to-bottom (`TB`).
+ */
+export function layoutGraph(nodes: Node[], edges: Edge[], direction: LayoutDirection = 'TB'): Node[] {
+  const g = new dagre.graphlib.Graph()
+  g.setDefaultEdgeLabel(() => ({}))
+  g.setGraph({ rankdir: direction, nodesep: 60, ranksep: 90 })
+
+  for (const n of nodes) {
+    g.setNode(n.id, { width: n.width ?? NODE_W, height: n.height ?? NODE_H })
+  }
+  for (const e of edges) {
+    // Only lay out edges whose endpoints are present as nodes.
+    if (g.hasNode(e.source) && g.hasNode(e.target)) g.setEdge(e.source, e.target)
+  }
+
+  dagre.layout(g)
+
+  return nodes.map((n) => {
+    const laid = g.node(n.id)
+    if (!laid) return n
+    const w = n.width ?? NODE_W
+    const h = n.height ?? NODE_H
+    // dagre returns the node center; xyflow positions are the top-left corner.
+    return { ...n, position: { x: laid.x - w / 2, y: laid.y - h / 2 } }
+  })
+}

--- a/frontend/src/lib/workflow-graph.test.ts
+++ b/frontend/src/lib/workflow-graph.test.ts
@@ -47,10 +47,37 @@ describe('definitionToGraph', () => {
     expect(trigger?.position).toEqual({ x: 100, y: 200 })
   })
 
-  it('uses default trigger position when not set', () => {
+  it('auto-positions the trigger when no positions are set', () => {
     const { nodes } = definitionToGraph(makeDef())
     const trigger = nodes.find(n => n.id === TRIGGER_NODE_ID)
-    expect(trigger?.position).toEqual({ x: 0, y: -150 })
+    expect(typeof trigger?.position.x).toBe('number')
+    expect(typeof trigger?.position.y).toBe('number')
+  })
+
+  it('applies a layered layout when no positions are stored', () => {
+    // Trigger → s1 → s2 with no stored positions should flow top-to-bottom
+    // (increasing y), not a same-row grid.
+    const def = makeDef({
+      steps: [
+        makeStep('s1', 'Step 1', { next: [Transition.createFrom({ goto: 's2', when: null })] }),
+        makeStep('s2', 'Step 2'),
+      ],
+    })
+    const { nodes } = definitionToGraph(def)
+    const trig = nodes.find(n => n.id === TRIGGER_NODE_ID)!
+    const s1 = nodes.find(n => n.id === 's1')!
+    const s2 = nodes.find(n => n.id === 's2')!
+    expect(trig.position.y).toBeLessThan(s1.position.y)
+    expect(s1.position.y).toBeLessThan(s2.position.y)
+  })
+
+  it('keeps stored positions when every node is positioned', () => {
+    const def = makeDef({
+      trigger: Trigger.createFrom({ on: 'manual', conditions: [], position: Position.createFrom({ x: 0, y: 0 }) }),
+      steps: [makeStep('s1', 'Step 1', { position: Position.createFrom({ x: 300, y: 400 }) })],
+    })
+    const { nodes } = definitionToGraph(def)
+    expect(nodes.find(n => n.id === 's1')?.position).toEqual({ x: 300, y: 400 })
   })
 
   it('creates one step node per step', () => {
@@ -96,14 +123,33 @@ describe('definitionToGraph', () => {
     expect(endNode).toBeDefined()
   })
 
-  it('uses step position when set', () => {
+  it('uses step position when every node is positioned', () => {
     const step = makeStep('s1', 'Step 1', {
       position: Position.createFrom({ x: 300, y: 400 }),
     })
-    const def = makeDef({ steps: [step] })
+    const def = makeDef({
+      trigger: Trigger.createFrom({ on: 'manual', conditions: [], position: Position.createFrom({ x: 0, y: 0 }) }),
+      steps: [step],
+    })
     const { nodes } = definitionToGraph(def)
     const stepNode = nodes.find(n => n.id === 's1')
     expect(stepNode?.position).toEqual({ x: 300, y: 400 })
+  })
+
+  it('auto-positions a partially-positioned def (trigger set, step not)', () => {
+    // Only the trigger has a position — the step must still be laid out, not
+    // dropped on the grid where it could overlap.
+    const step = makeStep('s1', 'Step 1')
+    const def = makeDef({
+      trigger: Trigger.createFrom({ on: 'manual', conditions: [], position: Position.createFrom({ x: 0, y: 0 }) }),
+      steps: [step],
+    })
+    const { nodes } = definitionToGraph(def)
+    const trig = nodes.find(n => n.id === TRIGGER_NODE_ID)!
+    const s1 = nodes.find(n => n.id === 's1')!
+    expect(typeof s1.position.x).toBe('number')
+    // Laid out below the trigger, not stacked on it.
+    expect(s1.position.y).toBeGreaterThan(trig.position.y)
   })
 
   it('falls back to computed position when no step position set', () => {

--- a/frontend/src/lib/workflow-graph.ts
+++ b/frontend/src/lib/workflow-graph.ts
@@ -1,5 +1,6 @@
 import type { Node, Edge } from '@xyflow/svelte'
 import { Condition, Definition, Position, Step, Trigger } from '../../bindings/github.com/Automaat/sybra/internal/workflow/models.js'
+import { layoutGraph } from './graph-layout.js'
 
 const NODE_SPACING_X = 250
 const NODE_SPACING_Y = 120
@@ -29,6 +30,12 @@ export function definitionToGraph(def: Definition): { nodes: Node[], edges: Edge
   const nodes: Node[] = []
   const edges: Edge[] = []
   const steps = def.steps ?? []
+
+  // Auto-layout unless EVERY node already has a stored position. Gating on "all"
+  // (not "any") means a partially-positioned def — e.g. a hand-edited YAML with
+  // only the trigger placed, or a fresh step added — still gets a clean layered
+  // layout instead of dropping the position-less nodes onto the naive grid.
+  const allPositioned = !!def.trigger?.position && steps.every((s) => s.position)
 
   // Synthesize the trigger node — always present, even when empty.
   const triggerPos = def.trigger?.position
@@ -102,7 +109,7 @@ export function definitionToGraph(def: Definition): { nodes: Node[], edges: Edge
     }
   }
 
-  return { nodes, edges }
+  return { nodes: allPositioned ? nodes : layoutGraph(nodes, edges), edges }
 }
 
 export function graphToDefinition(

--- a/frontend/src/pages/WorkflowDetail.svelte
+++ b/frontend/src/pages/WorkflowDetail.svelte
@@ -101,8 +101,8 @@
     const id = `step-${crypto.randomUUID().slice(0, 8)}`
     // Drop the new node below the current graph so it never lands on top of an
     // existing one; the user can drag it or hit Auto-layout to re-flow.
-    const baseX = nodes.length ? Math.min(...nodes.map((n) => n.position.x)) : 0
-    const belowY = nodes.length ? Math.max(...nodes.map((n) => n.position.y)) + 120 : 0
+    const baseX = nodes.reduce((min, n) => Math.min(min, n.position.x), 0)
+    const belowY = nodes.reduce((max, n) => Math.max(max, n.position.y), 0) + (nodes.length ? 120 : 0)
     const newStep = new Step({
       id,
       name: 'New step',

--- a/frontend/src/pages/WorkflowDetail.svelte
+++ b/frontend/src/pages/WorkflowDetail.svelte
@@ -14,6 +14,7 @@
     TRIGGER_NODE_ID,
     type StepNodeData,
   } from '../lib/workflow-graph.js'
+  import { layoutGraph } from '../lib/graph-layout.js'
 
   type Selection = { kind: 'step'; step: Step } | { kind: 'trigger' } | null
 
@@ -98,6 +99,10 @@
   function handleStepAdd() {
     if (!def) return
     const id = `step-${crypto.randomUUID().slice(0, 8)}`
+    // Drop the new node below the current graph so it never lands on top of an
+    // existing one; the user can drag it or hit Auto-layout to re-flow.
+    const baseX = nodes.length ? Math.min(...nodes.map((n) => n.position.x)) : 0
+    const belowY = nodes.length ? Math.max(...nodes.map((n) => n.position.y)) + 120 : 0
     const newStep = new Step({
       id,
       name: 'New step',
@@ -105,7 +110,7 @@
       config: new StepConfig({}),
       next: [],
       parallel: [],
-      position: new Position({ x: 100 + def.steps.length * 40, y: 100 + def.steps.length * 40 }),
+      position: new Position({ x: baseX, y: belowY }),
     })
     def.steps = [...def.steps, newStep]
     rebuildGraphFrom(def)
@@ -122,6 +127,11 @@
 
   function handlePositionChange(nodeId: string, x: number, y: number) {
     nodes = nodes.map((n) => (n.id === nodeId ? { ...n, position: { x, y } } : n))
+    dirty = true
+  }
+
+  function handleAutoLayout() {
+    nodes = layoutGraph(nodes, edges)
     dirty = true
   }
 
@@ -174,6 +184,15 @@
     {#if dirty}
       <span class="text-xs text-warning-500">unsaved</span>
     {/if}
+    <button
+      type="button"
+      class="rounded-lg border border-surface-300 bg-surface-100 px-3 py-1.5 text-sm font-medium hover:bg-surface-200 disabled:opacity-50 dark:border-surface-600 dark:bg-surface-700 dark:hover:bg-surface-600"
+      onclick={handleAutoLayout}
+      disabled={!def || nodes.length === 0}
+      title="Re-arrange the graph into a layered layout"
+    >
+      Auto-layout
+    </button>
     <button
       type="button"
       class="rounded-lg border border-surface-300 bg-surface-100 px-3 py-1.5 text-sm font-medium hover:bg-surface-200 disabled:opacity-50 dark:border-surface-600 dark:bg-surface-700 dark:hover:bg-surface-600"


### PR DESCRIPTION
## Motivation

The workflow editor laid position-less nodes on a naive 4-column grid, so edges crisscrossed into spaghetti for larger workflows, and the default white connection handles read like rendering glitches (issue #919).

## Implementation information

- **Layered auto-layout** via `@dagrejs/dagre` (`lib/graph-layout.ts`, `layoutGraph` top-down by default). `definitionToGraph` runs it unless **every** node already has a stored position, so fresh *and* partially-positioned defs flow consistently; fully hand-arranged graphs keep their layout.
- **Auto-layout** toolbar button re-flows any graph on demand (and persists on save).
- **Add-step placement**: a new step is dropped below the existing graph instead of a fixed diagonal, so it never lands on top of another node.
- **Handles** restyled into muted slate connectors (primary on hover/drop-target), scoped under a `.wf-graph` wrapper so other graphs are unaffected.

A pre-PR adversarial review caught two real layout regressions, both fixed: the position gate was "any node positioned" (a hand-edited def with only the trigger placed dropped its steps onto the overlap-prone grid) — now gated on "all positioned"; and a newly-added step landed at a diagonal that could overlap — now placed below the graph. The handle CSS was also scoped (was app-global) and the drop-target state restyled.

## Open questions

- First render uses a fallback node size (180×72) since xyflow hasn't measured the DOM yet, so very long step labels can crowd within a rank until the user clicks Auto-layout (which re-runs with measured widths). Cosmetic, first-render only.

Closes #919

> Changelog: feat(workflows): layered graph layout & handles