### PR TITLE
feat(verify): detect test tampering

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -630,6 +630,14 @@ export enum StepType {
     StepTriageReview = "triage_review",
 
     /**
+     * StepDetectTampering inspects the worktree diff for reward-hacking /
+     * test-tampering signals (deleted assertions, added skip/xfail markers,
+     * deleted test files, neutered CI). A high-severity finding flips the task
+     * to human-required so it cannot reach done without an explicit human bless.
+     */
+    StepDetectTampering = "detect_tampering",
+
+    /**
      * StepRouteTestResult reads the test-runner verdict and routes the task:
      * pass → ready-pr, fail → in-progress (re-implement) until the attempt
      * cap is hit, then human-required.

--- a/internal/sybra/app_agents.go
+++ b/internal/sybra/app_agents.go
@@ -425,7 +425,7 @@ func (o *AgentOrchestrator) StartPRFixAgent(taskID string) error {
 // review comments) and includes it so the agent amends the existing PR rather
 // than starting from scratch.
 func buildPRFixPrompt(t task.Task, logger *slog.Logger) string {
-	base := fmt.Sprintf("# Task: %s\n\n%s\n\n---\n\nFix the issues raised in the PR review. Push the changes when done.", t.Title, t.Body)
+	base := fmt.Sprintf("# Task: %s\n\n%s\n\n---\n\nFix the issues raised in the PR review. Push the changes when done.\n\nNever weaken, skip, delete, comment out, or hardcode tests, snapshots, or fixtures to make checks pass, and never edit CI config to neuter a gate. Fix the underlying code; tampering is detected and blocks the task.", t.Title, t.Body)
 	if t.PRNumber == 0 || t.ProjectID == "" {
 		return base
 	}

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -143,6 +143,10 @@ func (r *ReviewHandler) handlePRIssue(issue github.PRIssue) {
 			"Fix failing CI on branch `%s` (PR #%d). "+
 				"Check the failing run with `gh run view --log-failed`, "+
 				"fix the code, commit and push. No unrelated changes.\n\n"+
+				"Never weaken, skip, delete, or hardcode tests, snapshots, or "+
+				"fixtures to make CI pass, and never edit CI config to neuter a "+
+				"gate — fix the underlying code. Tampering is detected and blocks "+
+				"the task.\n\n"+
 				"Push to the remote that hosts the PR's head branch:\n"+
 				"```sh\n"+
 				"PUSH_REMOTE=origin\n"+
@@ -264,6 +268,9 @@ func commentsPrompt(pr github.PullRequest) string {
 		"Run /fix-review %s --auto\n\n"+
 			"This is your own PR (#%d) — reviewers left comments or unresolved "+
 			"threads. Address the valid ones, reply on every thread, and push.\n\n"+
+			"Never weaken, skip, delete, or hardcode tests to satisfy a comment "+
+			"— fix the underlying code; tampering is detected and blocks the "+
+			"task.\n\n"+
 			"IMPORTANT: when committing, use conventional commit format "+
 			"`fix(review): address PR review comments` (type(scope) required by "+
 			"repo hooks). Sign the commit with `git commit -s -S`.\n\n"+

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -52,6 +52,16 @@ func (a *artifactRecorderAdapter) PutPlanSnapshot(taskID, role, stepID, sourcePa
 	return err
 }
 
+func (a *artifactRecorderAdapter) PutGeneric(taskID, name, stepID, content string) error {
+	_, err := a.store.Put(taskID, artifact.Artifact{
+		Kind:    artifact.KindGeneric,
+		Name:    name,
+		StepID:  stepID,
+		Content: []byte(content),
+	})
+	return err
+}
+
 // taskAdapter bridges task.Manager → workflow.TaskProvider.
 type taskAdapter struct {
 	tasks    *task.Manager

--- a/internal/workflow/builtin/pr-fix.yaml
+++ b/internal/workflow/builtin/pr-fix.yaml
@@ -49,6 +49,21 @@ steps:
           operator: equals
           value: done
         goto: ""
+      - goto: detect_tampering
+
+  # Mechanical check (no LLM): the pr-fix agent is under pressure to turn red
+  # CI green, the highest-risk context for reward hacking. Scan the diff for
+  # test/CI tampering before the PR moves on; a high-severity finding flips the
+  # task to human-required. Skips gracefully without a worktree.
+  - id: detect_tampering
+    name: Detect Test Tampering
+    type: detect_tampering
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
       - goto: link_pr_and_review
 
   # Non-LLM step: recover PR number from task, agent result history, or

--- a/internal/workflow/builtin/simple-task-implement.yaml
+++ b/internal/workflow/builtin/simple-task-implement.yaml
@@ -29,6 +29,12 @@ steps:
         section. If present, a prior implementation FAILED adversarial manual
         testing — fix the root cause of every reported defect (not just the
         symptom); the feature will be re-tested after this run.
+
+        Never weaken, skip, delete, comment out, or hardcode tests, snapshots,
+        or fixtures to make checks pass, and never edit CI config to neuter a
+        gate. If an existing test is genuinely wrong, fix it correctly and
+        explain why in the commit message — do not silently disable it.
+        Tampering is detected mechanically and will block the task.
         {{- if .Task.Plan}}
 
         ## Plan
@@ -67,6 +73,24 @@ steps:
           field: task.status
           operator: equals
           value: done
+        goto: ""
+      - goto: detect_tampering
+
+  # Mechanical check (no LLM): inspects the worktree diff for reward-hacking /
+  # test-tampering signals — deleted assertions, added skip/xfail markers,
+  # deleted test files, neutered CI config. A high-severity finding flips the
+  # task to human-required (with the offending rules in the reason) so it
+  # cannot reach done without an explicit human bless. Benign test changes are
+  # recorded in a tamper-report.json artifact but do not block. Skips
+  # gracefully when no worktree exists or no verification files changed.
+  - id: detect_tampering
+    name: Detect Test Tampering
+    type: detect_tampering
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
         goto: ""
       - goto: set_ready_review
 

--- a/internal/workflow/builtin/simple-task-review.yaml
+++ b/internal/workflow/builtin/simple-task-review.yaml
@@ -168,7 +168,26 @@ steps:
         When done, commit your changes (do NOT push yet — push happens with PR
         creation). Sign commits with `git commit -s -S`.
         Use conventional commit format: `fix(review): address review comments`.
+
+        Never weaken, skip, delete, or hardcode tests to satisfy a review
+        comment — fix the underlying code. Tampering is checked and blocks the
+        task.
     next:
+      - goto: detect_tampering
+
+  # Mechanical check (no LLM): re-scan the full diff for test/CI tampering after
+  # the review-fix agent has added commits (the implement-stage scan only saw
+  # the original diff). A high-severity finding flips the task to
+  # human-required. Skips gracefully without a worktree.
+  - id: detect_tampering
+    name: Detect Test Tampering
+    type: detect_tampering
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
       - goto: done_review
 
   # Hand the reviewed (and fixed) branch to the testing phase. The PR is NOT

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -77,9 +77,10 @@ func TestBuiltinSimpleTask_MaybeCritiqueReplanSkip(t *testing.T) {
 }
 
 // TestBuiltinSimpleTaskImplement_VerifyCommitsRouting pins the verify_commits
-// transition table: human-required and done end the run, everything else hands
-// off to review. (The sibling-still-running case is handled in Go by parking
-// the workflow in ExecWaiting, not by a transition — see execVerifyCommits.)
+// transition table: human-required and done end the run, everything else flows
+// into the detect_tampering gate before review. (The sibling-still-running case
+// is handled in Go by parking the workflow in ExecWaiting, not by a transition
+// — see execVerifyCommits.)
 func TestBuiltinSimpleTaskImplement_VerifyCommitsRouting(t *testing.T) {
 	t.Parallel()
 
@@ -118,9 +119,9 @@ func TestBuiltinSimpleTaskImplement_VerifyCommitsRouting(t *testing.T) {
 			want:   "",
 		},
 		{
-			name:   "clean in-progress hands off to review",
+			name:   "clean in-progress flows into tamper gate",
 			fields: map[string]string{"task.status": "in-progress"},
-			want:   "set_ready_review",
+			want:   "detect_tampering",
 		},
 	}
 	for _, tc := range cases {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -104,6 +104,10 @@ type ArtifactRecorder interface {
 	RecordTrace(taskID string, ev any) error
 	// PutPlanSnapshot stores a raw markdown plan as an artifact for the task.
 	PutPlanSnapshot(taskID, role, stepID, sourcePath, content string) error
+	// PutGeneric stores an arbitrary named blob (e.g. a tamper-detection
+	// report) as a generic artifact for the task. Local debug/audit only —
+	// callers must scrub before surfacing the content on any public destination.
+	PutGeneric(taskID, name, stepID, content string) error
 }
 
 // CompletionInfo is passed to the OnComplete callback when a workflow finishes.

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -330,7 +330,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			return e.execParallel(taskID, def, step, wfExec, ctx)
 		case StepWaitHuman:
 			return nil, e.execWaitHuman(taskID, step, wfExec)
-		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepRerequestReview, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepTriageReview, StepRouteTestResult:
+		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepRerequestReview, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepTriageReview, StepDetectTampering, StepRouteTestResult:
 			// handled below as sync steps
 		default:
 			return nil, fmt.Errorf("unknown step type %q", step.Type)
@@ -416,6 +416,8 @@ func (e *Engine) execSyncStep(taskID string, step *Step, wfExec *Execution, ctx 
 		return e.execValidatePlan(taskID, step, t)
 	case StepTriageReview:
 		return e.execTriageReview(taskID, step, t)
+	case StepDetectTampering:
+		return e.execDetectTampering(taskID, step, t)
 	case StepRouteTestResult:
 		return e.execRouteTestResult(taskID, step, wfExec, t)
 	default:

--- a/internal/workflow/engine_steps_tamper.go
+++ b/internal/workflow/engine_steps_tamper.go
@@ -1,0 +1,402 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+// tamperCategory classifies a changed file by the role it plays in the
+// project's verification surface. Only test/snapshot/fixture/ci files are
+// scanned for tampering; everything else is treated as implementation.
+type tamperCategory string
+
+const (
+	tamperCatTest     tamperCategory = "test"
+	tamperCatSnapshot tamperCategory = "snapshot"
+	tamperCatFixture  tamperCategory = "fixture"
+	tamperCatCI       tamperCategory = "ci"
+	tamperCatOther    tamperCategory = "other"
+)
+
+// tamperSeverity grades a finding. A high finding blocks the task (flips it to
+// human-required); medium is recorded for audit / reviewer context only.
+const (
+	tamperHigh   = "high"
+	tamperMedium = "medium"
+)
+
+// tamperMaxScannedFiles bounds the number of per-file `git diff` subprocesses
+// run on a pathological diff. Verification files past this cap still appear in
+// the report (and produce a coarse medium finding) but are not scanned in
+// detail.
+const tamperMaxScannedFiles = 60
+
+// tamperMaxReasonFindings caps how many high findings are spelled out in the
+// human-required status reason before it is elided.
+const tamperMaxReasonFindings = 5
+
+// tamperFinding is one suspicious edit detected in a verification file.
+type tamperFinding struct {
+	File     string `json:"file"`
+	Category string `json:"category"`
+	Severity string `json:"severity"`
+	Rule     string `json:"rule"`
+	Detail   string `json:"detail,omitempty"`
+}
+
+// tamperReport is the structured result of inspecting a task's diff. Stored as
+// a generic artifact for audit; never surfaced to a public destination without
+// scrubbing first.
+type tamperReport struct {
+	TaskID   string          `json:"taskId"`
+	Base     string          `json:"base"`
+	Files    []string        `json:"files"`
+	Findings []tamperFinding `json:"findings"`
+}
+
+func (r tamperReport) highCount() int {
+	n := 0
+	for i := range r.Findings {
+		if r.Findings[i].Severity == tamperHigh {
+			n++
+		}
+	}
+	return n
+}
+
+// tamperChange is one entry of `git diff --name-status`, optionally enriched
+// with the file's unified-diff patch (empty for deletions and ignored files).
+type tamperChange struct {
+	Status string // "A", "M", "D", "R100", …
+	Path   string
+	Patch  string
+}
+
+var (
+	// tamperTestPathRe matches test source files by filename convention across
+	// Go, Python, and JS/TS.
+	tamperTestPathRe = regexp.MustCompile(
+		`(^|/)([^/]+_test\.go|test_[^/]+\.py|[^/]+_test\.py|[^/]+\.(test|spec)\.[jt]sx?)$`)
+	// tamperTestDirRe matches files that live under a conventional test dir.
+	tamperTestDirRe = regexp.MustCompile(`(^|/)(tests?|__tests__|specs?)/`)
+	// tamperSnapshotRe matches snapshot / golden fixtures.
+	tamperSnapshotRe = regexp.MustCompile(`(^|/)__snapshots__/|\.snap$|\.golden$|(^|/)testdata/`)
+	// tamperFixtureRe matches fixture directories.
+	tamperFixtureRe = regexp.MustCompile(`(^|/)fixtures?/`)
+	// tamperCIPathRe matches CI / quality-gate config whose edit can neuter the
+	// checks themselves.
+	tamperCIPathRe = regexp.MustCompile(
+		`(^|/)\.github/workflows/|(^|/)\.gitlab-ci\.yml$|(^|/)\.sybra\.yaml$|` +
+			`(^|/)\.golangci\.ya?ml$|(^|/)\.pre-commit-config\.yaml$|(^|/)Makefile$|(^|/)mise\.toml$`)
+)
+
+// classifyTamperPath maps a repo-relative path to its verification category.
+func classifyTamperPath(path string) tamperCategory {
+	switch {
+	case tamperTestPathRe.MatchString(path), tamperTestDirRe.MatchString(path):
+		return tamperCatTest
+	case tamperSnapshotRe.MatchString(path):
+		return tamperCatSnapshot
+	case tamperFixtureRe.MatchString(path):
+		return tamperCatFixture
+	case tamperCIPathRe.MatchString(path):
+		return tamperCatCI
+	default:
+		return tamperCatOther
+	}
+}
+
+var (
+	// tamperAddedSkipRe matches added lines that disable a test outright.
+	tamperAddedSkipRe = regexp.MustCompile(
+		`\bt\.Skip(Now|f)?\s*\(|\bt\.SkipNow\b|` + // Go
+			`@pytest\.mark\.(skip|skipif|xfail)|\bpytest\.skip\s*\(|` + // pytest
+			`@(unittest\.)?skip(Unless|If)?\s*\(|\braise\s+SkipTest\b|` + // unittest
+			`\b(it|describe|test|context)\.skip\s*\(|\bx(it|describe|test)\s*\(|` + // jest/mocha/vitest
+			`\b(test|it)\.todo\s*\(|@(Ignore|Disabled)\b`) // todo / JUnit
+	// tamperAddedExitRe matches an added forced success exit.
+	tamperAddedExitRe = regexp.MustCompile(
+		`\bos\.Exit\s*\(\s*0\s*\)|\bsys\.exit\s*\(\s*0\s*\)|\bprocess\.exit\s*\(\s*0\s*\)|(^|[^.\w])exit\s*\(\s*0\s*\)`)
+	// tamperBuildIgnoreRe matches an added Go build-ignore tag (excludes the
+	// file from the build, so its tests stop running).
+	tamperBuildIgnoreRe = regexp.MustCompile(`^//go:build\s+ignore\b|^// \+build\s+ignore\b`)
+	// tamperAssertionRe matches an assertion line. Counted on both sides of the
+	// diff so a net removal (deletions > additions) flags weakened coverage
+	// without false-positiving on pure refactors/renames.
+	tamperAssertionRe = regexp.MustCompile(
+		`\bassert\b|\brequire\b|\bassert\.|\brequire\.|\bexpect\s*\(|` +
+			`\bt\.(Error|Errorf|Fatal|Fatalf)\b|\bEXPECT_|\bASSERT_|\.should\b|\bshould\.`)
+	// tamperTestDeclRe matches a test-case declaration. Net removal flags
+	// deleted test cases.
+	tamperTestDeclRe = regexp.MustCompile(
+		`\bfunc\s+(Test|Benchmark|Fuzz|Example)[A-Z_0-9]|\bdef\s+test_|\b(it|test|describe)\s*\(`)
+)
+
+// scanTamperPatch inspects one file's unified diff for high-severity tampering
+// signals. Pure — no git, no IO — so it is exhaustively unit-tested.
+func scanTamperPatch(path string, cat tamperCategory, patch string) []tamperFinding {
+	var findings []tamperFinding
+	seen := map[string]bool{} // dedupe direct-match rules to one finding per file
+	addAssert, delAssert := 0, 0
+	addDecl, delDecl := 0, 0
+
+	add := func(rule, detail string) {
+		if seen[rule] {
+			return
+		}
+		seen[rule] = true
+		findings = append(findings, tamperFinding{
+			File: path, Category: string(cat), Severity: tamperHigh, Rule: rule, Detail: detail,
+		})
+	}
+
+	for line := range strings.SplitSeq(patch, "\n") {
+		switch {
+		case strings.HasPrefix(line, "+++"), strings.HasPrefix(line, "---"), strings.HasPrefix(line, "@@"):
+			continue
+		case strings.HasPrefix(line, "+"):
+			content := line[1:]
+			if tamperAddedSkipRe.MatchString(content) {
+				add("added-skip", trimDiffLine(content))
+			}
+			if tamperAddedExitRe.MatchString(content) {
+				add("added-early-exit", trimDiffLine(content))
+			}
+			if tamperBuildIgnoreRe.MatchString(strings.TrimSpace(content)) {
+				add("added-build-ignore", trimDiffLine(content))
+			}
+			if tamperAssertionRe.MatchString(content) {
+				addAssert++
+			}
+			if tamperTestDeclRe.MatchString(content) {
+				addDecl++
+			}
+		case strings.HasPrefix(line, "-"):
+			content := line[1:]
+			if tamperAssertionRe.MatchString(content) {
+				delAssert++
+			}
+			if tamperTestDeclRe.MatchString(content) {
+				delDecl++
+			}
+		}
+	}
+
+	if net := delAssert - addAssert; net > 0 {
+		findings = append(findings, tamperFinding{
+			File: path, Category: string(cat), Severity: tamperHigh,
+			Rule: "removed-assertions", Detail: fmt.Sprintf("net %d assertion line(s) removed", net),
+		})
+	}
+	if net := delDecl - addDecl; net > 0 {
+		findings = append(findings, tamperFinding{
+			File: path, Category: string(cat), Severity: tamperHigh,
+			Rule: "removed-test-cases", Detail: fmt.Sprintf("net %d test declaration(s) removed", net),
+		})
+	}
+	return findings
+}
+
+// buildTamperReport assembles the report from the parsed diff. Pure function:
+// classification + per-file scan + medium fallback. No git access.
+func buildTamperReport(taskID, base string, changes []tamperChange) tamperReport {
+	report := tamperReport{TaskID: taskID, Base: base}
+	scanned := 0
+	for i := range changes {
+		c := changes[i]
+		cat := classifyTamperPath(c.Path)
+		if cat == tamperCatOther {
+			continue
+		}
+		report.Files = append(report.Files, c.Path)
+
+		// Whole-file deletion of a verification file is itself high-severity.
+		if strings.HasPrefix(c.Status, "D") {
+			report.Findings = append(report.Findings, tamperFinding{
+				File: c.Path, Category: string(cat), Severity: tamperHigh,
+				Rule: "deleted-verification-file", Detail: string(cat) + " file deleted",
+			})
+			continue
+		}
+		if scanned >= tamperMaxScannedFiles {
+			continue
+		}
+		scanned++
+		report.Findings = append(report.Findings, scanTamperPatch(c.Path, cat, c.Patch)...)
+	}
+
+	// Verification files changed but nothing high fired: record one medium
+	// finding per file so the stored report and the reviewer still have the
+	// context (benign test edits are normal for feature work and do not block).
+	if report.highCount() == 0 {
+		for _, f := range report.Files {
+			report.Findings = append(report.Findings, tamperFinding{
+				File: f, Category: string(classifyTamperPath(f)),
+				Severity: tamperMedium, Rule: "verification-file-changed",
+			})
+		}
+	}
+	return report
+}
+
+// execDetectTampering inspects the worktree diff (base...HEAD) for reward-
+// hacking / test-tampering signals. A high-severity finding flips the task to
+// human-required so it cannot reach done without an explicit human bless;
+// benign verification-file changes are recorded but do not block.
+//
+// Skip conditions (no-op, returns "clean"):
+//   - No WorktreeGetter configured
+//   - No worktree found for the task
+//   - No verification files changed
+//
+// Fail-open on git/context errors: verify_commits already gates broken
+// worktrees to human-required, so a diff failure here is logged and passed
+// through rather than double-flipping or stranding the task.
+func (e *Engine) execDetectTampering(taskID string, step *Step, _ TaskInfo) (StepOutput, error) {
+	if e.worktrees == nil {
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no worktree getter configured"}, nil
+	}
+	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
+	if !ok {
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no worktree for task"}, nil
+	}
+
+	report, err := e.collectTamperReport(taskID, wtPath)
+	if err != nil {
+		if errors.Is(e.ctx.Err(), context.Canceled) || errors.Is(e.ctx.Err(), context.DeadlineExceeded) {
+			return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: context canceled"}, nil
+		}
+		e.logger.Warn("workflow.detect-tampering.diff-error", "task_id", taskID, "err", err)
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "clean"}, nil
+	}
+
+	if len(report.Files) == 0 {
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "clean"}, nil
+	}
+
+	if e.recorder != nil {
+		if data, mErr := json.MarshalIndent(report, "", "  "); mErr == nil {
+			if recErr := e.recorder.PutGeneric(taskID, "tamper-report.json", step.ID, string(data)); recErr != nil {
+				e.logger.Warn("workflow.detect-tampering.artifact", "task_id", taskID, "err", recErr)
+			}
+		}
+	}
+
+	if high := report.highCount(); high > 0 {
+		reason := tamperReason(report)
+		if statusErr := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); statusErr != nil {
+			e.logger.Error("workflow.detect-tampering.status", "task_id", taskID, "err", statusErr)
+		}
+		e.logger.Warn("workflow.detect-tampering.flagged",
+			"task_id", taskID, "high", high, "files", len(report.Files))
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "flagged"}, nil
+	}
+
+	e.logger.Info("workflow.detect-tampering.clean", "task_id", taskID, "files", len(report.Files))
+	return StepOutput{StepID: step.ID, Status: "completed", Output: "clean"}, nil
+}
+
+// collectTamperReport runs git to gather the changed files and per-file patches
+// for verification files, then delegates to the pure buildTamperReport.
+func (e *Engine) collectTamperReport(taskID, wtPath string) (tamperReport, error) {
+	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
+	defer cancel()
+	base := resolveOriginBase(ctx, wtPath)
+	rangeSpec := base + "...HEAD"
+
+	nsCmd := exec.CommandContext(ctx, "git", "diff", "--name-status", rangeSpec)
+	nsCmd.Dir = wtPath
+	nsOut, err := nsCmd.Output()
+	if err != nil {
+		return tamperReport{}, fmt.Errorf("git diff --name-status: %w", err)
+	}
+
+	changes := parseNameStatus(string(nsOut))
+	for i := range changes {
+		c := &changes[i]
+		if classifyTamperPath(c.Path) == tamperCatOther || strings.HasPrefix(c.Status, "D") {
+			continue
+		}
+		patch, pErr := gitFilePatch(ctx, wtPath, rangeSpec, c.Path)
+		if pErr != nil {
+			e.logger.Warn("workflow.detect-tampering.file-patch", "task_id", taskID, "file", c.Path, "err", pErr)
+			continue
+		}
+		c.Patch = patch
+	}
+	return buildTamperReport(taskID, base, changes), nil
+}
+
+func gitFilePatch(ctx context.Context, wtPath, rangeSpec, path string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "diff", rangeSpec, "--", path)
+	cmd.Dir = wtPath
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// parseNameStatus parses `git diff --name-status` output into changes. Renames
+// and copies (R/C) report old and new tab-separated paths; the new path (last
+// field) is used.
+func parseNameStatus(out string) []tamperChange {
+	var changes []tamperChange
+	for line := range strings.SplitSeq(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		if len(fields) < 2 {
+			continue
+		}
+		changes = append(changes, tamperChange{
+			Status: strings.TrimSpace(fields[0]),
+			Path:   strings.TrimSpace(fields[len(fields)-1]),
+		})
+	}
+	return changes
+}
+
+// tamperReason builds the human-required status reason from high findings.
+func tamperReason(r tamperReport) string {
+	var b strings.Builder
+	b.WriteString("possible test tampering — needs human bless before review: ")
+	shown := 0
+	for i := range r.Findings {
+		f := r.Findings[i]
+		if f.Severity != tamperHigh {
+			continue
+		}
+		if shown > 0 {
+			b.WriteString("; ")
+		}
+		fmt.Fprintf(&b, "%s in %s", f.Rule, f.File)
+		if f.Detail != "" {
+			fmt.Fprintf(&b, " (%s)", f.Detail)
+		}
+		shown++
+		if shown >= tamperMaxReasonFindings {
+			b.WriteString("; …")
+			break
+		}
+	}
+	return b.String()
+}
+
+// trimDiffLine normalizes a diff content line for inclusion in a finding:
+// trimmed and capped to a sane length.
+func trimDiffLine(s string) string {
+	s = strings.TrimSpace(s)
+	const maxLen = 120
+	if len(s) > maxLen {
+		return s[:maxLen] + "…"
+	}
+	return s
+}

--- a/internal/workflow/engine_steps_tamper.go
+++ b/internal/workflow/engine_steps_tamper.go
@@ -7,8 +7,15 @@ import (
 	"fmt"
 	"os/exec"
 	"regexp"
+	"slices"
 	"strings"
 )
+
+// tamperBlessedTag short-circuits the detector: a human who has reviewed a
+// flagged diff and accepted it adds this tag, then moves the task back into the
+// flow. Without it, re-dispatching a flagged task would re-scan the same
+// committed diff and re-flag forever (livelock).
+const tamperBlessedTag = "tamper-blessed"
 
 // tamperCategory classifies a changed file by the role it plays in the
 // project's verification surface. Only test/snapshot/fixture/ci files are
@@ -135,15 +142,81 @@ var (
 	// deleted test cases.
 	tamperTestDeclRe = regexp.MustCompile(
 		`\bfunc\s+(Test|Benchmark|Fuzz|Example)[A-Z_0-9]|\bdef\s+test_|\b(it|test|describe)\s*\(`)
+	// tamperCINeuterRe matches an added CI/quality-gate line that defeats the
+	// gate without failing it. Scoped to tamperCatCI files.
+	tamperCINeuterRe = regexp.MustCompile(
+		`continue-on-error:\s*true|allow_failure:\s*true|\|\|\s*true\b|\bif:\s*false\b|\bexit\s+0\b`)
+	// tamperTautoExpectRe matches a jest/vitest expect(...).toBe(...) pair; the
+	// two operands are compared in detectTautology.
+	tamperTautoExpectRe = regexp.MustCompile(
+		`expect\s*\(([^()]+)\)\s*\.\s*(?:toBe|toEqual|toStrictEqual)\s*\(([^()]+)\)`)
+	// tamperTautoCallRe matches an equality-assertion call with a flat (no
+	// nested parens) argument list.
+	tamperTautoCallRe = regexp.MustCompile(
+		`\b(?:assertEqual|assertEquals|assertSame|Equal|Equalf)\s*\(([^()]*)\)`)
+	// tamperTautoCmpRe matches a bare `assert`/`if` equality comparison.
+	tamperTautoCmpRe = regexp.MustCompile(
+		`\b(?:assert|if)\s+(.+?)\s*={2,3}\s*(.+?)\s*[:{]?\s*$`)
 )
+
+// looksLikeComment reports whether a (diff-stripped) line is a source comment.
+// Commenting code out adds nothing of substance, so commented additions are
+// ignored — a commented-out assertion then counts as a removal, not an offset.
+func looksLikeComment(s string) bool {
+	t := strings.TrimSpace(s)
+	return strings.HasPrefix(t, "//") || strings.HasPrefix(t, "#") ||
+		strings.HasPrefix(t, "/*") || strings.HasPrefix(t, "* ") ||
+		strings.HasPrefix(t, "<!--")
+}
+
+// detectTautology reports whether an added assertion compares a value to
+// itself (e.g. require.Equal(t, got, got), expect(x).toBe(x), assert a == a) —
+// a near-unambiguous way to make a test pass without testing anything. Pure
+// literal hardcoding (expected 5 → 4) is NOT detectable here; that is the
+// baseline-suite's job (see issue #1058 follow-up).
+func detectTautology(content string) bool {
+	if m := tamperTautoExpectRe.FindStringSubmatch(content); len(m) == 3 && eqOperand(m[1], m[2]) {
+		return true
+	}
+	if m := tamperTautoCallRe.FindStringSubmatch(content); len(m) == 2 {
+		args := splitTopArgs(m[1])
+		if n := len(args); n >= 2 && eqOperand(args[n-1], args[n-2]) {
+			return true
+		}
+	}
+	if m := tamperTautoCmpRe.FindStringSubmatch(content); len(m) == 3 && eqOperand(m[1], m[2]) {
+		return true
+	}
+	return false
+}
+
+func eqOperand(a, b string) bool {
+	a, b = strings.TrimSpace(a), strings.TrimSpace(b)
+	return a != "" && a == b
+}
+
+func splitTopArgs(s string) []string {
+	parts := strings.Split(s, ",")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	return parts
+}
 
 // scanTamperPatch inspects one file's unified diff for high-severity tampering
 // signals. Pure — no git, no IO — so it is exhaustively unit-tested.
+//
+// Hunk state is tracked explicitly: `---`/`+++` are file headers only before
+// the first `@@`, so a removed/added line whose content itself begins with
+// `--`/`++` is still classified by its leading diff marker rather than mistaken
+// for a header. Comment-only additions are ignored, so commenting out a test or
+// assertion registers as a removal (the deletion side) with no offsetting add.
 func scanTamperPatch(path string, cat tamperCategory, patch string) []tamperFinding {
 	var findings []tamperFinding
 	seen := map[string]bool{} // dedupe direct-match rules to one finding per file
 	addAssert, delAssert := 0, 0
 	addDecl, delDecl := 0, 0
+	isCI := cat == tamperCatCI
 
 	add := func(rule, detail string) {
 		if seen[rule] {
@@ -155,29 +228,58 @@ func scanTamperPatch(path string, cat tamperCategory, patch string) []tamperFind
 		})
 	}
 
+	inHunk := false
 	for line := range strings.SplitSeq(patch, "\n") {
 		switch {
-		case strings.HasPrefix(line, "+++"), strings.HasPrefix(line, "---"), strings.HasPrefix(line, "@@"):
+		case strings.HasPrefix(line, "diff --git "), strings.HasPrefix(line, "index "),
+			strings.HasPrefix(line, "old mode "), strings.HasPrefix(line, "new mode "),
+			strings.HasPrefix(line, "new file"), strings.HasPrefix(line, "deleted file"),
+			strings.HasPrefix(line, "similarity "), strings.HasPrefix(line, "rename "),
+			strings.HasPrefix(line, "copy "), strings.HasPrefix(line, "Binary "):
+			inHunk = false
 			continue
-		case strings.HasPrefix(line, "+"):
+		case strings.HasPrefix(line, "@@"):
+			inHunk = true
+			continue
+		case !inHunk && (strings.HasPrefix(line, "---") || strings.HasPrefix(line, "+++")):
+			continue
+		case inHunk && strings.HasPrefix(line, "+"):
 			content := line[1:]
+			// A build-ignore tag is syntactically a comment but a meaningful
+			// directive that excludes the file from the build — check it before
+			// the comment skip below.
+			if tamperBuildIgnoreRe.MatchString(strings.TrimSpace(content)) {
+				add("added-build-ignore", trimDiffLine(content))
+				continue
+			}
+			if looksLikeComment(content) {
+				continue
+			}
 			if tamperAddedSkipRe.MatchString(content) {
 				add("added-skip", trimDiffLine(content))
 			}
 			if tamperAddedExitRe.MatchString(content) {
 				add("added-early-exit", trimDiffLine(content))
 			}
-			if tamperBuildIgnoreRe.MatchString(strings.TrimSpace(content)) {
-				add("added-build-ignore", trimDiffLine(content))
+			if isCI && tamperCINeuterRe.MatchString(content) {
+				add("ci-neutered", trimDiffLine(content))
 			}
-			if tamperAssertionRe.MatchString(content) {
-				addAssert++
+			if !isCI {
+				if tamperAssertionRe.MatchString(content) {
+					addAssert++
+				}
+				if tamperTestDeclRe.MatchString(content) {
+					addDecl++
+				}
+				if detectTautology(content) {
+					add("tautological-assertion", trimDiffLine(content))
+				}
 			}
-			if tamperTestDeclRe.MatchString(content) {
-				addDecl++
-			}
-		case strings.HasPrefix(line, "-"):
+		case inHunk && strings.HasPrefix(line, "-"):
 			content := line[1:]
+			if isCI || looksLikeComment(content) {
+				continue
+			}
 			if tamperAssertionRe.MatchString(content) {
 				delAssert++
 			}
@@ -245,19 +347,31 @@ func buildTamperReport(taskID, base string, changes []tamperChange) tamperReport
 }
 
 // execDetectTampering inspects the worktree diff (base...HEAD) for reward-
-// hacking / test-tampering signals. A high-severity finding flips the task to
-// human-required so it cannot reach done without an explicit human bless;
-// benign verification-file changes are recorded but do not block.
+// hacking / test-tampering signals: added skip/xfail markers, forced exit(0),
+// Go build-ignore tags, commented-out or net-removed assertions and test
+// cases, tautological self-comparisons, deleted verification files, and
+// neutered CI gates. A high-severity finding flips the task to human-required
+// so it cannot reach done without an explicit human bless; benign
+// verification-file changes are recorded but do not block.
 //
-// Skip conditions (no-op, returns "clean"):
-//   - No WorktreeGetter configured
-//   - No worktree found for the task
-//   - No verification files changed
+// Pure literal-value hardcoding (an expected `5` swapped to `4`) is NOT
+// detectable from the diff alone — that is the baseline-suite's job, deferred
+// to the issue #1058 follow-up.
+//
+// Short-circuits (no-op):
+//   - task carries the tamper-blessed tag (human already accepted the diff →
+//     returns "blessed" so re-dispatch does not re-flag the same commits)
+//   - No WorktreeGetter configured / no worktree / no verification files
+//     changed (returns "clean")
 //
 // Fail-open on git/context errors: verify_commits already gates broken
 // worktrees to human-required, so a diff failure here is logged and passed
 // through rather than double-flipping or stranding the task.
-func (e *Engine) execDetectTampering(taskID string, step *Step, _ TaskInfo) (StepOutput, error) {
+func (e *Engine) execDetectTampering(taskID string, step *Step, t TaskInfo) (StepOutput, error) {
+	if slices.Contains(t.Tags, tamperBlessedTag) {
+		e.logger.Info("workflow.detect-tampering.blessed", "task_id", taskID)
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "blessed"}, nil
+	}
 	if e.worktrees == nil {
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no worktree getter configured"}, nil
 	}
@@ -309,7 +423,9 @@ func (e *Engine) collectTamperReport(taskID, wtPath string) (tamperReport, error
 	base := resolveOriginBase(ctx, wtPath)
 	rangeSpec := base + "...HEAD"
 
-	nsCmd := exec.CommandContext(ctx, "git", "diff", "--name-status", rangeSpec)
+	// core.quotePath=false keeps non-ASCII paths unquoted so classification and
+	// the per-file diff pathspec below see the real filename.
+	nsCmd := exec.CommandContext(ctx, "git", "-c", "core.quotePath=false", "diff", "--name-status", rangeSpec)
 	nsCmd.Dir = wtPath
 	nsOut, err := nsCmd.Output()
 	if err != nil {
@@ -333,7 +449,7 @@ func (e *Engine) collectTamperReport(taskID, wtPath string) (tamperReport, error
 }
 
 func gitFilePatch(ctx context.Context, wtPath, rangeSpec, path string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "diff", rangeSpec, "--", path)
+	cmd := exec.CommandContext(ctx, "git", "-c", "core.quotePath=false", "diff", rangeSpec, "--", path)
 	cmd.Dir = wtPath
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/workflow/engine_steps_tamper.go
+++ b/internal/workflow/engine_steps_tamper.go
@@ -134,9 +134,12 @@ var (
 	tamperBuildIgnoreRe = regexp.MustCompile(`^//go:build\s+ignore\b|^// \+build\s+ignore\b`)
 	// tamperAssertionRe matches an assertion line. Counted on both sides of the
 	// diff so a net removal (deletions > additions) flags weakened coverage
-	// without false-positiving on pure refactors/renames.
+	// without false-positiving on pure refactors/renames. Bare `require` is
+	// deliberately excluded: it matches JS `require("dep")` / Ruby
+	// `require "spec_helper"` imports, whose removal is not a coverage loss —
+	// only `require.` (testify-style assertions) counts.
 	tamperAssertionRe = regexp.MustCompile(
-		`\bassert\b|\brequire\b|\bassert\.|\brequire\.|\bexpect\s*\(|` +
+		`\bassert\b|\brequire\.|\bexpect\s*\(|` +
 			`\bt\.(Error|Errorf|Fatal|Fatalf)\b|\bEXPECT_|\bASSERT_|\.should\b|\bshould\.`)
 	// tamperTestDeclRe matches a test-case declaration. Net removal flags
 	// deleted test cases.
@@ -146,6 +149,14 @@ var (
 	// gate without failing it. Scoped to tamperCatCI files.
 	tamperCINeuterRe = regexp.MustCompile(
 		`continue-on-error:\s*true|allow_failure:\s*true|\|\|\s*true\b|\bif:\s*false\b|\bexit\s+0\b`)
+	// tamperCIRunRe matches a CI line that runs the project's checks. A net
+	// removal of such lines in a CI file flags a deleted gate (e.g. dropping
+	// the `run: go test` step) even when no neuter token is added.
+	tamperCIRunRe = regexp.MustCompile(
+		`(?i)\b(go test|go vet|npm (?:run )?(?:test|lint|check|typecheck)|` +
+			`pnpm (?:run )?(?:test|lint)|yarn (?:test|lint)|pytest|jest|vitest|` +
+			`golangci-lint|nilaway|make (?:test|lint|check)|cargo (?:test|clippy)|` +
+			`ctest|tox|svelte-check|tsc)\b`)
 	// tamperTautoExpectRe matches a jest/vitest expect(...).toBe(...) pair; the
 	// two operands are compared in detectTautology.
 	tamperTautoExpectRe = regexp.MustCompile(
@@ -212,96 +223,134 @@ func splitTopArgs(s string) []string {
 // for a header. Comment-only additions are ignored, so commenting out a test or
 // assertion registers as a removal (the deletion side) with no offsetting add.
 func scanTamperPatch(path string, cat tamperCategory, patch string) []tamperFinding {
-	var findings []tamperFinding
-	seen := map[string]bool{} // dedupe direct-match rules to one finding per file
-	addAssert, delAssert := 0, 0
-	addDecl, delDecl := 0, 0
-	isCI := cat == tamperCatCI
-
-	add := func(rule, detail string) {
-		if seen[rule] {
-			return
-		}
-		seen[rule] = true
-		findings = append(findings, tamperFinding{
-			File: path, Category: string(cat), Severity: tamperHigh, Rule: rule, Detail: detail,
-		})
-	}
-
+	s := &tamperScan{path: path, cat: cat, isCI: cat == tamperCatCI, seen: map[string]bool{}}
 	inHunk := false
 	for line := range strings.SplitSeq(patch, "\n") {
 		switch {
-		case strings.HasPrefix(line, "diff --git "), strings.HasPrefix(line, "index "),
-			strings.HasPrefix(line, "old mode "), strings.HasPrefix(line, "new mode "),
-			strings.HasPrefix(line, "new file"), strings.HasPrefix(line, "deleted file"),
-			strings.HasPrefix(line, "similarity "), strings.HasPrefix(line, "rename "),
-			strings.HasPrefix(line, "copy "), strings.HasPrefix(line, "Binary "):
+		case isDiffHeaderLine(line):
 			inHunk = false
-			continue
 		case strings.HasPrefix(line, "@@"):
 			inHunk = true
-			continue
 		case !inHunk && (strings.HasPrefix(line, "---") || strings.HasPrefix(line, "+++")):
-			continue
+			// file header before any hunk; ignore
 		case inHunk && strings.HasPrefix(line, "+"):
-			content := line[1:]
-			// A build-ignore tag is syntactically a comment but a meaningful
-			// directive that excludes the file from the build — check it before
-			// the comment skip below.
-			if tamperBuildIgnoreRe.MatchString(strings.TrimSpace(content)) {
-				add("added-build-ignore", trimDiffLine(content))
-				continue
-			}
-			if looksLikeComment(content) {
-				continue
-			}
-			if tamperAddedSkipRe.MatchString(content) {
-				add("added-skip", trimDiffLine(content))
-			}
-			if tamperAddedExitRe.MatchString(content) {
-				add("added-early-exit", trimDiffLine(content))
-			}
-			if isCI && tamperCINeuterRe.MatchString(content) {
-				add("ci-neutered", trimDiffLine(content))
-			}
-			if !isCI {
-				if tamperAssertionRe.MatchString(content) {
-					addAssert++
-				}
-				if tamperTestDeclRe.MatchString(content) {
-					addDecl++
-				}
-				if detectTautology(content) {
-					add("tautological-assertion", trimDiffLine(content))
-				}
-			}
+			s.feedAdded(line[1:])
 		case inHunk && strings.HasPrefix(line, "-"):
-			content := line[1:]
-			if isCI || looksLikeComment(content) {
-				continue
-			}
-			if tamperAssertionRe.MatchString(content) {
-				delAssert++
-			}
-			if tamperTestDeclRe.MatchString(content) {
-				delDecl++
-			}
+			s.feedRemoved(line[1:])
 		}
 	}
+	return s.finalize()
+}
 
-	if net := delAssert - addAssert; net > 0 {
-		findings = append(findings, tamperFinding{
-			File: path, Category: string(cat), Severity: tamperHigh,
-			Rule: "removed-assertions", Detail: fmt.Sprintf("net %d assertion line(s) removed", net),
-		})
+// isDiffHeaderLine reports whether a line is a git diff metadata header that
+// resets hunk state (so a subsequent `---`/`+++` is a file header, not content).
+func isDiffHeaderLine(line string) bool {
+	for _, p := range []string{"diff --git ", "index ", "old mode ", "new mode ",
+		"new file", "deleted file", "similarity ", "rename ", "copy ", "Binary "} {
+		if strings.HasPrefix(line, p) {
+			return true
+		}
 	}
-	if net := delDecl - addDecl; net > 0 {
-		findings = append(findings, tamperFinding{
-			File: path, Category: string(cat), Severity: tamperHigh,
-			Rule: "removed-test-cases", Detail: fmt.Sprintf("net %d test declaration(s) removed", net),
-		})
+	return false
+}
+
+// tamperScan accumulates findings and net token counts while walking a patch.
+type tamperScan struct {
+	path      string
+	cat       tamperCategory
+	isCI      bool
+	seen      map[string]bool
+	findings  []tamperFinding
+	addAssert int
+	delAssert int
+	addDecl   int
+	delDecl   int
+	addRun    int
+	delRun    int
+}
+
+func (s *tamperScan) add(rule, detail string) {
+	if s.seen[rule] {
+		return
 	}
-	return findings
+	s.seen[rule] = true
+	s.findings = append(s.findings, tamperFinding{
+		File: s.path, Category: string(s.cat), Severity: tamperHigh, Rule: rule, Detail: detail,
+	})
+}
+
+func (s *tamperScan) feedAdded(content string) {
+	// A build-ignore tag is syntactically a comment but a meaningful directive
+	// that excludes the file from the build — check it before the comment skip.
+	if tamperBuildIgnoreRe.MatchString(strings.TrimSpace(content)) {
+		s.add("added-build-ignore", trimDiffLine(content))
+		return
+	}
+	if looksLikeComment(content) {
+		return
+	}
+	if tamperAddedSkipRe.MatchString(content) {
+		s.add("added-skip", trimDiffLine(content))
+	}
+	if tamperAddedExitRe.MatchString(content) {
+		s.add("added-early-exit", trimDiffLine(content))
+	}
+	if s.isCI {
+		if tamperCINeuterRe.MatchString(content) {
+			s.add("ci-neutered", trimDiffLine(content))
+		}
+		if tamperCIRunRe.MatchString(content) {
+			s.addRun++
+		}
+		return
+	}
+	if tamperAssertionRe.MatchString(content) {
+		s.addAssert++
+	}
+	if tamperTestDeclRe.MatchString(content) {
+		s.addDecl++
+	}
+	if detectTautology(content) {
+		s.add("tautological-assertion", trimDiffLine(content))
+	}
+}
+
+func (s *tamperScan) feedRemoved(content string) {
+	if looksLikeComment(content) {
+		return
+	}
+	if s.isCI {
+		if tamperCIRunRe.MatchString(content) {
+			s.delRun++
+		}
+		return
+	}
+	if tamperAssertionRe.MatchString(content) {
+		s.delAssert++
+	}
+	if tamperTestDeclRe.MatchString(content) {
+		s.delDecl++
+	}
+}
+
+// finalize appends the net-removal findings (a deletion not offset by an
+// addition signals weakened coverage / a removed gate) and returns the result.
+func (s *tamperScan) finalize() []tamperFinding {
+	netFinding := func(rule, noun string, del, add int) {
+		if net := del - add; net > 0 {
+			s.findings = append(s.findings, tamperFinding{
+				File: s.path, Category: string(s.cat), Severity: tamperHigh,
+				Rule: rule, Detail: fmt.Sprintf("net %d %s removed", net, noun),
+			})
+		}
+	}
+	if s.isCI {
+		netFinding("removed-ci-step", "check step(s)", s.delRun, s.addRun)
+		return s.findings
+	}
+	netFinding("removed-assertions", "assertion line(s)", s.delAssert, s.addAssert)
+	netFinding("removed-test-cases", "test declaration(s)", s.delDecl, s.addDecl)
+	return s.findings
 }
 
 // buildTamperReport assembles the report from the parsed diff. Pure function:
@@ -382,7 +431,10 @@ func (e *Engine) execDetectTampering(taskID string, step *Step, t TaskInfo) (Ste
 
 	report, err := e.collectTamperReport(taskID, wtPath)
 	if err != nil {
-		if errors.Is(e.ctx.Err(), context.Canceled) || errors.Is(e.ctx.Err(), context.DeadlineExceeded) {
+		// collectTamperReport wraps the per-step timeout/cancel into the
+		// returned error, so check the chain (not e.ctx, which stays live when
+		// only the inner shellTimeout fires).
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: context canceled"}, nil
 		}
 		e.logger.Warn("workflow.detect-tampering.diff-error", "task_id", taskID, "err", err)
@@ -429,17 +481,32 @@ func (e *Engine) collectTamperReport(taskID, wtPath string) (tamperReport, error
 	nsCmd.Dir = wtPath
 	nsOut, err := nsCmd.Output()
 	if err != nil {
+		// Surface the per-step timeout/cancel through the error chain so the
+		// caller can distinguish it from a genuine git failure.
+		if ctx.Err() != nil {
+			return tamperReport{}, fmt.Errorf("git diff --name-status: %w", ctx.Err())
+		}
 		return tamperReport{}, fmt.Errorf("git diff --name-status: %w", err)
 	}
 
 	changes := parseNameStatus(string(nsOut))
+	fetched := 0
 	for i := range changes {
 		c := &changes[i]
 		if classifyTamperPath(c.Path) == tamperCatOther || strings.HasPrefix(c.Status, "D") {
 			continue
 		}
+		// Honour the same cap buildTamperReport scans under, so a pathological
+		// diff cannot spawn an unbounded number of per-file `git diff` calls.
+		if fetched >= tamperMaxScannedFiles {
+			break
+		}
+		fetched++
 		patch, pErr := gitFilePatch(ctx, wtPath, rangeSpec, c.Path)
 		if pErr != nil {
+			if ctx.Err() != nil {
+				return tamperReport{}, fmt.Errorf("git diff %s: %w", c.Path, ctx.Err())
+			}
 			e.logger.Warn("workflow.detect-tampering.file-patch", "task_id", taskID, "file", c.Path, "err", pErr)
 			continue
 		}

--- a/internal/workflow/engine_steps_tamper_test.go
+++ b/internal/workflow/engine_steps_tamper_test.go
@@ -46,6 +46,7 @@ func TestScanTamperPatch(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
 		name      string
+		cat       tamperCategory // defaults to test when empty
 		patch     string
 		wantRules []string // high-severity rules expected (order-insensitive subset)
 	}{
@@ -129,10 +130,37 @@ func TestScanTamperPatch(t *testing.T) {
 			patch:     "@@ -1 +0,0 @@\n--- legacy bullet text\n",
 			wantRules: nil, // in-hunk content line (not a file header); no tokens → no finding
 		},
+		{
+			name:      "js_require_import_removal_is_not_an_assertion",
+			patch:     "@@ @@\n-const dep = require(\"dep\")\n",
+			wantRules: nil, // bare require is an import, not an assertion
+		},
+		{
+			name:      "ci_removed_test_step",
+			cat:       tamperCatCI,
+			patch:     "@@ @@\n       - run: go vet ./...\n-      - run: go test ./...\n",
+			wantRules: []string{"removed-ci-step"},
+		},
+		{
+			name:      "ci_neuter_token",
+			cat:       tamperCatCI,
+			patch:     "@@ @@\n+    continue-on-error: true\n",
+			wantRules: []string{"ci-neutered"},
+		},
+		{
+			name:      "ci_renamed_step_no_net_loss",
+			cat:       tamperCatCI,
+			patch:     "@@ @@\n-      - run: go test ./...\n+      - run: go test ./... -race\n",
+			wantRules: nil, // 1 removed, 1 re-added → net 0
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := scanTamperPatch("x_test.go", tamperCatTest, tc.patch)
+			cat := tc.cat
+			if cat == "" {
+				cat = tamperCatTest
+			}
+			got := scanTamperPatch("x_test.go", cat, tc.patch)
 			gotRules := map[string]bool{}
 			for _, f := range got {
 				if f.Severity != tamperHigh {
@@ -519,6 +547,9 @@ func TestBuiltinPRFix_DetectTamperingWiring(t *testing.T) {
 		t.Fatal("detect_tampering step missing from pr-fix")
 	}
 	vc := prfix.StepByID("verify_commits")
+	if vc == nil {
+		t.Fatal("verify_commits step missing from pr-fix")
+	}
 	if got, _ := ResolveTransition(vc.Next, map[string]string{"task.status": "in-progress"}); got != "detect_tampering" {
 		t.Errorf("pr-fix verify_commits default goto = %q, want detect_tampering", got)
 	}
@@ -545,6 +576,9 @@ func TestBuiltinSimpleTaskReview_DetectTamperingWiring(t *testing.T) {
 		t.Fatal("detect_tampering step missing from simple-task-review")
 	}
 	fix := rev.StepByID("fix_review")
+	if fix == nil {
+		t.Fatal("fix_review step missing from simple-task-review")
+	}
 	if got, _ := ResolveTransition(fix.Next, map[string]string{"task.status": "ready-review"}); got != "detect_tampering" {
 		t.Errorf("fix_review goto = %q, want detect_tampering", got)
 	}

--- a/internal/workflow/engine_steps_tamper_test.go
+++ b/internal/workflow/engine_steps_tamper_test.go
@@ -1,0 +1,414 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestClassifyTamperPath(t *testing.T) {
+	t.Parallel()
+	cases := map[string]tamperCategory{
+		"internal/task/parser_test.go":     tamperCatTest,
+		"pkg/util/strings_test.go":         tamperCatTest,
+		"tests/test_login.py":              tamperCatTest,
+		"app/auth_test.py":                 tamperCatTest,
+		"frontend/src/App.test.ts":         tamperCatTest,
+		"frontend/src/App.spec.tsx":        tamperCatTest,
+		"src/__tests__/util.js":            tamperCatTest,
+		"spec/models/user_spec.rb":         tamperCatTest,
+		"frontend/src/__snapshots__/x.js":  tamperCatSnapshot,
+		"internal/foo/testdata/golden.txt": tamperCatSnapshot,
+		"cmd/x/cli.snap":                   tamperCatSnapshot,
+		"internal/render/out.golden":       tamperCatSnapshot,
+		"test/fixtures/payload.json":       tamperCatTest, // under tests dir wins
+		"internal/fixtures/payload.json":   tamperCatFixture,
+		".github/workflows/ci.yml":         tamperCatCI,
+		".gitlab-ci.yml":                   tamperCatCI,
+		".sybra.yaml":                      tamperCatCI,
+		".golangci.yaml":                   tamperCatCI,
+		"Makefile":                         tamperCatCI,
+		"mise.toml":                        tamperCatCI,
+		"internal/workflow/engine.go":      tamperCatOther,
+		"frontend/src/App.svelte":          tamperCatOther,
+		"README.md":                        tamperCatOther,
+		"internal/task/model.go":           tamperCatOther,
+		"contestant/best.go":               tamperCatOther, // "test" substring must not match
+	}
+	for path, want := range cases {
+		if got := classifyTamperPath(path); got != want {
+			t.Errorf("classifyTamperPath(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
+func TestScanTamperPatch(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		patch     string
+		wantRules []string // high-severity rules expected (order-insensitive subset)
+	}{
+		{
+			name:      "added_go_skip",
+			patch:     "@@ -1,3 +1,4 @@\n func TestFoo(t *testing.T) {\n+\tt.Skip(\"flaky\")\n \tif x != 1 {\n",
+			wantRules: []string{"added-skip"},
+		},
+		{
+			name:      "added_pytest_skip",
+			patch:     "@@ @@\n+@pytest.mark.skip(reason=\"todo\")\n def test_login():\n",
+			wantRules: []string{"added-skip"},
+		},
+		{
+			name:      "added_jest_skip",
+			patch:     "@@ @@\n-it(\"works\", () => {\n+it.skip(\"works\", () => {\n",
+			wantRules: []string{"added-skip"},
+		},
+		{
+			name:      "added_early_exit",
+			patch:     "@@ @@\n func TestX(t *testing.T) {\n+\tos.Exit(0)\n",
+			wantRules: []string{"added-early-exit"},
+		},
+		{
+			name:      "added_build_ignore",
+			patch:     "@@ @@\n+//go:build ignore\n package foo\n",
+			wantRules: []string{"added-build-ignore"},
+		},
+		{
+			name:      "removed_assertions_net",
+			patch:     "@@ @@\n-\tif x != 1 { t.Errorf(\"a\") }\n-\tif y != 2 { t.Fatalf(\"b\") }\n \tok := true\n",
+			wantRules: []string{"removed-assertions"},
+		},
+		{
+			name:      "removed_test_case",
+			patch:     "@@ @@\n-func TestGone(t *testing.T) {\n-\tt.Errorf(\"x\")\n-}\n",
+			wantRules: []string{"removed-test-cases", "removed-assertions"},
+		},
+		{
+			name:      "assertion_rename_no_net_loss",
+			patch:     "@@ @@\n-\trequire.Equal(t, a, b)\n+\trequire.Equal(t, a, c)\n",
+			wantRules: nil, // 1 removed, 1 added → net 0, no finding
+		},
+		{
+			name:      "pure_addition_no_finding",
+			patch:     "@@ @@\n+func TestNew(t *testing.T) {\n+\trequire.NoError(t, err)\n+}\n",
+			wantRules: nil,
+		},
+		{
+			name:      "headers_ignored",
+			patch:     "--- a/foo_test.go\n+++ b/foo_test.go\n@@ @@\n context\n",
+			wantRules: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scanTamperPatch("x_test.go", tamperCatTest, tc.patch)
+			gotRules := map[string]bool{}
+			for _, f := range got {
+				if f.Severity != tamperHigh {
+					t.Errorf("finding %q has severity %q, want high", f.Rule, f.Severity)
+				}
+				gotRules[f.Rule] = true
+			}
+			for _, want := range tc.wantRules {
+				if !gotRules[want] {
+					t.Errorf("missing expected rule %q; got %v", want, gotRules)
+				}
+			}
+			if tc.wantRules == nil && len(got) != 0 {
+				t.Errorf("expected no findings, got %v", got)
+			}
+		})
+	}
+}
+
+func TestBuildTamperReport(t *testing.T) {
+	t.Parallel()
+
+	t.Run("deleted_test_file_is_high", func(t *testing.T) {
+		r := buildTamperReport("t1", "origin/main", []tamperChange{
+			{Status: "D", Path: "internal/foo/foo_test.go"},
+		})
+		if r.highCount() != 1 {
+			t.Fatalf("highCount = %d, want 1 (%v)", r.highCount(), r.Findings)
+		}
+		if r.Findings[0].Rule != "deleted-verification-file" {
+			t.Errorf("rule = %q, want deleted-verification-file", r.Findings[0].Rule)
+		}
+	})
+
+	t.Run("impl_only_change_no_files", func(t *testing.T) {
+		r := buildTamperReport("t1", "origin/main", []tamperChange{
+			{Status: "M", Path: "internal/foo/foo.go", Patch: "@@ @@\n+x := 1\n"},
+		})
+		if len(r.Files) != 0 {
+			t.Errorf("Files = %v, want empty (non-verification change)", r.Files)
+		}
+		if len(r.Findings) != 0 {
+			t.Errorf("Findings = %v, want none", r.Findings)
+		}
+	})
+
+	t.Run("benign_test_change_is_medium_not_blocking", func(t *testing.T) {
+		r := buildTamperReport("t1", "origin/main", []tamperChange{
+			{Status: "A", Path: "internal/foo/new_test.go", Patch: "@@ @@\n+func TestNew(t *testing.T){ require.NoError(t, err) }\n"},
+		})
+		if r.highCount() != 0 {
+			t.Fatalf("highCount = %d, want 0 (%v)", r.highCount(), r.Findings)
+		}
+		if len(r.Files) != 1 {
+			t.Errorf("Files = %v, want the changed test file recorded", r.Files)
+		}
+		if len(r.Findings) != 1 || r.Findings[0].Severity != tamperMedium {
+			t.Errorf("want one medium finding, got %v", r.Findings)
+		}
+	})
+
+	t.Run("tampering_mixes_high_and_skips_medium", func(t *testing.T) {
+		r := buildTamperReport("t1", "origin/main", []tamperChange{
+			{Status: "M", Path: "a_test.go", Patch: "@@ @@\n+\tt.Skip(\"x\")\n"},
+			{Status: "M", Path: "b_test.go", Patch: "@@ @@\n+\tfoo := 1\n"},
+		})
+		if r.highCount() != 1 {
+			t.Fatalf("highCount = %d, want 1 (%v)", r.highCount(), r.Findings)
+		}
+		// When a high finding fires, medium fallbacks are suppressed.
+		for _, f := range r.Findings {
+			if f.Severity == tamperMedium {
+				t.Errorf("unexpected medium finding alongside high: %v", f)
+			}
+		}
+	})
+}
+
+func TestParseNameStatus(t *testing.T) {
+	t.Parallel()
+	out := "M\tinternal/foo/foo.go\nD\tinternal/foo/foo_test.go\nR100\told/x_test.go\tnew/x_test.go\n\nA\tbar.go\n"
+	got := parseNameStatus(out)
+	want := []tamperChange{
+		{Status: "M", Path: "internal/foo/foo.go"},
+		{Status: "D", Path: "internal/foo/foo_test.go"},
+		{Status: "R100", Path: "new/x_test.go"},
+		{Status: "A", Path: "bar.go"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+// --- execDetectTampering integration tests (real git) ---
+
+func newTamperStep() *Step { return &Step{ID: "detect_tampering", Type: StepDetectTampering} }
+
+func TestBuiltinSimpleTaskImplement_DetectTamperingWiring(t *testing.T) {
+	t.Parallel()
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var impl *Definition
+	for i := range defs {
+		if defs[i].ID == "simple-task-implement" {
+			impl = &defs[i]
+			break
+		}
+	}
+	if impl == nil {
+		t.Fatal("simple-task-implement builtin not found")
+	}
+
+	tamper := impl.StepByID("detect_tampering")
+	if tamper == nil {
+		t.Fatal("detect_tampering step missing from simple-task-implement")
+	}
+	if tamper.Type != StepDetectTampering {
+		t.Errorf("detect_tampering type = %q, want %q", tamper.Type, StepDetectTampering)
+	}
+
+	// verify_commits default (no status condition) must route to detect_tampering.
+	vc := impl.StepByID("verify_commits")
+	if vc == nil {
+		t.Fatal("verify_commits step missing")
+	}
+	if got, _ := ResolveTransition(vc.Next, map[string]string{"task.status": "ready-review"}); got != "detect_tampering" {
+		t.Errorf("verify_commits default goto = %q, want detect_tampering", got)
+	}
+
+	cases := []struct {
+		name   string
+		status string
+		want   string
+	}{
+		{"flagged_ends_workflow", "human-required", ""},
+		{"clean_hands_off_to_review", "ready-review", "set_ready_review"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ResolveTransition(tamper.Next, map[string]string{"task.status": tc.status})
+			if err != nil {
+				t.Fatalf("ResolveTransition: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("goto = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func writeRepoFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	full := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// makeBaseRepo inits a repo with baseFiles committed as the origin/main state.
+func makeBaseRepo(t *testing.T, baseFiles map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	gitRun(t, dir, "init", "-b", "main")
+	gitRun(t, dir, "config", "user.email", "test@test.com")
+	gitRun(t, dir, "config", "user.name", "Test")
+	for path, content := range baseFiles {
+		writeRepoFile(t, dir, path, content)
+	}
+	gitRun(t, dir, "add", ".")
+	gitRun(t, dir, "commit", "-m", "init")
+	gitRun(t, dir, "remote", "add", "origin", dir)
+	gitRun(t, dir, "fetch", "origin")
+	return dir
+}
+
+func newTamperEngine(t *testing.T, wt string) (*Engine, *memTasks) {
+	t.Helper()
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wt, ok: true})
+	return engine, tasks
+}
+
+func TestExecDetectTampering_NoWorktreeSkips(t *testing.T) {
+	t.Parallel()
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+
+	out, err := engine.execDetectTampering("t1", newTamperStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output == "flagged" {
+		t.Errorf("no worktree must not flag; got %q", out.Output)
+	}
+}
+
+func TestExecDetectTampering_CleanImplChange(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	writeRepoFile(t, wt, "internal/foo/foo.go", "package foo\n\nfunc Foo() int { return 1 }\n")
+	gitRun(t, wt, "add", ".")
+	gitRun(t, wt, "commit", "-m", "feat: add foo")
+
+	engine, tasks := newTamperEngine(t, wt)
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execDetectTampering("t1", newTamperStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "clean" {
+		t.Errorf("Output = %q, want clean", out.Output)
+	}
+	if ti, _ := tasks.GetTask("t1"); ti.Status != "in-progress" {
+		t.Errorf("status = %q, want unchanged in-progress", ti.Status)
+	}
+}
+
+func TestExecDetectTampering_AddedSkipFlags(t *testing.T) {
+	t.Parallel()
+	base := "package foo\n\nimport \"testing\"\n\nfunc TestFoo(t *testing.T) {\n\tif Foo() != 1 {\n\t\tt.Errorf(\"bad\")\n\t}\n}\n"
+	wt := makeBaseRepo(t, map[string]string{
+		"README.md":                "init\n",
+		"internal/foo/foo.go":      "package foo\n\nfunc Foo() int { return 1 }\n",
+		"internal/foo/foo_test.go": base,
+	})
+	// Neuter the test with a skip.
+	tampered := "package foo\n\nimport \"testing\"\n\nfunc TestFoo(t *testing.T) {\n\tt.Skip(\"flaky\")\n\tif Foo() != 1 {\n\t\tt.Errorf(\"bad\")\n\t}\n}\n"
+	writeRepoFile(t, wt, "internal/foo/foo_test.go", tampered)
+	gitRun(t, wt, "commit", "-am", "test: skip foo")
+
+	engine, tasks := newTamperEngine(t, wt)
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execDetectTampering("t1", newTamperStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "flagged" {
+		t.Fatalf("Output = %q, want flagged", out.Output)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+	if reason := tasks.Reason("t1"); reason == "" {
+		t.Errorf("expected a non-empty status reason")
+	}
+}
+
+func TestExecDetectTampering_DeletedTestFlags(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{
+		"README.md":                "init\n",
+		"internal/foo/foo_test.go": "package foo\n\nimport \"testing\"\n\nfunc TestFoo(t *testing.T) { t.Errorf(\"x\") }\n",
+	})
+	gitRun(t, wt, "rm", "internal/foo/foo_test.go")
+	gitRun(t, wt, "commit", "-m", "chore: drop test")
+
+	engine, tasks := newTamperEngine(t, wt)
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execDetectTampering("t1", newTamperStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "flagged" {
+		t.Fatalf("Output = %q, want flagged", out.Output)
+	}
+	if ti, _ := tasks.GetTask("t1"); ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+}
+
+func TestExecDetectTampering_BenignTestAddDoesNotBlock(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n", "internal/foo/foo.go": "package foo\n\nfunc Foo() int { return 1 }\n"})
+	writeRepoFile(t, wt, "internal/foo/foo_test.go",
+		"package foo\n\nimport \"testing\"\n\nfunc TestFoo(t *testing.T) {\n\tif Foo() != 1 {\n\t\tt.Errorf(\"bad\")\n\t}\n}\n")
+	gitRun(t, wt, "add", ".")
+	gitRun(t, wt, "commit", "-m", "test: add coverage")
+
+	engine, tasks := newTamperEngine(t, wt)
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execDetectTampering("t1", newTamperStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "clean" {
+		t.Errorf("Output = %q, want clean (adding tests is not tampering)", out.Output)
+	}
+	if ti, _ := tasks.GetTask("t1"); ti.Status != "in-progress" {
+		t.Errorf("status = %q, want unchanged in-progress", ti.Status)
+	}
+}

--- a/internal/workflow/engine_steps_tamper_test.go
+++ b/internal/workflow/engine_steps_tamper_test.go
@@ -99,6 +99,36 @@ func TestScanTamperPatch(t *testing.T) {
 			patch:     "--- a/foo_test.go\n+++ b/foo_test.go\n@@ @@\n context\n",
 			wantRules: nil,
 		},
+		{
+			name:      "commented_out_assertion_counts_as_removal",
+			patch:     "@@ @@\n-\trequire.NoError(t, err)\n+\t// require.NoError(t, err)\n",
+			wantRules: []string{"removed-assertions"},
+		},
+		{
+			name:      "commented_out_test_func_counts_as_removal",
+			patch:     "@@ @@\n-func TestFoo(t *testing.T) {\n+// func TestFoo(t *testing.T) {\n",
+			wantRules: []string{"removed-test-cases"},
+		},
+		{
+			name:      "tautological_testify_equal",
+			patch:     "@@ @@\n-\trequire.Equal(t, want, got)\n+\trequire.Equal(t, got, got)\n",
+			wantRules: []string{"tautological-assertion"},
+		},
+		{
+			name:      "tautological_jest_tobe",
+			patch:     "@@ @@\n+\texpect(result).toBe(result)\n",
+			wantRules: []string{"tautological-assertion"},
+		},
+		{
+			name:      "tautological_python_assert",
+			patch:     "@@ @@\n+    assert value == value\n",
+			wantRules: []string{"tautological-assertion"},
+		},
+		{
+			name:      "removed_line_starting_with_dashes_not_header",
+			patch:     "@@ -1 +0,0 @@\n--- legacy bullet text\n",
+			wantRules: nil, // in-hunk content line (not a file header); no tokens → no finding
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -387,6 +417,139 @@ func TestExecDetectTampering_DeletedTestFlags(t *testing.T) {
 	}
 	if ti, _ := tasks.GetTask("t1"); ti.Status != "human-required" {
 		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+}
+
+func TestExecDetectTampering_BlessedTagShortCircuits(t *testing.T) {
+	t.Parallel()
+	base := "package foo\n\nimport \"testing\"\n\nfunc TestFoo(t *testing.T) {\n\tif Foo() != 1 {\n\t\tt.Errorf(\"bad\")\n\t}\n}\n"
+	wt := makeBaseRepo(t, map[string]string{
+		"README.md":                "init\n",
+		"internal/foo/foo.go":      "package foo\n\nfunc Foo() int { return 1 }\n",
+		"internal/foo/foo_test.go": base,
+	})
+	// Same tampering as the AddedSkip test, but the human has blessed it.
+	tampered := "package foo\n\nimport \"testing\"\n\nfunc TestFoo(t *testing.T) {\n\tt.Skip(\"flaky\")\n}\n"
+	writeRepoFile(t, wt, "internal/foo/foo_test.go", tampered)
+	gitRun(t, wt, "commit", "-am", "test: skip foo")
+
+	engine, tasks := newTamperEngine(t, wt)
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execDetectTampering("t1", newTamperStep(),
+		TaskInfo{ID: "t1", Tags: []string{"tamper-blessed"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "blessed" {
+		t.Errorf("Output = %q, want blessed (tag short-circuits the scan)", out.Output)
+	}
+	if ti, _ := tasks.GetTask("t1"); ti.Status != "in-progress" {
+		t.Errorf("status = %q, want unchanged (no block when blessed)", ti.Status)
+	}
+}
+
+func TestExecDetectTampering_CommentedOutTestFlags(t *testing.T) {
+	t.Parallel()
+	base := "package foo\n\nimport \"testing\"\n\nfunc TestFoo(t *testing.T) {\n\trequire.NoError(t, doThing())\n}\n"
+	wt := makeBaseRepo(t, map[string]string{
+		"README.md":                "init\n",
+		"internal/foo/foo_test.go": base,
+	})
+	// Comment out the assertion instead of fixing the code.
+	tampered := "package foo\n\nimport \"testing\"\n\nfunc TestFoo(t *testing.T) {\n\t// require.NoError(t, doThing())\n}\n"
+	writeRepoFile(t, wt, "internal/foo/foo_test.go", tampered)
+	gitRun(t, wt, "commit", "-am", "test: comment out")
+
+	engine, tasks := newTamperEngine(t, wt)
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execDetectTampering("t1", newTamperStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "flagged" {
+		t.Fatalf("Output = %q, want flagged (commenting out an assertion is tampering)", out.Output)
+	}
+	if ti, _ := tasks.GetTask("t1"); ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+}
+
+func TestExecDetectTampering_NeuteredCIFlags(t *testing.T) {
+	t.Parallel()
+	base := "name: ci\njobs:\n  test:\n    steps:\n      - run: go test ./...\n"
+	wt := makeBaseRepo(t, map[string]string{
+		"README.md":                "init\n",
+		".github/workflows/ci.yml": base,
+	})
+	tampered := "name: ci\njobs:\n  test:\n    continue-on-error: true\n    steps:\n      - run: go test ./...\n"
+	writeRepoFile(t, wt, ".github/workflows/ci.yml", tampered)
+	gitRun(t, wt, "commit", "-am", "ci: neuter")
+
+	engine, tasks := newTamperEngine(t, wt)
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execDetectTampering("t1", newTamperStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "flagged" {
+		t.Fatalf("Output = %q, want flagged (continue-on-error neuters the gate)", out.Output)
+	}
+}
+
+func TestBuiltinPRFix_DetectTamperingWiring(t *testing.T) {
+	t.Parallel()
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var prfix *Definition
+	for i := range defs {
+		if defs[i].ID == "pr-fix" {
+			prfix = &defs[i]
+			break
+		}
+	}
+	if prfix == nil {
+		t.Fatal("pr-fix builtin not found")
+	}
+	if prfix.StepByID("detect_tampering") == nil {
+		t.Fatal("detect_tampering step missing from pr-fix")
+	}
+	vc := prfix.StepByID("verify_commits")
+	if got, _ := ResolveTransition(vc.Next, map[string]string{"task.status": "in-progress"}); got != "detect_tampering" {
+		t.Errorf("pr-fix verify_commits default goto = %q, want detect_tampering", got)
+	}
+}
+
+func TestBuiltinSimpleTaskReview_DetectTamperingWiring(t *testing.T) {
+	t.Parallel()
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var rev *Definition
+	for i := range defs {
+		if defs[i].ID == "simple-task-review" {
+			rev = &defs[i]
+			break
+		}
+	}
+	if rev == nil {
+		t.Fatal("simple-task-review builtin not found")
+	}
+	tamper := rev.StepByID("detect_tampering")
+	if tamper == nil {
+		t.Fatal("detect_tampering step missing from simple-task-review")
+	}
+	fix := rev.StepByID("fix_review")
+	if got, _ := ResolveTransition(fix.Next, map[string]string{"task.status": "ready-review"}); got != "detect_tampering" {
+		t.Errorf("fix_review goto = %q, want detect_tampering", got)
+	}
+	if got, _ := ResolveTransition(tamper.Next, map[string]string{"task.status": "human-required"}); got != "" {
+		t.Errorf("flagged detect_tampering goto = %q, want end", got)
 	}
 }
 

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -88,6 +88,11 @@ const (
 	StepRequireSidecar      StepType = "require_sidecar"
 	StepValidatePlan        StepType = "validate_plan"
 	StepTriageReview        StepType = "triage_review"
+	// StepDetectTampering inspects the worktree diff for reward-hacking /
+	// test-tampering signals (deleted assertions, added skip/xfail markers,
+	// deleted test files, neutered CI). A high-severity finding flips the task
+	// to human-required so it cannot reach done without an explicit human bless.
+	StepDetectTampering StepType = "detect_tampering"
 	// StepRouteTestResult reads the test-runner verdict and routes the task:
 	// pass → ready-pr, fail → in-progress (re-implement) until the attempt
 	// cap is hit, then human-required.


### PR DESCRIPTION
## Motivation

Reward hacking is Sybra's least-defended agent failure mode. `verify`
today only counts commits ahead of `origin/main` — it cannot tell whether
an agent passed by solving the task or by gaming the checks (deleting a
test, adding `t.Skip`, commenting out an assertion, neutering CI). This
adds the mechanical diff-inspector layer of #1072 so a gamed change is
detected and cannot reach `done` without an explicit human bless.

> Changelog: feat(verify): detect test tampering

## Implementation information

New `detect_tampering` workflow step (`internal/workflow/engine_steps_tamper.go`):

- Runs `git diff --name-status base...HEAD`, classifies changed files
  (test / snapshot / fixture / CI / other), and scans the per-file
  patches of verification files for high-severity signals:
  added skip/xfail/`exit(0)`/`//go:build ignore`; commented-out or
  net-removed assertions and test cases; tautological self-comparisons
  (`Equal(t, got, got)`); deleted verification files; neutered CI gates
  (`continue-on-error: true`, `|| true`, `exit 0`).
- A high finding flips the task to `human-required` with the offending
  rules in the status reason; benign test edits are recorded in a
  `tamper-report.json` artifact (via the new `ArtifactRecorder.PutGeneric`)
  but do not block.
- Hunk-aware diff parsing (a content line beginning with `--`/`++` is not
  mistaken for a file header) and `core.quotePath=false` for unicode paths.
- A `tamper-blessed` tag short-circuits the scan so a human-accepted diff
  is not re-flagged on re-dispatch (no livelock). To accept a flagged
  change: add the `tamper-blessed` tag, then move the task back into flow.

Wired into the three paths where reward-hacking pressure exists —
`simple-task-implement` (after `verify_commits`), `simple-task-review`
(after `fix_review`), and `pr-fix` (after `verify_commits`). Each routes a
flagged task to `human-required` and ends the workflow before a PR opens.

Prompt floor added to the implementation and PR/review-fix prompts:
never weaken, skip, delete, comment out, or hardcode tests.

### Scope / follow-ups

- This is the diff-inspector layer only. Pure literal-value hardcoding
  (an expected `5` swapped to `4`) is undetectable from the diff alone;
  robust coverage comes from the **baseline-suite (Pass-to-Pass)**
  execution, which depends on the check-runner harness in #1058 and lands
  as a follow-up. The tautology check covers the common lazy case.
- Net-counting favors detection over false-negatives, so some legitimate
  refactors (moving assertions into a helper) may flag — the
  `tamper-blessed` escape hatch makes that a one-tag action.

## Supporting documentation

Closes #1072. Depends conceptually on #1058 for the deferred baseline-suite layer.

Table-driven unit tests cover path classification, every detection rule,
diff parsing edge cases, the bless escape, and the workflow wiring on all
three paths.