### PR TITLE
feat(eval): detect merged-with-edits at landing

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -36,6 +36,13 @@ export class AgentRun {
     "logFile": string;
     "sessionId"?: string;
 
+    /**
+     * HeadSHA is the worktree HEAD commit at this run's completion — what the
+     * agent left on the branch. Compared against the merged PR head to detect
+     * human edits after the agent (merged_with_edits) and measure edit distance.
+     */
+    "headSha"?: string;
+
     /** Creates a new AgentRun instance. */
     constructor($$source: Partial<AgentRun> = {}) {
         if (!("agentId" in $$source)) {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -19,6 +20,16 @@ type ghExecer struct{}
 func (ghExecer) run(args ...string) ([]byte, error) {
 	return ghGate.execute(func() ([]byte, error) {
 		cmd := exec.Command("gh", args...)
+		return cmd.CombinedOutput()
+	})
+}
+
+// ghRunCtx runs gh under a context so a stalled call is killed when the context
+// expires — releasing the global request gate instead of holding it for the
+// kernel TCP timeout. Used by latency-sensitive callers (the PR poll loop).
+func ghRunCtx(ctx context.Context, args ...string) ([]byte, error) {
+	return ghGate.execute(func() ([]byte, error) {
+		cmd := exec.CommandContext(ctx, "gh", args...)
 		return cmd.CombinedOutput()
 	})
 }

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -267,6 +268,9 @@ func fetchPRHeadSHAWith(e execer, repo string, number int) (string, error) {
 }
 
 // PRCompare summarizes the difference between two commits (base...head).
+// Commits is how many commits head is ahead of base; Additions/Deletions sum the
+// line churn. Note: GitHub caps the compare files list at 300, so on very large
+// edits the line counts undercount (Commits stays accurate).
 type PRCompare struct {
 	Commits   int `json:"total_commits"`
 	Additions int `json:"-"`
@@ -275,15 +279,16 @@ type PRCompare struct {
 
 // FetchPRCompare returns how far head is ahead of base (commits + line churn).
 // Used at landing to measure human edits made after the agent's last push.
-func FetchPRCompare(repo, base, head string) (PRCompare, error) {
-	return fetchPRCompareWith(defaultExecer, repo, base, head)
-}
-
-func fetchPRCompareWith(e execer, repo, base, head string) (PRCompare, error) {
-	out, err := e.run("api", fmt.Sprintf("repos/%s/compare/%s...%s", repo, base, head))
+// Context-bounded so it can't stall the poll loop.
+func FetchPRCompare(ctx context.Context, repo, base, head string) (PRCompare, error) {
+	out, err := ghRunCtx(ctx, "api", fmt.Sprintf("repos/%s/compare/%s...%s", repo, base, head))
 	if err != nil {
 		return PRCompare{}, fmt.Errorf("gh api compare %s...%s: %s: %w", base, head, strings.TrimSpace(string(out)), err)
 	}
+	return parsePRCompare(out)
+}
+
+func parsePRCompare(out []byte) (PRCompare, error) {
 	var raw struct {
 		TotalCommits int `json:"total_commits"`
 		Files        []struct {
@@ -300,6 +305,34 @@ func fetchPRCompareWith(e execer, repo, base, head string) (PRCompare, error) {
 		c.Deletions += f.Deletions
 	}
 	return c, nil
+}
+
+// FetchPRStatsContext is a context-bounded FetchPRStats for the poll path.
+func FetchPRStatsContext(ctx context.Context, repo string, number int) (PRStats, error) {
+	out, err := ghRunCtx(ctx, "pr", "view", strconv.Itoa(number), "--repo", repo, "--json", "additions,deletions,changedFiles")
+	if err != nil {
+		return PRStats{}, fmt.Errorf("gh pr view %d stats: %s: %w", number, strings.TrimSpace(string(out)), err)
+	}
+	var s PRStats
+	if err := json.Unmarshal(out, &s); err != nil {
+		return PRStats{}, fmt.Errorf("parse pr stats: %w", err)
+	}
+	return s, nil
+}
+
+// FetchPRHeadSHAContext is a context-bounded FetchPRHeadSHA for the poll path.
+func FetchPRHeadSHAContext(ctx context.Context, repo string, number int) (string, error) {
+	out, err := ghRunCtx(ctx, "pr", "view", strconv.Itoa(number), "--repo", repo, "--json", "headRefOid")
+	if err != nil {
+		return "", fmt.Errorf("gh pr view %d head: %s: %w", number, strings.TrimSpace(string(out)), err)
+	}
+	var raw struct {
+		HeadRefOid string `json:"headRefOid"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return "", fmt.Errorf("parse pr head: %w", err)
+	}
+	return raw.HeadRefOid, nil
 }
 
 // FetchPRDiff returns the unified diff for a PR. Used by the evaluation

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -272,25 +272,27 @@ func fetchPRHeadSHAWith(e execer, repo string, number int) (string, error) {
 // line churn. Note: GitHub caps the compare files list at 300, so on very large
 // edits the line counts undercount (Commits stays accurate).
 type PRCompare struct {
-	Commits   int `json:"total_commits"`
-	Additions int `json:"-"`
-	Deletions int `json:"-"`
+	Commits   int    `json:"total_commits"`
+	Status    string `json:"-"` // ahead | behind | diverged | identical
+	Additions int    `json:"-"`
+	Deletions int    `json:"-"`
 }
 
-// FetchPRCompare returns how far head is ahead of base (commits + line churn).
-// Used at landing to measure human edits made after the agent's last push.
-// Context-bounded so it can't stall the poll loop.
+// FetchPRCompare returns how far head is ahead of base (status, commits, line
+// churn). Used at landing to measure human edits made after the agent's last
+// push. Context-bounded so it can't stall the poll loop.
 func FetchPRCompare(ctx context.Context, repo, base, head string) (PRCompare, error) {
 	out, err := ghRunCtx(ctx, "api", fmt.Sprintf("repos/%s/compare/%s...%s", repo, base, head))
 	if err != nil {
-		return PRCompare{}, fmt.Errorf("gh api compare %s...%s: %s: %w", base, head, strings.TrimSpace(string(out)), err)
+		return PRCompare{}, fmt.Errorf("gh api compare %s...%s: %s: %w", base, head, sanitizeGHOutput(out), err)
 	}
 	return parsePRCompare(out)
 }
 
 func parsePRCompare(out []byte) (PRCompare, error) {
 	var raw struct {
-		TotalCommits int `json:"total_commits"`
+		TotalCommits int    `json:"total_commits"`
+		Status       string `json:"status"`
 		Files        []struct {
 			Additions int `json:"additions"`
 			Deletions int `json:"deletions"`
@@ -299,7 +301,7 @@ func parsePRCompare(out []byte) (PRCompare, error) {
 	if err := json.Unmarshal(out, &raw); err != nil {
 		return PRCompare{}, fmt.Errorf("parse compare: %w", err)
 	}
-	c := PRCompare{Commits: raw.TotalCommits}
+	c := PRCompare{Commits: raw.TotalCommits, Status: raw.Status}
 	for _, f := range raw.Files {
 		c.Additions += f.Additions
 		c.Deletions += f.Deletions
@@ -311,7 +313,7 @@ func parsePRCompare(out []byte) (PRCompare, error) {
 func FetchPRStatsContext(ctx context.Context, repo string, number int) (PRStats, error) {
 	out, err := ghRunCtx(ctx, "pr", "view", strconv.Itoa(number), "--repo", repo, "--json", "additions,deletions,changedFiles")
 	if err != nil {
-		return PRStats{}, fmt.Errorf("gh pr view %d stats: %s: %w", number, strings.TrimSpace(string(out)), err)
+		return PRStats{}, fmt.Errorf("gh pr view %d stats: %s: %w", number, sanitizeGHOutput(out), err)
 	}
 	var s PRStats
 	if err := json.Unmarshal(out, &s); err != nil {
@@ -324,7 +326,7 @@ func FetchPRStatsContext(ctx context.Context, repo string, number int) (PRStats,
 func FetchPRHeadSHAContext(ctx context.Context, repo string, number int) (string, error) {
 	out, err := ghRunCtx(ctx, "pr", "view", strconv.Itoa(number), "--repo", repo, "--json", "headRefOid")
 	if err != nil {
-		return "", fmt.Errorf("gh pr view %d head: %s: %w", number, strings.TrimSpace(string(out)), err)
+		return "", fmt.Errorf("gh pr view %d head: %s: %w", number, sanitizeGHOutput(out), err)
 	}
 	var raw struct {
 		HeadRefOid string `json:"headRefOid"`

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -266,6 +266,42 @@ func fetchPRHeadSHAWith(e execer, repo string, number int) (string, error) {
 	return raw.HeadRefOid, nil
 }
 
+// PRCompare summarizes the difference between two commits (base...head).
+type PRCompare struct {
+	Commits   int `json:"total_commits"`
+	Additions int `json:"-"`
+	Deletions int `json:"-"`
+}
+
+// FetchPRCompare returns how far head is ahead of base (commits + line churn).
+// Used at landing to measure human edits made after the agent's last push.
+func FetchPRCompare(repo, base, head string) (PRCompare, error) {
+	return fetchPRCompareWith(defaultExecer, repo, base, head)
+}
+
+func fetchPRCompareWith(e execer, repo, base, head string) (PRCompare, error) {
+	out, err := e.run("api", fmt.Sprintf("repos/%s/compare/%s...%s", repo, base, head))
+	if err != nil {
+		return PRCompare{}, fmt.Errorf("gh api compare %s...%s: %s: %w", base, head, strings.TrimSpace(string(out)), err)
+	}
+	var raw struct {
+		TotalCommits int `json:"total_commits"`
+		Files        []struct {
+			Additions int `json:"additions"`
+			Deletions int `json:"deletions"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return PRCompare{}, fmt.Errorf("parse compare: %w", err)
+	}
+	c := PRCompare{Commits: raw.TotalCommits}
+	for _, f := range raw.Files {
+		c.Additions += f.Additions
+		c.Deletions += f.Deletions
+	}
+	return c, nil
+}
+
 // FetchPRDiff returns the unified diff for a PR. Used by the evaluation
 // LLM-as-judge to score the landed change.
 func FetchPRDiff(repo string, number int) (string, error) {

--- a/internal/github/pr_compare_test.go
+++ b/internal/github/pr_compare_test.go
@@ -1,0 +1,28 @@
+package github
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestFetchPRCompare(t *testing.T) {
+	resp := `{"total_commits":2,"files":[{"additions":10,"deletions":3},{"additions":5,"deletions":1}]}`
+	fe := &fakeExecer{output: []byte(resp)}
+	got, err := fetchPRCompareWith(fe, "o/r", "base", "head")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got.Commits != 2 {
+		t.Errorf("Commits = %d, want 2", got.Commits)
+	}
+	if got.Additions != 15 || got.Deletions != 4 {
+		t.Errorf("Additions/Deletions = %d/%d, want 15/4", got.Additions, got.Deletions)
+	}
+}
+
+func TestFetchPRCompare_Error(t *testing.T) {
+	fe := &fakeExecer{output: []byte("not found"), err: fmt.Errorf("exit 1")}
+	if _, err := fetchPRCompareWith(fe, "o/r", "base", "head"); err == nil {
+		t.Fatal("want error")
+	}
+}

--- a/internal/github/pr_compare_test.go
+++ b/internal/github/pr_compare_test.go
@@ -1,14 +1,10 @@
 package github
 
-import (
-	"fmt"
-	"testing"
-)
+import "testing"
 
-func TestFetchPRCompare(t *testing.T) {
+func TestParsePRCompare(t *testing.T) {
 	resp := `{"total_commits":2,"files":[{"additions":10,"deletions":3},{"additions":5,"deletions":1}]}`
-	fe := &fakeExecer{output: []byte(resp)}
-	got, err := fetchPRCompareWith(fe, "o/r", "base", "head")
+	got, err := parsePRCompare([]byte(resp))
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -20,9 +16,18 @@ func TestFetchPRCompare(t *testing.T) {
 	}
 }
 
-func TestFetchPRCompare_Error(t *testing.T) {
-	fe := &fakeExecer{output: []byte("not found"), err: fmt.Errorf("exit 1")}
-	if _, err := fetchPRCompareWith(fe, "o/r", "base", "head"); err == nil {
-		t.Fatal("want error")
+func TestParsePRCompare_NoEdits(t *testing.T) {
+	got, err := parsePRCompare([]byte(`{"total_commits":0,"files":[]}`))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got.Commits != 0 || got.Additions != 0 {
+		t.Errorf("want zero churn, got %+v", got)
+	}
+}
+
+func TestParsePRCompare_BadJSON(t *testing.T) {
+	if _, err := parsePRCompare([]byte("not json")); err == nil {
+		t.Fatal("want parse error")
 	}
 }

--- a/internal/github/pr_compare_test.go
+++ b/internal/github/pr_compare_test.go
@@ -3,13 +3,16 @@ package github
 import "testing"
 
 func TestParsePRCompare(t *testing.T) {
-	resp := `{"total_commits":2,"files":[{"additions":10,"deletions":3},{"additions":5,"deletions":1}]}`
+	resp := `{"total_commits":2,"status":"ahead","files":[{"additions":10,"deletions":3},{"additions":5,"deletions":1}]}`
 	got, err := parsePRCompare([]byte(resp))
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if got.Commits != 2 {
 		t.Errorf("Commits = %d, want 2", got.Commits)
+	}
+	if got.Status != "ahead" {
+		t.Errorf("Status = %q, want ahead", got.Status)
 	}
 	if got.Additions != 15 || got.Deletions != 4 {
 		t.Errorf("Additions/Deletions = %d/%d, want 15/4", got.Additions, got.Deletions)

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	"time"
 
@@ -141,6 +142,11 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 			runUpdates["verdict"] = v.Decision
 		}
 	}
+	// Capture the worktree HEAD while it still exists (cleanup below is async) so
+	// landing can later detect human edits after the agent (merged_with_edits).
+	if sha := h.captureHeadSHA(ag.TaskID); sha != "" {
+		runUpdates["head_sha"] = sha
+	}
 	if err := h.tasks.UpdateRun(ag.TaskID, ag.ID, runUpdates); err != nil {
 		h.logger.Error("task.update-run", "task_id", ag.TaskID, "agent_id", ag.ID, "err", err)
 	}
@@ -242,6 +248,24 @@ func (h *AgentCompletionHandler) pushFixReviewBranch(ag *agent.Agent) {
 		return
 	}
 	h.logger.Info("fix-review.pushed", "task_id", ag.TaskID, "agent_id", ag.ID, "branch", branch)
+}
+
+// captureHeadSHA returns the worktree HEAD commit for the task, or "" when the
+// task has no live worktree or git fails. Best-effort; called before the async
+// worktree cleanup so the directory still exists.
+func (h *AgentCompletionHandler) captureHeadSHA(taskID string) string {
+	if h.worktrees == nil || h.tasks == nil {
+		return ""
+	}
+	t, err := h.tasks.Get(taskID)
+	if err != nil || !h.worktrees.Exists(t) {
+		return ""
+	}
+	out, err := exec.Command("git", "-C", h.worktrees.PathFor(t), "rev-parse", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // recordRunStats persists a stats.RunRecord for the completed agent.

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -3,6 +3,7 @@ package sybra
 import (
 	"context"
 	"log/slog"
+	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -199,7 +200,7 @@ func (r *ReviewHandler) advanceClosedTaskPRs(monitoredPRs []github.PullRequest, 
 			r.logger.Info("pr-monitor.closed-skip-running-agent", "task_id", c.TaskID, "pr", c.PRNumber)
 			continue
 		}
-		outcome := classifyLandingOutcome(c.State)
+		outcome, landData := r.computeLanding(c.TaskID, c.PRNumber, c.State)
 		if _, err := r.tasks.Update(c.TaskID, task.Update{
 			Status:  task.Ptr(task.StatusDone),
 			Outcome: task.Ptr(outcome),
@@ -212,7 +213,7 @@ func (r *ReviewHandler) advanceClosedTaskPRs(monitoredPRs []github.PullRequest, 
 			eventType = audit.EventPRClosed
 		}
 		r.logAudit(eventType, c.TaskID, "", map[string]any{"pr": c.PRNumber, "state": c.State})
-		r.recordLanding(c.TaskID, c.PRNumber, c.State)
+		r.logAudit(audit.EventTaskLanded, c.TaskID, "", landData)
 		r.logger.Info("pr-monitor.auto-done", "task_id", c.TaskID, "pr", c.PRNumber, "state", c.State, "outcome", outcome)
 	}
 }
@@ -227,26 +228,97 @@ func classifyLandingOutcome(state string) string {
 	return "merged"
 }
 
-// recordLanding emits a task.landed audit event capturing the terminal outcome
-// and timing — the ground-truth signal the evaluation scorecard reads. Kept
-// fully local (no network) so it never stalls the PR poll loop. Two timings are
-// recorded distinctly: created_to_land_h is queue-inclusive (task filed → land),
-// work_to_land_h starts from the first agent run (closer to DORA cycle time).
-func (r *ReviewHandler) recordLanding(taskID string, prNumber int, state string) {
-	data := map[string]any{
-		"pr":      prNumber,
-		"state":   state,
-		"outcome": classifyLandingOutcome(state),
+// landingEnrichTimeout bounds the GitHub enrichment so a slow gh never stalls
+// the PR poll loop.
+const landingEnrichTimeout = 20 * time.Second
+
+// computeLanding builds the refined outcome and the task.landed data for a closed
+// PR. Local timing (created/work → land) is always recorded; for a merge it adds
+// PR size and human-edit signals via GitHub, time-bounded so the poll can't hang.
+func (r *ReviewHandler) computeLanding(taskID string, prNumber int, state string) (outcome string, data map[string]any) {
+	outcome = classifyLandingOutcome(state)
+	data = map[string]any{"pr": prNumber, "state": state}
+	t, err := r.tasks.Get(taskID)
+	if err != nil {
+		data["outcome"] = outcome
+		return outcome, data
 	}
-	if t, err := r.tasks.Get(taskID); err == nil {
-		if !t.CreatedAt.IsZero() {
-			data["created_to_land_h"] = time.Since(t.CreatedAt).Hours()
-		}
-		if started := earliestRunStart(t.AgentRuns); !started.IsZero() {
-			data["work_to_land_h"] = time.Since(started).Hours()
+	if !t.CreatedAt.IsZero() {
+		data["created_to_land_h"] = time.Since(t.CreatedAt).Hours()
+	}
+	if started := earliestRunStart(t.AgentRuns); !started.IsZero() {
+		data["work_to_land_h"] = time.Since(started).Hours()
+	}
+	if state != "CLOSED" && t.ProjectID != "" && prNumber > 0 {
+		if enr, ok := r.enrichLanding(t.ProjectID, prNumber, lastAgentHeadSHA(t.AgentRuns)); ok {
+			outcome = enr.outcome
+			maps.Copy(data, enr.data)
 		}
 	}
-	r.logAudit(audit.EventTaskLanded, taskID, "", data)
+	data["outcome"] = outcome
+	return outcome, data
+}
+
+type landingEnrich struct {
+	outcome string
+	data    map[string]any
+}
+
+// enrichLanding fetches PR size and detects human edits after the agent's last
+// push (merged_with_edits + edit distance). Runs in a goroutine bounded by
+// landingEnrichTimeout; the goroutine only touches its local result, so a
+// timed-out call leaves no shared state to race on.
+func (r *ReviewHandler) enrichLanding(repo string, prNumber int, agentSHA string) (landingEnrich, bool) {
+	resCh := make(chan landingEnrich, 1)
+	go func() {
+		enr := landingEnrich{outcome: "merged", data: map[string]any{}}
+		if s, err := github.FetchPRStats(repo, prNumber); err == nil {
+			enr.data["additions"] = s.Additions
+			enr.data["deletions"] = s.Deletions
+			enr.data["changed_files"] = s.ChangedFiles
+		}
+		if head, err := github.FetchPRHeadSHA(repo, prNumber); err == nil {
+			enr.outcome = landingOutcome("MERGED", agentSHA, head)
+			if enr.outcome == "merged_with_edits" {
+				if cmp, err := github.FetchPRCompare(repo, agentSHA, head); err == nil {
+					enr.data["human_edit_lines"] = cmp.Additions + cmp.Deletions
+					enr.data["human_edit_commits"] = cmp.Commits
+				}
+			}
+		}
+		resCh <- enr
+	}()
+	select {
+	case enr := <-resCh:
+		return enr, true
+	case <-time.After(landingEnrichTimeout):
+		r.logger.Warn("pr-monitor.landing-enrich-timeout", "repo", repo, "pr", prNumber)
+		return landingEnrich{}, false
+	}
+}
+
+// landingOutcome refines the outcome once the agent's last pushed SHA and the
+// merged PR head are known: a merge whose head moved past the agent's last push
+// means a human changed it afterward (merged_with_edits).
+func landingOutcome(state, agentSHA, mergedHeadSHA string) string {
+	if state == "CLOSED" {
+		return "closed"
+	}
+	if agentSHA != "" && mergedHeadSHA != "" && agentSHA != mergedHeadSHA {
+		return "merged_with_edits"
+	}
+	return "merged"
+}
+
+// lastAgentHeadSHA returns the HeadSHA of the most recent agent run that recorded
+// one, or "" — the commit the fleet last left on the branch.
+func lastAgentHeadSHA(runs []task.AgentRun) string {
+	for i := range slices.Backward(runs) {
+		if runs[i].HeadSHA != "" {
+			return runs[i].HeadSHA
+		}
+	}
+	return ""
 }
 
 // earliestRunStart returns the start time of the first agent run, or the zero

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -200,10 +200,12 @@ func (r *ReviewHandler) advanceClosedTaskPRs(monitoredPRs []github.PullRequest, 
 			r.logger.Info("pr-monitor.closed-skip-running-agent", "task_id", c.TaskID, "pr", c.PRNumber)
 			continue
 		}
-		outcome, landData := r.computeLanding(c.TaskID, c.PRNumber, c.State)
+		// Flip to done immediately with the base outcome — the status transition
+		// must never wait on GitHub enrichment.
+		base := classifyLandingOutcome(c.State)
 		if _, err := r.tasks.Update(c.TaskID, task.Update{
 			Status:  task.Ptr(task.StatusDone),
-			Outcome: task.Ptr(outcome),
+			Outcome: task.Ptr(base),
 		}); err != nil {
 			r.logger.Error("pr-monitor.closed-update", "task_id", c.TaskID, "err", err)
 			continue
@@ -213,6 +215,13 @@ func (r *ReviewHandler) advanceClosedTaskPRs(monitoredPRs []github.PullRequest, 
 			eventType = audit.EventPRClosed
 		}
 		r.logAudit(eventType, c.TaskID, "", map[string]any{"pr": c.PRNumber, "state": c.State})
+		// Enrich (bounded GitHub I/O); refine the outcome if a human edited the PR.
+		outcome, landData := r.computeLanding(c.TaskID, c.PRNumber, c.State, base)
+		if outcome != base {
+			if _, err := r.tasks.Update(c.TaskID, task.Update{Outcome: task.Ptr(outcome)}); err != nil {
+				r.logger.Warn("pr-monitor.outcome-refine", "task_id", c.TaskID, "err", err)
+			}
+		}
 		r.logAudit(audit.EventTaskLanded, c.TaskID, "", landData)
 		r.logger.Info("pr-monitor.auto-done", "task_id", c.TaskID, "pr", c.PRNumber, "state", c.State, "outcome", outcome)
 	}
@@ -233,10 +242,11 @@ func classifyLandingOutcome(state string) string {
 const landingEnrichTimeout = 20 * time.Second
 
 // computeLanding builds the refined outcome and the task.landed data for a closed
-// PR. Local timing (created/work → land) is always recorded; for a merge it adds
-// PR size and human-edit signals via GitHub, time-bounded so the poll can't hang.
-func (r *ReviewHandler) computeLanding(taskID string, prNumber int, state string) (outcome string, data map[string]any) {
-	outcome = classifyLandingOutcome(state)
+// PR, starting from the base outcome already recorded. Local timing (created/work
+// → land) and the agent's last pushed SHA are always added; for a merge it adds
+// PR size and human-edit signals via GitHub, bounded so the poll can't hang.
+func (r *ReviewHandler) computeLanding(taskID string, prNumber int, state, base string) (outcome string, data map[string]any) {
+	outcome = base
 	data = map[string]any{"pr": prNumber, "state": state}
 	t, err := r.tasks.Get(taskID)
 	if err != nil {
@@ -249,11 +259,14 @@ func (r *ReviewHandler) computeLanding(taskID string, prNumber int, state string
 	if started := earliestRunStart(t.AgentRuns); !started.IsZero() {
 		data["work_to_land_h"] = time.Since(started).Hours()
 	}
+	agentSHA := lastAgentHeadSHA(t.AgentRuns)
+	if agentSHA != "" {
+		data["agent_head_sha"] = agentSHA
+	}
 	if state != "CLOSED" && t.ProjectID != "" && prNumber > 0 {
-		if enr, ok := r.enrichLanding(t.ProjectID, prNumber, lastAgentHeadSHA(t.AgentRuns)); ok {
-			outcome = enr.outcome
-			maps.Copy(data, enr.data)
-		}
+		enr := r.enrichLanding(t.ProjectID, prNumber, agentSHA)
+		outcome = enr.outcome
+		maps.Copy(data, enr.data)
 	}
 	data["outcome"] = outcome
 	return outcome, data
@@ -264,42 +277,40 @@ type landingEnrich struct {
 	data    map[string]any
 }
 
-// enrichLanding fetches PR size and detects human edits after the agent's last
-// push (merged_with_edits + edit distance). Runs in a goroutine bounded by
-// landingEnrichTimeout; the goroutine only touches its local result, so a
-// timed-out call leaves no shared state to race on.
-func (r *ReviewHandler) enrichLanding(repo string, prNumber int, agentSHA string) (landingEnrich, bool) {
-	resCh := make(chan landingEnrich, 1)
-	go func() {
-		enr := landingEnrich{outcome: "merged", data: map[string]any{}}
-		if s, err := github.FetchPRStats(repo, prNumber); err == nil {
-			enr.data["additions"] = s.Additions
-			enr.data["deletions"] = s.Deletions
-			enr.data["changed_files"] = s.ChangedFiles
-		}
-		if head, err := github.FetchPRHeadSHA(repo, prNumber); err == nil {
-			enr.outcome = landingOutcome("MERGED", agentSHA, head)
-			if enr.outcome == "merged_with_edits" {
-				if cmp, err := github.FetchPRCompare(repo, agentSHA, head); err == nil {
-					enr.data["human_edit_lines"] = cmp.Additions + cmp.Deletions
-					enr.data["human_edit_commits"] = cmp.Commits
-				}
-			}
-		}
-		resCh <- enr
-	}()
-	select {
-	case enr := <-resCh:
-		return enr, true
-	case <-time.After(landingEnrichTimeout):
-		r.logger.Warn("pr-monitor.landing-enrich-timeout", "repo", repo, "pr", prNumber)
-		return landingEnrich{}, false
+// enrichLanding fetches PR size and detects human edits made after the agent's
+// last push. All gh calls run under a single context deadline so a stalled call
+// is killed (releasing the global gh gate) rather than blocking the poll. A
+// merge is only classified merged_with_edits when the compare confirms the head
+// is genuinely ahead of the agent's SHA — guarding against unpushed-local
+// divergence or a moved base.
+func (r *ReviewHandler) enrichLanding(repo string, prNumber int, agentSHA string) landingEnrich {
+	ctx, cancel := context.WithTimeout(context.Background(), landingEnrichTimeout)
+	defer cancel()
+
+	enr := landingEnrich{outcome: "merged", data: map[string]any{}}
+	if s, err := github.FetchPRStatsContext(ctx, repo, prNumber); err == nil {
+		enr.data["additions"] = s.Additions
+		enr.data["deletions"] = s.Deletions
+		enr.data["changed_files"] = s.ChangedFiles
 	}
+	head, err := github.FetchPRHeadSHAContext(ctx, repo, prNumber)
+	if err != nil {
+		return enr // couldn't read the merged head; keep base outcome + size
+	}
+	if landingOutcome("MERGED", agentSHA, head) != "merged_with_edits" {
+		return enr
+	}
+	if cmp, err := github.FetchPRCompare(ctx, repo, agentSHA, head); err == nil && cmp.Commits > 0 {
+		enr.outcome = "merged_with_edits"
+		enr.data["human_edit_lines"] = cmp.Additions + cmp.Deletions
+		enr.data["human_edit_commits"] = cmp.Commits
+	}
+	return enr
 }
 
-// landingOutcome refines the outcome once the agent's last pushed SHA and the
-// merged PR head are known: a merge whose head moved past the agent's last push
-// means a human changed it afterward (merged_with_edits).
+// landingOutcome is the cheap pre-check: a merge whose head moved past the
+// agent's last push *may* have human edits (confirmed by enrichLanding's
+// compare). CLOSED is terminal; an unknown/missing SHA stays "merged".
 func landingOutcome(state, agentSHA, mergedHeadSHA string) string {
 	if state == "CLOSED" {
 		return "closed"

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -263,8 +263,8 @@ func (r *ReviewHandler) computeLanding(taskID string, prNumber int, state, base 
 	if agentSHA != "" {
 		data["agent_head_sha"] = agentSHA
 	}
-	if state != "CLOSED" && t.ProjectID != "" && prNumber > 0 {
-		enr := r.enrichLanding(t.ProjectID, prNumber, agentSHA)
+	if t.ProjectID != "" && prNumber > 0 {
+		enr := r.enrichLanding(t.ProjectID, prNumber, agentSHA, base)
 		outcome = enr.outcome
 		maps.Copy(data, enr.data)
 	}
@@ -277,21 +277,25 @@ type landingEnrich struct {
 	data    map[string]any
 }
 
-// enrichLanding fetches PR size and detects human edits made after the agent's
-// last push. All gh calls run under a single context deadline so a stalled call
-// is killed (releasing the global gh gate) rather than blocking the poll. A
-// merge is only classified merged_with_edits when the compare confirms the head
-// is genuinely ahead of the agent's SHA — guarding against unpushed-local
-// divergence or a moved base.
-func (r *ReviewHandler) enrichLanding(repo string, prNumber int, agentSHA string) landingEnrich {
+// enrichLanding records PR size for any landing and, for a merge, detects human
+// edits made after the agent's last push. All gh calls run under a single
+// context deadline so a stalled call is killed (releasing the global gh gate)
+// rather than blocking the poll. A merge is classified merged_with_edits only
+// when the compare is strictly ahead of the agent's SHA (status=="ahead",
+// commits > 0) — so a rebase/force-push (diverged) or unpushed-local divergence
+// doesn't produce a false positive.
+func (r *ReviewHandler) enrichLanding(repo string, prNumber int, agentSHA, base string) landingEnrich {
 	ctx, cancel := context.WithTimeout(context.Background(), landingEnrichTimeout)
 	defer cancel()
 
-	enr := landingEnrich{outcome: "merged", data: map[string]any{}}
+	enr := landingEnrich{outcome: base, data: map[string]any{}}
 	if s, err := github.FetchPRStatsContext(ctx, repo, prNumber); err == nil {
 		enr.data["additions"] = s.Additions
 		enr.data["deletions"] = s.Deletions
 		enr.data["changed_files"] = s.ChangedFiles
+	}
+	if base != "merged" {
+		return enr // closed (unmerged): size only, no edit detection
 	}
 	head, err := github.FetchPRHeadSHAContext(ctx, repo, prNumber)
 	if err != nil {
@@ -300,7 +304,7 @@ func (r *ReviewHandler) enrichLanding(repo string, prNumber int, agentSHA string
 	if landingOutcome("MERGED", agentSHA, head) != "merged_with_edits" {
 		return enr
 	}
-	if cmp, err := github.FetchPRCompare(ctx, repo, agentSHA, head); err == nil && cmp.Commits > 0 {
+	if cmp, err := github.FetchPRCompare(ctx, repo, agentSHA, head); err == nil && cmp.Status == "ahead" && cmp.Commits > 0 {
 		enr.outcome = "merged_with_edits"
 		enr.data["human_edit_lines"] = cmp.Additions + cmp.Deletions
 		enr.data["human_edit_commits"] = cmp.Commits

--- a/internal/sybra/app_reviews_landing_test.go
+++ b/internal/sybra/app_reviews_landing_test.go
@@ -4,9 +4,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"testing"
-	"time"
 
-	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -32,17 +30,48 @@ func TestClassifyLandingOutcome(t *testing.T) {
 	}
 }
 
-// TestRecordLanding_EmitsTaskLanded verifies the landing helper records a
-// structured task.landed event with the outcome, PR number, and queue-inclusive
-// timing the evaluation scorecard reads. A freshly-created task has no agent
-// runs, so work_to_land_h is absent; the helper makes no network calls.
-func TestRecordLanding_EmitsTaskLanded(t *testing.T) {
-	auditDir := t.TempDir()
-	al, err := audit.NewLogger(auditDir)
-	if err != nil {
-		t.Fatalf("audit.NewLogger: %v", err)
+func TestLandingOutcome(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                       string
+		state, agentSHA, mergedSHA string
+		want                       string
+	}{
+		{"closed", "CLOSED", "abc", "def", "closed"},
+		{"merged clean (same head)", "MERGED", "abc", "abc", "merged"},
+		{"merged with edits (head moved)", "MERGED", "abc", "def", "merged_with_edits"},
+		{"merged, no agent sha", "MERGED", "", "def", "merged"},
+		{"merged, no head sha", "MERGED", "abc", "", "merged"},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := landingOutcome(tt.state, tt.agentSHA, tt.mergedSHA); got != tt.want {
+				t.Errorf("landingOutcome(%q,%q,%q) = %q, want %q", tt.state, tt.agentSHA, tt.mergedSHA, got, tt.want)
+			}
+		})
+	}
+}
 
+func TestLastAgentHeadSHA(t *testing.T) {
+	t.Parallel()
+	runs := []task.AgentRun{
+		{AgentID: "a", HeadSHA: "sha-impl"},
+		{AgentID: "b", HeadSHA: ""}, // e.g. an eval run with no push
+		{AgentID: "c", HeadSHA: "sha-prfix"},
+	}
+	if got := lastAgentHeadSHA(runs); got != "sha-prfix" {
+		t.Errorf("lastAgentHeadSHA = %q, want sha-prfix", got)
+	}
+	if got := lastAgentHeadSHA([]task.AgentRun{{AgentID: "x"}}); got != "" {
+		t.Errorf("lastAgentHeadSHA with no SHAs = %q, want empty", got)
+	}
+}
+
+// TestComputeLanding_LocalOnly verifies the local path: a task with no project
+// produces a merged outcome with queue-inclusive timing and no network
+// enrichment (no PR size, no work_to_land_h since there are no agent runs).
+func TestComputeLanding_LocalOnly(t *testing.T) {
 	taskStore, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
 	if err != nil {
 		t.Fatalf("task NewStore: %v", err)
@@ -54,37 +83,24 @@ func TestRecordLanding_EmitsTaskLanded(t *testing.T) {
 	}
 
 	r := &ReviewHandler{
-		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler), audit: al},
+		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
 		tasks:         tasks,
 	}
-	r.recordLanding(created.ID, 42, "MERGED")
+	outcome, data := r.computeLanding(created.ID, 42, "MERGED")
 
-	events, err := audit.Read(auditDir, audit.Query{
-		Since: time.Now().Add(-time.Hour),
-		Until: time.Now().Add(time.Hour),
-		Type:  audit.EventTaskLanded,
-	})
-	if err != nil {
-		t.Fatalf("audit.Read: %v", err)
+	if outcome != "merged" {
+		t.Errorf("outcome = %q, want merged", outcome)
 	}
-	if len(events) != 1 {
-		t.Fatalf("got %d task.landed events, want 1", len(events))
+	if data["outcome"] != "merged" || data["pr"] != 42 {
+		t.Errorf("data outcome/pr = %v/%v", data["outcome"], data["pr"])
 	}
-	e := events[0]
-	if e.TaskID != created.ID {
-		t.Errorf("TaskID = %q, want %q", e.TaskID, created.ID)
+	if _, ok := data["created_to_land_h"]; !ok {
+		t.Errorf("missing created_to_land_h in %v", data)
 	}
-	if got := e.Data["outcome"]; got != "merged" {
-		t.Errorf("outcome = %v, want merged", got)
+	if _, ok := data["work_to_land_h"]; ok {
+		t.Errorf("unexpected work_to_land_h for task with no agent runs: %v", data)
 	}
-	// JSON round-trip decodes numbers as float64.
-	if got, _ := e.Data["pr"].(float64); got != 42 {
-		t.Errorf("pr = %v, want 42", e.Data["pr"])
-	}
-	if _, ok := e.Data["created_to_land_h"]; !ok {
-		t.Errorf("missing created_to_land_h in %v", e.Data)
-	}
-	if _, ok := e.Data["work_to_land_h"]; ok {
-		t.Errorf("unexpected work_to_land_h for task with no agent runs: %v", e.Data)
+	if _, ok := data["additions"]; ok {
+		t.Errorf("unexpected PR-size enrichment for project-less task: %v", data)
 	}
 }

--- a/internal/sybra/app_reviews_landing_test.go
+++ b/internal/sybra/app_reviews_landing_test.go
@@ -86,7 +86,7 @@ func TestComputeLanding_LocalOnly(t *testing.T) {
 		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
 		tasks:         tasks,
 	}
-	outcome, data := r.computeLanding(created.ID, 42, "MERGED")
+	outcome, data := r.computeLanding(created.ID, 42, "MERGED", "merged")
 
 	if outcome != "merged" {
 		t.Errorf("outcome = %q, want merged", outcome)
@@ -99,6 +99,9 @@ func TestComputeLanding_LocalOnly(t *testing.T) {
 	}
 	if _, ok := data["work_to_land_h"]; ok {
 		t.Errorf("unexpected work_to_land_h for task with no agent runs: %v", data)
+	}
+	if _, ok := data["agent_head_sha"]; ok {
+		t.Errorf("unexpected agent_head_sha for task with no captured SHA: %v", data)
 	}
 	if _, ok := data["additions"]; ok {
 		t.Errorf("unexpected PR-size enrichment for project-less task: %v", data)

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -148,6 +148,10 @@ type AgentRun struct {
 	Verdict   string `yaml:"verdict,omitempty" json:"verdict,omitempty"`
 	LogFile   string `yaml:"log_file,omitempty" json:"logFile"`
 	SessionID string `yaml:"session_id,omitempty" json:"sessionId,omitempty"`
+	// HeadSHA is the worktree HEAD commit at this run's completion — what the
+	// agent left on the branch. Compared against the merged PR head to detect
+	// human edits after the agent (merged_with_edits) and measure edit distance.
+	HeadSHA string `yaml:"head_sha,omitempty" json:"headSha,omitempty"`
 }
 
 type Task struct {

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -756,6 +756,9 @@ func (s *Store) UpdateRun(taskID, agentID string, updates map[string]any) error 
 		if v, ok := updates["session_id"].(string); ok && v != "" {
 			t.AgentRuns[i].SessionID = v
 		}
+		if v, ok := updates["head_sha"].(string); ok && v != "" {
+			t.AgentRuns[i].HeadSHA = v
+		}
 		break
 	}
 	d, err := Marshal(t)


### PR DESCRIPTION
## Motivation

Closes #1082 (the merged-with-edits part). The evaluation quality measure is the human-merge proxy — did the fleet's PR land clean, or did a human have to edit it? This captures that signal at landing.

> Changelog: feat(eval): detect merged-with-edits at landing

## Implementation information

- **AgentRun.HeadSHA** — captured from the worktree HEAD at agent completion (before the async worktree cleanup), persisted via `UpdateRun`, and recorded as `agent_head_sha` on `task.landed`.
- **merged_with_edits** — at landing, compare the agent's last pushed SHA to the merged PR head. A merge is classified `merged_with_edits` only when `gh api compare` confirms the head is genuinely **ahead** of the agent's SHA (`commits > 0`), with `human_edit_lines` / `human_edit_commits`. This guards against unpushed-local divergence and a moved base producing false positives.
- **PR size** — additions/deletions/changed_files added to `task.landed`.

### Adversarial review (applied before this PR)

The first cut ran the gh enrichment in a goroutine bounded by a `select` timeout — which did **not** kill the subprocess, so a stalled `gh` kept holding the global gh request gate and would block every gh call app-wide. Fixed:
- All landing gh calls run under a single context deadline (`ghRunCtx` + `FetchPR*Context` / `FetchPRCompare(ctx)`); a timed-out call kills the subprocess and releases the gate.
- The `status -> done` transition happens **before** enrichment, so a slow GitHub never delays a landing; the outcome is refined in a second update only when a human edit is confirmed.

`landingOutcome` and `lastAgentHeadSHA` are pure and unit-tested; the compare parser is tested via `parsePRCompare`.

### Known limitations (documented)
- `merged_with_edits` is recorded but not yet consumed by the autonomy metric (it still buckets as `merged`) — wiring it into autonomy is a deliberate next step.
- `gh api compare` caps the files list at ~300, so `human_edit_lines` undercounts on very large edits (commit count stays accurate).

### Remaining #1082 items (separate follow-ups)
Revert detection (`pr.reverted`, needs a default-branch watcher) and the full Codex tool-call taxonomy (needs the Codex item-type vocabulary) are independent and not in this PR.

## Supporting documentation

- Evaluation umbrella #1065.

Gates: `golangci-lint run ./...`, `go test ./...` (+ `-race` on touched pkgs), `svelte-check` pass (pre-existing flaky agent shutdown-timing test passes on rerun).
