### PR TITLE
feat(codex): use plugin list for skills

### DIFF
--- a/cmd/fake-codex/main.go
+++ b/cmd/fake-codex/main.go
@@ -32,6 +32,11 @@ func cleanEnvPath(p string) string {
 }
 
 func main() {
+	if len(os.Args) > 3 && os.Args[1] == "plugin" && os.Args[2] == "list" && os.Args[3] == "--json" {
+		fmt.Println(`{"installed":[],"available":[]}`)
+		return
+	}
+
 	if logFile := cleanEnvPath(os.Getenv("FAKE_CODEX_ARGS_LOG")); logFile != "" {
 		_ = os.WriteFile(logFile, []byte(strings.Join(os.Args[1:], "\n")), 0o644)
 	}

--- a/internal/agent/skill_invoke.go
+++ b/internal/agent/skill_invoke.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -61,7 +62,41 @@ func discoverCodexSkills() []string {
 	if err != nil {
 		return nil
 	}
-	return discoverCodexSkillsInHome(home)
+	now := time.Now()
+	codexSkillsCacheMu.Lock()
+	if home == codexSkillsCacheHome && now.Before(codexSkillsCacheExpires) {
+		out := cloneSkillNames(codexSkillsCacheNames)
+		codexSkillsCacheMu.Unlock()
+		return out
+	}
+	codexSkillsCacheMu.Unlock()
+
+	names := discoverCodexSkillsInHome(home)
+
+	codexSkillsCacheMu.Lock()
+	codexSkillsCacheHome = home
+	codexSkillsCacheNames = cloneSkillNames(names)
+	codexSkillsCacheExpires = now.Add(codexSkillsCacheTTL)
+	codexSkillsCacheMu.Unlock()
+	return names
+}
+
+const codexSkillsCacheTTL = 30 * time.Second
+
+var (
+	codexSkillsCacheMu      sync.Mutex
+	codexSkillsCacheHome    string
+	codexSkillsCacheNames   []string
+	codexSkillsCacheExpires time.Time
+)
+
+func cloneSkillNames(names []string) []string {
+	if names == nil {
+		return nil
+	}
+	out := make([]string, len(names))
+	copy(out, names)
+	return out
 }
 
 func discoverCodexSkillsInHome(home string) []string {
@@ -72,8 +107,11 @@ func discoverCodexSkillsInHome(home string) []string {
 	for _, name := range listSkillDirs(filepath.Join(home, ".claude", "skills")) {
 		seen[name] = struct{}{}
 	}
-	codexPluginSkills, fallbackPlugins, ok := listCodexPluginListSkills()
-	if !ok {
+	codexPluginSkills, fallbackPlugins, fallbackAll := listCodexPluginListSkills()
+	switch {
+	case fallbackAll:
+		codexPluginSkills = append(codexPluginSkills, listPluginSkillDirs(filepath.Join(home, ".codex", "plugins", "cache"))...)
+	case len(fallbackPlugins) > 0:
 		codexPluginSkills = append(codexPluginSkills, listPluginSkillDirsFiltered(filepath.Join(home, ".codex", "plugins", "cache"), fallbackPlugins)...)
 	}
 	for _, name := range codexPluginSkills {
@@ -93,10 +131,20 @@ func discoverCodexSkillsInHome(home string) []string {
 	return out
 }
 
-var runCodexPluginListJSON = func() ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	return exec.CommandContext(ctx, "codex", "plugin", "list", "--json").Output()
+var (
+	codexPluginListRunnerMu sync.RWMutex
+	runCodexPluginListJSON  = func() ([]byte, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return exec.CommandContext(ctx, "codex", "plugin", "list", "--json").Output()
+	}
+)
+
+func runCodexPluginListJSONSafe() ([]byte, error) {
+	codexPluginListRunnerMu.RLock()
+	runner := runCodexPluginListJSON
+	codexPluginListRunnerMu.RUnlock()
+	return runner()
 }
 
 type codexPluginList struct {
@@ -116,17 +164,16 @@ type codexPluginManifest struct {
 	Skills json.RawMessage `json:"skills"`
 }
 
-func listCodexPluginListSkills() (names, fallbackPlugins []string, ok bool) {
-	out, err := runCodexPluginListJSON()
+func listCodexPluginListSkills() (names, fallbackPlugins []string, fallbackAll bool) {
+	out, err := runCodexPluginListJSONSafe()
 	if err != nil && len(out) == 0 {
-		return nil, nil, false
+		return nil, nil, true
 	}
-	commandErr := err
 	names, fallbackPlugins, err = parseCodexPluginListSkills(out)
 	if err != nil {
-		return nil, nil, false
+		return nil, nil, true
 	}
-	return names, fallbackPlugins, commandErr == nil && len(fallbackPlugins) == 0
+	return names, fallbackPlugins, false
 }
 
 func parseCodexPluginListSkills(data []byte) (names, fallbackPlugins []string, err error) {

--- a/internal/agent/skill_invoke.go
+++ b/internal/agent/skill_invoke.go
@@ -2,11 +2,18 @@ package agent
 
 import (
 	"cmp"
+	"context"
+	"encoding/json"
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 // rewriteSkillInvocations converts Claude-style `/skill-name` invocations
@@ -40,7 +47,7 @@ func rewriteSkillInvocations(prompt string, skillNames []string) string {
 
 // discoverCodexSkills returns the union of skill names sybra knows about for
 // the codex skill rewriter. A "known" skill is one whose name shows up in
-// any of: ~/.codex/skills/, ~/.claude/skills/, ~/.codex/plugins/cache/*/*/*/skills/,
+// any of: ~/.codex/skills/, ~/.claude/skills/, `codex plugin list --json`,
 // or ~/.claude/plugins/cache/*/*/*/skills/. Pulling from both providers and
 // their plugin caches matters because /staff-code-review can be installed
 // for claude via the sai plugin marketplace but absent from ~/.codex/skills/
@@ -54,6 +61,10 @@ func discoverCodexSkills() []string {
 	if err != nil {
 		return nil
 	}
+	return discoverCodexSkillsInHome(home)
+}
+
+func discoverCodexSkillsInHome(home string) []string {
 	seen := make(map[string]struct{}, 64)
 	for _, name := range listSkillDirs(filepath.Join(home, ".codex", "skills")) {
 		seen[name] = struct{}{}
@@ -61,13 +72,15 @@ func discoverCodexSkills() []string {
 	for _, name := range listSkillDirs(filepath.Join(home, ".claude", "skills")) {
 		seen[name] = struct{}{}
 	}
-	for _, root := range []string{
-		filepath.Join(home, ".codex", "plugins", "cache"),
-		filepath.Join(home, ".claude", "plugins", "cache"),
-	} {
-		for _, name := range listPluginSkillDirs(root) {
-			seen[name] = struct{}{}
-		}
+	codexPluginSkills, fallbackPlugins, ok := listCodexPluginListSkills()
+	if !ok {
+		codexPluginSkills = append(codexPluginSkills, listPluginSkillDirsFiltered(filepath.Join(home, ".codex", "plugins", "cache"), fallbackPlugins)...)
+	}
+	for _, name := range codexPluginSkills {
+		seen[name] = struct{}{}
+	}
+	for _, name := range listPluginSkillDirs(filepath.Join(home, ".claude", "plugins", "cache")) {
+		seen[name] = struct{}{}
 	}
 	if len(seen) == 0 {
 		return nil
@@ -78,6 +91,292 @@ func discoverCodexSkills() []string {
 	}
 	slices.Sort(out)
 	return out
+}
+
+var runCodexPluginListJSON = func() ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return exec.CommandContext(ctx, "codex", "plugin", "list", "--json").Output()
+}
+
+type codexPluginList struct {
+	Installed []codexPlugin `json:"installed"`
+}
+
+type codexPlugin struct {
+	Name            string `json:"name"`
+	MarketplaceName string `json:"marketplaceName"`
+	Enabled         *bool  `json:"enabled"`
+	Source          struct {
+		Path string `json:"path"`
+	} `json:"source"`
+}
+
+type codexPluginManifest struct {
+	Skills json.RawMessage `json:"skills"`
+}
+
+func listCodexPluginListSkills() (names, fallbackPlugins []string, ok bool) {
+	out, err := runCodexPluginListJSON()
+	if err != nil && len(out) == 0 {
+		return nil, nil, false
+	}
+	commandErr := err
+	names, fallbackPlugins, err = parseCodexPluginListSkills(out)
+	if err != nil {
+		return nil, nil, false
+	}
+	return names, fallbackPlugins, commandErr == nil && len(fallbackPlugins) == 0
+}
+
+func parseCodexPluginListSkills(data []byte) (names, fallbackPlugins []string, err error) {
+	var plugins codexPluginList
+	if err := json.Unmarshal(data, &plugins); err != nil {
+		return nil, nil, err
+	}
+	seen := map[string]struct{}{}
+	for _, plugin := range plugins.Installed {
+		if plugin.Enabled != nil && !*plugin.Enabled {
+			continue
+		}
+		if plugin.Source.Path == "" {
+			fallbackPlugins = append(fallbackPlugins, codexPluginCacheKey(plugin))
+			continue
+		}
+		names, ok := listCodexPluginSourceSkills(plugin.Source.Path)
+		for _, name := range names {
+			seen[name] = struct{}{}
+		}
+		if !ok {
+			fallbackPlugins = append(fallbackPlugins, codexPluginCacheKey(plugin))
+			continue
+		}
+	}
+	if len(seen) == 0 {
+		return []string{}, fallbackPlugins, nil
+	}
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+	slices.Sort(out)
+	return out, fallbackPlugins, nil
+}
+
+func codexPluginCacheKey(plugin codexPlugin) string {
+	if plugin.Name == "" {
+		return ""
+	}
+	if plugin.MarketplaceName == "" {
+		return plugin.Name
+	}
+	return plugin.MarketplaceName + "/" + plugin.Name
+}
+
+func listCodexPluginSourceSkills(pluginRoot string) (names []string, ok bool) {
+	if _, err := os.Stat(pluginRoot); err != nil {
+		return nil, false
+	}
+	seen := map[string]struct{}{}
+	needsFallback := false
+	sawManifest := false
+	addSkillNames(seen, filepath.Join(pluginRoot, "skills"))
+	for _, manifestPath := range []string{
+		filepath.Join(pluginRoot, ".codex-plugin", "plugin.json"),
+		filepath.Join(pluginRoot, ".claude-plugin", "plugin.json"),
+		filepath.Join(pluginRoot, "plugin.json"),
+	} {
+		if _, err := os.Stat(manifestPath); err == nil {
+			sawManifest = true
+		}
+		skillPathCandidates, ok := codexPluginManifestSkillPaths(pluginRoot, manifestPath)
+		if !ok {
+			needsFallback = true
+			continue
+		}
+		for _, candidates := range skillPathCandidates {
+			found := 0
+			for _, skillPath := range candidates {
+				found += addSkillNames(seen, skillPath)
+			}
+			if len(candidates) > 0 && found == 0 {
+				needsFallback = true
+			}
+		}
+	}
+	if len(seen) == 0 {
+		return nil, sawManifest && !needsFallback
+	}
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+	return out, !needsFallback
+}
+
+func codexPluginManifestSkillPaths(pluginRoot, manifestPath string) ([][]string, bool) {
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, os.IsNotExist(err)
+	}
+	paths, err := parseCodexPluginManifestSkillPaths(data)
+	if err != nil {
+		return nil, false
+	}
+	out := make([][]string, 0, len(paths))
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		candidates := safeCodexManifestSkillPathCandidates(pluginRoot, manifestPath, p)
+		if len(candidates) == 0 {
+			return nil, false
+		}
+		out = append(out, candidates)
+	}
+	return out, true
+}
+
+func safeCodexManifestSkillPathCandidates(pluginRoot, manifestPath, skillPath string) []string {
+	allowedRoots := []string{
+		filepath.Clean(pluginRoot),
+	}
+	if filepath.Base(filepath.Dir(pluginRoot)) == "plugins" {
+		allowedRoots = append(allowedRoots, filepath.Clean(filepath.Dir(filepath.Dir(pluginRoot))))
+	}
+	if filepath.IsAbs(skillPath) {
+		clean := filepath.Clean(skillPath)
+		if pathInsideAny(clean, allowedRoots) {
+			return []string{clean}
+		}
+		return nil
+	}
+	candidates := []string{filepath.Clean(filepath.Join(pluginRoot, skillPath))}
+	manifestRelative := filepath.Clean(filepath.Join(filepath.Dir(manifestPath), skillPath))
+	if manifestRelative != candidates[0] {
+		candidates = append(candidates, manifestRelative)
+	}
+	out := candidates[:0]
+	for _, candidate := range candidates {
+		if pathInsideAny(candidate, allowedRoots) {
+			out = append(out, candidate)
+		}
+	}
+	return out
+}
+
+func pathInsideAny(path string, roots []string) bool {
+	for _, root := range roots {
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			continue
+		}
+		if rel == "." || (!strings.HasPrefix(rel, ".."+string(filepath.Separator)) && rel != ".." && !filepath.IsAbs(rel)) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseCodexPluginManifestSkillPaths(data []byte) ([]string, error) {
+	var manifest codexPluginManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, err
+	}
+	if len(manifest.Skills) == 0 || string(manifest.Skills) == "null" {
+		return nil, nil
+	}
+	var skillPath string
+	if err := json.Unmarshal(manifest.Skills, &skillPath); err == nil {
+		if skillPath == "" {
+			return nil, nil
+		}
+		return []string{skillPath}, nil
+	}
+	var skillPaths []string
+	if err := json.Unmarshal(manifest.Skills, &skillPaths); err == nil {
+		return skillPaths, nil
+	}
+	return nil, errors.New("unsupported codex plugin skills value")
+}
+
+func addSkillNames(seen map[string]struct{}, root string) int {
+	found := 0
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			if path == root {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			if path != root && strings.HasPrefix(d.Name(), ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Name() != "SKILL.md" {
+			return nil
+		}
+		skillDir := filepath.Dir(path)
+		name := skillNameFromSkillMD(path)
+		if !validSkillName(name) {
+			name = filepath.Base(skillDir)
+		}
+		if validSkillName(name) {
+			found++
+			if _, ok := seen[name]; !ok {
+				seen[name] = struct{}{}
+			}
+		}
+		return nil
+	})
+	return found
+}
+
+func validSkillName(name string) bool {
+	if name == "" || name == "." || strings.HasPrefix(name, ".") {
+		return false
+	}
+	return !strings.ContainsAny(name, "/\\ \t\r\n")
+}
+
+type skillFrontmatter struct {
+	Name string `yaml:"name"`
+}
+
+func skillNameFromSkillMD(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	frontmatter := skillFrontmatterBlock(data)
+	if len(frontmatter) == 0 {
+		return ""
+	}
+	var meta skillFrontmatter
+	if err := yaml.Unmarshal(frontmatter, &meta); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(meta.Name)
+}
+
+func skillFrontmatterBlock(data []byte) []byte {
+	text := strings.TrimLeft(string(data), " \t\r\n\ufeff")
+	var rest string
+	switch {
+	case strings.HasPrefix(text, "---\n"):
+		rest = text[len("---\n"):]
+	case strings.HasPrefix(text, "---\r\n"):
+		rest = text[len("---\r\n"):]
+	default:
+		return nil
+	}
+	frontmatter, _, ok := strings.Cut(rest, "\n---")
+	if !ok {
+		return nil
+	}
+	return []byte(frontmatter)
 }
 
 func listSkillDirs(root string) []string {
@@ -98,13 +397,28 @@ func listSkillDirs(root string) []string {
 	return names
 }
 
-// listPluginSkillDirs walks the plugin-cache layout used by both claude and
-// codex: <root>/<marketplace>/<plugin>/<version>/skills/<skill-name>/SKILL.md.
+// listPluginSkillDirs walks the plugin-cache layout used by claude and older
+// codex versions: <root>/<marketplace>/<plugin>/<version>/.
 // Returns every skill-name with a SKILL.md, deduping across versions.
 func listPluginSkillDirs(root string) []string {
+	return listPluginSkillDirsFiltered(root, nil)
+}
+
+func listPluginSkillDirsFiltered(root string, pluginNames []string) []string {
 	marketplaces, err := os.ReadDir(root)
 	if err != nil {
 		return nil
+	}
+	var pluginFilter map[string]struct{}
+	if len(pluginNames) > 0 {
+		pluginFilter = map[string]struct{}{}
+		for _, name := range pluginNames {
+			if name == "" {
+				pluginFilter = nil
+				break
+			}
+			pluginFilter[name] = struct{}{}
+		}
 	}
 	seen := map[string]struct{}{}
 	for _, mp := range marketplaces {
@@ -119,6 +433,13 @@ func listPluginSkillDirs(root string) []string {
 			if !pl.IsDir() || strings.HasPrefix(pl.Name(), ".") {
 				continue
 			}
+			if pluginFilter != nil {
+				_, byName := pluginFilter[pl.Name()]
+				_, byMarketplaceName := pluginFilter[mp.Name()+"/"+pl.Name()]
+				if !byName && !byMarketplaceName {
+					continue
+				}
+			}
 			versions, err := os.ReadDir(filepath.Join(root, mp.Name(), pl.Name()))
 			if err != nil {
 				continue
@@ -127,8 +448,12 @@ func listPluginSkillDirs(root string) []string {
 				if !ver.IsDir() || strings.HasPrefix(ver.Name(), ".") {
 					continue
 				}
-				skillsDir := filepath.Join(root, mp.Name(), pl.Name(), ver.Name(), "skills")
-				for _, name := range listSkillDirs(skillsDir) {
+				versionDir := filepath.Join(root, mp.Name(), pl.Name(), ver.Name())
+				names, _ := listCodexPluginSourceSkills(versionDir)
+				if len(names) == 0 {
+					names = listSkillDirs(filepath.Join(versionDir, "skills"))
+				}
+				for _, name := range names {
 					seen[name] = struct{}{}
 				}
 			}

--- a/internal/agent/skill_invoke_test.go
+++ b/internal/agent/skill_invoke_test.go
@@ -272,7 +272,7 @@ func TestDiscoverCodexSkillsKeepsStdoutFromNonzeroPluginList(t *testing.T) {
 	withCodexPluginListOutput(t, codexPluginListPayload(t, pluginRoot, true), errors.New("codex plugin list exited nonzero"))
 
 	got := discoverCodexSkillsInHome(home)
-	want := []string{"new-skill", "staff-code-review"}
+	want := []string{"new-skill"}
 	if !slices.Equal(got, want) {
 		t.Fatalf("got %v, want %v", got, want)
 	}
@@ -600,23 +600,41 @@ func writePluginManifestJSON(t *testing.T, path string, data []byte) {
 
 func withCodexPluginListJSON(t *testing.T, data []byte) {
 	t.Helper()
+	codexPluginListRunnerMu.Lock()
 	orig := runCodexPluginListJSON
 	runCodexPluginListJSON = func() ([]byte, error) { return data, nil }
-	t.Cleanup(func() { runCodexPluginListJSON = orig })
+	codexPluginListRunnerMu.Unlock()
+	t.Cleanup(func() {
+		codexPluginListRunnerMu.Lock()
+		runCodexPluginListJSON = orig
+		codexPluginListRunnerMu.Unlock()
+	})
 }
 
 func withCodexPluginListError(t *testing.T, err error) {
 	t.Helper()
+	codexPluginListRunnerMu.Lock()
 	orig := runCodexPluginListJSON
 	runCodexPluginListJSON = func() ([]byte, error) { return nil, err }
-	t.Cleanup(func() { runCodexPluginListJSON = orig })
+	codexPluginListRunnerMu.Unlock()
+	t.Cleanup(func() {
+		codexPluginListRunnerMu.Lock()
+		runCodexPluginListJSON = orig
+		codexPluginListRunnerMu.Unlock()
+	})
 }
 
 func withCodexPluginListOutput(t *testing.T, data []byte, err error) {
 	t.Helper()
+	codexPluginListRunnerMu.Lock()
 	orig := runCodexPluginListJSON
 	runCodexPluginListJSON = func() ([]byte, error) { return data, err }
-	t.Cleanup(func() { runCodexPluginListJSON = orig })
+	codexPluginListRunnerMu.Unlock()
+	t.Cleanup(func() {
+		codexPluginListRunnerMu.Lock()
+		runCodexPluginListJSON = orig
+		codexPluginListRunnerMu.Unlock()
+	})
 }
 
 func codexPluginListPayload(t *testing.T, pluginRoot string, enabled bool) []byte {

--- a/internal/agent/skill_invoke_test.go
+++ b/internal/agent/skill_invoke_test.go
@@ -1,8 +1,11 @@
 package agent
 
 import (
+	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -158,6 +161,377 @@ func TestListPluginSkillDirs(t *testing.T) {
 	}
 }
 
+func TestDiscoverCodexSkillsUsesPluginListAndSkipsCodexCache(t *testing.T) {
+	home := t.TempDir()
+	mkLocalSkill(t, filepath.Join(home, ".codex", "skills"), "codex-direct")
+	mkLocalSkill(t, filepath.Join(home, ".claude", "skills"), "claude-direct")
+	mkSkill(t, filepath.Join(home, ".codex", "plugins", "cache"), "sai", "stale", "1.0.0", "stale-codex-cache")
+	mkSkill(t, filepath.Join(home, ".claude", "plugins", "cache"), "sai", "council", "1.0.0", "claude-plugin")
+
+	pluginRoot := filepath.Join(home, "marketplaces", "sai", "plugins", "plugin-json")
+	skillRoot := filepath.Clean(filepath.Join(pluginRoot, "../../codex/plugin-json"))
+	mkSkillRoot(t, skillRoot)
+	writePluginManifest(t, filepath.Join(pluginRoot, ".codex-plugin", "plugin.json"), "../../codex/plugin-json")
+	withCodexPluginListJSON(t, codexPluginListPayload(t, pluginRoot, true))
+
+	got := discoverCodexSkillsInHome(home)
+	want := []string{"claude-direct", "claude-plugin", "codex-direct", "plugin-json"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestListCodexPluginSourceSkillsRejectsInvalidFrontmatterName(t *testing.T) {
+	pluginRoot := t.TempDir()
+	singleSkillRoot := filepath.Join(pluginRoot, "opaque-dir")
+	mkNamedSkillRoot(t, singleSkillRoot, "tmp/secret", "\n")
+	writePluginManifest(t, filepath.Join(pluginRoot, ".codex-plugin", "plugin.json"), "opaque-dir")
+
+	got, ok := listCodexPluginSourceSkills(pluginRoot)
+	if !ok {
+		t.Fatal("listCodexPluginSourceSkills returned ok=false")
+	}
+	want := []string{"opaque-dir"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestListCodexPluginSourceSkillsRejectsSpacedFrontmatterName(t *testing.T) {
+	pluginRoot := t.TempDir()
+	singleSkillRoot := filepath.Join(pluginRoot, "staff-code-review")
+	mkNamedSkillRoot(t, singleSkillRoot, "Staff Code Review", "\n")
+	writePluginManifest(t, filepath.Join(pluginRoot, ".codex-plugin", "plugin.json"), "staff-code-review")
+
+	got, ok := listCodexPluginSourceSkills(pluginRoot)
+	if !ok {
+		t.Fatal("listCodexPluginSourceSkills returned ok=false")
+	}
+	want := []string{"staff-code-review"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestDiscoverCodexSkillsFallsBackToCodexCache(t *testing.T) {
+	home := t.TempDir()
+	mkSkill(t, filepath.Join(home, ".codex", "plugins", "cache"), "sai", "staff-code-review", "1.0.0", "staff-code-review")
+	withCodexPluginListError(t, errors.New("codex plugin list unavailable"))
+
+	got := discoverCodexSkillsInHome(home)
+	want := []string{"staff-code-review"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestListCodexPluginSourceSkills(t *testing.T) {
+	pluginRoot := filepath.Join(t.TempDir(), "marketplaces", "sai", "plugins", "plugin")
+	mkLocalSkill(t, filepath.Join(pluginRoot, "skills"), "direct-skill")
+	mkLocalSkill(t, filepath.Join(pluginRoot, "copilot-skills", "nested"), "recursive-skill")
+	writePluginManifest(t, filepath.Join(pluginRoot, "plugin.json"), "copilot-skills/")
+	singleSkillRoot := filepath.Clean(filepath.Join(pluginRoot, "../../codex/opaque-dir"))
+	mkNamedSkillRoot(t, singleSkillRoot, "single-skill", "\n")
+	writePluginManifest(t, filepath.Join(pluginRoot, ".codex-plugin", "plugin.json"), "../../codex/opaque-dir")
+	claudePluginSkillRoot := filepath.Join(pluginRoot, "claude-skills", "claude-plugin-skill")
+	mkSkillRoot(t, claudePluginSkillRoot)
+	writePluginManifest(t, filepath.Join(pluginRoot, ".claude-plugin", "plugin.json"), "claude-skills/")
+
+	got, ok := listCodexPluginSourceSkills(pluginRoot)
+	if !ok {
+		t.Fatal("listCodexPluginSourceSkills returned ok=false")
+	}
+	want := []string{"claude-plugin-skill", "direct-skill", "recursive-skill", "single-skill"}
+	slices.Sort(got)
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestListCodexPluginSourceSkillsReadsCRLFFrontmatter(t *testing.T) {
+	pluginRoot := t.TempDir()
+	singleSkillRoot := filepath.Join(pluginRoot, "opaque-dir")
+	mkNamedSkillRoot(t, singleSkillRoot, "single-skill", "\r\n")
+	writePluginManifest(t, filepath.Join(pluginRoot, ".codex-plugin", "plugin.json"), "opaque-dir")
+
+	got, ok := listCodexPluginSourceSkills(pluginRoot)
+	if !ok {
+		t.Fatal("listCodexPluginSourceSkills returned ok=false")
+	}
+	want := []string{"single-skill"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestDiscoverCodexSkillsKeepsStdoutFromNonzeroPluginList(t *testing.T) {
+	home := t.TempDir()
+	mkSkill(t, filepath.Join(home, ".codex", "plugins", "cache"), "sai", "staff-code-review", "1.0.0", "staff-code-review")
+	pluginRoot := filepath.Join(home, "plugin")
+	mkLocalSkill(t, filepath.Join(pluginRoot, "skills"), "new-skill")
+	withCodexPluginListOutput(t, codexPluginListPayload(t, pluginRoot, true), errors.New("codex plugin list exited nonzero"))
+
+	got := discoverCodexSkillsInHome(home)
+	want := []string{"new-skill", "staff-code-review"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestDiscoverCodexSkillsFallsBackOnMalformedManifest(t *testing.T) {
+	home := t.TempDir()
+	mkSkill(t, filepath.Join(home, ".codex", "plugins", "cache"), "sai", "staff-code-review", "1.0.0", "staff-code-review")
+	goodPluginRoot := filepath.Join(home, "good-plugin")
+	mkLocalSkill(t, filepath.Join(goodPluginRoot, "skills"), "good-skill")
+	pluginRoot := filepath.Join(home, "broken-plugin")
+	if err := os.MkdirAll(filepath.Join(pluginRoot, ".codex-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginRoot, ".codex-plugin", "plugin.json"), []byte("{"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	withCodexPluginListJSON(t, codexPluginListPayloadForRoots(t, true, goodPluginRoot, pluginRoot))
+
+	got := discoverCodexSkillsInHome(home)
+	want := []string{"good-skill", "staff-code-review"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestDiscoverCodexSkillsFallsBackOnUnsupportedManifestSkills(t *testing.T) {
+	home := t.TempDir()
+	mkSkill(t, filepath.Join(home, ".codex", "plugins", "cache"), "sai", "staff-code-review", "1.0.0", "staff-code-review")
+	pluginRoot := filepath.Join(home, "unsupported-plugin")
+	mkLocalSkill(t, filepath.Join(pluginRoot, "skills"), "direct-skill")
+	if err := os.MkdirAll(filepath.Join(pluginRoot, ".codex-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginRoot, ".codex-plugin", "plugin.json"), []byte(`{"skills":{"path":"skills"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	withCodexPluginListJSON(t, codexPluginListPayload(t, pluginRoot, true))
+
+	got := discoverCodexSkillsInHome(home)
+	want := []string{"direct-skill", "staff-code-review"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestDiscoverCodexSkillsFallsBackOnMissingPluginSourcePath(t *testing.T) {
+	home := t.TempDir()
+	mkSkill(t, filepath.Join(home, ".codex", "plugins", "cache"), "sai", "staff-code-review", "1.0.0", "staff-code-review")
+	payload := struct {
+		Installed []codexPlugin `json:"installed"`
+	}{
+		Installed: []codexPlugin{{}},
+	}
+	enabled := true
+	payload.Installed[0].Enabled = &enabled
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withCodexPluginListJSON(t, data)
+
+	got := discoverCodexSkillsInHome(home)
+	want := []string{"staff-code-review"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestDiscoverCodexSkillsFallsBackOnStalePluginSourcePath(t *testing.T) {
+	home := t.TempDir()
+	mkSkill(t, filepath.Join(home, ".codex", "plugins", "cache"), "sai", "staff-code-review", "1.0.0", "staff-code-review")
+	withCodexPluginListJSON(t, codexPluginListPayload(t, filepath.Join(home, "deleted-plugin"), true))
+
+	got := discoverCodexSkillsInHome(home)
+	want := []string{"staff-code-review"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestDiscoverCodexSkillsFallsBackOnEmptyPluginSourcePath(t *testing.T) {
+	home := t.TempDir()
+	mkSkill(t, filepath.Join(home, ".codex", "plugins", "cache"), "sai", "staff-code-review", "1.0.0", "staff-code-review")
+	emptyPluginRoot := filepath.Join(home, "empty-plugin")
+	if err := os.MkdirAll(emptyPluginRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	withCodexPluginListJSON(t, codexPluginListPayload(t, emptyPluginRoot, true))
+
+	got := discoverCodexSkillsInHome(home)
+	want := []string{"staff-code-review"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestDiscoverCodexSkillsDoesNotFallbackForNoSkillManifest(t *testing.T) {
+	home := t.TempDir()
+	mkSkill(t, filepath.Join(home, ".codex", "plugins", "cache"), "sai", "old-skill", "1.0.0", "old-skill")
+	pluginRoot := filepath.Join(home, "command-only-plugin")
+	writePluginManifestJSON(t, filepath.Join(pluginRoot, ".codex-plugin", "plugin.json"), []byte(`{"name":"command-only"}`))
+	withCodexPluginListJSON(t, codexPluginListPayload(t, pluginRoot, true))
+
+	got := discoverCodexSkillsInHome(home)
+	if got != nil {
+		t.Fatalf("got %v, want nil", got)
+	}
+}
+
+func TestDiscoverCodexSkillsRejectsUnsafeManifestPath(t *testing.T) {
+	home := t.TempDir()
+	mkSkill(t, filepath.Join(home, ".codex", "plugins", "cache"), "sai", "staff-code-review", "1.0.0", "staff-code-review")
+	pluginRoot := filepath.Join(home, "plugin")
+	writePluginManifest(t, filepath.Join(pluginRoot, ".codex-plugin", "plugin.json"), "/")
+	withCodexPluginListJSON(t, codexPluginListPayload(t, pluginRoot, true))
+
+	got := discoverCodexSkillsInHome(home)
+	want := []string{"staff-code-review"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestDiscoverCodexSkillsRejectsUnsafeAbsolutePeerPath(t *testing.T) {
+	home := t.TempDir()
+	pluginRoot := filepath.Join(home, "plugin")
+	otherRoot := filepath.Join(home, "other")
+	mkLocalSkill(t, otherRoot, "evil")
+	writePluginManifest(t, filepath.Join(pluginRoot, ".codex-plugin", "plugin.json"), otherRoot)
+	withCodexPluginListJSON(t, codexPluginListPayload(t, pluginRoot, true))
+
+	got := discoverCodexSkillsInHome(home)
+	if got != nil {
+		t.Fatalf("got %v, want nil", got)
+	}
+}
+
+func TestDiscoverCodexSkillsFallsBackOnStaleManifestTarget(t *testing.T) {
+	home := t.TempDir()
+	mkSkill(t, filepath.Join(home, ".codex", "plugins", "cache"), "sai", "staff-code-review", "1.0.0", "staff-code-review")
+	pluginRoot := filepath.Join(home, "plugin")
+	writePluginManifest(t, filepath.Join(pluginRoot, ".codex-plugin", "plugin.json"), "../../codex/deleted-skill")
+	withCodexPluginListJSON(t, codexPluginListPayload(t, pluginRoot, true))
+
+	got := discoverCodexSkillsInHome(home)
+	want := []string{"staff-code-review"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestDiscoverCodexSkillsDoesNotFallbackForDuplicateManifestSkill(t *testing.T) {
+	home := t.TempDir()
+	mkSkill(t, filepath.Join(home, ".codex", "plugins", "cache"), "sai", "old-skill", "1.0.0", "old-skill")
+	pluginRoot := filepath.Join(home, "plugin")
+	mkLocalSkill(t, filepath.Join(pluginRoot, "skills"), "current-skill")
+	writePluginManifest(t, filepath.Join(pluginRoot, ".codex-plugin", "plugin.json"), "skills")
+	withCodexPluginListJSON(t, codexPluginListPayload(t, pluginRoot, true))
+
+	got := discoverCodexSkillsInHome(home)
+	want := []string{"current-skill"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestDiscoverCodexSkillsFallsBackForMissingManifestArrayEntry(t *testing.T) {
+	home := t.TempDir()
+	mkSkill(t, filepath.Join(home, ".codex", "plugins", "cache"), "sai", "missing-skill", "1.0.0", "missing-skill")
+	pluginRoot := filepath.Join(home, "plugin")
+	mkLocalSkill(t, filepath.Join(pluginRoot, "skills-a"), "current-skill")
+	writePluginManifestJSON(t, filepath.Join(pluginRoot, ".codex-plugin", "plugin.json"), []byte(`{"skills":["skills-a","skills-b"]}`))
+	withCodexPluginListJSON(t, codexPluginListPayload(t, pluginRoot, true))
+
+	got := discoverCodexSkillsInHome(home)
+	want := []string{"current-skill", "missing-skill"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestDiscoverCodexSkillsScopesFallbackToFailedPlugins(t *testing.T) {
+	home := t.TempDir()
+	mkSkill(t, filepath.Join(home, ".codex", "plugins", "cache"), "sai", "old-skill", "1.0.0", "old-skill")
+	mkSkill(t, filepath.Join(home, ".codex", "plugins", "cache"), "sai", "missing-plugin", "1.0.0", "missing-plugin")
+	mkSkill(t, filepath.Join(home, ".codex", "plugins", "cache"), "other", "missing-plugin", "1.0.0", "wrong-marketplace-skill")
+	noSkillPluginRoot := filepath.Join(home, "old-skill")
+	writePluginManifestJSON(t, filepath.Join(noSkillPluginRoot, ".codex-plugin", "plugin.json"), []byte(`{"name":"old-skill"}`))
+	missingPluginRoot := filepath.Join(home, "deleted-plugin")
+	payload := struct {
+		Installed []codexPlugin `json:"installed"`
+	}{
+		Installed: []codexPlugin{
+			codexPluginWithNamedSource("old-skill", noSkillPluginRoot, true),
+			codexPluginWithNamedSource("missing-plugin", missingPluginRoot, true),
+		},
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withCodexPluginListJSON(t, data)
+
+	got := discoverCodexSkillsInHome(home)
+	want := []string{"missing-plugin"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestParseCodexPluginListSkills(t *testing.T) {
+	enabledRoot := filepath.Join(t.TempDir(), "enabled")
+	disabledRoot := filepath.Join(t.TempDir(), "disabled")
+	mkLocalSkill(t, filepath.Join(enabledRoot, "skills"), "enabled-skill")
+	mkLocalSkill(t, filepath.Join(disabledRoot, "skills"), "disabled-skill")
+
+	var enabled = true
+	var disabled = false
+	payload := struct {
+		Installed []codexPlugin `json:"installed"`
+	}{
+		Installed: []codexPlugin{
+			codexPluginWithSource(enabledRoot, &enabled),
+			codexPluginWithSource(disabledRoot, &disabled),
+			codexPluginWithSource("", &disabled),
+		},
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, fallbackPlugins, err := parseCodexPluginListSkills(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fallbackPlugins) > 0 {
+		t.Fatalf("parseCodexPluginListSkills returned fallbackPlugins=%v", fallbackPlugins)
+	}
+	want := []string{"enabled-skill"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestListPluginSkillDirsReadsPluginManifestLayouts(t *testing.T) {
+	root := t.TempDir()
+	versionDir := filepath.Join(root, "sai", "staff-code-review", "0.1.0")
+	mkLocalSkill(t, filepath.Join(versionDir, "copilot-skills"), "staff-code-review")
+	writePluginManifest(t, filepath.Join(versionDir, "plugin.json"), "copilot-skills/")
+
+	got := listPluginSkillDirs(root)
+	want := []string{"staff-code-review"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
 func TestListPluginSkillDirsMissingRoot(t *testing.T) {
 	t.Parallel()
 	if got := listPluginSkillDirs("/nonexistent/plugins/cache"); got != nil {
@@ -174,4 +548,112 @@ func mkSkill(t *testing.T, root, marketplace, plugin, version, skill string) {
 	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func mkLocalSkill(t *testing.T, root, skill string) {
+	t.Helper()
+	skillDir := filepath.Join(root, skill)
+	mkSkillRoot(t, skillDir)
+}
+
+func mkSkillRoot(t *testing.T, skillDir string) {
+	t.Helper()
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mkNamedSkillRoot(t *testing.T, skillDir, name, newline string) {
+	t.Helper()
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data := []byte("---" + newline + "name: " + name + newline + "---" + newline)
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writePluginManifest(t *testing.T, path, skills string) {
+	t.Helper()
+	data, err := json.Marshal(struct {
+		Skills string `json:"skills"`
+	}{Skills: skills})
+	if err != nil {
+		t.Fatal(err)
+	}
+	writePluginManifestJSON(t, path, data)
+}
+
+func writePluginManifestJSON(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func withCodexPluginListJSON(t *testing.T, data []byte) {
+	t.Helper()
+	orig := runCodexPluginListJSON
+	runCodexPluginListJSON = func() ([]byte, error) { return data, nil }
+	t.Cleanup(func() { runCodexPluginListJSON = orig })
+}
+
+func withCodexPluginListError(t *testing.T, err error) {
+	t.Helper()
+	orig := runCodexPluginListJSON
+	runCodexPluginListJSON = func() ([]byte, error) { return nil, err }
+	t.Cleanup(func() { runCodexPluginListJSON = orig })
+}
+
+func withCodexPluginListOutput(t *testing.T, data []byte, err error) {
+	t.Helper()
+	orig := runCodexPluginListJSON
+	runCodexPluginListJSON = func() ([]byte, error) { return data, err }
+	t.Cleanup(func() { runCodexPluginListJSON = orig })
+}
+
+func codexPluginListPayload(t *testing.T, pluginRoot string, enabled bool) []byte {
+	t.Helper()
+	return codexPluginListPayloadForRoots(t, enabled, pluginRoot)
+}
+
+func codexPluginListPayloadForRoots(t *testing.T, enabled bool, pluginRoots ...string) []byte {
+	t.Helper()
+	plugins := make([]codexPlugin, 0, len(pluginRoots))
+	for _, pluginRoot := range pluginRoots {
+		plugins = append(plugins, codexPluginWithSource(pluginRoot, &enabled))
+	}
+	payload := struct {
+		Installed []codexPlugin `json:"installed"`
+	}{
+		Installed: plugins,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+func codexPluginWithSource(path string, enabled *bool) codexPlugin {
+	var plugin codexPlugin
+	plugin.Enabled = enabled
+	plugin.Source.Path = path
+	return plugin
+}
+
+func codexPluginWithNamedSource(name, path string, enabled bool) codexPlugin {
+	var plugin codexPlugin
+	plugin.Name = name
+	plugin.MarketplaceName = "sai"
+	plugin.Enabled = &enabled
+	plugin.Source.Path = path
+	return plugin
 }


### PR DESCRIPTION
## Motivation

Codex now exposes installed plugin metadata through `codex plugin list --json`, so Sybra should not depend on fragile cache glob layouts for Codex plugin skill discovery. Closes #1034.

> Changelog: feat(codex): use plugin list for skills

## Implementation information

- Discover Codex plugin skills from `codex plugin list --json` and plugin manifests.
- Preserve direct `~/.codex/skills`, `~/.claude/skills`, and Claude plugin-cache discovery.
- Fall back to the legacy Codex cache only for failed, malformed, or stale plugin-list entries, scoped by plugin/marketplace.
- Cover manifest paths, nested skill roots, CRLF frontmatter, invalid names, stale sources, and unsafe path handling.

## Supporting documentation

- `go test ./internal/agent`
- `golangci-lint run ./internal/agent`
- Pre-push suite passed with clean Git config environment.