### PR TITLE
feat(reviews): conflict state in To Review lane

### DIFF
--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -48,7 +48,7 @@
 
   // lucide components keyed by the phase meta's icon name.
   const PHASE_ICONS: Record<ReviewPhaseIcon, typeof CheckCircle> = {
-    loader: Loader, eye: Eye, pen: PenLine, hourglass: Hourglass, shield: ShieldCheck, check: CheckCircle,
+    loader: Loader, eye: Eye, pen: PenLine, hourglass: Hourglass, shield: ShieldCheck, check: CheckCircle, conflict: AlertTriangle,
   }
 
   // lucide components for the outbound PR phase glyph.

--- a/frontend/src/lib/review-phase.test.ts
+++ b/frontend/src/lib/review-phase.test.ts
@@ -61,6 +61,12 @@ describe('reviewPhaseRank', () => {
     expect(rank('drafted')).toBeLessThan(rank('awaiting-author'))
     expect(rank('awaiting-author')).toBeLessThan(rank('approved'))
   })
+
+  it('sinks conflicting PRs to the bottom of the lane', () => {
+    const rank = (p: string) => reviewPhaseRank({ reviewPhase: p })
+    expect(rank('conflict')).toBeGreaterThan(rank('approved'))
+    expect(rank('conflict')).toBeGreaterThan(rank('needs-approval'))
+  })
 })
 
 describe('BOARD_LANES', () => {

--- a/frontend/src/lib/review-phase.ts
+++ b/frontend/src/lib/review-phase.ts
@@ -11,9 +11,10 @@ export type ReviewPhase =
   | 'awaiting-author'
   | 'needs-approval'
   | 'approved'
+  | 'conflict'
 
 /** Icon keys, resolved to lucide components at the call site. */
-export type ReviewPhaseIcon = 'loader' | 'eye' | 'pen' | 'hourglass' | 'shield' | 'check'
+export type ReviewPhaseIcon = 'loader' | 'eye' | 'pen' | 'hourglass' | 'shield' | 'check' | 'conflict'
 
 export interface ReviewPhaseMeta {
   label: string
@@ -57,9 +58,18 @@ export const REVIEW_PHASE_META: Record<ReviewPhase, ReviewPhaseMeta> = {
     icon: 'check',
     classes: 'bg-success-200 text-success-800 dark:bg-success-700 dark:text-success-200',
   },
+  // Blocked on the author rebasing — error-toned so it reads as a problem, but
+  // it sorts to the bottom (see REVIEW_PHASE_ORDER): nothing for you to do yet.
+  conflict: {
+    label: 'Conflict',
+    icon: 'conflict',
+    classes: 'bg-error-200 text-error-800 dark:bg-error-700 dark:text-error-200',
+  },
 }
 
-// Lane sort: the user's pending actions first, then waiting, then done.
+// Lane sort: the user's pending actions first, then waiting, then done, and
+// conflicting PRs last — they're blocked on the author, so they sink to the
+// bottom of the lane.
 const REVIEW_PHASE_ORDER: ReviewPhase[] = [
   'needs-approval',
   'drafted',
@@ -67,6 +77,7 @@ const REVIEW_PHASE_ORDER: ReviewPhase[] = [
   'reviewing',
   'awaiting-author',
   'approved',
+  'conflict',
 ]
 
 /** True when a task is an inbound PR review (reviewing someone else's code). */

--- a/internal/sybra/app_reviews_inbound.go
+++ b/internal/sybra/app_reviews_inbound.go
@@ -241,6 +241,16 @@ func (r *ReviewHandler) reconcileReviewTask(t *task.Task, requested, approved ma
 		return
 	}
 
+	// A conflicting PR is blocked on the author rebasing — surface "conflict"
+	// and skip the viewer-state round-trip (the conflict outranks every review
+	// phase anyway). FetchPRState is 30s-cached, so this is cheap on the poll.
+	if st, err := github.FetchPRState(t.ProjectID, t.PRNumber); err != nil {
+		r.logger.Warn("review.pr-state", "task_id", t.ID, "err", err)
+	} else if st.Mergeable == "CONFLICTING" {
+		r.applyReviewPhase(t, computeReviewPhase(reviewSignals{Mergeable: st.Mergeable}))
+		return
+	}
+
 	key := reviewPRKey(t.ProjectID, t.PRNumber)
 	reqPR, inReq := requested[key]
 	apPR, inApproved := approved[key]

--- a/internal/sybra/app_reviews_inbound.go
+++ b/internal/sybra/app_reviews_inbound.go
@@ -241,19 +241,34 @@ func (r *ReviewHandler) reconcileReviewTask(t *task.Task, requested, approved ma
 		return
 	}
 
-	// A conflicting PR is blocked on the author rebasing — surface "conflict"
-	// and skip the viewer-state round-trip (the conflict outranks every review
-	// phase anyway). FetchPRState is 30s-cached, so this is cheap on the poll.
-	if st, err := github.FetchPRState(t.ProjectID, t.PRNumber); err != nil {
-		r.logger.Warn("review.pr-state", "task_id", t.ID, "err", err)
-	} else if st.Mergeable == "CONFLICTING" {
-		r.applyReviewPhase(t, computeReviewPhase(reviewSignals{Mergeable: st.Mergeable}))
-		return
-	}
-
 	key := reviewPRKey(t.ProjectID, t.PRNumber)
 	reqPR, inReq := requested[key]
 	apPR, inApproved := approved[key]
+
+	// A conflicting PR is blocked on the author rebasing — surface "conflict" and
+	// sink it to the bottom of the lane, whatever the viewer's review state (the
+	// conflict outranks every other review phase). Prefer the mergeability already
+	// carried by the review summary; only spend a PR-state call when the PR is in
+	// neither leg (e.g. a submitted, non-re-requested review) or GitHub hasn't
+	// computed mergeability yet.
+	mergeable := ""
+	switch {
+	case inReq:
+		mergeable = reqPR.Mergeable
+	case inApproved:
+		mergeable = apPR.Mergeable
+	}
+	if mergeable == "" || mergeable == "UNKNOWN" {
+		if st, err := github.FetchPRState(t.ProjectID, t.PRNumber); err != nil {
+			r.logger.Warn("review.pr-state", "task_id", t.ID, "err", err)
+		} else {
+			mergeable = st.Mergeable
+		}
+	}
+	if mergeable == "CONFLICTING" {
+		r.applyReviewPhase(t, computeReviewPhase(reviewSignals{Mergeable: mergeable}))
+		return
+	}
 
 	myState, err := github.FetchMyReviewState(t.ProjectID, t.PRNumber)
 	if err != nil {

--- a/internal/sybra/review_phase.go
+++ b/internal/sybra/review_phase.go
@@ -7,6 +7,10 @@ import "github.com/Automaat/sybra/internal/task"
 const (
 	// ReviewPhaseReviewing: a review agent is actively working the PR.
 	ReviewPhaseReviewing = "reviewing"
+	// ReviewPhaseConflict: the PR has merge conflicts and can't land until the
+	// author rebases. Passive — the lane sinks it to the bottom; the human waits
+	// on the author, so it never asserts the needs-you (human-required) signal.
+	ReviewPhaseConflict = "conflict"
 	// ReviewPhaseManual: the PR was too small for an agent and was punted to
 	// the human to review by hand.
 	ReviewPhaseManual = "manual"
@@ -33,6 +37,7 @@ type reviewSignals struct {
 	ReRequested    bool   // PR is back in viewer's review-requested list
 	HeadSHA        string // current PR head commit ("" if unknown)
 	ReviewedSHA    string // commit the viewer's latest review was made against
+	Mergeable      string // MERGEABLE, CONFLICTING, UNKNOWN, or ""
 }
 
 // reviewPhaseResult is the desired task state for a review task.
@@ -53,6 +58,20 @@ func computeReviewPhase(s reviewSignals) reviewPhaseResult {
 	// the status untouched so we don't fight triage/fix dispatch.
 	if s.AgentRunning {
 		return reviewPhaseResult{Phase: ReviewPhaseReviewing}
+	}
+
+	// A conflicting PR can't land until the author rebases, so reviewing or
+	// approving it is wasted effort — surface "conflict" and let the lane sink
+	// it to the bottom. Outranks every viewer-state phase (drafted, approved,
+	// awaiting-author, manual): the conflict is the actionable fact. Status stays
+	// in-review so it never lights the needs-you accent — the ball is the
+	// author's, not the reviewer's.
+	if s.Mergeable == "CONFLICTING" {
+		return reviewPhaseResult{
+			Phase:  ReviewPhaseConflict,
+			Status: task.StatusInReview,
+			Reason: "PR has merge conflicts — author must rebase",
+		}
 	}
 
 	if s.ViewerApproved {

--- a/internal/sybra/review_phase_test.go
+++ b/internal/sybra/review_phase_test.go
@@ -18,6 +18,26 @@ func TestComputeReviewPhase(t *testing.T) {
 			want: reviewPhaseResult{Phase: ReviewPhaseReviewing},
 		},
 		{
+			name: "agent running trumps a conflicting PR",
+			sig:  reviewSignals{AgentRunning: true, Mergeable: "CONFLICTING"},
+			want: reviewPhaseResult{Phase: ReviewPhaseReviewing},
+		},
+		{
+			name: "conflicting PR → conflict phase, passive in-review status",
+			sig:  reviewSignals{Mergeable: "CONFLICTING"},
+			want: reviewPhaseResult{Phase: ReviewPhaseConflict, Status: task.StatusInReview, Reason: "PR has merge conflicts — author must rebase"},
+		},
+		{
+			name: "conflict outranks a pending draft / submitted review",
+			sig:  reviewSignals{Mergeable: "CONFLICTING", HasDraft: true, Submitted: true, ViewerApproved: true},
+			want: reviewPhaseResult{Phase: ReviewPhaseConflict, Status: task.StatusInReview, Reason: "PR has merge conflicts — author must rebase"},
+		},
+		{
+			name: "UNKNOWN mergeable is not a conflict → normal awaiting-author",
+			sig:  reviewSignals{Mergeable: "UNKNOWN", Submitted: true, HeadSHA: "sha1", ReviewedSHA: "sha1"},
+			want: reviewPhaseResult{Phase: ReviewPhaseAwaitingAuthor, Status: task.StatusInReview, Reason: "Awaiting author response"},
+		},
+		{
 			name: "approved waits for merge",
 			sig:  reviewSignals{ViewerApproved: true, Submitted: true, HeadSHA: "abc"},
 			want: reviewPhaseResult{Phase: ReviewPhaseApproved, Status: task.StatusInReview, Reason: "Approved — awaiting merge"},


### PR DESCRIPTION
## Motivation

PRs sitting in the **To Review** lane (inbound reviews, tag `review`) gave no signal when the underlying PR had merge conflicts. A conflicting PR can't land until the author rebases, so reviewing or approving it is wasted effort — yet it sat among the actionable cards with no way to tell it apart or push it down the queue.

> Changelog: feat(reviews): conflict state in To Review lane

## Implementation information

Surfaces a distinct **Conflict** phase for inbound review tasks and sinks them to the bottom of the lane. Passive only — no auto-fix change (inbound reviews are the author's PR to rebase).

**Backend**
- `review_phase.go`: new `ReviewPhaseConflict`; `reviewSignals` gains `Mergeable`. `computeReviewPhase` maps `CONFLICTING` to a passive `in-review` Conflict result, ranked right after agent-running so it outranks every viewer-state phase (drafted/approved/awaiting-author/manual). Status stays `in-review`, so it never lights the needs-you (human-required) accent — the ball is the author's.
- `app_reviews_inbound.go`: `reconcileReviewTask` reads mergeability via `github.FetchPRState` (30s-cached) and short-circuits on conflict, skipping the extra my-review-state round-trip.

**Frontend** (mirrors the Go phase)
- `review-phase.ts`: `conflict` added to the phase + icon unions, a `REVIEW_PHASE_META.conflict` entry (error-toned pill), and appended **last** in `REVIEW_PHASE_ORDER` — the existing `reviewPhaseRank` then sorts conflicting cards to the bottom automatically.
- `TaskCard.svelte`: `conflict` icon → `AlertTriangle`.

The card pill flows entirely through `reviewPhaseMeta`, and the To Review lane already filters review-tagged tasks out of the status-based In Review column, so a conflict task at `in-review` renders only in the lane (no double-render).

## Supporting documentation

Tests: `review_phase_test.go` (conflict surfaces; agent-running trumps conflict; conflict outranks a pending draft; `UNKNOWN` ≠ conflict) and `review-phase.test.ts` (conflict ranks below `approved`/`needs-approval`). Go tests, golangci-lint, svelte-check, oxlint, and vitest all pass.