### PR TITLE
chore(config): default max agents to 100

### DIFF
--- a/cmd/sybra-cli/monitor_test.go
+++ b/cmd/sybra-cli/monitor_test.go
@@ -48,10 +48,23 @@ func TestMonitorScanEmptyBoard(t *testing.T) {
 	}
 }
 
+// writeConfig writes a config.yaml into the test's SYBRA_HOME so a scan picks
+// up explicit overrides instead of falling back to packaged defaults.
+func writeConfig(t *testing.T, home, yaml string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(home, "config.yaml"), []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
 func TestMonitorScanDetectsUntriagedAndOverDispatch(t *testing.T) {
 	dir := setupStore(t)
 
-	// Plant 4 in-progress tasks (over the default DispatchLimit of 3) plus
+	// Pin the dispatch limit so this test is independent of the default
+	// agent concurrency (which is far above the 4 planted tasks).
+	writeConfig(t, dir, "monitor:\n  dispatch_limit: 3\n")
+
+	// Plant 4 in-progress tasks (over the pinned DispatchLimit of 3) plus
 	// an untriaged todo task. Tags are empty on one; a second has a full
 	// triage so only the first triggers untriaged. The in-progress tasks
 	// get the "medium" tag + headless mode so they do not also trip

--- a/frontend/src/pages/Settings.svelte
+++ b/frontend/src/pages/Settings.svelte
@@ -373,11 +373,11 @@
                     id="agent-concurrency"
                     type="number"
                     min="1"
-                    max="10"
+                    max="100"
                     class="rounded-lg border border-surface-300 bg-white px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
                     bind:value={settings.agent.maxConcurrent}
                   />
-                  <span class="text-xs text-surface-500 dark:text-surface-400">1–10</span>
+                  <span class="text-xs text-surface-500 dark:text-surface-400">1–100</span>
                 </div>
               </div>
             </section>

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -342,7 +342,7 @@ func DefaultConfig() *Config {
 		},
 		Agent: AgentDefaults{
 			Provider:      "claude",
-			MaxConcurrent: 3,
+			MaxConcurrent: 100,
 			MaxCostUSD:    5.0,
 			MaxTurns:      150,
 		},

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -94,8 +94,8 @@ func (s *ConfigService) validateSettings(settings AppSettings) error {
 	if !validModes[settings.Agent.Mode] {
 		return validationError(fmt.Sprintf("invalid mode: %q", settings.Agent.Mode))
 	}
-	if settings.Agent.MaxConcurrent < 1 || settings.Agent.MaxConcurrent > 10 {
-		return validationError("maxConcurrent must be 1–10")
+	if settings.Agent.MaxConcurrent < 1 || settings.Agent.MaxConcurrent > 100 {
+		return validationError("maxConcurrent must be 1–100")
 	}
 	validLevels := map[string]bool{"debug": true, "info": true, "warn": true, "error": true}
 	if !validLevels[settings.Logging.Level] {


### PR DESCRIPTION
## Motivation

The default agent concurrency was 3, with a hard validation cap of 10. Raise the default to 100 so a fresh install allows many concurrent agents out of the box.

> Changelog: chore(config): default max agents to 100

## Implementation information

- `internal/config/config.go` — default `AgentDefaults.MaxConcurrent` 3 → 100.
- `internal/sybra/svc_config.go` — settings validation bound `1–10` → `1–100`, otherwise the new default would be rejected on save.
- `frontend/src/pages/Settings.svelte` — Max Concurrent input `max` and helper label updated to `1–100`.

## Supporting documentation

None.