### PR TITLE
feat(agent): in-run NOTES.md working memory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,39 @@ tmux new-session -d -s sybra-<id> -x 200 -y 50 "claude"
 - GUI polls `tmux capture-pane -t sybra-<id> -p` for preview
 - User attaches via terminal
 
+### Worktree Agent Context
+
+Every implementation worktree is seeded with two git-excluded files (added to
+`.git/info/exclude`, never committed):
+
+- **`.sybra-context.md`** (`internal/worktree/context.go`) — identity beacon
+  (task id, title, branch). Regenerated on every prepare.
+- **`NOTES.md`** (`internal/notes` + `internal/worktree/notes.go`) — agent
+  working-memory scratchpad: running plan, decisions, dead ends. Seeded
+  **create-if-absent only** — `ensureNotesFile` must never clobber an existing
+  file, since it is the agent's memory across runs/resume.
+
+`agent.Manager.Run` is the single chokepoint that inlines `NOTES.md` (a
+read/maintain instruction + the file's current contents, head+tail-capped) into
+the prompt via `notes.SeedPrompt`. This is the resume substitute for Codex (no
+`--resume`) and a context-rot-resistant scratchpad for all providers. The seed
+lands on `Run`'s local `cfg` copy only, so the persisted `AgentRun.Prompt` stays
+clean.
+
+**Gated on `RunConfig.SeedWorkingMemory`, set only for code-author roles
+(`Role.AuthorsCode`: implementation/fix-review/pr-fix).** Verifier roles
+(review, test-runner, eval) reuse the *same* per-task worktree, so seeding them
+would feed an independent reviewer/tester the implementer's notes — and since
+`NOTES.md` is git-excluded, that bias is invisible to the diff-based
+`detect_tampering` / `verify_checks` gates. Do not flip a verifier role to
+seed.
+
+`ensureNotesFile` fails closed: it git-excludes *before* creating the file and
+aborts if exclusion fails, so an unignored scratchpad of work-derived notes is
+never left for `SanitizeWorktree`'s `git add -A` to commit onto the PR. For
+work-typed tasks the file stays local; route through `internal/scrub` if ever
+summarized into a persisted artifact.
+
 ### Per-Machine Automations
 
 Sybra can run on multiple machines (e.g. laptop + remote server). Each instance has its own `~/.sybra/` and runs background automations independently. Two routing axes prevent duplicate work:

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/events"
 	"github.com/Automaat/sybra/internal/metrics"
+	"github.com/Automaat/sybra/internal/notes"
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/google/uuid"
 )
@@ -30,6 +31,19 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 		return nil, fmt.Errorf("agent.Run: Dir %q not accessible: %w", cfg.Dir, err)
 	} else if !info.IsDir() {
 		return nil, fmt.Errorf("agent.Run: Dir %q is not a directory", cfg.Dir)
+	}
+
+	// Inject the worktree's working-memory scratchpad (NOTES.md): a standing
+	// read/maintain instruction plus the file's current contents, giving Codex
+	// (no --resume) and any restarted agent cross-run continuity. Gated on
+	// SeedWorkingMemory, set only for code-author roles: verifier roles (review,
+	// test-runner, eval) reuse the SAME per-task worktree, so seeding them would
+	// feed an independent reviewer/tester the implementer's notes and quietly
+	// erode the reward-hacking defense. Done on the local cfg copy so the inlined
+	// notes never reach the persisted AgentRun.Prompt, which callers record from
+	// their own prompt variable. No-op when Dir has no NOTES.md.
+	if cfg.SeedWorkingMemory {
+		cfg.Prompt = notes.SeedPrompt(cfg.Prompt, cfg.Dir)
 	}
 
 	resolvedProvider, gateErr := m.gateProvider(cfg)

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -694,6 +694,12 @@ type RunConfig struct {
 	// for this run. Empty = model default. Codex-only. NOT the same as Effort
 	// (claude --effort) — different provider, CLI surface, and value set.
 	ReasoningEffort string
+	// SeedWorkingMemory, when true, inlines the worktree's NOTES.md scratchpad
+	// into the prompt (read/maintain instruction + current contents). Set only
+	// for code-author roles (see Role.AuthorsCode): verifier roles share the
+	// implementation worktree, so seeding them would feed an independent
+	// reviewer/tester the implementer's notes. No-op if the dir has no NOTES.md.
+	SeedWorkingMemory bool
 }
 
 // PlanStep represents a single item from a TodoWrite tool call.

