### PR TITLE
feat(agent): survive restart for headless agents

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -54,6 +54,15 @@ export class AgentDefaults {
      */
     "logRetentionDays": number;
 
+    /**
+     * SurviveRestart keeps agent subprocesses running across an app
+     * restart (detached, output streamed to their log files) and reattaches
+     * to them on the next startup. nil means not configured (defaults to
+     * true). Set false to revert to the legacy behaviour where agents are
+     * killed on shutdown and recovered via restart-stale.
+     */
+    "surviveRestart": boolean | null;
+
     /** Creates a new AgentDefaults instance. */
     constructor($$source: Partial<AgentDefaults> = {}) {
         if (!("provider" in $$source)) {
@@ -94,6 +103,9 @@ export class AgentDefaults {
         }
         if (!("logRetentionDays" in $$source)) {
             this["logRetentionDays"] = 0;
+        }
+        if (!("surviveRestart" in $$source)) {
+            this["surviveRestart"] = null;
         }
 
         Object.assign(this, $$source);

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -41,6 +41,11 @@ type Manager struct {
 	guardrails    Guardrails
 	bashTimeoutMs int
 	gate          provider.HealthGate
+
+	// reg persists live-agent records so subprocesses can be reattached
+	// after an app restart. nil disables survival (legacy behaviour).
+	reg            *registryStore
+	surviveRestart bool
 }
 
 func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir string) *Manager {
@@ -56,6 +61,75 @@ func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir 
 
 func (m *Manager) SetOnComplete(fn func(ag *Agent)) {
 	m.onComplete = fn
+}
+
+// EnableSurviveRestart turns on restart survival: headless (and, once
+// Phase 3 lands, interactive) subprocesses are detached and recorded in a
+// registry under dir so the next app instance can reattach to them. Call
+// once during startup before ReattachAll.
+func (m *Manager) EnableSurviveRestart(dir string) error {
+	s, err := newRegistryStore(dir)
+	if err != nil {
+		return err
+	}
+	m.mu.Lock()
+	m.reg = s
+	m.surviveRestart = true
+	m.mu.Unlock()
+	return nil
+}
+
+// survives reports whether restart survival is active.
+func (m *Manager) survives() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.surviveRestart && m.reg != nil
+}
+
+// registry returns the registry store (nil when survival is disabled).
+func (m *Manager) registry() *registryStore {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.reg
+}
+
+// saveRegistry snapshots the agent to disk. No-op when survival is off.
+func (m *Manager) saveRegistry(a *Agent) {
+	reg := m.registry()
+	if reg == nil || a == nil {
+		return
+	}
+	a.mu.RLock()
+	rec := Record{
+		ID:        a.ID,
+		TaskID:    a.TaskID,
+		Name:      a.Name,
+		Mode:      a.Mode,
+		Provider:  a.Provider,
+		Model:     a.Model,
+		PID:       a.PID,
+		SessionID: a.SessionID,
+		LogPath:   a.LogPath,
+		CWD:       a.sessionCWD,
+		StartedAt: a.StartedAt,
+		MaxTurns:  a.MaxTurns,
+	}
+	a.mu.RUnlock()
+	rec.ProcStartedAt = processStartString(rec.PID)
+	if err := reg.Save(rec); err != nil {
+		m.logger.Warn("agent.registry.save", "id", a.ID, "err", err)
+	}
+}
+
+// signalKill terminates an agent's subprocess. Prefers the *exec.Cmd
+// handle (live this lifetime); falls back to the PID for reattached
+// agents that have no handle.
+func (m *Manager) signalKill(a *Agent) {
+	if cmd := a.GetCmd(); cmd != nil && cmd.Process != nil {
+		stopWithSIGINT(cmd, a.done, stopSIGINTGrace)
+		return
+	}
+	signalPID(a.GetPID(), stopSIGINTGrace)
 }
 
 // SetApprovalAddr sets the HTTP address for the tool approval server.

--- a/internal/agent/manager_control.go
+++ b/internal/agent/manager_control.go
@@ -224,7 +224,14 @@ func (m *Manager) ShutdownWithGrace(grace time.Duration) {
 	m.mu.RLock()
 	count := len(m.agents)
 	dones := make([]chan struct{}, 0, count)
+	survived := 0
 	for _, a := range m.agents {
+		// Detached agents are meant to outlive the app: do not cancel
+		// them and do not wait on their done channel (it stays open).
+		if a.isDetached() {
+			survived++
+			continue
+		}
 		if a.cancel != nil {
 			a.cancel()
 		}
@@ -234,7 +241,7 @@ func (m *Manager) ShutdownWithGrace(grace time.Duration) {
 	}
 	m.mu.RUnlock()
 
-	m.logger.Info("agent.shutdown", "count", count, "grace", grace, "wait", len(dones))
+	m.logger.Info("agent.shutdown", "count", count, "grace", grace, "wait", len(dones), "survived", survived)
 	if len(dones) == 0 || grace <= 0 {
 		return
 	}

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -72,9 +72,10 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 		a.escalationCh = make(chan bool, 1)
 		// Pre-mark detached so a shutdown racing the runner goroutine
 		// already knows to leave this agent's subprocess running. The
-		// runner re-asserts this after a successful Start.
+		// runner re-asserts this after a successful Start. Use the mutexed
+		// setter — detached is guarded by mu and read via isDetached().
 		if m.survives() {
-			a.detached = true
+			a.setDetached(true)
 		}
 	}
 

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -70,6 +70,12 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 	}
 	if cfg.Mode == "headless" {
 		a.escalationCh = make(chan bool, 1)
+		// Pre-mark detached so a shutdown racing the runner goroutine
+		// already knows to leave this agent's subprocess running. The
+		// runner re-asserts this after a successful Start.
+		if m.survives() {
+			a.detached = true
+		}
 	}
 
 	m.mu.Lock()
@@ -113,6 +119,9 @@ func (m *Manager) markAgentDone(a *Agent) {
 	}
 	a.doneOnce.Do(func() {
 		close(a.done)
+		if reg := m.registry(); reg != nil {
+			_ = reg.Delete(a.ID)
+		}
 		m.mu.Lock()
 		if m.liveCount > 0 {
 			m.liveCount--

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -107,6 +107,12 @@ type Agent struct {
 	// workflow step to "failed".
 	stopped bool
 
+	// detached is true when the agent's subprocess was spawned to survive
+	// an app restart (Setsid, output redirected to its log file, no ctx
+	// kill). ShutdownWithGrace leaves detached agents running instead of
+	// cancelling them. Guarded by mu.
+	detached bool
+
 	// mu guards mutable fields touched from multiple goroutines. See the
 	// package-level note above the Agent type.
 	mu sync.RWMutex
@@ -393,6 +399,44 @@ func (a *Agent) GetLogPath() string {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.LogPath
+}
+
+// GetPID returns the subprocess PID (0 if not yet started).
+func (a *Agent) GetPID() int {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.PID
+}
+
+// setDetached marks whether the agent's subprocess is detached for
+// restart survival.
+func (a *Agent) setDetached(v bool) {
+	a.mu.Lock()
+	a.detached = v
+	a.mu.Unlock()
+}
+
+// isDetached reports whether the agent's subprocess was spawned to
+// survive an app restart.
+func (a *Agent) isDetached() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.detached
+}
+
+// hasTerminalResult reports whether the output buffer contains a
+// non-error result event — the signal that a headless run completed its
+// work. Used by reattach completion to distinguish a clean finish from a
+// process that vanished mid-run.
+func (a *Agent) hasTerminalResult() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for i := range a.outputBuffer {
+		if a.outputBuffer[i].Type == "result" && a.outputBuffer[i].Subtype != "error" {
+			return true
+		}
+	}
+	return false
 }
 
 // GetLastEventAt returns the most recent event timestamp.

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -1,0 +1,187 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Automaat/sybra/internal/events"
+)
+
+// errReattachedGone marks a reattached agent whose process exited without
+// ever emitting a terminal result — treated as a crash so the completion
+// handler stalls the workflow instead of advancing it on partial work.
+var errReattachedGone = errors.New("agent: reattached process exited without result")
+
+// reattachPIDPoll is how often a reattached agent's PID is checked for
+// liveness (there is no *exec.Cmd to Wait on). Var, not const, so tests
+// can shorten it.
+var reattachPIDPoll = time.Second
+
+// ReattachAll rebuilds in-memory agents for subprocesses recorded in the
+// registry that are still alive, and resumes streaming their output by
+// tailing their log files. Records whose process is gone (or whose PID was
+// reused by an unrelated process) are deleted. Returns the agents that
+// were reattached. No-op when survival is disabled.
+//
+// Call once at startup, before recovery's restart-stale sweep, so
+// HasRunningAgentForTask sees the reattached agents and does not dispatch
+// duplicates.
+func (m *Manager) ReattachAll() []*Agent {
+	reg := m.registry()
+	if reg == nil {
+		return nil
+	}
+	recs, err := reg.List()
+	if err != nil {
+		m.logger.Warn("agent.reattach.list", "err", err)
+		return nil
+	}
+
+	var out []*Agent
+	for i := range recs {
+		r := recs[i]
+		// Phase 1 reattaches headless agents only. Interactive records are
+		// handled by a later phase; leave them untouched here.
+		if r.Mode != "headless" {
+			continue
+		}
+		if !reattachAlive(r) {
+			_ = reg.Delete(r.ID)
+			m.logger.Info("agent.reattach.dead", "id", r.ID, "pid", r.PID, "task", r.TaskID)
+			continue
+		}
+
+		a := agentFromRecord(r)
+		if r.LogPath != "" {
+			if evs, perr := ParseLogFile(r.LogPath, 0, r.Provider); perr == nil {
+				a.outputBuffer = evs
+			} else {
+				m.logger.Warn("agent.reattach.rehydrate", "id", r.ID, "err", perr)
+			}
+		}
+
+		ctx, cancel := context.WithCancel(m.ctx)
+		a.cancel = cancel
+		a.done = make(chan struct{})
+
+		m.mu.Lock()
+		if _, exists := m.agents[a.ID]; exists {
+			m.mu.Unlock()
+			cancel()
+			continue
+		}
+		m.agents[a.ID] = a
+		m.liveCount++
+		m.mu.Unlock()
+
+		m.logger.Info("agent.reattach", "id", a.ID, "pid", a.PID, "task", a.TaskID, "events", len(a.outputBuffer))
+		go m.reattachHeadless(ctx, a)
+		m.emit(events.AgentState(a.ID), a)
+		out = append(out, a)
+	}
+	return out
+}
+
+// reattachHeadless tails a reattached subprocess's log file until the
+// process exits (or the app shuts down), then finalizes the agent through
+// the same completion path as a freshly run one.
+func (m *Manager) reattachHeadless(ctx context.Context, a *Agent) {
+	procDone := make(chan struct{})
+	go watchPID(ctx, a.GetPID(), procDone)
+
+	exited := m.tailHeadlessFile(ctx, a, a.GetLogPath(), false, procDone)
+	if !exited {
+		// App shutting down while the child is still alive: keep it running
+		// and let the registry drive the next reattach.
+		m.logger.Info("agent.reattach.detach", "id", a.ID, "pid", a.GetPID(), "reason", "shutdown")
+		return
+	}
+
+	if !a.hasTerminalResult() {
+		a.SetExitErr(errReattachedGone)
+	}
+	a.SetState(StateStopped)
+	m.logger.Info("agent.reattach.done", "id", a.ID, "cost", a.GetCostUSD())
+	m.emit(events.AgentState(a.ID), a)
+	m.recordCompletion(a, a.GetExitErr() == nil)
+	if m.onComplete != nil {
+		m.onComplete(a)
+	}
+	m.markAgentDone(a)
+}
+
+// watchPID closes done when the process exits. On context cancel (app
+// shutdown) it returns WITHOUT closing done, so the tailer takes its own
+// ctx.Done path and leaves the agent running for the next reattach.
+func watchPID(ctx context.Context, pid int, done chan struct{}) {
+	if pid <= 0 {
+		close(done)
+		return
+	}
+	t := time.NewTicker(reattachPIDPoll)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if !processAlive(pid) {
+				close(done)
+				return
+			}
+		}
+	}
+}
+
+// reattachAlive reports whether the recorded process is still the agent we
+// spawned: alive, and (when we captured a start time) not a different
+// process that reused the PID.
+func reattachAlive(r Record) bool {
+	if r.PID <= 0 || !processAlive(r.PID) {
+		return false
+	}
+	if r.ProcStartedAt != "" {
+		if cur := processStartString(r.PID); cur != "" && cur != r.ProcStartedAt {
+			return false
+		}
+	}
+	return true
+}
+
+func agentFromRecord(r Record) *Agent {
+	return &Agent{
+		ID:          r.ID,
+		TaskID:      r.TaskID,
+		Name:        r.Name,
+		Mode:        r.Mode,
+		Provider:    r.Provider,
+		Model:       r.Model,
+		PID:         r.PID,
+		SessionID:   r.SessionID,
+		LogPath:     r.LogPath,
+		sessionCWD:  r.CWD,
+		StartedAt:   r.StartedAt,
+		LastEventAt: time.Now().UTC(),
+		State:       StateRunning,
+		MaxTurns:    r.MaxTurns,
+		detached:    true,
+	}
+}
+
+// processStartString returns the OS-reported start time of a process as an
+// opaque string, used only for equality comparison to detect PID reuse.
+// Best-effort: an empty result disables the guard for that record.
+func processStartString(pid int) string {
+	if pid <= 0 {
+		return ""
+	}
+	out, err := exec.Command("ps", "-o", "lstart=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -165,10 +165,15 @@ func watchPID(ctx context.Context, pid int, procStart string, done chan struct{}
 				close(done)
 				return
 			}
-			if procStart != "" && processStartString(pid) != procStart {
-				// PID reused by an unrelated process — our agent is gone.
-				close(done)
-				return
+			// Best-effort PID-reuse guard, matching reattachAlive: only act on
+			// a definite mismatch. An empty current start time (ps unavailable)
+			// must NOT be treated as a mismatch, or a still-running agent would
+			// be wrongly marked gone.
+			if procStart != "" {
+				if cur := processStartString(pid); cur != "" && cur != procStart {
+					close(done)
+					return
+				}
 			}
 		}
 	}

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"context"
 	"errors"
+	"io"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -23,9 +25,11 @@ var reattachPIDPoll = time.Second
 
 // ReattachAll rebuilds in-memory agents for subprocesses recorded in the
 // registry that are still alive, and resumes streaming their output by
-// tailing their log files. Records whose process is gone (or whose PID was
-// reused by an unrelated process) are deleted. Returns the agents that
-// were reattached. No-op when survival is disabled.
+// tailing their log files. A record whose process is gone is finalized if
+// its log shows the run completed (so a run that finished while the app was
+// down is not redone), otherwise deleted. Records whose PID was reused by
+// an unrelated process are treated as gone. Returns the reattached agents.
+// No-op when survival is disabled.
 //
 // Call once at startup, before recovery's restart-stale sweep, so
 // HasRunningAgentForTask sees the reattached agents and does not dispatch
@@ -50,18 +54,22 @@ func (m *Manager) ReattachAll() []*Agent {
 			continue
 		}
 		if !reattachAlive(r) {
+			// Process gone. If it finished its work before vanishing,
+			// finalize so the workflow advances instead of re-running it.
+			m.finalizeIfCompleted(r)
 			_ = reg.Delete(r.ID)
 			m.logger.Info("agent.reattach.dead", "id", r.ID, "pid", r.PID, "task", r.TaskID)
 			continue
 		}
 
 		a := agentFromRecord(r)
+		// Rehydrate the buffer and capture the exact byte offset consumed, so
+		// the tailer resumes from there with no gap (a line appended between
+		// rehydration and the tail's first read is not lost) and no
+		// duplication.
+		var startOffset int64
 		if r.LogPath != "" {
-			if evs, perr := ParseLogFile(r.LogPath, 0, r.Provider); perr == nil {
-				a.outputBuffer = evs
-			} else {
-				m.logger.Warn("agent.reattach.rehydrate", "id", r.ID, "err", perr)
-			}
+			startOffset = rehydrateFromLog(a, r.LogPath)
 		}
 
 		ctx, cancel := context.WithCancel(m.ctx)
@@ -78,22 +86,45 @@ func (m *Manager) ReattachAll() []*Agent {
 		m.liveCount++
 		m.mu.Unlock()
 
-		m.logger.Info("agent.reattach", "id", a.ID, "pid", a.PID, "task", a.TaskID, "events", len(a.outputBuffer))
-		go m.reattachHeadless(ctx, a)
+		m.logger.Info("agent.reattach", "id", a.ID, "pid", a.PID, "task", a.TaskID, "events", len(a.Output()))
+		go m.reattachHeadless(ctx, a, startOffset, r.ProcStartedAt)
 		m.emit(events.AgentState(a.ID), a)
 		out = append(out, a)
 	}
 	return out
 }
 
