### PR TITLE
fix(recovery): skip pr-fix in restart-stale

### DIFF
--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -31,6 +31,13 @@ type ProjectGetter interface {
 	Get(id string) (project.Project, error)
 }
 
+// WorkflowRestarter is the subset of *workflow.Engine that recovery needs.
+// Defined as an interface so tests can stub it without wiring the full engine.
+type WorkflowRestarter interface {
+	StartWorkflow(taskID, workflowID string) error
+	HandleAgentComplete(taskID string, completion workflow.AgentCompletion)
+}
+
 // Recovery owns the dependencies needed by the boot-time cleanup pass and
 // the periodic restart-stale sweep. Construct once during App.Startup,
 // reuse from the orchestrator loop.
@@ -38,7 +45,7 @@ type Recovery struct {
 	Tasks          *task.Manager
 	Agents         *agent.Manager
 	Worktrees      *worktree.Manager
-	WorkflowEngine *workflow.Engine // optional; nil-safe
+	WorkflowEngine WorkflowRestarter // optional; nil-safe
 	Orchestrator   Orchestrator
 	Projects       ProjectGetter
 	Logger         *slog.Logger

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/recovery"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
 	"github.com/Automaat/sybra/internal/worktree"
 )
 
@@ -269,6 +270,91 @@ func TestRestartStaleSteerBypassesRecentRunDebounce(t *testing.T) {
 
 	if stub.startCalls != 1 {
 		t.Fatalf("dispatch count = %d, want 1 (steer must bypass the recent-run debounce)", stub.startCalls)
+	}
+}
+
+// stubWorkflowEngine implements recovery.WorkflowRestarter for tests that need
+// a non-nil engine without a real workflow store.
+type stubWorkflowEngine struct {
+	startWorkflowCalls int
+}
+
+func (s *stubWorkflowEngine) StartWorkflow(_, _ string) error {
+	s.startWorkflowCalls++
+	return nil
+}
+
+func (s *stubWorkflowEngine) HandleAgentComplete(_ string, _ workflow.AgentCompletion) {}
+
+// TestRestartStalePRFixWorkflowRevertsToInReview verifies the root cause of the
+// b319d12f incident: a task left in-progress with a cancelled (ExecCompleted)
+// pr-fix workflow must NOT have StartWorkflow called on restart — that would
+// launch the agent with nil vars (wrong dir, empty prompt). Instead the task
+// reverts to in-review so the PR monitor re-detects and re-dispatches.
+func TestRestartStalePRFixWorkflowRevertsToInReview(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := discardLogger()
+	agents := agent.NewManager(ctx, func(string, any) {}, logger, t.TempDir())
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Tasks:        tasks,
+		Logger:       logger,
+		AgentChecker: agents.HasRunningAgentForTask,
+	})
+
+	// Simulate the post-cancel shape: in-progress task with an ExecCompleted
+	// pr-fix workflow (what cancelResolvedPRFixWorkflows leaves behind).
+	created, err := tasks.Create("fix pr conflict", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inProg := task.StatusInProgress
+	wfExec := &workflow.Execution{WorkflowID: "pr-fix", State: workflow.ExecCompleted}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:   &inProg,
+		Workflow: &wfExec,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	stub := stubOrchestrator{}
+	wfStub := &stubWorkflowEngine{}
+	r := &recovery.Recovery{
+		Tasks:          tasks,
+		Agents:         agents,
+		Worktrees:      wm,
+		Orchestrator:   &stub,
+		WorkflowEngine: wfStub,
+		Logger:         logger,
+		Throttle:       logging.NewErrorThrottle(),
+		WG:             &wg,
+		LogDir:         t.TempDir(),
+	}
+	r.RestartStaleInProgress()
+	wg.Wait()
+
+	if stub.startCalls != 0 || stub.prFixCalls != 0 {
+		t.Errorf("orchestrator called (start=%d prFix=%d); want 0", stub.startCalls, stub.prFixCalls)
+	}
+	if wfStub.startWorkflowCalls != 0 {
+		t.Errorf("WorkflowEngine.StartWorkflow called %d times; want 0", wfStub.startWorkflowCalls)
+	}
+
+	updated, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != task.StatusInReview {
+		t.Errorf("task status = %s; want %s", updated.Status, task.StatusInReview)
 	}
 }
 

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -62,27 +62,7 @@ func (r *Recovery) RestartStaleInProgress() {
 		// would loop forever (completion callback can't advance a terminal
 		// workflow), but restarting the workflow gives the callback a live
 		// execution to advance.
-		if r.WorkflowEngine != nil && t.Workflow != nil &&
-			(t.Workflow.State == workflow.ExecCompleted || t.Workflow.State == workflow.ExecFailed) {
-			wfID := t.Workflow.WorkflowID
-			// Review tasks are driven by the pr-review workflow, not the
-			// plan/implement pipeline. If simple-task-plan (or any non-review
-			// workflow) ended up attached to a review-tagged task due to the
-			// create-before-tag race, do NOT restart it — that would loop
-			// triage indefinitely. Skip so the task can be triaged manually
-			// or picked up by the correct workflow on the next create.
-			if slices.Contains(t.Tags, "review") && wfID == "simple-task-plan" {
-				r.Logger.Info("restart-stale.skip",
-					"task_id", t.ID, "reason", "review_task_on_plan_workflow", "workflow", wfID)
-				continue
-			}
-			taskID := t.ID
-			r.Logger.Info("restart-stale.restart-workflow", "task_id", taskID, "workflow", wfID)
-			r.WG.Go(func() {
-				if wfErr := r.WorkflowEngine.StartWorkflow(taskID, wfID); wfErr != nil {
-					r.Logger.Error("restart-stale.restart-workflow.failed", "task_id", taskID, "err", wfErr)
-				}
-			})
+		if r.handleTerminalWorkflow(&t) {
 			continue
 		}
 		// Debounce respawn when a previous run started recently. Covers
@@ -160,6 +140,50 @@ func (r *Recovery) RestartStaleInProgress() {
 			}
 		})
 	}
