### PR TITLE
fix(human-review): idempotent verdict gate

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -33,6 +33,14 @@ export class AgentRun {
      * it survives Result truncation.
      */
     "verdict"?: string;
+
+    /**
+     * VerdictRendered is set to true after onComplete has successfully applied
+     * all side-effects for this run (note appended, issue filed, local task
+     * created). Used by verdictAlreadyRendered as the durable rendered-marker
+     * instead of body-text patterns which can collide with user content.
+     */
+    "verdictRendered"?: boolean;
     "logFile": string;
     "sessionId"?: string;
 

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -580,17 +580,26 @@ func urlOrPlaceholder(url, title string) string {
 }
 
 // verdictAlreadyRendered reports whether any completed human-review agent run
-// already recorded a parsed verdict on t. A non-empty Verdict field means the
-// prior run finished cleanly enough for the handler to act on the diagnosis —
-// re-spawning on app restart or a repeated status-hook fire would only
-// duplicate the work.
+// already recorded a parsed verdict on t AND onComplete successfully rendered
+// the diagnosis into the task body. Both conditions are required: Verdict proves
+// the prior run parsed the outcome, and the "## Auto-review" section proves
+// onComplete appended the note. If only Verdict is set (e.g. the process crashed
+// between persisting the verdict and appending the note), we allow a re-spawn so
+// the task is not permanently stranded.
 func verdictAlreadyRendered(t task.Task) bool {
+	hasVerdict := false
 	for i := range t.AgentRuns {
 		if t.AgentRuns[i].Role == string(agent.RoleHumanReview) && t.AgentRuns[i].Verdict != "" {
-			return true
+			hasVerdict = true
+			break
 		}
 	}
-	return false
+	if !hasVerdict {
+		return false
+	}
+	// Every onComplete path appends a "## Auto-review …" section; its presence
+	// confirms the rendering completed, not just that the verdict was parsed.
+	return strings.Contains(t.Body, "## Auto-review")
 }
 
 // tailFile reads the last n lines of path. Best-effort: returns "" on error

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -582,10 +582,14 @@ func urlOrPlaceholder(url, title string) string {
 // verdictAlreadyRendered reports whether any completed human-review agent run
 // already recorded a parsed verdict on t AND onComplete successfully rendered
 // the diagnosis into the task body. Both conditions are required: Verdict proves
-// the prior run parsed the outcome, and the "## Auto-review" section proves
-// onComplete appended the note. If only Verdict is set (e.g. the process crashed
-// between persisting the verdict and appending the note), we allow a re-spawn so
-// the task is not permanently stranded.
+// the prior run parsed the outcome, and the presence of a specific rendered
+// section header proves onComplete appended the note. If only Verdict is set
+// (e.g. the process crashed between persisting the verdict and appending the
+// note), we allow a re-spawn so the task is not permanently stranded.
+//
+// The pattern must be specific: "## Auto-review verdict:" or "## Auto-review ("
+// are the only headers appended by onComplete. A broader "## Auto-review" match
+// would falsely trigger on pre-existing headings in the task body.
 func verdictAlreadyRendered(t task.Task) bool {
 	hasVerdict := false
 	for i := range t.AgentRuns {
@@ -597,9 +601,13 @@ func verdictAlreadyRendered(t task.Task) bool {
 	if !hasVerdict {
 		return false
 	}
-	// Every onComplete path appends a "## Auto-review …" section; its presence
-	// confirms the rendering completed, not just that the verdict was parsed.
-	return strings.Contains(t.Body, "## Auto-review")
+	// Every onComplete path appends exactly one of:
+	//   "## Auto-review verdict: …"  (human / sybra_bug / unknown-decision paths)
+	//   "## Auto-review (…)"         (unparseable-verdict path)
+	// Check for these specific prefixes so a pre-existing "## Auto-review <other>"
+	// heading in the original task body does not falsely satisfy the gate.
+	return strings.Contains(t.Body, "## Auto-review verdict:") ||
+		strings.Contains(t.Body, "## Auto-review (")
 }
 
 // tailFile reads the last n lines of path. Best-effort: returns "" on error

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -288,7 +288,12 @@ func (h *humanReviewHandler) fileLocalScrubbed(taskID, agentID string, v verdict
 	newTask, err := h.tasks.Create(title, body, task.AgentModeHeadless)
 	if err != nil {
 		h.logger.Error("human-review.local.create", "task_id", taskID, "agent_id", agentID, "err", err)
-		h.appendNote(taskID, "Auto-review verdict: sybra_bug (local task creation failed)", summary+"\n\nError: "+err.Error())
+		// The diagnosis note IS the durable artifact here; mark rendered so a
+		// restart does not re-spawn the reviewer and duplicate it (the local
+		// task creation failing does not undo the appended note).
+		if h.appendNote(taskID, "Auto-review verdict: sybra_bug (local task creation failed)", summary+"\n\nError: "+err.Error()) {
+			h.markVerdictRendered(taskID, agentID)
+		}
 		return
 	}
 	tags := append([]string{"sybra-bug", "scrubbed"}, v.IssueLabels...)

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -142,6 +142,12 @@ func (h *humanReviewHandler) maybeSpawn(taskID, prevStatus string) {
 		h.logger.Error("human-review.task.get", "task_id", taskID, "err", err)
 		return
 	}
+	// Idempotency gate: a prior run already produced a verdict — re-spawning
+	// on app restart or repeated status hooks would just duplicate the diagnosis.
+	if verdictAlreadyRendered(t) {
+		h.skip(taskID, "verdict_rendered")
+		return
+	}
 	// Work-Data Confidentiality: if the task's project is work-typed, the
 	// review still runs (we want the diagnosis) but the prompt is augmented
 	// with redaction instructions and the verdict is routed to a local
@@ -571,6 +577,20 @@ func urlOrPlaceholder(url, title string) string {
 		return url
 	}
 	return "(issue: " + title + ")"
+}
+
+// verdictAlreadyRendered reports whether any completed human-review agent run
+// already recorded a parsed verdict on t. A non-empty Verdict field means the
+// prior run finished cleanly enough for the handler to act on the diagnosis —
+// re-spawning on app restart or a repeated status-hook fire would only
+// duplicate the work.
+func verdictAlreadyRendered(t task.Task) bool {
+	for i := range t.AgentRuns {
+		if t.AgentRuns[i].Role == string(agent.RoleHumanReview) && t.AgentRuns[i].Verdict != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // tailFile reads the last n lines of path. Best-effort: returns "" on error

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -230,7 +230,9 @@ func (h *humanReviewHandler) onComplete(ag *agent.Agent) {
 	v, parseErr := parseVerdict(final)
 	if parseErr != nil {
 		h.logger.Warn("human-review.verdict.parse", "task_id", taskID, "agent_id", ag.ID, "err", parseErr)
-		h.appendNote(taskID, "Auto-review (unparseable verdict)", final)
+		if h.appendNote(taskID, "Auto-review (unparseable verdict)", final) {
+			h.markVerdictRendered(taskID, ag.ID)
+		}
 		h.logAudit(audit.EventHumanReviewVerdict, taskID, ag.ID, map[string]any{"decision": "unparseable"})
 		return
 	}
@@ -240,7 +242,9 @@ func (h *humanReviewHandler) onComplete(ag *agent.Agent) {
 
 	switch v.Decision {
 	case "human":
-		h.appendNote(taskID, "Auto-review verdict: needs human", v.Summary)
+		if h.appendNote(taskID, "Auto-review verdict: needs human", v.Summary) {
+			h.markVerdictRendered(taskID, ag.ID)
+		}
 	case "sybra_bug":
 		// Re-check work context at completion time so a project re-typed
 		// during the review run still routes correctly.
@@ -257,7 +261,9 @@ func (h *humanReviewHandler) onComplete(ag *agent.Agent) {
 		}
 	default:
 		h.logger.Warn("human-review.verdict.unknown", "task_id", taskID, "decision", v.Decision)
-		h.appendNote(taskID, "Auto-review (unknown decision)", final)
+		if h.appendNote(taskID, "Auto-review (unknown decision)", final) {
+			h.markVerdictRendered(taskID, ag.ID)
+		}
 	}
 }
 
@@ -270,7 +276,9 @@ func (h *humanReviewHandler) onComplete(ag *agent.Agent) {
 func (h *humanReviewHandler) fileLocalScrubbed(taskID, agentID string, v verdictDecision, wctx *WorkScrubContext) {
 	if strings.TrimSpace(v.IssueTitle) == "" || strings.TrimSpace(v.IssueBody) == "" {
 		h.logger.Warn("human-review.local.empty", "task_id", taskID, "agent_id", agentID)
-		h.appendNote(taskID, "Auto-review verdict: sybra_bug (no issue payload)", v.Summary)
+		if h.appendNote(taskID, "Auto-review verdict: sybra_bug (no issue payload)", v.Summary) {
+			h.markVerdictRendered(taskID, agentID)
+		}
 		return
 	}
 	title, titleRed := scrub.Scrub(v.IssueTitle, wctx.Blocklist)
@@ -312,13 +320,17 @@ func (h *humanReviewHandler) fileLocalScrubbed(taskID, agentID string, v verdict
 	}
 	if _, err := h.tasks.Update(taskID, upd); err != nil {
 		h.logger.Error("human-review.local.origin-update", "task_id", taskID, "err", err)
+		return
 	}
+	h.markVerdictRendered(taskID, agentID)
 }
 
 func (h *humanReviewHandler) fileIssue(taskID, agentID string, v verdictDecision) {
 	if strings.TrimSpace(v.IssueTitle) == "" || strings.TrimSpace(v.IssueBody) == "" {
 		h.logger.Warn("human-review.issue.empty", "task_id", taskID, "agent_id", agentID)
-		h.appendNote(taskID, "Auto-review verdict: sybra_bug (no issue payload)", v.Summary)
+		if h.appendNote(taskID, "Auto-review verdict: sybra_bug (no issue payload)", v.Summary) {
+			h.markVerdictRendered(taskID, agentID)
+		}
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -328,7 +340,9 @@ func (h *humanReviewHandler) fileIssue(taskID, agentID string, v verdictDecision
 		h.logger.Error("human-review.issue.submit", "task_id", taskID, "agent_id", agentID, "err", err)
 		// On rate limit or transient failure, leave the task in human-required
 		// and append the verdict so the user has the diagnosis text.
-		h.appendNote(taskID, "Auto-review verdict: sybra_bug (issue submission failed)", v.Summary+"\n\nError: "+err.Error())
+		if h.appendNote(taskID, "Auto-review verdict: sybra_bug (issue submission failed)", v.Summary+"\n\nError: "+err.Error()) {
+			h.markVerdictRendered(taskID, agentID)
+		}
 		return
 	}
 	h.logAudit(audit.EventHumanReviewIssue, taskID, agentID, map[string]any{
@@ -354,21 +368,36 @@ func (h *humanReviewHandler) fileIssue(taskID, agentID string, v verdictDecision
 	}
 	if _, err := h.tasks.Update(taskID, upd); err != nil {
 		h.logger.Error("human-review.task.update", "task_id", taskID, "err", err)
+		return
 	}
+	h.markVerdictRendered(taskID, agentID)
 }
 
-func (h *humanReviewHandler) appendNote(taskID, header, body string) {
+// appendNote appends a section to the task body. Returns true if the update
+// succeeded so callers can conditionally mark the verdict as rendered.
+func (h *humanReviewHandler) appendNote(taskID, header, body string) bool {
 	if strings.TrimSpace(body) == "" {
-		return
+		return false
 	}
 	t, err := h.tasks.Get(taskID)
 	if err != nil {
 		h.logger.Error("human-review.append.task-get", "task_id", taskID, "err", err)
-		return
+		return false
 	}
 	newBody := appendSection(t.Body, header, body)
 	if _, err := h.tasks.Update(taskID, task.Update{Body: &newBody}); err != nil {
 		h.logger.Error("human-review.append.task-update", "task_id", taskID, "err", err)
+		return false
+	}
+	return true
+}
+
+// markVerdictRendered sets VerdictRendered on the matching AgentRun, proving
+// that onComplete applied all side-effects. verdictAlreadyRendered reads this
+// field as the durable rendered-marker.
+func (h *humanReviewHandler) markVerdictRendered(taskID, agentID string) {
+	if err := h.tasks.UpdateRun(taskID, agentID, map[string]any{"verdict_rendered": true}); err != nil {
+		h.logger.Warn("human-review.mark-rendered", "task_id", taskID, "agent_id", agentID, "err", err)
 	}
 }
 
@@ -580,34 +609,18 @@ func urlOrPlaceholder(url, title string) string {
 }
 
 // verdictAlreadyRendered reports whether any completed human-review agent run
-// already recorded a parsed verdict on t AND onComplete successfully rendered
-// the diagnosis into the task body. Both conditions are required: Verdict proves
-// the prior run parsed the outcome, and the presence of a specific rendered
-// section header proves onComplete appended the note. If only Verdict is set
-// (e.g. the process crashed between persisting the verdict and appending the
-// note), we allow a re-spawn so the task is not permanently stranded.
-//
-// The pattern must be specific: "## Auto-review verdict:" or "## Auto-review ("
-// are the only headers appended by onComplete. A broader "## Auto-review" match
-// would falsely trigger on pre-existing headings in the task body.
+// has VerdictRendered set, proving onComplete ran to completion and applied all
+// side-effects (note appended, issue filed, local task created). Verdict alone
+// is not sufficient — it is persisted before onComplete runs, so if the process
+// crashed between persisting the verdict and rendering the diagnosis, we allow a
+// re-spawn so the task is not permanently stranded in human-required.
 func verdictAlreadyRendered(t task.Task) bool {
-	hasVerdict := false
 	for i := range t.AgentRuns {
-		if t.AgentRuns[i].Role == string(agent.RoleHumanReview) && t.AgentRuns[i].Verdict != "" {
-			hasVerdict = true
-			break
+		if t.AgentRuns[i].Role == string(agent.RoleHumanReview) && t.AgentRuns[i].VerdictRendered {
+			return true
 		}
 	}
-	if !hasVerdict {
-		return false
-	}
-	// Every onComplete path appends exactly one of:
-	//   "## Auto-review verdict: …"  (human / sybra_bug / unknown-decision paths)
-	//   "## Auto-review (…)"         (unparseable-verdict path)
-	// Check for these specific prefixes so a pre-existing "## Auto-review <other>"
-	// heading in the original task body does not falsely satisfy the gate.
-	return strings.Contains(t.Body, "## Auto-review verdict:") ||
-		strings.Contains(t.Body, "## Auto-review (")
+	return false
 }
 
 // tailFile reads the last n lines of path. Best-effort: returns "" on error

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -432,23 +432,21 @@ func TestMaybeSpawn_IdempotencyGate_SkipsWhenVerdictRendered(t *testing.T) {
 	h, tasks, _, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
-	// Body must include the "## Auto-review" section that onComplete appends,
-	// proving the rendering completed (not just that the verdict was parsed).
-	body := "Body.\n\n## Auto-review verdict: needs human\n\nLooks fine.\n"
-	tk, err := tasks.Create("Stale task", body, "headless")
+	tk, err := tasks.Create("Stale task", "Body.", "headless")
 	if err != nil {
 		t.Fatalf("create task: %v", err)
 	}
 	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
 		t.Fatalf("flip to human-required: %v", err)
 	}
-	// Simulate a prior completed review: add a run with a verdict already set.
+	// Simulate a fully completed review: VerdictRendered proves onComplete ran.
 	if err := tasks.AddRun(tk.ID, task.AgentRun{
-		AgentID: "agent-prior",
-		Role:    "human-review",
-		Mode:    "headless",
-		State:   "stopped",
-		Verdict: "human",
+		AgentID:         "agent-prior",
+		Role:            "human-review",
+		Mode:            "headless",
+		State:           "stopped",
+		Verdict:         "human",
+		VerdictRendered: true,
 	}); err != nil {
 		t.Fatalf("add prior run: %v", err)
 	}
@@ -511,9 +509,9 @@ func TestMaybeSpawn_IdempotencyGate_PreexistingAutoReviewTextDoesNotBlock(t *tes
 	t.Parallel()
 	// Regression: a task body that already contains a heading beginning with
 	// "## Auto-review" (for reasons unrelated to human-review rendering) must
-	// NOT satisfy the idempotency gate when the onComplete rendering hasn't run.
-	// Previously strings.Contains(body, "## Auto-review") was too broad and
-	// would strand the task in human-required with no diagnosis.
+	// NOT satisfy the idempotency gate when onComplete has not run.
+	// The gate now checks AgentRun.VerdictRendered, not body text, so
+	// pre-existing headings never falsely block a re-spawn.
 	h, tasks, _, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
@@ -589,5 +587,55 @@ func TestMaybeSpawn_IdempotencyGate_SpawnsWhenNoVerdict(t *testing.T) {
 		// If agents wasn't nil we'd check h.inflight; in tests it panics on
 		// agents.Run, confirming the gate let it through.
 		t.Log("no panic — agent manager must have been non-nil; check test setup")
+	}
+}
+
+func TestOnComplete_SetsVerdictRendered(t *testing.T) {
+	t.Parallel()
+	// Verifies that onComplete sets VerdictRendered on the matching AgentRun so
+	// verdictAlreadyRendered can use it as the durable rendered-marker on restart.
+	h, tasks, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	const agentID = "agent-hr-1"
+	tk, err := tasks.Create("Billing refactor", "Body.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+		t.Fatalf("flip to human-required: %v", err)
+	}
+	if err := tasks.AddRun(tk.ID, task.AgentRun{
+		AgentID: agentID,
+		Role:    string(agent.RoleHumanReview),
+		Mode:    "headless",
+		State:   "running",
+	}); err != nil {
+		t.Fatalf("add run: %v", err)
+	}
+
+	ag := &agent.Agent{ID: agentID, TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
+	ag.AppendOutput(agent.StreamEvent{
+		Type: "assistant",
+		Content: "Analysis done.\n\n```sybra-verdict\n" +
+			`{"decision":"human","summary":"scope clarification needed"}` +
+			"\n```\n",
+	})
+	h.inflight[tk.ID] = agentID
+	h.onComplete(ag)
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("re-load: %v", err)
+	}
+	var rendered bool
+	for i := range got.AgentRuns {
+		if got.AgentRuns[i].AgentID == agentID {
+			rendered = got.AgentRuns[i].VerdictRendered
+			break
+		}
+	}
+	if !rendered {
+		t.Error("expected AgentRun.VerdictRendered=true after onComplete; idempotency gate will not block re-spawn")
 	}
 }

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -507,6 +507,50 @@ func TestMaybeSpawn_IdempotencyGate_SpawnsWhenVerdictSetButNotRendered(t *testin
 	}
 }
 
+func TestMaybeSpawn_IdempotencyGate_PreexistingAutoReviewTextDoesNotBlock(t *testing.T) {
+	t.Parallel()
+	// Regression: a task body that already contains a heading beginning with
+	// "## Auto-review" (for reasons unrelated to human-review rendering) must
+	// NOT satisfy the idempotency gate when the onComplete rendering hasn't run.
+	// Previously strings.Contains(body, "## Auto-review") was too broad and
+	// would strand the task in human-required with no diagnosis.
+	h, tasks, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	body := "Original task body.\n\n## Auto-review requirements\n\nThis task is about auto-review diagnostics, but no diagnostic has been rendered yet.\n"
+	tk, err := tasks.Create("Crash window with preexisting auto-review text", body, "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+		t.Fatalf("flip to human-required: %v", err)
+	}
+	// Verdict persisted by onAgentComplete but onComplete never rendered the note.
+	if err := tasks.AddRun(tk.ID, task.AgentRun{
+		AgentID: "agent-crashed",
+		Role:    string(agent.RoleHumanReview),
+		Mode:    "headless",
+		State:   "stopped",
+		Verdict: "human",
+	}); err != nil {
+		t.Fatalf("add prior run: %v", err)
+	}
+
+	// Gate must NOT block — panic on nil agents.Run confirms spawn was attempted.
+	panicked := func() (p bool) {
+		defer func() {
+			if r := recover(); r != nil {
+				p = true
+			}
+		}()
+		h.maybeSpawn(tk.ID, "")
+		return false
+	}()
+	if !panicked {
+		t.Fatal("expected spawn attempt; gate should not treat pre-existing ## Auto-review heading as a rendered verdict")
+	}
+}
+
 func TestMaybeSpawn_IdempotencyGate_SpawnsWhenNoVerdict(t *testing.T) {
 	t.Parallel()
 	h, tasks, _, cleanup := newReviewTestEnv(t)

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -432,7 +432,10 @@ func TestMaybeSpawn_IdempotencyGate_SkipsWhenVerdictRendered(t *testing.T) {
 	h, tasks, _, cleanup := newReviewTestEnv(t)
 	defer cleanup()
 
-	tk, err := tasks.Create("Stale task", "Body.", "headless")
+	// Body must include the "## Auto-review" section that onComplete appends,
+	// proving the rendering completed (not just that the verdict was parsed).
+	body := "Body.\n\n## Auto-review verdict: needs human\n\nLooks fine.\n"
+	tk, err := tasks.Create("Stale task", body, "headless")
 	if err != nil {
 		t.Fatalf("create task: %v", err)
 	}
@@ -458,6 +461,49 @@ func TestMaybeSpawn_IdempotencyGate_SkipsWhenVerdictRendered(t *testing.T) {
 	h.mu.Unlock()
 	if busy {
 		t.Error("expected no inflight entry — gate should have skipped the spawn")
+	}
+}
+
+func TestMaybeSpawn_IdempotencyGate_SpawnsWhenVerdictSetButNotRendered(t *testing.T) {
+	t.Parallel()
+	// Regression test for the crash-window: Verdict persisted by onAgentComplete
+	// but the process crashed before onComplete appended the "## Auto-review"
+	// section. The gate must allow a re-spawn so the task is not permanently
+	// stranded at human-required with no diagnosis.
+	h, tasks, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	tk, err := tasks.Create("Crash-window task", "Body without auto-review section.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+		t.Fatalf("flip to human-required: %v", err)
+	}
+	// Verdict is set (persisted by onAgentComplete) but onComplete never ran —
+	// the task body has no "## Auto-review" section.
+	if err := tasks.AddRun(tk.ID, task.AgentRun{
+		AgentID: "agent-crashed",
+		Role:    "human-review",
+		Mode:    "headless",
+		State:   "stopped",
+		Verdict: "human",
+	}); err != nil {
+		t.Fatalf("add prior run: %v", err)
+	}
+
+	// Gate must NOT block — panic on nil agents.Run confirms spawn was attempted.
+	panicked := func() (p bool) {
+		defer func() {
+			if r := recover(); r != nil {
+				p = true
+			}
+		}()
+		h.maybeSpawn(tk.ID, "")
+		return false
+	}()
+	if !panicked {
+		t.Log("no panic — agent manager must have been non-nil; check test setup")
 	}
 }
 

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -501,7 +501,7 @@ func TestMaybeSpawn_IdempotencyGate_SpawnsWhenVerdictSetButNotRendered(t *testin
 		return false
 	}()
 	if !panicked {
-		t.Log("no panic — agent manager must have been non-nil; check test setup")
+		t.Fatal("expected spawn attempt; gate must not block when Verdict is set but VerdictRendered is false (crash window)")
 	}
 }
 
@@ -584,9 +584,7 @@ func TestMaybeSpawn_IdempotencyGate_SpawnsWhenNoVerdict(t *testing.T) {
 		return false
 	}()
 	if !panicked {
-		// If agents wasn't nil we'd check h.inflight; in tests it panics on
-		// agents.Run, confirming the gate let it through.
-		t.Log("no panic — agent manager must have been non-nil; check test setup")
+		t.Fatal("expected spawn attempt; gate must not block a run with no verdict (agent killed mid-run)")
 	}
 }
 

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -424,3 +424,80 @@ func TestOnComplete_MalformedVerdict_AppendsRaw(t *testing.T) {
 		t.Errorf("sink should not be called on malformed verdict; calls=%d", sink.calls)
 	}
 }
+
+func TestMaybeSpawn_IdempotencyGate_SkipsWhenVerdictRendered(t *testing.T) {
+	t.Parallel()
+	// h.agents is nil in newReviewTestEnv — if maybeSpawn tries to spawn an
+	// agent past the gate it will panic, which is the test's failure signal.
+	h, tasks, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	tk, err := tasks.Create("Stale task", "Body.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+		t.Fatalf("flip to human-required: %v", err)
+	}
+	// Simulate a prior completed review: add a run with a verdict already set.
+	if err := tasks.AddRun(tk.ID, task.AgentRun{
+		AgentID: "agent-prior",
+		Role:    "human-review",
+		Mode:    "headless",
+		State:   "stopped",
+		Verdict: "human",
+	}); err != nil {
+		t.Fatalf("add prior run: %v", err)
+	}
+
+	// Must not panic (agents is nil) and must skip.
+	h.maybeSpawn(tk.ID, "")
+
+	h.mu.Lock()
+	_, busy := h.inflight[tk.ID]
+	h.mu.Unlock()
+	if busy {
+		t.Error("expected no inflight entry — gate should have skipped the spawn")
+	}
+}
+
+func TestMaybeSpawn_IdempotencyGate_SpawnsWhenNoVerdict(t *testing.T) {
+	t.Parallel()
+	h, tasks, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	tk, err := tasks.Create("Fresh task", "Body.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+		t.Fatalf("flip to human-required: %v", err)
+	}
+	// Add a run with NO verdict (e.g. agent was killed mid-run).
+	if err := tasks.AddRun(tk.ID, task.AgentRun{
+		AgentID: "agent-killed",
+		Role:    "human-review",
+		Mode:    "headless",
+		State:   "stopped",
+		Verdict: "",
+	}); err != nil {
+		t.Fatalf("add prior run: %v", err)
+	}
+
+	// Gate should NOT block — recover from the expected nil-agents panic to
+	// confirm that spawn was attempted (past the idempotency gate).
+	panicked := func() (p bool) {
+		defer func() {
+			if r := recover(); r != nil {
+				p = true
+			}
+		}()
+		h.maybeSpawn(tk.ID, "")
+		return false
+	}()
+	if !panicked {
+		// If agents wasn't nil we'd check h.inflight; in tests it panics on
+		// agents.Run, confirming the gate let it through.
+		t.Log("no panic — agent manager must have been non-nil; check test setup")
+	}
+}

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -185,9 +185,14 @@ type AgentRun struct {
 	// Verdict holds the parsed decision for human-review runs ("human" or
 	// "sybra_bug"). Extracted from live agent output at completion time so
 	// it survives Result truncation.
-	Verdict   string `yaml:"verdict,omitempty" json:"verdict,omitempty"`
-	LogFile   string `yaml:"log_file,omitempty" json:"logFile"`
-	SessionID string `yaml:"session_id,omitempty" json:"sessionId,omitempty"`
+	Verdict string `yaml:"verdict,omitempty" json:"verdict,omitempty"`
+	// VerdictRendered is set to true after onComplete has successfully applied
+	// all side-effects for this run (note appended, issue filed, local task
+	// created). Used by verdictAlreadyRendered as the durable rendered-marker
+	// instead of body-text patterns which can collide with user content.
+	VerdictRendered bool   `yaml:"verdict_rendered,omitempty" json:"verdictRendered,omitempty"`
+	LogFile         string `yaml:"log_file,omitempty" json:"logFile"`
+	SessionID       string `yaml:"session_id,omitempty" json:"sessionId,omitempty"`
 	// HeadSHA is the worktree HEAD commit at this run's completion — what the
 	// agent left on the branch. Compared against the merged PR head to detect
 	// human edits after the agent (merged_with_edits) and measure edit distance.

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -950,6 +950,9 @@ func (s *Store) UpdateRun(taskID, agentID string, updates map[string]any) error 
 		if v, ok := updates["verdict"].(string); ok && v != "" {
 			t.AgentRuns[i].Verdict = v
 		}
+		if v, ok := updates["verdict_rendered"].(bool); ok && v {
+			t.AgentRuns[i].VerdictRendered = true
+		}
 		if v, ok := updates["log_file"].(string); ok {
 			t.AgentRuns[i].LogFile = v
 		}


### PR DESCRIPTION
## Motivation

On app restart or a repeated status hook, a task that had already received a human-review verdict would re-spawn the reviewer, duplicating the diagnosis. This adds an idempotency gate so the auto-reviewer runs at most once per task.

The gate must survive a crash *between* persisting the parsed verdict and rendering it. Keying off the parsed `AgentRun.Verdict` alone would falsely suppress a re-spawn for a task whose diagnosis was never actually written (process died mid-render) — permanently stranding it in `human-required` with no diagnosis.

> Changelog: fix(human-review): idempotent verdict gate

## Implementation information

- Add `AgentRun.VerdictRendered` (task model), set `true` only **after** `onComplete` successfully appends the `## Auto-review …` section / files the issue / routes the scrubbed local task.
- `verdictAlreadyRendered` gates on that durable marker, not the pre-render `Verdict` — closing the crash window.
- Regression tests:
  - spawns when `Verdict` is set but `VerdictRendered` is false (the crash window),
  - a pre-existing `## Auto-review` body text does not falsely block,
  - `onComplete` sets `VerdictRendered`.

## Supporting documentation

- `go test ./internal/sybra` — gate tests pass
- `golangci-lint run ./internal/sybra/` — 0 issues
- `go build ./cmd/sybra-server` — ok
