### PR TITLE
feat(tasks): de-emphasize timeline view

### DIFF
--- a/frontend/src/components/TaskListFilterBar.svelte
+++ b/frontend/src/components/TaskListFilterBar.svelte
@@ -114,8 +114,8 @@
       </button>
     </div>
     {#if !focusModeStore.enabled}
-      <!-- Advanced: the Timeline (Gantt) is de-emphasized; focus mode (which
-           always forces the list view) hides it entirely. -->
+      <!-- Advanced: the Timeline (Gantt) is de-emphasized and hidden while focus
+           mode is on (focus mode leads with the list view on enable). -->
       <button
         type="button"
         aria-label="Timeline view (advanced)"

--- a/frontend/src/components/TaskListFilterBar.svelte
+++ b/frontend/src/components/TaskListFilterBar.svelte
@@ -3,6 +3,7 @@
   import TaskFilterPanel from './TaskFilterPanel.svelte'
   import { navStore } from '../lib/navigation.svelte.js'
   import { viewModeStore, type ViewMode } from '../lib/view-mode.svelte.js'
+  import { focusModeStore } from '../lib/focus-mode.svelte.js'
 
   interface Props {
     searchQuery: string
@@ -91,11 +92,12 @@
       <input type="checkbox" bind:checked={showDone} class="accent-primary-500" />
       Show done
     </label>
+    <!-- Primary views: List / Board. Timeline is demoted to an advanced option. -->
     <div class="flex rounded-md border border-surface-300 dark:border-surface-700" title="Switch view (⌘B)">
       <button
         type="button"
         aria-label="List view"
-        class="flex items-center gap-1 px-2 py-1 text-xs font-medium transition-colors first:rounded-l-md last:rounded-r-md {viewMode === 'list' ? 'bg-primary-500 text-white dark:bg-primary-600' : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
+        class="flex items-center gap-1 rounded-l-md px-2 py-1 text-xs font-medium transition-colors {viewMode === 'list' ? 'bg-primary-500 text-white dark:bg-primary-600' : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
         onclick={() => pickViewMode('list')}
       >
         <List size={14} />
@@ -104,21 +106,28 @@
       <button
         type="button"
         aria-label="Board view"
-        class="flex items-center gap-1 border-x border-surface-300 px-2 py-1 text-xs font-medium transition-colors dark:border-surface-700 {viewMode === 'board' ? 'bg-primary-500 text-white dark:bg-primary-600' : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
+        class="flex items-center gap-1 rounded-r-md border-l border-surface-300 px-2 py-1 text-xs font-medium transition-colors dark:border-surface-700 {viewMode === 'board' ? 'bg-primary-500 text-white dark:bg-primary-600' : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
         onclick={() => pickViewMode('board')}
       >
         <Columns size={14} />
         Board
       </button>
+    </div>
+    {#if !focusModeStore.enabled}
+      <!-- Advanced: the Timeline (Gantt) is de-emphasized; focus mode (which
+           always forces the list view) hides it entirely. -->
       <button
         type="button"
-        aria-label="Timeline view"
-        class="flex items-center gap-1 px-2 py-1 text-xs font-medium transition-colors first:rounded-l-md last:rounded-r-md {viewMode === 'timeline' ? 'bg-primary-500 text-white dark:bg-primary-600' : 'bg-surface-50 text-surface-600 hover:bg-surface-200 dark:bg-surface-800 dark:text-surface-300 dark:hover:bg-surface-700'}"
+        aria-label="Timeline view (advanced)"
+        title="Timeline — advanced view"
+        class="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors {viewMode === 'timeline'
+          ? 'bg-primary-500 text-white dark:bg-primary-600'
+          : 'text-surface-400 hover:bg-surface-200 hover:text-surface-600 dark:text-surface-500 dark:hover:bg-surface-700 dark:hover:text-surface-300'}"
         onclick={() => pickViewMode('timeline')}
       >
         <GanttChart size={14} />
         Timeline
       </button>
-    </div>
+    {/if}
   </div>
 </div>

--- a/frontend/src/lib/keyboard.svelte.ts
+++ b/frontend/src/lib/keyboard.svelte.ts
@@ -15,7 +15,7 @@ export const SHORTCUTS: { scope: string; label: string; shortcuts: Shortcut[] }[
       { keys: '⌘1 – ⌘7', description: 'Navigate pages' },
       { keys: '⌘,', description: 'Settings' },
       { keys: '⌘F  /  /', description: 'Focus task search' },
-      { keys: '⌘B', description: 'Cycle view: List → Board → Timeline' },
+      { keys: '⌘B', description: 'Cycle view: List ↔ Board' },
       { keys: '⌘I', description: 'Open task detail sidebar' },
       { keys: '⌘=  /  ⌘-  /  ⌘0', description: 'Zoom in / out / reset' },
     ],

--- a/frontend/src/lib/view-mode.svelte.test.ts
+++ b/frontend/src/lib/view-mode.svelte.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { viewModeStore } from './view-mode.svelte.js'
+
+describe('viewModeStore', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    viewModeStore.set('list')
+  })
+
+  it('cycles between the primary list and board views only', () => {
+    viewModeStore.cycle()
+    expect(viewModeStore.mode).toBe('board')
+    viewModeStore.cycle()
+    expect(viewModeStore.mode).toBe('list')
+  })
+
+  it('returns to list when cycling out of the advanced timeline view', () => {
+    viewModeStore.set('timeline')
+    viewModeStore.cycle()
+    expect(viewModeStore.mode).toBe('list')
+  })
+
+  it('still allows setting the timeline view explicitly', () => {
+    viewModeStore.set('timeline')
+    expect(viewModeStore.mode).toBe('timeline')
+  })
+})

