### PR TITLE
feat(triage): emit noplan for trivial small tasks

### DIFF
--- a/internal/skills/data/sybra-triage.md
+++ b/internal/skills/data/sybra-triage.md
@@ -26,11 +26,11 @@ Classify pending tasks via the Go classifier. Go owns routing rules, tag validat
    This makes a single `claude -p` call that:
    - Rewrites the title into a clean imperative conventional-commit form (always, even if the input already looked fine)
    - Preserves the original title in the body
-   - Assigns tags from the controlled vocabulary (backend, frontend, infra, docs, ci, auth, db, test + size + type)
+   - Assigns tags from the controlled vocabulary (backend, frontend, infra, docs, ci, auth, db, test + size + type), plus `noplan` when the task is small and trivially mechanical (dep bumps, CI fixes, typo/docs) so it skips planning
    - Picks size (small|medium|large), type (bug|feature|refactor|review|chore|docs), and mode (headless|interactive)
    - Auto-matches a registered project if a github.com URL is in the title or body
    - Applies routing rules (work non-reviews → planning; medium/large features → planning; everything else → todo)
-   - The plan workflow honors two escape-hatch tags on a task — `noplan` skips planning entirely (triage → implement), `nocritic` keeps planning but skips the plan critique. The classifier does not assign these itself, but it **preserves** them when already set, so a human/orchestrator can tag a trivial/well-specified task before triage and the opt-out survives.
+   - The plan workflow honors two escape-hatch tags on a task — `noplan` skips planning entirely (triage → implement, and for work tasks also skips the human plan-review gate), `nocritic` keeps planning but skips the plan critique. The classifier now **assigns `noplan` itself** for trivially mechanical small tasks, bounded by a deterministic floor (emitted only when size is `small` and type is not `feature`; otherwise stripped in `ValidateVerdict`). It also **preserves** either tag when already set, so a human/orchestrator can still force the opt-out on any task before triage and it survives unchanged.
    - Forces `interactive` mode for `work` projects unless it's a PR review
    - Writes a `triage.classified` audit event
 

--- a/internal/triage/apply_test.go
+++ b/internal/triage/apply_test.go
@@ -83,6 +83,43 @@ func TestApplyPreservesEscapeHatchTags(t *testing.T) {
 	}
 }
 
