### PR TITLE
feat(umbrella): expand umbrella via CLI + LLM planner

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -76,6 +76,8 @@ func run(args []string) int {
 		return cmdCreate(store, rest, jsonOut)
 	case "handoff":
 		return cmdHandoff(store, projStore, rest, jsonOut)
+	case "umbrella":
+		return cmdUmbrella(store, rest, jsonOut)
 	case "update":
 		return cmdUpdate(store, rest, jsonOut)
 	case "delete":
@@ -1463,6 +1465,10 @@ Commands:
            so review/testing/PR steps can run on a different provider.
            Required for --stage review|testing|pr; optional for implement/ready-pr.
            --status STATUS creates the task directly in that status without workflow dispatch
+  umbrella <issue-url> [--model M]
+           Expand a GitHub umbrella issue into a gated task DAG: one umbrella tracker
+           plus one blocked child per sub-issue, with dependency edges extracted by an
+           LLM planner. Re-running only materializes sub-issues without an existing task.
   update   <id> [--title T] [--status S] [--status-reason R] [--body B] [--plan PLAN] [--plan-file PATH] [--mode M] [--type TYPE] [--tags T] [--project ID] [--branch B] [--pr N] [--issue URL] [--source-provider P|none] [--max-turns N] [--reasoning-effort E]
   delete   <id>
 

--- a/cmd/sybra-cli/umbrella.go
+++ b/cmd/sybra-cli/umbrella.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/umbrella"
+)
+
+// cmdUmbrella expands a GitHub umbrella issue into a gated task DAG: one
+// `umbrella` tracker task plus one `blocked` child per sub-issue, with
+// dependency edges extracted by an LLM planner. Re-running is idempotent —
+// only sub-issues without an existing task are materialized.
+func cmdUmbrella(s *task.Manager, args []string, jsonOut bool) int {
+	fs := flag.NewFlagSet("umbrella", flag.ContinueOnError)
+	urlFlag := fs.String("url", "", "umbrella issue URL (or pass as first argument)")
+	model := fs.String("model", "", "planner model (default: claude default)")
+	if err := fs.Parse(args); err != nil {
+		return fatal(jsonOut, "parse flags: %v", err)
+	}
+	issueURL := *urlFlag
+	if issueURL == "" && fs.NArg() > 0 {
+		issueURL = fs.Arg(0)
+	}
+	if issueURL == "" {
+		return fatal(jsonOut, "umbrella: an issue URL is required")
+	}
+
+	repo, number, err := parseIssueURL(issueURL)
+	if err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+
+	umb, subs, err := github.FetchUmbrella(repo, number)
+	if err != nil {
+		return fatal(jsonOut, "fetch umbrella: %v", err)
+	}
+	if len(subs) == 0 {
+		return fatal(jsonOut, "umbrella %s has no sub-issues", issueURL)
+	}
+
+	// Index sub-issues by canonical (URL) ref for planner input + later lookup.
+	planSubs := make([]umbrella.SubIssue, len(subs))
+	byRef := make(map[string]github.Issue, len(subs))
+	for i := range subs {
+		planSubs[i] = umbrella.SubIssue{Ref: subs[i].URL, Title: subs[i].Title, Body: subs[i].Body}
+		byRef[umbrella.NormalizeIssueRef(subs[i].URL)] = subs[i]
+	}
+
+	plan, err := umbrella.Generate(context.Background(), claudePlannerRunner(*model), umb.URL, umb.Body, planSubs)
+	if err != nil {
+		return fatal(jsonOut, "plan umbrella: %v", err)
+	}
+
+	existing, trackerExists := scanExisting(s, umb.URL)
+	specs := umbrella.ChildSpecs(plan, planSubs, existing)
+
+	created, err := materializeUmbrella(s, umb, repo, specs, byRef, trackerExists)
+	if err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+
+	return reportUmbrella(jsonOut, umb.URL, created, len(subs)-len(specs))
+}
+
+// scanExisting returns the set of normalized issue refs that already have a
+// task, and whether the umbrella tracker task already exists.
+func scanExisting(s *task.Manager, umbrellaURL string) (map[string]bool, bool) {
+	refs := map[string]bool{}
+	trackerExists := false
+	umbKey := umbrella.NormalizeIssueRef(umbrellaURL)
+	tasks, err := s.List()
+	if err != nil {
+		return refs, false
+	}
+	for i := range tasks {
+		t := &tasks[i]
+		if t.Issue != "" {
+			refs[umbrella.NormalizeIssueRef(t.Issue)] = true
+		}
+		if t.TaskType == task.TaskTypeUmbrella && umbrella.NormalizeIssueRef(t.Issue) == umbKey {
+			trackerExists = true
+		}
+	}
+	return refs, trackerExists
+}
+
+// materializeUmbrella creates the tracker (when absent) and one blocked child
+// task per spec. It returns the number of child tasks created.
+func materializeUmbrella(s *task.Manager, umb github.Issue, repo string, specs []umbrella.ChildSpec, byRef map[string]github.Issue, trackerExists bool) (int, error) {
+	if !trackerExists {
+		if _, err := s.CreateFull(umb.Title, umb.Body, task.AgentModeHeadless, task.Update{
+			Issue:     task.Ptr(umb.URL),
+			TaskType:  task.Ptr(task.TaskTypeUmbrella),
+			ProjectID: task.Ptr(repo),
+			Status:    task.Ptr(task.StatusInProgress),
+			Tags:      task.Ptr([]string{"umbrella"}),
+		}); err != nil {
+			return 0, fmt.Errorf("create tracker: %w", err)
+		}
+	}
+
+	created := 0
+	for _, spec := range specs {
+		if _, err := s.CreateFull(spec.Title, spec.Body, task.AgentModeHeadless, task.Update{
+			Issue:         task.Ptr(spec.Issue),
+			UmbrellaIssue: task.Ptr(umb.URL),
+			DependsOn:     task.Ptr(canonicalizeDeps(spec.DependsOn, byRef)),
+			ProjectID:     task.Ptr(repo),
+			Status:        task.Ptr(task.StatusBlocked),
+			Tags:          task.Ptr(childTags(spec.Issue, byRef)),
+		}); err != nil {
+			return created, fmt.Errorf("create child for %s: %w", spec.Issue, err)
+		}
+		created++
+	}
+	return created, nil
+}
+
+// canonicalizeDeps rewrites each dependency ref to the canonical issue URL of
+// the sub-issue it points at, so a child's DependsOn matches the dependency
+// task's Issue field exactly. An unknown ref (should not happen post-validate)
+// is kept as-is.
+func canonicalizeDeps(deps []string, byRef map[string]github.Issue) []string {
+	if len(deps) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(deps))
+	for _, d := range deps {
+		if iss, ok := byRef[umbrella.NormalizeIssueRef(d)]; ok {
+			out = append(out, iss.URL)
+		} else {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// childTags returns the gating marker plus the sub-issue's own labels.
+func childTags(ref string, byRef map[string]github.Issue) []string {
+	tags := []string{umbrella.GatedTag}
+	if iss, ok := byRef[umbrella.NormalizeIssueRef(ref)]; ok {
+		for _, l := range iss.Labels {
+			if !slices.Contains(tags, l) {
+				tags = append(tags, l)
+			}
+		}
+	}
+	return tags
+}
+
+func reportUmbrella(jsonOut bool, umbrellaURL string, created, skipped int) int {
+	if jsonOut {
+		out, _ := json.Marshal(map[string]any{
+			"umbrella": umbrellaURL,
+			"created":  created,
+			"skipped":  skipped,
+		})
+		fmt.Println(string(out))
+		return 0
+	}
+	fmt.Printf("Expanded %s: created %d child task(s), %d already present.\n", umbrellaURL, created, skipped)
+	return 0
+}
+
+// parseIssueURL extracts "owner/repo" and the issue number from a GitHub issue
+// URL.
+func parseIssueURL(raw string) (repo string, number int, err error) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid URL %q: %w", raw, err)
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 4 || parts[2] != "issues" {
+		return "", 0, fmt.Errorf("not a GitHub issue URL: %s", raw)
+	}
+	n, err := strconv.Atoi(parts[3])
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid issue number in %s", raw)
+	}
+	return parts[0] + "/" + parts[1], n, nil
+}
+
+// claudePlannerRunner returns a planner Runner that shells out to the claude
+// CLI for a single structured-output completion. The planner reasons over text
+// passed in the prompt and needs no tools.
+func claudePlannerRunner(model string) umbrella.Runner {
+	return func(ctx context.Context, prompt string) (string, error) {
+		cmdArgs := []string{"-p", prompt, "--output-format", "json", "--dangerously-skip-permissions"}
+		if model != "" {
+			cmdArgs = append(cmdArgs, "--model", model)
+		}
+		out, err := exec.CommandContext(ctx, "claude", cmdArgs...).Output()
+		if err != nil {
+			return "", fmt.Errorf("run claude: %w", err)
+		}
+		return string(out), nil
+	}
+}

