### PR TITLE
feat(permissions): add headless auto mode

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -89,6 +89,15 @@ export class AgentDefaults {
      */
     "approvalPort": number;
 
+    /**
+     * HeadlessPermissionMode sets the default permission posture for unattended
+     * headless claude runs. "bypass" (default) keeps the current
+     * --dangerously-skip-permissions behavior. "auto" emits --permission-mode auto
+     * which activates the Claude Code auto-mode classifier (blocks destructive ops
+     * such as rm -rf $HOME, force-push, terraform destroy). Empty treated as "bypass".
+     */
+    "headlessPermissionMode": string;
+
     /** Creates a new AgentDefaults instance. */
     constructor($$source: Partial<AgentDefaults> = {}) {
         if (!("provider" in $$source)) {
@@ -141,6 +150,9 @@ export class AgentDefaults {
         }
         if (!("approvalPort" in $$source)) {
             this["approvalPort"] = 0;
+        }
+        if (!("headlessPermissionMode" in $$source)) {
+            this["headlessPermissionMode"] = "";
         }
 
         Object.assign(this, $$source);

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -282,6 +282,13 @@ export class Task {
     "requirePermissions"?: boolean | null;
 
     /**
+     * HeadlessPermissionMode overrides the permission posture for headless claude
+     * runs on this task. "auto" emits --permission-mode auto; "bypass" keeps
+     * --dangerously-skip-permissions. Empty = use config default.
+     */
+    "headlessPermissionMode"?: string;
+
+    /**
      * ForkSubagent enables CLAUDE_CODE_FORK_SUBAGENT=1 for this task's headless
      * agent, allowing a single prompt to spawn parallel subagent runs. Trades
      * higher token cost for reduced wall-clock time on multi-part prompts.
@@ -401,9 +408,9 @@ export class Task {
         const $$createField6_0 = $$createType0;
         const $$createField7_0 = $$createType0;
         const $$createField17_0 = $$createType0;
-        const $$createField33_0 = $$createType2;
-        const $$createField34_0 = $$createType4;
-        const $$createField44_0 = $$createType5;
+        const $$createField34_0 = $$createType2;
+        const $$createField35_0 = $$createType4;
+        const $$createField45_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -415,13 +422,13 @@ export class Task {
             $$parsedSource["dependsOn"] = $$createField17_0($$parsedSource["dependsOn"]);
         }
         if ("agentRuns" in $$parsedSource) {
-            $$parsedSource["agentRuns"] = $$createField33_0($$parsedSource["agentRuns"]);
+            $$parsedSource["agentRuns"] = $$createField34_0($$parsedSource["agentRuns"]);
         }
         if ("workflow" in $$parsedSource) {
-            $$parsedSource["workflow"] = $$createField34_0($$parsedSource["workflow"]);
+            $$parsedSource["workflow"] = $$createField35_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField44_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField45_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -68,21 +68,22 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 
 	now := time.Now().UTC()
 	a := &Agent{
-		ID:                 id,
-		TaskID:             cfg.TaskID,
-		Name:               cfg.Name,
-		Mode:               cfg.Mode,
-		Provider:           resolvedProvider,
-		Model:              normalizeModel(resolvedProvider, cfg.Model),
-		ReasoningEffort:    cfg.ReasoningEffort,
-		Prompt:             cfg.Prompt,
-		State:              StateRunning,
-		StartedAt:          now,
-		LastEventAt:        now,
-		cancel:             cancel,
-		sessionCWD:         cfg.Dir,
-		MaxTurns:           cfg.MaxTurns,
-		requirePermissions: cfg.RequirePermissions,
+		ID:                     id,
+		TaskID:                 cfg.TaskID,
+		Name:                   cfg.Name,
+		Mode:                   cfg.Mode,
+		Provider:               resolvedProvider,
+		Model:                  normalizeModel(resolvedProvider, cfg.Model),
+		ReasoningEffort:        cfg.ReasoningEffort,
+		Prompt:                 cfg.Prompt,
+		State:                  StateRunning,
+		StartedAt:              now,
+		LastEventAt:            now,
+		cancel:                 cancel,
+		sessionCWD:             cfg.Dir,
+		MaxTurns:               cfg.MaxTurns,
+		requirePermissions:     cfg.RequirePermissions,
+		headlessPermissionMode: cfg.HeadlessPermissionMode,
 	}
 	if cfg.ResumeSessionID != "" {
 		a.SetSessionID(cfg.ResumeSessionID)
@@ -183,18 +184,14 @@ func (m *Manager) buildCommand(cfg RunConfig) (string, error) {
 	case "copilot":
 		return buildCopilotCommand(model), nil
 	default:
-		return buildClaudeCommand(model, cfg.AllowedTools, cfg.RequirePermissions), nil
+		return buildClaudeCommand(model, cfg.AllowedTools, cfg.RequirePermissions, cfg.HeadlessPermissionMode), nil
 	}
 }
 
 // buildClaudeCommand builds the display command string for a Claude agent.
-func buildClaudeCommand(model string, allowedTools []string, requirePerms bool) string {
+func buildClaudeCommand(model string, allowedTools []string, requirePerms bool, mode string) string {
 	parts := []string{"claude"}
-	if len(allowedTools) > 0 {
-		parts = append(parts, "--allowedTools", strings.Join(allowedTools, ","))
-	} else if !requirePerms {
-		parts = append(parts, "--dangerously-skip-permissions")
-	}
+	parts = append(parts, claudePermissionArgs(allowedTools, requirePerms, mode)...)
 	if model != "" {
 		parts = append(parts, "--model", model)
 	}

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -151,6 +151,15 @@ type Agent struct {
 	// choice across a restart instead of silently becoming permissive.
 	requirePermissions bool
 
+	// headlessPermissionMode is the resolved posture passed via RunConfig
+	// ("bypass" or "auto"). Stored for OnComplete so the denial audit events
+	// can record the posture without re-resolving it.
+	headlessPermissionMode string
+
+	// permissionDenials accumulates auto-mode classifier denial records
+	// observed during the run. Flushed to audit in OnComplete.
+	permissionDenials []PermissionDenial
+
 	// mu guards mutable fields touched from multiple goroutines. See the
 	// package-level note above the Agent type.
 	mu sync.RWMutex
@@ -456,6 +465,35 @@ func (a *Agent) SetEscalationReason(reason string) {
 	a.mu.Unlock()
 }
 
+// NotePermissionDenial records an auto-mode classifier denial observed during the run.
+func (a *Agent) NotePermissionDenial(toolUseID, reason string) {
+	a.mu.Lock()
+	a.permissionDenials = append(a.permissionDenials, PermissionDenial{
+		ToolUseID: toolUseID,
+		Reason:    reason,
+	})
+	a.mu.Unlock()
+}
+
+// GetPermissionDenials returns a snapshot of the recorded auto-mode denial records.
+func (a *Agent) GetPermissionDenials() []PermissionDenial {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if len(a.permissionDenials) == 0 {
+		return nil
+	}
+	cp := make([]PermissionDenial, len(a.permissionDenials))
+	copy(cp, a.permissionDenials)
+	return cp
+}
+
+// GetHeadlessPermissionMode returns the resolved headless permission posture for this run.
+func (a *Agent) GetHeadlessPermissionMode() string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.headlessPermissionMode
+}
+
 // SetPluginErrors records plugin load failures from the init event.
 func (a *Agent) SetPluginErrors(errs []string) {
 	a.mu.Lock()
@@ -708,6 +746,20 @@ type RunConfig struct {
 	// Set intra-package before buildHeadlessInvocation; cleared by defer after
 	// the subprocess exits. Never set by callers.
 	outputSchemaPath string
+	// HeadlessPermissionMode overrides the permission posture for this run.
+	// "auto" emits --permission-mode auto (Claude Code auto-mode classifier).
+	// "bypass" (or empty) keeps --dangerously-skip-permissions.
+	// Only effective for claude headless runs when AllowedTools is empty and
+	// RequirePermissions is false.
+	HeadlessPermissionMode string
+}
+
+// PermissionDenial records a single auto-mode classifier denial observed during
+// a headless run. Populated from tool_result error blocks that match the Claude
+// Code auto-mode classifier denial marker.
+type PermissionDenial struct {
+	ToolUseID string
+	Reason    string
 }
 
 // PlanStep represents a single item from a TodoWrite tool call.
@@ -749,6 +801,10 @@ type StreamEvent struct {
 	// repeating the same call. Unexported so it is never serialized to the
 	// NDJSON log or emitted to the frontend; it lives only in memory.
 	toolSig string
+	// permissionDenials carries auto-mode classifier denial records extracted
+	// from this event's tool_result error blocks. Unexported so it is never
+	// serialized; lives in-memory only. Populated for claude "user" events only.
+	permissionDenials []PermissionDenial
 }
 
 // ConvoEvent is a rich event for conversational mode, preserving full tool

--- a/internal/agent/permissions_test.go
+++ b/internal/agent/permissions_test.go
@@ -1,0 +1,134 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestClaudePermissionArgs(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		allowed      []string
+		requirePerms bool
+		mode         string
+		want         []string
+	}{
+		{"allowlist wins over bypass", []string{"Bash", "Read"}, false, "bypass", []string{"--allowedTools", "Bash,Read"}},
+		{"allowlist wins over auto", []string{"Bash"}, false, "auto", []string{"--allowedTools", "Bash"}},
+		{"allowlist wins over requirePerms", []string{"Read"}, true, "auto", []string{"--allowedTools", "Read"}},
+		{"requirePerms → nil", nil, true, "bypass", nil},
+		{"requirePerms with auto → nil", nil, true, "auto", nil},
+		{"auto mode", nil, false, "auto", []string{"--permission-mode", "auto"}},
+		{"bypass mode", nil, false, "bypass", []string{"--dangerously-skip-permissions"}},
+		{"empty mode → bypass", nil, false, "", []string{"--dangerously-skip-permissions"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := claudePermissionArgs(tc.allowed, tc.requirePerms, tc.mode)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestClassifyAutoModeDenial(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		tr   ToolResultBlock
+		want bool
+	}{
+		{
+			"exact match",
+			ToolResultBlock{IsError: true, Content: "denied by the claude code auto mode classifier"},
+			true,
+		},
+		{
+			"mixed case",
+			ToolResultBlock{IsError: true, Content: "DENIED BY THE CLAUDE CODE AUTO MODE CLASSIFIER"},
+			true,
+		},
+		{
+			"with surrounding text",
+			ToolResultBlock{IsError: true, Content: "operation failed: denied by the claude code auto mode classifier for tool bash"},
+			true,
+		},
+		{
+			"multiline content",
+			ToolResultBlock{IsError: true, Content: "line one\ndenied by the claude code auto mode classifier\nline three"},
+			true,
+		},
+		{
+			"not an error (IsError false)",
+			ToolResultBlock{IsError: false, Content: "denied by the claude code auto mode classifier"},
+			false,
+		},
+		{
+			"unrelated error",
+			ToolResultBlock{IsError: true, Content: "permission denied: file not found"},
+			false,
+		},
+		{
+			"empty",
+			ToolResultBlock{IsError: true, Content: ""},
+			false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := classifyAutoModeDenial(tc.tr); got != tc.want {
+				t.Errorf("classifyAutoModeDenial = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNoteAndGetPermissionDenials(t *testing.T) {
+	t.Parallel()
+	a := &Agent{}
+
+	if got := a.GetPermissionDenials(); got != nil {
+		t.Fatalf("expected nil before any denials, got %v", got)
+	}
+
+	a.NotePermissionDenial("tool-1", "denied because rm -rf")
+	a.NotePermissionDenial("tool-2", "denied because force push")
+
+	denials := a.GetPermissionDenials()
+	if len(denials) != 2 {
+		t.Fatalf("expected 2 denials, got %d", len(denials))
+	}
+	if denials[0].ToolUseID != "tool-1" || denials[0].Reason != "denied because rm -rf" {
+		t.Errorf("first denial mismatch: %+v", denials[0])
+	}
+	if denials[1].ToolUseID != "tool-2" {
+		t.Errorf("second denial mismatch: %+v", denials[1])
+	}
+
+	// GetPermissionDenials returns a copy — mutations don't affect original
+	denials[0].ToolUseID = "mutated"
+	original := a.GetPermissionDenials()
+	if original[0].ToolUseID == "mutated" {
+		t.Error("GetPermissionDenials returned a reference, not a copy")
+	}
+}
+
+func TestGetHeadlessPermissionMode(t *testing.T) {
+	t.Parallel()
+	a := &Agent{}
+	if got := a.GetHeadlessPermissionMode(); got != "" {
+		t.Errorf("zero-value should return empty, got %q", got)
+	}
+	a.headlessPermissionMode = "auto"
+	if got := a.GetHeadlessPermissionMode(); got != "auto" {
+		t.Errorf("got %q, want auto", got)
+	}
+}

--- a/internal/agent/permissions_test.go
+++ b/internal/agent/permissions_test.go
@@ -116,6 +116,9 @@ func TestNoteAndGetPermissionDenials(t *testing.T) {
 	// GetPermissionDenials returns a copy — mutations don't affect original
 	denials[0].ToolUseID = "mutated"
 	original := a.GetPermissionDenials()
+	if len(original) == 0 {
+		t.Fatal("expected copy to still have denials")
+	}
 	if original[0].ToolUseID == "mutated" {
 		t.Error("GetPermissionDenials returned a reference, not a copy")
 	}

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -515,6 +515,10 @@ func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte
 	// signature (non-tool event) is a no-op, so the streak survives reasoning
 	// between identical calls and the watchdog can spot an active loop.
 	a.NoteToolSignature(event.toolSig)
+	// Record any auto-mode classifier denials observed in this event's tool results.
+	for _, d := range event.permissionDenials {
+		a.NotePermissionDenial(d.ToolUseID, d.Reason)
+	}
 	if event.Type == "result" || time.Since(*lastEmit) >= headlessEmitInterval {
 		m.emit(events.AgentOutput(a.ID), event)
 		*lastEmit = time.Now()

--- a/internal/agent/runner_headless_invocation.go
+++ b/internal/agent/runner_headless_invocation.go
@@ -75,11 +75,7 @@ func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args, env []
 	if sid := a.GetSessionID(); sid != "" {
 		args = append(args, "--resume", sid)
 	}
-	if len(cfg.AllowedTools) > 0 {
-		args = append(args, "--allowedTools", strings.Join(cfg.AllowedTools, ","))
-	} else if !cfg.RequirePermissions {
-		args = append(args, "--dangerously-skip-permissions")
-	}
+	args = append(args, claudePermissionArgs(cfg.AllowedTools, cfg.RequirePermissions, cfg.HeadlessPermissionMode)...)
 	if a.Model != "" {
 		args = append(args, "--model", a.Model)
 	}
@@ -108,4 +104,24 @@ func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args, env []
 	}
 	command = "claude " + strings.Join(args, " ")
 	return
+}
+
+// claudePermissionArgs returns the permission-related CLI flags for a claude headless run.
+//
+// Precedence:
+//  1. len(allowed)>0 → --allowedTools <list> (explicit tool allowlist wins)
+//  2. requirePerms → nil (approval-hook mode; no bypass or auto flag)
+//  3. mode=="auto" → --permission-mode auto (auto-mode classifier)
+//  4. else → --dangerously-skip-permissions (legacy bypass, default)
+func claudePermissionArgs(allowed []string, requirePerms bool, mode string) []string {
+	if len(allowed) > 0 {
+		return []string{"--allowedTools", strings.Join(allowed, ",")}
+	}
+	if requirePerms {
+		return nil
+	}
+	if mode == "auto" {
+		return []string{"--permission-mode", "auto"}
+	}
+	return []string{"--dangerously-skip-permissions"}
 }

--- a/internal/agent/runner_headless_stream.go
+++ b/internal/agent/runner_headless_stream.go
@@ -56,6 +56,14 @@ func claudeEventToStreamEvent(e ClaudeEvent) StreamEvent {
 	case "user":
 		if e.Message != nil {
 			ev.Content = formatHeadlessToolResults(e.Message.ToolResults)
+			for _, tr := range e.Message.ToolResults {
+				if classifyAutoModeDenial(tr) {
+					ev.permissionDenials = append(ev.permissionDenials, PermissionDenial{
+						ToolUseID: tr.ToolUseID,
+						Reason:    tr.Content,
+					})
+				}
+			}
 		}
 	case "result":
 		if e.Result != nil {

--- a/internal/agent/stream.go
+++ b/internal/agent/stream.go
@@ -745,3 +745,16 @@ func strVal(m map[string]any, key string) string {
 	v, _ := m[key].(string)
 	return v
 }
+
+// autoModeDenialMarker is the substring Claude Code embeds in tool_result error
+// content when the auto-mode classifier blocks a tool call. Matched
+// case-insensitively so a minor wording change doesn't silently break detection.
+const autoModeDenialMarker = "denied by the claude code auto mode classifier"
+
+// classifyAutoModeDenial reports whether tr is an auto-mode classifier denial.
+// True when tr.IsError is set and tr.Content (case-insensitive) contains the
+// denial marker, regardless of how Content was assembled (plain string or
+// array-joined text blocks).
+func classifyAutoModeDenial(tr ToolResultBlock) bool {
+	return tr.IsError && strings.Contains(strings.ToLower(tr.Content), autoModeDenialMarker)
+}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -48,6 +48,9 @@ const (
 	// EventPRReverted records that a previously-merged PR was reverted on the
 	// default branch — a change-failure signal. Reserved for revert detection.
 	EventPRReverted = "pr.reverted"
+	// EventAgentPermissionDenied is emitted once per auto-mode classifier denial
+	// observed during a headless claude run. Batched at completion time.
+	EventAgentPermissionDenied = "agent.permission_denied"
 )
 
 type Event struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -187,7 +188,10 @@ func (c *Config) DefaultRequirePermissions() bool {
 // Empty string maps to "bypass". "bypass" and "auto" pass through unchanged.
 // Any other value is rejected with an error.
 func NormalizeHeadlessPermissionMode(s string) (string, error) {
-	switch s {
+	// Trim + lowercase first: a formatting slip (`auto `, `Auto`) must not
+	// silently fall through to the permissive bypass default and disable the
+	// guardrail this feature exists to provide.
+	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "", "bypass":
 		return "bypass", nil
 	case "auto":

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -112,6 +113,12 @@ type AgentDefaults struct {
 	// requests still resolve after a restart. 0 (default) binds a random
 	// port (no cross-restart approval survival).
 	ApprovalPort int `yaml:"approval_port" json:"approvalPort"`
+	// HeadlessPermissionMode sets the default permission posture for unattended
+	// headless claude runs. "bypass" (default) keeps the current
+	// --dangerously-skip-permissions behavior. "auto" emits --permission-mode auto
+	// which activates the Claude Code auto-mode classifier (blocks destructive ops
+	// such as rm -rf $HOME, force-push, terraform destroy). Empty treated as "bypass".
+	HeadlessPermissionMode string `yaml:"headless_permission_mode" json:"headlessPermissionMode"`
 }
 
 // DefaultBashTimeoutSeconds is the per-bash-tool-call timeout used when
@@ -174,6 +181,35 @@ func (c *Config) DefaultRequirePermissions() bool {
 		return *c.Agent.RequirePermissions
 	}
 	return true
+}
+
+// NormalizeHeadlessPermissionMode canonicalizes a headless permission mode value.
+// Empty string maps to "bypass". "bypass" and "auto" pass through unchanged.
+// Any other value is rejected with an error.
+func NormalizeHeadlessPermissionMode(s string) (string, error) {
+	switch s {
+	case "", "bypass":
+		return "bypass", nil
+	case "auto":
+		return "auto", nil
+	default:
+		return "", fmt.Errorf("invalid headless_permission_mode %q (valid: bypass, auto)", s)
+	}
+}
+
+// DefaultHeadlessPermissionMode returns the configured default headless permission
+// mode, or "bypass" if unset. An invalid config value is logged and treated as
+// "bypass" so a misconfigured server never silently switches posture.
+func (c *Config) DefaultHeadlessPermissionMode() string {
+	if c == nil || c.Agent.HeadlessPermissionMode == "" {
+		return "bypass"
+	}
+	mode, err := NormalizeHeadlessPermissionMode(c.Agent.HeadlessPermissionMode)
+	if err != nil {
+		slog.Warn("config: invalid agent.headless_permission_mode; falling back to bypass", "value", c.Agent.HeadlessPermissionMode)
+		return "bypass"
+	}
+	return mode
 }
 
 // SurviveRestartEnabled reports whether agent subprocesses should be

--- a/internal/config/permissions_test.go
+++ b/internal/config/permissions_test.go
@@ -15,8 +15,14 @@ func TestNormalizeHeadlessPermissionMode(t *testing.T) {
 		{"bypass", "bypass", false},
 		{"auto", "auto", false},
 		{"dangerously-skip", "", true},
-		{"BYPASS", "", true},
-		{"AUTO", "", true},
+		// Formatting slips are normalized, not rejected — a casing/whitespace
+		// typo must not silently disable the guardrail by falling back to bypass.
+		{"BYPASS", "bypass", false},
+		{"AUTO", "auto", false},
+		{"Auto", "auto", false},
+		{"auto ", "auto", false},
+		{"  bypass  ", "bypass", false},
+		{"   ", "bypass", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.input, func(t *testing.T) {

--- a/internal/config/permissions_test.go
+++ b/internal/config/permissions_test.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestNormalizeHeadlessPermissionMode(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"", "bypass", false},
+		{"bypass", "bypass", false},
+		{"auto", "auto", false},
+		{"dangerously-skip", "", true},
+		{"BYPASS", "", true},
+		{"AUTO", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			got, err := NormalizeHeadlessPermissionMode(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if !tc.wantErr && got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDefaultHeadlessPermissionMode(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		cfg  *Config
+		want string
+	}{
+		{"nil config", nil, "bypass"},
+		{"empty field", &Config{}, "bypass"},
+		{"valid bypass", &Config{Agent: AgentDefaults{HeadlessPermissionMode: "bypass"}}, "bypass"},
+		{"valid auto", &Config{Agent: AgentDefaults{HeadlessPermissionMode: "auto"}}, "auto"},
+		{"invalid → bypass fallback", &Config{Agent: AgentDefaults{HeadlessPermissionMode: "invalid"}}, "bypass"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.cfg.DefaultHeadlessPermissionMode(); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -134,6 +134,24 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 		return
 	}
 
+	// Emit one permission-denied audit event per recorded auto-mode denial.
+	// Batched here (completion time) rather than real-time to avoid spamming
+	// the audit log while a run is still live. A run killed before completion
+	// may drop its denial events — the permission_posture on agent.started is
+	// the durable observability signal.
+	posture := ag.GetHeadlessPermissionMode()
+	for _, d := range ag.GetPermissionDenials() {
+		toolID := d.ToolUseID
+		if toolID == "" {
+			toolID = "unknown"
+		}
+		h.logAudit(audit.EventAgentPermissionDenied, ag.TaskID, ag.ID, map[string]any{
+			"tool":    toolID,
+			"reason":  d.Reason,
+			"posture": posture,
+		})
+	}
+
 	truncated := resultContent
 	if len(truncated) > maxResultLen {
 		truncated = truncated[:maxResultLen] + "\n... (truncated)"

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -134,23 +134,7 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 		return
 	}
 
-	// Emit one permission-denied audit event per recorded auto-mode denial.
-	// Batched here (completion time) rather than real-time to avoid spamming
-	// the audit log while a run is still live. A run killed before completion
-	// may drop its denial events — the permission_posture on agent.started is
-	// the durable observability signal.
-	posture := ag.GetHeadlessPermissionMode()
-	for _, d := range ag.GetPermissionDenials() {
-		toolID := d.ToolUseID
-		if toolID == "" {
-			toolID = "unknown"
-		}
-		h.logAudit(audit.EventAgentPermissionDenied, ag.TaskID, ag.ID, map[string]any{
-			"tool":    toolID,
-			"reason":  d.Reason,
-			"posture": posture,
-		})
-	}
+	h.emitPermissionDenialAudits(ag)
 
 	truncated := resultContent
 	if len(truncated) > maxResultLen {
@@ -207,6 +191,25 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 		if h.sandboxes != nil {
 			go h.sandboxes.Stop(ag.TaskID)
 		}
+	}
+}
+
+// emitPermissionDenialAudits emits one agent.permission_denied audit event per
+// auto-mode denial recorded during the run. Batched at completion time so the
+// audit log is not spammed mid-run; a killed run may drop its denial events —
+// the permission_posture on agent.started is the durable observability signal.
+func (h *AgentCompletionHandler) emitPermissionDenialAudits(ag *agent.Agent) {
+	posture := ag.GetHeadlessPermissionMode()
+	for _, d := range ag.GetPermissionDenials() {
+		toolID := d.ToolUseID
+		if toolID == "" {
+			toolID = "unknown"
+		}
+		h.logAudit(audit.EventAgentPermissionDenied, ag.TaskID, ag.ID, map[string]any{
+			"tool":    toolID,
+			"reason":  d.Reason,
+			"posture": posture,
+		})
 	}
 }
 

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -271,7 +271,7 @@ func (a *App) Startup(ctx context.Context) error {
 	})
 	a.sandboxes = sandbox.NewManager(filepath.Join(config.HomeDir(), "sandboxes"), a.logger)
 	a.agentOrch = newAgentOrchestrator(a.tasks, a.projects, a.agents, a.audit, a.logger, a.worktrees, a.cfg)
-	a.reviewer = newReviewHandler(a.tasks, a.projects, a.agents, a.audit, a.logger, a.prTracker, emit, a.worktrees, a.renovatePRsForMonitor)
+	a.reviewer = newReviewHandler(a.tasks, a.projects, a.agents, a.audit, a.logger, a.prTracker, emit, a.worktrees, a.renovatePRsForMonitor, a.cfg)
 
 	a.initWorkflowEngine()
 

--- a/internal/sybra/app_agents.go
+++ b/internal/sybra/app_agents.go
@@ -48,6 +48,21 @@ func resolvePermission(t task.Task, cfg *config.Config) bool {
 	return cfg.DefaultRequirePermissions()
 }
 
+// resolveHeadlessPermissionMode returns the effective headless permission posture.
+// Priority: task field > config default > "bypass".
+// When the task carries an invalid value, an error is returned and the caller
+// must abort the launch rather than silently falling back to bypass.
+func resolveHeadlessPermissionMode(t task.Task, cfg *config.Config) (string, error) {
+	if t.HeadlessPermissionMode != "" {
+		mode, err := config.NormalizeHeadlessPermissionMode(t.HeadlessPermissionMode)
+		if err != nil {
+			return "", fmt.Errorf("task %s: %w", t.ID, err)
+		}
+		return mode, nil
+	}
+	return cfg.DefaultHeadlessPermissionMode(), nil
+}
+
 // pickImplementationResumeSession walks AgentRuns newest-first and returns
 // the most recent session_id from a prior implementation run that belongs
 // to the current workflow execution.
@@ -247,24 +262,30 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, includeTaskD
 	}
 	resumeSessionID := pickImplementationResumeSession(t.AgentRuns, workflowStart)
 
+	posture, postureErr := resolveHeadlessPermissionMode(t, o.cfg)
+	if postureErr != nil {
+		return nil, postureErr
+	}
+
 	extraEnv := o.sandboxEnvIfRunning(taskID)
 
 	fullPrompt := buildTaskStartPrompt(t, prompt, includeTaskDescription)
 	ag, err := o.agents.Run(agent.RunConfig{
-		TaskID:             taskID,
-		Name:               t.Title,
-		Mode:               effMode,
-		Prompt:             fullPrompt,
-		AllowedTools:       t.AllowedTools,
-		Dir:                dir,
-		Model:              "sonnet",
-		RequirePermissions: requirePerm,
-		OneShot:            oneShot,
-		ResumeSessionID:    resumeSessionID,
-		ExtraEnv:           extraEnv,
-		MaxTurns:           t.MaxTurns,
-		ForkSubagent:       t.ForkSubagent,
-		ReasoningEffort:    t.ReasoningEffort,
+		TaskID:                 taskID,
+		Name:                   t.Title,
+		Mode:                   effMode,
+		Prompt:                 fullPrompt,
+		AllowedTools:           t.AllowedTools,
+		Dir:                    dir,
+		Model:                  "sonnet",
+		RequirePermissions:     requirePerm,
+		HeadlessPermissionMode: posture,
+		OneShot:                oneShot,
+		ResumeSessionID:        resumeSessionID,
+		ExtraEnv:               extraEnv,
+		MaxTurns:               t.MaxTurns,
+		ForkSubagent:           t.ForkSubagent,
+		ReasoningEffort:        t.ReasoningEffort,
 		// Always an implementation run — prime it with the NOTES.md scratchpad.
 		SeedWorkingMemory: true,
 	})
@@ -284,6 +305,7 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, includeTaskD
 	o.logAudit(audit.EventAgentStarted, taskID, ag.ID, map[string]any{
 		"mode": effMode, "title": t.Title, "task_type": string(t.TaskType), "provider": ag.Provider,
 		"allowed_tools": t.AllowedTools, "require_permissions": requirePerm, "skip_permissions": skipPerm,
+		"permission_posture": posture,
 	})
 	var nextStatus *task.Status
 	if t.Status != task.StatusInProgress {
@@ -439,6 +461,11 @@ func (o *AgentOrchestrator) StartPRFixAgent(taskID string) error {
 		return fmt.Errorf("task %s: no working dir resolved (skipWorktree=%v) — refusing to run agent in Sybra cwd", taskID, skipWT)
 	}
 
+	posture, postureErr := resolveHeadlessPermissionMode(t, o.cfg)
+	if postureErr != nil {
+		return postureErr
+	}
+
 	prompt := buildPRFixPrompt(t, o.logger)
 	if steered, sErr := prependSupervisorSteer(o.tasks, taskID, prompt); sErr != nil {
 		o.logger.Warn("supervisor-steer.consume", "task_id", taskID, "err", sErr)
@@ -446,14 +473,15 @@ func (o *AgentOrchestrator) StartPRFixAgent(taskID string) error {
 		prompt = steered
 	}
 	ag, err := o.agents.Run(agent.RunConfig{
-		TaskID:             taskID,
-		Name:               agent.RolePRFix.AgentName(t.Title),
-		Mode:               effMode,
-		Prompt:             prompt,
-		AllowedTools:       t.AllowedTools,
-		Dir:                dir,
-		Model:              "sonnet",
-		RequirePermissions: requirePerm,
+		TaskID:                 taskID,
+		Name:                   agent.RolePRFix.AgentName(t.Title),
+		Mode:                   effMode,
+		Prompt:                 prompt,
+		AllowedTools:           t.AllowedTools,
+		Dir:                    dir,
+		Model:                  "sonnet",
+		RequirePermissions:     requirePerm,
+		HeadlessPermissionMode: posture,
 		// pr-fix is a code-author role — keep the NOTES.md contract airtight so
 		// an adopted (handoff) worktree's scratchpad carries through.
 		SeedWorkingMemory: agent.RolePRFix.AuthorsCode(),
@@ -466,6 +494,7 @@ func (o *AgentOrchestrator) StartPRFixAgent(taskID string) error {
 	o.logAudit(audit.EventAgentStarted, taskID, ag.ID, map[string]any{
 		"mode": effMode, "title": t.Title, "role": "pr-fix", "task_type": string(t.TaskType), "provider": ag.Provider,
 		"allowed_tools": t.AllowedTools, "require_permissions": requirePerm, "skip_permissions": skipPerm,
+		"permission_posture": posture,
 	})
 	if err := o.tasks.AddRun(taskID, task.AgentRun{
 		AgentID: ag.ID, Role: string(agent.RolePRFix), Mode: effMode,

--- a/internal/sybra/app_agents.go
+++ b/internal/sybra/app_agents.go
@@ -301,6 +301,13 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, includeTaskD
 		}
 		return nil, err
 	}
+	o.recordImplAgentStart(ag, t, taskID, effMode, posture, requirePerm, fullPrompt)
+	return ag, nil
+}
+
+// recordImplAgentStart emits the agent.started audit event and persists the
+// initial AgentRun record for an implementation agent.
+func (o *AgentOrchestrator) recordImplAgentStart(ag *agent.Agent, t task.Task, taskID, effMode, posture string, requirePerm bool, fullPrompt string) {
 	skipPerm := !requirePerm && len(t.AllowedTools) == 0
 	o.logAudit(audit.EventAgentStarted, taskID, ag.ID, map[string]any{
 		"mode": effMode, "title": t.Title, "task_type": string(t.TaskType), "provider": ag.Provider,
@@ -322,7 +329,6 @@ func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, includeTaskD
 	}, nextStatus); err != nil {
 		o.logger.Error("task.add-run", "task_id", taskID, "err", err)
 	}
-	return ag, nil
 }
 
 func buildTaskStartPrompt(t task.Task, prompt string, includeTaskDescription bool) string {

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
@@ -39,6 +40,7 @@ type ReviewHandler struct {
 	prTracker      *github.IssueTracker
 	worktrees      *worktree.Manager
 	workflowEngine *workflow.Engine
+	cfg            *config.Config
 	// renovatePRsFn returns Renovate-bot PRs to fold into the monitor pass.
 	// FetchReviews uses author:@me which excludes bot-authored PRs, so without
 	// this hook a Renovate PR linked to a task by pr_number/branch never gets
@@ -81,6 +83,7 @@ func newReviewHandler(
 	emit func(string, any),
 	worktrees *worktree.Manager,
 	renovatePRsFn func() []github.PullRequest,
+	cfg *config.Config,
 ) *ReviewHandler {
 	return &ReviewHandler{
 		DomainHandler: DomainHandler{audit: al, logger: logger, emit: emit},
@@ -94,6 +97,7 @@ func newReviewHandler(
 		mergePR:       github.MergePR,
 		fetchThreads:  github.FetchReviewThreads,
 		resolveThread: github.ResolveReviewThread,
+		cfg:           cfg,
 	}
 }
 

--- a/internal/sybra/app_reviews_inbound.go
+++ b/internal/sybra/app_reviews_inbound.go
@@ -87,6 +87,11 @@ func (r *ReviewHandler) startFixReviewAgent(t task.Task) error {
 		return fmt.Errorf("task %s has no linked PR", t.ID)
 	}
 
+	posture, postureErr := resolveHeadlessPermissionMode(t, r.cfg)
+	if postureErr != nil {
+		return postureErr
+	}
+
 	dir, err := r.worktrees.PrepareForFix(t, t.PRNumber)
 	if err != nil {
 		return fmt.Errorf("prepare worktree: %w", err)
@@ -101,12 +106,13 @@ func (r *ReviewHandler) startFixReviewAgent(t task.Task) error {
 	)
 
 	ag, err := r.agents.Run(agent.RunConfig{
-		TaskID: t.ID,
-		Name:   agent.RoleFixReview.AgentName(t.Title),
-		Mode:   "headless",
-		Prompt: prompt,
-		Dir:    dir,
-		Model:  "opus",
+		TaskID:                 t.ID,
+		Name:                   agent.RoleFixReview.AgentName(t.Title),
+		Mode:                   "headless",
+		Prompt:                 prompt,
+		Dir:                    dir,
+		Model:                  "opus",
+		HeadlessPermissionMode: posture,
 		// MaxTurns intentionally not inherited: fix-review agents need
 		// enough turns to fetch the PR, apply fixes, and commit.
 	})
@@ -151,6 +157,11 @@ func (r *ReviewHandler) startReviewAgent(t task.Task, force bool) error {
 		return nil
 	}
 
+	posture, postureErr := resolveHeadlessPermissionMode(current, r.cfg)
+	if postureErr != nil {
+		return postureErr
+	}
+
 	dir := config.HomeDir()
 	if current.ProjectID != "" {
 		d, err := r.worktrees.PrepareForReview(current)
@@ -164,12 +175,13 @@ func (r *ReviewHandler) startReviewAgent(t task.Task, force bool) error {
 	prompt := fmt.Sprintf("Run /staff-code-review on https://github.com/%s/pull/%d", current.ProjectID, current.PRNumber)
 
 	ag, err := r.agents.Run(agent.RunConfig{
-		TaskID: current.ID,
-		Name:   agent.RoleReview.AgentName(current.Title),
-		Mode:   "headless",
-		Prompt: prompt,
-		Dir:    dir,
-		Model:  "opus",
+		TaskID:                 current.ID,
+		Name:                   agent.RoleReview.AgentName(current.Title),
+		Mode:                   "headless",
+		Prompt:                 prompt,
+		Dir:                    dir,
+		Model:                  "opus",
+		HeadlessPermissionMode: posture,
 		// MaxTurns intentionally not inherited: review agents need
 		// enough turns to fetch the PR, run the skill, and write findings.
 	})

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -348,19 +348,25 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		}
 	}
 
+	posture, postureErr := resolveHeadlessPermissionMode(t, a.agentOrch.cfg)
+	if postureErr != nil {
+		return "", postureErr
+	}
+
 	cfg := agent.RunConfig{
-		TaskID:             taskID,
-		Name:               r.AgentName(t.Title),
-		Mode:               mode,
-		Prompt:             prompt,
-		AllowedTools:       allowedTools,
-		Model:              model,
-		Provider:           provider,
-		Dir:                dir,
-		OneShot:            oneShot,
-		MaxTurns:           t.MaxTurns,
-		RequirePermissions: resolvePermission(t, a.agentOrch.cfg),
-		ReasoningEffort:    t.ReasoningEffort,
+		TaskID:                 taskID,
+		Name:                   r.AgentName(t.Title),
+		Mode:                   mode,
+		Prompt:                 prompt,
+		AllowedTools:           allowedTools,
+		Model:                  model,
+		Provider:               provider,
+		Dir:                    dir,
+		OneShot:                oneShot,
+		MaxTurns:               t.MaxTurns,
+		RequirePermissions:     resolvePermission(t, a.agentOrch.cfg),
+		HeadlessPermissionMode: posture,
+		ReasoningEffort:        t.ReasoningEffort,
 		// Code-author roles (implementation/fix-review/pr-fix) are primed with
 		// NOTES.md; verifier roles (review/test-runner/eval) share the same
 		// worktree but must stay independent of the implementer's scratchpad.

--- a/internal/sybra/permissions_test.go
+++ b/internal/sybra/permissions_test.go
@@ -1,0 +1,244 @@
+package sybra
+
+import (
+	"bufio"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func TestResolveHeadlessPermissionMode(t *testing.T) {
+	t.Parallel()
+
+	cfgAuto := &config.Config{Agent: config.AgentDefaults{HeadlessPermissionMode: "auto"}}
+	cfgBypass := &config.Config{Agent: config.AgentDefaults{HeadlessPermissionMode: "bypass"}}
+	cfgEmpty := &config.Config{}
+
+	cases := []struct {
+		name    string
+		t       task.Task
+		cfg     *config.Config
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "task auto overrides config bypass",
+			t:    task.Task{ID: "t1", HeadlessPermissionMode: "auto"},
+			cfg:  cfgBypass,
+			want: "auto",
+		},
+		{
+			name: "task bypass overrides config auto",
+			t:    task.Task{ID: "t2", HeadlessPermissionMode: "bypass"},
+			cfg:  cfgAuto,
+			want: "bypass",
+		},
+		{
+			name: "task empty falls back to config auto",
+			t:    task.Task{ID: "t3"},
+			cfg:  cfgAuto,
+			want: "auto",
+		},
+		{
+			name: "task empty, config empty → bypass default",
+			t:    task.Task{ID: "t4"},
+			cfg:  cfgEmpty,
+			want: "bypass",
+		},
+		{
+			name: "task empty, nil config → bypass default",
+			t:    task.Task{ID: "t5"},
+			cfg:  nil,
+			want: "bypass",
+		},
+		{
+			name:    "invalid task value → error (abort, no fallback)",
+			t:       task.Task{ID: "t6", HeadlessPermissionMode: "dangerously-skip"},
+			cfg:     cfgBypass,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveHeadlessPermissionMode(tc.t, tc.cfg)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if !tc.wantErr && got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// readAuditEvents reads all NDJSON events from the audit directory.
+func readAuditEvents(t *testing.T, dir string) []audit.Event {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read audit dir: %v", err)
+	}
+	var events []audit.Event
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".ndjson") {
+			continue
+		}
+		f, err := os.Open(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatalf("open audit file: %v", err)
+		}
+		sc := bufio.NewScanner(f)
+		for sc.Scan() {
+			var ev audit.Event
+			if err := json.Unmarshal(sc.Bytes(), &ev); err != nil {
+				t.Fatalf("unmarshal audit event: %v", err)
+			}
+			events = append(events, ev)
+		}
+		_ = f.Close()
+	}
+	return events
+}
+
+// newMinimalTaskManager creates a real task.Manager backed by a temp directory.
+func newMinimalTaskManager(t *testing.T) *task.Manager {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "tasks")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return task.NewManager(store, nil)
+}
+
+func TestOnComplete_EmitsPermissionDeniedAuditEvents(t *testing.T) {
+	t.Parallel()
+
+	auditDir := t.TempDir()
+	al, err := audit.NewLogger(auditDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = al.Close() })
+
+	taskMgr := newMinimalTaskManager(t)
+	tk, err := taskMgr.Create("test task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := &AgentCompletionHandler{
+		DomainHandler: DomainHandler{
+			audit:  al,
+			logger: slog.New(slog.DiscardHandler),
+		},
+		tasks: taskMgr,
+	}
+
+	// Add an AgentRun so UpdateRun doesn't fail with "agent run not found".
+	if err := taskMgr.AddRun(tk.ID, task.AgentRun{
+		AgentID: "agent-1",
+		Role:    "implementation",
+		Mode:    "headless",
+		State:   "running",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ag := &agent.Agent{
+		TaskID: tk.ID,
+		ID:     "agent-1",
+	}
+	ag.NotePermissionDenial("tooluseID-1", "denied by the claude code auto mode classifier: rm -rf /")
+	ag.NotePermissionDenial("", "denied by the claude code auto mode classifier: git push --force")
+
+	h.OnComplete(ag)
+
+	_ = al.Close()
+
+	events := readAuditEvents(t, auditDir)
+	var denials []audit.Event
+	for _, ev := range events {
+		if ev.Type == audit.EventAgentPermissionDenied {
+			denials = append(denials, ev)
+		}
+	}
+
+	if len(denials) != 2 {
+		t.Fatalf("expected 2 permission_denied events, got %d (all events: %v)", len(denials), events)
+	}
+
+	d0 := denials[0]
+	if d0.TaskID != tk.ID {
+		t.Errorf("d0 TaskID = %q, want %q", d0.TaskID, tk.ID)
+	}
+	if d0.Data["tool"] != "tooluseID-1" {
+		t.Errorf("d0 tool = %v, want tooluseID-1", d0.Data["tool"])
+	}
+	if !strings.Contains(d0.Data["reason"].(string), "denied by") {
+		t.Errorf("d0 reason missing denial text: %v", d0.Data["reason"])
+	}
+
+	// Second denial: empty toolUseID → "unknown" fallback
+	d1 := denials[1]
+	if d1.Data["tool"] != "unknown" {
+		t.Errorf("d1 tool = %v, want 'unknown'", d1.Data["tool"])
+	}
+}
+
+func TestOnComplete_NoDenialsNoPermissionDeniedEvents(t *testing.T) {
+	t.Parallel()
+
+	auditDir := t.TempDir()
+	al, err := audit.NewLogger(auditDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = al.Close() })
+
+	taskMgr := newMinimalTaskManager(t)
+	tk, err := taskMgr.Create("clean task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := taskMgr.AddRun(tk.ID, task.AgentRun{
+		AgentID: "agent-clean",
+		Role:    "implementation",
+		Mode:    "headless",
+		State:   "running",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	h := &AgentCompletionHandler{
+		DomainHandler: DomainHandler{
+			audit:  al,
+			logger: slog.New(slog.DiscardHandler),
+		},
+		tasks: taskMgr,
+	}
+
+	ag := &agent.Agent{TaskID: tk.ID, ID: "agent-clean"}
+	h.OnComplete(ag)
+	_ = al.Close()
+
+	events := readAuditEvents(t, auditDir)
+	for _, ev := range events {
+		if ev.Type == audit.EventAgentPermissionDenied {
+			t.Errorf("unexpected permission_denied event when no denials recorded: %+v", ev)
+		}
+	}
+}

--- a/internal/sybra/services.go
+++ b/internal/sybra/services.go
@@ -20,6 +20,7 @@ func (a *App) wireServices(emit func(string, any)) {
 	a.taskSvc.wg = &a.wg
 	a.taskSvc.logger = a.logger
 	a.taskSvc.audit = a.audit
+	a.taskSvc.cfg = a.cfg
 	a.planSvc.engine = a.workflowEngine
 	a.planSvc.tasks = a.tasks
 	a.planSvc.agents = a.agents

--- a/internal/sybra/svc_reviews_test.go
+++ b/internal/sybra/svc_reviews_test.go
@@ -105,7 +105,7 @@ updated_at: 2025-01-01T00:00:00Z
 		AgentChecker: agentMgr.HasRunningAgentForTask,
 	})
 
-	handler := newReviewHandler(taskMgr, projStore, agentMgr, nil, logger, nil, func(string, any) {}, wm, nil)
+	handler := newReviewHandler(taskMgr, projStore, agentMgr, nil, logger, nil, func(string, any) {}, wm, nil, nil)
 	svc := &ReviewService{reviewer: handler, tasks: taskMgr}
 
 	return svc, taskMgr, barePath

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -27,6 +27,7 @@ type TaskService struct {
 	wg                  *sync.WaitGroup
 	logger              *slog.Logger
 	audit               *audit.Logger
+	cfg                 *config.Config
 	fetchPR             func(repo string, number int) (github.PullRequest, error)
 	fetchIssue          func(repo string, number int) (github.Issue, error)
 	fetchIssueLinkedPRs func(repo string, issueNumber int) ([]github.PullRequest, error)
@@ -270,6 +271,11 @@ func (s *TaskService) enrichFromPR(taskID, repo string, number int) {
 
 // startPRReviewAgent starts a headless agent that runs /staff-code-review on the PR.
 func (s *TaskService) startPRReviewAgent(t task.Task) error {
+	posture, postureErr := resolveHeadlessPermissionMode(t, s.cfg)
+	if postureErr != nil {
+		return postureErr
+	}
+
 	dir := config.HomeDir()
 	if t.ProjectID != "" {
 		d, err := s.worktrees.PrepareForReview(t)
@@ -282,12 +288,13 @@ func (s *TaskService) startPRReviewAgent(t task.Task) error {
 
 	prompt := fmt.Sprintf("Run /staff-code-review on https://github.com/%s/pull/%d", t.ProjectID, t.PRNumber)
 	ag, err := s.agents.Run(agent.RunConfig{
-		TaskID: t.ID,
-		Name:   agent.RoleReview.AgentName(t.Title),
-		Mode:   "headless",
-		Prompt: prompt,
-		Dir:    dir,
-		Model:  "opus",
+		TaskID:                 t.ID,
+		Name:                   agent.RoleReview.AgentName(t.Title),
+		Mode:                   "headless",
+		Prompt:                 prompt,
+		Dir:                    dir,
+		Model:                  "opus",
+		HeadlessPermissionMode: posture,
 		// MaxTurns intentionally not inherited: review agents need
 		// enough turns to fetch the PR, run the skill, and write findings.
 	})

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -274,6 +274,10 @@ type Task struct {
 	// RequirePermissions overrides the system default when set.
 	// nil = use system default (true). false = opt out (--dangerously-skip-permissions).
 	RequirePermissions *bool `yaml:"require_permissions,omitempty" json:"requirePermissions,omitempty"`
+	// HeadlessPermissionMode overrides the permission posture for headless claude
+	// runs on this task. "auto" emits --permission-mode auto; "bypass" keeps
+	// --dangerously-skip-permissions. Empty = use config default.
+	HeadlessPermissionMode string `yaml:"headless_permission_mode,omitempty" json:"headlessPermissionMode,omitempty"`
 	// ForkSubagent enables CLAUDE_CODE_FORK_SUBAGENT=1 for this task's headless
 	// agent, allowing a single prompt to spawn parallel subagent runs. Trades
 	// higher token cost for reduced wall-clock time on multi-part prompts.


### PR DESCRIPTION
## Motivation

Unattended headless agents ran with blanket `--dangerously-skip-permissions`, giving them unrestricted tool access. Claude Code's auto-mode classifier (introduced in v2.1.152, enabled on 3P providers since v2.1.158) blocks destructive operations — `rm -rf $HOME`, force-push, `git reset --hard`, `terraform destroy`, etc. — without requiring a human in the loop. Adopting it for server/unattended roles provides a meaningful safety guardrail with minimal overhead.

Closes https://github.com/Automaat/sybra/issues/1023

## Implementation information

- Adds a `HeadlessPermissionMode` field (`bypass` | `auto`) to both `task.Task` and agent config, resolved in priority order: task value → config default → `"bypass"`.
- `bypass` preserves current behavior (`--dangerously-skip-permissions`); `auto` passes `--permission-mode auto` instead.
- Invalid task values abort the launch rather than silently falling back, so misconfigured tasks are loud, not permissive.
- Auto-mode classifier denials (`tool_result` error blocks) are detected via `classifyAutoModeDenial`, accumulated during the run, and flushed as `agent.permission_denied` audit events on completion.
- Permission posture is recorded on `agent.started` for observability even when the run is killed mid-flight.
- Helpers `emitPermissionDenialAudits` and `recordImplAgentStart` were extracted to satisfy the 100-line `funlen` lint limit.
- Frontend bindings regenerated; new `HeadlessPermissionMode` exposed through `svc_tasks.go` and the task service.