### PR TITLE
feat(handoff): Orca worktree handoff + skills

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -356,8 +356,15 @@ func cmdHandoff(s *task.Manager, ps *project.Store, args []string, jsonOut bool)
 		}
 		updates["pr_number"] = float64(*pr)
 	default:
-		// implement/review adopt the worktree, so it must be on a dedicated
-		// feature branch (enforced again at adoption).
+		// implement/review adopt the worktree. Guard that the chosen project
+		// matches the worktree's origin — a mismatched --project (or stale
+		// ProjectID) would make agents run and push against the wrong repo.
+		// Best-effort: only enforced when origin is a parseable GitHub remote.
+		if wtProj, e := deriveProjectID(dir); e == nil && !strings.EqualFold(wtProj, projectID) {
+			return fatal(jsonOut, "worktree origin is %q but --project is %q — refusing to push agent work to a different repo", wtProj, projectID)
+		}
+		// The worktree must be on a dedicated feature branch (enforced again at
+		// adoption).
 		if e := assertFeatureBranch(dir, projRec); e != nil {
 			return fatal(jsonOut, "%v", e)
 		}
@@ -433,7 +440,14 @@ func assertFeatureBranch(dir string, proj project.Project) error {
 	if branch == "" {
 		return fmt.Errorf("worktree %q is in detached HEAD — check out a feature branch before handoff", dir)
 	}
-	if def, dErr := project.DefaultBranch(proj.ClonePath); dErr == nil && branch == def {
+	// Fail closed: if the default branch can't be determined we can't prove the
+	// worktree isn't on it, so refuse rather than risk pushing agent commits to
+	// the default branch with no PR.
+	def, dErr := project.DefaultBranch(proj.ClonePath)
+	if dErr != nil {
+		return fmt.Errorf("cannot determine default branch for %q: %w", proj.ID, dErr)
+	}
+	if branch == def {
 		return fmt.Errorf("worktree %q is on the default branch %q — create a feature branch before handoff", dir, def)
 	}
 	return nil

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -16,6 +18,8 @@ import (
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/monitor"
 	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/skills"
+	"github.com/Automaat/sybra/internal/skillsync"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -69,6 +73,8 @@ func run(args []string) int {
 		return cmdGet(store, rest, jsonOut)
 	case "create":
 		return cmdCreate(store, rest, jsonOut)
+	case "handoff":
+		return cmdHandoff(store, projStore, rest, jsonOut)
 	case "update":
 		return cmdUpdate(store, rest, jsonOut)
 	case "delete":
@@ -87,6 +93,8 @@ func run(args []string) int {
 		return cmdMonitor(cfg, store, rest, jsonOut)
 	case "selfmonitor":
 		return cmdSelfmonitor(cfg, store, rest, jsonOut)
+	case "install-skills":
+		return cmdInstallSkills(cfg, jsonOut)
 	default:
 		return fatal(jsonOut, "unknown command: %s", cmd)
 	}
@@ -272,6 +280,272 @@ func cmdCreate(s *task.Manager, args []string, jsonOut bool) int {
 	}
 	fmt.Printf("Created task %s: %s\n", t.ID, t.Title)
 	return 0
+}
+
+// cmdHandoff creates a task pre-tagged `handoff` that bypasses Sybra's
+// triage/planning phases and starts implementing immediately in an existing
+// (externally created) git worktree. Intended for handing off a researched,
+// already-planned task from a tool like Orca: the human did the thinking, Sybra
+// runs the implementation autonomously in the same worktree.
+func cmdHandoff(s *task.Manager, ps *project.Store, args []string, jsonOut bool) int {
+	fs := flag.NewFlagSet("handoff", flag.ContinueOnError)
+	title := fs.String("title", "", "task title (required)")
+	body := fs.String("body", "", "task body / research context markdown")
+	plan := fs.String("plan", "", "approved plan markdown")
+	planFile := fs.String("plan-file", "", "path to a file holding the approved plan (wins over --plan)")
+	proj := fs.String("project", "", "project id (owner/repo); derived from the worktree origin remote when omitted")
+	wtDir := fs.String("worktree-dir", "", "git worktree Sybra should reuse (default: current directory)")
+	mode := fs.String("mode", "headless", "agent mode: headless|interactive")
+	stage := fs.String("stage", "implement", "stage to hand off at: implement|review|pr")
+	pr := fs.Int("pr", 0, "PR number (required for --stage pr)")
+	extraTags := fs.String("tags", "", "extra comma-separated tags")
+	if err := fs.Parse(args); err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+	if *title == "" {
+		return fatal(jsonOut, "title is required")
+	}
+	stageTags, ok := handoffStageTags(*stage)
+	if !ok {
+		return fatal(jsonOut, "invalid --stage %q (valid: implement, review, pr)", *stage)
+	}
+
+	dir, dErr := resolveWorktreeDir(*wtDir)
+	if dErr != nil {
+		return fatal(jsonOut, "%v", dErr)
+	}
+
+	// --plan-file wins over --plan so callers can stream a large plan from disk.
+	planContent := *plan
+	if *planFile != "" {
+		data, rErr := os.ReadFile(*planFile)
+		if rErr != nil {
+			return fatal(jsonOut, "read plan file: %v", rErr)
+		}
+		planContent = string(data)
+	}
+
+	// A handoff task must carry a registered project so its agents run against
+	// the right repo. Derive owner/repo from the worktree's origin when omitted.
+	projectID := *proj
+	if projectID == "" {
+		derived, e := deriveProjectID(dir)
+		if e != nil {
+			return fatal(jsonOut, "derive project from %q: %v (pass --project owner/repo)", dir, e)
+		}
+		projectID = derived
+	}
+	projRec, gErr := ps.Get(projectID)
+	if gErr != nil {
+		return fatal(jsonOut, "project %q not registered: %v (run: sybra-cli project create --url <github-url>)", projectID, gErr)
+	}
+
+	updates := map[string]any{
+		"project_id": projectID,
+		"tags":       append(stageTags, parseExtraTags(*extraTags, stageTags)...),
+	}
+	if planContent != "" {
+		updates["plan"] = planContent
+	}
+	switch *stage {
+	case "pr":
+		// Existing PR: Sybra reviews it via the pr-review lane. No worktree
+		// adoption — pr-review checks out the PR head itself.
+		if *pr <= 0 {
+			return fatal(jsonOut, "--stage pr requires --pr <number>")
+		}
+		updates["pr_number"] = float64(*pr)
+	default:
+		// implement/review adopt the worktree, so it must be on a dedicated
+		// feature branch (enforced again at adoption).
+		if e := assertFeatureBranch(dir, projRec); e != nil {
+			return fatal(jsonOut, "%v", e)
+		}
+		updates["worktree_dir"] = dir
+		if *pr > 0 {
+			updates["pr_number"] = float64(*pr)
+		}
+	}
+
+	t, err := s.Create(*title, *body, *mode)
+	if err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+	t, err = s.UpdateMap(t.ID, updates)
+	if err != nil {
+		return fatal(jsonOut, "update after create: %v", err)
+	}
+
+	if jsonOut {
+		return printJSON(t)
+	}
+	printHandoffResult(t, *stage, projectID, dir)
+	return 0
+}
+
+// handoffStageTags maps a handoff stage to the tags that route the task into
+// the right Sybra lane on creation, or (nil,false) for an unknown stage.
+//   - implement: simple-task-handoff → in-progress → implement → review → PR
+//   - review:    simple-task-handoff-review → ready-review → review → PR
+//   - pr:        pr-review lane for an existing PR
+func handoffStageTags(stage string) ([]string, bool) {
+	switch stage {
+	case "implement":
+		return []string{"handoff"}, true
+	case "review":
+		return []string{"handoff", "handoff-review"}, true
+	case "pr":
+		return []string{"review"}, true
+	default:
+		return nil, false
+	}
+}
+
+// resolveWorktreeDir resolves the handoff worktree (default: cwd) to an
+// absolute path and verifies it is an existing directory.
+func resolveWorktreeDir(wtDir string) (string, error) {
+	dir := wtDir
+	if dir == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("resolve working dir: %w", err)
+		}
+		dir = cwd
+	}
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("resolve worktree dir: %w", err)
+	}
+	if info, statErr := os.Stat(abs); statErr != nil || !info.IsDir() {
+		return "", fmt.Errorf("worktree dir %q is not a directory", abs)
+	}
+	return abs, nil
+}
+
+// assertFeatureBranch fails when the worktree is in detached HEAD (no branch to
+// push) or on the repo's default branch (would push agent commits to origin's
+// default branch with no PR).
+func assertFeatureBranch(dir string, proj project.Project) error {
+	branch, err := project.CurrentBranch(dir)
+	if err != nil {
+		return fmt.Errorf("resolve worktree branch: %w", err)
+	}
+	if branch == "" {
+		return fmt.Errorf("worktree %q is in detached HEAD — check out a feature branch before handoff", dir)
+	}
+	if def, dErr := project.DefaultBranch(proj.ClonePath); dErr == nil && branch == def {
+		return fmt.Errorf("worktree %q is on the default branch %q — create a feature branch before handoff", dir, def)
+	}
+	return nil
+}
+
+// parseExtraTags splits a comma-separated tag list, trimming blanks and any tag
+// already present in exclude (the stage tags).
+func parseExtraTags(extra string, exclude []string) []string {
+	var out []string
+	for raw := range strings.SplitSeq(extra, ",") {
+		tg := strings.TrimSpace(raw)
+		if tg == "" || slices.Contains(exclude, tg) {
+			continue
+		}
+		out = append(out, tg)
+	}
+	return out
+}
+
+func printHandoffResult(t task.Task, stage, projectID, dir string) {
+	fmt.Printf("Handed off task %s: %s\n", t.ID, t.Title)
+	fmt.Printf("  project:  %s\n", projectID)
+	switch stage {
+	case "review":
+		fmt.Printf("  worktree: %s\n", dir)
+		fmt.Println("  Sybra will skip to review and open the PR from this worktree.")
+	case "pr":
+		fmt.Printf("  pr:       #%d\n", t.PRNumber)
+		fmt.Println("  Sybra will review the existing PR.")
+	default:
+		fmt.Printf("  worktree: %s\n", dir)
+		fmt.Println("  Sybra will skip planning and start implementing in this worktree.")
+	}
+}
+
+// deriveProjectID reads the origin remote of a git worktree and converts it to
+// a Sybra project id (owner/repo).
+func deriveProjectID(dir string) (string, error) {
+	out, err := exec.Command("git", "-C", dir, "remote", "get-url", "origin").Output()
+	if err != nil {
+		return "", fmt.Errorf("git remote get-url origin: %w", err)
+	}
+	owner, repo, err := project.ParseGitHubURL(strings.TrimSpace(string(out)))
+	if err != nil {
+		return "", err
+	}
+	return owner + "/" + repo, nil
+}
+
+// cmdInstallSkills mirrors Sybra's bundled skills into the per-agent skill
+// directories (~/.claude/skills, ~/.codex/skills, ~/.agents/skills) plus the
+// app's skills dir, so the skills are available in interactive Claude Code and
+// Codex sessions in any repo. Reuses the same skillsync.Syncer the app runs at
+// startup, so behaviour (frontmatter validation, orphan pruning) is identical.
+func cmdInstallSkills(cfg *config.Config, jsonOut bool) int {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fatal(jsonOut, "resolve home dir: %v", err)
+	}
+
+	// Resolve the skill source. Prefer a configured RepoDir; otherwise fall
+	// back to cwd ONLY when it is genuinely the sybra source repo (matching the
+	// app's launched-from-repo behaviour, which provides the richer dir-based
+	// skills). When cwd is some other repo, point at a path without a go.mod so
+	// the syncer uses the embedded bundle instead of installing the wrong
+	// repo's skills.
+	repoDir := cfg.RepoDir
+	if repoDir == "" {
+		if cwd, cwdErr := os.Getwd(); cwdErr == nil && isSybraRepo(cwd) {
+			repoDir = cwd
+		} else {
+			repoDir = config.HomeDir()
+		}
+	}
+
+	var logger *slog.Logger
+	if !jsonOut {
+		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	}
+	(&skillsync.Syncer{Logger: logger}).Run(skillsync.Options{
+		RepoDir:      repoDir,
+		SkillsFS:     skills.FS,
+		PrimaryDst:   cfg.SkillsDir,
+		SybraHomeDir: config.HomeDir(),
+		UserHomeDir:  home,
+	})
+
+	dsts := []string{
+		cfg.SkillsDir,
+		filepath.Join(home, ".claude", "skills"),
+		filepath.Join(home, ".codex", "skills"),
+		filepath.Join(home, ".agents", "skills"),
+	}
+	if jsonOut {
+		return printJSON(map[string]any{"status": "ok", "destinations": dsts})
+	}
+	fmt.Println("Installed Sybra skills to:")
+	for _, d := range dsts {
+		fmt.Printf("  %s\n", d)
+	}
+	return 0
+}
+
+// isSybraRepo reports whether dir is the sybra source checkout, by matching the
+// module path in its go.mod. Used to gate the cwd fallback in install-skills so
+// it never installs an unrelated repo's skills.
+func isSybraRepo(dir string) bool {
+	data, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), "module github.com/Automaat/sybra")
 }
 
 // findActiveDuplicate looks for an existing non-terminal task that matches
