### PR TITLE
fix(workflow): reject protocol-violating test reports

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -45,6 +45,13 @@ export class AgentRun {
     "sessionId"?: string;
 
     /**
+     * ProtocolViolation records deterministic workflow-level contract failures
+     * for this run. Test routing uses it to avoid counting a bad verifier report
+     * as an implementation failure across later workflow executions.
+     */
+    "protocolViolation"?: string;
+
+    /**
      * HeadSHA is the worktree HEAD commit at this run's completion — what the
      * agent left on the branch. Compared against the merged PR head to detect
      * human edits after the agent (merged_with_edits) and measure edit distance.

--- a/internal/skills/data/sybra-test.md
+++ b/internal/skills/data/sybra-test.md
@@ -56,12 +56,18 @@ In `## Test Failures` record, per defect: what you did (exact steps/commands), w
 
 5. **Use real oracles.** Compare observed vs the task's stated intent. HTTP: assert status + body via `curl "$SANDBOX_URL/..."`. K8s: `kubectl get/logs/describe`, port-forward + curl. CLI: run it, check exit code + stdout/stderr. Desktop/GUI apps that can't run headless (e.g. the Sybra Wails app itself): test the equivalent HTTP server surface (`cmd/*-server`, started in the sandbox) instead.
 
-6. **Decide.** Any deviation from the acceptance criteria → write `## Test Failures` and emit `TEST_VERDICT: FAIL`. Genuinely nothing broken after a real, multi-angle attempt → `TEST_VERDICT: PASS`.
+6. **Ground every claimed defect before writing about it.** For each behavior you believe deviates from the task:
+   - **Execution evidence** (mandatory): you ran a command and captured its actual output. Paste it verbatim. If you cannot produce real command output, you cannot include this defect — write "unable to reproduce: could not start X because Y" instead.
+   - **Code evidence** (when claiming a specific code bug): use `Read`/`Grep`/`cat` to find and quote the **current** source line(s) in the working tree. Never rely on a remembered diff or a prior read. If the actual current line contradicts your claim, your claim is wrong — omit it.
+   Exclude any defect that fails either check. Ungrounded claims are not defects; they are hallucinations.
+
+7. **Decide.** Any deviation from the acceptance criteria → write `## Test Failures` and emit `TEST_VERDICT: FAIL`. Genuinely nothing broken after a real, multi-angle attempt → `TEST_VERDICT: PASS`.
 
 ## Rules
 
-- Execute, don't plan. No test-plan document, no human approval step.
-- Don't suggest fixes — report symptoms + reproduction only.
-- Be conservative: when you cannot actually verify a claim, that is a FAIL, not a PASS.
-- Stay in scope: a deviation must be from a requirement the task **states or directly implies**. Never invent a new/contradictory requirement and fail the implementation on it. If the task's stated requirements themselves conflict or are unverifiable, write that plainly in `## Test Failures` ("spec is contradictory/under-specified: …") and emit FAIL — a human resolves the spec; the implementer cannot.
-- Never push, never open/modify a PR, never change task status — the workflow does that based on your verdict.
+- **Execute, don't plan.** No test-plan document, no human approval step. You run the real software.
+- **No fix suggestions.** Never write "the fix is", "you should", "consider", "try", "I recommend", "change X to Y", "switch X to Y", "replace X with Y", "use X instead of Y", or anything that prescribes a code change. Report what you observed — not what would resolve it. The implementer diagnoses from symptoms; you provide the symptoms. Violations are detected mechanically.
+- **No static-analysis FAILs.** Reading the code is allowed for orientation, but it is not a substitute for running the app. Every claimed defect requires real execution evidence (a command run + its actual output). If the feature cannot be run, note that explicitly and emit FAIL — but do not fabricate a defect from static reading or remembered diffs.
+- **Be conservative.** When you cannot actually verify a claim — because you could not run the app, could not find the relevant code, or the behavior was ambiguous — that is a FAIL, not a PASS. Emit FAIL and explain what you could not verify.
+- **Stay in scope.** A deviation must be from a requirement the task **states or directly implies**. Never invent a new/contradictory requirement and fail the implementation on it. If the task's stated requirements themselves conflict or are unverifiable, write that plainly in `## Test Failures` ("spec is contradictory/under-specified: …") and emit FAIL — a human resolves the spec; the implementer cannot.
+- **Never push, open/modify a PR, or change task status.** The workflow routes based on your verdict.

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -122,6 +122,10 @@ func (a *taskAdapter) MarkTaskReviewed(id string) error {
 	return err
 }
 
+func (a *taskAdapter) MarkAgentRunProtocolViolation(taskID, agentID, violation string) error {
+	return a.tasks.UpdateRun(taskID, agentID, map[string]any{"protocol_violation": violation})
+}
+
 func (a *taskAdapter) SetWorkflow(id string, wf *workflow.Execution) error {
 	_, err := a.tasks.Update(id, task.Update{Workflow: &wf})
 	return err
@@ -194,7 +198,13 @@ func toRunInfos(runs []task.AgentRun) []workflow.AgentRunInfo {
 	}
 	out := make([]workflow.AgentRunInfo, len(runs))
 	for i := range runs {
-		out[i] = workflow.AgentRunInfo{Role: runs[i].Role, Provider: runs[i].Provider, StartedAt: runs[i].StartedAt}
+		out[i] = workflow.AgentRunInfo{
+			AgentID:           runs[i].AgentID,
+			Role:              runs[i].Role,
+			Provider:          runs[i].Provider,
+			StartedAt:         runs[i].StartedAt,
+			ProtocolViolation: runs[i].ProtocolViolation,
+		}
 	}
 	return out
 }

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -193,6 +193,10 @@ type AgentRun struct {
 	VerdictRendered bool   `yaml:"verdict_rendered,omitempty" json:"verdictRendered,omitempty"`
 	LogFile         string `yaml:"log_file,omitempty" json:"logFile"`
 	SessionID       string `yaml:"session_id,omitempty" json:"sessionId,omitempty"`
+	// ProtocolViolation records deterministic workflow-level contract failures
+	// for this run. Test routing uses it to avoid counting a bad verifier report
+	// as an implementation failure across later workflow executions.
+	ProtocolViolation string `yaml:"protocol_violation,omitempty" json:"protocolViolation,omitempty"`
 	// HeadSHA is the worktree HEAD commit at this run's completion — what the
 	// agent left on the branch. Compared against the merged PR head to detect
 	// human edits after the agent (merged_with_edits) and measure edit distance.

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -972,6 +972,9 @@ func (s *Store) UpdateRun(taskID, agentID string, updates map[string]any) error 
 		if v, ok := updates["session_id"].(string); ok && v != "" {
 			t.AgentRuns[i].SessionID = v
 		}
+		if v, ok := updates["protocol_violation"].(string); ok && v != "" {
+			t.AgentRuns[i].ProtocolViolation = v
+		}
 		if v, ok := updates["head_sha"].(string); ok && v != "" {
 			t.AgentRuns[i].HeadSHA = v
 		}

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -947,10 +947,12 @@ func (s *Store) UpdateRun(taskID, agentID string, updates map[string]any) error 
 	if err != nil {
 		return err
 	}
+	found := false
 	for i := range t.AgentRuns {
 		if t.AgentRuns[i].AgentID != agentID {
 			continue
 		}
+		found = true
 		if v, ok := updates["state"].(string); ok {
 			t.AgentRuns[i].State = v
 		}
@@ -979,6 +981,9 @@ func (s *Store) UpdateRun(taskID, agentID string, updates map[string]any) error 
 			t.AgentRuns[i].HeadSHA = v
 		}
 		break
+	}
+	if !found {
+		return fmt.Errorf("agent run %s not found for task %s", agentID, taskID)
 	}
 	d, err := Marshal(t)
 	if err != nil {

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -700,10 +700,9 @@ func TestStoreUpdateRunNoMatchingAgent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Update with wrong agent ID — should not error but should not change anything
 	err = store.UpdateRun(created.ID, "agent-wrong", map[string]any{"state": "done"})
-	if err != nil {
-		t.Fatalf("UpdateRun with wrong agent: %v", err)
+	if err == nil {
+		t.Fatal("expected error for wrong agent")
 	}
 
 	got, err := store.Get(created.ID)

--- a/internal/workflow/builtin/testing-task.yaml
+++ b/internal/workflow/builtin/testing-task.yaml
@@ -72,12 +72,19 @@ steps:
         sandbox is already running for this task — use it. Bind only ephemeral
         ports and tear down anything you start.
 
+        For each claimed defect you MUST have: (1) a real command you ran
+        and its verbatim output, and (2) when claiming a specific code bug,
+        a line quoted from the CURRENT file read with Read/cat/grep — not
+        from diff memory. Exclude any claimed defect you cannot back with
+        both. An ungrounded claim is not a defect.
+
         When done:
           - If you found ANY deviation from the task's intent, append a
             "## Test Failures" section to the task body via
-            `sybra-cli update {{.Task.ID}} --body "<full body>"` describing the
-            observed-vs-expected symptoms and exact reproduction steps. Do NOT
-            suggest fixes — only report what is broken.
+            `sybra-cli update {{.Task.ID}} --body "<full body>"` listing
+            per-defect: the exact command run, verbatim output, expected
+            behaviour (cite the task), and the quoted code line when
+            relevant. Do NOT suggest fixes — describe symptoms only.
           - Print the verdict as the FINAL line of your output, exactly:
             `TEST_VERDICT: PASS`  (only if you could not break it)
             or

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -52,9 +52,11 @@ type TaskInfo struct {
 
 // AgentRunInfo is the engine-visible subset of a task's agent run.
 type AgentRunInfo struct {
-	Role      string
-	Provider  string
-	StartedAt time.Time
+	AgentID           string
+	Role              string
+	Provider          string
+	StartedAt         time.Time
+	ProtocolViolation string
 }
 
 // TaskProvider reads and updates tasks.
@@ -64,6 +66,7 @@ type TaskProvider interface {
 	UpdateTaskStatus(id, status, reason string) error
 	UpdateTaskPR(id string, prNumber int) error
 	MarkTaskReviewed(id string) error
+	MarkAgentRunProtocolViolation(taskID, agentID, violation string) error
 	SetWorkflow(id string, wf *Execution) error
 	// ConsumeSupervisorSteer prepends a pending watchdog headless-nudge steer to
 	// prompt and clears it, so a re-dispatched (resumed) step's agent carries the

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -53,6 +53,12 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 		return pErr
 	}
 
+	if violation := applyTestVerdictCompletion(wfExec, &output, ctx.Task.Body); violation != "" && output.AgentID != "" {
+		if err := e.tasks.MarkAgentRunProtocolViolation(taskID, output.AgentID, violation); err != nil {
+			return fmt.Errorf("mark test protocol violation: %w", err)
+		}
+	}
+
 	// Record step completion.
 	now := time.Now().UTC()
 	wfExec.RecordStep(StepRecord{
@@ -170,6 +176,7 @@ type advanceContext struct {
 	WfExec         *Execution
 	Def            Definition
 	Step           *Step
+	Task           TaskInfo
 	ParallelParent *Step
 }
 
@@ -248,6 +255,7 @@ func (e *Engine) loadAdvanceContext(taskID string, output StepOutput) (advanceCo
 		WfExec:         t.Workflow,
 		Def:            def,
 		Step:           resolvedStep,
+		Task:           t,
 		ParallelParent: parallelParent,
 	}, false, nil
 }

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -111,6 +111,8 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 		}
 	}
 
+	prepareTestVerdictAttemptVars(wfExec, step.ID, ctx.Task.Body)
+
 	mode := step.Config.Mode
 	if strings.Contains(mode, "{{") {
 		rendered, rErr := RenderTemplate(mode, ctx)

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -3,6 +3,8 @@ package workflow
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -20,7 +22,231 @@ const (
 	// testRunnerRole counts prior attempts; mirrors agent.RoleTestRunner
 	// (literal to avoid importing the agent package into the engine).
 	testRunnerRole = "test-runner"
+	// testVerdictTaintedKey records protocol violations found in a FAIL report.
+	// route_test_result uses it to avoid treating a bad test-runner report as
+	// evidence that the implementation itself is still broken.
+	testVerdictTaintedKey = "tainted"
+	// testFailureBodyStartLenKey records the task body length when run_test is
+	// dispatched. On completion, Codex structured output only contains
+	// {"verdict":"FAIL"}, so the actual failure text must be read from the body
+	// delta written by the runner.
+	testFailureBodyStartLenKey = "body_start_len"
+	testFailuresHeading        = "## Test Failures"
+
+	testProtocolFixSuggestions = "fix-suggestions"
 )
+
+// prepareTestVerdictAttemptVars resets per-attempt verdict metadata before a
+// test-runner starts. This prevents a protocol violation from a prior retry
+// from poisoning a clean retry.
+func prepareTestVerdictAttemptVars(wfExec *Execution, stepID, body string) {
+	if wfExec == nil || stepID != testVerdictSourceStep {
+		return
+	}
+	wfExec.SetVar("step."+stepID+"."+testFailureBodyStartLenKey, strconv.Itoa(len(body)))
+	delete(wfExec.Variables, "step."+stepID+".verdict")
+	delete(wfExec.Variables, "step."+stepID+"."+testVerdictTaintedKey)
+}
+
+// applyTestVerdictCompletion extracts the machine verdict from run_test output,
+// records protocol violations, and turns protocol-violating reports into failed
+// steps. The run_agent max_retries budget then retries the tester instead of
+// sending implementation agents after a bad report. It returns the violation
+// name when one should be persisted on the underlying AgentRun.
+func applyTestVerdictCompletion(wfExec *Execution, output *StepOutput, body string) string {
+	if wfExec == nil || output == nil || output.StepID != testVerdictSourceStep {
+		return ""
+	}
+	if output.Status != "completed" && output.Status != "failed" {
+		return ""
+	}
+	v := extractTestVerdict(output.Output)
+	if (v == "" || v == "FAIL") && containsFixSuggestionsInCurrentTestReport(output.Output, body, wfExec, output.StepID) {
+		wfExec.SetVar("step."+output.StepID+"."+testVerdictTaintedKey, testProtocolFixSuggestions)
+		output.Status = "failed"
+		output.Output = appendTestProtocolViolation(output.Output)
+		return testProtocolFixSuggestions
+	}
+	if output.Status != "completed" {
+		return ""
+	}
+	if v != "" {
+		wfExec.SetVar("step."+output.StepID+".verdict", v)
+	}
+	return ""
+}
+
+func appendTestProtocolViolation(output string) string {
+	msg := "test-runner protocol violation: FAIL report contained fix suggestions instead of observed symptoms"
+	if strings.TrimSpace(output) == "" {
+		return msg
+	}
+	return strings.TrimRight(output, "\n") + "\n\n" + msg
+}
+
+// containsFixSuggestionsInCurrentTestReport scans the agent result and the task
+// body text added during the current run_test attempt. The body delta matters
+// for Codex output_schema runs, where the result is only {"verdict":"FAIL"}.
+func containsFixSuggestionsInCurrentTestReport(output, body string, wfExec *Execution, stepID string) bool {
+	if containsFixSuggestions(output) {
+		return true
+	}
+	delta, ok := testFailureBodyDelta(body, wfExec, stepID)
+	if !ok {
+		return false
+	}
+	if strings.TrimSpace(delta) == "" {
+		return false
+	}
+	if testFailSectionOf(delta) != "" {
+		return containsFixSuggestions(delta)
+	}
+	return failureTextContainsFixSuggestions(delta)
+}
+
+func testFailureBodyDelta(body string, wfExec *Execution, stepID string) (string, bool) {
+	if body == "" || wfExec == nil {
+		return "", false
+	}
+	raw := wfExec.Variables["step."+stepID+"."+testFailureBodyStartLenKey]
+	n, err := strconv.Atoi(raw)
+	if raw == "" || err != nil || n < 0 {
+		return "", false
+	}
+	if n >= len(body) {
+		return "", true
+	}
+	return body[n:], true
+}
+
+// testFailSectionOf returns the substring starting at "## Test Failures" in
+// output, or "" when that heading is absent. Used to narrow full-output scans
+// to the part the runner authored under failure context, reducing false
+// positives from quoted app error messages or task description prose.
+func testFailSectionOf(output string) string {
+	idx := strings.Index(strings.ToLower(output), strings.ToLower(testFailuresHeading))
+	if idx < 0 {
+		return ""
+	}
+	return output[idx:]
+}
+
+// containsFixSuggestions reports whether the test-runner output includes
+// imperative fix language in the ## Test Failures section. Such language
+// violates the skill contract: test-runners report symptoms and reproduction
+// steps; implementers decide the fix.
+func containsFixSuggestions(output string) bool {
+	section := testFailSectionOf(output)
+	if section == "" {
+		return false
+	}
+	return failureTextContainsFixSuggestions(section)
+}
+
+func failureTextContainsFixSuggestions(text string) bool {
+	for _, line := range fixSuggestionScanLines(text) {
+		lower := strings.ToLower(line)
+		for _, phrase := range fixSuggestionPhrases {
+			if strings.Contains(lower, phrase) {
+				return true
+			}
+		}
+		for _, pat := range fixSuggestionPatterns {
+			if pat.MatchString(lower) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func fixSuggestionScanLines(text string) []string {
+	var out []string
+	inFence := false
+	for line := range strings.SplitSeq(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			inFence = !inFence
+			continue
+		}
+		if inFence || trimmed == "" || strings.HasPrefix(line, "    ") || strings.HasPrefix(line, "\t") {
+			continue
+		}
+		if skipFixSuggestionLine(trimmed) {
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	return out
+}
+
+func skipFixSuggestionLine(trimmed string) bool {
+	lower := strings.ToLower(trimmed)
+	for _, prefix := range fixSuggestionEvidencePrefixes {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	if strings.HasPrefix(lower, "code evidence:") && strings.ContainsAny(trimmed, "\"'`") {
+		return true
+	}
+	return false
+}
+
+// fixSuggestionPatterns match prescriptive code-edit forms that the test skill
+// explicitly prohibits, including the "switch X to Y" form that escaped the
+// original task b319d12f implementation.
+var fixSuggestionPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\b(?:change|switch|rename)\s+\S+\s+to\s+\S+`),
+	regexp.MustCompile(`\breplace\s+\S+\s+with\s+\S+`),
+	regexp.MustCompile(`\buse\s+\S+\s+instead\s+of\s+\S+`),
+}
+
+var fixSuggestionPhrases = []string{
+	"you should fix",
+	"you should change",
+	"you should update",
+	"you should add",
+	"you should remove",
+	"you should use",
+	"you could fix",
+	"you could change",
+	"i recommend",
+	"i suggest",
+	"the fix is",
+	"the fix would be",
+	"fix by",
+	"to fix this",
+	"to fix it",
+	"consider changing",
+	"consider adding",
+	"consider using",
+	"consider removing",
+	"try changing",
+	"try adding",
+	"try using",
+	"should be changed to",
+	"needs to be changed",
+	"needs to be updated",
+	"the implementation should",
+	"the code should be",
+}
+
+var fixSuggestionEvidencePrefixes = []string{
+	"command:",
+	"command run:",
+	"actual:",
+	"actual output:",
+	"output:",
+	"stdout:",
+	"stderr:",
+	"expected:",
+	"expected output:",
+	"verbatim output:",
+	"cleanup / control command:",
+	"cleanup / control output:",
+	"temporary test body",
+}
 
 // extractTestVerdict returns "PASS"/"FAIL"/"" from agent output.
 //
@@ -91,6 +317,15 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "pass"}, nil
 	}
 
+	if violation := wfExec.Variables["step."+testVerdictSourceStep+"."+testVerdictTaintedKey]; violation != "" {
+		reason := "test-runner report violated testing protocol after retry: contained fix suggestions instead of observed symptoms"
+		if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
+			return StepOutput{}, err
+		}
+		e.logger.Warn("workflow.test.protocol-violation", "task_id", taskID, "violation", violation)
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "protocol violation: " + violation}, nil
+	}
+
 	// Count test-runner runs that belong to the current testing cycle.
 	// When a human re-dispatches after human-required, TestingCycleStartedAt is
 	// set to the re-dispatch time; runs before that time are from prior cycles
@@ -99,6 +334,9 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 	attempts := 0
 	for i := range t.AgentRuns {
 		if t.AgentRuns[i].Role != testRunnerRole {
+			continue
+		}
+		if t.AgentRuns[i].ProtocolViolation != "" {
 			continue
 		}
 		if t.TestingCycleStartedAt != nil && t.AgentRuns[i].StartedAt.Before(*t.TestingCycleStartedAt) {

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -59,6 +60,101 @@ func TestExtractTestVerdict(t *testing.T) {
 	}
 }
 
+func TestContainsFixSuggestions(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name:   "change_x_to_y",
+			output: "## Test Failures\n\nCode evidence: route.go: change AgentRun.Verdict to VerdictRendered\nTEST_VERDICT: FAIL",
+			want:   true,
+		},
+		{
+			name:   "switch_x_to_y",
+			output: "## Test Failures\n\nCode evidence: route.go: switch AgentRun.Verdict to VerdictRendered\nTEST_VERDICT: FAIL",
+			want:   true,
+		},
+		{
+			name:   "replace_x_with_y",
+			output: "## Test Failures\n\nCode evidence: route.go: replace AgentRun.Verdict with VerdictRendered\nTEST_VERDICT: FAIL",
+			want:   true,
+		},
+		{
+			name:   "use_x_instead_of_y",
+			output: "## Test Failures\n\nCode evidence: route.go: use VerdictRendered instead of AgentRun.Verdict\nTEST_VERDICT: FAIL",
+			want:   true,
+		},
+		{
+			name:   "rename_x_to_y",
+			output: "## Test Failures\n\nCode evidence: route.go: rename Verdict to VerdictRendered\nTEST_VERDICT: FAIL",
+			want:   true,
+		},
+		{
+			name:   "recommendation_phrase",
+			output: "## Test Failures\n\nI recommend switching to VerdictRendered instead\nTEST_VERDICT: FAIL",
+			want:   true,
+		},
+		{
+			name:   "actual_output_not_advice",
+			output: "## Test Failures\n\nActual output: \"use --new instead of --old\"\nExpected: command succeeds",
+			want:   false,
+		},
+		{
+			name:   "fenced_output_not_advice",
+			output: "## Test Failures\n\nActual output:\n```text\nyou should use --new instead of --old\n```",
+			want:   false,
+		},
+		{
+			name:   "quoted_code_evidence_not_advice",
+			output: "## Test Failures\n\nCode evidence: cli.go: `fmt.Println(\"use --new instead of --old\")`",
+			want:   false,
+		},
+		{
+			name:   "symptom_only",
+			output: "## Test Failures\n\nCommand: curl /status\nActual: HTTP 500\nExpected: HTTP 200",
+			want:   false,
+		},
+		{
+			name:   "you_should_see_is_not_a_fix",
+			output: "## Test Failures\n\nYou should see a 200 response but instead got 500",
+			want:   false,
+		},
+		{
+			name:   "fix_language_before_failures_section_ignored",
+			output: "I recommend changing the handler.\n\n## Test Failures\n\nCommand returned exit code 1.",
+			want:   false,
+		},
+		{
+			name:   "no_failures_section",
+			output: "I recommend changing the handler.\nTEST_VERDICT: FAIL",
+			want:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := containsFixSuggestions(tc.output); got != tc.want {
+				t.Errorf("containsFixSuggestions(%q) = %v, want %v", tc.output, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestContainsFixSuggestionsInCurrentTestReport_MissingBodyStartIgnoresStaleBody(t *testing.T) {
+	t.Parallel()
+
+	body := "## Problem\nold task text\n\n## Test Failures\n\nI recommend changing the handler.\n"
+	wf := &Execution{Variables: map[string]string{}}
+	if containsFixSuggestionsInCurrentTestReport(`{"verdict":"FAIL"}`, body, wf, testVerdictSourceStep) {
+		t.Fatal("missing body_start_len must not scan stale full task body")
+	}
+}
+
 // makeTestEngine builds a minimal Engine for route_test_result unit tests.
 func makeTestEngine(t *testing.T) (*Engine, *memTasks) {
 	t.Helper()
@@ -91,6 +187,197 @@ func runRouteTestResult(e *Engine, tasks *memTasks, taskID, verdict string, wfSt
 	}
 	ti, _ := tasks.GetTask(taskID)
 	return e.execRouteTestResult(taskID, step, wfExec, ti)
+}
+
+func makeTestingTaskEngine(t *testing.T) (*Engine, *memTasks, *mockAgents) {
+	t.Helper()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := SyncBuiltins(store); err != nil {
+		t.Fatal(err)
+	}
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	return engine, tasks, agents
+}
+
+func TestAdvanceStep_TestProtocolViolationRetriesRunTestFromBodyDelta(t *testing.T) {
+	t.Parallel()
+	engine, tasks, agents := makeTestingTaskEngine(t)
+
+	initialBody := "## Problem\nExercise the testing gate."
+	body := initialBody + "\n\n### Failure\nCode evidence: route.go: switch AgentRun.Verdict to VerdictRendered\n"
+	wf := &Execution{
+		WorkflowID:  "testing-task",
+		CurrentStep: testVerdictSourceStep,
+		State:       ExecWaiting,
+		Variables:   map[string]string{},
+		StartedAt:   time.Now().UTC(),
+	}
+	prepareTestVerdictAttemptVars(wf, testVerdictSourceStep, initialBody)
+	tasks.Put(TaskInfo{
+		ID:        "t-proto",
+		Status:    "testing",
+		Body:      body,
+		AgentMode: "headless",
+		Workflow:  wf,
+		AgentRuns: []AgentRunInfo{{AgentID: "agent-original", Role: testRunnerRole}},
+	})
+
+	err := engine.AdvanceStep("t-proto", StepOutput{
+		StepID:   testVerdictSourceStep,
+		Status:   "completed",
+		Output:   `{"verdict":"FAIL"}`,
+		AgentID:  "agent-original",
+		Provider: "codex",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := agents.CallCount(); got != 1 {
+		t.Fatalf("retry StartAgent calls = %d, want 1", got)
+	}
+	got, err := tasks.GetTask("t-proto")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "testing" {
+		t.Errorf("status = %q, want testing", got.Status)
+	}
+	if got.Workflow == nil || got.Workflow.CurrentStep != testVerdictSourceStep || got.Workflow.State != ExecWaiting {
+		t.Fatalf("workflow = %+v, want waiting at run_test", got.Workflow)
+	}
+	if len(got.Workflow.StepHistory) != 1 {
+		t.Fatalf("step history len = %d, want 1", len(got.Workflow.StepHistory))
+	}
+	rec := got.Workflow.StepHistory[0]
+	if rec.Status != "failed" {
+		t.Errorf("run_test record status = %q, want failed", rec.Status)
+	}
+	if !strings.Contains(rec.Output, "protocol violation") {
+		t.Errorf("run_test output = %q, want protocol violation note", rec.Output)
+	}
+	if got.Workflow.Variables["step."+testVerdictSourceStep+"."+testVerdictTaintedKey] != "" {
+		t.Errorf("taint var should be cleared for retry, got %q", got.Workflow.Variables["step."+testVerdictSourceStep+"."+testVerdictTaintedKey])
+	}
+	if got.Workflow.Variables["step."+testVerdictSourceStep+"."+testFailureBodyStartLenKey] != strconv.Itoa(len(body)) {
+		t.Errorf("body start var = %q, want current body length", got.Workflow.Variables["step."+testVerdictSourceStep+"."+testFailureBodyStartLenKey])
+	}
+	if got.AgentRuns[0].ProtocolViolation != testProtocolFixSuggestions {
+		t.Errorf("agent run protocol violation = %q, want %q", got.AgentRuns[0].ProtocolViolation, testProtocolFixSuggestions)
+	}
+}
+
+func TestAdvanceStep_TestProtocolViolationRetriesRunTestForMalformedVerdict(t *testing.T) {
+	t.Parallel()
+	engine, tasks, agents := makeTestingTaskEngine(t)
+
+	initialBody := "## Problem\nExercise the testing gate."
+	body := initialBody + "\n\n## Test Failures\n\nI recommend changing the route_test gate.\n"
+	wf := &Execution{
+		WorkflowID:  "testing-task",
+		CurrentStep: testVerdictSourceStep,
+		State:       ExecWaiting,
+		Variables:   map[string]string{},
+		StartedAt:   time.Now().UTC(),
+	}
+	prepareTestVerdictAttemptVars(wf, testVerdictSourceStep, initialBody)
+	tasks.Put(TaskInfo{
+		ID:        "t-proto-malformed",
+		Status:    "testing",
+		Body:      body,
+		AgentMode: "headless",
+		Workflow:  wf,
+		AgentRuns: []AgentRunInfo{{AgentID: "agent-malformed", Role: testRunnerRole}},
+	})
+
+	err := engine.AdvanceStep("t-proto-malformed", StepOutput{
+		StepID:   testVerdictSourceStep,
+		Status:   "completed",
+		Output:   `{}`,
+		AgentID:  "agent-malformed",
+		Provider: "codex",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := agents.CallCount(); got != 1 {
+		t.Fatalf("retry StartAgent calls = %d, want 1", got)
+	}
+	got, err := tasks.GetTask("t-proto-malformed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AgentRuns[0].ProtocolViolation != testProtocolFixSuggestions {
+		t.Errorf("agent run protocol violation = %q, want %q", got.AgentRuns[0].ProtocolViolation, testProtocolFixSuggestions)
+	}
+}
+
+func TestAdvanceStep_TestProtocolViolationAfterRetryStopsWithProtocolReason(t *testing.T) {
+	t.Parallel()
+	engine, tasks, agents := makeTestingTaskEngine(t)
+
+	initialBody := "## Problem\nExercise the testing gate."
+	body := initialBody + "\n\n### Failure\nCode evidence: route.go: switch AgentRun.Verdict to VerdictRendered\n"
+	wf := &Execution{
+		WorkflowID:  "testing-task",
+		CurrentStep: testVerdictSourceStep,
+		State:       ExecWaiting,
+		Variables:   map[string]string{},
+		StartedAt:   time.Now().UTC(),
+		StepHistory: []StepRecord{{
+			StepID: testVerdictSourceStep,
+			Status: "failed",
+		}},
+	}
+	prepareTestVerdictAttemptVars(wf, testVerdictSourceStep, initialBody)
+	tasks.Put(TaskInfo{
+		ID:        "t-proto-exhausted",
+		Status:    "testing",
+		Body:      body,
+		AgentMode: "headless",
+		Workflow:  wf,
+		AgentRuns: []AgentRunInfo{{AgentID: "agent-retry", Role: testRunnerRole}},
+	})
+
+	err := engine.AdvanceStep("t-proto-exhausted", StepOutput{
+		StepID:   testVerdictSourceStep,
+		Status:   "completed",
+		Output:   `{"verdict":"FAIL"}`,
+		AgentID:  "agent-retry",
+		Provider: "codex",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := agents.CallCount(); got != 0 {
+		t.Fatalf("retry StartAgent calls = %d, want 0 after retry budget exhausted", got)
+	}
+	got, err := tasks.GetTask("t-proto-exhausted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required", got.Status)
+	}
+	if reason := tasks.Reason("t-proto-exhausted"); !strings.Contains(reason, "testing protocol") {
+		t.Errorf("status reason = %q, want testing protocol", reason)
+	}
+	if got.Workflow == nil || got.Workflow.State != ExecCompleted {
+		t.Fatalf("workflow = %+v, want completed", got.Workflow)
+	}
+	last := got.Workflow.StepHistory[len(got.Workflow.StepHistory)-1]
+	if last.StepID != "route_test" || !strings.Contains(last.Output, "protocol violation") {
+		t.Errorf("last step = %+v, want route_test protocol violation", last)
+	}
+	if got.AgentRuns[0].ProtocolViolation != testProtocolFixSuggestions {
+		t.Errorf("agent run protocol violation = %q, want %q", got.AgentRuns[0].ProtocolViolation, testProtocolFixSuggestions)
+	}
 }
 
 func TestRouteTestResult_Pass(t *testing.T) {
@@ -146,6 +433,28 @@ func TestRouteTestResult_FailAtCap(t *testing.T) {
 	ti, _ := tasks.GetTask("t3")
 	if ti.Status != "human-required" {
 		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+}
+
+func TestRouteTestResult_ProtocolViolationRunsDoNotCountTowardCap(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	now := time.Now().UTC()
+	runs := []AgentRunInfo{
+		{AgentID: "bad-report", Role: testRunnerRole, StartedAt: now, ProtocolViolation: testProtocolFixSuggestions},
+		{AgentID: "valid-1", Role: testRunnerRole, StartedAt: now.Add(time.Minute)},
+		{AgentID: "valid-2", Role: testRunnerRole, StartedAt: now.Add(2 * time.Minute)},
+	}
+	out, err := runRouteTestResult(e, tasks, "t3-protocol", "FAIL", now, runs, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "reimplement" {
+		t.Errorf("output = %q, want reimplement", out.Output)
+	}
+	ti, _ := tasks.GetTask("t3-protocol")
+	if ti.Status != "in-progress" {
+		t.Errorf("status = %q, want in-progress", ti.Status)
 	}
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -174,10 +174,10 @@ func (m *memTasks) MarkAgentRunProtocolViolation(taskID, agentID, violation stri
 	for i := range t.AgentRuns {
 		if t.AgentRuns[i].AgentID == agentID {
 			t.AgentRuns[i].ProtocolViolation = violation
-			break
+			return nil
 		}
 	}
-	return nil
+	return fmt.Errorf("agent run %s not found for task %s", agentID, taskID)
 }
 
 func (m *memTasks) SetWorkflow(id string, wf *Execution) error {

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -164,6 +164,22 @@ func (m *memTasks) MarkTaskReviewed(id string) error {
 	return nil
 }
 
+func (m *memTasks) MarkAgentRunProtocolViolation(taskID, agentID, violation string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	t, ok := m.tasks[taskID]
+	if !ok {
+		return fmt.Errorf("task %s not found", taskID)
+	}
+	for i := range t.AgentRuns {
+		if t.AgentRuns[i].AgentID == agentID {
+			t.AgentRuns[i].ProtocolViolation = violation
+			break
+		}
+	}
+	return nil
+}
+
 func (m *memTasks) SetWorkflow(id string, wf *Execution) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
## Summary
- require execution-grounded test-runner failure reports in the built-in workflow and embedded sybra-test skill
- detect fix-suggestion protocol violations from tester output or the current task-body delta, including malformed-verdict cases
- persist protocol violations on agent runs and exclude them from manual testing attempt counts

## Review
- spawned an adversarial subagent reviewer and addressed all four findings around attempt counting, evidence false positives, stale body scans, and malformed verdict handling

## Tests
- env GOCACHE=/private/tmp/synapse-go-cache go test ./internal/workflow -run 'Test(ContainsFixSuggestions|AdvanceStep_TestProtocolViolation|RouteTestResult|ExtractTestVerdict)' -count=1\n- env GOCACHE=/private/tmp/synapse-go-cache GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false go test ./...\n- git diff --cached --check\n- pre-push hook: go test ./... and cd frontend && npm run check