### PR TITLE
fix(workflow): don't auto-close on agent crash

### DIFF
--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -369,7 +369,7 @@ func (e *Engine) execSyncStep(taskID string, step *Step, wfExec *Execution, ctx 
 	case StepRerequestReview:
 		return e.execRerequestReview(taskID, step, t)
 	case StepVerifyCommits:
-		return e.execVerifyCommits(taskID, step, t)
+		return e.execVerifyCommits(taskID, step, wfExec, t)
 	case StepLinkPRAndReview:
 		return e.execLinkPRAndReview(taskID, step, wfExec, t)
 	case StepEvaluate:

--- a/internal/workflow/engine_steps_verify.go
+++ b/internal/workflow/engine_steps_verify.go
@@ -174,7 +174,7 @@ func resolveOriginBase(ctx context.Context, wtPath string) string {
 	return "origin/main"
 }
 
-func (e *Engine) execVerifyCommits(taskID string, step *Step, t TaskInfo) (StepOutput, error) {
+func (e *Engine) execVerifyCommits(taskID string, step *Step, wfExec *Execution, t TaskInfo) (StepOutput, error) {
 	if e.worktrees == nil {
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no worktree getter configured"}, nil
 	}
@@ -208,6 +208,21 @@ func (e *Engine) execVerifyCommits(taskID string, step *Step, t TaskInfo) (StepO
 	}
 
 	if strings.TrimSpace(string(output)) == "" {
+		// A crashed implementation agent (e.g. API error mid-run) leaves a fresh
+		// worktree branch sitting exactly on the base tip — git-indistinguishable
+		// from "work already merged via another branch". Marking such a task done
+		// silently discards the uncommitted work. Disambiguate with the upstream
+		// agent step's outcome: a failed implement step means the branch is empty
+		// because the agent died, not because the fix already shipped. Route to
+		// human-required so the run is surfaced, not closed.
+		if wfExec.LastAgentStepFailed() {
+			reason := "implementation agent failed before committing — no commits on branch"
+			if statusErr := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); statusErr != nil {
+				e.logger.Error("workflow.verify-commits.status", "task_id", taskID, "err", statusErr)
+			}
+			e.logger.Warn("workflow.verify-commits.agent-failed", "task_id", taskID)
+			return StepOutput{StepID: step.ID, Status: "completed", Output: "agent failed before commit: flipped to human-required"}, nil
+		}
 		// Disambiguate "no commits ahead" between two cases:
 		//   (a) HEAD == base ref tip → branch is identical to base. Implementation
 		//       was already on origin (e.g. merged via a different branch before

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2649,7 +2649,7 @@ func TestExecVerifyCommits_NoGetterSkips(t *testing.T) {
 	// worktrees nil by default
 
 	ti := TaskInfo{ID: "t1"}
-	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), ti)
+	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), &Execution{}, ti)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2669,7 +2669,7 @@ func TestExecVerifyCommits_NoWorktreeSkips(t *testing.T) {
 	engine := NewEngine(store, tasks, agents, discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{ok: false})
 
-	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), TaskInfo{ID: "t1"})
+	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), &Execution{}, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2691,7 +2691,7 @@ func TestExecVerifyCommits_WithCommitsVerified(t *testing.T) {
 	wtDir := makeGitRepo(t, true /* withExtraCommit */)
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
 
-	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), TaskInfo{ID: "t1"})
+	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), &Execution{}, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2719,7 +2719,7 @@ func TestExecVerifyCommits_GitErrorFlipsHumanRequired(t *testing.T) {
 	// simulating the broken-worktree scenario from the synapse→sybra rename.
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: t.TempDir(), ok: true})
 
-	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), TaskInfo{ID: "t1"})
+	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), &Execution{}, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2749,7 +2749,7 @@ func TestExecVerifyCommits_GitErrorReasonContainsDiagnosis(t *testing.T) {
 	// both fail with the same fatal so diagnosis surfaces it.
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: t.TempDir(), ok: true})
 
