### PR TITLE
ci(actions): add auto-merge-on-green workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,23 @@
+# Auto-merge PRs labeled "automerge" once all required checks pass.
+# Uses GitHub native auto-merge; requires repo setting allow_auto_merge=true.
+name: Auto-merge
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: contains(github.event.pull_request.labels.*.name, 'automerge')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge on green
+        run: gh pr merge --auto --squash "${PR}"
+        env:
+          PR: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Motivation

Enable hands-off merging of PRs once CI is green, reducing manual babysitting of the merge queue.

## Implementation information

Added `.github/workflows/auto-merge.yml`. It triggers on PR events, and when a PR carries the `automerge` label it enables GitHub native auto-merge (`gh pr merge --auto --squash`) so the PR merges automatically after required checks pass. Requires repo setting `allow_auto_merge=true`.

No release workflow added: a release mechanism already exists in `docker-publish.yml`, which tags, builds/pushes the image, generates notes, and runs `gh release create`.

> Changelog: skip