### PR TITLE
fix(review): keep automatic PR review one-shot

### DIFF
--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -5,7 +5,7 @@
   import { agentStore } from '../stores/agents.svelte.js'
   import { reviewStore } from '../stores/reviews.svelte.js'
   import { awaitsHuman, awaitsHumanLabel, coreStatus, statusLabel } from '../lib/statuses.js'
-  import { isReviewTask as isReviewTaskFn, reviewPhaseMeta, type ReviewPhaseIcon } from '../lib/review-phase.js'
+  import { isReviewTask as isReviewTaskFn, reviewPhaseMeta, reviewPhaseNeedsYou, type ReviewPhaseIcon } from '../lib/review-phase.js'
   import { isOwnPRTask as isOwnPRTaskFn, prPhaseMeta, prPhaseNeedsYou, type PRPhaseIcon } from '../lib/pr-phase.js'
   import { PRIORITY_OPTIONS } from '../lib/priorities.js'
   import { projectShortName, projectDotStyle } from '../lib/project-cue.js'
@@ -59,7 +59,7 @@
   // Task is waiting on the user (not an agent) — drives the red tile accent.
   // The strict own-PR phases (draft / approved) count too, so the card flags
   // "your move" while staying in the In Review column.
-  const needsYou = $derived(awaitsHuman(t.status) || prPhaseNeedsYou(t))
+  const needsYou = $derived(awaitsHuman(t.status) || prPhaseNeedsYou(t) || reviewPhaseNeedsYou(t))
 
   // A granular sub-state folded into this column that ISN'T an attention state
   // (e.g. `new` in Todo, `ready-review` in In Review). The column shows the

--- a/frontend/src/lib/review-phase.test.ts
+++ b/frontend/src/lib/review-phase.test.ts
@@ -4,6 +4,7 @@ import {
   isReviewTask,
   reviewPhaseOf,
   reviewPhaseMeta,
+  reviewPhaseNeedsYou,
   reviewPhaseRank,
   type ReviewPhase,
 } from './review-phase.js'
@@ -66,6 +67,20 @@ describe('reviewPhaseRank', () => {
     const rank = (p: string) => reviewPhaseRank({ reviewPhase: p })
     expect(rank('conflict')).toBeGreaterThan(rank('approved'))
     expect(rank('conflict')).toBeGreaterThan(rank('needs-approval'))
+  })
+})
+
+describe('reviewPhaseNeedsYou', () => {
+  it('flags inbound review phases that need explicit reviewer action', () => {
+    expect(reviewPhaseNeedsYou({ tags: ['review'], reviewPhase: 'manual' })).toBe(true)
+    expect(reviewPhaseNeedsYou({ tags: ['review'], reviewPhase: 'drafted' })).toBe(true)
+    expect(reviewPhaseNeedsYou({ tags: ['review'], reviewPhase: 'needs-approval' })).toBe(true)
+  })
+
+  it('does not flag passive review phases or non-review tasks', () => {
+    expect(reviewPhaseNeedsYou({ tags: ['review'], reviewPhase: 'awaiting-author' })).toBe(false)
+    expect(reviewPhaseNeedsYou({ tags: ['review'], reviewPhase: 'approved' })).toBe(false)
+    expect(reviewPhaseNeedsYou({ reviewPhase: 'needs-approval' })).toBe(false)
   })
 })
 

--- a/frontend/src/lib/review-phase.ts
+++ b/frontend/src/lib/review-phase.ts
@@ -23,10 +23,9 @@ export interface ReviewPhaseMeta {
   classes: string
 }
 
