### PR TITLE
fix(agent): guard onComplete with completedOnce

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -391,8 +391,8 @@ func (m *Manager) RespondEscalation(agentID string, continueRun bool) error {
 	return nil
 }
 
-// recordCompletion is called from every runner's terminal site just before
-// onComplete fires. Records duration + result into the metrics pipeline.
+// recordCompletion records duration + result into the metrics pipeline.
+// Call through fireComplete — do not call directly from runner terminal sites.
 func (m *Manager) recordCompletion(a *Agent, ok bool) {
 	dur := time.Since(a.StartedAt)
 	result := "ok"

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -402,6 +402,19 @@ func (m *Manager) recordCompletion(a *Agent, ok bool) {
 	metrics.AgentCompleted(result, dur)
 }
 
+// fireComplete records completion metrics and fires onComplete exactly once
+// per agent. The guard prevents a second runner goroutine (e.g.
+// runner_convo_survive whose tail is still live when runner_convo exits) from
+// calling onComplete a second time and double-advancing the workflow.
+func (m *Manager) fireComplete(a *Agent, ok bool) {
+	a.completedOnce.Do(func() {
+		m.recordCompletion(a, ok)
+		if m.onComplete != nil {
+			m.onComplete(a)
+		}
+	})
+}
+
 // RunningCount returns the number of currently running agents.
 func (m *Manager) RunningCount() int {
 	m.mu.RLock()

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -214,6 +214,49 @@ func TestStopAgent(t *testing.T) {
 	}
 }
 
+// TestFireComplete_IdempotentUnderConcurrency verifies that two runner
+// goroutines both reaching their terminal site for the same agent (the
+// runner_convo + runner_convo_survive double-fire scenario) call onComplete
+// exactly once.
+func TestFireComplete_IdempotentUnderConcurrency(t *testing.T) {
+	t.Parallel()
+	m, _ := newTestManager(t)
+
+	var (
+		mu    sync.Mutex
+		count int
+	)
+	m.SetOnComplete(func(_ *Agent) {
+		mu.Lock()
+		count++
+		mu.Unlock()
+	})
+
+	a := &Agent{
+		ID:     "race-agent",
+		TaskID: "task-1",
+		Mode:   "interactive",
+		State:  StateStopped,
+		done:   make(chan struct{}),
+		cancel: func() {},
+	}
+
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Go(func() {
+			m.fireComplete(a, true)
+		})
+	}
+	wg.Wait()
+
+	mu.Lock()
+	got := count
+	mu.Unlock()
+	if got != 1 {
+		t.Errorf("onComplete called %d times, want exactly 1", got)
+	}
+}
+
 // TestStopHeadlessDoesNotCallOnComplete verifies that StopAgent for a headless
 // agent does not call onComplete immediately — only the goroutine may call it
 // after the process exits, preventing premature worktree cleanup.

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -233,12 +233,13 @@ func TestFireComplete_IdempotentUnderConcurrency(t *testing.T) {
 	})
 
 	a := &Agent{
-		ID:     "race-agent",
-		TaskID: "task-1",
-		Mode:   "interactive",
-		State:  StateStopped,
-		done:   make(chan struct{}),
-		cancel: func() {},
+		ID:        "race-agent",
+		TaskID:    "task-1",
+		Mode:      "interactive",
+		State:     StateStopped,
+		StartedAt: time.Now(),
+		done:      make(chan struct{}),
+		cancel:    func() {},
 	}
 
 	var wg sync.WaitGroup

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -103,6 +103,11 @@ type Agent struct {
 	// doneOnce prevents double-close on done and lets Manager maintain an
 	// exact live-agent count even when multiple terminal paths race.
 	doneOnce sync.Once
+	// completedOnce guards recordCompletion + onComplete so that two runner
+	// goroutines reaching their terminal sites for the same agent (e.g.
+	// runner_convo and runner_convo_survive both firing when the process exits
+	// while a reattach tail is still live) only advance the workflow once.
+	completedOnce sync.Once
 
 	// escalationCh receives the human's decision when a guardrail is hit.
 	// true = continue, false = kill.

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -136,10 +136,7 @@ func (m *Manager) finalizeIfCompleted(r Record) bool {
 	}
 	a.SetState(StateStopped)
 	m.logger.Info("agent.reattach.recovered-complete", "id", a.ID, "task", a.TaskID)
-	m.recordCompletion(a, true)
-	if m.onComplete != nil {
-		m.onComplete(a)
-	}
+	m.fireComplete(a, true)
 	return true
 }
 
