### PR TITLE
feat(artifacts): add per-task harness artifact store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,9 @@ sybra/
 │   │   ├── model.go         # Task struct, Status enum
 │   │   ├── parser.go        # Frontmatter parse/marshal
 │   │   └── store.go         # Filesystem-backed store
+│   ├── artifact/            # Per-task harness artifact store (~/.sybra/artifacts/<task-id>/)
+│   │   ├── model.go         # Meta struct, Kind enum, Artifact write request
+│   │   └── store.go         # Put/Append/List/Read/Delete/Reindex
 │   ├── agent/               # Agent lifecycle management
 │   │   ├── model.go         # Agent struct, State enum, StreamEvent
 │   │   ├── manager.go       # Start/stop/list agents
@@ -389,3 +392,4 @@ Frontend must build before Go compilation due to `//go:embed all:frontend/dist`:
 - ❌ Baking project toolchains into the prod `Dockerfile` — the image ships `mise` only. Language-specific tools belong in each project's **Setup commands** (see Server Deployment section). New projects in new languages never require a container rebuild.
 - ❌ Treating `go build .` (desktop) as a server-context commit gate — Wails v3 needs GTK/webkit on Linux (not installed server-side) and desktop is darwin-only/CI-owned. Use `mise run build:server` for server-side verification.
 - ❌ Pasting, linking, or paraphrasing work-repo content (URLs, branches, SHAs, ticket IDs, snippets, logs, customer names) into sybra issues/PRs/tasks/commits — see **Work-Data Confidentiality** at the top. Any new auto-source that ingests external content must filter work-repo content at the source, not in post-processing.
+- ❌ Surfacing `internal/artifact/` content in a GitHub issue/PR/comment without routing through `App.workScrubContextForTask` + `scrub.Scrub` first — the artifact store is raw/local-debug-only and never scrubs at write time.

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -14,6 +14,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/Automaat/sybra/internal/artifact"
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/monitor"
@@ -97,6 +98,8 @@ func run(args []string) int {
 		return cmdEvaluation(cfg, store, rest, jsonOut)
 	case "install-skills":
 		return cmdInstallSkills(cfg, jsonOut)
+	case "artifact":
+		return cmdArtifact(rest, jsonOut)
 	default:
 		return fatal(jsonOut, "unknown command: %s", cmd)
 	}
@@ -1292,6 +1295,84 @@ Commands:
                                ~/.claude/skills, ~/.codex/skills, ~/.agents/skills
                                (and the app skills dir) for Claude Code + Codex.
 
