### PR TITLE
fix(board): truncate overflowing phase labels

### DIFF
--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -218,7 +218,7 @@
       >
         <PhaseIcon size={12} class="shrink-0" />
         {#if topPR}<span class="shrink-0">#{topPR.number}</span>{:else if t.prNumber}<span class="shrink-0">#{t.prNumber}</span>{/if}
-        <span class="truncate">{ph.label}</span>
+        <span class="min-w-0 truncate">{ph.label}</span>
         {#if t.issue}{@render issueGlyph()}{/if}
       </span>
     {:else if ownPRPhase}
@@ -230,7 +230,7 @@
       >
         <PhaseIcon size={12} class="shrink-0" />
         {#if topPR}<span class="shrink-0">#{topPR.number}</span>{:else if t.prNumber}<span class="shrink-0">#{t.prNumber}</span>{/if}
-        <span class="truncate">{ph.label}</span>
+        <span class="min-w-0 truncate">{ph.label}</span>
         {#if t.issue}{@render issueGlyph()}{/if}
       </span>
     {:else if topPR}

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -149,7 +149,7 @@
   {#snippet issueGlyph()}
     <!-- A linked issue alongside a PR: a real tooltip + accessible name (a
          lucide `title` prop only lands as an inert SVG attribute). -->
-    <span title={t.issue} aria-label="Also linked to an issue" class="inline-flex items-center">
+    <span title={t.issue} aria-label="Also linked to an issue" class="inline-flex shrink-0 items-center">
       <CircleDot size={11} class="opacity-60" aria-hidden="true" />
     </span>
   {/snippet}
@@ -213,24 +213,24 @@
       {@const ph = reviewPhaseMeta(t)}
       {@const PhaseIcon = PHASE_ICONS[ph.icon]}
       <span
-        class="inline-flex items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium {ph.classes}"
+        class="inline-flex min-w-0 max-w-full items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium {ph.classes}"
         title={t.statusReason || ph.label}
       >
         <PhaseIcon size={12} class="shrink-0" />
-        {#if topPR}#{topPR.number}{:else if t.prNumber}#{t.prNumber}{/if}
-        <span>{ph.label}</span>
+        {#if topPR}<span class="shrink-0">#{topPR.number}</span>{:else if t.prNumber}<span class="shrink-0">#{t.prNumber}</span>{/if}
+        <span class="truncate">{ph.label}</span>
         {#if t.issue}{@render issueGlyph()}{/if}
       </span>
     {:else if ownPRPhase}
       {@const ph = prPhaseMeta(t)}
       {@const PhaseIcon = PR_PHASE_ICONS[ph.icon]}
       <span
-        class="inline-flex items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium {ph.classes}"
+        class="inline-flex min-w-0 max-w-full items-center gap-1 whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-medium {ph.classes}"
         title={t.statusReason || ph.label}
       >
         <PhaseIcon size={12} class="shrink-0" />
-        {#if topPR}#{topPR.number}{:else if t.prNumber}#{t.prNumber}{/if}
-        <span>{ph.label}</span>
+        {#if topPR}<span class="shrink-0">#{topPR.number}</span>{:else if t.prNumber}<span class="shrink-0">#{t.prNumber}</span>{/if}
+        <span class="truncate">{ph.label}</span>
         {#if t.issue}{@render issueGlyph()}{/if}
       </span>
     {:else if topPR}


### PR DESCRIPTION
## Motivation

New PR-lifecycle phase pills (In Review / outbound-PR lanes) overflowed past the
right edge of fixed-width board cards. Long labels such as `Awaiting approval` and
`Draft — mark ready` were rendered in `whitespace-nowrap` flex items with no width
cap, so the pill could not shrink and spilled outside the card.

> Changelog: fix(board): truncate overflowing phase labels

## Implementation information

`frontend/src/components/TaskCard.svelte`, both phase badges (review-phase and
own-PR-phase):

- Added `min-w-0 max-w-full` to the pill so it shrinks within the card and never
  exceeds the card content width.
- Wrapped the PR number in `shrink-0`; the phase icon and trailing issue glyph also
  carry `shrink-0`, so they stay fixed-size.
- Made the label span `truncate` — it absorbs the shrink with an ellipsis when there
  is not enough room. The full label/status reason is still available via the
  existing `title` tooltip.

## Supporting documentation

`svelte-check` (0 errors/warnings) and `oxlint` pass clean.
