### PR TITLE
feat(eval): codex tool taxonomy + edited autonomy

### DIFF
--- a/cmd/sybra-cli/evaluation.go
+++ b/cmd/sybra-cli/evaluation.go
@@ -132,8 +132,8 @@ func cmdEvaluationScan(cfg *config.Config, jsonOut bool) int {
 		return printJSON(report)
 	}
 	o := report.Overall
-	fmt.Printf("evaluation (%dd window): landed=%d merged=%d closed=%d\n",
-		int(o.WindowDays), o.TasksLanded, o.Merged, o.Closed)
+	fmt.Printf("evaluation (%dd window): landed=%d merged=%d merged_with_edits=%d closed=%d\n",
+		int(o.WindowDays), o.TasksLanded, o.Merged, o.MergedWithEdits, o.Closed)
 	fmt.Printf("  autonomy=%.0f%%  ci-first-pass=%.0f%%  failure=%.0f%%  rework_tasks=%d\n",
 		o.AutonomyRate*100, o.CIFirstPassRate*100, o.FailureRate*100, o.ReworkTasks)
 	fmt.Printf("  lead p50/p90=%.1f/%.1fh  cycle p50/p90=%.1f/%.1fh\n",

--- a/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
@@ -136,11 +136,20 @@ export class Scorecard {
      * Throughput & outcomes (from task.landed events).
      */
     "tasksLanded": number;
+
+    /**
+     * clean merges (no human edits)
+     */
     "merged": number;
+
+    /**
+     * merged after a human edited the PR
+     */
+    "mergedWithEdits": number;
     "closed": number;
 
     /**
-     * merged / landed
+     * clean merged / landed
      */
     "mergeRate": number;
 
@@ -202,6 +211,9 @@ export class Scorecard {
         }
         if (!("merged" in $$source)) {
             this["merged"] = 0;
+        }
+        if (!("mergedWithEdits" in $$source)) {
+            this["mergedWithEdits"] = 0;
         }
         if (!("closed" in $$source)) {
             this["closed"] = 0;

--- a/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
@@ -126,8 +126,7 @@ export class Report {
  * Landing-derived metrics read task.landed audit events; reliability and
  * efficiency read stats run records (the run Outcome carries the accurate
  * success/failure outcome). Metrics that require signals not yet captured
- * (merge-without-edit, change-failure rate, review density) are deferred —
- * see Report.Notes.
+ * (change-failure rate, review density) are deferred — see Report.Notes.
  */
 export class Scorecard {
     "windowDays": number;

--- a/frontend/src/pages/Evaluation.svelte
+++ b/frontend/src/pages/Evaluation.svelte
@@ -65,7 +65,7 @@
       <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
         <span class="text-xs font-medium text-surface-500">Tasks landed</span>
         <p class="mt-1 text-2xl font-bold">{o.tasksLanded}</p>
-        <p class="mt-0.5 text-xs text-surface-400">{o.merged} merged · {o.closed} closed</p>
+        <p class="mt-0.5 text-xs text-surface-400">{o.merged} merged · {o.mergedWithEdits} edited · {o.closed} closed</p>
       </div>
       <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
         <span class="text-xs font-medium text-surface-500">Autonomy</span>

--- a/internal/agent/runner_headless_stream.go
+++ b/internal/agent/runner_headless_stream.go
@@ -82,10 +82,9 @@ func codexEventToStreamEvent(e CodexEvent) StreamEvent {
 			ev.Content = e.Message.Text
 		}
 	case "tool_use":
-		// Codex only emits a tool_use event for command_execution (Bash); file
-		// edits, MCP, and web search arrive as assistant text (ToolCalls=0). So
-		// ToolCalls undercounts non-Bash Codex tools — a follow-up should map the
-		// full Codex item taxonomy before comparing tool efficiency cross-provider.
+		// Codex tool item types (command_execution, file_change, collab_tool_call,
+		// web_search) are mapped to tool_use in parseCodexItemLineTyped and counted
+		// here once per item.started.
 		if e.Message != nil && len(e.Message.ToolUses) > 0 {
 			cmd, _ := e.Message.ToolUses[0].Input["command"].(string)
 			ev.Content = cmd

--- a/internal/agent/stream.go
+++ b/internal/agent/stream.go
@@ -509,6 +509,25 @@ func parseCodexItemLineTyped(eventType string, item *codexItem, rawCopy json.Raw
 			},
 		}, nil
 
+	case "file_change", "collab_tool_call", "web_search":
+		// Non-Bash Codex tool actions. Count each once on item.started (mirrors
+		// command_execution) so the tool-call metric isn't Bash-only; skip the
+		// completed half to avoid double-counting.
+		if eventType != "item.started" {
+			return CodexEvent{Raw: rawCopy}, nil
+		}
+		return CodexEvent{
+			Type: "tool_use",
+			Raw:  rawCopy,
+			Message: &ClaudeMessage{
+				Role: "assistant",
+				ToolUses: []ToolUseBlock{{
+					ID:   item.ID,
+					Name: codexToolName(item.Type),
+				}},
+			},
+		}, nil
+
 	default:
 		return CodexEvent{
 			Type: "assistant",
@@ -518,6 +537,20 @@ func parseCodexItemLineTyped(eventType string, item *codexItem, rawCopy json.Raw
 				Text: item.Text,
 			},
 		}, nil
+	}
+}
+
+// codexToolName maps a Codex item type to a display name for its tool use.
+func codexToolName(itemType string) string {
+	switch itemType {
+	case "file_change":
+		return "Edit"
+	case "collab_tool_call":
+		return "MCP"
+	case "web_search":
+		return "WebSearch"
+	default:
+		return itemType
 	}
 }
 

--- a/internal/agent/tool_calls_test.go
+++ b/internal/agent/tool_calls_test.go
@@ -57,3 +57,30 @@ func TestCodexEventToStreamEvent_ToolCalls(t *testing.T) {
 		t.Errorf("ToolCalls = %d, want 1", got)
 	}
 }
+
+func TestParseCodexItemLineTyped_NonBashTools(t *testing.T) {
+	// Real Codex item types beyond command_execution must count as tool calls.
+	for _, tt := range []struct{ itemType, wantName string }{
+		{"file_change", "Edit"},
+		{"collab_tool_call", "MCP"},
+		{"web_search", "WebSearch"},
+	} {
+		t.Run(tt.itemType, func(t *testing.T) {
+			ev, err := parseCodexItemLineTyped("item.started", &codexItem{Type: tt.itemType, ID: "x"}, nil)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if ev.Type != "tool_use" || len(ev.Message.ToolUses) != 1 || ev.Message.ToolUses[0].Name != tt.wantName {
+				t.Fatalf("started: got type=%q name=%v, want tool_use/%s", ev.Type, ev.Message, tt.wantName)
+			}
+			if got := codexEventToStreamEvent(ev).ToolCalls; got != 1 {
+				t.Errorf("ToolCalls = %d, want 1", got)
+			}
+			// Completed half must not double-count.
+			done, _ := parseCodexItemLineTyped("item.completed", &codexItem{Type: tt.itemType, ID: "x"}, nil)
+			if codexEventToStreamEvent(done).ToolCalls != 0 {
+				t.Errorf("completed counted a tool call (double count)")
+			}
+		})
+	}
+}

--- a/internal/evaluation/scorecard.go
+++ b/internal/evaluation/scorecard.go
@@ -18,8 +18,7 @@ import (
 // Landing-derived metrics read task.landed audit events; reliability and
 // efficiency read stats run records (the run Outcome carries the accurate
 // success/failure outcome). Metrics that require signals not yet captured
-// (merge-without-edit, change-failure rate, review density) are deferred —
-// see Report.Notes.
+// (change-failure rate, review density) are deferred — see Report.Notes.
 type Scorecard struct {
 	WindowDays float64 `json:"windowDays"`
 

--- a/internal/evaluation/scorecard.go
+++ b/internal/evaluation/scorecard.go
@@ -24,14 +24,15 @@ type Scorecard struct {
 	WindowDays float64 `json:"windowDays"`
 
 	// Throughput & outcomes (from task.landed events).
-	TasksLanded   int     `json:"tasksLanded"`
-	Merged        int     `json:"merged"`
-	Closed        int     `json:"closed"`
-	MergeRate     float64 `json:"mergeRate"`     // merged / landed
-	LeadTimeP50H  float64 `json:"leadTimeP50H"`  // created_to_land_h
-	LeadTimeP90H  float64 `json:"leadTimeP90H"`  //
-	CycleTimeP50H float64 `json:"cycleTimeP50H"` // work_to_land_h (first agent run → land)
-	CycleTimeP90H float64 `json:"cycleTimeP90H"` //
+	TasksLanded     int     `json:"tasksLanded"`
+	Merged          int     `json:"merged"`          // clean merges (no human edits)
+	MergedWithEdits int     `json:"mergedWithEdits"` // merged after a human edited the PR
+	Closed          int     `json:"closed"`
+	MergeRate       float64 `json:"mergeRate"`     // clean merged / landed
+	LeadTimeP50H    float64 `json:"leadTimeP50H"`  // created_to_land_h
+	LeadTimeP90H    float64 `json:"leadTimeP90H"`  //
+	CycleTimeP50H   float64 `json:"cycleTimeP50H"` // work_to_land_h (first agent run → land)
+	CycleTimeP90H   float64 `json:"cycleTimeP90H"` //
 
 	// Autonomy: did landed work reach done without a human in the loop?
 	AutonomousLandings   int     `json:"autonomousLandings"`
@@ -81,10 +82,9 @@ type Report struct {
 // deferredNotes documents metrics that need signals not yet captured, so the
 // report never silently presents a partial picture as complete.
 var deferredNotes = []string{
-	"merge-without-edit rate and human-edit distance pending #1082",
-	"change-failure rate and MTTR pending revert detection (#1082)",
-	"review-finding density pending review-count capture (#1082)",
-	"per-project/provider autonomy + throughput breakdowns pending project/provider on task.landed (#1082)",
+	"change-failure rate and MTTR pending revert detection (#1097)",
+	"review-finding density pending review-count capture",
+	"per-project/provider autonomy + throughput breakdowns pending project/provider on task.landed",
 }
 
 // taskSignals accumulates per-task lifecycle facts used for autonomy,
@@ -108,9 +108,10 @@ func Compute(records []stats.RunRecord, events []audit.Event, since, until time.
 	cost, turns, tools := scanEfficiency(records, win)
 
 	sc.TasksLanded, sc.Merged, sc.Closed = lg.count, lg.merged, lg.closed
+	sc.MergedWithEdits = lg.mergedWithEdits
 	sc.AgentRuns, sc.AgentFailures = runs, fails
 	sc.TotalCostUSD = cost
-	autonomous, humanTouched, ciClean := classifyLanded(lg.tasks, sigs)
+	autonomous, humanTouched, ciClean := classifyLanded(lg.tasks, lg.edited, sigs)
 	sc.AutonomousLandings, sc.HumanTouchedLandings = autonomous, humanTouched
 	sc.ReworkTasks = countRework(sigs, lg.tasks)
 
@@ -134,13 +135,14 @@ func Compute(records []stats.RunRecord, events []audit.Event, since, until time.
 
 // landingAgg holds the outcome counts and timing samples from task.landed events.
 type landingAgg struct {
-	count, merged, closed int
-	leadTimes, cycleTimes []float64
-	tasks                 map[string]bool
+	count, merged, mergedWithEdits, closed int
+	leadTimes, cycleTimes                  []float64
+	tasks                                  map[string]bool
+	edited                                 map[string]bool // landed but a human edited the PR
 }
 
 func scanLandings(events []audit.Event, win func(time.Time) bool) landingAgg {
-	lg := landingAgg{tasks: map[string]bool{}}
+	lg := landingAgg{tasks: map[string]bool{}, edited: map[string]bool{}}
 	for i := range events {
 		e := events[i]
 		if e.Type != audit.EventTaskLanded || !win(e.Timestamp) {
@@ -150,9 +152,15 @@ func scanLandings(events []audit.Event, win func(time.Time) bool) landingAgg {
 		if e.TaskID != "" {
 			lg.tasks[e.TaskID] = true
 		}
-		if strVal(e.Data, "outcome") == "closed" {
+		switch strVal(e.Data, "outcome") {
+		case "closed":
 			lg.closed++
-		} else {
+		case "merged_with_edits":
+			lg.mergedWithEdits++
+			if e.TaskID != "" {
+				lg.edited[e.TaskID] = true // a human edited the PR → not autonomous
+			}
+		default:
 			lg.merged++
 		}
 		if v, ok := floatVal(e.Data, "created_to_land_h"); ok {
@@ -233,10 +241,12 @@ func scanEfficiency(records []stats.RunRecord, win func(time.Time) bool) (cost f
 // classifyLanded splits landed tasks into autonomous vs human-touched and counts
 // those that landed without a CI fix. A task with no recorded signals counts as
 // autonomous and CI-clean.
-func classifyLanded(landed map[string]bool, sigs map[string]*taskSignals) (autonomous, humanTouched, ciClean int) {
+func classifyLanded(landed, edited map[string]bool, sigs map[string]*taskSignals) (autonomous, humanTouched, ciClean int) {
 	for id := range landed {
 		s := sigs[id]
-		if s == nil || !s.humanTouched {
+		// A task is human-touched if it went human-required / spawned a human
+		// review (sigs) OR a human edited its PR before merge (merged_with_edits).
+		if (s == nil || !s.humanTouched) && !edited[id] {
 			autonomous++
 		} else {
 			humanTouched++

--- a/internal/evaluation/scorecard_test.go
+++ b/internal/evaluation/scorecard_test.go
@@ -113,6 +113,35 @@ func TestBreakdownBy(t *testing.T) {
 	}
 }
 
+func TestCompute_MergedWithEditsNotAutonomous(t *testing.T) {
+	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -30)
+	in := base.Add(-1 * time.Hour)
+	ld := func(tid, outcome string) audit.Event {
+		return audit.Event{Type: audit.EventTaskLanded, TaskID: tid, Timestamp: in, Data: map[string]any{"outcome": outcome}}
+	}
+	events := []audit.Event{
+		ld("A", "merged"),            // clean → autonomous
+		ld("E", "merged_with_edits"), // human edited → not autonomous
+	}
+	got := Compute(nil, events, since, base)
+	if got.TasksLanded != 2 {
+		t.Fatalf("TasksLanded = %d, want 2", got.TasksLanded)
+	}
+	if got.Merged != 1 || got.MergedWithEdits != 1 {
+		t.Errorf("Merged/MergedWithEdits = %d/%d, want 1/1", got.Merged, got.MergedWithEdits)
+	}
+	if got.AutonomousLandings != 1 {
+		t.Errorf("AutonomousLandings = %d, want 1 (only the clean merge)", got.AutonomousLandings)
+	}
+	if got.HumanTouchedLandings != 1 {
+		t.Errorf("HumanTouchedLandings = %d, want 1 (the edited merge)", got.HumanTouchedLandings)
+	}
+	if got.AutonomyRate != 0.5 {
+		t.Errorf("AutonomyRate = %v, want 0.5", got.AutonomyRate)
+	}
+}
+
 func TestComputeEmpty(t *testing.T) {
 	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
 	got := Compute(nil, nil, now.AddDate(0, 0, -7), now)


### PR DESCRIPTION
## Motivation

Part of #1097. Two of the rich-signal gaps: Codex tool counting was Bash-only (incomparable cross-provider), and `merged_with_edits` (added in #1095) wasn't yet reflected in the autonomy metric.

> Changelog: feat(eval): codex tool taxonomy + edited autonomy

## Implementation information

- **Codex tool taxonomy** — `parseCodexItemLineTyped` now maps `file_change`, `collab_tool_call`, and `web_search` to a tool_use (counted once on `item.started`, like `command_execution`), so `ToolsPerLanded` is comparable across Claude and Codex instead of Bash-only. The item types are the real ones from session logs (verified, all emit paired started/completed).
- **merged_with_edits → autonomy** — `classifyLanded` now counts a landed task as human-touched when a human edited its PR (`merged_with_edits`), not just on a human-required transition. The scorecard exposes `MergedWithEdits` distinct from clean `Merged`; surfaced in the CLI scan and dashboard.

Adversarial review (incl. an empirical scan of 35 real codex logs) confirmed the new types are counted exactly once and the autonomy partition holds; it found only a stale comment, now fixed.

## Remaining (tracked in #1097)

Revert detection (`pr.reverted` + change-failure rate) is a write-capable periodic scanner — a distinct subsystem from this read-only/parse change. Shipping the change-failure metric without the detector would be a structurally-zero metric, so it's deliberately separate.

## Supporting documentation

- Evaluation umbrella #1065.

Gates: `golangci-lint run ./...`, `go test ./...`, `svelte-check` pass (pre-existing flaky agent shutdown-timing test passes on rerun).
