### PR TITLE
fix(agent): fallback on provider limits

### DIFF
--- a/cmd/sybra-cli/triage.go
+++ b/cmd/sybra-cli/triage.go
@@ -61,7 +61,7 @@ func cmdTriageClassify(
 	}
 
 	logger := slog.New(slog.DiscardHandler)
-	classifier := &triage.ClaudeClassifier{Model: *model, Logger: logger}
+	classifier := &triage.FallbackClassifier{Model: *model, Logger: logger}
 	al, _ := audit.NewLogger(cfg.AuditDir())
 
 	var targets []task.Task

--- a/cmd/sybra-cli/umbrella.go
+++ b/cmd/sybra-cli/umbrella.go
@@ -29,7 +29,7 @@ func cmdUmbrella(s *task.Manager, args []string, jsonOut bool) int {
 		return fatal(jsonOut, "umbrella: an issue URL is required")
 	}
 
-	res, err := umbrella.Expand(context.Background(), s, umbrella.ClaudePlannerRunner(*model), issueURL)
+	res, err := umbrella.Expand(context.Background(), s, umbrella.FallbackPlannerRunner(*model), issueURL)
 	if err != nil {
 		return fatal(jsonOut, "%v", err)
 	}

--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/orchestratorservice.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/orchestratorservice.ts
@@ -30,8 +30,8 @@ export function IsOrchestratorRunning(): $CancellablePromise<boolean> {
  * StartOrchestrator launches the orchestrator as an in-app conversational
  * Claude agent rooted at ~/.sybra (where the brain CLAUDE.md + skills live).
  * The orchestrator bootstraps its own monitor loop via CronCreate on first
- * turn, as instructed by orchestrator/CLAUDE.md. Provider is pinned to claude
- * because /sybra-monitor is a Claude-only skill.
+ * turn, as instructed by orchestrator/CLAUDE.md, so this run stays pinned to
+ * Claude even when generic task agents can fail over to another provider.
  */
 export function StartOrchestrator(): $CancellablePromise<void> {
     return $Call.ByID(4069016469);

--- a/internal/agent/inspector.go
+++ b/internal/agent/inspector.go
@@ -5,8 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"os/exec"
 	"strings"
+
+	"github.com/Automaat/sybra/internal/llmexec"
 )
 
 // InspectorVerdict is the structured judgment returned by the inspector agent.
@@ -49,17 +50,15 @@ func Inspect(ctx context.Context, logger *slog.Logger, in InspectInput) (Inspect
 	if model == "" {
 		model = "sonnet"
 	}
-	cmd := exec.CommandContext(ctx, "claude",
-		"-p", prompt,
-		"--output-format", "json",
-		"--dangerously-skip-permissions",
-		"--model", model,
-	)
-	out, err := cmd.Output()
+	res, err := llmexec.RunJSON(ctx, prompt, llmexec.Options{Model: model, Logger: logger})
 	if err != nil {
-		return InspectorVerdict{}, fmt.Errorf("inspector claude: %w", err)
+		return InspectorVerdict{}, fmt.Errorf("inspector: %w", err)
 	}
-	return parseInspectorOutput(out)
+	v, err := parseInspectorOutput([]byte(res.Text))
+	if err != nil {
+		return InspectorVerdict{}, fmt.Errorf("parse %s verdict: %w", res.Provider, err)
+	}
+	return v, nil
 }
 
 func buildInspectorPrompt(in InspectInput) string {
@@ -99,18 +98,19 @@ Recommendations:
 // The top-level response has a `result` string field containing the model's final message,
 // from which we extract the last JSON object.
 func parseInspectorOutput(raw []byte) (InspectorVerdict, error) {
+	text := string(raw)
 	var envelope struct {
-		Result string `json:"result"`
+		Result *string `json:"result"`
 	}
-	if err := json.Unmarshal(raw, &envelope); err != nil {
-		return InspectorVerdict{}, fmt.Errorf("unmarshal envelope: %w", err)
+	if err := json.Unmarshal(raw, &envelope); err == nil && envelope.Result != nil {
+		if *envelope.Result == "" {
+			return InspectorVerdict{}, fmt.Errorf("empty result field")
+		}
+		text = *envelope.Result
 	}
-	if envelope.Result == "" {
-		return InspectorVerdict{}, fmt.Errorf("empty result field")
-	}
-	jsonStr := extractLastJSONObject(envelope.Result)
+	jsonStr := extractLastJSONObject(text)
 	if jsonStr == "" {
-		return InspectorVerdict{}, fmt.Errorf("no JSON object in result: %q", envelope.Result)
+		return InspectorVerdict{}, fmt.Errorf("no JSON object in result: %q", text)
 	}
 	var v InspectorVerdict
 	if err := json.Unmarshal([]byte(jsonStr), &v); err != nil {

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -331,6 +331,31 @@ func (m *Manager) ProviderRateLimited(name string) bool {
 	return g.RateLimited(name)
 }
 
+// ProviderCanFailover reports whether the health/limit gates can route work
+// away from the named provider right now.
+func (m *Manager) ProviderCanFailover(name string) bool {
+	m.mu.RLock()
+	g := m.gate
+	lg := m.limitGate
+	lp := m.limitPolicy
+	if name == "" {
+		name = m.defaultProv
+	}
+	m.mu.RUnlock()
+	resolved := normalizeProvider(name)
+	healthy := func(p string) bool {
+		return g == nil || g.IsHealthy(p)
+	}
+	if g != nil && g.Failover(resolved) != "" {
+		return true
+	}
+	if lg == nil {
+		return false
+	}
+	alt, _ := lg.ChooseProvider(resolved, []string{"claude", "codex", "copilot"}, healthy, lp)
+	return alt != ""
+}
+
 // ReportProviderSignal forwards a runner-side passive signal (rate-limit or
 // auth failure) to the health gate. Safe to call with a nil gate.
 func (m *Manager) ReportProviderSignal(name string, sig provider.Signal, reason string, retryAfter time.Duration) {

--- a/internal/evaluation/judge.go
+++ b/internal/evaluation/judge.go
@@ -6,10 +6,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"os/exec"
 	"sort"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/Automaat/sybra/internal/llmexec"
+	"github.com/Automaat/sybra/internal/provider"
 )
 
 // defaultJudgeModel is a capable model for nuanced code-quality judgment.
@@ -69,6 +71,7 @@ type ClaudeQualityJudge struct {
 	Model   string
 	DimSeed int64
 	Logger  *slog.Logger
+	Gate    provider.HealthGate
 }
 
 // Judge shells out to claude -p and returns a validated verdict.
@@ -78,19 +81,13 @@ func (j *ClaudeQualityJudge) Judge(ctx context.Context, req JudgeRequest) (Quali
 		model = defaultJudgeModel
 	}
 	prompt := buildQualityPrompt(req, shuffledRubric(j.DimSeed))
-	cmd := exec.CommandContext(ctx, "claude",
-		"-p", prompt,
-		"--output-format", "json",
-		"--dangerously-skip-permissions",
-		"--model", model,
-	)
-	out, err := cmd.Output()
-	if err != nil {
-		return QualityVerdict{}, fmt.Errorf("claude -p: %w", err)
-	}
-	v, err := parseQualityVerdict(out)
+	res, err := llmexec.RunJSON(ctx, prompt, llmexec.Options{Model: model, Logger: j.Logger, Gate: j.Gate})
 	if err != nil {
 		return QualityVerdict{}, err
+	}
+	v, err := parseQualityVerdict([]byte(res.Text))
+	if err != nil {
+		return QualityVerdict{}, fmt.Errorf("parse %s verdict: %w", res.Provider, err)
 	}
 	v.TaskID = req.TaskID
 	return v, nil
@@ -156,18 +153,19 @@ func buildQualityPrompt(req JudgeRequest, dims []RubricDimension) string {
 // stdout, clamps each dimension score to [0,10], and fills Overall from the mean
 // when the model omitted or mis-scored it.
 func parseQualityVerdict(raw []byte) (QualityVerdict, error) {
+	text := string(raw)
 	var envelope struct {
-		Result string `json:"result"`
+		Result *string `json:"result"`
 	}
-	if err := json.Unmarshal(raw, &envelope); err != nil {
-		return QualityVerdict{}, fmt.Errorf("unmarshal envelope: %w", err)
+	if err := json.Unmarshal(raw, &envelope); err == nil && envelope.Result != nil {
+		if *envelope.Result == "" {
+			return QualityVerdict{}, fmt.Errorf("empty result field")
+		}
+		text = *envelope.Result
 	}
-	if envelope.Result == "" {
-		return QualityVerdict{}, fmt.Errorf("empty result field")
-	}
-	jsonStr := judgeExtractLastJSON(envelope.Result)
+	jsonStr := judgeExtractLastJSON(text)
 	if jsonStr == "" {
-		return QualityVerdict{}, fmt.Errorf("no JSON object in result: %q", envelope.Result)
+		return QualityVerdict{}, fmt.Errorf("no JSON object in result: %q", text)
 	}
 	var v QualityVerdict
 	if err := json.Unmarshal([]byte(jsonStr), &v); err != nil {

--- a/internal/llmexec/llmexec.go
+++ b/internal/llmexec/llmexec.go
@@ -1,0 +1,299 @@
+// Package llmexec runs short structured-output LLM CLI calls with provider
+// failover. It is for classifiers/judges/planners, not long-running coding
+// agents (those go through internal/agent.Manager).
+package llmexec
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/Automaat/sybra/internal/provider"
+)
+
+var providerOrder = []string{"claude", "codex", "copilot"}
+
+// Options configures a one-shot provider invocation.
+type Options struct {
+	// Provider is the preferred provider. Empty means claude first, then peers.
+	Provider string
+	// Model is passed only to Claude; alternate providers keep their CLI default
+	// because Claude aliases like "sonnet" are not portable.
+	Model  string
+	Logger *slog.Logger
+	Gate   provider.HealthGate
+}
+
+// Result is the normalized final assistant text.
+type Result struct {
+	Provider string
+	Text     string
+}
+
+// RunJSON runs prompt against the preferred provider and falls back to peers
+// when the provider is unavailable, unhealthy, logged out, or rate-limited.
+func RunJSON(ctx context.Context, prompt string, opts Options) (Result, error) {
+	candidates := candidates(opts.Provider)
+	var failures []string
+	for _, p := range candidates {
+		if ctx.Err() != nil {
+			return Result{}, ctx.Err()
+		}
+		if opts.Gate != nil && !opts.Gate.IsHealthy(p) {
+			failures = append(failures, fmt.Sprintf("%s: unhealthy (%s)", p, opts.Gate.Reason(p)))
+			continue
+		}
+		if _, err := exec.LookPath(binaryName(p)); err != nil {
+			failures = append(failures, fmt.Sprintf("%s: CLI not found", p))
+			continue
+		}
+
+		raw, stderrOut, err := runProvider(ctx, p, prompt, opts.Model)
+		if err != nil {
+			if overloaded(stderrOut, string(raw)) {
+				logFallback(opts.Logger, p, provider.SignalRateLimit, "overloaded")
+				failures = append(failures, fmt.Sprintf("%s: overloaded", p))
+				continue
+			}
+			sig, reason, retryAfter := classifyError(p, stderrOut, string(raw))
+			if sig != provider.SignalNone {
+				reportSignal(opts.Gate, p, sig, reason, retryAfter)
+				logFallback(opts.Logger, p, sig, reason)
+				failures = append(failures, fmt.Sprintf("%s: %s", p, reason))
+				continue
+			}
+			return Result{}, providerError(p, err, stderrOut)
+		}
+
+		text, parseErr := parseProviderText(p, raw)
+		if parseErr != nil {
+			if overloaded(stderrOut, string(raw)) {
+				logFallback(opts.Logger, p, provider.SignalRateLimit, "overloaded")
+				failures = append(failures, fmt.Sprintf("%s: overloaded", p))
+				continue
+			}
+			sig, reason, retryAfter := classifyError(p, stderrOut, string(raw))
+			if sig != provider.SignalNone {
+				reportSignal(opts.Gate, p, sig, reason, retryAfter)
+				logFallback(opts.Logger, p, sig, reason)
+				failures = append(failures, fmt.Sprintf("%s: %s", p, reason))
+				continue
+			}
+			return Result{}, fmt.Errorf("%s output: %w", p, parseErr)
+		}
+		return Result{Provider: p, Text: text}, nil
+	}
+	if len(failures) == 0 {
+		return Result{}, errors.New("no providers configured")
+	}
+	return Result{}, fmt.Errorf("all providers failed: %s", strings.Join(failures, "; "))
+}
+
+func candidates(preferred string) []string {
+	preferred = normalizeProvider(preferred)
+	if preferred == "" {
+		return slices.Clone(providerOrder)
+	}
+	out := []string{preferred}
+	for _, p := range providerOrder {
+		if p != preferred {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func normalizeProvider(p string) string {
+	switch strings.ToLower(strings.TrimSpace(p)) {
+	case "", "claude":
+		return "claude"
+	case "codex":
+		return "codex"
+	case "copilot":
+		return "copilot"
+	default:
+		return ""
+	}
+}
+
+func binaryName(p string) string {
+	if p == "copilot" {
+		return "copilot"
+	}
+	return p
+}
+
+func runProvider(ctx context.Context, p, prompt, model string) (stdout []byte, stderrOut string, err error) {
+	name, args := invocation(p, prompt, model)
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	return out, stderr.String(), err
+}
+
+func invocation(p, prompt, model string) (name string, args []string) {
+	switch p {
+	case "codex":
+		return "codex", []string{
+			"exec", "--json", "--skip-git-repo-check", "--ignore-user-config", "--ignore-rules",
+			"--dangerously-bypass-approvals-and-sandbox", prompt,
+		}
+	case "copilot":
+		return "copilot", []string{"-p", prompt, "--output-format", "json", "--allow-all-tools", "--no-ask-user"}
+	default:
+		args := []string{"-p", prompt, "--output-format", "json", "--dangerously-skip-permissions"}
+		if model != "" {
+			args = append(args, "--model", model)
+		}
+		return "claude", args
+	}
+}
+
+func parseProviderText(p string, raw []byte) (string, error) {
+	switch p {
+	case "codex":
+		return parseCodexText(raw)
+	case "copilot":
+		return parseCopilotText(raw)
+	default:
+		return parseClaudeText(raw)
+	}
+}
+
+func parseClaudeText(raw []byte) (string, error) {
+	var env struct {
+		Result string `json:"result"`
+	}
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return "", fmt.Errorf("unmarshal envelope: %w", err)
+	}
+	if strings.TrimSpace(env.Result) == "" {
+		return "", errors.New("empty result field")
+	}
+	return env.Result, nil
+}
+
+func parseCodexText(raw []byte) (string, error) {
+	var final string
+	scanner := bufio.NewScanner(bytes.NewReader(raw))
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+	for scanner.Scan() {
+		var ev struct {
+			Type      string `json:"type"`
+			Message   string `json:"message"`
+			ErrorType string `json:"error_type"`
+			Code      int    `json:"code"`
+			Item      *struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"item"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &ev); err != nil {
+			return "", err
+		}
+		if ev.Type == "error" {
+			return "", fmt.Errorf("provider error %s (%d): %s", ev.ErrorType, ev.Code, ev.Message)
+		}
+		if ev.Item != nil && strings.TrimSpace(ev.Item.Text) != "" {
+			final = ev.Item.Text
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(final) == "" {
+		return "", errors.New("no assistant message in codex output")
+	}
+	return final, nil
+}
+
+func parseCopilotText(raw []byte) (string, error) {
+	var final string
+	scanner := bufio.NewScanner(bytes.NewReader(raw))
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+	for scanner.Scan() {
+		var ev struct {
+			Type      string `json:"type"`
+			Ephemeral bool   `json:"ephemeral"`
+			ExitCode  int    `json:"exitCode"`
+			Data      *struct {
+				Content string `json:"content"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &ev); err != nil {
+			return "", err
+		}
+		if ev.Type == "result" && ev.ExitCode != 0 {
+			return "", fmt.Errorf("provider exit code %d", ev.ExitCode)
+		}
+		if ev.Type == "assistant.message" && !ev.Ephemeral && ev.Data != nil && strings.TrimSpace(ev.Data.Content) != "" {
+			final = ev.Data.Content
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(final) == "" {
+		return "", errors.New("no assistant message in copilot output")
+	}
+	return final, nil
+}
+
+func classifyError(p, stderrOut, content string) (provider.Signal, string, time.Duration) {
+	sample := provider.ErrorSample{Stderr: stderrOut, Content: content}
+	switch p {
+	case "codex":
+		return provider.ClassifyCodexError(sample)
+	case "copilot":
+		return provider.ClassifyCopilotError(sample)
+	default:
+		return provider.ClassifyClaudeError(sample)
+	}
+}
+
+func overloaded(parts ...string) bool {
+	for _, p := range parts {
+		lower := strings.ToLower(p)
+		if strings.Contains(lower, "529") || strings.Contains(lower, "overloaded") {
+			return true
+		}
+	}
+	return false
+}
+
+func reportSignal(g provider.HealthGate, p string, sig provider.Signal, reason string, retryAfter time.Duration) {
+	if g == nil {
+		return
+	}
+	switch sig {
+	case provider.SignalAuthFailure:
+		g.ReportAuthFailure(p, reason)
+	case provider.SignalRateLimit:
+		g.ReportRateLimit(p, retryAfter, reason)
+	case provider.SignalNone:
+	}
+}
+
+func logFallback(logger *slog.Logger, p string, sig provider.Signal, reason string) {
+	if logger == nil {
+		return
+	}
+	logger.Warn("llmexec.provider_fallback", "from", p, "signal", sig, "reason", reason)
+}
+
+func providerError(p string, err error, stderrOut string) error {
+	msg := strings.TrimSpace(stderrOut)
+	if msg == "" {
+		return fmt.Errorf("%s: %w", p, err)
+	}
+	return fmt.Errorf("%s: %w: %s", p, err, msg)
+}

--- a/internal/llmexec/llmexec.go
+++ b/internal/llmexec/llmexec.go
@@ -21,6 +21,8 @@ import (
 
 var providerOrder = []string{"claude", "codex", "copilot"}
 
+const streamScannerBuffer = 4 * 1024 * 1024
+
 // Options configures a one-shot provider invocation.
 type Options struct {
 	// Provider is the preferred provider. Empty means claude first, then peers.
@@ -185,7 +187,7 @@ func parseClaudeText(raw []byte) (string, error) {
 func parseCodexText(raw []byte) (string, error) {
 	var final string
 	scanner := bufio.NewScanner(bytes.NewReader(raw))
-	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+	scanner.Buffer(make([]byte, 0, streamScannerBuffer), streamScannerBuffer)
 	for scanner.Scan() {
 		var ev struct {
 			Type      string `json:"type"`
@@ -219,7 +221,7 @@ func parseCodexText(raw []byte) (string, error) {
 func parseCopilotText(raw []byte) (string, error) {
 	var final string
 	scanner := bufio.NewScanner(bytes.NewReader(raw))
-	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+	scanner.Buffer(make([]byte, 0, streamScannerBuffer), streamScannerBuffer)
 	for scanner.Scan() {
 		var ev struct {
 			Type      string `json:"type"`

--- a/internal/llmexec/llmexec_test.go
+++ b/internal/llmexec/llmexec_test.go
@@ -1,0 +1,38 @@
+package llmexec
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunJSONFallsBackOnRateLimit(t *testing.T) {
+	dir := t.TempDir()
+	writeExe(t, filepath.Join(dir, "claude"), `#!/bin/sh
+echo "rate limit exceeded" >&2
+exit 1
+`)
+	writeExe(t, filepath.Join(dir, "codex"), `#!/bin/sh
+printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"{\"ok\":true}"}}'
+`)
+	t.Setenv("PATH", dir)
+
+	res, err := RunJSON(context.Background(), "classify", Options{})
+	if err != nil {
+		t.Fatalf("RunJSON: %v", err)
+	}
+	if res.Provider != "codex" {
+		t.Fatalf("provider = %q, want codex", res.Provider)
+	}
+	if res.Text != `{"ok":true}` {
+		t.Fatalf("text = %q", res.Text)
+	}
+}
+
+func writeExe(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/llmexec/llmexec_test.go
+++ b/internal/llmexec/llmexec_test.go
@@ -2,8 +2,10 @@ package llmexec
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -27,6 +29,32 @@ printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"{
 	}
 	if res.Text != `{"ok":true}` {
 		t.Fatalf("text = %q", res.Text)
+	}
+}
+
+func TestParseCodexTextAllowsLargeStreamLine(t *testing.T) {
+	text := strings.Repeat("x", 2*1024*1024)
+	raw := fmt.Appendf(nil, `{"type":"item.completed","item":{"type":"agent_message","text":"%s"}}`, text)
+
+	got, err := parseCodexText(raw)
+	if err != nil {
+		t.Fatalf("parseCodexText: %v", err)
+	}
+	if got != text {
+		t.Fatalf("text length = %d, want %d", len(got), len(text))
+	}
+}
+
+func TestParseCopilotTextAllowsLargeStreamLine(t *testing.T) {
+	text := strings.Repeat("x", 2*1024*1024)
+	raw := fmt.Appendf(nil, `{"type":"assistant.message","data":{"content":"%s"}}`, text)
+
+	got, err := parseCopilotText(raw)
+	if err != nil {
+		t.Fatalf("parseCopilotText: %v", err)
+	}
+	if got != text {
+		t.Fatalf("text length = %d, want %d", len(got), len(text))
 	}
 }
 

--- a/internal/poll/triage.go
+++ b/internal/poll/triage.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/triage"
 )
@@ -29,6 +30,7 @@ type TriageHandler struct {
 	cfg        *config.TriageConfig
 	logger     *slog.Logger
 	audit      *audit.Logger
+	gate       provider.HealthGate
 	factory    classifierFactory
 	perTaskTTL time.Duration
 }
@@ -53,6 +55,12 @@ func NewTriageHandler(
 
 // Name implements poll.Fetcher.
 func (h *TriageHandler) Name() string { return "triage" }
+
+// SetProviderGate lets auto-triage skip/fallback from providers already known
+// to be rate-limited or logged out.
+func (h *TriageHandler) SetProviderGate(g provider.HealthGate) {
+	h.gate = g
+}
 
 // Poll implements poll.Fetcher. Returns the next poll interval.
 func (h *TriageHandler) Poll(ctx context.Context) time.Duration {
@@ -101,7 +109,7 @@ func (h *TriageHandler) buildClassifier() triage.Classifier {
 	if h.factory != nil {
 		return h.factory(h.cfg.Model, h.logger)
 	}
-	return &triage.ClaudeClassifier{Model: h.cfg.Model, Logger: h.logger}
+	return &triage.FallbackClassifier{Model: h.cfg.Model, Logger: h.logger, Gate: h.gate}
 }
 
 func (h *TriageHandler) classifyOne(

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -38,13 +38,12 @@ func (r *Recovery) RestartStaleInProgress() {
 		if r.Agents.HasRunningAgentForTask(t.ID) {
 			continue
 		}
-		// Don't re-dispatch while the last run's provider is rate-limited — it
-		// would just hit the same limit again and churn the worktree. The
-		// cooldown clears on its own and the next sweep re-dispatches. (A
+		// Don't re-dispatch to the same provider while it is rate-limited; do
+		// continue when failover can route this run to a healthy peer. (A
 		// rate-limited run is stalled in-progress by the completion handler, not
 		// flipped to human-required.) Auth failures are NOT skipped here: they
 		// take the human-required path so the operator knows to log in.
-		if lr := lastAgentRun(&t); lr != nil && r.Agents.ProviderRateLimited(lr.Provider) {
+		if lr := lastAgentRun(&t); lr != nil && r.Agents.ProviderRateLimited(lr.Provider) && !r.Agents.ProviderCanFailover(lr.Provider) {
 			r.Logger.Info("restart-stale.skip",
 				"task_id", t.ID, "reason", "provider_rate_limited", "provider", lr.Provider)
 			continue

--- a/internal/selfmonitor/judge.go
+++ b/internal/selfmonitor/judge.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"os/exec"
 	"strings"
 
 	"github.com/Automaat/sybra/internal/health"
+	"github.com/Automaat/sybra/internal/llmexec"
+	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -26,6 +27,7 @@ type Judge interface {
 type ClaudeJudge struct {
 	Model  string // default: claude-haiku-4-5-20251001
 	Logger *slog.Logger
+	Gate   provider.HealthGate
 }
 
 // Judge shells out to claude -p and returns a validated Verdict.
@@ -37,20 +39,14 @@ func (j *ClaudeJudge) Judge(ctx context.Context, f health.Finding, ls *LogSummar
 
 	prompt := buildJudgePrompt(f, ls, t)
 
-	cmd := exec.CommandContext(ctx, "claude",
-		"-p", prompt,
-		"--output-format", "json",
-		"--dangerously-skip-permissions",
-		"--model", model,
-	)
-	out, err := cmd.Output()
+	res, err := llmexec.RunJSON(ctx, prompt, llmexec.Options{Model: model, Logger: j.Logger, Gate: j.Gate})
 	if err != nil {
-		return Verdict{Classification: VerdictPending}, fmt.Errorf("claude -p: %w", err)
+		return Verdict{Classification: VerdictPending}, err
 	}
 
-	v, err := parseJudgeVerdict(out)
+	v, err := parseJudgeVerdict([]byte(res.Text))
 	if err != nil {
-		return Verdict{Classification: VerdictPending}, fmt.Errorf("parse verdict: %w", err)
+		return Verdict{Classification: VerdictPending}, fmt.Errorf("parse %s verdict: %w", res.Provider, err)
 	}
 	return v, nil
 }
@@ -120,18 +116,19 @@ Rules:
 // stdout. The envelope has a `result` string field; we extract the last JSON
 // object from it.
 func parseJudgeVerdict(raw []byte) (Verdict, error) {
+	text := string(raw)
 	var envelope struct {
-		Result string `json:"result"`
+		Result *string `json:"result"`
 	}
-	if err := json.Unmarshal(raw, &envelope); err != nil {
-		return Verdict{}, fmt.Errorf("unmarshal envelope: %w", err)
+	if err := json.Unmarshal(raw, &envelope); err == nil && envelope.Result != nil {
+		if *envelope.Result == "" {
+			return Verdict{}, fmt.Errorf("empty result field")
+		}
+		text = *envelope.Result
 	}
-	if envelope.Result == "" {
-		return Verdict{}, fmt.Errorf("empty result field")
-	}
-	jsonStr := judgeExtractLastJSON(envelope.Result)
+	jsonStr := judgeExtractLastJSON(text)
 	if jsonStr == "" {
-		return Verdict{}, fmt.Errorf("no JSON object in result: %q", envelope.Result)
+		return Verdict{}, fmt.Errorf("no JSON object in result: %q", text)
 	}
 	var v Verdict
 	if err := json.Unmarshal([]byte(jsonStr), &v); err != nil {

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -116,7 +116,7 @@ func (a *App) initIssuesFetcher(emit func(string, any)) *poll.IssuesFetcher {
 	if a.cfg.Umbrella.Enabled {
 		model := a.cfg.Umbrella.Model
 		f.SetUmbrellaExpander(func(issueURL string) (umbrella.Result, error) {
-			return umbrella.Expand(context.Background(), a.tasks, umbrella.ClaudePlannerRunner(model, a.providerHealth), issueURL)
+			return umbrella.Expand(context.Background(), a.tasks, umbrella.FallbackPlannerRunner(model, a.providerHealth), issueURL)
 		})
 		a.logger.Info("umbrella.autodetect.enabled")
 	}

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -116,7 +116,7 @@ func (a *App) initIssuesFetcher(emit func(string, any)) *poll.IssuesFetcher {
 	if a.cfg.Umbrella.Enabled {
 		model := a.cfg.Umbrella.Model
 		f.SetUmbrellaExpander(func(issueURL string) (umbrella.Result, error) {
-			return umbrella.Expand(context.Background(), a.tasks, umbrella.ClaudePlannerRunner(model), issueURL)
+			return umbrella.Expand(context.Background(), a.tasks, umbrella.ClaudePlannerRunner(model, a.providerHealth), issueURL)
 		})
 		a.logger.Info("umbrella.autodetect.enabled")
 	}

--- a/internal/sybra/app_triage.go
+++ b/internal/sybra/app_triage.go
@@ -10,5 +10,6 @@ func (a *App) initTriage() {
 		return
 	}
 	a.triageHandler = poll.NewTriageHandler(a.tasks, a.projects, a.audit, a.logger, &a.cfg.Triage)
+	a.triageHandler.SetProviderGate(a.providerHealth)
 	a.logger.Info("triage.enabled", "poll_seconds", a.cfg.Triage.PollSeconds, "model", a.cfg.Triage.Model)
 }

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -560,6 +560,10 @@ func (a *agentAdapter) ProviderRateLimited(provider string) bool {
 	return a.agents.ProviderRateLimited(provider)
 }
 
+func (a *agentAdapter) ProviderCanFailover(provider string) bool {
+	return a.agents.ProviderCanFailover(provider)
+}
+
 func firstNonEmpty(a, b string) string {
 	if a != "" {
 		return a

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -306,6 +306,7 @@ func (lm *LifecycleManager) startSelfMonitorService(ctx context.Context, emit fu
 		Judge: &selfmonitor.ClaudeJudge{
 			Model:  a.cfg.SelfMonitor.JudgeModel,
 			Logger: a.logger,
+			Gate:   a.providerHealth,
 		},
 		Actor: &selfmonitor.Actor{
 			Tasks:  a.tasks,

--- a/internal/sybra/services.go
+++ b/internal/sybra/services.go
@@ -28,7 +28,7 @@ func (a *App) wireServices(emit func(string, any)) {
 	// cfg.Umbrella.Enabled so a config reload toggles it without re-wiring.
 	// Mirrors initIssuesFetcher's poll-loop expander (same Expand entry point).
 	a.taskSvc.umbrellaExpand = func(issueURL string) (umbrella.Result, error) {
-		return umbrella.Expand(context.Background(), a.tasks, umbrella.ClaudePlannerRunner(a.cfg.Umbrella.Model, a.providerHealth), issueURL)
+		return umbrella.Expand(context.Background(), a.tasks, umbrella.FallbackPlannerRunner(a.cfg.Umbrella.Model, a.providerHealth), issueURL)
 	}
 	a.planSvc.engine = a.workflowEngine
 	a.planSvc.tasks = a.tasks

--- a/internal/sybra/services.go
+++ b/internal/sybra/services.go
@@ -28,7 +28,7 @@ func (a *App) wireServices(emit func(string, any)) {
 	// cfg.Umbrella.Enabled so a config reload toggles it without re-wiring.
 	// Mirrors initIssuesFetcher's poll-loop expander (same Expand entry point).
 	a.taskSvc.umbrellaExpand = func(issueURL string) (umbrella.Result, error) {
-		return umbrella.Expand(context.Background(), a.tasks, umbrella.ClaudePlannerRunner(a.cfg.Umbrella.Model), issueURL)
+		return umbrella.Expand(context.Background(), a.tasks, umbrella.ClaudePlannerRunner(a.cfg.Umbrella.Model, a.providerHealth), issueURL)
 	}
 	a.planSvc.engine = a.workflowEngine
 	a.planSvc.tasks = a.tasks

--- a/internal/sybra/svc_orchestrator.go
+++ b/internal/sybra/svc_orchestrator.go
@@ -131,8 +131,8 @@ func (s *OrchestratorService) reconcileOrchestratorsLocked() string {
 // StartOrchestrator launches the orchestrator as an in-app conversational
 // Claude agent rooted at ~/.sybra (where the brain CLAUDE.md + skills live).
 // The orchestrator bootstraps its own monitor loop via CronCreate on first
-// turn, as instructed by orchestrator/CLAUDE.md. Provider is pinned to claude
-// because /sybra-monitor is a Claude-only skill.
+// turn, as instructed by orchestrator/CLAUDE.md. Claude is requested first, but
+// agent.Manager may fail over if provider health marks it unavailable.
 func (s *OrchestratorService) StartOrchestrator() error {
 	// Hold the lock across agents.Run so two concurrent callers (the 1-minute
 	// auto-start loop and the UI Start button) cannot both pass the replaceable

--- a/internal/sybra/svc_orchestrator.go
+++ b/internal/sybra/svc_orchestrator.go
@@ -131,8 +131,8 @@ func (s *OrchestratorService) reconcileOrchestratorsLocked() string {
 // StartOrchestrator launches the orchestrator as an in-app conversational
 // Claude agent rooted at ~/.sybra (where the brain CLAUDE.md + skills live).
 // The orchestrator bootstraps its own monitor loop via CronCreate on first
-// turn, as instructed by orchestrator/CLAUDE.md. Claude is requested first, but
-// agent.Manager may fail over if provider health marks it unavailable.
+// turn, as instructed by orchestrator/CLAUDE.md, so this run stays pinned to
+// Claude even when generic task agents can fail over to another provider.
 func (s *OrchestratorService) StartOrchestrator() error {
 	// Hold the lock across agents.Run so two concurrent callers (the 1-minute
 	// auto-start loop and the UI Start button) cannot both pass the replaceable
@@ -147,12 +147,13 @@ func (s *OrchestratorService) StartOrchestrator() error {
 	}
 
 	a, err := s.agents.Run(agent.RunConfig{
-		Name:                   orchestratorAgentName,
-		Mode:                   "interactive",
-		Dir:                    config.HomeDir(),
-		Provider:               "claude",
-		Prompt:                 orchestratorKickoffPrompt,
-		IgnoreConcurrencyLimit: true,
+		Name:                    orchestratorAgentName,
+		Mode:                    "interactive",
+		Dir:                     config.HomeDir(),
+		Provider:                "claude",
+		Prompt:                  orchestratorKickoffPrompt,
+		IgnoreConcurrencyLimit:  true,
+		DisableProviderFailover: true,
 	})
 	if err != nil {
 		return fmt.Errorf("start orchestrator agent: %w", err)

--- a/internal/triage/classifier.go
+++ b/internal/triage/classifier.go
@@ -8,7 +8,9 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/Automaat/sybra/internal/llmexec"
 	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -23,6 +25,13 @@ type Classifier interface {
 type ClaudeClassifier struct {
 	Model  string       // default: "sonnet"
 	Logger *slog.Logger // required
+}
+
+// FallbackClassifier runs triage through the shared provider-fallback executor.
+type FallbackClassifier struct {
+	Model  string
+	Logger *slog.Logger
+	Gate   provider.HealthGate
 }
 
 // Classify shells out to claude -p and returns a validated verdict.
@@ -48,6 +57,31 @@ func (c *ClaudeClassifier) Classify(ctx context.Context, t task.Task, projects [
 	v, err := parseVerdict(out)
 	if err != nil {
 		return Verdict{}, fmt.Errorf("parse verdict: %w", err)
+	}
+	if err := ValidateVerdict(&v); err != nil {
+		return Verdict{}, fmt.Errorf("validate verdict: %w", err)
+	}
+	return v, nil
+}
+
+// Classify shells out to the first available provider and falls back when it is
+// rate-limited/logged-out/unavailable.
+func (c *FallbackClassifier) Classify(ctx context.Context, t task.Task, projects []project.Project) (Verdict, error) {
+	model := c.Model
+	if model == "" {
+		model = "sonnet"
+	}
+	res, err := llmexec.RunJSON(ctx, buildPrompt(t, projects), llmexec.Options{
+		Model:  model,
+		Logger: c.Logger,
+		Gate:   c.Gate,
+	})
+	if err != nil {
+		return Verdict{}, err
+	}
+	v, err := parseVerdict([]byte(res.Text))
+	if err != nil {
+		return Verdict{}, fmt.Errorf("parse %s verdict: %w", res.Provider, err)
 	}
 	if err := ValidateVerdict(&v); err != nil {
 		return Verdict{}, fmt.Errorf("validate verdict: %w", err)
@@ -137,18 +171,19 @@ Output schema (single JSON object):
 // The top-level response has a `result` string field containing the model's
 // final message, from which we extract the last JSON object.
 func parseVerdict(raw []byte) (Verdict, error) {
+	text := string(raw)
 	var envelope struct {
-		Result string `json:"result"`
+		Result *string `json:"result"`
 	}
-	if err := json.Unmarshal(raw, &envelope); err != nil {
-		return Verdict{}, fmt.Errorf("unmarshal envelope: %w", err)
+	if err := json.Unmarshal(raw, &envelope); err == nil && envelope.Result != nil {
+		if *envelope.Result == "" {
+			return Verdict{}, fmt.Errorf("empty result field")
+		}
+		text = *envelope.Result
 	}
-	if envelope.Result == "" {
-		return Verdict{}, fmt.Errorf("empty result field")
-	}
-	jsonStr := extractLastJSONObject(envelope.Result)
+	jsonStr := extractLastJSONObject(text)
 	if jsonStr == "" {
-		return Verdict{}, fmt.Errorf("no JSON object in result: %q", envelope.Result)
+		return Verdict{}, fmt.Errorf("no JSON object in result: %q", text)
 	}
 	var v Verdict
 	if err := json.Unmarshal([]byte(jsonStr), &v); err != nil {

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -3,12 +3,13 @@ package umbrella
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"slices"
 	"strings"
 	"time"
 
 	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/llmexec"
+	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -203,28 +204,19 @@ func childTags(ref string, byRef map[string]github.Issue) []string {
 	return tags
 }
 
-// ClaudePlannerRunner returns a planner Runner that shells out to the claude
-// CLI for a single structured-output completion. The planner reasons over text
-// in the prompt and needs no tools.
-func ClaudePlannerRunner(model string) Runner {
+// ClaudePlannerRunner returns a planner Runner that prefers Claude and falls
+// back to another CLI provider when the preferred provider is unavailable.
+func ClaudePlannerRunner(model string, gates ...provider.HealthGate) Runner {
+	var gate provider.HealthGate
+	if len(gates) > 0 {
+		gate = gates[0]
+	}
 	return func(ctx context.Context, prompt string) (string, error) {
-		cmdArgs := []string{"-p", prompt, "--output-format", "json", "--dangerously-skip-permissions"}
-		if model != "" {
-			cmdArgs = append(cmdArgs, "--model", model)
-		}
-		cmd := exec.CommandContext(ctx, "claude", cmdArgs...)
-		// Keep stdout clean for JSON parsing, but capture stderr so a planner
-		// failure (or timeout-killed process) surfaces the real CLI message.
-		var stderr strings.Builder
-		cmd.Stderr = &stderr
-		out, err := cmd.Output()
+		res, err := llmexec.RunJSON(ctx, prompt, llmexec.Options{Model: model, Gate: gate})
 		if err != nil {
-			if msg := strings.TrimSpace(stderr.String()); msg != "" {
-				return "", fmt.Errorf("run claude: %w: %s", err, msg)
-			}
-			return "", fmt.Errorf("run claude: %w", err)
+			return "", err
 		}
-		return string(out), nil
+		return res.Text, nil
 	}
 }
 

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -204,9 +204,9 @@ func childTags(ref string, byRef map[string]github.Issue) []string {
 	return tags
 }
 
-// ClaudePlannerRunner returns a planner Runner that prefers Claude and falls
+// FallbackPlannerRunner returns a planner Runner that prefers Claude and falls
 // back to another CLI provider when the preferred provider is unavailable.
-func ClaudePlannerRunner(model string, gates ...provider.HealthGate) Runner {
+func FallbackPlannerRunner(model string, gates ...provider.HealthGate) Runner {
 	var gate provider.HealthGate
 	if len(gates) > 0 {
 		gate = gates[0]

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -37,6 +37,9 @@ type AgentLauncher interface {
 	// it to wait out a transient throttle without also stalling auth failures,
 	// which must take the human-required path. Empty name = default provider.
 	ProviderRateLimited(provider string) bool
+	// ProviderCanFailover reports whether a currently blocked provider has a
+	// healthy peer available for this run.
+	ProviderCanFailover(provider string) bool
 }
 
 // AgentAssignment carries A/B experiment attribution selected before dispatch.

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -349,11 +349,11 @@ func (e *Engine) ResumeStalled() {
 		if e.agents.HasRunningAgent(t.ID) {
 			continue
 		}
-		// Don't re-dispatch while the step's provider is rate-limited — it would
-		// just hit the limit again. The cooldown clears on its own and a later
-		// sweep resumes the step. Auth failures are NOT skipped here: those need
-		// a human to log in and take the human-required path instead.
-		if prov := resolveProvider(step.Config.Provider, t.Workflow, e.agents.DefaultProvider(), *t); e.agents.ProviderRateLimited(prov) {
+		// Don't re-dispatch to the same provider while it is rate-limited; do
+		// continue when failover can route this run to a healthy peer.
+		// Auth failures are NOT skipped here: those need a human to log in and
+		// take the human-required path instead.
+		if prov := resolveProvider(step.Config.Provider, t.Workflow, e.agents.DefaultProvider(), *t); e.agents.ProviderRateLimited(prov) && !e.agents.ProviderCanFailover(prov) {
 			e.logger.Debug("workflow.resume-stalled.skip",
 				"task_id", t.ID, "reason", "provider_rate_limited", "provider", prov)
 			continue

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -300,6 +300,7 @@ type mockAgents struct {
 	counter           int
 	failSpawn         error // when non-nil, StartAgent returns this error and records nothing
 	providerRateLimit bool  // when true, ProviderRateLimited reports true
+	providerFailover  bool  // when true, ProviderCanFailover reports true
 }
 
 func newMockAgents() *mockAgents {
@@ -357,10 +358,22 @@ func (m *mockAgents) ProviderRateLimited(string) bool {
 	return m.providerRateLimit
 }
 
+func (m *mockAgents) ProviderCanFailover(string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.providerFailover
+}
+
 func (m *mockAgents) SetProviderRateLimited(v bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.providerRateLimit = v
+}
+
+func (m *mockAgents) SetProviderFailover(v bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.providerFailover = v
 }
 
 func (m *mockAgents) FindRunningAgentForRole(taskID, role string) (string, bool) {
@@ -1142,6 +1155,33 @@ func TestResumeStalled_SkipsRateLimitedProvider(t *testing.T) {
 	engine.ResumeStalled()
 	if agents.CallCount() != 1 {
 		t.Fatalf("expected 1 agent start after rate limit cleared, got %d", agents.CallCount())
+	}
+}
+
+func TestResumeStalled_FailoversRateLimitedProvider(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	agents.SetProviderRateLimited(true)
+	agents.SetProviderFailover(true)
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{
+		ID:        "t1",
+		Status:    "in-progress",
+		AgentMode: "headless",
+		Workflow: &Execution{
+			WorkflowID:  "test-simple",
+			CurrentStep: "implement",
+			State:       ExecRunning,
+			Variables:   make(map[string]string),
+		},
+	})
+
+	engine.ResumeStalled()
+
+	if agents.CallCount() != 1 {
+		t.Fatalf("expected 1 agent start when failover is available, got %d", agents.CallCount())
 	}
 }
 


### PR DESCRIPTION
## Motivation

> Changelog: fix(agent): fallback on provider limits

Provider rate limits should not strand Sybra workflows or direct classifier calls. Triage, orchestrator-adjacent structured calls, and recovery paths need the same provider fallback behavior as normal agent execution.

## Implementation information

Added a shared `internal/llmexec` structured-output runner that tries Claude, Codex, then Copilot while honoring provider health gates and reporting rate-limit/auth failures. Wired it into triage, self-monitor, evaluation, watchdog inspection, and umbrella planning. Workflow stale/resume recovery now allows rate-limited preferred providers to start when the agent manager can fail over.

## Supporting documentation

Validation covered by Go tests and frontend type-check during push hooks.