### PR TITLE
feat(reviews): PR review phase lane on board

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -180,6 +180,15 @@ export class Task {
      * pr-fix when fixing review issues, "" for initial impl
      */
     "runRole": string;
+
+    /**
+     * ReviewPhase tracks where an inbound PR-review task (tag `review`) sits in
+     * the review lifecycle: reviewing → drafted → awaiting-author →
+     * needs-approval → approved (plus `manual` for small PRs punted to the
+     * human). Computed by the PR poller; drives the board's PR Reviews lane.
+     * Empty for non-review tasks.
+     */
+    "reviewPhase"?: string;
     "todoistId": string;
     "priority"?: Priority;
     "dueDate"?: time$0.Time | null;
@@ -300,9 +309,9 @@ export class Task {
     static createFrom($$source: any = {}): Task {
         const $$createField6_0 = $$createType0;
         const $$createField7_0 = $$createType0;
-        const $$createField23_0 = $$createType2;
-        const $$createField24_0 = $$createType4;
-        const $$createField31_0 = $$createType5;
+        const $$createField24_0 = $$createType2;
+        const $$createField25_0 = $$createType4;
+        const $$createField32_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -311,13 +320,13 @@ export class Task {
             $$parsedSource["tags"] = $$createField7_0($$parsedSource["tags"]);
         }
         if ("agentRuns" in $$parsedSource) {
-            $$parsedSource["agentRuns"] = $$createField23_0($$parsedSource["agentRuns"]);
+            $$parsedSource["agentRuns"] = $$createField24_0($$parsedSource["agentRuns"]);
         }
         if ("workflow" in $$parsedSource) {
-            $$parsedSource["workflow"] = $$createField24_0($$parsedSource["workflow"]);
+            $$parsedSource["workflow"] = $$createField25_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField31_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField32_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }

--- a/frontend/src/components/TaskBoardView.svelte
+++ b/frontend/src/components/TaskBoardView.svelte
@@ -187,9 +187,17 @@
             </div>
           {/each}
         </div>
-        <div class="px-2 pb-2">
-          <InlineTaskAdd status={col.status} />
-        </div>
+        {#if col.kind === 'review'}
+          {#if tasks.length === 0}
+            <p class="px-3 pb-3 text-xs text-surface-500 dark:text-surface-400">
+              No PRs to review.
+            </p>
+          {/if}
+        {:else}
+          <div class="px-2 pb-2">
+            <InlineTaskAdd status={col.status} />
+          </div>
+        {/if}
       {/if}
     </div>
     {/if}

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { timeAgo } from '$lib/dates.js'
-  import { CheckCircle, XCircle, Clock, GitPullRequest, CircleDot, Copy, AlertTriangle, MoreHorizontal } from '@lucide/svelte'
+  import { CheckCircle, XCircle, Clock, GitPullRequest, CircleDot, Copy, AlertTriangle, MoreHorizontal, Eye, PenLine, Hourglass, ShieldCheck, Loader } from '@lucide/svelte'
   import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { agentStore } from '../stores/agents.svelte.js'
   import { reviewStore } from '../stores/reviews.svelte.js'
   import { notificationStore } from '../stores/notifications.svelte.js'
   import { awaitsHuman, awaitsHumanLabel, coreStatus, statusLabel } from '../lib/statuses.js'
+  import { isReviewTask as isReviewTaskFn, reviewPhaseMeta, type ReviewPhaseIcon } from '../lib/review-phase.js'
   import { PRIORITY_OPTIONS } from '../lib/priorities.js'
   import { projectShortName, projectDotStyle } from '../lib/project-cue.js'
   import StatusPicker from './StatusPicker.svelte'
@@ -57,7 +58,12 @@
 
   const linkedPRs = $derived(reviewStore.byTask(t))
   const topPR = $derived(linkedPRs.length > 0 ? linkedPRs[0] : null)
-  const isReviewTask = $derived(t.tags?.includes('review') ?? false)
+  const isReviewTask = $derived(isReviewTaskFn(t))
+
+  // lucide components keyed by the phase meta's icon name.
+  const PHASE_ICONS: Record<ReviewPhaseIcon, typeof CheckCircle> = {
+    loader: Loader, eye: Eye, pen: PenLine, hourglass: Hourglass, shield: ShieldCheck, check: CheckCircle,
+  }
 
   // Task is waiting on the user (not an agent) — drives the red tile accent.
   const needsYou = $derived(awaitsHuman(t.status))
@@ -169,11 +175,11 @@
       </span>
     {/if}
 
-    {#if needsYou}
+    {#if needsYou && !isReviewTask}
       <Pill role="attention" class="bg-error-200 text-error-800 dark:bg-error-700 dark:text-error-200">
         {awaitsHumanLabel(t.status)}
       </Pill>
-    {:else if subStateLabel}
+    {:else if subStateLabel && !isReviewTask}
       <span class="inline-flex items-center rounded-full bg-surface-200 px-2 py-0.5 text-surface-600 dark:bg-surface-700 dark:text-surface-300">
         {subStateLabel}
       </span>
@@ -193,21 +199,18 @@
       </span>
     {/if}
 
-    {#if topPR && isReviewTask}
-      {#if topPR.viewerHasApproved}
-        <Pill role="reference" title="Approved; waiting for PR to merge">
-          <GitPullRequest size={12} />
-          #{topPR.number}
-          <span class="text-success-500" title="Approved">✓</span>
-          {#if t.issue}{@render issueGlyph()}{/if}
-        </Pill>
-      {:else}
-        <Pill role="reference" title="Review requested">
-          <GitPullRequest size={12} />
-          #{topPR.number} Review
-          {#if t.issue}{@render issueGlyph()}{/if}
-        </Pill>
-      {/if}
+    {#if isReviewTask}
+      {@const ph = reviewPhaseMeta(t)}
+      {@const PhaseIcon = PHASE_ICONS[ph.icon]}
+      <span
+        class="inline-flex items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium {ph.classes}"
+        title={t.statusReason || ph.label}
+      >
+        <PhaseIcon size={12} class="shrink-0" />
+        {#if topPR}#{topPR.number}{:else if t.prNumber}#{t.prNumber}{/if}
+        <span>{ph.label}</span>
+        {#if t.issue}{@render issueGlyph()}{/if}
+      </span>
     {:else if topPR}
       <Pill role="reference" title={topPR.title}>
         <GitPullRequest size={12} />

--- a/frontend/src/components/TaskCard.svelte.test.ts
+++ b/frontend/src/components/TaskCard.svelte.test.ts
@@ -204,30 +204,30 @@ describe('TaskCard', () => {
     expect(container.querySelector('.border-l-error-500')).toBeNull()
   })
 
-  it('shows review-needed badge for review-requested PR tasks', () => {
+  it('shows the drafted phase badge for a review task with a pending draft', () => {
     reviewStore.reviewRequested = [makePR()]
     render(TaskCard, {
       props: {
-        task: { ...mockTask, tags: ['review'], projectId: 'owner/repo', prNumber: 42 } as Task,
+        task: { ...mockTask, tags: ['review'], projectId: 'owner/repo', prNumber: 42, reviewPhase: 'drafted' } as Task,
         onclick: () => {},
       },
     })
 
-    expect(screen.getByTitle('Review requested')).toBeDefined()
+    expect(screen.getByText('Post review')).toBeDefined()
     expect(screen.getByText(/#42/)).toBeDefined()
   })
 
-  it('shows approved waiting-merge badge for approved review tasks', () => {
+  it('shows the approved phase badge for an approved review task', () => {
     reviewStore.reviewedByMe = [makePR({ viewerHasApproved: true })]
     render(TaskCard, {
       props: {
-        task: { ...mockTask, tags: ['review'], projectId: 'owner/repo', prNumber: 42 } as Task,
+        task: { ...mockTask, tags: ['review'], projectId: 'owner/repo', prNumber: 42, reviewPhase: 'approved' } as Task,
         onclick: () => {},
       },
     })
 
-    expect(screen.getByTitle('Approved; waiting for PR to merge')).toBeDefined()
-    expect(screen.getByText('✓')).toBeDefined()
+    expect(screen.getByText('Approved')).toBeDefined()
+    expect(screen.getByText(/#42/)).toBeDefined()
   })
 
   it('keeps an accessible "issue exists" cue when a PR and an issue coexist', () => {

--- a/frontend/src/lib/review-phase.test.ts
+++ b/frontend/src/lib/review-phase.test.ts
@@ -29,6 +29,12 @@ describe('reviewPhaseOf', () => {
     expect(reviewPhaseOf({ reviewPhase: '' })).toBe('reviewing')
     expect(reviewPhaseOf({ reviewPhase: 'bogus' })).toBe('reviewing')
   })
+
+  it('does not treat inherited Object keys as valid phases', () => {
+    for (const proto of ['toString', 'constructor', 'hasOwnProperty', '__proto__']) {
+      expect(reviewPhaseOf({ reviewPhase: proto })).toBe('reviewing')
+    }
+  })
 })
 
 describe('reviewPhaseMeta', () => {

--- a/frontend/src/lib/review-phase.test.ts
+++ b/frontend/src/lib/review-phase.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import {
+  REVIEW_PHASE_META,
+  isReviewTask,
+  reviewPhaseOf,
+  reviewPhaseMeta,
+  reviewPhaseRank,
+  type ReviewPhase,
+} from './review-phase.js'
+import { BOARD_COLUMNS, BOARD_LANES, REVIEW_LANE, CORE_STATUSES } from './statuses.js'
+
+describe('isReviewTask', () => {
+  it('is true only when the review tag is present', () => {
+    expect(isReviewTask({ tags: ['review'] })).toBe(true)
+    expect(isReviewTask({ tags: ['backend', 'review'] })).toBe(true)
+    expect(isReviewTask({ tags: ['backend'] })).toBe(false)
+    expect(isReviewTask({})).toBe(false)
+  })
+})
+
+describe('reviewPhaseOf', () => {
+  it('returns the known phase', () => {
+    expect(reviewPhaseOf({ reviewPhase: 'drafted' })).toBe('drafted')
+    expect(reviewPhaseOf({ reviewPhase: 'needs-approval' })).toBe('needs-approval')
+  })
+
+  it('falls back to reviewing for empty or unknown values', () => {
+    expect(reviewPhaseOf({})).toBe('reviewing')
+    expect(reviewPhaseOf({ reviewPhase: '' })).toBe('reviewing')
+    expect(reviewPhaseOf({ reviewPhase: 'bogus' })).toBe('reviewing')
+  })
+})
+
+describe('reviewPhaseMeta', () => {
+  it('maps each phase to a non-empty label, icon, and classes', () => {
+    for (const phase of Object.keys(REVIEW_PHASE_META) as ReviewPhase[]) {
+      const m = REVIEW_PHASE_META[phase]
+      expect(m.label).not.toBe('')
+      expect(m.icon).not.toBe('')
+      expect(m.classes).toContain('bg-')
+    }
+  })
+
+  it('resolves a phase to its metadata', () => {
+    expect(reviewPhaseMeta({ reviewPhase: 'drafted' }).label).toBe('Post review')
+    expect(reviewPhaseMeta({ reviewPhase: 'needs-approval' }).label).toBe('Approve')
+    expect(reviewPhaseMeta({}).label).toBe('Reviewing')
+  })
+})
+
+describe('reviewPhaseRank', () => {
+  it('sorts user-action phases ahead of waiting and approved', () => {
+    const rank = (p: string) => reviewPhaseRank({ reviewPhase: p })
+    expect(rank('needs-approval')).toBeLessThan(rank('awaiting-author'))
+    expect(rank('drafted')).toBeLessThan(rank('awaiting-author'))
+    expect(rank('awaiting-author')).toBeLessThan(rank('approved'))
+  })
+})
+
+describe('BOARD_LANES', () => {
+  it('inserts the PR Reviews lane immediately before Human Required', () => {
+    const idx = BOARD_LANES.indexOf(REVIEW_LANE)
+    expect(idx).toBeGreaterThan(0)
+    expect(BOARD_LANES[idx + 1].status).toBe('human-required')
+  })
+
+  it('keeps every status column from BOARD_COLUMNS plus the one lane', () => {
+    expect(BOARD_LANES.length).toBe(BOARD_COLUMNS.length + 1)
+    for (const c of BOARD_COLUMNS) expect(BOARD_LANES).toContain(c)
+  })
+
+  it('keeps the review sentinel out of the pickable status set', () => {
+    expect(CORE_STATUSES).not.toContain('reviews')
+    expect(REVIEW_LANE.kind).toBe('review')
+  })
+})

--- a/frontend/src/lib/review-phase.ts
+++ b/frontend/src/lib/review-phase.ts
@@ -1,0 +1,91 @@
+// Lifecycle phases for inbound PR-review tasks (tag `review`) — the board's
+// "PR Reviews" lane colours each tile by phase. Mirrors the Go constants in
+// internal/sybra/review_phase.go. Hue→token mapping follows the amber theme
+// convention documented in agent-phases.ts (warning = violet, secondary =
+// teal/blue, primary = amber, success = green).
+
+export type ReviewPhase =
+  | 'reviewing'
+  | 'manual'
+  | 'drafted'
+  | 'awaiting-author'
+  | 'needs-approval'
+  | 'approved'
+
+/** Icon keys, resolved to lucide components at the call site. */
+export type ReviewPhaseIcon = 'loader' | 'eye' | 'pen' | 'hourglass' | 'shield' | 'check'
+
+export interface ReviewPhaseMeta {
+  label: string
+  icon: ReviewPhaseIcon
+  /** bg + text pill classes (light + dark) */
+  classes: string
+}
+
+// The needs-you signal (red tile accent) is driven by the task's status, not
+// duplicated here — the poller sets human-required for the manual/drafted/
+// needs-approval phases, so awaitsHuman(status) stays the single source of
+// truth and can't drift from this table.
+export const REVIEW_PHASE_META: Record<ReviewPhase, ReviewPhaseMeta> = {
+  reviewing: {
+    label: 'Reviewing',
+    icon: 'loader',
+    classes: 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-300',
+  },
+  manual: {
+    label: 'Your review',
+    icon: 'eye',
+    classes: 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200',
+  },
+  drafted: {
+    label: 'Post review',
+    icon: 'pen',
+    classes: 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200',
+  },
+  'awaiting-author': {
+    label: 'Awaiting author',
+    icon: 'hourglass',
+    classes: 'bg-secondary-200 text-secondary-800 dark:bg-secondary-700 dark:text-secondary-200',
+  },
+  'needs-approval': {
+    label: 'Approve',
+    icon: 'shield',
+    classes: 'bg-warning-200 text-warning-800 dark:bg-warning-700 dark:text-warning-200',
+  },
+  approved: {
+    label: 'Approved',
+    icon: 'check',
+    classes: 'bg-success-200 text-success-800 dark:bg-success-700 dark:text-success-200',
+  },
+}
+
+// Lane sort: the user's pending actions first, then waiting, then done.
+const REVIEW_PHASE_ORDER: ReviewPhase[] = [
+  'needs-approval',
+  'drafted',
+  'manual',
+  'reviewing',
+  'awaiting-author',
+  'approved',
+]
+
+/** True when a task is an inbound PR review (reviewing someone else's code). */
+export function isReviewTask(t: { tags?: string[] }): boolean {
+  return t.tags?.includes('review') ?? false
+}
+
+/** A task's review phase, defaulting unknown/empty values to `reviewing`. */
+export function reviewPhaseOf(t: { reviewPhase?: string }): ReviewPhase {
+  const p = t.reviewPhase
+  return p && p in REVIEW_PHASE_META ? (p as ReviewPhase) : 'reviewing'
+}
+
+export function reviewPhaseMeta(t: { reviewPhase?: string }): ReviewPhaseMeta {
+  return REVIEW_PHASE_META[reviewPhaseOf(t)]
+}
+
+/** Sort key for the PR Reviews lane — lower sorts first (needs-you on top). */
+export function reviewPhaseRank(t: { reviewPhase?: string }): number {
+  const idx = REVIEW_PHASE_ORDER.indexOf(reviewPhaseOf(t))
+  return idx === -1 ? REVIEW_PHASE_ORDER.length : idx
+}

--- a/frontend/src/lib/review-phase.ts
+++ b/frontend/src/lib/review-phase.ts
@@ -77,7 +77,9 @@ export function isReviewTask(t: { tags?: string[] }): boolean {
 /** A task's review phase, defaulting unknown/empty values to `reviewing`. */
 export function reviewPhaseOf(t: { reviewPhase?: string }): ReviewPhase {
   const p = t.reviewPhase
-  return p && p in REVIEW_PHASE_META ? (p as ReviewPhase) : 'reviewing'
+  // Own-property check: `in` would also match inherited keys like `toString`,
+  // letting corrupt data slip through and crash reviewPhaseMeta().
+  return p && Object.hasOwn(REVIEW_PHASE_META, p) ? (p as ReviewPhase) : 'reviewing'
 }
 
 export function reviewPhaseMeta(t: { reviewPhase?: string }): ReviewPhaseMeta {

--- a/frontend/src/lib/statuses.ts
+++ b/frontend/src/lib/statuses.ts
@@ -157,6 +157,13 @@ export interface BoardColumn {
   border: string
   /** Extra statuses folded into this column */
   includes: TaskStatus[]
+  /**
+   * Column kind. 'status' (default) groups tasks by status; 'review' is the
+   * tag-based PR Reviews lane that collects inbound review tasks across every
+   * phase, independent of their status. `status` is a sentinel for review
+   * lanes — never a real task status.
+   */
+  kind?: 'status' | 'review'
 }
 
 /** Kanban board columns — active work only; terminal tasks live in Logbook */
@@ -168,6 +175,29 @@ export const BOARD_COLUMNS: BoardColumn[] = [
   { status: 'testing', label: 'Testing', border: 'border-t-secondary-500 dark:border-t-secondary-400', includes: ['testing', 'test-plan-review'] },
   { status: 'human-required', label: 'Human Required', border: 'border-t-error-500 dark:border-t-error-400', includes: ['human-required', 'blocked'] },
 ]
+
+/**
+ * The PR Reviews lane: a tag-based column (not status-based) that collects
+ * every inbound review task (tag `review`) regardless of status, coloured per
+ * phase. `status: 'reviews'` is a sentinel used only as the column key — it is
+ * never a real task status, so it stays out of BOARD_COLUMNS / CORE_STATUSES.
+ */
+export const REVIEW_LANE: BoardColumn = {
+  status: 'reviews' as TaskStatus,
+  kind: 'review',
+  label: 'PR Reviews',
+  border: 'border-t-secondary-500 dark:border-t-secondary-400',
+  includes: [],
+}
+
+/**
+ * Board column order including the PR Reviews lane (inserted before Human
+ * Required). The board renders these; BOARD_COLUMNS stays the pure status set
+ * that drives CORE_STATUSES, the status picker, and per-project boards.
+ */
+export const BOARD_LANES: BoardColumn[] = BOARD_COLUMNS.flatMap((c) =>
+  c.status === 'human-required' ? [REVIEW_LANE, c] : [c],
+)
 
 /**
  * Core user-facing status set: the active board columns plus the terminal

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -4,7 +4,8 @@
   import { taskStore } from '../stores/tasks.svelte.js'
   import { projectStore } from '../stores/projects.svelte.js'
   import { notificationStore } from '../stores/notifications.svelte.js'
-  import { BOARD_COLUMNS, awaitsHuman, type BoardColumn } from '../lib/statuses.js'
+  import { BOARD_LANES, awaitsHuman, type BoardColumn } from '../lib/statuses.js'
+  import { isReviewTask, reviewPhaseRank } from '../lib/review-phase.js'
   import { navStore } from '../lib/navigation.svelte.js'
   import { matchesQuery, matchesProject, matchesTags, matchesAgentMode } from '../lib/task-filters.js'
   import TaskTimeline from '../components/TaskTimeline.svelte'
@@ -45,6 +46,9 @@
   }
 
   async function moveTask(taskId: string, status: string) {
+    // The PR Reviews lane key is a sentinel, not a real status — dropping onto
+    // it must not write an invalid status.
+    if (status === 'reviews') return
     const existing = taskStore.tasks.get(taskId)
     if (!existing || existing.status === status) return
     try {
@@ -64,8 +68,26 @@
   let assignProjectOpen = $state(false)
 
   function columnTasks(col: BoardColumn): Task[] {
+    if (col.kind === 'review') return reviewLaneTasks()
     const statuses = col.includes.length > 0 ? col.includes : [col.status]
-    return filteredByStatuses(statuses)
+    // Review tasks live in the PR Reviews lane, never their status column.
+    return filteredByStatuses(statuses).filter((t) => !isReviewTask(t))
+  }
+
+  // The PR Reviews lane: every active inbound review task, sorted so the
+  // phases that need the user (post / approve) float to the top.
+  function reviewLaneTasks(): Task[] {
+    return taskStore.list
+      .filter((t: Task) => {
+        if (!isReviewTask(t)) return false
+        if (t.status === 'done' || t.status === 'cancelled') return false
+        if (!matchesQuery(t, searchQuery)) return false
+        if (!matchesProject(t, selectedProjectId)) return false
+        if (!matchesTags(t, selectedTags)) return false
+        if (!matchesAgentMode(t, selectedAgentMode)) return false
+        return true
+      })
+      .sort((a, b) => reviewPhaseRank(a) - reviewPhaseRank(b))
   }
 
   function getColumnTasksByIdx(colIndex: number): Task[] {
@@ -201,7 +223,7 @@
         block: 'nearest',
         inline: 'start',
       })
-      const idx = BOARD_COLUMNS.findIndex((c) => c.status === 'in-progress')
+      const idx = BOARD_LANES.findIndex((c) => c.status === 'in-progress')
       if (idx >= 0) focusedColIdx = idx
     })
   })
@@ -258,7 +280,7 @@
   })
 
   const visibleColumns = $derived(
-    effectiveShowDone ? BOARD_COLUMNS : BOARD_COLUMNS.filter(c => c.status !== 'done')
+    effectiveShowDone ? BOARD_LANES : BOARD_LANES.filter(c => c.status !== 'done')
   )
 
   // Tasks awaiting the user across all columns (same set as the per-card red

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -235,6 +235,37 @@ func fetchPRFilesWith(e execer, repo string, number int) ([]string, error) {
 	return paths, nil
 }
 
+// FetchPRHeadSHA returns the head commit SHA of a PR. Used to detect a fresh
+// push by the PR author after a review was submitted.
+func FetchPRHeadSHA(repo string, number int) (string, error) {
+	return fetchPRHeadSHAWith(defaultExecer, repo, number)
+}
+
+func fetchPRHeadSHAWith(e execer, repo string, number int) (string, error) {
+	key := prCacheKey(repo, number)
+	if runtimeCacheEnabled(e) {
+		if cached, ok := prHeadSHACache.Get(key); ok {
+			return cached, nil
+		}
+	}
+
+	out, err := e.run("pr", "view", strconv.Itoa(number),
+		"--repo", repo, "--json", "headRefOid")
+	if err != nil {
+		return "", fmt.Errorf("gh pr view %d head: %s: %w", number, strings.TrimSpace(string(out)), err)
+	}
+	var raw struct {
+		HeadRefOid string `json:"headRefOid"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return "", fmt.Errorf("parse pr head: %w", err)
+	}
+	if runtimeCacheEnabled(e) {
+		prHeadSHACache.Set(key, raw.HeadRefOid, 30*time.Second)
+	}
+	return raw.HeadRefOid, nil
+}
+
 // FetchPRBranch returns the head branch name for a PR.
 func FetchPRBranch(repo string, number int) (string, error) {
 	return fetchPRBranchWith(defaultExecer, repo, number)

--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -207,6 +207,99 @@ func hasPendingReviewWith(e execer, repo string, number int) (bool, error) {
 	return false, nil
 }
 
+// MyReviewState summarises the authenticated user's own reviews on a PR.
+type MyReviewState struct {
+	Pending     bool   // an unsubmitted draft review exists
+	Submitted   bool   // a submitted (non-draft) review exists
+	Approved    bool   // the latest submitted review is an approval
+	ReviewedSHA string // commit_id of the latest submitted review ("" if none)
+}
+
+// FetchMyReviewState reports the authenticated user's review state on a PR.
+// It reads the per-PR reviews REST endpoint, which — unlike the
+// reviewed-by:@me search leg (filtered to approvals) — exposes COMMENTED and
+// CHANGES_REQUESTED reviews and each review's commit_id, the signals the
+// PR-review lifecycle needs.
+func FetchMyReviewState(repo string, number int) (MyReviewState, error) {
+	return fetchMyReviewStateWith(defaultExecer, repo, number)
+}
+
+func fetchMyReviewStateWith(e execer, repo string, number int) (MyReviewState, error) {
+	key := prCacheKey(repo, number)
+	if runtimeCacheEnabled(e) {
+		if cached, ok := myReviewStateCache.Get(key); ok {
+			return cached, nil
+		}
+	}
+
+	resp, err := runGHAPIWith(e, "30s", fmt.Sprintf("repos/%s/pulls/%d/reviews", repo, number))
+	if err != nil {
+		if runtimeCacheEnabled(e) {
+			if stale, ok := myReviewStateCache.GetStale(key); ok {
+				return stale, nil
+			}
+		}
+		return MyReviewState{}, fmt.Errorf("fetch reviews for %s#%d: %s: %w", repo, number, strings.TrimSpace(string(resp.body)), err)
+	}
+
+	var reviews []struct {
+		State       string `json:"state"`
+		CommitID    string `json:"commit_id"`
+		SubmittedAt string `json:"submitted_at"`
+		User        struct {
+			Login string `json:"login"`
+		} `json:"user"`
+	}
+	if err := json.Unmarshal(resp.body, &reviews); err != nil {
+		return MyReviewState{}, fmt.Errorf("parse reviews: %w", err)
+	}
+
+	me := viewerLogin(e)
+	if me == "" {
+		// Without the viewer's login we cannot attribute submitted reviews, and
+		// guessing would misclassify the phase. Surface a (transient) error so
+		// the caller leaves the task's phase untouched this cycle rather than
+		// flapping it to "manual".
+		return MyReviewState{}, fmt.Errorf("resolve viewer login for %s#%d", repo, number)
+	}
+
+	var st MyReviewState
+	var latestReview, latestVerdict string // submitted_at watermarks
+	for i := range reviews {
+		r := reviews[i]
+		// PENDING (draft) reviews are visible only to their author, so any we
+		// can see are ours.
+		if r.State == "PENDING" {
+			st.Pending = true
+			continue
+		}
+		// Submitted reviews include every reviewer's — keep only the viewer's.
+		if r.User.Login != me {
+			continue
+		}
+		st.Submitted = true
+		// Track the commit of the most recent review of any kind, for
+		// push-past-reviewed-commit detection. ISO-8601 sorts lexically.
+		if r.SubmittedAt >= latestReview {
+			latestReview = r.SubmittedAt
+			st.ReviewedSHA = r.CommitID
+		}
+		// Only APPROVED/CHANGES_REQUESTED/DISMISSED carry a standing verdict; a
+		// COMMENTED review left after an approval does not revoke it.
+		if r.State == "APPROVED" || r.State == "CHANGES_REQUESTED" || r.State == "DISMISSED" {
+			if r.SubmittedAt >= latestVerdict {
+				latestVerdict = r.SubmittedAt
+				st.Approved = r.State == "APPROVED"
+			}
+		}
+	}
+
+	if runtimeCacheEnabled(e) {
+		myReviewStateCache.Set(key, st, 30*time.Second)
+	}
+	return st, nil
+}
+
 // ApprovePR approves a pull request.
 func ApprovePR(repo string, number int) error {
 	return approvePRWith(defaultExecer, repo, number)

--- a/internal/github/review_state_test.go
+++ b/internal/github/review_state_test.go
@@ -1,0 +1,74 @@
+package github
+
+import "testing"
+
+func TestFetchMyReviewState(t *testing.T) {
+	// viewerLogin caches in a package global; seed it so the fake execer only
+	// needs to answer the reviews call, and restore it afterward.
+	viewerMu.Lock()
+	prevViewer := cachedViewer
+	cachedViewer = "me"
+	viewerMu.Unlock()
+	t.Cleanup(func() {
+		viewerMu.Lock()
+		cachedViewer = prevViewer
+		viewerMu.Unlock()
+	})
+
+	tests := []struct {
+		name string
+		body string
+		want MyReviewState
+	}{
+		{
+			name: "pending draft only",
+			body: `[{"state":"PENDING","user":{"login":"me"},"commit_id":"sha1"}]`,
+			want: MyReviewState{Pending: true},
+		},
+		{
+			name: "approved by me",
+			body: `[{"state":"APPROVED","user":{"login":"me"},"commit_id":"sha1","submitted_at":"2026-01-01T00:00:00Z"}]`,
+			want: MyReviewState{Submitted: true, Approved: true, ReviewedSHA: "sha1"},
+		},
+		{
+			name: "my changes-requested wins; a peer's approval is ignored",
+			body: `[{"state":"CHANGES_REQUESTED","user":{"login":"me"},"commit_id":"sha2","submitted_at":"2026-01-02T00:00:00Z"},{"state":"APPROVED","user":{"login":"peer"},"commit_id":"shaX","submitted_at":"2026-01-03T00:00:00Z"}]`,
+			want: MyReviewState{Submitted: true, Approved: false, ReviewedSHA: "sha2"},
+		},
+		{
+			name: "latest of my reviews wins",
+			body: `[{"state":"CHANGES_REQUESTED","user":{"login":"me"},"commit_id":"old","submitted_at":"2026-01-01T00:00:00Z"},{"state":"APPROVED","user":{"login":"me"},"commit_id":"new","submitted_at":"2026-01-05T00:00:00Z"}]`,
+			want: MyReviewState{Submitted: true, Approved: true, ReviewedSHA: "new"},
+		},
+		{
+			// A COMMENTED review after an approval doesn't revoke it; the
+			// approval verdict stands, while ReviewedSHA tracks the newer commit.
+			name: "comment after approval keeps the approval",
+			body: `[{"state":"APPROVED","user":{"login":"me"},"commit_id":"sha_a","submitted_at":"2026-01-01T00:00:00Z"},{"state":"COMMENTED","user":{"login":"me"},"commit_id":"sha_b","submitted_at":"2026-01-02T00:00:00Z"}]`,
+			want: MyReviewState{Submitted: true, Approved: true, ReviewedSHA: "sha_b"},
+		},
+		{
+			name: "pending plus a submitted comment review",
+			body: `[{"state":"PENDING","user":{"login":"me"}},{"state":"COMMENTED","user":{"login":"me"},"commit_id":"sha3","submitted_at":"2026-01-02T00:00:00Z"}]`,
+			want: MyReviewState{Pending: true, Submitted: true, ReviewedSHA: "sha3"},
+		},
+		{
+			name: "no reviews",
+			body: `[]`,
+			want: MyReviewState{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fe := &fakeExecer{output: []byte(tt.body)}
+			got, err := fetchMyReviewStateWith(fe, "o/r", 7)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/github/runtime.go
+++ b/internal/github/runtime.go
@@ -309,9 +309,11 @@ func invalidatePRCaches(repo string, number int) {
 	prStateCache.Delete(key)
 	prFilesCache.Delete(key)
 	prBranchCache.Delete(key)
+	prHeadSHACache.Delete(key)
 	prContextCache.Delete(key)
 	prClosingIssuesCache.Delete(key)
 	pendingReviewCache.Delete(key)
+	myReviewStateCache.Delete(key)
 }
 
 var (
@@ -326,9 +328,11 @@ var (
 	prStateCache         = newTTLCache[PRState]()
 	prFilesCache         = newTTLCache[[]string]()
 	prBranchCache        = newTTLCache[string]()
+	prHeadSHACache       = newTTLCache[string]()
 	prContextCache       = newTTLCache[PRContext]()
 	prClosingIssuesCache = newTTLCache[prClosingIssuesResult]()
 	pendingReviewCache   = newTTLCache[bool]()
+	myReviewStateCache   = newTTLCache[MyReviewState]()
 	issueCache           = newTTLCache[Issue]()
 )
 

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -176,7 +176,7 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 	}
 
 	r.maybeCreateReviewTasks(tasks, summary.ReviewRequested)
-	r.detectPublishedReviews(tasks)
+	r.reconcileReviewPhases(tasks, summary)
 	r.closeFinishedReviewTasks(tasks, openReviewPRs(summary))
 
 	if prNeedsAttention(monitoredPRs) {

--- a/internal/sybra/app_reviews_inbound.go
+++ b/internal/sybra/app_reviews_inbound.go
@@ -3,6 +3,7 @@ package sybra
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/Automaat/sybra/internal/agent"
@@ -208,32 +209,135 @@ func (r *ReviewHandler) hasReviewTask(tasks []task.Task, projectID string, prNum
 	return false
 }
 
-func (r *ReviewHandler) detectPublishedReviews(tasks []task.Task) {
-	for i := range tasks {
-		if tasks[i].Status != task.StatusHumanRequired {
-			continue
-		}
-		if !slices.Contains(tasks[i].Tags, "review") {
-			continue
-		}
-		if tasks[i].PRNumber == 0 || tasks[i].ProjectID == "" {
-			continue
-		}
+// reviewPRKey identifies a PR within a repo for summary lookups.
+func reviewPRKey(projectID string, prNumber int) string {
+	return projectID + "#" + strconv.Itoa(prNumber)
+}
 
-		pending, err := github.HasPendingReview(tasks[i].ProjectID, tasks[i].PRNumber)
-		if err != nil {
-			r.logger.Warn("review.poll-pending", "task_id", tasks[i].ID, "err", err)
+// reconcileReviewPhases recomputes the lifecycle phase of every inbound
+// PR-review task (tag `review`) from live GitHub signals and persists any
+// delta. It supersedes the old human-required→in-review "published" detector,
+// folding that transition into the phase machine.
+func (r *ReviewHandler) reconcileReviewPhases(tasks []task.Task, summary github.ReviewSummary) {
+	requested := indexPRsByKey(summary.ReviewRequested)
+	approved := indexPRsByKey(summary.ReviewedByMe) // reviewed-by:@me is approvals-only
+
+	for i := range tasks {
+		t := &tasks[i]
+		if !slices.Contains(t.Tags, "review") || task.IsTerminalStatus(t.Status) {
 			continue
 		}
-		if !pending {
-			if _, err := r.tasks.Update(tasks[i].ID, task.Update{Status: task.Ptr(task.StatusInReview)}); err != nil {
-				r.logger.Error("review.published-update", "task_id", tasks[i].ID, "err", err)
-				continue
-			}
-			r.logAudit(audit.EventReviewPublished, tasks[i].ID, "", map[string]any{"pr": tasks[i].PRNumber})
-			r.logger.Info("review.published", "task_id", tasks[i].ID, "pr", tasks[i].PRNumber)
+		if t.PRNumber == 0 || t.ProjectID == "" {
+			continue
+		}
+		r.reconcileReviewTask(t, requested, approved)
+	}
+}
+
+// reconcileReviewTask computes and applies the phase for a single review task.
+func (r *ReviewHandler) reconcileReviewTask(t *task.Task, requested, approved map[string]github.PullRequest) {
+	// An agent owning the PR short-circuits: surface "reviewing" without the
+	// extra GitHub round-trips.
+	if r.agents.HasRunningAgentForTask(t.ID) {
+		r.applyReviewPhase(t, computeReviewPhase(reviewSignals{AgentRunning: true}))
+		return
+	}
+
+	key := reviewPRKey(t.ProjectID, t.PRNumber)
+	reqPR, inReq := requested[key]
+	apPR, inApproved := approved[key]
+
+	myState, err := github.FetchMyReviewState(t.ProjectID, t.PRNumber)
+	if err != nil {
+		r.logger.Warn("review.my-state", "task_id", t.ID, "err", err)
+		return
+	}
+
+	submitted := myState.Submitted || inApproved
+	headSHA := ""
+	switch {
+	case inReq:
+		headSHA = reqPR.HeadSHA
+	case inApproved:
+		headSHA = apPR.HeadSHA
+	case submitted:
+		// A submitted (non-approval) review that wasn't re-requested leaves the
+		// PR in neither summary leg; fetch the head so a silent push past the
+		// reviewed commit still flips us to needs-approval.
+		if sha, herr := github.FetchPRHeadSHA(t.ProjectID, t.PRNumber); herr != nil {
+			r.logger.Warn("review.head-sha", "task_id", t.ID, "err", herr)
+		} else {
+			headSHA = sha
 		}
 	}
+
+	r.applyReviewPhase(t, computeReviewPhase(reviewSignals{
+		HasDraft:       myState.Pending,
+		ViewerApproved: myState.Approved || inApproved,
+		Submitted:      submitted,
+		ReRequested:    inReq,
+		HeadSHA:        headSHA,
+		ReviewedSHA:    myState.ReviewedSHA,
+	}))
+}
+
+// applyReviewPhase persists only the fields that changed. Status is set only
+// when the result names one and it differs (so an unchanged status never
+// clears a triage-authored reason); the reason follows a status or phase change.
+func (r *ReviewHandler) applyReviewPhase(t *task.Task, res reviewPhaseResult) {
+	statusChanged := res.Status != "" && res.Status != t.Status
+	phaseChanged := res.Phase != t.ReviewPhase
+	if !statusChanged && !phaseChanged {
+		return
+	}
+
+	u := task.Update{}
+	if phaseChanged {
+		u.ReviewPhase = task.Ptr(res.Phase)
+	}
+	if statusChanged {
+		u.Status = task.Ptr(res.Status)
+	}
+	if res.Reason != "" && (statusChanged || phaseChanged) {
+		u.StatusReason = task.Ptr(res.Reason)
+	}
+
+	prev := t.ReviewPhase
+	if _, err := r.tasks.Update(t.ID, u); err != nil {
+		r.logger.Error("review.phase-update", "task_id", t.ID, "phase", res.Phase, "err", err)
+		return
+	}
+	if !phaseChanged {
+		return
+	}
+	r.logger.Info("review.phase", "task_id", t.ID, "pr", t.PRNumber, "from", prev, "to", res.Phase)
+	if reviewPhasePublished(prev, res.Phase) {
+		r.logAudit(audit.EventReviewPublished, t.ID, "", map[string]any{"pr": t.PRNumber})
+	}
+}
+
+// reviewPhasePublished reports whether a transition represents the human
+// publishing their review — moving from a pre-submit phase into a submitted
+// one. Drives the EventReviewPublished audit log.
+func reviewPhasePublished(prev, next string) bool {
+	if next != ReviewPhaseAwaitingAuthor && next != ReviewPhaseNeedsApproval {
+		return false
+	}
+	switch prev {
+	case ReviewPhaseDrafted, ReviewPhaseManual, ReviewPhaseReviewing, "":
+		return true
+	default:
+		return false
+	}
+}
+
+// indexPRsByKey maps PRs by "owner/repo#number" for O(1) summary lookups.
+func indexPRsByKey(prs []github.PullRequest) map[string]github.PullRequest {
+	m := make(map[string]github.PullRequest, len(prs))
+	for i := range prs {
+		m[reviewPRKey(prs[i].Repository, prs[i].Number)] = prs[i]
+	}
+	return m
 }
 
 func reviewClosedPREligible(t *task.Task) bool {

--- a/internal/sybra/review_phase.go
+++ b/internal/sybra/review_phase.go
@@ -1,0 +1,95 @@
+package sybra
+
+import "github.com/Automaat/sybra/internal/task"
+
+// Review phases for inbound PR-review tasks (tag `review`). Persisted on
+// task.ReviewPhase and rendered as the board's PR Reviews lane badge.
+const (
+	// ReviewPhaseReviewing: a review agent is actively working the PR.
+	ReviewPhaseReviewing = "reviewing"
+	// ReviewPhaseManual: the PR was too small for an agent and was punted to
+	// the human to review by hand.
+	ReviewPhaseManual = "manual"
+	// ReviewPhaseDrafted: a PENDING (draft) review sits on the PR, waiting for
+	// the human to verify and submit it on GitHub.
+	ReviewPhaseDrafted = "drafted"
+	// ReviewPhaseAwaitingAuthor: the human submitted the review; the ball is in
+	// the PR author's court to push changes / respond.
+	ReviewPhaseAwaitingAuthor = "awaiting-author"
+	// ReviewPhaseNeedsApproval: the author re-requested review or pushed past
+	// the reviewed commit — the human needs a final pass and approval.
+	ReviewPhaseNeedsApproval = "needs-approval"
+	// ReviewPhaseApproved: the human approved; the PR is waiting to merge.
+	ReviewPhaseApproved = "approved"
+)
+
+// reviewSignals are the live GitHub facts about a review task's PR, gathered
+// from the review summary plus the per-PR reviews endpoint.
+type reviewSignals struct {
+	AgentRunning   bool   // a review agent is running for this task
+	HasDraft       bool   // viewer has a PENDING (unsubmitted) review
+	ViewerApproved bool   // viewer's latest submitted review is an approval
+	Submitted      bool   // viewer has a submitted (non-draft) review
+	ReRequested    bool   // PR is back in viewer's review-requested list
+	HeadSHA        string // current PR head commit ("" if unknown)
+	ReviewedSHA    string // commit the viewer's latest review was made against
+}
+
+// reviewPhaseResult is the desired task state for a review task.
+//
+// Status is "" when the phase must not touch task.Status (e.g. while an agent
+// runs).
+type reviewPhaseResult struct {
+	Phase  string
+	Status task.Status
+	Reason string
+}
+
+// computeReviewPhase maps live PR signals to the desired review phase and
+// status. Pure and table-tested; the poller wraps it to apply only the deltas
+// (see reconcileReviewPhases).
+func computeReviewPhase(s reviewSignals) reviewPhaseResult {
+	// An agent owning the PR trumps everything: surface "reviewing" but leave
+	// the status untouched so we don't fight triage/fix dispatch.
+	if s.AgentRunning {
+		return reviewPhaseResult{Phase: ReviewPhaseReviewing}
+	}
+
+	if s.ViewerApproved {
+		return reviewPhaseResult{
+			Phase:  ReviewPhaseApproved,
+			Status: task.StatusInReview,
+			Reason: "Approved — awaiting merge",
+		}
+	}
+
+	if s.HasDraft {
+		return reviewPhaseResult{
+			Phase:  ReviewPhaseDrafted,
+			Status: task.StatusHumanRequired,
+			Reason: "Draft review ready — verify & submit on GitHub",
+		}
+	}
+
+	if s.Submitted {
+		// The author pushed past the commit we reviewed, or re-requested review:
+		// either way it needs a fresh human pass before approval.
+		advanced := s.HeadSHA != "" && s.ReviewedSHA != "" && s.HeadSHA != s.ReviewedSHA
+		if s.ReRequested || advanced {
+			return reviewPhaseResult{
+				Phase:  ReviewPhaseNeedsApproval,
+				Status: task.StatusHumanRequired,
+				Reason: "Author updated PR — do a final review & approve",
+			}
+		}
+		return reviewPhaseResult{
+			Phase:  ReviewPhaseAwaitingAuthor,
+			Status: task.StatusInReview,
+			Reason: "Awaiting author response",
+		}
+	}
+
+	// No agent, no draft, no submitted review: the human owns it (typically a
+	// small PR punted by triage). Leave status/reason as triage set them.
+	return reviewPhaseResult{Phase: ReviewPhaseManual, Status: task.StatusHumanRequired}
+}

--- a/internal/sybra/review_phase.go
+++ b/internal/sybra/review_phase.go
@@ -90,6 +90,8 @@ func computeReviewPhase(s reviewSignals) reviewPhaseResult {
 	}
 
 	// No agent, no draft, no submitted review: the human owns it (typically a
-	// small PR punted by triage). Leave status/reason as triage set them.
+	// small PR punted by triage). Assert human-required for the needs-you
+	// signal, but emit no reason so applyReviewPhase keeps whatever reason
+	// triage already set (e.g. "PR too small for agent review").
 	return reviewPhaseResult{Phase: ReviewPhaseManual, Status: task.StatusHumanRequired}
 }

--- a/internal/sybra/review_phase_test.go
+++ b/internal/sybra/review_phase_test.go
@@ -1,0 +1,86 @@
+package sybra
+
+import (
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func TestComputeReviewPhase(t *testing.T) {
+	tests := []struct {
+		name string
+		sig  reviewSignals
+		want reviewPhaseResult
+	}{
+		{
+			name: "agent running trumps everything, leaves status untouched",
+			sig:  reviewSignals{AgentRunning: true, HasDraft: true, Submitted: true},
+			want: reviewPhaseResult{Phase: ReviewPhaseReviewing},
+		},
+		{
+			name: "approved waits for merge",
+			sig:  reviewSignals{ViewerApproved: true, Submitted: true, HeadSHA: "abc"},
+			want: reviewPhaseResult{Phase: ReviewPhaseApproved, Status: task.StatusInReview, Reason: "Approved — awaiting merge"},
+		},
+		{
+			name: "pending draft → drafted, needs human to post",
+			sig:  reviewSignals{HasDraft: true, ReRequested: true, HeadSHA: "abc"},
+			want: reviewPhaseResult{Phase: ReviewPhaseDrafted, Status: task.StatusHumanRequired, Reason: "Draft review ready — verify & submit on GitHub"},
+		},
+		{
+			name: "submitted at current head, not re-requested → awaiting author",
+			sig:  reviewSignals{Submitted: true, HeadSHA: "sha1", ReviewedSHA: "sha1"},
+			want: reviewPhaseResult{Phase: ReviewPhaseAwaitingAuthor, Status: task.StatusInReview, Reason: "Awaiting author response"},
+		},
+		{
+			name: "submitted, head unknown → awaiting author (no false advance)",
+			sig:  reviewSignals{Submitted: true, ReviewedSHA: "sha1"},
+			want: reviewPhaseResult{Phase: ReviewPhaseAwaitingAuthor, Status: task.StatusInReview, Reason: "Awaiting author response"},
+		},
+		{
+			name: "author pushed past reviewed commit → needs approval",
+			sig:  reviewSignals{Submitted: true, HeadSHA: "sha2", ReviewedSHA: "sha1"},
+			want: reviewPhaseResult{Phase: ReviewPhaseNeedsApproval, Status: task.StatusHumanRequired, Reason: "Author updated PR — do a final review & approve"},
+		},
+		{
+			name: "re-requested after review → needs approval even at same head",
+			sig:  reviewSignals{Submitted: true, ReRequested: true, HeadSHA: "sha1", ReviewedSHA: "sha1"},
+			want: reviewPhaseResult{Phase: ReviewPhaseNeedsApproval, Status: task.StatusHumanRequired, Reason: "Author updated PR — do a final review & approve"},
+		},
+		{
+			name: "no agent, no draft, not submitted → manual (small-PR punt)",
+			sig:  reviewSignals{ReRequested: true, HeadSHA: "sha1"},
+			want: reviewPhaseResult{Phase: ReviewPhaseManual, Status: task.StatusHumanRequired},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeReviewPhase(tt.sig)
+			if got != tt.want {
+				t.Errorf("computeReviewPhase(%+v)\n got: %+v\nwant: %+v", tt.sig, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReviewPhasePublished(t *testing.T) {
+	tests := []struct {
+		prev, next string
+		want       bool
+	}{
+		{ReviewPhaseDrafted, ReviewPhaseAwaitingAuthor, true},
+		{ReviewPhaseManual, ReviewPhaseAwaitingAuthor, true},
+		{ReviewPhaseReviewing, ReviewPhaseNeedsApproval, true},
+		{"", ReviewPhaseAwaitingAuthor, true},
+		{ReviewPhaseAwaitingAuthor, ReviewPhaseNeedsApproval, false}, // already published
+		{ReviewPhaseDrafted, ReviewPhaseApproved, false},             // approval, not a publish
+		{ReviewPhaseAwaitingAuthor, ReviewPhaseApproved, false},
+		{ReviewPhaseDrafted, ReviewPhaseManual, false},
+	}
+	for _, tt := range tests {
+		if got := reviewPhasePublished(tt.prev, tt.next); got != tt.want {
+			t.Errorf("reviewPhasePublished(%q, %q) = %v, want %v", tt.prev, tt.next, got, tt.want)
+		}
+	}
+}

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -167,13 +167,19 @@ type Task struct {
 	// BlockedByIssue stores the URL of the GitHub issue that put the task
 	// into status=blocked. Set by the human-review automation when it
 	// concludes the human-required transition was caused by a Sybra bug.
-	BlockedByIssue string     `yaml:"blocked_by_issue,omitempty" json:"blockedByIssue,omitempty"`
-	Reviewed       bool       `yaml:"reviewed,omitempty" json:"reviewed"`
-	RunRole        string     `yaml:"run_role,omitempty" json:"runRole"` // pr-fix when fixing review issues, "" for initial impl
-	TodoistID      string     `yaml:"todoist_id,omitempty" json:"todoistId"`
-	Priority       Priority   `yaml:"priority,omitempty" json:"priority,omitempty"`
-	DueDate        *time.Time `yaml:"due_date,omitempty" json:"dueDate,omitempty"`
-	ClosedAt       *time.Time `yaml:"closed_at,omitempty" json:"closedAt,omitempty"`
+	BlockedByIssue string `yaml:"blocked_by_issue,omitempty" json:"blockedByIssue,omitempty"`
+	Reviewed       bool   `yaml:"reviewed,omitempty" json:"reviewed"`
+	RunRole        string `yaml:"run_role,omitempty" json:"runRole"` // pr-fix when fixing review issues, "" for initial impl
+	// ReviewPhase tracks where an inbound PR-review task (tag `review`) sits in
+	// the review lifecycle: reviewing → drafted → awaiting-author →
+	// needs-approval → approved (plus `manual` for small PRs punted to the
+	// human). Computed by the PR poller; drives the board's PR Reviews lane.
+	// Empty for non-review tasks.
+	ReviewPhase string     `yaml:"review_phase,omitempty" json:"reviewPhase,omitempty"`
+	TodoistID   string     `yaml:"todoist_id,omitempty" json:"todoistId"`
+	Priority    Priority   `yaml:"priority,omitempty" json:"priority,omitempty"`
+	DueDate     *time.Time `yaml:"due_date,omitempty" json:"dueDate,omitempty"`
+	ClosedAt    *time.Time `yaml:"closed_at,omitempty" json:"closedAt,omitempty"`
 	// MaxTurns overrides the global agent turn limit for this task.
 	// Zero means "use global default".
 	MaxTurns int `yaml:"max_turns,omitempty" json:"maxTurns,omitempty"`

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -379,6 +379,18 @@ func (s *Store) Update(id string, u Update) (Task, error) {
 // UpdateWithPrev applies u and returns both the updated task and the prior
 // status. Lets callers (Manager.Update) wire status-change hooks without a
 // redundant Get to read the previous value before the write.
+// applyReviewFields copies the review-flow tracking fields (run role + inbound
+// PR-review phase) from an Update onto a task. Split out of UpdateWithPrev to
+// keep that function within the length budget.
+func applyReviewFields(t *Task, u Update) {
+	if u.RunRole != nil {
+		t.RunRole = *u.RunRole
+	}
+	if u.ReviewPhase != nil {
+		t.ReviewPhase = *u.ReviewPhase
+	}
+}
+
 func (s *Store) UpdateWithPrev(id string, u Update) (Task, Status, error) {
 	t, err := s.read(id)
 	if err != nil {
@@ -449,9 +461,7 @@ func (s *Store) UpdateWithPrev(id string, u Update) (Task, Status, error) {
 	if u.Reviewed != nil {
 		t.Reviewed = *u.Reviewed
 	}
-	if u.RunRole != nil {
-		t.RunRole = *u.RunRole
-	}
+	applyReviewFields(&t, u)
 	if u.TodoistID != nil {
 		t.TodoistID = *u.TodoistID
 	}

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -27,6 +27,7 @@ type Update struct {
 	Issue          *string
 	Reviewed       *bool
 	RunRole        *string
+	ReviewPhase    *string
 	TodoistID      *string
 	Priority       *Priority
 	DueDate        **time.Time
@@ -61,7 +62,8 @@ func UpdateFromMap(raw map[string]any) (Update, error) {
 func applyMapField(u *Update, k string, v any) error {
 	switch k {
 	case "title", "slug", "status_reason", "blocked_by_issue", "body",
-		"project_id", "branch", "issue", "run_role", "todoist_id", "plan", "plan_critique", "code_review":
+		"project_id", "branch", "issue", "run_role", "todoist_id", "plan", "plan_critique", "code_review",
+		"review_phase":
 		return applyPlainStringField(u, k, v)
 	case "priority":
 		return applyPriorityField(u, v)
@@ -135,6 +137,8 @@ func applyPlainStringField(u *Update, k string, v any) error {
 		u.PlanCritique = &s
 	case "code_review":
 		u.CodeReview = &s
+	case "review_phase":
+		u.ReviewPhase = &s
 	}
 	return nil
 }


### PR DESCRIPTION
## Motivation

Inbound PR-review tasks (Sybra reviewing someone else's GitHub PR, tag
`review`) were visually indistinguishable from tasks Sybra implements
itself, and gave no signal about *whose* turn it is. A review moves
through distinct stages — Sybra drafts a review, I verify and post it,
the author responds, I do a final pass and approve — and the board
showed none of that, so review work stalled silently in the In Review
column.

> Changelog: feat(reviews): add a PR review phase lane on the board

## Implementation information

**Phase model.** Each review task now carries a `review_phase` computed
by the PR poller from live GitHub signals:

| phase | trigger | board cue | status |
|---|---|---|---|
| `reviewing` | review agent running | grey, agent badge | in-review |
| `manual` | small-PR punt, review by hand | amber / eye | human-required |
| `drafted` | pending draft review on the PR | amber / pen "Post review" | human-required |
| `awaiting-author` | review submitted, waiting | teal / hourglass | in-review |
| `needs-approval` | re-requested **or** head advanced past reviewed commit | violet / shield "Approve" | human-required |
| `approved` | viewer approved | green / check | in-review |

The viewer's own review state (pending draft / submitted / approved +
the exact reviewed commit) is read from the per-PR reviews REST
endpoint, filtered to the viewer's login. This is the authoritative
source: the `reviewed-by:@me` search leg is approvals-only, so reading
it would hide `awaiting-author`/`needs-approval` entirely. GitHub's
`commit_id` anchors push detection, so no per-machine state is tracked.

**Board.** A tag-based **PR Reviews** lane (inserted before Human
Required) collects every active review task across all phases, sorted
needs-you-first, with a colour + glyph phase badge on the PR pill.
Review tasks are pulled out of their status columns into the lane. The
`reviews` column key is a sentinel, never written as a task status.

**Review.** Built via two parallel adversarial reviewers. The first
pass caught a critical bug (the two middle phases were unreachable
against real GitHub data) and a regression (lost published-review
transition); both were fixed by sourcing review state from the reviews
endpoint, which also let the fragile in-memory pending-edge tracking
and a persisted SHA field be dropped. A verification pass confirmed the
fixes and approved the result.

## Supporting documentation

- Pure phase logic is table-tested (`internal/sybra/review_phase_test.go`);
  the GitHub probe is tested against fixture payloads
  (`internal/github/review_state_test.go`); the lane/badge logic is
  covered in `frontend/src/lib/review-phase.test.ts`.
- Gates: `go test ./...`, `golangci-lint run ./...`, `svelte-check`,
  `oxlint`, `vitest` (1554), and the darwin desktop build all pass.