-	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), TaskInfo{ID: "t1"})
+	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), &Execution{}, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2794,7 +2794,7 @@ func TestExecVerifyCommits_RetriesAfterTransientFailure(t *testing.T) {
 	// First call may or may not actually be blocked by the lock depending
 	// on git behavior — but the retry path always runs once per error,
 	// and we just need the final outcome to be "commits verified".
-	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), TaskInfo{ID: "t1"})
+	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), &Execution{}, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2822,7 +2822,7 @@ func TestExecVerifyCommits_BranchAtBaseMarksDone(t *testing.T) {
 	wtDir := makeGitRepo(t, false /* no extra commit; HEAD == origin/main */)
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
 
-	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), TaskInfo{ID: "t1"})
+	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), &Execution{}, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2857,7 +2857,7 @@ func TestExecVerifyCommits_BranchAncestorOfBaseMarksDone(t *testing.T) {
 	wtDir := makeGitRepoBehindOrigin(t)
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
 
-	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), TaskInfo{ID: "t1"})
+	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), &Execution{}, TaskInfo{ID: "t1"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2870,6 +2870,48 @@ func TestExecVerifyCommits_BranchAncestorOfBaseMarksDone(t *testing.T) {
 	ti, _ := tasks.GetTask("t1")
 	if ti.Status != "done" {
 		t.Errorf("task status = %q, want done", ti.Status)
+	}
+}
+
+// TestExecVerifyCommits_AgentFailedFlipsHumanRequired covers the false-positive
+// auto-close: a fresh worktree branch sits exactly on origin/main (no commits
+// ahead, HEAD == base.tip — git-identical to "already merged") *because the
+// implementation agent crashed before committing*, not because the fix shipped.
+// With a failed agent step in history, the task must flip to human-required so
+// the run is surfaced, never silently marked done.
+func TestExecVerifyCommits_AgentFailedFlipsHumanRequired(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	// Same git state as TestExecVerifyCommits_BranchAtBaseMarksDone: HEAD ==
+	// origin/main, so branchMergedIntoBase would otherwise mark the task done.
+	wtDir := makeGitRepo(t, false /* no extra commit; HEAD == origin/main */)
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wtDir, ok: true})
+
+	// The upstream implement step failed (agent died mid-run).
+	wfExec := &Execution{StepHistory: []StepRecord{
+		{StepID: "implement", Status: "failed", AgentID: "a1", Provider: "claude"},
+	}}
+
+	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), wfExec, TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Status != "completed" {
+		t.Errorf("Status = %q, want completed", out.Status)
+	}
+	if !strings.Contains(out.Output, "agent failed before commit") {
+		t.Errorf("Output = %q, want 'agent failed before commit'", out.Output)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "human-required" {
+		t.Errorf("task status = %q, want human-required", ti.Status)
+	}
+	if reason := tasks.Reason("t1"); !strings.Contains(reason, "agent failed before committing") {
+		t.Errorf("status reason = %q, want 'agent failed before committing'", reason)
 	}
 }
 

--- a/internal/workflow/execution.go
+++ b/internal/workflow/execution.go
@@ -132,6 +132,20 @@ func (e *Execution) RecordForStep(stepID string) *StepRecord {
 	return nil
 }
 
+// LastAgentStepFailed reports whether the most recent step that ran an agent
+// (AgentID set) terminated with status "failed". verify_commits uses this to
+// tell "agent crashed before committing" (→ human-required) apart from "branch
+// already merged into base" (→ done): both leave a fresh worktree branch on the
+// base tip with no commits ahead, so git alone cannot distinguish them.
+func (e *Execution) LastAgentStepFailed() bool {
+	for i := range slices.Backward(e.StepHistory) {
+		if e.StepHistory[i].AgentID != "" {
+			return e.StepHistory[i].Status == "failed"
+		}
+	}
+	return false
+}
+
 // StepRecord captures the result of executing one step.
 type StepRecord struct {
 	StepID    string    `yaml:"step_id" json:"stepId"`


### PR DESCRIPTION
## Motivation

The `verify_commits` workflow step marked a task `done` whenever the branch
had no commits ahead of the base ref and HEAD was an ancestor of base —
interpreting it as "implementation already merged into origin".

For projects with `worktree_base_ref: fresh`, a fresh worktree branch starts
*on* the base tip. So a task whose implementation agent crashes before
committing (e.g. an API connection drop mid-run) leaves the branch sitting
exactly on base with zero commits ahead — git-indistinguishable from "work
already merged". The task was silently closed as `done` and the agents
uncommitted work was discarded, with no signal that anything went wrong.

> Changelog: fix(workflow): don't auto-close a task when its implementation agent crashed before committing

## Implementation information

`verify_commits` now disambiguates the two cases using the upstream agent
step outcome, which git alone cannot distinguish:

- New `Execution.LastAgentStepFailed()` reports whether the most recent
  agent-bearing step terminated with status `failed`.
- In the "no commits ahead" branch of `execVerifyCommits`, if the last agent
  step failed, the task flips to `human-required` (run surfaced) instead of
  `done`. The `branchMergedIntoBase` → `done` path is preserved only when the
  agent step succeeded (genuine "already merged").
- Threaded `wfExec` into `execVerifyCommits`.

Regression test `TestExecVerifyCommits_AgentFailedFlipsHumanRequired` uses the
same git state as the marks-done test but with a failed agent step in history,
asserting `human-required`. Full `internal/workflow` + `internal/sybra` suites
pass; golangci-lint clean.

## Supporting documentation

Surfaced by a real task that was silently auto-closed after its implementation
agent dropped mid-run before committing.