### PR TITLE
fix(workflow): scope local sybra bug tasks

### DIFF
--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -278,7 +278,11 @@ func (h *humanReviewHandler) fileLocalScrubbed(taskID, agentID string, v verdict
 		return
 	}
 	tags := append([]string{"sybra-bug", "scrubbed"}, v.IssueLabels...)
-	if _, err := h.tasks.Update(newTask.ID, task.Update{Tags: &tags}); err != nil {
+	update := task.Update{Tags: &tags}
+	if projectID := strings.TrimSpace(h.cfg.HumanReviewRepo()); projectID != "" {
+		update.ProjectID = &projectID
+	}
+	if _, err := h.tasks.Update(newTask.ID, update); err != nil {
 		h.logger.Warn("human-review.local.tag", "new_task_id", newTask.ID, "err", err)
 	}
 	h.logAudit(audit.EventHumanReviewIssue, taskID, agentID, map[string]any{

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -388,6 +388,9 @@ func TestOnComplete_WorkProject_LocalTaskScrubbed(t *testing.T) {
 	wantTag("sybra-bug")
 	wantTag("scrubbed")
 	wantTag("workflow")
+	if local.ProjectID != h.cfg.HumanReviewRepo() {
+		t.Errorf("local task project_id = %q, want %q", local.ProjectID, h.cfg.HumanReviewRepo())
+	}
 }
 
 func TestOnComplete_MalformedVerdict_AppendsRaw(t *testing.T) {

--- a/internal/triage/apply.go
+++ b/internal/triage/apply.go
@@ -18,7 +18,10 @@ import (
 func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project) (task.Task, error) {
 	updates := make(map[string]any, 8)
 
-	projectID := v.ProjectID
+	projectID := strings.TrimSpace(v.ProjectID)
+	if projectID == "" {
+		projectID = strings.TrimSpace(t.ProjectID)
+	}
 	if projectID == "" {
 		projectID = MatchProject(t.Title, t.Body, projects)
 	}

--- a/internal/triage/apply_test.go
+++ b/internal/triage/apply_test.go
@@ -173,6 +173,41 @@ func TestApplyWorkProjectForcesInteractiveAndPlanning(t *testing.T) {
 	}
 }
 
+func TestApplyUsesExistingProjectWhenTaskHasNoRepoURL(t *testing.T) {
+	mgr := newTestManager(t)
+	created, err := mgr.Create("debug workflow completion race", "no repository URL here", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	created, err = mgr.Update(created.ID, task.Update{ProjectID: task.Ptr("example-org/example-repo")})
+	if err != nil {
+		t.Fatalf("Update project: %v", err)
+	}
+	projects := []project.Project{
+		{ID: "example-org/example-repo", Owner: "example-org", Repo: "example-repo", Type: project.ProjectTypeWork},
+	}
+	v := Verdict{
+		Title: "fix(workflow): handle completion race",
+		Size:  "small",
+		Type:  "bug",
+		Mode:  "headless",
+		Tags:  []string{"backend", "small", "bug"},
+	}
+	updated, err := Apply(mgr, created, v, projects)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if updated.ProjectID != "example-org/example-repo" {
+		t.Errorf("project_id: got %q, want example-org/example-repo", updated.ProjectID)
+	}
+	if updated.AgentMode != task.AgentModeInteractive {
+		t.Errorf("mode: got %q, want interactive", updated.AgentMode)
+	}
+	if updated.Status != task.StatusPlanning {
+		t.Errorf("status: got %s, want planning", updated.Status)
+	}
+}
+
 func TestApplyPRFixRunRoleNeverPlanning(t *testing.T) {
 	mgr := newTestManager(t)
 	// Create a work-project task that would normally go to planning.


### PR DESCRIPTION
## Summary
- assign local scrubbed Sybra-bug tasks to the configured Sybra project
- preserve an existing project_id during triage before falling back to URL matching
- add regressions for local human-review tasks and pre-scoped triage routing

## Tests
- go test ./internal/triage ./internal/sybra
- pre-push hook: full Go tests + frontend svelte-check