### PR TITLE
fix(workflow): accept evidenced test JSON

### DIFF
--- a/cmd/fake-codex/main.go
+++ b/cmd/fake-codex/main.go
@@ -130,13 +130,19 @@ func runCodexTestVerdictPass() {
 		"surface_kind":      "cli",
 		"app_started":       true,
 		"start_command":     "sybra-cli --json list",
-		"readiness_probe":   "sybra-cli --json list",
+		"readiness_probe": map[string]any{
+			"command": "sybra-cli --json list",
+			"status":  "returned JSON task list",
+		},
 		"manual_probes": []map[string]string{{
 			"command":  "sybra-cli --json list",
 			"expected": "returns JSON task list",
-			"actual":   "[]",
+			"output":   "[]",
 		}},
-		"automated_checks":     []map[string]string{},
+		"automated_checks": []map[string]string{{
+			"command": "go test ./internal/workflow",
+			"output":  "ok",
+		}},
 		"unable_to_run_reason": "",
 	}))
 	emitTurnCompleted(100, 20)
@@ -150,13 +156,19 @@ func runCodexTestVerdictFail() {
 		"surface_kind":      "server",
 		"app_started":       true,
 		"start_command":     "go run ./cmd/test-server",
-		"readiness_probe":   "curl /status",
+		"readiness_probe": map[string]any{
+			"command": "curl /status",
+			"output":  "HTTP 500",
+		},
 		"manual_probes": []map[string]string{{
 			"command":  "curl /status",
 			"expected": "expected output",
-			"actual":   "wrong output",
+			"output":   "wrong output",
 		}},
-		"automated_checks":     []map[string]string{},
+		"automated_checks": []map[string]string{{
+			"command": "go test ./internal/workflow",
+			"output":  "ok",
+		}},
 		"unable_to_run_reason": "",
 	}))
 	emitTurnCompleted(100, 20)

--- a/cmd/fake-codex/main.go
+++ b/cmd/fake-codex/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -123,7 +124,7 @@ func runExec() {
 }
 
 func runCodexTestVerdictPass() {
-	emitAgentMessage(mustJSON(map[string]any{
+	emitSchemaValidAgentMessage(map[string]any{
 		"verdict":           "PASS",
 		"outcome":           "pass",
 		"failures_markdown": "",
@@ -144,12 +145,12 @@ func runCodexTestVerdictPass() {
 			"output":  "ok",
 		}},
 		"unable_to_run_reason": "",
-	}))
+	})
 	emitTurnCompleted(100, 20)
 }
 
 func runCodexTestVerdictFail() {
-	emitAgentMessage(mustJSON(map[string]any{
+	emitSchemaValidAgentMessage(map[string]any{
 		"verdict":           "FAIL",
 		"outcome":           "product_bug",
 		"failures_markdown": testFailureReport(),
@@ -170,8 +171,189 @@ func runCodexTestVerdictFail() {
 			"output":  "ok",
 		}},
 		"unable_to_run_reason": "",
-	}))
+	})
 	emitTurnCompleted(100, 20)
