### PR TITLE
fix(board): calm activity cue, drag, done routing

### DIFF
--- a/frontend/src/components/TaskBoardView.svelte
+++ b/frontend/src/components/TaskBoardView.svelte
@@ -55,11 +55,16 @@
     if (changed) expandedEmpty = next
   })
 
-  // A static "agents working now" count per column — the live activity cue the
-  // board otherwise lacks, without an animated pulse keeping a swarm in motion.
+  // Task IDs with at least one running agent — built once per agent-list change
+  // so the per-column count is an O(tasks) membership test, not O(tasks×agents).
+  const runningTaskIds = $derived(
+    new Set((agentStore.list ?? []).filter((a) => a.state === 'running').map((a) => a.taskId)),
+  )
+
+  // A static "tasks with an agent working" count per column — the live activity
+  // cue the board otherwise lacks, without a pulse keeping a swarm in motion.
   function runningCount(tasks: Task[]): number {
-    const list = agentStore.list ?? []
-    return tasks.filter((t) => list.some((a) => a.taskId === t.id && a.state === 'running')).length
+    return tasks.filter((t) => runningTaskIds.has(t.id)).length
   }
 
   async function handleDrop(e: DragEvent, targetStatus: string) {
@@ -114,7 +119,7 @@
           {#if rc > 0}
             <span
               class="inline-flex items-center gap-1 text-xs font-medium text-success-700 dark:text-success-400"
-              title="{rc} agent(s) working in this column"
+              title="{rc} task(s) with an agent working in this column"
             >
               <span class="h-1.5 w-1.5 rounded-full bg-success-500"></span>
               {rc}

--- a/frontend/src/components/TaskBoardView.svelte
+++ b/frontend/src/components/TaskBoardView.svelte
@@ -4,6 +4,7 @@
   import type { BoardColumn } from '../lib/statuses.js'
   import TaskCard from './TaskCard.svelte'
   import InlineTaskAdd from './InlineTaskAdd.svelte'
+  import { agentStore } from '../stores/agents.svelte.js'
   import { viewport } from '../lib/viewport.svelte.js'
   import { fly } from 'svelte/transition'
   import { flip } from 'svelte/animate'
@@ -54,6 +55,13 @@
     if (changed) expandedEmpty = next
   })
 