+}
+
+// handleTerminalWorkflow handles a task whose workflow reached a terminal state
+// (ExecCompleted/ExecFailed) while the task stayed in-progress. Returns true
+// when the task was handled and the caller should continue to the next task.
+//
+// Workflows that require external vars (pr-fix) are reverted to in-review so
+// the originating dispatcher re-evaluates rather than receiving nil vars from
+// a bare StartWorkflow call, which would launch the agent in the wrong dir.
+func (r *Recovery) handleTerminalWorkflow(t *task.Task) bool {
+	if r.WorkflowEngine == nil || t.Workflow == nil {
+		return false
+	}
+	if t.Workflow.State != workflow.ExecCompleted && t.Workflow.State != workflow.ExecFailed {
+		return false
+	}
+	wfID := t.Workflow.WorkflowID
+	// Review tasks are driven by the pr-review workflow, not the
+	// plan/implement pipeline. If simple-task-plan ended up attached to a
+	// review-tagged task due to the create-before-tag race, do NOT restart it.
+	if slices.Contains(t.Tags, "review") && wfID == "simple-task-plan" {
+		r.Logger.Info("restart-stale.skip",
+			"task_id", t.ID, "reason", "review_task_on_plan_workflow", "workflow", wfID)
+		return true
+	}
+	// pr-fix workflows require WorkflowVarDir and prompt vars seeded by
+	// DispatchEvent. StartWorkflow(nil vars) would launch in ~/.sybra (wrong
+	// dir) with an empty prompt → exit 1 → escalate to human-required.
+	if wfID == "pr-fix" {
+		r.Logger.Info("restart-stale.revert-to-review",
+			"task_id", t.ID, "reason", "pr_fix_workflow_not_restartable")
+		if _, updErr := r.Tasks.Update(t.ID, task.Update{Status: task.Ptr(task.StatusInReview)}); updErr != nil {
+			r.Logger.Error("restart-stale.revert", "task_id", t.ID, "err", updErr)
+		}
+		return true
+	}
+	taskID := t.ID
+	r.Logger.Info("restart-stale.restart-workflow", "task_id", taskID, "workflow", wfID)
+	r.WG.Go(func() {
+		if wfErr := r.WorkflowEngine.StartWorkflow(taskID, wfID); wfErr != nil {
+			r.Logger.Error("restart-stale.restart-workflow.failed", "task_id", taskID, "err", wfErr)
+		}
+	})
+	return true
 }
 
 // surfaceStartFailure mirrors workflow.Engine.surfaceStartFailure for the


### PR DESCRIPTION
## Motivation

`RestartStaleInProgress` was calling `StartWorkflow` for stale tasks whose terminal workflow was `pr-fix`. The `pr-fix` workflow requires `WorkflowVarDir` and prompt vars that are only seeded by the PR monitor's `DispatchEvent`. Without those vars the agent started in `~/.sybra` with an empty prompt, exited 1, and escalated the task to `human-required`.

> Changelog: fix(recovery): skip pr-fix in restart-stale

## Implementation information

- Added a guard in the new `handleTerminalWorkflow` helper: when the terminal workflow is `pr-fix`, revert the task to `in-review` instead of calling `StartWorkflow`. The PR monitor then re-detects the open issue and re-dispatches via `DispatchEvent` with the correct vars.
- Extracted the terminal-workflow handling block from `RestartStaleInProgress` into `handleTerminalWorkflow` (funlen fix).
- Widened `Recovery.WorkflowEngine` from `*workflow.Engine` to a new `WorkflowRestarter` interface so tests can stub it without wiring the full engine.
- Added `TestRestartStalePRFixWorkflowRevertsToInReview` covering the exact post-cancel shape (`ExecCompleted` + `pr-fix` workflow) and asserting that neither `StartWorkflow` nor the orchestrator is called, and the task ends up in `in-review`.