### PR TITLE
fix(task): show agent costs

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/agent/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/agent/models.ts
@@ -29,9 +29,8 @@ export class Agent {
     "reasoningTokens"?: number;
 
     /**
-     * PremiumRequests is Copilot's billing unit (AI credits). Copilot reports
-     * no USD cost, so this is the usage signal surfaced for copilot agents;
-     * always 0 for claude/codex.
+     * PremiumRequests is Copilot's billing unit (AI credits). Sybra keeps the
+     * raw count alongside the estimated USD equivalent persisted on task runs.
      */
     "premiumRequests"?: number;
     "startedAt": time$0.Time;

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -35,6 +35,7 @@ export class AgentRun {
     "state": string;
     "startedAt": time$0.Time;
     "costUsd": number;
+    "premiumRequests"?: number;
     "prompt"?: string;
     "result": string;
 

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -44,9 +44,8 @@ type Agent struct {
 	CacheCreationInputTokens int     `json:"cacheCreationInputTokens,omitempty"`
 	CacheReadInputTokens     int     `json:"cacheReadInputTokens,omitempty"`
 	ReasoningTokens          int     `json:"reasoningTokens,omitempty"`
-	// PremiumRequests is Copilot's billing unit (AI credits). Copilot reports
-	// no USD cost, so this is the usage signal surfaced for copilot agents;
-	// always 0 for claude/codex.
+	// PremiumRequests is Copilot's billing unit (AI credits). Sybra keeps the
+	// raw count alongside the estimated USD equivalent persisted on task runs.
 	PremiumRequests float64   `json:"premiumRequests,omitempty"`
 	StartedAt       time.Time `json:"startedAt"`
 	LastEventAt     time.Time `json:"lastEventAt"`

--- a/internal/agent/stream.go
+++ b/internal/agent/stream.go
@@ -38,8 +38,8 @@ type ClaudeResult struct {
 	ErrorType   string
 	ErrorStatus int
 	// PremiumRequests is Copilot's billing unit (AI credits), mapped from the
-	// result event's `usage.premiumRequests`. Copilot reports no USD cost.
-	// Always 0 for claude/codex.
+	// result event's `usage.premiumRequests`. Sybra estimates USD from this
+	// separately; always 0 for claude/codex.
 	PremiumRequests float64
 }
 

--- a/internal/stats/pricing.go
+++ b/internal/stats/pricing.go
@@ -2,6 +2,8 @@ package stats
 
 import "strings"
 
+const copilotAICreditUSD = 0.01
+
 // Per-million-token USD rates. Cached input rates apply to the
 // `cached_input_tokens` (Codex) or `cache_read_input_tokens` (Claude) subset.
 // Cache-write rate applies to Claude `cache_creation_input_tokens`.
@@ -63,6 +65,14 @@ func EstimateCost(model string, inputTokens, outputTokens int) float64 {
 		return 0
 	}
 	return float64(inputTokens)/1_000_000*p.in + float64(outputTokens)/1_000_000*p.out
+}
+
+// EstimateCopilotCost converts Copilot AI credit usage to USD overage-equivalent cost.
+func EstimateCopilotCost(premiumRequests float64) float64 {
+	if premiumRequests <= 0 {
+		return 0
+	}
+	return premiumRequests * copilotAICreditUSD
 }
 
 // EstimateCostDetailed prices a run using the full token breakdown.

--- a/internal/stats/pricing_test.go
+++ b/internal/stats/pricing_test.go
@@ -33,6 +33,15 @@ func TestEstimateCost(t *testing.T) {
 	}
 }
 
+func TestEstimateCopilotCost(t *testing.T) {
+	if got, want := EstimateCopilotCost(7.5), 0.075; got != want {
+		t.Errorf("EstimateCopilotCost(7.5) = %g, want %g", got, want)
+	}
+	if got := EstimateCopilotCost(0); got != 0 {
+		t.Errorf("EstimateCopilotCost(0) = %g, want 0", got)
+	}
+}
+
 func TestEstimateCostDetailed_ClaudeMatchesReportedTotalCost(t *testing.T) {
 	// Cross-check against a real Claude result event captured from a Sybra
 	// agent run (logs/agents/ff4fb283-*.ndjson). Claude reports

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -100,6 +100,8 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 	// persistence write and the audit entry see a consistent view.
 	state := ag.GetState()
 	cost := ag.GetCostUSD()
+	premiumRequests := ag.GetPremiumRequests()
+	cost = estimatedRunCost(ag, cost, premiumRequests)
 	exitErr := ag.GetExitErr()
 	reasoning := ag.GetReasoningTokens()
 
@@ -119,6 +121,9 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 	}
 	if reasoning > 0 {
 		auditData["reasoning_tokens"] = reasoning
+	}
+	if premiumRequests > 0 {
+		auditData["premium_requests"] = premiumRequests
 	}
 	h.logAudit(audit.EventAgentCompleted, ag.TaskID, ag.ID, auditData)
 
@@ -144,13 +149,14 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 		truncated = truncated[:maxResultLen] + "\n... (truncated)"
 	}
 	runUpdates := map[string]any{
-		"state":      string(state),
-		"cost_usd":   cost,
-		"result":     truncated,
-		"log_file":   ag.LogPath,
-		"session_id": ag.GetSessionID(),
-		"model":      ag.Model,
-		"provider":   ag.Provider,
+		"state":            string(state),
+		"cost_usd":         cost,
+		"premium_requests": premiumRequests,
+		"result":           truncated,
+		"log_file":         ag.LogPath,
+		"session_id":       ag.GetSessionID(),
+		"model":            ag.Model,
+		"provider":         ag.Provider,
 	}
 	addRunMetadata(runUpdates, ag)
 	// For human-review agents, parse the verdict from the live (untruncated)
