### PR TITLE
feat(workflow): codex output-schema support

### DIFF
--- a/cmd/fake-codex/main.go
+++ b/cmd/fake-codex/main.go
@@ -92,6 +92,12 @@ func runExec() {
 			"code":    529,
 		})
 		os.Exit(1)
+	case "test_verdict_pass":
+		emitAgentMessage(`{"verdict":"PASS","summary":"could not break it"}`)
+		emitTurnCompleted(100, 20)
+	case "test_verdict_fail":
+		emitAgentMessage(`{"verdict":"FAIL","summary":"feature misbehaves on edge input"}`)
+		emitTurnCompleted(100, 20)
 	case "implement", "interactive_implement":
 		emitAgentMessage("Implementing...")
 		emitTurnCompleted(100, 20)

--- a/cmd/fake-codex/main.go
+++ b/cmd/fake-codex/main.go
@@ -93,10 +93,10 @@ func runExec() {
 		})
 		os.Exit(1)
 	case "test_verdict_pass":
-		emitAgentMessage(`{"verdict":"PASS","summary":"could not break it"}`)
+		emitAgentMessage(`{"verdict":"PASS"}`)
 		emitTurnCompleted(100, 20)
 	case "test_verdict_fail":
-		emitAgentMessage(`{"verdict":"FAIL","summary":"feature misbehaves on edge input"}`)
+		emitAgentMessage(`{"verdict":"FAIL"}`)
 		emitTurnCompleted(100, 20)
 	case "implement", "interactive_implement":
 		emitAgentMessage("Implementing...")

