### PR TITLE
fix(provider): debounce probe errors

### DIFF
--- a/internal/provider/health.go
+++ b/internal/provider/health.go
@@ -29,12 +29,18 @@ type Config struct {
 	ClaudeRLCooldown  time.Duration
 	CodexRLCooldown   time.Duration
 	CopilotRLCooldown time.Duration
+	// ProbeErrorThreshold is the number of consecutive generic probe_error
+	// results required before a provider is marked unhealthy. Auth and
+	// rate-limit states still apply immediately.
+	ProbeErrorThreshold int
 }
 
 // failoverPriority is the order auto-failover prefers healthy peers in.
 // Copilot is last: it is never chosen over claude/codex, but can be a
 // fallback target when both are unhealthy, and can itself fail over to them.
 var failoverPriority = []string{"claude", "codex", "copilot"}
+
+const defaultProbeErrorThreshold = 2
 
 // HealthGate is the small surface the agent Manager depends on. Kept minimal
 // so tests can supply a fake without spinning up a Checker.
@@ -72,6 +78,10 @@ type Checker struct {
 	mu       sync.RWMutex
 	cfg      Config
 	statuses map[string]*Status
+	// probeFailures tracks consecutive generic probe_error results. The first
+	// one is treated as a soft failure so a transient local CLI hiccup does not
+	// flash a global provider outage or gate otherwise-working agents.
+	probeFailures map[string]int
 
 	emit   func(event string, data any)
 	logger *slog.Logger
@@ -96,6 +106,9 @@ func New(cfg Config, emit func(string, any), logger *slog.Logger) *Checker {
 	if cfg.CopilotRLCooldown <= 0 {
 		cfg.CopilotRLCooldown = 15 * time.Minute
 	}
+	if cfg.ProbeErrorThreshold <= 0 {
+		cfg.ProbeErrorThreshold = defaultProbeErrorThreshold
+	}
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -103,14 +116,15 @@ func New(cfg Config, emit func(string, any), logger *slog.Logger) *Checker {
 		emit = func(string, any) {}
 	}
 	c := &Checker{
-		cfg:          cfg,
-		statuses:     make(map[string]*Status),
-		emit:         emit,
-		logger:       logger,
-		probeClaude:  ProbeClaude,
-		probeCodex:   ProbeCodex,
-		probeCopilot: ProbeCopilot,
-		now:          time.Now,
+		cfg:           cfg,
+		statuses:      make(map[string]*Status),
+		probeFailures: make(map[string]int),
+		emit:          emit,
+		logger:        logger,
+		probeClaude:   ProbeClaude,
+		probeCodex:    ProbeCodex,
+		probeCopilot:  ProbeCopilot,
+		now:           time.Now,
 	}
 	// Seed defaults so Snapshot returns something meaningful before first probe.
 	c.statuses["claude"] = &Status{Provider: "claude", Healthy: cfg.ClaudeEnabled, Reason: initialReason(cfg.ClaudeEnabled)}
@@ -171,42 +185,103 @@ func (c *Checker) checkAll(ctx context.Context) {
 	}
 	wg.Wait()
 
+	results := make([]probeResult, 0, 3)
 	if doClaude {
-		c.applyProbeResult("claude", claudeStatus, claudeErr)
+		results = append(results, probeResult{provider: "claude", status: claudeStatus, err: claudeErr})
 	}
 	if doCodex {
-		c.applyProbeResult("codex", codexStatus, codexErr)
+		results = append(results, probeResult{provider: "codex", status: codexStatus, err: codexErr})
 	}
 	if doCopilot {
-		c.applyProbeResult("copilot", copilotStatus, copilotErr)
+		results = append(results, probeResult{provider: "copilot", status: copilotStatus, err: copilotErr})
 	}
-	c.clearExpiredRateLimits()
+	c.applyProbeResults(results)
 }
 
-func (c *Checker) applyProbeResult(name string, result Status, err error) {
-	metrics.ProviderProbe(name, err == nil)
-	if err != nil {
+type probeResult struct {
+	provider string
+	status   Status
+	err      error
+}
+
+func (c *Checker) applyProbeResults(results []probeResult) {
+	if len(results) == 0 {
+		return
+	}
+	for i := range results {
+		metrics.ProviderProbe(results[i].provider, results[i].err == nil)
+	}
+
+	var events []HealthEvent
+	c.mu.Lock()
+	var flips []Status
+	for i := range results {
+		status, ok := c.normalizeProbeResultLocked(results[i])
+		if !ok {
+			continue
+		}
+		if snapshot, flip := c.setStatusLocked(results[i].provider, status, true); flip {
+			flips = append(flips, snapshot)
+		}
+	}
+	flips = append(flips, c.clearExpiredRateLimitsLocked(c.now())...)
+	for _, st := range flips {
+		events = append(events, c.healthEventLocked(st))
+	}
+	c.mu.Unlock()
+
+	c.emitHealthEvents(events)
+}
+
+func (c *Checker) normalizeProbeResultLocked(r probeResult) (Status, bool) {
+	result := r.status
+	if r.err != nil {
 		result = Status{
-			Provider:  name,
+			Provider:  r.provider,
 			Healthy:   false,
 			Reason:    "probe_error",
-			Detail:    err.Error(),
+			Detail:    r.err.Error(),
 			LastCheck: c.now(),
 		}
+	}
+	if result.Provider == "" {
+		result.Provider = r.provider
 	}
 	if result.LastCheck.IsZero() {
 		result.LastCheck = c.now()
 	}
-	c.setStatus(name, result, true)
+	if !result.Healthy && result.Reason == "probe_error" {
+		c.probeFailures[r.provider]++
+		if c.probeFailures[r.provider] < c.cfg.ProbeErrorThreshold {
+			c.logger.Info("provider.probe.transient",
+				"provider", r.provider,
+				"failures", c.probeFailures[r.provider],
+				"threshold", c.cfg.ProbeErrorThreshold,
+				"detail", result.Detail)
+			return Status{}, false
+		}
+	} else {
+		c.probeFailures[r.provider] = 0
+	}
+	return result, true
 }
 
 // clearExpiredRateLimits walks the status map and flips providers back to
 // healthy when their rate-limit window has elapsed. Active probes will
 // eventually confirm state; this lets the gate release runs sooner.
 func (c *Checker) clearExpiredRateLimits() {
-	now := c.now()
-	var toEmit []Status
+	var events []HealthEvent
 	c.mu.Lock()
+	flips := c.clearExpiredRateLimitsLocked(c.now())
+	for _, st := range flips {
+		events = append(events, c.healthEventLocked(st))
+	}
+	c.mu.Unlock()
+	c.emitHealthEvents(events)
+}
+
+func (c *Checker) clearExpiredRateLimitsLocked(now time.Time) []Status {
+	var toEmit []Status
 	for _, s := range c.statuses {
 		if !s.RateLimitedUntil.IsZero() && now.After(s.RateLimitedUntil) {
 			s.RateLimitedUntil = time.Time{}
@@ -219,10 +294,7 @@ func (c *Checker) clearExpiredRateLimits() {
 			}
 		}
 	}
-	c.mu.Unlock()
-	for _, st := range toEmit {
-		c.emitHealthEvent(st)
-	}
+	return toEmit
 }
 
 // setStatus merges an incoming Status with the previous one and emits on flip.
@@ -231,10 +303,26 @@ func (c *Checker) clearExpiredRateLimits() {
 // not wipe a real-time auth failure).
 func (c *Checker) setStatus(name string, next Status, fromProbe bool) {
 	c.mu.Lock()
+	snapshot, flip := c.setStatusLocked(name, next, fromProbe)
+	var ev HealthEvent
+	if flip {
+		ev = c.healthEventLocked(snapshot)
+	}
+	c.mu.Unlock()
+
+	if flip {
+		c.emitHealthEvents([]HealthEvent{ev})
+	}
+}
+
+func (c *Checker) setStatusLocked(name string, next Status, fromProbe bool) (Status, bool) {
 	prev, ok := c.statuses[name]
 	if !ok {
 		prev = &Status{Provider: name}
 		c.statuses[name] = prev
+	}
+	if !fromProbe {
+		c.probeFailures[name] = 0
 	}
 	var flip bool
 	if fromProbe {
@@ -251,14 +339,12 @@ func (c *Checker) setStatus(name string, next Status, fromProbe bool) {
 	} else {
 		if next.Healthy {
 			// A passive "healthy" signal doesn't exist — guard anyway.
-			c.mu.Unlock()
-			return
+			return Status{}, false
 		}
 		// Passive failures only upgrade severity; they never mark a provider
 		// healthy and they never overwrite a more-recent probe result.
 		if !prev.Healthy && prev.Reason == next.Reason && prev.RateLimitedUntil.Equal(next.RateLimitedUntil) {
-			c.mu.Unlock()
-			return
+			return Status{}, false
 		}
 		prev.Healthy = false
 		prev.Reason = next.Reason
@@ -270,16 +356,7 @@ func (c *Checker) setStatus(name string, next Status, fromProbe bool) {
 		flip = true
 	}
 	snapshot := *prev
-	c.mu.Unlock()
-
-	if flip {
-		metrics.ProviderHealthFlip(snapshot.Provider, snapshot.Healthy)
-		c.logger.Info("provider.health.flip",
-			"provider", snapshot.Provider,
-			"healthy", snapshot.Healthy,
-			"reason", snapshot.Reason)
-		c.emitHealthEvent(snapshot)
-	}
+	return snapshot, flip
 }
 
 func statusChanged(a, b *Status) bool {
@@ -288,21 +365,36 @@ func statusChanged(a, b *Status) bool {
 		!a.RateLimitedUntil.Equal(b.RateLimitedUntil)
 }
 
-func (c *Checker) emitHealthEvent(s Status) {
-	ev := HealthEvent{
+func (c *Checker) healthEventLocked(s Status) HealthEvent {
+	return HealthEvent{
 		Provider:         s.Provider,
 		Healthy:          s.Healthy,
 		Reason:           s.Reason,
 		Detail:           s.Detail,
 		LastCheck:        s.LastCheck,
 		RateLimitedUntil: s.RateLimitedUntil,
-		FailoverActive:   c.failoverActive(s.Provider),
+		FailoverActive:   c.failoverActiveLocked(s.Provider),
 	}
-	c.emit(ProviderHealthEvent, ev)
 }
 
-func (c *Checker) failoverActive(unhealthy string) bool {
-	alt := c.Failover(unhealthy)
+func (c *Checker) emitHealthEvents(events []HealthEvent) {
+	for _, ev := range events {
+		metrics.ProviderHealthFlip(ev.Provider, ev.Healthy)
+		args := []any{
+			"provider", ev.Provider,
+			"healthy", ev.Healthy,
+			"reason", ev.Reason,
+		}
+		if ev.Detail != "" {
+			args = append(args, "detail", ev.Detail)
+		}
+		c.logger.Info("provider.health.flip", args...)
+		c.emit(ProviderHealthEvent, ev)
+	}
+}
+
+func (c *Checker) failoverActiveLocked(unhealthy string) bool {
+	alt := c.failoverLocked(unhealthy)
 	return alt != "" && alt != unhealthy
 }
 
@@ -350,6 +442,10 @@ func (c *Checker) Reason(provider string) string {
 func (c *Checker) Failover(unhealthy string) string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
+	return c.failoverLocked(unhealthy)
+}
+
+func (c *Checker) failoverLocked(unhealthy string) string {
 	if !c.cfg.AutoFailover {
 		return ""
 	}
@@ -470,9 +566,11 @@ func (c *Checker) SetProviderEnabled(provider string, v bool) {
 	} else if s.Reason == "disabled" {
 		s.Reason = "unknown"
 	}
+	c.probeFailures[provider] = 0
 	snapshot := *s
+	ev := c.healthEventLocked(snapshot)
 	c.mu.Unlock()
-	c.emitHealthEvent(snapshot)
+	c.emitHealthEvents([]HealthEvent{ev})
 }
 
 // AutoFailover reports the current auto-failover flag.

--- a/internal/provider/health.go
+++ b/internal/provider/health.go
@@ -258,6 +258,12 @@ func (c *Checker) normalizeProbeResultLocked(r probeResult) (Status, bool) {
 				"failures", c.probeFailures[r.provider],
 				"threshold", c.cfg.ProbeErrorThreshold,
 				"detail", result.Detail)
+			// A probe did run — advance LastCheck on the stored status so
+			// Snapshot/UX don't look like probing stalled, while leaving the
+			// debounced Healthy/Reason untouched until the threshold trips.
+			if prev, ok := c.statuses[r.provider]; ok {
+				prev.LastCheck = c.now()
+			}
 			return Status{}, false
 		}
 	} else {
@@ -544,14 +550,20 @@ func (c *Checker) SetAutoFailover(v bool) {
 // SetProviderEnabled toggles per-provider probing and participation in failover.
 func (c *Checker) SetProviderEnabled(provider string, v bool) {
 	c.mu.Lock()
+	var prev bool
 	switch provider {
 	case "claude":
-		c.cfg.ClaudeEnabled = v
+		prev, c.cfg.ClaudeEnabled = c.cfg.ClaudeEnabled, v
 	case "codex":
-		c.cfg.CodexEnabled = v
+		prev, c.cfg.CodexEnabled = c.cfg.CodexEnabled, v
 	case "copilot":
-		c.cfg.CopilotEnabled = v
+		prev, c.cfg.CopilotEnabled = c.cfg.CopilotEnabled, v
 	default:
+		c.mu.Unlock()
+		return
+	}
+	if prev == v {
+		// No-op toggle — don't emit a spurious health flip event.
 		c.mu.Unlock()
 		return
 	}

--- a/internal/provider/health_test.go
+++ b/internal/provider/health_test.go
@@ -352,6 +352,53 @@ func TestChecker_ProbeSuccessResetsProbeErrorStreak(t *testing.T) {
 	}
 }
 
+func TestChecker_SuppressedProbeErrorAdvancesLastCheck(t *testing.T) {
+	c, _, clock := newTestChecker(t)
+	c.probeClaude = func(context.Context) (Status, error) {
+		return Status{Provider: "claude", Healthy: true, Reason: "ok"}, nil
+	}
+	c.probeCodex = func(context.Context) (Status, error) {
+		return Status{Provider: "codex", Healthy: true, Reason: "ok"}, nil
+	}
+	ctx := context.Background()
+	c.checkAll(ctx)
+	healthyAt := c.Snapshot()["claude"].LastCheck
+
+	clock.advance(time.Minute)
+	c.probeClaude = func(context.Context) (Status, error) {
+		return Status{}, errors.New("context deadline exceeded")
+	}
+	c.checkAll(ctx)
+
+	snap := c.Snapshot()["claude"]
+	if !snap.Healthy || snap.Reason != "ok" {
+		t.Fatalf("suppressed probe_error must not flip status: healthy=%v reason=%q", snap.Healthy, snap.Reason)
+	}
+	if !snap.LastCheck.After(healthyAt) {
+		t.Fatalf("suppressed probe_error should advance LastCheck: got %v, want after %v", snap.LastCheck, healthyAt)
+	}
+}
+
+func TestChecker_SetProviderEnabledNoOpDoesNotEmit(t *testing.T) {
+	c, fe, _ := newTestChecker(t)
+	// claude is enabled by default — re-enabling is a no-op and must not emit.
+	c.SetProviderEnabled("claude", true)
+	if got := fe.count(); got != 0 {
+		t.Fatalf("no-op enable emitted %d events, want 0", got)
+	}
+
+	// Disabling is a real change — one event.
+	c.SetProviderEnabled("claude", false)
+	if got := fe.count(); got != 1 {
+		t.Fatalf("disable emitted %d events, want 1", got)
+	}
+	// Disabling again is a no-op — no further events.
+	c.SetProviderEnabled("claude", false)
+	if got := fe.count(); got != 1 {
+		t.Fatalf("repeated disable emitted %d events, want 1", got)
+	}
+}
+
 func TestChecker_BatchFailoverFlagsUseFinalStatuses(t *testing.T) {
 	c, fe, _ := newTestChecker(t)
 	c.probeClaude = func(context.Context) (Status, error) {

--- a/internal/provider/health_test.go
+++ b/internal/provider/health_test.go
@@ -210,6 +210,14 @@ func (f *fakeEmitter) count() int {
 	return len(f.events)
 }
 
+func (f *fakeEmitter) snapshot() []HealthEvent {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]HealthEvent, len(f.events))
+	copy(out, f.events)
+	return out
+}
+
 func newTestChecker(t *testing.T) (*Checker, *fakeEmitter, *fakeClock) {
 	t.Helper()
 	fe := &fakeEmitter{}
@@ -268,6 +276,110 @@ func TestChecker_FlipsOnFailure(t *testing.T) {
 	}
 	if c.IsHealthy("claude") {
 		t.Errorf("claude should be unhealthy")
+	}
+}
+
+func TestChecker_ProbeErrorRequiresConsecutiveFailures(t *testing.T) {
+	c, fe, _ := newTestChecker(t)
+	c.probeClaude = func(context.Context) (Status, error) {
+		return Status{Provider: "claude", Healthy: true, Reason: "ok"}, nil
+	}
+	c.probeCodex = func(context.Context) (Status, error) {
+		return Status{Provider: "codex", Healthy: true, Reason: "ok"}, nil
+	}
+	ctx := context.Background()
+	c.checkAll(ctx)
+	before := fe.count()
+
+	c.probeClaude = func(context.Context) (Status, error) {
+		return Status{}, errors.New("context deadline exceeded")
+	}
+	c.checkAll(ctx)
+	if !c.IsHealthy("claude") {
+		t.Fatalf("first generic probe_error should be suppressed; claude became unhealthy")
+	}
+	if got := c.Reason("claude"); got != "ok" {
+		t.Fatalf("first generic probe_error should preserve prior reason, got %q", got)
+	}
+	if got := fe.count(); got != before {
+		t.Fatalf("first generic probe_error emitted %d new events, want 0", got-before)
+	}
+
+	c.checkAll(ctx)
+	if c.IsHealthy("claude") {
+		t.Fatalf("second consecutive generic probe_error should mark claude unhealthy")
+	}
+	if got := c.Reason("claude"); got != "probe_error" {
+		t.Fatalf("Reason = %q, want probe_error", got)
+	}
+	if got := fe.count(); got != before+1 {
+		t.Fatalf("second consecutive probe_error should emit exactly one event: got count=%d before=%d", got, before)
+	}
+}
+
+func TestChecker_ProbeSuccessResetsProbeErrorStreak(t *testing.T) {
+	c, fe, _ := newTestChecker(t)
+	c.probeClaude = func(context.Context) (Status, error) {
+		return Status{Provider: "claude", Healthy: true, Reason: "ok"}, nil
+	}
+	c.probeCodex = func(context.Context) (Status, error) {
+		return Status{Provider: "codex", Healthy: true, Reason: "ok"}, nil
+	}
+	ctx := context.Background()
+	c.checkAll(ctx)
+	before := fe.count()
+
+	c.probeClaude = func(context.Context) (Status, error) {
+		return Status{}, errors.New("context deadline exceeded")
+	}
+	c.checkAll(ctx)
+
+	c.probeClaude = func(context.Context) (Status, error) {
+		return Status{Provider: "claude", Healthy: true, Reason: "ok"}, nil
+	}
+	c.checkAll(ctx)
+
+	c.probeClaude = func(context.Context) (Status, error) {
+		return Status{}, errors.New("context deadline exceeded")
+	}
+	c.checkAll(ctx)
+
+	if !c.IsHealthy("claude") {
+		t.Fatalf("non-consecutive generic probe_error should stay suppressed")
+	}
+	if got := fe.count(); got != before {
+		t.Fatalf("suppressed non-consecutive probe_error emitted %d new events, want 0", got-before)
+	}
+}
+
+func TestChecker_BatchFailoverFlagsUseFinalStatuses(t *testing.T) {
+	c, fe, _ := newTestChecker(t)
+	c.probeClaude = func(context.Context) (Status, error) {
+		return Status{Provider: "claude", Healthy: true, Reason: "ok"}, nil
+	}
+	c.probeCodex = func(context.Context) (Status, error) {
+		return Status{Provider: "codex", Healthy: true, Reason: "ok"}, nil
+	}
+	ctx := context.Background()
+	c.checkAll(ctx)
+	seed := fe.count()
+
+	c.probeClaude = func(context.Context) (Status, error) {
+		return Status{Provider: "claude", Healthy: false, Reason: "logged_out"}, nil
+	}
+	c.probeCodex = func(context.Context) (Status, error) {
+		return Status{Provider: "codex", Healthy: false, Reason: "logged_out"}, nil
+	}
+	c.checkAll(ctx)
+
+	events := fe.snapshot()[seed:]
+	if len(events) != 2 {
+		t.Fatalf("events after batch failure = %d, want 2: %#v", len(events), events)
+	}
+	for _, ev := range events {
+		if ev.FailoverActive {
+			t.Fatalf("%s emitted stale failoverActive=true even though all enabled peers failed in the same probe batch: %#v", ev.Provider, ev)
+		}
 	}
 }
 


### PR DESCRIPTION
## Motivation

Health probe errors were causing noisy provider state flapping when transient failures hit. A debounce mechanism now requires consecutive failures before marking a provider unhealthy.

## Implementation information

Added debounce logic to `internal/provider/health.go` that buffers probe errors and only transitions provider state after a configurable threshold of consecutive failures, with matching tests in `health_test.go`.

> Changelog: fix(provider): debounce health probe errors