### PR TITLE
fix(ui): mobile polish (pills, nav, columns)

### DIFF
--- a/frontend/src/components/StatusBadge.svelte
+++ b/frontend/src/components/StatusBadge.svelte
@@ -15,6 +15,6 @@
   )
 </script>
 
-<span class="inline-block rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors duration-100 {resolved.badgeClasses}">
+<span class="inline-block whitespace-nowrap rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors duration-100 {resolved.badgeClasses}">
   {resolved.label}
 </span>

--- a/frontend/src/components/TaskListView.svelte
+++ b/frontend/src/components/TaskListView.svelte
@@ -17,6 +17,11 @@
     return PRIORITY_OPTIONS.find(o => o.value === (p ?? ''))?.icon ?? '–'
   }
 
+  // Hide the Priority column entirely until at least one task has a priority,
+  // so it doesn't waste scarce width (notably on mobile) showing only "–".
+  const hasPriorities = $derived(tasks.some((t) => priorityIcon(t.priority) !== '–'))
+  const colCount = $derived(hasPriorities ? 5 : 4)
+
   function priorityLabel(p: string | undefined): string {
     return PRIORITY_OPTIONS.find(o => o.value === (p ?? ''))?.label ?? 'None'
   }
@@ -26,11 +31,13 @@
   }
 </script>
 
-<div class="min-h-0 flex-1 overflow-y-auto">
+<div class="min-h-0 flex-1 overflow-x-auto overflow-y-auto">
   <table class="w-full text-sm">
     <thead class="sticky top-0 z-10 border-b border-surface-200 bg-surface-100 dark:border-surface-700 dark:bg-surface-900">
       <tr>
