### PR TITLE
feat(harness): add evolution proposals

### DIFF
--- a/cmd/sybra-cli/harness_evolution.go
+++ b/cmd/sybra-cli/harness_evolution.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/harnessevolution"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func cmdHarnessEvolution(cfg *config.Config, store *task.Manager, args []string, jsonOut bool) int {
+	if len(args) == 0 {
+		return fatal(jsonOut, "usage: harness-evolution <run> [flags]")
+	}
+	switch args[0] {
+	case "run":
+		return cmdHarnessEvolutionRun(cfg, store, args[1:], jsonOut)
+	default:
+		return fatal(jsonOut, "unknown harness-evolution subcommand: %s", args[0])
+	}
+}
+
+func cmdHarnessEvolutionRun(cfg *config.Config, store *task.Manager, args []string, jsonOut bool) int {
+	fs := flag.NewFlagSet("harness-evolution run", flag.ContinueOnError)
+	defaultLookback := time.Duration(cfg.HarnessEvolve.LookbackHours * float64(time.Hour))
+	lookbackFlag := fs.String("lookback", defaultLookback.String(), "lookback window (e.g. 168h or 7d)")
+	minCluster := fs.Int("min-cluster-size", cfg.HarnessEvolve.MinClusterSize, "minimum events required to propose")
+	corpusDir := fs.String("corpus", "", "optional directory of regression corpus JSON files")
+	fileTasks := fs.Bool("file", false, "create local Sybra proposal tasks")
+	if err := fs.Parse(args); err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+	lookback, err := parseDurationFlag(*lookbackFlag)
+	if err != nil {
+		return fatal(jsonOut, "parse --lookback: %v", err)
+	}
+	result, err := harnessevolution.Run(context.Background(), harnessevolution.Options{
+		ReportPath:     config.SelfMonitorLastReportPath(),
+		CorpusDir:      *corpusDir,
+		OutputDir:      config.HarnessEvolveDir(),
+		Lookback:       lookback,
+		MinClusterSize: *minCluster,
+	})
+	if err != nil {
+		return fatal(jsonOut, "harness evolution: %v", err)
+	}
+	var filed []task.Task
+	if *fileTasks {
+		filed, err = fileHarnessProposals(store, result)
+		if err != nil {
+			return fatal(jsonOut, "file proposals: %v", err)
+		}
+	}
+	if jsonOut {
+		return printJSON(map[string]any{"result": result, "filed": filed})
+	}
+	printHarnessEvolutionResult(result, filed)
+	return 0
+}
+
+func fileHarnessProposals(store *task.Manager, result harnessevolution.RunResult) ([]task.Task, error) {
+	var filed []task.Task
+	existing, err := store.List()
+	if err != nil {
+		return nil, err
+	}
+	for i := range result.Proposals {
+		p := result.Proposals[i]
+		if p.Evaluation.Recommendation == harnessevolution.RecommendationReject {
+			continue
+		}
+		if _, ok := findExistingHarnessProposal(existing, p.ID); ok {
+			continue
+		}
+		cluster := result.Clusters[i]
+		body := harnessevolution.RenderProposalBody(p, cluster)
+		tags := []string{"harness-proposal", string(p.Kind), string(p.Evaluation.Recommendation)}
+		status := task.StatusTodo
+		if p.RequiresHumanApproval || p.Evaluation.Recommendation == harnessevolution.RecommendationNeedsHumanReview {
+			tags = append(tags, "requires-human")
+			status = task.StatusHumanRequired
+		}
+		created, err := store.CreateFull(p.Title, body, task.AgentModeHeadless, task.Update{
+			Status: &status,
+			Tags:   &tags,
+		})
+		if err != nil {
+			return filed, err
+		}
+		filed = append(filed, created)
+		existing = append(existing, created)
+	}
+	return filed, nil
+}
+
+func findExistingHarnessProposal(tasks []task.Task, proposalID string) (task.Task, bool) {
+	marker := "Proposal ID:** `" + proposalID + "`"
+	for i := range tasks {
+		if task.IsTerminalStatus(tasks[i].Status) {
+			continue
+		}
+		if !hasTag(tasks[i].Tags, "harness-proposal") {
+			continue
+		}
+		if strings.Contains(tasks[i].Body, marker) {
+			return tasks[i], true
+		}
+	}
+	return task.Task{}, false
+}
+
+func hasTag(tags []string, want string) bool {
+	return slices.Contains(tags, want)
+}
+
+func printHarnessEvolutionResult(result harnessevolution.RunResult, filed []task.Task) {
+	fmt.Printf("harness-evolution: events=%d clusters=%d proposals=%d filed=%d\n",
+		result.Events, len(result.Clusters), len(result.Proposals), len(filed))
+	if len(result.Proposals) == 0 {
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "ID\tKIND\tREC\tGATE\tTRACES\tTITLE")
+	for i := range result.Proposals {
+		p := result.Proposals[i]
+		gate := "standard"
+		if p.RequiresHumanApproval {
+			gate = "human"
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%s\n",
+			p.ID, p.Kind, p.Evaluation.Recommendation, gate, len(p.Evidence), p.Title)
+	}
+	_ = w.Flush()
+}

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -81,15 +81,9 @@ func run(args []string) int {
 		return cmdHook(cfg, filtered[1:])
 	}
 
-	rawStore, err := task.NewStore(cfg.TasksDir)
+	store, projStore, err := openStores(cfg)
 	if err != nil {
-		return fatal(jsonOut, "open store: %v", err)
-	}
-	store := task.NewManager(rawStore, nil)
-
-	projStore, err := project.NewStore(cfg.ProjectsDir, cfg.ClonesDir)
-	if err != nil {
-		return fatal(jsonOut, "open project store: %v", err)
+		return fatal(jsonOut, "%v", err)
 	}
 
 	cmd, rest := filtered[0], filtered[1:]
