### PR TITLE
refactor(ui): flatten nav, clarify dialog/views

### DIFF
--- a/frontend/src/components/CreateTaskDialog.svelte
+++ b/frontend/src/components/CreateTaskDialog.svelte
@@ -106,7 +106,7 @@
   <div class="flex flex-col px-5 pb-5 md:px-6 md:pb-6">
       <form onsubmit={handleSubmit} class="flex flex-col gap-4">
         <label class="flex flex-col gap-1">
-          <span class="text-sm font-medium">Title</span>
+          <span class="text-sm font-medium">Title <span class="text-error-500" title="Required">*</span></span>
           <input
             type="text"
             bind:value={title}
@@ -118,7 +118,7 @@
 
         {#if projectStore.list.length > 0}
           <div class="flex flex-col gap-1">
-            <span class="text-sm font-medium">Project</span>
+            <span class="text-sm font-medium">Project <span class="font-normal text-surface-400">(optional)</span></span>
             {#if selectedProject}
               <div class="flex items-center gap-2 rounded-lg border border-surface-300 bg-surface-100 px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700">
                 <Folder size={16} class="shrink-0 text-surface-400" />
@@ -181,6 +181,10 @@
             <option value="debug">debug (interactive, per-tool perms)</option>
             <option value="research">research (headless, research-machine)</option>
           </select>
+          <span class="text-xs text-surface-400">
+            Sets how the agent runs. Normal is the default; debug and research
+            force a specific execution mode.
+          </span>
         </label>
 
         {#if taskType === 'normal'}

--- a/frontend/src/components/CreateTaskDialog.svelte
+++ b/frontend/src/components/CreateTaskDialog.svelte
@@ -106,7 +106,7 @@
   <div class="flex flex-col px-5 pb-5 md:px-6 md:pb-6">
       <form onsubmit={handleSubmit} class="flex flex-col gap-4">
         <label class="flex flex-col gap-1">
-          <span class="text-sm font-medium">Title <span class="text-error-500" title="Required">*</span></span>
+          <span class="text-sm font-medium">Title <span class="text-error-500" aria-hidden="true">*</span><span class="sr-only">(required)</span></span>
           <input
             type="text"
             bind:value={title}
@@ -138,6 +138,7 @@
                   type="text"
                   bind:value={projectSearch}
                   placeholder="Search projects..."
+                  aria-label="Project (optional)"
                   class="w-full rounded-lg border border-surface-300 bg-surface-100 px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
                   onfocus={() => (projectDropdownOpen = true)}
                   onblur={handleProjectBlur}

--- a/frontend/src/components/CreateTaskDialog.svelte.test.ts
+++ b/frontend/src/components/CreateTaskDialog.svelte.test.ts
@@ -49,12 +49,13 @@ describe('CreateTaskDialog', () => {
     const { container } = render(CreateTaskDialog, {
       props: { open: true, onOpenChange: vi.fn() },
     })
-    // The required marker sits on the Title field, next to its required input.
+    // The required marker sits on the Title field, next to its required input,
+    // with a screen-reader-only "(required)" so it isn't visual-only.
     const titleLabel = Array.from(container.querySelectorAll('label')).find((l) =>
       l.textContent?.includes('Title'),
     )
-    expect(titleLabel?.querySelector('span[title="Required"]')).not.toBeNull()
     expect(titleLabel?.querySelector('input[required]')).not.toBeNull()
+    expect(titleLabel?.querySelector('.sr-only')?.textContent).toContain('required')
     // One-line Type helper.
     expect(container.textContent).toContain('Sets how the agent runs')
   })

--- a/frontend/src/components/CreateTaskDialog.svelte.test.ts
+++ b/frontend/src/components/CreateTaskDialog.svelte.test.ts
@@ -44,4 +44,18 @@ describe('CreateTaskDialog', () => {
     })
     expect(container).toBeDefined()
   })
+
+  it('marks the required title and explains the Type field', () => {
+    const { container } = render(CreateTaskDialog, {
+      props: { open: true, onOpenChange: vi.fn() },
+    })
+    // The required marker sits on the Title field, next to its required input.
+    const titleLabel = Array.from(container.querySelectorAll('label')).find((l) =>
+      l.textContent?.includes('Title'),
+    )
+    expect(titleLabel?.querySelector('span[title="Required"]')).not.toBeNull()
+    expect(titleLabel?.querySelector('input[required]')).not.toBeNull()
+    // One-line Type helper.
+    expect(container.textContent).toContain('Sets how the agent runs')
+  })
 })

