### PR TITLE
fix(workflow): preserve pr-fix escalations

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -670,6 +670,12 @@ export enum StepType {
     StepVerifyChecks = "verify_checks",
 
     /**
+     * StepRoutePRFixResult inspects the completed pr-fix agent output before
+     * mechanical PR relinking can overwrite a human-required escalation.
+     */
+    StepRoutePRFixResult = "route_pr_fix_result",
+
+    /**
      * StepRouteTestResult reads the test-runner verdict and routes the task:
      * pass → ready-pr, fail → in-progress (re-implement) until the attempt
      * cap is hit, then human-required.

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -15,6 +15,11 @@ import (
 
 const wtFailureLimit = 5
 
+const prFixResultContract = "\n\nBefore your final response, decide the outcome:\n" +
+	"- If you completed and pushed the fix, end with `SYBRA_PR_FIX_RESULT: continue`.\n" +
+	"- If you intentionally stopped because the PR needs a human, end with " +
+	"`SYBRA_PR_FIX_RESULT: human-required` and `SYBRA_PR_FIX_REASON: <short reason>`."
+
 // readyForCopilotAutoMerge reports whether a pet PR satisfies the auto-merge
 // policy: mechanically mergeable, CI green (or no checks), GitHub Copilot has
 // submitted a review, no unresolved review threads, and no outstanding change
@@ -184,7 +189,7 @@ func (r *ReviewHandler) handlePRIssue(issue github.PRIssue) {
 
 	// Dispatch pr.event through the engine so trigger conditions in the
 	// workflow YAML stay authoritative. StartWorkflow would bypass them.
-	fullPrompt := fmt.Sprintf("# Task: %s\n\n%s", t.Title, prompt)
+	fullPrompt := fmt.Sprintf("# Task: %s\n\n%s%s", t.Title, prompt, prFixResultContract)
 	vars := map[string]string{
 		"prompt":                fullPrompt,
 		"pr_issue_kind":         string(issue.Kind),

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -303,14 +303,19 @@ func conflictPrompt(pr github.PullRequest) string {
 		filesCtx = sb.String()
 	}
 
+	return buildConflictPrompt(pr, filesCtx)
+}
+
+func buildConflictPrompt(pr github.PullRequest, filesCtx string) string {
 	return fmt.Sprintf(
 		"Fix merge conflicts on branch `%s` (PR #%d). "+
-			"Do NOT investigate git state — go straight to rebasing.\n\n"+
+			"Use the task body, PR diff, changed-file list, and current code as context, then rebase.\n\n"+
 			"Steps:\n"+
 			"```bash\n"+
 			"git fetch origin\n"+
 			"git rebase refs/remotes/origin/main\n"+
-			"# resolve each conflict, git add, git rebase --continue\n"+
+			"# resolve every conflict preserving the PR intent and upstream changes\n"+
+			"# run targeted tests for touched code, then git add and git rebase --continue\n"+
 			"PUSH_REMOTE=origin\n"+
 			"if git config --get remote.fork.url >/dev/null; then PUSH_REMOTE=fork; fi\n"+
 			"git push --force-with-lease \"$PUSH_REMOTE\" HEAD:%s\n"+
@@ -319,7 +324,8 @@ func conflictPrompt(pr github.PullRequest) string {
 			"- Use `refs/remotes/origin/main` (not `origin/main`) to avoid ambiguous refs\n"+
 			"- Push to `fork` (not `origin`) when a `fork` remote exists — the PR was opened from the fork\n"+
 			"- Resolve conflicts keeping BOTH sides' intent\n"+
-			"- If rebase produces more than 3 conflicting files, run `git rebase --abort` and stop — the task needs human review\n"+
+			"- Do not stop just because the conflict count is high — split by file and resolve all conflicts autonomously\n"+
+			"- Stop only for a concrete blocker: binary conflict, missing secret/credential, deleted context you cannot reconstruct, or a semantic decision that the task/PR context does not answer\n"+
 			"- No investigation, no extra commits, no unrelated changes"+
 			"%s",
 		pr.HeadRefName, pr.Number, pr.HeadRefName, filesCtx,

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -17,6 +17,35 @@ import (
 	"github.com/Automaat/sybra/internal/worktree"
 )
 
+func TestConflictPrompt_ResolvesAllConflictsAutonomously(t *testing.T) {
+	t.Parallel()
+
+	prompt := buildConflictPrompt(github.PullRequest{
+		Number:      1178,
+		HeadRefName: "fix/example",
+	}, "\n\nFiles changed in this PR:\n- internal/workflow/engine.go\n")
+
+	for _, forbidden := range []string{
+		"more than 3",
+		"run `git rebase --abort` and stop",
+		"task needs human review",
+	} {
+		if strings.Contains(prompt, forbidden) {
+			t.Fatalf("conflict prompt still contains count-based stop instruction %q:\n%s", forbidden, prompt)
+		}
+	}
+	for _, want := range []string{
+		"Use the task body, PR diff, changed-file list, and current code as context",
+		"Do not stop just because the conflict count is high",
+		"resolve all conflicts autonomously",
+		"Stop only for a concrete blocker",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("conflict prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
 // TestPRMonitorEligible exercises the scan predicate used by the PR monitor
 // loop. The regression: tasks whose workflow exited to in-progress with a
 // live PR number (because an evaluate step crashed, or a manually-spawned

--- a/internal/sybra/svc_integrations.go
+++ b/internal/sybra/svc_integrations.go
@@ -132,8 +132,9 @@ func (s *IntegrationService) FixRenovateCI(repo string, number int, branch, titl
 		"# Task: Fix CI: %s\n\n"+
 			"Fix failing CI on branch `%s` (PR #%d). "+
 			"Check the failing run with `gh run view --log-failed`, "+
-			"fix the code, commit and push. No unrelated changes.",
+			"fix the code, commit and push. No unrelated changes.%s",
 		title, branch, number,
+		prFixResultContract,
 	)
 
 	ciFailure := string(github.PRIssueCIFailure)

--- a/internal/workflow/builtin/pr-fix.yaml
+++ b/internal/workflow/builtin/pr-fix.yaml
@@ -27,6 +27,20 @@ steps:
       prompt: >-
         {{ getvar .Vars "prompt" }}
     next:
+      - goto: route_pr_fix_result
+
+  # Mechanical check (no LLM): if the pr-fix agent deliberately stopped and
+  # requested human review (for example too many merge conflicts), preserve that
+  # escalation before PR relinking can move the task back to in-review.
+  - id: route_pr_fix_result
+    name: Route PR Fix Result
+    type: route_pr_fix_result
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
       - goto: verify_commits
 
   # Mechanical check (no LLM): verifies the task's branch has at least one

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -318,6 +318,44 @@ func TestBuiltinDefinitions_Valid(t *testing.T) {
 	}
 }
 
+func TestBuiltinPRFix_RoutesAgentHumanRequiredBeforePRRelink(t *testing.T) {
+	t.Parallel()
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var prfix *Definition
+	for i := range defs {
+		if defs[i].ID == "pr-fix" {
+			prfix = &defs[i]
+			break
+		}
+	}
+	if prfix == nil {
+		t.Fatal("pr-fix builtin definition not found")
+	}
+	fix := prfix.StepByID("fix")
+	if fix == nil {
+		t.Fatal("fix step missing from pr-fix")
+	}
+	if got, err := ResolveTransition(fix.Next, map[string]string{"task.status": "in-progress"}); err != nil || got != "route_pr_fix_result" {
+		t.Fatalf("fix next = %q, err=%v; want route_pr_fix_result", got, err)
+	}
+	route := prfix.StepByID("route_pr_fix_result")
+	if route == nil {
+		t.Fatal("route_pr_fix_result step missing from pr-fix")
+	}
+	if route.Type != StepRoutePRFixResult {
+		t.Fatalf("route_pr_fix_result type = %q, want %q", route.Type, StepRoutePRFixResult)
+	}
+	if got, err := ResolveTransition(route.Next, map[string]string{"task.status": "human-required"}); err != nil || got != "" {
+		t.Fatalf("human-required route next = %q, err=%v; want end", got, err)
+	}
+	if got, err := ResolveTransition(route.Next, map[string]string{"task.status": "in-progress"}); err != nil || got != "verify_commits" {
+		t.Fatalf("default route next = %q, err=%v; want verify_commits", got, err)
+	}
+}
+
 func TestBuiltinSimpleTaskReview_CreatePRUsesForkRemote(t *testing.T) {
 	t.Parallel()
 	defs, err := BuiltinDefinitions()

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -79,6 +79,12 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 			if v := extractTestVerdict(output.Output); v != "" {
 				wfExec.SetVar("step."+output.StepID+".verdict", v)
 			}
+			if currentStep.Config.Role == "pr-fix" {
+				if requiresHuman, reason := classifyPRFixResult(output.Output); requiresHuman {
+					wfExec.SetVar("step."+output.StepID+".pr_fix_requires_human", "true")
+					wfExec.SetVar("step."+output.StepID+".pr_fix_reason", reason)
+				}
+			}
 		}
 	}
 
@@ -338,7 +344,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			return e.execParallel(taskID, def, step, wfExec, ctx)
 		case StepWaitHuman:
 			return nil, e.execWaitHuman(taskID, step, wfExec)
-		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepRerequestReview, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepTriageReview, StepDetectTampering, StepVerifyChecks, StepRouteTestResult:
+		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepRerequestReview, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepTriageReview, StepDetectTampering, StepVerifyChecks, StepRoutePRFixResult, StepRouteTestResult:
 			// handled below as sync steps
 		default:
 			return nil, fmt.Errorf("unknown step type %q", step.Type)
@@ -428,6 +434,8 @@ func (e *Engine) execSyncStep(taskID string, step *Step, wfExec *Execution, ctx 
 		return e.execDetectTampering(taskID, step, t)
 	case StepVerifyChecks:
 		return e.execVerifyChecks(taskID, step, t)
+	case StepRoutePRFixResult:
+		return e.execRoutePRFixResult(taskID, step, wfExec)
 	case StepRouteTestResult:
 		return e.execRouteTestResult(taskID, step, wfExec, t)
 	default:

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -79,13 +79,12 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 			if v := extractTestVerdict(output.Output); v != "" {
 				wfExec.SetVar("step."+output.StepID+".verdict", v)
 			}
-			if currentStep.Config.Role == "pr-fix" {
-				if requiresHuman, reason := classifyPRFixResult(output.Output); requiresHuman {
-					wfExec.SetVar("step."+output.StepID+".pr_fix_requires_human", "true")
-					wfExec.SetVar("step."+output.StepID+".pr_fix_reason", reason)
-				}
-			}
 		}
+	}
+	if output.Status == "completed" && currentStep.Config.Role == "pr-fix" {
+		requiresHuman, reason := classifyPRFixResult(output.Output)
+		wfExec.SetVar("step."+output.StepID+".pr_fix_requires_human", strconv.FormatBool(requiresHuman))
+		wfExec.SetVar("step."+output.StepID+".pr_fix_reason", reason)
 	}
 
 	// Retry failed steps if max_retries configured and not exhausted.

--- a/internal/workflow/engine_steps_prfix.go
+++ b/internal/workflow/engine_steps_prfix.go
@@ -1,0 +1,115 @@
+package workflow
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var prFixSentinelRe = regexp.MustCompile(`(?im)^SYBRA_PR_FIX_RESULT:\s*([a-z_-]+)\s*$`)
+var prFixReasonRe = regexp.MustCompile(`(?im)^SYBRA_PR_FIX_REASON:\s*(.+?)\s*$`)
+
+func (e *Engine) execRoutePRFixResult(taskID string, step *Step, wfExec *Execution) (StepOutput, error) {
+	requiresHuman, reason := prFixRequiresHuman(wfExec)
+	if !requiresHuman {
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "continue"}, nil
+	}
+	if reason == "" {
+		reason = "pr-fix agent requested human review"
+	}
+	if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
+		return StepOutput{}, fmt.Errorf("route pr-fix result: set human-required: %w", err)
+	}
+	e.logger.Warn("workflow.pr-fix.human-required", "task_id", taskID, "reason", reason)
+	return StepOutput{StepID: step.ID, Status: "completed", Output: reason}, nil
+}
+
+func prFixRequiresHuman(wfExec *Execution) (requiresHuman bool, reason string) {
+	if wfExec == nil {
+		return false, ""
+	}
+	if wfExec.Variables != nil && wfExec.Variables["step.fix.pr_fix_requires_human"] == "true" {
+		return true, wfExec.Variables["step.fix.pr_fix_reason"]
+	}
+	return classifyPRFixResult(lastPRFixOutput(wfExec))
+}
+
+func lastPRFixOutput(wfExec *Execution) string {
+	if wfExec == nil {
+		return ""
+	}
+	if rec := wfExec.RecordForStep("fix"); rec != nil {
+		return rec.Output
+	}
+	if wfExec.Variables != nil {
+		return wfExec.Variables["step.fix.output"]
+	}
+	return ""
+}
+
+func classifyPRFixResult(output string) (requiresHuman bool, reason string) {
+	if strings.TrimSpace(output) == "" {
+		return false, ""
+	}
+	if m := prFixSentinelRe.FindStringSubmatch(output); len(m) == 2 {
+		switch strings.ToLower(strings.TrimSpace(m[1])) {
+		case "human-required", "human_required", "human":
+			return true, extractPRFixReason(output)
+		case "continue", "ok", "done":
+			return false, ""
+		}
+	}
+
+	lower := strings.ToLower(output)
+	negativePhrases := []string{
+		"no human review is required",
+		"does not require human",
+		"doesn't require human",
+		"without human review",
+	}
+	for _, phrase := range negativePhrases {
+		if strings.Contains(lower, phrase) {
+			return false, ""
+		}
+	}
+
+	humanPhrases := []string{
+		"human review is required",
+		"requires human review",
+		"require human review",
+		"needs human review",
+		"human intervention is required",
+		"requires human intervention",
+		"requires manual resolution",
+		"manual resolution is required",
+		"manually resolve",
+		"too many conflicts",
+		"more than 3 conflicting files",
+		"exceeds the 3-file limit",
+		"exceeds the limit of 3",
+		"this task requires human review",
+	}
+	for _, phrase := range humanPhrases {
+		if strings.Contains(lower, phrase) {
+			return true, "pr-fix agent requested human review: " + truncate(firstNonEmptyLine(output), 200)
+		}
+	}
+	return false, ""
+}
+
+func extractPRFixReason(output string) string {
+	if m := prFixReasonRe.FindStringSubmatch(output); len(m) == 2 {
+		return truncate(strings.TrimSpace(m[1]), 200)
+	}
+	return "pr-fix agent requested human review"
+}
+
+func firstNonEmptyLine(s string) string {
+	for line := range strings.Lines(s) {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}

--- a/internal/workflow/engine_steps_prfix.go
+++ b/internal/workflow/engine_steps_prfix.go
@@ -28,21 +28,30 @@ func prFixRequiresHuman(wfExec *Execution) (requiresHuman bool, reason string) {
 	if wfExec == nil {
 		return false, ""
 	}
-	if wfExec.Variables != nil && wfExec.Variables["step.fix.pr_fix_requires_human"] == "true" {
-		return true, wfExec.Variables["step.fix.pr_fix_reason"]
+	stepID := wfExec.LastAgentStepID()
+	if stepID == "" {
+		return false, ""
 	}
-	return classifyPRFixResult(lastPRFixOutput(wfExec))
+	if wfExec.Variables != nil {
+		switch wfExec.Variables["step."+stepID+".pr_fix_requires_human"] {
+		case "true":
+			return true, wfExec.Variables["step."+stepID+".pr_fix_reason"]
+		case "false":
+			return false, ""
+		}
+	}
+	return classifyPRFixResult(lastPRFixOutput(wfExec, stepID))
 }
 
-func lastPRFixOutput(wfExec *Execution) string {
-	if wfExec == nil {
+func lastPRFixOutput(wfExec *Execution, stepID string) string {
+	if wfExec == nil || stepID == "" {
 		return ""
 	}
-	if rec := wfExec.RecordForStep("fix"); rec != nil {
+	if rec := wfExec.RecordForStep(stepID); rec != nil {
 		return rec.Output
 	}
 	if wfExec.Variables != nil {
-		return wfExec.Variables["step.fix.output"]
+		return wfExec.Variables["step."+stepID+".output"]
 	}
 	return ""
 }
@@ -51,7 +60,9 @@ func classifyPRFixResult(output string) (requiresHuman bool, reason string) {
 	if strings.TrimSpace(output) == "" {
 		return false, ""
 	}
-	if m := prFixSentinelRe.FindStringSubmatch(output); len(m) == 2 {
+	matches := prFixSentinelRe.FindAllStringSubmatch(output, -1)
+	if len(matches) > 0 {
+		m := matches[len(matches)-1]
 		switch strings.ToLower(strings.TrimSpace(m[1])) {
 		case "human-required", "human_required", "human":
 			return true, extractPRFixReason(output)
@@ -98,7 +109,9 @@ func classifyPRFixResult(output string) (requiresHuman bool, reason string) {
 }
 
 func extractPRFixReason(output string) string {
-	if m := prFixReasonRe.FindStringSubmatch(output); len(m) == 2 {
+	matches := prFixReasonRe.FindAllStringSubmatch(output, -1)
+	if len(matches) > 0 {
+		m := matches[len(matches)-1]
 		return truncate(strings.TrimSpace(m[1]), 200)
 	}
 	return "pr-fix agent requested human review"

--- a/internal/workflow/engine_steps_prfix_test.go
+++ b/internal/workflow/engine_steps_prfix_test.go
@@ -39,6 +39,20 @@ func TestClassifyPRFixResult(t *testing.T) {
 			output:    "The conflict is resolved; no human review is required.\nSYBRA_PR_FIX_RESULT: continue\n",
 			wantHuman: false,
 		},
+		{
+			name: "last sentinel wins",
+			output: "Example contract:\nSYBRA_PR_FIX_RESULT: human-required\n\nActual result:\n" +
+				"SYBRA_PR_FIX_RESULT: continue\n",
+			wantHuman: false,
+		},
+		{
+			name: "last reason wins",
+			output: "SYBRA_PR_FIX_REASON: example only\n" +
+				"SYBRA_PR_FIX_RESULT: human-required\n" +
+				"SYBRA_PR_FIX_REASON: real blocker\n",
+			wantHuman:  true,
+			wantReason: "real blocker",
+		},
 	}
 
 	for _, tc := range cases {
@@ -96,6 +110,39 @@ func TestExecRoutePRFixResult_HumanRequiredStopsBeforeRelink(t *testing.T) {
 	}
 	if reason := tasks.Reason("t1"); !strings.Contains(reason, "Human review is required") {
 		t.Errorf("reason = %q, want agent output excerpt", reason)
+	}
+}
+
+func TestPRFixRequiresHuman_UsesLastAgentStepVars(t *testing.T) {
+	t.Parallel()
+
+	wf := &Execution{
+		StepHistory: []StepRecord{
+			{
+				StepID:  "old_fix",
+				Status:  "completed",
+				Output:  "SYBRA_PR_FIX_RESULT: human-required\nSYBRA_PR_FIX_REASON: stale\n",
+				AgentID: "agent-1",
+			},
+			{
+				StepID:  "repair_conflicts",
+				Status:  "completed",
+				Output:  "SYBRA_PR_FIX_RESULT: human-required\nSYBRA_PR_FIX_REASON: ignored because explicit false var wins\n",
+				AgentID: "agent-2",
+			},
+		},
+		Variables: map[string]string{
+			"step.old_fix.pr_fix_requires_human":          "true",
+			"step.old_fix.pr_fix_reason":                  "stale",
+			"step.repair_conflicts.pr_fix_requires_human": "false",
+			"step.repair_conflicts.pr_fix_reason":         "",
+			"step.repair_conflicts.output":                "SYBRA_PR_FIX_RESULT: human-required\n",
+		},
+	}
+
+	gotHuman, gotReason := prFixRequiresHuman(wf)
+	if gotHuman {
+		t.Fatalf("requiresHuman = true, reason %q; want explicit false from latest agent step", gotReason)
 	}
 }
 

--- a/internal/workflow/engine_steps_prfix_test.go
+++ b/internal/workflow/engine_steps_prfix_test.go
@@ -1,0 +1,168 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestClassifyPRFixResult(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		output     string
+		wantHuman  bool
+		wantReason string
+	}{
+		{
+			name: "sentinel human required with reason",
+			output: "Aborted rebase.\nSYBRA_PR_FIX_RESULT: human-required\n" +
+				"SYBRA_PR_FIX_REASON: 5 conflicting files exceed the auto-resolve limit\n",
+			wantHuman:  true,
+			wantReason: "5 conflicting files exceed the auto-resolve limit",
+		},
+		{
+			name:      "sentinel continue",
+			output:    "Pushed fixes.\nSYBRA_PR_FIX_RESULT: continue\n",
+			wantHuman: false,
+		},
+		{
+			name: "legacy conflict abort text",
+			output: "The rebase produced 5 conflicting files, which exceeds the limit of 3. " +
+				"As instructed, I ran git rebase --abort. This task requires human review.",
+			wantHuman:  true,
+			wantReason: "pr-fix agent requested human review: The rebase produced 5 conflicting files, which exceeds the limit of 3. As instructed, I ran git rebase --abort. This task requires human review.",
+		},
+		{
+			name:      "negative human phrase",
+			output:    "The conflict is resolved; no human review is required.\nSYBRA_PR_FIX_RESULT: continue\n",
+			wantHuman: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotHuman, gotReason := classifyPRFixResult(tc.output)
+			if gotHuman != tc.wantHuman {
+				t.Fatalf("human = %v, want %v", gotHuman, tc.wantHuman)
+			}
+			if tc.wantReason != "" && gotReason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", gotReason, tc.wantReason)
+			}
+		})
+	}
+}
+
+func TestExecRoutePRFixResult_HumanRequiredStopsBeforeRelink(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	wf := &Execution{
+		WorkflowID:  "pr-fix",
+		CurrentStep: "route_pr_fix_result",
+		State:       ExecRunning,
+		StepHistory: []StepRecord{{
+			StepID:    "fix",
+			Status:    "completed",
+			Output:    "Aborted - the rebase hit 5 conflicting files. Human review is required.",
+			AgentID:   "agent-1",
+			StartedAt: time.Now(),
+		}},
+	}
+	tasks.Put(TaskInfo{
+		ID:       "t1",
+		Status:   "in-progress",
+		PRNumber: 1178,
+		Workflow: wf,
+	})
+
+	out, err := engine.execRoutePRFixResult("t1", &Step{ID: "route_pr_fix_result"}, wf)
+	if err != nil {
+		t.Fatalf("execRoutePRFixResult: %v", err)
+	}
+	if out.Output == "continue" {
+		t.Fatal("route output = continue, want human-required reason")
+	}
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required", got.Status)
+	}
+	if reason := tasks.Reason("t1"); !strings.Contains(reason, "Human review is required") {
+		t.Errorf("reason = %q, want agent output excerpt", reason)
+	}
+}
+
+func TestAdvanceStep_PRFixHumanRequiredUsesUntruncatedOutput(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	if err := store.Save(Definition{
+		ID:   "pr-fix-route-test",
+		Name: "PR fix route test",
+		Steps: []Step{
+			{
+				ID:   "fix",
+				Type: StepRunAgent,
+				Config: StepConfig{
+					Role:   "pr-fix",
+					Prompt: "fix",
+				},
+				Next: []Transition{{GoTo: "route_pr_fix_result"}},
+			},
+			{
+				ID:   "route_pr_fix_result",
+				Type: StepRoutePRFixResult,
+				Next: []Transition{
+					{
+						When: &Condition{Field: "task.status", Operator: "equals", Value: "human-required"},
+						GoTo: "",
+					},
+					{GoTo: ""},
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("save workflow: %v", err)
+	}
+
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	if err := engine.StartWorkflow("t1", "pr-fix-route-test"); err != nil {
+		t.Fatalf("start workflow: %v", err)
+	}
+
+	longOutput := strings.Repeat("progress details\n", 400) +
+		"SYBRA_PR_FIX_RESULT: human-required\n" +
+		"SYBRA_PR_FIX_REASON: 5 conflicts exceed the limit\n"
+	if err := engine.AdvanceStep("t1", StepOutput{
+		StepID:  "fix",
+		Status:  "completed",
+		Output:  longOutput,
+		AgentID: "agent-1",
+	}); err != nil {
+		t.Fatalf("advance: %v", err)
+	}
+
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required", got.Status)
+	}
+	if reason := tasks.Reason("t1"); reason != "5 conflicts exceed the limit" {
+		t.Errorf("reason = %q, want sentinel reason", reason)
+	}
+	if got.Workflow == nil || got.Workflow.State != ExecCompleted {
+		t.Fatalf("workflow state = %+v, want completed", got.Workflow)
+	}
+}

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -100,6 +100,9 @@ const (
 	// detect_tampering: structural test tampering is caught there; this catches
 	// incomplete/broken work committed without the suite passing.
 	StepVerifyChecks StepType = "verify_checks"
+	// StepRoutePRFixResult inspects the completed pr-fix agent output before
+	// mechanical PR relinking can overwrite a human-required escalation.
+	StepRoutePRFixResult StepType = "route_pr_fix_result"
 	// StepRouteTestResult reads the test-runner verdict and routes the task:
 	// pass → ready-pr, fail → in-progress (re-implement) until the attempt
 	// cap is hit, then human-required.


### PR DESCRIPTION
## Motivation

Task `b319d12f` bounced after a pr-fix agent correctly stopped on too many merge conflicts. The workflow then relinked the existing PR and moved the task back to `in-review`, erasing the human-required stop signal.

> Changelog: fix(workflow): preserve pr-fix escalations

## Implementation information

Adds a `route_pr_fix_result` workflow step immediately after pr-fix agents. The step honors explicit `SYBRA_PR_FIX_RESULT: human-required` sentinels, preserves decisions from untruncated output, and handles legacy “human review required” conflict-abort text before PR relinking runs.

PR-fix prompts now ask agents to emit the sentinel so future stop/continue decisions are mechanical instead of inferred from a later status transition.

## Supporting documentation

`go test ./internal/workflow -count=1`

Pre-push hook passed: `go test ./...` and `cd frontend && npm run check`.