+  artifact list <task-id>      List artifacts for a task.
+  artifact get  <task-id> <name>  Print raw artifact bytes to stdout.
+  artifact reindex <task-id>   Rebuild index.json from *.meta.json files.
+
 Global flags:
   --json   Output as JSON`)
+}
+
+func cmdArtifact(args []string, jsonOut bool) int {
+	if len(args) == 0 {
+		return fatal(jsonOut, "artifact: subcommand required (list|get|reindex)")
+	}
+	sub, rest := args[0], args[1:]
+	store := artifact.New(config.ArtifactsDir())
+	switch sub {
+	case "list":
+		return cmdArtifactList(store, rest, jsonOut)
+	case "get":
+		return cmdArtifactGet(store, rest)
+	case "reindex":
+		return cmdArtifactReindex(store, rest, jsonOut)
+	default:
+		return fatal(jsonOut, "artifact: unknown subcommand %q", sub)
+	}
+}
+
+func cmdArtifactList(store *artifact.Store, args []string, jsonOut bool) int {
+	if len(args) < 1 {
+		return fatal(jsonOut, "artifact list: task-id required")
+	}
+	taskID := args[0]
+	metas, err := store.List(taskID)
+	if err != nil {
+		return fatal(jsonOut, "artifact list: %v", err)
+	}
+	if jsonOut {
+		return printJSON(metas)
+	}
+	if len(metas) == 0 {
+		fmt.Println("(no artifacts)")
+		return 0
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tKIND\tSIZE\tCREATED")
+	for i := range metas {
+		m := &metas[i]
+		fmt.Fprintf(w, "%s\t%s\t%d\t%s\n", m.Name, m.Kind, m.Size, m.CreatedAt.Format(time.RFC3339))
+	}
+	_ = w.Flush()
+	return 0
+}
+
+func cmdArtifactGet(store *artifact.Store, args []string) int {
+	if len(args) < 2 {
+		fmt.Fprintln(os.Stderr, "artifact get: task-id and name required")
+		return 1
+	}
+	taskID, name := args[0], args[1]
+	data, _, err := store.Read(taskID, name)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	_, _ = os.Stdout.Write(data)
+	return 0
+}
+
+func cmdArtifactReindex(store *artifact.Store, args []string, jsonOut bool) int {
+	if len(args) < 1 {
+		return fatal(jsonOut, "artifact reindex: task-id required")
+	}
+	taskID := args[0]
+	if err := store.Reindex(taskID); err != nil {
+		return fatal(jsonOut, "artifact reindex: %v", err)
+	}
+	if jsonOut {
+		return printJSON(map[string]string{"status": "ok", "task_id": taskID})
+	}
+	fmt.Printf("reindexed %s\n", taskID)
+	return 0
 }

--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -591,3 +591,119 @@ func TestProjectDeleteNoID(t *testing.T) {
 		t.Error("expected non-zero exit for missing id")
 	}
 }
+
+func TestArtifactListEmpty(t *testing.T) {
+	setupStore(t)
+	code, out := runCLI(t, "--json", "artifact", "list", "task-xyz")
+	if code != 0 {
+		t.Fatalf("exit %d: %s", code, out)
+	}
+	var metas []any
+	mustUnmarshal(t, out, &metas)
+	if len(metas) != 0 {
+		t.Errorf("expected empty list, got %d", len(metas))
+	}
+}
+
+func TestArtifactListAndGet(t *testing.T) {
+	dir := setupStore(t)
+	// Write a plan artifact directly into the store dir so the CLI can read it.
+	taskDir := filepath.Join(dir, "artifacts", "task-cli1")
+	if err := os.MkdirAll(taskDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	blob := []byte("# Plan content")
+	if err := os.WriteFile(filepath.Join(taskDir, "plan.md"), blob, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	meta := `{"name":"plan.md","kind":"plan","taskId":"task-cli1","createdAt":"2026-01-01T00:00:00Z","size":14}`
+	if err := os.WriteFile(filepath.Join(taskDir, "plan.md.meta.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, out := runCLI(t, "--json", "artifact", "list", "task-cli1")
+	if code != 0 {
+		t.Fatalf("list exit %d: %s", code, out)
+	}
+	var metas []map[string]any
+	mustUnmarshal(t, out, &metas)
+	if len(metas) != 1 {
+		t.Fatalf("expected 1 artifact, got %d", len(metas))
+	}
+	if metas[0]["name"] != "plan.md" {
+		t.Errorf("name = %v, want plan.md", metas[0]["name"])
+	}
+
+	// artifact get writes bytes to stdout, no --json flag
+	code2, got := runCLI(t, "artifact", "get", "task-cli1", "plan.md")
+	if code2 != 0 {
+		t.Fatalf("get exit %d", code2)
+	}
+	if got != string(blob) {
+		t.Errorf("get output = %q, want %q", got, blob)
+	}
+}
+
+func TestArtifactGetMissing(t *testing.T) {
+	setupStore(t)
+	// Capture stderr too via a second pipe since get writes errors there.
+	oldErr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	code, _ := runCLI(t, "artifact", "get", "task-none", "plan.md")
+
+	_ = w.Close()
+	os.Stderr = oldErr
+	buf := make([]byte, 1024)
+	_, _ = r.Read(buf)
+
+	if code == 0 {
+		t.Error("expected non-zero exit for missing artifact")
+	}
+}
+
+func TestArtifactReindex(t *testing.T) {
+	dir := setupStore(t)
+	taskDir := filepath.Join(dir, "artifacts", "task-ri1")
+	if err := os.MkdirAll(taskDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(taskDir, "plan.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	meta := `{"name":"plan.md","kind":"plan","taskId":"task-ri1","createdAt":"2026-01-01T00:00:00Z","size":1}`
+	if err := os.WriteFile(filepath.Join(taskDir, "plan.md.meta.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Corrupt the index to confirm reindex repairs it.
+	if err := os.WriteFile(filepath.Join(taskDir, "index.json"), []byte("!!!"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, out := runCLI(t, "--json", "artifact", "reindex", "task-ri1")
+	if code != 0 {
+		t.Fatalf("reindex exit %d: %s", code, out)
+	}
+	var result map[string]string
+	mustUnmarshal(t, out, &result)
+	if result["status"] != "ok" {
+		t.Errorf("status = %q, want ok", result["status"])
+	}
+}
+
+func TestArtifactInvalidTaskID(t *testing.T) {
+	setupStore(t)
+	code, _ := runCLI(t, "--json", "artifact", "list", "../escape")
+	if code == 0 {
+		t.Error("expected non-zero exit for hostile task ID")
+	}
+}
+
+func TestArtifactNoSubcommand(t *testing.T) {
+	setupStore(t)
+	code, _ := runCLI(t, "--json", "artifact")
+	if code == 0 {
+		t.Error("expected non-zero exit when subcommand missing")
+	}
+}

--- a/internal/artifact/model.go
+++ b/internal/artifact/model.go
@@ -1,0 +1,73 @@
+// Package artifact provides a per-task store for typed intermediate agent-run
+// state (plan snapshots, trace events, generic blobs).
+//
+// The store is local-debug-only and raw: artifacts are never scrubbed at write
+// time. Any future code that surfaces a work-typed artifact in a GitHub
+// issue/PR/comment MUST first route through App.workScrubContextForTask +
+// scrub.Scrub — the store deliberately does not scrub.
+package artifact
+
+import (
+	"regexp"
+	"time"
+)
+
+// Kind classifies an artifact's role in the workflow.
+type Kind string
+
+const (
+	// KindPlan holds a raw markdown plan snapshot.
+	KindPlan Kind = "plan"
+	// KindTrace holds an append-only NDJSON stream of step-completion events.
+	KindTrace Kind = "trace"
+	// KindGeneric is a catch-all for helper blobs that don't fit the above.
+	KindGeneric Kind = "generic"
+)
+
+func (k Kind) defaultExt() string {
+	switch k {
+	case KindTrace:
+		return ".jsonl"
+	default:
+		return ".md"
+	}
+}
+
+// defaultName returns the conventional artifact file name for a kind.
+func (k Kind) defaultName() string {
+	return string(k) + k.defaultExt()
+}
+
+// Meta is the per-artifact metadata stored alongside the raw bytes.
+// It is the source of truth for List; index.json is a derived cache.
+type Meta struct {
+	Name         string `json:"name"`
+	Kind         Kind   `json:"kind"`
+	ProducerRole string `json:"producerRole,omitempty"`
+	// TaskID is the containing task's ID (redundant with the dir name, kept for AC).
+	TaskID    string    `json:"taskId"`
+	StepID    string    `json:"stepId,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
+	// SourcePath is the agent-output file that was imported (forensic only).
+	SourcePath string `json:"sourcePath,omitempty"`
+	Size       int64  `json:"size"`
+	// Stream is true for append-only artifacts (trace.jsonl).
+	Stream bool `json:"stream,omitempty"`
+}
+
+// Artifact is the write request passed to Put.
+type Artifact struct {
+	Kind         Kind
+	Name         string // if empty, derived from Kind
+	ProducerRole string
+	StepID       string
+	SourcePath   string
+	Content      []byte // binary-safe end-to-end
+}
+
+// validName allows alphanumeric, dot, underscore, hyphen — no path separators.
+var validName = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
+// validTaskID allows alphanumeric, underscore, hyphen — matches the task ID
+// character set so a hostile ID cannot escape the store root.
+var validTaskID = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)

