### PR TITLE
feat(ui): add tasks done card to stats view

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/stats/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/stats/models.ts
@@ -251,6 +251,7 @@ export class Summary {
     "totalCacheReadInputTokens"?: number;
     "totalReasoningTokens"?: number;
     "totalPremiumRequests"?: number;
+    "tasksDone": number;
 
     /** Creates a new Summary instance. */
     constructor($$source: Partial<Summary> = {}) {
@@ -274,6 +275,9 @@ export class Summary {
         }
         if (!("totalOutputTokens" in $$source)) {
             this["totalOutputTokens"] = 0;
+        }
+        if (!("tasksDone" in $$source)) {
+            this["tasksDone"] = 0;
         }
 
         Object.assign(this, $$source);

--- a/frontend/src/pages/Stats.svelte
+++ b/frontend/src/pages/Stats.svelte
@@ -136,7 +136,11 @@
 
   <!-- Summary cards -->
   {#if summary}
-    <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+    <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
+      <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <span class="text-xs font-medium text-surface-500">Tasks Done</span>
+        <p class="mt-1 text-2xl font-bold">{summary.tasksDone}</p>
+      </div>
       <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
         <span class="text-xs font-medium text-surface-500">Total Cost</span>
         <p class="mt-1 text-2xl font-bold">${summary.totalCostUsd.toFixed(2)}</p>

--- a/internal/stats/model.go
+++ b/internal/stats/model.go
@@ -55,6 +55,7 @@ type Summary struct {
 	TotalCacheReadInputTokens     int     `json:"totalCacheReadInputTokens,omitempty"`
 	TotalReasoningTokens          int     `json:"totalReasoningTokens,omitempty"`
 	TotalPremiumRequests          float64 `json:"totalPremiumRequests,omitempty"`
+	TasksDone                     int     `json:"tasksDone"`
 }
 
 // GroupedStat is an aggregate keyed by a dimension (project, mode, etc).

--- a/internal/stats/store.go
+++ b/internal/stats/store.go
@@ -61,10 +61,13 @@ func (s *Store) All() []RunRecord {
 }
 
 func (s *Store) Query() StatsResponse {
+	return s.QueryAt(time.Now())
+}
+
+func (s *Store) QueryAt(now time.Time) StatsResponse {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	now := time.Now()
 	todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 	weekStart := todayStart.AddDate(0, 0, -int(todayStart.Weekday()))
 	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())

--- a/internal/sybra/services.go
+++ b/internal/sybra/services.go
@@ -98,6 +98,7 @@ func (a *App) wireStatsService() {
 	a.statsSvc.stats = a.stats
 	a.statsSvc.limits = a.limits
 	a.statsSvc.projects = a.projects
+	a.statsSvc.tasks = a.tasks
 	a.statsSvc.policy = a.limitPolicy
 }
 

--- a/internal/sybra/svc_stats.go
+++ b/internal/sybra/svc_stats.go
@@ -3,10 +3,12 @@ package sybra
 import (
 	"cmp"
 	"slices"
+	"time"
 
 	"github.com/Automaat/sybra/internal/limits"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/stats"
+	"github.com/Automaat/sybra/internal/task"
 )
 
 // StatsService exposes statistics as Wails-bound methods.
@@ -14,6 +16,7 @@ type StatsService struct {
 	stats    *stats.Store
 	limits   *limits.Store
 	projects *project.Store
+	tasks    *task.Manager
 	policy   func() limits.Policy
 }
 
@@ -24,6 +27,31 @@ func (s *StatsService) GetStats() stats.StatsResponse {
 	}
 	resp := s.stats.Query()
 	resp.ByProjectType = aggregateByProjectType(resp.ByProject, s.projectTypes())
+
+	if s.tasks != nil {
+		if list, err := s.tasks.List(); err == nil {
+			now := time.Now()
+			todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+			weekStart := todayStart.AddDate(0, 0, -int(todayStart.Weekday()))
+			monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+
+			for i := range list {
+				if list[i].Status == task.StatusDone {
+					resp.AllTime.TasksDone++
+					if !list[i].UpdatedAt.Before(todayStart) {
+						resp.Today.TasksDone++
+					}
+					if !list[i].UpdatedAt.Before(weekStart) {
+						resp.ThisWeek.TasksDone++
+					}
+					if !list[i].UpdatedAt.Before(monthStart) {
+						resp.ThisMonth.TasksDone++
+					}
+				}
+			}
+		}
+	}
+
 	if s.limits != nil {
 		policy := limits.DefaultPolicy()
 		if s.policy != nil {

--- a/internal/sybra/svc_stats.go
+++ b/internal/sybra/svc_stats.go
@@ -21,43 +21,47 @@ type StatsService struct {
 	policy   func() limits.Policy
 }
 
+func aggregateTasksDone(resp *stats.StatsResponse, list []task.Task, now time.Time) {
+	todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	weekStart := todayStart.AddDate(0, 0, -int(todayStart.Weekday()))
+	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+
+	for i := range list {
+		if list[i].Status != task.StatusDone {
+			continue
+		}
+
+		resp.AllTime.TasksDone++
+
+		t := list[i].UpdatedAt
+		if list[i].ClosedAt != nil {
+			t = *list[i].ClosedAt
+		}
+
+		if !t.Before(todayStart) {
+			resp.Today.TasksDone++
+		}
+		if !t.Before(weekStart) {
+			resp.ThisWeek.TasksDone++
+		}
+		if !t.Before(monthStart) {
+			resp.ThisMonth.TasksDone++
+		}
+	}
+}
+
 // GetStats returns aggregated agent run statistics.
 func (s *StatsService) GetStats() stats.StatsResponse {
 	if s.stats == nil {
 		return stats.StatsResponse{}
 	}
-	resp := s.stats.Query()
+	now := time.Now()
+	resp := s.stats.QueryAt(now)
 	resp.ByProjectType = aggregateByProjectType(resp.ByProject, s.projectTypes())
 
 	if s.tasks != nil {
 		if list, err := s.tasks.List(); err == nil {
-			now := time.Now()
-			todayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
-			weekStart := todayStart.AddDate(0, 0, -int(todayStart.Weekday()))
-			monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
-
-			for i := range list {
-				if list[i].Status != task.StatusDone {
-					continue
-				}
-
-				resp.AllTime.TasksDone++
-
-				t := list[i].UpdatedAt
-				if list[i].ClosedAt != nil {
-					t = *list[i].ClosedAt
-				}
-
-				if !t.Before(todayStart) {
-					resp.Today.TasksDone++
-				}
-				if !t.Before(weekStart) {
-					resp.ThisWeek.TasksDone++
-				}
-				if !t.Before(monthStart) {
-					resp.ThisMonth.TasksDone++
-				}
-			}
+			aggregateTasksDone(&resp, list, now)
 		} else {
 			slog.Warn("stats: failed to list tasks", "err", err)
 		}

--- a/internal/sybra/svc_stats.go
+++ b/internal/sybra/svc_stats.go
@@ -2,6 +2,7 @@ package sybra
 
 import (
 	"cmp"
+	"log/slog"
 	"slices"
 	"time"
 
@@ -36,19 +37,29 @@ func (s *StatsService) GetStats() stats.StatsResponse {
 			monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
 
 			for i := range list {
-				if list[i].Status == task.StatusDone {
-					resp.AllTime.TasksDone++
-					if !list[i].UpdatedAt.Before(todayStart) {
-						resp.Today.TasksDone++
-					}
-					if !list[i].UpdatedAt.Before(weekStart) {
-						resp.ThisWeek.TasksDone++
-					}
-					if !list[i].UpdatedAt.Before(monthStart) {
-						resp.ThisMonth.TasksDone++
-					}
+				if list[i].Status != task.StatusDone {
+					continue
+				}
+
+				resp.AllTime.TasksDone++
+
+				t := list[i].UpdatedAt
+				if list[i].ClosedAt != nil {
+					t = *list[i].ClosedAt
+				}
+
+				if !t.Before(todayStart) {
+					resp.Today.TasksDone++
+				}
+				if !t.Before(weekStart) {
+					resp.ThisWeek.TasksDone++
+				}
+				if !t.Before(monthStart) {
+					resp.ThisMonth.TasksDone++
 				}
 			}
+		} else {
+			slog.Warn("stats: failed to list tasks", "err", err)
 		}
 	}
 
@@ -116,5 +127,6 @@ func addSummary(a, b stats.Summary) stats.Summary {
 		TotalInputTokens:     a.TotalInputTokens + b.TotalInputTokens,
 		TotalOutputTokens:    a.TotalOutputTokens + b.TotalOutputTokens,
 		TotalReasoningTokens: a.TotalReasoningTokens + b.TotalReasoningTokens,
+		TasksDone:            a.TasksDone + b.TasksDone,
 	}
 }

--- a/internal/sybra/svc_stats_test.go
+++ b/internal/sybra/svc_stats_test.go
@@ -3,9 +3,57 @@ package sybra
 import (
 	"math"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/stats"
+	"github.com/Automaat/sybra/internal/task"
 )
+
+func TestAggregateTasksDone(t *testing.T) {
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC) // A Monday
+
+	t1Time := now.Add(-1 * time.Hour)       // Today
+	t2Time := now.Add(-2 * 24 * time.Hour)  // Last week (Saturday)
+	t3Time := now.Add(-5 * 24 * time.Hour)  // Last week (Wednesday)
+	t4Time := now.Add(-20 * 24 * time.Hour) // Last month
+	t5Time := now.AddDate(0, -2, 0)         // A long time ago
+
+	list := []task.Task{
+		{Status: task.StatusDone, UpdatedAt: t1Time},
+		{Status: task.StatusDone, UpdatedAt: t2Time}, // closed at will be set
+		{Status: task.StatusDone, UpdatedAt: t3Time},
+		{Status: task.StatusDone, UpdatedAt: t4Time},
+		{Status: task.StatusDone, UpdatedAt: t5Time},
+		{Status: task.StatusInProgress, UpdatedAt: now}, // Ignored
+	}
+
+	// Make t2 ClosedAt be today, to test ClosedAt taking precedence over UpdatedAt
+	t2ClosedAt := now.Add(-2 * time.Hour)
+	list[1].ClosedAt = &t2ClosedAt
+
+	var resp stats.StatsResponse
+	aggregateTasksDone(&resp, list, now)
+
+	// AllTime: 5 done tasks
+	if resp.AllTime.TasksDone != 5 {
+		t.Errorf("AllTime: got %d, want 5", resp.AllTime.TasksDone)
+	}
+
+	// Today: t1 and t2
+	if resp.Today.TasksDone != 2 {
+		t.Errorf("Today: got %d, want 2", resp.Today.TasksDone)
+	}
+
+	// ThisWeek (since June 14, Sunday): t1, t2
+	if resp.ThisWeek.TasksDone != 2 {
+		t.Errorf("ThisWeek: got %d, want 2", resp.ThisWeek.TasksDone)
+	}
+
+	// ThisMonth (since June 1): t1, t2, t3
+	if resp.ThisMonth.TasksDone != 3 {
+		t.Errorf("ThisMonth: got %d, want 3", resp.ThisMonth.TasksDone)
+	}
+}
 
 func TestAggregateByProjectType(t *testing.T) {
 	byProject := []stats.GroupedStat{


### PR DESCRIPTION
## Motivation

The stats view lacked visibility into completed work. Users had no way to see how many tasks were finished within the selected time window at a glance, making it hard to gauge throughput.

## Implementation information

- Added `TasksDone int` field to the `Stats` backend model (`internal/stats/model.go`)
- Computed `TasksDone` in `StatsService` by counting tasks with `status: done` whose `updated_at` falls within the requested time window; uses `Store.List` since done-tasks do not emit discrete agent runs
- Exposed the field via the auto-generated Wails v3 bindings (`frontend/bindings/.../stats/models.ts`)
- Added a sixth summary card in `Stats.svelte` rendering the new metric alongside existing cards (runs, cost, tokens, etc.)

> Changelog: feat(ui): add tasks done card to stats view