### PR TITLE
fix(workflow): reduce human-required noise

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -473,6 +473,12 @@ export class StepConfig {
     "sidecar": string;
 
     /**
+     * AllowMissing turns require_sidecar into a soft gate: the step records a
+     * warning output instead of flipping the task to human-required.
+     */
+    "allowMissing": boolean;
+
+    /**
      * run_agent: when set, the engine ingests a file produced by the agent
      * (typically under /tmp) and stores its content as the named task
      * sidecar after the agent exits. Lets review/critique steps work with
@@ -551,6 +557,9 @@ export class StepConfig {
         if (!("sidecar" in $$source)) {
             this["sidecar"] = "";
         }
+        if (!("allowMissing" in $$source)) {
+            this["allowMissing"] = false;
+        }
         if (!("importSidecars" in $$source)) {
             this["importSidecars"] = [];
         }
@@ -565,8 +574,8 @@ export class StepConfig {
         const $$createField5_0 = $$createType17;
         const $$createField7_0 = $$createType17;
         const $$createField10_0 = $$createType19;
-        const $$createField17_0 = $$createType21;
-        const $$createField18_0 = $$createType22;
+        const $$createField18_0 = $$createType21;
+        const $$createField19_0 = $$createType22;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField5_0($$parsedSource["allowedTools"]);
@@ -578,10 +587,10 @@ export class StepConfig {
             $$parsedSource["check"] = $$createField10_0($$parsedSource["check"]);
         }
         if ("importSidecar" in $$parsedSource) {
-            $$parsedSource["importSidecar"] = $$createField17_0($$parsedSource["importSidecar"]);
+            $$parsedSource["importSidecar"] = $$createField18_0($$parsedSource["importSidecar"]);
         }
         if ("importSidecars" in $$parsedSource) {
-            $$parsedSource["importSidecars"] = $$createField18_0($$parsedSource["importSidecars"]);
+            $$parsedSource["importSidecars"] = $$createField19_0($$parsedSource["importSidecars"]);
         }
         return new StepConfig($$parsedSource as Partial<StepConfig>);
     }

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -623,19 +623,22 @@ func (a *Agent) isDetached() bool {
 	return a.detached
 }
 
-// hasTerminalResult reports whether the output buffer contains a
-// non-error result event — the signal that a headless run completed its
-// work. Used by reattach completion to distinguish a clean finish from a
-// process that vanished mid-run.
-func (a *Agent) hasTerminalResult() bool {
+// lastHeadlessResult reports whether the output buffer contains a terminal
+// result event and whether that result was a provider error. Used by reattach
+// completion to distinguish a clean finish from an error result or a process
+// that vanished mid-run.
+func (a *Agent) lastHeadlessResult() (found, isError bool) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
-	for i := range a.outputBuffer {
-		if a.outputBuffer[i].Type == "result" && a.outputBuffer[i].Subtype != "error" {
-			return true
-		}
+	return lastHeadlessResultEvent(a.outputBuffer)
+}
+
+func lastHeadlessResultEvent(events []StreamEvent) (found, isError bool) {
+	for i := range slices.Backward(events) {
+		e := events[i]
+		return e.Type == "result", e.Type == "result" && (resultSubtypeIsError(e.Subtype) || e.ErrorType != "" || e.ErrorStatus != 0)
 	}
-	return false
+	return false, false
 }
 
 // lastConvoResult reports whether a terminal result event was observed in

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -131,12 +131,22 @@ func (m *Manager) finalizeIfCompleted(r Record) bool {
 	}
 	a := agentFromRecord(r)
 	rehydrateFromLog(a, r.LogPath)
-	if !a.hasTerminalResult() {
+	found, isError := a.lastHeadlessResult()
+	if !found {
 		return false
+	}
+	if isError {
+		outputs := a.Output()
+		if err := resultStreamError(outputs); err != nil {
+			a.SetExitErr(err)
+			m.reportProviderHealthSignal(a, "", outputs)
+		} else {
+			a.SetExitErr(errReattachedResultError)
+		}
 	}
 	a.SetState(StateStopped)
 	m.logger.Info("agent.reattach.recovered-complete", "id", a.ID, "task", a.TaskID)
-	m.fireComplete(a, true)
+	m.fireComplete(a, a.GetExitErr() == nil)
 	return true
 }
 
@@ -311,8 +321,16 @@ func (m *Manager) reattachHeadless(ctx context.Context, a *Agent, startOffset in
 		return
 	}
 
-	if !a.hasTerminalResult() {
+	outputs := a.Output()
+	if found, isError := lastHeadlessResultEvent(outputs); !found {
 		a.SetExitErr(errReattachedGone)
+	} else if isError {
+		if err := resultStreamError(outputs); err != nil {
+			a.SetExitErr(err)
+			m.reportProviderHealthSignal(a, "", outputs)
+		} else {
+			a.SetExitErr(errReattachedResultError)
+		}
 	}
 	a.SetState(StateStopped)
 	m.logger.Info("agent.reattach.done", "id", a.ID, "cost", a.GetCostUSD())

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 	"time"
 
@@ -193,18 +194,19 @@ func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfi
 	if stderrOut != "" {
 		m.logger.Error("agent.headless.stderr", "id", a.ID, "stderr", stderrOut)
 	}
+	if streamErr := resultStreamError(attemptEventsFrom(a, prevLen)); waitErr == nil && streamErr != nil {
+		waitErr = streamErr
+	}
 	if waitErr != nil {
 		m.logger.Error("agent.headless.exit", "id", a.ID, "err", waitErr)
 		a.SetExitErr(waitErr)
+	} else {
+		a.SetExitErr(nil)
 	}
 
 	if waitErr != nil {
 		// Only inspect the events produced during this attempt.
-		all := a.Output()
-		if prevLen > len(all) {
-			prevLen = len(all)
-		}
-		attemptEvents := all[prevLen:]
+		attemptEvents := attemptEventsFrom(a, prevLen)
 		if shouldRetry(stderrOut, attemptEvents, m.logger) {
 			return true, nil
 		}
@@ -295,23 +297,57 @@ func (m *Manager) runHeadlessAttemptSurvive(ctx context.Context, a *Agent, cfg R
 	if stderrOut != "" {
 		m.logger.Error("agent.headless.stderr", "id", a.ID, "stderr", stderrOut)
 	}
+	if streamErr := resultStreamError(attemptEventsFrom(a, prevLen)); waitErr == nil && streamErr != nil {
+		waitErr = streamErr
+	}
 	if waitErr != nil {
 		m.logger.Error("agent.headless.exit", "id", a.ID, "err", waitErr)
 		a.SetExitErr(waitErr)
+	} else {
+		a.SetExitErr(nil)
+	}
+	if waitErr != nil {
 		// Only inspect events from this attempt, mirroring the legacy path —
 		// otherwise a transient 529 from an earlier attempt makes every later
 		// attempt retry regardless of its real failure.
-		all := a.Output()
-		if prevLen > len(all) {
-			prevLen = len(all)
-		}
-		attemptEvents := all[prevLen:]
+		attemptEvents := attemptEventsFrom(a, prevLen)
 		if shouldRetry(stderrOut, attemptEvents, m.logger) {
 			return true, nil
 		}
 		m.reportProviderHealthSignal(a, stderrOut, attemptEvents)
 	}
 	return false, nil
+}
+
+func attemptEventsFrom(a *Agent, prevLen int) []StreamEvent {
+	all := a.Output()
+	if prevLen > len(all) {
+		prevLen = len(all)
+	}
+	return all[prevLen:]
+}
+
+func resultStreamError(streamEvents []StreamEvent) error {
+	for i := range slices.Backward(streamEvents) {
+		e := streamEvents[i]
+		if e.Type != "result" {
+			continue
+		}
+		if e.ErrorStatus != 0 || e.ErrorType != "" || resultSubtypeIsError(e.Subtype) {
+			if e.ErrorStatus != 0 && e.ErrorType != "" {
+				return fmt.Errorf("provider result error %s (%d)", e.ErrorType, e.ErrorStatus)
+			}
+			if e.ErrorStatus != 0 {
+				return fmt.Errorf("provider result error status %d", e.ErrorStatus)
+			}
+			if e.ErrorType == "" {
+				return fmt.Errorf("provider result error")
+			}
+			return fmt.Errorf("provider result error %s", e.ErrorType)
+		}
+		return nil
+	}
+	return nil
 }
 
 // drainTimeout bounds how long the tailer waits for a process it just

--- a/internal/agent/runner_headless_retry.go
+++ b/internal/agent/runner_headless_retry.go
@@ -118,49 +118,59 @@ func buildErrorSampleConvo(stderrOut string, attemptEvents []ConvoEvent) provide
 // Substring matching is used as a fallback and triggers a Warn log so format
 // regressions surface in logs without silently breaking retries.
 func shouldRetry(stderrOut string, streamEvents []StreamEvent, logger *slog.Logger) bool {
-	for i := range streamEvents {
-		if streamEvents[i].Type == "result" && streamEvents[i].Subtype == "error" {
-			if streamEvents[i].ErrorType == "overloaded_error" || streamEvents[i].ErrorStatus == 529 {
-				return true
-			}
-		}
+	if slices.ContainsFunc(streamEvents, retryableResultEvent) {
+		return true
 	}
 	// Substring fallback: keeps working if Anthropic changes the error envelope.
 	if substringMatch529(stderrOut) {
 		warnSubstringFallback(logger)
 		return true
 	}
-	for i := range streamEvents {
-		if streamEvents[i].Type == "result" && streamEvents[i].Subtype == "error" && substringMatch529(streamEvents[i].Content) {
-			warnSubstringFallback(logger)
-			return true
-		}
+	if slices.ContainsFunc(streamEvents, func(e StreamEvent) bool {
+		return resultEventCanCarryError(e) && substringMatch529(e.Content)
+	}) {
+		warnSubstringFallback(logger)
+		return true
 	}
 	return false
 }
 
 // shouldRetryConvo is the ConvoEvent variant of shouldRetry.
 func shouldRetryConvo(stderrOut string, convoEvents []ConvoEvent, logger *slog.Logger) bool {
-	for i := range convoEvents {
-		e := &convoEvents[i]
-		if e.Type == "result" && e.Subtype == "error" {
-			if e.ErrorType == "overloaded_error" || e.ErrorStatus == 529 {
-				return true
-			}
-		}
+	if slices.ContainsFunc(convoEvents, retryableConvoResultEvent) {
+		return true
 	}
 	if substringMatch529(stderrOut) {
 		warnSubstringFallback(logger)
 		return true
 	}
-	for i := range convoEvents {
-		e := &convoEvents[i]
-		if e.Type == "result" && e.Subtype == "error" && substringMatch529(e.Text) {
-			warnSubstringFallback(logger)
-			return true
-		}
+	if slices.ContainsFunc(convoEvents, func(e ConvoEvent) bool {
+		return convoResultEventCanCarryError(e) && substringMatch529(e.Text)
+	}) {
+		warnSubstringFallback(logger)
+		return true
 	}
 	return false
+}
+
+func retryableResultEvent(e StreamEvent) bool {
+	return e.Type == "result" && (e.ErrorType == "overloaded_error" || e.ErrorStatus == 529)
+}
+
+func resultEventCanCarryError(e StreamEvent) bool {
+	return e.Type == "result" && (resultSubtypeIsError(e.Subtype) || e.ErrorType != "" || e.ErrorStatus != 0)
+}
+
+func retryableConvoResultEvent(e ConvoEvent) bool {
+	return e.Type == "result" && (e.ErrorType == "overloaded_error" || e.ErrorStatus == 529)
+}
+
+func convoResultEventCanCarryError(e ConvoEvent) bool {
+	return e.Type == "result" && (resultSubtypeIsError(e.Subtype) || e.ErrorType != "" || e.ErrorStatus != 0)
+}
+
+func resultSubtypeIsError(subtype string) bool {
+	return subtype != "" && subtype != "success"
 }
 
 func substringMatch529(s string) bool {

--- a/internal/agent/runner_headless_stream.go
+++ b/internal/agent/runner_headless_stream.go
@@ -75,6 +75,8 @@ func claudeEventToStreamEvent(e ClaudeEvent) StreamEvent {
 			ev.CacheCreationInputTokens = e.Result.CacheCreationInputTokens
 			ev.CacheReadInputTokens = e.Result.CacheReadInputTokens
 			ev.ReasoningTokens = e.Result.ReasoningTokens
+			ev.ErrorType = e.Result.ErrorType
+			ev.ErrorStatus = e.Result.ErrorStatus
 		}
 
 	}

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -191,6 +191,29 @@ func TestParseCodexStreamEvent_Error_StructuredErrorType(t *testing.T) {
 	}
 }
 
+func TestShouldRetry_ResultErrorWithoutSubtype(t *testing.T) {
+	streamEvents := []StreamEvent{{
+		Type:        "result",
+		Content:     "Overloaded",
+		ErrorType:   "overloaded_error",
+		ErrorStatus: 529,
+	}}
+	if !shouldRetry("", streamEvents, nil) {
+		t.Fatal("shouldRetry = false, want true for structured overloaded result without subtype")
+	}
+}
+
+func TestShouldRetry_ResultErrorDuringExecutionSubtype(t *testing.T) {
+	streamEvents := []StreamEvent{{
+		Type:    "result",
+		Subtype: "error_during_execution",
+		Content: "API Error: 529 overloaded",
+	}}
+	if !shouldRetry("", streamEvents, nil) {
+		t.Fatal("shouldRetry = false, want true for 529 in error_during_execution result")
+	}
+}
+
 func TestShouldRetry_Stderr529(t *testing.T) {
 	if !shouldRetry("error: 529 overloaded", nil, nil) {
 		t.Fatal("shouldRetry = false on stderr containing 529")
@@ -201,6 +224,72 @@ func TestShouldRetry_FatalError_NoRetry(t *testing.T) {
 	streamEvents := []StreamEvent{{Type: "result", Subtype: "error", Content: "permission denied"}}
 	if shouldRetry("", streamEvents, nil) {
 		t.Fatal("shouldRetry = true on non-transient error, want false")
+	}
+}
+
+func TestResultStreamError(t *testing.T) {
+	t.Parallel()
+
+	err := resultStreamError([]StreamEvent{
+		{Type: "assistant", Content: "working"},
+		{Type: "result", Content: "You've hit your weekly limit", ErrorType: "rate_limit", ErrorStatus: 429},
+	})
+	if err == nil {
+		t.Fatal("resultStreamError = nil, want error")
+	}
+	if got := err.Error(); got != "provider result error rate_limit (429)" {
+		t.Fatalf("error = %q, want provider result error rate_limit (429)", got)
+	}
+
+	if err := resultStreamError([]StreamEvent{{Type: "result", Content: "ok"}}); err != nil {
+		t.Fatalf("resultStreamError(success) = %v, want nil", err)
+	}
+
+	err = resultStreamError([]StreamEvent{{Type: "result", Subtype: "error", Content: "You've hit your weekly limit"}})
+	if err == nil {
+		t.Fatal("resultStreamError(subtype error) = nil, want error")
+	}
+
+	err = resultStreamError([]StreamEvent{{Type: "result", Subtype: "error_during_execution", Content: "No conversation found"}})
+	if err == nil {
+		t.Fatal("resultStreamError(error_during_execution) = nil, want error")
+	}
+}
+
+func TestLastHeadlessResultMarksStructuredError(t *testing.T) {
+	a := &Agent{}
+	a.AppendOutput(StreamEvent{Type: "result", Content: "You've hit your weekly limit", ErrorType: "rate_limit", ErrorStatus: 429})
+
+	found, isError := a.lastHeadlessResult()
+	if !found {
+		t.Fatal("lastHeadlessResult found = false, want true")
+	}
+	if !isError {
+		t.Fatal("lastHeadlessResult isError = false, want true")
+	}
+}
+
+func TestLastHeadlessResultMarksErrorSubtype(t *testing.T) {
+	a := &Agent{}
+	a.AppendOutput(StreamEvent{Type: "result", Subtype: "error_during_execution", Content: "No conversation found"})
+
+	found, isError := a.lastHeadlessResult()
+	if !found {
+		t.Fatal("lastHeadlessResult found = false, want true")
+	}
+	if !isError {
+		t.Fatal("lastHeadlessResult isError = false, want true")
+	}
+}
+
+func TestLastHeadlessResultIgnoresPriorRetryResult(t *testing.T) {
+	a := &Agent{}
+	a.AppendOutput(StreamEvent{Type: "result", Content: "overloaded", ErrorType: "overloaded_error", ErrorStatus: 529})
+	a.AppendOutput(StreamEvent{Type: "system", Content: "new attempt"})
+
+	found, isError := a.lastHeadlessResult()
+	if found || isError {
+		t.Fatalf("lastHeadlessResult = (%v, %v), want no terminal result", found, isError)
 	}
 }
 

--- a/internal/agent/stream.go
+++ b/internal/agent/stream.go
@@ -33,8 +33,9 @@ type ClaudeResult struct {
 	CacheCreationInputTokens int
 	CacheReadInputTokens     int
 	ReasoningTokens          int
-	// ErrorType and ErrorStatus carry structured error info when Subtype == "error".
-	// Codex: mapped from the "code" field. Claude: reserved for future extraction.
+	// ErrorType and ErrorStatus carry structured error info when available.
+	// Codex maps these from its error envelope; Claude maps `error` and
+	// `api_error_status` from result events that set `is_error`.
 	ErrorType   string
 	ErrorStatus int
 	// PremiumRequests is Copilot's billing unit (AI credits), mapped from the
@@ -88,6 +89,9 @@ type claudeEnvelope struct {
 	Message      *claudeMessagePayload `json:"message"`
 	Result       string                `json:"result"`
 	TotalCostUSD float64               `json:"total_cost_usd"`
+	IsError      bool                  `json:"is_error"`
+	APIStatus    int                   `json:"api_error_status"`
+	Error        string                `json:"error"`
 	// Real Claude Code result events nest token counts under `usage` (per
 	// platform.claude.com/docs/en/agent-sdk/headless and verified against
 	// captured agent NDJSON). Earlier root-level `total_*_tokens` fields are
@@ -730,6 +734,13 @@ func extractResultFieldsTyped(raw claudeEnvelope) ClaudeResult {
 		}
 		r.CacheCreationInputTokens = raw.Usage.CacheCreationInputTokens
 		r.CacheReadInputTokens = raw.Usage.CacheReadInputTokens
+	}
+	if raw.IsError || raw.APIStatus != 0 || raw.Error != "" {
+		r.ErrorType = raw.Error
+		if r.ErrorType == "" && raw.IsError {
+			r.ErrorType = "provider_error"
+		}
+		r.ErrorStatus = raw.APIStatus
 	}
 	return r
 }

--- a/internal/agent/stream_test.go
+++ b/internal/agent/stream_test.go
@@ -623,6 +623,16 @@ func TestClaudeEventToStreamEvent(t *testing.T) {
 			want: StreamEvent{Type: "result", Content: "done", SessionID: "sess-456", CostUSD: 0.05},
 		},
 		{
+			name: "result api error",
+			line: `{"type":"result","result":"You've hit your weekly limit","is_error":true,"api_error_status":429,"error":"rate_limit"}`,
+			want: StreamEvent{Type: "result", Content: "You've hit your weekly limit", ErrorType: "rate_limit", ErrorStatus: 429},
+		},
+		{
+			name: "result is error without envelope",
+			line: `{"type":"result","result":"API Error: 529 overloaded","is_error":true}`,
+			want: StreamEvent{Type: "result", Content: "API Error: 529 overloaded", ErrorType: "provider_error"},
+		},
+		{
 			name: "unknown type preserved",
 			line: `{"type":"rate_limit_event","subtype":"throttle"}`,
 			want: StreamEvent{Type: "rate_limit_event", Subtype: "throttle"},
@@ -675,6 +685,12 @@ func TestClaudeEventToStreamEvent(t *testing.T) {
 			}
 			if got.Subtype != tt.want.Subtype {
 				t.Errorf("Subtype = %q, want %q", got.Subtype, tt.want.Subtype)
+			}
+			if got.ErrorType != tt.want.ErrorType {
+				t.Errorf("ErrorType = %q, want %q", got.ErrorType, tt.want.ErrorType)
+			}
+			if got.ErrorStatus != tt.want.ErrorStatus {
+				t.Errorf("ErrorStatus = %d, want %d", got.ErrorStatus, tt.want.ErrorStatus)
 			}
 		})
 	}

--- a/internal/agent/survive_restart_test.go
+++ b/internal/agent/survive_restart_test.go
@@ -189,7 +189,7 @@ func TestReattachAll_ReattachesLiveHeadlessAgent(t *testing.T) {
 	if a.GetExitErr() != nil {
 		t.Fatalf("expected clean completion (terminal result seen), got err: %v", a.GetExitErr())
 	}
-	if !a.hasTerminalResult() {
+	if found, isError := a.lastHeadlessResult(); !found || isError {
 		t.Fatal("expected terminal result in buffer")
 	}
 	// Registry record is removed on completion.

--- a/internal/health/checks.go
+++ b/internal/health/checks.go
@@ -210,6 +210,9 @@ func checkStatusBounce(events []audit.Event, now time.Time) []Finding {
 		if from == "" || to == "" {
 			continue
 		}
+		if to == "human-required" && isExpectedHumanRequired(e) {
+			continue
+		}
 
 		key := from + "→" + to
 		if transitions[e.TaskID] == nil {

--- a/internal/health/checks_extra.go
+++ b/internal/health/checks_extra.go
@@ -99,6 +99,9 @@ func checkTriageMismatch(events []audit.Event, now time.Time) []Finding {
 		}
 		to, _ := e.Data["to"].(string)
 		if to == "human-required" && classifiedHeadless[e.TaskID] {
+			if isExpectedHumanRequired(e) {
+				continue
+			}
 			escalated[e.TaskID] = true
 		}
 	}
@@ -118,7 +121,13 @@ func checkTriageMismatch(events []audit.Event, now time.Time) []Finding {
 			DetectedAt: now,
 		})
 	}
+
 	return findings
+}
+
+func isExpectedHumanRequired(e audit.Event) bool {
+	kind, _ := e.Data["human_kind"].(string)
+	return kind == "review_manual" || kind == "review_draft"
 }
 
 // checkStatusBottleneck flags statuses where the average dwell time exceeds a

--- a/internal/health/checks_extra_test.go
+++ b/internal/health/checks_extra_test.go
@@ -112,6 +112,22 @@ func TestCheckTriageMismatch(t *testing.T) {
 			},
 			0,
 		},
+		{
+			"headless expected manual review handoff",
+			[]audit.Event{
+				{Type: audit.EventTriageClassified, TaskID: "t1", Data: map[string]any{"mode": "headless"}},
+				{Type: audit.EventTaskStatusChanged, TaskID: "t1", Data: map[string]any{"from": "todo", "to": "human-required", "human_kind": "review_manual"}},
+			},
+			0,
+		},
+		{
+			"headless expected draft review handoff",
+			[]audit.Event{
+				{Type: audit.EventTriageClassified, TaskID: "t1", Data: map[string]any{"mode": "headless"}},
+				{Type: audit.EventTaskStatusChanged, TaskID: "t1", Data: map[string]any{"from": "in-review", "to": "human-required", "human_kind": "review_draft"}},
+			},
+			0,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/health/checks_test.go
+++ b/internal/health/checks_test.go
@@ -231,6 +231,17 @@ func TestCheckStatusBounce(t *testing.T) {
 	}
 }
 
+func TestCheckStatusBounceSkipsExpectedHumanReviewHandoffs(t *testing.T) {
+	now := time.Now().UTC()
+	events := []audit.Event{
+		{Type: audit.EventTaskStatusChanged, TaskID: "t1", Timestamp: now, Data: map[string]any{"from": "todo", "to": "human-required", "human_kind": "review_manual"}},
+		{Type: audit.EventTaskStatusChanged, TaskID: "t1", Timestamp: now, Data: map[string]any{"from": "todo", "to": "human-required", "human_kind": "review_manual"}},
+	}
+	if got := checkStatusBounce(events, now); len(got) != 0 {
+		t.Fatalf("got %d findings, want 0", len(got))
+	}
+}
+
 func TestCheckCostDrift(t *testing.T) {
 	now := time.Now().UTC()
 

--- a/internal/provider/health_test.go
+++ b/internal/provider/health_test.go
@@ -128,6 +128,7 @@ func TestClassifyClaudeError(t *testing.T) {
 		{"stderr_rate_limit", ErrorSample{Stderr: "rate limit exceeded"}, SignalRateLimit},
 		{"content_session_limit", ErrorSample{Content: "You've hit your session limit · resets 4:30pm"}, SignalRateLimit},
 		{"content_usage_limit", ErrorSample{Content: "usage limit reached for this period"}, SignalRateLimit},
+		{"content_weekly_limit", ErrorSample{Content: "You've hit your weekly limit · resets Jul 1 at 5pm"}, SignalRateLimit},
 		{"overloaded_ignored", ErrorSample{ErrorStatus: 529, ErrorType: "overloaded_error"}, SignalNone},
 		{"unrelated", ErrorSample{Stderr: "random crash"}, SignalNone},
 	}

--- a/internal/provider/signals.go
+++ b/internal/provider/signals.go
@@ -47,8 +47,8 @@ func ClassifyClaudeError(s ErrorSample) (Signal, string, time.Duration) {
 		containsAny(content, "not logged in", "please run claude auth login") {
 		return SignalAuthFailure, "logged_out", 0
 	}
-	if containsAny(stderr, "rate_limit", "rate limit", "credit_balance_too_low", "quota", "session limit", "usage limit") ||
-		containsAny(content, "rate_limit", "rate limit", "credit_balance_too_low", "quota", "session limit", "usage limit") {
+	if containsAny(stderr, "rate_limit", "rate limit", "credit_balance_too_low", "quota", "session limit", "usage limit", "weekly limit") ||
+		containsAny(content, "rate_limit", "rate limit", "credit_balance_too_low", "quota", "session limit", "usage limit", "weekly limit") {
 		return SignalRateLimit, "rate_limited", 0
 	}
 	return SignalNone, "", 0

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -229,6 +229,12 @@ func (h *humanReviewHandler) onComplete(ag *agent.Agent) {
 	final := finalAssistantText(ag)
 	v, parseErr := parseVerdict(final)
 	if parseErr != nil {
+		if ag.GetErrorKind() == "rate_limit" {
+			h.logger.Warn("human-review.verdict.deferred",
+				"task_id", taskID, "agent_id", ag.ID, "reason", "provider_rate_limited")
+			h.logAudit(audit.EventHumanReviewSkipped, taskID, ag.ID, map[string]any{"reason": "provider_rate_limited"})
+			return
+		}
 		h.logger.Warn("human-review.verdict.parse", "task_id", taskID, "agent_id", ag.ID, "err", parseErr)
 		if h.appendNote(taskID, "Auto-review (unparseable verdict)", final) {
 			h.markVerdictRendered(taskID, ag.ID)

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -426,6 +426,44 @@ func TestOnComplete_MalformedVerdict_AppendsRaw(t *testing.T) {
 	}
 }
 
+func TestOnComplete_RateLimitedVerdictDoesNotRenderNoise(t *testing.T) {
+	t.Parallel()
+	h, tasks, sink, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	tk, err := tasks.Create("Quota limited", "Body.", "headless")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{Status: task.Ptr(task.StatusHumanRequired)}); err != nil {
+		t.Fatalf("flip: %v", err)
+	}
+	if err := tasks.AddRun(tk.ID, task.AgentRun{AgentID: "hr1", Role: string(agent.RoleHumanReview)}); err != nil {
+		t.Fatalf("add run: %v", err)
+	}
+
+	ag := &agent.Agent{ID: "hr1", TaskID: tk.ID, Name: agent.RoleHumanReview.AgentName(tk.Title)}
+	ag.SetError("rate_limit", "weekly limit")
+	ag.AppendOutput(agent.StreamEvent{Type: "result", Content: "You've hit your weekly limit"})
+	h.onComplete(ag)
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("re-load: %v", err)
+	}
+	if strings.Contains(got.Body, "unparseable verdict") {
+		t.Errorf("rate-limited human-review should not append unparseable verdict noise; got:\n%s", got.Body)
+	}
+	for _, run := range got.AgentRuns {
+		if run.AgentID == "hr1" && run.VerdictRendered {
+			t.Fatal("rate-limited human-review must not mark verdict_rendered")
+		}
+	}
+	if sink.calls != 0 {
+		t.Errorf("sink should not be called on quota failure; calls=%d", sink.calls)
+	}
+}
+
 func TestMaybeSpawn_IdempotencyGate_SkipsWhenVerdictRendered(t *testing.T) {
 	t.Parallel()
 	// h.agents is nil in newReviewTestEnv — if maybeSpawn tries to spawn an

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -216,7 +217,15 @@ func (a *App) limitPolicy() limits.Policy {
 
 func (a *App) initStatusHook() {
 	a.tasks.SetStatusChangeHook(func(taskID, from, to string) {
-		a.logAudit(audit.EventTaskStatusChanged, taskID, "", map[string]any{"from": from, "to": to})
+		data := map[string]any{"from": from, "to": to}
+		if to == string(task.StatusHumanRequired) {
+			if t, err := a.tasks.Get(taskID); err == nil {
+				if kind := expectedHumanKind(t); kind != "" {
+					data["human_kind"] = kind
+				}
+			}
+		}
+		a.logAudit(audit.EventTaskStatusChanged, taskID, "", data)
 
 		// Wake the dispatch pass immediately so a task that just became ready
 		// (e.g. a dependency completing, a stage advancing) is picked up now
@@ -285,6 +294,22 @@ func (a *App) initStatusHook() {
 			}
 		}
 	})
+}
+
+func expectedHumanKind(t task.Task) string {
+	if !slices.Contains(t.Tags, "review") {
+		return ""
+	}
+	switch {
+	case t.ReviewPhase == ReviewPhaseDrafted ||
+		strings.HasPrefix(t.StatusReason, "Draft review ready"):
+		return "review_draft"
+	case t.ReviewPhase == ReviewPhaseManual ||
+		strings.HasPrefix(t.StatusReason, "PR too small for agent review"):
+		return "review_manual"
+	default:
+		return ""
+	}
 }
 
 // maybeStartWorkflowForExternalTask starts the matching task.created workflow

--- a/internal/sybra/app_reviews_outbound.go
+++ b/internal/sybra/app_reviews_outbound.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
 )
 
 const linkedPRDriftWindow = 10 * time.Minute
@@ -100,7 +101,7 @@ func linkedOwnPRHumanRequiredDrift(t *task.Task, livePR bool) bool {
 	if t.Workflow == nil {
 		return false
 	}
-	if t.Workflow.WorkflowID != "simple-task-pr" || string(t.Workflow.State) != "completed" || t.Workflow.CompletedAt == nil {
+	if t.Workflow.WorkflowID != "simple-task-pr" || t.Workflow.State != workflow.ExecCompleted || t.Workflow.CompletedAt == nil {
 		return false
 	}
 	completedAt := *t.Workflow.CompletedAt

--- a/internal/sybra/app_reviews_outbound.go
+++ b/internal/sybra/app_reviews_outbound.go
@@ -2,10 +2,14 @@ package sybra
 
 import (
 	"slices"
+	"strings"
+	"time"
 
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/task"
 )
+
+const linkedPRDriftWindow = 10 * time.Minute
 
 // reconcilePRPhases recomputes the lifecycle phase of every outbound own-PR
 // task (status in-review/ready-review, not tag `review`) from the live
@@ -25,6 +29,10 @@ func (r *ReviewHandler) reconcilePRPhases(tasks []task.Task, monitoredPRs []gith
 
 	for i := range tasks {
 		t := &tasks[i]
+		if repaired := r.reactivateLinkedOwnPR(t, matchingPR(t, byNumber, byBranch) != nil); repaired != nil {
+			tasks[i] = *repaired
+			t = repaired
+		}
 		if !ownPRColumnTask(t) {
 			// Clear a stale phase left over from when the task was in review
 			// (e.g. it was moved back to in-progress or its PR closed) so the
@@ -35,10 +43,7 @@ func (r *ReviewHandler) reconcilePRPhases(tasks []task.Task, monitoredPRs []gith
 			continue
 		}
 
-		pr := byNumber[t.PRNumber]
-		if pr == nil {
-			pr = byBranch[t.Branch]
-		}
+		pr := matchingPR(t, byNumber, byBranch)
 		if pr == nil {
 			// PR not in the current summary yet (just opened / cache miss).
 			// Leave the existing phase untouched until it appears.
@@ -56,6 +61,53 @@ func (r *ReviewHandler) reconcilePRPhases(tasks []task.Task, monitoredPRs []gith
 			ActionableCount:  pr.ActionableCount,
 		}))
 	}
+}
+
+func matchingPR(t *task.Task, byNumber map[int]*github.PullRequest, byBranch map[string]*github.PullRequest) *github.PullRequest {
+	if t == nil {
+		return nil
+	}
+	pr := byNumber[t.PRNumber]
+	if pr == nil {
+		pr = byBranch[t.Branch]
+	}
+	return pr
+}
+
+func (r *ReviewHandler) reactivateLinkedOwnPR(t *task.Task, livePR bool) *task.Task {
+	if !linkedOwnPRHumanRequiredDrift(t, livePR) {
+		return nil
+	}
+	updated, err := r.tasks.Update(t.ID, task.Update{
+		Status:       task.Ptr(task.StatusInReview),
+		StatusReason: task.Ptr(""),
+	})
+	if err != nil {
+		r.logger.Error("pr-monitor.reactivate-linked-pr", "task_id", t.ID, "pr", t.PRNumber, "err", err)
+		return nil
+	}
+	r.logger.Info("pr-monitor.reactivate-linked-pr", "task_id", t.ID, "pr", t.PRNumber)
+	return &updated
+}
+
+func linkedOwnPRHumanRequiredDrift(t *task.Task, livePR bool) bool {
+	if t == nil || t.TaskType == task.TaskTypeChat || slices.Contains(t.Tags, "review") {
+		return false
+	}
+	if !livePR || t.Status != task.StatusHumanRequired || t.PRNumber == 0 || strings.TrimSpace(t.StatusReason) != "" {
+		return false
+	}
+	if t.Workflow == nil {
+		return false
+	}
+	if t.Workflow.WorkflowID != "simple-task-pr" || string(t.Workflow.State) != "completed" || t.Workflow.CompletedAt == nil {
+		return false
+	}
+	completedAt := *t.Workflow.CompletedAt
+	if t.UpdatedAt.After(completedAt) {
+		return false
+	}
+	return completedAt.Sub(t.UpdatedAt) <= linkedPRDriftWindow
 }
 
 // ownPRColumnTask reports whether a task is one of the user's own PRs shown in

--- a/internal/sybra/app_reviews_outbound_test.go
+++ b/internal/sybra/app_reviews_outbound_test.go
@@ -4,10 +4,12 @@ import (
 	"log/slog"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
 )
 
 // newOutboundTestHandler builds a ReviewHandler backed by a temp task store and
@@ -107,6 +109,161 @@ func TestReconcilePRPhasesClearsStaleWhenIneligible(t *testing.T) {
 	}
 	if got.PRPhase != "" {
 		t.Errorf("stale PRPhase = %q, want cleared", got.PRPhase)
+	}
+}
+
+func TestLinkedOwnPRHumanRequiredDrift(t *testing.T) {
+	completedAt := time.Now().UTC()
+	ts := completedAt.Add(-time.Minute)
+	drifted := &task.Task{
+		Status:       task.StatusHumanRequired,
+		PRNumber:     42,
+		UpdatedAt:    ts,
+		StatusReason: "",
+		Workflow: &workflow.Execution{
+			WorkflowID:  "simple-task-pr",
+			State:       workflow.ExecCompleted,
+			CompletedAt: &completedAt,
+		},
+	}
+	if !linkedOwnPRHumanRequiredDrift(drifted, true) {
+		t.Fatal("expected linked PR drift")
+	}
+}
+
+func TestReconcilePRPhasesDoesNotReactivateFreshManualHumanRequired(t *testing.T) {
+	r, tasks := newOutboundTestHandler(t)
+
+	created := mkOwnPRTask(t, tasks, 42, nil)
+	completedAt := time.Now().UTC().Add(-500 * time.Millisecond)
+	wf := &workflow.Execution{
+		WorkflowID:  "simple-task-pr",
+		State:       workflow.ExecCompleted,
+		CompletedAt: &completedAt,
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr(""),
+		Workflow:     &wf,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.reconcilePRPhases(all, []github.PullRequest{{Number: 42, ReviewDecision: "APPROVED", Mergeable: "MERGEABLE", CIStatus: "SUCCESS"}})
+
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Errorf("status = %q, want human-required", got.Status)
+	}
+}
+
+func TestReconcilePRPhasesDoesNotReactivateReasonedHumanRequired(t *testing.T) {
+	r, tasks := newOutboundTestHandler(t)
+
+	created := mkOwnPRTask(t, tasks, 42, nil)
+	reason := "testing infrastructure failed after retry"
+	now := time.Now().UTC()
+	wf := &workflow.Execution{
+		WorkflowID:  "simple-task-pr",
+		State:       workflow.ExecCompleted,
+		CompletedAt: &now,
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: &reason,
+		Workflow:     &wf,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.reconcilePRPhases(all, []github.PullRequest{{Number: 42, ReviewDecision: "APPROVED", Mergeable: "MERGEABLE", CIStatus: "SUCCESS"}})
+
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Errorf("status = %q, want human-required", got.Status)
+	}
+	if got.PRPhase != "" {
+		t.Errorf("phase = %q, want unchanged empty", got.PRPhase)
+	}
+}
+
+func TestReconcilePRPhasesDoesNotReactivateLaterManualHumanRequired(t *testing.T) {
+	r, tasks := newOutboundTestHandler(t)
+
+	created := mkOwnPRTask(t, tasks, 42, nil)
+	completedAt := time.Now().UTC().Add(-5 * time.Minute)
+	wf := &workflow.Execution{
+		WorkflowID:  "simple-task-pr",
+		State:       workflow.ExecCompleted,
+		CompletedAt: &completedAt,
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr(""),
+		Workflow:     &wf,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.reconcilePRPhases(all, []github.PullRequest{{Number: 42, ReviewDecision: "APPROVED", Mergeable: "MERGEABLE", CIStatus: "SUCCESS"}})
+
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Errorf("status = %q, want human-required", got.Status)
+	}
+}
+
+func TestReconcilePRPhasesDoesNotReactivateWithoutLivePR(t *testing.T) {
+	r, tasks := newOutboundTestHandler(t)
+
+	created := mkOwnPRTask(t, tasks, 42, nil)
+	now := time.Now().UTC()
+	wf := &workflow.Execution{
+		WorkflowID:  "simple-task-pr",
+		State:       workflow.ExecCompleted,
+		CompletedAt: &now,
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr(""),
+		Workflow:     &wf,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.reconcilePRPhases(all, nil)
+
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Errorf("status = %q, want human-required", got.Status)
 	}
 }
 

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -2595,18 +2595,17 @@ func TestE2E_BuiltinSimpleTask_PlanCriticRunsBeforeReview(t *testing.T) {
 	}
 }
 
-// TestE2E_BuiltinSimpleTask_MissingCritiqueFlipsHumanRequired covers the
+// TestE2E_BuiltinSimpleTask_MissingCritiqueSkipsToPlanReview covers the
 // failure mode that motivated the require_sidecar guard: the critic agent
 // exits cleanly (no process error) but never ran `sybra-cli update
 // --plan-critique-file` — e.g. because its shell was sandboxed away inside
-// a Docker container. Without the guard the workflow would silently advance
-// to address_critique with nothing to address and the human review page
-// would render only the plan. The guard must flip the task to human-required
-// and halt the workflow.
-func TestE2E_BuiltinSimpleTask_MissingCritiqueFlipsHumanRequired(t *testing.T) {
+// a Docker container. The guard records a non-fatal skip and routes straight
+// to the existing human plan review instead of parking the task in
+// human-required.
+func TestE2E_BuiltinSimpleTask_MissingCritiqueSkipsToPlanReview(t *testing.T) {
 	// Single-opus plan flow: triage → plan → require_plan → validate_plan_refs
-	// → maybe_critique → critique_plan (no_save) → require_plan_critique guard
-	// fires.
+	// → maybe_critique → critique_plan (no_save) → require_plan_critique
+	// (soft skip) → review_plan.
 	env := setupE2EMulti(t, []string{
 		"triage_to_planning",    // triage: status=planning, tags=large
 		"write_sidecar_success", // plan — writes the plan sidecar
@@ -2623,13 +2622,15 @@ func TestE2E_BuiltinSimpleTask_MissingCritiqueFlipsHumanRequired(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Wait for ExecCompleted, not just status: execRequireSidecar updates status before the engine records the step, so a status-only poll races the history append.
-	waitFor(t, 30*time.Second, "workflow completes via require_plan_critique guard", func() bool {
+	waitFor(t, 30*time.Second, "workflow reaches review_plan after missing critique soft skip", func() bool {
 		tk, gErr := env.tasks.Get(created.ID)
 		if gErr != nil {
 			return false
 		}
-		return tk.Workflow != nil && tk.Workflow.State == workflow.ExecCompleted && tk.Status == task.StatusHumanRequired
+		return tk.Workflow != nil &&
+			tk.Workflow.CurrentStep == "review_plan" &&
+			tk.Workflow.State == workflow.ExecWaiting &&
+			tk.Status == task.StatusPlanReview
 	})
 
 	tk, err := env.tasks.Get(created.ID)
@@ -2645,13 +2646,20 @@ func TestE2E_BuiltinSimpleTask_MissingCritiqueFlipsHumanRequired(t *testing.T) {
 		t.Errorf("require_plan_critique guard did not execute\nhistory: %v", stepIDs)
 	}
 	if slices.Contains(stepIDs, "address_critique") {
-		t.Errorf("address_critique ran despite missing critique — guard failed to halt\nhistory: %v", stepIDs)
+		t.Errorf("address_critique ran despite missing critique — guard failed to soft-skip\nhistory: %v", stepIDs)
 	}
 	if tk.PlanCritique != "" {
 		t.Errorf("PlanCritique unexpectedly non-empty after no_save scenario: %q", tk.PlanCritique)
 	}
-	if !strings.Contains(strings.ToLower(tk.StatusReason), "plan critique") {
-		t.Errorf("status reason does not mention plan critique: %q", tk.StatusReason)
+	var requireOutput string
+	for _, rec := range tk.Workflow.StepHistory {
+		if rec.StepID == "require_plan_critique" {
+			requireOutput = rec.Output
+			break
+		}
+	}
+	if !strings.Contains(strings.ToLower(requireOutput), "skipped") {
+		t.Errorf("require_plan_critique output = %q, want skipped", requireOutput)
 	}
 }
 

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -719,12 +719,13 @@ func (s *Store) UpdateWithPrev(id string, u Update) (Task, Status, error) {
 	// stamp TestingCycleStartedAt so route_test_result only counts runs from
 	// this new cycle, not from prior ones. Skipped when the caller already
 	// supplied an explicit value (u.TestingCycleStartedAt != nil).
+	now := time.Now().UTC()
 	if prevStatus == StatusHumanRequired &&
 		t.Status != StatusHumanRequired &&
 		u.TestingCycleStartedAt == nil {
-		now := time.Now().UTC()
 		t.TestingCycleStartedAt = &now
 	}
+	t.UpdatedAt = now
 	if err := s.writeSidecars(id, u, &t); err != nil {
 		return Task{}, "", err
 	}

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -197,6 +197,9 @@ func TestStoreUpdate(t *testing.T) {
 	if updated.Body != "new body" {
 		t.Errorf("Body = %q, want %q", updated.Body, "new body")
 	}
+	if !updated.UpdatedAt.After(created.UpdatedAt) {
+		t.Errorf("UpdatedAt = %v, want after create time %v", updated.UpdatedAt, created.UpdatedAt)
+	}
 
 	// Verify persisted
 	reloaded, err := store.Get(created.ID)

--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -410,8 +410,8 @@ steps:
   # produced its output file (e.g. shell blocked by a sandbox). Without
   # this check the workflow silently advances to address_critique with
   # an empty sidecar, and the human sees only the plan — no critique —
-  # in the review UI. Flips task to human-required when the sidecar is
-  # empty so the failure is visible.
+  # in the review UI. This gate soft-skips missing critique output so planning
+  # can still reach human review instead of getting stranded.
   - id: require_plan_critique
     name: Require Plan Critique
     type: require_sidecar
@@ -421,8 +421,8 @@ steps:
     next:
       - when:
           field: vars.step.require_plan_critique.output
-          operator: equals
-          value: plan critique missing — upstream agent step completed without writing its sidecar — skipped
+          operator: contains
+          value: skipped
         goto: review_plan
       - when:
           field: task.status

--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -381,8 +381,12 @@ steps:
              weak verification, acceptance gaps, risk, permission posture, and
              rollback/recovery coverage.
           4. Invoke: /plan-critic /tmp/sybra-plan-contract-review-{{.Task.ID}}.md
-          5. Capture the full markdown Plan Review report you produce and
-             write it to /tmp/sybra-critique-{{.Task.ID}}.md
+          5. As soon as each persona/result is available, append a concise
+             grounded finding summary to /tmp/sybra-critique-{{.Task.ID}}.md.
+             Do not wait for the final synthesis before writing the first
+             useful content.
+          6. Capture the final markdown Plan Review report you produce and
+             overwrite /tmp/sybra-critique-{{.Task.ID}}.md with it.
 
         Do NOT modify the plan. Do NOT change the task status. Sybra
         will ingest /tmp/sybra-critique-{{.Task.ID}}.md as the task's
@@ -413,7 +417,13 @@ steps:
     type: require_sidecar
     config:
       sidecar: plan_critique
+      allow_missing: true
     next:
+      - when:
+          field: vars.step.require_plan_critique.output
+          operator: equals
+          value: plan critique missing — upstream agent step completed without writing its sidecar — skipped
+        goto: review_plan
       - when:
           field: task.status
           operator: equals

--- a/internal/workflow/builtin/testing-task.yaml
+++ b/internal/workflow/builtin/testing-task.yaml
@@ -52,7 +52,7 @@ steps:
       needs_worktree: true
       max_retries: 1
       output_schema: >-
-        {"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]},"outcome":{"type":"string","enum":["product_bug","infra_failure","ambiguous_requirement","missing_evidence"]},"failures_markdown":{"type":"string"}},"required":["verdict"],"additionalProperties":false}
+        {"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]},"outcome":{"type":"string","enum":["product_bug","infra_failure","ambiguous_requirement","missing_evidence"]},"failures_markdown":{"type":"string"}},"required":["verdict","outcome","failures_markdown"],"additionalProperties":false}
       prompt: >-
         Adversarially test task {{.Task.ID}} using the /sybra-test skill.
 

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -102,7 +102,7 @@ func TestBuiltinSimpleTask_MissingCritiqueSkipsToHumanReview(t *testing.T) {
 		t.Fatal("require_plan_critique must soft-fail when the critic produces no sidecar")
 	}
 	got, err := ResolveTransition(step.Next, map[string]string{
-		"vars.step.require_plan_critique.output": "plan critique missing — upstream agent step completed without writing its sidecar — skipped",
+		"vars.step.require_plan_critique.output": "plan critique missing — upstream agent step completed without writing its sidecar — skipped (non-fatal)",
 	})
 	if err != nil {
 		t.Fatalf("ResolveTransition: %v", err)

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -76,6 +76,41 @@ func TestBuiltinSimpleTask_MaybeCritiqueReplanSkip(t *testing.T) {
 	}
 }
 
+func TestBuiltinSimpleTask_MissingCritiqueSkipsToHumanReview(t *testing.T) {
+	t.Parallel()
+
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var simple *Definition
+	for i := range defs {
+		if defs[i].ID == "simple-task-plan" {
+			simple = &defs[i]
+			break
+		}
+	}
+	if simple == nil {
+		t.Fatal("simple-task-plan builtin definition not found")
+	}
+	step := simple.StepByID("require_plan_critique")
+	if step == nil {
+		t.Fatal("require_plan_critique step not found in simple-task-plan")
+	}
+	if !step.Config.AllowMissing {
+		t.Fatal("require_plan_critique must soft-fail when the critic produces no sidecar")
+	}
+	got, err := ResolveTransition(step.Next, map[string]string{
+		"vars.step.require_plan_critique.output": "plan critique missing — upstream agent step completed without writing its sidecar — skipped",
+	})
+	if err != nil {
+		t.Fatalf("ResolveTransition: %v", err)
+	}
+	if got != "review_plan" {
+		t.Fatalf("missing critique next = %q, want review_plan", got)
+	}
+}
+
 func TestBuiltinSimpleTask_AddressCritiqueRevalidatesPlanArtifacts(t *testing.T) {
 	t.Parallel()
 
@@ -573,7 +608,7 @@ func TestBuiltinTestingTask_RunTestOutputSchema(t *testing.T) {
 	if step == nil {
 		t.Fatal("run_test step not found in testing-task")
 	}
-	const wantSchema = `{"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]},"outcome":{"type":"string","enum":["product_bug","infra_failure","ambiguous_requirement","missing_evidence"]},"failures_markdown":{"type":"string"}},"required":["verdict"],"additionalProperties":false}`
+	const wantSchema = `{"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]},"outcome":{"type":"string","enum":["product_bug","infra_failure","ambiguous_requirement","missing_evidence"]},"failures_markdown":{"type":"string"}},"required":["verdict","outcome","failures_markdown"],"additionalProperties":false}`
 	if step.Config.OutputSchema != wantSchema {
 		t.Errorf("run_test.Config.OutputSchema =\n%q\nwant:\n%q", step.Config.OutputSchema, wantSchema)
 	}

--- a/internal/workflow/engine_steps_verify.go
+++ b/internal/workflow/engine_steps_verify.go
@@ -136,7 +136,8 @@ func (e *Engine) execRerequestReview(taskID string, step *Step, t TaskInfo) (Ste
 // exits cleanly without producing its expected output file.
 func (e *Engine) execRequireSidecar(taskID string, step *Step, t TaskInfo) (StepOutput, error) {
 	var content, label string
-	switch sk := step.Config.Sidecar; {
+	sk := step.Config.Sidecar
+	switch {
 	case sk == "plan_contract":
 		content = t.PlanContract
 		label = "plan contract"
@@ -167,8 +168,15 @@ func (e *Engine) execRequireSidecar(taskID string, step *Step, t TaskInfo) (Step
 	default:
 		return StepOutput{}, fmt.Errorf("require_sidecar: unknown sidecar %q (want plan|plan_contract|plan_critique|plan_research|plan_decisions|plan_brief|code_review|plan_draft.<name>)", sk)
 	}
+	if step.Config.AllowMissing && (step.ID != "require_plan_critique" || sk != "plan_critique") {
+		return StepOutput{}, fmt.Errorf("require_sidecar: allow_missing is only supported for require_plan_critique plan_critique")
+	}
 	if strings.TrimSpace(content) == "" {
 		reason := label + " missing — upstream agent step completed without writing its sidecar"
+		if step.Config.AllowMissing {
+			e.logger.Warn("workflow.require-sidecar.missing-soft", "task_id", taskID, "sidecar", step.Config.Sidecar)
+			return StepOutput{StepID: step.ID, Status: "completed", Output: reason + " — skipped"}, nil
+		}
 		if statusErr := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); statusErr != nil {
 			e.logger.Error("workflow.require-sidecar.status", "task_id", taskID, "err", statusErr)
 		}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -3464,6 +3464,13 @@ func newRequireSidecarStep(kind string) *Step {
 	}
 }
 
+func newRequireSidecarAllowMissingStep(kind string) *Step {
+	step := newRequireSidecarStep(kind)
+	step.ID = "require_plan_critique"
+	step.Config.AllowMissing = true
+	return step
+}
+
 func TestExecRequireSidecar_PlanCritiquePresent(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "planning", PlanCritique: "# critique\n"})
@@ -3503,6 +3510,40 @@ func TestExecRequireSidecar_PlanCritiqueMissingFlipsHumanRequired(t *testing.T) 
 	}
 	if !strings.Contains(tasks.Reason("t1"), "plan critique") {
 		t.Errorf("reason = %q, want substring 'plan critique'", tasks.Reason("t1"))
+	}
+}
+
+func TestExecRequireSidecar_AllowMissingDoesNotFlipHumanRequired(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "planning"})
+	engine := newEngineForEval(t, tasks)
+
+	out, err := engine.execRequireSidecar("t1", newRequireSidecarAllowMissingStep("plan_critique"), TaskInfo{ID: "t1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.Output, "skipped") {
+		t.Errorf("Output = %q, want skipped warning", out.Output)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if ti.Status == "human-required" {
+		t.Fatal("allow_missing should not flip task to human-required")
+	}
+}
+
+func TestExecRequireSidecar_AllowMissingRejectedOutsidePlanCritique(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "planning"})
+	engine := newEngineForEval(t, tasks)
+
+	step := newRequireSidecarStep("code_review")
+	step.Config.AllowMissing = true
+	_, err := engine.execRequireSidecar("t1", step, TaskInfo{ID: "t1"})
+	if err == nil {
+		t.Fatal("expected allow_missing validation error")
+	}
+	if !strings.Contains(err.Error(), "allow_missing is only supported") {
+		t.Fatalf("error = %v, want allow_missing validation", err)
 	}
 }
 

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -174,6 +174,9 @@ type StepConfig struct {
 	// Valid values: "plan", "plan_critique", "plan_research",
 	// "plan_decisions", "plan_brief", "code_review", or "plan_draft.<name>".
 	Sidecar string `yaml:"sidecar,omitempty" json:"sidecar"`
+	// AllowMissing turns require_sidecar into a soft gate: the step records a
+	// warning output instead of flipping the task to human-required.
+	AllowMissing bool `yaml:"allow_missing,omitempty" json:"allowMissing"`
 
 	// run_agent: when set, the engine ingests a file produced by the agent
 	// (typically under /tmp) and stores its content as the named task


### PR DESCRIPTION
## Motivation

Several expected or transient automation states were surfacing as noisy `human-required` tasks instead of retrying, stalling, or being ignored by health checks.

> Changelog: fix(workflow): reduce human-required noise

## Implementation information

- Parse Claude result error fields, retry overloads, classify quota failures, and handle detached reattach result errors.
- Fix Codex test-runner schema requirements and restrict soft missing sidecars to the plan-critic gate.
- Annotate expected review handoffs for health checks and make linked-PR drift repair conservative.
- Refresh task `updated_at` on updates so automation can distinguish fresh manual changes.

## Supporting documentation

- `go test ./...`