@@ -126,6 +120,8 @@ func run(args []string) int {
 		return cmdSelfmonitor(cfg, store, rest, jsonOut)
 	case "evaluation":
 		return cmdEvaluation(cfg, store, rest, jsonOut)
+	case "harness-evolution":
+		return cmdHarnessEvolution(cfg, store, rest, jsonOut)
 	case "stats":
 		return cmdStats(cfg, rest, jsonOut)
 	case "install-skills":
@@ -135,6 +131,18 @@ func run(args []string) int {
 	default:
 		return fatal(jsonOut, "unknown command: %s", cmd)
 	}
+}
+
+func openStores(cfg *config.Config) (*task.Manager, *project.Store, error) {
+	rawStore, err := task.NewStore(cfg.TasksDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open store: %w", err)
+	}
+	projStore, err := project.NewStore(cfg.ProjectsDir, cfg.ClonesDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open project store: %w", err)
+	}
+	return task.NewManager(rawStore, nil), projStore, nil
 }
 
 func cmdList(s *task.Manager, args []string, jsonOut bool) int {
@@ -1701,6 +1709,8 @@ Commands:
   board    (status counts + in-progress/plan-review/human-required task lists)
   monitor  scan [--json]    one-shot read-only detector pass (no remediation)
   evaluation scan [--json]  fleet scorecard (autonomy, throughput, efficiency)
+  harness-evolution run [--lookback 168h] [--min-cluster-size 2] [--file] [--json]
+           Cluster selfmonitor failures into governed harness-change proposals.
   stats lifecycle [--since 30d] [--slowest N] [--json]
            Per-phase lead-time breakdown (planning/implementing/testing/review/
            waiting) for tasks that landed in the window — where time is spent.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,33 +13,34 @@ import (
 )
 
 type Config struct {
-	Logging       LoggingConfig      `yaml:"logging" json:"logging"`
-	Audit         AuditConfig        `yaml:"audit" json:"audit"`
-	Agent         AgentDefaults      `yaml:"agent" json:"agent"`
-	Testing       TestingConfig      `yaml:"testing" json:"testing"`
-	Notification  NotificationConfig `yaml:"notification" json:"notification"`
-	Orchestrator  OrchestratorConfig `yaml:"orchestrator" json:"orchestrator"`
-	Todoist       TodoistConfig      `yaml:"todoist" json:"todoist"`
-	Renovate      RenovateConfig     `yaml:"renovate" json:"renovate"`
-	GitHub        GitHubConfig       `yaml:"github" json:"github"`
-	Umbrella      UmbrellaConfig     `yaml:"umbrella" json:"umbrella"`
-	Triage        TriageConfig       `yaml:"triage" json:"triage"`
-	HumanReview   HumanReviewConfig  `yaml:"human_review" json:"humanReview"`
-	Monitor       MonitorConfig      `yaml:"monitor" json:"monitor"`
-	Watchdog      WatchdogConfig     `yaml:"watchdog" json:"watchdog"`
-	SelfMonitor   SelfMonitorConfig  `yaml:"self_monitor" json:"selfMonitor"`
-	Evaluation    EvaluationConfig   `yaml:"evaluation" json:"evaluation"`
-	ABTesting     abtest.Config      `yaml:"ab_testing" json:"abTesting"`
-	Providers     ProvidersConfig    `yaml:"providers" json:"providers"`
-	Metrics       MetricsConfig      `yaml:"metrics" json:"metrics"`
-	ProjectTypes  []string           `yaml:"project_types" json:"projectTypes"`
-	TasksDir      string             `yaml:"tasks_dir" json:"tasksDir"`
-	SkillsDir     string             `yaml:"skills_dir" json:"skillsDir"`
-	RepoDir       string             `yaml:"repo_dir" json:"repoDir"`
-	ProjectsDir   string             `yaml:"projects_dir" json:"projectsDir"`
-	ClonesDir     string             `yaml:"clones_dir" json:"clonesDir"`
-	WorktreesDir  string             `yaml:"worktrees_dir" json:"worktreesDir"`
-	LoopAgentsDir string             `yaml:"loop_agents_dir" json:"loopAgentsDir"`
+	Logging       LoggingConfig       `yaml:"logging" json:"logging"`
+	Audit         AuditConfig         `yaml:"audit" json:"audit"`
+	Agent         AgentDefaults       `yaml:"agent" json:"agent"`
+	Testing       TestingConfig       `yaml:"testing" json:"testing"`
+	Notification  NotificationConfig  `yaml:"notification" json:"notification"`
+	Orchestrator  OrchestratorConfig  `yaml:"orchestrator" json:"orchestrator"`
+	Todoist       TodoistConfig       `yaml:"todoist" json:"todoist"`
+	Renovate      RenovateConfig      `yaml:"renovate" json:"renovate"`
+	GitHub        GitHubConfig        `yaml:"github" json:"github"`
+	Umbrella      UmbrellaConfig      `yaml:"umbrella" json:"umbrella"`
+	Triage        TriageConfig        `yaml:"triage" json:"triage"`
+	HumanReview   HumanReviewConfig   `yaml:"human_review" json:"humanReview"`
+	Monitor       MonitorConfig       `yaml:"monitor" json:"monitor"`
+	Watchdog      WatchdogConfig      `yaml:"watchdog" json:"watchdog"`
+	SelfMonitor   SelfMonitorConfig   `yaml:"self_monitor" json:"selfMonitor"`
+	Evaluation    EvaluationConfig    `yaml:"evaluation" json:"evaluation"`
+	HarnessEvolve HarnessEvolveConfig `yaml:"harness_evolution" json:"harnessEvolution"`
+	ABTesting     abtest.Config       `yaml:"ab_testing" json:"abTesting"`
+	Providers     ProvidersConfig     `yaml:"providers" json:"providers"`
+	Metrics       MetricsConfig       `yaml:"metrics" json:"metrics"`
+	ProjectTypes  []string            `yaml:"project_types" json:"projectTypes"`
+	TasksDir      string              `yaml:"tasks_dir" json:"tasksDir"`
+	SkillsDir     string              `yaml:"skills_dir" json:"skillsDir"`
+	RepoDir       string              `yaml:"repo_dir" json:"repoDir"`
+	ProjectsDir   string              `yaml:"projects_dir" json:"projectsDir"`
+	ClonesDir     string              `yaml:"clones_dir" json:"clonesDir"`
+	WorktreesDir  string              `yaml:"worktrees_dir" json:"worktreesDir"`
+	LoopAgentsDir string              `yaml:"loop_agents_dir" json:"loopAgentsDir"`
 }
 
 // AllowsProjectType reports whether automations on this machine should act on
@@ -449,6 +450,17 @@ type EvaluationConfig struct {
 	WindowDays    int     `yaml:"window_days" json:"windowDays"`
 }
 
+// HarnessEvolveConfig controls the governed harness-evolution proposal loop.
+// The loop proposes reviewable tasks/issues from telemetry; it never applies
+// prompt, workflow, permission, retry, validator, or deployment changes itself.
+type HarnessEvolveConfig struct {
+	Enabled        bool    `yaml:"enabled" json:"enabled"`
+	IntervalHours  float64 `yaml:"interval_hours" json:"intervalHours"`
+	LookbackHours  float64 `yaml:"lookback_hours" json:"lookbackHours"`
+	MinClusterSize int     `yaml:"min_cluster_size" json:"minClusterSize"`
+	Sink           string  `yaml:"sink" json:"sink"`
+}
+
 // ProvidersConfig groups per-machine routing for CLI providers (claude, codex,
 // copilot) and their background health-check loop. A missing block defaults to
 // "all providers enabled, health check on, auto-failover on, 300s interval".
@@ -526,6 +538,9 @@ func DefaultConfig() *Config {
 			Enabled: true,
 		},
 		Monitor: MonitorConfig{
+			Enabled: true,
+		},
+		HarnessEvolve: HarnessEvolveConfig{
 			Enabled: true,
 		},
 		Watchdog: WatchdogConfig{
@@ -666,6 +681,7 @@ func Load() (*Config, error) {
 	applyWatchdogDefaults(cfg)
 	applySelfMonitorDefaults(cfg)
 	applyEvaluationDefaults(cfg)
+	applyHarnessEvolveDefaults(cfg)
 	applyABTestingDefaults(cfg)
 	applyOrchestratorDefaults(cfg)
 
@@ -710,6 +726,24 @@ func applyEvaluationDefaults(cfg *Config) {
 	}
 	if e.WindowDays <= 0 {
 		e.WindowDays = 30
+	}
+}
+
+// applyHarnessEvolveDefaults fills zero values while preserving Enabled from
+// DefaultConfig or an explicit YAML override.
+func applyHarnessEvolveDefaults(cfg *Config) {
+	h := &cfg.HarnessEvolve
+	if h.IntervalHours < 1 {
+		h.IntervalHours = 24
+	}
+	if h.LookbackHours <= 0 {
+		h.LookbackHours = 168
+	}
+	if h.MinClusterSize <= 0 {
+		h.MinClusterSize = 2
+	}
+	if h.Sink == "" {
+		h.Sink = "local-task"
 	}
 }
 
@@ -945,6 +979,12 @@ func ArtifactsDir() string {
 // the service owns.
 func SelfMonitorDir() string {
 	return filepath.Join(HomeDir(), "selfmonitor")
+}
+
+// HarnessEvolveDir is the local store for governed harness-evolution proposal
+// records and run snapshots.
+func HarnessEvolveDir() string {
+	return filepath.Join(HomeDir(), "harness-evolution")
 }
 
 // SelfMonitorLedgerPath is the append-only ledger file selfmonitor.Open uses.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -114,6 +114,48 @@ func TestLoadMonitorDispatchLimitPreservesOverride(t *testing.T) {
 	}
 }
 
+func TestLoadHarnessEvolutionDefaults(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.HarnessEvolve.Enabled {
+		t.Fatal("harness evolution should default enabled")
+	}
+	if cfg.HarnessEvolve.IntervalHours != 24 {
+		t.Fatalf("interval = %.0f, want 24", cfg.HarnessEvolve.IntervalHours)
+	}
+	if cfg.HarnessEvolve.LookbackHours != 168 {
+		t.Fatalf("lookback = %.0f, want 168", cfg.HarnessEvolve.LookbackHours)
+	}
+	if cfg.HarnessEvolve.MinClusterSize != 2 {
+		t.Fatalf("min cluster size = %d, want 2", cfg.HarnessEvolve.MinClusterSize)
+	}
+	if cfg.HarnessEvolve.Sink != "local-task" {
+		t.Fatalf("sink = %q, want local-task", cfg.HarnessEvolve.Sink)
+	}
+}
+
+func TestLoadHarnessEvolutionPreservesExplicitDisabled(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+	yaml := []byte("harness_evolution:\n  enabled: false\n")
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), yaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.HarnessEvolve.Enabled {
+		t.Fatal("explicit harness_evolution.enabled=false was not preserved")
+	}
+}
+
 func TestLoadWatchdogDefaults(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/harnessevolution/cluster.go
+++ b/internal/harnessevolution/cluster.go
@@ -1,0 +1,91 @@
+package harnessevolution
+
+import (
+	"cmp"
+	"crypto/sha256"
+	"encoding/hex"
+	"slices"
+	"strings"
+	"time"
+)
+
+func ClusterEvents(events []FailureEvent, minSize int) []Cluster {
+	if minSize <= 0 {
+		minSize = 2
+	}
+	byKey := make(map[string][]FailureEvent)
+	for i := range events {
+		ev := events[i]
+		key := clusterKey(ev)
+		byKey[key] = append(byKey[key], ev)
+	}
+
+	clusters := make([]Cluster, 0, len(byKey))
+	for key, grouped := range byKey {
+		if len(grouped) < minSize {
+			continue
+		}
+		slices.SortFunc(grouped, func(a, b FailureEvent) int {
+			return a.OccurredAt.Compare(b.OccurredAt)
+		})
+		clusters = append(clusters, Cluster{
+			Key:          key,
+			Cause:        clusterCause(grouped[0]),
+			Count:        len(grouped),
+			Events:       slices.Clone(grouped),
+			FirstSeen:    firstTime(grouped),
+			LastSeen:     lastTime(grouped),
+			AffectedStep: grouped[0].WorkflowStep,
+			Category:     grouped[0].Category,
+			FailureKind:  grouped[0].FailureKind,
+		})
+	}
+	slices.SortFunc(clusters, func(a, b Cluster) int {
+		if c := cmp.Compare(b.Count, a.Count); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Key, b.Key)
+	})
+	return clusters
+}
+
+func clusterKey(ev FailureEvent) string {
+	parts := []string{
+		normalizeToken(ev.Category),
+		normalizeToken(ev.FailureKind),
+		normalizeToken(ev.WorkflowStep),
+		normalizeToken(ev.Role),
+		normalizeToken(ev.Provider),
+	}
+	raw := strings.Join(parts, "|")
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])[:12]
+}
+
+func clusterCause(ev FailureEvent) string {
+	parts := []string{ev.Category}
+	if ev.FailureKind != "" && ev.FailureKind != ev.Category {
+		parts = append(parts, ev.FailureKind)
+	}
+	if ev.WorkflowStep != "" {
+		parts = append(parts, "step:"+ev.WorkflowStep)
+	}
+	if ev.Role != "" {
+		parts = append(parts, "role:"+ev.Role)
+	}
+	return strings.Join(parts, " / ")
+}
+
+func firstTime(events []FailureEvent) time.Time {
+	if len(events) == 0 {
+		return time.Time{}
+	}
+	return events[0].OccurredAt
+}
+
+func lastTime(events []FailureEvent) time.Time {
+	if len(events) == 0 {
+		return time.Time{}
+	}
+	return events[len(events)-1].OccurredAt
+}

