### PR TITLE
feat(umbrella): show progress badge

### DIFF
--- a/frontend/src/components/TaskBoardView.svelte
+++ b/frontend/src/components/TaskBoardView.svelte
@@ -2,6 +2,7 @@
   import { ChevronDown } from '@lucide/svelte'
   import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import type { BoardColumn } from '../lib/statuses.js'
+  import type { UmbrellaProgress } from '../lib/umbrella-progress.js'
   import TaskCard from './TaskCard.svelte'
   import InlineTaskAdd from './InlineTaskAdd.svelte'
   import { agentStore } from '../stores/agents.svelte.js'
@@ -14,6 +15,7 @@
     visibleColumns: BoardColumn[]
     /** Tasks for a given column's statuses. Caller filters; we render. */
     columnTasks: (col: BoardColumn) => Task[]
+    umbrellaProgress?: (task: Task) => UmbrellaProgress | null
     focusedTaskId: string | null
     collapsedColumns: Set<string>
     onselect: (id: string) => void
@@ -24,6 +26,7 @@
   const {
     visibleColumns,
     columnTasks,
+    umbrellaProgress = () => null,
     focusedTaskId,
     collapsedColumns,
     onselect,
@@ -180,6 +183,7 @@
             >
               <TaskCard
                 task={t}
+                umbrellaProgress={umbrellaProgress(t)}
                 onclick={() => onselect(t.id)}
                 focused={focusedTaskId === t.id}
                 onstatuschange={(s) => onmove(t.id, s)}

--- a/frontend/src/components/TaskBoardView.svelte.test.ts
+++ b/frontend/src/components/TaskBoardView.svelte.test.ts
@@ -167,6 +167,24 @@ describe('TaskBoardView', () => {
     expect(screen.getByText('Second')).toBeDefined()
   })
 
+  it('passes umbrella progress into task cards', () => {
+    const cols = [{ status: 'umbrella', label: 'Umbrella', border: '', includes: [], kind: 'umbrella' }]
+    const tracker = { id: 'u1', title: 'Umbrella', status: 'in-progress', taskType: 'umbrella', tags: [], agentMode: 'headless' }
+    render(TaskBoardView, {
+      props: {
+        visibleColumns: cols as never,
+        columnTasks: (() => [tracker]) as never,
+        umbrellaProgress: (() => ({ done: 2, total: 5 })) as never,
+        focusedTaskId: null,
+        collapsedColumns: new Set<string>(),
+        onselect: vi.fn(),
+        onmove: vi.fn(),
+        ontogglecolumn: vi.fn(),
+      },
+    })
+    expect(screen.getByText('2/5')).toBeDefined()
+  })
+
   it('column header click fires ontogglecolumn with the status', async () => {
     const ontogglecolumn = vi.fn()
     render(TaskBoardView, {

--- a/frontend/src/components/TaskCard.svelte
+++ b/frontend/src/components/TaskCard.svelte
@@ -9,17 +9,19 @@
   import { isOwnPRTask as isOwnPRTaskFn, prPhaseMeta, prPhaseNeedsYou, type PRPhaseIcon } from '../lib/pr-phase.js'
   import { PRIORITY_OPTIONS } from '../lib/priorities.js'
   import { projectShortName, projectDotStyle } from '../lib/project-cue.js'
+  import type { UmbrellaProgress } from '../lib/umbrella-progress.js'
   import StatusPicker from './StatusPicker.svelte'
   import Pill from './Pill.svelte'
 
   interface Props {
     task: Task
+    umbrellaProgress?: UmbrellaProgress | null
     onclick: () => void
     focused?: boolean
     onstatuschange?: (status: string) => void
   }
 
-  const { task: t, onclick, focused = false, onstatuschange }: Props = $props()
+  const { task: t, umbrellaProgress = null, onclick, focused = false, onstatuschange }: Props = $props()
 
   let dragging = $state(false)
   let moveMenuOpen = $state(false)
@@ -145,6 +147,12 @@
       <Pill role="project" title={t.projectId}>
         <span class="h-2 w-2 shrink-0 rounded-full" style={projectDotStyle(t.projectId)}></span>
         {projectShortName(t.projectId)}
+      </Pill>
+    {/if}
+
+    {#if t.taskType === 'umbrella' && umbrellaProgress && umbrellaProgress.total > 0}
+      <Pill role="reference" title="{umbrellaProgress.done}/{umbrellaProgress.total} subissues complete">
+        {umbrellaProgress.done}/{umbrellaProgress.total}
       </Pill>
     {/if}
 

--- a/frontend/src/components/TaskCard.svelte.test.ts
+++ b/frontend/src/components/TaskCard.svelte.test.ts
@@ -87,6 +87,29 @@ describe('TaskCard', () => {
     expect(screen.getByText('backend')).toBeDefined()
   })
 
+  it('shows umbrella progress for tracker cards', () => {
+    render(TaskCard, {
+      props: {
+        task: { ...mockTask, taskType: 'umbrella' } as Task,
+        umbrellaProgress: { done: 3, total: 10 },
+        onclick: () => {},
+      },
+    })
+    expect(screen.getByText('3/10')).toBeDefined()
+    expect(screen.getByTitle('3/10 subissues complete')).toBeDefined()
+  })
+
+  it('hides empty umbrella progress', () => {
+    render(TaskCard, {
+      props: {
+        task: { ...mockTask, taskType: 'umbrella' } as Task,
+        umbrellaProgress: { done: 0, total: 0 },
+        onclick: () => {},
+      },
+    })
+    expect(screen.queryByText('0/0')).toBeNull()
+  })
+
   it('does not render tags section when empty', () => {
     const taskNoTags = { ...mockTask, tags: [] }
     render(TaskCard, { props: { task: taskNoTags, onclick: () => {} } })

--- a/frontend/src/components/TaskListView.svelte
+++ b/frontend/src/components/TaskListView.svelte
@@ -1,17 +1,19 @@
 <script lang="ts">
   import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { PRIORITY_OPTIONS } from '../lib/priorities.js'
+  import type { UmbrellaProgress } from '../lib/umbrella-progress.js'
   import StatusBadge from './StatusBadge.svelte'
   import { formatShortDate } from '../lib/dates.js'
 
   interface Props {
     tasks: Task[]
     focusedTaskId: string | null
+    umbrellaProgress?: (task: Task) => UmbrellaProgress | null
     onselect: (id: string) => void
     onhover: (rowIdx: number) => void
   }
 
-  const { tasks, focusedTaskId, onselect, onhover }: Props = $props()
+  const { tasks, focusedTaskId, umbrellaProgress = () => null, onselect, onhover }: Props = $props()
 
   function priorityIcon(p: string | undefined): string {
     return PRIORITY_OPTIONS.find(o => o.value === (p ?? ''))?.icon ?? '–'
@@ -50,6 +52,7 @@
     <tbody>
       {#each tasks as t, rowIdx (t.id)}
         {@const isFocused = focusedTaskId === t.id}
+        {@const progress = umbrellaProgress(t)}
         <tr
           data-focused-task={isFocused ? '' : undefined}
           class="cursor-pointer border-b border-surface-100 transition-colors dark:border-surface-800 {isFocused ? 'bg-primary-50 dark:bg-primary-900/20' : 'hover:bg-surface-100 dark:hover:bg-surface-800'}"
@@ -61,7 +64,19 @@
               <span class="font-mono text-sm {priorityClasses(t.priority)}" title="Priority: {priorityLabel(t.priority)}">{priorityIcon(t.priority)}</span>
             </td>
           {/if}
-          <td class="px-4 py-2 font-medium">{t.title}</td>
+          <td class="px-4 py-2 font-medium">
+            <div class="flex items-center gap-2">
+              <span>{t.title}</span>
+              {#if t.taskType === 'umbrella' && progress && progress.total > 0}
+                <span
+                  class="inline-flex shrink-0 items-center rounded-full bg-surface-200 px-2 py-0.5 text-xs font-medium text-surface-600 dark:bg-surface-700 dark:text-surface-300"
+                  title="{progress.done}/{progress.total} subissues complete"
+                >
+                  {progress.done}/{progress.total}
+                </span>
+              {/if}
+            </div>
+          </td>
           <td class="whitespace-nowrap px-4 py-2">
             <StatusBadge status={t.status} />
           </td>

--- a/frontend/src/components/TaskListView.svelte.test.ts
+++ b/frontend/src/components/TaskListView.svelte.test.ts
@@ -59,6 +59,19 @@ describe('TaskListView', () => {
     expect(screen.getByText('—')).toBeDefined()
   })
 
+  it('shows umbrella progress in list rows', () => {
+    render(TaskListView, {
+      props: {
+        tasks: [{ ...tasks[0], taskType: 'umbrella' }] as never,
+        focusedTaskId: null,
+        umbrellaProgress: (() => ({ done: 2, total: 5 })) as never,
+        onselect: vi.fn(),
+        onhover: vi.fn(),
+      },
+    })
+    expect(screen.getByTitle('2/5 subissues complete')).toBeDefined()
+  })
+
   it('row click fires onselect with task id', async () => {
     const onselect = vi.fn()
     render(TaskListView, {

--- a/frontend/src/lib/umbrella-progress.test.ts
+++ b/frontend/src/lib/umbrella-progress.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { Status, TaskType, type Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
+import {
+  buildUmbrellaProgress,
+  normalizeIssueRef,
+  progressForUmbrellaTracker,
+} from './umbrella-progress.js'
+
+function task(overrides: Partial<Task>): Task {
+  return {
+    id: '',
+    title: '',
+    status: Status.StatusTodo,
+    tags: [],
+    agentMode: 'headless',
+    issue: '',
+    umbrellaIssue: '',
+    taskType: TaskType.$zero,
+    updatedAt: '',
+    createdAt: '',
+    body: '',
+    ...overrides,
+  } as Task
+}
+
+describe('umbrella progress', () => {
+  it('normalizes GitHub issue refs across URL and shorthand forms', () => {
+    expect(normalizeIssueRef('https://github.com/Automaat/sybra/issues/1213')).toBe('automaat/sybra#1213')
+    expect(normalizeIssueRef('Automaat/sybra#1213')).toBe('automaat/sybra#1213')
+  })
+
+  it('counts done and total materialized children per umbrella', () => {
+    const byUmbrella = buildUmbrellaProgress([
+      task({ id: 'c1', status: Status.StatusDone, umbrellaIssue: 'https://github.com/Automaat/sybra/issues/1213' }),
+      task({ id: 'c2', status: Status.StatusInProgress, umbrellaIssue: 'Automaat/sybra#1213' }),
+      task({ id: 'c3', status: Status.StatusDone, umbrellaIssue: 'Automaat/sybra#999' }),
+      task({ id: 'standalone', status: Status.StatusDone }),
+    ])
+
+    expect(byUmbrella.get('automaat/sybra#1213')).toEqual({ done: 1, total: 2 })
+    expect(byUmbrella.get('automaat/sybra#999')).toEqual({ done: 1, total: 1 })
+  })
+
+  it('resolves tracker progress from its issue ref', () => {
+    const byUmbrella = buildUmbrellaProgress([
+      task({ id: 'c1', status: Status.StatusDone, umbrellaIssue: 'Automaat/sybra#1213' }),
+      task({ id: 'c2', status: Status.StatusTodo, umbrellaIssue: 'Automaat/sybra#1213' }),
+    ])
+
+    expect(progressForUmbrellaTracker(
+      task({ taskType: TaskType.TaskTypeUmbrella, issue: 'https://github.com/Automaat/sybra/issues/1213' }),
+      byUmbrella,
+    )).toEqual({ done: 1, total: 2 })
+    expect(progressForUmbrellaTracker(task({ taskType: TaskType.TaskTypeNormal }), byUmbrella)).toBeNull()
+  })
+})

--- a/frontend/src/lib/umbrella-progress.ts
+++ b/frontend/src/lib/umbrella-progress.ts
@@ -1,0 +1,39 @@
+import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
+
+export interface UmbrellaProgress {
+  done: number
+  total: number
+}
+
+export function buildUmbrellaProgress(tasks: Task[]): Map<string, UmbrellaProgress> {
+  const byUmbrella = new Map<string, UmbrellaProgress>()
+  for (const task of tasks) {
+    const key = normalizeIssueRef(task.umbrellaIssue ?? '')
+    if (!key) continue
+    const progress = byUmbrella.get(key) ?? { done: 0, total: 0 }
+    progress.total += 1
+    if (task.status === 'done') progress.done += 1
+    byUmbrella.set(key, progress)
+  }
+  return byUmbrella
+}
+
+export function progressForUmbrellaTracker(
+  task: Task,
+  byUmbrella: Map<string, UmbrellaProgress>,
+): UmbrellaProgress | null {
+  if (task.taskType !== 'umbrella') return null
+  const key = normalizeIssueRef(task.issue ?? '')
+  if (!key) return null
+  return byUmbrella.get(key) ?? { done: 0, total: 0 }
+}
+
+export function normalizeIssueRef(ref: string): string {
+  const trimmed = ref.trim()
+  if (!trimmed) return ''
+  const github = trimmed.match(/^https?:\/\/(?:www\.)?github\.com\/([^/]+)\/([^/]+)\/(?:issues|pull)\/(\d+)/i)
+  if (github) {
+    return `${github[1].toLowerCase()}/${github[2].toLowerCase()}#${github[3]}`
+  }
+  return trimmed.toLowerCase()
+}

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -421,6 +421,7 @@
     <TaskListView
       tasks={allFilteredTasks}
       focusedTaskId={focusedTaskId}
+      umbrellaProgress={umbrellaProgress}
       onselect={(id) => onselect(id)}
       onhover={(rowIdx) => { focusedColIdx = 0; focusedRowIdx = rowIdx }}
     />

--- a/frontend/src/pages/TaskList.svelte
+++ b/frontend/src/pages/TaskList.svelte
@@ -7,6 +7,11 @@
   import { BOARD_LANES, awaitsHuman, type BoardColumn } from '../lib/statuses.js'
   import { isInboundReview, reviewPhaseNeedsYou, reviewPhaseRank } from '../lib/review-phase.js'
   import { prPhaseRank, prPhaseNeedsYou } from '../lib/pr-phase.js'
+  import {
+    buildUmbrellaProgress,
+    progressForUmbrellaTracker,
+    type UmbrellaProgress,
+  } from '../lib/umbrella-progress.js'
   import { navStore } from '../lib/navigation.svelte.js'
   import { matchesQuery, matchesProject, matchesTags, matchesAgentMode } from '../lib/task-filters.js'
   import TaskTimeline from '../components/TaskTimeline.svelte'
@@ -93,6 +98,12 @@
       if (!matchesAgentMode(t, selectedAgentMode)) return false
       return true
     })
+  }
+
+  const umbrellaProgressByIssue = $derived(buildUmbrellaProgress(taskStore.list))
+
+  function umbrellaProgress(t: Task): UmbrellaProgress | null {
+    return progressForUmbrellaTracker(t, umbrellaProgressByIssue)
   }
 
   // The To Review lane: every active inbound review task, sorted so the
@@ -428,6 +439,7 @@
     <TaskBoardView
       visibleColumns={visibleColumns}
       columnTasks={columnTasks}
+      umbrellaProgress={umbrellaProgress}
       focusedTaskId={focusedTaskId}
       collapsedColumns={collapsedColumns}
       onselect={(id) => onselect(id)}

--- a/frontend/src/pages/TaskList.svelte.test.ts
+++ b/frontend/src/pages/TaskList.svelte.test.ts
@@ -99,6 +99,29 @@ describe('TaskList', () => {
     expect(screen.getByText('Second Task')).toBeDefined()
   })
 
+  it('renders umbrella progress from task store data', () => {
+    Object.assign(taskStore, {
+      list: [
+        {
+          ...mockTask('u1', 'Tracker', 'in-progress'),
+          taskType: 'umbrella',
+          issue: 'https://github.com/Automaat/sybra/issues/1213',
+        },
+        {
+          ...mockTask('c1', 'Done child', 'done'),
+          umbrellaIssue: 'Automaat/sybra#1213',
+        },
+        {
+          ...mockTask('c2', 'Active child', 'in-progress'),
+          umbrellaIssue: 'https://github.com/Automaat/sybra/issues/1213',
+        },
+      ],
+    })
+    render(TaskList, { props: { onselect: vi.fn() } })
+    expect(screen.getByText('Tracker')).toBeDefined()
+    expect(screen.getByText('1/2')).toBeDefined()
+  })
+
   describe('submitInlineAdd error handling', () => {
     it('shows notification when task creation fails', async () => {
       vi.mocked(taskStore.create).mockRejectedValueOnce(new Error('Network error'))

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -1,7 +1,9 @@
 package sybra
 
 import (
+	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/Automaat/sybra/internal/github"
@@ -30,7 +32,20 @@ type umbrellaState struct {
 	anyHR        bool
 	anyCancelled bool
 	released     int // children released so far this tick (counts toward the cap)
+	children     []umbrellaProgressChild
 }
+
+type umbrellaProgressChild struct {
+	id     string
+	title  string
+	issue  string
+	status task.Status
+}
+
+const (
+	umbrellaProgressStart = "<!-- sybra:umbrella-progress:start -->"
+	umbrellaProgressEnd   = "<!-- sybra:umbrella-progress:end -->"
+)
 
 // releaseUnblockedChildren is the umbrella gate, run every orchestrator tick.
 // It releases gate-blocked children whose dependencies are done — up to each
@@ -69,7 +84,7 @@ func (a *App) releaseUnblockedChildren() {
 		}
 		if t.UmbrellaIssue != "" {
 			hasUmbrella = true
-			accumulateChild(stateFor(t.UmbrellaIssue), t.Status, t.Tags)
+			accumulateChild(stateFor(t.UmbrellaIssue), t)
 		}
 		nodes[i] = umbrella.Node{
 			ID:        t.ID,
@@ -105,9 +120,15 @@ func (a *App) releaseUnblockedChildren() {
 // accumulateChild folds one child task's status into its umbrella's tally.
 // A todo child carrying the gating tag is still waiting for deps — it must not
 // count as active or it would consume a parallelism slot before being released.
-func accumulateChild(st *umbrellaState, status task.Status, tags []string) {
+func accumulateChild(st *umbrellaState, t *task.Task) {
 	st.total++
-	switch status {
+	st.children = append(st.children, umbrellaProgressChild{
+		id:     t.ID,
+		title:  t.Title,
+		issue:  t.Issue,
+		status: t.Status,
+	})
+	switch t.Status {
 	case task.StatusDone:
 		st.doneCount++
 	case task.StatusCancelled:
@@ -119,7 +140,7 @@ func accumulateChild(st *umbrellaState, status task.Status, tags []string) {
 		st.anyHR = true
 		st.active++ // a stuck child still occupies a slot until resolved
 	default:
-		if isRunningChild(status) && !slices.Contains(tags, umbrellaGatedTag) {
+		if isRunningChild(t.Status) && !slices.Contains(t.Tags, umbrellaGatedTag) {
 			st.active++
 		}
 	}
@@ -152,16 +173,27 @@ func (a *App) releaseCapped(ready []string, byID map[string]*task.Task, states m
 		newTags := slices.DeleteFunc(slices.Clone(t.Tags), func(s string) bool {
 			return s == umbrellaGatedTag
 		})
-		if _, err := a.tasks.Update(id, task.Update{
+		updated, err := a.tasks.Update(id, task.Update{
 			Status:       task.Ptr(task.StatusTodo),
 			Tags:         &newTags,
 			StatusReason: task.Ptr("umbrella dependencies satisfied"),
-		}); err != nil {
+		})
+		if err != nil {
 			a.logger.Error("umbrella.release.failed", "task_id", id, "err", err)
 			continue
 		}
+		st.setChildStatus(id, updated.Status)
 		st.released++
 		a.logger.Info("umbrella.child.released", "task_id", id)
+	}
+}
+
+func (st *umbrellaState) setChildStatus(id string, status task.Status) {
+	for i := range st.children {
+		if st.children[i].id == id {
+			st.children[i].status = status
+			return
+		}
 	}
 }
 
@@ -183,6 +215,14 @@ func (a *App) rollupTrackers(states map[string]*umbrellaState, cyclic map[string
 		settled := !st.tracker.CreatedAt.IsZero() &&
 			time.Since(st.tracker.CreatedAt) > umbrellaSettleDelay
 		desired, reason, doClose := trackerRollup(st, cyclic[key], settled)
+		if body := umbrellaTrackerBody(st.tracker.Body, st.children); body != st.tracker.Body {
+			if _, err := a.tasks.Update(st.tracker.ID, task.Update{
+				Body: task.Ptr(body),
+			}); err != nil {
+				a.logger.Error("umbrella.tracker.progress.update.failed", "task_id", st.tracker.ID, "err", err)
+				continue
+			}
+		}
 		if desired == st.tracker.Status {
 			continue
 		}
@@ -201,6 +241,74 @@ func (a *App) rollupTrackers(states map[string]*umbrellaState, cyclic map[string
 		}
 		a.logger.Info("umbrella.tracker.rollup", "task_id", st.tracker.ID, "status", desired)
 	}
+}
+
+func umbrellaTrackerBody(body string, children []umbrellaProgressChild) string {
+	block := renderUmbrellaProgressBlock(children)
+	start := strings.Index(body, umbrellaProgressStart)
+	if start >= 0 {
+		searchFrom := start + len(umbrellaProgressStart)
+		if relEnd := strings.Index(body[searchFrom:], umbrellaProgressEnd); relEnd >= 0 {
+			end := searchFrom + relEnd + len(umbrellaProgressEnd)
+			return body[:start] + block + body[end:]
+		}
+	}
+	if strings.TrimSpace(body) == "" {
+		return block
+	}
+	sep := "\n\n"
+	if strings.HasSuffix(body, "\n\n") {
+		sep = ""
+	} else if strings.HasSuffix(body, "\n") {
+		sep = "\n"
+	}
+	return body + sep + block
+}
+
+func renderUmbrellaProgressBlock(children []umbrellaProgressChild) string {
+	children = slices.Clone(children)
+	slices.SortFunc(children, func(a, b umbrellaProgressChild) int {
+		aIssue := umbrella.NormalizeIssueRef(a.issue)
+		bIssue := umbrella.NormalizeIssueRef(b.issue)
+		if aIssue != bIssue {
+			return strings.Compare(aIssue, bIssue)
+		}
+		return strings.Compare(a.title, b.title)
+	})
+
+	var b strings.Builder
+	b.WriteString(umbrellaProgressStart)
+	b.WriteString("\n## Subissues\n\n")
+	if len(children) == 0 {
+		b.WriteString("_No materialized subissues._\n")
+	} else {
+		for _, child := range children {
+			box := " "
+			if child.status == task.StatusDone {
+				box = "x"
+			}
+			fmt.Fprintf(&b, "- [%s] %s%s — %s\n",
+				box,
+				strings.ReplaceAll(child.title, "\n", " "),
+				umbrellaProgressIssueSuffix(child.issue),
+				child.status,
+			)
+		}
+	}
+	b.WriteString(umbrellaProgressEnd)
+	return b.String()
+}
+
+func umbrellaProgressIssueSuffix(ref string) string {
+	_, n, ok := umbrella.ParseRef(ref)
+	if ok {
+		return fmt.Sprintf(" (#%d)", n)
+	}
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ""
+	}
+	return " (" + ref + ")"
 }
 
 // trackerRollup decides an umbrella tracker's status from its children. A

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -252,6 +252,7 @@ func umbrellaTrackerBody(body string, children []umbrellaProgressChild) string {
 			end := searchFrom + relEnd + len(umbrellaProgressEnd)
 			return body[:start] + block + body[end:]
 		}
+		return body[:start] + block
 	}
 	if strings.TrimSpace(body) == "" {
 		return block

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log/slog"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/Automaat/sybra/internal/task"
@@ -101,6 +102,70 @@ func TestReleaseUnblockedChildren_RollupClosesUmbrella(t *testing.T) {
 	}
 	if closes != 1 || gotRepo != "Automaat/sybra" || gotNum != 100 {
 		t.Fatalf("close = %d times repo=%q num=%d, want 1 Automaat/sybra 100", closes, gotRepo, gotNum)
+	}
+}
+
+func TestReleaseUnblockedChildren_UpdatesTrackerProgressChecklist(t *testing.T) {
+	t.Parallel()
+	app, m := newUmbrellaGateApp(t)
+	const umb = "https://github.com/Automaat/sybra/issues/100"
+	tracker := mkTracker(t, m, umb, 5)
+	if _, err := m.Update(tracker.ID, task.Update{Body: task.Ptr("Original body.")}); err != nil {
+		t.Fatalf("seed tracker body: %v", err)
+	}
+	mkChild(t, m, "done child", "Automaat/sybra#1", umb, nil, task.StatusDone)
+	mkChild(t, m, "blocked child", "Automaat/sybra#2", umb, nil, task.StatusHumanRequired)
+
+	app.releaseUnblockedChildren()
+
+	body := mustTask(t, m, tracker.ID).Body
+	for _, want := range []string{
+		"Original body.",
+		umbrellaProgressStart,
+		"- [x] done child (#1) — done",
+		"- [ ] blocked child (#2) — human-required",
+		umbrellaProgressEnd,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("tracker body missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestUmbrellaTrackerBody_ReplacesBlockAndIsIdempotent(t *testing.T) {
+	t.Parallel()
+	children := []umbrellaProgressChild{
+		{title: "first", issue: "Automaat/sybra#1", status: task.StatusDone},
+		{title: "second", issue: "Automaat/sybra#2", status: task.StatusInProgress},
+	}
+	input := "Intro\n\n" +
+		umbrellaProgressStart + "\nold\n" + umbrellaProgressEnd +
+		"\n\nTail"
+
+	got := umbrellaTrackerBody(input, children)
+	if !strings.Contains(got, "Intro\n\n"+umbrellaProgressStart) || !strings.Contains(got, umbrellaProgressEnd+"\n\nTail") {
+		t.Fatalf("body outside generated block was not preserved:\n%s", got)
+	}
+	if strings.Contains(got, "old") {
+		t.Fatalf("old generated block was not replaced:\n%s", got)
+	}
+	if again := umbrellaTrackerBody(got, children); again != got {
+		t.Fatalf("umbrellaTrackerBody is not idempotent:\nfirst:\n%s\nsecond:\n%s", got, again)
+	}
+}
+
+func TestRenderUmbrellaProgressBlock_EmptyChildren(t *testing.T) {
+	t.Parallel()
+	got := renderUmbrellaProgressBlock(nil)
+	for _, want := range []string{
+		umbrellaProgressStart,
+		"## Subissues",
+		"_No materialized subissues._",
+		umbrellaProgressEnd,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("progress block missing %q:\n%s", want, got)
+		}
 	}
 }
 

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -154,6 +154,28 @@ func TestUmbrellaTrackerBody_ReplacesBlockAndIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestUmbrellaTrackerBody_ReplacesMalformedBlockFromStart(t *testing.T) {
+	t.Parallel()
+	children := []umbrellaProgressChild{
+		{title: "first", issue: "Automaat/sybra#1", status: task.StatusDone},
+	}
+	input := "Intro\n\n" +
+		umbrellaProgressStart + "\nold without end\n\nTail that belonged to malformed block"
+
+	got := umbrellaTrackerBody(input, children)
+	if !strings.HasPrefix(got, "Intro\n\n"+umbrellaProgressStart) {
+		t.Fatalf("body before malformed generated block was not preserved:\n%s", got)
+	}
+	for _, unwanted := range []string{"old without end", "Tail that belonged to malformed block"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("malformed generated block content %q was not replaced:\n%s", unwanted, got)
+		}
+	}
+	if !strings.Contains(got, "- [x] first (#1) — done") || !strings.Contains(got, umbrellaProgressEnd) {
+		t.Fatalf("replacement progress block missing expected content:\n%s", got)
+	}
+}
+
 func TestRenderUmbrellaProgressBlock_EmptyChildren(t *testing.T) {
 	t.Parallel()
 	got := renderUmbrellaProgressBlock(nil)


### PR DESCRIPTION
## Motivation

Show umbrella issue progress directly on task cards and list rows so queued subissues are visible at a glance.

Closes https://github.com/Automaat/sybra/issues/1213

## Implementation information

- Compute umbrella subissue checklist totals from gate state.
- Render progress badges in task board cards and the task list.
- Cover backend progress parsing and frontend rendering with tests.