### PR TITLE
fix(ui): reserve saturated colour for attention

### DIFF
--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -7,6 +7,7 @@
   import { notificationStore } from '../stores/notifications.svelte.js'
   import { awaitsHuman, awaitsHumanLabel } from '../lib/statuses.js'
   import { PRIORITY_OPTIONS } from '../lib/priorities.js'
+  import { projectShortName, projectDotStyle } from '../lib/project-cue.js'
   import StatusPicker from './StatusPicker.svelte'
   import Pill from './Pill.svelte'
 
@@ -128,8 +129,8 @@
 
     {#if t.projectId}
       <Pill role="project" title={t.projectId}>
-        <span class="h-2 w-2 shrink-0 rounded-full bg-surface-400 dark:bg-surface-500"></span>
-        {t.projectId}
+        <span class="h-2 w-2 shrink-0 rounded-full" style={projectDotStyle(t.projectId)}></span>
+        {projectShortName(t.projectId)}
       </Pill>
     {/if}
 
@@ -176,18 +177,19 @@
 
     {#if topPR && isReviewTask}
       {#if topPR.viewerHasApproved}
-        <span class="inline-flex items-center gap-1 rounded bg-success-500/15 px-1.5 py-0.5 font-medium text-success-700 dark:text-success-400" title="Approved; waiting for PR to merge">
+        <Pill role="reference" title="Approved; waiting for PR to merge">
           <GitPullRequest size={12} />
-          #{topPR.number} Approved, waiting merge
-        </span>
+          #{topPR.number}
+          <span class="text-success-500" title="Approved">✓</span>
+        </Pill>
       {:else}
-        <span class="inline-flex items-center gap-1 rounded bg-warning-500/15 px-1.5 py-0.5 font-medium text-warning-700 dark:text-warning-400" title="Review requested">
+        <Pill role="reference" title="Review requested">
           <GitPullRequest size={12} />
-          #{topPR.number} Review needed
-        </span>
+          #{topPR.number} Review
+        </Pill>
       {/if}
     {:else if topPR}
-      <span class="inline-flex items-center gap-1 rounded bg-warning-500/15 px-1.5 py-0.5 font-medium text-warning-700 dark:text-warning-400" title={topPR.title}>
+      <Pill role="reference" title={topPR.title}>
         <GitPullRequest size={12} />
         #{topPR.number}
         {#if topPR.reviewDecision === 'APPROVED'}
@@ -198,12 +200,12 @@
         {#if topPR.mergeable === 'CONFLICTING'}
           <span class="text-error-500" title="Merge conflicts">⚠</span>
         {/if}
-      </span>
+      </Pill>
     {:else if t.prNumber}
-      <span class="inline-flex items-center gap-1 rounded bg-warning-500/15 px-1.5 py-0.5 font-medium text-warning-700 dark:text-warning-400">
+      <Pill role="reference">
         <GitPullRequest size={12} />
         #{t.prNumber}
-      </span>
+      </Pill>
     {/if}
 
     {#if t.issue}

--- a/frontend/src/components/TaskCard.svelte.test.ts
+++ b/frontend/src/components/TaskCard.svelte.test.ts
@@ -196,7 +196,8 @@ describe('TaskCard', () => {
       },
     })
 
-    expect(screen.getByText(/Review needed/)).toBeDefined()
+    expect(screen.getByTitle('Review requested')).toBeDefined()
+    expect(screen.getByText(/#42/)).toBeDefined()
   })
 
   it('shows approved waiting-merge badge for approved review tasks', () => {
@@ -208,7 +209,8 @@ describe('TaskCard', () => {
       },
     })
 
-    expect(screen.getByText(/Approved, waiting merge/)).toBeDefined()
+    expect(screen.getByTitle('Approved; waiting for PR to merge')).toBeDefined()
+    expect(screen.getByText('✓')).toBeDefined()
   })
 
   describe('timeAgo', () => {

--- a/frontend/src/components/task-detail/AgentHistoryList.svelte
+++ b/frontend/src/components/task-detail/AgentHistoryList.svelte
@@ -4,6 +4,8 @@
   import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { GetAgentRunLog, GetAgentRunConvoLog } from '$lib/api'
   import { formatDateTime } from '../../lib/dates.js'
+  import { formatCostShort } from '../../lib/cost.js'
+  import { runStateClasses } from '../../lib/agent-run.js'
   import StreamOutput from '../StreamOutput.svelte'
   import MessageBubble from '../MessageBubble.svelte'
   import ProviderLogo from '../ProviderLogo.svelte'
@@ -85,15 +87,13 @@
             {/if}
             <span class="font-mono text-surface-400">{run.agentId}</span>
             <span class="rounded bg-surface-200 px-1.5 py-0.5 dark:bg-surface-700">{run.mode}</span>
-            <span
-              class="rounded px-1.5 py-0.5 {run.state === 'stopped' ? 'bg-surface-200 dark:bg-surface-700' : 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200'}"
-            >
+            <span class="rounded px-1.5 py-0.5 {runStateClasses(run.state || 'running')}">
               {run.state || 'running'}
             </span>
           </div>
           <div class="flex items-center gap-3 text-surface-400">
             {#if run.costUsd > 0}
-              <span>${run.costUsd.toFixed(4)}</span>
+              <span class="tabular-nums">{formatCostShort(run.costUsd)}</span>
             {/if}
             <span>{formatDateTime(run.startedAt)}</span>
             <ChevronDown size={16} class="transition-transform {expandedRun === run.agentId ? 'rotate-180' : ''}" />

--- a/frontend/src/lib/agent-run.test.ts
+++ b/frontend/src/lib/agent-run.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { runStateClasses } from './agent-run.js'
+
+describe('runStateClasses', () => {
+  // The actual persisted terminal state for finished runs — must be neutral,
+  // never the amber (primary) action colour that made it look like an alarm.
+  it('renders the real "stopped" finished state as neutral grey, not amber', () => {
+    const cls = runStateClasses('stopped')
+    expect(cls).toMatch(/surface/)
+    expect(cls).not.toMatch(/primary/)
+  })
+
+  it('only the live running state keeps the amber action colour', () => {
+    expect(runStateClasses('running')).toMatch(/primary/)
+  })
+
+  it('maps explicit positive outcomes to muted green', () => {
+    for (const s of ['completed', 'done', 'success']) {
+      expect(runStateClasses(s)).toMatch(/success/)
+      expect(runStateClasses(s)).not.toMatch(/primary/)
+    }
+  })
+
+  it('maps failures to coral, never amber', () => {
+    for (const s of ['failed', 'error']) {
+      expect(runStateClasses(s)).toMatch(/error/)
+      expect(runStateClasses(s)).not.toMatch(/primary/)
+    }
+  })
+
+  it('falls back to neutral grey for unknown states', () => {
+    expect(runStateClasses('mystery')).toMatch(/surface/)
+    expect(runStateClasses('mystery')).not.toMatch(/primary/)
+  })
+})

--- a/frontend/src/lib/agent-run.ts
+++ b/frontend/src/lib/agent-run.ts
@@ -1,0 +1,23 @@
+// Treatment for an agent run's state pill in the history list.
+//
+// A finished run is inert, so it must never wear the amber action colour. The
+// backend persists "stopped" for every finished headless run (it doesn't record
+// success vs failure separately), so that — the common real case — is neutral
+// grey: honest, and no longer the orange alarm. Only a live "running" run gets
+// amber. Explicit outcome labels ("completed"/"failed") that may appear in
+// hand-authored or future data map to muted green/coral rather than orange.
+export function runStateClasses(state: string): string {
+  switch (state) {
+    case 'completed':
+    case 'done':
+    case 'success':
+      return 'bg-success-100 text-success-700 dark:bg-success-900/50 dark:text-success-300'
+    case 'failed':
+    case 'error':
+      return 'bg-error-100 text-error-700 dark:bg-error-900/50 dark:text-error-300'
+    case 'running':
+      return 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200'
+    default: // stopped (the usual finished state), paused, idle, unknown
+      return 'bg-surface-200 text-surface-700 dark:bg-surface-700 dark:text-surface-300'
+  }
+}

--- a/frontend/src/lib/cost.test.ts
+++ b/frontend/src/lib/cost.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { formatCost } from './cost.js'
+import { formatCost, formatCostShort } from './cost.js'
 
 describe('formatCost', () => {
   it('uses a uniform 4-decimal precision', () => {
@@ -20,5 +20,26 @@ describe('formatCost', () => {
     expect(formatCost(undefined)).toBe('$0.0000')
     expect(formatCost(null)).toBe('$0.0000')
     expect(formatCost(Number.NaN)).toBe('$0.0000')
+  })
+})
+
+describe('formatCostShort', () => {
+  it('uses two decimals for at-a-glance lists', () => {
+    expect(formatCostShort(0.88)).toBe('$0.88')
+    expect(formatCostShort(0.8758)).toBe('$0.88')
+    expect(formatCostShort(5)).toBe('$5.00')
+  })
+
+  it('floors real sub-cent costs to <$0.01 instead of $0.00', () => {
+    expect(formatCostShort(0.0028)).toBe('<$0.01')
+  })
+
+  it('shows exact zero as $0.00', () => {
+    expect(formatCostShort(0)).toBe('$0.00')
+  })
+
+  it('coerces non-finite input to zero', () => {
+    expect(formatCostShort(undefined)).toBe('$0.00')
+    expect(formatCostShort(Number.NaN)).toBe('$0.00')
   })
 })

--- a/frontend/src/lib/cost.ts
+++ b/frontend/src/lib/cost.ts
@@ -6,3 +6,12 @@ export function formatCost(usd: number | null | undefined): string {
   const n = Number.isFinite(usd) ? (usd as number) : 0
   return `$${n.toFixed(4)}`
 }
+
+// Compact cost for at-a-glance lists (e.g. agent history rows) where 4 decimals
+// are noise. Two decimals, with a "<$0.01" floor so a real sub-cent run never
+// reads as a free "$0.00".
+export function formatCostShort(usd: number | null | undefined): string {
+  const n = Number.isFinite(usd) ? (usd as number) : 0
+  if (n > 0 && n < 0.005) return '<$0.01'
+  return `$${n.toFixed(2)}`
+}

--- a/frontend/src/lib/project-cue.test.ts
+++ b/frontend/src/lib/project-cue.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { projectShortName, projectDotStyle } from './project-cue.js'
+
+describe('projectShortName', () => {
+  it('drops the owner prefix', () => {
+    expect(projectShortName('Automaat/home-dashboard')).toBe('home-dashboard')
+  })
+
+  it('returns the id unchanged when there is no owner', () => {
+    expect(projectShortName('home-dashboard')).toBe('home-dashboard')
+  })
+
+  it('keeps only the last segment for nested paths', () => {
+    expect(projectShortName('org/group/repo')).toBe('repo')
+  })
+})
+
+describe('projectDotStyle', () => {
+  it('is deterministic for a given project', () => {
+    expect(projectDotStyle('Automaat/a')).toBe(projectDotStyle('Automaat/a'))
+  })
+
+  it('differs between projects', () => {
+    expect(projectDotStyle('Automaat/a')).not.toBe(projectDotStyle('Automaat/b'))
+  })
+
+  it('produces a restrained OKLCH colour (fixed lightness/chroma)', () => {
+    expect(projectDotStyle('x')).toMatch(/^background-color: oklch\(0\.68 0\.11 \d{1,3}deg\)$/)
+  })
+})

--- a/frontend/src/lib/project-cue.test.ts
+++ b/frontend/src/lib/project-cue.test.ts
@@ -25,6 +25,6 @@ describe('projectDotStyle', () => {
   })
 
   it('produces a restrained OKLCH colour (fixed lightness/chroma)', () => {
-    expect(projectDotStyle('x')).toMatch(/^background-color: oklch\(0\.68 0\.11 \d{1,3}deg\)$/)
+    expect(projectDotStyle('x')).toMatch(/^background-color: oklch\(68% 0\.11 \d{1,3}deg\)$/)
   })
 })

--- a/frontend/src/lib/project-cue.ts
+++ b/frontend/src/lib/project-cue.ts
@@ -1,0 +1,25 @@
+// A board card associates a task with a project. Rendered as a loud filled
+// label it dominated the card and burned the one saturated colour that should
+// mean "act on me". These helpers demote it to a quiet cue: the owner prefix
+// (constant repeated ink) is dropped from the visible label, and a small dot
+// keyed to the project gives an at-a-glance, restrained distinction.
+
+/** Drop the constant `owner/` prefix; the full id stays in the tooltip. */
+export function projectShortName(projectId: string): string {
+  const slash = projectId.lastIndexOf('/')
+  return slash >= 0 ? projectId.slice(slash + 1) : projectId
+}
+
+/**
+ * A stable, muted dot colour keyed to the project id. Inline OKLCH (fixed
+ * lightness/chroma, hashed hue) so it stays restrained, never collides with the
+ * amber action colour, and isn't subject to Tailwind class purging.
+ */
+export function projectDotStyle(projectId: string): string {
+  let h = 0
+  for (let i = 0; i < projectId.length; i++) {
+    h = (Math.imul(h, 31) + projectId.charCodeAt(i)) >>> 0
+  }
+  const hue = h % 360
+  return `background-color: oklch(0.68 0.11 ${hue}deg)`
+}

--- a/frontend/src/lib/project-cue.ts
+++ b/frontend/src/lib/project-cue.ts
@@ -12,8 +12,10 @@ export function projectShortName(projectId: string): string {
 
 /**
  * A stable, muted dot colour keyed to the project id. Inline OKLCH (fixed
- * lightness/chroma, hashed hue) so it stays restrained, never collides with the
- * amber action colour, and isn't subject to Tailwind class purging.
+ * lightness/chroma, hashed hue) so it stays restrained — the low chroma keeps
+ * it from competing with the saturated amber action colour even if the hashed
+ * hue lands near amber — and isn't subject to Tailwind class purging. Lightness
+ * is a percentage to match the theme's `oklch(…%)` tokens.
  */
 export function projectDotStyle(projectId: string): string {
   let h = 0
@@ -21,5 +23,5 @@ export function projectDotStyle(projectId: string): string {
     h = (Math.imul(h, 31) + projectId.charCodeAt(i)) >>> 0
   }
   const hue = h % 360
-  return `background-color: oklch(0.68 0.11 ${hue}deg)`
+  return `background-color: oklch(68% 0.11 ${hue}deg)`
 }


### PR DESCRIPTION
## Motivation

Part of ☂️ #968. On the board, up to five colours competed at equal
saturation (orange project fill, coloured PR/Issue pills, the red attention
pill), so nothing won and the one colour that should mean "act on me" was
diluted. In agent history, a finished run wore the same amber as the live
"Start agent" action, reading like an alarm.

Closes #969
Closes #972
Closes #987

## Implementation information

- **#969** — `lib/project-cue.ts`: drop the constant `owner/` prefix from the
  card label (full id stays in the tooltip) and key a small, restrained OKLCH
  dot to the project instead of a loud filled bar.
- **#972** — the card's PR references become monochrome `reference` pills
  (the tiny approved/changes/conflict glyphs remain as micro-signifiers), so
  the red attention pill is the only saturated *fill* on a card.
- **#987** — `lib/agent-run.ts` `runStateClasses`: a finished run never wears
  the amber action colour. Cost shows two decimals with a `<$0.01` floor
  (`lib/cost.ts` `formatCostShort`) instead of four.

All three are unit-tested (project cue, cost formatting, run-state treatment).

## Open questions

The backend persists `state: "stopped"` for every finished headless run and
does not record success vs failure separately, so a finished run renders
neutral grey (honest — the outcome isn't known) rather than green/red. The
green/coral treatments apply to explicit outcome labels that appear in
hand-authored/synthetic data. Surfacing a real per-run success/failure signal
would need backend outcome tracking — out of scope here; flagging as a
possible follow-up.

> Changelog: fix(ui): reserve saturated colour for board attention