--- a/internal/harnessevolution/cluster_test.go
+++ b/internal/harnessevolution/cluster_test.go
@@ -1,0 +1,35 @@
+package harnessevolution
+
+import (
+	"testing"
+	"time"
+)
+
+func TestClusterEvents_GroupsStableCause(t *testing.T) {
+	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	events := []FailureEvent{
+		{Category: "agent_retry_loop", FailureKind: "step_retry_exhausted", WorkflowStep: "implement", Role: "implementation", TraceID: "t1", OccurredAt: now},
+		{Category: "agent_retry_loop", FailureKind: "step_retry_exhausted", WorkflowStep: "implement", Role: "implementation", TraceID: "t2", OccurredAt: now.Add(time.Minute)},
+		{Category: "agent_retry_loop", FailureKind: "step_retry_exhausted", WorkflowStep: "testing", Role: "test-runner", TraceID: "t3", OccurredAt: now},
+	}
+
+	clusters := ClusterEvents(events, 2)
+	if len(clusters) != 1 {
+		t.Fatalf("clusters len = %d, want 1", len(clusters))
+	}
+	if clusters[0].Count != 2 {
+		t.Fatalf("cluster count = %d, want 2", clusters[0].Count)
+	}
+	if clusters[0].AffectedStep != "implement" {
+		t.Fatalf("affected step = %q, want implement", clusters[0].AffectedStep)
+	}
+}
+
+func TestClusterEvents_DropsSingletons(t *testing.T) {
+	events := []FailureEvent{
+		{Category: "failure_rate", FailureKind: "permission_denied", WorkflowStep: "review", TraceID: "t1", OccurredAt: time.Now()},
+	}
+	if got := ClusterEvents(events, 2); len(got) != 0 {
+		t.Fatalf("clusters len = %d, want 0", len(got))
+	}
+}