@@ -953,6 +1227,13 @@ Commands:
   get      <id>
   create   --title TITLE [--body BODY] [--plan PLAN] [--mode MODE] [--type TYPE] [--tags t1,t2] [--project ID] [--branch B] [--pr N] [--issue URL] [--allow-dup]
            TYPE: normal|debug|research
+  handoff  --title TITLE [--body BODY] [--plan PLAN | --plan-file PATH] [--project ID] [--worktree-dir DIR] [--stage STAGE] [--pr N] [--mode MODE] [--tags t1,t2]
+           Hand a task to Sybra at any stage, reusing the given git worktree
+           (default: cwd). Project is derived from the worktree's origin remote
+           when --project is omitted. STAGE (default implement):
+             implement  have a plan → Sybra implements, reviews, opens the PR
+             review     implemented locally → Sybra reviews + opens the PR
+             pr         existing PR (--pr N) → Sybra reviews the PR
   update   <id> [--title T] [--status S] [--status-reason R] [--body B] [--plan PLAN] [--plan-file PATH] [--mode M] [--type TYPE] [--tags T] [--project ID] [--branch B] [--pr N] [--issue URL] [--max-turns N]
   delete   <id>
 
@@ -969,6 +1250,10 @@ Commands:
 
   triage classify <id>         Classify a single task via claude -p and apply the verdict.
   triage classify --all        Classify every task with status=new.
