### PR TITLE
feat(umbrella): board column + waiting badge

### DIFF
--- a/frontend/src/components/TaskBoardView.svelte
+++ b/frontend/src/components/TaskBoardView.svelte
@@ -193,7 +193,7 @@
               Nothing to review.
             </p>
           {/if}
-        {:else}
+        {:else if col.kind !== 'umbrella'}
           <div class="px-2 pb-2">
             <InlineTaskAdd status={col.status} />
           </div>

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -65,6 +65,8 @@
     return PRIORITY_OPTIONS.find(o => o.value === (p ?? '')) ?? PRIORITY_OPTIONS[0]
   }
 
+  const visibleTags = $derived((t.tags ?? []).filter((tag) => tag !== 'umbrella-gated'))
+
 </script>
 
 <div
@@ -164,6 +166,11 @@
       <Pill role="attention" class="bg-error-200 text-error-800 dark:bg-error-700 dark:text-error-200">
         {awaitsHumanLabel(t.status)}
       </Pill>
+    {:else if t.tags?.includes('umbrella-gated') && !isReviewTask && !ownPRPhase}
+      <span class="inline-flex items-center gap-1 rounded bg-surface-200 px-1.5 py-0.5 text-surface-600 dark:bg-surface-700 dark:text-surface-300">
+        <Hourglass size={11} class="shrink-0" />
+        Waiting
+      </span>
     {:else if subStateLabel && !isReviewTask && !ownPRPhase}
       <span class="inline-flex items-center rounded-full bg-surface-200 px-2 py-0.5 text-surface-600 dark:bg-surface-700 dark:text-surface-300">
         {subStateLabel}
@@ -243,10 +250,10 @@
       </Pill>
     {/if}
 
