### PR TITLE
fix(workflow): persist tester failure reports

### DIFF
--- a/internal/skills/data/sybra-test.md
+++ b/internal/skills/data/sybra-test.md
@@ -15,7 +15,11 @@ You run headless, inside the task's own git worktree, with no human in the loop.
 
 ## Output contract (required)
 
-The **final line** of your output MUST be exactly one of:
+If your runtime enforces a JSON output schema, return a JSON object with
+`verdict` (`PASS` or `FAIL`), optional `outcome`, and on FAIL a
+`failures_markdown` string containing the full `## Test Failures` report.
+
+Otherwise, the **final line** of your output MUST be exactly one of:
 
 ```
 TEST_VERDICT: PASS
@@ -26,12 +30,9 @@ TEST_VERDICT: FAIL
 
 `PASS` only when you genuinely could not break it. Anything ambiguous, unreproducible-but-suspicious, or unverifiable → `FAIL` (be conservative; a false PASS ships a broken feature).
 
-On **FAIL**, before printing the verdict, append a `## Test Failures` section to the task body so the re-implementation agent sees it:
-
-```bash
-sybra-cli get <task-id>                      # read current body
-sybra-cli update <task-id> --body "<full body + ## Test Failures>"
-```
+On **FAIL**, include a `## Test Failures` section in your final output (or in
+`failures_markdown` for JSON output). Do **not** call `sybra-cli update` or
+mutate the task body; Sybra ingests your final report and appends it atomically.
 
 In `## Test Failures` record, per defect: what you did (exact steps/commands), what you expected (cite the task), what actually happened (paste the error/output). **Describe symptoms only — do NOT propose fixes.** The implementer diagnoses; you report.
 

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -679,7 +679,10 @@ func urlOrPlaceholder(url, title string) string {
 // re-spawn so the task is not permanently stranded in human-required.
 func verdictAlreadyRendered(t task.Task) bool {
 	for i := range t.AgentRuns {
-		if t.AgentRuns[i].Role == string(agent.RoleHumanReview) && t.AgentRuns[i].VerdictRendered {
+		if t.AgentRuns[i].Role != string(agent.RoleHumanReview) || !t.AgentRuns[i].VerdictRendered {
+			continue
+		}
+		if t.TestingCycleStartedAt == nil || !t.AgentRuns[i].StartedAt.Before(*t.TestingCycleStartedAt) {
 			return true
 		}
 	}

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -463,6 +463,48 @@ func TestMaybeSpawn_IdempotencyGate_SkipsWhenVerdictRendered(t *testing.T) {
 	}
 }
 
+func TestMaybeSpawn_IdempotencyGate_IgnoresRenderedVerdictBeforeTestingCycle(t *testing.T) {
+	t.Parallel()
+	h, tasks, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	tk, err := tasks.Create("Re-tested task", "Body.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	cycleStart := time.Now().UTC()
+	if _, err := tasks.Update(tk.ID, task.Update{
+		Status:                task.Ptr(task.StatusHumanRequired),
+		TestingCycleStartedAt: &cycleStart,
+	}); err != nil {
+		t.Fatalf("flip to human-required: %v", err)
+	}
+	if err := tasks.AddRun(tk.ID, task.AgentRun{
+		AgentID:         "agent-old-review",
+		Role:            string(agent.RoleHumanReview),
+		Mode:            "headless",
+		State:           "stopped",
+		StartedAt:       cycleStart.Add(-time.Minute),
+		Verdict:         "human",
+		VerdictRendered: true,
+	}); err != nil {
+		t.Fatalf("add prior run: %v", err)
+	}
+
+	panicked := func() (p bool) {
+		defer func() {
+			if r := recover(); r != nil {
+				p = true
+			}
+		}()
+		h.maybeSpawn(tk.ID, "")
+		return false
+	}()
+	if !panicked {
+		t.Fatal("expected spawn attempt; old rendered verdict must not block a new testing cycle")
+	}
+}
+
 func TestMaybeSpawn_IdempotencyGate_SpawnsWhenVerdictSetButNotRendered(t *testing.T) {
 	t.Parallel()
 	// Regression test for the crash-window: Verdict persisted by onAgentComplete

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -134,6 +134,11 @@ func (a *taskAdapter) MarkAgentRunTestOutcome(taskID, agentID, outcome, fingerpr
 	return a.tasks.UpdateRun(taskID, agentID, updates)
 }
 
+func (a *taskAdapter) AppendTaskBody(id, content string) error {
+	_, err := a.tasks.AppendBody(id, content)
+	return err
+}
+
 func (a *taskAdapter) SetWorkflow(id string, wf *workflow.Execution) error {
 	_, err := a.tasks.Update(id, task.Update{Workflow: &wf})
 	return err

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -1998,9 +1998,10 @@ func TestE2E_TestingTaskWorkflow_FailEscalatesAtCap(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Pre-seed two prior test-runner attempts; this run is the third → cap hit.
-	for range 2 {
+	for i := range 2 {
 		if err := env.tasks.AddRun(created.ID, task.AgentRun{
-			AgentID: "prior", Role: "test-runner", Mode: "headless", State: "stopped",
+			AgentID: fmt.Sprintf("prior-%d", i), Role: "test-runner", Mode: "headless", State: "stopped",
+			TestOutcome: "product_bug", TestFailureFingerprint: fmt.Sprintf("prior-fp-%d", i),
 		}); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -250,6 +250,33 @@ func (m *Manager) UpdateMap(id string, raw map[string]any) (Task, error) {
 	return m.Update(id, u)
 }
 
+// AppendBody appends markdown to a task body under the per-task mutation lock.
+func (m *Manager) AppendBody(id, content string) (Task, error) {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return m.Get(id)
+	}
+	mu := m.lockFor(id)
+	mu.Lock()
+	defer mu.Unlock()
+	t, err := m.store.Get(id)
+	if err != nil {
+		return Task{}, err
+	}
+	body := strings.TrimRight(t.Body, "\n")
+	if body != "" {
+		body += "\n\n"
+	}
+	body += content + "\n"
+	t, _, err = m.store.UpdateWithPrev(id, Update{Body: &body})
+	if err != nil {
+		return t, err
+	}
+	metrics.TaskUpdated()
+	m.emitter.Emit(events.TaskUpdated, t.FilePath)
+	return t, nil
+}
+
 // Delete removes a task and emits task:deleted.
 func (m *Manager) Delete(id string) error {
 	mu := m.lockFor(id)

--- a/internal/workflow/builtin/testing-task.yaml
+++ b/internal/workflow/builtin/testing-task.yaml
@@ -52,7 +52,7 @@ steps:
       needs_worktree: true
       max_retries: 1
       output_schema: >-
-        {"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]}},"required":["verdict"],"additionalProperties":false}
+        {"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]},"outcome":{"type":"string","enum":["product_bug","infra_failure","ambiguous_requirement","missing_evidence"]},"failures_markdown":{"type":"string"}},"required":["verdict"],"additionalProperties":false}
       prompt: >-
         Adversarially test task {{.Task.ID}} using the /sybra-test skill.
 
@@ -87,15 +87,18 @@ steps:
         failure; report the infrastructure failure plainly.
 
         When done:
-          - If you found ANY deviation from the task's intent, append a
-            "## Test Failures" section to the task body via
-            `sybra-cli update {{.Task.ID}} --body "<full body>"` listing
-            per-defect: the exact command run, verbatim output, expected
-            behaviour (cite the task), and the quoted code line when
-            relevant. Classify each defect as product_bug, infra_failure,
-            ambiguous_requirement, or missing_evidence in prose. Do NOT suggest
-            fixes — describe symptoms only.
-          - Print the verdict as the FINAL line of your output, exactly:
+          - Do NOT call `sybra-cli update` or mutate the task. Sybra ingests
+            your final report and appends it to the task atomically.
+          - If you found ANY deviation from the task's intent, include a
+            "## Test Failures" markdown report listing per-defect: the exact
+            command run, verbatim output, expected behaviour (cite the task),
+            and the quoted code line when relevant. Classify each defect as
+            product_bug, infra_failure, ambiguous_requirement, or
+            missing_evidence in prose. Do NOT suggest fixes — describe
+            symptoms only.
+          - If your provider returns JSON, set `verdict` and put that report in
+            `failures_markdown` (plus `outcome` when clear). Otherwise print
+            the report, then print the verdict as the FINAL line exactly:
             `TEST_VERDICT: PASS`  (only if you could not break it)
             or
             `TEST_VERDICT: FAIL`  (if any case failed)

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -534,7 +534,7 @@ func TestBuiltinTestingTask_RunTestOutputSchema(t *testing.T) {
 	if step == nil {
 		t.Fatal("run_test step not found in testing-task")
 	}
-	const wantSchema = `{"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]}},"required":["verdict"],"additionalProperties":false}`
+	const wantSchema = `{"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]},"outcome":{"type":"string","enum":["product_bug","infra_failure","ambiguous_requirement","missing_evidence"]},"failures_markdown":{"type":"string"}},"required":["verdict"],"additionalProperties":false}`
 	if step.Config.OutputSchema != wantSchema {
 		t.Errorf("run_test.Config.OutputSchema =\n%q\nwant:\n%q", step.Config.OutputSchema, wantSchema)
 	}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -71,6 +71,7 @@ type TaskProvider interface {
 	MarkTaskReviewed(id string) error
 	MarkAgentRunProtocolViolation(taskID, agentID, violation string) error
 	MarkAgentRunTestOutcome(taskID, agentID, outcome, fingerprint string) error
+	AppendTaskBody(id, content string) error
 	SetWorkflow(id string, wf *Execution) error
 	// ConsumeSupervisorSteer prepends a pending watchdog headless-nudge steer to
 	// prompt and clears it, so a re-dispatched (resumed) step's agent carries the

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -53,18 +53,8 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 		return pErr
 	}
 
-	violation, outcome, fingerprint := applyTestVerdictCompletion(wfExec, &output, ctx.Task.Body)
-	if output.AgentID != "" {
-		if outcome != "" {
-			if err := e.tasks.MarkAgentRunTestOutcome(taskID, output.AgentID, outcome, fingerprint); err != nil {
-				return fmt.Errorf("mark test outcome: %w", err)
-			}
-		}
-	}
-	if violation != "" && output.AgentID != "" {
-		if err := e.tasks.MarkAgentRunProtocolViolation(taskID, output.AgentID, violation); err != nil {
-			return fmt.Errorf("mark test protocol violation: %w", err)
-		}
+	if err := e.prepareTestStepCompletion(taskID, &output, wfExec, &ctx.Task.Body); err != nil {
+		return err
 	}
 
 	// Record step completion.

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -113,7 +113,7 @@ func (e *Engine) appendTestFailureReport(taskID string, output StepOutput, wfExe
 		return false, body, nil
 	}
 	if err := e.tasks.AppendTaskBody(taskID, report); err != nil {
-		return false, body, fmt.Errorf("append structured test failure report: %w", err)
+		return false, body, fmt.Errorf("append test failure report: %w", err)
 	}
 	return true, appendRawBody(body, report), nil
 }

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -48,6 +48,12 @@ const (
 	testProtocolMissingEvidence = "missing-evidence"
 )
 
+type structuredTestOutput struct {
+	Verdict          string `json:"verdict"`
+	Outcome          string `json:"outcome,omitempty"`
+	FailuresMarkdown string `json:"failures_markdown,omitempty"`
+}
+
 // prepareTestVerdictAttemptVars resets per-attempt verdict metadata before a
 // test-runner starts. This prevents a protocol violation from a prior retry
 // from poisoning a clean retry.
@@ -60,6 +66,141 @@ func prepareTestVerdictAttemptVars(wfExec *Execution, stepID, body string) {
 	delete(wfExec.Variables, "step."+stepID+"."+testVerdictTaintedKey)
 	delete(wfExec.Variables, "step."+stepID+"."+testVerdictOutcomeKey)
 	delete(wfExec.Variables, "step."+stepID+"."+testFailureFingerprintKey)
+}
+
+func (e *Engine) prepareTestStepCompletion(taskID string, output *StepOutput, wfExec *Execution, body *string) error {
+	if appended, nextBody, appendErr := e.appendTestFailureReport(taskID, *output, wfExec, *body); appendErr != nil {
+		return appendErr
+	} else if appended {
+		*body = nextBody
+	}
+
+	violation, outcome, fingerprint := applyTestVerdictCompletion(wfExec, output, *body)
+	if output.AgentID != "" && outcome != "" {
+		if err := e.tasks.MarkAgentRunTestOutcome(taskID, output.AgentID, outcome, fingerprint); err != nil {
+			return fmt.Errorf("mark test outcome: %w", err)
+		}
+	}
+	if output.AgentID != "" && violation != "" {
+		if err := e.tasks.MarkAgentRunProtocolViolation(taskID, output.AgentID, violation); err != nil {
+			return fmt.Errorf("mark test protocol violation: %w", err)
+		}
+	}
+	return nil
+}
+
+func (e *Engine) appendTestFailureReport(taskID string, output StepOutput, wfExec *Execution, body string) (appended bool, nextBody string, err error) {
+	if wfExec == nil || output.StepID != testVerdictSourceStep {
+		return false, body, nil
+	}
+	if output.Status != "completed" {
+		return false, body, nil
+	}
+
+	report := ""
+	if parsed, ok := parseStructuredTestOutput(output.Output); ok {
+		if strings.ToUpper(strings.TrimSpace(parsed.Verdict)) != "FAIL" {
+			return false, body, nil
+		}
+		report = normalizeStructuredFailuresMarkdown(parsed.FailuresMarkdown, parsed.Outcome)
+	} else if extractTestVerdict(output.Output) == "FAIL" {
+		report = plainTestFailureReport(output.Output)
+	}
+	if report == "" {
+		return false, body, nil
+	}
+	if delta, hasDelta := testFailureBodyDelta(body, wfExec, output.StepID); hasDelta && testFailSectionOf(delta) != "" {
+		return false, body, nil
+	}
+	if err := e.tasks.AppendTaskBody(taskID, report); err != nil {
+		return false, body, fmt.Errorf("append structured test failure report: %w", err)
+	}
+	return true, appendRawBody(body, report), nil
+}
+
+func plainTestFailureReport(output string) string {
+	section := testFailSectionOf(output)
+	if section == "" {
+		return ""
+	}
+	return stripTestVerdictMarkers(section)
+}
+
+func parseStructuredTestOutput(output string) (structuredTestOutput, bool) {
+	s := strings.TrimSpace(strings.TrimPrefix(output, "\xef\xbb\xbf"))
+	if !strings.HasPrefix(s, "{") {
+		return structuredTestOutput{}, false
+	}
+	var parsed structuredTestOutput
+	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
+		return structuredTestOutput{}, false
+	}
+	return parsed, true
+}
+
+func normalizeStructuredFailuresMarkdown(report, outcome string) string {
+	report = strings.TrimSpace(report)
+	if report == "" {
+		return ""
+	}
+	report = stripTestVerdictMarkers(report)
+	outcome = normalizeTestOutcome(outcome)
+	if testFailSectionOf(report) == "" {
+		prefix := testFailuresHeading + "\n\n"
+		if outcome != "" {
+			prefix += "Classification: " + outcome + "\n\n"
+		}
+		return prefix + report + "\n"
+	}
+	if outcome == "" || explicitTestOutcome(report) != "" {
+		return report + "\n"
+	}
+	return insertClassificationAfterFailuresHeading(report, outcome) + "\n"
+}
+
+func insertClassificationAfterFailuresHeading(report, outcome string) string {
+	lines := strings.Split(report, "\n")
+	for i, line := range lines {
+		if strings.EqualFold(strings.TrimSpace(line), testFailuresHeading) {
+			out := append([]string{}, lines[:i+1]...)
+			out = append(out, "", "Classification: "+outcome)
+			out = append(out, lines[i+1:]...)
+			return strings.Join(out, "\n")
+		}
+	}
+	return report
+}
+
+func appendRawBody(body, content string) string {
+	body = strings.TrimRight(body, "\n")
+	if body != "" {
+		body += "\n\n"
+	}
+	return body + strings.TrimSpace(content) + "\n"
+}
+
+func stripTestVerdictMarkers(report string) string {
+	lines := strings.Split(report, "\n")
+	lastNonEmpty := -1
+	lastNonEmptyInFence := false
+	inFence := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			lastNonEmpty = i
+			lastNonEmptyInFence = inFence
+		}
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			inFence = !inFence
+		}
+	}
+	if lastNonEmpty >= 0 && !lastNonEmptyInFence {
+		trimmed := strings.TrimSpace(lines[lastNonEmpty])
+		if trimmed == testVerdictPass || trimmed == testVerdictFail {
+			lines = append(lines[:lastNonEmpty], lines[lastNonEmpty+1:]...)
+		}
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
 }
 
 // applyTestVerdictCompletion extracts the machine verdict from run_test output,
@@ -164,6 +305,11 @@ func classifyTestOutcome(status, output, body string, wfExec *Execution, stepID 
 }
 
 func currentTestFailureReport(output, body string, wfExec *Execution, stepID string) string {
+	if parsed, ok := parseStructuredTestOutput(output); ok {
+		if report := normalizeStructuredFailuresMarkdown(parsed.FailuresMarkdown, parsed.Outcome); report != "" {
+			return report
+		}
+	}
 	if section := testFailSectionOf(output); section != "" {
 		return section
 	}
@@ -246,8 +392,9 @@ func hasGroundedFailureEvidence(report string) bool {
 		"command run:", "command:", "reproduction steps:", "repro:", "steps:",
 		"go test ", "npm run ", "pnpm ", "yarn ", "curl ", "rg ", "grep ")
 	hasObserved := containsAny(lower,
-		"actual output:", "actual:", "observed:", "stdout:", "stderr:",
-		"exit code", "printed:", "rendered:")
+		"actual output:", "actual:", "observed:", "observed output:",
+		"command output:", "stdout:", "stderr:", "exit code",
+		"printed:", "rendered:")
 	hasExpected := containsAny(lower,
 		"expected:", "expected output:", "requirement tested:", "task says", "from the task",
 		"violates", "should render", "should not")
@@ -312,11 +459,32 @@ func testFailureBodyDelta(body string, wfExec *Execution, stepID string) (string
 // to the part the runner authored under failure context, reducing false
 // positives from quoted app error messages or task description prose.
 func testFailSectionOf(output string) string {
-	idx := strings.Index(strings.ToLower(output), strings.ToLower(testFailuresHeading))
-	if idx < 0 {
-		return ""
+	inFence := false
+	offset := 0
+	for _, line := range strings.SplitAfter(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			inFence = !inFence
+			offset += len(line)
+			continue
+		}
+		if !inFence && isTestFailuresHeading(trimmed) {
+			return output[offset:]
+		}
+		offset += len(line)
 	}
-	return output[idx:]
+	return ""
+}
+
+func isTestFailuresHeading(line string) bool {
+	if !strings.HasPrefix(strings.ToLower(line), strings.ToLower(testFailuresHeading)) {
+		return false
+	}
+	if len(line) == len(testFailuresHeading) {
+		return true
+	}
+	next := line[len(testFailuresHeading)]
+	return next == '('
 }
 
 // containsFixSuggestions reports whether the test-runner output includes
@@ -604,7 +772,10 @@ func (e *Engine) countValidProductTestAttempts(t TaskInfo, wfExec *Execution) (i
 			continue
 		}
 		switch run.TestOutcome {
-		case "", testOutcomeProductBug:
+		case testOutcomeProductBug:
+			if run.TestFailureFingerprint == "" {
+				continue
+			}
 			attempts++
 			if currentFingerprint != "" && run.TestFailureFingerprint == currentFingerprint {
 				lastMatchingFailure = currentMatchingFailure

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -207,10 +207,40 @@ func TestApplyTestVerdictCompletion_ClassifiesOutcomes(t *testing.T) {
 			wantStatus: "failed",
 		},
 		{
+			name:       "structured_json_outcome_with_heading",
+			status:     "completed",
+			output:     `{"verdict":"FAIL","outcome":"infra_failure","failures_markdown":` + strconv.Quote(strings.TrimSpace(groundedReport)) + `}`,
+			bodySuffix: "",
+			want:       testOutcomeInfraFailure,
+			wantStatus: "failed",
+		},
+		{
+			name:   "structured_json_ignores_fenced_heading",
+			status: "completed",
+			output: `{"verdict":"FAIL","outcome":"product_bug","failures_markdown":` + strconv.Quote(
+				"Requirement tested: the task says Markdown headings render escaped.\n\n"+
+					"Command run:\n```sh\ncurl /preview\n```\n\n"+
+					"Observed output:\n```md\n## Test Failures\n```\n\n"+
+					"Expected: escaped text.\n\n"+
+					"Code evidence: internal/preview.go:42",
+			) + `}`,
+			bodySuffix: "",
+			want:       testOutcomeProductBug,
+			wantStatus: "completed",
+		},
+		{
 			name:       "expected_output_counts_as_evidence",
 			status:     "completed",
 			output:     `{"verdict":"FAIL"}`,
 			bodySuffix: strings.ReplaceAll(groundedReport, "Expected:", "Expected output:"),
+			want:       testOutcomeProductBug,
+			wantStatus: "completed",
+		},
+		{
+			name:       "observed_output_counts_as_evidence",
+			status:     "completed",
+			output:     `{"verdict":"FAIL"}`,
+			bodySuffix: strings.ReplaceAll(groundedReport, "Actual output:", "Observed output:"),
 			want:       testOutcomeProductBug,
 			wantStatus: "completed",
 		},
@@ -302,6 +332,15 @@ func makeTestEngine(t *testing.T) (*Engine, *memTasks) {
 	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
 	engine.SetTestingMaxAttempts(3)
 	return engine, tasks
+}
+
+func productBugRun(startedAt time.Time, fingerprint string) AgentRunInfo {
+	return AgentRunInfo{
+		Role:                   testRunnerRole,
+		StartedAt:              startedAt,
+		TestOutcome:            testOutcomeProductBug,
+		TestFailureFingerprint: fingerprint,
+	}
 }
 
 // runRouteTestResult calls execRouteTestResult with the given verdict and
@@ -417,6 +456,178 @@ func TestAdvanceStep_TestProtocolViolationRetriesRunTestFromBodyDelta(t *testing
 	}
 	if got.AgentRuns[0].ProtocolViolation != testProtocolFixSuggestions {
 		t.Errorf("agent run protocol violation = %q, want %q", got.AgentRuns[0].ProtocolViolation, testProtocolFixSuggestions)
+	}
+}
+
+func TestAdvanceStep_StructuredFailureMarkdownIsAppendedAtomically(t *testing.T) {
+	t.Parallel()
+	engine, tasks, _ := makeTestingTaskEngine(t)
+
+	initialBody := "## Problem\nExercise the testing gate."
+	wf := &Execution{
+		WorkflowID:  "testing-task",
+		CurrentStep: testVerdictSourceStep,
+		State:       ExecWaiting,
+		Variables:   map[string]string{},
+		StartedAt:   time.Now().UTC(),
+	}
+	prepareTestVerdictAttemptVars(wf, testVerdictSourceStep, initialBody)
+	tasks.Put(TaskInfo{
+		ID:        "t-structured",
+		Status:    "testing",
+		Body:      initialBody,
+		AgentMode: "headless",
+		Workflow:  wf,
+		AgentRuns: []AgentRunInfo{{AgentID: "agent-structured", Role: testRunnerRole}},
+	})
+
+	report := "Requirement tested: the task says the status endpoint should return HTTP 200.\n\n" +
+		"Command run:\n```sh\ncurl -i http://localhost/status\n```\n\n" +
+		"Observed output:\n```text\nHTTP/1.1 500 Internal Server Error\n```\n\n" +
+		"Expected: HTTP 200.\n\n" +
+		"Code evidence:\n```text\ninternal/server.go:42: return http.StatusInternalServerError\n```\n"
+	payload := `{"verdict":"FAIL","outcome":"product_bug","failures_markdown":` + strconv.Quote(report) + `}`
+
+	err := engine.AdvanceStep("t-structured", StepOutput{
+		StepID:  testVerdictSourceStep,
+		Status:  "completed",
+		Output:  payload,
+		AgentID: "agent-structured",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := tasks.GetTask("t-structured")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got.Body, "## Test Failures") || !strings.Contains(got.Body, "Observed output:") {
+		t.Fatalf("task body missing structured failure report:\n%s", got.Body)
+	}
+	if got.AgentRuns[0].TestOutcome != testOutcomeProductBug {
+		t.Fatalf("test outcome = %q, want %q", got.AgentRuns[0].TestOutcome, testOutcomeProductBug)
+	}
+	if got.AgentRuns[0].TestFailureFingerprint == "" {
+		t.Fatal("test failure fingerprint is empty")
+	}
+	if got.Status != "in-progress" {
+		t.Fatalf("status = %q, want in-progress", got.Status)
+	}
+}
+
+func TestAdvanceStep_StructuredFailureAppendsAfterUnrelatedBodyDelta(t *testing.T) {
+	t.Parallel()
+	engine, tasks, _ := makeTestingTaskEngine(t)
+
+	initialBody := "## Problem\nExercise the testing gate."
+	currentBody := initialBody + "\n\n## Test Failures are stale\n\nChecked locally while tester was running.\n"
+	wf := &Execution{
+		WorkflowID:  "testing-task",
+		CurrentStep: testVerdictSourceStep,
+		State:       ExecWaiting,
+		Variables:   map[string]string{},
+		StartedAt:   time.Now().UTC(),
+	}
+	prepareTestVerdictAttemptVars(wf, testVerdictSourceStep, initialBody)
+	tasks.Put(TaskInfo{
+		ID:        "t-structured-delta",
+		Status:    "testing",
+		Body:      currentBody,
+		AgentMode: "headless",
+		Workflow:  wf,
+		AgentRuns: []AgentRunInfo{{AgentID: "agent-structured-delta", Role: testRunnerRole}},
+	})
+
+	report := "Requirement tested: the task says the status endpoint should return HTTP 200.\n\n" +
+		"Command run:\n```sh\ncurl -i http://localhost/status\n```\n\n" +
+		"Observed output:\n```text\nHTTP/1.1 500 Internal Server Error\n```\n\n" +
+		"Expected: HTTP 200.\n\n" +
+		"Code evidence:\n```text\ninternal/server.go:42: return http.StatusInternalServerError\n```\n"
+	payload := `{"verdict":"FAIL","outcome":"product_bug","failures_markdown":` + strconv.Quote(report) + `}`
+
+	err := engine.AdvanceStep("t-structured-delta", StepOutput{
+		StepID:  testVerdictSourceStep,
+		Status:  "completed",
+		Output:  payload,
+		AgentID: "agent-structured-delta",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := tasks.GetTask("t-structured-delta")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got.Body, "## Test Failures are stale") || !strings.Contains(got.Body, "## Test Failures") {
+		t.Fatalf("body should preserve unrelated delta and append test report:\n%s", got.Body)
+	}
+	if strings.Count(got.Body, "\n\n## Test Failures\n") != 1 {
+		t.Fatalf("body should append exactly one test report section:\n%s", got.Body)
+	}
+	if got.Status != "in-progress" {
+		t.Fatalf("status = %q, want in-progress", got.Status)
+	}
+}
+
+func TestAdvanceStep_PlainTextFailureMarkdownIsAppendedAtomically(t *testing.T) {
+	t.Parallel()
+	engine, tasks, _ := makeTestingTaskEngine(t)
+
+	initialBody := "## Problem\nExercise the testing gate."
+	wf := &Execution{
+		WorkflowID:  "testing-task",
+		CurrentStep: testVerdictSourceStep,
+		State:       ExecWaiting,
+		Variables:   map[string]string{},
+		StartedAt:   time.Now().UTC(),
+	}
+	prepareTestVerdictAttemptVars(wf, testVerdictSourceStep, initialBody)
+	tasks.Put(TaskInfo{
+		ID:        "t-plain",
+		Status:    "testing",
+		Body:      initialBody,
+		AgentMode: "headless",
+		Workflow:  wf,
+		AgentRuns: []AgentRunInfo{{AgentID: "agent-plain", Role: testRunnerRole}},
+	})
+	output := "## Test Failures\n\n" +
+		"Requirement tested: the task says the status endpoint should return HTTP 200.\n\n" +
+		"Command run:\n```sh\ncurl -i http://localhost/status\n```\n\n" +
+		"Observed output:\n```text\nTEST_VERDICT: FAIL\n```\n\n" +
+		"Expected: HTTP 200.\n\n" +
+		"Code evidence:\n```text\ninternal/server.go:42: return http.StatusInternalServerError\n```\n\n" +
+		"TEST_VERDICT: FAIL"
+
+	err := engine.AdvanceStep("t-plain", StepOutput{
+		StepID:  testVerdictSourceStep,
+		Status:  "completed",
+		Output:  output,
+		AgentID: "agent-plain",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := tasks.GetTask("t-plain")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got.Body, "## Test Failures") || !strings.Contains(got.Body, "Observed output:") {
+		t.Fatalf("task body missing plain-text failure report:\n%s", got.Body)
+	}
+	if !strings.Contains(got.Body, testVerdictFail) {
+		t.Fatalf("task body should preserve verdict-shaped observed output:\n%s", got.Body)
+	}
+	if count := strings.Count(got.Body, testVerdictFail); count != 1 {
+		t.Fatalf("task body should strip only the final verdict marker, count=%d:\n%s", count, got.Body)
+	}
+	if got.AgentRuns[0].TestOutcome != testOutcomeProductBug {
+		t.Fatalf("test outcome = %q, want %q", got.AgentRuns[0].TestOutcome, testOutcomeProductBug)
+	}
+	if got.Status != "in-progress" {
+		t.Fatalf("status = %q, want in-progress", got.Status)
 	}
 }
 
@@ -602,7 +813,7 @@ func TestRouteTestResult_FailUnderCap(t *testing.T) {
 	t.Parallel()
 	e, tasks := makeTestEngine(t)
 	now := time.Now().UTC()
-	runs := []AgentRunInfo{{Role: testRunnerRole, StartedAt: now}}
+	runs := []AgentRunInfo{productBugRun(now, "fp-1")}
 	out, err := runRouteTestResult(e, tasks, "t2", "FAIL", now, runs, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -621,9 +832,9 @@ func TestRouteTestResult_FailAtCap(t *testing.T) {
 	e, tasks := makeTestEngine(t)
 	now := time.Now().UTC()
 	runs := []AgentRunInfo{
-		{Role: testRunnerRole, StartedAt: now},
-		{Role: testRunnerRole, StartedAt: now.Add(time.Minute)},
-		{Role: testRunnerRole, StartedAt: now.Add(2 * time.Minute)},
+		productBugRun(now, "fp-1"),
+		productBugRun(now.Add(time.Minute), "fp-2"),
+		productBugRun(now.Add(2*time.Minute), "fp-3"),
 	}
 	out, err := runRouteTestResult(e, tasks, "t3", "FAIL", now, runs, nil)
 	if err != nil {
@@ -644,8 +855,8 @@ func TestRouteTestResult_ProtocolViolationRunsDoNotCountTowardCap(t *testing.T) 
 	now := time.Now().UTC()
 	runs := []AgentRunInfo{
 		{AgentID: "bad-report", Role: testRunnerRole, StartedAt: now, ProtocolViolation: testProtocolFixSuggestions},
-		{AgentID: "valid-1", Role: testRunnerRole, StartedAt: now.Add(time.Minute)},
-		{AgentID: "valid-2", Role: testRunnerRole, StartedAt: now.Add(2 * time.Minute)},
+		productBugRun(now.Add(time.Minute), "fp-1"),
+		productBugRun(now.Add(2*time.Minute), "fp-2"),
 	}
 	out, err := runRouteTestResult(e, tasks, "t3-protocol", "FAIL", now, runs, nil)
 	if err != nil {
@@ -660,12 +871,35 @@ func TestRouteTestResult_ProtocolViolationRunsDoNotCountTowardCap(t *testing.T) 
 	}
 }
 
+func TestRouteTestResult_LegacyEmptyOutcomeRunsDoNotCountTowardCap(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	now := time.Now().UTC()
+	runs := []AgentRunInfo{
+		{AgentID: "legacy-1", Role: testRunnerRole, StartedAt: now},
+		{AgentID: "legacy-2", Role: testRunnerRole, StartedAt: now.Add(time.Minute)},
+		{AgentID: "legacy-3", Role: testRunnerRole, StartedAt: now.Add(2 * time.Minute)},
+		productBugRun(now.Add(3*time.Minute), "current-grounded"),
+	}
+	out, err := runRouteTestResult(e, tasks, "t3-legacy", "FAIL", now, runs, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "reimplement" {
+		t.Errorf("output = %q, want reimplement", out.Output)
+	}
+	ti, _ := tasks.GetTask("t3-legacy")
+	if ti.Status != "in-progress" {
+		t.Errorf("status = %q, want in-progress", ti.Status)
+	}
+}
+
 func TestRouteTestResult_InfraFailureDoesNotCountTowardCap(t *testing.T) {
 	t.Parallel()
 	e, tasks := makeTestEngine(t)
 	now := time.Now().UTC()
 	runs := []AgentRunInfo{
-		{AgentID: "valid-1", Role: testRunnerRole, StartedAt: now, TestOutcome: testOutcomeProductBug},
+		{AgentID: "valid-1", Role: testRunnerRole, StartedAt: now, TestOutcome: testOutcomeProductBug, TestFailureFingerprint: "fp-1"},
 		{AgentID: "infra", Role: testRunnerRole, StartedAt: now.Add(time.Minute), TestOutcome: testOutcomeInfraFailure},
 	}
 	tasks.Put(TaskInfo{
@@ -784,12 +1018,12 @@ func TestRouteTestResult_ReDispatch(t *testing.T) {
 
 	// 3 runs from a prior testing cycle (all before newCycleStart).
 	priorRuns := []AgentRunInfo{
-		{Role: testRunnerRole, StartedAt: priorCycleEnd.Add(-2 * time.Minute)},
-		{Role: testRunnerRole, StartedAt: priorCycleEnd.Add(-time.Minute)},
-		{Role: testRunnerRole, StartedAt: priorCycleEnd},
+		productBugRun(priorCycleEnd.Add(-2*time.Minute), "old-1"),
+		productBugRun(priorCycleEnd.Add(-time.Minute), "old-2"),
+		productBugRun(priorCycleEnd, "old-3"),
 	}
 	// 1 new run in the current cycle — must NOT count prior runs toward the cap.
-	priorRuns = append(priorRuns, AgentRunInfo{Role: testRunnerRole, StartedAt: newCycleStart.Add(time.Minute)})
+	priorRuns = append(priorRuns, productBugRun(newCycleStart.Add(time.Minute), "new-1"))
 	runs := priorRuns
 
 	out, err := runRouteTestResult(e, tasks, "t4", "FAIL", newCycleStart, runs, &newCycleStart)
@@ -816,15 +1050,15 @@ func TestRouteTestResult_ReDispatch_Escalates(t *testing.T) {
 
 	// 3 prior-cycle runs (must be ignored).
 	priorRuns := []AgentRunInfo{
-		{Role: testRunnerRole, StartedAt: priorCycleEnd.Add(-2 * time.Minute)},
-		{Role: testRunnerRole, StartedAt: priorCycleEnd.Add(-time.Minute)},
-		{Role: testRunnerRole, StartedAt: priorCycleEnd},
+		productBugRun(priorCycleEnd.Add(-2*time.Minute), "old-1"),
+		productBugRun(priorCycleEnd.Add(-time.Minute), "old-2"),
+		productBugRun(priorCycleEnd, "old-3"),
 	}
 	// 3 new-cycle runs — cap=3 → escalate.
 	newRuns := []AgentRunInfo{
-		{Role: testRunnerRole, StartedAt: newCycleStart.Add(time.Minute)},
-		{Role: testRunnerRole, StartedAt: newCycleStart.Add(2 * time.Minute)},
-		{Role: testRunnerRole, StartedAt: newCycleStart.Add(3 * time.Minute)},
+		productBugRun(newCycleStart.Add(time.Minute), "new-1"),
+		productBugRun(newCycleStart.Add(2*time.Minute), "new-2"),
+		productBugRun(newCycleStart.Add(3*time.Minute), "new-3"),
 	}
 	priorRuns = append(priorRuns, newRuns...)
 	runs := priorRuns

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -197,6 +197,21 @@ func (m *memTasks) MarkAgentRunTestOutcome(taskID, agentID, outcome, fingerprint
 	return fmt.Errorf("agent run %s not found for task %s", agentID, taskID)
 }
 
+func (m *memTasks) AppendTaskBody(id, content string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	t, ok := m.tasks[id]
+	if !ok {
+		return fmt.Errorf("task %s not found", id)
+	}
+	body := strings.TrimRight(t.Body, "\n")
+	if body != "" {
+		body += "\n\n"
+	}
+	t.Body = body + strings.TrimSpace(content) + "\n"
+	return nil
+}
+
 func (m *memTasks) SetWorkflow(id string, wf *Execution) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -198,6 +198,10 @@ func (m *memTasks) MarkAgentRunTestOutcome(taskID, agentID, outcome, fingerprint
 }
 
 func (m *memTasks) AppendTaskBody(id, content string) error {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return nil
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	t, ok := m.tasks[id]
@@ -208,7 +212,7 @@ func (m *memTasks) AppendTaskBody(id, content string) error {
 	if body != "" {
 		body += "\n\n"
 	}
-	t.Body = body + strings.TrimSpace(content) + "\n"
+	t.Body = body + content + "\n"
 	return nil
 }
 


### PR DESCRIPTION
## Motivation

> Changelog: fix(workflow): persist tester failure reports

Test-runner agents could move tasks to `human-required` without preserving the actionable failure report for the next implementation pass. Structured Codex output only returned a verdict, while plain-text runners were previously asked to rewrite the full task body themselves.

## Implementation information

- Extend the testing workflow output schema with `outcome` and `failures_markdown`.
- Let the workflow engine append structured and plain-text `## Test Failures` reports under the task mutation lock.
- Count only grounded `product_bug` attempts with fingerprints toward the retry cap.
- Scope human-review idempotency to the current testing cycle.
- Update sybra-test instructions so test agents report failures instead of mutating task bodies.

## Supporting documentation

- Adversarial code review was run and findings were addressed.
- Verified with focused workflow/task/sybra tests and the repository pre-push hook.