### PR TITLE
feat(agent): resume crashed headless by session

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -46,6 +46,11 @@ type Manager struct {
 	// after an app restart. nil disables survival (legacy behaviour).
 	reg            *registryStore
 	surviveRestart bool
+
+	// sessionSink, when set, persists a crashed agent's captured session id
+	// to its task's AgentRun on dead-reattach, so restart-stale recovery can
+	// resume the conversation via --resume instead of cold-restarting.
+	sessionSink func(taskID, agentID, sessionID string)
 }
 
 func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir string) *Manager {
@@ -77,6 +82,21 @@ func (m *Manager) EnableSurviveRestart(dir string) error {
 	m.surviveRestart = true
 	m.mu.Unlock()
 	return nil
+}
+
+// SetSessionSink installs the callback used to persist a crashed agent's
+// session id into its task's AgentRun during dead-reattach. Set once at
+// startup before ReattachAll.
+func (m *Manager) SetSessionSink(fn func(taskID, agentID, sessionID string)) {
+	m.mu.Lock()
+	m.sessionSink = fn
+	m.mu.Unlock()
+}
+
+func (m *Manager) sessionSinkFn() func(taskID, agentID, sessionID string) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.sessionSink
 }
 
 // survives reports whether restart survival is active.

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -49,8 +49,10 @@ type Manager struct {
 
 	// sessionSink, when set, persists a crashed agent's captured session id
 	// to its task's AgentRun on dead-reattach, so restart-stale recovery can
-	// resume the conversation via --resume instead of cold-restarting.
-	sessionSink func(taskID, agentID, sessionID string)
+	// resume the conversation via --resume instead of cold-restarting. A
+	// non-nil error means persistence failed and the registry record should
+	// be retained for a later retry.
+	sessionSink func(taskID, agentID, sessionID string) error
 }
 
 func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir string) *Manager {
@@ -87,13 +89,13 @@ func (m *Manager) EnableSurviveRestart(dir string) error {
 // SetSessionSink installs the callback used to persist a crashed agent's
 // session id into its task's AgentRun during dead-reattach. Set once at
 // startup before ReattachAll.
-func (m *Manager) SetSessionSink(fn func(taskID, agentID, sessionID string)) {
+func (m *Manager) SetSessionSink(fn func(taskID, agentID, sessionID string) error) {
 	m.mu.Lock()
 	m.sessionSink = fn
 	m.mu.Unlock()
 }
 
-func (m *Manager) sessionSinkFn() func(taskID, agentID, sessionID string) {
+func (m *Manager) sessionSinkFn() func(taskID, agentID, sessionID string) error {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.sessionSink

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -56,7 +56,11 @@ func (m *Manager) ReattachAll() []*Agent {
 		if !reattachAlive(r) {
 			// Process gone. If it finished its work before vanishing,
 			// finalize so the workflow advances instead of re-running it.
-			m.finalizeIfCompleted(r)
+			// Otherwise (a genuine crash), bridge its captured session id to
+			// the task so restart-stale recovery resumes instead of redoing.
+			if !m.finalizeIfCompleted(r) {
+				m.persistDeadSession(r)
+			}
 			_ = reg.Delete(r.ID)
 			m.logger.Info("agent.reattach.dead", "id", r.ID, "pid", r.PID, "task", r.TaskID)
 			continue
@@ -97,16 +101,17 @@ func (m *Manager) ReattachAll() []*Agent {
 // finalizeIfCompleted recovers a run whose process is gone but whose log
 // shows a terminal result: it rebuilds a transient agent, rehydrates its
 // buffer, and drives the normal completion callback so the workflow
-// advances. A process gone without a terminal result is a genuine crash
-// and is left for restart-stale / resume to handle.
-func (m *Manager) finalizeIfCompleted(r Record) {
+// advances. Returns true if it finalized. A process gone without a terminal
+// result is a genuine crash and is left for restart-stale / resume to
+// handle (see persistDeadSession).
+func (m *Manager) finalizeIfCompleted(r Record) bool {
 	if r.LogPath == "" || r.Mode != "headless" {
-		return
+		return false
 	}
 	a := agentFromRecord(r)
 	rehydrateFromLog(a, r.LogPath)
 	if !a.hasTerminalResult() {
-		return
+		return false
 	}
 	a.SetState(StateStopped)
 	m.logger.Info("agent.reattach.recovered-complete", "id", a.ID, "task", a.TaskID)
@@ -114,6 +119,23 @@ func (m *Manager) finalizeIfCompleted(r Record) {
 	if m.onComplete != nil {
 		m.onComplete(a)
 	}
+	return true
+}
+
+// persistDeadSession bridges a crashed headless agent's captured session id
+// from the registry into its task's AgentRun, so restart-stale recovery
+// resumes the conversation via --resume instead of cold-restarting and
+// redoing work. The session id otherwise lives only in the registry record
+// (the completion callback that normally writes it to the AgentRun never
+// ran on a hard crash) and would be lost when the record is deleted. No-op
+// without a sink, a captured session id, or a task.
+func (m *Manager) persistDeadSession(r Record) {
+	sink := m.sessionSinkFn()
+	if sink == nil || r.SessionID == "" || r.TaskID == "" {
+		return
+	}
+	m.logger.Info("agent.reattach.resume-session", "id", r.ID, "task", r.TaskID, "session", r.SessionID)
+	sink(r.TaskID, r.ID, r.SessionID)
 }
 
 // reattachHeadless tails a reattached subprocess's log file from

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -58,11 +58,14 @@ func (m *Manager) ReattachAll() []*Agent {
 			// finalize so the workflow advances instead of re-running it.
 			// Otherwise (a genuine crash), bridge its captured session id to
 			// the task so restart-stale recovery resumes instead of redoing.
-			if !m.finalizeIfCompleted(r) {
-				m.persistDeadSession(r)
+			// Retain the record (skip delete) when the bridge fails so a later
+			// startup retries it rather than losing the session permanently.
+			if m.finalizeIfCompleted(r) || m.persistDeadSession(r) {
+				_ = reg.Delete(r.ID)
+				m.logger.Info("agent.reattach.dead", "id", r.ID, "pid", r.PID, "task", r.TaskID)
+			} else {
+				m.logger.Warn("agent.reattach.bridge-retry", "id", r.ID, "task", r.TaskID)
 			}
-			_ = reg.Delete(r.ID)
-			m.logger.Info("agent.reattach.dead", "id", r.ID, "pid", r.PID, "task", r.TaskID)
 			continue
 		}
 
@@ -127,15 +130,24 @@ func (m *Manager) finalizeIfCompleted(r Record) bool {
 // resumes the conversation via --resume instead of cold-restarting and
 // redoing work. The session id otherwise lives only in the registry record
 // (the completion callback that normally writes it to the AgentRun never
-// ran on a hard crash) and would be lost when the record is deleted. No-op
-// without a sink, a captured session id, or a task.
-func (m *Manager) persistDeadSession(r Record) {
+// ran on a hard crash) and would be lost when the record is deleted.
+//
+// Returns true when the record is safe to delete: nothing to bridge (no
+// sink, session id, or task) or the bridge succeeded. Returns false only
+// when the bridge was attempted and the sink failed, so the caller retains
+// the record for a later retry rather than losing the session.
+func (m *Manager) persistDeadSession(r Record) (done bool) {
 	sink := m.sessionSinkFn()
 	if sink == nil || r.SessionID == "" || r.TaskID == "" {
-		return
+		return true
 	}
-	m.logger.Info("agent.reattach.resume-session", "id", r.ID, "task", r.TaskID, "session", r.SessionID)
-	sink(r.TaskID, r.ID, r.SessionID)
+	if err := sink(r.TaskID, r.ID, r.SessionID); err != nil {
+		m.logger.Warn("agent.reattach.resume-session.failed",
+			"id", r.ID, "task", r.TaskID, "session_id", r.SessionID, "err", err)
+		return false
+	}
+	m.logger.Info("agent.reattach.resume-session", "id", r.ID, "task", r.TaskID, "session_id", r.SessionID)
+	return true
 }
 
 // reattachHeadless tails a reattached subprocess's log file from

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -493,9 +493,20 @@ func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte
 		*lastEmit = time.Now()
 	}
 
-	if event.Type == "init" && event.SessionID != "" && a.Provider == "codex" {
-		if p := resolveCodexSessionFile(event.SessionID); p != "" {
-			a.SetSessionFilePath(p)
+	// Capture the session id as soon as it appears (init/system), not only on
+	// the terminal result. Claude/Codex report it at session start; without
+	// this a mid-run crash leaves the registry record with an empty session
+	// and restart-stale cold-restarts instead of resuming. Mirrors the
+	// conversational runner (runner_convo.go) and AddResultStats.
+	if (event.Type == "init" || event.Type == "system") && event.SessionID != "" {
+		if a.GetSessionID() != event.SessionID {
+			a.SetSessionID(event.SessionID)
+			m.saveRegistry(a)
+		}
+		if a.Provider == "codex" {
+			if p := resolveCodexSessionFile(event.SessionID); p != "" {
+				a.SetSessionFilePath(p)
+			}
 		}
 	}
 

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -503,7 +503,7 @@ func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte
 			a.SetSessionID(event.SessionID)
 			m.saveRegistry(a)
 		}
-		if a.Provider == "codex" {
+		if isCodex {
 			if p := resolveCodexSessionFile(event.SessionID); p != "" {
 				a.SetSessionFilePath(p)
 			}

--- a/internal/agent/survive_restart_test.go
+++ b/internal/agent/survive_restart_test.go
@@ -369,10 +369,11 @@ func TestReattachAll_BridgesDeadSessionForResume(t *testing.T) {
 		t.Fatalf("EnableSurviveRestart: %v", err)
 	}
 	var gotTask, gotAgent, gotSession atomic.Value
-	m.SetSessionSink(func(taskID, agentID, sessionID string) {
+	m.SetSessionSink(func(taskID, agentID, sessionID string) error {
 		gotTask.Store(taskID)
 		gotAgent.Store(agentID)
 		gotSession.Store(sessionID)
+		return nil
 	})
 
 	// Dead process (PID 0), session captured in the registry record.
@@ -394,6 +395,35 @@ func TestReattachAll_BridgesDeadSessionForResume(t *testing.T) {
 	}
 	if list, _ := m.reg.List(); len(list) != 0 {
 		t.Fatal("expected record deleted after bridge")
+	}
+}
+
+// TestReattachAll_RetainsRecordWhenBridgeFails verifies a sink error keeps
+// the registry record (for a later retry) instead of deleting it and losing
+// the session id.
+func TestReattachAll_RetainsRecordWhenBridgeFails(t *testing.T) {
+	logDir := t.TempDir()
+	logPath := filepath.Join(logDir, "agents", "crash2.ndjson")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(logPath, []byte(`{"type":"assistant","message":{"content":[{"type":"text","text":"x"}]}}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir)
+	if err := m.EnableSurviveRestart(t.TempDir()); err != nil {
+		t.Fatalf("EnableSurviveRestart: %v", err)
+	}
+	m.SetSessionSink(func(_, _, _ string) error { return fmt.Errorf("task store down") })
+
+	if err := m.reg.Save(Record{ID: "crash2", TaskID: "t", Mode: "headless", Provider: "claude", PID: 0, LogPath: logPath, SessionID: "s"}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	m.ReattachAll()
+
+	list, _ := m.reg.List()
+	if len(list) != 1 {
+		t.Fatalf("expected record retained on bridge failure, got %d", len(list))
 	}
 }
 

--- a/internal/agent/survive_restart_test.go
+++ b/internal/agent/survive_restart_test.go
@@ -321,6 +321,82 @@ func TestReattachAll_RecoversCompletedDuringDowntime(t *testing.T) {
 	}
 }
 
+// TestProcessHeadlessLine_CapturesSessionOnInit is the real regression
+// guard for Phase 2: the session id must be captured (and persisted to the
+// registry) on the init/system event, not only on the terminal result —
+// otherwise a mid-run crash leaves no session to resume.
+func TestProcessHeadlessLine_CapturesSessionOnInit(t *testing.T) {
+	regDir := t.TempDir()
+	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
+	if err := m.EnableSurviveRestart(regDir); err != nil {
+		t.Fatalf("EnableSurviveRestart: %v", err)
+	}
+	a := &Agent{ID: "cap1", TaskID: "t", Mode: "headless", Provider: "claude", StartedAt: time.Now().UTC()}
+	var lastEmit time.Time
+
+	// Claude reports the session id on the init/system event (no result yet).
+	line := []byte(`{"type":"system","subtype":"init","session_id":"sess-real"}`)
+	if stop := m.processHeadlessLine(context.Background(), a, line, &lastEmit, false); stop {
+		t.Fatal("init event must not stop the stream")
+	}
+
+	if a.GetSessionID() != "sess-real" {
+		t.Fatalf("expected session captured on init, got %q", a.GetSessionID())
+	}
+	list, _ := m.reg.List()
+	if len(list) != 1 || list[0].SessionID != "sess-real" {
+		t.Fatalf("expected registry record carrying session id, got %+v", list)
+	}
+}
+
+// TestReattachAll_BridgesDeadSessionForResume verifies a crashed headless
+// agent (process gone, log has no terminal result) has its captured session
+// id bridged to its AgentRun via the sink, so restart-stale can resume.
+func TestReattachAll_BridgesDeadSessionForResume(t *testing.T) {
+	logDir := t.TempDir()
+	logPath := filepath.Join(logDir, "agents", "crash1.ndjson")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Assistant output but NO terminal result -> genuine crash mid-run.
+	partial := `{"type":"assistant","message":{"content":[{"type":"text","text":"half"}]}}` + "\n"
+	if err := os.WriteFile(logPath, []byte(partial), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir)
+	if err := m.EnableSurviveRestart(t.TempDir()); err != nil {
+		t.Fatalf("EnableSurviveRestart: %v", err)
+	}
+	var gotTask, gotAgent, gotSession atomic.Value
+	m.SetSessionSink(func(taskID, agentID, sessionID string) {
+		gotTask.Store(taskID)
+		gotAgent.Store(agentID)
+		gotSession.Store(sessionID)
+	})
+
+	// Dead process (PID 0), session captured in the registry record.
+	if err := m.reg.Save(Record{ID: "crash1", TaskID: "t9", Mode: "headless", Provider: "claude", PID: 0, LogPath: logPath, SessionID: "sess-crash"}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	if got := m.ReattachAll(); len(got) != 0 {
+		t.Fatalf("expected crashed record not reattached as live, got %d", len(got))
+	}
+	if tid, _ := gotTask.Load().(string); tid != "t9" {
+		t.Fatalf("expected sink taskID t9, got %q", tid)
+	}
+	if aid, _ := gotAgent.Load().(string); aid != "crash1" {
+		t.Fatalf("expected sink agentID crash1, got %q", aid)
+	}
+	if sid, _ := gotSession.Load().(string); sid != "sess-crash" {
+		t.Fatalf("expected sink sessionID sess-crash, got %q", sid)
+	}
+	if list, _ := m.reg.List(); len(list) != 0 {
+		t.Fatal("expected record deleted after bridge")
+	}
+}
+
 // TestShutdownWithGrace_LeavesDetachedAgents verifies a detached agent is
 // neither cancelled nor waited on, while a normal agent is cancelled.
 func TestShutdownWithGrace_LeavesDetachedAgents(t *testing.T) {

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -345,11 +345,11 @@ func (a *App) initAgentConfig() {
 			a.logger.Info("agent.survive-restart.enabled", "dir", config.AgentsDir())
 		}
 		// Bridge a crashed agent's session id into its AgentRun on
-		// dead-reattach so restart-stale recovery resumes via --resume.
-		a.agents.SetSessionSink(func(taskID, agentID, sessionID string) {
-			if err := a.tasks.UpdateRun(taskID, agentID, map[string]any{"session_id": sessionID}); err != nil {
-				a.logger.Debug("agent.session-sink", "task_id", taskID, "agent_id", agentID, "err", err)
-			}
+		// dead-reattach so restart-stale recovery resumes via --resume. The
+		// error is returned (not swallowed) so the manager retains the
+		// registry record for retry and logs the failure at Warn.
+		a.agents.SetSessionSink(func(taskID, agentID, sessionID string) error {
+			return a.tasks.UpdateRun(taskID, agentID, map[string]any{"session_id": sessionID})
 		})
 	}
 	a.agents.SetGuardrails(agent.Guardrails{

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -344,6 +344,13 @@ func (a *App) initAgentConfig() {
 		} else {
 			a.logger.Info("agent.survive-restart.enabled", "dir", config.AgentsDir())
 		}
+		// Bridge a crashed agent's session id into its AgentRun on
+		// dead-reattach so restart-stale recovery resumes via --resume.
+		a.agents.SetSessionSink(func(taskID, agentID, sessionID string) {
+			if err := a.tasks.UpdateRun(taskID, agentID, map[string]any{"session_id": sessionID}); err != nil {
+				a.logger.Debug("agent.session-sink", "task_id", taskID, "agent_id", agentID, "err", err)
+			}
+		})
 	}
 	a.agents.SetGuardrails(agent.Guardrails{
 		MaxCostUSD:       a.cfg.Agent.MaxCostUSD,


### PR DESCRIPTION
## Motivation

Phase 2 of 3 for restart survival. Phase 1 (#959) keeps live headless agents running across a restart and reattaches to them. This phase handles the agents that genuinely **died** (hard app crash, machine reboot): their work should resume from the exact conversation, not be cold-restarted and redone.

The orchestrator's `StartAgent` already resumes via `pickImplementationResumeSession`, which reads `AgentRun.SessionID`. The gap was upstream: on a hard crash the completion callback that writes the session id to the `AgentRun` never runs, and the session id was only captured into the agent at the terminal `result` event — so a mid-run crash left **no session id anywhere** to resume from.

## Implementation information

- **Capture the session id on the `init`/`system` event** (not only the terminal `result`) in `processHeadlessLine`. Claude/Codex report it at session start; capturing it there means the Phase 1 registry record carries the session from the start of the run, so a mid-run crash stays resumable. This mirrors the conversational runner (`runner_convo.go`) and `AddResultStats`, and also lets headless retries resume the just-started session.
- **Bridge the session id on dead-reattach.** When `ReattachAll` finds a record whose process is gone and whose log shows no terminal result (a genuine crash), `persistDeadSession` writes the captured session id into the task's `AgentRun` through a `sessionSink` callback (wired in `app_init.go` to `tasks.UpdateRun`). The existing `StartAgent` → `pickImplementationResumeSession` path then resumes via `--resume`.
- `finalizeIfCompleted` now returns whether it finalized, so the bridge only runs for crashes — a run that completed during downtime is finalized (workflow advances) instead.

Found and fixed during adversarial pre-PR review: the first cut bridged a session id that, for the canonical mid-run crash, was never captured (only set on `result`). The `init`/`system` capture is the actual enabler; added a regression test that drives the real line-processing path (`TestProcessHeadlessLine_CapturesSessionOnInit`).

Tests: session captured on init + persisted to registry; dead crash bridges the session to the sink; completed-during-downtime finalizes instead of bridging. `go test -race`, golangci-lint, nilaway all clean.

## Supporting documentation

Part of the survive-restart series: #956 (Phase 1, merged in #959), this issue (Phase 2), #958 (Phase 3, interactive).

Closes #957

> Changelog: feat(agent): resume crashed headless agents by session id