@@ -302,10 +299,7 @@ func (m *Manager) reattachHeadless(ctx context.Context, a *Agent, startOffset in
 	a.SetState(StateStopped)
 	m.logger.Info("agent.reattach.done", "id", a.ID, "cost", a.GetCostUSD())
 	m.emit(events.AgentState(a.ID), a)
-	m.recordCompletion(a, a.GetExitErr() == nil)
-	if m.onComplete != nil {
-		m.onComplete(a)
-	}
+	m.fireComplete(a, a.GetExitErr() == nil)
 	m.markAgentDone(a)
 }
 

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -142,10 +142,7 @@ func (m *Manager) runPerTurnConversational(ctx context.Context, a *Agent, cfg Ru
 		a.SetState(StateStopped)
 		m.logger.Info("agent.convo.done", "id", a.ID, "provider", a.Provider, "cost", a.GetCostUSD())
 		m.emit(events.AgentState(a.ID), a)
-		m.recordCompletion(a, a.GetExitErr() == nil)
-		if m.onComplete != nil {
-			m.onComplete(a)
-		}
+		m.fireComplete(a, a.GetExitErr() == nil)
 		m.markAgentDone(a)
 	}()
 

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -200,10 +200,7 @@ done:
 	a.SetState(StateStopped)
 	m.logger.Info("agent.convo.done", "id", a.ID, "cost", a.GetCostUSD())
 	m.emit(events.AgentState(a.ID), a)
-	m.recordCompletion(a, a.GetExitErr() == nil)
-	if m.onComplete != nil {
-		m.onComplete(a)
-	}
+	m.fireComplete(a, a.GetExitErr() == nil)
 	m.markAgentDone(a)
 }
 

--- a/internal/agent/runner_convo_survive.go
+++ b/internal/agent/runner_convo_survive.go
@@ -429,9 +429,6 @@ func (m *Manager) reattachConvo(ctx context.Context, a *Agent, startOffset int64
 	a.SetState(StateStopped)
 	m.logger.Info("agent.reattach.convo.done", "id", a.ID, "cost", a.GetCostUSD())
 	m.emit(events.AgentState(a.ID), a)
-	m.recordCompletion(a, a.GetExitErr() == nil)
-	if m.onComplete != nil {
-		m.onComplete(a)
-	}
+	m.fireComplete(a, a.GetExitErr() == nil)
 	m.markAgentDone(a)
 }

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -100,10 +100,7 @@ done:
 	a.SetState(StateStopped)
 	m.logger.Info("agent.headless.done", "id", a.ID, "cost", a.GetCostUSD())
 	m.emit(events.AgentState(a.ID), a)
-	m.recordCompletion(a, a.GetExitErr() == nil)
-	if m.onComplete != nil {
-		m.onComplete(a)
-	}
+	m.fireComplete(a, a.GetExitErr() == nil)
 	// Close `done` only after onComplete returns. HasRunningAgentForTask
 	// gates ResumeStalled; releasing it before the workflow advance handler
 	// runs lets a tight ResumeStalled loop dispatch a duplicate agent.
@@ -646,10 +643,7 @@ func (m *Manager) handleError(a *Agent, err error) {
 	m.logger.Error("agent.error", "id", a.ID, "kind", kind, "err", err)
 	m.emit(events.AgentError(a.ID), ErrorEvent{Kind: kind, Msg: err.Error()})
 	m.emit(events.AgentState(a.ID), a)
-	m.recordCompletion(a, false)
-	if m.onComplete != nil {
-		m.onComplete(a)
-	}
+	m.fireComplete(a, false)
 	m.markAgentDone(a)
 }
 

