### PR TITLE
fix(umbrella): complete childless trackers

### DIFF
--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -2,6 +2,7 @@ package sybra
 
 import (
 	"slices"
+	"time"
 
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/task"
@@ -12,6 +13,12 @@ import (
 // gate requires it to release and strips it on release. Aliased from the
 // umbrella package so the CLI expander and this gate cannot drift.
 const umbrellaGatedTag = umbrella.GatedTag
+
+// umbrellaSettleDelay is how long after creation a childless umbrella tracker
+// must persist before the gate treats it as complete. Comfortably exceeds the
+// 1-minute orchestrator tick so a tracker whose children are still being
+// materialized in the same expansion is never closed prematurely.
+const umbrellaSettleDelay = 2 * time.Minute
 
 // umbrellaState aggregates one umbrella's tracker and children for a gate tick.
 type umbrellaState struct {
@@ -158,7 +165,11 @@ func (a *App) rollupTrackers(states map[string]*umbrellaState, cyclic map[string
 		if st.tracker == nil {
 			continue
 		}
-		desired, reason, doClose := trackerRollup(st, cyclic[key])
+		// A tracker is "settled" once it has outlived the creation window, so a
+		// childless tally that just reflects children still being materialized
+		// is not mistaken for a completed umbrella.
+		settled := time.Since(st.tracker.CreatedAt) > umbrellaSettleDelay
+		desired, reason, doClose := trackerRollup(st, cyclic[key], settled)
 		if desired == st.tracker.Status {
 			continue
 		}
@@ -181,8 +192,11 @@ func (a *App) rollupTrackers(states map[string]*umbrellaState, cyclic map[string
 
 // trackerRollup decides an umbrella tracker's status from its children. A
 // cycle, a stuck (human-required) child, or a cancelled child surfaces as
-// human-required (halting only that chain); all-done closes the umbrella.
-func trackerRollup(st *umbrellaState, cyclic bool) (status task.Status, reason string, doClose bool) {
+// human-required (halting only that chain); all-done closes the umbrella. A
+// tracker with no children (every sub-issue was already closed at expansion)
+// is vacuously complete, but only once `settled` so a tracker observed while
+// its children are still being materialized is not closed prematurely.
+func trackerRollup(st *umbrellaState, cyclic, settled bool) (status task.Status, reason string, doClose bool) {
 	switch {
 	case cyclic:
 		return task.StatusHumanRequired, "umbrella dependency cycle detected", false
@@ -192,6 +206,8 @@ func trackerRollup(st *umbrellaState, cyclic bool) (status task.Status, reason s
 		return task.StatusHumanRequired, "umbrella child was cancelled", false
 	case st.total > 0 && st.doneCount == st.total:
 		return task.StatusDone, "all umbrella children complete", true
+	case st.total == 0 && settled:
+		return task.StatusDone, "umbrella has no open sub-issues", true
 	default:
 		return task.StatusInProgress, "umbrella in progress", false
 	}

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -167,8 +167,11 @@ func (a *App) rollupTrackers(states map[string]*umbrellaState, cyclic map[string
 		}
 		// A tracker is "settled" once it has outlived the creation window, so a
 		// childless tally that just reflects children still being materialized
-		// is not mistaken for a completed umbrella.
-		settled := time.Since(st.tracker.CreatedAt) > umbrellaSettleDelay
+		// is not mistaken for a completed umbrella. A zero CreatedAt (e.g. a
+		// task file missing created_at) is treated as not settled rather than
+		// infinitely old, so it never bypasses the guard.
+		settled := !st.tracker.CreatedAt.IsZero() &&
+			time.Since(st.tracker.CreatedAt) > umbrellaSettleDelay
 		desired, reason, doClose := trackerRollup(st, cyclic[key], settled)
 		if desired == st.tracker.Status {
 			continue

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -102,6 +102,56 @@ func TestReleaseUnblockedChildren_RollupClosesUmbrella(t *testing.T) {
 	}
 }
 
+func TestTrackerRollup(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		st              umbrellaState
+		cyclic, settled bool
+		want            task.Status
+		wantClose       bool
+	}{
+		{"cycle", umbrellaState{total: 2}, true, true, task.StatusHumanRequired, false},
+		{"stuck child", umbrellaState{total: 2, anyHR: true}, false, true, task.StatusHumanRequired, false},
+		{"cancelled child", umbrellaState{total: 2, anyCancelled: true}, false, true, task.StatusHumanRequired, false},
+		{"all done", umbrellaState{total: 2, doneCount: 2}, false, true, task.StatusDone, true},
+		{"in progress", umbrellaState{total: 2, doneCount: 1}, false, true, task.StatusInProgress, false},
+		{"zero children settled completes", umbrellaState{total: 0}, false, true, task.StatusDone, true},
+		{"zero children not settled holds", umbrellaState{total: 0}, false, false, task.StatusInProgress, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			st := tt.st
+			got, _, doClose := trackerRollup(&st, tt.cyclic, tt.settled)
+			if got != tt.want || doClose != tt.wantClose {
+				t.Fatalf("trackerRollup = (%q, close=%v), want (%q, close=%v)", got, doClose, tt.want, tt.wantClose)
+			}
+		})
+	}
+}
+
+func TestReleaseUnblockedChildren_EmptyTrackerHeldUntilSettled(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	closes := 0
+	app.umbrellaCloseIssue = func(string, int, string) error { closes++; return nil }
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+	// Tracker with no children, created just now → not yet settled.
+	tracker := mkTracker(t, m, umb, 5)
+
+	app.releaseUnblockedChildren()
+
+	// A freshly-created childless tracker must not be closed — its children may
+	// still be materializing in the same expansion.
+	if got := mustStatus(t, m, tracker.ID); got != task.StatusInProgress {
+		t.Fatalf("tracker = %q, want in-progress until settled", got)
+	}
+	if closes != 0 {
+		t.Fatalf("childless tracker closed %d times before settling", closes)
+	}
+}
+
 func TestReleaseUnblockedChildren_CancelledChildSurfaces(t *testing.T) {
 	t.Parallel()
 	app, m := newUmbrellaGateApp(t)


### PR DESCRIPTION
## Motivation

Follow-up to the umbrella work. An umbrella whose sub-issues were all already closed at expansion produces a tracker with **zero** children, which the gate's roll-up left `in-progress` forever (never `done`, never closing the issue).

## Implementation information

`trackerRollup` now completes a childless tracker (→ `done` + close the umbrella) — but only once the tracker has **settled** (`time.Since(CreatedAt) > umbrellaSettleDelay`, 2 min, comfortably past the 1-min tick). The settle guard prevents a tracker observed mid-materialization (children written microseconds later in the same expansion) from being closed prematurely.

Covered by a table-driven `trackerRollup` test (incl. settled vs not-settled) and an integration test asserting a freshly-created childless tracker is held, not closed.

> Changelog: skip