### PR TITLE
feat(verify): add verify-checks gate

### DIFF
--- a/.sybra.yaml
+++ b/.sybra.yaml
@@ -27,3 +27,12 @@ checks:
   pre_push:
     - mise exec -- go test ./...
     - (cd frontend && npm run check)
+  # Verify suite run by the verify_checks workflow step (reward-hacking
+  # phase 2): runs on the agent's branch HEAD before review so an
+  # implementation that does not pass its own tests cannot reach a PR. Scoped
+  # to ./internal/... ./cmd/... because the root package's
+  # //go:embed all:frontend/dist needs a frontend build that worktrees don't
+  # run; the internal+cmd packages compile without it and hold the logic under
+  # test.
+  verify:
+    - mise exec -- go test ./internal/... ./cmd/...

--- a/frontend/bindings/github.com/Automaat/sybra/internal/project/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/project/models.ts
@@ -17,6 +17,15 @@ export class ChecksConfig {
     "preCommit"?: string[];
     "prePush"?: string[];
 
+    /**
+     * Verify is the project's deterministic verification suite (tests /
+     * typecheck), run by the verify_checks workflow step on the agent's branch
+     * before review so an implementation that does not pass its own tests
+     * cannot reach a PR. Opt-in: unset means the check is skipped. Each entry
+     * is a shell command run in the worktree root, in order.
+     */
+    "verify"?: string[];
+
     /** Creates a new ChecksConfig instance. */
     constructor($$source: Partial<ChecksConfig> = {}) {
 
@@ -29,12 +38,16 @@ export class ChecksConfig {
     static createFrom($$source: any = {}): ChecksConfig {
         const $$createField0_0 = $$createType0;
         const $$createField1_0 = $$createType0;
+        const $$createField2_0 = $$createType0;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("preCommit" in $$parsedSource) {
             $$parsedSource["preCommit"] = $$createField0_0($$parsedSource["preCommit"]);
         }
         if ("prePush" in $$parsedSource) {
             $$parsedSource["prePush"] = $$createField1_0($$parsedSource["prePush"]);
+        }
+        if ("verify" in $$parsedSource) {
+            $$parsedSource["verify"] = $$createField2_0($$parsedSource["verify"]);
         }
         return new ChecksConfig($$parsedSource as Partial<ChecksConfig>);
     }

--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -638,6 +638,16 @@ export enum StepType {
     StepDetectTampering = "detect_tampering",
 
     /**
+     * StepVerifyChecks runs the project's deterministic verify suite
+     * (checks.verify, opt-in) on the agent's branch HEAD before review. A
+     * non-zero exit flips the task to human-required so an implementation that
+     * does not pass its own declared tests cannot reach a PR. Complements
+     * detect_tampering: structural test tampering is caught there; this catches
+     * incomplete/broken work committed without the suite passing.
+     */
+    StepVerifyChecks = "verify_checks",
+
+    /**
      * StepRouteTestResult reads the test-runner verdict and routes the task:
      * pass → ready-pr, fail → in-progress (re-implement) until the attempt
      * cap is hit, then human-required.

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -545,6 +545,7 @@ func TestMergeChecks(t *testing.T) {
 		app           *ChecksConfig
 		wantPreCommit []string
 		wantPrePush   []string
+		wantVerify    []string
 		wantNil       bool
 	}{
 		{
@@ -586,6 +587,24 @@ func TestMergeChecks(t *testing.T) {
 			app:           &ChecksConfig{PreCommit: []string{"echo app"}},
 			wantPreCommit: []string{"echo app"},
 		},
+		{
+			name:       "verify only repo is non-nil",
+			repo:       &ChecksConfig{Verify: []string{"go test ./..."}},
+			wantVerify: []string{"go test ./..."},
+		},
+		{
+			name:       "repo wins verify",
+			repo:       &ChecksConfig{Verify: []string{"repo test"}},
+			app:        &ChecksConfig{Verify: []string{"app test"}},
+			wantVerify: []string{"repo test"},
+		},
+		{
+			name:          "verify falls back to app",
+			repo:          &ChecksConfig{PreCommit: []string{"echo repo"}},
+			app:           &ChecksConfig{Verify: []string{"app test"}},
+			wantPreCommit: []string{"echo repo"},
+			wantVerify:    []string{"app test"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -606,6 +625,9 @@ func TestMergeChecks(t *testing.T) {
 			}
 			if !slicesEqual(got.PrePush, tt.wantPrePush) {
 				t.Errorf("PrePush = %v, want %v", got.PrePush, tt.wantPrePush)
+			}
+			if !slicesEqual(got.Verify, tt.wantVerify) {
+				t.Errorf("Verify = %v, want %v", got.Verify, tt.wantVerify)
 			}
 		})
 	}

--- a/internal/project/model.go
+++ b/internal/project/model.go
@@ -14,6 +14,12 @@ const (
 type ChecksConfig struct {
 	PreCommit []string `yaml:"pre_commit,omitempty" json:"preCommit,omitempty"`
 	PrePush   []string `yaml:"pre_push,omitempty"   json:"prePush,omitempty"`
+	// Verify is the project's deterministic verification suite (tests /
+	// typecheck), run by the verify_checks workflow step on the agent's branch
+	// before review so an implementation that does not pass its own tests
+	// cannot reach a PR. Opt-in: unset means the check is skipped. Each entry
+	// is a shell command run in the worktree root, in order.
+	Verify []string `yaml:"verify,omitempty" json:"verify,omitempty"`
 }
 
 // RepoConfig is the subset of Sybra config that can be defined in a repo's
@@ -61,7 +67,12 @@ func MergeChecks(repo, app *ChecksConfig) *ChecksConfig {
 	} else if app != nil {
 		out.PrePush = app.PrePush
 	}
-	if len(out.PreCommit) == 0 && len(out.PrePush) == 0 {
+	if repo != nil && len(repo.Verify) > 0 {
+		out.Verify = repo.Verify
+	} else if app != nil {
+		out.Verify = app.Verify
+	}
+	if len(out.PreCommit) == 0 && len(out.PrePush) == 0 && len(out.Verify) == 0 {
 		return nil
 	}
 	return out

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -371,6 +371,7 @@ func (a *App) initWorkflowEngine() {
 	a.workflowEngine.SetPRLinker(prLinkerAdapter{})
 	a.workflowEngine.SetPRReviewRequester(prReviewRequesterAdapter{})
 	a.workflowEngine.SetWorktreeGetter(&worktreeGetterAdapter{tasks: a.tasks, mgr: a.worktrees})
+	a.workflowEngine.SetCheckConfigGetter(&checkConfigGetterAdapter{tasks: a.tasks, projects: a.projects, mgr: a.worktrees})
 	a.workflowEngine.SetTestingMaxAttempts(a.cfg.TestingMaxAttempts())
 	if a.artifacts != nil {
 		a.workflowEngine.SetArtifactRecorder(&artifactRecorderAdapter{store: a.artifacts})

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -24,6 +24,7 @@ var (
 	_ workflow.PRLinker          = (*prLinkerAdapter)(nil)
 	_ workflow.PRReviewRequester = (*prReviewRequesterAdapter)(nil)
 	_ workflow.WorktreeGetter    = (*worktreeGetterAdapter)(nil)
+	_ workflow.CheckConfigGetter = (*checkConfigGetterAdapter)(nil)
 	_ workflow.ArtifactRecorder  = (*artifactRecorderAdapter)(nil)
 )
 
@@ -246,6 +247,40 @@ func eligibleRerequestReviewer(login, viewer, prAuthor string) bool {
 type worktreeGetterAdapter struct {
 	tasks *task.Manager
 	mgr   *worktree.Manager
+}
+
+// checkConfigGetterAdapter resolves a task's verify-suite commands by merging
+// the repo `.sybra.yaml` checks with the app-level project config.
+type checkConfigGetterAdapter struct {
+	tasks    *task.Manager
+	projects *project.Store
+	mgr      *worktree.Manager
+}
+
+func (a *checkConfigGetterAdapter) VerifyCommands(taskID string) []string {
+	t, err := a.tasks.Get(taskID)
+	if err != nil {
+		return nil
+	}
+	wtPath := a.mgr.PathFor(t)
+	if _, statErr := os.Stat(wtPath); statErr != nil {
+		return nil
+	}
+	var repoChecks *project.ChecksConfig
+	if repoCfg, rErr := project.LoadRepoConfig(wtPath); rErr == nil && repoCfg != nil {
+		repoChecks = repoCfg.Checks
+	}
+	var appChecks *project.ChecksConfig
+	if t.ProjectID != "" {
+		if p, pErr := a.projects.Get(t.ProjectID); pErr == nil {
+			appChecks = p.Checks
+		}
+	}
+	merged := project.MergeChecks(repoChecks, appChecks)
+	if merged == nil {
+		return nil
+	}
+	return merged.Verify
 }
 
 func (a *worktreeGetterAdapter) GetWorktreePath(taskID string) (string, bool) {

--- a/internal/workflow/builtin/simple-task-implement.yaml
+++ b/internal/workflow/builtin/simple-task-implement.yaml
@@ -92,6 +92,24 @@ steps:
           operator: equals
           value: human-required
         goto: ""
+      - goto: verify_checks
+
+  # Mechanical check (no LLM): run the project's `checks.verify` suite on the
+  # agent's branch HEAD before review. A non-zero exit flips the task to
+  # human-required so an implementation that does not pass its own declared
+  # tests cannot reach a PR. Complements detect_tampering (which catches
+  # structural test tampering). Opt-in: a no-op unless the project defines
+  # checks.verify. No git mutation; add the `verify-blessed` tag to override a
+  # known-flaky suite.
+  - id: verify_checks
+    name: Verify Checks
+    type: verify_checks
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
       - goto: set_ready_review
 
   # Terminal hand-off to simple-task-review: flip status to ready-review

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -81,6 +81,15 @@ type WorktreeGetter interface {
 	GetWorktreePath(taskID string) (string, bool)
 }
 
+// CheckConfigGetter resolves a task's verify-suite commands (the project's
+// deterministic tests/typecheck), merged from repo `.sybra.yaml` and the
+// app-level project config. Returns nil/empty when the task has no verify
+// suite configured — the verify_checks step then becomes a no-op. Engine
+// operates with a nil getter (step skips), so unit tests need not wire one.
+type CheckConfigGetter interface {
+	VerifyCommands(taskID string) []string
+}
+
 // PRLinker inspects and updates GitHub pull request metadata for the
 // `ensure_pr_closes_issue` step. Implementations wrap `gh` CLI calls.
 // Engine operates with a nil PRLinker — the step becomes a no-op when
@@ -135,6 +144,7 @@ type Engine struct {
 	prLinker        PRLinker
 	prReviewers     PRReviewRequester
 	worktrees       WorktreeGetter
+	checks          CheckConfigGetter
 	recorder        ArtifactRecorder
 	onComplete      func(CompletionInfo)
 	logger          *slog.Logger
@@ -147,7 +157,8 @@ type Engine struct {
 	agentSteps      map[string]agentEntry  // agentID → {taskID, stepID}
 	cascadeDepth    map[string]int         // taskID → synchronous cascade hop depth (recursion guard)
 	resumeError     *logging.ErrorThrottle
-	maxTestAttempts int // testing → re-implement loop cap (0 → defaultTestAttempts)
+	maxTestAttempts int           // testing → re-implement loop cap (0 → defaultTestAttempts)
+	verifyTimeout   time.Duration // verify_checks budget (0 → verifyChecksDefaultTimeout)
 }
 
 // defaultTestAttempts caps the testing → in-progress re-implementation loop
@@ -191,6 +202,14 @@ func (e *Engine) SetPRReviewRequester(r PRReviewRequester) { e.prReviewers = r }
 // SetWorktreeGetter wires a WorktreeGetter used by the `verify_commits` step.
 // Leaving it unset makes the step a no-op.
 func (e *Engine) SetWorktreeGetter(g WorktreeGetter) { e.worktrees = g }
+
+// SetCheckConfigGetter wires the project verify-suite resolver used by the
+// `verify_checks` step. Leaving it unset makes the step a no-op.
+func (e *Engine) SetCheckConfigGetter(g CheckConfigGetter) { e.checks = g }
+
+// SetVerifyTimeout overrides the verify_checks time budget. Zero keeps the
+// default (verifyChecksDefaultTimeout). Used by tests for a short budget.
+func (e *Engine) SetVerifyTimeout(d time.Duration) { e.verifyTimeout = d }
 
 // SetArtifactRecorder wires an ArtifactRecorder that captures per-task
 // workflow artifacts (plan snapshots, trace events). Leaving it unset

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -330,7 +330,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			return e.execParallel(taskID, def, step, wfExec, ctx)
 		case StepWaitHuman:
 			return nil, e.execWaitHuman(taskID, step, wfExec)
-		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepRerequestReview, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepTriageReview, StepDetectTampering, StepRouteTestResult:
+		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepRerequestReview, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepTriageReview, StepDetectTampering, StepVerifyChecks, StepRouteTestResult:
 			// handled below as sync steps
 		default:
 			return nil, fmt.Errorf("unknown step type %q", step.Type)
@@ -418,6 +418,8 @@ func (e *Engine) execSyncStep(taskID string, step *Step, wfExec *Execution, ctx 
 		return e.execTriageReview(taskID, step, t)
 	case StepDetectTampering:
 		return e.execDetectTampering(taskID, step, t)
+	case StepVerifyChecks:
+		return e.execVerifyChecks(taskID, step, t)
 	case StepRouteTestResult:
 		return e.execRouteTestResult(taskID, step, wfExec, t)
 	default:

--- a/internal/workflow/engine_steps_tamper_test.go
+++ b/internal/workflow/engine_steps_tamper_test.go
@@ -303,7 +303,7 @@ func TestBuiltinSimpleTaskImplement_DetectTamperingWiring(t *testing.T) {
 		want   string
 	}{
 		{"flagged_ends_workflow", "human-required", ""},
-		{"clean_hands_off_to_review", "ready-review", "set_ready_review"},
+		{"clean_flows_to_verify_checks", "ready-review", "verify_checks"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -1,0 +1,180 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+)
+
+// verifyChecksDefaultTimeout bounds the whole verify run (every command). A test
+// suite is slower than the 30s shellTimeout used by lighter steps. Overridable
+// per-engine via SetVerifyTimeout (tests use a short value).
+const verifyChecksDefaultTimeout = 10 * time.Minute
+
+// verifyChecksOutputTail caps how much command output is kept in the artifact.
+const verifyChecksOutputTail = 8000
+
+// verifyBlessedTag lets a human accept a verify failure (e.g. a known-flaky
+// suite) and let the task proceed instead of re-blocking on every re-dispatch.
+const verifyBlessedTag = "verify-blessed"
+
+// verifyChecksReport is the structured result, stored as a generic artifact.
+type verifyChecksReport struct {
+	Commands   []string `json:"commands"`
+	FailedCmd  string   `json:"failedCmd,omitempty"`
+	OutputTail string   `json:"outputTail,omitempty"`
+}
+
+// execVerifyChecks runs the project's deterministic verify suite
+// (`checks.verify`, opt-in) in the agent's worktree before it hands off to
+// review. A non-zero exit flips the task to human-required so an implementation
+// that does not pass its own declared verification suite cannot reach a PR.
+// Complements detect_tampering (phase 1): structural test tampering is caught
+// there; this catches incomplete/broken work the agent committed without the
+// suite passing.
+//
+// The commands run in the agent's already-set-up worktree with no git mutation,
+// reusing the same `sh -c` + inherited-env mechanism as worktree setup so the
+// toolchain (mise) resolves identically.
+//
+// Short-circuits (no block): the verify-blessed tag, no CheckConfigGetter, no
+// verify commands configured, or no worktree. A genuine command failure — or
+// the suite exceeding the time budget (an agent could hang a test to dodge) —
+// blocks. Only engine-shutdown cancellation fails open, so a harness problem on
+// teardown never strands work.
+func (e *Engine) execVerifyChecks(taskID string, step *Step, t TaskInfo) (StepOutput, error) {
+	if slices.Contains(t.Tags, verifyBlessedTag) {
+		e.logger.Info("workflow.verify-checks.blessed", "task_id", taskID)
+		return stepDone(step, "blessed")
+	}
+	if e.checks == nil {
+		return stepDone(step, "skipped: no check config getter")
+	}
+	cmds := e.checks.VerifyCommands(taskID)
+	if len(cmds) == 0 {
+		return stepDone(step, "skipped: no verify commands configured")
+	}
+	if e.worktrees == nil {
+		return stepDone(step, "skipped: no worktree getter configured")
+	}
+	wtPath, ok := e.worktrees.GetWorktreePath(taskID)
+	if !ok {
+		return stepDone(step, "skipped: no worktree for task")
+	}
+
+	timeout := e.verifyTimeout
+	if timeout <= 0 {
+		timeout = verifyChecksDefaultTimeout
+	}
+	ctx, cancel := context.WithTimeout(e.ctx, timeout)
+	defer cancel()
+
+	maybeMiseTrust(ctx, wtPath)
+	failedCmd, output, runErr := runVerifyCommands(ctx, wtPath, cmds)
+
+	report := verifyChecksReport{
+		Commands: cmds, FailedCmd: failedCmd, OutputTail: tailString(output, verifyChecksOutputTail),
+	}
+	if e.recorder != nil {
+		if data, mErr := json.MarshalIndent(report, "", "  "); mErr == nil {
+			if recErr := e.recorder.PutGeneric(taskID, "verify-checks.json", step.ID, string(data)); recErr != nil {
+				e.logger.Warn("workflow.verify-checks.artifact", "task_id", taskID, "err", recErr)
+			}
+		}
+	}
+
+	// Engine-shutdown cancellation is the only fail-open: there is no point
+	// blocking work the engine is tearing down. Our own deadline fails CLOSED —
+	// otherwise an agent could hang a test past the budget to dodge the gate.
+	if runErr != nil {
+		if errors.Is(runErr, context.DeadlineExceeded) {
+			reason := "verify suite exceeded the time budget (" + timeout.String() +
+				") — fix slow or hanging tests, or add the `verify-blessed` tag to override"
+			return e.flagVerifyChecks(taskID, step, reason, "timeout")
+		}
+		e.logger.Warn("workflow.verify-checks.canceled", "task_id", taskID, "err", runErr)
+		return stepDone(step, "clean")
+	}
+
+	if failedCmd != "" {
+		reason := "implementation does not pass the project verify suite: " + trimDiffLine(failedCmd) +
+			" — fix the code, or add the `verify-blessed` tag to override (e.g. a known-flaky suite)"
+		return e.flagVerifyChecks(taskID, step, reason, failedCmd)
+	}
+
+	e.logger.Info("workflow.verify-checks.clean", "task_id", taskID, "commands", len(cmds))
+	return stepDone(step, "clean")
+}
+
+// flagVerifyChecks flips the task to human-required. A failed status write
+// returns an error so the workflow stalls instead of advancing past the gate —
+// the YAML transition keys off task.status, so a silently-failed write would
+// otherwise route a failing implementation straight to review.
+func (e *Engine) flagVerifyChecks(taskID string, step *Step, reason, detail string) (StepOutput, error) {
+	if statusErr := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); statusErr != nil {
+		return StepOutput{}, fmt.Errorf("verify-checks: set human-required: %w", statusErr)
+	}
+	e.logger.Warn("workflow.verify-checks.flagged", "task_id", taskID, "detail", detail)
+	return stepDone(step, "flagged")
+}
+
+// maybeMiseTrust trusts a mise config in the worktree before running verify
+// commands, mirroring worktree setup. A task that adds or edits mise config
+// would otherwise hit "config not trusted" and fail verify on honest work.
+// Best-effort: errors are ignored (the verify command surfaces any real issue).
+func maybeMiseTrust(ctx context.Context, wtPath string) {
+	for _, name := range []string{"mise.toml", ".mise.toml", "mise.local.toml"} {
+		if _, err := os.Stat(filepath.Join(wtPath, name)); err == nil {
+			cmd := exec.CommandContext(ctx, "sh", "-c", "mise trust --yes")
+			cmd.Dir = wtPath
+			_ = cmd.Run()
+			return
+		}
+	}
+}
+
+func stepDone(step *Step, output string) (StepOutput, error) {
+	return StepOutput{StepID: step.ID, Status: "completed", Output: output}, nil
+}
+
+// runVerifyCommands runs each command in order in the worktree via `sh -c`.
+// Returns the first command that exited non-zero (a real failure → caller
+// blocks). A non-nil err means the run could not complete (ctx timeout/cancel)
+// — the caller fails open rather than blocking on infra.
+func runVerifyCommands(ctx context.Context, wtPath string, cmds []string) (failedCmd, output string, err error) {
+	var buf strings.Builder
+	for _, raw := range cmds {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", buf.String(), ctxErr
+		}
+		cmd := exec.CommandContext(ctx, "sh", "-c", raw)
+		cmd.Dir = wtPath
+		out, runErr := cmd.CombinedOutput()
+		buf.WriteString("$ " + raw + "\n")
+		buf.Write(out)
+		buf.WriteString("\n")
+		if runErr != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return "", buf.String(), ctxErr
+			}
+			return raw, buf.String(), nil
+		}
+	}
+	return "", buf.String(), nil
+}
+
+// tailString returns the last n bytes of s, prefixed with an elision marker
+// when truncated. Debug output — not rune-aligned at the cut.
+func tailString(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return "…(truncated)…\n" + s[len(s)-n:]
+}

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
-	"strings"
+	"sync"
 	"time"
 )
 
@@ -18,7 +19,12 @@ import (
 // per-engine via SetVerifyTimeout (tests use a short value).
 const verifyChecksDefaultTimeout = 10 * time.Minute
 
-// verifyChecksOutputTail caps how much command output is kept in the artifact.
+// verifyChecksMaxOutput bounds how much command output is retained in memory.
+// A noisy or malicious verify command must not be able to OOM the engine, so
+// output streams into a fixed-size tail buffer rather than a growing slice.
+const verifyChecksMaxOutput = 64 * 1024
+
+// verifyChecksOutputTail caps how much of that buffer is stored in the artifact.
 const verifyChecksOutputTail = 8000
 
 // verifyBlessedTag lets a human accept a verify failure (e.g. a known-flaky
@@ -100,7 +106,7 @@ func (e *Engine) execVerifyChecks(taskID string, step *Step, t TaskInfo) (StepOu
 			return e.flagVerifyChecks(taskID, step, reason, "timeout")
 		}
 		e.logger.Warn("workflow.verify-checks.canceled", "task_id", taskID, "err", runErr)
-		return stepDone(step, "clean")
+		return stepDone(step, "skipped: context canceled")
 	}
 
 	if failedCmd != "" {
@@ -146,28 +152,56 @@ func stepDone(step *Step, output string) (StepOutput, error) {
 
 // runVerifyCommands runs each command in order in the worktree via `sh -c`.
 // Returns the first command that exited non-zero (a real failure → caller
-// blocks). A non-nil err means the run could not complete (ctx timeout/cancel)
-// — the caller fails open rather than blocking on infra.
+// blocks). A non-nil err means the run could not complete (ctx timeout/cancel);
+// the caller decides the policy (fail closed on our deadline, open on shutdown).
+// Output streams into a fixed-size tail buffer so a flood of stdout/stderr
+// cannot exhaust memory.
 func runVerifyCommands(ctx context.Context, wtPath string, cmds []string) (failedCmd, output string, err error) {
-	var buf strings.Builder
+	tail := &boundedTail{max: verifyChecksMaxOutput}
 	for _, raw := range cmds {
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return "", buf.String(), ctxErr
+			return "", tail.String(), ctxErr
 		}
+		_, _ = io.WriteString(tail, "$ "+raw+"\n")
 		cmd := exec.CommandContext(ctx, "sh", "-c", raw)
 		cmd.Dir = wtPath
-		out, runErr := cmd.CombinedOutput()
-		buf.WriteString("$ " + raw + "\n")
-		buf.Write(out)
-		buf.WriteString("\n")
+		cmd.Stdout = tail
+		cmd.Stderr = tail
+		runErr := cmd.Run()
+		_, _ = io.WriteString(tail, "\n")
 		if runErr != nil {
 			if ctxErr := ctx.Err(); ctxErr != nil {
-				return "", buf.String(), ctxErr
+				return "", tail.String(), ctxErr
 			}
-			return raw, buf.String(), nil
+			return raw, tail.String(), nil
 		}
 	}
-	return "", buf.String(), nil
+	return "", tail.String(), nil
+}
+
+// boundedTail is a concurrency-safe io.Writer that retains only the last `max`
+// bytes written. os/exec writes stdout and stderr from separate goroutines when
+// they share a non-*os.File writer, so Write must be guarded.
+type boundedTail struct {
+	mu  sync.Mutex
+	max int
+	buf []byte
+}
+
+func (b *boundedTail) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf = append(b.buf, p...)
+	if len(b.buf) > b.max {
+		b.buf = b.buf[len(b.buf)-b.max:]
+	}
+	return len(p), nil
+}
+
+func (b *boundedTail) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return string(b.buf)
 }
 
 // tailString returns the last n bytes of s, prefixed with an elision marker

--- a/internal/workflow/engine_steps_verify_checks_test.go
+++ b/internal/workflow/engine_steps_verify_checks_test.go
@@ -1,0 +1,181 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type fakeCheckGetter struct{ cmds []string }
+
+func (f *fakeCheckGetter) VerifyCommands(string) []string { return f.cmds }
+
+func newVerifyChecksStep() *Step { return &Step{ID: "verify_checks", Type: StepVerifyChecks} }
+
+func newVerifyChecksEngine(t *testing.T, wt string, cmds []string) (*Engine, *memTasks) {
+	t.Helper()
+	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: wt, ok: true})
+	engine.SetCheckConfigGetter(&fakeCheckGetter{cmds: cmds})
+	return engine, engine.tasks.(*memTasks)
+}
+
+func TestExecVerifyChecks_NoGetterSkips(t *testing.T) {
+	t.Parallel()
+	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	engine.SetWorktreeGetter(&fakeWorktreeGetter{path: t.TempDir(), ok: true})
+
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "skipped: no check config getter" {
+		t.Errorf("Output = %q, want skip", out.Output)
+	}
+}
+
+func TestExecVerifyChecks_NoCommandsSkips(t *testing.T) {
+	t.Parallel()
+	engine, tasks := newVerifyChecksEngine(t, t.TempDir(), nil)
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "skipped: no verify commands configured" {
+		t.Errorf("Output = %q, want skip", out.Output)
+	}
+}
+
+func TestExecVerifyChecks_PassIsClean(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	engine, tasks := newVerifyChecksEngine(t, wt, []string{"true", "echo ok"})
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "clean" {
+		t.Fatalf("Output = %q, want clean", out.Output)
+	}
+	if ti, _ := tasks.GetTask("t1"); ti.Status != "in-progress" {
+		t.Errorf("status = %q, want unchanged", ti.Status)
+	}
+}
+
+func TestExecVerifyChecks_FailureFlags(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	// First command passes, second fails — the failing one is reported.
+	engine, tasks := newVerifyChecksEngine(t, wt, []string{"true", "exit 1"})
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "flagged" {
+		t.Fatalf("Output = %q, want flagged", out.Output)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+	if r := tasks.Reason("t1"); r == "" {
+		t.Errorf("expected a non-empty status reason")
+	}
+}
+
+func TestExecVerifyChecks_BlessedTagSkips(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	engine, tasks := newVerifyChecksEngine(t, wt, []string{"exit 1"}) // would fail
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(),
+		TaskInfo{ID: "t1", Tags: []string{"verify-blessed"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "blessed" {
+		t.Errorf("Output = %q, want blessed (tag short-circuits before running)", out.Output)
+	}
+	if ti, _ := tasks.GetTask("t1"); ti.Status != "in-progress" {
+		t.Errorf("status = %q, want unchanged (blessed)", ti.Status)
+	}
+}
+
+func TestExecVerifyChecks_TimeoutFailsClosed(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	engine, tasks := newVerifyChecksEngine(t, wt, []string{"sleep 30"}) // hangs past budget
+	engine.SetVerifyTimeout(150 * time.Millisecond)
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "flagged" {
+		t.Fatalf("Output = %q, want flagged (our own timeout must fail closed)", out.Output)
+	}
+	if ti, _ := tasks.GetTask("t1"); ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required (an agent could hang a test to dodge)", ti.Status)
+	}
+}
+
+func TestRunVerifyCommands_DeadlineReturnsCtxErr(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	failed, _, err := runVerifyCommands(ctx, wt, []string{"sleep 20"})
+	if err == nil {
+		t.Fatal("expected a context error on deadline, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v, want context.DeadlineExceeded", err)
+	}
+	if failed != "" {
+		t.Errorf("failedCmd = %q, want empty (deadline is not a command failure)", failed)
+	}
+}
+
+func TestBuiltinSimpleTaskImplement_VerifyChecksWiring(t *testing.T) {
+	t.Parallel()
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var impl *Definition
+	for i := range defs {
+		if defs[i].ID == "simple-task-implement" {
+			impl = &defs[i]
+			break
+		}
+	}
+	if impl == nil {
+		t.Fatal("simple-task-implement builtin not found")
+	}
+	vc := impl.StepByID("verify_checks")
+	if vc == nil {
+		t.Fatal("verify_checks step missing from simple-task-implement")
+	}
+	dt := impl.StepByID("detect_tampering")
+	if dt == nil {
+		t.Fatal("detect_tampering step missing")
+	}
+	if got, _ := ResolveTransition(dt.Next, map[string]string{"task.status": "in-progress"}); got != "verify_checks" {
+		t.Errorf("detect_tampering clean goto = %q, want verify_checks", got)
+	}
+	if got, _ := ResolveTransition(vc.Next, map[string]string{"task.status": "human-required"}); got != "" {
+		t.Errorf("flagged verify_checks goto = %q, want end", got)
+	}
+	if got, _ := ResolveTransition(vc.Next, map[string]string{"task.status": "in-progress"}); got != "set_ready_review" {
+		t.Errorf("clean verify_checks goto = %q, want set_ready_review", got)
+	}
+}

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -93,6 +93,13 @@ const (
 	// deleted test files, neutered CI). A high-severity finding flips the task
 	// to human-required so it cannot reach done without an explicit human bless.
 	StepDetectTampering StepType = "detect_tampering"
+	// StepVerifyChecks runs the project's deterministic verify suite
+	// (checks.verify, opt-in) on the agent's branch HEAD before review. A
+	// non-zero exit flips the task to human-required so an implementation that
+	// does not pass its own declared tests cannot reach a PR. Complements
+	// detect_tampering: structural test tampering is caught there; this catches
+	// incomplete/broken work committed without the suite passing.
+	StepVerifyChecks StepType = "verify_checks"
 	// StepRouteTestResult reads the test-runner verdict and routes the task:
 	// pass → ready-pr, fail → in-progress (re-implement) until the attempt
 	// cap is hit, then human-required.


### PR DESCRIPTION
## Motivation

Phase 2 of reward-hacking defense (follow-up to #1072, which shipped the
phase-1 diff inspector in #1106). The implement workflow had no
deterministic gate that the agent's code actually passes the project's
tests before a PR is opened — an agent could commit incomplete or broken
work and reach review. This adds that gate.

> Changelog: feat(verify): add verify-checks gate

## Implementation information

New `verify_checks` workflow step that runs the project's `checks.verify`
suite (opt-in) in the agent's worktree before review. A non-zero exit
flips the task to `human-required`, so an implementation that does not
pass its own declared tests cannot reach a PR. It complements
`detect_tampering` (phase 1): structural test tampering is caught there;
this catches incomplete/broken work committed without the suite passing.

- `checks.verify` field added to `.sybra.yaml` / project config, merged
  repo-over-app via `MergeChecks`; resolved by a `CheckConfigGetter`
  adapter.
- Runs via `sh -c` in the worktree (same toolchain mechanism as worktree
  setup), with `mise trust` parity. No git mutation.
- **Fails closed** on the time budget (an agent could hang a test to
  dodge the gate) and on a status-write error; only engine-shutdown
  cancellation fails open.
- `verify-blessed` tag overrides a known-flaky suite without livelock.
- Wired into `simple-task-implement` after `detect_tampering`.
- Dogfooded: synapse's `.sybra.yaml` sets
  `verify: [mise exec -- go test ./internal/... ./cmd/...]` (scoped to
  avoid the root package's `//go:embed all:frontend/dist`).

### Design note (why not the restore-based baseline?)

The originally-sketched phase 2 was a restore-based Pass-to-Pass check
(restore the agent's test changes to origin/main, re-run). Adversarial
review showed it is unsafe: it blocks legitimate test+impl co-evolution
(rename a symbol + update its test → the restored old test won't compile)
and is gameable via the worktree config. Robust literal hardcoded-value
detection needs a curated invariant test set Sybra does not have, so that
remains a documented gap; this safe gate was chosen instead.

This also lands the deterministic-verify-gate core requested in #1058
(focused subset: a single ordered verify list + budget + artifact).

## Supporting documentation

Relates to #1072 (phase 2) and #1058. Table-driven tests cover
pass/fail/blessed/skip, the fail-closed timeout path (the security-
critical bypass an adversarial review found), and the workflow wiring.