### PR TITLE
feat(codex): plugin with stable lifecycle hooks

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -1589,16 +1589,19 @@ func cmdHook(cfg *config.Config, args []string) int {
 	payload, err := io.ReadAll(io.LimitReader(os.Stdin, 64*1024))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "hook: read stdin: %v\n", err)
+		logHookFailure(cfg, *taskID, "read_error")
 		return 0
 	}
 	if len(bytes.TrimSpace(payload)) == 0 {
 		fmt.Fprintln(os.Stderr, "hook: empty stdin payload")
+		logHookFailure(cfg, *taskID, "empty_payload")
 		return 0
 	}
 
 	auditEvent, err := codexhook.Map(payload, *taskID)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "hook: map payload: %v\n", err)
+		logHookFailure(cfg, *taskID, "map_error")
 		return 0
 	}
 
@@ -1611,8 +1614,32 @@ func cmdHook(cfg *config.Config, args []string) int {
 
 	if err := logger.Log(auditEvent); err != nil {
 		fmt.Fprintf(os.Stderr, "hook: log: %v\n", err)
+		_ = logger.Log(audit.Event{
+			Timestamp: time.Now().UTC(),
+			Type:      audit.EventCodexHookFailed,
+			TaskID:    *taskID,
+			Data:      map[string]any{"reason": "log_error"},
+		})
 	}
 	return 0
+}
+
+// logHookFailure writes a diagnostic audit event for hook receiver errors.
+// It is best-effort: all errors are silently discarded so the caller always
+// exits 0 and the hook stays fail-open. The reason field is a categorical
+// label — never the raw error message — so no sensitive content is persisted.
+func logHookFailure(cfg *config.Config, taskID, reason string) {
+	logger, err := audit.NewLogger(cfg.AuditDir())
+	if err != nil {
+		return
+	}
+	defer func() { _ = logger.Close() }()
+	_ = logger.Log(audit.Event{
+		Timestamp: time.Now().UTC(),
+		Type:      audit.EventCodexHookFailed,
+		TaskID:    taskID,
+		Data:      map[string]any{"reason": reason},
+	})
 }
 
 func usage() {

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -1583,13 +1583,19 @@ func cmdHook(cfg *config.Config, args []string) int {
 		fmt.Fprintln(os.Stderr, "hook: invalid --task value")
 		return 0
 	}
-	_ = event // event is validated by codexhook.Map via the JSON payload
-
 	// Read the hook payload from stdin (codex pipes JSON here).
-	payload, err := io.ReadAll(io.LimitReader(os.Stdin, 64*1024))
+	// Use a limit of 64 KiB; if exactly that many bytes are read the input
+	// exceeded the bound (LimitReader truncates silently) — reject it.
+	const maxPayloadBytes = 64 * 1024
+	payload, err := io.ReadAll(io.LimitReader(os.Stdin, maxPayloadBytes))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "hook: read stdin: %v\n", err)
 		logHookFailure(cfg, *taskID, "read_error")
+		return 0
+	}
+	if len(payload) >= maxPayloadBytes {
+		fmt.Fprintln(os.Stderr, "hook: stdin payload exceeds size limit")
+		logHookFailure(cfg, *taskID, "oversized_payload")
 		return 0
 	}
 	if len(bytes.TrimSpace(payload)) == 0 {
@@ -1598,7 +1604,7 @@ func cmdHook(cfg *config.Config, args []string) int {
 		return 0
 	}
 
-	auditEvent, err := codexhook.Map(payload, *taskID)
+	auditEvent, err := codexhook.Map(payload, *taskID, event)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "hook: map payload: %v\n", err)
 		logHookFailure(cfg, *taskID, "map_error")

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -1584,16 +1584,17 @@ func cmdHook(cfg *config.Config, args []string) int {
 		return 0
 	}
 	// Read the hook payload from stdin (codex pipes JSON here).
-	// Use a limit of 64 KiB; if exactly that many bytes are read the input
-	// exceeded the bound (LimitReader truncates silently) — reject it.
+	// Read up to 64 KiB + 1: if more than 64 KiB are available, the extra
+	// byte will be read and len(payload) > maxPayloadBytes, signalling
+	// overflow without silently truncating a valid exactly-64-KiB payload.
 	const maxPayloadBytes = 64 * 1024
-	payload, err := io.ReadAll(io.LimitReader(os.Stdin, maxPayloadBytes))
+	payload, err := io.ReadAll(io.LimitReader(os.Stdin, maxPayloadBytes+1))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "hook: read stdin: %v\n", err)
 		logHookFailure(cfg, *taskID, "read_error")
 		return 0
 	}
