### PR TITLE
fix(workflow): cascade synchronous workflows

### DIFF
--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -117,6 +117,7 @@ type Engine struct {
 	starting        map[string]struct{}    // taskID → StartWorkflowWithVars in progress
 	humanAction     map[string]struct{}    // taskID → HandleHumanAction in progress
 	agentSteps      map[string]agentEntry  // agentID → {taskID, stepID}
+	cascadeDepth    map[string]int         // taskID → synchronous cascade hop depth (recursion guard)
 	resumeError     *logging.ErrorThrottle
 }
 
@@ -133,6 +134,7 @@ func NewEngine(store *Store, tasks TaskProvider, agents AgentLauncher, logger *s
 		starting:        make(map[string]struct{}),
 		humanAction:     make(map[string]struct{}),
 		agentSteps:      make(map[string]agentEntry),
+		cascadeDepth:    make(map[string]int),
 		resumeError:     logging.NewErrorThrottle(),
 	}
 }

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -72,7 +72,9 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 				return err
 			}
 			release()
-			return e.executeSteps(taskID, &def, currentStep, wfExec)
+			comp, sErr := e.executeSteps(taskID, &def, currentStep, wfExec)
+			e.fireComplete(comp)
+			return sErr
 		}
 		e.logger.Warn("workflow.retry.exhausted", "task_id", taskID, "step", output.StepID,
 			"attempts", retries)
@@ -93,17 +95,23 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 	}
 	t.Workflow = wfExec
 
-	nextStep, err := e.resolveNext(taskID, &def, currentStep, wfExec, t)
+	nextStep, comp, err := e.resolveNext(taskID, &def, currentStep, wfExec, t)
 	if err != nil {
 		return err
 	}
 	if nextStep == nil {
+		// Release the inflight lock before the completion callback so its
+		// cascade dispatch doesn't re-enter AdvanceStep against a held lock.
+		release()
+		e.fireComplete(comp)
 		return nil // workflow completed
 	}
 
 	e.logger.Info("workflow.advance", "task_id", taskID, "from", output.StepID, "to", nextStep.ID)
 	release()
-	return e.executeSteps(taskID, &def, nextStep, wfExec)
+	comp, sErr := e.executeSteps(taskID, &def, nextStep, wfExec)
+	e.fireComplete(comp)
+	return sErr
 }
 
 // acquireInflight serializes AdvanceStep for a task. Blocks (rather than
@@ -263,12 +271,18 @@ func (e *CycleError) Error() string {
 // executeSteps iterates through synchronous steps until it hits an async step
 // (run_agent, wait_human) or the workflow ends. This avoids recursive calls
 // between executeStep/AdvanceStep that caused inflight guard deadlocks.
-func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec *Execution) error {
+// executeSteps drives synchronous steps until the workflow either reaches an
+// async step (run_agent/parallel/wait_human — returns nil completion) or ends
+// (returns a non-nil *CompletionInfo). The completion is returned rather than
+// fired here so marker-holding callers (StartWorkflowWithVars, DispatchEvent,
+// ResumeStalled) can fireComplete it only after their per-task marker is
+// released; non-marker callers fireComplete it immediately.
+func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec *Execution) (*CompletionInfo, error) {
 	visited := make(map[string]int) // stepID → first-seen iteration index
 	for i := range maxSyncSteps {
 		t, err := e.tasks.GetTask(taskID)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		// Snapshot the execution for the template context so that clearing
@@ -289,7 +303,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 		if wfExec.Recovered {
 			wfExec.Recovered = false
 			if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
-				return err
+				return nil, err
 			}
 		}
 
@@ -297,29 +311,29 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 		// will call AdvanceStep later.
 		switch step.Type {
 		case StepRunAgent:
-			return e.execRunAgent(taskID, step, wfExec, ctx)
+			return nil, e.execRunAgent(taskID, step, wfExec, ctx)
 		case StepParallel:
 			return e.execParallel(taskID, def, step, wfExec, ctx)
 		case StepWaitHuman:
-			return e.execWaitHuman(taskID, step, wfExec)
+			return nil, e.execWaitHuman(taskID, step, wfExec)
 		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepRerequestReview, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepTriageReview:
 			// handled below as sync steps
 		default:
-			return fmt.Errorf("unknown step type %q", step.Type)
+			return nil, fmt.Errorf("unknown step type %q", step.Type)
 		}
 
 		// Detect cycles: a sync step revisited without an async break means
 		// the workflow loops forever. Return a CycleError instead of hitting
 		// the generic maxSyncSteps limit.
 		if firstAt, seen := visited[step.ID]; seen {
-			return &CycleError{StepID: step.ID, At: i, FirstAt: firstAt}
+			return nil, &CycleError{StepID: step.ID, At: i, FirstAt: firstAt}
 		}
 		visited[step.ID] = i
 
 		// Sync steps: execute, record result, resolve next, loop.
 		output, execErr := e.execSyncStep(taskID, step, wfExec, ctx, t)
 		if execErr != nil {
-			return execErr
+			return nil, execErr
 		}
 
 		now := time.Now().UTC()
@@ -337,22 +351,22 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 		// Re-read task for latest state (set_status changes task).
 		t, err = e.tasks.GetTask(taskID)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		t.Workflow = wfExec
 
-		nextStep, nErr := e.resolveNext(taskID, def, step, wfExec, t)
+		nextStep, comp, nErr := e.resolveNext(taskID, def, step, wfExec, t)
 		if nErr != nil {
-			return nErr
+			return nil, nErr
 		}
 		if nextStep == nil {
-			return nil // workflow completed
+			return comp, nil // workflow completed; caller fires onComplete after marker release
 		}
 
 		e.logger.Info("workflow.advance", "task_id", taskID, "from", step.ID, "to", nextStep.ID)
 		step = nextStep
 	}
