### PR TITLE
fix(chat): label tokens, cost precision, paths

### DIFF
--- a/frontend/src/components/ChatView.svelte
+++ b/frontend/src/components/ChatView.svelte
@@ -4,6 +4,7 @@
   import MessageBubble from './MessageBubble.svelte'
   import ToolApproval from './ToolApproval.svelte'
   import ChatInput from './ChatInput.svelte'
+  import { formatCost } from '../lib/cost.js'
   import { ArrowDown } from '@lucide/svelte'
 
   interface Props {
@@ -134,7 +135,7 @@
     {/if}
 
     {#if costUsd > 0}
-      <span class="text-xs text-surface-500">${costUsd.toFixed(2)}</span>
+      <span class="text-xs text-surface-500">{formatCost(costUsd)}</span>
     {/if}
 
     <button

--- a/frontend/src/components/MessageBubble.svelte
+++ b/frontend/src/components/MessageBubble.svelte
@@ -10,8 +10,9 @@
 
   const { event }: Props = $props()
 
-  // Tool results larger than this are CC-offloaded to a temp file and arrive
-  // with the internal absolute path inline; collapse them rather than leak it.
+  // The backend truncates tool-result content to 2000 chars + "..." (see
+  // internal/agent/runner_convo.go), so anything longer is a truncated/oversized
+  // result whose head can contain an internal absolute path — collapse it.
   const OVERSIZED_RESULT = 2000
 
   function isOversized(content: string): boolean {
@@ -116,7 +117,7 @@
       <span
         title="input ↓ / output ↑ tokens"
         aria-label="{(event.inputTokens ?? 0).toLocaleString()} input tokens, {(event.outputTokens ?? 0).toLocaleString()} output tokens"
-      >{event.inputTokens?.toLocaleString()}↓ {event.outputTokens?.toLocaleString()}↑</span>
+      >{(event.inputTokens ?? 0).toLocaleString()}↓ {(event.outputTokens ?? 0).toLocaleString()}↑</span>
     {/if}
   </div>
 {/if}

--- a/frontend/src/components/MessageBubble.svelte
+++ b/frontend/src/components/MessageBubble.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { ConvoEvent } from '../../bindings/github.com/Automaat/sybra/internal/agent/models.js'
   import { renderMarkdown } from '../lib/markdown.js'
+  import { formatCost } from '../lib/cost.js'
   import DiffViewer from './DiffViewer.svelte'
 
   interface Props {
@@ -8,6 +9,14 @@
   }
 
   const { event }: Props = $props()
+
+  // Tool results larger than this are CC-offloaded to a temp file and arrive
+  // with the internal absolute path inline; collapse them rather than leak it.
+  const OVERSIZED_RESULT = 2000
+
+  function isOversized(content: string): boolean {
+    return content.length > OVERSIZED_RESULT
+  }
 
   const isUserInput = $derived(event.type === 'user_input')
   const isAssistant = $derived(event.type === 'assistant')
@@ -86,7 +95,11 @@
         {result.isError
           ? 'border-error-500 bg-error-50 text-error-800 dark:bg-error-950 dark:text-error-200'
           : 'border-success-500 bg-success-50 text-success-800 dark:bg-success-950 dark:text-success-200'}">
-        <pre class="max-h-40 overflow-y-auto whitespace-pre-wrap break-words">{truncate(result.content, 1000)}</pre>
+        {#if isOversized(result.content) && !result.isError}
+          <span class="italic text-surface-500 dark:text-surface-400">Output too large — view file</span>
+        {:else}
+          <pre class="max-h-40 overflow-y-auto whitespace-pre-wrap break-words">{truncate(result.content, 1000)}</pre>
+        {/if}
       </div>
     {/each}
   {/if}
@@ -97,10 +110,13 @@
       DONE
     </span>
     {#if event.costUsd}
-      <span>${event.costUsd.toFixed(4)}</span>
+      <span>{formatCost(event.costUsd)}</span>
     {/if}
     {#if event.inputTokens || event.outputTokens}
-      <span>{event.inputTokens?.toLocaleString()}↓ {event.outputTokens?.toLocaleString()}↑</span>
+      <span
+        title="input ↓ / output ↑ tokens"
+        aria-label="{(event.inputTokens ?? 0).toLocaleString()} input tokens, {(event.outputTokens ?? 0).toLocaleString()} output tokens"
+      >{event.inputTokens?.toLocaleString()}↓ {event.outputTokens?.toLocaleString()}↑</span>
     {/if}
   </div>
 {/if}

--- a/frontend/src/components/MessageBubble.svelte.test.ts
+++ b/frontend/src/components/MessageBubble.svelte.test.ts
@@ -142,6 +142,12 @@ describe('MessageBubble', () => {
     expect(span.getAttribute('aria-label')).toBe('50 input tokens, 1,200 output tokens')
   })
 
+  it('renders a zero token side as 0, not blank', () => {
+    const ev = makeEvent({ type: 'result', inputTokens: 0, outputTokens: 1200 })
+    render(MessageBubble, { props: { event: ev } })
+    expect(screen.getByText(/^0↓ 1,200↑$/)).toBeDefined()
+  })
+
   it('shows DONE badge for result event', () => {
     const ev = makeEvent({ type: 'result', costUsd: 0.01 })
     render(MessageBubble, { props: { event: ev } })

--- a/frontend/src/components/MessageBubble.svelte.test.ts
+++ b/frontend/src/components/MessageBubble.svelte.test.ts
@@ -98,6 +98,50 @@ describe('MessageBubble', () => {
     expect(screen.getByText('Error occurred')).toBeDefined()
   })
 
+  it('collapses an oversized tool result without leaking its inline path', () => {
+    const big = 'x'.repeat(2500) + '\nsaved to /var/folders/zz/secret/output.txt'
+    const ev = makeEvent({
+      type: 'user',
+      toolResults: [
+        ToolResultBlock.createFrom({ toolUseId: 'tu1', content: big, isError: false }),
+      ],
+    })
+    render(MessageBubble, { props: { event: ev } })
+    expect(screen.getByText('Output too large — view file')).toBeDefined()
+    expect(screen.queryByText(/\/var\/folders/)).toBeNull()
+  })
+
+  it('still renders a normal-sized tool result', () => {
+    const ev = makeEvent({
+      type: 'user',
+      toolResults: [
+        ToolResultBlock.createFrom({ toolUseId: 'tu1', content: 'normal output', isError: false }),
+      ],
+    })
+    render(MessageBubble, { props: { event: ev } })
+    expect(screen.getByText('normal output')).toBeDefined()
+    expect(screen.queryByText('Output too large — view file')).toBeNull()
+  })
+
+  it('does not collapse a large error result (keeps the failure detail)', () => {
+    const bigErr = 'compile error: ' + 'detail '.repeat(400) // > 2000 chars
+    const ev = makeEvent({
+      type: 'user',
+      toolResults: [ToolResultBlock.createFrom({ toolUseId: 'tu1', content: bigErr, isError: true })],
+    })
+    render(MessageBubble, { props: { event: ev } })
+    expect(screen.queryByText('Output too large — view file')).toBeNull()
+    expect(screen.getByText(/compile error/)).toBeDefined()
+  })
+
+  it('labels the token arrows for tooltip and screen readers', () => {
+    const ev = makeEvent({ type: 'result', inputTokens: 50, outputTokens: 1200 })
+    render(MessageBubble, { props: { event: ev } })
+    const span = screen.getByText(/1,200/)
+    expect(span.getAttribute('title')).toContain('input')
+    expect(span.getAttribute('aria-label')).toBe('50 input tokens, 1,200 output tokens')
+  })
+
   it('shows DONE badge for result event', () => {
     const ev = makeEvent({ type: 'result', costUsd: 0.01 })
     render(MessageBubble, { props: { event: ev } })

--- a/frontend/src/lib/cost.test.ts
+++ b/frontend/src/lib/cost.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { formatCost } from './cost.js'
+
+describe('formatCost', () => {
+  it('uses a uniform 4-decimal precision', () => {
+    expect(formatCost(0.2758)).toBe('$0.2758')
+    expect(formatCost(0.28)).toBe('$0.2800')
+  })
+
+  it('keeps sub-cent costs visible', () => {
+    expect(formatCost(0.0028)).toBe('$0.0028')
+  })
+
+  it('handles zero and whole values', () => {
+    expect(formatCost(0)).toBe('$0.0000')
+    expect(formatCost(5)).toBe('$5.0000')
+  })
+
+  it('coerces non-finite input to zero instead of $NaN', () => {
+    expect(formatCost(undefined)).toBe('$0.0000')
+    expect(formatCost(null)).toBe('$0.0000')
+    expect(formatCost(Number.NaN)).toBe('$0.0000')
+  })
+})

--- a/frontend/src/lib/cost.ts
+++ b/frontend/src/lib/cost.ts
@@ -1,0 +1,8 @@
+// Uniform USD cost formatting for the chat surface. A single fixed precision so
+// the same cumulative cost never renders as e.g. "$0.28" in the header and
+// "$0.2758" in a message footer. Four decimals keeps sub-cent per-run costs
+// readable instead of collapsing them to "$0.00".
+export function formatCost(usd: number | null | undefined): string {
+  const n = Number.isFinite(usd) ? (usd as number) : 0
+  return `$${n.toFixed(4)}`
+}


### PR DESCRIPTION
## Motivation

Chat/agent output polish gaps (issue #924): token counts (`NN↓ N,NNN↑`) had no labels; the same cumulative cost rendered as `$0.28` in the ChatView header and `$0.2758` in the MessageBubble footer; and large tool outputs leaked CC's internal absolute temp-file path inline.

## Implementation information

- **Tokens labelled**: the arrow span gets `title="input ↓ / output ↑ tokens"` and an `aria-label` ("N input tokens, M output tokens") so the mapping is clear for mouse, touch and screen-reader users.
- **Uniform cost precision**: a shared `lib/cost.ts` `formatCost` (fixed 4 decimals, non-finite coerced to `$0.0000`) now backs both the chat header and the message footer, so the same value can't show two precisions.
- **No leaked temp paths**: oversized **successful** tool results collapse to "Output too large — view file" instead of printing the offloaded temp path. Large **errors** are left expanded (truncated) so the failure detail the user needs isn't hidden.

### Scope notes (from the pre-PR adversarial review)
- The review argued the path fix should also cover tool-**use** `file_path`/Bash/JSON displays and sub-2000-char results. Those are intentional transparency (the file being edited, the command being run, real project paths in errors) — the issue is specifically about *large outputs* leaking an *internal temp* path (the offload artifact), which is what the size-gated collapse targets. Blanket path-scrubbing would remove useful file references.
- `formatCost` is wired into the chat surfaces the issue cites; broader app-wide adoption (cards/stats use `toFixed(2)`) is a separate follow-up under this `fix(chat)` scope.

Closes #924

> Changelog: fix(chat): label tokens, cost precision, paths