### PR TITLE
Fix stale plan approval workflow state

### DIFF
--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -26,6 +26,10 @@ func (e *Engine) HandleHumanAction(taskID, action string, data map[string]string
 	if err != nil {
 		return err
 	}
+	t, err = e.advanceSatisfiedWaitForStatus(taskID, t)
+	if err != nil {
+		return err
+	}
 	if t.Workflow == nil || t.Workflow.State != ExecWaiting {
 		return fmt.Errorf("task %s is not waiting for human action", taskID)
 	}
@@ -59,6 +63,42 @@ func (e *Engine) HandleHumanAction(taskID, action string, data map[string]string
 		Status: "completed",
 		Output: action,
 	})
+}
+
+// advanceSatisfiedWaitForStatus repairs the common "missed watcher event"
+// state where a run_agent step is waiting for a status that the task already
+// has. This lets human approve/reject clicks reconcile the workflow before
+// validating that the current step is wait_human.
+func (e *Engine) advanceSatisfiedWaitForStatus(taskID string, t TaskInfo) (TaskInfo, error) {
+	if t.Workflow == nil || t.Workflow.CurrentStep == "" {
+		return t, nil
+	}
+	if t.Workflow.State != ExecWaiting && t.Workflow.State != ExecRunning {
+		return t, nil
+	}
+
+	def, err := e.store.Get(t.Workflow.WorkflowID)
+	if err != nil {
+		return t, err
+	}
+	step := def.StepByID(t.Workflow.CurrentStep)
+	if step == nil {
+		return t, fmt.Errorf("step %s not found in workflow %s", t.Workflow.CurrentStep, def.ID)
+	}
+	if step.Type != StepRunAgent || step.Config.WaitForStatus == "" || step.Config.WaitForStatus != t.Status {
+		return t, nil
+	}
+
+	e.logger.Info("workflow.wait-for-status.reconcile",
+		"task_id", taskID, "step", step.ID, "status", t.Status)
+	if err := e.AdvanceStep(taskID, StepOutput{
+		StepID: step.ID,
+		Status: "completed",
+		Output: "status:" + t.Status,
+	}); err != nil {
+		return TaskInfo{}, err
+	}
+	return e.tasks.GetTask(taskID)
 }
 
 // HandleStatusChange is called when a task's status transitions. If the

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1979,6 +1979,39 @@ func TestPlanReuse_ApproveAdvancesPastReviewPlan(t *testing.T) {
 	}
 }
 
+func TestPlanReuse_ApproveReconcilesMissedWaitForStatus(t *testing.T) {
+	store := newTestStoreWith(t, "test-plan-reuse.yaml")
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{ID: "t1", Status: "planning", AgentMode: "interactive"})
+	if err := engine.StartWorkflow("t1", "test-plan-reuse"); err != nil {
+		t.Fatalf("start workflow: %v", err)
+	}
+
+	// Simulate a cross-process sybra-cli status write that happened while the
+	// app was down, or whose watcher event was missed: the task is visibly
+	// plan-review, but the workflow is still parked on the run_agent step.
+	tasks.SetStatus("t1", "plan-review")
+	stuck, _ := tasks.GetTask("t1")
+	if stuck.Workflow.CurrentStep != "plan" {
+		t.Fatalf("precondition: CurrentStep = %q, want plan", stuck.Workflow.CurrentStep)
+	}
+
+	if err := engine.HandleHumanAction("t1", "approve", nil); err != nil {
+		t.Fatalf("approve should reconcile stale wait_for_status step: %v", err)
+	}
+
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "in-progress" {
+		t.Errorf("Status = %q, want in-progress", ti.Status)
+	}
+	if ti.Workflow.State != ExecCompleted {
+		t.Errorf("State = %q, want ExecCompleted", ti.Workflow.State)
+	}
+}
+
 // --- ensure_pr_closes_issue step ---
 
 // fakePRLinker is a scripted PRLinker used by executor tests.


### PR DESCRIPTION
## Summary
- reconcile satisfied `wait_for_status` run-agent steps before processing plan approve/reject actions
- prevent `plan-review` tasks from failing approval with “not at a wait_human step” after a missed status-change event
- add regression coverage for stale plan approval state

## Tests
- `go test ./internal/workflow -run TestPlanReuse_ApproveReconcilesMissedWaitForStatus`
- `go test ./internal/workflow`
- `go test ./internal/sybra -run 'TestPlanningService_|TestApp_WatcherStatusHook_AdvancesWorkflow|TestApp_StatusHook_AdvancesWorkflow'`\n\nNote: pre-push/full package tests currently hit unrelated git fixture failures in `internal/project`, `internal/worktree`, and `internal/sybra` (`fatal: not in a git directory`).