### PR TITLE
fix(umbrella): preserve blocked trackers

### DIFF
--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -170,6 +170,9 @@ func (a *App) rollupTrackers(states map[string]*umbrellaState, cyclic map[string
 		if st.tracker == nil {
 			continue
 		}
+		if st.tracker.Status == task.StatusBlocked {
+			continue
+		}
 		// A tracker is "settled" once it has outlived the creation window, so a
 		// childless tally that just reflects children still being materialized
 		// is not mistaken for a completed umbrella. A zero CreatedAt (e.g. a

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -80,6 +80,31 @@ func TestReleaseUnblockedChildren_HaltChainFlagsTracker(t *testing.T) {
 	}
 }
 
+func TestReleaseUnblockedChildren_PreservesBlockedTracker(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+	tracker := mkTracker(t, m, umb, 5)
+	reason := "auto-review: Sybra bug isolated (local task abc123; issue filing failed)"
+	if _, err := m.Update(tracker.ID, task.Update{
+		Status:       task.Ptr(task.StatusBlocked),
+		StatusReason: task.Ptr(reason),
+	}); err != nil {
+		t.Fatalf("block tracker: %v", err)
+	}
+	mkChild(t, m, "stuck", "Automaat/sybra#1", umb, nil, task.StatusHumanRequired)
+
+	app.releaseUnblockedChildren()
+
+	got := mustTask(t, m, tracker.ID)
+	if got.Status != task.StatusBlocked {
+		t.Fatalf("tracker status = %q, want blocked", got.Status)
+	}
+	if got.StatusReason != reason {
+		t.Fatalf("tracker status_reason = %q, want %q", got.StatusReason, reason)
+	}
+}
+
 func TestReleaseUnblockedChildren_RollupClosesUmbrella(t *testing.T) {
 	t.Parallel()
 	app, m := newUmbrellaGateApp(t)

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -85,7 +85,13 @@ func TestReleaseUnblockedChildren_PreservesBlockedTracker(t *testing.T) {
 	app, m := newUmbrellaGateApp(t)
 	const umb = "https://github.com/Automaat/sybra/issues/100"
 	tracker := mkTracker(t, m, umb, 5)
-	reason := "auto-review: Sybra bug isolated (local task abc123; issue filing failed)"
+	localBug, err := m.CreateFull("Sybra bug", "", task.AgentModeHeadless, task.Update{
+		Tags: task.Ptr([]string{"sybra-bug"}),
+	})
+	if err != nil {
+		t.Fatalf("create local bug: %v", err)
+	}
+	reason := "auto-review: Sybra bug isolated (local task " + localBug.ID + "; issue filing failed)"
 	if _, err := m.Update(tracker.ID, task.Update{
 		Status:       task.Ptr(task.StatusBlocked),
 		StatusReason: task.Ptr(reason),


### PR DESCRIPTION
## Motivation

Blocked umbrella trackers represent human-review containment state and must not be overwritten by automatic child-state rollups.

> Changelog: fix(umbrella): preserve blocked trackers

## Implementation information

Skip tracker rollup when the umbrella tracker is already blocked, preserving its status and status reason. Added a regression test covering a blocked tracker with a human-required child.

## Supporting documentation

Regression coverage: `TestReleaseUnblockedChildren_PreservesBlockedTracker`.