--- a/frontend/src/lib/view-mode.svelte.ts
+++ b/frontend/src/lib/view-mode.svelte.ts
@@ -1,6 +1,8 @@
 export type ViewMode = 'list' | 'board' | 'timeline'
 
-const MODES: ViewMode[] = ['list', 'board', 'timeline']
+// The quick-switch cycle (⌘B) rotates only the primary views. Timeline is a
+// de-emphasized advanced view, reachable via its own button, not the cycle.
+const CYCLE_MODES: ViewMode[] = ['list', 'board']
 const STORAGE_KEY = 'taskViewMode'
 
 function loadStored(): ViewMode {
@@ -31,7 +33,8 @@ function createViewModeStore() {
       }
     },
     cycle(): void {
-      const next = MODES[(MODES.indexOf(mode) + 1) % MODES.length]
+      // From timeline (or any non-primary), indexOf is -1 → lands on 'list'.
+      const next = CYCLE_MODES[(CYCLE_MODES.indexOf(mode) + 1) % CYCLE_MODES.length]
       mode = next
       try {
         localStorage.setItem(STORAGE_KEY, next)

--- a/frontend/src/pages/TaskList.svelte.test.ts
+++ b/frontend/src/pages/TaskList.svelte.test.ts
@@ -34,6 +34,7 @@ const { taskStore } = await import('../stores/tasks.svelte.js')
 const { projectStore } = await import('../stores/projects.svelte.js')
 const { notificationStore } = await import('../stores/notifications.svelte.js')
 const { viewModeStore } = await import('../lib/view-mode.svelte.js')
+const { focusModeStore } = await import('../lib/focus-mode.svelte.js')
 const TaskList = (await import('./TaskList.svelte')).default
 
 const mockTask = (id: string, title: string, status = 'todo') => ({
@@ -56,6 +57,7 @@ describe('TaskList', () => {
     Object.assign(projectStore, { list: [] })
     vi.mocked(notificationStore.pushLocal).mockClear()
     viewModeStore.set('board')
+    focusModeStore.set(false)
   })
 
   afterEach(() => {
@@ -116,11 +118,20 @@ describe('TaskList', () => {
   })
 
   describe('view mode buttons', () => {
-    it('renders List, Board, and Timeline buttons', () => {
+    it('renders List, Board, and the de-emphasized Timeline button', () => {
       render(TaskList, { props: { onselect: vi.fn() } })
       expect(screen.getByText('List')).toBeDefined()
       expect(screen.getByText('Board')).toBeDefined()
       expect(screen.getByText('Timeline')).toBeDefined()
+    })
+
+    it('hides the advanced Timeline button in focus mode', () => {
+      focusModeStore.set(true)
+      viewModeStore.set('board')
+      render(TaskList, { props: { onselect: vi.fn() } })
+      expect(screen.getByText('List')).toBeDefined()
+      expect(screen.getByText('Board')).toBeDefined()
+      expect(screen.queryByText('Timeline')).toBeNull()
     })
 
     it('renders Show done checkbox', () => {


### PR DESCRIPTION
## Motivation

The Timeline (Gantt) renders low-value created→now "aging" bars for agent tasks that aren't calendar-scheduled, yet it occupied a top-level view toggle next to List and Board (issue #925).

## Implementation information

Chose the de-emphasis path (vs. reworking the bars):
- The primary segmented control is now **List | Board** only; the ⌘B `cycle()` rotates `['list','board']` (from timeline it lands back on list).
- Timeline becomes a **de-emphasized "advanced" ghost button** after the segmented group, hidden in Focus mode (which already forces the list view). It stays selectable and the timeline still renders + keyboard-zooms when chosen.
- Updated the ⌘B shortcut help text to "List ↔ Board".

A pre-PR adversarial review confirmed: the persisted-timeline + focus-mode "stuck" case can't occur (every focus-enable path forces the list view), the cycle modulo is correct, mobile exposes no view switcher, and the segmented-control border math is right. Its two findings are fixed — the stale ⌘B help text and a now-dead `|| viewMode === 'timeline'` gate clause (dropped).

## Open questions / scope

- The root complaint that the bars convey little (created→now age) is addressed by demotion, not by reworking the bars into a meaningful span — a larger follow-up if the Timeline is kept.

Closes #925

> Changelog: feat(tasks): de-emphasize timeline view