### PR TITLE
fix(triage): clear status_reason on success

### DIFF
--- a/internal/triage/apply.go
+++ b/internal/triage/apply.go
@@ -72,7 +72,10 @@ func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project
 
 	status := RouteStatus(v.Size, v.Type, projectType)
 	updates["status"] = string(status)
-	updates["status_reason"] = "triage"
+	// No status_reason on successful triage: the field is reserved for
+	// attention-worthy states (monitor/watchdog/blocked), which the UI renders
+	// as a warning. Setting "status" without a reason makes the store clear any
+	// stale reason (e.g. "monitor: awaiting triage").
 
 	updated, err := mgr.UpdateMap(t.ID, updates)
 	if err != nil {

--- a/internal/triage/apply_test.go
+++ b/internal/triage/apply_test.go
@@ -49,8 +49,8 @@ func TestApplyRewritesTitleAndPreservesOriginal(t *testing.T) {
 	if updated.Status != task.StatusTodo {
 		t.Errorf("status: got %s, want todo", updated.Status)
 	}
-	if updated.StatusReason != "triage" {
-		t.Errorf("status_reason: got %q", updated.StatusReason)
+	if updated.StatusReason != "" {
+		t.Errorf("status_reason: got %q, want empty (reason reserved for attention states)", updated.StatusReason)
 	}
 	if len(updated.Tags) != 3 {
 		t.Errorf("tags: got %v", updated.Tags)


### PR DESCRIPTION
## Motivation

Every triaged task showed a warning triangle reading "triage" on its card. The triage classifier stamped the literal string `"triage"` into `status_reason` for every task it processed, and the UI (`TaskCard.svelte`) renders any non-empty `status_reason` with an `AlertTriangle`. Result: a normal happy-path triage lit up a warning that said nothing actionable.

`status_reason` is meant for attention-worthy states — every other producer writes a real reason (`"monitor: agent lost, resetting"`, `"watchdog: turn limit exceeded"`, `"commits pushed but no PR created"`). Triage was polluting it.

> Changelog: fix(triage): clear status_reason on success

## Implementation information

- Removed `updates["status_reason"] = "triage"` in `internal/triage/apply.go`.
- Triage always sets `status`, so the store's existing auto-clear (`store.go:402` — clears reason on status change when no new reason is provided) wipes any stale reason such as `"monitor: awaiting triage"`. No extra clearing logic needed.
- Updated `apply_test.go` to assert an empty `status_reason` after triage.

Considered instead suppressing `"triage"` in the UI, but that retains a meaningless audit value; clearing at the source keeps the field's invariant (non-empty ⇒ needs attention) intact.

## Supporting documentation

`go test ./internal/triage/` passes.