--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -475,6 +475,13 @@ export class StepConfig {
      */
     "importSidecar"?: ImportSidecar | null;
 
+    /**
+     * run_agent (codex only): inline JSON Schema enforced on the model's final
+     * message via `codex exec --output-schema`. Ignored by claude/copilot, which
+     * use prompt-driven structured output. Empty = no enforcement.
+     */
+    "outputSchema"?: string;
+
     /** Creates a new StepConfig instance. */
     constructor($$source: Partial<StepConfig> = {}) {
         if (!("role" in $$source)) {

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -700,6 +700,14 @@ type RunConfig struct {
 	// implementation worktree, so seeding them would feed an independent
 	// reviewer/tester the implementer's notes. No-op if the dir has no NOTES.md.
 	SeedWorkingMemory bool
+	// OutputSchema is an inline JSON Schema (codex only). The runner writes it
+	// to a temp file and passes --output-schema <path> to codex exec. Empty =
+	// no schema enforcement. Ignored by claude/copilot.
+	OutputSchema string
+	// outputSchemaPath is the temp file path the runner wrote OutputSchema to.
+	// Set intra-package before buildHeadlessInvocation; cleared by defer after
+	// the subprocess exits. Never set by callers.
+	outputSchemaPath string
 }
 
 // PlanStep represents a single item from a TodoWrite tool call.

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -111,6 +111,27 @@ func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfi
 	if outFile == nil {
 		return false, nil
 	}
+
+	// Materialize the output schema to a temp file for codex so
+	// buildHeadlessInvocation can pass --output-schema <path>. The file is
+	// removed after cmd.Wait() returns (subprocess has exited), so there is no
+	// read-after-delete risk. os.CreateTemp gives a unique name per attempt so
+	// concurrent agents or retries never collide.
+	if normalizeProvider(a.Provider) == "codex" && cfg.OutputSchema != "" {
+		f, schemaErr := os.CreateTemp("", "sybra-codex-schema-*.json")
+		if schemaErr != nil {
+			return false, fmt.Errorf("create codex output schema: %w", schemaErr)
+		}
+		if _, wErr := f.WriteString(cfg.OutputSchema); wErr != nil {
+			_ = f.Close()
+			_ = os.Remove(f.Name())
+			return false, fmt.Errorf("write codex output schema: %w", wErr)
+		}
+		_ = f.Close()
+		cfg.outputSchemaPath = f.Name()
+		defer os.Remove(cfg.outputSchemaPath)
+	}
+
 	name, args, invokeEnv, command, err := buildHeadlessInvocation(a, cfg)
 	if err != nil {
 		return false, err

--- a/internal/agent/runner_headless_invocation.go
+++ b/internal/agent/runner_headless_invocation.go
@@ -43,6 +43,9 @@ func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args, env []
 		if a.sessionCWD != "" {
 			args = append(args, "-C", a.sessionCWD)
 		}
+		if cfg.outputSchemaPath != "" {
+			args = append(args, "--output-schema", cfg.outputSchemaPath)
+		}
 		prompt := rewriteSkillInvocations(cfg.Prompt, discoverCodexSkills())
 		args = append(args, prompt)
 		command = "codex " + strings.Join(args, " ")

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -1054,6 +1054,61 @@ func TestBuildHeadlessInvocation_FallbackModel(t *testing.T) {
 	})
 }
 
+// TestBuildHeadlessInvocation_OutputSchema verifies the --output-schema flag
+// is appended to codex args when cfg.outputSchemaPath is set, and is absent
+// for claude and when the path is empty.
+func TestBuildHeadlessInvocation_OutputSchema(t *testing.T) {
+	t.Parallel()
+
+	t.Run("codex_with_schema_path", func(t *testing.T) {
+		a := &Agent{ID: "a", Provider: "codex"}
+		_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{
+			Prompt:           "run tests",
+			outputSchemaPath: "/tmp/sybra-codex-schema-12345.json",
+		})
+		if err != nil {
+			t.Fatalf("buildHeadlessInvocation: %v", err)
+		}
+		idx := slices.Index(args, "--output-schema")
+		if idx < 0 {
+			t.Fatalf("args missing --output-schema; got %v", args)
+		}
+		if idx+1 >= len(args) || args[idx+1] != "/tmp/sybra-codex-schema-12345.json" {
+			t.Errorf("--output-schema value wrong; args=%v", args)
+		}
+		// Flag must appear before the prompt (last element).
+		promptIdx := len(args) - 1
+		if idx >= promptIdx {
+			t.Errorf("--output-schema must precede the prompt; flag at %d, prompt at %d; args=%v", idx, promptIdx, args)
+		}
+	})
+
+	t.Run("codex_without_schema_path", func(t *testing.T) {
+		a := &Agent{ID: "a", Provider: "codex"}
+		_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{Prompt: "run tests"})
+		if err != nil {
+			t.Fatalf("buildHeadlessInvocation: %v", err)
+		}
+		if slices.Contains(args, "--output-schema") {
+			t.Fatalf("--output-schema must be absent when outputSchemaPath empty; got %v", args)
+		}
+	})
+
+	t.Run("claude_ignores_schema_path", func(t *testing.T) {
+		a := &Agent{ID: "a", Provider: "claude"}
+		_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{
+			Prompt:           "run tests",
+			outputSchemaPath: "/tmp/some-schema.json",
+		})
+		if err != nil {
+			t.Fatalf("buildHeadlessInvocation: %v", err)
+		}
+		if slices.Contains(args, "--output-schema") {
+			t.Fatalf("--output-schema must not appear for claude provider; got %v", args)
+		}
+	})
+}
+
 // TestCodexSandboxArgs_HeadlessAlwaysBypasses pins the invariant that headless
 // codex always bypasses approvals even when RequirePermissions=true. Interactive
 // mode with RequirePermissions=true must use --sandbox workspace-write.

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -75,11 +75,22 @@ type AgentCompletionHandler struct {
 // once per terminal agent state transition.
 func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 	var resultContent string
+	var hasResultEvent bool
 	outputs := ag.Output()
 	for i := range outputs {
 		if outputs[i].Type == "result" {
 			resultContent = outputs[i].Content
+			hasResultEvent = true
 		}
+	}
+	// Codex's terminal turn.completed event carries no text — the final message
+	// arrives as an assistant StreamEvent. When a result event was seen but
+	// carried empty content, fall back to the last assistant turn so that
+	// result-dependent paths (extractTestVerdict, PR-URL scraping) work for
+	// codex too. Guard with hasResultEvent so agents that exit-0 without
+	// emitting any result event (no_result scenario) are NOT back-filled.
+	if hasResultEvent && resultContent == "" {
+		resultContent = lastAssistantText(ag)
 	}
 
 	// Snapshot mutable fields once under the agent's lock so both the

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -178,38 +178,8 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 		h.pushFixReviewBranch(ag)
 	}
 
-	if h.workflowEngine != nil {
-		// Stall when (a) the process was killed by signal (ws.Signaled or the
-		// conventional 128+N exit codes claude/codex use after catching the
-		// signal), or (b) Sybra's own StopAgent set the `stopped` flag — even
-		// if the child exited cleanly. The latter is load-bearing: PR #722's
-		// SIGINT-first path lets default Go binaries (e.g. fake-claude in
-		// tests) terminate via the runtime's signal handler with ExitStatus=2
-		// (NOT WaitStatus.Signaled), so isSignalKill alone misses
-		// Sybra-initiated stops — the failure mode reported in #641 plus the
-		// flake in TestE2E_HeadlessAgent_StopAgent_DoesNotAdvanceWorkflow.
-		// A transient provider limit (rate/session/usage limit) is not a real
-		// failure: marking the step failed would route verify_commits to
-		// human-required and strand the task. Stall instead, like a signal
-		// kill — the task stays in-progress and the gate-aware recovery loops
-		// re-dispatch once the provider's limit window clears. Auth failures are
-		// deliberately excluded: they need a human to log in, so they fall
-		// through to the normal failed→human-required path.
-		rateLimited := isRateLimitedRun(ag, exitErr)
-		if isSignalKill(exitErr) || ag.WasStopped() || rateLimited {
-			h.logger.Warn("agent.completion.stall",
-				"task_id", ag.TaskID, "agent_id", ag.ID,
-				"signaled", isSignalKill(exitErr), "stopped", ag.WasStopped(),
-				"rate_limited", rateLimited)
-			h.workflowEngine.ClearAgentStep(ag.ID)
-			return
-		}
-		h.workflowEngine.HandleAgentComplete(ag.TaskID, workflow.AgentCompletion{
-			AgentID:  ag.ID,
-			Result:   resultContent,
-			Provider: ag.Provider,
-			Success:  exitErr == nil,
-		})
+	if !h.notifyWorkflowEngine(ag, resultContent, exitErr) {
+		return
 	}
 
 	// Worktree and sandbox cleanup for terminal tasks (after engine
@@ -220,6 +190,38 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 			go h.sandboxes.Stop(ag.TaskID)
 		}
 	}
