### PR TITLE
feat(agent): interactive agents survive restart

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -108,6 +108,22 @@ func (m *Manager) survives() bool {
 	return m.surviveRestart && m.reg != nil
 }
 
+// willDetach reports whether a run with this config/provider takes the
+// detached survival path: all headless runs, and interactive Claude runs
+// that are not one-shot. Codex interactive (spawns per turn) and one-shot
+// convo (signals completion via stdin EOF) stay on the legacy pipe path.
+// Single source of truth mirrored by the runner branches.
+func willDetach(cfg RunConfig, prov string) bool {
+	switch cfg.Mode {
+	case "headless":
+		return true
+	case "interactive":
+		return normalizeProvider(prov) != "codex" && !cfg.OneShot
+	default:
+		return false
+	}
+}
+
 // registry returns the registry store (nil when survival is disabled).
 func (m *Manager) registry() *registryStore {
 	m.mu.RLock()
@@ -134,6 +150,7 @@ func (m *Manager) saveRegistry(a *Agent) {
 		LogPath:   a.LogPath,
 		CWD:       a.sessionCWD,
 		StartedAt: a.StartedAt,
+		StdinPath: a.stdinPath,
 		MaxTurns:  a.MaxTurns,
 	}
 	a.mu.RUnlock()

--- a/internal/agent/manager_control.go
+++ b/internal/agent/manager_control.go
@@ -95,6 +95,14 @@ func (m *Manager) KillAgentsForTask(taskID string, timeout time.Duration) {
 
 	for _, a := range targets {
 		m.logger.Info("agent.kill-for-task", "agent_id", a.ID, "task_id", taskID)
+		// A detached subprocess cannot be killed via ctx-cancel or stdin EOF
+		// (own session, never-EOF FIFO stdin). Mark it stopped so its tailer
+		// finalizes, and signal it by PID so the process actually dies before
+		// the caller cleans up the worktree it is using.
+		if a.isDetached() {
+			a.MarkStopped()
+			m.signalKill(a)
+		}
 		if a.cancel != nil {
 			a.cancel()
 		}
@@ -134,11 +142,12 @@ func (m *Manager) StopAgent(agentID string) error {
 
 	a.MarkStopped()
 	// Send SIGINT first so CC can restore terminal modes and persist the
-	// session ID for --resume. Escalate to SIGKILL only after the grace window.
-	if a.Mode == "headless" {
-		if cmd := a.GetCmd(); cmd != nil {
-			stopWithSIGINT(cmd, a.done, stopSIGINTGrace)
-		}
+	// session ID for --resume. Escalate to SIGKILL only after the grace
+	// window. Detached agents (headless, or interactive whose stdin is a
+	// never-EOF O_RDWR FIFO) cannot be stopped by closing stdin, so they
+	// must be signalled by PID/handle.
+	if a.Mode == "headless" || a.isDetached() {
+		m.signalKill(a)
 	}
 	if a.cancel != nil {
 		a.cancel()

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -70,13 +70,14 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 	}
 	if cfg.Mode == "headless" {
 		a.escalationCh = make(chan bool, 1)
-		// Pre-mark detached so a shutdown racing the runner goroutine
-		// already knows to leave this agent's subprocess running. The
-		// runner re-asserts this after a successful Start. Use the mutexed
-		// setter — detached is guarded by mu and read via isDetached().
-		if m.survives() {
-			a.setDetached(true)
-		}
+	}
+	// Pre-mark detached so a shutdown racing the runner goroutine already
+	// knows to leave this agent's subprocess running. The runner re-asserts
+	// it after a successful Start. Detached applies to headless and to
+	// interactive Claude (non-one-shot, FIFO-backed) survival; codex
+	// interactive (spawns per turn) and one-shot stay on the legacy path.
+	if m.survives() && willDetach(cfg, a.Provider) {
+		a.setDetached(true)
 	}
 
 	m.mu.Lock()

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -121,6 +121,14 @@ func (m *Manager) markAgentDone(a *Agent) {
 	}
 	a.doneOnce.Do(func() {
 		close(a.done)
+		// Close the stdin pipe/FIFO and drop the registry record + FIFO file
+		// so a completed agent leaks neither an fd nor an on-disk pipe.
+		a.stdinMu.Lock()
+		if a.stdinPipe != nil {
+			_ = a.stdinPipe.Close()
+			a.stdinPipe = nil
+		}
+		a.stdinMu.Unlock()
 		if reg := m.registry(); reg != nil {
 			_ = reg.Delete(a.ID)
 		}

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -90,6 +90,11 @@ type Agent struct {
 	stdinMu    sync.Mutex
 	approvalCh chan ApprovalResponse
 
+	// stdinPath is the FIFO backing a detached conversational agent's stdin,
+	// reopened on reattach so follow-up messages survive a restart. Empty for
+	// pipe-backed (non-survival) agents. Guarded by mu.
+	stdinPath string
+
 	// pendingPrompts queues follow-up user messages that arrive while a turn
 	// is mid-flight. Drained after each "result" event so the next turn fires
 	// without waiting on the user. Guarded by mu.
@@ -406,6 +411,22 @@ func (a *Agent) GetPID() int {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.PID
+}
+
+// setStdinPath records the FIFO path backing a detached conversational
+// agent's stdin.
+func (a *Agent) setStdinPath(p string) {
+	a.mu.Lock()
+	a.stdinPath = p
+	a.mu.Unlock()
+}
+
+// GetStdinPath returns the FIFO path backing the agent's stdin ("" for
+// pipe-backed agents).
+func (a *Agent) GetStdinPath() string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.stdinPath
 }
 
 // setDetached marks whether the agent's subprocess is detached for

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -48,8 +48,12 @@ func (m *Manager) ReattachAll() []*Agent {
 	var out []*Agent
 	for i := range recs {
 		r := recs[i]
-		// Phase 1 reattaches headless agents only. Interactive records are
-		// handled by a later phase; leave them untouched here.
+		if r.Mode == "interactive" {
+			if a := m.reattachInteractive(r, reg); a != nil {
+				out = append(out, a)
+			}
+			continue
+		}
 		if r.Mode != "headless" {
 			continue
 		}
@@ -148,6 +152,48 @@ func (m *Manager) persistDeadSession(r Record) (done bool) {
 	}
 	m.logger.Info("agent.reattach.resume-session", "id", r.ID, "task", r.TaskID, "session_id", r.SessionID)
 	return true
+}
+
+// reattachInteractive rebuilds a live detached conversational agent: it
+// rehydrates the convo buffer from the log, registers the agent, reopens its
+// stdin FIFO, and resumes tailing. A dead record is deleted (interactive
+// recovery is handled by the workflow's recoverStaleInteractive / chat gc).
+// Returns the reattached agent, or nil when the process is gone or a
+// duplicate already exists.
+func (m *Manager) reattachInteractive(r Record, reg *registryStore) *Agent {
+	if !reattachAlive(r) {
+		_ = reg.Delete(r.ID)
+		m.logger.Info("agent.reattach.dead", "id", r.ID, "pid", r.PID, "task", r.TaskID, "mode", "interactive")
+		return nil
+	}
+
+	a := agentFromRecord(r)
+	var startOffset int64
+	if r.LogPath != "" {
+		startOffset = rehydrateConvoFromLog(a, r.LogPath)
+	}
+	// Interactive agents sit idle (Paused) between user turns; reattach in
+	// that state. processConvoLine flips to Running when a follow-up fires.
+	a.SetState(StatePaused)
+
+	ctx, cancel := context.WithCancel(m.ctx)
+	a.cancel = cancel
+	a.done = make(chan struct{})
+
+	m.mu.Lock()
+	if _, exists := m.agents[a.ID]; exists {
+		m.mu.Unlock()
+		cancel()
+		return nil
+	}
+	m.agents[a.ID] = a
+	m.liveCount++
+	m.mu.Unlock()
+
+	m.logger.Info("agent.reattach", "id", a.ID, "pid", a.PID, "task", a.TaskID, "mode", "interactive", "events", len(a.ConvoOutput()))
+	go m.reattachConvo(ctx, a, startOffset, r.ProcStartedAt)
+	m.emit(events.AgentState(a.ID), a)
+	return a
 }
 
 // reattachHeadless tails a reattached subprocess's log file from
@@ -283,6 +329,7 @@ func agentFromRecord(r Record) *Agent {
 		LastEventAt: time.Now().UTC(),
 		State:       StateRunning,
 		MaxTurns:    r.MaxTurns,
+		stdinPath:   r.StdinPath,
 		detached:    true,
 	}
 }

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -161,6 +162,12 @@ func (m *Manager) persistDeadSession(r Record) (done bool) {
 // Returns the reattached agent, or nil when the process is gone or a
 // duplicate already exists.
 func (m *Manager) reattachInteractive(r Record, reg *registryStore) *Agent {
+	// A record without a FIFO path is not a detached survival agent (e.g. a
+	// leaked one-shot record); never reattach it as a live session.
+	if r.StdinPath == "" {
+		_ = reg.Delete(r.ID)
+		return nil
+	}
 	if !reattachAlive(r) {
 		_ = reg.Delete(r.ID)
 		m.logger.Info("agent.reattach.dead", "id", r.ID, "pid", r.PID, "task", r.TaskID, "mode", "interactive")
@@ -172,9 +179,10 @@ func (m *Manager) reattachInteractive(r Record, reg *registryStore) *Agent {
 	if r.LogPath != "" {
 		startOffset = rehydrateConvoFromLog(a, r.LogPath)
 	}
-	// Interactive agents sit idle (Paused) between user turns; reattach in
-	// that state. processConvoLine flips to Running when a follow-up fires.
-	a.SetState(StatePaused)
+	// Resume in the right state: Paused if the last turn finished (idle,
+	// waiting for the user), Running if the agent was mid-generation at
+	// restart — so a follow-up is queued, not injected mid-turn.
+	a.SetState(convoResumeState(a.ConvoOutput()))
 
 	ctx, cancel := context.WithCancel(m.ctx)
 	a.cancel = cancel
@@ -194,6 +202,22 @@ func (m *Manager) reattachInteractive(r Record, reg *registryStore) *Agent {
 	go m.reattachConvo(ctx, a, startOffset, r.ProcStartedAt)
 	m.emit(events.AgentState(a.ID), a)
 	return a
+}
+
+// convoResumeState infers a reattached conversational agent's state from
+// its rehydrated buffer: Running when the most recent turn-shaping event is
+// an assistant event (mid-generation), Paused when it is a result (idle
+// between turns) or there is nothing yet.
+func convoResumeState(evs []ConvoEvent) State {
+	for i := range slices.Backward(evs) {
+		switch evs[i].Type {
+		case "result":
+			return StatePaused
+		case "assistant":
+			return StateRunning
+		}
+	}
+	return StatePaused
 }
 
 // reattachHeadless tails a reattached subprocess's log file from

--- a/internal/agent/registry.go
+++ b/internal/agent/registry.go
@@ -81,8 +81,12 @@ func (s *registryStore) List() ([]Record, error) {
 	return out, nil
 }
 
-// Delete removes the record file. A missing file is not an error.
+// Delete removes the record file and the agent's stdin FIFO (if any). A
+// missing file is not an error.
 func (s *registryStore) Delete(id string) error {
+	// Best-effort FIFO cleanup so detached conversational agents don't leak
+	// a named pipe per run under the agents dir.
+	_ = os.Remove(s.fifoPath(id))
 	if err := os.Remove(s.path(id)); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("delete record: %w", err)
 	}

--- a/internal/agent/registry.go
+++ b/internal/agent/registry.go
@@ -92,3 +92,9 @@ func (s *registryStore) Delete(id string) error {
 func (s *registryStore) path(id string) string {
 	return filepath.Join(s.dir, id+".yaml")
 }
+
+// fifoPath returns the stdin FIFO path for a detached conversational agent,
+// alongside its registry record under the agents dir.
+func (s *registryStore) fifoPath(id string) string {
+	return filepath.Join(s.dir, id+".stdin")
+}

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -326,11 +326,14 @@ func (m *Manager) processConvoLine(a *Agent, line []byte, st *convoEmitState, on
 
 	switch event.Type {
 	case "system":
-		if event.SessionID != "" {
-			// Capture the session id (and persist for survival) as soon as it
-			// appears, so a restart can resume / reattach the conversation.
-			if a.GetSessionID() != event.SessionID {
-				a.SetSessionID(event.SessionID)
+		if event.SessionID != "" && a.GetSessionID() != event.SessionID {
+			// Capture the session id as soon as it appears so a restart can
+			// resume the conversation. Only persist a registry record for a
+			// detached (FIFO-backed survival) agent — a one-shot or legacy
+			// interactive agent must not leave a record, or reattach would
+			// mis-recover it as a survivable session and stall the workflow.
+			a.SetSessionID(event.SessionID)
+			if a.isDetached() {
 				m.saveRegistry(a)
 			}
 		}
@@ -387,6 +390,10 @@ func (m *Manager) writeUserMessage(a *Agent, text string) error {
 	if a.stdinPipe == nil {
 		return fmt.Errorf("stdin pipe closed")
 	}
+	// Note: a message larger than the pipe buffer (~64KB) written while the
+	// child is not draining stdin blocks here under stdinMu until the child
+	// reads. In practice messages are far smaller and the child consumes
+	// stdin promptly; very large pastes are the only way to stall this.
 	if _, err := a.stdinPipe.Write(data); err != nil {
 		return fmt.Errorf("write stdin: %w", err)
 	}

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -139,18 +140,27 @@ func (m *Manager) runConversational(ctx context.Context, a *Agent, cfg RunConfig
 		}
 	}()
 
+	// tailOffset tracks the survival file tailer's position across retries.
+	var tailOffset int64
+
 	for attempt := range len(headlessRetryBackoffs) + 1 {
 		if attempt > 0 {
 			wait := headlessRetryBackoffs[attempt-1]
 			m.logger.Info("agent.convo.retry", "id", a.ID, "attempt", attempt, "backoff", wait)
 			select {
 			case <-ctx.Done():
+				if a.isDetached() && !a.WasStopped() {
+					return
+				}
 				goto done
 			case <-time.After(wait):
 			}
 		}
 
-		retry, fatalErr := m.runConvoAttempt(ctx, a, cfg, &outFile)
+		retry, fatalErr := m.runConvoAttempt(ctx, a, cfg, &outFile, &tailOffset)
+		if errors.Is(fatalErr, errSurviveShutdown) {
+			return
+		}
 		if fatalErr != nil {
 			m.handleError(a, fatalErr)
 			return
@@ -174,9 +184,15 @@ done:
 	m.markAgentDone(a)
 }
 
-func (m *Manager) runConvoAttempt(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File) (retry bool, err error) {
+func (m *Manager) runConvoAttempt(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File, tailOffset *int64) (retry bool, err error) {
 	if outFile == nil {
 		return false, nil
+	}
+	// Detached survival applies to interactive (non-one-shot) Claude agents.
+	// One-shot runs must keep the pipe path: they signal completion by
+	// closing stdin to send EOF, which a never-EOF survival FIFO cannot do.
+	if m.survives() && !cfg.OneShot {
+		return m.runConvoAttemptSurvive(ctx, a, cfg, outFile, tailOffset)
 	}
 	cmd, stdout, stderrBuf, startErr := m.startConvoProcess(ctx, a, cfg)
 	if startErr != nil {
@@ -241,100 +257,112 @@ func (m *Manager) runConvoAttempt(ctx context.Context, a *Agent, cfg RunConfig, 
 	return false, nil
 }
 
+// convoEmitState carries the throttle state across processConvoLine calls
+// so the live streamer and the file tailer share one emit cadence.
+type convoEmitState struct {
+	lastEmit time.Time
+	pending  *ConvoEvent // latest event buffered for the next emit window
+}
+
+// flush emits any buffered event. Called when the stream ends.
+func (m *Manager) flushConvo(a *Agent, st *convoEmitState) {
+	if st.pending != nil {
+		m.emit(events.AgentConvo(a.ID), *st.pending)
+		st.pending = nil
+	}
+}
+
 func (m *Manager) streamConvoOutput(a *Agent, stdout io.Reader, outFile io.Writer, oneShot bool) {
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
-	var lastEmit time.Time
-	var pending *ConvoEvent // buffered event waiting for next emit window
-
+	st := &convoEmitState{}
 	for scanner.Scan() {
 		line := scanner.Bytes()
-
 		if outFile != nil {
 			_, _ = outFile.Write(line)
 			_, _ = outFile.Write([]byte("\n"))
 		}
+		m.processConvoLine(a, line, st, oneShot)
+	}
+	m.flushConvo(a, st)
+}
 
-		parsed, parseErr := ParseClaudeLine(line)
-		if parseErr != nil {
-			m.logger.Warn("agent.convo.parse", "id", a.ID, "err", parseErr, "line", string(line))
-			continue
-		}
-		event := claudeEventToConvoEvent(parsed)
-		if event.Type == "" {
-			continue
-		}
-
-		a.AppendConvo(event)
-
-		// Always emit result/system events immediately. For others, buffer
-		// the latest and emit at most once per convoEmitInterval so the
-		// frontend still gets every meaningful update.
-		switch {
-		case event.Type == "result" || event.Type == "system":
-			pending = nil
-			m.emit(events.AgentConvo(a.ID), event)
-			lastEmit = time.Now()
-		case time.Since(lastEmit) >= convoEmitInterval:
-			if pending != nil {
-				m.emit(events.AgentConvo(a.ID), *pending)
-				pending = nil
-			}
-			m.emit(events.AgentConvo(a.ID), event)
-			lastEmit = time.Now()
-		default:
-			// Buffer the latest event; it will be emitted on the next window.
-			e := event
-			pending = &e
-		}
-
-		switch event.Type {
-		case "system":
-			if event.SessionID != "" {
-				a.SetSessionID(event.SessionID)
-			}
-		case "result":
-			costNow := a.AddResultStats(event.SessionID, event.CostUSD, event.InputTokens, event.OutputTokens, event.ReasoningTokens)
-			a.AddCacheStats(event.CacheCreationInputTokens, event.CacheReadInputTokens)
-			m.logger.Info("agent.convo.result", "id", a.ID, "session_id", event.SessionID, "cost", costNow)
-			// Drain any prompts queued mid-turn before flipping to paused.
-			// Each queued prompt fires the next turn back-to-back so the
-			// user's chat-window queue executes in order without manual
-			// re-trigger.
-			if next, ok := a.PopPendingPrompt(); ok {
-				if err := m.writeUserMessage(a, next); err != nil {
-					m.logger.Error("agent.convo.flush-queue", "id", a.ID, "err", err)
-					a.SetState(StatePaused)
-				} else {
-					a.SetState(StateRunning)
-					m.logger.Info("agent.convo.queue-flushed", "id", a.ID, "remaining", a.PendingPromptCount())
-				}
-			} else {
-				// After result, agent is idle waiting for next user message.
-				a.SetState(StatePaused)
-			}
-			m.emit(events.AgentState(a.ID), a)
-			// One-shot runs (workflow steps that expect a single turn) close
-			// stdin now so the claude process sees EOF and exits. The scanner
-			// loop unwinds on stdout EOF, cmd.Wait() returns, SetState(Stopped)
-			// fires, and onComplete advances the workflow to the next step.
-			// Without this, interactive agents sit paused forever and never
-			// trigger the evaluator.
-			if oneShot {
-				m.logger.Info("agent.convo.one-shot-close", "id", a.ID)
-				a.stdinMu.Lock()
-				if a.stdinPipe != nil {
-					_ = a.stdinPipe.Close()
-					a.stdinPipe = nil
-				}
-				a.stdinMu.Unlock()
-			}
-		}
+// processConvoLine parses one conversational NDJSON line, appends and
+// throttle-emits the event, and runs the session/result/queue/one-shot
+// state machine. Shared by the pipe-backed streamer and the survival file
+// tailer; it never writes the log file (caller or child owns that).
+func (m *Manager) processConvoLine(a *Agent, line []byte, st *convoEmitState, oneShot bool) {
+	parsed, parseErr := ParseClaudeLine(line)
+	if parseErr != nil {
+		m.logger.Warn("agent.convo.parse", "id", a.ID, "err", parseErr, "line", string(line))
+		return
+	}
+	event := claudeEventToConvoEvent(parsed)
+	if event.Type == "" {
+		return
 	}
 
-	// Flush any remaining buffered event.
-	if pending != nil {
-		m.emit(events.AgentConvo(a.ID), *pending)
+	a.AppendConvo(event)
+
+	// Always emit result/system events immediately. For others, buffer the
+	// latest and emit at most once per convoEmitInterval so the frontend
+	// still gets every meaningful update.
+	switch {
+	case event.Type == "result" || event.Type == "system":
+		st.pending = nil
+		m.emit(events.AgentConvo(a.ID), event)
+		st.lastEmit = time.Now()
+	case time.Since(st.lastEmit) >= convoEmitInterval:
+		if st.pending != nil {
+			m.emit(events.AgentConvo(a.ID), *st.pending)
+			st.pending = nil
+		}
+		m.emit(events.AgentConvo(a.ID), event)
+		st.lastEmit = time.Now()
+	default:
+		e := event
+		st.pending = &e
+	}
+
+	switch event.Type {
+	case "system":
+		if event.SessionID != "" {
+			// Capture the session id (and persist for survival) as soon as it
+			// appears, so a restart can resume / reattach the conversation.
+			if a.GetSessionID() != event.SessionID {
+				a.SetSessionID(event.SessionID)
+				m.saveRegistry(a)
+			}
+		}
+	case "result":
+		costNow := a.AddResultStats(event.SessionID, event.CostUSD, event.InputTokens, event.OutputTokens, event.ReasoningTokens)
+		a.AddCacheStats(event.CacheCreationInputTokens, event.CacheReadInputTokens)
+		m.logger.Info("agent.convo.result", "id", a.ID, "session_id", event.SessionID, "cost", costNow)
+		// Drain any prompts queued mid-turn before flipping to paused. Each
+		// queued prompt fires the next turn back-to-back so the user's
+		// chat-window queue executes in order without manual re-trigger.
+		if next, ok := a.PopPendingPrompt(); ok {
+			if err := m.writeUserMessage(a, next); err != nil {
+				m.logger.Error("agent.convo.flush-queue", "id", a.ID, "err", err)
+				a.SetState(StatePaused)
+			} else {
+				a.SetState(StateRunning)
+				m.logger.Info("agent.convo.queue-flushed", "id", a.ID, "remaining", a.PendingPromptCount())
+			}
+		} else {
+			a.SetState(StatePaused)
+		}
+		m.emit(events.AgentState(a.ID), a)
+		// One-shot runs close stdin so the claude process sees EOF and exits.
+		if oneShot {
+			m.logger.Info("agent.convo.one-shot-close", "id", a.ID)
+			a.stdinMu.Lock()
+			if a.stdinPipe != nil {
+				_ = a.stdinPipe.Close()
+				a.stdinPipe = nil
+			}
+			a.stdinMu.Unlock()
+		}
 	}
 }
 

--- a/internal/agent/runner_convo_survive.go
+++ b/internal/agent/runner_convo_survive.go
@@ -1,0 +1,315 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+
+	"github.com/Automaat/sybra/internal/events"
+	"github.com/Automaat/sybra/internal/logging"
+)
+
+// makeFIFO creates (or recreates) a named pipe at path. A stale pipe from a
+// prior run is removed first so the mode bits are always fresh.
+func makeFIFO(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return syscall.Mkfifo(path, 0o600)
+}
+
+// startConvoProcessSurvive spawns a detached conversational Claude process
+// whose stdin is a FIFO (opened O_RDWR so it never sees EOF and survives the
+// parent's exit) and whose stdout is the NDJSON log file. The manager reads
+// output by tailing that file; follow-up messages are written to the FIFO,
+// which a reattaching instance reopens.
+func (m *Manager) startConvoProcessSurvive(a *Agent, cfg RunConfig, outFile **os.File) (*exec.Cmd, error) {
+	reg := m.registry()
+	if reg == nil {
+		return nil, fmt.Errorf("survive convo: registry not enabled")
+	}
+
+	args := m.buildConvoArgs(a, cfg)
+	cmd := exec.Command("claude", args...) // no Context: a cancelled ctx must not kill a detached child
+	configureDetached(cmd)
+	if a.sessionCWD != "" {
+		cmd.Dir = a.sessionCWD
+	}
+	if len(cfg.ExtraEnv) > 0 {
+		cmd.Env = append(os.Environ(), cfg.ExtraEnv...)
+	}
+
+	fifoPath := reg.fifoPath(a.ID)
+	if err := makeFIFO(fifoPath); err != nil {
+		return nil, fmt.Errorf("mkfifo: %w", err)
+	}
+	// O_RDWR keeps a writer on the pipe for the child's whole life, so the
+	// child's read end never hits EOF even after the parent dies.
+	fifo, err := os.OpenFile(fifoPath, os.O_RDWR, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open fifo: %w", err)
+	}
+	cmd.Stdin = fifo
+	a.stdinMu.Lock()
+	a.stdinPipe = fifo
+	a.stdinMu.Unlock()
+	a.setStdinPath(fifoPath)
+
+	// Log file is the child's stdout, so it must exist before Start. Opened
+	// once and reused across retries.
+	if *outFile == nil {
+		f, fileErr := logging.NewAgentOutputFile(m.logDir, a.ID)
+		if fileErr != nil {
+			_ = fifo.Close()
+			return nil, fmt.Errorf("open agent log: %w", fileErr)
+		}
+		a.SetLogPath(f.Name())
+		*outFile = f
+	}
+	cmd.Stdout = *outFile
+
+	stderrPath := (*outFile).Name() + ".stderr"
+	stderrF, sErr := os.OpenFile(stderrPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if sErr == nil {
+		cmd.Stderr = stderrF
+	}
+
+	if startErr := cmd.Start(); startErr != nil {
+		_ = fifo.Close()
+		if stderrF != nil {
+			_ = stderrF.Close()
+		}
+		return nil, fmt.Errorf("start claude: %w", startErr)
+	}
+	// The child holds its own dup of stderr; the parent copy can close.
+	if stderrF != nil {
+		_ = stderrF.Close()
+	}
+
+	a.SetCmd(cmd)
+	a.setDetached(true)
+	m.saveRegistry(a)
+	return cmd, nil
+}
+
+// runConvoAttemptSurvive runs one detached conversational attempt: spawn,
+// send the initial prompt, then tail the log file until the process exits or
+// the app shuts down (errSurviveShutdown leaves it running for reattach).
+func (m *Manager) runConvoAttemptSurvive(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File, tailOffset *int64) (retry bool, err error) {
+	cmd, startErr := m.startConvoProcessSurvive(a, cfg, outFile)
+	if startErr != nil {
+		return false, startErr
+	}
+	m.logger.Info("agent.convo.start", "id", a.ID, "pid", cmd.Process.Pid, "dir", cmd.Dir, "detached", true)
+
+	logPath := (*outFile).Name()
+	stderrPath := logPath + ".stderr"
+
+	// Send the initial prompt only when starting a fresh session; on a resume
+	// (--resume) re-sending would duplicate the turn. With no prompt and no
+	// session, the agent is idle waiting for the first user message.
+	if cfg.Prompt != "" && a.GetSessionID() == "" {
+		if werr := m.writeUserMessage(a, cfg.Prompt); werr != nil {
+			m.logger.Error("agent.convo.initial-prompt", "id", a.ID, "err", werr)
+		}
+	} else if cfg.Prompt == "" && a.GetSessionID() == "" {
+		a.SetState(StatePaused)
+		m.emit(events.AgentState(a.ID), a)
+	}
+
+	procDone := make(chan struct{})
+	var waitErr error
+	go func() {
+		waitErr = cmd.Wait()
+		close(procDone)
+	}()
+
+	prevLen := len(a.ConvoOutput())
+	startOffset := int64(0)
+	if tailOffset != nil {
+		startOffset = *tailOffset
+	}
+	exited, endOffset := m.tailConvoFile(ctx, a, logPath, startOffset, cfg.OneShot, procDone)
+	if tailOffset != nil {
+		*tailOffset = endOffset
+	}
+	if !exited {
+		m.logger.Info("agent.convo.detach", "id", a.ID, "pid", a.GetPID(), "reason", "shutdown")
+		return false, errSurviveShutdown
+	}
+
+	var stderrOut string
+	if b, readErr := os.ReadFile(stderrPath); readErr == nil {
+		stderrOut = string(b)
+	}
+	if stderrOut != "" {
+		m.logger.Error("agent.convo.stderr", "id", a.ID, "stderr", stderrOut)
+	}
+	if waitErr != nil {
+		m.logger.Error("agent.convo.exit", "id", a.ID, "err", waitErr)
+		a.SetExitErr(waitErr)
+		all := a.ConvoOutput()
+		if prevLen > len(all) {
+			prevLen = len(all)
+		}
+		attemptEvents := all[prevLen:]
+		if shouldRetryConvo(stderrOut, attemptEvents, m.logger) {
+			return true, nil
+		}
+		m.reportProviderHealthSignalConvo(a, stderrOut, attemptEvents)
+	}
+	return false, nil
+}
+
+// tailConvoFile follows a detached/reattached conversational agent's log
+// file from startOffset, feeding each complete line through
+// processConvoLine. Semantics mirror tailHeadlessFile: exited=true when the
+// run is over (process exited, or intentional stop), false only on app
+// shutdown of a still-running, not-stopped agent (leave it for reattach).
+func (m *Manager) tailConvoFile(ctx context.Context, a *Agent, path string, startOffset int64, oneShot bool, procDone <-chan struct{}) (exited bool, endOffset int64) {
+	offset := startOffset
+
+	f, err := os.Open(path)
+	if err != nil {
+		m.logger.Warn("agent.convo.tail.open", "id", a.ID, "path", path, "err", err)
+		select {
+		case <-procDone:
+			return true, offset
+		case <-ctx.Done():
+			return a.WasStopped(), offset
+		}
+	}
+	defer func() { _ = f.Close() }()
+
+	var buf []byte
+	st := &convoEmitState{}
+	end := func() int64 { return offset - int64(len(buf)) }
+
+	drain := func() {
+		if _, seekErr := f.Seek(offset, io.SeekStart); seekErr != nil {
+			return
+		}
+		chunk, readErr := io.ReadAll(f)
+		if readErr != nil || len(chunk) == 0 {
+			return
+		}
+		offset += int64(len(chunk))
+		a.TouchLastEvent()
+		buf = append(buf, chunk...)
+		for {
+			i := bytes.IndexByte(buf, '\n')
+			if i < 0 {
+				break
+			}
+			line := buf[:i]
+			buf = buf[i+1:]
+			m.processConvoLine(a, line, st, oneShot)
+		}
+	}
+
+	for {
+		if ctx.Err() != nil && !a.WasStopped() {
+			return false, end()
+		}
+		drain()
+		select {
+		case <-procDone:
+			drain()
+			m.flushConvo(a, st)
+			return true, end()
+		case <-ctx.Done():
+			if a.WasStopped() {
+				select {
+				case <-procDone:
+				case <-time.After(drainTimeout):
+				}
+				drain()
+				m.flushConvo(a, st)
+				return true, end()
+			}
+			return false, end()
+		case <-time.After(headlessTailPoll):
+		}
+	}
+}
+
+// rehydrateConvoFromLog replays a conversational agent's log into its convo
+// buffer (and session id) without emitting events, returning the byte offset
+// just past the last complete line for the tailer to resume from.
+func rehydrateConvoFromLog(a *Agent, path string) int64 {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer func() { _ = f.Close() }()
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return 0
+	}
+
+	var offset int64
+	start := 0
+	for i := range data {
+		if data[i] != '\n' {
+			continue
+		}
+		line := data[start:i]
+		start = i + 1
+		offset = int64(start)
+		parsed, perr := ParseClaudeLine(line)
+		if perr != nil {
+			continue
+		}
+		ev := claudeEventToConvoEvent(parsed)
+		if ev.Type == "" {
+			continue
+		}
+		a.AppendConvo(ev)
+		if ev.Type == "system" && ev.SessionID != "" {
+			a.SetSessionID(ev.SessionID)
+		}
+		if ev.Type == "result" {
+			a.AddResultStats(ev.SessionID, ev.CostUSD, ev.InputTokens, ev.OutputTokens, ev.ReasoningTokens)
+			a.AddCacheStats(ev.CacheCreationInputTokens, ev.CacheReadInputTokens)
+		}
+	}
+	return offset
+}
+
+// reattachConvo resumes a live detached conversational agent: reopen its
+// stdin FIFO so follow-ups still reach the child, then tail its log until it
+// exits or the app shuts down.
+func (m *Manager) reattachConvo(ctx context.Context, a *Agent, startOffset int64, procStart string) {
+	if sp := a.GetStdinPath(); sp != "" {
+		if fifo, err := os.OpenFile(sp, os.O_RDWR, 0); err == nil {
+			a.stdinMu.Lock()
+			a.stdinPipe = fifo
+			a.stdinMu.Unlock()
+		} else {
+			m.logger.Warn("agent.reattach.fifo", "id", a.ID, "path", sp, "err", err)
+		}
+	}
+
+	procDone := make(chan struct{})
+	go watchPID(ctx, a.GetPID(), procStart, procDone)
+
+	exited, _ := m.tailConvoFile(ctx, a, a.GetLogPath(), startOffset, false, procDone)
+	if !exited {
+		m.logger.Info("agent.reattach.detach", "id", a.ID, "pid", a.GetPID(), "reason", "shutdown")
+		return
+	}
+
+	a.SetState(StateStopped)
+	m.logger.Info("agent.reattach.convo.done", "id", a.ID, "cost", a.GetCostUSD())
+	m.emit(events.AgentState(a.ID), a)
+	m.recordCompletion(a, a.GetExitErr() == nil)
+	if m.onComplete != nil {
+		m.onComplete(a)
+	}
+	m.markAgentDone(a)
+}

--- a/internal/agent/runner_convo_survive.go
+++ b/internal/agent/runner_convo_survive.go
@@ -147,6 +147,16 @@ func (m *Manager) runConvoAttemptSurvive(ctx context.Context, a *Agent, cfg RunC
 		return false, errSurviveShutdown
 	}
 
+	// Only inspect exit status / retry once the process has actually exited.
+	// On an intentional stop the tailer can return after drainTimeout with
+	// the wait goroutine still running, so reading waitErr then would race
+	// the write and misread a live process as a clean exit.
+	select {
+	case <-procDone:
+	default:
+		return false, nil
+	}
+
 	var stderrOut string
 	if b, readErr := os.ReadFile(stderrPath); readErr == nil {
 		stderrOut = string(b)

--- a/internal/agent/runner_convo_survive.go
+++ b/internal/agent/runner_convo_survive.go
@@ -56,6 +56,10 @@ func (m *Manager) startConvoProcessSurvive(a *Agent, cfg RunConfig, outFile **os
 	}
 	cmd.Stdin = fifo
 	a.stdinMu.Lock()
+	if a.stdinPipe != nil {
+		// Close a prior attempt's FIFO writer before replacing it.
+		_ = a.stdinPipe.Close()
+	}
 	a.stdinPipe = fifo
 	a.stdinMu.Unlock()
 	a.setStdinPath(fifoPath)

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -260,6 +260,16 @@ func (m *Manager) runHeadlessAttemptSurvive(ctx context.Context, a *Agent, cfg R
 		return false, errSurviveShutdown
 	}
 
+	// Only inspect exit status / retry once the process has actually exited.
+	// A guardrail kill or intentional stop can return from the tailer after
+	// drainTimeout with the wait goroutine still running; reading waitErr
+	// then would race the write and misread a live process as a clean exit.
+	select {
+	case <-procDone:
+	default:
+		return false, nil
+	}
+
 	var stderrOut string
 	if b, readErr := os.ReadFile(stderrPath); readErr == nil {
 		stderrOut = string(b)

--- a/internal/agent/survive_convo_test.go
+++ b/internal/agent/survive_convo_test.go
@@ -92,6 +92,74 @@ func TestRehydrateConvoFromLog(t *testing.T) {
 	}
 }
 
+// TestProcessConvoLine_RegistryGatedByDetached locks in the fix for the
+// one-shot leak: only a detached agent persists a registry record; a
+// non-detached (one-shot/legacy) interactive agent must not, while still
+// capturing the session id.
+func TestProcessConvoLine_RegistryGatedByDetached(t *testing.T) {
+	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
+	if err := m.EnableSurviveRestart(t.TempDir()); err != nil {
+		t.Fatalf("EnableSurviveRestart: %v", err)
+	}
+	st := &convoEmitState{}
+
+	// Non-detached one-shot: session captured, NO registry record.
+	a := &Agent{ID: "os1", Mode: "interactive", Provider: "claude"}
+	m.processConvoLine(a, []byte(`{"type":"system","subtype":"init","session_id":"s1"}`), st, true)
+	if a.GetSessionID() != "s1" {
+		t.Fatalf("expected session captured even when not detached, got %q", a.GetSessionID())
+	}
+	if list, _ := m.reg.List(); len(list) != 0 {
+		t.Fatalf("non-detached agent must not write a registry record, got %d", len(list))
+	}
+
+	// Detached survival agent: record written.
+	a2 := &Agent{ID: "d1", Mode: "interactive", Provider: "claude", StartedAt: time.Now().UTC()}
+	a2.setDetached(true)
+	m.processConvoLine(a2, []byte(`{"type":"system","subtype":"init","session_id":"s2"}`), st, false)
+	if list, _ := m.reg.List(); len(list) != 1 {
+		t.Fatalf("detached agent must write a registry record, got %d", len(list))
+	}
+}
+
+func TestConvoResumeState(t *testing.T) {
+	cases := []struct {
+		name   string
+		events []ConvoEvent
+		want   State
+	}{
+		{"empty", nil, StatePaused},
+		{"ended with result", []ConvoEvent{{Type: "assistant"}, {Type: "result"}}, StatePaused},
+		{"mid-generation after result", []ConvoEvent{{Type: "result"}, {Type: "assistant"}}, StateRunning},
+		{"assistant only", []ConvoEvent{{Type: "system"}, {Type: "assistant"}}, StateRunning},
+	}
+	for _, c := range cases {
+		if got := convoResumeState(c.events); got != c.want {
+			t.Errorf("%s: convoResumeState=%v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestRegistryDelete_RemovesFIFO(t *testing.T) {
+	s, err := newRegistryStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("newRegistryStore: %v", err)
+	}
+	if err := s.Save(Record{ID: "f1", Mode: "interactive", Provider: "claude"}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	fifo := s.fifoPath("f1")
+	if err := makeFIFO(fifo); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	if err := s.Delete("f1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := os.Stat(fifo); !os.IsNotExist(err) {
+		t.Fatalf("expected FIFO removed on Delete, stat err=%v", err)
+	}
+}
+
 // TestReattachInteractive_ReattachesLiveAgent reattaches a live detached
 // conversational agent, rehydrates its buffer, reopens its FIFO, streams a
 // late event, and finalizes when the process exits.

--- a/internal/agent/survive_convo_test.go
+++ b/internal/agent/survive_convo_test.go
@@ -1,0 +1,174 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWillDetach(t *testing.T) {
+	cases := []struct {
+		mode     string
+		provider string
+		oneShot  bool
+		want     bool
+	}{
+		{"headless", "claude", false, true},
+		{"headless", "codex", false, true},
+		{"interactive", "claude", false, true},
+		{"interactive", "claude", true, false}, // one-shot stays on pipe path
+		{"interactive", "codex", false, false}, // codex spawns per turn
+		{"interactive", "", false, true},       // empty provider normalizes to claude
+		{"chat", "claude", false, false},       // unknown mode
+	}
+	for _, c := range cases {
+		got := willDetach(RunConfig{Mode: c.mode, OneShot: c.oneShot}, c.provider)
+		if got != c.want {
+			t.Errorf("willDetach(mode=%s provider=%s oneShot=%v)=%v, want %v", c.mode, c.provider, c.oneShot, got, c.want)
+		}
+	}
+}
+
+func TestMakeFIFO_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "x.stdin")
+	if err := makeFIFO(path); err != nil {
+		t.Fatalf("makeFIFO: %v", err)
+	}
+	// Recreate is idempotent (removes stale first).
+	if err := makeFIFO(path); err != nil {
+		t.Fatalf("makeFIFO recreate: %v", err)
+	}
+
+	// O_RDWR never blocks and keeps a writer present.
+	w, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatalf("open rdwr: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+	r, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("open rdonly: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	if _, err := w.WriteString("hello\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, 6)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(buf) != "hello\n" {
+		t.Fatalf("got %q, want %q", string(buf), "hello\n")
+	}
+}
+
+func TestRehydrateConvoFromLog(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "convo.ndjson")
+	complete := `{"type":"system","subtype":"init","session_id":"sess-c"}` + "\n" +
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"hi there"}]}}` + "\n"
+	partial := `{"type":"assistant"` // no newline
+	if err := os.WriteFile(path, []byte(complete+partial), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	a := &Agent{ID: "c", Provider: "claude"}
+	off := rehydrateConvoFromLog(a, path)
+
+	if off != int64(len(complete)) {
+		t.Fatalf("offset=%d, want %d (after last complete line)", off, len(complete))
+	}
+	if a.GetSessionID() != "sess-c" {
+		t.Fatalf("expected session captured, got %q", a.GetSessionID())
+	}
+	if got := a.ConvoOutput(); len(got) != 2 {
+		t.Fatalf("expected 2 rehydrated convo events, got %d", len(got))
+	}
+}
+
+// TestReattachInteractive_ReattachesLiveAgent reattaches a live detached
+// conversational agent, rehydrates its buffer, reopens its FIFO, streams a
+// late event, and finalizes when the process exits.
+func TestReattachInteractive_ReattachesLiveAgent(t *testing.T) {
+	prev := reattachPIDPoll
+	reattachPIDPoll = 50 * time.Millisecond
+	t.Cleanup(func() { reattachPIDPoll = prev })
+
+	logDir := t.TempDir()
+	regDir := t.TempDir()
+	logPath := filepath.Join(logDir, "agents", "ic1.ndjson")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	history := `{"type":"system","subtype":"init","session_id":"sess-ic"}` + "\n" +
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"earlier"}]}}` + "\n"
+	if err := os.WriteFile(logPath, []byte(history), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir)
+	if err := m.EnableSurviveRestart(regDir); err != nil {
+		t.Fatalf("EnableSurviveRestart: %v", err)
+	}
+	var completed atomic.Bool
+	m.SetOnComplete(func(*Agent) { completed.Store(true) })
+
+	// FIFO must exist for the reopen to succeed.
+	fifoPath := m.reg.fifoPath("ic1")
+	if err := makeFIFO(fifoPath); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	// Live helper: append a result line, then exit.
+	result := `{"type":"result","result":"ok","session_id":"sess-ic","total_cost_usd":0.1}`
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("sleep 0.3; printf '%%s\\n' '%s' >> %q", result, logPath))
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	go func() { _ = cmd.Wait() }()
+
+	rec := Record{
+		ID: "ic1", TaskID: "t-ic", Mode: "interactive", Provider: "claude",
+		PID: cmd.Process.Pid, LogPath: logPath, StdinPath: fifoPath,
+		SessionID: "sess-ic", StartedAt: time.Now().UTC(), ProcStartedAt: processStartString(cmd.Process.Pid),
+	}
+	if err := m.reg.Save(rec); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got := m.ReattachAll()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 reattached interactive agent, got %d", len(got))
+	}
+	a, err := m.GetAgent("ic1")
+	if err != nil {
+		t.Fatalf("GetAgent: %v", err)
+	}
+	if len(a.ConvoOutput()) < 2 {
+		t.Fatalf("expected rehydrated convo buffer, got %d events", len(a.ConvoOutput()))
+	}
+	if a.GetStdinPath() != fifoPath {
+		t.Fatalf("expected FIFO path restored, got %q", a.GetStdinPath())
+	}
+
+	deadline := time.After(5 * time.Second)
+	for !completed.Load() {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for reattached interactive agent to complete")
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+	if a.GetState() != StateStopped {
+		t.Fatalf("expected stopped after completion, got %s", a.GetState())
+	}
+	if list, _ := m.reg.List(); len(list) != 0 {
+		t.Fatalf("expected registry empty after completion, got %d", len(list))
+	}
+}


### PR DESCRIPTION
## Motivation

Phase 3 of 3 for restart survival, completing the series. Phases 1–2 (#959, #960) made **headless** agents survive an app restart and resume after a crash. This phase extends true survival to **interactive (conversational) Claude** agents, so a chat/interactive session keeps running across an app restart and reattaches with no interruption — the remaining piece of "all agents survive restart".

## Implementation information

- **FIFO-backed stdin** (`startConvoProcessSurvive`): the conversational `claude` is spawned detached (`exec.Command` + `Setsid`) with stdin a named pipe opened **`O_RDWR`** (so it never sees EOF and survives the parent's death) and stdout redirected to the NDJSON log file. Follow-up messages are written to the FIFO via the existing `writeUserMessage`; a reattaching instance reopens it.
- **Shared state machine**: the conversational per-line logic was extracted into `processConvoLine`, used by both the live `streamConvoOutput` (pipe) and the new `tailConvoFile` (survival, reads the log by offset). Live and reattached paths emit, throttle, queue, and transition identically — no divergence.
- **Reattach** (`reattachInteractive`): rehydrate the convo buffer from the log at the exact resume offset, reopen the FIFO, resume tailing, finalize via the normal completion path. State is restored as Running (mid-generation) or Paused (idle).
- `willDetach` centralizes the detach predicate: headless, or interactive Claude that is not one-shot. **One-shot** convo (signals completion via stdin EOF) and **codex interactive** (spawns per turn) stay on the legacy pipe path.

### Adversarial review

A pre-PR adversarial pass found two blockers, both fixed in the second commit:
1. The shared `saveRegistry` made one-shot interactive workflow steps leak a registry record that reattach mis-recovered into a permanent stall (and suppressed the existing `recoverStaleInteractive`). Fixed: persist only for detached agents; reattach skips record­less-FIFO entries.
2. A detached convo child's `O_RDWR` FIFO stdin can't be EOF'd, so `StopAgent`/`KillAgentsForTask` couldn't kill it — orphaning the process while the worktree was cleaned up under it. Fixed: signal-kill detached agents by PID.

Plus mid-generation reattach state, a FIFO-file leak, and a parent-fd leak (registry `Delete` unlinks the FIFO; `markAgentDone` closes stdin; the survive path closes a prior attempt's FIFO before reopening).

### Known limitation

Permission-gated interactive agents keep working but lose their approval-hook port across restart (the approval server binds a random port). Documented; most interactive/chat agents run skip-permissions.

Tests: FIFO round-trip, `willDetach`, convo rehydrate/offset, live interactive reattach end-to-end, registry-gated-by-detached, `convoResumeState`, FIFO unlink on delete. `go test -race`, golangci-lint, nilaway all clean.

## Supporting documentation

Completes the survive-restart series: #956 (Phase 1, #959), #957 (Phase 2, #960), this issue (Phase 3).

Closes #958

> Changelog: feat(agent): interactive agents survive restart