### PR TITLE
fix(testing): require manual evidence

### DIFF
--- a/.sybra.yaml
+++ b/.sybra.yaml
@@ -10,6 +10,16 @@ setup:
   - mise install
   - (cd frontend && npm ci)
 
+# Black-box testing guidance for the testing workflow. Test-runners must prefer
+# this runnable surface over static inspection: start the server, wait for
+# health, then drive at least one user/operator-facing probe.
+manual_test:
+  kind: server
+  command: PORT=${SYBRA_MANUAL_TEST_PORT:-$((49152 + RANDOM % 10000))}; printf '%s\n' "$PORT" > .sybra-manual-test-port; SYBRA_PORT=$PORT go run ./cmd/sybra-server
+  health_url: http://127.0.0.1:<port from .sybra-manual-test-port>/health
+  probe_commands:
+    - PORT=$(cat .sybra-manual-test-port); curl -fsS "http://127.0.0.1:${PORT}/health"
+
 # Git hooks installed by sybra into every worktree on creation.
 #
 # Every command is routed through `mise exec --` so the hook resolves tools

--- a/.sybra.yaml
+++ b/.sybra.yaml
@@ -15,8 +15,8 @@ setup:
 # health, then drive at least one user/operator-facing probe.
 manual_test:
   kind: server
-  command: PORT=${SYBRA_MANUAL_TEST_PORT:-$((49152 + RANDOM % 10000))}; printf '%s\n' "$PORT" > .sybra-manual-test-port; SYBRA_PORT=$PORT go run ./cmd/sybra-server
-  health_url: http://127.0.0.1:<port from .sybra-manual-test-port>/health
+  command: export SYBRA_PORT=${SYBRA_MANUAL_TEST_PORT:-$((49152 + RANDOM % 10000))}; printf '%s\n' "$SYBRA_PORT" > .sybra-manual-test-port; go run ./cmd/sybra-server
+  health_url: http://127.0.0.1:$SYBRA_PORT/health
   probe_commands:
     - PORT=$(cat .sybra-manual-test-port); curl -fsS "http://127.0.0.1:${PORT}/health"
 

--- a/cmd/fake-claude/main.go
+++ b/cmd/fake-claude/main.go
@@ -164,7 +164,7 @@ func runEvaluate(taskID string) {
 func runTestPass() {
 	emitSystem()
 	emitAssistant("Ran the app; every case matched the task.")
-	emitResult("Could not break it.\nTEST_VERDICT: PASS")
+	emitResult(testPassReport() + "\nTEST_VERDICT: PASS")
 }
 
 func runTestFail() {
@@ -183,6 +183,19 @@ func testFailureReport() string {
 		"Code evidence:\n```text\ninternal/fake.go:42: return \"wrong output\"\n```"
 }
 
+func testPassReport() string {
+	return "surface_kind: server\n" +
+		"app_started: true\n" +
+		"start_command: go run ./cmd/test-server\n" +
+		"readiness_probe: curl /status\n" +
+		"manual_probes:\n" +
+		"command: curl /status\n" +
+		"expected: expected output\n" +
+		"actual: expected output\n" +
+		"automated_checks: go test ./internal/sybra => ok\n" +
+		"unable_to_run_reason:"
+}
+
 // runTestPassVerbose emits a >2000-char summary BEFORE the final-line verdict,
 // reproducing a thorough tester's output. The step-output var is truncated to
 // 2000 bytes (prefix), so this guards that the engine extracts the verdict from
@@ -191,7 +204,7 @@ func runTestPassVerbose() {
 	emitSystem()
 	emitAssistant("Exercising every angle...")
 	long := strings.Repeat("Exercised an edge case and the feature held as the task requires. ", 50)
-	emitResult(long + "\nTEST_VERDICT: PASS")
+	emitResult(long + "\n" + testPassReport() + "\nTEST_VERDICT: PASS")
 }
 
 // runInteractiveImplement emits a full implement result then blocks on stdin

--- a/cmd/fake-codex/main.go
+++ b/cmd/fake-codex/main.go
@@ -98,12 +98,9 @@ func runExec() {
 		})
 		os.Exit(1)
 	case "test_verdict_pass":
-		emitAgentMessage(`{"verdict":"PASS"}`)
-		emitTurnCompleted(100, 20)
+		runCodexTestVerdictPass()
 	case "test_verdict_fail":
-		writeTestFailureReport(taskID)
-		emitAgentMessage(`{"verdict":"FAIL"}`)
-		emitTurnCompleted(100, 20)
+		runCodexTestVerdictFail()
 	case "implement", "interactive_implement":
 		emitAgentMessage("Implementing...")
 		emitTurnCompleted(100, 20)
@@ -123,6 +120,46 @@ func runExec() {
 		fmt.Fprintf(os.Stderr, "unknown scenario: %s\n", scenario)
 		os.Exit(2)
 	}
+}
+
+func runCodexTestVerdictPass() {
+	emitAgentMessage(mustJSON(map[string]any{
+		"verdict":           "PASS",
+		"outcome":           "pass",
+		"failures_markdown": "",
+		"surface_kind":      "cli",
+		"app_started":       true,
+		"start_command":     "sybra-cli --json list",
+		"readiness_probe":   "sybra-cli --json list",
+		"manual_probes": []map[string]string{{
+			"command":  "sybra-cli --json list",
+			"expected": "returns JSON task list",
+			"actual":   "[]",
+		}},
+		"automated_checks":     []map[string]string{},
+		"unable_to_run_reason": "",
+	}))
+	emitTurnCompleted(100, 20)
+}
+
+func runCodexTestVerdictFail() {
+	emitAgentMessage(mustJSON(map[string]any{
+		"verdict":           "FAIL",
+		"outcome":           "product_bug",
+		"failures_markdown": testFailureReport(),
+		"surface_kind":      "server",
+		"app_started":       true,
+		"start_command":     "go run ./cmd/test-server",
+		"readiness_probe":   "curl /status",
+		"manual_probes": []map[string]string{{
+			"command":  "curl /status",
+			"expected": "expected output",
+			"actual":   "wrong output",
+		}},
+		"automated_checks":     []map[string]string{},
+		"unable_to_run_reason": "",
+	}))
+	emitTurnCompleted(100, 20)
 }
 
 func runCodexMalformedPR() {
@@ -337,13 +374,20 @@ func runCLI(taskID, subcmd string, args ...string) {
 	}
 }
 
