### PR TITLE
feat(settings): save semantics & section nav

### DIFF
--- a/frontend/src/pages/Settings.svelte
+++ b/frontend/src/pages/Settings.svelte
@@ -154,7 +154,8 @@
   ]
 
   function scrollToSection(id: string) {
-    document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    document.getElementById(id)?.scrollIntoView({ behavior: reduced ? 'auto' : 'smooth', block: 'start' })
   }
 </script>
 
@@ -162,7 +163,7 @@
   <!-- Sticky save bar + section sub-nav -->
   <div class="sticky top-0 z-10 -mx-4 flex flex-col gap-2 border-b border-surface-200 bg-surface-100/95 px-4 py-2 backdrop-blur dark:border-surface-700 dark:bg-surface-900/95 md:-mx-6 md:px-6">
     <div class="flex items-center justify-between gap-3">
-      <p class="hidden text-xs text-surface-400 sm:block">
+      <p class="min-w-0 text-xs leading-tight text-surface-400">
         Appearance &amp; provider toggles apply instantly · other settings save together
       </p>
       <div class="flex shrink-0 flex-nowrap items-center gap-2">

--- a/frontend/src/pages/Settings.svelte
+++ b/frontend/src/pages/Settings.svelte
@@ -103,7 +103,17 @@
   }
 
   function syncOriginal() {
-    if (settings) original = JSON.stringify(settings)
+    if (!settings) return
+    // Provider toggles persist immediately on their own; fold ONLY the providers
+    // sub-tree into the saved baseline. Resetting the whole baseline here would
+    // silently clear (and on reload drop) unsaved edits in other sections.
+    try {
+      const base = original ? JSON.parse(original) : {}
+      base.providers = JSON.parse(JSON.stringify($state.snapshot(settings.providers)))
+      original = JSON.stringify(base)
+    } catch {
+      original = JSON.stringify(settings)
+    }
   }
 
   const modelOptions = $derived.by(() => {
@@ -128,39 +138,75 @@
       settings.agent.model = ''
     }
   })