--- a/internal/agent/shutdown_test.go
+++ b/internal/agent/shutdown_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"context"
 	"errors"
+	"io"
+	"os"
 	"os/exec"
 	"syscall"
 	"testing"
@@ -131,16 +133,34 @@ func TestStopWithSIGINT_ProcessReceivesInterrupt(t *testing.T) {
 // escalates to SIGKILL. Asserts SIGKILL (not hang) as the exit signal.
 func TestStopWithSIGINT_EscalatesToSIGKILL(t *testing.T) {
 	t.Parallel()
-	// bash with SIGINT ignored; sleep subprocess inherits the ignore disposition.
-	cmd := exec.Command("bash", "-c", "trap '' INT; sleep 30")
+	// Synchronize via stdout: bash prints "ready" only after trap '' INT is
+	// in effect, so SIGINT cannot arrive before the SIG_IGN disposition is set.
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+
+	cmd := exec.Command("bash", "-c", "trap '' INT; echo ready; sleep 30")
+	cmd.Stdout = pw
+
 	if err := cmd.Start(); err != nil {
+		pw.Close()
+		pr.Close()
 		t.Fatalf("start: %v", err)
 	}
+	pw.Close() // write end belongs to the child only
 
 	waitErr := make(chan error, 1)
 	go func() { waitErr <- cmd.Wait() }()
 
-	time.Sleep(20 * time.Millisecond) // let process settle
+	// Block until bash has printed "ready", guaranteeing SIG_IGN is active.
+	ready := make([]byte, 6) // "ready\n"
+	if _, err := io.ReadFull(pr, ready); err != nil {
+		pr.Close()
+		t.Fatalf("read ready signal: %v", err)
+	}
+	pr.Close()
+
 	// Pass a done channel that is never closed — simulates SIGINT being ignored.
 	neverDone := make(chan struct{})
 	stopWithSIGINT(cmd, neverDone, 150*time.Millisecond)

--- a/internal/agent/shutdown_test.go
+++ b/internal/agent/shutdown_test.go
@@ -160,6 +160,9 @@ func TestStopWithSIGINT_EscalatesToSIGKILL(t *testing.T) {
 		t.Fatalf("read ready signal: %v", err)
 	}
 	pr.Close()
+	if string(ready) != "ready\n" {
+		t.Fatalf("unexpected ready signal %q, want %q (SIG_IGN guarantee not established)", ready, "ready\n")
+	}
 
 	// Pass a done channel that is never closed — simulates SIGINT being ignored.
 	neverDone := make(chan struct{})


### PR DESCRIPTION
## Motivation

When a headless agent exits while a reattach tail goroutine is still live,
two runner goroutines (`runner_convo` + `runner_convo_survive`, or
`runner_headless` + `reattachHeadless`) can each reach their terminal site and
call `onComplete` for the same agent. The second call raced past the
`code_review` workflow step because `hasTrackedAgentForTaskStep` returned
`false` in the window between `AdvanceStep` clearing the implementation agent
from `agentSteps` and the review agent being registered there (blocked by
`StopAgentsForTask`), causing the workflow to double-advance and skip review.

> Changelog: fix(agent): guard onComplete with completedOnce

## Implementation information

- Added `completedOnce sync.Once` to `Agent` to track per-agent completion state.
- Added `fireComplete` helper on `Manager` that wraps `recordCompletion` +
  `onComplete` inside the guard — only the first caller wins.
- All seven runner terminal sites (`runner_headless`, `runner_convo`,
  `runner_convo_survive`, `runner_codex_convo`, `reattach.go` ×2,
  `handleError`) now call `fireComplete` instead of the inline
  `recordCompletion + onComplete` pattern.
- Updated the stale `recordCompletion` comment to reflect the new call
  contract (go through `fireComplete`).
- Fixed a flaky SIGKILL escalation test: replaced a 20ms timing settle
  (insufficient under the race detector) with pipe-based synchronization —
  bash prints "ready" after setting the trap, test blocks on `io.ReadFull`
  before sending SIGINT, making the race window zero.