### PR TITLE
fix(agent): retry rate-limited runs, don't strand

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -259,6 +259,24 @@ func (m *Manager) SetHealthGate(g provider.HealthGate) {
 	m.mu.Unlock()
 }
 
+// ProviderHealthy reports whether the named provider can currently be used
+// (not rate-limited / logged out). A nil health gate (checks disabled, tests)
+// always reports healthy. An empty name resolves to the default provider.
+// Recovery loops consult this to avoid re-dispatching a run that would just
+// hit the same provider limit again.
+func (m *Manager) ProviderHealthy(name string) bool {
+	m.mu.RLock()
+	g := m.gate
+	if name == "" {
+		name = m.defaultProv
+	}
+	m.mu.RUnlock()
+	if g == nil {
+		return true
+	}
+	return g.IsHealthy(name)
+}
+
 // ReportProviderSignal forwards a runner-side passive signal (rate-limit or
 // auth failure) to the health gate. Safe to call with a nil gate.
 func (m *Manager) ReportProviderSignal(name string, sig provider.Signal, reason string, retryAfter time.Duration) {

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -259,12 +259,13 @@ func (m *Manager) SetHealthGate(g provider.HealthGate) {
 	m.mu.Unlock()
 }
 
-// ProviderHealthy reports whether the named provider can currently be used
-// (not rate-limited / logged out). A nil health gate (checks disabled, tests)
-// always reports healthy. An empty name resolves to the default provider.
-// Recovery loops consult this to avoid re-dispatching a run that would just
-// hit the same provider limit again.
-func (m *Manager) ProviderHealthy(name string) bool {
+// ProviderRateLimited reports whether the named provider is currently in a
+// rate-limit cooldown — distinct from logged-out / auth failure. A nil health
+// gate (checks disabled, tests) reports false. An empty name resolves to the
+// default provider. Recovery loops consult this to wait out a transient rate
+// limit; auth failures deliberately do NOT count here so they keep taking the
+// human-required path (a human must log in) instead of waiting indefinitely.
+func (m *Manager) ProviderRateLimited(name string) bool {
 	m.mu.RLock()
 	g := m.gate
 	if name == "" {
@@ -272,9 +273,9 @@ func (m *Manager) ProviderHealthy(name string) bool {
 	}
 	m.mu.RUnlock()
 	if g == nil {
-		return true
+		return false
 	}
-	return g.IsHealthy(name)
+	return g.RateLimited(name)
 }
 
 // ReportProviderSignal forwards a runner-side passive signal (rate-limit or

--- a/internal/agent/manager_gate_test.go
+++ b/internal/agent/manager_gate_test.go
@@ -21,6 +21,7 @@ type fakeGate struct {
 }
 
 func (f *fakeGate) IsHealthy(p string) bool       { return f.healthy[p] }
+func (f *fakeGate) RateLimited(p string) bool     { return !f.healthy[p] }
 func (f *fakeGate) Failover(p string) string      { return f.failover[p] }
 func (f *fakeGate) Reason(p string) string        { return f.reasons[p] }
 func (f *fakeGate) ReportAuthFailure(p, _ string) { f.reportedAuth = append(f.reportedAuth, p) }

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -442,6 +442,33 @@ func TestHasRunningAgentForTask(t *testing.T) {
 	}
 }
 
+type stubGate struct{ healthy bool }
+
+func (s stubGate) IsHealthy(string) bool                         { return s.healthy }
+func (s stubGate) Failover(string) string                        { return "" }
+func (s stubGate) Reason(string) string                          { return "" }
+func (s stubGate) ReportAuthFailure(string, string)              {}
+func (s stubGate) ReportRateLimit(string, time.Duration, string) {}
+
+func TestProviderHealthy(t *testing.T) {
+	m, _ := newTestManager(t)
+
+	// No gate configured → always healthy.
+	if !m.ProviderHealthy("claude") {
+		t.Error("nil gate should report healthy")
+	}
+
+	m.SetHealthGate(stubGate{healthy: false})
+	if m.ProviderHealthy("claude") {
+		t.Error("unhealthy gate should report false")
+	}
+
+	m.SetHealthGate(stubGate{healthy: true})
+	if !m.ProviderHealthy("claude") {
+		t.Error("healthy gate should report true")
+	}
+}
+
 func TestClaimTaskDispatch(t *testing.T) {
 	m, _ := newTestManager(t)
 

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -442,30 +442,31 @@ func TestHasRunningAgentForTask(t *testing.T) {
 	}
 }
 
-type stubGate struct{ healthy bool }
+type stubGate struct{ rateLimited bool }
 
-func (s stubGate) IsHealthy(string) bool                         { return s.healthy }
+func (s stubGate) IsHealthy(string) bool                         { return !s.rateLimited }
+func (s stubGate) RateLimited(string) bool                       { return s.rateLimited }
 func (s stubGate) Failover(string) string                        { return "" }
 func (s stubGate) Reason(string) string                          { return "" }
 func (s stubGate) ReportAuthFailure(string, string)              {}
 func (s stubGate) ReportRateLimit(string, time.Duration, string) {}
 
-func TestProviderHealthy(t *testing.T) {
+func TestProviderRateLimited(t *testing.T) {
 	m, _ := newTestManager(t)
 
-	// No gate configured → always healthy.
-	if !m.ProviderHealthy("claude") {
-		t.Error("nil gate should report healthy")
+	// No gate configured → never rate-limited.
+	if m.ProviderRateLimited("claude") {
+		t.Error("nil gate should report not rate-limited")
 	}
 
-	m.SetHealthGate(stubGate{healthy: false})
-	if m.ProviderHealthy("claude") {
-		t.Error("unhealthy gate should report false")
+	m.SetHealthGate(stubGate{rateLimited: true})
+	if !m.ProviderRateLimited("claude") {
+		t.Error("rate-limited gate should report true")
 	}
 
-	m.SetHealthGate(stubGate{healthy: true})
-	if !m.ProviderHealthy("claude") {
-		t.Error("healthy gate should report true")
+	m.SetHealthGate(stubGate{rateLimited: false})
+	if m.ProviderRateLimited("claude") {
+		t.Error("healthy gate should report false")
 	}
 }
 

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -663,6 +663,16 @@ func (a *Agent) SetError(kind, msg string) {
 	a.mu.Unlock()
 }
 
+// GetErrorKind returns the classified error kind recorded on the agent
+// ("rate_limit", "auth", or ""). The runner sets it when a failed run is
+// classified against the provider health gate, letting the completion handler
+// tell a transient provider limit apart from a real crash.
+func (a *Agent) GetErrorKind() string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.ErrorKind
+}
+
 // ErrorEvent is the payload emitted on agent:error:{id}.
 type ErrorEvent struct {
 	Kind string `json:"kind"`

--- a/internal/agent/runner_headless_retry.go
+++ b/internal/agent/runner_headless_retry.go
@@ -31,16 +31,37 @@ func (m *Manager) reportProviderHealthSignal(a *Agent, stderrOut string, attempt
 		}
 		return
 	}
+	// Record the classification on the agent so the completion handler can tell
+	// a transient provider limit apart from a real crash and retry instead of
+	// stranding the task in human-required.
+	a.SetError(signalErrorKind(sig), reason)
 	m.ReportProviderSignal(a.Provider, sig, reason, retryAfter)
+}
+
+// signalErrorKind maps a provider health signal to the short error-kind tag
+// recorded on the agent (consumed by the completion handler).
+func signalErrorKind(sig provider.Signal) string {
+	switch sig {
+	case provider.SignalRateLimit:
+		return "rate_limit"
+	case provider.SignalAuthFailure:
+		return "auth"
+	default:
+		return ""
+	}
 }
 
 func buildErrorSample(stderrOut string, attemptEvents []StreamEvent) provider.ErrorSample {
 	sample := provider.ErrorSample{Stderr: stderrOut}
 	for i := range slices.Backward(attemptEvents) {
 		e := &attemptEvents[i]
-		if e.Type != "result" || e.Subtype != "error" {
+		if e.Type != "result" {
 			continue
 		}
+		// Capture the terminal result regardless of subtype. A provider usage
+		// cap (e.g. a five-hour session limit) is reported on a subtype:"success"
+		// result with the limit text in Content — not a structured error
+		// envelope — so a subtype=="error" filter would miss it.
 		sample.ErrorType = e.ErrorType
 		sample.ErrorStatus = e.ErrorStatus
 		sample.Content = e.Content
@@ -70,6 +91,7 @@ func (m *Manager) reportProviderHealthSignalConvo(a *Agent, stderrOut string, at
 		}
 		return
 	}
+	a.SetError(signalErrorKind(sig), reason)
 	m.ReportProviderSignal(a.Provider, sig, reason, retryAfter)
 }
 
@@ -77,9 +99,10 @@ func buildErrorSampleConvo(stderrOut string, attemptEvents []ConvoEvent) provide
 	sample := provider.ErrorSample{Stderr: stderrOut}
 	for i := range slices.Backward(attemptEvents) {
 		e := &attemptEvents[i]
-		if e.Type != "result" || e.Subtype != "error" {
+		if e.Type != "result" {
 			continue
 		}
+		// Capture the terminal result regardless of subtype (see buildErrorSample).
 		sample.ErrorType = e.ErrorType
 		sample.ErrorStatus = e.ErrorStatus
 		sample.Content = e.Text

--- a/internal/provider/health.go
+++ b/internal/provider/health.go
@@ -33,6 +33,11 @@ type Config struct {
 // so tests can supply a fake without spinning up a Checker.
 type HealthGate interface {
 	IsHealthy(provider string) bool
+	// RateLimited reports whether the provider is specifically in a rate-limit
+	// cooldown window (as opposed to logged out / auth-failed). Lets callers
+	// wait-and-retry a transient throttle without also waiting on auth failures
+	// that need human login.
+	RateLimited(provider string) bool
 	Failover(unhealthy string) string
 	Reason(provider string) string
 	ReportAuthFailure(provider, reason string)
@@ -290,6 +295,21 @@ func (c *Checker) IsHealthy(provider string) bool {
 		return true
 	}
 	return s.Healthy
+}
+
+// RateLimited reports whether the provider is currently inside a rate-limit
+// cooldown window. Only ReportRateLimit sets RateLimitedUntil, so an auth
+// failure (logged out) returns false here even though IsHealthy is false —
+// that's the distinction recovery uses to wait-and-retry rate limits while
+// letting auth failures take the human-required path.
+func (c *Checker) RateLimited(provider string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	s, ok := c.statuses[provider]
+	if !ok {
+		return false
+	}
+	return !s.RateLimitedUntil.IsZero() && c.now().Before(s.RateLimitedUntil)
 }
 
 // Reason returns the current reason string for a provider, or empty if unknown.

--- a/internal/provider/health_test.go
+++ b/internal/provider/health_test.go
@@ -126,6 +126,8 @@ func TestClassifyClaudeError(t *testing.T) {
 		{"credit", ErrorSample{ErrorType: "credit_balance_too_low"}, SignalRateLimit},
 		{"stderr_not_logged", ErrorSample{Stderr: "Error: Not logged in"}, SignalAuthFailure},
 		{"stderr_rate_limit", ErrorSample{Stderr: "rate limit exceeded"}, SignalRateLimit},
+		{"content_session_limit", ErrorSample{Content: "You've hit your session limit · resets 4:30pm"}, SignalRateLimit},
+		{"content_usage_limit", ErrorSample{Content: "usage limit reached for this period"}, SignalRateLimit},
 		{"overloaded_ignored", ErrorSample{ErrorStatus: 529, ErrorType: "overloaded_error"}, SignalNone},
 		{"unrelated", ErrorSample{Stderr: "random crash"}, SignalNone},
 	}

--- a/internal/provider/signals.go
+++ b/internal/provider/signals.go
@@ -47,8 +47,8 @@ func ClassifyClaudeError(s ErrorSample) (Signal, string, time.Duration) {
 		containsAny(content, "not logged in", "please run claude auth login") {
 		return SignalAuthFailure, "logged_out", 0
 	}
-	if containsAny(stderr, "rate_limit", "rate limit", "credit_balance_too_low", "quota") ||
-		containsAny(content, "rate_limit", "rate limit", "credit_balance_too_low", "quota") {
+	if containsAny(stderr, "rate_limit", "rate limit", "credit_balance_too_low", "quota", "session limit", "usage limit") ||
+		containsAny(content, "rate_limit", "rate limit", "credit_balance_too_low", "quota", "session limit", "usage limit") {
 		return SignalRateLimit, "rate_limited", 0
 	}
 	return SignalNone, "", 0

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -18,18 +18,22 @@ func discardLogger() *slog.Logger {
 	return slog.New(slog.DiscardHandler)
 }
 
-// fakeGate is a provider.HealthGate stub: every provider reports `healthy`.
-type fakeGate struct{ healthy bool }
-
-func (f fakeGate) IsHealthy(string) bool { return f.healthy }
-func (f fakeGate) Failover(string) string {
-	return ""
+// fakeGate is a provider.HealthGate stub. IsHealthy/RateLimited return the
+// configured flags so tests can simulate a rate-limited (or auth-failed)
+// provider.
+type fakeGate struct {
+	healthy     bool
+	rateLimited bool
 }
+
+func (f fakeGate) IsHealthy(string) bool   { return f.healthy }
+func (f fakeGate) RateLimited(string) bool { return f.rateLimited }
+func (f fakeGate) Failover(string) string  { return "" }
 func (f fakeGate) Reason(string) string {
-	if f.healthy {
-		return ""
+	if f.rateLimited {
+		return "rate_limited"
 	}
-	return "rate_limited"
+	return ""
 }
 func (f fakeGate) ReportAuthFailure(string, string)              {}
 func (f fakeGate) ReportRateLimit(string, time.Duration, string) {}
@@ -148,7 +152,7 @@ func TestRestartStaleSkipsRateLimitedProvider(t *testing.T) {
 	tasks := task.NewManager(store, nil)
 	logger := discardLogger()
 	agents := agent.NewManager(ctx, func(string, any) {}, logger, t.TempDir())
-	agents.SetHealthGate(fakeGate{healthy: false}) // provider rate-limited
+	agents.SetHealthGate(fakeGate{rateLimited: true}) // provider rate-limited
 	wm := worktree.New(worktree.Config{
 		WorktreesDir: t.TempDir(),
 		Tasks:        tasks,

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -18,6 +18,22 @@ func discardLogger() *slog.Logger {
 	return slog.New(slog.DiscardHandler)
 }
 
+// fakeGate is a provider.HealthGate stub: every provider reports `healthy`.
+type fakeGate struct{ healthy bool }
+
+func (f fakeGate) IsHealthy(string) bool { return f.healthy }
+func (f fakeGate) Failover(string) string {
+	return ""
+}
+func (f fakeGate) Reason(string) string {
+	if f.healthy {
+		return ""
+	}
+	return "rate_limited"
+}
+func (f fakeGate) ReportAuthFailure(string, string)              {}
+func (f fakeGate) ReportRateLimit(string, time.Duration, string) {}
+
 // TestRunStartupCleanupEmpty verifies the boot pass is idempotent on a
 // fresh, empty store — no panics, no error returns, no spurious task
 // mutations.
@@ -113,6 +129,70 @@ func TestRestartStaleSkipsRecentRun(t *testing.T) {
 
 	if stub.startCalls != 0 {
 		t.Errorf("orchestrator was called %d times; want 0 (recent run debounce)", stub.startCalls)
+	}
+}
+
+// TestRestartStaleSkipsRateLimitedProvider verifies a stalled task whose last
+// run's provider is rate-limited is left in-progress (not re-dispatched, which
+// would just hit the limit again). The debounce is satisfied (old run) so the
+// provider gate is the only thing that can hold it back.
+func TestRestartStaleSkipsRateLimitedProvider(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := discardLogger()
+	agents := agent.NewManager(ctx, func(string, any) {}, logger, t.TempDir())
+	agents.SetHealthGate(fakeGate{healthy: false}) // provider rate-limited
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Tasks:        tasks,
+		Logger:       logger,
+		AgentChecker: agents.HasRunningAgentForTask,
+	})
+
+	created, err := tasks.Create("rate-limited", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inProg := task.StatusInProgress
+	projID := "owner/repo"
+	if _, err := tasks.Update(created.ID, task.Update{Status: &inProg, ProjectID: &projID}); err != nil {
+		t.Fatal(err)
+	}
+	// Old run → debounce passes, so only the provider gate can stop re-dispatch.
+	if err := tasks.AddRun(created.ID, task.AgentRun{
+		AgentID:   "ag-1",
+		Mode:      "headless",
+		Provider:  "claude",
+		State:     string(agent.StateStopped),
+		StartedAt: time.Now().Add(-30 * time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	stub := stubOrchestrator{}
+	r := &recovery.Recovery{
+		Tasks:        tasks,
+		Agents:       agents,
+		Worktrees:    wm,
+		Orchestrator: &stub,
+		Logger:       logger,
+		Throttle:     logging.NewErrorThrottle(),
+		WG:           &wg,
+		LogDir:       t.TempDir(),
+	}
+	r.RestartStaleInProgress()
+	wg.Wait()
+
+	if stub.startCalls != 0 {
+		t.Errorf("orchestrator was called %d times; want 0 (provider rate-limited)", stub.startCalls)
 	}
 }
 

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -37,6 +37,16 @@ func (r *Recovery) RestartStaleInProgress() {
 		if r.Agents.HasRunningAgentForTask(t.ID) {
 			continue
 		}
+		// Don't re-dispatch while the last run's provider is rate-limited /
+		// logged out — it would just hit the same limit again and churn the
+		// worktree. The gate clears once the limit window elapses; the next
+		// sweep then re-dispatches. (A rate-limited run is stalled in-progress
+		// by the completion handler, not flipped to human-required.)
+		if lr := lastAgentRun(&t); lr != nil && !r.Agents.ProviderHealthy(lr.Provider) {
+			r.Logger.Info("restart-stale.skip",
+				"task_id", t.ID, "reason", "provider_unhealthy", "provider", lr.Provider)
+			continue
+		}
 		if slices.Contains(t.Tags, "review") && r.recoverCompletedHeadlessRun(&t) {
 			// recoverCompletedHeadlessRun handled this task (last headless run
 			// completed but workflow step was never recorded). Skip the generic

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -37,14 +37,15 @@ func (r *Recovery) RestartStaleInProgress() {
 		if r.Agents.HasRunningAgentForTask(t.ID) {
 			continue
 		}
-		// Don't re-dispatch while the last run's provider is rate-limited /
-		// logged out — it would just hit the same limit again and churn the
-		// worktree. The gate clears once the limit window elapses; the next
-		// sweep then re-dispatches. (A rate-limited run is stalled in-progress
-		// by the completion handler, not flipped to human-required.)
-		if lr := lastAgentRun(&t); lr != nil && !r.Agents.ProviderHealthy(lr.Provider) {
+		// Don't re-dispatch while the last run's provider is rate-limited — it
+		// would just hit the same limit again and churn the worktree. The
+		// cooldown clears on its own and the next sweep re-dispatches. (A
+		// rate-limited run is stalled in-progress by the completion handler, not
+		// flipped to human-required.) Auth failures are NOT skipped here: they
+		// take the human-required path so the operator knows to log in.
+		if lr := lastAgentRun(&t); lr != nil && r.Agents.ProviderRateLimited(lr.Provider) {
 			r.Logger.Info("restart-stale.skip",
-				"task_id", t.ID, "reason", "provider_unhealthy", "provider", lr.Provider)
+				"task_id", t.ID, "reason", "provider_rate_limited", "provider", lr.Provider)
 			continue
 		}
 		if slices.Contains(t.Tags, "review") && r.recoverCompletedHeadlessRun(&t) {

--- a/internal/selfmonitor/provider_feedback_test.go
+++ b/internal/selfmonitor/provider_feedback_test.go
@@ -24,6 +24,7 @@ type providerRateLimitCall struct {
 }
 
 func (s *stubProviderGate) IsHealthy(_ string) bool       { return true }
+func (s *stubProviderGate) RateLimited(_ string) bool     { return false }
 func (s *stubProviderGate) Failover(_ string) string      { return "" }
 func (s *stubProviderGate) Reason(_ string) string        { return "" }
 func (s *stubProviderGate) ReportAuthFailure(_, _ string) {}

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -170,10 +170,19 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 		// (NOT WaitStatus.Signaled), so isSignalKill alone misses
 		// Sybra-initiated stops — the failure mode reported in #641 plus the
 		// flake in TestE2E_HeadlessAgent_StopAgent_DoesNotAdvanceWorkflow.
-		if isSignalKill(exitErr) || ag.WasStopped() {
+		// A transient provider limit (rate/session/usage limit) is not a real
+		// failure: marking the step failed would route verify_commits to
+		// human-required and strand the task. Stall instead, like a signal
+		// kill — the task stays in-progress and the gate-aware recovery loops
+		// re-dispatch once the provider's limit window clears. Auth failures are
+		// deliberately excluded: they need a human to log in, so they fall
+		// through to the normal failed→human-required path.
+		rateLimited := isRateLimitedRun(ag, exitErr)
+		if isSignalKill(exitErr) || ag.WasStopped() || rateLimited {
 			h.logger.Warn("agent.completion.stall",
 				"task_id", ag.TaskID, "agent_id", ag.ID,
-				"signaled", isSignalKill(exitErr), "stopped", ag.WasStopped())
+				"signaled", isSignalKill(exitErr), "stopped", ag.WasStopped(),
+				"rate_limited", rateLimited)
 			h.workflowEngine.ClearAgentStep(ag.ID)
 			return
 		}
@@ -281,6 +290,15 @@ func (h *AgentCompletionHandler) recordRunStats(ag *agent.Agent, cost, duration 
 		Outcome:                  outcome,
 		Timestamp:                time.Now(),
 	})
+}
+
+// isRateLimitedRun reports whether a failed run was rejected by a transient
+// provider limit (rate/session/usage limit) rather than crashing. Such runs are
+// stalled for retry instead of being marked failed (which would strand the task
+// in human-required). Auth failures are intentionally NOT included — they need
+// a human to log in, so they take the normal failed path.
+func isRateLimitedRun(ag *agent.Agent, exitErr error) bool {
+	return exitErr != nil && ag.GetErrorKind() == "rate_limit"
 }
 
 // isSignalKill reports whether err represents a process killed by an OS signal.

--- a/internal/sybra/agent_completion_test.go
+++ b/internal/sybra/agent_completion_test.go
@@ -6,7 +6,36 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/Automaat/sybra/internal/agent"
 )
+
+func TestIsRateLimitedRun(t *testing.T) {
+	t.Parallel()
+	rateLimited := &agent.Agent{}
+	rateLimited.SetError("rate_limit", "rate_limited")
+	authFailed := &agent.Agent{}
+	authFailed.SetError("auth", "logged_out")
+
+	cases := []struct {
+		name    string
+		ag      *agent.Agent
+		exitErr error
+		want    bool
+	}{
+		{"rate limit with exit error", rateLimited, errors.New("exit status 1"), true},
+		{"rate limit but clean exit", rateLimited, nil, false},
+		{"auth failure is not retried", authFailed, errors.New("exit status 1"), false},
+		{"plain crash", &agent.Agent{}, errors.New("exit status 1"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRateLimitedRun(tc.ag, tc.exitErr); got != tc.want {
+				t.Errorf("isRateLimitedRun = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
 
 func TestIsSignalKill(t *testing.T) {
 	t.Parallel()

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -330,3 +330,7 @@ func (a *agentAdapter) SendPrompt(agentID, message string) error {
 func (a *agentAdapter) DefaultProvider() string {
 	return a.agents.DefaultProvider()
 }
+
+func (a *agentAdapter) ProviderHealthy(provider string) bool {
+	return a.agents.ProviderHealthy(provider)
+}

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -331,6 +331,6 @@ func (a *agentAdapter) DefaultProvider() string {
 	return a.agents.DefaultProvider()
 }
 
-func (a *agentAdapter) ProviderHealthy(provider string) bool {
-	return a.agents.ProviderHealthy(provider)
+func (a *agentAdapter) ProviderRateLimited(provider string) bool {
+	return a.agents.ProviderRateLimited(provider)
 }

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -2869,6 +2869,12 @@ func (g *scriptedGate) IsHealthy(p string) bool {
 	return g.healthy[p]
 }
 
+func (g *scriptedGate) RateLimited(p string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return !g.healthy[p] && g.reason[p] == "rate_limited"
+}
+
 func (g *scriptedGate) Failover(unhealthy string) string {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -2919,6 +2925,13 @@ func (g *cooldownGate) IsHealthy(p string) bool {
 	defer g.mu.Unlock()
 	until, ok := g.limitedTo[p]
 	return !ok || time.Now().After(until)
+}
+
+func (g *cooldownGate) RateLimited(p string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	until, ok := g.limitedTo[p]
+	return ok && time.Now().Before(until)
 }
 
 func (g *cooldownGate) Failover(unhealthy string) string {

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -32,11 +32,11 @@ type AgentLauncher interface {
 	StopAgentsForTask(taskID string, role string)
 	SendPrompt(agentID, message string) error
 	DefaultProvider() string
-	// ProviderHealthy reports whether the named provider can currently be used
-	// (not rate-limited / logged out). ResumeStalled consults it so it doesn't
-	// re-dispatch a step whose provider would just reject the run again. Empty
-	// name = default provider.
-	ProviderHealthy(provider string) bool
+	// ProviderRateLimited reports whether the named provider is in a rate-limit
+	// cooldown (distinct from logged out / auth failure). ResumeStalled consults
+	// it to wait out a transient throttle without also stalling auth failures,
+	// which must take the human-required path. Empty name = default provider.
+	ProviderRateLimited(provider string) bool
 }
 
 // WorkflowVarDir is the reserved variable name used to pass a pre-prepared

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -32,6 +32,11 @@ type AgentLauncher interface {
 	StopAgentsForTask(taskID string, role string)
 	SendPrompt(agentID, message string) error
 	DefaultProvider() string
+	// ProviderHealthy reports whether the named provider can currently be used
+	// (not rate-limited / logged out). ResumeStalled consults it so it doesn't
+	// re-dispatch a step whose provider would just reject the run again. Empty
+	// name = default provider.
+	ProviderHealthy(provider string) bool
 }
 
 // WorkflowVarDir is the reserved variable name used to pass a pre-prepared

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -269,12 +269,13 @@ func (e *Engine) ResumeStalled() {
 		if e.agents.HasRunningAgent(t.ID) {
 			continue
 		}
-		// Don't re-dispatch while the step's provider is rate-limited / logged
-		// out — it would just reject the run again. The gate clears once the
-		// limit window elapses; a later sweep then resumes the step.
-		if prov := resolveProvider(step.Config.Provider, t.Workflow, e.agents.DefaultProvider()); !e.agents.ProviderHealthy(prov) {
+		// Don't re-dispatch while the step's provider is rate-limited — it would
+		// just hit the limit again. The cooldown clears on its own and a later
+		// sweep resumes the step. Auth failures are NOT skipped here: those need
+		// a human to log in and take the human-required path instead.
+		if prov := resolveProvider(step.Config.Provider, t.Workflow, e.agents.DefaultProvider()); e.agents.ProviderRateLimited(prov) {
 			e.logger.Debug("workflow.resume-stalled.skip",
-				"task_id", t.ID, "reason", "provider_unhealthy", "provider", prov)
+				"task_id", t.ID, "reason", "provider_rate_limited", "provider", prov)
 			continue
 		}
 		// Skip tasks whose step is currently being dispatched. Interactive

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -269,6 +269,14 @@ func (e *Engine) ResumeStalled() {
 		if e.agents.HasRunningAgent(t.ID) {
 			continue
 		}
+		// Don't re-dispatch while the step's provider is rate-limited / logged
+		// out — it would just reject the run again. The gate clears once the
+		// limit window elapses; a later sweep then resumes the step.
+		if prov := resolveProvider(step.Config.Provider, t.Workflow, e.agents.DefaultProvider()); !e.agents.ProviderHealthy(prov) {
+			e.logger.Debug("workflow.resume-stalled.skip",
+				"task_id", t.ID, "reason", "provider_unhealthy", "provider", prov)
+			continue
+		}
 		// Skip tasks whose step is currently being dispatched. Interactive
 		// spawns (worktree creation, rebase, agent process start) take
 		// several seconds during which no agent is yet registered — without

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -208,13 +208,14 @@ type sentPrompt struct {
 }
 
 type mockAgents struct {
-	mu        sync.Mutex
-	calls     []startCall
-	prompts   []sentPrompt
-	running   map[string]string // taskID -> agentID
-	roles     map[string]string // taskID+"/"+role -> agentID
-	counter   int
-	failSpawn error // when non-nil, StartAgent returns this error and records nothing
+	mu                sync.Mutex
+	calls             []startCall
+	prompts           []sentPrompt
+	running           map[string]string // taskID -> agentID
+	roles             map[string]string // taskID+"/"+role -> agentID
+	counter           int
+	failSpawn         error // when non-nil, StartAgent returns this error and records nothing
+	providerUnhealthy bool  // when true, ProviderHealthy reports false (rate-limited)
 }
 
 func newMockAgents() *mockAgents {
@@ -263,6 +264,18 @@ func (m *mockAgents) HasOtherRunningAgentForTask(taskID, exceptAgentID string) b
 	defer m.mu.Unlock()
 	id, ok := m.running[taskID]
 	return ok && id != exceptAgentID
+}
+
+func (m *mockAgents) ProviderHealthy(string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return !m.providerUnhealthy
+}
+
+func (m *mockAgents) SetProviderUnhealthy(v bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.providerUnhealthy = v
 }
 
 func (m *mockAgents) FindRunningAgentForRole(taskID, role string) (string, bool) {
@@ -1011,6 +1024,39 @@ func TestResumeStalled_RunAgent(t *testing.T) {
 	}
 	if agents.LastCall().Role != "implementation" {
 		t.Fatalf("expected implementation, got %q", agents.LastCall().Role)
+	}
+}
+
+func TestResumeStalled_SkipsProviderUnhealthy(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	agents.SetProviderUnhealthy(true) // provider rate-limited
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{
+		ID:        "t1",
+		Status:    "in-progress",
+		AgentMode: "headless",
+		Workflow: &Execution{
+			WorkflowID:  "test-simple",
+			CurrentStep: "implement",
+			State:       ExecRunning,
+			Variables:   make(map[string]string),
+		},
+	})
+
+	engine.ResumeStalled()
+
+	if agents.CallCount() != 0 {
+		t.Fatalf("expected 0 agent starts while provider rate-limited, got %d", agents.CallCount())
+	}
+
+	// Once the provider recovers, the next sweep resumes the step.
+	agents.SetProviderUnhealthy(false)
+	engine.ResumeStalled()
+	if agents.CallCount() != 1 {
+		t.Fatalf("expected 1 agent start after provider recovered, got %d", agents.CallCount())
 	}
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -215,7 +215,7 @@ type mockAgents struct {
 	roles             map[string]string // taskID+"/"+role -> agentID
 	counter           int
 	failSpawn         error // when non-nil, StartAgent returns this error and records nothing
-	providerUnhealthy bool  // when true, ProviderHealthy reports false (rate-limited)
+	providerRateLimit bool  // when true, ProviderRateLimited reports true
 }
 
 func newMockAgents() *mockAgents {
@@ -266,16 +266,16 @@ func (m *mockAgents) HasOtherRunningAgentForTask(taskID, exceptAgentID string) b
 	return ok && id != exceptAgentID
 }
 
-func (m *mockAgents) ProviderHealthy(string) bool {
+func (m *mockAgents) ProviderRateLimited(string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return !m.providerUnhealthy
+	return m.providerRateLimit
 }
 
-func (m *mockAgents) SetProviderUnhealthy(v bool) {
+func (m *mockAgents) SetProviderRateLimited(v bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.providerUnhealthy = v
+	m.providerRateLimit = v
 }
 
 func (m *mockAgents) FindRunningAgentForRole(taskID, role string) (string, bool) {
@@ -1027,11 +1027,11 @@ func TestResumeStalled_RunAgent(t *testing.T) {
 	}
 }
 
-func TestResumeStalled_SkipsProviderUnhealthy(t *testing.T) {
+func TestResumeStalled_SkipsRateLimitedProvider(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
 	agents := newMockAgents()
-	agents.SetProviderUnhealthy(true) // provider rate-limited
+	agents.SetProviderRateLimited(true)
 	engine := NewEngine(store, tasks, agents, discardLogger())
 
 	tasks.Put(TaskInfo{
@@ -1052,11 +1052,11 @@ func TestResumeStalled_SkipsProviderUnhealthy(t *testing.T) {
 		t.Fatalf("expected 0 agent starts while provider rate-limited, got %d", agents.CallCount())
 	}
 
-	// Once the provider recovers, the next sweep resumes the step.
-	agents.SetProviderUnhealthy(false)
+	// Once the cooldown clears, the next sweep resumes the step.
+	agents.SetProviderRateLimited(false)
 	engine.ResumeStalled()
 	if agents.CallCount() != 1 {
-		t.Fatalf("expected 1 agent start after provider recovered, got %d", agents.CallCount())
+		t.Fatalf("expected 1 agent start after rate limit cleared, got %d", agents.CallCount())
 	}
 }
 


### PR DESCRIPTION
## Motivation

Tasks were stranding in `human-required` after a routine, self-resolving
provider limit. A headless implement agent that hit a rate / session / usage
limit mid-run (e.g. a five-hour Claude session cap) exited non-zero, so
`OnComplete` marked the step `failed`, `verify_commits` saw no commits, and the
task was flipped to `human-required` — even though the limit resets on its own.
Two real tasks were stranded this way.

The system already tracks provider limits in the health gate (with a reset
window); the workflow just never consulted it, and nothing distinguished a
transient limit from a real crash.

> Changelog: fix(agent): retry rate-limited runs instead of stranding them

## Implementation information

- **Detection** (`internal/provider`, `internal/agent`): broaden the Claude
  error classifier to catch usage caps that arrive on a non-error result (the
  five-hour session limit surfaces as a `subtype:"success"` result with the
  limit text in `Content`, not a structured error envelope), and have the
  runner record the classification on the agent (`ErrorKind` = `rate_limit` /
  `auth`).
- **Don't strand** (`internal/sybra/agent_completion.go`): `OnComplete` now
  stalls a rate-limited run (the same path as a signal kill / external stop)
  instead of marking the step failed — the task stays `in-progress`. Auth
  failures are intentionally excluded: they need a human to log in, so they
  keep taking the `human-required` path.
- **Auto-resume** (`internal/recovery`, `internal/workflow`): `RestartStaleInProgress`
  and `ResumeStalled` skip re-dispatch while the run's provider is rate-limited
  (via `agent.Manager.ProviderHealthy`, backed by the existing health gate), so
  the task waits in-progress and resumes on its own once the limit window
  clears — instead of hot-looping the gate or reverting to `todo` (which
  nothing re-picks-up).

Tests: classifier session/usage-limit cases, the `OnComplete` stall decision,
`ProviderHealthy`, and the recovery / `ResumeStalled` skip-while-rate-limited
paths.

## Supporting documentation

Root cause traced from the agent log for the stranded task: a `rate_limit_event`
(`rateLimitType: five_hour`, `overageStatus: rejected`) and a result with
`is_error: true` / `"You've hit your session limit"`, exit non-zero →
`Success: false` → step `failed` → `verify_commits` → `human-required`.

Follow-up (not in this PR): parse the limit's `resetsAt` to set a precise
cooldown instead of the gate's default window, so retries don't probe before the
real reset.
