### PR TITLE
Make Sybra handoff source-provider aware

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -184,6 +184,9 @@ func cmdGet(s *task.Manager, args []string, jsonOut bool) int {
 	if t.Issue != "" {
 		fmt.Printf("Issue: %s\n", t.Issue)
 	}
+	if t.HandoffSourceProvider != "" {
+		fmt.Printf("Source: %s\n", t.HandoffSourceProvider)
+	}
 	fmt.Printf("Created: %s\n", t.CreatedAt.Format("2006-01-02 15:04"))
 	fmt.Printf("Updated: %s\n", t.UpdatedAt.Format("2006-01-02 15:04"))
 	if t.Body != "" {
@@ -302,6 +305,7 @@ func cmdHandoff(s *task.Manager, ps *project.Store, args []string, jsonOut bool)
 	mode := fs.String("mode", "headless", "agent mode: headless|interactive")
 	stage := fs.String("stage", "implement", "workflow entry stage: implement|in-progress|review|ready-review|agentic-review|testing|ready-pr|pr|in-review")
 	rawStatus := fs.String("status", "", "raw task status to create without starting a workflow")
+	sourceProvider := fs.String("source-provider", "", "provider that produced the handed-off work: claude|codex|copilot")
 	pr := fs.Int("pr", 0, "PR number (required for --stage pr)")
 	extraTags := fs.String("tags", "", "extra comma-separated tags")
 	if err := fs.Parse(args); err != nil {
@@ -313,6 +317,13 @@ func cmdHandoff(s *task.Manager, ps *project.Store, args []string, jsonOut bool)
 	stageCfg, status, rawStatusMode, modeErr := resolveHandoffMode(fs, *stage, *rawStatus, *pr)
 	if modeErr != nil {
 		return fatal(jsonOut, "%v", modeErr)
+	}
+	handoffSource, srcErr := normalizeHandoffSourceProvider(*sourceProvider)
+	if srcErr != nil {
+		return fatal(jsonOut, "%v", srcErr)
+	}
+	if !rawStatusMode && handoffSource == "" && handoffStageRequiresSource(stageCfg.name) {
+		return fatal(jsonOut, "--stage %s requires --source-provider <claude|codex|copilot> so cross-provider review/testing is deterministic", *stage)
 	}
 
 	dir, dErr := resolveWorktreeDir(*wtDir)
@@ -338,6 +349,9 @@ func cmdHandoff(s *task.Manager, ps *project.Store, args []string, jsonOut bool)
 	}
 	if planContent != "" {
 		init.Plan = &planContent
+	}
+	if handoffSource != "" {
+		init.HandoffSourceProvider = &handoffSource
 	}
 	if rawStatusMode {
 		init.Status = &status
@@ -473,6 +487,27 @@ func handoffStageConfigFor(stage string) (handoffStageConfig, bool) {
 	}
 }
 
+func handoffStageRequiresSource(stage string) bool {
+	switch stage {
+	case "review", "testing", "pr":
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeHandoffSourceProvider(raw string) (string, error) {
+	provider := strings.ToLower(strings.TrimSpace(raw))
+	switch provider {
+	case "none", "clear":
+		provider = ""
+	}
+	if _, err := task.ValidateAgentProvider(provider); err != nil {
+		return "", err
+	}
+	return provider, nil
+}
+
 // resolveWorktreeDir resolves the handoff worktree (default: cwd) to an
 // absolute path and verifies it is an existing directory.
 func resolveWorktreeDir(wtDir string) (string, error) {
@@ -535,6 +570,9 @@ func parseExtraTags(extra string, exclude []string) []string {
 func printHandoffResult(t task.Task, stage, projectID, dir string) {
 	fmt.Printf("Handed off task %s: %s\n", t.ID, t.Title)
 	fmt.Printf("  project:  %s\n", projectID)
+	if t.HandoffSourceProvider != "" {
+		fmt.Printf("  source:   %s\n", t.HandoffSourceProvider)
+	}
 	switch stage {
 	case "review":
 		fmt.Printf("  worktree: %s\n", dir)
@@ -675,85 +713,14 @@ func cmdUpdate(s *task.Manager, args []string, jsonOut bool) int {
 
 	id := args[0]
 	fs := flag.NewFlagSet("update", flag.ContinueOnError)
-	title := fs.String("title", "", "new title")
-	status := fs.String("status", "", "new status")
-	body := fs.String("body", "", "new body")
-	plan := fs.String("plan", "", "plan content markdown (empty string clears plan)")
-	planFile := fs.String("plan-file", "", "path to file with plan content")
-	planCritique := fs.String("plan-critique", "", "plan critique markdown (empty string clears critique)")
-	planCritiqueFile := fs.String("plan-critique-file", "", "path to file with plan critique content")
-	codeReview := fs.String("code-review", "", "code review markdown (empty string clears review)")
-	codeReviewFile := fs.String("code-review-file", "", "path to file with code review content")
-	mode := fs.String("mode", "", "new agent mode")
-	ttype := fs.String("type", "", "new task type: normal|debug|research")
-	tags := fs.String("tags", "", "comma-separated tags (replaces existing)")
-	proj := fs.String("project", "", "project id (owner/repo)")
-	branch := fs.String("branch", "", "Git branch name")
-	pr := fs.Int("pr", 0, "GitHub PR number")
-	issue := fs.String("issue", "", "GitHub issue URL")
-	statusReason := fs.String("status-reason", "", "reason for status change")
-	maxTurnsFlag := fs.Int("max-turns", -1, "per-task max turns override (0 clears override, >0 sets limit)")
-	reasoningEffort := fs.String("reasoning-effort", "", "codex reasoning effort: low|medium|high|xhigh ('default' or 'none' clears the override)")
+	flags := newUpdateFlags(fs)
 	if err := fs.Parse(args[1:]); err != nil {
 		return fatal(jsonOut, "%v", err)
 	}
 
-	updates := map[string]any{}
-	if *title != "" {
-		updates["title"] = *title
-	}
-	if *status != "" {
-		updates["status"] = *status
-	}
-	if *statusReason != "" {
-		updates["status_reason"] = *statusReason
-	}
-	if *body != "" {
-		updates["body"] = *body
-	}
-	for _, fu := range []struct{ flag, key, str, file string }{
-		{"plan", "plan", *plan, *planFile},
-		{"plan-critique", "plan_critique", *planCritique, *planCritiqueFile},
-		{"code-review", "code_review", *codeReview, *codeReviewFile},
-	} {
-		if err := applyFileOrStringUpdate(fs, updates, fu.flag, fu.key, fu.str, fu.file); err != nil {
-			return fatal(jsonOut, "%v", err)
-		}
-	}
-	if *mode != "" {
-		updates["agent_mode"] = *mode
-	}
-	if *ttype != "" {
-		if _, err := task.ValidateTaskType(*ttype); err != nil {
-			return fatal(jsonOut, "%v", err)
-		}
-		updates["task_type"] = *ttype
-	}
-	if *tags != "" {
-		updates["tags"] = parseTags(*tags)
-	}
-	if *proj != "" {
-		updates["project_id"] = *proj
-	}
-	if *branch != "" {
-		updates["branch"] = *branch
-	}
-	if *pr > 0 {
-		updates["pr_number"] = float64(*pr)
-	}
-	if *issue != "" {
-		updates["issue"] = *issue
-	}
-	// -1 is the sentinel "not provided"; 0 clears override, >0 sets limit.
-	if *maxTurnsFlag >= 0 {
-		updates["max_turns"] = float64(*maxTurnsFlag)
-	}
-	if *reasoningEffort != "" {
-		v, err := normalizeReasoningEffort(*reasoningEffort)
-		if err != nil {
-			return fatal(jsonOut, "%v", err)
-		}
-		updates["reasoning_effort"] = v
+	updates, uErr := buildUpdateMap(fs, flags)
+	if uErr != nil {
+		return fatal(jsonOut, "%v", uErr)
 	}
 
 	if len(updates) == 0 {
@@ -770,6 +737,139 @@ func cmdUpdate(s *task.Manager, args []string, jsonOut bool) int {
 	}
 	fmt.Printf("Updated task %s\n", t.ID)
 	return 0
+}
+
+type updateFlags struct {
+	title            *string
+	status           *string
+	body             *string
+	plan             *string
+	planFile         *string
+	planCritique     *string
+	planCritiqueFile *string
+	codeReview       *string
+	codeReviewFile   *string
+	mode             *string
+	taskType         *string
+	tags             *string
+	project          *string
+	branch           *string
+	pr               *int
+	issue            *string
+	sourceProvider   *string
+	statusReason     *string
+	maxTurns         *int
+	reasoningEffort  *string
+}
+
+func newUpdateFlags(fs *flag.FlagSet) updateFlags {
+	return updateFlags{
+		title:            fs.String("title", "", "new title"),
+		status:           fs.String("status", "", "new status"),
+		body:             fs.String("body", "", "new body"),
+		plan:             fs.String("plan", "", "plan content markdown (empty string clears plan)"),
+		planFile:         fs.String("plan-file", "", "path to file with plan content"),
+		planCritique:     fs.String("plan-critique", "", "plan critique markdown (empty string clears critique)"),
+		planCritiqueFile: fs.String("plan-critique-file", "", "path to file with plan critique content"),
+		codeReview:       fs.String("code-review", "", "code review markdown (empty string clears review)"),
+		codeReviewFile:   fs.String("code-review-file", "", "path to file with code review content"),
+		mode:             fs.String("mode", "", "new agent mode"),
+		taskType:         fs.String("type", "", "new task type: normal|debug|research"),
+		tags:             fs.String("tags", "", "comma-separated tags (replaces existing)"),
+		project:          fs.String("project", "", "project id (owner/repo)"),
+		branch:           fs.String("branch", "", "Git branch name"),
+		pr:               fs.Int("pr", 0, "GitHub PR number"),
+		issue:            fs.String("issue", "", "GitHub issue URL"),
+		sourceProvider:   fs.String("source-provider", "", "handoff source provider: claude|codex|copilot|none"),
+		statusReason:     fs.String("status-reason", "", "reason for status change"),
+		maxTurns:         fs.Int("max-turns", -1, "per-task max turns override (0 clears override, >0 sets limit)"),
+		reasoningEffort:  fs.String("reasoning-effort", "", "codex reasoning effort: low|medium|high|xhigh ('default' or 'none' clears the override)"),
+	}
+}
+
+func buildUpdateMap(fs *flag.FlagSet, f updateFlags) (map[string]any, error) {
+	updates := map[string]any{}
+	applyBasicUpdateFlags(updates, f)
+	if err := applySidecarUpdateFlags(fs, updates, f); err != nil {
+		return nil, err
+	}
+	if err := applyTypedUpdateFlags(fs, updates, f); err != nil {
+		return nil, err
+	}
+	return updates, nil
+}
+
+func applyBasicUpdateFlags(updates map[string]any, f updateFlags) {
+	if *f.title != "" {
+		updates["title"] = *f.title
+	}
+	if *f.status != "" {
+		updates["status"] = *f.status
+	}
+	if *f.statusReason != "" {
+		updates["status_reason"] = *f.statusReason
+	}
+	if *f.body != "" {
+		updates["body"] = *f.body
+	}
+	if *f.mode != "" {
+		updates["agent_mode"] = *f.mode
+	}
+	if *f.tags != "" {
+		updates["tags"] = parseTags(*f.tags)
+	}
+	if *f.project != "" {
+		updates["project_id"] = *f.project
+	}
+	if *f.branch != "" {
+		updates["branch"] = *f.branch
+	}
+	if *f.pr > 0 {
+		updates["pr_number"] = float64(*f.pr)
+	}
+	if *f.issue != "" {
+		updates["issue"] = *f.issue
+	}
+}
+
+func applySidecarUpdateFlags(fs *flag.FlagSet, updates map[string]any, f updateFlags) error {
+	for _, fu := range []struct{ flag, key, str, file string }{
+		{"plan", "plan", *f.plan, *f.planFile},
+		{"plan-critique", "plan_critique", *f.planCritique, *f.planCritiqueFile},
+		{"code-review", "code_review", *f.codeReview, *f.codeReviewFile},
+	} {
+		if err := applyFileOrStringUpdate(fs, updates, fu.flag, fu.key, fu.str, fu.file); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyTypedUpdateFlags(fs *flag.FlagSet, updates map[string]any, f updateFlags) error {
+	if *f.taskType != "" {
+		if _, err := task.ValidateTaskType(*f.taskType); err != nil {
+			return err
+		}
+		updates["task_type"] = *f.taskType
+	}
+	if flagWasProvided(fs, "source-provider") {
+		v, err := normalizeHandoffSourceProvider(*f.sourceProvider)
+		if err != nil {
+			return err
+		}
+		updates["handoff_source_provider"] = v
+	}
+	if *f.maxTurns >= 0 {
+		updates["max_turns"] = float64(*f.maxTurns)
+	}
+	if *f.reasoningEffort != "" {
+		v, err := normalizeReasoningEffort(*f.reasoningEffort)
+		if err != nil {
+			return err
+		}
+		updates["reasoning_effort"] = v
+	}
+	return nil
 }
 
 func cmdDelete(s *task.Manager, args []string, jsonOut bool) int {
@@ -810,6 +910,16 @@ func applyFileOrStringUpdate(fs *flag.FlagSet, updates map[string]any, flagName,
 		})
 	}
 	return nil
+}
+
+func flagWasProvided(fs *flag.FlagSet, name string) bool {
+	found := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			found = true
+		}
+	})
+	return found
 }
 
 func parseTags(s string) []string {
@@ -1340,7 +1450,7 @@ Commands:
   get      <id>
   create   --title TITLE [--body BODY] [--plan PLAN] [--mode MODE] [--type TYPE] [--tags t1,t2] [--project ID] [--branch B] [--pr N] [--issue URL] [--allow-dup]
            TYPE: normal|debug|research
-  handoff  --title TITLE [--body BODY] [--plan PLAN | --plan-file PATH] [--project ID] [--worktree-dir DIR] [--stage STAGE | --status STATUS] [--pr N] [--mode MODE] [--tags t1,t2]
+  handoff  --title TITLE [--body BODY] [--plan PLAN | --plan-file PATH] [--project ID] [--worktree-dir DIR] [--stage STAGE | --status STATUS] [--source-provider claude|codex|copilot] [--pr N] [--mode MODE] [--tags t1,t2]
            Hand a task to Sybra at a workflow entry point, reusing the given git worktree
            (default: cwd). Project is derived from the worktree's origin remote
            when --project is omitted. STAGE (default implement):
@@ -1349,8 +1459,11 @@ Commands:
              testing        reviewed locally -> Sybra tests, then opens the PR
              ready-pr       tested locally -> Sybra opens or updates the PR
              pr|in-review   existing PR (--pr N) -> Sybra reviews the PR
+           --source-provider records which local agent produced handed-off work
+           so review/testing/PR steps can run on a different provider.
+           Required for --stage review|testing|pr; optional for implement/ready-pr.
            --status STATUS creates the task directly in that status without workflow dispatch
-  update   <id> [--title T] [--status S] [--status-reason R] [--body B] [--plan PLAN] [--plan-file PATH] [--mode M] [--type TYPE] [--tags T] [--project ID] [--branch B] [--pr N] [--issue URL] [--max-turns N] [--reasoning-effort E]
+  update   <id> [--title T] [--status S] [--status-reason R] [--body B] [--plan PLAN] [--plan-file PATH] [--mode M] [--type TYPE] [--tags T] [--project ID] [--branch B] [--pr N] [--issue URL] [--source-provider P|none] [--max-turns N] [--reasoning-effort E]
   delete   <id>
 
   project list

--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -3,9 +3,12 @@ package main
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -39,6 +42,19 @@ func runCLI(t *testing.T, args ...string) (exitCode int, output string) {
 	buf := make([]byte, 64*1024)
 	n, _ := r.Read(buf)
 	return code, string(buf[:n])
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, string(out))
+	}
+	return string(out)
 }
 
 func TestListEmpty(t *testing.T) {
@@ -357,6 +373,111 @@ func TestCreateWithProject(t *testing.T) {
 	mustUnmarshal(t, out, &created)
 	if created.ProjectID != "owner/repo" {
 		t.Errorf("projectId = %q, want %q", created.ProjectID, "owner/repo")
+	}
+}
+
+func TestHandoffPersistsSourceProviderAtomically(t *testing.T) {
+	setupStore(t)
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	ps, err := project.NewStore(cfg.ProjectsDir, cfg.ClonesDir)
+	if err != nil {
+		t.Fatalf("project.NewStore: %v", err)
+	}
+	proj, err := ps.CreateMeta("https://github.com/acme/repo.git", project.ProjectTypePet)
+	if err != nil {
+		t.Fatalf("CreateMeta: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(proj.ClonePath), 0o755); err != nil {
+		t.Fatalf("mkdir clone parent: %v", err)
+	}
+	runGit(t, "", "init", "--bare", proj.ClonePath)
+	runGit(t, proj.ClonePath, "symbolic-ref", "HEAD", "refs/heads/main")
+
+	worktree := filepath.Join(t.TempDir(), "repo")
+	runGit(t, "", "init", worktree)
+	runGit(t, worktree, "checkout", "-b", "feature/handoff")
+	runGit(t, worktree, "remote", "add", "origin", "https://github.com/acme/repo.git")
+
+	code, out := runCLI(t,
+		"--json", "handoff",
+		"--title", "feat(test): handoff source",
+		"--body", "body",
+		"--plan", "approved plan",
+		"--project", "acme/repo",
+		"--worktree-dir", worktree,
+		"--stage", "review",
+		"--source-provider", "CoDeX",
+	)
+	if code != 0 {
+		t.Fatalf("handoff exit %d: %s", code, out)
+	}
+
+	var created task.Task
+	mustUnmarshal(t, out, &created)
+	if created.ProjectID != "acme/repo" {
+		t.Errorf("ProjectID = %q, want acme/repo", created.ProjectID)
+	}
+	if created.WorktreeDir != worktree {
+		t.Errorf("WorktreeDir = %q, want %q", created.WorktreeDir, worktree)
+	}
+	if created.HandoffSourceProvider != "codex" {
+		t.Errorf("HandoffSourceProvider = %q, want codex", created.HandoffSourceProvider)
+	}
+	if created.Plan != "approved plan" {
+		t.Errorf("Plan = %q, want approved plan", created.Plan)
+	}
+	wantTags := []string{"handoff", "handoff-review"}
+	for i := range wantTags {
+		if i >= len(created.Tags) || created.Tags[i] != wantTags[i] {
+			t.Fatalf("Tags = %v, want prefix %v", created.Tags, wantTags)
+		}
+	}
+}
+
+func TestHandoffReviewRequiresSourceProvider(t *testing.T) {
+	setupStore(t)
+
+	code, _ := runCLI(t,
+		"--json", "handoff",
+		"--title", "feat(test): missing source",
+		"--stage", "review",
+	)
+	if code == 0 {
+		t.Fatal("handoff review without source provider succeeded, want failure")
+	}
+}
+
+func TestUpdateHandoffSourceProvider(t *testing.T) {
+	setupStore(t)
+
+	code, out := runCLI(t, "--json", "create", "--title", "source repair")
+	if code != 0 {
+		t.Fatalf("create exit %d: %s", code, out)
+	}
+	var created task.Task
+	mustUnmarshal(t, out, &created)
+
+	code, out = runCLI(t, "--json", "update", created.ID, "--source-provider", "Copilot")
+	if code != 0 {
+		t.Fatalf("update source exit %d: %s", code, out)
+	}
+	var updated task.Task
+	mustUnmarshal(t, out, &updated)
+	if updated.HandoffSourceProvider != "copilot" {
+		t.Fatalf("HandoffSourceProvider = %q, want copilot", updated.HandoffSourceProvider)
+	}
+
+	code, out = runCLI(t, "--json", "update", created.ID, "--source-provider", "none")
+	if code != 0 {
+		t.Fatalf("clear source exit %d: %s", code, out)
+	}
+	var cleared task.Task
+	mustUnmarshal(t, out, &cleared)
+	if cleared.HandoffSourceProvider != "" {
+		t.Fatalf("HandoffSourceProvider = %q, want cleared", cleared.HandoffSourceProvider)
 	}
 }
 

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -186,6 +186,14 @@ export class Task {
     "statusReason": string;
 
     /**
+     * HandoffSourceProvider records which local agent provider produced the
+     * work before a handoff skipped directly into review/testing/PR. Workflow
+     * steps with provider=cross use it when there is no Sybra-authored run
+     * history to flip from.
+     */
+    "handoffSourceProvider"?: string;
+
+    /**
      * BlockedByIssue stores the URL of the GitHub issue that put the task
      * into status=blocked. Set by the human-review automation when it
      * concludes the human-required transition was caused by a Sybra bug.
@@ -367,9 +375,9 @@ export class Task {
     static createFrom($$source: any = {}): Task {
         const $$createField6_0 = $$createType0;
         const $$createField7_0 = $$createType0;
-        const $$createField30_0 = $$createType2;
-        const $$createField31_0 = $$createType4;
-        const $$createField38_0 = $$createType5;
+        const $$createField31_0 = $$createType2;
+        const $$createField32_0 = $$createType4;
+        const $$createField39_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -378,13 +386,13 @@ export class Task {
             $$parsedSource["tags"] = $$createField7_0($$parsedSource["tags"]);
         }
         if ("agentRuns" in $$parsedSource) {
-            $$parsedSource["agentRuns"] = $$createField30_0($$parsedSource["agentRuns"]);
+            $$parsedSource["agentRuns"] = $$createField31_0($$parsedSource["agentRuns"]);
         }
         if ("workflow" in $$parsedSource) {
-            $$parsedSource["workflow"] = $$createField31_0($$parsedSource["workflow"]);
+            $$parsedSource["workflow"] = $$createField32_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField38_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField39_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }

--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -414,7 +414,7 @@ export class StepConfig {
     "model": string;
 
     /**
-     * "", "claude", "codex", "cross"
+     * "", "claude", "codex", "copilot", "cross"
      */
     "provider": string;
     "prompt": string;

--- a/internal/skills/data/sybra-handoff.md
+++ b/internal/skills/data/sybra-handoff.md
@@ -1,9 +1,9 @@
 ---
 name: sybra-handoff
-description: Hand a researched, already-decided task off to Sybra for autonomous implementation. Use after you have explored a problem in an Orca (or any) git worktree, agreed on the approach, and want Sybra to skip its own planning and start implementing immediately — reusing this exact worktree. Triggers on "hand this off to Sybra", "let Sybra implement this", "ship this to Sybra", "handoff to sybra". Works under both Claude Code and Codex.
+description: Hand a researched, already-decided task off to Sybra for autonomous implementation or cross-provider review/testing. Use after you have explored a problem in an Orca (or any) git worktree, agreed on the approach, and want Sybra to skip its own planning and start at the right stage — reusing this exact worktree. Triggers on "hand this off to Sybra", "let Sybra implement this", "ship this to Sybra", "handoff to sybra". Works under Claude Code, Codex, and Copilot.
 allowed-tools: Bash
 user-invocable: true
-argument-hint: "[--stage STAGE | --status STATUS] [--title \"...\"] [--plan-file PATH] [--worktree-dir DIR] [--pr N]"
+argument-hint: "[--stage STAGE | --status STATUS] [--title \"...\"] [--plan-file PATH] [--worktree-dir DIR] [--source-provider claude|codex|copilot] [--pr N]"
 ---
 
 # Sybra Handoff
@@ -20,14 +20,14 @@ Sybra is the autonomous execution phase.
 
 Hand off at whatever stage you have reached — Sybra picks up from there:
 - You have a **plan** but have not implemented → `--stage implement` (default).
-- You have **implemented** locally and want agentic review + PR → `--stage review`
+- You have **implemented** locally and want cross-provider agentic review + PR → `--stage review`
   (aliases: `ready-review`, `agentic-review`).
 - You have **implemented and reviewed** locally and want the testing gate →
-  `--stage testing`.
+  `--stage testing` with a different provider.
 - You have **implemented, reviewed, and tested** locally and want Sybra to open
   or update the PR from this worktree → `--stage ready-pr`.
-- You already **opened a PR** and want Sybra to review it → `--stage pr --pr N`
-  (alias: `in-review --pr N`).
+- You already **opened a PR** and want Sybra to review it with a different
+  provider → `--stage pr --pr N` (alias: `in-review --pr N`).
 
 In all cases the approach is decided and you want Sybra to carry it the rest of
 the way autonomously. Do **not** use for exploratory work that still needs human
@@ -52,13 +52,14 @@ Stages:
 - **implement** (default): flips to `in-progress`; the implementation agent runs
   now with your plan as context, then review → PR.
 - **review**: flips to `ready-review`; Sybra reviews your existing commits in the
-  worktree and opens the PR (no implementation step).
+  worktree with a different provider and opens the PR (no implementation step).
 - **testing**: flips to `testing`; Sybra runs the adversarial testing gate in the
-  adopted worktree and opens the PR if tests pass.
+  adopted worktree with a different provider and opens the PR if tests pass.
 - **ready-pr**: flips to `ready-pr`; Sybra opens or updates the PR from the
   adopted worktree (no implementation, review, or testing step).
 - **pr**: for an existing PR (`--pr N`); Sybra reviews the open PR via its
-  pr-review lane (no worktree adoption — it checks out the PR head itself).
+  pr-review lane with a different provider (no worktree adoption — it checks out
+  the PR head itself).
 
 ## Workflow entry context
 
@@ -118,8 +119,14 @@ such as `review` unless you intentionally want the existing-PR lane.
    sybra-cli handoff \
      --title "feat(auth): add jwt refresh middleware" \
      --body  "One-paragraph problem statement + the research context Sybra needs." \
+     --source-provider "<claude|codex|copilot>" \
      --plan-file ./.sybra-handoff-plan.md
    ```
+   Set `--source-provider` to the provider running this skill: Claude Code uses
+   `claude`, Codex uses `codex`, and Copilot uses `copilot`. It is required for
+   `--stage review`, `--stage testing`, and `--stage pr`, and recommended for
+   `--stage implement` and `--stage ready-pr` so provenance is visible on the
+   task.
    - `--stage review` / `ready-review` / `agentic-review` to skip implementation
      (you already coded it); `--stage testing` to skip implementation and
      review; `--stage ready-pr` to skip directly to PR creation/update;

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -155,35 +155,36 @@ func (a *taskAdapter) WriteSidecar(id, kind, content string) error {
 
 func taskToInfo(t task.Task) workflow.TaskInfo {
 	return workflow.TaskInfo{
-		ID:           t.ID,
-		Title:        t.Title,
-		Status:       string(t.Status),
-		Tags:         t.Tags,
-		AgentMode:    t.AgentMode,
-		ProjectID:    t.ProjectID,
-		PRNumber:     t.PRNumber,
-		Branch:       t.Branch,
-		Body:         t.Body,
-		Plan:         t.Plan,
-		PlanCritique: t.PlanCritique,
-		CodeReview:   t.CodeReview,
-		PlanDrafts:   t.PlanDrafts,
-		Issue:        t.Issue,
-		Reviewed:     t.Reviewed,
-		Workflow:     t.Workflow,
-		AgentRuns:    toRunInfos(t.AgentRuns),
+		ID:                    t.ID,
+		Title:                 t.Title,
+		Status:                string(t.Status),
+		Tags:                  t.Tags,
+		AgentMode:             t.AgentMode,
+		ProjectID:             t.ProjectID,
+		HandoffSourceProvider: t.HandoffSourceProvider,
+		PRNumber:              t.PRNumber,
+		Branch:                t.Branch,
+		Body:                  t.Body,
+		Plan:                  t.Plan,
+		PlanCritique:          t.PlanCritique,
+		CodeReview:            t.CodeReview,
+		PlanDrafts:            t.PlanDrafts,
+		Issue:                 t.Issue,
+		Reviewed:              t.Reviewed,
+		Workflow:              t.Workflow,
+		AgentRuns:             toRunInfos(t.AgentRuns),
 	}
 }
 
-// toRunInfos projects a task's agent runs onto the engine-visible subset
-// (role only) used by route_test_result's attempt counter.
+// toRunInfos projects a task's agent runs onto the engine-visible subset used
+// by route_test_result and cross-provider provenance.
 func toRunInfos(runs []task.AgentRun) []workflow.AgentRunInfo {
 	if len(runs) == 0 {
 		return nil
 	}
 	out := make([]workflow.AgentRunInfo, len(runs))
 	for i := range runs {
-		out[i] = workflow.AgentRunInfo{Role: runs[i].Role}
+		out[i] = workflow.AgentRunInfo{Role: runs[i].Role, Provider: runs[i].Provider}
 	}
 	return out
 }

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -4593,8 +4593,8 @@ func TestE2E_CrossDefaultEmptyProvider_ResolvesDeterministically(t *testing.T) {
 			prov = tk.Workflow.StepHistory[i].Provider
 		}
 	}
-	if prov != "codex" {
-		t.Fatalf("cross_step provider = %q, want codex when default empty(normalized claude)", prov)
+	if prov != "claude" {
+		t.Fatalf("cross_step provider = %q, want claude default when no provenance exists", prov)
 	}
 }
 

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -149,6 +149,24 @@ func ValidateReasoningEffort(s string) (string, error) {
 	return s, nil
 }
 
+// AllAgentProviders returns every supported CLI provider name in display order.
+func AllAgentProviders() []string { return []string{"claude", "codex", "copilot"} }
+
+var validAgentProviders = map[string]bool{"claude": true, "codex": true, "copilot": true}
+
+// ValidateAgentProvider accepts the empty string (unset/default) or one of the
+// providers Sybra can dispatch. It is used for handoff provenance, not the
+// task's execution mode.
+func ValidateAgentProvider(s string) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+	if !validAgentProviders[s] {
+		return "", fmt.Errorf("invalid provider %q (valid: claude, codex, copilot, or empty)", s)
+	}
+	return s, nil
+}
+
 type AgentRun struct {
 	AgentID   string    `yaml:"agent_id" json:"agentId"`
 	Role      string    `yaml:"role,omitempty" json:"role"` // triage, plan, eval, pr-fix, or "" for implementation
@@ -192,6 +210,11 @@ type Task struct {
 	PRNumber     int    `yaml:"pr_number,omitempty" json:"prNumber"`
 	Issue        string `yaml:"issue,omitempty" json:"issue"`
 	StatusReason string `yaml:"status_reason,omitempty" json:"statusReason"`
+	// HandoffSourceProvider records which local agent provider produced the
+	// work before a handoff skipped directly into review/testing/PR. Workflow
+	// steps with provider=cross use it when there is no Sybra-authored run
+	// history to flip from.
+	HandoffSourceProvider string `yaml:"handoff_source_provider,omitempty" json:"handoffSourceProvider,omitempty"`
 	// BlockedByIssue stores the URL of the GitHub issue that put the task
 	// into status=blocked. Set by the human-review automation when it
 	// concludes the human-required transition was caused by a Sybra bug.

--- a/internal/task/model_test.go
+++ b/internal/task/model_test.go
@@ -165,6 +165,32 @@ func TestAllReasoningEfforts(t *testing.T) {
 	}
 }
 
+func TestValidateAgentProvider(t *testing.T) {
+	t.Parallel()
+
+	for _, v := range []string{"", "claude", "codex", "copilot"} {
+		t.Run("valid_"+v, func(t *testing.T) {
+			t.Parallel()
+			got, err := ValidateAgentProvider(v)
+			if err != nil {
+				t.Fatalf("ValidateAgentProvider(%q): %v", v, err)
+			}
+			if got != v {
+				t.Errorf("got %q, want %q", got, v)
+			}
+		})
+	}
+
+	for _, v := range []string{"gpt", "Claude", " codex "} {
+		t.Run("invalid_"+v, func(t *testing.T) {
+			t.Parallel()
+			if _, err := ValidateAgentProvider(v); err == nil {
+				t.Fatalf("expected error for %q, got nil", v)
+			}
+		})
+	}
+}
+
 func TestTask_DirName_WithSlug(t *testing.T) {
 	t.Parallel()
 	task := Task{ID: "a1b2c3d4", Slug: "my-task"}

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -361,6 +361,33 @@ func (s *Store) CreateFull(title, body, mode string, init Update) (Task, error) 
 	if init.Body != nil {
 		t.Body = *init.Body
 	}
+	if init.Branch != nil {
+		t.Branch = *init.Branch
+	}
+	if init.WorktreeDir != nil {
+		t.WorktreeDir = *init.WorktreeDir
+	}
+	if init.HandoffSourceProvider != nil {
+		t.HandoffSourceProvider = *init.HandoffSourceProvider
+	}
+	if init.Issue != nil {
+		t.Issue = *init.Issue
+	}
+	if init.Reviewed != nil {
+		t.Reviewed = *init.Reviewed
+	}
+	if init.MaxTurns != nil {
+		t.MaxTurns = *init.MaxTurns
+	}
+	if init.ForkSubagent != nil {
+		t.ForkSubagent = *init.ForkSubagent
+	}
+	if init.ReasoningEffort != nil {
+		t.ReasoningEffort = *init.ReasoningEffort
+	}
+	if err := s.writeSidecars(id, init, &t); err != nil {
+		return Task{}, err
+	}
 
 	if err := s.writeSidecars(t.ID, init, &t); err != nil {
 		return Task{}, err
@@ -491,6 +518,9 @@ func applyLinkFields(t *Task, u Update) {
 	}
 	if u.WorktreeDir != nil {
 		t.WorktreeDir = *u.WorktreeDir
+	}
+	if u.HandoffSourceProvider != nil {
+		t.HandoffSourceProvider = *u.HandoffSourceProvider
 	}
 	if u.PRNumber != nil {
 		t.PRNumber = *u.PRNumber

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -12,37 +12,38 @@ import (
 // A nil pointer means "leave unchanged"; a non-nil pointer applies the new value.
 // For Workflow: nil = unchanged; non-nil = overwrite (even if pointed-to value is nil).
 type Update struct {
-	Title           *string
-	Slug            *string
-	Status          *Status
-	StatusReason    *string
-	BlockedByIssue  *string
-	AgentMode       *string
-	TaskType        *TaskType
-	Body            *string
-	Tags            *[]string
-	ProjectID       *string
-	Branch          *string
-	WorktreeDir     *string
-	PRNumber        *int
-	Issue           *string
-	Reviewed        *bool
-	RunRole         *string
-	SupervisorSteer *string
-	ReviewPhase     *string
-	PRPhase         *string
-	TodoistID       *string
-	Priority        *Priority
-	DueDate         **time.Time
-	Workflow        **workflow.Execution
-	Plan            *string
-	PlanCritique    *string
-	CodeReview      *string
-	MaxTurns        *int
-	ForkSubagent    *bool
-	ReasoningEffort *string
-	Outcome         *string
-	MergeCommit     *string
+	Title                 *string
+	Slug                  *string
+	Status                *Status
+	StatusReason          *string
+	BlockedByIssue        *string
+	AgentMode             *string
+	TaskType              *TaskType
+	Body                  *string
+	Tags                  *[]string
+	ProjectID             *string
+	Branch                *string
+	WorktreeDir           *string
+	HandoffSourceProvider *string
+	PRNumber              *int
+	Issue                 *string
+	Reviewed              *bool
+	RunRole               *string
+	SupervisorSteer       *string
+	ReviewPhase           *string
+	PRPhase               *string
+	TodoistID             *string
+	Priority              *Priority
+	DueDate               **time.Time
+	Workflow              **workflow.Execution
+	Plan                  *string
+	PlanCritique          *string
+	CodeReview            *string
+	MaxTurns              *int
+	ForkSubagent          *bool
+	ReasoningEffort       *string
+	Outcome               *string
+	MergeCommit           *string
 }
 
 // Ptr returns a pointer to v. Convenience for building Update literals.
@@ -71,6 +72,8 @@ func applyMapField(u *Update, k string, v any) error {
 		"project_id", "branch", "worktree_dir", "issue", "run_role", "todoist_id", "plan", "plan_critique", "code_review",
 		"review_phase", "pr_phase", "outcome", "merge_commit", "supervisor_steer":
 		return applyPlainStringField(u, k, v)
+	case "handoff_source_provider":
+		return applyAgentProviderField(u, k, v)
 	case "priority":
 		return applyPriorityField(u, v)
 	case "status":
@@ -166,6 +169,19 @@ func applyPlainStringField(u *Update, k string, v any) error {
 	case "merge_commit":
 		u.MergeCommit = &s
 	}
+	return nil
+}
+
+func applyAgentProviderField(u *Update, k string, v any) error {
+	s, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("field %q: want string, got %T", k, v)
+	}
+	prov, err := ValidateAgentProvider(strings.ToLower(strings.TrimSpace(s)))
+	if err != nil {
+		return err
+	}
+	u.HandoffSourceProvider = &prov
 	return nil
 }
 

--- a/internal/workflow/builtin/pr-review.yaml
+++ b/internal/workflow/builtin/pr-review.yaml
@@ -53,6 +53,7 @@ steps:
       role: review
       mode: headless
       model: sonnet
+      provider: cross
       prompt: >-
         Run /pr-review on https://github.com/{{.Task.ProjectID}}/pull/{{.Task.PRNumber}}
     next:
@@ -65,6 +66,7 @@ steps:
       role: review
       mode: headless
       model: opus
+      provider: cross
       prompt: >-
         Run /staff-code-review on https://github.com/{{.Task.ProjectID}}/pull/{{.Task.PRNumber}}
     next:

--- a/internal/workflow/builtin/testing-task.yaml
+++ b/internal/workflow/builtin/testing-task.yaml
@@ -48,6 +48,7 @@ steps:
       role: test-runner
       mode: headless
       model: sonnet
+      provider: cross
       needs_worktree: true
       max_retries: 1
       prompt: >-

--- a/internal/workflow/condition.go
+++ b/internal/workflow/condition.go
@@ -17,15 +17,16 @@ import (
 // dead code, since its "project.type" condition had no populating caller.
 var KnownTriggerFields = map[string]bool{
 	// Populated by engine.taskFields for every dispatch/transition.
-	"task.id":         true,
-	"task.title":      true,
-	"task.status":     true,
-	"task.tags":       true,
-	"task.agent_mode": true,
-	"task.project_id": true,
-	"task.branch":     true,
-	"task.pr_number":  true,
-	"task.reviewed":   true,
+	"task.id":                      true,
+	"task.title":                   true,
+	"task.status":                  true,
+	"task.tags":                    true,
+	"task.agent_mode":              true,
+	"task.project_id":              true,
+	"task.handoff_source_provider": true,
+	"task.branch":                  true,
+	"task.pr_number":               true,
+	"task.reviewed":                true,
 	// Supplied as extras by DispatchEvent("pr.event", ...) callers in
 	// app_reviews.go and svc_integrations.go.
 	"pr.issue_kind": true,

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -17,34 +17,36 @@ const (
 
 // TaskInfo is the subset of task data the engine needs.
 type TaskInfo struct {
-	ID           string
-	Title        string
-	Status       string
-	Tags         []string
-	AgentMode    string
-	ProjectID    string
-	ProjectType  string
-	PRNumber     int
-	Branch       string
-	Body         string
-	Plan         string
-	PlanCritique string
-	CodeReview   string
+	ID                    string
+	Title                 string
+	Status                string
+	Tags                  []string
+	AgentMode             string
+	ProjectID             string
+	ProjectType           string
+	HandoffSourceProvider string
+	PRNumber              int
+	Branch                string
+	Body                  string
+	Plan                  string
+	PlanCritique          string
+	CodeReview            string
 	// PlanDrafts holds raw per-provider plans during dual-/N-provider planning.
 	// Keys are parallel child step IDs (e.g. "plan_claude", "plan_codex").
 	PlanDrafts map[string]string
 	Issue      string
 	Reviewed   bool
 	Workflow   *Execution
-	// AgentRuns is the minimal per-task agent-run history the engine needs
-	// (role only). route_test_result counts prior test-runner runs to enforce
-	// the testing → re-implementation attempt cap.
+	// AgentRuns is the minimal per-task agent-run history the engine needs.
+	// route_test_result counts prior test-runner runs; provider=cross uses
+	// code-authoring run providers when a previous workflow wrote the code.
 	AgentRuns []AgentRunInfo
 }
 
 // AgentRunInfo is the engine-visible subset of a task's agent run.
 type AgentRunInfo struct {
-	Role string
+	Role     string
+	Provider string
 }
 
 // TaskProvider reads and updates tasks.

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -527,14 +527,15 @@ func (e *Engine) fireComplete(c *CompletionInfo) {
 
 func taskFields(t TaskInfo) map[string]string {
 	fields := map[string]string{
-		"task.id":         t.ID,
-		"task.title":      t.Title,
-		"task.status":     t.Status,
-		"task.tags":       strings.Join(t.Tags, ","),
-		"task.agent_mode": t.AgentMode,
-		"task.project_id": t.ProjectID,
-		"task.branch":     t.Branch,
-		"task.reviewed":   strconv.FormatBool(t.Reviewed),
+		"task.id":                      t.ID,
+		"task.title":                   t.Title,
+		"task.status":                  t.Status,
+		"task.tags":                    strings.Join(t.Tags, ","),
+		"task.agent_mode":              t.AgentMode,
+		"task.project_id":              t.ProjectID,
+		"task.handoff_source_provider": t.HandoffSourceProvider,
+		"task.branch":                  t.Branch,
+		"task.reviewed":                strconv.FormatBool(t.Reviewed),
 	}
 	if t.PRNumber > 0 {
 		fields["task.pr_number"] = strconv.Itoa(t.PRNumber)

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -285,7 +285,7 @@ func (e *Engine) ResumeStalled() {
 		// just hit the limit again. The cooldown clears on its own and a later
 		// sweep resumes the step. Auth failures are NOT skipped here: those need
 		// a human to log in and take the human-required path instead.
-		if prov := resolveProvider(step.Config.Provider, t.Workflow, e.agents.DefaultProvider()); e.agents.ProviderRateLimited(prov) {
+		if prov := resolveProvider(step.Config.Provider, t.Workflow, e.agents.DefaultProvider(), *t); e.agents.ProviderRateLimited(prov) {
 			e.logger.Debug("workflow.resume-stalled.skip",
 				"task_id", t.ID, "reason", "provider_rate_limited", "provider", prov)
 			continue

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -113,7 +113,7 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 		model = "sonnet"
 	}
 
-	provider := resolveProvider(step.Config.Provider, wfExec, e.agents.DefaultProvider())
+	provider := resolveProvider(step.Config.Provider, wfExec, e.agents.DefaultProvider(), ctx.Task)
 	if provider != "" && !providerAvailable(provider) {
 		e.logger.Warn("workflow.cross-provider.fallback", "wanted", provider, "reason", "CLI not found")
 		provider = ""
@@ -166,30 +166,89 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 	return e.tasks.SetWorkflow(taskID, wfExec)
 }
 
-// flipProvider returns the opposite provider.
-func flipProvider(p string) string {
-	if p == "codex" {
-		return "claude"
-	}
-	return "codex"
-}
-
 // resolveProvider resolves the step-level provider string.
-// "cross" flips the last agent step's provider; "" defers to manager default.
-func resolveProvider(stepProv string, wfExec *Execution, defaultProv string) string {
+// "cross" flips the most relevant code-producing provider; "" defers to the
+// manager default.
+func resolveProvider(stepProv string, wfExec *Execution, _ string, t TaskInfo) string {
 	switch stepProv {
 	case "cross":
-		for i := range slices.Backward(wfExec.StepHistory) {
-			if p := wfExec.StepHistory[i].Provider; p != "" {
-				return flipProvider(p)
-			}
+		if p := lastWorkflowProvider(wfExec); p != "" {
+			return crossProvider(p)
 		}
-		return flipProvider(defaultProv)
+		if p := lastCodeAuthorProvider(t.AgentRuns); p != "" {
+			return crossProvider(p)
+		}
+		if p := normalizeExplicitWorkflowProvider(t.HandoffSourceProvider); p != "" {
+			return crossProvider(p)
+		}
+		return ""
 	case "":
 		return ""
 	default:
 		return stepProv
 	}
+}
+
+func lastWorkflowProvider(wfExec *Execution) string {
+	if wfExec == nil {
+		return ""
+	}
+	for i := range slices.Backward(wfExec.StepHistory) {
+		if p := normalizeExplicitWorkflowProvider(wfExec.StepHistory[i].Provider); p != "" {
+			return p
+		}
+	}
+	return ""
+}
+
+func lastCodeAuthorProvider(runs []AgentRunInfo) string {
+	for i := range slices.Backward(runs) {
+		if !isCodeAuthorRole(runs[i].Role) {
+			continue
+		}
+		if p := normalizeExplicitWorkflowProvider(runs[i].Provider); p != "" {
+			return p
+		}
+	}
+	return ""
+}
+
+func isCodeAuthorRole(role string) bool {
+	switch role {
+	case "", "implementation", "fix-review", "pr-fix":
+		return true
+	default:
+		return false
+	}
+}
+
+func crossProvider(provider string) string {
+	switch normalizeWorkflowProvider(provider) {
+	case "codex", "copilot":
+		return "claude"
+	default:
+		return "codex"
+	}
+}
+
+func normalizeWorkflowProvider(provider string) string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "", "claude":
+		return "claude"
+	case "codex":
+		return "codex"
+	case "copilot":
+		return "copilot"
+	default:
+		return ""
+	}
+}
+
+func normalizeExplicitWorkflowProvider(provider string) string {
+	if strings.TrimSpace(provider) == "" {
+		return ""
+	}
+	return normalizeWorkflowProvider(provider)
 }
 
 // providerAvailable reports whether the CLI for a provider is on PATH.

--- a/internal/workflow/engine_steps_parallel.go
+++ b/internal/workflow/engine_steps_parallel.go
@@ -125,7 +125,7 @@ func (e *Engine) spawnParallelChild(taskID string, parent, child *Step, wfExec *
 		model = "sonnet"
 	}
 
-	provider := resolveProvider(child.Config.Provider, wfExec, e.agents.DefaultProvider())
+	provider := resolveProvider(child.Config.Provider, wfExec, e.agents.DefaultProvider(), childCtx.Task)
 	if provider != "" && !providerAvailable(provider) {
 		e.logger.Warn("workflow.parallel.cross-provider.fallback", "child", child.ID, "wanted", provider, "reason", "CLI not found")
 		provider = ""

--- a/internal/workflow/handoff_test.go
+++ b/internal/workflow/handoff_test.go
@@ -87,6 +87,13 @@ func TestBuiltinHandoffTesting_SkipsToTesting(t *testing.T) {
 	if !hasCondition(testWf.Trigger.Conditions, "task.status", "equals", "testing") {
 		t.Errorf("testing-task must trigger on status=testing; got %+v", testWf.Trigger.Conditions)
 	}
+	runTest := testWf.StepByID("run_test")
+	if runTest == nil {
+		t.Fatal("testing-task run_test step not found")
+	}
+	if runTest.Config.Provider != "cross" {
+		t.Errorf("testing-task run_test provider = %q, want cross", runTest.Config.Provider)
+	}
 }
 
 // TestBuiltinHandoffReview_SkipsToReview locks the review-stage contract: a task
@@ -112,6 +119,39 @@ func TestBuiltinHandoffReview_SkipsToReview(t *testing.T) {
 	review := defByID(t, "simple-task-review")
 	if !hasCondition(review.Trigger.Conditions, "task.status", "equals", "ready-review") {
 		t.Errorf("simple-task-review must trigger on status=ready-review; got %+v", review.Trigger.Conditions)
+	}
+	for _, stepID := range []string{"code_review_simple", "code_review_staff"} {
+		step := review.StepByID(stepID)
+		if step == nil {
+			t.Fatalf("simple-task-review %s step not found", stepID)
+		}
+		if step.Config.Provider != "cross" {
+			t.Errorf("simple-task-review %s provider = %q, want cross", stepID, step.Config.Provider)
+		}
+	}
+}
+
+// TestBuiltinHandoffPR_ReviewsCrossProvider locks the existing-PR handoff
+// contract: pr-review is also a cross-check lane, using handoff provenance when
+// present and default-provider fallback when no provenance exists.
+func TestBuiltinHandoffPR_ReviewsCrossProvider(t *testing.T) {
+	t.Parallel()
+
+	pr := defByID(t, "pr-review")
+	if pr.Trigger.On != "task.created" {
+		t.Errorf("pr-review trigger.on = %q, want task.created", pr.Trigger.On)
+	}
+	if !hasCondition(pr.Trigger.Conditions, "task.tags", "contains", "review") {
+		t.Errorf("pr-review trigger must require tag review; got %+v", pr.Trigger.Conditions)
+	}
+	for _, stepID := range []string{"review_simple", "review_staff"} {
+		step := pr.StepByID(stepID)
+		if step == nil {
+			t.Fatalf("pr-review %s step not found", stepID)
+		}
+		if step.Config.Provider != "cross" {
+			t.Errorf("pr-review %s provider = %q, want cross", stepID, step.Config.Provider)
+		}
 	}
 }
 

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -137,7 +137,7 @@ type StepConfig struct {
 	Role          string   `yaml:"role,omitempty" json:"role"`
 	Mode          string   `yaml:"mode,omitempty" json:"mode"`
 	Model         string   `yaml:"model,omitempty" json:"model"`
-	Provider      string   `yaml:"provider,omitempty" json:"provider"` // "", "claude", "codex", "cross"
+	Provider      string   `yaml:"provider,omitempty" json:"provider"` // "", "claude", "codex", "copilot", "cross"
 	Prompt        string   `yaml:"prompt,omitempty" json:"prompt"`
 	AllowedTools  []string `yaml:"allowed_tools,omitempty" json:"allowedTools"`
 	NeedsWorktree bool     `yaml:"needs_worktree,omitempty" json:"needsWorktree"`

--- a/internal/workflow/provider_resolution_test.go
+++ b/internal/workflow/provider_resolution_test.go
@@ -1,0 +1,74 @@
+package workflow
+
+import "testing"
+
+func TestResolveProviderCrossUsesCurrentWorkflowHistory(t *testing.T) {
+	wf := &Execution{StepHistory: []StepRecord{
+		{StepID: "implement", Provider: "claude"},
+		{StepID: "set_ready_review"},
+	}}
+	tk := TaskInfo{
+		HandoffSourceProvider: "codex",
+		AgentRuns: []AgentRunInfo{
+			{Role: "implementation", Provider: "codex"},
+		},
+	}
+
+	got := resolveProvider("cross", wf, "claude", tk)
+	if got != "codex" {
+		t.Fatalf("provider = %q, want codex", got)
+	}
+}
+
+func TestResolveProviderCrossUsesCodeAuthorRunBeforeHandoffSource(t *testing.T) {
+	tk := TaskInfo{
+		HandoffSourceProvider: "codex",
+		AgentRuns: []AgentRunInfo{
+			{Role: "implementation", Provider: "claude"},
+		},
+	}
+
+	got := resolveProvider("cross", &Execution{}, "codex", tk)
+	if got != "codex" {
+		t.Fatalf("provider = %q, want codex", got)
+	}
+}
+
+func TestResolveProviderCrossIgnoresReviewRunsForTaskProvenance(t *testing.T) {
+	tk := TaskInfo{
+		AgentRuns: []AgentRunInfo{
+			{Role: "implementation", Provider: "claude"},
+			{Role: "review", Provider: "codex"},
+		},
+	}
+
+	got := resolveProvider("cross", &Execution{}, "claude", tk)
+	if got != "codex" {
+		t.Fatalf("provider = %q, want codex", got)
+	}
+}
+
+func TestResolveProviderCrossUsesHandoffSourceProvider(t *testing.T) {
+	tk := TaskInfo{HandoffSourceProvider: "codex"}
+
+	got := resolveProvider("cross", &Execution{}, "codex", tk)
+	if got != "claude" {
+		t.Fatalf("provider = %q, want claude", got)
+	}
+}
+
+func TestResolveProviderCrossCopilotFallsBackToClaude(t *testing.T) {
+	tk := TaskInfo{HandoffSourceProvider: "copilot"}
+
+	got := resolveProvider("cross", &Execution{}, "codex", tk)
+	if got != "claude" {
+		t.Fatalf("provider = %q, want claude", got)
+	}
+}
+
+func TestResolveProviderCrossWithoutProvenanceDefersToDefaultProvider(t *testing.T) {
+	got := resolveProvider("cross", &Execution{}, "claude", TaskInfo{})
+	if got != "" {
+		t.Fatalf("provider = %q, want empty default-provider sentinel", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add handoff source-provider metadata to tasks and sybra-cli handoff/update
- route provider: cross from workflow history, code-author runs, or handoff provenance
- require source provider for review/testing/PR handoff stages and update the bundled handoff skill docs

## Verification
- go test ./internal/task ./internal/workflow ./cmd/sybra-cli
- golangci-lint run ./cmd/sybra-cli ./internal/task ./internal/workflow
- go test ./internal/sybra -run '^$'
- commit/push hooks ran full Go tests and frontend svelte-check

## Review
- spawned an adversarial subagent review; fixed its findings around missing provenance, arbitrary fallback routing, and CLI repair support