-	return fmt.Errorf("workflow exceeded max sync step depth (%d)", maxSyncSteps)
+	return nil, fmt.Errorf("workflow exceeded max sync step depth (%d)", maxSyncSteps)
 }
 
 // execSyncStep dispatches to a synchronous step handler and returns its output.
@@ -385,8 +399,15 @@ func (e *Engine) execSyncStep(taskID string, step *Step, wfExec *Execution, ctx 
 	}
 }
 
-// resolveNext evaluates transitions and returns the next step, or nil if workflow ends.
-func (e *Engine) resolveNext(taskID string, def *Definition, current *Step, wfExec *Execution, t TaskInfo) (*Step, error) {
+// resolveNext evaluates transitions and returns the next step, or nil if the
+// workflow ends. When the workflow ends it returns a non-nil *CompletionInfo;
+// the caller must hand it to fireComplete *after* releasing any per-task start
+// marker (see fireComplete). resolveNext deliberately does NOT invoke
+// e.onComplete itself: it runs inside DispatchEvent/StartWorkflowWithVars while
+// the dispatching/starting marker is held, so a cascade dispatched here would
+// be rejected as re-entrant (the bug that left synchronous mechanical workflows
+// — e.g. simple-task-handoff — never starting their successor).
+func (e *Engine) resolveNext(taskID string, def *Definition, current *Step, wfExec *Execution, t TaskInfo) (*Step, *CompletionInfo, error) {
 	fields := taskFields(t)
 	for k, v := range wfExec.Variables {
 		fields["vars."+k] = v
@@ -400,7 +421,7 @@ func (e *Engine) resolveNext(taskID string, def *Definition, current *Step, wfEx
 		e.logger.Error("workflow.transition.failed", "task_id", taskID, "step", current.ID, "err", tErr)
 		wfExec.State = ExecFailed
 		_ = e.tasks.SetWorkflow(taskID, wfExec)
-		return nil, tErr
+		return nil, nil, tErr
 	}
 
 	if nextID == "" {
@@ -409,28 +430,71 @@ func (e *Engine) resolveNext(taskID string, def *Definition, current *Step, wfEx
 		wfExec.CompletedAt = &now
 		wfExec.CurrentStep = ""
 		e.logger.Info("workflow.completed", "task_id", taskID, "workflow", def.ID)
-		err := e.tasks.SetWorkflow(taskID, wfExec)
-		if err == nil && e.onComplete != nil {
-			e.onComplete(CompletionInfo{
-				TaskID:     taskID,
-				WorkflowID: def.ID,
-				Variables:  wfExec.Variables,
-			})
+		if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
+			return nil, nil, err
 		}
-		return nil, err
+		return nil, &CompletionInfo{
+			TaskID:     taskID,
+			WorkflowID: def.ID,
+			Variables:  wfExec.Variables,
+		}, nil
 	}
 
 	nextStep := def.StepByID(nextID)
 	if nextStep == nil {
-		return nil, fmt.Errorf("next step %s not found in workflow %s", nextID, def.ID)
+		return nil, nil, fmt.Errorf("next step %s not found in workflow %s", nextID, def.ID)
 	}
 
 	wfExec.CurrentStep = nextStep.ID
 	wfExec.State = ExecRunning
 	if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return nextStep, nil
+	return nextStep, nil, nil
+}
+
+// maxCascadeDepth bounds how many workflows may chain synchronously off a
+// single task before the engine refuses to cascade further. The completion
+// callback runs the next workflow's DispatchEvent inline, so an all-mechanical
+// loop (e.g. two set_status workflows that ping-pong a task between two
+// non-terminal statuses) would otherwise recurse on the stack until it
+// overflows. Production builtins never approach this — every successor reaches
+// an async run_agent/wait_human step that breaks the chain — so the bound only
+// fires on a misconfigured definition set, which it converts into a logged
+// error instead of a crash.
+const maxCascadeDepth = 64
+
+// fireComplete invokes the workflow-completion callback for a synchronously
+// finished workflow. Callers MUST invoke it only after releasing any per-task
+// start marker (the dispatching/starting maps), so the callback's cascade
+// DispatchEvent isn't rejected as re-entrant against the workflow that just
+// finished. A nil completion (workflow did not finish in this call) is a no-op.
+func (e *Engine) fireComplete(c *CompletionInfo) {
+	if c == nil || e.onComplete == nil {
+		return
+	}
+
+	e.mu.Lock()
+	e.cascadeDepth[c.TaskID]++
+	depth := e.cascadeDepth[c.TaskID]
+	e.mu.Unlock()
+	defer func() {
+		e.mu.Lock()
+		if e.cascadeDepth[c.TaskID] <= 1 {
+			delete(e.cascadeDepth, c.TaskID)
+		} else {
+			e.cascadeDepth[c.TaskID]--
+		}
+		e.mu.Unlock()
+	}()
+
+	if depth > maxCascadeDepth {
+		e.logger.Error("workflow.cascade.depth-exceeded",
+			"task_id", c.TaskID, "workflow", c.WorkflowID, "depth", depth)
+		return
+	}
+
+	e.onComplete(*c)
 }
 
 func taskFields(t TaskInfo) map[string]string {

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -44,7 +44,12 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 	// step's record + transitions are emitted only after every child has
 	// terminated, so we never go through the single-step record path here.
 	if ctx.ParallelParent != nil {
-		return e.advanceParallelChild(taskID, &def, ctx.ParallelParent, currentStep, wfExec, output)
+		comp, pErr := e.advanceParallelChild(taskID, &def, ctx.ParallelParent, currentStep, wfExec, output)
+		// Release inflight before the completion callback so its cascade
+		// dispatch never runs under the held lock (matches the paths below).
+		release()
+		e.fireComplete(comp)
+		return pErr
 	}
 
 	// Record step completion.

--- a/internal/workflow/engine_cascade_test.go
+++ b/internal/workflow/engine_cascade_test.go
@@ -1,0 +1,206 @@
+package workflow
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// addStatusWorkflow registers a minimal mechanical workflow: a single
+// set_status step that flips the task to setStatus, then ends. With an empty
+// condStatus the trigger has no conditions (used for the task.created entry
+// workflow); otherwise it fires on task.status_changed when task.status equals
+// condStatus.
+func addStatusWorkflow(t *testing.T, store *Store, id, on, condStatus, setStatus string) {
+	t.Helper()
+	trigger := Trigger{On: on}
+	if condStatus != "" {
+		trigger.Conditions = []Condition{
+			{Field: "task.status", Operator: "equals", Value: condStatus},
+		}
+	}
+	def := Definition{
+		ID:      id,
+		Name:    id,
+		Trigger: trigger,
+		Steps: []Step{
+			{
+				ID:     "flip",
+				Name:   "Flip",
+				Type:   StepSetStatus,
+				Config: StepConfig{Status: setStatus},
+				Next:   []Transition{{GoTo: ""}},
+			},
+		},
+	}
+	if err := store.Save(def); err != nil {
+		t.Fatalf("save %s: %v", id, err)
+	}
+}
+
+// cascadeOnComplete mirrors sybra's OnWorkflowComplete: on every workflow
+// completion it re-dispatches a task.status_changed event for the task's
+// current status, letting the next workflow in the chain pick up.
+func cascadeOnComplete(engine *Engine, tasks *memTasks) func(CompletionInfo) {
+	return func(info CompletionInfo) {
+		cur, err := tasks.GetTask(info.TaskID)
+		if err != nil {
+			return
+		}
+		_, _ = engine.DispatchEvent(info.TaskID, "task.status_changed",
+			map[string]string{"task.status": cur.Status}, nil)
+	}
+}
+
+// TestCascade_SynchronousWorkflowChainsToSuccessor is the regression test for
+// the handoff bug: a fully mechanical workflow (set_status only, no async step)
+// completes synchronously inside the start/dispatch call, so its completion
+// callback used to fire while the per-task start marker was still held and the
+// cascade DispatchEvent was rejected as re-entrant — the next workflow never
+// started. The fix fires onComplete only after the marker releases.
+//
+// Chain: "kickoff" (on task.created) → in-progress; "follow" (on
+// task.status_changed where status==in-progress) → done.
+func TestCascade_SynchronousWorkflowChainsToSuccessor(t *testing.T) {
+	t.Run("via DispatchEvent (task.created)", func(t *testing.T) {
+		store := newTestStoreWith(t)
+		tasks := newMemTasks()
+		agents := newMockAgents()
+		engine := NewEngine(store, tasks, agents, discardLogger())
+		engine.SetOnComplete(cascadeOnComplete(engine, tasks))
+
+		addStatusWorkflow(t, store, "kickoff", "task.created", "", "in-progress")
+		addStatusWorkflow(t, store, "follow", "task.status_changed", "in-progress", "done")
+		tasks.Put(TaskInfo{ID: "t1", Status: "new", AgentMode: "headless"})
+
+		if _, err := engine.DispatchEvent("t1", "task.created", nil, nil); err != nil {
+			t.Fatalf("dispatch task.created: %v", err)
+		}
+
+		got, err := tasks.GetTask("t1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status != "done" {
+			t.Fatalf("status = %q, want done — cascade to successor workflow did not run", got.Status)
+		}
+	})
+
+	t.Run("via StartWorkflow (restart-stale path)", func(t *testing.T) {
+		store := newTestStoreWith(t)
+		tasks := newMemTasks()
+		agents := newMockAgents()
+		engine := NewEngine(store, tasks, agents, discardLogger())
+		engine.SetOnComplete(cascadeOnComplete(engine, tasks))
+
+		addStatusWorkflow(t, store, "kickoff", "task.created", "", "in-progress")
+		addStatusWorkflow(t, store, "follow", "task.status_changed", "in-progress", "done")
+		// restart-stale restarts a task's own terminal mechanical workflow by ID.
+		tasks.Put(TaskInfo{
+			ID:        "t2",
+			Status:    "in-progress",
+			AgentMode: "headless",
+			Workflow:  &Execution{WorkflowID: "kickoff", State: ExecCompleted},
+		})
+
+		if err := engine.StartWorkflow("t2", "kickoff"); err != nil {
+			t.Fatalf("start workflow: %v", err)
+		}
+
+		got, err := tasks.GetTask("t2")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status != "done" {
+			t.Fatalf("status = %q, want done — cascade to successor workflow did not run", got.Status)
+		}
+	})
+}
+
+// TestCascade_ParallelTerminalStepCascades guards the mirror bug the adversary
+// surfaced: a workflow whose TERMINAL step is a `parallel` block can also
+// complete synchronously — when every child fails at spawn, execParallel calls
+// finalizeParallelParent inline, inside the dispatch markers. The completion
+// must still thread up and cascade after the markers release, not be dropped.
+func TestCascade_ParallelTerminalStepCascades(t *testing.T) {
+	store := newTestStoreWith(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	agents.failSpawn = errors.New("spawn boom") // force all parallel children to fail at spawn
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine.SetOnComplete(cascadeOnComplete(engine, tasks))
+
+	// kickoff ends on a parallel block (no set_status), so it leaves the task
+	// at "new"; the successor triggers on that.
+	par := Definition{
+		ID:      "kickoff-par",
+		Name:    "kickoff-par",
+		Trigger: Trigger{On: "task.created"},
+		Steps: []Step{{
+			ID:   "fanout",
+			Name: "Fanout",
+			Type: StepParallel,
+			Parallel: []Step{
+				{ID: "a", Type: StepRunAgent, Config: StepConfig{Role: "plan", Mode: "headless", Prompt: "x"}},
+				{ID: "b", Type: StepRunAgent, Config: StepConfig{Role: "plan", Mode: "headless", Prompt: "x"}},
+			},
+			Next: []Transition{{GoTo: ""}},
+		}},
+	}
+	if err := store.Save(par); err != nil {
+		t.Fatalf("save kickoff-par: %v", err)
+	}
+	addStatusWorkflow(t, store, "follow", "task.status_changed", "new", "done")
+	tasks.Put(TaskInfo{ID: "t1", Status: "new", AgentMode: "headless"})
+
+	if _, err := engine.DispatchEvent("t1", "task.created", nil, nil); err != nil {
+		t.Fatalf("dispatch task.created: %v", err)
+	}
+
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "done" {
+		t.Fatalf("status = %q, want done — parallel-terminal completion did not cascade", got.Status)
+	}
+}
+
+// TestCascade_DepthGuardStopsRunawayChain proves the recursion guard: two
+// mechanical workflows that ping-pong a task between two non-terminal statuses
+// would recurse synchronously forever (stack overflow) without maxCascadeDepth.
+// The guard converts it into a bounded, logged stop. The test completing at all
+// (instead of overflowing) is the assertion; the log line confirms the cause.
+func TestCascade_DepthGuardStopsRunawayChain(t *testing.T) {
+	store := newTestStoreWith(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	var logBuf bytes.Buffer
+	engine := NewEngine(store, tasks, agents, slog.New(slog.NewTextHandler(&logBuf, nil)))
+	engine.SetOnComplete(cascadeOnComplete(engine, tasks))
+
+	// Ping-pong between two real non-terminal statuses (definition validation
+	// rejects non-enum values).
+	addStatusWorkflow(t, store, "kickoff", "task.created", "", "todo")
+	addStatusWorkflow(t, store, "todo2prog", "task.status_changed", "todo", "in-progress")
+	addStatusWorkflow(t, store, "prog2todo", "task.status_changed", "in-progress", "todo")
+	tasks.Put(TaskInfo{ID: "t1", Status: "new", AgentMode: "headless"})
+
+	// Without the guard this never returns; with it, it unwinds at the bound.
+	if _, err := engine.DispatchEvent("t1", "task.created", nil, nil); err != nil {
+		t.Fatalf("dispatch task.created: %v", err)
+	}
+
+	if !strings.Contains(logBuf.String(), "workflow.cascade.depth-exceeded") {
+		t.Fatalf("expected a cascade depth-exceeded log, got:\n%s", logBuf.String())
+	}
+	// The cascade map must not leak after unwinding.
+	engine.mu.Lock()
+	leaked := len(engine.cascadeDepth)
+	engine.mu.Unlock()
+	if leaked != 0 {
+		t.Fatalf("cascadeDepth leaked %d entries after unwind", leaked)
+	}
+}

--- a/internal/workflow/engine_dispatch.go
+++ b/internal/workflow/engine_dispatch.go
@@ -25,10 +25,26 @@ func (e *Engine) StartWorkflow(taskID, workflowID string) error {
 // (restart + UI button, two loop-agent ticks, etc) never both spawn agents
 // for the same task. Second caller gets ErrWorkflowAlreadyActive.
 func (e *Engine) StartWorkflowWithVars(taskID, workflowID string, vars map[string]string) error {
+	// startWorkflowLocked holds the `starting` marker; it is released by the
+	// time this returns, so firing the completion here cannot re-enter against
+	// it. This is what lets a synchronous mechanical workflow (e.g.
+	// simple-task-handoff) cascade into its successor.
+	comp, err := e.startWorkflowLocked(taskID, workflowID, vars)
+	e.fireComplete(comp)
+	return err
+}
+
+// startWorkflowLocked is the marker-holding body shared by StartWorkflowWithVars
+// and DispatchEvent. It returns a non-nil *CompletionInfo when the workflow
+// finished synchronously within this call; the caller must hand it to
+// fireComplete only AFTER releasing its own per-task marker (starting via this
+// function's defer, plus dispatching for DispatchEvent) so the completion's
+// cascade dispatch is not rejected as re-entrant.
+func (e *Engine) startWorkflowLocked(taskID, workflowID string, vars map[string]string) (*CompletionInfo, error) {
 	e.mu.Lock()
 	if _, busy := e.starting[taskID]; busy {
 		e.mu.Unlock()
-		return fmt.Errorf("%w: start in progress", ErrWorkflowAlreadyActive)
+		return nil, fmt.Errorf("%w: start in progress", ErrWorkflowAlreadyActive)
 	}
 	e.starting[taskID] = struct{}{}
 	e.mu.Unlock()
@@ -48,18 +64,18 @@ func (e *Engine) StartWorkflowWithVars(taskID, workflowID string, vars map[strin
 		t.Workflow != nil &&
 		t.Workflow.State != ExecCompleted &&
 		t.Workflow.State != ExecFailed {
-		return fmt.Errorf("%w: %s (state=%s)",
+		return nil, fmt.Errorf("%w: %s (state=%s)",
 			ErrWorkflowAlreadyActive, t.Workflow.WorkflowID, t.Workflow.State)
 	}
 
 	def, err := e.store.Get(workflowID)
 	if err != nil {
-		return fmt.Errorf("get workflow %s: %w", workflowID, err)
+		return nil, fmt.Errorf("get workflow %s: %w", workflowID, err)
 	}
 
 	first := def.FirstStep()
 	if first == nil {
-		return fmt.Errorf("workflow %s has no steps", workflowID)
+		return nil, fmt.Errorf("workflow %s has no steps", workflowID)
 	}
 
 	variables := make(map[string]string, len(vars))
@@ -74,7 +90,7 @@ func (e *Engine) StartWorkflowWithVars(taskID, workflowID string, vars map[strin
 	}
 
 	if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
-		return fmt.Errorf("set workflow on task: %w", err)
+		return nil, fmt.Errorf("set workflow on task: %w", err)
 	}
 
 	e.logger.Info("workflow.start", "task_id", taskID, "workflow", workflowID, "step", first.ID)
@@ -146,6 +162,12 @@ func (e *Engine) DispatchEvent(taskID, event string, extraFields, vars map[strin
 	}
 	e.dispatching[taskID] = struct{}{}
 	e.mu.Unlock()
+	// If the matched workflow finishes synchronously (a mechanical workflow with
+	// no async step), its completion must be fired only after `dispatching` is
+	// cleared, or its cascade dispatch re-enters and is dropped. Register the
+	// fire defer *before* the marker-delete defer so LIFO runs it afterwards.
+	var completion *CompletionInfo
+	defer func() { e.fireComplete(completion) }()
 	defer func() {
 		e.mu.Lock()
 		delete(e.dispatching, taskID)
@@ -166,9 +188,11 @@ func (e *Engine) DispatchEvent(taskID, event string, extraFields, vars map[strin
 	if def == nil {
 		return "", nil
 	}
-	if err := e.StartWorkflowWithVars(taskID, def.ID, vars); err != nil {
-		return "", fmt.Errorf("start %s: %w", def.ID, err)
+	comp, sErr := e.startWorkflowLocked(taskID, def.ID, vars)
+	if sErr != nil {
+		return "", fmt.Errorf("start %s: %w", def.ID, sErr)
 	}
+	completion = comp
 	return def.ID, nil
 }
 

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -328,10 +328,15 @@ func (e *Engine) ResumeStalled() {
 		}
 
 		e.logger.Info("workflow.resume-stalled", "task_id", t.ID, "step", step.ID)
-		rErr := e.executeSteps(t.ID, &def, step, t.Workflow)
+		comp, rErr := e.executeSteps(t.ID, &def, step, t.Workflow)
 		e.mu.Lock()
 		delete(e.dispatching, t.ID)
 		e.mu.Unlock()
+		// ResumeStalled only resumes async run_agent steps, so comp is normally
+		// nil (fireComplete no-ops). Kept defensive + after the dispatching
+		// marker is cleared, so the day a sync step becomes resumable its
+		// completion cascades correctly instead of being silently dropped.
+		e.fireComplete(comp)
 		e.resumeError.Log(e.logger, "workflow.resume-stalled.exec", t.ID, rErr, "task_id", t.ID)
 		if rErr != nil {
 			e.surfaceStartFailure(t.ID, fresh.Status, rErr)

--- a/internal/workflow/engine_steps_parallel.go
+++ b/internal/workflow/engine_steps_parallel.go
@@ -162,13 +162,18 @@ func (e *Engine) spawnParallelChild(taskID string, parent, child *Step, wfExec *
 // The parent step's StepRecord + Next-evaluation only fire after every
 // child has terminated. Aggregate parent status: completed iff every
 // child completed; failed otherwise.
-func (e *Engine) advanceParallelChild(taskID string, def *Definition, parent, child *Step, wfExec *Execution, output StepOutput) error {
+//
+// Returns a non-nil *CompletionInfo when the final child completion ends the
+// workflow synchronously. It is NOT fired here: AdvanceStep releases the
+// inflight mutex first and then fires it, so the cascade never runs under the
+// held lock.
+func (e *Engine) advanceParallelChild(taskID string, def *Definition, parent, child *Step, wfExec *Execution, output StepOutput) (comp *CompletionInfo, err error) {
 	rec := wfExec.ParallelInflight[parent.ID]
 	if rec == nil {
 		// Parent record was cleared (e.g. another late callback after the
-		// parent already advanced). Treat as a stale callback.
+		// parent already advanced). Stale callback: no completion, no error.
 		e.logger.Debug("workflow.parallel.stale", "task_id", taskID, "parent", parent.ID, "child", child.ID)
-		return nil
+		return
 	}
 	status := rec.Children[child.ID]
 	if status == nil {
@@ -185,14 +190,14 @@ func (e *Engine) advanceParallelChild(taskID string, def *Definition, parent, ch
 		e.logger.Info("workflow.parallel.retry",
 			"task_id", taskID, "parent", parent.ID, "child", child.ID,
 			"attempt", status.Retries, "max", child.Config.MaxRetries)
-		if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
-			return err
+		if sErr := e.tasks.SetWorkflow(taskID, wfExec); sErr != nil {
+			return nil, sErr
 		}
 		// Re-spawn just this child. Reuse the parent's template context
 		// rendered fresh from the latest task state.
 		t, gErr := e.tasks.GetTask(taskID)
 		if gErr != nil {
-			return gErr
+			return nil, gErr
 		}
 		dir := wfExec.Variables[WorkflowVarDir]
 		ctx := TemplateContext{
@@ -206,7 +211,7 @@ func (e *Engine) advanceParallelChild(taskID string, def *Definition, parent, ch
 			status.Output = "respawn failed: " + spawnErr.Error()
 			e.logger.Error("workflow.parallel.respawn", "task_id", taskID, "parent", parent.ID, "child", child.ID, "err", spawnErr)
 		}
-		return e.tasks.SetWorkflow(taskID, wfExec)
+		return nil, e.tasks.SetWorkflow(taskID, wfExec)
 	}
 
 	// Terminal status — update slot.
@@ -220,15 +225,12 @@ func (e *Engine) advanceParallelChild(taskID string, def *Definition, parent, ch
 		e.logger.Debug("workflow.parallel.child-done",
 			"task_id", taskID, "parent", parent.ID, "child", child.ID,
 			"status", status.Status)
-		return e.tasks.SetWorkflow(taskID, wfExec)
+		return nil, e.tasks.SetWorkflow(taskID, wfExec)
 	}
 
-	// Reached via AdvanceStep (agent-completion goroutine): the dispatching/
-	// starting markers are not held, only the inflight mutex (which the
-	// completion callback never re-acquires), so firing inline is safe.
-	comp, err := e.finalizeParallelParent(taskID, def, parent, wfExec)
-	e.fireComplete(comp)
-	return err
+	// Last child done: collapse the parent and return any synchronous
+	// completion up to AdvanceStep, which fires it after releasing inflight.
+	return e.finalizeParallelParent(taskID, def, parent, wfExec)
 }
 
 // finalizeParallelParent collapses a parallel block whose children have all

--- a/internal/workflow/engine_steps_parallel.go
+++ b/internal/workflow/engine_steps_parallel.go
@@ -13,9 +13,14 @@ import (
 // on the worktree is benign. The parent step advances to its `next` only
 // after every child has terminated; per-child completions are routed
 // through AdvanceStep via the existing agentSteps mapping.
-func (e *Engine) execParallel(taskID string, def *Definition, step *Step, wfExec *Execution, ctx TemplateContext) error {
+//
+// Returns a non-nil *CompletionInfo when every child terminates at spawn time
+// and the parent's `next` ends the workflow synchronously — threaded up to the
+// marker-releasing caller (via executeSteps) rather than fired here, so the
+// completion's cascade isn't rejected as re-entrant.
+func (e *Engine) execParallel(taskID string, def *Definition, step *Step, wfExec *Execution, ctx TemplateContext) (*CompletionInfo, error) {
 	if len(step.Parallel) < 2 {
-		return fmt.Errorf("parallel step %q has fewer than 2 children", step.ID)
+		return nil, fmt.Errorf("parallel step %q has fewer than 2 children", step.ID)
 	}
 
 	// Resume-safe: a re-entry into the same parallel parent (e.g. after a
@@ -48,7 +53,7 @@ func (e *Engine) execParallel(taskID string, def *Definition, step *Step, wfExec
 	// completes mid-loop finds the parent record on AdvanceStep.
 	wfExec.State = ExecWaiting
 	if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
-		return err
+		return nil, err
 	}
 
 	dir := wfExec.Variables[WorkflowVarDir]
@@ -80,7 +85,7 @@ func (e *Engine) execParallel(taskID string, def *Definition, step *Step, wfExec
 		return e.finalizeParallelParent(taskID, def, step, wfExec)
 	}
 
-	return e.tasks.SetWorkflow(taskID, wfExec)
+	return nil, e.tasks.SetWorkflow(taskID, wfExec)
 }
 
 // spawnParallelChild spawns one child agent of a parallel block. Mirrors
@@ -218,7 +223,12 @@ func (e *Engine) advanceParallelChild(taskID string, def *Definition, parent, ch
 		return e.tasks.SetWorkflow(taskID, wfExec)
 	}
 
-	return e.finalizeParallelParent(taskID, def, parent, wfExec)
+	// Reached via AdvanceStep (agent-completion goroutine): the dispatching/
+	// starting markers are not held, only the inflight mutex (which the
+	// completion callback never re-acquires), so firing inline is safe.
+	comp, err := e.finalizeParallelParent(taskID, def, parent, wfExec)
+	e.fireComplete(comp)
+	return err
 }
 
 // finalizeParallelParent collapses a parallel block whose children have all
@@ -226,10 +236,17 @@ func (e *Engine) advanceParallelChild(taskID string, def *Definition, parent, ch
 // the parent's Next. Called from advanceParallelChild on the last
 // completion, and from execParallel when every child failed at spawn time
 // (no agent ever ran → no completion callback will fire).
-func (e *Engine) finalizeParallelParent(taskID string, def *Definition, parent *Step, wfExec *Execution) error {
+//
+// Returns a non-nil *CompletionInfo when advancing the parent ends the
+// workflow synchronously. It is NOT fired here: advanceParallelChild fires it
+// inline (inflight-only), while execParallel threads it up to its
+// marker-releasing caller — see those call sites.
+func (e *Engine) finalizeParallelParent(taskID string, def *Definition, parent *Step, wfExec *Execution) (comp *CompletionInfo, err error) {
 	rec := wfExec.ParallelInflight[parent.ID]
 	if rec == nil {
-		return nil
+		// Stale/duplicate finalize — the record was already collapsed by a
+		// prior call. Benign no-op: neither a completion nor an error.
+		return
 	}
 
 	parentStatus := "completed"
@@ -256,15 +273,15 @@ func (e *Engine) finalizeParallelParent(taskID string, def *Definition, parent *
 
 	t, err := e.tasks.GetTask(taskID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	t.Workflow = wfExec
-	nextStep, err := e.resolveNext(taskID, def, parent, wfExec, t)
+	nextStep, comp, err := e.resolveNext(taskID, def, parent, wfExec, t)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if nextStep == nil {
-		return nil
+		return comp, nil
 	}
 	e.logger.Info("workflow.parallel.advance", "task_id", taskID, "from", parent.ID, "to", nextStep.ID, "status", parentStatus)
 	return e.executeSteps(taskID, def, nextStep, wfExec)


### PR DESCRIPTION
## Motivation

> Changelog: fix(workflow): cascade synchronous workflows to their successor

A fully **mechanical** workflow — one whose steps are all synchronous (e.g.
`simple-task-handoff`, a single `set_status` step with no agent) — completes
*inside* the same `DispatchEvent`/`StartWorkflow` call that triggered it. The
engine fired its completion callback (`onComplete`) **inline from `resolveNext`,
while the per-task re-entrancy marker was still held** (`dispatching` in
`DispatchEvent`, `starting` in `StartWorkflowWithVars`). The callback's job is to
dispatch the next workflow in the chain (`task.status_changed` → successor), but
that nested `DispatchEvent` re-entered the held marker and was rejected as
`ErrWorkflowAlreadyActive` — which `OnWorkflowComplete` treats as benign and
drops. **The successor workflow never started.**

Concretely: a handoff task (`simple-task-handoff` → `in-progress`) flips status
and then stalls forever; `simple-task-implement` is never dispatched, so no
implementation agent runs. `restart-stale` just re-runs the mechanical workflow
and re-drops the cascade every minute. Agent-driven workflows escaped the bug
only because their `onComplete` fires later, on the agent-completion goroutine,
with no marker held.

## Implementation information

Thread the completion **up to the marker-releasing caller** instead of firing it
inline:

- `resolveNext` no longer calls `onComplete`; it returns a `*CompletionInfo`.
  `executeSteps`, `execParallel` and `finalizeParallelParent` propagate it.
- New `fireComplete` helper invokes the callback. Each caller fires **only after
  releasing its per-task marker**: `DispatchEvent` and `ResumeStalled` via
  defer/ordering after the `dispatching` delete; the `starting` path via an
  unexported `startWorkflowLocked` split so the public `StartWorkflow`/
  `StartWorkflowWithVars` signatures are unchanged; `AdvanceStep` after
  `release()` of the inflight mutex.
- The same fix covers a workflow whose **terminal step is a `parallel` block**
  where every child fails at spawn (`execParallel` → `finalizeParallelParent`
  ran inline under the markers) — surfaced by an adversarial review pass.
- `fireComplete` bounds synchronous cascade recursion (`maxCascadeDepth = 64`):
  a misconfigured all-mechanical loop now logs `workflow.cascade.depth-exceeded`
  instead of overflowing the stack. Production builtins never approach this —
  every successor reaches an async `run_agent`/`wait_human` step that breaks the
  chain.

No public API signatures changed; no behavior change for agent-driven workflows.

### Tests

`internal/workflow/engine_cascade_test.go`:
- Synchronous workflow cascades to its successor — via `DispatchEvent`
  (`task.created`) and via `StartWorkflow` (the `restart-stale` path).
- A parallel-terminal workflow (all children fail at spawn) cascades.
- The depth guard stops a runaway ping-pong chain and does not leak its
  bookkeeping.

All three cascade tests were confirmed to **fail on the pre-fix engine** (status
stuck at `in-progress`) and pass after. `go test ./...`, `go test -race
./internal/workflow/...`, and `golangci-lint run ./...` are clean.

## Supporting documentation

Found while diagnosing why a handed-off task (`simple-task-handoff`) stayed at
`in-progress` and never started its implementation agent.
