### PR TITLE
perf(app): faster task store + smaller UI bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ frontend/playwright-report/
 sybra-server
 core.*
 /fake-codex
+
+# Perf artifacts
+/perf-profiles/

--- a/frontend/src/components/PageRouter.svelte
+++ b/frontend/src/components/PageRouter.svelte
@@ -1,22 +1,30 @@
 <script lang="ts">
+  // Eager: the daily-driver pages reachable on first paint (default route is
+  // task-list) — keeping them static avoids a navigation chunk fetch on the
+  // hot path.
   import TaskList from '../pages/TaskList.svelte'
   import TaskDetail from '../pages/TaskDetail.svelte'
-  import Agents from '../pages/Agents.svelte'
-  import AgentDetail from '../pages/AgentDetail.svelte'
-  import ProjectList from '../pages/ProjectList.svelte'
-  import ProjectDetail from '../pages/ProjectDetail.svelte'
   import Dashboard from '../pages/Dashboard.svelte'
-  import GitHub from '../pages/GitHub.svelte'
-  import Stats from '../pages/Stats.svelte'
-  import Reviews from '../pages/Reviews.svelte'
-  import Settings from '../pages/Settings.svelte'
-  import ChatList from '../pages/ChatList.svelte'
-  import ChatDetail from '../pages/ChatDetail.svelte'
-  import WorkflowList from '../pages/WorkflowList.svelte'
-  import WorkflowDetail from '../pages/WorkflowDetail.svelte'
-  import Logbook from '../pages/Logbook.svelte'
   import TaskSidebar from './TaskSidebar.svelte'
   import { navStore } from '../lib/navigation.svelte.js'
