### PR TITLE
fix(board): keep every column reachable at 1440px

### DIFF
--- a/frontend/src/components/TaskBoardView.svelte
+++ b/frontend/src/components/TaskBoardView.svelte
@@ -57,12 +57,16 @@
     const left = canScrollLeft ? 'transparent, #000 3rem' : '#000'
     const right = canScrollRight ? '#000 calc(100% - 3rem), transparent' : '#000'
     const grad = `linear-gradient(to right, ${left}, ${right})`
-    return `mask-image: ${grad}; -webkit-mask-image: ${grad}`
+    // no-repeat: a gradient ending in transparent must not tile and leave
+    // transparent seams mid-board.
+    return `mask-image: ${grad}; -webkit-mask-image: ${grad}; mask-repeat: no-repeat; -webkit-mask-repeat: no-repeat`
   })
 
   $effect(() => {
-    // Recompute when the visible column set changes (and on resize/mount).
-    if (visibleColumns) updateScroll()
+    // Recompute on mount and whenever layout changes the board's scrollWidth
+    // without a scroll event: the column set, or an empty rail expanding /
+    // auto-collapsing. (Plus viewport resize via the listener.)
+    if (visibleColumns && expandedEmpty && collapsedColumns) updateScroll()
     window.addEventListener('resize', updateScroll)
     return () => window.removeEventListener('resize', updateScroll)
   })

--- a/frontend/src/components/TaskBoardView.svelte
+++ b/frontend/src/components/TaskBoardView.svelte
@@ -36,6 +36,37 @@
   // tasks can still be added there.
   let expandedEmpty = $state<Set<string>>(new Set())
 
+  // Scroll-shadow: when the board overflows horizontally (e.g. 6 columns at
+  // laptop width), fade the right edge so it's obvious a column is off-screen
+  // and scrollable — the Human Required column must never be silently hidden.
+  let scrollEl = $state<HTMLDivElement | null>(null)
+  let canScrollLeft = $state(false)
+  let canScrollRight = $state(false)
+
+  function updateScroll() {
+    const el = scrollEl
+    if (!el) return
+    canScrollLeft = el.scrollLeft > 1
+    canScrollRight = el.scrollLeft + el.clientWidth < el.scrollWidth - 1
+  }
+
+  // Fade whichever edge(s) have off-screen columns, so it's always visible that
+  // the board scrolls (and which way) — no column is silently hidden.
+  const maskStyle = $derived.by(() => {
+    if (!canScrollLeft && !canScrollRight) return undefined
+    const left = canScrollLeft ? 'transparent, #000 3rem' : '#000'
+    const right = canScrollRight ? '#000 calc(100% - 3rem), transparent' : '#000'
+    const grad = `linear-gradient(to right, ${left}, ${right})`
+    return `mask-image: ${grad}; -webkit-mask-image: ${grad}`
+  })
+
+  $effect(() => {
+    // Recompute when the visible column set changes (and on resize/mount).
+    if (visibleColumns) updateScroll()
+    window.addEventListener('resize', updateScroll)
+    return () => window.removeEventListener('resize', updateScroll)
+  })
+
   function expandEmpty(status: string) {
     expandedEmpty = new Set(expandedEmpty).add(status)
   }
@@ -76,7 +107,12 @@
   }
 </script>
 
-<div class="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-3 md:flex-row md:gap-4 md:overflow-x-auto md:overflow-y-hidden md:p-6">
+<div
+  bind:this={scrollEl}
+  onscroll={updateScroll}
+  class="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-3 md:flex-row md:gap-4 md:overflow-x-auto md:overflow-y-hidden md:p-6"
+  style={maskStyle}
+>
   {#each visibleColumns as col}
     {@const tasks = columnTasks(col)}
     {@const rc = runningCount(tasks)}
@@ -101,7 +137,7 @@
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       data-col-status={col.status}
-      class="flex w-full shrink-0 flex-col rounded-lg border-t-4 bg-surface-100 transition-shadow dark:bg-surface-900 md:min-w-[260px] md:flex-1 md:shrink {col.border} {dragOverStatus === col.status ? 'ring-2 ring-primary-400 dark:ring-primary-500' : ''}"
+      class="flex w-full shrink-0 flex-col rounded-lg border-t-4 bg-surface-100 transition-shadow dark:bg-surface-900 md:min-w-[200px] md:flex-1 md:shrink {col.border} {dragOverStatus === col.status ? 'ring-2 ring-primary-400 dark:ring-primary-500' : ''}"
       ondragover={(e) => { e.preventDefault(); dragOverStatus = col.status }}
       ondragleave={() => { dragOverStatus = null }}
       ondrop={(e) => handleDrop(e, col.status)}

--- a/frontend/src/components/TaskListFilterBar.svelte
+++ b/frontend/src/components/TaskListFilterBar.svelte
@@ -14,6 +14,8 @@
     showDone: boolean
     hasActiveFilters: boolean
     viewMode: ViewMode
+    /** Count of tasks awaiting the user — surfaced persistently on the board. */
+    needYouCount?: number
     onclear: () => void
     onviewchange?: () => void
   }
@@ -27,6 +29,7 @@
     showDone = $bindable(),
     hasActiveFilters,
     viewMode,
+    needYouCount = 0,
     onclear,
     onviewchange,
   }: Props = $props()
@@ -96,6 +99,18 @@
         <input type="checkbox" bind:checked={showDone} class="accent-primary-500" />
         Show done
       </label>
