### PR TITLE
feat(sybra): lifecycle stats + faster dispatch

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -98,6 +98,8 @@ func run(args []string) int {
 		return cmdSelfmonitor(cfg, store, rest, jsonOut)
 	case "evaluation":
 		return cmdEvaluation(cfg, store, rest, jsonOut)
+	case "stats":
+		return cmdStats(cfg, rest, jsonOut)
 	case "install-skills":
 		return cmdInstallSkills(cfg, jsonOut)
 	case "artifact":
@@ -1533,6 +1535,9 @@ Commands:
   board    (status counts + in-progress/plan-review/human-required task lists)
   monitor  scan [--json]    one-shot read-only detector pass (no remediation)
   evaluation scan [--json]  fleet scorecard (autonomy, throughput, efficiency)
+  stats lifecycle [--since 30d] [--slowest N] [--json]
+           Per-phase lead-time breakdown (planning/implementing/testing/review/
+           waiting) for tasks that landed in the window — where time is spent.
   health   [--severity warning|critical] [--category CATEGORY]
 
   triage classify <id>         Classify a single task via claude -p and apply the verdict.

--- a/cmd/sybra-cli/stats.go
+++ b/cmd/sybra-cli/stats.go
@@ -62,17 +62,20 @@ func printPhaseReport(rep evaluation.PhaseReport) {
 		return
 	}
 
-	var meanSum float64
+	// Share is share-of-lead-time across the cohort, so the denominator is the
+	// summed time in each phase (TotalH) — not MeanH, which averages only over
+	// tasks that entered the phase and would over-weight phases many tasks skip.
+	var totalSum float64
 	for _, p := range rep.Phases {
-		meanSum += p.MeanH
+		totalSum += p.TotalH
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "PHASE\tP50H\tP90H\tMEAN\tSHARE\tN")
 	for _, p := range rep.Phases {
 		share := 0.0
-		if meanSum > 0 {
-			share = p.MeanH / meanSum * 100
+		if totalSum > 0 {
+			share = p.TotalH / totalSum * 100
 		}
 		_, _ = fmt.Fprintf(w, "%s\t%.1f\t%.1f\t%.1f\t%.0f%%\t%d\n",
 			p.Phase, p.P50H, p.P90H, p.MeanH, share, p.Count)

--- a/cmd/sybra-cli/stats.go
+++ b/cmd/sybra-cli/stats.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"text/tabwriter"
+	"time"
+
+	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/evaluation"
+)
+
+func cmdStats(cfg *config.Config, args []string, jsonOut bool) int {
+	if len(args) == 0 {
+		return fatal(jsonOut, "usage: stats <lifecycle> [args] [--json]")
+	}
+	switch args[0] {
+	case "lifecycle":
+		return cmdStatsLifecycle(cfg, args[1:], jsonOut)
+	default:
+		return fatal(jsonOut, "unknown stats subcommand: %s", args[0])
+	}
+}
+
+// cmdStatsLifecycle decomposes the lead time of tasks that landed in the window
+// into per-phase durations (planning/implementing/testing/review/waiting), so
+// you can see where end-to-end time actually goes.
+func cmdStatsLifecycle(cfg *config.Config, args []string, jsonOut bool) int {
+	fs := flag.NewFlagSet("lifecycle", flag.ContinueOnError)
+	since := fs.String("since", "30d", "cohort window for landed tasks (duration like 7d/720h or date YYYY-MM-DD)")
+	slowest := fs.Int("slowest", 10, "number of slowest landed tasks to list (0 = none)")
+	if err := fs.Parse(args); err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+
+	now := time.Now().UTC()
+	sinceTime := parseSince(*since, now)
+	// Read status history wider than the cohort window so a task that landed
+	// in-window but started earlier is fully reconstructed.
+	histSince := sinceTime.Add(-2 * now.Sub(sinceTime))
+	evts, err := audit.Read(cfg.AuditDir(), audit.Query{Since: histSince, Until: now})
+	if err != nil {
+		return fatal(jsonOut, "read audit: %v", err)
+	}
+
+	rep := evaluation.ComputePhaseDurations(evts, sinceTime, now, *slowest)
+	if jsonOut {
+		return printJSON(rep)
+	}
+	printPhaseReport(rep)
+	return 0
+}
+
+func printPhaseReport(rep evaluation.PhaseReport) {
+	days := rep.Until.Sub(rep.Since).Hours() / 24
+	fmt.Printf("lifecycle phases — %d landed tasks, last %.0fd\n", rep.Cohort, days)
+	if rep.Cohort == 0 {
+		fmt.Println("  (no tasks landed in the window — nothing to decompose)")
+		return
+	}
+
+	var meanSum float64
+	for _, p := range rep.Phases {
+		meanSum += p.MeanH
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "PHASE\tP50H\tP90H\tMEAN\tSHARE\tN")
+	for _, p := range rep.Phases {
+		share := 0.0
+		if meanSum > 0 {
+			share = p.MeanH / meanSum * 100
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%.1f\t%.1f\t%.1f\t%.0f%%\t%d\n",
+			p.Phase, p.P50H, p.P90H, p.MeanH, share, p.Count)
+	}
+	_ = w.Flush()
+
+	if len(rep.Slowest) == 0 {
+		return
+	}
+	fmt.Println("\nslowest landed tasks:")
+	for _, t := range rep.Slowest {
+		fmt.Printf("  %-12s %5.1fh  %s\n", t.TaskID, t.TotalH, formatByPhase(t.ByPhase))
+	}
+}
+
+// formatByPhase renders a task's per-phase split in canonical order, e.g.
+// "planning 6.0, implementing 9.0, review 3.4".
+func formatByPhase(byPhase map[string]float64) string {
+	keys := make([]string, 0, len(byPhase))
+	for k := range byPhase {
+		keys = append(keys, k)
+	}
+	sort.SliceStable(keys, func(i, j int) bool {
+		return phaseRank(keys[i]) < phaseRank(keys[j])
+	})
+	out := ""
+	for _, k := range keys {
+		if out != "" {
+			out += ", "
+		}
+		out += fmt.Sprintf("%s %.1f", k, byPhase[k])
+	}
+	return out
+}
+
+func phaseRank(phase string) int {
+	order := []string{
+		evaluation.PhaseQueued, evaluation.PhasePlanning, evaluation.PhaseImplementing,
+		evaluation.PhaseTesting, evaluation.PhaseReview, evaluation.PhaseWaiting, evaluation.PhaseOther,
+	}
+	for i, p := range order {
+		if p == phase {
+			return i
+		}
+	}
+	return len(order)
+}

--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -205,6 +205,22 @@ export class OrchestratorConfig {
     "autoTriage": boolean;
     "autoPlan": boolean;
 
+    /**
+     * DispatchIntervalSeconds is the cadence of the cheap, latency-sensitive
+     * dispatch pass (start the orchestrator, release unblocked children). Kept
+     * short — and also fired on demand on every status change — so a
+     * freshly-ready task is not left idle for a full tick. Default 10.
+     */
+    "dispatchIntervalSeconds": number;
+
+    /**
+     * MaintenanceIntervalSeconds is the cadence of the expensive recovery/cleanup
+     * pass (resume stalled workflows, restart stale agents, prune orphan
+     * worktrees) which hits git and may spawn agents, so it must not run hot.
+     * Default 60.
+     */
+    "maintenanceIntervalSeconds": number;
+
     /** Creates a new OrchestratorConfig instance. */
     constructor($$source: Partial<OrchestratorConfig> = {}) {
         if (!("autoTriage" in $$source)) {
@@ -212,6 +228,12 @@ export class OrchestratorConfig {
         }
         if (!("autoPlan" in $$source)) {
             this["autoPlan"] = false;
+        }
+        if (!("dispatchIntervalSeconds" in $$source)) {
+            this["dispatchIntervalSeconds"] = 0;
+        }
+        if (!("maintenanceIntervalSeconds" in $$source)) {
+            this["maintenanceIntervalSeconds"] = 0;
         }
 
         Object.assign(this, $$source);

--- a/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/index.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/index.ts
@@ -3,7 +3,10 @@
 
 export {
     Breakdown,
+    PhaseReport,
+    PhaseStat,
     Report,
     Scorecard,
+    TaskPhases,
     Weakness
 } from "./models.js";

--- a/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
@@ -61,6 +61,102 @@ export class Breakdown {
 }
 
 /**
+ * PhaseReport is the per-phase lifecycle-duration breakdown over a window.
+ */
+export class PhaseReport {
+    "since": time$0.Time;
+    "until": time$0.Time;
+
+    /**
+     * landed tasks analyzed
+     */
+    "cohort": number;
+    "phases": PhaseStat[];
+    "slowest"?: TaskPhases[];
+
+    /** Creates a new PhaseReport instance. */
+    constructor($$source: Partial<PhaseReport> = {}) {
+        if (!("since" in $$source)) {
+            this["since"] = null;
+        }
+        if (!("until" in $$source)) {
+            this["until"] = null;
+        }
+        if (!("cohort" in $$source)) {
+            this["cohort"] = 0;
+        }
+        if (!("phases" in $$source)) {
+            this["phases"] = [];
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new PhaseReport instance from a string or object.
+     */
+    static createFrom($$source: any = {}): PhaseReport {
+        const $$createField3_0 = $$createType1;
+        const $$createField4_0 = $$createType3;
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        if ("phases" in $$parsedSource) {
+            $$parsedSource["phases"] = $$createField3_0($$parsedSource["phases"]);
+        }
+        if ("slowest" in $$parsedSource) {
+            $$parsedSource["slowest"] = $$createField4_0($$parsedSource["slowest"]);
+        }
+        return new PhaseReport($$parsedSource as Partial<PhaseReport>);
+    }
+}
+
+/**
+ * PhaseStat aggregates one phase across the landed-task cohort. Percentiles and
+ * mean are over the tasks that actually entered the phase (Count), so a phase
+ * many tasks skip is not dragged toward zero; TotalH sums across the whole
+ * cohort for share-of-lead-time.
+ */
+export class PhaseStat {
+    "phase": string;
+    "count": number;
+    "p50h": number;
+    "p90h": number;
+    "meanH": number;
+    "totalH": number;
+
+    /** Creates a new PhaseStat instance. */
+    constructor($$source: Partial<PhaseStat> = {}) {
+        if (!("phase" in $$source)) {
+            this["phase"] = "";
+        }
+        if (!("count" in $$source)) {
+            this["count"] = 0;
+        }
+        if (!("p50h" in $$source)) {
+            this["p50h"] = 0;
+        }
+        if (!("p90h" in $$source)) {
+            this["p90h"] = 0;
+        }
+        if (!("meanH" in $$source)) {
+            this["meanH"] = 0;
+        }
+        if (!("totalH" in $$source)) {
+            this["totalH"] = 0;
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new PhaseStat instance from a string or object.
+     */
+    static createFrom($$source: any = {}): PhaseStat {
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        return new PhaseStat($$parsedSource as Partial<PhaseStat>);
+    }
+}
+
+/**
  * Report is the persisted, emitted, and CLI-printed output of one evaluation tick.
  */
 export class Report {
@@ -95,11 +191,11 @@ export class Report {
      * Creates a new Report instance from a string or object.
      */
     static createFrom($$source: any = {}): Report {
-        const $$createField3_0 = $$createType0;
-        const $$createField4_0 = $$createType2;
-        const $$createField5_0 = $$createType2;
-        const $$createField6_0 = $$createType4;
-        const $$createField7_0 = $$createType5;
+        const $$createField3_0 = $$createType4;
+        const $$createField4_0 = $$createType6;
+        const $$createField5_0 = $$createType6;
+        const $$createField6_0 = $$createType8;
+        const $$createField7_0 = $$createType9;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("overall" in $$parsedSource) {
             $$parsedSource["overall"] = $$createField3_0($$parsedSource["overall"]);
@@ -298,6 +394,43 @@ export class Scorecard {
 }
 
 /**
+ * TaskPhases is one landed task's lifecycle decomposition (≈ its lead time split
+ * by phase).
+ */
+export class TaskPhases {
+    "taskId": string;
+    "totalH": number;
+    "byPhase": { [_ in string]?: number };
+
+    /** Creates a new TaskPhases instance. */
+    constructor($$source: Partial<TaskPhases> = {}) {
+        if (!("taskId" in $$source)) {
+            this["taskId"] = "";
+        }
+        if (!("totalH" in $$source)) {
+            this["totalH"] = 0;
+        }
+        if (!("byPhase" in $$source)) {
+            this["byPhase"] = {};
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new TaskPhases instance from a string or object.
+     */
+    static createFrom($$source: any = {}): TaskPhases {
+        const $$createField2_0 = $$createType10;
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        if ("byPhase" in $$parsedSource) {
+            $$parsedSource["byPhase"] = $$createField2_0($$parsedSource["byPhase"]);
+        }
+        return new TaskPhases($$parsedSource as Partial<TaskPhases>);
+    }
+}
+
+/**
  * Weakness is one systematic shortfall the scorecard surfaces, paired with a
  * concrete suggested action — the deterministic half of the improvement loop.
  */
@@ -338,9 +471,14 @@ export class Weakness {
 }
 
 // Private type creation functions
-const $$createType0 = Scorecard.createFrom;
-const $$createType1 = Breakdown.createFrom;
-const $$createType2 = $Create.Array($$createType1);
-const $$createType3 = Weakness.createFrom;
-const $$createType4 = $Create.Array($$createType3);
-const $$createType5 = $Create.Array($Create.Any);
+const $$createType0 = PhaseStat.createFrom;
+const $$createType1 = $Create.Array($$createType0);
+const $$createType2 = TaskPhases.createFrom;
+const $$createType3 = $Create.Array($$createType2);
+const $$createType4 = Scorecard.createFrom;
+const $$createType5 = Breakdown.createFrom;
+const $$createType6 = $Create.Array($$createType5);
+const $$createType7 = Weakness.createFrom;
+const $$createType8 = $Create.Array($$createType7);
+const $$createType9 = $Create.Array($Create.Any);
+const $$createType10 = $Create.Map($Create.Any, $Create.Any);

--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/app.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/app.ts
@@ -46,6 +46,17 @@ export function GetEvaluationReport(): $CancellablePromise<evaluation$0.Report> 
 }
 
 /**
+ * GetLifecyclePhases returns the per-phase lifecycle-duration breakdown for
+ * tasks that landed in the evaluation window — where end-to-end time is spent
+ * (planning vs implementing vs testing vs review vs waiting).
+ */
+export function GetLifecyclePhases(): $CancellablePromise<evaluation$0.PhaseReport> {
+    return $Call.ByID(842035659).then(($result: any) => {
+        return $$createType1($result);
+    });
+}
+
+/**
  * GetMonitorReport returns the most recent finished report from the
  * in-process monitor service. Ready is false until the first tick completes;
  * the frontend should show an empty state in that window. Enabled mirrors
@@ -53,7 +64,7 @@ export function GetEvaluationReport(): $CancellablePromise<evaluation$0.Report> 
  */
 export function GetMonitorReport(): $CancellablePromise<$models.MonitorReportBinding> {
     return $Call.ByID(936556103).then(($result: any) => {
-        return $$createType1($result);
+        return $$createType2($result);
     });
 }
 
@@ -62,7 +73,7 @@ export function GetMonitorReport(): $CancellablePromise<$models.MonitorReportBin
  */
 export function ListBackgroundOps(): $CancellablePromise<bgop$0.Operation[]> {
     return $Call.ByID(729571497).then(($result: any) => {
-        return $$createType3($result);
+        return $$createType4($result);
     });
 }
 
@@ -71,7 +82,7 @@ export function ListBackgroundOps(): $CancellablePromise<bgop$0.Operation[]> {
  */
 export function ListNotifications(): $CancellablePromise<notification$0.Notification[]> {
     return $Call.ByID(706012029).then(($result: any) => {
-        return $$createType5($result);
+        return $$createType6($result);
     });
 }
 
@@ -100,7 +111,7 @@ export function Shutdown(): $CancellablePromise<void> {
  */
 export function StartAgent(taskID: string, mode: string, prompt: string, includeTaskDescription: boolean): $CancellablePromise<agent$0.Agent | null> {
     return $Call.ByID(2345014098, taskID, mode, prompt, includeTaskDescription).then(($result: any) => {
-        return $$createType7($result);
+        return $$createType8($result);
     });
 }
 
@@ -111,7 +122,7 @@ export function StartAgent(taskID: string, mode: string, prompt: string, include
  */
 export function StartChat(projectID: string, providerName: string, prompt: string): $CancellablePromise<agent$0.Agent | null> {
     return $Call.ByID(4013768999, projectID, providerName, prompt).then(($result: any) => {
-        return $$createType7($result);
+        return $$createType8($result);
     });
 }
 
@@ -139,18 +150,19 @@ export function StopChat(agentID: string): $CancellablePromise<void> {
  */
 export function V3Services(): $CancellablePromise<application$0.Service[]> {
     return $Call.ByID(1114222916).then(($result: any) => {
-        return $$createType9($result);
+        return $$createType10($result);
     });
 }
 
 // Private type creation functions
 const $$createType0 = evaluation$0.Report.createFrom;
-const $$createType1 = $models.MonitorReportBinding.createFrom;
-const $$createType2 = bgop$0.Operation.createFrom;
-const $$createType3 = $Create.Array($$createType2);
-const $$createType4 = notification$0.Notification.createFrom;
-const $$createType5 = $Create.Array($$createType4);
-const $$createType6 = agent$0.Agent.createFrom;
-const $$createType7 = $Create.Nullable($$createType6);
-const $$createType8 = application$0.Service.createFrom;
-const $$createType9 = $Create.Array($$createType8);
+const $$createType1 = evaluation$0.PhaseReport.createFrom;
+const $$createType2 = $models.MonitorReportBinding.createFrom;
+const $$createType3 = bgop$0.Operation.createFrom;
+const $$createType4 = $Create.Array($$createType3);
+const $$createType5 = notification$0.Notification.createFrom;
+const $$createType6 = $Create.Array($$createType5);
+const $$createType7 = agent$0.Agent.createFrom;
+const $$createType8 = $Create.Nullable($$createType7);
+const $$createType9 = application$0.Service.createFrom;
+const $$createType10 = $Create.Array($$createType9);

--- a/frontend/src/components/TaskBoardView.svelte.test.ts
+++ b/frontend/src/components/TaskBoardView.svelte.test.ts
@@ -8,7 +8,33 @@ vi.mock('../stores/notifications.svelte.js', () => ({
   notificationStore: { pushLocal: vi.fn() },
 }))
 
-const agentMock = vi.hoisted(() => ({ list: [] as Array<Record<string, unknown>> }))
+// Mirror the real store: TaskCard reads the precomputed agentStatusByTask map,
+// derived here from `list` so tests keep setting only `list`.
+const agentMock = vi.hoisted(() => {
+  type Flags = { triaging: boolean; evaluating: boolean; planning: boolean; running: boolean }
+  const m = {
+    list: [] as Array<Record<string, unknown>>,
+    get agentStatusByTask(): Map<string, Flags> {
+      const map = new Map<string, Flags>()
+      for (const a of m.list) {
+        if (a.state !== 'running' || !a.taskId) continue
+        const id = a.taskId as string
+        let s = map.get(id)
+        if (!s) {
+          s = { triaging: false, evaluating: false, planning: false, running: false }
+          map.set(id, s)
+        }
+        const name = (a.name as string) ?? ''
+        if (name.startsWith('triage:')) s.triaging = true
+        else if (name.startsWith('eval:')) s.evaluating = true
+        else if (name.startsWith('plan:')) s.planning = true
+        else s.running = true
+      }
+      return map
+    },
+  }
+  return m
+})
 vi.mock('../stores/agents.svelte.js', () => ({ agentStore: agentMock }))
 
 // Drives the empty-column thin-rail (desktop only); default off keeps the

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -24,21 +24,13 @@
   let dragging = $state(false)
   let moveMenuOpen = $state(false)
 
-  const triaging = $derived(
-    (agentStore.list ?? []).some((a) => a.taskId === t.id && a.name?.startsWith('triage:') && a.state === 'running')
-  )
-
-  const evaluating = $derived(
-    (agentStore.list ?? []).some((a) => a.taskId === t.id && a.name?.startsWith('eval:') && a.state === 'running')
-  )
-
-  const planning = $derived(
-    (agentStore.list ?? []).some((a) => a.taskId === t.id && a.name?.startsWith('plan:') && a.state === 'running')
-  )
-
-  const agentRunning = $derived(
-    (agentStore.list ?? []).some((a) => a.taskId === t.id && a.state === 'running' && !a.name?.startsWith('triage:') && !a.name?.startsWith('eval:') && !a.name?.startsWith('plan:'))
-  )
+  // O(1) lookup into the store's precomputed per-task status map instead of
+  // scanning the full agent list 4× per render.
+  const agentStatus = $derived(agentStore.agentStatusByTask.get(t.id))
+  const triaging = $derived(agentStatus?.triaging ?? false)
+  const evaluating = $derived(agentStatus?.evaluating ?? false)
+  const planning = $derived(agentStatus?.planning ?? false)
+  const agentRunning = $derived(agentStatus?.running ?? false)
 
   const linkedPRs = $derived(reviewStore.byTask(t))
   const topPR = $derived(linkedPRs.length > 0 ? linkedPRs[0] : null)

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -9,7 +9,7 @@ import type { LoopAgent } from '../../bindings/github.com/Automaat/sybra/interna
 import type { AppSettings, CodexModel, CopilotModel, LoopAgentRun, MonitorReportBinding, VersionInfo } from '../../bindings/github.com/Automaat/sybra/internal/sybra/models.js'
 import type { Notification } from '../../bindings/github.com/Automaat/sybra/internal/notification/models.js'
 import type { StatsResponse } from '../../bindings/github.com/Automaat/sybra/internal/stats/models.js'
-import type { Report as EvaluationReportData } from '../../bindings/github.com/Automaat/sybra/internal/evaluation/models.js'
+import type { Report as EvaluationReportData, PhaseReport as PhaseReportData } from '../../bindings/github.com/Automaat/sybra/internal/evaluation/models.js'
 import type { Definition } from '../../bindings/github.com/Automaat/sybra/internal/workflow/models.js'
 import type { Project as TodoistProject } from '../../bindings/github.com/Automaat/sybra/internal/todoist/models.js'
 import type { Status } from '../../bindings/github.com/Automaat/sybra/internal/provider/models.js'
@@ -55,6 +55,7 @@ export function ResumeInClaudeCode(_arg1: string): Promise<void> { return Promis
 // App
 export function GetMonitorReport(): Promise<MonitorReportBinding> { return call('App', 'GetMonitorReport') }
 export function GetEvaluationReport(): Promise<EvaluationReportData> { return call('App', 'GetEvaluationReport') }
+export function GetLifecyclePhases(): Promise<PhaseReportData> { return call('App', 'GetLifecyclePhases') }
 export function ListBackgroundOps(): Promise<Array<any>> { return call('App', 'ListBackgroundOps') }
 export function ListNotifications(): Promise<Array<Notification>> { return call('App', 'ListNotifications') }
 export function RegisterSpotlightHotkey(): Promise<void> { return Promise.reject(new Error('not available in web mode')) }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -52,6 +52,7 @@ export const ResumeInClaudeCode = pick(AgentSvc.ResumeInClaudeCode, http.ResumeI
 // App
 export const GetMonitorReport = pick(AppSvc.GetMonitorReport, http.GetMonitorReport)
 export const GetEvaluationReport = pick(AppSvc.GetEvaluationReport, http.GetEvaluationReport)
+export const GetLifecyclePhases = pick(AppSvc.GetLifecyclePhases, http.GetLifecyclePhases)
 export const ListBackgroundOps = pick(AppSvc.ListBackgroundOps, http.ListBackgroundOps)
 export const ListNotifications = pick(AppSvc.ListNotifications, http.ListNotifications)
 export const RegisterSpotlightHotkey = pick(AppSvc.RegisterSpotlightHotkey, http.RegisterSpotlightHotkey)

--- a/frontend/src/lib/app-lifecycle.ts
+++ b/frontend/src/lib/app-lifecycle.ts
@@ -34,33 +34,60 @@ export interface AppLifecycleHooks {
   onQuitConfirm: () => void
 }
 
-function onEvents(events: string[], handler: () => void): () => void {
-  const unsubs = events.map((e) => EventsOn(e, handler))
-  return () => unsubs.forEach((u) => u())
+// The backend can fire dozens of task:created/updated/deleted events per second
+// when agents churn (restart-stale loops, rapid workflow advances, large
+// headless sessions). A full taskStore.load() on every event re-builds the
+// reactive Map and forces every kanban card to re-render, which saturates the
+// WebKit main thread and freezes the UI even though the Go side is idle.
+//
+// Instead we patch only the affected task. The watcher payload is the changed
+// file's path: a task lives at `<id>.md`, its sidecars (plan, critique, drafts)
+// at `<id>.<suffix>.md`. Task ids are dot-free (uuid[:8]), so the id is the
+// basename's first segment, and a sidecar change maps to a patch of its parent.
+function taskIdFromPath(path: string): string {
+  const base = path.split('/').pop() ?? path
+  return base.split('.')[0] ?? ''
 }
 
-// Coalesce bursts of backend events into a single handler call. The backend
-// can fire dozens of task:updated events per second when agents churn
-// (restart-stale loops, rapid workflow advances, large headless sessions);
-// a full taskStore.load() on every event re-builds the reactive Map and
-// forces every kanban card to re-render, which saturates the WebKit main
-// thread and freezes the UI even though the Go side is idle.
-function debounced(fn: () => void, wait = 150): () => void {
+// A primary task file is `<id>.md` exactly; a sidecar carries an extra dotted
+// segment. Only removing the primary file deletes the task — a sidecar removal
+// is a content change on the still-present parent.
+function isPrimaryTaskFile(path: string): boolean {
+  const base = path.split('/').pop() ?? path
+  return /^[^.]+\.md$/.test(base)
+}
+
+type TaskEventKind = 'change' | 'delete'
+
+// Coalesce a burst of file events into one action PER task id, flushed on a
+// trailing timer. 50 events for one task collapse to a single fetch, and
+// events for different tasks don't cancel each other. A `remove` is sticky: a
+// task-file delete plus its sidecar-delete cascade must not downgrade back to a
+// patch of an already-gone task.
+function makeTaskEventCoalescer(): (path: string, kind: TaskEventKind) => void {
+  const pending = new Map<string, 'patch' | 'remove'>()
   let timer: ReturnType<typeof setTimeout> | null = null
-  let lastInvoke = 0
-  return () => {
-    const now = Date.now()
-    if (now - lastInvoke >= wait && timer === null) {
-      lastInvoke = now
-      fn()
-      return
+  const flushDelay = 120
+
+  const flush = (): void => {
+    timer = null
+    const batch = [...pending.entries()]
+    pending.clear()
+    for (const [id, action] of batch) {
+      if (action === 'remove') taskStore.removeOne(id)
+      else void taskStore.patchOne(id)
     }
-    if (timer !== null) clearTimeout(timer)
-    timer = setTimeout(() => {
-      lastInvoke = Date.now()
-      timer = null
-      fn()
-    }, wait)
+  }
+
+  return (path: string, kind: TaskEventKind): void => {
+    const id = taskIdFromPath(path)
+    if (!id) return
+    if (kind === 'delete' && isPrimaryTaskFile(path)) {
+      pending.set(id, 'remove')
+    } else if (pending.get(id) !== 'remove') {
+      pending.set(id, 'patch')
+    }
+    if (timer === null) timer = setTimeout(flush, flushDelay)
   }
 }
 
@@ -76,8 +103,16 @@ export function startAppLifecycle(hooks: AppLifecycleHooks): () => void {
   // ever opened. The GitHub page owns the live polling.
   reviewStore.load()
 
-  const reloadTasks = debounced(() => taskStore.load(), 150)
-  const unsubTasks = onEvents([ev.TaskCreated, ev.TaskUpdated, ev.TaskDeleted], reloadTasks)
+  // Patch only the affected task per event instead of reloading the whole list.
+  const onTaskEvent = makeTaskEventCoalescer()
+  const unsubTaskCreated = EventsOn(ev.TaskCreated, (p: unknown) => onTaskEvent(String(p ?? ''), 'change'))
+  const unsubTaskUpdated = EventsOn(ev.TaskUpdated, (p: unknown) => onTaskEvent(String(p ?? ''), 'change'))
+  const unsubTaskDeleted = EventsOn(ev.TaskDeleted, (p: unknown) => onTaskEvent(String(p ?? ''), 'delete'))
+  const unsubTasks = (): void => {
+    unsubTaskCreated()
+    unsubTaskUpdated()
+    unsubTaskDeleted()
+  }
   notificationStore.load()
   const unsubNotif = notificationStore.listen()
   bgopStore.load()

--- a/frontend/src/pages/Evaluation.svelte
+++ b/frontend/src/pages/Evaluation.svelte
@@ -1,7 +1,34 @@
 <script lang="ts">
   import { evaluationStore } from '../stores/evaluation.svelte.js'
+  import { lifecycleStore } from '../stores/lifecycle.svelte.js'
 
   const report = $derived(evaluationStore.data)
+  const phases = $derived(lifecycleStore.data)
+  // Share is computed from mean dwell so a phase only a few tasks hit still reads
+  // proportionally. Sum once for the denominator.
+  const phaseMeanSum = $derived(
+    (phases?.phases ?? []).reduce((acc, p) => acc + p.meanH, 0),
+  )
+  // Stable colour per phase so the bar and legend agree across renders.
+  const phaseColor: Record<string, string> = {
+    queued: 'bg-surface-400',
+    planning: 'bg-tertiary-500',
+    implementing: 'bg-primary-500',
+    testing: 'bg-secondary-500',
+    review: 'bg-warning-500',
+    waiting: 'bg-error-500',
+    other: 'bg-surface-300',
+  }
+  function phaseShare(meanH: number): number {
+    return phaseMeanSum > 0 ? (meanH / phaseMeanSum) * 100 : 0
+  }
+  function phaseBreakdown(byPhase: { [_ in string]?: number }): string {
+    const order = ['queued', 'planning', 'implementing', 'testing', 'review', 'waiting', 'other']
+    return order
+      .filter((p) => (byPhase[p] ?? 0) > 0)
+      .map((p) => `${p} ${(byPhase[p] ?? 0).toFixed(1)}`)
+      .join(' · ')
+  }
   // A zero-value Report (service disabled / no data yet) still has a non-null
   // overall, which would render as a measured "0% / failing" fleet. Treat it as
   // no-data unless there's at least one run or landing in the window.
@@ -13,6 +40,7 @@
   $effect(() => {
     evaluationStore.load()
     evaluationStore.listen()
+    lifecycleStore.load()
     return () => evaluationStore.stopListening()
   })
 
@@ -49,7 +77,10 @@
       type="button"
       class="rounded-lg bg-surface-200 px-3 py-1.5 text-sm font-medium hover:bg-surface-300 disabled:opacity-50 dark:bg-surface-700 dark:hover:bg-surface-600"
       disabled={evaluationStore.loading}
-      onclick={() => evaluationStore.load()}
+      onclick={() => {
+        evaluationStore.load()
+        lifecycleStore.load()
+      }}
     >
       {evaluationStore.loading ? 'Loading…' : 'Refresh'}
     </button>
@@ -125,6 +156,68 @@
         </table>
       </div>
     </div>
+
+    <!-- Where time goes: lead time decomposed by lifecycle phase -->
+    {#if phases && phases.cohort > 0 && phases.phases.length > 0}
+      <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <div class="mb-3 flex items-baseline justify-between">
+          <h3 class="text-sm font-semibold text-surface-500">Where time goes</h3>
+          <span class="text-xs text-surface-400">{phases.cohort} landed tasks</span>
+        </div>
+
+        <!-- Stacked share-of-lead-time bar -->
+        <div class="mb-3 flex h-3 w-full overflow-hidden rounded-full">
+          {#each phases.phases as p (p.phase)}
+            <div
+              class="{phaseColor[p.phase] ?? 'bg-surface-300'} h-full"
+              style="width: {phaseShare(p.meanH)}%"
+              title="{p.phase}: {phaseShare(p.meanH).toFixed(0)}%"
+            ></div>
+          {/each}
+        </div>
+
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-surface-200 text-left text-xs text-surface-400 dark:border-surface-700">
+              <th class="pb-2">Phase</th>
+              <th class="pb-2 text-right">Share</th>
+              <th class="pb-2 text-right">p50</th>
+              <th class="pb-2 text-right">p90</th>
+              <th class="pb-2 text-right">Mean</th>
+              <th class="pb-2 text-right">Tasks</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each phases.phases as p (p.phase)}
+              <tr class="border-b border-surface-100 last:border-0 dark:border-surface-700">
+                <td class="py-1.5">
+                  <span class="mr-2 inline-block h-2 w-2 rounded-full {phaseColor[p.phase] ?? 'bg-surface-300'}"></span>
+                  {p.phase}
+                </td>
+                <td class="py-1.5 text-right">{phaseShare(p.meanH).toFixed(0)}%</td>
+                <td class="py-1.5 text-right">{hours(p.p50h)}</td>
+                <td class="py-1.5 text-right text-surface-400">{hours(p.p90h)}</td>
+                <td class="py-1.5 text-right">{hours(p.meanH)}</td>
+                <td class="py-1.5 text-right text-surface-400">{p.count}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+
+        {#if phases.slowest && phases.slowest.length > 0}
+          <h4 class="mb-2 mt-4 text-xs font-semibold text-surface-400">Slowest landed tasks</h4>
+          <ul class="flex flex-col gap-1.5">
+            {#each phases.slowest as t (t.taskId)}
+              <li class="flex items-baseline justify-between gap-3 text-xs">
+                <span class="font-mono text-surface-500">{t.taskId}</span>
+                <span class="flex-1 truncate text-surface-400">{phaseBreakdown(t.byPhase)}</span>
+                <span class="shrink-0 font-medium">{hours(t.totalH)}</span>
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </div>
+    {/if}
 
     <!-- Weaknesses / feedback loop -->
     {#if report?.weaknesses && report.weaknesses.length > 0}

--- a/frontend/src/pages/Evaluation.svelte
+++ b/frontend/src/pages/Evaluation.svelte
@@ -4,10 +4,11 @@
 
   const report = $derived(evaluationStore.data)
   const phases = $derived(lifecycleStore.data)
-  // Share is computed from mean dwell so a phase only a few tasks hit still reads
-  // proportionally. Sum once for the denominator.
-  const phaseMeanSum = $derived(
-    (phases?.phases ?? []).reduce((acc, p) => acc + p.meanH, 0),
+  // Share is share-of-lead-time across the cohort, so the denominator is the
+  // summed time in each phase (totalH) — not meanH, which averages only over
+  // tasks that entered the phase and would over-weight phases many tasks skip.
+  const phaseTotalSum = $derived(
+    (phases?.phases ?? []).reduce((acc, p) => acc + p.totalH, 0),
   )
   // Stable colour per phase so the bar and legend agree across renders.
   const phaseColor: Record<string, string> = {
@@ -19,8 +20,8 @@
     waiting: 'bg-error-500',
     other: 'bg-surface-300',
   }
-  function phaseShare(meanH: number): number {
-    return phaseMeanSum > 0 ? (meanH / phaseMeanSum) * 100 : 0
+  function phaseShare(totalH: number): number {
+    return phaseTotalSum > 0 ? (totalH / phaseTotalSum) * 100 : 0
   }
   function phaseBreakdown(byPhase: { [_ in string]?: number }): string {
     const order = ['queued', 'planning', 'implementing', 'testing', 'review', 'waiting', 'other']
@@ -170,8 +171,8 @@
           {#each phases.phases as p (p.phase)}
             <div
               class="{phaseColor[p.phase] ?? 'bg-surface-300'} h-full"
-              style="width: {phaseShare(p.meanH)}%"
-              title="{p.phase}: {phaseShare(p.meanH).toFixed(0)}%"
+              style="width: {phaseShare(p.totalH)}%"
+              title="{p.phase}: {phaseShare(p.totalH).toFixed(0)}%"
             ></div>
           {/each}
         </div>
@@ -194,7 +195,7 @@
                   <span class="mr-2 inline-block h-2 w-2 rounded-full {phaseColor[p.phase] ?? 'bg-surface-300'}"></span>
                   {p.phase}
                 </td>
-                <td class="py-1.5 text-right">{phaseShare(p.meanH).toFixed(0)}%</td>
+                <td class="py-1.5 text-right">{phaseShare(p.totalH).toFixed(0)}%</td>
                 <td class="py-1.5 text-right">{hours(p.p50h)}</td>
                 <td class="py-1.5 text-right text-surface-400">{hours(p.p90h)}</td>
                 <td class="py-1.5 text-right">{hours(p.meanH)}</td>

--- a/frontend/src/stores/agents.svelte.ts
+++ b/frontend/src/stores/agents.svelte.ts
@@ -13,9 +13,41 @@ import { EntityStore } from './entity-store.svelte.js'
 import { extractStepText } from '$lib/step-text.js'
 import type { TimestampedStreamEvent } from '$lib/timeline.js'
 
+// Per-task agent-status flags, precomputed once per agent-list change so a
+// card reads O(1) instead of scanning the whole agent list 4× per render.
+// Mirrors the running/role predicates TaskCard used to compute inline.
+export type AgentTaskStatus = {
+  triaging: boolean
+  evaluating: boolean
+  planning: boolean
+  running: boolean
+}
+
 class AgentStore extends EntityStore<Agent> {
   outputs = new SvelteMap<string, TimestampedStreamEvent[]>()
   stepTexts = new SvelteMap<string, string>()
+
+  // taskId → role flags for that task's running agents. Recomputed once when
+  // the agent list changes; cards index into it by task id (see TaskCard).
+  // Each running agent maps to exactly one flag, matching the original
+  // mutually-exclusive prefix predicates (triage:/eval:/plan:, else generic).
+  agentStatusByTask = $derived.by(() => {
+    const map = new Map<string, AgentTaskStatus>()
+    for (const a of this.list) {
+      if (a.state !== 'running' || !a.taskId) continue
+      let s = map.get(a.taskId)
+      if (!s) {
+        s = { triaging: false, evaluating: false, planning: false, running: false }
+        map.set(a.taskId, s)
+      }
+      const name = a.name ?? ''
+      if (name.startsWith('triage:')) s.triaging = true
+      else if (name.startsWith('eval:')) s.evaluating = true
+      else if (name.startsWith('plan:')) s.planning = true
+      else s.running = true
+    }
+    return map
+  })
 
   constructor() {
     super(

--- a/frontend/src/stores/lifecycle.svelte.ts
+++ b/frontend/src/stores/lifecycle.svelte.ts
@@ -1,0 +1,25 @@
+import { GetLifecyclePhases } from '$lib/api'
+import type { PhaseReport } from '../../bindings/github.com/Automaat/sybra/internal/evaluation/models.js'
+
+// Per-phase lifecycle-duration breakdown for landed tasks. Pull-only: there's no
+// push event, so the Evaluation page loads it alongside the scorecard and on
+// Refresh.
+class LifecycleStore {
+  data = $state<PhaseReport | null>(null)
+  loading = $state(false)
+  error = $state('')
+
+  async load(): Promise<void> {
+    this.loading = true
+    this.error = ''
+    try {
+      this.data = await GetLifecyclePhases()
+    } catch (e) {
+      this.error = String(e)
+    } finally {
+      this.loading = false
+    }
+  }
+}
+
+export const lifecycleStore = new LifecycleStore()

--- a/frontend/src/stores/tasks.svelte.ts
+++ b/frontend/src/stores/tasks.svelte.ts
@@ -13,6 +13,20 @@ import { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/mod
 import { EntityStore } from './entity-store.svelte.js'
 
 class TaskStore extends EntityStore<Task> {
+  // Per-id operation counter guarding the async patchOne against its own
+  // out-of-order completion. patchOne re-reads it after GetTask resolves and
+  // drops the result if a newer op (a delete, or a later patch) has since run —
+  // otherwise a slow in-flight fetch could resurrect a just-deleted task or
+  // overwrite newer state, since the Map is last-write-wins. IDs are never
+  // reused, so a monotonic per-id counter is sufficient.
+  #opSeq = new Map<string, number>()
+
+  #bumpSeq(id: string): number {
+    const n = (this.#opSeq.get(id) ?? 0) + 1
+    this.#opSeq.set(id, n)
+    return n
+  }
+
   constructor() {
     super(
       () => ListTasks(),
@@ -40,6 +54,33 @@ class TaskStore extends EntityStore<Task> {
     const result = await GetTask(id)
     this.set(result.id, result)
     return result
+  }
+
+  // Fetch one task and upsert it into the reactive Map without rebuilding the
+  // whole Map. Drives the live task:created/updated event handler so a single
+  // changed file re-renders one card instead of forcing a full reload + total
+  // re-render. Swallows errors: the id may have just vanished, or be derived
+  // from a sidecar whose parent is gone — the trailing delete event or the
+  // background poll reconciles.
+  async patchOne(id: string): Promise<void> {
+    const mine = this.#bumpSeq(id)
+    try {
+      const result = await GetTask(id)
+      // Superseded by a later remove/patch while this fetch was in flight —
+      // applying it now would resurrect a deleted task or clobber newer state.
+      if (this.#opSeq.get(id) !== mine) return
+      if (result?.id) this.set(result.id, result)
+    } catch {
+      // Task unreadable/removed — leave the Map untouched.
+    }
+  }
+
+  // Drop one task from the reactive Map (pure local, no fetch). Drives the
+  // task:deleted handler. Bumps the op counter so any in-flight patchOne for
+  // this id is discarded when it resolves.
+  removeOne(id: string): void {
+    this.#bumpSeq(id)
+    this.delete(id)
   }
 
   async create(title: string, body: string, mode: string): Promise<Task> {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -233,6 +233,16 @@ type NotificationConfig struct {
 type OrchestratorConfig struct {
 	AutoTriage bool `yaml:"auto_triage" json:"autoTriage"`
 	AutoPlan   bool `yaml:"auto_plan" json:"autoPlan"`
+	// DispatchIntervalSeconds is the cadence of the cheap, latency-sensitive
+	// dispatch pass (start the orchestrator, release unblocked children). Kept
+	// short — and also fired on demand on every status change — so a
+	// freshly-ready task is not left idle for a full tick. Default 10.
+	DispatchIntervalSeconds int `yaml:"dispatch_interval_seconds" json:"dispatchIntervalSeconds"`
+	// MaintenanceIntervalSeconds is the cadence of the expensive recovery/cleanup
+	// pass (resume stalled workflows, restart stale agents, prune orphan
+	// worktrees) which hits git and may spawn agents, so it must not run hot.
+	// Default 60.
+	MaintenanceIntervalSeconds int `yaml:"maintenance_interval_seconds" json:"maintenanceIntervalSeconds"`
 }
 
 type TodoistConfig struct {
@@ -594,6 +604,7 @@ func Load() (*Config, error) {
 	applyWatchdogDefaults(cfg)
 	applySelfMonitorDefaults(cfg)
 	applyEvaluationDefaults(cfg)
+	applyOrchestratorDefaults(cfg)
 
 	return cfg, nil
 }
@@ -679,6 +690,18 @@ func applySelfMonitorDefaults(cfg *Config) {
 	}
 	if s.SuppressionThreshold <= 0 {
 		s.SuppressionThreshold = 3
+	}
+}
+
+// applyOrchestratorDefaults fills zero values for the Orchestrator block so the
+// dispatch loop has a fast scheduling cadence and a slower maintenance cadence
+// even on configs that predate the split.
+func applyOrchestratorDefaults(cfg *Config) {
+	if cfg.Orchestrator.DispatchIntervalSeconds <= 0 {
+		cfg.Orchestrator.DispatchIntervalSeconds = 10
+	}
+	if cfg.Orchestrator.MaintenanceIntervalSeconds <= 0 {
+		cfg.Orchestrator.MaintenanceIntervalSeconds = 60
 	}
 }
 

--- a/internal/evaluation/phases.go
+++ b/internal/evaluation/phases.go
@@ -1,0 +1,242 @@
+package evaluation
+
+import (
+	"sort"
+	"time"
+
+	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// Canonical lifecycle phases, in order. A phase groups one or more task statuses
+// so a landed task's wall-clock can be decomposed into where the time went.
+// "other" catches any status not mapped below, so a newly-added status is never
+// silently dropped from the accounting.
+const (
+	PhaseQueued       = "queued"
+	PhasePlanning     = "planning"
+	PhaseImplementing = "implementing"
+	PhaseTesting      = "testing"
+	PhaseReview       = "review"
+	PhaseWaiting      = "waiting"
+	PhaseOther        = "other"
+)
+
+var phaseOrder = []string{
+	PhaseQueued, PhasePlanning, PhaseImplementing,
+	PhaseTesting, PhaseReview, PhaseWaiting, PhaseOther,
+}
+
+// phaseOf maps a task status (as recorded in task.status_changed audit events)
+// to its lifecycle phase. Terminal statuses return "" — no duration accrues to
+// them.
+func phaseOf(status string) string {
+	switch task.Status(status) {
+	case "":
+		return "" // missing status (e.g. first-observation from=="") — not a phase
+	case task.StatusNew, task.StatusTodo:
+		return PhaseQueued
+	case task.StatusPlanning, task.StatusPlanReview:
+		return PhasePlanning
+	case task.StatusInProgress:
+		return PhaseImplementing
+	case task.StatusTesting:
+		return PhaseTesting
+	case task.StatusReadyReview, task.StatusInReview, task.StatusReadyPR:
+		return PhaseReview
+	case task.StatusBlocked, task.StatusHumanRequired:
+		return PhaseWaiting
+	case task.StatusDone, task.StatusCancelled:
+		return ""
+	default:
+		return PhaseOther
+	}
+}
+
+// PhaseStat aggregates one phase across the landed-task cohort. Percentiles and
+// mean are over the tasks that actually entered the phase (Count), so a phase
+// many tasks skip is not dragged toward zero; TotalH sums across the whole
+// cohort for share-of-lead-time.
+type PhaseStat struct {
+	Phase  string  `json:"phase"`
+	Count  int     `json:"count"`
+	P50H   float64 `json:"p50h"`
+	P90H   float64 `json:"p90h"`
+	MeanH  float64 `json:"meanH"`
+	TotalH float64 `json:"totalH"`
+}
+
+// TaskPhases is one landed task's lifecycle decomposition (≈ its lead time split
+// by phase).
+type TaskPhases struct {
+	TaskID  string             `json:"taskId"`
+	TotalH  float64            `json:"totalH"`
+	ByPhase map[string]float64 `json:"byPhase"`
+}
+
+// PhaseReport is the per-phase lifecycle-duration breakdown over a window.
+type PhaseReport struct {
+	Since   time.Time    `json:"since"`
+	Until   time.Time    `json:"until"`
+	Cohort  int          `json:"cohort"` // landed tasks analyzed
+	Phases  []PhaseStat  `json:"phases"`
+	Slowest []TaskPhases `json:"slowest,omitempty"`
+}
+
+type statusEdge struct {
+	ts   time.Time
+	from string
+	to   string
+}
+
+// ComputePhaseDurations decomposes the wall-clock of each task that landed in
+// [since, until] into per-phase durations, reconstructed from its full
+// task.status_changed history. events should span wider than [since, until] so a
+// task that landed in-window but started earlier is fully reconstructed (the
+// caller is expected to read a wider audit range). slowestN bounds the per-task
+// detail list (0 = none).
+//
+// Pure and deterministic for a given input — no I/O.
+func ComputePhaseDurations(events []audit.Event, since, until time.Time, slowestN int) PhaseReport {
+	landed := landedInWindow(events, since, until)
+	rep := PhaseReport{Since: since, Until: until, Cohort: len(landed)}
+
+	// Gather creation + status-change timelines for cohort tasks only.
+	created := map[string]time.Time{}
+	transitions := map[string][]statusEdge{}
+	for i := range events {
+		e := events[i]
+		if e.TaskID == "" {
+			continue
+		}
+		if _, ok := landed[e.TaskID]; !ok {
+			continue
+		}
+		switch e.Type {
+		case audit.EventTaskCreated:
+			if t, ok := created[e.TaskID]; !ok || e.Timestamp.Before(t) {
+				created[e.TaskID] = e.Timestamp
+			}
+		case audit.EventTaskStatusChanged:
+			transitions[e.TaskID] = append(transitions[e.TaskID], statusEdge{
+				ts:   e.Timestamp,
+				from: strVal(e.Data, "from"),
+				to:   strVal(e.Data, "to"),
+			})
+		}
+	}
+
+	perPhaseSamples := map[string][]float64{}
+	perPhaseTotal := map[string]float64{}
+	details := make([]TaskPhases, 0, len(landed))
+	for id, landedAt := range landed {
+		byPhase := taskPhaseDurations(created[id], transitions[id], landedAt)
+		if len(byPhase) == 0 {
+			continue
+		}
+		var total float64
+		for ph, h := range byPhase {
+			perPhaseSamples[ph] = append(perPhaseSamples[ph], h)
+			perPhaseTotal[ph] += h
+			total += h
+		}
+		details = append(details, TaskPhases{TaskID: id, TotalH: total, ByPhase: byPhase})
+	}
+
+	for _, ph := range phaseOrder {
+		s := perPhaseSamples[ph]
+		if len(s) == 0 {
+			continue
+		}
+		rep.Phases = append(rep.Phases, PhaseStat{
+			Phase:  ph,
+			Count:  len(s),
+			P50H:   percentile(s, 50),
+			P90H:   percentile(s, 90),
+			MeanH:  mean(s),
+			TotalH: perPhaseTotal[ph],
+		})
+	}
+
+	sort.Slice(details, func(i, j int) bool {
+		if details[i].TotalH != details[j].TotalH {
+			return details[i].TotalH > details[j].TotalH
+		}
+		return details[i].TaskID < details[j].TaskID
+	})
+	switch {
+	case slowestN <= 0:
+		details = nil // contract: 0 (or negative) = no per-task detail
+	case len(details) > slowestN:
+		details = details[:slowestN]
+	}
+	rep.Slowest = details
+	return rep
+}
+
+func landedInWindow(events []audit.Event, since, until time.Time) map[string]time.Time {
+	landed := map[string]time.Time{}
+	for i := range events {
+		e := events[i]
+		if e.Type != audit.EventTaskLanded || e.TaskID == "" {
+			continue
+		}
+		if e.Timestamp.Before(since) || e.Timestamp.After(until) {
+			continue
+		}
+		if t, ok := landed[e.TaskID]; !ok || e.Timestamp.Before(t) {
+			landed[e.TaskID] = e.Timestamp // earliest landing wins (guard dup events)
+		}
+	}
+	return landed
+}
+
+// taskPhaseDurations reconstructs how long one task spent in each phase, from
+// creation through each status transition to landing. Segments with a
+// non-positive span (clock skew, or transitions recorded after landing) are
+// skipped rather than counted negative. Returns nil when there are no
+// transitions to anchor a timeline.
+func taskPhaseDurations(created time.Time, edges []statusEdge, landedAt time.Time) map[string]float64 {
+	if len(edges) == 0 {
+		return nil
+	}
+	sort.Slice(edges, func(i, j int) bool { return edges[i].ts.Before(edges[j].ts) })
+
+	out := map[string]float64{}
+	add := func(status string, start, end time.Time) {
+		ph := phaseOf(status)
+		if ph == "" {
+			return
+		}
+		if d := end.Sub(start).Hours(); d > 0 {
+			out[ph] += d
+		}
+	}
+
+	// Anchor the first segment at creation when known (counts the initial dwell
+	// in edges[0].from); otherwise start at the first transition (initial dwell
+	// is unknown, not zero).
+	prevStatus := edges[0].from
+	prevTime := edges[0].ts
+	if !created.IsZero() && !created.After(edges[0].ts) {
+		prevTime = created
+	}
+	for i := range edges {
+		add(prevStatus, prevTime, edges[i].ts)
+		prevStatus = edges[i].to
+		prevTime = edges[i].ts
+	}
+	add(prevStatus, prevTime, landedAt) // final open segment runs to landing
+	return out
+}
+
+func mean(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	var s float64
+	for _, x := range xs {
+		s += x
+	}
+	return s / float64(len(xs))
+}

--- a/internal/evaluation/phases_test.go
+++ b/internal/evaluation/phases_test.go
@@ -1,0 +1,186 @@
+package evaluation
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/audit"
+)
+
+func TestPhaseOf(t *testing.T) {
+	cases := map[string]string{
+		"new":            PhaseQueued,
+		"todo":           PhaseQueued,
+		"planning":       PhasePlanning,
+		"plan-review":    PhasePlanning,
+		"in-progress":    PhaseImplementing,
+		"testing":        PhaseTesting,
+		"ready-review":   PhaseReview,
+		"in-review":      PhaseReview,
+		"ready-pr":       PhaseReview,
+		"blocked":        PhaseWaiting,
+		"human-required": PhaseWaiting,
+		"done":           "",
+		"cancelled":      "",
+		"":               "", // missing status is not a phase
+		"made-up-status": PhaseOther,
+	}
+	for status, want := range cases {
+		if got := phaseOf(status); got != want {
+			t.Errorf("phaseOf(%q) = %q, want %q", status, got, want)
+		}
+	}
+}
+
+// at returns base + the given hours, so scenario timelines read clearly.
+func ev(typ, taskID string, ts time.Time, data map[string]any) audit.Event {
+	return audit.Event{Type: typ, TaskID: taskID, Timestamp: ts, Data: data}
+}
+
+func statusChange(taskID string, ts time.Time, from, to string) audit.Event {
+	return ev(audit.EventTaskStatusChanged, taskID, ts, map[string]any{"from": from, "to": to})
+}
+
+func TestComputePhaseDurations(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	at := func(h float64) time.Time { return base.Add(time.Duration(h * float64(time.Hour))) }
+
+	events := []audit.Event{
+		// Task A: queued 1h, planning 2h, implementing 3h, review 1h → total 7h.
+		ev(audit.EventTaskCreated, "A", at(0), nil),
+		statusChange("A", at(1), "todo", "planning"),
+		statusChange("A", at(3), "planning", "in-progress"),
+		statusChange("A", at(6), "in-progress", "in-review"),
+		statusChange("A", at(7), "in-review", "done"),
+		ev(audit.EventTaskLanded, "A", at(7), map[string]any{"outcome": "merged"}),
+
+		// Task B: queued 0.5h, planning 1.5h, implementing 3h, testing 1h, review 3h → total 9h.
+		ev(audit.EventTaskCreated, "B", at(0), nil),
+		statusChange("B", at(0.5), "todo", "planning"),
+		statusChange("B", at(2), "planning", "in-progress"),
+		statusChange("B", at(5), "in-progress", "testing"),
+		statusChange("B", at(6), "testing", "in-review"),
+		statusChange("B", at(9), "in-review", "done"),
+		ev(audit.EventTaskLanded, "B", at(9), map[string]any{"outcome": "merged"}),
+
+		// Task C: landed OUTSIDE the cohort window → must be excluded.
+		ev(audit.EventTaskCreated, "C", at(-100), nil),
+		statusChange("C", at(-99), "todo", "in-progress"),
+		ev(audit.EventTaskLanded, "C", at(-98), map[string]any{"outcome": "merged"}),
+	}
+
+	since := at(-24)
+	until := at(24)
+	rep := ComputePhaseDurations(events, since, until, 10)
+
+	if rep.Cohort != 2 {
+		t.Fatalf("cohort = %d, want 2 (C is out of window)", rep.Cohort)
+	}
+
+	totals := map[string]float64{}
+	counts := map[string]int{}
+	for _, p := range rep.Phases {
+		totals[p.Phase] = p.TotalH
+		counts[p.Phase] = p.Count
+	}
+	wantTotals := map[string]float64{
+		PhaseQueued:       1.5, // 1 + 0.5
+		PhasePlanning:     3.5, // 2 + 1.5
+		PhaseImplementing: 6,   // 3 + 3
+		PhaseTesting:      1,   // B only
+		PhaseReview:       4,   // 1 + 3
+	}
+	for ph, want := range wantTotals {
+		if got := totals[ph]; !approxEq(got, want) {
+			t.Errorf("phase %q total = %.3f, want %.3f", ph, got, want)
+		}
+	}
+	if counts[PhaseTesting] != 1 {
+		t.Errorf("testing count = %d, want 1 (only B was tested)", counts[PhaseTesting])
+	}
+	if counts[PhaseImplementing] != 2 {
+		t.Errorf("implementing count = %d, want 2", counts[PhaseImplementing])
+	}
+
+	// Phases must be emitted in canonical lifecycle order.
+	wantOrder := []string{PhaseQueued, PhasePlanning, PhaseImplementing, PhaseTesting, PhaseReview}
+	if len(rep.Phases) != len(wantOrder) {
+		t.Fatalf("got %d phases, want %d", len(rep.Phases), len(wantOrder))
+	}
+	for i, ph := range wantOrder {
+		if rep.Phases[i].Phase != ph {
+			t.Errorf("phase[%d] = %q, want %q", i, rep.Phases[i].Phase, ph)
+		}
+	}
+
+	// Slowest is sorted by total lead time desc; B (9h) before A (7h).
+	if len(rep.Slowest) != 2 || rep.Slowest[0].TaskID != "B" || rep.Slowest[1].TaskID != "A" {
+		t.Fatalf("slowest = %+v, want [B, A]", rep.Slowest)
+	}
+	if !approxEq(rep.Slowest[0].TotalH, 9) {
+		t.Errorf("B total = %.3f, want 9", rep.Slowest[0].TotalH)
+	}
+
+	// slowestN <= 0 means no per-task detail, even though the cohort is non-empty.
+	for _, n := range []int{0, -1} {
+		if r := ComputePhaseDurations(events, since, until, n); len(r.Slowest) != 0 {
+			t.Errorf("slowestN=%d: got %d detail rows, want 0", n, len(r.Slowest))
+		}
+	}
+}
+
+// TestComputePhaseDurations_EmptyFromStatus: a first transition with from=="" (a
+// first-observation status flip) must not book the creation→first-flip gap to
+// the "other" phase.
+func TestComputePhaseDurations_EmptyFromStatus(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	at := func(h float64) time.Time { return base.Add(time.Duration(h * float64(time.Hour))) }
+	events := []audit.Event{
+		ev(audit.EventTaskCreated, "A", at(0), nil),
+		statusChange("A", at(2), "", "in-progress"), // first observation: from is empty
+		statusChange("A", at(5), "in-progress", "in-review"),
+		statusChange("A", at(6), "in-review", "done"),
+		ev(audit.EventTaskLanded, "A", at(6), map[string]any{"outcome": "merged"}),
+	}
+	rep := ComputePhaseDurations(events, at(-24), at(24), 5)
+	for _, p := range rep.Phases {
+		if p.Phase == PhaseOther {
+			t.Errorf("empty from-status leaked into %q (%.3fh); want it skipped", PhaseOther, p.TotalH)
+		}
+	}
+}
+
+// TestComputePhaseDurations_NoCreatedEvent: without a creation timestamp the
+// initial dwell is unknown, so queued is not counted, but later phases still are.
+func TestComputePhaseDurations_NoCreatedEvent(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	at := func(h float64) time.Time { return base.Add(time.Duration(h * float64(time.Hour))) }
+	events := []audit.Event{
+		statusChange("A", at(1), "todo", "in-progress"),
+		statusChange("A", at(4), "in-progress", "in-review"),
+		statusChange("A", at(5), "in-review", "done"),
+		ev(audit.EventTaskLanded, "A", at(5), map[string]any{"outcome": "merged"}),
+	}
+	rep := ComputePhaseDurations(events, at(-24), at(24), 0)
+	if rep.Cohort != 1 {
+		t.Fatalf("cohort = %d, want 1", rep.Cohort)
+	}
+	totals := map[string]float64{}
+	for _, p := range rep.Phases {
+		totals[p.Phase] = p.TotalH
+	}
+	if _, ok := totals[PhaseQueued]; ok {
+		t.Errorf("queued must be absent without a creation timestamp, got %.3f", totals[PhaseQueued])
+	}
+	if !approxEq(totals[PhaseImplementing], 3) {
+		t.Errorf("implementing = %.3f, want 3", totals[PhaseImplementing])
+	}
+	if !approxEq(totals[PhaseReview], 1) {
+		t.Errorf("review = %.3f, want 1", totals[PhaseReview])
+	}
+}
+
+func approxEq(a, b float64) bool {
+	d := a - b
+	return d < 1e-9 && d > -1e-9
+}

--- a/internal/evaluation/service.go
+++ b/internal/evaluation/service.go
@@ -184,6 +184,26 @@ func (s *Service) GetEvaluationReport() Report {
 	return rep
 }
 
+// PhaseReport decomposes the lead time of tasks that landed in the window into
+// per-phase durations (planning/implementing/testing/review/…), so callers can
+// see where end-to-end time is actually spent. Reads task.status_changed history
+// from a wider range than the cohort window so an in-window landing that started
+// earlier is fully reconstructed. Read-only.
+func (s *Service) PhaseReport(_ context.Context) (PhaseReport, error) {
+	now := s.now()
+	wd := s.windowDays()
+	since := now.AddDate(0, 0, -wd)
+	if s.audit == nil {
+		return PhaseReport{Since: since, Until: now}, nil
+	}
+	histSince := now.AddDate(0, 0, -3*wd)
+	evts, err := s.audit.Read(audit.Query{Since: histSince, Until: now})
+	if err != nil {
+		return PhaseReport{}, err
+	}
+	return ComputePhaseDurations(evts, since, now, 10), nil
+}
+
 // LastReport returns the cached report and whether one exists.
 func (s *Service) LastReport() (Report, bool) {
 	s.mu.RLock()

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -89,8 +89,12 @@ type App struct {
 	emitFactory                   func(context.Context) func(string, any)
 	openBrowser                   func(string)
 	restartStaleErr               *logging.ErrorThrottle
-	recovery                      *recovery.Recovery
-	agentCompletion               *AgentCompletionHandler
+	// dispatchNudge wakes the orchestrator dispatch pass on demand (e.g. on a
+	// status change) so a freshly-ready task isn't left idle until the next
+	// fast tick. Buffered, size 1, coalescing — see nudgeDispatch.
+	dispatchNudge   chan struct{}
+	recovery        *recovery.Recovery
+	agentCompletion *AgentCompletionHandler
 	// umbrellaCloseIssue closes the umbrella GitHub issue on full roll-up.
 	// nil defaults to github.CloseIssue; overridden in tests.
 	umbrellaCloseIssue func(repo string, number int, comment string) error
@@ -160,6 +164,7 @@ func NewApp(logger *slog.Logger, logLevel *slog.LevelVar, cfg *config.Config, op
 		cfg:             cfg,
 		logLevel:        logLevel,
 		restartStaleErr: logging.NewErrorThrottle(),
+		dispatchNudge:   make(chan struct{}, 1),
 	}
 	// Pre-allocate service structs so Wails can bind them before startup().
 	// Fields are populated in startup() once dependencies are initialized.
@@ -313,6 +318,21 @@ func (a *App) GetEvaluationReport() evaluation.Report {
 		return evaluation.Report{}
 	}
 	return a.evaluationSvc.GetEvaluationReport()
+}
+
+// GetLifecyclePhases returns the per-phase lifecycle-duration breakdown for
+// tasks that landed in the evaluation window — where end-to-end time is spent
+// (planning vs implementing vs testing vs review vs waiting).
+func (a *App) GetLifecyclePhases() evaluation.PhaseReport {
+	if a.evaluationSvc == nil {
+		return evaluation.PhaseReport{}
+	}
+	rep, err := a.evaluationSvc.PhaseReport(context.Background())
+	if err != nil {
+		a.logger.Warn("evaluation.phases.failed", "err", err)
+		return evaluation.PhaseReport{}
+	}
+	return rep
 }
 
 func (a *App) Shutdown(_ context.Context) {

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -164,6 +164,11 @@ func (a *App) initStatusHook() {
 	a.tasks.SetStatusChangeHook(func(taskID, from, to string) {
 		a.logAudit(audit.EventTaskStatusChanged, taskID, "", map[string]any{"from": from, "to": to})
 
+		// Wake the dispatch pass immediately so a task that just became ready
+		// (e.g. a dependency completing, a stage advancing) is picked up now
+		// instead of waiting for the next fast tick.
+		a.nudgeDispatch()
+
 		// Advance workflows whose current run_agent step declares a
 		// matching wait_for_status. This is how interactive agents (which
 		// never exit between turns) signal step completion.

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -56,7 +56,9 @@ func (a *App) maintenancePass() {
 
 // nudgeDispatch asks the orchestrator loop to run a dispatch pass promptly
 // instead of waiting for the next fast tick. Non-blocking and coalescing: a full
-// buffer means a pass is already pending. No-op if the loop hasn't started.
+// buffer means a pass is already pending. If the loop hasn't started yet, the
+// buffered signal is drained on its first iteration; the nil-guard only skips
+// when the channel was never created (non-NewApp test construction).
 func (a *App) nudgeDispatch() {
 	if a.dispatchNudge == nil {
 		return

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -8,30 +8,79 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 )
 
+// orchestratorLoop runs two cadences. The cheap, latency-sensitive dispatch pass
+// (start the orchestrator, release unblocked children) fires on a fast ticker and
+// on demand via dispatchNudge, so a freshly-ready task isn't left idle. The
+// expensive recovery/cleanup pass (resume stalled workflows, restart stale
+// agents, prune orphan worktrees) — which hits git and may spawn agents — fires
+// on a slower ticker so it never runs hot.
 func (a *App) orchestratorLoop(ctx context.Context) {
-	ticker := time.NewTicker(1 * time.Minute)
-	defer ticker.Stop()
+	dispatch := time.NewTicker(a.dispatchInterval())
+	defer dispatch.Stop()
+	maintenance := time.NewTicker(a.maintenanceInterval())
+	defer maintenance.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
-			metrics.OrchestratorTick()
-			a.maybeStartOrchestrator()
-			if a.workflowEngine != nil {
-				a.workflowEngine.ResumeStalled()
-			}
-			// Release umbrella child tasks whose dependencies have merged, so
-			// the normal dispatch picks them up like any todo task.
-			a.releaseUnblockedChildren()
-			// Recover in-progress tasks whose agent died — runs continuously,
-			// not just at startup, to catch agents that finished without
-			// advancing the workflow.
-			a.recovery.RestartStaleInProgress()
-			a.worktrees.CleanupOrphaned()
+		case <-a.dispatchNudge:
+			a.dispatchPass()
+		case <-dispatch.C:
+			a.dispatchPass()
+		case <-maintenance.C:
+			a.maintenancePass()
 		}
 	}
+}
+
+// dispatchPass runs the cheap scheduling actions that gate a ready task. Safe to
+// run often: maybeStartOrchestrator no-ops when already running, and
+// releaseUnblockedChildren only acts on tasks whose dependencies merged.
+func (a *App) dispatchPass() {
+	a.maybeStartOrchestrator()
+	a.releaseUnblockedChildren()
+}
+
+// maintenancePass runs the expensive, git/agent-touching recovery and cleanup.
+func (a *App) maintenancePass() {
+	metrics.OrchestratorTick()
+	if a.workflowEngine != nil {
+		a.workflowEngine.ResumeStalled()
+	}
+	// Recover in-progress tasks whose agent died — runs continuously, not just at
+	// startup, to catch agents that finished without advancing the workflow.
+	a.recovery.RestartStaleInProgress()
+	a.worktrees.CleanupOrphaned()
+}
+
+// nudgeDispatch asks the orchestrator loop to run a dispatch pass promptly
+// instead of waiting for the next fast tick. Non-blocking and coalescing: a full
+// buffer means a pass is already pending. No-op if the loop hasn't started.
+func (a *App) nudgeDispatch() {
+	if a.dispatchNudge == nil {
+		return
+	}
+	select {
+	case a.dispatchNudge <- struct{}{}:
+	default:
+	}
+}
+
+func (a *App) dispatchInterval() time.Duration {
+	s := a.cfg.Orchestrator.DispatchIntervalSeconds
+	if s <= 0 {
+		s = 10
+	}
+	return time.Duration(s) * time.Second
+}
+
+func (a *App) maintenanceInterval() time.Duration {
+	s := a.cfg.Orchestrator.MaintenanceIntervalSeconds
+	if s <= 0 {
+		s = 60
+	}
+	return time.Duration(s) * time.Second
 }
 
 func (a *App) maybeStartOrchestrator() {

--- a/internal/sybra/config_diff.go
+++ b/internal/sybra/config_diff.go
@@ -60,9 +60,16 @@ func diffConfig(old, next config.Config) (hot, restart []string) {
 		hot = append(hot, "agent.other")
 	}
 
-	// Orchestrator and audit are live-effective via pointer read; no setter needed
-	if !reflect.DeepEqual(old.Orchestrator, next.Orchestrator) {
+	// Orchestrator AutoTriage/AutoPlan are live-effective via pointer read; the
+	// dispatch/maintenance intervals are sampled once at loop start (NewTicker),
+	// so changing them needs a restart to take effect.
+	if old.Orchestrator.AutoTriage != next.Orchestrator.AutoTriage ||
+		old.Orchestrator.AutoPlan != next.Orchestrator.AutoPlan {
 		hot = append(hot, "orchestrator")
+	}
+	if old.Orchestrator.DispatchIntervalSeconds != next.Orchestrator.DispatchIntervalSeconds ||
+		old.Orchestrator.MaintenanceIntervalSeconds != next.Orchestrator.MaintenanceIntervalSeconds {
+		restart = append(restart, "orchestrator.intervals")
 	}
 	if !reflect.DeepEqual(old.Audit, next.Audit) {
 		hot = append(hot, "audit")

--- a/internal/sybra/services.go
+++ b/internal/sybra/services.go
@@ -95,6 +95,7 @@ func (a *App) coreHTTPServices() map[string]httpapi.Service {
 		"App": httpapi.NewService(a,
 			"GetMonitorReport",
 			"GetEvaluationReport",
+			"GetLifecyclePhases",
 			"StartAgent",
 			"StartChat",
 			"StopChat",


### PR DESCRIPTION
## Motivation

The app felt slow to deliver new tasks and to switch board states, and there was no way to see *where* a task's wall-clock actually goes. We measured end-to-end lead/cycle time already, but nothing decomposed it by phase, so "what step should we make faster" was unanswerable. The orchestrator also only acted on a 1-minute tick, leaving freshly-ready tasks idle for up to ~60s.

> Changelog: feat(evaluation): per-phase lifecycle stats + faster dispatch

## Implementation information

**1. Per-phase lifecycle stats (new — reuses existing audit data, no new instrumentation)**
- `internal/evaluation/phases.go`: `ComputePhaseDurations` reconstructs each landed task's timeline from `task.status_changed` audit events and splits lead time into `queued / planning / implementing / testing / review / waiting`, with p50/p90/mean/share per phase plus a slowest-tasks list. Pure/deterministic; reuses the package's `percentile`/`strVal`.
- `sybra-cli stats lifecycle [--since 30d] [--slowest N] [--json]` and a "Where time goes" panel on the Evaluation page (new `App.GetLifecyclePhases` binding).
- On real data this immediately shows review (~45%) and waiting (~43%) dominate lead time; planning/implementing/testing are sub-hour — i.e. throughput is gated on review turnaround and human-wait, not implementation speed.

**2. Faster dispatch**
- Split `orchestratorLoop` into a fast **dispatch pass** (`maybeStartOrchestrator` + `releaseUnblockedChildren`, default 10s, configurable) and a slower **maintenance pass** (resume-stalled / restart-stale / cleanup-orphans, default 60s) that keeps git/agent cost off the hot path.
- Every status change now nudges the dispatch pass on demand (buffered, coalescing channel), so an unblocked/advanced task is picked up immediately instead of waiting a full tick.
- New `orchestrator.dispatch_interval_seconds` / `maintenance_interval_seconds`; interval changes are correctly flagged restart-required.

**3. Frontend responsiveness**
- Task events now patch the single changed task (per-id coalesced) instead of full-reloading and re-rendering the whole board on every event; the 30s poll stays as a reconcile safety net.
- TaskCard's 4× full agent-list scans replaced with one O(1) per-task agent-status map.

**Adversarial review** (two reviewers) ran before this PR; findings fixed and covered by tests:
- HIGH — async `patchOne` could resurrect a just-deleted task (zombie card): added a per-id sequence guard so a stale in-flight fetch is discarded.
- MEDIUM — `stats lifecycle --slowest 0` listed *all* tasks instead of none.
- MEDIUM — hot-reloaded dispatch/maintenance intervals were mislabeled "applied"; now reported restart-required.
- LOW — an empty `from` status (first-observation flip) was booked to an `other` phase; now skipped.

## Supporting documentation

Gates: `golangci-lint` 0 issues · `go test ./...` 42 pkgs pass · `svelte-check` 0 · `oxlint` 0 · frontend `build:desktop` + `go build .` succeed. Bindings regenerated (`wails3 generate bindings`).