--- a/cmd/sybra-cli/umbrella.go
+++ b/cmd/sybra-cli/umbrella.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/task"
@@ -52,36 +53,71 @@ func cmdUmbrella(s *task.Manager, args []string, jsonOut bool) int {
 	planSubs := make([]umbrella.SubIssue, len(subs))
 	byRef := make(map[string]github.Issue, len(subs))
 	for i := range subs {
-		planSubs[i] = umbrella.SubIssue{Ref: subs[i].URL, Title: subs[i].Title, Body: subs[i].Body}
+		planSubs[i] = umbrella.SubIssue{
+			Ref:    subs[i].URL,
+			Title:  subs[i].Title,
+			Body:   subs[i].Body,
+			Closed: strings.EqualFold(subs[i].State, "CLOSED"),
+		}
 		byRef[umbrella.NormalizeIssueRef(subs[i].URL)] = subs[i]
 	}
 
-	plan, err := umbrella.Generate(context.Background(), claudePlannerRunner(*model), umb.URL, umb.Body, planSubs)
+	existing, trackerExists, err := scanExisting(s, umb.URL)
+	if err != nil {
+		return fatal(jsonOut, "scan existing tasks: %v", err)
+	}
+	// Short-circuit a full re-run: when every open sub-issue already has a task
+	// and the tracker exists, there is nothing to create — skip the (costly,
+	// stochastic) planner entirely.
+	if trackerExists && allMaterialized(planSubs, existing) {
+		return reportUmbrella(jsonOut, umb.URL, 0, len(subs))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), plannerTimeout)
+	defer cancel()
+	plan, err := umbrella.Generate(ctx, claudePlannerRunner(*model), umb.URL, umb.Body, planSubs)
 	if err != nil {
 		return fatal(jsonOut, "plan umbrella: %v", err)
 	}
 
-	existing, trackerExists := scanExisting(s, umb.URL)
 	specs := umbrella.ChildSpecs(plan, planSubs, existing)
-
-	created, err := materializeUmbrella(s, umb, repo, specs, byRef, trackerExists)
+	created, err := materializeUmbrella(s, umb, specs, byRef, trackerExists, plan.MaxParallel)
 	if err != nil {
 		return fatal(jsonOut, "%v", err)
 	}
 
-	return reportUmbrella(jsonOut, umb.URL, created, len(subs)-len(specs))
+	return reportUmbrella(jsonOut, umb.URL, created, len(subs)-created)
+}
+
+// plannerTimeout bounds a single planner LLM invocation so a hung claude
+// process cannot wedge the command indefinitely.
+const plannerTimeout = 5 * time.Minute
+
+// allMaterialized reports whether every open sub-issue already has a task.
+// Closed sub-issues never get a task, so they do not count as missing.
+func allMaterialized(subs []umbrella.SubIssue, existing map[string]bool) bool {
+	for _, s := range subs {
+		if s.Closed {
+			continue
+		}
+		if !existing[umbrella.NormalizeIssueRef(s.Ref)] {
+			return false
+		}
+	}
+	return true
 }
 
 // scanExisting returns the set of normalized issue refs that already have a
