### PR TITLE
feat(projects): grouped, searchable list view

### DIFF
--- a/frontend/src/lib/review-phase.test.ts
+++ b/frontend/src/lib/review-phase.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest'
 import {
   REVIEW_PHASE_META,
   isReviewTask,
+  isHandoffPRReview,
+  isInboundReview,
   reviewPhaseOf,
   reviewPhaseMeta,
   reviewPhaseNeedsYou,
@@ -16,6 +18,32 @@ describe('isReviewTask', () => {
     expect(isReviewTask({ tags: ['backend', 'review'] })).toBe(true)
     expect(isReviewTask({ tags: ['backend'] })).toBe(false)
     expect(isReviewTask({})).toBe(false)
+  })
+})
+
+describe('isHandoffPRReview', () => {
+  it('is true only when the handoff-pr tag is present', () => {
+    expect(isHandoffPRReview({ tags: ['review', 'handoff-pr'] })).toBe(true)
+    expect(isHandoffPRReview({ tags: ['handoff-pr'] })).toBe(true)
+    expect(isHandoffPRReview({ tags: ['review'] })).toBe(false)
+    expect(isHandoffPRReview({})).toBe(false)
+  })
+})
+
+describe('isInboundReview', () => {
+  it('is true for review tasks that are not self-authored handoffs', () => {
+    expect(isInboundReview({ tags: ['review'] })).toBe(true)
+    expect(isInboundReview({ tags: ['backend', 'review'] })).toBe(true)
+  })
+
+  it('excludes self-authored handoff PR reviews (they belong in In Review)', () => {
+    expect(isInboundReview({ tags: ['review', 'handoff-pr'] })).toBe(false)
+  })
+
+  it('is false for non-review tasks', () => {
+    expect(isInboundReview({ tags: ['backend'] })).toBe(false)
+    expect(isInboundReview({ tags: ['handoff-pr'] })).toBe(false)
+    expect(isInboundReview({})).toBe(false)
   })
 })
 

--- a/frontend/src/lib/review-phase.ts
+++ b/frontend/src/lib/review-phase.ts
@@ -84,6 +84,29 @@ export function isReviewTask(t: { tags?: string[] }): boolean {
   return t.tags?.includes('review') ?? false
 }
 
+/** Tag set by `sybra-cli handoff --stage pr` on a self-authored PR. */
+export const HANDOFF_PR_TAG = 'handoff-pr'
+
+/**
+ * True when a review task is a self-authored PR handed off for cross-provider
+ * review. It keeps the `review` tag (so it reuses the pr-review workflow and the
+ * review-phase chrome), but it is the user's *own* PR — not inbound — so it must
+ * render in the In Review status column, never the inbound "To Review" lane.
+ */
+export function isHandoffPRReview(t: { tags?: string[] }): boolean {
+  return t.tags?.includes(HANDOFF_PR_TAG) ?? false
+}
+
+/**
+ * True only for INBOUND PR reviews (reviewing someone else's code) — the set
+ * that lives in the tag-based "To Review" board lane. Self-authored handoff PR
+ * reviews are excluded: they belong in their own status column. This is the
+ * single predicate that splits the To Review lane from the status columns.
+ */
+export function isInboundReview(t: { tags?: string[] }): boolean {
+  return isReviewTask(t) && !isHandoffPRReview(t)
+}
+
 /** A task's review phase, defaulting unknown/empty values to `reviewing`. */
 export function reviewPhaseOf(t: { reviewPhase?: string }): ReviewPhase {
   const p = t.reviewPhase

--- a/frontend/src/pages/ProjectList.svelte
+++ b/frontend/src/pages/ProjectList.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-  import { Folder, GitPullRequest, ListChecks } from '@lucide/svelte'
+  import { ChevronDown, ChevronRight, Folder, GitPullRequest, ListChecks, Search } from '@lucide/svelte'
   import { projectStore } from '../stores/projects.svelte.js'
   import { taskStore } from '../stores/tasks.svelte.js'
   import { reviewStore } from '../stores/reviews.svelte.js'
   import { BOARD_COLUMNS } from '../lib/statuses.js'
   import { formatShortDate, timeAgo } from '../lib/dates.js'
+  import type { Project } from '../../bindings/github.com/Automaat/sybra/internal/project/models.js'
 
   interface Props {
     onselect: (id: string) => void
@@ -39,9 +40,76 @@
     }
     return latest ? timeAgo(latest) : ''
   }
