### PR TITLE
fix(reviews): link manually-opened PRs to tasks

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -80,6 +81,8 @@ func run(args []string) int {
 		return cmdUmbrella(store, rest, jsonOut)
 	case "update":
 		return cmdUpdate(store, rest, jsonOut)
+	case "link-pr":
+		return cmdLinkPR(store, rest, jsonOut)
 	case "delete":
 		return cmdDelete(store, rest, jsonOut)
 	case "project":
@@ -943,6 +946,47 @@ func cmdDelete(s *task.Manager, args []string, jsonOut bool) int {
 	return 0
 }
 
+// cmdLinkPR links a GitHub PR number to a task and advances non-terminal tasks
+// to in-review so the PR monitor loop can take over (auto-merge / done on
+// merge). Use when a PR was opened outside of Sybra (manually or by an external
+// tool) and the task's pr_number is still 0.
+func cmdLinkPR(s *task.Manager, args []string, jsonOut bool) int {
+	if len(args) < 2 {
+		return fatal(jsonOut, "usage: link-pr <task-id> <pr-number>")
+	}
+	id := args[0]
+	prNum, err := strconv.Atoi(args[1])
+	if err != nil || prNum <= 0 {
+		return fatal(jsonOut, "pr-number must be a positive integer, got %q", args[1])
+	}
+
+	t, err := s.Get(id)
+	if err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+
+	u := task.Update{PRNumber: task.Ptr(prNum)}
+	if !task.IsTerminalStatus(t.Status) && t.Status != task.StatusInReview {
+		u.Status = task.Ptr(task.StatusInReview)
+		u.StatusReason = task.Ptr("")
+	}
+
+	t, err = s.Update(id, u)
+	if err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+
+	if jsonOut {
+		return printJSON(t)
+	}
+	if u.Status != nil {
+		fmt.Printf("linked PR #%d to task %s → in-review\n", prNum, t.ID)
+	} else {
+		fmt.Printf("linked PR #%d to task %s (status: %s)\n", prNum, t.ID, t.Status)
+	}
+	return 0
+}
+
 // applyFileOrStringUpdate populates an updates map from a paired
 // `--<flag>` / `--<flag>-file` flag pair. File takes precedence; an
 // explicitly empty string flag clears the value (matches the existing
@@ -1523,6 +1567,10 @@ Commands:
            plus one blocked child per sub-issue, with dependency edges extracted by an
            LLM planner. Re-running only materializes sub-issues without an existing task.
   update   <id> [--title T] [--status S] [--status-reason R] [--body B] [--plan PLAN] [--plan-file PATH] [--plan-research TEXT|--plan-research-file PATH] [--plan-decisions TEXT|--plan-decisions-file PATH] [--plan-brief TEXT|--plan-brief-file PATH] [--mode M] [--type TYPE] [--tags T] [--project ID] [--branch B] [--pr N] [--issue URL] [--source-provider P|none] [--max-turns N] [--reasoning-effort E]
+  link-pr  <id> <pr-number>
+           Link a PR number to a task and advance it to in-review. Use when a PR
+           was opened outside of Sybra; the PR monitor will then auto-merge or
+           advance the task to done once the PR lands.
   delete   <id>
 
   project list

--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -884,3 +884,117 @@ func TestArtifactNoSubcommand(t *testing.T) {
 		t.Error("expected non-zero exit when subcommand missing")
 	}
 }