+
+  install-skills               Install/refresh Sybra's bundled skills into
+                               ~/.claude/skills, ~/.codex/skills, ~/.agents/skills
+                               (and the app skills dir) for Claude Code + Codex.
 
 Global flags:
   --json   Output as JSON`)

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -164,6 +164,16 @@ export class Task {
     "tags": string[];
     "projectId": string;
     "branch": string;
+
+    /**
+     * WorktreeDir, when non-empty, makes Sybra adopt an externally-created git
+     * worktree at this path instead of creating its own under
+     * ~/.sybra/worktrees. Used for handoff from tools like Orca: every agent
+     * for this task runs in this directory, and Sybra never rebases, force-
+     * pushes, or removes it — the external tool owns its lifecycle. Empty =
+     * Sybra-managed worktree (default).
+     */
+    "worktreeDir"?: string;
     "prNumber": number;
     "issue": string;
     "statusReason": string;
@@ -318,9 +328,9 @@ export class Task {
     static createFrom($$source: any = {}): Task {
         const $$createField6_0 = $$createType0;
         const $$createField7_0 = $$createType0;
-        const $$createField25_0 = $$createType2;
-        const $$createField26_0 = $$createType4;
-        const $$createField33_0 = $$createType5;
+        const $$createField26_0 = $$createType2;
+        const $$createField27_0 = $$createType4;
+        const $$createField34_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -329,13 +339,13 @@ export class Task {
             $$parsedSource["tags"] = $$createField7_0($$parsedSource["tags"]);
         }
         if ("agentRuns" in $$parsedSource) {
-            $$parsedSource["agentRuns"] = $$createField25_0($$parsedSource["agentRuns"]);
+            $$parsedSource["agentRuns"] = $$createField26_0($$parsedSource["agentRuns"]);
         }
         if ("workflow" in $$parsedSource) {
-            $$parsedSource["workflow"] = $$createField26_0($$parsedSource["workflow"]);
+            $$parsedSource["workflow"] = $$createField27_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField33_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField34_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }

--- a/internal/skills/data/sybra-handoff.md
+++ b/internal/skills/data/sybra-handoff.md
@@ -65,9 +65,9 @@ Stages:
    thought through; one that says "update the auth code" has not. Write the
    former.
 
-3. **Pick a conventional-commit title** (`type(scope): summary`, ≤50 chars), e.g.
-   `feat(auth): add jwt refresh middleware`. Sybra derives the branch prefix from
-   it.
+3. **Pick a clear title** (`type(scope): summary`, ≤50 chars), e.g.
+   `feat(auth): add jwt refresh middleware`. The implement/review handoff keeps
+   the worktree's existing branch — the title only names the task.
 
 4. **Run the handoff** from the worktree root:
    ```bash

--- a/internal/skills/data/sybra-handoff.md
+++ b/internal/skills/data/sybra-handoff.md
@@ -1,0 +1,110 @@
+---
+name: sybra-handoff
+description: Hand a researched, already-decided task off to Sybra for autonomous implementation. Use after you have explored a problem in an Orca (or any) git worktree, agreed on the approach, and want Sybra to skip its own planning and start implementing immediately — reusing this exact worktree. Triggers on "hand this off to Sybra", "let Sybra implement this", "ship this to Sybra", "handoff to sybra". Works under both Claude Code and Codex.
+allowed-tools: Bash
+user-invocable: true
+argument-hint: "[--title \"...\"] [--plan-file PATH] [--worktree-dir DIR]"
+---
+
+# Sybra Handoff
+
+Hand the **current** worktree's task to Sybra for autonomous implementation. The
+human did the research and chose the approach here; Sybra takes the agreed plan
+and implements it **without re-planning**, running its agents **in this same
+worktree** so the work lands where you were just looking.
+
+This is the Orca → Sybra seam: Orca is the research/planning phase, Sybra is the
+autonomous execution phase.
+
+## When to use
+
+Hand off at whatever stage you have reached — Sybra picks up from there:
+- You have a **plan** but have not implemented → `--stage implement` (default).
+- You have **implemented** locally and want review + PR → `--stage review`.
+- You already **opened a PR** and want Sybra to review it → `--stage pr --pr N`.
+
+In all cases the approach is decided and you want Sybra to carry it the rest of
+the way autonomously. Do **not** use for exploratory work that still needs human
+direction — keep that in Orca.
+
+## What it does
+
+`sybra-cli handoff` creates a task that skips straight to the requested stage —
+no triage, no planning gate — and (for implement/review) reuses **this** git
+worktree (`--worktree-dir`, default: cwd) instead of cutting a fresh one: no
+rebase, no force-push, and Sybra never deletes it.
+
+Stages:
+- **implement** (default): flips to `in-progress`; the implementation agent runs
+  now with your plan as context, then review → PR.
+- **review**: flips to `ready-review`; Sybra reviews your existing commits in the
+  worktree and opens the PR (no implementation step).
+- **pr**: for an existing PR (`--pr N`); Sybra reviews the open PR via its
+  pr-review lane (no worktree adoption — it checks out the PR head itself).
+
+## Procedure
+
+1. **Confirm the worktree and branch.** Run from the worktree root:
+   ```bash
+   pwd && git rev-parse --abbrev-ref HEAD && git remote get-url origin
+   ```
+   The branch must not be the default branch (Sybra commits + opens a PR on it).
+   The origin remote must be a GitHub repo registered as a Sybra project.
+
+2. **Write the approved plan to a file.** Synthesize the decision reached in this
+   session into a concrete, file-level plan (name the files and symbols to
+   change, the ordered steps, and how to verify each), then write it to a file
+   in the worktree — e.g. via a heredoc so this works with shell-only tools:
+   ```bash
+   cat > ./.sybra-handoff-plan.md <<'PLAN'
+   # Plan
+   ... your file-level plan here ...
+   PLAN
+   ```
+   A plan that names `verify_jwt_token` at `auth/middleware.go:42` has been
+   thought through; one that says "update the auth code" has not. Write the
+   former.
+
+3. **Pick a conventional-commit title** (`type(scope): summary`, ≤50 chars), e.g.
+   `feat(auth): add jwt refresh middleware`. Sybra derives the branch prefix from
+   it.
+
+4. **Run the handoff** from the worktree root:
+   ```bash
+   sybra-cli handoff \
+     --title "feat(auth): add jwt refresh middleware" \
+     --body  "One-paragraph problem statement + the research context Sybra needs." \
+     --plan-file ./.sybra-handoff-plan.md
+   ```
+   - `--stage review` to skip implementation (you already coded it); `--stage pr
+     --pr N` to hand off an existing PR. Default is `--stage implement`.
+   - `--plan-file` matters most for `--stage implement`; for `review`/`pr` it is
+     optional context.
+   - `--worktree-dir` defaults to the current directory; pass it explicitly if you
+     run the command from elsewhere.
+   - `--project` is derived from the origin remote; pass `--project owner/repo`
+     only if derivation fails (the command will tell you).
+
+5. **Report back** the printed task id and that Sybra is now implementing in this
+   worktree. The user can watch the changes land here live (e.g. in Orca's diff
+   view).
+
+## Failure handling
+
+- **"project … not registered"** — register it first, then re-run:
+  ```bash
+  sybra-cli project create --url "$(git remote get-url origin)"
+  ```
+- **Branch is the default branch** — create/switch to a feature branch before
+  handing off; Sybra must not commit to `main`.
+- **Sybra not running** — the task is created but stays at `todo` until the local
+  Sybra app/server picks up the `task.created` event. Start Sybra, no re-run
+  needed.
+
+## Notes
+
+- Nothing about the handoff modifies your working tree — Sybra's agent does the
+  editing once it starts. Commit or stash anything you want preserved as-is first
+  if it matters.
+- The handoff is one-directional. To stop it, manage the task in Sybra
+  (`sybra-cli update <id> --status cancelled`).