+
+  // Anchored section sub-nav so the page isn't one long scroll.
+  const navSections = [
+    { id: 'appearance', label: 'Appearance' },
+    { id: 'agent-defaults', label: 'Agent' },
+    { id: 'provider-health', label: 'Providers' },
+    { id: 'notifications', label: 'Notifications' },
+    { id: 'orchestrator', label: 'Orchestrator' },
+    { id: 'logging', label: 'Logging' },
+    { id: 'todoist', label: 'Todoist' },
+    { id: 'renovate', label: 'Renovate' },
+    { id: 'version', label: 'Version' },
+    { id: 'directories', label: 'Directories' },
+  ]
+
+  function scrollToSection(id: string) {
+    document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
 </script>
 
 <div class="flex flex-col gap-4 p-4 md:gap-6 md:p-6">
-  <div class="flex items-center justify-end">
-    <div class="flex items-center gap-2">
-      {#if successMsg}
-        <span class="text-sm text-success-500">{successMsg}</span>
-      {/if}
-      {#if error}
-        <span class="text-sm text-error-500">{error}</span>
-      {/if}
-      {#if dirty}
+  <!-- Sticky save bar + section sub-nav -->
+  <div class="sticky top-0 z-10 -mx-4 flex flex-col gap-2 border-b border-surface-200 bg-surface-100/95 px-4 py-2 backdrop-blur dark:border-surface-700 dark:bg-surface-900/95 md:-mx-6 md:px-6">
+    <div class="flex items-center justify-between gap-3">
+      <p class="hidden text-xs text-surface-400 sm:block">
+        Appearance &amp; provider toggles apply instantly · other settings save together
+      </p>
+      <div class="flex shrink-0 flex-nowrap items-center gap-2">
+        {#if successMsg}
+          <span class="text-sm text-success-500">{successMsg}</span>
+        {/if}
+        {#if error}
+          <span class="text-sm text-error-500">{error}</span>
+        {/if}
+        {#if dirty}
+          <span class="text-xs font-medium text-warning-600 dark:text-warning-400">Unsaved changes</span>
+          <button
+            type="button"
+            class="rounded-lg bg-surface-200 px-3 py-1.5 text-sm font-medium hover:bg-surface-300 dark:bg-surface-700 dark:hover:bg-surface-600"
+            onclick={reset}
+          >
+            Reset
+          </button>
+        {/if}
         <button
           type="button"
-          class="rounded-lg bg-surface-200 px-3 py-1.5 text-sm font-medium hover:bg-surface-300 dark:bg-surface-700 dark:hover:bg-surface-600"
-          onclick={reset}
+          class="rounded-lg bg-primary-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-600 disabled:opacity-50"
+          onclick={save}
+          disabled={!dirty || saving}
         >
-          Reset
+          {saving ? 'Saving…' : 'Save'}
         </button>
-      {/if}
-      <button
-        type="button"
-        class="rounded-lg bg-primary-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-600 disabled:opacity-50"
-        onclick={save}
-        disabled={!dirty || saving}
-      >
-        {saving ? 'Saving…' : 'Save'}
-      </button>
+      </div>
     </div>
+    <nav class="flex gap-1 overflow-x-auto" aria-label="Settings sections">
+      {#each navSections as s (s.id)}
+        <button
+          type="button"
+          class="shrink-0 rounded-md px-2.5 py-1 text-xs font-medium text-surface-500 transition-colors hover:bg-surface-200 hover:text-surface-800 dark:hover:bg-surface-700 dark:hover:text-surface-200"
+          onclick={() => scrollToSection(s.id)}
+        >
+          {s.label}
+        </button>
+      {/each}
+    </nav>
   </div>
 
   <!-- Appearance (localStorage-backed, no save required) -->
-  <div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
+  <div id="appearance" class="scroll-mt-28 rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
     <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Appearance</h2>
     <div class="flex flex-col gap-1 sm:max-w-xs">
       <label class="text-sm font-medium" for="color-scheme">Color Scheme</label>
@@ -191,7 +237,7 @@
 
   {#if settings}
     <!-- Agent Defaults -->
-    <div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
+    <div id="agent-defaults" class="scroll-mt-28 rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
       <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Agent Defaults</h2>
       <div class="grid grid-cols-1 gap-4 sm:grid-cols-4">
         <div class="flex flex-col gap-1">
@@ -244,10 +290,12 @@
       </div>
     </div>
 
-    <ProviderHealthPanel {settings} onsettingschange={syncOriginal} />
+    <section id="provider-health" class="scroll-mt-28">
+      <ProviderHealthPanel {settings} onsettingschange={syncOriginal} />
+    </section>
 
     <!-- Notifications -->
-    <div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
+    <div id="notifications" class="scroll-mt-28 rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
       <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Notifications</h2>
       <label class="flex cursor-pointer items-center gap-3">
         <input
@@ -260,7 +308,7 @@
     </div>
 
     <!-- Orchestrator -->
-    <div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
+    <div id="orchestrator" class="scroll-mt-28 rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
       <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Orchestrator</h2>
       <div class="flex flex-col gap-3">
         <label class="flex cursor-pointer items-center gap-3">
@@ -288,14 +336,20 @@
       </div>
     </div>
 
-    <LoggingPanel settings={settings} />
+    <section id="logging" class="scroll-mt-28">
+      <LoggingPanel settings={settings} />
+    </section>
 
-    <TodoistPanel settings={settings} />
+    <section id="todoist" class="scroll-mt-28">
+      <TodoistPanel settings={settings} />
+    </section>
 
-    <RenovatePanel settings={settings} />
+    <section id="renovate" class="scroll-mt-28">
+      <RenovatePanel settings={settings} />
+    </section>
 
     <!-- Version (read-only) -->
-    <div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
+    <div id="version" class="scroll-mt-28 rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
       <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Version</h2>
       <div class="flex flex-col gap-2">
         <div class="flex items-center gap-3">
@@ -310,7 +364,7 @@
     </div>
 
     <!-- Directories (read-only) -->
-    <div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
+    <div id="directories" class="scroll-mt-28 rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
       <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Directories</h2>
       <div class="flex flex-col gap-2">
         {#each dirOrder as key (key)}

--- a/frontend/src/pages/Settings.svelte.test.ts
+++ b/frontend/src/pages/Settings.svelte.test.ts
@@ -96,7 +96,66 @@ describe('Settings', () => {
   it('renders the appearance section', () => {
     mockGetSettings.mockReturnValue(new Promise(() => {}))
     render(Settings)
-    expect(screen.getByText('Appearance')).toBeDefined()
+    expect(screen.getByRole('heading', { name: 'Appearance' })).toBeDefined()
+  })
+
+  it('renders the section sub-nav and clarifies save scope', () => {
+    mockGetSettings.mockReturnValue(new Promise(() => {}))
+    render(Settings)
+    const nav = screen.getByRole('navigation', { name: 'Settings sections' })
+    expect(nav).toBeDefined()
+    // Sub-nav exposes the sections as quick links.
+    expect(screen.getByRole('button', { name: 'Orchestrator' })).toBeDefined()
+    // Save scope is spelled out (immediate vs save-together).
+    expect(screen.getByText(/apply instantly/)).toBeDefined()
+  })
+
+  it('scrolls to a settings-gated section via its sub-nav link', async () => {
+    mockGetSettings.mockResolvedValue(mockSettings)
+    // jsdom has no native scrollIntoView; stub it and restore so it can't leak.
+    const orig = Element.prototype.scrollIntoView
+    const scrollSpy = vi.fn()
+    Element.prototype.scrollIntoView = scrollSpy as never
+    try {
+      render(Settings)
+      // Logging only renders inside {#if settings}; wait for load so the anchor exists.
+      await vi.waitFor(() => screen.getByText('Logging & Audit'))
+      await fireEvent.click(screen.getByRole('button', { name: 'Logging' }))
+      expect(scrollSpy).toHaveBeenCalled()
+    } finally {
+      if (orig) Element.prototype.scrollIntoView = orig
+      else delete (Element.prototype as { scrollIntoView?: unknown }).scrollIntoView
+    }
+  })
+
+  it('keeps another section dirty when a provider toggles (no baseline wipe)', async () => {
+    mockGetSettings.mockResolvedValue(structuredClone(mockSettings))
+    mockProviderHealthEnabled.mockResolvedValue(true)
+    mockSetProviderAutoFailover.mockResolvedValue(undefined)
+    render(Settings)
+    await vi.waitFor(() => screen.getByRole('heading', { name: 'Notifications' }))
+    // Dirty a non-provider section.
+    await fireEvent.click(screen.getByLabelText('Desktop notifications (macOS)'))
+    expect((screen.getByText('Save') as HTMLButtonElement).disabled).toBe(false)
+    // Toggle a provider setting — it persists immediately and reconciles ONLY the
+    // providers sub-tree, so the pending Notifications edit must survive.
+    await fireEvent.click(screen.getByLabelText(/Auto-failover between providers/))
+    await vi.waitFor(() => expect(mockSetProviderAutoFailover).toHaveBeenCalled())
+    expect((screen.getByText('Save') as HTMLButtonElement).disabled).toBe(false)
+    expect(screen.getByText('Unsaved changes')).toBeDefined()
+  })
+
+  it('every sub-nav link resolves to a rendered section anchor', async () => {
+    mockGetSettings.mockResolvedValue(mockSettings)
+    const navIds = [
+      'appearance', 'agent-defaults', 'provider-health', 'notifications',
+      'orchestrator', 'logging', 'todoist', 'renovate', 'version', 'directories',
+    ]
+    const { container } = render(Settings)
+    await vi.waitFor(() => screen.getByRole('heading', { name: 'Directories' }))
+    for (const id of navIds) {
+      expect(container.querySelector(`#${id}`), `missing anchor #${id}`).not.toBeNull()
+    }
   })
 
   it('renders Agent Defaults section after load', async () => {
@@ -111,7 +170,7 @@ describe('Settings', () => {
     mockGetSettings.mockResolvedValue(mockSettings)
     render(Settings)
     await vi.waitFor(() => {
-      expect(screen.getByText('Notifications')).toBeDefined()
+      expect(screen.getByRole('heading', { name: 'Notifications' })).toBeDefined()
     })
   })
 
@@ -119,7 +178,7 @@ describe('Settings', () => {
     mockGetSettings.mockResolvedValue(mockSettings)
     render(Settings)
     await vi.waitFor(() => {
-      expect(screen.getByText('Orchestrator')).toBeDefined()
+      expect(screen.getByRole('heading', { name: 'Orchestrator' })).toBeDefined()
     })
   })
 
@@ -135,7 +194,7 @@ describe('Settings', () => {
     mockGetSettings.mockResolvedValue(mockSettings)
     render(Settings)
     await vi.waitFor(() => {
-      expect(screen.getByText('Directories')).toBeDefined()
+      expect(screen.getByRole('heading', { name: 'Directories' })).toBeDefined()
     })
   })
 
@@ -187,7 +246,7 @@ describe('Settings', () => {
     mockGetSettings.mockResolvedValue(mockSettings)
     render(Settings)
     await vi.waitFor(() => {
-      expect(screen.getByText('Todoist')).toBeDefined()
+      expect(screen.getByRole('heading', { name: 'Todoist' })).toBeDefined()
     })
   })
 
@@ -204,7 +263,7 @@ describe('Settings', () => {
     mockGetSettings.mockResolvedValue(mockSettings)
     render(Settings)
     await vi.waitFor(() => {
-      expect(screen.getByText('Renovate')).toBeDefined()
+      expect(screen.getByRole('heading', { name: 'Renovate' })).toBeDefined()
     })
   })
 
@@ -212,14 +271,14 @@ describe('Settings', () => {
     mockGetSettings.mockResolvedValue(mockSettings)
     render(Settings)
     await vi.waitFor(() => {
-      expect(screen.getByText('Version')).toBeDefined()
+      expect(screen.getByRole('heading', { name: 'Version' })).toBeDefined()
     })
   })
 
   it('shows Appearance section with Color Scheme select', () => {
     mockGetSettings.mockReturnValue(new Promise(() => {}))
     render(Settings)
-    expect(screen.getByText('Appearance')).toBeDefined()
+    expect(screen.getByRole('heading', { name: 'Appearance' })).toBeDefined()
     expect(screen.getByLabelText('Color Scheme')).toBeDefined()
   })
 
@@ -322,7 +381,7 @@ describe('Settings', () => {
     mockGetSettings.mockResolvedValue({ ...mockSettings })
     render(Settings)
     await vi.waitFor(() => {
-      expect(screen.getByText('Directories')).toBeDefined()
+      expect(screen.getByRole('heading', { name: 'Directories' })).toBeDefined()
       expect(screen.getByDisplayValue('/home/.sybra/tasks')).toBeDefined()
       expect(screen.getByDisplayValue('/home/.sybra/skills')).toBeDefined()
     })
@@ -331,7 +390,7 @@ describe('Settings', () => {
   it('toggles desktop notifications checkbox', async () => {
     mockGetSettings.mockResolvedValue({ ...mockSettings })
     render(Settings)
-    await vi.waitFor(() => screen.getByText('Notifications'))
+    await vi.waitFor(() => screen.getByRole('heading', { name: 'Notifications' }))
     const checkbox = screen.getByLabelText('Desktop notifications (macOS)') as HTMLInputElement
     expect(checkbox.checked).toBe(false)
     await fireEvent.click(checkbox)


### PR DESCRIPTION
## Motivation

Settings mixed immediate-apply controls with a top "Save" button on one long single-scroll page, so it was never clear what saved when and the page was hard to navigate (issue #923).

## Implementation information

- **Clear save scope**: a sticky header now holds the Save/Reset controls with an "Unsaved changes" badge (shown only when dirty) and a scope note — "Appearance & provider toggles apply instantly · other settings save together".
- **Section sub-nav**: an anchored `<nav>` of section links (Appearance, Agent, Providers, Notifications, Orchestrator, Logging, Todoist, Renovate, Version, Directories) scrolls to each `id`'d section, so it's no longer one long scroll.
- **Data-loss fix** (caught by the pre-PR adversarial review): provider toggles persist immediately, then called `syncOriginal()` which reset the **entire** saved baseline — silently discarding unsaved edits in other sections while the UI showed "saved". `syncOriginal` now folds only the `providers` sub-tree into the baseline, preserving other sections' dirty state. Covered by a regression test.

The adversarial review's other findings are addressed: five section tests that were matching the new nav buttons instead of the headings now assert `getByRole('heading')`; a new test asserts every sub-nav id resolves to a rendered anchor; the `scrollIntoView` stub is restored to avoid cross-test leakage; and the save-bar button cluster is `flex-nowrap`/`shrink-0` so a narrow dirty header can't grow past the scroll offset.

Closes #923

> Changelog: feat(settings): save semantics & section nav