--- a/frontend/src/components/TaskListFilterBar.svelte
+++ b/frontend/src/components/TaskListFilterBar.svelte
@@ -119,7 +119,7 @@
       <button
         type="button"
         aria-label="Timeline view (advanced)"
-        title="Timeline — advanced view"
+        title="Timeline — Gantt of tasks and agent runs over time, which the list and board can't show"
         class="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors {viewMode === 'timeline'
           ? 'bg-primary-500 text-white dark:bg-primary-600'
           : 'text-surface-400 hover:bg-surface-200 hover:text-surface-600 dark:text-surface-500 dark:hover:bg-surface-700 dark:hover:text-surface-300'}"

--- a/frontend/src/components/shell/SideRail.svelte
+++ b/frontend/src/components/shell/SideRail.svelte
@@ -7,8 +7,7 @@
   import { focusModeStore } from '../../lib/focus-mode.svelte.js'
 
   // Focus mode collapses the rail to the core destinations; "More" expands the
-  // full grouped nav so advanced views stay reachable.
-  const PRIMARY_LABELS = ['Board', 'Reviews', 'Chats', 'Agents']
+  // full nav so advanced views stay reachable.
   let moreExpanded = $state(false)
 
   const interactiveAgentCount = $derived(
@@ -31,45 +30,23 @@
     onclick: () => void
   }
 
-  interface NavGroup {
-    label: string
-    items: NavItem[]
-  }
+  // The mobile bottom bar already picks the real primaries — promote them to a
+  // flat top section, tuck everything else into a flat secondary section, and
+  // drop the WORK/SESSIONS/BUILD/DATA group headers. Settings is pinned bottom.
+  const primaryItems: NavItem[] = [
+    { kind: ['task-list', 'task-detail'], label: 'Board', icon: ClipboardList, onclick: () => navStore.reset({ kind: 'task-list' }) },
+    { kind: ['chats', 'chat-detail'], label: 'Chats', icon: MessageCircle, onclick: () => navStore.reset({ kind: 'chats' }) },
+    { kind: ['agents', 'agent-detail'], label: 'Agents', icon: UserCircle, onclick: () => navStore.reset({ kind: 'agents' }) },
+    { kind: ['reviews'], label: 'Reviews', icon: ClipboardCheck, onclick: () => navStore.reset({ kind: 'reviews' }) },
+  ]
 
