### PR TITLE
fix(workflow): harden handoff stage routing

### DIFF
--- a/cmd/sybra-cli/handoff_test.go
+++ b/cmd/sybra-cli/handoff_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestHandoffStageConfigForAliases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		stage string
+		name  string
+		tags  []string
+	}{
+		{stage: "", name: "implement", tags: []string{"handoff"}},
+		{stage: "implement", name: "implement", tags: []string{"handoff"}},
+		{stage: "in-progress", name: "implement", tags: []string{"handoff"}},
+		{stage: "review", name: "review", tags: []string{"handoff", "handoff-review"}},
+		{stage: "ready-review", name: "review", tags: []string{"handoff", "handoff-review"}},
+		{stage: "agentic-review", name: "review", tags: []string{"handoff", "handoff-review"}},
+		{stage: "testing", name: "testing", tags: []string{"handoff", "handoff-testing"}},
+		{stage: "ready-pr", name: "ready-pr", tags: []string{"handoff", "handoff-ready-pr"}},
+		{stage: "open-pr", name: "ready-pr", tags: []string{"handoff", "handoff-ready-pr"}},
+		{stage: "in-review", name: "pr", tags: []string{"review", handoffPRTag}},
+		{stage: "pr", name: "pr", tags: []string{"review", handoffPRTag}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.stage, func(t *testing.T) {
+			t.Parallel()
+			got, ok := handoffStageConfigFor(tt.stage)
+			if !ok {
+				t.Fatalf("handoffStageConfigFor(%q) returned ok=false", tt.stage)
+			}
+			if got.name != tt.name {
+				t.Fatalf("handoffStageConfigFor(%q).name = %q, want %q", tt.stage, got.name, tt.name)
+			}
+			if !slices.Equal(got.tags, tt.tags) {
+				t.Fatalf("handoffStageConfigFor(%q).tags = %+v, want %+v", tt.stage, got.tags, tt.tags)
+			}
+		})
+	}
+}
+
+func TestHandoffStageConfigForRejectsUnknownStage(t *testing.T) {
+	t.Parallel()
+
+	if _, ok := handoffStageConfigFor("done"); ok {
+		t.Fatal("handoffStageConfigFor(\"done\") returned ok=true")
+	}
+}

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -287,11 +287,10 @@ func cmdCreate(s *task.Manager, args []string, jsonOut bool) int {
 	return 0
 }
 
