### PR TITLE
refactor(board): slim card to one meta line

### DIFF
--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -122,23 +122,29 @@
     </a>
   {/if}
 
-  <div class="flex flex-wrap items-center gap-1.5 text-xs text-surface-500">
-    <span class="rounded bg-surface-200 px-1.5 py-0.5 dark:bg-surface-700">
-      {t.agentMode}
+  {#snippet issueGlyph()}
+    <!-- A linked issue alongside a PR: a real tooltip + accessible name (a
+         lucide `title` prop only lands as an inert SVG attribute). -->
+    <span title={t.issue} aria-label="Also linked to an issue" class="inline-flex items-center">
+      <CircleDot size={11} class="opacity-60" aria-hidden="true" />
     </span>
+  {/snippet}
+
+  <div class="flex flex-wrap items-center gap-1.5 text-xs text-surface-500">
+    {#if t.agentMode === 'interactive'}
+      <span
+        class="inline-flex items-center rounded bg-surface-200 px-1.5 py-0.5 text-surface-500 dark:bg-surface-700 dark:text-surface-400"
+        title="Interactive agent"
+      >
+        interactive
+      </span>
+    {/if}
 
     {#if t.projectId}
       <Pill role="project" title={t.projectId}>
         <span class="h-2 w-2 shrink-0 rounded-full" style={projectDotStyle(t.projectId)}></span>
         {projectShortName(t.projectId)}
       </Pill>
-    {/if}
-
-    {#if t.branch}
-      <span class="inline-flex items-center gap-1 rounded bg-surface-200 px-1.5 py-0.5 font-mono dark:bg-surface-700">
-        <svg class="h-3 w-3 shrink-0" viewBox="0 0 16 16" fill="currentColor"><title>Branch</title><path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.493 2.493 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Z"/></svg>
-        {t.branch.replace(/^sybra\//, '')}
-      </span>
     {/if}
 
     {#if triaging}
@@ -181,11 +187,13 @@
           <GitPullRequest size={12} />
           #{topPR.number}
           <span class="text-success-500" title="Approved">✓</span>
+          {#if t.issue}{@render issueGlyph()}{/if}
         </Pill>
       {:else}
         <Pill role="reference" title="Review requested">
           <GitPullRequest size={12} />
           #{topPR.number} Review
+          {#if t.issue}{@render issueGlyph()}{/if}
         </Pill>
       {/if}
     {:else if topPR}
@@ -200,15 +208,15 @@
         {#if topPR.mergeable === 'CONFLICTING'}
           <span class="text-error-500" title="Merge conflicts">⚠</span>
         {/if}
+        {#if t.issue}{@render issueGlyph()}{/if}
       </Pill>
     {:else if t.prNumber}
       <Pill role="reference">
         <GitPullRequest size={12} />
         #{t.prNumber}
+        {#if t.issue}{@render issueGlyph()}{/if}
       </Pill>
-    {/if}
-
-    {#if t.issue}
+    {:else if t.issue}
       <Pill role="reference" title={t.issue}>
         <CircleDot size={12} />
         Issue
@@ -216,12 +224,13 @@
     {/if}
 
     {#if t.tags?.length}
-      {#each t.tags as tag}
-        <Pill role="tag">{tag}</Pill>
-      {/each}
+      <Pill role="tag">{t.tags[0]}</Pill>
+      {#if t.tags.length > 1}
+        <span class="text-surface-400" title={t.tags.join(', ')}>+{t.tags.length - 1}</span>
+      {/if}
     {/if}
 
-    <span class="ml-auto opacity-60">{timeAgo(t.updatedAt)}</span>
+    <span class="ml-auto text-[11px] text-surface-400/80">{timeAgo(t.updatedAt)}</span>
   </div>
   </button>
   {#if t.projectId}

--- a/frontend/src/components/TaskCard.svelte.test.ts
+++ b/frontend/src/components/TaskCard.svelte.test.ts
@@ -79,9 +79,14 @@ describe('TaskCard', () => {
     expect(screen.getByText('Test Task')).toBeDefined()
   })
 
-  it('renders agent mode', () => {
+  it('does not show a pill for the default headless mode', () => {
     render(TaskCard, { props: { task: mockTask, onclick: () => {} } })
-    expect(screen.getByText('headless')).toBeDefined()
+    expect(screen.queryByText('headless')).toBeNull()
+  })
+
+  it('marks the minority interactive mode by exception', () => {
+    render(TaskCard, { props: { task: { ...mockTask, agentMode: 'interactive' }, onclick: () => {} } })
+    expect(screen.getByText('interactive')).toBeDefined()
   })
 
   it('renders tags when present', () => {
@@ -213,6 +218,30 @@ describe('TaskCard', () => {
     expect(screen.getByText('✓')).toBeDefined()
   })
 
+  it('keeps an accessible "issue exists" cue when a PR and an issue coexist', () => {
+    render(TaskCard, {
+      props: {
+        task: { ...mockTask, prNumber: 42, issue: 'https://github.com/owner/repo/issues/7' } as Task,
+        onclick: () => {},
+      },
+    })
+    // The PR is the primary reference; the issue must not be silently dropped.
+    expect(screen.getByText(/#42/)).toBeDefined()
+    const cue = screen.getByLabelText('Also linked to an issue')
+    expect(cue).toBeDefined()
+    expect(cue.getAttribute('title')).toBe('https://github.com/owner/repo/issues/7')
+  })
+
+  it('shows a standalone issue reference when there is no PR', () => {
+    render(TaskCard, {
+      props: {
+        task: { ...mockTask, issue: 'https://github.com/owner/repo/issues/7' } as Task,
+        onclick: () => {},
+      },
+    })
+    expect(screen.getByText('Issue')).toBeDefined()
+  })
+
   describe('timeAgo', () => {
     beforeEach(() => {
       vi.useFakeTimers()
@@ -226,8 +255,8 @@ describe('TaskCard', () => {
     it('returns empty string for falsy date', () => {
       const taskNullDate = { ...mockTask, updatedAt: '' }
       vi.setSystemTime(new Date('2026-04-01T12:00:00Z'))
-      render(TaskCard, { props: { task: taskNullDate, onclick: () => {} } })
-      const timeSpan = screen.getByText('headless').parentElement?.querySelector('.ml-auto')
+      const { container } = render(TaskCard, { props: { task: taskNullDate, onclick: () => {} } })
+      const timeSpan = container.querySelector('.ml-auto')
       expect(timeSpan?.textContent).toBe('')
     })
 


### PR DESCRIPTION
## Motivation

Part of ☂️ #968. A board card stacked four-to-five full-width bands under the
title (mode badge → project → branch → PR/Issue pills → tag+timestamp), so it
read as a pile of strips rather than one calm object.

Closes #970
Closes #971
Closes #976
Closes #977

## Implementation information

- **#971** — drop the per-card `headless` pill (it's on ~every card, so it
  carries no information); mark only the minority `interactive` mode by
  exception, so the eye lands on the exception.
- **#970** — drop the branch band (branch is in the detail view and the
  hover copy-branch footer already), collapsing the card to title + one meta
  line + footer.
- **#976** — merge the PR and the number-less Issue pills into one reference
  affix. When both exist the PR is primary with a small issue glyph; the glyph
  is a titled, `aria-label`led span (a lucide `title` prop only lands as an
  inert SVG attribute), so "an issue also exists" is not silently dropped for
  mouse or screen-reader users.
- **#977** — show at most one tag with a `+N` overflow (full set in the
  tooltip), and render the timestamp as faint right-aligned text.

Tests cover the interactive-by-exception marker and the PR+issue coexistence
cue (tooltip + accessible name).

> Changelog: refactor(board): slim the task card to one meta line