@@ -342,13 +348,7 @@ func (h *AgentCompletionHandler) recordRunStats(ag *agent.Agent, cost, duration 
 	cacheCreate := ag.GetCacheCreationInputTokens()
 	cacheRead := ag.GetCacheReadInputTokens()
 	reasoning := ag.GetReasoningTokens()
-	agCost := cost
-	if agCost == 0 && ag.Provider == "codex" {
-		// Codex CLI doesn't emit cost — estimate from token counts.
-		// Pricing covers cached vs uncached input separately so the estimate
-		// matches actual OpenAI billing rather than the gross-input ceiling.
-		agCost = stats.EstimateCostDetailed(ag.Model, in, out, 0, cacheRead, reasoning)
-	}
+	agCost := estimatedRunCost(ag, cost, ag.GetPremiumRequests())
 	outcome := "failed"
 	if exitErr == nil {
 		outcome = "completed"
@@ -404,6 +404,26 @@ func (h *AgentCompletionHandler) recordRunStats(ag *agent.Agent, cost, duration 
 			Timestamp:                time.Now(),
 		})
 	}
+}
+
+func estimatedRunCost(ag *agent.Agent, cost, premiumRequests float64) float64 {
+	if cost > 0 {
+		return cost
+	}
+	if ag.Provider == "copilot" {
+		return stats.EstimateCopilotCost(premiumRequests)
+	}
+	if ag.Provider == "codex" {
+		return stats.EstimateCostDetailed(
+			ag.Model,
+			ag.GetInputTokens(),
+			ag.GetOutputTokens(),
+			0,
+			ag.GetCacheReadInputTokens(),
+			ag.GetReasoningTokens(),
+		)
+	}
+	return 0
 }
 
 // isRateLimitedRun reports whether a failed run was rejected by a transient

--- a/internal/sybra/agent_completion_test.go
+++ b/internal/sybra/agent_completion_test.go
@@ -228,6 +228,37 @@ func TestLastAssistantText(t *testing.T) {
 	})
 }
 
