### PR TITLE
feat(watchdog): headless nudge via stop+resume

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -199,6 +199,16 @@ export class Task {
     "runRole": string;
 
     /**
+     * SupervisorSteer is a one-shot corrective message left by the watchdog's
+     * headless nudge: it stops a looping headless agent (which has no mid-stream
+     * channel) and persists the steer here so the recovery loop re-dispatches
+     * the resumed agent with the correction prepended to its prompt. Recovery
+     * clears it after consuming it exactly once. Empty for tasks with no pending
+     * nudge.
+     */
+    "supervisorSteer"?: string;
+
+    /**
      * ReviewPhase tracks where an inbound PR-review task (tag `review`) sits in
      * the review lifecycle: reviewing → drafted → awaiting-author →
      * needs-approval → approved (plus `manual` for small PRs punted to the
@@ -357,9 +367,9 @@ export class Task {
     static createFrom($$source: any = {}): Task {
         const $$createField6_0 = $$createType0;
         const $$createField7_0 = $$createType0;
-        const $$createField29_0 = $$createType2;
-        const $$createField30_0 = $$createType4;
-        const $$createField37_0 = $$createType5;
+        const $$createField30_0 = $$createType2;
+        const $$createField31_0 = $$createType4;
+        const $$createField38_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -368,13 +378,13 @@ export class Task {
             $$parsedSource["tags"] = $$createField7_0($$parsedSource["tags"]);
         }
         if ("agentRuns" in $$parsedSource) {
-            $$parsedSource["agentRuns"] = $$createField29_0($$parsedSource["agentRuns"]);
+            $$parsedSource["agentRuns"] = $$createField30_0($$parsedSource["agentRuns"]);
         }
         if ("workflow" in $$parsedSource) {
-            $$parsedSource["workflow"] = $$createField30_0($$parsedSource["workflow"]);
+            $$parsedSource["workflow"] = $$createField31_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField37_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField38_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -2,6 +2,7 @@ package recovery_test
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
 	"testing"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/logging"
+	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/recovery"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/worktree"
@@ -200,20 +202,100 @@ func TestRestartStaleSkipsRateLimitedProvider(t *testing.T) {
 	}
 }
 
+// TestRestartStaleSteerBypassesRecentRunDebounce verifies the recovery half of
+// a watchdog headless nudge: a pending SupervisorSteer makes a just-stopped task
+// re-dispatch immediately instead of waiting out the recent-run debounce. The
+// steer is consumed + prepended inside AgentOrchestrator.StartAgent (covered by
+// the internal/sybra helper test), not here.
+func TestRestartStaleSteerBypassesRecentRunDebounce(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := discardLogger()
+	agents := agent.NewManager(ctx, func(string, any) {}, logger, t.TempDir())
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Tasks:        tasks,
+		Logger:       logger,
+		AgentChecker: agents.HasRunningAgentForTask,
+	})
+
+	created, err := tasks.Create("looping", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inProg := task.StatusInProgress
+	projID := "owner/repo"
+	steer := "stop retrying the failing command; read the error first"
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:          &inProg,
+		ProjectID:       &projID,
+		SupervisorSteer: &steer,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// RECENT run: the debounce would normally skip it, but a pending steer
+	// (the watchdog just stopped a looping agent) must bypass the debounce.
+	if err := tasks.AddRun(created.ID, task.AgentRun{
+		AgentID:   "ag-1",
+		Mode:      "headless",
+		State:     string(agent.StateStopped),
+		StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	stub := stubOrchestrator{}
+	r := &recovery.Recovery{
+		Tasks:        tasks,
+		Agents:       agents,
+		Worktrees:    wm,
+		Orchestrator: &stub,
+		Projects:     stubProjects{},
+		Logger:       logger,
+		Throttle:     logging.NewErrorThrottle(),
+		WG:           &wg,
+		LogDir:       t.TempDir(),
+	}
+	r.RestartStaleInProgress()
+	wg.Wait()
+
+	if stub.startCalls != 1 {
+		t.Fatalf("dispatch count = %d, want 1 (steer must bypass the recent-run debounce)", stub.startCalls)
+	}
+}
+
 type stubOrchestrator struct {
 	startCalls    int
 	prFixCalls    int
 	startErr      error
 	prFixErr      error
 	startReturned *agent.Agent
+	lastPrompt    string
 }
 
-func (s *stubOrchestrator) StartAgent(_, _, _ string, _, _ bool) (*agent.Agent, error) {
+func (s *stubOrchestrator) StartAgent(_, _, prompt string, _, _ bool) (*agent.Agent, error) {
 	s.startCalls++
+	s.lastPrompt = prompt
 	return s.startReturned, s.startErr
 }
 
 func (s *stubOrchestrator) StartPRFixAgent(_ string) error {
 	s.prFixCalls++
 	return s.prFixErr
+}
+
+// stubProjects is a recovery.ProjectGetter that reports no project so the
+// re-dispatch prompt uses the default (non-pet) PR flag.
+type stubProjects struct{}
+
+func (stubProjects) Get(string) (project.Project, error) {
+	return project.Project{}, errors.New("no project")
 }

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -2,6 +2,7 @@ package recovery
 
 import (
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
@@ -87,7 +88,11 @@ func (r *Recovery) RestartStaleInProgress() {
 		// Debounce respawn when a previous run started recently. Covers
 		// the dev-reload case: app restarts every few seconds, but a
 		// headless subprocess from the prior lifecycle is still alive.
-		if lr := lastAgentRun(&t); lr != nil && time.Since(lr.StartedAt) < restartStaleMinAge {
+		// A pending supervisor steer bypasses the debounce: the watchdog
+		// deliberately stopped a looping agent to re-dispatch it with a
+		// correction, and that should not wait out the recent-run window.
+		if lr := lastAgentRun(&t); lr != nil && time.Since(lr.StartedAt) < restartStaleMinAge &&
+			strings.TrimSpace(t.SupervisorSteer) == "" {
 			r.Logger.Info("restart-stale.skip",
 				"task_id", t.ID, "reason", "recent_run",
 				"last_run_age_s", time.Since(lr.StartedAt).Seconds())
@@ -136,6 +141,11 @@ func (r *Recovery) RestartStaleInProgress() {
 		if proj, pErr := r.Projects.Get(t.ProjectID); pErr == nil && proj.Type == project.ProjectTypePet {
 			prFlag = ""
 		}
+		// A pending supervisor steer (set by the watchdog's headless nudge) is
+		// consumed and prepended to the prompt inside AgentOrchestrator.StartAgent,
+		// the single dispatch choke point this path and the workflow resume path
+		// both funnel through — so it is delivered exactly once regardless of
+		// which loop re-dispatches the task.
 		prompt := "Continue implementing this task. When done, create a PR with `gh pr create" + prFlag + "`."
 		currentStatus := t.Status
 		r.WG.Go(func() {

--- a/internal/sybra/app_agents.go
+++ b/internal/sybra/app_agents.go
@@ -155,6 +155,38 @@ func (o *AgentOrchestrator) sandboxEnv(taskID, dir string, t task.Task) []string
 	return inst.EnvVars()
 }
 
+// prependSupervisorSteer consumes a pending watchdog headless-nudge steer for
+// taskID: it clears the one-shot SupervisorSteer field and returns prompt with
+// the correction prepended. Returns prompt unchanged when none is pending.
+// Called at the head of the headless re-dispatch entry points (this orchestrator,
+// the workflow run_agent path, and the pr-fix agent) so the first agent resumed
+// after a nudge carries the correction and later ones do not. The orchestrator
+// resume loops (ResumeStalled then RestartStaleInProgress) run sequentially on a
+// single goroutine and each gates on no-running-agent before dispatching, so the
+// read-then-clear is not raced by a concurrent dispatcher for the same task.
+//
+// The prompt is steered ONLY after the clear succeeds, so a failed clear leaves
+// the steer pending (the error is returned, the prompt is unchanged) rather than
+// applying it twice — preserving the one-shot contract. A start that then fails
+// loses the nudge, which is recoverable: the watchdog re-nudges if the resumed
+// agent loops again.
+func prependSupervisorSteer(tasks *task.Manager, taskID, prompt string) (string, error) {
+	t, err := tasks.Get(taskID)
+	if err != nil {
+		// Cannot read the task → cannot consume a steer; dispatch unsteered and
+		// let the caller log. Any pending steer stays for a later dispatch.
+		return prompt, err
+	}
+	steer := strings.TrimSpace(t.SupervisorSteer)
+	if steer == "" {
+		return prompt, nil
+	}
+	if _, uErr := tasks.Update(taskID, task.Update{SupervisorSteer: task.Ptr("")}); uErr != nil {
+		return prompt, fmt.Errorf("clear supervisor steer: %w", uErr)
+	}
+	return "Supervisor course-correction: " + steer + "\n\n" + prompt, nil
+}
+
 func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, includeTaskDescription, oneShot bool) (*agent.Agent, error) {
 	// Serialize dispatch per task. Held across the whole start — including the
 	// multi-second worktree prep below, during which the agent is not yet
@@ -166,6 +198,15 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, includeTaskD
 		return nil, workflow.ErrDispatchInFlight
 	}
 	defer o.agents.ReleaseTaskDispatch(taskID)
+
+	// Consume a pending watchdog headless-nudge steer (no-op when none). Held
+	// within the dispatch claim so the read-then-clear is serialized per task.
+	// On a clear failure the steer stays pending and we dispatch unsteered.
+	if steered, sErr := prependSupervisorSteer(o.tasks, taskID, prompt); sErr != nil {
+		o.logger.Warn("supervisor-steer.consume", "task_id", taskID, "err", sErr)
+	} else {
+		prompt = steered
+	}
 
 	t, err := o.tasks.Get(taskID)
 	if err != nil {
@@ -391,6 +432,11 @@ func (o *AgentOrchestrator) StartPRFixAgent(taskID string) error {
 	}
 
 	prompt := buildPRFixPrompt(t, o.logger)
+	if steered, sErr := prependSupervisorSteer(o.tasks, taskID, prompt); sErr != nil {
+		o.logger.Warn("supervisor-steer.consume", "task_id", taskID, "err", sErr)
+	} else {
+		prompt = steered
+	}
 	ag, err := o.agents.Run(agent.RunConfig{
 		TaskID:             taskID,
 		Name:               agent.RolePRFix.AgentName(t.Title),

--- a/internal/sybra/app_agents_steer_test.go
+++ b/internal/sybra/app_agents_steer_test.go
@@ -1,0 +1,60 @@
+package sybra
+
+import (
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// TestPrependSupervisorSteer covers the consumption point that delivers a
+// watchdog headless nudge: the steer is prepended to the next agent's prompt
+// and cleared so it is applied exactly once.
+func TestPrependSupervisorSteer(t *testing.T) {
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	tk, err := tasks.Create("loop", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// No pending steer → prompt unchanged, no error.
+	if got, err := prependSupervisorSteer(tasks, tk.ID, "DO X"); err != nil || got != "DO X" {
+		t.Fatalf("no-steer = (%q, %v), want (\"DO X\", nil)", got, err)
+	}
+
+	steer := "stop retrying; read the error first"
+	if _, err := tasks.Update(tk.ID, task.Update{SupervisorSteer: &steer}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := prependSupervisorSteer(tasks, tk.ID, "DO X")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := "Supervisor course-correction: stop retrying; read the error first\n\nDO X"
+	if got != want {
+		t.Fatalf("steered prompt = %q, want %q", got, want)
+	}
+
+	// One-shot: the steer is cleared, so a second dispatch is unsteered.
+	reread, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reread.SupervisorSteer != "" {
+		t.Fatalf("steer not cleared after use: %q", reread.SupervisorSteer)
+	}
+	if again, err := prependSupervisorSteer(tasks, tk.ID, "DO Y"); err != nil || again != "DO Y" {
+		t.Fatalf("second call = (%q, %v), want (\"DO Y\", nil) — steer already consumed", again, err)
+	}
+
+	// Unknown task: prompt is returned unchanged and the read error surfaces so
+	// the caller dispatches unsteered rather than silently swallowing it.
+	if got, err := prependSupervisorSteer(tasks, "does-not-exist", "DO Z"); err == nil || got != "DO Z" {
+		t.Fatalf("unknown-task = (%q, %v), want (\"DO Z\", <error>)", got, err)
+	}
+}

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -126,6 +126,10 @@ func (a *taskAdapter) SetWorkflow(id string, wf *workflow.Execution) error {
 	return err
 }
 
+func (a *taskAdapter) ConsumeSupervisorSteer(taskID, prompt string) (string, error) {
+	return prependSupervisorSteer(a.tasks, taskID, prompt)
+}
+
 func (a *taskAdapter) WriteSidecar(id, kind, content string) error {
 	// Plan drafts are namespaced "plan_draft.<name>" so the workflow can fan
 	// out to N parallel planners without growing the static sidecar enum.
@@ -265,6 +269,9 @@ type agentAdapter struct {
 }
 
 func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool) (string, error) {
+	// (A pending watchdog headless-nudge steer is consumed upstream in
+	// execRunAgent, before the prompt reaches here.)
+
 	// For implementation agents without a pre-staged dir, use the full
 	// orchestrator (handles worktree, project assignment). A workflow that
 	// seeds WorkflowVarDir (e.g. tests or flows that pre-stage via

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -198,6 +198,13 @@ type Task struct {
 	BlockedByIssue string `yaml:"blocked_by_issue,omitempty" json:"blockedByIssue,omitempty"`
 	Reviewed       bool   `yaml:"reviewed,omitempty" json:"reviewed"`
 	RunRole        string `yaml:"run_role,omitempty" json:"runRole"` // pr-fix when fixing review issues, "" for initial impl
+	// SupervisorSteer is a one-shot corrective message left by the watchdog's
+	// headless nudge: it stops a looping headless agent (which has no mid-stream
+	// channel) and persists the steer here so the recovery loop re-dispatches
+	// the resumed agent with the correction prepended to its prompt. Recovery
+	// clears it after consuming it exactly once. Empty for tasks with no pending
+	// nudge.
+	SupervisorSteer string `yaml:"supervisor_steer,omitempty" json:"supervisorSteer,omitempty"`
 	// ReviewPhase tracks where an inbound PR-review task (tag `review`) sits in
 	// the review lifecycle: reviewing → drafted → awaiting-author →
 	// needs-approval → approved (plus `manual` for small PRs punted to the

--- a/internal/task/parser_test.go
+++ b/internal/task/parser_test.go
@@ -265,6 +265,32 @@ func TestMarshalRoundTrip(t *testing.T) {
 	}
 }
 
+// TestMarshalRoundTripSupervisorSteer guards the watchdog headless-nudge steer:
+// it must survive marshal→parse so a pending nudge is not lost if the app
+// restarts between the stop and the recovery re-dispatch.
+func TestMarshalRoundTripSupervisorSteer(t *testing.T) {
+	t.Parallel()
+	original := Task{
+		ID:              "ss1",
+		Title:           "Steer roundtrip",
+		Status:          StatusInProgress,
+		AgentMode:       "headless",
+		SupervisorSteer: "stop retrying the failing command; read the error first",
+	}
+
+	data, err := Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	parsed, err := ParseBytes(data)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if parsed.SupervisorSteer != original.SupervisorSteer {
+		t.Errorf("SupervisorSteer = %q, want %q", parsed.SupervisorSteer, original.SupervisorSteer)
+	}
+}
+
 func TestMarshalEmptyBody(t *testing.T) {
 	t.Parallel()
 	task := Task{ID: "e1", Title: "No body", Status: StatusTodo}

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -516,6 +516,9 @@ func (s *Store) UpdateWithPrev(id string, u Update) (Task, Status, error) {
 	if u.BlockedByIssue != nil {
 		t.BlockedByIssue = *u.BlockedByIssue
 	}
+	if u.SupervisorSteer != nil {
+		t.SupervisorSteer = *u.SupervisorSteer
+	}
 	if u.AgentMode != nil {
 		if _, err := ValidateAgentMode(*u.AgentMode); err != nil {
 			return Task{}, "", err

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -28,6 +28,7 @@ type Update struct {
 	Issue           *string
 	Reviewed        *bool
 	RunRole         *string
+	SupervisorSteer *string
 	ReviewPhase     *string
 	PRPhase         *string
 	TodoistID       *string
@@ -68,7 +69,7 @@ func applyMapField(u *Update, k string, v any) error {
 	switch k {
 	case "title", "slug", "status_reason", "blocked_by_issue", "body",
 		"project_id", "branch", "worktree_dir", "issue", "run_role", "todoist_id", "plan", "plan_critique", "code_review",
-		"review_phase", "pr_phase", "outcome", "merge_commit":
+		"review_phase", "pr_phase", "outcome", "merge_commit", "supervisor_steer":
 		return applyPlainStringField(u, k, v)
 	case "priority":
 		return applyPriorityField(u, v)
@@ -146,6 +147,8 @@ func applyPlainStringField(u *Update, k string, v any) error {
 		u.Issue = &s
 	case "run_role":
 		u.RunRole = &s
+	case "supervisor_steer":
+		u.SupervisorSteer = &s
 	case "todoist_id":
 		u.TodoistID = &s
 	case "plan":

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -249,26 +249,27 @@ func (w *Watchdog) applyVerdict(ag *agent.Agent, verdict agent.InspectorVerdict)
 			w.logger.Error("agent.watchdog.stop.failed", "id", ag.ID, "err", err)
 		}
 	case "nudge":
-		// Deliver a corrective steer to a live agent and leave it running. Only
-		// agents with a live transport (interactive/conversational) can be
-		// nudged mid-stream; a headless agent has no stdin, so SendPromptToAgent
-		// errors and the nudge degrades to an advisory escalate (leave running,
-		// debounce suppresses re-check). Headless nudge via stop+resume is
-		// tracked separately.
+		// Steer a drifting-but-recoverable agent. An agent with a live transport
+		// (interactive/conversational) is nudged in place. A headless agent has
+		// no mid-stream channel, so fall back to the resume path: persist the
+		// steer on the task and stop the looping run, so the recovery loop
+		// re-dispatches (resumes) it with the correction prepended.
 		steer := verdict.Nudge
 		if steer == "" {
 			steer = verdict.Reason
 		}
-		if w.nudgeAgent == nil {
-			w.logger.Warn("agent.watchdog.nudge.unwired", "id", ag.ID)
-			return
+		if steer == "" {
+			steer = "you appear to be repeating the same action; stop and reconsider your approach"
 		}
-		if err := w.nudgeAgent(ag.ID, "⚠️ Supervisor: "+steer); err != nil {
-			w.logger.Warn("agent.watchdog.nudge.degraded",
-				"id", ag.ID, "err", err, "steer", steer)
-			return
+		if w.nudgeAgent != nil {
+			if err := w.nudgeAgent(ag.ID, supervisorNudgePrefix+steer); err == nil {
+				w.logger.Info("agent.watchdog.nudge", "id", ag.ID, "transport", "live", "steer", steer)
+				return
+			} else {
+				w.logger.Info("agent.watchdog.nudge.no_live_transport", "id", ag.ID, "err", err)
+			}
 		}
-		w.logger.Info("agent.watchdog.nudge", "id", ag.ID, "steer", steer)
+		w.headlessNudge(ag, steer)
 	case "escalate":
 		// Ambiguous verdicts are advisory only. Flipping the task to
 		// human-required while the agent keeps running leaves task status
@@ -276,4 +277,27 @@ func (w *Watchdog) applyVerdict(ag *agent.Agent, verdict agent.InspectorVerdict)
 	case "continue":
 		// intentional no-op; debounce suppresses re-check
 	}
+}
+
+// supervisorNudgePrefix tags a watchdog steer delivered to a live agent so the
+// agent can tell it apart from a user message.
+const supervisorNudgePrefix = "⚠️ Supervisor: "
+
+// headlessNudge delivers a course-correction to a headless agent, which has no
+// mid-stream channel. It persists the steer on the task and stops the looping
+// run; the run's session is captured for --resume, and the recovery loop
+// re-dispatches the still-in-progress task with the steer prepended to the
+// prompt. The task is deliberately left in-progress (not human-required) so
+// recovery resumes it rather than parking it for a human.
+func (w *Watchdog) headlessNudge(ag *agent.Agent, steer string) {
+	if ag.TaskID != "" {
+		if _, err := w.tasks.Update(ag.TaskID, task.Update{SupervisorSteer: task.Ptr(steer)}); err != nil {
+			w.logger.Error("agent.watchdog.nudge.steer", "task_id", ag.TaskID, "err", err)
+		}
+	}
+	if err := w.stopAgent(ag.ID); err != nil {
+		w.logger.Error("agent.watchdog.nudge.stop", "id", ag.ID, "err", err)
+		return
+	}
+	w.logger.Info("agent.watchdog.nudge", "id", ag.ID, "transport", "headless-resume", "steer", steer)
 }

--- a/internal/watchdog/agent_test.go
+++ b/internal/watchdog/agent_test.go
@@ -128,12 +128,10 @@ func TestDecideTrigger(t *testing.T) {
 	}
 }
 
-// TestApplyVerdict_NudgeDeliversAndLeavesRunning covers the live-transport
-// delivery path. In production the watchdog only inspects headless agents,
-// which have no live transport, so the real path today is the degrade in
-// TestApplyVerdict_NudgeDegradesWhenNoTransport; this test guards the delivery
-// wiring used once interactive/conversational agents are supervised (#1105).
-func TestApplyVerdict_NudgeDeliversAndLeavesRunning(t *testing.T) {
+// TestApplyVerdict_NudgeLiveTransportDeliversInPlace covers the live-transport
+// path: an agent with a working SendPromptToAgent (interactive/conversational)
+// is steered in place and left running — no stop, no persisted steer.
+func TestApplyVerdict_NudgeLiveTransportDeliversInPlace(t *testing.T) {
 	tasks, tk := newTestTasks(t)
 
 	var nudged string
@@ -155,15 +153,22 @@ func TestApplyVerdict_NudgeDeliversAndLeavesRunning(t *testing.T) {
 		t.Fatalf("nudge message = %q", nudged)
 	}
 	if stopped {
-		t.Fatal("stopAgent called on nudge verdict")
+		t.Fatal("stopAgent called on a live-transport nudge")
 	}
 	got, _ := tasks.Get(tk.ID)
 	if got.Status != task.StatusInProgress {
 		t.Fatalf("status = %q, want in-progress (nudge must not flip status)", got.Status)
 	}
+	if got.SupervisorSteer != "" {
+		t.Fatalf("supervisor_steer = %q, want empty for a live nudge", got.SupervisorSteer)
+	}
 }
 
-func TestApplyVerdict_NudgeDegradesWhenNoTransport(t *testing.T) {
+// TestApplyVerdict_NudgeHeadlessPersistsSteerAndStops covers the headless path:
+// no live transport, so the steer is persisted on the task and the agent is
+// stopped so the recovery loop re-dispatches with the correction. The task is
+// left in-progress (not human-required) so recovery resumes it.
+func TestApplyVerdict_NudgeHeadlessPersistsSteerAndStops(t *testing.T) {
 	tasks, tk := newTestTasks(t)
 
 	stopped := false
@@ -177,16 +182,18 @@ func TestApplyVerdict_NudgeDegradesWhenNoTransport(t *testing.T) {
 	w.applyVerdict(&agent.Agent{ID: "a1", TaskID: tk.ID}, agent.InspectorVerdict{
 		Recommendation: "nudge",
 		Reason:         "drifting",
+		Nudge:          "stop retrying the failing command",
 	})
 
-	// A headless agent cannot be nudged mid-stream; the nudge degrades to an
-	// advisory no-op — the agent keeps running and the task is untouched.
-	if stopped {
-		t.Fatal("stopAgent called when nudge degraded")
+	if !stopped {
+		t.Fatal("headless nudge must stop the agent so recovery re-dispatches")
 	}
 	got, _ := tasks.Get(tk.ID)
-	if got.Status != task.StatusInProgress || got.StatusReason != "" {
-		t.Fatalf("status=%q reason=%q, want in-progress with no reason", got.Status, got.StatusReason)
+	if got.SupervisorSteer != "stop retrying the failing command" {
+		t.Fatalf("supervisor_steer = %q, want the steer persisted", got.SupervisorSteer)
+	}
+	if got.Status != task.StatusInProgress {
+		t.Fatalf("status = %q, want in-progress (recovery must resume, not park)", got.Status)
 	}
 }
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -55,6 +55,10 @@ type TaskProvider interface {
 	UpdateTaskPR(id string, prNumber int) error
 	MarkTaskReviewed(id string) error
 	SetWorkflow(id string, wf *Execution) error
+	// ConsumeSupervisorSteer prepends a pending watchdog headless-nudge steer to
+	// prompt and clears it, so a re-dispatched (resumed) step's agent carries the
+	// correction exactly once. Returns prompt unchanged when none is pending.
+	ConsumeSupervisorSteer(taskID, prompt string) (string, error)
 	// WriteSidecar stores content as the named sidecar for the task. Used
 	// by run_agent steps that declare import_sidecar so the engine can
 	// ingest the agent's output file without depending on the agent's

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -74,6 +74,15 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 		return fmt.Errorf("render prompt: %w", err)
 	}
 
+	// Consume a pending watchdog headless-nudge steer (no-op when none). Done
+	// here, before dispatch (fresh or resumed via ResumeStalled), so a step
+	// re-run after the watchdog stopped a looping agent carries the correction.
+	if steered, sErr := e.tasks.ConsumeSupervisorSteer(taskID, prompt); sErr != nil {
+		e.logger.Warn("workflow.consume-steer", "task_id", taskID, "step", step.ID, "err", sErr)
+	} else {
+		prompt = steered
+	}
+
 	// Reuse a live agent if configured and one exists for this role.
 	if step.Config.ReuseAgent {
 		if agentID, found := e.agents.FindRunningAgentForRole(taskID, step.Config.Role); found {

--- a/internal/workflow/engine_steps_parallel.go
+++ b/internal/workflow/engine_steps_parallel.go
@@ -102,6 +102,15 @@ func (e *Engine) spawnParallelChild(taskID string, parent, child *Step, wfExec *
 		return fmt.Errorf("render prompt: %w", err)
 	}
 
+	// Consume a pending watchdog headless-nudge steer here too, so a steer set
+	// for a looping parallel child is delivered to (and cleared by) this
+	// dispatch rather than leaking into a later run_agent step's prompt.
+	if steered, sErr := e.tasks.ConsumeSupervisorSteer(taskID, prompt); sErr != nil {
+		e.logger.Warn("workflow.parallel.consume-steer", "task_id", taskID, "child", child.ID, "err", sErr)
+	} else {
+		prompt = steered
+	}
+
 	mode := child.Config.Mode
 	if strings.Contains(mode, "{{") {
 		if rendered, rErr := RenderTemplate(mode, childCtx); rErr == nil {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -62,10 +62,30 @@ type memTasks struct {
 	mu      sync.Mutex
 	tasks   map[string]*TaskInfo
 	reasons map[string]string
+	steers  map[string]string
 }
 
 func newMemTasks() *memTasks {
-	return &memTasks{tasks: make(map[string]*TaskInfo), reasons: make(map[string]string)}
+	return &memTasks{tasks: make(map[string]*TaskInfo), reasons: make(map[string]string), steers: make(map[string]string)}
+}
+
+// SetSteer arms a pending supervisor steer for a task, as the watchdog's
+// headless nudge would. Consumed (and cleared) by ConsumeSupervisorSteer.
+func (m *memTasks) SetSteer(id, steer string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.steers[id] = steer
+}
+
+func (m *memTasks) ConsumeSupervisorSteer(taskID, prompt string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	steer := m.steers[taskID]
+	if steer == "" {
+		return prompt, nil
+	}
+	delete(m.steers, taskID)
+	return "Supervisor course-correction: " + steer + "\n\n" + prompt, nil
 }
 
 func (m *memTasks) Put(t TaskInfo) {
@@ -2545,6 +2565,47 @@ func TestResumeStalled_SkipsInflightDispatch(t *testing.T) {
 	engine.ResumeStalled()
 	if got := agents.CallCount(); got != before+1 {
 		t.Errorf("ResumeStalled after inflight cleared: calls %d → %d (want +1)", before, got)
+	}
+}
+
+// TestExecRunAgent_ConsumesSupervisorSteer verifies the workflow half of a
+// watchdog headless nudge: when a step is (re-)dispatched and a steer is
+// pending, execRunAgent prepends the correction to the agent's prompt and the
+// steer is consumed exactly once. This is the path ResumeStalled drives when it
+// re-runs a stalled run_agent step — the case a prior design missed entirely.
+func TestExecRunAgent_ConsumesSupervisorSteer(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", AgentMode: "headless"})
+	tasks.SetSteer("t1", "stop retrying the failing command")
+
+	step := &Step{
+		ID:     "implement",
+		Type:   StepRunAgent,
+		Config: StepConfig{Role: "implementation", Mode: "headless", Prompt: "do the work"},
+	}
+	wfExec := &Execution{WorkflowID: "test-simple", CurrentStep: "implement", State: ExecRunning, Variables: map[string]string{}}
+	ctx := TemplateContext{Task: TaskInfo{ID: "t1"}, Step: *step, Vars: wfExec.Variables}
+
+	if err := engine.execRunAgent("t1", step, wfExec, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	got := agents.LastCall().Prompt
+	want := "Supervisor course-correction: stop retrying the failing command\n\ndo the work"
+	if got != want {
+		t.Fatalf("dispatched prompt = %q, want %q", got, want)
+	}
+
+	// One-shot: a second dispatch (steer consumed) carries only the step prompt.
+	if err := engine.execRunAgent("t1", step, wfExec, ctx); err != nil {
+		t.Fatal(err)
+	}
+	if got := agents.LastCall().Prompt; got != "do the work" {
+		t.Fatalf("second dispatch prompt = %q, want unsteered (steer already consumed)", got)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Follow-up to #1104. There, a watchdog `nudge` on a headless agent degraded to an
advisory escalate, because a headless agent (`claude -p`, one-shot, no stdin)
has no mid-stream channel to steer. This delivers the real headless nudge:
**stop the looping run and resume it carrying the supervisor's correction**, so
the agent course-corrects instead of repeating the loop.

Closes #1105

> Changelog: feat(watchdog): headless nudge via resume-with-steer

## Implementation information

- **task**: a transient `SupervisorSteer` frontmatter field (survives restart).
- **watchdog**: `applyVerdict("nudge")` steers a live-transport agent in place;
  for a headless agent it persists the steer on the task and stops the run
  (leaving the task in-progress so it is re-dispatched, not parked for a human).
- **workflow engine**: `TaskProvider.ConsumeSupervisorSteer` prepends a pending
  steer to the prompt and clears it. Consumed in `execRunAgent` (and parallel
  children) so any re-dispatched `run_agent` step — the path `ResumeStalled`
  drives — carries the correction exactly once, **role-agnostically**.
- **internal/sybra**: a shared `prependSupervisorSteer` helper consumes the
  steer on the non-workflow recovery bare-dispatch (`AgentOrchestrator.StartAgent`)
  and pr-fix (`StartPRFixAgent`) paths.
- **recovery**: a pending steer bypasses the recent-run debounce so the
  correction is timely.

The steer is one-shot — the first agent re-dispatched after a nudge carries it,
later ones do not.

### Review notes

This change was hardened across three adversarial-review iterations. The key
trap (and the reason it was split from #1104): workflow-driven agents are
re-dispatched by the engine's `ResumeStalled`, **not** the recovery loop, so an
earlier design that wired the steer into recovery delivered nothing for the main
case. Consumption now lives in `execRunAgent`, on the exact resume path, and is
covered by `TestExecRunAgent_ConsumesSupervisorSteer` (asserts the mock launcher
receives the prepended prompt + one-shot clear).

## Supporting documentation

- Parent: #1104
- Completion stop path: `internal/sybra/agent_completion.go` (`WasStopped` → `ClearAgentStep`)
- Resume path: `internal/workflow/engine_events.go` (`ResumeStalled` → `execRunAgent`)