+func TestApplyKeepsClassifierEmittedNoplanOnWorkProject(t *testing.T) {
+	mgr := newTestManager(t)
+	created, err := mgr.Create("bump dep on work repo", "https://github.com/myco/work-repo/pull/9", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	projects := []project.Project{
+		{ID: "myco/work-repo", Owner: "myco", Repo: "work-repo", Type: project.ProjectTypeWork},
+	}
+	// Headline case: the classifier itself emits noplan for a trivially
+	// mechanical work-typed task. Run the full emit→validate→apply path (the
+	// task has no pre-existing escape-hatch tag, so this is emission, not the
+	// human-set preservation path). ValidateVerdict's floor must keep noplan
+	// (small + chore qualifies); Apply must persist it so the workflow skips
+	// planning even though RouteStatus still parks the task at status=planning.
+	v := Verdict{
+		Title: "chore(deps): bump dependency",
+		Tags:  []string{"infra", "small", "chore", "noplan"},
+		Size:  "small",
+		Type:  "chore",
+		Mode:  "headless",
+	}
+	if err := ValidateVerdict(&v); err != nil {
+		t.Fatalf("ValidateVerdict: %v", err)
+	}
+	updated, err := Apply(mgr, created, v, projects)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !slices.Contains(updated.Tags, "noplan") {
+		t.Errorf("classifier-emitted noplan tag not persisted; got %v", updated.Tags)
+	}
+	if updated.Status != task.StatusPlanning {
+		t.Errorf("status: got %s, want planning (workflow skips via noplan tag, not status)", updated.Status)
+	}
+}
+
 func TestApplyMediumFeatureGoesToPlanning(t *testing.T) {
 	mgr := newTestManager(t)
 	created, err := mgr.Create("add auth middleware", "some body", task.AgentModeHeadless)

--- a/internal/triage/classifier.go
+++ b/internal/triage/classifier.go
@@ -64,7 +64,7 @@ Rules:
 - title: ALWAYS rewrite into a clean, human-readable, imperative conventional-commit-style title (e.g. "feat(auth): add JWT middleware", "fix(api): handle nil pointer on empty body"). Even if the input title already looks fine, produce your best version. Max 80 chars.
 - original_title: copy the input title verbatim so the user can recover it later.
 - description: ONLY set if the input body is empty/just-a-URL. 2-3 sentences describing what the task is about and what "done" looks like. Otherwise leave empty string.
-- tags: pick from: backend, frontend, infra, docs, ci, auth, db, test. Also include one of small|medium|large and one of bug|feature|refactor|review|chore|docs. 2-5 tags total.
+- tags: pick from: backend, frontend, infra, docs, ci, auth, db, test. Also include one of small|medium|large and one of bug|feature|refactor|review|chore|docs. 2-5 of these tags total. Additionally add the routing tag "noplan" when the task qualifies (see the noplan guide below) — it is the only tag outside the lists above you may emit.
 - size: small|medium|large
 - type: bug|feature|refactor|review|chore|docs
 - mode: headless (automated, no human-in-the-loop needed) or interactive (needs human judgment during execution)
@@ -78,6 +78,16 @@ Decision guide for size:
 - small: <50 LOC, single file, trivial
 - medium: multiple files, clear scope, design mostly known
 - large: cross-cutting, new subsystem, or unclear scope
+
+Decision guide for noplan (skip the planning phase — go straight to implementation):
+- Add "noplan" ONLY when the task is small AND trivially mechanical: the fix is
+  obvious and needs no design decisions or up-front scoping.
+- Good fits: dependency/version bumps, lockfile regeneration, CI/lint/config
+  tweaks, fixing a red CI check on a Renovate PR, typo/comment/docstring fixes,
+  a small mechanical rename.
+- Do NOT add "noplan" when the approach is non-obvious, scope is unclear, type is
+  feature, or the change touches a public API, data model, auth, or concurrency.
+- When in doubt, omit it — planning is the safe default.
 
 Output schema (single JSON object):
 {"title":"...","original_title":"...","description":"","tags":["..."],"size":"small","type":"feature","mode":"headless","project_id":""}

--- a/internal/triage/classifier.go
+++ b/internal/triage/classifier.go
@@ -64,7 +64,7 @@ Rules:
 - title: ALWAYS rewrite into a clean, human-readable, imperative conventional-commit-style title (e.g. "feat(auth): add JWT middleware", "fix(api): handle nil pointer on empty body"). Even if the input title already looks fine, produce your best version. Max 80 chars.
 - original_title: copy the input title verbatim so the user can recover it later.
 - description: ONLY set if the input body is empty/just-a-URL. 2-3 sentences describing what the task is about and what "done" looks like. Otherwise leave empty string.
-- tags: pick from: backend, frontend, infra, docs, ci, auth, db, test. Also include one of small|medium|large and one of bug|feature|refactor|review|chore|docs. 2-5 of these tags total. Additionally add the routing tag "noplan" when the task qualifies (see the noplan guide below) — it is the only tag outside the lists above you may emit.
+- tags: pick from: backend, frontend, infra, docs, ci, auth, db, test. Also include one of small|medium|large and one of bug|feature|refactor|review|chore|docs — 2-5 of these vocabulary tags. Separately, add the routing tag "noplan" when the task qualifies (see the noplan guide below): it is the only tag outside the lists above you may emit, and it does NOT count toward the 2-5 — never drop a deserved "noplan" to stay under the cap.
 - size: small|medium|large
 - type: bug|feature|refactor|review|chore|docs
 - mode: headless (automated, no human-in-the-loop needed) or interactive (needs human judgment during execution)

--- a/internal/triage/classifier_test.go
+++ b/internal/triage/classifier_test.go
@@ -1,6 +1,20 @@
 package triage
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func TestBuildPromptInstructsNoplan(t *testing.T) {
+	p := buildPrompt(task.Task{Title: "fix CI on renovate PR", Body: ""}, nil)
+	for _, want := range []string{"noplan", "Decision guide for noplan"} {
+		if !strings.Contains(p, want) {
+			t.Errorf("prompt missing %q; classifier won't be told to emit noplan", want)
+		}
+	}
+}
 
 func TestParseVerdict(t *testing.T) {
 	raw := []byte(`{"result":"Here is the verdict:\n{\"title\":\"feat(api): add auth\",\"original_title\":\"i want auth\",\"description\":\"\",\"tags\":[\"backend\",\"medium\",\"feature\"],\"size\":\"medium\",\"type\":\"feature\",\"mode\":\"headless\",\"project_id\":\"\"}"}`)

--- a/internal/triage/model.go
+++ b/internal/triage/model.go
@@ -30,11 +30,14 @@ var (
 	// this set and the size/type sets are rejected.
 	domainTags = []string{"backend", "frontend", "infra", "docs", "ci", "auth", "db", "test"}
 
-	// escapeHatchTags are workflow-routing opt-outs, not part of the
-	// classifier's assignable vocabulary. They are accepted by NormalizeTags
+	// escapeHatchTags are workflow-routing opt-outs accepted by NormalizeTags
 	// (so they aren't stripped) and preserved through triage (see Apply) so a
-	// human/orchestrator can set them on a task without triage dropping them.
-	// `noplan` skips the plan pipeline; `nocritic` skips the plan critique.
+	// manually-set opt-out is never dropped. `noplan` skips the plan pipeline
+	// (and, for work tasks, the human plan-review gate) and is also
+	// classifier-emittable — the triage prompt instructs the model to assign it
+	// for trivially mechanical small tasks, bounded by the deterministic floor
+	// in ValidateVerdict (small + non-feature). `nocritic` skips the plan
+	// critique and remains human/orchestrator-set only.
 	escapeHatchTags = []string{"noplan", "nocritic"}
 
 	// tagAliases normalize common abbreviations into the canonical tag.
@@ -113,5 +116,17 @@ func ValidateVerdict(v *Verdict) error {
 	// the caller can log them but the verdict is still usable.
 	norm, _ := NormalizeTags(v.Tags)
 	v.Tags = norm
+
+	// Deterministic floor on classifier-emitted noplan. The prompt tells the
+	// model to add noplan only for small, non-feature work, but the model is
+	// the one category it's told to avoid — so a code-level guard, not trust,
+	// decides. noplan skips planning AND (for work tasks) the human plan-review
+	// gate, so an over-eager verdict on a large/feature task would route it
+	// straight to one-shot implementation unreviewed. Strip it unless the size
+	// and type actually qualify. Human/orchestrator-set noplan is unaffected:
+	// it lives on the task, not the verdict, and is preserved in Apply.
+	if v.Size != "small" || v.Type == "feature" {
+		v.Tags = slices.DeleteFunc(v.Tags, func(tag string) bool { return tag == "noplan" })
+	}
 	return nil
 }

--- a/internal/triage/model_test.go
+++ b/internal/triage/model_test.go
@@ -2,6 +2,7 @@ package triage
 
 import (
 	"reflect"
+	"slices"
 	"testing"
 )
 
@@ -51,6 +52,37 @@ func TestValidateVerdict(t *testing.T) {
 			err := ValidateVerdict(&v)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("err = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateVerdictNoplanFloor(t *testing.T) {
+	tests := []struct {
+		name      string
+		size      string
+		typ       string
+		wantNopla bool
+	}{
+		{"small chore keeps", "small", "chore", true},
+		{"small bug keeps", "small", "bug", true},
+		{"small refactor keeps", "small", "refactor", true},
+		{"small feature strips", "small", "feature", false},
+		{"medium chore strips", "medium", "chore", false},
+		{"large bug strips", "large", "bug", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			v := Verdict{
+				Title: "t", Size: tc.size, Type: tc.typ, Mode: "headless",
+				Tags: []string{"backend", tc.size, tc.typ, "noplan"},
+			}
+			if err := ValidateVerdict(&v); err != nil {
+				t.Fatalf("ValidateVerdict: %v", err)
+			}
+			gotNoplan := slices.Contains(v.Tags, "noplan")
+			if gotNoplan != tc.wantNopla {
+				t.Errorf("noplan present = %v, want %v (tags %v)", gotNoplan, tc.wantNopla, v.Tags)
 			}
 		})
 	}

--- a/internal/triage/model_test.go
+++ b/internal/triage/model_test.go
@@ -59,10 +59,10 @@ func TestValidateVerdict(t *testing.T) {
 
 func TestValidateVerdictNoplanFloor(t *testing.T) {
 	tests := []struct {
-		name      string
-		size      string
-		typ       string
-		wantNopla bool
+		name       string
+		size       string
+		typ        string
+		wantNoplan bool
 	}{
 		{"small chore keeps", "small", "chore", true},
 		{"small bug keeps", "small", "bug", true},
@@ -81,8 +81,8 @@ func TestValidateVerdictNoplanFloor(t *testing.T) {
 				t.Fatalf("ValidateVerdict: %v", err)
 			}
 			gotNoplan := slices.Contains(v.Tags, "noplan")
-			if gotNoplan != tc.wantNopla {
-				t.Errorf("noplan present = %v, want %v (tags %v)", gotNoplan, tc.wantNopla, v.Tags)
+			if gotNoplan != tc.wantNoplan {
+				t.Errorf("noplan present = %v, want %v (tags %v)", gotNoplan, tc.wantNoplan, v.Tags)
 			}
 		})
 	}


### PR DESCRIPTION
## Motivation

Work-typed tasks are unconditionally routed to `StatusPlanning` by triage
(`RouteStatus`), so even trivially mechanical work — dependency bumps, CI
fixes, typo/doc edits — ran the full plan + human-review loop before
implementation. There was an escape hatch (`noplan`) but it only worked when a
human set it by hand.

> Changelog: feat(triage): emit noplan for trivial small tasks

This lets the triage classifier emit the existing `noplan` tag itself, so
trivially mechanical small tasks skip planning and go straight to
implementation — including on work projects, which otherwise always plan.

## Implementation information

- **Classifier prompt** (`internal/triage/classifier.go`): `noplan` added to the
  emittable tags with a tight "Decision guide for noplan" — only for small,
  mechanical work (dep/version bumps, CI/lint/config tweaks, red CI on a
  Renovate PR, typo/docstring fixes, small renames); explicitly not for
  features, unclear scope, or changes touching public API / data model / auth /
  concurrency. All triage paths (background poller, `/sybra-triage` skill,
  `sybra-cli triage classify`) share this `buildPrompt`, so one edit covers all.
- **Deterministic floor** (`internal/triage/model.go`, `ValidateVerdict`): a
  classifier-emitted `noplan` is stripped unless `size == small && type !=
  feature`. The LLM guidance is advisory; the code is authoritative, so an
  over-eager verdict can't route a large/feature task past planning. This is
  scoped to the verdict only — a human/orchestrator-set `noplan` lives on the
  task and remains an unconditional override (preserved in `Apply`).
- **Routing unchanged**: `RouteStatus` still parks work tasks at
  `status=planning`; the `simple-task-plan` workflow already checks the `noplan`
  tag *before* the planning route (and after the terminal guards), so the tag —
  not the status — is what skips the plan/critique/human-review loop.
- **Note**: for work tasks, `noplan` also skips the human plan-review gate
  (documented in the skill + code comments). The deterministic floor is the
  guard that keeps that safe.

## Supporting documentation

- Tests: `TestBuildPromptInstructsNoplan` (prompt carries the guidance),
  `TestValidateVerdictNoplanFloor` (floor keeps small/non-feature, strips the
  rest), `TestApplyKeepsClassifierEmittedNoplanOnWorkProject` (full
  emit→validate→apply on a work project; tag persists, status stays planning).
  Existing preservation/routing tests unchanged.
- Skill doc `internal/skills/data/sybra-triage.md` updated to describe emission,
  the floor, and the human-review consequence.
- The Renovate auto-source is unaffected — those tasks are created as
  `StatusTodo` and dispatched to the `pr-fix` workflow, which has no planning
  steps; this change targets hand-created / triaged small work tasks.