--- a/internal/harnessevolution/collector.go
+++ b/internal/harnessevolution/collector.go
@@ -1,0 +1,159 @@
+package harnessevolution
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Automaat/sybra/internal/health"
+	"github.com/Automaat/sybra/internal/selfmonitor"
+)
+
+func LoadSelfMonitorReport(path string) (selfmonitor.Report, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return selfmonitor.Report{}, err
+	}
+	var report selfmonitor.Report
+	if err := json.Unmarshal(data, &report); err != nil {
+		return selfmonitor.Report{}, fmt.Errorf("parse selfmonitor report: %w", err)
+	}
+	return report, nil
+}
+
+func EventsFromReport(report selfmonitor.Report, since time.Time) []FailureEvent {
+	events := make([]FailureEvent, 0, len(report.Findings))
+	for i := range report.Findings {
+		inv := report.Findings[i]
+		if !actionableVerdict(inv.Verdict.Classification) {
+			continue
+		}
+		ev := eventFromFinding(inv)
+		if ev.Category == "" {
+			continue
+		}
+		if !since.IsZero() && ev.OccurredAt.Before(since) {
+			continue
+		}
+		events = append(events, ev)
+	}
+	return events
+}
+
+func actionableVerdict(v string) bool {
+	switch v {
+	case selfmonitor.VerdictConfirmed, selfmonitor.VerdictNeedsHuman:
+		return true
+	default:
+		return false
+	}
+}
+
+func eventFromFinding(inv selfmonitor.InvestigatedFinding) FailureEvent {
+	f := inv.Finding
+	fp := firstNonEmpty(inv.Fingerprint, f.Fingerprint)
+	step := workflowStep(f)
+	failureKind := inferFailureKind(f, inv.LogSummary)
+	occurredAt := f.DetectedAt
+	if occurredAt.IsZero() {
+		occurredAt = time.Now().UTC()
+	}
+	ev := FailureEvent{
+		TraceID:      stableTraceID(f.TaskID, step, f.AgentID),
+		TaskID:       f.TaskID,
+		AgentID:      f.AgentID,
+		Role:         normalizeToken(f.Role),
+		Category:     string(f.Category),
+		WorkflowStep: step,
+		FailureKind:  failureKind,
+		Fingerprint:  fp,
+		OccurredAt:   occurredAt.UTC(),
+	}
+	return ev
+}
+
+func workflowStep(f health.Finding) string {
+	for _, key := range []string{"workflow_step", "step", "status", "transition", "role"} {
+		if s, ok := f.Evidence[key].(string); ok && strings.TrimSpace(s) != "" {
+			return normalizeToken(s)
+		}
+	}
+	if f.Role != "" {
+		return normalizeToken(f.Role)
+	}
+	return normalizeToken(string(f.Category))
+}
+
+func inferFailureKind(f health.Finding, ls *selfmonitor.LogSummary) string {
+	if ls != nil {
+		if sensitive := sensitiveErrorClass(ls.ErrorClasses); sensitive != "" {
+			return sensitive
+		}
+		if ls.StallDetected {
+			return "step_retry_exhausted"
+		}
+		if len(ls.ErrorClasses) > 0 && ls.ErrorClasses[0].Class != "" {
+			return normalizeToken(ls.ErrorClasses[0].Class)
+		}
+	}
+	switch f.Category {
+	case health.CatAgentRetryLoop, health.CatWorkflowLoop:
+		return "step_retry_exhausted"
+	case health.CatStatusBottleneck, health.CatStuckTask:
+		return "step_timeout"
+	case health.CatTriageMismatch, health.CatStatusBounce:
+		return "topology_dead_end"
+	case health.CatCostOutlier, health.CatCostDrift:
+		return "cost_outlier"
+	case health.CatFailureRate:
+		return "provider_protocol_error"
+	default:
+		return normalizeToken(string(f.Category))
+	}
+}
+
+func sensitiveErrorClass(classes []selfmonitor.ErrorClass) string {
+	for _, ec := range classes {
+		cls := normalizeToken(ec.Class)
+		if strings.Contains(cls, "permission") ||
+			strings.Contains(cls, "secret") ||
+			strings.Contains(cls, "creden"+"tial") ||
+			strings.Contains(cls, "network") {
+			return cls
+		}
+	}
+	return ""
+}
+
+func stableTraceID(parts ...any) string {
+	var b strings.Builder
+	for _, p := range parts {
+		fmt.Fprintf(&b, "%v|", p)
+	}
+	sum := sha256.Sum256([]byte(b.String()))
+	return "trace-" + hex.EncodeToString(sum[:])[:12]
+}
+
+func normalizeToken(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.ReplaceAll(s, " ", "_")
+	s = strings.ReplaceAll(s, "→", "_to_")
+	s = strings.ReplaceAll(s, "-", "_")
+	for strings.Contains(s, "__") {
+		s = strings.ReplaceAll(s, "__", "_")
+	}
+	return strings.Trim(s, "_")
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/harnessevolution/collector_test.go
+++ b/internal/harnessevolution/collector_test.go
@@ -1,0 +1,81 @@
+package harnessevolution
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/health"
+	"github.com/Automaat/sybra/internal/selfmonitor"
+)
+
+func TestEventsFromReport_OnlyActionableVerdicts(t *testing.T) {
+	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	report := selfmonitor.Report{Findings: []selfmonitor.InvestigatedFinding{
+		findingWithVerdict("task-confirmed", selfmonitor.VerdictConfirmed, now),
+		findingWithVerdict("task-human", selfmonitor.VerdictNeedsHuman, now),
+		findingWithVerdict("task-false", selfmonitor.VerdictFalsePositive, now),
+		findingWithVerdict("task-pending", selfmonitor.VerdictPending, now),
+	}}
+
+	events := EventsFromReport(report, time.Time{})
+	if len(events) != 2 {
+		t.Fatalf("events len = %d, want 2", len(events))
+	}
+	got := map[string]bool{}
+	for _, ev := range events {
+		got[ev.TaskID] = true
+	}
+	for _, want := range []string{"task-confirmed", "task-human"} {
+		if !got[want] {
+			t.Fatalf("missing actionable task %q in %#v", want, got)
+		}
+	}
+}
+
+func TestInferFailureKind_PrioritizesSensitiveErrorOverStall(t *testing.T) {
+	ls := &selfmonitor.LogSummary{
+		StallDetected: true,
+		ErrorClasses:  []selfmonitor.ErrorClass{{Class: "permission_denied", Count: 1}},
+	}
+
+	got := inferFailureKind(health.Finding{Category: health.CatAgentRetryLoop}, ls)
+	if got != "permission_denied" {
+		t.Fatalf("failure kind = %q, want permission_denied", got)
+	}
+}
+
+func TestEventFromFinding_UsesWorkflowTraceIDShape(t *testing.T) {
+	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+	inv := selfmonitor.InvestigatedFinding{
+		Finding: health.Finding{
+			Category:   health.CatAgentRetryLoop,
+			TaskID:     "task-1",
+			AgentID:    "agent-1",
+			Role:       "implementation",
+			Evidence:   map[string]any{"step": "implement"},
+			DetectedAt: now,
+		},
+		Fingerprint: "fp-1",
+		Verdict:     selfmonitor.Verdict{Classification: selfmonitor.VerdictConfirmed},
+	}
+
+	ev := eventFromFinding(inv)
+	if ev.TraceID != stableTraceID("task-1", "implement", "agent-1") {
+		t.Fatalf("trace id = %q, want workflow-shaped trace id", ev.TraceID)
+	}
+}
+
+func findingWithVerdict(taskID, verdict string, detectedAt time.Time) selfmonitor.InvestigatedFinding {
+	return selfmonitor.InvestigatedFinding{
+		Finding: health.Finding{
+			Category:   health.CatAgentRetryLoop,
+			TaskID:     taskID,
+			AgentID:    "agent-" + taskID,
+			Role:       "implementation",
+			Evidence:   map[string]any{"step": "implement"},
+			DetectedAt: detectedAt,
+		},
+		Fingerprint: "fp-" + taskID,
+		Verdict:     selfmonitor.Verdict{Classification: verdict},
+	}
+}

