### PR TITLE
feat(ui): lift light mode to dark-mode parity

### DIFF
--- a/frontend/src/components/StreamOutput.svelte
+++ b/frontend/src/components/StreamOutput.svelte
@@ -112,7 +112,7 @@
   <div
     bind:this={container}
     onscroll={onScroll}
-    class="flex max-h-[60dvh] md:max-h-[600px] flex-col gap-1 overflow-y-auto rounded-lg border border-surface-300 bg-surface-100 p-3 font-mono text-xs text-surface-900 dark:border-surface-700 dark:bg-surface-950 dark:text-surface-50"
+    class="flex max-h-[60dvh] md:max-h-[600px] flex-col gap-1 overflow-y-auto rounded-lg border border-surface-300 bg-surface-200 p-3 font-mono text-xs text-surface-900 dark:border-surface-700 dark:bg-surface-950 dark:text-surface-50"
   >
     {#if events.length === 0}
       <p class="py-8 text-center text-surface-500">Waiting for output...</p>

--- a/frontend/src/components/TaskBoardView.svelte
+++ b/frontend/src/components/TaskBoardView.svelte
@@ -132,16 +132,16 @@
         ondragleave={() => { dragOverStatus = null }}
         ondrop={(e) => handleDrop(e, col.status)}
         title="{col.label} (empty) — click to expand"
-        class="hidden shrink-0 flex-col items-center gap-2 rounded-lg border-t-4 bg-surface-100 py-3 transition-colors hover:bg-surface-200 dark:bg-surface-900 dark:hover:bg-surface-800 md:flex md:w-10 {col.border} {dragOverStatus === col.status ? 'ring-2 ring-primary-400 dark:ring-primary-500' : ''}"
+        class="hidden shrink-0 flex-col items-center gap-2 rounded-lg border-t-4 bg-surface-200 py-3 transition-colors hover:bg-surface-300 dark:bg-surface-900 dark:hover:bg-surface-800 md:flex md:w-10 {col.border} {dragOverStatus === col.status ? 'ring-2 ring-primary-400 dark:ring-primary-500' : ''}"
       >
-        <span class="rounded-full bg-surface-200 px-1.5 py-0.5 text-[10px] font-medium text-surface-400 dark:bg-surface-700">0</span>
-        <span role="heading" aria-level="2" class="text-xs font-medium text-surface-400 [writing-mode:vertical-rl]">{col.label}</span>
+        <span class="rounded-full bg-surface-300 px-1.5 py-0.5 text-[10px] font-medium text-surface-600 dark:bg-surface-700 dark:text-surface-400">0</span>
+        <span role="heading" aria-level="2" class="text-xs font-medium text-surface-600 dark:text-surface-400 [writing-mode:vertical-rl]">{col.label}</span>
       </button>
     {:else}
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       data-col-status={col.status}
-      class="flex w-full shrink-0 flex-col rounded-lg border-t-4 bg-surface-100 transition-shadow dark:bg-surface-900 md:min-w-[200px] md:flex-1 md:shrink {col.border} {dragOverStatus === col.status ? 'ring-2 ring-primary-400 dark:ring-primary-500' : ''}"
+      class="flex w-full shrink-0 flex-col rounded-lg border-t-4 bg-surface-200 transition-shadow dark:bg-surface-900 md:min-w-[200px] md:flex-1 md:shrink {col.border} {dragOverStatus === col.status ? 'ring-2 ring-primary-400 dark:ring-primary-500' : ''}"
       ondragover={(e) => { e.preventDefault(); dragOverStatus = col.status }}
       ondragleave={() => { dragOverStatus = null }}
       ondrop={(e) => handleDrop(e, col.status)}
@@ -149,7 +149,7 @@
       <button
         type="button"
         onclick={() => ontogglecolumn(col.status)}
-        class="tap flex w-full items-center justify-between gap-2 px-3 py-2 text-left active:bg-surface-200 dark:active:bg-surface-800 md:cursor-default md:active:bg-transparent dark:md:active:bg-transparent"
+        class="tap flex w-full items-center justify-between gap-2 px-3 py-2 text-left active:bg-surface-300 dark:active:bg-surface-800 md:cursor-default md:active:bg-transparent dark:md:active:bg-transparent"
       >
         <span class="flex items-center gap-2">
           <ChevronDown size={16} class="transition-transform md:hidden {isCollapsed ? '-rotate-90' : ''}" aria-hidden="true" />
@@ -165,7 +165,7 @@
               {rc}
             </span>
           {/if}
-          <span class="rounded-full bg-surface-200 px-2 py-0.5 text-xs font-medium dark:bg-surface-700">
+          <span class="rounded-full bg-surface-300 px-2 py-0.5 text-xs font-medium dark:bg-surface-700">
             {tasks.length}
           </span>
         </span>

--- a/frontend/src/components/task-detail/TaskStatusBanner.svelte
+++ b/frontend/src/components/task-detail/TaskStatusBanner.svelte
@@ -22,7 +22,7 @@
     role="status"
     class="flex items-start gap-2 rounded-md border px-3 py-2 text-sm {tone === 'attention'
       ? 'border-warning-300 bg-warning-50 text-warning-800 dark:border-warning-700 dark:bg-warning-900/40 dark:text-warning-200'
-      : 'border-surface-300 bg-surface-100 text-surface-700 dark:border-surface-600 dark:bg-surface-800 dark:text-surface-300'}"
+      : 'border-surface-300 bg-surface-200 text-surface-700 dark:border-surface-600 dark:bg-surface-800 dark:text-surface-300'}"
   >
     {#if tone === 'attention'}
       <AlertTriangle size={16} class="mt-0.5 shrink-0" />

--- a/frontend/src/pages/Stats.svelte
+++ b/frontend/src/pages/Stats.svelte
@@ -84,7 +84,7 @@
   {/if}
 
   <!-- Period tabs -->
-  <div class="flex gap-1 rounded-lg bg-surface-100 p-1 dark:bg-surface-800">
+  <div class="flex gap-1 rounded-lg bg-surface-200 p-1 dark:bg-surface-800">
     {#each periods as p (p.key)}
       <button
         type="button"

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -60,6 +60,16 @@ html, body {
   height: 100%;
 }
 
+/* Light-mode tertiary text (timestamps, hints, meta) uses surface-400, which on
+ * the near-white canvas reads at ~1.7:1 — far fainter than the same token on
+ * dark's near-black page (~10:1). Lift it one step in light only so secondary
+ * text is as legible as it is in dark. Scoped to :not(.dark) and to the literal
+ * `text-surface-400` class, so `dark:text-surface-400` and dark mode are
+ * untouched. */
+html:not(.dark) .text-surface-400 {
+  color: var(--color-surface-500);
+}
+
 [data-active] {
   background-color: var(--color-surface-200);
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -65,9 +65,17 @@ html, body {
  * dark's near-black page (~10:1). Lift it one step in light only so secondary
  * text is as legible as it is in dark. Scoped to :not(.dark) and to the literal
  * `text-surface-400` class, so `dark:text-surface-400` and dark mode are
- * untouched. */
-html:not(.dark) .text-surface-400 {
-  color: var(--color-surface-500);
+ * untouched.
+ *
+ * Lives in the `utilities` layer (not unlayered) and wraps the mode guard in
+ * `:where()` so its specificity stays at one class: it beats the base
+ * `text-surface-400` utility by source order, but `hover:`/`focus:` text-colour
+ * variants (which add a pseudo-class) still win, keeping hover transitions on
+ * elements like `text-surface-400 hover:text-surface-600`. */
+@layer utilities {
+  :where(html:not(.dark)) .text-surface-400 {
+    color: var(--color-surface-500);
+  }
 }
 
 [data-active] {

--- a/frontend/src/theme-amber.css
+++ b/frontend/src/theme-amber.css
@@ -48,7 +48,10 @@
   --default-border-width: 1px;
   --default-divide-width: 1px;
   --default-ring-width: 1px;
-  --body-background-color: var(--color-surface-50);
+  /* Light canvas sits one step below the card surface (surface-50) so white
+   * cards, chrome and dialogs lift off it — mirroring dark's 950-page /
+   * 900-card layering. Recessed troughs (board columns) drop to surface-200. */
+  --body-background-color: var(--color-surface-100);
   --body-background-color-dark: var(--color-surface-950);
 
   /* ── primary: amber 55deg ───────────────────────────────────────────────── */
@@ -209,10 +212,12 @@
 
   /* ── surface: warm 33deg ────────────────────────────────────────────────── */
   /* light → dark: parchment white (#faf8f7) to warm black (#110e0b)          */
-  --color-surface-50:  oklch(98%   0.003 30deg);
-  --color-surface-100: oklch(96%   0.004 31deg);
-  --color-surface-200: oklch(93%   0.005 32deg);
-  --color-surface-300: oklch(88%   0.007 33deg);
+  /* Light top end retuned for a 3-plane system: near-white cards (50) lift off
+   * a soft warm-gray canvas (100); 200 is a clearly recessed trough/border.   */
+  --color-surface-50:  oklch(99.3% 0.0025 30deg);
+  --color-surface-100: oklch(97%   0.004  31deg);
+  --color-surface-200: oklch(92%   0.006  32deg);
+  --color-surface-300: oklch(86%   0.009  33deg);
   --color-surface-400: oklch(80%   0.008 33deg);
   --color-surface-500: oklch(65%   0.009 34deg);
   --color-surface-600: oklch(50%   0.010 34deg);


### PR DESCRIPTION
## Motivation

Light mode was noticeably less polished than dark. Dark uses a real
3-plane system — near-black page (surface-950), raised cards
(surface-900), visible borders (surface-700) — so cards, columns and
panels have clear depth. Light collapsed all of those onto the same
near-white surface-50 with hairline borders, so nothing lifted off the
canvas: dashboard/settings/task cards floated borderless, board columns
and their empty "rails" were nearly invisible, and tertiary text sat at
~1.7:1 contrast (vs ~10:1 for the same token in dark).

> Changelog: feat(ui): lift light mode to dark-mode parity

## Implementation information

Mirror dark's layering in the light theme, with no changes to dark
tokens (its 700–950 backgrounds are untouched):

- **Canvas** drops to `surface-100` so white cards, chrome and dialogs
  lift off it; the light surface ramp top (`50/100/200/300`) is retuned
  for distinct planes (near-white cards, soft-gray canvas, clearly
  recessed `200`).
- **Board** columns and collapsed rails become recessed `surface-200`
  troughs (the empty rails were invisible before); their labels and
  count badges are darkened so they read.
- **Status banner**, **stream/output panel** and **Stats period tabs**
  now sit on a recessed surface instead of blending into the canvas.
- **Tertiary text** (`text-surface-400`: timestamps, hints, meta) is
  lifted one step in light only, via a `:not(.dark)`-scoped rule that
  matches only the literal class, leaving `dark:` siblings alone.

Verified by driving the web build in Chromium across Board, Dashboard,
Stats, Settings, Task Detail, Agent Detail, Projects, Logbook, GitHub,
Reviews, Workflows and Timeline in both modes; dark renders identically
to before. Gates: svelte-check, oxlint, 1545 frontend tests, web +
desktop builds all pass.

## Supporting documentation

None.