--- a/internal/agent/role.go
+++ b/internal/agent/role.go
@@ -22,6 +22,22 @@ const (
 // (e.g. "triage:My Task Title").
 func (r Role) AgentName(title string) string { return string(r) + ":" + title }
 
+// AuthorsCode reports whether the role produces code commits and may therefore
+// be primed with the task's NOTES.md working memory. Only these roles inherit
+// the scratchpad: independent verifier roles (review, test-runner, eval) must
+// NOT, or the implementer's notes could bias an adversarial check — and because
+// NOTES.md is git-excluded, that bias is invisible to the diff-based
+// reward-hacking gates (detect_tampering / verify_checks). Empty name maps to
+// implementation, matching RoleFromName.
+func (r Role) AuthorsCode() bool {
+	switch r {
+	case RoleImplementation, RoleFixReview, RolePRFix, "":
+		return true
+	default:
+		return false
+	}
+}
+
 // IsSystem returns true for roles whose agents should not trigger
 // user-facing notifications (triage, eval, plan-critic, human-review).
 func (r Role) IsSystem() bool {

--- a/internal/agent/role_test.go
+++ b/internal/agent/role_test.go
@@ -60,6 +60,38 @@ func TestRole_IsSystem(t *testing.T) {
 	}
 }
 
+func TestRole_AuthorsCode(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		role Role
+		want bool
+	}{
+		// Code authors — primed with NOTES.md working memory.
+		{RoleImplementation, true},
+		{RoleFixReview, true},
+		{RolePRFix, true},
+		{Role(""), true}, // empty maps to implementation
+		// Independent verifiers — must NOT inherit the implementer's scratchpad,
+		// or the reward-hacking defense is silently weakened.
+		{RoleReview, false},
+		{RoleTestRunner, false},
+		{RoleEval, false},
+		{RolePlan, false},
+		{RolePlanCritic, false},
+		{RoleTriage, false},
+		{RoleHumanReview, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.role), func(t *testing.T) {
+			t.Parallel()
+			if got := tt.role.AuthorsCode(); got != tt.want {
+				t.Errorf("Role(%q).AuthorsCode() = %v, want %v", tt.role, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRoleFromName(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/notes/notes.go
+++ b/internal/notes/notes.go
@@ -1,0 +1,140 @@
+// Package notes defines the agent working-memory scratchpad (NOTES.md): a
+// git-excluded file Sybra seeds into implementation worktrees and inlines into
+// agent prompts. It gives providers without session resume (Codex) and any
+// restarted agent a durable record of plan, decisions, and dead ends that
+// survives runs and context compaction — the Ralph-loop external-memory
+// pattern.
+//
+// The file lifecycle (creation + git-exclusion) lives in internal/worktree;
+// this leaf holds only the shared constants and the pure read/seed helpers so
+// both internal/worktree and internal/agent can depend on it without a cycle
+// (worktree deliberately avoids importing agent, and agent must not import
+// worktree's project/task chain just to seed a prompt).
+package notes
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+)
+
+// FileName is the scratchpad's name at the worktree root.
+const FileName = "NOTES.md"
+
+// seedMaxBytes caps how much of NOTES.md is inlined into a prompt. Agents are
+// told to keep it concise, but a runaway file must not blow up the context
+// window. When over the cap, a head+tail window is kept (see clampNotes).
+const seedMaxBytes = 16 * 1024
+
+// seedHeadBytes is the slice of an over-cap NOTES.md kept from the top. The
+// seed template puts Plan/Decisions first, so keeping a head preserves the
+// durable structure while the remaining budget keeps the recent tail.
+const seedHeadBytes = seedMaxBytes / 3
+
+const elisionMarker = "\n\n…(middle of NOTES.md elided to fit context; keep it concise)…\n\n"
+
+// SeedTemplate is written when a worktree first gets a scratchpad. It is short
+// on purpose: it teaches the structure without crowding the agent's prompt when
+// inlined verbatim on the first run.
+const SeedTemplate = `# Working Notes
+
+Persistent scratchpad for this task. Survives across agent runs, restarts, and
+context compaction — for providers without session resume (e.g. Codex) this is
+the only memory of prior turns. Git-excluded; never committed. Keep it concise
+and current.
+
+## Plan
+
+## Decisions
+
+## Tried & failed
+`
+
+// Read returns the scratchpad contents for the worktree at dir and whether it
+// exists. A missing file (non-worktree agent, or an unseeded worktree) yields
+// ("", false) so callers can no-op.
+func Read(dir string) (string, bool) {
+	if strings.TrimSpace(dir) == "" {
+		return "", false
+	}
+	data, err := os.ReadFile(filepath.Join(dir, FileName))
+	if err != nil {
+		return "", false
+	}
+	return string(data), true
+}
+
+// SeedPrompt appends the working-memory section to an agent prompt: a standing
+// instruction to read and maintain NOTES.md, plus its current contents inlined
+// so a resume-less provider (Codex) or a restarted agent recovers prior
+// decisions without a tool call. Returns prompt unchanged when dir has no
+// NOTES.md. The section is appended (not prepended) so it lands near the end of
+// the prompt, where instruction-following is strongest.
+func SeedPrompt(prompt, dir string) string {
+	content, ok := Read(dir)
+	if !ok {
+		return prompt
+	}
+	body, truncated := clampNotes(strings.TrimSpace(content))
+
+	var sb strings.Builder
+	sb.WriteString(prompt)
+	sb.WriteString("\n\n---\n\n## Working memory: `")
+	sb.WriteString(FileName)
+	sb.WriteString("`\n\n")
+	sb.WriteString("A persistent scratchpad lives at `")
+	sb.WriteString(FileName)
+	sb.WriteString("` in your worktree root (git-excluded, never committed). It is your\n")
+	sb.WriteString("durable record of plan, decisions, and dead ends — it survives runs,\n")
+	sb.WriteString("restarts, and context compaction. **Read it before acting and keep it\n")
+	sb.WriteString("current as you work.** Current contents")
+	if truncated {
+		sb.WriteString(" (head+tail; middle elided to fit context)")
+	}
+	sb.WriteString(":\n\n")
+	if body == "" {
+		sb.WriteString("_(empty — start filling it in)_\n")
+	} else {
+		sb.WriteString(body)
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+// clampNotes bounds an over-cap NOTES.md to a head+tail window joined by an
+// elision marker, returning (clamped, wasTruncated). The head preserves the
+// template's Plan/Decisions sections (top of file); the tail preserves the most
+// recent activity. Both cuts land on UTF-8 rune boundaries so the inlined text
+// never begins or ends mid-rune (which would decode to U+FFFD).
+func clampNotes(body string) (string, bool) {
+	if len(body) <= seedMaxBytes {
+		return body, false
+	}
+	head := trimToRuneBoundaryEnd(body[:seedHeadBytes])
+	tail := trimToRuneBoundaryStart(body[len(body)-(seedMaxBytes-seedHeadBytes):])
+	return head + elisionMarker + tail, true
+}
+
+// trimToRuneBoundaryStart drops a leading partial rune so s begins on a rune
+// boundary. A valid UTF-8 string with no leading continuation byte is returned
+// unchanged.
+func trimToRuneBoundaryStart(s string) string {
+	for len(s) > 0 && !utf8.RuneStart(s[0]) {
+		s = s[1:]
+	}
+	return s
+}
+
+// trimToRuneBoundaryEnd drops a trailing partial rune so s ends on a rune
+// boundary. Only an invalid encoding (RuneError with size 1) is trimmed; a
+// legitimately-present U+FFFD (size 3) is kept.
+func trimToRuneBoundaryEnd(s string) string {
+	for len(s) > 0 {
+		if r, size := utf8.DecodeLastRuneInString(s); r != utf8.RuneError || size > 1 {
+			break
+		}
+		s = s[:len(s)-1]
+	}
+	return s
+}

--- a/internal/notes/notes.go
+++ b/internal/notes/notes.go
@@ -52,8 +52,10 @@ and current.
 `
 
 // Read returns the scratchpad contents for the worktree at dir and whether it
-// exists. A missing file (non-worktree agent, or an unseeded worktree) yields
-// ("", false) so callers can no-op.
+// was read. Any read failure — a missing file (non-worktree agent or unseeded
+// worktree), a permission error, or transient IO — yields ("", false) so
+// callers no-op rather than seed a partial/empty scratchpad. "false" therefore
+// means "unavailable", not strictly "file missing".
 func Read(dir string) (string, bool) {
 	if strings.TrimSpace(dir) == "" {
 		return "", false

--- a/internal/notes/notes_test.go
+++ b/internal/notes/notes_test.go
@@ -1,0 +1,117 @@
+package notes
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestSeedPrompt_NoFile_ReturnsUnchanged(t *testing.T) {
+	got := SeedPrompt("do the thing", t.TempDir())
+	if got != "do the thing" {
+		t.Errorf("SeedPrompt with no NOTES.md = %q, want unchanged prompt", got)
+	}
+}
+
+func TestSeedPrompt_EmptyDir_ReturnsUnchanged(t *testing.T) {
+	if got := SeedPrompt("p", ""); got != "p" {
+		t.Errorf("SeedPrompt with empty dir = %q, want %q", got, "p")
+	}
+}
+
+func TestSeedPrompt_InlinesContentAndInstruction(t *testing.T) {
+	dir := t.TempDir()
+	body := "## Plan\n- did the migration\n## Decisions\n- chose option B"
+	if err := os.WriteFile(filepath.Join(dir, FileName), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := SeedPrompt("# Task: ship it", dir)
+
+	if !strings.HasPrefix(got, "# Task: ship it") {
+		t.Errorf("seeded prompt must preserve the original prompt at the front:\n%s", got)
+	}
+	for _, want := range []string{FileName, "Read it before acting", "chose option B", "did the migration"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("seeded prompt missing %q. got:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "older lines truncated") {
+		t.Errorf("small NOTES.md should not be marked truncated. got:\n%s", got)
+	}
+}
+
+func TestSeedPrompt_TruncatesKeepingHeadAndTail(t *testing.T) {
+	dir := t.TempDir()
+	headMarker := "PLAN-AND-DECISIONS-MARKER"
+	tailMarker := "RECENT-DECISION-MARKER"
+	body := headMarker + strings.Repeat("\nfiller line\n", seedMaxBytes) + tailMarker
+	if err := os.WriteFile(filepath.Join(dir, FileName), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := SeedPrompt("p", dir)
+
+	if !strings.Contains(got, "head+tail") {
+		t.Errorf("oversized NOTES.md should be marked truncated. got tail:\n%s", got[max(0, len(got)-200):])
+	}
+	if !strings.Contains(got, headMarker) {
+		t.Error("truncation must keep the structured head (Plan/Decisions)")
+	}
+	if !strings.Contains(got, tailMarker) {
+		t.Error("truncation must keep the most recent tail")
+	}
+	if !strings.Contains(got, "elided") {
+		t.Error("truncated seed should carry an elision marker between head and tail")
+	}
+	// The seed must stay bounded near the cap (head + tail + marker + framing).
+	if len(got) > seedMaxBytes+2048 {
+		t.Errorf("seeded prompt = %d bytes, expected bounded near seedMaxBytes=%d", len(got), seedMaxBytes)
+	}
+}
+
+func TestSeedPrompt_TruncationIsRuneSafe(t *testing.T) {
+	dir := t.TempDir()
+	// A body of multibyte runes guarantees both the head and tail cut points
+	// land mid-rune unless trimmed to a boundary.
+	body := strings.Repeat("€", seedMaxBytes) // 3 bytes each, far over the cap
+	if err := os.WriteFile(filepath.Join(dir, FileName), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := SeedPrompt("p", dir)
+
+	if !utf8.ValidString(got) {
+		t.Error("seeded prompt must be valid UTF-8 after truncation (no mid-rune cut)")
+	}
+	if strings.Contains(got, "�") {
+		t.Error("truncation must not introduce replacement runes")
+	}
+}
+
+func TestSeedPrompt_EmptyFile_PromptsToFill(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, FileName), []byte("   \n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := SeedPrompt("p", dir)
+	if !strings.Contains(got, "start filling it in") {
+		t.Errorf("empty NOTES.md should invite the agent to fill it. got:\n%s", got)
+	}
+}
+
+func TestRead(t *testing.T) {
+	dir := t.TempDir()
+	if _, ok := Read(dir); ok {
+		t.Error("Read should report absent file as not-ok")
+	}
+	if err := os.WriteFile(filepath.Join(dir, FileName), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	content, ok := Read(dir)
+	if !ok || content != "hi" {
+		t.Errorf("Read = (%q, %v), want (%q, true)", content, ok, "hi")
+	}
+}

--- a/internal/sybra/app_agents.go
+++ b/internal/sybra/app_agents.go
@@ -259,6 +259,8 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, includeTaskD
 		MaxTurns:           t.MaxTurns,
 		ForkSubagent:       t.ForkSubagent,
 		ReasoningEffort:    t.ReasoningEffort,
+		// Always an implementation run — prime it with the NOTES.md scratchpad.
+		SeedWorkingMemory: true,
 	})
 	if err != nil {
 		// Gate block leaves no running agent. Flip the task back to todo so
@@ -446,6 +448,9 @@ func (o *AgentOrchestrator) StartPRFixAgent(taskID string) error {
 		Dir:                dir,
 		Model:              "sonnet",
 		RequirePermissions: requirePerm,
+		// pr-fix is a code-author role — keep the NOTES.md contract airtight so
+		// an adopted (handoff) worktree's scratchpad carries through.
+		SeedWorkingMemory: agent.RolePRFix.AuthorsCode(),
 	})
 	if err != nil {
 		return err

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -352,6 +352,10 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		MaxTurns:           t.MaxTurns,
 		RequirePermissions: resolvePermission(t, a.agentOrch.cfg),
 		ReasoningEffort:    t.ReasoningEffort,
+		// Code-author roles (implementation/fix-review/pr-fix) are primed with
+		// NOTES.md; verifier roles (review/test-runner/eval) share the same
+		// worktree but must stay independent of the implementer's scratchpad.
+		SeedWorkingMemory: r.AuthorsCode(),
 	}
 
 	// Caller-provided dir takes precedence (e.g. pr-fix flow pre-stages a

--- a/internal/worktree/context.go
+++ b/internal/worktree/context.go
@@ -1,6 +1,7 @@
 package worktree
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -76,7 +77,14 @@ func addToInfoExclude(wtPath, entry string) error {
 	if err := os.MkdirAll(filepath.Dir(excludePath), 0o755); err != nil {
 		return fmt.Errorf("mkdir info dir: %w", err)
 	}
-	existing, _ := os.ReadFile(excludePath)
+	// A not-exist read is fine — the append below creates the file. Any other
+	// read error (e.g. unreadable exclude) must surface: silently treating it as
+	// empty would skip the dedup check and, worse, let a fail-closed caller
+	// (ensureNotesFile) believe exclusion succeeded when it could not be verified.
+	existing, rerr := os.ReadFile(excludePath)
+	if rerr != nil && !errors.Is(rerr, os.ErrNotExist) {
+		return fmt.Errorf("read info/exclude: %w", rerr)
+	}
 	line := "/" + entry
 	for raw := range strings.SplitSeq(string(existing), "\n") {
 		if strings.TrimSpace(raw) == line {

--- a/internal/worktree/context.go
+++ b/internal/worktree/context.go
@@ -28,7 +28,9 @@ func writeContextFile(t task.Task, wtPath, branch string) error {
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", contextFileName, err)
 	}
-	addToInfoExclude(wtPath, contextFileName)
+	// Best-effort for the beacon: it carries only task identity (no work content),
+	// so a failed exclude is a cosmetic git-status nuisance, not a leak.
+	_ = addToInfoExclude(wtPath, contextFileName)
 	return nil
 }
 
@@ -54,38 +56,44 @@ func renderContextFile(t task.Task, wtPath, branch string) string {
 }
 
 // addToInfoExclude appends entry to the worktree's per-worktree info/exclude
-// so `git status` and `git add -A` ignore it. Best-effort: a missing or
-// unwritable exclude file is logged elsewhere but not fatal — the beacon is
-// still usable, the agent just risks staging it.
-func addToInfoExclude(wtPath, entry string) {
+// so `git status` and `git add -A` ignore it. Returns an error when exclusion
+// could not be applied; callers for whom a committed file is merely cosmetic
+// (the identity beacon) may ignore it, while callers seeding agent-authored
+// content (NOTES.md) must fail closed — an unexcluded file would be swept into
+// SanitizeWorktree's `git add -A` auto-commit and pushed to the PR. The
+// "already present" case returns nil.
+func addToInfoExclude(wtPath, entry string) error {
 	cmd := exec.Command("git", "rev-parse", "--git-path", "info/exclude")
 	cmd.Dir = wtPath
 	out, err := cmd.Output()
 	if err != nil {
-		return
+		return fmt.Errorf("resolve info/exclude: %w", err)
 	}
 	excludePath := strings.TrimSpace(string(out))
 	if !filepath.IsAbs(excludePath) {
 		excludePath = filepath.Join(wtPath, excludePath)
 	}
 	if err := os.MkdirAll(filepath.Dir(excludePath), 0o755); err != nil {
-		return
+		return fmt.Errorf("mkdir info dir: %w", err)
 	}
 	existing, _ := os.ReadFile(excludePath)
 	line := "/" + entry
 	for raw := range strings.SplitSeq(string(existing), "\n") {
 		if strings.TrimSpace(raw) == line {
-			return
+			return nil
 		}
 	}
 	f, err := os.OpenFile(excludePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
-		return
+		return fmt.Errorf("open info/exclude: %w", err)
 	}
 	defer func() { _ = f.Close() }()
 	prefix := ""
 	if len(existing) > 0 && !strings.HasSuffix(string(existing), "\n") {
 		prefix = "\n"
 	}
-	_, _ = f.WriteString(prefix + line + "\n")
+	if _, err := f.WriteString(prefix + line + "\n"); err != nil {
+		return fmt.Errorf("append info/exclude: %w", err)
+	}
+	return nil
 }

--- a/internal/worktree/notes.go
+++ b/internal/worktree/notes.go
@@ -1,0 +1,42 @@
+package worktree
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Automaat/sybra/internal/notes"
+)
+
+// ensureNotesFile seeds the agent working-memory scratchpad (notes.FileName) at
+// the worktree root and git-excludes it, mirroring the identity beacon. Unlike
+// the beacon it fails closed: exclusion is applied BEFORE the file is created,
+// and a failed exclude aborts the seed. The scratchpad holds agent-authored
+// (for work tasks, work-derived) content, so an unexcluded NOTES.md would be
+// swept into SanitizeWorktree's `git add -A` auto-commit and pushed to the PR —
+// a confidentiality leak. No scratchpad is safer than a committable one.
+//
+// The file is created only when absent: it is agent-maintained memory that must
+// persist across worktree reuse/resume, so a re-prepare must never clobber
+// accumulated notes. Exclusion is idempotent (dedup'd on the line) and shared
+// across a clone's linked worktrees, so re-asserting it every call is cheap and
+// safe.
+func ensureNotesFile(wtPath string) error {
+	if err := addToInfoExclude(wtPath, notes.FileName); err != nil {
+		return fmt.Errorf("exclude %s (refusing to seed an unignored scratchpad): %w", notes.FileName, err)
+	}
+	path := filepath.Join(wtPath, notes.FileName)
+	_, statErr := os.Stat(path)
+	switch {
+	case statErr == nil:
+		return nil // already present and now excluded — preserve contents
+	case errors.Is(statErr, os.ErrNotExist):
+		if err := os.WriteFile(path, []byte(notes.SeedTemplate), 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", notes.FileName, err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("stat %s: %w", notes.FileName, statErr)
+	}
+}

--- a/internal/worktree/notes.go
+++ b/internal/worktree/notes.go
@@ -32,7 +32,9 @@ func ensureNotesFile(wtPath string) error {
 	case statErr == nil:
 		return nil // already present and now excluded — preserve contents
 	case errors.Is(statErr, os.ErrNotExist):
-		if err := os.WriteFile(path, []byte(notes.SeedTemplate), 0o644); err != nil {
+		// 0600, not 0644: the scratchpad holds agent-authored (for work tasks,
+		// work-derived) content, so keep it private to the user on multi-user hosts.
+		if err := os.WriteFile(path, []byte(notes.SeedTemplate), 0o600); err != nil {
 			return fmt.Errorf("write %s: %w", notes.FileName, err)
 		}
 		return nil

--- a/internal/worktree/notes_test.go
+++ b/internal/worktree/notes_test.go
@@ -1,0 +1,86 @@
+package worktree
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/notes"
+)
+
+func TestEnsureNotesFile_SeedsAndExcludes(t *testing.T) {
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	wt := t.TempDir()
+	mustRunInDir(t, wt, "git", "init", "-b", "main")
+
+	if err := ensureNotesFile(wt); err != nil {
+		t.Fatalf("ensureNotesFile: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(wt, notes.FileName))
+	if err != nil {
+		t.Fatalf("read scratchpad: %v", err)
+	}
+	if string(content) != notes.SeedTemplate {
+		t.Errorf("scratchpad = %q, want seed template", content)
+	}
+
+	out, err := exec.Command("git", "-C", wt, "status", "--porcelain").Output()
+	if err != nil {
+		t.Fatalf("git status: %v", err)
+	}
+	if strings.Contains(string(out), notes.FileName) {
+		t.Errorf("expected %s to be git-excluded, got status:\n%s", notes.FileName, out)
+	}
+}
+
+func TestEnsureNotesFile_PreservesExistingContent(t *testing.T) {
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	wt := t.TempDir()
+	mustRunInDir(t, wt, "git", "init", "-b", "main")
+
+	// Simulate an agent that has already accrued working memory across a run.
+	accrued := "# Working Notes\n\n## Decisions\n- picked the BK-tree approach\n"
+	path := filepath.Join(wt, notes.FileName)
+	if err := os.WriteFile(path, []byte(accrued), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A worktree re-prepare (resume/reuse) must not clobber it.
+	for range 3 {
+		if err := ensureNotesFile(wt); err != nil {
+			t.Fatalf("ensureNotesFile: %v", err)
+		}
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != accrued {
+		t.Errorf("ensureNotesFile clobbered agent memory: got %q, want %q", got, accrued)
+	}
+
+	// Exclude must still be present and not duplicated across the re-runs.
+	excludeBytes, err := exec.Command("git", "-C", wt, "rev-parse", "--git-path", "info/exclude").Output()
+	if err != nil {
+		t.Fatalf("rev-parse: %v", err)
+	}
+	excludePath := strings.TrimSpace(string(excludeBytes))
+	if !filepath.IsAbs(excludePath) {
+		excludePath = filepath.Join(wt, excludePath)
+	}
+	data, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("read exclude: %v", err)
+	}
+	if n := strings.Count(string(data), "/"+notes.FileName); n != 1 {
+		t.Errorf("expected exactly 1 exclude entry, got %d. exclude:\n%s", n, data)
+	}
+}

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -124,10 +124,21 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 	}
 
 	m.ensureBranch(t, wtBranch)
-	if err := writeContextFile(t, wtPath, wtBranch); err != nil {
+	m.seedWorktree(t, wtPath, wtBranch)
+	return wtPath, nil
+}
+
+// seedWorktree drops the per-worktree agent context into an implementation
+// worktree: the identity beacon (writeContextFile) and the working-memory
+// scratchpad (ensureNotesFile). Both are git-excluded and best-effort —
+// failures are logged, not fatal, since neither blocks the agent from running.
+func (m *Manager) seedWorktree(t task.Task, wtPath, branch string) {
+	if err := writeContextFile(t, wtPath, branch); err != nil {
 		m.logger.Warn("worktree.context-file", "task_id", t.ID, "err", err)
 	}
-	return wtPath, nil
+	if err := ensureNotesFile(wtPath); err != nil {
+		m.logger.Warn("worktree.notes-file", "task_id", t.ID, "err", err)
+	}
 }
 
 // adoptWorktree wires Sybra to run a task inside a pre-existing, externally
@@ -185,9 +196,7 @@ func (m *Manager) adoptWorktree(t task.Task, onPhase func(string)) (string, erro
 
 	m.ensureBranch(t, branch)
 	m.installChecks(wtPath, proj)
-	if err := writeContextFile(t, wtPath, branch); err != nil {
-		m.logger.Warn("worktree.context-file", "task_id", t.ID, "err", err)
-	}
+	m.seedWorktree(t, wtPath, branch)
 	m.logger.Info("worktree.adopted", "task_id", t.ID, "path", wtPath, "branch", branch)
 	return wtPath, nil
 }
@@ -197,9 +206,7 @@ func (m *Manager) adoptWorktree(t task.Task, onPhase func(string)) (string, erro
 func (m *Manager) finalizeWorktree(t task.Task, wtPath, wtBranch string, proj project.Project) (string, error) {
 	m.installChecks(wtPath, proj)
 	m.ensureBranch(t, wtBranch)
-	if err := writeContextFile(t, wtPath, wtBranch); err != nil {
-		m.logger.Warn("worktree.context-file", "task_id", t.ID, "err", err)
-	}
+	m.seedWorktree(t, wtPath, wtBranch)
 	return wtPath, nil
 }
 


### PR DESCRIPTION
## Motivation

Closes #1074.

Codex has no `--resume`, so a Codex agent loses all state across turns and
restarts and re-derives prior decisions from scratch. Long runs of any provider
also suffer context rot through compaction. The proven mitigation is an
external memory file the agent maintains and re-reads (the Ralph-loop pattern).
Sybra's existing `.sybra-context.md` beacon is identity-only — not a working
scratchpad.

> Changelog: feat(agent): in-run NOTES.md working memory

## Implementation information

- **`internal/notes`** (new leaf package, no deps): `FileName`, a short
  `SeedTemplate`, `Read`, and `SeedPrompt(prompt, dir)`. `SeedPrompt` appends a
  "read it first / keep it current" instruction plus the file's current
  contents to a prompt. Oversized files are clamped to a **head+tail** window
  (keeps top-of-file Plan/Decisions and the recent tail) on **UTF-8 rune
  boundaries**, so the inlined text never starts/ends mid-rune.
- **`internal/worktree/notes.go`**: `ensureNotesFile` seeds the template
  **create-if-absent** (never clobbers accrued memory on worktree reuse/resume)
  and **fails closed** — it git-excludes *before* creating the file and aborts
  if exclusion fails, so a scratchpad of work-derived notes can never be left in
  a state where `SanitizeWorktree`'s `git add -A` would commit it to the PR.
- **`internal/worktree/prepare.go`**: folded beacon + notes into one
  `seedWorktree` helper, wired into the implementation worktree entry points
  (new / adopt / finalize). Chat/review worktrees are deliberately not seeded.
- **`internal/agent` (`Manager.Run`)**: the single dispatch chokepoint inlines
  `NOTES.md` via `notes.SeedPrompt`, on `Run`'s local `cfg` copy so the
  persisted `AgentRun.Prompt` stays clean. **Gated on `RunConfig.SeedWorkingMemory`,
  set only for code-author roles** (`Role.AuthorsCode`: implementation /
  fix-review / pr-fix). Verifier roles (review, test-runner, eval) reuse the
  same per-task worktree, so seeding them would feed an independent
  reviewer/tester the implementer's notes — and since `NOTES.md` is
  git-excluded, that bias would be invisible to the diff-based `detect_tampering`
  / `verify_checks` reward-hacking gates.
- **Confidentiality**: for work-typed tasks the file stays local in the
  worktree and is never filed; documented the `internal/scrub` route if ever
  summarized into a persisted artifact.

## Supporting documentation

- New unit tests: `notes` (no-op / inline / head+tail truncation / rune-safety /
  empty-invite / Read), `worktree` (seeds+excludes, **preserves existing content
  across re-prepares**, single exclude entry), and `agent.Role.AuthorsCode`
  (verifiers never seed).
- The change passed an adversarial sub-agent review: the headline
  verifier-independence flaw, a commit-on-exclude-failure confidentiality leak,
  a UTF-8 rune-cut bug, and tail-only truncation dropping Plan/Decisions were
  all found and fixed, then re-verified against the diff.
- `CLAUDE.md` documents the convention and the load-bearing invariants
  (never-clobber, role-gating, fail-closed exclusion).
- All Go tests / golangci-lint / svelte-check pass. The desktop `go build .`
  (frontend embed) is CI/darwin-owned and out of scope for this backend change.
