### PR TITLE
fix(agent): serialize per-task agent dispatch

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -59,17 +59,56 @@ type Manager struct {
 	// taskExists, when set, reports whether a task still exists. Used to
 	// avoid recreating a zombie codex agent whose chat task was deleted.
 	taskExists func(taskID string) bool
+
+	// dispatchClaims serializes agent dispatch per task. A claim is held for
+	// the full duration of a StartAgent call — across the (multi-second)
+	// worktree-preparation window during which the agent is not yet registered
+	// in `agents`. Without it, two independent dispatchers (the workflow
+	// cascade and the recovery loop) can both observe "no running agent" and
+	// each start an agent on the same worktree. This is a pure in-flight lock:
+	// it intentionally does NOT inspect running agents, so a step transition
+	// dispatching its next agent inside the prior agent's onComplete (whose
+	// `done` channel is not yet closed) is never blocked.
+	dispatchClaims map[string]struct{}
 }
 
 func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir string) *Manager {
 	return &Manager{
-		agents:      make(map[string]*Agent),
-		ctx:         ctx,
-		emit:        emit,
-		logger:      logger,
-		logDir:      logDir,
-		defaultProv: "claude",
+		agents:         make(map[string]*Agent),
+		dispatchClaims: make(map[string]struct{}),
+		ctx:            ctx,
+		emit:           emit,
+		logger:         logger,
+		logDir:         logDir,
+		defaultProv:    "claude",
 	}
+}
+
+// ClaimTaskDispatch reserves the right to dispatch an agent for taskID,
+// returning false when a dispatch is already in flight for the same task. The
+// caller MUST NOT start an agent on a false return, and MUST ReleaseTaskDispatch
+// once dispatch finishes (success or failure) on a true return. This closes the
+// window between dispatch start and agent registration where a concurrent
+// dispatcher would otherwise see no running agent and start a duplicate.
+func (m *Manager) ClaimTaskDispatch(taskID string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, held := m.dispatchClaims[taskID]; held {
+		return false
+	}
+	if m.dispatchClaims == nil {
+		m.dispatchClaims = make(map[string]struct{})
+	}
+	m.dispatchClaims[taskID] = struct{}{}
+	return true
+}
+
+// ReleaseTaskDispatch releases a claim acquired by ClaimTaskDispatch. Safe to
+// call for a task with no outstanding claim.
+func (m *Manager) ReleaseTaskDispatch(taskID string) {
+	m.mu.Lock()
+	delete(m.dispatchClaims, taskID)
+	m.mu.Unlock()
 }
 
 func (m *Manager) SetOnComplete(fn func(ag *Agent)) {

--- a/internal/agent/manager_control.go
+++ b/internal/agent/manager_control.go
@@ -192,6 +192,13 @@ func (m *Manager) ListAgents() []*Agent {
 func (m *Manager) HasRunningAgentForTask(taskID string) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+	// An in-flight dispatch counts as "running": the agent is mid-start and
+	// not yet in the map, but a second dispatcher must not treat the task as
+	// idle. Lets recovery / ResumeStalled / pr-fix pollers skip during the
+	// worktree-prep window instead of racing the dispatch.
+	if _, held := m.dispatchClaims[taskID]; held {
+		return true
+	}
 	for _, a := range m.agents {
 		if a.TaskID != taskID {
 			continue
@@ -206,6 +213,35 @@ func (m *Manager) HasRunningAgentForTask(taskID string) bool {
 			}
 		} else if a.GetState() == StateRunning {
 			// interactive: no goroutine, rely on state
+			return true
+		}
+	}
+	return false
+}
+
+// HasOtherRunningAgentForTask is HasRunningAgentForTask excluding the agent
+// with exceptAgentID. verify_commits uses it to detect a sibling agent still
+// working the task without false-positiving on the agent whose own completion
+// is currently being processed — that agent's `done` channel is closed only
+// after onComplete returns (see runner_headless), so it would otherwise still
+// read as running.
+func (m *Manager) HasOtherRunningAgentForTask(taskID, exceptAgentID string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if _, held := m.dispatchClaims[taskID]; held {
+		return true
+	}
+	for _, a := range m.agents {
+		if a.TaskID != taskID || a.ID == exceptAgentID {
+			continue
+		}
+		if a.done != nil {
+			select {
+			case <-a.done:
+			default:
+				return true
+			}
+		} else if a.GetState() == StateRunning {
 			return true
 		}
 	}

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -442,6 +442,63 @@ func TestHasRunningAgentForTask(t *testing.T) {
 	}
 }
 
+func TestClaimTaskDispatch(t *testing.T) {
+	m, _ := newTestManager(t)
+
+	if !m.ClaimTaskDispatch("t1") {
+		t.Fatal("first claim should succeed")
+	}
+	if m.ClaimTaskDispatch("t1") {
+		t.Error("second claim while held must fail (serializes dispatch)")
+	}
+	if !m.ClaimTaskDispatch("t2") {
+		t.Error("claim for a different task must succeed")
+	}
+
+	// A held claim makes the task look busy even though no agent is registered
+	// yet — this is what blocks a concurrent recovery dispatch during the
+	// worktree-prep window.
+	if !m.HasRunningAgentForTask("t1") {
+		t.Error("claimed task should report a running agent")
+	}
+
+	m.ReleaseTaskDispatch("t1")
+	if m.HasRunningAgentForTask("t1") {
+		t.Error("released claim with no agent should report not running")
+	}
+	if !m.ClaimTaskDispatch("t1") {
+		t.Error("claim after release should succeed")
+	}
+
+	// Releasing an unheld claim is a no-op (must not panic).
+	m.ReleaseTaskDispatch("never-claimed")
+}
+
+func TestHasOtherRunningAgentForTask(t *testing.T) {
+	m, _ := newTestManager(t)
+
+	running := &Agent{ID: "a1", TaskID: "t1", State: StateRunning, cancel: func() {}}
+	m.mu.Lock()
+	m.agents["a1"] = running
+	m.mu.Unlock()
+
+	// Excluding the only running agent → false. This is the case that prevents
+	// verify_commits from deadlocking on the agent whose own completion is
+	// being processed (its done channel closes only after onComplete).
+	if m.HasOtherRunningAgentForTask("t1", "a1") {
+		t.Error("excluding the only running agent must yield false")
+	}
+	// A different except-id leaves a1 visible → true.
+	if !m.HasOtherRunningAgentForTask("t1", "other") {
+		t.Error("a1 not excluded should yield true")
+	}
+	// An in-flight dispatch counts even when the only registered agent is excluded.
+	m.ClaimTaskDispatch("t1")
+	if !m.HasOtherRunningAgentForTask("t1", "a1") {
+		t.Error("a held dispatch claim should count as another running agent")
+	}
+}
+
 func TestBuildCommand(t *testing.T) {
 	// Reset server-side env override so tests see the default sandbox logic.
 	t.Setenv("SYBRA_DISABLE_CODEX_SANDBOX", "")

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -24,6 +24,7 @@ const (
 	EventPRMerged                 = "pr_monitor.merged"
 	EventPRClosed                 = "pr_monitor.closed"
 	EventPRAutoMerged             = "pr_monitor.auto_merged"
+	EventPROrphanAdopted          = "pr_monitor.orphan_adopted"
 	EventPRCopilotThreadsResolved = "pr_monitor.copilot_threads_resolved"
 	EventReviewStarted            = "review.agent_started"
 	EventFixReviewStarted         = "fix_review.agent_started"

--- a/internal/sybra/app_agents.go
+++ b/internal/sybra/app_agents.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/sandbox"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
 	"github.com/Automaat/sybra/internal/worktree"
 )
 
@@ -115,7 +116,42 @@ func newAgentOrchestrator(
 	}
 }
 
+// sandboxEnv resolves the extra environment variables a task's configured
+// sandbox injects into its agent subprocess, starting the sandbox on demand.
+// Returns nil when no sandbox applies or startup fails (a failed start is
+// logged, not fatal — the agent runs without the sandbox env).
+func (o *AgentOrchestrator) sandboxEnv(taskID, dir string, t task.Task) []string {
+	if o.sandboxes == nil || t.ProjectID == "" {
+		return nil
+	}
+	proj, pErr := o.projects.Get(t.ProjectID)
+	if pErr != nil || proj.Sandbox == nil {
+		return nil
+	}
+	inst := o.sandboxes.Get(taskID)
+	if inst == nil {
+		newInst, startErr := o.sandboxes.Start(context.Background(), taskID, dir, proj.Sandbox)
+		if startErr != nil {
+			o.logger.Warn("sandbox.start.failed", "task_id", taskID, "err", startErr)
+			return nil
+		}
+		inst = newInst
+	}
+	return inst.EnvVars()
+}
+
 func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, includeTaskDescription, oneShot bool) (*agent.Agent, error) {
+	// Serialize dispatch per task. Held across the whole start — including the
+	// multi-second worktree prep below, during which the agent is not yet
+	// registered — so a concurrent dispatcher (recovery loop, ResumeStalled,
+	// a manual start) cannot observe "no running agent" and launch a duplicate
+	// on the same worktree. workflow.ErrDispatchInFlight is benign: the holder
+	// will produce the task's agent.
+	if !o.agents.ClaimTaskDispatch(taskID) {
+		return nil, workflow.ErrDispatchInFlight
+	}
+	defer o.agents.ReleaseTaskDispatch(taskID)
+
 	t, err := o.tasks.Get(taskID)
 	if err != nil {
 		return nil, err
@@ -149,23 +185,7 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, includeTaskD
 	}
 	resumeSessionID := pickImplementationResumeSession(t.AgentRuns, workflowStart)
 
-	var extraEnv []string
-	if o.sandboxes != nil && t.ProjectID != "" {
-		if proj, pErr := o.projects.Get(t.ProjectID); pErr == nil && proj.Sandbox != nil {
-			inst := o.sandboxes.Get(taskID)
-			if inst == nil {
-				newInst, startErr := o.sandboxes.Start(context.Background(), taskID, dir, proj.Sandbox)
-				if startErr != nil {
-					o.logger.Warn("sandbox.start.failed", "task_id", taskID, "err", startErr)
-				} else {
-					inst = newInst
-				}
-			}
-			if inst != nil {
-				extraEnv = inst.EnvVars()
-			}
-		}
-	}
+	extraEnv := o.sandboxEnv(taskID, dir, t)
 
 	fullPrompt := buildTaskStartPrompt(t, prompt, includeTaskDescription)
 	ag, err := o.agents.Run(agent.RunConfig{
@@ -319,6 +339,13 @@ func (o *AgentOrchestrator) autoAssignProject(t task.Task) task.Task {
 // StartPRFixAgent starts a headless agent to address review comments on
 // the task's PR. Named "pr-fix:" so handleAgentComplete routes it correctly.
 func (o *AgentOrchestrator) StartPRFixAgent(taskID string) error {
+	// Same per-task dispatch serialization as StartAgent — a pr-fix dispatch
+	// must not race a concurrent implementation/recovery dispatch.
+	if !o.agents.ClaimTaskDispatch(taskID) {
+		return workflow.ErrDispatchInFlight
+	}
+	defer o.agents.ReleaseTaskDispatch(taskID)
+
 	t, err := o.tasks.Get(taskID)
 	if err != nil {
 		return err

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
@@ -328,12 +329,33 @@ func prClosedEligible(t *task.Task) bool {
 	return t.Status == task.StatusHumanRequired && t.PRNumber != 0
 }
 
+// orphanStrandReasons are the status_reason fragments the implement / verify /
+// evaluate workflow steps write when they park a task without linking a PR.
+// Adoption is gated to these (FAIL CLOSED): a task parked for any other reason
+// — notably a deliberate watchdog stop ("watchdog: …") or a dwell escalation —
+// must never be auto-resurrected, even if a PR happens to match its branch.
+// Keep in sync with internal/workflow/engine_steps_verify.go (no-commits
+// verdicts) and engine_steps_link.go (evaluate).
+var orphanStrandReasons = []string{
+	"no commits",               // verify_commits: empty branch / agent crashed before commit
+	"commits pushed but no PR", // evaluate: commits exist but the PR was never linked
+}
+
+func hasOrphanStrandReason(reason string) bool {
+	for _, frag := range orphanStrandReasons {
+		if strings.Contains(reason, frag) {
+			return true
+		}
+	}
+	return false
+}
+
 // orphanPRAdoptionEligible reports whether a task is a candidate for orphan-PR
-// adoption: parked in human-required with a branch but no linked PR. That is
-// the signature of a workflow that exited (e.g. a premature verify_commits
-// verdict, or any crash) before a late-finishing agent opened the PR — the PR
-// exists on GitHub but the task never recorded its number, so the monitor is
-// blind to it. Chat tasks and inbound review tasks are never own-PR tasks.
+// adoption: parked in human-required with a branch but no linked PR, *and* with
+// a status_reason that marks it as stranded by the implement/verify/evaluate
+// path before a late-finishing agent opened the PR. The reason gate is what
+// keeps adoption from resurrecting a task a human or the watchdog deliberately
+// stopped. Chat tasks and inbound review tasks are never own-PR tasks.
 func orphanPRAdoptionEligible(t *task.Task) bool {
 	if t.TaskType == task.TaskTypeChat || slices.Contains(t.Tags, "review") {
 		return false
@@ -341,17 +363,21 @@ func orphanPRAdoptionEligible(t *task.Task) bool {
 	return t.Status == task.StatusHumanRequired &&
 		t.PRNumber == 0 &&
 		t.Branch != "" &&
-		t.ProjectID != ""
+		t.ProjectID != "" &&
+		hasOrphanStrandReason(t.StatusReason)
 }
 
 // adoptOrphanPRs re-links tasks stranded in human-required without a PR number
-// to a matching open PR discovered by head branch, then flips them to in-review
-// so the monitor's normal pr-fix/auto-merge path resumes. Re-activation is
-// non-destructive: a pet PR still passes through the full auto-merge gate
-// (Copilot review + green CI), and a work PR is merged by a human. A branch
-// matching more than one open PR is left untouched (ambiguous). Matched entries
-// of `tasks` are mutated in place so the caller's matcher assembly observes the
-// new state in the same poll.
+// to a matching open PR discovered by head branch *within the task's own
+// project*, then flips them to in-review so the monitor's normal pr-fix/
+// auto-merge path resumes. Re-activation is non-destructive: a pet PR still
+// passes through the full auto-merge gate (Copilot review + green CI), and a
+// work PR is merged by a human. The repo guard (prs[j].Repository ==
+// t.ProjectID) is essential: monitoredPRs spans every repo the user authors PRs
+// in, so a same-named branch in another repo must not be linked. A branch
+// matching more than one open PR in the project is left untouched (ambiguous).
+// Matched entries of `tasks` are mutated in place so the caller's matcher
+// assembly observes the new state in the same poll.
 func (r *ReviewHandler) adoptOrphanPRs(tasks []task.Task, prs []github.PullRequest) {
 	for i := range tasks {
 		t := &tasks[i]
@@ -361,7 +387,7 @@ func (r *ReviewHandler) adoptOrphanPRs(tasks []task.Task, prs []github.PullReque
 		var match *github.PullRequest
 		ambiguous := false
 		for j := range prs {
-			if prs[j].HeadRefName != t.Branch {
+			if prs[j].HeadRefName != t.Branch || prs[j].Repository != t.ProjectID {
 				continue
 			}
 			if match != nil {

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -111,6 +111,15 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 		return prPollSlow
 	}
 
+	monitoredPRs := r.monitoredPRs(summary)
+
+	// Recover PRs orphaned by a workflow that exited before linking — e.g. a
+	// task stranded in human-required while a late-finishing agent opened the
+	// PR (PRNumber never recorded). Re-link by branch and re-activate so the
+	// normal pr-fix/auto-merge path resumes. Runs before matcher assembly so an
+	// adopted task is monitored in this same poll.
+	r.adoptOrphanPRs(tasks, monitoredPRs)
+
 	var (
 		matchers       []github.TaskMatcher
 		closedMatchers []github.TaskMatcher
@@ -131,8 +140,6 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 			closedMatchers = append(closedMatchers, m)
 		}
 	}
-
-	monitoredPRs := r.monitoredPRs(summary)
 
 	if len(matchers) > 0 {
 		issues := github.MatchTaskPRs(monitoredPRs, matchers)
@@ -319,6 +326,69 @@ func prClosedEligible(t *task.Task) bool {
 		return false
 	}
 	return t.Status == task.StatusHumanRequired && t.PRNumber != 0
+}
+
+// orphanPRAdoptionEligible reports whether a task is a candidate for orphan-PR
+// adoption: parked in human-required with a branch but no linked PR. That is
+// the signature of a workflow that exited (e.g. a premature verify_commits
+// verdict, or any crash) before a late-finishing agent opened the PR — the PR
+// exists on GitHub but the task never recorded its number, so the monitor is
+// blind to it. Chat tasks and inbound review tasks are never own-PR tasks.
+func orphanPRAdoptionEligible(t *task.Task) bool {
+	if t.TaskType == task.TaskTypeChat || slices.Contains(t.Tags, "review") {
+		return false
+	}
+	return t.Status == task.StatusHumanRequired &&
+		t.PRNumber == 0 &&
+		t.Branch != "" &&
+		t.ProjectID != ""
+}
+
+// adoptOrphanPRs re-links tasks stranded in human-required without a PR number
+// to a matching open PR discovered by head branch, then flips them to in-review
+// so the monitor's normal pr-fix/auto-merge path resumes. Re-activation is
+// non-destructive: a pet PR still passes through the full auto-merge gate
+// (Copilot review + green CI), and a work PR is merged by a human. A branch
+// matching more than one open PR is left untouched (ambiguous). Matched entries
+// of `tasks` are mutated in place so the caller's matcher assembly observes the
+// new state in the same poll.
+func (r *ReviewHandler) adoptOrphanPRs(tasks []task.Task, prs []github.PullRequest) {
+	for i := range tasks {
+		t := &tasks[i]
+		if !orphanPRAdoptionEligible(t) {
+			continue
+		}
+		var match *github.PullRequest
+		ambiguous := false
+		for j := range prs {
+			if prs[j].HeadRefName != t.Branch {
+				continue
+			}
+			if match != nil {
+				ambiguous = true
+				break
+			}
+			match = &prs[j]
+		}
+		if ambiguous || match == nil {
+			continue
+		}
+		updated, err := r.tasks.Update(t.ID, task.Update{
+			PRNumber:     task.Ptr(match.Number),
+			Status:       task.Ptr(task.StatusInReview),
+			StatusReason: task.Ptr(""),
+		})
+		if err != nil {
+			r.logger.Error("pr-monitor.orphan-adopt", "task_id", t.ID, "pr", match.Number, "err", err)
+			continue
+		}
+		tasks[i] = updated
+		r.logAudit(audit.EventPROrphanAdopted, t.ID, "", map[string]any{
+			"pr": match.Number, "repo": match.Repository, "branch": t.Branch,
+		})
+		r.logger.Info("pr-monitor.orphan-adopted",
+			"task_id", t.ID, "pr", match.Number, "branch", t.Branch)
+	}
 }
 
 func prNeedsAttention(prs []github.PullRequest) bool {

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -41,6 +41,16 @@ func (r *ReviewHandler) handleAutoMerge(issue github.PRIssue) {
 		return
 	}
 
+	// Defense in depth: never merge a PR that lives outside the task's own
+	// project. A mis-linked PR number (e.g. a branch-name collision) must not
+	// be able to squash-merge an unrelated repo. proj.ID and PR.Repository are
+	// both owner/repo.
+	if issue.PR.Repository != proj.ID {
+		r.logger.Warn("auto-merge.repo-mismatch",
+			"task_id", t.ID, "task_project", proj.ID, "pr_repo", issue.PR.Repository, "pr", issue.PR.Number)
+		return
+	}
+
 	// Hold the merge until Copilot has reviewed and its threads are resolved.
 	// Without this, a green PR merges on the first poll after CI passes — before
 	// Copilot's (asynchronous) review lands — and its feedback is skipped.

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -332,17 +332,35 @@ func TestAdoptOrphanPRs(t *testing.T) {
 		Branch:       task.Ptr("feat/stranded"),
 		ProjectID:    task.Ptr("o/r"),
 	})
-	// Ambiguous: two open PRs share the branch → must NOT adopt.
+	// Ambiguous: two open PRs in the project share the branch → must NOT adopt.
 	ambiguous := mk("ambiguous", task.Update{
-		Status:    task.Ptr(task.StatusHumanRequired),
-		Branch:    task.Ptr("feat/ambig"),
-		ProjectID: task.Ptr("o/r"),
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr("no commits pushed to branch"),
+		Branch:       task.Ptr("feat/ambig"),
+		ProjectID:    task.Ptr("o/r"),
 	})
 	// No matching PR → must NOT adopt.
 	noMatch := mk("no-match", task.Update{
-		Status:    task.Ptr(task.StatusHumanRequired),
-		Branch:    task.Ptr("feat/orphaned-forever"),
-		ProjectID: task.Ptr("o/r"),
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr("no commits pushed to branch"),
+		Branch:       task.Ptr("feat/orphaned-forever"),
+		ProjectID:    task.Ptr("o/r"),
+	})
+	// Same branch name but the only matching PR is in a DIFFERENT repo → the
+	// repo guard must reject it (monitoredPRs spans every repo the user owns).
+	wrongRepo := mk("wrong-repo", task.Update{
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr("no commits pushed to branch"),
+		Branch:       task.Ptr("feat/cross"),
+		ProjectID:    task.Ptr("o/r"),
+	})
+	// Deliberately stopped by the watchdog (not a link-failure strand) → the
+	// reason gate must keep adoption from resurrecting it.
+	watchdog := mk("watchdog", task.Update{
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr("watchdog: runaway loop"),
+		Branch:       task.Ptr("feat/wd"),
+		ProjectID:    task.Ptr("o/r"),
 	})
 	// Already in-review with a PR → not eligible, must be left untouched.
 	healthy := mk("healthy", task.Update{
@@ -365,6 +383,8 @@ func TestAdoptOrphanPRs(t *testing.T) {
 		{Number: 1051, HeadRefName: "feat/stranded", Repository: "o/r"},
 		{Number: 7, HeadRefName: "feat/ambig", Repository: "o/r"},
 		{Number: 8, HeadRefName: "feat/ambig", Repository: "o/r"},
+		{Number: 9, HeadRefName: "feat/cross", Repository: "o/other-repo"}, // wrong repo
+		{Number: 10, HeadRefName: "feat/wd", Repository: "o/r"},            // watchdog task's branch
 		{Number: 42, HeadRefName: "feat/healthy", Repository: "o/r"},
 	}
 
@@ -409,6 +429,20 @@ func TestAdoptOrphanPRs(t *testing.T) {
 		}
 	})
 
+	t.Run("cross-repo branch collision rejected", func(t *testing.T) {
+		got, _ := tasks.Get(wrongRepo)
+		if got.Status != task.StatusHumanRequired || got.PRNumber != 0 {
+			t.Errorf("cross-repo PR adopted: status=%q pr=%d, want human-required/0", got.Status, got.PRNumber)
+		}
+	})
+
+	t.Run("watchdog-stopped task not resurrected", func(t *testing.T) {
+		got, _ := tasks.Get(watchdog)
+		if got.Status != task.StatusHumanRequired || got.PRNumber != 0 {
+			t.Errorf("watchdog-stopped task adopted: status=%q pr=%d, want human-required/0", got.Status, got.PRNumber)
+		}
+	})
+
 	t.Run("ineligible task untouched", func(t *testing.T) {
 		got, _ := tasks.Get(healthy)
 		if got.Status != task.StatusInReview || got.PRNumber != 42 {
@@ -418,18 +452,22 @@ func TestAdoptOrphanPRs(t *testing.T) {
 }
 
 func TestOrphanPRAdoptionEligible(t *testing.T) {
+	const orphanReason = "no commits pushed to branch"
 	cases := []struct {
 		name string
 		t    task.Task
 		want bool
 	}{
-		{"stranded orphan", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r"}, true},
-		{"has pr number", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r", PRNumber: 5}, false},
-		{"no branch", task.Task{Status: task.StatusHumanRequired, ProjectID: "o/r"}, false},
-		{"no project", task.Task{Status: task.StatusHumanRequired, Branch: "b"}, false},
-		{"not human-required", task.Task{Status: task.StatusInProgress, Branch: "b", ProjectID: "o/r"}, false},
-		{"review task excluded", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r", Tags: []string{"review"}}, false},
-		{"chat task excluded", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r", TaskType: task.TaskTypeChat}, false},
+		{"stranded orphan (no-commits)", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r", StatusReason: orphanReason}, true},
+		{"evaluate orphan (no PR)", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r", StatusReason: "commits pushed but no PR created"}, true},
+		{"has pr number", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r", PRNumber: 5, StatusReason: orphanReason}, false},
+		{"no branch", task.Task{Status: task.StatusHumanRequired, ProjectID: "o/r", StatusReason: orphanReason}, false},
+		{"no project", task.Task{Status: task.StatusHumanRequired, Branch: "b", StatusReason: orphanReason}, false},
+		{"not human-required", task.Task{Status: task.StatusInProgress, Branch: "b", ProjectID: "o/r", StatusReason: orphanReason}, false},
+		{"watchdog stop not eligible", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r", StatusReason: "watchdog: runaway loop"}, false},
+		{"unrelated reason not eligible", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r", StatusReason: "needs design input"}, false},
+		{"review task excluded", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r", StatusReason: orphanReason, Tags: []string{"review"}}, false},
+		{"chat task excluded", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r", StatusReason: orphanReason, TaskType: task.TaskTypeChat}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -304,6 +304,142 @@ func TestCreateReviewTaskPassesUpdatedTaskToTriage(t *testing.T) {
 // re-spawning agents long after the underlying CI failure was resolved.
 // The fix: cancel any in-flight pr-fix workflow whose pr_issue_kind is no
 // longer present in the current MatchTaskPRs output.
+func TestAdoptOrphanPRs(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := task.NewStore(filepath.Join(tmp, "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	mk := func(title string, u task.Update) string {
+		t.Helper()
+		created, cErr := tasks.Create(title, "", string(task.AgentModeHeadless))
+		if cErr != nil {
+			t.Fatalf("create %s: %v", title, cErr)
+		}
+		if _, uErr := tasks.Update(created.ID, u); uErr != nil {
+			t.Fatalf("update %s: %v", title, uErr)
+		}
+		return created.ID
+	}
+
+	// Stranded by a premature verify_commits verdict: human-required, branch
+	// set, no PR number — the exact 94af6462 failure shape.
+	orphan := mk("stranded", task.Update{
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr("implementation agent failed before committing — no commits on branch"),
+		Branch:       task.Ptr("feat/stranded"),
+		ProjectID:    task.Ptr("o/r"),
+	})
+	// Ambiguous: two open PRs share the branch → must NOT adopt.
+	ambiguous := mk("ambiguous", task.Update{
+		Status:    task.Ptr(task.StatusHumanRequired),
+		Branch:    task.Ptr("feat/ambig"),
+		ProjectID: task.Ptr("o/r"),
+	})
+	// No matching PR → must NOT adopt.
+	noMatch := mk("no-match", task.Update{
+		Status:    task.Ptr(task.StatusHumanRequired),
+		Branch:    task.Ptr("feat/orphaned-forever"),
+		ProjectID: task.Ptr("o/r"),
+	})
+	// Already in-review with a PR → not eligible, must be left untouched.
+	healthy := mk("healthy", task.Update{
+		Status:    task.Ptr(task.StatusInReview),
+		Branch:    task.Ptr("feat/healthy"),
+		ProjectID: task.Ptr("o/r"),
+		PRNumber:  task.Ptr(42),
+	})
+
+	r := &ReviewHandler{
+		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
+		tasks:         tasks,
+	}
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	prs := []github.PullRequest{
+		{Number: 1051, HeadRefName: "feat/stranded", Repository: "o/r"},
+		{Number: 7, HeadRefName: "feat/ambig", Repository: "o/r"},
+		{Number: 8, HeadRefName: "feat/ambig", Repository: "o/r"},
+		{Number: 42, HeadRefName: "feat/healthy", Repository: "o/r"},
+	}
+
+	r.adoptOrphanPRs(all, prs)
+
+	t.Run("orphan adopted and re-activated", func(t *testing.T) {
+		got, _ := tasks.Get(orphan)
+		if got.Status != task.StatusInReview {
+			t.Errorf("status = %q, want in-review", got.Status)
+		}
+		if got.PRNumber != 1051 {
+			t.Errorf("PRNumber = %d, want 1051", got.PRNumber)
+		}
+		if got.StatusReason != "" {
+			t.Errorf("StatusReason = %q, want cleared", got.StatusReason)
+		}
+	})
+
+	t.Run("in-place slice mutation visible to same poll", func(t *testing.T) {
+		for i := range all {
+			if all[i].ID == orphan {
+				if all[i].Status != task.StatusInReview || all[i].PRNumber != 1051 {
+					t.Errorf("slice entry not updated in place: status=%q pr=%d", all[i].Status, all[i].PRNumber)
+				}
+				return
+			}
+		}
+		t.Fatal("orphan not found in slice")
+	})
+
+	t.Run("ambiguous branch left untouched", func(t *testing.T) {
+		got, _ := tasks.Get(ambiguous)
+		if got.Status != task.StatusHumanRequired || got.PRNumber != 0 {
+			t.Errorf("ambiguous adopted: status=%q pr=%d, want human-required/0", got.Status, got.PRNumber)
+		}
+	})
+
+	t.Run("no matching PR left untouched", func(t *testing.T) {
+		got, _ := tasks.Get(noMatch)
+		if got.Status != task.StatusHumanRequired {
+			t.Errorf("no-match adopted: status=%q, want human-required", got.Status)
+		}
+	})
+
+	t.Run("ineligible task untouched", func(t *testing.T) {
+		got, _ := tasks.Get(healthy)
+		if got.Status != task.StatusInReview || got.PRNumber != 42 {
+			t.Errorf("healthy task mutated: status=%q pr=%d", got.Status, got.PRNumber)
+		}
+	})
+}
+
+func TestOrphanPRAdoptionEligible(t *testing.T) {
+	cases := []struct {
+		name string
+		t    task.Task
+		want bool
+	}{
+		{"stranded orphan", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r"}, true},
+		{"has pr number", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r", PRNumber: 5}, false},
+		{"no branch", task.Task{Status: task.StatusHumanRequired, ProjectID: "o/r"}, false},
+		{"no project", task.Task{Status: task.StatusHumanRequired, Branch: "b"}, false},
+		{"not human-required", task.Task{Status: task.StatusInProgress, Branch: "b", ProjectID: "o/r"}, false},
+		{"review task excluded", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r", Tags: []string{"review"}}, false},
+		{"chat task excluded", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r", TaskType: task.TaskTypeChat}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := orphanPRAdoptionEligible(&tc.t); got != tc.want {
+				t.Errorf("orphanPRAdoptionEligible = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCancelResolvedPRFixWorkflows(t *testing.T) {
 	tmp := t.TempDir()
 	store, err := task.NewStore(filepath.Join(tmp, "tasks"))

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -303,6 +303,10 @@ func (a *agentAdapter) HasRunningAgent(taskID string) bool {
 	return a.agents.HasRunningAgentForTask(taskID)
 }
 
+func (a *agentAdapter) HasOtherRunningAgentForTask(taskID, exceptAgentID string) bool {
+	return a.agents.HasOtherRunningAgentForTask(taskID, exceptAgentID)
+}
+
 func (a *agentAdapter) FindRunningAgentForRole(taskID, role string) (string, bool) {
 	r := agent.Role(role)
 	ag := a.agents.FindRunningAgentForTask(taskID, r)

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -23,6 +23,11 @@ type AgentCompletion struct {
 type AgentLauncher interface {
 	StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool) (agentID string, err error)
 	HasRunningAgent(taskID string) bool
+	// HasOtherRunningAgentForTask reports whether an agent other than
+	// exceptAgentID is still running for the task. verify_commits uses it to
+	// avoid a premature verdict while a sibling agent is mid-flight, excluding
+	// the agent whose completion is currently being processed.
+	HasOtherRunningAgentForTask(taskID, exceptAgentID string) bool
 	FindRunningAgentForRole(taskID, role string) (agentID string, found bool)
 	StopAgentsForTask(taskID string, role string)
 	SendPrompt(agentID, message string) error

--- a/internal/workflow/builtin/simple-task-implement.yaml
+++ b/internal/workflow/builtin/simple-task-implement.yaml
@@ -49,15 +49,6 @@ steps:
     name: Verify Commits
     type: verify_commits
     next:
-      # A sibling agent is still working this task (verify_commits set
-      # verify_deferred): end this run without a verdict instead of flipping to
-      # human-required on a task with live work in flight. Recovery re-drives
-      # the workflow once the worktree is quiescent.
-      - when:
-          field: vars.verify_deferred
-          operator: equals
-          value: "true"
-        goto: ""
       - when:
           field: task.status
           operator: equals

--- a/internal/workflow/builtin/simple-task-implement.yaml
+++ b/internal/workflow/builtin/simple-task-implement.yaml
@@ -49,6 +49,15 @@ steps:
     name: Verify Commits
     type: verify_commits
     next:
+      # A sibling agent is still working this task (verify_commits set
+      # verify_deferred): end this run without a verdict instead of flipping to
+      # human-required on a task with live work in flight. Recovery re-drives
+      # the workflow once the worktree is quiescent.
+      - when:
+          field: vars.verify_deferred
+          operator: equals
+          value: "true"
+        goto: ""
       - when:
           field: task.status
           operator: equals

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -77,10 +77,9 @@ func TestBuiltinSimpleTask_MaybeCritiqueReplanSkip(t *testing.T) {
 }
 
 // TestBuiltinSimpleTaskImplement_VerifyCommitsRouting pins the verify_commits
-// transition table — in particular the verify_deferred escape that ends the run
-// without a verdict when a sibling agent is still working. `vars.*` fields skip
-// enum validation, so a typo in the field/operator/value would silently route a
-// deferred (possibly no-commits) task to set_ready_review; this test guards it.
+// transition table: human-required and done end the run, everything else hands
+// off to review. (The sibling-still-running case is handled in Go by parking
+// the workflow in ExecWaiting, not by a transition — see execVerifyCommits.)
 func TestBuiltinSimpleTaskImplement_VerifyCommitsRouting(t *testing.T) {
 	t.Parallel()
 
@@ -108,11 +107,6 @@ func TestBuiltinSimpleTaskImplement_VerifyCommitsRouting(t *testing.T) {
 		fields map[string]string
 		want   string
 	}{
-		{
-			name:   "deferred ends the run (no verdict)",
-			fields: map[string]string{"vars.verify_deferred": "true", "task.status": "in-progress"},
-			want:   "",
-		},
 		{
 			name:   "human-required ends the run",
 			fields: map[string]string{"task.status": "human-required"},

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -76,6 +76,72 @@ func TestBuiltinSimpleTask_MaybeCritiqueReplanSkip(t *testing.T) {
 	}
 }
 
+// TestBuiltinSimpleTaskImplement_VerifyCommitsRouting pins the verify_commits
+// transition table — in particular the verify_deferred escape that ends the run
+// without a verdict when a sibling agent is still working. `vars.*` fields skip
+// enum validation, so a typo in the field/operator/value would silently route a
+// deferred (possibly no-commits) task to set_ready_review; this test guards it.
+func TestBuiltinSimpleTaskImplement_VerifyCommitsRouting(t *testing.T) {
+	t.Parallel()
+
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var impl *Definition
+	for i := range defs {
+		if defs[i].ID == "simple-task-implement" {
+			impl = &defs[i]
+			break
+		}
+	}
+	if impl == nil {
+		t.Fatal("simple-task-implement builtin definition not found")
+	}
+	step := impl.StepByID("verify_commits")
+	if step == nil {
+		t.Fatal("verify_commits step not found in simple-task-implement")
+	}
+
+	cases := []struct {
+		name   string
+		fields map[string]string
+		want   string
+	}{
+		{
+			name:   "deferred ends the run (no verdict)",
+			fields: map[string]string{"vars.verify_deferred": "true", "task.status": "in-progress"},
+			want:   "",
+		},
+		{
+			name:   "human-required ends the run",
+			fields: map[string]string{"task.status": "human-required"},
+			want:   "",
+		},
+		{
+			name:   "done ends the run",
+			fields: map[string]string{"task.status": "done"},
+			want:   "",
+		},
+		{
+			name:   "clean in-progress hands off to review",
+			fields: map[string]string{"task.status": "in-progress"},
+			want:   "set_ready_review",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveTransition(step.Next, tc.fields)
+			if err != nil {
+				t.Fatalf("ResolveTransition: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("goto = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestBuiltinSimpleTask_TriageNoplanRouting locks the noplan escape hatch in
 // the triage step's transition table: a noplan tag routes straight to
 // implement (winning over a planning status), terminal statuses still win over

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -338,6 +339,14 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 		// Sync steps: execute, record result, resolve next, loop.
 		output, execErr := e.execSyncStep(taskID, step, wfExec, ctx, t)
 		if execErr != nil {
+			// The step parked the workflow in ExecWaiting (it persisted the new
+			// CurrentStep/State itself). Stop without recording/advancing/
+			// completing: completing here would fire the status-change cascade.
+			// ResumeStalled re-drives the re-armed run_agent step once idle.
+			if errors.Is(execErr, errStepParked) {
+				var parkedNoCompletion *CompletionInfo
+				return parkedNoCompletion, nil
+			}
 			return nil, execErr
 		}
 

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -116,6 +117,16 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 	oneShot := mode == "interactive" && !step.Config.ReuseAgent && step.Config.WaitForStatus == ""
 	agentID, err := e.agents.StartAgent(taskID, step.Config.Role, mode, model, provider, prompt, dir, step.Config.AllowedTools, step.Config.NeedsWorktree, oneShot)
 	if err != nil {
+		// Another dispatcher already holds the per-task dispatch claim (e.g. the
+		// recovery loop won the race for this task). That agent will run and its
+		// completion drives the workflow forward — so wait rather than failing
+		// the step (which would otherwise route into verify_commits /
+		// human-required on a task that has live work in flight).
+		if errors.Is(err, ErrDispatchInFlight) {
+			wfExec.State = ExecWaiting
+			e.logger.Info("workflow.run-agent.dispatch-in-flight", "task_id", taskID, "step", step.ID)
+			return e.tasks.SetWorkflow(taskID, wfExec)
+		}
 		return fmt.Errorf("start agent: %w", err)
 	}
 

--- a/internal/workflow/engine_steps_verify.go
+++ b/internal/workflow/engine_steps_verify.go
@@ -183,6 +183,22 @@ func (e *Engine) execVerifyCommits(taskID string, step *Step, wfExec *Execution,
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no worktree for task"}, nil
 	}
 
+	// Defense in depth against the duplicate-dispatch class of bug: if a
+	// sibling agent (other than the one whose completion triggered this step)
+	// is still working the task, the branch may have no commits simply because
+	// that agent has not pushed yet. Flipping to human-required now would
+	// strand a task with live work in flight. End this run without a verdict
+	// via the verify_deferred transition; recovery re-drives the workflow once
+	// the worktree is quiescent, and the dispatch claim guarantees no duplicate.
+	if e.agents != nil {
+		if exceptID := wfExec.LastAgentID(); e.agents.HasOtherRunningAgentForTask(taskID, exceptID) {
+			wfExec.SetVar("verify_deferred", "true")
+			e.logger.Warn("workflow.verify-commits.deferred",
+				"task_id", taskID, "except_agent", exceptID)
+			return StepOutput{StepID: step.ID, Status: "completed", Output: "deferred: another agent still running for task"}, nil
+		}
+	}
+
 	output, err := e.gitLogAheadOfBase(wtPath)
 	if err != nil && !errors.Is(e.ctx.Err(), context.Canceled) && !errors.Is(e.ctx.Err(), context.DeadlineExceeded) {
 		verifyCommitsRetrySleep(verifyCommitsRetryBackoff)

--- a/internal/workflow/engine_steps_verify.go
+++ b/internal/workflow/engine_steps_verify.go
@@ -11,6 +11,13 @@ import (
 	"github.com/Automaat/sybra/internal/github"
 )
 
+// errStepParked is a sentinel returned by a synchronous step that has parked
+// its own workflow in ExecWaiting (persisting the new CurrentStep/State itself).
+// executeSteps treats it as "stop, do not record/advance/complete" — completing
+// would fire the status-change cascade. Used by verify_commits to wait out a
+// still-running sibling agent without re-dispatching over it.
+var errStepParked = errors.New("workflow step parked in ExecWaiting")
+
 // execEnsurePRClosesIssue verifies the task's PR closes its linked
 // GitHub issue. When the closing reference is missing, it appends
 // `Closes <issue-url>` to the PR body via the PRLinker and re-verifies.
@@ -183,19 +190,29 @@ func (e *Engine) execVerifyCommits(taskID string, step *Step, wfExec *Execution,
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no worktree for task"}, nil
 	}
 
-	// Defense in depth against the duplicate-dispatch class of bug: if a
-	// sibling agent (other than the one whose completion triggered this step)
-	// is still working the task, the branch may have no commits simply because
-	// that agent has not pushed yet. Flipping to human-required now would
-	// strand a task with live work in flight. End this run without a verdict
-	// via the verify_deferred transition; recovery re-drives the workflow once
-	// the worktree is quiescent, and the dispatch claim guarantees no duplicate.
+	// Defense in depth against the duplicate-dispatch class of bug: if a sibling
+	// agent (other than the one whose completion triggered this step) is still
+	// working the task, the branch may have no commits simply because that agent
+	// has not pushed yet. Both flipping to human-required (strands live work) and
+	// completing the workflow (its status-change cascade would re-dispatch the
+	// implement workflow and StopAgentsForTask the sibling) are wrong. Instead
+	// re-arm the implementation run_agent step and park the workflow in
+	// ExecWaiting WITHOUT completing it — ResumeStalled re-drives verification
+	// once the worktree is quiescent, and the dispatch claim guarantees no
+	// duplicate. Excludes the just-completed agent (its done channel closes only
+	// after onComplete) so this never fires on the triggering agent itself.
 	if e.agents != nil {
 		if exceptID := wfExec.LastAgentID(); e.agents.HasOtherRunningAgentForTask(taskID, exceptID) {
-			wfExec.SetVar("verify_deferred", "true")
-			e.logger.Warn("workflow.verify-commits.deferred",
-				"task_id", taskID, "except_agent", exceptID)
-			return StepOutput{StepID: step.ID, Status: "completed", Output: "deferred: another agent still running for task"}, nil
+			if rearm := wfExec.LastAgentStepID(); rearm != "" {
+				wfExec.CurrentStep = rearm
+				wfExec.State = ExecWaiting
+				if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
+					return StepOutput{}, err
+				}
+				e.logger.Warn("workflow.verify-commits.parked",
+					"task_id", taskID, "rearm_step", rearm, "except_agent", exceptID)
+				return StepOutput{}, errStepParked
+			}
 		}
 	}
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -258,6 +258,13 @@ func (m *mockAgents) HasRunningAgent(taskID string) bool {
 	return ok
 }
 
+func (m *mockAgents) HasOtherRunningAgentForTask(taskID, exceptAgentID string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	id, ok := m.running[taskID]
+	return ok && id != exceptAgentID
+}
+
 func (m *mockAgents) FindRunningAgentForRole(taskID, role string) (string, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -2639,6 +2646,114 @@ func makeGitRepo(t *testing.T, withExtraCommit bool) string {
 	}
 
 	return dir
+}
+
+// TestExecRunAgent_DispatchInFlightWaits asserts a run_agent step whose
+// StartAgent loses the per-task dispatch claim parks the workflow in
+// ExecWaiting (the claim holder's agent will drive it) rather than failing the
+// step and routing toward human-required.
+func TestExecRunAgent_DispatchInFlightWaits(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
+	agents := newMockAgents()
+	agents.SetFailSpawn(ErrDispatchInFlight)
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	if err := engine.StartWorkflow("t1", "test-simple"); err != nil {
+		t.Fatalf("StartWorkflow returned error, want nil (dispatch-in-flight is benign): %v", err)
+	}
+
+	ti, _ := tasks.GetTask("t1")
+	if ti.Workflow == nil || ti.Workflow.State != ExecWaiting {
+		t.Fatalf("workflow state = %v, want ExecWaiting", ti.Workflow)
+	}
+	if ti.Status == "human-required" {
+		t.Errorf("dispatch-in-flight must not flip task to human-required")
+	}
+	if agents.CallCount() != 0 {
+		t.Errorf("no agent should have been recorded as started, got %d calls", agents.CallCount())
+	}
+}
+
+// TestExecRunAgent_RealSpawnErrorPropagates is the contrast to the test above:
+// a genuine (non-dispatch-in-flight) spawn error must still surface.
+func TestExecRunAgent_RealSpawnErrorPropagates(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
+	agents := newMockAgents()
+	agents.SetFailSpawn(errors.New("worktree boom"))
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	if err := engine.StartWorkflow("t1", "test-simple"); err == nil {
+		t.Fatal("StartWorkflow should propagate a real spawn error")
+	}
+}
+
+// TestExecVerifyCommits_DefersWhileSiblingRunning asserts the step ends the run
+// without a verdict (verify_deferred) when another agent is still working the
+// task, rather than flipping a task with live work to human-required.
+func TestExecVerifyCommits_DefersWhileSiblingRunning(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	agents := newMockAgents()
+	agents.mu.Lock()
+	agents.running["t1"] = "sibling" // a different agent than the completer
+	agents.mu.Unlock()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: makeGitRepo(t, false /* no commits */), ok: true})
+
+	wfExec := &Execution{}
+	wfExec.RecordStep(StepRecord{StepID: "implement", Status: "failed", AgentID: "completer"})
+
+	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), wfExec, TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.Output, "deferred") {
+		t.Errorf("Output = %q, want deferred", out.Output)
+	}
+	if wfExec.Variables["verify_deferred"] != "true" {
+		t.Errorf("verify_deferred = %q, want true", wfExec.Variables["verify_deferred"])
+	}
+	if ti, _ := tasks.GetTask("t1"); ti.Status != "in-progress" {
+		t.Errorf("status = %q, want unchanged in-progress (no human-required flip)", ti.Status)
+	}
+}
+
+// TestExecVerifyCommits_ExcludesCompletingAgent guards against the self-deadlock
+// the deferral could otherwise cause: the agent whose completion triggered the
+// step still reads as running (its done channel closes after onComplete), so it
+// must be excluded. With no genuine sibling, the normal no-commits verdict fires.
+func TestExecVerifyCommits_ExcludesCompletingAgent(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	agents := newMockAgents()
+	agents.mu.Lock()
+	agents.running["t1"] = "completer" // the same agent whose completion drives this step
+	agents.mu.Unlock()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: makeGitRepo(t, false /* no commits */), ok: true})
+
+	wfExec := &Execution{}
+	wfExec.RecordStep(StepRecord{StepID: "implement", Status: "failed", AgentID: "completer"})
+
+	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), wfExec, TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wfExec.Variables["verify_deferred"] == "true" {
+		t.Error("must not defer when only the completing agent appears running")
+	}
+	if !strings.Contains(out.Output, "human-required") {
+		t.Errorf("Output = %q, want the human-required verdict", out.Output)
+	}
+	if ti, _ := tasks.GetTask("t1"); ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required (genuine crash, no sibling)", ti.Status)
+	}
 }
 
 func TestExecVerifyCommits_NoGetterSkips(t *testing.T) {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2691,13 +2691,16 @@ func TestExecRunAgent_RealSpawnErrorPropagates(t *testing.T) {
 	}
 }
 
-// TestExecVerifyCommits_DefersWhileSiblingRunning asserts the step ends the run
-// without a verdict (verify_deferred) when another agent is still working the
-// task, rather than flipping a task with live work to human-required.
-func TestExecVerifyCommits_DefersWhileSiblingRunning(t *testing.T) {
+// TestExecVerifyCommits_ParksWhileSiblingRunning asserts the step re-arms the
+// implement run_agent step and parks the workflow in ExecWaiting (returning
+// errStepParked) when another agent is still working the task — instead of
+// flipping a task with live work to human-required OR completing the workflow
+// (whose status-change cascade would re-dispatch over the sibling).
+func TestExecVerifyCommits_ParksWhileSiblingRunning(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
-	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress",
+		Workflow: &Execution{WorkflowID: "x", CurrentStep: "verify_commits", State: ExecRunning}})
 	agents := newMockAgents()
 	agents.mu.Lock()
 	agents.running["t1"] = "sibling" // a different agent than the completer
@@ -2705,18 +2708,18 @@ func TestExecVerifyCommits_DefersWhileSiblingRunning(t *testing.T) {
 	engine := NewEngine(store, tasks, agents, discardLogger())
 	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: makeGitRepo(t, false /* no commits */), ok: true})
 
-	wfExec := &Execution{}
+	wfExec := &Execution{WorkflowID: "x", CurrentStep: "verify_commits", State: ExecRunning}
 	wfExec.RecordStep(StepRecord{StepID: "implement", Status: "failed", AgentID: "completer"})
 
-	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), wfExec, TaskInfo{ID: "t1"})
-	if err != nil {
-		t.Fatal(err)
+	_, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), wfExec, TaskInfo{ID: "t1"})
+	if !errors.Is(err, errStepParked) {
+		t.Fatalf("err = %v, want errStepParked", err)
 	}
-	if !strings.Contains(out.Output, "deferred") {
-		t.Errorf("Output = %q, want deferred", out.Output)
+	if wfExec.State != ExecWaiting {
+		t.Errorf("State = %q, want ExecWaiting", wfExec.State)
 	}
-	if wfExec.Variables["verify_deferred"] != "true" {
-		t.Errorf("verify_deferred = %q, want true", wfExec.Variables["verify_deferred"])
+	if wfExec.CurrentStep != "implement" {
+		t.Errorf("CurrentStep = %q, want implement (re-armed run_agent step)", wfExec.CurrentStep)
 	}
 	if ti, _ := tasks.GetTask("t1"); ti.Status != "in-progress" {
 		t.Errorf("status = %q, want unchanged in-progress (no human-required flip)", ti.Status)
@@ -2742,17 +2745,68 @@ func TestExecVerifyCommits_ExcludesCompletingAgent(t *testing.T) {
 	wfExec.RecordStep(StepRecord{StepID: "implement", Status: "failed", AgentID: "completer"})
 
 	out, err := engine.execVerifyCommits("t1", newVerifyCommitsStep(), wfExec, TaskInfo{ID: "t1"})
+	if errors.Is(err, errStepParked) {
+		t.Fatal("must not park when only the completing agent appears running")
+	}
 	if err != nil {
 		t.Fatal(err)
-	}
-	if wfExec.Variables["verify_deferred"] == "true" {
-		t.Error("must not defer when only the completing agent appears running")
 	}
 	if !strings.Contains(out.Output, "human-required") {
 		t.Errorf("Output = %q, want the human-required verdict", out.Output)
 	}
 	if ti, _ := tasks.GetTask("t1"); ti.Status != "human-required" {
 		t.Errorf("status = %q, want human-required (genuine crash, no sibling)", ti.Status)
+	}
+}
+
+// TestExecuteSteps_VerifyCommitsParkDoesNotComplete is the regression test for
+// the Copilot finding: a deferred verify_commits must NOT complete the workflow,
+// because OnWorkflowComplete cascades on the (still in-progress) status and would
+// re-dispatch simple-task-implement — whose execRunAgent StopAgentsForTask would
+// kill the still-running sibling. executeSteps must return a nil completion
+// (parked, ExecWaiting), never a CompletionInfo.
+func TestExecuteSteps_VerifyCommitsParkDoesNotComplete(t *testing.T) {
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var impl *Definition
+	for i := range defs {
+		if defs[i].ID == "simple-task-implement" {
+			impl = &defs[i]
+			break
+		}
+	}
+	if impl == nil {
+		t.Fatal("simple-task-implement builtin not found")
+	}
+
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress",
+		Workflow: &Execution{WorkflowID: "simple-task-implement", CurrentStep: "verify_commits", State: ExecRunning}})
+	agents := newMockAgents()
+	agents.mu.Lock()
+	agents.running["t1"] = "sibling"
+	agents.mu.Unlock()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: makeGitRepo(t, false /* no commits */), ok: true})
+
+	wf := &Execution{WorkflowID: "simple-task-implement", CurrentStep: "verify_commits", State: ExecRunning}
+	wf.RecordStep(StepRecord{StepID: "implement", Status: "failed", AgentID: "completer"})
+
+	comp, err := engine.executeSteps("t1", impl, impl.StepByID("verify_commits"), wf)
+	if err != nil {
+		t.Fatalf("executeSteps: %v", err)
+	}
+	if comp != nil {
+		t.Errorf("executeSteps returned a completion (workflow finished → cascade would re-dispatch over the sibling); want nil (parked)")
+	}
+	if wf.State != ExecWaiting {
+		t.Errorf("State = %q, want ExecWaiting", wf.State)
+	}
+	if wf.CurrentStep != "implement" {
+		t.Errorf("CurrentStep = %q, want implement (re-armed for ResumeStalled)", wf.CurrentStep)
 	}
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2795,7 +2795,11 @@ func TestExecuteSteps_VerifyCommitsParkDoesNotComplete(t *testing.T) {
 	wf := &Execution{WorkflowID: "simple-task-implement", CurrentStep: "verify_commits", State: ExecRunning}
 	wf.RecordStep(StepRecord{StepID: "implement", Status: "failed", AgentID: "completer"})
 
-	comp, err := engine.executeSteps("t1", impl, impl.StepByID("verify_commits"), wf)
+	verifyStep := impl.StepByID("verify_commits")
+	if verifyStep == nil {
+		t.Fatal("verify_commits step not found in simple-task-implement")
+	}
+	comp, err := engine.executeSteps("t1", impl, verifyStep, wf)
 	if err != nil {
 		t.Fatalf("executeSteps: %v", err)
 	}

--- a/internal/workflow/execution.go
+++ b/internal/workflow/execution.go
@@ -146,6 +146,19 @@ func (e *Execution) LastAgentStepFailed() bool {
 	return false
 }
 
+// LastAgentID returns the agent ID of the most recent step that ran an agent,
+// or "" if none. verify_commits uses it to identify the just-completed agent
+// (whose own completion triggered the step) so it can be excluded when checking
+// for a sibling agent still working the task.
+func (e *Execution) LastAgentID() string {
+	for i := range slices.Backward(e.StepHistory) {
+		if e.StepHistory[i].AgentID != "" {
+			return e.StepHistory[i].AgentID
+		}
+	}
+	return ""
+}
+
 // StepRecord captures the result of executing one step.
 type StepRecord struct {
 	StepID    string    `yaml:"step_id" json:"stepId"`

--- a/internal/workflow/execution.go
+++ b/internal/workflow/execution.go
@@ -159,6 +159,20 @@ func (e *Execution) LastAgentID() string {
 	return ""
 }
 
+// LastAgentStepID returns the step ID of the most recent step that ran an agent
+// (always a run_agent step, the only kind that records an AgentID), or "" if
+// none. verify_commits uses it to re-arm that step when parking the workflow to
+// wait out a sibling agent, so ResumeStalled — which only resumes run_agent
+// steps — re-drives it.
+func (e *Execution) LastAgentStepID() string {
+	for i := range slices.Backward(e.StepHistory) {
+		if e.StepHistory[i].AgentID != "" {
+			return e.StepHistory[i].StepID
+		}
+	}
+	return ""
+}
+
 // StepRecord captures the result of executing one step.
 type StepRecord struct {
 	StepID    string    `yaml:"step_id" json:"stepId"`

--- a/internal/workflow/execution_test.go
+++ b/internal/workflow/execution_test.go
@@ -23,6 +23,23 @@ func TestLastAgentID(t *testing.T) {
 	})
 }
 
+func TestLastAgentStepID(t *testing.T) {
+	t.Run("empty history", func(t *testing.T) {
+		e := &Execution{}
+		if got := e.LastAgentStepID(); got != "" {
+			t.Errorf("LastAgentStepID = %q, want empty", got)
+		}
+	})
+	t.Run("returns step id of most recent agent step", func(t *testing.T) {
+		e := &Execution{}
+		e.RecordStep(StepRecord{StepID: "implement", Status: "failed", AgentID: "agent-1"})
+		e.RecordStep(StepRecord{StepID: "verify", Status: "completed"}) // no AgentID
+		if got := e.LastAgentStepID(); got != "implement" {
+			t.Errorf("LastAgentStepID = %q, want implement", got)
+		}
+	})
+}
+
 func TestSetVar_InitializesNilMap(t *testing.T) {
 	e := &Execution{}
 

--- a/internal/workflow/execution_test.go
+++ b/internal/workflow/execution_test.go
@@ -5,6 +5,24 @@ import (
 	"time"
 )
 
+func TestLastAgentID(t *testing.T) {
+	t.Run("empty history", func(t *testing.T) {
+		e := &Execution{}
+		if got := e.LastAgentID(); got != "" {
+			t.Errorf("LastAgentID = %q, want empty", got)
+		}
+	})
+	t.Run("most recent agent step wins, non-agent steps skipped", func(t *testing.T) {
+		e := &Execution{}
+		e.RecordStep(StepRecord{StepID: "implement", Status: "failed", AgentID: "agent-old"})
+		e.RecordStep(StepRecord{StepID: "implement2", Status: "failed", AgentID: "agent-new"})
+		e.RecordStep(StepRecord{StepID: "verify", Status: "completed"}) // no AgentID
+		if got := e.LastAgentID(); got != "agent-new" {
+			t.Errorf("LastAgentID = %q, want agent-new", got)
+		}
+	})
+}
+
 func TestSetVar_InitializesNilMap(t *testing.T) {
 	e := &Execution{}
 

--- a/internal/workflow/start_error.go
+++ b/internal/workflow/start_error.go
@@ -11,6 +11,13 @@ import (
 // Longer messages clutter the UI and rarely add value beyond the lead error.
 const startReasonMaxLen = 200
 
+// ErrDispatchInFlight is returned by an agent-start path when another dispatch
+// for the same task is already in flight (the per-task dispatch claim is held).
+// It is a benign, transient outcome — the in-flight dispatch will produce the
+// task's agent — so it must never flip the task to human-required or write a
+// scary status_reason. ClassifyAgentStartError maps it to an empty reason.
+var ErrDispatchInFlight = errors.New("agent dispatch already in flight for task")
+
 // ClassifyAgentStartError translates an agent-start error into a UI-safe
 // status_reason and a "permanent" flag.
 //
@@ -25,6 +32,10 @@ func ClassifyAgentStartError(err error) (reason string, permanent bool) {
 		return "", false
 	}
 	switch {
+	case errors.Is(err, ErrDispatchInFlight):
+		// Transient and self-healing: another dispatcher holds the claim and
+		// will start the agent. Suppress the reason entirely.
+		return "", false
 	case errors.Is(err, project.ErrProjectNotRegistered):
 		permanent = true
 		reason = "agent start blocked: project not registered locally — create the project to resume"

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -59,6 +59,40 @@ func TestClassifyAgentStartError(t *testing.T) {
 	}
 }
 
+func TestClassifyAgentStartError_DispatchInFlightSuppressed(t *testing.T) {
+	// A dispatch-in-flight outcome is benign: the holder of the claim produces
+	// the agent. It must yield an empty reason (no status_reason written) and
+	// be non-permanent so the resume loop leaves the task alone.
+	reason, permanent := ClassifyAgentStartError(ErrDispatchInFlight)
+	if reason != "" {
+		t.Errorf("reason = %q, want empty", reason)
+	}
+	if permanent {
+		t.Error("dispatch-in-flight must not be permanent")
+	}
+	// Also when wrapped.
+	wrapped := fmt.Errorf("start agent: %w", ErrDispatchInFlight)
+	if r, p := ClassifyAgentStartError(wrapped); r != "" || p {
+		t.Errorf("wrapped: got reason=%q permanent=%v, want empty/false", r, p)
+	}
+}
+
+func TestSurfaceStartFailure_DispatchInFlightIsNoOp(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+
+	engine.surfaceStartFailure("t1", "in-progress", ErrDispatchInFlight)
+
+	got, _ := tasks.GetTask("t1")
+	if got.Status != "in-progress" {
+		t.Errorf("dispatch-in-flight flipped status: got %q, want in-progress", got.Status)
+	}
+	if reason := tasks.Reason("t1"); reason != "" {
+		t.Errorf("dispatch-in-flight wrote reason %q, want empty", reason)
+	}
+}
+
 func TestSurfaceStartFailure_TransientKeepsStatus(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})


### PR DESCRIPTION
## Motivation

A task could end up with two implementation agents running on the same git
worktree. When `simple-task-plan` cascades into `simple-task-implement`, the
implement agent's `StartAgent` spends several seconds preparing the worktree
before it registers the agent. The recovery loop scans during that window,
sees no running agent (and debounces against the stale plan run), and spawns a
second "Continue implementing" agent. The two corrupt each other's worktree;
`verify_commits` then flips the task to human-required while the survivor opens
a PR that is never linked — so the PR monitor can neither auto-fix CI nor
auto-merge it.

> Changelog: fix(agent): serialize per-task agent dispatch

## Implementation information

Three layers:

1. **Per-task dispatch claim** (`internal/agent`): `agent.Manager` holds a
   claim for the whole `StartAgent`/`StartPRFixAgent` call, including the
   worktree-prep window. A second dispatcher gets `ErrDispatchInFlight` and
   aborts; `execRunAgent` treats that as a wait, not a failure.
   `HasRunningAgentForTask` reports a held claim, so the recovery loop and
   `ResumeStalled` skip during the prep window. This is a pure in-flight lock —
   it does not inspect running agents, so a normal step transition dispatching
   its next agent inside the prior agent's `onComplete` is never blocked.
2. **verify_commits defer** (`internal/workflow`): when a sibling agent is still
   running, `verify_commits` ends the run without a verdict instead of flipping
   a task with live work to human-required. It excludes the just-completed agent
   (whose `done` channel closes after `onComplete`) to avoid self-deadlock.
   Recovery re-drives once quiescent.
3. **Orphan-PR adoption** (`internal/sybra`): the PR monitor adopts an open PR
   by branch — within the task's own project — for tasks stranded in
   human-required without a linked PR, re-activating them so the normal
   pr-fix/auto-merge path resumes.

Adversarial-review hardening on layer 3: adoption is scoped by repo (a
same-named branch in another repo can no longer mis-link a PR), gated to a
fail-closed status_reason allowlist (a deliberate watchdog stop is never
resurrected), and `handleAutoMerge` refuses any PR outside the task's own
project.

## Supporting documentation

Root cause traced from the server logs for task `94af6462` / PR #1051: the plan
workflow flipped the task to in-progress at 14:45:34, the implement agent
registered at 14:45:39 (after the worktree rebase), and the recovery loop fired
at 14:45:35 — squarely inside the gap — and spawned the duplicate.

Tests: per-layer unit coverage plus the adversarial cases (cross-repo branch
collision rejected, watchdog-stop not resurrected, and the `verify_deferred`
transition pinned through `ResolveTransition`).
