### PR TITLE
feat(eval): dashboard + improvement feedback loop

### DIFF
--- a/cmd/sybra-cli/evaluation.go
+++ b/cmd/sybra-cli/evaluation.go
@@ -54,6 +54,12 @@ func cmdEvaluationScan(cfg *config.Config, jsonOut bool) int {
 		o.LeadTimeP50H, o.LeadTimeP90H, o.CycleTimeP50H, o.CycleTimeP90H)
 	fmt.Printf("  cost=$%.2f ($%.2f/landed)  turns/landed=%.1f  tools/landed=%.1f\n",
 		o.TotalCostUSD, o.CostPerLanded, o.TurnsPerLanded, o.ToolsPerLanded)
+	if len(report.Weaknesses) > 0 {
+		fmt.Println("weaknesses:")
+		for _, w := range report.Weaknesses {
+			fmt.Printf("  [%s] %s: %s\n    → %s\n", w.Severity, w.Metric, w.Detail, w.Suggestion)
+		}
+	}
 	return 0
 }
 

--- a/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/index.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/index.ts
@@ -4,5 +4,6 @@
 export {
     Breakdown,
     Report,
-    Scorecard
+    Scorecard,
+    Weakness
 } from "./models.js";

--- a/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
@@ -70,6 +70,7 @@ export class Report {
     "overall": Scorecard;
     "byProvider"?: Breakdown[];
     "byRole"?: Breakdown[];
+    "weaknesses"?: Weakness[];
     "notes"?: string[];
 
     /** Creates a new Report instance. */
@@ -97,7 +98,8 @@ export class Report {
         const $$createField3_0 = $$createType0;
         const $$createField4_0 = $$createType2;
         const $$createField5_0 = $$createType2;
-        const $$createField6_0 = $$createType3;
+        const $$createField6_0 = $$createType4;
+        const $$createField7_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("overall" in $$parsedSource) {
             $$parsedSource["overall"] = $$createField3_0($$parsedSource["overall"]);
@@ -108,8 +110,11 @@ export class Report {
         if ("byRole" in $$parsedSource) {
             $$parsedSource["byRole"] = $$createField5_0($$parsedSource["byRole"]);
         }
+        if ("weaknesses" in $$parsedSource) {
+            $$parsedSource["weaknesses"] = $$createField6_0($$parsedSource["weaknesses"]);
+        }
         if ("notes" in $$parsedSource) {
-            $$parsedSource["notes"] = $$createField6_0($$parsedSource["notes"]);
+            $$parsedSource["notes"] = $$createField7_0($$parsedSource["notes"]);
         }
         return new Report($$parsedSource as Partial<Report>);
     }
@@ -265,8 +270,50 @@ export class Scorecard {
     }
 }
 
+/**
+ * Weakness is one systematic shortfall the scorecard surfaces, paired with a
+ * concrete suggested action — the deterministic half of the improvement loop.
+ */
+export class Weakness {
+    /**
+     * "warn" | "info"
+     */
+    "severity": string;
+    "metric": string;
+    "detail": string;
+    "suggestion": string;
+
+    /** Creates a new Weakness instance. */
+    constructor($$source: Partial<Weakness> = {}) {
+        if (!("severity" in $$source)) {
+            this["severity"] = "";
+        }
+        if (!("metric" in $$source)) {
+            this["metric"] = "";
+        }
+        if (!("detail" in $$source)) {
+            this["detail"] = "";
+        }
+        if (!("suggestion" in $$source)) {
+            this["suggestion"] = "";
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new Weakness instance from a string or object.
+     */
+    static createFrom($$source: any = {}): Weakness {
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        return new Weakness($$parsedSource as Partial<Weakness>);
+    }
+}
+
 // Private type creation functions
 const $$createType0 = Scorecard.createFrom;
 const $$createType1 = Breakdown.createFrom;
 const $$createType2 = $Create.Array($$createType1);
-const $$createType3 = $Create.Array($Create.Any);
+const $$createType3 = Weakness.createFrom;
+const $$createType4 = $Create.Array($$createType3);
+const $$createType5 = $Create.Array($Create.Any);

--- a/frontend/src/components/PageRouter.svelte
+++ b/frontend/src/components/PageRouter.svelte
@@ -18,6 +18,7 @@
   const loadProjectDetail = lazyComponent(() => import('../pages/ProjectDetail.svelte'))
   const loadGitHub = lazyComponent(() => import('../pages/GitHub.svelte'))
   const loadStats = lazyComponent(() => import('../pages/Stats.svelte'))
+  const loadEvaluation = lazyComponent(() => import('../pages/Evaluation.svelte'))
   const loadReviews = lazyComponent(() => import('../pages/Reviews.svelte'))
   const loadSettings = lazyComponent(() => import('../pages/Settings.svelte'))
   const loadChatList = lazyComponent(() => import('../pages/ChatList.svelte'))
@@ -137,6 +138,10 @@
   {:else if navStore.page.kind === 'stats'}
     {#await loadStats() then Stats}
       <Stats />
+    {/await}
+  {:else if navStore.page.kind === 'evaluation'}
+    {#await loadEvaluation() then Evaluation}
+      <Evaluation />
     {/await}
   {:else if navStore.page.kind === 'workflows'}
     {#await loadWorkflowList() then WorkflowList}

--- a/frontend/src/components/shell/MoreSheet.svelte
+++ b/frontend/src/components/shell/MoreSheet.svelte
@@ -19,6 +19,7 @@
     { label: 'GitHub', page: { kind: 'github' } },
     { label: 'Workflows', page: { kind: 'workflows' } },
     { label: 'Stats', page: { kind: 'stats' } },
+    { label: 'Evaluation', page: { kind: 'evaluation' } },
     { label: 'Settings', page: { kind: 'settings' } },
   ])
 

--- a/frontend/src/components/shell/SideRail.svelte
+++ b/frontend/src/components/shell/SideRail.svelte
@@ -47,6 +47,7 @@
     { kind: ['workflows', 'workflow-detail'], label: 'Workflows', icon: LayoutDashboard, onclick: () => navStore.reset({ kind: 'workflows' }) },
     { kind: ['github'], label: 'GitHub', icon: GitBranch, onclick: () => navStore.reset({ kind: 'github' }) },
     { kind: ['stats'], label: 'Stats', icon: BarChart3, onclick: () => navStore.reset({ kind: 'stats' }) },
+    { kind: ['evaluation'], label: 'Evaluation', icon: ClipboardCheck, onclick: () => navStore.reset({ kind: 'evaluation' }) },
   ]
 
   const settingsItem: NavItem = {

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -9,6 +9,7 @@ import type { LoopAgent } from '../../bindings/github.com/Automaat/sybra/interna
 import type { AppSettings, CodexModel, CopilotModel, LoopAgentRun, MonitorReportBinding, VersionInfo } from '../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
 import type { Notification } from '../../bindings/github.com/Automaat/sybra/internal/notification/models.js'
 import type { StatsResponse } from '../../bindings/github.com/Automaat/sybra/internal/stats/models.js'
+import type { Report as EvaluationReportData } from '../../bindings/github.com/Automaat/sybra/internal/evaluation/models.js'
 import type { Definition } from '../../bindings/github.com/Automaat/sybra/internal/workflow/models.js'
 import type { Project as TodoistProject } from '../../bindings/github.com/Automaat/sybra/internal/todoist/models.js'
 import type { Status } from '../../bindings/github.com/Automaat/sybra/internal/provider/models.js'
@@ -53,6 +54,7 @@ export function ResumeInClaudeCode(_arg1: string): Promise<void> { return Promis
 
 // App
 export function GetMonitorReport(): Promise<MonitorReportBinding> { return call('App', 'GetMonitorReport') }
+export function GetEvaluationReport(): Promise<EvaluationReportData> { return call('App', 'GetEvaluationReport') }
 export function ListBackgroundOps(): Promise<Array<any>> { return call('App', 'ListBackgroundOps') }
 export function ListNotifications(): Promise<Array<Notification>> { return call('App', 'ListNotifications') }
 export function RegisterSpotlightHotkey(): Promise<void> { return Promise.reject(new Error('not available in web mode')) }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -51,6 +51,7 @@ export const ResumeInClaudeCode = pick(AgentSvc.ResumeInClaudeCode, http.ResumeI
 
 // App
 export const GetMonitorReport = pick(AppSvc.GetMonitorReport, http.GetMonitorReport)
+export const GetEvaluationReport = pick(AppSvc.GetEvaluationReport, http.GetEvaluationReport)
 export const ListBackgroundOps = pick(AppSvc.ListBackgroundOps, http.ListBackgroundOps)
 export const ListNotifications = pick(AppSvc.ListNotifications, http.ListNotifications)
 export const RegisterSpotlightHotkey = pick(AppSvc.RegisterSpotlightHotkey, http.RegisterSpotlightHotkey)

--- a/frontend/src/lib/navigation.svelte.ts
+++ b/frontend/src/lib/navigation.svelte.ts
@@ -13,6 +13,7 @@ export type Page =
   | { kind: 'agent-detail'; agentId: string }
   | { kind: 'github' }
   | { kind: 'stats' }
+  | { kind: 'evaluation' }
   | { kind: 'reviews' }
   | { kind: 'settings' }
   | { kind: 'workflows' }
@@ -73,6 +74,7 @@ class NavStore {
       case 'agent-detail': return 'Agent Detail'
       case 'github': return 'GitHub'
       case 'stats': return 'Stats'
+      case 'evaluation': return 'Evaluation'
       case 'reviews': return 'Reviews'
       case 'settings': return 'Settings'
       case 'workflows': return 'Workflows'

--- a/frontend/src/pages/Evaluation.svelte
+++ b/frontend/src/pages/Evaluation.svelte
@@ -1,0 +1,191 @@
+<script lang="ts">
+  import { evaluationStore } from '../stores/evaluation.svelte.js'
+
+  $effect(() => {
+    evaluationStore.load()
+  })
+
+  const report = $derived(evaluationStore.data)
+  const o = $derived(report?.overall ?? null)
+
+  function pct(x: number | undefined): string {
+    return x === undefined ? '—' : `${(x * 100).toFixed(0)}%`
+  }
+  function hours(x: number | undefined): string {
+    return x === undefined ? '—' : `${x.toFixed(1)}h`
+  }
+  function num(x: number | undefined, digits = 1): string {
+    return x === undefined ? '—' : x.toFixed(digits)
+  }
+  // Higher is better for these; render the bar/colour accordingly.
+  function goodScale(x: number): string {
+    if (x >= 0.8) return 'text-success-600 dark:text-success-400'
+    if (x >= 0.5) return 'text-warning-600 dark:text-warning-400'
+    return 'text-error-600 dark:text-error-400'
+  }
+  function sevClasses(sev: string): string {
+    return sev === 'warn'
+      ? 'bg-warning-200 text-warning-800 dark:bg-warning-800 dark:text-warning-200'
+      : 'bg-surface-200 text-surface-700 dark:bg-surface-700 dark:text-surface-200'
+  }
+</script>
+
+<div class="flex flex-col gap-4 p-4 md:gap-6 md:p-6">
+  <div class="flex items-center justify-between">
+    <p class="text-xs text-surface-400">
+      {#if report}
+        Fleet scorecard · last {o?.windowDays ?? 0} days
+      {/if}
+    </p>
+    <button
+      type="button"
+      class="rounded-lg bg-surface-200 px-3 py-1.5 text-sm font-medium hover:bg-surface-300 dark:bg-surface-700 dark:hover:bg-surface-600"
+      onclick={() => evaluationStore.load()}
+    >
+      Refresh
+    </button>
+  </div>
+
+  {#if evaluationStore.error}
+    <p class="text-error-500">{evaluationStore.error}</p>
+  {/if}
+
+  {#if o}
+    <!-- Headline scorecard -->
+    <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
+      <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <span class="text-xs font-medium text-surface-500">Tasks landed</span>
+        <p class="mt-1 text-2xl font-bold">{o.tasksLanded}</p>
+        <p class="mt-0.5 text-xs text-surface-400">{o.merged} merged · {o.closed} closed</p>
+      </div>
+      <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <span class="text-xs font-medium text-surface-500">Autonomy</span>
+        <p class="mt-1 text-2xl font-bold {goodScale(o.autonomyRate)}">{pct(o.autonomyRate)}</p>
+        <p class="mt-0.5 text-xs text-surface-400">{o.humanTouchedLandings} needed a human</p>
+      </div>
+      <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <span class="text-xs font-medium text-surface-500">CI first pass</span>
+        <p class="mt-1 text-2xl font-bold {goodScale(o.ciFirstPassRate)}">{pct(o.ciFirstPassRate)}</p>
+      </div>
+      <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <span class="text-xs font-medium text-surface-500">Failure rate</span>
+        <p class="mt-1 text-2xl font-bold {goodScale(1 - o.failureRate)}">{pct(o.failureRate)}</p>
+        <p class="mt-0.5 text-xs text-surface-400">{o.agentFailures}/{o.agentRuns} runs</p>
+      </div>
+      <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <span class="text-xs font-medium text-surface-500">Cost / landed</span>
+        <p class="mt-1 text-2xl font-bold">${num(o.costPerLanded, 2)}</p>
+        <p class="mt-0.5 text-xs text-surface-400">${num(o.totalCostUsd, 2)} total</p>
+      </div>
+      <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <span class="text-xs font-medium text-surface-500">Rework tasks</span>
+        <p class="mt-1 text-2xl font-bold">{o.reworkTasks}</p>
+      </div>
+    </div>
+
+    <!-- Throughput & efficiency detail -->
+    <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+      <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <h3 class="mb-3 text-sm font-semibold text-surface-500">Cycle time</h3>
+        <table class="w-full text-sm">
+          <tbody>
+            <tr class="border-b border-surface-100 dark:border-surface-700">
+              <td class="py-1.5 text-surface-500">Lead time (created → landed)</td>
+              <td class="py-1.5 text-right">p50 {hours(o.leadTimeP50H)} · p90 {hours(o.leadTimeP90H)}</td>
+            </tr>
+            <tr>
+              <td class="py-1.5 text-surface-500">Cycle time (first run → landed)</td>
+              <td class="py-1.5 text-right">p50 {hours(o.cycleTimeP50H)} · p90 {hours(o.cycleTimeP90H)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <h3 class="mb-3 text-sm font-semibold text-surface-500">Effort per landed PR</h3>
+        <table class="w-full text-sm">
+          <tbody>
+            <tr class="border-b border-surface-100 dark:border-surface-700">
+              <td class="py-1.5 text-surface-500">Turns / landed</td>
+              <td class="py-1.5 text-right">{num(o.turnsPerLanded)}</td>
+            </tr>
+            <tr>
+              <td class="py-1.5 text-surface-500">Tools / landed</td>
+              <td class="py-1.5 text-right">{num(o.toolsPerLanded)}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Weaknesses / feedback loop -->
+    {#if report?.weaknesses && report.weaknesses.length > 0}
+      <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <h3 class="mb-3 text-sm font-semibold text-surface-500">What to improve</h3>
+        <ul class="flex flex-col gap-3">
+          {#each report.weaknesses as w (w.metric)}
+            <li class="flex flex-col gap-1">
+              <div class="flex items-center gap-2">
+                <span class="rounded px-1.5 py-0.5 text-xs {sevClasses(w.severity)}">{w.metric}</span>
+                <span class="text-sm">{w.detail}</span>
+              </div>
+              <p class="pl-1 text-xs text-surface-400">→ {w.suggestion}</p>
+            </li>
+          {/each}
+        </ul>
+      </div>
+    {/if}
+
+    <!-- Breakdowns -->
+    <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+      {#each [
+        { title: 'By Provider', data: report?.byProvider },
+        { title: 'By Role', data: report?.byRole },
+      ] as section (section.title)}
+        <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+          <h3 class="mb-3 text-sm font-semibold text-surface-500">{section.title}</h3>
+          {#if section.data && section.data.length > 0}
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="border-b border-surface-200 text-left text-xs text-surface-400 dark:border-surface-700">
+                  <th class="pb-2">Name</th>
+                  <th class="pb-2 text-right">Runs</th>
+                  <th class="pb-2 text-right">Fail %</th>
+                  <th class="pb-2 text-right">Cost</th>
+                  <th class="pb-2 text-right">Turns</th>
+                  <th class="pb-2 text-right">Tools</th>
+                </tr>
+              </thead>
+              <tbody>
+                {#each section.data as row (row.key)}
+                  <tr class="border-b border-surface-100 last:border-0 dark:border-surface-700">
+                    <td class="py-1.5 font-mono text-xs">{row.key}</td>
+                    <td class="py-1.5 text-right">{row.runs}</td>
+                    <td class="py-1.5 text-right">{pct(row.failureRate)}</td>
+                    <td class="py-1.5 text-right">${row.totalCostUsd.toFixed(2)}</td>
+                    <td class="py-1.5 text-right text-surface-400">{row.turns}</td>
+                    <td class="py-1.5 text-right text-surface-400">{row.tools}</td>
+                  </tr>
+                {/each}
+              </tbody>
+            </table>
+          {:else}
+            <p class="text-xs text-surface-400">No data</p>
+          {/if}
+        </div>
+      {/each}
+    </div>
+
+    {#if report?.notes && report.notes.length > 0}
+      <div class="rounded-lg border border-dashed border-surface-300 p-4 text-xs text-surface-400 dark:border-surface-600">
+        <p class="mb-1 font-semibold">Deferred metrics</p>
+        <ul class="list-inside list-disc">
+          {#each report.notes as note (note)}
+            <li>{note}</li>
+          {/each}
+        </ul>
+      </div>
+    {/if}
+  {:else if !evaluationStore.error}
+    <p class="text-sm text-surface-400">No evaluation data yet.</p>
+  {/if}
+</div>

--- a/frontend/src/pages/Evaluation.svelte
+++ b/frontend/src/pages/Evaluation.svelte
@@ -1,12 +1,20 @@
 <script lang="ts">
   import { evaluationStore } from '../stores/evaluation.svelte.js'
 
+  const report = $derived(evaluationStore.data)
+  // A zero-value Report (service disabled / no data yet) still has a non-null
+  // overall, which would render as a measured "0% / failing" fleet. Treat it as
+  // no-data unless there's at least one run or landing in the window.
+  const hasData = $derived(
+    !!report && !!report.overall && (report.overall.agentRuns > 0 || report.overall.tasksLanded > 0),
+  )
+  const o = $derived(hasData && report ? report.overall : null)
+
   $effect(() => {
     evaluationStore.load()
+    evaluationStore.listen()
+    return () => evaluationStore.stopListening()
   })
-
-  const report = $derived(evaluationStore.data)
-  const o = $derived(report?.overall ?? null)
 
   function pct(x: number | undefined): string {
     return x === undefined ? '—' : `${(x * 100).toFixed(0)}%`
@@ -33,16 +41,17 @@
 <div class="flex flex-col gap-4 p-4 md:gap-6 md:p-6">
   <div class="flex items-center justify-between">
     <p class="text-xs text-surface-400">
-      {#if report}
-        Fleet scorecard · last {o?.windowDays ?? 0} days
+      {#if o}
+        Fleet scorecard · last {o.windowDays} days
       {/if}
     </p>
     <button
       type="button"
-      class="rounded-lg bg-surface-200 px-3 py-1.5 text-sm font-medium hover:bg-surface-300 dark:bg-surface-700 dark:hover:bg-surface-600"
+      class="rounded-lg bg-surface-200 px-3 py-1.5 text-sm font-medium hover:bg-surface-300 disabled:opacity-50 dark:bg-surface-700 dark:hover:bg-surface-600"
+      disabled={evaluationStore.loading}
       onclick={() => evaluationStore.load()}
     >
-      Refresh
+      {evaluationStore.loading ? 'Loading…' : 'Refresh'}
     </button>
   </div>
 

--- a/frontend/src/stores/evaluation.svelte.ts
+++ b/frontend/src/stores/evaluation.svelte.ts
@@ -1,0 +1,38 @@
+import { GetEvaluationReport, EventsOn } from '$lib/api'
+import { EvaluationReport } from '../lib/events.js'
+import type { Report } from '../../bindings/github.com/Automaat/sybra/internal/evaluation/models.js'
+
+class EvaluationStore {
+  data = $state<Report | null>(null)
+  loading = $state(false)
+  error = $state('')
+  private cancelListener: (() => void) | null = null
+
+  async load(): Promise<void> {
+    this.loading = true
+    this.error = ''
+    try {
+      this.data = await GetEvaluationReport()
+    } catch (e) {
+      this.error = String(e)
+    } finally {
+      this.loading = false
+    }
+  }
+
+  listen(): void {
+    this.stopListening()
+    this.cancelListener = EventsOn(EvaluationReport, (report: Report) => {
+      this.data = report
+    })
+  }
+
+  stopListening(): void {
+    if (this.cancelListener) {
+      this.cancelListener()
+      this.cancelListener = null
+    }
+  }
+}
+
+export const evaluationStore = new EvaluationStore()

--- a/internal/evaluation/scorecard.go
+++ b/internal/evaluation/scorecard.go
@@ -74,6 +74,7 @@ type Report struct {
 	Overall     Scorecard   `json:"overall"`
 	ByProvider  []Breakdown `json:"byProvider,omitempty"`
 	ByRole      []Breakdown `json:"byRole,omitempty"`
+	Weaknesses  []Weakness  `json:"weaknesses,omitempty"`
 	Notes       []string    `json:"notes,omitempty"`
 }
 

--- a/internal/evaluation/service.go
+++ b/internal/evaluation/service.go
@@ -146,7 +146,7 @@ func (s *Service) Scan(_ context.Context) (Report, error) {
 	if s.stats != nil {
 		recs = s.stats.All()
 	}
-	return Report{
+	rep := Report{
 		GeneratedAt: now,
 		Since:       since,
 		Until:       now,
@@ -154,7 +154,9 @@ func (s *Service) Scan(_ context.Context) (Report, error) {
 		ByProvider:  BreakdownBy(recs, since, now, func(r stats.RunRecord) string { return r.Provider }),
 		ByRole:      BreakdownBy(recs, since, now, func(r stats.RunRecord) string { return r.Role }),
 		Notes:       deferredNotes,
-	}, nil
+	}
+	rep.Weaknesses = Weaknesses(rep)
+	return rep, nil
 }
 
 // reportCacheTTL bounds how stale an on-demand report may be. When the ticker

--- a/internal/evaluation/weakness.go
+++ b/internal/evaluation/weakness.go
@@ -1,6 +1,9 @@
 package evaluation
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+)
 
 // Weakness is one systematic shortfall the scorecard surfaces, paired with a
 // concrete suggested action — the deterministic half of the improvement loop.
@@ -66,7 +69,24 @@ func Weaknesses(r Report) []Weakness {
 
 	out = append(out, outlierWeaknesses(r.ByProvider, o.FailureRate, "provider")...)
 	out = append(out, outlierWeaknesses(r.ByRole, o.FailureRate, "role")...)
+
+	// Rank by severity (warn before info), stable within a severity so the
+	// detection order is preserved for equal-severity entries.
+	sort.SliceStable(out, func(i, j int) bool {
+		return severityRank(out[i].Severity) < severityRank(out[j].Severity)
+	})
 	return out
+}
+
+func severityRank(sev string) int {
+	switch sev {
+	case "warn":
+		return 0
+	case "info":
+		return 1
+	default:
+		return 2
+	}
 }
 
 // outlierWeaknesses flags any breakdown group whose failure rate exceeds the

--- a/internal/evaluation/weakness.go
+++ b/internal/evaluation/weakness.go
@@ -1,0 +1,89 @@
+package evaluation
+
+import "fmt"
+
+// Weakness is one systematic shortfall the scorecard surfaces, paired with a
+// concrete suggested action — the deterministic half of the improvement loop.
+type Weakness struct {
+	Severity   string `json:"severity"` // "warn" | "info"
+	Metric     string `json:"metric"`
+	Detail     string `json:"detail"`
+	Suggestion string `json:"suggestion"`
+}
+
+// Signal gates: don't emit weaknesses from a near-empty window, where a single
+// task or run swings every ratio.
+const (
+	minLandedForSignal = 3
+	minRunsForSignal   = 5
+	// outlierMargin is how far a provider/role failure rate must exceed the
+	// overall before it's flagged as a systematic outlier.
+	outlierMargin = 0.15
+)
+
+// Weaknesses inspects a report and returns ranked systematic weaknesses, each
+// with a suggested action. Empty when there is too little data or nothing
+// stands out. Pure and deterministic.
+func Weaknesses(r Report) []Weakness {
+	var out []Weakness
+	o := r.Overall
+
+	if o.TasksLanded >= minLandedForSignal {
+		if o.AutonomyRate < 0.7 {
+			out = append(out, Weakness{
+				Severity:   "warn",
+				Metric:     "autonomy",
+				Detail:     fmt.Sprintf("%.0f%% of landings needed a human touch", (1-o.AutonomyRate)*100),
+				Suggestion: "review what escalated to human-required; tighten triage so more tasks run headless end-to-end",
+			})
+		}
+		if o.CIFirstPassRate < 0.6 {
+			out = append(out, Weakness{
+				Severity:   "warn",
+				Metric:     "ci_first_pass",
+				Detail:     fmt.Sprintf("only %.0f%% of landings passed CI on the first push", o.CIFirstPassRate*100),
+				Suggestion: "have the implementation agent run the full test/lint suite before pushing",
+			})
+		}
+		if rework := float64(o.ReworkTasks) / float64(o.TasksLanded); rework > 0.3 {
+			out = append(out, Weakness{
+				Severity:   "info",
+				Metric:     "rework",
+				Detail:     fmt.Sprintf("%.0f%% of landed tasks bounced between statuses", rework*100),
+				Suggestion: "strengthen plan-review so tasks converge in fewer rounds",
+			})
+		}
+	}
+
+	if o.AgentRuns >= minRunsForSignal && o.FailureRate > 0.2 {
+		out = append(out, Weakness{
+			Severity:   "warn",
+			Metric:     "failure_rate",
+			Detail:     fmt.Sprintf("%.0f%% of agent runs failed", o.FailureRate*100),
+			Suggestion: "investigate the failing roles/providers below; check guardrails and prompts",
+		})
+	}
+
+	out = append(out, outlierWeaknesses(r.ByProvider, o.FailureRate, "provider")...)
+	out = append(out, outlierWeaknesses(r.ByRole, o.FailureRate, "role")...)
+	return out
+}
+
+// outlierWeaknesses flags any breakdown group whose failure rate exceeds the
+// overall by more than outlierMargin, given enough runs.
+func outlierWeaknesses(groups []Breakdown, overallFailure float64, dimension string) []Weakness {
+	var out []Weakness
+	for i := range groups {
+		b := groups[i]
+		if b.Runs < minRunsForSignal || b.FailureRate <= overallFailure+outlierMargin {
+			continue
+		}
+		out = append(out, Weakness{
+			Severity:   "info",
+			Metric:     dimension + ":" + b.Key,
+			Detail:     fmt.Sprintf("%s %s fails %.0f%% vs %.0f%% overall", dimension, b.Key, b.FailureRate*100, overallFailure*100),
+			Suggestion: fmt.Sprintf("review the %s %s prompt/guardrails or route work away from it", dimension, b.Key),
+		})
+	}
+	return out
+}

--- a/internal/evaluation/weakness_test.go
+++ b/internal/evaluation/weakness_test.go
@@ -38,6 +38,15 @@ func TestWeaknesses_FlagsShortfalls(t *testing.T) {
 	if hasMetric(ws, "provider:claude") {
 		t.Errorf("claude is not an outlier; should not be flagged")
 	}
+	// Ranked: all warn-severity weaknesses precede any info-severity ones.
+	seenInfo := false
+	for _, w := range ws {
+		if w.Severity == "info" {
+			seenInfo = true
+		} else if w.Severity == "warn" && seenInfo {
+			t.Errorf("unranked: warn %q appears after an info weakness", w.Metric)
+		}
+	}
 }
 
 func TestWeaknesses_HealthyAndLowData(t *testing.T) {

--- a/internal/evaluation/weakness_test.go
+++ b/internal/evaluation/weakness_test.go
@@ -1,0 +1,74 @@
+package evaluation
+
+import (
+	"strings"
+	"testing"
+)
+
+func hasMetric(ws []Weakness, metric string) bool {
+	for _, w := range ws {
+		if w.Metric == metric {
+			return true
+		}
+	}
+	return false
+}
+
+func TestWeaknesses_FlagsShortfalls(t *testing.T) {
+	r := Report{
+		Overall: Scorecard{
+			TasksLanded:     10,
+			AutonomyRate:    0.4, // < 0.7 → autonomy
+			CIFirstPassRate: 0.5, // < 0.6 → ci_first_pass
+			ReworkTasks:     5,   // 5/10 = 0.5 > 0.3 → rework
+			AgentRuns:       20,
+			FailureRate:     0.3, // > 0.2 → failure_rate
+		},
+		ByProvider: []Breakdown{
+			{Key: "codex", Runs: 10, FailureRate: 0.6}, // 0.6 > 0.3+0.15 → outlier
+			{Key: "claude", Runs: 10, FailureRate: 0.3},
+		},
+	}
+	ws := Weaknesses(r)
+	for _, m := range []string{"autonomy", "ci_first_pass", "rework", "failure_rate", "provider:codex"} {
+		if !hasMetric(ws, m) {
+			t.Errorf("expected weakness %q, got %+v", m, ws)
+		}
+	}
+	if hasMetric(ws, "provider:claude") {
+		t.Errorf("claude is not an outlier; should not be flagged")
+	}
+}
+
+func TestWeaknesses_HealthyAndLowData(t *testing.T) {
+	// Healthy fleet with enough data → no weaknesses.
+	healthy := Report{Overall: Scorecard{
+		TasksLanded: 10, AutonomyRate: 0.95, CIFirstPassRate: 0.9, ReworkTasks: 0,
+		AgentRuns: 20, FailureRate: 0.05,
+	}}
+	if ws := Weaknesses(healthy); len(ws) != 0 {
+		t.Errorf("healthy fleet flagged: %+v", ws)
+	}
+
+	// Too little data → gates suppress everything despite bad ratios.
+	sparse := Report{Overall: Scorecard{
+		TasksLanded: 1, AutonomyRate: 0, CIFirstPassRate: 0, ReworkTasks: 1,
+		AgentRuns: 1, FailureRate: 1,
+	}}
+	if ws := Weaknesses(sparse); len(ws) != 0 {
+		t.Errorf("sparse window flagged (should be gated): %+v", ws)
+	}
+}
+
+func TestWeaknesses_SuggestionsPresent(t *testing.T) {
+	r := Report{Overall: Scorecard{TasksLanded: 10, AutonomyRate: 0.1, CIFirstPassRate: 1, AgentRuns: 10}}
+	ws := Weaknesses(r)
+	if len(ws) == 0 {
+		t.Fatal("expected at least one weakness")
+	}
+	for _, w := range ws {
+		if strings.TrimSpace(w.Suggestion) == "" {
+			t.Errorf("weakness %q has no suggestion", w.Metric)
+		}
+	}
+}


### PR DESCRIPTION
## Motivation

Closes #1069. The visible + actionable half of the evaluation umbrella (#1065): surface the fleet scorecard (#1067) and judge-ready data, and turn it into concrete next steps.

> Changelog: feat(eval): dashboard + improvement feedback loop

## Implementation information

**Dashboard** — new Evaluation page (Svelte 5), reachable from the side rail and the more sheet:
- Headline scorecard cards (tasks landed, autonomy, CI-first-pass, failure rate, cost/landed, rework), colour-scaled good→bad.
- Cycle-time and effort-per-landed detail; per-provider and per-role breakdown tables.
- Live-refreshes on the `evaluation:report` event (listener wired into the page lifecycle) and on manual Refresh; an empty fleet shows a no-data state rather than zeros-as-measured.

**Feedback loop** — `internal/evaluation/weakness.go`:
- `Weaknesses()` inspects the report and returns ranked systematic shortfalls (low autonomy, low CI-first-pass, high failure/rework, per-provider and per-role failure outliers), each with a concrete suggested action.
- Gated by minimum landings/runs so a near-empty window stays quiet.
- Rolled into `Report.Weaknesses`; rendered on the dashboard and printed by `sybra-cli evaluation scan`.

`GetEvaluationReport` is re-exported through the api shim (desktop + web).

Adversarial review applied before review: the empty-fleet zeros-as-data display and the never-wired live-refresh listener were both fixed; loading state added.

## Supporting documentation

- Umbrella #1065; builds on #1066, #1067, #1068.

Gates: `golangci-lint run ./...`, `go test ./...`, `oxlint`, `svelte-check`, `hadolint` pass (one pre-existing flaky agent shutdown-timing test passes on rerun).
