### PR TITLE
fix(monitor): skip umbrella tasks in lost-agent detection

### DIFF
--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -241,7 +241,12 @@ func detectLostAgents(in DetectInput) []Anomaly {
 		if t.Status != task.StatusInProgress {
 			continue
 		}
-		if t.TaskType == task.TaskTypeChat {
+		// Chat sessions and umbrella trackers run no agent of their own: a
+		// chat is synthetic and an umbrella's in-progress is a rollup of its
+		// children (app_umbrella_gate.go). Flagging either as a lost agent
+		// would loop — reset→todo fights the rollup→in-progress and re-files a
+		// failing GH issue every cycle. Mirrors recovery's RestartStaleInProgress.
+		if t.TaskType == task.TaskTypeChat || t.TaskType == task.TaskTypeUmbrella {
 			continue
 		}
 		if !projectAllowed(in.AllowsProject, t.ProjectID) {

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -204,6 +204,30 @@ func TestDetect(t *testing.T) {
 			want: []AnomalyKind{KindLostAgent},
 		},
 		{
+			name: "lost_agent suppressed for umbrella tracker (rollup status, no agent)",
+			in: DetectInput{
+				Now: now,
+				Tasks: []task.Task{mkTask("a", task.StatusInProgress, func(t *task.Task) {
+					t.TaskType = task.TaskTypeUmbrella
+				})},
+				LiveAgents: []liveAgent{},
+				Cfg:        cfg,
+			},
+			want: nil,
+		},
+		{
+			name: "stuck_human_blocked still fires for a stalled umbrella tracker",
+			in: DetectInput{
+				Now: now,
+				Tasks: []task.Task{mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
+					t.TaskType = task.TaskTypeUmbrella
+					t.UpdatedAt = now.Add(-24 * time.Hour)
+				})},
+				Cfg: cfg,
+			},
+			want: []AnomalyKind{KindStuckHumanBlocked},
+		},
+		{
 			name: "lost_agent suppressed by recent agent.* event",
 			in: DetectInput{
 				Now:   now,


### PR DESCRIPTION
## Motivation

Umbrella tracker tasks can sit `in-progress` as a rollup of their children's statuses — they run no agent of their own. When `detectLostAgents` flagged these tasks, it triggered a tight loop: the detector reset them to `todo`, but `app_umbrella_gate.go` immediately moved them back to `in-progress`, causing the monitor to re-file a failing GitHub issue on every cycle.

> Changelog: fix(monitor): skip umbrella tasks in lost-agent detection

## Implementation information

- `internal/monitor/detector.go`: extend the task-type guard in `detectLostAgents` to also skip `TaskTypeUmbrella`, mirroring the existing `RestartStaleInProgress` exclusion in the recovery path
- `internal/monitor/detector_test.go`: two new cases — suppression confirmed for umbrella `in-progress`, and `stuck_human_blocked` still fires for a stalled umbrella `human-required`
- `internal/workflow/engine_steps_testroute.go`: add comment to `fixSuggestionPhrases` clarifying it is advisory and false positives are acceptable
- `internal/workflow/fix_suggestion_adversarial_test.go`: adversarial test verifying `containsFixSuggestions` correctly detects a prescriptive code-change suggestion in test-runner output