--- a/internal/artifact/store.go
+++ b/internal/artifact/store.go
@@ -87,7 +87,7 @@ func (s *Store) Put(taskID string, a Artifact) (Meta, error) {
 	if err != nil {
 		return Meta{}, err
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return Meta{}, fmt.Errorf("artifact: mkdir: %w", err)
 	}
 
@@ -132,7 +132,7 @@ func (s *Store) Append(taskID string, kind Kind, event any) error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("artifact: mkdir: %w", err)
 	}
 
@@ -164,7 +164,7 @@ func (s *Store) Append(taskID string, kind Kind, event any) error {
 		}
 	}
 
-	f, err := os.OpenFile(filepath.Join(dir, name), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	f, err := os.OpenFile(filepath.Join(dir, name), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return fmt.Errorf("artifact: open stream: %w", err)
 	}
@@ -246,6 +246,10 @@ func (s *Store) Read(taskID, name string) ([]byte, Meta, error) {
 		return nil, Meta{}, err
 	}
 
+	mu := s.lockFor(taskID)
+	mu.Lock()
+	defer mu.Unlock()
+
 	data, err := os.ReadFile(filepath.Join(dir, name))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -271,6 +275,9 @@ func (s *Store) Delete(taskID string) error {
 	if err != nil {
 		return err
 	}
+	mu := s.lockFor(taskID)
+	mu.Lock()
+	defer mu.Unlock()
 	if err := os.RemoveAll(dir); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("artifact: delete: %w", err)
 	}

--- a/internal/artifact/store.go
+++ b/internal/artifact/store.go
@@ -1,0 +1,333 @@
+package artifact
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Automaat/sybra/internal/fsutil"
+)
+
+// Store is a per-task artifact store backed by ~/.sybra/artifacts/<task-id>/.
+// Put uses atomic-rename for blobs; Append uses O_APPEND for streams.
+// Correctness never depends on index.json — List does a dir scan.
+//
+// Lock ordering: the Store's outer mu guards the locks map only. Per-task
+// mutexes (returned by lockFor) guard all I/O for that task. Nothing that
+// holds a per-task lock may call public methods that re-acquire the same lock.
+// Internal helpers that scan/write under an already-held per-task lock use
+// scanMetaLocked / rebuildIndexLocked directly.
+type Store struct {
+	root  string
+	mu    sync.Mutex // guards locks map only
+	locks map[string]*sync.Mutex
+}
+
+// New creates a Store rooted at dir. The directory is created on first write.
+func New(dir string) *Store {
+	return &Store{root: dir, locks: make(map[string]*sync.Mutex)}
+}
+
+// lockFor returns the per-task mutex, creating it if absent.
+func (s *Store) lockFor(taskID string) *sync.Mutex {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	mu, ok := s.locks[taskID]
+	if !ok {
+		mu = &sync.Mutex{}
+		s.locks[taskID] = mu
+	}
+	return mu
+}
+
+// pruneLock removes the per-task lock entry. Call after Delete.
+func (s *Store) pruneLock(taskID string) {
+	s.mu.Lock()
+	delete(s.locks, taskID)
+	s.mu.Unlock()
+}
+
+// taskDir returns the per-task directory, rejecting hostile IDs and verifying
+// path containment as defence in depth even after the regex passes.
+func (s *Store) taskDir(taskID string) (string, error) {
+	if !validTaskID.MatchString(taskID) {
+		return "", fmt.Errorf("artifact: invalid task id %q", taskID)
+	}
+	dir := filepath.Join(s.root, taskID)
+	if !strings.HasPrefix(filepath.Clean(dir)+string(filepath.Separator),
+		filepath.Clean(s.root)+string(filepath.Separator)) {
+		return "", fmt.Errorf("artifact: task id %q escapes store root", taskID)
+	}
+	return dir, nil
+}
+
+// Put writes a blob artifact atomically. Bytes are written before the meta
+// companion so a crash leaves an ignorable orphan, never a meta pointing at
+// missing bytes.
+func (s *Store) Put(taskID string, a Artifact) (Meta, error) {
+	if !validTaskID.MatchString(taskID) {
+		return Meta{}, fmt.Errorf("artifact: invalid task id %q", taskID)
+	}
+	name := a.Name
+	if name == "" {
+		name = a.Kind.defaultName()
+	}
+	if !validName.MatchString(name) {
+		return Meta{}, fmt.Errorf("artifact: invalid artifact name %q", name)
+	}
+
+	dir, err := s.taskDir(taskID)
+	if err != nil {
+		return Meta{}, err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return Meta{}, fmt.Errorf("artifact: mkdir: %w", err)
+	}
+
+	m := Meta{
+		Name:         name,
+		Kind:         a.Kind,
+		ProducerRole: a.ProducerRole,
+		TaskID:       taskID,
+		StepID:       a.StepID,
+		CreatedAt:    time.Now().UTC(),
+		SourcePath:   a.SourcePath,
+		Size:         int64(len(a.Content)),
+	}
+	metaData, err := json.Marshal(m)
+	if err != nil {
+		return Meta{}, fmt.Errorf("artifact: marshal meta: %w", err)
+	}
+
+	mu := s.lockFor(taskID)
+	mu.Lock()
+	defer mu.Unlock()
+
+	if err := fsutil.AtomicWrite(filepath.Join(dir, name), a.Content); err != nil {
+		return Meta{}, fmt.Errorf("artifact: write blob: %w", err)
+	}
+	if err := fsutil.AtomicWrite(filepath.Join(dir, name+".meta.json"), metaData); err != nil {
+		return Meta{}, fmt.Errorf("artifact: write meta: %w", err)
+	}
+	s.rebuildIndexLocked(taskID, dir)
+	return m, nil
+}
+
+// Append appends one JSON-encoded event line to a stream artifact (O_APPEND).
+// Creates the stream file and its .meta.json on first call.
+func (s *Store) Append(taskID string, kind Kind, event any) error {
+	if !validTaskID.MatchString(taskID) {
+		return fmt.Errorf("artifact: invalid task id %q", taskID)
+	}
+	name := kind.defaultName()
+
+	dir, err := s.taskDir(taskID)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("artifact: mkdir: %w", err)
+	}
+
+	line, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("artifact: marshal event: %w", err)
+	}
+	line = append(line, '\n')
+
+	mu := s.lockFor(taskID)
+	mu.Lock()
+	defer mu.Unlock()
+
+	metaPath := filepath.Join(dir, name+".meta.json")
+	if _, statErr := os.Stat(metaPath); errors.Is(statErr, os.ErrNotExist) {
+		m := Meta{
+			Name:      name,
+			Kind:      kind,
+			TaskID:    taskID,
+			CreatedAt: time.Now().UTC(),
+			Stream:    true,
+		}
+		metaData, mErr := json.Marshal(m)
+		if mErr != nil {
+			return fmt.Errorf("artifact: marshal meta: %w", mErr)
+		}
+		if wErr := fsutil.AtomicWrite(metaPath, metaData); wErr != nil {
+			return fmt.Errorf("artifact: write meta: %w", wErr)
+		}
+	}
+
+	f, err := os.OpenFile(filepath.Join(dir, name), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("artifact: open stream: %w", err)
+	}
+	_, writeErr := f.Write(line)
+	closeErr := f.Close()
+	if writeErr != nil {
+		return fmt.Errorf("artifact: write stream: %w", writeErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("artifact: close stream: %w", closeErr)
+	}
+
+	s.rebuildIndexLocked(taskID, dir)
+	return nil
+}
+
+// List returns metadata for all artifacts for a task, sorted by CreatedAt.
+// A missing task directory returns an empty slice, not an error.
+func (s *Store) List(taskID string) ([]Meta, error) {
+	if !validTaskID.MatchString(taskID) {
+		return nil, fmt.Errorf("artifact: invalid task id %q", taskID)
+	}
+	dir, err := s.taskDir(taskID)
+	if err != nil {
+		return nil, err
+	}
+	mu := s.lockFor(taskID)
+	mu.Lock()
+	defer mu.Unlock()
+	return s.scanMetaLocked(taskID, dir)
+}
+
+// scanMetaLocked scans the task directory for *.meta.json files and parses
+// them. Caller must hold the per-task lock. Malformed rows are skipped with a
+// warning log. Missing dir returns an empty slice, nil error.
+func (s *Store) scanMetaLocked(taskID, dir string) ([]Meta, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("artifact: readdir %s: %w", taskID, err)
+	}
+
+	var metas []Meta
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".meta.json") {
+			continue
+		}
+		data, rErr := os.ReadFile(filepath.Join(dir, e.Name()))
+		if rErr != nil {
+			slog.Warn("artifact.meta.read-err", "task_id", taskID, "file", e.Name(), "err", rErr)
+			continue
+		}
+		var m Meta
+		if jErr := json.Unmarshal(data, &m); jErr != nil {
+			slog.Warn("artifact.meta.parse-err", "task_id", taskID, "file", e.Name(), "err", jErr)
+			continue
+		}
+		metas = append(metas, m)
+	}
+
+	sort.Slice(metas, func(i, j int) bool {
+		return metas[i].CreatedAt.Before(metas[j].CreatedAt)
+	})
+	return metas, nil
+}
+
+// Read returns the raw bytes and metadata for an artifact.
+func (s *Store) Read(taskID, name string) ([]byte, Meta, error) {
+	if !validTaskID.MatchString(taskID) {
+		return nil, Meta{}, fmt.Errorf("artifact: invalid task id %q", taskID)
+	}
+	if !validName.MatchString(name) {
+		return nil, Meta{}, fmt.Errorf("artifact: invalid artifact name %q", name)
+	}
+	dir, err := s.taskDir(taskID)
+	if err != nil {
+		return nil, Meta{}, err
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, name))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, Meta{}, fmt.Errorf("artifact: %s/%s: not found", taskID, name)
+		}
+		return nil, Meta{}, fmt.Errorf("artifact: read blob: %w", err)
+	}
+	metaData, err := os.ReadFile(filepath.Join(dir, name+".meta.json"))
+	if err != nil {
+		return nil, Meta{}, fmt.Errorf("artifact: read meta: %w", err)
+	}
+	var m Meta
+	if err := json.Unmarshal(metaData, &m); err != nil {
+		return nil, Meta{}, fmt.Errorf("artifact: parse meta: %w", err)
+	}
+	return data, m, nil
+}
+
+// Delete removes all artifacts for a task and prunes the lock-map entry.
+// Ignores a missing directory (idempotent).
+func (s *Store) Delete(taskID string) error {
+	dir, err := s.taskDir(taskID)
+	if err != nil {
+		return err
+	}
+	if err := os.RemoveAll(dir); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("artifact: delete: %w", err)
+	}
+	s.pruneLock(taskID)
+	return nil
+}
+
+// Reindex rebuilds index.json from the current *.meta.json files.
+// Public repair tool — never call while already holding the per-task lock.
+func (s *Store) Reindex(taskID string) error {
+	if !validTaskID.MatchString(taskID) {
+		return fmt.Errorf("artifact: invalid task id %q", taskID)
+	}
+	dir, err := s.taskDir(taskID)
+	if err != nil {
+		return err
+	}
+	mu := s.lockFor(taskID)
+	mu.Lock()
+	defer mu.Unlock()
+	s.rebuildIndexLocked(taskID, dir)
+	return nil
+}
+
+// rebuildIndexLocked writes a derived index.json from current *.meta.json
+// files. Caller must hold the per-task lock. Errors are logged, not returned —
+// index.json is a convenience cache, not the source of truth.
+func (s *Store) rebuildIndexLocked(taskID, dir string) {
+	metas, err := s.scanMetaLocked(taskID, dir)
+	if err != nil {
+		slog.Warn("artifact.index.scan-err", "task_id", taskID, "err", err)
+		return
+	}
+	data, err := json.Marshal(metas)
+	if err != nil {
+		slog.Warn("artifact.index.marshal-err", "task_id", taskID, "err", err)
+		return
+	}
+	if wErr := fsutil.AtomicWrite(filepath.Join(dir, "index.json"), data); wErr != nil {
+		slog.Warn("artifact.index.write-err", "task_id", taskID, "err", wErr)
+	}
+}
+
+// ListTaskIDs returns the task IDs that have an artifact directory.
+func (s *Store) ListTaskIDs() ([]string, error) {
+	entries, err := os.ReadDir(s.root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("artifact: list task ids: %w", err)
+	}
+	var ids []string
+	for _, e := range entries {
+		if e.IsDir() {
+			ids = append(ids, e.Name())
+		}
+	}
+	return ids, nil
+}

