### PR TITLE
fix(agent): fail bad convo exits

### DIFF
--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -654,7 +654,8 @@ func (a *Agent) lastConvoResult() (found, isError bool) {
 	defer a.mu.RUnlock()
 	for i := range slices.Backward(a.convoBuffer) {
 		if a.convoBuffer[i].Type == "result" {
-			return true, a.convoBuffer[i].Subtype == "error"
+			e := a.convoBuffer[i]
+			return true, resultSubtypeIsError(e.Subtype) || e.ErrorType != "" || e.ErrorStatus != 0
 		}
 	}
 	return false, false

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -227,7 +227,7 @@ func (m *Manager) runPerTurnConversational(ctx context.Context, a *Agent, cfg Ru
 
 // runConvoTurn runs one per-turn provider process (`codex exec --json` or
 // `copilot -p --output-format json`) and streams output as ConvoEvents.
-// Returns true when the turn's terminal result was observed.
+// Returns true only when the turn produced a terminal result and exited cleanly.
 func (m *Manager) runConvoTurn(ctx context.Context, a *Agent, cfg RunConfig, prompt string, logWriter io.Writer) bool {
 	bin, args := buildPerTurnConvoArgs(a, cfg, prompt)
 	cmd := exec.CommandContext(ctx, bin, args...)

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"slices"
 	"time"
 
 	"github.com/Automaat/sybra/internal/events"
@@ -263,17 +264,46 @@ func (m *Manager) runConvoTurn(ctx context.Context, a *Agent, cfg RunConfig, pro
 		prevLen = len(all)
 	}
 	attemptEvents := all[prevLen:]
+	if streamErr := resultConvoStreamError(attemptEvents); waitErr == nil && streamErr != nil {
+		waitErr = streamErr
+	}
 	if waitErr != nil {
 		m.logger.Error("agent.convo.exit", "id", a.ID, "provider", a.Provider, "err", waitErr)
 		a.SetExitErr(waitErr)
 		m.reportProviderHealthSignalConvo(a, stderrOut, attemptEvents)
-	} else if m.reportCleanProviderHealthSignalConvo(a, stderrOut, attemptEvents) == providerpkg.SignalRateLimit {
-		a.SetExitErr(errProviderRateLimited)
+	} else {
+		a.SetExitErr(nil)
+		if m.reportCleanProviderHealthSignalConvo(a, stderrOut, attemptEvents) == providerpkg.SignalRateLimit {
+			a.SetExitErr(errProviderRateLimited)
+		}
 	}
 	if stderrOut != "" {
 		m.logger.Error("agent.convo.stderr", "id", a.ID, "provider", a.Provider, "stderr", stderrOut)
 	}
-	return gotResult
+	return gotResult && a.GetExitErr() == nil
+}
+
+func resultConvoStreamError(streamEvents []ConvoEvent) error {
+	for i := range slices.Backward(streamEvents) {
+		e := streamEvents[i]
+		if e.Type != "result" {
+			continue
+		}
+		if e.ErrorStatus != 0 || e.ErrorType != "" || resultSubtypeIsError(e.Subtype) {
+			if e.ErrorStatus != 0 && e.ErrorType != "" {
+				return fmt.Errorf("provider result error %s (%d)", e.ErrorType, e.ErrorStatus)
+			}
+			if e.ErrorStatus != 0 {
+				return fmt.Errorf("provider result error status %d", e.ErrorStatus)
+			}
+			if e.ErrorType == "" {
+				return fmt.Errorf("provider result error")
+			}
+			return fmt.Errorf("provider result error %s", e.ErrorType)
+		}
+		return nil
+	}
+	return nil
 }
 
 // buildPerTurnConvoArgs returns the binary name and argv for one per-turn

--- a/internal/agent/runner_codex_convo_test.go
+++ b/internal/agent/runner_codex_convo_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -33,6 +35,51 @@ func TestBuildCodexConvoArgs_ReasoningEffort(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestRunConvoTurn_NonZeroExitAfterResultFailsTurn(t *testing.T) {
+	dir := t.TempDir()
+	fakeCodex := filepath.Join(dir, "codex")
+	script := `#!/bin/sh
+printf '%s\n' '{"type":"thread.started","thread_id":"cx-fake"}'
+printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}'
+printf '%s\n' 'Reading additional input from stdin...' >&2
+exit 1
+`
+	if err := os.WriteFile(fakeCodex, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	m, _ := newTestManager(t)
+	a := &Agent{ID: "cx", Provider: "codex", sessionCWD: t.TempDir()}
+
+	if got := m.runConvoTurn(t.Context(), a, RunConfig{}, "prompt", nil); got {
+		t.Fatal("runConvoTurn returned true; non-zero exit after result must fail the turn")
+	}
+	if a.GetExitErr() == nil {
+		t.Fatal("expected exit error recorded")
+	}
+	found, isError := a.lastConvoResult()
+	if !found {
+		t.Fatal("expected terminal result to remain in convo history")
+	}
+	if isError {
+		t.Fatal("clean result plus non-zero process exit should fail via ExitErr, not rewrite result as error")
+	}
+}
+
+func TestLastConvoResult_TreatsStructuredResultErrorsAsError(t *testing.T) {
+	a := &Agent{ID: "cx", Provider: "codex"}
+	a.AppendConvo(ConvoEvent{Type: "result", ErrorType: "rate_limit", ErrorStatus: 429})
+
+	found, isError := a.lastConvoResult()
+	if !found {
+		t.Fatal("expected result event")
+	}
+	if !isError {
+		t.Fatal("expected structured result error to be classified as error")
+	}
 }
 
 func TestCodexReasoningArgs(t *testing.T) {


### PR DESCRIPTION
## Motivation

A per-turn Codex/Copilot conversational run could emit a terminal result and then exit non-zero. Sybra treated the observed result as a successful turn, paused the agent, and left workflow steps waiting forever.

> Changelog: fix(agent): fail bad convo exits

## Implementation information

- Treat structured conversational result errors like headless result errors.
- Clear stale exit errors on clean turns and return failure when the process exits non-zero after a result.
- Teach conversational reattach completion to classify structured result errors.
- Add regression coverage for the non-zero-after-result path and structured result-error classification.

## Supporting documentation

Validated with `go test ./internal/agent ./internal/workflow ./internal/sybra`; push hooks also ran the full Go suite and frontend check.