--- a/internal/skillsync/copy.go
+++ b/internal/skillsync/copy.go
@@ -49,6 +49,15 @@ func copyDirTree(src, dst string) error {
 	})
 }
 
+// userOwnedSkill reports whether a destination skill dir is a symlink — a
+// skill the user manages themselves (e.g. symlinked from their dotfiles). The
+// syncer owns only the real directories it creates and must never overwrite a
+// user-owned symlink, so every write path skips these.
+func userOwnedSkill(skillDir string) bool {
+	info, err := os.Lstat(skillDir)
+	return err == nil && info.Mode()&os.ModeSymlink != 0
+}
+
 // copySkillDir validates and recursively copies a directory-style skill
 // (src/<name>/SKILL.md + siblings) to dst/<name>/. Returns true if the copy
 // succeeded. Missing/malformed SKILL.md and traversal/IO errors are logged
@@ -64,6 +73,10 @@ func (s *Syncer) copySkillDir(src, dst, cleanSrc, cleanDst, name, logPrefix stri
 		return false
 	}
 	dstSkillDir := filepath.Join(filepath.Clean(dst), name)
+	if userOwnedSkill(dstSkillDir) {
+		s.info(logPrefix+".skip.user_owned", "name", name)
+		return false
+	}
 	if !strings.HasPrefix(srcSkillDir+string(filepath.Separator), cleanSrc) ||
 		!strings.HasPrefix(dstSkillDir+string(filepath.Separator), cleanDst) {
 		s.warn(logPrefix+".skip.traversal", "name", name)

--- a/internal/skillsync/copy.go
+++ b/internal/skillsync/copy.go
@@ -55,7 +55,10 @@ func copyDirTree(src, dst string) error {
 // user-owned symlink, so every write path skips these.
 func userOwnedSkill(skillDir string) bool {
 	info, err := os.Lstat(skillDir)
-	return err == nil && info.Mode()&os.ModeSymlink != 0
+	if err != nil || info == nil {
+		return false
+	}
+	return info.Mode()&os.ModeSymlink != 0
 }
 
 // copySkillDir validates and recursively copies a directory-style skill

--- a/internal/skillsync/syncer.go
+++ b/internal/skillsync/syncer.go
@@ -1,7 +1,7 @@
 // Package skillsync mirrors Claude Code skill files from a source
 // (repository checkout or embedded fs.FS) into one or more destinations
-// (the app's skills dir, ~/.claude/skills, ~/.codex/skills). Validates
-// YAML frontmatter on each .md file and prunes orphan skill subdirs
+// (the app's skills dir, ~/.claude/skills, ~/.codex/skills, ~/.agents/skills).
+// Validates YAML frontmatter on each .md file and prunes orphan skill subdirs
 // from the destination.
 package skillsync
 
@@ -110,20 +110,25 @@ func (s *Syncer) Run(opts Options) {
 	s.info("skills.sync.done")
 }
 
-// destinations returns PrimaryDst plus ~/.claude/skills and ~/.codex/skills
-// when UserHomeDir is set, deduplicating against PrimaryDst (some test
-// setups point PrimaryDst at the user's claude dir).
+// destinations returns PrimaryDst plus the per-agent skill directories
+// (~/.claude/skills, ~/.codex/skills, ~/.agents/skills) when UserHomeDir is
+// set, deduplicating against PrimaryDst (some test setups point PrimaryDst at
+// the user's claude dir). ~/.agents/skills is the cross-agent location read by
+// Orca-launched agents and newer Codex builds.
 func (s *Syncer) destinations(primary, userHome string) []string {
 	dsts := []string{primary}
 	if userHome == "" {
 		return dsts
 	}
-	claudeDst := filepath.Join(userHome, ".claude", "skills")
-	codexDst := filepath.Join(userHome, ".codex", "skills")
-	if filepath.Clean(primary) != filepath.Clean(claudeDst) {
-		dsts = append(dsts, claudeDst)
+	for _, agentDir := range []string{
+		filepath.Join(userHome, ".claude", "skills"),
+		filepath.Join(userHome, ".codex", "skills"),
+		filepath.Join(userHome, ".agents", "skills"),
+	} {
+		if filepath.Clean(primary) != filepath.Clean(agentDir) {
+			dsts = append(dsts, agentDir)
+		}
 	}
-	dsts = append(dsts, codexDst)
 	return dsts
 }
 
@@ -194,6 +199,10 @@ func (s *Syncer) syncDir(src, dst string, prune bool) map[string]struct{} {
 			s.warn("sync.skill.skip.traversal", "name", e.Name())
 			continue
 		}
+		if userOwnedSkill(skillDir) {
+			s.info("sync.skill.skip.user_owned", "skill", name)
+			continue
+		}
 		dstPath := filepath.Join(skillDir, "SKILL.md")
 		data, err := os.ReadFile(srcPath)
 		if err != nil {
@@ -249,6 +258,10 @@ func (s *Syncer) syncFS(fsys fs.FS, srcDir, dst string, prune bool) map[string]s
 		skillDir := filepath.Join(filepath.Clean(dst), name)
 		if !strings.HasPrefix(skillDir+string(filepath.Separator), cleanDst) {
 			s.warn("sync.skill.skip.traversal", "name", e.Name())
+			continue
+		}
+		if userOwnedSkill(skillDir) {
+			s.info("sync.skill.skip.user_owned", "skill", name)
 			continue
 		}
 		dstPath := filepath.Join(skillDir, "SKILL.md")

--- a/internal/skillsync/syncer_test.go
+++ b/internal/skillsync/syncer_test.go
@@ -214,6 +214,37 @@ func TestSyncDirMissingSrc(t *testing.T) {
 	}
 }
 
+// TestSyncDirSkipsUserOwnedSymlink locks that the syncer never overwrites a
+// destination skill the user owns as a symlink (e.g. one symlinked from their
+// dotfiles), even when a bundle skill shares its name.
+func TestSyncDirSkipsUserOwnedSymlink(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "shared.md"),
+		[]byte("---\nname: shared\ndescription: from sybra\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := t.TempDir()
+	userSrc := t.TempDir()
+	if err := os.WriteFile(filepath.Join(userSrc, "SKILL.md"), []byte("USER OWNED"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(userSrc, filepath.Join(dst, "shared")); err != nil {
+		t.Fatal(err)
+	}
+
+	newSyncer().SyncDir(src, dst)
+
+	info, err := os.Lstat(filepath.Join(dst, "shared"))
+	if err != nil || info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("user-owned symlink was replaced (err=%v)", err)
+	}
+	got, _ := os.ReadFile(filepath.Join(dst, "shared", "SKILL.md"))
+	if string(got) != "USER OWNED" {
+		t.Errorf("user content overwritten: %q", got)
+	}
+}
+
 func TestRunPrefersEmbeddedWhenNoGoMod(t *testing.T) {
 	embeddedSrc := filepath.Join(t.TempDir(), "embedded")
 	dataDir := filepath.Join(embeddedSrc, "data")
@@ -246,6 +277,39 @@ func TestRunPrefersEmbeddedWhenNoGoMod(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(primaryDst, "rogue")); !os.IsNotExist(err) {
 		t.Errorf("rogue skill leaked into app skills dir")
+	}
+}
+
+// TestRunInstallsToAgentDirs locks that Run mirrors skills into all three
+// per-agent destinations — ~/.claude/skills, ~/.codex/skills, and the
+// cross-agent ~/.agents/skills (read by Orca-launched agents) — when
+// UserHomeDir is set.
+func TestRunInstallsToAgentDirs(t *testing.T) {
+	embeddedSrc := filepath.Join(t.TempDir(), "embedded")
+	dataDir := filepath.Join(embeddedSrc, "data")
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	skill := []byte("---\nname: embedded-skill\ndescription: from embed\n---\n\n# embed")
+	if err := os.WriteFile(filepath.Join(dataDir, "embedded-skill.md"), skill, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	userHome := t.TempDir()
+	newSyncer().Run(skillsync.Options{
+		// A path without go.mod forces embedded mode (no cwd fallback to the
+		// real repo this test runs in).
+		RepoDir:     filepath.Join(t.TempDir(), "not-a-repo"),
+		SkillsFS:    os.DirFS(embeddedSrc),
+		PrimaryDst:  filepath.Join(t.TempDir(), "app-skills"),
+		UserHomeDir: userHome,
+	})
+
+	for _, dir := range []string{".claude", ".codex", ".agents"} {
+		p := filepath.Join(userHome, dir, "skills", "embedded-skill", "SKILL.md")
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("skill missing in %s/skills: %v", dir, err)
+		}
 	}
 }
 

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -161,9 +161,16 @@ type Task struct {
 	Tags         []string `yaml:"tags" json:"tags"`
 	ProjectID    string   `yaml:"project_id,omitempty" json:"projectId"`
 	Branch       string   `yaml:"branch,omitempty" json:"branch"`
-	PRNumber     int      `yaml:"pr_number,omitempty" json:"prNumber"`
-	Issue        string   `yaml:"issue,omitempty" json:"issue"`
-	StatusReason string   `yaml:"status_reason,omitempty" json:"statusReason"`
+	// WorktreeDir, when non-empty, makes Sybra adopt an externally-created git
+	// worktree at this path instead of creating its own under
+	// ~/.sybra/worktrees. Used for handoff from tools like Orca: every agent
+	// for this task runs in this directory, and Sybra never rebases, force-
+	// pushes, or removes it — the external tool owns its lifecycle. Empty =
+	// Sybra-managed worktree (default).
+	WorktreeDir  string `yaml:"worktree_dir,omitempty" json:"worktreeDir,omitempty"`
+	PRNumber     int    `yaml:"pr_number,omitempty" json:"prNumber"`
+	Issue        string `yaml:"issue,omitempty" json:"issue"`
+	StatusReason string `yaml:"status_reason,omitempty" json:"statusReason"`
 	// BlockedByIssue stores the URL of the GitHub issue that put the task
 	// into status=blocked. Set by the human-review automation when it
 	// concludes the human-required transition was caused by a Sybra bug.

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -394,6 +394,26 @@ func applyReviewFields(t *Task, u Update) {
 	}
 }
 
+// applyLinkFields applies the repo-location fields (project, branch, adopted
+// worktree dir, PR, issue) that tie a task to its code.
+func applyLinkFields(t *Task, u Update) {
+	if u.ProjectID != nil {
+		t.ProjectID = *u.ProjectID
+	}
+	if u.Branch != nil {
+		t.Branch = *u.Branch
+	}
+	if u.WorktreeDir != nil {
+		t.WorktreeDir = *u.WorktreeDir
+	}
+	if u.PRNumber != nil {
+		t.PRNumber = *u.PRNumber
+	}
+	if u.Issue != nil {
+		t.Issue = *u.Issue
+	}
+}
+
 func (s *Store) UpdateWithPrev(id string, u Update) (Task, Status, error) {
 	t, err := s.read(id)
 	if err != nil {
@@ -449,18 +469,7 @@ func (s *Store) UpdateWithPrev(id string, u Update) (Task, Status, error) {
 	if u.Tags != nil {
 		t.Tags = *u.Tags
 	}
-	if u.ProjectID != nil {
-		t.ProjectID = *u.ProjectID
-	}
-	if u.Branch != nil {
-		t.Branch = *u.Branch
-	}
-	if u.PRNumber != nil {
-		t.PRNumber = *u.PRNumber
-	}
-	if u.Issue != nil {
-		t.Issue = *u.Issue
-	}
+	applyLinkFields(&t, u)
 	if u.Reviewed != nil {
 		t.Reviewed = *u.Reviewed
 	}

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -23,6 +23,7 @@ type Update struct {
 	Tags           *[]string
 	ProjectID      *string
 	Branch         *string
+	WorktreeDir    *string
 	PRNumber       *int
 	Issue          *string
 	Reviewed       *bool
@@ -63,7 +64,7 @@ func UpdateFromMap(raw map[string]any) (Update, error) {
 func applyMapField(u *Update, k string, v any) error {
 	switch k {
 	case "title", "slug", "status_reason", "blocked_by_issue", "body",
-		"project_id", "branch", "issue", "run_role", "todoist_id", "plan", "plan_critique", "code_review",
+		"project_id", "branch", "worktree_dir", "issue", "run_role", "todoist_id", "plan", "plan_critique", "code_review",
 		"review_phase", "pr_phase":
 		return applyPlainStringField(u, k, v)
 	case "priority":
@@ -126,6 +127,8 @@ func applyPlainStringField(u *Update, k string, v any) error {
 		u.ProjectID = &s
 	case "branch":
 		u.Branch = &s
+	case "worktree_dir":
+		u.WorktreeDir = &s
 	case "issue":
 		u.Issue = &s
 	case "run_role":

--- a/internal/workflow/builtin/simple-task-handoff-review.yaml
+++ b/internal/workflow/builtin/simple-task-handoff-review.yaml
@@ -1,0 +1,30 @@
+id: simple-task-handoff-review
+name: Simple Task — Handoff (Review)
+description: >-
+  A task handed off from an external tool (e.g. Orca) that is already
+  implemented in its worktree and only needs review + PR creation. Skip
+  triage/planning/implementation; flip straight to ready-review so
+  simple-task-review reviews the adopted worktree and opens the PR. The cascade
+  in OnWorkflowComplete picks up the status_changed event.
+builtin: true
+trigger:
+  on: task.created
+  conditions:
+    - field: task.tags
+      operator: contains
+      value: handoff-review
+    # A PR-review task (tag `review`) is its own lane; never collide with it.
+    - field: task.tags
+      operator: not_contains
+      value: review
+steps:
+  # No triage, planning, or implementation agent — a single deterministic status
+  # flip into the review lane. simple-task-review runs its review agents in the
+  # adopted worktree (worktree_dir) and creates the PR from the existing commits.
+  - id: set_ready_review
+    name: Hand Off to Review
+    type: set_status
+    config:
+      status: ready-review
+    next:
+      - goto: ""

--- a/internal/workflow/builtin/simple-task-handoff.yaml
+++ b/internal/workflow/builtin/simple-task-handoff.yaml
@@ -1,0 +1,35 @@
+id: simple-task-handoff
+name: Simple Task — Handoff
+description: >-
+  A task handed off from an external tool (e.g. Orca) that already carries the
+  approved plan in its body/plan. Skip triage and planning entirely; flip the
+  task straight to in-progress so simple-task-implement runs the implementation
+  agent. The cascade in OnWorkflowComplete picks up the status_changed event.
+builtin: true
+trigger:
+  on: task.created
+  conditions:
+    - field: task.tags
+      operator: contains
+      value: handoff
+    # The review-stage handoff (handoff-review) is handled by
+    # simple-task-handoff-review; this workflow owns the implement stage only.
+    - field: task.tags
+      operator: not_contains
+      value: handoff-review
+    # A PR-review task (tag `review`) is its own lane; never collide with it.
+    - field: task.tags
+      operator: not_contains
+      value: review
+steps:
+  # No triage, no planning agent — a single deterministic status flip. The
+  # implementation agent receives the handed-off plan via {{.Task.Plan}} in
+  # simple-task-implement. The agent runs in the adopted worktree when the
+  # task carries an explicit worktree_dir.
+  - id: set_in_progress
+    name: Hand Off to Implement
+    type: set_status
+    config:
+      status: in-progress
+    next:
+      - goto: ""

--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -8,6 +8,12 @@ trigger:
     - field: task.tags
       operator: not_contains
       value: review
+    # Handoff tasks arrive with a finished plan from an external tool (e.g.
+    # Orca) and are driven by simple-task-handoff straight to implementation.
+    # Excluding them here keeps triage/planning from also firing on create.
+    - field: task.tags
+      operator: not_contains
+      value: handoff
 steps:
   - id: triage
     name: Triage

--- a/internal/workflow/handoff_test.go
+++ b/internal/workflow/handoff_test.go
@@ -1,0 +1,83 @@
+package workflow
+
+import "testing"
+
+func hasCondition(conds []Condition, field, op, value string) bool {
+	for _, c := range conds {
+		if c.Field == field && c.Operator == op && c.Value == value {
+			return true
+		}
+	}
+	return false
+}
+
+func defByID(t *testing.T, id string) *Definition {
+	t.Helper()
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	for i := range defs {
+		if defs[i].ID == id {
+			return &defs[i]
+		}
+	}
+	t.Fatalf("%s builtin definition not found", id)
+	return nil
+}
+
+// TestBuiltinHandoff_SkipsPlanningToImplement locks the handoff contract: a
+// task tagged `handoff` fires simple-task-handoff on creation, which flips it
+// straight to in-progress (no triage, no planning) so simple-task-implement
+// runs. simple-task-plan must exclude handoff tasks so it does not also fire.
+func TestBuiltinHandoff_SkipsPlanningToImplement(t *testing.T) {
+	t.Parallel()
+
+	handoff := defByID(t, "simple-task-handoff")
+	if handoff.Trigger.On != "task.created" {
+		t.Errorf("handoff trigger.on = %q, want task.created", handoff.Trigger.On)
+	}
+	if !hasCondition(handoff.Trigger.Conditions, "task.tags", "contains", "handoff") {
+		t.Errorf("handoff trigger must require tag handoff; got %+v", handoff.Trigger.Conditions)
+	}
+	first := handoff.FirstStep()
+	if first == nil || first.Type != StepSetStatus || first.Config.Status != "in-progress" {
+		t.Errorf("handoff first step must set status in-progress; got %+v", first)
+	}
+
+	// simple-task-plan must NOT fire for handoff tasks.
+	plan := defByID(t, "simple-task-plan")
+	if !hasCondition(plan.Trigger.Conditions, "task.tags", "not_contains", "handoff") {
+		t.Errorf("simple-task-plan must exclude handoff tasks; got %+v", plan.Trigger.Conditions)
+	}
+	// The implement-stage handoff must NOT also fire for review-stage tasks.
+	if !hasCondition(handoff.Trigger.Conditions, "task.tags", "not_contains", "handoff-review") {
+		t.Errorf("simple-task-handoff must exclude handoff-review tasks; got %+v", handoff.Trigger.Conditions)
+	}
+}
+
+// TestBuiltinHandoffReview_SkipsToReview locks the review-stage contract: a task
+// tagged `handoff-review` fires simple-task-handoff-review on creation, which
+// flips it straight to ready-review (no implement) so simple-task-review reviews
+// the adopted worktree and opens the PR.
+func TestBuiltinHandoffReview_SkipsToReview(t *testing.T) {
+	t.Parallel()
+
+	hr := defByID(t, "simple-task-handoff-review")
+	if hr.Trigger.On != "task.created" {
+		t.Errorf("handoff-review trigger.on = %q, want task.created", hr.Trigger.On)
+	}
+	if !hasCondition(hr.Trigger.Conditions, "task.tags", "contains", "handoff-review") {
+		t.Errorf("handoff-review trigger must require tag handoff-review; got %+v", hr.Trigger.Conditions)
+	}
+	first := hr.FirstStep()
+	if first == nil || first.Type != StepSetStatus || first.Config.Status != "ready-review" {
+		t.Errorf("handoff-review first step must set status ready-review; got %+v", first)
+	}
+
+	// simple-task-review enters on ready-review, so the cascade reaches it.
+	review := defByID(t, "simple-task-review")
+	if !hasCondition(review.Trigger.Conditions, "task.status", "equals", "ready-review") {
+		t.Errorf("simple-task-review must trigger on status=ready-review; got %+v", review.Trigger.Conditions)
+	}
+}

--- a/internal/worktree/adopt_test.go
+++ b/internal/worktree/adopt_test.go
@@ -1,0 +1,125 @@
+package worktree
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// TestPrepareForTask_AdoptsExternalWorktree verifies that a task carrying an
+// explicit WorktreeDir is run in that directory verbatim: PrepareForTask
+// returns the external path, records its branch, drops the identity beacon,
+// creates nothing under the managed worktrees dir, and Remove leaves it alone.
+func TestPrepareForTask_AdoptsExternalWorktree(t *testing.T) {
+	h := prepareHarness(t, nil, 0)
+
+	// Simulate an Orca-created worktree: a real linked worktree off the bare
+	// clone, checked out on its own branch.
+	ext := filepath.Join(t.TempDir(), "orca-worktree")
+	const extBranch = "orca/feature-x"
+	if out, err := exec.Command("git", "-C", h.proj.ClonePath, "worktree", "add", "-b", extBranch, ext, "main").CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v: %s", err, out)
+	}
+
+	tk, err := h.tasks.Create("adopt me", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = h.tasks.UpdateMap(tk.ID, map[string]any{
+		"project_id":   h.proj.ID,
+		"worktree_dir": ext,
+	})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	got, err := h.m.PrepareForTask(tk, nil)
+	if err != nil {
+		t.Fatalf("PrepareForTask: %v", err)
+	}
+	if got != ext {
+		t.Fatalf("adopted path = %q, want %q", got, ext)
+	}
+
+	// Beacon written into the adopted dir.
+	if _, err := os.Stat(filepath.Join(ext, contextFileName)); err != nil {
+		t.Errorf("context beacon not written: %v", err)
+	}
+
+	// Branch recorded from the adopted worktree's checkout.
+	reloaded, err := h.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if reloaded.Branch != extBranch {
+		t.Errorf("task branch = %q, want %q", reloaded.Branch, extBranch)
+	}
+
+	// Nothing created under the managed worktrees dir.
+	entries, err := os.ReadDir(h.wtDir)
+	if err != nil {
+		t.Fatalf("read worktrees dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("managed worktrees dir not empty: %v", entries)
+	}
+
+	// Remove must not delete an adopted worktree.
+	h.m.Remove(tk.ID)
+	if _, err := os.Stat(ext); err != nil {
+		t.Errorf("adopted worktree removed by cleanup: %v", err)
+	}
+}
+
+// TestPrepareForTask_AdoptRejectsMissingDir verifies adoption fails cleanly
+// when the declared worktree directory does not exist.
+func TestPrepareForTask_AdoptRejectsMissingDir(t *testing.T) {
+	h := prepareHarness(t, nil, 0)
+
+	tk := task.Task{
+		ID:          "deadbeef",
+		Title:       "bad adopt",
+		ProjectID:   h.proj.ID,
+		WorktreeDir: filepath.Join(t.TempDir(), "does-not-exist"),
+	}
+	if _, err := h.m.PrepareForTask(tk, nil); err == nil {
+		t.Fatal("expected error for missing adopted worktree dir, got nil")
+	}
+}
+
+// TestPrepareForTask_AdoptRejectsDefaultBranch guards the blocker: adopting a
+// worktree sitting on the repo's default branch would push the agent's commits
+// straight to origin's default branch with no PR. Adoption must refuse it.
+func TestPrepareForTask_AdoptRejectsDefaultBranch(t *testing.T) {
+	h := prepareHarness(t, nil, 0)
+
+	ext := filepath.Join(t.TempDir(), "orca-on-main")
+	if out, err := exec.Command("git", "-C", h.proj.ClonePath, "worktree", "add", ext, "main").CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v: %s", err, out)
+	}
+
+	tk := task.Task{ID: "cafe1234", Title: "adopt main", ProjectID: h.proj.ID, WorktreeDir: ext}
+	if _, err := h.m.PrepareForTask(tk, nil); err == nil {
+		t.Fatal("expected error adopting a worktree on the default branch, got nil")
+	}
+}
+
+// TestPrepareForTask_AdoptRejectsDetachedHead guards the empty-branch path: a
+// detached-HEAD worktree has no branch to push, so adoption must refuse rather
+// than silently proceed with an empty branch.
+func TestPrepareForTask_AdoptRejectsDetachedHead(t *testing.T) {
+	h := prepareHarness(t, nil, 0)
+
+	ext := filepath.Join(t.TempDir(), "orca-detached")
+	if out, err := exec.Command("git", "-C", h.proj.ClonePath, "worktree", "add", "--detach", ext, "main").CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add --detach: %v: %s", err, out)
+	}
+
+	tk := task.Task{ID: "beef5678", Title: "adopt detached", ProjectID: h.proj.ID, WorktreeDir: ext}
+	if _, err := h.m.PrepareForTask(tk, nil); err == nil {
+		t.Fatal("expected error adopting a detached-HEAD worktree, got nil")
+	}
+}

--- a/internal/worktree/cleanup.go
+++ b/internal/worktree/cleanup.go
@@ -17,7 +17,7 @@ func (m *Manager) Remove(taskID string) {
 	}
 	// Never touch an externally-adopted worktree: the tool that created it
 	// (e.g. Orca) owns its lifecycle. Removing it would delete the user's
-	// checkout out from under them.
+	// checkout from under them.
 	if t.WorktreeDir != "" {
 		return
 	}

--- a/internal/worktree/cleanup.go
+++ b/internal/worktree/cleanup.go
@@ -15,6 +15,12 @@ func (m *Manager) Remove(taskID string) {
 	if err != nil || t.ProjectID == "" {
 		return
 	}
+	// Never touch an externally-adopted worktree: the tool that created it
+	// (e.g. Orca) owns its lifecycle. Removing it would delete the user's
+	// checkout out from under them.
+	if t.WorktreeDir != "" {
+		return
+	}
 	wtPath := filepath.Join(m.dir, t.DirName())
 	if _, err := os.Stat(wtPath); err != nil {
 		return

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -78,8 +78,13 @@ func New(cfg Config) *Manager {
 // Dir returns the base worktrees directory.
 func (m *Manager) Dir() string { return m.dir }
 
-// PathFor returns the worktree path for a task.
+// PathFor returns the worktree path for a task. A task with an explicit
+// WorktreeDir (an externally-adopted worktree, e.g. created by Orca) resolves
+// to that path; otherwise the path is derived under the worktrees directory.
 func (m *Manager) PathFor(t task.Task) string {
+	if t.WorktreeDir != "" {
+		return t.WorktreeDir
+	}
 	return filepath.Join(m.dir, t.DirName())
 }
 

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -132,12 +132,13 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 
 // adoptWorktree wires Sybra to run a task inside a pre-existing, externally
 // managed git worktree (t.WorktreeDir). It validates the directory, records the
-// checked-out branch on the task, installs the project's commit/push gates, and
-// drops the identity beacon — but performs no git mutations (no fetch, add,
-// rebase, or push) and never schedules cleanup. The owning tool (e.g. Orca)
-// keeps responsibility for the directory's lifecycle. Project setup commands
-// are intentionally skipped: the adopted worktree is assumed already
-// provisioned by the owning tool.
+// checked-out branch on the task, installs the project's commit/push hooks, and
+// drops the identity beacon. It deliberately performs no history-changing git
+// operations (no fetch, add, rebase, or push) and never schedules cleanup — the
+// only worktree mutations are the hook/push-gate install (via installChecks)
+// and the beacon file. The owning tool (e.g. Orca) keeps responsibility for the
+// directory's lifecycle. Project setup commands are intentionally skipped: the
+// adopted worktree is assumed already provisioned by the owning tool.
 //
 // Adoption is refused when the worktree is in detached HEAD or sits on the
 // repo's default branch — the implementation agent commits to and pushes the
@@ -171,12 +172,14 @@ func (m *Manager) adoptWorktree(t task.Task, onPhase func(string)) (string, erro
 		return "", fmt.Errorf("adopt worktree %q: detached HEAD — check out a feature branch before handoff", wtPath)
 	}
 	// Refuse the default branch: pushing the agent's commits there bypasses PR
-	// review entirely. A failure to determine the default branch must not
-	// silently disable this guard, but it also shouldn't abort an otherwise
-	// valid adoption — log and proceed with the empty/detached guard intact.
-	if def, derr := project.DefaultBranch(proj.ClonePath); derr != nil {
-		m.logger.Warn("worktree.adopt-default-branch-check", "task_id", t.ID, "err", derr)
-	} else if branch == def {
+	// review entirely. Fail closed — if the default branch cannot be
+	// determined, abort rather than risk adopting a worktree that turns out to
+	// be on it.
+	def, derr := project.DefaultBranch(proj.ClonePath)
+	if derr != nil {
+		return "", fmt.Errorf("adopt worktree %q: cannot determine default branch to guard against: %w", wtPath, derr)
+	}
+	if branch == def {
 		return "", fmt.Errorf("adopt worktree %q: checked out on default branch %q — create a feature branch before handoff", wtPath, def)
 	}
 

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -20,6 +20,15 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 		}
 	}
 
+	// Adopt an externally-created worktree (e.g. one Orca already checked out)
+	// instead of creating a Sybra-managed one. Runs every agent in that
+	// directory as-is — no fetch/add/rebase/push-create/cleanup. This both
+	// honours the user's existing checkout and sidesteps git's "branch already
+	// checked out" refusal that a second worktree on the same branch would hit.
+	if t.WorktreeDir != "" {
+		return m.adoptWorktree(t, onPhase)
+	}
+
 	proj, err := m.projects.Get(t.ProjectID)
 	if err != nil {
 		return "", fmt.Errorf("get project: %w", err)
@@ -118,6 +127,65 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 	if err := writeContextFile(t, wtPath, wtBranch); err != nil {
 		m.logger.Warn("worktree.context-file", "task_id", t.ID, "err", err)
 	}
+	return wtPath, nil
+}
+
+// adoptWorktree wires Sybra to run a task inside a pre-existing, externally
+// managed git worktree (t.WorktreeDir). It validates the directory, records the
+// checked-out branch on the task, installs the project's commit/push gates, and
+// drops the identity beacon — but performs no git mutations (no fetch, add,
+// rebase, or push) and never schedules cleanup. The owning tool (e.g. Orca)
+// keeps responsibility for the directory's lifecycle. Project setup commands
+// are intentionally skipped: the adopted worktree is assumed already
+// provisioned by the owning tool.
+//
+// Adoption is refused when the worktree is in detached HEAD or sits on the
+// repo's default branch — the implementation agent commits to and pushes the
+// checked-out branch, so either case would push agent work to a shared branch
+// (or origin's default) with no PR/review. The caller must hand off from a
+// dedicated feature branch.
+func (m *Manager) adoptWorktree(t task.Task, onPhase func(string)) (string, error) {
+	wtPath := t.WorktreeDir
+	callPhase(onPhase, "Adopting worktree…")
+	info, err := os.Stat(wtPath)
+	if err != nil {
+		return "", fmt.Errorf("adopt worktree %q: %w", wtPath, err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("adopt worktree %q: not a directory", wtPath)
+	}
+	if !project.WorktreeHealthy(wtPath) {
+		return "", fmt.Errorf("adopt worktree %q: not a healthy git worktree", wtPath)
+	}
+
+	proj, err := m.projects.Get(t.ProjectID)
+	if err != nil {
+		return "", fmt.Errorf("adopt worktree: get project %q: %w", t.ProjectID, err)
+	}
+
+	branch, err := project.CurrentBranch(wtPath)
+	if err != nil {
+		return "", fmt.Errorf("adopt worktree %q: resolve branch: %w", wtPath, err)
+	}
+	if branch == "" {
+		return "", fmt.Errorf("adopt worktree %q: detached HEAD — check out a feature branch before handoff", wtPath)
+	}
+	// Refuse the default branch: pushing the agent's commits there bypasses PR
+	// review entirely. A failure to determine the default branch must not
+	// silently disable this guard, but it also shouldn't abort an otherwise
+	// valid adoption — log and proceed with the empty/detached guard intact.
+	if def, derr := project.DefaultBranch(proj.ClonePath); derr != nil {
+		m.logger.Warn("worktree.adopt-default-branch-check", "task_id", t.ID, "err", derr)
+	} else if branch == def {
+		return "", fmt.Errorf("adopt worktree %q: checked out on default branch %q — create a feature branch before handoff", wtPath, def)
+	}
+
+	m.ensureBranch(t, branch)
+	m.installChecks(wtPath, proj)
+	if err := writeContextFile(t, wtPath, branch); err != nil {
+		m.logger.Warn("worktree.context-file", "task_id", t.ID, "err", err)
+	}
+	m.logger.Info("worktree.adopted", "task_id", t.ID, "path", wtPath, "branch", branch)
 	return wtPath, nil
 }
 

--- a/mise.toml
+++ b/mise.toml
@@ -11,10 +11,11 @@ description = "Configure git to use project hooks from .githooks/"
 [tasks.dev]
 run = [
   "go install ./cmd/sybra-cli",
+  "sybra-cli install-skills || true",
   "cd frontend && npm run build:desktop",
   "go run .",
 ]
-description = "Install CLI, rebuild frontend, run the desktop app on Wails v3 (darwin-only)."
+description = "Install CLI, refresh agent skills, rebuild frontend, run the desktop app on Wails v3 (darwin-only)."
 env = { SYBRA_PPROF = "127.0.0.1:6060" }
 
 [tasks.build]


### PR DESCRIPTION
## Motivation

I use Orca (onorca.dev) to research and shape a change interactively, then want Sybra to take it the rest of the way on its own. This adds that handoff — reusing the Orca worktree so the work lands where I was already looking — and makes the handoff skill available in both Claude Code and Codex everywhere.

> Changelog: feat(handoff): Orca worktree handoff + stage routing

## Implementation information

**Handoff (`sybra-cli handoff`)**

- New `Task.WorktreeDir`: when set, Sybra adopts that existing git worktree instead of creating its own — no fetch / add / rebase / push, and never cleaned up (the owning tool keeps the directory). Centralised in `worktree.PrepareForTask`, so every downstream agent (implement, review, testing) reuses it; `Remove` no-ops on it.
- New builtin workflows `simple-task-handoff` / `simple-task-handoff-review` skip triage + planning and flip straight to the requested stage; `simple-task-plan` now excludes handoff tasks so it does not also fire.
- `--stage implement|review|pr` picks the entry point: `in-progress`, `ready-review`, or the existing `pr-review` lane for an open PR (`--pr N`).
- Adoption refuses detached HEAD and the repo default branch — fail-fast in the CLI and again at adoption — so agent commits never land on the default branch without a PR.

**Skill install (`sybra-cli install-skills`)**

- Reuses `skillsync.Syncer` to mirror the bundled skills into `~/.claude/skills`, `~/.codex/skills` and `~/.agents/skills`; wired into `mise dev` (non-fatal).
- The syncer skips any user-owned (symlinked) destination skill and still only prunes `sybra-`-prefixed orphans, so it never overrides a skill it does not own.
- `sybra-handoff` added to the embedded bundle; one SKILL.md works under both Claude Code and Codex.

Bindings regenerated (`Task` gained `worktreeDir`). Tests added for worktree adoption (incl. default-branch / detached-HEAD rejection), the handoff workflows, and the symlink-skip guard. `golangci-lint` + `go test ./...` green.

## Supporting documentation

- Skill: `internal/skills/data/sybra-handoff.md`
- Workflows: `internal/workflow/builtin/simple-task-handoff.yaml`, `internal/workflow/builtin/simple-task-handoff-review.yaml`
