### PR TITLE
feat(task): add task dependency DAG primitive

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -199,6 +199,22 @@ export class Task {
      * concludes the human-required transition was caused by a Sybra bug.
      */
     "blockedByIssue"?: string;
+
+    /**
+     * UmbrellaIssue links this task to the ☂️ umbrella issue it was expanded
+     * from. Set on child tasks; empty for standalone tasks. The orchestrator's
+     * dependency gate reads it with DependsOn to decide when a child may leave
+     * `blocked`.
+     */
+    "umbrellaIssue"?: string;
+
+    /**
+     * DependsOn lists the issue refs (full URL or owner/repo#n) this task waits
+     * on. While the task is `blocked`, the gate holds it until every referenced
+     * task has reached `done`; an empty list releases immediately. Used only by
+     * umbrella child tasks.
+     */
+    "dependsOn"?: string[];
     "reviewed": boolean;
 
     /**
@@ -375,9 +391,10 @@ export class Task {
     static createFrom($$source: any = {}): Task {
         const $$createField6_0 = $$createType0;
         const $$createField7_0 = $$createType0;
-        const $$createField31_0 = $$createType2;
-        const $$createField32_0 = $$createType4;
-        const $$createField39_0 = $$createType5;
+        const $$createField17_0 = $$createType0;
+        const $$createField33_0 = $$createType2;
+        const $$createField34_0 = $$createType4;
+        const $$createField41_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -385,14 +402,17 @@ export class Task {
         if ("tags" in $$parsedSource) {
             $$parsedSource["tags"] = $$createField7_0($$parsedSource["tags"]);
         }
+        if ("dependsOn" in $$parsedSource) {
+            $$parsedSource["dependsOn"] = $$createField17_0($$parsedSource["dependsOn"]);
+        }
         if ("agentRuns" in $$parsedSource) {
-            $$parsedSource["agentRuns"] = $$createField31_0($$parsedSource["agentRuns"]);
+            $$parsedSource["agentRuns"] = $$createField33_0($$parsedSource["agentRuns"]);
         }
         if ("workflow" in $$parsedSource) {
-            $$parsedSource["workflow"] = $$createField32_0($$parsedSource["workflow"]);
+            $$parsedSource["workflow"] = $$createField34_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField39_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField41_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }
@@ -413,6 +433,13 @@ export enum TaskType {
      * Hidden from the task list UI and skipped by restart-stale/watchdog.
      */
     TaskTypeChat = "chat",
+
+    /**
+     * TaskTypeUmbrella is the tracker task for an expanded ☂️ umbrella issue.
+     * It runs no agent: it rolls up the status of its child tasks and is the
+     * task the dependency gate flips to human-required on a dependency cycle.
+     */
+    TaskTypeUmbrella = "umbrella",
 };
 
 // Private type creation functions

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -209,10 +209,11 @@ export class Task {
     "umbrellaIssue"?: string;
 
     /**
-     * DependsOn lists the issue refs (full URL or owner/repo#n) this task waits
-     * on. While the task is `blocked`, the gate holds it until every referenced
-     * task has reached `done`; an empty list releases immediately. Used only by
-     * umbrella child tasks.
+     * DependsOn lists the issue refs (full github.com issue/PR URL or
+     * owner/repo#n shorthand) this task waits on — resolved by issue ref only,
+     * not task IDs. While the task is `blocked`, the gate holds it until every
+     * referenced task has reached `done`; an empty list releases immediately.
+     * Used only by umbrella child tasks.
      */
     "dependsOn"?: string[];
     "reviewed": boolean;

--- a/internal/sybra/app_agents.go
+++ b/internal/sybra/app_agents.go
@@ -212,6 +212,12 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, includeTaskD
 	if err != nil {
 		return nil, err
 	}
+	// An umbrella tracker task runs no agent — it only rolls up its children.
+	// Refuse here, the single dispatch choke point, so no path (workflow,
+	// recovery, manual start) can launch an agent against it.
+	if t.TaskType == task.TaskTypeUmbrella {
+		return nil, fmt.Errorf("task %s is an umbrella tracker; it runs no agent", taskID)
+	}
 	researchDir := ""
 	if o.cfg != nil {
 		researchDir = o.cfg.Agent.ResearchMachineDir

--- a/internal/sybra/app_external_task_test.go
+++ b/internal/sybra/app_external_task_test.go
@@ -146,6 +146,11 @@ func TestSkipTaskCreatedWorkflow_PRLinkedHandoffExceptions(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "umbrella tracker never starts a workflow",
+			task: task.Task{TaskType: task.TaskTypeUmbrella},
+			want: true,
+		},
+		{
 			name: "run role still skips task.created",
 			task: task.Task{RunRole: "pr-fix", PRNumber: 42, Tags: []string{"handoff"}},
 			want: true,

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -22,6 +22,9 @@ func (a *App) orchestratorLoop(ctx context.Context) {
 			if a.workflowEngine != nil {
 				a.workflowEngine.ResumeStalled()
 			}
+			// Release umbrella child tasks whose dependencies have merged, so
+			// the normal dispatch picks them up like any todo task.
+			a.releaseUnblockedChildren()
 			// Recover in-progress tasks whose agent died — runs continuously,
 			// not just at startup, to catch agents that finished without
 			// advancing the workflow.

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -59,7 +59,10 @@ func (a *App) releaseUnblockedChildren() {
 	}
 
 	for _, id := range g.ReadyToRelease() {
-		t := byID[id]
+		t, ok := byID[id]
+		if !ok || t == nil {
+			continue
+		}
 		// Strip the gating marker on release so a later re-block (e.g. a
 		// Sybra-bug containment) cannot retrigger a release of the same task.
 		newTags := slices.DeleteFunc(slices.Clone(t.Tags), func(s string) bool {

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -1,14 +1,25 @@
 package sybra
 
 import (
+	"slices"
+
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/umbrella"
 )
 
-// releaseUnblockedChildren scans umbrella child tasks held in `blocked` and
-// releases those whose dependencies have all reached `done`, in dependency
-// order. Children caught in a dependency cycle are never released; their
-// umbrella tracker is flipped to human-required instead. Runs every
+// umbrellaGatedTag marks a child task that is held in `blocked` specifically by
+// the umbrella dependency gate (set by the expander when the child is
+// materialized). It distinguishes umbrella gating from the unrelated `blocked`
+// the human-review automation uses for a contained Sybra bug, so the gate only
+// releases tasks it is actually responsible for. The gate strips the tag on
+// release, so a child that later re-enters `blocked` for a different reason is
+// never re-released.
+const umbrellaGatedTag = "umbrella-gated"
+
+// releaseUnblockedChildren scans umbrella child tasks held in `blocked` by the
+// gate and releases those whose dependencies have all reached `done`, in
+// dependency order. Children caught in a dependency cycle are never released;
+// their umbrella tracker is flipped to human-required instead. Runs every
 // orchestrator tick and is a no-op when no umbrella tasks exist.
 func (a *App) releaseUnblockedChildren() {
 	tasks, err := a.tasks.List()
@@ -16,10 +27,12 @@ func (a *App) releaseUnblockedChildren() {
 		return
 	}
 
+	byID := make(map[string]*task.Task, len(tasks))
 	nodes := make([]umbrella.Node, len(tasks))
 	hasUmbrella := false
 	for i := range tasks {
 		t := &tasks[i]
+		byID[t.ID] = t
 		if t.UmbrellaIssue != "" || t.TaskType == task.TaskTypeUmbrella {
 			hasUmbrella = true
 		}
@@ -29,7 +42,10 @@ func (a *App) releaseUnblockedChildren() {
 			Umbrella:  t.UmbrellaIssue,
 			DependsOn: t.DependsOn,
 			Done:      t.Status == task.StatusDone,
-			Awaiting:  t.UmbrellaIssue != "" && t.Status == task.StatusBlocked,
+			// Only a task the gate itself blocked is eligible for release —
+			// never one parked in `blocked` for a contained Sybra bug.
+			Awaiting: t.UmbrellaIssue != "" && t.Status == task.StatusBlocked &&
+				slices.Contains(t.Tags, umbrellaGatedTag),
 		}
 	}
 	if !hasUmbrella {
@@ -43,8 +59,15 @@ func (a *App) releaseUnblockedChildren() {
 	}
 
 	for _, id := range g.ReadyToRelease() {
+		t := byID[id]
+		// Strip the gating marker on release so a later re-block (e.g. a
+		// Sybra-bug containment) cannot retrigger a release of the same task.
+		newTags := slices.DeleteFunc(slices.Clone(t.Tags), func(s string) bool {
+			return s == umbrellaGatedTag
+		})
 		if _, err := a.tasks.Update(id, task.Update{
 			Status:       task.Ptr(task.StatusTodo),
+			Tags:         &newTags,
 			StatusReason: task.Ptr("umbrella dependencies satisfied"),
 		}); err != nil {
 			a.logger.Error("umbrella.release.failed", "task_id", id, "err", err)

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -1,0 +1,79 @@
+package sybra
+
+import (
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/umbrella"
+)
+
+// releaseUnblockedChildren scans umbrella child tasks held in `blocked` and
+// releases those whose dependencies have all reached `done`, in dependency
+// order. Children caught in a dependency cycle are never released; their
+// umbrella tracker is flipped to human-required instead. Runs every
+// orchestrator tick and is a no-op when no umbrella tasks exist.
+func (a *App) releaseUnblockedChildren() {
+	tasks, err := a.tasks.List()
+	if err != nil {
+		return
+	}
+
+	nodes := make([]umbrella.Node, len(tasks))
+	hasUmbrella := false
+	for i := range tasks {
+		t := &tasks[i]
+		if t.UmbrellaIssue != "" || t.TaskType == task.TaskTypeUmbrella {
+			hasUmbrella = true
+		}
+		nodes[i] = umbrella.Node{
+			ID:        t.ID,
+			Issue:     t.Issue,
+			Umbrella:  t.UmbrellaIssue,
+			DependsOn: t.DependsOn,
+			Done:      t.Status == task.StatusDone,
+			Awaiting:  t.UmbrellaIssue != "" && t.Status == task.StatusBlocked,
+		}
+	}
+	if !hasUmbrella {
+		return
+	}
+
+	g := umbrella.Build(nodes)
+
+	for _, umb := range g.CyclicUmbrellas() {
+		a.flagCyclicUmbrella(tasks, umb)
+	}
+
+	for _, id := range g.ReadyToRelease() {
+		if _, err := a.tasks.Update(id, task.Update{
+			Status:       task.Ptr(task.StatusTodo),
+			StatusReason: task.Ptr("umbrella dependencies satisfied"),
+		}); err != nil {
+			a.logger.Error("umbrella.release.failed", "task_id", id, "err", err)
+			continue
+		}
+		a.logger.Info("umbrella.child.released", "task_id", id)
+	}
+}
+
+// flagCyclicUmbrella flips the umbrella tracker for umb to human-required when
+// its children form a dependency cycle. Idempotent: a tracker already in
+// human-required is left untouched so the gate does not churn the file every
+// tick.
+func (a *App) flagCyclicUmbrella(tasks []task.Task, umb string) {
+	key := umbrella.NormalizeIssueRef(umb)
+	for i := range tasks {
+		t := &tasks[i]
+		if t.TaskType != task.TaskTypeUmbrella || umbrella.NormalizeIssueRef(t.Issue) != key {
+			continue
+		}
+		if t.Status == task.StatusHumanRequired {
+			return
+		}
+		if _, err := a.tasks.Update(t.ID, task.Update{
+			Status:       task.Ptr(task.StatusHumanRequired),
+			StatusReason: task.Ptr("umbrella dependency cycle detected"),
+		}); err != nil {
+			a.logger.Error("umbrella.cycle.flag.failed", "task_id", t.ID, "err", err)
+		}
+		return
+	}
+}

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -1,0 +1,149 @@
+package sybra
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func newUmbrellaGateApp(t *testing.T) (*App, *task.Manager) {
+	t.Helper()
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatalf("task.NewStore: %v", err)
+	}
+	tasks := task.NewManager(store, task.EmitterFunc(func(string, any) {}))
+	app := &App{tasks: tasks, logger: slog.New(slog.DiscardHandler)}
+	return app, tasks
+}
+
+// mkChild creates an umbrella child task in the given status.
+func mkChild(t *testing.T, m *task.Manager, title, issue, umb string, deps []string, status task.Status) task.Task {
+	t.Helper()
+	tk, err := m.CreateFull(title, "", task.AgentModeHeadless, task.Update{
+		Issue:         task.Ptr(issue),
+		UmbrellaIssue: task.Ptr(umb),
+		DependsOn:     task.Ptr(deps),
+		Status:        task.Ptr(status),
+	})
+	if err != nil {
+		t.Fatalf("CreateFull(%s): %v", title, err)
+	}
+	return tk
+}
+
+func mustStatus(t *testing.T, m *task.Manager, id string) task.Status {
+	t.Helper()
+	tk, err := m.Get(id)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", id, err)
+	}
+	return tk.Status
+}
+
+func TestReleaseUnblockedChildren_ReleasesRootWithNoDeps(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+
+	root := mkChild(t, m, "root", "Automaat/sybra#1", umb, nil, task.StatusBlocked)
+
+	app.releaseUnblockedChildren()
+
+	if got := mustStatus(t, m, root.ID); got != task.StatusTodo {
+		t.Fatalf("root status = %q, want %q", got, task.StatusTodo)
+	}
+}
+
+func TestReleaseUnblockedChildren_HoldsThenReleasesChain(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+
+	// dep is still in progress; child depends on it.
+	dep := mkChild(t, m, "dep", "Automaat/sybra#1", umb, nil, task.StatusInProgress)
+	child := mkChild(t, m, "child", "Automaat/sybra#2", umb, []string{"Automaat/sybra#1"}, task.StatusBlocked)
+
+	app.releaseUnblockedChildren()
+	if got := mustStatus(t, m, child.ID); got != task.StatusBlocked {
+		t.Fatalf("child released early: status = %q, want %q", got, task.StatusBlocked)
+	}
+
+	// Finish the dependency, then the child must release.
+	if _, err := m.Update(dep.ID, task.Update{Status: task.Ptr(task.StatusDone)}); err != nil {
+		t.Fatalf("finish dep: %v", err)
+	}
+	app.releaseUnblockedChildren()
+	if got := mustStatus(t, m, child.ID); got != task.StatusTodo {
+		t.Fatalf("child status = %q, want %q after dep done", got, task.StatusTodo)
+	}
+}
+
+func TestReleaseUnblockedChildren_CrossFormDependencyResolves(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+
+	// Dependency recorded as a full URL; the child references it in shorthand.
+	mkChild(t, m, "dep", "https://github.com/Automaat/sybra/issues/1", umb, nil, task.StatusDone)
+	child := mkChild(t, m, "child", "Automaat/sybra#2", umb, []string{"Automaat/sybra#1"}, task.StatusBlocked)
+
+	app.releaseUnblockedChildren()
+	if got := mustStatus(t, m, child.ID); got != task.StatusTodo {
+		t.Fatalf("child status = %q, want %q (cross-form dep should resolve)", got, task.StatusTodo)
+	}
+}
+
+func TestReleaseUnblockedChildren_CycleFlagsTracker(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+
+	// Tracker task for the umbrella.
+	tracker, err := m.CreateFull("umbrella", "", task.AgentModeHeadless, task.Update{
+		Issue:    task.Ptr(umb),
+		TaskType: task.Ptr(task.TaskTypeUmbrella),
+		Status:   task.Ptr(task.StatusInProgress),
+	})
+	if err != nil {
+		t.Fatalf("create tracker: %v", err)
+	}
+
+	// x <-> y mutual dependency.
+	x := mkChild(t, m, "x", "Automaat/sybra#1", umb, []string{"Automaat/sybra#2"}, task.StatusBlocked)
+	y := mkChild(t, m, "y", "Automaat/sybra#2", umb, []string{"Automaat/sybra#1"}, task.StatusBlocked)
+
+	app.releaseUnblockedChildren()
+
+	if got := mustStatus(t, m, tracker.ID); got != task.StatusHumanRequired {
+		t.Fatalf("tracker status = %q, want %q on cycle", got, task.StatusHumanRequired)
+	}
+	// Cyclic children must stay blocked.
+	if got := mustStatus(t, m, x.ID); got != task.StatusBlocked {
+		t.Fatalf("x status = %q, want blocked", got)
+	}
+	if got := mustStatus(t, m, y.ID); got != task.StatusBlocked {
+		t.Fatalf("y status = %q, want blocked", got)
+	}
+}
+
+func TestReleaseUnblockedChildren_NoUmbrellaNoOp(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+
+	// A plain blocked task with no umbrella must be left untouched.
+	tk, err := m.CreateFull("plain", "", task.AgentModeHeadless, task.Update{
+		Status:         task.Ptr(task.StatusBlocked),
+		BlockedByIssue: task.Ptr("https://github.com/Automaat/sybra/issues/9"),
+	})
+	if err != nil {
+		t.Fatalf("create plain: %v", err)
+	}
+
+	app.releaseUnblockedChildren()
+	if got := mustStatus(t, m, tk.ID); got != task.StatusBlocked {
+		t.Fatalf("plain blocked task changed to %q, want blocked", got)
+	}
+}

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -2,6 +2,7 @@ package sybra
 
 import (
 	"log/slog"
+	"slices"
 	"testing"
 
 	"github.com/Automaat/sybra/internal/task"
@@ -19,7 +20,8 @@ func newUmbrellaGateApp(t *testing.T) (*App, *task.Manager) {
 	return app, tasks
 }
 
-// mkChild creates an umbrella child task in the given status.
+// mkChild creates a gate-managed umbrella child task in the given status,
+// carrying the gating marker tag the expander would set.
 func mkChild(t *testing.T, m *task.Manager, title, issue, umb string, deps []string, status task.Status) task.Task {
 	t.Helper()
 	tk, err := m.CreateFull(title, "", task.AgentModeHeadless, task.Update{
@@ -27,6 +29,7 @@ func mkChild(t *testing.T, m *task.Manager, title, issue, umb string, deps []str
 		UmbrellaIssue: task.Ptr(umb),
 		DependsOn:     task.Ptr(deps),
 		Status:        task.Ptr(status),
+		Tags:          task.Ptr([]string{umbrellaGatedTag}),
 	})
 	if err != nil {
 		t.Fatalf("CreateFull(%s): %v", title, err)
@@ -52,8 +55,45 @@ func TestReleaseUnblockedChildren_ReleasesRootWithNoDeps(t *testing.T) {
 
 	app.releaseUnblockedChildren()
 
-	if got := mustStatus(t, m, root.ID); got != task.StatusTodo {
-		t.Fatalf("root status = %q, want %q", got, task.StatusTodo)
+	released, err := m.Get(root.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if released.Status != task.StatusTodo {
+		t.Fatalf("root status = %q, want %q", released.Status, task.StatusTodo)
+	}
+	// The gating marker must be stripped on release so a later re-block cannot
+	// retrigger a release.
+	if slices.Contains(released.Tags, umbrellaGatedTag) {
+		t.Fatalf("gating tag not stripped on release: tags=%v", released.Tags)
+	}
+}
+
+func TestReleaseUnblockedChildren_IgnoresSybraBugBlock(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+
+	// A dependency that has merged.
+	mkChild(t, m, "dep", "Automaat/sybra#1", umb, nil, task.StatusDone)
+	// An umbrella child that ran, hit a Sybra bug, and was parked in `blocked`
+	// by human-review WITHOUT the gating marker. Its dep is done, but the gate
+	// must not resurrect it.
+	bug, err := m.CreateFull("buggy", "", task.AgentModeHeadless, task.Update{
+		Issue:          task.Ptr("Automaat/sybra#2"),
+		UmbrellaIssue:  task.Ptr(umb),
+		DependsOn:      task.Ptr([]string{"Automaat/sybra#1"}),
+		Status:         task.Ptr(task.StatusBlocked),
+		BlockedByIssue: task.Ptr("https://github.com/Automaat/sybra/issues/500"),
+	})
+	if err != nil {
+		t.Fatalf("create buggy: %v", err)
+	}
+
+	app.releaseUnblockedChildren()
+
+	if got := mustStatus(t, m, bug.ID); got != task.StatusBlocked {
+		t.Fatalf("sybra-bug-blocked child was released to %q, want blocked", got)
 	}
 }
 

--- a/internal/sybra/workflow_dispatch.go
+++ b/internal/sybra/workflow_dispatch.go
@@ -12,6 +12,11 @@ const (
 )
 
 func skipTaskCreatedWorkflow(t task.Task) bool {
+	// An umbrella tracker runs no agent — it only rolls up its children — so it
+	// must never trigger the plan/implement pipeline.
+	if t.TaskType == task.TaskTypeUmbrella {
+		return true
+	}
 	if slices.Contains(t.Tags, handoffManualTag) {
 		return true
 	}

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -229,10 +229,11 @@ type Task struct {
 	// dependency gate reads it with DependsOn to decide when a child may leave
 	// `blocked`.
 	UmbrellaIssue string `yaml:"umbrella_issue,omitempty" json:"umbrellaIssue,omitempty"`
-	// DependsOn lists the issue refs (full URL or owner/repo#n) this task waits
-	// on. While the task is `blocked`, the gate holds it until every referenced
-	// task has reached `done`; an empty list releases immediately. Used only by
-	// umbrella child tasks.
+	// DependsOn lists the issue refs (full github.com issue/PR URL or
+	// owner/repo#n shorthand) this task waits on — resolved by issue ref only,
+	// not task IDs. While the task is `blocked`, the gate holds it until every
+	// referenced task has reached `done`; an empty list releases immediately.
+	// Used only by umbrella child tasks.
 	DependsOn []string `yaml:"depends_on,omitempty" json:"dependsOn,omitempty"`
 	Reviewed  bool     `yaml:"reviewed,omitempty" json:"reviewed"`
 	RunRole   string   `yaml:"run_role,omitempty" json:"runRole"` // pr-fix when fixing review issues, "" for initial impl

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -89,15 +89,20 @@ const (
 	// TaskTypeChat is a synthetic task created for interactive chat sessions.
 	// Hidden from the task list UI and skipped by restart-stale/watchdog.
 	TaskTypeChat TaskType = "chat"
+	// TaskTypeUmbrella is the tracker task for an expanded ☂️ umbrella issue.
+	// It runs no agent: it rolls up the status of its child tasks and is the
+	// task the dependency gate flips to human-required on a dependency cycle.
+	TaskTypeUmbrella TaskType = "umbrella"
 )
 
 var validTaskTypes = map[TaskType]bool{
-	TaskTypeNormal: true, TaskTypeDebug: true, TaskTypeResearch: true, TaskTypeChat: true,
+	TaskTypeNormal: true, TaskTypeDebug: true, TaskTypeResearch: true,
+	TaskTypeChat: true, TaskTypeUmbrella: true,
 }
 
 // AllTaskTypes returns every valid task type in display order.
 func AllTaskTypes() []TaskType {
-	return []TaskType{TaskTypeNormal, TaskTypeDebug, TaskTypeResearch, TaskTypeChat}
+	return []TaskType{TaskTypeNormal, TaskTypeDebug, TaskTypeResearch, TaskTypeChat, TaskTypeUmbrella}
 }
 
 func ValidateTaskType(s string) (TaskType, error) {
@@ -219,8 +224,18 @@ type Task struct {
 	// into status=blocked. Set by the human-review automation when it
 	// concludes the human-required transition was caused by a Sybra bug.
 	BlockedByIssue string `yaml:"blocked_by_issue,omitempty" json:"blockedByIssue,omitempty"`
-	Reviewed       bool   `yaml:"reviewed,omitempty" json:"reviewed"`
-	RunRole        string `yaml:"run_role,omitempty" json:"runRole"` // pr-fix when fixing review issues, "" for initial impl
+	// UmbrellaIssue links this task to the ☂️ umbrella issue it was expanded
+	// from. Set on child tasks; empty for standalone tasks. The orchestrator's
+	// dependency gate reads it with DependsOn to decide when a child may leave
+	// `blocked`.
+	UmbrellaIssue string `yaml:"umbrella_issue,omitempty" json:"umbrellaIssue,omitempty"`
+	// DependsOn lists the issue refs (full URL or owner/repo#n) this task waits
+	// on. While the task is `blocked`, the gate holds it until every referenced
+	// task has reached `done`; an empty list releases immediately. Used only by
+	// umbrella child tasks.
+	DependsOn []string `yaml:"depends_on,omitempty" json:"dependsOn,omitempty"`
+	Reviewed  bool     `yaml:"reviewed,omitempty" json:"reviewed"`
+	RunRole   string   `yaml:"run_role,omitempty" json:"runRole"` // pr-fix when fixing review issues, "" for initial impl
 	// SupervisorSteer is a one-shot corrective message left by the watchdog's
 	// headless nudge: it stops a looping headless agent (which has no mid-stream
 	// channel) and persists the steer here so the recovery loop re-dispatches

--- a/internal/task/model_test.go
+++ b/internal/task/model_test.go
@@ -69,8 +69,8 @@ func TestValidateTaskType_Invalid(t *testing.T) {
 func TestAllTaskTypes(t *testing.T) {
 	t.Parallel()
 	types := AllTaskTypes()
-	if len(types) != 4 {
-		t.Errorf("got %d types, want 4", len(types))
+	if len(types) != 5 {
+		t.Errorf("got %d types, want 5", len(types))
 	}
 }
 

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -327,21 +327,31 @@ func (s *Store) CreateFull(title, body, mode string, init Update) (Task, error) 
 	}
 	// Apply initial field overrides before the first disk write so that any
 	// watcher reading the file sees the complete task from the start.
-	if init.ProjectID != nil {
-		t.ProjectID = *init.ProjectID
+	applyCreateInit(&t, init, now)
+	if err := s.writeSidecars(t.ID, init, &t); err != nil {
+		return Task{}, err
 	}
-	if init.Branch != nil {
-		t.Branch = *init.Branch
+
+	data, err := Marshal(t)
+	if err != nil {
+		return Task{}, err
 	}
-	if init.WorktreeDir != nil {
-		t.WorktreeDir = *init.WorktreeDir
+	filename := fmt.Sprintf("%s.md", t.ID)
+	t.FilePath = filepath.Join(s.dir, filename)
+	if err := fsutil.AtomicWrite(t.FilePath, data); err != nil {
+		return Task{}, fmt.Errorf("write task file: %w", err)
 	}
-	if init.PRNumber != nil {
-		t.PRNumber = *init.PRNumber
-	}
-	if init.Issue != nil {
-		t.Issue = *init.Issue
-	}
+	s.storeTaskCache(t)
+	return t, nil
+}
+
+// applyCreateInit applies the CreateFull init overrides onto a fresh task.
+// Split out of CreateFull so the create path stays within the length budget as
+// new initializable fields are added. Link fields (project, branch, worktree,
+// PR, issue, umbrella, depends_on) reuse applyLinkFields so the create and
+// update paths cannot drift.
+func applyCreateInit(t *Task, init Update, now time.Time) {
+	applyLinkFields(t, init)
 	if init.Tags != nil {
 		t.Tags = *init.Tags
 	}
@@ -361,20 +371,11 @@ func (s *Store) CreateFull(title, body, mode string, init Update) (Task, error) 
 	if init.Body != nil {
 		t.Body = *init.Body
 	}
-	if init.Branch != nil {
-		t.Branch = *init.Branch
-	}
-	if init.WorktreeDir != nil {
-		t.WorktreeDir = *init.WorktreeDir
-	}
-	if init.HandoffSourceProvider != nil {
-		t.HandoffSourceProvider = *init.HandoffSourceProvider
-	}
-	if init.Issue != nil {
-		t.Issue = *init.Issue
-	}
 	if init.Reviewed != nil {
 		t.Reviewed = *init.Reviewed
+	}
+	if init.TaskType != nil {
+		t.TaskType = *init.TaskType
 	}
 	if init.MaxTurns != nil {
 		t.MaxTurns = *init.MaxTurns
@@ -385,25 +386,6 @@ func (s *Store) CreateFull(title, body, mode string, init Update) (Task, error) 
 	if init.ReasoningEffort != nil {
 		t.ReasoningEffort = *init.ReasoningEffort
 	}
-	if err := s.writeSidecars(id, init, &t); err != nil {
-		return Task{}, err
-	}
-
-	if err := s.writeSidecars(t.ID, init, &t); err != nil {
-		return Task{}, err
-	}
-
-	data, err := Marshal(t)
-	if err != nil {
-		return Task{}, err
-	}
-	filename := fmt.Sprintf("%s.md", t.ID)
-	t.FilePath = filepath.Join(s.dir, filename)
-	if err := fsutil.AtomicWrite(t.FilePath, data); err != nil {
-		return Task{}, fmt.Errorf("write task file: %w", err)
-	}
-	s.storeTaskCache(t)
-	return t, nil
 }
 
 // CreateChat creates a synthetic chat task bound to projectID. Chat tasks are
@@ -527,6 +509,12 @@ func applyLinkFields(t *Task, u Update) {
 	}
 	if u.Issue != nil {
 		t.Issue = *u.Issue
+	}
+	if u.UmbrellaIssue != nil {
+		t.UmbrellaIssue = *u.UmbrellaIssue
+	}
+	if u.DependsOn != nil {
+		t.DependsOn = slices.Clone(*u.DependsOn)
 	}
 }
 
@@ -743,6 +731,7 @@ func cloneTask(t Task) Task {
 	clone := t
 	clone.AllowedTools = slices.Clone(t.AllowedTools)
 	clone.Tags = slices.Clone(t.Tags)
+	clone.DependsOn = slices.Clone(t.DependsOn)
 	clone.AgentRuns = slices.Clone(t.AgentRuns)
 	if t.DueDate != nil {
 		d := *t.DueDate

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -17,6 +17,8 @@ type Update struct {
 	Status                *Status
 	StatusReason          *string
 	BlockedByIssue        *string
+	UmbrellaIssue         *string
+	DependsOn             *[]string
 	AgentMode             *string
 	TaskType              *TaskType
 	Body                  *string
@@ -68,10 +70,12 @@ func UpdateFromMap(raw map[string]any) (Update, error) {
 
 func applyMapField(u *Update, k string, v any) error {
 	switch k {
-	case "title", "slug", "status_reason", "blocked_by_issue", "body",
+	case "title", "slug", "status_reason", "blocked_by_issue", "umbrella_issue", "body",
 		"project_id", "branch", "worktree_dir", "issue", "run_role", "todoist_id", "plan", "plan_critique", "code_review",
 		"review_phase", "pr_phase", "outcome", "merge_commit", "supervisor_steer":
 		return applyPlainStringField(u, k, v)
+	case "depends_on":
+		return applyDependsOnField(u, k, v)
 	case "handoff_source_provider":
 		return applyAgentProviderField(u, k, v)
 	case "priority":
@@ -138,6 +142,8 @@ func applyPlainStringField(u *Update, k string, v any) error {
 		u.StatusReason = &s
 	case "blocked_by_issue":
 		u.BlockedByIssue = &s
+	case "umbrella_issue":
+		u.UmbrellaIssue = &s
 	case "body":
 		u.Body = &s
 	case "project_id":
@@ -233,6 +239,29 @@ func applyTagsField(u *Update, k string, v any) error {
 	case string:
 		parts := strings.Split(tv, ",")
 		u.Tags = &parts
+	default:
+		return fmt.Errorf("field %q: want []string or string, got %T", k, v)
+	}
+	return nil
+}
+
+func applyDependsOnField(u *Update, k string, v any) error {
+	switch dv := v.(type) {
+	case []string:
+		cp := make([]string, len(dv))
+		copy(cp, dv)
+		u.DependsOn = &cp
+	case string:
+		// Comma-separated shorthand from the CLI; trim and drop empties so a
+		// trailing comma or stray space cannot inject a blank dependency ref
+		// (which would otherwise resolve to "" and never satisfy).
+		var parts []string
+		for p := range strings.SplitSeq(dv, ",") {
+			if p = strings.TrimSpace(p); p != "" {
+				parts = append(parts, p)
+			}
+		}
+		u.DependsOn = &parts
 	default:
 		return fmt.Errorf("field %q: want []string or string, got %T", k, v)
 	}

--- a/internal/umbrella/dag.go
+++ b/internal/umbrella/dag.go
@@ -1,0 +1,183 @@
+// Package umbrella implements the dependency-DAG primitive that gates the
+// child tasks of an expanded ☂️ umbrella issue. A child stays `blocked` until
+// every task it depends on has reached `done`, then is released in dependency
+// order. The logic here is pure: it reads a snapshot of task state and reports
+// which children are ready to release or are caught in a dependency cycle,
+// leaving all task mutation to the caller (the orchestrator gate).
+package umbrella
+
+import (
+	"slices"
+	"sort"
+	"strings"
+)
+
+// Node is the minimal projection of a task the dependency DAG reasons about.
+type Node struct {
+	ID        string   // task ID
+	Issue     string   // issue ref this task implements (URL or shorthand); may be empty
+	Umbrella  string   // umbrella issue ref this task belongs to; empty for non-children
+	DependsOn []string // issue refs this task waits on
+	Done      bool     // task has reached a satisfied (done) state
+	Awaiting  bool     // task is currently held in `blocked`, awaiting release
+}
+
+// Graph is a resolved dependency graph over a snapshot of nodes. Build it with
+// Build; it is read-only thereafter.
+type Graph struct {
+	nodes   []Node
+	byIssue map[string]int // normalized issue ref -> index into nodes
+}
+
+// NormalizeIssueRef canonicalizes an issue URL or shorthand to
+// "owner/repo#number" (lowercased) so a DependsOn entry matches a task's Issue
+// field regardless of the spelling used to write it. A full GitHub issue/PR
+// URL collapses to that form; anything else is lowercased and trimmed so
+// shorthand like "Automaat/sybra#12" still matches a URL-form Issue. Empty in,
+// empty out.
+func NormalizeIssueRef(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if _, after, ok := strings.Cut(s, "github.com/"); ok {
+		parts := strings.Split(after, "/")
+		if len(parts) >= 4 && (parts[2] == "issues" || parts[2] == "pull") {
+			if num := leadingDigits(parts[3]); num != "" {
+				return strings.ToLower(parts[0]+"/"+parts[1]) + "#" + num
+			}
+		}
+	}
+	return strings.ToLower(s)
+}
+
+// leadingDigits returns the run of ASCII digits at the start of s (empty if
+// none). Trims trailing URL noise like "#issuecomment-..." or "?foo" off an
+// issue number.
+func leadingDigits(s string) string {
+	for i := range len(s) {
+		if s[i] < '0' || s[i] > '9' {
+			return s[:i]
+		}
+	}
+	return s
+}
+
+// Build indexes nodes by their normalized issue ref for dependency resolution.
+// On duplicate issue refs the first node wins, so a stray duplicate cannot
+// shadow the canonical task.
+func Build(nodes []Node) *Graph {
+	g := &Graph{nodes: nodes, byIssue: make(map[string]int, len(nodes))}
+	for i := range nodes {
+		key := NormalizeIssueRef(nodes[i].Issue)
+		if key == "" {
+			continue
+		}
+		if _, ok := g.byIssue[key]; !ok {
+			g.byIssue[key] = i
+		}
+	}
+	return g
+}
+
+// ReadyToRelease returns the IDs of awaiting (blocked) child nodes whose every
+// resolvable dependency is done, excluding any node on a dependency cycle. The
+// result is sorted for deterministic dispatch. A node with an unresolvable
+// dependency stays held until that dependency appears.
+func (g *Graph) ReadyToRelease() []string {
+	onCycle := g.cycleMembers()
+	var ready []string
+	for i := range g.nodes {
+		if !g.nodes[i].Awaiting || onCycle[i] {
+			continue
+		}
+		if g.depsSatisfied(i) {
+			ready = append(ready, g.nodes[i].ID)
+		}
+	}
+	sort.Strings(ready)
+	return ready
+}
+
+// CyclicUmbrellas returns the umbrella refs that contain at least one child on
+// a dependency cycle. The caller flips those trackers to human-required since
+// the chain can never make progress on its own. Result is sorted.
+func (g *Graph) CyclicUmbrellas() []string {
+	onCycle := g.cycleMembers()
+	seen := map[string]bool{}
+	var out []string
+	for i := range g.nodes {
+		if !onCycle[i] {
+			continue
+		}
+		u := g.nodes[i].Umbrella
+		if u == "" || seen[u] {
+			continue
+		}
+		seen[u] = true
+		out = append(out, u)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// depsSatisfied reports whether every dependency of node i resolves to a known
+// node that is done. An unresolvable dependency is treated as unsatisfied so a
+// child is never released ahead of a dependency that has not been materialized
+// yet.
+func (g *Graph) depsSatisfied(i int) bool {
+	for _, dep := range g.nodes[i].DependsOn {
+		j, ok := g.byIssue[NormalizeIssueRef(dep)]
+		if !ok || !g.nodes[j].Done {
+			return false
+		}
+	}
+	return true
+}
+
+// cycleMembers returns the set of node indices that lie on at least one
+// dependency cycle, via DFS three-coloring over the resolved dependency edges.
+// Unresolvable dependency refs are skipped (they form no edge).
+func (g *Graph) cycleMembers() map[int]bool {
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+	color := make([]int8, len(g.nodes))
+	onCycle := make(map[int]bool)
+	var stack []int
+
+	var dfs func(i int)
+	dfs = func(i int) {
+		color[i] = gray
+		stack = append(stack, i)
+		for _, dep := range g.nodes[i].DependsOn {
+			j, ok := g.byIssue[NormalizeIssueRef(dep)]
+			if !ok {
+				continue
+			}
+			switch color[j] {
+			case gray:
+				// Back-edge: every node from j to the top of the stack is on a cycle.
+				for _, n := range slices.Backward(stack) {
+					onCycle[n] = true
+					if n == j {
+						break
+					}
+				}
+			case white:
+				dfs(j)
+			}
+		}
+		stack = stack[:len(stack)-1]
+		color[i] = black
+	}
+
+	for i := range g.nodes {
+		if color[i] == white {
+			dfs(i)
+		}
+	}
+	return onCycle
+}

--- a/internal/umbrella/dag.go
+++ b/internal/umbrella/dag.go
@@ -7,7 +7,7 @@
 package umbrella
 
 import (
-	"slices"
+	"net/url"
 	"sort"
 	"strings"
 )
@@ -31,17 +31,18 @@ type Graph struct {
 
 // NormalizeIssueRef canonicalizes an issue URL or shorthand to
 // "owner/repo#number" (lowercased) so a DependsOn entry matches a task's Issue
-// field regardless of the spelling used to write it. A full GitHub issue/PR
-// URL collapses to that form; anything else is lowercased and trimmed so
-// shorthand like "Automaat/sybra#12" still matches a URL-form Issue. Empty in,
-// empty out.
+// field regardless of the spelling used to write it. Only a github.com
+// issue/PR URL collapses to that form; anything else (shorthand, or a
+// non-github.com host) is lowercased and trimmed so "Automaat/sybra#12" still
+// matches a URL-form Issue. The host is matched exactly to avoid a substring
+// like "notgithub.com" being read as github.com. Empty in, empty out.
 func NormalizeIssueRef(s string) string {
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return ""
 	}
-	if _, after, ok := strings.Cut(s, "github.com/"); ok {
-		parts := strings.Split(after, "/")
+	if u, err := url.Parse(s); err == nil && isGitHubHost(u.Host) {
+		parts := strings.Split(strings.Trim(u.Path, "/"), "/")
 		if len(parts) >= 4 && (parts[2] == "issues" || parts[2] == "pull") {
 			if num := leadingDigits(parts[3]); num != "" {
 				return strings.ToLower(parts[0]+"/"+parts[1]) + "#" + num
@@ -49,6 +50,14 @@ func NormalizeIssueRef(s string) string {
 		}
 	}
 	return strings.ToLower(s)
+}
+
+// isGitHubHost reports whether h is github.com (case-insensitive, with or
+// without a www prefix). Anchored so a lookalike host cannot cross-link to an
+// unrelated github.com issue.
+func isGitHubHost(h string) bool {
+	h = strings.ToLower(h)
+	return h == "github.com" || h == "www.github.com"
 }
 
 // leadingDigits returns the run of ASCII digits at the start of s (empty if
@@ -136,47 +145,73 @@ func (g *Graph) depsSatisfied(i int) bool {
 }
 
 // cycleMembers returns the set of node indices that lie on at least one
-// dependency cycle, via DFS three-coloring over the resolved dependency edges.
-// Unresolvable dependency refs are skipped (they form no edge).
+// dependency cycle. A node is on a cycle iff its strongly-connected component
+// has more than one node, or it depends on itself. Computed with Tarjan's SCC
+// over the resolved dependency edges — a plain DFS back-edge walk misses cycle
+// members reached through an already-finished node. Unresolvable dependency
+// refs form no edge.
 func (g *Graph) cycleMembers() map[int]bool {
-	const (
-		white = 0
-		gray  = 1
-		black = 2
-	)
-	color := make([]int8, len(g.nodes))
-	onCycle := make(map[int]bool)
+	const unvisited = -1
+	n := len(g.nodes)
+	idx := make([]int, n)
+	low := make([]int, n)
+	onStack := make([]bool, n)
+	for i := range idx {
+		idx[i] = unvisited
+	}
 	var stack []int
+	counter := 0
+	onCycle := make(map[int]bool)
 
-	var dfs func(i int)
-	dfs = func(i int) {
-		color[i] = gray
-		stack = append(stack, i)
-		for _, dep := range g.nodes[i].DependsOn {
-			j, ok := g.byIssue[NormalizeIssueRef(dep)]
+	var strongconnect func(v int)
+	strongconnect = func(v int) {
+		idx[v] = counter
+		low[v] = counter
+		counter++
+		stack = append(stack, v)
+		onStack[v] = true
+
+		for _, dep := range g.nodes[v].DependsOn {
+			w, ok := g.byIssue[NormalizeIssueRef(dep)]
 			if !ok {
 				continue
 			}
-			switch color[j] {
-			case gray:
-				// Back-edge: every node from j to the top of the stack is on a cycle.
-				for _, n := range slices.Backward(stack) {
-					onCycle[n] = true
-					if n == j {
-						break
-					}
-				}
-			case white:
-				dfs(j)
+			if w == v {
+				onCycle[v] = true // self-loop
+			}
+			switch {
+			case idx[w] == unvisited:
+				strongconnect(w)
+				low[v] = min(low[v], low[w])
+			case onStack[w]:
+				low[v] = min(low[v], idx[w])
 			}
 		}
-		stack = stack[:len(stack)-1]
-		color[i] = black
+
+		if low[v] != idx[v] {
+			return
+		}
+		// v roots an SCC: pop it off the stack.
+		var comp []int
+		for {
+			w := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			onStack[w] = false
+			comp = append(comp, w)
+			if w == v {
+				break
+			}
+		}
+		if len(comp) > 1 {
+			for _, w := range comp {
+				onCycle[w] = true
+			}
+		}
 	}
 
-	for i := range g.nodes {
-		if color[i] == white {
-			dfs(i)
+	for v := range n {
+		if idx[v] == unvisited {
+			strongconnect(v)
 		}
 	}
 	return onCycle

--- a/internal/umbrella/dag_test.go
+++ b/internal/umbrella/dag_test.go
@@ -1,0 +1,199 @@
+package umbrella
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNormalizeIssueRef(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"  ", ""},
+		{"https://github.com/Automaat/sybra/issues/1129", "automaat/sybra#1129"},
+		{"https://github.com/Automaat/sybra/pull/1129", "automaat/sybra#1129"},
+		{"https://github.com/Automaat/sybra/issues/1129#issuecomment-99", "automaat/sybra#1129"},
+		{"Automaat/sybra#1129", "automaat/sybra#1129"},
+		{"automaat/sybra#1129", "automaat/sybra#1129"},
+		{"#1129", "#1129"},
+		// URL and shorthand for the same issue must normalize identically so a
+		// DependsOn written either way matches the dependency's Issue field.
+	}
+	for _, c := range cases {
+		if got := NormalizeIssueRef(c.in); got != c.want {
+			t.Errorf("NormalizeIssueRef(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+	// Cross-form equality: the canonical key is spelling-independent.
+	if NormalizeIssueRef("https://github.com/Automaat/sybra/issues/7") != NormalizeIssueRef("Automaat/sybra#7") {
+		t.Error("URL and shorthand for the same issue normalized differently")
+	}
+}
+
+// node builds a Node; status flags are set by the caller per case.
+func node(id, issue, umb string, deps []string, done, awaiting bool) Node {
+	return Node{ID: id, Issue: issue, Umbrella: umb, DependsOn: deps, Done: done, Awaiting: awaiting}
+}
+
+func TestReadyToRelease(t *testing.T) {
+	t.Parallel()
+	const umb = "Automaat/sybra#100"
+	tests := []struct {
+		name  string
+		nodes []Node
+		want  []string
+	}{
+		{
+			name: "no deps releases immediately",
+			nodes: []Node{
+				node("a", "o/r#1", umb, nil, false, true),
+			},
+			want: []string{"a"},
+		},
+		{
+			name: "blocked child held while dep not done",
+			nodes: []Node{
+				node("root", "o/r#1", umb, nil, false, false), // in progress, not done
+				node("dep", "o/r#2", umb, []string{"o/r#1"}, false, true),
+			},
+			want: nil,
+		},
+		{
+			name: "blocked child released once dep done",
+			nodes: []Node{
+				node("root", "o/r#1", umb, nil, true, false), // done
+				node("dep", "o/r#2", umb, []string{"o/r#1"}, false, true),
+			},
+			want: []string{"dep"},
+		},
+		{
+			name: "parallel tracks both release after shared root done",
+			nodes: []Node{
+				node("root", "o/r#1", umb, nil, true, false),
+				node("b", "o/r#2", umb, []string{"o/r#1"}, false, true),
+				node("c", "o/r#3", umb, []string{"o/r#1"}, false, true),
+			},
+			want: []string{"b", "c"},
+		},
+		{
+			name: "chain only releases the next link",
+			nodes: []Node{
+				node("a", "o/r#1", umb, nil, true, false),               // done
+				node("b", "o/r#2", umb, []string{"o/r#1"}, false, true), // ready
+				node("c", "o/r#3", umb, []string{"o/r#2"}, false, true), // still blocked on b
+			},
+			want: []string{"b"},
+		},
+		{
+			name: "multi-dep child waits for all",
+			nodes: []Node{
+				node("a", "o/r#1", umb, nil, true, false),
+				node("b", "o/r#2", umb, nil, false, true), // b not done yet
+				node("c", "o/r#3", umb, []string{"o/r#1", "o/r#2"}, false, true),
+			},
+			want: []string{"b"}, // c held until b done; b itself has no deps
+		},
+		{
+			name: "url and shorthand dep forms both resolve",
+			nodes: []Node{
+				node("a", "https://github.com/o/r/issues/1", umb, nil, true, false),
+				node("b", "o/r#2", umb, []string{"o/r#1"}, false, true),
+			},
+			want: []string{"b"},
+		},
+		{
+			name: "unresolvable dep keeps child blocked",
+			nodes: []Node{
+				node("b", "o/r#2", umb, []string{"o/r#999"}, false, true),
+			},
+			want: nil,
+		},
+		{
+			name: "non-awaiting node never released",
+			nodes: []Node{
+				node("a", "o/r#1", umb, nil, false, false), // not awaiting (already running)
+			},
+			want: nil,
+		},
+		{
+			name: "cyclic nodes excluded from release",
+			nodes: []Node{
+				node("x", "o/r#1", umb, []string{"o/r#2"}, false, true),
+				node("y", "o/r#2", umb, []string{"o/r#1"}, false, true),
+			},
+			want: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := Build(tc.nodes).ReadyToRelease()
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ReadyToRelease() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCyclicUmbrellas(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		nodes []Node
+		want  []string
+	}{
+		{
+			name: "acyclic graph has no cyclic umbrellas",
+			nodes: []Node{
+				node("a", "o/r#1", "o/r#100", nil, true, false),
+				node("b", "o/r#2", "o/r#100", []string{"o/r#1"}, false, true),
+			},
+			want: nil,
+		},
+		{
+			name: "direct two-node cycle detected",
+			nodes: []Node{
+				node("x", "o/r#1", "o/r#100", []string{"o/r#2"}, false, true),
+				node("y", "o/r#2", "o/r#100", []string{"o/r#1"}, false, true),
+			},
+			want: []string{"o/r#100"},
+		},
+		{
+			name: "three-node cycle detected",
+			nodes: []Node{
+				node("x", "o/r#1", "o/r#100", []string{"o/r#2"}, false, true),
+				node("y", "o/r#2", "o/r#100", []string{"o/r#3"}, false, true),
+				node("z", "o/r#3", "o/r#100", []string{"o/r#1"}, false, true),
+			},
+			want: []string{"o/r#100"},
+		},
+		{
+			name: "self-dependency is a cycle",
+			nodes: []Node{
+				node("x", "o/r#1", "o/r#100", []string{"o/r#1"}, false, true),
+			},
+			want: []string{"o/r#100"},
+		},
+		{
+			name: "diamond is acyclic",
+			nodes: []Node{
+				node("a", "o/r#1", "o/r#100", nil, true, false),
+				node("b", "o/r#2", "o/r#100", []string{"o/r#1"}, false, true),
+				node("c", "o/r#3", "o/r#100", []string{"o/r#1"}, false, true),
+				node("d", "o/r#4", "o/r#100", []string{"o/r#2", "o/r#3"}, false, true),
+			},
+			want: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := Build(tc.nodes).CyclicUmbrellas()
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("CyclicUmbrellas() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/umbrella/dag_test.go
+++ b/internal/umbrella/dag_test.go
@@ -177,6 +177,20 @@ func TestCyclicUmbrellas(t *testing.T) {
 			want: []string{"o/r#100"},
 		},
 		{
+			// Regression: a cycle member reached through an already-finished
+			// node must still be flagged. D (umbrella 200) joins the A→B→C→A
+			// cycle via B→D, D→C; a plain DFS back-edge walk drops D and never
+			// flags umbrella 200. Tarjan SCC catches it.
+			name: "cross-component cycle flags both umbrellas",
+			nodes: []Node{
+				node("a", "o/r#1", "o/r#100", []string{"o/r#2"}, false, true),
+				node("b", "o/r#2", "o/r#100", []string{"o/r#3", "o/r#4"}, false, true),
+				node("c", "o/r#3", "o/r#100", []string{"o/r#1"}, false, true),
+				node("d", "o/r#4", "o/r#200", []string{"o/r#3"}, false, true),
+			},
+			want: []string{"o/r#100", "o/r#200"},
+		},
+		{
 			name: "diamond is acyclic",
 			nodes: []Node{
 				node("a", "o/r#1", "o/r#100", nil, true, false),

--- a/internal/workflow/condition.go
+++ b/internal/workflow/condition.go
@@ -73,7 +73,7 @@ var FieldAllowedValues = map[string]map[string]bool{
 		"done": true, "cancelled": true,
 	},
 	"task.task_type": {
-		"normal": true, "debug": true, "research": true, "chat": true,
+		"normal": true, "debug": true, "research": true, "chat": true, "umbrella": true,
 	},
 	"pr.issue_kind": {
 		"conflict": true, "ci_failure": true, "comments": true, "ready_to_merge": true,


### PR DESCRIPTION
## Motivation

Sybra ingests GitHub issues flat — one issue → one task — and `Task` has no dependency fields, so tasks are fully independent and nothing waits on anything. Native umbrella-task orchestration needs a dependency-DAG primitive first: child tasks that stay `blocked` until their prerequisites merge, released by the orchestrator in dependency order. This is phase 0 of that umbrella, built standalone (no GitHub, no LLM) so it is testable with hand-authored tasks.

## Implementation information

- **Model** (`internal/task/model.go`): `UmbrellaIssue` + `DependsOn []string` fields on `Task`, and a new `umbrella` task type for the tracker (runs no agent). Update/CreateFull plumbing wires both fields; `CreateFull`'s init block was extracted to `applyCreateInit` (reusing `applyLinkFields`), which also removed a duplicate `writeSidecars` call so create and update paths cannot drift.
- **Pure DAG** (`internal/umbrella`): `NormalizeIssueRef` (github.com issue/PR URL ⇄ `owner/repo#n` shorthand, host anchored), `ReadyToRelease` (blocked children whose every dep is `done`, in deterministic order), and `CyclicUmbrellas` (umbrellas whose children form a dependency cycle, via Tarjan SCC). Fully unit-tested.
- **Gate** (`internal/sybra/app_umbrella_gate.go`, wired into the 1-minute `orchestratorLoop`): releases gate-blocked children to `todo` once deps merge so normal dispatch picks them up; flips an umbrella tracker to `human-required` on a cycle. Release is keyed on a dedicated `umbrella-gated` tag (stripped on release) so a child parked in `blocked` for a contained Sybra bug is never resurrected.

Branch strategy is sequential-off-fresh-main: a dependent child is only released after its dependency reaches `done` (PR merged), so its fresh worktree already contains the merged change — no rebase choreography.

Reviewed adversarially before opening (Tarjan SCC, the gating-tag marker, and host anchoring are all fixes from that pass).

Closes #1129

## Open questions

- A `cancelled` (or otherwise unresolvable) dependency currently holds its child in `blocked` indefinitely with no escalation. Deliberate for this phase — failure/halt-chain handling and umbrella roll-up land in #1131.

> Changelog: feat(task): add task dependency DAG primitive
