### PR TITLE
fix(umbrella): bound sub-issue fetch with context

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -37,6 +37,31 @@ func ghRunCtx(ctx context.Context, args ...string) ([]byte, error) {
 	})
 }
 
+// runCtx lets ghExecer satisfy the optional ctxRunner interface, so callers
+// that thread a context (e.g. the umbrella fetch from the poll loop) get a
+// cancellable gh invocation instead of one bounded only by the kernel TCP
+// timeout.
+func (ghExecer) runCtx(ctx context.Context, args ...string) ([]byte, error) {
+	return ghRunCtx(ctx, args...)
+}
+
+// ctxRunner is the optional context-aware extension of execer. The real
+// ghExecer implements it; test fakes need not — runE falls back to run.
+type ctxRunner interface {
+	runCtx(ctx context.Context, args ...string) ([]byte, error)
+}
+
+// runE executes args on e, using the context-aware path when ctx is non-nil
+// and e supports it; otherwise it falls back to the plain (uncancellable) run.
+func runE(ctx context.Context, e execer, args ...string) ([]byte, error) {
+	if ctx != nil {
+		if cr, ok := e.(ctxRunner); ok {
+			return cr.runCtx(ctx, args...)
+		}
+	}
+	return e.run(args...)
+}
+
 var defaultExecer execer = ghExecer{}
 
 var (

--- a/internal/github/runtime.go
+++ b/internal/github/runtime.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"sync"
@@ -252,6 +253,13 @@ func isRateLimitedMessage(msg string) bool {
 }
 
 func runGHAPIWith(e execer, cacheTTL string, args ...string) (ghHTTPResponse, error) {
+	return runGHAPICtxWith(context.Background(), e, cacheTTL, args...)
+}
+
+// runGHAPICtxWith is runGHAPIWith with a context: a cancelled/expired context
+// kills the in-flight gh process (when e supports it) and aborts the retry
+// loop, so a stalled call cannot wedge the caller (e.g. the poll loop).
+func runGHAPICtxWith(ctx context.Context, e execer, cacheTTL string, args ...string) (ghHTTPResponse, error) {
 	cmdArgs := make([]string, 0, len(args)+4)
 	cmdArgs = append(cmdArgs, "api")
 	if cacheTTL != "" {
@@ -269,10 +277,14 @@ func runGHAPIWith(e execer, cacheTTL string, args ...string) (ghHTTPResponse, er
 	var err error
 	for attempt := 0; ; attempt++ {
 		var out []byte
-		out, err = e.run(cmdArgs...)
+		out, err = runE(ctx, e, cmdArgs...)
 		resp = parseGHHTTPResponse(out)
 		ghGate.observe(resp, err)
 		if err == nil || write || attempt >= ghMaxRetries || !isTransientGHError(out, err) {
+			break
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err = ctxErr
 			break
 		}
 		ghRetrySleep(attempt)

--- a/internal/github/subissues.go
+++ b/internal/github/subissues.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -52,17 +53,18 @@ type gqlUmbrellaIssue struct {
 }
 
 // FetchUmbrella returns an umbrella issue and its GitHub sub-issues. repo is
-// "owner/name". Sub-issues come back in the order GitHub lists them.
-func FetchUmbrella(repo string, number int) (umbrella Issue, subs []Issue, err error) {
-	return fetchUmbrellaWith(defaultExecer, repo, number)
+// "owner/name". The context bounds the gh call so a stalled fetch cannot wedge
+// the caller. Sub-issues come back in the order GitHub lists them.
+func FetchUmbrella(ctx context.Context, repo string, number int) (umbrella Issue, subs []Issue, err error) {
+	return fetchUmbrellaWith(ctx, defaultExecer, repo, number)
 }
 
-func fetchUmbrellaWith(e execer, repo string, number int) (umbrella Issue, subs []Issue, err error) {
+func fetchUmbrellaWith(ctx context.Context, e execer, repo string, number int) (umbrella Issue, subs []Issue, err error) {
 	owner, name, ok := splitOwnerRepo(repo)
 	if !ok {
 		return Issue{}, nil, fmt.Errorf("invalid repo %q (want owner/name)", repo)
 	}
-	httpResp, err := runGHAPIWith(e, "", "graphql",
+	httpResp, err := runGHAPICtxWith(ctx, e, "", "graphql",
 		"-H", "GraphQL-Features: sub_issues",
 		"-f", "query="+umbrellaQuery,
 		"-f", "owner="+owner,

--- a/internal/github/subissues_test.go
+++ b/internal/github/subissues_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -74,7 +75,7 @@ func TestFetchUmbrellaWith(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			fe := &fakeExecer{output: []byte(tt.output), err: tt.execErr}
-			umb, subs, err := fetchUmbrellaWith(fe, "o/r", 100)
+			umb, subs, err := fetchUmbrellaWith(context.Background(), fe, "o/r", 100)
 			if tt.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 					t.Fatalf("err = %v, want containing %q", err, tt.wantErr)
@@ -97,6 +98,51 @@ func TestFetchUmbrellaWith(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ctxFakeExecer records whether the context-aware path was taken and honors
+// context cancellation, so tests can assert FetchUmbrella threads its context.
+type ctxFakeExecer struct {
+	output  []byte
+	usedCtx bool
+}
+
+func (c *ctxFakeExecer) run(_ ...string) ([]byte, error) { return c.output, nil }
+
+func (c *ctxFakeExecer) runCtx(ctx context.Context, _ ...string) ([]byte, error) {
+	c.usedCtx = true
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return c.output, nil
+}
+
+func TestFetchUmbrellaWith_UsesContext(t *testing.T) {
+	t.Parallel()
+	valid := umbrellaResponse(
+		`"number":100,"title":"u","body":"","url":"https://github.com/o/r/issues/100","state":"OPEN","repository":{"name":"r","nameWithOwner":"o/r"}`,
+		`[]`)
+
+	t.Run("context-aware execer is used", func(t *testing.T) {
+		t.Parallel()
+		fe := &ctxFakeExecer{output: []byte(valid)}
+		if _, _, err := fetchUmbrellaWith(context.Background(), fe, "o/r", 100); err != nil {
+			t.Fatalf("fetch: %v", err)
+		}
+		if !fe.usedCtx {
+			t.Fatal("expected the context-aware runCtx path to be used")
+		}
+	})
+
+	t.Run("cancelled context aborts the fetch", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		fe := &ctxFakeExecer{output: []byte(valid)}
+		if _, _, err := fetchUmbrellaWith(ctx, fe, "o/r", 100); err == nil {
+			t.Fatal("expected an error from a cancelled context")
+		}
+	})
 }
 
 func TestSplitOwnerRepo(t *testing.T) {

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -16,6 +16,10 @@ import (
 // cannot wedge an expansion indefinitely.
 const PlannerTimeout = 5 * time.Minute
 
+// FetchTimeout bounds the GitHub sub-issue fetch so a stalled gh call cannot
+// wedge the caller (notably the issue poll loop).
+const FetchTimeout = 60 * time.Second
+
 // Result summarizes an expansion.
 type Result struct {
 	UmbrellaURL string
@@ -35,7 +39,9 @@ func Expand(ctx context.Context, tasks *task.Manager, run Runner, issueURL strin
 	if !ok {
 		return Result{}, fmt.Errorf("not a GitHub issue URL: %s", issueURL)
 	}
-	umb, subs, err := github.FetchUmbrella(repo, number)
+	fctx, fcancel := context.WithTimeout(ctx, FetchTimeout)
+	umb, subs, err := github.FetchUmbrella(fctx, repo, number)
+	fcancel()
 	if err != nil {
 		return Result{}, fmt.Errorf("fetch umbrella: %w", err)
 	}

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -20,6 +20,14 @@ const PlannerTimeout = 5 * time.Minute
 // wedge the caller (notably the issue poll loop).
 const FetchTimeout = 60 * time.Second
 
+// fetchUmbrellaBounded fetches the umbrella under FetchTimeout, releasing the
+// timer as soon as the fetch returns (defer right after WithTimeout).
+func fetchUmbrellaBounded(ctx context.Context, repo string, number int) (umbrella github.Issue, subs []github.Issue, err error) {
+	fctx, cancel := context.WithTimeout(ctx, FetchTimeout)
+	defer cancel()
+	return github.FetchUmbrella(fctx, repo, number)
+}
+
 // Result summarizes an expansion.
 type Result struct {
 	UmbrellaURL string
@@ -39,9 +47,7 @@ func Expand(ctx context.Context, tasks *task.Manager, run Runner, issueURL strin
 	if !ok {
 		return Result{}, fmt.Errorf("not a GitHub issue URL: %s", issueURL)
 	}
-	fctx, fcancel := context.WithTimeout(ctx, FetchTimeout)
-	umb, subs, err := github.FetchUmbrella(fctx, repo, number)
-	fcancel()
+	umb, subs, err := fetchUmbrellaBounded(ctx, repo, number)
 	if err != nil {
 		return Result{}, fmt.Errorf("fetch umbrella: %w", err)
 	}


### PR DESCRIPTION
## Motivation

Follow-up to the umbrella auto-detect work (#1139). `FetchUmbrella` shelled out to `gh` via the context-less execer, so a stalled GitHub call could wedge the issue poll loop indefinitely — the planner step was timeout-bounded but the fetch was not.

## Implementation information

- Add an optional context-aware extension to the github `execer`: `ghExecer.runCtx` runs `gh` under `exec.CommandContext` (reusing the existing `ghRunCtx` + request gate); a `runE(ctx, e, …)` helper uses it when available and falls back to the plain `run` for test fakes.
- `runGHAPIWith` keeps its exact behavior, delegating to a new `runGHAPICtxWith` that threads the context to the gh process and aborts the retry loop on cancellation.
- `FetchUmbrella` takes a context; `Expand` bounds the fetch with a 60s `FetchTimeout`.

Tested: the context-aware path is exercised and a cancelled context aborts the fetch. Full suite, lint, nilaway clean; bindings no-drift.

> Changelog: skip