### PR TITLE
chore(codex): spike app-server stdio vs NDJSON, add ADR

### DIFF
--- a/cmd/codex-appserver-spike/main.go
+++ b/cmd/codex-appserver-spike/main.go
@@ -1,0 +1,252 @@
+// codex-appserver-spike exercises codex app-server --stdio via JSON-RPC 2.0.
+// It sends one simple turn ("say hello") and prints every received message,
+// then summarises token usage and compares field coverage to codex exec --json.
+//
+// Run: go run ./cmd/codex-appserver-spike
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync/atomic"
+	"time"
+)
+
+// ── JSON-RPC envelope types ──────────────────────────────────────────────────
+
+type rpcRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      int    `json:"id"`
+	Method  string `json:"method"`
+	Params  any    `json:"params"`
+}
+
+type rpcMessage struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      *int            `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   json.RawMessage `json:"error,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// ── Protocol params ──────────────────────────────────────────────────────────
+
+type clientInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type initializeParams struct {
+	ClientInfo clientInfo `json:"clientInfo"`
+}
+
+type userInput struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type threadStartParams struct {
+	// WorkingDirectory is optional but helps codex find the right config.
+	WorkingDirectory *string `json:"workingDirectory,omitempty"`
+}
+
+type turnStartParams struct {
+	ThreadID string      `json:"threadId"`
+	Input    []userInput `json:"input"`
+}
+
+// ── Spike state ──────────────────────────────────────────────────────────────
+
+var (
+	reqID     atomic.Int64
+	threadID  string
+	startedAt time.Time
+)
+
+// eventLog collects all server messages for the summary.
+type eventLog struct {
+	method string
+	params json.RawMessage
+}
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	fmt.Println("=== codex app-server --stdio spike ===")
+	fmt.Println()
+
+	cmd := exec.CommandContext(ctx, "codex", "app-server", "--stdio")
+	cmd.Stderr = os.Stderr
+
+	stdin, err := cmd.StdinPipe()
+	must(err, "stdin pipe")
+	stdout, err := cmd.StdoutPipe()
+	must(err, "stdout pipe")
+	must(cmd.Start(), "start codex")
+	startedAt = time.Now()
+
+	// Receive goroutine: print and collect every server message.
+	var logs []eventLog
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sc := bufio.NewScanner(stdout)
+		sc.Buffer(make([]byte, 0, 4*1024*1024), 4*1024*1024)
+		for sc.Scan() {
+			line := sc.Bytes()
+			var msg rpcMessage
+			if err := json.Unmarshal(line, &msg); err != nil {
+				fmt.Printf("[raw] %s\n", line)
+				continue
+			}
+			printMessage(msg)
+			if msg.Method != "" {
+				logs = append(logs, eventLog{method: msg.Method, params: msg.Params})
+			}
+			if msg.ID != nil && msg.Method == "" && msg.Error == nil {
+				// Response to one of our requests — extract threadId from thread/start.
+				if threadID == "" {
+					var res struct {
+						Thread struct {
+							ID string `json:"id"`
+						} `json:"thread"`
+					}
+					if json.Unmarshal(msg.Result, &res) == nil && res.Thread.ID != "" {
+						threadID = res.Thread.ID
+					}
+				}
+			}
+			// Detect turn completion.
+			if msg.Method == "turn/completed" {
+				time.AfterFunc(500*time.Millisecond, cancel)
+			}
+		}
+	}()
+
+	// ── 1. initialize ─────────────────────────────────────────────────────────
+	send(stdin, rpcRequest{
+		JSONRPC: "2.0",
+		ID:      nextID(),
+		Method:  "initialize",
+		Params:  initializeParams{ClientInfo: clientInfo{Name: "sybra-spike", Version: "0.0.1"}},
+	})
+
+	// Give the server a moment to respond before sending thread/start.
+	time.Sleep(500 * time.Millisecond)
+
+	// ── 2. thread/start ───────────────────────────────────────────────────────
+	cwd, _ := os.Getwd()
+	send(stdin, rpcRequest{
+		JSONRPC: "2.0",
+		ID:      nextID(),
+		Method:  "thread/start",
+		Params:  threadStartParams{WorkingDirectory: &cwd},
+	})
+
+	// Wait until we have a threadId (or 3 s timeout).
+	deadline := time.Now().Add(3 * time.Second)
+	for threadID == "" && time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+	}
+	if threadID == "" {
+		fmt.Println("[spike] no threadId received — aborting")
+		cancel()
+		<-done
+		return
+	}
+
+	// ── 3. turn/start ─────────────────────────────────────────────────────────
+	send(stdin, rpcRequest{
+		JSONRPC: "2.0",
+		ID:      nextID(),
+		Method:  "turn/start",
+		Params: turnStartParams{
+			ThreadID: threadID,
+			Input:    []userInput{{Type: "text", Text: "Reply with exactly: hello from app-server"}},
+		},
+	})
+
+	<-done
+	elapsed := time.Since(startedAt)
+
+	_ = cmd.Wait()
+
+	// ── Summary ───────────────────────────────────────────────────────────────
+	fmt.Println()
+	fmt.Println("=== spike summary ===")
+	fmt.Printf("elapsed: %s\n", elapsed.Round(time.Millisecond))
+	fmt.Println()
+	printEventCounts(logs)
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func nextID() int {
+	return int(reqID.Add(1))
+}
+
+func send(w io.Writer, req rpcRequest) {
+	b, _ := json.Marshal(req)
+	fmt.Printf("[→] %s %s\n", req.Method, string(b))
+	_, _ = fmt.Fprintf(w, "%s\n", b)
+}
+
+func printMessage(msg rpcMessage) {
+	switch {
+	case msg.Method != "":
+		// Notification or server request.
+		fmt.Printf("[←] %s %s\n", msg.Method, string(msg.Params))
+	case msg.ID != nil && msg.Error != nil:
+		fmt.Printf("[←] ERROR id=%d %s\n", *msg.ID, string(msg.Error))
+	case msg.ID != nil:
+		fmt.Printf("[←] RESPONSE id=%d %s\n", *msg.ID, string(msg.Result))
+	}
+}
+
+func printEventCounts(logs []eventLog) {
+	counts := map[string]int{}
+	for _, l := range logs {
+		counts[l.method]++
+	}
+	fmt.Println("server notifications/requests received:")
+	for m, n := range counts {
+		fmt.Printf("  %-52s %d\n", m, n)
+	}
+	fmt.Println()
+
+	// Check for token usage.
+	for _, l := range logs {
+		if l.method == "thread/tokenUsage/updated" {
+			var p struct {
+				TokenUsage struct {
+					Last struct {
+						InputTokens           int `json:"inputTokens"`
+						CachedInputTokens     int `json:"cachedInputTokens"`
+						OutputTokens          int `json:"outputTokens"`
+						ReasoningOutputTokens int `json:"reasoningOutputTokens"`
+						TotalTokens           int `json:"totalTokens"`
+					} `json:"last"`
+				} `json:"tokenUsage"`
+			}
+			if json.Unmarshal(l.params, &p) == nil {
+				u := p.TokenUsage.Last
+				fmt.Printf("token usage (last turn): input=%d cached=%d output=%d reasoning=%d total=%d\n",
+					u.InputTokens, u.CachedInputTokens, u.OutputTokens, u.ReasoningOutputTokens, u.TotalTokens)
+			}
+		}
+	}
+}
+
+func must(err error, msg string) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fatal %s: %v\n", msg, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/codex-appserver-spike/main.go
+++ b/cmd/codex-appserver-spike/main.go
@@ -65,7 +65,6 @@ type turnStartParams struct {
 
 var (
 	reqID     atomic.Int64
-	threadID  string
 	startedAt time.Time
 )
 
@@ -92,43 +91,7 @@ func main() {
 	must(cmd.Start(), "start codex")
 	startedAt = time.Now()
 
-	// Receive goroutine: print and collect every server message.
-	var logs []eventLog
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		sc := bufio.NewScanner(stdout)
-		sc.Buffer(make([]byte, 0, 4*1024*1024), 4*1024*1024)
-		for sc.Scan() {
-			line := sc.Bytes()
-			var msg rpcMessage
-			if err := json.Unmarshal(line, &msg); err != nil {
-				fmt.Printf("[raw] %s\n", line)
-				continue
-			}
-			printMessage(msg)
-			if msg.Method != "" {
-				logs = append(logs, eventLog{method: msg.Method, params: msg.Params})
-			}
-			if msg.ID != nil && msg.Method == "" && msg.Error == nil {
-				// Response to one of our requests — extract threadId from thread/start.
-				if threadID == "" {
-					var res struct {
-						Thread struct {
-							ID string `json:"id"`
-						} `json:"thread"`
-					}
-					if json.Unmarshal(msg.Result, &res) == nil && res.Thread.ID != "" {
-						threadID = res.Thread.ID
-					}
-				}
-			}
-			// Detect turn completion.
-			if msg.Method == "turn/completed" {
-				time.AfterFunc(500*time.Millisecond, cancel)
-			}
-		}
-	}()
+	threadIDCh, logsPtr, done := startReader(stdout, cancel)
 
 	// ── 1. initialize ─────────────────────────────────────────────────────────
 	send(stdin, rpcRequest{
@@ -151,9 +114,10 @@ func main() {
 	})
 
 	// Wait until we have a threadId (or 3 s timeout).
-	deadline := time.Now().Add(3 * time.Second)
-	for threadID == "" && time.Now().Before(deadline) {
-		time.Sleep(50 * time.Millisecond)
+	var threadID string
+	select {
+	case threadID = <-threadIDCh:
+	case <-time.After(3 * time.Second):
 	}
 	if threadID == "" {
 		fmt.Println("[spike] no threadId received — aborting")
@@ -175,7 +139,6 @@ func main() {
 
 	<-done
 	elapsed := time.Since(startedAt)
-
 	_ = cmd.Wait()
 
 	// ── Summary ───────────────────────────────────────────────────────────────
@@ -183,7 +146,53 @@ func main() {
 	fmt.Println("=== spike summary ===")
 	fmt.Printf("elapsed: %s\n", elapsed.Round(time.Millisecond))
 	fmt.Println()
-	printEventCounts(logs)
+	printEventCounts(*logsPtr)
+}
+
+// startReader spawns the server-message reader goroutine. It returns a channel
+// that delivers the first thread ID seen in a response, a pointer to the
+// collected event log (safe to read after done is closed), and a done channel
+// that is closed when stdout is exhausted.
+//
+// threadIDCh is buffered so the send never blocks if main has already timed out.
+func startReader(stdout io.Reader, cancel context.CancelFunc) (threadIDCh <-chan string, logs *[]eventLog, done <-chan struct{}) {
+	ch := make(chan string, 1)
+	var collected []eventLog
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		sc := bufio.NewScanner(stdout)
+		sc.Buffer(make([]byte, 0, 4*1024*1024), 4*1024*1024)
+		for sc.Scan() {
+			line := sc.Bytes()
+			var msg rpcMessage
+			if err := json.Unmarshal(line, &msg); err != nil {
+				fmt.Printf("[raw] %s\n", line)
+				continue
+			}
+			printMessage(msg)
+			if msg.Method != "" {
+				collected = append(collected, eventLog{method: msg.Method, params: msg.Params})
+			}
+			if msg.ID != nil && msg.Method == "" && msg.Error == nil {
+				var res struct {
+					Thread struct {
+						ID string `json:"id"`
+					} `json:"thread"`
+				}
+				if json.Unmarshal(msg.Result, &res) == nil && res.Thread.ID != "" {
+					select {
+					case ch <- res.Thread.ID:
+					default:
+					}
+				}
+			}
+			if msg.Method == "turn/completed" {
+				time.AfterFunc(500*time.Millisecond, cancel)
+			}
+		}
+	}()
+	return ch, &collected, doneCh
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────

--- a/cmd/codex-appserver-spike/main.go
+++ b/cmd/codex-appserver-spike/main.go
@@ -105,12 +105,15 @@ func main() {
 	time.Sleep(500 * time.Millisecond)
 
 	// ── 2. thread/start ───────────────────────────────────────────────────────
-	cwd, _ := os.Getwd()
+	var wd *string
+	if cwd, err := os.Getwd(); err == nil {
+		wd = &cwd
+	}
 	send(stdin, rpcRequest{
 		JSONRPC: "2.0",
 		ID:      nextID(),
 		Method:  "thread/start",
-		Params:  threadStartParams{WorkingDirectory: &cwd},
+		Params:  threadStartParams{WorkingDirectory: wd},
 	})
 
 	// Wait until we have a threadId (or 3 s timeout).
@@ -191,6 +194,9 @@ func startReader(stdout io.Reader, cancel context.CancelFunc) (threadIDCh <-chan
 				time.AfterFunc(500*time.Millisecond, cancel)
 			}
 		}
+		if err := sc.Err(); err != nil {
+			fmt.Fprintf(os.Stderr, "[spike] scanner error: %v\n", err)
+		}
 	}()
 	return ch, &collected, doneCh
 }
@@ -202,9 +208,11 @@ func nextID() int {
 }
 
 func send(w io.Writer, req rpcRequest) {
-	b, _ := json.Marshal(req)
+	b, err := json.Marshal(req)
+	must(err, "marshal request")
 	fmt.Printf("[→] %s %s\n", req.Method, string(b))
-	_, _ = fmt.Fprintf(w, "%s\n", b)
+	_, err = fmt.Fprintf(w, "%s\n", b)
+	must(err, "write request")
 }
 
 func printMessage(msg rpcMessage) {

--- a/docs/adr-codex-app-server-vs-ndjson.md
+++ b/docs/adr-codex-app-server-vs-ndjson.md
@@ -112,17 +112,29 @@ These flags prevent:
 - `AGENTS.md` files in the working tree from being injected as system prompt
 - User hooks from firing (`sessionStart`, `userPromptSubmit`, `stop`)
 
-With app-server, the daemon is started once with the user's global config
-already loaded. `ThreadStartParams` does allow per-thread `sandbox`, `model`,
-and `approvalPolicy` overrides, but there is **no per-thread equivalent of
-`--ignore-user-config` or `--ignore-rules`**. The spike confirmed that hooks
-from the user's `hooks.json` fire on every turn (3 hooks, ~150 ms overhead
-per turn).
+`codex app-server` exposes process-level `-c/--config` overrides that can
+point the daemon at a custom config file. However, the spike identified two
+gaps that have no per-thread equivalent in `ThreadStartParams`:
 
-For Sybra's multi-task orchestration this is a concrete problem:
+1. **Repo rules / instruction sources** — `AGENTS.md` files in the working
+   tree are loaded as system-prompt injections. The spike observed
+   `instructionSources` in the server's `initialize` response; there is no
+   per-thread flag to suppress them.
+2. **Hook and MCP isolation** — user hooks (`sessionStart`, `userPromptSubmit`,
+   `stop`) fire on every turn (3 hooks, ~150 ms overhead observed), and user
+   MCP servers are started at daemon boot and shared across all threads.
+
+`ThreadStartParams` allows per-thread `sandbox`, `model`, and `approvalPolicy`
+overrides, but none of these cover hook suppression or instruction-source
+exclusion. A `-c/--config` daemon restart with a stripped config would
+suppress hooks globally, but Sybra needs this isolation per-task without
+restarting the shared daemon.
+
+For Sybra's multi-task orchestration these two gaps are concrete problems:
 - User's `stop` hook might report telemetry or send notifications Sybra doesn't want
 - User's `userPromptSubmit` hook might transform prompts in unexpected ways
 - User's MCP servers (chrome-devtools, etc.) are started even for isolated agents
+- `AGENTS.md` from one project's worktree could bleed into another thread's context
 
 ---
 
@@ -149,10 +161,11 @@ manageable at current agent volumes.
 
 Switch to app-server for **conversational mode** when codex ships:
 
-1. A `config` override in `ThreadStartParams` that suppresses hook loading
-   (e.g. `config: { hooks: { enabled: false } }`), or a
-   per-thread `--ignore-rules` equivalent.
-2. Confirmed equivalence between `sandbox: "workspace-write"` and
+1. A per-thread mechanism to suppress hook loading (e.g. `hooks: { enabled: false }`
+   in `ThreadStartParams`) — the spike confirmed hooks fire unconditionally today.
+2. A per-thread mechanism to exclude repo instruction sources / `AGENTS.md` injection
+   (a `--ignore-rules` equivalent scoped to the thread, not the daemon).
+3. Confirmed equivalence between `sandbox: "workspace-write"` and
    `codex exec --sandbox workspace-write --ignore-user-config`.
 
 At that point, conversational mode benefits most: streaming text deltas

--- a/docs/adr-codex-app-server-vs-ndjson.md
+++ b/docs/adr-codex-app-server-vs-ndjson.md
@@ -1,0 +1,181 @@
+# ADR: codex app-server stdio vs codex exec --json NDJSON
+
+**Status:** Accepted  
+**Date:** 2026-06-25  
+**Issue:** #1031 (supersedes #704)  
+**Spike branch:** `chore/spike-codex-app-server-stdio-vs-ndjson-435246db`
+
+---
+
+## Context
+
+Sybra drives Codex via `codex exec --json` and hand-rolls NDJSON parsing in
+`internal/agent/stream.go:178-300`. The parsed event types (`thread.started`,
+`turn.completed`, `item.completed`) map to Sybra's `CodexEvent` /
+`ConvoEvent` types.
+
+`codex app-server` (shipped in 0.136, stable in 0.142.2) exposes the same
+agent loop over a JSON-RPC 2.0 protocol (stdio or Unix socket). It is what
+the new `openai-codex` Python SDK and the VSCode extension use. The question
+is: should Sybra adopt it?
+
+---
+
+## Spike
+
+`cmd/codex-appserver-spike/main.go` was run against `codex 0.142.2`. The spike
+exercised the full handshake (`initialize` → `thread/start` → `turn/start`)
+and captured one complete turn ("Reply with exactly: hello from app-server").
+
+### Observed protocol flow
+
+```
+client → initialize
+server ← response: userAgent, codexHome, platformFamily
+server ← remoteControl/status/changed
+client → thread/start  {cwd}
+server ← response: thread{id, path, model, sandbox, approvalPolicy, …}
+server ← thread/started
+server ← mcpServer/startupStatus/updated  ×2 (starting → ready)
+client → turn/start  {threadId, input}
+server ← response: turn{id, status=inProgress}
+server ← thread/status/changed {type: active}
+server ← turn/started
+server ← hook/started + hook/completed  (sessionStart hook from user config)
+server ← hook/started + hook/completed  (userPromptSubmit hook from user config)
+server ← item/started + item/completed  (userMessage)
+server ← item/started                   (reasoning)
+server ← item/completed                 (reasoning)
+server ← item/started                   (agentMessage)
+server ← item/agentMessage/delta ×4     ("hello", " from", " app", "-server")
+server ← item/completed                 (agentMessage{text: "hello from app-server"})
+server ← thread/tokenUsage/updated
+server ← account/rateLimits/updated
+server ← hook/started + hook/completed  (stop hook from user config)
+server ← thread/status/changed {type: idle}
+server ← turn/completed {durationMs: 4942}
+```
+
+Total wall-clock: 7.6 s (including process startup and MCP init).
+
+### Token data (thread/tokenUsage/updated)
+
+| field                  | value  | available in NDJSON? |
+|------------------------|--------|----------------------|
+| inputTokens            | 16 792 | ✅                    |
+| cachedInputTokens      | 4 992  | ✅                    |
+| outputTokens           | 27     | ✅                    |
+| reasoningOutputTokens  | 17     | ✅                    |
+| totalTokens            | 16 819 | ❌ (computed by Sybra) |
+| modelContextWindow     | 258 400| ❌ (not in NDJSON)    |
+| last vs total split    | yes    | ❌ (no multi-turn sum) |
+
+---
+
+## Comparison
+
+### Event richness
+
+| capability                     | codex exec --json    | app-server --stdio             |
+|--------------------------------|----------------------|--------------------------------|
+| streaming text deltas          | ❌                   | ✅ item/agentMessage/delta      |
+| explicit reasoning items       | ❌                   | ✅ type=reasoning               |
+| turn durationMs                | ❌                   | ✅ turn.completed               |
+| multi-turn token accumulation  | ❌ (per-run only)    | ✅ last + total                 |
+| modelContextWindow             | ❌                   | ✅                              |
+| hook visibility                | ❌                   | ✅ hook/started + completed     |
+| MCP server status              | ❌                   | ✅ mcpServer/startupStatus      |
+
+### Process model
+
+| aspect                      | codex exec --json               | app-server --stdio                  |
+|-----------------------------|---------------------------------|-------------------------------------|
+| process lifetime            | one subprocess per turn         | persistent daemon process           |
+| per-turn startup cost       | ~0.5 – 1 s                      | ~0 (process already running)        |
+| isolation between tasks     | process-level (strongest)       | thread-level (weaker)               |
+| config isolation flags      | `--ignore-user-config --ignore-rules` | ❌ no per-thread equivalent    |
+| user hooks                  | suppressed via --ignore-rules   | ✅ always fire (observed in spike)   |
+| resume across restarts      | `codex exec --resume <session>` | `thread/resume` (richer)            |
+| protocol complexity         | one-shot command + NDJSON       | JSON-RPC 2.0 handshake (3 round trips) |
+
+### Config isolation: the key blocker
+
+Sybra's current invocation for both headless and conversational agents:
+
+```go
+args := []string{"exec", "--json", "--skip-git-repo-check",
+    "--ignore-user-config", "--ignore-rules"}
+```
+
+These flags prevent:
+- `~/.codex/config.toml` (model, sandbox, MCP servers) from affecting the agent
+- `AGENTS.md` files in the working tree from being injected as system prompt
+- User hooks from firing (`sessionStart`, `userPromptSubmit`, `stop`)
+
+With app-server, the daemon is started once with the user's global config
+already loaded. `ThreadStartParams` does allow per-thread `sandbox`, `model`,
+and `approvalPolicy` overrides, but there is **no per-thread equivalent of
+`--ignore-user-config` or `--ignore-rules`**. The spike confirmed that hooks
+from the user's `hooks.json` fire on every turn (3 hooks, ~150 ms overhead
+per turn).
+
+For Sybra's multi-task orchestration this is a concrete problem:
+- User's `stop` hook might report telemetry or send notifications Sybra doesn't want
+- User's `userPromptSubmit` hook might transform prompts in unexpected ways
+- User's MCP servers (chrome-devtools, etc.) are started even for isolated agents
+
+---
+
+## Decision
+
+**Do not adopt `codex app-server --stdio` for Sybra today.**
+
+Keep `codex exec --json` with `--ignore-user-config --ignore-rules` for both
+headless and conversational modes.
+
+### Rationale
+
+The config isolation gap is a correctness issue, not a performance issue. If
+user hooks fire on every Sybra-managed turn, agent behaviour becomes
+non-deterministic across machines (each user has a different hooks.json). The
+`--ignore-user-config`/`--ignore-rules` flags exist precisely because Sybra
+needs agents with predictable, controlled environments.
+
+The event-richness benefits (streaming deltas, reasoning items, durationMs)
+are UX improvements, not blockers. The per-turn spawn overhead (~0.5 s) is
+manageable at current agent volumes.
+
+### What to revisit when
+
+Switch to app-server for **conversational mode** when codex ships:
+
+1. A `config` override in `ThreadStartParams` that suppresses hook loading
+   (e.g. `config: { hooks: { enabled: false } }`), or a
+   per-thread `--ignore-rules` equivalent.
+2. Confirmed equivalence between `sandbox: "workspace-write"` and
+   `codex exec --sandbox workspace-write --ignore-user-config`.
+
+At that point, conversational mode benefits most: streaming text deltas
+(`item/agentMessage/delta`) would enable real-time chat UI without
+per-character polling, and the persistent process eliminates the ~1 s
+per-turn respawn overhead.
+
+Headless mode can stay on `codex exec --json` indefinitely — the one-shot
+subprocess model provides the strongest isolation and `--resume` works well.
+
+### Supersedes #704
+
+\#704 proposed `codex remote-control`, which is now daemon + server-token
+oriented at remote machines — wrong fit for Sybra's local subprocess model.
+This spike evaluates the correct structured-protocol alternative (`app-server`).
+Close #704 as superseded by this ADR.
+
+---
+
+## Consequences
+
+- `internal/agent/stream.go` NDJSON parsing is retained as-is.
+- `cmd/codex-appserver-spike/` is kept in the repo as a runnable reference
+  for the protocol (see `go run ./cmd/codex-appserver-spike/`).
+- `docs/codex-setup.md` may note app-server as a future direction.
+- Revisit this ADR when codex adds per-thread hook suppression.

--- a/docs/adr-codex-app-server-vs-ndjson.md
+++ b/docs/adr-codex-app-server-vs-ndjson.md
@@ -178,7 +178,7 @@ subprocess model provides the strongest isolation and `--resume` works well.
 
 ### Supersedes #704
 
-\#704 proposed `codex remote-control`, which is now daemon + server-token
+#704 proposed `codex remote-control`, which is now daemon + server-token
 oriented at remote machines — wrong fit for Sybra's local subprocess model.
 This spike evaluates the correct structured-protocol alternative (`app-server`).
 Close #704 as superseded by this ADR.


### PR DESCRIPTION
## Motivation

Evaluate whether replacing `codex exec --json` (NDJSON) with the `codex app-server --stdio` JSON-RPC 2.0 transport would improve Sybra's headless agent pipeline — specifically around streaming fidelity (delta items, reasoning) and per-thread configuration isolation.

Closes https://github.com/Automaat/sybra/issues/1031

## Implementation information

- Added `cmd/codex-appserver-spike/main.go`: a self-contained Go program that exercises the full `app-server --stdio` lifecycle (JSON-RPC 2.0: `initialize` → `thread/start` → `turn/start`) and captures a complete turn end-to-end.
- Added `docs/adr-codex-app-server-vs-ndjson.md`: ADR documenting the findings and decision.

**Key findings vs `codex exec --json`:**
- `app-server` delivers `item/agentMessage/delta` streaming and reasoning items unavailable in the NDJSON format.
- Per-thread config isolation (`--ignore-user-config`, `--ignore-rules`) has no equivalent in `app-server`; user hooks fire on every turn.
- Hook firing is a correctness blocker for Sybra's managed agents (hooks must not interfere with headless runs).

**Decision:** keep `codex exec --json` for both headless and interactive modes. Revisit when `app-server` ships per-thread hook suppression. Supersedes #704.

> Changelog: chore(codex): spike app-server stdio vs NDJSON, add ADR