### PR TITLE
fix(monitor): grace period for recent agent runs

### DIFF
--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -232,6 +232,7 @@ func detectLostAgents(in DetectInput) []Anomaly {
 	if in.Cfg.LostAgentMinutes <= 0 {
 		return nil
 	}
+	window := time.Duration(in.Cfg.LostAgentMinutes) * time.Minute
 	live := liveTaskIDs(in.LiveAgents)
 	active := tasksWithRecentAgentEvents(in.Events15m)
 	var out []Anomaly
@@ -247,6 +248,13 @@ func detectLostAgents(in DetectInput) []Anomaly {
 			continue
 		}
 		if active[t.ID] || live[t.ID] {
+			continue
+		}
+		// Skip if any running agent run started within the window. A freshly
+		// dispatched agent may not yet appear in the live list or have written
+		// its first audit event (e.g. during app restart recovery), so we wait
+		// at least one full window before declaring it lost.
+		if recentRunningRun(t.AgentRuns, in.Now, window) {
 			continue
 		}
 		ev := map[string]any{
@@ -265,6 +273,17 @@ func detectLostAgents(in DetectInput) []Anomaly {
 		})
 	}
 	return out
+}
+
+// recentRunningRun reports whether any agent run in state "running" started
+// within d of now.
+func recentRunningRun(runs []task.AgentRun, now time.Time, d time.Duration) bool {
+	for i := range runs {
+		if runs[i].State == "running" && now.Sub(runs[i].StartedAt) < d {
+			return true
+		}
+	}
+	return false
 }
 
 func detectFromAudit(in DetectInput) []Anomaly {

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -226,6 +226,34 @@ func TestDetect(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "lost_agent suppressed when running run started recently",
+			in: DetectInput{
+				Now: now,
+				Tasks: []task.Task{mkTask("a", task.StatusInProgress, func(t *task.Task) {
+					t.AgentRuns = []task.AgentRun{
+						{AgentID: "x", State: "running", StartedAt: now.Add(-2 * time.Minute)},
+					}
+				})},
+				LiveAgents: []liveAgent{},
+				Cfg:        cfg,
+			},
+			want: nil,
+		},
+		{
+			name: "lost_agent fires when running run started outside window",
+			in: DetectInput{
+				Now: now,
+				Tasks: []task.Task{mkTask("a", task.StatusInProgress, func(t *task.Task) {
+					t.AgentRuns = []task.AgentRun{
+						{AgentID: "x", State: "running", StartedAt: now.Add(-20 * time.Minute)},
+					}
+				})},
+				LiveAgents: []liveAgent{},
+				Cfg:        cfg,
+			},
+			want: []AnomalyKind{KindLostAgent},
+		},
+		{
 			name: "failure_spike when failure_rate > threshold",
 			in: DetectInput{
 				Now: now,


### PR DESCRIPTION
## Motivation

The `lost_agent` detector was firing false positives for tasks whose agent had just been dispatched. A freshly started agent may not yet appear in the live agent list or have written its first audit event — especially after an app restart recovery — causing the monitor to incorrectly reset the task to `todo`.

## Implementation information

Added a `recentRunningRun` helper that checks whether any agent run on a task has `state == "running"` and `started_at` within the `LostAgentMinutes` window. If so, `detectLostAgents` skips that task entirely, giving the agent at least one full detection window to register before it can be declared lost.

Two test cases added: one that suppresses detection when the run started recently, one that fires when the run started outside the window.

> Changelog: fix(monitor): grace period for recent agent runs