### PR TITLE
fix(reviews): bound pr-fix review-comment loop

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/github/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/github/models.ts
@@ -155,10 +155,11 @@ export class PullRequest {
     "actionableCount": number;
 
     /**
-     * FeedbackSig fingerprints the current reviewer feedback (review decision +
-     * unresolved threads keyed by their latest reviewer comment). It changes
-     * only on genuinely new reviewer activity, not on the agent's own replies —
-     * so the pr-fix retry budget resets on new feedback and caps on stale.
+     * FeedbackSig fingerprints the current reviewer feedback (the review decision
+     * plus the set of unresolved thread IDs). It changes when the reviewer opens
+     * a new thread but not on the agent's own replies (a replied-to thread is
+     * still unresolved, so its ID stays in the set) — so the pr-fix retry budget
+     * resets on new feedback and caps on stale.
      */
     "feedbackSig": string;
     "viewerHasApproved": boolean;
@@ -298,10 +299,11 @@ export class RenovatePR {
     "actionableCount": number;
 
     /**
-     * FeedbackSig fingerprints the current reviewer feedback (review decision +
-     * unresolved threads keyed by their latest reviewer comment). It changes
-     * only on genuinely new reviewer activity, not on the agent's own replies —
-     * so the pr-fix retry budget resets on new feedback and caps on stale.
+     * FeedbackSig fingerprints the current reviewer feedback (the review decision
+     * plus the set of unresolved thread IDs). It changes when the reviewer opens
+     * a new thread but not on the agent's own replies (a replied-to thread is
+     * still unresolved, so its ID stays in the set) — so the pr-fix retry budget
+     * resets on new feedback and caps on stale.
      */
     "feedbackSig": string;
     "viewerHasApproved": boolean;

--- a/frontend/bindings/github.com/Automaat/sybra/internal/github/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/github/models.ts
@@ -144,6 +144,23 @@ export class PullRequest {
      */
     "mergeable": string;
     "unresolvedCount": number;
+
+    /**
+     * ActionableCount is the subset of unresolved threads where a reviewer
+     * (human or bot) left the last comment — i.e. the ball is in the agent's
+     * court. A thread the fix agent already replied to is unresolved but NOT
+     * actionable, so it stops re-triggering pr-fix. This is the dispatch
+     * trigger; UnresolvedCount stays the raw merge-gate signal.
+     */
+    "actionableCount": number;
+
+    /**
+     * FeedbackSig fingerprints the current reviewer feedback (review decision +
+     * unresolved threads keyed by their latest reviewer comment). It changes
+     * only on genuinely new reviewer activity, not on the agent's own replies —
+     * so the pr-fix retry budget resets on new feedback and caps on stale.
+     */
+    "feedbackSig": string;
     "viewerHasApproved": boolean;
 
     /**
@@ -199,6 +216,12 @@ export class PullRequest {
         }
         if (!("unresolvedCount" in $$source)) {
             this["unresolvedCount"] = 0;
+        }
+        if (!("actionableCount" in $$source)) {
+            this["actionableCount"] = 0;
+        }
+        if (!("feedbackSig" in $$source)) {
+            this["feedbackSig"] = "";
         }
         if (!("viewerHasApproved" in $$source)) {
             this["viewerHasApproved"] = false;
@@ -264,6 +287,23 @@ export class RenovatePR {
      */
     "mergeable": string;
     "unresolvedCount": number;
+
+    /**
+     * ActionableCount is the subset of unresolved threads where a reviewer
+     * (human or bot) left the last comment — i.e. the ball is in the agent's
+     * court. A thread the fix agent already replied to is unresolved but NOT
+     * actionable, so it stops re-triggering pr-fix. This is the dispatch
+     * trigger; UnresolvedCount stays the raw merge-gate signal.
+     */
+    "actionableCount": number;
+
+    /**
+     * FeedbackSig fingerprints the current reviewer feedback (review decision +
+     * unresolved threads keyed by their latest reviewer comment). It changes
+     * only on genuinely new reviewer activity, not on the agent's own replies —
+     * so the pr-fix retry budget resets on new feedback and caps on stale.
+     */
+    "feedbackSig": string;
     "viewerHasApproved": boolean;
 
     /**
@@ -321,6 +361,12 @@ export class RenovatePR {
         if (!("unresolvedCount" in $$source)) {
             this["unresolvedCount"] = 0;
         }
+        if (!("actionableCount" in $$source)) {
+            this["actionableCount"] = 0;
+        }
+        if (!("feedbackSig" in $$source)) {
+            this["feedbackSig"] = "";
+        }
         if (!("viewerHasApproved" in $$source)) {
             this["viewerHasApproved"] = false;
         }
@@ -345,13 +391,13 @@ export class RenovatePR {
      */
     static createFrom($$source: any = {}): RenovatePR {
         const $$createField7_0 = $$createType0;
-        const $$createField19_0 = $$createType2;
+        const $$createField21_0 = $$createType2;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("labels" in $$parsedSource) {
             $$parsedSource["labels"] = $$createField7_0($$parsedSource["labels"]);
         }
         if ("checkRuns" in $$parsedSource) {
-            $$parsedSource["checkRuns"] = $$createField19_0($$parsedSource["checkRuns"]);
+            $$parsedSource["checkRuns"] = $$createField21_0($$parsedSource["checkRuns"]);
         }
         return new RenovatePR($$parsedSource as Partial<RenovatePR>);
     }

--- a/frontend/src/components/PRCard.svelte.test.ts
+++ b/frontend/src/components/PRCard.svelte.test.ts
@@ -19,6 +19,8 @@ function makePR(overrides: Record<string, unknown> = {}) {
     reviewDecision: '',
     mergeable: '',
     unresolvedCount: 0,
+    actionableCount: 0,
+    feedbackSig: '',
     viewerHasApproved: false,
     copilotReviewed: false,
     createdAt: '2026-04-01T00:00:00Z',

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -21,6 +21,7 @@ const (
 	EventPRCIFailureDetected      = "pr_monitor.ci_failure_detected"
 	EventPRCommentsDetected       = "pr_monitor.comments_detected"
 	EventPRFixAgentStarted        = "pr_monitor.fix_agent_started"
+	EventPRFixExhausted           = "pr_monitor.fix_exhausted"
 	EventPRMerged                 = "pr_monitor.merged"
 	EventPRClosed                 = "pr_monitor.closed"
 	EventPRAutoMerged             = "pr_monitor.auto_merged"

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -354,11 +354,13 @@ func convertCommonPR(n *gqlPR, viewer string) PullRequest {
 
 // reviewFeedbackSig fingerprints a PR's reviewer feedback so the pr-fix retry
 // budget can tell genuinely-new feedback (reset the budget) from stale,
-// already-addressed feedback (let the budget cap and escalate). Tokens are
-// sorted so order is irrelevant; an "addressed" thread collapses to its stable
-// "D:<id>" token regardless of how many times the agent replies, so the agent's
-// own replies never reset the budget. Returns "" when there is no feedback at
-// all (no unresolved threads and no change request).
+// already-addressed feedback (let the budget cap and escalate). The tokens are
+// the unresolved-thread IDs; sorted and hashed with the review decision. Keying
+// on the thread set (not comment ids or who replied last) means the agent's own
+// replies never change the signature — a thread it replied to is still
+// unresolved, so its ID stays in the set — while a new reviewer thread does.
+// Returns "" when there is no feedback at all (no unresolved threads and no
+// change request).
 func reviewFeedbackSig(reviewDecision string, tokens []string) string {
 	if reviewDecision != "CHANGES_REQUESTED" && len(tokens) == 0 {
 		return ""

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -2,9 +2,12 @@ package github
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -123,7 +126,11 @@ const prQuery = `query($q: String!) {
           }
         }
         reviewThreads(first: 100) {
-          nodes { isResolved }
+          nodes {
+            id
+            isResolved
+            comments(last: 1) { nodes { id author { login } } }
+          }
         }
         latestReviews(first: 20) {
           nodes { state author { login } }
@@ -203,7 +210,16 @@ type gqlPR struct {
 	} `json:"commits"`
 	ReviewThreads struct {
 		Nodes []struct {
-			IsResolved bool `json:"isResolved"`
+			ID         string `json:"id"`
+			IsResolved bool   `json:"isResolved"`
+			Comments   struct {
+				Nodes []struct {
+					ID     string `json:"id"`
+					Author struct {
+						Login string `json:"login"`
+					} `json:"author"`
+				} `json:"nodes"`
+			} `json:"comments"`
 		} `json:"nodes"`
 	} `json:"reviewThreads"`
 	LatestReviews struct {
@@ -269,12 +285,37 @@ func convertCommonPR(n *gqlPR, viewer string) PullRequest {
 		}
 	}
 
-	var unresolved int
-	for _, t := range n.ReviewThreads.Nodes {
-		if !t.IsResolved {
-			unresolved++
+	// The fix agent acts as the authenticated user (viewer). On own-PRs that
+	// equals the PR author; fall back to it when the viewer lookup failed.
+	agentLogin := viewer
+	if agentLogin == "" {
+		agentLogin = n.Author.Login
+	}
+	var unresolved, actionable int
+	var sigTokens []string
+	for i := range n.ReviewThreads.Nodes {
+		th := &n.ReviewThreads.Nodes[i]
+		if th.IsResolved {
+			continue
+		}
+		unresolved++
+		var lastAuthor, lastID string
+		if len(th.Comments.Nodes) > 0 {
+			lc := th.Comments.Nodes[len(th.Comments.Nodes)-1]
+			lastAuthor = lc.Author.Login
+			lastID = lc.ID
+		}
+		// Actionable = a reviewer had the last word. Once the agent replies the
+		// thread drops out of the actionable set (so pr-fix stops re-firing) but
+		// stays unresolved (so the merge gate still holds until it's resolved).
+		if lastAuthor != "" && !strings.EqualFold(lastAuthor, agentLogin) {
+			actionable++
+			sigTokens = append(sigTokens, "A:"+th.ID+":"+lastID)
+		} else {
+			sigTokens = append(sigTokens, "D:"+th.ID)
 		}
 	}
+	feedbackSig := reviewFeedbackSig(n.ReviewDecision, sigTokens)
 
 	var viewerApproved bool
 	var copilotReviewed bool
@@ -303,11 +344,34 @@ func convertCommonPR(n *gqlPR, viewer string) PullRequest {
 		HasPendingChecks:  hasPendingChecks,
 		ReviewDecision:    n.ReviewDecision,
 		UnresolvedCount:   unresolved,
+		ActionableCount:   actionable,
+		FeedbackSig:       feedbackSig,
 		ViewerHasApproved: viewerApproved,
 		CopilotReviewed:   copilotReviewed,
 		CreatedAt:         n.CreatedAt,
 		UpdatedAt:         n.UpdatedAt,
 	}
+}
+
+// reviewFeedbackSig fingerprints a PR's reviewer feedback so the pr-fix retry
+// budget can tell genuinely-new feedback (reset the budget) from stale,
+// already-addressed feedback (let the budget cap and escalate). Tokens are
+// sorted so order is irrelevant; an "addressed" thread collapses to its stable
+// "D:<id>" token regardless of how many times the agent replies, so the agent's
+// own replies never reset the budget. Returns "" when there is no feedback at
+// all (no unresolved threads and no change request).
+func reviewFeedbackSig(reviewDecision string, tokens []string) string {
+	if reviewDecision != "CHANGES_REQUESTED" && len(tokens) == 0 {
+		return ""
+	}
+	sort.Strings(tokens)
+	h := sha256.New()
+	h.Write([]byte(reviewDecision))
+	for _, tok := range tokens {
+		h.Write([]byte{'\n'})
+		h.Write([]byte(tok))
+	}
+	return hex.EncodeToString(h.Sum(nil)[:8])
 }
 
 func convertPRs(nodes []gqlPR, viewer string) []PullRequest {

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -129,7 +129,7 @@ const prQuery = `query($q: String!) {
           nodes {
             id
             isResolved
-            comments(last: 1) { nodes { id author { login } } }
+            comments(last: 1) { nodes { author { login } } }
           }
         }
         latestReviews(first: 20) {
@@ -214,7 +214,6 @@ type gqlPR struct {
 			IsResolved bool   `json:"isResolved"`
 			Comments   struct {
 				Nodes []struct {
-					ID     string `json:"id"`
 					Author struct {
 						Login string `json:"login"`
 					} `json:"author"`
@@ -299,21 +298,21 @@ func convertCommonPR(n *gqlPR, viewer string) PullRequest {
 			continue
 		}
 		unresolved++
-		var lastAuthor, lastID string
+		var lastAuthor string
 		if len(th.Comments.Nodes) > 0 {
-			lc := th.Comments.Nodes[len(th.Comments.Nodes)-1]
-			lastAuthor = lc.Author.Login
-			lastID = lc.ID
+			lastAuthor = th.Comments.Nodes[len(th.Comments.Nodes)-1].Author.Login
 		}
 		// Actionable = a reviewer had the last word. Once the agent replies the
 		// thread drops out of the actionable set (so pr-fix stops re-firing) but
 		// stays unresolved (so the merge gate still holds until it's resolved).
 		if lastAuthor != "" && !strings.EqualFold(lastAuthor, agentLogin) {
 			actionable++
-			sigTokens = append(sigTokens, "A:"+th.ID+":"+lastID)
-		} else {
-			sigTokens = append(sigTokens, "D:"+th.ID)
 		}
+		// The signature keys on the unresolved-thread set + review decision only,
+		// not on who commented last or comment ids. So the agent's own replies
+		// never change it — the retry budget caps honestly at MaxRetries —
+		// while a new reviewer thread does change it (a fresh budget).
+		sigTokens = append(sigTokens, th.ID)
 	}
 	feedbackSig := reviewFeedbackSig(n.ReviewDecision, sigTokens)
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -284,19 +284,103 @@ func TestConvertPRs_unresolvedThreads(t *testing.T) {
 			node.Repository.NameWithOwner = "org/repo"
 
 			for _, resolved := range tt.threads {
-				node.ReviewThreads.Nodes = append(node.ReviewThreads.Nodes, struct {
-					IsResolved bool `json:"isResolved"`
-				}{IsResolved: resolved})
+				var n threadNode
+				n.IsResolved = resolved
+				// Each unresolved thread's last comment is a reviewer's, so it is
+				// also actionable (the ball is in the agent's court).
+				n.Comments.Nodes = []commentNode{{ID: "c", Author: authorLogin("reviewer")}}
+				node.ReviewThreads.Nodes = append(node.ReviewThreads.Nodes, n)
 			}
 
-			prs := convertPRs([]gqlPR{node}, "")
+			prs := convertPRs([]gqlPR{node}, "user")
 			if len(prs) != 1 {
 				t.Fatalf("got %d PRs, want 1", len(prs))
 			}
 			if prs[0].UnresolvedCount != tt.expected {
 				t.Errorf("UnresolvedCount = %d, want %d", prs[0].UnresolvedCount, tt.expected)
 			}
+			if prs[0].ActionableCount != tt.expected {
+				t.Errorf("ActionableCount = %d, want %d", prs[0].ActionableCount, tt.expected)
+			}
 		})
+	}
+}
+
+// threadNode / commentNode mirror the anonymous gqlPR.ReviewThreads node shape
+// so tests can build review-thread fixtures without spelling out the nested
+// anonymous structs at every call site.
+type threadNode = struct {
+	ID         string `json:"id"`
+	IsResolved bool   `json:"isResolved"`
+	Comments   struct {
+		Nodes []struct {
+			ID     string `json:"id"`
+			Author struct {
+				Login string `json:"login"`
+			} `json:"author"`
+		} `json:"nodes"`
+	} `json:"comments"`
+}
+
+type commentNode = struct {
+	ID     string `json:"id"`
+	Author struct {
+		Login string `json:"login"`
+	} `json:"author"`
+}
+
+func authorLogin(login string) struct {
+	Login string `json:"login"`
+} {
+	return struct {
+		Login string `json:"login"`
+	}{Login: login}
+}
+
+// TestConvertPRs_actionableAndSig locks the edge-trigger: a thread the agent
+// has replied to is unresolved but not actionable, and the feedback signature
+// is stable across the agent's own replies yet changes on new reviewer comments.
+func TestConvertPRs_actionableAndSig(t *testing.T) {
+	t.Parallel()
+	mk := func(lastAuthor, lastID string) gqlPR {
+		var n gqlPR
+		n.Number = 1
+		n.Author.Login = "me"
+		n.Author.Type = "User"
+		n.Repository.NameWithOwner = "o/r"
+		var th threadNode
+		th.ID = "T1"
+		th.Comments.Nodes = []commentNode{{ID: lastID, Author: authorLogin(lastAuthor)}}
+		n.ReviewThreads.Nodes = append(n.ReviewThreads.Nodes, th)
+		return n
+	}
+
+	// Reviewer had the last word → actionable, non-empty signature.
+	rev := convertPRs([]gqlPR{mk("copilot-pull-request-reviewer[bot]", "c1")}, "me")[0]
+	if rev.ActionableCount != 1 || rev.UnresolvedCount != 1 {
+		t.Fatalf("reviewer-last: actionable=%d unresolved=%d, want 1/1", rev.ActionableCount, rev.UnresolvedCount)
+	}
+	if rev.FeedbackSig == "" {
+		t.Fatal("reviewer-last: want non-empty FeedbackSig")
+	}
+
+	// Agent (viewer "me") replied last → unresolved but NOT actionable.
+	addr := convertPRs([]gqlPR{mk("me", "c2")}, "me")[0]
+	if addr.ActionableCount != 0 || addr.UnresolvedCount != 1 {
+		t.Fatalf("agent-last: actionable=%d unresolved=%d, want 0/1", addr.ActionableCount, addr.UnresolvedCount)
+	}
+
+	// The addressed signature must not change with the agent's own comment id —
+	// otherwise each reply would reset the retry budget and re-loop.
+	addr2 := convertPRs([]gqlPR{mk("me", "c2-different-id")}, "me")[0]
+	if addr.FeedbackSig != addr2.FeedbackSig {
+		t.Error("addressed signature changed with the agent's own comment id")
+	}
+
+	// A new reviewer comment id DOES change the signature (budget should reset).
+	rev2 := convertPRs([]gqlPR{mk("copilot-pull-request-reviewer[bot]", "c9")}, "me")[0]
+	if rev.FeedbackSig == rev2.FeedbackSig {
+		t.Error("new reviewer comment did not change the signature")
 	}
 }
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -288,7 +288,7 @@ func TestConvertPRs_unresolvedThreads(t *testing.T) {
 				n.IsResolved = resolved
 				// Each unresolved thread's last comment is a reviewer's, so it is
 				// also actionable (the ball is in the agent's court).
-				n.Comments.Nodes = []commentNode{{ID: "c", Author: authorLogin("reviewer")}}
+				n.Comments.Nodes = []commentNode{{Author: authorLogin("reviewer")}}
 				node.ReviewThreads.Nodes = append(node.ReviewThreads.Nodes, n)
 			}
 
@@ -314,7 +314,6 @@ type threadNode = struct {
 	IsResolved bool   `json:"isResolved"`
 	Comments   struct {
 		Nodes []struct {
-			ID     string `json:"id"`
 			Author struct {
 				Login string `json:"login"`
 			} `json:"author"`
@@ -323,7 +322,6 @@ type threadNode = struct {
 }
 
 type commentNode = struct {
-	ID     string `json:"id"`
 	Author struct {
 		Login string `json:"login"`
 	} `json:"author"`
@@ -337,50 +335,54 @@ func authorLogin(login string) struct {
 	}{Login: login}
 }
 
-// TestConvertPRs_actionableAndSig locks the edge-trigger: a thread the agent
-// has replied to is unresolved but not actionable, and the feedback signature
-// is stable across the agent's own replies yet changes on new reviewer comments.
+// TestConvertPRs_actionableAndSig locks two properties: (1) a thread the agent
+// replied to is unresolved but NOT actionable (so pr-fix stops firing), and
+// (2) the feedback signature is stable across the agent's own replies but
+// changes when the reviewer opens a new thread (so the retry budget caps on
+// stale feedback yet resets on genuinely new feedback).
 func TestConvertPRs_actionableAndSig(t *testing.T) {
 	t.Parallel()
-	mk := func(lastAuthor, lastID string) gqlPR {
+	// mk builds a PR whose unresolved threads each have the given last-comment
+	// author. Thread IDs are positional ("T0", "T1", ...).
+	mk := func(lastAuthors ...string) PullRequest {
 		var n gqlPR
 		n.Number = 1
 		n.Author.Login = "me"
 		n.Author.Type = "User"
 		n.Repository.NameWithOwner = "o/r"
-		var th threadNode
-		th.ID = "T1"
-		th.Comments.Nodes = []commentNode{{ID: lastID, Author: authorLogin(lastAuthor)}}
-		n.ReviewThreads.Nodes = append(n.ReviewThreads.Nodes, th)
-		return n
+		for i, la := range lastAuthors {
+			var th threadNode
+			th.ID = "T" + string(rune('0'+i))
+			th.Comments.Nodes = []commentNode{{Author: authorLogin(la)}}
+			n.ReviewThreads.Nodes = append(n.ReviewThreads.Nodes, th)
+		}
+		return convertPRs([]gqlPR{n}, "me")[0]
 	}
+
+	const copilot = "copilot-pull-request-reviewer[bot]"
 
 	// Reviewer had the last word → actionable, non-empty signature.
-	rev := convertPRs([]gqlPR{mk("copilot-pull-request-reviewer[bot]", "c1")}, "me")[0]
-	if rev.ActionableCount != 1 || rev.UnresolvedCount != 1 {
-		t.Fatalf("reviewer-last: actionable=%d unresolved=%d, want 1/1", rev.ActionableCount, rev.UnresolvedCount)
-	}
-	if rev.FeedbackSig == "" {
-		t.Fatal("reviewer-last: want non-empty FeedbackSig")
+	rev := mk(copilot)
+	if rev.ActionableCount != 1 || rev.UnresolvedCount != 1 || rev.FeedbackSig == "" {
+		t.Fatalf("reviewer-last: actionable=%d unresolved=%d sig=%q, want 1/1/non-empty",
+			rev.ActionableCount, rev.UnresolvedCount, rev.FeedbackSig)
 	}
 
-	// Agent (viewer "me") replied last → unresolved but NOT actionable.
-	addr := convertPRs([]gqlPR{mk("me", "c2")}, "me")[0]
+	// Agent (viewer "me") replied last → unresolved but NOT actionable, and the
+	// signature is unchanged (same thread set) — the agent's reply must not reset
+	// the retry budget.
+	addr := mk("me")
 	if addr.ActionableCount != 0 || addr.UnresolvedCount != 1 {
 		t.Fatalf("agent-last: actionable=%d unresolved=%d, want 0/1", addr.ActionableCount, addr.UnresolvedCount)
 	}
-
-	// The addressed signature must not change with the agent's own comment id —
-	// otherwise each reply would reset the retry budget and re-loop.
-	addr2 := convertPRs([]gqlPR{mk("me", "c2-different-id")}, "me")[0]
-	if addr.FeedbackSig != addr2.FeedbackSig {
-		t.Error("addressed signature changed with the agent's own comment id")
+	if addr.FeedbackSig != rev.FeedbackSig {
+		t.Error("signature changed when the agent replied (same thread set) — would reset the budget")
 	}
 
-	// A new reviewer comment id DOES change the signature (budget should reset).
-	rev2 := convertPRs([]gqlPR{mk("copilot-pull-request-reviewer[bot]", "c9")}, "me")[0]
-	if rev.FeedbackSig == rev2.FeedbackSig {
-		t.Error("new reviewer comment did not change the signature")
+	// A new reviewer thread changes the thread set → new signature → fresh budget.
+	rev2 := mk(copilot, copilot)
+	if rev2.FeedbackSig == rev.FeedbackSig {
+		t.Error("new reviewer thread did not change the signature")
 	}
 }
 

--- a/internal/github/debounce.go
+++ b/internal/github/debounce.go
@@ -57,7 +57,7 @@ func issueKey(taskID string, kind PRIssueKind) string {
 // Decide is the signature-aware dispatch gate. When sig differs from the last
 // one recorded for this issue, the feedback genuinely changed since the last
 // attempt, so the retry budget resets (new feedback deserves a fresh response).
-// When sig is unchanged it caps at MaxFixRetries and returns DispatchExhausted —
+// When sig is unchanged it caps at MaxRetries and returns DispatchExhausted —
 // the caller escalates to a human instead of looping forever. A "" sig disables
 // signature gating (legacy SHA-only behavior), used for issue kinds without a
 // feedback fingerprint (conflict, ci_failure, ready_to_merge).
@@ -154,17 +154,18 @@ func (t *IssueTracker) Cleanup() {
 	defer t.mu.Unlock()
 	cutoff := t.now().Add(-2 * t.cooldown)
 	for k, v := range t.handled {
-		if v.Before(cutoff) {
-			if t.retries[k] >= maxRetries {
-				// At cap: keep retries/lastSHA so the caller can escalate;
-				// only drop the time-based handled entry (no more cooldown).
-				delete(t.handled, k)
-				continue
-			}
-			delete(t.handled, k)
-			delete(t.retries, k)
-			delete(t.lastSHA, k)
-			delete(t.sigs, k)
+		if !v.Before(cutoff) {
+			continue
 		}
+		if t.retries[k] >= maxRetries {
+			// At cap: keep retries/lastSHA so the caller can escalate;
+			// only drop the time-based handled entry (no more cooldown).
+			delete(t.handled, k)
+			continue
+		}
+		delete(t.handled, k)
+		delete(t.retries, k)
+		delete(t.lastSHA, k)
+		delete(t.sigs, k)
 	}
 }

--- a/internal/github/debounce.go
+++ b/internal/github/debounce.go
@@ -7,9 +7,24 @@ import (
 
 const maxRetries = 3
 
-// MaxRetries is the exported retry cap for callers that need to reference it
-// in escalation messages or tests.
+// MaxRetries is the per-issue retry budget the monitor allows before escalating
+// to a human. Exported for callers that reference it in escalation messages or
+// tests.
 const MaxRetries = maxRetries
+
+// DispatchDecision is the verdict of Decide for one detected PR issue.
+type DispatchDecision int
+
+const (
+	// DispatchSkip: do nothing this cycle (cooldown, no new commit, or the
+	// exact attempt already ran).
+	DispatchSkip DispatchDecision = iota
+	// DispatchHandle: dispatch a fix agent now.
+	DispatchHandle
+	// DispatchExhausted: the retry budget for the current feedback signature is
+	// spent — escalate to a human instead of looping.
+	DispatchExhausted
+)
 
 // IssueTracker prevents re-dispatching agents for the same PR issue
 // within a cooldown period and caps total retries.
@@ -18,6 +33,7 @@ type IssueTracker struct {
 	handled  map[string]time.Time
 	retries  map[string]int
 	lastSHA  map[string]string
+	sigs     map[string]string
 	cooldown time.Duration
 	now      func() time.Time // injectable for testing
 }
@@ -28,6 +44,7 @@ func NewIssueTracker(cooldown time.Duration) *IssueTracker {
 		handled:  make(map[string]time.Time),
 		retries:  make(map[string]int),
 		lastSHA:  make(map[string]string),
+		sigs:     make(map[string]string),
 		cooldown: cooldown,
 		now:      time.Now,
 	}
@@ -37,26 +54,49 @@ func issueKey(taskID string, kind PRIssueKind) string {
 	return taskID + ":" + string(kind)
 }
 
-// ShouldHandle returns true if this issue should be retried.
-// Blocks when: max retries reached, same SHA as last attempt (no new commit),
-// or within cooldown window (first attempt or SHA unknown).
-func (t *IssueTracker) ShouldHandle(taskID string, kind PRIssueKind, sha string) bool {
+// Decide is the signature-aware dispatch gate. When sig differs from the last
+// one recorded for this issue, the feedback genuinely changed since the last
+// attempt, so the retry budget resets (new feedback deserves a fresh response).
+// When sig is unchanged it caps at MaxFixRetries and returns DispatchExhausted —
+// the caller escalates to a human instead of looping forever. A "" sig disables
+// signature gating (legacy SHA-only behavior), used for issue kinds without a
+// feedback fingerprint (conflict, ci_failure, ready_to_merge).
+func (t *IssueTracker) Decide(taskID string, kind PRIssueKind, sha, sig string) DispatchDecision {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	key := issueKey(taskID, kind)
+
+	// New feedback since the last attempt: reset the budget and the per-commit
+	// gate so the agent can respond to it immediately.
+	if sig != "" && t.sigs[key] != sig {
+		t.retries[key] = 0
+		delete(t.handled, key)
+		delete(t.lastSHA, key)
+		t.sigs[key] = sig
+	}
+
 	if t.retries[key] >= maxRetries {
-		return false
+		return DispatchExhausted
 	}
 	// If SHA is known and unchanged, the fix attempt ran against this exact
 	// commit with no new push since — skip until a new commit arrives.
 	if sha != "" && t.lastSHA[key] == sha {
-		return false
+		return DispatchSkip
 	}
 	last, ok := t.handled[key]
 	if !ok {
-		return true
+		return DispatchHandle
 	}
-	return t.now().Sub(last) >= t.cooldown
+	if t.now().Sub(last) >= t.cooldown {
+		return DispatchHandle
+	}
+	return DispatchSkip
+}
+
+// ShouldHandle returns true if this issue should be retried. Equivalent to
+// Decide with no feedback signature (SHA-only gating).
+func (t *IssueTracker) ShouldHandle(taskID string, kind PRIssueKind, sha string) bool {
+	return t.Decide(taskID, kind, sha, "") == DispatchHandle
 }
 
 // MarkHandled records that an agent was spawned for this issue.
@@ -88,6 +128,7 @@ func (t *IssueTracker) Clear(taskID string, kind PRIssueKind) {
 	delete(t.handled, key)
 	delete(t.retries, key)
 	delete(t.lastSHA, key)
+	delete(t.sigs, key)
 }
 
 // Retries returns the current retry count for a task+issue.
@@ -123,6 +164,7 @@ func (t *IssueTracker) Cleanup() {
 			delete(t.handled, k)
 			delete(t.retries, k)
 			delete(t.lastSHA, k)
+			delete(t.sigs, k)
 		}
 	}
 }

--- a/internal/github/debounce_test.go
+++ b/internal/github/debounce_test.go
@@ -2,9 +2,51 @@ package github
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 )
+
+// TestIssueTracker_DecideSignature locks the loop fix: a fix agent that keeps
+// pushing new commits against the SAME unchanged feedback signature exhausts the
+// budget (so the monitor escalates instead of looping), while genuinely new
+// reviewer feedback resets it.
+func TestIssueTracker_DecideSignature(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 4, 3, 12, 0, 0, 0, time.UTC)
+	tr := NewIssueTracker(30 * time.Minute)
+	tr.now = func() time.Time { return now }
+
+	if got := tr.Decide("t1", PRIssueComments, "sha1", "sigA"); got != DispatchHandle {
+		t.Fatalf("first dispatch = %v, want Handle", got)
+	}
+	tr.MarkHandled("t1", PRIssueComments, "sha1")
+
+	if got := tr.Decide("t1", PRIssueComments, "sha1", "sigA"); got != DispatchSkip {
+		t.Fatalf("same sha/sig within cooldown = %v, want Skip", got)
+	}
+
+	// A new commit each round (defeating the old SHA-only cap) must NOT keep the
+	// loop alive: the unchanged sig caps the budget.
+	for i := 1; i < MaxRetries; i++ {
+		now = now.Add(31 * time.Minute)
+		sha := "sha" + strconv.Itoa(i+1)
+		if got := tr.Decide("t1", PRIssueComments, sha, "sigA"); got != DispatchHandle {
+			t.Fatalf("round %d = %v, want Handle", i, got)
+		}
+		tr.MarkHandled("t1", PRIssueComments, sha)
+	}
+
+	now = now.Add(31 * time.Minute)
+	if got := tr.Decide("t1", PRIssueComments, "sha-new", "sigA"); got != DispatchExhausted {
+		t.Fatalf("budget spent on unchanged sig = %v, want Exhausted", got)
+	}
+
+	// Genuinely new feedback (different sig) resets the budget.
+	if got := tr.Decide("t1", PRIssueComments, "sha-new", "sigB"); got != DispatchHandle {
+		t.Fatalf("new feedback = %v, want Handle", got)
+	}
+}
 
 func TestIssueTracker(t *testing.T) {
 	t.Parallel()

--- a/internal/github/model.go
+++ b/internal/github/model.go
@@ -23,10 +23,11 @@ type PullRequest struct {
 	// actionable, so it stops re-triggering pr-fix. This is the dispatch
 	// trigger; UnresolvedCount stays the raw merge-gate signal.
 	ActionableCount int `json:"actionableCount"`
-	// FeedbackSig fingerprints the current reviewer feedback (review decision +
-	// unresolved threads keyed by their latest reviewer comment). It changes
-	// only on genuinely new reviewer activity, not on the agent's own replies —
-	// so the pr-fix retry budget resets on new feedback and caps on stale.
+	// FeedbackSig fingerprints the current reviewer feedback (the review decision
+	// plus the set of unresolved thread IDs). It changes when the reviewer opens
+	// a new thread but not on the agent's own replies (a replied-to thread is
+	// still unresolved, so its ID stays in the set) — so the pr-fix retry budget
+	// resets on new feedback and caps on stale.
 	FeedbackSig       string `json:"feedbackSig"`
 	ViewerHasApproved bool   `json:"viewerHasApproved"`
 	CopilotReviewed   bool   `json:"copilotReviewed"` // GitHub Copilot has submitted a review

--- a/internal/github/model.go
+++ b/internal/github/model.go
@@ -2,25 +2,36 @@ package github
 
 // PullRequest represents a GitHub pull request for display.
 type PullRequest struct {
-	Number            int      `json:"number"`
-	Title             string   `json:"title"`
-	URL               string   `json:"url"`
-	Repository        string   `json:"repository"`
-	RepoName          string   `json:"repoName"`
-	Author            string   `json:"author"`
-	IsDraft           bool     `json:"isDraft"`
-	Labels            []string `json:"labels"`
-	HeadRefName       string   `json:"headRefName"`
-	HeadSHA           string   `json:"headSha"`
-	CIStatus          string   `json:"ciStatus"`         // SUCCESS, FAILURE, PENDING, or ""
-	HasPendingChecks  bool     `json:"hasPendingChecks"` // true when any check is still in-progress/queued
-	ReviewDecision    string   `json:"reviewDecision"`   // APPROVED, CHANGES_REQUESTED, REVIEW_REQUIRED, or ""
-	Mergeable         string   `json:"mergeable"`        // MERGEABLE, CONFLICTING, UNKNOWN, or ""
-	UnresolvedCount   int      `json:"unresolvedCount"`
-	ViewerHasApproved bool     `json:"viewerHasApproved"`
-	CopilotReviewed   bool     `json:"copilotReviewed"` // GitHub Copilot has submitted a review
-	CreatedAt         string   `json:"createdAt"`
-	UpdatedAt         string   `json:"updatedAt"`
+	Number           int      `json:"number"`
+	Title            string   `json:"title"`
+	URL              string   `json:"url"`
+	Repository       string   `json:"repository"`
+	RepoName         string   `json:"repoName"`
+	Author           string   `json:"author"`
+	IsDraft          bool     `json:"isDraft"`
+	Labels           []string `json:"labels"`
+	HeadRefName      string   `json:"headRefName"`
+	HeadSHA          string   `json:"headSha"`
+	CIStatus         string   `json:"ciStatus"`         // SUCCESS, FAILURE, PENDING, or ""
+	HasPendingChecks bool     `json:"hasPendingChecks"` // true when any check is still in-progress/queued
+	ReviewDecision   string   `json:"reviewDecision"`   // APPROVED, CHANGES_REQUESTED, REVIEW_REQUIRED, or ""
+	Mergeable        string   `json:"mergeable"`        // MERGEABLE, CONFLICTING, UNKNOWN, or ""
+	UnresolvedCount  int      `json:"unresolvedCount"`
+	// ActionableCount is the subset of unresolved threads where a reviewer
+	// (human or bot) left the last comment — i.e. the ball is in the agent's
+	// court. A thread the fix agent already replied to is unresolved but NOT
+	// actionable, so it stops re-triggering pr-fix. This is the dispatch
+	// trigger; UnresolvedCount stays the raw merge-gate signal.
+	ActionableCount int `json:"actionableCount"`
+	// FeedbackSig fingerprints the current reviewer feedback (review decision +
+	// unresolved threads keyed by their latest reviewer comment). It changes
+	// only on genuinely new reviewer activity, not on the agent's own replies —
+	// so the pr-fix retry budget resets on new feedback and caps on stale.
+	FeedbackSig       string `json:"feedbackSig"`
+	ViewerHasApproved bool   `json:"viewerHasApproved"`
+	CopilotReviewed   bool   `json:"copilotReviewed"` // GitHub Copilot has submitted a review
+	CreatedAt         string `json:"createdAt"`
+	UpdatedAt         string `json:"updatedAt"`
 }
 
 // ReviewSummary contains PRs grouped by relationship to the user.

--- a/internal/github/monitor.go
+++ b/internal/github/monitor.go
@@ -107,9 +107,11 @@ func MatchTaskPRs(prs []PullRequest, tasks []TaskMatcher) []PRIssue {
 		if pr.CIStatus == "FAILURE" && !pr.HasPendingChecks {
 			issues = append(issues, PRIssue{Kind: PRIssueCIFailure, TaskID: tm.ID, PR: *pr})
 		}
-		// Reviewers asked for changes or left unresolved threads — dispatch a
-		// fix-review agent. Skip drafts: the author is still iterating.
-		if !pr.IsDraft && (pr.ReviewDecision == "CHANGES_REQUESTED" || pr.UnresolvedCount > 0) {
+		// Reviewers asked for changes or left actionable threads (a reviewer had
+		// the last word) — dispatch a fix-review agent. Threads the agent has
+		// already replied to are unresolved but NOT actionable, so they no longer
+		// re-trigger pr-fix. Skip drafts: the author is still iterating.
+		if !pr.IsDraft && (pr.ReviewDecision == "CHANGES_REQUESTED" || pr.ActionableCount > 0) {
 			issues = append(issues, PRIssue{Kind: PRIssueComments, TaskID: tm.ID, PR: *pr})
 		}
 		if !pr.IsDraft && pr.Mergeable == "MERGEABLE" && (pr.CIStatus == "SUCCESS" || pr.CIStatus == "") {

--- a/internal/github/monitor_test.go
+++ b/internal/github/monitor_test.go
@@ -110,10 +110,16 @@ func TestMatchTaskPRs(t *testing.T) {
 			want:  []PRIssue{{Kind: PRIssueComments, TaskID: "t1"}},
 		},
 		{
-			name:  "unresolved threads → comments fix",
-			prs:   []PullRequest{{Number: 42, UnresolvedCount: 2}},
+			name:  "actionable threads → comments fix",
+			prs:   []PullRequest{{Number: 42, UnresolvedCount: 2, ActionableCount: 2}},
 			tasks: []TaskMatcher{{ID: "t1", PRNumber: 42}},
 			want:  []PRIssue{{Kind: PRIssueComments, TaskID: "t1"}},
+		},
+		{
+			name:  "unresolved but addressed (agent replied) → no comments fix",
+			prs:   []PullRequest{{Number: 42, UnresolvedCount: 2, ActionableCount: 0}},
+			tasks: []TaskMatcher{{ID: "t1", PRNumber: 42}},
+			want:  nil,
 		},
 		{
 			name:  "draft with comments is not fixed",

--- a/internal/github/threads.go
+++ b/internal/github/threads.go
@@ -10,10 +10,11 @@ import (
 // decide whether a Copilot-authored thread has been addressed and can be
 // auto-resolved.
 type ReviewThread struct {
-	ID          string
-	AuthorLogin string // login of the thread's first comment author
-	IsResolved  bool
-	IsOutdated  bool // the anchored code changed since the comment — i.e. addressed
+	ID              string
+	AuthorLogin     string // login of the thread's first comment author
+	LastAuthorLogin string // login of the thread's most recent comment author
+	IsResolved      bool
+	IsOutdated      bool // the anchored code changed since the comment — i.e. addressed
 }
 
 const reviewThreadsQuery = `query($owner: String!, $name: String!, $number: Int!) {
@@ -24,7 +25,8 @@ const reviewThreadsQuery = `query($owner: String!, $name: String!, $number: Int!
           id
           isResolved
           isOutdated
-          comments(first: 1) { nodes { author { login } } }
+          first: comments(first: 1) { nodes { author { login } } }
+          last: comments(last: 1) { nodes { author { login } } }
         }
       }
     }
@@ -40,13 +42,20 @@ type gqlReviewThreadsResponse struct {
 						ID         string `json:"id"`
 						IsResolved bool   `json:"isResolved"`
 						IsOutdated bool   `json:"isOutdated"`
-						Comments   struct {
+						First      struct {
 							Nodes []struct {
 								Author struct {
 									Login string `json:"login"`
 								} `json:"author"`
 							} `json:"nodes"`
-						} `json:"comments"`
+						} `json:"first"`
+						Last struct {
+							Nodes []struct {
+								Author struct {
+									Login string `json:"login"`
+								} `json:"author"`
+							} `json:"nodes"`
+						} `json:"last"`
 					} `json:"nodes"`
 				} `json:"reviewThreads"`
 			} `json:"pullRequest"`
@@ -92,15 +101,19 @@ func fetchReviewThreadsWith(e execer, repo string, number int) ([]ReviewThread, 
 	nodes := gqlResp.Data.Repository.PullRequest.ReviewThreads.Nodes
 	threads := make([]ReviewThread, 0, len(nodes))
 	for i := range nodes {
-		var login string
-		if len(nodes[i].Comments.Nodes) > 0 {
-			login = nodes[i].Comments.Nodes[0].Author.Login
+		var firstLogin, lastLogin string
+		if len(nodes[i].First.Nodes) > 0 {
+			firstLogin = nodes[i].First.Nodes[0].Author.Login
+		}
+		if len(nodes[i].Last.Nodes) > 0 {
+			lastLogin = nodes[i].Last.Nodes[0].Author.Login
 		}
 		threads = append(threads, ReviewThread{
-			ID:          nodes[i].ID,
-			AuthorLogin: login,
-			IsResolved:  nodes[i].IsResolved,
-			IsOutdated:  nodes[i].IsOutdated,
+			ID:              nodes[i].ID,
+			AuthorLogin:     firstLogin,
+			LastAuthorLogin: lastLogin,
+			IsResolved:      nodes[i].IsResolved,
+			IsOutdated:      nodes[i].IsOutdated,
 		})
 	}
 	return threads, nil

--- a/internal/github/threads_test.go
+++ b/internal/github/threads_test.go
@@ -5,9 +5,9 @@ import "testing"
 func TestFetchReviewThreads_parse(t *testing.T) {
 	t.Parallel()
 	body := `{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[
-		{"id":"T1","isResolved":false,"isOutdated":true,"comments":{"nodes":[{"author":{"login":"copilot-pull-request-reviewer[bot]"}}]}},
-		{"id":"T2","isResolved":true,"isOutdated":false,"comments":{"nodes":[{"author":{"login":"dev"}}]}},
-		{"id":"T3","isResolved":false,"isOutdated":false,"comments":{"nodes":[]}}
+		{"id":"T1","isResolved":false,"isOutdated":true,"first":{"nodes":[{"author":{"login":"copilot-pull-request-reviewer[bot]"}}]},"last":{"nodes":[{"author":{"login":"dev"}}]}},
+		{"id":"T2","isResolved":true,"isOutdated":false,"first":{"nodes":[{"author":{"login":"dev"}}]},"last":{"nodes":[{"author":{"login":"dev"}}]}},
+		{"id":"T3","isResolved":false,"isOutdated":false,"first":{"nodes":[]},"last":{"nodes":[]}}
 	]}}}}}`
 	fe := &fakeExecer{output: []byte(body)}
 
@@ -18,14 +18,16 @@ func TestFetchReviewThreads_parse(t *testing.T) {
 	if len(threads) != 3 {
 		t.Fatalf("got %d threads, want 3", len(threads))
 	}
-	if threads[0].ID != "T1" || threads[0].AuthorLogin != "copilot-pull-request-reviewer[bot]" || !threads[0].IsOutdated || threads[0].IsResolved {
+	// T1: Copilot opened it, the agent (dev) replied last → addressed.
+	if threads[0].ID != "T1" || threads[0].AuthorLogin != "copilot-pull-request-reviewer[bot]" ||
+		threads[0].LastAuthorLogin != "dev" || !threads[0].IsOutdated || threads[0].IsResolved {
 		t.Errorf("thread[0] = %+v", threads[0])
 	}
-	if threads[1].AuthorLogin != "dev" || !threads[1].IsResolved {
+	if threads[1].AuthorLogin != "dev" || threads[1].LastAuthorLogin != "dev" || !threads[1].IsResolved {
 		t.Errorf("thread[1] = %+v", threads[1])
 	}
-	if threads[2].AuthorLogin != "" { // no comments → empty author
-		t.Errorf("thread[2] author = %q, want empty", threads[2].AuthorLogin)
+	if threads[2].AuthorLogin != "" || threads[2].LastAuthorLogin != "" { // no comments → empty
+		t.Errorf("thread[2] = %+v, want empty authors", threads[2])
 	}
 }
 

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -2,7 +2,6 @@ package sybra
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"maps"
 	"slices"
@@ -164,15 +163,23 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 			if r.workflowEngine != nil && r.workflowEngine.HasActiveWorkflow(issues[i].TaskID) {
 				continue
 			}
-			if !r.prTracker.ShouldHandle(issues[i].TaskID, issues[i].Kind, issues[i].PR.HeadSHA) {
-				r.maybeEscalateRetryCap(issues[i].TaskID, issues[i].Kind)
-				continue
+			// Only the comments kind carries a feedback fingerprint; conflict,
+			// ci_failure, and ready_to_merge fall back to SHA-only gating.
+			var sig string
+			if issues[i].Kind == github.PRIssueComments {
+				sig = issues[i].PR.FeedbackSig
 			}
-			if issues[i].Kind == github.PRIssueReadyToMerge {
-				r.handleAutoMerge(issues[i])
-				continue
+			switch r.prTracker.Decide(issues[i].TaskID, issues[i].Kind, issues[i].PR.HeadSHA, sig) {
+			case github.DispatchHandle:
+				if issues[i].Kind == github.PRIssueReadyToMerge {
+					r.handleAutoMerge(issues[i])
+					continue
+				}
+				r.handlePRIssue(issues[i])
+			case github.DispatchExhausted:
+				r.escalateExhaustedFix(issues[i])
+			case github.DispatchSkip:
 			}
-			r.handlePRIssue(issues[i])
 		}
 	}
 
@@ -352,27 +359,6 @@ func earliestRunStart(runs []task.AgentRun) time.Time {
 		}
 	}
 	return earliest
-}
-
-// maybeEscalateRetryCap flips a task to human-required when its retry budget is
-// exhausted. Removes the task from the tracker so it does not re-trigger.
-func (r *ReviewHandler) maybeEscalateRetryCap(taskID string, kind github.PRIssueKind) {
-	if !r.prTracker.AtCap(taskID, kind) {
-		return
-	}
-	reason := fmt.Sprintf(
-		"pr-monitor: CI fix attempted %d× without going green (likely flaky infra or unfixable) — needs human",
-		github.MaxRetries,
-	)
-	if _, uerr := r.tasks.Update(taskID, task.Update{
-		Status:       task.Ptr(task.StatusHumanRequired),
-		StatusReason: task.Ptr(reason),
-	}); uerr != nil {
-		r.logger.Error("pr-monitor.retry-cap.escalate", "task_id", taskID, "err", uerr)
-		return
-	}
-	r.logger.Info("pr-monitor.retry-cap", "task_id", taskID, "kind", string(kind))
-	r.prTracker.Clear(taskID, kind)
 }
 
 // cancelResolvedPRFixWorkflows terminates any in-flight pr-fix workflow

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -54,6 +54,18 @@ type ReviewHandler struct {
 	// overridable in tests. nil falls back to the github package functions.
 	fetchThreads  func(repo string, number int) ([]github.ReviewThread, error)
 	resolveThread func(threadID string) error
+	// viewerLoginFn returns the authenticated GitHub login (the identity the fix
+	// agent posts as), used to tell the agent's own thread replies from a human
+	// collaborator's. Overridable in tests; nil falls back to github.ViewerLogin.
+	viewerLoginFn func() string
+}
+
+// agentLogin returns the GitHub login the fix agent posts as.
+func (r *ReviewHandler) agentLogin() string {
+	if r.viewerLoginFn != nil {
+		return r.viewerLoginFn()
+	}
+	return github.ViewerLogin()
 }
 
 func newReviewHandler(

--- a/internal/sybra/app_reviews_automerge_test.go
+++ b/internal/sybra/app_reviews_automerge_test.go
@@ -278,6 +278,8 @@ func TestResolveAddressedCopilotThreads(t *testing.T) {
 			resolvedIDs = append(resolvedIDs, id)
 			return nil
 		},
+		// The agent posts as "dev"; T5's last reply is "dev" → addressed.
+		viewerLoginFn: func() string { return "dev" },
 	}
 
 	prs := []github.PullRequest{{
@@ -289,4 +291,123 @@ func TestResolveAddressedCopilotThreads(t *testing.T) {
 	if len(resolvedIDs) != 2 || resolvedIDs[0] != "T1" || resolvedIDs[1] != "T5" {
 		t.Fatalf("resolvedIDs = %v, want [T1 T5]", resolvedIDs)
 	}
+}
+
+// TestResolveCopilotThreads_humanReplyNotDismissed locks the fix for the
+// over-broad agentReplied predicate: a human collaborator replying on a Copilot
+// thread must NOT auto-resolve it (that would discard live feedback). Only the
+// agent's own identity counts as "addressed".
+func TestResolveCopilotThreads_humanReplyNotDismissed(t *testing.T) {
+	threads := []github.ReviewThread{
+		// Copilot thread, last reply by a human collaborator (not the agent).
+		{ID: "H1", AuthorLogin: "Copilot", IsOutdated: false, LastAuthorLogin: "alice"},
+		// Copilot thread the agent itself replied to → addressed.
+		{ID: "A1", AuthorLogin: "Copilot", IsOutdated: false, LastAuthorLogin: "agent-bot"},
+	}
+	var resolvedIDs []string
+	r := &ReviewHandler{
+		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
+		fetchThreads:  func(string, int) ([]github.ReviewThread, error) { return threads, nil },
+		resolveThread: func(id string) error { resolvedIDs = append(resolvedIDs, id); return nil },
+	}
+	pr := github.PullRequest{Number: 7, Repository: "o/r"}
+
+	r.resolveCopilotThreadsForPR("task1", pr, "agent-bot")
+
+	if len(resolvedIDs) != 1 || resolvedIDs[0] != "A1" {
+		t.Fatalf("resolvedIDs = %v, want [A1] (human reply on H1 must be left alone)", resolvedIDs)
+	}
+}
+
+// TestEscalateExhaustedFix locks the scope of escalation: every fixable kind
+// (conflict, ci_failure, comments) parks a task to human-required once its
+// durable retry budget is spent — leaving a capped kind un-escalated would
+// strand it (capped, never retried, never surfaced). ready_to_merge never
+// escalates, and an already-parked task is left untouched.
+func TestEscalateExhaustedFix(t *testing.T) {
+	newHandler := func(t *testing.T) (*ReviewHandler, *task.Manager, string) {
+		t.Helper()
+		store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+		if err != nil {
+			t.Fatalf("NewStore: %v", err)
+		}
+		tasks := task.NewManager(store, nil)
+		created, err := tasks.Create("ship it", "", string(task.AgentModeHeadless))
+		if err != nil {
+			t.Fatalf("create: %v", err)
+		}
+		if _, err := tasks.Update(created.ID, task.Update{
+			Status:   task.Ptr(task.StatusInReview),
+			PRNumber: task.Ptr(9),
+		}); err != nil {
+			t.Fatalf("update: %v", err)
+		}
+		r := &ReviewHandler{
+			DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
+			tasks:         tasks,
+			prTracker:     github.NewIssueTracker(30 * time.Minute),
+		}
+		return r, tasks, created.ID
+	}
+
+	t.Run("conflict exhaustion parks to human-required", func(t *testing.T) {
+		r, tasks, id := newHandler(t)
+		r.escalateExhaustedFix(github.PRIssue{Kind: github.PRIssueConflict, TaskID: id, PR: github.PullRequest{Number: 9}})
+		got, _ := tasks.Get(id)
+		if got.Status != task.StatusHumanRequired {
+			t.Fatalf("conflict: status = %q, want human-required", got.Status)
+		}
+	})
+
+	t.Run("ci_failure exhaustion parks to human-required", func(t *testing.T) {
+		r, tasks, id := newHandler(t)
+		r.escalateExhaustedFix(github.PRIssue{Kind: github.PRIssueCIFailure, TaskID: id, PR: github.PullRequest{Number: 9}})
+		got, _ := tasks.Get(id)
+		if got.Status != task.StatusHumanRequired {
+			t.Fatalf("ci_failure: status = %q, want human-required", got.Status)
+		}
+	})
+
+	t.Run("ready_to_merge never escalates", func(t *testing.T) {
+		r, tasks, id := newHandler(t)
+		r.escalateExhaustedFix(github.PRIssue{Kind: github.PRIssueReadyToMerge, TaskID: id, PR: github.PullRequest{Number: 9}})
+		got, _ := tasks.Get(id)
+		if got.Status != task.StatusInReview {
+			t.Fatalf("ready_to_merge: status = %q, want in-review (no escalation)", got.Status)
+		}
+	})
+
+	t.Run("comments exhaustion parks to human-required and clears tracker", func(t *testing.T) {
+		r, tasks, id := newHandler(t)
+		// Spend the budget so the tracker has a non-zero retry count to clear.
+		for range github.MaxRetries {
+			r.prTracker.MarkHandled(id, github.PRIssueComments, "sha")
+		}
+		r.escalateExhaustedFix(github.PRIssue{Kind: github.PRIssueComments, TaskID: id, PR: github.PullRequest{Number: 9}})
+		got, _ := tasks.Get(id)
+		if got.Status != task.StatusHumanRequired {
+			t.Fatalf("comments: status = %q, want human-required", got.Status)
+		}
+		if got.StatusReason == "" {
+			t.Error("comments: want a status reason explaining the escalation")
+		}
+		if n := r.prTracker.Retries(id, github.PRIssueComments); n != 0 {
+			t.Errorf("tracker retries = %d after escalation, want 0 (cleared for a human un-park)", n)
+		}
+	})
+
+	t.Run("already human-required is left untouched", func(t *testing.T) {
+		r, tasks, id := newHandler(t)
+		if _, err := tasks.Update(id, task.Update{
+			Status:       task.Ptr(task.StatusHumanRequired),
+			StatusReason: task.Ptr("set by a human"),
+		}); err != nil {
+			t.Fatalf("pre-set: %v", err)
+		}
+		r.escalateExhaustedFix(github.PRIssue{Kind: github.PRIssueComments, TaskID: id, PR: github.PullRequest{Number: 9}})
+		got, _ := tasks.Get(id)
+		if got.StatusReason != "set by a human" {
+			t.Errorf("status reason overwritten = %q, want idempotent no-op", got.StatusReason)
+		}
+	})
 }

--- a/internal/sybra/app_reviews_automerge_test.go
+++ b/internal/sybra/app_reviews_automerge_test.go
@@ -249,13 +249,17 @@ func TestResolveAddressedCopilotThreads(t *testing.T) {
 		t.Fatalf("list: %v", err)
 	}
 
-	// T1: addressed Copilot thread -> resolve. T2: live Copilot thread -> skip.
-	// T3: human thread (even outdated) -> skip. T4: already resolved -> skip.
+	// T1: addressed Copilot thread (outdated) -> resolve. T2: live Copilot thread
+	// -> skip. T3: human thread (even outdated) -> skip. T4: already resolved ->
+	// skip. T5: Copilot thread the agent replied to (not outdated) -> resolve.
+	// T6: Copilot thread, no reply yet (Copilot still last) -> skip.
 	threads := []github.ReviewThread{
 		{ID: "T1", AuthorLogin: "copilot-pull-request-reviewer[bot]", IsOutdated: true},
 		{ID: "T2", AuthorLogin: "Copilot", IsOutdated: false},
 		{ID: "T3", AuthorLogin: "dev", IsOutdated: true},
 		{ID: "T4", AuthorLogin: "Copilot", IsOutdated: true, IsResolved: true},
+		{ID: "T5", AuthorLogin: "Copilot", IsOutdated: false, LastAuthorLogin: "dev"},
+		{ID: "T6", AuthorLogin: "Copilot", IsOutdated: false, LastAuthorLogin: "Copilot"},
 	}
 	var resolvedIDs []string
 	agents := agent.NewManager(t.Context(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
@@ -282,7 +286,7 @@ func TestResolveAddressedCopilotThreads(t *testing.T) {
 	}}
 	r.resolveAddressedCopilotThreads(all, prs)
 
-	if len(resolvedIDs) != 1 || resolvedIDs[0] != "T1" {
-		t.Fatalf("resolvedIDs = %v, want [T1]", resolvedIDs)
+	if len(resolvedIDs) != 2 || resolvedIDs[0] != "T1" || resolvedIDs[1] != "T5" {
+		t.Fatalf("resolvedIDs = %v, want [T1 T5]", resolvedIDs)
 	}
 }

--- a/internal/sybra/app_reviews_automerge_test.go
+++ b/internal/sybra/app_reviews_automerge_test.go
@@ -319,6 +319,30 @@ func TestResolveCopilotThreads_humanReplyNotDismissed(t *testing.T) {
 	}
 }
 
+// TestResolveCopilotThreads_emptyAgentLoginFallsBackToAuthor locks the fix for
+// the empty-viewer edge: when ViewerLogin() fails (agentLogin ""), the PR author
+// stands in for the agent's identity, so an addressed thread is still resolved
+// rather than re-parking the pet PR.
+func TestResolveCopilotThreads_emptyAgentLoginFallsBackToAuthor(t *testing.T) {
+	threads := []github.ReviewThread{
+		// Copilot thread the agent (== PR author "me") replied to → addressed.
+		{ID: "A1", AuthorLogin: "Copilot", IsOutdated: false, LastAuthorLogin: "me"},
+	}
+	var resolvedIDs []string
+	r := &ReviewHandler{
+		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
+		fetchThreads:  func(string, int) ([]github.ReviewThread, error) { return threads, nil },
+		resolveThread: func(id string) error { resolvedIDs = append(resolvedIDs, id); return nil },
+	}
+	pr := github.PullRequest{Number: 7, Repository: "o/r", Author: "me"}
+
+	r.resolveCopilotThreadsForPR("task1", pr, "")
+
+	if len(resolvedIDs) != 1 || resolvedIDs[0] != "A1" {
+		t.Fatalf("resolvedIDs = %v, want [A1] (empty agentLogin must fall back to PR author)", resolvedIDs)
+	}
+}
+
 // TestEscalateExhaustedFix locks the scope of escalation: every fixable kind
 // (conflict, ci_failure, comments) parks a task to human-required once its
 // durable retry budget is spent — leaving a capped kind un-escalated would

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -79,6 +79,51 @@ func (r *ReviewHandler) handleAutoMerge(issue github.PRIssue) {
 	r.logger.Info("auto-merge.merged", "task_id", t.ID, "pr", issue.PR.Number)
 }
 
+// escalateExhaustedFix parks a task whose pr-fix retry budget is spent. Trying
+// the same fix MaxRetries times without clearing the issue means the agent
+// can't resolve it on its own — flaky/unfixable CI, an unrebasable conflict, or
+// review feedback that needs a human call — so stop looping and surface it.
+// Mirrors the worktree circuit-breaker: own-PR tasks normally stay in In
+// Review, but a hard, repeated failure escalates to human-required.
+//
+// Applies to every fixable kind (conflict, ci_failure, comments) — the durable
+// retry cap keeps a capped entry across Cleanup, so a kind that did not escalate
+// here would sit capped forever, never retried and never surfaced. Only the
+// comments kind carries a feedback signature, so genuinely new reviewer feedback
+// resets its budget (in Decide) before it ever reaches here. ready_to_merge
+// never escalates — a green PR that simply hasn't merged is not a failure.
+//
+// Idempotent: a task already in human-required is left untouched. The tracker
+// entry is cleared so a human un-parking the task starts from a fresh budget.
+func (r *ReviewHandler) escalateExhaustedFix(issue github.PRIssue) {
+	if issue.Kind == github.PRIssueReadyToMerge {
+		return
+	}
+	t, err := r.tasks.Get(issue.TaskID)
+	if err != nil || t.Status == task.StatusHumanRequired {
+		return
+	}
+	reason := fmt.Sprintf(
+		"pr-monitor: auto-fix exhausted after %d attempts (%s) — needs a human",
+		github.MaxRetries, issue.Kind,
+	)
+	if _, err := r.tasks.Update(issue.TaskID, task.Update{
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr(reason),
+	}); err != nil {
+		r.logger.Error("pr-monitor.fix-exhausted.escalate", "task_id", issue.TaskID, "err", err)
+		return
+	}
+	r.prTracker.Clear(issue.TaskID, issue.Kind)
+	r.logAudit(audit.EventPRFixExhausted, issue.TaskID, "", map[string]any{
+		"pr": issue.PR.Number, "repo": issue.PR.Repository,
+		"kind": string(issue.Kind), "attempts": github.MaxRetries,
+	})
+	r.logger.Warn("pr-monitor.fix-exhausted",
+		"task_id", issue.TaskID, "pr", issue.PR.Number,
+		"kind", string(issue.Kind), "attempts", github.MaxRetries)
+}
+
 func (r *ReviewHandler) handlePRIssue(issue github.PRIssue) {
 	t, err := r.tasks.Get(issue.TaskID)
 	if err != nil {

--- a/internal/sybra/app_reviews_outbound.go
+++ b/internal/sybra/app_reviews_outbound.go
@@ -53,6 +53,7 @@ func (r *ReviewHandler) reconcilePRPhases(tasks []task.Task, monitoredPRs []gith
 			Mergeable:        pr.Mergeable,
 			ReviewDecision:   pr.ReviewDecision,
 			UnresolvedCount:  pr.UnresolvedCount,
+			ActionableCount:  pr.ActionableCount,
 		}))
 	}
 }

--- a/internal/sybra/app_reviews_threads.go
+++ b/internal/sybra/app_reviews_threads.go
@@ -1,6 +1,8 @@
 package sybra
 
 import (
+	"strings"
+
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/project"
@@ -61,7 +63,7 @@ func (r *ReviewHandler) resolveAddressedCopilotThreads(tasks []task.Task, prs []
 		if r.workflowEngine != nil && r.workflowEngine.HasActiveWorkflow(taskID) {
 			continue
 		}
-		r.resolveCopilotThreadsForPR(taskID, *pr)
+		r.resolveCopilotThreadsForPR(taskID, *pr, r.agentLogin())
 	}
 }
 
@@ -77,7 +79,7 @@ func blockedOnlyByThreads(pr github.PullRequest) bool {
 		pr.UnresolvedCount > 0
 }
 
-func (r *ReviewHandler) resolveCopilotThreadsForPR(taskID string, pr github.PullRequest) {
+func (r *ReviewHandler) resolveCopilotThreadsForPR(taskID string, pr github.PullRequest, agentLogin string) {
 	fetch := r.fetchThreads
 	if fetch == nil {
 		fetch = github.FetchReviewThreads
@@ -101,11 +103,13 @@ func (r *ReviewHandler) resolveCopilotThreadsForPR(taskID string, pr github.Pull
 		if th.IsResolved || !github.IsCopilotReviewer(th.AuthorLogin) {
 			continue
 		}
-		// Addressed = the anchored code changed (outdated) OR the agent posted a
-		// reply (the last comment is no longer Copilot's). Copilot never resolves
-		// its own threads, so without this an addressed-but-not-outdated thread
-		// would block the pet merge forever.
-		agentReplied := th.LastAuthorLogin != "" && !github.IsCopilotReviewer(th.LastAuthorLogin)
+		// Addressed = the anchored code changed (outdated) OR the fix agent itself
+		// posted the last reply. Copilot never resolves its own threads, so
+		// without this an addressed-but-not-outdated thread would block the pet
+		// merge forever. The reply must be the agent's own identity, not just
+		// "not Copilot" — otherwise a human collaborator's reply on a Copilot
+		// thread would be auto-dismissed, discarding live feedback.
+		agentReplied := agentLogin != "" && strings.EqualFold(th.LastAuthorLogin, agentLogin)
 		if !th.IsOutdated && !agentReplied {
 			continue
 		}

--- a/internal/sybra/app_reviews_threads.go
+++ b/internal/sybra/app_reviews_threads.go
@@ -96,9 +96,17 @@ func (r *ReviewHandler) resolveCopilotThreadsForPR(taskID string, pr github.Pull
 	var resolved int
 	for i := range threads {
 		th := &threads[i]
-		// Resolve only Copilot-authored threads the fix agent has addressed
-		// (outdated). Leave human threads and live Copilot threads alone.
-		if th.IsResolved || !th.IsOutdated || !github.IsCopilotReviewer(th.AuthorLogin) {
+		// Resolve only Copilot-authored threads the fix agent has addressed.
+		// Leave human threads and live Copilot threads (no reply yet) alone.
+		if th.IsResolved || !github.IsCopilotReviewer(th.AuthorLogin) {
+			continue
+		}
+		// Addressed = the anchored code changed (outdated) OR the agent posted a
+		// reply (the last comment is no longer Copilot's). Copilot never resolves
+		// its own threads, so without this an addressed-but-not-outdated thread
+		// would block the pet merge forever.
+		agentReplied := th.LastAuthorLogin != "" && !github.IsCopilotReviewer(th.LastAuthorLogin)
+		if !th.IsOutdated && !agentReplied {
 			continue
 		}
 		if err := resolve(th.ID); err != nil {

--- a/internal/sybra/app_reviews_threads.go
+++ b/internal/sybra/app_reviews_threads.go
@@ -80,6 +80,13 @@ func blockedOnlyByThreads(pr github.PullRequest) bool {
 }
 
 func (r *ReviewHandler) resolveCopilotThreadsForPR(taskID string, pr github.PullRequest, agentLogin string) {
+	// ViewerLogin() can fail (returns ""); fall back to the PR author so an
+	// addressed thread is still detected. On own-PRs the author is the agent's
+	// identity, mirroring convertCommonPR's fallback. Without this an empty
+	// agentLogin would match nothing and re-park the pet PR on its threads.
+	if agentLogin == "" {
+		agentLogin = pr.Author
+	}
 	fetch := r.fetchThreads
 	if fetch == nil {
 		fetch = github.FetchReviewThreads

--- a/internal/sybra/pr_phase.go
+++ b/internal/sybra/pr_phase.go
@@ -34,7 +34,8 @@ type prSignals struct {
 	HasPendingChecks bool   // a check is still in-progress/queued
 	Mergeable        string // MERGEABLE, CONFLICTING, UNKNOWN, or ""
 	ReviewDecision   string // APPROVED, CHANGES_REQUESTED, REVIEW_REQUIRED, or ""
-	UnresolvedCount  int    // unresolved review threads
+	UnresolvedCount  int    // unresolved review threads (raw — drives merge gate)
+	ActionableCount  int    // unresolved threads a reviewer last touched (drives fix dispatch)
 }
 
 // computePRPhase maps live PR signals to the desired phase. Pure and
@@ -58,9 +59,11 @@ func computePRPhase(s prSignals) string {
 	// hide the "mark ready" action.
 	case s.IsDraft:
 		return PRPhaseDraft
-	// Reviewers asked for changes (or left unresolved threads): a fix-review
-	// agent is dispatched to address them.
-	case s.ReviewDecision == "CHANGES_REQUESTED" || s.UnresolvedCount > 0:
+	// Reviewers asked for changes (or left actionable threads — a reviewer had
+	// the last word): a fix-review agent is dispatched to address them. Threads
+	// the agent already replied to are unresolved but not actionable, so they
+	// surface as awaiting-approval (waiting on the reviewer), not changes.
+	case s.ReviewDecision == "CHANGES_REQUESTED" || s.ActionableCount > 0:
 		return PRPhaseChangesRequested
 	// CI is still running — wait it out.
 	case s.CIStatus == "PENDING" || s.HasPendingChecks:

--- a/internal/sybra/pr_phase_test.go
+++ b/internal/sybra/pr_phase_test.go
@@ -34,13 +34,18 @@ func TestComputePRPhase(t *testing.T) {
 			want: PRPhaseChangesRequested,
 		},
 		{
-			name: "unresolved threads → changes-requested",
-			sig:  prSignals{UnresolvedCount: 2},
+			name: "actionable threads → changes-requested",
+			sig:  prSignals{UnresolvedCount: 2, ActionableCount: 2},
 			want: PRPhaseChangesRequested,
 		},
 		{
+			name: "unresolved but addressed (agent replied) → awaiting-approval, not changes",
+			sig:  prSignals{UnresolvedCount: 2, ActionableCount: 0},
+			want: PRPhaseAwaitingApproval,
+		},
+		{
 			name: "draft with comments stays draft (comment-fix is skipped on drafts)",
-			sig:  prSignals{IsDraft: true, UnresolvedCount: 1},
+			sig:  prSignals{IsDraft: true, UnresolvedCount: 1, ActionableCount: 1},
 			want: PRPhaseDraft,
 		},
 		{


### PR DESCRIPTION
## Motivation

The pr-fix monitor re-dispatched a fix agent on any PR with an
unresolved review thread — a level signal it could not clear — while the
only safeguard, a 3-retry cap, was wiped hourly by `IssueTracker.Cleanup`.
Copilot never resolves its own threads and the fix agent is told not to,
so PRs with Copilot comments looped roughly three fixes per hour
indefinitely, burning tokens. Observed live: one PR cycled
`changes-requested → fixing` 14 times in a day across four open PRs.

> Changelog: fix(reviews): bound pr-fix on stale review feedback

## Implementation information

**A — Edge-trigger** (`internal/github/client.go`, `monitor.go`,
`internal/sybra/pr_phase.go`). Dispatch now counts *actionable* threads —
unresolved threads where a reviewer left the last comment — instead of
the raw unresolved count. Once the agent replies, the thread is no longer
actionable, so the trigger clears. `unresolvedCount` stays the raw
merge-gate signal.

**B — Durable budget** (`internal/github/debounce.go`,
`internal/sybra/app_reviews.go`, `app_reviews_fix.go`). New `Decide`
gates on a feedback signature keyed on the unresolved-thread set plus the
review decision, so the agent’s own replies never reset it. The budget
caps at `MaxFixRetries` against unchanged feedback and parks the task to
`human-required` instead of looping. This also closes the new-commit
reset that bypassed the old cap. Escalation is scoped to the comments
kind only — conflict and ci_failure are self-healing and keep prior
skip-on-exhaustion behavior so a PR that later goes green is not
stranded. The tracker entry is cleared on escalation so a human un-park
starts from a fresh budget.

**C — Resolve addressed Copilot threads** (`app_reviews_threads.go`).
Resolves Copilot threads the fix agent itself replied to (matched against
the authenticated viewer login), not just outdated ones, so addressed pet
PRs can merge. Human threads and a collaborator’s replies stay untouched.

Both commits include an adversarial review pass and its fixes
(escalation scope, agent-identity check on thread resolution, signature
stability). A stale `human_review.sybra_repo_dir` pointing at a deleted
worktree was also fixed in the live machine config (not in this branch).

## Supporting documentation

- Regression tests: actionable/signature scheme and its stability across
  the agent’s own replies (`client_test.go`), the `Decide` budget
  exhaustion and reset (`debounce_test.go`), escalation scoped to
  comments with tracker clear (`app_reviews_automerge_test.go`), and a
  human reply on a Copilot thread left un-resolved.
- `golangci-lint run ./...` clean, `go test ./...` green,
  `go build ./cmd/sybra-server` ok, Wails bindings regenerated,
  `npm run check` clean.