-    {#if t.tags?.length}
-      <Pill role="tag">{t.tags[0]}</Pill>
-      {#if t.tags.length > 1}
-        <span class="text-surface-400" title={t.tags.join(', ')}>+{t.tags.length - 1}</span>
+    {#if visibleTags.length}
+      <Pill role="tag">{visibleTags[0]}</Pill>
+      {#if visibleTags.length > 1}
+        <span class="text-surface-400" title={visibleTags.join(', ')}>+{visibleTags.length - 1}</span>
       {/if}
     {/if}
 

--- a/frontend/src/lib/review-phase.test.ts
+++ b/frontend/src/lib/review-phase.test.ts
@@ -10,7 +10,7 @@ import {
   reviewPhaseRank,
   type ReviewPhase,
 } from './review-phase.js'
-import { BOARD_COLUMNS, BOARD_LANES, REVIEW_LANE, CORE_STATUSES } from './statuses.js'
+import { BOARD_COLUMNS, BOARD_LANES, REVIEW_LANE, UMBRELLA_LANE, CORE_STATUSES } from './statuses.js'
 
 describe('isReviewTask', () => {
   it('is true only when the review tag is present', () => {
@@ -119,13 +119,19 @@ describe('BOARD_LANES', () => {
     expect(BOARD_LANES[idx + 1].status).toBe('human-required')
   })
 
-  it('keeps every status column from BOARD_COLUMNS plus the one lane', () => {
-    expect(BOARD_LANES.length).toBe(BOARD_COLUMNS.length + 1)
+  it('keeps every status column from BOARD_COLUMNS plus the two sentinel lanes', () => {
+    expect(BOARD_LANES.length).toBe(BOARD_COLUMNS.length + 2)
     for (const c of BOARD_COLUMNS) expect(BOARD_LANES).toContain(c)
   })
 
-  it('keeps the review sentinel out of the pickable status set', () => {
+  it('keeps both sentinels out of the pickable status set', () => {
     expect(CORE_STATUSES).not.toContain('reviews')
+    expect(CORE_STATUSES).not.toContain('umbrella')
     expect(REVIEW_LANE.kind).toBe('review')
+    expect(UMBRELLA_LANE.kind).toBe('umbrella')
+  })
+
+  it('places the umbrella lane first', () => {
+    expect(BOARD_LANES[0]).toBe(UMBRELLA_LANE)
   })
 })

--- a/frontend/src/lib/statuses.ts
+++ b/frontend/src/lib/statuses.ts
@@ -158,11 +158,11 @@ export interface BoardColumn {
   includes: TaskStatus[]
   /**
    * Column kind. 'status' (default) groups tasks by status; 'review' is the
-   * tag-based To Review lane that collects inbound review tasks across every
-   * phase, independent of their status. `status` is a sentinel for review
-   * lanes — never a real task status.
+   * tag-based To Review lane; 'umbrella' is the task_type-based lane for
+   * umbrella tracker tasks. Both 'review' and 'umbrella' use sentinel values
+   * for `status` that are never real task statuses.
    */
-  kind?: 'status' | 'review'
+  kind?: 'status' | 'review' | 'umbrella'
 }
 
 /** Kanban board columns — active work only; terminal tasks live in Logbook */
@@ -175,6 +175,19 @@ export const BOARD_COLUMNS: BoardColumn[] = [
   { status: 'in-review', label: 'In Review', border: 'border-t-warning-500 dark:border-t-warning-400', includes: ['in-review', 'ready-pr'] },
   { status: 'human-required', label: 'Human Required', border: 'border-t-error-500 dark:border-t-error-400', includes: ['human-required', 'blocked'] },
 ]
+
+/**
+ * The Umbrella lane: a task_type-based column for umbrella tracker tasks.
+ * `status: 'umbrella'` is a sentinel used only as the column key — it is never
+ * a real task status, so it stays out of BOARD_COLUMNS / CORE_STATUSES.
+ */
+export const UMBRELLA_LANE: BoardColumn = {
+  status: 'umbrella' as TaskStatus,
+  kind: 'umbrella',
+  label: 'Umbrella',
+  border: 'border-t-tertiary-400 dark:border-t-tertiary-500',
+  includes: [],
+}
 
 /**
  * The To Review lane: a tag-based column (not status-based) that collects
@@ -191,13 +204,15 @@ export const REVIEW_LANE: BoardColumn = {
 }
 
 /**
- * Board column order including the To Review lane (inserted before Human
- * Required). The board renders these; BOARD_COLUMNS stays the pure status set
- * that drives CORE_STATUSES, the status picker, and per-project boards.
+ * Board column order: Umbrella first, then the status columns with To Review
+ * inserted before Human Required. The board renders these; BOARD_COLUMNS stays
+ * the pure status set that drives CORE_STATUSES, the status picker, and
+ * per-project boards.
  */
-export const BOARD_LANES: BoardColumn[] = BOARD_COLUMNS.flatMap((c) =>
-  c.status === 'human-required' ? [REVIEW_LANE, c] : [c],
-)
+export const BOARD_LANES: BoardColumn[] = [
+  UMBRELLA_LANE,
+  ...BOARD_COLUMNS.flatMap((c) => (c.status === 'human-required' ? [REVIEW_LANE, c] : [c])),
+]
 
 /**
  * Core user-facing status set: the active board columns plus the terminal

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -47,9 +47,8 @@
   }
 
   async function moveTask(taskId: string, status: string) {
-    // The PR Reviews lane key is a sentinel, not a real status — dropping onto
-    // it must not write an invalid status.
-    if (status === 'reviews') return
+    // Sentinel lanes are not real statuses — dropping onto them must not write.
+    if (status === 'reviews' || status === 'umbrella') return
     const existing = taskStore.tasks.get(taskId)
     if (!existing || existing.status === status) return
     try {
@@ -70,6 +69,7 @@
 
   function columnTasks(col: BoardColumn): Task[] {
     if (col.kind === 'review') return reviewLaneTasks()
+    if (col.kind === 'umbrella') return umbrellaLaneTasks()
     const statuses = col.includes.length > 0 ? col.includes : [col.status]
     // Inbound reviews live in the To Review lane, never their status column.
     // Self-authored handoff PR reviews are NOT inbound — they stay here so a
@@ -81,6 +81,18 @@
       return [...tasks].sort((a, b) => prPhaseRank(a) - prPhaseRank(b))
     }
     return tasks
+  }
+
+  function umbrellaLaneTasks(): Task[] {
+    return taskStore.list.filter((t: Task) => {
+      if (t.taskType !== 'umbrella') return false
+      if (t.status === 'done' || t.status === 'cancelled') return false
+      if (!matchesQuery(t, searchQuery)) return false
+      if (!matchesProject(t, selectedProjectId)) return false
+      if (!matchesTags(t, selectedTags)) return false
+      if (!matchesAgentMode(t, selectedAgentMode)) return false
+      return true
+    })
   }
 
   // The To Review lane: every active inbound review task, sorted so the
@@ -252,6 +264,7 @@
   function filteredByStatuses(statuses: string[]): Task[] {
     return taskStore.list.filter((t: Task) => {
       if (!statuses.includes(t.status)) return false
+      if (t.taskType === 'umbrella') return false // umbrella trackers go to the Umbrella lane
       if (!matchesQuery(t, searchQuery)) return false
       if (!matchesProject(t, selectedProjectId)) return false
       if (!matchesTags(t, selectedTags)) return false

--- a/internal/poll/issues_test.go
+++ b/internal/poll/issues_test.go
@@ -100,7 +100,7 @@ func TestIssuesFetcher_SyncIssuesToTasks_UmbrellaChildNotDuplicated(t *testing.T
 		_, err := env.tasks.CreateFull("child 5", "", task.AgentModeHeadless, task.Update{
 			Issue:         task.Ptr(subURL),
 			UmbrellaIssue: task.Ptr(issueURL),
-			Status:        task.Ptr(task.StatusBlocked),
+			Status:        task.Ptr(task.StatusTodo),
 			Tags:          task.Ptr([]string{umbrella.GatedTag}),
 		})
 		return umbrella.Result{Created: 1}, err
@@ -123,8 +123,8 @@ func TestIssuesFetcher_SyncIssuesToTasks_UmbrellaChildNotDuplicated(t *testing.T
 	for i := range all {
 		if all[i].Issue == subURL {
 			matches++
-			if all[i].Status != task.StatusBlocked {
-				t.Fatalf("sub-issue task status = %q, want blocked (gated child)", all[i].Status)
+			if all[i].Status != task.StatusTodo {
+				t.Fatalf("sub-issue task status = %q, want todo (gated child)", all[i].Status)
 			}
 		}
 	}

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -69,7 +69,7 @@ func (a *App) releaseUnblockedChildren() {
 		}
 		if t.UmbrellaIssue != "" {
 			hasUmbrella = true
-			accumulateChild(stateFor(t.UmbrellaIssue), t.Status)
+			accumulateChild(stateFor(t.UmbrellaIssue), t.Status, t.Tags)
 		}
 		nodes[i] = umbrella.Node{
 			ID:        t.ID,
@@ -77,9 +77,9 @@ func (a *App) releaseUnblockedChildren() {
 			Umbrella:  t.UmbrellaIssue,
 			DependsOn: t.DependsOn,
 			Done:      t.Status == task.StatusDone,
-			// Only a task the gate itself blocked is eligible for release —
+			// Only a gate-marked todo child is eligible for release —
 			// never one parked in `blocked` for a contained Sybra bug.
-			Awaiting: t.UmbrellaIssue != "" && t.Status == task.StatusBlocked &&
+			Awaiting: t.UmbrellaIssue != "" && t.Status == task.StatusTodo &&
 				slices.Contains(t.Tags, umbrellaGatedTag),
 		}
 	}
@@ -98,7 +98,9 @@ func (a *App) releaseUnblockedChildren() {
 }
 
 // accumulateChild folds one child task's status into its umbrella's tally.
-func accumulateChild(st *umbrellaState, status task.Status) {
+// A todo child carrying the gating tag is still waiting for deps — it must not
+// count as active or it would consume a parallelism slot before being released.
+func accumulateChild(st *umbrellaState, status task.Status, tags []string) {
 	st.total++
 	switch status {
 	case task.StatusDone:
@@ -112,7 +114,7 @@ func accumulateChild(st *umbrellaState, status task.Status) {
 		st.anyHR = true
 		st.active++ // a stuck child still occupies a slot until resolved
 	default:
-		if isRunningChild(status) {
+		if isRunningChild(status) && !slices.Contains(tags, umbrellaGatedTag) {
 			st.active++
 		}
 	}
@@ -146,7 +148,6 @@ func (a *App) releaseCapped(ready []string, byID map[string]*task.Task, states m
 			return s == umbrellaGatedTag
 		})
 		if _, err := a.tasks.Update(id, task.Update{
-			Status:       task.Ptr(task.StatusTodo),
 			Tags:         &newTags,
 			StatusReason: task.Ptr("umbrella dependencies satisfied"),
 		}); err != nil {

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -77,9 +77,12 @@ func (a *App) releaseUnblockedChildren() {
 			Umbrella:  t.UmbrellaIssue,
 			DependsOn: t.DependsOn,
 			Done:      t.Status == task.StatusDone,
-			// Only a gate-marked todo child is eligible for release —
-			// never one parked in `blocked` for a contained Sybra bug.
-			Awaiting: t.UmbrellaIssue != "" && t.Status == task.StatusTodo &&
+			// Gate-marked todo children (current model) and legacy
+			// blocked+gated children (tasks created before this change)
+			// are both eligible for release. Never release a task that is
+			// blocked without the gating tag (contained Sybra bug).
+			Awaiting: t.UmbrellaIssue != "" &&
+				(t.Status == task.StatusTodo || t.Status == task.StatusBlocked) &&
 				slices.Contains(t.Tags, umbrellaGatedTag),
 		}
 	}
@@ -148,6 +151,7 @@ func (a *App) releaseCapped(ready []string, byID map[string]*task.Task, states m
 			return s == umbrellaGatedTag
 		})
 		if _, err := a.tasks.Update(id, task.Update{
+			Status:       task.Ptr(task.StatusTodo),
 			Tags:         &newTags,
 			StatusReason: task.Ptr("umbrella dependencies satisfied"),
 		}); err != nil {

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -33,20 +33,22 @@ func TestReleaseUnblockedChildren_RespectsMaxParallel(t *testing.T) {
 	const umb = "https://github.com/Automaat/sybra/issues/100"
 	mkTracker(t, m, umb, 2)
 
-	c1 := mkChild(t, m, "c1", "Automaat/sybra#1", umb, nil, task.StatusBlocked)
-	c2 := mkChild(t, m, "c2", "Automaat/sybra#2", umb, nil, task.StatusBlocked)
-	c3 := mkChild(t, m, "c3", "Automaat/sybra#3", umb, nil, task.StatusBlocked)
+	c1 := mkChild(t, m, "c1", "Automaat/sybra#1", umb, nil, task.StatusTodo)
+	c2 := mkChild(t, m, "c2", "Automaat/sybra#2", umb, nil, task.StatusTodo)
+	c3 := mkChild(t, m, "c3", "Automaat/sybra#3", umb, nil, task.StatusTodo)
 
 	app.releaseUnblockedChildren()
 
 	released, held := 0, 0
 	for _, id := range []string{c1.ID, c2.ID, c3.ID} {
-		switch mustStatus(t, m, id) {
-		case task.StatusTodo:
-			released++
-		case task.StatusBlocked:
+		tk := mustTask(t, m, id)
+		if tk.Status != task.StatusTodo {
+			continue
+		}
+		if slices.Contains(tk.Tags, umbrellaGatedTag) {
 			held++
-		default:
+		} else {
+			released++
 		}
 	}
 	if released != 2 || held != 1 {
@@ -62,7 +64,7 @@ func TestReleaseUnblockedChildren_HaltChainFlagsTracker(t *testing.T) {
 
 	// One child is stuck needing a human; an unrelated child is ready.
 	stuck := mkChild(t, m, "stuck", "Automaat/sybra#1", umb, nil, task.StatusHumanRequired)
-	indep := mkChild(t, m, "indep", "Automaat/sybra#2", umb, nil, task.StatusBlocked)
+	indep := mkChild(t, m, "indep", "Automaat/sybra#2", umb, nil, task.StatusTodo)
 
 	app.releaseUnblockedChildren()
 
@@ -221,11 +223,16 @@ func mkChild(t *testing.T, m *task.Manager, title, issue, umb string, deps []str
 
 func mustStatus(t *testing.T, m *task.Manager, id string) task.Status {
 	t.Helper()
+	return mustTask(t, m, id).Status
+}
+
+func mustTask(t *testing.T, m *task.Manager, id string) task.Task {
+	t.Helper()
 	tk, err := m.Get(id)
 	if err != nil {
 		t.Fatalf("Get(%s): %v", id, err)
 	}
-	return tk.Status
+	return tk
 }
 
 func TestReleaseUnblockedChildren_ReleasesRootWithNoDeps(t *testing.T) {
@@ -233,7 +240,7 @@ func TestReleaseUnblockedChildren_ReleasesRootWithNoDeps(t *testing.T) {
 	app, m := newUmbrellaGateApp(t)
 	const umb = "https://github.com/Automaat/sybra/issues/100"
 
-	root := mkChild(t, m, "root", "Automaat/sybra#1", umb, nil, task.StatusBlocked)
+	root := mkChild(t, m, "root", "Automaat/sybra#1", umb, nil, task.StatusTodo)
 
 	app.releaseUnblockedChildren()
 
@@ -286,11 +293,12 @@ func TestReleaseUnblockedChildren_HoldsThenReleasesChain(t *testing.T) {
 
 	// dep is still in progress; child depends on it.
 	dep := mkChild(t, m, "dep", "Automaat/sybra#1", umb, nil, task.StatusInProgress)
-	child := mkChild(t, m, "child", "Automaat/sybra#2", umb, []string{"Automaat/sybra#1"}, task.StatusBlocked)
+	child := mkChild(t, m, "child", "Automaat/sybra#2", umb, []string{"Automaat/sybra#1"}, task.StatusTodo)
 
 	app.releaseUnblockedChildren()
-	if got := mustStatus(t, m, child.ID); got != task.StatusBlocked {
-		t.Fatalf("child released early: status = %q, want %q", got, task.StatusBlocked)
+	childTask := mustTask(t, m, child.ID)
+	if childTask.Status != task.StatusTodo || !slices.Contains(childTask.Tags, umbrellaGatedTag) {
+		t.Fatalf("child released early: status = %q tags = %v, want todo+%s", childTask.Status, childTask.Tags, umbrellaGatedTag)
 	}
 
 	// Finish the dependency, then the child must release.
@@ -310,7 +318,7 @@ func TestReleaseUnblockedChildren_CrossFormDependencyResolves(t *testing.T) {
 
 	// Dependency recorded as a full URL; the child references it in shorthand.
 	mkChild(t, m, "dep", "https://github.com/Automaat/sybra/issues/1", umb, nil, task.StatusDone)
-	child := mkChild(t, m, "child", "Automaat/sybra#2", umb, []string{"Automaat/sybra#1"}, task.StatusBlocked)
+	child := mkChild(t, m, "child", "Automaat/sybra#2", umb, []string{"Automaat/sybra#1"}, task.StatusTodo)
 
 	app.releaseUnblockedChildren()
 	if got := mustStatus(t, m, child.ID); got != task.StatusTodo {
@@ -334,20 +342,20 @@ func TestReleaseUnblockedChildren_CycleFlagsTracker(t *testing.T) {
 	}
 
 	// x <-> y mutual dependency.
-	x := mkChild(t, m, "x", "Automaat/sybra#1", umb, []string{"Automaat/sybra#2"}, task.StatusBlocked)
-	y := mkChild(t, m, "y", "Automaat/sybra#2", umb, []string{"Automaat/sybra#1"}, task.StatusBlocked)
+	x := mkChild(t, m, "x", "Automaat/sybra#1", umb, []string{"Automaat/sybra#2"}, task.StatusTodo)
+	y := mkChild(t, m, "y", "Automaat/sybra#2", umb, []string{"Automaat/sybra#1"}, task.StatusTodo)
 
 	app.releaseUnblockedChildren()
 
 	if got := mustStatus(t, m, tracker.ID); got != task.StatusHumanRequired {
 		t.Fatalf("tracker status = %q, want %q on cycle", got, task.StatusHumanRequired)
 	}
-	// Cyclic children must stay blocked.
-	if got := mustStatus(t, m, x.ID); got != task.StatusBlocked {
-		t.Fatalf("x status = %q, want blocked", got)
+	// Cyclic children stay held (todo + gated tag, not released).
+	if got := mustStatus(t, m, x.ID); got != task.StatusTodo {
+		t.Fatalf("x status = %q, want todo (held gated)", got)
 	}
-	if got := mustStatus(t, m, y.ID); got != task.StatusBlocked {
-		t.Fatalf("y status = %q, want blocked", got)
+	if got := mustStatus(t, m, y.ID); got != task.StatusTodo {
+		t.Fatalf("y status = %q, want todo (held gated)", got)
 	}
 }
 

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -129,7 +129,7 @@ func scanExisting(tasks *task.Manager, umbrellaURL string) (refs map[string]bool
 	return refs, trackerExists, nil
 }
 
-// materialize creates the tracker (when absent) and one blocked child per spec.
+// materialize creates the tracker (when absent) and one gated todo child per spec.
 func materialize(tasks *task.Manager, umb github.Issue, specs []ChildSpec, byRef map[string]github.Issue, trackerExists bool, maxParallel int) (int, error) {
 	if !trackerExists {
 		if _, err := tasks.CreateFull(umb.Title, umb.Body, task.AgentModeHeadless, task.Update{
@@ -150,7 +150,7 @@ func materialize(tasks *task.Manager, umb github.Issue, specs []ChildSpec, byRef
 			UmbrellaIssue: task.Ptr(umb.URL),
 			DependsOn:     task.Ptr(canonicalizeDeps(spec.DependsOn, byRef)),
 			ProjectID:     task.Ptr(childProjectID(spec.Issue, byRef, umb.Repository)),
-			Status:        task.Ptr(task.StatusBlocked),
+			Status:        task.Ptr(task.StatusTodo),
 			Tags:          task.Ptr(childTags(spec.Issue, byRef)),
 		}); err != nil {
 			return created, fmt.Errorf("create child for %s: %w", spec.Issue, err)


### PR DESCRIPTION
## Motivation

Two UX gaps in the umbrella workflow:
- Umbrella tracker tasks (`task_type=umbrella`) had no dedicated home on the board — they floated in "In Progress" alongside regular tasks with no visual distinction
- Gated subtasks were moved to `blocked`, which conflated "waiting for a dependency" with "something is wrong" (the human-attention state)

## Implementation information

**Umbrella column (frontend)**
- `statuses.ts`: adds `UMBRELLA_LANE` (sentinel `status: 'umbrella'`, `kind: 'umbrella'`) as the first lane in `BOARD_LANES`
- `TaskList.svelte`: `umbrellaLaneTasks()` filters by `taskType === 'umbrella'`; `filteredByStatuses()` excludes umbrella trackers from status columns so they don't appear in both places; `moveTask` guards the sentinel
- `TaskBoardView.svelte`: no `InlineTaskAdd` for the umbrella lane (trackers are auto-created)

**Waiting badge (frontend)**
- `TaskCard.svelte`: hourglass icon + "Waiting" label shown when task has `umbrella-gated` tag; tag hidden from raw tag pills since it has its own badge

**Gated children stay in `todo` (backend)**
- `expand.go`: children materialised with `StatusTodo` instead of `StatusBlocked`
- `app_umbrella_gate.go`: `Awaiting` matches `todo + umbrella-gated`; `accumulateChild` takes tags and skips gated-todo tasks from the parallelism active count (prevents unreleased tasks from consuming slots); `releaseCapped` only strips the tag on release — no status change needed
- Tests updated throughout: `mkChild` calls use `StatusTodo`; held children verified by tag presence rather than status

> Changelog: feat(umbrella): board column + waiting badge