+}
+
+// notifyWorkflowEngine advances the workflow engine for a completed agent.
+// Returns false if the caller should return immediately (agent was stalled).
+// Stall conditions: signal kill, Sybra-initiated stop, or transient rate limit.
+// Auth failures fall through (need human login) — they take the normal failed path.
+//
+// Load-bearing: PR #722's SIGINT-first path lets default Go binaries (e.g.
+// fake-claude in tests) exit with code 2 (NOT WaitStatus.Signaled), so
+// isSignalKill alone misses Sybra-initiated stops — the failure mode from #641.
+// Rate limits stall rather than marking failed to avoid stranding tasks in
+// human-required while the provider's window clears.
+func (h *AgentCompletionHandler) notifyWorkflowEngine(ag *agent.Agent, resultContent string, exitErr error) bool {
+	if h.workflowEngine == nil {
+		return true
+	}
+	rateLimited := isRateLimitedRun(ag, exitErr)
+	if isSignalKill(exitErr) || ag.WasStopped() || rateLimited {
+		h.logger.Warn("agent.completion.stall",
+			"task_id", ag.TaskID, "agent_id", ag.ID,
+			"signaled", isSignalKill(exitErr), "stopped", ag.WasStopped(),
+			"rate_limited", rateLimited)
+		h.workflowEngine.ClearAgentStep(ag.ID)
+		return false
+	}
+	h.workflowEngine.HandleAgentComplete(ag.TaskID, workflow.AgentCompletion{
+		AgentID:  ag.ID,
+		Result:   resultContent,
+		Provider: ag.Provider,
+		Success:  exitErr == nil,
+	})
+	return true
 }
 
 func (h *AgentCompletionHandler) markCompletedReview(ag *agent.Agent, exitErr error) {

--- a/internal/sybra/agent_completion_test.go
+++ b/internal/sybra/agent_completion_test.go
@@ -145,6 +145,89 @@ func TestIsSignalKill(t *testing.T) {
 	}
 }
 
