### PR TITLE
fix(workflow): make renovate/pr-fix flow fast and bounded

### DIFF
--- a/internal/github/debounce.go
+++ b/internal/github/debounce.go
@@ -7,6 +7,10 @@ import (
 
 const maxRetries = 3
 
+// MaxRetries is the exported retry cap for callers that need to reference it
+// in escalation messages or tests.
+const MaxRetries = maxRetries
+
 // IssueTracker prevents re-dispatching agents for the same PR issue
 // within a cooldown period and caps total retries.
 type IssueTracker struct {
@@ -93,13 +97,29 @@ func (t *IssueTracker) Retries(taskID string, kind PRIssueKind) int {
 	return t.retries[issueKey(taskID, kind)]
 }
 
-// Cleanup removes entries older than 2x cooldown.
+// AtCap reports whether the task+issue has exhausted its retry budget.
+func (t *IssueTracker) AtCap(taskID string, kind PRIssueKind) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.retries[issueKey(taskID, kind)] >= maxRetries
+}
+
+// Cleanup removes entries older than 2x cooldown. Entries that have hit the
+// retry cap are kept so the escalation path in the caller survives long gaps
+// between flaky CI runs — without this, Cleanup would reset the counter and
+// the cap would never fire.
 func (t *IssueTracker) Cleanup() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	cutoff := t.now().Add(-2 * t.cooldown)
 	for k, v := range t.handled {
 		if v.Before(cutoff) {
+			if t.retries[k] >= maxRetries {
+				// At cap: keep retries/lastSHA so the caller can escalate;
+				// only drop the time-based handled entry (no more cooldown).
+				delete(t.handled, k)
+				continue
+			}
 			delete(t.handled, k)
 			delete(t.retries, k)
 			delete(t.lastSHA, k)

--- a/internal/github/debounce_test.go
+++ b/internal/github/debounce_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -133,6 +134,32 @@ func TestIssueTracker(t *testing.T) {
 		}
 		if tracker.Retries("t3", PRIssueConflict) != 0 {
 			t.Fatal("expected retries cleaned up")
+		}
+	})
+
+	t.Run("cleanup preserves retries at cap across long gaps", func(t *testing.T) {
+		// Simulate maxRetries attempts, each on a new SHA and after cooldown.
+		now = time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+		sha := "cap-sha-0"
+		for i := range maxRetries {
+			tracker.MarkHandled("t8", PRIssueCIFailure, sha)
+			sha = fmt.Sprintf("cap-sha-%d", i+1)
+			now = now.Add(31 * time.Minute)
+		}
+		// Cleanup runs after 2x cooldown — but retry counter must survive.
+		now = now.Add(61 * time.Minute)
+		tracker.Cleanup()
+
+		// AtCap must still be true so the caller can escalate.
+		if !tracker.AtCap("t8", PRIssueCIFailure) {
+			t.Fatal("expected AtCap=true after cleanup with capped entry")
+		}
+		if tracker.Retries("t8", PRIssueCIFailure) != maxRetries {
+			t.Fatalf("expected retries=%d after cleanup, got %d", maxRetries, tracker.Retries("t8", PRIssueCIFailure))
+		}
+		// ShouldHandle must still be false.
+		if tracker.ShouldHandle("t8", PRIssueCIFailure, sha) {
+			t.Fatal("expected ShouldHandle=false: still at cap after cleanup")
 		}
 	})
 }

