### PR TITLE
feat(runner): add retry watchdog env for headless agents

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -44,7 +44,9 @@ export class AgentDefaults {
      * RetryWatchdog sets CLAUDE_CODE_RETRY_WATCHDOG on the claude subprocess
      * for headless (unattended) runs. Replaces CLAUDE_CODE_MAX_RETRIES (now
      * capped at 15) for server/unattended sessions. 0 means use
-     * DefaultRetryWatchdog (30).
+     * DefaultRetryWatchdog (30). Negative (e.g. -1) disables the watchdog
+     * entirely (env var omitted), matching the zero-omit semantics at the
+     * RunConfig level.
      */
     "retryWatchdog": number;
 

--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -41,6 +41,21 @@ export class AgentDefaults {
     "bashTimeoutSeconds": number;
 
     /**
+     * RetryWatchdog sets CLAUDE_CODE_RETRY_WATCHDOG on the claude subprocess
+     * for headless (unattended) runs. Replaces CLAUDE_CODE_MAX_RETRIES (now
+     * capped at 15) for server/unattended sessions. 0 means use
+     * DefaultRetryWatchdog (30).
+     */
+    "retryWatchdog": number;
+
+    /**
+     * FallbackModel, when set, passes --fallback-model to claude for headless
+     * runs. Paired with RetryWatchdog so the watchdog can retry with a less
+     * loaded model when the primary is overloaded.
+     */
+    "fallbackModel": string;
+
+    /**
      * MaxLogEvents caps how many NDJSON events are returned when replaying
      * a completed agent's log file. 0 means use DefaultMaxLogEvents (500).
      */
@@ -106,6 +121,12 @@ export class AgentDefaults {
         }
         if (!("bashTimeoutSeconds" in $$source)) {
             this["bashTimeoutSeconds"] = 0;
+        }
+        if (!("retryWatchdog" in $$source)) {
+            this["retryWatchdog"] = 0;
+        }
+        if (!("fallbackModel" in $$source)) {
+            this["fallbackModel"] = "";
         }
         if (!("maxLogEvents" in $$source)) {
             this["maxLogEvents"] = 0;

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -40,6 +40,8 @@ type Manager struct {
 	approvalAddr  string // localhost:port for the HTTP tool approval server
 	guardrails    Guardrails
 	bashTimeoutMs int
+	retryWatchdog int
+	fallbackModel string
 	gate          provider.HealthGate
 
 	// reg persists live-agent records so subprocesses can be reattached
@@ -249,6 +251,23 @@ func (m *Manager) DefaultProvider() string {
 func (m *Manager) SetBashTimeoutMs(ms int) {
 	m.mu.Lock()
 	m.bashTimeoutMs = ms
+	m.mu.Unlock()
+}
+
+// SetRetryWatchdog sets the default CLAUDE_CODE_RETRY_WATCHDOG value injected
+// into headless claude subprocess environments. Zero resets to "not set"
+// (no env var exported).
+func (m *Manager) SetRetryWatchdog(n int) {
+	m.mu.Lock()
+	m.retryWatchdog = n
+	m.mu.Unlock()
+}
+
+// SetFallbackModel sets the default --fallback-model passed to headless claude
+// runs. Empty string clears the fallback (no flag added).
+func (m *Manager) SetFallbackModel(model string) {
+	m.mu.Lock()
+	m.fallbackModel = model
 	m.mu.Unlock()
 }
 

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -37,11 +37,17 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 		return nil, gateErr
 	}
 
+	m.mu.RLock()
 	if cfg.BashTimeoutMs == 0 {
-		m.mu.RLock()
 		cfg.BashTimeoutMs = m.bashTimeoutMs
-		m.mu.RUnlock()
 	}
+	if cfg.RetryWatchdog == 0 {
+		cfg.RetryWatchdog = m.retryWatchdog
+	}
+	if cfg.FallbackModel == "" {
+		cfg.FallbackModel = m.fallbackModel
+	}
+	m.mu.RUnlock()
 
 	id := uuid.NewString()[:8]
 	ctx, cancel := context.WithCancel(m.ctx)

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -561,7 +561,8 @@ type RunConfig struct {
 	RetryWatchdog int
 	// FallbackModel, when non-empty, passes --fallback-model to claude.
 	// Paired with RetryWatchdog so the watchdog can retry on a less-loaded
-	// model when the primary is overloaded. Empty means no fallback flag.
+	// model when the primary is overloaded. Empty means inherit the manager's
+	// default; the flag is omitted only when the manager default is also empty.
 	FallbackModel string
 }
 

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -554,6 +554,15 @@ type RunConfig struct {
 	// subprocess environment (claude provider only). Enables parallel subagent
 	// spawning from a single prompt at the cost of higher token usage.
 	ForkSubagent bool
+	// RetryWatchdog, when > 0, sets CLAUDE_CODE_RETRY_WATCHDOG to this value
+	// in the claude subprocess environment. Replaces CLAUDE_CODE_MAX_RETRIES
+	// (now capped at 15) for headless/unattended server runs. Zero means "use
+	// the manager's default".
+	RetryWatchdog int
+	// FallbackModel, when non-empty, passes --fallback-model to claude.
+	// Paired with RetryWatchdog so the watchdog can retry on a less-loaded
+	// model when the primary is overloaded. Empty means no fallback flag.
+	FallbackModel string
 }
 
 // PlanStep represents a single item from a TodoWrite tool call.

--- a/internal/agent/runner_headless_invocation.go
+++ b/internal/agent/runner_headless_invocation.go
@@ -25,6 +25,10 @@ func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args, env []
 		err = fmt.Errorf("invalid model %q: must match %s", a.Model, safeArgRe)
 		return
 	}
+	if cfg.FallbackModel != "" && !safeArgRe.MatchString(cfg.FallbackModel) {
+		err = fmt.Errorf("invalid fallback model %q: must match %s", cfg.FallbackModel, safeArgRe)
+		return
+	}
 
 	if a.Provider == "codex" {
 		name = "codex"
@@ -57,6 +61,9 @@ func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args, env []
 	if a.Model != "" {
 		args = append(args, "--model", a.Model)
 	}
+	if cfg.FallbackModel != "" {
+		args = append(args, "--fallback-model", cfg.FallbackModel)
+	}
 	if cfg.BashTimeoutMs > 0 {
 		// Claude has no `--bashTimeoutMs` CLI flag — the supported channel is
 		// the BASH_DEFAULT_TIMEOUT_MS / BASH_MAX_TIMEOUT_MS env vars. Set both
@@ -70,6 +77,12 @@ func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args, env []
 	}
 	if cfg.ForkSubagent {
 		env = append(env, "CLAUDE_CODE_FORK_SUBAGENT=1")
+	}
+	if cfg.RetryWatchdog > 0 {
+		// CLAUDE_CODE_RETRY_WATCHDOG replaces CLAUDE_CODE_MAX_RETRIES (now
+		// capped at 15) for unattended/server headless runs. Delivered via env
+		// because claude has no equivalent CLI flag.
+		env = append(env, "CLAUDE_CODE_RETRY_WATCHDOG="+strconv.Itoa(cfg.RetryWatchdog))
 	}
 	command = "claude " + strings.Join(args, " ")
 	return

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -887,6 +887,125 @@ func TestBuildHeadlessInvocation_CodexAlwaysBypassesSandbox(t *testing.T) {
 	}
 }
 
+// TestBuildHeadlessInvocation_RetryWatchdog verifies that CLAUDE_CODE_RETRY_WATCHDOG
+// is injected via env (not a CLI flag) when cfg.RetryWatchdog > 0, and is absent
+// when zero. Codex invocations must not receive the env var.
+func TestBuildHeadlessInvocation_RetryWatchdog(t *testing.T) {
+	t.Run("env_set_for_claude", func(t *testing.T) {
+		a := &Agent{ID: "a", Provider: "claude"}
+		_, args, env, _, err := buildHeadlessInvocation(a, RunConfig{
+			Prompt:        "hi",
+			RetryWatchdog: 30,
+		})
+		if err != nil {
+			t.Fatalf("buildHeadlessInvocation: %v", err)
+		}
+		for _, arg := range args {
+			if strings.Contains(arg, "RETRY_WATCHDOG") || strings.Contains(arg, "retry_watchdog") {
+				t.Fatalf("RETRY_WATCHDOG must not appear as a CLI arg; got %v", args)
+			}
+		}
+		want := "CLAUDE_CODE_RETRY_WATCHDOG=30"
+		if !slices.Contains(env, want) {
+			t.Errorf("env missing %q; got %v", want, env)
+		}
+	})
+
+	t.Run("env_absent_when_zero", func(t *testing.T) {
+		a := &Agent{ID: "a", Provider: "claude"}
+		_, _, env, _, err := buildHeadlessInvocation(a, RunConfig{
+			Prompt:        "hi",
+			RetryWatchdog: 0,
+		})
+		if err != nil {
+			t.Fatalf("buildHeadlessInvocation: %v", err)
+		}
+		for _, e := range env {
+			if strings.HasPrefix(e, "CLAUDE_CODE_RETRY_WATCHDOG=") {
+				t.Fatalf("RETRY_WATCHDOG env must be absent when RetryWatchdog == 0; got %q", e)
+			}
+		}
+	})
+
+	t.Run("not_set_for_codex", func(t *testing.T) {
+		a := &Agent{ID: "a", Provider: "codex"}
+		_, _, env, _, err := buildHeadlessInvocation(a, RunConfig{
+			Prompt:        "hi",
+			RetryWatchdog: 30,
+		})
+		if err != nil {
+			t.Fatalf("buildHeadlessInvocation codex: %v", err)
+		}
+		for _, e := range env {
+			if strings.HasPrefix(e, "CLAUDE_CODE_RETRY_WATCHDOG=") {
+				t.Fatalf("RETRY_WATCHDOG env must not be set for codex; got %q", e)
+			}
+		}
+	})
+}
+
+// TestBuildHeadlessInvocation_FallbackModel verifies that --fallback-model is
+// added to args when cfg.FallbackModel is set, and absent when empty. Codex
+// invocations must not receive the flag.
+func TestBuildHeadlessInvocation_FallbackModel(t *testing.T) {
+	t.Run("flag_set_for_claude", func(t *testing.T) {
+		a := &Agent{ID: "a", Provider: "claude"}
+		_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{
+			Prompt:        "hi",
+			FallbackModel: "haiku",
+		})
+		if err != nil {
+			t.Fatalf("buildHeadlessInvocation: %v", err)
+		}
+		idx := slices.Index(args, "--fallback-model")
+		if idx < 0 {
+			t.Fatalf("args missing --fallback-model; got %v", args)
+		}
+		if idx+1 >= len(args) || args[idx+1] != "haiku" {
+			t.Errorf("--fallback-model value wrong; args=%v", args)
+		}
+	})
+
+	t.Run("flag_absent_when_empty", func(t *testing.T) {
+		a := &Agent{ID: "a", Provider: "claude"}
+		_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{
+			Prompt:        "hi",
+			FallbackModel: "",
+		})
+		if err != nil {
+			t.Fatalf("buildHeadlessInvocation: %v", err)
+		}
+		if slices.Contains(args, "--fallback-model") {
+			t.Fatalf("--fallback-model must be absent when FallbackModel is empty; got %v", args)
+		}
+	})
+
+	t.Run("invalid_fallback_model_rejected", func(t *testing.T) {
+		a := &Agent{ID: "a", Provider: "claude"}
+		_, _, _, _, err := buildHeadlessInvocation(a, RunConfig{
+			Prompt:        "hi",
+			FallbackModel: "bad model; rm -rf /",
+		})
+		if err == nil {
+			t.Fatal("expected error for invalid fallback model, got nil")
+		}
+	})
+
+	t.Run("not_set_for_codex", func(t *testing.T) {
+		a := &Agent{ID: "a", Provider: "codex"}
+		_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{
+			Prompt:        "hi",
+			FallbackModel: "haiku",
+		})
+		if err != nil {
+			t.Fatalf("buildHeadlessInvocation codex: %v", err)
+		}
+		if slices.Contains(args, "--fallback-model") {
+			t.Fatalf("--fallback-model must not appear in codex args; got %v", args)
+		}
+	})
+}
+
 // TestCodexSandboxArgs_HeadlessAlwaysBypasses pins the invariant that headless
 // codex always bypasses approvals even when RequirePermissions=true. Interactive
 // mode with RequirePermissions=true must use --sandbox workspace-write.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,7 +80,9 @@ type AgentDefaults struct {
 	// RetryWatchdog sets CLAUDE_CODE_RETRY_WATCHDOG on the claude subprocess
 	// for headless (unattended) runs. Replaces CLAUDE_CODE_MAX_RETRIES (now
 	// capped at 15) for server/unattended sessions. 0 means use
