### PR TITLE
fix(worktree): reuse adopted worktree in PR-fix

### DIFF
--- a/internal/worktree/adopt_test.go
+++ b/internal/worktree/adopt_test.go
@@ -74,6 +74,51 @@ func TestPrepareForTask_AdoptsExternalWorktree(t *testing.T) {
 	}
 }
 
+// TestPrepareForFix_AdoptsExternalWorktree is the regression for the
+// circuit-breaker strand: a handoff/adopted worktree sent through the PR-fix
+// flow must be reused as-is, not re-created with `git worktree add` (which
+// fails "already exists" and, after wtFailureLimit retries, flips the task to
+// human-required). The adoption guard short-circuits before any PR-branch
+// fetch, so the PR number is irrelevant here.
+func TestPrepareForFix_AdoptsExternalWorktree(t *testing.T) {
+	h := prepareHarness(t, nil, 0)
+
+	ext := filepath.Join(t.TempDir(), "orca-worktree")
+	const extBranch = "orca/fix-x"
+	if out, err := exec.Command("git", "-C", h.proj.ClonePath, "worktree", "add", "-b", extBranch, ext, "main").CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v: %s", err, out)
+	}
+
+	tk, err := h.tasks.Create("adopt fix", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = h.tasks.UpdateMap(tk.ID, map[string]any{
+		"project_id":   h.proj.ID,
+		"worktree_dir": ext,
+	})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	got, err := h.m.PrepareForFix(tk, 1)
+	if err != nil {
+		t.Fatalf("PrepareForFix: %v", err)
+	}
+	if got != ext {
+		t.Fatalf("adopted path = %q, want %q", got, ext)
+	}
+
+	// No managed worktree was created — proves no `git worktree add` ran.
+	entries, err := os.ReadDir(h.wtDir)
+	if err != nil {
+		t.Fatalf("read worktrees dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("managed worktrees dir not empty: %v", entries)
+	}
+}
+
 // TestPrepareForTask_AdoptRejectsMissingDir verifies adoption fails cleanly
 // when the declared worktree directory does not exist.
 func TestPrepareForTask_AdoptRejectsMissingDir(t *testing.T) {

--- a/internal/worktree/adopt_test.go
+++ b/internal/worktree/adopt_test.go
@@ -109,6 +109,20 @@ func TestPrepareForFix_AdoptsExternalWorktree(t *testing.T) {
 		t.Fatalf("adopted path = %q, want %q", got, ext)
 	}
 
+	// Assert the adoption side effects so the test fails if adoption is ever
+	// replaced by a plain early return: the identity beacon is written into the
+	// adopted dir and the task records the adopted worktree's branch.
+	if _, err := os.Stat(filepath.Join(ext, contextFileName)); err != nil {
+		t.Errorf("context beacon not written: %v", err)
+	}
+	reloaded, err := h.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if reloaded.Branch != extBranch {
+		t.Errorf("task branch = %q, want %q", reloaded.Branch, extBranch)
+	}
+
 	// No managed worktree was created — proves no `git worktree add` ran.
 	entries, err := os.ReadDir(h.wtDir)
 	if err != nil {

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -323,11 +323,12 @@ func (m *Manager) PrepareForReview(t task.Task) (string, error) {
 // so the agent can rebase and push.
 func (m *Manager) PrepareForFix(t task.Task, prNumber int) (string, error) {
 	// Adopt an externally-created worktree (e.g. an Orca handoff) as-is instead
-	// of re-creating it. Without this guard PrepareForFix runs `git worktree
-	// add` at the adopted path, which fails ("already exists" / "branch already
-	// checked out") and — after wtFailureLimit retries — strands the task in
-	// human-required. The fix agent rebases/pushes from this worktree itself,
-	// so no Sybra-managed checkout is needed. Mirrors PrepareForTask.
+	// of re-creating it. Without this guard PrepareForFix runs
+	// `git worktree add` at the adopted path, which fails ("already exists" /
+	// "branch already checked out") and — after wtFailureLimit retries — strands
+	// the task in human-required. The fix agent rebases/pushes from this
+	// worktree itself, so no Sybra-managed checkout is needed. Mirrors
+	// PrepareForTask.
 	if t.WorktreeDir != "" {
 		return m.adoptWorktree(t, nil)
 	}

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -322,6 +322,16 @@ func (m *Manager) PrepareForReview(t task.Task) (string, error) {
 // PrepareForFix creates a worktree checking out the PR's head branch
 // so the agent can rebase and push.
 func (m *Manager) PrepareForFix(t task.Task, prNumber int) (string, error) {
+	// Adopt an externally-created worktree (e.g. an Orca handoff) as-is instead
+	// of re-creating it. Without this guard PrepareForFix runs `git worktree
+	// add` at the adopted path, which fails ("already exists" / "branch already
+	// checked out") and — after wtFailureLimit retries — strands the task in
+	// human-required. The fix agent rebases/pushes from this worktree itself,
+	// so no Sybra-managed checkout is needed. Mirrors PrepareForTask.
+	if t.WorktreeDir != "" {
+		return m.adoptWorktree(t, nil)
+	}
+
 	proj, err := m.projects.Get(t.ProjectID)
 	if err != nil {
 		return "", fmt.Errorf("get project: %w", err)


### PR DESCRIPTION
## Motivation

A handoff task whose worktree was adopted from an external tool (Orca, via
`worktree_dir`) stranded in `human-required` whenever its PR needed a fix. The
PR-monitor's `PrepareForFix` ran `git worktree add` at the already-registered
adopted path, which fails:

```
fatal: '…/agentic-review-column' already exists
```

After `wtFailureLimit` (5) consecutive failures the circuit breaker flipped the
task to `human-required`. `PrepareForTask` already guards this case by adopting
the existing worktree when `WorktreeDir` is set — `PrepareForFix` was missing
the same guard.

> Changelog: fix(worktree): reuse adopted worktree in the PR-fix flow

## Implementation information

- `PrepareForFix` now short-circuits to `adoptWorktree` when the task carries
  `WorktreeDir`, mirroring `PrepareForTask`. The adopted worktree is reused
  as-is — the fix agent rebases/pushes from it directly — so no `git worktree
  add` is attempted and the collision (and the resulting circuit-breaker
  strand) can't happen.

Test: `TestPrepareForFix_AdoptsExternalWorktree` sets up a real linked worktree,
sends it through `PrepareForFix`, and asserts the adopted path is returned with
nothing created under the managed worktrees dir (proving no `git worktree add`
ran). The adoption guard short-circuits before any PR-branch fetch, so the PR
number is irrelevant.

## Supporting documentation

Observed on task `8a1541fe` (`worktree_dir:
~/orca/workspaces/synapse/agentic-review-column`, PR #1053): five
`pr-monitor.worktree` errors → `pr-monitor.worktree.circuit-open` →
`human-required`.
