### PR TITLE
fix(ui): split blocked board lane

### DIFF
--- a/frontend/src/components/StatusPicker.svelte
+++ b/frontend/src/components/StatusPicker.svelte
@@ -19,8 +19,8 @@
   let selectedIdx = $state(initialIdx())
 
   // Picking the bucket the task is already in is a no-op — don't overwrite a
-  // granular status (e.g. blocked) with its rolled-up core (human-required)
-  // just because the user confirmed the highlighted "current" option.
+  // granular status with its rolled-up core just because the user confirmed
+  // the highlighted "current" option.
   function pick(value: string) {
     if (value === coreStatus(currentStatus)) { onclose(); return }
     onpick(value)

--- a/frontend/src/lib/status-summary.test.ts
+++ b/frontend/src/lib/status-summary.test.ts
@@ -10,11 +10,10 @@ describe('statusSummary', () => {
       tone: 'attention',
     })
     expect(statusSummary('human-required')?.tone).toBe('attention')
-    expect(statusSummary('blocked')?.tone).toBe('attention')
   })
 
   it('summarises agent/pipeline states as info', () => {
-    for (const s of ['planning', 'in-progress', 'in-review', 'testing', 'ready-review', 'new']) {
+    for (const s of ['planning', 'in-progress', 'in-review', 'testing', 'ready-review', 'new', 'blocked']) {
       expect(statusSummary(s)?.tone).toBe('info')
       expect(statusSummary(s)?.hint).toBeTruthy()
     }

--- a/frontend/src/lib/status-summary.ts
+++ b/frontend/src/lib/status-summary.ts
@@ -16,8 +16,8 @@ export interface StatusSummary {
   tone: StatusTone
 }
 
-// `attention` = waiting on the user; `info` = an agent or the pipeline is
-// working. Statuses absent here (todo, done, cancelled) get no banner.
+// `attention` = waiting on the user; `info` = an agent/pipeline state or
+// non-human blockage. Statuses absent here (todo, done, cancelled) get no banner.
 const SUMMARY: Record<string, { hint: string; tone: StatusTone }> = {
   new: { hint: 'not yet triaged', tone: 'info' },
   planning: { hint: 'an agent is drafting a plan', tone: 'info' },
@@ -28,7 +28,7 @@ const SUMMARY: Record<string, { hint: string; tone: StatusTone }> = {
   testing: { hint: 'an agent is adversarially testing the feature', tone: 'info' },
   'ready-pr': { hint: 'tests passed — opening the PR', tone: 'info' },
   'human-required': { hint: 'needs your input', tone: 'attention' },
-  blocked: { hint: 'needs your response', tone: 'attention' },
+  blocked: { hint: 'blocked until its cause is resolved', tone: 'info' },
 }
 
 /** The per-state summary to surface in the detail banner, or null when there's

--- a/frontend/src/lib/statuses.test.ts
+++ b/frontend/src/lib/statuses.test.ts
@@ -19,10 +19,11 @@ describe('CORE_STATUSES', () => {
   })
 
   it('is a small set (<= 9) and excludes granular states', () => {
-    expect(CORE_STATUSES.length).toBeLessThanOrEqual(9)
-    for (const granular of ['new', 'plan-review', 'ready-pr', 'blocked']) {
+    expect(CORE_STATUSES.length).toBeLessThanOrEqual(10)
+    for (const granular of ['new', 'plan-review', 'ready-pr']) {
       expect(CORE_STATUSES).not.toContain(granular)
     }
+    expect(CORE_STATUSES).toContain('blocked')
   })
 
   it('exposes options with labels from STATUS_MAP', () => {
@@ -38,7 +39,7 @@ describe('coreStatus', () => {
     expect(coreStatus('plan-review')).toBe('planning')
     expect(coreStatus('ready-review')).toBe('ready-review')
     expect(coreStatus('ready-pr')).toBe('in-review')
-    expect(coreStatus('blocked')).toBe('human-required')
+    expect(coreStatus('blocked')).toBe('blocked')
   })
 
   it('maps a column status to itself', () => {
@@ -105,6 +106,11 @@ describe('awaitsHumanLabel — canonical, never a divergent name', () => {
       // no invented "Needs Review"/"Needs You" vocabulary.
       expect(awaitsHumanLabel(status)).toBe(statusLabel(status))
     }
+  })
+
+  it('does not treat blocked containment as a human-required escalation', () => {
+    expect(awaitsHuman('blocked')).toBe(false)
+    expect(awaitsHumanLabel('blocked')).toBe('')
   })
 
   it('is empty for statuses that do not await the user', () => {

--- a/frontend/src/lib/statuses.ts
+++ b/frontend/src/lib/statuses.ts
@@ -110,13 +110,13 @@ export const ALL_STATUSES: StatusMeta[] = [
 /**
  * Statuses that await the user's own action — distinct from agent-driven
  * review states (`in-review`, `ready-review`) where an agent is working.
- * Mirrors orchestrator/CLAUDE.md: plan-review waits for the human to
- * approve/reject; human-required/blocked need human input.
+ * Plan-review waits for approval; human-required is the explicit escalation.
+ * Blocked is tracked separately so Sybra-bug containment does not look like a
+ * fresh request for the operator.
  */
 export const AWAITS_HUMAN: ReadonlySet<TaskStatus> = new Set<TaskStatus>([
   'human-required',
   'plan-review',
-  'blocked',
 ])
 
 /** True when a task is waiting on the user (not on an agent). */
@@ -173,7 +173,8 @@ export const BOARD_COLUMNS: BoardColumn[] = [
   { status: 'ready-review', label: 'Agentic Review', border: 'border-t-success-500 dark:border-t-success-400', includes: [] },
   { status: 'testing', label: 'Testing', border: 'border-t-secondary-500 dark:border-t-secondary-400', includes: ['testing'] },
   { status: 'in-review', label: 'In Review', border: 'border-t-warning-500 dark:border-t-warning-400', includes: ['in-review', 'ready-pr'] },
-  { status: 'human-required', label: 'Human Required', border: 'border-t-error-500 dark:border-t-error-400', includes: ['human-required', 'blocked'] },
+  { status: 'human-required', label: 'Human Required', border: 'border-t-error-500 dark:border-t-error-400', includes: ['human-required'] },
+  { status: 'blocked', label: 'Blocked', border: 'border-t-error-300 dark:border-t-error-600', includes: ['blocked'] },
 ]
 
 /**
@@ -217,7 +218,7 @@ export const BOARD_LANES: BoardColumn[] = [
 /**
  * Core user-facing status set: the active board columns plus the terminal
  * states (`done`, `cancelled`). Granular states (new, plan-review,
- * ready-pr, blocked) are internal/derived — set by automations, not
+ * ready-pr) are internal/derived — set by automations, not
  * picked by hand. Users choose from this small set so a task's status always
  * lines up with a board column.
  */

--- a/frontend/src/pages/TaskList.svelte.test.ts
+++ b/frontend/src/pages/TaskList.svelte.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
+import { render, screen, cleanup, fireEvent, within } from '@testing-library/svelte'
 
 vi.mock('../stores/tasks.svelte.js', () => ({
   taskStore: {
@@ -84,6 +84,7 @@ describe('TaskList', () => {
     expect(screen.getByText('In Progress')).toBeDefined()
     expect(screen.getByText('In Review')).toBeDefined()
     expect(screen.getByText('Human Required')).toBeDefined()
+    expect(screen.getByText('Blocked')).toBeDefined()
     expect(screen.queryByText(/^Done$/)).toBeNull()
   })
 
@@ -151,14 +152,34 @@ describe('TaskList', () => {
       viewModeStore.set('board')
       Object.assign(taskStore, {
         list: [
-          mockTask('h1', 'Blocked task', 'human-required'),
+          mockTask('h1', 'Human task', 'human-required'),
           mockTask('p1', 'Plan to review', 'plan-review'),
+          mockTask('b1', 'Blocked task', 'blocked'),
           mockTask('t1', 'Normal task', 'todo'),
         ],
       })
       render(TaskList, { props: { onselect: vi.fn() } })
-      // 2 of 3 tasks await the user — visible regardless of horizontal scroll.
+      // 2 of 4 tasks await the user; blocked is tracked separately.
       expect(screen.getByText('2 need you')).toBeDefined()
+    })
+
+    it('keeps blocked tasks out of the Human Required column', () => {
+      viewModeStore.set('board')
+      Object.assign(taskStore, {
+        list: [
+          mockTask('h1', 'Needs human', 'human-required'),
+          mockTask('b1', 'Blocked by workflow bug', 'blocked'),
+        ],
+      })
+      render(TaskList, { props: { onselect: vi.fn() } })
+
+      const humanCol = document.querySelector('[data-col-status="human-required"]')
+      const blockedCol = document.querySelector('[data-col-status="blocked"]')
+      expect(humanCol).toBeTruthy()
+      expect(blockedCol).toBeTruthy()
+      expect(within(humanCol as HTMLElement).getByText('Needs human')).toBeDefined()
+      expect(within(humanCol as HTMLElement).queryByText('Blocked by workflow bug')).toBeNull()
+      expect(within(blockedCol as HTMLElement).getByText('Blocked by workflow bug')).toBeDefined()
     })
 
     it('hides the need-you counter in list view even when tasks await', () => {


### PR DESCRIPTION
## Motivation

Blocked tasks were folded into the Human Required board lane, making contained Sybra-bug fallout look like fresh human-required work.

> Changelog: fix(ui): split blocked board lane

## Implementation information

- Add a dedicated Blocked board column.
- Stop counting blocked tasks in the board-level "need you" counter.
- Keep blocked detail summaries informational instead of attention-only.
- Add regression coverage that blocked cards stay out of Human Required.

## Supporting documentation

Targeted checks:
- `cd frontend && npm test -- --run src/lib/statuses.test.ts src/lib/status-summary.test.ts src/pages/TaskList.svelte.test.ts`
- `cd frontend && npm run check`