### PR TITLE
fix(review): ignore base-only PR merges

### DIFF
--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -267,6 +267,45 @@ func fetchPRHeadSHAWith(e execer, repo string, number int) (string, error) {
 	return raw.HeadRefOid, nil
 }
 
+// FetchCommitParentSHAs returns a commit's parent SHAs in Git's parent order.
+func FetchCommitParentSHAs(repo, sha string) ([]string, error) {
+	return fetchCommitParentSHAsWith(defaultExecer, repo, sha)
+}
+
+func fetchCommitParentSHAsWith(e execer, repo, sha string) ([]string, error) {
+	if strings.TrimSpace(sha) == "" {
+		return nil, fmt.Errorf("fetch commit parents for %s: empty sha", repo)
+	}
+	key := repo + "@" + sha
+	if runtimeCacheEnabled(e) {
+		if cached, ok := commitParentsCache.Get(key); ok {
+			return append([]string(nil), cached...), nil
+		}
+	}
+
+	resp, err := runGHAPIWith(e, "30s", fmt.Sprintf("repos/%s/commits/%s", repo, sha), "--jq", ".parents[].sha")
+	if err != nil {
+		return nil, fmt.Errorf("gh api commit %s: %s: %w", sha, sanitizeGHOutput(resp.body), err)
+	}
+	parents := parseCommitParentSHAs(resp.body)
+	if runtimeCacheEnabled(e) {
+		commitParentsCache.Set(key, append([]string(nil), parents...), 5*time.Minute)
+	}
+	return parents, nil
+}
+
+func parseCommitParentSHAs(out []byte) []string {
+	lines := strings.Split(string(out), "\n")
+	parents := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			parents = append(parents, line)
+		}
+	}
+	return parents
+}
+
 // PRCompare summarizes the difference between two commits (base...head).
 // Commits is how many commits head is ahead of base; Additions/Deletions sum the
 // line churn. Note: GitHub caps the compare files list at 300, so on very large

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -267,14 +267,45 @@ func fetchPRHeadSHAWith(e execer, repo string, number int) (string, error) {
 	return raw.HeadRefOid, nil
 }
 