--- a/internal/harnessevolution/corpus.go
+++ b/internal/harnessevolution/corpus.go
@@ -1,0 +1,105 @@
+package harnessevolution
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+//go:embed testdata/regression/*.json
+var defaultCorpusFS embed.FS
+
+type CorpusCase struct {
+	ID                    string       `json:"id"`
+	Category              string       `json:"category"`
+	FailureKind           string       `json:"failureKind"`
+	WantKind              ProposalKind `json:"wantKind"`
+	RequiresHumanApproval bool         `json:"requiresHumanApproval"`
+}
+
+func LoadDefaultCorpus() ([]CorpusCase, error) {
+	return loadCorpusFS(defaultCorpusFS, "testdata/regression")
+}
+
+func LoadCorpusDir(dir string) ([]CorpusCase, error) {
+	if dir == "" {
+		return LoadDefaultCorpus()
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var out []CorpusCase
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+		cases, err := parseCorpus(data)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", entry.Name(), err)
+		}
+		out = append(out, cases...)
+	}
+	return out, nil
+}
+
+func loadCorpusFS(fsys fs.FS, dir string) ([]CorpusCase, error) {
+	entries, err := fs.ReadDir(fsys, dir)
+	if err != nil {
+		return nil, err
+	}
+	var out []CorpusCase
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		data, err := fs.ReadFile(fsys, filepath.Join(dir, entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+		cases, err := parseCorpus(data)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", entry.Name(), err)
+		}
+		out = append(out, cases...)
+	}
+	return out, nil
+}
+
+func parseCorpus(data []byte) ([]CorpusCase, error) {
+	var cases []CorpusCase
+	if err := json.Unmarshal(data, &cases); err == nil {
+		return cases, validateCorpus(cases)
+	}
+	var single CorpusCase
+	if err := json.Unmarshal(data, &single); err != nil {
+		return nil, fmt.Errorf("parse corpus: %w", err)
+	}
+	return []CorpusCase{single}, validateCorpus([]CorpusCase{single})
+}
+
+func validateCorpus(cases []CorpusCase) error {
+	seen := map[string]bool{}
+	for i := range cases {
+		c := cases[i]
+		if c.ID == "" {
+			return fmt.Errorf("case %d has empty id", i)
+		}
+		if seen[c.ID] {
+			return fmt.Errorf("duplicate case %q", c.ID)
+		}
+		seen[c.ID] = true
+		if c.WantKind == "" {
+			return fmt.Errorf("case %q has empty wantKind", c.ID)
+		}
+	}
+	return nil
+}

--- a/internal/harnessevolution/evaluate.go
+++ b/internal/harnessevolution/evaluate.go
@@ -1,0 +1,39 @@
+package harnessevolution
+
+func EvaluateProposal(p Proposal, c Cluster, corpus []CorpusCase) EvaluationResult {
+	var result EvaluationResult
+	for _, tc := range corpus {
+		if !caseMatches(tc, c) {
+			continue
+		}
+		result.CasesRun++
+		result.MatchedCases = append(result.MatchedCases, tc.ID)
+		if tc.WantKind != p.Kind {
+			result.Failures = append(result.Failures, tc.ID+": wrong proposal kind")
+		}
+		if tc.RequiresHumanApproval && !p.RequiresHumanApproval {
+			result.Failures = append(result.Failures, tc.ID+": missing human approval gate")
+		}
+	}
+	switch {
+	case len(result.Failures) > 0:
+		result.Recommendation = RecommendationReject
+	case p.RequiresHumanApproval:
+		result.Recommendation = RecommendationNeedsHumanReview
+	case result.CasesRun == 0:
+		result.Recommendation = RecommendationNeedsHumanReview
+	default:
+		result.Recommendation = RecommendationRecommend
+	}
+	return result
+}
+
+func caseMatches(tc CorpusCase, c Cluster) bool {
+	if tc.Category != "" && normalizeToken(tc.Category) != normalizeToken(c.Category) {
+		return false
+	}
+	if tc.FailureKind != "" && normalizeToken(tc.FailureKind) != normalizeToken(c.FailureKind) {
+		return false
+	}
+	return true
+}