-	if len(payload) >= maxPayloadBytes {
+	if len(payload) > maxPayloadBytes {
 		fmt.Fprintln(os.Stderr, "hook: stdin payload exceeds size limit")
 		logHookFailure(cfg, *taskID, "oversized_payload")
 		return 0

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -1,14 +1,17 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -17,6 +20,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/artifact"
 	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/codexhook"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/monitor"
 	"github.com/Automaat/sybra/internal/project"
@@ -24,6 +28,11 @@ import (
 	"github.com/Automaat/sybra/internal/skillsync"
 	"github.com/Automaat/sybra/internal/task"
 )
+
+// hookTaskIDRe mirrors agent.safeArgRe: alphanumerics, dot, underscore,
+// hyphen, forward-slash. Shared allowlist keeps arg builder and hook receiver
+// in sync without an import cycle.
+var hookTaskIDRe = regexp.MustCompile(`^[a-zA-Z0-9._/-]+$`)
 
 func main() {
 	os.Exit(run(os.Args[1:]))
@@ -54,6 +63,13 @@ func run(args []string) int {
 	cfg, err := config.Load()
 	if err != nil {
 		return fatal(jsonOut, "load config: %v", err)
+	}
+
+	// Fast path for hook subcommand — only needs cfg for AuditDir(), not stores.
+	// Branch before store construction so cold start is cheap (hook is invoked
+	// per-event by codex and must complete quickly).
+	if len(filtered) >= 1 && filtered[0] == "hook" {
+		return cmdHook(cfg, filtered[1:])
 	}
 
 	rawStore, err := task.NewStore(cfg.TasksDir)
@@ -1538,6 +1554,65 @@ func parseSince(s string, now time.Time) time.Time {
 		return t
 	}
 	return now.Add(-24 * time.Hour)
+}
+
+// cmdHook is the fast-path handler for "sybra-cli hook <Event> --task <id>".
+// It is invoked by codex lifecycle hooks — once per event, as a short-lived
+// subprocess. Only config.Load() is needed (no task/project stores). Always
+// exits 0 (fail-open): hook errors must never stall a codex agent run.
+func cmdHook(cfg *config.Config, args []string) int {
+	if len(args) < 1 {
+		fmt.Fprintln(os.Stderr, "hook: missing event name")
+		return 0
+	}
+	event := args[0]
+	rest := args[1:]
+
+	fs := flag.NewFlagSet("hook", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	taskID := fs.String("task", "", "task id")
+	if err := fs.Parse(rest); err != nil {
+		return 0 // flag already wrote to stderr
+	}
+
+	if *taskID == "" {
+		fmt.Fprintln(os.Stderr, "hook: --task required")
+		return 0
+	}
+	if !hookTaskIDRe.MatchString(*taskID) {
+		fmt.Fprintln(os.Stderr, "hook: invalid --task value")
+		return 0
+	}
+	_ = event // event is validated by codexhook.Map via the JSON payload
+
+	// Read the hook payload from stdin (codex pipes JSON here).
+	payload, err := io.ReadAll(io.LimitReader(os.Stdin, 64*1024))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "hook: read stdin: %v\n", err)
+		return 0
+	}
+	if len(bytes.TrimSpace(payload)) == 0 {
+		fmt.Fprintln(os.Stderr, "hook: empty stdin payload")
+		return 0
+	}
+
+	auditEvent, err := codexhook.Map(payload, *taskID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "hook: map payload: %v\n", err)
+		return 0
+	}
+
+	logger, err := audit.NewLogger(cfg.AuditDir())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "hook: create audit logger: %v\n", err)
+		return 0
+	}
+	defer func() { _ = logger.Close() }()
+
+	if err := logger.Log(auditEvent); err != nil {
+		fmt.Fprintf(os.Stderr, "hook: log: %v\n", err)
+	}
+	return 0
 }
 
 func usage() {

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -60,15 +60,24 @@ func run(args []string) int {
 		return 1
 	}
 
+	// Detect the hook subcommand before config.Load can abort: codex lifecycle
+	// hooks must fail open (see cmdHook) — a malformed config must never make
+	// `sybra-cli hook` exit non-zero and stall an agent run.
+	isHook := len(filtered) >= 1 && filtered[0] == "hook"
+
 	cfg, err := config.Load()
 	if err != nil {
+		if isHook {
+			fmt.Fprintf(os.Stderr, "hook: load config: %v (continuing fail-open)\n", err)
+			return 0
+		}
 		return fatal(jsonOut, "load config: %v", err)
 	}
 
 	// Fast path for hook subcommand — only needs cfg for AuditDir(), not stores.
 	// Branch before store construction so cold start is cheap (hook is invoked
 	// per-event by codex and must complete quickly).
-	if len(filtered) >= 1 && filtered[0] == "hook" {
+	if isHook {
 		return cmdHook(cfg, filtered[1:])
 	}
 

--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -1110,3 +1110,24 @@ func TestHookCmd_ValidPayloadExitsZero(t *testing.T) {
 		t.Errorf("hook must produce no stdout; got %q", out)
 	}
 }
+
+// TestHookCmd_ExactLimitAccepted verifies that a payload padded to exactly
+// 64 KiB (the inclusive upper bound) is accepted as a valid lifecycle event,
+// not rejected as oversized.
+func TestHookCmd_ExactLimitAccepted(t *testing.T) {
+	setupStore(t)
+	const maxPayloadBytes = 64 * 1024
+	base := `{"hook_event_name":"SessionStart","session_id":"s-exact"}`
+	pad := maxPayloadBytes - len(base)
+	payload := base + strings.Repeat(" ", pad)
+	if len(payload) != maxPayloadBytes {
+		t.Fatalf("test setup: payload length %d != %d", len(payload), maxPayloadBytes)
+	}
+	code, out := runHookWithStdin(t, payload, "hook", "SessionStart", "--task", "task-exact")
+	if code != 0 {
+		t.Errorf("exact-limit payload must exit 0; got %d", code)
+	}
+	if out != "" {
+		t.Errorf("hook must produce no stdout; got %q", out)
+	}
+}

--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -1012,8 +1012,12 @@ func runHookWithStdin(t *testing.T, stdin string, args ...string) (exitCode int,
 	oldStdin := os.Stdin
 	sr, sw, _ := os.Pipe()
 	os.Stdin = sr
-	_, _ = sw.WriteString(stdin)
-	_ = sw.Close()
+	// Write stdin in a goroutine: large payloads (> pipe buffer ~64 KiB) would
+	// deadlock if written synchronously before run() starts reading.
+	go func() {
+		_, _ = sw.WriteString(stdin)
+		_ = sw.Close()
+	}()
 
 	code := run(args)
 
@@ -1065,6 +1069,18 @@ func TestHookCmd_FailOpen(t *testing.T) {
 			name:  "unknown_event_in_payload",
 			args:  []string{"hook", "PreToolUse", "--task", "task-abc"},
 			stdin: `{"hook_event_name":"PreToolUse","session_id":"s"}`,
+		},
+		{
+			// Positional event arg disagrees with payload's hook_event_name.
+			name:  "event_mismatch",
+			args:  []string{"hook", "Stop", "--task", "task-abc"},
+			stdin: `{"hook_event_name":"SessionStart","session_id":"s-mismatch","model":"m"}`,
+		},
+		{
+			// Payload > 64 KiB: first bytes are valid JSON but total exceeds limit.
+			name:  "oversized_payload",
+			args:  []string{"hook", "SessionStart", "--task", "task-abc"},
+			stdin: `{"hook_event_name":"SessionStart","session_id":"s-oversize"}` + strings.Repeat(" ", 70000),
 		},
 	}
 

--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -1131,3 +1131,23 @@ func TestHookCmd_ExactLimitAccepted(t *testing.T) {
 		t.Errorf("hook must produce no stdout; got %q", out)
 	}
 }
+
+// TestHookCmd_FailsOpenOnBadConfig verifies the hook subcommand exits 0 even
+// when config.Load fails. config.Load runs before the hook fast-path, so a
+// malformed config must not make `sybra-cli hook` exit non-zero and stall a
+// codex agent run — the diagnosis bypasses the fail-open cmdHook handler.
+func TestHookCmd_FailsOpenOnBadConfig(t *testing.T) {
+	home := setupStore(t)
+	// An unclosed flow sequence makes yaml.Unmarshal (and thus config.Load) error.
+	if err := os.WriteFile(filepath.Join(home, "config.yaml"), []byte("agent: [unclosed"), 0o644); err != nil {
+		t.Fatalf("write bad config: %v", err)
+	}
+	code, out := runHookWithStdin(t, `{"hook_event_name":"SessionStart","session_id":"s","model":"m"}`,
+		"hook", "SessionStart", "--task", "task-abc")
+	if code != 0 {
+		t.Errorf("hook must exit 0 (fail-open) when config.Load fails; got %d", code)
+	}
+	if out != "" {
+		t.Errorf("hook must produce no stdout; got %q", out)
+	}
+}

