### PR TITLE
fix(frontend): register plaintext hljs grammar

### DIFF
--- a/frontend/src/lib/markdown.test.ts
+++ b/frontend/src/lib/markdown.test.ts
@@ -12,6 +12,26 @@ describe('renderMarkdown', () => {
     expect(renderMarkdown('')).toBe('')
     expect(renderMarkdown(null)).toBe('')
   })
+
+  // Regression: a bare ``` fence (and any fence whose language isn't in the
+  // curated highlight.js set) makes marked fall back to the 'plaintext'
+  // grammar. In the `highlight.js/lib/core` build that grammar isn't
+  // registered unless imported, so hljs.highlight() threw "Unknown language:
+  // plaintext", aborting marked.parse() and blanking every view rendering the
+  // markdown — a plan with a bare fence left the task detail stuck on "Loading…".
+  it('does not throw on a bare ``` fence (empty language)', () => {
+    const md = 'before\n\n```\nplain code line\n```\n\nafter'
+    expect(() => renderMarkdown(md)).not.toThrow()
+    expect(renderMarkdown(md)).toContain('plain code line')
+  })
+
+  it('does not throw on an unregistered fence language', () => {
+    expect(() => renderMarkdown('```brainfuck\n+[-]\n```')).not.toThrow()
+  })
+
+  it('still highlights a registered language', () => {
+    expect(renderMarkdown('```go\npackage main\n```')).toContain('language-go')
+  })
 })
 
 describe('renderChecklistMarkdown', () => {

--- a/frontend/src/lib/markdown.ts
+++ b/frontend/src/lib/markdown.ts
@@ -6,9 +6,13 @@ import { markedHighlight } from 'marked-highlight'
 // ~915 kB / 304 kB-gzip chunk loaded eagerly (markdown rendering is on the
 // initial paint path). Registering only the languages we actually render in
 // agent output / task bodies / plans cuts that chunk by ~80%. Unregistered
-// languages fall back to 'plaintext' via the guard in highlight() below, so
-// the only cost is no syntax colour on an exotic language — never a crash.
+// (and empty / bare-```-fence) languages fall back to 'plaintext' in
+// highlight() below — so 'plaintext' MUST be registered too, otherwise the
+// fallback target is itself unknown and hljs.highlight() throws, aborting
+// marked.parse() and blanking every view that renders that markdown (a bare
+// ``` fence in a plan made the whole task detail page hang on "Loading…").
 import hljs from 'highlight.js/lib/core'
+import plaintext from 'highlight.js/lib/languages/plaintext'
 import bash from 'highlight.js/lib/languages/bash'
 import shell from 'highlight.js/lib/languages/shell'
 import javascript from 'highlight.js/lib/languages/javascript'
@@ -27,7 +31,7 @@ import css from 'highlight.js/lib/languages/css'
 import 'highlight.js/styles/github-dark.css'
 
 for (const [name, lang] of Object.entries({
-  bash, shell, javascript, typescript, json, yaml, go, python,
+  plaintext, bash, shell, javascript, typescript, json, yaml, go, python,
   rust, markdown, diff, dockerfile, sql, xml, css,
 })) {
   hljs.registerLanguage(name, lang)
@@ -52,6 +56,12 @@ marked.use(
     langPrefix: 'hljs language-',
     highlight(code: string, lang: string) {
       const language = hljs.getLanguage(lang) ? lang : 'plaintext'
+      // Defensive: a throw here aborts the whole marked.parse() and blanks any
+      // view rendering the markdown. If even the resolved grammar is somehow
+      // unregistered, return HTML-escaped code instead of letting hljs throw.
+      if (!hljs.getLanguage(language)) {
+        return code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      }
       return hljs.highlight(code, { language }).value
     },
   }),


### PR DESCRIPTION
## Motivation

A task in `plan-review` could not be opened from the board: the detail view
hung on "Loading…" with no error shown.

Root cause is in `frontend/src/lib/markdown.ts`. The app uses the slim
`highlight.js/lib/core` build and registers a curated language set — but not
`plaintext`, which is the fallback for any unknown or empty fence language.
A bare ` ``` ` fence (empty language) therefore resolved to `plaintext`,
`hljs.highlight()` threw `Unknown language: "plaintext"`, and that throw
aborted `marked.parse()`. Since `renderMarkdown` throws inside a child
component's render and `TaskDetail`'s try/catch only wraps the data fetch,
the whole subtree fails to mount — perpetual "Loading…". Any plan, body, or
agent output containing a bare/unregistered fence hit this.

> Changelog: fix(frontend): register plaintext hljs grammar so markdown with a bare ``` fence no longer crashes the view

## Implementation information

- Import and register the `plaintext` grammar so the existing fallback target
  actually exists.
- Harden the highlight callback: if the resolved grammar is somehow still
  unregistered, return HTML-escaped code instead of letting `hljs` throw — a
  render throw must never be able to blank a whole view.
- Add regression tests in `markdown.test.ts`: bare fence, unregistered fence
  language, and that a registered language still highlights.

Verified end-to-end by driving the rebuilt web bundle in a headless browser:
the detail view renders (Plan Review panel, rendered plan, Approve/Reject
buttons) with no JS errors.

## Supporting documentation

Gates green: `oxlint`, `svelte-check`, `vitest` (markdown suite 8/8).