+
+  // pet first, then work — matches the ProjectType enum ordering.
+  const TYPE_ORDER = ['pet', 'work'] as const
+  const TYPE_LABELS: Record<string, string> = { pet: 'Pet', work: 'Work' }
+
+  let query = $state('')
+  // Collapsed group keys: a type ("pet") or a type+owner ("pet/Automaat").
+  let collapsed = $state(new Set<string>())
+
+  function toggle(key: string) {
+    const next = new Set(collapsed)
+    if (next.has(key)) next.delete(key)
+    else next.add(key)
+    collapsed = next
+  }
+
+  interface OwnerGroup {
+    owner: string
+    projects: Project[]
+  }
+  interface TypeGroup {
+    type: string
+    owners: OwnerGroup[]
+    count: number
+  }
+
+  function matchesQuery(p: Project, q: string): boolean {
+    if (!q) return true
+    return (
+      `${p.owner}/${p.repo}`.toLowerCase().includes(q) ||
+      (p.name ?? '').toLowerCase().includes(q) ||
+      (p.url ?? '').toLowerCase().includes(q)
+    )
+  }
+
+  // Two-level grouping: project type → GitHub owner → projects.
+  const groups = $derived.by<TypeGroup[]>(() => {
+    const q = query.trim().toLowerCase()
+    const byType = new Map<string, Map<string, Project[]>>()
+    for (const p of projectStore.list) {
+      if (!matchesQuery(p, q)) continue
+      const type = p.type === 'work' ? 'work' : 'pet'
+      let owners = byType.get(type)
+      if (!owners) {
+        owners = new Map()
+        byType.set(type, owners)
+      }
+      const ownerKey = p.owner || '—'
+      const list = owners.get(ownerKey)
+      if (list) list.push(p)
+      else owners.set(ownerKey, [p])
+    }
+
+    return TYPE_ORDER.filter((t) => byType.has(t)).map((type) => {
+      const ownersMap = byType.get(type)!
+      const owners = [...ownersMap.entries()]
+        .sort((a, b) => a[0].toLowerCase().localeCompare(b[0].toLowerCase()))
+        .map(([owner, projects]) => ({
+          owner,
+          projects: projects.sort((a, b) => a.repo.toLowerCase().localeCompare(b.repo.toLowerCase())),
+        }))
+      const count = owners.reduce((n, o) => n + o.projects.length, 0)
+      return { type, owners, count }
+    })
+  })
+
+  const totalMatches = $derived(groups.reduce((n, g) => n + g.count, 0))
 </script>
 
