### PR TITLE
feat(eval): capture PR outcomes + per-run effort

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/agent/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/agent/models.ts
@@ -38,6 +38,13 @@ export class Agent {
     "turnCount"?: number;
 
     /**
+     * ToolCalls counts tool_use blocks observed across the run. Persisted to
+     * stats.RunRecord at completion so efficiency (tools per turn, tools per
+     * landed PR) can be measured. Tracked in-memory during the run.
+     */
+    "toolCalls"?: number;
+
+    /**
      * MaxTurns is the per-agent turn limit override; zero means use global guardrail.
      */
     "maxTurns"?: number;
@@ -95,10 +102,10 @@ export class Agent {
      * Creates a new Agent instance from a string or object.
      */
     static createFrom($$source: any = {}): Agent {
-        const $$createField24_0 = $$createType0;
+        const $$createField25_0 = $$createType0;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("pluginErrors" in $$parsedSource) {
-            $$parsedSource["pluginErrors"] = $$createField24_0($$parsedSource["pluginErrors"]);
+            $$parsedSource["pluginErrors"] = $$createField25_0($$parsedSource["pluginErrors"]);
         }
         return new Agent($$parsedSource as Partial<Agent>);
     }
@@ -235,6 +242,13 @@ export class StreamEvent {
      * PluginErrors carries plugin load failures surfaced by the init event.
      */
     "plugin_errors"?: string[];
+
+    /**
+     * ToolCalls is the number of tool_use blocks in this event: all tool uses
+     * in a Claude assistant turn, or a single Codex tool_use. The runner
+     * accumulates these into Agent.ToolCalls.
+     */
+    "tool_calls"?: number;
 
     /** Creates a new StreamEvent instance. */
     constructor($$source: Partial<StreamEvent> = {}) {

--- a/frontend/bindings/github.com/Automaat/sybra/internal/stats/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/stats/models.ts
@@ -64,6 +64,14 @@ export class RunRecord {
     "cacheCreationInputTokens"?: number;
     "cacheReadInputTokens"?: number;
     "reasoningTokens"?: number;
+
+    /**
+     * TurnCount and ToolCalls capture per-run effort so the evaluation
+     * scorecard can measure convergence (turns per landed PR) and tool
+     * efficiency. Zero for runs recorded before these were tracked.
+     */
+    "turnCount"?: number;
+    "toolCalls"?: number;
     "outcome": string;
     "timestamp": time$0.Time;
 

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -214,6 +214,13 @@ export class Task {
     "closedAt"?: time$0.Time | null;
 
     /**
+     * Outcome records how a task's own PR concluded: "merged" or "closed".
+     * Stamped by the PR monitor when the task auto-advances to done. Empty for
+     * tasks that never produced a PR. Feeds the evaluation scorecard.
+     */
+    "outcome"?: string;
+
+    /**
      * MaxTurns overrides the global agent turn limit for this task.
      * Zero means "use global default".
      */
@@ -328,9 +335,9 @@ export class Task {
     static createFrom($$source: any = {}): Task {
         const $$createField6_0 = $$createType0;
         const $$createField7_0 = $$createType0;
-        const $$createField26_0 = $$createType2;
-        const $$createField27_0 = $$createType4;
-        const $$createField34_0 = $$createType5;
+        const $$createField27_0 = $$createType2;
+        const $$createField28_0 = $$createType4;
+        const $$createField35_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -339,13 +346,13 @@ export class Task {
             $$parsedSource["tags"] = $$createField7_0($$parsedSource["tags"]);
         }
         if ("agentRuns" in $$parsedSource) {
-            $$parsedSource["agentRuns"] = $$createField26_0($$parsedSource["agentRuns"]);
+            $$parsedSource["agentRuns"] = $$createField27_0($$parsedSource["agentRuns"]);
         }
         if ("workflow" in $$parsedSource) {
-            $$parsedSource["workflow"] = $$createField27_0($$parsedSource["workflow"]);
+            $$parsedSource["workflow"] = $$createField28_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField34_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField35_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -55,6 +55,10 @@ type Agent struct {
 	Prompt                   string    `json:"prompt,omitempty"`
 
 	TurnCount int `json:"turnCount,omitempty"`
+	// ToolCalls counts tool_use blocks observed across the run. Persisted to
+	// stats.RunRecord at completion so efficiency (tools per turn, tools per
+	// landed PR) can be measured. Tracked in-memory during the run.
+	ToolCalls int `json:"toolCalls,omitempty"`
 	// MaxTurns is the per-agent turn limit override; zero means use global guardrail.
 	MaxTurns int `json:"maxTurns,omitempty"`
 	// PluginErrors holds plugin load failures from the most recent init event.
@@ -321,6 +325,30 @@ func (a *Agent) IncTurnCount() int {
 	n := a.TurnCount
 	a.mu.Unlock()
 	return n
+}
+
+// GetTurnCount returns the current turn count.
+func (a *Agent) GetTurnCount() int {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.TurnCount
+}
+
+// AddToolCalls increments the tool-call counter by n. No-op for n <= 0.
+func (a *Agent) AddToolCalls(n int) {
+	if n <= 0 {
+		return
+	}
+	a.mu.Lock()
+	a.ToolCalls += n
+	a.mu.Unlock()
+}
+
+// GetToolCalls returns the number of tool_use blocks observed so far.
+func (a *Agent) GetToolCalls() int {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.ToolCalls
 }
 
 // SetEscalationReason updates the escalation reason string.
@@ -593,6 +621,10 @@ type StreamEvent struct {
 	PlanSteps []PlanStep `json:"plan_steps,omitempty"`
 	// PluginErrors carries plugin load failures surfaced by the init event.
 	PluginErrors []string `json:"plugin_errors,omitempty"`
+	// ToolCalls is the number of tool_use blocks in this event: all tool uses
+	// in a Claude assistant turn, or a single Codex tool_use. The runner
+	// accumulates these into Agent.ToolCalls.
+	ToolCalls int `json:"tool_calls,omitempty"`
 }
 
 // ConvoEvent is a rich event for conversational mode, preserving full tool

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -371,6 +371,14 @@ func rehydrateFromLog(a *Agent, path string) int64 {
 		}
 		ev.Timestamp = time.Now().UTC()
 		a.AppendOutput(ev)
+		// Restore per-run effort the same way the live stream loop accumulates
+		// it (processHeadlessLine + checkTurnsGuardrail). Without this a run
+		// that crosses an app restart — or completes while the app is down and
+		// is finalized on reattach — records zero turns/tool calls.
+		a.AddToolCalls(ev.ToolCalls)
+		if ev.Type == "assistant" {
+			a.IncTurnCount()
+		}
 		if ev.Type == "result" {
 			a.AddResultStats(ev.SessionID, ev.CostUSD, ev.InputTokens, ev.OutputTokens, ev.ReasoningTokens)
 			a.AddCacheStats(ev.CacheCreationInputTokens, ev.CacheReadInputTokens)

--- a/internal/agent/reattach_effort_test.go
+++ b/internal/agent/reattach_effort_test.go
@@ -1,0 +1,42 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRehydrateFromLog_RestoresEffort guards the reattach/recovery path: an
+// agent whose run crossed an app restart (or completed while the app was down
+// and is finalized on reattach) must restore its turn and tool-call counts from
+// the replayed log, not record zeros into stats.RunRecord.
+func TestRehydrateFromLog_RestoresEffort(t *testing.T) {
+	lines := []string{
+		// Assistant turn with two tool_use blocks → +1 turn, +2 tool calls.
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Read","input":{}},{"type":"tool_use","id":"t2","name":"Bash","input":{"command":"ls"}}]}}`,
+		// Assistant text-only turn → +1 turn, +0 tool calls.
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"thinking"}]}}`,
+		// Result carries no turn or tool call.
+		`{"type":"result","subtype":"success"}`,
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.ndjson")
+	data := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatalf("write log: %v", err)
+	}
+
+	a := &Agent{Provider: "claude"}
+	off := rehydrateFromLog(a, path)
+
+	if off != int64(len(data)) {
+		t.Errorf("offset = %d, want %d (end of file)", off, len(data))
+	}
+	if got := a.GetTurnCount(); got != 2 {
+		t.Errorf("TurnCount = %d, want 2", got)
+	}
+	if got := a.GetToolCalls(); got != 2 {
+		t.Errorf("ToolCalls = %d, want 2", got)
+	}
+}

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -498,6 +498,7 @@ func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte
 
 	event.Timestamp = time.Now().UTC()
 	a.AppendOutput(event)
+	a.AddToolCalls(event.ToolCalls)
 	if event.Type == "result" || time.Since(*lastEmit) >= headlessEmitInterval {
 		m.emit(events.AgentOutput(a.ID), event)
 		*lastEmit = time.Now()

--- a/internal/agent/runner_headless_stream.go
+++ b/internal/agent/runner_headless_stream.go
@@ -82,6 +82,10 @@ func codexEventToStreamEvent(e CodexEvent) StreamEvent {
 			ev.Content = e.Message.Text
 		}
 	case "tool_use":
+		// Codex only emits a tool_use event for command_execution (Bash); file
+		// edits, MCP, and web search arrive as assistant text (ToolCalls=0). So
+		// ToolCalls undercounts non-Bash Codex tools — a follow-up should map the
+		// full Codex item taxonomy before comparing tool efficiency cross-provider.
 		if e.Message != nil && len(e.Message.ToolUses) > 0 {
 			cmd, _ := e.Message.ToolUses[0].Input["command"].(string)
 			ev.Content = cmd

--- a/internal/agent/runner_headless_stream.go
+++ b/internal/agent/runner_headless_stream.go
@@ -17,6 +17,7 @@ func claudeEventToStreamEvent(e ClaudeEvent) StreamEvent {
 		if e.Message != nil {
 			ev.Content = formatHeadlessAssistant(e.Message)
 			ev.PlanSteps = extractTodoWriteSteps(e.Message.ToolUses)
+			ev.ToolCalls = len(e.Message.ToolUses)
 		}
 	case "user":
 		if e.Message != nil {
@@ -84,6 +85,7 @@ func codexEventToStreamEvent(e CodexEvent) StreamEvent {
 		if e.Message != nil && len(e.Message.ToolUses) > 0 {
 			cmd, _ := e.Message.ToolUses[0].Input["command"].(string)
 			ev.Content = cmd
+			ev.ToolCalls = len(e.Message.ToolUses)
 		}
 	case "tool_result":
 		if e.Message != nil && len(e.Message.ToolResults) > 0 {

--- a/internal/agent/tool_calls_test.go
+++ b/internal/agent/tool_calls_test.go
@@ -1,0 +1,59 @@
+package agent
+
+import "testing"
+
+func TestAgentToolCalls(t *testing.T) {
+	a := &Agent{}
+	if got := a.GetToolCalls(); got != 0 {
+		t.Fatalf("initial GetToolCalls = %d, want 0", got)
+	}
+	a.AddToolCalls(3)
+	a.AddToolCalls(2)
+	a.AddToolCalls(0)  // no-op
+	a.AddToolCalls(-5) // no-op, never decrements
+	if got := a.GetToolCalls(); got != 5 {
+		t.Errorf("GetToolCalls = %d, want 5", got)
+	}
+}
+
+func TestClaudeEventToStreamEvent_ToolCalls(t *testing.T) {
+	tests := []struct {
+		name string
+		ev   ClaudeEvent
+		want int
+	}{
+		{
+			name: "assistant with two tool uses",
+			ev: ClaudeEvent{Type: "assistant", Message: &ClaudeMessage{
+				ToolUses: []ToolUseBlock{{Name: "Read"}, {Name: "Bash"}},
+			}},
+			want: 2,
+		},
+		{
+			name: "assistant text only",
+			ev:   ClaudeEvent{Type: "assistant", Message: &ClaudeMessage{Text: "hi"}},
+			want: 0,
+		},
+		{
+			name: "result event carries no tool calls",
+			ev:   ClaudeEvent{Type: "result", Result: &ClaudeResult{Text: "done"}},
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := claudeEventToStreamEvent(tt.ev).ToolCalls; got != tt.want {
+				t.Errorf("ToolCalls = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCodexEventToStreamEvent_ToolCalls(t *testing.T) {
+	e := CodexEvent{Type: "tool_use", Message: &ClaudeMessage{
+		ToolUses: []ToolUseBlock{{Name: "shell", Input: map[string]any{"command": "ls"}}},
+	}}
+	if got := codexEventToStreamEvent(e).ToolCalls; got != 1 {
+		t.Errorf("ToolCalls = %d, want 1", got)
+	}
+}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -38,6 +38,14 @@ const (
 	EventHumanReviewVerdict       = "human_review.verdict"
 	EventHumanReviewIssue         = "human_review.issue_filed"
 	EventHumanReviewSkipped       = "human_review.skipped"
+
+	// EventTaskLanded records a task's terminal outcome (merged/closed) with PR
+	// size and lead-time signal for the evaluation scorecard. Emitted once when
+	// a task auto-advances to done on its PR closing.
+	EventTaskLanded = "task.landed"
+	// EventPRReverted records that a previously-merged PR was reverted on the
+	// default branch — a change-failure signal. Reserved for revert detection.
+	EventPRReverted = "pr.reverted"
 )
 
 type Event struct {

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -39,9 +39,9 @@ const (
 	EventHumanReviewIssue         = "human_review.issue_filed"
 	EventHumanReviewSkipped       = "human_review.skipped"
 
-	// EventTaskLanded records a task's terminal outcome (merged/closed) with PR
-	// size and lead-time signal for the evaluation scorecard. Emitted once when
-	// a task auto-advances to done on its PR closing.
+	// EventTaskLanded records a task's terminal outcome (merged/closed) with
+	// queue-inclusive and work-based timing for the evaluation scorecard.
+	// Emitted once when a task auto-advances to done on its PR closing.
 	EventTaskLanded = "task.landed"
 	// EventPRReverted records that a previously-merged PR was reverted on the
 	// default branch — a change-failure signal. Reserved for revert detection.

--- a/internal/stats/model.go
+++ b/internal/stats/model.go
@@ -9,22 +9,27 @@ import "time"
 // (e.g. 1.07M cache reads vs 24 uncached input tokens in a single result
 // event), so plain InputTokens alone looks misleadingly small.
 type RunRecord struct {
-	ID                       string    `json:"id"`
-	TaskID                   string    `json:"taskId"`
-	ProjectID                string    `json:"projectId,omitempty"`
-	Mode                     string    `json:"mode"`
-	Role                     string    `json:"role"`
-	Model                    string    `json:"model,omitempty"`
-	Provider                 string    `json:"provider,omitempty"`
-	CostUSD                  float64   `json:"costUsd"`
-	DurationS                float64   `json:"durationS"`
-	InputTokens              int       `json:"inputTokens,omitempty"`
-	OutputTokens             int       `json:"outputTokens,omitempty"`
-	CacheCreationInputTokens int       `json:"cacheCreationInputTokens,omitempty"`
-	CacheReadInputTokens     int       `json:"cacheReadInputTokens,omitempty"`
-	ReasoningTokens          int       `json:"reasoningTokens,omitempty"`
-	Outcome                  string    `json:"outcome"`
-	Timestamp                time.Time `json:"timestamp"`
+	ID                       string  `json:"id"`
+	TaskID                   string  `json:"taskId"`
+	ProjectID                string  `json:"projectId,omitempty"`
+	Mode                     string  `json:"mode"`
+	Role                     string  `json:"role"`
+	Model                    string  `json:"model,omitempty"`
+	Provider                 string  `json:"provider,omitempty"`
+	CostUSD                  float64 `json:"costUsd"`
+	DurationS                float64 `json:"durationS"`
+	InputTokens              int     `json:"inputTokens,omitempty"`
+	OutputTokens             int     `json:"outputTokens,omitempty"`
+	CacheCreationInputTokens int     `json:"cacheCreationInputTokens,omitempty"`
+	CacheReadInputTokens     int     `json:"cacheReadInputTokens,omitempty"`
+	ReasoningTokens          int     `json:"reasoningTokens,omitempty"`
+	// TurnCount and ToolCalls capture per-run effort so the evaluation
+	// scorecard can measure convergence (turns per landed PR) and tool
+	// efficiency. Zero for runs recorded before these were tracked.
+	TurnCount int       `json:"turnCount,omitempty"`
+	ToolCalls int       `json:"toolCalls,omitempty"`
+	Outcome   string    `json:"outcome"`
+	Timestamp time.Time `json:"timestamp"`
 }
 
 // Summary holds aggregate metrics over a set of runs.

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -278,6 +278,8 @@ func (h *AgentCompletionHandler) recordRunStats(ag *agent.Agent, cost, duration 
 		CacheCreationInputTokens: cacheCreate,
 		CacheReadInputTokens:     cacheRead,
 		ReasoningTokens:          reasoning,
+		TurnCount:                ag.GetTurnCount(),
+		ToolCalls:                ag.GetToolCalls(),
 		Outcome:                  outcome,
 		Timestamp:                time.Now(),
 	})

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -166,23 +166,7 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 	}
 
 	if len(closedMatchers) > 0 {
-		closedPRs := github.DetectClosedTaskPRs(monitoredPRs, closedMatchers, github.FetchPRState)
-		for _, c := range closedPRs {
-			if r.agents.HasRunningAgentForTask(c.TaskID) {
-				r.logger.Info("pr-monitor.closed-skip-running-agent", "task_id", c.TaskID, "pr", c.PRNumber)
-				continue
-			}
-			if _, err := r.tasks.Update(c.TaskID, task.Update{Status: task.Ptr(task.StatusDone)}); err != nil {
-				r.logger.Error("pr-monitor.closed-update", "task_id", c.TaskID, "err", err)
-				continue
-			}
-			eventType := audit.EventPRMerged
-			if c.State == "CLOSED" {
-				eventType = audit.EventPRClosed
-			}
-			r.logAudit(eventType, c.TaskID, "", map[string]any{"pr": c.PRNumber, "state": c.State})
-			r.logger.Info("pr-monitor.auto-done", "task_id", c.TaskID, "pr", c.PRNumber, "state", c.State)
-		}
+		r.advanceClosedTaskPRs(monitoredPRs, closedMatchers)
 	}
 
 	r.resolveAddressedCopilotThreads(tasks, monitoredPRs)
@@ -195,6 +179,69 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 		return prPollFast
 	}
 	return prPollSlow
+}
+
+// advanceClosedTaskPRs moves tasks whose linked PR is no longer open to done,
+// stamping the terminal outcome and emitting the audit + task.landed events the
+// evaluation scorecard reads. Skips tasks with a still-running agent.
+func (r *ReviewHandler) advanceClosedTaskPRs(monitoredPRs []github.PullRequest, closedMatchers []github.TaskMatcher) {
+	closedPRs := github.DetectClosedTaskPRs(monitoredPRs, closedMatchers, github.FetchPRState)
+	for _, c := range closedPRs {
+		if r.agents.HasRunningAgentForTask(c.TaskID) {
+			r.logger.Info("pr-monitor.closed-skip-running-agent", "task_id", c.TaskID, "pr", c.PRNumber)
+			continue
+		}
+		outcome := classifyLandingOutcome(c.State)
+		if _, err := r.tasks.Update(c.TaskID, task.Update{
+			Status:  task.Ptr(task.StatusDone),
+			Outcome: task.Ptr(outcome),
+		}); err != nil {
+			r.logger.Error("pr-monitor.closed-update", "task_id", c.TaskID, "err", err)
+			continue
+		}
+		eventType := audit.EventPRMerged
+		if c.State == "CLOSED" {
+			eventType = audit.EventPRClosed
+		}
+		r.logAudit(eventType, c.TaskID, "", map[string]any{"pr": c.PRNumber, "state": c.State})
+		r.recordLanding(c.TaskID, c.PRNumber, c.State)
+		r.logger.Info("pr-monitor.auto-done", "task_id", c.TaskID, "pr", c.PRNumber, "state", c.State, "outcome", outcome)
+	}
+}
+
+// classifyLandingOutcome maps a terminal PR state to a task outcome label.
+// Explicit "CLOSED" (closed unmerged) → "closed"; everything else
+// ("MERGED" and the eligible default) → "merged".
+func classifyLandingOutcome(state string) string {
+	if state == "CLOSED" {
+		return "closed"
+	}
+	return "merged"
+}
+
+// recordLanding emits a task.landed audit event capturing the terminal outcome,
+// PR size, and lead time — the ground-truth signal the evaluation scorecard
+// reads. Best-effort: a missing task or a stats-fetch failure still records the
+// outcome and PR number.
+func (r *ReviewHandler) recordLanding(taskID string, prNumber int, state string) {
+	data := map[string]any{
+		"pr":      prNumber,
+		"state":   state,
+		"outcome": classifyLandingOutcome(state),
+	}
+	if t, err := r.tasks.Get(taskID); err == nil {
+		if !t.CreatedAt.IsZero() {
+			data["lead_time_h"] = time.Since(t.CreatedAt).Hours()
+		}
+		if t.ProjectID != "" && prNumber > 0 {
+			if s, err := github.FetchPRStats(t.ProjectID, prNumber); err == nil {
+				data["additions"] = s.Additions
+				data["deletions"] = s.Deletions
+				data["changed_files"] = s.ChangedFiles
+			}
+		}
+	}
+	r.logAudit(audit.EventTaskLanded, taskID, "", data)
 }
 
 // cancelResolvedPRFixWorkflows terminates any in-flight pr-fix workflow

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -219,10 +219,11 @@ func classifyLandingOutcome(state string) string {
 	return "merged"
 }
 
-// recordLanding emits a task.landed audit event capturing the terminal outcome,
-// PR size, and lead time — the ground-truth signal the evaluation scorecard
-// reads. Best-effort: a missing task or a stats-fetch failure still records the
-// outcome and PR number.
+// recordLanding emits a task.landed audit event capturing the terminal outcome
+// and timing — the ground-truth signal the evaluation scorecard reads. Kept
+// fully local (no network) so it never stalls the PR poll loop. Two timings are
+// recorded distinctly: created_to_land_h is queue-inclusive (task filed → land),
+// work_to_land_h starts from the first agent run (closer to DORA cycle time).
 func (r *ReviewHandler) recordLanding(taskID string, prNumber int, state string) {
 	data := map[string]any{
 		"pr":      prNumber,
@@ -231,17 +232,29 @@ func (r *ReviewHandler) recordLanding(taskID string, prNumber int, state string)
 	}
 	if t, err := r.tasks.Get(taskID); err == nil {
 		if !t.CreatedAt.IsZero() {
-			data["lead_time_h"] = time.Since(t.CreatedAt).Hours()
+			data["created_to_land_h"] = time.Since(t.CreatedAt).Hours()
 		}
-		if t.ProjectID != "" && prNumber > 0 {
-			if s, err := github.FetchPRStats(t.ProjectID, prNumber); err == nil {
-				data["additions"] = s.Additions
-				data["deletions"] = s.Deletions
-				data["changed_files"] = s.ChangedFiles
-			}
+		if started := earliestRunStart(t.AgentRuns); !started.IsZero() {
+			data["work_to_land_h"] = time.Since(started).Hours()
 		}
 	}
 	r.logAudit(audit.EventTaskLanded, taskID, "", data)
+}
+
+// earliestRunStart returns the start time of the first agent run, or the zero
+// time when there are no runs with a start timestamp.
+func earliestRunStart(runs []task.AgentRun) time.Time {
+	var earliest time.Time
+	for i := range runs {
+		s := runs[i].StartedAt
+		if s.IsZero() {
+			continue
+		}
+		if earliest.IsZero() || s.Before(earliest) {
+			earliest = s
+		}
+	}
+	return earliest
 }
 
 // cancelResolvedPRFixWorkflows terminates any in-flight pr-fix workflow

--- a/internal/sybra/app_reviews_landing_test.go
+++ b/internal/sybra/app_reviews_landing_test.go
@@ -1,0 +1,90 @@
+package sybra
+
+import (
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func TestClassifyLandingOutcome(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		state string
+		want  string
+	}{
+		{"merged", "MERGED", "merged"},
+		{"closed unmerged", "CLOSED", "closed"},
+		{"empty defaults to merged", "", "merged"},
+		{"unknown defaults to merged", "OPEN", "merged"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := classifyLandingOutcome(tt.state); got != tt.want {
+				t.Errorf("classifyLandingOutcome(%q) = %q, want %q", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRecordLanding_EmitsTaskLanded verifies the landing helper records a
+// structured task.landed event with the outcome, PR number, and lead time the
+// evaluation scorecard reads. A task without a ProjectID skips the network PR
+// stats fetch, keeping the test hermetic.
+func TestRecordLanding_EmitsTaskLanded(t *testing.T) {
+	auditDir := t.TempDir()
+	al, err := audit.NewLogger(auditDir)
+	if err != nil {
+		t.Fatalf("audit.NewLogger: %v", err)
+	}
+
+	taskStore, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatalf("task NewStore: %v", err)
+	}
+	tasks := task.NewManager(taskStore, nil)
+	created, err := tasks.Create("ship it", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	r := &ReviewHandler{
+		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler), audit: al},
+		tasks:         tasks,
+	}
+	r.recordLanding(created.ID, 42, "MERGED")
+
+	events, err := audit.Read(auditDir, audit.Query{
+		Since: time.Now().Add(-time.Hour),
+		Until: time.Now().Add(time.Hour),
+		Type:  audit.EventTaskLanded,
+	})
+	if err != nil {
+		t.Fatalf("audit.Read: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d task.landed events, want 1", len(events))
+	}
+	e := events[0]
+	if e.TaskID != created.ID {
+		t.Errorf("TaskID = %q, want %q", e.TaskID, created.ID)
+	}
+	if got := e.Data["outcome"]; got != "merged" {
+		t.Errorf("outcome = %v, want merged", got)
+	}
+	// JSON round-trip decodes numbers as float64.
+	if got, _ := e.Data["pr"].(float64); got != 42 {
+		t.Errorf("pr = %v, want 42", e.Data["pr"])
+	}
+	if _, ok := e.Data["lead_time_h"]; !ok {
+		t.Errorf("missing lead_time_h in %v", e.Data)
+	}
+	if _, ok := e.Data["additions"]; ok {
+		t.Errorf("unexpected PR stats for project-less task: %v", e.Data)
+	}
+}

--- a/internal/sybra/app_reviews_landing_test.go
+++ b/internal/sybra/app_reviews_landing_test.go
@@ -33,9 +33,9 @@ func TestClassifyLandingOutcome(t *testing.T) {
 }
 
 // TestRecordLanding_EmitsTaskLanded verifies the landing helper records a
-// structured task.landed event with the outcome, PR number, and lead time the
-// evaluation scorecard reads. A task without a ProjectID skips the network PR
-// stats fetch, keeping the test hermetic.
+// structured task.landed event with the outcome, PR number, and queue-inclusive
+// timing the evaluation scorecard reads. A freshly-created task has no agent
+// runs, so work_to_land_h is absent; the helper makes no network calls.
 func TestRecordLanding_EmitsTaskLanded(t *testing.T) {
 	auditDir := t.TempDir()
 	al, err := audit.NewLogger(auditDir)
@@ -81,10 +81,10 @@ func TestRecordLanding_EmitsTaskLanded(t *testing.T) {
 	if got, _ := e.Data["pr"].(float64); got != 42 {
 		t.Errorf("pr = %v, want 42", e.Data["pr"])
 	}
-	if _, ok := e.Data["lead_time_h"]; !ok {
-		t.Errorf("missing lead_time_h in %v", e.Data)
+	if _, ok := e.Data["created_to_land_h"]; !ok {
+		t.Errorf("missing created_to_land_h in %v", e.Data)
 	}
-	if _, ok := e.Data["additions"]; ok {
-		t.Errorf("unexpected PR stats for project-less task: %v", e.Data)
+	if _, ok := e.Data["work_to_land_h"]; ok {
+		t.Errorf("unexpected work_to_land_h for task with no agent runs: %v", e.Data)
 	}
 }

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -193,6 +193,10 @@ type Task struct {
 	Priority  Priority   `yaml:"priority,omitempty" json:"priority,omitempty"`
 	DueDate   *time.Time `yaml:"due_date,omitempty" json:"dueDate,omitempty"`
 	ClosedAt  *time.Time `yaml:"closed_at,omitempty" json:"closedAt,omitempty"`
+	// Outcome records how a task's own PR concluded: "merged" or "closed".
+	// Stamped by the PR monitor when the task auto-advances to done. Empty for
+	// tasks that never produced a PR. Feeds the evaluation scorecard.
+	Outcome string `yaml:"outcome,omitempty" json:"outcome,omitempty"`
 	// MaxTurns overrides the global agent turn limit for this task.
 	// Zero means "use global default".
 	MaxTurns int `yaml:"max_turns,omitempty" json:"maxTurns,omitempty"`

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -386,6 +386,9 @@ func applyReviewFields(t *Task, u Update) {
 	if u.RunRole != nil {
 		t.RunRole = *u.RunRole
 	}
+	if u.Outcome != nil {
+		t.Outcome = *u.Outcome
+	}
 	if u.ReviewPhase != nil {
 		t.ReviewPhase = *u.ReviewPhase
 	}

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -39,6 +39,7 @@ type Update struct {
 	CodeReview     *string
 	MaxTurns       *int
 	ForkSubagent   *bool
+	Outcome        *string
 }
 
 // Ptr returns a pointer to v. Convenience for building Update literals.
@@ -65,7 +66,7 @@ func applyMapField(u *Update, k string, v any) error {
 	switch k {
 	case "title", "slug", "status_reason", "blocked_by_issue", "body",
 		"project_id", "branch", "worktree_dir", "issue", "run_role", "todoist_id", "plan", "plan_critique", "code_review",
-		"review_phase", "pr_phase":
+		"review_phase", "pr_phase", "outcome":
 		return applyPlainStringField(u, k, v)
 	case "priority":
 		return applyPriorityField(u, v)
@@ -145,6 +146,8 @@ func applyPlainStringField(u *Update, k string, v any) error {
 		u.ReviewPhase = &s
 	case "pr_phase":
 		u.PRPhase = &s
+	case "outcome":
+		u.Outcome = &s
 	}
 	return nil
 }


### PR DESCRIPTION
## Motivation

Closes #1066. First step toward the evaluation system (umbrella #1065): Sybra records cost, duration, and tokens per run, but never records what happened to a task's work or how hard the agent worked to get there. Without that ground truth there is no way to score whether the fleet ships mid-level code autonomously. This change captures the outcome and per-run effort the scorecard will read.

> Changelog: feat(eval): capture PR outcomes + per-run effort

## Implementation information

- **Per-run effort** — `stats.RunRecord` gains `TurnCount` and `ToolCalls`. The headless runner counts tool_use blocks per assistant turn (Claude) or per tool_use event (Codex); the completion handler persists both to `stats.json`. The reattach/recovery replay (`rehydrateFromLog`) re-accumulates both from the log, so a run that crosses an app restart — or finishes while the app is down and is finalized on reattach — records real counts, not zero.
- **Terminal outcome** — new audit event `task.landed`, emitted once when a task auto-advances to done on its PR closing, with `outcome` (merged/closed) and two distinct timings: `created_to_land_h` (queue-inclusive) and `work_to_land_h` (from first agent run). The `Task` model gains an `Outcome` field stamped at landing. `recordLanding` is fully local — no `gh` call on the poll path.
- **Reserved** — `pr.reverted` audit constant added for revert detection (implemented in the follow-up).

The closed-PR handling was extracted from `pollAndMonitorPRs` into `advanceClosedTaskPRs` (behavior-preserving). New tests cover outcome classification, the landing event, tool-call counting + converters, and the reattach-effort restore.

Deferred to #1082 (with reasons): `merged_with_edits` + human-edit distance, revert detection, PR-size enrichment off the poll path, and full Codex tool taxonomy.

## Supporting documentation

- Umbrella: #1065
- Follow-up for richer landing signals: #1082

Gates: `golangci-lint run ./...`, `go test ./...` (incl. `-race` on internal/agent), `oxlint`, `svelte-check`, `hadolint`, and `go build ./cmd/sybra-server` all pass.
