### PR TITLE
feat(umbrella): max_parallel cap + roll-up close

### DIFF
--- a/internal/github/issue_close.go
+++ b/internal/github/issue_close.go
@@ -1,0 +1,25 @@
+package github
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// CloseIssue closes a GitHub issue, optionally leaving a comment. repo is
+// "owner/name".
+func CloseIssue(repo string, number int, comment string) error {
+	return closeIssueWith(defaultExecer, repo, number, comment)
+}
+
+func closeIssueWith(e execer, repo string, number int, comment string) error {
+	args := []string{"issue", "close", strconv.Itoa(number), "--repo", repo, "--reason", "completed"}
+	if comment != "" {
+		args = append(args, "--comment", comment)
+	}
+	out, err := e.run(args...)
+	if err != nil {
+		return fmt.Errorf("gh issue close %d: %s: %w", number, strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}

--- a/internal/github/issue_close_test.go
+++ b/internal/github/issue_close_test.go
@@ -1,0 +1,42 @@
+package github
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+)
+
+func TestCloseIssueWith(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with comment", func(t *testing.T) {
+		t.Parallel()
+		rec := &recordingExecer{}
+		if err := closeIssueWith(rec, "o/r", 42, "done"); err != nil {
+			t.Fatalf("closeIssueWith: %v", err)
+		}
+		want := []string{"issue", "close", "42", "--repo", "o/r", "--reason", "completed", "--comment", "done"}
+		if !slices.Equal(rec.lastArgs, want) {
+			t.Fatalf("args = %v, want %v", rec.lastArgs, want)
+		}
+	})
+
+	t.Run("without comment omits flag", func(t *testing.T) {
+		t.Parallel()
+		rec := &recordingExecer{}
+		if err := closeIssueWith(rec, "o/r", 7, ""); err != nil {
+			t.Fatalf("closeIssueWith: %v", err)
+		}
+		if slices.Contains(rec.lastArgs, "--comment") {
+			t.Fatalf("did not expect --comment: %v", rec.lastArgs)
+		}
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		t.Parallel()
+		rec := &recordingExecer{err: fmt.Errorf("exit 1"), output: []byte("not found")}
+		if err := closeIssueWith(rec, "o/r", 9, ""); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -91,6 +91,9 @@ type App struct {
 	restartStaleErr               *logging.ErrorThrottle
 	recovery                      *recovery.Recovery
 	agentCompletion               *AgentCompletionHandler
+	// umbrellaCloseIssue closes the umbrella GitHub issue on full roll-up.
+	// nil defaults to github.CloseIssue; overridden in tests.
+	umbrellaCloseIssue func(repo string, number int, comment string) error
 
 	bgops *bgop.Tracker
 

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -198,10 +198,12 @@ func trackerRollup(st *umbrellaState, cyclic bool) (status task.Status, reason s
 }
 
 // closeUmbrellaIssue closes the umbrella's GitHub issue with a generic comment
-// (no work content). It returns retry=true only on a transient failure, so the
-// caller holds off flipping the tracker to done and tries again next tick. An
-// unparseable ref is permanent (retry=false): the tracker still completes, the
-// issue is just left for manual closing.
+// (no work content). It returns retry=true on any close failure so the caller
+// holds off flipping the tracker to done and tries again next tick (gh issue
+// close is idempotent, so re-attempts are safe); a persistently failing close
+// leaves the tracker in-progress for the operator to notice. An unparseable
+// ref is permanent (retry=false): the tracker still completes, the issue is
+// just left for manual closing.
 func (a *App) closeUmbrellaIssue(umbRef string) (retry bool) {
 	repo, number, ok := umbrella.ParseRef(umbRef)
 	if !ok {

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -15,13 +15,14 @@ const umbrellaGatedTag = umbrella.GatedTag
 
 // umbrellaState aggregates one umbrella's tracker and children for a gate tick.
 type umbrellaState struct {
-	tracker   *task.Task
-	cap       int // max children running at once
-	total     int // child task count
-	doneCount int
-	active    int // children occupying a parallelism slot
-	anyHR     bool
-	released  int // children released so far this tick (counts toward the cap)
+	tracker      *task.Task
+	cap          int // max children running at once
+	total        int // child task count
+	doneCount    int
+	active       int // children occupying a parallelism slot
+	anyHR        bool
+	anyCancelled bool
+	released     int // children released so far this tick (counts toward the cap)
 }
 
 // releaseUnblockedChildren is the umbrella gate, run every orchestrator tick.
@@ -95,6 +96,11 @@ func accumulateChild(st *umbrellaState, status task.Status) {
 	switch status {
 	case task.StatusDone:
 		st.doneCount++
+	case task.StatusCancelled:
+		// A cancelled prerequisite is a deliberate abandonment — surface it for
+		// a human rather than silently completing the umbrella or proceeding on
+		// the cancelled work (its dependents stay held; see depsSatisfied).
+		st.anyCancelled = true
 	case task.StatusHumanRequired:
 		st.anyHR = true
 		st.active++ // a stuck child still occupies a slot until resolved
@@ -156,6 +162,12 @@ func (a *App) rollupTrackers(states map[string]*umbrellaState, cyclic map[string
 		if desired == st.tracker.Status {
 			continue
 		}
+		// Close the umbrella issue BEFORE flipping the tracker to done, so a
+		// transient close failure is retried next tick rather than leaving the
+		// issue open under a done tracker that never re-attempts the close.
+		if doClose && a.closeUmbrellaIssue(st.tracker.Issue) {
+			continue
+		}
 		if _, err := a.tasks.Update(st.tracker.ID, task.Update{
 			Status:       task.Ptr(desired),
 			StatusReason: task.Ptr(reason),
@@ -164,21 +176,20 @@ func (a *App) rollupTrackers(states map[string]*umbrellaState, cyclic map[string
 			continue
 		}
 		a.logger.Info("umbrella.tracker.rollup", "task_id", st.tracker.ID, "status", desired)
-		if doClose {
-			a.closeUmbrellaIssue(st.tracker.Issue)
-		}
 	}
 }
 
 // trackerRollup decides an umbrella tracker's status from its children. A
-// cycle or a stuck (human-required) child surfaces as human-required and halts
-// only that chain; all-done closes the umbrella.
+// cycle, a stuck (human-required) child, or a cancelled child surfaces as
+// human-required (halting only that chain); all-done closes the umbrella.
 func trackerRollup(st *umbrellaState, cyclic bool) (status task.Status, reason string, doClose bool) {
 	switch {
 	case cyclic:
 		return task.StatusHumanRequired, "umbrella dependency cycle detected", false
 	case st.anyHR:
 		return task.StatusHumanRequired, "umbrella child needs attention", false
+	case st.anyCancelled:
+		return task.StatusHumanRequired, "umbrella child was cancelled", false
 	case st.total > 0 && st.doneCount == st.total:
 		return task.StatusDone, "all umbrella children complete", true
 	default:
@@ -187,12 +198,15 @@ func trackerRollup(st *umbrellaState, cyclic bool) (status task.Status, reason s
 }
 
 // closeUmbrellaIssue closes the umbrella's GitHub issue with a generic comment
-// (no work content). Best-effort: a failure is logged, not retried.
-func (a *App) closeUmbrellaIssue(umbRef string) {
+// (no work content). It returns retry=true only on a transient failure, so the
+// caller holds off flipping the tracker to done and tries again next tick. An
+// unparseable ref is permanent (retry=false): the tracker still completes, the
+// issue is just left for manual closing.
+func (a *App) closeUmbrellaIssue(umbRef string) (retry bool) {
 	repo, number, ok := umbrella.ParseRef(umbRef)
 	if !ok {
 		a.logger.Warn("umbrella.close.skip", "reason", "unparseable ref", "ref", umbRef)
-		return
+		return false
 	}
 	closeFn := a.umbrellaCloseIssue
 	if closeFn == nil {
@@ -200,7 +214,8 @@ func (a *App) closeUmbrellaIssue(umbRef string) {
 	}
 	if err := closeFn(repo, number, "All umbrella sub-tasks completed."); err != nil {
 		a.logger.Error("umbrella.close.failed", "repo", repo, "number", number, "err", err)
-		return
+		return true
 	}
 	a.logger.Info("umbrella.closed", "repo", repo, "number", number)
+	return false
 }

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -3,6 +3,7 @@ package sybra
 import (
 	"slices"
 
+	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/umbrella"
 )
@@ -12,11 +13,22 @@ import (
 // umbrella package so the CLI expander and this gate cannot drift.
 const umbrellaGatedTag = umbrella.GatedTag
 
-// releaseUnblockedChildren scans umbrella child tasks held in `blocked` by the
-// gate and releases those whose dependencies have all reached `done`, in
-// dependency order. Children caught in a dependency cycle are never released;
-// their umbrella tracker is flipped to human-required instead. Runs every
-// orchestrator tick and is a no-op when no umbrella tasks exist.
+// umbrellaState aggregates one umbrella's tracker and children for a gate tick.
+type umbrellaState struct {
+	tracker   *task.Task
+	cap       int // max children running at once
+	total     int // child task count
+	doneCount int
+	active    int // children occupying a parallelism slot
+	anyHR     bool
+	released  int // children released so far this tick (counts toward the cap)
+}
+
+// releaseUnblockedChildren is the umbrella gate, run every orchestrator tick.
+// It releases gate-blocked children whose dependencies are done — up to each
+// umbrella's max-parallel cap — and rolls each umbrella tracker's status up
+// from its children (cycle or a stuck child → human-required; all done →
+// done + close the umbrella issue). No-op when no umbrella tasks exist.
 func (a *App) releaseUnblockedChildren() {
 	tasks, err := a.tasks.List()
 	if err != nil {
@@ -24,13 +36,32 @@ func (a *App) releaseUnblockedChildren() {
 	}
 
 	byID := make(map[string]*task.Task, len(tasks))
+	states := map[string]*umbrellaState{}
 	nodes := make([]umbrella.Node, len(tasks))
 	hasUmbrella := false
+
+	stateFor := func(ref string) *umbrellaState {
+		key := umbrella.NormalizeIssueRef(ref)
+		s := states[key]
+		if s == nil {
+			s = &umbrellaState{cap: umbrella.DefaultMaxParallel}
+			states[key] = s
+		}
+		return s
+	}
+
 	for i := range tasks {
 		t := &tasks[i]
 		byID[t.ID] = t
-		if t.UmbrellaIssue != "" || t.TaskType == task.TaskTypeUmbrella {
+		if t.TaskType == task.TaskTypeUmbrella {
 			hasUmbrella = true
+			st := stateFor(t.Issue)
+			st.tracker = t
+			st.cap = umbrella.ParseMaxParallel(t.Tags)
+		}
+		if t.UmbrellaIssue != "" {
+			hasUmbrella = true
+			accumulateChild(stateFor(t.UmbrellaIssue), t.Status)
 		}
 		nodes[i] = umbrella.Node{
 			ID:        t.ID,
@@ -49,18 +80,55 @@ func (a *App) releaseUnblockedChildren() {
 	}
 
 	g := umbrella.Build(nodes)
-
+	cyclic := map[string]bool{}
 	for _, umb := range g.CyclicUmbrellas() {
-		a.flagCyclicUmbrella(tasks, umb)
+		cyclic[umbrella.NormalizeIssueRef(umb)] = true
 	}
 
-	for _, id := range g.ReadyToRelease() {
+	a.releaseCapped(g.ReadyToRelease(), byID, states)
+	a.rollupTrackers(states, cyclic)
+}
+
+// accumulateChild folds one child task's status into its umbrella's tally.
+func accumulateChild(st *umbrellaState, status task.Status) {
+	st.total++
+	switch status {
+	case task.StatusDone:
+		st.doneCount++
+	case task.StatusHumanRequired:
+		st.anyHR = true
+		st.active++ // a stuck child still occupies a slot until resolved
+	default:
+		if isRunningChild(status) {
+			st.active++
+		}
+	}
+}
+
+// isRunningChild reports whether a child status occupies a parallelism slot —
+// i.e. it has been released and is somewhere in the pipeline but not finished.
+func isRunningChild(s task.Status) bool {
+	switch s {
+	case task.StatusBlocked, task.StatusNew, task.StatusDone, task.StatusCancelled:
+		return false
+	default:
+		return true
+	}
+}
+
+// releaseCapped releases ready children to `todo`, but no more than each
+// umbrella's remaining parallelism budget (cap - active). Strips the gating
+// marker on release so a later re-block cannot retrigger it.
+func (a *App) releaseCapped(ready []string, byID map[string]*task.Task, states map[string]*umbrellaState) {
+	for _, id := range ready {
 		t, ok := byID[id]
 		if !ok || t == nil {
 			continue
 		}
-		// Strip the gating marker on release so a later re-block (e.g. a
-		// Sybra-bug containment) cannot retrigger a release of the same task.
+		st := states[umbrella.NormalizeIssueRef(t.UmbrellaIssue)]
+		if st == nil || st.active+st.released >= st.cap {
+			continue // at the umbrella's parallelism cap for this tick
+		}
 		newTags := slices.DeleteFunc(slices.Clone(t.Tags), func(s string) bool {
 			return s == umbrellaGatedTag
 		})
@@ -72,30 +140,67 @@ func (a *App) releaseUnblockedChildren() {
 			a.logger.Error("umbrella.release.failed", "task_id", id, "err", err)
 			continue
 		}
+		st.released++
 		a.logger.Info("umbrella.child.released", "task_id", id)
 	}
 }
 
-// flagCyclicUmbrella flips the umbrella tracker for umb to human-required when
-// its children form a dependency cycle. Idempotent: a tracker already in
-// human-required is left untouched so the gate does not churn the file every
-// tick.
-func (a *App) flagCyclicUmbrella(tasks []task.Task, umb string) {
-	key := umbrella.NormalizeIssueRef(umb)
-	for i := range tasks {
-		t := &tasks[i]
-		if t.TaskType != task.TaskTypeUmbrella || umbrella.NormalizeIssueRef(t.Issue) != key {
+// rollupTrackers advances each umbrella tracker's status to reflect its
+// children and closes the umbrella issue when everything is done.
+func (a *App) rollupTrackers(states map[string]*umbrellaState, cyclic map[string]bool) {
+	for key, st := range states {
+		if st.tracker == nil {
 			continue
 		}
-		if t.Status == task.StatusHumanRequired {
-			return
+		desired, reason, doClose := trackerRollup(st, cyclic[key])
+		if desired == st.tracker.Status {
+			continue
 		}
-		if _, err := a.tasks.Update(t.ID, task.Update{
-			Status:       task.Ptr(task.StatusHumanRequired),
-			StatusReason: task.Ptr("umbrella dependency cycle detected"),
+		if _, err := a.tasks.Update(st.tracker.ID, task.Update{
+			Status:       task.Ptr(desired),
+			StatusReason: task.Ptr(reason),
 		}); err != nil {
-			a.logger.Error("umbrella.cycle.flag.failed", "task_id", t.ID, "err", err)
+			a.logger.Error("umbrella.tracker.update.failed", "task_id", st.tracker.ID, "err", err)
+			continue
 		}
+		a.logger.Info("umbrella.tracker.rollup", "task_id", st.tracker.ID, "status", desired)
+		if doClose {
+			a.closeUmbrellaIssue(st.tracker.Issue)
+		}
+	}
+}
+
+// trackerRollup decides an umbrella tracker's status from its children. A
+// cycle or a stuck (human-required) child surfaces as human-required and halts
+// only that chain; all-done closes the umbrella.
+func trackerRollup(st *umbrellaState, cyclic bool) (status task.Status, reason string, doClose bool) {
+	switch {
+	case cyclic:
+		return task.StatusHumanRequired, "umbrella dependency cycle detected", false
+	case st.anyHR:
+		return task.StatusHumanRequired, "umbrella child needs attention", false
+	case st.total > 0 && st.doneCount == st.total:
+		return task.StatusDone, "all umbrella children complete", true
+	default:
+		return task.StatusInProgress, "umbrella in progress", false
+	}
+}
+
+// closeUmbrellaIssue closes the umbrella's GitHub issue with a generic comment
+// (no work content). Best-effort: a failure is logged, not retried.
+func (a *App) closeUmbrellaIssue(umbRef string) {
+	repo, number, ok := umbrella.ParseRef(umbRef)
+	if !ok {
+		a.logger.Warn("umbrella.close.skip", "reason", "unparseable ref", "ref", umbRef)
 		return
 	}
+	closeFn := a.umbrellaCloseIssue
+	if closeFn == nil {
+		closeFn = github.CloseIssue
+	}
+	if err := closeFn(repo, number, "All umbrella sub-tasks completed."); err != nil {
+		a.logger.Error("umbrella.close.failed", "repo", repo, "number", number, "err", err)
+		return
+	}
+	a.logger.Info("umbrella.closed", "repo", repo, "number", number)
 }

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -6,7 +6,98 @@ import (
 	"testing"
 
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/umbrella"
 )
+
+// mkTracker creates an umbrella tracker task carrying the given parallelism cap.
+func mkTracker(t *testing.T, m *task.Manager, umb string, maxPar int) task.Task {
+	t.Helper()
+	tk, err := m.CreateFull("umbrella", "", task.AgentModeHeadless, task.Update{
+		Issue:    task.Ptr(umb),
+		TaskType: task.Ptr(task.TaskTypeUmbrella),
+		Status:   task.Ptr(task.StatusInProgress),
+		Tags:     task.Ptr([]string{"umbrella", umbrella.MaxParallelTag(maxPar)}),
+	})
+	if err != nil {
+		t.Fatalf("create tracker: %v", err)
+	}
+	return tk
+}
+
+func TestReleaseUnblockedChildren_RespectsMaxParallel(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+	mkTracker(t, m, umb, 2)
+
+	c1 := mkChild(t, m, "c1", "Automaat/sybra#1", umb, nil, task.StatusBlocked)
+	c2 := mkChild(t, m, "c2", "Automaat/sybra#2", umb, nil, task.StatusBlocked)
+	c3 := mkChild(t, m, "c3", "Automaat/sybra#3", umb, nil, task.StatusBlocked)
+
+	app.releaseUnblockedChildren()
+
+	released, held := 0, 0
+	for _, id := range []string{c1.ID, c2.ID, c3.ID} {
+		switch mustStatus(t, m, id) {
+		case task.StatusTodo:
+			released++
+		case task.StatusBlocked:
+			held++
+		default:
+		}
+	}
+	if released != 2 || held != 1 {
+		t.Fatalf("cap=2 should release 2 and hold 1, got released=%d held=%d", released, held)
+	}
+}
+
+func TestReleaseUnblockedChildren_HaltChainFlagsTracker(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+	tracker := mkTracker(t, m, umb, 5)
+
+	// One child is stuck needing a human; an unrelated child is ready.
+	stuck := mkChild(t, m, "stuck", "Automaat/sybra#1", umb, nil, task.StatusHumanRequired)
+	indep := mkChild(t, m, "indep", "Automaat/sybra#2", umb, nil, task.StatusBlocked)
+
+	app.releaseUnblockedChildren()
+
+	if got := mustStatus(t, m, tracker.ID); got != task.StatusHumanRequired {
+		t.Fatalf("tracker = %q, want human-required on stuck child", got)
+	}
+	if got := mustStatus(t, m, stuck.ID); got != task.StatusHumanRequired {
+		t.Fatalf("stuck child = %q, want human-required", got)
+	}
+	// Independent chains keep running.
+	if got := mustStatus(t, m, indep.ID); got != task.StatusTodo {
+		t.Fatalf("independent child = %q, want released to todo", got)
+	}
+}
+
+func TestReleaseUnblockedChildren_RollupClosesUmbrella(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	var gotRepo string
+	var gotNum, closes int
+	app.umbrellaCloseIssue = func(repo string, number int, _ string) error {
+		gotRepo, gotNum, closes = repo, number, closes+1
+		return nil
+	}
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+	tracker := mkTracker(t, m, umb, 5)
+	mkChild(t, m, "c1", "Automaat/sybra#1", umb, nil, task.StatusDone)
+	mkChild(t, m, "c2", "Automaat/sybra#2", umb, nil, task.StatusDone)
+
+	app.releaseUnblockedChildren()
+
+	if got := mustStatus(t, m, tracker.ID); got != task.StatusDone {
+		t.Fatalf("tracker = %q, want done when all children done", got)
+	}
+	if closes != 1 || gotRepo != "Automaat/sybra" || gotNum != 100 {
+		t.Fatalf("close = %d times repo=%q num=%d, want 1 Automaat/sybra 100", closes, gotRepo, gotNum)
+	}
+}
 
 func newUmbrellaGateApp(t *testing.T) (*App, *task.Manager) {
 	t.Helper()

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -1,6 +1,7 @@
 package sybra
 
 import (
+	"errors"
 	"log/slog"
 	"slices"
 	"testing"
@@ -8,6 +9,8 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/umbrella"
 )
+
+var errTestClose = errors.New("close failed")
 
 // mkTracker creates an umbrella tracker task carrying the given parallelism cap.
 func mkTracker(t *testing.T, m *task.Manager, umb string, maxPar int) task.Task {
@@ -96,6 +99,44 @@ func TestReleaseUnblockedChildren_RollupClosesUmbrella(t *testing.T) {
 	}
 	if closes != 1 || gotRepo != "Automaat/sybra" || gotNum != 100 {
 		t.Fatalf("close = %d times repo=%q num=%d, want 1 Automaat/sybra 100", closes, gotRepo, gotNum)
+	}
+}
+
+func TestReleaseUnblockedChildren_CancelledChildSurfaces(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	closes := 0
+	app.umbrellaCloseIssue = func(string, int, string) error { closes++; return nil }
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+	tracker := mkTracker(t, m, umb, 5)
+	mkChild(t, m, "c1", "Automaat/sybra#1", umb, nil, task.StatusDone)
+	mkChild(t, m, "c2", "Automaat/sybra#2", umb, nil, task.StatusCancelled)
+
+	app.releaseUnblockedChildren()
+
+	// A cancelled child must surface for a human, never silently complete/close.
+	if got := mustStatus(t, m, tracker.ID); got != task.StatusHumanRequired {
+		t.Fatalf("tracker = %q, want human-required on cancelled child", got)
+	}
+	if closes != 0 {
+		t.Fatalf("umbrella was closed %d times despite a cancelled child", closes)
+	}
+}
+
+func TestReleaseUnblockedChildren_CloseFailureDefersDone(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	app.umbrellaCloseIssue = func(string, int, string) error { return errTestClose }
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+	tracker := mkTracker(t, m, umb, 5)
+	mkChild(t, m, "c1", "Automaat/sybra#1", umb, nil, task.StatusDone)
+
+	app.releaseUnblockedChildren()
+
+	// Close failed transiently → tracker must NOT flip to done (so the close
+	// retries next tick rather than orphaning the open issue).
+	if got := mustStatus(t, m, tracker.ID); got != task.StatusInProgress {
+		t.Fatalf("tracker = %q, want in-progress held for close retry", got)
 	}
 }
 

--- a/internal/umbrella/dag.go
+++ b/internal/umbrella/dag.go
@@ -9,6 +9,7 @@ package umbrella
 import (
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -65,6 +66,29 @@ func NormalizeIssueRef(s string) string {
 func isGitHubHost(h string) bool {
 	h = strings.ToLower(h)
 	return h == "github.com" || h == "www.github.com"
+}
+
+// ParseRef splits an issue ref into "owner/repo" and its number. It accepts a
+// github.com issue/PR URL (preserving the repo's original case for API calls)
+// or "owner/repo#n" shorthand. ok is false for anything else.
+func ParseRef(ref string) (repo string, number int, ok bool) {
+	ref = strings.TrimSpace(ref)
+	if u, err := url.Parse(ref); err == nil && isGitHubHost(u.Host) {
+		parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+		if len(parts) >= 4 && (parts[2] == "issues" || parts[2] == "pull") {
+			if n, err := strconv.Atoi(leadingDigits(parts[3])); err == nil {
+				return parts[0] + "/" + parts[1], n, true
+			}
+		}
+		return "", 0, false
+	}
+	r, num, found := strings.Cut(ref, "#")
+	if found && strings.Contains(r, "/") {
+		if n, err := strconv.Atoi(strings.TrimSpace(num)); err == nil {
+			return r, n, true
+		}
+	}
+	return "", 0, false
 }
 
 // leadingDigits returns the run of ASCII digits at the start of s (empty if

--- a/internal/umbrella/dag.go
+++ b/internal/umbrella/dag.go
@@ -83,6 +83,7 @@ func ParseRef(ref string) (repo string, number int, ok bool) {
 		return "", 0, false
 	}
 	r, num, found := strings.Cut(ref, "#")
+	r = strings.TrimSpace(r)
 	if found && strings.Contains(r, "/") {
 		if n, err := strconv.Atoi(strings.TrimSpace(num)); err == nil {
 			return r, n, true

--- a/internal/umbrella/dag_test.go
+++ b/internal/umbrella/dag_test.go
@@ -43,6 +43,7 @@ func TestParseRef(t *testing.T) {
 		{"https://github.com/Automaat/sybra/issues/100", "Automaat/sybra", 100, true},
 		{"https://github.com/Automaat/sybra/pull/7", "Automaat/sybra", 7, true},
 		{"Automaat/sybra#42", "Automaat/sybra", 42, true},
+		{"Automaat/sybra #42", "Automaat/sybra", 42, true},
 		{"#42", "", 0, false},
 		{"not a ref", "", 0, false},
 		{"https://notgithub.com/o/r/issues/5", "", 0, false},

--- a/internal/umbrella/dag_test.go
+++ b/internal/umbrella/dag_test.go
@@ -32,6 +32,29 @@ func TestNormalizeIssueRef(t *testing.T) {
 	}
 }
 
+func TestParseRef(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in     string
+		repo   string
+		number int
+		ok     bool
+	}{
+		{"https://github.com/Automaat/sybra/issues/100", "Automaat/sybra", 100, true},
+		{"https://github.com/Automaat/sybra/pull/7", "Automaat/sybra", 7, true},
+		{"Automaat/sybra#42", "Automaat/sybra", 42, true},
+		{"#42", "", 0, false},
+		{"not a ref", "", 0, false},
+		{"https://notgithub.com/o/r/issues/5", "", 0, false},
+	}
+	for _, c := range cases {
+		repo, n, ok := ParseRef(c.in)
+		if repo != c.repo || n != c.number || ok != c.ok {
+			t.Errorf("ParseRef(%q) = (%q,%d,%v), want (%q,%d,%v)", c.in, repo, n, ok, c.repo, c.number, c.ok)
+		}
+	}
+}
+
 // node builds a Node; status flags are set by the caller per case.
 func node(id, issue, umb string, deps []string, done, awaiting bool) Node {
 	return Node{ID: id, Issue: issue, Umbrella: umb, DependsOn: deps, Done: done, Awaiting: awaiting}

--- a/internal/umbrella/tags.go
+++ b/internal/umbrella/tags.go
@@ -15,6 +15,19 @@ func MaxParallelTag(n int) string {
 	return MaxParallelTagPrefix + strconv.Itoa(n)
 }
 
+// ParseMaxParallel reads the max-parallel value from a tracker's tags, falling
+// back to DefaultMaxParallel when the tag is absent or malformed.
+func ParseMaxParallel(tags []string) int {
+	for _, t := range tags {
+		if rest, ok := strings.CutPrefix(t, MaxParallelTagPrefix); ok {
+			if n, err := strconv.Atoi(strings.TrimSpace(rest)); err == nil && n > 0 {
+				return n
+			}
+		}
+	}
+	return DefaultMaxParallel
+}
+
 // controlTags are Sybra-load-bearing tags a child task must not inherit from a
 // GitHub sub-issue's labels — they route the task into other automations
 // (reviews, handoff lanes, the gate itself, bug containment).

--- a/internal/umbrella/tags_test.go
+++ b/internal/umbrella/tags_test.go
@@ -34,3 +34,23 @@ func TestMaxParallelTag(t *testing.T) {
 		t.Errorf("MaxParallelTag(5) = %q", got)
 	}
 }
+
+func TestParseMaxParallel(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		tags []string
+		want int
+	}{
+		{"present", []string{"umbrella", "umbrella-max-parallel:3"}, 3},
+		{"absent defaults", []string{"umbrella"}, DefaultMaxParallel},
+		{"malformed defaults", []string{"umbrella-max-parallel:abc"}, DefaultMaxParallel},
+		{"zero defaults", []string{"umbrella-max-parallel:0"}, DefaultMaxParallel},
+		{"nil defaults", nil, DefaultMaxParallel},
+	}
+	for _, c := range cases {
+		if got := ParseMaxParallel(c.tags); got != c.want {
+			t.Errorf("%s: ParseMaxParallel(%v) = %d, want %d", c.name, c.tags, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Motivation

Expanding an umbrella (#1130) can release many children at once, but the orchestrator gate had no concurrency bound and the tracker had no defined completion. This adds per-umbrella accounting to the gate so parallelism is capped, failures are surfaced, and a finished umbrella closes itself.

## Implementation information

Extends the gate (`internal/sybra/app_umbrella_gate.go`) with a per-umbrella tally each tick:

- **Cap**: release gate-blocked children only up to the tracker's `umbrella-max-parallel:N` tag (default 5), counting running children (and human-required ones) against the budget. Independent tracks run concurrently up to the cap; the rest stay blocked.
- **Halt-chain**: a `human-required` child flips its tracker to `human-required` and surfaces it; other chains keep releasing. A `cancelled` child likewise surfaces the tracker (a cancelled prerequisite is a deliberate human decision — its dependents stay held rather than auto-proceeding on abandoned work).
- **Roll-up close**: when every child reaches `done`, close the umbrella GitHub issue (generic comment, no work content) **then** flip the tracker to `done` — close-before-flip so a transient close failure retries next tick instead of orphaning the issue. The close fn is injectable for tests.

New helpers: `umbrella.ParseRef` (URL/shorthand → repo+number, host-anchored), `umbrella.ParseMaxParallel`, and `github.CloseIssue`. All unit-tested; the gate behaviors (cap, halt-chain, cancelled-surfacing, close-retry, roll-up) are covered by store-backed tests with an injected close fn.

Reviewed adversarially before opening — cancelled-child surfacing and the close-then-flip ordering are fixes from that pass.

Closes #1131

## Open questions

- An umbrella whose sub-issues were all already closed at expansion has a tracker but zero children; it stays `in-progress` (not auto-closed). Degenerate case, left as-is.

> Changelog: feat(umbrella): cap parallelism and close umbrella on completion