+}
+
+func emitSchemaValidAgentMessage(payload map[string]any) {
+	text := mustJSON(payload)
+	if err := validateAgainstOutputSchema(os.Args, []byte(text)); err != nil {
+		emitError("fake-codex schema validation failed: " + err.Error())
+		os.Exit(2)
+	}
+	emitAgentMessage(text)
+}
+
+func validateAgainstOutputSchema(args []string, payload []byte) error {
+	schemaPath, ok := outputSchemaPath(args)
+	if !ok {
+		return fmt.Errorf("--output-schema missing")
+	}
+	schemaPath = cleanEnvPath(schemaPath)
+	if schemaPath == "" {
+		return fmt.Errorf("--output-schema path is not under %s", os.TempDir())
+	}
+	schemaData, err := os.ReadFile(schemaPath)
+	if err != nil {
+		return fmt.Errorf("read --output-schema: %w", err)
+	}
+
+	var schema any
+	if err := json.Unmarshal(schemaData, &schema); err != nil {
+		return fmt.Errorf("parse --output-schema: %w", err)
+	}
+	var value any
+	if err := json.Unmarshal(payload, &value); err != nil {
+		return fmt.Errorf("parse payload: %w", err)
+	}
+	return validateJSONSchema(schema, value, "$")
+}
+
+func outputSchemaPath(args []string) (string, bool) {
+	for i, arg := range args {
+		if arg == "--output-schema" && i+1 < len(args) {
+			return args[i+1], true
+		}
+		if path, found := strings.CutPrefix(arg, "--output-schema="); found {
+			return path, true
+		}
+	}
+	return "", false
+}
+
+func validateJSONSchema(schema, value any, path string) error {
+	schemaObject, ok := schema.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	schemaType, _ := schemaObject["type"].(string)
+	switch schemaType {
+	case "object":
+		object, ok := value.(map[string]any)
+		if !ok {
+			return fmt.Errorf("%s: expected object", path)
+		}
+		if err := validateObjectSchema(schemaObject, object, path); err != nil {
+			return err
+		}
+	case "array":
+		items, ok := value.([]any)
+		if !ok {
+			return fmt.Errorf("%s: expected array", path)
+		}
+		if itemSchema, ok := schemaObject["items"]; ok {
+			for i, item := range items {
+				if err := validateJSONSchema(itemSchema, item, fmt.Sprintf("%s[%d]", path, i)); err != nil {
+					return err
+				}
+			}
+		}
+	case "string":
+		if _, ok := value.(string); !ok {
+			return fmt.Errorf("%s: expected string", path)
+		}
+	case "boolean":
+		if _, ok := value.(bool); !ok {
+			return fmt.Errorf("%s: expected boolean", path)
+		}
+	case "number":
+		if _, ok := value.(float64); !ok {
+			return fmt.Errorf("%s: expected number", path)
+		}
+	case "":
+		if hasObjectKeywords(schemaObject) {
+			object, ok := value.(map[string]any)
+			if !ok {
+				return fmt.Errorf("%s: expected object", path)
+			}
+			if err := validateObjectSchema(schemaObject, object, path); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("%s: unsupported schema type %q", path, schemaType)
+	}
+
+	if enumValues, ok := schemaObject["enum"].([]any); ok {
+		matched := false
+		for _, enumValue := range enumValues {
+			if reflect.DeepEqual(value, enumValue) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return fmt.Errorf("%s: value %v not in enum", path, value)
+		}
+	}
+
+	if variants, ok := schemaObject["anyOf"].([]any); ok {
+		var firstErr error
+		for _, variant := range variants {
+			if err := validateJSONSchema(variant, value, path); err == nil {
+				return nil
+			} else if firstErr == nil {
+				firstErr = err
+			}
+		}
+		return fmt.Errorf("%s: does not match anyOf: %w", path, firstErr)
+	}
+
+	return nil
+}
+
+func hasObjectKeywords(schema map[string]any) bool {
+	_, hasProperties := schema["properties"]
+	_, hasRequired := schema["required"]
+	_, hasAdditional := schema["additionalProperties"]
+	return hasProperties || hasRequired || hasAdditional
+}
+
+func validateObjectSchema(schema, object map[string]any, path string) error {
+	properties := map[string]any{}
+	if rawProperties, ok := schema["properties"].(map[string]any); ok {
+		properties = rawProperties
+	}
+
+	for _, field := range stringList(schema["required"]) {
+		if _, ok := object[field]; !ok {
+			return fmt.Errorf("%s: missing required field %q", path, field)
+		}
+	}
+
+	if allowAdditional, ok := schema["additionalProperties"].(bool); ok && !allowAdditional {
+		for field := range object {
+			if _, ok := properties[field]; !ok {
+				return fmt.Errorf("%s: unexpected field %q", path, field)
+			}
+		}
+	}
+
+	for field, fieldSchema := range properties {
+		fieldValue, ok := object[field]
+		if !ok {
+			continue
+		}
+		if err := validateJSONSchema(fieldSchema, fieldValue, path+"."+field); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func stringList(value any) []string {
+	items, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 func runCodexMalformedPR() {

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -2026,10 +2026,13 @@ func TestE2E_TestingTaskWorkflow_FailEscalatesAtCap(t *testing.T) {
 	}
 }
 
-// testTestingTaskWithOutputSchemaYAML mirrors testTestingTaskWorkflowYAML but
-// includes output_schema on the run_test step so --output-schema is passed to
-// codex and the JSON agent_message is captured via the B3 fallback.
-const testTestingTaskWithOutputSchemaYAML = `id: testing-task
+// testingTaskWithOutputSchemaYAML mirrors testTestingTaskWorkflowYAML but uses
+// the real builtin test-runner schema so e2e coverage cannot drift from the
+// production structured evidence contract.
+func testingTaskWithOutputSchemaYAML(t *testing.T) string {
+	t.Helper()
+
+	return `id: testing-task
 name: Test Manual Testing (with schema)
 trigger:
   on: task.status_changed
@@ -2045,7 +2048,7 @@ steps:
       role: test-runner
       mode: headless
       model: sonnet
-      output_schema: '{"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]},"outcome":{"type":"string","enum":["pass","product_bug","infra_failure","ambiguous_requirement","missing_evidence"]},"failures_markdown":{"type":"string"},"surface_kind":{"type":"string","enum":["web","cli","server","desktop","k8s","library","docs","none"]},"app_started":{"type":"boolean"},"start_command":{"type":"string"},"readiness_probe":{"type":"string"},"manual_probes":{"type":"array","items":{"anyOf":[{"type":"string"},{"type":"object","properties":{"command":{"type":"string"},"expected":{"type":"string"},"actual":{"type":"string"},"output":{"type":"string"},"observed":{"type":"string"}},"required":["command"],"anyOf":[{"required":["actual"]},{"required":["output"]},{"required":["observed"]}],"additionalProperties":false}]}},"automated_checks":{"type":"array","items":{"anyOf":[{"type":"string"},{"type":"object","properties":{"command":{"type":"string"},"actual":{"type":"string"},"output":{"type":"string"},"observed":{"type":"string"}},"required":["command"],"anyOf":[{"required":["actual"]},{"required":["output"]},{"required":["observed"]}],"additionalProperties":false}]}},"unable_to_run_reason":{"type":"string"}},"required":["verdict","outcome","failures_markdown","surface_kind","app_started","start_command","readiness_probe","manual_probes","automated_checks","unable_to_run_reason"],"additionalProperties":false}'
+      output_schema: '` + testingTaskOutputSchema(t) + `'
       prompt: 'Test {{.Task.ID}}'
     next:
       - goto: route_test
@@ -2056,6 +2059,28 @@ steps:
     next:
       - goto: ""
 `
+}
+
+func testingTaskOutputSchema(t *testing.T) string {
+	t.Helper()
+
+	defs, err := workflow.BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("load builtin definitions: %v", err)
+	}
+	for _, def := range defs {
+		if def.ID != "testing-task" {
+			continue
+		}
+		step := def.StepByID("run_test")
+		if step == nil {
+			t.Fatal("run_test step not found in testing-task")
+		}
+		return step.Config.OutputSchema
+	}
+	t.Fatal("testing-task builtin not found")
+	return ""
+}
 
 // installTestingTaskWithOutputSchemaWorkflow writes the fixture with
 // output_schema into the engine's workflow store.
@@ -2063,7 +2088,7 @@ func installTestingTaskWithOutputSchemaWorkflow(t *testing.T, env *e2eEnv) {
 	t.Helper()
 	if err := os.WriteFile(
 		filepath.Join(env.wfStore.Dir(), "testing-task.yaml"),
-		[]byte(testTestingTaskWithOutputSchemaYAML), 0o644,
+		[]byte(testingTaskWithOutputSchemaYAML(t)), 0o644,
 	); err != nil {
 		t.Fatalf("write testing-task.yaml: %v", err)
 	}

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/workflow"
 	"github.com/Automaat/sybra/internal/worktree"
+	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -2032,33 +2033,44 @@ func TestE2E_TestingTaskWorkflow_FailEscalatesAtCap(t *testing.T) {
 func testingTaskWithOutputSchemaYAML(t *testing.T) string {
 	t.Helper()
 
-	return `id: testing-task
-name: Test Manual Testing (with schema)
-trigger:
-  on: task.status_changed
-  conditions:
-    - field: task.status
-      operator: equals
-      value: testing
-steps:
-  - id: run_test
-    name: Adversarial Testing
-    type: run_agent
-    config:
-      role: test-runner
-      mode: headless
-      model: sonnet
-      output_schema: '` + testingTaskOutputSchema(t) + `'
-      prompt: 'Test {{.Task.ID}}'
-    next:
-      - goto: route_test
-
-  - id: route_test
-    name: Route Test Result
-    type: route_test_result
-    next:
-      - goto: ""
-`
+	def := workflow.Definition{
+		ID:   "testing-task",
+		Name: "Test Manual Testing (with schema)",
+		Trigger: workflow.Trigger{
+			On: "task.status_changed",
+			Conditions: []workflow.Condition{{
+				Field:    "task.status",
+				Operator: "equals",
+				Value:    "testing",
+			}},
+		},
+		Steps: []workflow.Step{
+			{
+				ID:   "run_test",
+				Name: "Adversarial Testing",
+				Type: workflow.StepRunAgent,
+				Config: workflow.StepConfig{
+					Role:         "test-runner",
+					Mode:         "headless",
+					Model:        "sonnet",
+					OutputSchema: testingTaskOutputSchema(t),
+					Prompt:       "Test {{.Task.ID}}",
+				},
+				Next: []workflow.Transition{{GoTo: "route_test"}},
+			},
+			{
+				ID:   "route_test",
+				Name: "Route Test Result",
+				Type: workflow.StepRouteTestResult,
+				Next: []workflow.Transition{{GoTo: ""}},
+			},
+		},
+	}
+	data, err := yaml.Marshal(def)
+	if err != nil {
+		t.Fatalf("marshal testing-task fixture: %v", err)
+	}
+	return string(data)
 }
 
 func testingTaskOutputSchema(t *testing.T) string {


### PR DESCRIPTION
## Motivation

Workflow test evidence can arrive as structured JSON with flexible fields. The workflow should accept that shape instead of rejecting valid evidenced test output.

## Implementation information

Adds fake Codex support for evidenced test JSON scenarios and expands workflow coverage for the accepted schema variants.