### PR TITLE
feat(watchdog): real-time off-rails supervision

### DIFF
--- a/internal/agent/inspector.go
+++ b/internal/agent/inspector.go
@@ -13,7 +13,10 @@ import (
 type InspectorVerdict struct {
 	Stuck          bool   `json:"stuck"`
 	Reason         string `json:"reason"`
-	Recommendation string `json:"recommendation"` // "stop" | "continue" | "escalate"
+	Recommendation string `json:"recommendation"` // "stop" | "continue" | "escalate" | "nudge"
+	// Nudge is the short corrective message the supervisor should deliver to the
+	// agent when Recommendation == "nudge". Empty for other recommendations.
+	Nudge string `json:"nudge,omitempty"`
 }
 
 // InspectInput holds the context handed to the inspector about the target agent.
@@ -23,6 +26,12 @@ type InspectInput struct {
 	LogPath   string
 	StallSec  int
 	TotalSec  int
+	// Trigger names why inspection fired ("stall", "budget", or "loop"), so the
+	// prompt can focus the judge. Empty is treated as a generic stall check.
+	Trigger string
+	// Model selects the judge model (e.g. a cheap "haiku" for routine checks).
+	// Empty falls back to "sonnet" for backwards compatibility.
+	Model string
 }
 
 // Inspect spawns `claude -p` to analyze a running agent's NDJSON log and return
@@ -36,11 +45,15 @@ func Inspect(ctx context.Context, logger *slog.Logger, in InspectInput) (Inspect
 
 	prompt := buildInspectorPrompt(in)
 
+	model := in.Model
+	if model == "" {
+		model = "sonnet"
+	}
 	cmd := exec.CommandContext(ctx, "claude",
 		"-p", prompt,
 		"--output-format", "json",
 		"--dangerously-skip-permissions",
-		"--model", "sonnet",
+		"--model", model,
 	)
 	out, err := cmd.Output()
 	if err != nil {
@@ -50,11 +63,16 @@ func Inspect(ctx context.Context, logger *slog.Logger, in InspectInput) (Inspect
 }
 
 func buildInspectorPrompt(in InspectInput) string {
+	trigger := in.Trigger
+	if trigger == "" {
+		trigger = "stall"
+	}
 	return fmt.Sprintf(`You are a watchdog inspecting a running Claude Code agent that may be stuck.
 
 Agent ID: %s
 Task: %s
-Stalled for: %d seconds (no new stream events)
+Inspection trigger: %s
+Time since last stream event: %d seconds
 Total runtime: %d seconds
 NDJSON log path: %s
 
@@ -65,13 +83,16 @@ Read the log file (last ~200 lines are most relevant). Look for:
 - No forward progress toward the task goal
 
 Output ONLY a single JSON object on the final line, nothing else:
-{"stuck": bool, "reason": "short explanation", "recommendation": "stop"|"continue"|"escalate"}
+{"stuck": bool, "reason": "short explanation", "recommendation": "stop"|"continue"|"escalate"|"nudge", "nudge": "corrective steer (only when recommendation is nudge)"}
 
 Recommendations:
-- "stop": agent is clearly looping/stuck, kill it
+- "stop": agent is clearly looping/stuck with no recovery, kill it
+- "nudge": agent is drifting but recoverable — set "nudge" to a one-sentence
+  steer that redirects it (e.g. "stop retrying the failing command; read the
+  error and fix the root cause first")
 - "escalate": ambiguous or needs human judgment, flag for human
 - "continue": agent is making progress, leave it alone`,
-		in.AgentID, in.TaskTitle, in.StallSec, in.TotalSec, in.LogPath)
+		in.AgentID, in.TaskTitle, trigger, in.StallSec, in.TotalSec, in.LogPath)
 }
 
 // parseInspectorOutput extracts the verdict from `claude -p --output-format json` stdout.
@@ -96,7 +117,7 @@ func parseInspectorOutput(raw []byte) (InspectorVerdict, error) {
 		return InspectorVerdict{}, fmt.Errorf("unmarshal verdict: %w", err)
 	}
 	switch v.Recommendation {
-	case "stop", "continue", "escalate":
+	case "stop", "continue", "escalate", "nudge":
 	default:
 		return InspectorVerdict{}, fmt.Errorf("invalid recommendation: %q", v.Recommendation)
 	}

--- a/internal/agent/inspector_test.go
+++ b/internal/agent/inspector_test.go
@@ -30,6 +30,11 @@ func TestParseInspectorOutput(t *testing.T) {
 			want: InspectorVerdict{Stuck: true, Reason: "ambiguous", Recommendation: "escalate"},
 		},
 		{
+			name: "nudge recommendation with steer",
+			raw:  `{"result":"{\"stuck\":false,\"reason\":\"retrying failing cmd\",\"recommendation\":\"nudge\",\"nudge\":\"read the error and fix the root cause\"}"}`,
+			want: InspectorVerdict{Stuck: false, Reason: "retrying failing cmd", Recommendation: "nudge", Nudge: "read the error and fix the root cause"},
+		},
+		{
 			name:    "invalid recommendation",
 			raw:     `{"result":"{\"stuck\":true,\"reason\":\"x\",\"recommendation\":\"kill\"}"}`,
 			wantErr: true,

--- a/internal/agent/loop_signature_test.go
+++ b/internal/agent/loop_signature_test.go
@@ -1,0 +1,110 @@
+package agent
+
+import "testing"
+
+func TestToolSignature(t *testing.T) {
+	bash := func(cmd string) ToolUseBlock {
+		return ToolUseBlock{Name: "Bash", Input: map[string]any{"command": cmd}}
+	}
+
+	t.Run("empty for no tools", func(t *testing.T) {
+		if got := toolSignature(nil); got != "" {
+			t.Fatalf("toolSignature(nil) = %q, want empty", got)
+		}
+	})
+
+	t.Run("identical calls share a signature", func(t *testing.T) {
+		a := toolSignature([]ToolUseBlock{bash("ls -la")})
+		b := toolSignature([]ToolUseBlock{bash("ls -la")})
+		if a == "" || a != b {
+			t.Fatalf("identical calls: %q vs %q, want equal non-empty", a, b)
+		}
+	})
+
+	t.Run("different input differs", func(t *testing.T) {
+		if toolSignature([]ToolUseBlock{bash("ls")}) == toolSignature([]ToolUseBlock{bash("pwd")}) {
+			t.Fatal("different commands hashed to the same signature")
+		}
+	})
+
+	t.Run("different tool name differs", func(t *testing.T) {
+		read := ToolUseBlock{Name: "Read", Input: map[string]any{"command": "ls"}}
+		if toolSignature([]ToolUseBlock{bash("ls")}) == toolSignature([]ToolUseBlock{read}) {
+			t.Fatal("different tool names hashed to the same signature")
+		}
+	})
+
+	t.Run("order independent within an event", func(t *testing.T) {
+		ab := toolSignature([]ToolUseBlock{bash("a"), bash("b")})
+		ba := toolSignature([]ToolUseBlock{bash("b"), bash("a")})
+		if ab != ba {
+			t.Fatalf("order changed signature: %q vs %q", ab, ba)
+		}
+	})
+}
+
+func TestAgentNoteToolSignature(t *testing.T) {
+	t.Run("repeats accumulate, new signature resets", func(t *testing.T) {
+		a := &Agent{}
+		if got := a.NoteToolSignature("x"); got != 1 {
+			t.Fatalf("first note streak = %d, want 1", got)
+		}
+		if got := a.NoteToolSignature("x"); got != 2 {
+			t.Fatalf("second note streak = %d, want 2", got)
+		}
+		if got := a.NoteToolSignature("x"); got != 3 {
+			t.Fatalf("third note streak = %d, want 3", got)
+		}
+		if got := a.NoteToolSignature("y"); got != 1 {
+			t.Fatalf("new signature streak = %d, want 1", got)
+		}
+		if got := a.ToolLoopStreak(); got != 1 {
+			t.Fatalf("ToolLoopStreak = %d, want 1", got)
+		}
+	})
+
+	t.Run("empty signature preserves the streak", func(t *testing.T) {
+		a := &Agent{}
+		a.NoteToolSignature("x")
+		a.NoteToolSignature("x") // streak 2
+		if got := a.NoteToolSignature(""); got != 2 {
+			t.Fatalf("empty note streak = %d, want 2 (unchanged)", got)
+		}
+		if got := a.NoteToolSignature("x"); got != 3 {
+			t.Fatalf("resumed streak = %d, want 3 (interleaved reasoning did not reset)", got)
+		}
+	})
+}
+
+func TestAgentToolLoopAcknowledge(t *testing.T) {
+	t.Run("ack suppresses the same signature until it changes", func(t *testing.T) {
+		a := &Agent{}
+		a.NoteToolSignature("x")
+		a.NoteToolSignature("x")
+		if a.ToolLoopAcknowledged() {
+			t.Fatal("unacknowledged before AckToolLoop")
+		}
+		a.AckToolLoop()
+		if !a.ToolLoopAcknowledged() {
+			t.Fatal("want acknowledged after AckToolLoop on same signature")
+		}
+		// Same signature keeps climbing but stays acknowledged.
+		a.NoteToolSignature("x")
+		if !a.ToolLoopAcknowledged() {
+			t.Fatal("same signature must stay acknowledged")
+		}
+		// A new loop signature re-arms the trigger.
+		a.NoteToolSignature("y")
+		if a.ToolLoopAcknowledged() {
+			t.Fatal("a different signature must clear the acknowledgement")
+		}
+	})
+
+	t.Run("ack on no signature is not acknowledged", func(t *testing.T) {
+		a := &Agent{}
+		a.AckToolLoop() // lastToolSig is "" — must not count as acknowledged
+		if a.ToolLoopAcknowledged() {
+			t.Fatal("empty signature must never read as acknowledged")
+		}
+	})
+}

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -64,6 +64,19 @@ type Agent struct {
 	// stats.RunRecord at completion so efficiency (tools per turn, tools per
 	// landed PR) can be measured. Tracked in-memory during the run.
 	ToolCalls int `json:"toolCalls,omitempty"`
+	// lastToolSig / toolLoopStreak track consecutive identical tool-call
+	// signatures so the watchdog can detect an agent looping on the same call
+	// in real time (it never stalls, so the stall trigger misses it). Guarded
+	// by mu; updated from the headless stream via NoteToolSignature.
+	lastToolSig    string
+	toolLoopStreak int
+	// loopAckSig is the signature the watchdog has already inspected and
+	// decided not to kill. While it equals lastToolSig the loop trigger is
+	// suppressed, so a cleared (or legitimately repetitive) loop is not
+	// re-inspected every debounce window — and a now-frozen high streak no
+	// longer masks the stall trigger. Cleared implicitly when the signature
+	// changes (a genuinely new loop re-arms the trigger).
+	loopAckSig string
 	// MaxTurns is the per-agent turn limit override; zero means use global guardrail.
 	MaxTurns int `json:"maxTurns,omitempty"`
 	// PluginErrors holds plugin load failures from the most recent init event.
@@ -382,6 +395,55 @@ func (a *Agent) GetToolCalls() int {
 	return a.ToolCalls
 }
 
+// NoteToolSignature feeds the next assistant event's tool-call signature into
+// the loop detector and returns the resulting consecutive-repeat streak. An
+// empty signature (an assistant turn with no tool calls — pure text/thinking)
+// carries no loop signal and leaves the streak untouched, so interleaved
+// reasoning between identical calls does not reset a genuine loop. A new
+// signature resets the streak to 1.
+func (a *Agent) NoteToolSignature(sig string) int {
+	if sig == "" {
+		a.mu.RLock()
+		defer a.mu.RUnlock()
+		return a.toolLoopStreak
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if sig == a.lastToolSig {
+		a.toolLoopStreak++
+	} else {
+		a.lastToolSig = sig
+		a.toolLoopStreak = 1
+	}
+	return a.toolLoopStreak
+}
+
+// ToolLoopStreak returns the current count of consecutive identical tool-call
+// signatures. A high value means the agent is repeating the same call.
+func (a *Agent) ToolLoopStreak() int {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.toolLoopStreak
+}
+
+// AckToolLoop records the current loop signature as already inspected, so the
+// watchdog does not re-trigger on the same unchanged loop. Called after a
+// loop-triggered inspection whose verdict left the agent running.
+func (a *Agent) AckToolLoop() {
+	a.mu.Lock()
+	a.loopAckSig = a.lastToolSig
+	a.mu.Unlock()
+}
+
+// ToolLoopAcknowledged reports whether the current loop signature has already
+// been inspected (and the agent left running). True suppresses the loop
+// trigger until the signature changes.
+func (a *Agent) ToolLoopAcknowledged() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.loopAckSig != "" && a.loopAckSig == a.lastToolSig
+}
+
 // SetEscalationReason updates the escalation reason string.
 func (a *Agent) SetEscalationReason(reason string) {
 	a.mu.Lock()
@@ -663,6 +725,11 @@ type StreamEvent struct {
 	// in a Claude assistant turn, or a single Codex tool_use. The runner
 	// accumulates these into Agent.ToolCalls.
 	ToolCalls int `json:"tool_calls,omitempty"`
+	// toolSig is a canonical fingerprint of this event's tool calls (name +
+	// input), used by the watchdog's real-time loop detector to spot an agent
+	// repeating the same call. Unexported so it is never serialized to the
+	// NDJSON log or emitted to the frontend; it lives only in memory.
+	toolSig string
 }
 
 // ConvoEvent is a rich event for conversational mode, preserving full tool

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -493,6 +493,10 @@ func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte
 	event.Timestamp = time.Now().UTC()
 	a.AppendOutput(event)
 	a.AddToolCalls(event.ToolCalls)
+	// Feed the tool-call fingerprint into the real-time loop detector. An empty
+	// signature (non-tool event) is a no-op, so the streak survives reasoning
+	// between identical calls and the watchdog can spot an active loop.
+	a.NoteToolSignature(event.toolSig)
 	if event.Type == "result" || time.Since(*lastEmit) >= headlessEmitInterval {
 		m.emit(events.AgentOutput(a.ID), event)
 		*lastEmit = time.Now()

--- a/internal/agent/runner_headless_stream.go
+++ b/internal/agent/runner_headless_stream.go
@@ -1,9 +1,42 @@
 package agent
 
 import (
+	"encoding/json"
 	"fmt"
+	"hash/fnv"
+	"slices"
+	"strconv"
 	"strings"
 )
+
+// toolSignature returns a canonical fingerprint of a set of tool calls (each
+// tool's name plus its JSON-canonicalized input), order-independent, or "" when
+// there are no tool calls. The watchdog's loop detector compares consecutive
+// signatures to spot an agent repeating the same call. json.Marshal sorts map
+// keys, so the same call always hashes identically.
+func toolSignature(toolUses []ToolUseBlock) string {
+	if len(toolUses) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(toolUses))
+	for i := range toolUses {
+		var b strings.Builder
+		b.WriteString(toolUses[i].Name)
+		if toolUses[i].Input != nil {
+			if raw, err := json.Marshal(toolUses[i].Input); err == nil {
+				b.Write(raw)
+			}
+		}
+		parts = append(parts, b.String())
+	}
+	slices.Sort(parts)
+	h := fnv.New64a()
+	for _, p := range parts {
+		_, _ = h.Write([]byte(p))
+		_, _ = h.Write([]byte{0})
+	}
+	return strconv.FormatUint(h.Sum64(), 16)
+}
 
 // claudeEventToStreamEvent converts a shared ClaudeEvent into a StreamEvent
 // for the headless runner. Tool uses are formatted as "[name] cmd/desc" strings.
@@ -18,6 +51,7 @@ func claudeEventToStreamEvent(e ClaudeEvent) StreamEvent {
 			ev.Content = formatHeadlessAssistant(e.Message)
 			ev.PlanSteps = extractTodoWriteSteps(e.Message.ToolUses)
 			ev.ToolCalls = len(e.Message.ToolUses)
+			ev.toolSig = toolSignature(e.Message.ToolUses)
 		}
 	case "user":
 		if e.Message != nil {
@@ -89,6 +123,7 @@ func codexEventToStreamEvent(e CodexEvent) StreamEvent {
 			cmd, _ := e.Message.ToolUses[0].Input["command"].(string)
 			ev.Content = cmd
 			ev.ToolCalls = len(e.Message.ToolUses)
+			ev.toolSig = toolSignature(e.Message.ToolUses)
 		}
 	case "tool_result":
 		if e.Message != nil && len(e.Message.ToolResults) > 0 {
@@ -128,6 +163,8 @@ func copilotEventToStreamEvent(e CopilotEvent) StreamEvent {
 		if e.Message != nil && len(e.Message.ToolUses) > 0 {
 			cmd, _ := e.Message.ToolUses[0].Input["command"].(string)
 			ev.Content = cmd
+			ev.ToolCalls = len(e.Message.ToolUses)
+			ev.toolSig = toolSignature(e.Message.ToolUses)
 		}
 	case "tool_result":
 		if e.Message != nil && len(e.Message.ToolResults) > 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Triage        TriageConfig       `yaml:"triage" json:"triage"`
 	HumanReview   HumanReviewConfig  `yaml:"human_review" json:"humanReview"`
 	Monitor       MonitorConfig      `yaml:"monitor" json:"monitor"`
+	Watchdog      WatchdogConfig     `yaml:"watchdog" json:"watchdog"`
 	SelfMonitor   SelfMonitorConfig  `yaml:"self_monitor" json:"selfMonitor"`
 	Evaluation    EvaluationConfig   `yaml:"evaluation" json:"evaluation"`
 	Providers     ProvidersConfig    `yaml:"providers" json:"providers"`
@@ -363,6 +364,19 @@ type MonitorConfig struct {
 	IssueRepo            string             `yaml:"issue_repo" json:"issueRepo"`
 }
 
+// WatchdogConfig controls the in-process agent watchdog (internal/watchdog),
+// which supervises running headless agents: it triggers a cheap LLM inspection
+// when an agent stalls, overruns its size budget, or loops on the same tool
+// call (real-time loop detection), then stops/escalates/nudges based on the
+// verdict. Enabled defaults to true — the watchdog is an always-on safety net,
+// not an opt-in automation. Model selects the cheap judge model; LoopThreshold
+// is the number of consecutive identical tool-call signatures that flags a loop.
+type WatchdogConfig struct {
+	Enabled       bool   `yaml:"enabled" json:"enabled"`
+	Model         string `yaml:"model" json:"model"`
+	LoopThreshold int    `yaml:"loop_threshold" json:"loopThreshold"`
+}
+
 // EvaluationConfig controls the in-process evaluation service, which periodically
 // computes a fleet scorecard (autonomy, throughput, reliability, efficiency) from
 // stats + audit data. Read-only: it never dispatches agents or files issues, so
@@ -439,6 +453,10 @@ func DefaultConfig() *Config {
 		},
 		Monitor: MonitorConfig{
 			Enabled: true,
+		},
+		Watchdog: WatchdogConfig{
+			Enabled:       true,
+			LoopThreshold: 6,
 		},
 		Providers: ProvidersConfig{
 			HealthCheck: ProviderHealthCheckConfig{
@@ -563,10 +581,24 @@ func Load() (*Config, error) {
 
 	applyProvidersDefaults(cfg)
 	applyMonitorDefaults(cfg)
+	applyWatchdogDefaults(cfg)
 	applySelfMonitorDefaults(cfg)
 	applyEvaluationDefaults(cfg)
 
 	return cfg, nil
+}
+
+// applyWatchdogDefaults fills the Watchdog model default. Enabled and
+// LoopThreshold are seeded by DefaultConfig (true / 6), so a config missing the
+// watchdog block keeps the always-on default while an explicit `enabled: false`
+// or `loop_threshold: 0` survives — the latter being the documented way to keep
+// the watchdog running with the real-time loop trigger off. LoopThreshold is
+// deliberately NOT defaulted here so an explicit 0 is not clobbered back to 6.
+func applyWatchdogDefaults(cfg *Config) {
+	w := &cfg.Watchdog
+	if w.Model == "" {
+		w.Model = "claude-haiku-4-5-20251001"
+	}
 }
 
 // applyEvaluationDefaults fills zero values for the Evaluation block so older

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -114,6 +114,60 @@ func TestLoadMonitorDispatchLimitPreservesOverride(t *testing.T) {
 	}
 }
 
+func TestLoadWatchdogDefaults(t *testing.T) {
+	tests := []struct {
+		name          string
+		yaml          string
+		wantEnabled   bool
+		wantThreshold int
+		wantModel     string
+	}{
+		{
+			name:          "missing block keeps always-on defaults",
+			yaml:          "agent:\n  max_concurrent: 10\n",
+			wantEnabled:   true,
+			wantThreshold: 6,
+			wantModel:     "claude-haiku-4-5-20251001",
+		},
+		{
+			name:          "explicit loop_threshold 0 disables loop detection",
+			yaml:          "watchdog:\n  enabled: true\n  loop_threshold: 0\n",
+			wantEnabled:   true,
+			wantThreshold: 0,
+			wantModel:     "claude-haiku-4-5-20251001",
+		},
+		{
+			name:          "explicit overrides preserved",
+			yaml:          "watchdog:\n  enabled: false\n  loop_threshold: 3\n  model: sonnet\n",
+			wantEnabled:   false,
+			wantThreshold: 3,
+			wantModel:     "sonnet",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("SYBRA_HOME", dir)
+			if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(tc.yaml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.Watchdog.Enabled != tc.wantEnabled {
+				t.Errorf("Enabled = %v, want %v", cfg.Watchdog.Enabled, tc.wantEnabled)
+			}
+			if cfg.Watchdog.LoopThreshold != tc.wantThreshold {
+				t.Errorf("LoopThreshold = %d, want %d", cfg.Watchdog.LoopThreshold, tc.wantThreshold)
+			}
+			if cfg.Watchdog.Model != tc.wantModel {
+				t.Errorf("Model = %q, want %q", cfg.Watchdog.Model, tc.wantModel)
+			}
+		})
+	}
+}
+
 func TestLoadEnvOverride(t *testing.T) {
 	t.Setenv("SYBRA_HOME", t.TempDir())
 	t.Setenv("SYBRA_LOG_LEVEL", "error")

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -39,8 +39,12 @@ func newLifecycleManager(app *App) *LifecycleManager {
 func (lm *LifecycleManager) StartManagers(ctx context.Context, emit func(string, any)) {
 	a := lm.app
 
-	wdog := watchdog.New(a.agents, a.tasks, a.logger, emit, &a.wg)
-	a.wg.Go(func() { wdog.Run(ctx) })
+	if a.cfg.Watchdog.Enabled {
+		wdog := watchdog.New(a.agents, a.tasks, a.logger, emit, &a.wg, a.cfg.Watchdog)
+		a.wg.Go(func() { wdog.Run(ctx) })
+	} else {
+		a.logger.Info("watchdog.disabled")
+	}
 
 	hcheck := health.New(a.cfg.AuditDir(), a.tasks, config.HomeDir(), a.logger, emit)
 	a.wg.Go(func() { hcheck.Run(ctx) })

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/events"
 	"github.com/Automaat/sybra/internal/task"
 )
@@ -63,7 +64,9 @@ func (s *state) shouldInspect(id string, now time.Time) bool {
 	return true
 }
 
-// Watchdog monitors headless agents for stalls and budget overruns.
+// Watchdog monitors headless agents for stalls, budget overruns, and tool-call
+// loops, inspecting suspect agents with a cheap judge and stopping, nudging, or
+// escalating based on the verdict.
 type Watchdog struct {
 	agents *agent.Manager
 	tasks  *task.Manager
@@ -71,26 +74,41 @@ type Watchdog struct {
 	emit   func(string, any)
 	wg     *sync.WaitGroup
 
+	// model is the judge model passed to the inspector (e.g. a cheap "haiku").
+	model string
+	// loopThreshold is the consecutive identical tool-call count that flags an
+	// agent as looping. Zero disables the real-time loop trigger.
+	loopThreshold int
+
 	inspectAgent func(context.Context, *slog.Logger, agent.InspectInput) (agent.InspectorVerdict, error)
 	stopAgent    func(string) error
+	// nudgeAgent delivers a corrective steer to a live agent. Returns an error
+	// for agents with no live transport (headless has no mid-stream stdin), in
+	// which case applyVerdict degrades the nudge to an escalate.
+	nudgeAgent func(agentID, text string) error
 }
 
-// New creates a Watchdog.
+// New creates a Watchdog. cfg.Model selects the cheap judge model and
+// cfg.LoopThreshold tunes the real-time loop trigger.
 func New(
 	agents *agent.Manager,
 	tasks *task.Manager,
 	logger *slog.Logger,
 	emit func(string, any),
 	wg *sync.WaitGroup,
+	cfg config.WatchdogConfig,
 ) *Watchdog {
 	return &Watchdog{
-		agents:       agents,
-		tasks:        tasks,
-		logger:       logger,
-		emit:         emit,
-		wg:           wg,
-		inspectAgent: agent.Inspect,
-		stopAgent:    agents.StopAgent,
+		agents:        agents,
+		tasks:         tasks,
+		logger:        logger,
+		emit:          emit,
+		wg:            wg,
+		model:         cfg.Model,
+		loopThreshold: cfg.LoopThreshold,
+		inspectAgent:  agent.Inspect,
+		stopAgent:     agents.StopAgent,
+		nudgeAgent:    agents.SendPromptToAgent,
 	}
 }
 
@@ -137,13 +155,7 @@ func (w *Watchdog) tick(ctx context.Context, s *state, now time.Time) {
 			sl = stallLimit(nil)
 		}
 
-		trigger := ""
-		switch {
-		case stall > sl:
-			trigger = "stall"
-		case total > budget:
-			trigger = "budget"
-		}
+		trigger := decideTrigger(ag.ToolLoopStreak(), w.loopThreshold, ag.ToolLoopAcknowledged(), stall, sl, total, budget)
 		if trigger == "" {
 			continue
 		}
@@ -153,13 +165,34 @@ func (w *Watchdog) tick(ctx context.Context, s *state, now time.Time) {
 
 		w.logger.Info("agent.watchdog.inspect",
 			"id", ag.ID, "trigger", trigger,
+			"loop_streak", ag.ToolLoopStreak(),
 			"stall_sec", int(stall.Seconds()), "total_sec", int(total.Seconds()))
 
-		w.wg.Go(func() { w.inspect(ctx, ag, t, int(stall.Seconds()), int(total.Seconds())) })
+		w.wg.Go(func() { w.inspect(ctx, ag, t, trigger, int(stall.Seconds()), int(total.Seconds())) })
 	}
 }
 
-func (w *Watchdog) inspect(ctx context.Context, ag *agent.Agent, t task.Task, stallSec, totalSec int) {
+// decideTrigger selects the inspection trigger for an agent, or "" when none
+// fires. The loop trigger takes precedence — an actively looping agent never
+// stalls, so catching the loop early is the whole point — but only while the
+// loop is unacknowledged: once a loop has been inspected and cleared, loopAcked
+// suppresses it so the same unchanged loop neither re-storms the judge nor
+// masks the stall trigger for a now-frozen agent. A non-positive loopThreshold
+// disables loop detection.
+func decideTrigger(loopStreak, loopThreshold int, loopAcked bool, stall, stallLim, total, budget time.Duration) string {
+	switch {
+	case loopThreshold > 0 && loopStreak >= loopThreshold && !loopAcked:
+		return "loop"
+	case stall > stallLim:
+		return "stall"
+	case total > budget:
+		return "budget"
+	default:
+		return ""
+	}
+}
+
+func (w *Watchdog) inspect(ctx context.Context, ag *agent.Agent, t task.Task, trigger string, stallSec, totalSec int) {
 	ictx, cancel := context.WithTimeout(ctx, InspectTimeout)
 	defer cancel()
 
@@ -169,6 +202,8 @@ func (w *Watchdog) inspect(ctx context.Context, ag *agent.Agent, t task.Task, st
 		LogPath:   ag.GetLogPath(),
 		StallSec:  stallSec,
 		TotalSec:  totalSec,
+		Trigger:   trigger,
+		Model:     w.model,
 	})
 	if err != nil {
 		w.logger.Warn("agent.watchdog.inspect.failed", "id", ag.ID, "err", err)
@@ -181,6 +216,15 @@ func (w *Watchdog) inspect(ctx context.Context, ag *agent.Agent, t task.Task, st
 
 	w.emit(events.AgentStuck(ag.ID), verdict)
 	w.applyVerdict(ag, verdict)
+
+	// Acknowledge a loop-triggered inspection that left the agent running, so the
+	// same unchanged signature does not re-trigger every debounce window. Skip
+	// the ack on a "stop" verdict: if the stop fails the agent keeps looping, and
+	// acking would suppress the next inspection that could retry the stop. A
+	// genuinely new loop (different signature) re-arms the trigger automatically.
+	if trigger == "loop" && verdict.Recommendation != "stop" {
+		ag.AckToolLoop()
+	}
 }
 
 func (w *Watchdog) applyVerdict(ag *agent.Agent, verdict agent.InspectorVerdict) {
@@ -204,6 +248,27 @@ func (w *Watchdog) applyVerdict(ag *agent.Agent, verdict agent.InspectorVerdict)
 		if err := w.stopAgent(ag.ID); err != nil {
 			w.logger.Error("agent.watchdog.stop.failed", "id", ag.ID, "err", err)
 		}
+	case "nudge":
+		// Deliver a corrective steer to a live agent and leave it running. Only
+		// agents with a live transport (interactive/conversational) can be
+		// nudged mid-stream; a headless agent has no stdin, so SendPromptToAgent
+		// errors and the nudge degrades to an advisory escalate (leave running,
+		// debounce suppresses re-check). Headless nudge via stop+resume is
+		// tracked separately.
+		steer := verdict.Nudge
+		if steer == "" {
+			steer = verdict.Reason
+		}
+		if w.nudgeAgent == nil {
+			w.logger.Warn("agent.watchdog.nudge.unwired", "id", ag.ID)
+			return
+		}
+		if err := w.nudgeAgent(ag.ID, "⚠️ Supervisor: "+steer); err != nil {
+			w.logger.Warn("agent.watchdog.nudge.degraded",
+				"id", ag.ID, "err", err, "steer", steer)
+			return
+		}
+		w.logger.Info("agent.watchdog.nudge", "id", ag.ID, "steer", steer)
 	case "escalate":
 		// Ambiguous verdicts are advisory only. Flipping the task to
 		// human-required while the agent keeps running leaves task status

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -1,6 +1,8 @@
 package watchdog
 
 import (
+	"context"
+	"errors"
 	"log/slog"
 	"testing"
 	"time"
@@ -89,6 +91,136 @@ func TestApplyVerdict_StopSetsReasonAndStopsAgent(t *testing.T) {
 	}
 	if !stopped {
 		t.Fatal("stopAgent not called on stop verdict")
+	}
+}
+
+func TestDecideTrigger(t *testing.T) {
+	const (
+		sl     = 15 * time.Minute
+		budget = 45 * time.Minute
+		thresh = 6
+	)
+	tests := []struct {
+		name              string
+		streak, threshold int
+		acked             bool
+		stall, total      time.Duration
+		want              string
+	}{
+		{"none", 1, thresh, false, time.Minute, time.Minute, ""},
+		{"loop over threshold", thresh, thresh, false, time.Minute, time.Minute, "loop"},
+		{"loop below threshold", thresh - 1, thresh, false, time.Minute, time.Minute, ""},
+		{"loop disabled by zero threshold", 100, 0, false, time.Minute, time.Minute, ""},
+		{"loop wins over stall", thresh, thresh, false, 30 * time.Minute, time.Minute, "loop"},
+		{"acked loop suppressed, none left", thresh, thresh, true, time.Minute, time.Minute, ""},
+		{"acked loop falls through to stall", thresh, thresh, true, 30 * time.Minute, time.Minute, "stall"},
+		{"stall", 0, thresh, false, 20 * time.Minute, time.Minute, "stall"},
+		{"budget", 0, thresh, false, time.Minute, time.Hour, "budget"},
+		{"stall wins over budget", 0, thresh, false, 20 * time.Minute, time.Hour, "stall"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decideTrigger(tc.streak, tc.threshold, tc.acked, tc.stall, sl, tc.total, budget)
+			if got != tc.want {
+				t.Fatalf("decideTrigger = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestApplyVerdict_NudgeDeliversAndLeavesRunning covers the live-transport
+// delivery path. In production the watchdog only inspects headless agents,
+// which have no live transport, so the real path today is the degrade in
+// TestApplyVerdict_NudgeDegradesWhenNoTransport; this test guards the delivery
+// wiring used once interactive/conversational agents are supervised (#1105).
+func TestApplyVerdict_NudgeDeliversAndLeavesRunning(t *testing.T) {
+	tasks, tk := newTestTasks(t)
+
+	var nudged string
+	stopped := false
+	w := &Watchdog{
+		tasks:      tasks,
+		logger:     slog.New(slog.DiscardHandler),
+		stopAgent:  func(string) error { stopped = true; return nil },
+		nudgeAgent: func(_, text string) error { nudged = text; return nil },
+	}
+
+	w.applyVerdict(&agent.Agent{ID: "a1", TaskID: tk.ID}, agent.InspectorVerdict{
+		Recommendation: "nudge",
+		Reason:         "drifting",
+		Nudge:          "fix the root cause first",
+	})
+
+	if nudged != "⚠️ Supervisor: fix the root cause first" {
+		t.Fatalf("nudge message = %q", nudged)
+	}
+	if stopped {
+		t.Fatal("stopAgent called on nudge verdict")
+	}
+	got, _ := tasks.Get(tk.ID)
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("status = %q, want in-progress (nudge must not flip status)", got.Status)
+	}
+}
+
+func TestApplyVerdict_NudgeDegradesWhenNoTransport(t *testing.T) {
+	tasks, tk := newTestTasks(t)
+
+	stopped := false
+	w := &Watchdog{
+		tasks:      tasks,
+		logger:     slog.New(slog.DiscardHandler),
+		stopAgent:  func(string) error { stopped = true; return nil },
+		nudgeAgent: func(_, _ string) error { return errors.New("no active transport") },
+	}
+
+	w.applyVerdict(&agent.Agent{ID: "a1", TaskID: tk.ID}, agent.InspectorVerdict{
+		Recommendation: "nudge",
+		Reason:         "drifting",
+	})
+
+	// A headless agent cannot be nudged mid-stream; the nudge degrades to an
+	// advisory no-op — the agent keeps running and the task is untouched.
+	if stopped {
+		t.Fatal("stopAgent called when nudge degraded")
+	}
+	got, _ := tasks.Get(tk.ID)
+	if got.Status != task.StatusInProgress || got.StatusReason != "" {
+		t.Fatalf("status=%q reason=%q, want in-progress with no reason", got.Status, got.StatusReason)
+	}
+}
+
+func TestInspect_LoopAckOnlyWhenLeftRunning(t *testing.T) {
+	tests := []struct {
+		name    string
+		verdict string
+		wantAck bool
+	}{
+		{"continue acks the loop", "continue", true},
+		{"escalate acks the loop", "escalate", true},
+		{"stop does not ack (stop may fail, keep inspecting)", "stop", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tasks, tk := newTestTasks(t)
+			w := &Watchdog{
+				tasks:     tasks,
+				logger:    slog.New(slog.DiscardHandler),
+				emit:      func(string, any) {},
+				stopAgent: func(string) error { return nil },
+				inspectAgent: func(context.Context, *slog.Logger, agent.InspectInput) (agent.InspectorVerdict, error) {
+					return agent.InspectorVerdict{Recommendation: tc.verdict, Reason: "x"}, nil
+				},
+			}
+			ag := &agent.Agent{ID: "a1", TaskID: tk.ID}
+			ag.NoteToolSignature("sig") // arm a loop signature
+
+			w.inspect(context.Background(), ag, tk, "loop", 1, 1)
+
+			if got := ag.ToolLoopAcknowledged(); got != tc.wantAck {
+				t.Fatalf("ToolLoopAcknowledged after %q = %v, want %v", tc.verdict, got, tc.wantAck)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Motivation

The agent watchdog only inspected a running agent on **stall** (no events for N
minutes) or **budget** (runtime over the size budget). An agent that is
*actively* looping — repeating the same tool call — never stalls, so it slipped
past until the budget cap, burning cost. This adds a real-time, cheap-model
supervisor on top of the existing watchdog so loops are caught promptly and a
recoverable agent can be steered, not just stopped.

Closes #1104

> Changelog: feat(watchdog): real-time off-rails supervision with cheap judge

## Implementation information

Two tiers, layered onto `internal/watchdog` (no new package):

- **Tier 1 — deterministic loop trigger.** `internal/agent` tracks consecutive
  identical tool-call signatures from the headless stream (a canonical hash of
  each event's tool name + JSON-sorted input, carried on an unexported
  `StreamEvent` field so logs/frontend are untouched). The watchdog adds a
  `loop` trigger when the streak crosses `LoopThreshold`. An interleaved
  non-tool turn (thinking) is a no-op, so reasoning between identical calls does
  not reset a real loop. Once a loop is inspected and the verdict leaves the
  agent running, the signature is acknowledged so the same unchanged loop does
  not re-inspect every debounce window — and no longer masks the stall trigger
  if the agent later freezes. A different signature re-arms the trigger.

- **Tier 2 — cheap judge.** `agent.Inspect` takes a configurable model (empty →
  `sonnet`, for back-compat). New `config.WatchdogConfig{Enabled, Model,
  LoopThreshold}` defaults the judge to `claude-haiku-4-5-20251001`. `Enabled`
  and `LoopThreshold` are seeded in `DefaultConfig`, so a config missing the
  block stays always-on at threshold 6 while an explicit `loop_threshold: 0`
  disables only the loop trigger.

- **Intervention — `nudge`.** The verdict gains a `nudge` recommendation plus a
  steer string, delivered via `Manager.SendPromptToAgent`. Headless agents have
  no mid-stream stdin, so a nudge there degrades to an advisory escalate
  (leaves the agent running). Real headless nudge via stop+resume-with-steer is
  tracked as #1105.

Tests cover signature canonicalization, streak/ack behavior, trigger
precedence, the `0`-disables-loop config contract, and verdict/nudge handling.

## Supporting documentation

- Existing watchdog: `internal/watchdog/agent.go`, `internal/agent/inspector.go`
- Headless stream: `internal/agent/runner_headless.go`, `runner_headless_stream.go`
- Follow-up: #1105