-        <th class="px-4 py-2 text-left font-semibold text-surface-500 text-xs uppercase tracking-wider w-8">P</th>
+        {#if hasPriorities}
+          <th class="px-4 py-2 text-left font-semibold text-surface-500 text-xs uppercase tracking-wider w-8">P</th>
+        {/if}
         <th class="px-4 py-2 text-left font-semibold text-surface-500 text-xs uppercase tracking-wider">Title</th>
         <th class="px-4 py-2 text-left font-semibold text-surface-500 text-xs uppercase tracking-wider">Status</th>
         <th class="px-4 py-2 text-left font-semibold text-surface-500 text-xs uppercase tracking-wider hidden md:table-cell">Project</th>
@@ -46,11 +53,13 @@
           onclick={() => onselect(t.id)}
           onmouseenter={() => onhover(rowIdx)}
         >
-          <td class="px-4 py-2">
-            <span class="font-mono text-sm {priorityClasses(t.priority)}" title="Priority: {priorityLabel(t.priority)}">{priorityIcon(t.priority)}</span>
-          </td>
+          {#if hasPriorities}
+            <td class="px-4 py-2">
+              <span class="font-mono text-sm {priorityClasses(t.priority)}" title="Priority: {priorityLabel(t.priority)}">{priorityIcon(t.priority)}</span>
+            </td>
+          {/if}
           <td class="px-4 py-2 font-medium">{t.title}</td>
-          <td class="px-4 py-2">
+          <td class="whitespace-nowrap px-4 py-2">
             <StatusBadge status={t.status} />
           </td>
           <td class="hidden px-4 py-2 text-surface-500 md:table-cell">{t.projectId || '—'}</td>
@@ -61,7 +70,7 @@
       {/each}
       {#if tasks.length === 0}
         <tr>
-          <td colspan="5" class="px-4 py-8 text-center text-surface-400">No tasks match your filters</td>
+          <td colspan={colCount} class="px-4 py-8 text-center text-surface-400">No tasks match your filters</td>
         </tr>
       {/if}
     </tbody>

--- a/frontend/src/components/TaskListView.svelte
+++ b/frontend/src/components/TaskListView.svelte
@@ -17,9 +17,12 @@
     return PRIORITY_OPTIONS.find(o => o.value === (p ?? ''))?.icon ?? '–'
   }
 
+  // The set of real (non-"None") priority values, derived from the options.
+  const SET_PRIORITIES = new Set(PRIORITY_OPTIONS.map((o) => o.value).filter(Boolean))
+
   // Hide the Priority column entirely until at least one task has a priority,
   // so it doesn't waste scarce width (notably on mobile) showing only "–".
-  const hasPriorities = $derived(tasks.some((t) => priorityIcon(t.priority) !== '–'))
+  const hasPriorities = $derived(tasks.some((t) => SET_PRIORITIES.has(t.priority ?? '')))
   const colCount = $derived(hasPriorities ? 5 : 4)
 
   function priorityLabel(p: string | undefined): string {

--- a/frontend/src/components/TaskListView.svelte.test.ts
+++ b/frontend/src/components/TaskListView.svelte.test.ts
@@ -30,6 +30,22 @@ describe('TaskListView', () => {
     expect(screen.getByText('Second')).toBeDefined()
   })
 
+  it('shows the Priority (P) column when a task has a priority', () => {
+    render(TaskListView, {
+      props: { tasks: tasks as never, focusedTaskId: null, onselect: vi.fn(), onhover: vi.fn() },
+    })
+    expect(screen.getByRole('columnheader', { name: 'P' })).toBeDefined()
+  })
+
+  it('hides the Priority column when no task has a priority', () => {
+    const none = tasks.map((t) => ({ ...t, priority: '' }))
+    render(TaskListView, {
+      props: { tasks: none as never, focusedTaskId: null, onselect: vi.fn(), onhover: vi.fn() },
+    })
+    expect(screen.queryByRole('columnheader', { name: 'P' })).toBeNull()
+    expect(screen.getByText('First')).toBeDefined()
+  })
+
   it('shows project for tasks that have one, em-dash otherwise', () => {
     render(TaskListView, {
       props: {

--- a/frontend/src/components/shell/BottomTabBar.svelte.test.ts
+++ b/frontend/src/components/shell/BottomTabBar.svelte.test.ts
@@ -3,7 +3,7 @@ import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
 
 const mockReset = vi.fn()
 vi.mock('../../lib/navigation.svelte.js', () => ({
-  navStore: { reset: (...a: unknown[]) => mockReset(...a), get activeTab() { return 'task-list' } },
+  navStore: { reset: (...a: unknown[]) => mockReset(...a), get activeTab() { return 'board' } },
 }))
 vi.mock('../../stores/tasks.svelte.js', () => ({
   taskStore: { byStatus: () => [] },

--- a/frontend/src/components/shell/BottomTabBar.svelte.test.ts
+++ b/frontend/src/components/shell/BottomTabBar.svelte.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
+
+const mockReset = vi.fn()
+vi.mock('../../lib/navigation.svelte.js', () => ({
+  navStore: { reset: (...a: unknown[]) => mockReset(...a), get activeTab() { return 'task-list' } },
+}))
+vi.mock('../../stores/tasks.svelte.js', () => ({
+  taskStore: { byStatus: () => [] },
+}))
+vi.mock('../../stores/agents.svelte.js', () => ({
+  agentStore: { get list() { return [] } },
+}))
+
+const BottomTabBar = (await import('./BottomTabBar.svelte')).default
+
+describe('BottomTabBar', () => {
+  afterEach(() => {
+    cleanup()
+    mockReset.mockClear()
+  })
+
+  it('exposes the primary tabs incl. Reviews (its only mobile home)', () => {
+    render(BottomTabBar, { props: { onmore: vi.fn() } })
+    for (const label of ['Chats', 'Agents', 'Reviews']) {
+      expect(screen.getByLabelText(label)).toBeDefined()
+    }
+  })
+
+  it('navigates to reviews from the Reviews tab', async () => {
+    render(BottomTabBar, { props: { onmore: vi.fn() } })
+    await fireEvent.click(screen.getByLabelText('Reviews'))
+    expect(mockReset).toHaveBeenCalledWith({ kind: 'reviews' })
+  })
+
+  it('opens the More sheet', async () => {
+    const onmore = vi.fn()
+    render(BottomTabBar, { props: { onmore } })
+    await fireEvent.click(screen.getByLabelText('More'))
+    expect(onmore).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/shell/MoreSheet.svelte
+++ b/frontend/src/components/shell/MoreSheet.svelte
@@ -2,7 +2,6 @@
   import { ChevronRight } from '@lucide/svelte'
   import MobileSheet from './MobileSheet.svelte'
   import { navStore, type Page } from '../../lib/navigation.svelte.js'
-  import { taskStore } from '../../stores/tasks.svelte.js'
 
   interface Props {
     open: boolean
@@ -11,17 +10,13 @@
 
   const { open, onOpenChange }: Props = $props()
 
-  const reviewCount = $derived(
-    taskStore.byStatus('plan-review').length + taskStore.byStatus('test-plan-review').length
-  )
-
   type Item = { label: string; page: Page; badge?: number }
 
   const items: Item[] = $derived([
     { label: 'Dashboard', page: { kind: 'dashboard' } },
     { label: 'Projects', page: { kind: 'project-list' } },
+    { label: 'Logbook', page: { kind: 'logbook' } },
     { label: 'GitHub', page: { kind: 'github' } },
-    { label: 'Reviews', page: { kind: 'reviews' }, badge: reviewCount },
     { label: 'Workflows', page: { kind: 'workflows' } },
     { label: 'Stats', page: { kind: 'stats' } },
     { label: 'Settings', page: { kind: 'settings' } },

--- a/frontend/src/components/shell/MoreSheet.svelte.test.ts
+++ b/frontend/src/components/shell/MoreSheet.svelte.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
+
+const mockReset = vi.fn()
+vi.mock('../../lib/navigation.svelte.js', () => ({
+  navStore: { reset: (...a: unknown[]) => mockReset(...a) },
+}))
+
+const MoreSheet = (await import('./MoreSheet.svelte')).default
+
+describe('MoreSheet', () => {
+  afterEach(() => {
+    cleanup()
+    mockReset.mockClear()
+  })
+
+  it('lists Logbook (reachable on mobile) and not Reviews (it lives in the tab bar)', () => {
+    render(MoreSheet, { props: { open: true, onOpenChange: vi.fn() } })
+    expect(screen.getByText('Logbook')).toBeDefined()
+    // Reviews is a primary bottom-tab; it must not be duplicated here.
+    expect(screen.queryByText('Reviews')).toBeNull()
+  })
+
+  it('navigates to the logbook when its entry is tapped', async () => {
+    render(MoreSheet, { props: { open: true, onOpenChange: vi.fn() } })
+    await fireEvent.click(screen.getByText('Logbook'))
+    expect(mockReset).toHaveBeenCalledWith({ kind: 'logbook' })
+  })
+})


### PR DESCRIPTION
## Motivation

Mobile polish gaps (issue #926): the `in-review` status pill wrapped to two lines in the narrow status column; the empty Priority ("P") column wasted scarce width; "Reviews" appeared in both the bottom tab bar and the More sheet; and Logbook was unreachable from mobile nav.

## Implementation information

- **No wrapped pills**: `whitespace-nowrap` on `StatusBadge` and the status cell; the list container gets `overflow-x-auto` so a too-wide table (long unbreakable title + a long status pill on a 320px screen) scrolls instead of clipping.
- **No dead column**: the Priority "P" column (header + cells + empty-state colspan) is hidden until at least one visible task has a priority.
- **No duplicate nav**: removed the `Reviews` entry from the More sheet (it's a primary bottom tab) and added `Logbook` so every page is reachable on mobile.

A pre-PR adversarial review confirmed all four acceptance criteria hold (enumerated all 16 `Page` kinds against the bottom bar + More sheet — all reachable; `hasPriorities`/colspan math correct). Its one real finding — no test guarded that Reviews stays reachable via the bottom bar after the de-dupe — is fixed with a new `BottomTabBar` test; its x-overflow suggestion is addressed by the `overflow-x-auto`.

Closes #926

> Changelog: fix(ui): mobile polish (pills, nav, columns)