+    {/if}
+    {#if viewMode === 'board' && needYouCount > 0}
+      <!-- Persistent "needs you" count (tasks awaiting you across all columns):
+           visible in the toolbar regardless of horizontal scroll, so an
+           awaiting task isn't missed when its column sits off-screen. -->
+      <span
+        class="inline-flex items-center gap-1.5 rounded-full bg-error-100 px-2.5 py-1 text-xs font-semibold text-error-700 dark:bg-error-900/50 dark:text-error-300"
+        title="{needYouCount} task(s) need you"
+      >
+        <span class="h-1.5 w-1.5 rounded-full bg-error-500"></span>
+        {needYouCount} need you
+      </span>
     {/if}
     <!-- Primary views: List / Board. Timeline is demoted to an advanced option. -->
     <div class="flex rounded-md border border-surface-300 dark:border-surface-700" title="Switch view (⌘B)">

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -4,7 +4,7 @@
   import { taskStore } from '../stores/tasks.svelte.js'
   import { projectStore } from '../stores/projects.svelte.js'
   import { notificationStore } from '../stores/notifications.svelte.js'
-  import { BOARD_COLUMNS, type BoardColumn } from '../lib/statuses.js'
+  import { BOARD_COLUMNS, awaitsHuman, type BoardColumn } from '../lib/statuses.js'
   import { navStore } from '../lib/navigation.svelte.js'
   import { matchesQuery, matchesProject, matchesTags, matchesAgentMode } from '../lib/task-filters.js'
   import TaskTimeline from '../components/TaskTimeline.svelte'
@@ -261,6 +261,11 @@
     effectiveShowDone ? BOARD_COLUMNS : BOARD_COLUMNS.filter(c => c.status !== 'done')
   )
 
+  // Tasks awaiting the user across all columns (same set as the per-card red
+  // attention border) — surfaced as a persistent board-toolbar counter so an
+  // awaiting task is never missed when its column scrolls off-screen.
+  const needYouCount = $derived(allFilteredTasks.filter((t: Task) => awaitsHuman(t.status)).length)
+
   const hasActiveFilters = $derived(
     Boolean(searchQuery) || Boolean(selectedProjectId) || selectedTags.length > 0 || Boolean(selectedAgentMode)
   )
@@ -347,6 +352,7 @@
     {allTags}
     {hasActiveFilters}
     {viewMode}
+    {needYouCount}
     onclear={clearFilters}
     onviewchange={() => { focusedColIdx = -1; focusedRowIdx = -1 }}
   />

--- a/frontend/src/pages/TaskList.svelte.test.ts
+++ b/frontend/src/pages/TaskList.svelte.test.ts
@@ -146,6 +146,20 @@ describe('TaskList', () => {
       expect(screen.getByText('Done → Logbook')).toBeDefined()
       expect(screen.queryByLabelText('Show done')).toBeNull()
     })
+
+    it('surfaces a persistent "need you" count on the board', () => {
+      viewModeStore.set('board')
+      Object.assign(taskStore, {
+        list: [
+          mockTask('h1', 'Blocked task', 'human-required'),
+          mockTask('p1', 'Plan to review', 'plan-review'),
+          mockTask('t1', 'Normal task', 'todo'),
+        ],
+      })
+      render(TaskList, { props: { onselect: vi.fn() } })
+      // 2 of 3 tasks await the user — visible regardless of horizontal scroll.
+      expect(screen.getByText('2 need you')).toBeDefined()
+    })
   })
 
   describe('task selection', () => {

--- a/frontend/src/pages/TaskList.svelte.test.ts
+++ b/frontend/src/pages/TaskList.svelte.test.ts
@@ -160,6 +160,20 @@ describe('TaskList', () => {
       // 2 of 3 tasks await the user — visible regardless of horizontal scroll.
       expect(screen.getByText('2 need you')).toBeDefined()
     })
+
+    it('hides the need-you counter in list view even when tasks await', () => {
+      viewModeStore.set('list')
+      Object.assign(taskStore, { list: [mockTask('h1', 'Blocked', 'human-required')] })
+      render(TaskList, { props: { onselect: vi.fn() } })
+      expect(screen.queryByText(/need you/)).toBeNull()
+    })
+
+    it('hides the need-you counter on the board when nothing awaits', () => {
+      viewModeStore.set('board')
+      Object.assign(taskStore, { list: [mockTask('t1', 'Normal', 'todo')] })
+      render(TaskList, { props: { onselect: vi.fn() } })
+      expect(screen.queryByText(/need you/)).toBeNull()
+    })
   })
 
   describe('task selection', () => {


### PR DESCRIPTION
## Motivation

Part of ☂️ #968 (final subissue). At 1440px only 5 of 6 board columns fit;
"Human Required" — the column that by definition needs *you* — was entirely
off the right edge with no scrollbar, fade, arrow, or count. The one column an
operator most needs to check was the one the default laptop layout hid.

Closes #974

## Implementation information

- **Narrower columns** (`min-w` 260 → 200) so all six fit at 1440px (1328px of
  board width vs 1280px needed). Combined with the earlier card slim-down,
  cards stay readable.
- **Scroll-shadow** — when the board still overflows (narrower laptops), a CSS
  mask fades whichever edge has off-screen columns (and only then), so it's
  always visible that the board scrolls and which way. It never applies on
  mobile (vertical scroll) since there's no horizontal overflow there.
- **Persistent "N need you" counter** in the board toolbar — counts tasks
  awaiting you across all columns (the same set as the per-card red attention
  border), visible regardless of horizontal scroll, so an awaiting task is
  never missed when its column is off-screen.

Tests cover the awaiting-count and its board-only visibility.

> Changelog: fix(board): keep every column reachable + a "needs you" counter