### PR TITLE
feat(agent): complete Claude interactive survival

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -63,6 +63,15 @@ export class AgentDefaults {
      */
     "surviveRestart": boolean | null;
 
+    /**
+     * ApprovalPort pins the localhost port of the PreToolUse approval
+     * server. The hook URL is baked into a permission-gated agent's
+     * --settings at spawn, so a fixed port lets a detached agent's approval
+     * requests still resolve after a restart. 0 (default) binds a random
+     * port (no cross-restart approval survival).
+     */
+    "approvalPort": number;
+
     /** Creates a new AgentDefaults instance. */
     constructor($$source: Partial<AgentDefaults> = {}) {
         if (!("provider" in $$source)) {
@@ -106,6 +115,9 @@ export class AgentDefaults {
         }
         if (!("surviveRestart" in $$source)) {
             this["surviveRestart"] = null;
+        }
+        if (!("approvalPort" in $$source)) {
+            this["approvalPort"] = 0;
         }
 
         Object.assign(this, $$source);

--- a/internal/agent/approval_server.go
+++ b/internal/agent/approval_server.go
@@ -27,9 +27,21 @@ type ApprovalServer struct {
 	agents   *Manager
 }
 
-// NewApprovalServer creates and starts the approval HTTP server on a random port.
-func NewApprovalServer(emit EmitFunc, logger *slog.Logger) (*ApprovalServer, error) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+// NewApprovalServer creates and starts the approval HTTP server. port pins
+// the localhost port (so a detached agent's baked approval-hook URL still
+// resolves after a restart); 0 binds a random port. A pinned port that is
+// already taken falls back to a random port with a warning rather than
+// failing startup.
+func NewApprovalServer(emit EmitFunc, logger *slog.Logger, port int) (*ApprovalServer, error) {
+	addr := "127.0.0.1:0"
+	if port > 0 {
+		addr = fmt.Sprintf("127.0.0.1:%d", port)
+	}
+	listener, err := net.Listen("tcp", addr)
+	if err != nil && port > 0 {
+		logger.Warn("approval-server.port-taken", "port", port, "err", err, "fallback", "random")
+		listener, err = net.Listen("tcp", "127.0.0.1:0")
+	}
 	if err != nil {
 		return nil, fmt.Errorf("listen: %w", err)
 	}

--- a/internal/agent/approval_server_test.go
+++ b/internal/agent/approval_server_test.go
@@ -4,16 +4,49 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 )
 
+// TestNewApprovalServer_PinnedPort verifies the approval server binds the
+// configured port (so a detached agent's baked hook URL survives restart),
+// and that 0 binds a random port.
+func TestNewApprovalServer_PinnedPort(t *testing.T) {
+	// Find a currently-free port.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close()
+
+	srv, err := NewApprovalServer(func(_ string, _ any) {}, discardLogger(), port)
+	if err != nil {
+		t.Fatalf("NewApprovalServer pinned: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
+	if !strings.HasSuffix(srv.Addr(), ":"+strconv.Itoa(port)) {
+		t.Fatalf("addr %q does not use pinned port %d", srv.Addr(), port)
+	}
+
+	rnd, err := NewApprovalServer(func(_ string, _ any) {}, discardLogger(), 0)
+	if err != nil {
+		t.Fatalf("NewApprovalServer random: %v", err)
+	}
+	t.Cleanup(func() { _ = rnd.Shutdown(context.Background()) })
+	if rnd.Addr() == "" {
+		t.Fatal("random-port server has empty addr")
+	}
+}
+
 func newTestApprovalServer(t *testing.T) *ApprovalServer {
 	t.Helper()
-	srv, err := NewApprovalServer(func(_ string, _ any) {}, discardLogger())
+	srv, err := NewApprovalServer(func(_ string, _ any) {}, discardLogger(), 0)
 	if err != nil {
 		t.Fatalf("NewApprovalServer: %v", err)
 	}
@@ -113,7 +146,7 @@ func TestApprovalServer_CanceledContext(t *testing.T) {
 	mgr.agents["fake-ag-cancel"] = fakeAgent
 	mgr.mu.Unlock()
 
-	srv, err := NewApprovalServer(func(_ string, _ any) {}, discardLogger())
+	srv, err := NewApprovalServer(func(_ string, _ any) {}, discardLogger(), 0)
 	if err != nil {
 		t.Fatalf("NewApprovalServer: %v", err)
 	}
@@ -187,7 +220,7 @@ func TestApprovalServer_ApprovalFlow_Approve(t *testing.T) {
 	mgr.agents["fake-ag-1"] = fakeAgent
 	mgr.mu.Unlock()
 
-	srv, err := NewApprovalServer(func(_ string, _ any) {}, discardLogger())
+	srv, err := NewApprovalServer(func(_ string, _ any) {}, discardLogger(), 0)
 	if err != nil {
 		t.Fatalf("NewApprovalServer: %v", err)
 	}
@@ -225,7 +258,7 @@ func TestApprovalServer_ApprovalFlow_Deny(t *testing.T) {
 	mgr.agents["fake-ag-2"] = fakeAgent
 	mgr.mu.Unlock()
 
-	srv, err := NewApprovalServer(func(_ string, _ any) {}, discardLogger())
+	srv, err := NewApprovalServer(func(_ string, _ any) {}, discardLogger(), 0)
 	if err != nil {
 		t.Fatalf("NewApprovalServer: %v", err)
 	}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -110,9 +110,9 @@ func (m *Manager) survives() bool {
 
 // willDetach reports whether a run with this config/provider takes the
 // detached survival path: all headless runs, and interactive Claude runs
-// (one-shot included — it uses a file-backed stdin for natural EOF). Codex
-// interactive (spawns per turn) stays on the legacy pipe path. Single
-// source of truth mirrored by the runner branches.
+// (one-shot included — its prompt is passed as an argument, no stdin).
+// Codex interactive (spawns per turn) stays on the legacy pipe path.
+// Single source of truth mirrored by the runner branches.
 func willDetach(cfg RunConfig, prov string) bool {
 	switch cfg.Mode {
 	case "headless":

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -110,15 +110,15 @@ func (m *Manager) survives() bool {
 
 // willDetach reports whether a run with this config/provider takes the
 // detached survival path: all headless runs, and interactive Claude runs
-// that are not one-shot. Codex interactive (spawns per turn) and one-shot
-// convo (signals completion via stdin EOF) stay on the legacy pipe path.
-// Single source of truth mirrored by the runner branches.
+// (one-shot included — it uses a file-backed stdin for natural EOF). Codex
+// interactive (spawns per turn) stays on the legacy pipe path. Single
+// source of truth mirrored by the runner branches.
 func willDetach(cfg RunConfig, prov string) bool {
 	switch cfg.Mode {
 	case "headless":
 		return true
 	case "interactive":
-		return normalizeProvider(prov) != "codex" && !cfg.OneShot
+		return normalizeProvider(prov) != "codex"
 	default:
 		return false
 	}

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -74,8 +74,8 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 	// Pre-mark detached so a shutdown racing the runner goroutine already
 	// knows to leave this agent's subprocess running. The runner re-asserts
 	// it after a successful Start. Detached applies to headless and to
-	// interactive Claude (non-one-shot, FIFO-backed) survival; codex
-	// interactive (spawns per turn) and one-shot stay on the legacy path.
+	// interactive Claude (one-shot via file-arg prompt, sessions via FIFO);
+	// codex interactive (spawns per turn) stays on the legacy path.
 	if m.survives() && willDetach(cfg, a.Provider) {
 		a.setDetached(true)
 	}

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -460,6 +460,20 @@ func (a *Agent) hasTerminalResult() bool {
 	return false
 }
 
+// hasTerminalConvoResult is hasTerminalResult for the conversational buffer:
+// reports whether a non-error result event was seen, so a reattached convo
+// agent that vanished mid-turn is not finalized as success.
+func (a *Agent) hasTerminalConvoResult() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for i := range a.convoBuffer {
+		if a.convoBuffer[i].Type == "result" && a.convoBuffer[i].Subtype != "error" {
+			return true
+		}
+	}
+	return false
+}
+
 // GetLastEventAt returns the most recent event timestamp.
 func (a *Agent) GetLastEventAt() time.Time {
 	a.mu.RLock()

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"os/exec"
+	"slices"
 	"sync"
 	"time"
 )
@@ -460,18 +461,19 @@ func (a *Agent) hasTerminalResult() bool {
 	return false
 }
 
-// hasTerminalConvoResult is hasTerminalResult for the conversational buffer:
-// reports whether a non-error result event was seen, so a reattached convo
-// agent that vanished mid-turn is not finalized as success.
-func (a *Agent) hasTerminalConvoResult() bool {
+// lastConvoResult reports whether a terminal result event was observed in
+// the conversational buffer and whether that result was an error, scanning
+// newest-first. Used by reattach completion to tell a clean finish from an
+// error completion from a process that vanished mid-turn.
+func (a *Agent) lastConvoResult() (found, isError bool) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
-	for i := range a.convoBuffer {
-		if a.convoBuffer[i].Type == "result" && a.convoBuffer[i].Subtype != "error" {
-			return true
+	for i := range slices.Backward(a.convoBuffer) {
+		if a.convoBuffer[i].Type == "result" {
+			return true, a.convoBuffer[i].Subtype == "error"
 		}
 	}
-	return false
+	return false, false
 }
 
 // GetLastEventAt returns the most recent event timestamp.

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -19,6 +19,11 @@ import (
 // handler stalls the workflow instead of advancing it on partial work.
 var errReattachedGone = errors.New("agent: reattached process exited without result")
 
+// errReattachedResultError marks a reattached agent that completed with an
+// error result while the app was down — a real failure outcome (distinct
+// from a crash with no result), so the workflow advances as failed.
+var errReattachedResultError = errors.New("agent: reattached run completed with an error result")
+
 // reattachPIDPoll is how often a reattached agent's PID is checked for
 // liveness (there is no *exec.Cmd to Wait on). Var, not const, so tests
 // can shorten it.
@@ -168,8 +173,8 @@ func (m *Manager) reattachInteractive(r Record, reg *registryStore) *Agent {
 		return nil
 	}
 
-	// A record with no FIFO path is a one-shot survival agent (file-backed
-	// stdin, already consumed): reattach tail-only, no FIFO to reopen.
+	// A record with no FIFO path is a one-shot survival agent (prompt passed
+	// as an argument, no stdin): reattach tail-only, no FIFO to reopen.
 	oneShot := r.StdinPath == ""
 
 	a := agentFromRecord(r)

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -162,17 +162,15 @@ func (m *Manager) persistDeadSession(r Record) (done bool) {
 // Returns the reattached agent, or nil when the process is gone or a
 // duplicate already exists.
 func (m *Manager) reattachInteractive(r Record, reg *registryStore) *Agent {
-	// A record without a FIFO path is not a detached survival agent (e.g. a
-	// leaked one-shot record); never reattach it as a live session.
-	if r.StdinPath == "" {
-		_ = reg.Delete(r.ID)
-		return nil
-	}
 	if !reattachAlive(r) {
 		_ = reg.Delete(r.ID)
 		m.logger.Info("agent.reattach.dead", "id", r.ID, "pid", r.PID, "task", r.TaskID, "mode", "interactive")
 		return nil
 	}
+
+	// A record with no FIFO path is a one-shot survival agent (file-backed
+	// stdin, already consumed): reattach tail-only, no FIFO to reopen.
+	oneShot := r.StdinPath == ""
 
 	a := agentFromRecord(r)
 	var startOffset int64
@@ -198,8 +196,8 @@ func (m *Manager) reattachInteractive(r Record, reg *registryStore) *Agent {
 	m.liveCount++
 	m.mu.Unlock()
 
-	m.logger.Info("agent.reattach", "id", a.ID, "pid", a.PID, "task", a.TaskID, "mode", "interactive", "events", len(a.ConvoOutput()))
-	go m.reattachConvo(ctx, a, startOffset, r.ProcStartedAt)
+	m.logger.Info("agent.reattach", "id", a.ID, "pid", a.PID, "task", a.TaskID, "mode", "interactive", "oneshot", oneShot, "events", len(a.ConvoOutput()))
+	go m.reattachConvo(ctx, a, startOffset, r.ProcStartedAt, oneShot)
 	m.emit(events.AgentState(a.ID), a)
 	return a
 }

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -63,12 +63,35 @@ func claudeEventToConvoEvent(e ClaudeEvent) ConvoEvent {
 const convoEmitInterval = 50 * time.Millisecond
 
 func (m *Manager) buildConvoArgs(a *Agent, cfg RunConfig) []string {
+	// Interactive session: messages arrive on stdin as stream-json.
 	args := []string{
 		"-p",
 		"--input-format", "stream-json",
 		"--output-format", "stream-json",
 		"--verbose",
 	}
+	return append(args, m.convoCommonArgs(a, cfg)...)
+}
+
+// buildOneShotConvoArgs builds args for a single detached conversational
+// turn: the prompt is passed as an argument (no stdin), so the process needs
+// no FIFO, reads nothing from stdin, runs the one turn, and exits — which
+// makes it survive a restart while still emitting the same stream-json the
+// convo parser consumes. (A regular-file stdin does NOT work: claude only
+// reads stream-json from a pipe, not a regular file.)
+func (m *Manager) buildOneShotConvoArgs(a *Agent, cfg RunConfig) []string {
+	args := []string{
+		"-p", cfg.Prompt,
+		"--output-format", "stream-json",
+		"--verbose",
+	}
+	return append(args, m.convoCommonArgs(a, cfg)...)
+}
+
+// convoCommonArgs returns the resume/permission/model/approval-hook flags
+// shared by the interactive and one-shot conversational invocations.
+func (m *Manager) convoCommonArgs(a *Agent, cfg RunConfig) []string {
+	args := make([]string, 0, 8)
 	if sid := a.GetSessionID(); sid != "" {
 		args = append(args, "--resume", sid)
 	}

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -213,8 +213,8 @@ func (m *Manager) runConvoAttempt(ctx context.Context, a *Agent, cfg RunConfig, 
 	}
 	// Detached survival for interactive Claude agents (this path is only
 	// reached for Claude; codex uses runCodexConversational). A one-shot run
-	// uses a file-backed stdin (natural EOF after its single message);
-	// interactive sessions use a never-EOF FIFO for follow-ups.
+	// passes its prompt as an argument (no stdin); interactive sessions use a
+	// never-EOF FIFO for follow-ups.
 	if m.survives() {
 		if cfg.OneShot {
 			return m.runConvoAttemptSurviveOneShot(ctx, a, cfg, outFile, tailOffset)

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -188,10 +188,14 @@ func (m *Manager) runConvoAttempt(ctx context.Context, a *Agent, cfg RunConfig, 
 	if outFile == nil {
 		return false, nil
 	}
-	// Detached survival applies to interactive (non-one-shot) Claude agents.
-	// One-shot runs must keep the pipe path: they signal completion by
-	// closing stdin to send EOF, which a never-EOF survival FIFO cannot do.
-	if m.survives() && !cfg.OneShot {
+	// Detached survival for interactive Claude agents (this path is only
+	// reached for Claude; codex uses runCodexConversational). A one-shot run
+	// uses a file-backed stdin (natural EOF after its single message);
+	// interactive sessions use a never-EOF FIFO for follow-ups.
+	if m.survives() {
+		if cfg.OneShot {
+			return m.runConvoAttemptSurviveOneShot(ctx, a, cfg, outFile, tailOffset)
+		}
 		return m.runConvoAttemptSurvive(ctx, a, cfg, outFile, tailOffset)
 	}
 	cmd, stdout, stderrBuf, startErr := m.startConvoProcess(ctx, a, cfg)
@@ -369,8 +373,9 @@ func (m *Manager) processConvoLine(a *Agent, line []byte, st *convoEmitState, on
 	}
 }
 
-// writeUserMessage writes a user message to the agent's stdin in stream-json format.
-func (m *Manager) writeUserMessage(a *Agent, text string) error {
+// encodeUserMessage renders a user message as a newline-terminated
+// stream-json line for claude's stdin.
+func encodeUserMessage(text string) ([]byte, error) {
 	msg := map[string]any{
 		"type": "user",
 		"message": map[string]any{
@@ -380,9 +385,17 @@ func (m *Manager) writeUserMessage(a *Agent, text string) error {
 	}
 	data, err := json.Marshal(msg)
 	if err != nil {
-		return fmt.Errorf("marshal message: %w", err)
+		return nil, fmt.Errorf("marshal message: %w", err)
 	}
-	data = append(data, '\n')
+	return append(data, '\n'), nil
+}
+
+// writeUserMessage writes a user message to the agent's stdin in stream-json format.
+func (m *Manager) writeUserMessage(a *Agent, text string) error {
+	data, err := encodeUserMessage(text)
+	if err != nil {
+		return err
+	}
 
 	a.stdinMu.Lock()
 	defer a.stdinMu.Unlock()

--- a/internal/agent/runner_convo_survive.go
+++ b/internal/agent/runner_convo_survive.go
@@ -180,6 +180,135 @@ func (m *Manager) runConvoAttemptSurvive(ctx context.Context, a *Agent, cfg RunC
 	return false, nil
 }
 
+// runConvoAttemptSurvive_oneShotInput writes a single user message to a
+// regular file and returns an O_RDONLY handle to it. A regular file gives
+// the child a natural EOF after its one message (so a one-shot turn runs
+// then exits) and survives the parent's death (no pipe to break). The
+// record's StdinPath is left empty, which is how reattach recognizes a
+// one-shot agent (tail-only, no FIFO to reopen).
+func (m *Manager) oneShotStdinFile(a *Agent, prompt string) (*os.File, error) {
+	reg := m.registry()
+	if reg == nil {
+		return nil, fmt.Errorf("survive convo: registry not enabled")
+	}
+	path := reg.fifoPath(a.ID) // a plain file here, cleaned up by reg.Delete
+	var data []byte
+	if prompt != "" {
+		enc, err := encodeUserMessage(prompt)
+		if err != nil {
+			return nil, err
+		}
+		data = enc
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return nil, fmt.Errorf("write oneshot stdin: %w", err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open oneshot stdin: %w", err)
+	}
+	return f, nil
+}
+
+// runConvoAttemptSurviveOneShot runs a detached one-shot conversational
+// turn: feed the single message via a file stdin (natural EOF), stream
+// output to the log file, and tail until the turn completes and the process
+// exits — so an interrupted one-shot step finishes across a restart instead
+// of faking completion via stale recovery.
+func (m *Manager) runConvoAttemptSurviveOneShot(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File, tailOffset *int64) (retry bool, err error) {
+	args := m.buildConvoArgs(a, cfg)
+	cmd := exec.Command("claude", args...)
+	configureDetached(cmd)
+	if a.sessionCWD != "" {
+		cmd.Dir = a.sessionCWD
+	}
+	if len(cfg.ExtraEnv) > 0 {
+		cmd.Env = append(os.Environ(), cfg.ExtraEnv...)
+	}
+
+	inFile, inErr := m.oneShotStdinFile(a, cfg.Prompt)
+	if inErr != nil {
+		return false, inErr
+	}
+	defer func() { _ = inFile.Close() }() // child keeps its own dup after Start
+	cmd.Stdin = inFile
+
+	if *outFile == nil {
+		f, fileErr := logging.NewAgentOutputFile(m.logDir, a.ID)
+		if fileErr != nil {
+			return false, fmt.Errorf("open agent log: %w", fileErr)
+		}
+		a.SetLogPath(f.Name())
+		*outFile = f
+	}
+	cmd.Stdout = *outFile
+
+	stderrPath := (*outFile).Name() + ".stderr"
+	if stderrF, sErr := os.OpenFile(stderrPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644); sErr == nil {
+		cmd.Stderr = stderrF
+		defer func() { _ = stderrF.Close() }()
+	}
+
+	if startErr := cmd.Start(); startErr != nil {
+		return false, fmt.Errorf("start claude: %w", startErr)
+	}
+	a.SetCmd(cmd)
+	a.setDetached(true)
+	// StdinPath intentionally left unset: reattach treats a record with no
+	// StdinPath as a one-shot (tail-only) agent.
+	m.saveRegistry(a)
+	m.logger.Info("agent.convo.start", "id", a.ID, "pid", cmd.Process.Pid, "dir", cmd.Dir, "detached", true, "oneshot", true)
+
+	procDone := make(chan struct{})
+	var waitErr error
+	go func() {
+		waitErr = cmd.Wait()
+		close(procDone)
+	}()
+
+	prevLen := len(a.ConvoOutput())
+	startOffset := int64(0)
+	if tailOffset != nil {
+		startOffset = *tailOffset
+	}
+	exited, endOffset := m.tailConvoFile(ctx, a, (*outFile).Name(), startOffset, true, procDone)
+	if tailOffset != nil {
+		*tailOffset = endOffset
+	}
+	if !exited {
+		m.logger.Info("agent.convo.detach", "id", a.ID, "pid", a.GetPID(), "reason", "shutdown", "oneshot", true)
+		return false, errSurviveShutdown
+	}
+
+	select {
+	case <-procDone:
+	default:
+		return false, nil
+	}
+
+	var stderrOut string
+	if b, readErr := os.ReadFile(stderrPath); readErr == nil {
+		stderrOut = string(b)
+	}
+	if stderrOut != "" {
+		m.logger.Error("agent.convo.stderr", "id", a.ID, "stderr", stderrOut)
+	}
+	if waitErr != nil {
+		m.logger.Error("agent.convo.exit", "id", a.ID, "err", waitErr)
+		a.SetExitErr(waitErr)
+		all := a.ConvoOutput()
+		if prevLen > len(all) {
+			prevLen = len(all)
+		}
+		attemptEvents := all[prevLen:]
+		if shouldRetryConvo(stderrOut, attemptEvents, m.logger) {
+			return true, nil
+		}
+		m.reportProviderHealthSignalConvo(a, stderrOut, attemptEvents)
+	}
+	return false, nil
+}
+
 // tailConvoFile follows a detached/reattached conversational agent's log
 // file from startOffset, feeding each complete line through
 // processConvoLine. Semantics mirror tailHeadlessFile: exited=true when the
@@ -298,21 +427,25 @@ func rehydrateConvoFromLog(a *Agent, path string) int64 {
 // reattachConvo resumes a live detached conversational agent: reopen its
 // stdin FIFO so follow-ups still reach the child, then tail its log until it
 // exits or the app shuts down.
-func (m *Manager) reattachConvo(ctx context.Context, a *Agent, startOffset int64, procStart string) {
-	if sp := a.GetStdinPath(); sp != "" {
-		if fifo, err := os.OpenFile(sp, os.O_RDWR, 0); err == nil {
-			a.stdinMu.Lock()
-			a.stdinPipe = fifo
-			a.stdinMu.Unlock()
-		} else {
-			m.logger.Warn("agent.reattach.fifo", "id", a.ID, "path", sp, "err", err)
+func (m *Manager) reattachConvo(ctx context.Context, a *Agent, startOffset int64, procStart string, oneShot bool) {
+	// A one-shot agent's stdin (a regular file) was already consumed; only an
+	// interactive session needs its FIFO reopened for follow-ups.
+	if !oneShot {
+		if sp := a.GetStdinPath(); sp != "" {
+			if fifo, err := os.OpenFile(sp, os.O_RDWR, 0); err == nil {
+				a.stdinMu.Lock()
+				a.stdinPipe = fifo
+				a.stdinMu.Unlock()
+			} else {
+				m.logger.Warn("agent.reattach.fifo", "id", a.ID, "path", sp, "err", err)
+			}
 		}
 	}
 
 	procDone := make(chan struct{})
 	go watchPID(ctx, a.GetPID(), procStart, procDone)
 
-	exited, _ := m.tailConvoFile(ctx, a, a.GetLogPath(), startOffset, false, procDone)
+	exited, _ := m.tailConvoFile(ctx, a, a.GetLogPath(), startOffset, oneShot, procDone)
 	if !exited {
 		m.logger.Info("agent.reattach.detach", "id", a.ID, "pid", a.GetPID(), "reason", "shutdown")
 		return

--- a/internal/agent/runner_convo_survive.go
+++ b/internal/agent/runner_convo_survive.go
@@ -180,43 +180,15 @@ func (m *Manager) runConvoAttemptSurvive(ctx context.Context, a *Agent, cfg RunC
 	return false, nil
 }
 
-// runConvoAttemptSurvive_oneShotInput writes a single user message to a
-// regular file and returns an O_RDONLY handle to it. A regular file gives
-// the child a natural EOF after its one message (so a one-shot turn runs
-// then exits) and survives the parent's death (no pipe to break). The
-// record's StdinPath is left empty, which is how reattach recognizes a
-// one-shot agent (tail-only, no FIFO to reopen).
-func (m *Manager) oneShotStdinFile(a *Agent, prompt string) (*os.File, error) {
-	reg := m.registry()
-	if reg == nil {
-		return nil, fmt.Errorf("survive convo: registry not enabled")
-	}
-	path := reg.fifoPath(a.ID) // a plain file here, cleaned up by reg.Delete
-	var data []byte
-	if prompt != "" {
-		enc, err := encodeUserMessage(prompt)
-		if err != nil {
-			return nil, err
-		}
-		data = enc
-	}
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		return nil, fmt.Errorf("write oneshot stdin: %w", err)
-	}
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("open oneshot stdin: %w", err)
-	}
-	return f, nil
-}
-
 // runConvoAttemptSurviveOneShot runs a detached one-shot conversational
-// turn: feed the single message via a file stdin (natural EOF), stream
-// output to the log file, and tail until the turn completes and the process
-// exits — so an interrupted one-shot step finishes across a restart instead
-// of faking completion via stale recovery.
+// turn: the prompt is passed as a CLI argument (no stdin), output is
+// streamed to the log file, and the tailer follows it until the turn
+// completes and the process exits — so an interrupted one-shot step
+// finishes across a restart instead of faking completion via stale
+// recovery. No FIFO is created, so the registry record's StdinPath stays
+// empty, which is how reattach recognizes a one-shot (tail-only).
 func (m *Manager) runConvoAttemptSurviveOneShot(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File, tailOffset *int64) (retry bool, err error) {
-	args := m.buildConvoArgs(a, cfg)
+	args := m.buildOneShotConvoArgs(a, cfg)
 	cmd := exec.Command("claude", args...)
 	configureDetached(cmd)
 	if a.sessionCWD != "" {
@@ -225,13 +197,8 @@ func (m *Manager) runConvoAttemptSurviveOneShot(ctx context.Context, a *Agent, c
 	if len(cfg.ExtraEnv) > 0 {
 		cmd.Env = append(os.Environ(), cfg.ExtraEnv...)
 	}
-
-	inFile, inErr := m.oneShotStdinFile(a, cfg.Prompt)
-	if inErr != nil {
-		return false, inErr
-	}
-	defer func() { _ = inFile.Close() }() // child keeps its own dup after Start
-	cmd.Stdin = inFile
+	// No stdin: the prompt is an argument; a nil Stdin reads from /dev/null,
+	// which claude -p <prompt> never touches.
 
 	if *outFile == nil {
 		f, fileErr := logging.NewAgentOutputFile(m.logDir, a.ID)
@@ -451,6 +418,12 @@ func (m *Manager) reattachConvo(ctx context.Context, a *Agent, startOffset int64
 		return
 	}
 
+	// No cmd.Wait runs for a reattached agent, so GetExitErr is nil. A turn
+	// that vanished without a terminal result is a crash — mark it so the
+	// completion handler stalls instead of advancing on partial work.
+	if !a.hasTerminalConvoResult() {
+		a.SetExitErr(errReattachedGone)
+	}
 	a.SetState(StateStopped)
 	m.logger.Info("agent.reattach.convo.done", "id", a.ID, "cost", a.GetCostUSD())
 	m.emit(events.AgentState(a.ID), a)

--- a/internal/agent/runner_convo_survive.go
+++ b/internal/agent/runner_convo_survive.go
@@ -418,11 +418,13 @@ func (m *Manager) reattachConvo(ctx context.Context, a *Agent, startOffset int64
 		return
 	}
 
-	// No cmd.Wait runs for a reattached agent, so GetExitErr is nil. A turn
-	// that vanished without a terminal result is a crash — mark it so the
-	// completion handler stalls instead of advancing on partial work.
-	if !a.hasTerminalConvoResult() {
+	// No cmd.Wait runs for a reattached agent, so GetExitErr is nil. Infer
+	// the outcome from the terminal result: none -> crash (errReattachedGone);
+	// an error result -> a real failure; a success result -> leave nil.
+	if found, isError := a.lastConvoResult(); !found {
 		a.SetExitErr(errReattachedGone)
+	} else if isError {
+		a.SetExitErr(errReattachedResultError)
 	}
 	a.SetState(StateStopped)
 	m.logger.Info("agent.reattach.convo.done", "id", a.ID, "cost", a.GetCostUSD())

--- a/internal/agent/survive_convo_test.go
+++ b/internal/agent/survive_convo_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -34,6 +35,37 @@ func TestWillDetach(t *testing.T) {
 		if got != c.want {
 			t.Errorf("willDetach(mode=%s provider=%s oneShot=%v)=%v, want %v", c.mode, c.provider, c.oneShot, got, c.want)
 		}
+	}
+}
+
+// TestBuildOneShotConvoArgs verifies a one-shot survival turn passes the
+// prompt as an argument with NO --input-format — claude only reads
+// stream-json from a pipe, not a regular file, so one-shot survival must
+// feed the prompt via argv, not stdin.
+func TestBuildOneShotConvoArgs(t *testing.T) {
+	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
+	a := &Agent{ID: "x", Provider: "claude", Model: "sonnet"}
+	args := m.buildOneShotConvoArgs(a, RunConfig{Prompt: "do the thing", RequirePermissions: false})
+
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "--input-format") {
+		t.Fatalf("one-shot must not use --input-format (stdin stream-json): %q", joined)
+	}
+	// The prompt must be the argument immediately after -p.
+	found := false
+	for i := range len(args) - 1 {
+		if args[i] == "-p" {
+			if args[i+1] != "do the thing" {
+				t.Fatalf("expected prompt as arg after -p, got %q", args[i+1])
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected -p <prompt> in args: %q", joined)
+	}
+	if !strings.Contains(joined, "--output-format stream-json") {
+		t.Fatalf("expected stream-json output: %q", joined)
 	}
 }
 

--- a/internal/agent/survive_convo_test.go
+++ b/internal/agent/survive_convo_test.go
@@ -23,8 +23,9 @@ func TestWillDetach(t *testing.T) {
 		{"headless", "claude", false, true},
 		{"headless", "codex", false, true},
 		{"interactive", "claude", false, true},
-		{"interactive", "claude", true, false}, // one-shot stays on pipe path
+		{"interactive", "claude", true, true},  // one-shot now survives via file stdin
 		{"interactive", "codex", false, false}, // codex spawns per turn
+		{"interactive", "codex", true, false},  // codex one-shot also legacy
 		{"interactive", "", false, true},       // empty provider normalizes to claude
 		{"chat", "claude", false, false},       // unknown mode
 	}
@@ -157,6 +158,71 @@ func TestRegistryDelete_RemovesFIFO(t *testing.T) {
 	}
 	if _, err := os.Stat(fifo); !os.IsNotExist(err) {
 		t.Fatalf("expected FIFO removed on Delete, stat err=%v", err)
+	}
+}
+
+// TestReattachInteractive_OneShotTailOnly verifies a one-shot survival
+// record (no FIFO / empty StdinPath) reattaches tail-only and finalizes
+// when its single turn completes — no FIFO reopen required.
+func TestReattachInteractive_OneShotTailOnly(t *testing.T) {
+	prev := reattachPIDPoll
+	reattachPIDPoll = 50 * time.Millisecond
+	t.Cleanup(func() { reattachPIDPoll = prev })
+
+	logDir := t.TempDir()
+	regDir := t.TempDir()
+	logPath := filepath.Join(logDir, "agents", "os9.ndjson")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	history := `{"type":"system","subtype":"init","session_id":"sess-os"}` + "\n" +
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"working"}]}}` + "\n"
+	if err := os.WriteFile(logPath, []byte(history), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir)
+	if err := m.EnableSurviveRestart(regDir); err != nil {
+		t.Fatalf("EnableSurviveRestart: %v", err)
+	}
+	var completed atomic.Bool
+	m.SetOnComplete(func(*Agent) { completed.Store(true) })
+
+	result := `{"type":"result","result":"done","session_id":"sess-os","total_cost_usd":0.1}`
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("sleep 0.3; printf '%%s\\n' '%s' >> %q", result, logPath))
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	go func() { _ = cmd.Wait() }()
+
+	// One-shot survival record: StdinPath intentionally empty.
+	rec := Record{
+		ID: "os9", TaskID: "t-os", Mode: "interactive", Provider: "claude",
+		PID: cmd.Process.Pid, LogPath: logPath, StdinPath: "",
+		SessionID: "sess-os", StartedAt: time.Now().UTC(), ProcStartedAt: processStartString(cmd.Process.Pid),
+	}
+	if err := m.reg.Save(rec); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got := m.ReattachAll()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 reattached one-shot agent, got %d", len(got))
+	}
+	if _, err := m.GetAgent("os9"); err != nil {
+		t.Fatalf("GetAgent: %v", err)
+	}
+
+	deadline := time.After(5 * time.Second)
+	for !completed.Load() {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for one-shot reattach to complete")
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+	if list, _ := m.reg.List(); len(list) != 0 {
+		t.Fatalf("expected registry empty after completion, got %d", len(list))
 	}
 }
 

--- a/internal/agent/survive_convo_test.go
+++ b/internal/agent/survive_convo_test.go
@@ -24,7 +24,7 @@ func TestWillDetach(t *testing.T) {
 		{"headless", "claude", false, true},
 		{"headless", "codex", false, true},
 		{"interactive", "claude", false, true},
-		{"interactive", "claude", true, true},  // one-shot now survives via file stdin
+		{"interactive", "claude", true, true},  // one-shot survives via prompt arg
 		{"interactive", "codex", false, false}, // codex spawns per turn
 		{"interactive", "codex", true, false},  // codex one-shot also legacy
 		{"interactive", "", false, true},       // empty provider normalizes to claude

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,6 +91,12 @@ type AgentDefaults struct {
 	// true). Set false to revert to the legacy behaviour where agents are
 	// killed on shutdown and recovered via restart-stale.
 	SurviveRestart *bool `yaml:"survive_restart" json:"surviveRestart"`
+	// ApprovalPort pins the localhost port of the PreToolUse approval
+	// server. The hook URL is baked into a permission-gated agent's
+	// --settings at spawn, so a fixed port lets a detached agent's approval
+	// requests still resolve after a restart. 0 (default) binds a random
+	// port (no cross-restart approval survival).
+	ApprovalPort int `yaml:"approval_port" json:"approvalPort"`
 }
 
 // DefaultBashTimeoutSeconds is the per-bash-tool-call timeout used when

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -361,7 +361,7 @@ func (a *App) initAgentConfig() {
 }
 
 func (a *App) initApprovalServer(emit func(string, any)) {
-	srv, err := agent.NewApprovalServer(emit, a.logger)
+	srv, err := agent.NewApprovalServer(emit, a.logger, a.cfg.Agent.ApprovalPort)
 	if err != nil {
 		a.logger.Error("approval-server.init", "err", err)
 		return


### PR DESCRIPTION
## Motivation

Close the two Claude-interactive gaps left out of scope by the survive-restart series (#959/#960/#962): one-shot conversational steps, and the random approval-server port that broke approval survival for permission-gated agents.

## Implementation information

**One-shot conversational survival.** One-shot steps complete by signalling stdin EOF, which the never-EOF survival FIFO can't do. The adversarial review proved a regular-file stdin doesn't work either — claude reads stream-json only from a pipe, so a regular-file stdin makes it exit immediately with no output. The fix: a one-shot needs no follow-ups, so pass its prompt as a **CLI argument** (`buildOneShotConvoArgs`: `-p <prompt> --output-format stream-json`, no `--input-format`, no stdin), run the single turn detached, and tail the log as ConvoEvents. No FIFO, survives a restart; reattach is tail-only (a record with no `StdinPath` is a one-shot). An interrupted one-shot step now completes across a restart instead of faking success via stale recovery. `reattachConvo` marks a convo that vanished without a terminal result as `errReattachedGone` so a crash stalls instead of advancing.

**Stable approval-server port.** Add `agent.approval_port`. When set, the PreToolUse approval server binds it (falling back to random if taken), so a detached permission-gated agent's baked hook URL still resolves after a restart. Default 0 keeps the random-port behaviour.

`willDetach` now detaches one-shot interactive Claude; `convoCommonArgs` is shared by the interactive and one-shot arg builders; bindings regenerated for the new config field.

Found by adversarial pre-PR review: the first cut used a regular-file stdin (proven non-working) and a test that didn't exercise it — replaced with the prompt-arg approach + an arg-shape regression test.

## Supporting documentation

Follows the survive-restart series: #956/#959, #957/#960, #958/#962. Known limitation unchanged: codex interactive (spawns per turn) is tracked separately.

Closes #963

> Changelog: feat(agent): complete Claude interactive survival