-// task, and whether the umbrella tracker task already exists.
-func scanExisting(s *task.Manager, umbrellaURL string) (map[string]bool, bool) {
-	refs := map[string]bool{}
-	trackerExists := false
-	umbKey := umbrella.NormalizeIssueRef(umbrellaURL)
+// task, and whether the umbrella tracker task already exists. A List failure
+// is propagated so the caller aborts rather than treating an unreadable store
+// as empty and creating a duplicate DAG.
+func scanExisting(s *task.Manager, umbrellaURL string) (refs map[string]bool, trackerExists bool, err error) {
 	tasks, err := s.List()
 	if err != nil {
-		return refs, false
+		return nil, false, err
 	}
+	refs = make(map[string]bool, len(tasks))
+	umbKey := umbrella.NormalizeIssueRef(umbrellaURL)
 	for i := range tasks {
 		t := &tasks[i]
 		if t.Issue != "" {
@@ -91,19 +127,19 @@ func scanExisting(s *task.Manager, umbrellaURL string) (map[string]bool, bool) {
 			trackerExists = true
 		}
 	}
-	return refs, trackerExists
+	return refs, trackerExists, nil
 }
 
 // materializeUmbrella creates the tracker (when absent) and one blocked child
 // task per spec. It returns the number of child tasks created.
-func materializeUmbrella(s *task.Manager, umb github.Issue, repo string, specs []umbrella.ChildSpec, byRef map[string]github.Issue, trackerExists bool) (int, error) {
+func materializeUmbrella(s *task.Manager, umb github.Issue, specs []umbrella.ChildSpec, byRef map[string]github.Issue, trackerExists bool, maxParallel int) (int, error) {
 	if !trackerExists {
 		if _, err := s.CreateFull(umb.Title, umb.Body, task.AgentModeHeadless, task.Update{
 			Issue:     task.Ptr(umb.URL),
 			TaskType:  task.Ptr(task.TaskTypeUmbrella),
-			ProjectID: task.Ptr(repo),
+			ProjectID: task.Ptr(umb.Repository),
 			Status:    task.Ptr(task.StatusInProgress),
-			Tags:      task.Ptr([]string{"umbrella"}),
+			Tags:      task.Ptr([]string{"umbrella", umbrella.MaxParallelTag(maxParallel)}),
 		}); err != nil {
 			return 0, fmt.Errorf("create tracker: %w", err)
 		}
@@ -115,7 +151,7 @@ func materializeUmbrella(s *task.Manager, umb github.Issue, repo string, specs [
 			Issue:         task.Ptr(spec.Issue),
 			UmbrellaIssue: task.Ptr(umb.URL),
 			DependsOn:     task.Ptr(canonicalizeDeps(spec.DependsOn, byRef)),
-			ProjectID:     task.Ptr(repo),
+			ProjectID:     task.Ptr(childProjectID(spec.Issue, byRef, umb.Repository)),
 			Status:        task.Ptr(task.StatusBlocked),
 			Tags:          task.Ptr(childTags(spec.Issue, byRef)),
 		}); err != nil {
@@ -124,6 +160,16 @@ func materializeUmbrella(s *task.Manager, umb github.Issue, repo string, specs [
 		created++
 	}
 	return created, nil
+}
+
+// childProjectID returns the repo a child task should be worked in: the
+// sub-issue's own repository (sub-issues can live in a different repo than the
+// umbrella), falling back to the umbrella's repo when unknown.
+func childProjectID(ref string, byRef map[string]github.Issue, fallback string) string {
+	if iss, ok := byRef[umbrella.NormalizeIssueRef(ref)]; ok && iss.Repository != "" {
+		return iss.Repository
+	}
+	return fallback
 }
 
 // canonicalizeDeps rewrites each dependency ref to the canonical issue URL of
@@ -145,11 +191,12 @@ func canonicalizeDeps(deps []string, byRef map[string]github.Issue) []string {
 	return out
 }
 
-// childTags returns the gating marker plus the sub-issue's own labels.
+// childTags returns the gating marker plus the sub-issue's inheritable labels
+// (load-bearing routing tags are filtered out so a child is not mis-routed).
 func childTags(ref string, byRef map[string]github.Issue) []string {
 	tags := []string{umbrella.GatedTag}
 	if iss, ok := byRef[umbrella.NormalizeIssueRef(ref)]; ok {
-		for _, l := range iss.Labels {
+		for _, l := range umbrella.InheritableLabels(iss.Labels) {
 			if !slices.Contains(tags, l) {
 				tags = append(tags, l)
 			}
@@ -168,7 +215,7 @@ func reportUmbrella(jsonOut bool, umbrellaURL string, created, skipped int) int 
 		fmt.Println(string(out))
 		return 0
 	}
-	fmt.Printf("Expanded %s: created %d child task(s), %d already present.\n", umbrellaURL, created, skipped)
+	fmt.Printf("Expanded %s: created %d child task(s), %d skipped (done or already present).\n", umbrellaURL, created, skipped)
 	return 0
 }
 

--- a/cmd/sybra-cli/umbrella.go
+++ b/cmd/sybra-cli/umbrella.go
@@ -246,8 +246,17 @@ func claudePlannerRunner(model string) umbrella.Runner {
 		if model != "" {
 			cmdArgs = append(cmdArgs, "--model", model)
 		}
-		out, err := exec.CommandContext(ctx, "claude", cmdArgs...).Output()
+		cmd := exec.CommandContext(ctx, "claude", cmdArgs...)
+		// Keep stdout clean for JSON parsing, but capture stderr so a planner
+		// failure (or a timeout-killed process) surfaces the real CLI message
+		// instead of a bare "exit status 1".
+		var stderr strings.Builder
+		cmd.Stderr = &stderr
+		out, err := cmd.Output()
 		if err != nil {
+			if msg := strings.TrimSpace(stderr.String()); msg != "" {
+				return "", fmt.Errorf("run claude: %w: %s", err, msg)
+			}
 			return "", fmt.Errorf("run claude: %w", err)
 		}
 		return string(out), nil

--- a/frontend/bindings/github.com/Automaat/sybra/internal/github/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/github/models.ts
@@ -53,6 +53,7 @@ export class Issue {
     "title": string;
     "body": string;
     "url": string;
+    "state": string;
     "repository": string;
     "repoName": string;
     "labels": string[];
@@ -73,6 +74,9 @@ export class Issue {
         }
         if (!("url" in $$source)) {
             this["url"] = "";
+        }
+        if (!("state" in $$source)) {
+            this["state"] = "";
         }
         if (!("repository" in $$source)) {
             this["repository"] = "";
@@ -100,10 +104,10 @@ export class Issue {
      * Creates a new Issue instance from a string or object.
      */
     static createFrom($$source: any = {}): Issue {
-        const $$createField6_0 = $$createType0;
+        const $$createField7_0 = $$createType0;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("labels" in $$parsedSource) {
-            $$parsedSource["labels"] = $$createField6_0($$parsedSource["labels"]);
+            $$parsedSource["labels"] = $$createField7_0($$parsedSource["labels"]);
         }
         return new Issue($$parsedSource as Partial<Issue>);
     }

--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -365,6 +365,7 @@ func convertIssues(nodes []gqlIssue) []Issue {
 			Title:      n.Title,
 			Body:       n.Body,
 			URL:        n.URL,
+			State:      n.State,
 			Repository: n.Repository.NameWithOwner,
 			RepoName:   n.Repository.Name,
 			Labels:     labels,

--- a/internal/github/model.go
+++ b/internal/github/model.go
@@ -61,6 +61,7 @@ type Issue struct {
 	Title      string   `json:"title"`
 	Body       string   `json:"body"`
 	URL        string   `json:"url"`
+	State      string   `json:"state"`
 	Repository string   `json:"repository"`
 	RepoName   string   `json:"repoName"`
 	Labels     []string `json:"labels"`

--- a/internal/github/subissues.go
+++ b/internal/github/subissues.go
@@ -12,11 +12,15 @@ import (
 const umbrellaQuery = `query($owner:String!,$name:String!,$number:Int!){
   repository(owner:$owner,name:$name){
     issue(number:$number){
-      number title body url state
+      number title body url state createdAt updatedAt
+      author{ login }
       repository{ name nameWithOwner }
       subIssues(first:100){
+        totalCount
+        pageInfo{ hasNextPage }
         nodes{
-          number title body url state
+          number title body url state createdAt updatedAt
+          author{ login }
           repository{ name nameWithOwner }
           labels(first:20){ nodes{ name } }
         }
@@ -39,6 +43,10 @@ type gqlUmbrellaResponse struct {
 type gqlUmbrellaIssue struct {
 	gqlIssue
 	SubIssues struct {
+		TotalCount int `json:"totalCount"`
+		PageInfo   struct {
+			HasNextPage bool `json:"hasNextPage"`
+		} `json:"pageInfo"`
 		Nodes []gqlIssue `json:"nodes"`
 	} `json:"subIssues"`
 }
@@ -77,6 +85,11 @@ func fetchUmbrellaWith(e execer, repo string, number int) (umbrella Issue, subs 
 	}
 
 	node := resp.Data.Repository.Issue
+	// Refuse to plan from a truncated sub-issue set rather than silently
+	// materializing an incomplete DAG. (first:100 is the page size.)
+	if node.SubIssues.PageInfo.HasNextPage {
+		return Issue{}, nil, fmt.Errorf("umbrella %s#%d has more than 100 sub-issues (%d); pagination not yet supported", repo, number, node.SubIssues.TotalCount)
+	}
 	umbrellas := convertIssues([]gqlIssue{node.gqlIssue})
 	if len(umbrellas) == 0 {
 		return Issue{}, nil, fmt.Errorf("issue %s#%d is not a convertible issue", repo, number)

--- a/internal/github/subissues.go
+++ b/internal/github/subissues.go
@@ -1,0 +1,95 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// umbrellaQuery fetches an umbrella issue together with its native GitHub
+// sub-issues in one round trip. The subIssues connection requires the
+// sub_issues GraphQL feature, requested via the GraphQL-Features header.
+const umbrellaQuery = `query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){
+    issue(number:$number){
+      number title body url state
+      repository{ name nameWithOwner }
+      subIssues(first:100){
+        nodes{
+          number title body url state
+          repository{ name nameWithOwner }
+          labels(first:20){ nodes{ name } }
+        }
+      }
+    }
+  }
+}`
+
+type gqlUmbrellaResponse struct {
+	Data struct {
+		Repository struct {
+			Issue *gqlUmbrellaIssue `json:"issue"`
+		} `json:"repository"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+type gqlUmbrellaIssue struct {
+	gqlIssue
+	SubIssues struct {
+		Nodes []gqlIssue `json:"nodes"`
+	} `json:"subIssues"`
+}
+
+// FetchUmbrella returns an umbrella issue and its GitHub sub-issues. repo is
+// "owner/name". Sub-issues come back in the order GitHub lists them.
+func FetchUmbrella(repo string, number int) (umbrella Issue, subs []Issue, err error) {
+	return fetchUmbrellaWith(defaultExecer, repo, number)
+}
+
+func fetchUmbrellaWith(e execer, repo string, number int) (umbrella Issue, subs []Issue, err error) {
+	owner, name, ok := splitOwnerRepo(repo)
+	if !ok {
+		return Issue{}, nil, fmt.Errorf("invalid repo %q (want owner/name)", repo)
+	}
+	httpResp, err := runGHAPIWith(e, "", "graphql",
+		"-H", "GraphQL-Features: sub_issues",
+		"-f", "query="+umbrellaQuery,
+		"-f", "owner="+owner,
+		"-f", "name="+name,
+		"-F", fmt.Sprintf("number=%d", number),
+	)
+	if err != nil {
+		return Issue{}, nil, fmt.Errorf("gh api graphql: %s: %w", sanitizeGHOutput(httpResp.body), err)
+	}
+
+	var resp gqlUmbrellaResponse
+	if err := json.Unmarshal(httpResp.body, &resp); err != nil {
+		return Issue{}, nil, fmt.Errorf("parse graphql response: %w", err)
+	}
+	if len(resp.Errors) > 0 {
+		return Issue{}, nil, fmt.Errorf("graphql: %s", resp.Errors[0].Message)
+	}
+	if resp.Data.Repository.Issue == nil {
+		return Issue{}, nil, fmt.Errorf("issue %s#%d not found", repo, number)
+	}
+
+	node := resp.Data.Repository.Issue
+	umbrellas := convertIssues([]gqlIssue{node.gqlIssue})
+	if len(umbrellas) == 0 {
+		return Issue{}, nil, fmt.Errorf("issue %s#%d is not a convertible issue", repo, number)
+	}
+	return umbrellas[0], convertIssues(node.SubIssues.Nodes), nil
+}
+
+// splitOwnerRepo splits "owner/name" into its parts. ok is false when either
+// half is empty.
+func splitOwnerRepo(repo string) (owner, name string, ok bool) {
+	owner, name, ok = strings.Cut(repo, "/")
+	if !ok || owner == "" || name == "" {
+		return "", "", false
+	}
+	return owner, name, true
+}

--- a/internal/github/subissues_test.go
+++ b/internal/github/subissues_test.go
@@ -41,6 +41,13 @@ func TestFetchUmbrellaWith(t *testing.T) {
 			wantSubs:  nil,
 		},
 		{
+			name: "truncated sub-issue set is rejected",
+			output: `{"data":{"repository":{"issue":{` +
+				`"number":100,"title":"big","url":"https://github.com/o/r/issues/100","state":"OPEN","repository":{"name":"r","nameWithOwner":"o/r"},` +
+				`"subIssues":{"totalCount":150,"pageInfo":{"hasNextPage":true},"nodes":[]}}}}}`,
+			wantErr: "more than 100 sub-issues",
+		},
+		{
 			name:    "issue not found",
 			output:  `{"data":{"repository":{"issue":null}}}`,
 			wantErr: "not found",

--- a/internal/github/subissues_test.go
+++ b/internal/github/subissues_test.go
@@ -1,0 +1,115 @@
+package github
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func umbrellaResponse(umbrella, subNodes string) string {
+	return `{"data":{"repository":{"issue":{` + umbrella +
+		`,"subIssues":{"nodes":` + subNodes + `}}}}}`
+}
+
+func TestFetchUmbrellaWith(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		output    string
+		execErr   error
+		wantTitle string
+		wantSubs  []int // sub-issue numbers expected, in order
+		wantErr   string
+	}{
+		{
+			name: "umbrella with two sub-issues",
+			output: umbrellaResponse(
+				`"number":100,"title":"umbrella","body":"track","url":"https://github.com/o/r/issues/100","state":"OPEN","repository":{"name":"r","nameWithOwner":"o/r"}`,
+				`[
+					{"number":1,"title":"first","body":"b1","url":"https://github.com/o/r/issues/1","state":"OPEN","repository":{"name":"r","nameWithOwner":"o/r"},"labels":{"nodes":[{"name":"tech-debt"}]}},
+					{"number":2,"title":"second","body":"b2","url":"https://github.com/o/r/issues/2","state":"OPEN","repository":{"name":"r","nameWithOwner":"o/r"},"labels":{"nodes":[]}}
+				]`),
+			wantTitle: "umbrella",
+			wantSubs:  []int{1, 2},
+		},
+		{
+			name: "umbrella with no sub-issues",
+			output: umbrellaResponse(
+				`"number":100,"title":"empty","body":"","url":"https://github.com/o/r/issues/100","state":"OPEN","repository":{"name":"r","nameWithOwner":"o/r"}`,
+				`[]`),
+			wantTitle: "empty",
+			wantSubs:  nil,
+		},
+		{
+			name:    "issue not found",
+			output:  `{"data":{"repository":{"issue":null}}}`,
+			wantErr: "not found",
+		},
+		{
+			name:    "graphql error",
+			output:  `{"errors":[{"message":"sub_issues feature unavailable"}]}`,
+			wantErr: "graphql: sub_issues feature unavailable",
+		},
+		{
+			name:    "malformed json",
+			output:  "not json",
+			wantErr: "parse graphql response",
+		},
+		{
+			name:    "exec error",
+			output:  "gh: bad credentials",
+			execErr: fmt.Errorf("exit 1"),
+			wantErr: "gh api graphql",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fe := &fakeExecer{output: []byte(tt.output), err: tt.execErr}
+			umb, subs, err := fetchUmbrellaWith(fe, "o/r", 100)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if umb.Title != tt.wantTitle {
+				t.Fatalf("umbrella title = %q, want %q", umb.Title, tt.wantTitle)
+			}
+			if len(subs) != len(tt.wantSubs) {
+				t.Fatalf("got %d sub-issues, want %d", len(subs), len(tt.wantSubs))
+			}
+			for i, n := range tt.wantSubs {
+				if subs[i].Number != n {
+					t.Fatalf("sub[%d].Number = %d, want %d", i, subs[i].Number, n)
+				}
+			}
+		})
+	}
+}
+
+func TestSplitOwnerRepo(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in          string
+		owner, name string
+		ok          bool
+	}{
+		{"Automaat/sybra", "Automaat", "sybra", true},
+		{"o/r", "o", "r", true},
+		{"noSlash", "", "", false},
+		{"/r", "", "", false},
+		{"o/", "", "", false},
+		{"", "", "", false},
+	}
+	for _, c := range cases {
+		o, n, ok := splitOwnerRepo(c.in)
+		if o != c.owner || n != c.name || ok != c.ok {
+			t.Errorf("splitOwnerRepo(%q) = (%q,%q,%v), want (%q,%q,%v)", c.in, o, n, ok, c.owner, c.name, c.ok)
+		}
+	}
+}

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -29,7 +29,7 @@ func (r *Recovery) RestartStaleInProgress() {
 	}
 	for i := range tasks {
 		t := tasks[i]
-		if t.TaskType == task.TaskTypeChat {
+		if t.TaskType == task.TaskTypeChat || t.TaskType == task.TaskTypeUmbrella {
 			continue
 		}
 		if t.Status != task.StatusInProgress {

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -7,14 +7,10 @@ import (
 	"github.com/Automaat/sybra/internal/umbrella"
 )
 
-// umbrellaGatedTag marks a child task that is held in `blocked` specifically by
-// the umbrella dependency gate (set by the expander when the child is
-// materialized). It distinguishes umbrella gating from the unrelated `blocked`
-// the human-review automation uses for a contained Sybra bug, so the gate only
-// releases tasks it is actually responsible for. The gate strips the tag on
-// release, so a child that later re-enters `blocked` for a different reason is
-// never re-released.
-const umbrellaGatedTag = "umbrella-gated"
+// umbrellaGatedTag is the tag the expander sets on a gate-blocked child; the
+// gate requires it to release and strips it on release. Aliased from the
+// umbrella package so the CLI expander and this gate cannot drift.
+const umbrellaGatedTag = umbrella.GatedTag
 
 // releaseUnblockedChildren scans umbrella child tasks held in `blocked` by the
 // gate and releases those whose dependencies have all reached `done`, in

--- a/internal/umbrella/dag.go
+++ b/internal/umbrella/dag.go
@@ -12,6 +12,13 @@ import (
 	"strings"
 )
 
+// GatedTag marks a child task held in `blocked` specifically by the umbrella
+// dependency gate. It distinguishes umbrella gating from the unrelated
+// `blocked` the human-review automation uses for a contained Sybra bug, so the
+// gate only releases tasks it is responsible for. The expander sets it; the
+// gate strips it on release.
+const GatedTag = "umbrella-gated"
+
 // Node is the minimal projection of a task the dependency DAG reasons about.
 type Node struct {
 	ID        string   // task ID
@@ -128,6 +135,11 @@ func (g *Graph) CyclicUmbrellas() []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// HasCycle reports whether the graph contains any dependency cycle.
+func (g *Graph) HasCycle() bool {
+	return len(g.cycleMembers()) > 0
 }
 
 // depsSatisfied reports whether every dependency of node i resolves to a known

--- a/internal/umbrella/materialize.go
+++ b/internal/umbrella/materialize.go
@@ -1,0 +1,42 @@
+package umbrella
+
+// ChildSpec is one child task an umbrella expansion will create: its source
+// sub-issue content plus the dependency edges the planner assigned.
+type ChildSpec struct {
+	Title     string
+	Body      string
+	Issue     string // canonical issue ref/URL this child implements
+	DependsOn []string
+	Track     string
+}
+
+// ChildSpecs computes the child tasks to create for an umbrella expansion. It
+// is idempotent: a sub-issue whose ref is already in existingRefs (a task
+// exists for it) is skipped, so re-expanding an umbrella only materializes
+// newly added sub-issues. existingRefs keys are normalized issue refs
+// (NormalizeIssueRef). Plan children must already be validated against subs.
+func ChildSpecs(plan Plan, subs []SubIssue, existingRefs map[string]bool) []ChildSpec {
+	byRef := make(map[string]SubIssue, len(subs))
+	for _, s := range subs {
+		byRef[NormalizeIssueRef(s.Ref)] = s
+	}
+	var specs []ChildSpec
+	for _, c := range plan.Children {
+		key := NormalizeIssueRef(c.Ref)
+		if existingRefs[key] {
+			continue
+		}
+		s, ok := byRef[key]
+		if !ok {
+			continue
+		}
+		specs = append(specs, ChildSpec{
+			Title:     s.Title,
+			Body:      s.Body,
+			Issue:     s.Ref,
+			DependsOn: c.DependsOn,
+			Track:     c.Track,
+		})
+	}
+	return specs
+}

--- a/internal/umbrella/materialize.go
+++ b/internal/umbrella/materialize.go
@@ -10,31 +10,47 @@ type ChildSpec struct {
 	Track     string
 }
 
-// ChildSpecs computes the child tasks to create for an umbrella expansion. It
-// is idempotent: a sub-issue whose ref is already in existingRefs (a task
-// exists for it) is skipped, so re-expanding an umbrella only materializes
-// newly added sub-issues. existingRefs keys are normalized issue refs
-// (NormalizeIssueRef). Plan children must already be validated against subs.
+// ChildSpecs computes the child tasks to create for an umbrella expansion from
+// a resolved, validated plan. It:
+//   - skips a sub-issue that already has a task (idempotent re-expansion),
+//   - skips a closed sub-issue (the work is done — no child),
+//   - drops a dependency that points at a closed sub-issue (already satisfied,
+//     and it would otherwise have no task to resolve against and block forever).
+//
+// existingRefs keys are normalized issue refs (NormalizeIssueRef). Plan child
+// refs must already be canonical (see Plan.resolve).
 func ChildSpecs(plan Plan, subs []SubIssue, existingRefs map[string]bool) []ChildSpec {
 	byRef := make(map[string]SubIssue, len(subs))
+	closed := make(map[string]bool, len(subs))
 	for _, s := range subs {
-		byRef[NormalizeIssueRef(s.Ref)] = s
+		key := NormalizeIssueRef(s.Ref)
+		byRef[key] = s
+		if s.Closed {
+			closed[key] = true
+		}
 	}
+
 	var specs []ChildSpec
 	for _, c := range plan.Children {
 		key := NormalizeIssueRef(c.Ref)
-		if existingRefs[key] {
+		if existingRefs[key] || closed[key] {
 			continue
 		}
 		s, ok := byRef[key]
 		if !ok {
 			continue
 		}
+		deps := make([]string, 0, len(c.DependsOn))
+		for _, d := range c.DependsOn {
+			if !closed[NormalizeIssueRef(d)] {
+				deps = append(deps, d)
+			}
+		}
 		specs = append(specs, ChildSpec{
 			Title:     s.Title,
 			Body:      s.Body,
 			Issue:     s.Ref,
-			DependsOn: c.DependsOn,
+			DependsOn: deps,
 			Track:     c.Track,
 		})
 	}

--- a/internal/umbrella/materialize_test.go
+++ b/internal/umbrella/materialize_test.go
@@ -1,6 +1,9 @@
 package umbrella
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestChildSpecs(t *testing.T) {
 	t.Parallel()
@@ -39,6 +42,29 @@ func TestChildSpecs(t *testing.T) {
 		specs := ChildSpecs(plan, ss, existing)
 		if len(specs) != 1 || specs[0].Issue != "o/r#3" {
 			t.Fatalf("re-expansion should only create #3, got %+v", specs)
+		}
+	})
+
+	t.Run("closed sub-issue skipped and dropped as a dependency", func(t *testing.T) {
+		t.Parallel()
+		// #1 is already closed (done). It must not become a child, and #2/#3's
+		// dependency on it must be dropped (it has no task to gate against).
+		closedSubs := []SubIssue{
+			{Ref: "o/r#1", Title: "first", Closed: true},
+			{Ref: "o/r#2", Title: "second"},
+			{Ref: "o/r#3", Title: "third"},
+		}
+		specs := ChildSpecs(plan, closedSubs, nil)
+		if len(specs) != 2 {
+			t.Fatalf("closed #1 should be skipped, got %d specs: %+v", len(specs), specs)
+		}
+		for _, s := range specs {
+			if s.Issue == "o/r#1" {
+				t.Fatal("closed sub-issue must not be materialized")
+			}
+			if slices.Contains(s.DependsOn, "o/r#1") {
+				t.Fatalf("dependency on closed #1 must be dropped: %+v", s)
+			}
 		}
 	})
 }

--- a/internal/umbrella/materialize_test.go
+++ b/internal/umbrella/materialize_test.go
@@ -1,0 +1,44 @@
+package umbrella
+
+import "testing"
+
+func TestChildSpecs(t *testing.T) {
+	t.Parallel()
+	plan := Plan{Children: []PlannedChild{
+		{Ref: "o/r#1", DependsOn: nil, Track: "A"},
+		{Ref: "o/r#2", DependsOn: []string{"o/r#1"}, Track: "A"},
+		{Ref: "o/r#3", DependsOn: []string{"o/r#1"}, Track: "B"},
+	}}
+	ss := []SubIssue{
+		{Ref: "o/r#1", Title: "first", Body: "b1"},
+		{Ref: "o/r#2", Title: "second", Body: "b2"},
+		{Ref: "o/r#3", Title: "third", Body: "b3"},
+	}
+
+	t.Run("creates all when none exist", func(t *testing.T) {
+		t.Parallel()
+		specs := ChildSpecs(plan, ss, nil)
+		if len(specs) != 3 {
+			t.Fatalf("got %d specs, want 3", len(specs))
+		}
+		if specs[0].Title != "first" || specs[0].Body != "b1" || specs[0].Issue != "o/r#1" {
+			t.Errorf("spec[0] not populated from sub-issue: %+v", specs[0])
+		}
+		if specs[1].DependsOn[0] != "o/r#1" {
+			t.Errorf("spec[1] deps = %v", specs[1].DependsOn)
+		}
+	})
+
+	t.Run("idempotent: skips already-materialized refs", func(t *testing.T) {
+		t.Parallel()
+		// #1 and #2 already have tasks (refs written in different forms).
+		existing := map[string]bool{
+			NormalizeIssueRef("https://github.com/o/r/issues/1"): true,
+			NormalizeIssueRef("o/r#2"):                           true,
+		}
+		specs := ChildSpecs(plan, ss, existing)
+		if len(specs) != 1 || specs[0].Issue != "o/r#3" {
+			t.Fatalf("re-expansion should only create #3, got %+v", specs)
+		}
+	})
+}

--- a/internal/umbrella/planner.go
+++ b/internal/umbrella/planner.go
@@ -91,7 +91,7 @@ func BuildPrompt(umbrellaRef, umbrellaBody string, subs []SubIssue) string {
 	b.WriteString(umbrellaBody)
 	b.WriteString("\n\nSub-issues (reference each by its owner/repo#number):\n")
 	for _, s := range subs {
-		line := "- " + s.Ref + " — " + strings.TrimSpace(s.Title)
+		line := "- " + NormalizeIssueRef(s.Ref) + " — " + strings.TrimSpace(s.Title)
 		if s.Closed {
 			line += " (already done)"
 		}

--- a/internal/umbrella/planner.go
+++ b/internal/umbrella/planner.go
@@ -11,11 +11,17 @@ import (
 // the planner does not specify a value.
 const DefaultMaxParallel = 5
 
+// plannerAttempts is how many times Generate re-asks the model when its output
+// fails to parse or validate. The planner is stochastic, so a fresh sample
+// often fixes a malformed or incomplete DAG.
+const plannerAttempts = 3
+
 // SubIssue is the minimal projection of a GitHub sub-issue the planner needs.
 type SubIssue struct {
-	Ref   string // issue ref (owner/repo#n or full URL)
-	Title string
-	Body  string
+	Ref    string // issue ref (owner/repo#n or full URL)
+	Title  string
+	Body   string
+	Closed bool // already completed — no child task, satisfies dependents
 }
 
 // PlannedChild is one child task the planner proposes: the sub-issue it maps
@@ -37,56 +43,76 @@ type Plan struct {
 type Runner func(ctx context.Context, prompt string) (string, error)
 
 // Generate runs the planner end to end: build the prompt, invoke the model,
-// parse and normalize the result, and validate it against the sub-issues.
+// then resolve and validate the result against the sub-issues. A malformed or
+// invalid plan is retried (the model is stochastic); a runner error is fatal.
+// All child and dependency refs in the returned plan are canonical.
 func Generate(ctx context.Context, run Runner, umbrellaRef, umbrellaBody string, subs []SubIssue) (Plan, error) {
 	if len(subs) == 0 {
 		return Plan{}, fmt.Errorf("umbrella %s has no sub-issues to expand", umbrellaRef)
 	}
-	raw, err := run(ctx, BuildPrompt(umbrellaRef, umbrellaBody, subs))
-	if err != nil {
-		return Plan{}, fmt.Errorf("run planner: %w", err)
+	idx := buildRefIndex(subs)
+	prompt := BuildPrompt(umbrellaRef, umbrellaBody, subs)
+
+	var lastErr error
+	for range plannerAttempts {
+		raw, err := run(ctx, prompt)
+		if err != nil {
+			return Plan{}, fmt.Errorf("run planner: %w", err)
+		}
+		plan, err := ParsePlan(raw)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if err := plan.resolve(idx); err != nil {
+			lastErr = err
+			continue
+		}
+		if err := plan.validate(subs); err != nil {
+			lastErr = err
+			continue
+		}
+		if plan.MaxParallel <= 0 {
+			plan.MaxParallel = DefaultMaxParallel
+		}
+		return plan, nil
 	}
-	plan, err := ParsePlan(raw)
-	if err != nil {
-		return Plan{}, err
-	}
-	plan.normalize(subs)
-	if err := plan.validate(subs); err != nil {
-		return Plan{}, err
-	}
-	return plan, nil
+	return Plan{}, fmt.Errorf("planner produced no valid plan in %d attempts: %w", plannerAttempts, lastErr)
 }
 
 // BuildPrompt renders the planner instruction. The model is asked to emit ONLY
-// a JSON object using the exact sub-issue refs provided, reading the umbrella
-// body for dependency edges and parallel tracks.
+// a JSON object covering every sub-issue, reading the umbrella body for
+// dependency edges and parallel tracks.
 func BuildPrompt(umbrellaRef, umbrellaBody string, subs []SubIssue) string {
 	var b strings.Builder
 	b.WriteString("You are decomposing a GitHub umbrella issue into a dependency DAG of its sub-issues.\n")
 	b.WriteString("Umbrella: " + umbrellaRef + "\n\n")
 	b.WriteString("Umbrella body:\n")
 	b.WriteString(umbrellaBody)
-	b.WriteString("\n\nSub-issues (use these exact refs):\n")
+	b.WriteString("\n\nSub-issues (reference each by its owner/repo#number):\n")
 	for _, s := range subs {
-		b.WriteString("- " + s.Ref + " — " + strings.TrimSpace(s.Title) + "\n")
+		line := "- " + s.Ref + " — " + strings.TrimSpace(s.Title)
+		if s.Closed {
+			line += " (already done)"
+		}
+		b.WriteString(line + "\n")
 	}
-	b.WriteString("\nFrom the umbrella body, infer for each sub-issue which other sub-issues it depends on")
-	b.WriteString(" (must finish first) and an optional parallel-track label. Read dependency markers")
-	b.WriteString(" like \"← #N\" (depends on N) and \"⛔ blocks all\", plus any prose describing")
-	b.WriteString(" serial vs parallel work.\n\n")
+	b.WriteString("\nFor each sub-issue, infer which other sub-issues it depends on (must finish first)")
+	b.WriteString(" and an optional parallel-track label. Read dependency markers like \"← #N\"")
+	b.WriteString(" (depends on N) and \"⛔ blocks all\", plus prose describing serial vs parallel work.\n\n")
 	b.WriteString("Output ONLY a JSON object, no prose, no code fence:\n")
 	b.WriteString(`{"children":[{"issue":"<ref>","dependsOn":["<ref>"],"track":"<label>"}],"maxParallel":<int>}` + "\n")
-	b.WriteString("Rules: include every sub-issue exactly once; dependsOn must reference only the refs above;")
-	b.WriteString(" never create a cycle; maxParallel is the max children to run at once (default 5).\n")
+	b.WriteString("Rules: include EVERY sub-issue exactly once (including done ones); dependsOn must")
+	b.WriteString(" reference only the sub-issues above; never create a cycle; maxParallel is the max")
+	b.WriteString(" children to run at once (default 5).\n")
 	return b.String()
 }
 
-// ParsePlan extracts a Plan from a model's raw stdout. It tolerates the
-// claude `--output-format json` envelope ({"result":"..."}) and a surrounding
-// code fence or prose by extracting the first balanced JSON object.
+// ParsePlan extracts a Plan from a model's raw stdout. It tolerates the claude
+// `--output-format json` envelope ({"result":"..."}) and a surrounding code
+// fence or prose by extracting the first balanced JSON object.
 func ParsePlan(raw string) (Plan, error) {
 	text := raw
-	// Unwrap the claude json envelope if present.
 	var env struct {
 		Result string `json:"result"`
 	}
@@ -138,37 +164,36 @@ func firstJSONObject(s string) (string, bool) {
 	return "", false
 }
 
-// normalize fills defaults and drops anything that does not map onto a real
-// sub-issue, so a planner that hallucinates a ref or omits maxParallel still
-// yields a usable plan rather than failing validation outright.
-func (p *Plan) normalize(subs []SubIssue) {
-	if p.MaxParallel <= 0 {
-		p.MaxParallel = DefaultMaxParallel
-	}
-	known := make(map[string]bool, len(subs))
-	for _, s := range subs {
-		known[NormalizeIssueRef(s.Ref)] = true
-	}
-	children := p.Children[:0]
-	for _, c := range p.Children {
-		if !known[NormalizeIssueRef(c.Ref)] {
-			continue
+// resolve rewrites every child and dependency ref to its canonical sub-issue
+// ref, accepting shorthand (`#N`, `N`) and URL forms. It errors loudly on a
+// ref that matches no sub-issue rather than silently dropping the edge, so a
+// planner mistake becomes a retry instead of a wrong DAG. Self-dependencies
+// are dropped (they are noise, not ordering).
+func (p *Plan) resolve(idx refIndex) error {
+	for i := range p.Children {
+		c := &p.Children[i]
+		canon, ok := idx.lookup(c.Ref)
+		if !ok {
+			return fmt.Errorf("planner referenced unknown sub-issue %q", c.Ref)
 		}
-		deps := c.DependsOn[:0]
+		c.Ref = canon
+		deps := make([]string, 0, len(c.DependsOn))
 		for _, d := range c.DependsOn {
-			if known[NormalizeIssueRef(d)] && NormalizeIssueRef(d) != NormalizeIssueRef(c.Ref) {
-				deps = append(deps, d)
+			dc, ok := idx.lookup(d)
+			if !ok {
+				return fmt.Errorf("child %s has unresolved dependency %q", canon, d)
+			}
+			if dc != canon {
+				deps = append(deps, dc)
 			}
 		}
 		c.DependsOn = deps
-		children = append(children, c)
 	}
-	p.Children = children
+	return nil
 }
 
 // validate confirms the plan covers every sub-issue exactly once and is
-// acyclic. normalize must run first so refs are already constrained to the
-// sub-issue set.
+// acyclic. resolve must run first so all refs are canonical.
 func (p *Plan) validate(subs []SubIssue) error {
 	if len(p.Children) != len(subs) {
 		return fmt.Errorf("planner covered %d of %d sub-issues", len(p.Children), len(subs))
@@ -176,15 +201,75 @@ func (p *Plan) validate(subs []SubIssue) error {
 	seen := make(map[string]bool, len(p.Children))
 	nodes := make([]Node, 0, len(p.Children))
 	for _, c := range p.Children {
-		key := NormalizeIssueRef(c.Ref)
-		if seen[key] {
+		if seen[c.Ref] {
 			return fmt.Errorf("planner listed %s more than once", c.Ref)
 		}
-		seen[key] = true
+		seen[c.Ref] = true
 		nodes = append(nodes, Node{ID: c.Ref, Issue: c.Ref, DependsOn: c.DependsOn})
 	}
 	if Build(nodes).HasCycle() {
 		return fmt.Errorf("planner produced a dependency cycle")
 	}
 	return nil
+}
+
+// refIndex resolves an issue ref in any form (URL, owner/repo#n, or bare #n/n)
+// to the canonical ref of the sub-issue it names.
+type refIndex struct {
+	byNorm map[string]string // normalized ref -> canonical
+	byNum  map[string]string // issue number -> canonical (only when unambiguous)
+}
+
+func buildRefIndex(subs []SubIssue) refIndex {
+	idx := refIndex{byNorm: make(map[string]string, len(subs)), byNum: make(map[string]string, len(subs))}
+	ambiguous := map[string]bool{}
+	for _, s := range subs {
+		canon := NormalizeIssueRef(s.Ref)
+		idx.byNorm[canon] = canon
+		if n := numberOf(canon); n != "" {
+			if _, seen := idx.byNum[n]; seen {
+				ambiguous[n] = true
+			} else {
+				idx.byNum[n] = canon
+			}
+		}
+	}
+	// A number shared by sub-issues in different repos cannot be resolved from
+	// a bare "#N", so drop it from the number index.
+	for n := range ambiguous {
+		delete(idx.byNum, n)
+	}
+	return idx
+}
+
+func (idx refIndex) lookup(ref string) (string, bool) {
+	key := NormalizeIssueRef(ref)
+	if c, ok := idx.byNorm[key]; ok {
+		return c, true
+	}
+	if n := numberOf(key); n != "" {
+		if c, ok := idx.byNum[n]; ok {
+			return c, true
+		}
+	}
+	return "", false
+}
+
+// numberOf returns the trailing issue number of a ref ("o/r#12" -> "12",
+// "#12" -> "12", "12" -> "12"), or "" when the tail is not all digits.
+func numberOf(ref string) string {
+	r := ref
+	if i := strings.LastIndexByte(r, '#'); i >= 0 {
+		r = r[i+1:]
+	}
+	r = strings.TrimSpace(r)
+	if r == "" {
+		return ""
+	}
+	for i := range len(r) {
+		if r[i] < '0' || r[i] > '9' {
+			return ""
+		}
+	}
+	return r
 }

--- a/internal/umbrella/planner.go
+++ b/internal/umbrella/planner.go
@@ -1,0 +1,190 @@
+package umbrella
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// DefaultMaxParallel bounds how many children of one umbrella run at once when
+// the planner does not specify a value.
+const DefaultMaxParallel = 5
+
+// SubIssue is the minimal projection of a GitHub sub-issue the planner needs.
+type SubIssue struct {
+	Ref   string // issue ref (owner/repo#n or full URL)
+	Title string
+	Body  string
+}
+
+// PlannedChild is one child task the planner proposes: the sub-issue it maps
+// to, the issue refs it depends on, and an advisory parallel-track label.
+type PlannedChild struct {
+	Ref       string   `json:"issue"`
+	DependsOn []string `json:"dependsOn"`
+	Track     string   `json:"track,omitempty"`
+}
+
+// Plan is the dependency DAG the planner extracts from an umbrella body.
+type Plan struct {
+	Children    []PlannedChild `json:"children"`
+	MaxParallel int            `json:"maxParallel"`
+}
+
+// Runner executes one planner prompt and returns the model's raw stdout.
+// Injected so the planner logic is unit-testable without spawning a CLI.
+type Runner func(ctx context.Context, prompt string) (string, error)
+
+// Generate runs the planner end to end: build the prompt, invoke the model,
+// parse and normalize the result, and validate it against the sub-issues.
+func Generate(ctx context.Context, run Runner, umbrellaRef, umbrellaBody string, subs []SubIssue) (Plan, error) {
+	if len(subs) == 0 {
+		return Plan{}, fmt.Errorf("umbrella %s has no sub-issues to expand", umbrellaRef)
+	}
+	raw, err := run(ctx, BuildPrompt(umbrellaRef, umbrellaBody, subs))
+	if err != nil {
+		return Plan{}, fmt.Errorf("run planner: %w", err)
+	}
+	plan, err := ParsePlan(raw)
+	if err != nil {
+		return Plan{}, err
+	}
+	plan.normalize(subs)
+	if err := plan.validate(subs); err != nil {
+		return Plan{}, err
+	}
+	return plan, nil
+}
+
+// BuildPrompt renders the planner instruction. The model is asked to emit ONLY
+// a JSON object using the exact sub-issue refs provided, reading the umbrella
+// body for dependency edges and parallel tracks.
+func BuildPrompt(umbrellaRef, umbrellaBody string, subs []SubIssue) string {
+	var b strings.Builder
+	b.WriteString("You are decomposing a GitHub umbrella issue into a dependency DAG of its sub-issues.\n")
+	b.WriteString("Umbrella: " + umbrellaRef + "\n\n")
+	b.WriteString("Umbrella body:\n")
+	b.WriteString(umbrellaBody)
+	b.WriteString("\n\nSub-issues (use these exact refs):\n")
+	for _, s := range subs {
+		b.WriteString("- " + s.Ref + " — " + strings.TrimSpace(s.Title) + "\n")
+	}
+	b.WriteString("\nFrom the umbrella body, infer for each sub-issue which other sub-issues it depends on")
+	b.WriteString(" (must finish first) and an optional parallel-track label. Read dependency markers")
+	b.WriteString(" like \"← #N\" (depends on N) and \"⛔ blocks all\", plus any prose describing")
+	b.WriteString(" serial vs parallel work.\n\n")
+	b.WriteString("Output ONLY a JSON object, no prose, no code fence:\n")
+	b.WriteString(`{"children":[{"issue":"<ref>","dependsOn":["<ref>"],"track":"<label>"}],"maxParallel":<int>}` + "\n")
+	b.WriteString("Rules: include every sub-issue exactly once; dependsOn must reference only the refs above;")
+	b.WriteString(" never create a cycle; maxParallel is the max children to run at once (default 5).\n")
+	return b.String()
+}
+
+// ParsePlan extracts a Plan from a model's raw stdout. It tolerates the
+// claude `--output-format json` envelope ({"result":"..."}) and a surrounding
+// code fence or prose by extracting the first balanced JSON object.
+func ParsePlan(raw string) (Plan, error) {
+	text := raw
+	// Unwrap the claude json envelope if present.
+	var env struct {
+		Result string `json:"result"`
+	}
+	if err := json.Unmarshal([]byte(raw), &env); err == nil && env.Result != "" {
+		text = env.Result
+	}
+
+	obj, ok := firstJSONObject(text)
+	if !ok {
+		return Plan{}, fmt.Errorf("planner output contains no JSON object")
+	}
+	var plan Plan
+	if err := json.Unmarshal([]byte(obj), &plan); err != nil {
+		return Plan{}, fmt.Errorf("parse planner JSON: %w", err)
+	}
+	return plan, nil
+}
+
+// firstJSONObject returns the first brace-balanced JSON object substring in s,
+// ignoring braces inside string literals. ok is false when none is found.
+func firstJSONObject(s string) (string, bool) {
+	start := strings.IndexByte(s, '{')
+	if start < 0 {
+		return "", false
+	}
+	depth := 0
+	inStr := false
+	escaped := false
+	for i := start; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case escaped:
+			escaped = false
+		case c == '\\' && inStr:
+			escaped = true
+		case c == '"':
+			inStr = !inStr
+		case inStr:
+			// skip
+		case c == '{':
+			depth++
+		case c == '}':
+			depth--
+			if depth == 0 {
+				return s[start : i+1], true
+			}
+		}
+	}
+	return "", false
+}
+
+// normalize fills defaults and drops anything that does not map onto a real
+// sub-issue, so a planner that hallucinates a ref or omits maxParallel still
+// yields a usable plan rather than failing validation outright.
+func (p *Plan) normalize(subs []SubIssue) {
+	if p.MaxParallel <= 0 {
+		p.MaxParallel = DefaultMaxParallel
+	}
+	known := make(map[string]bool, len(subs))
+	for _, s := range subs {
+		known[NormalizeIssueRef(s.Ref)] = true
+	}
+	children := p.Children[:0]
+	for _, c := range p.Children {
+		if !known[NormalizeIssueRef(c.Ref)] {
+			continue
+		}
+		deps := c.DependsOn[:0]
+		for _, d := range c.DependsOn {
+			if known[NormalizeIssueRef(d)] && NormalizeIssueRef(d) != NormalizeIssueRef(c.Ref) {
+				deps = append(deps, d)
+			}
+		}
+		c.DependsOn = deps
+		children = append(children, c)
+	}
+	p.Children = children
+}
+
+// validate confirms the plan covers every sub-issue exactly once and is
+// acyclic. normalize must run first so refs are already constrained to the
+// sub-issue set.
+func (p *Plan) validate(subs []SubIssue) error {
+	if len(p.Children) != len(subs) {
+		return fmt.Errorf("planner covered %d of %d sub-issues", len(p.Children), len(subs))
+	}
+	seen := make(map[string]bool, len(p.Children))
+	nodes := make([]Node, 0, len(p.Children))
+	for _, c := range p.Children {
+		key := NormalizeIssueRef(c.Ref)
+		if seen[key] {
+			return fmt.Errorf("planner listed %s more than once", c.Ref)
+		}
+		seen[key] = true
+		nodes = append(nodes, Node{ID: c.Ref, Issue: c.Ref, DependsOn: c.DependsOn})
+	}
+	if Build(nodes).HasCycle() {
+		return fmt.Errorf("planner produced a dependency cycle")
+	}
+	return nil
+}

--- a/internal/umbrella/planner_test.go
+++ b/internal/umbrella/planner_test.go
@@ -1,0 +1,199 @@
+package umbrella
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func subs(refs ...string) []SubIssue {
+	out := make([]SubIssue, len(refs))
+	for i, r := range refs {
+		out[i] = SubIssue{Ref: r, Title: "t" + r}
+	}
+	return out
+}
+
+func TestFirstJSONObject(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, in, want string
+		ok             bool
+	}{
+		{"plain", `{"a":1}`, `{"a":1}`, true},
+		{"prose around", "sure:\n{\"a\":1}\ndone", `{"a":1}`, true},
+		{"code fence", "```json\n{\"a\":1}\n```", `{"a":1}`, true},
+		{"nested", `{"a":{"b":2}}`, `{"a":{"b":2}}`, true},
+		{"brace in string", `{"a":"}"}`, `{"a":"}"}`, true},
+		{"escaped quote in string", `{"a":"x\"}y"}`, `{"a":"x\"}y"}`, true},
+		{"none", "no json here", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := firstJSONObject(c.in)
+			if ok != c.ok || got != c.want {
+				t.Fatalf("firstJSONObject(%q) = (%q,%v), want (%q,%v)", c.in, got, ok, c.want, c.ok)
+			}
+		})
+	}
+}
+
+func TestParsePlan(t *testing.T) {
+	t.Parallel()
+	want := `{"children":[{"issue":"o/r#1","dependsOn":[]}],"maxParallel":3}`
+	cases := []struct {
+		name, raw string
+	}{
+		{"plain json", want},
+		{"claude envelope", `{"type":"result","result":"` + strings.ReplaceAll(want, `"`, `\"`) + `"}`},
+		{"fenced in prose", "Here is the plan:\n```json\n" + want + "\n```"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			p, err := ParsePlan(c.raw)
+			if err != nil {
+				t.Fatalf("ParsePlan: %v", err)
+			}
+			if len(p.Children) != 1 || p.Children[0].Ref != "o/r#1" || p.MaxParallel != 3 {
+				t.Fatalf("unexpected plan: %+v", p)
+			}
+		})
+	}
+
+	if _, err := ParsePlan("no json at all"); err == nil {
+		t.Error("expected error on output with no JSON object")
+	}
+}
+
+func TestPlanNormalize(t *testing.T) {
+	t.Parallel()
+	p := Plan{
+		Children: []PlannedChild{
+			{Ref: "o/r#1", DependsOn: nil},
+			{Ref: "o/r#2", DependsOn: []string{"o/r#1", "o/r#999", "o/r#2"}}, // unknown + self dep
+			{Ref: "o/r#404"}, // hallucinated ref
+		},
+		MaxParallel: 0,
+	}
+	p.normalize(subs("o/r#1", "o/r#2"))
+
+	if p.MaxParallel != DefaultMaxParallel {
+		t.Errorf("MaxParallel = %d, want default %d", p.MaxParallel, DefaultMaxParallel)
+	}
+	if len(p.Children) != 2 {
+		t.Fatalf("hallucinated child not dropped: %+v", p.Children)
+	}
+	deps := p.Children[1].DependsOn
+	if len(deps) != 1 || deps[0] != "o/r#1" {
+		t.Errorf("deps = %v, want [o/r#1] (unknown + self dep dropped)", deps)
+	}
+}
+
+func TestPlanValidate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		plan    Plan
+		subs    []SubIssue
+		wantErr string
+	}{
+		{
+			name: "valid acyclic",
+			plan: Plan{Children: []PlannedChild{
+				{Ref: "o/r#1"},
+				{Ref: "o/r#2", DependsOn: []string{"o/r#1"}},
+			}},
+			subs: subs("o/r#1", "o/r#2"),
+		},
+		{
+			name:    "incomplete coverage",
+			plan:    Plan{Children: []PlannedChild{{Ref: "o/r#1"}}},
+			subs:    subs("o/r#1", "o/r#2"),
+			wantErr: "covered 1 of 2",
+		},
+		{
+			name: "duplicate child",
+			plan: Plan{Children: []PlannedChild{
+				{Ref: "o/r#1"},
+				{Ref: "o/r#1"},
+			}},
+			subs:    subs("o/r#1", "o/r#2"),
+			wantErr: "more than once",
+		},
+		{
+			name: "cycle",
+			plan: Plan{Children: []PlannedChild{
+				{Ref: "o/r#1", DependsOn: []string{"o/r#2"}},
+				{Ref: "o/r#2", DependsOn: []string{"o/r#1"}},
+			}},
+			subs:    subs("o/r#1", "o/r#2"),
+			wantErr: "cycle",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.plan.validate(tt.subs)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected err: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("err = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGenerate(t *testing.T) {
+	t.Parallel()
+	good := `{"children":[{"issue":"o/r#1","dependsOn":[]},{"issue":"o/r#2","dependsOn":["o/r#1"]}],"maxParallel":2}`
+
+	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+		run := func(_ context.Context, prompt string) (string, error) {
+			// Prompt must carry the sub-issue refs so the model can use them.
+			if !strings.Contains(prompt, "o/r#1") || !strings.Contains(prompt, "o/r#2") {
+				t.Errorf("prompt missing sub-issue refs:\n%s", prompt)
+			}
+			return good, nil
+		}
+		plan, err := Generate(context.Background(), run, "o/r#100", "body", subs("o/r#1", "o/r#2"))
+		if err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		if plan.MaxParallel != 2 || len(plan.Children) != 2 {
+			t.Fatalf("unexpected plan: %+v", plan)
+		}
+	})
+
+	t.Run("runner error", func(t *testing.T) {
+		t.Parallel()
+		run := func(_ context.Context, _ string) (string, error) { return "", errors.New("boom") }
+		if _, err := Generate(context.Background(), run, "o/r#100", "body", subs("o/r#1")); err == nil {
+			t.Error("expected runner error to propagate")
+		}
+	})
+
+	t.Run("no sub-issues", func(t *testing.T) {
+		t.Parallel()
+		run := func(_ context.Context, _ string) (string, error) { return good, nil }
+		if _, err := Generate(context.Background(), run, "o/r#100", "body", nil); err == nil {
+			t.Error("expected error when umbrella has no sub-issues")
+		}
+	})
+
+	t.Run("cycle rejected", func(t *testing.T) {
+		t.Parallel()
+		cyclic := `{"children":[{"issue":"o/r#1","dependsOn":["o/r#2"]},{"issue":"o/r#2","dependsOn":["o/r#1"]}],"maxParallel":2}`
+		run := func(_ context.Context, _ string) (string, error) { return cyclic, nil }
+		if _, err := Generate(context.Background(), run, "o/r#100", "body", subs("o/r#1", "o/r#2")); err == nil {
+			t.Error("expected cycle to be rejected")
+		}
+	})
+}

--- a/internal/umbrella/planner_test.go
+++ b/internal/umbrella/planner_test.go
@@ -68,28 +68,44 @@ func TestParsePlan(t *testing.T) {
 	}
 }
 
-func TestPlanNormalize(t *testing.T) {
+func TestPlanResolve(t *testing.T) {
 	t.Parallel()
-	p := Plan{
-		Children: []PlannedChild{
-			{Ref: "o/r#1", DependsOn: nil},
-			{Ref: "o/r#2", DependsOn: []string{"o/r#1", "o/r#999", "o/r#2"}}, // unknown + self dep
-			{Ref: "o/r#404"}, // hallucinated ref
-		},
-		MaxParallel: 0,
-	}
-	p.normalize(subs("o/r#1", "o/r#2"))
+	idx := buildRefIndex(subs("o/r#1", "o/r#2"))
 
-	if p.MaxParallel != DefaultMaxParallel {
-		t.Errorf("MaxParallel = %d, want default %d", p.MaxParallel, DefaultMaxParallel)
-	}
-	if len(p.Children) != 2 {
-		t.Fatalf("hallucinated child not dropped: %+v", p.Children)
-	}
-	deps := p.Children[1].DependsOn
-	if len(deps) != 1 || deps[0] != "o/r#1" {
-		t.Errorf("deps = %v, want [o/r#1] (unknown + self dep dropped)", deps)
-	}
+	t.Run("shorthand and self-dep", func(t *testing.T) {
+		t.Parallel()
+		// #2 depends on bare "#1" (shorthand) and on itself; resolve must
+		// canonicalize the shorthand and drop the self-dep.
+		p := Plan{Children: []PlannedChild{
+			{Ref: "o/r#1"},
+			{Ref: "https://github.com/o/r/issues/2", DependsOn: []string{"#1", "o/r#2"}},
+		}}
+		if err := p.resolve(idx); err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if p.Children[1].Ref != "o/r#2" {
+			t.Errorf("child ref not canonicalized: %q", p.Children[1].Ref)
+		}
+		if len(p.Children[1].DependsOn) != 1 || p.Children[1].DependsOn[0] != "o/r#1" {
+			t.Errorf("deps = %v, want [o/r#1] (shorthand resolved, self-dep dropped)", p.Children[1].DependsOn)
+		}
+	})
+
+	t.Run("unknown child ref errors", func(t *testing.T) {
+		t.Parallel()
+		p := Plan{Children: []PlannedChild{{Ref: "o/r#404"}}}
+		if err := p.resolve(idx); err == nil {
+			t.Error("expected error for hallucinated child ref")
+		}
+	})
+
+	t.Run("unresolved dependency errors loudly", func(t *testing.T) {
+		t.Parallel()
+		p := Plan{Children: []PlannedChild{{Ref: "o/r#1", DependsOn: []string{"o/r#999"}}}}
+		if err := p.resolve(idx); err == nil {
+			t.Error("expected error for unresolved dependency (must not be silently dropped)")
+		}
+	})
 }
 
 func TestPlanValidate(t *testing.T) {
@@ -169,6 +185,27 @@ func TestGenerate(t *testing.T) {
 		}
 		if plan.MaxParallel != 2 || len(plan.Children) != 2 {
 			t.Fatalf("unexpected plan: %+v", plan)
+		}
+	})
+
+	t.Run("shorthand deps resolve end to end", func(t *testing.T) {
+		t.Parallel()
+		// Model emits the dependency in bare "#1" shorthand — the natural form
+		// given the prompt's "← #N" markers. Must resolve, not silently drop.
+		shorthand := `{"children":[{"issue":"o/r#1","dependsOn":[]},{"issue":"o/r#2","dependsOn":["#1"]}],"maxParallel":2}`
+		run := func(_ context.Context, _ string) (string, error) { return shorthand, nil }
+		plan, err := Generate(context.Background(), run, "o/r#100", "body", subs("o/r#1", "o/r#2"))
+		if err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		var child2 PlannedChild
+		for _, c := range plan.Children {
+			if c.Ref == "o/r#2" {
+				child2 = c
+			}
+		}
+		if len(child2.DependsOn) != 1 || child2.DependsOn[0] != "o/r#1" {
+			t.Fatalf("shorthand dep not resolved: %+v", child2)
 		}
 	})
 

--- a/internal/umbrella/tags.go
+++ b/internal/umbrella/tags.go
@@ -1,0 +1,46 @@
+package umbrella
+
+import (
+	"strconv"
+	"strings"
+)
+
+// MaxParallelTagPrefix carries the planner's max-parallel value on the tracker
+// task so the cap can be enforced without re-planning. Value is the integer
+// suffix, e.g. "umbrella-max-parallel:5".
+const MaxParallelTagPrefix = "umbrella-max-parallel:"
+
+// MaxParallelTag renders the tracker tag encoding n.
+func MaxParallelTag(n int) string {
+	return MaxParallelTagPrefix + strconv.Itoa(n)
+}
+
+// controlTags are Sybra-load-bearing tags a child task must not inherit from a
+// GitHub sub-issue's labels — they route the task into other automations
+// (reviews, handoff lanes, the gate itself, bug containment).
+var controlTags = map[string]bool{
+	"review":    true,
+	"blocked":   true,
+	"handoff":   true,
+	"umbrella":  true,
+	GatedTag:    true,
+	"sybra-bug": true,
+	"scrubbed":  true,
+}
+
+// InheritableLabels filters a sub-issue's GitHub labels down to those safe to
+// copy onto a child task, dropping any tag that would mis-route it into another
+// automation (exact control tags, or the handoff-/umbrella-/monitor: families).
+func InheritableLabels(labels []string) []string {
+	out := make([]string, 0, len(labels))
+	for _, l := range labels {
+		if controlTags[l] ||
+			strings.HasPrefix(l, "handoff-") ||
+			strings.HasPrefix(l, "umbrella-") ||
+			strings.HasPrefix(l, "monitor:") {
+			continue
+		}
+		out = append(out, l)
+	}
+	return out
+}

--- a/internal/umbrella/tags_test.go
+++ b/internal/umbrella/tags_test.go
@@ -1,0 +1,36 @@
+package umbrella
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestInheritableLabels(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"keeps plain labels", []string{"backend", "tech-debt"}, []string{"backend", "tech-debt"}},
+		{"drops exact control tags", []string{"review", "blocked", "handoff", "umbrella", GatedTag, "sybra-bug", "scrubbed", "keep"}, []string{"keep"}},
+		{"drops control families", []string{"handoff-review", "umbrella-max-parallel:5", "monitor:loop", "ok"}, []string{"ok"}},
+		{"empty in empty out", nil, []string{}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			got := InheritableLabels(c.in)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("InheritableLabels(%v) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestMaxParallelTag(t *testing.T) {
+	t.Parallel()
+	if got := MaxParallelTag(5); got != "umbrella-max-parallel:5" {
+		t.Errorf("MaxParallelTag(5) = %q", got)
+	}
+}


### PR DESCRIPTION
## Motivation

With the dependency-DAG primitive merged (#1129), Sybra can now turn a ☂️ umbrella issue into the gated child tasks that primitive expects. The dependency edges and parallel tracks in an umbrella body are free-form prose, so extraction uses an LLM planner that emits a structured DAG, deterministically materialized into tasks — LLM proposes, code executes.

## Implementation information

- **`sybra-cli umbrella <issue-url>`** (`cmd/sybra-cli/umbrella.go`): fetch → plan → materialize. Idempotent — re-running only creates sub-issues that lack a task, and short-circuits the planner entirely when nothing is missing.
- **GitHub sub-issues** (`internal/github/subissues.go`): one GraphQL call returns the umbrella plus its native sub-issues (requires the `sub_issues` feature, sent as a header). Verified against a live umbrella.
- **LLM planner** (`internal/umbrella/planner.go`): builds a prompt over the umbrella body + sub-issue list, runs the model (injected `Runner`; the CLI shells out to `claude` with a timeout), and parses the JSON DAG out of the `--output-format json` envelope. Refs are resolved canonically — shorthand (`#N`), `owner/repo#n`, and URL forms all match — and an **unresolved dependency is a hard error** (retried), never a silently dropped edge. Output is validated for full coverage and acyclicity before use.
- **Materialization** (`internal/umbrella/materialize.go`): one `umbrella` tracker (runs no agent) plus one `blocked` + `umbrella-gated` child per open sub-issue. Closed sub-issues are skipped and dropped as dependencies (already done). Children get their own sub-issue's repo as `project_id` (sub-issues may live in another repo) and inherit only non-load-bearing labels.

The pure logic (planner parse/resolve/validate, materialization/dedup, ref index) is unit-tested; the `claude` invocation is injected so tests never spawn a process. Umbrella trackers are also skipped by restart-stale recovery (they run no agent).

Reviewed adversarially before opening — shorthand-dep resolution, cross-repo project_id, closed-sub-issue handling, the planner timeout/short-circuit, and the duplicate-DAG guard are all fixes from that pass.

Closes #1130

## Open questions

- `max_parallel` is extracted and persisted on the tracker (`umbrella-max-parallel:<n>` tag) but not yet enforced; the cap and umbrella roll-up land in #1131.

> Changelog: feat(umbrella): expand umbrella issues into a gated task DAG
