### PR TITLE
feat(eval): revert detection + change-failure rate

### DIFF
--- a/cmd/sybra-cli/evaluation.go
+++ b/cmd/sybra-cli/evaluation.go
@@ -134,8 +134,8 @@ func cmdEvaluationScan(cfg *config.Config, jsonOut bool) int {
 	o := report.Overall
 	fmt.Printf("evaluation (%dd window): landed=%d merged=%d merged_with_edits=%d closed=%d\n",
 		int(o.WindowDays), o.TasksLanded, o.Merged, o.MergedWithEdits, o.Closed)
-	fmt.Printf("  autonomy=%.0f%%  ci-first-pass=%.0f%%  failure=%.0f%%  rework_tasks=%d\n",
-		o.AutonomyRate*100, o.CIFirstPassRate*100, o.FailureRate*100, o.ReworkTasks)
+	fmt.Printf("  autonomy=%.0f%%  ci-first-pass=%.0f%%  failure=%.0f%%  change-failure=%.0f%% (%d reverted)  rework_tasks=%d\n",
+		o.AutonomyRate*100, o.CIFirstPassRate*100, o.FailureRate*100, o.ChangeFailureRate*100, o.Reverted, o.ReworkTasks)
 	fmt.Printf("  lead p50/p90=%.1f/%.1fh  cycle p50/p90=%.1f/%.1fh\n",
 		o.LeadTimeP50H, o.LeadTimeP90H, o.CycleTimeP50H, o.CycleTimeP90H)
 	fmt.Printf("  cost=$%.2f ($%.2f/landed)  turns/landed=%.1f  tools/landed=%.1f\n",

--- a/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
@@ -188,6 +188,16 @@ export class Scorecard {
     "ciFirstPassRate": number;
 
     /**
+     * merged landings later reverted on the default branch
+     */
+    "reverted": number;
+
+    /**
+     * reverted / merged landings (DORA)
+     */
+    "changeFailureRate": number;
+
+    /**
      * Efficiency: window spend and effort per landed PR.
      */
     "totalCostUsd": number;
@@ -252,6 +262,12 @@ export class Scorecard {
         }
         if (!("ciFirstPassRate" in $$source)) {
             this["ciFirstPassRate"] = 0;
+        }
+        if (!("reverted" in $$source)) {
+            this["reverted"] = 0;
+        }
+        if (!("changeFailureRate" in $$source)) {
+            this["changeFailureRate"] = 0;
         }
         if (!("totalCostUsd" in $$source)) {
             this["totalCostUsd"] = 0;

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -221,11 +221,18 @@ export class Task {
     "closedAt"?: time$0.Time | null;
 
     /**
-     * Outcome records how a task's own PR concluded: "merged" or "closed".
-     * Stamped by the PR monitor when the task auto-advances to done. Empty for
-     * tasks that never produced a PR. Feeds the evaluation scorecard.
+     * Outcome records how a task's own PR concluded: "merged", "merged_with_edits",
+     * "closed", or "reverted". Stamped by the PR monitor when the task auto-advances
+     * to done (and updated to "reverted" by the revert scanner). Empty for tasks
+     * that never produced a PR. Feeds the evaluation scorecard.
      */
     "outcome"?: string;
+
+    /**
+     * MergeCommit is the default-branch commit a merged PR produced, recorded at
+     * landing so the revert scanner can detect a later revert of it.
+     */
+    "mergeCommit"?: string;
 
     /**
      * MaxTurns overrides the global agent turn limit for this task.
@@ -350,9 +357,9 @@ export class Task {
     static createFrom($$source: any = {}): Task {
         const $$createField6_0 = $$createType0;
         const $$createField7_0 = $$createType0;
-        const $$createField28_0 = $$createType2;
-        const $$createField29_0 = $$createType4;
-        const $$createField36_0 = $$createType5;
+        const $$createField29_0 = $$createType2;
+        const $$createField30_0 = $$createType4;
+        const $$createField37_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -361,13 +368,13 @@ export class Task {
             $$parsedSource["tags"] = $$createField7_0($$parsedSource["tags"]);
         }
         if ("agentRuns" in $$parsedSource) {
-            $$parsedSource["agentRuns"] = $$createField28_0($$parsedSource["agentRuns"]);
+            $$parsedSource["agentRuns"] = $$createField29_0($$parsedSource["agentRuns"]);
         }
         if ("workflow" in $$parsedSource) {
-            $$parsedSource["workflow"] = $$createField29_0($$parsedSource["workflow"]);
+            $$parsedSource["workflow"] = $$createField30_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField36_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField37_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }

--- a/frontend/src/pages/Evaluation.svelte
+++ b/frontend/src/pages/Evaluation.svelte
@@ -79,7 +79,7 @@
       <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
         <span class="text-xs font-medium text-surface-500">Failure rate</span>
         <p class="mt-1 text-2xl font-bold {goodScale(1 - o.failureRate)}">{pct(o.failureRate)}</p>
-        <p class="mt-0.5 text-xs text-surface-400">{o.agentFailures}/{o.agentRuns} runs</p>
+        <p class="mt-0.5 text-xs text-surface-400">{o.agentFailures}/{o.agentRuns} runs · {o.reverted} reverted ({pct(o.changeFailureRate)})</p>
       </div>
       <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
         <span class="text-xs font-medium text-surface-500">Cost / landed</span>

--- a/internal/evaluation/scorecard.go
+++ b/internal/evaluation/scorecard.go
@@ -86,6 +86,7 @@ var deferredNotes = []string{
 	"MTTR (time to restore after a revert) pending revert-to-fix timing",
 	"review-finding density pending review-count capture",
 	"per-project/provider autonomy + throughput breakdowns pending project/provider on task.landed",
+	"revert detection scans the latest 100 default-branch commits per repo; a revert beyond that on a very busy repo can be missed",
 }
 
 // taskSignals accumulates per-task lifecycle facts used for autonomy,
@@ -111,7 +112,7 @@ func Compute(records []stats.RunRecord, events []audit.Event, since, until time.
 	sc.TasksLanded, sc.Merged, sc.Closed = lg.count, lg.merged, lg.closed
 	sc.MergedWithEdits = lg.mergedWithEdits
 	sc.AgentRuns, sc.AgentFailures = runs, fails
-	sc.Reverted = countReverts(events, win)
+	sc.Reverted = countReverts(events, win, lg.tasks)
 	sc.TotalCostUSD = cost
 	autonomous, humanTouched, ciClean := classifyLanded(lg.tasks, lg.edited, sigs)
 	sc.AutonomousLandings, sc.HumanTouchedLandings = autonomous, humanTouched
@@ -216,12 +217,15 @@ func scanTaskSignals(events []audit.Event) map[string]*taskSignals {
 // scanReliability derives runs and failures from stats run records, not audit
 // events: the failure outcome is recorded on every run record (set from the
 // process exit), whereas a distinct agent.failed audit event is never emitted.
-// countReverts counts pr.reverted events in the window — landed PRs a revert
-// later undid on the default branch (the change-failure signal).
-func countReverts(events []audit.Event, win func(time.Time) bool) int {
+// countReverts counts pr.reverted events in the window — but only for tasks that
+// also landed in the window, so the change-failure numerator and denominator
+// share a cohort (a revert of a PR that merged before the window doesn't push
+// the rate above 100%).
+func countReverts(events []audit.Event, win func(time.Time) bool, landed map[string]bool) int {
 	n := 0
 	for i := range events {
-		if events[i].Type == audit.EventPRReverted && win(events[i].Timestamp) {
+		e := events[i]
+		if e.Type == audit.EventPRReverted && win(e.Timestamp) && landed[e.TaskID] {
 			n++
 		}
 	}

--- a/internal/evaluation/scorecard.go
+++ b/internal/evaluation/scorecard.go
@@ -39,10 +39,12 @@ type Scorecard struct {
 	AutonomyRate         float64 `json:"autonomyRate"` // autonomous / landed
 
 	// Reliability (from stats run outcomes).
-	AgentRuns       int     `json:"agentRuns"`
-	AgentFailures   int     `json:"agentFailures"`
-	FailureRate     float64 `json:"failureRate"`
-	CIFirstPassRate float64 `json:"ciFirstPassRate"` // landed without a CI-fix / landed
+	AgentRuns         int     `json:"agentRuns"`
+	AgentFailures     int     `json:"agentFailures"`
+	FailureRate       float64 `json:"failureRate"`
+	CIFirstPassRate   float64 `json:"ciFirstPassRate"`   // landed without a CI-fix / landed
+	Reverted          int     `json:"reverted"`          // merged landings later reverted on the default branch
+	ChangeFailureRate float64 `json:"changeFailureRate"` // reverted / merged landings (DORA)
 
 	// Efficiency: window spend and effort per landed PR.
 	TotalCostUSD   float64 `json:"totalCostUsd"`
@@ -81,7 +83,7 @@ type Report struct {
 // deferredNotes documents metrics that need signals not yet captured, so the
 // report never silently presents a partial picture as complete.
 var deferredNotes = []string{
-	"change-failure rate and MTTR pending revert detection (#1097)",
+	"MTTR (time to restore after a revert) pending revert-to-fix timing",
 	"review-finding density pending review-count capture",
 	"per-project/provider autonomy + throughput breakdowns pending project/provider on task.landed",
 }
@@ -109,6 +111,7 @@ func Compute(records []stats.RunRecord, events []audit.Event, since, until time.
 	sc.TasksLanded, sc.Merged, sc.Closed = lg.count, lg.merged, lg.closed
 	sc.MergedWithEdits = lg.mergedWithEdits
 	sc.AgentRuns, sc.AgentFailures = runs, fails
+	sc.Reverted = countReverts(events, win)
 	sc.TotalCostUSD = cost
 	autonomous, humanTouched, ciClean := classifyLanded(lg.tasks, lg.edited, sigs)
 	sc.AutonomousLandings, sc.HumanTouchedLandings = autonomous, humanTouched
@@ -124,6 +127,9 @@ func Compute(records []stats.RunRecord, events []audit.Event, since, until time.
 	}
 	if sc.AgentRuns > 0 {
 		sc.FailureRate = float64(sc.AgentFailures) / float64(sc.AgentRuns)
+	}
+	if mergedLandings := sc.Merged + sc.MergedWithEdits; mergedLandings > 0 {
+		sc.ChangeFailureRate = float64(sc.Reverted) / float64(mergedLandings)
 	}
 	sc.LeadTimeP50H = percentile(lg.leadTimes, 50)
 	sc.LeadTimeP90H = percentile(lg.leadTimes, 90)
@@ -210,6 +216,18 @@ func scanTaskSignals(events []audit.Event) map[string]*taskSignals {
 // scanReliability derives runs and failures from stats run records, not audit
 // events: the failure outcome is recorded on every run record (set from the
 // process exit), whereas a distinct agent.failed audit event is never emitted.
+// countReverts counts pr.reverted events in the window — landed PRs a revert
+// later undid on the default branch (the change-failure signal).
+func countReverts(events []audit.Event, win func(time.Time) bool) int {
+	n := 0
+	for i := range events {
+		if events[i].Type == audit.EventPRReverted && win(events[i].Timestamp) {
+			n++
+		}
+	}
+	return n
+}
+
 func scanReliability(records []stats.RunRecord, win func(time.Time) bool) (runs, failures int) {
 	for i := range records {
 		r := records[i]

--- a/internal/evaluation/scorecard_test.go
+++ b/internal/evaluation/scorecard_test.go
@@ -162,6 +162,27 @@ func TestCompute_ChangeFailureRate(t *testing.T) {
 	}
 }
 
+func TestCompute_RevertOfOutOfWindowMergeNotCounted(t *testing.T) {
+	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -30)
+	in := base.Add(-1 * time.Hour)
+	events := []audit.Event{
+		// One in-window merged landing.
+		{Type: audit.EventTaskLanded, TaskID: "A", Timestamp: in, Data: map[string]any{"outcome": "merged"}},
+		// Reverts in-window, but for tasks that did NOT land in-window → must not
+		// count, so the rate can't exceed 100%.
+		{Type: audit.EventPRReverted, TaskID: "OLD1", Timestamp: in},
+		{Type: audit.EventPRReverted, TaskID: "OLD2", Timestamp: in},
+	}
+	got := Compute(nil, events, since, base)
+	if got.Reverted != 0 {
+		t.Errorf("Reverted = %d, want 0 (reverts for out-of-window landings excluded)", got.Reverted)
+	}
+	if got.ChangeFailureRate != 0 {
+		t.Errorf("ChangeFailureRate = %v, want 0 (no in-cohort reverts)", got.ChangeFailureRate)
+	}
+}
+
 func TestComputeEmpty(t *testing.T) {
 	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
 	got := Compute(nil, nil, now.AddDate(0, 0, -7), now)

--- a/internal/evaluation/scorecard_test.go
+++ b/internal/evaluation/scorecard_test.go
@@ -142,6 +142,26 @@ func TestCompute_MergedWithEditsNotAutonomous(t *testing.T) {
 	}
 }
 
+func TestCompute_ChangeFailureRate(t *testing.T) {
+	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -30)
+	in := base.Add(-1 * time.Hour)
+	events := []audit.Event{
+		{Type: audit.EventTaskLanded, TaskID: "A", Timestamp: in, Data: map[string]any{"outcome": "merged"}},
+		{Type: audit.EventTaskLanded, TaskID: "B", Timestamp: in, Data: map[string]any{"outcome": "merged"}},
+		{Type: audit.EventTaskLanded, TaskID: "C", Timestamp: in, Data: map[string]any{"outcome": "merged_with_edits"}},
+		{Type: audit.EventPRReverted, TaskID: "A", Timestamp: in}, // one of 3 merged landings reverted
+	}
+	got := Compute(nil, events, since, base)
+	if got.Reverted != 1 {
+		t.Errorf("Reverted = %d, want 1", got.Reverted)
+	}
+	// 1 revert / 3 merged landings (merged + merged_with_edits).
+	if got.ChangeFailureRate < 0.33 || got.ChangeFailureRate > 0.34 {
+		t.Errorf("ChangeFailureRate = %v, want ~0.333", got.ChangeFailureRate)
+	}
+}
+
 func TestComputeEmpty(t *testing.T) {
 	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
 	got := Compute(nil, nil, now.AddDate(0, 0, -7), now)

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -337,6 +337,54 @@ func FetchPRHeadSHAContext(ctx context.Context, repo string, number int) (string
 	return raw.HeadRefOid, nil
 }
 
+// FetchPRMergeCommitContext returns the default-branch commit SHA a merged PR
+// produced (empty if not merged). Context-bounded for the poll path.
+func FetchPRMergeCommitContext(ctx context.Context, repo string, number int) (string, error) {
+	out, err := ghRunCtx(ctx, "pr", "view", strconv.Itoa(number), "--repo", repo, "--json", "mergeCommit")
+	if err != nil {
+		return "", fmt.Errorf("gh pr view %d mergeCommit: %s: %w", number, sanitizeGHOutput(out), err)
+	}
+	var raw struct {
+		MergeCommit struct {
+			OID string `json:"oid"`
+		} `json:"mergeCommit"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return "", fmt.Errorf("parse merge commit: %w", err)
+	}
+	return raw.MergeCommit.OID, nil
+}
+
+// FetchRecentCommitMessages returns the messages of the most recent commits on
+// the repo's default branch (up to limit, capped at 100). Used by revert
+// detection to spot a "This reverts commit <sha>" referencing a landed merge
+// commit. Context-bounded.
+func FetchRecentCommitMessages(ctx context.Context, repo string, limit int) ([]string, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 100
+	}
+	out, err := ghRunCtx(ctx, "api",
+		fmt.Sprintf("repos/%s/commits?per_page=%d", repo, limit),
+		"--jq", ".[].commit.message")
+	if err != nil {
+		return nil, fmt.Errorf("gh api commits %s: %s: %w", repo, sanitizeGHOutput(out), err)
+	}
+	return parseCommitMessages(out), nil
+}
+
+// parseCommitMessages splits the newline-delimited messages from the --jq
+// extraction, dropping blanks.
+func parseCommitMessages(out []byte) []string {
+	lines := strings.Split(string(out), "\n")
+	msgs := make([]string, 0, len(lines))
+	for _, l := range lines {
+		if s := strings.TrimSpace(l); s != "" {
+			msgs = append(msgs, s)
+		}
+	}
+	return msgs
+}
+
 // FetchPRDiff returns the unified diff for a PR. Used by the evaluation
 // LLM-as-judge to score the landed change.
 func FetchPRDiff(repo string, number int) (string, error) {

--- a/internal/github/pr_commits_test.go
+++ b/internal/github/pr_commits_test.go
@@ -1,0 +1,23 @@
+package github
+
+import "testing"
+
+func TestParseCommitMessages(t *testing.T) {
+	out := []byte("feat: a\n\nThis reverts commit abc.\nfix: b\n  \n")
+	got := parseCommitMessages(out)
+	want := []string{"feat: a", "This reverts commit abc.", "fix: b"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d msgs %v, want %d", len(got), got, len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("msg[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestParseCommitMessages_Empty(t *testing.T) {
+	if got := parseCommitMessages([]byte("")); len(got) != 0 {
+		t.Errorf("empty output should yield no messages, got %v", got)
+	}
+}

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -2,6 +2,7 @@ package sybra
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"maps"
 	"slices"
@@ -394,23 +395,31 @@ func (r *ReviewHandler) scanForReverts(tasks []task.Task) {
 	if !r.lastRevertScan.IsZero() && now.Sub(r.lastRevertScan) < revertScanInterval {
 		return
 	}
-	r.lastRevertScan = now
 
 	byRepo := map[string][]task.Task{}
 	for i := range tasks {
 		t := tasks[i]
-		if t.ProjectID == "" || t.MergeCommit == "" {
+		// A PR number is enough to detect a revert (by the "Reverts #n" form), so
+		// a task whose merge-commit capture failed at landing is still checked.
+		if t.ProjectID == "" || t.PRNumber == 0 {
 			continue
 		}
 		if t.Outcome != "merged" && t.Outcome != "merged_with_edits" {
-			continue // skip closed / already-reverted
+			// Skip closed / already-reverted. A reverted task stays reverted even
+			// if the revert is later re-applied — the change-failure still occurred.
+			continue
 		}
 		if t.ClosedAt != nil && now.Sub(*t.ClosedAt) > revertScanMaxAge {
 			continue
 		}
 		byRepo[t.ProjectID] = append(byRepo[t.ProjectID], t)
 	}
+	if len(byRepo) == 0 {
+		r.lastRevertScan = now // nothing to check; hold off until the next interval
+		return
+	}
 
+	scannedAny := false
 	for repo, cands := range byRepo {
 		ctx, cancel := context.WithTimeout(context.Background(), landingEnrichTimeout)
 		msgs, err := github.FetchRecentCommitMessages(ctx, repo, revertScanCommits)
@@ -419,9 +428,10 @@ func (r *ReviewHandler) scanForReverts(tasks []task.Task) {
 			r.logger.Warn("pr-monitor.revert-scan", "repo", repo, "err", err)
 			continue
 		}
+		scannedAny = true
 		for j := range cands {
 			t := &cands[j]
-			if !isReverted(t.MergeCommit, msgs) {
+			if !isReverted(t.MergeCommit, t.ProjectID, t.PRNumber, msgs) {
 				continue
 			}
 			if _, err := r.tasks.Update(t.ID, task.Update{Outcome: task.Ptr("reverted")}); err != nil {
@@ -432,19 +442,40 @@ func (r *ReviewHandler) scanForReverts(tasks []task.Task) {
 			r.logger.Info("pr-monitor.reverted", "task_id", t.ID, "pr", t.PRNumber, "merge_commit", t.MergeCommit)
 		}
 	}
+	// Only start the rate-limit clock once at least one repo was actually scanned,
+	// so a transient gh outage retries on the next poll instead of waiting 30m.
+	if scannedAny {
+		r.lastRevertScan = now
+	}
 }
 
-// isReverted reports whether any commit message reverts mergeCommit. Git's
-// revert template writes "This reverts commit <full-sha>." — match the full SHA
-// to avoid false positives.
-func isReverted(mergeCommit string, commitMessages []string) bool {
-	if mergeCommit == "" {
+// isReverted reports whether any default-branch commit message reverts the task.
+// It matches two GitHub revert forms so it works regardless of squash config:
+//   - the git footer "This reverts commit <full-sha>" (default COMMIT_MESSAGES)
+//   - the auto-generated body "Reverts #<n>" / "Reverts owner/repo#<n>" (which
+//     is what survives when the squash commit message is PR_BODY, as this repo's)
+//
+// Both anchor on the original PR's full SHA or number, so a passing mention of
+// the PR isn't a false positive.
+func isReverted(mergeCommit, repo string, prNumber int, commitMessages []string) bool {
+	var needles []string
+	if mergeCommit != "" {
+		needles = append(needles, "This reverts commit "+mergeCommit)
+	}
+	if prNumber > 0 {
+		needles = append(needles, fmt.Sprintf("Reverts #%d", prNumber))
+		if repo != "" {
+			needles = append(needles, fmt.Sprintf("Reverts %s#%d", repo, prNumber))
+		}
+	}
+	if len(needles) == 0 {
 		return false
 	}
-	needle := "This reverts commit " + mergeCommit
 	for _, m := range commitMessages {
-		if strings.Contains(m, needle) {
-			return true
+		for _, n := range needles {
+			if strings.Contains(m, n) {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -58,6 +58,8 @@ type ReviewHandler struct {
 	// agent posts as), used to tell the agent's own thread replies from a human
 	// collaborator's. Overridable in tests; nil falls back to github.ViewerLogin.
 	viewerLoginFn func() string
+	// lastRevertScan rate-limits the default-branch revert scan (revertScanInterval).
+	lastRevertScan time.Time
 }
 
 // agentLogin returns the GitHub login the fix agent posts as.
@@ -199,6 +201,7 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 		r.advanceClosedTaskPRs(monitoredPRs, closedMatchers)
 	}
 
+	r.scanForReverts(tasks)
 	r.resolveAddressedCopilotThreads(tasks, monitoredPRs)
 	r.maybeCreateReviewTasks(tasks, summary.ReviewRequested)
 	r.reconcileReviewPhases(tasks, summary)
@@ -236,10 +239,21 @@ func (r *ReviewHandler) advanceClosedTaskPRs(monitoredPRs []github.PullRequest, 
 			eventType = audit.EventPRClosed
 		}
 		r.logAudit(eventType, c.TaskID, "", map[string]any{"pr": c.PRNumber, "state": c.State})
-		// Enrich (bounded GitHub I/O); refine the outcome if a human edited the PR.
+		// Enrich (bounded GitHub I/O); refine the outcome if a human edited the PR
+		// and persist the merge commit for later revert detection.
 		outcome, landData := r.computeLanding(c.TaskID, c.PRNumber, c.State, base)
+		upd := task.Update{}
+		refine := false
 		if outcome != base {
-			if _, err := r.tasks.Update(c.TaskID, task.Update{Outcome: task.Ptr(outcome)}); err != nil {
+			upd.Outcome = task.Ptr(outcome)
+			refine = true
+		}
+		if mc, ok := landData["merge_commit"].(string); ok && mc != "" {
+			upd.MergeCommit = task.Ptr(mc)
+			refine = true
+		}
+		if refine {
+			if _, err := r.tasks.Update(c.TaskID, upd); err != nil {
 				r.logger.Warn("pr-monitor.outcome-refine", "task_id", c.TaskID, "err", err)
 			}
 		}
@@ -318,6 +332,10 @@ func (r *ReviewHandler) enrichLanding(repo string, prNumber int, agentSHA, base 
 	if base != "merged" {
 		return enr // closed (unmerged): size only, no edit detection
 	}
+	// Record the merge commit so the revert scanner can later detect a revert.
+	if mc, err := github.FetchPRMergeCommitContext(ctx, repo, prNumber); err == nil && mc != "" {
+		enr.data["merge_commit"] = mc
+	}
 	head, err := github.FetchPRHeadSHAContext(ctx, repo, prNumber)
 	if err != nil {
 		return enr // couldn't read the merged head; keep base outcome + size
@@ -355,6 +373,81 @@ func lastAgentHeadSHA(runs []task.AgentRun) string {
 		}
 	}
 	return ""
+}
+
+const (
+	// revertScanInterval rate-limits the revert scan so it doesn't run every poll.
+	revertScanInterval = 30 * time.Minute
+	// revertScanMaxAge bounds how far back a merged task is still checked for reverts.
+	revertScanMaxAge = 30 * 24 * time.Hour
+	// revertScanCommits is how many recent default-branch commits to fetch per repo.
+	revertScanCommits = 100
+)
+
+// scanForReverts detects when a landed task's merge commit was later reverted on
+// the default branch, flips the task outcome to "reverted", and emits
+// pr.reverted (the change-failure signal). Rate-limited and bounded: one gh call
+// per repo with eligible tasks, every revertScanInterval, with each call killed
+// after landingEnrichTimeout. Reuses the already-listed tasks (no extra read).
+func (r *ReviewHandler) scanForReverts(tasks []task.Task) {
+	now := time.Now()
+	if !r.lastRevertScan.IsZero() && now.Sub(r.lastRevertScan) < revertScanInterval {
+		return
+	}
+	r.lastRevertScan = now
+
+	byRepo := map[string][]task.Task{}
+	for i := range tasks {
+		t := tasks[i]
+		if t.ProjectID == "" || t.MergeCommit == "" {
+			continue
+		}
+		if t.Outcome != "merged" && t.Outcome != "merged_with_edits" {
+			continue // skip closed / already-reverted
+		}
+		if t.ClosedAt != nil && now.Sub(*t.ClosedAt) > revertScanMaxAge {
+			continue
+		}
+		byRepo[t.ProjectID] = append(byRepo[t.ProjectID], t)
+	}
+
+	for repo, cands := range byRepo {
+		ctx, cancel := context.WithTimeout(context.Background(), landingEnrichTimeout)
+		msgs, err := github.FetchRecentCommitMessages(ctx, repo, revertScanCommits)
+		cancel()
+		if err != nil {
+			r.logger.Warn("pr-monitor.revert-scan", "repo", repo, "err", err)
+			continue
+		}
+		for j := range cands {
+			t := &cands[j]
+			if !isReverted(t.MergeCommit, msgs) {
+				continue
+			}
+			if _, err := r.tasks.Update(t.ID, task.Update{Outcome: task.Ptr("reverted")}); err != nil {
+				r.logger.Warn("pr-monitor.revert-update", "task_id", t.ID, "err", err)
+				continue
+			}
+			r.logAudit(audit.EventPRReverted, t.ID, "", map[string]any{"pr": t.PRNumber, "merge_commit": t.MergeCommit})
+			r.logger.Info("pr-monitor.reverted", "task_id", t.ID, "pr", t.PRNumber, "merge_commit", t.MergeCommit)
+		}
+	}
+}
+
+// isReverted reports whether any commit message reverts mergeCommit. Git's
+// revert template writes "This reverts commit <full-sha>." — match the full SHA
+// to avoid false positives.
+func isReverted(mergeCommit string, commitMessages []string) bool {
+	if mergeCommit == "" {
+		return false
+	}
+	needle := "This reverts commit " + mergeCommit
+	for _, m := range commitMessages {
+		if strings.Contains(m, needle) {
+			return true
+		}
+	}
+	return false
 }
 
 // earliestRunStart returns the start time of the first agent run, or the zero

--- a/internal/sybra/app_reviews_revert_test.go
+++ b/internal/sybra/app_reviews_revert_test.go
@@ -8,19 +8,24 @@ func TestIsReverted(t *testing.T) {
 	tests := []struct {
 		name string
 		sha  string
+		repo string
+		pr   int
 		msgs []string
 		want bool
 	}{
-		{"reverted full sha", sha, []string{"Revert \"feat: x\"", "This reverts commit " + sha + "."}, true},
-		{"not reverted", sha, []string{"feat: unrelated", "fix: other"}, false},
-		{"empty sha never reverted", "", []string{"This reverts commit ."}, false},
-		{"different sha", sha, []string{"This reverts commit 0000000000000000000000000000000000000000."}, false},
-		{"no messages", sha, nil, false},
+		{"footer full sha", sha, "o/r", 42, []string{"Revert \"feat: x\"", "This reverts commit " + sha + "."}, true},
+		{"pr-number body form", "", "o/r", 42, []string{"Revert \"feat: x\" (#99)\n\nReverts #42"}, true},
+		{"qualified pr-number form", "", "o/r", 42, []string{"Reverts o/r#42"}, true},
+		{"not reverted", sha, "o/r", 42, []string{"feat: unrelated", "fix: other"}, false},
+		{"passing mention of pr not a revert", "", "o/r", 42, []string{"see #42 for context"}, false},
+		{"no sha and no pr", "", "o/r", 0, []string{"This reverts commit ."}, false},
+		{"different sha", sha, "o/r", 7, []string{"This reverts commit 0000000000000000000000000000000000000000."}, false},
+		{"no messages", sha, "o/r", 42, nil, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := isReverted(tt.sha, tt.msgs); got != tt.want {
+			if got := isReverted(tt.sha, tt.repo, tt.pr, tt.msgs); got != tt.want {
 				t.Errorf("isReverted = %v, want %v", got, tt.want)
 			}
 		})

--- a/internal/sybra/app_reviews_revert_test.go
+++ b/internal/sybra/app_reviews_revert_test.go
@@ -1,0 +1,28 @@
+package sybra
+
+import "testing"
+
+func TestIsReverted(t *testing.T) {
+	t.Parallel()
+	sha := "abc123def456abc123def456abc123def456abcd"
+	tests := []struct {
+		name string
+		sha  string
+		msgs []string
+		want bool
+	}{
+		{"reverted full sha", sha, []string{"Revert \"feat: x\"", "This reverts commit " + sha + "."}, true},
+		{"not reverted", sha, []string{"feat: unrelated", "fix: other"}, false},
+		{"empty sha never reverted", "", []string{"This reverts commit ."}, false},
+		{"different sha", sha, []string{"This reverts commit 0000000000000000000000000000000000000000."}, false},
+		{"no messages", sha, nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isReverted(tt.sha, tt.msgs); got != tt.want {
+				t.Errorf("isReverted = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -214,10 +214,14 @@ type Task struct {
 	Priority  Priority   `yaml:"priority,omitempty" json:"priority,omitempty"`
 	DueDate   *time.Time `yaml:"due_date,omitempty" json:"dueDate,omitempty"`
 	ClosedAt  *time.Time `yaml:"closed_at,omitempty" json:"closedAt,omitempty"`
-	// Outcome records how a task's own PR concluded: "merged" or "closed".
-	// Stamped by the PR monitor when the task auto-advances to done. Empty for
-	// tasks that never produced a PR. Feeds the evaluation scorecard.
+	// Outcome records how a task's own PR concluded: "merged", "merged_with_edits",
+	// "closed", or "reverted". Stamped by the PR monitor when the task auto-advances
+	// to done (and updated to "reverted" by the revert scanner). Empty for tasks
+	// that never produced a PR. Feeds the evaluation scorecard.
 	Outcome string `yaml:"outcome,omitempty" json:"outcome,omitempty"`
+	// MergeCommit is the default-branch commit a merged PR produced, recorded at
+	// landing so the revert scanner can detect a later revert of it.
+	MergeCommit string `yaml:"merge_commit,omitempty" json:"mergeCommit,omitempty"`
 	// MaxTurns overrides the global agent turn limit for this task.
 	// Zero means "use global default".
 	MaxTurns int `yaml:"max_turns,omitempty" json:"maxTurns,omitempty"`

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -445,6 +445,9 @@ func applyReviewFields(t *Task, u Update) {
 	if u.Outcome != nil {
 		t.Outcome = *u.Outcome
 	}
+	if u.MergeCommit != nil {
+		t.MergeCommit = *u.MergeCommit
+	}
 	if u.ReviewPhase != nil {
 		t.ReviewPhase = *u.ReviewPhase
 	}

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -41,6 +41,7 @@ type Update struct {
 	ForkSubagent    *bool
 	ReasoningEffort *string
 	Outcome         *string
+	MergeCommit     *string
 }
 
 // Ptr returns a pointer to v. Convenience for building Update literals.
@@ -67,7 +68,7 @@ func applyMapField(u *Update, k string, v any) error {
 	switch k {
 	case "title", "slug", "status_reason", "blocked_by_issue", "body",
 		"project_id", "branch", "worktree_dir", "issue", "run_role", "todoist_id", "plan", "plan_critique", "code_review",
-		"review_phase", "pr_phase", "outcome":
+		"review_phase", "pr_phase", "outcome", "merge_commit":
 		return applyPlainStringField(u, k, v)
 	case "priority":
 		return applyPriorityField(u, v)
@@ -159,6 +160,8 @@ func applyPlainStringField(u *Update, k string, v any) error {
 		u.PRPhase = &s
 	case "outcome":
 		u.Outcome = &s
+	case "merge_commit":
+		u.MergeCommit = &s
 	}
 	return nil
 }


### PR DESCRIPTION
## Motivation

Closes #1097. Final piece of the rich-landing-signals follow-up: detect when a landed PR is later reverted and surface the DORA change-failure rate — the "does the code stay merged" half of measuring quality.

> Changelog: feat(eval): revert detection + change-failure rate

## Implementation information

- **Merge-commit capture** — `Task.MergeCommit` recorded at landing (via `enrichLanding`), so a revert can be tied back to its task.
- **`scanForReverts`** (PR poller, rate-limited to 30m, bounded) — groups eligible merged-and-not-reverted tasks by repo, fetches the latest default-branch commit messages once per repo (context-killed), and flips a task to `reverted` + emits `pr.reverted` when a revert is found. The rate-limit clock only advances after a repo is actually scanned, so a transient `gh` outage retries.
- **Match by both forms** — `isReverted` matches the git footer `This reverts commit <sha>` **and** the `Reverts #<n>` body form. This repo squash-merges with `PR_BODY`, so the footer is replaced by the body; keying on the PR number also means a task whose merge-commit capture failed is still checked.
- **Change-failure rate** — scorecard gains `Reverted` + `ChangeFailureRate` (reverts of in-window landings ÷ in-window merged landings, so it can't exceed 100%). Surfaced in the CLI scan and dashboard.

### Adversarial review (applied before this PR)
Caught that the SHA-only matcher would miss every revert under this repo's `PR_BODY` squash config (now matches `Reverts #n`), that the change-failure cohort could exceed 100% (now cohort-bounded), and that a landing-time `gh` failure would permanently disable detection for a task (now keyed on PR number). The 100-commit-per-repo scan ceiling is documented in `Report.Notes`.

## Supporting documentation
- Evaluation umbrella #1065; completes #1097 (Codex taxonomy + autonomy shipped in #1098).

Gates: `golangci-lint run ./...`, `go test ./...`, `svelte-check` pass (pre-existing flaky agent shutdown-timing test passes on rerun).
