### PR TITLE
fix(reviews): sticky conflict stops lane flap

### DIFF
--- a/internal/sybra/app_reviews_inbound.go
+++ b/internal/sybra/app_reviews_inbound.go
@@ -265,8 +265,8 @@ func (r *ReviewHandler) reconcileReviewTask(t *task.Task, requested, approved ma
 			mergeable = st.Mergeable
 		}
 	}
-	if mergeable == "CONFLICTING" {
-		r.applyReviewPhase(t, computeReviewPhase(reviewSignals{Mergeable: mergeable}))
+	if res, decided := stickyConflictPhase(mergeable, t.ReviewPhase); decided {
+		r.applyReviewPhase(t, res)
 		return
 	}
 

--- a/internal/sybra/review_phase.go
+++ b/internal/sybra/review_phase.go
@@ -50,6 +50,33 @@ type reviewPhaseResult struct {
 	Reason string
 }
 
+// stickyConflictPhase applies hysteresis to GitHub's noisy mergeability signal
+// so a conflicting PR can't flap out of the conflict phase. GitHub recomputes
+// mergeability asynchronously and reports UNKNOWN (or "") while a PR's base
+// branch is moving, so a genuinely-conflicting PR briefly looks non-conflicting
+// on any poll that catches that window. Conflict is the lane's most actionable
+// fact — the PR can't land until the author rebases — so it's sticky: only a
+// definitive MERGEABLE clears it.
+//
+// decided is true when mergeability settles the phase (the caller applies res
+// and stops); false means "not conflicting — fall through to the viewer-state
+// phase computation".
+func stickyConflictPhase(mergeable, currentPhase string) (res reviewPhaseResult, decided bool) {
+	switch mergeable {
+	case "CONFLICTING":
+		return computeReviewPhase(reviewSignals{Mergeable: "CONFLICTING"}), true
+	case "", "UNKNOWN":
+		// Indeterminate read: hold an existing conflict rather than flapping out
+		// of it. If the task isn't already conflict, let viewer state win.
+		if currentPhase == ReviewPhaseConflict {
+			return computeReviewPhase(reviewSignals{Mergeable: "CONFLICTING"}), true
+		}
+		return reviewPhaseResult{}, false
+	default: // MERGEABLE — definitively clears any prior conflict.
+		return reviewPhaseResult{}, false
+	}
+}
+
 // computeReviewPhase maps live PR signals to the desired review phase and
 // status. Pure and table-tested; the poller wraps it to apply only the deltas
 // (see reconcileReviewPhases).

--- a/internal/sybra/review_phase.go
+++ b/internal/sybra/review_phase.go
@@ -65,14 +65,17 @@ func stickyConflictPhase(mergeable, currentPhase string) (res reviewPhaseResult,
 	switch mergeable {
 	case "CONFLICTING":
 		return computeReviewPhase(reviewSignals{Mergeable: "CONFLICTING"}), true
-	case "", "UNKNOWN":
-		// Indeterminate read: hold an existing conflict rather than flapping out
-		// of it. If the task isn't already conflict, let viewer state win.
+	case "MERGEABLE":
+		// The only definitive non-conflict: clears any prior conflict and falls
+		// through to the viewer-state phase computation.
+		return reviewPhaseResult{}, false
+	default:
+		// Indeterminate read — UNKNOWN, "", or any unexpected/new state GitHub
+		// might return: hold an existing conflict rather than flapping out of it.
+		// If the task isn't already conflict, let viewer state win.
 		if currentPhase == ReviewPhaseConflict {
 			return computeReviewPhase(reviewSignals{Mergeable: "CONFLICTING"}), true
 		}
-		return reviewPhaseResult{}, false
-	default: // MERGEABLE — definitively clears any prior conflict.
 		return reviewPhaseResult{}, false
 	}
 }

--- a/internal/sybra/review_phase_test.go
+++ b/internal/sybra/review_phase_test.go
@@ -98,6 +98,8 @@ func TestStickyConflictPhase(t *testing.T) {
 		{"unknown does not invent a conflict", "UNKNOWN", ReviewPhaseAwaitingAuthor, false, ""},
 		{"empty does not invent a conflict", "", ReviewPhaseDrafted, false, ""},
 		{"mergeable clears a prior conflict", "MERGEABLE", ReviewPhaseConflict, false, ""},
+		{"unexpected state holds an existing conflict", "SOME_NEW_STATE", ReviewPhaseConflict, true, ReviewPhaseConflict},
+		{"unexpected state does not invent a conflict", "SOME_NEW_STATE", ReviewPhaseDrafted, false, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/sybra/review_phase_test.go
+++ b/internal/sybra/review_phase_test.go
@@ -84,6 +84,34 @@ func TestComputeReviewPhase(t *testing.T) {
 	}
 }
 
+func TestStickyConflictPhase(t *testing.T) {
+	tests := []struct {
+		name         string
+		mergeable    string
+		currentPhase string
+		wantDecided  bool
+		wantPhase    string
+	}{
+		{"definitive conflict decides over any current phase", "CONFLICTING", ReviewPhaseDrafted, true, ReviewPhaseConflict},
+		{"unknown holds an existing conflict", "UNKNOWN", ReviewPhaseConflict, true, ReviewPhaseConflict},
+		{"empty holds an existing conflict", "", ReviewPhaseConflict, true, ReviewPhaseConflict},
+		{"unknown does not invent a conflict", "UNKNOWN", ReviewPhaseAwaitingAuthor, false, ""},
+		{"empty does not invent a conflict", "", ReviewPhaseDrafted, false, ""},
+		{"mergeable clears a prior conflict", "MERGEABLE", ReviewPhaseConflict, false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, decided := stickyConflictPhase(tt.mergeable, tt.currentPhase)
+			if decided != tt.wantDecided {
+				t.Fatalf("decided = %v, want %v", decided, tt.wantDecided)
+			}
+			if decided && res.Phase != tt.wantPhase {
+				t.Errorf("phase = %q, want %q", res.Phase, tt.wantPhase)
+			}
+		})
+	}
+}
+
 func TestReviewPhasePublished(t *testing.T) {
 	tests := []struct {
 		prev, next string


### PR DESCRIPTION
## Motivation

Tasks in the **To Review** lane were flapping — their phase changed back and
forth every poll cycle (`conflict ↔ drafted`, `conflict ↔ awaiting-author`).

Root cause: GitHub computes PR mergeability **asynchronously** and returns
`UNKNOWN` (or empty) whenever a PR's base branch moves. `reconcileReviewTask`
recomputed the review phase from that signal on every poll, so a genuinely
**CONFLICTING** PR briefly looked non-conflicting and fell through to a
viewer-state phase. On a busy fleet where the default branch moves constantly,
this oscillated every cycle and the lane never settled.

> Changelog: fix(reviews): sticky conflict stops lane flap

## Implementation information

- Add `stickyConflictPhase(mergeable, currentPhase)` (pure, table-tested) and
  route `reconcileReviewTask` through it:
  - definitive `CONFLICTING` → conflict phase
  - indeterminate `UNKNOWN`/`""` → **hold** an existing conflict instead of
    flapping out of it; if not already conflict, fall through to viewer state
  - only a definitive `MERGEABLE` clears a prior conflict
- Conflict is the lane's most actionable fact (the PR can't land until the
  author rebases), so it is sticky and wins on any indeterminate read.
- Every reconcile pass now computes the same held result for a conflicting PR,
  so `applyReviewPhase` writes nothing and the lane stops moving regardless of
  poll cadence.

## Supporting documentation

- `TestStickyConflictPhase` covers the hold/clear/decide matrix.
- Verified locally: `go test ./internal/sybra/` ok, `golangci-lint` 0 issues.
