### PR TITLE
fix(workflow): retry PR rate limits

### DIFF
--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"slices"
+	"time"
 )
 
 // HandleHumanAction processes approve/reject/input from the UI.
@@ -331,6 +332,11 @@ func (e *Engine) ResumeStalled() {
 		if step.Type != StepRunAgent {
 			continue
 		}
+		if retryAt, ok := workflowRetryAfter(t.Workflow); ok && time.Now().Before(retryAt) {
+			e.logger.Debug("workflow.resume-stalled.skip",
+				"task_id", t.ID, "reason", "retry_after", "retry_after", retryAt.Format(time.RFC3339), "step", step.ID)
+			continue
+		}
 		// A task in human-required was halted by a competing path (e.g. the
 		// inline review triage deciding the PR is too small). Do not resume its
 		// workflow: that would override the triage verdict and re-dispatch an
@@ -382,6 +388,7 @@ func (e *Engine) ResumeStalled() {
 				break
 			}
 		}
+
 		if !advancing && !dispatching && !hasOutstandingAgent {
 			e.dispatching[t.ID] = struct{}{}
 		}
@@ -425,6 +432,18 @@ func (e *Engine) ResumeStalled() {
 			e.surfaceStartFailure(t.ID, fresh.Status, rErr)
 		}
 	}
+}
+
+func workflowRetryAfter(wf *Execution) (time.Time, bool) {
+	if wf == nil || wf.Variables == nil {
+		return time.Time{}, false
+	}
+	raw := wf.Variables[workflowRetryAfterVar]
+	if raw == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, raw)
+	return t, err == nil
 }
 
 // surfaceStartFailure writes a human-readable reason to task.StatusReason

--- a/internal/workflow/engine_steps_link.go
+++ b/internal/workflow/engine_steps_link.go
@@ -9,10 +9,17 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 )
 
 var prURLRe = regexp.MustCompile(`github\.com/[^/\s]+/[^/\s]+/pull/(\d+)`)
 var prShortRe = regexp.MustCompile(`\b[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+#(\d+)`)
+
+const (
+	workflowRetryAfterVar     = "workflow.retry_after"
+	prCreateRetryBackoff      = 15 * time.Minute
+	prCreateRetryStatusReason = "GitHub rate limit during PR creation — retrying later"
+)
 
 // execLinkPRAndReview is a non-LLM mechanical step that tries to recover the
 // PR number from three sources and flip the task to in-review:
@@ -136,6 +143,19 @@ func (e *Engine) execEvaluate(taskID string, step *Step, wfExec *Execution, t Ta
 
 	reason := "no agent result to evaluate"
 	if last != nil {
+		if isPRCreationStep(last.StepID) && looksLikeGitHubRateLimit(last.Output) {
+			wfExec.CurrentStep = last.StepID
+			wfExec.State = ExecWaiting
+			wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(prCreateRetryBackoff).Format(time.RFC3339))
+			if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
+				return StepOutput{}, err
+			}
+			if statusErr := e.tasks.UpdateTaskStatus(taskID, t.Status, prCreateRetryStatusReason); statusErr != nil {
+				return StepOutput{}, statusErr
+			}
+			e.logger.Warn("workflow.evaluate.pr-create-rate-limited", "task_id", taskID, "step", last.StepID)
+			return StepOutput{}, errStepParked
+		}
 		if last.Status == "failed" {
 			reason = truncate(strings.TrimSpace(last.Output), 200)
 			if reason == "" {
@@ -151,4 +171,20 @@ func (e *Engine) execEvaluate(taskID string, step *Step, wfExec *Execution, t Ta
 	}
 	e.logger.Info("workflow.evaluate.human-required", "task_id", taskID, "reason", reason)
 	return StepOutput{StepID: step.ID, Status: "completed", Output: reason}, nil
+}
+
+func isPRCreationStep(stepID string) bool {
+	return stepID == "create_pr" || stepID == "push_existing_pr"
+}
+
+func looksLikeGitHubRateLimit(output string) bool {
+	lower := strings.ToLower(output)
+	if !strings.Contains(lower, "rate limit") {
+		return false
+	}
+	return strings.Contains(lower, "github") ||
+		strings.Contains(lower, "graphql") ||
+		strings.Contains(lower, "gh ") ||
+		strings.Contains(lower, "api rate limit") ||
+		strings.Contains(lower, "secondary rate limit")
 }

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -1143,6 +1143,46 @@ func TestResumeStalled_SkipsRateLimitedProvider(t *testing.T) {
 	}
 }
 