-// FetchCommitParentSHAs returns a commit's parent SHAs in Git's parent order.
-func FetchCommitParentSHAs(repo, sha string) ([]string, error) {
-	return fetchCommitParentSHAsWith(defaultExecer, repo, sha)
+// FetchPRBaseSHAContext is a context-bounded lookup for the current base commit
+// SHA of a PR.
+func FetchPRBaseSHAContext(ctx context.Context, repo string, number int) (string, error) {
+	key := prCacheKey(repo, number)
+	if cached, ok := prBaseSHACache.Get(key); ok {
+		return cached, nil
+	}
+	out, err := ghRunCtx(ctx, "pr", "view", strconv.Itoa(number), "--repo", repo, "--json", "baseRefOid")
+	if err != nil {
+		return "", fmt.Errorf("gh pr view %d base: %s: %w", number, sanitizeGHOutput(out), err)
+	}
+	var raw struct {
+		BaseRefOid string `json:"baseRefOid"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return "", fmt.Errorf("parse pr base: %w", err)
+	}
+	prBaseSHACache.Set(key, raw.BaseRefOid, 30*time.Second)
+	return raw.BaseRefOid, nil
 }
 
-func fetchCommitParentSHAsWith(e execer, repo, sha string) ([]string, error) {
+// FetchCommitParentSHAs returns a commit's parent SHAs in Git's parent order.
+func FetchCommitParentSHAs(repo, sha string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return FetchCommitParentSHAsContext(ctx, repo, sha)
+}
+
+// FetchCommitParentSHAsContext is a context-bounded FetchCommitParentSHAs.
+func FetchCommitParentSHAsContext(ctx context.Context, repo, sha string) ([]string, error) {
+	return fetchCommitParentSHAsWith(ctx, defaultExecer, repo, sha)
+}
+
+func fetchCommitParentSHAsWith(ctx context.Context, e execer, repo, sha string) ([]string, error) {
 	if strings.TrimSpace(sha) == "" {
 		return nil, fmt.Errorf("fetch commit parents for %s: empty sha", repo)
+	}
+	if !isCommitSHA(sha) {
+		return nil, fmt.Errorf("fetch commit parents for %s: invalid commit sha %q", repo, sha)
 	}
 	key := repo + "@" + sha
 	if runtimeCacheEnabled(e) {
@@ -283,7 +314,7 @@ func fetchCommitParentSHAsWith(e execer, repo, sha string) ([]string, error) {
 		}
 	}
 
-	resp, err := runGHAPIWith(e, "30s", fmt.Sprintf("repos/%s/commits/%s", repo, sha), "--jq", ".parents[].sha")
+	resp, err := runGHAPICtxWith(ctx, e, "30s", fmt.Sprintf("repos/%s/commits/%s", repo, sha), "--jq", ".parents[].sha")
 	if err != nil {
 		return nil, fmt.Errorf("gh api commit %s: %s: %w", sha, sanitizeGHOutput(resp.body), err)
 	}
@@ -292,6 +323,48 @@ func fetchCommitParentSHAsWith(e execer, repo, sha string) ([]string, error) {
 		commitParentsCache.Set(key, append([]string(nil), parents...), 5*time.Minute)
 	}
 	return parents, nil
+}
+
+// FetchBaseOnlyMergeFromReviewed reports whether head is a two-parent merge
+// commit whose first parent is the reviewed commit and whose second parent is
+// reachable from the PR base branch. If any GitHub lookup fails the caller
+// should treat the lineage as unknown, not as author advancement.
+func FetchBaseOnlyMergeFromReviewed(ctx context.Context, repo string, number int, headSHA, reviewedSHA string) (bool, error) {
+	parents, err := FetchCommitParentSHAsContext(ctx, repo, headSHA)
+	if err != nil {
+		return false, err
+	}
+	if len(parents) != 2 || parents[0] != reviewedSHA {
+		return false, nil
+	}
+	baseSHA, err := FetchPRBaseSHAContext(ctx, repo, number)
+	if err != nil {
+		return false, err
+	}
+	cmp, err := FetchPRCompare(ctx, repo, parents[1], baseSHA)
+	if err != nil {
+		return false, err
+	}
+	return isBaseOnlyMergeFromReviewed(parents, reviewedSHA, cmp.Status), nil
+}
+
+func isCommitSHA(s string) bool {
+	if len(s) != 40 && len(s) != 64 {
+		return false
+	}
+	for _, r := range s {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
+			return false
+		}
+	}
+	return true
+}
+
+func isBaseOnlyMergeFromReviewed(parents []string, reviewedSHA, baseCompareStatus string) bool {
+	if len(parents) != 2 || parents[0] != reviewedSHA {
+		return false
+	}
+	return baseCompareStatus == "identical" || baseCompareStatus == "ahead"
 }
 
 func parseCommitParentSHAs(out []byte) []string {

--- a/internal/github/pr_commits_test.go
+++ b/internal/github/pr_commits_test.go
@@ -1,6 +1,10 @@
 package github
 
-import "testing"
+import (
+	"context"
+	"strings"
+	"testing"
+)
 
 func TestParseCommitMessages(t *testing.T) {
 	out := []byte("feat: a\n\nThis reverts commit abc.\nfix: b\n  \n")
@@ -25,15 +29,16 @@ func TestParseCommitMessages_Empty(t *testing.T) {
 func TestFetchCommitParentSHAsWith(t *testing.T) {
 	t.Parallel()
 	fe := &recordingExecer{output: []byte("parent1\nparent2\n")}
+	sha := "0123456789abcdef0123456789abcdef01234567"
 
-	got, err := fetchCommitParentSHAsWith(fe, "o/r", "head")
+	got, err := fetchCommitParentSHAsWith(context.Background(), fe, "o/r", sha)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
 	if len(got) != 2 || got[0] != "parent1" || got[1] != "parent2" {
 		t.Fatalf("parents = %v, want [parent1 parent2]", got)
 	}
-	wantPath := "repos/o/r/commits/head"
+	wantPath := "repos/o/r/commits/" + sha
 	foundPath := false
 	foundJQ := false
 	for _, arg := range fe.lastArgs {
@@ -46,6 +51,87 @@ func TestFetchCommitParentSHAsWith(t *testing.T) {
 	}
 	if !foundPath || !foundJQ {
 		t.Fatalf("args = %v, want commit endpoint and parent jq", fe.lastArgs)
+	}
+}
+
+func TestFetchCommitParentSHAsWith_RejectsNonSHA(t *testing.T) {
+	t.Parallel()
+	fe := &recordingExecer{output: []byte("parent1\nparent2\n")}
+
+	_, err := fetchCommitParentSHAsWith(context.Background(), fe, "o/r", "main")
+	if err == nil || !strings.Contains(err.Error(), "invalid commit sha") {
+		t.Fatalf("err = %v, want invalid commit sha", err)
+	}
+	if fe.calls != 0 {
+		t.Fatalf("calls = %d, want 0", fe.calls)
+	}
+}
+
+func TestFetchCommitParentSHAsWith_UsesContext(t *testing.T) {
+	t.Parallel()
+	sha := "0123456789abcdef0123456789abcdef01234567"
+	fe := &ctxFakeExecer{output: []byte("parent1\nparent2\n")}
+
+	if _, err := fetchCommitParentSHAsWith(context.Background(), fe, "o/r", sha); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !fe.usedCtx {
+		t.Fatal("expected the context-aware runCtx path to be used")
+	}
+}
+
+func TestIsBaseOnlyMergeFromReviewed(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name              string
+		parents           []string
+		reviewedSHA       string
+		baseCompareStatus string
+		want              bool
+	}{
+		{
+			name:              "direct merge of reachable base into reviewed commit",
+			parents:           []string{"reviewed", "base-parent"},
+			reviewedSHA:       "reviewed",
+			baseCompareStatus: "ahead",
+			want:              true,
+		},
+		{
+			name:              "base parent is current base",
+			parents:           []string{"reviewed", "base-parent"},
+			reviewedSHA:       "reviewed",
+			baseCompareStatus: "identical",
+			want:              true,
+		},
+		{
+			name:              "second parent is not reachable from base",
+			parents:           []string{"reviewed", "feature-parent"},
+			reviewedSHA:       "reviewed",
+			baseCompareStatus: "diverged",
+			want:              false,
+		},
+		{
+			name:              "first parent is not the reviewed commit",
+			parents:           []string{"author-fix", "base-parent"},
+			reviewedSHA:       "reviewed",
+			baseCompareStatus: "ahead",
+			want:              false,
+		},
+		{
+			name:              "not a merge commit",
+			parents:           []string{"reviewed"},
+			reviewedSHA:       "reviewed",
+			baseCompareStatus: "ahead",
+			want:              false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isBaseOnlyMergeFromReviewed(tt.parents, tt.reviewedSHA, tt.baseCompareStatus)
+			if got != tt.want {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/github/pr_commits_test.go
+++ b/internal/github/pr_commits_test.go
@@ -21,3 +21,37 @@ func TestParseCommitMessages_Empty(t *testing.T) {
 		t.Errorf("empty output should yield no messages, got %v", got)
 	}
 }
+
+func TestFetchCommitParentSHAsWith(t *testing.T) {
+	t.Parallel()
+	fe := &recordingExecer{output: []byte("parent1\nparent2\n")}
+
+	got, err := fetchCommitParentSHAsWith(fe, "o/r", "head")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 2 || got[0] != "parent1" || got[1] != "parent2" {
+		t.Fatalf("parents = %v, want [parent1 parent2]", got)
+	}
+	wantPath := "repos/o/r/commits/head"
+	foundPath := false
+	foundJQ := false
+	for _, arg := range fe.lastArgs {
+		if arg == wantPath {
+			foundPath = true
+		}
+		if arg == ".parents[].sha" {
+			foundJQ = true
+		}
+	}
+	if !foundPath || !foundJQ {
+		t.Fatalf("args = %v, want commit endpoint and parent jq", fe.lastArgs)
+	}
+}
+
+func TestParseCommitParentSHAs(t *testing.T) {
+	got := parseCommitParentSHAs([]byte(" parent1 \n\nparent2\n"))
+	if len(got) != 2 || got[0] != "parent1" || got[1] != "parent2" {
+		t.Fatalf("parents = %v, want [parent1 parent2]", got)
+	}
+}

--- a/internal/github/runtime.go
+++ b/internal/github/runtime.go
@@ -347,6 +347,7 @@ var (
 	prFilesCache         = newTTLCache[[]string]()
 	prBranchCache        = newTTLCache[string]()
 	prHeadSHACache       = newTTLCache[string]()
+	commitParentsCache   = newTTLCache[[]string]()
 	prContextCache       = newTTLCache[PRContext]()
 	prClosingIssuesCache = newTTLCache[prClosingIssuesResult]()
 	pendingReviewCache   = newTTLCache[bool]()

--- a/internal/github/runtime.go
+++ b/internal/github/runtime.go
@@ -49,8 +49,9 @@ func isTransientGHError(out []byte, err error) bool {
 }
 
 type ttlCache[T any] struct {
-	mu    sync.RWMutex
-	items map[string]ttlCacheEntry[T]
+	mu         sync.RWMutex
+	items      map[string]ttlCacheEntry[T]
+	maxEntries int
 }
 
 type ttlCacheEntry[T any] struct {
@@ -60,6 +61,10 @@ type ttlCacheEntry[T any] struct {
 
 func newTTLCache[T any]() *ttlCache[T] {
 	return &ttlCache[T]{items: make(map[string]ttlCacheEntry[T])}
+}
+
+func newBoundedTTLCache[T any](maxEntries int) *ttlCache[T] {
+	return &ttlCache[T]{items: make(map[string]ttlCacheEntry[T]), maxEntries: maxEntries}
 }
 
 func (c *ttlCache[T]) Get(key string) (T, bool) {
@@ -91,12 +96,39 @@ func (c *ttlCache[T]) GetStale(key string) (T, bool) {
 }
 
 func (c *ttlCache[T]) Set(key string, value T, ttl time.Duration) {
+	now := time.Now()
 	c.mu.Lock()
+	c.pruneExpiredLocked(now)
 	c.items[key] = ttlCacheEntry[T]{
 		value:     value,
-		expiresAt: time.Now().Add(ttl),
+		expiresAt: now.Add(ttl),
 	}
+	c.evictOverflowLocked()
 	c.mu.Unlock()
+}
+
+func (c *ttlCache[T]) pruneExpiredLocked(now time.Time) {
+	for key, entry := range c.items {
+		if !entry.expiresAt.IsZero() && now.After(entry.expiresAt) {
+			delete(c.items, key)
+		}
+	}
+}
+
+func (c *ttlCache[T]) evictOverflowLocked() {
+	for c.maxEntries > 0 && len(c.items) > c.maxEntries {
+		var oldestKey string
+		var oldest time.Time
+		first := true
+		for key, entry := range c.items {
+			if first || entry.expiresAt.Before(oldest) {
+				oldestKey = key
+				oldest = entry.expiresAt
+				first = false
+			}
+		}
+		delete(c.items, oldestKey)
+	}
 }
 
 func (c *ttlCache[T]) Delete(key string) {
@@ -328,6 +360,7 @@ func invalidatePRCaches(repo string, number int) {
 	prFilesCache.Delete(key)
 	prBranchCache.Delete(key)
 	prHeadSHACache.Delete(key)
+	prBaseSHACache.Delete(key)
 	prContextCache.Delete(key)
 	prClosingIssuesCache.Delete(key)
 	pendingReviewCache.Delete(key)
@@ -347,7 +380,8 @@ var (
 	prFilesCache         = newTTLCache[[]string]()
 	prBranchCache        = newTTLCache[string]()
 	prHeadSHACache       = newTTLCache[string]()
-	commitParentsCache   = newTTLCache[[]string]()
+	prBaseSHACache       = newTTLCache[string]()
+	commitParentsCache   = newBoundedTTLCache[[]string](512)
 	prContextCache       = newTTLCache[PRContext]()
 	prClosingIssuesCache = newTTLCache[prClosingIssuesResult]()
 	pendingReviewCache   = newTTLCache[bool]()

--- a/internal/sybra/app_reviews_inbound.go
+++ b/internal/sybra/app_reviews_inbound.go
@@ -1,10 +1,12 @@
 package sybra
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/audit"
@@ -325,7 +327,8 @@ func (r *ReviewHandler) reconcileReviewTask(t *task.Task, requested, approved ma
 
 	submitted := myState.Submitted || inApproved
 	headSHA := ""
-	var headParentSHAs []string
+	baseOnlyMergeFromReviewed := false
+	headLineageUnknown := false
 	switch {
 	case inReq:
 		headSHA = reqPR.HeadSHA
@@ -341,22 +344,35 @@ func (r *ReviewHandler) reconcileReviewTask(t *task.Task, requested, approved ma
 			headSHA = sha
 		}
 	}
-	if submitted && headSHA != "" && myState.ReviewedSHA != "" && headSHA != myState.ReviewedSHA {
-		if parents, perr := github.FetchCommitParentSHAs(t.ProjectID, headSHA); perr != nil {
-			r.logger.Warn("review.head-parents", "task_id", t.ID, "err", perr)
+	if submitted && !inReq && !myState.Approved && !inApproved && headSHA != "" && myState.ReviewedSHA != "" && headSHA != myState.ReviewedSHA {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		baseOnly, lerr := github.FetchBaseOnlyMergeFromReviewed(ctx, t.ProjectID, t.PRNumber, headSHA, myState.ReviewedSHA)
+		cancel()
+		if lerr != nil {
+			headLineageUnknown = true
+			r.logger.Warn(
+				"review.head-lineage",
+				"task_id", t.ID,
+				"repo", t.ProjectID,
+				"pr", t.PRNumber,
+				"head_sha", headSHA,
+				"reviewed_sha", myState.ReviewedSHA,
+				"err", lerr,
+			)
 		} else {
-			headParentSHAs = parents
+			baseOnlyMergeFromReviewed = baseOnly
 		}
 	}
 
 	r.applyReviewPhase(t, computeReviewPhase(reviewSignals{
-		HasDraft:       myState.Pending,
-		ViewerApproved: myState.Approved || inApproved,
-		Submitted:      submitted,
-		ReRequested:    inReq,
-		HeadSHA:        headSHA,
-		ReviewedSHA:    myState.ReviewedSHA,
-		HeadParentSHAs: headParentSHAs,
+		HasDraft:                  myState.Pending,
+		ViewerApproved:            myState.Approved || inApproved,
+		Submitted:                 submitted,
+		ReRequested:               inReq,
+		HeadSHA:                   headSHA,
+		ReviewedSHA:               myState.ReviewedSHA,
+		HeadLineageUnknown:        headLineageUnknown,
+		BaseOnlyMergeFromReviewed: baseOnlyMergeFromReviewed,
 	}))
 }
 

--- a/internal/sybra/app_reviews_inbound.go
+++ b/internal/sybra/app_reviews_inbound.go
@@ -325,6 +325,7 @@ func (r *ReviewHandler) reconcileReviewTask(t *task.Task, requested, approved ma
 
 	submitted := myState.Submitted || inApproved
 	headSHA := ""
+	var headParentSHAs []string
 	switch {
 	case inReq:
 		headSHA = reqPR.HeadSHA
@@ -340,6 +341,13 @@ func (r *ReviewHandler) reconcileReviewTask(t *task.Task, requested, approved ma
 			headSHA = sha
 		}
 	}
+	if submitted && headSHA != "" && myState.ReviewedSHA != "" && headSHA != myState.ReviewedSHA {
+		if parents, perr := github.FetchCommitParentSHAs(t.ProjectID, headSHA); perr != nil {
+			r.logger.Warn("review.head-parents", "task_id", t.ID, "err", perr)
+		} else {
+			headParentSHAs = parents
+		}
+	}
 
 	r.applyReviewPhase(t, computeReviewPhase(reviewSignals{
 		HasDraft:       myState.Pending,
@@ -348,6 +356,7 @@ func (r *ReviewHandler) reconcileReviewTask(t *task.Task, requested, approved ma
 		ReRequested:    inReq,
 		HeadSHA:        headSHA,
 		ReviewedSHA:    myState.ReviewedSHA,
+		HeadParentSHAs: headParentSHAs,
 	}))
 }
 

--- a/internal/sybra/review_phase.go
+++ b/internal/sybra/review_phase.go
@@ -32,14 +32,15 @@ const (
 // reviewSignals are the live GitHub facts about a review task's PR, gathered
 // from the review summary plus the per-PR reviews endpoint.
 type reviewSignals struct {
-	AgentRunning   bool   // a review agent is running for this task
-	HasDraft       bool   // viewer has a PENDING (unsubmitted) review
-	ViewerApproved bool   // viewer's latest submitted review is an approval
-	Submitted      bool   // viewer has a submitted (non-draft) review
-	ReRequested    bool   // PR is back in viewer's review-requested list
-	HeadSHA        string // current PR head commit ("" if unknown)
-	ReviewedSHA    string // commit the viewer's latest review was made against
-	Mergeable      string // MERGEABLE, CONFLICTING, UNKNOWN, or ""
+	AgentRunning   bool     // a review agent is running for this task
+	HasDraft       bool     // viewer has a PENDING (unsubmitted) review
+	ViewerApproved bool     // viewer's latest submitted review is an approval
+	Submitted      bool     // viewer has a submitted (non-draft) review
+	ReRequested    bool     // PR is back in viewer's review-requested list
+	HeadSHA        string   // current PR head commit ("" if unknown)
+	ReviewedSHA    string   // commit the viewer's latest review was made against
+	HeadParentSHAs []string // current PR head parents in Git parent order
+	Mergeable      string   // MERGEABLE, CONFLICTING, UNKNOWN, or ""
 }
 
 // reviewPhaseResult is the desired task state for a review task.
@@ -127,7 +128,7 @@ func computeReviewPhase(s reviewSignals) reviewPhaseResult {
 		// either way it needs a fresh human pass before approval. Keep the task
 		// in-review so the human-required auto-diagnostic machinery does not
 		// start another review round.
-		advanced := s.HeadSHA != "" && s.ReviewedSHA != "" && s.HeadSHA != s.ReviewedSHA
+		advanced := reviewAdvancedPastReviewed(s)
 		if s.ReRequested || advanced {
 			return reviewPhaseResult{
 				Phase:  ReviewPhaseNeedsApproval,
@@ -147,4 +148,14 @@ func computeReviewPhase(s reviewSignals) reviewPhaseResult {
 	// signal, but emit no reason so applyReviewPhase keeps whatever reason
 	// triage already set (e.g. "PR too small for agent review").
 	return reviewPhaseResult{Phase: ReviewPhaseManual, Status: task.StatusHumanRequired}
+}
+
+func reviewAdvancedPastReviewed(s reviewSignals) bool {
+	if s.HeadSHA == "" || s.ReviewedSHA == "" || s.HeadSHA == s.ReviewedSHA {
+		return false
+	}
+	if len(s.HeadParentSHAs) >= 2 && s.HeadParentSHAs[0] == s.ReviewedSHA {
+		return false
+	}
+	return true
 }

--- a/internal/sybra/review_phase.go
+++ b/internal/sybra/review_phase.go
@@ -32,15 +32,16 @@ const (
 // reviewSignals are the live GitHub facts about a review task's PR, gathered
 // from the review summary plus the per-PR reviews endpoint.
 type reviewSignals struct {
-	AgentRunning   bool     // a review agent is running for this task
-	HasDraft       bool     // viewer has a PENDING (unsubmitted) review
-	ViewerApproved bool     // viewer's latest submitted review is an approval
-	Submitted      bool     // viewer has a submitted (non-draft) review
-	ReRequested    bool     // PR is back in viewer's review-requested list
-	HeadSHA        string   // current PR head commit ("" if unknown)
-	ReviewedSHA    string   // commit the viewer's latest review was made against
-	HeadParentSHAs []string // current PR head parents in Git parent order
-	Mergeable      string   // MERGEABLE, CONFLICTING, UNKNOWN, or ""
+	AgentRunning              bool   // a review agent is running for this task
+	HasDraft                  bool   // viewer has a PENDING (unsubmitted) review
+	ViewerApproved            bool   // viewer's latest submitted review is an approval
+	Submitted                 bool   // viewer has a submitted (non-draft) review
+	ReRequested               bool   // PR is back in viewer's review-requested list
+	HeadSHA                   string // current PR head commit ("" if unknown)
+	ReviewedSHA               string // commit the viewer's latest review was made against
+	HeadLineageUnknown        bool   // head changed, but GitHub lineage lookup failed
+	BaseOnlyMergeFromReviewed bool   // head only merged base into the reviewed commit
+	Mergeable                 string // MERGEABLE, CONFLICTING, UNKNOWN, or ""
 }
 
 // reviewPhaseResult is the desired task state for a review task.
@@ -154,7 +155,7 @@ func reviewAdvancedPastReviewed(s reviewSignals) bool {
 	if s.HeadSHA == "" || s.ReviewedSHA == "" || s.HeadSHA == s.ReviewedSHA {
 		return false
 	}
-	if len(s.HeadParentSHAs) >= 2 && s.HeadParentSHAs[0] == s.ReviewedSHA {
+	if s.HeadLineageUnknown || s.BaseOnlyMergeFromReviewed {
 		return false
 	}
 	return true

--- a/internal/sybra/review_phase_test.go
+++ b/internal/sybra/review_phase_test.go
@@ -63,6 +63,16 @@ func TestComputeReviewPhase(t *testing.T) {
 			want: reviewPhaseResult{Phase: ReviewPhaseNeedsApproval, Status: task.StatusInReview, Reason: "Author updated PR — do a final review & approve"},
 		},
 		{
+			name: "base-only merge commit after review → still awaiting author",
+			sig:  reviewSignals{Submitted: true, HeadSHA: "merge", ReviewedSHA: "sha1", HeadParentSHAs: []string{"sha1", "base"}},
+			want: reviewPhaseResult{Phase: ReviewPhaseAwaitingAuthor, Status: task.StatusInReview, Reason: "Awaiting author response"},
+		},
+		{
+			name: "merge commit after author fix → needs approval",
+			sig:  reviewSignals{Submitted: true, HeadSHA: "merge", ReviewedSHA: "sha1", HeadParentSHAs: []string{"fix", "base"}},
+			want: reviewPhaseResult{Phase: ReviewPhaseNeedsApproval, Status: task.StatusInReview, Reason: "Author updated PR — do a final review & approve"},
+		},
+		{
 			name: "re-requested after review → needs approval even at same head",
 			sig:  reviewSignals{Submitted: true, ReRequested: true, HeadSHA: "sha1", ReviewedSHA: "sha1"},
 			want: reviewPhaseResult{Phase: ReviewPhaseNeedsApproval, Status: task.StatusInReview, Reason: "Author updated PR — do a final review & approve"},

--- a/internal/sybra/review_phase_test.go
+++ b/internal/sybra/review_phase_test.go
@@ -64,12 +64,17 @@ func TestComputeReviewPhase(t *testing.T) {
 		},
 		{
 			name: "base-only merge commit after review → still awaiting author",
-			sig:  reviewSignals{Submitted: true, HeadSHA: "merge", ReviewedSHA: "sha1", HeadParentSHAs: []string{"sha1", "base"}},
+			sig:  reviewSignals{Submitted: true, HeadSHA: "merge", ReviewedSHA: "sha1", BaseOnlyMergeFromReviewed: true},
+			want: reviewPhaseResult{Phase: ReviewPhaseAwaitingAuthor, Status: task.StatusInReview, Reason: "Awaiting author response"},
+		},
+		{
+			name: "changed head with unknown lineage → fail closed awaiting author",
+			sig:  reviewSignals{Submitted: true, HeadSHA: "sha2", ReviewedSHA: "sha1", HeadLineageUnknown: true},
 			want: reviewPhaseResult{Phase: ReviewPhaseAwaitingAuthor, Status: task.StatusInReview, Reason: "Awaiting author response"},
 		},
 		{
 			name: "merge commit after author fix → needs approval",
-			sig:  reviewSignals{Submitted: true, HeadSHA: "merge", ReviewedSHA: "sha1", HeadParentSHAs: []string{"fix", "base"}},
+			sig:  reviewSignals{Submitted: true, HeadSHA: "merge", ReviewedSHA: "sha1"},
 			want: reviewPhaseResult{Phase: ReviewPhaseNeedsApproval, Status: task.StatusInReview, Reason: "Author updated PR — do a final review & approve"},
 		},
 		{


### PR DESCRIPTION
## Motivation

Review tasks should not move to approval when a PR author only merged the base branch after Sybra posted review feedback.

> Changelog: fix(review): ignore base-only PR merges

## Implementation information

- Fetch current PR head parent SHAs when the head differs from the reviewed commit.
- Keep the task awaiting the author for merge commits whose first parent is the reviewed commit.
- Preserve needs-approval behavior for real author commits and re-requested reviews.

## Supporting documentation

Regression coverage added in review phase and GitHub commit-parent tests.