### PR TITLE
fix(autoupdate): restore restart marker

### DIFF
--- a/internal/autoupdate/autoupdate.go
+++ b/internal/autoupdate/autoupdate.go
@@ -15,6 +15,7 @@ import (
 const (
 	ModeAuto        = "auto"
 	ModeNotify      = "notify"
+	RestartMarker   = "restart-requested"
 	RestartExitCode = 42
 )
 
@@ -46,6 +47,23 @@ func New(cfg Config, logger *slog.Logger) *Runner {
 		logger = slog.Default()
 	}
 	return &Runner{cfg: cfg.withDefaults(), logger: logger}
+}
+
+func RestartMarkerPath(homeDir string) string {
+	return filepath.Join(homeDir, RestartMarker)
+}
+
+func WriteRestartMarker(homeDir string) error {
+	if homeDir == "" {
+		return errors.New("home dir is empty")
+	}
+	if err := os.MkdirAll(homeDir, 0o755); err != nil {
+		return fmt.Errorf("create sybra home: %w", err)
+	}
+	if err := os.WriteFile(RestartMarkerPath(homeDir), []byte(time.Now().Format(time.RFC3339Nano)+"\n"), 0o644); err != nil {
+		return fmt.Errorf("write restart marker: %w", err)
+	}
+	return nil
 }
 
 func (r *Runner) Run(ctx context.Context) {

--- a/internal/autoupdate/autoupdate_test.go
+++ b/internal/autoupdate/autoupdate_test.go
@@ -60,6 +60,17 @@ func TestRunRequestsRestartAfterAutoApply(t *testing.T) {
 	}
 }
 
+func TestWriteRestartMarkerCreatesMarker(t *testing.T) {
+	homeDir := filepath.Join(t.TempDir(), "nested", "sybra-home")
+
+	if err := WriteRestartMarker(homeDir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(RestartMarkerPath(homeDir)); err != nil {
+		t.Fatalf("restart marker missing: %v", err)
+	}
+}
+
 func TestCheckAndApplyBlocksDirtyWorktree(t *testing.T) {
 	_, work := seedRepos(t)
 	writeFile(t, work, "dirty.txt", "dirty\n")

--- a/main.go
+++ b/main.go
@@ -79,6 +79,12 @@ func run() (int, error) {
 		}),
 		sybra.WithBrowserOpener(func(url string) { v3openBrowser(url) }),
 		sybra.WithRestartRequest(func() {
+			homeDir := config.HomeDir()
+			if err := autoupdate.WriteRestartMarker(homeDir); err != nil {
+				logger.Error("autoupdate.restart.marker.failed", "err", err)
+			} else {
+				logger.Info("autoupdate.restart.marker.written", "path", autoupdate.RestartMarkerPath(homeDir))
+			}
 			restartRequested.Store(true)
 			if v3app != nil {
 				v3app.Quit()


### PR DESCRIPTION
## Motivation

Auto-update restarts can lose the Sybra exit code when launched through `go run`/`mise run dev`, so the dev supervisor may stop after updating instead of relaunching.

> Changelog: fix(autoupdate): restore restart marker

## Implementation information

- Add an autoupdate helper for the `restart-requested` marker path and creation.
- Write the marker from the desktop restart hook before quitting Wails.
- Cover marker creation in the autoupdate package tests.

## Supporting documentation

- `go test ./internal/autoupdate`
- `go test .`
- pre-push hooks: `go test ./...` and `cd frontend && npm run check`