### PR TITLE
feat(settings): left-rail layout + contrast fixes

### DIFF
--- a/frontend/e2e/provider-smoke.spec.ts
+++ b/frontend/e2e/provider-smoke.spec.ts
@@ -14,6 +14,8 @@ async function goToSettings(page: Page) {
   await page.goto('/')
   await page.locator('[data-part="trigger"]', { hasText: /Settings/ }).click()
   await expect(page.locator('h2', { hasText: 'Settings' })).toBeVisible()
+  // Agent Defaults is its own pane in the settings rail — open it.
+  await page.getByRole('button', { name: 'Defaults' }).click()
   await expect(page.locator('#agent-provider')).toBeVisible()
 }
 

--- a/frontend/e2e/settings-provider.spec.ts
+++ b/frontend/e2e/settings-provider.spec.ts
@@ -5,6 +5,8 @@ async function goToSettings(page: Page) {
   await page.goto('/')
   await page.locator('[data-part="trigger"]', { hasText: /Settings/ }).click()
   await expect(page.locator('h2', { hasText: 'Settings' })).toBeVisible()
+  // Agent Defaults is its own pane in the settings rail — open it.
+  await page.getByRole('button', { name: 'Defaults' }).click()
   await expect(page.locator('#agent-provider')).toBeVisible()
 }
 

--- a/frontend/src/components/settings/LoggingPanel.svelte
+++ b/frontend/src/components/settings/LoggingPanel.svelte
@@ -8,9 +8,9 @@
   const { settings }: Props = $props()
 </script>
 
-<div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
-  <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Logging & Audit</h2>
-  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+<div class="rounded-xl border border-surface-200 bg-surface-50 p-5 shadow-sm dark:border-surface-700 dark:bg-surface-800 dark:shadow-none">
+  <h2 class="mb-4 text-sm font-semibold uppercase tracking-wide text-surface-600 dark:text-surface-300">Logging & Audit</h2>
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
     <div class="flex flex-col gap-1">
       <label class="text-sm font-medium" for="log-level">Log Level</label>
       <select
@@ -34,7 +34,7 @@
         class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
         bind:value={settings.logging.maxSizeMB}
       />
-      <span class="text-xs text-surface-400">1–500 MB</span>
+      <span class="text-xs text-surface-500 dark:text-surface-400">1–500 MB</span>
     </div>
     <div class="flex flex-col gap-1">
       <label class="text-sm font-medium" for="log-max-files">Max Log Files</label>
@@ -46,7 +46,7 @@
         class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
         bind:value={settings.logging.maxFiles}
       />
-      <span class="text-xs text-surface-400">1–50 files</span>
+      <span class="text-xs text-surface-500 dark:text-surface-400">1–50 files</span>
     </div>
     <div class="flex flex-col gap-1">
       <label class="text-sm font-medium" for="audit-retention">Audit Retention (days)</label>
@@ -58,14 +58,14 @@
         class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
         bind:value={settings.audit.retentionDays}
       />
-      <span class="text-xs text-surface-400">1–365 days</span>
+      <span class="text-xs text-surface-500 dark:text-surface-400">1–365 days</span>
     </div>
   </div>
   <div class="mt-4">
     <label class="flex cursor-pointer items-center gap-3">
       <input
         type="checkbox"
-        class="h-4 w-4 cursor-pointer rounded border-surface-300"
+        class="h-4 w-4 cursor-pointer rounded border-surface-300 accent-primary-500"
         bind:checked={settings.audit.enabled}
       />
       <span class="text-sm">Enable audit logging</span>

--- a/frontend/src/components/settings/ProviderHealthPanel.svelte
+++ b/frontend/src/components/settings/ProviderHealthPanel.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
   import {
+    EventsOn,
     GetProviderHealth,
     ProviderHealthEnabled,
     SetProviderAutoFailover,
     SetProviderEnabled,
-  } from '../../../bindings/github.com/Automaat/sybra/internal/sybra/integrationservice.js'
-  import { EventsOn } from '$lib/api'
+  } from '$lib/api'
   import * as ev from '../../lib/events.js'
   import type { AppSettings } from '../../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
 
