### PR TITLE
fix(limits): poll live provider quotas

### DIFF
--- a/internal/limits/collect_test.go
+++ b/internal/limits/collect_test.go
@@ -30,6 +30,56 @@ func TestParseCodexLine_RateLimitsAndUsage(t *testing.T) {
 	}
 }
 
+func TestParseClaudeUsageSnapshot(t *testing.T) {
+	now := time.Date(2026, 6, 28, 8, 45, 0, 0, time.UTC)
+	line := []byte(`{"five_hour":{"utilization":0.0,"resets_at":null},"seven_day":{"utilization":100.0,"resets_at":"2026-07-01T14:59:59.747459+00:00"}}`)
+
+	snapshot, ok, err := parseClaudeUsageSnapshot(line, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("parseClaudeUsageSnapshot returned ok=false")
+	}
+	if snapshot.Provider != ProviderClaude || snapshot.Source != SourceLivePoll || snapshot.Confidence != ConfidenceExact {
+		t.Fatalf("snapshot provider/source/confidence mismatch: %+v", snapshot)
+	}
+	if snapshot.Primary == nil || snapshot.Primary.UsedPercent != 0 || snapshot.Primary.WindowMinutes != 300 {
+		t.Fatalf("primary snapshot mismatch: %+v", snapshot.Primary)
+	}
+	if snapshot.Secondary == nil || snapshot.Secondary.UsedPercent != 100 || snapshot.Secondary.WindowMinutes != 10080 {
+		t.Fatalf("secondary snapshot mismatch: %+v", snapshot.Secondary)
+	}
+	if snapshot.Secondary.ResetsAt.IsZero() {
+		t.Fatalf("secondary reset was not parsed: %+v", snapshot.Secondary)
+	}
+}
+
+func TestParseCodexAppServerSnapshot(t *testing.T) {
+	now := time.Date(2026, 6, 28, 8, 45, 0, 0, time.UTC)
+	line := []byte(`{"rateLimits":{"limitId":"codex","limitName":null,"primary":{"usedPercent":9,"windowDurationMins":300,"resetsAt":1782652179},"secondary":{"usedPercent":100,"windowDurationMins":10080,"resetsAt":1782989755},"credits":{"hasCredits":false,"unlimited":false,"balance":"0"},"individualLimit":null,"planType":"prolite","rateLimitReachedType":"rate_limit_reached"}}`)
+
+	snapshot, ok, err := parseCodexAppServerSnapshot(line, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("parseCodexAppServerSnapshot returned ok=false")
+	}
+	if snapshot.Provider != ProviderCodex || snapshot.Source != SourceLivePoll || snapshot.Confidence != ConfidenceExact {
+		t.Fatalf("snapshot provider/source/confidence mismatch: %+v", snapshot)
+	}
+	if snapshot.PlanType != "prolite" || snapshot.RateLimitReachedType != "rate_limit_reached" {
+		t.Fatalf("metadata mismatch: %+v", snapshot)
+	}
+	if snapshot.Primary == nil || snapshot.Primary.UsedPercent != 9 || snapshot.Primary.WindowMinutes != 300 {
+		t.Fatalf("primary snapshot mismatch: %+v", snapshot.Primary)
+	}
+	if snapshot.Secondary == nil || snapshot.Secondary.UsedPercent != 100 || snapshot.Secondary.WindowMinutes != 10080 {
+		t.Fatalf("secondary snapshot mismatch: %+v", snapshot.Secondary)
+	}
+}
+
 func TestStoreProviderAvailableAndChooseProvider(t *testing.T) {
 	s, err := NewStore(filepath.Join(t.TempDir(), "limits.json"))
 	if err != nil {
@@ -65,6 +115,68 @@ func TestStoreProviderAvailableAndChooseProvider(t *testing.T) {
 	alt, _ := s.ChooseProvider(ProviderCodex, []string{ProviderClaude, ProviderCodex, ProviderCopilot}, func(string) bool { return true }, policy)
 	if alt != ProviderClaude {
 		t.Fatalf("alternative = %q, want claude", alt)
+	}
+}
+
+func TestSummary_DowngradesStaleExactSnapshot(t *testing.T) {
+	s, err := NewStore(filepath.Join(t.TempDir(), "limits.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+	s.now = func() time.Time { return now }
+	if err := s.UpdateSnapshot(Snapshot{
+		Provider:   ProviderCodex,
+		Source:     SourceSessionFiles,
+		Confidence: ConfidenceExact,
+		CapturedAt: now.Add(-2 * time.Hour),
+		Primary:    &CycleSnapshot{UsedPercent: 10, WindowMinutes: 300, ResetsAt: now.Add(time.Hour)},
+		Secondary:  &CycleSnapshot{UsedPercent: 68, WindowMinutes: 10080, ResetsAt: now.AddDate(0, 0, 4)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	summary := s.Summary(DefaultPolicy())
+	var codex ProviderSummary
+	for _, p := range summary.Providers {
+		if p.Provider == ProviderCodex {
+			codex = p
+			break
+		}
+	}
+	if codex.Confidence != ConfidenceEstimated {
+		t.Fatalf("confidence = %q, want estimated for stale snapshot", codex.Confidence)
+	}
+	if codex.SessionUsedPercent != 0 || codex.WeeklyUsedPercent != 0 {
+		t.Fatalf("stale exact percentages surfaced: %+v", codex)
+	}
+	if codex.QuotaLimited {
+		t.Fatalf("stale exact snapshot limited provider: %+v", codex)
+	}
+}
+
+func TestSummary_RateLimitReachedTypeLimitsProvider(t *testing.T) {
+	s, err := NewStore(filepath.Join(t.TempDir(), "limits.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+	s.now = func() time.Time { return now }
+	if err := s.UpdateSnapshot(Snapshot{
+		Provider:             ProviderCodex,
+		Source:               SourceLivePoll,
+		Confidence:           ConfidenceExact,
+		CapturedAt:           now,
+		RateLimitReachedType: "rate_limit_reached",
+		Primary:              &CycleSnapshot{UsedPercent: 9, WindowMinutes: 300, ResetsAt: now.Add(time.Hour)},
+		Secondary:            &CycleSnapshot{UsedPercent: 100, WindowMinutes: 10080, ResetsAt: now.AddDate(0, 0, 4)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ok, reason := s.ProviderAvailable(ProviderCodex, DefaultPolicy())
+	if ok || reason != "provider reports rate limit reached" {
+		t.Fatalf("ProviderAvailable = %v, reason=%q; want provider-reported limit", ok, reason)
 	}
 }
 

--- a/internal/limits/live.go
+++ b/internal/limits/live.go
@@ -76,15 +76,15 @@ type codexAppServerLimitWindow struct {
 // snapshots they expose. Missing credentials/CLIs are non-fatal for the other
 // provider; callers can log the returned joined error for diagnostics.
 func (s *Store) RefreshLiveSnapshots(ctx context.Context, policy Policy) error {
-	ctx, cancel := context.WithTimeout(ctx, liveFetchTimeout)
-	defer cancel()
-
 	now := s.now().UTC()
 	var snapshots []Snapshot
 	var errs []error
 
 	if providerEnabled(policy, ProviderClaude) {
-		if snapshot, ok, err := fetchClaudeLiveSnapshot(ctx, now); err != nil {
+		providerCtx, cancel := context.WithTimeout(ctx, liveFetchTimeout)
+		snapshot, ok, err := fetchClaudeLiveSnapshot(providerCtx, now)
+		cancel()
+		if err != nil {
 			errs = append(errs, fmt.Errorf("claude: %w", err))
 		} else if ok {
 			snapshots = append(snapshots, snapshot)
@@ -92,7 +92,10 @@ func (s *Store) RefreshLiveSnapshots(ctx context.Context, policy Policy) error {
 	}
 
 	if providerEnabled(policy, ProviderCodex) {
-		if snapshot, ok, err := fetchCodexLiveSnapshot(ctx, now); err != nil {
+		providerCtx, cancel := context.WithTimeout(ctx, liveFetchTimeout)
+		snapshot, ok, err := fetchCodexLiveSnapshot(providerCtx, now)
+		cancel()
+		if err != nil {
 			errs = append(errs, fmt.Errorf("codex: %w", err))
 		} else if ok {
 			snapshots = append(snapshots, snapshot)

--- a/internal/limits/live.go
+++ b/internal/limits/live.go
@@ -1,0 +1,410 @@
+package limits
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+const (
+	claudeOAuthUsageURL = "https://api.anthropic.com/api/oauth/usage"
+	claudeOAuthBeta     = "oauth-2025-04-20"
+	claudeUserAgent     = "claude-code/2.1.0"
+	liveFetchTimeout    = 15 * time.Second
+	keychainTimeout     = 3 * time.Second
+)
+
+type claudeCredentials struct {
+	ClaudeAIOAuth struct {
+		AccessToken      string `json:"accessToken"`
+		SubscriptionType string `json:"subscriptionType"`
+		RateLimitTier    string `json:"rateLimitTier"`
+	} `json:"claudeAiOauth"`
+}
+
+type claudeUsageResponse struct {
+	FiveHour *claudeUsageWindow `json:"five_hour"`
+	SevenDay *claudeUsageWindow `json:"seven_day"`
+}
+
+type claudeUsageWindow struct {
+	Utilization *float64 `json:"utilization"`
+	ResetsAt    *string  `json:"resets_at"`
+}
+
+type codexRPCMessage struct {
+	ID     *int            `json:"id,omitempty"`
+	Method string          `json:"method,omitempty"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Error  *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+type codexRateLimitsResponse struct {
+	RateLimits *codexAppServerRateLimits `json:"rateLimits"`
+}
+
+type codexAppServerRateLimits struct {
+	LimitID              string                     `json:"limitId"`
+	LimitName            *string                    `json:"limitName"`
+	Primary              *codexAppServerLimitWindow `json:"primary"`
+	Secondary            *codexAppServerLimitWindow `json:"secondary"`
+	PlanType             string                     `json:"planType"`
+	RateLimitReachedType *string                    `json:"rateLimitReachedType"`
+}
+
+type codexAppServerLimitWindow struct {
+	UsedPercent       float64 `json:"usedPercent"`
+	WindowDurationMin int     `json:"windowDurationMins"`
+	ResetsAt          int64   `json:"resetsAt"`
+}
+
+// RefreshLiveSnapshots polls provider account quota APIs and persists any exact
+// snapshots they expose. Missing credentials/CLIs are non-fatal for the other
+// provider; callers can log the returned joined error for diagnostics.
+func (s *Store) RefreshLiveSnapshots(ctx context.Context, policy Policy) error {
+	ctx, cancel := context.WithTimeout(ctx, liveFetchTimeout)
+	defer cancel()
+
+	now := s.now().UTC()
+	var snapshots []Snapshot
+	var errs []error
+
+	if providerEnabled(policy, ProviderClaude) {
+		if snapshot, ok, err := fetchClaudeLiveSnapshot(ctx, now); err != nil {
+			errs = append(errs, fmt.Errorf("claude: %w", err))
+		} else if ok {
+			snapshots = append(snapshots, snapshot)
+		}
+	}
+
+	if providerEnabled(policy, ProviderCodex) {
+		if snapshot, ok, err := fetchCodexLiveSnapshot(ctx, now); err != nil {
+			errs = append(errs, fmt.Errorf("codex: %w", err))
+		} else if ok {
+			snapshots = append(snapshots, snapshot)
+		}
+	}
+
+	if len(snapshots) > 0 {
+		if err := s.Import(nil, snapshots); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func fetchClaudeLiveSnapshot(ctx context.Context, capturedAt time.Time) (Snapshot, bool, error) {
+	credentials, ok, err := readClaudeOAuthCredentials()
+	if err != nil || !ok {
+		return Snapshot{}, false, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, claudeOAuthUsageURL, http.NoBody)
+	if err != nil {
+		return Snapshot{}, false, err
+	}
+	req.Header.Set("Authorization", "Bearer "+credentials.ClaudeAIOAuth.AccessToken)
+	req.Header.Set("anthropic-beta", claudeOAuthBeta)
+	req.Header.Set("User-Agent", claudeUserAgent)
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return Snapshot{}, false, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return Snapshot{}, false, fmt.Errorf("usage endpoint returned HTTP %d", res.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(res.Body, 1<<20))
+	if err != nil {
+		return Snapshot{}, false, err
+	}
+	snapshot, ok, err := parseClaudeUsageSnapshot(data, capturedAt)
+	if !ok || err != nil {
+		return snapshot, ok, err
+	}
+	snapshot.PlanType = credentials.ClaudeAIOAuth.SubscriptionType
+	if snapshot.PlanType == "" {
+		snapshot.PlanType = credentials.ClaudeAIOAuth.RateLimitTier
+	}
+	return snapshot, true, nil
+}
+
+func readClaudeOAuthCredentials() (claudeCredentials, bool, error) {
+	if runtime.GOOS == "darwin" {
+		if credentials, ok, err := readClaudeCredentialsFromKeychain(os.Getenv("CLAUDE_CONFIG_DIR")); err != nil || ok {
+			return credentials, ok, err
+		}
+	}
+	return readClaudeCredentialsFromFile()
+}
+
+func readClaudeCredentialsFromKeychain(configDir string) (claudeCredentials, bool, error) {
+	for _, service := range claudeKeychainServices(configDir) {
+		ctx, cancel := context.WithTimeout(context.Background(), keychainTimeout)
+		cmd := exec.CommandContext(ctx, "security", "find-generic-password", "-s", service, "-a", keychainUser(), "-w")
+		out, err := cmd.Output()
+		cancel()
+		if err != nil {
+			continue
+		}
+		credentials, ok, err := parseClaudeCredentials(bytes.TrimSpace(out))
+		if err != nil || ok {
+			return credentials, ok, err
+		}
+	}
+	return claudeCredentials{}, false, nil
+}
+
+func claudeKeychainServices(configDir string) []string {
+	const legacy = "Claude Code-credentials"
+	if configDir == "" {
+		return []string{legacy}
+	}
+	hash := sha256.Sum256([]byte(configDir))
+	return []string{legacy + "-" + hex.EncodeToString(hash[:])[:8], legacy}
+}
+
+func keychainUser() string {
+	if user := os.Getenv("USER"); user != "" {
+		return user
+	}
+	if user := os.Getenv("USERNAME"); user != "" {
+		return user
+	}
+	return "user"
+}
+
+func readClaudeCredentialsFromFile() (claudeCredentials, bool, error) {
+	configDir := os.Getenv("CLAUDE_CONFIG_DIR")
+	if configDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return claudeCredentials{}, false, err
+		}
+		configDir = filepath.Join(home, ".claude")
+	}
+	data, err := os.ReadFile(filepath.Join(configDir, ".credentials.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return claudeCredentials{}, false, nil
+		}
+		return claudeCredentials{}, false, err
+	}
+	return parseClaudeCredentials(data)
+}
+
+func parseClaudeCredentials(data []byte) (claudeCredentials, bool, error) {
+	var credentials claudeCredentials
+	if err := json.Unmarshal(data, &credentials); err != nil {
+		return claudeCredentials{}, false, err
+	}
+	if credentials.ClaudeAIOAuth.AccessToken == "" {
+		return claudeCredentials{}, false, nil
+	}
+	return credentials, true, nil
+}
+
+func parseClaudeUsageSnapshot(data []byte, capturedAt time.Time) (Snapshot, bool, error) {
+	var usage claudeUsageResponse
+	if err := json.Unmarshal(data, &usage); err != nil {
+		return Snapshot{}, false, err
+	}
+	primary, hasPrimary, err := claudeUsageCycle(usage.FiveHour, 300)
+	if err != nil {
+		return Snapshot{}, false, err
+	}
+	secondary, hasSecondary, err := claudeUsageCycle(usage.SevenDay, 10080)
+	if err != nil {
+		return Snapshot{}, false, err
+	}
+	if !hasPrimary && !hasSecondary {
+		return Snapshot{}, false, nil
+	}
+	return Snapshot{
+		Provider:   ProviderClaude,
+		LimitID:    ProviderClaude,
+		Primary:    primary,
+		Secondary:  secondary,
+		Source:     SourceLivePoll,
+		Confidence: ConfidenceExact,
+		CapturedAt: capturedAt,
+	}, true, nil
+}
+
+func claudeUsageCycle(raw *claudeUsageWindow, windowMinutes int) (*CycleSnapshot, bool, error) {
+	if raw == nil || raw.Utilization == nil {
+		return nil, false, nil
+	}
+	out := &CycleSnapshot{
+		UsedPercent:   clampPercent(*raw.Utilization),
+		WindowMinutes: windowMinutes,
+	}
+	if raw.ResetsAt != nil && *raw.ResetsAt != "" {
+		resetsAt, err := time.Parse(time.RFC3339Nano, *raw.ResetsAt)
+		if err != nil {
+			return nil, false, err
+		}
+		out.ResetsAt = resetsAt.UTC()
+	}
+	return out, true, nil
+}
+
+func fetchCodexLiveSnapshot(ctx context.Context, capturedAt time.Time) (Snapshot, bool, error) {
+	cmd := exec.CommandContext(ctx, "codex", "-s", "read-only", "-a", "untrusted", "app-server")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return Snapshot{}, false, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return Snapshot{}, false, err
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return Snapshot{}, false, err
+	}
+	defer func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+	}()
+
+	sendRPC := func(id int, method string, params any) error {
+		payload := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      id,
+			"method":  method,
+			"params":  params,
+		}
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintf(stdin, "%s\n", data)
+		return err
+	}
+	sendNotification := func(method string) error {
+		data, err := json.Marshal(map[string]any{
+			"jsonrpc": "2.0",
+			"method":  method,
+			"params":  map[string]any{},
+		})
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintf(stdin, "%s\n", data)
+		return err
+	}
+
+	if err := sendRPC(1, "initialize", map[string]any{
+		"clientInfo": map[string]string{"name": "sybra", "version": "0.0.0"},
+	}); err != nil {
+		return Snapshot{}, false, err
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), scannerBuffer)
+	rateLimitsRequested := false
+	for scanner.Scan() {
+		var msg codexRPCMessage
+		if err := json.Unmarshal(scanner.Bytes(), &msg); err != nil {
+			continue
+		}
+		if msg.ID == nil {
+			continue
+		}
+		if msg.Error != nil {
+			return Snapshot{}, false, fmt.Errorf("rpc error: %s", msg.Error.Message)
+		}
+		if *msg.ID == 1 && !rateLimitsRequested {
+			if err := sendNotification("initialized"); err != nil {
+				return Snapshot{}, false, err
+			}
+			if err := sendRPC(2, "account/rateLimits/read", map[string]any{}); err != nil {
+				return Snapshot{}, false, err
+			}
+			rateLimitsRequested = true
+			continue
+		}
+		if *msg.ID == 2 {
+			return parseCodexAppServerSnapshot(msg.Result, capturedAt)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return Snapshot{}, false, err
+	}
+	if stderr.Len() > 0 {
+		return Snapshot{}, false, fmt.Errorf("codex app-server exited: %s", stderr.String())
+	}
+	return Snapshot{}, false, errors.New("codex app-server exited before rate limits response")
+}
+
+func parseCodexAppServerSnapshot(data []byte, capturedAt time.Time) (Snapshot, bool, error) {
+	var response codexRateLimitsResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return Snapshot{}, false, err
+	}
+	limits := response.RateLimits
+	if limits == nil {
+		return Snapshot{}, false, nil
+	}
+	snapshot := Snapshot{
+		Provider:             ProviderCodex,
+		PlanType:             limits.PlanType,
+		LimitID:              limits.LimitID,
+		Primary:              codexAppServerCycle(limits.Primary),
+		Secondary:            codexAppServerCycle(limits.Secondary),
+		RateLimitReachedType: ptrString(limits.RateLimitReachedType),
+		Source:               SourceLivePoll,
+		Confidence:           ConfidenceExact,
+		CapturedAt:           capturedAt,
+	}
+	if limits.LimitName != nil {
+		snapshot.LimitName = *limits.LimitName
+	}
+	if snapshot.LimitID == "" {
+		snapshot.LimitID = ProviderCodex
+	}
+	return snapshot, snapshot.Primary != nil || snapshot.Secondary != nil, nil
+}
+
+func codexAppServerCycle(raw *codexAppServerLimitWindow) *CycleSnapshot {
+	if raw == nil {
+		return nil
+	}
+	out := &CycleSnapshot{
+		UsedPercent:   clampPercent(raw.UsedPercent),
+		WindowMinutes: raw.WindowDurationMin,
+	}
+	if raw.ResetsAt > 0 {
+		out.ResetsAt = time.Unix(raw.ResetsAt, 0).UTC()
+	}
+	return out
+}
+
+func clampPercent(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 100 {
+		return 100
+	}
+	return v
+}

--- a/internal/limits/model.go
+++ b/internal/limits/model.go
@@ -10,6 +10,7 @@ const (
 	SourceStream       = "stream"
 	SourceSessionFiles = "session-files"
 	SourceRunStats     = "run-stats"
+	SourceLivePoll     = "live-poll"
 
 	ConfidenceExact     = "exact"
 	ConfidenceEstimated = "estimated"

--- a/internal/limits/store.go
+++ b/internal/limits/store.go
@@ -5,11 +5,14 @@ import (
 	"encoding/json"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/Automaat/sybra/internal/fsutil"
 )
+
+const exactSnapshotMaxAge = 30 * time.Minute
 
 type persisted struct {
 	Snapshots map[string]Snapshot `json:"snapshots"`
@@ -159,16 +162,21 @@ func (s *Store) Summary(policy Policy) Summary {
 	out := make([]ProviderSummary, 0, len(providers))
 	for _, provider := range providers {
 		snap := s.snapshots[provider]
+		snapshotFresh := freshExactSnapshot(snap, now)
+		confidence := snap.Confidence
+		if snap.Confidence == ConfidenceExact && !snapshotFresh {
+			confidence = ConfidenceEstimated
+		}
 		ps := ProviderSummary{
 			Provider:               provider,
 			PlanType:               snap.PlanType,
 			LimitID:                snap.LimitID,
 			Source:                 snap.Source,
-			Confidence:             snap.Confidence,
+			Confidence:             confidence,
 			MonthlySubscriptionUSD: policy.SubscriptionMonthlyUSD[provider],
 		}
 		sessionStart, weeklyStart := fallbackWindows(now)
-		if activeCycle(snap.Primary, now) {
+		if snapshotFresh && activeCycle(snap.Primary, now) {
 			primary := snap.Primary
 			ps.SessionUsedPercent = primary.UsedPercent
 			ps.SessionWindowMinutes = primary.WindowMinutes
@@ -177,7 +185,7 @@ func (s *Store) Summary(policy Policy) Summary {
 				sessionStart = primary.ResetsAt.Add(-time.Duration(primary.WindowMinutes) * time.Minute)
 			}
 		}
-		if activeCycle(snap.Secondary, now) {
+		if snapshotFresh && activeCycle(snap.Secondary, now) {
 			secondary := snap.Secondary
 			ps.WeeklyUsedPercent = secondary.UsedPercent
 			ps.WeeklyWindowMinutes = secondary.WindowMinutes
@@ -200,7 +208,7 @@ func (s *Store) Summary(policy Policy) Summary {
 				addEventToProviderSummary(e, &ps, false, e.Source == weeklyUsageSource)
 			}
 		}
-		ps.QuotaLimited, ps.QuotaReason = quotaLimited(ps, policy)
+		ps.QuotaLimited, ps.QuotaReason = quotaLimited(ps, snap, policy)
 		if ps.MonthlySubscriptionUSD > 0 {
 			ps.MonthlySubscriptionBurnRate = ps.WeeklySpendUSD / ps.MonthlySubscriptionUSD
 		}
@@ -309,6 +317,13 @@ func activeCycle(c *CycleSnapshot, now time.Time) bool {
 	return c != nil && (c.ResetsAt.IsZero() || c.ResetsAt.After(now))
 }
 
+func freshExactSnapshot(snap Snapshot, now time.Time) bool {
+	if snap.Confidence != ConfidenceExact || snap.CapturedAt.IsZero() {
+		return false
+	}
+	return !snap.CapturedAt.Before(now.Add(-exactSnapshotMaxAge))
+}
+
 func providerEnabled(policy Policy, provider string) bool {
 	if len(policy.ProviderEnabled) == 0 {
 		return true
@@ -351,9 +366,12 @@ func addEventToProviderSummary(e *UsageEvent, ps *ProviderSummary, session, addC
 	ps.WeeklyReasoningTokens += e.ReasoningTokens
 }
 
-func quotaLimited(ps ProviderSummary, policy Policy) (limited bool, reason string) {
+func quotaLimited(ps ProviderSummary, snap Snapshot, policy Policy) (limited bool, reason string) {
 	if ps.Confidence != ConfidenceExact {
 		return false, ""
+	}
+	if strings.TrimSpace(snap.RateLimitReachedType) != "" {
+		return true, "provider reports rate limit reached"
 	}
 	if ps.SessionUsedPercent > 0 && ps.SessionUsedPercent >= policy.SessionThresholdPercent {
 		return true, "session limit near threshold"

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -219,7 +219,7 @@ func (a *App) startLiveLimitPolling(ctx context.Context, limitStore *limits.Stor
 
 func (a *App) refreshLiveLimits(ctx context.Context, limitStore *limits.Store, policy limits.Policy) {
 	if err := limitStore.RefreshLiveSnapshots(ctx, policy); err != nil {
-		if errors.Is(err, context.Canceled) {
+		if ctx.Err() != nil {
 			return
 		}
 		a.logger.Warn("limits.live_poll", "err", err)

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -31,6 +31,8 @@ import (
 	"github.com/Automaat/sybra/internal/workflow"
 )
 
+const liveLimitPollInterval = 15 * time.Minute
+
 func (a *App) initBgops(emit func(string, any)) {
 	a.bgops = bgop.NewTracker(emit, filepath.Join(config.HomeDir(), "bgops.json"))
 	a.bgops.LoadFromDisk()
@@ -193,6 +195,34 @@ func (a *App) initLimits() {
 			}
 			a.logger.Info("limits.backfill.done")
 		})
+		if a.ctx != nil {
+			a.startLiveLimitPolling(a.ctx, limitStore, policy)
+		}
+	}
+}
+
+func (a *App) startLiveLimitPolling(ctx context.Context, limitStore *limits.Store, policy limits.Policy) {
+	a.wg.Go(func() {
+		a.refreshLiveLimits(ctx, limitStore, policy)
+		ticker := time.NewTicker(liveLimitPollInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				a.refreshLiveLimits(ctx, limitStore, policy)
+			}
+		}
+	})
+}
+
+func (a *App) refreshLiveLimits(ctx context.Context, limitStore *limits.Store, policy limits.Policy) {
+	if err := limitStore.RefreshLiveSnapshots(ctx, policy); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
+		a.logger.Warn("limits.live_poll", "err", err)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Stats could show stale Claude and Codex availability because it relied on token usage and old session-file snapshots instead of current provider quota state.

> Changelog: fix(limits): poll live provider quotas

## Implementation information

Adds live quota polling for Claude OAuth usage and Codex app-server rate limits. Stale exact snapshots are downgraded after 30 minutes, and provider-reported rate-limit states now block availability.

## Supporting documentation

N/A