--- a/internal/artifact/store_test.go
+++ b/internal/artifact/store_test.go
@@ -1,0 +1,304 @@
+package artifact
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	return New(t.TempDir())
+}
+
+func TestPutListRead(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+
+	content := []byte("# Plan\nDo the thing.")
+	meta, err := s.Put("task-abc", Artifact{
+		Kind:         KindPlan,
+		ProducerRole: "planner",
+		StepID:       "plan",
+		Content:      content,
+	})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if meta.Name != "plan.md" {
+		t.Errorf("Name = %q, want plan.md", meta.Name)
+	}
+	if meta.TaskID != "task-abc" {
+		t.Errorf("TaskID = %q, want task-abc", meta.TaskID)
+	}
+
+	metas, err := s.List("task-abc")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(metas) != 1 {
+		t.Fatalf("List len = %d, want 1", len(metas))
+	}
+
+	got, gotMeta, err := s.Read("task-abc", "plan.md")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("content mismatch: got %q, want %q", got, content)
+	}
+	if gotMeta.StepID != "plan" {
+		t.Errorf("StepID = %q, want plan", gotMeta.StepID)
+	}
+}
+
+func TestListIgnoresCorruptIndex(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+
+	_, err := s.Put("task-1", Artifact{Kind: KindPlan, Content: []byte("x")})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	dir := filepath.Join(s.root, "task-1")
+	if wErr := os.WriteFile(filepath.Join(dir, "index.json"), []byte("!!!not json!!!"), 0o644); wErr != nil {
+		t.Fatal(wErr)
+	}
+
+	metas, err := s.List("task-1")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(metas) != 1 {
+		t.Errorf("List len = %d, want 1", len(metas))
+	}
+}
+
+func TestListSkipsMalformedMeta(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+
+	_, err := s.Put("task-2", Artifact{Kind: KindPlan, Content: []byte("x")})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	dir := filepath.Join(s.root, "task-2")
+	if wErr := os.WriteFile(filepath.Join(dir, "bad.meta.json"), []byte("{bad"), 0o644); wErr != nil {
+		t.Fatal(wErr)
+	}
+
+	metas, err := s.List("task-2")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(metas) != 1 {
+		t.Errorf("List len = %d, want 1 (bad row skipped)", len(metas))
+	}
+}
+
+func TestAppend(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+
+	type event struct {
+		Step string `json:"step"`
+	}
+	if err := s.Append("task-3", KindTrace, event{"a"}); err != nil {
+		t.Fatalf("Append 1: %v", err)
+	}
+	if err := s.Append("task-3", KindTrace, event{"b"}); err != nil {
+		t.Fatalf("Append 2: %v", err)
+	}
+
+	data, _, err := s.Read("task-3", "trace.jsonl")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	lines := splitLines(data)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+	var e0, e1 event
+	if err := json.Unmarshal([]byte(lines[0]), &e0); err != nil {
+		t.Fatalf("line 0 parse: %v", err)
+	}
+	if err := json.Unmarshal([]byte(lines[1]), &e1); err != nil {
+		t.Fatalf("line 1 parse: %v", err)
+	}
+	if e0.Step != "a" || e1.Step != "b" {
+		t.Errorf("order wrong: got %q %q", e0.Step, e1.Step)
+	}
+}
+
+func splitLines(b []byte) []string {
+	var lines []string
+	start := 0
+	for i, c := range b {
+		if c == '\n' {
+			if i > start {
+				lines = append(lines, string(b[start:i]))
+			}
+			start = i + 1
+		}
+	}
+	return lines
+}
+
+func TestRace(t *testing.T) {
+	s := newTestStore(t)
+	const n = 20
+	var wg sync.WaitGroup
+	wg.Add(n * 2)
+
+	for i := range n {
+		go func(i int) {
+			defer wg.Done()
+			_, _ = s.Put("race-task", Artifact{
+				Kind:    KindGeneric,
+				Name:    "generic.md",
+				Content: []byte("data"),
+			})
+			_ = i
+		}(i)
+		go func() {
+			defer wg.Done()
+			_ = s.Append("race-task", KindTrace, map[string]any{"t": time.Now().UnixNano()})
+		}()
+	}
+	wg.Wait()
+
+	metas, err := s.List("race-task")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(metas) == 0 {
+		t.Error("expected at least one artifact")
+	}
+}
+
+func TestDelete(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+
+	_, err := s.Put("del-task", Artifact{Kind: KindPlan, Content: []byte("x")})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	if err := s.Delete("del-task"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if err := s.Delete("del-task"); err != nil {
+		t.Fatalf("second Delete: %v", err)
+	}
+
+	s.mu.Lock()
+	_, exists := s.locks["del-task"]
+	s.mu.Unlock()
+	if exists {
+		t.Error("lock entry not pruned after Delete")
+	}
+
+	metas, err := s.List("del-task")
+	if err != nil {
+		t.Fatalf("List after delete: %v", err)
+	}
+	if len(metas) != 0 {
+		t.Errorf("expected empty list after delete, got %d", len(metas))
+	}
+}
+
+func TestReindex(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+
+	_, err := s.Put("reindex-task", Artifact{Kind: KindPlan, Content: []byte("x")})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	dir := filepath.Join(s.root, "reindex-task")
+	if wErr := os.WriteFile(filepath.Join(dir, "index.json"), []byte("corrupt"), 0o644); wErr != nil {
+		t.Fatal(wErr)
+	}
+
+	if err := s.Reindex("reindex-task"); err != nil {
+		t.Fatalf("Reindex: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "index.json"))
+	if err != nil {
+		t.Fatalf("read index.json: %v", err)
+	}
+	var metas []Meta
+	if err := json.Unmarshal(data, &metas); err != nil {
+		t.Fatalf("parse index.json: %v", err)
+	}
+	if len(metas) != 1 {
+		t.Errorf("index has %d entries, want 1", len(metas))
+	}
+}
+
+func TestBinaryContent(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+
+	content := []byte{0x00, 0x01, 0xFF, 0xFE, 0x0A, 0x00}
+	_, err := s.Put("bin-task", Artifact{Kind: KindGeneric, Name: "blob.bin", Content: content})
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, _, err := s.Read("bin-task", "blob.bin")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("content mismatch: got %v, want %v", got, content)
+	}
+}
+
+func TestInvalidTaskID(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+
+	cases := []string{"../escape", "foo/bar", "", "task\x00bad"}
+	for _, id := range cases {
+		if _, err := s.Put(id, Artifact{Kind: KindPlan, Content: []byte("x")}); err == nil {
+			t.Errorf("Put(%q) expected error, got nil", id)
+		}
+		if _, err := s.List(id); err == nil {
+			t.Errorf("List(%q) expected error, got nil", id)
+		}
+		if _, _, err := s.Read(id, "plan.md"); err == nil {
+			t.Errorf("Read(%q) expected error, got nil", id)
+		}
+	}
+}
+
+func TestInvalidArtifactName(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+
+	_, err := s.Put("task-valid", Artifact{Kind: KindPlan, Name: "../escape.md", Content: []byte("x")})
+	if err == nil {
+		t.Error("expected error for hostile name, got nil")
+	}
+}
+
+func TestListEmptyDir(t *testing.T) {
+	t.Parallel()
+	s := newTestStore(t)
+
+	metas, err := s.List("no-such-task")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(metas) != 0 {
+		t.Errorf("expected empty, got %d", len(metas))
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -441,6 +441,7 @@ func (c *Config) Directories() map[string]string {
 		"logs":        c.Logging.Dir,
 		"audit":       c.AuditDir(),
 		"loop_agents": c.LoopAgentsDir,
+		"artifacts":   ArtifactsDir(),
 	}
 }
 
@@ -732,6 +733,13 @@ func AgentsDir() string {
 
 func StatsFile() string {
 	return filepath.Join(HomeDir(), "stats.json")
+}
+
+// ArtifactsDir is the directory under ~/.sybra that holds per-task harness
+// artifacts (plan snapshots, trace events, generic intermediate outputs).
+// Layout: <dir>/<task-id>/<name> + <name>.meta.json.
+func ArtifactsDir() string {
+	return filepath.Join(HomeDir(), "artifacts")
 }
 
 // SelfMonitorDir is the directory under ~/.sybra that holds the

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -342,6 +342,9 @@ func TestPathsUnderHomeDir(t *testing.T) {
 	if got := defaultTasksDir(); got != filepath.Join(dir, "tasks") {
 		t.Errorf("defaultTasksDir() = %q, want under %q", got, dir)
 	}
+	if got := ArtifactsDir(); got != filepath.Join(dir, "artifacts") {
+		t.Errorf("ArtifactsDir() = %q, want under %q", got, dir)
+	}
 }
 
 func TestDefaultLogRetentionDays(t *testing.T) {

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/artifact"
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/bgop"
 	"github.com/Automaat/sybra/internal/config"
@@ -56,6 +57,7 @@ type App struct {
 	configWatcher                 *confighot.Watcher
 	notifier                      *notification.Emitter
 	audit                         *audit.Logger
+	artifacts                     *artifact.Store
 	stats                         *stats.Store
 	tasksDir                      string
 	skillsDir                     string
@@ -240,6 +242,7 @@ func (a *App) Startup(ctx context.Context) error {
 	a.emitDegradedWarnings(emit)
 	a.tasks = task.NewManager(store, task.EmitterFunc(emit))
 	a.initStatusHook()
+	a.initArtifacts()
 	a.notifier = notification.New(emit)
 	a.notifier.SetDesktop(a.cfg.Notification.Desktop)
 	a.agents = agent.NewManager(ctx, emit, a.logger, a.logDir)

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/artifact"
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/bgop"
 	"github.com/Automaat/sybra/internal/config"
@@ -265,6 +266,32 @@ func (a *App) initAudit() {
 	}
 }
 
+// initArtifacts constructs the artifact store, wires the task delete hook to
+// GC artifact directories on task deletion, and sweeps orphaned artifact
+// directories left by tasks that no longer exist.
+func (a *App) initArtifacts() {
+	a.artifacts = artifact.New(config.ArtifactsDir())
+	a.tasks.SetDeleteHook(func(id string) {
+		if err := a.artifacts.Delete(id); err != nil {
+			a.logger.Warn("artifact.gc.delete", "task_id", id, "err", err)
+		}
+	})
+	ids, err := a.artifacts.ListTaskIDs()
+	if err != nil {
+		a.logger.Warn("artifact.gc.list", "err", err)
+		return
+	}
+	for _, id := range ids {
+		if _, getErr := a.tasks.Get(id); getErr != nil {
+			if delErr := a.artifacts.Delete(id); delErr != nil {
+				a.logger.Warn("artifact.gc.orphan-sweep", "task_id", id, "err", delErr)
+				continue
+			}
+			a.logger.Info("artifact.orphan.swept", "task_id", id)
+		}
+	}
+}
+
 // initProviderHealth constructs the provider health checker, wires it into
 // the agent manager as a gate, and starts its background probe loop. When
 // providers.health_check.enabled=false the checker is skipped entirely and
@@ -338,6 +365,9 @@ func (a *App) initWorkflowEngine() {
 	a.workflowEngine.SetPRLinker(prLinkerAdapter{})
 	a.workflowEngine.SetPRReviewRequester(prReviewRequesterAdapter{})
 	a.workflowEngine.SetWorktreeGetter(&worktreeGetterAdapter{tasks: a.tasks, mgr: a.worktrees})
+	if a.artifacts != nil {
+		a.workflowEngine.SetArtifactRecorder(&artifactRecorderAdapter{store: a.artifacts})
+	}
 	a.workflowEngine.SetContext(a.ctx)
 	// SetOnComplete moves to wireServices so the callback closure binds
 	// to the AgentCompletionHandler constructed there.

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -37,8 +37,13 @@ func (a *artifactRecorderAdapter) RecordTrace(taskID string, ev any) error {
 }
 
 func (a *artifactRecorderAdapter) PutPlanSnapshot(taskID, role, stepID, sourcePath, content string) error {
+	name := ""
+	if stepID != "" {
+		name = "plan-" + stepID + ".md"
+	}
 	_, err := a.store.Put(taskID, artifact.Artifact{
 		Kind:         artifact.KindPlan,
+		Name:         name,
 		ProducerRole: role,
 		StepID:       stepID,
 		SourcePath:   sourcePath,

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/artifact"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/project"
@@ -23,7 +24,28 @@ var (
 	_ workflow.PRLinker          = (*prLinkerAdapter)(nil)
 	_ workflow.PRReviewRequester = (*prReviewRequesterAdapter)(nil)
 	_ workflow.WorktreeGetter    = (*worktreeGetterAdapter)(nil)
+	_ workflow.ArtifactRecorder  = (*artifactRecorderAdapter)(nil)
 )
+
+// artifactRecorderAdapter bridges artifact.Store → workflow.ArtifactRecorder.
+type artifactRecorderAdapter struct {
+	store *artifact.Store
+}
+
+func (a *artifactRecorderAdapter) RecordTrace(taskID string, ev any) error {
+	return a.store.Append(taskID, artifact.KindTrace, ev)
+}
+
+func (a *artifactRecorderAdapter) PutPlanSnapshot(taskID, role, stepID, sourcePath, content string) error {
+	_, err := a.store.Put(taskID, artifact.Artifact{
+		Kind:         artifact.KindPlan,
+		ProducerRole: role,
+		StepID:       stepID,
+		SourcePath:   sourcePath,
+		Content:      []byte(content),
+	})
+	return err
+}
 
 // taskAdapter bridges task.Manager → workflow.TaskProvider.
 type taskAdapter struct {

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -31,6 +31,9 @@ func NoopEmitter() EventEmitter { return noopEmitter{} }
 // could not be read.
 type StatusChangeHook func(taskID, from, to string)
 
+// DeleteHook is invoked after a task is successfully deleted.
+type DeleteHook func(taskID string)
+
 // Manager is the single entrypoint for task mutations. It wraps Store with
 // per-task mutual exclusion and emits events on mutations.
 type Manager struct {
@@ -38,6 +41,7 @@ type Manager struct {
 	emitter      EventEmitter
 	locks        sync.Map // string -> *sync.Mutex
 	onStatusHook StatusChangeHook
+	onDeleteHook DeleteHook
 
 	// firedMu/firedStatus tracks the most recent status value that has
 	// triggered onStatusHook. OnExternalUpdate uses it to dedupe repeated
@@ -50,6 +54,10 @@ type Manager struct {
 // SetStatusChangeHook registers a callback fired on every status transition.
 // Passing nil disables the hook.
 func (m *Manager) SetStatusChangeHook(h StatusChangeHook) { m.onStatusHook = h }
+
+// SetDeleteHook registers a callback fired after a task is successfully deleted.
+// Passing nil disables the hook.
+func (m *Manager) SetDeleteHook(h DeleteHook) { m.onDeleteHook = h }
 
 // NewManager constructs a Manager over the given Store. If emitter is nil,
 // events are discarded.
@@ -258,6 +266,9 @@ func (m *Manager) Delete(id string) error {
 	m.forgetFiredStatus(id)
 	metrics.TaskDeleted()
 	m.emitter.Emit(events.TaskDeleted, t.FilePath)
+	if m.onDeleteHook != nil {
+		m.onDeleteHook(id)
+	}
 	return nil
 }
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -87,6 +87,16 @@ type PRReviewRequester interface {
 	RerequestReview(repo string, prNumber int) (reviewers []string, err error)
 }
 
+// ArtifactRecorder stores per-task workflow artifacts (plan snapshots, trace
+// events). Engine operates with a nil recorder — all recorder calls are
+// guarded by nil checks so engine unit tests compile and pass unchanged.
+type ArtifactRecorder interface {
+	// RecordTrace appends a structured event to the task's trace.jsonl stream.
+	RecordTrace(taskID string, ev any) error
+	// PutPlanSnapshot stores a raw markdown plan as an artifact for the task.
+	PutPlanSnapshot(taskID, role, stepID, sourcePath, content string) error
+}
+
 // CompletionInfo is passed to the OnComplete callback when a workflow finishes.
 type CompletionInfo struct {
 	TaskID     string
@@ -108,6 +118,7 @@ type Engine struct {
 	prLinker        PRLinker
 	prReviewers     PRReviewRequester
 	worktrees       WorktreeGetter
+	recorder        ArtifactRecorder
 	onComplete      func(CompletionInfo)
 	logger          *slog.Logger
 	ctx             context.Context
@@ -157,6 +168,12 @@ func (e *Engine) SetPRReviewRequester(r PRReviewRequester) { e.prReviewers = r }
 // SetWorktreeGetter wires a WorktreeGetter used by the `verify_commits` step.
 // Leaving it unset makes the step a no-op.
 func (e *Engine) SetWorktreeGetter(g WorktreeGetter) { e.worktrees = g }
+
+// SetArtifactRecorder wires an ArtifactRecorder that captures per-task
+// workflow artifacts (plan snapshots, trace events). Leaving it unset
+// disables artifact recording — all calls are nil-guarded so engine unit
+// tests remain unchanged.
+func (e *Engine) SetArtifactRecorder(r ArtifactRecorder) { e.recorder = r }
 
 // SetOnComplete registers a callback fired when a workflow reaches the
 // completed state. Used to clear external debounce trackers.

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -172,6 +172,18 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 		e.importSidecarIfConfigured(taskID, spawnedStep, t)
 	}
 
+	if e.recorder != nil {
+		ev := map[string]any{
+			"step":     spawnedStep,
+			"status":   status,
+			"agentId":  c.AgentID,
+			"provider": c.Provider,
+		}
+		if recErr := e.recorder.RecordTrace(taskID, ev); recErr != nil {
+			e.logger.Warn("artifact.record.failed", "kind", "trace", "task_id", taskID, "step", spawnedStep, "err", recErr)
+		}
+	}
+
 	if err := e.AdvanceStep(taskID, StepOutput{
 		StepID:   spawnedStep,
 		Status:   status,

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -58,6 +58,14 @@ func (e *Engine) importSidecarIfConfigured(taskID, stepID string, info TaskInfo)
 		return
 	}
 	e.logger.Info("workflow.import-sidecar", "task_id", taskID, "step", stepID, "kind", kind, "path", path, "bytes", len(content))
+
+	// Capture a plan artifact for plan-kind sidecars so the raw markdown is
+	// available for later agent re-reading alongside its provenance metadata.
+	if cfg.Kind == "plan" && e.recorder != nil {
+		if recErr := e.recorder.PutPlanSnapshot(taskID, step.Config.Role, stepID, path, string(content)); recErr != nil {
+			e.logger.Warn("artifact.record.failed", "kind", "plan", "task_id", taskID, "step", stepID, "err", recErr)
+		}
+	}
 }
 
 func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx TemplateContext) error {


### PR DESCRIPTION
## Motivation

Agent runs produce intermediate state (plan snapshots, trace events, generic blobs) that currently has no durable home — the data lives only in agent output text and is lost when the run ends. A typed, per-task artifact store gives the harness a first-class place to persist and retrieve this material, enabling richer evals, forensics, and future UI surfaces without coupling the write path to any specific consumer.

Closes https://github.com/Automaat/sybra/issues/1057

## Implementation information

Adds `internal/artifact/` with two files:

- **`model.go`** — `Kind` enum (`plan`, `trace`, `generic`), `Meta` struct (name, kind, producer, task/step IDs, timestamps, size, stream flag), `Artifact` write-request type, and input-validation regexes (`validName`, `validTaskID`) that prevent path-traversal and hostile IDs.

- **`store.go`** — `Store` backed by `~/.sybra/artifacts/<task-id>/`. Key design decisions:
  - **Two-level locking**: outer `sync.Mutex` guards the per-task locks map; per-task mutexes serialize all I/O for a single task, preventing concurrent writes from racing.
  - **Atomic blobs**: `Put` uses `fsutil.AtomicWrite` (write-to-temp + rename) so a crash leaves an ignorable orphan, never a partial blob with valid metadata pointing at it.
  - **Append-only streams**: `Append` uses `O_APPEND` for NDJSON trace streams (`KindTrace`), allowing concurrent producers to safely grow the file.
  - **Index as cache only**: `List` always does a directory scan; `index.json` is a derived cache rebuilt after each mutation. Correctness never depends on the index being current.
  - **Path-containment defence**: `taskDir` validates IDs with a regex _and_ checks that the resolved path stays inside the store root, so neither a crafted task ID nor an unexpected `filepath.Join` expansion can escape.

The store is deliberately local/debug-only — it never scrubs at write time. Any code that surfaces artifact content in a GitHub issue/PR/comment must route through `App.workScrubContextForTask` + `scrub.Scrub` first (noted in the package doc).

> Changelog: feat(artifacts): add per-task harness artifact store