+  // A static "agents working now" count per column — the live activity cue the
+  // board otherwise lacks, without an animated pulse keeping a swarm in motion.
+  function runningCount(tasks: Task[]): number {
+    const list = agentStore.list ?? []
+    return tasks.filter((t) => list.some((a) => a.taskId === t.id && a.state === 'running')).length
+  }
+
   async function handleDrop(e: DragEvent, targetStatus: string) {
     e.preventDefault()
     dragOverStatus = null
@@ -66,6 +74,7 @@
 <div class="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-3 md:flex-row md:gap-4 md:overflow-x-auto md:overflow-y-hidden md:p-6">
   {#each visibleColumns as col}
     {@const tasks = columnTasks(col)}
+    {@const rc = runningCount(tasks)}
     {@const isCollapsed = !viewport.isDesktop && collapsedColumns.has(col.status)}
     {@const isThin = viewport.isDesktop && tasks.length === 0 && !expandedEmpty.has(col.status)}
     {#if isThin}
@@ -101,8 +110,19 @@
           <ChevronDown size={16} class="transition-transform md:hidden {isCollapsed ? '-rotate-90' : ''}" aria-hidden="true" />
           <h2 class="text-sm font-semibold">{col.label}</h2>
         </span>
-        <span class="rounded-full bg-surface-200 px-2 py-0.5 text-xs font-medium dark:bg-surface-700">
-          {tasks.length}
+        <span class="flex items-center gap-1.5">
+          {#if rc > 0}
+            <span
+              class="inline-flex items-center gap-1 text-xs font-medium text-success-700 dark:text-success-400"
+              title="{rc} agent(s) working in this column"
+            >
+              <span class="h-1.5 w-1.5 rounded-full bg-success-500"></span>
+              {rc}
+            </span>
+          {/if}
+          <span class="rounded-full bg-surface-200 px-2 py-0.5 text-xs font-medium dark:bg-surface-700">
+            {tasks.length}
+          </span>
         </span>
       </button>
       {#if !isCollapsed}

--- a/frontend/src/components/TaskBoardView.svelte.test.ts
+++ b/frontend/src/components/TaskBoardView.svelte.test.ts
@@ -53,7 +53,7 @@ describe('TaskBoardView', () => {
       },
     })
     // t2 lives in the In Progress column and has a running agent.
-    expect(screen.getByTitle('1 agent(s) working in this column')).toBeDefined()
+    expect(screen.getByTitle('1 task(s) with an agent working in this column')).toBeDefined()
   })
 
   it('collapses an empty desktop column to a thin rail, expandable on click', async () => {

--- a/frontend/src/components/TaskBoardView.svelte.test.ts
+++ b/frontend/src/components/TaskBoardView.svelte.test.ts
@@ -8,6 +8,9 @@ vi.mock('../stores/notifications.svelte.js', () => ({
   notificationStore: { pushLocal: vi.fn() },
 }))
 
+const agentMock = vi.hoisted(() => ({ list: [] as Array<Record<string, unknown>> }))
+vi.mock('../stores/agents.svelte.js', () => ({ agentStore: agentMock }))
+
 // Drives the empty-column thin-rail (desktop only); default off keeps the
 // existing populated-column tests on the normal layout.
 const vpMock = vi.hoisted(() => ({ isDesktop: false }))
@@ -33,6 +36,24 @@ describe('TaskBoardView', () => {
   afterEach(() => {
     cleanup()
     vpMock.isDesktop = false
+    agentMock.list = []
+  })
+
+  it('shows a static running-agent count in the column header', () => {
+    agentMock.list = [{ taskId: 't2', state: 'running', name: '' }]
+    render(TaskBoardView, {
+      props: {
+        visibleColumns: columns as never,
+        columnTasks: columnTasks as never,
+        focusedTaskId: null,
+        collapsedColumns: new Set<string>(),
+        onselect: vi.fn(),
+        onmove: vi.fn(),
+        ontogglecolumn: vi.fn(),
+      },
+    })
+    // t2 lives in the In Progress column and has a running agent.
+    expect(screen.getByTitle('1 agent(s) working in this column')).toBeDefined()
   })
 
   it('collapses an empty desktop column to a thin rail, expandable on click', async () => {

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -90,7 +90,7 @@
       e.dataTransfer!.effectAllowed = 'move'
     }}
     ondragend={() => { dragging = false }}
-    class="flex w-full flex-col items-stretch gap-1.5 text-left"
+    class="flex w-full cursor-grab flex-col items-stretch gap-1.5 text-left active:cursor-grabbing"
   >
   <div class="mb-1.5 flex items-center gap-1.5">
     {#if topPR?.ciStatus === 'SUCCESS'}
@@ -157,14 +157,14 @@
 
     {#if triaging}
       <span class="inline-flex items-center gap-1 rounded bg-primary-200 px-1.5 py-0.5 text-primary-800 dark:bg-primary-700 dark:text-primary-200">
-        <span class="h-1.5 w-1.5 animate-pulse-subtle rounded-full bg-primary-500"></span>
+        <span class="h-1.5 w-1.5 rounded-full bg-primary-500"></span>
         Triaging
       </span>
     {/if}
 
     {#if planning}
       <span class="inline-flex items-center gap-1 rounded bg-tertiary-200 px-1.5 py-0.5 text-tertiary-800 dark:bg-tertiary-700 dark:text-tertiary-200">
-        <span class="h-1.5 w-1.5 animate-pulse-subtle rounded-full bg-tertiary-500"></span>
+        <span class="h-1.5 w-1.5 rounded-full bg-tertiary-500"></span>
         Planning
       </span>
     {/if}
@@ -181,14 +181,14 @@
 
     {#if agentRunning}
       <span class="inline-flex items-center gap-1 rounded bg-success-200 px-1.5 py-0.5 text-success-800 dark:bg-success-700 dark:text-success-200">
-        <span class="h-1.5 w-1.5 animate-pulse-subtle rounded-full bg-success-500"></span>
+        <span class="h-1.5 w-1.5 rounded-full bg-success-500"></span>
         Agent
       </span>
     {/if}
 
     {#if evaluating}
       <span class="inline-flex items-center gap-1 rounded bg-warning-200 px-1.5 py-0.5 text-warning-800 dark:bg-warning-700 dark:text-warning-200">
-        <span class="h-1.5 w-1.5 animate-pulse-subtle rounded-full bg-warning-500"></span>
+        <span class="h-1.5 w-1.5 rounded-full bg-warning-500"></span>
         Evaluating
       </span>
     {/if}

--- a/frontend/src/components/TaskListFilterBar.svelte
+++ b/frontend/src/components/TaskListFilterBar.svelte
@@ -81,17 +81,22 @@
         Clear filters
       </button>
     {/if}
-    <button
-      type="button"
-      class="text-xs text-surface-500 underline hover:text-surface-700 dark:hover:text-surface-300"
-      onclick={() => navStore.reset({ kind: 'logbook' })}
-    >
-      Logbook →
-    </button>
-    <label class="flex items-center gap-1.5 text-xs text-surface-500">
-      <input type="checkbox" bind:checked={showDone} class="accent-primary-500" />
-      Show done
-    </label>
+    {#if viewMode === 'board'}
+      <!-- The board has no Done column (terminal tasks live in the Logbook), so
+           a "Show done" toggle here does nothing visible. Route there instead. -->
+      <button
+        type="button"
+        class="text-xs text-surface-500 underline hover:text-surface-700 dark:hover:text-surface-300"
+        onclick={() => navStore.reset({ kind: 'logbook' })}
+      >
+        Done → Logbook
+      </button>
+    {:else}
+      <label class="flex items-center gap-1.5 text-xs text-surface-500">
+        <input type="checkbox" bind:checked={showDone} class="accent-primary-500" />
+        Show done
+      </label>
+    {/if}
     <!-- Primary views: List / Board. Timeline is demoted to an advanced option. -->
     <div class="flex rounded-md border border-surface-300 dark:border-surface-700" title="Switch view (⌘B)">
       <button

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -5,6 +5,7 @@
   import { projectStore } from '../stores/projects.svelte.js'
   import { notificationStore } from '../stores/notifications.svelte.js'
   import { BOARD_COLUMNS, type BoardColumn } from '../lib/statuses.js'
+  import { navStore } from '../lib/navigation.svelte.js'
   import { matchesQuery, matchesProject, matchesTags, matchesAgentMode } from '../lib/task-filters.js'
   import TaskTimeline from '../components/TaskTimeline.svelte'
   import StatusPicker from '../components/StatusPicker.svelte'
@@ -449,10 +450,22 @@
       </div>
     {/if}
 
-    <label class="tap flex items-center gap-3 rounded-lg border border-surface-300 bg-surface-100 px-3 py-3 dark:border-surface-600 dark:bg-surface-700">
-      <input type="checkbox" bind:checked={showDone} class="h-5 w-5 accent-primary-500" />
-      <span class="text-sm font-medium">Show done</span>
-    </label>
+    {#if viewMode === 'board'}
+      <!-- No Done column on the board — route to the Logbook instead of a
+           toggle that would do nothing. -->
+      <button
+        type="button"
+        class="tap flex items-center gap-3 rounded-lg border border-surface-300 bg-surface-100 px-3 py-3 text-left dark:border-surface-600 dark:bg-surface-700"
+        onclick={() => { navStore.reset({ kind: 'logbook' }); filtersOpen = false }}
+      >
+        <span class="text-sm font-medium">Done → Logbook</span>
+      </button>
+    {:else}
+      <label class="tap flex items-center gap-3 rounded-lg border border-surface-300 bg-surface-100 px-3 py-3 dark:border-surface-600 dark:bg-surface-700">
+        <input type="checkbox" bind:checked={showDone} class="h-5 w-5 accent-primary-500" />
+        <span class="text-sm font-medium">Show done</span>
+      </label>
+    {/if}
 
     <div class="sticky bottom-0 -mx-5 -mb-5 flex gap-2 border-t border-surface-200 bg-surface-50/95 px-5 pt-3 pb-safe backdrop-blur dark:border-surface-800 dark:bg-surface-900/95">
       <button

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -237,9 +237,14 @@
     'urgent': 0, 'high': 1, 'medium': 2, 'low': 3, '': 4,
   }
 
+  // The board has no Done column (terminal tasks live in the Logbook), so it
+  // ignores "Show done" entirely — a value carried over from list view can't
+  // resurrect done tasks on the board.
+  const effectiveShowDone = $derived(viewMode === 'board' ? false : showDone)
+
   const allFilteredTasks = $derived.by(() => {
     return taskStore.list.filter((t: Task) => {
-      if (!showDone && (t.status === 'done' || t.status === 'cancelled')) return false
+      if (!effectiveShowDone && (t.status === 'done' || t.status === 'cancelled')) return false
       if (!matchesQuery(t, searchQuery)) return false
       if (!matchesProject(t, selectedProjectId)) return false
       if (!matchesTags(t, selectedTags)) return false
@@ -253,7 +258,7 @@
   })
 
   const visibleColumns = $derived(
-    showDone ? BOARD_COLUMNS : BOARD_COLUMNS.filter(c => c.status !== 'done')
+    effectiveShowDone ? BOARD_COLUMNS : BOARD_COLUMNS.filter(c => c.status !== 'done')
   )
 
   const hasActiveFilters = $derived(

--- a/frontend/src/pages/TaskList.svelte.test.ts
+++ b/frontend/src/pages/TaskList.svelte.test.ts
@@ -134,14 +134,17 @@ describe('TaskList', () => {
       expect(screen.queryByText('Timeline')).toBeNull()
     })
 
-    it('renders Show done checkbox', () => {
+    it('renders the Show done checkbox in list view', () => {
+      viewModeStore.set('list')
       render(TaskList, { props: { onselect: vi.fn() } })
       expect(screen.getByLabelText('Show done')).toBeDefined()
     })
 
-    it('renders Logbook link', () => {
+    it('routes done to the Logbook in board view (no broken Show done)', () => {
+      viewModeStore.set('board')
       render(TaskList, { props: { onselect: vi.fn() } })
-      expect(screen.getByText('Logbook →')).toBeDefined()
+      expect(screen.getByText('Done → Logbook')).toBeDefined()
+      expect(screen.queryByLabelText('Show done')).toBeNull()
     })
   })
 
@@ -332,9 +335,18 @@ describe('TaskList', () => {
   })
 
   describe('show done column visibility', () => {
-    it('renders Done column hidden by default and Show done checkbox unchecked', () => {
+    it('hides the Done column and the broken Show done toggle in board view', () => {
+      viewModeStore.set('board')
       render(TaskList, { props: { onselect: vi.fn() } })
+      // No Done column on the board; done tasks are routed to the Logbook.
       expect(screen.queryByText(/^Done$/)).toBeNull()
+      expect(screen.queryByLabelText('Show done')).toBeNull()
+      expect(screen.getByText('Done → Logbook')).toBeDefined()
+    })
+
+    it('offers a working Show done toggle (unchecked) in list view', () => {
+      viewModeStore.set('list')
+      render(TaskList, { props: { onselect: vi.fn() } })
       const checkbox = screen.getByLabelText('Show done') as HTMLInputElement
       expect(checkbox.checked).toBe(false)
     })

--- a/frontend/src/pages/TaskList.svelte.test.ts
+++ b/frontend/src/pages/TaskList.svelte.test.ts
@@ -350,6 +350,19 @@ describe('TaskList', () => {
       const checkbox = screen.getByLabelText('Show done') as HTMLInputElement
       expect(checkbox.checked).toBe(false)
     })
+
+    it('ignores Show done on the board even when enabled in list view', async () => {
+      // Enable in list, switch to board: the board must not resurrect done.
+      viewModeStore.set('list')
+      render(TaskList, { props: { onselect: vi.fn() } })
+      await fireEvent.click(screen.getByLabelText('Show done'))
+      viewModeStore.set('board')
+      await vi.waitFor(() => {
+        expect(screen.queryByText(/^Done$/)).toBeNull()
+        expect(screen.queryByLabelText('Show done')).toBeNull()
+        expect(screen.getByText('Done → Logbook')).toBeDefined()
+      })
+    })
   })
 
   describe('view mode switching', () => {

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -42,3 +42,10 @@ vi.mock('@wailsio/runtime', () => ({
   objectNames: {},
   clientId: 'test',
 }))
+
+// jsdom doesn't implement scrollIntoView, but several components call it when
+// focusing/scrolling a card or column into view. Stub it globally so those
+// side effects don't throw "not a function" Unhandled Errors during tests.
+if (typeof Element !== 'undefined' && typeof Element.prototype.scrollIntoView !== 'function') {
+  Element.prototype.scrollIntoView = vi.fn()
+}


### PR DESCRIPTION
## Motivation

Part of ☂️ #968. The board gave no calm live signal of who's working now, it
was unclear whether drag or the Move popover was the canonical move, a nav
item leaked into the view-toggle row, and "Show done" did nothing at laptop
width (it tried to add an off-screen 7th column).

Closes #973
Closes #975
Closes #978

## Implementation information

- **#973** — per-card activity dots are static (the pulse is gone), and each
  board column header shows a static "N agents working" count.
- **#978** — cards get a grab cursor so drag-between-columns reads as the
  primary move (the Move popover stays as the a11y fallback); the "Logbook →"
  nav item is removed from the view-toggle row — it lives in the rail.
- **#975** — the board has no Done column (terminal tasks live in the Logbook),
  so "Show done" did nothing there; in board view it's replaced with a
  "Done → Logbook" route (desktop bar and mobile sheet). The working toggle
  stays in list/timeline.

> Changelog: fix(board): calm live-activity cue; fix done routing and drag