### PR TITLE
feat(codex): add per-task reasoning effort

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -634,14 +634,14 @@ func cmdUpdate(s *task.Manager, args []string, jsonOut bool) int {
 	if *body != "" {
 		updates["body"] = *body
 	}
-	if err := applyFileOrStringUpdate(fs, updates, "plan", "plan", *plan, *planFile); err != nil {
-		return fatal(jsonOut, "%v", err)
-	}
-	if err := applyFileOrStringUpdate(fs, updates, "plan-critique", "plan_critique", *planCritique, *planCritiqueFile); err != nil {
-		return fatal(jsonOut, "%v", err)
-	}
-	if err := applyFileOrStringUpdate(fs, updates, "code-review", "code_review", *codeReview, *codeReviewFile); err != nil {
-		return fatal(jsonOut, "%v", err)
+	for _, fu := range []struct{ flag, key, str, file string }{
+		{"plan", "plan", *plan, *planFile},
+		{"plan-critique", "plan_critique", *planCritique, *planCritiqueFile},
+		{"code-review", "code_review", *codeReview, *codeReviewFile},
+	} {
+		if err := applyFileOrStringUpdate(fs, updates, fu.flag, fu.key, fu.str, fu.file); err != nil {
+			return fatal(jsonOut, "%v", err)
+		}
 	}
 	if *mode != "" {
 		updates["agent_mode"] = *mode
@@ -653,11 +653,7 @@ func cmdUpdate(s *task.Manager, args []string, jsonOut bool) int {
 		updates["task_type"] = *ttype
 	}
 	if *tags != "" {
-		tagList := strings.Split(*tags, ",")
-		for i := range tagList {
-			tagList[i] = strings.TrimSpace(tagList[i])
-		}
-		updates["tags"] = tagList
+		updates["tags"] = parseTags(*tags)
 	}
 	if *proj != "" {
 		updates["project_id"] = *proj
@@ -676,11 +672,8 @@ func cmdUpdate(s *task.Manager, args []string, jsonOut bool) int {
 		updates["max_turns"] = float64(*maxTurnsFlag)
 	}
 	if *reasoningEffort != "" {
-		v := *reasoningEffort
-		if v == "default" || v == "none" {
-			v = ""
-		}
-		if _, err := task.ValidateReasoningEffort(v); err != nil {
+		v, err := normalizeReasoningEffort(*reasoningEffort)
+		if err != nil {
 			return fatal(jsonOut, "%v", err)
 		}
 		updates["reasoning_effort"] = v
@@ -740,6 +733,22 @@ func applyFileOrStringUpdate(fs *flag.FlagSet, updates map[string]any, flagName,
 		})
 	}
 	return nil
+}
+
+func parseTags(s string) []string {
+	parts := strings.Split(s, ",")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	return parts
+}
+
+// normalizeReasoningEffort converts "default"/"none" to "" (use model default) then validates.
+func normalizeReasoningEffort(s string) (string, error) {
+	if s == "default" || s == "none" {
+		s = ""
+	}
+	return task.ValidateReasoningEffort(s)
 }
 
 func filterStatus(tasks []task.Task, status string) []task.Task {

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -616,7 +616,7 @@ func cmdUpdate(s *task.Manager, args []string, jsonOut bool) int {
 	issue := fs.String("issue", "", "GitHub issue URL")
 	statusReason := fs.String("status-reason", "", "reason for status change")
 	maxTurnsFlag := fs.Int("max-turns", -1, "per-task max turns override (0 clears override, >0 sets limit)")
-	reasoningEffort := fs.String("reasoning-effort", "", "codex reasoning effort: low|medium|high|xhigh ('default' clears the override)")
+	reasoningEffort := fs.String("reasoning-effort", "", "codex reasoning effort: low|medium|high|xhigh ('default' or 'none' clears the override)")
 	if err := fs.Parse(args[1:]); err != nil {
 		return fatal(jsonOut, "%v", err)
 	}

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -616,6 +616,7 @@ func cmdUpdate(s *task.Manager, args []string, jsonOut bool) int {
 	issue := fs.String("issue", "", "GitHub issue URL")
 	statusReason := fs.String("status-reason", "", "reason for status change")
 	maxTurnsFlag := fs.Int("max-turns", -1, "per-task max turns override (0 clears override, >0 sets limit)")
+	reasoningEffort := fs.String("reasoning-effort", "", "codex reasoning effort: low|medium|high|xhigh ('default' clears the override)")
 	if err := fs.Parse(args[1:]); err != nil {
 		return fatal(jsonOut, "%v", err)
 	}
@@ -673,6 +674,16 @@ func cmdUpdate(s *task.Manager, args []string, jsonOut bool) int {
 	// -1 is the sentinel "not provided"; 0 clears override, >0 sets limit.
 	if *maxTurnsFlag >= 0 {
 		updates["max_turns"] = float64(*maxTurnsFlag)
+	}
+	if *reasoningEffort != "" {
+		v := *reasoningEffort
+		if v == "default" || v == "none" {
+			v = ""
+		}
+		if _, err := task.ValidateReasoningEffort(v); err != nil {
+			return fatal(jsonOut, "%v", err)
+		}
+		updates["reasoning_effort"] = v
 	}
 
 	if len(updates) == 0 {
@@ -1250,7 +1261,7 @@ Commands:
              implement  have a plan → Sybra implements, reviews, opens the PR
              review     implemented locally → Sybra reviews + opens the PR
              pr         existing PR (--pr N) → Sybra reviews the PR
-  update   <id> [--title T] [--status S] [--status-reason R] [--body B] [--plan PLAN] [--plan-file PATH] [--mode M] [--type TYPE] [--tags T] [--project ID] [--branch B] [--pr N] [--issue URL] [--max-turns N]
+  update   <id> [--title T] [--status S] [--status-reason R] [--body B] [--plan PLAN] [--plan-file PATH] [--mode M] [--type TYPE] [--tags T] [--project ID] [--branch B] [--pr N] [--issue URL] [--max-turns N] [--reasoning-effort E]
   delete   <id>
 
   project list

--- a/frontend/bindings/github.com/Automaat/sybra/internal/agent/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/agent/models.ts
@@ -41,6 +41,7 @@ export class Agent {
     "project"?: string;
     "provider"?: string;
     "model"?: string;
+    "reasoningEffort"?: string;
     "prompt"?: string;
     "turnCount"?: number;
 

--- a/frontend/bindings/github.com/Automaat/sybra/internal/agent/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/agent/models.ts
@@ -110,10 +110,10 @@ export class Agent {
      * Creates a new Agent instance from a string or object.
      */
     static createFrom($$source: any = {}): Agent {
-        const $$createField26_0 = $$createType0;
+        const $$createField27_0 = $$createType0;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("pluginErrors" in $$parsedSource) {
-            $$parsedSource["pluginErrors"] = $$createField26_0($$parsedSource["pluginErrors"]);
+            $$parsedSource["pluginErrors"] = $$createField27_0($$parsedSource["pluginErrors"]);
         }
         return new Agent($$parsedSource as Partial<Agent>);
     }

--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/models.ts
@@ -113,6 +113,7 @@ export class AppSettings {
 export class CodexModel {
     "slug": string;
     "display_name": string;
+    "supported_reasoning_levels"?: string[];
 
     /** Creates a new CodexModel instance. */
     constructor($$source: Partial<CodexModel> = {}) {
@@ -130,7 +131,11 @@ export class CodexModel {
      * Creates a new CodexModel instance from a string or object.
      */
     static createFrom($$source: any = {}): CodexModel {
+        const $$createField2_0 = $$createType9;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        if ("supported_reasoning_levels" in $$parsedSource) {
+            $$parsedSource["supported_reasoning_levels"] = $$createField2_0($$parsedSource["supported_reasoning_levels"]);
+        }
         return new CodexModel($$parsedSource as Partial<CodexModel>);
     }
 }
@@ -271,7 +276,7 @@ export class MonitorReportBinding {
      * Creates a new MonitorReportBinding instance from a string or object.
      */
     static createFrom($$source: any = {}): MonitorReportBinding {
-        const $$createField2_0 = $$createType9;
+        const $$createField2_0 = $$createType10;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("report" in $$parsedSource) {
             $$parsedSource["report"] = $$createField2_0($$parsedSource["report"]);
@@ -314,4 +319,5 @@ const $$createType5 = config$0.TodoistConfig.createFrom;
 const $$createType6 = config$0.RenovateConfig.createFrom;
 const $$createType7 = config$0.ProvidersConfig.createFrom;
 const $$createType8 = $Create.Map($Create.Any, $Create.Any);
-const $$createType9 = monitor$0.Report.createFrom;
+const $$createType9 = $Create.Array($Create.Any);
+const $$createType10 = monitor$0.Report.createFrom;

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -350,9 +350,9 @@ export class Task {
     static createFrom($$source: any = {}): Task {
         const $$createField6_0 = $$createType0;
         const $$createField7_0 = $$createType0;
-        const $$createField27_0 = $$createType2;
-        const $$createField28_0 = $$createType4;
-        const $$createField35_0 = $$createType5;
+        const $$createField28_0 = $$createType2;
+        const $$createField29_0 = $$createType4;
+        const $$createField36_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -361,13 +361,13 @@ export class Task {
             $$parsedSource["tags"] = $$createField7_0($$parsedSource["tags"]);
         }
         if ("agentRuns" in $$parsedSource) {
-            $$parsedSource["agentRuns"] = $$createField27_0($$parsedSource["agentRuns"]);
+            $$parsedSource["agentRuns"] = $$createField28_0($$parsedSource["agentRuns"]);
         }
         if ("workflow" in $$parsedSource) {
-            $$parsedSource["workflow"] = $$createField28_0($$parsedSource["workflow"]);
+            $$parsedSource["workflow"] = $$createField29_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField35_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField36_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -245,6 +245,14 @@ export class Task {
      * higher token cost for reduced wall-clock time on multi-part prompts.
      */
     "forkSubagent"?: boolean;
+
+    /**
+     * ReasoningEffort sets the Codex model reasoning level for this task's agents
+     * via -c model_reasoning_effort=<v>. Empty = model default. Codex-only;
+     * ignored for claude agents. Distinct from the claude-only extended-thinking
+     * knob — different CLI surface and vocabulary (xhigh vs max).
+     */
+    "reasoningEffort"?: string;
     "agentRuns": AgentRun[];
     "workflow": workflow$0.Execution | null;
     "createdAt": time$0.Time;

--- a/frontend/src/components/CreateTaskDialog.svelte
+++ b/frontend/src/components/CreateTaskDialog.svelte
@@ -16,6 +16,7 @@
   let body = $state('')
   let headless = $state(false)
   let forkSubagent = $state(false)
+  let reasoningEffort = $state('')
   let taskType = $state('normal')
   let selectedProject = $state('')
   let projectSearch = $state('')
@@ -52,6 +53,7 @@
     body = ''
     headless = false
     forkSubagent = false
+    reasoningEffort = ''
     taskType = 'normal'
     selectedProject = ''
     projectSearch = ''
@@ -80,6 +82,7 @@
       if (taskType !== 'normal') updates.task_type = taskType
       if (selectedProject) updates.project_id = selectedProject
       if (forkSubagent && effectiveMode === 'headless') updates.fork_subagent = true
+      if (reasoningEffort) updates.reasoning_effort = reasoningEffort
       if (Object.keys(updates).length > 0) {
         t = await taskStore.update(t.id, updates)
       }
@@ -208,6 +211,19 @@
               <span class="text-xs text-surface-400">(parallel, higher token cost)</span>
             </label>
           {/if}
+          <label class="flex flex-col gap-1">
+            <span class="text-sm font-medium">Reasoning effort <span class="font-normal text-surface-400">(Codex only)</span></span>
+            <select
+              bind:value={reasoningEffort}
+              class="rounded-lg border border-surface-300 bg-surface-100 px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
+            >
+              <option value="">model default</option>
+              <option value="low">low</option>
+              <option value="medium">medium</option>
+              <option value="high">high</option>
+              <option value="xhigh">xhigh</option>
+            </select>
+          </label>
         {/if}
 
         <label class="flex flex-col gap-1">

--- a/frontend/src/components/CreateTaskDialog.svelte
+++ b/frontend/src/components/CreateTaskDialog.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import MobileSheet from './shell/MobileSheet.svelte'
   import { Folder, X } from '@lucide/svelte'
+  import { onMount } from 'svelte'
   import { taskStore } from '../stores/tasks.svelte.js'
   import { projectStore } from '../stores/projects.svelte.js'
+  import { fallbackReasoningEffortOptions, loadReasoningEffortOptions } from '../lib/codex-reasoning.js'
 
   interface Props {
     open: boolean
@@ -23,6 +25,13 @@
   let projectDropdownOpen = $state(false)
   let submitting = $state(false)
   let error = $state('')
+  let reasoningEffortOptions = $state(fallbackReasoningEffortOptions)
+
+  onMount(() => {
+    loadReasoningEffortOptions().then((options) => {
+      reasoningEffortOptions = options
+    })
+  })
 
   const filteredProjects = $derived(
     projectStore.list.filter((p) => {
@@ -218,10 +227,9 @@
               class="rounded-lg border border-surface-300 bg-surface-100 px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"
             >
               <option value="">model default</option>
-              <option value="low">low</option>
-              <option value="medium">medium</option>
-              <option value="high">high</option>
-              <option value="xhigh">xhigh</option>
+              {#each reasoningEffortOptions as option}
+                <option value={option.value}>{option.label}</option>
+              {/each}
             </select>
           </label>
         {/if}

--- a/frontend/src/components/task-detail/TaskMetadataRow.svelte
+++ b/frontend/src/components/task-detail/TaskMetadataRow.svelte
@@ -163,6 +163,28 @@
   {/if}
 
   <div class="flex flex-col gap-1">
+    <span class="font-medium text-surface-500">Reasoning Effort <span class="font-normal text-surface-400 text-xs">(Codex only)</span></span>
+    <select
+      class="w-fit rounded bg-transparent px-1 py-0.5 text-sm text-surface-600 dark:text-surface-300"
+      value={task.reasoningEffort ?? ''}
+      onchange={async (e) => {
+        try {
+          await taskStore.update(task.id, { reasoning_effort: e.currentTarget.value })
+        } catch (e) {
+          error = String(e)
+        }
+      }}
+      title="Codex model_reasoning_effort. Empty = model default. Ignored for claude agents."
+    >
+      <option value="">default</option>
+      <option value="low">low</option>
+      <option value="medium">medium</option>
+      <option value="high">high</option>
+      <option value="xhigh">xhigh</option>
+    </select>
+  </div>
+
+  <div class="flex flex-col gap-1">
     <span class="font-medium text-surface-500">Max Turns</span>
     <TaskMaxTurnsEditor {task} onerror={handleError} />
   </div>

--- a/frontend/src/components/task-detail/TaskMetadataRow.svelte
+++ b/frontend/src/components/task-detail/TaskMetadataRow.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import { CircleDot, Copy } from '@lucide/svelte'
+  import { onMount } from 'svelte'
   import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { taskStore } from '../../stores/tasks.svelte.js'
   import { notificationStore } from '../../stores/notifications.svelte.js'
   import { openLink } from '$lib/browser.svelte.js'
   import { formatDateTime } from '../../lib/dates.js'
+  import { fallbackReasoningEffortOptions, loadReasoningEffortOptions } from '../../lib/codex-reasoning.js'
   import AssignProjectDialog from '../AssignProjectDialog.svelte'
   import TaskTagEditor from './TaskTagEditor.svelte'
   import TaskDueDateEditor from './TaskDueDateEditor.svelte'
@@ -22,6 +24,13 @@
 
   let tagEditor = $state<TaskTagEditor | null>(null)
   let dueDateEditor = $state<TaskDueDateEditor | null>(null)
+  let reasoningEffortOptions = $state(fallbackReasoningEffortOptions)
+
+  onMount(() => {
+    loadReasoningEffortOptions().then((options) => {
+      reasoningEffortOptions = options
+    })
+  })
 
   const taskBranchName = $derived(
     task ? 'sybra/' + (task.slug ? task.slug + '-' + task.id : task.id) : '',
@@ -178,10 +187,9 @@
       title="Codex model_reasoning_effort. Empty = model default. Ignored for claude agents."
     >
       <option value="">default</option>
-      <option value="low">low</option>
-      <option value="medium">medium</option>
-      <option value="high">high</option>
-      <option value="xhigh">xhigh</option>
+      {#each reasoningEffortOptions as option}
+        <option value={option.value}>{option.label}</option>
+      {/each}
     </select>
   </div>
 

--- a/frontend/src/components/task-detail/TaskMetadataRow.svelte
+++ b/frontend/src/components/task-detail/TaskMetadataRow.svelte
@@ -165,6 +165,7 @@
   <div class="flex flex-col gap-1">
     <span class="font-medium text-surface-500">Reasoning Effort <span class="font-normal text-surface-400 text-xs">(Codex only)</span></span>
     <select
+      aria-label="Reasoning Effort"
       class="w-fit rounded bg-transparent px-1 py-0.5 text-sm text-surface-600 dark:text-surface-300"
       value={task.reasoningEffort ?? ''}
       onchange={async (e) => {

--- a/frontend/src/lib/codex-reasoning.test.ts
+++ b/frontend/src/lib/codex-reasoning.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { fallbackReasoningEffortOptions, reasoningEffortOptionsFromModels } from './codex-reasoning'
+
+describe('reasoningEffortOptionsFromModels', () => {
+  it('preserves codex-supported reasoning level order and de-dupes repeats', () => {
+    const got = reasoningEffortOptionsFromModels([
+      {
+        slug: 'gpt-a',
+        display_name: 'GPT A',
+        supported_reasoning_levels: ['medium', 'high'],
+      },
+      {
+        slug: 'gpt-b',
+        display_name: 'GPT B',
+        supported_reasoning_levels: ['low', 'medium', 'xhigh'],
+      },
+    ])
+
+    expect(got).toEqual([
+      { value: 'medium', label: 'medium' },
+      { value: 'high', label: 'high' },
+      { value: 'low', label: 'low' },
+      { value: 'xhigh', label: 'xhigh' },
+    ])
+  })
+
+  it('falls back when codex returns no supported reasoning levels', () => {
+    expect(reasoningEffortOptionsFromModels([
+      { slug: 'gpt-a', display_name: 'GPT A' },
+    ])).toBe(fallbackReasoningEffortOptions)
+  })
+})

--- a/frontend/src/lib/codex-reasoning.ts
+++ b/frontend/src/lib/codex-reasoning.ts
@@ -1,0 +1,34 @@
+import { GetCodexModels } from '$lib/api'
+import type { CodexModel } from '../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
+
+export type ReasoningEffortOption = { value: string; label: string }
+
+export const fallbackReasoningEffortOptions: ReasoningEffortOption[] = [
+  { value: 'low', label: 'low' },
+  { value: 'medium', label: 'medium' },
+  { value: 'high', label: 'high' },
+  { value: 'xhigh', label: 'xhigh' },
+]
+
+export function reasoningEffortOptionsFromModels(models: CodexModel[] | null | undefined): ReasoningEffortOption[] {
+  const seen = new Set<string>()
+  const options: ReasoningEffortOption[] = []
+
+  for (const model of models ?? []) {
+    for (const level of model.supported_reasoning_levels ?? []) {
+      if (seen.has(level)) continue
+      seen.add(level)
+      options.push({ value: level, label: level })
+    }
+  }
+
+  return options.length > 0 ? options : fallbackReasoningEffortOptions
+}
+
+export async function loadReasoningEffortOptions(): Promise<ReasoningEffortOption[]> {
+  try {
+    return reasoningEffortOptionsFromModels(await GetCodexModels())
+  } catch {
+    return fallbackReasoningEffortOptions
+  }
+}

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -212,6 +212,7 @@ func (m *Manager) saveRegistry(a *Agent) {
 		StdinPath:          a.stdinPath,
 		MaxTurns:           a.MaxTurns,
 		RequirePermissions: a.requirePermissions,
+		ReasoningEffort:    a.ReasoningEffort,
 	}
 	a.mu.RUnlock()
 	rec.ProcStartedAt = processStartString(rec.PID)

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -60,6 +60,7 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 		Mode:               cfg.Mode,
 		Provider:           resolvedProvider,
 		Model:              normalizeModel(resolvedProvider, cfg.Model),
+		ReasoningEffort:    cfg.ReasoningEffort,
 		Prompt:             cfg.Prompt,
 		State:              StateRunning,
 		StartedAt:          now,
@@ -164,7 +165,7 @@ func (m *Manager) buildCommand(cfg RunConfig) (string, error) {
 	}
 	switch prov {
 	case "codex":
-		return buildCodexCommand(model, cfg.RequirePermissions, cfg.Mode == "headless"), nil
+		return buildCodexCommand(model, cfg.ReasoningEffort, cfg.RequirePermissions, cfg.Mode == "headless"), nil
 	case "copilot":
 		return buildCopilotCommand(model), nil
 	default:
@@ -187,12 +188,13 @@ func buildClaudeCommand(model string, allowedTools []string, requirePerms bool) 
 }
 
 // buildCodexCommand builds the display command string for a Codex agent.
-func buildCodexCommand(model string, requirePerms, headless bool) string {
+func buildCodexCommand(model, effort string, requirePerms, headless bool) string {
 	parts := []string{"codex", "exec", "--json", "--skip-git-repo-check", "--ignore-user-config", "--ignore-rules"}
 	parts = append(parts, codexSandboxArgs(requirePerms, headless)...)
 	if model != "" {
 		parts = append(parts, "--model", model)
 	}
+	parts = append(parts, codexReasoningArgs(effort)...)
 	return strings.Join(parts, " ")
 }
 
@@ -208,6 +210,18 @@ func buildCopilotCommand(model string) string {
 		parts = append(parts, "--model", model)
 	}
 	return strings.Join(parts, " ")
+}
+
+// codexReasoningArgs returns the codex config override for model reasoning
+// effort, or nil when effort is empty (model default). Centralizing the
+// empty-value no-op here keeps all three codex builders from each re-deriving
+// it — a bare -c model_reasoning_effort= (empty value) is NOT the same as
+// omitting the flag.
+func codexReasoningArgs(effort string) []string {
+	if effort == "" {
+		return nil
+	}
+	return []string{"-c", "model_reasoning_effort=" + effort}
 }
 
 // codexSandboxArgs returns the sandbox/permission flags for `codex exec`.

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -221,6 +221,12 @@ func codexReasoningArgs(effort string) []string {
 	if effort == "" {
 		return nil
 	}
+	// Allowlist guards against tampered task YAML bypassing API-layer validation.
+	switch effort {
+	case "low", "medium", "high", "xhigh":
+	default:
+		return nil
+	}
 	return []string{"-c", "model_reasoning_effort=" + effort}
 }
 

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -648,6 +648,11 @@ func TestBuildCommand(t *testing.T) {
 			cfg:     RunConfig{Provider: "codex", Model: "gpt-5.4[1m]"},
 			wantErr: true,
 		},
+		{
+			name:    "codex with reasoning effort high",
+			cfg:     RunConfig{Provider: "codex", ReasoningEffort: "high"},
+			wantCmd: "codex exec --json --skip-git-repo-check --ignore-user-config --ignore-rules --dangerously-bypass-approvals-and-sandbox --model gpt-5.5 -c model_reasoning_effort=high",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -31,33 +31,33 @@ const (
 )
 
 type Agent struct {
-	ID                       string    `json:"id"`
-	TaskID                   string    `json:"taskId"`
-	Mode                     string    `json:"mode"`
-	State                    State     `json:"state"`
-	SessionID                string    `json:"sessionId"`
-	CostUSD                  float64   `json:"costUsd"`
-	InputTokens              int       `json:"inputTokens,omitempty"`
-	OutputTokens             int       `json:"outputTokens,omitempty"`
-	CacheCreationInputTokens int       `json:"cacheCreationInputTokens,omitempty"`
-	CacheReadInputTokens     int       `json:"cacheReadInputTokens,omitempty"`
-	ReasoningTokens          int       `json:"reasoningTokens,omitempty"`
+	ID                       string  `json:"id"`
+	TaskID                   string  `json:"taskId"`
+	Mode                     string  `json:"mode"`
+	State                    State   `json:"state"`
+	SessionID                string  `json:"sessionId"`
+	CostUSD                  float64 `json:"costUsd"`
+	InputTokens              int     `json:"inputTokens,omitempty"`
+	OutputTokens             int     `json:"outputTokens,omitempty"`
+	CacheCreationInputTokens int     `json:"cacheCreationInputTokens,omitempty"`
+	CacheReadInputTokens     int     `json:"cacheReadInputTokens,omitempty"`
+	ReasoningTokens          int     `json:"reasoningTokens,omitempty"`
 	// PremiumRequests is Copilot's billing unit (AI credits). Copilot reports
 	// no USD cost, so this is the usage signal surfaced for copilot agents;
 	// always 0 for claude/codex.
-	PremiumRequests          int       `json:"premiumRequests,omitempty"`
-	StartedAt                time.Time `json:"startedAt"`
-	LastEventAt              time.Time `json:"lastEventAt"`
-	LogPath                  string    `json:"logPath,omitempty"`
-	External                 bool      `json:"external"`
-	PID                      int       `json:"pid,omitempty"`
-	Command                  string    `json:"command,omitempty"`
-	Name                     string    `json:"name,omitempty"`
-	Project                  string    `json:"project,omitempty"`
-	Provider                 string    `json:"provider,omitempty"`
-	Model                    string    `json:"model,omitempty"`
-	ReasoningEffort          string    `json:"reasoningEffort,omitempty"`
-	Prompt                   string    `json:"prompt,omitempty"`
+	PremiumRequests int       `json:"premiumRequests,omitempty"`
+	StartedAt       time.Time `json:"startedAt"`
+	LastEventAt     time.Time `json:"lastEventAt"`
+	LogPath         string    `json:"logPath,omitempty"`
+	External        bool      `json:"external"`
+	PID             int       `json:"pid,omitempty"`
+	Command         string    `json:"command,omitempty"`
+	Name            string    `json:"name,omitempty"`
+	Project         string    `json:"project,omitempty"`
+	Provider        string    `json:"provider,omitempty"`
+	Model           string    `json:"model,omitempty"`
+	ReasoningEffort string    `json:"reasoningEffort,omitempty"`
+	Prompt          string    `json:"prompt,omitempty"`
 
 	TurnCount int `json:"turnCount,omitempty"`
 	// ToolCalls counts tool_use blocks observed across the run. Persisted to

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -31,32 +31,33 @@ const (
 )
 
 type Agent struct {
-	ID                       string  `json:"id"`
-	TaskID                   string  `json:"taskId"`
-	Mode                     string  `json:"mode"`
-	State                    State   `json:"state"`
-	SessionID                string  `json:"sessionId"`
-	CostUSD                  float64 `json:"costUsd"`
-	InputTokens              int     `json:"inputTokens,omitempty"`
-	OutputTokens             int     `json:"outputTokens,omitempty"`
-	CacheCreationInputTokens int     `json:"cacheCreationInputTokens,omitempty"`
-	CacheReadInputTokens     int     `json:"cacheReadInputTokens,omitempty"`
-	ReasoningTokens          int     `json:"reasoningTokens,omitempty"`
+	ID                       string    `json:"id"`
+	TaskID                   string    `json:"taskId"`
+	Mode                     string    `json:"mode"`
+	State                    State     `json:"state"`
+	SessionID                string    `json:"sessionId"`
+	CostUSD                  float64   `json:"costUsd"`
+	InputTokens              int       `json:"inputTokens,omitempty"`
+	OutputTokens             int       `json:"outputTokens,omitempty"`
+	CacheCreationInputTokens int       `json:"cacheCreationInputTokens,omitempty"`
+	CacheReadInputTokens     int       `json:"cacheReadInputTokens,omitempty"`
+	ReasoningTokens          int       `json:"reasoningTokens,omitempty"`
 	// PremiumRequests is Copilot's billing unit (AI credits). Copilot reports
 	// no USD cost, so this is the usage signal surfaced for copilot agents;
 	// always 0 for claude/codex.
-	PremiumRequests int       `json:"premiumRequests,omitempty"`
-	StartedAt       time.Time `json:"startedAt"`
-	LastEventAt     time.Time `json:"lastEventAt"`
-	LogPath         string    `json:"logPath,omitempty"`
-	External        bool      `json:"external"`
-	PID             int       `json:"pid,omitempty"`
-	Command         string    `json:"command,omitempty"`
-	Name            string    `json:"name,omitempty"`
-	Project         string    `json:"project,omitempty"`
-	Provider        string    `json:"provider,omitempty"`
-	Model           string    `json:"model,omitempty"`
-	Prompt          string    `json:"prompt,omitempty"`
+	PremiumRequests          int       `json:"premiumRequests,omitempty"`
+	StartedAt                time.Time `json:"startedAt"`
+	LastEventAt              time.Time `json:"lastEventAt"`
+	LogPath                  string    `json:"logPath,omitempty"`
+	External                 bool      `json:"external"`
+	PID                      int       `json:"pid,omitempty"`
+	Command                  string    `json:"command,omitempty"`
+	Name                     string    `json:"name,omitempty"`
+	Project                  string    `json:"project,omitempty"`
+	Provider                 string    `json:"provider,omitempty"`
+	Model                    string    `json:"model,omitempty"`
+	ReasoningEffort          string    `json:"reasoningEffort,omitempty"`
+	Prompt                   string    `json:"prompt,omitempty"`
 
 	TurnCount int `json:"turnCount,omitempty"`
 	// ToolCalls counts tool_use blocks observed across the run. Persisted to
@@ -622,6 +623,10 @@ type RunConfig struct {
 	// model when the primary is overloaded. Empty means inherit the manager's
 	// default; the flag is omitted only when the manager default is also empty.
 	FallbackModel string
+	// ReasoningEffort sets codex's model_reasoning_effort (low/medium/high/xhigh)
+	// for this run. Empty = model default. Codex-only. NOT the same as Effort
+	// (claude --effort) — different provider, CLI surface, and value set.
+	ReasoningEffort string
 }
 
 // PlanStep represents a single item from a TodoWrite tool call.

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -429,6 +429,7 @@ func agentFromRecord(r Record) *Agent {
 		MaxTurns:           r.MaxTurns,
 		stdinPath:          r.StdinPath,
 		requirePermissions: r.RequirePermissions,
+		ReasoningEffort:    r.ReasoningEffort,
 		detached:           true,
 	}
 }

--- a/internal/agent/registry.go
+++ b/internal/agent/registry.go
@@ -34,6 +34,10 @@ type Record struct {
 	// across a restart (codex respawns per turn and would otherwise default
 	// to permissive).
 	RequirePermissions bool `yaml:"require_permissions,omitempty"`
+	// ReasoningEffort preserves the codex model_reasoning_effort across restarts.
+	// Codex convo respawns a fresh process per turn — without this the effort
+	// would revert to model default after a restart.
+	ReasoningEffort string `yaml:"reasoning_effort,omitempty"`
 }
 
 // registryStore persists Records as one YAML file per agent under dir.

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -291,6 +291,7 @@ func buildCodexConvoArgs(a *Agent, cfg RunConfig, prompt string) []string {
 	if a.Model != "" {
 		args = append(args, "--model", a.Model)
 	}
+	args = append(args, codexReasoningArgs(a.ReasoningEffort)...)
 	if a.sessionCWD != "" {
 		args = append(args, "-C", a.sessionCWD)
 	}

--- a/internal/agent/runner_codex_convo_test.go
+++ b/internal/agent/runner_codex_convo_test.go
@@ -1,0 +1,63 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildCodexConvoArgs_ReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	t.Run("flag_present_when_set", func(t *testing.T) {
+		a := &Agent{ID: "a", Provider: "codex", ReasoningEffort: "xhigh"}
+		args := buildCodexConvoArgs(a, RunConfig{}, "hello")
+		found := false
+		for i := range len(args) - 1 {
+			if args[i] == "-c" && args[i+1] == "model_reasoning_effort=xhigh" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected -c model_reasoning_effort=xhigh in args; got %v", args)
+		}
+	})
+
+	t.Run("flag_absent_when_empty", func(t *testing.T) {
+		a := &Agent{ID: "a", Provider: "codex", ReasoningEffort: ""}
+		args := buildCodexConvoArgs(a, RunConfig{}, "hello")
+		for _, arg := range args {
+			if strings.Contains(arg, "model_reasoning_effort=") {
+				t.Errorf("model_reasoning_effort must be absent when empty; got %v", args)
+			}
+		}
+	})
+}
+
+func TestCodexReasoningArgs(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		effort string
+		want   []string
+	}{
+		{"", nil},
+		{"low", []string{"-c", "model_reasoning_effort=low"}},
+		{"medium", []string{"-c", "model_reasoning_effort=medium"}},
+		{"high", []string{"-c", "model_reasoning_effort=high"}},
+		{"xhigh", []string{"-c", "model_reasoning_effort=xhigh"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.effort, func(t *testing.T) {
+			got := codexReasoningArgs(tc.effort)
+			if len(got) != len(tc.want) {
+				t.Fatalf("codexReasoningArgs(%q) = %v, want %v", tc.effort, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("codexReasoningArgs(%q)[%d] = %q, want %q", tc.effort, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/agent/runner_headless_invocation.go
+++ b/internal/agent/runner_headless_invocation.go
@@ -39,6 +39,7 @@ func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args, env []
 		if a.Model != "" {
 			args = append(args, "--model", a.Model)
 		}
+		args = append(args, codexReasoningArgs(a.ReasoningEffort)...)
 		if a.sessionCWD != "" {
 			args = append(args, "-C", a.sessionCWD)
 		}

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -826,6 +826,54 @@ func TestBuildHeadlessInvocation_BashTimeout(t *testing.T) {
 	})
 }
 
+func TestBuildHeadlessInvocation_CodexReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	t.Run("flag_present_when_set", func(t *testing.T) {
+		a := &Agent{ID: "a", Provider: "codex", ReasoningEffort: "high"}
+		_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{Prompt: "hi"})
+		if err != nil {
+			t.Fatalf("buildHeadlessInvocation: %v", err)
+		}
+		found := false
+		for i := range len(args) - 1 {
+			if args[i] == "-c" && args[i+1] == "model_reasoning_effort=high" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected -c model_reasoning_effort=high in args; got %v", args)
+		}
+	})
+
+	t.Run("flag_absent_when_empty", func(t *testing.T) {
+		a := &Agent{ID: "a", Provider: "codex", ReasoningEffort: ""}
+		_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{Prompt: "hi"})
+		if err != nil {
+			t.Fatalf("buildHeadlessInvocation: %v", err)
+		}
+		for _, arg := range args {
+			if strings.Contains(arg, "model_reasoning_effort=") {
+				t.Errorf("model_reasoning_effort must be absent when empty; got %v", args)
+			}
+		}
+	})
+
+	t.Run("not_present_for_claude", func(t *testing.T) {
+		a := &Agent{ID: "a", Provider: "claude", ReasoningEffort: "high"}
+		_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{Prompt: "hi"})
+		if err != nil {
+			t.Fatalf("buildHeadlessInvocation: %v", err)
+		}
+		for _, arg := range args {
+			if strings.Contains(arg, "model_reasoning_effort=") {
+				t.Errorf("model_reasoning_effort must not appear for claude provider; got %v", args)
+			}
+		}
+	})
+}
+
 // TestBuildHeadlessInvocation_CodexAlwaysBypassesSandbox verifies that headless
 // codex invocations always use --dangerously-bypass-approvals-and-sandbox,
 // even when RequirePermissions=true. In headless mode there is no UI to serve

--- a/internal/sybra/app_agents.go
+++ b/internal/sybra/app_agents.go
@@ -202,6 +202,7 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, includeTaskD
 		ExtraEnv:           extraEnv,
 		MaxTurns:           t.MaxTurns,
 		ForkSubagent:       t.ForkSubagent,
+		ReasoningEffort:    t.ReasoningEffort,
 	})
 	if err != nil {
 		// Gate block leaves no running agent. Flip the task back to todo so

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -246,6 +246,7 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		OneShot:            oneShot,
 		MaxTurns:           t.MaxTurns,
 		RequirePermissions: resolvePermission(t, a.agentOrch.cfg),
+		ReasoningEffort:    t.ReasoningEffort,
 	}
 
 	// Caller-provided dir takes precedence (e.g. pr-fix flow pre-stages a

--- a/internal/sybra/svc_info.go
+++ b/internal/sybra/svc_info.go
@@ -15,8 +15,9 @@ type VersionInfo struct {
 
 // CodexModel is a single entry from `codex debug models`.
 type CodexModel struct {
-	Slug        string `json:"slug"`
-	DisplayName string `json:"display_name"`
+	Slug                     string   `json:"slug"`
+	DisplayName              string   `json:"display_name"`
+	SupportedReasoningLevels []string `json:"supported_reasoning_levels,omitempty"`
 }
 
 // CopilotModel is a single Copilot model option (slug + display name).

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -132,6 +132,23 @@ func ValidateAgentMode(s string) (string, error) {
 	return s, nil
 }
 
+// AllReasoningEfforts returns every valid codex reasoning effort level.
+func AllReasoningEfforts() []string { return []string{"low", "medium", "high", "xhigh"} }
+
+var validReasoningEfforts = map[string]bool{"low": true, "medium": true, "high": true, "xhigh": true}
+
+// ValidateReasoningEffort accepts the empty string (model default) or one of the
+// codex-advertised levels. Static allowlist — offline-safe, no codex probe.
+func ValidateReasoningEffort(s string) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+	if !validReasoningEfforts[s] {
+		return "", fmt.Errorf("invalid reasoning_effort %q (valid: low, medium, high, xhigh, or empty)", s)
+	}
+	return s, nil
+}
+
 type AgentRun struct {
 	AgentID   string    `yaml:"agent_id" json:"agentId"`
 	Role      string    `yaml:"role,omitempty" json:"role"` // triage, plan, eval, pr-fix, or "" for implementation
@@ -210,11 +227,16 @@ type Task struct {
 	// ForkSubagent enables CLAUDE_CODE_FORK_SUBAGENT=1 for this task's headless
 	// agent, allowing a single prompt to spawn parallel subagent runs. Trades
 	// higher token cost for reduced wall-clock time on multi-part prompts.
-	ForkSubagent bool                `yaml:"fork_subagent,omitempty" json:"forkSubagent,omitempty"`
-	AgentRuns    []AgentRun          `yaml:"agent_runs,omitempty" json:"agentRuns"`
-	Workflow     *workflow.Execution `yaml:"workflow,omitempty" json:"workflow"`
-	CreatedAt    time.Time           `yaml:"created_at" json:"createdAt"`
-	UpdatedAt    time.Time           `yaml:"updated_at" json:"updatedAt"`
+	ForkSubagent bool `yaml:"fork_subagent,omitempty" json:"forkSubagent,omitempty"`
+	// ReasoningEffort sets the Codex model reasoning level for this task's agents
+	// via -c model_reasoning_effort=<v>. Empty = model default. Codex-only;
+	// ignored for claude agents. Distinct from the claude-only extended-thinking
+	// knob — different CLI surface and vocabulary (xhigh vs max).
+	ReasoningEffort string              `yaml:"reasoning_effort,omitempty" json:"reasoningEffort,omitempty"`
+	AgentRuns       []AgentRun          `yaml:"agent_runs,omitempty" json:"agentRuns"`
+	Workflow        *workflow.Execution `yaml:"workflow,omitempty" json:"workflow"`
+	CreatedAt       time.Time           `yaml:"created_at" json:"createdAt"`
+	UpdatedAt       time.Time           `yaml:"updated_at" json:"updatedAt"`
 
 	Body         string `yaml:"-" json:"body"`
 	Plan         string `yaml:"-" json:"plan,omitempty"`

--- a/internal/task/model_test.go
+++ b/internal/task/model_test.go
@@ -118,6 +118,53 @@ func TestAllAgentModes(t *testing.T) {
 	}
 }
 
+func TestValidateReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty_ok", func(t *testing.T) {
+		t.Parallel()
+		got, err := ValidateReasoningEffort("")
+		if err != nil {
+			t.Fatalf("ValidateReasoningEffort(%q): %v", "", err)
+		}
+		if got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+
+	valid := []string{"low", "medium", "high", "xhigh"}
+	for _, v := range valid {
+		t.Run(v+"_ok", func(t *testing.T) {
+			t.Parallel()
+			got, err := ValidateReasoningEffort(v)
+			if err != nil {
+				t.Fatalf("ValidateReasoningEffort(%q): %v", v, err)
+			}
+			if got != v {
+				t.Errorf("got %q, want %q", got, v)
+			}
+		})
+	}
+
+	invalid := []string{"max", "ultra", "XHIGH", "extreme", "bogus", " high"}
+	for _, v := range invalid {
+		t.Run("invalid_"+v, func(t *testing.T) {
+			t.Parallel()
+			if _, err := ValidateReasoningEffort(v); err == nil {
+				t.Fatalf("expected error for %q, got nil", v)
+			}
+		})
+	}
+}
+
+func TestAllReasoningEfforts(t *testing.T) {
+	t.Parallel()
+	efforts := AllReasoningEfforts()
+	if len(efforts) != 4 {
+		t.Errorf("got %d efforts, want 4", len(efforts))
+	}
+}
+
 func TestTask_DirName_WithSlug(t *testing.T) {
 	t.Parallel()
 	task := Task{ID: "a1b2c3d4", Slug: "my-task"}

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -551,6 +551,9 @@ func (s *Store) UpdateWithPrev(id string, u Update) (Task, Status, error) {
 	if u.ForkSubagent != nil {
 		t.ForkSubagent = *u.ForkSubagent
 	}
+	if u.ReasoningEffort != nil {
+		t.ReasoningEffort = *u.ReasoningEffort
+	}
 	if err := s.writeSidecars(id, u, &t); err != nil {
 		return Task{}, "", err
 	}

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -1514,3 +1514,48 @@ func TestStoreListInvalidatePathTargetedRefresh(t *testing.T) {
 		t.Fatalf("want 1 task remaining, got %d", len(tasks))
 	}
 }
+
+func TestReasoningEffortRoundTrip(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tk, err := store.Create("effort test", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set reasoning effort via UpdateMap.
+	updated, err := store.UpdateMap(tk.ID, map[string]any{"reasoning_effort": "high"})
+	if err != nil {
+		t.Fatalf("UpdateMap: %v", err)
+	}
+	if updated.ReasoningEffort != "high" {
+		t.Errorf("after update: ReasoningEffort = %q, want %q", updated.ReasoningEffort, "high")
+	}
+
+	// Re-read from disk to verify persistence.
+	got, err := store.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ReasoningEffort != "high" {
+		t.Errorf("after re-read: ReasoningEffort = %q, want %q", got.ReasoningEffort, "high")
+	}
+
+	// Clear via "default" sentinel (empty string).
+	cleared, err := store.UpdateMap(tk.ID, map[string]any{"reasoning_effort": ""})
+	if err != nil {
+		t.Fatalf("UpdateMap clear: %v", err)
+	}
+	if cleared.ReasoningEffort != "" {
+		t.Errorf("after clear: ReasoningEffort = %q, want empty", cleared.ReasoningEffort)
+	}
+
+	// Invalid value must error.
+	if _, err := store.UpdateMap(tk.ID, map[string]any{"reasoning_effort": "ultra"}); err == nil {
+		t.Error("expected error for invalid reasoning_effort, got nil")
+	}
+}

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -12,34 +12,35 @@ import (
 // A nil pointer means "leave unchanged"; a non-nil pointer applies the new value.
 // For Workflow: nil = unchanged; non-nil = overwrite (even if pointed-to value is nil).
 type Update struct {
-	Title          *string
-	Slug           *string
-	Status         *Status
-	StatusReason   *string
-	BlockedByIssue *string
-	AgentMode      *string
-	TaskType       *TaskType
-	Body           *string
-	Tags           *[]string
-	ProjectID      *string
-	Branch         *string
-	WorktreeDir    *string
-	PRNumber       *int
-	Issue          *string
-	Reviewed       *bool
-	RunRole        *string
-	ReviewPhase    *string
-	PRPhase        *string
-	TodoistID      *string
-	Priority       *Priority
-	DueDate        **time.Time
-	Workflow       **workflow.Execution
-	Plan           *string
-	PlanCritique   *string
-	CodeReview     *string
-	MaxTurns       *int
-	ForkSubagent   *bool
-	Outcome        *string
+	Title           *string
+	Slug            *string
+	Status          *Status
+	StatusReason    *string
+	BlockedByIssue  *string
+	AgentMode       *string
+	TaskType        *TaskType
+	Body            *string
+	Tags            *[]string
+	ProjectID       *string
+	Branch          *string
+	WorktreeDir     *string
+	PRNumber        *int
+	Issue           *string
+	Reviewed        *bool
+	RunRole         *string
+	ReviewPhase     *string
+	PRPhase         *string
+	TodoistID       *string
+	Priority        *Priority
+	DueDate         **time.Time
+	Workflow        **workflow.Execution
+	Plan            *string
+	PlanCritique    *string
+	CodeReview      *string
+	MaxTurns        *int
+	ForkSubagent    *bool
+	ReasoningEffort *string
+	Outcome         *string
 }
 
 // Ptr returns a pointer to v. Convenience for building Update literals.
@@ -88,6 +89,16 @@ func applyMapField(u *Update, k string, v any) error {
 			return fmt.Errorf("field %q: want bool, got %T", k, v)
 		}
 		u.ForkSubagent = &b
+	case "reasoning_effort":
+		s, ok := v.(string)
+		if !ok {
+			return fmt.Errorf("field %q: want string, got %T", k, v)
+		}
+		eff, err := ValidateReasoningEffort(s)
+		if err != nil {
+			return err
+		}
+		u.ReasoningEffort = &eff
 	case "due_date":
 		return applyDueDateField(u, v)
 	case "reviewed":


### PR DESCRIPTION
## Motivation

Adds an optional per-task `reasoning_effort` field (`low | medium | high | xhigh`) that flows into every Codex `exec` invocation as `-c model_reasoning_effort=<value>`. Empty = model default. Mirrors the existing per-task `ForkSubagent` knob.

> Changelog: feat(codex): add per-task reasoning effort

## Implementation information

- **Task/model layer** (`internal/task`): `ReasoningEffort string` field on `Task`, static `ValidateReasoningEffort` allowlist (offline-safe), update/store plumbing
- **Agent layer** (`internal/agent`): field on `Agent` + `RunConfig`; single `codexReasoningArgs()` helper wired into all 3 Codex builders (`buildCodexCommand`, `runner_headless_invocation`, `buildCodexConvoArgs`); field persisted on registry `Record` for reattach survival; `agentFromRecord` and `saveRegistry` updated
- **Dispatch** (`internal/sybra/app_agents.go`, `app_workflow.go`): `ReasoningEffort: t.ReasoningEffort` threaded into `RunConfig`
- **CLI** (`cmd/sybra-cli`): `--reasoning-effort E` flag on `update`; `default` clears the override
- **GUI**: `<select>` picker in `CreateTaskDialog` (create flow) and `TaskMetadataRow` (metadata panel); labeled "Codex only"
- **Bindings**: regenerated via `wails3 generate bindings`
- **Tests**: `ValidateReasoningEffort`, `codexReasoningArgs`, store round-trip, headless builder, convo builder

Deliberately **not** wired for system-role dispatch (`app_workflow.go` only supplies impl-agent effort) — deferred per the plan's scope decision. Claude agents silently ignore the field (failover case documented in GUI label).

Closes https://github.com/Automaat/sybra/issues/1035