### PR TITLE
feat(tasks): group task detail action bar

### DIFF
--- a/frontend/src/components/task-detail/TaskHeaderBar.svelte
+++ b/frontend/src/components/task-detail/TaskHeaderBar.svelte
@@ -335,13 +335,13 @@
         aria-label="More actions"
         title="More actions"
         class="rounded p-1 text-surface-500 transition-colors hover:bg-surface-200 hover:text-surface-800 dark:hover:bg-surface-700 dark:hover:text-surface-200"
-        onclick={() => (menuOpen = !menuOpen)}
+        onclick={() => (menuOpen ? closeMenu() : (menuOpen = true))}
       >
         <MoreHorizontal size={16} />
       </button>
 
       {#if menuOpen}
-        <button type="button" class="fixed inset-0 z-40 cursor-default" aria-label="Close menu" onclick={closeMenu}></button>
+        <button type="button" tabindex="-1" class="fixed inset-0 z-40 cursor-default" aria-label="Close menu" onclick={closeMenu}></button>
         <div role="menu" class="absolute right-0 z-50 mt-1 w-44 rounded-lg py-1 elevation-popover">
           <button
             type="button"

--- a/frontend/src/components/task-detail/TaskHeaderBar.svelte
+++ b/frontend/src/components/task-detail/TaskHeaderBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Copy } from '@lucide/svelte'
+  import { MoreHorizontal } from '@lucide/svelte'
   import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { taskStore } from '../../stores/tasks.svelte.js'
   import { agentStore } from '../../stores/agents.svelte.js'
@@ -29,6 +29,27 @@
   let reviewLoading = $state(false)
   let fixReviewLoading = $state(false)
   let error = $state('')
