### PR TITLE
refactor(agent): extract loop detector

### DIFF
--- a/internal/agent/loop_detector.go
+++ b/internal/agent/loop_detector.go
@@ -1,0 +1,46 @@
+package agent
+
+import "sync"
+
+type loopDetector struct {
+	mu sync.RWMutex
+
+	lastSig string
+	streak  int
+	ackSig  string
+}
+
+func (d *loopDetector) NoteSignature(sig string) int {
+	if sig == "" {
+		return d.Streak()
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if sig == d.lastSig {
+		d.streak++
+	} else {
+		d.lastSig = sig
+		d.streak = 1
+	}
+	return d.streak
+}
+
+func (d *loopDetector) Streak() int {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.streak
+}
+
+func (d *loopDetector) Ack() {
+	d.mu.Lock()
+	d.ackSig = d.lastSig
+	d.mu.Unlock()
+}
+
+func (d *loopDetector) Acknowledged() bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.ackSig != "" && d.ackSig == d.lastSig
+}

--- a/internal/agent/loop_detector.go
+++ b/internal/agent/loop_detector.go
@@ -5,14 +5,16 @@ import "sync"
 type loopDetector struct {
 	mu sync.RWMutex
 
+	// Empty signatures preserve streaks. Ack suppresses only the current
+	// non-empty signature; a different signature re-arms loop detection.
 	lastSig string
 	streak  int
 	ackSig  string
 }
 