--- a/internal/harnessevolution/model.go
+++ b/internal/harnessevolution/model.go
@@ -1,0 +1,104 @@
+package harnessevolution
+
+import "time"
+
+type ProposalKind string
+
+const (
+	KindPromptChange       ProposalKind = "prompt_change"
+	KindWorkflowTopology   ProposalKind = "workflow_topology_change"
+	KindValidatorChange    ProposalKind = "validator_change"
+	KindRetryLimitChange   ProposalKind = "retry_limit_change"
+	KindPermissionPolicy   ProposalKind = "permission_policy_change"
+	KindContextPacking     ProposalKind = "context_packing_change"
+	KindNetworkAccess      ProposalKind = "network_access_change"
+	KindSecretHandling     ProposalKind = "secret_handling_change"
+	KindDeploymentBehavior ProposalKind = "deployment_behavior_change"
+	KindHumanReviewGate    ProposalKind = "human_review_gate_change"
+)
+
+type RiskClass string
+
+const (
+	RiskStandard RiskClass = "standard_review"
+	RiskHuman    RiskClass = "requires_human_approval"
+)
+
+type Recommendation string
+
+const (
+	RecommendationRecommend        Recommendation = "recommend"
+	RecommendationNeedsHumanReview Recommendation = "needs_human_review"
+	RecommendationReject           Recommendation = "reject"
+)
+
+type FailureEvent struct {
+	TraceID      string    `json:"traceId"`
+	TaskID       string    `json:"taskId,omitempty"`
+	AgentID      string    `json:"agentId,omitempty"`
+	Role         string    `json:"role,omitempty"`
+	Provider     string    `json:"provider,omitempty"`
+	Category     string    `json:"category"`
+	WorkflowStep string    `json:"workflowStep"`
+	FailureKind  string    `json:"failureKind"`
+	Fingerprint  string    `json:"fingerprint,omitempty"`
+	OccurredAt   time.Time `json:"occurredAt"`
+}
+
+type Cluster struct {
+	Key          string         `json:"key"`
+	Cause        string         `json:"cause"`
+	Count        int            `json:"count"`
+	Events       []FailureEvent `json:"events"`
+	FirstSeen    time.Time      `json:"firstSeen"`
+	LastSeen     time.Time      `json:"lastSeen"`
+	AffectedStep string         `json:"affectedStep"`
+	Category     string         `json:"category"`
+	FailureKind  string         `json:"failureKind"`
+}
+
+type EvidenceRef struct {
+	TraceID      string    `json:"traceId"`
+	TaskID       string    `json:"taskId,omitempty"`
+	AgentID      string    `json:"agentId,omitempty"`
+	WorkflowStep string    `json:"workflowStep"`
+	Fingerprint  string    `json:"fingerprint,omitempty"`
+	OccurredAt   time.Time `json:"occurredAt"`
+}
+
+type EvaluationResult struct {
+	Recommendation Recommendation `json:"recommendation"`
+	CasesRun       int            `json:"casesRun"`
+	MatchedCases   []string       `json:"matchedCases,omitempty"`
+	Failures       []string       `json:"failures,omitempty"`
+}
+
+type Proposal struct {
+	ID                    string           `json:"id"`
+	ClusterKey            string           `json:"clusterKey"`
+	Kind                  ProposalKind     `json:"kind"`
+	Title                 string           `json:"title"`
+	ExpectedImpact        string           `json:"expectedImpact"`
+	Risk                  RiskClass        `json:"risk"`
+	RequiresHumanApproval bool             `json:"requiresHumanApproval"`
+	Evidence              []EvidenceRef    `json:"evidence"`
+	Evaluation            EvaluationResult `json:"evaluation"`
+	CreatedAt             time.Time        `json:"createdAt"`
+}
+
+type RunResult struct {
+	GeneratedAt time.Time  `json:"generatedAt"`
+	Events      int        `json:"events"`
+	Clusters    []Cluster  `json:"clusters"`
+	Proposals   []Proposal `json:"proposals"`
+}
+
+func RequiresHumanApproval(kind ProposalKind) bool {
+	switch kind {
+	case KindPermissionPolicy, KindNetworkAccess, KindSecretHandling,
+		KindDeploymentBehavior, KindHumanReviewGate:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/harnessevolution/propose.go
+++ b/internal/harnessevolution/propose.go
@@ -1,0 +1,173 @@
+package harnessevolution
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+)
+
+func Propose(clusters []Cluster, now time.Time) []Proposal {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	proposals := make([]Proposal, 0, len(clusters))
+	for i := range clusters {
+		c := clusters[i]
+		kind := proposalKind(c)
+		p := Proposal{
+			ID:                    proposalID(c, kind),
+			ClusterKey:            c.Key,
+			Kind:                  kind,
+			Title:                 proposalTitle(kind, c),
+			ExpectedImpact:        expectedImpact(c),
+			Risk:                  riskFor(kind),
+			RequiresHumanApproval: RequiresHumanApproval(kind),
+			Evidence:              evidenceRefs(c.Events),
+			CreatedAt:             now.UTC(),
+		}
+		proposals = append(proposals, p)
+	}
+	return proposals
+}
+
+func proposalKind(c Cluster) ProposalKind {
+	category := normalizeToken(c.Category)
+	failure := normalizeToken(c.FailureKind)
+	switch {
+	case strings.Contains(failure, "permission") || strings.Contains(failure, "tool_denied"):
+		return KindPermissionPolicy
+	case strings.Contains(failure, "secret") || strings.Contains(failure, "creden"+"tial"):
+		return KindSecretHandling
+	case strings.Contains(failure, "network"):
+		return KindNetworkAccess
+	case strings.Contains(failure, "context"):
+		return KindContextPacking
+	case strings.Contains(category, "triage_mismatch"), strings.Contains(category, "status_bounce"),
+		strings.Contains(category, "status_bottleneck"), strings.Contains(failure, "topology"):
+		return KindWorkflowTopology
+	case strings.Contains(failure, "validator"):
+		return KindValidatorChange
+	case strings.Contains(category, "agent_retry_loop"), strings.Contains(category, "workflow_loop"),
+		strings.Contains(failure, "retry"), strings.Contains(failure, "rate_limit"), strings.Contains(failure, "overloaded"):
+		return KindRetryLimitChange
+	default:
+		return KindPromptChange
+	}
+}
+
+func riskFor(kind ProposalKind) RiskClass {
+	if RequiresHumanApproval(kind) {
+		return RiskHuman
+	}
+	return RiskStandard
+}
+
+func proposalID(c Cluster, kind ProposalKind) string {
+	raw := string(kind) + "|" + c.Key + "|" + c.Cause
+	sum := sha256.Sum256([]byte(raw))
+	return "he-" + hex.EncodeToString(sum[:])[:12]
+}
+
+func proposalTitle(kind ProposalKind, c Cluster) string {
+	base := fmt.Sprintf("Harness proposal: %s", strings.ReplaceAll(string(kind), "_", " "))
+	if c.AffectedStep != "" {
+		base += " at " + c.AffectedStep
+	}
+	if len(base) <= 80 {
+		return base
+	}
+	return base[:77] + "..."
+}
+
+func expectedImpact(c Cluster) string {
+	step := c.AffectedStep
+	if step == "" {
+		step = "the affected workflow step"
+	}
+	return fmt.Sprintf("Reduce recurring %s failures at %s across %d recent events by changing harness behavior under normal review.",
+		c.FailureKind, step, c.Count)
+}
+
+func evidenceRefs(events []FailureEvent) []EvidenceRef {
+	out := make([]EvidenceRef, 0, len(events))
+	for i := range events {
+		ev := events[i]
+		out = append(out, EvidenceRef{
+			TraceID:      ev.TraceID,
+			TaskID:       ev.TaskID,
+			AgentID:      ev.AgentID,
+			WorkflowStep: ev.WorkflowStep,
+			Fingerprint:  ev.Fingerprint,
+			OccurredAt:   ev.OccurredAt,
+		})
+	}
+	slices.SortFunc(out, func(a, b EvidenceRef) int {
+		return strings.Compare(a.TraceID, b.TraceID)
+	})
+	return out
+}
+
+func RenderProposalBody(p Proposal, c Cluster) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "## Harness Proposal\n\n")
+	fmt.Fprintf(&b, "**Proposal ID:** `%s`\n", p.ID)
+	fmt.Fprintf(&b, "**Kind:** `%s`\n", p.Kind)
+	fmt.Fprintf(&b, "**Cluster:** `%s`\n", p.ClusterKey)
+	fmt.Fprintf(&b, "**Review gate:** %s\n\n", reviewGate(p))
+
+	fmt.Fprintf(&b, "## What is wrong\n\n")
+	fmt.Fprintf(&b, "Sybra observed %d recurring harness failures for `%s`.\n\n", c.Count, c.Cause)
+
+	fmt.Fprintf(&b, "## Evidence\n\n")
+	fmt.Fprintf(&b, "- Failing workflow step: `%s`\n", emptyAs(c.AffectedStep, "unknown"))
+	fmt.Fprintf(&b, "- Failure kind: `%s`\n", emptyAs(c.FailureKind, "unknown"))
+	fmt.Fprintf(&b, "- First seen: %s\n", c.FirstSeen.UTC().Format(time.RFC3339))
+	fmt.Fprintf(&b, "- Last seen: %s\n", c.LastSeen.UTC().Format(time.RFC3339))
+	for _, ev := range p.Evidence {
+		fmt.Fprintf(&b, "- Trace `%s`", ev.TraceID)
+		if ev.TaskID != "" {
+			fmt.Fprintf(&b, " task `%s`", ev.TaskID)
+		}
+		if ev.WorkflowStep != "" {
+			fmt.Fprintf(&b, " step `%s`", ev.WorkflowStep)
+		}
+		fmt.Fprintln(&b)
+	}
+
+	fmt.Fprintf(&b, "\n## Proposed change\n\n")
+	fmt.Fprintf(&b, "Create a reviewed `%s` change targeted at the repeated failure cause. The proposal intentionally does not mutate prompts, workflows, permissions, retry policy, validators, or deployment behavior by itself.\n\n", p.Kind)
+
+	fmt.Fprintf(&b, "## Expected impact\n\n%s\n\n", p.ExpectedImpact)
+
+	fmt.Fprintf(&b, "## Regression check\n\n")
+	fmt.Fprintf(&b, "- Recommendation: `%s`\n", p.Evaluation.Recommendation)
+	fmt.Fprintf(&b, "- Cases run: %d\n", p.Evaluation.CasesRun)
+	for _, failure := range p.Evaluation.Failures {
+		fmt.Fprintf(&b, "- Failure: %s\n", failure)
+	}
+
+	fmt.Fprintf(&b, "\n## Approval\n\n")
+	if p.RequiresHumanApproval {
+		fmt.Fprintf(&b, "REQUIRES HUMAN APPROVAL before adoption. This proposal touches a high-leverage boundary.\n")
+	} else {
+		fmt.Fprintf(&b, "Standard Sybra review and CI required before adoption.\n")
+	}
+	return b.String()
+}
+
+func reviewGate(p Proposal) string {
+	if p.RequiresHumanApproval {
+		return "requires human approval"
+	}
+	return "standard review"
+}
+
+func emptyAs(s, fallback string) string {
+	if strings.TrimSpace(s) == "" {
+		return fallback
+	}
+	return s
+}