-  // Grouped so 11 destinations read as ~4 scannable sections instead of a flat
-  // wall. Group labels avoid colliding with any item label. Settings is pinned
-  // to the bottom. Every destination stays one click away.
-  const groups: NavGroup[] = [
-    {
-      label: 'Work',
-      items: [
-        { kind: ['dashboard'], label: 'Dashboard', icon: LayoutGrid, onclick: () => navStore.reset({ kind: 'dashboard' }) },
-        { kind: ['task-list', 'task-detail'], label: 'Board', icon: ClipboardList, onclick: () => navStore.reset({ kind: 'task-list' }) },
-        { kind: ['reviews'], label: 'Reviews', icon: ClipboardCheck, onclick: () => navStore.reset({ kind: 'reviews' }) },
-        { kind: ['logbook'], label: 'Logbook', icon: Archive, onclick: () => navStore.reset({ kind: 'logbook' }) },
-      ],
-    },
-    {
-      label: 'Sessions',
-      items: [
-        { kind: ['chats', 'chat-detail'], label: 'Chats', icon: MessageCircle, onclick: () => navStore.reset({ kind: 'chats' }) },
-        { kind: ['agents', 'agent-detail'], label: 'Agents', icon: UserCircle, onclick: () => navStore.reset({ kind: 'agents' }) },
-      ],
-    },
-    {
-      label: 'Build',
-      items: [
-        { kind: ['project-list', 'project-detail'], label: 'Projects', icon: Folder, onclick: () => navStore.reset({ kind: 'project-list' }) },
-        { kind: ['workflows', 'workflow-detail'], label: 'Workflows', icon: LayoutDashboard, onclick: () => navStore.reset({ kind: 'workflows' }) },
-      ],
-    },
-    {
-      label: 'Data',
-      items: [
-        { kind: ['github'], label: 'GitHub', icon: GitBranch, onclick: () => navStore.reset({ kind: 'github' }) },
-        { kind: ['stats'], label: 'Stats', icon: BarChart3, onclick: () => navStore.reset({ kind: 'stats' }) },
-      ],
-    },
+  const secondaryItems: NavItem[] = [
+    { kind: ['dashboard'], label: 'Dashboard', icon: LayoutGrid, onclick: () => navStore.reset({ kind: 'dashboard' }) },
+    { kind: ['logbook'], label: 'Logbook', icon: Archive, onclick: () => navStore.reset({ kind: 'logbook' }) },
+    { kind: ['project-list', 'project-detail'], label: 'Projects', icon: Folder, onclick: () => navStore.reset({ kind: 'project-list' }) },
+    { kind: ['workflows', 'workflow-detail'], label: 'Workflows', icon: LayoutDashboard, onclick: () => navStore.reset({ kind: 'workflows' }) },
+    { kind: ['github'], label: 'GitHub', icon: GitBranch, onclick: () => navStore.reset({ kind: 'github' }) },
+    { kind: ['stats'], label: 'Stats', icon: BarChart3, onclick: () => navStore.reset({ kind: 'stats' }) },
   ]
 
   const settingsItem: NavItem = {
@@ -80,9 +57,6 @@
     onclick: () => navStore.reset({ kind: 'settings' }),
   }
 
-  const primaryItems = $derived(
-    groups.flatMap((g) => g.items).filter((i) => PRIMARY_LABELS.includes(i.label)),
-  )
   // Minimal rail only when focus mode is on and the user hasn't expanded "More".
   const minimal = $derived(focusModeStore.enabled && !moreExpanded)
 
@@ -138,14 +112,12 @@
         <span class="leading-tight">More</span>
       </button>
     {:else}
-      {#each groups as group, gi}
-        {#if gi > 0}
-          <div class="mx-2 mb-0.5 mt-1.5 border-t border-surface-200 dark:border-surface-700"></div>
-        {/if}
-        <span class="px-1 pb-0.5 text-center text-[8px] font-semibold uppercase tracking-wider text-surface-400">{group.label}</span>
-        {#each group.items as item}
-          {@render navButton(item)}
-        {/each}
+      {#each primaryItems as item}
+        {@render navButton(item)}
+      {/each}
+      <div class="mx-2 mb-0.5 mt-1.5 border-t border-surface-200 dark:border-surface-700"></div>
+      {#each secondaryItems as item}
+        {@render navButton(item)}
       {/each}
       {#if focusModeStore.enabled}
         <button

--- a/frontend/src/components/shell/SideRail.svelte.test.ts
+++ b/frontend/src/components/shell/SideRail.svelte.test.ts
@@ -58,10 +58,10 @@ describe('SideRail', () => {
     expect(screen.getByText('S')).toBeDefined()
   })
 
-  it('renders the nav group headers', () => {
+  it('has no group headers — the rail is flat', () => {
     render(SideRail)
     for (const group of ['Work', 'Sessions', 'Build', 'Data']) {
-      expect(screen.getByText(group)).toBeDefined()
+      expect(screen.queryByText(group)).toBeNull()
     }
   })
 
@@ -78,7 +78,7 @@ describe('SideRail', () => {
     expect(screen.queryByText('Work')).toBeNull()
   })
 
-  it('expands to the full grouped nav when More is clicked', async () => {
+  it('expands to the full flat nav when More is clicked', async () => {
     focusModeStore.set(true)
     render(SideRail)
     await fireEvent.click(screen.getByText('More'))


### PR DESCRIPTION
## Motivation

Part of ☂️ #968. The left rail split 10 destinations across 4 group headers
(WORK/SESSIONS/BUILD/DATA), the New Task dialog gave no hint which fields were
required or what Type does, and the Timeline toggle was unjustified.

Closes #994
Closes #996
Closes #997

## Implementation information

- **#994** — flatten the rail using the mobile bottom bar as source of truth:
  Board / Chats / Agents / Reviews are a flat top section, the rest a flat
  secondary section, and the four group headers are gone. Focus mode still
  collapses to the primaries + More. Every destination, active-state highlight,
  badge, and the `data-part="trigger"` nav contract is preserved.
- **#996** — the New Task dialog marks Title required (`*`) and Project
  optional, with a one-line helper explaining the Type field.
- **#997** — the Timeline view is a Gantt of tasks and agent runs over time
  that the list/board can't show, so it stays (already demoted out of the
  primary List/Board toggle); its tooltip now states that unique value.

> Changelog: refactor(ui): flatten the nav rail; clarify the new-task dialog