### PR TITLE
fix(workflow): harden test outcome routing

### DIFF
--- a/cmd/fake-claude/main.go
+++ b/cmd/fake-claude/main.go
@@ -170,7 +170,17 @@ func runTestPass() {
 func runTestFail() {
 	emitSystem()
 	emitAssistant("Found a defect against the task.")
-	emitResult("Observed wrong output on the happy path.\nTEST_VERDICT: FAIL")
+	emitResult(testFailureReport() + "\nTEST_VERDICT: FAIL")
+}
+
+func testFailureReport() string {
+	return "## Test Failures\n\n" +
+		"Classification: product_bug\n\n" +
+		"Requirement tested: the task says the happy path should render the expected output.\n\n" +
+		"Command run:\n```sh\ncurl /status\n```\n\n" +
+		"Actual output:\n```text\nwrong output\n```\n\n" +
+		"Expected output: expected output.\n\n" +
+		"Code evidence:\n```text\ninternal/fake.go:42: return \"wrong output\"\n```"
 }
 
 // runTestPassVerbose emits a >2000-char summary BEFORE the final-line verdict,

--- a/cmd/fake-codex/main.go
+++ b/cmd/fake-codex/main.go
@@ -96,6 +96,7 @@ func runExec() {
 		emitAgentMessage(`{"verdict":"PASS"}`)
 		emitTurnCompleted(100, 20)
 	case "test_verdict_fail":
+		writeTestFailureReport(taskID)
 		emitAgentMessage(`{"verdict":"FAIL"}`)
 		emitTurnCompleted(100, 20)
 	case "implement", "interactive_implement":
@@ -304,4 +305,15 @@ func runCLI(taskID, subcmd string, args ...string) {
 	if err := cmd.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "sybra-cli failed: %v\n", err)
 	}
+}
+
+func writeTestFailureReport(taskID string) {
+	body := "## Test Failures\n\n" +
+		"Classification: product_bug\n\n" +
+		"Requirement tested: the task says the happy path should render the expected output.\n\n" +
+		"Command run:\n```sh\ncurl /status\n```\n\n" +
+		"Actual output:\n```text\nwrong output\n```\n\n" +
+		"Expected output: expected output.\n\n" +
+		"Code evidence:\n```text\ninternal/fake.go:42: return \"wrong output\"\n```"
+	runCLI(taskID, "update", taskID, "--body", body)
 }

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -52,6 +52,20 @@ export class AgentRun {
     "protocolViolation"?: string;
 
     /**
+     * TestOutcome records the deterministic classification of a test-runner run
+     * (product_bug, infra_failure, ambiguous_requirement, etc.). The testing
+     * router counts only product_bug outcomes against the implementation budget.
+     */
+    "testOutcome"?: string;
+
+    /**
+     * TestFailureFingerprint is a stable hash of the grounded failure report.
+     * Repeated fingerprints mean the same repro survived a fix attempt and should
+     * get targeted human/local reproduction instead of another broad retry.
+     */
+    "testFailureFingerprint"?: string;
+
+    /**
      * HeadSHA is the worktree HEAD commit at this run's completion — what the
      * agent left on the branch. Compared against the merged PR head to detect
      * human edits after the agent (merged_with_edits) and measure edit distance.

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -343,8 +343,11 @@ func (h *humanReviewHandler) fileIssue(taskID, agentID string, v verdictDecision
 	created, url, err := h.sink.SubmitIssue(ctx, v.IssueTitle, v.IssueBody, v.IssueLabels)
 	if err != nil {
 		h.logger.Error("human-review.issue.submit", "task_id", taskID, "agent_id", agentID, "err", err)
-		// On rate limit or transient failure, leave the task in human-required
-		// and append the verdict so the user has the diagnosis text.
+		// On rate limit or transient failure, keep the diagnosis actionable by
+		// falling back to a local Sybra bug task and blocking the origin on it.
+		if h.fileLocalIssueFallback(taskID, agentID, v, err) {
+			return
+		}
 		if h.appendNote(taskID, "Auto-review verdict: sybra_bug (issue submission failed)", v.Summary+"\n\nError: "+err.Error()) {
 			h.markVerdictRendered(taskID, agentID)
 		}
@@ -376,6 +379,54 @@ func (h *humanReviewHandler) fileIssue(taskID, agentID string, v verdictDecision
 		return
 	}
 	h.markVerdictRendered(taskID, agentID)
+}
+
+func (h *humanReviewHandler) fileLocalIssueFallback(taskID, agentID string, v verdictDecision, submitErr error) bool {
+	if strings.TrimSpace(v.IssueTitle) == "" || strings.TrimSpace(v.IssueBody) == "" {
+		return false
+	}
+	body := strings.TrimSpace(v.IssueBody) + "\n\n## Filing failure\n\nGitHub issue filing failed, so Sybra created this local fallback task instead.\n\nError: " + submitErr.Error()
+	newTask, err := h.tasks.Create(v.IssueTitle, body, task.AgentModeHeadless)
+	if err != nil {
+		h.logger.Error("human-review.issue.local-fallback.create", "task_id", taskID, "agent_id", agentID, "err", err)
+		return false
+	}
+	tags := append([]string{"sybra-bug", "issue-filing-failed"}, v.IssueLabels...)
+	update := task.Update{Tags: &tags}
+	if projectID := strings.TrimSpace(h.cfg.HumanReviewRepo()); projectID != "" {
+		update.ProjectID = &projectID
+	}
+	if _, err := h.tasks.Update(newTask.ID, update); err != nil {
+		h.logger.Warn("human-review.issue.local-fallback.tag", "new_task_id", newTask.ID, "err", err)
+	}
+	h.logAudit(audit.EventHumanReviewIssue, taskID, agentID, map[string]any{
+		"created":       true,
+		"url":           "",
+		"title":         v.IssueTitle,
+		"local_task_id": newTask.ID,
+		"fallback":      true,
+		"err":           submitErr.Error(),
+	})
+
+	origin, err := h.tasks.Get(taskID)
+	if err != nil {
+		h.logger.Error("human-review.issue.local-fallback.origin-get", "task_id", taskID, "err", err)
+		return false
+	}
+	noteBody := fmt.Sprintf("**Linked local Sybra bug:** %s\n\n%s\n\nGitHub issue filing failed: %s", newTask.ID, v.Summary, submitErr.Error())
+	newBody := appendSection(origin.Body, "Auto-review verdict: blocked by Sybra bug (local fallback)", noteBody)
+	statusReason := fmt.Sprintf("auto-review: %s (local task %s; issue filing failed)", v.Summary, newTask.ID)
+	upd := task.Update{
+		Body:         &newBody,
+		Status:       task.Ptr(task.StatusBlocked),
+		StatusReason: task.Ptr(statusReason),
+	}
+	if _, err := h.tasks.Update(taskID, upd); err != nil {
+		h.logger.Error("human-review.issue.local-fallback.origin-update", "task_id", taskID, "err", err)
+		return false
+	}
+	h.markVerdictRendered(taskID, agentID)
+	return true
 }
 
 // appendNote appends a section to the task body. Returns true if the update
@@ -489,8 +540,13 @@ func (h *humanReviewHandler) buildPrompt(t task.Task, wctx *WorkScrubContext) st
 	} else {
 		for i := range runs {
 			r := runs[i]
-			fmt.Fprintf(&b, "\n### Run %d — role=%s mode=%s state=%s started=%s\n",
-				i+1, defaultStr(r.Role, "implementation"), r.Mode, r.State, r.StartedAt.Format(time.RFC3339))
+			fmt.Fprintf(&b, "\n### Run %d — role=%s mode=%s provider=%s state=%s started=%s cost=%.4f session=%s\n",
+				i+1, defaultStr(r.Role, "implementation"), r.Mode, defaultStr(r.Provider, "default"),
+				r.State, r.StartedAt.Format(time.RFC3339), r.CostUSD, defaultStr(r.SessionID, "(empty)"))
+			if r.ProtocolViolation != "" || r.TestOutcome != "" || r.TestFailureFingerprint != "" {
+				fmt.Fprintf(&b, "Deterministic test metadata: protocol_violation=%s test_outcome=%s fingerprint=%s\n",
+					defaultStr(r.ProtocolViolation, "(none)"), defaultStr(r.TestOutcome, "(none)"), defaultStr(r.TestFailureFingerprint, "(none)"))
+			}
 			if r.Result != "" {
 				res := r.Result
 				if len(res) > humanReviewMaxAgentResult {
@@ -524,6 +580,8 @@ func (h *humanReviewHandler) buildPrompt(t task.Task, wctx *WorkScrubContext) st
 	b.WriteString("- Working directory is the Sybra source tree. Use Grep/Read/Glob to inspect Go code under internal/ when a stack trace or error message points there.\n")
 	fmt.Fprintf(&b, "- Audit events live under %s (newest file is today's). Run `gh issue list --repo %s --label %s` first to avoid duplicate filings.\n",
 		filepath.Join(h.homeDir, "audit"), h.cfg.HumanReviewRepo(), h.cfg.HumanReviewIssueLabel())
+	b.WriteString("- Trust deterministic workflow signals before inferring from weak provider metadata: status history, exit state, parsed verdict, protocol_violation, test_outcome, failure fingerprint, task body delta, and log tail. Do NOT classify a Codex run as crashed solely because cost=0 or session is empty; confirm from log contents or exit failure.\n")
+	b.WriteString("- For test escalations, separate product_bug, test_protocol_violation, infra_failure, ambiguous_requirement, and missing_evidence. Only grounded product_bug failures should be described as implementation misses.\n")
 	b.WriteString("- A genuine human-required reason looks like: scope question, creative decision, missing credentials, ambiguous requirement, or an external system the agent legitimately cannot reach.\n")
 	b.WriteString("- A Sybra bug looks like: workflow step never ran the agent, agent started in the wrong dir, status flipped despite a successful PR, sidecar required but never written, repeated provider gate blocks, panics in logs, mis-routed completions.\n\n")
 

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -262,7 +262,7 @@ func TestOnComplete_SybraBugVerdict_FilesIssueAndBlocks(t *testing.T) {
 	}
 }
 
-func TestOnComplete_SinkError_LeavesHumanRequired(t *testing.T) {
+func TestOnComplete_SinkError_CreatesLocalFallback(t *testing.T) {
 	t.Parallel()
 	h, tasks, sink, cleanup := newReviewTestEnv(t)
 	defer cleanup()
@@ -287,14 +287,15 @@ func TestOnComplete_SinkError_LeavesHumanRequired(t *testing.T) {
 	if err != nil {
 		t.Fatalf("re-load: %v", err)
 	}
-	if got.Status != task.StatusHumanRequired {
-		t.Errorf("status: got %q want human-required (sink error path)", got.Status)
+	if got.Status != task.StatusBlocked {
+		t.Errorf("status: got %q want blocked (local fallback path)", got.Status)
 	}
 	if got.BlockedByIssue != "" {
 		t.Errorf("BlockedByIssue should be empty on sink error; got %q", got.BlockedByIssue)
 	}
-	if !strings.Contains(got.Body, "issue submission failed") {
-		t.Errorf("expected failure note in body; got:\n%s", got.Body)
+	if !strings.Contains(got.Body, "Auto-review verdict: blocked by Sybra bug (local fallback)") ||
+		!strings.Contains(got.Body, "GitHub issue filing failed: rate limited") {
+		t.Errorf("expected local fallback note in body; got:\n%s", got.Body)
 	}
 }
 

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -126,6 +126,14 @@ func (a *taskAdapter) MarkAgentRunProtocolViolation(taskID, agentID, violation s
 	return a.tasks.UpdateRun(taskID, agentID, map[string]any{"protocol_violation": violation})
 }
 
+func (a *taskAdapter) MarkAgentRunTestOutcome(taskID, agentID, outcome, fingerprint string) error {
+	updates := map[string]any{"test_outcome": outcome}
+	if fingerprint != "" {
+		updates["test_failure_fingerprint"] = fingerprint
+	}
+	return a.tasks.UpdateRun(taskID, agentID, updates)
+}
+
 func (a *taskAdapter) SetWorkflow(id string, wf *workflow.Execution) error {
 	_, err := a.tasks.Update(id, task.Update{Workflow: &wf})
 	return err
@@ -199,11 +207,14 @@ func toRunInfos(runs []task.AgentRun) []workflow.AgentRunInfo {
 	out := make([]workflow.AgentRunInfo, len(runs))
 	for i := range runs {
 		out[i] = workflow.AgentRunInfo{
-			AgentID:           runs[i].AgentID,
-			Role:              runs[i].Role,
-			Provider:          runs[i].Provider,
-			StartedAt:         runs[i].StartedAt,
-			ProtocolViolation: runs[i].ProtocolViolation,
+			AgentID:                runs[i].AgentID,
+			Role:                   runs[i].Role,
+			Provider:               runs[i].Provider,
+			StartedAt:              runs[i].StartedAt,
+			ProtocolViolation:      runs[i].ProtocolViolation,
+			TestOutcome:            runs[i].TestOutcome,
+			TestFailureFingerprint: runs[i].TestFailureFingerprint,
+			HeadSHA:                runs[i].HeadSHA,
 		}
 	}
 	return out

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -197,6 +197,14 @@ type AgentRun struct {
 	// for this run. Test routing uses it to avoid counting a bad verifier report
 	// as an implementation failure across later workflow executions.
 	ProtocolViolation string `yaml:"protocol_violation,omitempty" json:"protocolViolation,omitempty"`
+	// TestOutcome records the deterministic classification of a test-runner run
+	// (product_bug, infra_failure, ambiguous_requirement, etc.). The testing
+	// router counts only product_bug outcomes against the implementation budget.
+	TestOutcome string `yaml:"test_outcome,omitempty" json:"testOutcome,omitempty"`
+	// TestFailureFingerprint is a stable hash of the grounded failure report.
+	// Repeated fingerprints mean the same repro survived a fix attempt and should
+	// get targeted human/local reproduction instead of another broad retry.
+	TestFailureFingerprint string `yaml:"test_failure_fingerprint,omitempty" json:"testFailureFingerprint,omitempty"`
 	// HeadSHA is the worktree HEAD commit at this run's completion — what the
 	// agent left on the branch. Compared against the merged PR head to detect
 	// human edits after the agent (merged_with_edits) and measure edit distance.

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -977,6 +977,12 @@ func (s *Store) UpdateRun(taskID, agentID string, updates map[string]any) error 
 		if v, ok := updates["protocol_violation"].(string); ok && v != "" {
 			t.AgentRuns[i].ProtocolViolation = v
 		}
+		if v, ok := updates["test_outcome"].(string); ok && v != "" {
+			t.AgentRuns[i].TestOutcome = v
+		}
+		if v, ok := updates["test_failure_fingerprint"].(string); ok && v != "" {
+			t.AgentRuns[i].TestFailureFingerprint = v
+		}
 		if v, ok := updates["head_sha"].(string); ok && v != "" {
 			t.AgentRuns[i].HeadSHA = v
 		}

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -645,9 +645,11 @@ func TestStoreUpdateRun(t *testing.T) {
 	}
 
 	err = store.UpdateRun(created.ID, "agent-upd", map[string]any{
-		"state":    "done",
-		"cost_usd": 0.42,
-		"result":   "success",
+		"state":                    "done",
+		"cost_usd":                 0.42,
+		"result":                   "success",
+		"test_outcome":             "product_bug",
+		"test_failure_fingerprint": "abc123",
 	})
 	if err != nil {
 		t.Fatalf("UpdateRun: %v", err)
@@ -669,6 +671,12 @@ func TestStoreUpdateRun(t *testing.T) {
 	}
 	if r.Result != "success" {
 		t.Errorf("Result = %q, want %q", r.Result, "success")
+	}
+	if r.TestOutcome != "product_bug" {
+		t.Errorf("TestOutcome = %q, want product_bug", r.TestOutcome)
+	}
+	if r.TestFailureFingerprint != "abc123" {
+		t.Errorf("TestFailureFingerprint = %q, want abc123", r.TestFailureFingerprint)
 	}
 }
 

--- a/internal/workflow/builtin/simple-task-implement.yaml
+++ b/internal/workflow/builtin/simple-task-implement.yaml
@@ -30,6 +30,12 @@ steps:
         testing — fix the root cause of every reported defect (not just the
         symptom); the feature will be re-tested after this run.
 
+        Before committing broad/sweep changes ("everywhere", "all", "single
+        utility", "unified", "no raw X remains"), derive and run a cheap
+        acceptance probe such as a repo-wide `rg` invariant that would catch
+        missed call sites. If the task has a plan, use its Verification probes
+        as part of your final checks.
+
         Never weaken, skip, delete, comment out, or hardcode tests, snapshots,
         or fixtures to make checks pass, and never edit CI config to neuter a
         gate. If an existing test is genuinely wrong, fix it correctly and

--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -178,6 +178,12 @@ steps:
                 ## Verification
                 - `command` - expected signal
 
+                For sweep/refactor tasks ("everywhere", "all", "single
+                utility", "unified", "no raw X remains"), include at least one
+                cheap acceptance probe such as a repo-wide `rg` invariant that
+                would catch missed call sites. If no mechanical probe is
+                possible, say why.
+
                 ## Stop Conditions
                 - Stop/replan if ...
 

--- a/internal/workflow/builtin/testing-task.yaml
+++ b/internal/workflow/builtin/testing-task.yaml
@@ -72,11 +72,19 @@ steps:
         sandbox is already running for this task — use it. Bind only ephemeral
         ports and tear down anything you start.
 
+        Before looking for defects, derive a cheap acceptance probe from the
+        task when possible. For sweep/refactor wording like "everywhere",
+        "all", "single utility", "unified", or "no raw X remains", run a
+        repo-wide grep/test invariant that would catch missed call sites. Include
+        that command in the failure report when it fails.
+
         For each claimed defect you MUST have: (1) a real command you ran
         and its verbatim output, and (2) when claiming a specific code bug,
         a line quoted from the CURRENT file read with Read/cat/grep — not
         from diff memory. Exclude any claimed defect you cannot back with
-        both. An ungrounded claim is not a defect.
+        both. An ungrounded claim is not a defect. If the runner or provider
+        fails before you can gather this evidence, do not invent a product
+        failure; report the infrastructure failure plainly.
 
         When done:
           - If you found ANY deviation from the task's intent, append a
@@ -84,7 +92,9 @@ steps:
             `sybra-cli update {{.Task.ID}} --body "<full body>"` listing
             per-defect: the exact command run, verbatim output, expected
             behaviour (cite the task), and the quoted code line when
-            relevant. Do NOT suggest fixes — describe symptoms only.
+            relevant. Classify each defect as product_bug, infra_failure,
+            ambiguous_requirement, or missing_evidence in prose. Do NOT suggest
+            fixes — describe symptoms only.
           - Print the verdict as the FINAL line of your output, exactly:
             `TEST_VERDICT: PASS`  (only if you could not break it)
             or

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -52,11 +52,14 @@ type TaskInfo struct {
 
 // AgentRunInfo is the engine-visible subset of a task's agent run.
 type AgentRunInfo struct {
-	AgentID           string
-	Role              string
-	Provider          string
-	StartedAt         time.Time
-	ProtocolViolation string
+	AgentID                string
+	Role                   string
+	Provider               string
+	StartedAt              time.Time
+	ProtocolViolation      string
+	TestOutcome            string
+	TestFailureFingerprint string
+	HeadSHA                string
 }
 
 // TaskProvider reads and updates tasks.
@@ -67,6 +70,7 @@ type TaskProvider interface {
 	UpdateTaskPR(id string, prNumber int) error
 	MarkTaskReviewed(id string) error
 	MarkAgentRunProtocolViolation(taskID, agentID, violation string) error
+	MarkAgentRunTestOutcome(taskID, agentID, outcome, fingerprint string) error
 	SetWorkflow(id string, wf *Execution) error
 	// ConsumeSupervisorSteer prepends a pending watchdog headless-nudge steer to
 	// prompt and clears it, so a re-dispatched (resumed) step's agent carries the

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -53,7 +53,15 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 		return pErr
 	}
 
-	if violation := applyTestVerdictCompletion(wfExec, &output, ctx.Task.Body); violation != "" && output.AgentID != "" {
+	violation, outcome, fingerprint := applyTestVerdictCompletion(wfExec, &output, ctx.Task.Body)
+	if output.AgentID != "" {
+		if outcome != "" {
+			if err := e.tasks.MarkAgentRunTestOutcome(taskID, output.AgentID, outcome, fingerprint); err != nil {
+				return fmt.Errorf("mark test outcome: %w", err)
+			}
+		}
+	}
+	if violation != "" && output.AgentID != "" {
 		if err := e.tasks.MarkAgentRunProtocolViolation(taskID, output.AgentID, violation); err != nil {
 			return fmt.Errorf("mark test protocol violation: %w", err)
 		}
@@ -77,8 +85,10 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 		// line and would otherwise be lost to the 2000-byte prefix truncation
 		// above whenever a thorough test-runner writes a long summary. No-op
 		// (empty) for every non-test step. See route_test_result.
-		if v := extractTestVerdict(output.Output); v != "" {
-			wfExec.SetVar("step."+output.StepID+".verdict", v)
+		if output.Status == "completed" {
+			if v := extractTestVerdict(output.Output); v != "" {
+				wfExec.SetVar("step."+output.StepID+".verdict", v)
+			}
 		}
 	}
 

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -1,6 +1,8 @@
 package workflow
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -31,9 +33,19 @@ const (
 	// {"verdict":"FAIL"}, so the actual failure text must be read from the body
 	// delta written by the runner.
 	testFailureBodyStartLenKey = "body_start_len"
+	testVerdictOutcomeKey      = "outcome"
+	testFailureFingerprintKey  = "failure_fingerprint"
 	testFailuresHeading        = "## Test Failures"
 
-	testProtocolFixSuggestions = "fix-suggestions"
+	testOutcomePass                 = "pass"
+	testOutcomeProductBug           = "product_bug"
+	testOutcomeAmbiguousRequirement = "ambiguous_requirement"
+	testOutcomeInfraFailure         = "infra_failure"
+	testOutcomeMissingEvidence      = "missing_evidence"
+	testOutcomeProtocolViolation    = "protocol_violation"
+
+	testProtocolFixSuggestions  = "fix-suggestions"
+	testProtocolMissingEvidence = "missing-evidence"
 )
 
 // prepareTestVerdictAttemptVars resets per-attempt verdict metadata before a
@@ -46,42 +58,218 @@ func prepareTestVerdictAttemptVars(wfExec *Execution, stepID, body string) {
 	wfExec.SetVar("step."+stepID+"."+testFailureBodyStartLenKey, strconv.Itoa(len(body)))
 	delete(wfExec.Variables, "step."+stepID+".verdict")
 	delete(wfExec.Variables, "step."+stepID+"."+testVerdictTaintedKey)
+	delete(wfExec.Variables, "step."+stepID+"."+testVerdictOutcomeKey)
+	delete(wfExec.Variables, "step."+stepID+"."+testFailureFingerprintKey)
 }
 
 // applyTestVerdictCompletion extracts the machine verdict from run_test output,
 // records protocol violations, and turns protocol-violating reports into failed
 // steps. The run_agent max_retries budget then retries the tester instead of
 // sending implementation agents after a bad report. It returns the violation
-// name when one should be persisted on the underlying AgentRun.
-func applyTestVerdictCompletion(wfExec *Execution, output *StepOutput, body string) string {
+// name when one should be persisted on the underlying AgentRun, plus the typed
+// outcome and failure fingerprint for attempt accounting.
+func applyTestVerdictCompletion(wfExec *Execution, output *StepOutput, body string) (violation, outcome, fingerprint string) {
 	if wfExec == nil || output == nil || output.StepID != testVerdictSourceStep {
-		return ""
+		return "", "", ""
 	}
 	if output.Status != "completed" && output.Status != "failed" {
-		return ""
+		return "", "", ""
 	}
 	v := extractTestVerdict(output.Output)
-	if (v == "" || v == "FAIL") && containsFixSuggestionsInCurrentTestReport(output.Output, body, wfExec, output.StepID) {
+	outcome, fingerprint = classifyTestOutcome(output.Status, output.Output, body, wfExec, output.StepID)
+	if outcome != "" {
+		wfExec.SetVar("step."+output.StepID+"."+testVerdictOutcomeKey, outcome)
+	}
+	if fingerprint != "" {
+		wfExec.SetVar("step."+output.StepID+"."+testFailureFingerprintKey, fingerprint)
+	}
+	if outcome == testOutcomeProtocolViolation {
 		wfExec.SetVar("step."+output.StepID+"."+testVerdictTaintedKey, testProtocolFixSuggestions)
 		output.Status = "failed"
-		output.Output = appendTestProtocolViolation(output.Output)
-		return testProtocolFixSuggestions
+		output.Output = appendTestProtocolViolation(output.Output, "FAIL report contained fix suggestions instead of observed symptoms")
+		return testProtocolFixSuggestions, outcome, fingerprint
+	}
+	if outcome == testOutcomeMissingEvidence {
+		wfExec.SetVar("step."+output.StepID+"."+testVerdictTaintedKey, testProtocolMissingEvidence)
+		output.Status = "failed"
+		output.Output = appendTestProtocolViolation(output.Output, "FAIL report lacked machine-checkable evidence")
+		return testProtocolMissingEvidence, outcome, fingerprint
+	}
+	if outcome == testOutcomeInfraFailure {
+		output.Status = "failed"
+		output.Output = appendTestInfrastructureFailure(output.Output)
+		return "", outcome, fingerprint
 	}
 	if output.Status != "completed" {
-		return ""
+		return "", outcome, fingerprint
 	}
 	if v != "" {
 		wfExec.SetVar("step."+output.StepID+".verdict", v)
 	}
-	return ""
+	return "", outcome, fingerprint
 }
 
-func appendTestProtocolViolation(output string) string {
-	msg := "test-runner protocol violation: FAIL report contained fix suggestions instead of observed symptoms"
+func appendTestProtocolViolation(output, detail string) string {
+	msg := "test-runner protocol violation: " + detail
 	if strings.TrimSpace(output) == "" {
 		return msg
 	}
 	return strings.TrimRight(output, "\n") + "\n\n" + msg
+}
+
+func appendTestInfrastructureFailure(output string) string {
+	msg := "test-runner infrastructure failure: runner exited without a parseable, evidenced verdict"
+	if strings.TrimSpace(output) == "" {
+		return msg
+	}
+	return strings.TrimRight(output, "\n") + "\n\n" + msg
+}
+
+func classifyTestOutcome(status, output, body string, wfExec *Execution, stepID string) (outcome, fingerprint string) {
+	v := extractTestVerdict(output)
+	if status == "failed" {
+		return testOutcomeInfraFailure, ""
+	}
+	if (v == "" || v == "FAIL") && containsFixSuggestionsInCurrentTestReport(output, body, wfExec, stepID) {
+		return testOutcomeProtocolViolation, ""
+	}
+	switch v {
+	case "PASS":
+		return testOutcomePass, ""
+	case "FAIL":
+	default:
+		if currentTestFailureReport(output, body, wfExec, stepID) == "" {
+			return testOutcomeInfraFailure, ""
+		}
+		return testOutcomeMissingEvidence, ""
+	}
+
+	report := currentTestFailureReport(output, body, wfExec, stepID)
+	if strings.TrimSpace(report) == "" {
+		return testOutcomeMissingEvidence, ""
+	}
+	if explicit := explicitTestOutcome(report); explicit != "" {
+		if explicit == testOutcomeProductBug || explicit == testOutcomeAmbiguousRequirement {
+			if !hasGroundedFailureEvidence(report) {
+				return testOutcomeMissingEvidence, ""
+			}
+			return explicit, testFailureFingerprint(report)
+		}
+		return explicit, ""
+	}
+	if !hasGroundedFailureEvidence(report) {
+		return testOutcomeMissingEvidence, ""
+	}
+	return testOutcomeProductBug, testFailureFingerprint(report)
+}
+
+func currentTestFailureReport(output, body string, wfExec *Execution, stepID string) string {
+	if section := testFailSectionOf(output); section != "" {
+		return section
+	}
+	delta, ok := testFailureBodyDelta(body, wfExec, stepID)
+	if !ok || strings.TrimSpace(delta) == "" {
+		return ""
+	}
+	if section := testFailSectionOf(delta); section != "" {
+		return section
+	}
+	return delta
+}
+
+func explicitTestOutcome(report string) string {
+	for _, line := range reportScanLines(report) {
+		field, value, ok := strings.Cut(strings.ToLower(line), ":")
+		if !ok {
+			continue
+		}
+		field = strings.Trim(field, "-* \t")
+		if field != "classification" && field != "class" && field != "type" && field != "outcome" {
+			continue
+		}
+		if outcome := normalizeTestOutcome(value); outcome != "" {
+			return outcome
+		}
+	}
+	return ""
+}
+
+func normalizeTestOutcome(s string) string {
+	token := strings.Trim(strings.ToLower(s), " .;,-_*`\"'")
+	token = strings.NewReplacer("-", "_", " ", "_", ":", "_", ",", "_").Replace(token)
+	token = strings.Trim(token, "_")
+	switch {
+	case outcomeTokenStarts(token, testOutcomeProductBug, "bug", "product_failure"):
+		return testOutcomeProductBug
+	case outcomeTokenStarts(token, testOutcomeInfraFailure, "infrastructure_failure", "infrastructure", "infra"):
+		return testOutcomeInfraFailure
+	case outcomeTokenStarts(token, testOutcomeMissingEvidence, "ungrounded", "no_evidence"):
+		return testOutcomeMissingEvidence
+	case outcomeTokenStarts(token, testOutcomeAmbiguousRequirement, "ambiguous", "spec_ambiguity", "ambiguous_spec"):
+		return testOutcomeAmbiguousRequirement
+	case outcomeTokenStarts(token, testOutcomeProtocolViolation, "test_protocol_violation", "protocol"):
+		return testOutcomeProtocolViolation
+	default:
+		return ""
+	}
+}
+
+func outcomeTokenStarts(token string, candidates ...string) bool {
+	for _, candidate := range candidates {
+		if token == candidate || strings.HasPrefix(token, candidate+"_") {
+			return true
+		}
+	}
+	return false
+}
+
+func reportScanLines(text string) []string {
+	var out []string
+	inFence := false
+	for line := range strings.SplitSeq(text, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			inFence = !inFence
+			continue
+		}
+		if inFence || trimmed == "" || strings.HasPrefix(line, "    ") || strings.HasPrefix(line, "\t") {
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	return out
+}
+
+func hasGroundedFailureEvidence(report string) bool {
+	lower := strings.ToLower(report)
+	hasCommand := containsAny(lower,
+		"command run:", "command:", "reproduction steps:", "repro:", "steps:",
+		"go test ", "npm run ", "pnpm ", "yarn ", "curl ", "rg -n ", "grep ")
+	hasObserved := containsAny(lower,
+		"actual output:", "actual:", "observed:", "stdout:", "stderr:",
+		"exit code", "printed:", "rendered:")
+	hasExpected := containsAny(lower,
+		"expected:", "expected output:", "requirement tested:", "task says", "from the task",
+		"violates", "should render", "should not")
+	hasGrounding := containsAny(lower,
+		"code evidence:", "quoted code", "current source", "src/", "internal/",
+		".go:", ".ts:", ".tsx:", ".svelte:", ".js:", ".jsx:")
+	return hasCommand && hasObserved && hasExpected && hasGrounding
+}
+
+func containsAny(s string, needles ...string) bool {
+	for _, needle := range needles {
+		if strings.Contains(s, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func testFailureFingerprint(report string) string {
+	normalized := strings.Join(strings.Fields(strings.ToLower(report)), " ")
+	sum := sha256.Sum256([]byte(normalized))
+	return hex.EncodeToString(sum[:8])
 }
 
 // containsFixSuggestionsInCurrentTestReport scans the agent result and the task
@@ -298,17 +486,19 @@ func extractTestVerdict(output string) string {
 // The test-runner's job is to PROVE the implementation does not satisfy the
 // task. It prints testVerdictPass only when it failed to break the feature.
 //
-//   - pass  → ready-pr   (a separate workflow opens the PR)
-//   - fail  → in-progress (re-implement, carrying the agent's test-failure
-//     notes in the task body) — until the attempt cap, then human-required.
+//   - pass        → ready-pr (a separate workflow opens the PR)
+//   - product bug → in-progress with the latest grounded repro, until the
+//     distinct-defect cap, then human-required for targeted local reproduction.
+//   - tester/provisioning failures and ambiguous specs do not consume the
+//     implementation retry budget.
 //
 // Counting prior test-runner runs (which persist on the task across the
 // implement→review→test loop) gives a natural, stateless attempt counter:
 // the just-finished run is already recorded, so the Nth failure sees N runs.
 func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Execution, t TaskInfo) (StepOutput, error) {
-	// Read the untruncated verdict var (set in engine_advance from the full
-	// agent output). Anything other than PASS — including a missing verdict from
-	// a crashed/empty run — is treated as a failure, conservative by design.
+	// Read the untruncated verdict/outcome vars (set in engine_advance from the
+	// full agent output and current body delta). Missing or infrastructure-shaped
+	// outcomes fail closed, but do not burn implementation attempts.
 	if wfExec.Variables["step."+testVerdictSourceStep+".verdict"] == "PASS" {
 		if err := e.tasks.UpdateTaskStatus(taskID, "ready-pr", "manual testing passed"); err != nil {
 			return StepOutput{}, err
@@ -319,11 +509,38 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 
 	if violation := wfExec.Variables["step."+testVerdictSourceStep+"."+testVerdictTaintedKey]; violation != "" {
 		reason := "test-runner report violated testing protocol after retry: contained fix suggestions instead of observed symptoms"
+		if violation == testProtocolMissingEvidence {
+			reason = "test-runner report violated testing protocol after retry: missing machine-checkable evidence"
+		}
 		if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
 			return StepOutput{}, err
 		}
 		e.logger.Warn("workflow.test.protocol-violation", "task_id", taskID, "violation", violation)
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "protocol violation: " + violation}, nil
+	}
+	outcome := wfExec.Variables["step."+testVerdictSourceStep+"."+testVerdictOutcomeKey]
+	switch outcome {
+	case testOutcomeInfraFailure:
+		reason := "testing infrastructure failed after retry — no implementation attempt consumed; rerun testing or inspect the test-runner log"
+		if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
+			return StepOutput{}, err
+		}
+		e.logger.Warn("workflow.test.infra-failure", "task_id", taskID)
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "infra failure"}, nil
+	case testOutcomeMissingEvidence:
+		reason := "test-runner failed without grounded evidence after retry — needs local reproduction before implementation retries"
+		if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
+			return StepOutput{}, err
+		}
+		e.logger.Warn("workflow.test.missing-evidence", "task_id", taskID)
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "missing evidence"}, nil
+	case testOutcomeAmbiguousRequirement:
+		reason := "testing found ambiguous or contradictory requirements — human decision needed; see latest ## Test Failures"
+		if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
+			return StepOutput{}, err
+		}
+		e.logger.Warn("workflow.test.ambiguous-requirement", "task_id", taskID)
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "ambiguous requirement"}, nil
 	}
 
 	// Count test-runner runs that belong to the current testing cycle.
@@ -331,26 +548,23 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 	// set to the re-dispatch time; runs before that time are from prior cycles
 	// and must not inflate the counter. Nil means no re-dispatch has happened
 	// (first cycle or automatic implement→test loop), so all runs count.
-	attempts := 0
-	for i := range t.AgentRuns {
-		if t.AgentRuns[i].Role != testRunnerRole {
-			continue
-		}
-		if t.AgentRuns[i].ProtocolViolation != "" {
-			continue
-		}
-		if t.TestingCycleStartedAt != nil && t.AgentRuns[i].StartedAt.Before(*t.TestingCycleStartedAt) {
-			continue
-		}
-		attempts++
-	}
+	attempts, duplicate := e.countValidProductTestAttempts(t, wfExec)
 	limit := e.maxTestAttempts
 	if limit <= 0 {
 		limit = defaultTestAttempts
 	}
 
+	if duplicate {
+		reason := "same grounded test failure reproduced twice — needs targeted local reproduction/fix from latest ## Test Failures"
+		if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
+			return StepOutput{}, err
+		}
+		e.logger.Warn("workflow.test.duplicate-failure", "task_id", taskID)
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "duplicate failure"}, nil
+	}
+
 	if attempts >= limit {
-		reason := fmt.Sprintf("manual testing failed %d×: feature still does not match the task — needs a human", attempts)
+		reason := fmt.Sprintf("manual testing found %d grounded product defects: feature still does not match the task — needs targeted local reproduction/fix from latest ## Test Failures", attempts)
 		if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
 			return StepOutput{}, err
 		}
@@ -365,10 +579,63 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 	if err := e.tasks.MarkTaskReviewed(taskID); err != nil {
 		e.logger.Warn("workflow.test.mark-reviewed", "task_id", taskID, "err", err)
 	}
-	reason := "manual testing found defects — re-implementing (see ## Test Failures in the task)"
+	reason := "manual testing found a grounded product defect — re-implementing the latest ## Test Failures repro"
 	if err := e.tasks.UpdateTaskStatus(taskID, "in-progress", reason); err != nil {
 		return StepOutput{}, err
 	}
 	e.logger.Info("workflow.test.reimplement", "task_id", taskID, "attempts", attempts, "cap", limit)
 	return StepOutput{StepID: step.ID, Status: "completed", Output: "reimplement"}, nil
+}
+
+func (e *Engine) countValidProductTestAttempts(t TaskInfo, wfExec *Execution) (int, bool) {
+	currentFingerprint := wfExec.Variables["step."+testVerdictSourceStep+"."+testFailureFingerprintKey]
+	attempts := 0
+	lastMatchingFailure := -1
+	currentMatchingFailure := -1
+	for i := range t.AgentRuns {
+		run := t.AgentRuns[i]
+		if t.TestingCycleStartedAt != nil && run.StartedAt.Before(*t.TestingCycleStartedAt) {
+			continue
+		}
+		if run.Role != testRunnerRole {
+			continue
+		}
+		if run.ProtocolViolation != "" {
+			continue
+		}
+		switch run.TestOutcome {
+		case "", testOutcomeProductBug:
+			attempts++
+			if currentFingerprint != "" && run.TestFailureFingerprint == currentFingerprint {
+				lastMatchingFailure = currentMatchingFailure
+				currentMatchingFailure = i
+			}
+		default:
+			continue
+		}
+	}
+	return attempts, currentMatchingFailure >= 0 &&
+		lastMatchingFailure >= 0 &&
+		hasInterveningCodeAuthorRun(t.AgentRuns, lastMatchingFailure, currentMatchingFailure)
+}
+
+func hasInterveningCodeAuthorRun(runs []AgentRunInfo, prev, current int) bool {
+	if prev < 0 || current <= prev || current > len(runs) {
+		return false
+	}
+	for i := prev + 1; i < current; i++ {
+		if isCodeAuthorRun(runs[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+func isCodeAuthorRun(run AgentRunInfo) bool {
+	switch run.Role {
+	case "", "implementation", "fix-review", "pr-fix":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -244,7 +244,7 @@ func hasGroundedFailureEvidence(report string) bool {
 	lower := strings.ToLower(report)
 	hasCommand := containsAny(lower,
 		"command run:", "command:", "reproduction steps:", "repro:", "steps:",
-		"go test ", "npm run ", "pnpm ", "yarn ", "curl ", "rg -n ", "grep ")
+		"go test ", "npm run ", "pnpm ", "yarn ", "curl ", "rg ", "grep ")
 	hasObserved := containsAny(lower,
 		"actual output:", "actual:", "observed:", "stdout:", "stderr:",
 		"exit code", "printed:", "rendered:")
@@ -620,7 +620,7 @@ func (e *Engine) countValidProductTestAttempts(t TaskInfo, wfExec *Execution) (i
 }
 
 func hasInterveningCodeAuthorRun(runs []AgentRunInfo, prev, current int) bool {
-	if prev < 0 || current <= prev || current > len(runs) {
+	if prev < 0 || current <= prev || current >= len(runs) {
 		return false
 	}
 	for i := prev + 1; i < current; i++ {

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -155,6 +155,145 @@ func TestContainsFixSuggestionsInCurrentTestReport_MissingBodyStartIgnoresStaleB
 	}
 }
 
+func TestApplyTestVerdictCompletion_ClassifiesOutcomes(t *testing.T) {
+	t.Parallel()
+
+	initialBody := "## Problem\nExercise the testing gate."
+	groundedReport := "\n\n## Test Failures\n\n" +
+		"Requirement tested: the task says the status endpoint should return HTTP 200.\n\n" +
+		"Command run:\n```sh\ncurl -i http://localhost/status\n```\n\n" +
+		"Actual output:\n```text\nHTTP/1.1 500 Internal Server Error\n```\n\n" +
+		"Expected: HTTP 200.\n\n" +
+		"Code evidence:\n```text\ninternal/server.go:42: return http.StatusInternalServerError\n```\n"
+	cases := []struct {
+		name       string
+		status     string
+		output     string
+		bodySuffix string
+		want       string
+		wantStatus string
+		wantTaint  string
+	}{
+		{
+			name:       "product_bug",
+			status:     "completed",
+			output:     `{"verdict":"FAIL"}`,
+			bodySuffix: groundedReport,
+			want:       testOutcomeProductBug,
+			wantStatus: "completed",
+		},
+		{
+			name:       "ambiguous_requirement",
+			status:     "completed",
+			output:     `{"verdict":"FAIL"}`,
+			bodySuffix: strings.ReplaceAll(groundedReport, "Requirement tested:", "Classification: ambiguous_requirement: task says two incompatible things\n\nRequirement tested:"),
+			want:       testOutcomeAmbiguousRequirement,
+			wantStatus: "completed",
+		},
+		{
+			name:       "actual_output_mentions_ambiguous_but_product_bug",
+			status:     "completed",
+			output:     `{"verdict":"FAIL"}`,
+			bodySuffix: strings.ReplaceAll(groundedReport, "HTTP/1.1 500 Internal Server Error", `{"error":"ambiguous requirement"}`),
+			want:       testOutcomeProductBug,
+			wantStatus: "completed",
+		},
+		{
+			name:       "explicit_infra_failure_with_evidence",
+			status:     "completed",
+			output:     `{"verdict":"FAIL"}`,
+			bodySuffix: strings.ReplaceAll(groundedReport, "Requirement tested:", "Classification: infra_failure, Docker daemon unavailable\n\nRequirement tested:"),
+			want:       testOutcomeInfraFailure,
+			wantStatus: "failed",
+		},
+		{
+			name:       "expected_output_counts_as_evidence",
+			status:     "completed",
+			output:     `{"verdict":"FAIL"}`,
+			bodySuffix: strings.ReplaceAll(groundedReport, "Expected:", "Expected output:"),
+			want:       testOutcomeProductBug,
+			wantStatus: "completed",
+		},
+		{
+			name:       "missing_evidence",
+			status:     "completed",
+			output:     `{"verdict":"FAIL"}`,
+			bodySuffix: "\n\n## Test Failures\n\nIt broke.\n",
+			want:       testOutcomeMissingEvidence,
+			wantStatus: "failed",
+			wantTaint:  testProtocolMissingEvidence,
+		},
+		{
+			name:       "explicit_product_bug_still_requires_evidence",
+			status:     "completed",
+			output:     `{"verdict":"FAIL"}`,
+			bodySuffix: "\n\n## Test Failures\n\nClassification: product_bug\n\nCommand run: curl /status\nActual output: HTTP 500\nExpected: HTTP 200 with one line JSON response\n",
+			want:       testOutcomeMissingEvidence,
+			wantStatus: "failed",
+			wantTaint:  testProtocolMissingEvidence,
+		},
+		{
+			name:       "expected_output_does_not_count_as_observed_output",
+			status:     "completed",
+			output:     `{"verdict":"FAIL"}`,
+			bodySuffix: "\n\n## Test Failures\n\nCommand run: curl /status\nExpected output: HTTP 200\nCode evidence: internal/server.go:42: return http.StatusInternalServerError\n",
+			want:       testOutcomeMissingEvidence,
+			wantStatus: "failed",
+			wantTaint:  testProtocolMissingEvidence,
+		},
+		{
+			name:       "infra_failure",
+			status:     "completed",
+			output:     `{}`,
+			bodySuffix: "",
+			want:       testOutcomeInfraFailure,
+			wantStatus: "failed",
+		},
+		{
+			name:       "failed_process_with_pass_verdict_is_infra",
+			status:     "failed",
+			output:     `{"verdict":"PASS"}`,
+			bodySuffix: "",
+			want:       testOutcomeInfraFailure,
+			wantStatus: "failed",
+		},
+		{
+			name:       "pass",
+			status:     "completed",
+			output:     `{"verdict":"PASS"}`,
+			bodySuffix: "",
+			want:       testOutcomePass,
+			wantStatus: "completed",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			body := initialBody + tc.bodySuffix
+			wf := &Execution{Variables: map[string]string{}}
+			prepareTestVerdictAttemptVars(wf, testVerdictSourceStep, initialBody)
+			out := StepOutput{StepID: testVerdictSourceStep, Status: tc.status, Output: tc.output}
+			violation, outcome, fingerprint := applyTestVerdictCompletion(wf, &out, body)
+			if outcome != tc.want {
+				t.Fatalf("outcome = %q, want %q", outcome, tc.want)
+			}
+			if out.Status != tc.wantStatus {
+				t.Fatalf("status = %q, want %q", out.Status, tc.wantStatus)
+			}
+			if got := wf.Variables["step."+testVerdictSourceStep+"."+testVerdictOutcomeKey]; got != tc.want {
+				t.Fatalf("workflow outcome = %q, want %q", got, tc.want)
+			}
+			if tc.wantTaint != "" && violation != tc.wantTaint {
+				t.Fatalf("violation = %q, want %q", violation, tc.wantTaint)
+			}
+			if (tc.want == testOutcomeProductBug || tc.want == testOutcomeAmbiguousRequirement) && fingerprint == "" {
+				t.Fatal("fingerprint is empty for evidenced failure")
+			}
+		})
+	}
+}
+
 // makeTestEngine builds a minimal Engine for route_test_result unit tests.
 func makeTestEngine(t *testing.T) (*Engine, *memTasks) {
 	t.Helper()
@@ -187,6 +326,15 @@ func runRouteTestResult(e *Engine, tasks *memTasks, taskID, verdict string, wfSt
 	}
 	ti, _ := tasks.GetTask(taskID)
 	return e.execRouteTestResult(taskID, step, wfExec, ti)
+}
+
+func mustGetTaskInfo(t *testing.T, tasks *memTasks, taskID string) TaskInfo {
+	t.Helper()
+	ti, err := tasks.GetTask(taskID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ti
 }
 
 func makeTestingTaskEngine(t *testing.T) (*Engine, *memTasks, *mockAgents) {
@@ -380,6 +528,60 @@ func TestAdvanceStep_TestProtocolViolationAfterRetryStopsWithProtocolReason(t *t
 	}
 }
 
+func TestAdvanceStep_FailedRunnerWithPassMarkerRoutesAsInfraFailure(t *testing.T) {
+	t.Parallel()
+	engine, tasks, agents := makeTestingTaskEngine(t)
+
+	initialBody := "## Problem\nExercise the testing gate."
+	wf := &Execution{
+		WorkflowID:  "testing-task",
+		CurrentStep: testVerdictSourceStep,
+		State:       ExecWaiting,
+		Variables:   map[string]string{},
+		StartedAt:   time.Now().UTC(),
+		StepHistory: []StepRecord{{
+			StepID: testVerdictSourceStep,
+			Status: "failed",
+		}},
+	}
+	prepareTestVerdictAttemptVars(wf, testVerdictSourceStep, initialBody)
+	tasks.Put(TaskInfo{
+		ID:        "t-failed-pass",
+		Status:    "testing",
+		Body:      initialBody,
+		AgentMode: "headless",
+		Workflow:  wf,
+		AgentRuns: []AgentRunInfo{{AgentID: "agent-failed-pass", Role: testRunnerRole}},
+	})
+
+	err := engine.AdvanceStep("t-failed-pass", StepOutput{
+		StepID:  testVerdictSourceStep,
+		Status:  "failed",
+		Output:  "runner crashed after printing\nTEST_VERDICT: PASS",
+		AgentID: "agent-failed-pass",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := agents.CallCount(); got != 0 {
+		t.Fatalf("retry StartAgent calls = %d, want 0 after retry budget exhausted", got)
+	}
+	got, err := tasks.GetTask("t-failed-pass")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required", got.Status)
+	}
+	if reason := tasks.Reason("t-failed-pass"); !strings.Contains(reason, "infrastructure failed") {
+		t.Errorf("status reason = %q, want infrastructure failure", reason)
+	}
+	if got.AgentRuns[0].TestOutcome != testOutcomeInfraFailure {
+		t.Errorf("test outcome = %q, want %q", got.AgentRuns[0].TestOutcome, testOutcomeInfraFailure)
+	}
+}
+
 func TestRouteTestResult_Pass(t *testing.T) {
 	t.Parallel()
 	e, tasks := makeTestEngine(t)
@@ -453,6 +655,118 @@ func TestRouteTestResult_ProtocolViolationRunsDoNotCountTowardCap(t *testing.T) 
 		t.Errorf("output = %q, want reimplement", out.Output)
 	}
 	ti, _ := tasks.GetTask("t3-protocol")
+	if ti.Status != "in-progress" {
+		t.Errorf("status = %q, want in-progress", ti.Status)
+	}
+}
+
+func TestRouteTestResult_InfraFailureDoesNotCountTowardCap(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	now := time.Now().UTC()
+	runs := []AgentRunInfo{
+		{AgentID: "valid-1", Role: testRunnerRole, StartedAt: now, TestOutcome: testOutcomeProductBug},
+		{AgentID: "infra", Role: testRunnerRole, StartedAt: now.Add(time.Minute), TestOutcome: testOutcomeInfraFailure},
+	}
+	tasks.Put(TaskInfo{
+		ID:        "t-infra",
+		Status:    "testing",
+		AgentRuns: runs,
+	})
+	wf := &Execution{
+		WorkflowID: "testing-task",
+		StartedAt:  now,
+		Variables: map[string]string{
+			"step." + testVerdictSourceStep + "." + testVerdictOutcomeKey: testOutcomeInfraFailure,
+		},
+	}
+	out, err := e.execRouteTestResult("t-infra", &Step{ID: "route_test"}, wf, mustGetTaskInfo(t, tasks, "t-infra"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "infra failure" {
+		t.Errorf("output = %q, want infra failure", out.Output)
+	}
+	ti, _ := tasks.GetTask("t-infra")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+	if reason := tasks.Reason("t-infra"); !strings.Contains(reason, "no implementation attempt consumed") {
+		t.Errorf("reason = %q, want no implementation attempt consumed", reason)
+	}
+}
+
+func TestRouteTestResult_DuplicateFailureEscalatesWithoutAnotherRetry(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	now := time.Now().UTC()
+	fp := "same-repro"
+	runs := []AgentRunInfo{
+		{AgentID: "first", Role: testRunnerRole, StartedAt: now, TestOutcome: testOutcomeProductBug, TestFailureFingerprint: fp},
+		{AgentID: "impl", Role: "implementation", StartedAt: now.Add(time.Minute)},
+		{AgentID: "second", Role: testRunnerRole, StartedAt: now.Add(2 * time.Minute), TestOutcome: testOutcomeProductBug, TestFailureFingerprint: fp},
+	}
+	tasks.Put(TaskInfo{
+		ID:        "t-dup",
+		Status:    "testing",
+		AgentRuns: runs,
+	})
+	wf := &Execution{
+		WorkflowID: "testing-task",
+		StartedAt:  now,
+		Variables: map[string]string{
+			"step." + testVerdictSourceStep + ".verdict":                      "FAIL",
+			"step." + testVerdictSourceStep + "." + testVerdictOutcomeKey:     testOutcomeProductBug,
+			"step." + testVerdictSourceStep + "." + testFailureFingerprintKey: fp,
+		},
+	}
+	out, err := e.execRouteTestResult("t-dup", &Step{ID: "route_test"}, wf, mustGetTaskInfo(t, tasks, "t-dup"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "duplicate failure" {
+		t.Errorf("output = %q, want duplicate failure", out.Output)
+	}
+	ti, _ := tasks.GetTask("t-dup")
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+	if reason := tasks.Reason("t-dup"); !strings.Contains(reason, "same grounded test failure") {
+		t.Errorf("reason = %q, want duplicate failure", reason)
+	}
+}
+
+func TestRouteTestResult_DuplicateFailureWithoutInterveningFixDoesNotEscalate(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	now := time.Now().UTC()
+	fp := "same-repro"
+	runs := []AgentRunInfo{
+		{AgentID: "first", Role: testRunnerRole, StartedAt: now, TestOutcome: testOutcomeProductBug, TestFailureFingerprint: fp},
+		{AgentID: "retry", Role: testRunnerRole, StartedAt: now.Add(time.Minute), TestOutcome: testOutcomeProductBug, TestFailureFingerprint: fp},
+	}
+	tasks.Put(TaskInfo{
+		ID:        "t-dup-no-fix",
+		Status:    "testing",
+		AgentRuns: runs,
+	})
+	wf := &Execution{
+		WorkflowID: "testing-task",
+		StartedAt:  now,
+		Variables: map[string]string{
+			"step." + testVerdictSourceStep + ".verdict":                      "FAIL",
+			"step." + testVerdictSourceStep + "." + testVerdictOutcomeKey:     testOutcomeProductBug,
+			"step." + testVerdictSourceStep + "." + testFailureFingerprintKey: fp,
+		},
+	}
+	out, err := e.execRouteTestResult("t-dup-no-fix", &Step{ID: "route_test"}, wf, mustGetTaskInfo(t, tasks, "t-dup-no-fix"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "reimplement" {
+		t.Errorf("output = %q, want reimplement", out.Output)
+	}
+	ti, _ := tasks.GetTask("t-dup-no-fix")
 	if ti.Status != "in-progress" {
 		t.Errorf("status = %q, want in-progress", ti.Status)
 	}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -180,6 +180,23 @@ func (m *memTasks) MarkAgentRunProtocolViolation(taskID, agentID, violation stri
 	return fmt.Errorf("agent run %s not found for task %s", agentID, taskID)
 }
 
+func (m *memTasks) MarkAgentRunTestOutcome(taskID, agentID, outcome, fingerprint string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	t, ok := m.tasks[taskID]
+	if !ok {
+		return fmt.Errorf("task %s not found", taskID)
+	}
+	for i := range t.AgentRuns {
+		if t.AgentRuns[i].AgentID == agentID {
+			t.AgentRuns[i].TestOutcome = outcome
+			t.AgentRuns[i].TestFailureFingerprint = fingerprint
+			return nil
+		}
+	}
+	return fmt.Errorf("agent run %s not found for task %s", agentID, taskID)
+}
+
 func (m *memTasks) SetWorkflow(id string, wf *Execution) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
## Summary
- persist typed test-runner outcomes and failure fingerprints on agent runs
- route infra failures, missing evidence, protocol violations, ambiguity, and product bugs separately
- count only grounded product bugs toward implementation retry budget and require an intervening code-author run before duplicate-fingerprint escalation
- make human-review use deterministic test metadata and fall back to a local Sybra bug task when GitHub issue filing fails
- update plan/implement/test prompts to require cheap acceptance probes for broad sweep tasks

## Validation
- go test ./internal/workflow -run 'TestApplyTestVerdictCompletion|TestAdvanceStep_FailedRunnerWithPassMarker|TestRouteTestResult'
- go test ./internal/workflow ./internal/task ./internal/sybra -run 'Test(ApplyTestVerdictCompletion|AdvanceStep_FailedRunnerWithPassMarker|RouteTestResult|StoreUpdateRun|OnComplete_SinkError|OnComplete_SybraBug|OnComplete_WorkProject)'
- go test ./internal/... -run '^$'

Note: the default pre-push hook's broader test run hit unrelated git temp/worktree failures in project/worktree/sybra tests on this machine; the targeted workflow/task/sybra tests and internal package compile check passed before push.