### PR TITLE
feat(agent): codex interactive survives restart

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -108,17 +108,17 @@ func (m *Manager) survives() bool {
 	return m.surviveRestart && m.reg != nil
 }
 
-// willDetach reports whether a run with this config/provider takes the
-// detached survival path: all headless runs, and interactive Claude runs
-// (one-shot included — its prompt is passed as an argument, no stdin).
-// Codex interactive (spawns per turn) stays on the legacy pipe path.
-// Single source of truth mirrored by the runner branches.
-func willDetach(cfg RunConfig, prov string) bool {
+// willDetach reports whether a run survives a restart. Headless and
+// interactive Claude survive as detached processes (Claude one-shot passes
+// its prompt as an argument, no stdin). Interactive codex "survives" by
+// recreate-on-restart: it has no persistent process between its independent
+// per-turn `codex exec` invocations, so the agent record persists and the
+// idle agent is rebuilt on the next startup. Single source of truth
+// mirrored by the runner branches.
+func willDetach(cfg RunConfig) bool {
 	switch cfg.Mode {
-	case "headless":
+	case "headless", "interactive":
 		return true
-	case "interactive":
-		return normalizeProvider(prov) != "codex"
 	default:
 		return false
 	}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -53,6 +53,10 @@ type Manager struct {
 	// non-nil error means persistence failed and the registry record should
 	// be retained for a later retry.
 	sessionSink func(taskID, agentID, sessionID string) error
+
+	// taskExists, when set, reports whether a task still exists. Used to
+	// avoid recreating a zombie codex agent whose chat task was deleted.
+	taskExists func(taskID string) bool
 }
 
 func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir string) *Manager {
@@ -101,6 +105,20 @@ func (m *Manager) sessionSinkFn() func(taskID, agentID, sessionID string) error 
 	return m.sessionSink
 }
 
+// SetTaskExists installs the callback used to skip recreating a codex agent
+// whose task was deleted. Set once at startup before ReattachAll.
+func (m *Manager) SetTaskExists(fn func(taskID string) bool) {
+	m.mu.Lock()
+	m.taskExists = fn
+	m.mu.Unlock()
+}
+
+func (m *Manager) taskExistsFn() func(taskID string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.taskExists
+}
+
 // survives reports whether restart survival is active.
 func (m *Manager) survives() bool {
 	m.mu.RLock()
@@ -139,19 +157,20 @@ func (m *Manager) saveRegistry(a *Agent) {
 	}
 	a.mu.RLock()
 	rec := Record{
-		ID:        a.ID,
-		TaskID:    a.TaskID,
-		Name:      a.Name,
-		Mode:      a.Mode,
-		Provider:  a.Provider,
-		Model:     a.Model,
-		PID:       a.PID,
-		SessionID: a.SessionID,
-		LogPath:   a.LogPath,
-		CWD:       a.sessionCWD,
-		StartedAt: a.StartedAt,
-		StdinPath: a.stdinPath,
-		MaxTurns:  a.MaxTurns,
+		ID:                 a.ID,
+		TaskID:             a.TaskID,
+		Name:               a.Name,
+		Mode:               a.Mode,
+		Provider:           a.Provider,
+		Model:              a.Model,
+		PID:                a.PID,
+		SessionID:          a.SessionID,
+		LogPath:            a.LogPath,
+		CWD:                a.sessionCWD,
+		StartedAt:          a.StartedAt,
+		StdinPath:          a.stdinPath,
+		MaxTurns:           a.MaxTurns,
+		RequirePermissions: a.requirePermissions,
 	}
 	a.mu.RUnlock()
 	rec.ProcStartedAt = processStartString(rec.PID)

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -76,7 +76,7 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 	// it after a successful Start. Detached applies to headless and to
 	// interactive Claude (one-shot via file-arg prompt, sessions via FIFO);
 	// codex interactive (spawns per turn) stays on the legacy path.
-	if m.survives() && willDetach(cfg, a.Provider) {
+	if m.survives() && willDetach(cfg) {
 		a.setDetached(true)
 	}
 
@@ -101,7 +101,7 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 	case "interactive":
 		if a.Provider == "codex" {
 			a.promptCh = make(chan string, 1)
-			go m.runCodexConversational(ctx, a, cfg)
+			go m.runCodexConversational(ctx, a, cfg, false)
 		} else {
 			a.approvalCh = make(chan ApprovalResponse, 1)
 			go m.runConversational(ctx, a, cfg)

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -48,19 +48,20 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 
 	now := time.Now().UTC()
 	a := &Agent{
-		ID:          id,
-		TaskID:      cfg.TaskID,
-		Name:        cfg.Name,
-		Mode:        cfg.Mode,
-		Provider:    resolvedProvider,
-		Model:       normalizeModel(resolvedProvider, cfg.Model),
-		Prompt:      cfg.Prompt,
-		State:       StateRunning,
-		StartedAt:   now,
-		LastEventAt: now,
-		cancel:      cancel,
-		sessionCWD:  cfg.Dir,
-		MaxTurns:    cfg.MaxTurns,
+		ID:                 id,
+		TaskID:             cfg.TaskID,
+		Name:               cfg.Name,
+		Mode:               cfg.Mode,
+		Provider:           resolvedProvider,
+		Model:              normalizeModel(resolvedProvider, cfg.Model),
+		Prompt:             cfg.Prompt,
+		State:              StateRunning,
+		StartedAt:          now,
+		LastEventAt:        now,
+		cancel:             cancel,
+		sessionCWD:         cfg.Dir,
+		MaxTurns:           cfg.MaxTurns,
+		requirePermissions: cfg.RequirePermissions,
 	}
 	if cfg.ResumeSessionID != "" {
 		a.SetSessionID(cfg.ResumeSessionID)
@@ -72,10 +73,10 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 		a.escalationCh = make(chan bool, 1)
 	}
 	// Pre-mark detached so a shutdown racing the runner goroutine already
-	// knows to leave this agent's subprocess running. The runner re-asserts
-	// it after a successful Start. Detached applies to headless and to
-	// interactive Claude (one-shot via file-arg prompt, sessions via FIFO);
-	// codex interactive (spawns per turn) stays on the legacy path.
+	// knows to leave this agent's record alive. Headless and interactive
+	// Claude survive as detached processes; codex interactive has no
+	// persistent process and survives by recreate-on-restart, but is still
+	// marked so ShutdownWithGrace leaves its record for recreate.
 	if m.survives() && willDetach(cfg) {
 		a.setDetached(true)
 	}

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -119,6 +119,11 @@ type Agent struct {
 	// cancelling them. Guarded by mu.
 	detached bool
 
+	// requirePermissions mirrors RunConfig.RequirePermissions. Persisted to
+	// the registry so a recreated codex chat keeps its sandbox/approval
+	// choice across a restart instead of silently becoming permissive.
+	requirePermissions bool
+
 	// mu guards mutable fields touched from multiple goroutines. See the
 	// package-level note above the Agent type.
 	mu sync.RWMutex

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -236,6 +236,17 @@ func convoResumeState(evs []ConvoEvent) State {
 // (waiting for the next prompt). Liveness is not checked — the agent is
 // recreated regardless. Returns nil only on a duplicate.
 func (m *Manager) reattachCodexConvo(r Record, reg *registryStore) *Agent {
+	// Codex recreate is unconditional (no live process to gate on), so guard
+	// against resurrecting an agent for a task that was deleted while the app
+	// was down — that would leak a zombie agent gcOrphanChats can't reap.
+	if r.TaskID != "" {
+		if exists := m.taskExistsFn(); exists != nil && !exists(r.TaskID) {
+			_ = reg.Delete(r.ID)
+			m.logger.Info("agent.reattach.skip", "id", r.ID, "task", r.TaskID, "reason", "task_gone")
+			return nil
+		}
+	}
+
 	a := agentFromRecord(r)
 	if r.LogPath != "" {
 		rehydrateCodexConvoFromLog(a, r.LogPath)
@@ -259,9 +270,9 @@ func (m *Manager) reattachCodexConvo(r Record, reg *registryStore) *Agent {
 
 	m.logger.Info("agent.reattach", "id", a.ID, "task", a.TaskID, "mode", "interactive", "provider", "codex", "events", len(a.ConvoOutput()))
 	// Resume idle: skip the first turn, wait for the next prompt. CWD/model
-	// come from the rebuilt agent; permissions default to permissive (the
-	// original chat's permission mode is not persisted).
-	go m.runCodexConversational(ctx, a, RunConfig{Dir: a.sessionCWD}, true)
+	// come from the rebuilt agent; the sandbox/approval choice is restored
+	// from the record so a sandboxed chat stays sandboxed.
+	go m.runCodexConversational(ctx, a, RunConfig{Dir: a.sessionCWD, RequirePermissions: a.requirePermissions}, true)
 	m.emit(events.AgentState(a.ID), a)
 	return a
 }
@@ -385,22 +396,23 @@ func reattachAlive(r Record) bool {
 
 func agentFromRecord(r Record) *Agent {
 	return &Agent{
-		ID:          r.ID,
-		TaskID:      r.TaskID,
-		Name:        r.Name,
-		Mode:        r.Mode,
-		Provider:    r.Provider,
-		Model:       r.Model,
-		PID:         r.PID,
-		SessionID:   r.SessionID,
-		LogPath:     r.LogPath,
-		sessionCWD:  r.CWD,
-		StartedAt:   r.StartedAt,
-		LastEventAt: time.Now().UTC(),
-		State:       StateRunning,
-		MaxTurns:    r.MaxTurns,
-		stdinPath:   r.StdinPath,
-		detached:    true,
+		ID:                 r.ID,
+		TaskID:             r.TaskID,
+		Name:               r.Name,
+		Mode:               r.Mode,
+		Provider:           r.Provider,
+		Model:              r.Model,
+		PID:                r.PID,
+		SessionID:          r.SessionID,
+		LogPath:            r.LogPath,
+		sessionCWD:         r.CWD,
+		StartedAt:          r.StartedAt,
+		LastEventAt:        time.Now().UTC(),
+		State:              StateRunning,
+		MaxTurns:           r.MaxTurns,
+		stdinPath:          r.StdinPath,
+		requirePermissions: r.RequirePermissions,
+		detached:           true,
 	}
 }
 

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -55,6 +55,12 @@ func (m *Manager) ReattachAll() []*Agent {
 	for i := range recs {
 		r := recs[i]
 		if r.Mode == "interactive" {
+			if normalizeProvider(r.Provider) == "codex" {
+				if a := m.reattachCodexConvo(r, reg); a != nil {
+					out = append(out, a)
+				}
+				continue
+			}
 			if a := m.reattachInteractive(r, reg); a != nil {
 				out = append(out, a)
 			}
@@ -221,6 +227,43 @@ func convoResumeState(evs []ConvoEvent) State {
 		}
 	}
 	return StatePaused
+}
+
+// reattachCodexConvo recreates a codex conversational agent after a restart.
+// Codex convo has no persistent process between its independent per-turn
+// invocations, so there is nothing to reattach to: rebuild the idle agent,
+// rehydrate its chat from the log, and restart the loop in resume-wait mode
+// (waiting for the next prompt). Liveness is not checked — the agent is
+// recreated regardless. Returns nil only on a duplicate.
+func (m *Manager) reattachCodexConvo(r Record, reg *registryStore) *Agent {
+	a := agentFromRecord(r)
+	if r.LogPath != "" {
+		rehydrateCodexConvoFromLog(a, r.LogPath)
+	}
+	a.SetState(StatePaused)
+
+	ctx, cancel := context.WithCancel(m.ctx)
+	a.cancel = cancel
+	a.done = make(chan struct{})
+	a.promptCh = make(chan string, 1)
+
+	m.mu.Lock()
+	if _, exists := m.agents[a.ID]; exists {
+		m.mu.Unlock()
+		cancel()
+		return nil
+	}
+	m.agents[a.ID] = a
+	m.liveCount++
+	m.mu.Unlock()
+
+	m.logger.Info("agent.reattach", "id", a.ID, "task", a.TaskID, "mode", "interactive", "provider", "codex", "events", len(a.ConvoOutput()))
+	// Resume idle: skip the first turn, wait for the next prompt. CWD/model
+	// come from the rebuilt agent; permissions default to permissive (the
+	// original chat's permission mode is not persisted).
+	go m.runCodexConversational(ctx, a, RunConfig{Dir: a.sessionCWD}, true)
+	m.emit(events.AgentState(a.ID), a)
+	return a
 }
 
 // reattachHeadless tails a reattached subprocess's log file from

--- a/internal/agent/registry.go
+++ b/internal/agent/registry.go
@@ -30,6 +30,10 @@ type Record struct {
 	ProcStartedAt string    `yaml:"proc_started_at,omitempty"` // ps lstart, guards PID reuse
 	StdinPath     string    `yaml:"stdin_path,omitempty"`      // FIFO for interactive survival
 	MaxTurns      int       `yaml:"max_turns,omitempty"`
+	// RequirePermissions preserves a codex chat's sandbox/approval choice
+	// across a restart (codex respawns per turn and would otherwise default
+	// to permissive).
+	RequirePermissions bool `yaml:"require_permissions,omitempty"`
 }
 
 // registryStore persists Records as one YAML file per agent under dir.

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -70,8 +70,24 @@ func codexEventToConvoEvent(e CodexEvent) ConvoEvent {
 // Each turn spawns a fresh `codex exec --json` process. After turn.completed
 // the agent transitions to StatePaused and waits for the next prompt on
 // promptCh. OneShot skips the wait and exits after the first turn.
-func (m *Manager) runCodexConversational(ctx context.Context, a *Agent, cfg RunConfig) {
+//
+// resumeWait starts the loop already idle (skip the first turn, wait for the
+// next prompt) — used when reattaching a recreated codex agent after a
+// restart.
+//
+// Restart survival: codex convo has no persistent process between turns, so
+// it "survives" by recreate-on-restart. When survival is on, the agent is
+// recorded; on a shutdown (ctx cancel that is NOT an intentional stop) the
+// goroutine returns WITHOUT finalizing, leaving the record for the next
+// startup to recreate. A normal completion / user-close finalizes and
+// deletes the record.
+func (m *Manager) runCodexConversational(ctx context.Context, a *Agent, cfg RunConfig, resumeWait bool) {
+	survived := false
 	defer func() {
+		if survived {
+			m.logger.Info("agent.codex.convo.detach", "id", a.ID, "reason", "shutdown")
+			return
+		}
 		a.SetState(StateStopped)
 		m.logger.Info("agent.codex.convo.done", "id", a.ID, "cost", a.GetCostUSD())
 		m.emit(events.AgentState(a.ID), a)
@@ -96,18 +112,36 @@ func (m *Manager) runCodexConversational(ctx context.Context, a *Agent, cfg RunC
 		logWriter = outFile
 	}
 
+	// Record the agent so a restart can recreate it (the log path is now set).
+	if m.survives() {
+		a.setDetached(true)
+		m.saveRegistry(a)
+	}
+
+	// shutdownSurvive reports whether a ctx cancel should leave the agent
+	// running for recreate (survival on, app shutdown, not an intentional stop).
+	shutdownSurvive := func() bool {
+		return m.survives() && ctx.Err() != nil && !a.WasStopped()
+	}
+
 	prompt := cfg.Prompt
 	for {
-		if !m.runCodexTurn(ctx, a, cfg, prompt, logWriter) {
-			return
-		}
+		if !resumeWait {
+			if !m.runCodexTurn(ctx, a, cfg, prompt, logWriter) {
+				if shutdownSurvive() {
+					survived = true
+				}
+				return
+			}
 
-		a.SetState(StatePaused)
-		m.emit(events.AgentState(a.ID), a)
+			a.SetState(StatePaused)
+			m.emit(events.AgentState(a.ID), a)
 
-		if cfg.OneShot {
-			return
+			if cfg.OneShot {
+				return
+			}
 		}
+		resumeWait = false
 
 		a.mu.RLock()
 		ch := a.promptCh
@@ -115,6 +149,9 @@ func (m *Manager) runCodexConversational(ctx context.Context, a *Agent, cfg RunC
 
 		select {
 		case <-ctx.Done():
+			if shutdownSurvive() {
+				survived = true
+			}
 			return
 		case next, ok := <-ch:
 			if !ok {
@@ -254,6 +291,37 @@ func (m *Manager) streamCodexConvoOutput(a *Agent, stdout io.Reader, outFile io.
 		m.emit(events.AgentConvo(a.ID), *pending)
 	}
 	return gotResult
+}
+
+// rehydrateCodexConvoFromLog replays a codex conversational agent's log into
+// its convo buffer (and session id) without emitting events, so a recreated
+// agent shows its prior chat history after a restart.
+func rehydrateCodexConvoFromLog(a *Agent, path string) {
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 256*1024), 1024*1024)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		parsed, perr := ParseCodexLine(line)
+		if perr != nil {
+			continue
+		}
+		ev := codexEventToConvoEvent(parsed)
+		if ev.Type == "" {
+			continue
+		}
+		a.AppendConvo(ev)
+		if ev.SessionID != "" {
+			a.SetSessionID(ev.SessionID)
+		}
+	}
 }
 
 // sendCodexPrompt delivers a follow-up prompt to a Codex conversational agent.

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -98,7 +98,17 @@ func (m *Manager) runCodexConversational(ctx context.Context, a *Agent, cfg RunC
 		m.markAgentDone(a)
 	}()
 
-	outFile, fileErr := logging.NewAgentOutputFile(m.logDir, a.ID)
+	// On recreate (resume), append to the existing log so the rehydrated
+	// chat history is preserved across restarts; a fresh run opens a new
+	// file. Without this, each restart would open a new empty log and the
+	// next restart would rehydrate zero history.
+	var outFile *os.File
+	var fileErr error
+	if existing := a.GetLogPath(); existing != "" {
+		outFile, fileErr = os.OpenFile(existing, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	} else {
+		outFile, fileErr = logging.NewAgentOutputFile(m.logDir, a.ID)
+	}
 	if fileErr != nil {
 		m.logger.Error("agent.output.file", "id", a.ID, "err", fileErr)
 	}

--- a/internal/agent/survive_convo_test.go
+++ b/internal/agent/survive_convo_test.go
@@ -16,24 +16,21 @@ import (
 
 func TestWillDetach(t *testing.T) {
 	cases := []struct {
-		mode     string
-		provider string
-		oneShot  bool
-		want     bool
+		mode    string
+		oneShot bool
+		want    bool
 	}{
-		{"headless", "claude", false, true},
-		{"headless", "codex", false, true},
-		{"interactive", "claude", false, true},
-		{"interactive", "claude", true, true},  // one-shot survives via prompt arg
-		{"interactive", "codex", false, false}, // codex spawns per turn
-		{"interactive", "codex", true, false},  // codex one-shot also legacy
-		{"interactive", "", false, true},       // empty provider normalizes to claude
-		{"chat", "claude", false, false},       // unknown mode
+		{"headless", false, true},
+		{"headless", true, true},
+		{"interactive", false, true},
+		{"interactive", true, true}, // one-shot survives too
+		{"chat", false, false},      // unknown mode
+		{"", false, false},          // empty mode
 	}
 	for _, c := range cases {
-		got := willDetach(RunConfig{Mode: c.mode, OneShot: c.oneShot}, c.provider)
+		got := willDetach(RunConfig{Mode: c.mode, OneShot: c.oneShot})
 		if got != c.want {
-			t.Errorf("willDetach(mode=%s provider=%s oneShot=%v)=%v, want %v", c.mode, c.provider, c.oneShot, got, c.want)
+			t.Errorf("willDetach(mode=%s oneShot=%v)=%v, want %v", c.mode, c.oneShot, got, c.want)
 		}
 	}
 }
@@ -66,6 +63,81 @@ func TestBuildOneShotConvoArgs(t *testing.T) {
 	}
 	if !strings.Contains(joined, "--output-format stream-json") {
 		t.Fatalf("expected stream-json output: %q", joined)
+	}
+}
+
+func TestRehydrateCodexConvoFromLog(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "codex.ndjson")
+	// Minimal codex stream-json: a session init then an agent message.
+	lines := `{"type":"thread.started","thread_id":"cx-1"}` + "\n" +
+		`{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}` + "\n"
+	if err := os.WriteFile(path, []byte(lines), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	a := &Agent{ID: "cx", Provider: "codex"}
+	rehydrateCodexConvoFromLog(a, path)
+	if len(a.ConvoOutput()) == 0 {
+		t.Fatal("expected codex convo events rehydrated")
+	}
+}
+
+// TestReattachCodexConvo_RecreatesIdleAgent verifies a codex interactive
+// record is recreated as an idle, sendable agent on restart (no live process
+// required — codex has none between turns).
+func TestReattachCodexConvo_RecreatesIdleAgent(t *testing.T) {
+	logDir := t.TempDir()
+	regDir := t.TempDir()
+	logPath := filepath.Join(logDir, "agents", "cx9.ndjson")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	lines := `{"type":"thread.started","thread_id":"cx-9"}` + "\n" +
+		`{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}` + "\n"
+	if err := os.WriteFile(logPath, []byte(lines), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir)
+	if err := m.EnableSurviveRestart(regDir); err != nil {
+		t.Fatalf("EnableSurviveRestart: %v", err)
+	}
+	// Codex record: PID 0 (no live process between turns).
+	rec := Record{ID: "cx9", TaskID: "t-cx", Mode: "interactive", Provider: "codex", PID: 0, LogPath: logPath, SessionID: "cx-9", StartedAt: time.Now().UTC()}
+	if err := m.reg.Save(rec); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got := m.ReattachAll()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 recreated codex agent, got %d", len(got))
+	}
+	a, err := m.GetAgent("cx9")
+	if err != nil {
+		t.Fatalf("GetAgent: %v", err)
+	}
+	if a.GetState() != StatePaused {
+		t.Fatalf("expected recreated codex agent Paused, got %s", a.GetState())
+	}
+	if len(a.ConvoOutput()) == 0 {
+		t.Fatal("expected rehydrated codex convo buffer")
+	}
+	// The recreated agent is sendable: it has a live prompt channel. (Don't
+	// actually send — that would spawn a real codex process.)
+	a.mu.RLock()
+	hasPromptCh := a.promptCh != nil
+	a.mu.RUnlock()
+	if !hasPromptCh {
+		t.Fatal("recreated codex agent should have a prompt channel")
+	}
+
+	// Stop and wait for the goroutine to exit before TempDir cleanup.
+	if err := m.StopAgent("cx9"); err != nil {
+		t.Fatalf("StopAgent: %v", err)
+	}
+	select {
+	case <-a.done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("recreated codex agent did not exit after StopAgent")
 	}
 }
 

--- a/internal/agent/survive_convo_test.go
+++ b/internal/agent/survive_convo_test.go
@@ -139,6 +139,45 @@ func TestReattachCodexConvo_RecreatesIdleAgent(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("recreated codex agent did not exit after StopAgent")
 	}
+
+	// History preservation: recreate must reuse the existing log (append),
+	// not open a new empty file — otherwise the next restart loses history.
+	if a.GetLogPath() != logPath {
+		t.Fatalf("recreate must reuse the existing log, got %q want %q", a.GetLogPath(), logPath)
+	}
+}
+
+// TestReattachCodexConvo_SkipsDeletedTask verifies a codex record whose task
+// no longer exists is dropped (not recreated as a zombie agent).
+func TestReattachCodexConvo_SkipsDeletedTask(t *testing.T) {
+	logDir := t.TempDir()
+	regDir := t.TempDir()
+	logPath := filepath.Join(logDir, "agents", "gone1.ndjson")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(logPath, []byte(`{"type":"thread.started","thread_id":"g"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir)
+	if err := m.EnableSurviveRestart(regDir); err != nil {
+		t.Fatalf("EnableSurviveRestart: %v", err)
+	}
+	m.SetTaskExists(func(string) bool { return false }) // task is gone
+
+	if err := m.reg.Save(Record{ID: "gone1", TaskID: "deleted", Mode: "interactive", Provider: "codex", LogPath: logPath, StartedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if got := m.ReattachAll(); len(got) != 0 {
+		t.Fatalf("expected no recreate for deleted task, got %d", len(got))
+	}
+	if _, err := m.GetAgent("gone1"); err == nil {
+		t.Fatal("expected no agent registered for deleted task")
+	}
+	if list, _ := m.reg.List(); len(list) != 0 {
+		t.Fatal("expected record deleted for gone task")
+	}
 }
 
 func TestMakeFIFO_RoundTrip(t *testing.T) {

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -351,6 +351,11 @@ func (a *App) initAgentConfig() {
 		a.agents.SetSessionSink(func(taskID, agentID, sessionID string) error {
 			return a.tasks.UpdateRun(taskID, agentID, map[string]any{"session_id": sessionID})
 		})
+		// Skip recreating a codex chat agent whose task was deleted.
+		a.agents.SetTaskExists(func(taskID string) bool {
+			_, err := a.tasks.Get(taskID)
+			return err == nil
+		})
 	}
 	a.agents.SetGuardrails(agent.Guardrails{
 		MaxCostUSD:       a.cfg.Agent.MaxCostUSD,

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -351,10 +351,19 @@ func (a *App) initAgentConfig() {
 		a.agents.SetSessionSink(func(taskID, agentID, sessionID string) error {
 			return a.tasks.UpdateRun(taskID, agentID, map[string]any{"session_id": sessionID})
 		})
-		// Skip recreating a codex chat agent whose task was deleted.
+		// Skip recreating a codex chat agent whose task was deleted. Only a
+		// definite not-exist returns false; a transient error fails open
+		// (retain the record) so a surviving chat is not lost to a flaky read.
 		a.agents.SetTaskExists(func(taskID string) bool {
 			_, err := a.tasks.Get(taskID)
-			return err == nil
+			if err == nil {
+				return true
+			}
+			if errors.Is(err, os.ErrNotExist) {
+				return false
+			}
+			a.logger.Warn("agent.task-exists.error", "task_id", taskID, "err", err)
+			return true
 		})
 	}
 	a.agents.SetGuardrails(agent.Guardrails{


### PR DESCRIPTION
## Motivation

Final gap in the survive-restart series: codex interactive (conversational) agents. Closes #966.

## Implementation information

Codex convo is structurally different from Claude: each turn spawns a fresh `codex exec --json` (independent, no `--resume`), and there is **no persistent process between turns** (the loop blocks on a prompt channel). So codex "survives" by **recreate-on-restart** — rebuild the idle agent, rehydrate its chat from the log, resume the wait loop — rather than reattaching to a live process. An in-flight turn is lost and re-prompted; conversation context is unaffected (turns are independent).

- `runCodexConversational(ctx, a, cfg, resumeWait)` records a detached codex agent (once the log path is known) and, on a shutdown ctx-cancel that is not an intentional stop, returns WITHOUT finalizing so the record persists for recreate. Normal completion / user-close / `StopAgent` finalizes and deletes the record. `resumeWait` starts the loop idle.
- `ReattachAll` routes interactive records by provider: codex → `reattachCodexConvo` (recreate idle agent, rehydrate, restart loop in resume-wait mode). Liveness is not checked (no process to find).
- `willDetach` now covers all interactive agents.

Found by adversarial pre-PR review and fixed:
- **Blocker** — recreate opened a new empty log and repointed the record, so a second restart rehydrated zero history. Now the recreated run appends to the existing log, preserving chat history across restarts (regression-tested).
- Skip recreating a codex agent whose task was deleted (`taskExists` hook) — avoids a zombie agent `gcOrphanChats` can't reap.
- Persist `RequirePermissions` in the record and restore it, so a sandboxed codex chat doesn't silently become permissive after a restart.

Out of scope: a mid-turn `codex exec` is not process-detached (turns are independent; an interrupted turn is re-prompted).

## Supporting documentation

Completes the survive-restart series: #959, #960, #962, #965. With this, all agent kinds — headless (claude/codex), interactive claude (sessions + one-shot), and interactive codex — survive an app restart.

Closes #966

> Changelog: feat(agent): codex interactive agents survive restart