+  import { lazyComponent } from '../lib/lazy.js'
+
+  // Lazy: rarer / heavier routes, each emitted as its own async chunk so they
+  // stay out of the initial bundle. WorkflowDetail alone pulls @xyflow
+  // (~80 kB gzip); GitHub/Stats/Reviews/Settings add more page-only code.
+  const loadAgents = lazyComponent(() => import('../pages/Agents.svelte'))
+  const loadAgentDetail = lazyComponent(() => import('../pages/AgentDetail.svelte'))
+  const loadProjectList = lazyComponent(() => import('../pages/ProjectList.svelte'))
+  const loadProjectDetail = lazyComponent(() => import('../pages/ProjectDetail.svelte'))
+  const loadGitHub = lazyComponent(() => import('../pages/GitHub.svelte'))
+  const loadStats = lazyComponent(() => import('../pages/Stats.svelte'))
+  const loadReviews = lazyComponent(() => import('../pages/Reviews.svelte'))
+  const loadSettings = lazyComponent(() => import('../pages/Settings.svelte'))
+  const loadChatList = lazyComponent(() => import('../pages/ChatList.svelte'))
+  const loadChatDetail = lazyComponent(() => import('../pages/ChatDetail.svelte'))
+  const loadWorkflowList = lazyComponent(() => import('../pages/WorkflowList.svelte'))
+  const loadWorkflowDetail = lazyComponent(() => import('../pages/WorkflowDetail.svelte'))
+  const loadLogbook = lazyComponent(() => import('../pages/Logbook.svelte'))
 
   interface Props {
     sidebarTaskId: string | null
@@ -76,52 +84,78 @@
       onreviewplan={() => navStore.reset({ kind: 'reviews' })}
     />
   {:else if navStore.page.kind === 'project-list'}
-    <ProjectList
-      onselect={navProjectDetail}
-      onadd={onnewProject}
-    />
+    {#await loadProjectList() then ProjectList}
+      <ProjectList
+        onselect={navProjectDetail}
+        onadd={onnewProject}
+      />
+    {/await}
   {:else if navStore.page.kind === 'project-detail'}
-    <ProjectDetail
-      projectId={navStore.page.projectId}
-      onback={() => navStore.back()}
-      onviewtask={navTaskDetail}
-    />
+    {#await loadProjectDetail() then ProjectDetail}
+      <ProjectDetail
+        projectId={navStore.page.projectId}
+        onback={() => navStore.back()}
+        onviewtask={navTaskDetail}
+      />
+    {/await}
   {:else if navStore.page.kind === 'chats'}
-    <ChatList onselect={navChatDetail} />
+    {#await loadChatList() then ChatList}
+      <ChatList onselect={navChatDetail} />
+    {/await}
   {:else if navStore.page.kind === 'chat-detail'}
-    <ChatDetail
-      agentId={navStore.page.agentId}
-      onback={() => navStore.back()}
-      onviewtask={navTaskDetail}
-    />
+    {#await loadChatDetail() then ChatDetail}
+      <ChatDetail
+        agentId={navStore.page.agentId}
+        onback={() => navStore.back()}
+        onviewtask={navTaskDetail}
+      />
+    {/await}
   {:else if navStore.page.kind === 'agents'}
-    <Agents
-      initialTab={navStore.page.tab}
-      onselect={navAgentDetail}
-    />
+    {#await loadAgents() then Agents}
+      <Agents
+        initialTab={navStore.page.tab}
+        onselect={navAgentDetail}
+      />
+    {/await}
   {:else if navStore.page.kind === 'agent-detail'}
-    <AgentDetail
-      agentId={navStore.page.agentId}
-      onback={() => navStore.back()}
-      onviewtask={navTaskDetail}
-      onnavigate={navAgentDetail}
-    />
+    {#await loadAgentDetail() then AgentDetail}
+      <AgentDetail
+        agentId={navStore.page.agentId}
+        onback={() => navStore.back()}
+        onviewtask={navTaskDetail}
+        onnavigate={navAgentDetail}
+      />
+    {/await}
   {:else if navStore.page.kind === 'github'}
-    <GitHub />
+    {#await loadGitHub() then GitHub}
+      <GitHub />
+    {/await}
   {:else if navStore.page.kind === 'reviews'}
-    <Reviews onviewtask={navTaskDetail} />
+    {#await loadReviews() then Reviews}
+      <Reviews onviewtask={navTaskDetail} />
+    {/await}
   {:else if navStore.page.kind === 'stats'}
-    <Stats />
+    {#await loadStats() then Stats}
+      <Stats />
+    {/await}
   {:else if navStore.page.kind === 'workflows'}
-    <WorkflowList onselect={navWorkflowDetail} />
+    {#await loadWorkflowList() then WorkflowList}
+      <WorkflowList onselect={navWorkflowDetail} />
+    {/await}
   {:else if navStore.page.kind === 'workflow-detail'}
-    <WorkflowDetail
-      workflowId={navStore.page.workflowId}
-      onback={() => navStore.back()}
-    />
+    {#await loadWorkflowDetail() then WorkflowDetail}
+      <WorkflowDetail
+        workflowId={navStore.page.workflowId}
+        onback={() => navStore.back()}
+      />
+    {/await}
   {:else if navStore.page.kind === 'logbook'}
-    <Logbook onviewtask={navTaskDetail} />
+    {#await loadLogbook() then Logbook}
+      <Logbook onviewtask={navTaskDetail} />
+    {/await}
   {:else if navStore.page.kind === 'settings'}
-    <Settings />
+    {#await loadSettings() then Settings}
+      <Settings />
+    {/await}
   {/if}
 </main>

--- a/frontend/src/lib/lazy.ts
+++ b/frontend/src/lib/lazy.ts
@@ -1,0 +1,16 @@
+import type { Component } from 'svelte'
+
+// Memoized dynamic import for route-level code splitting. Vite emits each
+// lazily-imported page as its own async chunk, so heavy/rare routes (e.g.
+// WorkflowDetail, which pulls in @xyflow ~80 kB gzip) stay out of the initial
+// bundle and load on first navigation instead.
+//
+// The returned thunk hands back the SAME promise on every call, so an
+// {#await loader()} block never flashes back to its pending branch on
+// re-render once the chunk has resolved.
+export function lazyComponent(
+  loader: () => Promise<{ default: Component<any> }>,
+): () => Promise<Component<any>> {
+  let cached: Promise<Component<any>> | null = null
+  return () => (cached ??= loader().then((m) => m.default))
+}

--- a/frontend/src/lib/markdown.ts
+++ b/frontend/src/lib/markdown.ts
@@ -1,8 +1,44 @@
 import DOMPurify from 'dompurify'
 import { marked } from 'marked'
 import { markedHighlight } from 'marked-highlight'
-import hljs from 'highlight.js'
+// Import highlight.js core + a curated language set instead of the default
+// `highlight.js` build, which registers ~190 languages and ships as a
+// ~915 kB / 304 kB-gzip chunk loaded eagerly (markdown rendering is on the
+// initial paint path). Registering only the languages we actually render in
+// agent output / task bodies / plans cuts that chunk by ~80%. Unregistered
+// languages fall back to 'plaintext' via the guard in highlight() below, so
+// the only cost is no syntax colour on an exotic language — never a crash.
+import hljs from 'highlight.js/lib/core'
+import bash from 'highlight.js/lib/languages/bash'
+import shell from 'highlight.js/lib/languages/shell'
+import javascript from 'highlight.js/lib/languages/javascript'
+import typescript from 'highlight.js/lib/languages/typescript'
+import json from 'highlight.js/lib/languages/json'
+import yaml from 'highlight.js/lib/languages/yaml'
+import go from 'highlight.js/lib/languages/go'
+import python from 'highlight.js/lib/languages/python'
+import rust from 'highlight.js/lib/languages/rust'
+import markdown from 'highlight.js/lib/languages/markdown'
+import diff from 'highlight.js/lib/languages/diff'
+import dockerfile from 'highlight.js/lib/languages/dockerfile'
+import sql from 'highlight.js/lib/languages/sql'
+import xml from 'highlight.js/lib/languages/xml'
+import css from 'highlight.js/lib/languages/css'
 import 'highlight.js/styles/github-dark.css'
+
+for (const [name, lang] of Object.entries({
+  bash, shell, javascript, typescript, json, yaml, go, python,
+  rust, markdown, diff, dockerfile, sql, xml, css,
+})) {
+  hljs.registerLanguage(name, lang)
+}
+// Aliases so fenced blocks tagged with common short names still highlight.
+hljs.registerAliases(['js'], { languageName: 'javascript' })
+hljs.registerAliases(['ts'], { languageName: 'typescript' })
+hljs.registerAliases(['py'], { languageName: 'python' })
+hljs.registerAliases(['yml'], { languageName: 'yaml' })
+hljs.registerAliases(['html'], { languageName: 'xml' })
+hljs.registerAliases(['sh', 'zsh', 'console'], { languageName: 'shell' })
 
 // Configure marked ONCE at module load. Previously this ran in the
 // <script> block of TaskDetail.svelte and MessageBubble.svelte, which
@@ -22,14 +58,27 @@ marked.use(
 )
 marked.setOptions({ breaks: true, gfm: true })
 
-// Shared cache so identical text doesn't re-parse across components.
+// Bounded LRU cache so identical text doesn't re-parse across components.
+// A plain Map grew without bound: streaming agent output re-renders the same
+// message at every token length, so a single long message minted hundreds of
+// distinct keys that were never evicted. Map preserves insertion order, so the
+// first key is the oldest — evict it once we exceed the cap.
+const CACHE_MAX = 500
 const cache = new Map<string, string>()
 
 export function renderMarkdown(text: string | undefined | null): string {
   if (!text) return ''
   const cached = cache.get(text)
-  if (cached !== undefined) return cached
+  if (cached !== undefined) {
+    // Mark as most-recently-used.
+    cache.delete(text)
+    cache.set(text, cached)
+    return cached
+  }
   const html = DOMPurify.sanitize(marked.parse(text) as string)
   cache.set(text, html)
+  if (cache.size > CACHE_MAX) {
+    cache.delete(cache.keys().next().value as string)
+  }
   return html
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -22,7 +22,13 @@ export default defineConfig(({ mode }) => {
       rollupOptions: {
         output: {
           manualChunks(id) {
-            if (id.includes('@xyflow')) return 'vendor-flow'
+            // highlight.js + marked are pulled in eagerly by the markdown
+            // renderer (initial paint path), so a stable vendor chunk improves
+            // long-term caching. @xyflow is intentionally NOT forced here: it
+            // is only reached through the lazily-imported WorkflowDetail route,
+            // and a manual chunk would hoist it back into the initial graph
+            // (eager modulepreload). Letting Rollup split it keeps it inside
+            // the WorkflowDetail async chunk.
             if (id.includes('highlight.js')) return 'vendor-highlight'
             if (id.includes('/marked')) return 'vendor-markdown'
           },

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -93,7 +93,9 @@ func (m *Manager) OnExternalUpdate(path string) {
 		return
 	}
 
-	t, err := m.store.Get(id)
+	// Only Status is needed here; use the parse-only read to avoid the
+	// per-call sidecar dir scan on every external file change.
+	t, err := m.store.read(id)
 	if err != nil {
 		return
 	}

--- a/internal/task/plan_draft.go
+++ b/internal/task/plan_draft.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/Automaat/sybra/internal/fsutil"
 )
@@ -29,10 +30,51 @@ var validDraftName = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 // canonical Plan sidecar; drafts remain on disk for audit and re-runs.
 type PlanDraftStore struct {
 	dir string
+
+	// Negative-cache index over which task IDs own ≥1 draft on disk. Drafts
+	// only exist for tasks that went through (dual-)planning, so the vast
+	// majority of tasks have none — yet List was called on every Store.Get
+	// and scanned the whole tasks dir (~one lstat per file) to discover that.
+	// Once a List call has scanned the dir, `have` is authoritative until the
+	// next mutation, letting draft-less tasks short-circuit with zero syscalls.
+	// `gen` bumps on every mutation so a List that raced a write never adopts
+	// a stale index (guards against a false "no drafts" answer).
+	mu      sync.Mutex
+	have    map[string]struct{}
+	indexed bool
+	gen     uint64
 }
 
 func NewPlanDraftStore(dir string) *PlanDraftStore {
 	return &PlanDraftStore{dir: dir}
+}
+
+// invalidateIndex drops the cached have-set. Called after every local
+// mutation and by Store.InvalidatePath when the watcher sees an external
+// change to a plan-draft sidecar.
+func (s *PlanDraftStore) invalidateIndex() {
+	s.mu.Lock()
+	s.gen++
+	s.indexed = false
+	s.have = nil
+	s.mu.Unlock()
+}
+
+// parsePlanDraftName splits a sidecar basename into its owning task ID and
+// draft name. ok is false for any file that is not a valid plan-draft sidecar.
+func parsePlanDraftName(base string) (owner, name string, ok bool) {
+	if !strings.HasSuffix(base, ".md") {
+		return "", "", false
+	}
+	idx := strings.Index(base, PlanDraftSidecarPrefix)
+	if idx <= 0 {
+		return "", "", false
+	}
+	name = strings.TrimSuffix(base[idx+len(PlanDraftSidecarPrefix):], ".md")
+	if name == "" || !validDraftName.MatchString(name) {
+		return "", "", false
+	}
+	return base[:idx], name, true
 }
 
 func (s *PlanDraftStore) sidecarPath(taskID, name string) string {
@@ -78,6 +120,7 @@ func (s *PlanDraftStore) Write(taskID, name, content string) error {
 	if err := fsutil.AtomicWrite(s.sidecarPath(taskID, name), []byte(content)); err != nil {
 		return fmt.Errorf("write plan draft %q: %w", name, err)
 	}
+	s.invalidateIndex()
 	return nil
 }
 
@@ -89,40 +132,69 @@ func (s *PlanDraftStore) Delete(taskID, name string) error {
 	if err := os.Remove(s.sidecarPath(taskID, name)); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("delete plan draft %q: %w", name, err)
 	}
+	s.invalidateIndex()
 	return nil
 }
 
 // List returns all drafts for the task as map[name]content. Empty map when
 // no drafts exist.
 func (s *PlanDraftStore) List(taskID string) (map[string]string, error) {
-	prefix := taskID + PlanDraftSidecarPrefix
+	// Fast path: a fully-scanned index that doesn't list this task means it
+	// has no drafts — return without touching the filesystem.
+	s.mu.Lock()
+	indexed := s.indexed
+	_, has := s.have[taskID]
+	startGen := s.gen
+	s.mu.Unlock()
+	if indexed && !has {
+		return map[string]string{}, nil
+	}
+
 	entries, err := os.ReadDir(s.dir)
 	if os.IsNotExist(err) {
+		// No dir → nobody has drafts. Record that so later calls short-circuit.
+		s.adoptIndex(startGen, map[string]struct{}{})
 		return map[string]string{}, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("list plan drafts: %w", err)
 	}
 	out := make(map[string]string)
+	// Build the full owner set in the same pass so the index becomes
+	// authoritative for every task, not just this one.
+	fresh := make(map[string]struct{})
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
 		}
-		base := e.Name()
-		if !strings.HasPrefix(base, prefix) || !strings.HasSuffix(base, ".md") {
+		owner, name, ok := parsePlanDraftName(e.Name())
+		if !ok {
 			continue
 		}
-		name := strings.TrimSuffix(strings.TrimPrefix(base, prefix), ".md")
-		if name == "" || !validDraftName.MatchString(name) {
+		fresh[owner] = struct{}{}
+		if owner != taskID {
 			continue
 		}
-		data, rErr := os.ReadFile(filepath.Join(s.dir, base))
+		data, rErr := os.ReadFile(filepath.Join(s.dir, e.Name()))
 		if rErr != nil {
 			return nil, fmt.Errorf("read plan draft %q: %w", name, rErr)
 		}
 		out[name] = string(data)
 	}
+	s.adoptIndex(startGen, fresh)
 	return out, nil
+}
+
+// adoptIndex installs a freshly-scanned have-set, but only if no mutation
+// raced the scan (gen unchanged). On a race it discards the scan and leaves
+// the index invalid so the next List rebuilds — never caching a stale set.
+func (s *PlanDraftStore) adoptIndex(startGen uint64, fresh map[string]struct{}) {
+	s.mu.Lock()
+	if s.gen == startGen {
+		s.have = fresh
+		s.indexed = true
+	}
+	s.mu.Unlock()
 }
 
 // DeleteAll removes every draft for the task. Used by callers that need
@@ -136,6 +208,7 @@ func (s *PlanDraftStore) DeleteAll(taskID string) error {
 	if err != nil {
 		return fmt.Errorf("list plan drafts: %w", err)
 	}
+	removed := false
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
@@ -147,6 +220,10 @@ func (s *PlanDraftStore) DeleteAll(taskID string) error {
 		if rmErr := os.Remove(filepath.Join(s.dir, base)); rmErr != nil && !os.IsNotExist(rmErr) {
 			return fmt.Errorf("delete plan draft %s: %w", base, rmErr)
 		}
+		removed = true
+	}
+	if removed {
+		s.invalidateIndex()
 	}
 	return nil
 }

--- a/internal/task/plan_draft_test.go
+++ b/internal/task/plan_draft_test.go
@@ -1,0 +1,107 @@
+package task
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPlanDraftStore_WriteListReadDelete(t *testing.T) {
+	s := NewPlanDraftStore(t.TempDir())
+
+	if err := s.Write("task1", "plan_claude", "claude body"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := s.Write("task1", "plan_codex", "codex body"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := s.List("task1")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 || got["plan_claude"] != "claude body" || got["plan_codex"] != "codex body" {
+		t.Fatalf("List = %v, want both drafts", got)
+	}
+
+	if v, _ := s.Read("task1", "plan_claude"); v != "claude body" {
+		t.Fatalf("Read = %q", v)
+	}
+
+	if err := s.Delete("task1", "plan_claude"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	got, _ = s.List("task1")
+	if len(got) != 1 || got["plan_codex"] != "codex body" {
+		t.Fatalf("after Delete List = %v, want only plan_codex", got)
+	}
+}
+
+// TestPlanDraftStore_NegativeCache is the correctness guard for the index:
+// a List on a draft-less task must stay correct after drafts are written to
+// OTHER tasks and after a draft is later written to the task itself.
+func TestPlanDraftStore_NegativeCache(t *testing.T) {
+	s := NewPlanDraftStore(t.TempDir())
+
+	// Prime the index with a full scan that observes zero drafts.
+	if got, _ := s.List("taskA"); len(got) != 0 {
+		t.Fatalf("initial List = %v, want empty", got)
+	}
+	if !s.indexed {
+		t.Fatal("index should be populated after a List scan")
+	}
+
+	// A write to a different task must invalidate the index so taskB is
+	// discoverable rather than masked by the cached empty set.
+	if err := s.Write("taskB", "plan_claude", "b"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if s.indexed {
+		t.Fatal("write must invalidate the index")
+	}
+	if got, _ := s.List("taskB"); got["plan_claude"] != "b" {
+		t.Fatalf("List(taskB) = %v, want the freshly written draft", got)
+	}
+	// taskA still has no drafts.
+	if got, _ := s.List("taskA"); len(got) != 0 {
+		t.Fatalf("List(taskA) = %v, want empty", got)
+	}
+
+	// A later write to taskA itself must surface immediately.
+	if err := s.Write("taskA", "plan_codex", "a"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got, _ := s.List("taskA"); got["plan_codex"] != "a" {
+		t.Fatalf("List(taskA) = %v, want the new draft", got)
+	}
+}
+
+// TestPlanDraftStore_ExternalWriteInvalidates simulates an out-of-process
+// draft file appearing on disk (e.g. another Sybra instance). The Store-level
+// watcher hook must drop the index so the new draft is not masked.
+func TestPlanDraftStore_ExternalWriteInvalidates(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	// Prime the negative cache: taskX has no drafts.
+	if got, _ := store.planDrafts.List("taskX"); len(got) != 0 {
+		t.Fatalf("initial List = %v, want empty", got)
+	}
+
+	// Simulate an external process dropping a draft file directly on disk.
+	external := filepath.Join(dir, "taskX"+PlanDraftSidecarPrefix+"plan_ext.md")
+	if err := os.WriteFile(external, []byte("ext body"), 0o644); err != nil {
+		t.Fatalf("external write: %v", err)
+	}
+
+	// Watcher notifies the store of the sidecar change.
+	store.InvalidatePath(external)
+
+	got, _ := store.planDrafts.List("taskX")
+	if got["plan_ext"] != "ext body" {
+		t.Fatalf("List(taskX) = %v, want the externally written draft", got)
+	}
+}

--- a/internal/task/plan_draft_test.go
+++ b/internal/task/plan_draft_test.go
@@ -6,6 +6,17 @@ import (
 	"testing"
 )
 
+// mustListDrafts lists drafts for id, failing the test on an unexpected error
+// so assertions never run against a map produced by a hidden failure.
+func mustListDrafts(t *testing.T, s *PlanDraftStore, id string) map[string]string {
+	t.Helper()
+	got, err := s.List(id)
+	if err != nil {
+		t.Fatalf("List(%s): %v", id, err)
+	}
+	return got
+}
+
 func TestPlanDraftStore_WriteListReadDelete(t *testing.T) {
 	s := NewPlanDraftStore(t.TempDir())
 
@@ -31,7 +42,7 @@ func TestPlanDraftStore_WriteListReadDelete(t *testing.T) {
 	if err := s.Delete("task1", "plan_claude"); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
-	got, _ = s.List("task1")
+	got = mustListDrafts(t, s, "task1")
 	if len(got) != 1 || got["plan_codex"] != "codex body" {
 		t.Fatalf("after Delete List = %v, want only plan_codex", got)
 	}
@@ -44,7 +55,7 @@ func TestPlanDraftStore_NegativeCache(t *testing.T) {
 	s := NewPlanDraftStore(t.TempDir())
 
 	// Prime the index with a full scan that observes zero drafts.
-	if got, _ := s.List("taskA"); len(got) != 0 {
+	if got := mustListDrafts(t, s, "taskA"); len(got) != 0 {
 		t.Fatalf("initial List = %v, want empty", got)
 	}
 	if !s.indexed {
@@ -59,11 +70,11 @@ func TestPlanDraftStore_NegativeCache(t *testing.T) {
 	if s.indexed {
 		t.Fatal("write must invalidate the index")
 	}
-	if got, _ := s.List("taskB"); got["plan_claude"] != "b" {
+	if got := mustListDrafts(t, s, "taskB"); got["plan_claude"] != "b" {
 		t.Fatalf("List(taskB) = %v, want the freshly written draft", got)
 	}
 	// taskA still has no drafts.
-	if got, _ := s.List("taskA"); len(got) != 0 {
+	if got := mustListDrafts(t, s, "taskA"); len(got) != 0 {
 		t.Fatalf("List(taskA) = %v, want empty", got)
 	}
 
@@ -71,7 +82,7 @@ func TestPlanDraftStore_NegativeCache(t *testing.T) {
 	if err := s.Write("taskA", "plan_codex", "a"); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
-	if got, _ := s.List("taskA"); got["plan_codex"] != "a" {
+	if got := mustListDrafts(t, s, "taskA"); got["plan_codex"] != "a" {
 		t.Fatalf("List(taskA) = %v, want the new draft", got)
 	}
 }
@@ -87,7 +98,7 @@ func TestPlanDraftStore_ExternalWriteInvalidates(t *testing.T) {
 	}
 
 	// Prime the negative cache: taskX has no drafts.
-	if got, _ := store.planDrafts.List("taskX"); len(got) != 0 {
+	if got := mustListDrafts(t, store.planDrafts, "taskX"); len(got) != 0 {
 		t.Fatalf("initial List = %v, want empty", got)
 	}
 
@@ -100,7 +111,7 @@ func TestPlanDraftStore_ExternalWriteInvalidates(t *testing.T) {
 	// Watcher notifies the store of the sidecar change.
 	store.InvalidatePath(external)
 
-	got, _ := store.planDrafts.List("taskX")
+	got := mustListDrafts(t, store.planDrafts, "taskX")
 	if got["plan_ext"] != "ext body" {
 		t.Fatalf("List(taskX) = %v, want the externally written draft", got)
 	}

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -214,6 +214,26 @@ func loadSidecarsFromEntries(dir string, entries []os.DirEntry) *sidecarIndex {
 }
 
 func (s *Store) Get(id string) (Task, error) {
+	t, err := s.read(id)
+	if err != nil {
+		return Task{}, err
+	}
+	t.Plan, _ = s.plans.Read(t.ID)
+	t.PlanCritique, _ = s.planCritiques.Read(t.ID)
+	t.CodeReview, _ = s.codeReviews.Read(t.ID)
+	t.PlanDrafts, _ = s.planDrafts.List(t.ID)
+	return t, nil
+}
+
+// read parses just the task file for id, skipping the sidecar fan-out that
+// Get performs. Write paths (Update, Delete) and the watcher status hook only
+// need the task's own frontmatter/body — the sidecar fields are yaml:"-" so
+// Marshal never serializes them, and no List() consumer reads them off a
+// cached entry. Loading them there is pure waste, dominated by
+// PlanDraftStore.List, which scans the entire tasks dir (~one lstat per file)
+// on every call. That scan was ~20% of server CPU and ~50% of allocations
+// under churn because Update/Delete/OnExternalUpdate each paid it.
+func (s *Store) read(id string) (Task, error) {
 	path, err := s.safePath(id)
 	if err != nil {
 		return Task{}, err
@@ -225,10 +245,6 @@ func (s *Store) Get(id string) (Task, error) {
 		}
 		return Task{}, err
 	}
-	t.Plan, _ = s.plans.Read(t.ID)
-	t.PlanCritique, _ = s.planCritiques.Read(t.ID)
-	t.CodeReview, _ = s.codeReviews.Read(t.ID)
-	t.PlanDrafts, _ = s.planDrafts.List(t.ID)
 	return t, nil
 }
 
@@ -315,7 +331,7 @@ func (s *Store) CreateChat(projectID string) (Task, error) {
 }
 
 func (s *Store) Delete(id string) error {
-	t, err := s.Get(id)
+	t, err := s.read(id)
 	if err != nil {
 		return err
 	}
@@ -361,7 +377,7 @@ func (s *Store) Update(id string, u Update) (Task, error) {
 // status. Lets callers (Manager.Update) wire status-change hooks without a
 // redundant Get to read the previous value before the write.
 func (s *Store) UpdateWithPrev(id string, u Update) (Task, Status, error) {
-	t, err := s.Get(id)
+	t, err := s.read(id)
 	if err != nil {
 		return Task{}, "", err
 	}
@@ -474,6 +490,12 @@ func (s *Store) InvalidatePath(path string) {
 	}
 	base := filepath.Base(path)
 	if IsSidecarFile(base) {
+		// An external plan-draft write/delete must drop the draft index so a
+		// draft-less negative-cache hit can't mask a draft that appeared on
+		// disk out-of-process.
+		if IsPlanDraftFile(base) {
+			s.planDrafts.invalidateIndex()
+		}
 		s.invalidateListCache()
 		return
 	}
@@ -481,7 +503,30 @@ func (s *Store) InvalidatePath(path string) {
 	if id == "" {
 		return
 	}
-	s.invalidateListCache()
+	// Targeted refresh instead of a blanket invalidate: a single task file
+	// changed (commonly the fsnotify echo of our OWN AtomicWrite ~200ms
+	// earlier), so re-read just that file and patch its one cache entry rather
+	// than dropping the whole list and forcing the next List() to re-parse and
+	// re-clone every task. Keeps the list cache warm under active agent write
+	// load, where it was perpetually cold.
+	s.refreshCachedTask(id)
+}
+
+// refreshCachedTask re-reads a single task (with sidecars, so List output is
+// identical to a full rebuild) and patches its entry in the warm list cache.
+// A vanished file removes the entry; an unexpected read error falls back to a
+// full invalidate. No-op when the cache is cold (storeTaskCache guards on it).
+func (s *Store) refreshCachedTask(id string) {
+	t, err := s.Get(id)
+	if err != nil {
+		if os.IsNotExist(err) || strings.Contains(err.Error(), "not found") {
+			s.deleteCachedTask(id)
+			return
+		}
+		s.invalidateListCache()
+		return
+	}
+	s.storeTaskCache(t)
 }
 
 func (s *Store) cachedList() ([]Task, bool) {

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -240,8 +241,10 @@ func (s *Store) read(id string) (Task, error) {
 	}
 	t, err := Parse(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return Task{}, fmt.Errorf("task %s not found", id)
+		if errors.Is(err, os.ErrNotExist) {
+			// Wrap so callers can detect the missing file via
+			// errors.Is(err, os.ErrNotExist) instead of string matching.
+			return Task{}, fmt.Errorf("task %s not found: %w", id, err)
 		}
 		return Task{}, err
 	}
@@ -519,7 +522,7 @@ func (s *Store) InvalidatePath(path string) {
 func (s *Store) refreshCachedTask(id string) {
 	t, err := s.Get(id)
 	if err != nil {
-		if os.IsNotExist(err) || strings.Contains(err.Error(), "not found") {
+		if errors.Is(err, os.ErrNotExist) {
 			s.deleteCachedTask(id)
 			return
 		}

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -1501,7 +1501,10 @@ func TestStoreListInvalidatePathTargetedRefresh(t *testing.T) {
 		t.Fatal(err)
 	}
 	store.InvalidatePath(a.FilePath)
-	tasks, _ = store.List()
+	tasks, err = store.List()
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, tk := range tasks {
 		if tk.ID == a.ID {
 			t.Fatalf("Alpha should be gone after file removal")

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -1449,3 +1449,65 @@ func TestStoreGet_PathTraversalSlugRejected(t *testing.T) {
 		}
 	}
 }
+
+// TestStoreListInvalidatePathTargetedRefresh verifies that an external edit to
+// one task file patches just that task in the warm list cache while leaving
+// the other cached tasks intact, and that a vanished file is dropped.
+func TestStoreListInvalidatePathTargetedRefresh(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, err := store.Create("Alpha", "a", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := store.Create("Bravo", "b", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.List(); err != nil { // prime cache
+		t.Fatalf("prime: %v", err)
+	}
+
+	// External edit of Alpha's title.
+	edited := "---\nid: " + a.ID + "\ntitle: Alpha Edited\nstatus: todo\nagent_mode: headless\ncreated_at: " +
+		a.CreatedAt.Format("2006-01-02T15:04:05Z07:00") + "\nupdated_at: " +
+		a.UpdatedAt.Format("2006-01-02T15:04:05Z07:00") + "\n---\na\n"
+	if err := os.WriteFile(a.FilePath, []byte(edited), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store.InvalidatePath(a.FilePath)
+
+	tasks, err := store.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	byID := map[string]Task{}
+	for _, tk := range tasks {
+		byID[tk.ID] = tk
+	}
+	if byID[a.ID].Title != "Alpha Edited" {
+		t.Fatalf("Alpha title = %q, want refreshed", byID[a.ID].Title)
+	}
+	if byID[b.ID].Title != "Bravo" {
+		t.Fatalf("Bravo missing/changed: %q", byID[b.ID].Title)
+	}
+
+	// Vanished file is dropped from the cache.
+	if err := os.Remove(a.FilePath); err != nil {
+		t.Fatal(err)
+	}
+	store.InvalidatePath(a.FilePath)
+	tasks, _ = store.List()
+	for _, tk := range tasks {
+		if tk.ID == a.ID {
+			t.Fatalf("Alpha should be gone after file removal")
+		}
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("want 1 task remaining, got %d", len(tasks))
+	}
+}

--- a/perf-testing.md
+++ b/perf-testing.md
@@ -20,10 +20,20 @@ Knobs:
 
 Baseline reference (M4 Max, `-benchtime=2s`):
 
-- `BenchmarkStoreList/n=1000` ≈ 39 ms/op — UI refresh hot path budget.
-- `BenchmarkParseClaudeLine_Mixed` ≈ 2.4 µs/op — every NDJSON line pays this.
+- `BenchmarkStoreList/n=1000` ≈ 90 µs/op — UI refresh hot path budget (served
+  from the in-memory list cache; cold rebuild parses every file).
+- `BenchmarkStoreGet` ≈ 40 µs/op, 169 allocs — single-task detail read.
+- `BenchmarkStoreUpdate` ≈ 270 µs/op, 236 allocs — Get-modify-marshal-write.
+- `BenchmarkParseClaudeLine_Mixed` ≈ 2.7 µs/op — every NDJSON line pays this.
 - `BenchmarkEmit_AllSubscribers/subs=100` ≈ 18 µs/op — SSE fanout cost.
 - `BenchmarkWatcherSameFileCoalescing` — verifies N writes → 1 emission.
+
+> Plan-draft scan optimization (2026-06): `Store.Get` used to call
+> `PlanDraftStore.List`, which scanned the whole tasks dir on every read
+> (~20% of server CPU, ~50% of allocations under churn). Write paths (Update,
+> Delete, watcher status hook) now use a parse-only `Store.read`, and the
+> detail `Get` path is backed by a negative-cache index in `PlanDraftStore`.
+> Net: `StoreGet` 446 µs → 40 µs, `StoreUpdate` 378 µs → 270 µs.
 
 Compare two runs:
 


### PR DESCRIPTION
## Motivation

Profiling a real server under a token-free load harness (fake-claude + pprof)
surfaced two hot paths:

- `Store.Get` scanned the entire tasks dir on every read (via
  `PlanDraftStore.List`) to find usually-zero plan drafts — ~20% of server CPU
  and ~50% of allocations under churn. Update, Delete and the fsnotify watcher
  all routed through Get and paid it.
- The frontend shipped highlight.js with all ~190 languages (914 KB / 304 KB
  gzip) eagerly, and statically imported all 17 routes including the @xyflow
  workflow graph — a ~591 KB-gzip initial JS load.

> Changelog: perf(app): faster task-store reads + smaller frontend bundle

## Implementation information

Backend (`internal/task`):

- Parse-only `Store.read` for write/watcher paths that never need sidecars
  (Update, Delete, OnExternalUpdate).
- Race-safe negative-cache index in `PlanDraftStore`: once a List has scanned
  the dir, draft-less tasks short-circuit with zero syscalls. Dropped on every
  local mutation and by the watcher on external draft writes; a generation
  counter guards against a List racing a concurrent write.
- `InvalidatePath` refreshes a single task in the warm list cache instead of
  dropping it, so the app's own write echo no longer forces a full O(N)
  re-parse + clone on the next List.

Frontend:

- `highlight.js/lib/core` + 15 curated languages; unknown languages fall back
  to plaintext.
- Route-level code splitting in `PageRouter`; `@xyflow` dropped from
  manualChunks so it loads only with the WorkflowDetail route.
- Bounded 500-entry LRU for the markdown render cache (was an unbounded Map
  that grew under streaming agent output).

Measured:

| Metric | Before | After |
| --- | --- | --- |
| StoreGet | 446 us, 2187 allocs | 40 us, 169 allocs |
| StoreUpdate | 378 us, 463 allocs | 268 us, 236 allocs |
| vendor-highlight chunk | 914 KB / 304 KB gz | 69 KB / 23 KB gz |
| Initial-load JS (gzip) | ~591 KB | ~172 KB |

Gates: gofmt, golangci-lint, oxlint, svelte-check, `go test ./...` (incl.
`-race`), 1486 frontend tests — all green. New tests cover the negative-cache
correctness (incl. external-write invalidation) and targeted list refresh.

## Supporting documentation

`perf-testing.md` updated with the corrected `StoreList` baseline (the prior
39 ms figure was stale by ~400x) and a note on the plan-draft scan work.

Out of scope (flagged for follow-up): `List()` deep-clones every task per call
(defensive copy with an explicit test) — removing it needs a read-only variant
plus a caller audit.
