### PR TITLE
fix(umbrella): expand umbrellas on manual create

### DIFF
--- a/internal/sybra/services.go
+++ b/internal/sybra/services.go
@@ -1,9 +1,11 @@
 package sybra
 
 import (
+	"context"
 	"maps"
 
 	"github.com/Automaat/sybra/internal/httpapi"
+	"github.com/Automaat/sybra/internal/umbrella"
 )
 
 // wireServices populates the Wails-bound service structs that were pre-allocated
@@ -21,6 +23,13 @@ func (a *App) wireServices(emit func(string, any)) {
 	a.taskSvc.logger = a.logger
 	a.taskSvc.audit = a.audit
 	a.taskSvc.cfg = a.cfg
+	// Expand a manually-added ☂️ umbrella issue into a gated child DAG instead
+	// of a flat task. Wired unconditionally; enrichFromIssue gates the call on
+	// cfg.Umbrella.Enabled so a config reload toggles it without re-wiring.
+	// Mirrors initIssuesFetcher's poll-loop expander (same Expand entry point).
+	a.taskSvc.umbrellaExpand = func(issueURL string) (umbrella.Result, error) {
+		return umbrella.Expand(context.Background(), a.tasks, umbrella.ClaudePlannerRunner(a.cfg.Umbrella.Model), issueURL)
+	}
 	a.planSvc.engine = a.workflowEngine
 	a.planSvc.tasks = a.tasks
 	a.planSvc.agents = a.agents

--- a/internal/sybra/svc_config_reload.go
+++ b/internal/sybra/svc_config_reload.go
@@ -43,6 +43,7 @@ func (s *ConfigService) ReloadFromDisk() (changedHot []string, err error) {
 	s.cfg.Renovate.Author = next.Renovate.Author
 	s.cfg.Providers = next.Providers
 	s.cfg.GitHub = next.GitHub
+	s.cfg.Umbrella = next.Umbrella
 	s.cfg.Triage = next.Triage
 	s.cfg.Monitor = next.Monitor
 	s.cfg.SelfMonitor = next.SelfMonitor

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -64,21 +64,32 @@ func (s *TaskService) GetTask(id string) (task.Task, error) {
 // CreateTask creates a new task and starts a matching workflow.
 // If the title is a GitHub issue URL, fetches real title/body from GitHub.
 func (s *TaskService) CreateTask(title, body, mode string) (task.Task, error) {
-	t, err := s.tasks.Create(title, body, mode)
+	prRepo, prNumber := github.ParsePRURL(title)
+	issueRepo, issueNumber := github.ParseIssueURL(title)
+	isURLStub := prRepo != "" || issueRepo != ""
+
+	// A URL stub is created with the enrich-pending marker so the emit-path
+	// task.created dispatch can't race async enrichment and start a flat
+	// workflow on the un-enriched stub (CreateFull persists the tag before
+	// emitting TaskCreated). Non-URL tasks take the plain create path.
+	var t task.Task
+	var err error
+	if isURLStub {
+		t, err = s.tasks.CreateFull(title, body, mode, task.Update{Tags: task.Ptr([]string{enrichPendingTag})})
+	} else {
+		t, err = s.tasks.Create(title, body, mode)
+	}
 	if err != nil {
 		return t, err
 	}
-	isIssueURL := false
-	// Enrich from GitHub PR URL if title looks like one.
-	if repo, number := github.ParsePRURL(title); repo != "" {
+
+	if prRepo != "" {
 		s.wg.Go(func() {
-			s.enrichFromPR(t.ID, repo, number)
+			s.enrichFromPR(t.ID, prRepo, prNumber)
 		})
-	} else if repo, number := github.ParseIssueURL(title); repo != "" {
-		isIssueURL = true
-		// Enrich from GitHub issue URL if title looks like one.
+	} else if issueRepo != "" {
 		s.wg.Go(func() {
-			s.enrichFromIssue(t.ID, repo, number)
+			s.enrichFromIssue(t.ID, issueRepo, issueNumber)
 		})
 	}
 	if s.audit != nil {
@@ -88,8 +99,9 @@ func (s *TaskService) CreateTask(title, body, mode string) (task.Task, error) {
 			Data:   map[string]any{"title": title, "mode": mode},
 		})
 	}
-	// Match and start a workflow for the new task.
-	if !isIssueURL {
+	// A URL stub is dispatched by its enrich step (after the marker clears);
+	// only plain tasks start their workflow here.
+	if !isURLStub {
 		s.startCreatedWorkflow(t)
 	}
 	return t, nil
@@ -240,11 +252,10 @@ func (s *TaskService) enrichFromPR(taskID, repo string, number int) {
 		Branch:    task.Ptr(pr.HeadRefName),
 		Slug:      task.Ptr(slug),
 	}
-	var labels []string
-	if len(pr.Labels) > 0 {
-		labels = pr.Labels
-		u.Tags = &labels
-	}
+	// Replace tags with the PR's labels (possibly empty), which also clears the
+	// enrich-pending marker set on the URL stub at creation.
+	labels := pr.Labels
+	u.Tags = &labels
 
 	isMyPR := viewer != "" && strings.EqualFold(pr.Author, viewer)
 	if isMyPR {
@@ -352,10 +363,10 @@ func (s *TaskService) enrichFromIssue(taskID, repo string, number int) {
 	if issue.Body != "" {
 		u.Body = task.Ptr(issue.Body)
 	}
-	if len(issue.Labels) > 0 {
-		labels := issue.Labels
-		u.Tags = &labels
-	}
+	// Replace tags with the issue's labels (possibly empty), which also clears
+	// the enrich-pending marker so startCreatedWorkflow below can dispatch.
+	labels := issue.Labels
+	u.Tags = &labels
 	linkedPRs, linkedErr := s.fetchIssueLinkedPRsFunc()(repo, number)
 	if linkedErr != nil {
 		s.logger.Warn("enrich-issue.linked-prs", "task_id", taskID, "repo", repo, "number", number, "err", linkedErr)
@@ -402,7 +413,10 @@ func (s *TaskService) expandUmbrellaStub(taskID, repo string, issue github.Issue
 		return
 	}
 	// Expand created the real tracker + children; the stub is now a duplicate.
-	if delErr := s.tasks.Delete(taskID); delErr != nil {
+	// Use DeleteTask (not the raw store Delete) so any agent/sandbox/worktree
+	// that started on the stub — e.g. if a flat workflow won the create race
+	// before the enrich-pending marker took effect — is torn down, not leaked.
+	if delErr := s.DeleteTask(taskID); delErr != nil {
 		s.logger.Error("enrich-issue.umbrella-stub-delete", "task_id", taskID, "err", delErr)
 		// Cleanup failed: enrich the stub so it is an identifiable,
 		// user-deletable duplicate rather than a raw-URL task with no metadata.
@@ -429,10 +443,10 @@ func (s *TaskService) enrichInertUmbrellaStub(taskID, repo string, issue github.
 	if issue.Body != "" {
 		u.Body = task.Ptr(issue.Body)
 	}
-	if len(issue.Labels) > 0 {
-		labels := issue.Labels
-		u.Tags = &labels
-	}
+	// Replace tags with the issue's labels (possibly empty), preserving them for
+	// identification/routing while clearing the enrich-pending marker.
+	labels := issue.Labels
+	u.Tags = &labels
 	if _, err := s.tasks.Update(taskID, u); err != nil {
 		s.logger.Error("enrich-issue.umbrella-stub-enrich", "task_id", taskID, "err", err)
 	}

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/sandbox"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/umbrella"
 	"github.com/Automaat/sybra/internal/workflow"
 	"github.com/Automaat/sybra/internal/worktree"
 )
@@ -32,6 +33,10 @@ type TaskService struct {
 	fetchIssue          func(repo string, number int) (github.Issue, error)
 	fetchIssueLinkedPRs func(repo string, issueNumber int) ([]github.PullRequest, error)
 	viewerLogin         func() string
+	// umbrellaExpand expands a detected ☂️ umbrella issue into a gated child
+	// DAG instead of a flat task. Wired in wireServices; gated at call time on
+	// cfg.Umbrella.Enabled. nil in tests that don't exercise umbrellas.
+	umbrellaExpand func(issueURL string) (umbrella.Result, error)
 }
 
 // ListTasks returns all tasks from the store, excluding ephemeral chat tasks.
@@ -325,6 +330,18 @@ func (s *TaskService) enrichFromIssue(taskID, repo string, number int) {
 		s.logger.Error("enrich-issue.fetch", "task_id", taskID, "repo", repo, "number", number, "err", err)
 		return
 	}
+
+	// An umbrella issue must not become a flat implementation task. Expand it
+	// into a gated child DAG (the expander builds its own tracker) and drop the
+	// stub. This mirrors the poll fetcher's pass-1 detection so manual "paste
+	// issue URL" creation and background polling converge on identical handling
+	// — previously a manually-added umbrella was triaged and implemented as one
+	// flat task, ignoring its sub-issues entirely.
+	if s.umbrellaExpansionEnabled() && umbrella.IsUmbrellaIssue(issue.Title, issue.Labels) {
+		s.expandUmbrellaStub(taskID, repo, issue)
+		return
+	}
+
 	slug := task.Slugify(issue.Title)
 	u := task.Update{
 		Title:     task.Ptr(issue.Title),
@@ -360,6 +377,44 @@ func (s *TaskService) enrichFromIssue(taskID, repo string, number int) {
 		s.startCreatedWorkflow(updated)
 	}
 	s.logger.Info("enrich-issue.done", "task_id", taskID, "title", issue.Title)
+}
+
+// umbrellaExpansionEnabled reports whether a detected umbrella issue should be
+// auto-expanded on the manual-create path. Read live (not wired-once) so a
+// config reload toggling umbrella.enabled takes effect without re-wiring.
+func (s *TaskService) umbrellaExpansionEnabled() bool {
+	return s.cfg != nil && s.cfg.Umbrella.Enabled && s.umbrellaExpand != nil
+}
+
+// expandUmbrellaStub expands a manually-created stub whose URL resolved to a
+// ☂️ umbrella issue into a gated child DAG, then deletes the stub — the
+// expander creates its own umbrella-typed tracker, so keeping the stub would
+// leave a duplicate flat task for the same issue. On expansion failure the stub
+// is enriched into an identifiable (but inert) task so the user is not left
+// empty-handed and can retry with `sybra-cli umbrella <url>`; crucially no flat
+// workflow is started on a known umbrella, which is the bug this path fixes.
+func (s *TaskService) expandUmbrellaStub(taskID, repo string, issue github.Issue) {
+	res, err := s.umbrellaExpand(issue.URL)
+	if err != nil {
+		s.logger.Error("enrich-issue.umbrella-expand", "task_id", taskID, "issue", issue.URL, "err", err)
+		u := task.Update{
+			Title:     task.Ptr(issue.Title),
+			Issue:     task.Ptr(issue.URL),
+			ProjectID: task.Ptr(repo),
+			Slug:      task.Ptr(task.Slugify(issue.Title)),
+		}
+		if issue.Body != "" {
+			u.Body = task.Ptr(issue.Body)
+		}
+		if _, uerr := s.tasks.Update(taskID, u); uerr != nil {
+			s.logger.Error("enrich-issue.umbrella-fallback", "task_id", taskID, "err", uerr)
+		}
+		return
+	}
+	if err := s.tasks.Delete(taskID); err != nil {
+		s.logger.Error("enrich-issue.umbrella-stub-delete", "task_id", taskID, "err", err)
+	}
+	s.logger.Info("enrich-issue.umbrella-expanded", "issue", issue.URL, "created", res.Created, "stub", taskID)
 }
 
 func (s *TaskService) fetchPRFunc() func(string, int) (github.PullRequest, error) {

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -397,24 +397,45 @@ func (s *TaskService) expandUmbrellaStub(taskID, repo string, issue github.Issue
 	res, err := s.umbrellaExpand(issue.URL)
 	if err != nil {
 		s.logger.Error("enrich-issue.umbrella-expand", "task_id", taskID, "issue", issue.URL, "err", err)
-		u := task.Update{
-			Title:     task.Ptr(issue.Title),
-			Issue:     task.Ptr(issue.URL),
-			ProjectID: task.Ptr(repo),
-			Slug:      task.Ptr(task.Slugify(issue.Title)),
-		}
-		if issue.Body != "" {
-			u.Body = task.Ptr(issue.Body)
-		}
-		if _, uerr := s.tasks.Update(taskID, u); uerr != nil {
-			s.logger.Error("enrich-issue.umbrella-fallback", "task_id", taskID, "err", uerr)
-		}
+		s.enrichInertUmbrellaStub(taskID, repo, issue,
+			"umbrella expansion failed; retry with `sybra-cli umbrella <url>`")
 		return
 	}
-	if err := s.tasks.Delete(taskID); err != nil {
-		s.logger.Error("enrich-issue.umbrella-stub-delete", "task_id", taskID, "err", err)
+	// Expand created the real tracker + children; the stub is now a duplicate.
+	if delErr := s.tasks.Delete(taskID); delErr != nil {
+		s.logger.Error("enrich-issue.umbrella-stub-delete", "task_id", taskID, "err", delErr)
+		// Cleanup failed: enrich the stub so it is an identifiable,
+		// user-deletable duplicate rather than a raw-URL task with no metadata.
+		s.enrichInertUmbrellaStub(taskID, repo, issue,
+			"umbrella expanded to a separate tracker; this duplicate can be deleted")
+		return
 	}
 	s.logger.Info("enrich-issue.umbrella-expanded", "issue", issue.URL, "created", res.Created, "stub", taskID)
+}
+
+// enrichInertUmbrellaStub turns the stub into an identifiable, inert task: real
+// title/body/issue plus the issue's labels as tags (mirroring the normal
+// enrichFromIssue path so tag-driven routing and the UI still recognize it),
+// and a StatusReason explaining why no workflow started. No flat workflow is
+// started — the task is a known umbrella.
+func (s *TaskService) enrichInertUmbrellaStub(taskID, repo string, issue github.Issue, reason string) {
+	u := task.Update{
+		Title:        task.Ptr(issue.Title),
+		Issue:        task.Ptr(issue.URL),
+		ProjectID:    task.Ptr(repo),
+		Slug:         task.Ptr(task.Slugify(issue.Title)),
+		StatusReason: task.Ptr(reason),
+	}
+	if issue.Body != "" {
+		u.Body = task.Ptr(issue.Body)
+	}
+	if len(issue.Labels) > 0 {
+		labels := issue.Labels
+		u.Tags = &labels
+	}
+	if _, err := s.tasks.Update(taskID, u); err != nil {
+		s.logger.Error("enrich-issue.umbrella-stub-enrich", "task_id", taskID, "err", err)
+	}
 }
 
 func (s *TaskService) fetchPRFunc() func(string, int) (github.PullRequest, error) {

--- a/internal/sybra/svc_tasks_test.go
+++ b/internal/sybra/svc_tasks_test.go
@@ -1,11 +1,14 @@
 package sybra
 
 import (
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/umbrella"
 )
 
 func TestTaskService_CreateTask_IssueURLWaitsForEnrichment(t *testing.T) {
@@ -69,6 +72,109 @@ func TestTaskService_CreateTask_IssueURLWaitsForEnrichment(t *testing.T) {
 	}
 	if got.Workflow != nil {
 		t.Fatalf("workflow = %+v, want nil for linked viewer PR", got.Workflow)
+	}
+}
+
+func TestTaskService_CreateTask_UmbrellaIssueExpandsAndDropsStub(t *testing.T) {
+	svc, _ := setupTaskService(t)
+	svc.cfg = &config.Config{Umbrella: config.UmbrellaConfig{Enabled: true}}
+	svc.fetchIssue = func(string, int) (github.Issue, error) {
+		return github.Issue{
+			Number:     1151,
+			Title:      "☂️ Workflow reliability: re-dispatch & PR-linking",
+			URL:        "https://github.com/owner/repo/issues/1151",
+			Repository: "owner/repo",
+		}, nil
+	}
+	// A linked-PR fetch must NOT happen on the umbrella path — fail loudly if it does.
+	svc.fetchIssueLinkedPRs = func(string, int) ([]github.PullRequest, error) {
+		t.Fatal("linked-PR fetch must not run for an umbrella issue")
+		return nil, nil
+	}
+
+	var expandedURL string
+	svc.umbrellaExpand = func(issueURL string) (umbrella.Result, error) {
+		expandedURL = issueURL
+		return umbrella.Result{UmbrellaURL: issueURL, Created: 6}, nil
+	}
+
+	created, err := svc.CreateTask("https://github.com/owner/repo/issues/1151", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.wg.Wait()
+
+	if expandedURL != "https://github.com/owner/repo/issues/1151" {
+		t.Fatalf("expander called with %q, want the umbrella URL", expandedURL)
+	}
+	// The stub must be deleted — the expander created its own tracker.
+	if _, err := svc.GetTask(created.ID); err == nil {
+		t.Fatalf("stub task %s still exists; want it deleted after expansion", created.ID)
+	}
+}
+
+func TestTaskService_CreateTask_UmbrellaExpandFailureKeepsInertStub(t *testing.T) {
+	svc, _ := setupTaskService(t)
+	svc.cfg = &config.Config{Umbrella: config.UmbrellaConfig{Enabled: true}}
+	svc.fetchIssue = func(string, int) (github.Issue, error) {
+		return github.Issue{
+			Number:     1151,
+			Title:      "☂️ broken umbrella",
+			URL:        "https://github.com/owner/repo/issues/1151",
+			Repository: "owner/repo",
+		}, nil
+	}
+	svc.umbrellaExpand = func(string) (umbrella.Result, error) {
+		return umbrella.Result{}, errors.New("planner boom")
+	}
+
+	created, err := svc.CreateTask("https://github.com/owner/repo/issues/1151", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.wg.Wait()
+
+	got, err := svc.GetTask(created.ID)
+	if err != nil {
+		t.Fatalf("stub task should survive a failed expansion: %v", err)
+	}
+	if got.Title != "☂️ broken umbrella" {
+		t.Fatalf("Title = %q, want enriched umbrella title", got.Title)
+	}
+	// No flat workflow may be started on a known umbrella, even when expansion failed.
+	if got.Workflow != nil {
+		t.Fatalf("workflow = %+v, want nil for a failed umbrella expansion", got.Workflow)
+	}
+}
+
+func TestTaskService_CreateTask_UmbrellaDisabledFallsBackToFlat(t *testing.T) {
+	svc, _ := setupTaskService(t)
+	svc.cfg = &config.Config{Umbrella: config.UmbrellaConfig{Enabled: false}}
+	svc.fetchIssue = func(string, int) (github.Issue, error) {
+		return github.Issue{
+			Number:     1151,
+			Title:      "☂️ umbrella but feature off",
+			URL:        "https://github.com/owner/repo/issues/1151",
+			Repository: "owner/repo",
+		}, nil
+	}
+	svc.fetchIssueLinkedPRs = func(string, int) ([]github.PullRequest, error) { return nil, nil }
+	svc.viewerLogin = func() string { return "me" }
+	svc.umbrellaExpand = func(string) (umbrella.Result, error) {
+		t.Fatal("expander must not run when umbrella.enabled is false")
+		return umbrella.Result{}, nil
+	}
+
+	created, err := svc.CreateTask("https://github.com/owner/repo/issues/1151", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.wg.Wait()
+
+	// Disabled → flat enrichment proceeds and a workflow is started.
+	got := waitForWorkflow(t, svc, created.ID)
+	if got.Title != "☂️ umbrella but feature off" {
+		t.Fatalf("Title = %q, want enriched title", got.Title)
 	}
 }
 

--- a/internal/sybra/svc_tasks_test.go
+++ b/internal/sybra/svc_tasks_test.go
@@ -2,6 +2,7 @@ package sybra
 
 import (
 	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -122,6 +123,7 @@ func TestTaskService_CreateTask_UmbrellaExpandFailureKeepsInertStub(t *testing.T
 			Title:      "☂️ broken umbrella",
 			URL:        "https://github.com/owner/repo/issues/1151",
 			Repository: "owner/repo",
+			Labels:     []string{"umbrella", "backend"},
 		}, nil
 	}
 	svc.umbrellaExpand = func(string) (umbrella.Result, error) {
@@ -140,6 +142,15 @@ func TestTaskService_CreateTask_UmbrellaExpandFailureKeepsInertStub(t *testing.T
 	}
 	if got.Title != "☂️ broken umbrella" {
 		t.Fatalf("Title = %q, want enriched umbrella title", got.Title)
+	}
+	// Labels must be preserved so tag-driven routing/UI still identify the
+	// umbrella when the title doesn't start with ☂️.
+	if !slices.Equal(got.Tags, []string{"umbrella", "backend"}) {
+		t.Fatalf("Tags = %v, want [umbrella backend] from the issue labels", got.Tags)
+	}
+	// A StatusReason must explain why no workflow started.
+	if got.StatusReason == "" {
+		t.Fatal("StatusReason is empty, want an explanation for the inert stub")
 	}
 	// No flat workflow may be started on a known umbrella, even when expansion failed.
 	if got.Workflow != nil {

--- a/internal/sybra/svc_tasks_test.go
+++ b/internal/sybra/svc_tasks_test.go
@@ -3,6 +3,7 @@ package sybra
 import (
 	"errors"
 	"slices"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -87,15 +88,18 @@ func TestTaskService_CreateTask_UmbrellaIssueExpandsAndDropsStub(t *testing.T) {
 			Repository: "owner/repo",
 		}, nil
 	}
-	// A linked-PR fetch must NOT happen on the umbrella path — fail loudly if it does.
+	// A linked-PR fetch must NOT happen on the umbrella path. Record the call
+	// from the async enrichment goroutine and assert after wg.Wait() — calling
+	// t.Fatal from a non-test goroutine is unreliable.
+	var linkedPRFetched atomic.Bool
 	svc.fetchIssueLinkedPRs = func(string, int) ([]github.PullRequest, error) {
-		t.Fatal("linked-PR fetch must not run for an umbrella issue")
+		linkedPRFetched.Store(true)
 		return nil, nil
 	}
 
-	var expandedURL string
+	var expandedURL atomic.Value
 	svc.umbrellaExpand = func(issueURL string) (umbrella.Result, error) {
-		expandedURL = issueURL
+		expandedURL.Store(issueURL)
 		return umbrella.Result{UmbrellaURL: issueURL, Created: 6}, nil
 	}
 
@@ -105,8 +109,11 @@ func TestTaskService_CreateTask_UmbrellaIssueExpandsAndDropsStub(t *testing.T) {
 	}
 	svc.wg.Wait()
 
-	if expandedURL != "https://github.com/owner/repo/issues/1151" {
-		t.Fatalf("expander called with %q, want the umbrella URL", expandedURL)
+	if linkedPRFetched.Load() {
+		t.Fatal("linked-PR fetch must not run for an umbrella issue")
+	}
+	if got, _ := expandedURL.Load().(string); got != "https://github.com/owner/repo/issues/1151" {
+		t.Fatalf("expander called with %q, want the umbrella URL", got)
 	}
 	// The stub must be deleted — the expander created its own tracker.
 	if _, err := svc.GetTask(created.ID); err == nil {
@@ -171,8 +178,9 @@ func TestTaskService_CreateTask_UmbrellaDisabledFallsBackToFlat(t *testing.T) {
 	}
 	svc.fetchIssueLinkedPRs = func(string, int) ([]github.PullRequest, error) { return nil, nil }
 	svc.viewerLogin = func() string { return "me" }
+	var expanderCalled atomic.Bool
 	svc.umbrellaExpand = func(string) (umbrella.Result, error) {
-		t.Fatal("expander must not run when umbrella.enabled is false")
+		expanderCalled.Store(true)
 		return umbrella.Result{}, nil
 	}
 
@@ -182,6 +190,9 @@ func TestTaskService_CreateTask_UmbrellaDisabledFallsBackToFlat(t *testing.T) {
 	}
 	svc.wg.Wait()
 
+	if expanderCalled.Load() {
+		t.Fatal("expander must not run when umbrella.enabled is false")
+	}
 	// Disabled → flat enrichment proceeds and a workflow is started.
 	got := waitForWorkflow(t, svc, created.ID)
 	if got.Title != "☂️ umbrella but feature off" {

--- a/internal/sybra/svc_tasks_test.go
+++ b/internal/sybra/svc_tasks_test.go
@@ -189,6 +189,59 @@ func TestTaskService_CreateTask_UmbrellaDisabledFallsBackToFlat(t *testing.T) {
 	}
 }
 
+func TestSkipTaskCreatedWorkflow_EnrichPendingStub(t *testing.T) {
+	t.Parallel()
+	if !skipTaskCreatedWorkflow(task.Task{Tags: []string{enrichPendingTag}}) {
+		t.Fatal("enrich-pending stub must be skipped by the emit-path dispatch")
+	}
+	if skipTaskCreatedWorkflow(task.Task{Tags: []string{"backend"}}) {
+		t.Fatal("an ordinary task must not be skipped")
+	}
+}
+
+func TestTaskService_CreateTask_IssueURLStubMarkedThenCleared(t *testing.T) {
+	svc, _ := setupTaskService(t)
+
+	releaseFetch := make(chan struct{})
+	svc.fetchIssue = func(string, int) (github.Issue, error) {
+		<-releaseFetch
+		return github.Issue{
+			Number:     13,
+			Title:      "plain issue",
+			URL:        "https://github.com/owner/repo/issues/13",
+			Repository: "owner/repo",
+		}, nil
+	}
+	svc.fetchIssueLinkedPRs = func(string, int) ([]github.PullRequest, error) { return nil, nil }
+	svc.viewerLogin = func() string { return "me" }
+
+	created, err := svc.CreateTask("https://github.com/owner/repo/issues/13", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Before enrichment: the stub carries the marker so the emit-path
+	// task.created dispatch skips it (no flat workflow on a raw-URL stub).
+	got, err := svc.GetTask(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(got.Tags, enrichPendingTag) {
+		t.Fatalf("Tags = %v, want enrich-pending marker before enrichment", got.Tags)
+	}
+	if skipTaskCreatedWorkflow(got) != true {
+		t.Fatal("stub must be skipped while enrich-pending")
+	}
+
+	// After enrichment: marker is cleared and the workflow dispatches.
+	close(releaseFetch)
+	svc.wg.Wait()
+	got = waitForWorkflow(t, svc, created.ID)
+	if slices.Contains(got.Tags, enrichPendingTag) {
+		t.Fatalf("Tags = %v, enrich-pending marker should be cleared after enrichment", got.Tags)
+	}
+}
+
 func TestTaskService_CreateTask_IssueURLNoPRStartsWorkflowAfterEnrichment(t *testing.T) {
 	svc, _ := setupTaskService(t)
 	svc.fetchIssue = func(string, int) (github.Issue, error) {

--- a/internal/sybra/workflow_dispatch.go
+++ b/internal/sybra/workflow_dispatch.go
@@ -9,12 +9,27 @@ import (
 const (
 	handoffManualTag = "handoff-manual"
 	handoffPRTag     = "handoff-pr"
+	// enrichPendingTag marks a stub created from a raw GitHub issue/PR URL
+	// whose real title/body/labels are still being fetched asynchronously
+	// (TaskService.enrichFromIssue/enrichFromPR). It is set atomically at
+	// creation so the emit-path task.created dispatch
+	// (maybeStartWorkflowForExternalTask) cannot race enrichment and start a
+	// flat workflow on the un-enriched stub — notably an umbrella that must be
+	// expanded, not implemented. The enrich step clears it and then dispatches.
+	// CLI-created URL tasks use plain Create (no marker), so they keep going
+	// through task.created → triage, which fetches the title itself.
+	enrichPendingTag = "enrich-pending"
 )
 
 func skipTaskCreatedWorkflow(t task.Task) bool {
 	// An umbrella tracker runs no agent — it only rolls up its children — so it
 	// must never trigger the plan/implement pipeline.
 	if t.TaskType == task.TaskTypeUmbrella {
+		return true
+	}
+	// A stub awaiting async enrichment is dispatched by the enrich step, not
+	// the emit path — skip until the real title/labels land.
+	if slices.Contains(t.Tags, enrichPendingTag) {
 		return true
 	}
 	if slices.Contains(t.Tags, handoffManualTag) {


### PR DESCRIPTION
## Motivation

Adding an umbrella issue (☂️) as a task directly in the app silently
failed to expand: the task was triaged and dispatched as one flat
implementation task, ignoring its sub-issues. Root cause: umbrella
auto-expansion was wired **only** into the GitHub issue poll loop
(`poll.IssuesFetcher`). The manual-create path (`CreateTask` →
`enrichFromIssue` → `startCreatedWorkflow`) had no umbrella check, so a
pasted umbrella URL became a flat task and ran `simple-task-implement`.

> Changelog: fix(umbrella): expand umbrellas on manual create

## Implementation information

- `svc_tasks.go` — `enrichFromIssue` now detects `umbrella.IsUmbrellaIssue`
  and routes to `expandUmbrellaStub`, which runs the expander (builds the
  umbrella tracker + gated child DAG) and drops the user stub. On expander
  failure it keeps the stub as an inert, identifiable task and never starts
  a flat workflow on a known umbrella. Gated at call time on
  `cfg.Umbrella.Enabled` so a config reload toggles it without re-wiring.
- `services.go` — wires the expander closure into `TaskService`, mirroring
  `initIssuesFetcher` (same `umbrella.Expand` entry point).
- `svc_config_reload.go` — `Umbrella` config is now copied on hot-reload.
- Tests: expand-and-drop-stub, failure-keeps-inert-stub, and
  disabled-falls-back-to-flat.

## Supporting documentation

Manual-create and poll-loop paths now converge on identical umbrella
handling. Requires `umbrella.enabled: true` in config (already the
documented per-machine toggle).