+  let menuOpen = $state(false)
+
+  function closeMenu() {
+    menuOpen = false
+    // Drop any lingering "Copied!" so reopening shows the default labels.
+    copied = false
+    copiedBranch = false
+  }
+
+  $effect(() => {
+    if (!menuOpen) return
+    function onKeydown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        e.stopImmediatePropagation()
+        closeMenu()
+      }
+    }
+    window.addEventListener('keydown', onKeydown, { capture: true })
+    return () => window.removeEventListener('keydown', onKeydown, { capture: true })
+  })
 
   const taskBranchName = $derived(
     task ? 'sybra/' + (task.slug ? task.slug + '-' + task.id : task.id) : '',
@@ -305,32 +326,53 @@
         Fixing review
       </span>
     {/if}
-    <button
-      type="button"
-      class="rounded bg-surface-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-surface-600"
-      onclick={copyId}
-      title="Copy task ID (⌘.)"
-    >
-      {copied ? 'Copied!' : 'Copy ID'}
-    </button>
-    {#if task.projectId}
+    <!-- Secondary / utility actions tucked into an overflow menu. -->
+    <div class="relative">
       <button
         type="button"
-        class="inline-flex items-center gap-1 rounded bg-surface-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-surface-600"
-        onclick={copyBranch}
-        title="Copy branch name (⇧⌘.)"
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        aria-label="More actions"
+        title="More actions"
+        class="rounded p-1 text-surface-500 transition-colors hover:bg-surface-200 hover:text-surface-800 dark:hover:bg-surface-700 dark:hover:text-surface-200"
+        onclick={() => (menuOpen = !menuOpen)}
       >
-        <Copy size={12} />
-        {copiedBranch ? 'Copied!' : 'Copy branch'}
+        <MoreHorizontal size={16} />
       </button>
-    {/if}
-    <button
-      type="button"
-      class="rounded bg-error-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-error-600 disabled:opacity-50"
-      onclick={deleteTask}
-      disabled={deleting}
-    >
-      {deleting ? 'Deleting...' : 'Delete'}
-    </button>
+
+      {#if menuOpen}
+        <button type="button" class="fixed inset-0 z-40 cursor-default" aria-label="Close menu" onclick={closeMenu}></button>
+        <div role="menu" class="absolute right-0 z-50 mt-1 w-44 rounded-lg py-1 elevation-popover">
+          <button
+            type="button"
+            role="menuitem"
+            class="flex w-full items-center px-3 py-1.5 text-left text-xs hover:bg-surface-200 dark:hover:bg-surface-700"
+            onclick={copyId}
+          >
+            {copied ? 'Copied!' : 'Copy ID'}
+          </button>
+          {#if task.projectId}
+            <button
+              type="button"
+              role="menuitem"
+              class="flex w-full items-center px-3 py-1.5 text-left text-xs hover:bg-surface-200 dark:hover:bg-surface-700"
+              onclick={copyBranch}
+            >
+              {copiedBranch ? 'Copied!' : 'Copy branch'}
+            </button>
+          {/if}
+          <div class="my-1 border-t border-surface-200 dark:border-surface-700"></div>
+          <button
+            type="button"
+            role="menuitem"
+            class="flex w-full items-center px-3 py-1.5 text-left text-xs text-error-600 hover:bg-error-50 disabled:opacity-50 dark:text-error-400 dark:hover:bg-error-950"
+            onclick={() => { closeMenu(); deleteTask() }}
+            disabled={deleting}
+          >
+            {deleting ? 'Deleting...' : 'Delete task'}
+          </button>
+        </div>
+      {/if}
+    </div>
   </div>
 </div>

--- a/frontend/src/components/task-detail/TaskHeaderBar.svelte.test.ts
+++ b/frontend/src/components/task-detail/TaskHeaderBar.svelte.test.ts
@@ -116,10 +116,11 @@ describe('TaskHeaderBar', () => {
     expect(screen.getByText('Run Review')).toBeDefined()
   })
 
-  it('calls remove and ondelete on Delete', async () => {
+  it('calls remove and ondelete on Delete from the overflow menu', async () => {
     const ondelete = vi.fn()
     render(TaskHeaderBar, { props: { task: baseTask as never, ondelete } })
-    await fireEvent.click(screen.getByText('Delete'))
+    await fireEvent.click(screen.getByLabelText('More actions'))
+    await fireEvent.click(screen.getByText('Delete task'))
     await waitFor(() => {
       expect(mockRemove).toHaveBeenCalledWith('t1')
       expect(ondelete).toHaveBeenCalled()
@@ -182,13 +183,27 @@ describe('TaskHeaderBar', () => {
     })
   })
 
-  it('Copy ID button is rendered', () => {
+  it('Copy ID / Copy branch live in the overflow menu', async () => {
     render(TaskHeaderBar, { props: { task: baseTask as never, ondelete: vi.fn() } })
+    // Utility actions are not in the always-visible action row.
+    expect(screen.queryByText('Copy ID')).toBeNull()
+    await fireEvent.click(screen.getByLabelText('More actions'))
     expect(screen.getByText('Copy ID')).toBeDefined()
+    expect(screen.getByText('Copy branch')).toBeDefined()
   })
 
-  it('Copy branch button is rendered when projectId set', () => {
+  it('closes the overflow menu on Escape', async () => {
     render(TaskHeaderBar, { props: { task: baseTask as never, ondelete: vi.fn() } })
-    expect(screen.getByText('Copy branch')).toBeDefined()
+    await fireEvent.click(screen.getByLabelText('More actions'))
+    expect(screen.getByText('Copy ID')).toBeDefined()
+    await fireEvent.keyDown(window, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByText('Copy ID')).toBeNull())
+  })
+
+  it('hides Copy branch in the menu when the task has no project', async () => {
+    render(TaskHeaderBar, { props: { task: { ...baseTask, projectId: '' } as never, ondelete: vi.fn() } })
+    await fireEvent.click(screen.getByLabelText('More actions'))
+    expect(screen.getByText('Copy ID')).toBeDefined()
+    expect(screen.queryByText('Copy branch')).toBeNull()
   })
 })

--- a/frontend/src/pages/TaskDetail.svelte.test.ts
+++ b/frontend/src/pages/TaskDetail.svelte.test.ts
@@ -157,7 +157,7 @@ describe('TaskDetail', () => {
       props: { taskId: 'task-1', onback: vi.fn(), onviewagent: vi.fn(), ondelete: vi.fn() },
     })
     await vi.waitFor(() => {
-      expect(screen.getByText('Delete')).toBeDefined()
+      expect(screen.getByLabelText('More actions')).toBeDefined()
     })
   })
 
@@ -169,9 +169,13 @@ describe('TaskDetail', () => {
       props: { taskId: 'task-1', onback: vi.fn(), onviewagent: vi.fn(), ondelete },
     })
     await vi.waitFor(() => {
-      expect(screen.getByText('Delete')).toBeDefined()
+      expect(screen.getByLabelText('More actions')).toBeDefined()
     })
-    screen.getByText('Delete').click()
+    screen.getByLabelText('More actions').click()
+    await vi.waitFor(() => {
+      expect(screen.getByText('Delete task')).toBeDefined()
+    })
+    screen.getByText('Delete task').click()
     await vi.waitFor(() => {
       expect(mockRemove).toHaveBeenCalledWith('task-1')
       expect(ondelete).toHaveBeenCalled()
@@ -288,8 +292,8 @@ describe('TaskDetail', () => {
       await vi.waitFor(() => {
         expect(screen.getByText('Test Task')).toBeDefined()
       })
-      const copyBtn = screen.getByText('Copy ID')
-      await fireEvent.click(copyBtn)
+      await fireEvent.click(screen.getByLabelText('More actions'))
+      await fireEvent.click(screen.getByText('Copy ID'))
       expect(navigator.clipboard.writeText).toHaveBeenCalledWith('task-1')
     })
 
@@ -302,8 +306,8 @@ describe('TaskDetail', () => {
       await vi.waitFor(() => {
         expect(screen.getByText('Test Task')).toBeDefined()
       })
-      const copyBtn = screen.getByText('Copy ID')
-      await fireEvent.click(copyBtn)
+      await fireEvent.click(screen.getByLabelText('More actions'))
+      await fireEvent.click(screen.getByText('Copy ID'))
       await vi.waitFor(() => {
         expect(mockPushLocal).toHaveBeenCalledWith('error', 'Copy failed', expect.any(String))
       })


### PR DESCRIPTION
## Motivation

The Task Detail action row crammed seven mixed-style controls together (status + type dropdowns, Reviewed pill, Fix Review, Copy ID, Copy branch, Delete) — inconsistent shapes and uneven alignment (issue #921).

## Implementation information

- Moved the secondary/utility actions — **Copy ID, Copy branch, Delete** — into a `⋯` overflow menu (`role="menu"` / `role="menuitem"`, `aria-haspopup`/`aria-expanded`, outside-click + Escape to close), leaving a tidy primary set inline: status, type, the live-state pills, Reviewed, and the Run/Fix Review actions.
- Copy actions keep the menu open to show the "Copied!" confirmation; the label resets on close. Keyboard shortcuts (copy id/branch, delete) are unaffected — they call the same handlers directly.

A pre-PR adversarial review returned no blockers; its nits are addressed: stale "Copied!" on menu reopen (now reset on close), missing menu semantics (added `role="menu"`/`menuitem`), and a missing test for the no-project Copy-branch path (added).

## Open questions / scope

- This PR delivers the grouping half of "standardize control styling". The status pill and the type select stay visually distinct because they're different control types (a status-colored pill vs a plain enum select), and the two review buttons keep distinct colors to signal distinct actions (they're mutually exclusive). Further visual unification can follow if desired.

Closes #921

> Changelog: feat(tasks): group task detail action bar