### PR TITLE
fix(detail): polish affordances and metadata

### DIFF
--- a/frontend/e2e/tasks.spec.ts
+++ b/frontend/e2e/tasks.spec.ts
@@ -108,7 +108,9 @@ test.describe('Task Detail', () => {
 
     await expect(page.locator('h1', { hasText: 'Implement auth middleware' })).toBeVisible()
     await expect(page.getByText('Back to tasks')).toBeVisible()
-    await expect(page.locator('h2', { hasText: 'Task Detail' })).toBeVisible()
+    // The generic "Task Detail" chrome heading is intentionally gone — the task
+    // title (h1) plus "Back to tasks" are the heading and orientation.
+    await expect(page.locator('h2', { hasText: 'Task Detail' })).toHaveCount(0)
   })
 
   test('shows task metadata', async ({ page }) => {

--- a/frontend/src/components/shell/AppShell.svelte
+++ b/frontend/src/components/shell/AppShell.svelte
@@ -41,7 +41,11 @@
   <div class="flex min-w-0 flex-1 flex-col overflow-hidden">
     {#if viewport.isDesktop}
       <header class="flex shrink-0 items-center justify-between gap-4 border-b border-surface-200 bg-surface-50 px-4 py-3 dark:border-surface-700 dark:bg-surface-900">
-        <h2 class="text-lg font-semibold">{navStore.pageTitle}</h2>
+        {#if navStore.pageTitle}
+          <h2 class="text-lg font-semibold">{navStore.pageTitle}</h2>
+        {:else}
+          <div></div>
+        {/if}
         <div class="flex items-center gap-2">
           <BgOpsIndicator />
           {#if primaryAction}

--- a/frontend/src/components/shell/MobileAppBar.svelte
+++ b/frontend/src/components/shell/MobileAppBar.svelte
@@ -32,7 +32,11 @@
       <span class="px-2 text-base font-bold text-primary-600 dark:text-primary-400">S</span>
     {/if}
 
-    <h1 class="flex-1 truncate text-base font-semibold">{navStore.pageTitle}</h1>
+    {#if navStore.pageTitle}
+      <h1 class="flex-1 truncate text-base font-semibold">{navStore.pageTitle}</h1>
+    {:else}
+      <div class="flex-1"></div>
+    {/if}
 
     <button
       type="button"

--- a/frontend/src/components/task-detail/AgentHistoryList.svelte
+++ b/frontend/src/components/task-detail/AgentHistoryList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ChevronDown } from '@lucide/svelte'
+  import { ChevronDown, RefreshCw } from '@lucide/svelte'
   import type { ConvoEvent, StreamEvent } from '../../../bindings/github.com/Automaat/sybra/internal/agent/models.js'
   import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { GetAgentRunLog, GetAgentRunConvoLog } from '$lib/api'
@@ -30,18 +30,10 @@
     (task.agentRuns ?? []).filter((r) => r.state !== 'running').reverse(),
   )
 
-  async function toggleRunLog(agentId: string) {
-    if (expandedRun === agentId) {
-      expandedRun = null
-      return
-    }
-    expandedRun = agentId
+  async function loadRunLog(agentId: string) {
     const run = (task.agentRuns ?? []).find((r) => r.agentId === agentId)
     const isInteractive = run?.mode === 'interactive'
-    const alreadyLoaded = isInteractive
-      ? runLogConvoEvents.has(agentId)
-      : runLogStreamEvents.has(agentId)
-    if (alreadyLoaded || runLogLoading.has(agentId) || !task.id) return
+    if (runLogLoading.has(agentId) || !task.id) return
     runLogLoading = new Set([...runLogLoading, agentId])
     try {
       if (isInteractive) {
@@ -67,6 +59,33 @@
     const next = new Set(runLogLoading)
     next.delete(agentId)
     runLogLoading = next
+  }
+
+  async function toggleRunLog(agentId: string) {
+    if (expandedRun === agentId) {
+      expandedRun = null
+      return
+    }
+    expandedRun = agentId
+    const run = (task.agentRuns ?? []).find((r) => r.agentId === agentId)
+    const isInteractive = run?.mode === 'interactive'
+    const alreadyLoaded = isInteractive
+      ? runLogConvoEvents.has(agentId)
+      : runLogStreamEvents.has(agentId)
+    if (alreadyLoaded) return
+    await loadRunLog(agentId)
+  }
+
+  // Drop the cached empty result + error so the next load re-fetches.
+  async function retryRunLog(agentId: string) {
+    const run = (task.agentRuns ?? []).find((r) => r.agentId === agentId)
+    if (run?.mode === 'interactive') {
+      const m = new Map(runLogConvoEvents); m.delete(agentId); runLogConvoEvents = m
+    } else {
+      const m = new Map(runLogStreamEvents); m.delete(agentId); runLogStreamEvents = m
+    }
+    const e = new Map(runLogError); e.delete(agentId); runLogError = e
+    await loadRunLog(agentId)
   }
 </script>
 
@@ -118,7 +137,25 @@
             {:else if run.mode !== 'interactive' && (runLogStreamEvents.get(run.agentId)?.length ?? 0) > 0}
               <StreamOutput staticEvents={runLogStreamEvents.get(run.agentId)} />
             {:else if runLogError.has(run.agentId)}
-              <p class="py-4 text-center text-xs text-error-600 dark:text-error-400">Failed to load log: {runLogError.get(run.agentId)}</p>
+              <div class="flex flex-col items-center gap-2 py-4 text-center text-xs text-surface-500">
+                <p>Couldn't load this run's log — it may not have been written yet.</p>
+                <div class="flex items-center gap-2">
+                  <button
+                    type="button"
+                    class="inline-flex items-center gap-1 rounded border border-surface-300 px-2 py-1 font-medium text-surface-600 transition-colors hover:bg-surface-200 dark:border-surface-600 dark:text-surface-300 dark:hover:bg-surface-700"
+                    onclick={() => retryRunLog(run.agentId)}
+                  >
+                    <RefreshCw size={12} /> Retry
+                  </button>
+                  {#if run.logFile}
+                    <span class="font-mono text-surface-400" title={run.logFile}>{run.logFile}</span>
+                  {/if}
+                </div>
+                <details class="w-full">
+                  <summary class="cursor-pointer text-surface-400">Details</summary>
+                  <p class="mt-1 break-words font-mono text-surface-400">{runLogError.get(run.agentId)}</p>
+                </details>
+              </div>
             {:else if run.result}
               <pre class="max-h-[60dvh] md:max-h-[600px] overflow-y-auto whitespace-pre-wrap rounded-lg border border-surface-300 bg-surface-100 p-3 text-xs text-surface-700 dark:border-surface-600 dark:bg-surface-900 dark:text-surface-300">{run.result}</pre>
             {:else}

--- a/frontend/src/components/task-detail/AgentHistoryList.svelte.test.ts
+++ b/frontend/src/components/task-detail/AgentHistoryList.svelte.test.ts
@@ -87,12 +87,28 @@ describe('AgentHistoryList', () => {
     })
   })
 
-  it('shows error message when log fetch fails', async () => {
+  it('shows a recoverable, human error with a retry when log fetch fails', async () => {
     mockGetRunLog.mockRejectedValue(new Error('boom'))
     render(AgentHistoryList, { props: { task: baseTask as never } })
     await fireEvent.click(screen.getByText('a-old-1'))
     await waitFor(() => {
-      expect(screen.getByText(/Failed to load log: boom/)).toBeDefined()
+      expect(screen.getByText(/Couldn't load this run's log/)).toBeDefined()
+      expect(screen.getByText('Retry')).toBeDefined()
+      // The raw error stays available under "Details", not as the headline.
+      expect(screen.getByText(/boom/)).toBeDefined()
+    })
+  })
+
+  it('Retry re-fetches the log and recovers', async () => {
+    mockGetRunLog.mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce([])
+    render(AgentHistoryList, { props: { task: baseTask as never } })
+    await fireEvent.click(screen.getByText('a-old-1'))
+    await waitFor(() => expect(screen.getByText('Retry')).toBeDefined())
+    await fireEvent.click(screen.getByText('Retry'))
+    await waitFor(() => {
+      expect(mockGetRunLog).toHaveBeenCalledTimes(2)
+      // Error cleared; the empty successful load falls through to "No output".
+      expect(screen.queryByText(/Couldn't load this run's log/)).toBeNull()
     })
   })
 

--- a/frontend/src/components/task-detail/TaskDescriptionEditor.svelte
+++ b/frontend/src/components/task-detail/TaskDescriptionEditor.svelte
@@ -2,7 +2,7 @@
   import { ChevronRight } from '@lucide/svelte'
   import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { taskStore } from '../../stores/tasks.svelte.js'
-  import { renderMarkdown } from '../../lib/markdown.js'
+  import { renderMarkdown, renderChecklistMarkdown } from '../../lib/markdown.js'
 
   interface Props {
     task: Task
@@ -24,7 +24,7 @@
     }
   }
 
-  const renderedBody = $derived(renderMarkdown(task.body))
+  const renderedBody = $derived(renderChecklistMarkdown(task.body))
   const renderedPlan = $derived(renderMarkdown(task.plan))
   const renderedCodeReview = $derived(renderMarkdown(task.codeReview))
 
@@ -110,7 +110,7 @@
     >
       <ChevronRight size={14} class="text-surface-400 transition-transform {planCollapsed ? '' : 'rotate-90'}" />
       <span class="text-sm font-medium text-surface-500">Plan</span>
-      <span class="text-xs text-surface-400 italic">read-only · edit via sybra-cli --plan</span>
+      <span class="text-xs text-surface-400 italic">read-only</span>
     </button>
     {#if !planCollapsed}
       <div class="rounded-lg border border-surface-300 bg-surface-100 p-4 dark:border-surface-600 dark:bg-surface-900">

--- a/frontend/src/components/task-detail/TaskDescriptionEditor.svelte.test.ts
+++ b/frontend/src/components/task-detail/TaskDescriptionEditor.svelte.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../stores/tasks.svelte.js', () => ({
 
 vi.mock('../../lib/markdown.js', () => ({
   renderMarkdown: (s: unknown) => (s ? `<p>${s}</p>` : ''),
+  renderChecklistMarkdown: (s: unknown) => (s ? `<p>${s}</p>` : ''),
 }))
 
 const TaskDescriptionEditor = (await import('./TaskDescriptionEditor.svelte')).default

--- a/frontend/src/components/task-detail/TaskHeaderBar.svelte
+++ b/frontend/src/components/task-detail/TaskHeaderBar.svelte
@@ -290,7 +290,9 @@
       </span>
     {/if}
     {#if task.reviewed}
-      <span class="inline-flex items-center gap-1 rounded-full bg-success-200 px-2 py-0.5 text-xs font-medium text-success-800 dark:bg-success-700 dark:text-success-200" title="Review agent completed">
+      <!-- A passive status label, not a control: no pill/button chrome, so it
+           reads as "this has been reviewed", not a toggle to click. -->
+      <span class="inline-flex items-center gap-1 text-xs font-medium text-success-600 dark:text-success-400" title="The review agent has run for this task">
         ✓ Reviewed
       </span>
     {/if}

--- a/frontend/src/components/task-detail/TaskMetadataRow.svelte
+++ b/frontend/src/components/task-detail/TaskMetadataRow.svelte
@@ -69,7 +69,9 @@
 <div class="flex gap-6 text-sm">
   <div class="flex flex-col gap-1">
     <span class="font-medium text-surface-500">Agent Mode</span>
-    <span class="rounded bg-surface-200 px-2 py-0.5 dark:bg-surface-700">{task.agentMode}</span>
+    <!-- Read-only: plain text, no pill chrome, so it doesn't imply the
+         click-to-edit affordance the Project/Tags pills carry. -->
+    <span class="text-surface-700 dark:text-surface-300">{task.agentMode}</span>
   </div>
 
   <div class="flex flex-col gap-1">
@@ -133,6 +135,9 @@
     </div>
   {/if}
 
+  <!-- Per-run knobs stay editable (they're the only place to set them), but
+       render quietly at their default so they don't shout: Fork shows a muted
+       "disabled", Max Turns a muted "global default". -->
   {#if task.agentMode === 'headless'}
   <div class="flex flex-col gap-1">
     <span class="font-medium text-surface-500">Fork Subagents</span>

--- a/frontend/src/components/task-detail/TaskMetadataRow.svelte.test.ts
+++ b/frontend/src/components/task-detail/TaskMetadataRow.svelte.test.ts
@@ -48,6 +48,16 @@ describe('TaskMetadataRow', () => {
   })
   afterEach(cleanup)
 
+  it('keeps the per-run knobs editable even at their default value', () => {
+    // They render quietly at default (muted "disabled"/"global default") but
+    // stay present — they are the only place to set max turns / fork.
+    render(TaskMetadataRow, { props: { task: baseTask as never } })
+    expect(screen.getByText('Fork Subagents')).toBeDefined()
+    expect(screen.getByText('disabled')).toBeDefined()
+    expect(screen.getByText('Max Turns')).toBeDefined()
+    expect(screen.getByText('global default')).toBeDefined()
+  })
+
   it('renders agent mode + tags + project + branch + issue + allowed tools', () => {
     render(TaskMetadataRow, { props: { task: baseTask as never } })
     expect(screen.getByText('Agent Mode')).toBeDefined()

--- a/frontend/src/lib/markdown.test.ts
+++ b/frontend/src/lib/markdown.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { renderMarkdown, renderChecklistMarkdown } from './markdown.js'
+
+describe('renderMarkdown', () => {
+  it('renders markdown and sanitises raw HTML', () => {
+    const html = renderMarkdown('# Hi\n\n<script>alert(1)</script>')
+    expect(html).toContain('<h1')
+    expect(html).not.toContain('<script')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(renderMarkdown('')).toBe('')
+    expect(renderMarkdown(null)).toBe('')
+  })
+})
+
+describe('renderChecklistMarkdown', () => {
+  it('replaces GFM task-list checkboxes with non-interactive glyphs', () => {
+    const html = renderChecklistMarkdown('- [x] done\n- [ ] todo')
+    expect(html).not.toContain('<input')
+    // The done glyph must be the checked one, the todo glyph the unchecked one
+    // (would catch an inverted checked/unchecked mapping).
+    expect(html).toMatch(/<span class="task-check task-check--done"[^>]*>✓<\/span>/)
+    expect(html).toMatch(/<span class="task-check"[^>]*>○<\/span>/)
+  })
+
+  it('does not mistake a non-checkbox input with "checked" in a value', () => {
+    // A raw text input whose value mentions checkbox/checked must not become a
+    // checklist glyph.
+    const html = renderChecklistMarkdown('<input type="text" value="type=checkbox checked">')
+    expect(html).not.toContain('task-check')
+  })
+
+  it('leaves non-checklist markdown untouched', () => {
+    const html = renderChecklistMarkdown('**bold** text')
+    expect(html).toContain('<strong>')
+    expect(html).not.toContain('task-check')
+  })
+})

--- a/frontend/src/lib/markdown.ts
+++ b/frontend/src/lib/markdown.ts
@@ -82,3 +82,23 @@ export function renderMarkdown(text: string | undefined | null): string {
   }
   return html
 }
+
+// GFM task lists render as disabled <input type=checkbox> — the strongest
+// "click me" signifier in the body, yet inert. Swap each for a non-interactive
+// status glyph so a checklist reads as progress, not a dead control. Parse the
+// (already-sanitised) HTML so we key off the real `checked` attribute, never a
+// stray "checked"/"checkbox" sitting inside some other attribute's value.
+export function renderChecklistMarkdown(text: string | undefined | null): string {
+  const html = renderMarkdown(text)
+  if (!html.includes('type="checkbox"') || typeof DOMParser === 'undefined') return html
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  for (const input of Array.from(doc.querySelectorAll('input[type="checkbox"]'))) {
+    const done = input.hasAttribute('checked')
+    const span = doc.createElement('span')
+    span.className = done ? 'task-check task-check--done' : 'task-check'
+    span.setAttribute('aria-hidden', 'true')
+    span.textContent = done ? '✓' : '○'
+    input.replaceWith(span)
+  }
+  return doc.body.innerHTML
+}

--- a/frontend/src/lib/markdown.ts
+++ b/frontend/src/lib/markdown.ts
@@ -96,7 +96,10 @@ export function renderChecklistMarkdown(text: string | undefined | null): string
     const done = input.hasAttribute('checked')
     const span = doc.createElement('span')
     span.className = done ? 'task-check task-check--done' : 'task-check'
-    span.setAttribute('aria-hidden', 'true')
+    // Expose the completion state to assistive tech (the glyph carries meaning),
+    // rather than hiding it.
+    span.setAttribute('role', 'img')
+    span.setAttribute('aria-label', done ? 'done' : 'to do')
     span.textContent = done ? '✓' : '○'
     input.replaceWith(span)
   }

--- a/frontend/src/lib/navigation.svelte.test.ts
+++ b/frontend/src/lib/navigation.svelte.test.ts
@@ -133,7 +133,7 @@ describe('NavStore', () => {
     it.each([
       [{ kind: 'dashboard' }, 'Dashboard'],
       [{ kind: 'task-list' }, 'Board'],
-      [{ kind: 'task-detail', taskId: 't1' }, 'Task Detail'],
+      [{ kind: 'task-detail', taskId: 't1' }, ''],
       [{ kind: 'project-list' }, 'Projects'],
       [{ kind: 'project-detail', projectId: 'p1' }, 'Project Detail'],
       [{ kind: 'chats' }, 'Chats'],

--- a/frontend/src/lib/navigation.svelte.ts
+++ b/frontend/src/lib/navigation.svelte.ts
@@ -61,7 +61,10 @@ class NavStore {
     switch (p.kind) {
       case 'dashboard': return 'Dashboard'
       case 'task-list': return 'Board'
-      case 'task-detail': return 'Task Detail'
+      // The detail page promotes the task title to its own heading (with a
+      // "Back to tasks" chevron), so a generic "Task Detail" chrome heading is
+      // pure redundancy — suppress it.
+      case 'task-detail': return ''
       case 'project-list': return 'Projects'
       case 'project-detail': return 'Project Detail'
       case 'chats': return 'Chats'

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -138,4 +138,11 @@
   :global(.markdown-body h1, .markdown-body h2, .markdown-body h3) { margin: 0.5em 0 0.25em; font-weight: 600; }
   :global(.markdown-body blockquote) { border-left: 3px solid currentColor; padding-left: 0.75em; opacity: 0.8; margin: 0.25em 0; }
   :global(.markdown-body a) { text-decoration: underline; }
+  /* Non-interactive checklist glyphs (replacing GFM's disabled checkboxes). */
+  :global(.markdown-body .task-check) {
+    display: inline-block; width: 1.1em; margin-right: 0.15em;
+    text-align: center; opacity: 0.55;
+  }
+  :global(.markdown-body .task-check--done) { color: var(--color-success-600); opacity: 1; }
+  :global(.markdown-body li:has(.task-check)) { list-style: none; }
 </style>


### PR DESCRIPTION
## Motivation

Part of ☂️ #968. The task detail page had several trust- and clarity-erosions:
a redundant "Task Detail" chrome heading, disabled-but-clickable checklist
checkboxes, a "leave the GUI for the CLI" instruction, an ambiguous "✓ Reviewed"
pill, a gappy metadata row with a pill that looked editable but wasn't, and an
unrecoverable red "internal error" log state.

Closes #979
Closes #984
Closes #985
Closes #986
Closes #988
Closes #989
Closes #990

## Implementation information

- **#979** — `pageTitle` returns '' for task-detail; the task title (with the
  back chevron) is the page heading.
- **#986** — `renderChecklistMarkdown` swaps GFM task-list checkboxes for
  non-interactive status glyphs (✓ / ○), parsed via `DOMParser` so it keys off
  the real `checked` attribute rather than string-matching.
- **#990** — dropped the "edit via sybra-cli --plan" instruction.
- **#984** — "✓ Reviewed" is now a passive label (no pill/button chrome).
- **#985** — tightened the metadata row; the per-run knobs render quietly at
  their default. Note: they stay **editable** rather than being hidden, since
  the metadata row is the only place to set Max Turns / Fork Subagents —
  hiding them would remove the sole edit path.
- **#989** — read-only Agent Mode renders as plain text, not a pill, so it no
  longer implies the click-to-edit affordance its neighbours carry.
- **#988** — the agent-log load error is a neutral, human message with a Retry
  (which re-fetches) and the raw detail tucked under a disclosure.

Tests cover the checklist glyph mapping (incl. a non-checkbox-with-"checked"
guard), the recoverable retry path, and the editable-at-default knobs.

> Changelog: fix(detail): polish task-detail affordances and metadata