### PR TITLE
fix(agent): treat 128+signal exit codes as signal kills

### DIFF
--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -161,15 +161,15 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 	}
 
 	if h.workflowEngine != nil {
-		// Stall when (a) the kernel killed the process via signal (OS/container
-		// SIGTERM, SIGKILL escalation), or (b) Sybra's own StopAgent set the
-		// `stopped` flag — even if the child exited cleanly. The latter is
-		// load-bearing: PR #722's SIGINT-first path lets default Go binaries
-		// (e.g. fake-claude in tests, claude/codex in prod) terminate via the
-		// runtime's signal handler with ExitStatus=2 (NOT WaitStatus.Signaled),
-		// so isSignalKill alone misses Sybra-initiated stops and the workflow
-		// advances on incomplete work — the failure mode reported in #641 plus
-		// the flake in TestE2E_HeadlessAgent_StopAgent_DoesNotAdvanceWorkflow.
+		// Stall when (a) the process was killed by signal (ws.Signaled or the
+		// conventional 128+N exit codes claude/codex use after catching the
+		// signal), or (b) Sybra's own StopAgent set the `stopped` flag — even
+		// if the child exited cleanly. The latter is load-bearing: PR #722's
+		// SIGINT-first path lets default Go binaries (e.g. fake-claude in
+		// tests) terminate via the runtime's signal handler with ExitStatus=2
+		// (NOT WaitStatus.Signaled), so isSignalKill alone misses
+		// Sybra-initiated stops — the failure mode reported in #641 plus the
+		// flake in TestE2E_HeadlessAgent_StopAgent_DoesNotAdvanceWorkflow.
 		if isSignalKill(exitErr) || ag.WasStopped() {
 			h.logger.Warn("agent.completion.stall",
 				"task_id", ag.TaskID, "agent_id", ag.ID,
@@ -287,6 +287,13 @@ func (h *AgentCompletionHandler) recordRunStats(ag *agent.Agent, cost, duration 
 // Signal kills cover both infrastructure interruptions (SIGTERM from container/OS
 // shutdown) and Sybra's own StopAgent (cancel ctx → process killed). Neither
 // completes the agent's work, so the workflow should not advance.
+//
+// Two paths are detected:
+//   - ws.Signaled() == true: the kernel delivered the signal directly (rare for
+//     claude/codex, which install their own signal handlers).
+//   - Exit codes 130/143/137 (128+SIGINT/SIGTERM/SIGKILL): claude/codex catch the
+//     signal, clean up, then exit with this conventional code. Go reports these as
+//     Exited()==true/Signaled()==false, so ws.Signaled() misses them.
 func isSignalKill(err error) bool {
 	if err == nil {
 		return false
@@ -295,8 +302,19 @@ func isSignalKill(err error) bool {
 	if !errors.As(err, &exitErr) {
 		return false
 	}
-	ws, ok := exitErr.Sys().(syscall.WaitStatus)
-	return ok && ws.Signaled()
+	if ws, ok := exitErr.Sys().(syscall.WaitStatus); ok && ws.Signaled() {
+		return true
+	}
+	// claude/codex install signal handlers and convert SIGINT/SIGTERM/SIGKILL
+	// into conventional 128+signal exit codes (Exited()==true, Signaled()==false),
+	// so ws.Signaled() misses an externally-interrupted run. Treat those codes as
+	// kills so the workflow stalls (ClearAgentStep) and restart-stale retries,
+	// instead of advancing on incomplete work and escalating to human-required.
+	switch exitErr.ExitCode() {
+	case 130, 143, 137: // 128+SIGINT, 128+SIGTERM, 128+SIGKILL
+		return true
+	}
+	return false
 }
 
 // OnWorkflowComplete is the callback installed via

--- a/internal/sybra/agent_completion_test.go
+++ b/internal/sybra/agent_completion_test.go
@@ -1,0 +1,133 @@
+package sybra
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestIsSignalKill(t *testing.T) {
+	t.Parallel()
+
+	// Helper: run "sh -c 'exit N'" and assert the error has the expected code.
+	exitErr := func(t *testing.T, code int) error {
+		t.Helper()
+		err := exec.Command("sh", "-c", "exit "+itoa(code)).Run()
+		if err == nil {
+			t.Fatalf("expected non-nil error for exit %d", code)
+		}
+		var ee *exec.ExitError
+		if !errors.As(err, &ee) {
+			t.Fatalf("expected *exec.ExitError for exit %d, got %T: %v", code, err, err)
+		}
+		if ee.ExitCode() != code {
+			t.Fatalf("exit code mismatch: got %d want %d", ee.ExitCode(), code)
+		}
+		return err
+	}
+
+	// Helper: send SIGKILL to a running process and return the Wait error.
+	sigkillErr := func(t *testing.T) error {
+		t.Helper()
+		cmd := exec.Command("sleep", "60")
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start sleep: %v", err)
+		}
+		time.Sleep(20 * time.Millisecond)
+		if err := cmd.Process.Signal(syscall.SIGKILL); err != nil {
+			t.Fatalf("signal: %v", err)
+		}
+		return cmd.Wait()
+	}
+
+	tests := []struct {
+		name string
+		err  func(t *testing.T) error
+		want bool
+	}{
+		{
+			name: "nil",
+			err:  func(*testing.T) error { return nil },
+			want: false,
+		},
+		{
+			name: "non-ExitError",
+			err:  func(*testing.T) error { return errors.New("boom") },
+			want: false,
+		},
+		{
+			name: "exit 1 (genuine failure)",
+			err: func(t *testing.T) error {
+				t.Helper()
+				return exitErr(t, 1)
+			},
+			want: false,
+		},
+		{
+			name: "exit 2 (normal failure, not a signal code)",
+			err: func(t *testing.T) error {
+				t.Helper()
+				return exitErr(t, 2)
+			},
+			want: false,
+		},
+		{
+			name: "exit 130 (128+SIGINT)",
+			err: func(t *testing.T) error {
+				t.Helper()
+				return exitErr(t, 130)
+			},
+			want: true,
+		},
+		{
+			name: "exit 143 (128+SIGTERM)",
+			err: func(t *testing.T) error {
+				t.Helper()
+				return exitErr(t, 143)
+			},
+			want: true,
+		},
+		{
+			name: "exit 137 (128+SIGKILL)",
+			err: func(t *testing.T) error {
+				t.Helper()
+				return exitErr(t, 137)
+			},
+			want: true,
+		},
+		{
+			name: "truly signaled process (ws.Signaled==true)",
+			err:  sigkillErr,
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.err(t)
+			got := isSignalKill(err)
+			if got != tc.want {
+				t.Errorf("isSignalKill(%v) = %v, want %v", err, got, tc.want)
+			}
+		})
+	}
+}
+
+// itoa converts a small non-negative int to its decimal string representation
+// without importing strconv (avoids an extra import just for test helpers).
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	buf := [20]byte{}
+	pos := len(buf)
+	for n > 0 {
+		pos--
+		buf[pos] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[pos:])
+}


### PR DESCRIPTION
## Motivation

`claude` and `codex` install their own signal handlers: when the process receives SIGTERM, SIGINT, or SIGKILL it catches the signal, cleans up, and exits with the conventional `128+N` code (130, 143, 137). The OS reports these exits as `Exited()==true` / `Signaled()==false`, so `ws.Signaled()` never fires for a real CLI process.

`isSignalKill` only checked `ws.Signaled()`, so container/OS shutdowns and Sybra-initiated kills via task stop were not detected as signal kills. The completion handler then treated the agent as finished, advanced the workflow on incomplete work, and escalated the task to `human-required` instead of stalling for `restart-stale` to retry automatically.

> Changelog: fix(agent): treat 128+signal exit codes as signal kills

## Implementation information

- Extended `isSignalKill` in `internal/sybra/agent_completion.go` to check exit codes 130 / 143 / 137 (`128+SIGINT/SIGTERM/SIGKILL`) in addition to the existing `ws.Signaled()` path.
- Added `TestIsSignalKill` in `internal/sybra/agent_completion_test.go` covering: `nil` error, non-`ExitError`, genuine failure (exit 1/2), each of the three signal codes, and a process that was truly signaled (`ws.Signaled()==true`).
- Updated the comment block in `OnComplete` to explain both detection paths.