-// reattachHeadless tails a reattached subprocess's log file until the
-// process exits (or the app shuts down), then finalizes the agent through
-// the same completion path as a freshly run one.
-func (m *Manager) reattachHeadless(ctx context.Context, a *Agent) {
-	procDone := make(chan struct{})
-	go watchPID(ctx, a.GetPID(), procDone)
+// finalizeIfCompleted recovers a run whose process is gone but whose log
+// shows a terminal result: it rebuilds a transient agent, rehydrates its
+// buffer, and drives the normal completion callback so the workflow
+// advances. A process gone without a terminal result is a genuine crash
+// and is left for restart-stale / resume to handle.
+func (m *Manager) finalizeIfCompleted(r Record) {
+	if r.LogPath == "" || r.Mode != "headless" {
+		return
+	}
+	a := agentFromRecord(r)
+	rehydrateFromLog(a, r.LogPath)
+	if !a.hasTerminalResult() {
+		return
+	}
+	a.SetState(StateStopped)
+	m.logger.Info("agent.reattach.recovered-complete", "id", a.ID, "task", a.TaskID)
+	m.recordCompletion(a, true)
+	if m.onComplete != nil {
+		m.onComplete(a)
+	}
+}
 
-	exited := m.tailHeadlessFile(ctx, a, a.GetLogPath(), false, procDone)
+// reattachHeadless tails a reattached subprocess's log file from
+// startOffset until the process exits (or the app shuts down), then
+// finalizes the agent through the same completion path as a freshly run
+// one.
+func (m *Manager) reattachHeadless(ctx context.Context, a *Agent, startOffset int64, procStart string) {
+	procDone := make(chan struct{})
+	go watchPID(ctx, a.GetPID(), procStart, procDone)
+
+	exited, _ := m.tailHeadlessFile(ctx, a, a.GetLogPath(), startOffset, procDone)
 	if !exited {
 		// App shutting down while the child is still alive: keep it running
 		// and let the registry drive the next reattach.
@@ -114,10 +145,11 @@ func (m *Manager) reattachHeadless(ctx context.Context, a *Agent) {
 	m.markAgentDone(a)
 }
 
-// watchPID closes done when the process exits. On context cancel (app
-// shutdown) it returns WITHOUT closing done, so the tailer takes its own
-// ctx.Done path and leaves the agent running for the next reattach.
-func watchPID(ctx context.Context, pid int, done chan struct{}) {
+// watchPID closes done when the process exits or is replaced by a PID-reuse
+// (start time no longer matches). On context cancel (app shutdown) it
+// returns WITHOUT closing done, so the tailer takes its own ctx.Done path
+// and leaves the agent running for the next reattach.
+func watchPID(ctx context.Context, pid int, procStart string, done chan struct{}) {
 	if pid <= 0 {
 		close(done)
 		return
@@ -133,8 +165,52 @@ func watchPID(ctx context.Context, pid int, done chan struct{}) {
 				close(done)
 				return
 			}
+			if procStart != "" && processStartString(pid) != procStart {
+				// PID reused by an unrelated process — our agent is gone.
+				close(done)
+				return
+			}
 		}
 	}
+}
+
+// rehydrateFromLog replays an agent's NDJSON log into its output buffer
+// (and cost/session stats) WITHOUT emitting events or running guardrails,
+// and returns the byte offset just past the last complete line — the point
+// from which live tailing should resume.
+func rehydrateFromLog(a *Agent, path string) int64 {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer func() { _ = f.Close() }()
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return 0
+	}
+
+	isCodex := normalizeProvider(a.Provider) == "codex"
+	var offset int64
+	start := 0
+	for i := range data {
+		if data[i] != '\n' {
+			continue
+		}
+		line := data[start:i]
+		start = i + 1
+		offset = int64(start)
+		ev, perr := parseHeadlessEvent(line, isCodex)
+		if perr != nil || ev.Type == "" {
+			continue
+		}
+		ev.Timestamp = time.Now().UTC()
+		a.AppendOutput(ev)
+		if ev.Type == "result" {
+			a.AddResultStats(ev.SessionID, ev.CostUSD, ev.InputTokens, ev.OutputTokens, ev.ReasoningTokens)
+			a.AddCacheStats(ev.CacheCreationInputTokens, ev.CacheReadInputTokens)
+		}
+	}
+	return offset
 }
 
 // reattachAlive reports whether the recorded process is still the agent we

--- a/internal/agent/registry.go
+++ b/internal/agent/registry.go
@@ -1,0 +1,94 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Automaat/sybra/internal/fsutil"
+	"gopkg.in/yaml.v3"
+)
+
+// Record is the on-disk snapshot of a live agent, written so the next app
+// instance can rediscover and reattach to a subprocess that survived a
+// restart. One YAML file per agent under the registry dir
+// (~/.sybra/agents/<id>.yaml). Written when the PID is known and whenever
+// the session ID is first captured; deleted when the agent terminates.
+type Record struct {
+	ID            string    `yaml:"id"`
+	TaskID        string    `yaml:"task_id,omitempty"`
+	Name          string    `yaml:"name,omitempty"`
+	Mode          string    `yaml:"mode"`
+	Provider      string    `yaml:"provider"`
+	Model         string    `yaml:"model,omitempty"`
+	PID           int       `yaml:"pid"`
+	SessionID     string    `yaml:"session_id,omitempty"`
+	LogPath       string    `yaml:"log_path,omitempty"`
+	CWD           string    `yaml:"cwd,omitempty"`
+	StartedAt     time.Time `yaml:"started_at"`
+	ProcStartedAt string    `yaml:"proc_started_at,omitempty"` // ps lstart, guards PID reuse
+	StdinPath     string    `yaml:"stdin_path,omitempty"`      // FIFO for interactive survival
+	MaxTurns      int       `yaml:"max_turns,omitempty"`
+}
+
+// registryStore persists Records as one YAML file per agent under dir.
+// Mirrors internal/loopagent.Store.
+type registryStore struct {
+	dir string
+}
+
+func newRegistryStore(dir string) (*registryStore, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("create agents dir %s: %w", dir, err)
+	}
+	return &registryStore{dir: dir}, nil
+}
+
+// Save atomically writes the record. A blank ID is rejected so a malformed
+// record can never overwrite the directory listing logic.
+func (s *registryStore) Save(r Record) error {
+	if r.ID == "" {
+		return fmt.Errorf("registry: empty agent id")
+	}
+	data, err := yaml.Marshal(r)
+	if err != nil {
+		return fmt.Errorf("marshal record: %w", err)
+	}
+	return fsutil.AtomicWrite(s.path(r.ID), data)
+}
+
+// List returns every persisted record. Unreadable or malformed files are
+// skipped rather than failing the whole sweep — a corrupt record must not
+// block reattachment of healthy ones.
+func (s *registryStore) List() ([]Record, error) {
+	paths, err := fsutil.ListFiles(s.dir, ".yaml")
+	if err != nil {
+		return nil, fmt.Errorf("read agents dir: %w", err)
+	}
+	out := make([]Record, 0, len(paths))
+	for _, p := range paths {
+		data, readErr := os.ReadFile(p)
+		if readErr != nil {
+			continue
+		}
+		var r Record
+		if yaml.Unmarshal(data, &r) != nil || r.ID == "" {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+// Delete removes the record file. A missing file is not an error.
+func (s *registryStore) Delete(id string) error {
+	if err := os.Remove(s.path(id)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("delete record: %w", err)
+	}
+	return nil
+}
+
+func (s *registryStore) path(id string) string {
+	return filepath.Join(s.dir, id+".yaml")
+}

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,6 +15,16 @@ import (
 	"github.com/Automaat/sybra/internal/events"
 	"github.com/Automaat/sybra/internal/logging"
 )
+
+// errSurviveShutdown is returned by a detached headless attempt when the
+// app's context is cancelled (shutdown) while the subprocess is still
+// alive. The runner returns without finalizing so the agent is left
+// running for the next instance to reattach.
+var errSurviveShutdown = errors.New("agent: detached, leaving process running for reattach")
+
+// headlessTailPoll is how often the detached/reattached tailer polls the
+// log file for new NDJSON lines.
+const headlessTailPoll = 100 * time.Millisecond
 
 // headlessEmitInterval caps per-agent stream event emission rate.
 // Result events always emit immediately (terminal signal). Frontend
@@ -52,6 +63,11 @@ func (m *Manager) runHeadless(ctx context.Context, a *Agent, cfg RunConfig) {
 		}
 
 		retry, fatalErr := m.runHeadlessAttempt(ctx, a, cfg, &outFile)
+		if errors.Is(fatalErr, errSurviveShutdown) {
+			// Detached subprocess left running across shutdown — do not
+			// finalize; the next app instance reattaches via the registry.
+			return
+		}
 		if fatalErr != nil {
 			m.handleError(a, fatalErr)
 			return
@@ -90,6 +106,10 @@ func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfi
 	name, args, invokeEnv, command, err := buildHeadlessInvocation(a, cfg)
 	if err != nil {
 		return false, err
+	}
+
+	if m.survives() && a.Mode == "headless" {
+		return m.runHeadlessAttemptSurvive(ctx, a, cfg, outFile, name, args, invokeEnv, command)
 	}
 
 	cmd := exec.CommandContext(ctx, name, args...)
@@ -164,6 +184,164 @@ func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfi
 	return false, nil
 }
 
+// runHeadlessAttemptSurvive spawns a detached headless subprocess whose
+// stdout is the NDJSON log file (not a pipe), so it survives the parent's
+// exit and a terminal Ctrl-C. The manager reads output by tailing that
+// file. Returns errSurviveShutdown if the app shuts down while the child
+// is still alive — the caller then leaves it running for reattach.
+func (m *Manager) runHeadlessAttemptSurvive(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File, name string, args, invokeEnv []string, command string) (retry bool, err error) {
+	// The log file is the child's stdout, so it must exist before Start.
+	// Opened once and reused across retries (append mode).
+	if *outFile == nil {
+		f, fileErr := logging.NewAgentOutputFile(m.logDir, a.ID)
+		if fileErr != nil {
+			return false, fmt.Errorf("open agent log: %w", fileErr)
+		}
+		a.SetLogPath(f.Name())
+		*outFile = f
+	}
+	logPath := (*outFile).Name()
+
+	cmd := exec.Command(name, args...) // no Context: a cancelled ctx must not kill a detached child
+	configureDetached(cmd)
+	if a.sessionCWD != "" {
+		cmd.Dir = a.sessionCWD
+	}
+	if len(cfg.ExtraEnv) > 0 || len(invokeEnv) > 0 {
+		cmd.Env = append(os.Environ(), invokeEnv...)
+		cmd.Env = append(cmd.Env, cfg.ExtraEnv...)
+	}
+	a.Command = command
+	cmd.Stdout = *outFile
+
+	stderrPath := logPath + ".stderr"
+	if stderrF, ferr := os.OpenFile(stderrPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644); ferr == nil {
+		cmd.Stderr = stderrF
+		defer func() { _ = stderrF.Close() }()
+	}
+
+	if startErr := cmd.Start(); startErr != nil {
+		return false, fmt.Errorf("start %s: %w", name, startErr)
+	}
+	a.SetCmd(cmd)
+	a.setDetached(true)
+	m.saveRegistry(a)
+	m.logger.Info("agent.headless.start", "id", a.ID, "pid", cmd.Process.Pid, "dir", cmd.Dir, "detached", true)
+
+	procDone := make(chan struct{})
+	var waitErr error
+	go func() {
+		waitErr = cmd.Wait()
+		close(procDone)
+	}()
+
+	exited := m.tailHeadlessFile(ctx, a, logPath, true, procDone)
+	if !exited {
+		m.logger.Info("agent.headless.detach", "id", a.ID, "pid", a.GetPID(), "reason", "shutdown")
+		return false, errSurviveShutdown
+	}
+
+	var stderrOut string
+	if b, readErr := os.ReadFile(stderrPath); readErr == nil {
+		stderrOut = string(b)
+	}
+	if stderrOut != "" {
+		m.logger.Error("agent.headless.stderr", "id", a.ID, "stderr", stderrOut)
+	}
+	if waitErr != nil {
+		m.logger.Error("agent.headless.exit", "id", a.ID, "err", waitErr)
+		a.SetExitErr(waitErr)
+		attemptEvents := a.Output()
+		if shouldRetry(stderrOut, attemptEvents, m.logger) {
+			return true, nil
+		}
+		m.reportProviderHealthSignal(a, stderrOut, attemptEvents)
+	}
+	return false, nil
+}
+
+// tailHeadlessFile follows an NDJSON log file written by a detached or
+// reattached subprocess, feeding each complete line through
+// processHeadlessLine. It returns true when the process exited (procDone
+// closed), false when the context was cancelled (app shutdown) while the
+// process was still running — the latter signals the caller to leave the
+// agent running for reattach. When fromStart is false the tailer seeks to
+// the current end of file (reattach: history is rehydrated separately).
+func (m *Manager) tailHeadlessFile(ctx context.Context, a *Agent, path string, fromStart bool, procDone <-chan struct{}) (exited bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		m.logger.Warn("agent.headless.tail.open", "id", a.ID, "path", path, "err", err)
+		select {
+		case <-procDone:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
+	defer func() { _ = f.Close() }()
+
+	var offset int64
+	if !fromStart {
+		if fi, statErr := f.Stat(); statErr == nil {
+			offset = fi.Size()
+		}
+	}
+
+	var buf []byte
+	var lastEmit time.Time
+	isCodex := normalizeProvider(a.Provider) == "codex"
+
+	// drain reads all bytes appended since offset, splits complete lines,
+	// and processes them. Returns true if a guardrail asked to stop.
+	drain := func() (stop bool) {
+		if _, seekErr := f.Seek(offset, io.SeekStart); seekErr != nil {
+			return false
+		}
+		chunk, readErr := io.ReadAll(f)
+		if readErr != nil || len(chunk) == 0 {
+			return false
+		}
+		offset += int64(len(chunk))
+		a.TouchLastEvent()
+		buf = append(buf, chunk...)
+		for {
+			i := bytes.IndexByte(buf, '\n')
+			if i < 0 {
+				break
+			}
+			line := buf[:i]
+			buf = buf[i+1:]
+			if m.processHeadlessLine(ctx, a, line, &lastEmit, isCodex) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for {
+		if drain() {
+			// Guardrail kill: force the detached child to stop, then wait
+			// for it to actually exit before finalizing.
+			m.signalKill(a)
+			select {
+			case <-procDone:
+				drain()
+				return true
+			case <-ctx.Done():
+				return false
+			}
+		}
+		select {
+		case <-procDone:
+			drain()
+			return true
+		case <-ctx.Done():
+			return false
+		case <-time.After(headlessTailPoll):
+		}
+	}
+}
+
 // trackingReader wraps an io.Reader and calls touch on every Read, keeping
 // LastEventAt alive during extended thinking where no complete NDJSON lines
 // are emitted for several minutes.
@@ -194,77 +372,100 @@ func (m *Manager) streamHeadlessOutput(ctx context.Context, a *Agent, stdout io.
 			_, _ = outFile.Write([]byte("\n"))
 		}
 
-		var event StreamEvent
-		var parseErr error
-		if isCodex {
-			var ce CodexEvent
-			ce, parseErr = ParseCodexLine(line)
-			if parseErr == nil {
-				event = codexEventToStreamEvent(ce)
+		if m.processHeadlessLine(ctx, a, line, &lastEmit, isCodex) {
+			// Guardrail asked to stop: cancel the context so the pipe-backed
+			// subprocess is terminated, then unwind. cancel may be nil in
+			// unit tests that drive the streamer directly.
+			if a.cancel != nil {
+				a.cancel()
 			}
-		} else {
-			var ce ClaudeEvent
-			ce, parseErr = ParseClaudeLine(line)
-			if parseErr == nil {
-				event = claudeEventToStreamEvent(ce)
-			}
-		}
-		if parseErr != nil {
-			m.logger.Warn("agent.headless.parse", "id", a.ID, "err", parseErr, "line", string(line))
-			continue
-		}
-		if event.Type == "" {
-			continue
-		}
-
-		event.Timestamp = time.Now().UTC()
-		a.AppendOutput(event)
-		if event.Type == "result" || time.Since(lastEmit) >= headlessEmitInterval {
-			m.emit(events.AgentOutput(a.ID), event)
-			lastEmit = time.Now()
-		}
-
-		if event.Type == "init" && event.SessionID != "" && a.Provider == "codex" {
-			if p := resolveCodexSessionFile(event.SessionID); p != "" {
-				a.SetSessionFilePath(p)
-			}
-		}
-
-		if (event.Type == "system" || event.Type == "init") && len(event.PluginErrors) > 0 {
-			for _, e := range event.PluginErrors {
-				m.logger.Warn("agent.plugin_error", "id", a.ID, "error", e)
-			}
-			a.SetPluginErrors(event.PluginErrors)
-			m.emit(events.AgentPluginErrors(a.ID), PluginErrorsEvent{Errors: event.PluginErrors})
-			m.emit(events.AgentState(a.ID), a)
-		}
-
-		if event.Type == "assistant" {
-			if keepGoing := m.checkTurnsGuardrail(ctx, a); !keepGoing {
-				return
-			}
-		}
-
-		if event.Type == "result" {
-			costNow := a.AddResultStats(event.SessionID, event.CostUSD, event.InputTokens, event.OutputTokens, event.ReasoningTokens)
-			a.AddCacheStats(event.CacheCreationInputTokens, event.CacheReadInputTokens)
-			m.logger.Info("agent.headless.result", "id", a.ID, "session_id", event.SessionID, "cost", costNow)
-			m.mu.RLock()
-			maxCost := m.guardrails.MaxCostUSD
-			m.mu.RUnlock()
-			if maxCost > 0 && costNow > maxCost {
-				m.logger.Warn("agent.guardrail.cost", "id", a.ID, "cost", costNow, "limit", maxCost)
-				a.SetEscalationReason("cost")
-				m.emit(events.AgentEscalation(a.ID), EscalationEvent{
-					Reason:  "cost",
-					CostUSD: costNow,
-					Limit:   maxCost,
-				})
-				m.emit(events.AgentState(a.ID), a)
-			}
+			return
 		}
 	}
 	m.reportScannerError(a, scanner.Err())
+}
+
+// processHeadlessLine parses one NDJSON line, appends and emits the event,
+// captures session/plugin metadata, and applies the turn and cost
+// guardrails. Returns true when a guardrail decision says to stop the
+// stream. Shared by the pipe-backed streamer and the file tailer; it never
+// writes the log file (the caller or the child process owns that).
+func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte, lastEmit *time.Time, isCodex bool) (stop bool) {
+	var event StreamEvent
+	var parseErr error
+	if isCodex {
+		var ce CodexEvent
+		ce, parseErr = ParseCodexLine(line)
+		if parseErr == nil {
+			event = codexEventToStreamEvent(ce)
+		}
+	} else {
+		var ce ClaudeEvent
+		ce, parseErr = ParseClaudeLine(line)
+		if parseErr == nil {
+			event = claudeEventToStreamEvent(ce)
+		}
+	}
+	if parseErr != nil {
+		m.logger.Warn("agent.headless.parse", "id", a.ID, "err", parseErr, "line", string(line))
+		return false
+	}
+	if event.Type == "" {
+		return false
+	}
+
+	event.Timestamp = time.Now().UTC()
+	a.AppendOutput(event)
+	if event.Type == "result" || time.Since(*lastEmit) >= headlessEmitInterval {
+		m.emit(events.AgentOutput(a.ID), event)
+		*lastEmit = time.Now()
+	}
+
+	if event.Type == "init" && event.SessionID != "" && a.Provider == "codex" {
+		if p := resolveCodexSessionFile(event.SessionID); p != "" {
+			a.SetSessionFilePath(p)
+		}
+	}
+
+	if (event.Type == "system" || event.Type == "init") && len(event.PluginErrors) > 0 {
+		for _, e := range event.PluginErrors {
+			m.logger.Warn("agent.plugin_error", "id", a.ID, "error", e)
+		}
+		a.SetPluginErrors(event.PluginErrors)
+		m.emit(events.AgentPluginErrors(a.ID), PluginErrorsEvent{Errors: event.PluginErrors})
+		m.emit(events.AgentState(a.ID), a)
+	}
+
+	if event.Type == "assistant" {
+		if keepGoing := m.checkTurnsGuardrail(ctx, a); !keepGoing {
+			return true
+		}
+	}
+
+	if event.Type == "result" {
+		costNow := a.AddResultStats(event.SessionID, event.CostUSD, event.InputTokens, event.OutputTokens, event.ReasoningTokens)
+		a.AddCacheStats(event.CacheCreationInputTokens, event.CacheReadInputTokens)
+		m.logger.Info("agent.headless.result", "id", a.ID, "session_id", event.SessionID, "cost", costNow)
+		// Persist the captured session ID so a reattach or restart-stale
+		// recovery can pass --resume. No-op when survival is disabled.
+		if event.SessionID != "" {
+			m.saveRegistry(a)
+		}
+		m.mu.RLock()
+		maxCost := m.guardrails.MaxCostUSD
+		m.mu.RUnlock()
+		if maxCost > 0 && costNow > maxCost {
+			m.logger.Warn("agent.guardrail.cost", "id", a.ID, "cost", costNow, "limit", maxCost)
+			a.SetEscalationReason("cost")
+			m.emit(events.AgentEscalation(a.ID), EscalationEvent{
+				Reason:  "cost",
+				CostUSD: costNow,
+				Limit:   maxCost,
+			})
+			m.emit(events.AgentState(a.ID), a)
+		}
+	}
+	return false
 }
 
 // reportScannerError surfaces bufio.Scanner errors at the end of the NDJSON
@@ -307,7 +508,9 @@ func (m *Manager) checkTurnsGuardrail(ctx context.Context, a *Agent) bool {
 	select {
 	case continueRun := <-a.escalationCh:
 		if !continueRun {
-			a.cancel()
+			// Caller terminates the subprocess: streamHeadlessOutput cancels
+			// the context (pipe-backed); tailHeadlessFile signal-kills the
+			// detached child by PID.
 			return false
 		}
 		a.SetEscalationReason("")

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -51,18 +51,29 @@ func (m *Manager) runHeadless(ctx context.Context, a *Agent, cfg RunConfig) {
 		}
 	}()
 
+	// tailOffset tracks how far the detached tailer has consumed the shared
+	// log file, so a retry resumes after the prior attempt's lines instead
+	// of reprocessing them. Unused by the legacy pipe path.
+	var tailOffset int64
+
 	for attempt := range len(headlessRetryBackoffs) + 1 {
 		if attempt > 0 {
 			wait := headlessRetryBackoffs[attempt-1]
 			m.logger.Info("agent.headless.retry", "id", a.ID, "attempt", attempt, "backoff", wait)
 			select {
 			case <-ctx.Done():
+				// App shutdown between retries on a detached agent: the prior
+				// process is already gone, so leave finalize to the next
+				// reattach rather than advancing a workflow mid-shutdown.
+				if a.isDetached() && !a.WasStopped() {
+					return
+				}
 				goto done
 			case <-time.After(wait):
 			}
 		}
 
-		retry, fatalErr := m.runHeadlessAttempt(ctx, a, cfg, &outFile)
+		retry, fatalErr := m.runHeadlessAttempt(ctx, a, cfg, &outFile, &tailOffset)
 		if errors.Is(fatalErr, errSurviveShutdown) {
 			// Detached subprocess left running across shutdown — do not
 			// finalize; the next app instance reattaches via the registry.
@@ -99,7 +110,7 @@ done:
 	m.markAgentDone(a)
 }
 
-func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File) (retry bool, err error) {
+func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File, tailOffset *int64) (retry bool, err error) {
 	if outFile == nil {
 		return false, nil
 	}
@@ -109,7 +120,7 @@ func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfi
 	}
 
 	if m.survives() && a.Mode == "headless" {
-		return m.runHeadlessAttemptSurvive(ctx, a, cfg, outFile, name, args, invokeEnv, command)
+		return m.runHeadlessAttemptSurvive(ctx, a, cfg, outFile, tailOffset, name, args, invokeEnv, command)
 	}
 
 	cmd := exec.CommandContext(ctx, name, args...)
@@ -189,7 +200,7 @@ func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfi
 // exit and a terminal Ctrl-C. The manager reads output by tailing that
 // file. Returns errSurviveShutdown if the app shuts down while the child
 // is still alive — the caller then leaves it running for reattach.
-func (m *Manager) runHeadlessAttemptSurvive(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File, name string, args, invokeEnv []string, command string) (retry bool, err error) {
+func (m *Manager) runHeadlessAttemptSurvive(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File, tailOffset *int64, name string, args, invokeEnv []string, command string) (retry bool, err error) {
 	// The log file is the child's stdout, so it must exist before Start.
 	// Opened once and reused across retries (append mode).
 	if *outFile == nil {
@@ -235,7 +246,15 @@ func (m *Manager) runHeadlessAttemptSurvive(ctx context.Context, a *Agent, cfg R
 		close(procDone)
 	}()
 
-	exited := m.tailHeadlessFile(ctx, a, logPath, true, procDone)
+	prevLen := len(a.Output())
+	startOffset := int64(0)
+	if tailOffset != nil {
+		startOffset = *tailOffset
+	}
+	exited, endOffset := m.tailHeadlessFile(ctx, a, logPath, startOffset, procDone)
+	if tailOffset != nil {
+		*tailOffset = endOffset
+	}
 	if !exited {
 		m.logger.Info("agent.headless.detach", "id", a.ID, "pid", a.GetPID(), "reason", "shutdown")
 		return false, errSurviveShutdown
@@ -251,7 +270,14 @@ func (m *Manager) runHeadlessAttemptSurvive(ctx context.Context, a *Agent, cfg R
 	if waitErr != nil {
 		m.logger.Error("agent.headless.exit", "id", a.ID, "err", waitErr)
 		a.SetExitErr(waitErr)
-		attemptEvents := a.Output()
+		// Only inspect events from this attempt, mirroring the legacy path —
+		// otherwise a transient 529 from an earlier attempt makes every later
+		// attempt retry regardless of its real failure.
+		all := a.Output()
+		if prevLen > len(all) {
+			prevLen = len(all)
+		}
+		attemptEvents := all[prevLen:]
 		if shouldRetry(stderrOut, attemptEvents, m.logger) {
 			return true, nil
 		}
@@ -260,32 +286,35 @@ func (m *Manager) runHeadlessAttemptSurvive(ctx context.Context, a *Agent, cfg R
 	return false, nil
 }
 
+// drainTimeout bounds how long the tailer waits for a process it just
+// asked to stop (guardrail kill or StopAgent) to actually exit before it
+// gives up and finalizes anyway.
+const drainTimeout = stopSIGINTGrace + 2*time.Second
+
 // tailHeadlessFile follows an NDJSON log file written by a detached or
 // reattached subprocess, feeding each complete line through
-// processHeadlessLine. It returns true when the process exited (procDone
-// closed), false when the context was cancelled (app shutdown) while the
-// process was still running — the latter signals the caller to leave the
-// agent running for reattach. When fromStart is false the tailer seeks to
-// the current end of file (reattach: history is rehydrated separately).
-func (m *Manager) tailHeadlessFile(ctx context.Context, a *Agent, path string, fromStart bool, procDone <-chan struct{}) (exited bool) {
+// processHeadlessLine starting at startOffset. It returns exited=true when
+// the run is over (process exited, or it was intentionally stopped) and
+// the agent should be finalized; exited=false only when the app is
+// shutting down while the process is still alive and was NOT intentionally
+// stopped — the caller then leaves it running for the next reattach. The
+// returned endOffset is the byte position after the last complete line
+// consumed, so a retry or reattach can resume without re-reading or
+// skipping lines.
+func (m *Manager) tailHeadlessFile(ctx context.Context, a *Agent, path string, startOffset int64, procDone <-chan struct{}) (exited bool, endOffset int64) {
+	offset := startOffset
+
 	f, err := os.Open(path)
 	if err != nil {
 		m.logger.Warn("agent.headless.tail.open", "id", a.ID, "path", path, "err", err)
 		select {
 		case <-procDone:
-			return true
+			return true, offset
 		case <-ctx.Done():
-			return false
+			return a.WasStopped(), offset
 		}
 	}
 	defer func() { _ = f.Close() }()
-
-	var offset int64
-	if !fromStart {
-		if fi, statErr := f.Stat(); statErr == nil {
-			offset = fi.Size()
-		}
-	}
 
 	var buf []byte
 	var lastEmit time.Time
@@ -318,25 +347,45 @@ func (m *Manager) tailHeadlessFile(ctx context.Context, a *Agent, path string, f
 		return false
 	}
 
-	for {
-		if drain() {
-			// Guardrail kill: force the detached child to stop, then wait
-			// for it to actually exit before finalizing.
-			m.signalKill(a)
-			select {
-			case <-procDone:
-				drain()
-				return true
-			case <-ctx.Done():
-				return false
-			}
+	// waitExit drains until the process exits or drainTimeout elapses, then
+	// returns. Used after we have asked the process to stop.
+	waitExit := func() {
+		select {
+		case <-procDone:
+		case <-time.After(drainTimeout):
 		}
+		drain()
+	}
+
+	for {
+		// On app shutdown, leave a detached-but-not-stopped agent running
+		// for the next reattach. An intentional StopAgent (WasStopped) does
+		// not survive — fall through and finalize. Checked before the select
+		// so a simultaneously-ready procDone never wins the shutdown race.
+		if ctx.Err() != nil && !a.WasStopped() {
+			return false, offset
+		}
+
+		if drain() {
+			// Guardrail kill: force the child to stop, wait for it, finalize.
+			m.signalKill(a)
+			waitExit()
+			return true, offset
+		}
+
 		select {
 		case <-procDone:
 			drain()
-			return true
+			return true, offset
 		case <-ctx.Done():
-			return false
+			if a.WasStopped() {
+				// Intentional stop: the child is being terminated; wait for
+				// it, then finalize.
+				waitExit()
+				return true, offset
+			}
+			// App shutdown: leave the detached child running for reattach.
+			return false, offset
 		case <-time.After(headlessTailPoll):
 		}
 	}
@@ -390,6 +439,24 @@ func (m *Manager) streamHeadlessOutput(ctx context.Context, a *Agent, stdout io.
 // guardrails. Returns true when a guardrail decision says to stop the
 // stream. Shared by the pipe-backed streamer and the file tailer; it never
 // writes the log file (the caller or the child process owns that).
+// parseHeadlessEvent parses one raw NDJSON line into a StreamEvent using
+// the provider-appropriate parser. Shared by the live line handler and the
+// reattach rehydrator.
+func parseHeadlessEvent(line []byte, isCodex bool) (StreamEvent, error) {
+	if isCodex {
+		ce, err := ParseCodexLine(line)
+		if err != nil {
+			return StreamEvent{}, err
+		}
+		return codexEventToStreamEvent(ce), nil
+	}
+	ce, err := ParseClaudeLine(line)
+	if err != nil {
+		return StreamEvent{}, err
+	}
+	return claudeEventToStreamEvent(ce), nil
+}
+
 func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte, lastEmit *time.Time, isCodex bool) (stop bool) {
 	var event StreamEvent
 	var parseErr error

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -320,6 +320,11 @@ func (m *Manager) tailHeadlessFile(ctx context.Context, a *Agent, path string, s
 	var lastEmit time.Time
 	isCodex := normalizeProvider(a.Provider) == "codex"
 
+	// end is the byte position after the last complete line consumed: total
+	// bytes read minus any trailing partial line still buffered. Resuming a
+	// retry or reattach from here never re-reads or skips a line.
+	end := func() int64 { return offset - int64(len(buf)) }
+
 	// drain reads all bytes appended since offset, splits complete lines,
 	// and processes them. Returns true if a guardrail asked to stop.
 	drain := func() (stop bool) {
@@ -363,29 +368,29 @@ func (m *Manager) tailHeadlessFile(ctx context.Context, a *Agent, path string, s
 		// not survive — fall through and finalize. Checked before the select
 		// so a simultaneously-ready procDone never wins the shutdown race.
 		if ctx.Err() != nil && !a.WasStopped() {
-			return false, offset
+			return false, end()
 		}
 
 		if drain() {
 			// Guardrail kill: force the child to stop, wait for it, finalize.
 			m.signalKill(a)
 			waitExit()
-			return true, offset
+			return true, end()
 		}
 
 		select {
 		case <-procDone:
 			drain()
-			return true, offset
+			return true, end()
 		case <-ctx.Done():
 			if a.WasStopped() {
 				// Intentional stop: the child is being terminated; wait for
 				// it, then finalize.
 				waitExit()
-				return true, offset
+				return true, end()
 			}
 			// App shutdown: leave the detached child running for reattach.
-			return false, offset
+			return false, end()
 		case <-time.After(headlessTailPoll):
 		}
 	}
@@ -434,11 +439,6 @@ func (m *Manager) streamHeadlessOutput(ctx context.Context, a *Agent, stdout io.
 	m.reportScannerError(a, scanner.Err())
 }
 
-// processHeadlessLine parses one NDJSON line, appends and emits the event,
-// captures session/plugin metadata, and applies the turn and cost
-// guardrails. Returns true when a guardrail decision says to stop the
-// stream. Shared by the pipe-backed streamer and the file tailer; it never
-// writes the log file (the caller or the child process owns that).
 // parseHeadlessEvent parses one raw NDJSON line into a StreamEvent using
 // the provider-appropriate parser. Shared by the live line handler and the
 // reattach rehydrator.
@@ -457,6 +457,11 @@ func parseHeadlessEvent(line []byte, isCodex bool) (StreamEvent, error) {
 	return claudeEventToStreamEvent(ce), nil
 }
 
+// processHeadlessLine parses one NDJSON line, appends and emits the event,
+// captures session/plugin metadata, and applies the turn and cost
+// guardrails. Returns true when a guardrail decision says to stop the
+// stream. Shared by the pipe-backed streamer and the file tailer; it never
+// writes the log file (the caller or the child process owns that).
 func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte, lastEmit *time.Time, isCodex bool) (stop bool) {
 	var event StreamEvent
 	var parseErr error

--- a/internal/agent/shutdown.go
+++ b/internal/agent/shutdown.go
@@ -65,3 +65,42 @@ func configureGracefulShutdown(cmd *exec.Cmd) {
 	}
 	cmd.WaitDelay = shutdownWaitDelay
 }
+
+// configureDetached puts the subprocess in its own session (Setsid) so it
+// survives both the app's exit and a terminal SIGINT (Ctrl-C of `mise run
+// dev` sends the signal to the whole foreground process group; a new
+// session is immune). Detached agents are spawned with exec.Command (no
+// Context), so a cancelled context never reaches the child — the only
+// kill paths are an explicit StopAgent or signalKill. The output stream
+// is the child's log file (written directly), not a pipe that breaks when
+// the parent dies. Reattachment on the next startup tails that file.
+func configureDetached(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setsid = true
+}
+
+// signalPID sends SIGINT to a detached/reattached process by PID and
+// escalates to SIGKILL after the grace window. Used when there is no
+// *exec.Cmd handle (a reattached agent) or to force a detached child to
+// stop on a guardrail kill.
+func signalPID(pid int, grace time.Duration) {
+	if pid <= 0 {
+		return
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return
+	}
+	_ = p.Signal(os.Interrupt)
+	go func() {
+		time.Sleep(grace)
+		if processAlive(pid) {
+			_ = p.Signal(syscall.SIGKILL)
+		}
+	}()
+}

--- a/internal/agent/survive_restart_test.go
+++ b/internal/agent/survive_restart_test.go
@@ -1,0 +1,251 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRegistryStore_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s, err := newRegistryStore(dir)
+	if err != nil {
+		t.Fatalf("newRegistryStore: %v", err)
+	}
+
+	rec := Record{
+		ID:        "a1",
+		TaskID:    "t1",
+		Mode:      "headless",
+		Provider:  "claude",
+		PID:       4321,
+		SessionID: "sess-1",
+		LogPath:   "/tmp/a1.ndjson",
+		StartedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	if err := s.Save(rec); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	list, err := s.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(list))
+	}
+	got := list[0]
+	if got.ID != rec.ID || got.PID != rec.PID || got.SessionID != rec.SessionID || got.LogPath != rec.LogPath {
+		t.Fatalf("record round-trip mismatch: %+v", got)
+	}
+
+	if err := s.Delete("a1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	list, _ = s.List()
+	if len(list) != 0 {
+		t.Fatalf("expected 0 records after delete, got %d", len(list))
+	}
+	// Deleting a missing record is not an error.
+	if err := s.Delete("a1"); err != nil {
+		t.Fatalf("Delete missing: %v", err)
+	}
+}
+
+func TestRegistryStore_RejectsEmptyID(t *testing.T) {
+	s, err := newRegistryStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("newRegistryStore: %v", err)
+	}
+	if err := s.Save(Record{}); err == nil {
+		t.Fatal("expected error saving record with empty ID")
+	}
+}
+
+func TestConfigureDetached_SetsSid(t *testing.T) {
+	cmd := exec.Command("true")
+	configureDetached(cmd)
+	if cmd.SysProcAttr == nil || !cmd.SysProcAttr.Setsid {
+		t.Fatal("expected configureDetached to set Setsid")
+	}
+}
+
+func TestReattachAlive_PIDReuseGuard(t *testing.T) {
+	self := os.Getpid()
+	start := processStartString(self)
+	if start == "" {
+		t.Skip("processStartString unavailable on this platform")
+	}
+
+	if !reattachAlive(Record{PID: self, ProcStartedAt: start}) {
+		t.Fatal("expected own live process with matching start time to be alive")
+	}
+	if reattachAlive(Record{PID: self, ProcStartedAt: "Wed Jan  1 00:00:00 2020"}) {
+		t.Fatal("expected PID-reuse guard to reject mismatched start time")
+	}
+	// Missing start time disables the guard (best-effort).
+	if !reattachAlive(Record{PID: self}) {
+		t.Fatal("expected alive process with no recorded start time to pass")
+	}
+	if reattachAlive(Record{PID: 0}) {
+		t.Fatal("expected PID 0 to be dead")
+	}
+}
+
+// TestReattachAll_ReattachesLiveHeadlessAgent spawns a live process that
+// appends a terminal result to a pre-seeded log file, registers it, and
+// asserts ReattachAll rebuilds the agent, rehydrates its buffer, streams
+// the new result, and finalizes via onComplete when the process exits.
+func TestReattachAll_ReattachesLiveHeadlessAgent(t *testing.T) {
+	prev := reattachPIDPoll
+	reattachPIDPoll = 50 * time.Millisecond
+	t.Cleanup(func() { reattachPIDPoll = prev })
+
+	logDir := t.TempDir()
+	regDir := t.TempDir()
+	logPath := filepath.Join(logDir, "agents", "reat1.ndjson")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Pre-seed history so rehydration has something to load.
+	history := `{"type":"assistant","message":{"content":[{"type":"text","text":"working"}]}}` + "\n"
+	if err := os.WriteFile(logPath, []byte(history), 0o644); err != nil {
+		t.Fatalf("seed log: %v", err)
+	}
+
+	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir)
+	if err := m.EnableSurviveRestart(regDir); err != nil {
+		t.Fatalf("EnableSurviveRestart: %v", err)
+	}
+	var completed atomic.Bool
+	var completedID atomic.Value
+	m.SetOnComplete(func(ag *Agent) {
+		completedID.Store(ag.ID)
+		completed.Store(true)
+	})
+
+	// Live helper: after a short delay append a terminal result, then exit.
+	resultLine := `{"type":"result","result":"done","session_id":"sess-1","total_cost_usd":0.1}`
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("sleep 0.3; printf '%%s\\n' '%s' >> %q", resultLine, logPath))
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	// Reap on exit so processAlive flips to false (mirrors init reaping a
+	// reparented orphan in production).
+	go func() { _ = cmd.Wait() }()
+
+	rec := Record{
+		ID:            "reat1",
+		TaskID:        "task-1",
+		Mode:          "headless",
+		Provider:      "claude",
+		PID:           cmd.Process.Pid,
+		LogPath:       logPath,
+		StartedAt:     time.Now().UTC(),
+		ProcStartedAt: processStartString(cmd.Process.Pid),
+	}
+	if err := m.reg.Save(rec); err != nil {
+		t.Fatalf("save record: %v", err)
+	}
+
+	reattached := m.ReattachAll()
+	if len(reattached) != 1 {
+		t.Fatalf("expected 1 reattached agent, got %d", len(reattached))
+	}
+
+	a, err := m.GetAgent("reat1")
+	if err != nil {
+		t.Fatalf("GetAgent: %v", err)
+	}
+	if a.GetState() != StateRunning {
+		t.Fatalf("expected reattached agent running, got %s", a.GetState())
+	}
+	if got := a.Output(); len(got) == 0 {
+		t.Fatal("expected rehydrated output buffer, got empty")
+	}
+
+	// Wait for the helper to exit and completion to fire.
+	deadline := time.After(5 * time.Second)
+	for !completed.Load() {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for reattached agent to complete")
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+
+	if id, _ := completedID.Load().(string); id != "reat1" {
+		t.Fatalf("expected completion for reat1, got %q", id)
+	}
+	if a.GetState() != StateStopped {
+		t.Fatalf("expected stopped after completion, got %s", a.GetState())
+	}
+	if a.GetExitErr() != nil {
+		t.Fatalf("expected clean completion (terminal result seen), got err: %v", a.GetExitErr())
+	}
+	if !a.hasTerminalResult() {
+		t.Fatal("expected terminal result in buffer")
+	}
+	// Registry record is removed on completion.
+	if list, _ := m.reg.List(); len(list) != 0 {
+		t.Fatalf("expected registry empty after completion, got %d", len(list))
+	}
+}
+
+// TestReattachAll_DropsDeadRecords verifies a record whose process is gone
+// is deleted and not reattached.
+func TestReattachAll_DropsDeadRecords(t *testing.T) {
+	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
+	if err := m.EnableSurviveRestart(t.TempDir()); err != nil {
+		t.Fatalf("EnableSurviveRestart: %v", err)
+	}
+	// PID 0 is never alive.
+	if err := m.reg.Save(Record{ID: "dead1", Mode: "headless", Provider: "claude", PID: 0}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if got := m.ReattachAll(); len(got) != 0 {
+		t.Fatalf("expected no reattach for dead record, got %d", len(got))
+	}
+	if list, _ := m.reg.List(); len(list) != 0 {
+		t.Fatal("expected dead record to be deleted")
+	}
+}
+
+// TestShutdownWithGrace_LeavesDetachedAgents verifies a detached agent is
+// neither cancelled nor waited on, while a normal agent is cancelled.
+func TestShutdownWithGrace_LeavesDetachedAgents(t *testing.T) {
+	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
+
+	var normalCancelled atomic.Bool
+	normal := &Agent{ID: "n1", Mode: "headless", done: make(chan struct{}), cancel: func() { normalCancelled.Store(true) }}
+	// Normal agent's goroutine would close done on cancel; emulate it.
+	go func() {
+		for !normalCancelled.Load() {
+			time.Sleep(5 * time.Millisecond)
+		}
+		close(normal.done)
+	}()
+
+	var detachedCancelled atomic.Bool
+	detached := &Agent{ID: "d1", Mode: "headless", detached: true, done: make(chan struct{}), cancel: func() { detachedCancelled.Store(true) }}
+
+	m.mu.Lock()
+	m.agents["n1"] = normal
+	m.agents["d1"] = detached
+	m.mu.Unlock()
+
+	m.ShutdownWithGrace(2 * time.Second)
+
+	if !normalCancelled.Load() {
+		t.Fatal("expected normal agent to be cancelled")
+	}
+	if detachedCancelled.Load() {
+		t.Fatal("expected detached agent to be left running (not cancelled)")
+	}
+}

--- a/internal/agent/survive_restart_test.go
+++ b/internal/agent/survive_restart_test.go
@@ -259,6 +259,30 @@ func TestTailHeadlessFile_StopVsShutdown(t *testing.T) {
 	})
 }
 
+// TestTailHeadlessFile_EndOffsetExcludesPartialLine verifies the tailer
+// returns the byte offset after the last COMPLETE line, not raw bytes read
+// — so a resume never skips the start of a still-incomplete trailing line.
+func TestTailHeadlessFile_EndOffsetExcludesPartialLine(t *testing.T) {
+	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
+	logPath := filepath.Join(t.TempDir(), "tail.ndjson")
+	complete := `{"type":"assistant","message":{"content":[{"type":"text","text":"x"}]}}` + "\n"
+	partial := `{"type":"result","result":"in-flight` // no newline yet
+	if err := os.WriteFile(logPath, []byte(complete+partial), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	a := &Agent{ID: "o", Provider: "claude"}
+	procDone := make(chan struct{})
+	close(procDone) // process already exited
+
+	exited, end := m.tailHeadlessFile(context.Background(), a, logPath, 0, procDone)
+	if !exited {
+		t.Fatal("expected exited=true")
+	}
+	if end != int64(len(complete)) {
+		t.Fatalf("expected endOffset=%d (after complete line only), got %d", len(complete), end)
+	}
+}
+
 // TestReattachAll_RecoversCompletedDuringDowntime verifies a run that
 // finished while the app was down (process gone, log has a terminal result)
 // is finalized via onComplete instead of being dropped and re-run.

--- a/internal/agent/survive_restart_test.go
+++ b/internal/agent/survive_restart_test.go
@@ -217,6 +217,86 @@ func TestReattachAll_DropsDeadRecords(t *testing.T) {
 	}
 }
 
+// TestTailHeadlessFile_StopVsShutdown verifies the core of the blocking
+// review fix: a cancelled context finalizes (exited=true) when the agent
+// was intentionally stopped, but survives (exited=false) on a plain app
+// shutdown.
+func TestTailHeadlessFile_StopVsShutdown(t *testing.T) {
+	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
+	logPath := filepath.Join(t.TempDir(), "tail.ndjson")
+	if err := os.WriteFile(logPath, nil, 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Shutdown (not stopped): ctx cancelled, process still alive -> survive.
+	t.Run("shutdown survives", func(t *testing.T) {
+		a := &Agent{ID: "s", Provider: "claude"}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		procDone := make(chan struct{}) // never closed: process alive
+		exited, _ := m.tailHeadlessFile(ctx, a, logPath, 0, procDone)
+		if exited {
+			t.Fatal("expected survive (exited=false) on plain shutdown")
+		}
+	})
+
+	// Intentional stop: ctx cancelled, WasStopped -> finalize once the
+	// process exits.
+	t.Run("stop finalizes", func(t *testing.T) {
+		a := &Agent{ID: "s2", Provider: "claude"}
+		a.MarkStopped()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		procDone := make(chan struct{})
+		go func() {
+			time.Sleep(30 * time.Millisecond)
+			close(procDone) // process exits shortly after the stop signal
+		}()
+		exited, _ := m.tailHeadlessFile(ctx, a, logPath, 0, procDone)
+		if !exited {
+			t.Fatal("expected finalize (exited=true) on intentional stop")
+		}
+	})
+}
+
+// TestReattachAll_RecoversCompletedDuringDowntime verifies a run that
+// finished while the app was down (process gone, log has a terminal result)
+// is finalized via onComplete instead of being dropped and re-run.
+func TestReattachAll_RecoversCompletedDuringDowntime(t *testing.T) {
+	logDir := t.TempDir()
+	logPath := filepath.Join(logDir, "agents", "comp1.ndjson")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	content := `{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}` + "\n" +
+		`{"type":"result","result":"done","session_id":"sess-9","total_cost_usd":0.2}` + "\n"
+	if err := os.WriteFile(logPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir)
+	if err := m.EnableSurviveRestart(t.TempDir()); err != nil {
+		t.Fatalf("EnableSurviveRestart: %v", err)
+	}
+	var completedID atomic.Value
+	m.SetOnComplete(func(ag *Agent) { completedID.Store(ag.ID) })
+
+	// PID 0 -> process gone; log shows a terminal result.
+	if err := m.reg.Save(Record{ID: "comp1", TaskID: "t", Mode: "headless", Provider: "claude", PID: 0, LogPath: logPath}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	if got := m.ReattachAll(); len(got) != 0 {
+		t.Fatalf("expected dead record not reattached as live, got %d", len(got))
+	}
+	if id, _ := completedID.Load().(string); id != "comp1" {
+		t.Fatalf("expected onComplete for comp1 (recovered completion), got %q", id)
+	}
+	if list, _ := m.reg.List(); len(list) != 0 {
+		t.Fatal("expected record deleted after recovery")
+	}
+}
+
 // TestShutdownWithGrace_LeavesDetachedAgents verifies a detached agent is
 // neither cancelled nor waited on, while a normal agent is cancelled.
 func TestShutdownWithGrace_LeavesDetachedAgents(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,6 +85,12 @@ type AgentDefaults struct {
 	// files, regardless of age) are swept on app startup and daily
 	// thereafter. 0 falls back to DefaultLogRetentionDays (14).
 	LogRetentionDays int `yaml:"log_retention_days" json:"logRetentionDays"`
+	// SurviveRestart keeps agent subprocesses running across an app
+	// restart (detached, output streamed to their log files) and reattaches
+	// to them on the next startup. nil means not configured (defaults to
+	// true). Set false to revert to the legacy behaviour where agents are
+	// killed on shutdown and recovered via restart-stale.
+	SurviveRestart *bool `yaml:"survive_restart" json:"surviveRestart"`
 }
 
 // DefaultBashTimeoutSeconds is the per-bash-tool-call timeout used when
@@ -128,6 +134,16 @@ func (c *Config) DefaultLogRetentionDays() int {
 func (c *Config) DefaultRequirePermissions() bool {
 	if c != nil && c.Agent.RequirePermissions != nil {
 		return *c.Agent.RequirePermissions
+	}
+	return true
+}
+
+// SurviveRestartEnabled reports whether agent subprocesses should be
+// detached to survive an app restart and reattached on the next startup.
+// Defaults to true when unset.
+func (c *Config) SurviveRestartEnabled() bool {
+	if c != nil && c.Agent.SurviveRestart != nil {
+		return *c.Agent.SurviveRestart
 	}
 	return true
 }
@@ -642,6 +658,13 @@ func defaultLoopAgentsDir() string {
 
 func WorkflowsDir() string {
 	return filepath.Join(HomeDir(), "workflows")
+}
+
+// AgentsDir is the directory under ~/.sybra that holds the live-agent
+// registry (one YAML file per running agent) used to reattach to
+// subprocesses that survived an app restart.
+func AgentsDir() string {
+	return filepath.Join(HomeDir(), "agents")
 }
 
 func StatsFile() string {

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -54,6 +54,13 @@ type Recovery struct {
 // worktrees show up as orphans to the subsequent sweep; stale run state
 // next so restart-stale sees a clean slate.
 func (r *Recovery) RunStartupCleanup() {
+	// Reattach to surviving agent subprocesses FIRST so the sweeps below —
+	// which all key off HasRunningAgentForTask — see them as live and do
+	// not remove their worktrees, gc their chat tasks, mark their runs
+	// stale, or restart them.
+	if reattached := r.Agents.ReattachAll(); len(reattached) > 0 {
+		r.Logger.Info("recovery.reattach", "count", len(reattached))
+	}
 	r.Worktrees.RepairAll()
 	r.gcOrphanChats()
 	r.Worktrees.CleanupOrphaned()

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -338,6 +338,13 @@ func (a *App) initWorkflowEngine() {
 func (a *App) initAgentConfig() {
 	a.agents.SetMaxConcurrent(a.cfg.Agent.MaxConcurrent)
 	a.agents.SetBashTimeoutMs(a.cfg.BashTimeoutMs())
+	if a.cfg.SurviveRestartEnabled() {
+		if err := a.agents.EnableSurviveRestart(config.AgentsDir()); err != nil {
+			a.logger.Error("agent.survive-restart.init", "err", err)
+		} else {
+			a.logger.Info("agent.survive-restart.enabled", "dir", config.AgentsDir())
+		}
+	}
 	a.agents.SetGuardrails(agent.Guardrails{
 		MaxCostUSD:       a.cfg.Agent.MaxCostUSD,
 		MaxTurns:         a.cfg.Agent.MaxTurns,


### PR DESCRIPTION
## Motivation

Agents are in-memory only and their `claude -p` / `codex exec` subprocesses die with the app — killed by the terminal Ctrl-C of `mise run dev` (same process group), by `App.Shutdown` cancelling their context, or by the broken stdout pipe when the parent exits. This makes it impossible to iterate on the app while the agent swarm keeps working. Phase 1 of 3 (closes the headless case) makes headless agents genuinely survive an app restart and reattach with no interruption.

## Implementation information

Decouples "process writes output" from "manager reads output":

- **Detach** (`configureDetached`): headless subprocesses spawn with `exec.Command` (no Context) + `Setsid`, so a cancelled context never reaches the child and a terminal Ctrl-C to the foreground group is ignored. Stdout/stderr go straight to the NDJSON log file (no pipe to break).
- **Tail** (`tailHeadlessFile`): the manager reads output by following that log file from a tracked byte offset; per-line handling is shared with the pipe streamer via `processHeadlessLine`.
- **Registry** (`internal/agent/registry.go`): one YAML record per live agent under `~/.sybra/agents/` (PID, session id, log path, cwd, `ps lstart`), written when the PID is known / session id captured, deleted on completion.
- **Reattach** (`ReattachAll`, wired first in `recovery.RunStartupCleanup`): rebuilds agents whose process is still alive (PID + start-time reuse guard), rehydrates the output buffer from the log at the exact offset tailing resumes from, and finalizes via the normal completion path. A process gone with a terminal result is recovered as a completion (not re-run); gone without one is marked `errReattachedGone` so the workflow stalls instead of advancing on partial work.
- **Shutdown** leaves detached agents running; `StopAgent` still finalizes them (intentional stop is distinguished from app shutdown).
- Gated by `agent.survive_restart` config (default on); legacy pipe path is unchanged when disabled.

Reviewed pre-PR by an adversarial subagent; the blocking finding (StopAgent on a detached agent wedging the task) and three issues (completion-lost-during-downtime, rehydrate/tail TOCTOU, retry-window event leak) were fixed in the second commit.

Tests: registry round-trip, `configureDetached`, PID-reuse guard, end-to-end reattach of a live process, recover-completed-during-downtime, stop-vs-shutdown finalize semantics, shutdown leaves detached agents. `go test -race`, golangci-lint, and nilaway all clean.

## Supporting documentation

Part of the survive-restart series: this issue (Phase 1), Phase 2 (resume dead headless agents by session), Phase 3 (interactive agents).

Closes #956

> Changelog: feat(agent): survive restart for headless agents