### PR TITLE
feat(eval): LLM-as-judge quality rubric

### DIFF
--- a/cmd/sybra-cli/evaluation.go
+++ b/cmd/sybra-cli/evaluation.go
@@ -2,20 +2,26 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
+	"strings"
 
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/evaluation"
+	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/stats"
+	"github.com/Automaat/sybra/internal/task"
 )
 
-func cmdEvaluation(cfg *config.Config, args []string, jsonOut bool) int {
+func cmdEvaluation(cfg *config.Config, store *task.Manager, args []string, jsonOut bool) int {
 	if len(args) == 0 {
-		return fatal(jsonOut, "usage: evaluation <scan> [--json]")
+		return fatal(jsonOut, "usage: evaluation <scan|judge> [args] [--json]")
 	}
 	switch args[0] {
 	case "scan":
 		return cmdEvaluationScan(cfg, jsonOut)
+	case "judge":
+		return cmdEvaluationJudge(store, args[1:], jsonOut)
 	default:
 		return fatal(jsonOut, "unknown evaluation subcommand: %s", args[0])
 	}
@@ -48,4 +54,72 @@ func cmdEvaluationScan(cfg *config.Config, jsonOut bool) int {
 	fmt.Printf("  cost=$%.2f ($%.2f/landed)  turns/landed=%.1f  tools/landed=%.1f\n",
 		o.TotalCostUSD, o.CostPerLanded, o.TurnsPerLanded, o.ToolsPerLanded)
 	return 0
+}
+
+func cmdEvaluationJudge(store *task.Manager, args []string, jsonOut bool) int {
+	fs := flag.NewFlagSet("judge", flag.ContinueOnError)
+	model := fs.String("model", "", "judge model (default claude-sonnet-4-6)")
+	seed := fs.Int64("seed", 0, "rubric shuffle seed (0 = stable order)")
+	if err := fs.Parse(args); err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+	rest := fs.Args()
+	if len(rest) < 1 {
+		return fatal(jsonOut, "usage: evaluation judge <task-id> [--model M] [--seed N]")
+	}
+	t, err := store.Get(rest[0])
+	if err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+	if t.ProjectID == "" || t.PRNumber == 0 {
+		return fatal(jsonOut, "task %s has no PR/project to judge", t.ID)
+	}
+	diff, err := github.FetchPRDiff(t.ProjectID, t.PRNumber)
+	if err != nil {
+		return fatal(jsonOut, "fetch diff: %v", err)
+	}
+	judge := &evaluation.ClaudeQualityJudge{Model: *model, DimSeed: *seed}
+	v, err := judge.Judge(context.Background(), evaluation.JudgeRequest{
+		TaskID:     t.ID,
+		Title:      t.Title,
+		Body:       t.Body,
+		Diff:       diff,
+		Trajectory: trajectorySummary(t),
+	})
+	if err != nil {
+		return fatal(jsonOut, "judge: %v", err)
+	}
+	if jsonOut {
+		return printJSON(v)
+	}
+	fmt.Printf("quality verdict for %s (PR #%d): overall %.1f/10\n", t.ID, t.PRNumber, v.Overall)
+	for _, d := range evaluation.Rubric {
+		s := v.Dimensions[d.Key]
+		fmt.Printf("  %-18s %2d/10  %s\n", d.Key, s.Score, s.Rationale)
+	}
+	if v.Summary != "" {
+		fmt.Printf("  summary: %s\n", v.Summary)
+	}
+	if t.Outcome != "" {
+		fmt.Printf("  outcome=%s  judge-agrees=%v\n", t.Outcome, evaluation.AgreesWithOutcome(v, t.Outcome, 6.0))
+	}
+	return 0
+}
+
+// trajectorySummary renders the task's agent-run history into a one-line summary
+// the judge can use to assess how the agent reached the result (agent-as-judge).
+func trajectorySummary(t task.Task) string {
+	if len(t.AgentRuns) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(t.AgentRuns))
+	for i := range t.AgentRuns {
+		r := t.AgentRuns[i]
+		role := r.Role
+		if role == "" {
+			role = "implementation"
+		}
+		parts = append(parts, fmt.Sprintf("%s(%s $%.2f)", role, r.State, r.CostUSD))
+	}
+	return fmt.Sprintf("%d agent runs: %s", len(t.AgentRuns), strings.Join(parts, " → "))
 }

--- a/cmd/sybra-cli/evaluation.go
+++ b/cmd/sybra-cli/evaluation.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/evaluation"
@@ -60,6 +61,7 @@ func cmdEvaluationJudge(store *task.Manager, args []string, jsonOut bool) int {
 	fs := flag.NewFlagSet("judge", flag.ContinueOnError)
 	model := fs.String("model", "", "judge model (default claude-sonnet-4-6)")
 	seed := fs.Int64("seed", 0, "rubric shuffle seed (0 = stable order)")
+	timeout := fs.Duration("timeout", 3*time.Minute, "max time to wait for the judge")
 	if err := fs.Parse(args); err != nil {
 		return fatal(jsonOut, "%v", err)
 	}
@@ -78,8 +80,10 @@ func cmdEvaluationJudge(store *task.Manager, args []string, jsonOut bool) int {
 	if err != nil {
 		return fatal(jsonOut, "fetch diff: %v", err)
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
 	judge := &evaluation.ClaudeQualityJudge{Model: *model, DimSeed: *seed}
-	v, err := judge.Judge(context.Background(), evaluation.JudgeRequest{
+	v, err := judge.Judge(ctx, evaluation.JudgeRequest{
 		TaskID:     t.ID,
 		Title:      t.Title,
 		Body:       t.Body,

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -94,7 +94,7 @@ func run(args []string) int {
 	case "selfmonitor":
 		return cmdSelfmonitor(cfg, store, rest, jsonOut)
 	case "evaluation":
-		return cmdEvaluation(cfg, rest, jsonOut)
+		return cmdEvaluation(cfg, store, rest, jsonOut)
 	case "install-skills":
 		return cmdInstallSkills(cfg, jsonOut)
 	default:

--- a/internal/evaluation/judge.go
+++ b/internal/evaluation/judge.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"sort"
 	"strings"
+	"unicode/utf8"
 )
 
 // defaultJudgeModel is a capable model for nuanced code-quality judgment.
@@ -172,20 +173,24 @@ func parseQualityVerdict(raw []byte) (QualityVerdict, error) {
 	if err := json.Unmarshal([]byte(jsonStr), &v); err != nil {
 		return QualityVerdict{}, fmt.Errorf("unmarshal verdict: %w", err)
 	}
-	if len(v.Dimensions) == 0 {
-		return QualityVerdict{}, fmt.Errorf("verdict has no dimension scores")
-	}
+	// Require every rubric dimension: a partial verdict would skew Overall and
+	// the outcome calibration. Clamp scores and sum over the rubric keys (not
+	// len(v.Dimensions)) so extra/unknown keys can't distort the mean.
 	var sum float64
-	for k, d := range v.Dimensions {
-		d.Score = clampScore(d.Score)
-		v.Dimensions[k] = d
-		sum += float64(d.Score)
+	for _, d := range Rubric {
+		ds, ok := v.Dimensions[d.Key]
+		if !ok {
+			return QualityVerdict{}, fmt.Errorf("verdict missing dimension %q", d.Key)
+		}
+		ds.Score = clampScore(ds.Score)
+		v.Dimensions[d.Key] = ds
+		sum += float64(ds.Score)
 	}
-	mean := sum / float64(len(v.Dimensions))
-	// Trust the model's overall only if it's in range and close to the mean;
-	// otherwise recompute, so a bogus overall can't misrepresent the scores.
-	if v.Overall < 0 || v.Overall > 10 || absf(v.Overall-mean) > 2 {
-		v.Overall = mean
+	// Recompute Overall only when out of range or omitted (<=0). A valid in-range
+	// Overall is preserved even when it deviates from the mean — the prompt lets a
+	// blocker dimension pull Overall below the average, and that must survive.
+	if v.Overall <= 0 || v.Overall > 10 {
+		v.Overall = sum / float64(len(Rubric))
 	}
 	return v, nil
 }
@@ -270,16 +275,13 @@ func clampScore(s int) int {
 	return s
 }
 
-func absf(x float64) float64 {
-	if x < 0 {
-		return -x
-	}
-	return x
-}
-
 func truncate(s string, n int) string {
 	if len(s) <= n {
 		return s
+	}
+	// Back up to a rune boundary so the cut never splits a multibyte character.
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
 	}
 	return s[:n] + "\n…(truncated)"
 }

--- a/internal/evaluation/judge.go
+++ b/internal/evaluation/judge.go
@@ -1,0 +1,285 @@
+package evaluation
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// defaultJudgeModel is a capable model for nuanced code-quality judgment.
+const defaultJudgeModel = "claude-sonnet-4-6"
+
+// maxDiffChars caps the diff fed to the judge so a huge PR can't blow the prompt.
+const maxDiffChars = 16000
+
+// RubricDimension is one scored axis of the mid-level-SWE quality rubric.
+type RubricDimension struct {
+	Key      string
+	Question string
+}
+
+// Rubric is the set of dimensions a landed change is scored on (0–10 each).
+var Rubric = []RubricDimension{
+	{"correctness", "Does the change correctly do what the task asked, with tests passing?"},
+	{"code_quality", "Is the code idiomatic, readable, and consistent with the surrounding code?"},
+	{"scope_discipline", "Did it solve the task without over-reaching or leaving it half-done?"},
+	{"test_coverage", "Were tests added or updated appropriately for the behavior changed?"},
+	{"review_worthiness", "Would this survive a mid-level engineer's PR review without major changes?"},
+}
+
+// DimensionScore is a single 0–10 score with a one-line rationale.
+type DimensionScore struct {
+	Score     int    `json:"score"`
+	Rationale string `json:"rationale,omitempty"`
+}
+
+// QualityVerdict is the judge's assessment of one landed change.
+type QualityVerdict struct {
+	TaskID     string                    `json:"taskId,omitempty"`
+	Overall    float64                   `json:"overall"`
+	Dimensions map[string]DimensionScore `json:"dimensions"`
+	Summary    string                    `json:"summary,omitempty"`
+}
+
+// JudgeRequest is the material the judge scores: the task intent, the landed
+// diff, and (optionally) a compact trajectory summary of how the agent worked.
+type JudgeRequest struct {
+	TaskID     string
+	Title      string
+	Body       string
+	Diff       string
+	Trajectory string
+}
+
+// QualityJudge scores a landed change against the rubric.
+type QualityJudge interface {
+	Judge(ctx context.Context, req JudgeRequest) (QualityVerdict, error)
+}
+
+// ClaudeQualityJudge spawns `claude -p` and parses the rubric verdict, mirroring
+// selfmonitor.ClaudeJudge. DimSeed permutes the rubric order per call to reduce
+// the LLM's position bias toward dimensions listed first (seed 0 = stable order).
+type ClaudeQualityJudge struct {
+	Model   string
+	DimSeed int64
+	Logger  *slog.Logger
+}
+
+// Judge shells out to claude -p and returns a validated verdict.
+func (j *ClaudeQualityJudge) Judge(ctx context.Context, req JudgeRequest) (QualityVerdict, error) {
+	model := j.Model
+	if model == "" {
+		model = defaultJudgeModel
+	}
+	prompt := buildQualityPrompt(req, shuffledRubric(j.DimSeed))
+	cmd := exec.CommandContext(ctx, "claude",
+		"-p", prompt,
+		"--output-format", "json",
+		"--dangerously-skip-permissions",
+		"--model", model,
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return QualityVerdict{}, fmt.Errorf("claude -p: %w", err)
+	}
+	v, err := parseQualityVerdict(out)
+	if err != nil {
+		return QualityVerdict{}, err
+	}
+	v.TaskID = req.TaskID
+	return v, nil
+}
+
+// shuffledRubric returns the rubric in a deterministic permutation for the seed,
+// to mitigate the LLM's position bias toward dimensions listed first. Seed 0
+// leaves the canonical order untouched. The order is derived by ranking each
+// dimension by a hash of "seed:key", which is reproducible for a given seed and
+// avoids any signed/unsigned integer conversions.
+func shuffledRubric(seed int64) []RubricDimension {
+	out := append([]RubricDimension(nil), Rubric...)
+	if seed == 0 {
+		return out
+	}
+	rank := func(key string) [32]byte {
+		return sha256.Sum256(fmt.Appendf(nil, "%d:%s", seed, key))
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		ri, rj := rank(out[i].Key), rank(out[j].Key)
+		return string(ri[:]) < string(rj[:])
+	})
+	return out
+}
+
+func buildQualityPrompt(req JudgeRequest, dims []RubricDimension) string {
+	var b strings.Builder
+	b.WriteString("You are a staff engineer grading whether an AI agent's merged code change ")
+	b.WriteString("meets the bar of a competent mid-level software engineer.\n")
+	b.WriteString("Score each dimension 0–10 (10 = excellent). Output ONLY a single JSON object on the final line.\n\n")
+
+	fmt.Fprintf(&b, "Task: %s\n", req.Title)
+	if body := truncate(req.Body, 800); body != "" {
+		fmt.Fprintf(&b, "Task details: %s\n", body)
+	}
+	if req.Trajectory != "" {
+		fmt.Fprintf(&b, "How the agent worked: %s\n", req.Trajectory)
+	}
+	b.WriteString("\nDiff (may be truncated):\n")
+	b.WriteString(truncate(req.Diff, maxDiffChars))
+	b.WriteString("\n\nScore these dimensions:\n")
+	for _, d := range dims {
+		fmt.Fprintf(&b, "- %s: %s\n", d.Key, d.Question)
+	}
+
+	b.WriteString("\nOutput schema (single JSON object, nothing else):\n")
+	b.WriteString(`{"dimensions":{`)
+	for i, d := range dims {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		fmt.Fprintf(&b, `"%s":{"score":0,"rationale":"..."}`, d.Key)
+	}
+	b.WriteString(`},"overall":0.0,"summary":"one sentence"}`)
+	b.WriteString("\n\nRules:\n")
+	b.WriteString("- Be a tough but fair reviewer; reserve 9–10 for genuinely excellent work.\n")
+	b.WriteString("- overall is the mean of the dimension scores unless one is a blocker.\n")
+	b.WriteString("- rationale: one concrete clause, not boilerplate.\n")
+	return b.String()
+}
+
+// parseQualityVerdict extracts the verdict from `claude -p --output-format json`
+// stdout, clamps each dimension score to [0,10], and fills Overall from the mean
+// when the model omitted or mis-scored it.
+func parseQualityVerdict(raw []byte) (QualityVerdict, error) {
+	var envelope struct {
+		Result string `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return QualityVerdict{}, fmt.Errorf("unmarshal envelope: %w", err)
+	}
+	if envelope.Result == "" {
+		return QualityVerdict{}, fmt.Errorf("empty result field")
+	}
+	jsonStr := judgeExtractLastJSON(envelope.Result)
+	if jsonStr == "" {
+		return QualityVerdict{}, fmt.Errorf("no JSON object in result: %q", envelope.Result)
+	}
+	var v QualityVerdict
+	if err := json.Unmarshal([]byte(jsonStr), &v); err != nil {
+		return QualityVerdict{}, fmt.Errorf("unmarshal verdict: %w", err)
+	}
+	if len(v.Dimensions) == 0 {
+		return QualityVerdict{}, fmt.Errorf("verdict has no dimension scores")
+	}
+	var sum float64
+	for k, d := range v.Dimensions {
+		d.Score = clampScore(d.Score)
+		v.Dimensions[k] = d
+		sum += float64(d.Score)
+	}
+	mean := sum / float64(len(v.Dimensions))
+	// Trust the model's overall only if it's in range and close to the mean;
+	// otherwise recompute, so a bogus overall can't misrepresent the scores.
+	if v.Overall < 0 || v.Overall > 10 || absf(v.Overall-mean) > 2 {
+		v.Overall = mean
+	}
+	return v, nil
+}
+
+// AgreesWithOutcome reports whether a verdict is consistent with the task's
+// recorded landing outcome — a merged change should score at least threshold; a
+// closed (abandoned) one should not. Used to validate the judge against ground
+// truth before trusting it on unreviewed runs. Outcomes other than merged/closed
+// are treated as agreement (no signal). Coarse until richer outcome labels
+// (merge-with-edits, revert) land in #1082.
+func AgreesWithOutcome(v QualityVerdict, outcome string, threshold float64) bool {
+	switch outcome {
+	case "merged":
+		return v.Overall >= threshold
+	case "closed":
+		return v.Overall < threshold
+	default:
+		return true
+	}
+}
+
+// judgeExtractLastJSON returns the last balanced {...} substring in s, or "".
+// The model may prepend prose before the final JSON object.
+func judgeExtractLastJSON(s string) string {
+	s = strings.TrimSpace(s)
+	var (
+		inString  bool
+		escape    bool
+		depth     int
+		objStart  = -1
+		lastStart = -1
+		lastEnd   = -1
+	)
+	for i := range len(s) {
+		c := s[i]
+		if escape {
+			escape = false
+			continue
+		}
+		if inString {
+			switch c {
+			case '\\':
+				escape = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inString = true
+		case '{':
+			if depth == 0 {
+				objStart = i
+			}
+			depth++
+		case '}':
+			if depth == 0 {
+				continue
+			}
+			depth--
+			if depth == 0 && objStart >= 0 {
+				lastStart = objStart
+				lastEnd = i
+				objStart = -1
+			}
+		}
+	}
+	if lastStart < 0 {
+		return ""
+	}
+	return s[lastStart : lastEnd+1]
+}
+
+func clampScore(s int) int {
+	if s < 0 {
+		return 0
+	}
+	if s > 10 {
+		return 10
+	}
+	return s
+}
+
+func absf(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "\n…(truncated)"
+}

--- a/internal/evaluation/judge.go
+++ b/internal/evaluation/judge.go
@@ -186,11 +186,14 @@ func parseQualityVerdict(raw []byte) (QualityVerdict, error) {
 		v.Dimensions[d.Key] = ds
 		sum += float64(ds.Score)
 	}
-	// Recompute Overall only when out of range or omitted (<=0). A valid in-range
+	// Recompute Overall only when out of range, or when it is the zero default
+	// while the mean is non-zero (i.e. the model omitted it). A valid in-range
 	// Overall is preserved even when it deviates from the mean — the prompt lets a
-	// blocker dimension pull Overall below the average, and that must survive.
-	if v.Overall <= 0 || v.Overall > 10 {
-		v.Overall = sum / float64(len(Rubric))
+	// blocker dimension pull Overall below the average, and a genuine 0 (every
+	// dimension scored 0) must survive too.
+	mean := sum / float64(len(Rubric))
+	if v.Overall < 0 || v.Overall > 10 || (v.Overall == 0 && mean != 0) {
+		v.Overall = mean
 	}
 	return v, nil
 }

--- a/internal/evaluation/judge_test.go
+++ b/internal/evaluation/judge_test.go
@@ -1,0 +1,145 @@
+package evaluation
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestShuffledRubric_Deterministic(t *testing.T) {
+	a := shuffledRubric(42)
+	b := shuffledRubric(42)
+	if len(a) != len(Rubric) {
+		t.Fatalf("len %d, want %d", len(a), len(Rubric))
+	}
+	for i := range a {
+		if a[i].Key != b[i].Key {
+			t.Fatalf("not deterministic at %d: %s vs %s", i, a[i].Key, b[i].Key)
+		}
+	}
+	seen := map[string]bool{}
+	for _, d := range a {
+		seen[d.Key] = true
+	}
+	for _, d := range Rubric {
+		if !seen[d.Key] {
+			t.Errorf("shuffle dropped dimension %s", d.Key)
+		}
+	}
+}
+
+func TestShuffledRubric_SeedZeroStable(t *testing.T) {
+	a := shuffledRubric(0)
+	for i := range Rubric {
+		if a[i].Key != Rubric[i].Key {
+			t.Errorf("seed 0 reordered at %d", i)
+		}
+	}
+}
+
+func TestShuffledRubric_ActuallyShuffles(t *testing.T) {
+	canonical := func(d []RubricDimension) bool {
+		for i := range d {
+			if d[i].Key != Rubric[i].Key {
+				return false
+			}
+		}
+		return true
+	}
+	// At least one non-zero seed must reorder away from canonical.
+	reordered := false
+	for seed := int64(1); seed <= 20; seed++ {
+		if !canonical(shuffledRubric(seed)) {
+			reordered = true
+			break
+		}
+	}
+	if !reordered {
+		t.Error("no seed in 1..20 reordered the rubric")
+	}
+}
+
+func TestBuildQualityPrompt_ContainsAllDimensions(t *testing.T) {
+	p := buildQualityPrompt(JudgeRequest{Title: "T", Diff: "d"}, Rubric)
+	for _, d := range Rubric {
+		if !strings.Contains(p, d.Key) {
+			t.Errorf("prompt missing dimension %s", d.Key)
+		}
+	}
+}
+
+func TestBuildQualityPrompt_TruncatesDiff(t *testing.T) {
+	big := strings.Repeat("x", maxDiffChars+5000)
+	p := buildQualityPrompt(JudgeRequest{Title: "T", Diff: big}, Rubric)
+	if !strings.Contains(p, "truncated") {
+		t.Error("expected truncation marker for oversized diff")
+	}
+	if len(p) > maxDiffChars+4000 {
+		t.Errorf("prompt not bounded: %d chars", len(p))
+	}
+}
+
+func TestParseQualityVerdict(t *testing.T) {
+	inner := `{"dimensions":{"correctness":{"score":12,"rationale":"ok"},"code_quality":{"score":-3},` +
+		`"scope_discipline":{"score":8},"test_coverage":{"score":6},"review_worthiness":{"score":7}},` +
+		`"overall":99,"summary":"s"}`
+	v, err := parseQualityVerdict(mustEnvelope(t, "prose before "+inner))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got := v.Dimensions["correctness"].Score; got != 10 {
+		t.Errorf("clamp high: got %d, want 10", got)
+	}
+	if got := v.Dimensions["code_quality"].Score; got != 0 {
+		t.Errorf("clamp low: got %d, want 0", got)
+	}
+	// overall 99 is out of range → recomputed mean of [10,0,8,6,7] = 6.2.
+	if v.Overall < 6.1 || v.Overall > 6.3 {
+		t.Errorf("overall = %v, want ~6.2", v.Overall)
+	}
+}
+
+func TestParseQualityVerdict_Errors(t *testing.T) {
+	cases := map[string][]byte{
+		"bad envelope":  []byte("not json"),
+		"empty result":  mustEnvelope(t, ""),
+		"no json":       mustEnvelope(t, "just prose, no object"),
+		"no dimensions": mustEnvelope(t, `{"overall":5}`),
+	}
+	for name, raw := range cases {
+		if _, err := parseQualityVerdict(raw); err == nil {
+			t.Errorf("%s: want error, got nil", name)
+		}
+	}
+}
+
+func TestAgreesWithOutcome(t *testing.T) {
+	hi, lo := QualityVerdict{Overall: 8}, QualityVerdict{Overall: 3}
+	cases := []struct {
+		v       QualityVerdict
+		outcome string
+		want    bool
+	}{
+		{hi, "merged", true},
+		{lo, "merged", false},
+		{lo, "closed", true},
+		{hi, "closed", false},
+		{lo, "unknown", true},
+	}
+	for _, c := range cases {
+		if got := AgreesWithOutcome(c.v, c.outcome, 6.0); got != c.want {
+			t.Errorf("AgreesWithOutcome(%.0f, %s) = %v, want %v", c.v.Overall, c.outcome, got, c.want)
+		}
+	}
+}
+
+func mustEnvelope(t *testing.T, result string) []byte {
+	t.Helper()
+	b, err := json.Marshal(struct {
+		Result string `json:"result"`
+	}{Result: result})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}

--- a/internal/evaluation/judge_test.go
+++ b/internal/evaluation/judge_test.go
@@ -114,6 +114,30 @@ func TestParseQualityVerdict_PreservesBlockerOverall(t *testing.T) {
 	}
 }
 
+func TestParseQualityVerdict_OverallZero(t *testing.T) {
+	allZero := `{"dimensions":{"correctness":{"score":0},"code_quality":{"score":0},` +
+		`"scope_discipline":{"score":0},"test_coverage":{"score":0},"review_worthiness":{"score":0}},` +
+		`"overall":0,"summary":"all bad"}`
+	v, err := parseQualityVerdict(mustEnvelope(t, allZero))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if v.Overall != 0 {
+		t.Errorf("genuine overall=0 (mean 0) = %v, want 0 preserved", v.Overall)
+	}
+
+	// overall omitted (zero default) but dimensions are high → recompute to mean.
+	omitted := `{"dimensions":{"correctness":{"score":8},"code_quality":{"score":8},` +
+		`"scope_discipline":{"score":8},"test_coverage":{"score":8},"review_worthiness":{"score":8}}}`
+	v2, err := parseQualityVerdict(mustEnvelope(t, omitted))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if v2.Overall != 8 {
+		t.Errorf("omitted overall = %v, want 8 (recomputed mean)", v2.Overall)
+	}
+}
+
 func TestParseQualityVerdict_Errors(t *testing.T) {
 	cases := map[string][]byte{
 		"bad envelope":       []byte("not json"),

--- a/internal/evaluation/judge_test.go
+++ b/internal/evaluation/judge_test.go
@@ -99,12 +99,28 @@ func TestParseQualityVerdict(t *testing.T) {
 	}
 }
 
+func TestParseQualityVerdict_PreservesBlockerOverall(t *testing.T) {
+	// A blocker (correctness=2) legitimately pulls overall to 2.5, far below the
+	// mean of [2,8,8,8,8]=6.8. The parser must NOT overwrite it with the mean.
+	inner := `{"dimensions":{"correctness":{"score":2},"code_quality":{"score":8},` +
+		`"scope_discipline":{"score":8},"test_coverage":{"score":8},"review_worthiness":{"score":8}},` +
+		`"overall":2.5,"summary":"correctness blocker"}`
+	v, err := parseQualityVerdict(mustEnvelope(t, inner))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if v.Overall != 2.5 {
+		t.Errorf("overall = %v, want 2.5 (blocker-driven, preserved)", v.Overall)
+	}
+}
+
 func TestParseQualityVerdict_Errors(t *testing.T) {
 	cases := map[string][]byte{
-		"bad envelope":  []byte("not json"),
-		"empty result":  mustEnvelope(t, ""),
-		"no json":       mustEnvelope(t, "just prose, no object"),
-		"no dimensions": mustEnvelope(t, `{"overall":5}`),
+		"bad envelope":       []byte("not json"),
+		"empty result":       mustEnvelope(t, ""),
+		"no json":            mustEnvelope(t, "just prose, no object"),
+		"no dimensions":      mustEnvelope(t, `{"overall":5}`),
+		"partial dimensions": mustEnvelope(t, `{"dimensions":{"correctness":{"score":9}},"overall":9}`),
 	}
 	for name, raw := range cases {
 		if _, err := parseQualityVerdict(raw); err == nil {

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -266,6 +266,20 @@ func fetchPRHeadSHAWith(e execer, repo string, number int) (string, error) {
 	return raw.HeadRefOid, nil
 }
 
+// FetchPRDiff returns the unified diff for a PR. Used by the evaluation
+// LLM-as-judge to score the landed change.
+func FetchPRDiff(repo string, number int) (string, error) {
+	return fetchPRDiffWith(defaultExecer, repo, number)
+}
+
+func fetchPRDiffWith(e execer, repo string, number int) (string, error) {
+	out, err := e.run("pr", "diff", strconv.Itoa(number), "--repo", repo)
+	if err != nil {
+		return "", fmt.Errorf("gh pr diff %d: %s: %w", number, strings.TrimSpace(string(out)), err)
+	}
+	return string(out), nil
+}
+
 // FetchPRBranch returns the head branch name for a PR.
 func FetchPRBranch(repo string, number int) (string, error) {
 	return fetchPRBranchWith(defaultExecer, repo, number)

--- a/internal/github/pr_diff_test.go
+++ b/internal/github/pr_diff_test.go
@@ -1,0 +1,25 @@
+package github
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestFetchPRDiff(t *testing.T) {
+	fe := &fakeExecer{output: []byte("diff --git a/x b/x\n+hi\n")}
+	got, err := fetchPRDiffWith(fe, "o/r", 7)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !strings.Contains(got, "diff --git") {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestFetchPRDiff_Error(t *testing.T) {
+	fe := &fakeExecer{output: []byte("boom"), err: fmt.Errorf("exit 1")}
+	if _, err := fetchPRDiffWith(fe, "o/r", 7); err == nil {
+		t.Fatal("want error")
+	}
+}


### PR DESCRIPTION
## Motivation

Closes #1068. The quality half of the evaluation umbrella (#1065). Aggregate metrics (#1067) say how much and how fast; this adds the hands-off LLM-as-judge that scores whether a landed change is mid-level-good.

> Changelog: feat(eval): LLM-as-judge quality rubric

## Implementation information

Engine (`internal/evaluation/judge.go`):
- Rubric of five 0–10 dimensions: correctness, code quality, scope discipline, test coverage, review-worthiness.
- `ClaudeQualityJudge` spawns `claude -p` and parses the JSON verdict, mirroring `selfmonitor.ClaudeJudge`. Scores are clamped; every rubric dimension is required (partial responses error); `Overall` is recomputed from the mean only when out of range or omitted, so a legitimate blocker-driven low `Overall` survives.
- Rubric order is permuted per call (seeded, SHA-256-of `seed:key`) to reduce the model's position bias; seed 0 keeps canonical order.
- `AgreesWithOutcome` validates a verdict against the recorded landing outcome, so the judge can be calibrated before it's trusted unattended.

Plumbing:
- `github.FetchPRDiff` returns a PR's unified diff for the judge input.
- `sybra-cli evaluation judge <task-id>` gathers the diff plus an agent-run trajectory summary and prints the verdict (`--json`, `--model`, `--seed`, `--timeout`).

Adversarial review applied before review: the parser no longer overrides a valid blocker-driven `Overall` with the mean (that bug inverted the outcome-calibration); the judge CLI runs under a context timeout; and diff truncation respects rune boundaries.

Automatic per-landing judging (cost-budgeted background judger, verdict cache) and rolling scores into the periodic report are the next slice, tracked in the Phase 0.1 follow-up.

## Supporting documentation

- Umbrella #1065; builds on #1066 and #1067.

Gates: `golangci-lint run ./...`, `go test ./...`, `oxlint`, `svelte-check`, `hadolint` all pass.
