### PR TITLE
fix(autoupdate): apply auto updates

### DIFF
--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -19,12 +19,13 @@ const (
 )
 
 type Config struct {
-	Enabled      bool
-	RepoDir      string
-	Remote       string
-	Branch       string
-	Mode         string
-	PollInterval time.Duration
+	Enabled        bool
+	RepoDir        string
+	Remote         string
+	Branch         string
+	Mode           string
+	PollInterval   time.Duration
+	RequestRestart func()
 }
 
 type Result struct {
@@ -109,6 +110,13 @@ func (r *Runner) CheckAndApply(ctx context.Context) (Result, error) {
 		return Result{}, err
 	}
 	res := Result{Status: "available", OldSHA: head, NewSHA: remoteSHA, ChangedFiles: changed}
+	if cfg.Mode != ModeAuto {
+		return res, nil
+	}
+	if _, err := git(ctx, cfg.RepoDir, "merge", "--ff-only", remoteRef); err != nil {
+		return Result{}, fmt.Errorf("fast-forward %s: %w", remoteRef, err)
+	}
+	res.Status = "applied"
 	return res, nil
 }
 
@@ -129,6 +137,10 @@ func (r *Runner) check(ctx context.Context) {
 		attrs = append(attrs, "changed", res.ChangedFiles)
 	}
 	r.logger.Info("autoupdate.check", attrs...)
+	if res.Status == "applied" && r.cfg.RequestRestart != nil {
+		r.logger.Info("autoupdate.restart.requested")
+		r.cfg.RequestRestart()
+	}
 }
 
 func validateRepoState(ctx context.Context, cfg Config) error {

--- a/internal/autoupdate/autoupdate_test.go
+++ b/internal/autoupdate/autoupdate_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func TestCheckAndApplyAutoModeDoesNotMerge(t *testing.T) {
+func TestCheckAndApplyAutoModeFastForwards(t *testing.T) {
 	ctx := t.Context()
 	upstream, work := seedRepos(t)
 	writeFile(t, upstream, "feature.txt", "new\n")
@@ -28,11 +28,35 @@ func TestCheckAndApplyAutoModeDoesNotMerge(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.Status != "available" {
-		t.Fatalf("status = %q, want available (reason=%q)", res.Status, res.Reason)
+	if res.Status != "applied" {
+		t.Fatalf("status = %q, want applied (reason=%q)", res.Status, res.Reason)
 	}
-	if _, err := os.Stat(filepath.Join(work, "feature.txt")); !os.IsNotExist(err) {
-		t.Fatalf("feature.txt exists after auto mode: %v", err)
+	if _, err := os.Stat(filepath.Join(work, "feature.txt")); err != nil {
+		t.Fatalf("feature.txt missing after auto mode: %v", err)
+	}
+}
+
+func TestRunRequestsRestartAfterAutoApply(t *testing.T) {
+	upstream, work := seedRepos(t)
+	writeFile(t, upstream, "feature.txt", "new\n")
+	gitTest(t, upstream, "add", "feature.txt")
+	gitTest(t, upstream, "commit", "-m", "add feature")
+
+	restarted := false
+	r := New(Config{
+		Enabled: true,
+		RepoDir: work,
+		Remote:  "origin",
+		Branch:  "main",
+		Mode:    ModeAuto,
+		RequestRestart: func() {
+			restarted = true
+		},
+	}, nil)
+
+	r.check(t.Context())
+	if !restarted {
+		t.Fatal("restart was not requested after auto apply")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -502,8 +502,8 @@ type MetricsConfig struct {
 	Enabled bool `yaml:"enabled" json:"enabled"`
 }
 
-// AutoUpdateConfig controls source update checks. It reports newer remote
-// commits but does not merge or restart Sybra.
+// AutoUpdateConfig controls source update checks. In "auto" mode a clean
+// fast-forward update is applied and Sybra requests a supervisor restart.
 type AutoUpdateConfig struct {
 	Enabled     bool   `yaml:"enabled" json:"enabled"`
 	RepoDir     string `yaml:"repo_dir" json:"repoDir"`

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -105,12 +105,13 @@ func (lm *LifecycleManager) startAutoUpdate(ctx context.Context) {
 		return
 	}
 	runner := autoupdate.New(autoupdate.Config{
-		Enabled:      a.cfg.AutoUpdate.Enabled,
-		RepoDir:      repoDir,
-		Remote:       a.cfg.AutoUpdate.Remote,
-		Branch:       a.cfg.AutoUpdate.Branch,
-		Mode:         a.cfg.AutoUpdate.Mode,
-		PollInterval: time.Duration(a.cfg.AutoUpdate.PollSeconds) * time.Second,
+		Enabled:        a.cfg.AutoUpdate.Enabled,
+		RepoDir:        repoDir,
+		Remote:         a.cfg.AutoUpdate.Remote,
+		Branch:         a.cfg.AutoUpdate.Branch,
+		Mode:           a.cfg.AutoUpdate.Mode,
+		PollInterval:   time.Duration(a.cfg.AutoUpdate.PollSeconds) * time.Second,
+		RequestRestart: a.requestRestart,
 	}, a.logger)
 	a.wg.Go(func() { runner.Run(ctx) })
 }


### PR DESCRIPTION
## Motivation

Local Sybra auto-update detected newer commits but never applied them, so the supervisor had nothing to rebuild or restart.

> Changelog: fix(autoupdate): apply auto updates

## Implementation information

Auto mode now fast-forwards a clean repository to the fetched remote branch and then calls the existing restart hook. Desktop and server entrypoints already translate that hook into exit code 42, which the dev supervisor treats as a rebuild/restart request.

Notify mode remains detection-only, and dirty/diverged repositories still block instead of mutating local work.

## Supporting documentation

Targeted and full Go test suites pass locally.