### PR TITLE
fix(workflow): prune stale builtins

### DIFF
--- a/internal/workflow/builtin.go
+++ b/internal/workflow/builtin.go
@@ -45,12 +45,34 @@ func BuiltinDefinitions() ([]Definition, error) {
 //   - If a stored version exists with Builtin=true and its semantic content
 //     differs from the embedded version, it is overwritten. This repairs
 //     drift from older app versions that seeded now-broken definitions.
+//   - If a stored version is Builtin=true but no longer exists in the embedded
+//     set, it is deleted. This prevents retired built-ins from continuing to
+//     match triggers with stale prompts or sidecar contracts.
 //   - If a stored version exists with Builtin=false (user cleared the flag
 //     to opt out of sync), it is preserved.
 func SyncBuiltins(store *Store) error {
 	defs, err := BuiltinDefinitions()
 	if err != nil {
 		return err
+	}
+	current := make(map[string]struct{}, len(defs))
+	for i := range defs {
+		current[defs[i].ID] = struct{}{}
+	}
+	stored, err := store.List()
+	if err != nil {
+		return fmt.Errorf("list workflows for builtin sync: %w", err)
+	}
+	for i := range stored {
+		if !stored[i].Builtin {
+			continue
+		}
+		if _, ok := current[stored[i].ID]; ok {
+			continue
+		}
+		if dErr := store.Delete(stored[i].ID); dErr != nil {
+			return fmt.Errorf("prune obsolete builtin %s: %w", stored[i].ID, dErr)
+		}
 	}
 	for i := range defs {
 		existing, getErr := store.Get(defs[i].ID)

--- a/internal/workflow/builtin.go
+++ b/internal/workflow/builtin.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"embed"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"reflect"
@@ -63,6 +64,7 @@ func SyncBuiltins(store *Store) error {
 	if err != nil {
 		return fmt.Errorf("list workflows for builtin sync: %w", err)
 	}
+	var pruneErr error
 	for i := range stored {
 		if !stored[i].Builtin {
 			continue
@@ -71,7 +73,7 @@ func SyncBuiltins(store *Store) error {
 			continue
 		}
 		if dErr := store.Delete(stored[i].ID); dErr != nil {
-			return fmt.Errorf("prune obsolete builtin %s: %w", stored[i].ID, dErr)
+			pruneErr = errors.Join(pruneErr, fmt.Errorf("prune obsolete builtin %s: %w", stored[i].ID, dErr))
 		}
 	}
 	for i := range defs {
@@ -95,7 +97,7 @@ func SyncBuiltins(store *Store) error {
 			return fmt.Errorf("sync builtin %s: %w", defs[i].ID, sErr)
 		}
 	}
-	return nil
+	return pruneErr
 }
 
 // builtinsEqual compares two definitions ignoring timestamps. Timestamps are

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -2,6 +2,8 @@ package workflow
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -557,7 +559,7 @@ func TestSyncBuiltins_PrunesObsoleteBuiltin(t *testing.T) {
 		t.Fatalf("NewStore: %v", err)
 	}
 
-	obsolete := newTestDef("simple-task")
+	obsolete := newTestDef("obsolete-builtin-sync-test")
 	obsolete.Builtin = true
 	if err := store.Save(obsolete); err != nil {
 		t.Fatalf("Save obsolete: %v", err)
@@ -578,7 +580,7 @@ func TestSyncBuiltins_PreservesObsoleteUserWorkflow(t *testing.T) {
 		t.Fatalf("NewStore: %v", err)
 	}
 
-	custom := newTestDef("simple-task")
+	custom := newTestDef("obsolete-custom-workflow-sync-test")
 	custom.Builtin = false
 	if err := store.Save(custom); err != nil {
 		t.Fatalf("Save custom: %v", err)
@@ -589,6 +591,41 @@ func TestSyncBuiltins_PreservesObsoleteUserWorkflow(t *testing.T) {
 	}
 	if _, err := store.Get(custom.ID); err != nil {
 		t.Fatalf("custom workflow was pruned: %v", err)
+	}
+}
+
+func TestSyncBuiltins_PruneFailureDoesNotBlockRefresh(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	bad := []byte(`id: ../obsolete-builtin-sync-test
+name: Bad Builtin
+trigger:
+  on: task.created
+steps:
+  - id: s
+    type: set_status
+    config:
+      status: todo
+builtin: true
+`)
+	if err := os.WriteFile(filepath.Join(store.Dir(), "bad.yaml"), bad, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	err = SyncBuiltins(store)
+	if err == nil {
+		t.Fatal("SyncBuiltins succeeded, want prune error")
+	}
+	defs, defsErr := BuiltinDefinitions()
+	if defsErr != nil || len(defs) == 0 {
+		t.Fatalf("BuiltinDefinitions: %v (len=%d)", defsErr, len(defs))
+	}
+	if _, getErr := store.Get(defs[0].ID); getErr != nil {
+		t.Fatalf("current builtin was not refreshed after prune failure: %v", getErr)
 	}
 }
 

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -550,6 +550,48 @@ func TestSyncBuiltins_OverwriteStaleBuiltin(t *testing.T) {
 	}
 }
 
+func TestSyncBuiltins_PrunesObsoleteBuiltin(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	obsolete := newTestDef("simple-task")
+	obsolete.Builtin = true
+	if err := store.Save(obsolete); err != nil {
+		t.Fatalf("Save obsolete: %v", err)
+	}
+
+	if err := SyncBuiltins(store); err != nil {
+		t.Fatalf("SyncBuiltins: %v", err)
+	}
+	if _, err := store.Get(obsolete.ID); err == nil {
+		t.Fatalf("obsolete builtin %q still exists", obsolete.ID)
+	}
+}
+
+func TestSyncBuiltins_PreservesObsoleteUserWorkflow(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	custom := newTestDef("simple-task")
+	custom.Builtin = false
+	if err := store.Save(custom); err != nil {
+		t.Fatalf("Save custom: %v", err)
+	}
+
+	if err := SyncBuiltins(store); err != nil {
+		t.Fatalf("SyncBuiltins: %v", err)
+	}
+	if _, err := store.Get(custom.ID); err != nil {
+		t.Fatalf("custom workflow was pruned: %v", err)
+	}
+}
+
 // TestSyncBuiltins_IdempotentOnClean verifies the no-op path: calling
 // SyncBuiltins twice in a row on a freshly seeded store must not bounce
 // the UpdatedAt timestamp on every startup.


### PR DESCRIPTION
## Motivation

Stored built-in workflow definitions can outlive the embedded built-in set. A retired workflow may still match new task triggers and run stale prompts/sidecar contracts, blocking tasks even after the fixed workflow definitions ship.

> Changelog: fix(workflow): prune stale builtins

## Implementation information

`workflow.SyncBuiltins` now deletes stored workflows that are still marked `builtin: true` when their ID no longer exists in the embedded built-in set. Workflows where users cleared `builtin` remain untouched.

Added coverage for pruning obsolete built-ins and preserving obsolete user-owned workflows.

## Supporting documentation

Validated with `go test ./internal/workflow`; push hooks also ran Go tests and frontend check successfully.