### PR TITLE
feat(umbrella): auto-detect umbrellas in fetcher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,7 @@ Sybra can run on multiple machines (e.g. laptop + remote server). Each instance 
 **1. Per-feature `enabled` toggle** (kill-switch per machine):
 - `todoist.enabled` — Todoist polling (`internal/sybra/app_todoist.go`)
 - `github.enabled` — GitHub Issues fetcher (`internal/sybra/app.go`)
+- `umbrella.enabled` — auto-expand ☂️ umbrella issues into a gated task DAG (`internal/sybra/app_init.go` wires `umbrella.Expand` onto the issues fetcher)
 - `renovate.enabled` — Renovate CI fixer (`internal/sybra/app_renovate.go`)
 - Loop agents are stored per-machine in `~/.sybra/loop-agents/<id>.yaml` with their own `enabled` field — already independent.
 

--- a/cmd/sybra-cli/umbrella.go
+++ b/cmd/sybra-cli/umbrella.go
@@ -5,14 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"net/url"
-	"os/exec"
-	"slices"
-	"strconv"
-	"strings"
-	"time"
 
-	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/umbrella"
 )
@@ -36,173 +29,11 @@ func cmdUmbrella(s *task.Manager, args []string, jsonOut bool) int {
 		return fatal(jsonOut, "umbrella: an issue URL is required")
 	}
 
-	repo, number, err := parseIssueURL(issueURL)
+	res, err := umbrella.Expand(context.Background(), s, umbrella.ClaudePlannerRunner(*model), issueURL)
 	if err != nil {
 		return fatal(jsonOut, "%v", err)
 	}
-
-	umb, subs, err := github.FetchUmbrella(repo, number)
-	if err != nil {
-		return fatal(jsonOut, "fetch umbrella: %v", err)
-	}
-	if len(subs) == 0 {
-		return fatal(jsonOut, "umbrella %s has no sub-issues", issueURL)
-	}
-
-	// Index sub-issues by canonical (URL) ref for planner input + later lookup.
-	planSubs := make([]umbrella.SubIssue, len(subs))
-	byRef := make(map[string]github.Issue, len(subs))
-	for i := range subs {
-		planSubs[i] = umbrella.SubIssue{
-			Ref:    subs[i].URL,
-			Title:  subs[i].Title,
-			Body:   subs[i].Body,
-			Closed: strings.EqualFold(subs[i].State, "CLOSED"),
-		}
-		byRef[umbrella.NormalizeIssueRef(subs[i].URL)] = subs[i]
-	}
-
-	existing, trackerExists, err := scanExisting(s, umb.URL)
-	if err != nil {
-		return fatal(jsonOut, "scan existing tasks: %v", err)
-	}
-	// Short-circuit a full re-run: when every open sub-issue already has a task
-	// and the tracker exists, there is nothing to create — skip the (costly,
-	// stochastic) planner entirely.
-	if trackerExists && allMaterialized(planSubs, existing) {
-		return reportUmbrella(jsonOut, umb.URL, 0, len(subs))
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), plannerTimeout)
-	defer cancel()
-	plan, err := umbrella.Generate(ctx, claudePlannerRunner(*model), umb.URL, umb.Body, planSubs)
-	if err != nil {
-		return fatal(jsonOut, "plan umbrella: %v", err)
-	}
-
-	specs := umbrella.ChildSpecs(plan, planSubs, existing)
-	created, err := materializeUmbrella(s, umb, specs, byRef, trackerExists, plan.MaxParallel)
-	if err != nil {
-		return fatal(jsonOut, "%v", err)
-	}
-
-	return reportUmbrella(jsonOut, umb.URL, created, len(subs)-created)
-}
-
-// plannerTimeout bounds a single planner LLM invocation so a hung claude
-// process cannot wedge the command indefinitely.
-const plannerTimeout = 5 * time.Minute
-
-// allMaterialized reports whether every open sub-issue already has a task.
-// Closed sub-issues never get a task, so they do not count as missing.
-func allMaterialized(subs []umbrella.SubIssue, existing map[string]bool) bool {
-	for _, s := range subs {
-		if s.Closed {
-			continue
-		}
-		if !existing[umbrella.NormalizeIssueRef(s.Ref)] {
-			return false
-		}
-	}
-	return true
-}
-
-// scanExisting returns the set of normalized issue refs that already have a
-// task, and whether the umbrella tracker task already exists. A List failure
-// is propagated so the caller aborts rather than treating an unreadable store
-// as empty and creating a duplicate DAG.
-func scanExisting(s *task.Manager, umbrellaURL string) (refs map[string]bool, trackerExists bool, err error) {
-	tasks, err := s.List()
-	if err != nil {
-		return nil, false, err
-	}
-	refs = make(map[string]bool, len(tasks))
-	umbKey := umbrella.NormalizeIssueRef(umbrellaURL)
-	for i := range tasks {
-		t := &tasks[i]
-		if t.Issue != "" {
-			refs[umbrella.NormalizeIssueRef(t.Issue)] = true
-		}
-		if t.TaskType == task.TaskTypeUmbrella && umbrella.NormalizeIssueRef(t.Issue) == umbKey {
-			trackerExists = true
-		}
-	}
-	return refs, trackerExists, nil
-}
-
-// materializeUmbrella creates the tracker (when absent) and one blocked child
-// task per spec. It returns the number of child tasks created.
-func materializeUmbrella(s *task.Manager, umb github.Issue, specs []umbrella.ChildSpec, byRef map[string]github.Issue, trackerExists bool, maxParallel int) (int, error) {
-	if !trackerExists {
-		if _, err := s.CreateFull(umb.Title, umb.Body, task.AgentModeHeadless, task.Update{
-			Issue:     task.Ptr(umb.URL),
-			TaskType:  task.Ptr(task.TaskTypeUmbrella),
-			ProjectID: task.Ptr(umb.Repository),
-			Status:    task.Ptr(task.StatusInProgress),
-			Tags:      task.Ptr([]string{"umbrella", umbrella.MaxParallelTag(maxParallel)}),
-		}); err != nil {
-			return 0, fmt.Errorf("create tracker: %w", err)
-		}
-	}
-
-	created := 0
-	for _, spec := range specs {
-		if _, err := s.CreateFull(spec.Title, spec.Body, task.AgentModeHeadless, task.Update{
-			Issue:         task.Ptr(spec.Issue),
-			UmbrellaIssue: task.Ptr(umb.URL),
-			DependsOn:     task.Ptr(canonicalizeDeps(spec.DependsOn, byRef)),
-			ProjectID:     task.Ptr(childProjectID(spec.Issue, byRef, umb.Repository)),
-			Status:        task.Ptr(task.StatusBlocked),
-			Tags:          task.Ptr(childTags(spec.Issue, byRef)),
-		}); err != nil {
-			return created, fmt.Errorf("create child for %s: %w", spec.Issue, err)
-		}
-		created++
-	}
-	return created, nil
-}
-
-// childProjectID returns the repo a child task should be worked in: the
-// sub-issue's own repository (sub-issues can live in a different repo than the
-// umbrella), falling back to the umbrella's repo when unknown.
-func childProjectID(ref string, byRef map[string]github.Issue, fallback string) string {
-	if iss, ok := byRef[umbrella.NormalizeIssueRef(ref)]; ok && iss.Repository != "" {
-		return iss.Repository
-	}
-	return fallback
-}
-
-// canonicalizeDeps rewrites each dependency ref to the canonical issue URL of
-// the sub-issue it points at, so a child's DependsOn matches the dependency
-// task's Issue field exactly. An unknown ref (should not happen post-validate)
-// is kept as-is.
-func canonicalizeDeps(deps []string, byRef map[string]github.Issue) []string {
-	if len(deps) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(deps))
-	for _, d := range deps {
-		if iss, ok := byRef[umbrella.NormalizeIssueRef(d)]; ok {
-			out = append(out, iss.URL)
-		} else {
-			out = append(out, d)
-		}
-	}
-	return out
-}
-
-// childTags returns the gating marker plus the sub-issue's inheritable labels
-// (load-bearing routing tags are filtered out so a child is not mis-routed).
-func childTags(ref string, byRef map[string]github.Issue) []string {
-	tags := []string{umbrella.GatedTag}
-	if iss, ok := byRef[umbrella.NormalizeIssueRef(ref)]; ok {
-		for _, l := range umbrella.InheritableLabels(iss.Labels) {
-			if !slices.Contains(tags, l) {
-				tags = append(tags, l)
-			}
-		}
-	}
-	return tags
+	return reportUmbrella(jsonOut, res.UmbrellaURL, res.Created, res.Skipped)
 }
 
 func reportUmbrella(jsonOut bool, umbrellaURL string, created, skipped int) int {
@@ -217,48 +48,4 @@ func reportUmbrella(jsonOut bool, umbrellaURL string, created, skipped int) int 
 	}
 	fmt.Printf("Expanded %s: created %d child task(s), %d skipped (done or already present).\n", umbrellaURL, created, skipped)
 	return 0