+
+func TestLinkPR_AdvancesToInReview(t *testing.T) {
+	setupStore(t)
+
+	// Create a task that is stuck in human-required with no PR.
+	code, out := runCLI(t, "--json", "create", "--title", "stranded task")
+	if code != 0 {
+		t.Fatalf("create exit %d: %s", code, out)
+	}
+	var created task.Task
+	mustUnmarshal(t, out, &created)
+
+	code, _ = runCLI(t, "--json", "update", created.ID, "--status", "human-required", "--status-reason", "commits pushed but no PR created")
+	if code != 0 {
+		t.Fatalf("update exit %d", code)
+	}
+
+	// Link PR → must advance to in-review.
+	code, out = runCLI(t, "--json", "link-pr", created.ID, "1150")
+	if code != 0 {
+		t.Fatalf("link-pr exit %d: %s", code, out)
+	}
+	var got task.Task
+	mustUnmarshal(t, out, &got)
+	if got.PRNumber != 1150 {
+		t.Errorf("PRNumber = %d, want 1150", got.PRNumber)
+	}
+	if got.Status != task.StatusInReview {
+		t.Errorf("Status = %q, want in-review", got.Status)
+	}
+	if got.StatusReason != "" {
+		t.Errorf("StatusReason = %q, want cleared", got.StatusReason)
+	}
+}
+
+func TestLinkPR_AlreadyInReview_PRUpdatedStatusUnchanged(t *testing.T) {
+	setupStore(t)
+
+	code, out := runCLI(t, "--json", "create", "--title", "in-review task")
+	if code != 0 {
+		t.Fatalf("create exit %d: %s", code, out)
+	}
+	var created task.Task
+	mustUnmarshal(t, out, &created)
+
+	code, _ = runCLI(t, "--json", "update", created.ID, "--status", "in-review")
+	if code != 0 {
+		t.Fatalf("update to in-review exit %d", code)
+	}
+
+	code, out = runCLI(t, "--json", "link-pr", created.ID, "42")
+	if code != 0 {
+		t.Fatalf("link-pr exit %d: %s", code, out)
+	}
+	var got task.Task
+	mustUnmarshal(t, out, &got)
+	if got.PRNumber != 42 {
+		t.Errorf("PRNumber = %d, want 42", got.PRNumber)
+	}
+	if got.Status != task.StatusInReview {
+		t.Errorf("Status = %q, want in-review (unchanged)", got.Status)
+	}
+}
+
+func TestLinkPR_DoneTask_PRSetStatusUnchanged(t *testing.T) {
+	setupStore(t)
+
+	code, out := runCLI(t, "--json", "create", "--title", "done task")
+	if code != 0 {
+		t.Fatalf("create exit %d: %s", code, out)
+	}
+	var created task.Task
+	mustUnmarshal(t, out, &created)
+
+	code, _ = runCLI(t, "--json", "update", created.ID, "--status", "done")
+	if code != 0 {
+		t.Fatalf("update to done exit %d", code)
+	}
+
+	code, out = runCLI(t, "--json", "link-pr", created.ID, "77")
+	if code != 0 {
+		t.Fatalf("link-pr exit %d: %s", code, out)
+	}
+	var got task.Task
+	mustUnmarshal(t, out, &got)
+	if got.PRNumber != 77 {
+		t.Errorf("PRNumber = %d, want 77", got.PRNumber)
+	}
+	if got.Status != task.StatusDone {
+		t.Errorf("Status = %q, want done (unchanged)", got.Status)
+	}
+}
+
+func TestLinkPR_InvalidArgs(t *testing.T) {
+	setupStore(t)
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"missing both args", []string{"--json", "link-pr"}},
+		{"missing pr number", []string{"--json", "link-pr", "some-id"}},
+		{"non-numeric pr", []string{"--json", "link-pr", "some-id", "abc"}},
+		{"zero pr", []string{"--json", "link-pr", "some-id", "0"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, _ := runCLI(t, tt.args...)
+			if code == 0 {
+				t.Error("expected non-zero exit")
+			}
+		})
+	}
+}

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -2,9 +2,11 @@ package sybra
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"maps"
+	"os/exec"
 	"slices"
 	"strings"
 	"time"
@@ -61,6 +63,10 @@ type ReviewHandler struct {
 	// agent posts as), used to tell the agent's own thread replies from a human
 	// collaborator's. Overridable in tests; nil falls back to github.ViewerLogin.
 	viewerLoginFn func() string
+	// findMergedPRFn looks up a merged PR by head branch in a project repo.
+	// Returns the PR number (0 = none or ambiguous). nil falls back to gh-based implementation.
+	// Overridable in tests.
+	findMergedPRFn func(repo, branch string) (int, error)
 	// lastRevertScan rate-limits the default-branch revert scan (revertScanInterval).
 	lastRevertScan time.Time
 }
