### PR TITLE
chore(ui): remove branch name from board cards

### DIFF
--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -4,7 +4,7 @@
   import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { agentStore } from '../stores/agents.svelte.js'
   import { reviewStore } from '../stores/reviews.svelte.js'
-import { awaitsHuman, awaitsHumanLabel, coreStatus, statusLabel } from '../lib/statuses.js'
+  import { awaitsHuman, awaitsHumanLabel, coreStatus, statusLabel } from '../lib/statuses.js'
   import { isReviewTask as isReviewTaskFn, reviewPhaseMeta, type ReviewPhaseIcon } from '../lib/review-phase.js'
   import { isOwnPRTask as isOwnPRTaskFn, prPhaseMeta, prPhaseNeedsYou, type PRPhaseIcon } from '../lib/pr-phase.js'
   import { PRIORITY_OPTIONS } from '../lib/priorities.js'

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
   import { timeAgo } from '$lib/dates.js'
-  import { CheckCircle, XCircle, Clock, GitPullRequest, GitPullRequestDraft, CircleDot, Copy, AlertTriangle, MoreHorizontal, Eye, PenLine, Hourglass, ShieldCheck, Loader, Wrench, MessageSquare } from '@lucide/svelte'
+  import { CheckCircle, XCircle, Clock, GitPullRequest, GitPullRequestDraft, CircleDot, AlertTriangle, MoreHorizontal, Eye, PenLine, Hourglass, ShieldCheck, Loader, Wrench, MessageSquare } from '@lucide/svelte'
   import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { agentStore } from '../stores/agents.svelte.js'
   import { reviewStore } from '../stores/reviews.svelte.js'
-  import { notificationStore } from '../stores/notifications.svelte.js'
-  import { awaitsHuman, awaitsHumanLabel, coreStatus, statusLabel } from '../lib/statuses.js'
+import { awaitsHuman, awaitsHumanLabel, coreStatus, statusLabel } from '../lib/statuses.js'
   import { isReviewTask as isReviewTaskFn, reviewPhaseMeta, type ReviewPhaseIcon } from '../lib/review-phase.js'
   import { isOwnPRTask as isOwnPRTaskFn, prPhaseMeta, prPhaseNeedsYou, type PRPhaseIcon } from '../lib/pr-phase.js'
   import { PRIORITY_OPTIONS } from '../lib/priorities.js'
@@ -23,23 +22,7 @@
   const { task: t, onclick, focused = false, onstatuschange }: Props = $props()
 
   let dragging = $state(false)
-  let copiedBranch = $state(false)
   let moveMenuOpen = $state(false)
-
-  const taskBranchName = $derived(
-    'sybra/' + (t.slug ? t.slug + '-' + t.id : t.id)
-  )
-
-  async function copyBranch(e: MouseEvent) {
-    e.stopPropagation()
-    try {
-      await navigator.clipboard.writeText(taskBranchName)
-      copiedBranch = true
-      setTimeout(() => { copiedBranch = false }, 1500)
-    } catch {
-      notificationStore.pushLocal('error', 'Copy failed', 'Could not copy branch name to clipboard')
-    }
-  }
 
   const triaging = $derived(
     (agentStore.list ?? []).some((a) => a.taskId === t.id && a.name?.startsWith('triage:') && a.state === 'running')
@@ -270,19 +253,6 @@
     <span class="ml-auto text-[11px] text-surface-400/80">{timeAgo(t.updatedAt)}</span>
   </div>
   </button>
-  {#if t.projectId}
-    <div class="mt-1.5 flex items-center opacity-0 transition-opacity group-hover:opacity-100">
-      <button
-        type="button"
-        onclick={copyBranch}
-        class="inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-mono text-xs text-surface-400 transition-colors hover:bg-surface-200 hover:text-surface-600 dark:hover:bg-surface-600 dark:hover:text-surface-300"
-        title="Copy branch name (⇧⌘.)"
-      >
-        <Copy size={10} />
-        {copiedBranch ? 'Copied!' : taskBranchName.replace(/^sybra\//, '')}
-      </button>
-    </div>
-  {/if}
   {#if focused}
     <div class="mt-1.5 flex flex-wrap items-center gap-1.5 text-xs text-surface-400">
       <kbd class="rounded bg-surface-200 px-1 py-0.5 font-mono text-xs dark:bg-surface-700">Enter</kbd><span>open</span>

--- a/frontend/src/components/TaskCard.svelte.test.ts
+++ b/frontend/src/components/TaskCard.svelte.test.ts
@@ -4,13 +4,6 @@ import TaskCard from './TaskCard.svelte'
 import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
 import { PullRequest } from '../../bindings/github.com/Automaat/sybra/internal/github/models.js'
 
-vi.mock('../stores/notifications.svelte.js', () => ({
-  notificationStore: {
-    pushLocal: vi.fn(),
-  },
-}))
-
-const { notificationStore } = await import('../stores/notifications.svelte.js')
 const { reviewStore } = await import('../stores/reviews.svelte.js')
 
 const mockTask = {
@@ -118,44 +111,6 @@ describe('TaskCard', () => {
     await fireEvent.click(screen.getByLabelText('Move task'))
     await fireEvent.click(screen.getByText('In Progress'))
     expect(onstatuschange).toHaveBeenCalledWith('in-progress')
-  })
-
-  describe('copyBranch error handling', () => {
-    beforeEach(() => {
-      Object.defineProperty(navigator, 'clipboard', {
-        value: { writeText: vi.fn() },
-        configurable: true,
-        writable: true,
-      })
-      vi.mocked(notificationStore.pushLocal).mockClear()
-    })
-
-    afterEach(() => {
-      vi.restoreAllMocks()
-    })
-
-    it('shows notification when clipboard write fails', async () => {
-      vi.mocked(navigator.clipboard.writeText).mockRejectedValueOnce(new Error('Permission denied'))
-      const taskWithProject = { ...mockTask, projectId: 'owner/repo' }
-      render(TaskCard, { props: { task: taskWithProject, onclick: () => {} } })
-
-      const copyBtn = screen.getByTitle('Copy branch name (⇧⌘.)')
-      await fireEvent.click(copyBtn)
-
-      expect(notificationStore.pushLocal).toHaveBeenCalledWith('error', 'Copy failed', 'Could not copy branch name to clipboard')
-    })
-
-    it('copies branch name on success', async () => {
-      vi.mocked(navigator.clipboard.writeText).mockResolvedValueOnce(undefined)
-      const taskWithProject = { ...mockTask, projectId: 'owner/repo' }
-      render(TaskCard, { props: { task: taskWithProject, onclick: () => {} } })
-
-      const copyBtn = screen.getByTitle('Copy branch name (⇧⌘.)')
-      await fireEvent.click(copyBtn)
-
-      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(expect.stringContaining(mockTask.id))
-      expect(notificationStore.pushLocal).not.toHaveBeenCalled()
-    })
   })
 
   it('shows the canonical Plan Review badge for plan-review status', () => {


### PR DESCRIPTION
## Motivation

The on-hover branch name copy button on board cards was unused and added visual noise to an already dense UI. The feature is still accessible via the task detail overflow menu and copy-branch shortcut, so removing it from the card surface loses no functionality.

## Implementation information

- Removed the branch name hover overlay and copy button from `TaskCard.svelte`
- Deleted the corresponding tests in `TaskCard.svelte.test.ts` that covered the now-removed behaviour

> Changelog: chore(ui): remove branch name from board cards