### PR TITLE
feat(eval): golden-task regression scoring

### DIFF
--- a/cmd/sybra-cli/evaluation.go
+++ b/cmd/sybra-cli/evaluation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -23,9 +24,77 @@ func cmdEvaluation(cfg *config.Config, store *task.Manager, args []string, jsonO
 		return cmdEvaluationScan(cfg, jsonOut)
 	case "judge":
 		return cmdEvaluationJudge(store, args[1:], jsonOut)
+	case "golden":
+		return cmdEvaluationGolden(args[1:], jsonOut)
 	default:
 		return fatal(jsonOut, "unknown evaluation subcommand: %s", args[0])
 	}
+}
+
+// cmdEvaluationGolden scores a golden-set run's results against expectations and,
+// when a baseline is given, reports regressions. Exits non-zero on any
+// regression so it can gate prompt/skill/model changes in CI.
+func cmdEvaluationGolden(args []string, jsonOut bool) int {
+	fs := flag.NewFlagSet("golden", flag.ContinueOnError)
+	setPath := fs.String("set", "", "path to the golden-set JSON (required)")
+	resultsPath := fs.String("results", "", "path to the case-results JSON (required)")
+	baselinePath := fs.String("baseline", "", "optional baseline report to diff against")
+	updateBaseline := fs.Bool("update-baseline", false, "write the fresh report to --baseline")
+	if err := fs.Parse(args); err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+	if *setPath == "" || *resultsPath == "" {
+		return fatal(jsonOut, "usage: evaluation golden --set <set.json> --results <results.json> [--baseline <b.json>] [--update-baseline]")
+	}
+	cases, err := evaluation.LoadGoldenSet(*setPath)
+	if err != nil {
+		return fatal(jsonOut, "load set: %v", err)
+	}
+	results, err := evaluation.LoadCaseResults(*resultsPath)
+	if err != nil {
+		return fatal(jsonOut, "load results: %v", err)
+	}
+	rep := evaluation.ScoreSet(cases, results)
+
+	var delta *evaluation.GoldenDelta
+	if *baselinePath != "" {
+		if prev, err := evaluation.LoadGoldenReport(*baselinePath); err == nil {
+			d := evaluation.DiffBaseline(prev, rep)
+			delta = &d
+		} else if !os.IsNotExist(err) {
+			return fatal(jsonOut, "load baseline: %v", err)
+		}
+		if *updateBaseline {
+			if err := evaluation.SaveGoldenReport(*baselinePath, rep); err != nil {
+				return fatal(jsonOut, "write baseline: %v", err)
+			}
+		}
+	}
+
+	if jsonOut {
+		printJSON(map[string]any{"report": rep, "delta": delta})
+	} else {
+		fmt.Printf("golden: %d/%d passed (score %.2f)\n", rep.Passed, rep.Total, rep.Score)
+		for _, c := range rep.Cases {
+			if !c.Passed {
+				fmt.Printf("  FAIL %s: %s\n", c.CaseID, strings.Join(c.Failures, "; "))
+			}
+		}
+		if delta != nil {
+			fmt.Printf("  vs baseline: score %+.2f", delta.ScoreDelta)
+			if len(delta.Fixed) > 0 {
+				fmt.Printf("  fixed=%s", strings.Join(delta.Fixed, ","))
+			}
+			if len(delta.Regressions) > 0 {
+				fmt.Printf("  REGRESSIONS=%s", strings.Join(delta.Regressions, ","))
+			}
+			fmt.Println()
+		}
+	}
+	if delta != nil && len(delta.Regressions) > 0 {
+		return 1 // gate: a change regressed the golden set
+	}
+	return 0
 }
 
 func cmdEvaluationScan(cfg *config.Config, jsonOut bool) int {

--- a/cmd/sybra-cli/evaluation.go
+++ b/cmd/sybra-cli/evaluation.go
@@ -46,9 +46,18 @@ func cmdEvaluationGolden(args []string, jsonOut bool) int {
 	if *setPath == "" || *resultsPath == "" {
 		return fatal(jsonOut, "usage: evaluation golden --set <set.json> --results <results.json> [--baseline <b.json>] [--update-baseline]")
 	}
+	if *updateBaseline && *baselinePath == "" {
+		return fatal(jsonOut, "--update-baseline requires --baseline")
+	}
 	cases, err := evaluation.LoadGoldenSet(*setPath)
 	if err != nil {
 		return fatal(jsonOut, "load set: %v", err)
+	}
+	if err := evaluation.ValidateGoldenSet(cases); err != nil {
+		return fatal(jsonOut, "invalid golden set: %v", err)
+	}
+	if len(cases) == 0 {
+		return fatal(jsonOut, "golden set is empty")
 	}
 	results, err := evaluation.LoadCaseResults(*resultsPath)
 	if err != nil {
@@ -64,10 +73,18 @@ func cmdEvaluationGolden(args []string, jsonOut bool) int {
 		} else if !os.IsNotExist(err) {
 			return fatal(jsonOut, "load baseline: %v", err)
 		}
-		if *updateBaseline {
-			if err := evaluation.SaveGoldenReport(*baselinePath, rep); err != nil {
-				return fatal(jsonOut, "write baseline: %v", err)
-			}
+	}
+
+	// Gate: any failing case is a hard floor (protects even with no baseline),
+	// and any regression vs the baseline. A clean run is required to bless a new
+	// baseline, so --update-baseline can never record a failing/regressed report.
+	clean := rep.Passed == rep.Total && (delta == nil || len(delta.Regressions) == 0)
+	if *updateBaseline {
+		if !clean {
+			return fatal(jsonOut, "refusing to update baseline from a failing/regressed run")
+		}
+		if err := evaluation.SaveGoldenReport(*baselinePath, rep); err != nil {
+			return fatal(jsonOut, "write baseline: %v", err)
 		}
 	}
 
@@ -88,11 +105,14 @@ func cmdEvaluationGolden(args []string, jsonOut bool) int {
 			if len(delta.Regressions) > 0 {
 				fmt.Printf("  REGRESSIONS=%s", strings.Join(delta.Regressions, ","))
 			}
+			if len(delta.Removed) > 0 {
+				fmt.Printf("  removed=%s", strings.Join(delta.Removed, ","))
+			}
 			fmt.Println()
 		}
 	}
-	if delta != nil && len(delta.Regressions) > 0 {
-		return 1 // gate: a change regressed the golden set
+	if !clean {
+		return 1 // gate: failing cases or a regression
 	}
 	return 0
 }

--- a/cmd/sybra-cli/evaluation.go
+++ b/cmd/sybra-cli/evaluation.go
@@ -17,7 +17,7 @@ import (
 
 func cmdEvaluation(cfg *config.Config, store *task.Manager, args []string, jsonOut bool) int {
 	if len(args) == 0 {
-		return fatal(jsonOut, "usage: evaluation <scan|judge> [args] [--json]")
+		return fatal(jsonOut, "usage: evaluation <scan|judge|golden> [args] [--json]")
 	}
 	switch args[0] {
 	case "scan":
@@ -32,8 +32,8 @@ func cmdEvaluation(cfg *config.Config, store *task.Manager, args []string, jsonO
 }
 
 // cmdEvaluationGolden scores a golden-set run's results against expectations and,
-// when a baseline is given, reports regressions. Exits non-zero on any
-// regression so it can gate prompt/skill/model changes in CI.
+// when a baseline is given, reports regressions. Exits non-zero on any failing
+// case or regression so it can gate prompt/skill/model changes in CI.
 func cmdEvaluationGolden(args []string, jsonOut bool) int {
 	fs := flag.NewFlagSet("golden", flag.ContinueOnError)
 	setPath := fs.String("set", "", "path to the golden-set JSON (required)")
@@ -55,9 +55,6 @@ func cmdEvaluationGolden(args []string, jsonOut bool) int {
 	}
 	if err := evaluation.ValidateGoldenSet(cases); err != nil {
 		return fatal(jsonOut, "invalid golden set: %v", err)
-	}
-	if len(cases) == 0 {
-		return fatal(jsonOut, "golden set is empty")
 	}
 	results, err := evaluation.LoadCaseResults(*resultsPath)
 	if err != nil {

--- a/internal/evaluation/golden.go
+++ b/internal/evaluation/golden.go
@@ -1,0 +1,167 @@
+package evaluation
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// GoldenCase is one representative task with known-good expectations. Running the
+// fleet against a curated set of these catches regressions when prompts, skills,
+// or models change — SWE-bench-style, scoped to Sybra's own workload.
+type GoldenCase struct {
+	ID        string      `json:"id"`
+	Title     string      `json:"title"`
+	ProjectID string      `json:"projectId,omitempty"`
+	Prompt    string      `json:"prompt"`
+	Expect    Expectation `json:"expect"`
+}
+
+// Expectation is the bar a golden case must clear. A zero field is unchecked.
+type Expectation struct {
+	TestsPass  bool    `json:"testsPass"`            // the run must end with tests passing
+	MinQuality float64 `json:"minQuality,omitempty"` // minimum judge overall (0–10)
+	MaxTurns   int     `json:"maxTurns,omitempty"`   // turn budget
+}
+
+// CaseResult is the observed outcome of executing a golden case. It is produced
+// by the runner (live agent execution — out of scope for this engine) and fed
+// to the scorer.
+type CaseResult struct {
+	CaseID    string  `json:"caseId"`
+	TestsPass bool    `json:"testsPass"`
+	Quality   float64 `json:"quality"`
+	Turns     int     `json:"turns"`
+}
+
+// CaseOutcome is the scored result of one golden case.
+type CaseOutcome struct {
+	CaseID   string   `json:"caseId"`
+	Passed   bool     `json:"passed"`
+	Failures []string `json:"failures,omitempty"`
+}
+
+// GoldenReport is the aggregate score of a golden-set run.
+type GoldenReport struct {
+	Total  int           `json:"total"`
+	Passed int           `json:"passed"`
+	Score  float64       `json:"score"` // passed / total
+	Cases  []CaseOutcome `json:"cases"`
+}
+
+// GoldenDelta compares a fresh report against a baseline.
+type GoldenDelta struct {
+	ScoreDelta  float64  `json:"scoreDelta"`
+	Regressions []string `json:"regressions,omitempty"` // passed in baseline, fail now
+	Fixed       []string `json:"fixed,omitempty"`       // failed in baseline, pass now
+}
+
+// ScoreCase checks one observed result against its case's expectations.
+func ScoreCase(c GoldenCase, r CaseResult) CaseOutcome {
+	var fails []string
+	if c.Expect.TestsPass && !r.TestsPass {
+		fails = append(fails, "tests did not pass")
+	}
+	if c.Expect.MinQuality > 0 && r.Quality < c.Expect.MinQuality {
+		fails = append(fails, fmt.Sprintf("quality %.1f < min %.1f", r.Quality, c.Expect.MinQuality))
+	}
+	if c.Expect.MaxTurns > 0 && r.Turns > c.Expect.MaxTurns {
+		fails = append(fails, fmt.Sprintf("turns %d > max %d", r.Turns, c.Expect.MaxTurns))
+	}
+	return CaseOutcome{CaseID: c.ID, Passed: len(fails) == 0, Failures: fails}
+}
+
+// ScoreSet scores every case against its result. A case with no matching result
+// fails explicitly, so a runner that silently skips a case can't inflate the score.
+func ScoreSet(cases []GoldenCase, results []CaseResult) GoldenReport {
+	byID := make(map[string]CaseResult, len(results))
+	for _, r := range results {
+		byID[r.CaseID] = r
+	}
+	rep := GoldenReport{Total: len(cases)}
+	for i := range cases {
+		c := cases[i]
+		r, ok := byID[c.ID]
+		if !ok {
+			rep.Cases = append(rep.Cases, CaseOutcome{CaseID: c.ID, Passed: false, Failures: []string{"no result for case"}})
+			continue
+		}
+		oc := ScoreCase(c, r)
+		if oc.Passed {
+			rep.Passed++
+		}
+		rep.Cases = append(rep.Cases, oc)
+	}
+	if rep.Total > 0 {
+		rep.Score = float64(rep.Passed) / float64(rep.Total)
+	}
+	return rep
+}
+
+// DiffBaseline reports the score change and which cases regressed (passed in the
+// baseline, fail now) or were fixed. Regressions are what gate a change.
+func DiffBaseline(prev, cur GoldenReport) GoldenDelta {
+	prevPass := make(map[string]bool, len(prev.Cases))
+	for _, c := range prev.Cases {
+		prevPass[c.CaseID] = c.Passed
+	}
+	d := GoldenDelta{ScoreDelta: cur.Score - prev.Score}
+	for _, c := range cur.Cases {
+		was, existed := prevPass[c.CaseID]
+		switch {
+		case existed && was && !c.Passed:
+			d.Regressions = append(d.Regressions, c.CaseID)
+		case existed && !was && c.Passed:
+			d.Fixed = append(d.Fixed, c.CaseID)
+		}
+	}
+	return d
+}
+
+// LoadGoldenSet reads a JSON array of golden cases.
+func LoadGoldenSet(path string) ([]GoldenCase, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cases []GoldenCase
+	if err := json.Unmarshal(data, &cases); err != nil {
+		return nil, fmt.Errorf("parse golden set: %w", err)
+	}
+	return cases, nil
+}
+
+// LoadCaseResults reads a JSON array of observed case results.
+func LoadCaseResults(path string) ([]CaseResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var results []CaseResult
+	if err := json.Unmarshal(data, &results); err != nil {
+		return nil, fmt.Errorf("parse results: %w", err)
+	}
+	return results, nil
+}
+
+// LoadGoldenReport reads a persisted report (used as a baseline).
+func LoadGoldenReport(path string) (GoldenReport, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return GoldenReport{}, err
+	}
+	var rep GoldenReport
+	if err := json.Unmarshal(data, &rep); err != nil {
+		return GoldenReport{}, fmt.Errorf("parse report: %w", err)
+	}
+	return rep, nil
+}
+
+// SaveGoldenReport writes a report as indented JSON (the new baseline).
+func SaveGoldenReport(path string, rep GoldenReport) error {
+	data, err := json.MarshalIndent(rep, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/internal/evaluation/golden.go
+++ b/internal/evaluation/golden.go
@@ -57,9 +57,12 @@ type GoldenDelta struct {
 	Removed     []string `json:"removed,omitempty"`     // in baseline, absent from this run
 }
 
-// ValidateGoldenSet rejects a set with duplicate case IDs, which would double-
-// count the denominator and let one result score two cases.
+// ValidateGoldenSet rejects an empty set or one with empty/duplicate case IDs,
+// which would make the score meaningless or let one result score two cases.
 func ValidateGoldenSet(cases []GoldenCase) error {
+	if len(cases) == 0 {
+		return fmt.Errorf("golden set is empty")
+	}
 	seen := make(map[string]bool, len(cases))
 	for i := range cases {
 		id := cases[i].ID
@@ -93,12 +96,22 @@ func ScoreCase(c GoldenCase, r CaseResult) CaseOutcome {
 // fails explicitly, so a runner that silently skips a case can't inflate the score.
 func ScoreSet(cases []GoldenCase, results []CaseResult) GoldenReport {
 	byID := make(map[string]CaseResult, len(results))
+	dup := make(map[string]bool)
 	for _, r := range results {
+		if _, seen := byID[r.CaseID]; seen {
+			dup[r.CaseID] = true
+		}
 		byID[r.CaseID] = r
 	}
 	rep := GoldenReport{Total: len(cases)}
 	for i := range cases {
 		c := cases[i]
+		// Duplicate results for one case mask a runner bug; fail it explicitly
+		// rather than silently letting the last result win.
+		if dup[c.ID] {
+			rep.Cases = append(rep.Cases, CaseOutcome{CaseID: c.ID, Passed: false, Failures: []string{"duplicate results for case"}})
+			continue
+		}
 		r, ok := byID[c.ID]
 		if !ok {
 			rep.Cases = append(rep.Cases, CaseOutcome{CaseID: c.ID, Passed: false, Failures: []string{"no result for case"}})

--- a/internal/evaluation/golden.go
+++ b/internal/evaluation/golden.go
@@ -54,6 +54,24 @@ type GoldenDelta struct {
 	ScoreDelta  float64  `json:"scoreDelta"`
 	Regressions []string `json:"regressions,omitempty"` // passed in baseline, fail now
 	Fixed       []string `json:"fixed,omitempty"`       // failed in baseline, pass now
+	Removed     []string `json:"removed,omitempty"`     // in baseline, absent from this run
+}
+
+// ValidateGoldenSet rejects a set with duplicate case IDs, which would double-
+// count the denominator and let one result score two cases.
+func ValidateGoldenSet(cases []GoldenCase) error {
+	seen := make(map[string]bool, len(cases))
+	for i := range cases {
+		id := cases[i].ID
+		if id == "" {
+			return fmt.Errorf("golden case %d has an empty id", i)
+		}
+		if seen[id] {
+			return fmt.Errorf("duplicate golden case id %q", id)
+		}
+		seen[id] = true
+	}
+	return nil
 }
 
 // ScoreCase checks one observed result against its case's expectations.
@@ -106,13 +124,21 @@ func DiffBaseline(prev, cur GoldenReport) GoldenDelta {
 		prevPass[c.CaseID] = c.Passed
 	}
 	d := GoldenDelta{ScoreDelta: cur.Score - prev.Score}
+	curIDs := make(map[string]bool, len(cur.Cases))
 	for _, c := range cur.Cases {
+		curIDs[c.CaseID] = true
 		was, existed := prevPass[c.CaseID]
 		switch {
 		case existed && was && !c.Passed:
 			d.Regressions = append(d.Regressions, c.CaseID)
 		case existed && !was && c.Passed:
 			d.Fixed = append(d.Fixed, c.CaseID)
+		}
+	}
+	// Cases dropped from the set since the baseline — coverage loss worth surfacing.
+	for _, c := range prev.Cases {
+		if !curIDs[c.CaseID] {
+			d.Removed = append(d.Removed, c.CaseID)
 		}
 	}
 	return d

--- a/internal/evaluation/golden_test.go
+++ b/internal/evaluation/golden_test.go
@@ -76,6 +76,27 @@ func TestDiffBaseline(t *testing.T) {
 	}
 }
 
+func TestDiffBaseline_Removed(t *testing.T) {
+	prev := GoldenReport{Cases: []CaseOutcome{{CaseID: "a", Passed: true}, {CaseID: "b", Passed: true}}}
+	cur := GoldenReport{Cases: []CaseOutcome{{CaseID: "a", Passed: true}}}
+	d := DiffBaseline(prev, cur)
+	if len(d.Removed) != 1 || d.Removed[0] != "b" {
+		t.Errorf("Removed = %v, want [b]", d.Removed)
+	}
+}
+
+func TestValidateGoldenSet(t *testing.T) {
+	if err := ValidateGoldenSet([]GoldenCase{{ID: "a"}, {ID: "b"}}); err != nil {
+		t.Errorf("valid set errored: %v", err)
+	}
+	if err := ValidateGoldenSet([]GoldenCase{{ID: "a"}, {ID: "a"}}); err == nil {
+		t.Error("duplicate id should error")
+	}
+	if err := ValidateGoldenSet([]GoldenCase{{ID: ""}}); err == nil {
+		t.Error("empty id should error")
+	}
+}
+
 func TestLoadGoldenSet_Example(t *testing.T) {
 	cases, err := LoadGoldenSet(filepath.Join("testdata", "goldenset.example.json"))
 	if err != nil {

--- a/internal/evaluation/golden_test.go
+++ b/internal/evaluation/golden_test.go
@@ -1,0 +1,110 @@
+package evaluation
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestScoreCase(t *testing.T) {
+	c := GoldenCase{ID: "c1", Expect: Expectation{TestsPass: true, MinQuality: 7, MaxTurns: 30}}
+	tests := []struct {
+		name      string
+		r         CaseResult
+		wantPass  bool
+		wantFails int
+	}{
+		{"all good", CaseResult{CaseID: "c1", TestsPass: true, Quality: 8, Turns: 20}, true, 0},
+		{"tests fail", CaseResult{CaseID: "c1", TestsPass: false, Quality: 8, Turns: 20}, false, 1},
+		{"low quality", CaseResult{CaseID: "c1", TestsPass: true, Quality: 5, Turns: 20}, false, 1},
+		{"too many turns", CaseResult{CaseID: "c1", TestsPass: true, Quality: 8, Turns: 40}, false, 1},
+		{"multiple failures", CaseResult{CaseID: "c1", TestsPass: false, Quality: 1, Turns: 99}, false, 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oc := ScoreCase(c, tt.r)
+			if oc.Passed != tt.wantPass {
+				t.Errorf("Passed = %v, want %v (%v)", oc.Passed, tt.wantPass, oc.Failures)
+			}
+			if len(oc.Failures) != tt.wantFails {
+				t.Errorf("Failures = %d, want %d: %v", len(oc.Failures), tt.wantFails, oc.Failures)
+			}
+		})
+	}
+}
+
+func TestScoreCase_UncheckedFields(t *testing.T) {
+	// Zero expectations mean "unchecked": only TestsPass matters here.
+	c := GoldenCase{ID: "c", Expect: Expectation{TestsPass: true}}
+	oc := ScoreCase(c, CaseResult{CaseID: "c", TestsPass: true, Quality: 0, Turns: 9999})
+	if !oc.Passed {
+		t.Errorf("unchecked quality/turns should not fail: %v", oc.Failures)
+	}
+}
+
+func TestScoreSet_MissingResultFails(t *testing.T) {
+	cases := []GoldenCase{
+		{ID: "a", Expect: Expectation{TestsPass: true}},
+		{ID: "b", Expect: Expectation{TestsPass: true}},
+	}
+	results := []CaseResult{{CaseID: "a", TestsPass: true}} // b has no result
+	rep := ScoreSet(cases, results)
+	if rep.Total != 2 || rep.Passed != 1 {
+		t.Fatalf("Total/Passed = %d/%d, want 2/1", rep.Total, rep.Passed)
+	}
+	if rep.Score != 0.5 {
+		t.Errorf("Score = %v, want 0.5", rep.Score)
+	}
+}
+
+func TestDiffBaseline(t *testing.T) {
+	prev := GoldenReport{Total: 3, Passed: 2, Score: 2.0 / 3.0, Cases: []CaseOutcome{
+		{CaseID: "a", Passed: true},
+		{CaseID: "b", Passed: true},
+		{CaseID: "c", Passed: false},
+	}}
+	cur := GoldenReport{Total: 3, Passed: 2, Score: 2.0 / 3.0, Cases: []CaseOutcome{
+		{CaseID: "a", Passed: true},
+		{CaseID: "b", Passed: false}, // regression
+		{CaseID: "c", Passed: true},  // fixed
+	}}
+	d := DiffBaseline(prev, cur)
+	if len(d.Regressions) != 1 || d.Regressions[0] != "b" {
+		t.Errorf("Regressions = %v, want [b]", d.Regressions)
+	}
+	if len(d.Fixed) != 1 || d.Fixed[0] != "c" {
+		t.Errorf("Fixed = %v, want [c]", d.Fixed)
+	}
+}
+
+func TestLoadGoldenSet_Example(t *testing.T) {
+	cases, err := LoadGoldenSet(filepath.Join("testdata", "goldenset.example.json"))
+	if err != nil {
+		t.Fatalf("load example: %v", err)
+	}
+	if len(cases) == 0 {
+		t.Fatal("example golden set is empty")
+	}
+	for _, c := range cases {
+		if c.ID == "" || c.Prompt == "" {
+			t.Errorf("golden case missing id/prompt: %+v", c)
+		}
+	}
+}
+
+func TestSaveLoadReportRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	rep := GoldenReport{Total: 2, Passed: 1, Score: 0.5, Cases: []CaseOutcome{
+		{CaseID: "a", Passed: true},
+		{CaseID: "b", Passed: false, Failures: []string{"tests did not pass"}},
+	}}
+	if err := SaveGoldenReport(path, rep); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := LoadGoldenReport(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got.Total != rep.Total || got.Passed != rep.Passed || len(got.Cases) != 2 {
+		t.Errorf("round-trip mismatch: %+v", got)
+	}
+}

--- a/internal/evaluation/golden_test.go
+++ b/internal/evaluation/golden_test.go
@@ -56,6 +56,22 @@ func TestScoreSet_MissingResultFails(t *testing.T) {
 	}
 }
 
+func TestScoreSet_DuplicateResultsFail(t *testing.T) {
+	cases := []GoldenCase{{ID: "a", Expect: Expectation{TestsPass: true}}}
+	// Two results for the same case — a runner bug; the case must fail explicitly.
+	results := []CaseResult{
+		{CaseID: "a", TestsPass: true},
+		{CaseID: "a", TestsPass: true},
+	}
+	rep := ScoreSet(cases, results)
+	if rep.Passed != 0 {
+		t.Fatalf("Passed = %d, want 0 (duplicate results fail the case)", rep.Passed)
+	}
+	if len(rep.Cases) != 1 || rep.Cases[0].Passed {
+		t.Fatalf("case should fail: %+v", rep.Cases)
+	}
+}
+
 func TestDiffBaseline(t *testing.T) {
 	prev := GoldenReport{Total: 3, Passed: 2, Score: 2.0 / 3.0, Cases: []CaseOutcome{
 		{CaseID: "a", Passed: true},
@@ -94,6 +110,9 @@ func TestValidateGoldenSet(t *testing.T) {
 	}
 	if err := ValidateGoldenSet([]GoldenCase{{ID: ""}}); err == nil {
 		t.Error("empty id should error")
+	}
+	if err := ValidateGoldenSet(nil); err == nil {
+		t.Error("empty set should error")
 	}
 }
 

--- a/internal/evaluation/testdata/goldenset.example.json
+++ b/internal/evaluation/testdata/goldenset.example.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "go-add-flag",
+    "title": "Add a --json flag to an existing CLI command",
+    "projectId": "Automaat/sybra",
+    "prompt": "Add a --json flag to the `board` CLI command that prints the board as machine-readable JSON, matching how other commands handle --json. Add a table-driven test.",
+    "expect": { "testsPass": true, "minQuality": 7, "maxTurns": 40 }
+  },
+  {
+    "id": "go-fix-nil-guard",
+    "title": "Fix a nil-pointer guard in a store method",
+    "projectId": "Automaat/sybra",
+    "prompt": "A store method dereferences an optional field without a nil check, panicking when it is unset. Add the guard and a regression test reproducing the panic.",
+    "expect": { "testsPass": true, "minQuality": 7, "maxTurns": 25 }
+  },
+  {
+    "id": "frontend-empty-state",
+    "title": "Add an empty state to a Svelte list page",
+    "projectId": "Automaat/sybra",
+    "prompt": "A list page renders nothing when the list is empty. Add a friendly empty-state message, matching the conventions of the other pages. svelte-check and oxlint must pass.",
+    "expect": { "testsPass": true, "minQuality": 6, "maxTurns": 30 }
+  }
+]


### PR DESCRIPTION
## Motivation

Closes #1070 (optional). The last piece of the evaluation umbrella (#1065): catch regressions before they reach real work. A golden set of representative tasks with known-good expectations, scored and gated against a baseline — SWE-bench-style, scoped to Sybra's own workload.

> Changelog: feat(eval): golden-task regression scoring

## Implementation information

Engine (`internal/evaluation/golden.go`):
- `GoldenCase` + `Expectation` (tests pass, min quality, max turns); a zero expectation field is unchecked.
- `ScoreSet` scores each case's observed `CaseResult` against its expectation; a case with no matching result fails explicitly so a skipped case can't inflate the score.
- `DiffBaseline` reports the score delta, regressions (passed in baseline, fail now), fixes, and removed cases (coverage loss).
- `ValidateGoldenSet` rejects empty/duplicate ids. JSON load/save for the set, results, and baseline.

CLI — `sybra-cli evaluation golden --set --results [--baseline] [--update-baseline]`:
- Prints the report + baseline delta and **exits non-zero on any failing case or regression**, so it can gate prompt/skill/model changes in CI.
- `--update-baseline` refuses to write a failing/regressed report (no baseline poisoning) and requires `--baseline`.

An example golden set lives under `testdata`.

Adversarial review applied before review closed three gate-escape paths: no protection without a baseline, baseline poisoning via `--update-baseline`, and newly-added failing cases never gating.

This is the deterministic scoring engine. The live runner that executes the fleet against the set in worktrees to produce `CaseResult`s reuses the existing agent/worktree machinery and is the remaining integration, tracked in the Phase 0.1 follow-up.

## Supporting documentation

- Umbrella #1065; completes the phased plan (#1066–#1069 merged).

Gates: `golangci-lint run ./...`, `go test ./...`, `oxlint`, `svelte-check`, `hadolint` pass (pre-existing flaky agent shutdown-timing test passes on rerun).
