### PR TITLE
Fix desktop startup stall during limits backfill

### DIFF
--- a/internal/limits/collect.go
+++ b/internal/limits/collect.go
@@ -2,6 +2,7 @@ package limits
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"hash/fnv"
 	"io"
@@ -198,19 +199,22 @@ func ParseCopilotLine(line []byte, source, id, sessionID string) (UsageEvent, bo
 // BackfillLocalSessionFiles imports usage from local provider session files
 // newer than cutoff. It is best-effort: unreadable provider directories are
 // skipped so one missing CLI never disables Sybra stats.
-func (s *Store) BackfillLocalSessionFiles(cutoff time.Time) error {
+func (s *Store) BackfillLocalSessionFiles(ctx context.Context, cutoff time.Time) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	home, ok := userHomeDir()
 	if !ok {
 		return nil
 	}
 	batch := newSessionImport()
-	if err := batch.backfillCodex(filepath.Join(home, ".codex", "sessions"), cutoff); err != nil {
+	if err := batch.backfillCodex(ctx, filepath.Join(home, ".codex", "sessions"), cutoff); err != nil {
 		return err
 	}
-	if err := batch.backfillClaude(filepath.Join(home, ".claude", "projects"), cutoff); err != nil {
+	if err := batch.backfillClaude(ctx, filepath.Join(home, ".claude", "projects"), cutoff); err != nil {
 		return err
 	}
-	if err := batch.backfillCopilot(filepath.Join(home, ".copilot", "session-state"), cutoff); err != nil {
+	if err := batch.backfillCopilot(ctx, filepath.Join(home, ".copilot", "session-state"), cutoff); err != nil {
 		return err
 	}
 	return s.Import(batch.events, batch.snapshotsList())
@@ -262,8 +266,8 @@ func (b *sessionImport) snapshotsList() []Snapshot {
 	return out
 }
 
-func (b *sessionImport) backfillCodex(root string, cutoff time.Time) error {
-	return walkJSONL(root, cutoff, func(path string, offset int64, line []byte) error {
+func (b *sessionImport) backfillCodex(ctx context.Context, root string, cutoff time.Time) error {
+	return walkJSONL(ctx, root, cutoff, func(path string, offset int64, line []byte) error {
 		sessionID := strings.TrimSuffix(strings.TrimPrefix(filepath.Base(path), "rollout-"), ".jsonl")
 		snapshot, event, ok := ParseCodexLine(line, SourceSessionFiles, eventID(ProviderCodex, path, offset), sessionID)
 		if !ok {
@@ -279,8 +283,8 @@ func (b *sessionImport) backfillCodex(root string, cutoff time.Time) error {
 	})
 }
 
-func (b *sessionImport) backfillClaude(root string, cutoff time.Time) error {
-	return walkJSONL(root, cutoff, func(path string, offset int64, line []byte) error {
+func (b *sessionImport) backfillClaude(ctx context.Context, root string, cutoff time.Time) error {
+	return walkJSONL(ctx, root, cutoff, func(path string, offset int64, line []byte) error {
 		event, ok := ParseClaudeLine(line, SourceSessionFiles, eventID(ProviderClaude, path, offset))
 		if !ok {
 			return nil
@@ -290,8 +294,8 @@ func (b *sessionImport) backfillClaude(root string, cutoff time.Time) error {
 	})
 }
 
-func (b *sessionImport) backfillCopilot(root string, cutoff time.Time) error {
-	return walkJSONL(root, cutoff, func(path string, offset int64, line []byte) error {
+func (b *sessionImport) backfillCopilot(ctx context.Context, root string, cutoff time.Time) error {
+	return walkJSONL(ctx, root, cutoff, func(path string, offset int64, line []byte) error {
 		sessionID := filepath.Base(filepath.Dir(path))
 		event, ok := ParseCopilotLine(line, SourceSessionFiles, eventID(ProviderCopilot, path, offset), sessionID)
 		if !ok {
@@ -302,11 +306,17 @@ func (b *sessionImport) backfillCopilot(root string, cutoff time.Time) error {
 	})
 }
 
-func walkJSONL(root string, cutoff time.Time, fn func(path string, offset int64, line []byte) error) error {
+func walkJSONL(ctx context.Context, root string, cutoff time.Time, fn func(path string, offset int64, line []byte) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if _, ok := sessionRootInfo(root); !ok {
 		return nil
 	}
 	return filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if walkEntryUnreadable(err) || d.IsDir() || !strings.HasSuffix(path, ".jsonl") {
 			return nil
 		}
@@ -314,11 +324,14 @@ func walkJSONL(root string, cutoff time.Time, fn func(path string, offset int64,
 		if !ok || (!cutoff.IsZero() && modTime.Before(cutoff)) {
 			return nil
 		}
-		return scanLines(path, fn)
+		return scanLines(ctx, path, fn)
 	})
 }
 
-func scanLines(path string, fn func(path string, offset int64, line []byte) error) error {
+func scanLines(ctx context.Context, path string, fn func(path string, offset int64, line []byte) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	f, ok := openSessionFile(path)
 	if !ok {
 		return nil
@@ -327,6 +340,9 @@ func scanLines(path string, fn func(path string, offset int64, line []byte) erro
 	r := bufio.NewReaderSize(f, 64*1024)
 	var offset int64
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		line, err := r.ReadBytes('\n')
 		if len(line) > 0 {
 			startOffset := offset

--- a/internal/limits/collect.go
+++ b/internal/limits/collect.go
@@ -203,16 +203,66 @@ func (s *Store) BackfillLocalSessionFiles(cutoff time.Time) error {
 	if !ok {
 		return nil
 	}
-	if err := s.backfillCodex(filepath.Join(home, ".codex", "sessions"), cutoff); err != nil {
+	batch := newSessionImport()
+	if err := batch.backfillCodex(filepath.Join(home, ".codex", "sessions"), cutoff); err != nil {
 		return err
 	}
-	if err := s.backfillClaude(filepath.Join(home, ".claude", "projects"), cutoff); err != nil {
+	if err := batch.backfillClaude(filepath.Join(home, ".claude", "projects"), cutoff); err != nil {
 		return err
 	}
-	return s.backfillCopilot(filepath.Join(home, ".copilot", "session-state"), cutoff)
+	if err := batch.backfillCopilot(filepath.Join(home, ".copilot", "session-state"), cutoff); err != nil {
+		return err
+	}
+	return s.Import(batch.events, batch.snapshotsList())
 }
 
-func (s *Store) backfillCodex(root string, cutoff time.Time) error {
+type sessionImport struct {
+	events    []UsageEvent
+	eventIDs  map[string]struct{}
+	snapshots map[string]Snapshot
+}
+
+func newSessionImport() *sessionImport {
+	return &sessionImport{
+		eventIDs:  map[string]struct{}{},
+		snapshots: map[string]Snapshot{},
+	}
+}
+
+func (b *sessionImport) addEvent(event UsageEvent) {
+	if event.ID == "" || event.Provider == "" {
+		return
+	}
+	if _, ok := b.eventIDs[event.ID]; ok {
+		return
+	}
+	b.eventIDs[event.ID] = struct{}{}
+	b.events = append(b.events, event)
+}
+
+func (b *sessionImport) addSnapshot(snapshot Snapshot) {
+	if snapshot.Provider == "" {
+		return
+	}
+	prev, ok := b.snapshots[snapshot.Provider]
+	if ok && snapshot.CapturedAt.Before(prev.CapturedAt) {
+		return
+	}
+	b.snapshots[snapshot.Provider] = snapshot
+}
+
+func (b *sessionImport) snapshotsList() []Snapshot {
+	if len(b.snapshots) == 0 {
+		return nil
+	}
+	out := make([]Snapshot, 0, len(b.snapshots))
+	for provider := range b.snapshots {
+		out = append(out, b.snapshots[provider])
+	}
+	return out
+}
+
+func (b *sessionImport) backfillCodex(root string, cutoff time.Time) error {
 	return walkJSONL(root, cutoff, func(path string, offset int64, line []byte) error {
 		sessionID := strings.TrimSuffix(strings.TrimPrefix(filepath.Base(path), "rollout-"), ".jsonl")
 		snapshot, event, ok := ParseCodexLine(line, SourceSessionFiles, eventID(ProviderCodex, path, offset), sessionID)
@@ -220,35 +270,35 @@ func (s *Store) backfillCodex(root string, cutoff time.Time) error {
 			return nil
 		}
 		if snapshot.Provider != "" {
-			if err := s.UpdateSnapshot(snapshot); err != nil {
-				return err
-			}
+			b.addSnapshot(snapshot)
 		}
 		if event.ID != "" {
-			return s.RecordUsage(event)
+			b.addEvent(event)
 		}
 		return nil
 	})
 }
 
-func (s *Store) backfillClaude(root string, cutoff time.Time) error {
+func (b *sessionImport) backfillClaude(root string, cutoff time.Time) error {
 	return walkJSONL(root, cutoff, func(path string, offset int64, line []byte) error {
 		event, ok := ParseClaudeLine(line, SourceSessionFiles, eventID(ProviderClaude, path, offset))
 		if !ok {
 			return nil
 		}
-		return s.RecordUsage(event)
+		b.addEvent(event)
+		return nil
 	})
 }
 
-func (s *Store) backfillCopilot(root string, cutoff time.Time) error {
+func (b *sessionImport) backfillCopilot(root string, cutoff time.Time) error {
 	return walkJSONL(root, cutoff, func(path string, offset int64, line []byte) error {
 		sessionID := filepath.Base(filepath.Dir(path))
 		event, ok := ParseCopilotLine(line, SourceSessionFiles, eventID(ProviderCopilot, path, offset), sessionID)
 		if !ok {
 			return nil
 		}
-		return s.RecordUsage(event)
+		b.addEvent(event)
+		return nil
 	})
 }
 

--- a/internal/limits/collect_test.go
+++ b/internal/limits/collect_test.go
@@ -1,6 +1,9 @@
 package limits
 
 import (
+	"context"
+	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -263,5 +266,40 @@ func TestSessionImport_DedupesEventsAndKeepsLatestSnapshot(t *testing.T) {
 	snapshots := batch.snapshotsList()
 	if len(snapshots) != 1 || snapshots[0].PlanType != "new" {
 		t.Fatalf("snapshots = %+v, want latest only", snapshots)
+	}
+}
+
+func TestBackfillLocalSessionFiles_StopsOnCanceledContext(t *testing.T) {
+	s, err := NewStore(filepath.Join(t.TempDir(), "limits.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = s.BackfillLocalSessionFiles(ctx, time.Time{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("BackfillLocalSessionFiles error = %v, want context.Canceled", err)
+	}
+}
+
+func TestWalkJSONL_StopsOnCanceledContext(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "session.jsonl"), []byte(`{"type":"message"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	called := false
+	err := walkJSONL(ctx, root, time.Time{}, func(string, int64, []byte) error {
+		called = true
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("walkJSONL error = %v, want context.Canceled", err)
+	}
+	if called {
+		t.Fatal("walkJSONL callback ran after context cancellation")
 	}
 }

--- a/internal/limits/collect_test.go
+++ b/internal/limits/collect_test.go
@@ -198,3 +198,70 @@ func TestSummary_PrefersSessionFileUsageCountersButKeepsRunSpend(t *testing.T) {
 		t.Fatalf("premium requests = session %d weekly %d, want 2/2", codex.SessionPremiumRequests, codex.WeeklyPremiumRequests)
 	}
 }
+
+func TestStoreImport_DedupesAndPersistsBatch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "limits.json")
+	s, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	s.now = func() time.Time { return now }
+
+	if err := s.Import(
+		[]UsageEvent{
+			{ID: "claude-1", Provider: ProviderClaude, Source: SourceSessionFiles, InputTokens: 10},
+			{ID: "claude-1", Provider: ProviderClaude, Source: SourceSessionFiles, InputTokens: 99},
+			{ID: "codex-1", Provider: ProviderCodex, Source: SourceSessionFiles, InputTokens: 20, Timestamp: now.Add(-time.Minute)},
+		},
+		[]Snapshot{
+			{Provider: ProviderCodex, Source: SourceSessionFiles, Confidence: ConfidenceExact, PlanType: "new", CapturedAt: now},
+			{Provider: ProviderCodex, Source: SourceSessionFiles, Confidence: ConfidenceExact, PlanType: "old", CapturedAt: now.Add(-time.Hour)},
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(s.events) != 2 {
+		t.Fatalf("events = %d, want 2 after duplicate import", len(s.events))
+	}
+	if s.events[0].Timestamp != now {
+		t.Fatalf("zero timestamp was not normalized: %v", s.events[0].Timestamp)
+	}
+	snap, ok := s.Snapshot(ProviderCodex)
+	if !ok || snap.PlanType != "new" {
+		t.Fatalf("snapshot = %+v, ok=%v; want latest snapshot", snap, ok)
+	}
+
+	reopened, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reopened.events) != 2 {
+		t.Fatalf("persisted events = %d, want 2", len(reopened.events))
+	}
+	snap, ok = reopened.Snapshot(ProviderCodex)
+	if !ok || snap.PlanType != "new" {
+		t.Fatalf("persisted snapshot = %+v, ok=%v; want latest snapshot", snap, ok)
+	}
+}
+
+func TestSessionImport_DedupesEventsAndKeepsLatestSnapshot(t *testing.T) {
+	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	batch := newSessionImport()
+
+	batch.addEvent(UsageEvent{ID: "event-1", Provider: ProviderClaude, Source: SourceSessionFiles, InputTokens: 1})
+	batch.addEvent(UsageEvent{ID: "event-1", Provider: ProviderClaude, Source: SourceSessionFiles, InputTokens: 2})
+	batch.addEvent(UsageEvent{ID: "", Provider: ProviderClaude, Source: SourceSessionFiles})
+
+	batch.addSnapshot(Snapshot{Provider: ProviderCodex, PlanType: "new", CapturedAt: now})
+	batch.addSnapshot(Snapshot{Provider: ProviderCodex, PlanType: "old", CapturedAt: now.Add(-time.Hour)})
+
+	if len(batch.events) != 1 {
+		t.Fatalf("events = %d, want 1", len(batch.events))
+	}
+	snapshots := batch.snapshotsList()
+	if len(snapshots) != 1 || snapshots[0].PlanType != "new" {
+		t.Fatalf("snapshots = %+v, want latest only", snapshots)
+	}
+}

--- a/internal/limits/store.go
+++ b/internal/limits/store.go
@@ -66,8 +66,43 @@ func NewStore(path string) (*Store, error) {
 }
 
 func (s *Store) UpdateSnapshot(snapshot Snapshot) error {
-	if snapshot.Provider == "" {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.updateSnapshotLocked(snapshot) {
 		return nil
+	}
+	return s.flushLocked()
+}
+
+func (s *Store) RecordUsage(e UsageEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.recordUsageLocked(e) {
+		return nil
+	}
+	return s.flushLocked()
+}
+
+// Import records a batch of parsed session-file data and flushes at most once.
+func (s *Store) Import(events []UsageEvent, snapshots []Snapshot) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	changed := false
+	for i := range snapshots {
+		changed = s.updateSnapshotLocked(snapshots[i]) || changed
+	}
+	for i := range events {
+		changed = s.recordUsageLocked(events[i]) || changed
+	}
+	if !changed {
+		return nil
+	}
+	return s.flushLocked()
+}
+
+func (s *Store) updateSnapshotLocked(snapshot Snapshot) bool {
+	if snapshot.Provider == "" {
+		return false
 	}
 	if snapshot.CapturedAt.IsZero() {
 		snapshot.CapturedAt = s.now().UTC()
@@ -78,31 +113,27 @@ func (s *Store) UpdateSnapshot(snapshot Snapshot) error {
 	if snapshot.Confidence == "" {
 		snapshot.Confidence = ConfidenceExact
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	prev, ok := s.snapshots[snapshot.Provider]
 	if ok && snapshot.CapturedAt.Before(prev.CapturedAt) {
-		return nil
+		return false
 	}
 	s.snapshots[snapshot.Provider] = snapshot
-	return s.flushLocked()
+	return true
 }
 
-func (s *Store) RecordUsage(e UsageEvent) error {
+func (s *Store) recordUsageLocked(e UsageEvent) bool {
 	if e.ID == "" || e.Provider == "" {
-		return nil
+		return false
 	}
 	if e.Timestamp.IsZero() {
 		e.Timestamp = s.now().UTC()
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	if _, ok := s.seen[e.ID]; ok {
-		return nil
+		return false
 	}
 	s.events = append(s.events, e)
 	s.seen[e.ID] = struct{}{}
-	return s.flushLocked()
+	return true
 }
 
 func (s *Store) Snapshot(provider string) (Snapshot, bool) {

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -177,9 +177,14 @@ func (a *App) initLimits() {
 	})
 	if policy.Enabled {
 		cutoff := time.Now().AddDate(0, 0, -a.cfg.Providers.Limits.BackfillDays)
-		if err := limitStore.BackfillLocalSessionFiles(cutoff); err != nil {
-			a.logger.Warn("limits.backfill", "err", err)
-		}
+		a.wg.Go(func() {
+			a.logger.Info("limits.backfill.start", "cutoff", cutoff)
+			if err := limitStore.BackfillLocalSessionFiles(cutoff); err != nil {
+				a.logger.Warn("limits.backfill", "err", err)
+				return
+			}
+			a.logger.Info("limits.backfill.done")
+		})
 	}
 }
 

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -177,9 +177,16 @@ func (a *App) initLimits() {
 	})
 	if policy.Enabled {
 		cutoff := time.Now().AddDate(0, 0, -a.cfg.Providers.Limits.BackfillDays)
+		backfillCtx := a.ctx
+		if backfillCtx == nil {
+			backfillCtx = context.Background()
+		}
 		a.wg.Go(func() {
 			a.logger.Info("limits.backfill.start", "cutoff", cutoff)
-			if err := limitStore.BackfillLocalSessionFiles(cutoff); err != nil {
+			if err := limitStore.BackfillLocalSessionFiles(backfillCtx, cutoff); err != nil {
+				if errors.Is(err, context.Canceled) {
+					return
+				}
 				a.logger.Warn("limits.backfill", "err", err)
 				return
 			}


### PR DESCRIPTION
## Summary
- run provider limit session backfill after startup instead of blocking Wails window creation
- batch session-file imports so limits data is flushed once per backfill
- add tests for dedupe, persistence, and latest snapshot selection

## Test plan
- go test ./...
- mise run dev smoke check
- push hook: go test ./... and frontend svelte-check