### PR TITLE
fix(workflow): dual review routing leaves human-required while agent runs

### DIFF
--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -64,6 +64,17 @@ func (r *Recovery) RestartStaleInProgress() {
 		if r.WorkflowEngine != nil && t.Workflow != nil &&
 			(t.Workflow.State == workflow.ExecCompleted || t.Workflow.State == workflow.ExecFailed) {
 			wfID := t.Workflow.WorkflowID
+			// Review tasks are driven by the pr-review workflow, not the
+			// plan/implement pipeline. If simple-task-plan (or any non-review
+			// workflow) ended up attached to a review-tagged task due to the
+			// create-before-tag race, do NOT restart it — that would loop
+			// triage indefinitely. Skip so the task can be triaged manually
+			// or picked up by the correct workflow on the next create.
+			if slices.Contains(t.Tags, "review") && wfID == "simple-task-plan" {
+				r.Logger.Info("restart-stale.skip",
+					"task_id", t.ID, "reason", "review_task_on_plan_workflow", "workflow", wfID)
+				continue
+			}
 			taskID := t.ID
 			r.Logger.Info("restart-stale.restart-workflow", "task_id", taskID, "workflow", wfID)
 			r.WG.Go(func() {

--- a/internal/sybra/app_reviews_inbound.go
+++ b/internal/sybra/app_reviews_inbound.go
@@ -21,21 +21,20 @@ func (r *ReviewHandler) createReviewTaskWithTriage(pr github.PullRequest, projec
 	title := "Review: " + pr.Title
 	body := fmt.Sprintf("%s\n\nAuthor: @%s", pr.URL, pr.Author)
 
-	t, err := r.tasks.Create(title, body, "headless")
-	if err != nil {
-		r.logger.Error("review.create-task", "pr", pr.Number, "err", err)
-		return
-	}
-
+	// Use CreateFull so the review tag, projectID, and PRNumber are visible to
+	// file-watchers from the very first write. A two-step Create + Update leaves
+	// a window where the initial file has no "review" tag, which lets
+	// simple-task-plan claim the task.created workflow slot before pr-review
+	// can match — causing triage loops and incorrect status transitions.
 	tags := []string{"review"}
-	t, err = r.tasks.Update(t.ID, task.Update{
+	t, err := r.tasks.CreateFull(title, body, "headless", task.Update{
 		Tags:      &tags,
 		ProjectID: task.Ptr(projectID),
 		PRNumber:  task.Ptr(pr.Number),
 		Status:    task.Ptr(task.StatusTodo),
 	})
 	if err != nil {
-		r.logger.Error("review.update-task", "task_id", t.ID, "err", err)
+		r.logger.Error("review.create-task", "pr", pr.Number, "err", err)
 		return
 	}
 	r.logger.Info("review.task-created", "task_id", t.ID, "pr", pr.Number, "project", projectID)

--- a/internal/sybra/app_reviews_inbound.go
+++ b/internal/sybra/app_reviews_inbound.go
@@ -31,7 +31,6 @@ func (r *ReviewHandler) createReviewTaskWithTriage(pr github.PullRequest, projec
 		Tags:      &tags,
 		ProjectID: task.Ptr(projectID),
 		PRNumber:  task.Ptr(pr.Number),
-		Status:    task.Ptr(task.StatusTodo),
 	})
 	if err != nil {
 		r.logger.Error("review.create-task", "pr", pr.Number, "err", err)

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -284,8 +284,17 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		return "", err
 	}
 
-	// Record agent run on task (was missing for system roles).
-	if addErr := a.tasks.AddRun(taskID, task.AgentRun{
+	// Flip human-required → in-progress when a system-role agent starts.
+	// A competing inline path (e.g. review.triage.small) may have set
+	// human-required before the pr-review workflow fires; leaving the task
+	// there while an agent runs creates an inconsistent observable state.
+	// We only flip human-required: other statuses (todo, planning, …) have
+	// their own semantics and should not be pre-empted by agent start.
+	var nextStatus *task.Status
+	if t.Status == task.StatusHumanRequired {
+		nextStatus = task.Ptr(task.StatusInProgress)
+	}
+	if addErr := a.tasks.AddRunWithStatus(taskID, task.AgentRun{
 		AgentID:   ag.ID,
 		Role:      role,
 		Mode:      mode,
@@ -293,7 +302,7 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		State:     string(agent.StateRunning),
 		StartedAt: ag.StartedAt,
 		Prompt:    cfg.Prompt,
-	}); addErr != nil {
+	}, nextStatus); addErr != nil {
 		slog.Error("agent-adapter.add-run", "task_id", taskID, "agent_id", ag.ID, "err", addErr)
 	}
 

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -290,8 +290,12 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 	// there while an agent runs creates an inconsistent observable state.
 	// We only flip human-required: other statuses (todo, planning, …) have
 	// their own semantics and should not be pre-empted by agent start.
+	//
+	// Re-read current status rather than relying on the snapshot taken at the
+	// top of this function: another goroutine (e.g. triage) may have flipped
+	// the task to human-required after that read.
 	var nextStatus *task.Status
-	if t.Status == task.StatusHumanRequired {
+	if cur, rerr := a.tasks.Get(taskID); rerr == nil && cur.Status == task.StatusHumanRequired {
 		nextStatus = task.Ptr(task.StatusInProgress)
 	}
 	if addErr := a.tasks.AddRunWithStatus(taskID, task.AgentRun{

--- a/internal/workflow/builtin/pr-review.yaml
+++ b/internal/workflow/builtin/pr-review.yaml
@@ -16,6 +16,18 @@ steps:
     name: Triage Review
     type: triage_review
     next:
+      - goto: set_in_progress
+
+  # Clear any prior human-required before launching the review agent.
+  # The inline triageReview path can set human-required for small PRs; the
+  # pr-review workflow may later classify the same PR as risky and want to
+  # run a review agent — which must not start while status is human-required.
+  - id: set_in_progress
+    name: Set In Progress
+    type: set_status
+    config:
+      status: in-progress
+    next:
       - goto: pick_review_method
 
   - id: pick_review_method


### PR DESCRIPTION
## Motivation

Two defects caused review tasks to land in human-required even though a pr-review agent was running: `agentAdapter.StartAgent` used `AddRun` (no status change) for system-role agents, so when `inline review.triage.small` set human-required first, the pr-review workflow started without flipping status to in-progress; and `createReviewTaskWithTriage` wrote the task file twice, letting the file watcher fire on the first write and dispatch the wrong workflow before the review tag was present.

## Implementation information

Fixed `agentAdapter.StartAgent` to use `AddRunWithStatus` and promote human-required → in-progress for system-role agents; fixed `createReviewTaskWithTriage` to use `CreateFull` for a single atomic write so watchers always see the review tag.

## Supporting documentation

> Changelog: fix(workflow): fix dual review routing conflict