### PR TITLE
fix(workflow): allow manual re-entry at ready-review

### DIFF
--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -196,6 +196,22 @@ func (a *App) initStatusHook() {
 			if a.humanReview != nil {
 				go a.humanReview.maybeSpawn(taskID, from)
 			}
+		case string(task.StatusReadyReview):
+			if a.workflowEngine != nil {
+				// ErrWorkflowAlreadyActive is benign: when the cascade flips to
+				// ready-review (simple-task-implement ending), this hook fires
+				// while the implement workflow is still active; OnWorkflowComplete
+				// drives the cascade instead. Only real errors are surfaced —
+				// this also enables the manual "move card to Ready Review" path.
+				if _, err := a.workflowEngine.DispatchEvent(
+					taskID,
+					"task.status_changed",
+					map[string]string{"task.status": string(task.StatusReadyReview)},
+					nil,
+				); err != nil && !errors.Is(err, workflow.ErrWorkflowAlreadyActive) {
+					a.logger.Error("workflow.dispatch.ready-review", "task_id", taskID, "err", err)
+				}
+			}
 		case string(task.StatusTesting):
 			if a.workflowEngine != nil {
 				// ErrWorkflowAlreadyActive is benign and the COMMON case: when

--- a/internal/sybra/app_watcher_status_test.go
+++ b/internal/sybra/app_watcher_status_test.go
@@ -2,6 +2,8 @@ package sybra
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -124,5 +126,81 @@ func TestApp_WatcherStatusHook_AdvancesWorkflow(t *testing.T) {
 				return // success — workflow advanced
 			}
 		}
+	}
+}
+
+// TestApp_StatusHook_ReadyReview_DispatchesReviewWorkflow verifies that
+// initStatusHook dispatches simple-task-review when a task is manually
+// moved to ready-review. Before this fix the ready-review case was absent
+// from the switch, so the hook silently no-opped and simple-task-review
+// never ran on manual re-entry.
+func TestApp_StatusHook_ReadyReview_DispatchesReviewWorkflow(t *testing.T) {
+	a := setupApp(t)
+
+	// Build a custom workflow store containing only a lightweight version of
+	// simple-task-review that completes without spawning agents. The real
+	// builtin has run_agent steps that require a live claude binary.
+	wfDir := t.TempDir()
+	wfStore, err := workflow.NewStore(wfDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const testReviewWF = `id: simple-task-review
+name: Test Review
+trigger:
+  on: task.status_changed
+  conditions:
+    - field: task.status
+      operator: equals
+      value: ready-review
+steps:
+  - id: mark_testing
+    name: Hand to Testing
+    type: set_status
+    config:
+      status: testing
+    next:
+      - goto: ""
+`
+	if err := os.WriteFile(filepath.Join(wfDir, "simple-task-review.yaml"), []byte(testReviewWF), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ta := &taskAdapter{tasks: a.tasks}
+	aa := &agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks}
+	a.workflowEngine = workflow.NewEngine(wfStore, ta, aa, a.logger)
+	a.initStatusHook()
+
+	created, err := a.tasks.Create("ready-review dispatch", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Act — move to ready-review, mirroring a manual sybra-cli update.
+	if _, err := a.tasks.UpdateMap(created.ID, map[string]any{
+		"status": string(task.StatusReadyReview),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert — the hook must have dispatched simple-task-review, which runs
+	// synchronously (single set_status step, no agents) and completes before
+	// UpdateMap returns.
+	tk, err := a.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tk.Workflow == nil {
+		t.Fatal("no workflow attached — initStatusHook did not dispatch simple-task-review on ready-review")
+	}
+	if tk.Workflow.WorkflowID != "simple-task-review" {
+		t.Errorf("workflow.id = %q, want simple-task-review", tk.Workflow.WorkflowID)
+	}
+	if tk.Workflow.State != workflow.ExecCompleted {
+		t.Errorf("workflow.state = %q, want ExecCompleted", tk.Workflow.State)
+	}
+	// The test workflow's single step flips status to testing.
+	if tk.Status != task.StatusTesting {
+		t.Errorf("task status = %q, want testing (set_status step in test workflow)", tk.Status)
 	}
 }


### PR DESCRIPTION
## Motivation

Manual `sybra-cli update <id> --status ready-review` silently no-opped — `initStatusHook`'s switch had no `ready-review` case. The `simple-task-review` workflow only ever ran via the internal `OnWorkflowComplete` cascade, making `ready-review` unreachable by hand and violating the CLAUDE.md "every stage must be directly reachable" anti-pattern.

> Changelog: fix(workflow): allow manual re-entry at ready-review

Closes https://github.com/Automaat/sybra/issues/1152

## Implementation information

- Added `ready-review` case to `initStatusHook` in `internal/sybra/app_init.go`, mirroring the existing `testing` case: dispatches `task.status_changed` with `task.status=ready-review`, tolerating `ErrWorkflowAlreadyActive` (the normal cascade path).
- Added unit test in `internal/sybra/app_watcher_status_test.go` that verifies the hook dispatches `simple-task-review` on a manual `ready-review` transition, using a lightweight stub workflow that completes synchronously without spawning agents.