### PR TITLE
fix(workflow): tolerate verify-gate flakes

### DIFF
--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -85,12 +85,17 @@ func startTestAgent(t *testing.T, m *Manager, taskID, title, mode, prompt string
 		t.Cleanup(func() {
 			_ = m.StopAgent(a.ID)
 			// Wait for the runner goroutine to close done (released the dir)
-			// before the enclosing TempDir cleanups run; cap so a wedged child
-			// never hangs the suite.
+			// before the enclosing TempDir cleanups run. StopAgent kills the
+			// child within stopSIGINTGrace (3s) and the runner drains within
+			// drainTimeout (5s), so 10s is generous; if it is still not closed,
+			// fail loudly rather than swallow it — a child alive here is the
+			// exact tempdir-cleanup flake this teardown exists to prevent.
 			if a.done != nil {
 				select {
 				case <-a.done:
 				case <-time.After(10 * time.Second):
+					t.Errorf("agent %s did not exit within 10s of StopAgent; "+
+						"a lingering child process can flake t.TempDir cleanup", a.ID)
 				}
 			}
 		})
@@ -298,10 +303,11 @@ func TestStopHeadlessDoesNotCallOnComplete(t *testing.T) {
 	// holdOpen blocks the onComplete callback from completing until we have
 	// checked completeCalls. Without this, in environments where the claude
 	// binary is absent the runner goroutine fails immediately and races to
-	// call onComplete before StopAgent returns. t.Cleanup closes it so the
-	// goroutine can eventually finish without leaking.
+	// call onComplete before StopAgent returns. defer (not t.Cleanup) closes
+	// it at body return — before startTestAgent's drain cleanup runs — so the
+	// goroutine finishes and a.done closes without the drain timing out.
 	holdOpen := make(chan struct{})
-	t.Cleanup(func() { close(holdOpen) })
+	defer close(holdOpen)
 
 	m.SetOnComplete(func(_ *Agent) {
 		<-holdOpen

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -65,6 +65,14 @@ func newTestManager(t *testing.T) (mgr *Manager, emitted *eventRecorder) {
 // Run guard that requires a valid, existing working dir. Uses os.MkdirTemp
 // with a best-effort cleanup (not t.TempDir) because background goroutines
 // spawned by runHeadless may still be touching the dir when the test ends.
+//
+// It also stops the agent and drains its done channel at teardown. A headless
+// agent spawns a *detached* claude child (runner_headless.go) that outlives the
+// test; left running, it keeps the manager's base `agents/` dir open, so the
+// strict t.TempDir RemoveAll from newTestManager fails non-deterministically
+// with "directory not empty". That flaked the whole package — and because the
+// workflow verify-checks gate runs `go test ./...` and previously blocked on a
+// single failure, the flake escalated unrelated tasks to human-required.
 func startTestAgent(t *testing.T, m *Manager, taskID, title, mode, prompt string, allowedTools []string) (*Agent, error) {
 	t.Helper()
 	dir, err := os.MkdirTemp("", "sybra-agent-test-*")
@@ -72,7 +80,22 @@ func startTestAgent(t *testing.T, m *Manager, taskID, title, mode, prompt string
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-	return m.StartAgent(taskID, title, mode, prompt, dir, allowedTools)
+	a, err := m.StartAgent(taskID, title, mode, prompt, dir, allowedTools)
+	if a != nil {
+		t.Cleanup(func() {
+			_ = m.StopAgent(a.ID)
+			// Wait for the runner goroutine to close done (released the dir)
+			// before the enclosing TempDir cleanups run; cap so a wedged child
+			// never hangs the suite.
+			if a.done != nil {
+				select {
+				case <-a.done:
+				case <-time.After(10 * time.Second):
+				}
+			}
+		})
+	}
+	return a, err
 }
 
 func TestNewManager(t *testing.T) {

--- a/internal/skills/data/sybra-test.md
+++ b/internal/skills/data/sybra-test.md
@@ -37,7 +37,7 @@ In `## Test Failures` record, per defect: what you did (exact steps/commands), w
 
 ## Procedure
 
-1. **Derive acceptance criteria.** Read the task (`sybra-cli get <task-id>`) and its PR/diff if present. Write down, concretely, what "works" means: every behaviour the description promises, plus the implicit ones (errors handled, nothing regressed).
+1. **Derive acceptance criteria — from the task, not your imagination.** Read the task (`sybra-cli get <task-id>`) and its PR/diff if present. Write down, concretely, what "works" means: every behaviour the description promises, plus the narrowly-implicit ones (errors handled, nothing the change touched regressed). **Do not invent requirements the task never stated** — legacy/back-compat behaviour, APIs the task did not promise, a stricter contract than asked. Failing the implementation on an unstated requirement escalates correct work to a human. If the task's own stated requirements contradict each other or are too under-specified to verify, that is a spec problem, not an implementation defect: record it as such (see Rules) rather than manufacturing a failing case.
 
 2. **Figure out how to run it.** You decide — inspect the repo: `README`, `.sybra.yaml` (`setup:`/run hints), `mise tasks ls`, `package.json` scripts, `Makefile`, `docker-compose*.yml`, `cmd/`. Pick the smallest way to exercise the changed surface for real.
 
@@ -51,6 +51,7 @@ In `## Test Failures` record, per defect: what you did (exact steps/commands), w
    - **Edge cases** — empty/missing input, max/min/boundary values, unicode, very large input, concurrent/repeated calls, re-entrancy.
    - **Negative/abuse** — invalid input, wrong order of operations, missing prerequisites, permission/auth gaps. Expect graceful failure, not a crash.
    - **Regression** — adjacent behaviour the change could have broken.
+   Keep every angle anchored to a requirement the task actually states or directly implies — stress those edges hard, but don't fail the build on a requirement you wish the task had.
    For breadth you MAY fan out parallel explorations with the Agent tool, but converge to one verdict yourself.
 
 5. **Use real oracles.** Compare observed vs the task's stated intent. HTTP: assert status + body via `curl "$SANDBOX_URL/..."`. K8s: `kubectl get/logs/describe`, port-forward + curl. CLI: run it, check exit code + stdout/stderr. Desktop/GUI apps that can't run headless (e.g. the Sybra Wails app itself): test the equivalent HTTP server surface (`cmd/*-server`, started in the sandbox) instead.
@@ -62,4 +63,5 @@ In `## Test Failures` record, per defect: what you did (exact steps/commands), w
 - Execute, don't plan. No test-plan document, no human approval step.
 - Don't suggest fixes — report symptoms + reproduction only.
 - Be conservative: when you cannot actually verify a claim, that is a FAIL, not a PASS.
+- Stay in scope: a deviation must be from a requirement the task **states or directly implies**. Never invent a new/contradictory requirement and fail the implementation on it. If the task's stated requirements themselves conflict or are unverifiable, write that plainly in `## Test Failures` ("spec is contradictory/under-specified: …") and emit FAIL — a human resolves the spec; the implementer cannot.
 - Never push, never open/modify a PR, never change task status — the workflow does that based on your verdict.

--- a/internal/workflow/builtin/testing-task.yaml
+++ b/internal/workflow/builtin/testing-task.yaml
@@ -58,8 +58,16 @@ steps:
 
         Your goal is to PROVE the implementation does NOT satisfy the task —
         exercise the happy path AND edge cases, boundary inputs, and failure
-        modes. You decide how to start and drive the real app/cluster (read the
-        repo: README, .sybra.yaml, mise tasks, package.json, compose, Makefile).
+        modes. Test ONLY behaviour the task description states or directly
+        implies; attack the edges OF those requirements. Do NOT invent new
+        requirements the task never stated (e.g. legacy/back-compat behaviour,
+        an API the task did not promise) and fail the implementation on them —
+        that escalates correct work to a human. If the task's own stated
+        requirements contradict each other or are too ambiguous to verify, that
+        is not an implementation defect: say so plainly in `## Test Failures`
+        and still emit FAIL (a human resolves the spec). You decide how to start
+        and drive the real app/cluster (read the repo: README, .sybra.yaml, mise
+        tasks, package.json, compose, Makefile).
         If SANDBOX_URL / KUBECONFIG are set in your environment, an isolated
         sandbox is already running for this task — use it. Bind only ephemeral
         ports and tear down anything you start.

--- a/internal/workflow/engine_steps_verify_checks.go
+++ b/internal/workflow/engine_steps_verify_checks.go
@@ -31,6 +31,13 @@ const verifyChecksOutputTail = 8000
 // suite) and let the task proceed instead of re-blocking on every re-dispatch.
 const verifyBlessedTag = "verify-blessed"
 
+// verifyChecksFlakeRetries is how many extra times a failed verify command is
+// re-run before the gate blocks. A single retry absorbs a nondeterministic
+// flake (e.g. a test-teardown TempDir race) that would otherwise escalate
+// unrelated work to human-required. A genuine failure fails every attempt and
+// still blocks; the cost is one extra suite run only on the failing command.
+const verifyChecksFlakeRetries = 1
+
 // verifyChecksReport is the structured result, stored as a generic artifact.
 type verifyChecksReport struct {
 	Commands   []string `json:"commands"`
@@ -83,7 +90,7 @@ func (e *Engine) execVerifyChecks(taskID string, step *Step, t TaskInfo) (StepOu
 	defer cancel()
 
 	maybeMiseTrust(ctx, wtPath)
-	failedCmd, output, runErr := runVerifyCommands(ctx, wtPath, cmds)
+	failedCmd, output, runErr := e.runVerifyCommands(ctx, taskID, wtPath, cmds)
 
 	report := verifyChecksReport{
 		Commands: cmds, FailedCmd: failedCmd, OutputTail: tailString(output, verifyChecksOutputTail),
@@ -151,29 +158,45 @@ func stepDone(step *Step, output string) (StepOutput, error) {
 }
 
 // runVerifyCommands runs each command in order in the worktree via `sh -c`.
-// Returns the first command that exited non-zero (a real failure → caller
-// blocks). A non-nil err means the run could not complete (ctx timeout/cancel);
-// the caller decides the policy (fail closed on our deadline, open on shutdown).
-// Output streams into a fixed-size tail buffer so a flood of stdout/stderr
-// cannot exhaust memory.
-func runVerifyCommands(ctx context.Context, wtPath string, cmds []string) (failedCmd, output string, err error) {
+// Returns the first command that exited non-zero on every attempt (a real
+// failure → caller blocks). A failing command is retried up to
+// verifyChecksFlakeRetries times to absorb nondeterministic flakes; a command
+// that passes on any attempt moves on. A non-nil err means the run could not
+// complete (ctx timeout/cancel) and is never retried — the budget is already
+// spent; the caller decides the policy (fail closed on our deadline, open on
+// shutdown). Output streams into a fixed-size tail buffer so a flood of
+// stdout/stderr cannot exhaust memory.
+func (e *Engine) runVerifyCommands(ctx context.Context, taskID, wtPath string, cmds []string) (failedCmd, output string, err error) {
 	tail := &boundedTail{max: verifyChecksMaxOutput}
 	for _, raw := range cmds {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return "", tail.String(), ctxErr
-		}
-		_, _ = io.WriteString(tail, "$ "+raw+"\n")
-		cmd := exec.CommandContext(ctx, "sh", "-c", raw)
-		cmd.Dir = wtPath
-		cmd.Stdout = tail
-		cmd.Stderr = tail
-		runErr := cmd.Run()
-		_, _ = io.WriteString(tail, "\n")
-		if runErr != nil {
+		passed := false
+		for attempt := 0; attempt <= verifyChecksFlakeRetries; attempt++ {
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return "", tail.String(), ctxErr
 			}
-			return raw, tail.String(), nil
+			if attempt > 0 {
+				_, _ = fmt.Fprintf(tail,
+					"[verify] command failed; retry %d/%d to rule out a flake\n", attempt, verifyChecksFlakeRetries)
+				e.logger.Info("workflow.verify-checks.retry",
+					"task_id", taskID, "attempt", attempt, "cmd", trimDiffLine(raw))
+			}
+			_, _ = io.WriteString(tail, "$ "+raw+"\n")
+			cmd := exec.CommandContext(ctx, "sh", "-c", raw)
+			cmd.Dir = wtPath
+			cmd.Stdout = tail
+			cmd.Stderr = tail
+			runErr := cmd.Run()
+			_, _ = io.WriteString(tail, "\n")
+			if runErr == nil {
+				passed = true
+				break // passed (possibly on retry) — go to the next command
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return "", tail.String(), ctxErr // deadline/cancel: do not retry
+			}
+		}
+		if !passed {
+			return raw, tail.String(), nil // failed every attempt → block
 		}
 	}
 	return "", tail.String(), nil

--- a/internal/workflow/engine_steps_verify_checks_test.go
+++ b/internal/workflow/engine_steps_verify_checks_test.go
@@ -128,12 +128,34 @@ func TestExecVerifyChecks_TimeoutFailsClosed(t *testing.T) {
 	}
 }
 
+func TestExecVerifyChecks_FlakeRetryPasses(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
+	// Fails the first run, succeeds on retry (the marker persists in the
+	// worktree between attempts) — a nondeterministic flake must not block.
+	flaky := "test -f .flake-marker || { touch .flake-marker; exit 1; }"
+	engine, tasks := newVerifyChecksEngine(t, wt, []string{flaky})
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execVerifyChecks("t1", newVerifyChecksStep(), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "clean" {
+		t.Fatalf("Output = %q, want clean (flake absorbed by retry)", out.Output)
+	}
+	if ti, _ := tasks.GetTask("t1"); ti.Status != "in-progress" {
+		t.Errorf("status = %q, want unchanged (retry passed)", ti.Status)
+	}
+}
+
 func TestRunVerifyCommands_DeadlineReturnsCtxErr(t *testing.T) {
 	t.Parallel()
 	wt := makeBaseRepo(t, map[string]string{"README.md": "init\n"})
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	failed, _, err := runVerifyCommands(ctx, wt, []string{"sleep 20"})
+	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	failed, _, err := engine.runVerifyCommands(ctx, "t1", wt, []string{"sleep 20"})
 	if err == nil {
 		t.Fatal("expected a context error on deadline, got nil")
 	}


### PR DESCRIPTION
## Motivation

Three tasks landed in `human-required` this morning from causes that were **not** implementation defects:

| Task | Gate | Real cause |
|------|------|-----------|
| auto-mode permissions | `verify-checks` | False escalation — a flaky test |
| human-review idempotency gate | `test.escalate` 3/3 | Adversarial tester authored contradictory requirements |
| codex plugin | `test.escalate` 3/3 | Genuine bug — gate worked correctly (no change here) |

Two of the three were avoidable. Root causes:

1. **`verify_checks` had zero flake tolerance.** It ran each command exactly once; a single nondeterministic test failure escalated the task. `TestListAgentsMultiple` was that flake — it starts 3 headless agents and never stops them, so the detached `claude` children outlive the test, hold `<manager base>/agents/` open, and race `t.TempDir`'s strict `RemoveAll` (`unlinkat … directory not empty`). Passes on re-run. Because the gate runs `go test ./...`, this flake could escalate *any* task.
2. **The adversarial tester invented out-of-scope requirements** (e.g. legacy back-compat the task never asked for) and failed correct work on them — burning the 3-attempt loop and escalating.

> Changelog: fix(workflow): tolerate verify-gate flakes and scope the adversarial tester

## Implementation information

- **Flake tolerance (`engine_steps_verify_checks.go`)** — a failed verify command is retried once; only a command that fails *every* attempt blocks. A deadline/cancel is never retried (budget already spent). New `TestExecVerifyChecks_FlakeRetryPasses` covers fail-then-pass.
- **Stop leaked agents (`manager_test.go`)** — `startTestAgent` now stops each agent and drains its `done` channel at teardown, releasing the dir before `t.TempDir` cleanup. Fixed at the shared helper, closing the whole class of leakers (not just `TestListAgentsMultiple`).
- **Scope the tester (`testing-task.yaml` + `sybra-test.md`)** — the adversarial tester is constrained to behaviour the task states or directly implies, told not to fail the build on invented/legacy requirements, and told to report a contradictory/under-specified spec *as a spec problem* rather than manufacturing a failing case.

The third task (codex plugin) needed no change — that was a real bug (`config.Load()` before the hook fast-path) the gate correctly caught.

## Supporting documentation

- `golangci-lint`: 0 issues on changed packages
- `go test ./internal/... ./cmd/...`: all green; `agent` / `workflow` / `skillsync` pass; formerly-flaky `internal/agent` stable under `-count=3` and full-suite load