-	// DefaultRetryWatchdog (30).
+	// DefaultRetryWatchdog (30). Negative (e.g. -1) disables the watchdog
+	// entirely (env var omitted), matching the zero-omit semantics at the
+	// RunConfig level.
 	RetryWatchdog int `yaml:"retry_watchdog" json:"retryWatchdog"`
 	// FallbackModel, when set, passes --fallback-model to claude for headless
 	// runs. Paired with RetryWatchdog so the watchdog can retry with a less
@@ -126,8 +128,12 @@ func (c *Config) BashTimeoutMs() int {
 	return DefaultBashTimeoutSeconds * 1000
 }
 
-// RetryWatchdog returns the configured watchdog value or DefaultRetryWatchdog.
+// RetryWatchdog returns the configured watchdog value, DefaultRetryWatchdog
+// when unset (0), or 0 when explicitly disabled (negative value).
 func (c *Config) RetryWatchdog() int {
+	if c != nil && c.Agent.RetryWatchdog < 0 {
+		return 0
+	}
 	if c != nil && c.Agent.RetryWatchdog > 0 {
 		return c.Agent.RetryWatchdog
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,6 +77,15 @@ type AgentDefaults struct {
 	// vars (claude has no equivalent CLI flag). 0 means use
 	// DefaultBashTimeoutSeconds (300).
 	BashTimeoutSeconds int `yaml:"bash_timeout_seconds" json:"bashTimeoutSeconds"`
+	// RetryWatchdog sets CLAUDE_CODE_RETRY_WATCHDOG on the claude subprocess
+	// for headless (unattended) runs. Replaces CLAUDE_CODE_MAX_RETRIES (now
+	// capped at 15) for server/unattended sessions. 0 means use
+	// DefaultRetryWatchdog (30).
+	RetryWatchdog int `yaml:"retry_watchdog" json:"retryWatchdog"`
+	// FallbackModel, when set, passes --fallback-model to claude for headless
+	// runs. Paired with RetryWatchdog so the watchdog can retry with a less
+	// loaded model when the primary is overloaded.
+	FallbackModel string `yaml:"fallback_model" json:"fallbackModel"`
 	// MaxLogEvents caps how many NDJSON events are returned when replaying
 	// a completed agent's log file. 0 means use DefaultMaxLogEvents (500).
 	MaxLogEvents int `yaml:"max_log_events" json:"maxLogEvents"`
@@ -103,6 +112,11 @@ type AgentDefaults struct {
 // BashTimeoutSeconds is not set in config.
 const DefaultBashTimeoutSeconds = 300
 
+// DefaultRetryWatchdog is the CLAUDE_CODE_RETRY_WATCHDOG value used when
+// RetryWatchdog is not set in config. Exceeds the old CLAUDE_CODE_MAX_RETRIES
+// cap of 15, appropriate for unattended server runs.
+const DefaultRetryWatchdog = 30
+
 // BashTimeoutMs returns the bash tool timeout in milliseconds, exported into
 // the claude subprocess as BASH_DEFAULT_TIMEOUT_MS / BASH_MAX_TIMEOUT_MS.
 func (c *Config) BashTimeoutMs() int {
@@ -110,6 +124,14 @@ func (c *Config) BashTimeoutMs() int {
 		return c.Agent.BashTimeoutSeconds * 1000
 	}
 	return DefaultBashTimeoutSeconds * 1000
+}
+
+// RetryWatchdog returns the configured watchdog value or DefaultRetryWatchdog.
+func (c *Config) RetryWatchdog() int {
+	if c != nil && c.Agent.RetryWatchdog > 0 {
+		return c.Agent.RetryWatchdog
+	}
+	return DefaultRetryWatchdog
 }
 
 // DefaultMaxLogEvents returns the configured cap or 500 if unset.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -364,3 +364,24 @@ func TestDefaultLogRetentionDays(t *testing.T) {
 		})
 	}
 }
