### PR TITLE
feat(stats): add cost & usage charts

### DIFF
--- a/frontend/src/components/stats/StatsBarChart.svelte
+++ b/frontend/src/components/stats/StatsBarChart.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import type { ProjectCost } from '../../lib/stats-charts.js'
+
+  interface Props {
+    bars: ProjectCost[]
+  }
+
+  const { bars }: Props = $props()
+
+  const max = $derived(Math.max(0, ...bars.map((b) => b.cost)))
+
+  function width(cost: number): string {
+    if (max <= 0) return '0%'
+    return `${Math.max(2, (cost / max) * 100)}%`
+  }
+</script>
+
+{#if bars.length === 0}
+  <p class="py-8 text-center text-xs text-surface-400">No cost in this range</p>
+{:else}
+  <div class="flex flex-col gap-1.5">
+    {#each bars as b (b.project)}
+      <div class="flex items-center gap-2 text-xs">
+        <span class="w-28 shrink-0 truncate font-mono text-surface-500" title={b.project}>{b.project}</span>
+        <div class="h-3 flex-1 overflow-hidden rounded bg-surface-200 dark:bg-surface-700">
+          <div class="h-full rounded bg-primary-500" style="width: {width(b.cost)}"></div>
+        </div>
+        <span class="w-14 shrink-0 text-right tabular-nums text-surface-600 dark:text-surface-300">${b.cost.toFixed(2)}</span>
+      </div>
+    {/each}
+  </div>
+{/if}

--- a/frontend/src/components/stats/StatsLineChart.svelte
+++ b/frontend/src/components/stats/StatsLineChart.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import type { DailyCost } from '../../lib/stats-charts.js'
+
+  interface Props {
+    points: DailyCost[]
+  }
+
+  const { points }: Props = $props()
+
+  const W = 320
+  const H = 96
+  const PAD = 6
+
+  const max = $derived(Math.max(0, ...points.map((p) => p.cost)))
+
+  // x evenly spaced; y inverted (SVG origin top-left), scaled to max.
+  function px(i: number): number {
+    if (points.length <= 1) return W / 2
+    return PAD + (i / (points.length - 1)) * (W - 2 * PAD)
+  }
+  function py(cost: number): number {
+    if (max <= 0) return H - PAD
+    return H - PAD - (cost / max) * (H - 2 * PAD)
+  }
+
+  const line = $derived(points.map((p, i) => `${px(i)},${py(p.cost)}`).join(' '))
+  const area = $derived(
+    points.length > 0 ? `${px(0)},${H - PAD} ${line} ${px(points.length - 1)},${H - PAD}` : '',
+  )
+</script>
+
+{#if points.length === 0}
+  <p class="py-8 text-center text-xs text-surface-400">No cost in this range</p>
+{:else}
+  <svg viewBox="0 0 {W} {H}" class="h-24 w-full" preserveAspectRatio="none" role="img" aria-label="Cost over time">
+    {#if points.length > 1}
+      <polygon points={area} class="fill-primary-500/10" />
+      <polyline points={line} fill="none" class="stroke-primary-500" stroke-width="2" vector-effect="non-scaling-stroke" />
+    {/if}
+    {#each points as p, i (p.date)}
+      <circle cx={px(i)} cy={py(p.cost)} r="2.5" class="fill-primary-500" vector-effect="non-scaling-stroke" />
+    {/each}
+  </svg>
+  <div class="mt-1 flex justify-between text-[10px] text-surface-400">
+    <span>{points[0].date}</span>
+    {#if points.length > 1}
+      <span>{points[points.length - 1].date}</span>
+    {/if}
+  </div>
+{/if}

--- a/frontend/src/lib/stats-charts.test.ts
+++ b/frontend/src/lib/stats-charts.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { periodCutoff, dailyCost, costByProject } from './stats-charts.js'
+import type { RunRecord } from '../../bindings/github.com/Automaat/sybra/internal/stats/models.js'
+
+function run(timestamp: string, costUsd: number, projectId = ''): RunRecord {
+  return { timestamp, costUsd, projectId } as unknown as RunRecord
+}
+
+describe('periodCutoff', () => {
+  // Wed Jun 24 2026, 15:00 local.
+  const now = new Date(2026, 5, 24, 15, 0, 0)
+
+  it('today is local midnight', () => {
+    expect(periodCutoff('today', now)).toEqual(new Date(2026, 5, 24))
+  })
+
+  it('thisWeek is the most recent Sunday, on or before today', () => {
+    const c = periodCutoff('thisWeek', now)!
+    expect(c.getDay()).toBe(0)
+    expect(c.getTime()).toBeLessThanOrEqual(new Date(2026, 5, 24).getTime())
+  })
+
+  it('thisMonth is the first of the month', () => {
+    expect(periodCutoff('thisMonth', now)).toEqual(new Date(2026, 5, 1))
+  })
+
+  it('allTime has no cutoff', () => {
+    expect(periodCutoff('allTime', now)).toBeNull()
+  })
+})
+
+describe('dailyCost', () => {
+  it('buckets by local day and sums, ascending', () => {
+    const runs = [
+      run('2026-06-24T10:00:00', 1.5, 'a'),
+      run('2026-06-24T12:00:00', 0.5, 'a'),
+      run('2026-06-23T09:00:00', 2, 'b'),
+    ]
+    expect(dailyCost(runs, null)).toEqual([
+      { date: '2026-06-23', cost: 2 },
+      { date: '2026-06-24', cost: 2 },
+    ])
+  })
+
+  it('excludes runs before the cutoff', () => {
+    const runs = [run('2026-06-20T10:00:00', 5, 'a'), run('2026-06-24T10:00:00', 1, 'a')]
+    expect(dailyCost(runs, new Date(2026, 5, 23))).toEqual([{ date: '2026-06-24', cost: 1 }])
+  })
+
+  it('skips runs with an invalid timestamp', () => {
+    const runs = [run('not-a-date', 5, 'a'), run('2026-06-24T10:00:00', 1, 'a')]
+    expect(dailyCost(runs, null)).toEqual([{ date: '2026-06-24', cost: 1 }])
+  })
+
+  it('fills zero-cost days through `end` so the line is time-proportional', () => {
+    const runs = [run('2026-06-22T10:00:00', 2, 'a'), run('2026-06-24T10:00:00', 1, 'a')]
+    const out = dailyCost(runs, new Date(2026, 5, 22), new Date(2026, 5, 24, 15))
+    expect(out).toEqual([
+      { date: '2026-06-22', cost: 2 },
+      { date: '2026-06-23', cost: 0 },
+      { date: '2026-06-24', cost: 1 },
+    ])
+  })
+
+  it('returns empty (no fill) when there are no runs in range', () => {
+    expect(dailyCost([], new Date(2026, 5, 22), new Date(2026, 5, 24))).toEqual([])
+  })
+})
+
+describe('costByProject', () => {
+  it('groups by project, descending', () => {
+    const runs = [
+      run('2026-06-24T10:00:00', 3, 'a'),
+      run('2026-06-24T11:00:00', 1, 'a'),
+      run('2026-06-24T10:00:00', 2, 'b'),
+    ]
+    expect(costByProject(runs, null)).toEqual([
+      { project: 'a', cost: 4 },
+      { project: 'b', cost: 2 },
+    ])
+  })
+
+  it('labels a missing project as (none), matching the backend', () => {
+    expect(costByProject([run('2026-06-24T10:00:00', 1, '')], null)).toEqual([
+      { project: '(none)', cost: 1 },
+    ])
+  })
+
+  it('drops zero-cost projects and caps to topN', () => {
+    const runs = Array.from({ length: 8 }, (_, i) => run('2026-06-24T10:00:00', i + 1, `p${i}`))
+    const out = costByProject(runs, null, 3)
+    expect(out).toHaveLength(3)
+    expect(out[0]).toEqual({ project: 'p7', cost: 8 })
+  })
+})

--- a/frontend/src/lib/stats-charts.test.ts
+++ b/frontend/src/lib/stats-charts.test.ts
@@ -47,8 +47,12 @@ describe('dailyCost', () => {
     expect(dailyCost(runs, new Date(2026, 5, 23))).toEqual([{ date: '2026-06-24', cost: 1 }])
   })
 
-  it('skips runs with an invalid timestamp', () => {
-    const runs = [run('not-a-date', 5, 'a'), run('2026-06-24T10:00:00', 1, 'a')]
+  it('skips runs with an invalid or missing timestamp', () => {
+    const runs = [
+      run('not-a-date', 5, 'a'),
+      { timestamp: null, costUsd: 9, projectId: 'a' } as unknown as RunRecord,
+      run('2026-06-24T10:00:00', 1, 'a'),
+    ]
     expect(dailyCost(runs, null)).toEqual([{ date: '2026-06-24', cost: 1 }])
   })
 

--- a/frontend/src/lib/stats-charts.ts
+++ b/frontend/src/lib/stats-charts.ts
@@ -1,0 +1,101 @@
+import type { RunRecord } from '../../bindings/github.com/Automaat/sybra/internal/stats/models.js'
+
+export type StatsPeriod = 'today' | 'thisWeek' | 'thisMonth' | 'allTime'
+
+/**
+ * Start-of-period cutoff matching the backend's summary boundaries
+ * (internal/stats/store.go): local midnight today, the most recent Sunday for
+ * the week, the first of the month. `allTime` has no cutoff.
+ */
+export function periodCutoff(period: StatsPeriod, now: Date): Date | null {
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  switch (period) {
+    case 'today':
+      return todayStart
+    case 'thisWeek': {
+      const d = new Date(todayStart)
+      d.setDate(d.getDate() - todayStart.getDay())
+      return d
+    }
+    case 'thisMonth':
+      return new Date(now.getFullYear(), now.getMonth(), 1)
+    default:
+      return null
+  }
+}
+
+function runDate(r: RunRecord): Date {
+  return new Date(r.timestamp as unknown as string)
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+export interface DailyCost {
+  date: string
+  cost: number
+}
+
+function dayKey(d: Date): string {
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+}
+
+/**
+ * Cost summed per local calendar day within the cutoff, ascending. When `end`
+ * is given, every day from the range start (cutoff, or the first run) through
+ * `end` is emitted — including zero-cost days — so the line is time-proportional
+ * rather than just connecting the days that happen to have runs.
+ */
+export function dailyCost(runs: RunRecord[], cutoff: Date | null, end?: Date): DailyCost[] {
+  const buckets = new Map<string, number>()
+  let earliest: Date | null = null
+  for (const r of runs) {
+    const t = runDate(r)
+    if (Number.isNaN(t.getTime())) continue
+    if (cutoff && t < cutoff) continue
+    buckets.set(dayKey(t), (buckets.get(dayKey(t)) ?? 0) + (r.costUsd ?? 0))
+    if (!earliest || t < earliest) earliest = t
+  }
+
+  if (!end) {
+    return [...buckets.entries()]
+      .map(([date, cost]) => ({ date, cost }))
+      .sort((a, b) => a.date.localeCompare(b.date))
+  }
+
+  if (buckets.size === 0) return []
+  const startSrc = cutoff ?? earliest ?? end
+  const out: DailyCost[] = []
+  const cursor = new Date(startSrc.getFullYear(), startSrc.getMonth(), startSrc.getDate())
+  const last = new Date(end.getFullYear(), end.getMonth(), end.getDate())
+  while (cursor <= last) {
+    const key = dayKey(cursor)
+    out.push({ date: key, cost: buckets.get(key) ?? 0 })
+    cursor.setDate(cursor.getDate() + 1)
+  }
+  return out
+}
+
+export interface ProjectCost {
+  project: string
+  cost: number
+}
+
+/** Cost summed per project within the cutoff, descending, capped at topN. */
+export function costByProject(runs: RunRecord[], cutoff: Date | null, topN = 6): ProjectCost[] {
+  const buckets = new Map<string, number>()
+  for (const r of runs) {
+    const t = runDate(r)
+    if (Number.isNaN(t.getTime())) continue
+    if (cutoff && t < cutoff) continue
+    // Match the backend's label for project-less runs (internal/stats/store.go).
+    const key = r.projectId || '(none)'
+    buckets.set(key, (buckets.get(key) ?? 0) + (r.costUsd ?? 0))
+  }
+  return [...buckets.entries()]
+    .map(([project, cost]) => ({ project, cost }))
+    .filter((b) => b.cost > 0)
+    .sort((a, b) => b.cost - a.cost)
+    .slice(0, topN)
+}

--- a/frontend/src/lib/stats-charts.ts
+++ b/frontend/src/lib/stats-charts.ts
@@ -25,7 +25,10 @@ export function periodCutoff(period: StatsPeriod, now: Date): Date | null {
 }
 
 function runDate(r: RunRecord): Date {
-  return new Date(r.timestamp as unknown as string)
+  // The binding types timestamp as time.Time, defaulting to null; `new Date(null)`
+  // is the epoch (not NaN), so coalesce missing values to an invalid date.
+  const ts = r.timestamp as unknown as string | null | undefined
+  return ts == null ? new Date(NaN) : new Date(ts)
 }
 
 function pad(n: number): string {

--- a/frontend/src/pages/Stats.svelte
+++ b/frontend/src/pages/Stats.svelte
@@ -28,7 +28,8 @@
   // not represented, so the captions flag it and the tables below stay
   // authoritative for full totals.
   const recentRuns = $derived(statsStore.data?.recentRuns ?? [])
-  const sampleCapped = $derived(recentRuns.length >= 50)
+  // The backend only caps recentRuns once there are MORE than 50 total runs.
+  const sampleCapped = $derived((statsStore.data?.allTime?.totalRuns ?? 0) > 50)
   const cutoff = $derived(periodCutoff(period, now))
   const costSeries = $derived(dailyCost(recentRuns, cutoff, now))
   const projectCosts = $derived(costByProject(recentRuns, cutoff))

--- a/frontend/src/pages/Stats.svelte
+++ b/frontend/src/pages/Stats.svelte
@@ -1,10 +1,14 @@
 <script lang="ts">
   import { statsStore } from '../stores/stats.svelte.js'
+  import { periodCutoff, dailyCost, costByProject, type StatsPeriod } from '$lib/stats-charts.js'
+  import StatsLineChart from '../components/stats/StatsLineChart.svelte'
+  import StatsBarChart from '../components/stats/StatsBarChart.svelte'
 
-
-  type Period = 'today' | 'thisWeek' | 'thisMonth' | 'allTime'
+  type Period = StatsPeriod
 
   let period = $state<Period>('allTime')
+  // Captured once so the period cutoffs don't recompute on every clock tick.
+  const now = new Date()
 
   const periods: { key: Period; label: string }[] = [
     { key: 'today', label: 'Today' },
@@ -13,9 +17,21 @@
     { key: 'allTime', label: 'All Time' },
   ]
 
+  const periodLabel = $derived(periods.find((p) => p.key === period)?.label ?? '')
+
   const summary = $derived(
     statsStore.data ? statsStore.data[period] : null,
   )
+
+  // Charts are derived from the recent-runs sample, filtered to the selected
+  // period. The backend caps that sample at 50; when it's full, older runs are
+  // not represented, so the captions flag it and the tables below stay
+  // authoritative for full totals.
+  const recentRuns = $derived(statsStore.data?.recentRuns ?? [])
+  const sampleCapped = $derived(recentRuns.length >= 50)
+  const cutoff = $derived(periodCutoff(period, now))
+  const costSeries = $derived(dailyCost(recentRuns, cutoff, now))
+  const projectCosts = $derived(costByProject(recentRuns, cutoff))
 
   $effect(() => {
     statsStore.load()
@@ -108,6 +124,26 @@
         {#if summary.totalReasoningTokens}
           <p class="mt-0.5 text-xs text-surface-400">{formatTokens(summary.totalReasoningTokens)} reasoning</p>
         {/if}
+      </div>
+    </div>
+  {/if}
+
+  <!-- Charts -->
+  {#if statsStore.data}
+    <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+      <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <div class="mb-3 flex items-baseline justify-between gap-2">
+          <h3 class="text-sm font-semibold text-surface-500">Cost over time</h3>
+          <span class="text-[10px] text-surface-400">{periodLabel}{#if sampleCapped} · recent 50 runs{/if}</span>
+        </div>
+        <StatsLineChart points={costSeries} />
+      </div>
+      <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <div class="mb-3 flex items-baseline justify-between gap-2">
+          <h3 class="text-sm font-semibold text-surface-500">Cost by project</h3>
+          <span class="text-[10px] text-surface-400">{periodLabel}{#if sampleCapped} · recent 50 runs{/if}</span>
+        </div>
+        <StatsBarChart bars={projectCosts} />
       </div>
     </div>
   {/if}

--- a/frontend/src/pages/Stats.svelte.test.ts
+++ b/frontend/src/pages/Stats.svelte.test.ts
@@ -288,6 +288,41 @@ describe('Stats', () => {
     expect(screen.getByText('failed')).toBeDefined()
   })
 
+  it('renders cost-over-time and cost-by-project charts', () => {
+    const s = makeSummary()
+    mockStatsStore.data = StatsResponse.createFrom({
+      today: s, thisWeek: s, thisMonth: s, allTime: s,
+      byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      recentRuns: [
+        { id: 'r1', taskId: 't1', projectId: 'org/repo', role: 'plan', mode: 'headless', model: 'm', costUsd: 1.5, durationS: 1, reasoningTokens: 0, timestamp: '2026-05-01T10:00:00Z', outcome: 'completed' },
+        { id: 'r2', taskId: 't2', projectId: 'org/other', role: 'plan', mode: 'headless', model: 'm', costUsd: 0.5, durationS: 1, reasoningTokens: 0, timestamp: '2026-05-01T11:00:00Z', outcome: 'completed' },
+      ],
+    })
+    render(Stats, { props: {} })
+    expect(screen.getByText('Cost over time')).toBeDefined()
+    expect(screen.getByText('Cost by project')).toBeDefined()
+    // Bar chart renders both project labels (default period is All Time).
+    expect(screen.getByText('org/repo')).toBeDefined()
+    expect(screen.getByText('org/other')).toBeDefined()
+  })
+
+  it('flags the 50-run sample cap on the charts', () => {
+    const s = makeSummary()
+    const runs = Array.from({ length: 50 }, (_, i) => ({
+      id: `r${i}`, taskId: `t${i}`, projectId: 'org/repo', role: 'plan', mode: 'headless',
+      model: 'm', costUsd: 0.1, durationS: 1, reasoningTokens: 0,
+      timestamp: '2026-05-01T10:00:00Z', outcome: 'completed',
+    }))
+    mockStatsStore.data = StatsResponse.createFrom({
+      today: s, thisWeek: s, thisMonth: s, allTime: s,
+      byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      recentRuns: runs,
+    })
+    render(Stats, { props: {} })
+    // Both chart captions disclose the cap so the numbers aren't read as authoritative.
+    expect(screen.getAllByText(/recent 50 runs/).length).toBeGreaterThanOrEqual(2)
+  })
+
   it('shows dash for missing model in recent runs', () => {
     const s = makeSummary()
     mockStatsStore.data = StatsResponse.createFrom({

--- a/frontend/src/pages/Stats.svelte.test.ts
+++ b/frontend/src/pages/Stats.svelte.test.ts
@@ -306,7 +306,7 @@ describe('Stats', () => {
     expect(screen.getByText('org/other')).toBeDefined()
   })
 
-  it('flags the 50-run sample cap on the charts', () => {
+  it('flags the sample cap on the charts when there are more than 50 runs', () => {
     const s = makeSummary()
     const runs = Array.from({ length: 50 }, (_, i) => ({
       id: `r${i}`, taskId: `t${i}`, projectId: 'org/repo', role: 'plan', mode: 'headless',
@@ -314,7 +314,8 @@ describe('Stats', () => {
       timestamp: '2026-05-01T10:00:00Z', outcome: 'completed',
     }))
     mockStatsStore.data = StatsResponse.createFrom({
-      today: s, thisWeek: s, thisMonth: s, allTime: s,
+      // The backend caps recentRuns only when total runs exceeds 50.
+      today: s, thisWeek: s, thisMonth: s, allTime: makeSummary({ totalRuns: 60 }),
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
       recentRuns: runs,
     })


### PR DESCRIPTION
## Motivation

The Stats page was all tables — clean but flat, with no visual trend (issue #922).

## Implementation information

- New `lib/stats-charts.ts` derives chart data from the runs sample, filtered to the selected time range with cutoffs that match the backend's period boundaries (`internal/stats/store.go`): `dailyCost` (per-day totals, fills zero-cost days so the line is time-proportional) and `costByProject` (per-project totals, `(none)` for project-less runs to match the backend label).
- Two dependency-free SVG components — `StatsLineChart` (cost over time) and `StatsBarChart` (cost by project) — render above the existing tables, which stay authoritative for full detail. The period cutoff is captured once (not the live clock) so the charts don't re-render every second.

### Scope / known limitations (disclosed in the UI)
A pre-PR adversarial review flagged that the chart source — `recentRuns` — is **capped at 50 by the backend** and the `byProject` table is all-time, so for large histories the charts could silently disagree with the tables. Rather than present misleading numbers, each chart now carries a scope caption (the selected period, plus "· recent 50 runs" when the sample is capped). The tables remain the authoritative full totals. A fully period-bucketed series would need a new backend field + a Wails bindings regen (the `wails3` generator isn't available in this environment), so that's deferred; the charts are framed as an at-a-glance view, matching the issue's "keep the tables for detail."

## Open questions

- On a remote-server deployment viewed from a browser in a different timezone, the chart's day buckets/cutoff (browser-local) can differ from the summary cards (server-local) at the boundary — inherent to the server-tz period model the summaries already use. Not an issue for the primary local desktop app (same tz).

Closes #922

> Changelog: feat(stats): add cost & usage charts