### PR TITLE
fix(workflows): hide e2e fixture from list

### DIFF
--- a/frontend/e2e/screenshots.spec.ts
+++ b/frontend/e2e/screenshots.spec.ts
@@ -369,13 +369,15 @@ for (const theme of ['light', 'dark'] as const) {
     // ─── Workflows ────────────────────────────────────────────────────────────
 
     test('workflows', async ({ page }) => {
+      // Normal user-facing list — the e2e fixture must stay hidden here.
       await page.goto('/')
       await page.locator('[data-part="trigger"]', { hasText: /Workflows/ }).click()
-      await page.getByRole('button', { name: /E2E Editor Fixture/ }).waitFor({ timeout: 10_000 })
+      await page.getByRole('button', { name: /PR Review/ }).waitFor({ timeout: 10_000 })
       await shot(page, theme, 'workflows')
     })
 
     test('workflow-editor', async ({ page }) => {
+      await page.addInitScript(() => localStorage.setItem('sybra.showFixtures', 'true'))
       await page.goto('/')
       await page.locator('[data-part="trigger"]', { hasText: /Workflows/ }).click()
       await page.getByRole('button', { name: /E2E Editor Fixture/ }).waitFor({ timeout: 10_000 })
@@ -385,6 +387,7 @@ for (const theme of ['light', 'dark'] as const) {
     })
 
     test('workflow-editor-trigger-panel', async ({ page }) => {
+      await page.addInitScript(() => localStorage.setItem('sybra.showFixtures', 'true'))
       await page.goto('/')
       await page.locator('[data-part="trigger"]', { hasText: /Workflows/ }).click()
       await page.getByRole('button', { name: /E2E Editor Fixture/ }).waitFor({ timeout: 10_000 })

--- a/frontend/e2e/workflow-editor.spec.ts
+++ b/frontend/e2e/workflow-editor.spec.ts
@@ -44,6 +44,11 @@ test.afterAll(async () => {
   await removeFixture()
 })
 
+// The fixture is hidden from the user-facing list; reveal it for the editor tests.
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem('sybra.showFixtures', 'true'))
+})
+
 test.describe('Workflow editor — list page', () => {
   test('list card shows trigger event and condition count', async ({
     page,

--- a/frontend/src/lib/workflow-fixtures.test.ts
+++ b/frontend/src/lib/workflow-fixtures.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { isFixtureWorkflow, showFixtures } from './workflow-fixtures.js'
+
+describe('isFixtureWorkflow', () => {
+  it('flags the e2e editor fixture by id and name', () => {
+    expect(isFixtureWorkflow({ id: 'wf-editor-e2e', name: 'E2E Editor Fixture' })).toBe(true)
+  })
+
+  it('flags e2e-prefixed ids and fixture names', () => {
+    expect(isFixtureWorkflow({ id: 'e2e-smoke' })).toBe(true)
+    expect(isFixtureWorkflow({ name: 'My Fixture' })).toBe(true)
+  })
+
+  it('does not flag real workflows', () => {
+    expect(isFixtureWorkflow({ id: 'pr-review', name: 'PR Review' })).toBe(false)
+    expect(isFixtureWorkflow({ id: 'simple-task-implement', name: 'Simple Task — Implement' })).toBe(false)
+    // "end-to-end" is not the "e2e" token.
+    expect(isFixtureWorkflow({ id: 'end-to-end-deploy', name: 'End to End Deploy' })).toBe(false)
+  })
+})
+
+describe('showFixtures', () => {
+  afterEach(() => localStorage.clear())
+
+  it('is false by default', () => {
+    expect(showFixtures()).toBe(false)
+  })
+
+  it('is true when the reveal flag is set', () => {
+    localStorage.setItem('sybra.showFixtures', 'true')
+    expect(showFixtures()).toBe(true)
+  })
+})

--- a/frontend/src/lib/workflow-fixtures.ts
+++ b/frontend/src/lib/workflow-fixtures.ts
@@ -1,0 +1,26 @@
+// Test/e2e fixture workflows (e.g. the workflow-editor.spec.ts fixture) get
+// seeded into the workflow store during testing and should never appear in the
+// user-facing Workflows list.
+
+const STORAGE_KEY = 'sybra.showFixtures'
+
+interface WorkflowLike {
+  id?: string
+  name?: string
+}
+
+/** True for workflows that exist only to support automated tests. */
+export function isFixtureWorkflow(wf: WorkflowLike): boolean {
+  const id = (wf.id ?? '').toLowerCase()
+  const name = (wf.name ?? '').toLowerCase()
+  // `wf-editor-e2e`, `e2e-*`, names containing "E2E" or "fixture".
+  return /(^|[-_])e2e([-_]|$)/.test(id) || name.includes('e2e') || name.includes('fixture')
+}
+
+/**
+ * Whether fixture workflows should be revealed anyway. Off for real users; the
+ * e2e suite sets the flag so its fixture stays reachable in the list.
+ */
+export function showFixtures(): boolean {
+  return typeof localStorage !== 'undefined' && localStorage.getItem(STORAGE_KEY) === 'true'
+}

--- a/frontend/src/lib/workflow-fixtures.ts
+++ b/frontend/src/lib/workflow-fixtures.ts
@@ -22,5 +22,11 @@ export function isFixtureWorkflow(wf: WorkflowLike): boolean {
  * e2e suite sets the flag so its fixture stays reachable in the list.
  */
 export function showFixtures(): boolean {
-  return typeof localStorage !== 'undefined' && localStorage.getItem(STORAGE_KEY) === 'true'
+  if (typeof localStorage === 'undefined') return false
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true'
+  } catch {
+    // storage blocked (private mode, restricted context) — default to hidden
+    return false
+  }
 }

--- a/frontend/src/pages/WorkflowList.svelte
+++ b/frontend/src/pages/WorkflowList.svelte
@@ -1,12 +1,19 @@
 <script lang="ts">
   import { LayoutDashboard } from '@lucide/svelte'
   import { workflowStore } from '../stores/workflows.svelte.js'
+  import { isFixtureWorkflow, showFixtures } from '../lib/workflow-fixtures.js'
 
   interface Props {
     onselect: (id: string) => void
   }
 
   const { onselect }: Props = $props()
+
+  // Hide test/e2e fixture workflows from the user-facing list.
+  const reveal = showFixtures()
+  const workflows = $derived(
+    reveal ? workflowStore.list : workflowStore.list.filter((wf) => !isFixtureWorkflow(wf)),
+  )
 
   $effect(() => {
     workflowStore.load()
@@ -15,18 +22,18 @@
 </script>
 
 <div class="flex flex-col gap-3 p-4 md:gap-4 md:p-6">
-  {#if workflowStore.loading && workflowStore.list.length === 0}
+  {#if workflowStore.loading && workflows.length === 0}
     <p class="text-sm opacity-60">Loading workflows...</p>
   {:else if workflowStore.error}
     <p class="text-sm text-error-500">{workflowStore.error}</p>
-  {:else if workflowStore.list.length === 0}
+  {:else if workflows.length === 0}
     <div class="flex flex-col items-center gap-3 py-16 text-center">
       <LayoutDashboard size={48} class="text-surface-400" />
       <p class="text-sm text-surface-500">No workflows found</p>
     </div>
   {:else}
     <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-      {#each workflowStore.list as wf (wf.id)}
+      {#each workflows as wf (wf.id)}
         <button
           type="button"
           class="flex flex-col gap-2 rounded-lg border border-surface-300 bg-surface-50 p-4 text-left transition-colors hover:bg-surface-100 dark:border-surface-600 dark:bg-surface-800 dark:hover:bg-surface-700"

--- a/frontend/src/pages/WorkflowList.svelte.test.ts
+++ b/frontend/src/pages/WorkflowList.svelte.test.ts
@@ -31,11 +31,13 @@ describe('WorkflowList', () => {
   beforeEach(() => {
     Object.assign(workflowStore, { list: [], loading: false, error: '' })
     vi.mocked(workflowStore.load).mockClear()
+    localStorage.clear()
   })
 
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
+    localStorage.clear()
   })
 
   it('loads workflows on mount', () => {
@@ -117,5 +119,34 @@ describe('WorkflowList', () => {
     })
     render(WorkflowList, { props: { onselect: vi.fn() } })
     expect(screen.getByText(/1 cond/)).toBeDefined()
+  })
+
+  it('hides e2e fixture workflows from the list by default', () => {
+    Object.assign(workflowStore, {
+      list: [
+        makeWorkflow({ id: 'pr-review', name: 'PR Review' }),
+        makeWorkflow({ id: 'wf-editor-e2e', name: 'E2E Editor Fixture' }),
+      ],
+    })
+    render(WorkflowList, { props: { onselect: vi.fn() } })
+    expect(screen.getByText('PR Review')).toBeDefined()
+    expect(screen.queryByText('E2E Editor Fixture')).toBeNull()
+  })
+
+  it('reveals fixtures when the showFixtures flag is set', () => {
+    localStorage.setItem('sybra.showFixtures', 'true')
+    Object.assign(workflowStore, {
+      list: [makeWorkflow({ id: 'wf-editor-e2e', name: 'E2E Editor Fixture' })],
+    })
+    render(WorkflowList, { props: { onselect: vi.fn() } })
+    expect(screen.getByText('E2E Editor Fixture')).toBeDefined()
+  })
+
+  it('shows empty state when only fixtures exist', () => {
+    Object.assign(workflowStore, {
+      list: [makeWorkflow({ id: 'wf-editor-e2e', name: 'E2E Editor Fixture' })],
+    })
+    render(WorkflowList, { props: { onselect: vi.fn() } })
+    expect(screen.getByText('No workflows found')).toBeDefined()
   })
 })


### PR DESCRIPTION
## Motivation

The workflow-editor e2e fixture ("E2E Editor Fixture", id `wf-editor-e2e`) is seeded into the workflow store during testing and showed up in the user-facing Workflows list (and its screenshot) as noise — issue #920.

## Implementation information

- New `lib/workflow-fixtures.ts`: `isFixtureWorkflow(wf)` flags fixtures by an `e2e` id token or a `fixture`/`E2E` name; `showFixtures()` reads a `sybra.showFixtures` localStorage reveal flag.
- `WorkflowList` filters fixtures out by default; the empty-state and grid use the filtered set.
- The e2e suite still needs the fixture reachable, so the editor specs set the reveal flag via `addInitScript`; the list-view screenshot waits on a built-in (`PR Review`) instead of the fixture, capturing the clean user-facing list.

A pre-PR adversarial review confirmed the approach: `WorkflowList` is lazily mounted (default page is the task list) so it always reads the flag *after* `addInitScript` runs; none of the six built-ins match the fixture filter; `PR Review` is synced by `SyncBuiltins` on init and is a unique match; and Playwright's per-test contexts keep the reveal flag from leaking into the clean list screenshot. Verdict: no defects.

## Open questions

- The naming filter would also hide a *user* workflow whose name contains "fixture"/"e2e" (intended per the issue's "naming filter" guidance); there is no in-app toggle, only the localStorage flag. Acceptable for now given no built-in collides.

Closes #920

> Changelog: fix(workflows): hide e2e fixture from list