### PR TITLE
fix(reviews): reconcile stale in-review on close

### DIFF
--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -57,6 +57,10 @@ type ReviewHandler struct {
 	// overridable in tests. nil falls back to the github package functions.
 	fetchThreads  func(repo string, number int) ([]github.ReviewThread, error)
 	resolveThread func(threadID string) error
+	// fetchPRStateFn is used by closeFinishedReviewTasks to check whether a
+	// review-task's PR is still open. Overridable in tests; nil falls back to
+	// github.FetchPRState.
+	fetchPRStateFn func(repo string, number int) (github.PRState, error)
 	// viewerLoginFn returns the authenticated GitHub login (the identity the fix
 	// agent posts as), used to tell the agent's own thread replies from a human
 	// collaborator's. Overridable in tests; nil falls back to github.ViewerLogin.
@@ -108,29 +112,36 @@ func (r *ReviewHandler) Poll(_ context.Context) time.Duration {
 }
 
 func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
-	summary, err := github.FetchReviews()
+	// Load tasks up-front so stale review-task reconciliation runs even
+	// when FetchReviews fails (transient errors, rate limits, etc.).
+	tasks, err := r.tasks.List()
 	if err != nil {
-		if github.IsTransientError(err) {
+		return prPollSlow
+	}
+
+	summary, fetchErr := github.FetchReviews()
+	if fetchErr != nil {
+		if github.IsTransientError(fetchErr) {
 			r.transientFetchFails++
 			if r.transientFetchFails < transientFetchWarnThreshold {
-				r.logger.Info("pr-monitor.fetch", "err", err)
+				r.logger.Info("pr-monitor.fetch", "err", fetchErr)
 			} else {
-				r.logger.Warn("pr-monitor.fetch", "err", err, "consecutive", r.transientFetchFails)
+				r.logger.Warn("pr-monitor.fetch", "err", fetchErr, "consecutive", r.transientFetchFails)
 			}
 		} else {
 			r.transientFetchFails = 0
-			r.logger.Warn("pr-monitor.fetch", "err", err)
+			r.logger.Warn("pr-monitor.fetch", "err", fetchErr)
 		}
+		// Reconcile stale review tasks even without a live summary: any
+		// task whose PR FetchPRState confirms as merged/closed is advanced
+		// to done. Passing nil tells DetectClosedTaskPRs to check every
+		// review task directly instead of filtering against an open list.
+		r.closeFinishedReviewTasks(tasks, nil)
 		return prPollSlow
 	}
 	r.transientFetchFails = 0
 
 	r.emit("reviews:updated", summary)
-
-	tasks, err := r.tasks.List()
-	if err != nil {
-		return prPollSlow
-	}
 
 	monitoredPRs := r.monitoredPRs(summary)
 

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -61,6 +61,9 @@ type ReviewHandler struct {
 	// review-task's PR is still open. Overridable in tests; nil falls back to
 	// github.FetchPRState.
 	fetchPRStateFn func(repo string, number int) (github.PRState, error)
+	// fetchReviewsFn fetches the PR review summary. Overridable in tests; nil
+	// falls back to github.FetchReviews.
+	fetchReviewsFn func() (github.ReviewSummary, error)
 	// viewerLoginFn returns the authenticated GitHub login (the identity the fix
 	// agent posts as), used to tell the agent's own thread replies from a human
 	// collaborator's. Overridable in tests; nil falls back to github.ViewerLogin.
@@ -119,7 +122,11 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 		return prPollSlow
 	}
 
-	summary, fetchErr := github.FetchReviews()
+	fetchFn := github.FetchReviews
+	if r.fetchReviewsFn != nil {
+		fetchFn = r.fetchReviewsFn
+	}
+	summary, fetchErr := fetchFn()
 	if fetchErr != nil {
 		if github.IsTransientError(fetchErr) {
 			r.transientFetchFails++
@@ -128,15 +135,14 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 			} else {
 				r.logger.Warn("pr-monitor.fetch", "err", fetchErr, "consecutive", r.transientFetchFails)
 			}
+			// Reconcile stale review tasks on transient failures only. Non-transient
+			// errors (auth, 4xx) mean the per-task FetchPRState calls will also fail
+			// or be wasted, compounding backoff under an already-throttled API.
+			r.closeFinishedReviewTasks(tasks, nil)
 		} else {
 			r.transientFetchFails = 0
 			r.logger.Warn("pr-monitor.fetch", "err", fetchErr)
 		}
-		// Reconcile stale review tasks even without a live summary: any
-		// task whose PR FetchPRState confirms as merged/closed is advanced
-		// to done. Passing nil tells DetectClosedTaskPRs to check every
-		// review task directly instead of filtering against an open list.
-		r.closeFinishedReviewTasks(tasks, nil)
 		return prPollSlow
 	}
 	r.transientFetchFails = 0

--- a/internal/sybra/app_reviews_inbound.go
+++ b/internal/sybra/app_reviews_inbound.go
@@ -448,7 +448,11 @@ func (r *ReviewHandler) closeFinishedReviewTasks(tasks []task.Task, openReviewPR
 	if len(matchers) == 0 {
 		return
 	}
-	closedPRs := github.DetectClosedTaskPRs(openReviewPRs, matchers, github.FetchPRState)
+	fetchFn := github.FetchPRState
+	if r.fetchPRStateFn != nil {
+		fetchFn = r.fetchPRStateFn
+	}
+	closedPRs := github.DetectClosedTaskPRs(openReviewPRs, matchers, fetchFn)
 	for _, c := range closedPRs {
 		if r.agents.HasRunningAgentForTask(c.TaskID) {
 			r.logger.Info("review.closed-skip-running-agent", "task_id", c.TaskID, "pr", c.PRNumber)

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -948,3 +948,74 @@ func TestCloseFinishedReviewTasks(t *testing.T) {
 		})
 	}
 }
+
+// TestPollAndMonitorPRs_FetchErrorReconcile verifies that stale in-review
+// review tasks are reconciled (via FetchPRState) only on transient fetch
+// failures, not on non-transient ones (auth, 4xx) where those calls would
+// compound backoff against an already-throttled API.
+func TestPollAndMonitorPRs_FetchErrorReconcile(t *testing.T) {
+	transientErr := errors.New("dial tcp: connection refused")
+	nonTransientErr := errors.New("gh: authentication required")
+
+	tests := []struct {
+		name          string
+		fetchErr      error
+		wantReconcile bool // whether fetchPRStateFn should be called
+	}{
+		{
+			name:          "transient error — reconciliation runs",
+			fetchErr:      transientErr,
+			wantReconcile: true,
+		},
+		{
+			name:          "non-transient error — reconciliation skipped",
+			fetchErr:      nonTransientErr,
+			wantReconcile: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			tasks := task.NewManager(store, nil)
+
+			created, err := tasks.Create("Review: stale PR", "", string(task.AgentModeHeadless))
+			if err != nil {
+				t.Fatal(err)
+			}
+			tags := []string{"review"}
+			if _, err := tasks.Update(created.ID, task.Update{
+				Status:    task.Ptr(task.StatusInReview),
+				Tags:      &tags,
+				ProjectID: task.Ptr("o/r"),
+				PRNumber:  task.Ptr(99),
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			reconcileCalled := false
+			agentMgr := agent.NewManager(t.Context(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
+			r := &ReviewHandler{
+				DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler), emit: func(string, any) {}},
+				tasks:         tasks,
+				agents:        agentMgr,
+				fetchReviewsFn: func() (github.ReviewSummary, error) {
+					return github.ReviewSummary{}, tt.fetchErr
+				},
+				fetchPRStateFn: func(repo string, number int) (github.PRState, error) {
+					reconcileCalled = true
+					return github.PRState{State: "MERGED"}, nil
+				},
+			}
+
+			r.pollAndMonitorPRs()
+
+			if reconcileCalled != tt.wantReconcile {
+				t.Errorf("reconcileCalled = %v, want %v", reconcileCalled, tt.wantReconcile)
+			}
+		})
+	}
+}

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -1,6 +1,7 @@
 package sybra
 
 import (
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -820,6 +821,129 @@ func TestHasReviewTask_ScopedByProject(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := r.hasReviewTask(existing, tt.projectID, tt.prNumber); got != tt.want {
 				t.Errorf("hasReviewTask(%q, %d) = %v, want %v", tt.projectID, tt.prNumber, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCloseFinishedReviewTasks verifies that review tasks whose linked PR is
+// merged or closed are advanced to done, and tasks with open or
+// inaccessible PRs are left untouched.
+//
+// Regression: before this fix, closeFinishedReviewTasks was only called when
+// FetchReviews() succeeded. A transient summary-fetch failure left any
+// in-review review task stranded indefinitely.
+func TestCloseFinishedReviewTasks(t *testing.T) {
+	tests := []struct {
+		name       string
+		taskStatus task.Status
+		prState    string
+		fetchErr   error
+		// openPRs lists PRs already known to be open (nil = check all tasks
+		// directly, which is what happens on the FetchReviews failure path).
+		openPRs    []github.PullRequest
+		wantStatus task.Status
+	}{
+		{
+			name:       "merged PR — task advances to done",
+			taskStatus: task.StatusInReview,
+			prState:    "MERGED",
+			wantStatus: task.StatusDone,
+		},
+		{
+			name:       "closed PR — task advances to done",
+			taskStatus: task.StatusInReview,
+			prState:    "CLOSED",
+			wantStatus: task.StatusDone,
+		},
+		{
+			name:       "open PR — task stays in-review",
+			taskStatus: task.StatusInReview,
+			prState:    "OPEN",
+			wantStatus: task.StatusInReview,
+		},
+		{
+			// PR still in the open-PR summary (e.g. GitHub search lag): the
+			// function must not re-check it via FetchPRState.
+			name:       "PR present in open list — suppressed, stays in-review",
+			taskStatus: task.StatusInReview,
+			prState:    "MERGED", // fetchPRStateFn would return MERGED, but must not be called
+			openPRs:    []github.PullRequest{{Number: 42, Repository: "o/r"}},
+			wantStatus: task.StatusInReview,
+		},
+		{
+			// human-required tasks are eligible too (small PR punted to human).
+			name:       "human-required review task with merged PR — advances to done",
+			taskStatus: task.StatusHumanRequired,
+			prState:    "MERGED",
+			wantStatus: task.StatusDone,
+		},
+		{
+			// FetchPRState fails transiently; task must be left untouched.
+			name:       "fetch error — task stays in-review",
+			taskStatus: task.StatusInReview,
+			fetchErr:   errors.New("network error"),
+			wantStatus: task.StatusInReview,
+		},
+		{
+			// Nil open list replicates the FetchReviews-failure path: every
+			// review task's PR is queried directly, so a merged PR is still caught.
+			name:       "nil open list (FetchReviews failure path) — merged PR caught",
+			taskStatus: task.StatusInReview,
+			prState:    "MERGED",
+			openPRs:    nil,
+			wantStatus: task.StatusDone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			tasks := task.NewManager(store, nil)
+
+			created, err := tasks.Create("Review: some PR", "", string(task.AgentModeHeadless))
+			if err != nil {
+				t.Fatal(err)
+			}
+			tags := []string{"review"}
+			if _, err := tasks.Update(created.ID, task.Update{
+				Status:    task.Ptr(tt.taskStatus),
+				Tags:      &tags,
+				ProjectID: task.Ptr("o/r"),
+				PRNumber:  task.Ptr(42),
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			agentMgr := agent.NewManager(t.Context(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
+
+			r := &ReviewHandler{
+				DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
+				tasks:         tasks,
+				agents:        agentMgr,
+				fetchPRStateFn: func(repo string, number int) (github.PRState, error) {
+					if tt.fetchErr != nil {
+						return github.PRState{}, tt.fetchErr
+					}
+					return github.PRState{State: tt.prState}, nil
+				},
+			}
+
+			all, err := tasks.List()
+			if err != nil {
+				t.Fatal(err)
+			}
+			r.closeFinishedReviewTasks(all, tt.openPRs)
+
+			got, err := tasks.Get(created.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Status != tt.wantStatus {
+				t.Errorf("status = %q, want %q", got.Status, tt.wantStatus)
 			}
 		})
 	}


### PR DESCRIPTION
## Motivation

Review tasks could get stranded in the `in-review` status indefinitely after their PR merged or closed. The root cause: `closeFinishedReviewTasks` was only called when `FetchReviews()` succeeded. During transient GitHub API failures the poll loop returned early, skipping reconciliation entirely — leaving those tasks stuck until the next successful poll that happened to return the same PRs.

Closes https://github.com/Automaat/sybra/issues/1156

> Changelog: fix(reviews): reconcile stale in-review on close

## Implementation information

- Moved task loading before the `FetchReviews()` guard in `app_reviews.go`
- In the failure path, call `closeFinishedReviewTasks(tasks, nil)` — `nil` open-PR list signals `DetectClosedTaskPRs` to query each review task directly via `FetchPRState` instead of filtering against a (missing) open-PR list
- Added `fetchPRStateFn` injectable field to `ReviewHandler` so the reconcile path is testable without a live `gh` CLI
- Added `TestCloseFinishedReviewTasks` covering: merged, closed, open, suppressed, human-required, fetch-error, and nil-open-list cases