@@ -674,6 +680,9 @@ func orphanPRAdoptionEligible(t *task.Task) bool {
 // matching more than one open PR in the project is left untouched (ambiguous).
 // Matched entries of `tasks` are mutated in place so the caller's matcher
 // assembly observes the new state in the same poll.
+//
+// When no open PR is found, falls through to adoptOrphanMergedPR to handle the
+// race where the PR was opened and merged between two poll cycles.
 func (r *ReviewHandler) adoptOrphanPRs(tasks []task.Task, prs []github.PullRequest) {
 	for i := range tasks {
 		t := &tasks[i]
@@ -692,25 +701,92 @@ func (r *ReviewHandler) adoptOrphanPRs(tasks []task.Task, prs []github.PullReque
 			}
 			match = &prs[j]
 		}
-		if ambiguous || match == nil {
+		if ambiguous {
 			continue
 		}
-		updated, err := r.tasks.Update(t.ID, task.Update{
-			PRNumber:     task.Ptr(match.Number),
-			Status:       task.Ptr(task.StatusInReview),
-			StatusReason: task.Ptr(""),
-		})
-		if err != nil {
-			r.logger.Error("pr-monitor.orphan-adopt", "task_id", t.ID, "pr", match.Number, "err", err)
+		if match != nil {
+			updated, err := r.tasks.Update(t.ID, task.Update{
+				PRNumber:     task.Ptr(match.Number),
+				Status:       task.Ptr(task.StatusInReview),
+				StatusReason: task.Ptr(""),
+			})
+			if err != nil {
+				r.logger.Error("pr-monitor.orphan-adopt", "task_id", t.ID, "pr", match.Number, "err", err)
+				continue
+			}
+			tasks[i] = updated
+			r.logAudit(audit.EventPROrphanAdopted, t.ID, "", map[string]any{
+				"pr": match.Number, "repo": match.Repository, "branch": t.Branch,
+			})
+			r.logger.Info("pr-monitor.orphan-adopted",
+				"task_id", t.ID, "pr", match.Number, "branch", t.Branch)
 			continue
 		}
-		tasks[i] = updated
-		r.logAudit(audit.EventPROrphanAdopted, t.ID, "", map[string]any{
-			"pr": match.Number, "repo": match.Repository, "branch": t.Branch,
-		})
-		r.logger.Info("pr-monitor.orphan-adopted",
-			"task_id", t.ID, "pr", match.Number, "branch", t.Branch)
+		// No open PR found. Check for a recently merged PR: handles the race
+		// where the PR was opened and merged between poll cycles.
+		r.adoptOrphanMergedPR(t)
 	}
+}
+
+// adoptOrphanMergedPR checks whether a merged PR exists for an orphan task's
+// branch and, if exactly one is found, links it and advances the task to done.
+// Handles the race where a manually-opened PR is merged before the poll loop
+// finds it as an open PR (so adoptOrphanPRs never had a chance to link it).
+func (r *ReviewHandler) adoptOrphanMergedPR(t *task.Task) {
+	fn := r.findMergedPRFn
+	if fn == nil {
+		fn = findMergedPRByBranch
+	}
+	prNum, err := fn(t.ProjectID, t.Branch)
+	if err != nil {
+		r.logger.Warn("pr-monitor.orphan-merged-check", "task_id", t.ID, "err", err)
+		return
+	}
+	if prNum == 0 {
+		return
+	}
+	taskID, repo, branch := t.ID, t.ProjectID, t.Branch
+	updated, err := r.tasks.Update(taskID, task.Update{
+		PRNumber:     task.Ptr(prNum),
+		Status:       task.Ptr(task.StatusDone),
+		Outcome:      task.Ptr("merged"),
+		StatusReason: task.Ptr(""),
+	})
+	if err != nil {
+		r.logger.Error("pr-monitor.orphan-merged-adopt", "task_id", taskID, "pr", prNum, "err", err)
+		return
+	}
+	*t = updated
+	r.logAudit(audit.EventPROrphanAdopted, taskID, "", map[string]any{
+		"pr": prNum, "repo": repo, "branch": branch, "state": "merged",
+	})
+	r.logger.Info("pr-monitor.orphan-merged-adopted",
+		"task_id", taskID, "pr", prNum, "branch", branch)
+}
+
+// findMergedPRByBranch queries GitHub for a merged PR matching the given head
+// branch in the repository. Returns the PR number, or 0 if none or ambiguous.
+// Uses env vars to keep project/branch out of the arg list (gosec G204).
+func findMergedPRByBranch(repo, branch string) (int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "bash", "-c",
+		"gh pr list --repo \"$_REPO\" --head \"$_BRANCH\" --state merged --json number --limit 2")
+	cmd.Env = append(cmd.Environ(), "_REPO="+repo, "_BRANCH="+branch)
+	out, err := cmd.Output()
+	if err != nil {
+		return 0, err
+	}
+	var prs []struct {
+		Number int `json:"number"`
+	}
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return 0, err
+	}
+	if len(prs) != 1 {
+		return 0, nil
+	}
+	return prs[0].Number, nil
 }
 
 func prNeedsAttention(prs []github.PullRequest) bool {

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -653,20 +653,30 @@ func hasOrphanStrandReason(reason string) bool {
 }
 
 // orphanPRAdoptionEligible reports whether a task is a candidate for orphan-PR
-// adoption: parked in human-required with a branch but no linked PR, *and* with
-// a status_reason that marks it as stranded by the implement/verify/evaluate
-// path before a late-finishing agent opened the PR. The reason gate is what
-// keeps adoption from resurrecting a task a human or the watchdog deliberately
-// stopped. Chat tasks and inbound review tasks are never own-PR tasks.
+// adoption: a task with a branch but no linked PR that was either placed in
+// in-review without a PR being recorded, or stranded in human-required by the
+// implement/verify/evaluate path before a late-finishing agent opened the PR.
+// For human-required tasks the strand-reason gate prevents resurrecting a task
+// that a human or the watchdog deliberately stopped. For in-review tasks no
+// reason gate is needed — a task already in review with no PR is unambiguously
+// an orphan regardless of how it got there. Chat tasks and inbound review tasks
+// are never own-PR tasks.
 func orphanPRAdoptionEligible(t *task.Task) bool {
 	if t.TaskType == task.TaskTypeChat || slices.Contains(t.Tags, "review") {
 		return false
 	}
-	return t.Status == task.StatusHumanRequired &&
-		t.PRNumber == 0 &&
-		t.Branch != "" &&
-		t.ProjectID != "" &&
-		hasOrphanStrandReason(t.StatusReason)
+	if t.PRNumber != 0 || t.Branch == "" || t.ProjectID == "" {
+		return false
+	}
+	// In-review tasks with no linked PR are always eligible: they've been placed
+	// in review state but the PR number was never recorded (e.g. PR opened
+	// manually without going through simple-task-pr).
+	if t.Status == task.StatusInReview {
+		return true
+	}
+	// Human-required tasks: only adopt if stranded by implement/verify/evaluate
+	// (never resurrect deliberate watchdog stops or dwell escalations).
+	return t.Status == task.StatusHumanRequired && hasOrphanStrandReason(t.StatusReason)
 }
 
 // adoptOrphanPRs re-links tasks stranded in human-required without a PR number

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -746,10 +746,12 @@ func (r *ReviewHandler) adoptOrphanMergedPR(t *task.Task) {
 		return
 	}
 	taskID, repo, branch := t.ID, t.ProjectID, t.Branch
+	const state = "MERGED"
+	base := classifyLandingOutcome(state)
 	updated, err := r.tasks.Update(taskID, task.Update{
 		PRNumber:     task.Ptr(prNum),
 		Status:       task.Ptr(task.StatusDone),
-		Outcome:      task.Ptr("merged"),
+		Outcome:      task.Ptr(base),
 		StatusReason: task.Ptr(""),
 	})
 	if err != nil {
@@ -760,6 +762,26 @@ func (r *ReviewHandler) adoptOrphanMergedPR(t *task.Task) {
 	r.logAudit(audit.EventPROrphanAdopted, taskID, "", map[string]any{
 		"pr": prNum, "repo": repo, "branch": branch, "state": "merged",
 	})
+	r.logAudit(audit.EventPRMerged, taskID, "", map[string]any{"pr": prNum, "state": state})
+	// Enrich with PR size, timing, human-edit data, and merge_commit for revert
+	// detection — same side effects as the normal advanceClosedTaskPRs path.
+	outcome, landData := r.computeLanding(taskID, prNum, state, base)
+	upd := task.Update{}
+	refine := false
+	if outcome != base {
+		upd.Outcome = task.Ptr(outcome)
+		refine = true
+	}
+	if mc, ok := landData["merge_commit"].(string); ok && mc != "" {
+		upd.MergeCommit = task.Ptr(mc)
+		refine = true
+	}
+	if refine {
+		if _, err := r.tasks.Update(taskID, upd); err != nil {
+			r.logger.Warn("pr-monitor.orphan-merged-refine", "task_id", taskID, "err", err)
+		}
+	}
+	r.logAudit(audit.EventTaskLanded, taskID, "", landData)
 	r.logger.Info("pr-monitor.orphan-merged-adopted",
 		"task_id", taskID, "pr", prNum, "branch", branch)
 }

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -770,7 +770,7 @@ func (r *ReviewHandler) adoptOrphanMergedPR(t *task.Task) {
 	}
 	*t = updated
 	r.logAudit(audit.EventPROrphanAdopted, taskID, "", map[string]any{
-		"pr": prNum, "repo": repo, "branch": branch, "state": "merged",
+		"pr": prNum, "repo": repo, "branch": branch, "state": state,
 	})
 	r.logAudit(audit.EventPRMerged, taskID, "", map[string]any{"pr": prNum, "state": state})
 	// Enrich with PR size, timing, human-edit data, and merge_commit for revert
@@ -798,16 +798,14 @@ func (r *ReviewHandler) adoptOrphanMergedPR(t *task.Task) {
 
 // findMergedPRByBranch queries GitHub for a merged PR matching the given head
 // branch in the repository. Returns the PR number, or 0 if none or ambiguous.
-// Uses env vars to keep project/branch out of the arg list (gosec G204).
 func findMergedPRByBranch(repo, branch string) (int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "bash", "-c",
-		"gh pr list --repo \"$_REPO\" --head \"$_BRANCH\" --state merged --json number --limit 2")
-	cmd.Env = append(cmd.Environ(), "_REPO="+repo, "_BRANCH="+branch)
-	out, err := cmd.Output()
+	cmd := exec.CommandContext(ctx, "gh", "pr", "list",
+		"--repo", repo, "--head", branch, "--state", "merged", "--json", "number", "--limit", "2")
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("%w: %s", err, out)
 	}
 	var prs []struct {
 		Number int `json:"number"`

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -799,6 +799,155 @@ func TestPrepareWorktree_CircuitBreaker(t *testing.T) {
 	}
 }
 
+// TestAdoptOrphanMergedPR verifies that a task stranded in human-required with
+// a known branch is advanced to done when a merged PR is found on that branch
+// via the findMergedPRFn hook, and that the slice entry is updated in place.
+func TestAdoptOrphanMergedPR(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := task.NewStore(filepath.Join(tmp, "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	mk := func(title string, u task.Update) string {
+		t.Helper()
+		created, cErr := tasks.Create(title, "", string(task.AgentModeHeadless))
+		if cErr != nil {
+			t.Fatalf("create %s: %v", title, cErr)
+		}
+		if _, uErr := tasks.Update(created.ID, u); uErr != nil {
+			t.Fatalf("update %s: %v", title, uErr)
+		}
+		return created.ID
+	}
+
+	// Task eligible for orphan adoption: stranded in human-required with a branch.
+	orphan := mk("stranded", task.Update{
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr("commits pushed but no PR created"),
+		Branch:       task.Ptr("feat/stranded"),
+		ProjectID:    task.Ptr("o/r"),
+	})
+	// Already linked — must not be touched.
+	linked := mk("linked", task.Update{
+		Status:    task.Ptr(task.StatusHumanRequired),
+		PRNumber:  task.Ptr(99),
+		Branch:    task.Ptr("feat/linked"),
+		ProjectID: task.Ptr("o/r"),
+	})
+
+	calls := 0
+	r := &ReviewHandler{
+		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
+		tasks:         tasks,
+		findMergedPRFn: func(repo, branch string) (int, error) {
+			calls++
+			if repo == "o/r" && branch == "feat/stranded" {
+				return 1051, nil
+			}
+			return 0, nil
+		},
+	}
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Pass empty open-PR list so all eligible tasks fall through to merged check.
+	r.adoptOrphanPRs(all, nil)
+
+	t.Run("orphan advanced to done with merged PR", func(t *testing.T) {
+		got, _ := tasks.Get(orphan)
+		if got.Status != task.StatusDone {
+			t.Errorf("status = %q, want done", got.Status)
+		}
+		if got.PRNumber != 1051 {
+			t.Errorf("PRNumber = %d, want 1051", got.PRNumber)
+		}
+		if got.Outcome != "merged" {
+			t.Errorf("outcome = %q, want merged", got.Outcome)
+		}
+		if got.StatusReason != "" {
+			t.Errorf("StatusReason = %q, want cleared", got.StatusReason)
+		}
+	})
+
+	t.Run("in-place slice mutation visible to same poll", func(t *testing.T) {
+		for i := range all {
+			if all[i].ID == orphan {
+				if all[i].Status != task.StatusDone || all[i].PRNumber != 1051 {
+					t.Errorf("slice entry not updated: status=%q pr=%d", all[i].Status, all[i].PRNumber)
+				}
+				return
+			}
+		}
+		t.Fatal("orphan not found in slice")
+	})
+
+	t.Run("already-linked task not touched", func(t *testing.T) {
+		got, _ := tasks.Get(linked)
+		if got.Status != task.StatusHumanRequired || got.PRNumber != 99 {
+			t.Errorf("linked task mutated: status=%q pr=%d", got.Status, got.PRNumber)
+		}
+	})
+
+	t.Run("findMergedPRFn called only for eligible orphan", func(t *testing.T) {
+		// Only the orphan (no PR number, strand reason) should trigger the lookup.
+		if calls != 1 {
+			t.Errorf("findMergedPRFn calls = %d, want 1", calls)
+		}
+	})
+}
+
+// TestAdoptOrphanPRs_OpenTakesPrecedence verifies that when an open PR is found
+// for an eligible task, the merged-PR fallback is not called.
+func TestAdoptOrphanPRs_OpenTakesPrecedence(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := task.NewStore(filepath.Join(tmp, "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	created, err := tasks.Create("stranded", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr("commits pushed but no PR created"),
+		Branch:       task.Ptr("feat/my-branch"),
+		ProjectID:    task.Ptr("o/r"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mergedCalled := false
+	r := &ReviewHandler{
+		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
+		tasks:         tasks,
+		findMergedPRFn: func(_, _ string) (int, error) {
+			mergedCalled = true
+			return 0, nil
+		},
+	}
+
+	all, _ := tasks.List()
+	openPRs := []github.PullRequest{
+		{Number: 42, HeadRefName: "feat/my-branch", Repository: "o/r"},
+	}
+	r.adoptOrphanPRs(all, openPRs)
+
+	if mergedCalled {
+		t.Error("findMergedPRFn was called even though an open PR matched")
+	}
+	got, _ := tasks.Get(created.ID)
+	if got.Status != task.StatusInReview || got.PRNumber != 42 {
+		t.Errorf("status=%q pr=%d, want in-review/42", got.Status, got.PRNumber)
+	}
+}
+
 func TestHasReviewTask_ScopedByProject(t *testing.T) {
 	r := &ReviewHandler{}
 	existing := []task.Task{

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -412,6 +412,12 @@ func TestAdoptOrphanPRs(t *testing.T) {
 		ProjectID: task.Ptr("o/r"),
 		PRNumber:  task.Ptr(42),
 	})
+	// In-review with no PR → eligible: PR was opened manually but never linked.
+	inReviewOrphan := mk("in-review-orphan", task.Update{
+		Status:    task.Ptr(task.StatusInReview),
+		Branch:    task.Ptr("feat/in-review-orphan"),
+		ProjectID: task.Ptr("o/r"),
+	})
 
 	r := &ReviewHandler{
 		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
@@ -429,6 +435,7 @@ func TestAdoptOrphanPRs(t *testing.T) {
 		{Number: 9, HeadRefName: "feat/cross", Repository: "o/other-repo"}, // wrong repo
 		{Number: 10, HeadRefName: "feat/wd", Repository: "o/r"},            // watchdog task's branch
 		{Number: 42, HeadRefName: "feat/healthy", Repository: "o/r"},
+		{Number: 1055, HeadRefName: "feat/in-review-orphan", Repository: "o/r"},
 	}
 
 	r.adoptOrphanPRs(all, prs)
@@ -486,6 +493,16 @@ func TestAdoptOrphanPRs(t *testing.T) {
 		}
 	})
 
+	t.Run("in-review orphan linked without status change", func(t *testing.T) {
+		got, _ := tasks.Get(inReviewOrphan)
+		if got.Status != task.StatusInReview {
+			t.Errorf("status = %q, want in-review (must not change)", got.Status)
+		}
+		if got.PRNumber != 1055 {
+			t.Errorf("PRNumber = %d, want 1055", got.PRNumber)
+		}
+	})
+
 	t.Run("ineligible task untouched", func(t *testing.T) {
 		got, _ := tasks.Get(healthy)
 		if got.Status != task.StatusInReview || got.PRNumber != 42 {
@@ -501,16 +518,24 @@ func TestOrphanPRAdoptionEligible(t *testing.T) {
 		t    task.Task
 		want bool
 	}{
+		// human-required cases (strand-reason gate applies)
 		{"stranded orphan (no-commits)", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r", StatusReason: orphanReason}, true},
 		{"evaluate orphan (no PR)", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r", StatusReason: "commits pushed but no PR created"}, true},
 		{"has pr number", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r", PRNumber: 5, StatusReason: orphanReason}, false},
 		{"no branch", task.Task{Status: task.StatusHumanRequired, ProjectID: "o/r", StatusReason: orphanReason}, false},
 		{"no project", task.Task{Status: task.StatusHumanRequired, Branch: "b", StatusReason: orphanReason}, false},
-		{"not human-required", task.Task{Status: task.StatusInProgress, Branch: "b", ProjectID: "o/r", StatusReason: orphanReason}, false},
+		{"not human-required or in-review", task.Task{Status: task.StatusInProgress, Branch: "b", ProjectID: "o/r", StatusReason: orphanReason}, false},
 		{"watchdog stop not eligible", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r", StatusReason: "watchdog: runaway loop"}, false},
 		{"unrelated reason not eligible", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r", StatusReason: "needs design input"}, false},
 		{"review task excluded", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r", StatusReason: orphanReason, Tags: []string{"review"}}, false},
 		{"chat task excluded", task.Task{Status: task.StatusHumanRequired, Branch: "b", ProjectID: "o/r", StatusReason: orphanReason, TaskType: task.TaskTypeChat}, false},
+		// in-review cases (no strand-reason gate: already in review with no PR is unambiguously an orphan)
+		{"in-review no PR — eligible", task.Task{Status: task.StatusInReview, Branch: "b", ProjectID: "o/r"}, true},
+		{"in-review with PR — not eligible (already linked)", task.Task{Status: task.StatusInReview, Branch: "b", ProjectID: "o/r", PRNumber: 5}, false},
+		{"in-review no branch — not eligible", task.Task{Status: task.StatusInReview, ProjectID: "o/r"}, false},
+		{"in-review no project — not eligible", task.Task{Status: task.StatusInReview, Branch: "b"}, false},
+		{"in-review review tag excluded", task.Task{Status: task.StatusInReview, Branch: "b", ProjectID: "o/r", Tags: []string{"review"}}, false},
+		{"in-review chat task excluded", task.Task{Status: task.StatusInReview, Branch: "b", ProjectID: "o/r", TaskType: task.TaskTypeChat}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Motivation

When a PR is opened outside the normal `simple-task-pr` flow (manually or by an external tool), the task's `pr_number` stays `0` and Sybra never associates the PR. On merge, the PR-merge watcher can't match the task, leaving it stuck in `human-required`/`in-review` indefinitely — requiring manual reconciliation.

Closes https://github.com/Automaat/sybra/issues/1157

> Changelog: fix(reviews): link manually-opened PRs to tasks

## Implementation information

- **Reconcile pass** (`fix(reviews): link manually-opened PRs to tasks`): on each monitor cycle, matches open tasks with `pr_number == 0` to GitHub PRs by head-branch name pattern (`<type>/<slug>-<id>`) and adopts the PR number + advances status.
- **Landing audit for orphan adoption** (`fix(review): add landing audit to orphan adoption`): extends the reconcile to also run a landing audit when adopting an orphan PR, so tasks that already had their PR merged are detected and completed.
- **In-review tasks with no PR** (`fix(reviews): adopt in-review tasks with no PR`): handles the case where a task is already in `in-review` with `pr_number == 0` — adopts those too so the watcher can fire when the PR merges.