### PR TITLE
refactor(ui): add pill role design system

### DIFF
--- a/frontend/src/components/Pill.svelte
+++ b/frontend/src/components/Pill.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+  import { pillClass, type PillRole } from '../lib/pills.js'
+
+  interface Props {
+    role: PillRole
+    children: Snippet
+    title?: string
+    /** Extra classes layered on the role treatment (e.g. status colour). */
+    class?: string
+  }
+
+  const { role, children, title = undefined, class: extra = '' }: Props = $props()
+</script>
+
+<span class={pillClass(role, extra)} {title}>{@render children()}</span>

--- a/frontend/src/components/Pill.svelte
+++ b/frontend/src/components/Pill.svelte
@@ -8,9 +8,11 @@
     title?: string
     /** Extra classes layered on the role treatment (e.g. status colour). */
     class?: string
+    /** Any other attribute (aria-*, data-testid, onclick, …) is forwarded. */
+    [key: string]: unknown
   }
 
-  const { role, children, title = undefined, class: extra = '' }: Props = $props()
+  const { role, children, title = undefined, class: extra = '', ...rest }: Props = $props()
 </script>
 
-<span class={pillClass(role, extra)} {title}>{@render children()}</span>
+<span class={pillClass(role, extra)} {title} {...rest}>{@render children()}</span>

