### PR TITLE
feat(reviews): In Review PR lifecycle phases

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -189,6 +189,15 @@ export class Task {
      * Empty for non-review tasks.
      */
     "reviewPhase"?: string;
+
+    /**
+     * PRPhase tracks where an outbound own-PR task (status in-review/ready-review,
+     * not tag `review`) sits in its lifecycle: draft → building → fixing →
+     * changes-requested → awaiting-approval → approved. Computed by the PR poller;
+     * drives the phase glyph on the board's In Review cards. Empty for tasks
+     * without an own PR (and for inbound review tasks, which use ReviewPhase).
+     */
+    "prPhase"?: string;
     "todoistId": string;
     "priority"?: Priority;
     "dueDate"?: time$0.Time | null;
@@ -309,9 +318,9 @@ export class Task {
     static createFrom($$source: any = {}): Task {
         const $$createField6_0 = $$createType0;
         const $$createField7_0 = $$createType0;
-        const $$createField24_0 = $$createType2;
-        const $$createField25_0 = $$createType4;
-        const $$createField32_0 = $$createType5;
+        const $$createField25_0 = $$createType2;
+        const $$createField26_0 = $$createType4;
+        const $$createField33_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -320,13 +329,13 @@ export class Task {
             $$parsedSource["tags"] = $$createField7_0($$parsedSource["tags"]);
         }
         if ("agentRuns" in $$parsedSource) {
-            $$parsedSource["agentRuns"] = $$createField24_0($$parsedSource["agentRuns"]);
+            $$parsedSource["agentRuns"] = $$createField25_0($$parsedSource["agentRuns"]);
         }
         if ("workflow" in $$parsedSource) {
-            $$parsedSource["workflow"] = $$createField25_0($$parsedSource["workflow"]);
+            $$parsedSource["workflow"] = $$createField26_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField32_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField33_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
   import { timeAgo } from '$lib/dates.js'
-  import { CheckCircle, XCircle, Clock, GitPullRequest, CircleDot, Copy, AlertTriangle, MoreHorizontal, Eye, PenLine, Hourglass, ShieldCheck, Loader } from '@lucide/svelte'
+  import { CheckCircle, XCircle, Clock, GitPullRequest, GitPullRequestDraft, CircleDot, Copy, AlertTriangle, MoreHorizontal, Eye, PenLine, Hourglass, ShieldCheck, Loader, Wrench, MessageSquare } from '@lucide/svelte'
   import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { agentStore } from '../stores/agents.svelte.js'
   import { reviewStore } from '../stores/reviews.svelte.js'
   import { notificationStore } from '../stores/notifications.svelte.js'
   import { awaitsHuman, awaitsHumanLabel, coreStatus, statusLabel } from '../lib/statuses.js'
   import { isReviewTask as isReviewTaskFn, reviewPhaseMeta, type ReviewPhaseIcon } from '../lib/review-phase.js'
+  import { isOwnPRTask as isOwnPRTaskFn, prPhaseMeta, prPhaseNeedsYou, type PRPhaseIcon } from '../lib/pr-phase.js'
   import { PRIORITY_OPTIONS } from '../lib/priorities.js'
   import { projectShortName, projectDotStyle } from '../lib/project-cue.js'
   import StatusPicker from './StatusPicker.svelte'
@@ -59,14 +60,23 @@
   const linkedPRs = $derived(reviewStore.byTask(t))
   const topPR = $derived(linkedPRs.length > 0 ? linkedPRs[0] : null)
   const isReviewTask = $derived(isReviewTaskFn(t))
+  // Own-PR task with a computed lifecycle phase (In Review column).
+  const ownPRPhase = $derived(isOwnPRTaskFn(t))
 
   // lucide components keyed by the phase meta's icon name.
   const PHASE_ICONS: Record<ReviewPhaseIcon, typeof CheckCircle> = {
     loader: Loader, eye: Eye, pen: PenLine, hourglass: Hourglass, shield: ShieldCheck, check: CheckCircle,
   }
 
+  // lucide components for the outbound PR phase glyph.
+  const PR_PHASE_ICONS: Record<PRPhaseIcon, typeof CheckCircle> = {
+    draft: GitPullRequestDraft, loader: Loader, wrench: Wrench, comment: MessageSquare, hourglass: Hourglass, check: CheckCircle,
+  }
+
   // Task is waiting on the user (not an agent) — drives the red tile accent.
-  const needsYou = $derived(awaitsHuman(t.status))
+  // Own-PR phases (draft / awaiting-approval / approved) count too, so the card
+  // flags "your move" while staying in the In Review column.
+  const needsYou = $derived(awaitsHuman(t.status) || prPhaseNeedsYou(t))
 
   // A granular sub-state folded into this column that ISN'T an attention state
   // (e.g. `new` in Todo, `ready-review` in In Review). The column shows the
@@ -175,11 +185,11 @@
       </span>
     {/if}
 
-    {#if needsYou && !isReviewTask}
+    {#if needsYou && !isReviewTask && !ownPRPhase}
       <Pill role="attention" class="bg-error-200 text-error-800 dark:bg-error-700 dark:text-error-200">
         {awaitsHumanLabel(t.status)}
       </Pill>
-    {:else if subStateLabel && !isReviewTask}
+    {:else if subStateLabel && !isReviewTask && !ownPRPhase}
       <span class="inline-flex items-center rounded-full bg-surface-200 px-2 py-0.5 text-surface-600 dark:bg-surface-700 dark:text-surface-300">
         {subStateLabel}
       </span>
@@ -202,6 +212,18 @@
     {#if isReviewTask}
       {@const ph = reviewPhaseMeta(t)}
       {@const PhaseIcon = PHASE_ICONS[ph.icon]}
+      <span
+        class="inline-flex items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium {ph.classes}"
+        title={t.statusReason || ph.label}
+      >
+        <PhaseIcon size={12} class="shrink-0" />
+        {#if topPR}#{topPR.number}{:else if t.prNumber}#{t.prNumber}{/if}
+        <span>{ph.label}</span>
+        {#if t.issue}{@render issueGlyph()}{/if}
+      </span>
+    {:else if ownPRPhase}
+      {@const ph = prPhaseMeta(t)}
+      {@const PhaseIcon = PR_PHASE_ICONS[ph.icon]}
       <span
         class="inline-flex items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium {ph.classes}"
         title={t.statusReason || ph.label}

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -74,8 +74,8 @@
   }
 
   // Task is waiting on the user (not an agent) — drives the red tile accent.
-  // Own-PR phases (draft / awaiting-approval / approved) count too, so the card
-  // flags "your move" while staying in the In Review column.
+  // The strict own-PR phases (draft / approved) count too, so the card flags
+  // "your move" while staying in the In Review column.
   const needsYou = $derived(awaitsHuman(t.status) || prPhaseNeedsYou(t))
 
   // A granular sub-state folded into this column that ISN'T an attention state

--- a/frontend/src/lib/pr-phase.test.ts
+++ b/frontend/src/lib/pr-phase.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import {
+  PR_PHASE_META,
+  isOwnPRTask,
+  prPhaseOf,
+  prPhaseMeta,
+  prPhaseRank,
+  prPhaseNeedsYou,
+  type PRPhase,
+} from './pr-phase.js'
+
+describe('isOwnPRTask', () => {
+  it('is true only for non-review tasks that carry a phase', () => {
+    expect(isOwnPRTask({ prPhase: 'draft' })).toBe(true)
+    expect(isOwnPRTask({ tags: ['backend'], prPhase: 'approved' })).toBe(true)
+    expect(isOwnPRTask({ prPhase: '' })).toBe(false)
+    expect(isOwnPRTask({})).toBe(false)
+    // A review-tagged task is inbound — never an own-PR task, even with a phase.
+    expect(isOwnPRTask({ tags: ['review'], prPhase: 'draft' })).toBe(false)
+  })
+})
+
+describe('prPhaseOf', () => {
+  it('returns the known phase', () => {
+    expect(prPhaseOf({ prPhase: 'draft' })).toBe('draft')
+    expect(prPhaseOf({ prPhase: 'awaiting-approval' })).toBe('awaiting-approval')
+  })
+
+  it('falls back to building for empty or unknown values', () => {
+    expect(prPhaseOf({})).toBe('building')
+    expect(prPhaseOf({ prPhase: '' })).toBe('building')
+    expect(prPhaseOf({ prPhase: 'bogus' })).toBe('building')
+  })
+
+  it('does not treat inherited Object keys as valid phases', () => {
+    for (const proto of ['toString', 'constructor', 'hasOwnProperty', '__proto__']) {
+      expect(prPhaseOf({ prPhase: proto })).toBe('building')
+    }
+  })
+})
+
+describe('prPhaseMeta', () => {
+  it('maps each phase to a non-empty label, icon, and classes', () => {
+    for (const phase of Object.keys(PR_PHASE_META) as PRPhase[]) {
+      const m = PR_PHASE_META[phase]
+      expect(m.label).not.toBe('')
+      expect(m.icon).not.toBe('')
+      expect(m.classes).toContain('bg-')
+    }
+  })
+
+  it('resolves a phase to its metadata', () => {
+    expect(prPhaseMeta({ prPhase: 'draft' }).label).toBe('Draft — mark ready')
+    expect(prPhaseMeta({ prPhase: 'approved' }).label).toBe('Approved — merge')
+    expect(prPhaseMeta({}).label).toBe('Building')
+  })
+})
+
+describe('prPhaseRank', () => {
+  it('sorts user-action phases ahead of waiting and agent-owned ones', () => {
+    const rank = (p: string) => prPhaseRank({ prPhase: p })
+    expect(rank('approved')).toBeLessThan(rank('awaiting-approval'))
+    expect(rank('awaiting-approval')).toBeLessThan(rank('changes-requested'))
+    expect(rank('draft')).toBeLessThan(rank('building'))
+    expect(rank('changes-requested')).toBeLessThan(rank('fixing'))
+  })
+})
+
+describe('prPhaseNeedsYou', () => {
+  it('flags only the strict your-court phases: draft and approved', () => {
+    expect(prPhaseNeedsYou({ prPhase: 'draft' })).toBe(true)
+    expect(prPhaseNeedsYou({ prPhase: 'approved' })).toBe(true)
+  })
+
+  it('does not flag waiting, agent-owned, or passive phases', () => {
+    expect(prPhaseNeedsYou({ prPhase: 'awaiting-approval' })).toBe(false)
+    expect(prPhaseNeedsYou({ prPhase: 'building' })).toBe(false)
+    expect(prPhaseNeedsYou({ prPhase: 'fixing' })).toBe(false)
+    expect(prPhaseNeedsYou({ prPhase: 'changes-requested' })).toBe(false)
+  })
+
+  it('never flags a task without a phase or a review task', () => {
+    expect(prPhaseNeedsYou({})).toBe(false)
+    expect(prPhaseNeedsYou({ tags: ['review'], prPhase: 'draft' })).toBe(false)
+  })
+})

--- a/frontend/src/lib/pr-phase.ts
+++ b/frontend/src/lib/pr-phase.ts
@@ -23,9 +23,9 @@ export interface PRPhaseMeta {
   classes: string
 }
 
-// Needs-you phases (draft, awaiting-approval, approved) drive the red tile
-// accent via prPhaseNeedsYou — the colour here is the phase hue, distinct from
-// that attention signal.
+// Needs-you phases (draft, approved) drive the red tile accent via
+// prPhaseNeedsYou — the colour here is the phase hue, distinct from that
+// attention signal. `awaiting-approval` is a waiting state, not needs-you.
 export const PR_PHASE_META: Record<PRPhase, PRPhaseMeta> = {
   draft: {
     label: 'Draft — mark ready',
@@ -102,7 +102,11 @@ export function prPhaseRank(t: { prPhase?: string }): number {
   return idx === -1 ? PR_PHASE_ORDER.length : idx
 }
 
-/** True when an own-PR task's phase awaits the user (mark ready / ping / merge). */
+/**
+ * True when an own-PR task's phase strictly awaits the user — `draft` (mark
+ * ready) or `approved` (merge). `awaiting-approval` is excluded on purpose: the
+ * PR is waiting on reviewers, not on a concrete user action.
+ */
 export function prPhaseNeedsYou(t: { tags?: string[]; prPhase?: string }): boolean {
   return isOwnPRTask(t) && PR_PHASE_NEEDS_YOU.has(prPhaseOf(t))
 }

--- a/frontend/src/lib/pr-phase.ts
+++ b/frontend/src/lib/pr-phase.ts
@@ -1,0 +1,108 @@
+// Lifecycle phases for outbound own-PR tasks (status in-review/ready-review, not
+// tag `review`) — the board's In Review cards show a colour-coded phase glyph.
+// Mirrors the Go constants in internal/sybra/pr_phase.go. The phase is a pure
+// overlay; it never changes the task's status (own-PR tasks stay in In Review).
+
+import { isReviewTask } from './review-phase.js'
+
+export type PRPhase =
+  | 'draft'
+  | 'building'
+  | 'fixing'
+  | 'changes-requested'
+  | 'awaiting-approval'
+  | 'approved'
+
+/** Icon keys, resolved to lucide components at the call site. */
+export type PRPhaseIcon = 'draft' | 'loader' | 'wrench' | 'comment' | 'hourglass' | 'check'
+
+export interface PRPhaseMeta {
+  label: string
+  icon: PRPhaseIcon
+  /** bg + text pill classes (light + dark) */
+  classes: string
+}
+
+// Needs-you phases (draft, awaiting-approval, approved) drive the red tile
+// accent via prPhaseNeedsYou — the colour here is the phase hue, distinct from
+// that attention signal.
+export const PR_PHASE_META: Record<PRPhase, PRPhaseMeta> = {
+  draft: {
+    label: 'Draft — mark ready',
+    icon: 'draft',
+    classes: 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200',
+  },
+  building: {
+    label: 'Building',
+    icon: 'loader',
+    classes: 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-300',
+  },
+  fixing: {
+    label: 'Fixing',
+    icon: 'wrench',
+    classes: 'bg-tertiary-200 text-tertiary-800 dark:bg-tertiary-700 dark:text-tertiary-200',
+  },
+  'changes-requested': {
+    label: 'Comments',
+    icon: 'comment',
+    classes: 'bg-warning-200 text-warning-800 dark:bg-warning-700 dark:text-warning-200',
+  },
+  'awaiting-approval': {
+    label: 'Awaiting approval',
+    icon: 'hourglass',
+    classes: 'bg-secondary-200 text-secondary-800 dark:bg-secondary-700 dark:text-secondary-200',
+  },
+  approved: {
+    label: 'Approved — merge',
+    icon: 'check',
+    classes: 'bg-success-200 text-success-800 dark:bg-success-700 dark:text-success-200',
+  },
+}
+
+// Column sort: the user's pending actions first (merge, ping, mark-ready), then
+// the auto-handled / waiting phases.
+const PR_PHASE_ORDER: PRPhase[] = [
+  'approved',
+  'awaiting-approval',
+  'draft',
+  'changes-requested',
+  'building',
+  'fixing',
+]
+
+// Phases where the ball is strictly in the user's court (mark ready / merge) —
+// drives the red card accent. `awaiting-approval` is deliberately excluded: the
+// PR is waiting on reviewers, not on a concrete action the user must take, so
+// it stays a visible-but-passive teal phase rather than adding red noise.
+const PR_PHASE_NEEDS_YOU: ReadonlySet<PRPhase> = new Set<PRPhase>([
+  'draft',
+  'approved',
+])
+
+/** True when a task is one of the user's own PRs with a computed phase. */
+export function isOwnPRTask(t: { tags?: string[]; prPhase?: string }): boolean {
+  return !isReviewTask(t) && !!t.prPhase
+}
+
+/** A task's PR phase, defaulting unknown/empty values to `building`. */
+export function prPhaseOf(t: { prPhase?: string }): PRPhase {
+  const p = t.prPhase
+  // Own-property check: `in` would also match inherited keys like `toString`,
+  // letting corrupt data slip through and crash prPhaseMeta().
+  return p && Object.hasOwn(PR_PHASE_META, p) ? (p as PRPhase) : 'building'
+}
+
+export function prPhaseMeta(t: { prPhase?: string }): PRPhaseMeta {
+  return PR_PHASE_META[prPhaseOf(t)]
+}
+
+/** Sort key for the In Review column — lower sorts first (needs-you on top). */
+export function prPhaseRank(t: { prPhase?: string }): number {
+  const idx = PR_PHASE_ORDER.indexOf(prPhaseOf(t))
+  return idx === -1 ? PR_PHASE_ORDER.length : idx
+}
+
+/** True when an own-PR task's phase awaits the user (mark ready / ping / merge). */
+export function prPhaseNeedsYou(t: { tags?: string[]; prPhase?: string }): boolean {
+  return isOwnPRTask(t) && PR_PHASE_NEEDS_YOU.has(prPhaseOf(t))
+}

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -6,6 +6,7 @@
   import { notificationStore } from '../stores/notifications.svelte.js'
   import { BOARD_LANES, awaitsHuman, type BoardColumn } from '../lib/statuses.js'
   import { isReviewTask, reviewPhaseRank } from '../lib/review-phase.js'
+  import { prPhaseRank, prPhaseNeedsYou } from '../lib/pr-phase.js'
   import { navStore } from '../lib/navigation.svelte.js'
   import { matchesQuery, matchesProject, matchesTags, matchesAgentMode } from '../lib/task-filters.js'
   import TaskTimeline from '../components/TaskTimeline.svelte'
@@ -71,7 +72,13 @@
     if (col.kind === 'review') return reviewLaneTasks()
     const statuses = col.includes.length > 0 ? col.includes : [col.status]
     // Review tasks live in the PR Reviews lane, never their status column.
-    return filteredByStatuses(statuses).filter((t) => !isReviewTask(t))
+    const tasks = filteredByStatuses(statuses).filter((t) => !isReviewTask(t))
+    // In Review: float the user's pending PR actions (merge / ping / mark-ready)
+    // to the top, mirroring the PR Reviews lane.
+    if (col.status === 'in-review') {
+      return [...tasks].sort((a, b) => prPhaseRank(a) - prPhaseRank(b))
+    }
+    return tasks
   }
 
   // The PR Reviews lane: every active inbound review task, sorted so the
@@ -286,7 +293,7 @@
   // Tasks awaiting the user across all columns (same set as the per-card red
   // attention border) — surfaced as a persistent board-toolbar counter so an
   // awaiting task is never missed when its column scrolls off-screen.
-  const needYouCount = $derived(allFilteredTasks.filter((t: Task) => awaitsHuman(t.status)).length)
+  const needYouCount = $derived(allFilteredTasks.filter((t: Task) => awaitsHuman(t.status) || prPhaseNeedsYou(t)).length)
 
   const hasActiveFilters = $derived(
     Boolean(searchQuery) || Boolean(selectedProjectId) || selectedTags.length > 0 || Boolean(selectedAgentMode)

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -19,6 +19,7 @@ const (
 	EventOrchestratorStop    = "orchestrator.stopped"
 	EventPRConflictDetected  = "pr_monitor.conflict_detected"
 	EventPRCIFailureDetected = "pr_monitor.ci_failure_detected"
+	EventPRCommentsDetected  = "pr_monitor.comments_detected"
 	EventPRFixAgentStarted   = "pr_monitor.fix_agent_started"
 	EventPRMerged            = "pr_monitor.merged"
 	EventPRClosed            = "pr_monitor.closed"

--- a/internal/github/monitor.go
+++ b/internal/github/monitor.go
@@ -8,6 +8,7 @@ type PRIssueKind string
 const (
 	PRIssueConflict     PRIssueKind = "conflict"
 	PRIssueCIFailure    PRIssueKind = "ci_failure"
+	PRIssueComments     PRIssueKind = "comments"
 	PRIssueReadyToMerge PRIssueKind = "ready_to_merge"
 )
 
@@ -105,6 +106,11 @@ func MatchTaskPRs(prs []PullRequest, tasks []TaskMatcher) []PRIssue {
 		}
 		if pr.CIStatus == "FAILURE" && !pr.HasPendingChecks {
 			issues = append(issues, PRIssue{Kind: PRIssueCIFailure, TaskID: tm.ID, PR: *pr})
+		}
+		// Reviewers asked for changes or left unresolved threads — dispatch a
+		// fix-review agent. Skip drafts: the author is still iterating.
+		if !pr.IsDraft && (pr.ReviewDecision == "CHANGES_REQUESTED" || pr.UnresolvedCount > 0) {
+			issues = append(issues, PRIssue{Kind: PRIssueComments, TaskID: tm.ID, PR: *pr})
 		}
 		if !pr.IsDraft && pr.Mergeable == "MERGEABLE" && (pr.CIStatus == "SUCCESS" || pr.CIStatus == "") {
 			issues = append(issues, PRIssue{Kind: PRIssueReadyToMerge, TaskID: tm.ID, PR: *pr})

--- a/internal/github/monitor_test.go
+++ b/internal/github/monitor_test.go
@@ -103,6 +103,33 @@ func TestMatchTaskPRs(t *testing.T) {
 			},
 			want: []PRIssue{{Kind: PRIssueCIFailure, TaskID: "t1", PR: PullRequest{Number: 42, HeadRefName: "feat/x", CIStatus: "FAILURE"}}},
 		},
+		{
+			name:  "changes requested → comments fix",
+			prs:   []PullRequest{{Number: 42, ReviewDecision: "CHANGES_REQUESTED"}},
+			tasks: []TaskMatcher{{ID: "t1", PRNumber: 42}},
+			want:  []PRIssue{{Kind: PRIssueComments, TaskID: "t1"}},
+		},
+		{
+			name:  "unresolved threads → comments fix",
+			prs:   []PullRequest{{Number: 42, UnresolvedCount: 2}},
+			tasks: []TaskMatcher{{ID: "t1", PRNumber: 42}},
+			want:  []PRIssue{{Kind: PRIssueComments, TaskID: "t1"}},
+		},
+		{
+			name:  "draft with comments is not fixed",
+			prs:   []PullRequest{{Number: 42, IsDraft: true, ReviewDecision: "CHANGES_REQUESTED", UnresolvedCount: 3}},
+			tasks: []TaskMatcher{{ID: "t1", PRNumber: 42}},
+			want:  nil,
+		},
+		{
+			name:  "CI failure and comments both trigger",
+			prs:   []PullRequest{{Number: 42, CIStatus: "FAILURE", ReviewDecision: "CHANGES_REQUESTED"}},
+			tasks: []TaskMatcher{{ID: "t1", PRNumber: 42}},
+			want: []PRIssue{
+				{Kind: PRIssueCIFailure, TaskID: "t1"},
+				{Kind: PRIssueComments, TaskID: "t1"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -177,6 +177,7 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 
 	r.maybeCreateReviewTasks(tasks, summary.ReviewRequested)
 	r.reconcileReviewPhases(tasks, summary)
+	r.reconcilePRPhases(tasks, monitoredPRs)
 	r.closeFinishedReviewTasks(tasks, openReviewPRs(summary))
 
 	if prNeedsAttention(monitoredPRs) {
@@ -315,6 +316,11 @@ func prNeedsAttention(prs []github.PullRequest) bool {
 			return true
 		}
 		if prs[i].Mergeable == "CONFLICTING" || prs[i].Mergeable == "UNKNOWN" {
+			return true
+		}
+		// Review comments just landed — poll fast so the fix agent dispatches
+		// and the In Review card flips to "fixing" without a 5-minute lag.
+		if !prs[i].IsDraft && (prs[i].ReviewDecision == "CHANGES_REQUESTED" || prs[i].UnresolvedCount > 0) {
 			return true
 		}
 		if !prs[i].IsDraft && prs[i].Mergeable == "MERGEABLE" && (prs[i].CIStatus == "SUCCESS" || prs[i].CIStatus == "") {

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -70,6 +70,12 @@ func (r *ReviewHandler) handlePRIssue(issue github.PRIssue) {
 			"pr": issue.PR.Number, "repo": issue.PR.Repository,
 		})
 
+	case github.PRIssueComments:
+		prompt = commentsPrompt(issue.PR)
+		r.logAudit(audit.EventPRCommentsDetected, t.ID, "", map[string]any{
+			"pr": issue.PR.Number, "repo": issue.PR.Repository,
+		})
+
 	case github.PRIssueReadyToMerge:
 		// handled by handleAutoMerge, not by agent spawn
 		return
@@ -132,7 +138,9 @@ func (r *ReviewHandler) prepareWorktree(t task.Task, issue github.PRIssue) (stri
 		d     string
 		wtErr error
 	)
-	if issue.Kind == github.PRIssueConflict {
+	// Conflict and comment fixes operate on the PR's existing branch, so check
+	// it out (PrepareForFix). A CI fix re-runs on a fresh worktree.
+	if issue.Kind == github.PRIssueConflict || issue.Kind == github.PRIssueComments {
 		d, wtErr = r.worktrees.PrepareForFix(t, issue.PR.Number)
 	} else {
 		d, wtErr = r.worktrees.PrepareForTask(t, nil)
@@ -159,6 +167,28 @@ func (r *ReviewHandler) prepareWorktree(t task.Task, issue github.PRIssue) (stri
 	}
 	delete(r.wtFailures, t.ID)
 	return d, true
+}
+
+// commentsPrompt instructs the fix agent to address unresolved review comments
+// on the user's own PR via the /fix-review skill (which replies on every
+// thread), then push and re-request review.
+func commentsPrompt(pr github.PullRequest) string {
+	return fmt.Sprintf(
+		"Run /fix-review %s --auto\n\n"+
+			"This is your own PR (#%d) — reviewers left comments or unresolved "+
+			"threads. Address the valid ones, reply on every thread, and push.\n\n"+
+			"IMPORTANT: when committing, use conventional commit format "+
+			"`fix(review): address PR review comments` (type(scope) required by "+
+			"repo hooks). Sign the commit with `git commit -s -S`.\n\n"+
+			"Push to the same remote the PR was opened from — never to `origin` "+
+			"when a `fork` remote exists:\n"+
+			"```sh\n"+
+			"PUSH_REMOTE=origin\n"+
+			"if git config --get remote.fork.url >/dev/null; then PUSH_REMOTE=fork; fi\n"+
+			"git push \"$PUSH_REMOTE\" HEAD:%s\n"+
+			"```",
+		pr.URL, pr.Number, pr.HeadRefName,
+	)
 }
 
 func conflictPrompt(pr github.PullRequest) string {

--- a/internal/sybra/app_reviews_outbound.go
+++ b/internal/sybra/app_reviews_outbound.go
@@ -1,0 +1,83 @@
+package sybra
+
+import (
+	"slices"
+
+	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// reconcilePRPhases recomputes the lifecycle phase of every outbound own-PR
+// task (status in-review/ready-review, not tag `review`) from the live
+// monitored PRs and persists any delta. The phase is a pure overlay on the In
+// Review column — it never changes task.Status.
+func (r *ReviewHandler) reconcilePRPhases(tasks []task.Task, monitoredPRs []github.PullRequest) {
+	byNumber := make(map[int]*github.PullRequest, len(monitoredPRs))
+	byBranch := make(map[string]*github.PullRequest, len(monitoredPRs))
+	for i := range monitoredPRs {
+		if monitoredPRs[i].Number > 0 {
+			byNumber[monitoredPRs[i].Number] = &monitoredPRs[i]
+		}
+		if monitoredPRs[i].HeadRefName != "" {
+			byBranch[monitoredPRs[i].HeadRefName] = &monitoredPRs[i]
+		}
+	}
+
+	for i := range tasks {
+		t := &tasks[i]
+		if !ownPRColumnTask(t) {
+			// Clear a stale phase left over from when the task was in review
+			// (e.g. it was moved back to in-progress or its PR closed) so the
+			// glyph only ever shows in the In Review column.
+			if t.PRPhase != "" {
+				r.applyPRPhase(t, "")
+			}
+			continue
+		}
+
+		pr := byNumber[t.PRNumber]
+		if pr == nil {
+			pr = byBranch[t.Branch]
+		}
+		if pr == nil {
+			// PR not in the current summary yet (just opened / cache miss).
+			// Leave the existing phase untouched until it appears.
+			continue
+		}
+
+		r.applyPRPhase(t, computePRPhase(prSignals{
+			AgentRunning:     r.agents.HasRunningAgentForTask(t.ID),
+			IsDraft:          pr.IsDraft,
+			CIStatus:         pr.CIStatus,
+			HasPendingChecks: pr.HasPendingChecks,
+			Mergeable:        pr.Mergeable,
+			ReviewDecision:   pr.ReviewDecision,
+			UnresolvedCount:  pr.UnresolvedCount,
+		}))
+	}
+}
+
+// ownPRColumnTask reports whether a task is one of the user's own PRs shown in
+// the In Review column — the set reconcilePRPhases assigns a PR phase to.
+func ownPRColumnTask(t *task.Task) bool {
+	if t.TaskType == task.TaskTypeChat || slices.Contains(t.Tags, "review") {
+		return false
+	}
+	if t.Status != task.StatusInReview && t.Status != task.StatusReadyReview {
+		return false
+	}
+	return t.PRNumber != 0 || t.Branch != ""
+}
+
+// applyPRPhase persists the PR phase only when it changed.
+func (r *ReviewHandler) applyPRPhase(t *task.Task, phase string) {
+	if phase == t.PRPhase {
+		return
+	}
+	prev := t.PRPhase
+	if _, err := r.tasks.Update(t.ID, task.Update{PRPhase: task.Ptr(phase)}); err != nil {
+		r.logger.Error("pr-monitor.phase-update", "task_id", t.ID, "phase", phase, "err", err)
+		return
+	}
+	r.logger.Info("pr-monitor.phase", "task_id", t.ID, "pr", t.PRNumber, "from", prev, "to", phase)
+}

--- a/internal/sybra/app_reviews_outbound_test.go
+++ b/internal/sybra/app_reviews_outbound_test.go
@@ -1,0 +1,138 @@
+package sybra
+
+import (
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// newOutboundTestHandler builds a ReviewHandler backed by a temp task store and
+// a real (idle) agent manager — enough to exercise the PR-phase reconciler.
+func newOutboundTestHandler(t *testing.T) (*ReviewHandler, *task.Manager) {
+	t.Helper()
+	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := slog.New(slog.DiscardHandler)
+	agents := agent.NewManager(t.Context(), func(string, any) {}, logger, t.TempDir())
+	r := &ReviewHandler{
+		DomainHandler: DomainHandler{logger: logger},
+		tasks:         tasks,
+		agents:        agents,
+	}
+	return r, tasks
+}
+
+// mkOwnPRTask creates a task and drives it to in-review with a linked PR.
+func mkOwnPRTask(t *testing.T, tasks *task.Manager, prNumber int, tags []string) task.Task {
+	t.Helper()
+	created, err := tasks.Create("Implement thing", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	updated, err := tasks.Update(created.ID, task.Update{
+		Status:    task.Ptr(task.StatusInReview),
+		PRNumber:  task.Ptr(prNumber),
+		ProjectID: task.Ptr("Automaat/sybra"),
+		Tags:      &tags,
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	return updated
+}
+
+func TestReconcilePRPhases(t *testing.T) {
+	r, tasks := newOutboundTestHandler(t)
+
+	own := mkOwnPRTask(t, tasks, 42, nil)
+	review := mkOwnPRTask(t, tasks, 7, []string{"review"})
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	prs := []github.PullRequest{
+		{Number: 42, ReviewDecision: "APPROVED", Mergeable: "MERGEABLE", CIStatus: "SUCCESS"},
+		{Number: 7, ReviewDecision: "CHANGES_REQUESTED"},
+	}
+	r.reconcilePRPhases(all, prs)
+
+	got, err := tasks.Get(own.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PRPhase != PRPhaseApproved {
+		t.Errorf("own PR phase = %q, want %q", got.PRPhase, PRPhaseApproved)
+	}
+
+	// A review-tagged task is inbound — the outbound reconciler must skip it so
+	// it stays driven by ReviewPhase, not PRPhase.
+	gotReview, err := tasks.Get(review.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotReview.PRPhase != "" {
+		t.Errorf("review task PRPhase = %q, want empty", gotReview.PRPhase)
+	}
+}
+
+func TestReconcilePRPhasesClearsStaleWhenIneligible(t *testing.T) {
+	r, tasks := newOutboundTestHandler(t)
+
+	created := mkOwnPRTask(t, tasks, 42, nil)
+	// Seed a phase, then move the task out of the In Review column.
+	if _, err := tasks.Update(created.ID, task.Update{
+		PRPhase: task.Ptr(PRPhaseAwaitingApproval),
+		Status:  task.Ptr(task.StatusInProgress),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.reconcilePRPhases(all, []github.PullRequest{{Number: 42, CIStatus: "SUCCESS"}})
+
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PRPhase != "" {
+		t.Errorf("stale PRPhase = %q, want cleared", got.PRPhase)
+	}
+}
+
+func TestApplyPRPhaseSkipsNoOp(t *testing.T) {
+	r, tasks := newOutboundTestHandler(t)
+	created := mkOwnPRTask(t, tasks, 42, nil)
+	if _, err := tasks.Update(created.ID, task.Update{PRPhase: task.Ptr(PRPhaseDraft)}); err != nil {
+		t.Fatal(err)
+	}
+
+	cur, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := cur.UpdatedAt
+
+	// Same phase → no write, status untouched.
+	r.applyPRPhase(&cur, PRPhaseDraft)
+	after, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !after.UpdatedAt.Equal(before) {
+		t.Errorf("no-op applyPRPhase wrote the task (updatedAt changed)")
+	}
+	if after.Status != task.StatusInReview {
+		t.Errorf("applyPRPhase changed status to %q", after.Status)
+	}
+}

--- a/internal/sybra/pr_phase.go
+++ b/internal/sybra/pr_phase.go
@@ -1,0 +1,71 @@
+package sybra
+
+// PR phases for outbound own-PR tasks (status in-review/ready-review, not tag
+// `review`). Persisted on task.PRPhase and rendered as the phase glyph on the
+// board's In Review cards. Unlike the inbound review machine (review_phase.go),
+// these phases never change task.Status — own-PR tasks must stay in the In
+// Review column; the phase is a pure overlay.
+const (
+	// PRPhaseDraft: the PR is still a draft. The human must mark it ready.
+	PRPhaseDraft = "draft"
+	// PRPhaseBuilding: CI is still running — nothing to do but wait.
+	PRPhaseBuilding = "building"
+	// PRPhaseFixing: an agent is (or is about to be) auto-fixing the PR — a CI
+	// failure, a merge conflict, or review comments.
+	PRPhaseFixing = "fixing"
+	// PRPhaseChangesRequested: reviewers left changes/unresolved comments; a
+	// fix-review agent is dispatched to address them.
+	PRPhaseChangesRequested = "changes-requested"
+	// PRPhaseAwaitingApproval: the PR is clean and green but not yet approved —
+	// the human may want to ping reviewers.
+	PRPhaseAwaitingApproval = "awaiting-approval"
+	// PRPhaseApproved: the PR is approved and waiting to merge (pet projects
+	// auto-merge; the human merges the rest).
+	PRPhaseApproved = "approved"
+)
+
+// prSignals are the live GitHub facts about an own-PR task's pull request,
+// taken straight from the monitored github.PullRequest plus whether an agent is
+// running for the task.
+type prSignals struct {
+	AgentRunning     bool   // an agent is running for this task (fix/impl)
+	IsDraft          bool   // PR is a draft
+	CIStatus         string // SUCCESS, FAILURE, PENDING, or ""
+	HasPendingChecks bool   // a check is still in-progress/queued
+	Mergeable        string // MERGEABLE, CONFLICTING, UNKNOWN, or ""
+	ReviewDecision   string // APPROVED, CHANGES_REQUESTED, REVIEW_REQUIRED, or ""
+	UnresolvedCount  int    // unresolved review threads
+}
+
+// computePRPhase maps live PR signals to the desired phase. Pure and
+// table-tested; the poller wraps it to apply only the deltas (see
+// reconcilePRPhases). First match wins — the order encodes priority.
+func computePRPhase(s prSignals) string {
+	switch {
+	// An agent actively working the PR trumps everything.
+	case s.AgentRunning:
+		return PRPhaseFixing
+	// CI failed or the branch conflicts: the monitor dispatches a fix agent,
+	// so surface "fixing" even in the brief gap before it spins up.
+	case s.CIStatus == "FAILURE" && !s.HasPendingChecks:
+		return PRPhaseFixing
+	case s.Mergeable == "CONFLICTING":
+		return PRPhaseFixing
+	// Reviewers asked for changes (or left unresolved threads): a fix-review
+	// agent is dispatched to address them.
+	case s.ReviewDecision == "CHANGES_REQUESTED" || s.UnresolvedCount > 0:
+		return PRPhaseChangesRequested
+	// Still a draft with nothing broken: the human needs to mark it ready.
+	case s.IsDraft:
+		return PRPhaseDraft
+	// CI is still running — wait it out.
+	case s.CIStatus == "PENDING" || s.HasPendingChecks:
+		return PRPhaseBuilding
+	// Approved and clean: ready to merge.
+	case s.ReviewDecision == "APPROVED":
+		return PRPhaseApproved
+	// Clean, green, not draft, not yet approved: waiting on reviewers.
+	default:
+		return PRPhaseAwaitingApproval
+	}
+}

--- a/internal/sybra/pr_phase.go
+++ b/internal/sybra/pr_phase.go
@@ -51,13 +51,17 @@ func computePRPhase(s prSignals) string {
 		return PRPhaseFixing
 	case s.Mergeable == "CONFLICTING":
 		return PRPhaseFixing
+	// Still a draft (and not actively being fixed for CI/conflict): the human
+	// must mark it ready. This outranks the comment check because the monitor
+	// skips comment-fix dispatch on drafts (MatchTaskPRs gates on !IsDraft), so
+	// a draft with comments would otherwise imply a fix that never runs and
+	// hide the "mark ready" action.
+	case s.IsDraft:
+		return PRPhaseDraft
 	// Reviewers asked for changes (or left unresolved threads): a fix-review
 	// agent is dispatched to address them.
 	case s.ReviewDecision == "CHANGES_REQUESTED" || s.UnresolvedCount > 0:
 		return PRPhaseChangesRequested
-	// Still a draft with nothing broken: the human needs to mark it ready.
-	case s.IsDraft:
-		return PRPhaseDraft
 	// CI is still running — wait it out.
 	case s.CIStatus == "PENDING" || s.HasPendingChecks:
 		return PRPhaseBuilding

--- a/internal/sybra/pr_phase_test.go
+++ b/internal/sybra/pr_phase_test.go
@@ -1,0 +1,90 @@
+package sybra
+
+import "testing"
+
+func TestComputePRPhase(t *testing.T) {
+	tests := []struct {
+		name string
+		sig  prSignals
+		want string
+	}{
+		{
+			name: "agent running trumps everything",
+			sig:  prSignals{AgentRunning: true, IsDraft: true, ReviewDecision: "APPROVED"},
+			want: PRPhaseFixing,
+		},
+		{
+			name: "CI failure → fixing",
+			sig:  prSignals{CIStatus: "FAILURE"},
+			want: PRPhaseFixing,
+		},
+		{
+			name: "CI failure with pending checks is not yet fixing",
+			sig:  prSignals{CIStatus: "FAILURE", HasPendingChecks: true},
+			want: PRPhaseBuilding,
+		},
+		{
+			name: "merge conflict → fixing",
+			sig:  prSignals{Mergeable: "CONFLICTING"},
+			want: PRPhaseFixing,
+		},
+		{
+			name: "changes requested → changes-requested",
+			sig:  prSignals{ReviewDecision: "CHANGES_REQUESTED"},
+			want: PRPhaseChangesRequested,
+		},
+		{
+			name: "unresolved threads → changes-requested",
+			sig:  prSignals{UnresolvedCount: 2},
+			want: PRPhaseChangesRequested,
+		},
+		{
+			name: "comments outrank draft so the fix dispatches",
+			sig:  prSignals{IsDraft: true, UnresolvedCount: 1},
+			want: PRPhaseChangesRequested,
+		},
+		{
+			name: "clean draft → draft",
+			sig:  prSignals{IsDraft: true},
+			want: PRPhaseDraft,
+		},
+		{
+			name: "CI pending → building",
+			sig:  prSignals{CIStatus: "PENDING"},
+			want: PRPhaseBuilding,
+		},
+		{
+			name: "pending checks flag → building",
+			sig:  prSignals{HasPendingChecks: true},
+			want: PRPhaseBuilding,
+		},
+		{
+			name: "approved and clean → approved",
+			sig:  prSignals{ReviewDecision: "APPROVED", CIStatus: "SUCCESS", Mergeable: "MERGEABLE"},
+			want: PRPhaseApproved,
+		},
+		{
+			name: "approved but CI failing → fixing wins",
+			sig:  prSignals{ReviewDecision: "APPROVED", CIStatus: "FAILURE"},
+			want: PRPhaseFixing,
+		},
+		{
+			name: "clean green not approved → awaiting approval",
+			sig:  prSignals{CIStatus: "SUCCESS", Mergeable: "MERGEABLE", ReviewDecision: "REVIEW_REQUIRED"},
+			want: PRPhaseAwaitingApproval,
+		},
+		{
+			name: "no signals → awaiting approval",
+			sig:  prSignals{},
+			want: PRPhaseAwaitingApproval,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := computePRPhase(tt.sig); got != tt.want {
+				t.Errorf("computePRPhase(%+v) = %q, want %q", tt.sig, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sybra/pr_phase_test.go
+++ b/internal/sybra/pr_phase_test.go
@@ -39,9 +39,14 @@ func TestComputePRPhase(t *testing.T) {
 			want: PRPhaseChangesRequested,
 		},
 		{
-			name: "comments outrank draft so the fix dispatches",
+			name: "draft with comments stays draft (comment-fix is skipped on drafts)",
 			sig:  prSignals{IsDraft: true, UnresolvedCount: 1},
-			want: PRPhaseChangesRequested,
+			want: PRPhaseDraft,
+		},
+		{
+			name: "draft with CI failure still shows fixing (CI-fix runs on drafts)",
+			sig:  prSignals{IsDraft: true, CIStatus: "FAILURE"},
+			want: PRPhaseFixing,
 		},
 		{
 			name: "clean draft → draft",

--- a/internal/sybra/workflow_enum_crosscheck_test.go
+++ b/internal/sybra/workflow_enum_crosscheck_test.go
@@ -38,6 +38,7 @@ func TestWorkflowFieldAllowedValues_MatchEnumSources(t *testing.T) {
 	prKinds := map[string]bool{
 		string(github.PRIssueConflict):     true,
 		string(github.PRIssueCIFailure):    true,
+		string(github.PRIssueComments):     true,
 		string(github.PRIssueReadyToMerge): true,
 	}
 
@@ -121,6 +122,12 @@ func TestPRIssueKindConstants_MatchBuiltinWorkflowTriggers(t *testing.T) {
 			wantStr:  "conflict",
 			yamlFile: "../../internal/workflow/builtin/pr-fix.yaml",
 			needle:   "value: conflict,ci_failure",
+		},
+		{
+			kind:     github.PRIssueComments,
+			wantStr:  "comments",
+			yamlFile: "../../internal/workflow/builtin/pr-fix.yaml",
+			needle:   "value: conflict,ci_failure,comments",
 		},
 	}
 	for _, tc := range cases {

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -175,11 +175,17 @@ type Task struct {
 	// needs-approval → approved (plus `manual` for small PRs punted to the
 	// human). Computed by the PR poller; drives the board's PR Reviews lane.
 	// Empty for non-review tasks.
-	ReviewPhase string     `yaml:"review_phase,omitempty" json:"reviewPhase,omitempty"`
-	TodoistID   string     `yaml:"todoist_id,omitempty" json:"todoistId"`
-	Priority    Priority   `yaml:"priority,omitempty" json:"priority,omitempty"`
-	DueDate     *time.Time `yaml:"due_date,omitempty" json:"dueDate,omitempty"`
-	ClosedAt    *time.Time `yaml:"closed_at,omitempty" json:"closedAt,omitempty"`
+	ReviewPhase string `yaml:"review_phase,omitempty" json:"reviewPhase,omitempty"`
+	// PRPhase tracks where an outbound own-PR task (status in-review/ready-review,
+	// not tag `review`) sits in its lifecycle: draft → building → fixing →
+	// changes-requested → awaiting-approval → approved. Computed by the PR poller;
+	// drives the phase glyph on the board's In Review cards. Empty for tasks
+	// without an own PR (and for inbound review tasks, which use ReviewPhase).
+	PRPhase   string     `yaml:"pr_phase,omitempty" json:"prPhase,omitempty"`
+	TodoistID string     `yaml:"todoist_id,omitempty" json:"todoistId"`
+	Priority  Priority   `yaml:"priority,omitempty" json:"priority,omitempty"`
+	DueDate   *time.Time `yaml:"due_date,omitempty" json:"dueDate,omitempty"`
+	ClosedAt  *time.Time `yaml:"closed_at,omitempty" json:"closedAt,omitempty"`
 	// MaxTurns overrides the global agent turn limit for this task.
 	// Zero means "use global default".
 	MaxTurns int `yaml:"max_turns,omitempty" json:"maxTurns,omitempty"`

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -389,6 +389,9 @@ func applyReviewFields(t *Task, u Update) {
 	if u.ReviewPhase != nil {
 		t.ReviewPhase = *u.ReviewPhase
 	}
+	if u.PRPhase != nil {
+		t.PRPhase = *u.PRPhase
+	}
 }
 
 func (s *Store) UpdateWithPrev(id string, u Update) (Task, Status, error) {

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -28,6 +28,7 @@ type Update struct {
 	Reviewed       *bool
 	RunRole        *string
 	ReviewPhase    *string
+	PRPhase        *string
 	TodoistID      *string
 	Priority       *Priority
 	DueDate        **time.Time
@@ -63,7 +64,7 @@ func applyMapField(u *Update, k string, v any) error {
 	switch k {
 	case "title", "slug", "status_reason", "blocked_by_issue", "body",
 		"project_id", "branch", "issue", "run_role", "todoist_id", "plan", "plan_critique", "code_review",
-		"review_phase":
+		"review_phase", "pr_phase":
 		return applyPlainStringField(u, k, v)
 	case "priority":
 		return applyPriorityField(u, v)
@@ -139,6 +140,8 @@ func applyPlainStringField(u *Update, k string, v any) error {
 		u.CodeReview = &s
 	case "review_phase":
 		u.ReviewPhase = &s
+	case "pr_phase":
+		u.PRPhase = &s
 	}
 	return nil
 }

--- a/internal/workflow/builtin/pr-fix.yaml
+++ b/internal/workflow/builtin/pr-fix.yaml
@@ -7,7 +7,7 @@ trigger:
   conditions:
     - field: pr.issue_kind
       operator: in
-      value: conflict,ci_failure
+      value: conflict,ci_failure,comments
 steps:
   - id: set_in_progress
     name: Mark In Progress

--- a/internal/workflow/condition.go
+++ b/internal/workflow/condition.go
@@ -75,7 +75,7 @@ var FieldAllowedValues = map[string]map[string]bool{
 		"normal": true, "debug": true, "research": true, "chat": true,
 	},
 	"pr.issue_kind": {
-		"conflict": true, "ci_failure": true, "ready_to_merge": true,
+		"conflict": true, "ci_failure": true, "comments": true, "ready_to_merge": true,
 	},
 }
 

--- a/internal/workflow/model_test.go
+++ b/internal/workflow/model_test.go
@@ -192,6 +192,23 @@ func TestValidateFields_RejectsInvalidStatus(t *testing.T) {
 // TestValidateFields_InOperatorChecksEachCSVEntry locks the csv-aware
 // validation for the `in`/`not_in` operators: a single bad entry in a list
 // of otherwise valid values must still fail.
+// The pr-fix workflow triggers on conflict,ci_failure,comments — every kind in
+// that CSV must be a recognised pr.issue_kind or DispatchEvent silently never
+// fires the comment-fix path.
+func TestValidateFields_AcceptsPRFixTriggerKinds(t *testing.T) {
+	d := Definition{
+		ID: "pr-fix-kinds",
+		Trigger: Trigger{
+			Conditions: []Condition{
+				{Field: "pr.issue_kind", Operator: "in", Value: "conflict,ci_failure,comments"},
+			},
+		},
+	}
+	if err := d.ValidateFields(); err != nil {
+		t.Errorf("ValidateFields rejected a valid kind set: %v", err)
+	}
+}
+
 func TestValidateFields_InOperatorChecksEachCSVEntry(t *testing.T) {
 	d := Definition{
 		ID: "mixed-csv",


### PR DESCRIPTION
## Motivation

The board's **In Review** column collects the user's own PRs (an agent
opened them, status `in-review`/`ready-review`). Until now they rendered
as a flat PR pill — the column showed nothing about *where* a PR sat in
its lifecycle or who needed to act, and there was no monitoring of
inbound review comments.

This brings the In Review column to parity with the **PR Reviews** lane
(#1015): each card surfaces a phase glyph and the user's pending action.

| Phase | Meaning | Needs you? |
|-------|---------|------------|
| `draft` | PR is a draft → mark it ready | red accent |
| `building` | CI still running | — |
| `fixing` | an agent is auto-fixing CI / conflict / comments | — |
| `changes-requested` | review comments present → auto-fix dispatched | — |
| `awaiting-approval` | clean + green, waiting on reviewers | — |
| `approved` | approved → merge (pet projects auto-merge) | red accent |

## Implementation information

**Backend**
- New `Task.PRPhase` overlay field (persisted like `ReviewPhase`).
- `internal/sybra/pr_phase.go` — pure, table-tested `computePRPhase`
  machine (priority-ordered).
- `internal/sybra/app_reviews_outbound.go` — `reconcilePRPhases` runs
  each poll, computing each In Review task's phase from the monitored PR
  signals. It never changes task status (tasks stay in the column) and
  clears stale phases when a task leaves it.
- Comment monitoring: new `PRIssueComments` kind fires on
  `CHANGES_REQUESTED` / unresolved threads (skips drafts) and dispatches
  a `/fix-review --auto` agent through the existing `pr-fix` workflow,
  on every project. `prNeedsAttention` polls fast when comments land.

**Frontend**
- `frontend/src/lib/pr-phase.ts` — phase metadata, icons, sort order,
  `prPhaseNeedsYou` (strict: `draft`/`approved`).
- `TaskCard.svelte` — phase glyph pill for own-PR cards; red accent for
  draft/approved; suppresses the redundant sub-state pill on phased cards.
- `TaskList.svelte` — In Review sorted by phase; toolbar "needs you"
  counter includes own-PR actions.
- Regenerated Wails bindings (only `prPhase` added).

**Design notes**
- `awaiting-approval` is a passive teal phase, not a red needs-you state
  (the PR is waiting on reviewers, not on a concrete user action).
- A single `fixing` phase covers CI-failure, conflict, and the brief
  window before a comment-fix agent spins up.

## Supporting documentation

- New tests: `pr_phase_test.go`, `app_reviews_outbound_test.go`,
  `pr-phase.test.ts`, plus `MatchTaskPRs` comment cases and the
  workflow enum cross-check / `pr.issue_kind` validation.
- Gates: `go test ./...`, `golangci-lint`, `svelte-check`, `oxlint`,
  and the full `vitest` suite (1565 tests) all pass.
