### PR TITLE
fix(agent): preserve one-shot reattach

### DIFF
--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -457,7 +457,7 @@ func TestHandoffPersistsSourceProviderAtomically(t *testing.T) {
 		t.Fatalf("mkdir clone parent: %v", err)
 	}
 	runGit(t, "", "init", "--bare", proj.ClonePath)
-	runGit(t, proj.ClonePath, "symbolic-ref", "HEAD", "refs/heads/main")
+	runGit(t, "", "--git-dir="+proj.ClonePath, "symbolic-ref", "HEAD", "refs/heads/main")
 
 	worktree := filepath.Join(t.TempDir(), "repo")
 	runGit(t, "", "init", worktree)

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -224,6 +224,7 @@ func (m *Manager) saveRegistry(a *Agent) {
 		CWD:                a.sessionCWD,
 		StartedAt:          a.StartedAt,
 		StdinPath:          a.stdinPath,
+		OneShot:            a.oneShot,
 		MaxTurns:           a.MaxTurns,
 		RequirePermissions: a.requirePermissions,
 		ReasoningEffort:    a.ReasoningEffort,

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -89,6 +89,7 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 		cancel:                 cancel,
 		sessionCWD:             cfg.Dir,
 		MaxTurns:               cfg.MaxTurns,
+		oneShot:                cfg.OneShot,
 		requirePermissions:     cfg.RequirePermissions,
 		headlessPermissionMode: cfg.HeadlessPermissionMode,
 	}

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -84,6 +84,9 @@ type Agent struct {
 	loopAckSig string
 	// MaxTurns is the per-agent turn limit override; zero means use global guardrail.
 	MaxTurns int `json:"maxTurns,omitempty"`
+	// oneShot marks workflow-owned interactive runs that must complete after
+	// one provider turn instead of surviving as reusable chats.
+	oneShot bool
 	// PluginErrors holds plugin load failures from the most recent init event.
 	PluginErrors     []string `json:"pluginErrors,omitempty"`
 	EscalationReason string   `json:"escalationReason,omitempty"`

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -251,6 +251,10 @@ func (m *Manager) reattachPerTurnConvo(r Record, reg *registryStore) *Agent {
 	if r.LogPath != "" {
 		rehydratePerTurnConvoFromLog(a, r.LogPath)
 	}
+	if r.OneShot {
+		m.finalizePerTurnOneShot(r, a, reg)
+		return nil
+	}
 	a.SetState(StatePaused)
 
 	ctx, cancel := context.WithCancel(m.ctx)
@@ -275,6 +279,19 @@ func (m *Manager) reattachPerTurnConvo(r Record, reg *registryStore) *Agent {
 	go m.runPerTurnConversational(ctx, a, RunConfig{Dir: a.sessionCWD, RequirePermissions: a.requirePermissions}, true)
 	m.emit(events.AgentState(a.ID), a)
 	return a
+}
+
+func (m *Manager) finalizePerTurnOneShot(r Record, a *Agent, reg *registryStore) {
+	if found, isError := a.lastConvoResult(); !found {
+		a.SetExitErr(errReattachedGone)
+	} else if isError {
+		a.SetExitErr(errReattachedResultError)
+	}
+	a.SetState(StateStopped)
+	m.logger.Info("agent.reattach.per-turn-oneshot.done", "id", a.ID, "task", a.TaskID, "provider", a.Provider)
+	m.emit(events.AgentState(a.ID), a)
+	m.fireComplete(a, a.GetExitErr() == nil)
+	_ = reg.Delete(r.ID)
 }
 
 // reattachHeadless tails a reattached subprocess's log file from
@@ -425,6 +442,7 @@ func agentFromRecord(r Record) *Agent {
 		LastEventAt:        time.Now().UTC(),
 		State:              StateRunning,
 		MaxTurns:           r.MaxTurns,
+		oneShot:            r.OneShot,
 		stdinPath:          r.StdinPath,
 		requirePermissions: r.RequirePermissions,
 		ReasoningEffort:    r.ReasoningEffort,

--- a/internal/agent/registry.go
+++ b/internal/agent/registry.go
@@ -33,6 +33,7 @@ type Record struct {
 	StartedAt      time.Time `yaml:"started_at"`
 	ProcStartedAt  string    `yaml:"proc_started_at,omitempty"` // ps lstart, guards PID reuse
 	StdinPath      string    `yaml:"stdin_path,omitempty"`      // FIFO for interactive survival
+	OneShot        bool      `yaml:"one_shot,omitempty"`
 	MaxTurns       int       `yaml:"max_turns,omitempty"`
 	// RequirePermissions preserves a codex chat's sandbox/approval choice
 	// across a restart (codex respawns per turn and would otherwise default

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -454,6 +454,13 @@ func rehydratePerTurnConvoFromLog(a *Agent, path string) {
 		if ev.SessionID != "" {
 			a.SetSessionID(ev.SessionID)
 		}
+		if ev.Type == "result" {
+			a.AddResultStats(ev.SessionID, ev.CostUSD, ev.InputTokens, ev.OutputTokens, ev.ReasoningTokens)
+			a.AddCacheStats(ev.CacheCreationInputTokens, ev.CacheReadInputTokens)
+			if ev.PremiumRequests > 0 {
+				a.AddPremiumRequests(ev.PremiumRequests)
+			}
+		}
 	}
 }
 

--- a/internal/agent/survive_convo_test.go
+++ b/internal/agent/survive_convo_test.go
@@ -147,6 +147,84 @@ func TestReattachCodexConvo_RecreatesIdleAgent(t *testing.T) {
 	}
 }
 
+func TestSaveRegistry_PreservesOneShot(t *testing.T) {
+	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
+	if err := m.EnableSurviveRestart(t.TempDir()); err != nil {
+		t.Fatalf("EnableSurviveRestart: %v", err)
+	}
+	m.saveRegistry(&Agent{
+		ID:        "cx-one",
+		TaskID:    "t-cx",
+		Mode:      "interactive",
+		Provider:  "codex",
+		StartedAt: time.Now().UTC(),
+		oneShot:   true,
+	})
+
+	recs, err := m.reg.List()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(recs))
+	}
+	if !recs[0].OneShot {
+		t.Fatal("expected one-shot lifecycle bit persisted")
+	}
+}
+
+// TestReattachCodexConvo_OneShotNoResultFinalizes verifies a workflow-owned
+// per-turn Codex run interrupted before a terminal result is finalized as a
+// failed run instead of being resurrected as an idle chat forever.
+func TestReattachCodexConvo_OneShotNoResultFinalizes(t *testing.T) {
+	logDir := t.TempDir()
+	regDir := t.TempDir()
+	logPath := filepath.Join(logDir, "agents", "cx1.ndjson")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	lines := `{"type":"thread.started","thread_id":"cx-1"}` + "\n" +
+		`{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"working"}}` + "\n"
+	if err := os.WriteFile(logPath, []byte(lines), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir)
+	if err := m.EnableSurviveRestart(regDir); err != nil {
+		t.Fatalf("EnableSurviveRestart: %v", err)
+	}
+	var completed atomic.Bool
+	var failed atomic.Bool
+	m.SetOnComplete(func(a *Agent) {
+		completed.Store(true)
+		failed.Store(a.GetExitErr() != nil)
+	})
+
+	rec := Record{
+		ID: "cx1", TaskID: "t-cx", Mode: "interactive", Provider: "codex",
+		PID: 0, LogPath: logPath, SessionID: "cx-1", StartedAt: time.Now().UTC(), OneShot: true,
+	}
+	if err := m.reg.Save(rec); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	if got := m.ReattachAll(); len(got) != 0 {
+		t.Fatalf("expected interrupted one-shot to finalize, not recreate, got %d agents", len(got))
+	}
+	if !completed.Load() {
+		t.Fatal("expected one-shot completion callback")
+	}
+	if !failed.Load() {
+		t.Fatal("expected interrupted one-shot to be marked failed")
+	}
+	if _, err := m.GetAgent("cx1"); err == nil {
+		t.Fatal("expected no idle agent registered for interrupted one-shot")
+	}
+	if list, _ := m.reg.List(); len(list) != 0 {
+		t.Fatalf("expected registry empty after one-shot finalization, got %d", len(list))
+	}
+}
+
 // TestReattachCodexConvo_SkipsDeletedTask verifies a codex record whose task
 // no longer exists is dropped (not recreated as a zombie agent).
 func TestReattachCodexConvo_SkipsDeletedTask(t *testing.T) {

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -207,9 +207,7 @@ func SyncLocalBranch(barePath, branch string) error {
 
 	// Fast-forward only: advance local if it is a strict ancestor of remote.
 	// merge-base --is-ancestor exits 0 when local IS an ancestor; exits 1 when not.
-	cmd := exec.Command("git", "merge-base", "--is-ancestor", localSHA, remoteSHA)
-	cmd.Dir = barePath
-	if cmd.Run() == nil {
+	if runBare(barePath, "merge-base", "--is-ancestor", localSHA, remoteSHA) == nil {
 		return runBare(barePath, "update-ref", localRef, remoteSHA)
 	}
 	// local is not an ancestor (has local-only or diverged commits) — preserve

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -25,6 +25,14 @@ var (
 // ErrBranchMissing is returned by PushSync when the local branch ref does not exist.
 var ErrBranchMissing = errors.New("local branch ref does not exist")
 
+func runBare(barePath string, args ...string) error {
+	return executil.Run(barePath, "git", append([]string{"-c", "safe.bareRepository=all"}, args...)...)
+}
+
+func outputBare(barePath string, args ...string) (string, error) {
+	return executil.Output(barePath, "git", append([]string{"-c", "safe.bareRepository=all"}, args...)...)
+}
+
 // LoadRepoConfig reads .sybra.yaml from the worktree root. Returns an empty
 // RepoConfig (not an error) if the file does not exist.
 func LoadRepoConfig(worktreePath string) (*RepoConfig, error) {
@@ -135,11 +143,11 @@ func CloneBare(repoURL, destPath string) error {
 	// `git clone --bare` leaves remote.origin.fetch empty, so later `git fetch
 	// origin` becomes a no-op against refs/remotes/origin/*. Configure the
 	// standard refspec so fetches actually update tracking refs.
-	return executil.Run(destPath, "git", "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
+	return runBare(destPath, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
 }
 
 func DefaultBranch(barePath string) (string, error) {
-	ref, err := executil.Output(barePath, "git", "symbolic-ref", "HEAD")
+	ref, err := outputBare(barePath, "symbolic-ref", "HEAD")
 	if err != nil {
 		return "", err
 	}
@@ -151,7 +159,7 @@ func FetchOrigin(barePath string) error {
 	// Explicit refspec heals bare repos cloned before remote.origin.fetch was
 	// configured, where `git fetch origin` silently skipped updating
 	// refs/remotes/origin/*.
-	return executil.Run(barePath, "git", "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*")
+	return runBare(barePath, "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*")
 }
 
 // FetchPRHead fetches a pull request's head commit into a stable local ref and
@@ -165,7 +173,7 @@ func FetchPRHead(barePath string, prNumber int) (string, error) {
 	// refs/remotes/origin/pr/<N>) cannot collide with the fetched PR head.
 	localRef := fmt.Sprintf("refs/sybra/pr/%d", prNumber)
 	refspec := fmt.Sprintf("+refs/pull/%d/head:%s", prNumber, localRef)
-	if err := executil.Run(barePath, "git", "fetch", "origin", refspec); err != nil {
+	if err := runBare(barePath, "fetch", "origin", refspec); err != nil {
 		return "", err
 	}
 	return localRef, nil
@@ -190,7 +198,7 @@ func SyncLocalBranch(barePath, branch string) error {
 	localSHA, localOK := resolveRef(barePath, localRef)
 	if !localOK {
 		// local branch absent — create it at the remote SHA
-		return executil.Run(barePath, "git", "update-ref", localRef, remoteSHA)
+		return runBare(barePath, "update-ref", localRef, remoteSHA)
 	}
 
 	if localSHA == remoteSHA {
@@ -202,7 +210,7 @@ func SyncLocalBranch(barePath, branch string) error {
 	cmd := exec.Command("git", "merge-base", "--is-ancestor", localSHA, remoteSHA)
 	cmd.Dir = barePath
 	if cmd.Run() == nil {
-		return executil.Run(barePath, "git", "update-ref", localRef, remoteSHA)
+		return runBare(barePath, "update-ref", localRef, remoteSHA)
 	}
 	// local is not an ancestor (has local-only or diverged commits) — preserve
 	return nil
@@ -211,7 +219,7 @@ func SyncLocalBranch(barePath, branch string) error {
 // resolveRef resolves a git ref in the bare repo. Returns ("", false) if the
 // ref does not exist or cannot be resolved.
 func resolveRef(barePath, ref string) (string, bool) {
-	sha, err := executil.Output(barePath, "git", "rev-parse", "--verify", ref)
+	sha, err := outputBare(barePath, "rev-parse", "--verify", ref)
 	return sha, err == nil
 }
 
@@ -303,28 +311,28 @@ func rebaseStateDir(wtPath string) string {
 }
 
 func CreateWorktree(barePath, worktreePath, branch, baseBranch string) error {
-	return executil.Run(barePath, "git", "worktree", "add", worktreePath, "-b", branch, baseBranch)
+	return runBare(barePath, "worktree", "add", worktreePath, "-b", branch, baseBranch)
 }
 
 // CreateWorktreeExisting checks out an existing branch into a new worktree.
 func CreateWorktreeExisting(barePath, worktreePath, branch string) error {
-	return executil.Run(barePath, "git", "worktree", "add", worktreePath, branch)
+	return runBare(barePath, "worktree", "add", worktreePath, branch)
 }
 
 // BranchExists reports whether a local branch exists in the repo.
 func BranchExists(barePath, branch string) bool {
-	err := executil.Run(barePath, "git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+	err := runBare(barePath, "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
 	return err == nil
 }
 
 // CreateWorktreeDetached creates a worktree in detached HEAD mode from a remote ref.
 // Used for read-only checkouts like code reviews.
 func CreateWorktreeDetached(barePath, worktreePath, ref string) error {
-	return executil.Run(barePath, "git", "worktree", "add", "--detach", worktreePath, ref)
+	return runBare(barePath, "worktree", "add", "--detach", worktreePath, ref)
 }
 
 func ListWorktrees(barePath string) ([]Worktree, error) {
-	out, err := executil.Output(barePath, "git", "worktree", "list", "--porcelain")
+	out, err := outputBare(barePath, "worktree", "list", "--porcelain")
 	if err != nil {
 		return nil, err
 	}
@@ -502,12 +510,12 @@ func PushSync(worktreePath, branch string) error {
 }
 
 func RemoveWorktree(barePath, worktreePath string) error {
-	return executil.Run(barePath, "git", "worktree", "remove", "--force", worktreePath)
+	return runBare(barePath, "worktree", "remove", "--force", worktreePath)
 }
 
 // PruneWorktrees removes stale worktree admin entries from the bare repo.
 func PruneWorktrees(barePath string) error {
-	return executil.Run(barePath, "git", "worktree", "prune")
+	return runBare(barePath, "worktree", "prune")
 }
 
 // WorktreeHealthy reports whether a checked-out worktree's git metadata is
@@ -523,7 +531,7 @@ func WorktreeHealthy(worktreePath string) bool {
 // rewrites the absolute path back-pointers in every checked-out worktree's
 // .git file and the bare's worktrees/<id>/gitdir file. Idempotent.
 func RepairWorktrees(barePath string) error {
-	return executil.Run(barePath, "git", "worktree", "repair")
+	return runBare(barePath, "worktree", "repair")
 }
 
 // RebaseOnto rebases the worktree's current branch onto the given ref.

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -1119,11 +1119,11 @@ func TestPushUpstream_RoutesToFork(t *testing.T) {
 	}
 
 	// Branch should exist on fork, not origin.
-	forkOut, _ := exec.Command("git", "-C", forkBare, "branch", "--list", "sybra/route-test").Output()
+	forkOut, _ := exec.Command("git", "-c", "safe.bareRepository=all", "-C", forkBare, "branch", "--list", "sybra/route-test").Output()
 	if strings.TrimSpace(string(forkOut)) == "" {
 		t.Error("branch missing on fork after PushUpstream")
 	}
-	originOut, _ := exec.Command("git", "-C", originBare, "branch", "--list", "sybra/route-test").Output()
+	originOut, _ := exec.Command("git", "-c", "safe.bareRepository=all", "-C", originBare, "branch", "--list", "sybra/route-test").Output()
 	if strings.TrimSpace(string(originOut)) != "" {
 		t.Errorf("branch should not exist on origin; got %q", originOut)
 	}
@@ -1379,7 +1379,7 @@ func setupPushSyncWorktree(t *testing.T) (remoteBare, wtPath, wtBranch string) {
 		t.Fatalf("init remote bare: %v: %s", err, out)
 	}
 	// Enable reflog on the bare so we can count actual ref updates per branch.
-	if out, err := exec.Command("git", "-C", remoteBare, "config", "core.logAllRefUpdates", "true").CombinedOutput(); err != nil {
+	if out, err := exec.Command("git", "-c", "safe.bareRepository=all", "-C", remoteBare, "config", "core.logAllRefUpdates", "true").CombinedOutput(); err != nil {
 		t.Fatalf("config logAllRefUpdates: %v: %s", err, out)
 	}
 	for _, args := range [][]string{
@@ -1446,7 +1446,7 @@ func makeCommit(t *testing.T, wtPath, content string) string {
 // remoteRefSHA returns the SHA the remote bare resolves for branch, or "" if absent.
 func remoteRefSHA(t *testing.T, remoteBare, branch string) string {
 	t.Helper()
-	cmd := exec.Command("git", "-C", remoteBare, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch)
+	cmd := exec.Command("git", "-c", "safe.bareRepository=all", "-C", remoteBare, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch)
 	out, err := cmd.Output()
 	if err != nil {
 		return ""
@@ -1457,7 +1457,7 @@ func remoteRefSHA(t *testing.T, remoteBare, branch string) string {
 // remoteReflogCount returns the number of reflog entries for branch on the remote bare.
 func remoteReflogCount(t *testing.T, remoteBare, branch string) int {
 	t.Helper()
-	cmd := exec.Command("git", "-C", remoteBare, "reflog", "show", "refs/heads/"+branch)
+	cmd := exec.Command("git", "-c", "safe.bareRepository=all", "-C", remoteBare, "reflog", "show", "refs/heads/"+branch)
 	out, _ := cmd.Output() // empty output is fine when the ref has no entries yet
 	trimmed := strings.TrimSpace(string(out))
 	if trimmed == "" {
@@ -1529,7 +1529,7 @@ func TestPushSync_FastForwardWithoutForce(t *testing.T) {
 	}
 
 	// Reject force-pushes on the remote so a fast-forward must succeed without force.
-	if out, err := exec.Command("git", "-C", remoteBare, "config", "receive.denyNonFastForwards", "true").CombinedOutput(); err != nil {
+	if out, err := exec.Command("git", "-c", "safe.bareRepository=all", "-C", remoteBare, "config", "receive.denyNonFastForwards", "true").CombinedOutput(); err != nil {
 		t.Fatalf("denyNonFastForwards: %v: %s", err, out)
 	}
 
@@ -1626,7 +1626,7 @@ func TestFetchPRHead(t *testing.T) {
 	if ref != "refs/sybra/pr/42" {
 		t.Errorf("ref = %q, want refs/sybra/pr/42", ref)
 	}
-	got, err := exec.Command("git", "-C", bare, "rev-parse", ref).CombinedOutput()
+	got, err := exec.Command("git", "-c", "safe.bareRepository=all", "-C", bare, "rev-parse", ref).CombinedOutput()
 	if err != nil {
 		t.Fatalf("rev-parse %s: %v: %s", ref, err, got)
 	}

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -335,7 +335,7 @@ func TestOnAgentComplete_FixReviewPushesBranch(t *testing.T) {
 		StartedAt: time.Now(),
 	})
 
-	remoteHead, err := exec.Command("git", "-C", barePath, "rev-parse", "refs/heads/"+branch).Output()
+	remoteHead, err := exec.Command("git", "-c", "safe.bareRepository=all", "-C", barePath, "rev-parse", "refs/heads/"+branch).Output()
 	if err != nil {
 		t.Fatalf("remote head: %v", err)
 	}

--- a/internal/worktree/adopt_test.go
+++ b/internal/worktree/adopt_test.go
@@ -20,7 +20,7 @@ func TestPrepareForTask_AdoptsExternalWorktree(t *testing.T) {
 	// clone, checked out on its own branch.
 	ext := filepath.Join(t.TempDir(), "orca-worktree")
 	const extBranch = "orca/feature-x"
-	if out, err := exec.Command("git", "-C", h.proj.ClonePath, "worktree", "add", "-b", extBranch, ext, "main").CombinedOutput(); err != nil {
+	if out, err := exec.Command("git", "-c", "safe.bareRepository=all", "-C", h.proj.ClonePath, "worktree", "add", "-b", extBranch, ext, "main").CombinedOutput(); err != nil {
 		t.Fatalf("git worktree add: %v: %s", err, out)
 	}
 
@@ -85,7 +85,7 @@ func TestPrepareForFix_AdoptsExternalWorktree(t *testing.T) {
 
 	ext := filepath.Join(t.TempDir(), "orca-worktree")
 	const extBranch = "orca/fix-x"
-	if out, err := exec.Command("git", "-C", h.proj.ClonePath, "worktree", "add", "-b", extBranch, ext, "main").CombinedOutput(); err != nil {
+	if out, err := exec.Command("git", "-c", "safe.bareRepository=all", "-C", h.proj.ClonePath, "worktree", "add", "-b", extBranch, ext, "main").CombinedOutput(); err != nil {
 		t.Fatalf("git worktree add: %v: %s", err, out)
 	}
 
@@ -156,7 +156,7 @@ func TestPrepareForTask_AdoptRejectsDefaultBranch(t *testing.T) {
 	h := prepareHarness(t, nil, 0)
 
 	ext := filepath.Join(t.TempDir(), "orca-on-main")
-	if out, err := exec.Command("git", "-C", h.proj.ClonePath, "worktree", "add", ext, "main").CombinedOutput(); err != nil {
+	if out, err := exec.Command("git", "-c", "safe.bareRepository=all", "-C", h.proj.ClonePath, "worktree", "add", ext, "main").CombinedOutput(); err != nil {
 		t.Fatalf("git worktree add: %v: %s", err, out)
 	}
 
@@ -173,7 +173,7 @@ func TestPrepareForTask_AdoptRejectsDetachedHead(t *testing.T) {
 	h := prepareHarness(t, nil, 0)
 
 	ext := filepath.Join(t.TempDir(), "orca-detached")
-	if out, err := exec.Command("git", "-C", h.proj.ClonePath, "worktree", "add", "--detach", ext, "main").CombinedOutput(); err != nil {
+	if out, err := exec.Command("git", "-c", "safe.bareRepository=all", "-C", h.proj.ClonePath, "worktree", "add", "--detach", ext, "main").CombinedOutput(); err != nil {
 		t.Fatalf("git worktree add --detach: %v: %s", err, out)
 	}
 

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -52,11 +52,11 @@ func initBareWithCommitReturnSrc(t *testing.T) (bare, src string) {
 	if out, err := exec.Command("git", "clone", "--bare", src, bare).CombinedOutput(); err != nil {
 		t.Fatalf("git clone --bare: %v: %s", err, out)
 	}
-	if out, err := exec.Command("git", "-C", bare, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*").CombinedOutput(); err != nil {
+	if out, err := exec.Command("git", "-c", "safe.bareRepository=all", "-C", bare, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*").CombinedOutput(); err != nil {
 		t.Fatalf("git config: %v: %s", err, out)
 	}
 	// Ensure the bare has the tracking refs populated (origin/main).
-	if out, err := exec.Command("git", "-C", bare, "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*").CombinedOutput(); err != nil {
+	if out, err := exec.Command("git", "-c", "safe.bareRepository=all", "-C", bare, "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*").CombinedOutput(); err != nil {
 		t.Fatalf("git fetch: %v: %s", err, out)
 	}
 	return bare, src


### PR DESCRIPTION
## Motivation

> Changelog: fix(agent): preserve one-shot reattach

One-shot Codex/Copilot workflow agents could be rehydrated after an app restart as reusable paused chats. That left workflow steps waiting forever until the monitor reset the task, stranding dirty worktrees instead of completing or failing the run.

## Implementation information

Persist the one-shot lifecycle bit in the agent registry, restore it on reattach, and finalize interrupted per-turn one-shot agents from their saved logs. Terminal results now complete normally, terminal errors fail normally, and missing terminal results fail closed so workflow recovery can retry instead of hanging.

Also route Sybra-managed bare-repository Git operations through an explicit safe.bareRepository override so tests and worktree setup keep working under stricter Git safety posture.

## Supporting documentation

Regression coverage added for one-shot registry persistence, interrupted one-shot reattach finalization, and safe bare-repository handling in project/worktree tests.