+// TestLastAssistantText verifies that lastAssistantText returns the last
+// assistant-typed event's content without sybra-verdict gating, and that
+// a populated result event is preferred when present (guards against the
+// fallback overriding a real result).
+func TestLastAssistantText(t *testing.T) {
+	t.Parallel()
+
+	makeAgent := func(events ...agent.StreamEvent) *agent.Agent {
+		ag := &agent.Agent{}
+		for _, ev := range events {
+			ag.AppendOutput(ev)
+		}
+		return ag
+	}
+
+	t.Run("returns_last_assistant", func(t *testing.T) {
+		ag := makeAgent(
+			agent.StreamEvent{Type: "assistant", Content: "first message"},
+			agent.StreamEvent{Type: "assistant", Content: "final message"},
+		)
+		got := lastAssistantText(ag)
+		if got != "final message" {
+			t.Errorf("lastAssistantText = %q, want %q", got, "final message")
+		}
+	})
+
+	t.Run("no_assistant_events_returns_empty", func(t *testing.T) {
+		ag := makeAgent(
+			agent.StreamEvent{Type: "result", Content: "some result"},
+		)
+		got := lastAssistantText(ag)
+		if got != "" {
+			t.Errorf("lastAssistantText = %q, want empty", got)
+		}
+	})
+
+	t.Run("no_events_returns_empty", func(t *testing.T) {
+		ag := &agent.Agent{}
+		if got := lastAssistantText(ag); got != "" {
+			t.Errorf("lastAssistantText = %q, want empty", got)
+		}
+	})
+
+	// B3 fallback: result event empty → falls back to last assistant text.
+	t.Run("b3_fallback_result_empty", func(t *testing.T) {
+		ag := makeAgent(
+			agent.StreamEvent{Type: "assistant", Content: `{"verdict":"PASS"}`},
+			agent.StreamEvent{Type: "result", Content: ""},
+		)
+		// Confirm lastAssistantText gives the assistant body.
+		got := lastAssistantText(ag)
+		if got != `{"verdict":"PASS"}` {
+			t.Errorf("lastAssistantText = %q, want JSON verdict", got)
+		}
+	})
+
+	// B3 preserved: populated result event must NOT be overridden.
+	t.Run("b3_preserved_result_populated", func(t *testing.T) {
+		ag := makeAgent(
+			agent.StreamEvent{Type: "assistant", Content: "assistant text"},
+			agent.StreamEvent{Type: "result", Content: "real result"},
+		)
+		// lastAssistantText itself just returns assistant content; the
+		// OnComplete guard (hasResultEvent && resultContent == "") keeps result intact.
+		// Verify the result event's content is accessible as-is.
+		out := ag.Output()
+		var resultContent string
+		for i := range out {
+			if out[i].Type == "result" {
+				resultContent = out[i].Content
+			}
+		}
+		if resultContent != "real result" {
+			t.Errorf("result content = %q, want %q", resultContent, "real result")
+		}
+		// lastAssistantText returns assistant text — the guard in OnComplete
+		// ensures this would not replace a non-empty result.
+		if last := lastAssistantText(ag); last != "assistant text" {
+			t.Errorf("lastAssistantText = %q, want %q", last, "assistant text")
+		}
+	})
+}
+
 // itoa converts a small non-negative int to its decimal string representation
 // without importing strconv (avoids an extra import just for test helpers).
 func itoa(n int) string {

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -534,6 +534,20 @@ func finalAssistantText(ag *agent.Agent) string {
 	return ""
 }
 
+// lastAssistantText returns the content of the last assistant-typed stream event.
+// Unlike finalAssistantText it applies no sybra-verdict gating — it is the
+// general "what did the model say last" accessor used to fill c.Result for
+// providers (codex) whose terminal turn.completed event carries no text.
+func lastAssistantText(ag *agent.Agent) string {
+	out := ag.Output()
+	for i := range slices.Backward(out) {
+		if out[i].Type == "assistant" {
+			return out[i].Content
+		}
+	}
+	return ""
+}
+
 // appendSection appends a `## header` section to body, separated by a blank
 // line. Keeps the source body intact even if it already ends without newline.
 func appendSection(body, header, content string) string {

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -304,7 +304,7 @@ type agentAdapter struct {
 	sandboxes *sandbox.Manager
 }
 
-func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool) (string, error) {
+func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool, outputSchema string) (string, error) {
 	// (A pending watchdog headless-nudge steer is consumed upstream in
 	// execRunAgent, before the prompt reaches here.)
 
@@ -356,6 +356,7 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		// NOTES.md; verifier roles (review/test-runner/eval) share the same
 		// worktree but must stay independent of the implementer's scratchpad.
 		SeedWorkingMemory: r.AuthorsCode(),
+		OutputSchema:      outputSchema,
 	}
 
 	// Caller-provided dir takes precedence (e.g. pr-fix flow pre-stages a

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -252,11 +252,20 @@ func setupE2EProvider(t *testing.T, provider, scenario string) *e2eEnv {
 		env.pendingCompletions.Add(1)
 		defer env.pendingCompletions.Add(-1)
 		var result string
+		var hasResult bool
 		output := ag.Output()
 		for i := range output {
 			if output[i].Type == "result" {
 				result = output[i].Content
+				hasResult = true
 			}
+		}
+		// B3: codex's turn.completed carries no text — fall back to the last
+		// assistant event so the workflow engine receives the model's response.
+		// Guard with hasResult so agents that exit-0 without any result event
+		// (no_result scenario) are not back-filled with assistant text.
+		if hasResult && result == "" {
+			result = lastAssistantText(ag)
 		}
 		engine.HandleAgentComplete(ag.TaskID, workflow.AgentCompletion{
 			AgentID:  ag.ID,
@@ -2014,6 +2023,129 @@ func TestE2E_TestingTaskWorkflow_FailEscalatesAtCap(t *testing.T) {
 	tk, _ := env.tasks.Get(created.ID)
 	if tk.Status != task.StatusHumanRequired {
 		t.Errorf("status at attempt cap = %q, want %q", tk.Status, task.StatusHumanRequired)
+	}
+}
+
+// testTestingTaskWithOutputSchemaYAML mirrors testTestingTaskWorkflowYAML but
+// includes output_schema on the run_test step so --output-schema is passed to
+// codex and the JSON agent_message is captured via the B3 fallback.
+const testTestingTaskWithOutputSchemaYAML = `id: testing-task
+name: Test Manual Testing (with schema)
+trigger:
+  on: task.status_changed
+  conditions:
+    - field: task.status
+      operator: equals
+      value: testing
+steps:
+  - id: run_test
+    name: Adversarial Testing
+    type: run_agent
+    config:
+      role: test-runner
+      mode: headless
+      model: sonnet
+      output_schema: '{"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]},"summary":{"type":"string"}},"required":["verdict"],"additionalProperties":false}'
+      prompt: 'Test {{.Task.ID}}'
+    next:
+      - goto: route_test
+
+  - id: route_test
+    name: Route Test Result
+    type: route_test_result
+    next:
+      - goto: ""
+`
+
+// installTestingTaskWithOutputSchemaWorkflow writes the fixture with
+// output_schema into the engine's workflow store.
+func installTestingTaskWithOutputSchemaWorkflow(t *testing.T, env *e2eEnv) {
+	t.Helper()
+	if err := os.WriteFile(
+		filepath.Join(env.wfStore.Dir(), "testing-task.yaml"),
+		[]byte(testTestingTaskWithOutputSchemaYAML), 0o644,
+	); err != nil {
+		t.Fatalf("write testing-task.yaml: %v", err)
+	}
+}
+
+// TestE2E_Codex_TestVerdict_Pass_JSON verifies that when the codex provider
+// emits a schema-valid JSON verdict object as its final agent_message:
+//  1. The B3 fallback captures it as the run's result (resultContent).
+//  2. extractTestVerdict parses "PASS" from the JSON → route_test_result
+//     flips the task to ready-pr.
+//  3. The --output-schema flag reaches fake-codex via FAKE_CODEX_ARGS_LOG.
+func TestE2E_Codex_TestVerdict_Pass_JSON(t *testing.T) {
+	argsLog := filepath.Join(t.TempDir(), "codex-args.log")
+	t.Setenv("FAKE_CODEX_ARGS_LOG", argsLog)
+
+	env := setupE2EMultiProvider(t, "codex", []string{"test_verdict_pass"})
+	installTestingTaskWithOutputSchemaWorkflow(t, env)
+
+	created, err := env.tasks.Create("codex json verdict pass", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := env.engine.DispatchEvent(created.ID, "task.status_changed",
+		map[string]string{"task.status": string(task.StatusTesting)},
+		map[string]string{workflow.WorkflowVarDir: env.agentDir}); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+
+	waitFor(t, 20*time.Second, "workflow completes", func() bool {
+		tk, gErr := env.tasks.Get(created.ID)
+		if gErr != nil {
+			return false
+		}
+		return tk.Workflow != nil && tk.Workflow.State == workflow.ExecCompleted
+	})
+
+	tk, _ := env.tasks.Get(created.ID)
+	if tk.Status != task.StatusReadyPR {
+		t.Errorf("status after JSON PASS = %q, want %q", tk.Status, task.StatusReadyPR)
+	}
+
+	// Verify --output-schema reached fake-codex.
+	waitFor(t, 5*time.Second, "args log written", func() bool {
+		_, statErr := os.Stat(argsLog)
+		return statErr == nil
+	})
+	if data, readErr := os.ReadFile(argsLog); readErr == nil {
+		if !strings.Contains(string(data), "--output-schema") {
+			t.Errorf("--output-schema missing from codex args:\n%s", string(data))
+		}
+	}
+}
+
+// TestE2E_Codex_TestVerdict_Fail_JSON verifies that a JSON FAIL verdict from
+// codex routes the task back to in-progress (re-implement path).
+func TestE2E_Codex_TestVerdict_Fail_JSON(t *testing.T) {
+	env := setupE2EMultiProvider(t, "codex", []string{"test_verdict_fail"})
+	installTestingTaskWithOutputSchemaWorkflow(t, env)
+
+	created, err := env.tasks.Create("codex json verdict fail", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := env.engine.DispatchEvent(created.ID, "task.status_changed",
+		map[string]string{"task.status": string(task.StatusTesting)},
+		map[string]string{workflow.WorkflowVarDir: env.agentDir}); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+
+	waitFor(t, 20*time.Second, "workflow completes", func() bool {
+		tk, gErr := env.tasks.Get(created.ID)
+		if gErr != nil {
+			return false
+		}
+		return tk.Workflow != nil && tk.Workflow.State == workflow.ExecCompleted
+	})
+
+	tk, _ := env.tasks.Get(created.ID)
+	if tk.Status != task.StatusInProgress {
+		t.Errorf("status after JSON FAIL = %q, want %q", tk.Status, task.StatusInProgress)
 	}
 }
 

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -2045,7 +2045,7 @@ steps:
       role: test-runner
       mode: headless
       model: sonnet
-      output_schema: '{"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]},"summary":{"type":"string"}},"required":["verdict"],"additionalProperties":false}'
+      output_schema: '{"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]}},"required":["verdict"],"additionalProperties":false}'
       prompt: 'Test {{.Task.ID}}'
     next:
       - goto: route_test

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -21,7 +21,7 @@ type AgentCompletion struct {
 // workflow steps that expect a single turn — otherwise the agent sits paused
 // forever and the workflow never advances to the next step.
 type AgentLauncher interface {
-	StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool) (agentID string, err error)
+	StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool, outputSchema string) (agentID string, err error)
 	HasRunningAgent(taskID string) bool
 	// HasOtherRunningAgentForTask reports whether an agent other than
 	// exceptAgentID is still running for the task. verify_commits uses it to

--- a/internal/workflow/builtin/testing-task.yaml
+++ b/internal/workflow/builtin/testing-task.yaml
@@ -52,7 +52,7 @@ steps:
       needs_worktree: true
       max_retries: 1
       output_schema: >-
-        {"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]},"summary":{"type":"string"}},"required":["verdict"],"additionalProperties":false}
+        {"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]}},"required":["verdict"],"additionalProperties":false}
       prompt: >-
         Adversarially test task {{.Task.ID}} using the /sybra-test skill.
 

--- a/internal/workflow/builtin/testing-task.yaml
+++ b/internal/workflow/builtin/testing-task.yaml
@@ -51,6 +51,8 @@ steps:
       provider: cross
       needs_worktree: true
       max_retries: 1
+      output_schema: >-
+        {"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]},"summary":{"type":"string"}},"required":["verdict"],"additionalProperties":false}
       prompt: >-
         Adversarially test task {{.Task.ID}} using the /sybra-test skill.
 

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -427,3 +427,35 @@ func TestSyncBuiltins_IdempotentOnClean(t *testing.T) {
 			before.UpdatedAt, after.UpdatedAt)
 	}
 }
+
+// TestBuiltinTestingTask_RunTestOutputSchema verifies that the testing-task
+// builtin's run_test step carries a non-empty OutputSchema that round-trips
+// through YAML without alteration. Exact-string assertion so YAML folding
+// or escaping errors surface immediately rather than silently passing an
+// empty schema to codex.
+func TestBuiltinTestingTask_RunTestOutputSchema(t *testing.T) {
+	t.Parallel()
+
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var testingDef *Definition
+	for i := range defs {
+		if defs[i].ID == "testing-task" {
+			testingDef = &defs[i]
+			break
+		}
+	}
+	if testingDef == nil {
+		t.Fatal("testing-task builtin definition not found")
+	}
+	step := testingDef.StepByID("run_test")
+	if step == nil {
+		t.Fatal("run_test step not found in testing-task")
+	}
+	const wantSchema = `{"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]},"summary":{"type":"string"}},"required":["verdict"],"additionalProperties":false}`
+	if step.Config.OutputSchema != wantSchema {
+		t.Errorf("run_test.Config.OutputSchema =\n%q\nwant:\n%q", step.Config.OutputSchema, wantSchema)
+	}
+}

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -454,7 +454,7 @@ func TestBuiltinTestingTask_RunTestOutputSchema(t *testing.T) {
 	if step == nil {
 		t.Fatal("run_test step not found in testing-task")
 	}
-	const wantSchema = `{"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]},"summary":{"type":"string"}},"required":["verdict"],"additionalProperties":false}`
+	const wantSchema = `{"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]}},"required":["verdict"],"additionalProperties":false}`
 	if step.Config.OutputSchema != wantSchema {
 		t.Errorf("run_test.Config.OutputSchema =\n%q\nwant:\n%q", step.Config.OutputSchema, wantSchema)
 	}

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -132,7 +132,7 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 	// event so claude exits and onComplete fires, unblocking the next step
 	// (e.g. evaluate). Without this, the workflow stalls on implement forever.
 	oneShot := mode == "interactive" && !step.Config.ReuseAgent && step.Config.WaitForStatus == ""
-	agentID, err := e.agents.StartAgent(taskID, step.Config.Role, mode, model, provider, prompt, dir, step.Config.AllowedTools, step.Config.NeedsWorktree, oneShot)
+	agentID, err := e.agents.StartAgent(taskID, step.Config.Role, mode, model, provider, prompt, dir, step.Config.AllowedTools, step.Config.NeedsWorktree, oneShot, step.Config.OutputSchema)
 	if err != nil {
 		// Another dispatcher already holds the per-task dispatch claim (e.g. the
 		// recovery loop won the race for this task). That agent will run and its

--- a/internal/workflow/engine_steps_parallel.go
+++ b/internal/workflow/engine_steps_parallel.go
@@ -145,7 +145,7 @@ func (e *Engine) spawnParallelChild(taskID string, parent, child *Step, wfExec *
 	// Fast-exiting agents (e.g. fail_exit in tests) can otherwise complete
 	// before agentSteps is populated, causing the wrong step to advance.
 	e.mu.Lock()
-	agentID, err := e.agents.StartAgent(taskID, child.Config.Role, mode, model, provider, prompt, dir, child.Config.AllowedTools, child.Config.NeedsWorktree, oneShot)
+	agentID, err := e.agents.StartAgent(taskID, child.Config.Role, mode, model, provider, prompt, dir, child.Config.AllowedTools, child.Config.NeedsWorktree, oneShot, child.Config.OutputSchema)
 	if err != nil {
 		e.mu.Unlock()
 		return fmt.Errorf("start agent: %w", err)

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -21,15 +22,39 @@ const (
 	testRunnerRole = "test-runner"
 )
 
-// extractTestVerdict returns "PASS"/"FAIL"/"" by scanning output for a line that
-// is EXACTLY the verdict marker (after trimming surrounding whitespace). Exact
-// match — not substring — so an incidental mention in prose (e.g. the agent
-// quoting the contract "the final line must be TEST_VERDICT: PASS") is ignored
-// rather than misread as a real verdict. The last matching line wins (the skill
-// prints it last), and the scan runs over the untruncated agent result so the
-// marker survives long summaries. Missing/ambiguous output yields "" → FAIL,
+// extractTestVerdict returns "PASS"/"FAIL"/"" from agent output.
+//
+// Object-shaped output (leading `{` after trimming BOM/whitespace) is treated
+// as authoritative JSON: the `verdict` field is parsed and the marker scan is
+// skipped entirely. A malformed or unexpected object yields "" → FAIL without
+// falling through to the marker, so a JSON body that incidentally contains a
+// marker-shaped substring cannot misroute. This is the path codex takes when
+// --output-schema enforces a structured response.
+//
+// Non-object-shaped output (claude plain text) falls to the exact-line marker
+// scan. The last matching line wins; missing/ambiguous output yields "" → FAIL,
 // which is the safe direction.
 func extractTestVerdict(output string) string {
+	// Strip a leading UTF-8 BOM, then trim whitespace before shape detection.
+	s := strings.TrimSpace(strings.TrimPrefix(output, "\xef\xbb\xbf"))
+	if strings.HasPrefix(s, "{") {
+		// Object-shaped: JSON is authoritative. Parse fail → "" (→FAIL).
+		// No fall-through to marker scan.
+		var v struct {
+			Verdict string `json:"verdict"`
+		}
+		if json.Unmarshal([]byte(s), &v) == nil {
+			switch strings.ToUpper(strings.TrimSpace(v.Verdict)) {
+			case "PASS":
+				return "PASS"
+			case "FAIL":
+				return "FAIL"
+			}
+		}
+		return ""
+	}
+
+	// Plain-text path (claude): exact-line marker scan, last match wins.
 	verdict := ""
 	for line := range strings.SplitSeq(output, "\n") {
 		switch strings.TrimSpace(line) {

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -15,6 +15,7 @@ func TestExtractTestVerdict(t *testing.T) {
 		output string
 		want   string
 	}{
+		// --- plain-text marker path (claude) ---
 		{"pass_final_line", "ran the app\nTEST_VERDICT: PASS", "PASS"},
 		{"fail_final_line", "found a defect\nTEST_VERDICT: FAIL", "FAIL"},
 		{"pass_after_long_summary", longPrefix + "\nTEST_VERDICT: PASS", "PASS"},
@@ -27,6 +28,24 @@ func TestExtractTestVerdict(t *testing.T) {
 		// match, not substring) — else an agent quoting the contract ships broken.
 		{"contract_quote_ignored", "Remember: the final line must be exactly TEST_VERDICT: PASS\nbut I never actually ran the app", ""},
 		{"inline_prose_after_marker_ignored", "TEST_VERDICT: PASS (could not break it)", ""},
+
+		// --- JSON object path (codex --output-schema) ---
+		{"json_pass", `{"verdict":"PASS"}`, "PASS"},
+		{"json_fail", `{"verdict":"FAIL"}`, "FAIL"},
+		{"json_pass_lowercase", `{"verdict":"pass"}`, "PASS"},
+		{"json_fail_lowercase", `{"verdict":"fail"}`, "FAIL"},
+		{"json_with_summary", `{"verdict":"PASS","summary":"could not break it"}`, "PASS"},
+		{"json_invalid_verdict", `{"verdict":"maybe"}`, ""},
+		{"json_malformed_object", `{"oops":`, ""},
+		// A JSON object that contains a marker-shaped substring must NOT route via
+		// the marker — JSON authority is absolute for object-shaped output.
+		{"json_marker_substring_no_fallthrough", `{"note":"saw TEST_VERDICT: FAIL in logs"}`, ""},
+		// BOM + leading whitespace stripping.
+		{"json_bom_prefix", "\xef\xbb\xbf{\"verdict\":\"PASS\"}", "PASS"},
+		{"json_leading_whitespace", "  \n{\"verdict\":\"PASS\"}", "PASS"},
+		// Non-object shapes fall through to the marker scan (safe direction).
+		{"json_array_not_object", `[{"verdict":"PASS"}]`, ""},
+		{"fenced_json_no_marker", "```json\n{\"verdict\":\"PASS\"}\n```", ""},
 	}
 
 	for _, tc := range cases {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -221,6 +221,7 @@ type startCall struct {
 	AllowedTools                                     []string
 	NeedsWorktree                                    bool
 	OneShot                                          bool
+	OutputSchema                                     string
 }
 
 type sentPrompt struct {
@@ -245,7 +246,7 @@ func newMockAgents() *mockAgents {
 	}
 }
 
-func (m *mockAgents) StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool) (string, error) {
+func (m *mockAgents) StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool, outputSchema string) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.failSpawn != nil {
@@ -256,7 +257,7 @@ func (m *mockAgents) StartAgent(taskID, role, mode, model, provider, prompt, dir
 	m.calls = append(m.calls, startCall{
 		TaskID: taskID, Role: role, Mode: mode, Model: model, Provider: provider,
 		Prompt: prompt, Dir: dir, AllowedTools: allowedTools,
-		NeedsWorktree: needsWorktree, OneShot: oneShot,
+		NeedsWorktree: needsWorktree, OneShot: oneShot, OutputSchema: outputSchema,
 	})
 	m.running[taskID] = id
 	m.roles[taskID+"/"+role] = id
@@ -917,7 +918,7 @@ func TestCancelWorkflow(t *testing.T) {
 	tasks.Put(TaskInfo{ID: "no-wf", Status: "todo"})
 
 	// Pretend an agent is running for "active" so we can verify it's stopped.
-	if _, err := agents.StartAgent("active", "pr-fix", "headless", "sonnet", "claude", "p", "", nil, false, false); err != nil {
+	if _, err := agents.StartAgent("active", "pr-fix", "headless", "sonnet", "claude", "p", "", nil, false, false, ""); err != nil {
 		t.Fatalf("seed agent: %v", err)
 	}
 
@@ -1245,7 +1246,7 @@ func TestResumeStalled_SkipsTaskWithRunningAgent(t *testing.T) {
 		},
 	})
 	// Simulate an agent already running.
-	_, _ = agents.StartAgent("t1", "implementation", "headless", "sonnet", "", "test", "", nil, false, false)
+	_, _ = agents.StartAgent("t1", "implementation", "headless", "sonnet", "", "test", "", nil, false, false, "")
 
 	initialCalls := agents.CallCount()
 	engine.ResumeStalled()

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -179,6 +179,11 @@ type StepConfig struct {
 	// guard still flips the task to human-required when the sidecar ends
 	// up empty, preserving the existing safety net.
 	ImportSidecar *ImportSidecar `yaml:"import_sidecar,omitempty" json:"importSidecar,omitempty"`
+
+	// run_agent (codex only): inline JSON Schema enforced on the model's final
+	// message via `codex exec --output-schema`. Ignored by claude/copilot, which
+	// use prompt-driven structured output. Empty = no enforcement.
+	OutputSchema string `yaml:"output_schema,omitempty" json:"outputSchema,omitempty"`
 }
 
 // ImportSidecar describes a sidecar file the engine should ingest after a


### PR DESCRIPTION
## Motivation

> Changelog: feat(workflow): add codex output-schema support

Closes #1033.

`codex exec --output-schema <FILE>` (codex 0.132 #23123, verified on
0.142.2) enforces a JSON Schema on the model's final message. Sybra's
codex-provider workflow steps previously routed on free-form
`agent_message` text scraping, which is brittle.

Separately, this fixes a latent bug that sent task `37ff65d8` to
`human-required` after 3 false test "failures": the completion handler
read the verdict only from codex's terminal `result` event, which is
synthesized from `turn.completed` and carries **empty content**. The
real `TEST_VERDICT: PASS` text lives in the preceding assistant
`agent_message` event, so `extractTestVerdict("")` returned `""` and
`route_test` mis-routed every passing run as FAIL.

## Implementation information

- `agent.RunConfig.OutputSchema` (inline JSON Schema, codex only). The
  headless runner writes it to a temp file and passes
  `--output-schema <path>` to `codex exec`; `defer`-cleaned after exit.
  Ignored by claude/copilot (different mechanism — unchanged).
- Threaded through `internal/workflow` → `StartAgent` →
  `buildHeadlessInvocation`.
- Builtin `testing-task.yaml` declares the verdict `output_schema`
  (`{verdict: enum[PASS,FAIL]}`, `required:[verdict]`,
  `additionalProperties:false`). `summary` was dropped because OpenAI's
  `response_format` requires every property to appear in `required`,
  else codex rejects the schema with `invalid_json_schema` (400).
- `agent_completion.go`: when a `result` event is present but empty,
  fall back to the last assistant turn (`lastAssistantText`) so
  verdict/PR-URL scraping works for codex. Guarded by `hasResultEvent`
  so genuine no-result exits are not back-filled.
- `fake-codex` emits a schema-shaped final message for the e2e tests.

## Supporting documentation

- codex 0.132 #23123 — `--output-schema` for `exec` / `exec resume`
- `codex exec --help`
- Empirically verified on codex 0.142.2: the fixed schema is accepted
  and returns `{"verdict":"PASS"}` as the structured final message.