-func writeTestFailureReport(taskID string) {
-	body := "## Test Failures\n\n" +
+func mustJSON(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+func testFailureReport() string {
+	return "## Test Failures\n\n" +
 		"Classification: product_bug\n\n" +
 		"Requirement tested: the task says the happy path should render the expected output.\n\n" +
 		"Command run:\n```sh\ncurl /status\n```\n\n" +
 		"Actual output:\n```text\nwrong output\n```\n\n" +
 		"Expected output: expected output.\n\n" +
 		"Code evidence:\n```text\ninternal/fake.go:42: return \"wrong output\"\n```"
-	runCLI(taskID, "update", taskID, "--body", body)
 }

--- a/frontend/bindings/github.com/Automaat/sybra/internal/project/index.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/project/index.ts
@@ -3,6 +3,8 @@
 
 export {
     ChecksConfig,
+    ManualTestConfig,
+    ManualTestKind,
     Project,
     ProjectStatus,
     ProjectType,

--- a/frontend/bindings/github.com/Automaat/sybra/internal/project/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/project/models.ts
@@ -53,6 +53,52 @@ export class ChecksConfig {
     }
 }
 
+/**
+ * ManualTestConfig is repo-declared black-box testing guidance from .sybra.yaml.
+ * Commands execute in the worktree root when a test-runner chooses to use them.
+ */
+export class ManualTestConfig {
+    "kind"?: ManualTestKind;
+    "command"?: string;
+    "healthUrl"?: string;
+    "probeCommands"?: string[];
+
+    /** Creates a new ManualTestConfig instance. */
+    constructor($$source: Partial<ManualTestConfig> = {}) {
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new ManualTestConfig instance from a string or object.
+     */
+    static createFrom($$source: any = {}): ManualTestConfig {
+        const $$createField3_0 = $$createType0;
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        if ("probeCommands" in $$parsedSource) {
+            $$parsedSource["probeCommands"] = $$createField3_0($$parsedSource["probeCommands"]);
+        }
+        return new ManualTestConfig($$parsedSource as Partial<ManualTestConfig>);
+    }
+}
+
+/**
+ * ManualTestKind identifies the runnable surface a test-runner should drive.
+ */
+export enum ManualTestKind {
+    /**
+     * The Go zero value for the underlying type of the enum.
+     */
+    $zero = "",
+
+    ManualTestKindWeb = "web",
+    ManualTestKindCLI = "cli",
+    ManualTestKindServer = "server",
+    ManualTestKindDesktop = "desktop",
+    ManualTestKindK8s = "k8s",
+    ManualTestKindLibrary = "library",
+};
+
 export class Project {
     "id": string;
     "name": string;
@@ -70,6 +116,7 @@ export class Project {
     "setupCommands"?: string[];
     "sandbox"?: SandboxConfig | null;
     "checks"?: ChecksConfig | null;
+    "manualTest"?: ManualTestConfig | null;
 
     /**
      * WorktreeBaseRef controls the starting point for new worktree branches.
@@ -123,6 +170,7 @@ export class Project {
         const $$createField8_0 = $$createType0;
         const $$createField9_0 = $$createType2;
         const $$createField10_0 = $$createType4;
+        const $$createField11_0 = $$createType6;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("setupCommands" in $$parsedSource) {
             $$parsedSource["setupCommands"] = $$createField8_0($$parsedSource["setupCommands"]);
@@ -132,6 +180,9 @@ export class Project {
         }
         if ("checks" in $$parsedSource) {
             $$parsedSource["checks"] = $$createField10_0($$parsedSource["checks"]);
+        }
+        if ("manualTest" in $$parsedSource) {
+            $$parsedSource["manualTest"] = $$createField11_0($$parsedSource["manualTest"]);
         }
         return new Project($$parsedSource as Partial<Project>);
     }
@@ -217,7 +268,7 @@ export class SandboxConfig {
      */
     static createFrom($$source: any = {}): SandboxConfig {
         const $$createField2_0 = $$createType0;
-        const $$createField6_0 = $$createType5;
+        const $$createField6_0 = $$createType7;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("with" in $$parsedSource) {
             $$parsedSource["with"] = $$createField2_0($$parsedSource["with"]);
@@ -268,4 +319,6 @@ const $$createType1 = SandboxConfig.createFrom;
 const $$createType2 = $Create.Nullable($$createType1);
 const $$createType3 = ChecksConfig.createFrom;
 const $$createType4 = $Create.Nullable($$createType3);
-const $$createType5 = $Create.Map($Create.Any, $Create.Any);
+const $$createType5 = ManualTestConfig.createFrom;
+const $$createType6 = $Create.Nullable($$createType5);
+const $$createType7 = $Create.Map($Create.Any, $Create.Any);

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -686,6 +686,7 @@ func TestLoadRepoConfig_SetupBlock(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, ".sybra.yaml"), []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
+
 	cfg, err := LoadRepoConfig(dir)
 	if err != nil {
 		t.Fatalf("LoadRepoConfig: %v", err)
@@ -702,6 +703,38 @@ func TestLoadRepoConfig_SetupBlock(t *testing.T) {
 	// Sanity: checks block still parses when setup is present.
 	if cfg.Checks == nil || len(cfg.Checks.PreCommit) != 1 {
 		t.Errorf("checks dropped when setup added: %+v", cfg.Checks)
+	}
+}
+
+func TestLoadRepoConfig_ManualTestBlock(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	content := `manual_test:
+  kind: server
+  command: SYBRA_PORT=0 go run ./cmd/sybra-server
+  health_url: http://127.0.0.1:$SYBRA_PORT/health
+  probe_commands:
+    - curl -fsS http://127.0.0.1:$SYBRA_PORT/api/tasks
+    - sybra-cli --json list
+`
+	if err := os.WriteFile(filepath.Join(dir, ".sybra.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadRepoConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadRepoConfig: %v", err)
+	}
+	if cfg.ManualTest == nil {
+		t.Fatal("ManualTest is nil")
+	}
+	if cfg.ManualTest.Kind != ManualTestKindServer {
+		t.Errorf("ManualTest.Kind = %q, want %q", cfg.ManualTest.Kind, ManualTestKindServer)
+	}
+	if cfg.ManualTest.Command == "" || cfg.ManualTest.HealthURL == "" {
+		t.Fatalf("ManualTest command/health missing: %+v", cfg.ManualTest)
+	}
+	if len(cfg.ManualTest.ProbeCommands) != 2 {
+		t.Fatalf("ProbeCommands len = %d, want 2", len(cfg.ManualTest.ProbeCommands))
 	}
 }
 
@@ -737,6 +770,18 @@ func TestMergeSetup(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestMergeManualTest(t *testing.T) {
+	t.Parallel()
+	app := &ManualTestConfig{Kind: ManualTestKindCLI, Command: "sybra-cli list"}
+	repo := &ManualTestConfig{Kind: ManualTestKindServer, Command: "go run ./cmd/sybra-server"}
+	if got := MergeManualTest(nil, app); got != app {
+		t.Fatalf("MergeManualTest(nil, app) = %+v, want app", got)
+	}
+	if got := MergeManualTest(repo, app); got != repo {
+		t.Fatalf("MergeManualTest(repo, app) = %+v, want repo", got)
 	}
 }
 

--- a/internal/project/model.go
+++ b/internal/project/model.go
@@ -31,6 +31,30 @@ type RepoConfig struct {
 	// this project gets identical bootstrap (tool installs, dependency fetches)
 	// without per-instance UI toil.
 	Setup []string `yaml:"setup,omitempty" json:"setup,omitempty"`
+	// ManualTest tells the testing workflow how this project can be exercised
+	// through a user/operator-facing surface instead of only via unit tests.
+	ManualTest *ManualTestConfig `yaml:"manual_test,omitempty" json:"manualTest,omitempty"`
+}
+
+// ManualTestKind identifies the runnable surface a test-runner should drive.
+type ManualTestKind string
+
+const (
+	ManualTestKindWeb     ManualTestKind = "web"
+	ManualTestKindCLI     ManualTestKind = "cli"
+	ManualTestKindServer  ManualTestKind = "server"
+	ManualTestKindDesktop ManualTestKind = "desktop"
+	ManualTestKindK8s     ManualTestKind = "k8s"
+	ManualTestKindLibrary ManualTestKind = "library"
+)
+
+// ManualTestConfig is repo-declared black-box testing guidance from .sybra.yaml.
+// Commands execute in the worktree root when a test-runner chooses to use them.
+type ManualTestConfig struct {
+	Kind          ManualTestKind `yaml:"kind,omitempty" json:"kind,omitempty"`
+	Command       string         `yaml:"command,omitempty" json:"command,omitempty"`
+	HealthURL     string         `yaml:"health_url,omitempty" json:"healthUrl,omitempty"`
+	ProbeCommands []string       `yaml:"probe_commands,omitempty" json:"probeCommands,omitempty"`
 }
 
 // MergeSetup combines repo-declared setup (.sybra.yaml) with app-level setup
@@ -76,6 +100,15 @@ func MergeChecks(repo, app *ChecksConfig) *ChecksConfig {
 		return nil
 	}
 	return out
+}
+
+// MergeManualTest returns repo-declared manual-test guidance when present,
+// falling back to machine-local project config.
+func MergeManualTest(repo, app *ManualTestConfig) *ManualTestConfig {
+	if repo != nil {
+		return repo
+	}
+	return app
 }
 
 // SandboxConfig describes how to spin up an isolated app environment for a task.
@@ -140,10 +173,11 @@ type Project struct {
 	Type      ProjectType `yaml:"type" json:"type"`
 	// Status reflects the clone lifecycle. Empty value is treated as ready
 	// so existing projects without this field continue to work.
-	Status        ProjectStatus  `yaml:"status,omitempty" json:"status"`
-	SetupCommands []string       `yaml:"setup_commands,omitempty" json:"setupCommands,omitempty"`
-	Sandbox       *SandboxConfig `yaml:"sandbox,omitempty" json:"sandbox,omitempty"`
-	Checks        *ChecksConfig  `yaml:"checks,omitempty"  json:"checks,omitempty"`
+	Status        ProjectStatus     `yaml:"status,omitempty" json:"status"`
+	SetupCommands []string          `yaml:"setup_commands,omitempty" json:"setupCommands,omitempty"`
+	Sandbox       *SandboxConfig    `yaml:"sandbox,omitempty" json:"sandbox,omitempty"`
+	Checks        *ChecksConfig     `yaml:"checks,omitempty"  json:"checks,omitempty"`
+	ManualTest    *ManualTestConfig `yaml:"manual_test,omitempty" json:"manualTest,omitempty"`
 	// WorktreeBaseRef controls the starting point for new worktree branches.
 	// "fresh" (default) branches off origin/<default>; "head" branches off the
 	// local HEAD so unpushed commits are included. Empty value treated as "fresh".

--- a/internal/skills/data/sybra-test.md
+++ b/internal/skills/data/sybra-test.md
@@ -15,11 +15,21 @@ You run headless, inside the task's own git worktree, with no human in the loop.
 
 ## Output contract (required)
 
-If your runtime enforces a JSON output schema, return a JSON object with
-`verdict` (`PASS` or `FAIL`), optional `outcome`, and on FAIL a
-`failures_markdown` string containing the full `## Test Failures` report.
+Prefer a single JSON object as your final response. If your runtime enforces a
+JSON output schema, that JSON object is mandatory. Return fields
+`verdict` (`PASS` or `FAIL`), `outcome` (`pass`, `product_bug`,
+`infra_failure`, `ambiguous_requirement`, or `missing_evidence`), and
+`failures_markdown`. Also include black-box evidence fields:
+`surface_kind`, `app_started`, `start_command`, `readiness_probe`,
+`manual_probes`, `automated_checks`, and `unable_to_run_reason`. On PASS, set
+`outcome` to `pass` and `failures_markdown` to an empty string. On FAIL,
+`failures_markdown` must contain the full `## Test Failures` report.
 
-Otherwise, the **final line** of your output MUST be exactly one of:
+If you cannot return JSON, a plain-text PASS must include the same evidence
+labels: `surface_kind`, `app_started`, `start_command`, `readiness_probe`,
+`manual_probes`, `automated_checks`, and `unable_to_run_reason`; otherwise the
+workflow treats it as a tester protocol failure. The **final line** of
+plain-text output MUST be exactly one of:
 
 ```
 TEST_VERDICT: PASS
@@ -40,14 +50,27 @@ In `## Test Failures` record, per defect: what you did (exact steps/commands), w
 
 1. **Derive acceptance criteria — from the task, not your imagination.** Read the task (`sybra-cli get <task-id>`) and its PR/diff if present. Write down, concretely, what "works" means: every behaviour the description promises, plus the narrowly-implicit ones (errors handled, nothing the change touched regressed). **Do not invent requirements the task never stated** — legacy/back-compat behaviour, APIs the task did not promise, a stricter contract than asked. Failing the implementation on an unstated requirement escalates correct work to a human. If the task's own stated requirements contradict each other or are too under-specified to verify, that is a spec problem, not an implementation defect: record it as such (see Rules) rather than manufacturing a failing case. Existing `## Test Failures` sections are historical context only: reproduce them against the CURRENT worktree before counting them; if the current code no longer exhibits that behavior, ignore the stale report instead of emitting FAIL.
 
-2. **Figure out how to run it.** You decide — inspect the repo: `README`, `.sybra.yaml` (`setup:`/run hints), `mise tasks ls`, `package.json` scripts, `Makefile`, `docker-compose*.yml`, `cmd/`. Pick the smallest way to exercise the changed surface for real.
+2. **Figure out how to run it.** You decide — inspect the repo: `README`, `.sybra.yaml` (`setup:`/`manual_test:`/run hints), `mise tasks ls`, `package.json` scripts, `Makefile`, `docker-compose*.yml`, `cmd/`. Pick the smallest way to exercise the changed surface for real. If `.sybra.yaml` has `manual_test`, prefer its `kind`, `command`, `health_url`, and `probe_commands` unless the task scope clearly makes that surface irrelevant.
 
-3. **Use the isolated sandbox.** If `SANDBOX_URL` and/or `KUBECONFIG` are set in your environment, an isolated per-task sandbox is already running — drive the app through `SANDBOX_URL`, or the cluster via `kubectl --kubeconfig "$KUBECONFIG"`. If you must start something yourself:
+3. **Manual testing is mandatory by default.** Before PASS, run at least one product-level probe that a user/operator would recognize:
+   - Web/server: start the app/server and hit it with `curl`, browser/devtools, or an equivalent HTTP client.
+   - CLI/workflow: run the real CLI/workflow command in an isolated temp home/project and inspect stdout/stderr/state changes.
+   - K8s/cluster: use `kubectl` against the sandbox, port-forward when needed, and inspect resources/logs.
+   - Desktop/GUI: drive the headless HTTP/server equivalent; use browser/computer-use tooling when available.
+   Automated tests, lint, builds, diff review, and source grep are useful support evidence, but they **do not count as manual testing by themselves**.
+
+   **Exception:** for pure refactors, internal-library changes, docs-only work, or changes with no runnable product surface, do not force an app start. Instead, state the exception in your final PASS summary and run the strongest behavioral regression evidence available: a CLI/test harness probe (for example `go test`, package tests, `npm run check`, or the real CLI command) plus grep/invariant probes when useful for sweep wording like "everywhere", "all", "single utility", or "no raw X remains". Static review or grep alone is not enough. If you cannot justify the exception from the task scope, missing manual testing is `missing_evidence` → FAIL.
+
+   If manual testing is impossible, say exactly why in your response. In JSON
+   output, put the reason in `unable_to_run_reason`; in plain-text output, add
+   `Unable to run manual test: <reason>`.
+
+4. **Use the isolated sandbox.** If `SANDBOX_URL` and/or `KUBECONFIG` are set in your environment, an isolated per-task sandbox is already running — drive the app through `SANDBOX_URL`, or the cluster via `kubectl --kubeconfig "$KUBECONFIG"`. If you must start something yourself:
    - Bind **only ephemeral/dynamic ports** (`:0` or a high random port). Never a fixed well-known port — other test agents run in parallel on this machine.
    - Namespace anything global by the task id.
    - **Tear down** every process/container/cluster you start before exiting (trap/defer). Leaks starve the next agent.
 
-4. **Attack across all angles** (aim for thorough, not one path):
+5. **Attack across all angles** (aim for thorough, not one path):
    - **Happy path** — the primary flow from the task, end to end.
    - **Edge cases** — empty/missing input, max/min/boundary values, unicode, very large input, concurrent/repeated calls, re-entrancy.
    - **Negative/abuse** — invalid input, wrong order of operations, missing prerequisites, permission/auth gaps. Expect graceful failure, not a crash.
@@ -55,18 +78,19 @@ In `## Test Failures` record, per defect: what you did (exact steps/commands), w
    Keep every angle anchored to a requirement the task actually states or directly implies — stress those edges hard, but don't fail the build on a requirement you wish the task had.
    For breadth you MAY fan out parallel explorations with the Agent tool, but converge to one verdict yourself.
 
-5. **Use real oracles.** Compare observed vs the task's stated intent. HTTP: assert status + body via `curl "$SANDBOX_URL/..."`. K8s: `kubectl get/logs/describe`, port-forward + curl. CLI: run it, check exit code + stdout/stderr. Desktop/GUI apps that can't run headless (e.g. the Sybra Wails app itself): test the equivalent HTTP server surface (`cmd/*-server`, started in the sandbox) instead.
+6. **Use real oracles.** Compare observed vs the task's stated intent. HTTP: assert status + body via `curl "$SANDBOX_URL/..."`. K8s: `kubectl get/logs/describe`, port-forward + curl. CLI: run it, check exit code + stdout/stderr. Desktop/GUI apps that can't run headless (e.g. the Sybra Wails app itself): test the equivalent HTTP server surface (`cmd/*-server`, started in the sandbox) instead.
 
-6. **Ground every claimed defect before writing about it.** For each behavior you believe deviates from the task:
+7. **Ground every claimed defect before writing about it.** For each behavior you believe deviates from the task:
    - **Execution evidence** (mandatory): you ran a command and captured its actual output. Paste it verbatim. If you cannot produce real command output, you cannot include this defect — write "unable to reproduce: could not start X because Y" instead.
    - **Code evidence** (when claiming a specific code bug): use `Read`/`Grep`/`cat` to find and quote the **current** source line(s) in the working tree. Never rely on a remembered diff or a prior read. If the actual current line contradicts your claim, your claim is wrong — omit it.
    Exclude any defect that fails either check. Ungrounded claims are not defects; they are hallucinations.
 
-7. **Decide.** Any deviation from the acceptance criteria → write `## Test Failures` and emit `TEST_VERDICT: FAIL`. Genuinely nothing broken after a real, multi-angle attempt → `TEST_VERDICT: PASS`.
+8. **Decide.** Any deviation from the acceptance criteria → write `## Test Failures` and emit `TEST_VERDICT: FAIL` or JSON `verdict: "FAIL"`. Genuinely nothing broken after a real, multi-angle attempt with manual testing evidence (or a justified refactor/library exception) → JSON `verdict: "PASS"` with `outcome: "pass"` and empty `failures_markdown`, or a plain-text `TEST_VERDICT: PASS` with the evidence labels above.
 
 ## Rules
 
 - **Execute, don't plan.** No test-plan document, no human approval step. You run the real software.
+- **PASS requires manual evidence.** A PASS without a product-level probe, or without a justified refactor/library/no-surface exception plus regression evidence, is invalid.
 - **No fix suggestions.** Never write "the fix is", "you should", "consider", "try", "I recommend", "change X to Y", "switch X to Y", "replace X with Y", "use X instead of Y", or anything that prescribes a code change. Report what you observed — not what would resolve it. The implementer diagnoses from symptoms; you provide the symptoms. Violations are detected mechanically.
 - **No static-analysis FAILs.** Reading the code is allowed for orientation, but it is not a substitute for running the app. Every claimed defect requires real execution evidence (a command run + its actual output). If the feature cannot be run, note that explicitly and emit FAIL — but do not fabricate a defect from static reading or remembered diffs.
 - **Be conservative.** When you cannot actually verify a claim — because you could not run the app, could not find the relevant code, or the behavior was ambiguous — that is a FAIL, not a PASS. Emit FAIL and explain what you could not verify.

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -460,6 +460,7 @@ func (a *App) initWorkflowEngine() {
 	a.workflowEngine.SetPRReviewRequester(prReviewRequesterAdapter{})
 	a.workflowEngine.SetWorktreeGetter(&worktreeGetterAdapter{tasks: a.tasks, mgr: a.worktrees})
 	a.workflowEngine.SetCheckConfigGetter(&checkConfigGetterAdapter{tasks: a.tasks, projects: a.projects, mgr: a.worktrees})
+	a.workflowEngine.SetManualTestConfigGetter(&manualTestConfigGetterAdapter{tasks: a.tasks, projects: a.projects, mgr: a.worktrees})
 	a.workflowEngine.SetTestingMaxAttempts(a.cfg.TestingMaxAttempts())
 	a.workflowEngine.SetABTestingConfig(a.cfg.ABTesting)
 	if a.artifacts != nil {

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -19,13 +19,14 @@ import (
 
 // Compile-time interface checks.
 var (
-	_ workflow.TaskProvider      = (*taskAdapter)(nil)
-	_ workflow.AgentLauncher     = (*agentAdapter)(nil)
-	_ workflow.PRLinker          = (*prLinkerAdapter)(nil)
-	_ workflow.PRReviewRequester = (*prReviewRequesterAdapter)(nil)
-	_ workflow.WorktreeGetter    = (*worktreeGetterAdapter)(nil)
-	_ workflow.CheckConfigGetter = (*checkConfigGetterAdapter)(nil)
-	_ workflow.ArtifactRecorder  = (*artifactRecorderAdapter)(nil)
+	_ workflow.TaskProvider           = (*taskAdapter)(nil)
+	_ workflow.AgentLauncher          = (*agentAdapter)(nil)
+	_ workflow.PRLinker               = (*prLinkerAdapter)(nil)
+	_ workflow.PRReviewRequester      = (*prReviewRequesterAdapter)(nil)
+	_ workflow.WorktreeGetter         = (*worktreeGetterAdapter)(nil)
+	_ workflow.CheckConfigGetter      = (*checkConfigGetterAdapter)(nil)
+	_ workflow.ManualTestConfigGetter = (*manualTestConfigGetterAdapter)(nil)
+	_ workflow.ArtifactRecorder       = (*artifactRecorderAdapter)(nil)
 )
 
 // artifactRecorderAdapter bridges artifact.Store → workflow.ArtifactRecorder.
@@ -295,6 +296,47 @@ type checkConfigGetterAdapter struct {
 	tasks    *task.Manager
 	projects *project.Store
 	mgr      *worktree.Manager
+}
+
+// manualTestConfigGetterAdapter resolves repo .sybra.yaml manual_test hints.
+type manualTestConfigGetterAdapter struct {
+	tasks    *task.Manager
+	projects *project.Store
+	mgr      *worktree.Manager
+}
+
+func (a *manualTestConfigGetterAdapter) ManualTestConfig(taskID string) workflow.ManualTestInfo {
+	t, err := a.tasks.Get(taskID)
+	if err != nil {
+		return workflow.ManualTestInfo{}
+	}
+
+	var repoManual *project.ManualTestConfig
+	if a.mgr != nil {
+		wtPath := a.mgr.PathFor(t)
+		if _, statErr := os.Stat(wtPath); statErr == nil {
+			if repoCfg, rErr := project.LoadRepoConfig(wtPath); rErr == nil && repoCfg != nil {
+				repoManual = repoCfg.ManualTest
+			}
+		}
+	}
+
+	var appManual *project.ManualTestConfig
+	if t.ProjectID != "" && a.projects != nil {
+		if p, pErr := a.projects.Get(t.ProjectID); pErr == nil {
+			appManual = p.ManualTest
+		}
+	}
+	manual := project.MergeManualTest(repoManual, appManual)
+	if manual == nil {
+		return workflow.ManualTestInfo{}
+	}
+	return workflow.ManualTestInfo{
+		Kind:          string(manual.Kind),
+		Command:       manual.Command,
+		HealthURL:     manual.HealthURL,
+		ProbeCommands: manual.ProbeCommands,
+	}
 }
 
 func (a *checkConfigGetterAdapter) VerifyCommands(taskID string) []string {

--- a/internal/sybra/app_workflow_test.go
+++ b/internal/sybra/app_workflow_test.go
@@ -1,6 +1,14 @@
 package sybra
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/worktree"
+)
 
 func TestEligibleRerequestReviewer(t *testing.T) {
 	tests := []struct {
@@ -27,5 +35,53 @@ func TestEligibleRerequestReviewer(t *testing.T) {
 					tt.login, tt.viewer, tt.author, got, tt.expected)
 			}
 		})
+	}
+}
+
+func TestManualTestConfigGetterFallsBackToProjectConfigWithoutWorktree(t *testing.T) {
+	t.Parallel()
+
+	taskStore, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskMgr := task.NewManager(taskStore, nil)
+	created, err := taskMgr.Create("exercise manual test config", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectID := "owner/repo"
+	if _, err := taskMgr.Update(created.ID, task.Update{ProjectID: &projectID}); err != nil {
+		t.Fatal(err)
+	}
+
+	projectsDir := t.TempDir()
+	projects, err := project.NewStore(projectsDir, t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectYAML := `id: owner/repo
+name: repo
+owner: owner
+repo: repo
+url: https://github.com/owner/repo
+clone_path: /tmp/repo.git
+type: pet
+manual_test:
+  kind: cli
+  command: sybra-cli --json list
+`
+	if err := os.WriteFile(filepath.Join(projectsDir, "owner--repo.yaml"), []byte(projectYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	getter := &manualTestConfigGetterAdapter{
+		tasks:    taskMgr,
+		projects: projects,
+		mgr:      worktree.New(worktree.Config{WorktreesDir: t.TempDir(), Tasks: taskMgr, Logger: discardLogger()}),
+	}
+	got := getter.ManualTestConfig(created.ID)
+	if got.Kind != "cli" || got.Command != "sybra-cli --json list" {
+		t.Fatalf("ManualTestConfig = %+v, want project-level cli config", got)
 	}
 }

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -1809,9 +1809,8 @@ func TestE2E_DispatchPREvent_ReadyToMerge(t *testing.T) {
 }
 
 // testTestingTaskWorkflowYAML mirrors the real builtin testing-task.yaml
-// shape (id, trigger, run_test → route_test_result graph) but omits the
-// notest short-circuit so the core verdict-routing is deterministic on CI.
-// The real builtin's YAML is exercised by internal/workflow/builtin_test.go.
+// shape (id, trigger, run_test → route_test_result graph). The real builtin's
+// YAML is exercised by internal/workflow/builtin_test.go.
 const testTestingTaskWorkflowYAML = `id: testing-task
 name: Test Manual Testing
 trigger:
@@ -2046,7 +2045,7 @@ steps:
       role: test-runner
       mode: headless
       model: sonnet
-      output_schema: '{"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]}},"required":["verdict"],"additionalProperties":false}'
+      output_schema: '{"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]},"outcome":{"type":"string","enum":["pass","product_bug","infra_failure","ambiguous_requirement","missing_evidence"]},"failures_markdown":{"type":"string"},"surface_kind":{"type":"string","enum":["web","cli","server","desktop","k8s","library","docs","none"]},"app_started":{"type":"boolean"},"start_command":{"type":"string"},"readiness_probe":{"type":"string"},"manual_probes":{"type":"array","items":{"type":"object","properties":{"command":{"type":"string"},"expected":{"type":"string"},"actual":{"type":"string"}},"required":["command","expected","actual"],"additionalProperties":false}},"automated_checks":{"type":"array","items":{"type":"object","properties":{"command":{"type":"string"},"actual":{"type":"string"}},"required":["command","actual"],"additionalProperties":false}},"unable_to_run_reason":{"type":"string"}},"required":["verdict","outcome","failures_markdown","surface_kind","app_started","start_command","readiness_probe","manual_probes","automated_checks","unable_to_run_reason"],"additionalProperties":false}'
       prompt: 'Test {{.Task.ID}}'
     next:
       - goto: route_test

--- a/internal/workflow/builtin/simple-task-review.yaml
+++ b/internal/workflow/builtin/simple-task-review.yaml
@@ -192,8 +192,8 @@ steps:
 
   # Hand the reviewed (and fixed) branch to the testing phase. The PR is NOT
   # created here — testing-task validates the feature first, then simple-task-pr
-  # opens the PR only once tests pass. A task tagged `notest` short-circuits
-  # the testing-task workflow straight to ready-pr.
+  # opens the PR only once tests pass. A task tagged `notest` may skip app
+  # startup, but still needs CLI/test-harness evidence before PASS.
   - id: done_review
     name: Hand to Testing
     type: set_status

--- a/internal/workflow/builtin/testing-task.yaml
+++ b/internal/workflow/builtin/testing-task.yaml
@@ -14,27 +14,13 @@ trigger:
       operator: equals
       value: testing
 steps:
-  # Escape hatch: a task tagged `notest` (docs, config-only, anything not
-  # runnable) skips testing and goes straight to ready-pr so the PR still opens.
+  # Every task reaches the tester. `notest`/docs/library scopes only exempt the
+  # app start; the test-runner still has to provide CLI/test-harness evidence.
   - id: maybe_test
     name: Testing Decision
     type: condition
     next:
-      - when:
-          field: task.tags
-          operator: contains
-          value: notest
-        goto: skip_testing
       - goto: run_test
-
-  - id: skip_testing
-    name: Skip Testing
-    type: set_status
-    config:
-      status: ready-pr
-      status_reason: testing skipped (notest) — opening PR
-    next:
-      - goto: ""
 
   # A single headless adversarial test-runner. Its sandbox (Docker compose
   # project / k3d cluster, keyed by task id) is started on demand by the agent
@@ -52,7 +38,7 @@ steps:
       needs_worktree: true
       max_retries: 1
       output_schema: >-
-        {"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]},"outcome":{"type":"string","enum":["product_bug","infra_failure","ambiguous_requirement","missing_evidence"]},"failures_markdown":{"type":"string"}},"required":["verdict"],"additionalProperties":false}
+        {"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]},"outcome":{"type":"string","enum":["pass","product_bug","infra_failure","ambiguous_requirement","missing_evidence"]},"failures_markdown":{"type":"string"},"surface_kind":{"type":"string","enum":["web","cli","server","desktop","k8s","library","docs","none"]},"app_started":{"type":"boolean"},"start_command":{"type":"string"},"readiness_probe":{"type":"string"},"manual_probes":{"type":"array","items":{"type":"object","properties":{"command":{"type":"string"},"expected":{"type":"string"},"actual":{"type":"string"}},"required":["command","expected","actual"],"additionalProperties":false}},"automated_checks":{"type":"array","items":{"type":"object","properties":{"command":{"type":"string"},"actual":{"type":"string"}},"required":["command","actual"],"additionalProperties":false}},"unable_to_run_reason":{"type":"string"}},"required":["verdict","outcome","failures_markdown","surface_kind","app_started","start_command","readiness_probe","manual_probes","automated_checks","unable_to_run_reason"],"additionalProperties":false}
       prompt: >-
         Adversarially test task {{.Task.ID}} using the /sybra-test skill.
 
@@ -68,6 +54,14 @@ steps:
         and still emit FAIL (a human resolves the spec). You decide how to start
         and drive the real app/cluster (read the repo: README, .sybra.yaml, mise
         tasks, package.json, compose, Makefile).
+        {{if .Task.ManualTest.Kind}}This project's .sybra.yaml declares a manual_test surface:
+          - kind: {{.Task.ManualTest.Kind}}
+          - command: {{.Task.ManualTest.Command}}
+          - health_url: {{.Task.ManualTest.HealthURL}}
+          - probe_commands:
+        {{range .Task.ManualTest.ProbeCommands}}    - {{.}}
+        {{end}}Prefer this surface for black-box testing unless the task scope clearly makes it irrelevant.
+        {{end}}
         Existing `## Test Failures` sections in the task body are historical
         context only. Reproduce them against the CURRENT worktree before counting
         them; if the current code no longer exhibits that behavior, ignore the
@@ -75,6 +69,28 @@ steps:
         If SANDBOX_URL / KUBECONFIG are set in your environment, an isolated
         sandbox is already running for this task — use it. Bind only ephemeral
         ports and tear down anything you start.
+
+        Manual testing is mandatory by default. Before PASS, run at least one
+        product-level probe that a user/operator would recognize: start the
+        web/server surface and hit it with curl/browser/devtools; run the real
+        CLI/workflow command in an isolated temp home/project; use kubectl
+        against the sandbox; or drive the desktop task's headless HTTP/server
+        equivalent. Automated tests, lint, builds, diff review, and grep are
+        support evidence only — they do NOT count as manual testing by
+        themselves.
+
+        Exception: for pure refactors, internal-library changes, docs-only work,
+        or changes with no runnable product surface, do not force an app start.
+        Instead, state the exception in your final PASS summary and run the
+        strongest behavioral regression evidence available: a CLI/test harness
+        probe (for example go test, package tests, npm run check, or the real
+        CLI command) plus grep/invariant probes when useful for sweep wording.
+        Static review or grep alone is not enough. If you cannot justify the
+        exception from task scope, missing manual testing is missing_evidence
+        -> FAIL.
+        If manual testing is impossible, say exactly why in your response. In
+        JSON output, put the reason in `unable_to_run_reason`; in plain text,
+        add `Unable to run manual test: <reason>`.
 
         Before looking for defects, derive a cheap acceptance probe from the
         task when possible. For sweep/refactor wording like "everywhere",
@@ -100,8 +116,15 @@ steps:
             product_bug, infra_failure, ambiguous_requirement, or
             missing_evidence in prose. Do NOT suggest fixes — describe
             symptoms only.
-          - If your provider returns JSON, set `verdict` and put that report in
-            `failures_markdown` (plus `outcome` when clear). Otherwise print
+          - Prefer a single JSON object as your final response. Set `verdict`,
+            `outcome`, and `failures_markdown`; use `outcome: "pass"` and an
+            empty `failures_markdown` on PASS. PASS is valid only with manual
+            testing evidence, or with a justified refactor/library/no-surface
+            exception plus regression evidence. If you cannot return JSON, your
+            plain-text PASS must include the same evidence labels:
+            `surface_kind`, `app_started`, `start_command`, `readiness_probe`,
+            `manual_probes`, `automated_checks`, and `unable_to_run_reason`;
+            otherwise it is a tester protocol failure. For plain text, print
             the report, then print the verdict as the FINAL line exactly:
             `TEST_VERDICT: PASS`  (only if you could not break it)
             or

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -555,26 +556,61 @@ func TestSyncBuiltins_IdempotentOnClean(t *testing.T) {
 func TestBuiltinTestingTask_RunTestOutputSchema(t *testing.T) {
 	t.Parallel()
 
-	defs, err := BuiltinDefinitions()
-	if err != nil {
-		t.Fatalf("BuiltinDefinitions: %v", err)
-	}
-	var testingDef *Definition
-	for i := range defs {
-		if defs[i].ID == "testing-task" {
-			testingDef = &defs[i]
-			break
-		}
-	}
-	if testingDef == nil {
-		t.Fatal("testing-task builtin definition not found")
-	}
+	testingDef := mustBuiltinDefinition(t, "testing-task")
 	step := testingDef.StepByID("run_test")
 	if step == nil {
 		t.Fatal("run_test step not found in testing-task")
 	}
-	const wantSchema = `{"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]},"outcome":{"type":"string","enum":["product_bug","infra_failure","ambiguous_requirement","missing_evidence"]},"failures_markdown":{"type":"string"}},"required":["verdict"],"additionalProperties":false}`
+	const wantSchema = `{"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]},"outcome":{"type":"string","enum":["pass","product_bug","infra_failure","ambiguous_requirement","missing_evidence"]},"failures_markdown":{"type":"string"},"surface_kind":{"type":"string","enum":["web","cli","server","desktop","k8s","library","docs","none"]},"app_started":{"type":"boolean"},"start_command":{"type":"string"},"readiness_probe":{"type":"string"},"manual_probes":{"type":"array","items":{"type":"object","properties":{"command":{"type":"string"},"expected":{"type":"string"},"actual":{"type":"string"}},"required":["command","expected","actual"],"additionalProperties":false}},"automated_checks":{"type":"array","items":{"type":"object","properties":{"command":{"type":"string"},"actual":{"type":"string"}},"required":["command","actual"],"additionalProperties":false}},"unable_to_run_reason":{"type":"string"}},"required":["verdict","outcome","failures_markdown","surface_kind","app_started","start_command","readiness_probe","manual_probes","automated_checks","unable_to_run_reason"],"additionalProperties":false}`
 	if step.Config.OutputSchema != wantSchema {
 		t.Errorf("run_test.Config.OutputSchema =\n%q\nwant:\n%q", step.Config.OutputSchema, wantSchema)
 	}
+
+	var schema struct {
+		Properties map[string]json.RawMessage `json:"properties"`
+		Required   []string                   `json:"required"`
+	}
+	if err := json.Unmarshal([]byte(step.Config.OutputSchema), &schema); err != nil {
+		t.Fatalf("unmarshal output schema: %v", err)
+	}
+	required := map[string]bool{}
+	for _, field := range schema.Required {
+		required[field] = true
+	}
+	for field := range schema.Properties {
+		if !required[field] {
+			t.Fatalf("codex strict output schema requires every property; %q missing from required", field)
+		}
+	}
+}
+
+func TestBuiltinTestingTask_NotestStillRunsTester(t *testing.T) {
+	t.Parallel()
+
+	testingDef := mustBuiltinDefinition(t, "testing-task")
+	if testingDef.StepByID("skip_testing") != nil {
+		t.Fatal("testing-task must not bypass test-runner for notest tasks")
+	}
+	maybe := testingDef.StepByID("maybe_test")
+	if maybe == nil {
+		t.Fatal("maybe_test step not found in testing-task")
+	}
+	if len(maybe.Next) != 1 || maybe.Next[0].GoTo != "run_test" {
+		t.Fatalf("maybe_test next = %+v, want unconditional run_test", maybe.Next)
+	}
+}
+
+func mustBuiltinDefinition(t *testing.T, id string) *Definition {
+	t.Helper()
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	for i := range defs {
+		if defs[i].ID == id {
+			return &defs[i]
+		}
+	}
+	t.Fatalf("%s builtin definition not found", id)
+	return nil
 }

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -50,6 +50,16 @@ type TaskInfo struct {
 	// a human re-dispatches from human-required. Nil means no re-dispatch has
 	// occurred; route_test_result counts all test-runner runs in that case.
 	TestingCycleStartedAt *time.Time
+	// ManualTest is repo/project-declared guidance for black-box testing.
+	ManualTest ManualTestInfo
+}
+
+// ManualTestInfo describes the runnable surface a test-runner should exercise.
+type ManualTestInfo struct {
+	Kind          string
+	Command       string
+	HealthURL     string
+	ProbeCommands []string
 }
 
 // AgentRunInfo is the engine-visible subset of a task's agent run.
@@ -114,6 +124,12 @@ type CheckConfigGetter interface {
 	VerifyCommands(taskID string) []string
 }
 
+// ManualTestConfigGetter resolves repo/project-declared black-box testing hints.
+// Engine operates with a nil getter — prompts then fall back to repo discovery.
+type ManualTestConfigGetter interface {
+	ManualTestConfig(taskID string) ManualTestInfo
+}
+
 // PRLinker inspects and updates GitHub pull request metadata for the
 // `ensure_pr_closes_issue` step. Implementations wrap `gh` CLI calls.
 // Engine operates with a nil PRLinker — the step becomes a no-op when
@@ -169,6 +185,7 @@ type Engine struct {
 	prReviewers     PRReviewRequester
 	worktrees       WorktreeGetter
 	checks          CheckConfigGetter
+	manualTests     ManualTestConfigGetter
 	recorder        ArtifactRecorder
 	onComplete      func(CompletionInfo)
 	logger          *slog.Logger
@@ -232,6 +249,10 @@ func (e *Engine) SetWorktreeGetter(g WorktreeGetter) { e.worktrees = g }
 // `verify_checks` step. Leaving it unset makes the step a no-op.
 func (e *Engine) SetCheckConfigGetter(g CheckConfigGetter) { e.checks = g }
 
+// SetManualTestConfigGetter wires the manual-test surface resolver used by
+// testing prompts. Leaving it unset makes the prompt rely on repo discovery.
+func (e *Engine) SetManualTestConfigGetter(g ManualTestConfigGetter) { e.manualTests = g }
+
 // SetVerifyTimeout overrides the verify_checks time budget. Zero keeps the
 // default (verifyChecksDefaultTimeout). Used by tests for a short budget.
 func (e *Engine) SetVerifyTimeout(d time.Duration) { e.verifyTimeout = d }
@@ -253,3 +274,11 @@ func (e *Engine) SetTestingMaxAttempts(n int) { e.maxTestAttempts = n }
 
 // SetABTestingConfig wires deterministic A/B assignment for run_agent steps.
 func (e *Engine) SetABTestingConfig(cfg abtest.Config) { e.abTesting = cfg }
+
+func (e *Engine) withManualTestConfig(t TaskInfo) TaskInfo {
+	if e.manualTests == nil || t.ID == "" {
+		return t
+	}
+	t.ManualTest = e.manualTests.ManualTestConfig(t.ID)
+	return t
+}

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -53,7 +53,8 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 		return pErr
 	}
 
-	if err := e.prepareTestStepCompletion(taskID, &output, wfExec, &ctx.Task.Body); err != nil {
+	ctx.Task = e.withManualTestConfig(ctx.Task)
+	if err := e.prepareTestStepCompletion(taskID, ctx.Task, &output, wfExec, &ctx.Task.Body); err != nil {
 		return err
 	}
 
@@ -118,6 +119,7 @@ func (e *Engine) AdvanceStep(taskID string, output StepOutput) error {
 	if err != nil {
 		return err
 	}
+	t = e.withManualTestConfig(t)
 	t.Workflow = wfExec
 
 	nextStep, comp, err := e.resolveNext(taskID, &def, currentStep, wfExec, t)
@@ -201,6 +203,7 @@ func (e *Engine) loadAdvanceContext(taskID string, output StepOutput) (advanceCo
 	if err != nil {
 		return advanceContext{}, false, err
 	}
+	t = e.withManualTestConfig(t)
 	if t.Workflow == nil {
 		return advanceContext{}, false, fmt.Errorf("task %s has no active workflow", taskID)
 	}
@@ -311,6 +314,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 		if err != nil {
 			return nil, err
 		}
+		t = e.withManualTestConfig(t)
 
 		// Snapshot the execution for the template context so that clearing
 		// the Recovered flag below doesn't affect what the template sees.

--- a/internal/workflow/engine_steps_parallel.go
+++ b/internal/workflow/engine_steps_parallel.go
@@ -207,6 +207,7 @@ func (e *Engine) advanceParallelChild(taskID string, def *Definition, parent, ch
 		if gErr != nil {
 			return nil, gErr
 		}
+		t = e.withManualTestConfig(t)
 		dir := wfExec.Variables[WorkflowVarDir]
 		ctx := TemplateContext{
 			Task:     t,

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -30,8 +30,9 @@ const (
 	testVerdictTaintedKey = "tainted"
 	// testFailureBodyStartLenKey records the task body length when run_test is
 	// dispatched. On completion, Codex structured output only contains
-	// {"verdict":"FAIL"}, so the actual failure text must be read from the body
-	// delta written by the runner.
+	// older structured-output runs returned only {"verdict":"FAIL"}, so the
+	// actual failure text had to be read from the body delta written by the
+	// runner.
 	testFailureBodyStartLenKey = "body_start_len"
 	testVerdictOutcomeKey      = "outcome"
 	testFailureFingerprintKey  = "failure_fingerprint"
@@ -49,9 +50,27 @@ const (
 )
 
 type structuredTestOutput struct {
-	Verdict          string `json:"verdict"`
-	Outcome          string `json:"outcome,omitempty"`
-	FailuresMarkdown string `json:"failures_markdown,omitempty"`
+	Verdict           string                   `json:"verdict"`
+	Outcome           string                   `json:"outcome,omitempty"`
+	FailuresMarkdown  string                   `json:"failures_markdown,omitempty"`
+	SurfaceKind       string                   `json:"surface_kind,omitempty"`
+	AppStarted        bool                     `json:"app_started,omitempty"`
+	StartCommand      string                   `json:"start_command,omitempty"`
+	ReadinessProbe    string                   `json:"readiness_probe,omitempty"`
+	ManualProbes      []manualProbeEvidence    `json:"manual_probes,omitempty"`
+	AutomatedChecks   []automatedCheckEvidence `json:"automated_checks,omitempty"`
+	UnableToRunReason string                   `json:"unable_to_run_reason,omitempty"`
+}
+
+type manualProbeEvidence struct {
+	Command  string `json:"command"`
+	Expected string `json:"expected"`
+	Actual   string `json:"actual"`
+}
+
+type automatedCheckEvidence struct {
+	Command string `json:"command"`
+	Actual  string `json:"actual"`
 }
 
 // prepareTestVerdictAttemptVars resets per-attempt verdict metadata before a
@@ -68,14 +87,14 @@ func prepareTestVerdictAttemptVars(wfExec *Execution, stepID, body string) {
 	delete(wfExec.Variables, "step."+stepID+"."+testFailureFingerprintKey)
 }
 
-func (e *Engine) prepareTestStepCompletion(taskID string, output *StepOutput, wfExec *Execution, body *string) error {
+func (e *Engine) prepareTestStepCompletion(taskID string, t TaskInfo, output *StepOutput, wfExec *Execution, body *string) error {
 	if appended, nextBody, appendErr := e.appendTestFailureReport(taskID, *output, wfExec, *body); appendErr != nil {
 		return appendErr
 	} else if appended {
 		*body = nextBody
 	}
 
-	violation, outcome, fingerprint := applyTestVerdictCompletion(wfExec, output, *body)
+	violation, outcome, fingerprint := applyTestVerdictCompletion(wfExec, output, *body, t)
 	if output.AgentID != "" && outcome != "" {
 		if err := e.tasks.MarkAgentRunTestOutcome(taskID, output.AgentID, outcome, fingerprint); err != nil {
 			return fmt.Errorf("mark test outcome: %w", err)
@@ -158,6 +177,179 @@ func normalizeStructuredFailuresMarkdown(report, outcome string) string {
 	return insertClassificationAfterFailuresHeading(report, outcome) + "\n"
 }
 
+func hasManualPassEvidence(output string, t TaskInfo) (ok bool, reason string) {
+	parsed, ok := parseStructuredTestOutput(output)
+	if !ok {
+		return hasPlainTextManualPassEvidence(output, t)
+	}
+	if strings.ToUpper(strings.TrimSpace(parsed.Verdict)) != "PASS" {
+		return true, ""
+	}
+	if normalizeTestOutcome(parsed.Outcome) != testOutcomePass {
+		return false, "PASS report outcome was not pass"
+	}
+	if strings.TrimSpace(parsed.FailuresMarkdown) != "" {
+		return false, "PASS report included failures_markdown"
+	}
+	surface := normalizeSurfaceKind(parsed.SurfaceKind)
+	if surface == "" {
+		return false, "PASS report omitted surface_kind"
+	}
+	if isManualTestExemption(surface, t) {
+		if strings.TrimSpace(parsed.UnableToRunReason) == "" {
+			return false, "PASS used a no-app exemption but omitted unable_to_run_reason"
+		}
+		if !hasRegressionCheckEvidence(parsed.AutomatedChecks) {
+			return false, "PASS used a no-app exemption without CLI/test harness evidence"
+		}
+		return true, ""
+	}
+	if surface == "library" || surface == "docs" || surface == "none" {
+		return false, "PASS skipped manual testing without an explicit docs/library exemption"
+	}
+	if !parsed.AppStarted {
+		return false, "PASS report did not confirm app_started"
+	}
+	if strings.TrimSpace(parsed.StartCommand) == "" {
+		return false, "PASS report omitted start_command"
+	}
+	if strings.TrimSpace(parsed.ReadinessProbe) == "" {
+		return false, "PASS report omitted readiness_probe"
+	}
+	if !hasManualProbeEvidence(parsed.ManualProbes) {
+		return false, "PASS report omitted user-facing manual probe evidence"
+	}
+	return true, ""
+}
+
+func normalizeSurfaceKind(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "web", "cli", "server", "desktop", "k8s", "library", "docs", "none":
+		return strings.ToLower(strings.TrimSpace(s))
+	default:
+		return ""
+	}
+}
+
+func isManualTestExemption(surface string, t TaskInfo) bool {
+	if surface == "library" {
+		return true
+	}
+	if surface == "docs" {
+		return taskHasAnyTag(t, "docs", "documentation", "notest")
+	}
+	if surface == "none" {
+		return taskHasAnyTag(t, "notest")
+	}
+	return false
+}
+
+func hasPlainTextManualPassEvidence(output string, t TaskInfo) (ok bool, reason string) {
+	surface := normalizeSurfaceKind(firstPlainEvidenceField(output, "surface_kind", "surface kind"))
+	if surface == "" {
+		return false, "plain-text PASS report omitted surface_kind"
+	}
+	if isManualTestExemption(surface, t) {
+		if firstPlainEvidenceField(output, "unable_to_run_reason", "unable to run manual test") == "" {
+			return false, "plain-text PASS used a no-app exemption but omitted unable_to_run_reason"
+		}
+		if !hasPlainTextRegressionCheckEvidence(output) {
+			return false, "plain-text PASS used a no-app exemption without CLI/test harness evidence"
+		}
+		return true, ""
+	}
+	if surface == "library" || surface == "docs" || surface == "none" {
+		return false, "plain-text PASS skipped manual testing without an explicit docs/library exemption"
+	}
+	lower := strings.ToLower(output)
+	if !containsAny(lower, "app_started: true", "app started: true") {
+		return false, "plain-text PASS report did not confirm app_started"
+	}
+	if firstPlainEvidenceField(output, "start_command", "start command") == "" {
+		return false, "plain-text PASS report omitted start_command"
+	}
+	if firstPlainEvidenceField(output, "readiness_probe", "readiness probe") == "" {
+		return false, "plain-text PASS report omitted readiness_probe"
+	}
+	if !hasPlainTextManualProbeEvidence(output) {
+		return false, "plain-text PASS report omitted user-facing manual probe evidence"
+	}
+	return true, ""
+}
+
+func firstPlainEvidenceField(output string, names ...string) string {
+	for _, line := range reportScanLines(output) {
+		field, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		field = strings.Trim(strings.ToLower(field), "-* \t`")
+		field = strings.ReplaceAll(field, " ", "_")
+		for _, name := range names {
+			normalized := strings.ReplaceAll(strings.ToLower(strings.TrimSpace(name)), " ", "_")
+			if field == normalized {
+				return strings.TrimSpace(value)
+			}
+		}
+	}
+	return ""
+}
+
+func hasPlainTextManualProbeEvidence(output string) bool {
+	lower := strings.ToLower(output)
+	return containsAny(lower, "manual_probes:", "manual probe:", "manual_probe:") &&
+		containsAny(lower, "command:", "curl ", "sybra-cli", "kubectl ", "go run ", "npm run ") &&
+		containsAny(lower, "expected:", "expected output:") &&
+		containsAny(lower, "actual:", "actual output:", "observed:", "observed output:")
+}
+
+func hasPlainTextRegressionCheckEvidence(output string) bool {
+	lower := strings.ToLower(output)
+	return containsAny(lower, "automated_checks:", "automated checks:", "regression check:", "test harness:") &&
+		containsAny(lower,
+			"go test", "npm test", "npm run test", "npm run check",
+			"pnpm test", "pnpm run test", "yarn test", "pytest", "cargo test",
+			"sybra-cli", "go run", "curl ", "kubectl ")
+}
+
+func taskHasAnyTag(t TaskInfo, tags ...string) bool {
+	for _, got := range t.Tags {
+		for _, want := range tags {
+			if strings.EqualFold(strings.TrimSpace(got), want) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasManualProbeEvidence(probes []manualProbeEvidence) bool {
+	for _, p := range probes {
+		if strings.TrimSpace(p.Command) != "" &&
+			strings.TrimSpace(p.Expected) != "" &&
+			strings.TrimSpace(p.Actual) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasRegressionCheckEvidence(checks []automatedCheckEvidence) bool {
+	for _, c := range checks {
+		cmd := strings.ToLower(strings.TrimSpace(c.Command))
+		if cmd == "" || strings.TrimSpace(c.Actual) == "" {
+			continue
+		}
+		if containsAny(cmd,
+			"go test", "npm test", "npm run test", "npm run check",
+			"pnpm test", "pnpm run test", "yarn test", "pytest", "cargo test",
+			"sybra-cli", "go run", "curl ", "kubectl ") {
+			return true
+		}
+	}
+	return false
+}
+
 func insertClassificationAfterFailuresHeading(report, outcome string) string {
 	lines := strings.Split(report, "\n")
 	for i, line := range lines {
@@ -209,7 +401,7 @@ func stripTestVerdictMarkers(report string) string {
 // sending implementation agents after a bad report. It returns the violation
 // name when one should be persisted on the underlying AgentRun, plus the typed
 // outcome and failure fingerprint for attempt accounting.
-func applyTestVerdictCompletion(wfExec *Execution, output *StepOutput, body string) (violation, outcome, fingerprint string) {
+func applyTestVerdictCompletion(wfExec *Execution, output *StepOutput, body string, t TaskInfo) (violation, outcome, fingerprint string) {
 	if wfExec == nil || output == nil || output.StepID != testVerdictSourceStep {
 		return "", "", ""
 	}
@@ -235,6 +427,15 @@ func applyTestVerdictCompletion(wfExec *Execution, output *StepOutput, body stri
 		output.Status = "failed"
 		output.Output = appendTestProtocolViolation(output.Output, "FAIL report lacked machine-checkable evidence")
 		return testProtocolMissingEvidence, outcome, fingerprint
+	}
+	if output.Status == "completed" && outcome == testOutcomePass && v == "PASS" {
+		if ok, reason := hasManualPassEvidence(output.Output, t); !ok {
+			wfExec.SetVar("step."+output.StepID+"."+testVerdictOutcomeKey, testOutcomeMissingEvidence)
+			wfExec.SetVar("step."+output.StepID+"."+testVerdictTaintedKey, testProtocolMissingEvidence)
+			output.Status = "failed"
+			output.Output = appendTestProtocolViolation(output.Output, reason)
+			return testProtocolMissingEvidence, testOutcomeMissingEvidence, ""
+		}
 	}
 	if outcome == testOutcomeInfraFailure {
 		output.Status = "failed"
@@ -345,6 +546,8 @@ func normalizeTestOutcome(s string) string {
 	token = strings.NewReplacer("-", "_", " ", "_", ":", "_", ",", "_").Replace(token)
 	token = strings.Trim(token, "_")
 	switch {
+	case outcomeTokenStarts(token, testOutcomePass):
+		return testOutcomePass
 	case outcomeTokenStarts(token, testOutcomeProductBug, "bug", "product_failure"):
 		return testOutcomeProductBug
 	case outcomeTokenStarts(token, testOutcomeInfraFailure, "infrastructure_failure", "infrastructure", "infra"):
@@ -438,8 +641,9 @@ func testFailureFingerprint(report string) string {
 }
 
 // containsFixSuggestionsInCurrentTestReport scans the agent result and the task
-// body text added during the current run_test attempt. The body delta matters
-// for Codex output_schema runs, where the result is only {"verdict":"FAIL"}.
+// body text added during the current run_test attempt. The body delta keeps
+// compatibility with older Codex output_schema runs that returned only
+// {"verdict":"FAIL"}.
 func containsFixSuggestionsInCurrentTestReport(output, body string, wfExec *Execution, stepID string) bool {
 	if containsFixSuggestions(output) {
 		return true

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -491,6 +491,9 @@ func classifyTestOutcome(status, output, body string, wfExec *Execution, stepID 
 		return testOutcomeMissingEvidence, ""
 	}
 	if explicit := explicitTestOutcome(report); explicit != "" {
+		if explicit == testOutcomePass {
+			return testOutcomeMissingEvidence, ""
+		}
 		if explicit == testOutcomeProductBug || explicit == testOutcomeAmbiguousRequirement {
 			if !hasGroundedFailureEvidence(report) {
 				return testOutcomeMissingEvidence, ""

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -360,12 +360,90 @@ func TestApplyTestVerdictCompletion_ClassifiesOutcomes(t *testing.T) {
 			wantStatus: "failed",
 		},
 		{
-			name:       "pass",
+			name:       "pass_with_manual_evidence",
 			status:     "completed",
-			output:     `{"verdict":"PASS"}`,
+			output:     structuredPassOutput(),
 			bodySuffix: "",
 			want:       testOutcomePass,
 			wantStatus: "completed",
+		},
+		{
+			name:   "plain_text_pass_with_manual_evidence",
+			status: "completed",
+			output: "surface_kind: server\n" +
+				"app_started: true\n" +
+				"start_command: SYBRA_PORT=12345 go run ./cmd/sybra-server\n" +
+				"readiness_probe: curl -fsS http://127.0.0.1:12345/health\n" +
+				"manual_probes:\n" +
+				"command: curl -fsS http://127.0.0.1:12345/health\n" +
+				"expected: status ok\n" +
+				"actual: {\"status\":\"ok\"}\n" +
+				"automated_checks: go test ./internal/workflow => ok\n" +
+				"unable_to_run_reason:\n" +
+				"TEST_VERDICT: PASS",
+			bodySuffix: "",
+			want:       testOutcomePass,
+			wantStatus: "completed",
+		},
+		{
+			name:       "pass_without_manual_evidence",
+			status:     "completed",
+			output:     `{"verdict":"PASS"}`,
+			bodySuffix: "",
+			want:       testOutcomeMissingEvidence,
+			wantStatus: "failed",
+			wantTaint:  testProtocolMissingEvidence,
+		},
+		{
+			name:       "pass_with_library_exemption_requires_regression_check",
+			status:     "completed",
+			output:     `{"verdict":"PASS","outcome":"pass","failures_markdown":"","surface_kind":"library","app_started":false,"start_command":"","readiness_probe":"","manual_probes":[],"automated_checks":[{"command":"go test ./internal/foo","actual":"ok"}],"unable_to_run_reason":"pure internal-library refactor"}`,
+			bodySuffix: "",
+			want:       testOutcomePass,
+			wantStatus: "completed",
+		},
+		{
+			name:       "pass_with_notest_exemption_still_requires_regression_check",
+			status:     "completed",
+			output:     `{"verdict":"PASS","outcome":"pass","failures_markdown":"","surface_kind":"none","app_started":false,"start_command":"","readiness_probe":"","manual_probes":[],"automated_checks":[{"command":"go test ./internal/foo","actual":"ok"}],"unable_to_run_reason":"task tagged notest; no product surface changed"}`,
+			bodySuffix: "",
+			want:       testOutcomePass,
+			wantStatus: "completed",
+		},
+		{
+			name:       "pass_with_docs_exemption_still_requires_regression_check",
+			status:     "completed",
+			output:     `{"verdict":"PASS","outcome":"pass","failures_markdown":"","surface_kind":"docs","app_started":false,"start_command":"","readiness_probe":"","manual_probes":[],"automated_checks":[{"command":"npm run check","actual":"ok"}],"unable_to_run_reason":"docs-only task"}`,
+			bodySuffix: "",
+			want:       testOutcomePass,
+			wantStatus: "completed",
+		},
+		{
+			name:       "pass_with_library_exemption_rejects_static_only_check",
+			status:     "completed",
+			output:     `{"verdict":"PASS","outcome":"pass","failures_markdown":"","surface_kind":"library","app_started":false,"start_command":"","readiness_probe":"","manual_probes":[],"automated_checks":[{"command":"rg -n rawThing internal","actual":"no matches"}],"unable_to_run_reason":"pure internal-library refactor"}`,
+			bodySuffix: "",
+			want:       testOutcomeMissingEvidence,
+			wantStatus: "failed",
+			wantTaint:  testProtocolMissingEvidence,
+		},
+		{
+			name:       "pass_with_non_pass_outcome_rejected",
+			status:     "completed",
+			output:     `{"verdict":"PASS","outcome":"product_bug","failures_markdown":"","surface_kind":"server","app_started":true,"start_command":"go run ./cmd/sybra-server","readiness_probe":"curl /health","manual_probes":[{"command":"curl /health","expected":"200","actual":"200"}],"automated_checks":[],"unable_to_run_reason":""}`,
+			bodySuffix: "",
+			want:       testOutcomeMissingEvidence,
+			wantStatus: "failed",
+			wantTaint:  testProtocolMissingEvidence,
+		},
+		{
+			name:       "pass_with_failures_markdown_rejected",
+			status:     "completed",
+			output:     `{"verdict":"PASS","outcome":"pass","failures_markdown":"## Test Failures\n\nCommand run: curl /health","surface_kind":"server","app_started":true,"start_command":"go run ./cmd/sybra-server","readiness_probe":"curl /health","manual_probes":[{"command":"curl /health","expected":"200","actual":"200"}],"automated_checks":[],"unable_to_run_reason":""}`,
+			bodySuffix: "",
+			want:       testOutcomeMissingEvidence,
+			wantStatus: "failed",
+			wantTaint:  testProtocolMissingEvidence,
 		},
 	}
 
@@ -376,7 +454,14 @@ func TestApplyTestVerdictCompletion_ClassifiesOutcomes(t *testing.T) {
 			wf := &Execution{Variables: map[string]string{}}
 			prepareTestVerdictAttemptVars(wf, testVerdictSourceStep, initialBody)
 			out := StepOutput{StepID: testVerdictSourceStep, Status: tc.status, Output: tc.output}
-			violation, outcome, fingerprint := applyTestVerdictCompletion(wf, &out, body)
+			taskInfo := TaskInfo{}
+			if strings.Contains(tc.name, "_notest_") {
+				taskInfo.Tags = []string{"notest"}
+			}
+			if strings.Contains(tc.name, "_docs_") {
+				taskInfo.Tags = []string{"docs"}
+			}
+			violation, outcome, fingerprint := applyTestVerdictCompletion(wf, &out, body, taskInfo)
 			if outcome != tc.want {
 				t.Fatalf("outcome = %q, want %q", outcome, tc.want)
 			}
@@ -394,6 +479,10 @@ func TestApplyTestVerdictCompletion_ClassifiesOutcomes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func structuredPassOutput() string {
+	return `{"verdict":"PASS","outcome":"pass","failures_markdown":"","surface_kind":"server","app_started":true,"start_command":"SYBRA_PORT=0 go run ./cmd/sybra-server","readiness_probe":"curl -fsS http://127.0.0.1:12345/health","manual_probes":[{"command":"curl -fsS http://127.0.0.1:12345/health","expected":"HTTP 200 ok","actual":"ok"}],"automated_checks":[{"command":"go test ./internal/workflow","actual":"ok"}],"unable_to_run_reason":""}`
 }
 
 // makeTestEngine builds a minimal Engine for route_test_result unit tests.

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -323,6 +323,15 @@ func TestApplyTestVerdictCompletion_ClassifiesOutcomes(t *testing.T) {
 			wantTaint:  testProtocolMissingEvidence,
 		},
 		{
+			name:       "fail_with_pass_outcome_is_missing_evidence",
+			status:     "completed",
+			output:     `{"verdict":"FAIL","outcome":"pass","failures_markdown":` + strconv.Quote(strings.TrimSpace(groundedReport)) + `}`,
+			bodySuffix: "",
+			want:       testOutcomeMissingEvidence,
+			wantStatus: "failed",
+			wantTaint:  testProtocolMissingEvidence,
+		},
+		{
 			name:       "expected_output_does_not_count_as_observed_output",
 			status:     "completed",
 			output:     `{"verdict":"FAIL"}`,


### PR DESCRIPTION
## Motivation

Testing agents are supposed to run the real app or an equivalent user-facing surface before approving work. The existing flow still allowed prompt-only compliance gaps: `notest` skipped the tester entirely, PASS verdicts did not carry machine-checkable evidence, and no-app exceptions were not enforced consistently.

> Changelog: fix(testing): require manual evidence

## Implementation information

- Add repo/project `manual_test` config and inject it into testing workflow prompts.
- Require structured evidence fields for test-runner output: surface kind, app start, readiness probe, manual probes, automated checks, and unable-to-run reason.
- Gate PASS routing on manual black-box evidence, or explicit docs/notest/library exemptions with CLI/test-harness evidence.
- Preserve Claude/plain-text compatibility with evidence labels while rejecting contradictory PASS payloads.
- Add Sybra repo manual-test guidance using a per-run dynamic server port.

## Supporting documentation

- Adversarial review found and fixed PASS-routing holes for plain-text Claude output, library/refactor exemptions, fixed-port contention, and contradictory PASS JSON.
- Validation: `go test ./internal/project ./internal/workflow ./internal/sybra ./cmd/sybra-cli ./cmd/fake-codex -count=1`; `go test -tags e2e ./internal/sybra -run 'TestE2E_Codex_TestVerdict_(Pass|Fail)_JSON' -count=1`; `cd frontend && npm ci --quiet && npm run build:desktop && cd .. && go test ./...`; pre-push `go test ./...` and `cd frontend && npm run check`.