### PR TITLE
fix(detail): show actionable status sub-state

### DIFF
--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -5,7 +5,7 @@
   import { agentStore } from '../stores/agents.svelte.js'
   import { reviewStore } from '../stores/reviews.svelte.js'
   import { notificationStore } from '../stores/notifications.svelte.js'
-  import { awaitsHuman, awaitsHumanLabel } from '../lib/statuses.js'
+  import { awaitsHuman, awaitsHumanLabel, coreStatus, statusLabel } from '../lib/statuses.js'
   import { PRIORITY_OPTIONS } from '../lib/priorities.js'
   import { projectShortName, projectDotStyle } from '../lib/project-cue.js'
   import StatusPicker from './StatusPicker.svelte'
@@ -61,6 +61,14 @@
 
   // Task is waiting on the user (not an agent) — drives the red tile accent.
   const needsYou = $derived(awaitsHuman(t.status))
+
+  // A granular sub-state folded into this column that ISN'T an attention state
+  // (e.g. `new` in Todo, `ready-review` in In Review). The column shows the
+  // workflow stage; this quiet badge shows the precise sub-state, keeping the
+  // two board axes separate instead of silently merging the state away.
+  const subStateLabel = $derived(
+    !needsYou && coreStatus(t.status) !== t.status ? statusLabel(t.status) : '',
+  )
 
   function priorityMeta(p: string | undefined) {
     return PRIORITY_OPTIONS.find(o => o.value === (p ?? '')) ?? PRIORITY_OPTIONS[0]
@@ -165,6 +173,10 @@
       <Pill role="attention" class="bg-error-200 text-error-800 dark:bg-error-700 dark:text-error-200">
         {awaitsHumanLabel(t.status)}
       </Pill>
+    {:else if subStateLabel}
+      <span class="inline-flex items-center rounded-full bg-surface-200 px-2 py-0.5 text-surface-600 dark:bg-surface-700 dark:text-surface-300">
+        {subStateLabel}
+      </span>
     {/if}
 
     {#if agentRunning}

--- a/frontend/src/components/TaskCard.svelte.test.ts
+++ b/frontend/src/components/TaskCard.svelte.test.ts
@@ -173,6 +173,18 @@ describe('TaskCard', () => {
     expect(screen.getByText('Human Required')).toBeDefined()
   })
 
+  it('shows a quiet sub-state badge for a folded non-attention status', () => {
+    // `new` rolls up to the Todo column; surface the precise sub-state so the
+    // two board axes (stage column vs sub-state) stay separate.
+    render(TaskCard, { props: { task: { ...mockTask, status: 'new' as Task['status'] }, onclick: () => {} } })
+    expect(screen.getByText('New')).toBeDefined()
+  })
+
+  it('does not show a sub-state badge for a plain core status', () => {
+    render(TaskCard, { props: { task: mockTask, onclick: () => {} } })
+    expect(screen.queryByText('Todo')).toBeNull()
+  })
+
   it('shows Blocked badge for blocked status', () => {
     render(TaskCard, { props: { task: { ...mockTask, status: 'blocked' as Task['status'] }, onclick: () => {} } })
     expect(screen.getByText('Blocked')).toBeDefined()

--- a/frontend/src/components/task-detail/TaskStatusBanner.svelte
+++ b/frontend/src/components/task-detail/TaskStatusBanner.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { AlertTriangle, Info } from '@lucide/svelte'
+  import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
+  import { statusSummary } from '../../lib/status-summary.js'
+
+  interface Props {
+    task: Task
+  }
+
+  const { task }: Props = $props()
+
+  const summary = $derived(statusSummary(task.status))
+  // Attention sub-states (or any status_reason) warrant the warm banner; a
+  // quiet folded sub-state uses neutral surface styling.
+  const tone = $derived(summary?.tone === 'info' && !task.statusReason ? 'info' : 'attention')
+</script>
+
+{#if summary || task.statusReason}
+  <div
+    role="status"
+    class="flex items-start gap-2 rounded-md border px-3 py-2 text-sm {tone === 'attention'
+      ? 'border-warning-300 bg-warning-50 text-warning-800 dark:border-warning-700 dark:bg-warning-900/40 dark:text-warning-200'
+      : 'border-surface-300 bg-surface-100 text-surface-700 dark:border-surface-600 dark:bg-surface-800 dark:text-surface-300'}"
+  >
+    {#if tone === 'attention'}
+      <AlertTriangle size={16} class="mt-0.5 shrink-0" />
+    {:else}
+      <Info size={16} class="mt-0.5 shrink-0" />
+    {/if}
+    <div class="flex flex-col gap-0.5">
+      {#if summary}
+        <span>
+          <span class="font-semibold">{summary.label}</span>{#if summary.hint} — {summary.hint}{/if}
+        </span>
+      {/if}
+      {#if task.statusReason}
+        <span class={summary ? 'opacity-90' : ''}>{task.statusReason}</span>
+      {/if}
+    </div>
+  </div>
+{/if}

--- a/frontend/src/components/task-detail/TaskStatusBanner.svelte.test.ts
+++ b/frontend/src/components/task-detail/TaskStatusBanner.svelte.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/svelte'
+import TaskStatusBanner from './TaskStatusBanner.svelte'
+import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
+
+function task(overrides: Record<string, unknown> = {}): Task {
+  return { status: 'in-progress', statusReason: '', ...overrides } as unknown as Task
+}
+
+describe('TaskStatusBanner', () => {
+  it('surfaces an awaiting sub-state with an action hint (detail >= board)', () => {
+    render(TaskStatusBanner, { props: { task: task({ status: 'plan-review' }) } })
+    expect(screen.getByText('Plan Review')).toBeDefined()
+    expect(screen.getByText(/awaiting your approval/)).toBeDefined()
+  })
+
+  it('surfaces a quiet folded sub-state (ready-review) the dropdown would hide', () => {
+    render(TaskStatusBanner, { props: { task: task({ status: 'ready-review' }) } })
+    expect(screen.getByText('Ready for Review')).toBeDefined()
+  })
+
+  it('renders nothing for a plain core status with no reason', () => {
+    const { container } = render(TaskStatusBanner, { props: { task: task({ status: 'in-progress' }) } })
+    expect(container.querySelector('[role="status"]')).toBeNull()
+  })
+
+  it('shows the status reason when present', () => {
+    render(TaskStatusBanner, {
+      props: { task: task({ status: 'in-progress', statusReason: 'Waiting on upstream fix' }) },
+    })
+    expect(screen.getByText('Waiting on upstream fix')).toBeDefined()
+  })
+
+  it('uses the warm (attention) styling when a folded sub-state also has a reason', () => {
+    const { container } = render(TaskStatusBanner, {
+      props: { task: task({ status: 'ready-review', statusReason: 'CI is red' }) },
+    })
+    // A status_reason elevates an otherwise-quiet sub-state to the warm banner.
+    expect(container.querySelector('[role="status"]')?.className).toMatch(/border-warning/)
+  })
+})

--- a/frontend/src/lib/status-summary.test.ts
+++ b/frontend/src/lib/status-summary.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { statusSummary } from './status-summary.js'
+import { statusLabel } from './statuses.js'
+
+describe('statusSummary', () => {
+  it('surfaces awaiting-human states as attention with an action hint', () => {
+    const s = statusSummary('plan-review')
+    expect(s).toEqual({ label: 'Plan Review', hint: 'awaiting your approval', tone: 'attention' })
+  })
+
+  it('uses the canonical label, never an invented one', () => {
+    expect(statusSummary('human-required')?.label).toBe(statusLabel('human-required'))
+    expect(statusSummary('blocked')?.label).toBe(statusLabel('blocked'))
+  })
+
+  it('surfaces a non-attention folded sub-state quietly as info', () => {
+    // ready-review rolls up to the in-review column; new rolls up to todo.
+    expect(statusSummary('ready-review')).toEqual({ label: statusLabel('ready-review'), hint: '', tone: 'info' })
+    expect(statusSummary('new')).toEqual({ label: statusLabel('new'), hint: '', tone: 'info' })
+  })
+
+  it('returns null for a plain core status that matches its column', () => {
+    expect(statusSummary('in-progress')).toBeNull()
+    expect(statusSummary('todo')).toBeNull()
+    expect(statusSummary('testing')).toBeNull()
+  })
+
+  it('returns null for terminal states', () => {
+    expect(statusSummary('done')).toBeNull()
+    expect(statusSummary('cancelled')).toBeNull()
+  })
+})

--- a/frontend/src/lib/status-summary.ts
+++ b/frontend/src/lib/status-summary.ts
@@ -1,0 +1,39 @@
+import { awaitsHuman, coreStatus, statusLabel } from './statuses.js'
+
+// The detail page must never show *less* state than the board: a board card in
+// the "Planning" column can read "Plan Review" (awaiting you), but the detail
+// status control only shows the rolled-up column status. This derives the
+// actionable sub-state to surface as a banner under the title.
+
+export type StatusTone = 'attention' | 'info'
+
+export interface StatusSummary {
+  /** Canonical status label — same vocabulary as board/list. */
+  label: string
+  /** What the user should do, when the state implies an action. */
+  hint: string
+  tone: StatusTone
+}
+
+const HINTS: Record<string, string> = {
+  'plan-review': 'awaiting your approval',
+  'test-plan-review': 'awaiting your approval',
+  'human-required': 'needs your input',
+  blocked: 'needs your response',
+}
+
+/**
+ * The sub-state worth surfacing on detail, or null for a plain core status that
+ * matches its column (those get a per-state summary separately). Awaiting-human
+ * states are `attention`; other granular states folded into a column (new,
+ * ready-review) are surfaced quietly as `info` so detail still mirrors the board.
+ */
+export function statusSummary(status: string): StatusSummary | null {
+  if (awaitsHuman(status)) {
+    return { label: statusLabel(status), hint: HINTS[status] ?? '', tone: 'attention' }
+  }
+  if (coreStatus(status) !== status) {
+    return { label: statusLabel(status), hint: '', tone: 'info' }
+  }
+  return null
+}

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { ChevronLeft, AlertTriangle } from '@lucide/svelte'
+  import { ChevronLeft } from '@lucide/svelte'
   import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { taskStore } from '../stores/tasks.svelte.js'
   import TaskHeaderBar from '../components/task-detail/TaskHeaderBar.svelte'
+  import TaskStatusBanner from '../components/task-detail/TaskStatusBanner.svelte'
   import TaskMetadataRow from '../components/task-detail/TaskMetadataRow.svelte'
   import TaskPullRequestsPanel from '../components/task-detail/TaskPullRequestsPanel.svelte'
   import TaskDescriptionEditor from '../components/task-detail/TaskDescriptionEditor.svelte'
@@ -96,15 +97,7 @@
   {#if t}
     <div class="flex flex-col gap-6">
       <TaskHeaderBar task={t} {ondelete} />
-      {#if t.statusReason}
-        <div
-          class="flex items-start gap-2 rounded-md border border-warning-300 bg-warning-50 px-3 py-2 text-sm text-warning-800 dark:border-warning-700 dark:bg-warning-900/40 dark:text-warning-200"
-          role="status"
-        >
-          <AlertTriangle size={16} class="mt-0.5 shrink-0" />
-          <span>{t.statusReason}</span>
-        </div>
-      {/if}
+      <TaskStatusBanner task={t} />
       <TaskMetadataRow task={t} />
       <TaskPullRequestsPanel task={t} />
       <TaskDescriptionEditor task={t} />


### PR DESCRIPTION
## Motivation

Part of ☂️ #968. On the board a task shows "Plan Review"; open it and the
status dropdown reads plain "Planning" — the signal that told you to act is
gone in the place you go to act. And on the board, sub-states with no column
of their own were silently merged into another column.

Closes #983
Closes #993

## Implementation information

- **#983** — `lib/status-summary.ts` derives the actionable sub-state, and
  `TaskStatusBanner` renders it under the title: "Plan Review — awaiting your
  approval" for awaiting states, a quiet line for folded states like
  ready-review. It absorbs the old inline `status_reason` banner (strict
  superset — no reason is ever dropped), so the detail page never shows less
  state than the board. The status dropdown stays a core-status control.
- **#993** — separate the board's two axes. Columns remain workflow stage; a
  folded non-attention sub-state (`new` in Todo, `ready-review` in In Review)
  now shows a quiet neutral badge instead of being silently merged, while
  awaiting states keep the single red attention badge. (Per the umbrella, no
  columns were merged — Planning and Testing stay distinct stages.)

Unit tests cover the summary derivation across all statuses, the banner tones
(attention / info / reason-elevated), and the board sub-state badge.

> Changelog: fix(detail): show actionable status sub-state on detail and board