-// cmdHandoff creates a task pre-tagged `handoff` that bypasses Sybra's
-// triage/planning phases and starts implementing immediately in an existing
-// (externally created) git worktree. Intended for handing off a researched,
-// already-planned task from a tool like Orca: the human did the thinking, Sybra
-// runs the implementation autonomously in the same worktree.
+// cmdHandoff creates a task pre-tagged for a Sybra workflow entry point. It
+// bypasses triage/planning and either starts the requested agentic stage in an
+// existing worktree, reviews an existing PR, or places the task in a raw status
+// without workflow dispatch.
 func cmdHandoff(s *task.Manager, ps *project.Store, args []string, jsonOut bool) int {
 	fs := flag.NewFlagSet("handoff", flag.ContinueOnError)
 	title := fs.String("title", "", "task title (required)")
@@ -301,7 +300,8 @@ func cmdHandoff(s *task.Manager, ps *project.Store, args []string, jsonOut bool)
 	proj := fs.String("project", "", "project id (owner/repo); derived from the worktree origin remote when omitted")
 	wtDir := fs.String("worktree-dir", "", "git worktree Sybra should reuse (default: current directory)")
 	mode := fs.String("mode", "headless", "agent mode: headless|interactive")
-	stage := fs.String("stage", "implement", "stage to hand off at: implement|review|testing|pr")
+	stage := fs.String("stage", "implement", "workflow entry stage: implement|in-progress|review|ready-review|agentic-review|testing|ready-pr|pr|in-review")
+	rawStatus := fs.String("status", "", "raw task status to create without starting a workflow")
 	pr := fs.Int("pr", 0, "PR number (required for --stage pr)")
 	extraTags := fs.String("tags", "", "extra comma-separated tags")
 	if err := fs.Parse(args); err != nil {
@@ -310,9 +310,9 @@ func cmdHandoff(s *task.Manager, ps *project.Store, args []string, jsonOut bool)
 	if *title == "" {
 		return fatal(jsonOut, "title is required")
 	}
-	stageTags, ok := handoffStageTags(*stage)
-	if !ok {
-		return fatal(jsonOut, "invalid --stage %q (valid: implement, review, testing, pr)", *stage)
+	stageCfg, status, rawStatusMode, modeErr := resolveHandoffMode(fs, *stage, *rawStatus, *pr)
+	if modeErr != nil {
+		return fatal(jsonOut, "%v", modeErr)
 	}
 
 	dir, dErr := resolveWorktreeDir(*wtDir)
@@ -320,48 +320,38 @@ func cmdHandoff(s *task.Manager, ps *project.Store, args []string, jsonOut bool)
 		return fatal(jsonOut, "%v", dErr)
 	}
 
-	// --plan-file wins over --plan so callers can stream a large plan from disk.
-	planContent := *plan
-	if *planFile != "" {
-		data, rErr := os.ReadFile(*planFile)
-		if rErr != nil {
-			return fatal(jsonOut, "read plan file: %v", rErr)
-		}
-		planContent = string(data)
+	planContent, planErr := resolveHandoffPlan(*plan, *planFile)
+	if planErr != nil {
+		return fatal(jsonOut, "%v", planErr)
 	}
 
-	// A handoff task must carry a registered project so its agents run against
-	// the right repo. Derive owner/repo from the worktree's origin when omitted.
-	projectID := *proj
-	if projectID == "" {
-		derived, e := deriveProjectID(dir)
-		if e != nil {
-			return fatal(jsonOut, "derive project from %q: %v (pass --project owner/repo)", dir, e)
-		}
-		projectID = derived
-	}
-	projRec, gErr := ps.Get(projectID)
-	if gErr != nil {
-		return fatal(jsonOut, "project %q not registered: %v (run: sybra-cli project create --url <github-url>)", projectID, gErr)
+	projectID, projRec, projErr := resolveHandoffProject(ps, dir, *proj)
+	if projErr != nil {
+		return fatal(jsonOut, "%v", projErr)
 	}
 
-	updates := map[string]any{
-		"project_id": projectID,
-		"tags":       append(stageTags, parseExtraTags(*extraTags, stageTags)...),
+	tags := append([]string{}, stageCfg.tags...)
+	tags = append(tags, parseExtraTags(*extraTags, tags)...)
+	init := task.Update{
+		ProjectID: task.Ptr(projectID),
+		Tags:      &tags,
 	}
 	if planContent != "" {
-		updates["plan"] = planContent
+		init.Plan = &planContent
 	}
-	switch *stage {
+	if rawStatusMode {
+		init.Status = &status
+	}
+	switch stageCfg.name {
 	case "pr":
 		// Existing PR: Sybra reviews it via the pr-review lane. No worktree
 		// adoption — pr-review checks out the PR head itself.
 		if *pr <= 0 {
 			return fatal(jsonOut, "--stage pr requires --pr <number>")
 		}
-		updates["pr_number"] = float64(*pr)
+		init.PRNumber = task.Ptr(*pr)
 	default:
-		// implement/review adopt the worktree. Guard that the chosen project
+		// Non-PR stages adopt the worktree. Guard that the chosen project
 		// matches the worktree's origin — a mismatched --project (or stale
 		// ProjectID) would make agents run and push against the wrong repo.
 		// Best-effort: only enforced when origin is a parseable GitHub remote.
@@ -373,46 +363,113 @@ func cmdHandoff(s *task.Manager, ps *project.Store, args []string, jsonOut bool)
 		if e := assertFeatureBranch(dir, projRec); e != nil {
 			return fatal(jsonOut, "%v", e)
 		}
-		updates["worktree_dir"] = dir
+		init.WorktreeDir = task.Ptr(dir)
 		if *pr > 0 {
-			updates["pr_number"] = float64(*pr)
+			init.PRNumber = task.Ptr(*pr)
 		}
 	}
 
-	t, err := s.Create(*title, *body, *mode)
+	t, err := s.CreateFull(*title, *body, *mode, init)
 	if err != nil {
 		return fatal(jsonOut, "%v", err)
-	}
-	t, err = s.UpdateMap(t.ID, updates)
-	if err != nil {
-		return fatal(jsonOut, "update after create: %v", err)
 	}
 
 	if jsonOut {
 		return printJSON(t)
 	}
-	printHandoffResult(t, *stage, projectID, dir)
+	if rawStatusMode {
+		printHandoffStatusResult(t, status, projectID, dir)
+	} else {
+		printHandoffResult(t, stageCfg.name, projectID, dir)
+	}
 	return 0
 }
 
-// handoffStageTags maps a handoff stage to the tags that route the task into
-// the right Sybra lane on creation, or (nil,false) for an unknown stage.
+func resolveHandoffMode(fs *flag.FlagSet, stage, rawStatus string, pr int) (handoffStageConfig, task.Status, bool, error) {
+	stageProvided := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "stage" {
+			stageProvided = true
+		}
+	})
+	if rawStatus != "" && stageProvided {
+		return handoffStageConfig{}, "", false, fmt.Errorf("--status is raw board placement and cannot be combined with --stage")
+	}
+	if rawStatus != "" {
+		status, err := task.ValidateStatus(rawStatus)
+		if err != nil {
+			return handoffStageConfig{}, "", false, err
+		}
+		return handoffStageConfig{name: "manual", tags: []string{handoffManualTag}}, status, true, nil
+	}
+
+	stageCfg, ok := handoffStageConfigFor(stage)
+	if !ok {
+		return handoffStageConfig{}, "", false, fmt.Errorf("invalid --stage %q (valid: implement, in-progress, review, ready-review, agentic-review, testing, ready-pr, pr, in-review)", stage)
+	}
+	if pr > 0 && stageCfg.name != "pr" && stageCfg.name != "ready-pr" {
+		return handoffStageConfig{}, "", false, fmt.Errorf("--pr is only valid with --stage pr or --stage ready-pr")
+	}
+	return stageCfg, "", false, nil
+}
+
+func resolveHandoffPlan(plan, planFile string) (string, error) {
+	if planFile == "" {
+		return plan, nil
+	}
+	data, err := os.ReadFile(planFile)
+	if err != nil {
+		return "", fmt.Errorf("read plan file: %w", err)
+	}
+	return string(data), nil
+}
+
+func resolveHandoffProject(ps *project.Store, dir, projectID string) (string, project.Project, error) {
+	if projectID == "" {
+		derived, err := deriveProjectID(dir)
+		if err != nil {
+			return "", project.Project{}, fmt.Errorf("derive project from %q: %w (pass --project owner/repo)", dir, err)
+		}
+		projectID = derived
+	}
+	projRec, err := ps.Get(projectID)
+	if err != nil {
+		return "", project.Project{}, fmt.Errorf("project %q not registered: %w (run: sybra-cli project create --url <github-url>)", projectID, err)
+	}
+	return projectID, projRec, nil
+}
+
+type handoffStageConfig struct {
+	name string
+	tags []string
+}
+
+const (
+	handoffManualTag = "handoff-manual"
+	handoffPRTag     = "handoff-pr"
+)
+
+// handoffStageConfigFor maps a handoff stage to the tags that route the task
+// into the right Sybra lane on creation, or false for an unknown stage.
 //   - implement: simple-task-handoff → in-progress → implement → review → testing → PR
 //   - review:    simple-task-handoff-review → ready-review → review → testing → PR
 //   - testing:   simple-task-handoff-testing → testing → adversarial test → PR
+//   - ready-pr:  simple-task-handoff-ready-pr → ready-pr → open/update PR
 //   - pr:        pr-review lane for an existing PR
-func handoffStageTags(stage string) ([]string, bool) {
-	switch stage {
-	case "implement":
-		return []string{"handoff"}, true
-	case "review":
-		return []string{"handoff", "handoff-review"}, true
-	case "testing":
-		return []string{"handoff", "handoff-testing"}, true
-	case "pr":
-		return []string{"review"}, true
+func handoffStageConfigFor(stage string) (handoffStageConfig, bool) {
+	switch strings.ToLower(strings.TrimSpace(stage)) {
+	case "", "implement", "in-progress":
+		return handoffStageConfig{name: "implement", tags: []string{"handoff"}}, true
+	case "review", "ready-review", "agentic-review":
+		return handoffStageConfig{name: "review", tags: []string{"handoff", "handoff-review"}}, true
+	case "testing", "test":
+		return handoffStageConfig{name: "testing", tags: []string{"handoff", "handoff-testing"}}, true
+	case "ready-pr", "open-pr", "create-pr":
+		return handoffStageConfig{name: "ready-pr", tags: []string{"handoff", "handoff-ready-pr"}}, true
+	case "pr", "in-review", "pull-request", "pull_request":
+		return handoffStageConfig{name: "pr", tags: []string{"review", handoffPRTag}}, true
 	default:
-		return nil, false
+		return handoffStageConfig{}, false
 	}
 }
 
@@ -485,6 +542,9 @@ func printHandoffResult(t task.Task, stage, projectID, dir string) {
 	case "testing":
 		fmt.Printf("  worktree: %s\n", dir)
 		fmt.Println("  Sybra will skip straight to adversarial testing of this worktree.")
+	case "ready-pr":
+		fmt.Printf("  worktree: %s\n", dir)
+		fmt.Println("  Sybra will skip straight to opening or updating the PR from this worktree.")
 	case "pr":
 		fmt.Printf("  pr:       #%d\n", t.PRNumber)
 		fmt.Println("  Sybra will review the existing PR.")
@@ -492,6 +552,14 @@ func printHandoffResult(t task.Task, stage, projectID, dir string) {
 		fmt.Printf("  worktree: %s\n", dir)
 		fmt.Println("  Sybra will skip planning and start implementing in this worktree.")
 	}
+}
+
+func printHandoffStatusResult(t task.Task, status task.Status, projectID, dir string) {
+	fmt.Printf("Handed off task %s: %s\n", t.ID, t.Title)
+	fmt.Printf("  project:  %s\n", projectID)
+	fmt.Printf("  status:   %s\n", status)
+	fmt.Printf("  worktree: %s\n", dir)
+	fmt.Println("  Sybra created the task in that status without starting a workflow.")
 }
 
 // deriveProjectID reads the origin remote of a git worktree and converts it to
@@ -1272,13 +1340,16 @@ Commands:
   get      <id>
   create   --title TITLE [--body BODY] [--plan PLAN] [--mode MODE] [--type TYPE] [--tags t1,t2] [--project ID] [--branch B] [--pr N] [--issue URL] [--allow-dup]
            TYPE: normal|debug|research
-  handoff  --title TITLE [--body BODY] [--plan PLAN | --plan-file PATH] [--project ID] [--worktree-dir DIR] [--stage STAGE] [--pr N] [--mode MODE] [--tags t1,t2]
-           Hand a task to Sybra at any stage, reusing the given git worktree
+  handoff  --title TITLE [--body BODY] [--plan PLAN | --plan-file PATH] [--project ID] [--worktree-dir DIR] [--stage STAGE | --status STATUS] [--pr N] [--mode MODE] [--tags t1,t2]
+           Hand a task to Sybra at a workflow entry point, reusing the given git worktree
            (default: cwd). Project is derived from the worktree's origin remote
            when --project is omitted. STAGE (default implement):
-             implement  have a plan → Sybra implements, reviews, opens the PR
-             review     implemented locally → Sybra reviews + opens the PR
-             pr         existing PR (--pr N) → Sybra reviews the PR
+             implement      have a plan -> Sybra implements, reviews, tests, opens the PR
+             review         implemented locally -> Sybra enters agentic review
+             testing        reviewed locally -> Sybra tests, then opens the PR
+             ready-pr       tested locally -> Sybra opens or updates the PR
+             pr|in-review   existing PR (--pr N) -> Sybra reviews the PR
+           --status STATUS creates the task directly in that status without workflow dispatch
   update   <id> [--title T] [--status S] [--status-reason R] [--body B] [--plan PLAN] [--plan-file PATH] [--mode M] [--type TYPE] [--tags T] [--project ID] [--branch B] [--pr N] [--issue URL] [--max-turns N] [--reasoning-effort E]
   delete   <id>
 

--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -51,7 +51,7 @@ export class Condition {
     "field": string;
 
     /**
-     * "equals", "not_equals", "contains", "not_contains", "exists"
+     * "equals", "not_equals", "contains", "not_contains", "exists", "in", "not_in"
      */
     "operator": string;
     "value": string;

--- a/internal/skills/data/sybra-handoff.md
+++ b/internal/skills/data/sybra-handoff.md
@@ -3,7 +3,7 @@ name: sybra-handoff
 description: Hand a researched, already-decided task off to Sybra for autonomous implementation. Use after you have explored a problem in an Orca (or any) git worktree, agreed on the approach, and want Sybra to skip its own planning and start implementing immediately — reusing this exact worktree. Triggers on "hand this off to Sybra", "let Sybra implement this", "ship this to Sybra", "handoff to sybra". Works under both Claude Code and Codex.
 allowed-tools: Bash
 user-invocable: true
-argument-hint: "[--title \"...\"] [--plan-file PATH] [--worktree-dir DIR]"
+argument-hint: "[--stage STAGE | --status STATUS] [--title \"...\"] [--plan-file PATH] [--worktree-dir DIR] [--pr N]"
 ---
 
 # Sybra Handoff
@@ -13,34 +13,78 @@ human did the research and chose the approach here; Sybra takes the agreed plan
 and implements it **without re-planning**, running its agents **in this same
 worktree** so the work lands where you were just looking.
 
-This is the Orca → Sybra seam: Orca is the research/planning phase, Sybra is the
-autonomous execution phase.
+This is the Orca -> Sybra handoff point: Orca is the research/planning phase,
+Sybra is the autonomous execution phase.
 
 ## When to use
 
 Hand off at whatever stage you have reached — Sybra picks up from there:
 - You have a **plan** but have not implemented → `--stage implement` (default).
-- You have **implemented** locally and want review + PR → `--stage review`.
-- You already **opened a PR** and want Sybra to review it → `--stage pr --pr N`.
+- You have **implemented** locally and want agentic review + PR → `--stage review`
+  (aliases: `ready-review`, `agentic-review`).
+- You have **implemented and reviewed** locally and want the testing gate →
+  `--stage testing`.
+- You have **implemented, reviewed, and tested** locally and want Sybra to open
+  or update the PR from this worktree → `--stage ready-pr`.
+- You already **opened a PR** and want Sybra to review it → `--stage pr --pr N`
+  (alias: `in-review --pr N`).
 
 In all cases the approach is decided and you want Sybra to carry it the rest of
 the way autonomously. Do **not** use for exploratory work that still needs human
 direction — keep that in Orca.
 
+Use `--status STATUS` only when you explicitly want raw board placement with no
+workflow dispatch. For agentic handoff, prefer `--stage`; stage aliases are
+workflow entry points, not just column names.
+
 ## What it does
 
 `sybra-cli handoff` creates a task that skips straight to the requested stage —
-no triage, no planning gate — and (for implement/review) reuses **this** git
-worktree (`--worktree-dir`, default: cwd) instead of cutting a fresh one: no
+no triage, no planning gate — and (for all non-PR stages) reuses **this** git
+worktree (`--worktree-dir`, default: cwd) instead of creating a fresh one: no
 rebase, no force-push, and Sybra never deletes it.
+
+`sybra-cli handoff --status <status>` creates the task directly in that status
+with a `handoff-manual` tag and does **not** start any workflow. This is for
+manual board placement only.
 
 Stages:
 - **implement** (default): flips to `in-progress`; the implementation agent runs
   now with your plan as context, then review → PR.
 - **review**: flips to `ready-review`; Sybra reviews your existing commits in the
   worktree and opens the PR (no implementation step).
+- **testing**: flips to `testing`; Sybra runs the adversarial testing gate in the
+  adopted worktree and opens the PR if tests pass.
+- **ready-pr**: flips to `ready-pr`; Sybra opens or updates the PR from the
+  adopted worktree (no implementation, review, or testing step).
 - **pr**: for an existing PR (`--pr N`); Sybra reviews the open PR via its
   pr-review lane (no worktree adoption — it checks out the PR head itself).
+
+## Workflow entry context
+
+Pick the stage by the **next workflow Sybra should run**, not only by the visible
+column label:
+
+| CLI stage | Aliases | Workflow entry | Use when |
+| --- | --- | --- | --- |
+| `implement` | `in-progress` | `simple-task-handoff` -> `simple-task-implement` | The approach is decided but code is not written. |
+| `review` | `ready-review`, `agentic-review` | `simple-task-handoff-review` -> `simple-task-review` | Code exists in this worktree and needs Sybra's review/test/PR flow. |
+| `testing` | `test` | `simple-task-handoff-testing` -> `testing-task` | Code has already had the review you want and only needs Sybra's test/PR flow. |
+| `ready-pr` | `open-pr`, `create-pr` | `simple-task-handoff-ready-pr` -> `simple-task-pr` | Code has already been reviewed and tested, and Sybra should open/update the PR from this worktree. |
+| `pr` | `in-review`, `pull-request` | `pr-review` | A real PR already exists; pass `--pr N`. |
+
+Important status distinction:
+- `ready-review` / `agentic-review` means "start Sybra's review workflow".
+- `ready-pr` means "open or update a PR from this adopted worktree".
+- `in-review` means "an existing PR is already open and needs PR review"; it
+  requires `--pr N` and does not adopt the local worktree.
+- `--status in-review` means "place this task in the in-review column without
+  starting any review workflow"; use this only when a human or another system is
+  handling the next action.
+
+If unsure, inspect `internal/workflow/builtin/*.yaml` and choose the entry point
+whose trigger matches the next agentic step. Do not add broad workflow-lane tags
+such as `review` unless you intentionally want the existing-PR lane.
 
 ## Procedure
 
@@ -66,8 +110,8 @@ Stages:
    former.
 
 3. **Pick a clear title** (`type(scope): summary`, ≤50 chars), e.g.
-   `feat(auth): add jwt refresh middleware`. The implement/review handoff keeps
-   the worktree's existing branch — the title only names the task.
+   `feat(auth): add jwt refresh middleware`. Non-PR handoff stages keep the
+   worktree's existing branch — the title only names the task.
 
 4. **Run the handoff** from the worktree root:
    ```bash
@@ -76,9 +120,14 @@ Stages:
      --body  "One-paragraph problem statement + the research context Sybra needs." \
      --plan-file ./.sybra-handoff-plan.md
    ```
-   - `--stage review` to skip implementation (you already coded it); `--stage pr
-     --pr N` to hand off an existing PR. Default is `--stage implement`.
-   - `--plan-file` matters most for `--stage implement`; for `review`/`pr` it is
+   - `--stage review` / `ready-review` / `agentic-review` to skip implementation
+     (you already coded it); `--stage testing` to skip implementation and
+     review; `--stage ready-pr` to skip directly to PR creation/update;
+     `--stage pr --pr N` to hand off an existing PR. Default is
+     `--stage implement`.
+   - `--status STATUS` is mutually exclusive with `--stage` and creates a manual
+     task in that exact status without workflow dispatch.
+   - `--plan-file` matters most for `--stage implement`; for later stages it is
      optional context.
    - `--worktree-dir` defaults to the current directory; pass it explicitly if you
      run the command from elsewhere.

--- a/internal/sybra/app_external_task_test.go
+++ b/internal/sybra/app_external_task_test.go
@@ -116,3 +116,49 @@ func TestApp_MaybeStartWorkflowForExternalTask(t *testing.T) {
 		t.Errorf("pr-fix task: expected no task.created workflow, got %+v", pk.Workflow)
 	}
 }
+
+func TestSkipTaskCreatedWorkflow_PRLinkedHandoffExceptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		task task.Task
+		want bool
+	}{
+		{
+			name: "ordinary linked PR review skips task.created",
+			task: task.Task{PRNumber: 42, Tags: []string{"review"}},
+			want: true,
+		},
+		{
+			name: "explicit PR handoff may enter task.created pr-review lane",
+			task: task.Task{PRNumber: 42, Tags: []string{"review", handoffPRTag}},
+			want: false,
+		},
+		{
+			name: "ready-pr worktree handoff may enter task.created lane with known PR",
+			task: task.Task{PRNumber: 42, Tags: []string{"handoff", "handoff-ready-pr"}},
+			want: false,
+		},
+		{
+			name: "manual raw-status handoff never starts a workflow",
+			task: task.Task{Tags: []string{handoffManualTag}},
+			want: true,
+		},
+		{
+			name: "run role still skips task.created",
+			task: task.Task{RunRole: "pr-fix", PRNumber: 42, Tags: []string{"handoff"}},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := skipTaskCreatedWorkflow(tt.task)
+			if got != tt.want {
+				t.Fatalf("skipTaskCreatedWorkflow() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -233,10 +233,10 @@ func (a *App) maybeStartWorkflowForExternalTask(path string) {
 		if t.Status != task.StatusNew && t.Status != task.StatusTodo {
 			return
 		}
-		// pr-fix / existing-PR tasks are driven by pr.event, not task.created.
-		// Skipping here prevents simple-task-plan from claiming the workflow
-		// slot before the DispatchEvent("pr.event") call in FixRenovateCI.
-		if t.RunRole != "" || t.PRNumber > 0 {
+		// pr-fix / ordinary existing-PR tasks are driven outside task.created.
+		// Explicit handoff entry points are the exception: they intentionally
+		// route through task.created even when a PR number is already known.
+		if skipTaskCreatedWorkflow(t) {
 			return
 		}
 		if t.Workflow != nil &&

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -93,8 +93,10 @@ func (s *TaskService) startCreatedWorkflow(t task.Task) {
 	if s.workflowEngine == nil || t.Status != task.StatusTodo {
 		return
 	}
-	// pr-fix / existing-PR tasks are driven by pr.event, not task.created.
-	if t.RunRole != "" || t.PRNumber > 0 {
+	// pr-fix / ordinary existing-PR tasks are driven outside task.created.
+	// Explicit handoff entry points are the exception: they intentionally route
+	// through task.created even when a PR number is already known.
+	if skipTaskCreatedWorkflow(t) {
 		return
 	}
 	info := taskToInfo(t)

--- a/internal/sybra/workflow_dispatch.go
+++ b/internal/sybra/workflow_dispatch.go
@@ -1,0 +1,29 @@
+package sybra
+
+import (
+	"slices"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+const (
+	handoffManualTag = "handoff-manual"
+	handoffPRTag     = "handoff-pr"
+)
+
+func skipTaskCreatedWorkflow(t task.Task) bool {
+	if slices.Contains(t.Tags, handoffManualTag) {
+		return true
+	}
+	if t.RunRole != "" {
+		return true
+	}
+	if t.PRNumber > 0 && !allowsTaskCreatedWorkflowWithPR(t) {
+		return true
+	}
+	return false
+}
+
+func allowsTaskCreatedWorkflowWithPR(t task.Task) bool {
+	return slices.Contains(t.Tags, "handoff") || slices.Contains(t.Tags, handoffPRTag)
+}

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -300,10 +300,11 @@ func (s *Store) Create(title, body, mode string) (Task, error) {
 }
 
 // CreateFull persists a new task with optional initial field overrides applied
-// atomically in the first write. Use this instead of Create+Update when the
-// caller needs fields like RunRole, PRNumber, Tags, or ProjectID present before
-// any file-watcher can read the task — avoiding the race where watcher picks up
-// the bare task before the caller's Update applies.
+// atomically in the first task-file write. Use this instead of Create+Update
+// when the caller needs fields like RunRole, PRNumber, Tags, ProjectID,
+// WorktreeDir, or Plan present before any file-watcher can read the task —
+// avoiding the race where watcher picks up the bare task before the caller's
+// Update applies.
 func (s *Store) CreateFull(title, body, mode string, init Update) (Task, error) {
 	if mode == "" {
 		mode = AgentModeInteractive
@@ -329,8 +330,17 @@ func (s *Store) CreateFull(title, body, mode string, init Update) (Task, error) 
 	if init.ProjectID != nil {
 		t.ProjectID = *init.ProjectID
 	}
+	if init.Branch != nil {
+		t.Branch = *init.Branch
+	}
+	if init.WorktreeDir != nil {
+		t.WorktreeDir = *init.WorktreeDir
+	}
 	if init.PRNumber != nil {
 		t.PRNumber = *init.PRNumber
+	}
+	if init.Issue != nil {
+		t.Issue = *init.Issue
 	}
 	if init.Tags != nil {
 		t.Tags = *init.Tags
@@ -338,8 +348,22 @@ func (s *Store) CreateFull(title, body, mode string, init Update) (Task, error) 
 	if init.RunRole != nil {
 		t.RunRole = *init.RunRole
 	}
+	if init.Status != nil {
+		t.Status = *init.Status
+		if IsTerminalStatus(t.Status) {
+			closedAt := now
+			t.ClosedAt = &closedAt
+		}
+	}
+	if init.StatusReason != nil {
+		t.StatusReason = *init.StatusReason
+	}
 	if init.Body != nil {
 		t.Body = *init.Body
+	}
+
+	if err := s.writeSidecars(t.ID, init, &t); err != nil {
+		return Task{}, err
 	}
 
 	data, err := Marshal(t)

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -746,6 +746,52 @@ func TestStoreListSkipsPlanSidecars(t *testing.T) {
 	}
 }
 
+func TestStoreCreateFullAppliesInitialWorkflowFields(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tags := []string{"handoff", "handoff-review"}
+	status := StatusReadyReview
+	plan := "# Plan\n\nReview the existing branch."
+	created, err := store.CreateFull("Review task", "Body", "headless", Update{
+		Status:      &status,
+		Tags:        &tags,
+		ProjectID:   Ptr("owner/repo"),
+		WorktreeDir: Ptr("/tmp/worktree"),
+		Plan:        &plan,
+	})
+	if err != nil {
+		t.Fatalf("CreateFull: %v", err)
+	}
+
+	if created.Status != StatusReadyReview {
+		t.Errorf("Status = %q, want %q", created.Status, StatusReadyReview)
+	}
+	if created.ProjectID != "owner/repo" {
+		t.Errorf("ProjectID = %q, want owner/repo", created.ProjectID)
+	}
+	if created.WorktreeDir != "/tmp/worktree" {
+		t.Errorf("WorktreeDir = %q, want /tmp/worktree", created.WorktreeDir)
+	}
+	if created.Plan != plan {
+		t.Errorf("Plan = %q, want %q", created.Plan, plan)
+	}
+
+	got, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Plan != plan {
+		t.Errorf("Get Plan = %q, want %q", got.Plan, plan)
+	}
+	if got.WorktreeDir != "/tmp/worktree" {
+		t.Errorf("Get WorktreeDir = %q, want /tmp/worktree", got.WorktreeDir)
+	}
+}
+
 func TestStoreCreateDefaultMode(t *testing.T) {
 	t.Parallel()
 	store, err := NewStore(t.TempDir())

--- a/internal/workflow/builtin/simple-task-handoff-ready-pr.yaml
+++ b/internal/workflow/builtin/simple-task-handoff-ready-pr.yaml
@@ -1,0 +1,26 @@
+id: simple-task-handoff-ready-pr
+name: Simple Task - Handoff (Ready PR)
+description: >-
+  A task handed off from an external tool whose feature is already implemented,
+  reviewed, and tested in its worktree and only needs PR creation/push. Skip
+  triage/planning/implementation/review/testing; flip straight to ready-pr so
+  simple-task-pr opens or updates the PR from the adopted worktree.
+builtin: true
+trigger:
+  on: task.created
+  conditions:
+    - field: task.tags
+      operator: contains
+      value: handoff-ready-pr
+    # A PR-review task (tag `review`) is its own lane; never collide with it.
+    - field: task.tags
+      operator: not_contains
+      value: review
+steps:
+  - id: set_ready_pr
+    name: Hand Off to Ready PR
+    type: set_status
+    config:
+      status: ready-pr
+    next:
+      - goto: ""

--- a/internal/workflow/builtin/simple-task-handoff.yaml
+++ b/internal/workflow/builtin/simple-task-handoff.yaml
@@ -22,6 +22,11 @@ trigger:
     - field: task.tags
       operator: not_contains
       value: handoff-testing
+    # The ready-pr handoff (handoff-ready-pr) is handled by
+    # simple-task-handoff-ready-pr; never start implementation for it.
+    - field: task.tags
+      operator: not_contains
+      value: handoff-ready-pr
     # A PR-review task (tag `review`) is its own lane; never collide with it.
     - field: task.tags
       operator: not_contains

--- a/internal/workflow/condition.go
+++ b/internal/workflow/condition.go
@@ -111,10 +111,10 @@ func checkEnumValue(field, operator, value string) []string {
 }
 
 // checkEnumOperator reports whether the operator is semantically wrong for
-// an enum-shaped field. `contains`/`not_contains` do substring matching,
-// which silently fails on scalar enums (e.g. `contains "conflict,ci_failure"`
-// never matches `"ci_failure"`). Only free-form fields like task.tags — which
-// are joined into a single comma-separated string — should use these.
+// an enum-shaped field. `contains`/`not_contains` are list-membership checks
+// for task.tags and substring checks for other string fields, neither of which
+// is appropriate for scalar enums (e.g. `contains "ci"` would match
+// `"ci_failure"` by accident).
 func checkEnumOperator(field, operator string) bool {
 	if _, ok := FieldAllowedValues[field]; !ok {
 		return false
@@ -127,9 +127,8 @@ func checkEnumOperator(field, operator string) bool {
 //
 // Operators:
 //   - exists / equals / not_equals: single-value checks
-//   - contains / not_contains: substring check — field value must contain
-//     the condition value. Commonly used for comma-joined list fields
-//     (e.g. task.tags) to test element presence.
+//   - contains / not_contains: for task.tags, exact tag membership in the
+//     comma-joined tag list; for other fields, substring check.
 //   - in / not_in: membership check — condition value is a comma-separated
 //     list of allowed values, field must match one of them. Use this when
 //     the field is a single scalar (e.g. pr.issue_kind) and the trigger
@@ -145,9 +144,9 @@ func EvalCondition(c Condition, fields map[string]string) bool {
 	case "not_equals":
 		return val != c.Value
 	case "contains":
-		return strings.Contains(val, c.Value)
+		return containsFieldValue(c.Field, val, c.Value)
 	case "not_contains":
-		return !strings.Contains(val, c.Value)
+		return !containsFieldValue(c.Field, val, c.Value)
 	case "in":
 		return inList(val, c.Value)
 	case "not_in":
@@ -155,6 +154,13 @@ func EvalCondition(c Condition, fields map[string]string) bool {
 	default:
 		return false
 	}
+}
+
+func containsFieldValue(field, val, needle string) bool {
+	if field == "task.tags" {
+		return inList(needle, val)
+	}
+	return strings.Contains(val, needle)
 }
 
 // inList reports whether val exactly matches one of the comma-separated

--- a/internal/workflow/condition_test.go
+++ b/internal/workflow/condition_test.go
@@ -6,6 +6,7 @@ func TestEvalCondition(t *testing.T) {
 	fields := map[string]string{
 		"task.status": "in-progress",
 		"task.tags":   "backend,auth",
+		"task.title":  "implement auth middleware",
 		"empty":       "",
 	}
 
@@ -35,22 +36,27 @@ func TestEvalCondition(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "contains finds substring",
+			name: "contains finds exact tag",
 			cond: Condition{Field: "task.tags", Operator: "contains", Value: "auth"},
 			want: true,
 		},
 		{
-			name: "contains rejects missing substring",
+			name: "contains rejects missing tag",
 			cond: Condition{Field: "task.tags", Operator: "contains", Value: "frontend"},
 			want: false,
 		},
 		{
-			name: "not_contains passes when substring absent",
+			name: "contains keeps substring behavior for text fields",
+			cond: Condition{Field: "task.title", Operator: "contains", Value: "auth"},
+			want: true,
+		},
+		{
+			name: "not_contains passes when tag absent",
 			cond: Condition{Field: "task.tags", Operator: "not_contains", Value: "frontend"},
 			want: true,
 		},
 		{
-			name: "not_contains fails when substring present",
+			name: "not_contains fails when tag present",
 			cond: Condition{Field: "task.tags", Operator: "not_contains", Value: "auth"},
 			want: false,
 		},
@@ -108,6 +114,51 @@ func TestEvalCondition(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			got := EvalCondition(tt.cond, fields)
+			if got != tt.want {
+				t.Errorf("EvalCondition(%+v) = %v, want %v", tt.cond, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEvalCondition_TaskTagsUseExactMembership(t *testing.T) {
+	t.Parallel()
+
+	fields := map[string]string{
+		"task.tags": "handoff, handoff-review, force-staff-review",
+	}
+
+	tests := []struct {
+		name string
+		cond Condition
+		want bool
+	}{
+		{
+			name: "handoff-review is present",
+			cond: Condition{Field: "task.tags", Operator: "contains", Value: "handoff-review"},
+			want: true,
+		},
+		{
+			name: "broad review tag is not implied by suffixed tags",
+			cond: Condition{Field: "task.tags", Operator: "contains", Value: "review"},
+			want: false,
+		},
+		{
+			name: "not_contains broad review remains true for suffixed tags",
+			cond: Condition{Field: "task.tags", Operator: "not_contains", Value: "review"},
+			want: true,
+		},
+		{
+			name: "surrounding spaces are trimmed",
+			cond: Condition{Field: "task.tags", Operator: "contains", Value: "force-staff-review"},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := EvalCondition(tt.cond, fields)
 			if got != tt.want {
 				t.Errorf("EvalCondition(%+v) = %v, want %v", tt.cond, got, tt.want)

--- a/internal/workflow/handoff_test.go
+++ b/internal/workflow/handoff_test.go
@@ -50,13 +50,16 @@ func TestBuiltinHandoff_SkipsPlanningToImplement(t *testing.T) {
 	if !hasCondition(plan.Trigger.Conditions, "task.tags", "not_contains", "handoff") {
 		t.Errorf("simple-task-plan must exclude handoff tasks; got %+v", plan.Trigger.Conditions)
 	}
-	// The implement-stage handoff must NOT also fire for review- or
-	// testing-stage tasks (which also carry the bare `handoff` tag).
+	// The implement-stage handoff must NOT also fire for later-stage handoff
+	// tasks (which also carry the bare `handoff` tag).
 	if !hasCondition(handoff.Trigger.Conditions, "task.tags", "not_contains", "handoff-review") {
 		t.Errorf("simple-task-handoff must exclude handoff-review tasks; got %+v", handoff.Trigger.Conditions)
 	}
 	if !hasCondition(handoff.Trigger.Conditions, "task.tags", "not_contains", "handoff-testing") {
 		t.Errorf("simple-task-handoff must exclude handoff-testing tasks; got %+v", handoff.Trigger.Conditions)
+	}
+	if !hasCondition(handoff.Trigger.Conditions, "task.tags", "not_contains", "handoff-ready-pr") {
+		t.Errorf("simple-task-handoff must exclude handoff-ready-pr tasks; got %+v", handoff.Trigger.Conditions)
 	}
 }
 
@@ -109,5 +112,70 @@ func TestBuiltinHandoffReview_SkipsToReview(t *testing.T) {
 	review := defByID(t, "simple-task-review")
 	if !hasCondition(review.Trigger.Conditions, "task.status", "equals", "ready-review") {
 		t.Errorf("simple-task-review must trigger on status=ready-review; got %+v", review.Trigger.Conditions)
+	}
+}
+
+// TestBuiltinHandoffReadyPR_SkipsToPR locks the ready-pr-stage contract: a
+// task tagged `handoff-ready-pr` fires simple-task-handoff-ready-pr on creation,
+// which flips it straight to ready-pr so simple-task-pr opens or updates the PR
+// from the adopted worktree.
+func TestBuiltinHandoffReadyPR_SkipsToPR(t *testing.T) {
+	t.Parallel()
+
+	hp := defByID(t, "simple-task-handoff-ready-pr")
+	if hp.Trigger.On != "task.created" {
+		t.Errorf("handoff-ready-pr trigger.on = %q, want task.created", hp.Trigger.On)
+	}
+	if !hasCondition(hp.Trigger.Conditions, "task.tags", "contains", "handoff-ready-pr") {
+		t.Errorf("handoff-ready-pr trigger must require tag handoff-ready-pr; got %+v", hp.Trigger.Conditions)
+	}
+	first := hp.FirstStep()
+	if first == nil || first.Type != StepSetStatus || first.Config.Status != "ready-pr" {
+		t.Errorf("handoff-ready-pr first step must set status ready-pr; got %+v", first)
+	}
+
+	pr := defByID(t, "simple-task-pr")
+	if !hasCondition(pr.Trigger.Conditions, "task.status", "equals", "ready-pr") {
+		t.Errorf("simple-task-pr must trigger on status=ready-pr; got %+v", pr.Trigger.Conditions)
+	}
+}
+
+// TestBuiltinHandoffReview_DoesNotEnterPRReview is the regression for a real
+// misroute: task.tags used substring matching, so `handoff-review` satisfied
+// the pr-review workflow's broad `contains review` trigger and Sybra tried to
+// review PR #0 instead of entering the ready-review lane.
+func TestBuiltinHandoffReview_DoesNotEnterPRReview(t *testing.T) {
+	t.Parallel()
+
+	fields := map[string]string{
+		"task.tags": "handoff,handoff-review,force-staff-review",
+	}
+
+	hr := defByID(t, "simple-task-handoff-review")
+	if !EvalConditions(hr.Trigger.Conditions, fields) {
+		t.Fatalf("simple-task-handoff-review should match tags %q; conditions=%+v", fields["task.tags"], hr.Trigger.Conditions)
+	}
+
+	pr := defByID(t, "pr-review")
+	if EvalConditions(pr.Trigger.Conditions, fields) {
+		t.Fatalf("pr-review must not match handoff-review tags %q; conditions=%+v", fields["task.tags"], pr.Trigger.Conditions)
+	}
+}
+
+func TestBuiltinHandoffPR_EntersPRReview(t *testing.T) {
+	t.Parallel()
+
+	fields := map[string]string{
+		"task.tags": "review,handoff-pr",
+	}
+
+	pr := defByID(t, "pr-review")
+	if !EvalConditions(pr.Trigger.Conditions, fields) {
+		t.Fatalf("pr-review should match handoff-pr tags %q; conditions=%+v", fields["task.tags"], pr.Trigger.Conditions)
+	}
+
+	plan := defByID(t, "simple-task-plan")
+	if EvalConditions(plan.Trigger.Conditions, fields) {
+		t.Fatalf("simple-task-plan must not match handoff-pr tags %q; conditions=%+v", fields["task.tags"], plan.Trigger.Conditions)
 	}
 }

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -67,7 +67,7 @@ type Trigger struct {
 // Condition is a field-operator-value check.
 type Condition struct {
 	Field    string `yaml:"field" json:"field"`       // "task.tags", "task.status", "task.agent_mode"
-	Operator string `yaml:"operator" json:"operator"` // "equals", "not_equals", "contains", "not_contains", "exists"
+	Operator string `yaml:"operator" json:"operator"` // "equals", "not_equals", "contains", "not_contains", "exists", "in", "not_in"
 	Value    string `yaml:"value" json:"value"`
 }
 


### PR DESCRIPTION
## Summary
- make workflow tag matching exact for task.tags so handoff-review no longer triggers the broad PR-review lane
- make sybra-cli handoff create fully-populated tasks atomically via CreateFull, including plan/worktree/status fields
- add workflow-aware handoff stages for review/testing/ready-pr/pr plus raw --status placement with no workflow dispatch
- update bundled sybra-handoff skill with stage/status workflow context

## Tests
- env GOCACHE=/private/tmp/sybra-go-build-cache GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...