+func TestEstimatedRunCost(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reported cost wins", func(t *testing.T) {
+		t.Parallel()
+		ag := &agent.Agent{Provider: "codex", Model: "gpt-5"}
+		if got := estimatedRunCost(ag, 0.42, 9); got != 0.42 {
+			t.Errorf("estimatedRunCost reported = %g, want 0.42", got)
+		}
+	})
+
+	t.Run("codex estimates from tokens", func(t *testing.T) {
+		t.Parallel()
+		ag := &agent.Agent{Provider: "codex", Model: "gpt-5"}
+		ag.AddResultStats("", 0, 1_000_000, 100_000, 0)
+		ag.AddCacheStats(0, 800_000)
+		if got, want := estimatedRunCost(ag, 0, 0), 1.35; got != want {
+			t.Errorf("estimatedRunCost codex = %g, want %g", got, want)
+		}
+	})
+
+	t.Run("copilot estimates from credits", func(t *testing.T) {
+		t.Parallel()
+		ag := &agent.Agent{Provider: "copilot"}
+		ag.AddPremiumRequests(7.5)
+		if got, want := estimatedRunCost(ag, 0, ag.GetPremiumRequests()), 0.075; got != want {
+			t.Errorf("estimatedRunCost copilot = %g, want %g", got, want)
+		}
+	})
+}
+
 // itoa converts a small non-negative int to its decimal string representation
 // without importing strconv (avoids an extra import just for test helpers).
 func itoa(n int) string {

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -75,42 +75,103 @@ func (s *TaskService) withEstimatedAgentRunCosts(t task.Task) task.Task {
 		if run.CostUSD > 0 || run.LogFile == "" {
 			continue
 		}
-		provider := providerForRun(*run)
-		events, err := agent.ParseLogFile(run.LogFile, 0, provider)
-		if err != nil {
+		estimate, ok := estimateAgentRunUsage(*run)
+		if !ok {
 			if s.logger != nil {
-				s.logger.Debug("task.agent-run-cost.log-parse-skipped", "task_id", t.ID, "agent_id", run.AgentID, "log", run.LogFile, "err", err)
+				s.logger.Debug("task.agent-run-cost.estimate-skipped", "task_id", t.ID, "agent_id", run.AgentID, "log", run.LogFile)
 			}
 			continue
 		}
-		var input, output, cacheCreate, cacheRead, reasoning int
-		var cost, premiumRequests float64
-		for j := range events {
-			if events[j].Type != "result" {
-				continue
+		if estimate.PremiumRequests > 0 {
+			run.PremiumRequests = estimate.PremiumRequests
+		}
+		run.CostUSD = estimate.CostUSD
+		if estimate.CostUSD > 0 && s.tasks != nil {
+			updates := map[string]any{"cost_usd": estimate.CostUSD}
+			if estimate.PremiumRequests > 0 {
+				updates["premium_requests"] = estimate.PremiumRequests
 			}
-			cost += events[j].CostUSD
-			premiumRequests += events[j].PremiumRequests
-			input += events[j].InputTokens
-			output += events[j].OutputTokens
-			cacheCreate += events[j].CacheCreationInputTokens
-			cacheRead += events[j].CacheReadInputTokens
-			reasoning += events[j].ReasoningTokens
-		}
-		if premiumRequests > 0 {
-			run.PremiumRequests = premiumRequests
-		}
-		if cost == 0 {
-			switch provider {
-			case "copilot":
-				cost = stats.EstimateCopilotCost(premiumRequests)
-			case "codex", "claude":
-				cost = stats.EstimateCostDetailed(run.Model, input, output, cacheCreate, cacheRead, reasoning)
+			if run.Provider == "" && estimate.Provider != "" {
+				updates["provider"] = estimate.Provider
+				run.Provider = estimate.Provider
+			}
+			if err := s.tasks.UpdateRun(t.ID, run.AgentID, updates); err != nil && s.logger != nil {
+				s.logger.Debug("task.agent-run-cost.persist-skipped", "task_id", t.ID, "agent_id", run.AgentID, "err", err)
 			}
 		}
-		run.CostUSD = cost
 	}
 	return t
+}
+
+type agentRunUsageEstimate struct {
+	CostUSD         float64
+	PremiumRequests float64
+	Provider        string
+}
+
+func estimateAgentRunUsage(run task.AgentRun) (agentRunUsageEstimate, bool) {
+	for _, provider := range providersForRun(run) {
+		events, err := agent.ParseLogFile(run.LogFile, 0, provider)
+		if err != nil {
+			continue
+		}
+		estimate, ok := estimateUsageFromEvents(run.Model, provider, events)
+		if ok {
+			return estimate, true
+		}
+	}
+	return agentRunUsageEstimate{}, false
+}
+
+func estimateUsageFromEvents(model, provider string, events []agent.StreamEvent) (agentRunUsageEstimate, bool) {
+	var input, output, cacheCreate, cacheRead, reasoning int
+	var cost, premiumRequests float64
+	var resultSeen bool
+	for j := range events {
+		if events[j].Type != "result" {
+			continue
+		}
+		resultSeen = true
+		cost += events[j].CostUSD
+		premiumRequests += events[j].PremiumRequests
+		input += events[j].InputTokens
+		output += events[j].OutputTokens
+		cacheCreate += events[j].CacheCreationInputTokens
+		cacheRead += events[j].CacheReadInputTokens
+		reasoning += events[j].ReasoningTokens
+	}
+	if !resultSeen {
+		return agentRunUsageEstimate{}, false
+	}
+	if cost == 0 {
+		switch provider {
+		case "copilot":
+			cost = stats.EstimateCopilotCost(premiumRequests)
+		case "codex", "claude":
+			cost = stats.EstimateCostDetailed(model, input, output, cacheCreate, cacheRead, reasoning)
+		}
+	}
+	if cost == 0 && premiumRequests == 0 {
+		return agentRunUsageEstimate{}, false
+	}
+	return agentRunUsageEstimate{CostUSD: cost, PremiumRequests: premiumRequests, Provider: provider}, true
+}
+
+func providersForRun(run task.AgentRun) []string {
+	if run.Provider != "" {
+		return []string{run.Provider}
+	}
+	preferred := providerForRun(run)
+	providers := make([]string, 0, 3)
+	if preferred != "" {
+		providers = append(providers, preferred)
+	}
+	for _, provider := range []string{"codex", "copilot", "claude"} {
+		if provider != preferred {
+			providers = append(providers, provider)
+		}
+	}
+	return providers
 }
 
 func providerForRun(run task.AgentRun) string {

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/sandbox"
+	"github.com/Automaat/sybra/internal/stats"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/umbrella"
 	"github.com/Automaat/sybra/internal/workflow"
@@ -58,7 +59,75 @@ func (s *TaskService) ListTasks() ([]task.Task, error) {
 
 // GetTask returns a single task by ID.
 func (s *TaskService) GetTask(id string) (task.Task, error) {
-	return s.tasks.Get(id)
+	t, err := s.tasks.Get(id)
+	if err != nil {
+		return t, err
+	}
+	return s.withEstimatedAgentRunCosts(t), nil
+}
+
+func (s *TaskService) withEstimatedAgentRunCosts(t task.Task) task.Task {
+	if len(t.AgentRuns) == 0 {
+		return t
+	}
+	for i := range t.AgentRuns {
+		run := &t.AgentRuns[i]
+		if run.CostUSD > 0 || run.LogFile == "" {
+			continue
+		}
+		provider := providerForRun(*run)
+		events, err := agent.ParseLogFile(run.LogFile, 0, provider)
+		if err != nil {
+			if s.logger != nil {
+				s.logger.Debug("task.agent-run-cost.log-parse-skipped", "task_id", t.ID, "agent_id", run.AgentID, "log", run.LogFile, "err", err)
+			}
+			continue
+		}
+		var input, output, cacheCreate, cacheRead, reasoning int
+		var cost, premiumRequests float64
+		for j := range events {
+			if events[j].Type != "result" {
+				continue
+			}
+			cost += events[j].CostUSD
+			premiumRequests += events[j].PremiumRequests
+			input += events[j].InputTokens
+			output += events[j].OutputTokens
+			cacheCreate += events[j].CacheCreationInputTokens
+			cacheRead += events[j].CacheReadInputTokens
+			reasoning += events[j].ReasoningTokens
+		}
+		if premiumRequests > 0 {
+			run.PremiumRequests = premiumRequests
+		}
+		if cost == 0 {
+			switch provider {
+			case "copilot":
+				cost = stats.EstimateCopilotCost(premiumRequests)
+			case "codex", "claude":
+				cost = stats.EstimateCostDetailed(run.Model, input, output, cacheCreate, cacheRead, reasoning)
+			}
+		}
+		run.CostUSD = cost
+	}
+	return t
+}
+
+func providerForRun(run task.AgentRun) string {
+	if run.Provider != "" {
+		return run.Provider
+	}
+	model := run.Model
+	if i := strings.LastIndexByte(model, '/'); i >= 0 {
+		model = model[i+1:]
+	}
+	if strings.HasPrefix(model, "gpt-") || strings.HasPrefix(model, "o3") || strings.HasPrefix(model, "o4") {
+		return "codex"
+	}
+	if strings.HasPrefix(model, "claude-") || model == "sonnet" || model == "opus" || model == "haiku" {
+		return "claude"
+	}
+	return ""
 }
 
 // CreateTask creates a new task and starts a matching workflow.

--- a/internal/sybra/svc_tasks_test.go
+++ b/internal/sybra/svc_tasks_test.go
@@ -32,6 +32,7 @@ func TestTaskService_WithEstimatedAgentRunCosts(t *testing.T) {
 		AgentRuns: []task.AgentRun{
 			{AgentID: "codex", Model: "gpt-5", LogFile: codexLog},
 			{AgentID: "copilot", Provider: "copilot", LogFile: copilotLog},
+			{AgentID: "copilot-old", Model: "gpt-5", LogFile: copilotLog},
 			{AgentID: "reported", Provider: "codex", Model: "gpt-5", CostUSD: 0.42, LogFile: codexLog},
 		},
 	})
@@ -45,8 +46,56 @@ func TestTaskService_WithEstimatedAgentRunCosts(t *testing.T) {
 	if got.AgentRuns[1].PremiumRequests != 7.5 {
 		t.Fatalf("copilot premium requests = %g, want 7.5", got.AgentRuns[1].PremiumRequests)
 	}
-	if got.AgentRuns[2].CostUSD != 0.42 {
-		t.Fatalf("reported cost = %g, want 0.42", got.AgentRuns[2].CostUSD)
+	if diff := got.AgentRuns[2].CostUSD - 0.075; diff > 1e-9 || diff < -1e-9 {
+		t.Fatalf("legacy copilot cost = %g, want 0.075", got.AgentRuns[2].CostUSD)
+	}
+	if got.AgentRuns[2].PremiumRequests != 7.5 {
+		t.Fatalf("legacy copilot premium requests = %g, want 7.5", got.AgentRuns[2].PremiumRequests)
+	}
+	if got.AgentRuns[3].CostUSD != 0.42 {
+		t.Fatalf("reported cost = %g, want 0.42", got.AgentRuns[3].CostUSD)
+	}
+}
+
+func TestTaskService_GetTaskPersistsEstimatedAgentRunCosts(t *testing.T) {
+	t.Parallel()
+	svc, _ := setupTaskService(t)
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "copilot.ndjson")
+	if err := os.WriteFile(logPath, []byte(`{"type":"result","sessionId":"s1","usage":{"premiumRequests":7.5}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	created, err := svc.tasks.Create("Persist cost", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.tasks.AddRun(created.ID, task.AgentRun{
+		AgentID:   "agent-cost",
+		Model:     "gpt-5",
+		Mode:      "headless",
+		State:     "stopped",
+		StartedAt: time.Now().UTC(),
+		LogFile:   logPath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := svc.GetTask(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := got.AgentRuns[0].CostUSD - 0.075; diff > 1e-9 || diff < -1e-9 {
+		t.Fatalf("returned cost = %g, want 0.075", got.AgentRuns[0].CostUSD)
+	}
+	persisted, err := svc.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := persisted.AgentRuns[0].CostUSD - 0.075; diff > 1e-9 || diff < -1e-9 {
+		t.Fatalf("persisted cost = %g, want 0.075", persisted.AgentRuns[0].CostUSD)
+	}
+	if persisted.AgentRuns[0].Provider != "copilot" {
+		t.Fatalf("persisted provider = %q, want copilot", persisted.AgentRuns[0].Provider)
 	}
 }
 

--- a/internal/sybra/svc_tasks_test.go
+++ b/internal/sybra/svc_tasks_test.go
@@ -2,6 +2,8 @@ package sybra
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"slices"
 	"sync/atomic"
 	"testing"
@@ -12,6 +14,41 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/umbrella"
 )
+
+func TestTaskService_WithEstimatedAgentRunCosts(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	codexLog := filepath.Join(dir, "codex.ndjson")
+	if err := os.WriteFile(codexLog, []byte(`{"type":"turn.completed","usage":{"input_tokens":1000000,"cached_input_tokens":800000,"output_tokens":100000}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	copilotLog := filepath.Join(dir, "copilot.ndjson")
+	if err := os.WriteFile(copilotLog, []byte(`{"type":"result","sessionId":"s1","usage":{"premiumRequests":7.5}}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := &TaskService{}
+	got := svc.withEstimatedAgentRunCosts(task.Task{
+		AgentRuns: []task.AgentRun{
+			{AgentID: "codex", Model: "gpt-5", LogFile: codexLog},
+			{AgentID: "copilot", Provider: "copilot", LogFile: copilotLog},
+			{AgentID: "reported", Provider: "codex", Model: "gpt-5", CostUSD: 0.42, LogFile: codexLog},
+		},
+	})
+
+	if diff := got.AgentRuns[0].CostUSD - 1.35; diff > 1e-9 || diff < -1e-9 {
+		t.Fatalf("codex cost = %g, want 1.35", got.AgentRuns[0].CostUSD)
+	}
+	if diff := got.AgentRuns[1].CostUSD - 0.075; diff > 1e-9 || diff < -1e-9 {
+		t.Fatalf("copilot cost = %g, want 0.075", got.AgentRuns[1].CostUSD)
+	}
+	if got.AgentRuns[1].PremiumRequests != 7.5 {
+		t.Fatalf("copilot premium requests = %g, want 7.5", got.AgentRuns[1].PremiumRequests)
+	}
+	if got.AgentRuns[2].CostUSD != 0.42 {
+		t.Fatalf("reported cost = %g, want 0.42", got.AgentRuns[2].CostUSD)
+	}
+}
 
 func TestTaskService_CreateTask_IssueURLWaitsForEnrichment(t *testing.T) {
 	svc, _ := setupTaskService(t)

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -188,6 +188,7 @@ type AgentRun struct {
 	State           string    `yaml:"state" json:"state"`
 	StartedAt       time.Time `yaml:"started_at" json:"startedAt"`
 	CostUSD         float64   `yaml:"cost_usd,omitempty" json:"costUsd"`
+	PremiumRequests float64   `yaml:"premium_requests,omitempty" json:"premiumRequests,omitempty"`
 	Prompt          string    `yaml:"prompt,omitempty" json:"prompt,omitempty"`
 	Result          string    `yaml:"result,omitempty" json:"result"`
 	// Verdict holds the parsed decision for human-review runs ("human" or

--- a/internal/task/parser_test.go
+++ b/internal/task/parser_test.go
@@ -345,13 +345,14 @@ func TestMarshalRoundTripAgentRuns(t *testing.T) {
 		AgentMode: "headless",
 		AgentRuns: []AgentRun{
 			{
-				AgentID:   "agent-001",
-				Mode:      "headless",
-				State:     "done",
-				StartedAt: now,
-				CostUSD:   1.23,
-				Result:    "success",
-				LogFile:   "/tmp/log.txt",
+				AgentID:         "agent-001",
+				Mode:            "headless",
+				State:           "done",
+				StartedAt:       now,
+				CostUSD:         1.23,
+				PremiumRequests: 2.5,
+				Result:          "success",
+				LogFile:         "/tmp/log.txt",
 			},
 			{
 				AgentID:   "agent-002",
@@ -382,6 +383,9 @@ func TestMarshalRoundTripAgentRuns(t *testing.T) {
 	}
 	if r.CostUSD != 1.23 {
 		t.Errorf("AgentRuns[0].CostUSD = %f, want 1.23", r.CostUSD)
+	}
+	if r.PremiumRequests != 2.5 {
+		t.Errorf("AgentRuns[0].PremiumRequests = %f, want 2.5", r.PremiumRequests)
 	}
 	if r.Result != "success" {
 		t.Errorf("AgentRuns[0].Result = %q, want %q", r.Result, "success")

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -959,6 +959,9 @@ func (s *Store) UpdateRun(taskID, agentID string, updates map[string]any) error 
 		if v, ok := updates["cost_usd"].(float64); ok {
 			t.AgentRuns[i].CostUSD = v
 		}
+		if v, ok := updates["premium_requests"].(float64); ok {
+			t.AgentRuns[i].PremiumRequests = v
+		}
 		if v, ok := updates["result"].(string); ok {
 			t.AgentRuns[i].Result = v
 		}

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -647,6 +647,7 @@ func TestStoreUpdateRun(t *testing.T) {
 	err = store.UpdateRun(created.ID, "agent-upd", map[string]any{
 		"state":                    "done",
 		"cost_usd":                 0.42,
+		"premium_requests":         1.5,
 		"result":                   "success",
 		"test_outcome":             "product_bug",
 		"test_failure_fingerprint": "abc123",
@@ -668,6 +669,9 @@ func TestStoreUpdateRun(t *testing.T) {
 	}
 	if r.CostUSD != 0.42 {
 		t.Errorf("CostUSD = %f, want 0.42", r.CostUSD)
+	}
+	if r.PremiumRequests != 1.5 {
+		t.Errorf("PremiumRequests = %f, want 1.5", r.PremiumRequests)
 	}
 	if r.Result != "success" {
 		t.Errorf("Result = %q, want %q", r.Result, "success")


### PR DESCRIPTION
## Motivation

Task detail history only showed provider-reported `cost_usd`, so Codex and Copilot runs often appeared costless even though Sybra had token or AI-credit usage.

> Changelog: fix(task): show agent run costs

## Implementation information

Persist estimated USD for Codex and Copilot task agent runs. Codex uses existing token pricing; Copilot converts AI credits to overage-equivalent USD at $0.01 per credit while keeping raw premium request counts. Existing task histories with zero persisted cost are estimated from their agent logs when the task is opened.

## Supporting documentation

- `go test ./internal/stats ./internal/task ./internal/agent`
- `go test ./internal/sybra -run 'TestEstimatedRunCost|TestTaskService_WithEstimatedAgentRunCosts|TestIsRateLimitedRun|TestLastAssistantText'`\n- `cd frontend && npm run check`\n- Pre-push hook ran full Go tests and frontend check during push\n