### PR TITLE
fix(workflow): accept verbatim evidence

### DIFF
--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -657,7 +657,7 @@ func hasGroundedFailureEvidence(report string) bool {
 	hasObserved := containsAny(lower,
 		"actual output:", "actual:", "observed:", "observed output:",
 		"command output:", "stdout:", "stderr:", "exit code",
-		"printed:", "rendered:") || hasReportLinePrefix(report, "output:")
+		"verbatim output:", "printed:", "rendered:") || hasReportLinePrefix(report, "output:")
 	hasExpected := containsAny(lower,
 		"expected:", "expected output:", "requirement tested:", "task says", "from the task",
 		"violates", "should render", "should not")

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -198,6 +198,27 @@ func TestStructuredFailureOutcomeInsertedAfterParenthesizedHeading(t *testing.T)
 	}
 }
 
+func TestClassifyTestOutcome_AcceptsVerbatimOutputEvidence(t *testing.T) {
+	t.Parallel()
+
+	report := "## Test Failures\n\n" +
+		"### product_bug: parser rejects valid evidence\n\n" +
+		"**Command run:**\n\n```bash\ngo test ./internal/workflow\n```\n\n" +
+		"**Verbatim output:**\n\n```text\n--- FAIL: TestEvidence\n```\n\n" +
+		"**Expected behaviour:** The task says grounded product defects route back to implementation.\n\n" +
+		"**Actual behaviour:** The task escalated to human-required.\n\n" +
+		"**Code evidence:**\n\n```text\ninternal/workflow/engine_steps_testroute.go:659\n```\n"
+	payload := `{"verdict":"FAIL","outcome":"product_bug","failures_markdown":` + strconv.Quote(report) + `}`
+
+	got, fingerprint := classifyTestOutcome("completed", payload, "", &Execution{Variables: map[string]string{}}, testVerdictSourceStep)
+	if got != testOutcomeProductBug {
+		t.Fatalf("outcome = %q, want %q", got, testOutcomeProductBug)
+	}
+	if fingerprint == "" {
+		t.Fatal("fingerprint is empty")
+	}
+}
+
 func TestTestFailureSectionIgnoresStaleLookingHeading(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation

Grounded test-runner FAIL reports can use `Verbatim output:` to label exact command output. The deterministic route_test parser did not count that label as observed-output evidence, so real product defects were misclassified as missing evidence and escalated to human-required.

> Changelog: fix(workflow): accept verbatim evidence

## Implementation information

Added `verbatim output:` to the observed evidence labels accepted by `hasGroundedFailureEvidence`. Added a regression test covering a structured product_bug report with command, verbatim output, expected/actual behavior, and code evidence.

## Supporting documentation

Validated with `go test ./internal/workflow`; push hooks also ran Go tests and frontend check successfully.