--- a/frontend/src/components/StatusBadge.svelte
+++ b/frontend/src/components/StatusBadge.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { STATUS_MAP, statusLabel } from '../lib/statuses.js'
+  import { pillClass } from '../lib/pills.js'
 
   interface Props {
     status: string
@@ -14,6 +15,7 @@
   const label = $derived(statusLabel(status))
 </script>
 
-<span class="inline-block whitespace-nowrap rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors duration-100 {badgeClasses}">
+<!-- The canonical "status" pill role: shape from the role, colour from the status. -->
+<span class={pillClass('status', `transition-colors duration-100 ${badgeClasses}`)}>
   {label}
 </span>

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -8,6 +8,7 @@
   import { awaitsHuman, awaitsHumanLabel } from '../lib/statuses.js'
   import { PRIORITY_OPTIONS } from '../lib/priorities.js'
   import StatusPicker from './StatusPicker.svelte'
+  import Pill from './Pill.svelte'
 
   interface Props {
     task: Task
@@ -126,9 +127,10 @@
     </span>
 
     {#if t.projectId}
-      <span class="rounded bg-primary-100 px-1.5 py-0.5 text-primary-700 dark:bg-primary-800 dark:text-primary-300">
+      <Pill role="project" title={t.projectId}>
+        <span class="h-2 w-2 shrink-0 rounded-full bg-surface-400 dark:bg-surface-500"></span>
         {t.projectId}
-      </span>
+      </Pill>
     {/if}
 
     {#if t.branch}
@@ -153,9 +155,9 @@
     {/if}
 
     {#if needsYou}
-      <span class="inline-flex items-center gap-1 rounded bg-error-200 px-1.5 py-0.5 font-semibold text-error-800 dark:bg-error-700 dark:text-error-200">
+      <Pill role="attention" class="bg-error-200 text-error-800 dark:bg-error-700 dark:text-error-200">
         {awaitsHumanLabel(t.status)}
-      </span>
+      </Pill>
     {/if}
 
     {#if agentRunning}
@@ -205,20 +207,15 @@
     {/if}
 
     {#if t.issue}
-      <span
-        class="inline-flex items-center gap-1 rounded bg-secondary-500/15 px-1.5 py-0.5 font-medium text-secondary-700 dark:text-secondary-400"
-        title={t.issue}
-      >
+      <Pill role="reference" title={t.issue}>
         <CircleDot size={12} />
         Issue
-      </span>
+      </Pill>
     {/if}
 
     {#if t.tags?.length}
       {#each t.tags as tag}
-        <span class="rounded bg-surface-200 px-1.5 py-0.5 dark:bg-surface-700">
-          {tag}
-        </span>
+        <Pill role="tag">{tag}</Pill>
       {/each}
     {/if}
 

--- a/frontend/src/lib/pills.test.ts
+++ b/frontend/src/lib/pills.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { PILL_ROLE_CLASS, pillClass, type PillRole } from './pills.js'
+
+const ROLES: PillRole[] = ['status', 'attention', 'tag', 'reference', 'project']
+
+describe('pill roles', () => {
+  it('defines a treatment for every role', () => {
+    for (const role of ROLES) {
+      expect(PILL_ROLE_CLASS[role]).toBeTruthy()
+    }
+  })
+
+  it('gives each role a distinct treatment', () => {
+    const treatments = ROLES.map((r) => PILL_ROLE_CLASS[r])
+    expect(new Set(treatments).size).toBe(ROLES.length)
+  })
+
+  // A bg-/text-/border- utility keyed to any brand or status palette.
+  const PALETTE_COLOUR = /(?:bg|text|border)-(?:primary|secondary|tertiary|warning|error|success)/
+
+  it('keeps the passive roles monochrome (no status/brand colour baked in)', () => {
+    for (const role of ['tag', 'reference', 'project'] as PillRole[]) {
+      expect(PILL_ROLE_CLASS[role]).not.toMatch(PALETTE_COLOUR)
+    }
+  })
+
+  it('lets status/attention stay colourless so the caller layers status colour', () => {
+    for (const role of ['status', 'attention'] as PillRole[]) {
+      expect(PILL_ROLE_CLASS[role]).not.toMatch(PALETTE_COLOUR)
+      expect(PILL_ROLE_CLASS[role]).not.toMatch(/\bbg-\S/)
+    }
+  })
+})
+
+describe('pillClass', () => {
+  it('returns the role treatment unchanged with no extra', () => {
+    expect(pillClass('tag')).toBe(PILL_ROLE_CLASS.tag)
+  })
+
+  it('appends extra classes (e.g. status colour) after the role treatment', () => {
+    expect(pillClass('status', 'bg-error-200 text-error-800')).toBe(
+      `${PILL_ROLE_CLASS.status} bg-error-200 text-error-800`,
+    )
+  })
+})

--- a/frontend/src/lib/pills.ts
+++ b/frontend/src/lib/pills.ts
@@ -7,9 +7,10 @@
  * gets a distinct, *restrained* shape treatment, so the role reads before the
  * colour does and saturated colour is freed up for the one thing that needs it.
  *
- *  - status     filled, status-coloured — the canonical state (see StatusBadge).
- *               Colour is supplied by the status, not the role.
- *  - attention  filled accent — the single "needs you" signal. Colour supplied.
+ *  - status     the canonical state pill (see StatusBadge). The role supplies a
+ *               rounded, padded shape; the caller layers the status colour/fill.
+ *  - attention  the single "needs you" signal — shape from the role, colour
+ *               layered by the caller.
  *  - tag        outlined, monochrome — user labels; the quietest chip.
  *  - reference  monochrome + icon — an upstream PR/issue reference.
  *  - project    dot + plain text, no pill chrome — a passive association.

--- a/frontend/src/lib/pills.ts
+++ b/frontend/src/lib/pills.ts
@@ -1,0 +1,38 @@
+/**
+ * Pill roles.
+ *
+ * A card (and the detail metadata row) stacks several pill-shaped chips. Before
+ * roles, they were one widget differentiated only by colour — so colour carried
+ * all the meaning and a passive label looked as loud as an action. Each role now
+ * gets a distinct, *restrained* shape treatment, so the role reads before the
+ * colour does and saturated colour is freed up for the one thing that needs it.
+ *
+ *  - status     filled, status-coloured — the canonical state (see StatusBadge).
+ *               Colour is supplied by the status, not the role.
+ *  - attention  filled accent — the single "needs you" signal. Colour supplied.
+ *  - tag        outlined, monochrome — user labels; the quietest chip.
+ *  - reference  monochrome + icon — an upstream PR/issue reference.
+ *  - project    dot + plain text, no pill chrome — a passive association.
+ */
+export type PillRole = 'status' | 'attention' | 'tag' | 'reference' | 'project'
+
+const BASE = 'inline-flex items-center whitespace-nowrap text-xs'
+
+/**
+ * Per-role shape treatment. `status` and `attention` intentionally carry no
+ * colour — the caller layers the status colour on — while `tag`/`reference`/
+ * `project` bake in a monochrome treatment so they can never shout.
+ */
+export const PILL_ROLE_CLASS: Record<PillRole, string> = {
+  status: `${BASE} rounded-full px-2.5 py-0.5 font-medium`,
+  attention: `${BASE} gap-1 rounded-full px-2 py-0.5 font-semibold`,
+  tag: `${BASE} gap-0.5 rounded-full border px-1.5 py-0.5 border-surface-300 text-surface-500 dark:border-surface-600 dark:text-surface-400`,
+  reference: `${BASE} gap-1 rounded px-1.5 py-0.5 font-medium text-surface-600 dark:text-surface-300`,
+  project: `${BASE} gap-1.5 text-surface-500 dark:text-surface-400`,
+}
+
+/** Tailwind classes for a pill of the given role, optionally extended. */
+export function pillClass(role: PillRole, extra = ''): string {
+  const base = PILL_ROLE_CLASS[role]
+  return extra ? `${base} ${extra}` : base
+}


### PR DESCRIPTION
## Motivation

Part of ☂️ #968. On the board, `headless`, `Automaat/blog-engine`, and
`backend` were the *same* pill widget differing only by colour — which is
why saturated orange was doing all the disambiguation work and a passive
label looked as loud as an action.

Closes #995

## Implementation information

Introduce a small design-system primitive:
- `lib/pills.ts` — `PillRole` (`status` | `attention` | `tag` | `reference`
  | `project`) and `pillClass(role, extra?)`. Each role gets a distinct,
  restrained **shape** treatment so the role reads before the colour does.
  `status`/`attention` carry no colour (the caller layers status colour);
  `tag`/`reference`/`project` bake in a monochrome treatment so they can't
  shout.
- `Pill.svelte` — a thin role-driven wrapper.

Adopted across the board card:
- **project** → a small dot + quiet text (no loud amber fill),
- **tag** → outlined monochrome chips,
- the number-less **Issue** affix → a monochrome `reference`,
- the **attention** ("needs you") and **status** (StatusBadge) pills route
  through the role.

Tests lock the taxonomy: every role has a distinct treatment, the passive
roles stay monochrome, and `status`/`attention` stay colourless.

### Scope / coupling
The PR-reference pills keep their CI/review colour for now — the board's
one-accent colour discipline is #972 and merging the PR + Issue references
is #976. Removing the `headless` mode pill is #971. The detail metadata row
adopts the same roles under #985/#989. This PR establishes the system the
rest build on.

> Changelog: refactor(ui): add pill role design system