### PR TITLE
fix(status): unify status vocabulary across views

### DIFF
--- a/frontend/src/components/StatusBadge.svelte
+++ b/frontend/src/components/StatusBadge.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { STATUS_MAP } from '../lib/statuses.js'
+  import { STATUS_MAP, statusLabel } from '../lib/statuses.js'
 
   interface Props {
     status: string
@@ -7,14 +7,13 @@
 
   const { status }: Props = $props()
 
-  const resolved = $derived(
-    STATUS_MAP[status] ?? {
-      label: status,
-      badgeClasses: 'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200',
-    },
+  const badgeClasses = $derived(
+    STATUS_MAP[status]?.badgeClasses ??
+      'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200',
   )
+  const label = $derived(statusLabel(status))
 </script>
 
-<span class="inline-block whitespace-nowrap rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors duration-100 {resolved.badgeClasses}">
-  {resolved.label}
+<span class="inline-block whitespace-nowrap rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors duration-100 {badgeClasses}">
+  {label}
 </span>

--- a/frontend/src/components/TaskCard.svelte.test.ts
+++ b/frontend/src/components/TaskCard.svelte.test.ts
@@ -153,19 +153,19 @@ describe('TaskCard', () => {
     })
   })
 
-  it('shows Needs Review badge for plan-review status', () => {
+  it('shows the canonical Plan Review badge for plan-review status', () => {
     render(TaskCard, { props: { task: { ...mockTask, status: 'plan-review' as Task['status'] }, onclick: () => {} } })
-    expect(screen.getByText('Needs Review')).toBeDefined()
+    expect(screen.getByText('Plan Review')).toBeDefined()
   })
 
-  it('does not show Needs Review badge for other statuses', () => {
+  it('does not show an attention badge for non-awaiting statuses', () => {
     render(TaskCard, { props: { task: mockTask, onclick: () => {} } })
-    expect(screen.queryByText('Needs Review')).toBeNull()
+    expect(screen.queryByText('Plan Review')).toBeNull()
   })
 
-  it('shows Needs You badge for human-required status', () => {
+  it('shows the canonical Human Required badge for human-required status', () => {
     render(TaskCard, { props: { task: { ...mockTask, status: 'human-required' as Task['status'] }, onclick: () => {} } })
-    expect(screen.getByText('Needs You')).toBeDefined()
+    expect(screen.getByText('Human Required')).toBeDefined()
   })
 
   it('shows Blocked badge for blocked status', () => {

--- a/frontend/src/components/task-detail/TaskHeaderBar.svelte
+++ b/frontend/src/components/task-detail/TaskHeaderBar.svelte
@@ -246,6 +246,12 @@
     </h1>
   {/if}
   <div class="flex items-center gap-2">
+    <!--
+      This control selects among the core (column) statuses, so it shows the
+      rolled-up value. A granular awaiting sub-state (e.g. plan-review) still
+      reads as its column name ("Planning") here; surfacing that sub-state as a
+      banner under the title is tracked separately (detail-loses-substate).
+    -->
     <select
       bind:this={statusSelectRef}
       data-testid="task-status-select"

--- a/frontend/src/components/task-detail/TaskHeaderBar.svelte
+++ b/frontend/src/components/task-detail/TaskHeaderBar.svelte
@@ -250,7 +250,7 @@
       This control selects among the core (column) statuses, so it shows the
       rolled-up value. A granular awaiting sub-state (e.g. plan-review) still
       reads as its column name ("Planning") here; surfacing that sub-state as a
-      banner under the title is tracked separately (detail-loses-substate).
+      banner under the title is tracked separately in issue #983.
     -->
     <select
       bind:this={statusSelectRef}

--- a/frontend/src/lib/statuses.test.ts
+++ b/frontend/src/lib/statuses.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import {
+  ALL_STATUSES,
+  AWAITS_HUMAN,
   CORE_STATUSES,
   CORE_STATUS_OPTIONS,
+  awaitsHuman,
+  awaitsHumanLabel,
   coreStatus,
+  statusLabel,
   statusOptionsFor,
   BOARD_COLUMNS,
   STATUS_MAP,
@@ -71,5 +76,41 @@ describe('statusOptionsFor', () => {
     const opts = statusOptionsFor('mystery')
     expect(opts).toHaveLength(CORE_STATUS_OPTIONS.length + 1)
     expect(opts.at(-1)).toEqual({ value: 'mystery', label: 'mystery' })
+  })
+})
+
+describe('statusLabel — one canonical vocabulary', () => {
+  it('returns the STATUS_MAP label for every known status', () => {
+    for (const meta of ALL_STATUSES) {
+      expect(statusLabel(meta.value)).toBe(meta.label)
+    }
+  })
+
+  it('passes unknown statuses through verbatim', () => {
+    expect(statusLabel('mystery')).toBe('mystery')
+  })
+
+  it('is the label every picker option uses', () => {
+    for (const opt of CORE_STATUS_OPTIONS) {
+      expect(opt.label).toBe(statusLabel(opt.value))
+    }
+  })
+})
+
+describe('awaitsHumanLabel — canonical, never a divergent name', () => {
+  it('matches the canonical status label for every awaits-human status', () => {
+    for (const status of AWAITS_HUMAN) {
+      expect(awaitsHuman(status)).toBe(true)
+      // The attention pill must reuse the same word the list/detail show —
+      // no invented "Needs Review"/"Needs You" vocabulary.
+      expect(awaitsHumanLabel(status)).toBe(statusLabel(status))
+    }
+  })
+
+  it('is empty for statuses that do not await the user', () => {
+    for (const meta of ALL_STATUSES) {
+      if (AWAITS_HUMAN.has(meta.value)) continue
+      expect(awaitsHumanLabel(meta.value)).toBe('')
+    }
   })
 })

--- a/frontend/src/lib/statuses.ts
+++ b/frontend/src/lib/statuses.ts
@@ -125,19 +125,25 @@ export function awaitsHuman(status: string): boolean {
   return AWAITS_HUMAN.has(status as TaskStatus)
 }
 
-/** Short pill label for an awaits-human task; empty when not awaiting. */
+/**
+ * Canonical, human-facing label for a status — the single source of truth used
+ * identically on the board pill, list cell, detail dropdown, and move popover.
+ * One state, one word, everywhere. Unknown values pass through verbatim so the
+ * UI never mislabels a legacy/unrecognised status.
+ */
+export function statusLabel(status: string): string {
+  return STATUS_MAP[status]?.label ?? status
+}
+
+/**
+ * Label for an awaits-human task's attention pill; empty when not awaiting.
+ * Returns the *canonical* status label — the attention state is signalled by
+ * colour and placement, never by a divergent name. (Previously this invented
+ * "Needs Review"/"Needs You", which is exactly the vocabulary split this
+ * reconciles.)
+ */
 export function awaitsHumanLabel(status: string): string {
-  switch (status) {
-    case 'plan-review':
-    case 'test-plan-review':
-      return 'Needs Review'
-    case 'blocked':
-      return 'Blocked'
-    case 'human-required':
-      return 'Needs You'
-    default:
-      return ''
-  }
+  return awaitsHuman(status) ? statusLabel(status) : ''
 }
 
 /** O(1) lookup by status value */

--- a/frontend/src/lib/statuses.ts
+++ b/frontend/src/lib/statuses.ts
@@ -126,10 +126,10 @@ export function awaitsHuman(status: string): boolean {
 }
 
 /**
- * Canonical, human-facing label for a status — the single source of truth used
- * identically on the board pill, list cell, detail dropdown, and move popover.
- * One state, one word, everywhere. Unknown values pass through verbatim so the
- * UI never mislabels a legacy/unrecognised status.
+ * Canonical, human-facing label for a status — the label every status surface
+ * (board pill, list cell, move popover) should resolve through so one state
+ * reads the same wherever it appears. Unknown values pass through verbatim so
+ * the UI never mislabels a legacy/unrecognised status.
  */
 export function statusLabel(status: string): string {
   return STATUS_MAP[status]?.label ?? status


### PR DESCRIPTION
## Motivation

Part of ☂️ #968 (UI/UX overhaul). The same task state was named three
different ways depending on where you looked — board pill "Needs Review",
list cell "Plan Review", detail dropdown "Planning" — so users couldn't
build a stable mental model. This is the foundational vocabulary decision
the rest of the board/detail work builds on.

Closes #992

## Implementation information

- Added `statusLabel(status)` to `lib/statuses.ts` as the single source of
  truth for a status name (`STATUS_MAP` label, unknown values pass through).
- `awaitsHumanLabel()` now returns that canonical label instead of inventing
  "Needs Review"/"Needs You". The attention state is signalled by colour and
  placement, not by a divergent name, so the board pill and list cell now
  name an awaiting state with one word. The move popover, board column
  headers, and detail dropdown options already source from `STATUS_MAP`.
- `StatusBadge` reads the label through the same helper.
- Tests lock the invariant: every awaiting status's pill label equals its
  canonical `statusLabel`; no invented vocabulary can creep back in.

### Scope / coupling
The **model decision** (one canonical label per state, attention is a
separate axis) lands here. Two coupled pieces are intentionally deferred to
keep PRs reviewable:
- The detail status control still shows the rolled-up column name for a
  granular sub-state (e.g. a `plan-review` task reads "Planning"). Surfacing
  that sub-state as a banner under the title is #983.
- Separating workflow-stage columns from attention badges on the board is
  #993.

A code comment at the detail `<select>` records the deferred sub-state gap.

> Changelog: fix(status): unify status vocabulary across views