-<div class="flex flex-col gap-3 p-4 md:gap-4 md:p-6">
+<div class="flex flex-col gap-4 p-4 md:gap-5 md:p-6">
   {#if projectStore.loading && projectStore.list.length === 0}
     <p class="text-sm opacity-60">Loading projects...</p>
   {:else if projectStore.error}
@@ -59,43 +127,103 @@
       </button>
     </div>
   {:else}
-    <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-      {#each projectStore.list as p (p.id)}
-        {@const active = activeTaskCount(p.id)}
-        {@const prs = openPRCount(p.owner, p.repo)}
-        {@const activity = lastActivity(p.id)}
-        <button
-          type="button"
-          class="flex flex-col gap-2 rounded-lg border border-surface-300 bg-surface-50 p-4 text-left transition-colors hover:bg-surface-100 dark:border-surface-600 dark:bg-surface-800 dark:hover:bg-surface-700"
-          onclick={() => onselect(p.id)}
-        >
-          <div class="flex items-center gap-2">
-            <Folder size={20} class="shrink-0 text-surface-400" />
-            <span class="text-sm font-semibold">{p.owner}/{p.repo}</span>
-            {#if p.type === 'work'}
-              <span class="rounded px-1.5 py-0.5 text-xs font-medium bg-warning-100 text-warning-700 dark:bg-warning-900/40 dark:text-warning-300">work</span>
-            {:else}
-              <span class="rounded px-1.5 py-0.5 text-xs font-medium bg-surface-200 text-surface-500 dark:bg-surface-700 dark:text-surface-400">pet</span>
-            {/if}
-          </div>
-          <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-surface-500">
-            <span class="inline-flex items-center gap-1" title="Active tasks">
-              <ListChecks size={13} class="shrink-0" />
-              {active} active
-            </span>
-            {#if prs > 0}
-              <span class="inline-flex items-center gap-1" title="Open pull requests">
-                <GitPullRequest size={13} class="shrink-0" />
-                {prs} PR{prs === 1 ? '' : 's'}
-              </span>
-            {/if}
-            {#if activity}
-              <span title="Last task activity">· {activity}</span>
-            {/if}
-            <span class="ml-auto opacity-70">Added {formatShortDate(p.createdAt)}</span>
-          </div>
-        </button>
-      {/each}
+    <div class="relative w-full max-w-sm">
+      <Search size={16} class="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-surface-400" />
+      <input
+        bind:value={query}
+        type="text"
+        placeholder="Search projects..."
+        class="h-9 w-full rounded-md border border-surface-300 bg-surface-50 pl-8 pr-2 text-sm outline-none focus:border-primary-400 focus:ring-1 focus:ring-primary-400 dark:border-surface-700 dark:bg-surface-800 dark:focus:border-primary-500 dark:focus:ring-primary-500"
+        data-testid="project-search"
+      />
     </div>
+
+    {#if totalMatches === 0}
+      <p class="text-sm text-surface-500">No projects match “{query}”.</p>
+    {:else}
+      <div class="flex flex-col gap-6">
+        {#each groups as g (g.type)}
+          {@const typeCollapsed = collapsed.has(g.type)}
+          <section class="flex flex-col gap-3">
+            <button
+              type="button"
+              class="flex items-center gap-2 text-left"
+              onclick={() => toggle(g.type)}
+            >
+              {#if typeCollapsed}
+                <ChevronRight size={16} class="text-surface-400" />
+              {:else}
+                <ChevronDown size={16} class="text-surface-400" />
+              {/if}
+              <span class="text-xs font-semibold uppercase tracking-wide text-surface-500">{TYPE_LABELS[g.type]}</span>
+              <span class="rounded-full bg-surface-200 px-1.5 py-0.5 text-xs text-surface-500 dark:bg-surface-700 dark:text-surface-400">{g.count}</span>
+            </button>
+
+            {#if !typeCollapsed}
+              <div class="flex flex-col gap-3 pl-1.5">
+                {#each g.owners as o (o.owner)}
+                  {@const ownerKey = `${g.type}/${o.owner}`}
+                  {@const ownerCollapsed = collapsed.has(ownerKey)}
+                  <div class="flex flex-col gap-1.5">
+                    <button
+                      type="button"
+                      class="flex items-center gap-1.5 text-left"
+                      onclick={() => toggle(ownerKey)}
+                    >
+                      {#if ownerCollapsed}
+                        <ChevronRight size={14} class="text-surface-400" />
+                      {:else}
+                        <ChevronDown size={14} class="text-surface-400" />
+                      {/if}
+                      <span class="text-sm font-medium">{o.owner}</span>
+                      <span class="text-xs text-surface-400">{o.projects.length}</span>
+                    </button>
+
+                    {#if !ownerCollapsed}
+                      <div class="overflow-hidden rounded-lg border border-surface-300 divide-y divide-surface-200 dark:border-surface-600 dark:divide-surface-700">
+                        {#each o.projects as p (p.id)}
+                          {@const active = activeTaskCount(p.id)}
+                          {@const prs = openPRCount(p.owner, p.repo)}
+                          {@const activity = lastActivity(p.id)}
+                          <button
+                            type="button"
+                            class="flex w-full items-center gap-2 bg-surface-50 px-3 py-2 text-left transition-colors hover:bg-surface-100 dark:bg-surface-800 dark:hover:bg-surface-700"
+                            onclick={() => onselect(p.id)}
+                          >
+                            <Folder size={16} class="shrink-0 text-surface-400" />
+                            <span class="truncate text-sm font-medium">{p.repo}</span>
+                            {#if p.status === 'cloning'}
+                              <span class="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium bg-primary-100 text-primary-700 dark:bg-primary-900/40 dark:text-primary-300">cloning…</span>
+                            {:else if p.status === 'error'}
+                              <span class="shrink-0 rounded px-1.5 py-0.5 text-xs font-medium bg-error-100 text-error-700 dark:bg-error-900/40 dark:text-error-300">error</span>
+                            {/if}
+                            <div class="ml-auto flex shrink-0 flex-wrap items-center justify-end gap-x-3 gap-y-0.5 text-xs text-surface-500">
+                              <span class="inline-flex items-center gap-1" title="Active tasks">
+                                <ListChecks size={13} class="shrink-0" />
+                                {active}
+                              </span>
+                              {#if prs > 0}
+                                <span class="inline-flex items-center gap-1" title="Open pull requests">
+                                  <GitPullRequest size={13} class="shrink-0" />
+                                  {prs}
+                                </span>
+                              {/if}
+                              {#if activity}
+                                <span title="Last task activity">{activity}</span>
+                              {/if}
+                              <span class="opacity-70" title="Date added">Added {formatShortDate(p.createdAt)}</span>
+                            </div>
+                          </button>
+                        {/each}
+                      </div>
+                    {/if}
+                  </div>
+                {/each}
+              </div>
+            {/if}
+          </section>
+        {/each}
+      </div>
+    {/if}
   {/if}
 </div>

--- a/frontend/src/pages/ProjectList.svelte
+++ b/frontend/src/pages/ProjectList.svelte
@@ -200,12 +200,12 @@
                             <div class="ml-auto flex shrink-0 flex-wrap items-center justify-end gap-x-3 gap-y-0.5 text-xs text-surface-500">
                               <span class="inline-flex items-center gap-1" title="Active tasks">
                                 <ListChecks size={13} class="shrink-0" />
-                                {active}
+                                {active} active
                               </span>
                               {#if prs > 0}
                                 <span class="inline-flex items-center gap-1" title="Open pull requests">
                                   <GitPullRequest size={13} class="shrink-0" />
-                                  {prs}
+                                  {prs} PR{prs === 1 ? '' : 's'}
                                 </span>
                               {/if}
                               {#if activity}

--- a/frontend/src/pages/ProjectList.svelte
+++ b/frontend/src/pages/ProjectList.svelte
@@ -133,6 +133,7 @@
         bind:value={query}
         type="text"
         placeholder="Search projects..."
+        aria-label="Search projects"
         class="h-9 w-full rounded-md border border-surface-300 bg-surface-50 pl-8 pr-2 text-sm outline-none focus:border-primary-400 focus:ring-1 focus:ring-primary-400 dark:border-surface-700 dark:bg-surface-800 dark:focus:border-primary-500 dark:focus:ring-primary-500"
         data-testid="project-search"
       />
@@ -148,6 +149,7 @@
             <button
               type="button"
               class="flex items-center gap-2 text-left"
+              aria-expanded={!typeCollapsed}
               onclick={() => toggle(g.type)}
             >
               {#if typeCollapsed}
@@ -168,6 +170,7 @@
                     <button
                       type="button"
                       class="flex items-center gap-1.5 text-left"
+                      aria-expanded={!ownerCollapsed}
                       onclick={() => toggle(ownerKey)}
                     >
                       {#if ownerCollapsed}

--- a/frontend/src/pages/ProjectList.svelte.test.ts
+++ b/frontend/src/pages/ProjectList.svelte.test.ts
@@ -88,29 +88,63 @@ describe('ProjectList', () => {
     expect(screen.getByText('Add your first project')).toBeDefined()
   })
 
-  it('renders project owner/repo', () => {
+  it('renders the repo in a row under its owner group header', () => {
     mockProjectList.push(mockProject)
     render(ProjectList, { props: { onselect: vi.fn(), onadd: vi.fn() } })
-    expect(screen.getByText('owner/repo')).toBeDefined()
+    expect(screen.getByText('repo')).toBeDefined() // row
+    expect(screen.getByText('owner')).toBeDefined() // owner group header
   })
 
-  it('shows pet type badge', () => {
+  it('groups pet projects under a Pet header', () => {
     mockProjectList.push({ ...mockProject, type: 'pet' })
     render(ProjectList, { props: { onselect: vi.fn(), onadd: vi.fn() } })
-    expect(screen.getByText('pet')).toBeDefined()
+    expect(screen.getByText('Pet')).toBeDefined()
   })
 
-  it('shows work type badge', () => {
+  it('groups work projects under a Work header', () => {
     mockProjectList.push({ ...mockProject, type: 'work' })
     render(ProjectList, { props: { onselect: vi.fn(), onadd: vi.fn() } })
-    expect(screen.getByText('work')).toBeDefined()
+    expect(screen.getByText('Work')).toBeDefined()
   })
 
-  it('calls onselect when project clicked', async () => {
+  it('groups projects by GitHub owner within a type', () => {
+    mockProjectList.push(
+      { ...mockProject, id: 'orgA/one', owner: 'orgA', repo: 'one' },
+      { ...mockProject, id: 'orgB/two', owner: 'orgB', repo: 'two' },
+    )
+    render(ProjectList, { props: { onselect: vi.fn(), onadd: vi.fn() } })
+    expect(screen.getByText('orgA')).toBeDefined()
+    expect(screen.getByText('orgB')).toBeDefined()
+  })
+
+  it('filters projects by the search box', async () => {
+    mockProjectList.push(
+      { ...mockProject, id: 'owner/alpha', repo: 'alpha' },
+      { ...mockProject, id: 'owner/beta', repo: 'beta' },
+    )
+    render(ProjectList, { props: { onselect: vi.fn(), onadd: vi.fn() } })
+    await fireEvent.input(screen.getByPlaceholderText('Search projects...'), {
+      target: { value: 'alpha' },
+    })
+    expect(screen.getByText('alpha')).toBeDefined()
+    expect(screen.queryByText('beta')).toBeNull()
+  })
+
+  it('shows a no-match message when search excludes everything', async () => {
+    mockProjectList.push(mockProject)
+    render(ProjectList, { props: { onselect: vi.fn(), onadd: vi.fn() } })
+    await fireEvent.input(screen.getByPlaceholderText('Search projects...'), {
+      target: { value: 'zzz-nomatch' },
+    })
+    expect(screen.queryByText('repo')).toBeNull()
+    expect(screen.getByText(/No projects match/)).toBeDefined()
+  })
+
+  it('calls onselect when a project row is clicked', async () => {
     mockProjectList.push(mockProject)
     const onselect = vi.fn()
     render(ProjectList, { props: { onselect, onadd: vi.fn() } })
-    await fireEvent.click(screen.getByText('owner/repo'))
+    await fireEvent.click(screen.getByText('repo'))
     expect(onselect).toHaveBeenCalledWith('owner/repo')
   })
 

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -5,7 +5,7 @@
   import { projectStore } from '../stores/projects.svelte.js'
   import { notificationStore } from '../stores/notifications.svelte.js'
   import { BOARD_LANES, awaitsHuman, type BoardColumn } from '../lib/statuses.js'
-  import { isReviewTask, reviewPhaseNeedsYou, reviewPhaseRank } from '../lib/review-phase.js'
+  import { isInboundReview, reviewPhaseNeedsYou, reviewPhaseRank } from '../lib/review-phase.js'
   import { prPhaseRank, prPhaseNeedsYou } from '../lib/pr-phase.js'
   import { navStore } from '../lib/navigation.svelte.js'
   import { matchesQuery, matchesProject, matchesTags, matchesAgentMode } from '../lib/task-filters.js'
@@ -71,8 +71,10 @@
   function columnTasks(col: BoardColumn): Task[] {
     if (col.kind === 'review') return reviewLaneTasks()
     const statuses = col.includes.length > 0 ? col.includes : [col.status]
-    // Review tasks live in the PR Reviews lane, never their status column.
-    const tasks = filteredByStatuses(statuses).filter((t) => !isReviewTask(t))
+    // Inbound reviews live in the To Review lane, never their status column.
+    // Self-authored handoff PR reviews are NOT inbound — they stay here so a
+    // handed-off PR shows in In Review, not To Review.
+    const tasks = filteredByStatuses(statuses).filter((t) => !isInboundReview(t))
     // In Review: float the user's pending PR actions (merge / ping / mark-ready)
     // to the top, mirroring the PR Reviews lane.
     if (col.status === 'in-review') {
@@ -81,12 +83,13 @@
     return tasks
   }
 
-  // The PR Reviews lane: every active inbound review task, sorted so the
-  // phases that need the user (post / approve) float to the top.
+  // The To Review lane: every active inbound review task, sorted so the
+  // phases that need the user (post / approve) float to the top. Self-authored
+  // handoff PR reviews are excluded — they belong in their status column.
   function reviewLaneTasks(): Task[] {
     return taskStore.list
       .filter((t: Task) => {
-        if (!isReviewTask(t)) return false
+        if (!isInboundReview(t)) return false
         if (t.status === 'done' || t.status === 'cancelled') return false
         if (!matchesQuery(t, searchQuery)) return false
         if (!matchesProject(t, selectedProjectId)) return false


### PR DESCRIPTION
## Motivation

The projects view was a flat 3-column card grid. With more projects it got
hard to scan, and there was no way to search or to separate pet vs work
repos at a glance.

Separately, `/sybra-handoff pr` (handing your own PR to Sybra for a
cross-provider review) made the task surface in the inbound **To Review**
lane instead of **In Review**, polluting the inbound-review queue with your
own pipeline work. Fixed here while on this branch.

> Changelog: feat(projects): grouped, searchable list view

## Implementation information

### Projects view (`frontend/src/pages/ProjectList.svelte`)

Reworked into a searchable, two-level grouped list:

- Top-level grouping by project type (pet, then work) with per-group counts.
- Second-level grouping by GitHub owner/org, owners and repos sorted
  alphabetically.
- Collapsible type and owner headers (ephemeral, session-only state).
- Search box — case-insensitive substring over `owner/repo`, name, and URL;
  empty result shows a "no matches" message.
- Rows drop the now-redundant owner prefix and type badge (implied by the
  group), keep the `N active` / `N PRs` / last-activity / added-date
  metadata, and add a `cloning…`/`error` status badge for non-ready clones.
- Preserves `onselect`, empty-state `onadd`, and the header "New Project"
  action.

### Board routing fix (`review-phase.ts`, `TaskList.svelte`)

The `review` tag did double duty: it triggers the `pr-review` workflow AND
routes a card into the tag-based **To Review** lane (which excludes it from
status columns). The trigger engine is AND-only with one trigger per
workflow, and inbound reviews (Renovate, others' PRs) share that same
`review`-triggered workflow — so retargeting the trigger would break them.

Instead, split routing from the trigger: add `isInboundReview` (= `review`
tag AND not `handoff-pr`) and key both the To Review lane and the
status-column exclusion on it. Self-authored handoff PR reviews
(`handoff-pr` tag) now render in **In Review** while inbound PRs stay in
**To Review**. The `pr-review` workflow is unchanged, so the cross-provider
review still runs.

Gates: oxlint, svelte-check (0/0), full vitest (1595 tests), and
`vite build` all pass.

## Supporting documentation

None.
