### PR TITLE
fix(recovery): recover headless review on restart

### DIFF
--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -37,12 +37,12 @@ func (r *Recovery) RestartStaleInProgress() {
 		if r.Agents.HasRunningAgentForTask(t.ID) {
 			continue
 		}
-		if slices.Contains(t.Tags, "review") {
-			// For review tasks whose last headless run completed (state: stopped,
-			// non-empty result) but the workflow step was never recorded, advance
-			// the workflow now. This bridges completions lost across app restarts
-			// when the agent ran without survival support.
-			r.recoverCompletedHeadlessRun(&t)
+		if slices.Contains(t.Tags, "review") && r.recoverCompletedHeadlessRun(&t) {
+			// recoverCompletedHeadlessRun handled this task (last headless run
+			// completed but workflow step was never recorded). Skip the generic
+			// stale-restart path only when it actually fired HandleAgentComplete;
+			// unmatched review tasks (running agent, empty result, missing workflow,
+			// etc.) fall through so they can still be restarted.
 			continue
 		}
 		// Tasks with a terminal workflow stuck at in-progress: restart the
@@ -213,30 +213,33 @@ func (r *Recovery) recoverStaleInteractive(t *task.Task) {
 //
 // Guards: only fires when the workflow is non-terminal, the current step has no
 // history record (not yet processed), and no agent is currently running.
-func (r *Recovery) recoverCompletedHeadlessRun(t *task.Task) {
+// recoverCompletedHeadlessRun returns true when it fires HandleAgentComplete,
+// false when the task does not match the "completed but callback lost" shape.
+// Callers should only skip generic stale-restart logic on a true return.
+func (r *Recovery) recoverCompletedHeadlessRun(t *task.Task) bool {
 	lr := lastAgentRun(t)
 	if lr == nil {
-		return
+		return false
 	}
 	if lr.Mode != "headless" || lr.State != string(agent.StateStopped) || lr.Result == "" {
-		return
+		return false
 	}
 	if r.WorkflowEngine == nil || t.Workflow == nil {
-		return
+		return false
 	}
 	if t.Workflow.State == workflow.ExecCompleted || t.Workflow.State == workflow.ExecFailed {
-		return
+		return false
 	}
 	if t.Workflow.CurrentStep == "" {
-		return
+		return false
 	}
 	// Skip if the current step already has a history record — it was processed
 	// (completed or failed) and any stall belongs to a downstream step.
 	if t.Workflow.RecordForStep(t.Workflow.CurrentStep) != nil {
-		return
+		return false
 	}
 	if r.Agents.HasRunningAgentForTask(t.ID) {
-		return
+		return false
 	}
 	r.Logger.Info("recover-completed-headless-run",
 		"task_id", t.ID, "agent_id", lr.AgentID, "step", t.Workflow.CurrentStep)
@@ -246,7 +249,7 @@ func (r *Recovery) recoverCompletedHeadlessRun(t *task.Task) {
 	wf.Recovered = true
 	if _, err := r.Tasks.Update(t.ID, task.Update{Workflow: &wf}); err != nil {
 		r.Logger.Error("recover-completed-headless.set-recovered", "task_id", t.ID, "err", err)
-		return
+		return false
 	}
 	r.WorkflowEngine.HandleAgentComplete(t.ID, workflow.AgentCompletion{
 		AgentID:  lr.AgentID,
@@ -254,6 +257,7 @@ func (r *Recovery) recoverCompletedHeadlessRun(t *task.Task) {
 		Success:  true,
 		Result:   lr.Result,
 	})
+	return true
 }
 
 func lastAgentRun(t *task.Task) *task.AgentRun {

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -38,6 +38,11 @@ func (r *Recovery) RestartStaleInProgress() {
 			continue
 		}
 		if slices.Contains(t.Tags, "review") {
+			// For review tasks whose last headless run completed (state: stopped,
+			// non-empty result) but the workflow step was never recorded, advance
+			// the workflow now. This bridges completions lost across app restarts
+			// when the agent ran without survival support.
+			r.recoverCompletedHeadlessRun(&t)
 			continue
 		}
 		// Tasks with a terminal workflow stuck at in-progress: restart the
@@ -197,6 +202,57 @@ func (r *Recovery) recoverStaleInteractive(t *task.Task) {
 		AgentID:  lr.AgentID,
 		Provider: lr.Provider,
 		Success:  true,
+	})
+}
+
+// recoverCompletedHeadlessRun advances the workflow for a headless agent whose
+// run completed successfully (state: stopped, non-empty result) but whose step
+// was never recorded in the workflow history. This bridges the gap when the
+// HandleAgentComplete callback is lost across an app restart — e.g. when the
+// agent ran before the survival registry was active.
+//
+// Guards: only fires when the workflow is non-terminal, the current step has no
+// history record (not yet processed), and no agent is currently running.
+func (r *Recovery) recoverCompletedHeadlessRun(t *task.Task) {
+	lr := lastAgentRun(t)
+	if lr == nil {
+		return
+	}
+	if lr.Mode != "headless" || lr.State != string(agent.StateStopped) || lr.Result == "" {
+		return
+	}
+	if r.WorkflowEngine == nil || t.Workflow == nil {
+		return
+	}
+	if t.Workflow.State == workflow.ExecCompleted || t.Workflow.State == workflow.ExecFailed {
+		return
+	}
+	if t.Workflow.CurrentStep == "" {
+		return
+	}
+	// Skip if the current step already has a history record — it was processed
+	// (completed or failed) and any stall belongs to a downstream step.
+	if t.Workflow.RecordForStep(t.Workflow.CurrentStep) != nil {
+		return
+	}
+	if r.Agents.HasRunningAgentForTask(t.ID) {
+		return
+	}
+	r.Logger.Info("recover-completed-headless-run",
+		"task_id", t.ID, "agent_id", lr.AgentID, "step", t.Workflow.CurrentStep)
+	// Set Recovered so downstream steps know .Prev.Output is from a stored
+	// result, not a freshly produced one — same contract as recoverStaleInteractive.
+	wf := t.Workflow
+	wf.Recovered = true
+	if _, err := r.Tasks.Update(t.ID, task.Update{Workflow: &wf}); err != nil {
+		r.Logger.Error("recover-completed-headless.set-recovered", "task_id", t.ID, "err", err)
+		return
+	}
+	r.WorkflowEngine.HandleAgentComplete(t.ID, workflow.AgentCompletion{
+		AgentID:  lr.AgentID,
+		Provider: lr.Provider,
+		Success:  true,
+		Result:   lr.Result,
 	})
 }
 


### PR DESCRIPTION
## Motivation

When a headless review agent completes but the app restarts before `HandleAgentComplete` fires, the workflow stays stuck at the review step indefinitely. The recovery code skipped all review-tagged tasks unconditionally, leaving them stranded `in-progress` with no path forward.

## Implementation information

Two fixes in `internal/recovery/stale.go`:

1. **`recoverCompletedHeadlessRun`** — for review tasks whose last agent run is stopped and has a result but the current workflow step has no history record, advance the workflow via `HandleAgentComplete` with the stored result. Guards: non-terminal workflow, no live agent, step not yet in history. Mirrors `recoverStaleInteractive`'s contract (sets `Recovered`).

2. **Conditional review skip** — unmatched review tasks (running agent, empty result, missing workflow, etc.) now fall through to the generic stale-restart path instead of being permanently skipped. This ensures no review task can get permanently stranded in-progress when the completed-run recovery path doesn't apply.

> Changelog: fix(recovery): recover headless review on restart