### PR TITLE
fix(testing): require execution + grounded claims

### DIFF
--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -576,6 +576,10 @@ var fixSuggestionPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`\buse\s+\S+\s+instead\s+of\s+\S+`),
 }
 
+// fixSuggestionPhrases are case-insensitive substrings that signal the test
+// runner prescribed a code change rather than described observed behavior.
+// False positives are acceptable — the taint is advisory and never changes the
+// FAIL verdict or adds an extra re-implementation loop.
 var fixSuggestionPhrases = []string{
 	"you should fix",
 	"you should change",

--- a/internal/workflow/fix_suggestion_adversarial_test.go
+++ b/internal/workflow/fix_suggestion_adversarial_test.go
@@ -1,0 +1,11 @@
+package workflow
+
+import "testing"
+
+func TestAdversarialFixSuggestionRejected(t *testing.T) {
+	t.Parallel()
+	output := "## Test Failures\n\nCommand run: go test ./internal/workflow\nActual output: FAIL\nExpected: PASS\nCode evidence: engine_steps_testroute.go: change AgentRun.Verdict to VerdictRendered\nTEST_VERDICT: FAIL\n"
+	if got := containsFixSuggestions(output); !got {
+		t.Errorf("containsFixSuggestions(%q) = false, want true", output)
+	}
+}


### PR DESCRIPTION
## Motivation

Testing agents were hallucinating FAILs by reading code statically rather than running the app, then embedding fix suggestions in the report — both violations of the sybra-test skill contract. This caused the implementer to receive misleading, tainted test reports.

Closes https://github.com/Automaat/sybra/issues/1154

> Changelog: fix(testing): require execution + grounded claims

## Implementation information

Two-layer defense:

**Skill / prompt layer (primary):**
- Adds mandatory Step 6 "Ground every claimed defect": each defect requires verbatim command output proving execution and a quoted source line read from the current working tree
- Strengthens `## Test Failures` format to require `Command/Output/Expected/Code-evidence` fields per defect
- Promotes "No fix suggestions" to a bolded prominent rule with examples of forbidden phrases, noting mechanical detection
- Adds "No static-analysis FAILs" rule: reading code is orientation only, not a substitute for running the app
- Mirrors grounding + fix-suggestion requirements in `testing-task.yaml` workflow prompt

**Mechanical layer (secondary):**
- `containsFixSuggestions()`: scans the `## Test Failures` section of FAIL output for imperative fix-prescription phrases and structural prescription forms (`change X to Y`, `replace X with Y`, `use X instead of Y`)
- `route_test_result`: when tainted, annotates the in-progress status reason with a warning visible to the re-implementing agent via `sybra-cli get`
- Refactors single regex into a `fixSuggestionPatterns` slice for easy extension
- 24 unit tests covering fix-suggestion phrases, change-X-to-Y forms, symptom-only reports, missing sections, and preamble-only cases