@@ -82,8 +82,8 @@
 </script>
 
 {#if enabled}
-  <div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
-    <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Providers</h2>
+  <div class="rounded-xl border border-surface-200 bg-surface-50 p-5 shadow-sm dark:border-surface-700 dark:bg-surface-800 dark:shadow-none">
+    <h2 class="mb-4 text-sm font-semibold uppercase tracking-wide text-surface-600 dark:text-surface-300">Providers</h2>
     {#if error}
       <div class="mb-3 text-xs text-error-500">{error}</div>
     {/if}
@@ -101,16 +101,16 @@
               {/if}
             </div>
             {#if p?.detail}
-              <span class="text-xs text-surface-400">{p.detail}</span>
+              <span class="text-xs text-surface-500 dark:text-surface-400">{p.detail}</span>
             {/if}
             {#if p?.lastCheck}
-              <span class="text-xs text-surface-400">last check: {new Date(p.lastCheck).toLocaleTimeString()}</span>
+              <span class="text-xs text-surface-500 dark:text-surface-400">last check: {new Date(p.lastCheck).toLocaleTimeString()}</span>
             {/if}
           </div>
           <label class="flex cursor-pointer items-center gap-2 text-sm">
             <input
               type="checkbox"
-              class="h-4 w-4 cursor-pointer rounded border-surface-300"
+              class="h-4 w-4 cursor-pointer rounded border-surface-300 accent-primary-500"
               checked={name === 'claude' ? settings.providers.claude.enabled : settings.providers.codex.enabled}
               onchange={(e) => onProviderEnabledChange(name as 'claude' | 'codex', e)}
             />
@@ -127,7 +127,7 @@
         />
         <span class="text-sm">Auto-failover between providers when one is unhealthy</span>
       </label>
-      <span class="text-xs text-surface-400">
+      <span class="text-xs text-surface-500 dark:text-surface-400">
         Health check interval: {settings.providers.healthCheck.intervalSeconds}s. Edit config.yaml to change.
       </span>
     </div>

--- a/frontend/src/components/settings/ProviderHealthPanel.svelte
+++ b/frontend/src/components/settings/ProviderHealthPanel.svelte
@@ -2,7 +2,6 @@
   import {
     EventsOn,
     GetProviderHealth,
-    ProviderHealthEnabled,
     SetProviderAutoFailover,
     SetProviderEnabled,
   } from '$lib/api'
@@ -11,10 +10,14 @@
 
   interface Props {
     settings: AppSettings
+    // Whether provider health checks run server-side. Resolved once by the
+    // parent (Settings) so the rail entry and this pane share one source of
+    // truth — the tab is never shown while the panel renders blank.
+    enabled: boolean
     onsettingschange: () => void
   }
 
-  const { settings, onsettingschange }: Props = $props()
+  const { settings, enabled, onsettingschange }: Props = $props()
 
   type ProviderHealthEntry = {
     provider: string
@@ -25,14 +28,12 @@
     ratelimitedUntil?: string
   }
 
-  let enabled = $state(false)
   let map = $state<Record<string, ProviderHealthEntry>>({})
   let error = $state('')
 
   async function load() {
+    if (!enabled) return
     try {
-      enabled = await ProviderHealthEnabled()
-      if (!enabled) return
       const list = (await GetProviderHealth()) ?? []
       const next: Record<string, ProviderHealthEntry> = {}
       for (const p of list) next[p.provider] = p as ProviderHealthEntry

--- a/frontend/src/components/settings/ProviderHealthPanel.svelte.test.ts
+++ b/frontend/src/components/settings/ProviderHealthPanel.svelte.test.ts
@@ -7,15 +7,12 @@ const mockSetEnabled = vi.fn()
 const mockSetAutoFailover = vi.fn()
 const mockEventsOn = vi.fn()
 
-vi.mock('../../../bindings/github.com/Automaat/sybra/internal/sybra/integrationservice.js', () => ({
+vi.mock('$lib/api', () => ({
+  EventsOn: (...args: unknown[]) => mockEventsOn(...args),
   ProviderHealthEnabled: () => mockEnabled(),
   GetProviderHealth: () => mockGetHealth(),
   SetProviderEnabled: (...args: unknown[]) => mockSetEnabled(...args),
   SetProviderAutoFailover: (...args: unknown[]) => mockSetAutoFailover(...args),
-}))
-
-vi.mock('$lib/api', () => ({
-  EventsOn: (...args: unknown[]) => mockEventsOn(...args),
 }))
 
 const ProviderHealthPanel = (await import('./ProviderHealthPanel.svelte')).default

--- a/frontend/src/components/settings/ProviderHealthPanel.svelte.test.ts
+++ b/frontend/src/components/settings/ProviderHealthPanel.svelte.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte'
 
-const mockEnabled = vi.fn()
 const mockGetHealth = vi.fn()
 const mockSetEnabled = vi.fn()
 const mockSetAutoFailover = vi.fn()
@@ -9,7 +8,6 @@ const mockEventsOn = vi.fn()
 
 vi.mock('$lib/api', () => ({
   EventsOn: (...args: unknown[]) => mockEventsOn(...args),
-  ProviderHealthEnabled: () => mockEnabled(),
   GetProviderHealth: () => mockGetHealth(),
   SetProviderEnabled: (...args: unknown[]) => mockSetEnabled(...args),
   SetProviderAutoFailover: (...args: unknown[]) => mockSetAutoFailover(...args),
@@ -30,13 +28,11 @@ function buildSettings() {
 
 describe('ProviderHealthPanel', () => {
   beforeEach(() => {
-    mockEnabled.mockReset()
     mockGetHealth.mockReset()
     mockSetEnabled.mockReset()
     mockSetAutoFailover.mockReset()
     mockEventsOn.mockReset()
     mockEventsOn.mockReturnValue(() => {})
-    mockEnabled.mockResolvedValue(true)
     mockGetHealth.mockResolvedValue([
       { provider: 'claude', healthy: true, reason: '' },
       { provider: 'codex', healthy: false, reason: 'rate-limited' },
@@ -46,10 +42,9 @@ describe('ProviderHealthPanel', () => {
   })
   afterEach(cleanup)
 
-  it('renders nothing when provider health is disabled at runtime', async () => {
-    mockEnabled.mockResolvedValue(false)
+  it('renders nothing when provider health is disabled', async () => {
     const { container } = render(ProviderHealthPanel, {
-      props: { settings: buildSettings(), onsettingschange: vi.fn() },
+      props: { settings: buildSettings(), enabled: false, onsettingschange: vi.fn() },
     })
     await waitFor(() => {
       expect(container.querySelector('h2')).toBeNull()
@@ -58,7 +53,7 @@ describe('ProviderHealthPanel', () => {
 
   it('renders Providers section with both rows when enabled', async () => {
     render(ProviderHealthPanel, {
-      props: { settings: buildSettings(), onsettingschange: vi.fn() },
+      props: { settings: buildSettings(), enabled: true, onsettingschange: vi.fn() },
     })
     await waitFor(() => {
       expect(screen.getByText('Providers')).toBeDefined()
@@ -69,7 +64,7 @@ describe('ProviderHealthPanel', () => {
 
   it('shows healthy badge for claude and rate-limited reason for codex', async () => {
     render(ProviderHealthPanel, {
-      props: { settings: buildSettings(), onsettingschange: vi.fn() },
+      props: { settings: buildSettings(), enabled: true, onsettingschange: vi.fn() },
     })
     await waitFor(() => {
       expect(screen.getByText('healthy')).toBeDefined()
@@ -80,7 +75,7 @@ describe('ProviderHealthPanel', () => {
   it('toggling auto-failover calls SetProviderAutoFailover + onsettingschange', async () => {
     const onsettingschange = vi.fn()
     render(ProviderHealthPanel, {
-      props: { settings: buildSettings(), onsettingschange },
+      props: { settings: buildSettings(), enabled: true, onsettingschange },
     })
     await waitFor(() => screen.getByText('Providers'))
     const cb = screen.getByLabelText(/Auto-failover/) as HTMLInputElement
@@ -93,7 +88,7 @@ describe('ProviderHealthPanel', () => {
 
   it('subscribes to ProviderHealth events on mount', async () => {
     render(ProviderHealthPanel, {
-      props: { settings: buildSettings(), onsettingschange: vi.fn() },
+      props: { settings: buildSettings(), enabled: true, onsettingschange: vi.fn() },
     })
     await waitFor(() => {
       expect(mockEventsOn).toHaveBeenCalled()

--- a/frontend/src/components/settings/RenovatePanel.svelte
+++ b/frontend/src/components/settings/RenovatePanel.svelte
@@ -8,18 +8,18 @@
   const { settings }: Props = $props()
 </script>
 
-<div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
-  <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Renovate</h2>
+<div class="rounded-xl border border-surface-200 bg-surface-50 p-5 shadow-sm dark:border-surface-700 dark:bg-surface-800 dark:shadow-none">
+  <h2 class="mb-4 text-sm font-semibold uppercase tracking-wide text-surface-600 dark:text-surface-300">Renovate</h2>
   <div class="flex flex-col gap-4">
     <label class="flex cursor-pointer items-center gap-3">
       <input
         type="checkbox"
-        class="h-4 w-4 cursor-pointer rounded border-surface-300"
+        class="h-4 w-4 cursor-pointer rounded border-surface-300 accent-primary-500"
         bind:checked={settings.renovate.enabled}
       />
       <div>
         <span class="text-sm font-medium">Enable Renovate PR tracking</span>
-        <p class="text-xs text-surface-400">Show Renovate bot PRs for registered projects</p>
+        <p class="text-xs text-surface-500 dark:text-surface-400">Show Renovate bot PRs for registered projects</p>
       </div>
     </label>
     {#if settings.renovate.enabled}
@@ -32,7 +32,7 @@
           class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
           bind:value={settings.renovate.author}
         />
-        <span class="text-xs text-surface-400">GitHub author filter (default: app/renovate)</span>
+        <span class="text-xs text-surface-500 dark:text-surface-400">GitHub author filter (default: app/renovate)</span>
       </div>
     {/if}
   </div>

--- a/frontend/src/components/settings/TodoistPanel.svelte
+++ b/frontend/src/components/settings/TodoistPanel.svelte
@@ -8,18 +8,18 @@
   const { settings }: Props = $props()
 </script>
 
-<div class="rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
-  <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Todoist</h2>
+<div class="rounded-xl border border-surface-200 bg-surface-50 p-5 shadow-sm dark:border-surface-700 dark:bg-surface-800 dark:shadow-none">
+  <h2 class="mb-4 text-sm font-semibold uppercase tracking-wide text-surface-600 dark:text-surface-300">Todoist</h2>
   <div class="flex flex-col gap-4">
     <label class="flex cursor-pointer items-center gap-3">
       <input
         type="checkbox"
-        class="h-4 w-4 cursor-pointer rounded border-surface-300"
+        class="h-4 w-4 cursor-pointer rounded border-surface-300 accent-primary-500"
         bind:checked={settings.todoist.enabled}
       />
       <div>
         <span class="text-sm font-medium">Enable Todoist sync</span>
-        <p class="text-xs text-surface-400">Pull tasks from a Todoist project and close them when done</p>
+        <p class="text-xs text-surface-500 dark:text-surface-400">Pull tasks from a Todoist project and close them when done</p>
       </div>
     </label>
     {#if settings.todoist.enabled}
@@ -33,7 +33,7 @@
             class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
             bind:value={settings.todoist.apiToken}
           />
-          <span class="text-xs text-surface-400">Settings → Integrations → API token</span>
+          <span class="text-xs text-surface-500 dark:text-surface-400">Settings → Integrations → API token</span>
         </div>
         <div class="flex flex-col gap-1">
           <label class="text-sm font-medium" for="todoist-project">Project ID</label>
@@ -44,7 +44,7 @@
             class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
             bind:value={settings.todoist.projectId}
           />
-          <span class="text-xs text-surface-400">ID from project URL</span>
+          <span class="text-xs text-surface-500 dark:text-surface-400">ID from project URL</span>
         </div>
         <div class="flex flex-col gap-1">
           <label class="text-sm font-medium" for="todoist-poll">Poll Interval (seconds)</label>
@@ -56,7 +56,7 @@
             class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
             bind:value={settings.todoist.pollSeconds}
           />
-          <span class="text-xs text-surface-400">30–3600 seconds</span>
+          <span class="text-xs text-surface-500 dark:text-surface-400">30–3600 seconds</span>
         </div>
       </div>
     {/if}

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -80,6 +80,8 @@ export function GetTodoistProjects(): Promise<Array<TodoistProject>> { return ca
 export function ProviderHealthEnabled(): Promise<boolean> { return call('IntegrationService', 'ProviderHealthEnabled') }
 export function MergeRenovatePR(arg1: string, arg2: number): Promise<void> { return call('IntegrationService', 'MergeRenovatePR', arg1, arg2) }
 export function RerunRenovateChecks(arg1: string, arg2: number): Promise<void> { return call('IntegrationService', 'RerunRenovateChecks', arg1, arg2) }
+export function SetProviderAutoFailover(arg1: boolean): Promise<void> { return call('IntegrationService', 'SetProviderAutoFailover', arg1) }
+export function SetProviderEnabled(arg1: string, arg2: boolean): Promise<void> { return call('IntegrationService', 'SetProviderEnabled', arg1, arg2) }
 export function SyncTodoist(): Promise<void> { return call('IntegrationService', 'SyncTodoist') }
 export function TodoistEnabled(): Promise<boolean> { return call('IntegrationService', 'TodoistEnabled') }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -77,6 +77,8 @@ export const GetTodoistProjects = pick(IntegrationSvc.GetTodoistProjects, http.G
 export const MergeRenovatePR = pick(IntegrationSvc.MergeRenovatePR, http.MergeRenovatePR)
 export const ProviderHealthEnabled = pick(IntegrationSvc.ProviderHealthEnabled, http.ProviderHealthEnabled)
 export const RerunRenovateChecks = pick(IntegrationSvc.RerunRenovateChecks, http.RerunRenovateChecks)
+export const SetProviderAutoFailover = pick(IntegrationSvc.SetProviderAutoFailover, http.SetProviderAutoFailover)
+export const SetProviderEnabled = pick(IntegrationSvc.SetProviderEnabled, http.SetProviderEnabled)
 export const SyncTodoist = pick(IntegrationSvc.SyncTodoist, http.SyncTodoist)
 export const TodoistEnabled = pick(IntegrationSvc.TodoistEnabled, http.TodoistEnabled)
 

--- a/frontend/src/pages/Settings.svelte
+++ b/frontend/src/pages/Settings.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte'
-  import { GetSettings, UpdateSettings, GetVersion, GetCodexModels } from '$lib/api'
+  import { GetSettings, UpdateSettings, GetVersion, GetCodexModels, ProviderHealthEnabled } from '$lib/api'
   import type { AppSettings } from '../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
   import ProviderHealthPanel from '../components/settings/ProviderHealthPanel.svelte'
   import LoggingPanel from '../components/settings/LoggingPanel.svelte'
@@ -32,6 +32,12 @@
     applyColorScheme(colorScheme)
   })
 
+  const colorSchemes: { value: ColorScheme; label: string }[] = [
+    { value: 'system', label: 'System' },
+    { value: 'light', label: 'Light' },
+    { value: 'dark', label: 'Dark' },
+  ]
+
   let settings = $state<AppSettings | null>(null)
   let original = $state<string>('')
   let saving = $state(false)
@@ -54,6 +60,10 @@
   ]
   let codexDynamicModels = $state<ModelOption[]>([])
 
+  // Provider health is server-gated; only surface the Providers pane (and its
+  // rail entry) when the backend actually runs health checks.
+  let providerHealthEnabled = $state(false)
+
   $effect(() => {
     load()
   })
@@ -68,6 +78,7 @@
         ]
       }
     }).catch(() => {})
+    ProviderHealthEnabled().then(v => { providerHealthEnabled = v }).catch(() => {})
   })
 
   async function load() {
@@ -139,253 +150,318 @@
     }
   })
 
-  // Anchored section sub-nav so the page isn't one long scroll.
-  const navSections = [
-    { id: 'appearance', label: 'Appearance' },
-    { id: 'agent-defaults', label: 'Agent' },
-    { id: 'provider-health', label: 'Providers' },
-    { id: 'notifications', label: 'Notifications' },
-    { id: 'orchestrator', label: 'Orchestrator' },
-    { id: 'logging', label: 'Logging' },
-    { id: 'todoist', label: 'Todoist' },
-    { id: 'renovate', label: 'Renovate' },
-    { id: 'version', label: 'Version' },
-    { id: 'directories', label: 'Directories' },
-  ]
+  // Left-rail layout: each pane is a single section, grouped for scannability.
+  // The Providers entry only exists when health checks are enabled, so the rail
+  // never offers a link that resolves to nothing.
+  type TabId =
+    | 'appearance' | 'notifications' | 'agent-defaults' | 'provider-health'
+    | 'orchestrator' | 'todoist' | 'renovate' | 'logging' | 'version' | 'directories'
 
-  function scrollToSection(id: string) {
-    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-    document.getElementById(id)?.scrollIntoView({ behavior: reduced ? 'auto' : 'smooth', block: 'start' })
-  }
+  type RailItem = { id: TabId; label: string }
+  type RailGroup = { label: string; items: RailItem[] }
+
+  const groups = $derived<RailGroup[]>([
+    { label: 'General', items: [
+      { id: 'appearance', label: 'Appearance' },
+      { id: 'notifications', label: 'Notifications' },
+    ] },
+    { label: 'Agents', items: [
+      { id: 'agent-defaults', label: 'Defaults' },
+      ...(providerHealthEnabled ? [{ id: 'provider-health' as TabId, label: 'Providers' }] : []),
+    ] },
+    { label: 'Automation', items: [
+      { id: 'orchestrator', label: 'Orchestrator' },
+      { id: 'todoist', label: 'Todoist' },
+      { id: 'renovate', label: 'Renovate' },
+    ] },
+    { label: 'Advanced', items: [
+      { id: 'logging', label: 'Logging' },
+      { id: 'version', label: 'Version' },
+      { id: 'directories', label: 'Directories' },
+    ] },
+  ])
+
+  const tabs = $derived(groups.flatMap(g => g.items))
+
+  let active = $state<TabId>('appearance')
+
+  // If the active pane disappears (only Providers can), fall back to Appearance.
+  $effect(() => {
+    if (!tabs.some(t => t.id === active)) active = 'appearance'
+  })
 </script>
 
-<div class="flex flex-col gap-4 p-4 md:gap-6 md:p-6">
-  <!-- Sticky save bar + section sub-nav -->
-  <div class="sticky top-0 z-10 -mx-4 flex flex-col gap-2 border-b border-surface-200 bg-surface-100/95 px-4 py-2 backdrop-blur dark:border-surface-700 dark:bg-surface-900/95 md:-mx-6 md:px-6">
-    <div class="flex items-center justify-between gap-3">
-      <p class="min-w-0 text-xs leading-tight text-surface-400">
-        Appearance &amp; provider toggles apply instantly · other settings save together
-      </p>
-      <div class="flex shrink-0 flex-nowrap items-center gap-2">
-        {#if successMsg}
-          <span class="text-sm text-success-500">{successMsg}</span>
-        {/if}
-        {#if error}
-          <span class="text-sm text-error-500">{error}</span>
-        {/if}
-        {#if dirty}
-          <span class="text-xs font-medium text-warning-600 dark:text-warning-400">Unsaved changes</span>
-          <button
-            type="button"
-            class="rounded-lg bg-surface-200 px-3 py-1.5 text-sm font-medium hover:bg-surface-300 dark:bg-surface-700 dark:hover:bg-surface-600"
-            onclick={reset}
-          >
-            Reset
-          </button>
-        {/if}
+<div class="flex min-h-full flex-col">
+  <!-- Sticky save bar: visible from every pane so cross-pane dirty state is never hidden -->
+  <div class="sticky top-0 z-20 flex items-center justify-between gap-3 border-b border-surface-200 bg-surface-50/95 px-4 py-2.5 backdrop-blur dark:border-surface-700 dark:bg-surface-900/95 md:px-6">
+    <p class="hidden min-w-0 truncate text-xs text-surface-500 dark:text-surface-400 sm:block">
+      Appearance &amp; provider changes apply instantly · other settings save together
+    </p>
+    <div class="flex shrink-0 items-center gap-2">
+      {#if successMsg}
+        <span class="text-sm font-medium text-success-600 dark:text-success-400">{successMsg}</span>
+      {/if}
+      {#if error}
+        <span class="max-w-[16rem] truncate text-sm text-error-600 dark:text-error-400">{error}</span>
+      {/if}
+      {#if dirty}
+        <span class="text-xs font-medium text-warning-600 dark:text-warning-400">Unsaved changes</span>
         <button
           type="button"
-          class="rounded-lg bg-primary-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-600 disabled:opacity-50"
-          onclick={save}
-          disabled={!dirty || saving}
+          class="rounded-lg px-3 py-1.5 text-sm font-medium text-surface-700 hover:bg-surface-200 dark:text-surface-200 dark:hover:bg-surface-700"
+          onclick={reset}
         >
-          {saving ? 'Saving…' : 'Save'}
+          Reset
         </button>
-      </div>
-    </div>
-    <nav class="flex gap-1 overflow-x-auto" aria-label="Settings sections">
-      {#each navSections as s (s.id)}
-        <button
-          type="button"
-          class="shrink-0 rounded-md px-2.5 py-1 text-xs font-medium text-surface-500 transition-colors hover:bg-surface-200 hover:text-surface-800 dark:hover:bg-surface-700 dark:hover:text-surface-200"
-          onclick={() => scrollToSection(s.id)}
-        >
-          {s.label}
-        </button>
-      {/each}
-    </nav>
-  </div>
-
-  <!-- Appearance (localStorage-backed, no save required) -->
-  <div id="appearance" class="scroll-mt-28 rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
-    <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Appearance</h2>
-    <div class="flex flex-col gap-1 sm:max-w-xs">
-      <label class="text-sm font-medium" for="color-scheme">Color Scheme</label>
-      <select
-        id="color-scheme"
-        class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
-        bind:value={colorScheme}
+      {/if}
+      <button
+        type="button"
+        class="rounded-lg bg-primary-500 px-4 py-1.5 text-sm font-semibold text-primary-contrast-500 shadow-sm transition-colors hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-40 disabled:shadow-none"
+        onclick={save}
+        disabled={!dirty || saving}
       >
-        <option value="system">System</option>
-        <option value="light">Light</option>
-        <option value="dark">Dark</option>
-      </select>
-      <span class="text-xs text-surface-400">Applied immediately, no save needed</span>
+        {saving ? 'Saving…' : 'Save'}
+      </button>
     </div>
-    <label class="mt-4 flex items-start gap-3">
-      <input
-        type="checkbox"
-        class="mt-0.5 h-4 w-4 accent-primary-500"
-        checked={focusModeStore.enabled}
-        onchange={(e) => setFocusMode((e.target as HTMLInputElement).checked)}
-      />
-      <span class="flex flex-col">
-        <span class="text-sm font-medium">Focus mode</span>
-        <span class="text-xs text-surface-400">Cleaner, minimal surface — collapses the sidebar and leads with the list view. Advanced views stay reachable via “More”.</span>
-      </span>
-    </label>
   </div>
 
-  {#if settings}
-    <!-- Agent Defaults -->
-    <div id="agent-defaults" class="scroll-mt-28 rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
-      <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Agent Defaults</h2>
-      <div class="grid grid-cols-1 gap-4 sm:grid-cols-4">
-        <div class="flex flex-col gap-1">
-          <label class="text-sm font-medium" for="agent-provider">Agent Type</label>
-          <select
-            id="agent-provider"
-            class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
-            bind:value={settings.agent.provider}
-          >
-            <option value="claude">Claude</option>
-            <option value="codex">Codex</option>
-          </select>
-        </div>
-        <div class="flex flex-col gap-1">
-          <label class="text-sm font-medium" for="agent-model">Default Model</label>
-          <select
-            id="agent-model"
-            class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
-            bind:value={settings.agent.model}
-          >
-            {#each modelOptions as option}
-              <option value={option.value}>{option.label}</option>
-            {/each}
-          </select>
-        </div>
-        <div class="flex flex-col gap-1">
-          <label class="text-sm font-medium" for="agent-mode">Default Mode</label>
-          <select
-            id="agent-mode"
-            class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
-            bind:value={settings.agent.mode}
-          >
-            <option value="">— none —</option>
-            <option value="headless">Headless</option>
-            <option value="interactive">Interactive</option>
-          </select>
-        </div>
-        <div class="flex flex-col gap-1">
-          <label class="text-sm font-medium" for="agent-concurrency">Max Concurrent</label>
-          <input
-            id="agent-concurrency"
-            type="number"
-            min="1"
-            max="10"
-            class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
-            bind:value={settings.agent.maxConcurrent}
-          />
-          <span class="text-xs text-surface-400">1–10</span>
-        </div>
-      </div>
-    </div>
-
-    <section id="provider-health" class="scroll-mt-28">
-      <ProviderHealthPanel {settings} onsettingschange={syncOriginal} />
-    </section>
-
-    <!-- Notifications -->
-    <div id="notifications" class="scroll-mt-28 rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
-      <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Notifications</h2>
-      <label class="flex cursor-pointer items-center gap-3">
-        <input
-          type="checkbox"
-          class="h-4 w-4 cursor-pointer rounded border-surface-300"
-          bind:checked={settings.notification.desktop}
-        />
-        <span class="text-sm">Desktop notifications (macOS)</span>
-      </label>
-    </div>
-
-    <!-- Orchestrator -->
-    <div id="orchestrator" class="scroll-mt-28 rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
-      <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Orchestrator</h2>
-      <div class="flex flex-col gap-3">
-        <label class="flex cursor-pointer items-center gap-3">
-          <input
-            type="checkbox"
-            class="h-4 w-4 cursor-pointer rounded border-surface-300"
-            bind:checked={settings.orchestrator.autoTriage}
-          />
-          <div>
-            <span class="text-sm font-medium">Auto-triage</span>
-            <p class="text-xs text-surface-400">Automatically dispatch triage agents on task creation</p>
-          </div>
-        </label>
-        <label class="flex cursor-pointer items-center gap-3">
-          <input
-            type="checkbox"
-            class="h-4 w-4 cursor-pointer rounded border-surface-300"
-            bind:checked={settings.orchestrator.autoPlan}
-          />
-          <div>
-            <span class="text-sm font-medium">Auto-plan</span>
-            <p class="text-xs text-surface-400">Automatically dispatch planning agents on complex tasks</p>
-          </div>
-        </label>
-      </div>
-    </div>
-
-    <section id="logging" class="scroll-mt-28">
-      <LoggingPanel settings={settings} />
-    </section>
-
-    <section id="todoist" class="scroll-mt-28">
-      <TodoistPanel settings={settings} />
-    </section>
-
-    <section id="renovate" class="scroll-mt-28">
-      <RenovatePanel settings={settings} />
-    </section>
-
-    <!-- Version (read-only) -->
-    <div id="version" class="scroll-mt-28 rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
-      <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Version</h2>
-      <div class="flex flex-col gap-2">
-        <div class="flex items-center gap-3">
-          <span class="w-20 shrink-0 text-xs font-medium text-surface-400">Server</span>
-          <span class="flex-1 font-mono text-xs text-surface-500 dark:text-surface-400">{serverVersion ?? '…'}</span>
-        </div>
-        <div class="flex items-center gap-3">
-          <span class="w-20 shrink-0 text-xs font-medium text-surface-400">Client</span>
-          <span class="flex-1 font-mono text-xs text-surface-500 dark:text-surface-400">{clientVersion}</span>
-        </div>
-      </div>
-    </div>
-
-    <!-- Directories (read-only) -->
-    <div id="directories" class="scroll-mt-28 rounded-lg border border-surface-300 bg-surface-50 p-5 dark:border-surface-600 dark:bg-surface-800">
-      <h2 class="mb-4 text-sm font-semibold text-surface-500 uppercase tracking-wide">Directories</h2>
-      <div class="flex flex-col gap-2">
-        {#each dirOrder as key (key)}
-          {#if settings.directories[key]}
-            <div class="flex items-center gap-3">
-              <span class="w-20 shrink-0 text-xs font-medium text-surface-400 capitalize">{key}</span>
-              <input
-                type="text"
-                value={settings.directories[key]}
-                disabled
-                class="flex-1 rounded-lg border border-surface-200 bg-surface-100 px-3 py-1.5 font-mono text-xs text-surface-500 dark:border-surface-700 dark:bg-surface-900 dark:text-surface-400"
-              />
-            </div>
-          {/if}
+  <div class="flex min-h-0 flex-1 flex-col md:flex-row">
+    <!-- One responsive rail: vertical sidebar on md+, horizontal tab strip below -->
+    <nav
+      class="shrink-0 border-b border-surface-200 px-3 py-2 dark:border-surface-700 md:w-52 md:border-b-0 md:border-r md:py-4"
+      aria-label="Settings sections"
+    >
+      <div class="flex gap-1 overflow-x-auto md:flex-col md:gap-0.5 md:overflow-visible">
+        {#each groups as group (group.label)}
+          <p class="hidden px-2.5 pt-4 pb-1 text-[11px] font-semibold uppercase tracking-wider text-surface-500 first:pt-0 dark:text-surface-400 md:block">
+            {group.label}
+          </p>
+          {#each group.items as item (item.id)}
+            <button
+              type="button"
+              aria-current={active === item.id ? 'page' : undefined}
+              class="flex shrink-0 items-center rounded-md px-2.5 py-1.5 text-left text-sm transition-colors
+                {active === item.id
+                  ? 'bg-primary-500/12 font-medium text-primary-700 dark:bg-primary-500/15 dark:text-primary-300'
+                  : 'text-surface-600 hover:bg-surface-200/70 hover:text-surface-900 dark:text-surface-300 dark:hover:bg-surface-800 dark:hover:text-surface-50'}"
+              onclick={() => (active = item.id)}
+            >
+              {item.label}
+            </button>
+          {/each}
         {/each}
       </div>
+    </nav>
+
+    <!-- Content column -->
+    <div class="min-w-0 flex-1">
+      <div class="mx-auto max-w-3xl p-4 md:p-6">
+        <!-- Appearance (localStorage-backed, no save required) -->
+        {#if active === 'appearance'}
+          <section class="rounded-xl border border-surface-200 bg-surface-50 p-5 shadow-sm dark:border-surface-700 dark:bg-surface-800 dark:shadow-none">
+            <h2 class="mb-4 text-sm font-semibold uppercase tracking-wide text-surface-600 dark:text-surface-300">Appearance</h2>
+            <div class="flex flex-col gap-1.5">
+              <span class="text-sm font-medium" id="color-scheme-label">Color Scheme</span>
+              <div
+                role="group"
+                aria-labelledby="color-scheme-label"
+                class="inline-flex w-fit rounded-lg border border-surface-300 bg-surface-100 p-0.5 dark:border-surface-600 dark:bg-surface-900"
+              >
+                {#each colorSchemes as opt (opt.value)}
+                  <button
+                    type="button"
+                    aria-pressed={colorScheme === opt.value}
+                    class="rounded-md px-3.5 py-1.5 text-sm font-medium transition-colors
+                      {colorScheme === opt.value
+                        ? 'bg-primary-500 text-primary-contrast-500 shadow-sm'
+                        : 'text-surface-600 hover:text-surface-900 dark:text-surface-300 dark:hover:text-surface-50'}"
+                    onclick={() => (colorScheme = opt.value)}
+                  >
+                    {opt.label}
+                  </button>
+                {/each}
+              </div>
+              <span class="text-xs text-surface-500 dark:text-surface-400">Applied immediately, no save needed</span>
+            </div>
+            <label class="mt-5 flex items-start gap-3">
+              <input
+                type="checkbox"
+                class="mt-0.5 h-4 w-4 accent-primary-500"
+                checked={focusModeStore.enabled}
+                onchange={(e) => setFocusMode((e.target as HTMLInputElement).checked)}
+              />
+              <span class="flex flex-col">
+                <span class="text-sm font-medium">Focus mode</span>
+                <span class="text-xs text-surface-500 dark:text-surface-400">Cleaner, minimal surface — collapses the sidebar and leads with the list view. Advanced views stay reachable via “More”.</span>
+              </span>
+            </label>
+          </section>
+        {/if}
+
+        {#if settings}
+          <!-- Notifications -->
+          {#if active === 'notifications'}
+            <section class="rounded-xl border border-surface-200 bg-surface-50 p-5 shadow-sm dark:border-surface-700 dark:bg-surface-800 dark:shadow-none">
+              <h2 class="mb-4 text-sm font-semibold uppercase tracking-wide text-surface-600 dark:text-surface-300">Notifications</h2>
+              <label class="flex cursor-pointer items-center gap-3">
+                <input
+                  type="checkbox"
+                  class="h-4 w-4 cursor-pointer rounded border-surface-300 accent-primary-500"
+                  bind:checked={settings.notification.desktop}
+                />
+                <span class="text-sm">Desktop notifications (macOS)</span>
+              </label>
+            </section>
+          {/if}
+
+          <!-- Agent Defaults -->
+          {#if active === 'agent-defaults'}
+            <section class="rounded-xl border border-surface-200 bg-surface-50 p-5 shadow-sm dark:border-surface-700 dark:bg-surface-800 dark:shadow-none">
+              <h2 class="mb-4 text-sm font-semibold uppercase tracking-wide text-surface-600 dark:text-surface-300">Agent Defaults</h2>
+              <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div class="flex flex-col gap-1">
+                  <label class="text-sm font-medium" for="agent-provider">Agent Type</label>
+                  <select
+                    id="agent-provider"
+                    class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
+                    bind:value={settings.agent.provider}
+                  >
+                    <option value="claude">Claude</option>
+                    <option value="codex">Codex</option>
+                  </select>
+                </div>
+                <div class="flex flex-col gap-1">
+                  <label class="text-sm font-medium" for="agent-model">Default Model</label>
+                  <select
+                    id="agent-model"
+                    class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
+                    bind:value={settings.agent.model}
+                  >
+                    {#each modelOptions as option}
+                      <option value={option.value}>{option.label}</option>
+                    {/each}
+                  </select>
+                </div>
+                <div class="flex flex-col gap-1">
+                  <label class="text-sm font-medium" for="agent-mode">Default Mode</label>
+                  <select
+                    id="agent-mode"
+                    class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
+                    bind:value={settings.agent.mode}
+                  >
+                    <option value="">— none —</option>
+                    <option value="headless">Headless</option>
+                    <option value="interactive">Interactive</option>
+                  </select>
+                </div>
+                <div class="flex flex-col gap-1">
+                  <label class="text-sm font-medium" for="agent-concurrency">Max Concurrent</label>
+                  <input
+                    id="agent-concurrency"
+                    type="number"
+                    min="1"
+                    max="10"
+                    class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
+                    bind:value={settings.agent.maxConcurrent}
+                  />
+                  <span class="text-xs text-surface-500 dark:text-surface-400">1–10</span>
+                </div>
+              </div>
+            </section>
+          {/if}
+
+          <!-- Providers (server-gated) -->
+          {#if active === 'provider-health'}
+            <ProviderHealthPanel {settings} onsettingschange={syncOriginal} />
+          {/if}
+
+          <!-- Orchestrator -->
+          {#if active === 'orchestrator'}
+            <section class="rounded-xl border border-surface-200 bg-surface-50 p-5 shadow-sm dark:border-surface-700 dark:bg-surface-800 dark:shadow-none">
+              <h2 class="mb-4 text-sm font-semibold uppercase tracking-wide text-surface-600 dark:text-surface-300">Orchestrator</h2>
+              <div class="flex flex-col gap-3">
+                <label class="flex cursor-pointer items-start gap-3">
+                  <input
+                    type="checkbox"
+                    class="mt-0.5 h-4 w-4 cursor-pointer rounded border-surface-300 accent-primary-500"
+                    bind:checked={settings.orchestrator.autoTriage}
+                  />
+                  <div>
+                    <span class="text-sm font-medium">Auto-triage</span>
+                    <p class="text-xs text-surface-500 dark:text-surface-400">Automatically dispatch triage agents on task creation</p>
+                  </div>
+                </label>
+                <label class="flex cursor-pointer items-start gap-3">
+                  <input
+                    type="checkbox"
+                    class="mt-0.5 h-4 w-4 cursor-pointer rounded border-surface-300 accent-primary-500"
+                    bind:checked={settings.orchestrator.autoPlan}
+                  />
+                  <div>
+                    <span class="text-sm font-medium">Auto-plan</span>
+                    <p class="text-xs text-surface-500 dark:text-surface-400">Automatically dispatch planning agents on complex tasks</p>
+                  </div>
+                </label>
+              </div>
+            </section>
+          {/if}
+
+          {#if active === 'todoist'}
+            <TodoistPanel settings={settings} />
+          {/if}
+
+          {#if active === 'renovate'}
+            <RenovatePanel settings={settings} />
+          {/if}
+
+          {#if active === 'logging'}
+            <LoggingPanel settings={settings} />
+          {/if}
+
+          <!-- Version (read-only) -->
+          {#if active === 'version'}
+            <section class="rounded-xl border border-surface-200 bg-surface-50 p-5 shadow-sm dark:border-surface-700 dark:bg-surface-800 dark:shadow-none">
+              <h2 class="mb-4 text-sm font-semibold uppercase tracking-wide text-surface-600 dark:text-surface-300">Version</h2>
+              <div class="flex flex-col gap-2">
+                <div class="flex items-center gap-3">
+                  <span class="w-20 shrink-0 text-xs font-medium text-surface-500 dark:text-surface-400">Server</span>
+                  <span class="flex-1 font-mono text-xs text-surface-600 dark:text-surface-300">{serverVersion ?? '…'}</span>
+                </div>
+                <div class="flex items-center gap-3">
+                  <span class="w-20 shrink-0 text-xs font-medium text-surface-500 dark:text-surface-400">Client</span>
+                  <span class="flex-1 font-mono text-xs text-surface-600 dark:text-surface-300">{clientVersion}</span>
+                </div>
+              </div>
+            </section>
+          {/if}
+
+          <!-- Directories (read-only) -->
+          {#if active === 'directories'}
+            <section class="rounded-xl border border-surface-200 bg-surface-50 p-5 shadow-sm dark:border-surface-700 dark:bg-surface-800 dark:shadow-none">
+              <h2 class="mb-4 text-sm font-semibold uppercase tracking-wide text-surface-600 dark:text-surface-300">Directories</h2>
+              <div class="flex flex-col gap-2">
+                {#each dirOrder as key (key)}
+                  {#if settings.directories[key]}
+                    <div class="flex items-center gap-3">
+                      <span class="w-20 shrink-0 text-xs font-medium text-surface-500 capitalize dark:text-surface-400">{key}</span>
+                      <input
+                        type="text"
+                        value={settings.directories[key]}
+                        disabled
+                        class="flex-1 rounded-lg border border-surface-200 bg-surface-100 px-3 py-1.5 font-mono text-xs text-surface-600 dark:border-surface-700 dark:bg-surface-900 dark:text-surface-300"
+                      />
+                    </div>
+                  {/if}
+                {/each}
+              </div>
+            </section>
+          {/if}
+        {:else if error}
+          <p class="text-error-600 dark:text-error-400">{error}</p>
+        {:else}
+          <p class="text-surface-500 dark:text-surface-400">Loading…</p>
+        {/if}
+      </div>
     </div>
-  {:else if error}
-    <p class="text-error-500">{error}</p>
-  {:else}
-    <p class="text-surface-400">Loading…</p>
-  {/if}
+  </div>
 </div>

--- a/frontend/src/pages/Settings.svelte
+++ b/frontend/src/pages/Settings.svelte
@@ -372,7 +372,7 @@
 
           <!-- Providers (server-gated) -->
           {#if active === 'provider-health'}
-            <ProviderHealthPanel {settings} onsettingschange={syncOriginal} />
+            <ProviderHealthPanel {settings} enabled={providerHealthEnabled} onsettingschange={syncOriginal} />
           {/if}
 
           <!-- Orchestrator -->

--- a/frontend/src/pages/Settings.svelte.test.ts
+++ b/frontend/src/pages/Settings.svelte.test.ts
@@ -16,14 +16,11 @@ vi.mock('$lib/api', () => ({
   UpdateSettings: (...args: unknown[]) => mockUpdateSettings(...args),
   GetVersion: (...args: unknown[]) => mockGetVersion(...args),
   GetCodexModels: (...args: unknown[]) => mockGetCodexModels(...args),
-  EventsOn: (...args: any[]) => mockEventsOn(...args),
-}))
-
-vi.mock('../../bindings/github.com/Automaat/sybra/internal/sybra/integrationservice.js', () => ({
-  GetProviderHealth: (...args: unknown[]) => mockGetProviderHealth(...args),
   ProviderHealthEnabled: (...args: unknown[]) => mockProviderHealthEnabled(...args),
+  GetProviderHealth: (...args: unknown[]) => mockGetProviderHealth(...args),
   SetProviderAutoFailover: (...args: unknown[]) => mockSetProviderAutoFailover(...args),
   SetProviderEnabled: (...args: unknown[]) => mockSetProviderEnabled(...args),
+  EventsOn: (...args: any[]) => mockEventsOn(...args),
 }))
 
 const Settings = (await import('./Settings.svelte')).default
@@ -46,6 +43,12 @@ const mockSettings = {
     tasks: '/home/.sybra/tasks',
     skills: '/home/.sybra/skills',
   },
+}
+
+// The settings page is a left-rail of tabbed panes; jump to one by clicking its
+// rail entry, then the pane mounts.
+async function goTo(name: string) {
+  await fireEvent.click(screen.getByRole('button', { name }))
 }
 
 describe('Settings', () => {
@@ -93,39 +96,30 @@ describe('Settings', () => {
     })
   })
 
-  it('renders the appearance section', () => {
+  it('renders the appearance section (default pane)', () => {
     mockGetSettings.mockReturnValue(new Promise(() => {}))
     render(Settings)
     expect(screen.getByRole('heading', { name: 'Appearance' })).toBeDefined()
   })
 
-  it('renders the section sub-nav and clarifies save scope', () => {
+  it('renders the section rail and clarifies save scope', () => {
     mockGetSettings.mockReturnValue(new Promise(() => {}))
     render(Settings)
     const nav = screen.getByRole('navigation', { name: 'Settings sections' })
     expect(nav).toBeDefined()
-    // Sub-nav exposes the sections as quick links.
+    // Rail exposes the sections as buttons.
     expect(screen.getByRole('button', { name: 'Orchestrator' })).toBeDefined()
     // Save scope is spelled out (immediate vs save-together).
     expect(screen.getByText(/apply instantly/)).toBeDefined()
   })
 
-  it('scrolls to a settings-gated section via its sub-nav link', async () => {
+  it('opens a settings-gated pane from its rail entry', async () => {
     mockGetSettings.mockResolvedValue(mockSettings)
-    // jsdom has no native scrollIntoView; stub it and restore so it can't leak.
-    const orig = Element.prototype.scrollIntoView
-    const scrollSpy = vi.fn()
-    Element.prototype.scrollIntoView = scrollSpy as never
-    try {
-      render(Settings)
-      // Logging only renders inside {#if settings}; wait for load so the anchor exists.
-      await vi.waitFor(() => screen.getByText('Logging & Audit'))
-      await fireEvent.click(screen.getByRole('button', { name: 'Logging' }))
-      expect(scrollSpy).toHaveBeenCalled()
-    } finally {
-      if (orig) Element.prototype.scrollIntoView = orig
-      else delete (Element.prototype as { scrollIntoView?: unknown }).scrollIntoView
-    }
+    render(Settings)
+    // Logging pane only mounts once selected, and only when settings have loaded.
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Logging' }))
+    await goTo('Logging')
+    await vi.waitFor(() => expect(screen.getByText('Logging & Audit')).toBeDefined())
   })
 
   it('keeps another section dirty when a provider toggles (no baseline wipe)', async () => {
@@ -133,77 +127,85 @@ describe('Settings', () => {
     mockProviderHealthEnabled.mockResolvedValue(true)
     mockSetProviderAutoFailover.mockResolvedValue(undefined)
     render(Settings)
-    await vi.waitFor(() => screen.getByRole('heading', { name: 'Notifications' }))
     // Dirty a non-provider section.
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Notifications' }))
+    await goTo('Notifications')
     await fireEvent.click(screen.getByLabelText('Desktop notifications (macOS)'))
     expect((screen.getByText('Save') as HTMLButtonElement).disabled).toBe(false)
     // Toggle a provider setting — it persists immediately and reconciles ONLY the
     // providers sub-tree, so the pending Notifications edit must survive.
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Providers' }))
+    await goTo('Providers')
     await fireEvent.click(screen.getByLabelText(/Auto-failover between providers/))
     await vi.waitFor(() => expect(mockSetProviderAutoFailover).toHaveBeenCalled())
     expect((screen.getByText('Save') as HTMLButtonElement).disabled).toBe(false)
     expect(screen.getByText('Unsaved changes')).toBeDefined()
   })
 
-  it('every sub-nav link resolves to a rendered section anchor', async () => {
+  it('every rail entry opens a pane with a matching heading', async () => {
     mockGetSettings.mockResolvedValue(mockSettings)
-    const navIds = [
-      'appearance', 'agent-defaults', 'provider-health', 'notifications',
-      'orchestrator', 'logging', 'todoist', 'renovate', 'version', 'directories',
+    render(Settings)
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Defaults' }))
+    const cases: [string, string][] = [
+      ['Defaults', 'Agent Defaults'],
+      ['Notifications', 'Notifications'],
+      ['Orchestrator', 'Orchestrator'],
+      ['Todoist', 'Todoist'],
+      ['Renovate', 'Renovate'],
+      ['Logging', 'Logging & Audit'],
+      ['Version', 'Version'],
+      ['Directories', 'Directories'],
     ]
-    const { container } = render(Settings)
-    await vi.waitFor(() => screen.getByRole('heading', { name: 'Directories' }))
-    for (const id of navIds) {
-      expect(container.querySelector(`#${id}`), `missing anchor #${id}`).not.toBeNull()
+    for (const [tab, heading] of cases) {
+      await goTo(tab)
+      await vi.waitFor(() => expect(screen.getByRole('heading', { name: heading })).toBeDefined())
     }
   })
 
-  it('renders Agent Defaults section after load', async () => {
+  it('renders Agent Defaults pane when selected', async () => {
     mockGetSettings.mockResolvedValue(mockSettings)
     render(Settings)
-    await vi.waitFor(() => {
-      expect(screen.getByText('Agent Defaults')).toBeDefined()
-    })
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Defaults' }))
+    await goTo('Defaults')
+    await vi.waitFor(() => expect(screen.getByText('Agent Defaults')).toBeDefined())
   })
 
-  it('renders Notifications section after load', async () => {
+  it('renders Notifications pane when selected', async () => {
     mockGetSettings.mockResolvedValue(mockSettings)
     render(Settings)
-    await vi.waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Notifications' })).toBeDefined()
-    })
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Notifications' }))
+    await goTo('Notifications')
+    await vi.waitFor(() => expect(screen.getByRole('heading', { name: 'Notifications' })).toBeDefined())
   })
 
-  it('renders Orchestrator section after load', async () => {
+  it('renders Orchestrator pane when selected', async () => {
     mockGetSettings.mockResolvedValue(mockSettings)
     render(Settings)
-    await vi.waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Orchestrator' })).toBeDefined()
-    })
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Orchestrator' }))
+    await goTo('Orchestrator')
+    await vi.waitFor(() => expect(screen.getByRole('heading', { name: 'Orchestrator' })).toBeDefined())
   })
 
-  it('renders Logging & Audit section after load', async () => {
+  it('renders Logging & Audit pane when selected', async () => {
     mockGetSettings.mockResolvedValue(mockSettings)
     render(Settings)
-    await vi.waitFor(() => {
-      expect(screen.getByText('Logging & Audit')).toBeDefined()
-    })
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Logging' }))
+    await goTo('Logging')
+    await vi.waitFor(() => expect(screen.getByText('Logging & Audit')).toBeDefined())
   })
 
-  it('renders Directories section after load', async () => {
+  it('renders Directories pane when selected', async () => {
     mockGetSettings.mockResolvedValue(mockSettings)
     render(Settings)
-    await vi.waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Directories' })).toBeDefined()
-    })
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Directories' }))
+    await goTo('Directories')
+    await vi.waitFor(() => expect(screen.getByRole('heading', { name: 'Directories' })).toBeDefined())
   })
 
   it('Save button is disabled when settings not dirty', async () => {
     mockGetSettings.mockResolvedValue(mockSettings)
     render(Settings)
-    await vi.waitFor(() => {
-      expect(screen.getByText('Agent Defaults')).toBeDefined()
-    })
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Defaults' }))
     const saveBtn = screen.getByText('Save') as HTMLButtonElement
     expect(saveBtn.disabled).toBe(true)
   })
@@ -212,14 +214,11 @@ describe('Settings', () => {
     mockGetSettings.mockResolvedValue({ ...mockSettings })
     mockUpdateSettings.mockResolvedValue(undefined)
     render(Settings)
-    await vi.waitFor(() => {
-      expect(screen.getByLabelText('Max Concurrent')).toBeDefined()
-    })
-    // Make settings dirty by changing a field
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Defaults' }))
+    await goTo('Defaults')
     const concurrencyInput = screen.getByLabelText('Max Concurrent') as HTMLInputElement
     await fireEvent.input(concurrencyInput, { target: { value: '5' } })
-    const saveBtn = screen.getByText('Save') as HTMLButtonElement
-    await fireEvent.click(saveBtn)
+    await fireEvent.click(screen.getByText('Save'))
     await vi.waitFor(() => {
       expect(mockUpdateSettings).toHaveBeenCalled()
       expect(screen.getByText('Settings saved')).toBeDefined()
@@ -230,83 +229,93 @@ describe('Settings', () => {
     mockGetSettings.mockResolvedValue({ ...mockSettings })
     mockUpdateSettings.mockRejectedValue(new Error('save error'))
     render(Settings)
-    await vi.waitFor(() => {
-      expect(screen.getByLabelText('Max Concurrent')).toBeDefined()
-    })
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Defaults' }))
+    await goTo('Defaults')
     const concurrencyInput = screen.getByLabelText('Max Concurrent') as HTMLInputElement
     await fireEvent.input(concurrencyInput, { target: { value: '5' } })
-    const saveBtn = screen.getByText('Save') as HTMLButtonElement
-    await fireEvent.click(saveBtn)
+    await fireEvent.click(screen.getByText('Save'))
     await vi.waitFor(() => {
       expect(screen.getByText('Error: save error')).toBeDefined()
     })
   })
 
-  it('renders Todoist section after load', async () => {
+  it('renders Todoist pane when selected', async () => {
     mockGetSettings.mockResolvedValue(mockSettings)
     render(Settings)
-    await vi.waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Todoist' })).toBeDefined()
-    })
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Todoist' }))
+    await goTo('Todoist')
+    await vi.waitFor(() => expect(screen.getByRole('heading', { name: 'Todoist' })).toBeDefined())
   })
 
   it('shows Todoist fields when Todoist enabled', async () => {
     mockGetSettings.mockResolvedValue({ ...mockSettings, todoist: { enabled: true, apiToken: '', projectId: '', pollSeconds: 300 } })
     render(Settings)
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Todoist' }))
+    await goTo('Todoist')
     await vi.waitFor(() => {
       expect(screen.getByLabelText('API Token')).toBeDefined()
       expect(screen.getByLabelText('Project ID')).toBeDefined()
     })
   })
 
-  it('renders Renovate section after load', async () => {
+  it('renders Renovate pane when selected', async () => {
     mockGetSettings.mockResolvedValue(mockSettings)
     render(Settings)
-    await vi.waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Renovate' })).toBeDefined()
-    })
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Renovate' }))
+    await goTo('Renovate')
+    await vi.waitFor(() => expect(screen.getByRole('heading', { name: 'Renovate' })).toBeDefined())
   })
 
-  it('renders Version section after load', async () => {
+  it('renders Version pane when selected', async () => {
     mockGetSettings.mockResolvedValue(mockSettings)
     render(Settings)
-    await vi.waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Version' })).toBeDefined()
-    })
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Version' }))
+    await goTo('Version')
+    await vi.waitFor(() => expect(screen.getByRole('heading', { name: 'Version' })).toBeDefined())
   })
 
-  it('shows Appearance section with Color Scheme select', () => {
+  it('shows Appearance pane with a Color Scheme control', () => {
     mockGetSettings.mockReturnValue(new Promise(() => {}))
     render(Settings)
     expect(screen.getByRole('heading', { name: 'Appearance' })).toBeDefined()
-    expect(screen.getByLabelText('Color Scheme')).toBeDefined()
+    expect(screen.getByText('Color Scheme')).toBeDefined()
+    expect(screen.getByRole('group', { name: 'Color Scheme' })).toBeDefined()
   })
 
-  it('shows Providers section when providerHealthEnabled is true', async () => {
+  it('shows Providers pane when providerHealthEnabled is true', async () => {
     mockGetSettings.mockResolvedValue(mockSettings)
     mockProviderHealthEnabled.mockResolvedValue(true)
     mockGetProviderHealth.mockResolvedValue([
       { provider: 'claude', healthy: true, reason: '', detail: '' },
     ])
     render(Settings)
-    await vi.waitFor(() => {
-      expect(screen.getByText('Providers')).toBeDefined()
-    })
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Providers' }))
+    await goTo('Providers')
+    await vi.waitFor(() => expect(screen.getByRole('heading', { name: 'Providers' })).toBeDefined())
+  })
+
+  it('hides the Providers rail entry when provider health is disabled', async () => {
+    mockGetSettings.mockResolvedValue(mockSettings)
+    mockProviderHealthEnabled.mockResolvedValue(false)
+    render(Settings)
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Defaults' }))
+    // Give the async ProviderHealthEnabled() resolve a chance to settle.
+    await Promise.resolve()
+    expect(screen.queryByRole('button', { name: 'Providers' })).toBeNull()
   })
 
   it('renders Color Scheme options (system, light, dark)', () => {
     mockGetSettings.mockReturnValue(new Promise(() => {}))
     render(Settings)
-    expect(screen.getByText('System')).toBeDefined()
-    expect(screen.getByText('Light')).toBeDefined()
-    expect(screen.getByText('Dark')).toBeDefined()
+    expect(screen.getByRole('button', { name: 'System' })).toBeDefined()
+    expect(screen.getByRole('button', { name: 'Light' })).toBeDefined()
+    expect(screen.getByRole('button', { name: 'Dark' })).toBeDefined()
   })
 
   it('persists colorScheme to localStorage when changed', async () => {
     mockGetSettings.mockReturnValue(new Promise(() => {}))
     render(Settings)
-    const select = screen.getByLabelText('Color Scheme') as HTMLSelectElement
-    await fireEvent.change(select, { target: { value: 'dark' } })
+    await fireEvent.click(screen.getByRole('button', { name: 'Dark' }))
     await vi.waitFor(() => {
       expect(localStorage.getItem('colorScheme')).toBe('dark')
     })
@@ -315,21 +324,31 @@ describe('Settings', () => {
   it('toggles dark class on html when dark selected', async () => {
     mockGetSettings.mockReturnValue(new Promise(() => {}))
     render(Settings)
-    const select = screen.getByLabelText('Color Scheme') as HTMLSelectElement
-    await fireEvent.change(select, { target: { value: 'dark' } })
+    await fireEvent.click(screen.getByRole('button', { name: 'Dark' }))
     await vi.waitFor(() => {
       expect(document.documentElement.classList.contains('dark')).toBe(true)
     })
-    await fireEvent.change(select, { target: { value: 'light' } })
+    await fireEvent.click(screen.getByRole('button', { name: 'Light' }))
     await vi.waitFor(() => {
       expect(document.documentElement.classList.contains('dark')).toBe(false)
+    })
+  })
+
+  it('marks the active color scheme button as pressed', async () => {
+    mockGetSettings.mockReturnValue(new Promise(() => {}))
+    render(Settings)
+    await fireEvent.click(screen.getByRole('button', { name: 'Dark' }))
+    await vi.waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Dark' }).getAttribute('aria-pressed')).toBe('true')
+      expect(screen.getByRole('button', { name: 'Light' }).getAttribute('aria-pressed')).toBe('false')
     })
   })
 
   it('Reset button appears when settings are dirty', async () => {
     mockGetSettings.mockResolvedValue({ ...mockSettings })
     render(Settings)
-    await vi.waitFor(() => screen.getByLabelText('Max Concurrent'))
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Defaults' }))
+    await goTo('Defaults')
     const concurrencyInput = screen.getByLabelText('Max Concurrent') as HTMLInputElement
     await fireEvent.input(concurrencyInput, { target: { value: '7' } })
     await vi.waitFor(() => {
@@ -340,7 +359,8 @@ describe('Settings', () => {
   it('Reset button reverts pending changes', async () => {
     mockGetSettings.mockResolvedValue({ ...mockSettings })
     render(Settings)
-    await vi.waitFor(() => screen.getByLabelText('Max Concurrent'))
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Defaults' }))
+    await goTo('Defaults')
     const concurrencyInput = screen.getByLabelText('Max Concurrent') as HTMLInputElement
     await fireEvent.input(concurrencyInput, { target: { value: '7' } })
     await vi.waitFor(() => screen.getByText('Reset'))
@@ -351,10 +371,10 @@ describe('Settings', () => {
     })
   })
 
-  it('renders Save and Reset only one button initially (Save)', async () => {
+  it('renders Save without Reset initially', async () => {
     mockGetSettings.mockResolvedValue({ ...mockSettings })
     render(Settings)
-    await vi.waitFor(() => screen.getByText('Agent Defaults'))
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Defaults' }))
     expect(screen.getByText('Save')).toBeDefined()
     expect(screen.queryByText('Reset')).toBeNull()
   })
@@ -363,6 +383,8 @@ describe('Settings', () => {
     mockGetSettings.mockResolvedValue({ ...mockSettings })
     mockGetVersion.mockResolvedValue({ server: 'v2.7.0', client: 'v2.7.0' })
     render(Settings)
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Version' }))
+    await goTo('Version')
     await vi.waitFor(() => {
       expect(screen.getByText('v2.7.0')).toBeDefined()
     })
@@ -372,6 +394,8 @@ describe('Settings', () => {
     mockGetSettings.mockResolvedValue({ ...mockSettings })
     mockGetVersion.mockRejectedValue(new Error('no version'))
     render(Settings)
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Version' }))
+    await goTo('Version')
     await vi.waitFor(() => {
       expect(screen.getByText('unavailable')).toBeDefined()
     })
@@ -380,6 +404,8 @@ describe('Settings', () => {
   it('renders directories list for known dir keys', async () => {
     mockGetSettings.mockResolvedValue({ ...mockSettings })
     render(Settings)
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Directories' }))
+    await goTo('Directories')
     await vi.waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Directories' })).toBeDefined()
       expect(screen.getByDisplayValue('/home/.sybra/tasks')).toBeDefined()
@@ -390,7 +416,8 @@ describe('Settings', () => {
   it('toggles desktop notifications checkbox', async () => {
     mockGetSettings.mockResolvedValue({ ...mockSettings })
     render(Settings)
-    await vi.waitFor(() => screen.getByRole('heading', { name: 'Notifications' }))
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Notifications' }))
+    await goTo('Notifications')
     const checkbox = screen.getByLabelText('Desktop notifications (macOS)') as HTMLInputElement
     expect(checkbox.checked).toBe(false)
     await fireEvent.click(checkbox)
@@ -402,7 +429,8 @@ describe('Settings', () => {
   it('toggles autoTriage', async () => {
     mockGetSettings.mockResolvedValue({ ...mockSettings })
     render(Settings)
-    await vi.waitFor(() => screen.getByText('Auto-triage'))
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Orchestrator' }))
+    await goTo('Orchestrator')
     const label = screen.getByText('Auto-triage').closest('label')
     const checkbox = label?.querySelector('input[type="checkbox"]') as HTMLInputElement
     expect(checkbox.checked).toBe(false)
@@ -418,7 +446,8 @@ describe('Settings', () => {
       { slug: 'gpt-5.4', display_name: 'GPT-5.4' },
     ])
     render(Settings)
-    await vi.waitFor(() => screen.getByLabelText('Agent Type'))
+    await vi.waitFor(() => screen.getByRole('button', { name: 'Defaults' }))
+    await goTo('Defaults')
     const providerSelect = screen.getByLabelText('Agent Type') as HTMLSelectElement
     await fireEvent.change(providerSelect, { target: { value: 'codex' } })
     await vi.waitFor(() => {
@@ -432,7 +461,8 @@ describe('Settings', () => {
       mockGetSettings.mockResolvedValue({ ...mockSettings })
       mockUpdateSettings.mockResolvedValue(undefined)
       render(Settings)
-      await vi.waitFor(() => screen.getByLabelText('Max Concurrent'))
+      await vi.waitFor(() => screen.getByRole('button', { name: 'Defaults' }))
+      await goTo('Defaults')
       const concurrencyInput = screen.getByLabelText('Max Concurrent') as HTMLInputElement
       await fireEvent.input(concurrencyInput, { target: { value: '5' } })
       await fireEvent.click(screen.getByText('Save'))

--- a/frontend/src/pages/Settings.svelte.test.ts
+++ b/frontend/src/pages/Settings.svelte.test.ts
@@ -298,9 +298,10 @@ describe('Settings', () => {
     mockGetSettings.mockResolvedValue(mockSettings)
     mockProviderHealthEnabled.mockResolvedValue(false)
     render(Settings)
-    await vi.waitFor(() => screen.getByRole('button', { name: 'Defaults' }))
-    // Give the async ProviderHealthEnabled() resolve a chance to settle.
-    await Promise.resolve()
+    // Wait until the gating call has resolved and the rail has rendered, then
+    // assert the Providers entry never appears — no brittle microtask flush.
+    await vi.waitFor(() => expect(mockProviderHealthEnabled).toHaveBeenCalled())
+    await vi.waitFor(() => expect(screen.getByRole('button', { name: 'Defaults' })).toBeDefined())
     expect(screen.queryByRole('button', { name: 'Providers' })).toBeNull()
   })
 


### PR DESCRIPTION
## Motivation

The Settings page read flat and washed in light mode and carried a few
rough edges: a long single-scroll layout, a dead "Providers" sub-nav
link, low-contrast helper text, and cards that barely separated from the
page. The Providers pane was also blank in web/server mode.

> Changelog: feat(settings): left-rail layout + contrast fixes

## Implementation information

- Rebuilt `Settings.svelte` as a grouped left-rail of tabbed panes
  (General / Agents / Automation / Advanced); one section shows at a
  time, collapsing to a horizontal strip on small screens.
- Replaced the theme `<select>` with a System/Light/Dark segmented
  control (`aria-pressed`).
- The Providers tab renders only when provider health is enabled, so the
  rail never offers a link that resolves to nothing.
- Contrast and polish across all five panels: secondary text bumped from
  1.77:1 to AA, `rounded-xl` + `shadow-sm` so cards read as panels,
  aligned headings, accent checkboxes, Logging grid 4-col to 2x2.
- Fixed web/server mode: `ProviderHealthPanel` now calls `$lib/api`
  instead of the Wails binding directly; added `SetProviderEnabled` and
  `SetProviderAutoFailover` to the HTTP shim and api re-exports.
- Updated and extended the Settings/panel unit tests for the tabbed
  model.

Verified live in light and dark by driving the HTTP server build with
Chromium (rail nav, theme switch, Providers pane, dirty to Save/Reset).
svelte-check and oxlint clean; 1545 frontend tests pass.

## Supporting documentation

None.