### PR TITLE
fix(workflow): recover plan approval

### DIFF
--- a/internal/sybra/svc_planning.go
+++ b/internal/sybra/svc_planning.go
@@ -74,10 +74,80 @@ func (s *PlanningService) HasLivePlanAgent(id string) bool {
 }
 
 func (s *PlanningService) approve(id string) (task.Task, error) {
-	if err := s.engine.HandleHumanAction(id, "approve", nil); err != nil {
+	if err := s.handlePlanReviewAction(id, "approve", nil); err != nil {
 		return task.Task{}, err
 	}
 	return s.tasks.Get(id)
+}
+
+func (s *PlanningService) handlePlanReviewAction(id, action string, data map[string]string) error {
+	return s.engine.HandleHumanActionRecovering(id, action, data, recoverCompletedPlanReview)
+}
+
+func recoverCompletedPlanReview(t workflow.TaskInfo) (*workflow.Execution, bool, error) {
+	if t.Status != string(task.StatusPlanReview) || t.Workflow == nil ||
+		t.Workflow.WorkflowID != "simple-task-plan" ||
+		t.Workflow.CurrentStep != "" ||
+		t.Workflow.State != workflow.ExecCompleted {
+		return nil, false, nil
+	}
+	if problems := completedPlanReviewRecoveryProblems(t); len(problems) > 0 {
+		return nil, false, fmt.Errorf("cannot recover plan review workflow for task %s: %s", t.ID, strings.Join(problems, "; "))
+	}
+
+	wf := *t.Workflow
+	wf.CurrentStep = "review_plan"
+	wf.State = workflow.ExecWaiting
+	wf.CompletedAt = nil
+	wf.Variables = clearHumanActionVars(t.Workflow.Variables)
+	return &wf, true, nil
+}
+
+func clearHumanActionVars(vars map[string]string) map[string]string {
+	if len(vars) == 0 {
+		return vars
+	}
+	cleared := make(map[string]string, len(vars))
+	for k, v := range vars {
+		if k == "human_action" || strings.HasPrefix(k, "human.") {
+			continue
+		}
+		cleared[k] = v
+	}
+	return cleared
+}
+
+func completedPlanReviewRecoveryProblems(t workflow.TaskInfo) []string {
+	var problems []string
+	required := map[string]string{
+		"plan":           t.Plan,
+		"plan_research":  t.PlanResearch,
+		"plan_decisions": t.PlanDecisions,
+		"plan_brief":     t.PlanBrief,
+	}
+	for name, content := range required {
+		if strings.TrimSpace(content) == "" {
+			problems = append(problems, name+" is required")
+		}
+	}
+	if strings.TrimSpace(t.PlanContract) != "" {
+		for _, problem := range workflow.ValidatePlanContract(t.PlanContract, t.ID) {
+			problems = append(problems, "plan_contract "+problem)
+		}
+	}
+	if !hasCompletedStep(t.Workflow, "validate_plan_contract") &&
+		!hasCompletedStep(t.Workflow, "validate_plan_contract_after_address") {
+		problems = append(problems, "plan validation step did not complete")
+	}
+	return problems
+}
+
+func hasCompletedStep(wf *workflow.Execution, stepID string) bool {
+	if wf == nil {
+		return false
+	}
+	rec := wf.RecordForStep(stepID)
+	return rec != nil && rec.Status == "completed"
 }
 
 // reject forwards an optional human-typed feedback plus any unresolved
@@ -90,7 +160,7 @@ func (s *PlanningService) reject(id, feedback string) (task.Task, error) {
 		data["feedback"] = combined
 	}
 
-	if err := s.engine.HandleHumanAction(id, "reject", data); err != nil {
+	if err := s.handlePlanReviewAction(id, "reject", data); err != nil {
 		return task.Task{}, err
 	}
 	_ = s.tasks.Comments().ResolveAll(id)

--- a/internal/sybra/svc_planning_test.go
+++ b/internal/sybra/svc_planning_test.go
@@ -1,6 +1,7 @@
 package sybra
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -107,6 +108,149 @@ func TestPlanningService_ApprovePlan_ErrorWhenNotWaiting(t *testing.T) {
 	}
 }
 
+func TestPlanningService_ApprovePlan_RecoversCompletedPlanReviewWorkflow(t *testing.T) {
+	planSvc, _, a := setupPlanningService(t)
+
+	created, err := a.tasks.Create("approve stale plan", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	status := task.StatusPlanReview
+	completedAt := time.Now().UTC()
+	wf := &workflow.Execution{
+		WorkflowID:  "simple-task-plan",
+		CurrentStep: "",
+		State:       workflow.ExecCompleted,
+		Variables: map[string]string{
+			"human_action":               "reject",
+			"human.feedback":             "stale feedback",
+			"step.review_plan.output":    "reject",
+			"step.address_critique.note": "keep",
+		},
+		StepHistory: []workflow.StepRecord{{
+			StepID: "validate_plan_contract_after_address",
+			Status: "completed",
+		}},
+		StartedAt:   completedAt.Add(-time.Minute),
+		CompletedAt: &completedAt,
+	}
+	plan := "# Execution Plan\n\n## Steps\n1. Fix it."
+	planContract := validPlanningContract(created.ID)
+	planResearch := "researched relevant files"
+	planDecisions := "# Decisions\n\nNo open decisions."
+	planBrief := "safe to approve"
+	if _, err := a.tasks.Update(created.ID, task.Update{
+		Status:        &status,
+		Workflow:      &wf,
+		Plan:          &plan,
+		PlanContract:  &planContract,
+		PlanResearch:  &planResearch,
+		PlanDecisions: &planDecisions,
+		PlanBrief:     &planBrief,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	updated, err := planSvc.ApprovePlan(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != task.StatusInProgress {
+		t.Fatalf("Status = %q, want %q", updated.Status, task.StatusInProgress)
+	}
+	if updated.Workflow == nil || updated.Workflow.State != workflow.ExecCompleted {
+		t.Fatalf("workflow = %+v, want completed", updated.Workflow)
+	}
+	if updated.Workflow.CurrentStep != "" {
+		t.Fatalf("CurrentStep = %q, want empty after approval", updated.Workflow.CurrentStep)
+	}
+	if _, ok := updated.Workflow.Variables["human.feedback"]; ok {
+		t.Fatal("stale human.feedback should be cleared during recovery")
+	}
+	if got := updated.Workflow.Variables["step.address_critique.note"]; got != "keep" {
+		t.Fatalf("step variable = %q, want preserved", got)
+	}
+}
+
+func TestPlanningService_ApprovePlan_DoesNotRecoverWithoutValidatedPlan(t *testing.T) {
+	planSvc, _, a := setupPlanningService(t)
+
+	created, err := a.tasks.Create("approve invalid stale plan", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	status := task.StatusPlanReview
+	completedAt := time.Now().UTC()
+	wf := &workflow.Execution{
+		WorkflowID:  "simple-task-plan",
+		CurrentStep: "",
+		State:       workflow.ExecCompleted,
+		StartedAt:   completedAt.Add(-time.Minute),
+		CompletedAt: &completedAt,
+	}
+	if _, err := a.tasks.Update(created.ID, task.Update{Status: &status, Workflow: &wf}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := planSvc.ApprovePlan(created.ID); err == nil {
+		t.Fatal("expected error when recovering without validated plan artifacts")
+	}
+	updated, err := a.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != task.StatusPlanReview {
+		t.Fatalf("Status = %q, want %q", updated.Status, task.StatusPlanReview)
+	}
+	if updated.Workflow == nil || updated.Workflow.State != workflow.ExecCompleted {
+		t.Fatalf("workflow = %+v, want completed", updated.Workflow)
+	}
+}
+
+func TestPlanningService_ApprovePlan_RecoversMarkdownOnlyMigrationPlan(t *testing.T) {
+	planSvc, _, a := setupPlanningService(t)
+
+	created, err := a.tasks.Create("approve markdown-only stale plan", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	status := task.StatusPlanReview
+	completedAt := time.Now().UTC()
+	wf := &workflow.Execution{
+		WorkflowID:  "simple-task-plan",
+		CurrentStep: "",
+		State:       workflow.ExecCompleted,
+		StepHistory: []workflow.StepRecord{{
+			StepID: "validate_plan_contract",
+			Status: "completed",
+		}},
+		StartedAt:   completedAt.Add(-time.Minute),
+		CompletedAt: &completedAt,
+	}
+	plan := "# Execution Plan\n\n## Steps\n1. Fix it."
+	planResearch := "researched relevant files"
+	planDecisions := "# Decisions\n\nNo open decisions."
+	planBrief := "safe to approve"
+	if _, err := a.tasks.Update(created.ID, task.Update{
+		Status:        &status,
+		Workflow:      &wf,
+		Plan:          &plan,
+		PlanResearch:  &planResearch,
+		PlanDecisions: &planDecisions,
+		PlanBrief:     &planBrief,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	updated, err := planSvc.ApprovePlan(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != task.StatusInProgress {
+		t.Fatalf("Status = %q, want %q", updated.Status, task.StatusInProgress)
+	}
+}
+
 func TestPlanningService_RejectPlan_ErrorWhenNotWaiting(t *testing.T) {
 	planSvc, taskSvc, _ := setupPlanningService(t)
 
@@ -118,6 +262,25 @@ func TestPlanningService_RejectPlan_ErrorWhenNotWaiting(t *testing.T) {
 	if _, err := planSvc.RejectPlan(created.ID, "bad plan"); err == nil {
 		t.Fatal("expected error when rejecting task without active workflow")
 	}
+}
+
+func validPlanningContract(taskID string) string {
+	return fmt.Sprintf(`{
+  "task_id": %q,
+  "branch": "example-%s",
+  "worktree": "/tmp/sybra-%s",
+  "files": [
+    {"path": "internal/sybra/svc_planning.go", "purpose": "edit", "symbols": ["PlanningService"]}
+  ],
+  "steps": ["Recover stale plan-review wait state"],
+  "verification": [
+    {"command": "go test ./internal/sybra", "expected": "tests pass"}
+  ],
+  "acceptance_criteria": ["Accept Plan works for stale completed plan-review workflows"],
+  "risk_tier": "low",
+  "permission_tier": "repo-write",
+  "rollback": "revert the planning service recovery change"
+}`, taskID, taskID, taskID)
 }
 
 func TestPlanningService_SendPlanMessage_EmptyMessage(t *testing.T) {

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -10,6 +10,42 @@ import (
 
 // HandleHumanAction processes approve/reject/input from the UI.
 func (e *Engine) HandleHumanAction(taskID, action string, data map[string]string) error {
+	return e.withHumanActionLock(taskID, func() error {
+		return e.handleHumanAction(taskID, action, data)
+	})
+}
+
+// HandleHumanActionRecovering processes a human action, optionally repairing a
+// narrowly-recognized stale wait state before retrying the same action.
+func (e *Engine) HandleHumanActionRecovering(
+	taskID, action string,
+	data map[string]string,
+	recoverFn func(TaskInfo) (*Execution, bool, error),
+) error {
+	return e.withHumanActionLock(taskID, func() error {
+		err := e.handleHumanAction(taskID, action, data)
+		if err == nil || recoverFn == nil {
+			return err
+		}
+		t, getErr := e.tasks.GetTask(taskID)
+		if getErr != nil {
+			return err
+		}
+		wf, ok, recoverErr := recoverFn(t)
+		if recoverErr != nil {
+			return recoverErr
+		}
+		if !ok {
+			return err
+		}
+		if err := e.tasks.SetWorkflow(taskID, wf); err != nil {
+			return err
+		}
+		return e.handleHumanAction(taskID, action, data)
+	})
+}
+
+func (e *Engine) withHumanActionLock(taskID string, fn func() error) error {
 	// Serialize concurrent human actions per task so double-click races do not
 	// both mutate workflow vars and attempt to advance the same wait_human step.
 	e.mu.Lock()
@@ -25,6 +61,10 @@ func (e *Engine) HandleHumanAction(taskID, action string, data map[string]string
 		e.mu.Unlock()
 	}()
 
+	return fn()
+}
+
+func (e *Engine) handleHumanAction(taskID, action string, data map[string]string) error {
 	t, err := e.tasks.GetTask(taskID)
 	if err != nil {
 		return err

--- a/internal/workflow/engine_validate_plan_contract.go
+++ b/internal/workflow/engine_validate_plan_contract.go
@@ -38,7 +38,7 @@ func (e *Engine) execValidatePlanContract(taskID string, step *Step, t TaskInfo)
 	if raw == "" {
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "plan contract absent; markdown-only migration fallback"}, nil
 	}
-	if problems := validatePlanContract(raw, taskID); len(problems) > 0 {
+	if problems := ValidatePlanContract(raw, taskID); len(problems) > 0 {
 		reason := "plan contract invalid: " + strings.Join(problems, "; ")
 		if statusErr := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); statusErr != nil {
 			e.logger.Error("workflow.validate-plan-contract.status", "task_id", taskID, "err", statusErr)
@@ -49,7 +49,8 @@ func (e *Engine) execValidatePlanContract(taskID string, step *Step, t TaskInfo)
 	return StepOutput{StepID: step.ID, Status: "completed", Output: "plan contract OK"}, nil
 }
 
-func validatePlanContract(raw, taskID string) []string {
+// ValidatePlanContract returns all schema and safety problems in a plan contract.
+func ValidatePlanContract(raw, taskID string) []string {
 	var contract PlanContract
 	dec := json.NewDecoder(strings.NewReader(raw))
 	dec.DisallowUnknownFields()


### PR DESCRIPTION
## Motivation

Plan review tasks can get stuck with status `plan-review` while the planning workflow is already completed, which makes Accept Plan fail because the engine no longer sees a waiting human step.

> Changelog: fix(workflow): recover plan approval

## Implementation information

Adds an engine helper that keeps recovery and the retried human action under the same per-task action lock. Planning approval/rejection now restores only narrowly valid stale `simple-task-plan` review states: `plan-review`, completed workflow, empty current step, completed plan validation history, required plan sidecars, and a valid contract when present. Recovery also clears stale human-action vars while preserving step history context.

## Supporting documentation

- `go test ./internal/workflow`
- `go test ./internal/sybra -run 'TestPlanningService_ApprovePlan'`