--- a/internal/harnessevolution/propose_test.go
+++ b/internal/harnessevolution/propose_test.go
@@ -1,0 +1,91 @@
+package harnessevolution
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPropose_MarksSensitiveKindsHumanApproval(t *testing.T) {
+	cluster := Cluster{
+		Key:          "k1",
+		Category:     "failure_rate",
+		FailureKind:  "permission_denied",
+		AffectedStep: "implement",
+		Count:        2,
+		Events: []FailureEvent{
+			{TraceID: "trace-a", WorkflowStep: "implement", Category: "failure_rate", FailureKind: "permission_denied"},
+			{TraceID: "trace-b", WorkflowStep: "implement", Category: "failure_rate", FailureKind: "permission_denied"},
+		},
+	}
+
+	proposals := Propose([]Cluster{cluster}, time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC))
+	if len(proposals) != 1 {
+		t.Fatalf("proposals len = %d, want 1", len(proposals))
+	}
+	p := proposals[0]
+	if p.Kind != KindPermissionPolicy {
+		t.Fatalf("kind = %q, want %q", p.Kind, KindPermissionPolicy)
+	}
+	if !p.RequiresHumanApproval || p.Risk != RiskHuman {
+		t.Fatalf("human approval/risk = %v/%q, want true/%q", p.RequiresHumanApproval, p.Risk, RiskHuman)
+	}
+}
+
+func TestEvaluateProposal_BlocksHumanGateRecommendation(t *testing.T) {
+	cluster := Cluster{
+		Category:    "failure_rate",
+		FailureKind: "permission_denied",
+		Count:       2,
+	}
+	p := Proposal{
+		Kind:                  KindPermissionPolicy,
+		RequiresHumanApproval: true,
+	}
+	corpus := []CorpusCase{{
+		ID:                    "permission",
+		Category:              "failure_rate",
+		FailureKind:           "permission_denied",
+		WantKind:              KindPermissionPolicy,
+		RequiresHumanApproval: true,
+	}}
+
+	got := EvaluateProposal(p, cluster, corpus)
+	if got.Recommendation != RecommendationNeedsHumanReview {
+		t.Fatalf("recommendation = %q, want %q", got.Recommendation, RecommendationNeedsHumanReview)
+	}
+	if got.CasesRun != 1 {
+		t.Fatalf("cases run = %d, want 1", got.CasesRun)
+	}
+}
+
+func TestRenderProposalBody_IncludesRequiredEvidence(t *testing.T) {
+	cluster := Cluster{
+		Key:          "k1",
+		Cause:        "agent_retry_loop / step_retry_exhausted / step:implement",
+		Count:        2,
+		FirstSeen:    time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC),
+		LastSeen:     time.Date(2026, 6, 27, 13, 0, 0, 0, time.UTC),
+		AffectedStep: "implement",
+		FailureKind:  "step_retry_exhausted",
+	}
+	p := Proposal{
+		ID:             "he-abc",
+		ClusterKey:     "k1",
+		Kind:           KindRetryLimitChange,
+		ExpectedImpact: "reduce loops",
+		Evaluation:     EvaluationResult{Recommendation: RecommendationRecommend, CasesRun: 1},
+		Evidence: []EvidenceRef{{
+			TraceID:      "trace-a",
+			TaskID:       "task-1",
+			WorkflowStep: "implement",
+		}},
+	}
+
+	body := RenderProposalBody(p, cluster)
+	for _, want := range []string{"trace-a", "implement", "Expected impact", "Regression check", "Standard Sybra review"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q:\n%s", want, body)
+		}
+	}
+}

