### PR TITLE
ci(renovate): enable platform automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,6 @@
 {
+  "automerge": true,
+  "platformAutomerge": true,
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",


### PR DESCRIPTION
## Motivation

Match the platform-automerge convention applied across the other repos so all dependency PRs (incl. digests/majors) merge automatically once CI is green.

## Implementation information

Adds top-level `automerge: true` + `platformAutomerge: true` (and `automergeStrategy: squash` where missing) to `renovate.json`. Supersedes the previous narrower automerge scope.

> Changelog: skip