-}
-
-// parseIssueURL extracts "owner/repo" and the issue number from a GitHub issue
-// URL.
-func parseIssueURL(raw string) (repo string, number int, err error) {
-	u, err := url.Parse(strings.TrimSpace(raw))
-	if err != nil {
-		return "", 0, fmt.Errorf("invalid URL %q: %w", raw, err)
-	}
-	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
-	if len(parts) < 4 || parts[2] != "issues" {
-		return "", 0, fmt.Errorf("not a GitHub issue URL: %s", raw)
-	}
-	n, err := strconv.Atoi(parts[3])
-	if err != nil {
-		return "", 0, fmt.Errorf("invalid issue number in %s", raw)
-	}
-	return parts[0] + "/" + parts[1], n, nil
-}
-
-// claudePlannerRunner returns a planner Runner that shells out to the claude
-// CLI for a single structured-output completion. The planner reasons over text
-// passed in the prompt and needs no tools.
-func claudePlannerRunner(model string) umbrella.Runner {
-	return func(ctx context.Context, prompt string) (string, error) {
-		cmdArgs := []string{"-p", prompt, "--output-format", "json", "--dangerously-skip-permissions"}
-		if model != "" {
-			cmdArgs = append(cmdArgs, "--model", model)
-		}
-		cmd := exec.CommandContext(ctx, "claude", cmdArgs...)
-		// Keep stdout clean for JSON parsing, but capture stderr so a planner
-		// failure (or a timeout-killed process) surfaces the real CLI message
-		// instead of a bare "exit status 1".
-		var stderr strings.Builder
-		cmd.Stderr = &stderr
-		out, err := cmd.Output()
-		if err != nil {
-			if msg := strings.TrimSpace(stderr.String()); msg != "" {
-				return "", fmt.Errorf("run claude: %w: %s", err, msg)
-			}
-			return "", fmt.Errorf("run claude: %w", err)
-		}
-		return string(out), nil
-	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Todoist       TodoistConfig      `yaml:"todoist" json:"todoist"`
 	Renovate      RenovateConfig     `yaml:"renovate" json:"renovate"`
 	GitHub        GitHubConfig       `yaml:"github" json:"github"`
+	Umbrella      UmbrellaConfig     `yaml:"umbrella" json:"umbrella"`
 	Triage        TriageConfig       `yaml:"triage" json:"triage"`
 	HumanReview   HumanReviewConfig  `yaml:"human_review" json:"humanReview"`
 	Monitor       MonitorConfig      `yaml:"monitor" json:"monitor"`
@@ -249,6 +250,15 @@ type RenovateConfig struct {
 
 type GitHubConfig struct {
 	Enabled bool `yaml:"enabled" json:"enabled"`
+}
+
+// UmbrellaConfig governs auto-expansion of ☂️ umbrella issues by the GitHub
+// issue fetcher. Disabled by default; project-scoped via the top-level
+// project_types allowlist so only one machine expands a given umbrella.
+type UmbrellaConfig struct {
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// Model overrides the planner model (empty = claude default).
+	Model string `yaml:"model" json:"model"`
 }
 
 // TriageConfig controls the background auto-triage worker. When Enabled,

--- a/internal/poll/issues.go
+++ b/internal/poll/issues.go
@@ -37,7 +37,15 @@ type IssuesFetcher struct {
 	// umbrellaExpand, when set, auto-expands a detected ☂️ umbrella issue into a
 	// gated task DAG instead of creating a flat task. nil = feature disabled.
 	umbrellaExpand func(issueURL string) (umbrella.Result, error)
+	// umbrellaCooldown holds the earliest next-attempt time per umbrella URL
+	// after an expansion failure, so a broken umbrella does not re-run the
+	// planner every poll.
+	umbrellaCooldown map[string]time.Time
 }
+
+// umbrellaRetryCooldown is how long to wait before re-attempting an umbrella
+// whose expansion failed.
+const umbrellaRetryCooldown = time.Hour
 
 // SetUmbrellaExpander enables auto-expansion of umbrella issues. fn typically
 // wraps umbrella.Expand bound to the task store and a planner runner. A nil fn
@@ -70,6 +78,7 @@ func NewIssuesFetcher(
 		fetchSnapshot:       github.FetchIssueSnapshot,
 		fetchIssueLinkedPRs: github.FetchIssueLinkedPRs,
 		viewerLogin:         github.ViewerLogin,
+		umbrellaCooldown:    map[string]time.Time{},
 	}
 }
 
@@ -189,15 +198,32 @@ func (f *IssuesFetcher) allowedReposFrom(projects []project.Project) []string {
 }
 
 func (f *IssuesFetcher) syncIssuesToTasks(issues []github.Issue) {
+	// Pass 1: expand umbrella issues first. Each creates gated child tasks, so
+	// they must be persisted before the flat-task dedup snapshot is taken —
+	// otherwise a sub-issue sharing this batch with its umbrella would slip
+	// past dedup and get a duplicate, ungated flat task.
+	flat := make([]github.Issue, 0, len(issues))
+	for i := range issues {
+		issue := &issues[i]
+		if f.umbrellaExpand != nil && umbrella.IsUmbrellaIssue(issue.Title, issue.Labels) {
+			f.expandUmbrellaIssue(issue)
+			continue
+		}
+		flat = append(flat, *issue)
+	}
+	if len(flat) == 0 {
+		return
+	}
+
+	// Pass 2: flat tasks, with a dedup snapshot taken AFTER expansion so the
+	// children created above are visible.
 	tasks, err := f.tasks.List()
 	if err != nil {
 		f.logger.Error("issue-sync.list-tasks", "err", err)
 		return
 	}
-
 	issueURLs := make(map[string]struct{})
-	// Map URL-titled tasks so we can enrich them instead of creating duplicates.
-	urlTitleTasks := make(map[string]string) // issue URL → task ID
+	urlTitleTasks := make(map[string]string) // issue URL → task ID for URL-titled stubs
 	for i := range tasks {
 		if tasks[i].Issue != "" {
 			issueURLs[tasks[i].Issue] = struct{}{}
@@ -206,86 +232,89 @@ func (f *IssuesFetcher) syncIssuesToTasks(issues []github.Issue) {
 			urlTitleTasks[tasks[i].Title] = tasks[i].ID
 		}
 	}
+	for i := range flat {
+		f.syncFlatIssue(&flat[i], issueURLs, urlTitleTasks)
+	}
+}
 
-	for i := range issues {
-		issue := &issues[i]
+// expandUmbrellaIssue auto-expands a detected umbrella issue, gated by the
+// project-type allowlist and a per-umbrella failure cooldown so a broken
+// umbrella does not re-run the planner every poll.
+func (f *IssuesFetcher) expandUmbrellaIssue(issue *github.Issue) {
+	proj, err := f.projects.Get(issue.Repository)
+	if err != nil || !f.allowsType(proj.Type) {
+		return
+	}
+	if until, ok := f.umbrellaCooldown[issue.URL]; ok && time.Now().Before(until) {
+		return
+	}
+	res, err := f.umbrellaExpand(issue.URL)
+	if err != nil {
+		f.umbrellaCooldown[issue.URL] = time.Now().Add(umbrellaRetryCooldown)
+		f.logger.Error("issue-sync.umbrella-expand", "issue", issue.URL, "err", err)
+		return
+	}
+	delete(f.umbrellaCooldown, issue.URL)
+	if res.Created > 0 {
+		f.logger.Info("issue-sync.umbrella-expanded", "issue", issue.URL, "created", res.Created)
+	}
+}
 
-		// Umbrella issues are expanded into a gated task DAG, not a flat task.
-		// Checked before the URL dedup so an already-expanded umbrella still
-		// ingests newly added sub-issues on re-poll (Expand is idempotent and
-		// short-circuits when nothing is new).
-		if f.umbrellaExpand != nil && umbrella.IsUmbrellaIssue(issue.Title, issue.Labels) {
-			proj, err := f.projects.Get(issue.Repository)
-			if err != nil || !f.allowsType(proj.Type) {
-				continue
-			}
-			if res, err := f.umbrellaExpand(issue.URL); err != nil {
-				f.logger.Error("issue-sync.umbrella-expand", "issue", issue.URL, "err", err)
-			} else if res.Created > 0 {
-				f.logger.Info("issue-sync.umbrella-expanded", "issue", issue.URL, "created", res.Created)
-			}
-			continue
-		}
+// syncFlatIssue creates or enriches a single non-umbrella issue task, honoring
+// the dedup snapshot and project-type filter.
+func (f *IssuesFetcher) syncFlatIssue(issue *github.Issue, issueURLs map[string]struct{}, urlTitleTasks map[string]string) {
+	if _, exists := issueURLs[issue.URL]; exists {
+		return
+	}
 
-		if _, exists := issueURLs[issue.URL]; exists {
-			continue
-		}
+	// Require the issue's repo to be a registered project. Issues from
+	// unregistered repos are dropped entirely — sybra only tracks work
+	// for repos the user has explicitly added as projects.
+	proj, err := f.projects.Get(issue.Repository)
+	if err != nil || !f.allowsType(proj.Type) {
+		return
+	}
 
-		// Require the issue's repo to be a registered project. Issues from
-		// unregistered repos are dropped entirely — sybra only tracks work
-		// for repos the user has explicitly added as projects.
-		proj, err := f.projects.Get(issue.Repository)
-		if err != nil {
-			continue
-		}
-		if !f.allowsType(proj.Type) {
-			continue
-		}
-
-		// Task already exists with the issue URL as title (manually created).
-		// Enrich it with the real title and link instead of creating a duplicate.
-		if taskID, exists := urlTitleTasks[issue.URL]; exists {
-			u := task.Update{
-				Title:     task.Ptr(issue.Title),
-				Issue:     task.Ptr(issue.URL),
-				ProjectID: task.Ptr(issue.Repository),
-			}
-			f.enrichLinkedViewerPR(issue, &u)
-			if issue.Body != "" {
-				u.Body = task.Ptr(issue.Body)
-			}
-			if _, err := f.tasks.Update(taskID, u); err != nil {
-				f.logger.Error("issue-sync.enrich", "task_id", taskID, "err", err)
-			} else {
-				f.logger.Info("issue-sync.enriched", "task_id", taskID, "issue", issue.URL, "title", issue.Title)
-			}
-			continue
-		}
-
-		t, err := f.tasks.Create(issue.Title, issue.Body, "headless")
-		if err != nil {
-			f.logger.Error("issue-sync.create", "issue", issue.URL, "err", err)
-			continue
-		}
-
+	// Task already exists with the issue URL as title (manually created).
+	// Enrich it with the real title and link instead of creating a duplicate.
+	if taskID, exists := urlTitleTasks[issue.URL]; exists {
 		u := task.Update{
+			Title:     task.Ptr(issue.Title),
 			Issue:     task.Ptr(issue.URL),
-			Status:    task.Ptr(task.StatusTodo),
 			ProjectID: task.Ptr(issue.Repository),
 		}
 		f.enrichLinkedViewerPR(issue, &u)
-
-		if len(issue.Labels) > 0 {
-			labels := issue.Labels
-			u.Tags = &labels
+		if issue.Body != "" {
+			u.Body = task.Ptr(issue.Body)
 		}
-
-		if _, err := f.tasks.Update(t.ID, u); err != nil {
-			f.logger.Error("issue-sync.update", "task_id", t.ID, "err", err)
+		if _, err := f.tasks.Update(taskID, u); err != nil {
+			f.logger.Error("issue-sync.enrich", "task_id", taskID, "err", err)
+		} else {
+			f.logger.Info("issue-sync.enriched", "task_id", taskID, "issue", issue.URL, "title", issue.Title)
 		}
-
-		f.logger.Info("issue-sync.created", "task_id", t.ID, "issue", issue.URL)
+		return
 	}
+
+	t, err := f.tasks.Create(issue.Title, issue.Body, "headless")
+	if err != nil {
+		f.logger.Error("issue-sync.create", "issue", issue.URL, "err", err)
+		return
+	}
+
+	u := task.Update{
+		Issue:     task.Ptr(issue.URL),
+		Status:    task.Ptr(task.StatusTodo),
+		ProjectID: task.Ptr(issue.Repository),
+	}
+	f.enrichLinkedViewerPR(issue, &u)
+	if len(issue.Labels) > 0 {
+		labels := issue.Labels
+		u.Tags = &labels
+	}
+	if _, err := f.tasks.Update(t.ID, u); err != nil {
+		f.logger.Error("issue-sync.update", "task_id", t.ID, "err", err)
+	}
+	f.logger.Info("issue-sync.created", "task_id", t.ID, "issue", issue.URL)
 }
 
 func (f *IssuesFetcher) enrichLinkedViewerPR(issue *github.Issue, u *task.Update) {

--- a/internal/poll/issues.go
+++ b/internal/poll/issues.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Automaat/sybra/internal/metrics"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/umbrella"
 )
 
 const IssuesPollInterval = 5 * time.Minute
@@ -33,6 +34,16 @@ type IssuesFetcher struct {
 	viewerLogin           func() string
 	transientFetchFails   int
 	transientLabeledFails int
+	// umbrellaExpand, when set, auto-expands a detected ☂️ umbrella issue into a
+	// gated task DAG instead of creating a flat task. nil = feature disabled.
+	umbrellaExpand func(issueURL string) (umbrella.Result, error)
+}
+
+// SetUmbrellaExpander enables auto-expansion of umbrella issues. fn typically
+// wraps umbrella.Expand bound to the task store and a planner runner. A nil fn
+// leaves the feature disabled.
+func (f *IssuesFetcher) SetUmbrellaExpander(fn func(issueURL string) (umbrella.Result, error)) {
+	f.umbrellaExpand = fn
 }
 
 // NewIssuesFetcher creates an IssuesFetcher. allowsType filters issues whose
@@ -198,6 +209,24 @@ func (f *IssuesFetcher) syncIssuesToTasks(issues []github.Issue) {
 
 	for i := range issues {
 		issue := &issues[i]
+
+		// Umbrella issues are expanded into a gated task DAG, not a flat task.
+		// Checked before the URL dedup so an already-expanded umbrella still
+		// ingests newly added sub-issues on re-poll (Expand is idempotent and
+		// short-circuits when nothing is new).
+		if f.umbrellaExpand != nil && umbrella.IsUmbrellaIssue(issue.Title, issue.Labels) {
+			proj, err := f.projects.Get(issue.Repository)
+			if err != nil || !f.allowsType(proj.Type) {
+				continue
+			}
+			if res, err := f.umbrellaExpand(issue.URL); err != nil {
+				f.logger.Error("issue-sync.umbrella-expand", "issue", issue.URL, "err", err)
+			} else if res.Created > 0 {
+				f.logger.Info("issue-sync.umbrella-expanded", "issue", issue.URL, "created", res.Created)
+			}
+			continue
+		}
+
 		if _, exists := issueURLs[issue.URL]; exists {
 			continue
 		}

--- a/internal/poll/issues_test.go
+++ b/internal/poll/issues_test.go
@@ -89,6 +89,50 @@ func TestIssuesFetcher_SyncIssuesToTasks_AutoExpandsUmbrella(t *testing.T) {
 	assertStringSetEqual(t, taskIssueURLs(t, env.tasks), []string{"https://github.com/acme/pet1/issues/2"})
 }
 
+func TestIssuesFetcher_SyncIssuesToTasks_UmbrellaChildNotDuplicated(t *testing.T) {
+	t.Parallel()
+	env := newIssuesFetcherForTest(t, func(project.ProjectType) bool { return true }, nil)
+	writeProject(t, env.projectsDir, "acme--pet1.yaml", "acme/pet1", "acme", "pet1", project.ProjectTypePet)
+
+	const subURL = "https://github.com/acme/pet1/issues/5"
+	// Simulate Expand creating a gated child task for sub-issue #5.
+	env.fetcher.SetUmbrellaExpander(func(issueURL string) (umbrella.Result, error) {
+		_, err := env.tasks.CreateFull("child 5", "", task.AgentModeHeadless, task.Update{
+			Issue:         task.Ptr(subURL),
+			UmbrellaIssue: task.Ptr(issueURL),
+			Status:        task.Ptr(task.StatusBlocked),
+			Tags:          task.Ptr([]string{umbrella.GatedTag}),
+		})
+		return umbrella.Result{Created: 1}, err
+	})
+
+	// Umbrella and its sub-issue arrive in the SAME batch.
+	issues := []github.Issue{
+		{Number: 1, Title: "☂️ umbrella", URL: "https://github.com/acme/pet1/issues/1", Repository: "acme/pet1"},
+		{Number: 5, Title: "sub issue 5", URL: subURL, Repository: "acme/pet1"},
+	}
+	env.fetcher.syncIssuesToTasks(issues)
+
+	// Sub-issue #5 must have exactly one task — the gated child — not a second
+	// ungated flat todo task that would bypass the dependency DAG.
+	all, err := env.tasks.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	matches := 0
+	for i := range all {
+		if all[i].Issue == subURL {
+			matches++
+			if all[i].Status != task.StatusBlocked {
+				t.Fatalf("sub-issue task status = %q, want blocked (gated child)", all[i].Status)
+			}
+		}
+	}
+	if matches != 1 {
+		t.Fatalf("sub-issue #5 has %d tasks, want 1 (no duplicate flat task)", matches)
+	}
+}
+
 func TestIssuesFetcher_SyncIssuesToTasks_UmbrellaDisabledIsFlat(t *testing.T) {
 	t.Parallel()
 	env := newIssuesFetcherForTest(t, func(project.ProjectType) bool { return true }, nil)

--- a/internal/poll/issues_test.go
+++ b/internal/poll/issues_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/umbrella"
 )
 
 // issuesFetcherEnv holds the fully-wired dependencies for a single-machine
@@ -60,6 +61,67 @@ func newIssuesFetcherForTest(
 		tasks:       taskMgr,
 		projects:    projStore,
 		projectsDir: projectsDir,
+	}
+}
+
+func TestIssuesFetcher_SyncIssuesToTasks_AutoExpandsUmbrella(t *testing.T) {
+	t.Parallel()
+	env := newIssuesFetcherForTest(t, func(project.ProjectType) bool { return true }, nil)
+	writeProject(t, env.projectsDir, "acme--pet1.yaml", "acme/pet1", "acme", "pet1", project.ProjectTypePet)
+
+	var expanded []string
+	env.fetcher.SetUmbrellaExpander(func(issueURL string) (umbrella.Result, error) {
+		expanded = append(expanded, issueURL)
+		return umbrella.Result{Created: 2}, nil
+	})
+
+	issues := []github.Issue{
+		{Number: 1, Title: "☂️ umbrella", URL: "https://github.com/acme/pet1/issues/1", Repository: "acme/pet1"},
+		{Number: 2, Title: "normal issue", URL: "https://github.com/acme/pet1/issues/2", Repository: "acme/pet1"},
+	}
+	env.fetcher.syncIssuesToTasks(issues)
+
+	// The umbrella was expanded, not turned into a flat task.
+	if len(expanded) != 1 || expanded[0] != "https://github.com/acme/pet1/issues/1" {
+		t.Fatalf("expander calls = %v, want [issue 1]", expanded)
+	}
+	// Only the normal issue produced a flat task.
+	assertStringSetEqual(t, taskIssueURLs(t, env.tasks), []string{"https://github.com/acme/pet1/issues/2"})
+}
+
+func TestIssuesFetcher_SyncIssuesToTasks_UmbrellaDisabledIsFlat(t *testing.T) {
+	t.Parallel()
+	env := newIssuesFetcherForTest(t, func(project.ProjectType) bool { return true }, nil)
+	writeProject(t, env.projectsDir, "acme--pet1.yaml", "acme/pet1", "acme", "pet1", project.ProjectTypePet)
+	// No expander set → feature disabled → umbrella becomes an ordinary task.
+
+	issues := []github.Issue{
+		{Number: 1, Title: "☂️ umbrella", URL: "https://github.com/acme/pet1/issues/1", Repository: "acme/pet1"},
+	}
+	env.fetcher.syncIssuesToTasks(issues)
+
+	assertStringSetEqual(t, taskIssueURLs(t, env.tasks), []string{"https://github.com/acme/pet1/issues/1"})
+}
+
+func TestIssuesFetcher_SyncIssuesToTasks_UmbrellaRespectsProjectType(t *testing.T) {
+	t.Parallel()
+	// pet-only machine must not expand an umbrella in a work repo.
+	env := newIssuesFetcherForTest(t, func(pt project.ProjectType) bool { return pt == project.ProjectTypePet }, nil)
+	writeProject(t, env.projectsDir, "bigco--work1.yaml", "bigco/work1", "bigco", "work1", project.ProjectTypeWork)
+
+	called := false
+	env.fetcher.SetUmbrellaExpander(func(string) (umbrella.Result, error) {
+		called = true
+		return umbrella.Result{}, nil
+	})
+
+	issues := []github.Issue{
+		{Number: 1, Title: "☂️ work umbrella", URL: "https://github.com/bigco/work1/issues/1", Repository: "bigco/work1"},
+	}
+	env.fetcher.syncIssuesToTasks(issues)
+
+	if called {
+		t.Fatal("expander ran for a work umbrella on a pet-only machine")
 	}
 }
 

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Automaat/sybra/internal/skillsync"
 	"github.com/Automaat/sybra/internal/stats"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/umbrella"
 	"github.com/Automaat/sybra/internal/watcher"
 	"github.com/Automaat/sybra/internal/workflow"
 )
@@ -107,7 +108,15 @@ func (a *App) initIssuesFetcher(emit func(string, any)) *poll.IssuesFetcher {
 		a.logger.Info("github.disabled")
 		return nil
 	}
-	return poll.NewIssuesFetcher(a.tasks, a.projects, emit, a.logger, a.allowsProjectType)
+	f := poll.NewIssuesFetcher(a.tasks, a.projects, emit, a.logger, a.allowsProjectType)
+	if a.cfg.Umbrella.Enabled {
+		model := a.cfg.Umbrella.Model
+		f.SetUmbrellaExpander(func(issueURL string) (umbrella.Result, error) {
+			return umbrella.Expand(context.Background(), a.tasks, umbrella.ClaudePlannerRunner(model), issueURL)
+		})
+		a.logger.Info("umbrella.autodetect.enabled")
+	}
+	return f
 }
 
 // logAutomationsSummary logs a one-line snapshot of which automations this

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -1,0 +1,226 @@
+package umbrella
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// PlannerTimeout bounds a single planner LLM invocation so a hung process
+// cannot wedge an expansion indefinitely.
+const PlannerTimeout = 5 * time.Minute
+
+// Result summarizes an expansion.
+type Result struct {
+	UmbrellaURL string
+	Created     int // child tasks created this run
+	Skipped     int // sub-issues already materialized or done
+}
+
+// Expand fetches a GitHub umbrella issue's native sub-issues, runs the planner
+// to extract a dependency DAG, and materializes one `umbrella` tracker task
+// plus one `blocked`+gated child per open sub-issue. It is idempotent: only
+// sub-issues without an existing task are created, and a fully-materialized
+// re-run skips the planner entirely. The planner run is bounded by
+// PlannerTimeout. Shared by the `sybra-cli umbrella` command and the GitHub
+// issue fetcher's auto-detect path.
+func Expand(ctx context.Context, tasks *task.Manager, run Runner, issueURL string) (Result, error) {
+	repo, number, ok := ParseRef(issueURL)
+	if !ok {
+		return Result{}, fmt.Errorf("not a GitHub issue URL: %s", issueURL)
+	}
+	umb, subs, err := github.FetchUmbrella(repo, number)
+	if err != nil {
+		return Result{}, fmt.Errorf("fetch umbrella: %w", err)
+	}
+	if len(subs) == 0 {
+		return Result{}, fmt.Errorf("umbrella %s has no sub-issues", issueURL)
+	}
+
+	// Index sub-issues by canonical (URL) ref for planner input + later lookup.
+	planSubs := make([]SubIssue, len(subs))
+	byRef := make(map[string]github.Issue, len(subs))
+	for i := range subs {
+		planSubs[i] = SubIssue{
+			Ref:    subs[i].URL,
+			Title:  subs[i].Title,
+			Body:   subs[i].Body,
+			Closed: strings.EqualFold(subs[i].State, "CLOSED"),
+		}
+		byRef[NormalizeIssueRef(subs[i].URL)] = subs[i]
+	}
+
+	existing, trackerExists, err := scanExisting(tasks, umb.URL)
+	if err != nil {
+		return Result{}, fmt.Errorf("scan existing tasks: %w", err)
+	}
+	// Short-circuit a full re-run: nothing to create means no (costly,
+	// stochastic) planner call.
+	if trackerExists && allMaterialized(planSubs, existing) {
+		return Result{UmbrellaURL: umb.URL, Skipped: len(subs)}, nil
+	}
+
+	pctx, cancel := context.WithTimeout(ctx, PlannerTimeout)
+	defer cancel()
+	plan, err := Generate(pctx, run, umb.URL, umb.Body, planSubs)
+	if err != nil {
+		return Result{}, fmt.Errorf("plan umbrella: %w", err)
+	}
+
+	specs := ChildSpecs(plan, planSubs, existing)
+	created, err := materialize(tasks, umb, specs, byRef, trackerExists, plan.MaxParallel)
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{UmbrellaURL: umb.URL, Created: created, Skipped: len(subs) - created}, nil
+}
+
+// allMaterialized reports whether every open sub-issue already has a task.
+func allMaterialized(subs []SubIssue, existing map[string]bool) bool {
+	for _, s := range subs {
+		if s.Closed {
+			continue
+		}
+		if !existing[NormalizeIssueRef(s.Ref)] {
+			return false
+		}
+	}
+	return true
+}
+
+// scanExisting returns the set of normalized issue refs that already have a
+// task, and whether the umbrella tracker exists. A List failure is propagated
+// so the caller aborts rather than treating an unreadable store as empty and
+// creating a duplicate DAG.
+func scanExisting(tasks *task.Manager, umbrellaURL string) (refs map[string]bool, trackerExists bool, err error) {
+	all, err := tasks.List()
+	if err != nil {
+		return nil, false, err
+	}
+	refs = make(map[string]bool, len(all))
+	umbKey := NormalizeIssueRef(umbrellaURL)
+	for i := range all {
+		t := &all[i]
+		if t.Issue != "" {
+			refs[NormalizeIssueRef(t.Issue)] = true
+		}
+		if t.TaskType == task.TaskTypeUmbrella && NormalizeIssueRef(t.Issue) == umbKey {
+			trackerExists = true
+		}
+	}
+	return refs, trackerExists, nil
+}
+
+// materialize creates the tracker (when absent) and one blocked child per spec.
+func materialize(tasks *task.Manager, umb github.Issue, specs []ChildSpec, byRef map[string]github.Issue, trackerExists bool, maxParallel int) (int, error) {
+	if !trackerExists {
+		if _, err := tasks.CreateFull(umb.Title, umb.Body, task.AgentModeHeadless, task.Update{
+			Issue:     task.Ptr(umb.URL),
+			TaskType:  task.Ptr(task.TaskTypeUmbrella),
+			ProjectID: task.Ptr(umb.Repository),
+			Status:    task.Ptr(task.StatusInProgress),
+			Tags:      task.Ptr([]string{"umbrella", MaxParallelTag(maxParallel)}),
+		}); err != nil {
+			return 0, fmt.Errorf("create tracker: %w", err)
+		}
+	}
+
+	created := 0
+	for _, spec := range specs {
+		if _, err := tasks.CreateFull(spec.Title, spec.Body, task.AgentModeHeadless, task.Update{
+			Issue:         task.Ptr(spec.Issue),
+			UmbrellaIssue: task.Ptr(umb.URL),
+			DependsOn:     task.Ptr(canonicalizeDeps(spec.DependsOn, byRef)),
+			ProjectID:     task.Ptr(childProjectID(spec.Issue, byRef, umb.Repository)),
+			Status:        task.Ptr(task.StatusBlocked),
+			Tags:          task.Ptr(childTags(spec.Issue, byRef)),
+		}); err != nil {
+			return created, fmt.Errorf("create child for %s: %w", spec.Issue, err)
+		}
+		created++
+	}
+	return created, nil
+}
+
+// childProjectID returns the repo a child should be worked in: the sub-issue's
+// own repository (sub-issues can live in a different repo than the umbrella),
+// falling back to the umbrella's repo when unknown.
+func childProjectID(ref string, byRef map[string]github.Issue, fallback string) string {
+	if iss, ok := byRef[NormalizeIssueRef(ref)]; ok && iss.Repository != "" {
+		return iss.Repository
+	}
+	return fallback
+}
+
+// canonicalizeDeps rewrites each dependency ref to the canonical issue URL of
+// the sub-issue it points at, so a child's DependsOn matches the dependency
+// task's Issue field exactly. An unknown ref (should not happen post-validate)
+// is kept as-is.
+func canonicalizeDeps(deps []string, byRef map[string]github.Issue) []string {
+	if len(deps) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(deps))
+	for _, d := range deps {
+		if iss, ok := byRef[NormalizeIssueRef(d)]; ok {
+			out = append(out, iss.URL)
+		} else {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// childTags returns the gating marker plus the sub-issue's inheritable labels
+// (load-bearing routing tags are filtered out so a child is not mis-routed).
+func childTags(ref string, byRef map[string]github.Issue) []string {
+	tags := []string{GatedTag}
+	if iss, ok := byRef[NormalizeIssueRef(ref)]; ok {
+		for _, l := range InheritableLabels(iss.Labels) {
+			if !slices.Contains(tags, l) {
+				tags = append(tags, l)
+			}
+		}
+	}
+	return tags
+}
+
+// ClaudePlannerRunner returns a planner Runner that shells out to the claude
+// CLI for a single structured-output completion. The planner reasons over text
+// in the prompt and needs no tools.
+func ClaudePlannerRunner(model string) Runner {
+	return func(ctx context.Context, prompt string) (string, error) {
+		cmdArgs := []string{"-p", prompt, "--output-format", "json", "--dangerously-skip-permissions"}
+		if model != "" {
+			cmdArgs = append(cmdArgs, "--model", model)
+		}
+		cmd := exec.CommandContext(ctx, "claude", cmdArgs...)
+		// Keep stdout clean for JSON parsing, but capture stderr so a planner
+		// failure (or timeout-killed process) surfaces the real CLI message.
+		var stderr strings.Builder
+		cmd.Stderr = &stderr
+		out, err := cmd.Output()
+		if err != nil {
+			if msg := strings.TrimSpace(stderr.String()); msg != "" {
+				return "", fmt.Errorf("run claude: %w: %s", err, msg)
+			}
+			return "", fmt.Errorf("run claude: %w", err)
+		}
+		return string(out), nil
+	}
+}
+
+// IsUmbrellaIssue reports whether a GitHub issue should be auto-expanded as an
+// umbrella: a ☂️ title prefix or an "umbrella" label.
+func IsUmbrellaIssue(title string, labels []string) bool {
+	if strings.HasPrefix(strings.TrimSpace(title), "☂️") {
+		return true
+	}
+	return slices.Contains(labels, "umbrella")
+}

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -217,9 +217,10 @@ func ClaudePlannerRunner(model string) Runner {
 }
 
 // IsUmbrellaIssue reports whether a GitHub issue should be auto-expanded as an
-// umbrella: a ☂️ title prefix or an "umbrella" label.
+// umbrella: a ☂ title prefix (with or without the U+FE0F variation selector
+// that renders it as emoji) or an "umbrella" label.
 func IsUmbrellaIssue(title string, labels []string) bool {
-	if strings.HasPrefix(strings.TrimSpace(title), "☂️") {
+	if strings.HasPrefix(strings.TrimSpace(title), "☂") {
 		return true
 	}
 	return slices.Contains(labels, "umbrella")

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -218,10 +218,16 @@ func ClaudePlannerRunner(model string) Runner {
 
 // IsUmbrellaIssue reports whether a GitHub issue should be auto-expanded as an
 // umbrella: a ☂ title prefix (with or without the U+FE0F variation selector
-// that renders it as emoji) or an "umbrella" label.
+// that renders it as emoji) or an "umbrella" label (case-insensitive, trimmed —
+// GitHub preserves user-entered label casing/whitespace).
 func IsUmbrellaIssue(title string, labels []string) bool {
 	if strings.HasPrefix(strings.TrimSpace(title), "☂") {
 		return true
 	}
-	return slices.Contains(labels, "umbrella")
+	for _, l := range labels {
+		if strings.EqualFold(strings.TrimSpace(l), "umbrella") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/umbrella/expand_test.go
+++ b/internal/umbrella/expand_test.go
@@ -11,6 +11,7 @@ func TestIsUmbrellaIssue(t *testing.T) {
 		want   bool
 	}{
 		{"umbrella emoji prefix", "☂️ feat(x): umbrella", nil, true},
+		{"bare umbrella rune (no VS16)", "☂ feat(x): umbrella", nil, true},
 		{"emoji with leading space", "  ☂️ leading space", nil, true},
 		{"umbrella label", "ordinary title", []string{"bug", "umbrella"}, true},
 		{"emoji mid-title is not a prefix", "feat ☂️ inline", nil, false},

--- a/internal/umbrella/expand_test.go
+++ b/internal/umbrella/expand_test.go
@@ -14,6 +14,7 @@ func TestIsUmbrellaIssue(t *testing.T) {
 		{"bare umbrella rune (no VS16)", "☂ feat(x): umbrella", nil, true},
 		{"emoji with leading space", "  ☂️ leading space", nil, true},
 		{"umbrella label", "ordinary title", []string{"bug", "umbrella"}, true},
+		{"umbrella label mixed case + space", "ordinary title", []string{" Umbrella "}, true},
 		{"emoji mid-title is not a prefix", "feat ☂️ inline", nil, false},
 		{"plain issue", "ordinary title", []string{"bug"}, false},
 		{"no title no labels", "", nil, false},

--- a/internal/umbrella/expand_test.go
+++ b/internal/umbrella/expand_test.go
@@ -1,0 +1,28 @@
+package umbrella
+
+import "testing"
+
+func TestIsUmbrellaIssue(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		title  string
+		labels []string
+		want   bool
+	}{
+		{"umbrella emoji prefix", "☂️ feat(x): umbrella", nil, true},
+		{"emoji with leading space", "  ☂️ leading space", nil, true},
+		{"umbrella label", "ordinary title", []string{"bug", "umbrella"}, true},
+		{"emoji mid-title is not a prefix", "feat ☂️ inline", nil, false},
+		{"plain issue", "ordinary title", []string{"bug"}, false},
+		{"no title no labels", "", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsUmbrellaIssue(c.title, c.labels); got != c.want {
+				t.Errorf("IsUmbrellaIssue(%q, %v) = %v, want %v", c.title, c.labels, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Beyond the manual `sybra-cli umbrella` entry (#1130), labeling a ☂️ issue should be enough to kick off the swarm — zero-touch on a designated machine. This wires umbrella expansion into the GitHub issue poll loop.

## Implementation information

- **Shared core**: the expansion orchestration moves from the CLI into `umbrella.Expand(ctx, tasks, run, issueURL)` (+ `ClaudePlannerRunner`, `IsUmbrellaIssue`), so the CLI and the fetcher run identical logic. `cmd/sybra-cli/umbrella.go` is now a thin wrapper.
- **Auto-detect**: the fetcher (`internal/poll/issues.go`) expands a ☂️-prefixed or `umbrella`-labelled issue into a gated DAG instead of a flat task. Detection runs in a **first pass** before the flat-task dedup snapshot is rebuilt, so a sub-issue arriving in the same batch as its umbrella can't slip past dedup into a duplicate, ungated task.
- **Gating** (anti-pattern requirements for a new auto-source): a new `umbrella.enabled` config toggle (kill-switch per machine, default off) **and** the existing `project_types` allowlist (`cfg.AllowsProjectType`). A per-umbrella failure cooldown stops a broken umbrella from re-running the planner every poll. Re-polls re-expand idempotently to ingest newly added sub-issues.

CLAUDE.md's per-machine automation list documents the new toggle.

Pure logic stays unit-tested; new behaviors (auto-detect, disabled = flat, project-type filter, in-batch dedup, bare-rune detection) are covered by fetcher tests with an injected expander.

Reviewed adversarially before opening — the two-pass sync, the failure cooldown, and bare-☂ detection are fixes from that pass.

Closes #1132

## Supporting documentation

Completes the ☂️ #1133 umbrella: point Sybra at an umbrella (CLI or auto-detect) → gated DAG of children → each runs the full pipeline → tracker rolls up and closes the umbrella.

> Changelog: feat(umbrella): auto-detect and expand umbrellas in the poll loop