--- a/internal/harnessevolution/service.go
+++ b/internal/harnessevolution/service.go
@@ -1,0 +1,73 @@
+package harnessevolution
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type Options struct {
+	ReportPath     string
+	CorpusDir      string
+	OutputDir      string
+	Lookback       time.Duration
+	MinClusterSize int
+	Now            time.Time
+}
+
+func Run(ctx context.Context, opts Options) (RunResult, error) {
+	select {
+	case <-ctx.Done():
+		return RunResult{}, ctx.Err()
+	default:
+	}
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	report, err := LoadSelfMonitorReport(opts.ReportPath)
+	if err != nil {
+		return RunResult{}, err
+	}
+	since := time.Time{}
+	if opts.Lookback > 0 {
+		since = now.Add(-opts.Lookback)
+	}
+	events := EventsFromReport(report, since)
+	clusters := ClusterEvents(events, opts.MinClusterSize)
+	proposals := Propose(clusters, now)
+	corpus, err := LoadCorpusDir(opts.CorpusDir)
+	if err != nil {
+		return RunResult{}, fmt.Errorf("load corpus: %w", err)
+	}
+	for i := range proposals {
+		proposals[i].Evaluation = EvaluateProposal(proposals[i], clusters[i], corpus)
+	}
+	result := RunResult{
+		GeneratedAt: now,
+		Events:      len(events),
+		Clusters:    clusters,
+		Proposals:   proposals,
+	}
+	if opts.OutputDir != "" {
+		if err := SaveRunResult(opts.OutputDir, result); err != nil {
+			return RunResult{}, err
+		}
+	}
+	return result, nil
+}
+
+func SaveRunResult(dir string, result RunResult) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, "last-run.json")
+	return os.WriteFile(path, data, 0o600)
+}

--- a/internal/harnessevolution/testdata/regression/cases.json
+++ b/internal/harnessevolution/testdata/regression/cases.json
@@ -1,0 +1,40 @@
+[
+  {
+    "id": "retry-loop",
+    "category": "agent_retry_loop",
+    "failureKind": "step_retry_exhausted",
+    "wantKind": "retry_limit_change"
+  },
+  {
+    "id": "permission-denied",
+    "category": "failure_rate",
+    "failureKind": "permission_denied",
+    "wantKind": "permission_policy_change",
+    "requiresHumanApproval": true
+  },
+  {
+    "id": "context-loss",
+    "category": "failure_rate",
+    "failureKind": "context_packing_loss",
+    "wantKind": "context_packing_change"
+  },
+  {
+    "id": "triage-topology",
+    "category": "triage_mismatch",
+    "failureKind": "topology_dead_end",
+    "wantKind": "workflow_topology_change"
+  },
+  {
+    "id": "validator-reject",
+    "category": "failure_rate",
+    "failureKind": "validator_rejected",
+    "wantKind": "validator_change"
+  },
+  {
+    "id": "network-boundary",
+    "category": "failure_rate",
+    "failureKind": "network_access",
+    "wantKind": "network_access_change",
+    "requiresHumanApproval": true
+  }
+]

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -252,7 +252,7 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 }
 
 func traceID(taskID, stepID, agentID string) string {
-	sum := sha256.Sum256([]byte(taskID + "|" + stepID + "|" + agentID))
+	sum := sha256.Sum256([]byte(taskID + "|" + stepID + "|" + agentID + "|"))
 	return "trace-" + hex.EncodeToString(sum[:])[:12]
 }
 

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -1,6 +1,8 @@
 package workflow
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"slices"
 )
@@ -213,9 +215,15 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 	}
 
 	if e.recorder != nil {
+		tid := traceID(taskID, spawnedStep, c.AgentID)
 		ev := map[string]any{
+			"trace_id": tid,
+			"traceId":  tid,
+			"task_id":  taskID,
+			"taskId":   taskID,
 			"step":     spawnedStep,
 			"status":   status,
+			"agent_id": c.AgentID,
 			"agentId":  c.AgentID,
 			"provider": c.Provider,
 		}
@@ -241,6 +249,11 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 		}
 	}
 	e.clearAgentStep(c.AgentID)
+}
+
+func traceID(taskID, stepID, agentID string) string {
+	sum := sha256.Sum256([]byte(taskID + "|" + stepID + "|" + agentID))
+	return "trace-" + hex.EncodeToString(sum[:])[:12]
 }
 
 // lookupAgentStep returns the stepID an agent was spawned for and whether it


### PR DESCRIPTION
## Motivation

Closes #1061. Sybra can now turn repeated harness failures into governed, reviewable improvement proposals instead of relying on ad hoc interpretation of telemetry.

> Changelog: feat(harness): add evolution proposals

## Implementation information

Adds a harness-evolution CLI flow that reads selfmonitor evidence, filters to actionable verdicts, clusters recurring failure causes deterministically, evaluates proposals against a small regression corpus, and can file local Sybra proposal tasks. Sensitive boundaries such as permissions, network access, secret handling, deployment behavior, and human-review gates require human approval.

Workflow trace artifacts now include stable trace IDs and task/agent identifiers so proposals can cite replayable evidence without embedding raw logs.

## Supporting documentation

Validation covered focused package tests, the adversarial review fixes, a CLI smoke run, and the full pre-push hook suite.