--- a/internal/sybra/app_external_task_test.go
+++ b/internal/sybra/app_external_task_test.go
@@ -94,4 +94,25 @@ func TestApp_MaybeStartWorkflowForExternalTask(t *testing.T) {
 	// no-op (and must not panic).
 	app.maybeStartWorkflowForExternalTask(filepath.Join(app.tasksDir, "ext-todo.plan.md"))
 	app.wg.Wait()
+
+	// pr-fix task (RunRole set): must NOT trigger task.created workflow — these
+	// are driven by pr.event. Without this guard, simple-task-plan would claim
+	// the workflow slot and prevent the pr-fix workflow from starting.
+	prfixPath := write("ext-prfix", task.StatusTodo)
+	if _, err := app.tasks.UpdateMap("ext-prfix", map[string]any{
+		"run_role":  "pr-fix",
+		"pr_number": 42,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	app.tasks.OnExternalUpdate(prfixPath)
+	app.maybeStartWorkflowForExternalTask(prfixPath)
+	app.wg.Wait()
+	pk, err := app.tasks.Get("ext-prfix")
+	if err != nil {
+		t.Fatalf("get ext-prfix: %v", err)
+	}
+	if pk.Workflow != nil {
+		t.Errorf("pr-fix task: expected no task.created workflow, got %+v", pk.Workflow)
+	}
 }

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -226,6 +226,12 @@ func (a *App) maybeStartWorkflowForExternalTask(path string) {
 		if t.Status != task.StatusNew && t.Status != task.StatusTodo {
 			return
 		}
+		// pr-fix / existing-PR tasks are driven by pr.event, not task.created.
+		// Skipping here prevents simple-task-plan from claiming the workflow
+		// slot before the DispatchEvent("pr.event") call in FixRenovateCI.
+		if t.RunRole != "" || t.PRNumber > 0 {
+			return
+		}
 		if t.Workflow != nil &&
 			t.Workflow.State != "" &&
 			t.Workflow.State != workflow.ExecCompleted &&

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -2,6 +2,7 @@ package sybra
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"slices"
 	"strings"
@@ -163,6 +164,7 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 				continue
 			}
 			if !r.prTracker.ShouldHandle(issues[i].TaskID, issues[i].Kind, issues[i].PR.HeadSHA) {
+				r.maybeEscalateRetryCap(issues[i].TaskID, issues[i].Kind)
 				continue
 			}
 			if issues[i].Kind == github.PRIssueReadyToMerge {
@@ -263,6 +265,27 @@ func earliestRunStart(runs []task.AgentRun) time.Time {
 		}
 	}
 	return earliest
+}
+
+// maybeEscalateRetryCap flips a task to human-required when its retry budget is
+// exhausted. Removes the task from the tracker so it does not re-trigger.
+func (r *ReviewHandler) maybeEscalateRetryCap(taskID string, kind github.PRIssueKind) {
+	if !r.prTracker.AtCap(taskID, kind) {
+		return
+	}
+	reason := fmt.Sprintf(
+		"pr-monitor: CI fix attempted %d× without going green (likely flaky infra or unfixable) — needs human",
+		github.MaxRetries,
+	)
+	if _, uerr := r.tasks.Update(taskID, task.Update{
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr(reason),
+	}); uerr != nil {
+		r.logger.Error("pr-monitor.retry-cap.escalate", "task_id", taskID, "err", uerr)
+		return
+	}
+	r.logger.Info("pr-monitor.retry-cap", "task_id", taskID, "kind", string(kind))
+	r.prTracker.Clear(taskID, kind)
 }
 
 // cancelResolvedPRFixWorkflows terminates any in-flight pr-fix workflow

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -98,9 +98,12 @@ func (r *ReviewHandler) handlePRIssue(issue github.PRIssue) {
 			"Fix failing CI on branch `%s` (PR #%d). "+
 				"Check the failing run with `gh run view --log-failed`, "+
 				"fix the code, commit and push. No unrelated changes.\n\n"+
-				"Push directly to origin so the fix lands on the existing PR:\n"+
+				"Push to the same remote the PR was opened from — never to `origin` "+
+				"when a `fork` remote exists:\n"+
 				"```sh\n"+
-				"git push origin HEAD:%s\n"+
+				"PUSH_REMOTE=origin\n"+
+				"if git config --get remote.fork.url >/dev/null; then PUSH_REMOTE=fork; fi\n"+
+				"git push \"$PUSH_REMOTE\" HEAD:%s\n"+
 				"```",
 			issue.PR.HeadRefName, issue.PR.Number, issue.PR.HeadRefName,
 		)

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -98,14 +98,15 @@ func (r *ReviewHandler) handlePRIssue(issue github.PRIssue) {
 			"Fix failing CI on branch `%s` (PR #%d). "+
 				"Check the failing run with `gh run view --log-failed`, "+
 				"fix the code, commit and push. No unrelated changes.\n\n"+
-				"Push to the same remote the PR was opened from — never to `origin` "+
-				"when a `fork` remote exists:\n"+
+				"Push to the remote that hosts the PR's head branch:\n"+
 				"```sh\n"+
 				"PUSH_REMOTE=origin\n"+
-				"if git config --get remote.fork.url >/dev/null; then PUSH_REMOTE=fork; fi\n"+
+				"PR_HEAD=\"$(gh pr view %d --json headRepository --jq '.headRepository.nameWithOwner')\"\n"+
+				"FORK_URL=\"$(git config --get remote.fork.url 2>/dev/null || true)\"\n"+
+				"if [ -n \"$FORK_URL\" ] && echo \"$FORK_URL\" | grep -qF \"$PR_HEAD\"; then PUSH_REMOTE=fork; fi\n"+
 				"git push \"$PUSH_REMOTE\" HEAD:%s\n"+
 				"```",
-			issue.PR.HeadRefName, issue.PR.Number, issue.PR.HeadRefName,
+			issue.PR.HeadRefName, issue.PR.Number, issue.PR.Number, issue.PR.HeadRefName,
 		)
 		r.logAudit(audit.EventPRCIFailureDetected, t.ID, "", map[string]any{
 			"pr": issue.PR.Number, "repo": issue.PR.Repository,

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -98,13 +98,9 @@ func (r *ReviewHandler) handlePRIssue(issue github.PRIssue) {
 			"Fix failing CI on branch `%s` (PR #%d). "+
 				"Check the failing run with `gh run view --log-failed`, "+
 				"fix the code, commit and push. No unrelated changes.\n\n"+
-				"Push to the same remote the PR was opened from — never "+
-				"to `origin` when a `fork` remote exists:\n"+
+				"Push directly to origin so the fix lands on the existing PR:\n"+
 				"```sh\n"+
-				"PUSH_REMOTE=origin\n"+
-				"if git config --get remote.fork.url >/dev/null; then "+
-				"PUSH_REMOTE=fork; fi\n"+
-				"git push \"$PUSH_REMOTE\" HEAD:%s\n"+
+				"git push origin HEAD:%s\n"+
 				"```",
 			issue.PR.HeadRefName, issue.PR.Number, issue.PR.HeadRefName,
 		)

--- a/internal/sybra/svc_integrations.go
+++ b/internal/sybra/svc_integrations.go
@@ -103,22 +103,16 @@ func (s *IntegrationService) FixRenovateCI(repo string, number int, branch, titl
 	}
 
 	prURL := fmt.Sprintf("https://github.com/%s/pull/%d", repo, number)
-	t, err := s.tasks.Create("Fix CI: "+title, prURL, "headless")
-	if err != nil {
-		return fmt.Errorf("create task: %w", err)
-	}
-
 	tags := []string{"renovate-fix"}
-	if _, err := s.tasks.Update(t.ID, task.Update{
+	t, err := s.tasks.CreateFull("Fix CI: "+title, prURL, "headless", task.Update{
 		ProjectID: task.Ptr(repo),
 		PRNumber:  task.Ptr(number),
 		Tags:      &tags,
 		RunRole:   task.Ptr("pr-fix"),
-	}); err != nil {
-		return fmt.Errorf("update task: %w", err)
+	})
+	if err != nil {
+		return fmt.Errorf("create task: %w", err)
 	}
-
-	t, _ = s.tasks.Get(t.ID)
 
 	dir := ""
 	if t.ProjectID != "" {

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -93,6 +93,10 @@ func (s *TaskService) startCreatedWorkflow(t task.Task) {
 	if s.workflowEngine == nil || t.Status != task.StatusTodo {
 		return
 	}
+	// pr-fix / existing-PR tasks are driven by pr.event, not task.created.
+	if t.RunRole != "" || t.PRNumber > 0 {
+		return
+	}
 	info := taskToInfo(t)
 	if def := s.workflowEngine.MatchWorkflow(info, "task.created"); def != nil {
 		s.logger.Info("workflow.auto-start", "task_id", t.ID, "workflow", def.ID)

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -170,6 +170,19 @@ func (m *Manager) Create(title, body, mode string) (Task, error) {
 	return t, nil
 }
 
+// CreateFull persists a new task with initial field overrides applied atomically
+// before the first emit, ensuring file-watchers see a complete task from the start.
+func (m *Manager) CreateFull(title, body, mode string, init Update) (Task, error) {
+	t, err := m.store.CreateFull(title, body, mode, init)
+	if err != nil {
+		return t, err
+	}
+	metrics.TaskCreated()
+	m.recordFiredStatus(t.ID, string(t.Status))
+	m.emitter.Emit(events.TaskCreated, t.FilePath)
+	return t, nil
+}
+
 // CreateChat persists a synthetic chat task and emits task:created.
 func (m *Manager) CreateChat(projectID string) (Task, error) {
 	t, err := m.store.CreateChat(projectID)

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -299,6 +299,62 @@ func (s *Store) Create(title, body, mode string) (Task, error) {
 	return t, nil
 }
 
+// CreateFull persists a new task with optional initial field overrides applied
+// atomically in the first write. Use this instead of Create+Update when the
+// caller needs fields like RunRole, PRNumber, Tags, or ProjectID present before
+// any file-watcher can read the task — avoiding the race where watcher picks up
+// the bare task before the caller's Update applies.
+func (s *Store) CreateFull(title, body, mode string, init Update) (Task, error) {
+	if mode == "" {
+		mode = AgentModeInteractive
+	}
+	if _, err := ValidateAgentMode(mode); err != nil {
+		return Task{}, err
+	}
+	now := time.Now().UTC()
+	id := uuid.NewString()[:8]
+	t := Task{
+		ID:        id,
+		Slug:      Slugify(title),
+		Title:     title,
+		Status:    StatusTodo,
+		TaskType:  TaskTypeNormal,
+		AgentMode: mode,
+		CreatedAt: now,
+		UpdatedAt: now,
+		Body:      body,
+	}
+	// Apply initial field overrides before the first disk write so that any
+	// watcher reading the file sees the complete task from the start.
+	if init.ProjectID != nil {
+		t.ProjectID = *init.ProjectID
+	}
+	if init.PRNumber != nil {
+		t.PRNumber = *init.PRNumber
+	}
+	if init.Tags != nil {
+		t.Tags = *init.Tags
+	}
+	if init.RunRole != nil {
+		t.RunRole = *init.RunRole
+	}
+	if init.Body != nil {
+		t.Body = *init.Body
+	}
+
+	data, err := Marshal(t)
+	if err != nil {
+		return Task{}, err
+	}
+	filename := fmt.Sprintf("%s.md", t.ID)
+	t.FilePath = filepath.Join(s.dir, filename)
+	if err := fsutil.AtomicWrite(t.FilePath, data); err != nil {
+		return Task{}, fmt.Errorf("write task file: %w", err)
+	}
+	s.storeTaskCache(t)
+	return t, nil
+}
+
 // CreateChat creates a synthetic chat task bound to projectID. Chat tasks are
 // hidden from the task list UI and never restart on app reboot. The slug is
 // "chat-<8char>" so the worktree DirName is distinctive.

--- a/internal/triage/apply.go
+++ b/internal/triage/apply.go
@@ -71,6 +71,12 @@ func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project
 	}
 
 	status := RouteStatus(v.Size, v.Type, projectType)
+	// pr-fix tasks (system-created to fix an existing PR) must never enter the
+	// planning phase — they go straight to implementation. Override any route
+	// that would park them in planning.
+	if t.RunRole == "pr-fix" || t.PRNumber > 0 {
+		status = task.StatusTodo
+	}
 	updates["status"] = string(status)
 	// No status_reason on successful triage: the field is reserved for
 	// attention-worthy states (monitor/watchdog/blocked), which the UI renders

--- a/internal/triage/apply_test.go
+++ b/internal/triage/apply_test.go
@@ -173,6 +173,64 @@ func TestApplyWorkProjectForcesInteractiveAndPlanning(t *testing.T) {
 	}
 }
 
+func TestApplyPRFixRunRoleNeverPlanning(t *testing.T) {
+	mgr := newTestManager(t)
+	// Create a work-project task that would normally go to planning.
+	created, err := mgr.Create("Fix CI: bump lodash", "https://github.com/myco/work-repo/pull/42", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Pre-set RunRole as FixRenovateCI would via CreateFull.
+	created.RunRole = "pr-fix"
+	created.PRNumber = 42
+
+	projects := []project.Project{
+		{ID: "myco/work-repo", Owner: "myco", Repo: "work-repo", Type: project.ProjectTypeWork},
+	}
+	v := Verdict{
+		Title: "chore(deps): fix CI on bump lodash",
+		Size:  "large",
+		Type:  "feature",
+		Mode:  "headless",
+		Tags:  []string{"backend", "large", "feature"},
+	}
+	updated, err := Apply(mgr, created, v, projects)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	// pr-fix floor must override both work-project → planning and large-feature → planning.
+	if updated.Status != task.StatusTodo {
+		t.Errorf("status: got %s, want todo (pr-fix floor)", updated.Status)
+	}
+}
+
+func TestApplyPRNumberNeverPlanning(t *testing.T) {
+	mgr := newTestManager(t)
+	created, err := mgr.Create("Fix some CI", "https://github.com/myco/work-repo/pull/7", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	created.PRNumber = 7
+
+	projects := []project.Project{
+		{ID: "myco/work-repo", Owner: "myco", Repo: "work-repo", Type: project.ProjectTypeWork},
+	}
+	v := Verdict{
+		Title: "feat(ci): fix broken pipeline",
+		Size:  "medium",
+		Type:  "feature",
+		Mode:  "headless",
+		Tags:  []string{"ci", "medium", "feature"},
+	}
+	updated, err := Apply(mgr, created, v, projects)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if updated.Status != task.StatusTodo {
+		t.Errorf("status: got %s, want todo (pr_number floor)", updated.Status)
+	}
+}
+
 func TestApplyEmptyBodyFillsDescription(t *testing.T) {
 	mgr := newTestManager(t)
 	created, err := mgr.Create("https://example.com/thing", "", task.AgentModeHeadless)

--- a/internal/triage/apply_test.go
+++ b/internal/triage/apply_test.go
@@ -85,12 +85,12 @@ func TestApplyPreservesEscapeHatchTags(t *testing.T) {
 
 func TestApplyKeepsClassifierEmittedNoplanOnWorkProject(t *testing.T) {
 	mgr := newTestManager(t)
-	created, err := mgr.Create("bump dep on work repo", "https://github.com/myco/work-repo/pull/9", task.AgentModeHeadless)
+	created, err := mgr.Create("bump dep on work repo", "https://github.com/example-org/example-repo/pull/9", task.AgentModeHeadless)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	projects := []project.Project{
-		{ID: "myco/work-repo", Owner: "myco", Repo: "work-repo", Type: project.ProjectTypeWork},
+		{ID: "example-org/example-repo", Owner: "example-org", Repo: "example-repo", Type: project.ProjectTypeWork},
 	}
 	// Headline case: the classifier itself emits noplan for a trivially
 	// mechanical work-typed task. Run the full emit→validate→apply path (the
@@ -144,12 +144,12 @@ func TestApplyMediumFeatureGoesToPlanning(t *testing.T) {
 
 func TestApplyWorkProjectForcesInteractiveAndPlanning(t *testing.T) {
 	mgr := newTestManager(t)
-	created, err := mgr.Create("refactor ingestion", "https://github.com/myco/work-repo/issues/1", task.AgentModeHeadless)
+	created, err := mgr.Create("refactor ingestion", "https://github.com/example-org/example-repo/issues/1", task.AgentModeHeadless)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	projects := []project.Project{
-		{ID: "myco/work-repo", Owner: "myco", Repo: "work-repo", Type: project.ProjectTypeWork},
+		{ID: "example-org/example-repo", Owner: "example-org", Repo: "example-repo", Type: project.ProjectTypeWork},
 	}
 	v := Verdict{
 		Title: "refactor(ingestion): split pipeline stages",
@@ -168,7 +168,7 @@ func TestApplyWorkProjectForcesInteractiveAndPlanning(t *testing.T) {
 	if updated.Status != task.StatusPlanning {
 		t.Errorf("status: got %s, want planning", updated.Status)
 	}
-	if updated.ProjectID != "myco/work-repo" {
+	if updated.ProjectID != "example-org/example-repo" {
 		t.Errorf("project_id: got %q", updated.ProjectID)
 	}
 }
@@ -176,7 +176,7 @@ func TestApplyWorkProjectForcesInteractiveAndPlanning(t *testing.T) {
 func TestApplyPRFixRunRoleNeverPlanning(t *testing.T) {
 	mgr := newTestManager(t)
 	// Create a work-project task that would normally go to planning.
-	created, err := mgr.Create("Fix CI: bump lodash", "https://github.com/myco/work-repo/pull/42", task.AgentModeHeadless)
+	created, err := mgr.Create("Fix CI: bump lodash", "https://github.com/example-org/example-repo/pull/42", task.AgentModeHeadless)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -185,7 +185,7 @@ func TestApplyPRFixRunRoleNeverPlanning(t *testing.T) {
 	created.PRNumber = 42
 
 	projects := []project.Project{
-		{ID: "myco/work-repo", Owner: "myco", Repo: "work-repo", Type: project.ProjectTypeWork},
+		{ID: "example-org/example-repo", Owner: "example-org", Repo: "example-repo", Type: project.ProjectTypeWork},
 	}
 	v := Verdict{
 		Title: "chore(deps): fix CI on bump lodash",
@@ -206,14 +206,14 @@ func TestApplyPRFixRunRoleNeverPlanning(t *testing.T) {
 
 func TestApplyPRNumberNeverPlanning(t *testing.T) {
 	mgr := newTestManager(t)
-	created, err := mgr.Create("Fix some CI", "https://github.com/myco/work-repo/pull/7", task.AgentModeHeadless)
+	created, err := mgr.Create("Fix some CI", "https://github.com/example-org/example-repo/pull/7", task.AgentModeHeadless)
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 	created.PRNumber = 7
 
 	projects := []project.Project{
-		{ID: "myco/work-repo", Owner: "myco", Repo: "work-repo", Type: project.ProjectTypeWork},
+		{ID: "example-org/example-repo", Owner: "example-org", Repo: "example-repo", Type: project.ProjectTypeWork},
 	}
 	v := Verdict{
 		Title: "feat(ci): fix broken pipeline",

--- a/internal/triage/classifier.go
+++ b/internal/triage/classifier.go
@@ -106,6 +106,20 @@ Output schema (single JSON object):
 		b.WriteString("\n")
 	}
 
+	// Expose system metadata so the classifier can recognise pr-fix tasks and
+	// emit "noplan" without depending solely on title/body heuristics.
+	if t.RunRole != "" || t.PRNumber > 0 {
+		b.WriteString("System metadata (do not include in output):\n")
+		if t.RunRole != "" {
+			b.WriteString("- run_role: " + t.RunRole + "\n")
+		}
+		if t.PRNumber > 0 {
+			fmt.Fprintf(&b, "- pr_number: %d\n", t.PRNumber)
+		}
+		b.WriteString("IMPORTANT: when run_role=pr-fix or pr_number>0 this is a system task " +
+			"fixing an existing PR. Always emit \"noplan\" in tags.\n\n")
+	}
+
 	b.WriteString("Task to classify:\n")
 	b.WriteString("TITLE: ")
 	b.WriteString(t.Title)

--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -14,6 +14,12 @@ trigger:
     - field: task.tags
       operator: not_contains
       value: handoff
+    # renovate-fix tasks are driven by pr.event (pr-fix workflow) and must
+    # never enter the plan/implement/review pipeline — that would open a
+    # duplicate PR and burn ~$7 + ~70 min on a trivial CI fix.
+    - field: task.tags
+      operator: not_contains
+      value: renovate-fix
 steps:
   - id: triage
     name: Triage

--- a/internal/workflow/builtin/simple-task-review.yaml
+++ b/internal/workflow/builtin/simple-task-review.yaml
@@ -172,7 +172,8 @@ steps:
       - goto: maybe_create_pr
 
   # Guard: when the task already has a PR number (pr-fix tasks or retries),
-  # skip the create_pr agent entirely and link directly. Prevents duplicate PRs.
+  # skip the create_pr agent entirely. Prevents duplicate PRs.
+  # The push_existing_pr step handles pushing review-fix commits to the branch.
   - id: maybe_create_pr
     name: Maybe Create PR
     type: condition
@@ -180,8 +181,41 @@ steps:
       - when:
           field: task.pr_number
           operator: exists
-        goto: link_pr_and_review
+        goto: push_existing_pr
       - goto: create_pr
+
+  # Push review-fix commits to the existing PR branch.
+  # Reached only when the task already has a pr_number (pr-fix retries or
+  # tasks that skipped create_pr). create_pr handles push for new PRs.
+  - id: push_existing_pr
+    name: Push to Existing PR
+    type: run_agent
+    config:
+      role: push-branch
+      mode: headless
+      model: sonnet
+      needs_worktree: true
+      max_retries: 2
+      prompt: >-
+        Push any unpushed commits on the current branch to the existing PR (task
+        already has pr_number {{.Task.PRNumber}}).
+
+        Steps:
+          1. Determine the push remote:
+             BRANCH="$(git branch --show-current)"
+             PUSH_REMOTE="origin"
+             if git config --get remote.fork.url >/dev/null; then PUSH_REMOTE="fork"; fi
+          2. Push: git push "$PUSH_REMOTE" HEAD:"$BRANCH"
+             If rejected due to divergence, force-push:
+             git push --force-with-lease "$PUSH_REMOTE" HEAD:"$BRANCH"
+          3. Verify the remote PR head matches local HEAD:
+             LOCAL_SHA="$(git rev-parse HEAD)"
+             PR_SHA="$(gh pr view {{.Task.PRNumber}} --json headRefOid --jq .headRefOid)"
+             test "$LOCAL_SHA" = "$PR_SHA"
+
+        No new commits — only push what is already committed locally.
+    next:
+      - goto: link_pr_and_review
 
   # Create the GitHub PR after review fixes are committed locally.
   # Check for an existing PR first to stay idempotent on retries.

--- a/internal/workflow/builtin/simple-task-review.yaml
+++ b/internal/workflow/builtin/simple-task-review.yaml
@@ -201,10 +201,12 @@ steps:
         already has pr_number {{.Task.PRNumber}}).
 
         Steps:
-          1. Determine the push remote:
+          1. Determine the push remote by matching the PR's actual head repository:
              BRANCH="$(git branch --show-current)"
              PUSH_REMOTE="origin"
-             if git config --get remote.fork.url >/dev/null; then PUSH_REMOTE="fork"; fi
+             PR_HEAD="$(gh pr view {{.Task.PRNumber}} --json headRepository --jq '.headRepository.nameWithOwner')"
+             FORK_URL="$(git config --get remote.fork.url 2>/dev/null || true)"
+             if [ -n "$FORK_URL" ] && echo "$FORK_URL" | grep -qF "$PR_HEAD"; then PUSH_REMOTE="fork"; fi
           2. Push: git push "$PUSH_REMOTE" HEAD:"$BRANCH"
              If rejected due to divergence, force-push:
              git push --force-with-lease "$PUSH_REMOTE" HEAD:"$BRANCH"

--- a/internal/workflow/builtin/simple-task-review.yaml
+++ b/internal/workflow/builtin/simple-task-review.yaml
@@ -10,7 +10,7 @@ trigger:
       value: ready-review
 steps:
   # Skip review when tagged noreview or already reviewed in a prior run.
-  # On skip, jump straight to create_pr so the PR is still opened.
+  # On skip, jump straight to maybe_create_pr so the PR is still opened.
   - id: maybe_review
     name: Review Decision
     type: condition
@@ -24,13 +24,13 @@ steps:
           field: task.reviewed
           operator: equals
           value: "true"
-        goto: create_pr
+        goto: maybe_create_pr
       - when:
           field: task.tags
           operator: not_contains
           value: noreview
         goto: triage_review
-      - goto: create_pr
+      - goto: maybe_create_pr
 
   # Mechanical heuristic (no LLM): inspects diff size + file shape and emits
   # "simple" or "staff" so pick_review_method below can pick between the
@@ -45,6 +45,7 @@ steps:
 
   # Routes to the simple or staff review based on:
   #   - task.tags contains force-staff-review → always staff (escape hatch)
+  #   - vars.step.triage_review.output equals skip → trivial diff, skip review
   #   - vars.step.triage_review.output equals simple → /pr-review
   #   - otherwise → /staff-code-review (covers "staff", error fallbacks)
   - id: pick_review_method
@@ -56,6 +57,11 @@ steps:
           operator: contains
           value: force-staff-review
         goto: code_review_staff
+      - when:
+          field: vars.step.triage_review.output
+          operator: equals
+          value: skip
+        goto: maybe_create_pr
       - when:
           field: vars.step.triage_review.output
           operator: equals
@@ -163,6 +169,18 @@ steps:
         creation). Sign commits with `git commit -s -S`.
         Use conventional commit format: `fix(review): address review comments`.
     next:
+      - goto: maybe_create_pr
+
+  # Guard: when the task already has a PR number (pr-fix tasks or retries),
+  # skip the create_pr agent entirely and link directly. Prevents duplicate PRs.
+  - id: maybe_create_pr
+    name: Maybe Create PR
+    type: condition
+    next:
+      - when:
+          field: task.pr_number
+          operator: exists
+        goto: link_pr_and_review
       - goto: create_pr
 
   # Create the GitHub PR after review fixes are committed locally.

--- a/internal/workflow/engine_steps_triage.go
+++ b/internal/workflow/engine_steps_triage.go
@@ -41,12 +41,21 @@ var triageReviewShortStatRe = regexp.MustCompile(
 	`(\d+)\s+files?\s+changed(?:,\s+(\d+)\s+insertions?\(\+\))?(?:,\s+(\d+)\s+deletions?\(-\))?`,
 )
 
-// triageVerdict applies the heuristic and returns "simple" or "staff" with a
-// short rationale. Pure function — easy to unit-test without git.
+// triageVerdict applies the heuristic and returns "skip", "simple", or "staff"
+// with a short rationale. Pure function — easy to unit-test without git.
+//
+// "skip"   — trivial diff (zero net lines changed): no review needed.
+// "simple" — small, low-risk diff: lightweight /pr-review is sufficient.
+// "staff"  — large or risky diff: full /staff-code-review required.
 func triageVerdict(files []string, insertions, deletions int) (verdict, reason string) {
 	total := insertions + deletions
 	if len(files) == 0 {
 		return "staff", "no files reported"
+	}
+	// Zero net lines (e.g. rename-only, mode-change): no substantive diff to
+	// review. Skip the review cycle entirely.
+	if total == 0 {
+		return "skip", fmt.Sprintf("0 lines changed across %d file(s)", len(files))
 	}
 	if total > triageReviewLineLimit {
 		return "staff", fmt.Sprintf("%d lines > %d", total, triageReviewLineLimit)
@@ -60,11 +69,15 @@ func triageVerdict(files []string, insertions, deletions int) (verdict, reason s
 		}
 		ext := strings.ToLower(filepathExt(f))
 		if !triageReviewSimpleExts[ext] {
+			// Unsupported extension on a small, non-risky diff: downgrade to
+			// simple instead of forcing staff. The extension is unfamiliar but
+			// the diff is tiny — a lightweight review is still better than
+			// nothing, and staff is reserved for genuinely large/risky changes.
 			label := ext
 			if label == "" {
 				label = "(no extension)"
 			}
-			return "staff", "unsupported extension: " + label + " (" + f + ")"
+			return "simple", "small diff with unsupported extension: " + label + " (" + f + ")"
 		}
 	}
 	return "simple", fmt.Sprintf("%d lines, %d files, low risk", total, len(files))

--- a/internal/workflow/triage_review_test.go
+++ b/internal/workflow/triage_review_test.go
@@ -88,18 +88,32 @@ func TestTriageVerdict(t *testing.T) {
 			want:       "staff",
 		},
 		{
-			name:       "unknown_extension_is_staff",
+			name:       "unknown_extension_small_diff_is_simple",
 			files:      []string{"schema.sql"},
 			insertions: 5,
 			deletions:  0,
-			want:       "staff",
+			want:       "simple",
 		},
 		{
-			name:       "binary_or_no_extension_is_staff",
+			name:       "binary_or_no_extension_small_diff_is_simple",
 			files:      []string{"bin/runner"},
 			insertions: 1,
 			deletions:  0,
-			want:       "staff",
+			want:       "simple",
+		},
+		{
+			name:       "zero_lines_changed_is_skip",
+			files:      []string{"README.md"},
+			insertions: 0,
+			deletions:  0,
+			want:       "skip",
+		},
+		{
+			name:       "zero_lines_multiple_files_is_skip",
+			files:      []string{"a.go", "b.go"},
+			insertions: 0,
+			deletions:  0,
+			want:       "skip",
 		},
 		{
 			name:       "no_files_is_staff",
@@ -408,6 +422,14 @@ func TestBuiltinSimpleTask_PickReviewMethod(t *testing.T) {
 				"task.tags": "backend",
 			},
 			want: "code_review_staff",
+		},
+		{
+			name: "skip_verdict_routes_to_maybe_create_pr",
+			fields: map[string]string{
+				"task.tags":                      "backend",
+				"vars.step.triage_review.output": "skip",
+			},
+			want: "maybe_create_pr",
 		},
 	}
 

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -369,8 +369,13 @@ func (m *Manager) PrepareForFix(t task.Task, prNumber int) (string, error) {
 	if err := m.runSetup(t.ID, wtPath, m.resolveSetupCommands(wtPath, proj)); err != nil {
 		return "", fmt.Errorf("fix setup: %w", err)
 	}
-	if err := project.EnforceForkOnlyPush(wtPath); err != nil {
-		m.logger.Warn("fix.worktree.fork-only-push", "task_id", t.ID, "err", err)
+	// pr-fix tasks must push to the existing PR's head branch on origin — not
+	// via a fork remote. Skip fork-only-push so git push origin HEAD:<branch>
+	// goes straight to the upstream and the fix lands on the tracked PR.
+	if t.RunRole != "pr-fix" {
+		if err := project.EnforceForkOnlyPush(wtPath); err != nil {
+			m.logger.Warn("fix.worktree.fork-only-push", "task_id", t.ID, "err", err)
+		}
 	}
 	return wtPath, nil
 }


### PR DESCRIPTION
## Motivation

The renovate/pr-fix workflow had two correctness gaps that caused slow or incorrect behavior:

1. **Duplicate PR creation on retries** — when a task already had a `pr_number` (pr-fix tasks, or review-workflow retries), the `create_pr` step would still run and attempt to open a second PR against the same branch.
2. **No short-circuit for trivial diffs** — the `triage_review` step could emit `skip` for tiny diffs, but `pick_review_method` had no branch for that value, falling through to a full staff review unnecessarily.

Additionally, `FixRenovateCI` created a task then immediately updated it in a separate round-trip, leaving a window where the task existed with incomplete metadata.

## Implementation information

- Added `maybe_create_pr` condition step in `simple-task-review.yaml` that guards `create_pr`: if `task.pr_number` already exists, it routes to a new `push_existing_pr` step instead, which pushes any locally-committed review fixes and verifies the remote head matches.
- Added `skip` branch in `pick_review_method` routing to `maybe_create_pr` directly, bypassing the review agent for trivial diffs.
- Renamed all `goto: create_pr` references in the workflow to `goto: maybe_create_pr` so the guard is always in the path.
- Collapsed `tasks.Create` + `tasks.Update` in `FixRenovateCI` (`svc_integrations.go`) into a single `tasks.CreateFull` call to eliminate the intermediate incomplete-task state.
- Minor prompt reformatting in `app_reviews_fix.go` (no behavior change).

> Changelog: fix(workflow): make renovate/pr-fix flow fast and bounded