### PR TITLE
fix(workflow): reset test attempt counter correctly

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -310,6 +310,15 @@ export class Task {
      * knob — different CLI surface and vocabulary (xhigh vs max).
      */
     "reasoningEffort"?: string;
+
+    /**
+     * TestingCycleStartedAt marks the start of the current testing cycle. It is
+     * set when a human re-dispatches the task after a human-required escalation,
+     * so route_test_result can exclude test-runner runs from prior cycles when
+     * counting toward TestingMaxAttempts. Nil means no re-dispatch has occurred
+     * and all test-runner runs count (correct for first-ever cycles).
+     */
+    "testingCycleStartedAt"?: time$0.Time | null;
     "agentRuns": AgentRun[];
     "workflow": workflow$0.Execution | null;
     "createdAt": time$0.Time;
@@ -416,9 +425,9 @@ export class Task {
         const $$createField6_0 = $$createType0;
         const $$createField7_0 = $$createType0;
         const $$createField17_0 = $$createType0;
-        const $$createField34_0 = $$createType2;
-        const $$createField35_0 = $$createType4;
-        const $$createField45_0 = $$createType5;
+        const $$createField35_0 = $$createType2;
+        const $$createField36_0 = $$createType4;
+        const $$createField46_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -430,13 +439,13 @@ export class Task {
             $$parsedSource["dependsOn"] = $$createField17_0($$parsedSource["dependsOn"]);
         }
         if ("agentRuns" in $$parsedSource) {
-            $$parsedSource["agentRuns"] = $$createField34_0($$parsedSource["agentRuns"]);
+            $$parsedSource["agentRuns"] = $$createField35_0($$parsedSource["agentRuns"]);
         }
         if ("workflow" in $$parsedSource) {
-            $$parsedSource["workflow"] = $$createField35_0($$parsedSource["workflow"]);
+            $$parsedSource["workflow"] = $$createField36_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField45_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField46_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -182,6 +182,7 @@ func taskToInfo(t task.Task) workflow.TaskInfo {
 		Reviewed:              t.Reviewed,
 		Workflow:              t.Workflow,
 		AgentRuns:             toRunInfos(t.AgentRuns),
+		TestingCycleStartedAt: t.TestingCycleStartedAt,
 	}
 }
 

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -193,7 +193,7 @@ func toRunInfos(runs []task.AgentRun) []workflow.AgentRunInfo {
 	}
 	out := make([]workflow.AgentRunInfo, len(runs))
 	for i := range runs {
-		out[i] = workflow.AgentRunInfo{Role: runs[i].Role, Provider: runs[i].Provider}
+		out[i] = workflow.AgentRunInfo{Role: runs[i].Role, Provider: runs[i].Provider, StartedAt: runs[i].StartedAt}
 	}
 	return out
 }

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -167,6 +167,14 @@ func (s *TaskService) UpdateTask(id string, updates map[string]any) (task.Task, 
 	if err != nil {
 		return t, err
 	}
+	// When a human moves the task out of human-required, record the cycle start
+	// so route_test_result excludes prior-cycle test-runner runs from the count.
+	if cur.Status == task.StatusHumanRequired && t.Status != task.StatusHumanRequired {
+		now := time.Now().UTC()
+		if _, uErr := s.tasks.Update(id, task.Update{TestingCycleStartedAt: &now}); uErr != nil {
+			s.logger.Warn("testing-cycle.reset-failed", "task_id", id, "err", uErr)
+		}
+	}
 	if task.IsTerminalStatus(t.Status) {
 		s.wg.Go(func() {
 			s.worktrees.Remove(t.ID)

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -167,14 +167,6 @@ func (s *TaskService) UpdateTask(id string, updates map[string]any) (task.Task, 
 	if err != nil {
 		return t, err
 	}
-	// When a human moves the task out of human-required, record the cycle start
-	// so route_test_result excludes prior-cycle test-runner runs from the count.
-	if cur.Status == task.StatusHumanRequired && t.Status != task.StatusHumanRequired {
-		now := time.Now().UTC()
-		if _, uErr := s.tasks.Update(id, task.Update{TestingCycleStartedAt: &now}); uErr != nil {
-			s.logger.Warn("testing-cycle.reset-failed", "task_id", id, "err", uErr)
-		}
-	}
 	if task.IsTerminalStatus(t.Status) {
 		s.wg.Go(func() {
 			s.worktrees.Remove(t.ID)

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -291,11 +291,17 @@ type Task struct {
 	// via -c model_reasoning_effort=<v>. Empty = model default. Codex-only;
 	// ignored for claude agents. Distinct from the claude-only extended-thinking
 	// knob — different CLI surface and vocabulary (xhigh vs max).
-	ReasoningEffort string              `yaml:"reasoning_effort,omitempty" json:"reasoningEffort,omitempty"`
-	AgentRuns       []AgentRun          `yaml:"agent_runs,omitempty" json:"agentRuns"`
-	Workflow        *workflow.Execution `yaml:"workflow,omitempty" json:"workflow"`
-	CreatedAt       time.Time           `yaml:"created_at" json:"createdAt"`
-	UpdatedAt       time.Time           `yaml:"updated_at" json:"updatedAt"`
+	ReasoningEffort string `yaml:"reasoning_effort,omitempty" json:"reasoningEffort,omitempty"`
+	// TestingCycleStartedAt marks the start of the current testing cycle. It is
+	// set when a human re-dispatches the task after a human-required escalation,
+	// so route_test_result can exclude test-runner runs from prior cycles when
+	// counting toward TestingMaxAttempts. Nil means no re-dispatch has occurred
+	// and all test-runner runs count (correct for first-ever cycles).
+	TestingCycleStartedAt *time.Time          `yaml:"testing_cycle_started_at,omitempty" json:"testingCycleStartedAt,omitempty"`
+	AgentRuns             []AgentRun          `yaml:"agent_runs,omitempty" json:"agentRuns"`
+	Workflow              *workflow.Execution `yaml:"workflow,omitempty" json:"workflow"`
+	CreatedAt             time.Time           `yaml:"created_at" json:"createdAt"`
+	UpdatedAt             time.Time           `yaml:"updated_at" json:"updatedAt"`
 
 	Body         string `yaml:"-" json:"body"`
 	Plan         string `yaml:"-" json:"plan,omitempty"`

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -689,6 +689,16 @@ func (s *Store) UpdateWithPrev(id string, u Update) (Task, Status, error) {
 	if err := applyUpdateFields(&t, u); err != nil {
 		return Task{}, "", err
 	}
+	// When any caller (CLI, GUI, API) moves the task out of human-required,
+	// stamp TestingCycleStartedAt so route_test_result only counts runs from
+	// this new cycle, not from prior ones. Skipped when the caller already
+	// supplied an explicit value (u.TestingCycleStartedAt != nil).
+	if prevStatus == StatusHumanRequired &&
+		t.Status != StatusHumanRequired &&
+		u.TestingCycleStartedAt == nil {
+		now := time.Now().UTC()
+		t.TestingCycleStartedAt = &now
+	}
 	if err := s.writeSidecars(id, u, &t); err != nil {
 		return Task{}, "", err
 	}

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -674,6 +674,9 @@ func applyUpdateFields(t *Task, u Update) error {
 	if u.ReasoningEffort != nil {
 		t.ReasoningEffort = *u.ReasoningEffort
 	}
+	if u.TestingCycleStartedAt != nil {
+		t.TestingCycleStartedAt = u.TestingCycleStartedAt
+	}
 	return nil
 }
 

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -412,6 +412,85 @@ func TestStoreUpdateStatusHumanRequired(t *testing.T) {
 	}
 }
 
+// TestStoreUpdateTestingCycleStartedAt_AutoStamp verifies that UpdateWithPrev
+// automatically stamps TestingCycleStartedAt when a task moves out of
+// human-required. This covers all callers (CLI, GUI, engine) uniformly.
+func TestStoreUpdateTestingCycleStartedAt_AutoStamp(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("Redispatch task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Move to human-required (no cycle stamp set yet).
+	_, err = store.Update(created.ID, Update{Status: Ptr(StatusHumanRequired)})
+	if err != nil {
+		t.Fatalf("set human-required: %v", err)
+	}
+	before, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.TestingCycleStartedAt != nil {
+		t.Error("expected TestingCycleStartedAt to be nil before re-dispatch")
+	}
+
+	// Human re-dispatches: move out of human-required.
+	after, err := store.Update(created.ID, Update{Status: Ptr(StatusTesting)})
+	if err != nil {
+		t.Fatalf("set testing: %v", err)
+	}
+	if after.TestingCycleStartedAt == nil {
+		t.Fatal("expected TestingCycleStartedAt to be set after human-required → testing transition")
+	}
+
+	// Reload from disk to confirm persistence.
+	reloaded, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.TestingCycleStartedAt == nil {
+		t.Error("TestingCycleStartedAt not persisted after human-required → testing transition")
+	}
+	if reloaded.TestingCycleStartedAt.IsZero() {
+		t.Error("TestingCycleStartedAt is zero time")
+	}
+}
+
+// TestStoreUpdateTestingCycleStartedAt_NoAutoStampOnNonHumanRequired verifies
+// that the auto-stamp only fires for human-required → other transitions, not
+// for normal workflow-internal transitions (e.g. in-progress → testing).
+func TestStoreUpdateTestingCycleStartedAt_NoAutoStampOnNonHumanRequired(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("Normal cycle task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Workflow-internal transition: in-progress → testing (auto-loop, not human re-dispatch).
+	_, err = store.Update(created.ID, Update{Status: Ptr(StatusInProgress)})
+	if err != nil {
+		t.Fatalf("set in-progress: %v", err)
+	}
+	after, err := store.Update(created.ID, Update{Status: Ptr(StatusTesting)})
+	if err != nil {
+		t.Fatalf("set testing: %v", err)
+	}
+	if after.TestingCycleStartedAt != nil {
+		t.Error("TestingCycleStartedAt must not be set for non-human-required → testing transitions")
+	}
+}
+
 func TestStoreUpdateNotFound(t *testing.T) {
 	t.Parallel()
 	store, err := NewStore(t.TempDir())

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -49,6 +49,7 @@ type Update struct {
 	ReasoningEffort       *string
 	Outcome               *string
 	MergeCommit           *string
+	TestingCycleStartedAt *time.Time
 }
 
 func (u Update) writesSidecar() bool {

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -44,6 +44,10 @@ type TaskInfo struct {
 	// route_test_result counts prior test-runner runs; provider=cross uses
 	// code-authoring run providers when a previous workflow wrote the code.
 	AgentRuns []AgentRunInfo
+	// TestingCycleStartedAt is the start of the current testing cycle, set when
+	// a human re-dispatches from human-required. Nil means no re-dispatch has
+	// occurred; route_test_result counts all test-runner runs in that case.
+	TestingCycleStartedAt *time.Time
 }
 
 // AgentRunInfo is the engine-visible subset of a task's agent run.

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -48,8 +48,9 @@ type TaskInfo struct {
 
 // AgentRunInfo is the engine-visible subset of a task's agent run.
 type AgentRunInfo struct {
-	Role     string
-	Provider string
+	Role      string
+	Provider  string
+	StartedAt time.Time
 }
 
 // TaskProvider reads and updates tasks.

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -91,15 +91,20 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "pass"}, nil
 	}
 
-	// Count only test-runner runs that belong to the current testing cycle
-	// (i.e. started at or after this workflow execution). Runs from prior
-	// cycles (before a human re-dispatched the task to testing) must not
-	// inflate the counter and cause immediate escalation on re-entry.
+	// Count test-runner runs that belong to the current testing cycle.
+	// When a human re-dispatches after human-required, TestingCycleStartedAt is
+	// set to the re-dispatch time; runs before that time are from prior cycles
+	// and must not inflate the counter. Nil means no re-dispatch has happened
+	// (first cycle or automatic implement→test loop), so all runs count.
 	attempts := 0
 	for i := range t.AgentRuns {
-		if t.AgentRuns[i].Role == testRunnerRole && !t.AgentRuns[i].StartedAt.Before(wfExec.StartedAt) {
-			attempts++
+		if t.AgentRuns[i].Role != testRunnerRole {
+			continue
 		}
+		if t.TestingCycleStartedAt != nil && t.AgentRuns[i].StartedAt.Before(*t.TestingCycleStartedAt) {
+			continue
+		}
+		attempts++
 	}
 	limit := e.maxTestAttempts
 	if limit <= 0 {

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -91,9 +91,13 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "pass"}, nil
 	}
 
+	// Count only test-runner runs that belong to the current testing cycle
+	// (i.e. started at or after this workflow execution). Runs from prior
+	// cycles (before a human re-dispatched the task to testing) must not
+	// inflate the counter and cause immediate escalation on re-entry.
 	attempts := 0
 	for i := range t.AgentRuns {
-		if t.AgentRuns[i].Role == testRunnerRole {
+		if t.AgentRuns[i].Role == testRunnerRole && !t.AgentRuns[i].StartedAt.Before(wfExec.StartedAt) {
 			attempts++
 		}
 	}

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestExtractTestVerdict(t *testing.T) {
@@ -55,5 +56,162 @@ func TestExtractTestVerdict(t *testing.T) {
 				t.Errorf("extractTestVerdict(%q) = %q, want %q", tc.output, got, tc.want)
 			}
 		})
+	}
+}
+
+// makeTestEngine builds a minimal Engine for route_test_result unit tests.
+func makeTestEngine(t *testing.T) (*Engine, *memTasks) {
+	t.Helper()
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine.SetTestingMaxAttempts(3)
+	return engine, tasks
+}
+
+// runRouteTestResult calls execRouteTestResult with the given verdict and
+// agent-run history seeded into the in-memory task store.
+func runRouteTestResult(e *Engine, tasks *memTasks, taskID, verdict string, wfStartedAt time.Time, runs []AgentRunInfo) (StepOutput, error) {
+	tasks.Put(TaskInfo{
+		ID:        taskID,
+		Status:    "testing",
+		AgentRuns: runs,
+	})
+	step := &Step{ID: "route_test"}
+	wfExec := &Execution{
+		WorkflowID: "testing-task",
+		StartedAt:  wfStartedAt,
+		Variables:  map[string]string{},
+	}
+	if verdict != "" {
+		wfExec.Variables["step."+testVerdictSourceStep+".verdict"] = verdict
+	}
+	ti, _ := tasks.GetTask(taskID)
+	return e.execRouteTestResult(taskID, step, wfExec, ti)
+}
+
+func TestRouteTestResult_Pass(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	out, err := runRouteTestResult(e, tasks, "t1", "PASS", time.Now().UTC(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "pass" {
+		t.Errorf("output = %q, want pass", out.Output)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "ready-pr" {
+		t.Errorf("status = %q, want ready-pr", ti.Status)
+	}
+}
+
+func TestRouteTestResult_FailUnderCap(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	now := time.Now().UTC()
+	runs := []AgentRunInfo{{Role: testRunnerRole, StartedAt: now}}
+	out, err := runRouteTestResult(e, tasks, "t2", "FAIL", now, runs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "reimplement" {
+		t.Errorf("output = %q, want reimplement", out.Output)
+	}
+	ti, _ := tasks.GetTask("t2")
+	if ti.Status != "in-progress" {
+		t.Errorf("status = %q, want in-progress", ti.Status)
+	}
+}
+
+func TestRouteTestResult_FailAtCap(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	now := time.Now().UTC()
+	runs := []AgentRunInfo{
+		{Role: testRunnerRole, StartedAt: now},
+		{Role: testRunnerRole, StartedAt: now.Add(time.Minute)},
+		{Role: testRunnerRole, StartedAt: now.Add(2 * time.Minute)},
+	}
+	out, err := runRouteTestResult(e, tasks, "t3", "FAIL", now, runs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "escalated" {
+		t.Errorf("output = %q, want escalated", out.Output)
+	}
+	ti, _ := tasks.GetTask("t3")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+}
+
+// TestRouteTestResult_ReDispatch is the regression test for issue #1153: a task
+// re-dispatched to testing after a prior cycle already hit the cap must not
+// escalate immediately on its first new failure.
+func TestRouteTestResult_ReDispatch(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+
+	priorCycleEnd := time.Now().UTC().Add(-time.Hour)
+	newCycleStart := time.Now().UTC()
+
+	// 3 runs from a prior testing cycle (all before newCycleStart).
+	priorRuns := []AgentRunInfo{
+		{Role: testRunnerRole, StartedAt: priorCycleEnd.Add(-2 * time.Minute)},
+		{Role: testRunnerRole, StartedAt: priorCycleEnd.Add(-time.Minute)},
+		{Role: testRunnerRole, StartedAt: priorCycleEnd},
+	}
+	// 1 new run in the current cycle — must NOT count prior runs toward the cap.
+	priorRuns = append(priorRuns, AgentRunInfo{Role: testRunnerRole, StartedAt: newCycleStart.Add(time.Minute)})
+	runs := priorRuns
+
+	out, err := runRouteTestResult(e, tasks, "t4", "FAIL", newCycleStart, runs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "reimplement" {
+		t.Errorf("output = %q, want reimplement (prior-cycle runs must not count)", out.Output)
+	}
+	ti, _ := tasks.GetTask("t4")
+	if ti.Status != "in-progress" {
+		t.Errorf("status = %q, want in-progress", ti.Status)
+	}
+}
+
+// TestRouteTestResult_ReDispatch_Escalates verifies a re-dispatched task still
+// escalates once the new cycle exhausts its own cap.
+func TestRouteTestResult_ReDispatch_Escalates(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+
+	priorCycleEnd := time.Now().UTC().Add(-time.Hour)
+	newCycleStart := time.Now().UTC()
+
+	// 3 prior-cycle runs (must be ignored).
+	priorRuns := []AgentRunInfo{
+		{Role: testRunnerRole, StartedAt: priorCycleEnd.Add(-2 * time.Minute)},
+		{Role: testRunnerRole, StartedAt: priorCycleEnd.Add(-time.Minute)},
+		{Role: testRunnerRole, StartedAt: priorCycleEnd},
+	}
+	// 3 new-cycle runs — cap=3 → escalate.
+	newRuns := []AgentRunInfo{
+		{Role: testRunnerRole, StartedAt: newCycleStart.Add(time.Minute)},
+		{Role: testRunnerRole, StartedAt: newCycleStart.Add(2 * time.Minute)},
+		{Role: testRunnerRole, StartedAt: newCycleStart.Add(3 * time.Minute)},
+	}
+	priorRuns = append(priorRuns, newRuns...)
+	runs := priorRuns
+
+	out, err := runRouteTestResult(e, tasks, "t5", "FAIL", newCycleStart, runs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "escalated" {
+		t.Errorf("output = %q, want escalated", out.Output)
+	}
+	ti, _ := tasks.GetTask("t5")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
 	}
 }

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -71,11 +71,14 @@ func makeTestEngine(t *testing.T) (*Engine, *memTasks) {
 
 // runRouteTestResult calls execRouteTestResult with the given verdict and
 // agent-run history seeded into the in-memory task store.
-func runRouteTestResult(e *Engine, tasks *memTasks, taskID, verdict string, wfStartedAt time.Time, runs []AgentRunInfo) (StepOutput, error) {
+// cycleStart, when non-nil, simulates a human re-dispatch boundary: only runs
+// at or after that time are counted toward the cap.
+func runRouteTestResult(e *Engine, tasks *memTasks, taskID, verdict string, wfStartedAt time.Time, runs []AgentRunInfo, cycleStart *time.Time) (StepOutput, error) {
 	tasks.Put(TaskInfo{
-		ID:        taskID,
-		Status:    "testing",
-		AgentRuns: runs,
+		ID:                    taskID,
+		Status:                "testing",
+		AgentRuns:             runs,
+		TestingCycleStartedAt: cycleStart,
 	})
 	step := &Step{ID: "route_test"}
 	wfExec := &Execution{
@@ -93,7 +96,7 @@ func runRouteTestResult(e *Engine, tasks *memTasks, taskID, verdict string, wfSt
 func TestRouteTestResult_Pass(t *testing.T) {
 	t.Parallel()
 	e, tasks := makeTestEngine(t)
-	out, err := runRouteTestResult(e, tasks, "t1", "PASS", time.Now().UTC(), nil)
+	out, err := runRouteTestResult(e, tasks, "t1", "PASS", time.Now().UTC(), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +114,7 @@ func TestRouteTestResult_FailUnderCap(t *testing.T) {
 	e, tasks := makeTestEngine(t)
 	now := time.Now().UTC()
 	runs := []AgentRunInfo{{Role: testRunnerRole, StartedAt: now}}
-	out, err := runRouteTestResult(e, tasks, "t2", "FAIL", now, runs)
+	out, err := runRouteTestResult(e, tasks, "t2", "FAIL", now, runs, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +136,7 @@ func TestRouteTestResult_FailAtCap(t *testing.T) {
 		{Role: testRunnerRole, StartedAt: now.Add(time.Minute)},
 		{Role: testRunnerRole, StartedAt: now.Add(2 * time.Minute)},
 	}
-	out, err := runRouteTestResult(e, tasks, "t3", "FAIL", now, runs)
+	out, err := runRouteTestResult(e, tasks, "t3", "FAIL", now, runs, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +169,7 @@ func TestRouteTestResult_ReDispatch(t *testing.T) {
 	priorRuns = append(priorRuns, AgentRunInfo{Role: testRunnerRole, StartedAt: newCycleStart.Add(time.Minute)})
 	runs := priorRuns
 
-	out, err := runRouteTestResult(e, tasks, "t4", "FAIL", newCycleStart, runs)
+	out, err := runRouteTestResult(e, tasks, "t4", "FAIL", newCycleStart, runs, &newCycleStart)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +206,7 @@ func TestRouteTestResult_ReDispatch_Escalates(t *testing.T) {
 	priorRuns = append(priorRuns, newRuns...)
 	runs := priorRuns
 
-	out, err := runRouteTestResult(e, tasks, "t5", "FAIL", newCycleStart, runs)
+	out, err := runRouteTestResult(e, tasks, "t5", "FAIL", newCycleStart, runs, &newCycleStart)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Motivation

The test attempt counter was resetting on every automatic fail→reimplement loop, so `TestingMaxAttempts` was never reached and tasks never escalated — they cycled indefinitely. Root cause was using `wfExec.StartedAt` as the count boundary (resets each execution) and the cycle-start stamp only being written through one caller (svc_tasks.go), leaving CLI-dispatched tasks without a reset.

Closes https://github.com/Automaat/sybra/issues/1153

## Implementation information

- Moved `TestingCycleStartedAt` stamp into `Store.UpdateWithPrev` so it fires on every caller (CLI, GUI, workflow engine) when a task transitions out of `human-required`, not just through the service layer.
- Replaced `wfExec.StartedAt` boundary with `task.TestingCycleStartedAt` so the count spans a full human-dispatch cycle rather than a single workflow execution. Nil = count all runs (backward compatible).
- Removed the now-redundant post-update write from `svc_tasks.go`.
- Added unit tests: stamp fires on `human-required → any` transition; stamp does NOT fire on normal workflow-internal transitions (`in-progress → testing`); counter resets correctly after re-dispatch; escalation fires at cap within a cycle.

> Changelog: fix(workflow): reset test attempt counter correctly