### PR TITLE
fix(workflow): skip human-required stale resume

### DIFF
--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -278,6 +278,15 @@ func (e *Engine) ResumeStalled() {
 		if step.Type != StepRunAgent {
 			continue
 		}
+		// A task in human-required was halted by a competing path (e.g. the
+		// inline review triage deciding the PR is too small). Do not resume its
+		// workflow: that would override the triage verdict and re-dispatch an
+		// agent that the operator already suppressed.
+		if t.Status == "human-required" {
+			e.logger.Info("workflow.resume-stalled.skip",
+				"task_id", t.ID, "reason", "human_required", "step", step.ID)
+			continue
+		}
 		if e.agents.HasRunningAgent(t.ID) {
 			continue
 		}
@@ -341,7 +350,7 @@ func (e *Engine) ResumeStalled() {
 		// calls: by the time we acquire dispatching, a prior goroutine may have
 		// already advanced the workflow past this step.
 		fresh, fErr := e.tasks.GetTask(t.ID)
-		if fErr != nil || fresh.Workflow == nil || fresh.Workflow.CurrentStep != t.Workflow.CurrentStep || fresh.Workflow.State == ExecCompleted || fresh.Workflow.State == ExecFailed {
+		if fErr != nil || fresh.Workflow == nil || fresh.Workflow.CurrentStep != t.Workflow.CurrentStep || fresh.Workflow.State == ExecCompleted || fresh.Workflow.State == ExecFailed || fresh.Status == "human-required" {
 			e.mu.Lock()
 			delete(e.dispatching, t.ID)
 			e.mu.Unlock()

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -283,7 +283,7 @@ func (e *Engine) ResumeStalled() {
 		// workflow: that would override the triage verdict and re-dispatch an
 		// agent that the operator already suppressed.
 		if t.Status == "human-required" {
-			e.logger.Info("workflow.resume-stalled.skip",
+			e.logger.Debug("workflow.resume-stalled.skip",
 				"task_id", t.ID, "reason", "human_required", "step", step.ID)
 			continue
 		}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1113,6 +1113,40 @@ func TestResumeStalled_SkipWaitHuman(t *testing.T) {
 	}
 }
 
+// TestResumeStalled_SkipsHumanRequired reproduces the post-restart dispatch bug
+// where a review task was set to human-required by inline triage (small PR)
+// but ResumeStalled re-dispatched its workflow's run_agent step after restart,
+// overriding the triage verdict.
+func TestResumeStalled_SkipsHumanRequired(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	// Simulate a review task whose pr-review workflow is at the implement
+	// (run_agent) step but whose status was flipped to human-required by the
+	// inline triage path before the restart.
+	tasks.Put(TaskInfo{
+		ID:        "t1",
+		Status:    "human-required",
+		AgentMode: "headless",
+		Tags:      []string{"review"},
+		Workflow: &Execution{
+			WorkflowID:  "test-simple",
+			CurrentStep: "implement",
+			State:       ExecRunning,
+			Variables:   make(map[string]string),
+		},
+	})
+
+	engine.ResumeStalled()
+
+	// Must NOT dispatch an agent: human-required overrides the workflow.
+	if agents.CallCount() != 0 {
+		t.Fatalf("expected 0 agent starts for human-required task, got %d", agents.CallCount())
+	}
+}
+
 func TestHandleHumanAction_NotWaiting(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()


### PR DESCRIPTION
## Motivation

After restart, `workflowEngine.ResumeStalled()` was re-dispatching review agents for tasks already set to `human-required` by the inline triage path (e.g. small-PR threshold). The pr-review workflow's `set_in_progress` step normally handles racing `human-required`, but that logic doesn't apply when the status was set intentionally before the restart.

> Changelog: fix(workflow): skip human-required stale resume

## Implementation information

Added a guard in `ResumeStalled` that skips tasks whose status is `human-required` in both the list snapshot and a fresh re-read:

- Snapshot check covers the common post-restart recovery path.
- Fresh re-read closes the concurrent-triage race window where status changes between the list and the resume attempt.

Added `TestResumeStalled_SkipsHumanRequired` to reproduce the scenario.