-func (d *loopDetector) NoteSignature(sig string) int {
+func (d *loopDetector) noteSignature(sig string) int {
 	if sig == "" {
-		return d.Streak()
+		return d.currentStreak()
 	}
 
 	d.mu.Lock()
@@ -27,19 +29,19 @@ func (d *loopDetector) NoteSignature(sig string) int {
 	return d.streak
 }
 
-func (d *loopDetector) Streak() int {
+func (d *loopDetector) currentStreak() int {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	return d.streak
 }
 
-func (d *loopDetector) Ack() {
+func (d *loopDetector) ack() {
 	d.mu.Lock()
 	d.ackSig = d.lastSig
 	d.mu.Unlock()
 }
 
-func (d *loopDetector) Acknowledged() bool {
+func (d *loopDetector) acknowledged() bool {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	return d.ackSig != "" && d.ackSig == d.lastSig

--- a/internal/agent/loop_detector.go
+++ b/internal/agent/loop_detector.go
@@ -3,7 +3,7 @@ package agent
 import "sync"
 
 type loopDetector struct {
-	mu sync.RWMutex
+	mu sync.Mutex
 
 	// Empty signatures preserve streaks. Ack suppresses only the current
 	// non-empty signature; a different signature re-arms loop detection.
@@ -30,8 +30,8 @@ func (d *loopDetector) noteSignature(sig string) int {
 }
 
 func (d *loopDetector) currentStreak() int {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	return d.streak
 }
 
@@ -42,7 +42,7 @@ func (d *loopDetector) ack() {
 }
 
 func (d *loopDetector) acknowledged() bool {
-	d.mu.RLock()
-	defer d.mu.RUnlock()
+	d.mu.Lock()
+	defer d.mu.Unlock()
 	return d.ackSig != "" && d.ackSig == d.lastSig
 }

--- a/internal/agent/loop_signature_test.go
+++ b/internal/agent/loop_signature_test.go
@@ -102,7 +102,7 @@ func TestAgentToolLoopAcknowledge(t *testing.T) {
 
 	t.Run("ack on no signature is not acknowledged", func(t *testing.T) {
 		a := &Agent{}
-		a.AckToolLoop() // lastToolSig is "" — must not count as acknowledged
+		a.AckToolLoop() // no current signature must not count as acknowledged
 		if a.ToolLoopAcknowledged() {
 			t.Fatal("empty signature must never read as acknowledged")
 		}

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -12,7 +12,7 @@ import (
 	"github.com/Automaat/sybra/internal/limits"
 )
 
-// NOTE on concurrency: Agent has two distinct mutexes.
+// NOTE on concurrency: Agent has distinct mutexes.
 //   - mu: guards all mutable scalar and slice fields (State, outputBuffer,
 //     convoBuffer, LastEventAt, CostUSD, TurnCount, SessionID, ExitErr,
 //     cmd, PID, LogPath, EscalationReason). Use the helper methods
@@ -22,6 +22,7 @@ import (
 //     goroutine may hold it for the duration of a blocking Write, and
 //     we do not want to starve other consumers that only need to read
 //     State or append an event.
+//   - loops owns its own lock for loop-detection state.
 
 type State string
 
@@ -69,19 +70,7 @@ type Agent struct {
 	// stats.RunRecord at completion so efficiency (tools per turn, tools per
 	// landed PR) can be measured. Tracked in-memory during the run.
 	ToolCalls int `json:"toolCalls,omitempty"`
-	// lastToolSig / toolLoopStreak track consecutive identical tool-call
-	// signatures so the watchdog can detect an agent looping on the same call
-	// in real time (it never stalls, so the stall trigger misses it). Guarded
-	// by mu; updated from the headless stream via NoteToolSignature.
-	lastToolSig    string
-	toolLoopStreak int
-	// loopAckSig is the signature the watchdog has already inspected and
-	// decided not to kill. While it equals lastToolSig the loop trigger is
-	// suppressed, so a cleared (or legitimately repetitive) loop is not
-	// re-inspected every debounce window — and a now-frozen high streak no
-	// longer masks the stall trigger. Cleared implicitly when the signature
-	// changes (a genuinely new loop re-arms the trigger).
-	loopAckSig string
+	loops     loopDetector
 	// MaxTurns is the per-agent turn limit override; zero means use global guardrail.
 	MaxTurns int `json:"maxTurns,omitempty"`
 	// oneShot marks workflow-owned interactive runs that must complete after
@@ -424,46 +413,27 @@ func (a *Agent) GetToolCalls() int {
 // reasoning between identical calls does not reset a genuine loop. A new
 // signature resets the streak to 1.
 func (a *Agent) NoteToolSignature(sig string) int {
-	if sig == "" {
-		a.mu.RLock()
-		defer a.mu.RUnlock()
-		return a.toolLoopStreak
-	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if sig == a.lastToolSig {
-		a.toolLoopStreak++
-	} else {
-		a.lastToolSig = sig
-		a.toolLoopStreak = 1
-	}
-	return a.toolLoopStreak
+	return a.loops.NoteSignature(sig)
 }
 
 // ToolLoopStreak returns the current count of consecutive identical tool-call
 // signatures. A high value means the agent is repeating the same call.
 func (a *Agent) ToolLoopStreak() int {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	return a.toolLoopStreak
+	return a.loops.Streak()
 }
 
 // AckToolLoop records the current loop signature as already inspected, so the
 // watchdog does not re-trigger on the same unchanged loop. Called after a
 // loop-triggered inspection whose verdict left the agent running.
 func (a *Agent) AckToolLoop() {
-	a.mu.Lock()
-	a.loopAckSig = a.lastToolSig
-	a.mu.Unlock()
+	a.loops.Ack()
 }
 
 // ToolLoopAcknowledged reports whether the current loop signature has already
 // been inspected (and the agent left running). True suppresses the loop
 // trigger until the signature changes.
 func (a *Agent) ToolLoopAcknowledged() bool {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	return a.loopAckSig != "" && a.loopAckSig == a.lastToolSig
+	return a.loops.Acknowledged()
 }
 
 // SetEscalationReason updates the escalation reason string.

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -22,7 +22,10 @@ import (
 //     goroutine may hold it for the duration of a blocking Write, and
 //     we do not want to starve other consumers that only need to read
 //     State or append an event.
-//   - loops owns its own lock for loop-detection state.
+//   - loops owns its own lock for loop-detection state. Runner write paths and
+//     watchdog read/ack paths intentionally observe loop state independently
+//     from Agent.mu-protected fields; do not assume atomic snapshots across
+//     those lock domains.
 
 type State string
 
@@ -413,27 +416,27 @@ func (a *Agent) GetToolCalls() int {
 // reasoning between identical calls does not reset a genuine loop. A new
 // signature resets the streak to 1.
 func (a *Agent) NoteToolSignature(sig string) int {
-	return a.loops.NoteSignature(sig)
+	return a.loops.noteSignature(sig)
 }
 
 // ToolLoopStreak returns the current count of consecutive identical tool-call
 // signatures. A high value means the agent is repeating the same call.
 func (a *Agent) ToolLoopStreak() int {
-	return a.loops.Streak()
+	return a.loops.currentStreak()
 }
 
 // AckToolLoop records the current loop signature as already inspected, so the
 // watchdog does not re-trigger on the same unchanged loop. Called after a
 // loop-triggered inspection whose verdict left the agent running.
 func (a *Agent) AckToolLoop() {
-	a.loops.Ack()
+	a.loops.ack()
 }
 
 // ToolLoopAcknowledged reports whether the current loop signature has already
 // been inspected (and the agent left running). True suppresses the loop
 // trigger until the signature changes.
 func (a *Agent) ToolLoopAcknowledged() bool {
-	return a.loops.Acknowledged()
+	return a.loops.acknowledged()
 }
 
 // SetEscalationReason updates the escalation reason string.


### PR DESCRIPTION
## Motivation

Extract the agent loop detection state so the watchdog logic is easier to maintain and reason about.

Closes https://github.com/Automaat/sybra/issues/1123

## Implementation information

- Added a dedicated loop detector type for tracking repeated tool-call signatures and acknowledgement state.
- Updated agent state to delegate loop tracking through the extracted type.
- Adjusted loop signature tests to match the refactored behavior.