+func TestResumeStalled_SkipsWorkflowRetryUntil(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	wf := &Execution{
+		WorkflowID:  "test-simple",
+		CurrentStep: "implement",
+		State:       ExecWaiting,
+		Variables: map[string]string{
+			workflowRetryAfterVar: time.Now().UTC().Add(time.Hour).Format(time.RFC3339),
+		},
+	}
+	tasks.Put(TaskInfo{
+		ID:        "t1",
+		Status:    "in-progress",
+		AgentMode: "headless",
+		Workflow:  wf,
+	})
+
+	engine.ResumeStalled()
+	if agents.CallCount() != 0 {
+		t.Fatalf("agent starts before retry window = %d, want 0", agents.CallCount())
+	}
+
+	wf.Variables[workflowRetryAfterVar] = time.Now().UTC().Add(-time.Minute).Format(time.RFC3339)
+	tasks.Put(TaskInfo{
+		ID:        "t1",
+		Status:    "in-progress",
+		AgentMode: "headless",
+		Workflow:  wf,
+	})
+
+	engine.ResumeStalled()
+	if agents.CallCount() != 1 {
+		t.Fatalf("agent starts after retry window = %d, want 1", agents.CallCount())
+	}
+}
+
 func TestResumeStalled_SkipWaitHuman(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()
@@ -3627,6 +3667,47 @@ func TestExecEvaluate_LastAgentSucceededFlipsHumanRequiredWithDefault(t *testing
 	}
 	if got := tasks.Reason("t1"); got != "commits pushed but no PR created" {
 		t.Errorf("reason = %q, want %q", got, "commits pushed but no PR created")
+	}
+}
+
+func TestExecEvaluate_PRCreateRateLimitParksForRetry(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "ready-pr"})
+	engine := newEngineForEval(t, tasks)
+	wfExec := &Execution{
+		WorkflowID:  "simple-task-pr",
+		CurrentStep: "evaluate",
+		State:       ExecRunning,
+		Variables:   map[string]string{},
+		StepHistory: []StepRecord{
+			{
+				StepID:  "create_pr",
+				Status:  "completed",
+				AgentID: "a1",
+				Output:  "GitHub GraphQL rate limit exhausted; I will wait for reset.",
+			},
+		},
+	}
+
+	_, err := engine.execEvaluate("t1", newEvaluateStep(), wfExec, TaskInfo{ID: "t1", Status: "ready-pr"})
+	if !errors.Is(err, errStepParked) {
+		t.Fatalf("err = %v, want errStepParked", err)
+	}
+	if wfExec.CurrentStep != "create_pr" {
+		t.Errorf("CurrentStep = %q, want create_pr", wfExec.CurrentStep)
+	}
+	if wfExec.State != ExecWaiting {
+		t.Errorf("State = %q, want ExecWaiting", wfExec.State)
+	}
+	if _, ok := workflowRetryAfter(wfExec); !ok {
+		t.Errorf("%s not set to a valid retry timestamp", workflowRetryAfterVar)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status != "ready-pr" {
+		t.Errorf("task status = %q, want ready-pr", ti.Status)
+	}
+	if got := tasks.Reason("t1"); got != prCreateRetryStatusReason {
+		t.Errorf("reason = %q, want %q", got, prCreateRetryStatusReason)
 	}
 }
 


### PR DESCRIPTION
## Motivation

When an agent hits GitHub's secondary rate limit during PR creation (`create_pr` / `push_existing_pr` steps), the workflow engine was treating the failure as a permanent agent error and flipping the task to `human-required`. This forced manual intervention for a transient API limit that clears on its own.

> Changelog: fix(workflow): retry PR creation on GitHub rate limit

## Implementation information

- Added `looksLikeGitHubRateLimit` heuristic that matches rate-limit signal phrases in the agent's output (`rate limit`, `secondary rate limit`, `api rate limit`, `graphql`).
- When `execEvaluate` detects a rate-limited PR-creation step, it parks the workflow: rewinds `CurrentStep` to the failing step, sets `State = ExecWaiting`, and writes a `workflow.retry_after` timestamp (15 min from now) into the execution variables.
- `ResumeStalled` now reads `workflow.retry_after` and skips any task whose retry window hasn't elapsed, preventing premature re-dispatch.
- Two new tests cover both paths: `TestExecEvaluate_PRCreateRateLimitParksForRetry` and `TestResumeStalled_SkipsWorkflowRetryUntil`.