--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -998,3 +998,99 @@ func TestLinkPR_InvalidArgs(t *testing.T) {
 		})
 	}
 }
+
+// runHook calls sybra-cli hook <event> --task <taskID> with stdin payload.
+// Returns exit code and (stdout, stderr) combined via the same pipe used by
+// runCLI (stdout). Hook always exits 0, so this is primarily used to verify
+// no panic and no stdout decision output.
+func runHookWithStdin(t *testing.T, stdin string, args ...string) (exitCode int, stdout string) {
+	t.Helper()
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	oldStdin := os.Stdin
+	sr, sw, _ := os.Pipe()
+	os.Stdin = sr
+	_, _ = sw.WriteString(stdin)
+	_ = sw.Close()
+
+	code := run(args)
+
+	_ = w.Close()
+	os.Stdout = old
+	os.Stdin = oldStdin
+
+	buf := make([]byte, 64*1024)
+	n, _ := r.Read(buf)
+	return code, string(buf[:n])
+}
+
+// TestHookCmd_FailOpen verifies that every error path in cmdHook exits 0 and
+// produces no stdout content (observe-only, never a decision output).
+func TestHookCmd_FailOpen(t *testing.T) {
+	setupStore(t)
+
+	cases := []struct {
+		name  string
+		args  []string
+		stdin string
+	}{
+		{
+			name:  "missing_event",
+			args:  []string{"hook"},
+			stdin: "",
+		},
+		{
+			name:  "missing_task_flag",
+			args:  []string{"hook", "SessionStart"},
+			stdin: `{"hook_event_name":"SessionStart"}`,
+		},
+		{
+			name:  "invalid_task_id",
+			args:  []string{"hook", "SessionStart", "--task", "bad id with spaces"},
+			stdin: `{"hook_event_name":"SessionStart"}`,
+		},
+		{
+			name:  "empty_stdin",
+			args:  []string{"hook", "SessionStart", "--task", "task-abc"},
+			stdin: "",
+		},
+		{
+			name:  "malformed_json",
+			args:  []string{"hook", "SessionStart", "--task", "task-abc"},
+			stdin: "not json",
+		},
+		{
+			name:  "unknown_event_in_payload",
+			args:  []string{"hook", "PreToolUse", "--task", "task-abc"},
+			stdin: `{"hook_event_name":"PreToolUse","session_id":"s"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, out := runHookWithStdin(t, tc.stdin, tc.args...)
+			if code != 0 {
+				t.Errorf("hook must exit 0 (fail-open); got %d", code)
+			}
+			if out != "" {
+				t.Errorf("hook must produce no stdout; got %q", out)
+			}
+		})
+	}
+}
+
+// TestHookCmd_ValidPayloadExitsZero verifies a well-formed SessionStart payload
+// succeeds without panicking.
+func TestHookCmd_ValidPayloadExitsZero(t *testing.T) {
+	setupStore(t)
+	payload := `{"hook_event_name":"SessionStart","session_id":"sess-1","model":"gpt-5.5"}`
+	code, out := runHookWithStdin(t, payload, "hook", "SessionStart", "--task", "task-abc123")
+	if code != 0 {
+		t.Errorf("expected exit 0; got %d", code)
+	}
+	if out != "" {
+		t.Errorf("hook must produce no stdout; got %q", out)
+	}
+}

--- a/docs/codex-setup.md
+++ b/docs/codex-setup.md
@@ -110,6 +110,52 @@ Existing Sybra skills (`/sybra-tasks`, `/sybra-triage`, `/sybra-plan`, etc.) are
 
 The orchestrator prompt (`orchestrator/CLAUDE.md`) governs the Sybra orchestrator session, which always runs as a Claude Code agent. Codex is used for implementation agents dispatched by the orchestrator, not for the orchestrator itself.
 
+## Lifecycle Hook Telemetry
+
+Sybra injects observe-only lifecycle hooks into every `codex exec` invocation using inline `-c hooks.<Event>=...` config overrides. This is the only channel that survives Sybra's `--ignore-user-config --ignore-rules` flags — per-worktree `.codex/hooks.json` and `~/.codex` plugin files are explicitly ignored by those flags and do not fire.
+
+### Instrumented events
+
+| Event | Audit type |
+|-------|-----------|
+| `SessionStart` | `codex.session.start` |
+| `SubagentStart` | `codex.subagent.start` |
+| `SubagentStop` | `codex.subagent.stop` |
+| `Stop` | `codex.session.stop` |
+
+`PreToolUse` and `PostToolUse` are deliberately excluded — per-tool-call hooks would sit on the agent's critical path.
+
+### How it works
+
+For each event, Sybra appends a `-c` override to the `codex exec` command:
+
+```
+-c 'hooks.SessionStart=[{hooks=[{type="command",command="sybra-cli hook SessionStart --task <id>",run_mode="background",timeout_seconds=5}]}]'
+```
+
+The `--dangerously-bypass-hook-trust` flag is also passed so codex executes the hook without requiring a trusted source check.
+
+`sybra-cli hook <Event> --task <id>` is the hook receiver: it reads the JSON payload from stdin, maps it to a structural-only `audit.Event` (session_id, subagent_id, kind, model — never cwd, prompts, tool_input, or file paths), and appends it to the daily audit NDJSON (`~/.sybra/logs/audit/<date>.ndjson`). The receiver always exits 0 (fail-open) so hook errors never stall the agent run.
+
+### Fail-open behaviour
+
+Hooks are omitted (the codex run proceeds normally, without hooks) when:
+- `sybra-cli` is not on `PATH` and not adjacent to the Sybra binary
+- The resolved `sybra-cli` path contains shell-sensitive characters
+- The task ID is empty or contains characters outside `[a-zA-Z0-9._/-]`
+
+### Minimum supported codex version
+
+`--dangerously-bypass-hook-trust` is required and was verified present in codex **0.142.2**. Hooks fire via `-c` config overrides starting from codex **0.131** (when plugin hooks became default-enabled). Sybra does not probe the codex version at runtime — if the flag is unsupported, codex will reject the invocation and the agent will fail to start; update to 0.142.2+ in that case.
+
+### Viewing hook events
+
+```bash
+sybra-cli audit --type codex.session.start
+sybra-cli audit --type codex.subagent.start
+sybra-cli audit --since 1h --summary
+```
+
 ## Troubleshooting
 
 **`codex: command not found`**

--- a/internal/agent/codexhooks.go
+++ b/internal/agent/codexhooks.go
@@ -32,7 +32,7 @@ func resolveCodexHookBin() (string, bool) {
 		return "", false
 	}
 	adjacent := filepath.Join(filepath.Dir(self), "sybra-cli")
-	if _, err := os.Stat(adjacent); err != nil {
+	if _, err := exec.LookPath(adjacent); err != nil {
 		return "", false
 	}
 	// Reject paths with characters that require shell quoting — the hook

--- a/internal/agent/codexhooks.go
+++ b/internal/agent/codexhooks.go
@@ -1,0 +1,74 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// codexHookEvents are the low-frequency lifecycle events for which Sybra
+// registers observe-only hooks on codex invocations. Per-tool-call events
+// (PreToolUse, PostToolUse) are explicitly excluded — only session and
+// subagent boundaries are instrumented to keep hooks off the critical path.
+var codexHookEvents = []string{
+	"SessionStart",
+	"SubagentStart",
+	"SubagentStop",
+	"Stop",
+}
+
+// resolveCodexHookBin returns the sybra-cli binary name or path to use in a
+// codex hook command string. A bare "sybra-cli" on PATH is preferred — no path
+// interpolation occurs. If not found on PATH, the directory of the running
+// executable is checked. Returns ("", false) if no shell-safe path is
+// resolvable; the caller must omit hooks in that case (fail-open).
+func resolveCodexHookBin() (string, bool) {
+	if _, err := exec.LookPath("sybra-cli"); err == nil {
+		return "sybra-cli", true
+	}
+	self, err := os.Executable()
+	if err != nil {
+		return "", false
+	}
+	adjacent := filepath.Join(filepath.Dir(self), "sybra-cli")
+	if _, err := os.Stat(adjacent); err != nil {
+		return "", false
+	}
+	// Reject paths with characters that require shell quoting — the hook
+	// command string is passed verbatim to codex which runs it via a shell.
+	if !safeArgRe.MatchString(adjacent) {
+		return "", false
+	}
+	return adjacent, true
+}
+
+// buildCodexHookArgs returns the -c override pairs and
+// --dangerously-bypass-hook-trust flag to append to a codex exec invocation.
+// If sybra-cli cannot be resolved to a shell-safe path, or taskID fails the
+// allowlist check, an empty slice is returned (fail-open — the run proceeds
+// without hooks rather than erroring).
+func buildCodexHookArgs(taskID string) []string {
+	if !safeArgRe.MatchString(taskID) {
+		return nil
+	}
+	bin, ok := resolveCodexHookBin()
+	if !ok {
+		return nil
+	}
+
+	args := make([]string, 0, len(codexHookEvents)*2+1)
+	for _, event := range codexHookEvents {
+		cmd := fmt.Sprintf("%s hook %s --task %s", bin, event, taskID)
+		// TOML inline-table value for the hooks.<Event> config key.
+		// Outer array: hook-filter entry. Inner hooks: the action list.
+		// run_mode=background keeps hooks off the critical path.
+		val := fmt.Sprintf(
+			`hooks.%s=[{hooks=[{type="command",command=%q,run_mode="background",timeout_seconds=5}]}]`,
+			event, cmd,
+		)
+		args = append(args, "-c", val)
+	}
+	args = append(args, "--dangerously-bypass-hook-trust")
+	return args
+}

--- a/internal/agent/codexhooks_test.go
+++ b/internal/agent/codexhooks_test.go
@@ -1,0 +1,122 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// makeFakeSybraCLI creates a minimal executable named sybra-cli in dir and
+// prepends dir to PATH so resolveCodexHookBin finds it via exec.LookPath.
+func makeFakeSybraCLI(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "sybra-cli")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("create fake sybra-cli: %v", err)
+	}
+	t.Setenv("PATH", dir+":"+os.Getenv("PATH"))
+	return dir
+}
+
+func TestBuildCodexHookArgs_FourEvents(t *testing.T) {
+	makeFakeSybraCLI(t)
+
+	args := buildCodexHookArgs("task-abc123")
+	if len(args) == 0 {
+		t.Fatal("expected hook args, got none")
+	}
+
+	wantEvents := []string{"SessionStart", "SubagentStart", "SubagentStop", "Stop"}
+	for _, event := range wantEvents {
+		key := "hooks." + event + "="
+		found := false
+		for _, arg := range args {
+			if strings.HasPrefix(arg, key) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("hook override for event %q not found; args=%v", event, args)
+		}
+	}
+}
+
+func TestBuildCodexHookArgs_NoOutOfScopeEvents(t *testing.T) {
+	makeFakeSybraCLI(t)
+
+	args := buildCodexHookArgs("task-abc123")
+	for _, arg := range args {
+		if strings.Contains(arg, "PreToolUse") || strings.Contains(arg, "PostToolUse") {
+			t.Errorf("hook args contain out-of-scope event; arg=%q", arg)
+		}
+	}
+}
+
+func TestBuildCodexHookArgs_BypassHookTrustPresent(t *testing.T) {
+	makeFakeSybraCLI(t)
+
+	args := buildCodexHookArgs("task-abc123")
+	if !slices.Contains(args, "--dangerously-bypass-hook-trust") {
+		t.Errorf("--dangerously-bypass-hook-trust missing; args=%v", args)
+	}
+}
+
+func TestBuildCodexHookArgs_ArgsArePairs(t *testing.T) {
+	makeFakeSybraCLI(t)
+
+	args := buildCodexHookArgs("task-abc123")
+	// Every -c must be immediately followed by its value (not another flag).
+	for i, arg := range args {
+		if arg == "-c" {
+			if i+1 >= len(args) || strings.HasPrefix(args[i+1], "-") {
+				t.Errorf("-c at index %d not followed by a value; args=%v", i, args)
+			}
+		}
+	}
+}
+
+func TestBuildCodexHookArgs_TaskIDInjectionRejected(t *testing.T) {
+	badIDs := []string{
+		"",
+		"task id with spaces",
+		"task\nid",
+		"task;rm -rf /",
+		"task$(id)",
+	}
+	for _, id := range badIDs {
+		args := buildCodexHookArgs(id)
+		if len(args) != 0 {
+			t.Errorf("buildCodexHookArgs(%q) should return nil for unsafe taskID; got %v", id, args)
+		}
+	}
+}
+
+func TestBuildCodexHookArgs_MissingBinaryReturnsNil(t *testing.T) {
+	// Point PATH to an empty dir with no sybra-cli.
+	t.Setenv("PATH", t.TempDir())
+
+	args := buildCodexHookArgs("task-abc123")
+	if len(args) != 0 {
+		t.Errorf("expected nil when sybra-cli missing; got %v", args)
+	}
+}
+
+func TestBuildCodexHookArgs_CommandContainsTaskID(t *testing.T) {
+	makeFakeSybraCLI(t)
+
+	taskID := "task-xyz789"
+	args := buildCodexHookArgs(taskID)
+
+	// Each hook override value must embed the task ID.
+	for i, arg := range args {
+		if arg == "-c" && i+1 < len(args) {
+			if !strings.Contains(args[i+1], taskID) {
+				t.Errorf("-c value at index %d does not contain taskID %q; value=%q", i+1, taskID, args[i+1])
+			}
+		}
+	}
+}

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -292,6 +292,8 @@ func buildCodexConvoArgs(a *Agent, cfg RunConfig, prompt string) []string {
 	if a.sessionCWD != "" {
 		args = append(args, "-C", a.sessionCWD)
 	}
+	// Lifecycle hooks (fail-open: omitted when sybra-cli unresolvable or taskID unsafe).
+	args = append(args, buildCodexHookArgs(a.TaskID)...)
 	args = append(args, rewriteSkillInvocations(prompt, discoverCodexSkills()))
 	return args
 }

--- a/internal/agent/runner_codex_convo_test.go
+++ b/internal/agent/runner_codex_convo_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"slices"
 	"strings"
 	"testing"
 )
@@ -59,5 +60,74 @@ func TestCodexReasoningArgs(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestBuildCodexConvoArgs_HooksPresent verifies that hook overrides and
+// --dangerously-bypass-hook-trust are injected into per-turn convo args when
+// sybra-cli is on PATH and TaskID is set.
+func TestBuildCodexConvoArgs_HooksPresent(t *testing.T) {
+	makeFakeSybraCLI(t)
+
+	a := &Agent{ID: "a", Provider: "codex", TaskID: "task-abc123"}
+	args := buildCodexConvoArgs(a, RunConfig{}, "hello")
+
+	if !slices.Contains(args, "--dangerously-bypass-hook-trust") {
+		t.Errorf("--dangerously-bypass-hook-trust missing; args=%v", args)
+	}
+	found := false
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "hooks.SessionStart=") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("hooks.SessionStart= override not found; args=%v", args)
+	}
+}
+
+// TestBuildCodexConvoArgs_HooksAbsentWithEmptyTaskID verifies that no hook args
+// appear when TaskID is empty (fail-open invariant).
+func TestBuildCodexConvoArgs_HooksAbsentWithEmptyTaskID(t *testing.T) {
+	makeFakeSybraCLI(t)
+
+	a := &Agent{ID: "a", Provider: "codex"} // TaskID empty
+	args := buildCodexConvoArgs(a, RunConfig{}, "hello")
+
+	for _, arg := range args {
+		if strings.Contains(arg, "hooks.") {
+			t.Errorf("hook override must be absent when TaskID empty; got %q", arg)
+		}
+		if arg == "--dangerously-bypass-hook-trust" {
+			t.Errorf("--dangerously-bypass-hook-trust must be absent when TaskID empty")
+		}
+	}
+}
+
+// TestBuildCodexConvoArgs_HooksBeforePrompt verifies that hook -c args appear
+// before the prompt (last positional argument).
+func TestBuildCodexConvoArgs_HooksBeforePrompt(t *testing.T) {
+	makeFakeSybraCLI(t)
+
+	a := &Agent{ID: "a", Provider: "codex", TaskID: "task-abc123"}
+	const prompt = "do the work"
+	args := buildCodexConvoArgs(a, RunConfig{}, prompt)
+
+	promptIdx := -1
+	for i, arg := range args {
+		if arg == prompt {
+			promptIdx = i
+			break
+		}
+	}
+	if promptIdx < 0 {
+		t.Fatalf("prompt not found in args; args=%v", args)
+	}
+
+	for i, arg := range args {
+		if strings.HasPrefix(arg, "hooks.") && i > promptIdx {
+			t.Errorf("hook override at index %d appears after prompt at index %d; args=%v", i, promptIdx, args)
+		}
 	}
 }

--- a/internal/agent/runner_headless_invocation.go
+++ b/internal/agent/runner_headless_invocation.go
@@ -46,6 +46,8 @@ func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args, env []
 		if cfg.outputSchemaPath != "" {
 			args = append(args, "--output-schema", cfg.outputSchemaPath)
 		}
+		// Lifecycle hooks (fail-open: omitted when sybra-cli unresolvable or taskID unsafe).
+		args = append(args, buildCodexHookArgs(a.TaskID)...)
 		prompt := rewriteSkillInvocations(cfg.Prompt, discoverCodexSkills())
 		args = append(args, prompt)
 		command = "codex " + strings.Join(args, " ")

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -1139,3 +1139,77 @@ func TestCodexSandboxArgs_HeadlessAlwaysBypasses(t *testing.T) {
 		}
 	})
 }
+
+// TestBuildHeadlessInvocation_CodexHooksPresent verifies that when sybra-cli is
+// on PATH and a.TaskID is set, codex headless invocations include hook overrides
+// and --dangerously-bypass-hook-trust.
+func TestBuildHeadlessInvocation_CodexHooksPresent(t *testing.T) {
+	makeFakeSybraCLI(t)
+
+	a := &Agent{ID: "a", Provider: "codex", TaskID: "task-abc123"}
+	_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{Prompt: "do stuff"})
+	if err != nil {
+		t.Fatalf("buildHeadlessInvocation: %v", err)
+	}
+
+	if !slices.Contains(args, "--dangerously-bypass-hook-trust") {
+		t.Errorf("--dangerously-bypass-hook-trust missing from codex args; args=%v", args)
+	}
+
+	found := false
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "hooks.SessionStart=") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("hooks.SessionStart= override not found in codex args; args=%v", args)
+	}
+}
+
+// TestBuildHeadlessInvocation_CodexHooksAbsentWithEmptyTaskID verifies that
+// when TaskID is empty no hook args are injected (fail-open: existing task-less
+// invocations must be byte-for-byte unchanged).
+func TestBuildHeadlessInvocation_CodexHooksAbsentWithEmptyTaskID(t *testing.T) {
+	makeFakeSybraCLI(t)
+
+	a := &Agent{ID: "a", Provider: "codex"} // TaskID empty
+	_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{Prompt: "do stuff"})
+	if err != nil {
+		t.Fatalf("buildHeadlessInvocation: %v", err)
+	}
+
+	for _, arg := range args {
+		if strings.Contains(arg, "hooks.") {
+			t.Errorf("hook override must be absent when TaskID empty; got arg %q", arg)
+		}
+		if arg == "--dangerously-bypass-hook-trust" {
+			t.Errorf("--dangerously-bypass-hook-trust must be absent when TaskID empty")
+		}
+	}
+}
+
+// TestBuildHeadlessInvocation_Claude_NoHooks verifies that Claude and Copilot
+// invocations never receive codex hook args regardless of TaskID.
+func TestBuildHeadlessInvocation_Claude_NoHooks(t *testing.T) {
+	makeFakeSybraCLI(t)
+
+	for _, provider := range []string{"claude", "copilot"} {
+		t.Run(provider, func(t *testing.T) {
+			a := &Agent{ID: "a", Provider: provider, TaskID: "task-abc123"}
+			_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{Prompt: "do stuff"})
+			if err != nil {
+				t.Fatalf("buildHeadlessInvocation: %v", err)
+			}
+			for _, arg := range args {
+				if strings.Contains(arg, "hooks.") {
+					t.Errorf("%s: hook override must be absent; got arg %q", provider, arg)
+				}
+				if arg == "--dangerously-bypass-hook-trust" {
+					t.Errorf("%s: --dangerously-bypass-hook-trust must be absent", provider)
+				}
+			}
+		})
+	}
+}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -59,6 +59,11 @@ const (
 	EventCodexSubagentStart = "codex.subagent.start"
 	EventCodexSubagentStop  = "codex.subagent.stop"
 	EventCodexSessionStop   = "codex.session.stop"
+	// EventCodexHookFailed is written by the sybra-cli hook fast-path when
+	// the receiver encounters an error (payload read, JSON mapping, audit
+	// write). The Data.reason field carries a categorical label — never the
+	// raw error message — so failures are observable without exposing content.
+	EventCodexHookFailed = "codex.hook.failed"
 )
 
 type Event struct {

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -51,6 +51,14 @@ const (
 	// EventAgentPermissionDenied is emitted once per auto-mode classifier denial
 	// observed during a headless claude run. Batched at completion time.
 	EventAgentPermissionDenied = "agent.permission_denied"
+
+	// Codex lifecycle hook events — emitted by the sybra-cli hook fast-path
+	// when codex fires its session/subagent lifecycle hooks. Distinct from the
+	// stream-derived agent.* events to avoid double-counting.
+	EventCodexSessionStart  = "codex.session.start"
+	EventCodexSubagentStart = "codex.subagent.start"
+	EventCodexSubagentStop  = "codex.subagent.stop"
+	EventCodexSessionStop   = "codex.session.stop"
 )
 
 type Event struct {

--- a/internal/audit/concurrent_test.go
+++ b/internal/audit/concurrent_test.go
@@ -1,0 +1,74 @@
+package audit
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestConcurrentAppend_LineIntegrity verifies that simultaneous writes from
+// multiple independent Logger instances (each with their own file handle,
+// simulating separate processes) produce an NDJSON file where every line is
+// valid JSON. This is the structural check that replaces reliance on PIPE_BUF
+// atomicity reasoning for the hook subprocess + app concurrent-write scenario.
+func TestConcurrentAppend_LineIntegrity(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	const goroutines = 8
+	const eventsEach = 50
+
+	var wg sync.WaitGroup
+	for i := range goroutines {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			// Each goroutine creates its own Logger (separate file handle) to
+			// simulate a separate hook subprocess writing concurrently with the app.
+			l, err := NewLogger(dir)
+			if err != nil {
+				t.Errorf("g%d: NewLogger: %v", n, err)
+				return
+			}
+			defer func() { _ = l.Close() }()
+			for j := range eventsEach {
+				if err := l.Log(Event{
+					Type:   EventCodexSessionStart,
+					TaskID: fmt.Sprintf("task-%d-%03d", n, j),
+					Data:   map[string]any{"seq": n*eventsEach + j},
+				}); err != nil {
+					t.Errorf("g%d: Log %d: %v", n, j, err)
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	day := time.Now().UTC().Format(time.DateOnly)
+	raw, err := os.ReadFile(filepath.Join(dir, day+".ndjson"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	lines := bytes.Split(bytes.TrimRight(raw, "\n"), []byte("\n"))
+	corrupt := 0
+	for i, line := range lines {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var e Event
+		if err := json.Unmarshal(line, &e); err != nil {
+			t.Errorf("line %d is not valid JSON (concurrent-write interleave?): %v\nraw: %s", i, err, line)
+			corrupt++
+		}
+	}
+	if corrupt > 0 {
+		t.Fatalf("%d of %d lines are corrupted — audit.Logger needs an interprocess write lock (flock)", corrupt, len(lines))
+	}
+	t.Logf("wrote %d lines from %d goroutines × %d events each — all valid JSON", len(lines), goroutines, eventsEach)
+}

--- a/internal/audit/concurrent_test.go
+++ b/internal/audit/concurrent_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
-	"time"
 )
 
 // TestConcurrentAppend_LineIntegrity verifies that simultaneous writes from
@@ -49,10 +48,25 @@ func TestConcurrentAppend_LineIntegrity(t *testing.T) {
 	}
 	wg.Wait()
 
-	day := time.Now().UTC().Format(time.DateOnly)
-	raw, err := os.ReadFile(filepath.Join(dir, day+".ndjson"))
+	// Read all .ndjson files in the temp dir to avoid time-boundary flake when
+	// the test spans a UTC midnight and goroutines write to two daily log files.
+	entries, err := os.ReadDir(dir)
 	if err != nil {
-		t.Fatalf("ReadFile: %v", err)
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var raw []byte
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) != ".ndjson" {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatalf("ReadFile %s: %v", e.Name(), err)
+		}
+		raw = append(raw, b...)
+	}
+	if len(raw) == 0 {
+		t.Fatal("no .ndjson files written")
 	}
 
 	lines := bytes.Split(bytes.TrimRight(raw, "\n"), []byte("\n"))

--- a/internal/codexhook/hook.go
+++ b/internal/codexhook/hook.go
@@ -34,16 +34,22 @@ var knownEvents = map[string]string{
 }
 
 // Map parses raw JSON hook payload bytes and maps them to an audit.Event for
-// the given taskID. Returns an error for unknown event names or malformed JSON
-// — callers should treat errors as fail-open (exit 0, log to stderr only).
+// the given taskID. expectedEvent is the hook name passed on the command line
+// (e.g. "SessionStart"); it must match the payload's hook_event_name field —
+// a mismatch indicates the wrong hook fired or the payload was corrupted.
+// Returns an error for unknown/mismatched event names or malformed JSON —
+// callers should treat errors as fail-open (exit 0, log to stderr only).
 //
 // The returned Data map carries only structural fields: hook_event_name,
 // session_id, model, subagent_id, kind. The marshaled event line is always
 // well under 4096 bytes with these constraints.
-func Map(raw []byte, taskID string) (audit.Event, error) {
+func Map(raw []byte, taskID, expectedEvent string) (audit.Event, error) {
 	var p Payload
 	if err := json.Unmarshal(raw, &p); err != nil {
 		return audit.Event{}, fmt.Errorf("unmarshal codex hook payload: %w", err)
+	}
+	if p.HookEventName != expectedEvent {
+		return audit.Event{}, fmt.Errorf("hook event mismatch: arg=%q payload=%q", expectedEvent, p.HookEventName)
 	}
 	eventType, ok := knownEvents[p.HookEventName]
 	if !ok {

--- a/internal/codexhook/hook.go
+++ b/internal/codexhook/hook.go
@@ -1,0 +1,75 @@
+// Package codexhook maps the JSON payload that codex pipes on stdin to a hook
+// process into a structural-only audit.Event. It is the single place that
+// defines what data we keep from hook payloads — only session/subagent
+// identifiers and the model name. Sensitive fields (cwd, transcript_path,
+// tool_input, prompts, file paths, command strings) are never extracted.
+package codexhook
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/Automaat/sybra/internal/audit"
+)
+
+// Payload is the subset of fields Sybra reads from the JSON object codex pipes
+// on stdin when a hook fires. Unknown fields are silently ignored.
+type Payload struct {
+	HookEventName string `json:"hook_event_name"`
+	SessionID     string `json:"session_id"`
+	Model         string `json:"model"`
+	SubagentID    string `json:"subagent_id"`
+	Kind          string `json:"kind"`
+	// Deliberately excluded: cwd, transcript_path, tool_input, prompts, file
+	// paths, command strings, snippets — structural-only fields only.
+}
+
+// knownEvents maps the codex hook event name to an audit event type constant.
+var knownEvents = map[string]string{
+	"SessionStart":  audit.EventCodexSessionStart,
+	"SubagentStart": audit.EventCodexSubagentStart,
+	"SubagentStop":  audit.EventCodexSubagentStop,
+	"Stop":          audit.EventCodexSessionStop,
+}
+
+// Map parses raw JSON hook payload bytes and maps them to an audit.Event for
+// the given taskID. Returns an error for unknown event names or malformed JSON
+// — callers should treat errors as fail-open (exit 0, log to stderr only).
+//
+// The returned Data map carries only structural fields: hook_event_name,
+// session_id, model, subagent_id, kind. The marshaled event line is always
+// well under 4096 bytes with these constraints.
+func Map(raw []byte, taskID string) (audit.Event, error) {
+	var p Payload
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return audit.Event{}, fmt.Errorf("unmarshal codex hook payload: %w", err)
+	}
+	eventType, ok := knownEvents[p.HookEventName]
+	if !ok {
+		return audit.Event{}, fmt.Errorf("unknown codex hook event %q", p.HookEventName)
+	}
+
+	data := map[string]any{
+		"hook_event_name": p.HookEventName,
+	}
+	if p.SessionID != "" {
+		data["session_id"] = p.SessionID
+	}
+	if p.Model != "" {
+		data["model"] = p.Model
+	}
+	if p.SubagentID != "" {
+		data["subagent_id"] = p.SubagentID
+	}
+	if p.Kind != "" {
+		data["kind"] = p.Kind
+	}
+
+	return audit.Event{
+		Timestamp: time.Now().UTC(),
+		Type:      eventType,
+		TaskID:    taskID,
+		Data:      data,
+	}, nil
+}

--- a/internal/codexhook/hook_test.go
+++ b/internal/codexhook/hook_test.go
@@ -1,0 +1,141 @@
+package codexhook
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/audit"
+)
+
+func TestMap_SessionStart(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{"hook_event_name":"SessionStart","session_id":"sess-1","model":"gpt-5.5"}`)
+	ev, err := Map(raw, "task-abc123")
+	if err != nil {
+		t.Fatalf("Map: %v", err)
+	}
+	if ev.Type != audit.EventCodexSessionStart {
+		t.Errorf("Type = %q, want %q", ev.Type, audit.EventCodexSessionStart)
+	}
+	if ev.TaskID != "task-abc123" {
+		t.Errorf("TaskID = %q, want task-abc123", ev.TaskID)
+	}
+	if ev.Data["session_id"] != "sess-1" {
+		t.Errorf("session_id = %v", ev.Data["session_id"])
+	}
+	if ev.Data["model"] != "gpt-5.5" {
+		t.Errorf("model = %v", ev.Data["model"])
+	}
+	if ev.Timestamp.IsZero() {
+		t.Error("Timestamp is zero")
+	}
+}
+
+func TestMap_SubagentStart(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{"hook_event_name":"SubagentStart","session_id":"s","subagent_id":"sa-1","kind":"coder","model":"gpt-5.5"}`)
+	ev, err := Map(raw, "task-xyz")
+	if err != nil {
+		t.Fatalf("Map: %v", err)
+	}
+	if ev.Type != audit.EventCodexSubagentStart {
+		t.Errorf("Type = %q, want %q", ev.Type, audit.EventCodexSubagentStart)
+	}
+	if ev.Data["subagent_id"] != "sa-1" {
+		t.Errorf("subagent_id = %v", ev.Data["subagent_id"])
+	}
+	if ev.Data["kind"] != "coder" {
+		t.Errorf("kind = %v", ev.Data["kind"])
+	}
+}
+
+func TestMap_SubagentStop(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{"hook_event_name":"SubagentStop","session_id":"s","subagent_id":"sa-1","kind":"coder"}`)
+	ev, err := Map(raw, "t")
+	if err != nil {
+		t.Fatalf("Map: %v", err)
+	}
+	if ev.Type != audit.EventCodexSubagentStop {
+		t.Errorf("Type = %q", ev.Type)
+	}
+}
+
+func TestMap_Stop(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{"hook_event_name":"Stop","session_id":"s","model":"gpt-5.5"}`)
+	ev, err := Map(raw, "t")
+	if err != nil {
+		t.Fatalf("Map: %v", err)
+	}
+	if ev.Type != audit.EventCodexSessionStop {
+		t.Errorf("Type = %q", ev.Type)
+	}
+}
+
+func TestMap_UnknownEvent(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{"hook_event_name":"PreToolUse","session_id":"s"}`)
+	_, err := Map(raw, "t")
+	if err == nil {
+		t.Fatal("expected error for unknown event")
+	}
+	if !strings.Contains(err.Error(), "PreToolUse") {
+		t.Errorf("error should mention the unknown event name; got %v", err)
+	}
+}
+
+func TestMap_MalformedJSON(t *testing.T) {
+	t.Parallel()
+	_, err := Map([]byte("{not json"), "t")
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+// TestMap_NoForbiddenFields asserts that the returned audit event Data contains
+// only structural-identity fields and never carries sensitive payload content.
+func TestMap_NoForbiddenFields(t *testing.T) {
+	t.Parallel()
+	// Payload with extra fields that must be silently dropped.
+	raw := []byte(`{
+		"hook_event_name": "SessionStart",
+		"session_id": "sess-1",
+		"model": "gpt-5.5",
+		"cwd": "/home/user/secret",
+		"transcript_path": "/tmp/sess.jsonl",
+		"tool_input": {"cmd": "rm -rf /"},
+		"prompt": "secret prompt text",
+		"command": "rm -rf /"
+	}`)
+	ev, err := Map(raw, "task-1")
+	if err != nil {
+		t.Fatalf("Map: %v", err)
+	}
+
+	forbidden := []string{"cwd", "transcript_path", "tool_input", "prompt", "command"}
+	for _, key := range forbidden {
+		if _, ok := ev.Data[key]; ok {
+			t.Errorf("Data must not contain %q; got %v", key, ev.Data)
+		}
+	}
+}
+
+// TestMap_LineSizeUnder4096 asserts that the marshaled audit event from a
+// maximal structural payload stays well under 4096 bytes.
+func TestMap_LineSizeUnder4096(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{"hook_event_name":"SubagentStart","session_id":"sess-aaaaaaaaaaaaaaaaaaaaaaaaa","model":"gpt-5.5-turbo-xxxx","subagent_id":"subagent-bbbbbbbbbbbbbb","kind":"coder-specialist"}`)
+	ev, err := Map(raw, "task-cccccccccccccccccccc")
+	if err != nil {
+		t.Fatalf("Map: %v", err)
+	}
+	line, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if len(line) >= 4096 {
+		t.Errorf("marshaled event is %d bytes, must be < 4096; line=%s", len(line), line)
+	}
+}

--- a/internal/codexhook/hook_test.go
+++ b/internal/codexhook/hook_test.go
@@ -11,7 +11,7 @@ import (
 func TestMap_SessionStart(t *testing.T) {
 	t.Parallel()
 	raw := []byte(`{"hook_event_name":"SessionStart","session_id":"sess-1","model":"gpt-5.5"}`)
-	ev, err := Map(raw, "task-abc123")
+	ev, err := Map(raw, "task-abc123", "SessionStart")
 	if err != nil {
 		t.Fatalf("Map: %v", err)
 	}
@@ -35,7 +35,7 @@ func TestMap_SessionStart(t *testing.T) {
 func TestMap_SubagentStart(t *testing.T) {
 	t.Parallel()
 	raw := []byte(`{"hook_event_name":"SubagentStart","session_id":"s","subagent_id":"sa-1","kind":"coder","model":"gpt-5.5"}`)
-	ev, err := Map(raw, "task-xyz")
+	ev, err := Map(raw, "task-xyz", "SubagentStart")
 	if err != nil {
 		t.Fatalf("Map: %v", err)
 	}
@@ -53,7 +53,7 @@ func TestMap_SubagentStart(t *testing.T) {
 func TestMap_SubagentStop(t *testing.T) {
 	t.Parallel()
 	raw := []byte(`{"hook_event_name":"SubagentStop","session_id":"s","subagent_id":"sa-1","kind":"coder"}`)
-	ev, err := Map(raw, "t")
+	ev, err := Map(raw, "t", "SubagentStop")
 	if err != nil {
 		t.Fatalf("Map: %v", err)
 	}
@@ -65,7 +65,7 @@ func TestMap_SubagentStop(t *testing.T) {
 func TestMap_Stop(t *testing.T) {
 	t.Parallel()
 	raw := []byte(`{"hook_event_name":"Stop","session_id":"s","model":"gpt-5.5"}`)
-	ev, err := Map(raw, "t")
+	ev, err := Map(raw, "t", "Stop")
 	if err != nil {
 		t.Fatalf("Map: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestMap_Stop(t *testing.T) {
 func TestMap_UnknownEvent(t *testing.T) {
 	t.Parallel()
 	raw := []byte(`{"hook_event_name":"PreToolUse","session_id":"s"}`)
-	_, err := Map(raw, "t")
+	_, err := Map(raw, "t", "PreToolUse")
 	if err == nil {
 		t.Fatal("expected error for unknown event")
 	}
@@ -86,9 +86,22 @@ func TestMap_UnknownEvent(t *testing.T) {
 	}
 }
 
+func TestMap_EventMismatch(t *testing.T) {
+	t.Parallel()
+	// Positional event "Stop" but payload says "SessionStart" — must error.
+	raw := []byte(`{"hook_event_name":"SessionStart","session_id":"s-mismatch","model":"m"}`)
+	_, err := Map(raw, "t", "Stop")
+	if err == nil {
+		t.Fatal("expected error for event name mismatch")
+	}
+	if !strings.Contains(err.Error(), "mismatch") {
+		t.Errorf("error should mention mismatch; got %v", err)
+	}
+}
+
 func TestMap_MalformedJSON(t *testing.T) {
 	t.Parallel()
-	_, err := Map([]byte("{not json"), "t")
+	_, err := Map([]byte("{not json"), "t", "SessionStart")
 	if err == nil {
 		t.Fatal("expected error for malformed JSON")
 	}
@@ -109,7 +122,7 @@ func TestMap_NoForbiddenFields(t *testing.T) {
 		"prompt": "secret prompt text",
 		"command": "rm -rf /"
 	}`)
-	ev, err := Map(raw, "task-1")
+	ev, err := Map(raw, "task-1", "SessionStart")
 	if err != nil {
 		t.Fatalf("Map: %v", err)
 	}
@@ -127,7 +140,7 @@ func TestMap_NoForbiddenFields(t *testing.T) {
 func TestMap_LineSizeUnder4096(t *testing.T) {
 	t.Parallel()
 	raw := []byte(`{"hook_event_name":"SubagentStart","session_id":"sess-aaaaaaaaaaaaaaaaaaaaaaaaa","model":"gpt-5.5-turbo-xxxx","subagent_id":"subagent-bbbbbbbbbbbbbb","kind":"coder-specialist"}`)
-	ev, err := Map(raw, "task-cccccccccccccccccccc")
+	ev, err := Map(raw, "task-cccccccccccccccccccc", "SubagentStart")
 	if err != nil {
 		t.Fatalf("Map: %v", err)
 	}


### PR DESCRIPTION
## Motivation

Codex hooks are now production-ready: the plugin-hooks feature flag was removed in 0.134 and hooks are default-enabled since 0.131. Full lifecycle is available — SessionStart, PreToolUse/PostToolUse (blocking, 0.141), SubagentStart/SubagentStop (0.133), thread-idle (0.135) — plus hooks.json profile discovery (0.138) and tightened output schemas (0.136). This ships Sybra's Codex plugin to emit task-lifecycle events into the monitor pipeline, mirroring the Claude side.

Closes https://github.com/Automaat/sybra/issues/1032

## Implementation information

- Wire lifecycle hook receivers into the headless invocation builder (`runner_headless_invocation.go`) for the Codex provider path.
- Add hook telemetry events (`feat(codex): add lifecycle hook telemetry`) surfacing task-lifecycle signals in the monitor/selfmonitor pipeline.
- Validate hook event shape and enforce inclusive 64 KiB stdin bound to match Codex spec.
- Audit hook receiver failures and surface errors without blocking agent dispatch (fail-open on config-load errors).
- The plugin itself is not bundled in this PR — `--dangerously-bypass-hook-trust` is used for headless/server runs that already vet hook sources (verified present on 0.142.2).

> Changelog: feat(codex): plugin with stable lifecycle hooks