-// The needs-you signal (red tile accent) is driven by the task's status, not
-// duplicated here — the poller sets human-required for the manual/drafted/
-// needs-approval phases, so awaitsHuman(status) stays the single source of
-// truth and can't drift from this table.
+// Needs-you phases drive the red tile accent via reviewPhaseNeedsYou. Drafted
+// and manual also use human-required status, but needs-approval intentionally
+// stays in-review so it cannot start another automatic diagnostic review.
 export const REVIEW_PHASE_META: Record<ReviewPhase, ReviewPhaseMeta> = {
   reviewing: {
     label: 'Reviewing',
@@ -101,4 +100,15 @@ export function reviewPhaseMeta(t: { reviewPhase?: string }): ReviewPhaseMeta {
 export function reviewPhaseRank(t: { reviewPhase?: string }): number {
   const idx = REVIEW_PHASE_ORDER.indexOf(reviewPhaseOf(t))
   return idx === -1 ? REVIEW_PHASE_ORDER.length : idx
+}
+
+const REVIEW_PHASE_NEEDS_YOU: ReadonlySet<ReviewPhase> = new Set<ReviewPhase>([
+  'manual',
+  'drafted',
+  'needs-approval',
+])
+
+/** True when an inbound PR review task awaits the user's review action. */
+export function reviewPhaseNeedsYou(t: { tags?: string[]; reviewPhase?: string }): boolean {
+  return isReviewTask(t) && REVIEW_PHASE_NEEDS_YOU.has(reviewPhaseOf(t))
 }

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -5,7 +5,7 @@
   import { projectStore } from '../stores/projects.svelte.js'
   import { notificationStore } from '../stores/notifications.svelte.js'
   import { BOARD_LANES, awaitsHuman, type BoardColumn } from '../lib/statuses.js'
-  import { isReviewTask, reviewPhaseRank } from '../lib/review-phase.js'
+  import { isReviewTask, reviewPhaseNeedsYou, reviewPhaseRank } from '../lib/review-phase.js'
   import { prPhaseRank, prPhaseNeedsYou } from '../lib/pr-phase.js'
   import { navStore } from '../lib/navigation.svelte.js'
   import { matchesQuery, matchesProject, matchesTags, matchesAgentMode } from '../lib/task-filters.js'
@@ -293,7 +293,7 @@
   // Tasks awaiting the user across all columns (same set as the per-card red
   // attention border) — surfaced as a persistent board-toolbar counter so an
   // awaiting task is never missed when its column scrolls off-screen.
-  const needYouCount = $derived(allFilteredTasks.filter((t: Task) => awaitsHuman(t.status) || prPhaseNeedsYou(t)).length)
+  const needYouCount = $derived(allFilteredTasks.filter((t: Task) => awaitsHuman(t.status) || prPhaseNeedsYou(t) || reviewPhaseNeedsYou(t)).length)
 
   const hasActiveFilters = $derived(
     Boolean(searchQuery) || Boolean(selectedProjectId) || selectedTags.length > 0 || Boolean(selectedAgentMode)

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -150,6 +150,7 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 	if err := h.tasks.UpdateRun(ag.TaskID, ag.ID, runUpdates); err != nil {
 		h.logger.Error("task.update-run", "task_id", ag.TaskID, "agent_id", ag.ID, "err", err)
 	}
+	h.markCompletedReview(ag, exitErr)
 
 	// Human-review agents are out-of-band diagnostics — they must not
 	// feed into the workflow engine (which would advance the step that
@@ -207,6 +208,16 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 		if h.sandboxes != nil {
 			go h.sandboxes.Stop(ag.TaskID)
 		}
+	}
+}
+
+func (h *AgentCompletionHandler) markCompletedReview(ag *agent.Agent, exitErr error) {
+	if agent.RoleFromName(ag.Name) != agent.RoleReview || exitErr != nil {
+		return
+	}
+	reviewed := true
+	if _, err := h.tasks.Update(ag.TaskID, task.Update{Reviewed: &reviewed}); err != nil {
+		h.logger.Warn("task.mark-reviewed", "task_id", ag.TaskID, "agent_id", ag.ID, "err", err)
 	}
 }
 

--- a/internal/sybra/app_reviews_inbound.go
+++ b/internal/sybra/app_reviews_inbound.go
@@ -54,7 +54,7 @@ func (r *ReviewHandler) triageReview(t task.Task) {
 		if _, err := r.tasks.Update(t.ID, task.Update{Status: task.Ptr(task.StatusInReview)}); err != nil {
 			r.logger.Error("review.triage.status", "task_id", t.ID, "err", err)
 		}
-		if err := r.startReviewAgent(t); err != nil {
+		if err := r.startReviewAgent(t, false); err != nil {
 			r.logger.Error("review.triage.start", "task_id", t.ID, "err", err)
 		}
 		return
@@ -77,7 +77,7 @@ func (r *ReviewHandler) triageReview(t task.Task) {
 	if _, err := r.tasks.Update(t.ID, task.Update{Status: task.Ptr(task.StatusInReview)}); err != nil {
 		r.logger.Error("review.triage.status", "task_id", t.ID, "err", err)
 	}
-	if err := r.startReviewAgent(t); err != nil {
+	if err := r.startReviewAgent(t, false); err != nil {
 		r.logger.Error("review.triage.start", "task_id", t.ID, "err", err)
 	}
 }
@@ -124,26 +124,48 @@ func (r *ReviewHandler) startFixReviewAgent(t task.Task) error {
 	return nil
 }
 
-func (r *ReviewHandler) startReviewAgent(t task.Task) error {
-	if t.ProjectID == "" || t.PRNumber == 0 {
-		return fmt.Errorf("task %s has no linked PR", t.ID)
+func (r *ReviewHandler) startReviewAgent(t task.Task, force bool) error {
+	current := t
+	if force && r.tasks != nil {
+		if latest, err := r.tasks.Get(t.ID); err == nil {
+			current = latest
+		}
+	}
+	if r.agents != nil {
+		if !r.agents.ClaimTaskDispatch(current.ID) {
+			r.logger.Info("review.agent-skip", "task_id", current.ID, "pr", current.PRNumber, "reason", "dispatch_in_progress")
+			return nil
+		}
+		defer r.agents.ReleaseTaskDispatch(current.ID)
+	}
+	if !force && r.tasks != nil {
+		if latest, err := r.tasks.Get(current.ID); err == nil {
+			current = latest
+		}
+	}
+	if current.ProjectID == "" || current.PRNumber == 0 {
+		return fmt.Errorf("task %s has no linked PR", current.ID)
+	}
+	if !force && reviewAgentAlreadyRan(current) {
+		r.logger.Info("review.agent-skip", "task_id", current.ID, "pr", current.PRNumber, "reason", "already_reviewed")
+		return nil
 	}
 
 	dir := config.HomeDir()
-	if t.ProjectID != "" {
-		d, err := r.worktrees.PrepareForReview(t)
+	if current.ProjectID != "" {
+		d, err := r.worktrees.PrepareForReview(current)
 		if err != nil {
-			r.logger.Error("review.worktree", "task_id", t.ID, "err", err)
+			r.logger.Error("review.worktree", "task_id", current.ID, "err", err)
 		} else {
 			dir = d
 		}
 	}
 
-	prompt := fmt.Sprintf("Run /staff-code-review on https://github.com/%s/pull/%d", t.ProjectID, t.PRNumber)
+	prompt := fmt.Sprintf("Run /staff-code-review on https://github.com/%s/pull/%d", current.ProjectID, current.PRNumber)
 
 	ag, err := r.agents.Run(agent.RunConfig{
-		TaskID: t.ID,
-		Name:   agent.RoleReview.AgentName(t.Title),
+		TaskID: current.ID,
+		Name:   agent.RoleReview.AgentName(current.Title),
 		Mode:   "headless",
 		Prompt: prompt,
 		Dir:    dir,
@@ -154,15 +176,28 @@ func (r *ReviewHandler) startReviewAgent(t task.Task) error {
 	if err != nil {
 		return err
 	}
-	if err := r.tasks.AddRun(t.ID, task.AgentRun{
+	if err := r.tasks.AddRun(current.ID, task.AgentRun{
 		AgentID: ag.ID, Role: string(agent.RoleReview), Mode: "headless", State: string(agent.StateRunning), StartedAt: ag.StartedAt,
 		Prompt: prompt,
 	}); err != nil {
-		r.logger.Error("task.add-run", "task_id", t.ID, "err", err)
+		r.logger.Error("task.add-run", "task_id", current.ID, "err", err)
+		if stopErr := r.agents.StopAgent(ag.ID); stopErr != nil {
+			return fmt.Errorf("record review run: %w; stop started agent %s: %w", err, ag.ID, stopErr)
+		}
+		return fmt.Errorf("record review run: %w", err)
 	}
-	r.logAudit(audit.EventReviewStarted, t.ID, ag.ID, map[string]any{"pr": t.PRNumber})
-	r.logger.Info("review.agent-started", "task_id", t.ID, "agent_id", ag.ID, "pr", t.PRNumber)
+	r.logAudit(audit.EventReviewStarted, current.ID, ag.ID, map[string]any{"pr": current.PRNumber})
+	r.logger.Info("review.agent-started", "task_id", current.ID, "agent_id", ag.ID, "pr", current.PRNumber)
 	return nil
+}
+
+func reviewAgentAlreadyRan(t task.Task) bool {
+	if t.Reviewed {
+		return true
+	}
+	return slices.ContainsFunc(t.AgentRuns, func(r task.AgentRun) bool {
+		return r.Role == string(agent.RoleReview)
+	})
 }
 
 func (r *ReviewHandler) maybeCreateReviewTasks(tasks []task.Task, reviewPRs []github.PullRequest) {

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -300,6 +300,49 @@ func TestCreateReviewTaskPassesUpdatedTaskToTriage(t *testing.T) {
 	}
 }
 
+func TestReviewAgentAlreadyRan(t *testing.T) {
+	tests := []struct {
+		name string
+		tk   task.Task
+		want bool
+	}{
+		{
+			name: "reviewed flag counts",
+			tk:   task.Task{Reviewed: true},
+			want: true,
+		},
+		{
+			name: "prior review run counts even while running",
+			tk: task.Task{AgentRuns: []task.AgentRun{
+				{Role: string(agent.RoleReview), State: string(agent.StateRunning)},
+			}},
+			want: true,
+		},
+		{
+			name: "human diagnostic does not count as staff review",
+			tk: task.Task{AgentRuns: []task.AgentRun{
+				{Role: string(agent.RoleHumanReview), State: string(agent.StateStopped)},
+			}},
+			want: false,
+		},
+		{
+			name: "fix-review does not count as staff review",
+			tk: task.Task{AgentRuns: []task.AgentRun{
+				{Role: string(agent.RoleFixReview), State: string(agent.StateStopped)},
+			}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reviewAgentAlreadyRan(tt.tk); got != tt.want {
+				t.Fatalf("reviewAgentAlreadyRan() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestCancelResolvedPRFixWorkflows covers the loop where pr-fix kept
 // re-spawning agents long after the underlying CI failure was resolved.
 // The fix: cancel any in-flight pr-fix workflow whose pr_issue_kind is no

--- a/internal/sybra/review_phase.go
+++ b/internal/sybra/review_phase.go
@@ -21,7 +21,9 @@ const (
 	// the PR author's court to push changes / respond.
 	ReviewPhaseAwaitingAuthor = "awaiting-author"
 	// ReviewPhaseNeedsApproval: the author re-requested review or pushed past
-	// the reviewed commit — the human needs a final pass and approval.
+	// the reviewed commit. This is a visible reviewer action, but it must not
+	// flip the task to human-required: the one automatic review round is already
+	// spent, so the follow-up is manual approval only.
 	ReviewPhaseNeedsApproval = "needs-approval"
 	// ReviewPhaseApproved: the human approved; the PR is waiting to merge.
 	ReviewPhaseApproved = "approved"
@@ -122,12 +124,14 @@ func computeReviewPhase(s reviewSignals) reviewPhaseResult {
 
 	if s.Submitted {
 		// The author pushed past the commit we reviewed, or re-requested review:
-		// either way it needs a fresh human pass before approval.
+		// either way it needs a fresh human pass before approval. Keep the task
+		// in-review so the human-required auto-diagnostic machinery does not
+		// start another review round.
 		advanced := s.HeadSHA != "" && s.ReviewedSHA != "" && s.HeadSHA != s.ReviewedSHA
 		if s.ReRequested || advanced {
 			return reviewPhaseResult{
 				Phase:  ReviewPhaseNeedsApproval,
-				Status: task.StatusHumanRequired,
+				Status: task.StatusInReview,
 				Reason: "Author updated PR — do a final review & approve",
 			}
 		}

--- a/internal/sybra/review_phase_test.go
+++ b/internal/sybra/review_phase_test.go
@@ -60,12 +60,12 @@ func TestComputeReviewPhase(t *testing.T) {
 		{
 			name: "author pushed past reviewed commit → needs approval",
 			sig:  reviewSignals{Submitted: true, HeadSHA: "sha2", ReviewedSHA: "sha1"},
-			want: reviewPhaseResult{Phase: ReviewPhaseNeedsApproval, Status: task.StatusHumanRequired, Reason: "Author updated PR — do a final review & approve"},
+			want: reviewPhaseResult{Phase: ReviewPhaseNeedsApproval, Status: task.StatusInReview, Reason: "Author updated PR — do a final review & approve"},
 		},
 		{
 			name: "re-requested after review → needs approval even at same head",
 			sig:  reviewSignals{Submitted: true, ReRequested: true, HeadSHA: "sha1", ReviewedSHA: "sha1"},
-			want: reviewPhaseResult{Phase: ReviewPhaseNeedsApproval, Status: task.StatusHumanRequired, Reason: "Author updated PR — do a final review & approve"},
+			want: reviewPhaseResult{Phase: ReviewPhaseNeedsApproval, Status: task.StatusInReview, Reason: "Author updated PR — do a final review & approve"},
 		},
 		{
 			name: "no agent, no draft, not submitted → manual (small-PR punt)",

--- a/internal/sybra/svc_reviews.go
+++ b/internal/sybra/svc_reviews.go
@@ -22,7 +22,7 @@ func (s *ReviewService) StartReview(taskID string) error {
 	if t.ProjectID == "" || t.PRNumber == 0 {
 		return fmt.Errorf("task %s has no linked PR", taskID)
 	}
-	return s.reviewer.startReviewAgent(t)
+	return s.reviewer.startReviewAgent(t, true)
 }
 
 // StartFixReview starts a headless fix-review agent that applies unresolved


### PR DESCRIPTION
## Summary
- Keep inbound review follow-up approval in the review lane instead of flipping to human-required.
- Add one-shot automatic staff-review dispatch guards, including a per-task reservation for racing dispatches.
- Preserve manual review reruns and keep the review lane's needs-you highlight for final approval.

## Tests
- go test ./internal/sybra
- npm run test -- review-phase
- npm run check
- pre-push hook: go test ./... and npm run check