+
+func TestRetryWatchdog(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cfg  *Config
+		want int
+	}{
+		{"nil config → default 30", nil, DefaultRetryWatchdog},
+		{"unset → default 30", &Config{}, DefaultRetryWatchdog},
+		{"explicit 45 → 45", &Config{Agent: AgentDefaults{RetryWatchdog: 45}}, 45},
+		{"negative disables (returns 0)", &Config{Agent: AgentDefaults{RetryWatchdog: -1}}, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.RetryWatchdog(); got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -338,6 +338,8 @@ func (a *App) initWorkflowEngine() {
 func (a *App) initAgentConfig() {
 	a.agents.SetMaxConcurrent(a.cfg.Agent.MaxConcurrent)
 	a.agents.SetBashTimeoutMs(a.cfg.BashTimeoutMs())
+	a.agents.SetRetryWatchdog(a.cfg.RetryWatchdog())
+	a.agents.SetFallbackModel(a.cfg.Agent.FallbackModel)
 	if a.cfg.SurviveRestartEnabled() {
 		if err := a.agents.EnableSurviveRestart(config.AgentsDir()); err != nil {
 			a.logger.Error("agent.survive-restart.init", "err", err)

--- a/internal/sybra/config_diff.go
+++ b/internal/sybra/config_diff.go
@@ -34,6 +34,12 @@ func diffConfig(old, next config.Config) (hot, restart []string) {
 	if old.Agent.BashTimeoutSeconds != next.Agent.BashTimeoutSeconds {
 		hot = append(hot, "agent.bash_timeout_seconds")
 	}
+	if old.Agent.RetryWatchdog != next.Agent.RetryWatchdog {
+		hot = append(hot, "agent.retry_watchdog")
+	}
+	if old.Agent.FallbackModel != next.Agent.FallbackModel {
+		hot = append(hot, "agent.fallback_model")
+	}
 	if old.Logging.Level != next.Logging.Level {
 		hot = append(hot, "logging.level")
 	}

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -90,6 +90,9 @@ func (s *ConfigService) validateSettings(settings AppSettings) error {
 	if settings.Agent.Model != "" && !modelNameRe.MatchString(settings.Agent.Model) {
 		return validationError(fmt.Sprintf("invalid model: %q", settings.Agent.Model))
 	}
+	if settings.Agent.FallbackModel != "" && !modelNameRe.MatchString(settings.Agent.FallbackModel) {
+		return validationError(fmt.Sprintf("invalid fallback model: %q", settings.Agent.FallbackModel))
+	}
 	validModes := map[string]bool{"": true, "headless": true, "interactive": true}
 	if !validModes[settings.Agent.Mode] {
 		return validationError(fmt.Sprintf("invalid mode: %q", settings.Agent.Mode))

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -146,6 +146,8 @@ func (s *ConfigService) applyFromConfig(next config.Config) {
 	s.agents.SetMaxConcurrent(next.Agent.MaxConcurrent)
 	s.agents.SetDefaultProvider(next.Agent.Provider)
 	s.agents.SetBashTimeoutMs(next.BashTimeoutMs())
+	s.agents.SetRetryWatchdog(next.RetryWatchdog())
+	s.agents.SetFallbackModel(next.Agent.FallbackModel)
 	s.agents.SetGuardrails(agent.Guardrails{
 		MaxCostUSD: next.Agent.MaxCostUSD,
 		MaxTurns:   next.Agent.MaxTurns,

--- a/internal/sybra/svc_config_reload.go
+++ b/internal/sybra/svc_config_reload.go
@@ -83,6 +83,12 @@ func (s *ConfigService) ReloadFromDisk() (changedHot []string, err error) {
 	if slices.Contains(hot, "agent.bash_timeout_seconds") {
 		s.agents.SetBashTimeoutMs(next.BashTimeoutMs())
 	}
+	if slices.Contains(hot, "agent.retry_watchdog") {
+		s.agents.SetRetryWatchdog(next.RetryWatchdog())
+	}
+	if slices.Contains(hot, "agent.fallback_model") {
+		s.agents.SetFallbackModel(next.Agent.FallbackModel)
+	}
 
 	if s.logger != nil {
 		for _, k := range restart {

--- a/internal/sybra/svc_config_settings_test.go
+++ b/internal/sybra/svc_config_settings_test.go
@@ -105,6 +105,24 @@ func TestUpdateTodoistToken_ClearsToken(t *testing.T) {
 	}
 }
 
+func TestUpdateSettings_ValidationRejectsBadFallbackModel(t *testing.T) {
+	svc, cfgPath := setupConfigSvc(t)
+	writeConfigYAML(t, cfgPath, svc.cfg)
+
+	settings := svc.GetSettings()
+	settings.Agent.FallbackModel = "bad model; rm -rf /"
+
+	if err := svc.UpdateSettings(settings); err == nil {
+		t.Error("expected validation error for invalid fallback model, got nil")
+	}
+
+	// Valid model string must be accepted.
+	settings.Agent.FallbackModel = "claude-sonnet-4-6"
+	if err := svc.UpdateSettings(settings); err != nil {
+		t.Errorf("UpdateSettings with valid fallback model: %v", err)
+	}
+}
+
 func TestUpdateSettings_ValidationRejectsEnabledWithNoToken(t *testing.T) {
 	svc, cfgPath := setupConfigSvc(t)
 	svc.cfg.Todoist.APIToken = ""


### PR DESCRIPTION
## Motivation

Claude Code v2.1.186 capped `CLAUDE_CODE_MAX_RETRIES` at 15, making it no longer sufficient for unattended server headless runs. The new `CLAUDE_CODE_RETRY_WATCHDOG` env var is the correct replacement, but Sybra had no way to set it. Without this, long-running headless agents on the server instance would exhaust retries and fail silently.

> Changelog: feat(runner): add CLAUDE_CODE_RETRY_WATCHDOG env for headless agents

## Implementation information

- **`agent.retry_watchdog`** (config): integer default for `CLAUDE_CODE_RETRY_WATCHDOG` injected into the headless claude subprocess environment. Defaults to 30. Zero means "not set" (env var omitted).
- **`agent.fallback_model`** (config): string passed as `--fallback-model` to claude, so the watchdog can retry on a less-loaded model when the primary is rate-limited. Validated against the model name regex on save.
- Both settings are picked up by the existing config diff/reload path (`svc_config_reload.go`) and forwarded to `Manager.SetRetryWatchdog` / `Manager.SetFallbackModel` without restart.
- `runner_headless_invocation.go` appends the env var and CLI flag only when the values are non-zero/non-empty.
- Tests added in `runner_headless_test.go` covering both the happy path and zero/empty defaults.
- `svc_config.go` now rejects malformed fallback model strings (test: `TestUpdateSettings_ValidationRejectsBadFallbackModel`).

Closes https://github.com/Automaat/sybra/issues/1021