### PR TITLE
feat(stats): add closed task series

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/stats/index.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/stats/index.ts
@@ -5,5 +5,6 @@ export {
     GroupedStat,
     RunRecord,
     StatsResponse,
-    Summary
+    Summary,
+    TaskSeriesPoint
 } from "./models.js";

--- a/frontend/bindings/github.com/Automaat/sybra/internal/stats/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/stats/models.ts
@@ -138,7 +138,7 @@ export class StatsResponse {
     "byModel": GroupedStat[];
     "byProvider": GroupedStat[];
     "recentRuns": RunRecord[];
-    "closedTasksDaily": TaskSeriesPoint[];
+    "tasksDoneDaily": TaskSeriesPoint[];
     "limits"?: limits$0.Summary | null;
 
     /** Creates a new StatsResponse instance. */
@@ -176,8 +176,8 @@ export class StatsResponse {
         if (!("recentRuns" in $$source)) {
             this["recentRuns"] = [];
         }
-        if (!("closedTasksDaily" in $$source)) {
-            this["closedTasksDaily"] = [];
+        if (!("tasksDoneDaily" in $$source)) {
+            this["tasksDoneDaily"] = [];
         }
 
         Object.assign(this, $$source);
@@ -234,8 +234,8 @@ export class StatsResponse {
         if ("recentRuns" in $$parsedSource) {
             $$parsedSource["recentRuns"] = $$createField10_0($$parsedSource["recentRuns"]);
         }
-        if ("closedTasksDaily" in $$parsedSource) {
-            $$parsedSource["closedTasksDaily"] = $$createField11_0($$parsedSource["closedTasksDaily"]);
+        if ("tasksDoneDaily" in $$parsedSource) {
+            $$parsedSource["tasksDoneDaily"] = $$createField11_0($$parsedSource["tasksDoneDaily"]);
         }
         if ("limits" in $$parsedSource) {
             $$parsedSource["limits"] = $$createField12_0($$parsedSource["limits"]);
@@ -301,7 +301,7 @@ export class Summary {
 }
 
 /**
- * TaskSeriesPoint is a daily task-count bucket for time-series charts.
+ * TaskSeriesPoint is a UTC daily task-count bucket for time-series charts.
  */
 export class TaskSeriesPoint {
     "date": string;

--- a/frontend/bindings/github.com/Automaat/sybra/internal/stats/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/stats/models.ts
@@ -138,7 +138,7 @@ export class StatsResponse {
     "byModel": GroupedStat[];
     "byProvider": GroupedStat[];
     "recentRuns": RunRecord[];
-    "tasksDoneDaily": TaskSeriesPoint[];
+    "closedTasksDaily": TaskSeriesPoint[];
     "limits"?: limits$0.Summary | null;
 
     /** Creates a new StatsResponse instance. */
@@ -176,8 +176,8 @@ export class StatsResponse {
         if (!("recentRuns" in $$source)) {
             this["recentRuns"] = [];
         }
-        if (!("tasksDoneDaily" in $$source)) {
-            this["tasksDoneDaily"] = [];
+        if (!("closedTasksDaily" in $$source)) {
+            this["closedTasksDaily"] = [];
         }
 
         Object.assign(this, $$source);
@@ -234,8 +234,8 @@ export class StatsResponse {
         if ("recentRuns" in $$parsedSource) {
             $$parsedSource["recentRuns"] = $$createField10_0($$parsedSource["recentRuns"]);
         }
-        if ("tasksDoneDaily" in $$parsedSource) {
-            $$parsedSource["tasksDoneDaily"] = $$createField11_0($$parsedSource["tasksDoneDaily"]);
+        if ("closedTasksDaily" in $$parsedSource) {
+            $$parsedSource["closedTasksDaily"] = $$createField11_0($$parsedSource["closedTasksDaily"]);
         }
         if ("limits" in $$parsedSource) {
             $$parsedSource["limits"] = $$createField12_0($$parsedSource["limits"]);
@@ -301,7 +301,7 @@ export class Summary {
 }
 
 /**
- * TaskSeriesPoint is a UTC daily task-count bucket for time-series charts.
+ * TaskSeriesPoint is a daily task-count bucket for time-series charts.
  */
 export class TaskSeriesPoint {
     "date": string;

--- a/frontend/bindings/github.com/Automaat/sybra/internal/stats/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/stats/models.ts
@@ -138,6 +138,7 @@ export class StatsResponse {
     "byModel": GroupedStat[];
     "byProvider": GroupedStat[];
     "recentRuns": RunRecord[];
+    "closedTasksDaily": TaskSeriesPoint[];
     "limits"?: limits$0.Summary | null;
 
     /** Creates a new StatsResponse instance. */
@@ -175,6 +176,9 @@ export class StatsResponse {
         if (!("recentRuns" in $$source)) {
             this["recentRuns"] = [];
         }
+        if (!("closedTasksDaily" in $$source)) {
+            this["closedTasksDaily"] = [];
+        }
 
         Object.assign(this, $$source);
     }
@@ -195,6 +199,7 @@ export class StatsResponse {
         const $$createField9_0 = $$createType2;
         const $$createField10_0 = $$createType4;
         const $$createField11_0 = $$createType6;
+        const $$createField12_0 = $$createType8;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("today" in $$parsedSource) {
             $$parsedSource["today"] = $$createField0_0($$parsedSource["today"]);
@@ -229,8 +234,11 @@ export class StatsResponse {
         if ("recentRuns" in $$parsedSource) {
             $$parsedSource["recentRuns"] = $$createField10_0($$parsedSource["recentRuns"]);
         }
+        if ("closedTasksDaily" in $$parsedSource) {
+            $$parsedSource["closedTasksDaily"] = $$createField11_0($$parsedSource["closedTasksDaily"]);
+        }
         if ("limits" in $$parsedSource) {
-            $$parsedSource["limits"] = $$createField11_0($$parsedSource["limits"]);
+            $$parsedSource["limits"] = $$createField12_0($$parsedSource["limits"]);
         }
         return new StatsResponse($$parsedSource as Partial<StatsResponse>);
     }
@@ -292,11 +300,41 @@ export class Summary {
     }
 }
 
+/**
+ * TaskSeriesPoint is a daily task-count bucket for time-series charts.
+ */
+export class TaskSeriesPoint {
+    "date": string;
+    "count": number;
+
+    /** Creates a new TaskSeriesPoint instance. */
+    constructor($$source: Partial<TaskSeriesPoint> = {}) {
+        if (!("date" in $$source)) {
+            this["date"] = "";
+        }
+        if (!("count" in $$source)) {
+            this["count"] = 0;
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new TaskSeriesPoint instance from a string or object.
+     */
+    static createFrom($$source: any = {}): TaskSeriesPoint {
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        return new TaskSeriesPoint($$parsedSource as Partial<TaskSeriesPoint>);
+    }
+}
+
 // Private type creation functions
 const $$createType0 = Summary.createFrom;
 const $$createType1 = GroupedStat.createFrom;
 const $$createType2 = $Create.Array($$createType1);
 const $$createType3 = RunRecord.createFrom;
 const $$createType4 = $Create.Array($$createType3);
-const $$createType5 = limits$0.Summary.createFrom;
-const $$createType6 = $Create.Nullable($$createType5);
+const $$createType5 = TaskSeriesPoint.createFrom;
+const $$createType6 = $Create.Array($$createType5);
+const $$createType7 = limits$0.Summary.createFrom;
+const $$createType8 = $Create.Nullable($$createType7);

--- a/frontend/src/components/stats/StatsLineChart.svelte
+++ b/frontend/src/components/stats/StatsLineChart.svelte
@@ -1,44 +1,46 @@
 <script lang="ts">
-  import type { DailyCost } from '../../lib/stats-charts.js'
+  import type { TimeSeriesPoint } from '../../lib/stats-charts.js'
 
   interface Props {
-    points: DailyCost[]
+    points: TimeSeriesPoint[]
+    ariaLabel: string
+    emptyLabel: string
   }
 
-  const { points }: Props = $props()
+  const { points, ariaLabel, emptyLabel }: Props = $props()
 
   const W = 320
   const H = 96
   const PAD = 6
 
-  const max = $derived(Math.max(0, ...points.map((p) => p.cost)))
+  const max = $derived(Math.max(0, ...points.map((p) => p.value)))
 
   // x evenly spaced; y inverted (SVG origin top-left), scaled to max.
   function px(i: number): number {
     if (points.length <= 1) return W / 2
     return PAD + (i / (points.length - 1)) * (W - 2 * PAD)
   }
-  function py(cost: number): number {
+  function py(value: number): number {
     if (max <= 0) return H - PAD
-    return H - PAD - (cost / max) * (H - 2 * PAD)
+    return H - PAD - (value / max) * (H - 2 * PAD)
   }
 
-  const line = $derived(points.map((p, i) => `${px(i)},${py(p.cost)}`).join(' '))
+  const line = $derived(points.map((p, i) => `${px(i)},${py(p.value)}`).join(' '))
   const area = $derived(
     points.length > 0 ? `${px(0)},${H - PAD} ${line} ${px(points.length - 1)},${H - PAD}` : '',
   )
 </script>
 
 {#if points.length === 0}
-  <p class="py-8 text-center text-xs text-surface-400">No cost in this range</p>
+  <p class="py-8 text-center text-xs text-surface-400">{emptyLabel}</p>
 {:else}
-  <svg viewBox="0 0 {W} {H}" class="h-24 w-full" preserveAspectRatio="none" role="img" aria-label="Cost over time">
+  <svg viewBox="0 0 {W} {H}" class="h-24 w-full" preserveAspectRatio="none" role="img" aria-label={ariaLabel}>
     {#if points.length > 1}
       <polygon points={area} class="fill-primary-500/10" />
       <polyline points={line} fill="none" class="stroke-primary-500" stroke-width="2" vector-effect="non-scaling-stroke" />
     {/if}
     {#each points as p, i (p.date)}
-      <circle cx={px(i)} cy={py(p.cost)} r="2.5" class="fill-primary-500" vector-effect="non-scaling-stroke" />
+      <circle cx={px(i)} cy={py(p.value)} r="2.5" class="fill-primary-500" vector-effect="non-scaling-stroke" />
     {/each}
   </svg>
   <div class="mt-1 flex justify-between text-[10px] text-surface-400">

--- a/frontend/src/lib/stats-charts.test.ts
+++ b/frontend/src/lib/stats-charts.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import {
   periodCutoff,
-  periodCutoffDayKey,
-  utcDayKey,
   dailyCost,
   costByProject,
-  tasksDoneSeries,
+  closedTasksSeries,
   MAX_TIME_SERIES_POINTS,
 } from './stats-charts.js'
 import type { RunRecord, TaskSeriesPoint } from '../../bindings/github.com/Automaat/sybra/internal/stats/models.js'
@@ -14,26 +12,16 @@ function run(timestamp: string, costUsd: number, projectId = ''): RunRecord {
   return { timestamp, costUsd, projectId } as unknown as RunRecord
 }
 
+function localDayKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
 describe('periodCutoff', () => {
   // Wed Jun 24 2026, 15:00 local.
   const now = new Date(2026, 5, 24, 15, 0, 0)
 
   it('today is local midnight', () => {
     expect(periodCutoff('today', now)).toEqual(new Date(2026, 5, 24))
-  })
-
-  describe('periodCutoffDayKey', () => {
-    const now = new Date('2026-06-24T23:30:00-07:00')
-
-    it('uses UTC day boundaries for backend date keys', () => {
-      expect(periodCutoffDayKey('today', now)).toBe('2026-06-25')
-      expect(periodCutoffDayKey('thisMonth', now)).toBe('2026-06-01')
-      expect(periodCutoffDayKey('allTime', now)).toBeNull()
-    })
-
-    it('formats UTC date keys', () => {
-      expect(utcDayKey(now)).toBe('2026-06-25')
-    })
   })
 
   it('thisWeek is the most recent Sunday, on or before today', () => {
@@ -93,16 +81,16 @@ describe('dailyCost', () => {
   })
 })
 
-describe('tasksDoneSeries', () => {
+describe('closedTasksSeries', () => {
   function taskPoint(date: string, count: number): TaskSeriesPoint {
     return { date, count } as TaskSeriesPoint
   }
 
   it('sorts ascending and fills zero-count days through end', () => {
-    const out = tasksDoneSeries(
+    const out = closedTasksSeries(
       [taskPoint('2026-06-24', 2), taskPoint('2026-06-22', 1)],
-      '2026-06-22',
-      '2026-06-24',
+      new Date(2026, 5, 22),
+      new Date(2026, 5, 24),
     )
     expect(out).toEqual([
       { date: '2026-06-22', value: 1 },
@@ -112,28 +100,28 @@ describe('tasksDoneSeries', () => {
   })
 
   it('filters by cutoff and returns empty when no points remain in range', () => {
-    expect(tasksDoneSeries([taskPoint('2026-06-20', 5)], '2026-06-23', '2026-06-24')).toEqual([])
+    expect(closedTasksSeries([taskPoint('2026-06-20', 5)], new Date(2026, 5, 23), new Date(2026, 5, 24))).toEqual([])
   })
 
   it('returns empty for nil or empty input', () => {
-    expect(tasksDoneSeries(null, null, '2026-06-24')).toEqual([])
-    expect(tasksDoneSeries([], null, '2026-06-24')).toEqual([])
+    expect(closedTasksSeries(null, null, new Date(2026, 5, 24))).toEqual([])
+    expect(closedTasksSeries([], null, new Date(2026, 5, 24))).toEqual([])
   })
 
-  it('parses YYYY-MM-DD using the backend UTC date-key contract', () => {
-    const out = tasksDoneSeries([taskPoint('2026-06-24', 1)], '2026-06-24', '2026-06-24')
+  it('parses YYYY-MM-DD keys as local dates', () => {
+    const out = closedTasksSeries([taskPoint('2026-06-24', 1)], new Date(2026, 5, 24), new Date(2026, 5, 24))
     expect(out).toEqual([{ date: '2026-06-24', value: 1 }])
   })
 
   it('skips invalid date keys', () => {
-    expect(tasksDoneSeries([taskPoint('2026-02-31', 1), taskPoint('bad', 2)], null, '2026-06-24')).toEqual([])
+    expect(closedTasksSeries([taskPoint('2026-02-31', 1), taskPoint('bad', 2)], null, new Date(2026, 5, 24))).toEqual([])
   })
 
   it('does not zero-fill all-time ranges past the chart cap', () => {
-    const out = tasksDoneSeries(
+    const out = closedTasksSeries(
       [taskPoint('2024-01-01', 1), taskPoint('2026-06-24', 2)],
       null,
-      '2026-06-24',
+      new Date(2026, 5, 24),
     )
     expect(out).toEqual([
       { date: '2024-01-01', value: 1 },
@@ -142,14 +130,14 @@ describe('tasksDoneSeries', () => {
   })
 
   it('caps dense all-time series while preserving endpoints', () => {
-    const first = new Date(Date.UTC(2026, 0, 1))
+    const first = new Date(2026, 0, 1)
     const points = Array.from({ length: MAX_TIME_SERIES_POINTS + 20 }, (_, i) => {
       const d = new Date(first)
-      d.setUTCDate(d.getUTCDate() + i)
-      return taskPoint(utcDayKey(d), 1)
+      d.setDate(d.getDate() + i)
+      return taskPoint(localDayKey(d), 1)
     })
-    const out = tasksDoneSeries(points, null)
-    const last = utcDayKey(new Date(Date.UTC(2026, 0, MAX_TIME_SERIES_POINTS + 20)))
+    const out = closedTasksSeries(points, null)
+    const last = localDayKey(new Date(2026, 0, MAX_TIME_SERIES_POINTS + 20))
     expect(out).toHaveLength(MAX_TIME_SERIES_POINTS)
     expect(out[0]).toEqual({ date: '2026-01-01', value: 1 })
     expect(out[out.length - 1]).toEqual({ date: last, value: 1 })

--- a/frontend/src/lib/stats-charts.test.ts
+++ b/frontend/src/lib/stats-charts.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { periodCutoff, dailyCost, costByProject } from './stats-charts.js'
-import type { RunRecord } from '../../bindings/github.com/Automaat/sybra/internal/stats/models.js'
+import { periodCutoff, dailyCost, costByProject, closedTasksSeries } from './stats-charts.js'
+import type { RunRecord, TaskSeriesPoint } from '../../bindings/github.com/Automaat/sybra/internal/stats/models.js'
 
 function run(timestamp: string, costUsd: number, projectId = ''): RunRecord {
   return { timestamp, costUsd, projectId } as unknown as RunRecord
@@ -68,6 +68,43 @@ describe('dailyCost', () => {
 
   it('returns empty (no fill) when there are no runs in range', () => {
     expect(dailyCost([], new Date(2026, 5, 22), new Date(2026, 5, 24))).toEqual([])
+  })
+})
+
+describe('closedTasksSeries', () => {
+  function taskPoint(date: string, count: number): TaskSeriesPoint {
+    return { date, count } as TaskSeriesPoint
+  }
+
+  it('sorts ascending and fills zero-count days through end', () => {
+    const out = closedTasksSeries(
+      [taskPoint('2026-06-24', 2), taskPoint('2026-06-22', 1)],
+      new Date(2026, 5, 22),
+      new Date(2026, 5, 24, 15),
+    )
+    expect(out).toEqual([
+      { date: '2026-06-22', value: 1 },
+      { date: '2026-06-23', value: 0 },
+      { date: '2026-06-24', value: 2 },
+    ])
+  })
+
+  it('filters by cutoff and returns empty when no points remain in range', () => {
+    expect(closedTasksSeries([taskPoint('2026-06-20', 5)], new Date(2026, 5, 23), new Date(2026, 5, 24))).toEqual([])
+  })
+
+  it('returns empty for nil or empty input', () => {
+    expect(closedTasksSeries(null, null, new Date(2026, 5, 24))).toEqual([])
+    expect(closedTasksSeries([], null, new Date(2026, 5, 24))).toEqual([])
+  })
+
+  it('parses YYYY-MM-DD as local dates instead of UTC dates', () => {
+    const out = closedTasksSeries([taskPoint('2026-06-24', 1)], new Date(2026, 5, 24), new Date(2026, 5, 24, 15))
+    expect(out).toEqual([{ date: '2026-06-24', value: 1 }])
+  })
+
+  it('skips invalid date keys', () => {
+    expect(closedTasksSeries([taskPoint('2026-02-31', 1), taskPoint('bad', 2)], null, new Date(2026, 5, 24))).toEqual([])
   })
 })
 

--- a/frontend/src/lib/stats-charts.test.ts
+++ b/frontend/src/lib/stats-charts.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from 'vitest'
-import { periodCutoff, dailyCost, costByProject, closedTasksSeries } from './stats-charts.js'
+import {
+  periodCutoff,
+  periodCutoffDayKey,
+  utcDayKey,
+  dailyCost,
+  costByProject,
+  tasksDoneSeries,
+  MAX_TIME_SERIES_POINTS,
+} from './stats-charts.js'
 import type { RunRecord, TaskSeriesPoint } from '../../bindings/github.com/Automaat/sybra/internal/stats/models.js'
 
 function run(timestamp: string, costUsd: number, projectId = ''): RunRecord {
@@ -12,6 +20,20 @@ describe('periodCutoff', () => {
 
   it('today is local midnight', () => {
     expect(periodCutoff('today', now)).toEqual(new Date(2026, 5, 24))
+  })
+
+  describe('periodCutoffDayKey', () => {
+    const now = new Date('2026-06-24T23:30:00-07:00')
+
+    it('uses UTC day boundaries for backend date keys', () => {
+      expect(periodCutoffDayKey('today', now)).toBe('2026-06-25')
+      expect(periodCutoffDayKey('thisMonth', now)).toBe('2026-06-01')
+      expect(periodCutoffDayKey('allTime', now)).toBeNull()
+    })
+
+    it('formats UTC date keys', () => {
+      expect(utcDayKey(now)).toBe('2026-06-25')
+    })
   })
 
   it('thisWeek is the most recent Sunday, on or before today', () => {
@@ -71,16 +93,16 @@ describe('dailyCost', () => {
   })
 })
 
-describe('closedTasksSeries', () => {
+describe('tasksDoneSeries', () => {
   function taskPoint(date: string, count: number): TaskSeriesPoint {
     return { date, count } as TaskSeriesPoint
   }
 
   it('sorts ascending and fills zero-count days through end', () => {
-    const out = closedTasksSeries(
+    const out = tasksDoneSeries(
       [taskPoint('2026-06-24', 2), taskPoint('2026-06-22', 1)],
-      new Date(2026, 5, 22),
-      new Date(2026, 5, 24, 15),
+      '2026-06-22',
+      '2026-06-24',
     )
     expect(out).toEqual([
       { date: '2026-06-22', value: 1 },
@@ -90,21 +112,47 @@ describe('closedTasksSeries', () => {
   })
 
   it('filters by cutoff and returns empty when no points remain in range', () => {
-    expect(closedTasksSeries([taskPoint('2026-06-20', 5)], new Date(2026, 5, 23), new Date(2026, 5, 24))).toEqual([])
+    expect(tasksDoneSeries([taskPoint('2026-06-20', 5)], '2026-06-23', '2026-06-24')).toEqual([])
   })
 
   it('returns empty for nil or empty input', () => {
-    expect(closedTasksSeries(null, null, new Date(2026, 5, 24))).toEqual([])
-    expect(closedTasksSeries([], null, new Date(2026, 5, 24))).toEqual([])
+    expect(tasksDoneSeries(null, null, '2026-06-24')).toEqual([])
+    expect(tasksDoneSeries([], null, '2026-06-24')).toEqual([])
   })
 
-  it('parses YYYY-MM-DD as local dates instead of UTC dates', () => {
-    const out = closedTasksSeries([taskPoint('2026-06-24', 1)], new Date(2026, 5, 24), new Date(2026, 5, 24, 15))
+  it('parses YYYY-MM-DD using the backend UTC date-key contract', () => {
+    const out = tasksDoneSeries([taskPoint('2026-06-24', 1)], '2026-06-24', '2026-06-24')
     expect(out).toEqual([{ date: '2026-06-24', value: 1 }])
   })
 
   it('skips invalid date keys', () => {
-    expect(closedTasksSeries([taskPoint('2026-02-31', 1), taskPoint('bad', 2)], null, new Date(2026, 5, 24))).toEqual([])
+    expect(tasksDoneSeries([taskPoint('2026-02-31', 1), taskPoint('bad', 2)], null, '2026-06-24')).toEqual([])
+  })
+
+  it('does not zero-fill all-time ranges past the chart cap', () => {
+    const out = tasksDoneSeries(
+      [taskPoint('2024-01-01', 1), taskPoint('2026-06-24', 2)],
+      null,
+      '2026-06-24',
+    )
+    expect(out).toEqual([
+      { date: '2024-01-01', value: 1 },
+      { date: '2026-06-24', value: 2 },
+    ])
+  })
+
+  it('caps dense all-time series while preserving endpoints', () => {
+    const first = new Date(Date.UTC(2026, 0, 1))
+    const points = Array.from({ length: MAX_TIME_SERIES_POINTS + 20 }, (_, i) => {
+      const d = new Date(first)
+      d.setUTCDate(d.getUTCDate() + i)
+      return taskPoint(utcDayKey(d), 1)
+    })
+    const out = tasksDoneSeries(points, null)
+    const last = utcDayKey(new Date(Date.UTC(2026, 0, MAX_TIME_SERIES_POINTS + 20)))
+    expect(out).toHaveLength(MAX_TIME_SERIES_POINTS)
+    expect(out[0]).toEqual({ date: '2026-01-01', value: 1 })
+    expect(out[out.length - 1]).toEqual({ date: last, value: 1 })
   })
 })
 

--- a/frontend/src/lib/stats-charts.ts
+++ b/frontend/src/lib/stats-charts.ts
@@ -1,4 +1,4 @@
-import type { RunRecord } from '../../bindings/github.com/Automaat/sybra/internal/stats/models.js'
+import type { RunRecord, TaskSeriesPoint } from '../../bindings/github.com/Automaat/sybra/internal/stats/models.js'
 
 export type StatsPeriod = 'today' | 'thisWeek' | 'thisMonth' | 'allTime'
 
@@ -40,8 +40,23 @@ export interface DailyCost {
   cost: number
 }
 
+export interface TimeSeriesPoint {
+  date: string
+  value: number
+}
+
 function dayKey(d: Date): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+}
+
+function parseDayKey(key: string): Date | null {
+  const parts = key.split('-')
+  if (parts.length !== 3) return null
+  const [year, month, day] = parts.map((p) => Number(p))
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return null
+  const d = new Date(year, month - 1, day)
+  if (d.getFullYear() !== year || d.getMonth() !== month - 1 || d.getDate() !== day) return null
+  return d
 }
 
 /**
@@ -75,6 +90,43 @@ export function dailyCost(runs: RunRecord[], cutoff: Date | null, end?: Date): D
   while (cursor <= last) {
     const key = dayKey(cursor)
     out.push({ date: key, cost: buckets.get(key) ?? 0 })
+    cursor.setDate(cursor.getDate() + 1)
+  }
+  return out
+}
+
+export function closedTasksSeries(
+  points: TaskSeriesPoint[] | null | undefined,
+  cutoff: Date | null,
+  end?: Date,
+): TimeSeriesPoint[] {
+  if (!points || points.length === 0) return []
+
+  const buckets = new Map<string, number>()
+  let earliest: Date | null = null
+  for (const p of points) {
+    const day = parseDayKey(p.date)
+    if (!day) continue
+    if (cutoff && day < cutoff) continue
+    const key = dayKey(day)
+    buckets.set(key, (buckets.get(key) ?? 0) + (p.count ?? 0))
+    if (!earliest || day < earliest) earliest = day
+  }
+
+  if (!end) {
+    return [...buckets.entries()]
+      .map(([date, value]) => ({ date, value }))
+      .sort((a, b) => a.date.localeCompare(b.date))
+  }
+
+  if (buckets.size === 0) return []
+  const startSrc = cutoff ?? earliest ?? end
+  const out: TimeSeriesPoint[] = []
+  const cursor = new Date(startSrc.getFullYear(), startSrc.getMonth(), startSrc.getDate())
+  const last = new Date(end.getFullYear(), end.getMonth(), end.getDate())
+  while (cursor <= last) {
+    const key = dayKey(cursor)
+    out.push({ date: key, value: buckets.get(key) ?? 0 })
     cursor.setDate(cursor.getDate() + 1)
   }
   return out

--- a/frontend/src/lib/stats-charts.ts
+++ b/frontend/src/lib/stats-charts.ts
@@ -51,40 +51,19 @@ function dayKey(d: Date): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
 }
 
-export function utcDayKey(d: Date): string {
-  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`
-}
-
-function parseUTCDayKey(key: string): Date | null {
+function parseLocalDayKey(key: string): Date | null {
   const parts = key.split('-')
   if (parts.length !== 3) return null
   const [year, month, day] = parts.map((p) => Number(p))
   if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return null
-  const d = new Date(Date.UTC(year, month - 1, day))
-  if (d.getUTCFullYear() !== year || d.getUTCMonth() !== month - 1 || d.getUTCDate() !== day) return null
+  const d = new Date(year, month - 1, day)
+  if (d.getFullYear() !== year || d.getMonth() !== month - 1 || d.getDate() !== day) return null
   return d
 }
 
-export function periodCutoffDayKey(period: StatsPeriod, now: Date): string | null {
-  const todayStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
-  switch (period) {
-    case 'today':
-      return utcDayKey(todayStart)
-    case 'thisWeek': {
-      const d = new Date(todayStart)
-      d.setUTCDate(d.getUTCDate() - todayStart.getUTCDay())
-      return utcDayKey(d)
-    }
-    case 'thisMonth':
-      return utcDayKey(new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)))
-    default:
-      return null
-  }
-}
-
-function utcDaySpan(startKey: string, endKey: string): number {
-  const start = parseUTCDayKey(startKey)
-  const end = parseUTCDayKey(endKey)
+function localDaySpan(startKey: string, endKey: string): number {
+  const start = parseLocalDayKey(startKey)
+  const end = parseLocalDayKey(endKey)
   if (!start || !end) return 0
   return Math.floor((end.getTime() - start.getTime()) / 86_400_000) + 1
 }
@@ -140,21 +119,20 @@ export function dailyCost(runs: RunRecord[], cutoff: Date | null, end?: Date): D
   return out
 }
 
-export function tasksDoneSeries(
+export function closedTasksSeries(
   points: TaskSeriesPoint[] | null | undefined,
-  cutoffKey: string | null,
-  endKey?: string,
+  cutoff: Date | null,
+  end?: Date,
 ): TimeSeriesPoint[] {
   if (!points || points.length === 0) return []
 
   const buckets = new Map<string, number>()
-  const cutoffDay = cutoffKey ? parseUTCDayKey(cutoffKey) : null
-  const cutoff = cutoffDay ? utcDayKey(cutoffDay) : null
+  const cutoffKey = cutoff ? dayKey(cutoff) : null
   for (const p of points) {
-    const day = parseUTCDayKey(p.date)
+    const day = parseLocalDayKey(p.date)
     if (!day) continue
-    const key = utcDayKey(day)
-    if (cutoff && key < cutoff) continue
+    const key = dayKey(day)
+    if (cutoffKey && key < cutoffKey) continue
     buckets.set(key, (buckets.get(key) ?? 0) + (p.count ?? 0))
   }
 
@@ -162,26 +140,24 @@ export function tasksDoneSeries(
     .map(([date, value]) => ({ date, value }))
     .sort((a, b) => a.date.localeCompare(b.date))
 
-  if (!endKey) return capTimeSeries(entries)
+  if (!end) return capTimeSeries(entries)
 
   if (buckets.size === 0) return []
-  const end = parseUTCDayKey(endKey)
-  if (!end) return capTimeSeries(entries)
-  const normalizedEndKey = utcDayKey(end)
-  const startKey = cutoff ?? entries[0].date
+  const normalizedEndKey = dayKey(end)
+  const startKey = cutoffKey ?? entries[0].date
   if (startKey > normalizedEndKey) return []
-  if (!cutoff && utcDaySpan(startKey, normalizedEndKey) > MAX_TIME_SERIES_POINTS) {
+  if (!cutoffKey && localDaySpan(startKey, normalizedEndKey) > MAX_TIME_SERIES_POINTS) {
     return capTimeSeries(entries)
   }
 
   const out: TimeSeriesPoint[] = []
-  const cursor = parseUTCDayKey(startKey)
-  const last = parseUTCDayKey(normalizedEndKey)
+  const cursor = parseLocalDayKey(startKey)
+  const last = parseLocalDayKey(normalizedEndKey)
   if (!cursor || !last) return capTimeSeries(entries)
   while (cursor <= last) {
-    const key = utcDayKey(cursor)
+    const key = dayKey(cursor)
     out.push({ date: key, value: buckets.get(key) ?? 0 })
-    cursor.setUTCDate(cursor.getUTCDate() + 1)
+    cursor.setDate(cursor.getDate() + 1)
   }
   return capTimeSeries(out)
 }

--- a/frontend/src/lib/stats-charts.ts
+++ b/frontend/src/lib/stats-charts.ts
@@ -65,7 +65,9 @@ function localDaySpan(startKey: string, endKey: string): number {
   const start = parseLocalDayKey(startKey)
   const end = parseLocalDayKey(endKey)
   if (!start || !end) return 0
-  return Math.floor((end.getTime() - start.getTime()) / 86_400_000) + 1
+  const startUTC = Date.UTC(start.getFullYear(), start.getMonth(), start.getDate())
+  const endUTC = Date.UTC(end.getFullYear(), end.getMonth(), end.getDate())
+  return Math.floor((endUTC - startUTC) / 86_400_000) + 1
 }
 
 function capTimeSeries(points: TimeSeriesPoint[], maxPoints = MAX_TIME_SERIES_POINTS): TimeSeriesPoint[] {

--- a/frontend/src/lib/stats-charts.ts
+++ b/frontend/src/lib/stats-charts.ts
@@ -45,18 +45,63 @@ export interface TimeSeriesPoint {
   value: number
 }
 
+export const MAX_TIME_SERIES_POINTS = 366
+
 function dayKey(d: Date): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
 }
 
-function parseDayKey(key: string): Date | null {
+export function utcDayKey(d: Date): string {
+  return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`
+}
+
+function parseUTCDayKey(key: string): Date | null {
   const parts = key.split('-')
   if (parts.length !== 3) return null
   const [year, month, day] = parts.map((p) => Number(p))
   if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) return null
-  const d = new Date(year, month - 1, day)
-  if (d.getFullYear() !== year || d.getMonth() !== month - 1 || d.getDate() !== day) return null
+  const d = new Date(Date.UTC(year, month - 1, day))
+  if (d.getUTCFullYear() !== year || d.getUTCMonth() !== month - 1 || d.getUTCDate() !== day) return null
   return d
+}
+
+export function periodCutoffDayKey(period: StatsPeriod, now: Date): string | null {
+  const todayStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
+  switch (period) {
+    case 'today':
+      return utcDayKey(todayStart)
+    case 'thisWeek': {
+      const d = new Date(todayStart)
+      d.setUTCDate(d.getUTCDate() - todayStart.getUTCDay())
+      return utcDayKey(d)
+    }
+    case 'thisMonth':
+      return utcDayKey(new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)))
+    default:
+      return null
+  }
+}
+
+function utcDaySpan(startKey: string, endKey: string): number {
+  const start = parseUTCDayKey(startKey)
+  const end = parseUTCDayKey(endKey)
+  if (!start || !end) return 0
+  return Math.floor((end.getTime() - start.getTime()) / 86_400_000) + 1
+}
+
+function capTimeSeries(points: TimeSeriesPoint[], maxPoints = MAX_TIME_SERIES_POINTS): TimeSeriesPoint[] {
+  if (points.length <= maxPoints) return points
+  const out: TimeSeriesPoint[] = []
+  const lastIndex = points.length - 1
+  let prevIndex = -1
+  for (let i = 0; i < maxPoints; i += 1) {
+    const index = Math.round((i * lastIndex) / (maxPoints - 1))
+    if (index !== prevIndex) {
+      out.push(points[index])
+      prevIndex = index
+    }
+  }
+  return out
 }
 
 /**
@@ -95,41 +140,50 @@ export function dailyCost(runs: RunRecord[], cutoff: Date | null, end?: Date): D
   return out
 }
 
-export function closedTasksSeries(
+export function tasksDoneSeries(
   points: TaskSeriesPoint[] | null | undefined,
-  cutoff: Date | null,
-  end?: Date,
+  cutoffKey: string | null,
+  endKey?: string,
 ): TimeSeriesPoint[] {
   if (!points || points.length === 0) return []
 
   const buckets = new Map<string, number>()
-  let earliest: Date | null = null
+  const cutoffDay = cutoffKey ? parseUTCDayKey(cutoffKey) : null
+  const cutoff = cutoffDay ? utcDayKey(cutoffDay) : null
   for (const p of points) {
-    const day = parseDayKey(p.date)
+    const day = parseUTCDayKey(p.date)
     if (!day) continue
-    if (cutoff && day < cutoff) continue
-    const key = dayKey(day)
+    const key = utcDayKey(day)
+    if (cutoff && key < cutoff) continue
     buckets.set(key, (buckets.get(key) ?? 0) + (p.count ?? 0))
-    if (!earliest || day < earliest) earliest = day
   }
 
-  if (!end) {
-    return [...buckets.entries()]
-      .map(([date, value]) => ({ date, value }))
-      .sort((a, b) => a.date.localeCompare(b.date))
-  }
+  const entries = [...buckets.entries()]
+    .map(([date, value]) => ({ date, value }))
+    .sort((a, b) => a.date.localeCompare(b.date))
+
+  if (!endKey) return capTimeSeries(entries)
 
   if (buckets.size === 0) return []
-  const startSrc = cutoff ?? earliest ?? end
-  const out: TimeSeriesPoint[] = []
-  const cursor = new Date(startSrc.getFullYear(), startSrc.getMonth(), startSrc.getDate())
-  const last = new Date(end.getFullYear(), end.getMonth(), end.getDate())
-  while (cursor <= last) {
-    const key = dayKey(cursor)
-    out.push({ date: key, value: buckets.get(key) ?? 0 })
-    cursor.setDate(cursor.getDate() + 1)
+  const end = parseUTCDayKey(endKey)
+  if (!end) return capTimeSeries(entries)
+  const normalizedEndKey = utcDayKey(end)
+  const startKey = cutoff ?? entries[0].date
+  if (startKey > normalizedEndKey) return []
+  if (!cutoff && utcDaySpan(startKey, normalizedEndKey) > MAX_TIME_SERIES_POINTS) {
+    return capTimeSeries(entries)
   }
-  return out
+
+  const out: TimeSeriesPoint[] = []
+  const cursor = parseUTCDayKey(startKey)
+  const last = parseUTCDayKey(normalizedEndKey)
+  if (!cursor || !last) return capTimeSeries(entries)
+  while (cursor <= last) {
+    const key = utcDayKey(cursor)
+    out.push({ date: key, value: buckets.get(key) ?? 0 })
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  }
+  return capTimeSeries(out)
 }
 
 export interface ProjectCost {

--- a/frontend/src/pages/Stats.svelte
+++ b/frontend/src/pages/Stats.svelte
@@ -2,19 +2,19 @@
   import { statsStore } from '../stores/stats.svelte.js'
   import {
     periodCutoff,
+    periodCutoffDayKey,
+    utcDayKey,
     dailyCost,
     costByProject,
-    closedTasksSeries,
+    tasksDoneSeries,
     type StatsPeriod,
   } from '$lib/stats-charts.js'
   import StatsLineChart from '../components/stats/StatsLineChart.svelte'
   import StatsBarChart from '../components/stats/StatsBarChart.svelte'
 
   type Period = StatsPeriod
-
   let period = $state<Period>('allTime')
-  // Captured once so the period cutoffs don't recompute on every clock tick.
-  const now = new Date()
+  let now = $state(new Date())
 
   const periods: { key: Period; label: string }[] = [
     { key: 'today', label: 'Today' },
@@ -38,13 +38,19 @@
   // The backend only caps recentRuns once there are MORE than 50 total runs.
   const sampleCapped = $derived((statsStore.data?.allTime?.totalRuns ?? 0) > 50)
   const cutoff = $derived(periodCutoff(period, now))
+  const taskCutoff = $derived(periodCutoffDayKey(period, now))
   const costSeries = $derived(dailyCost(recentRuns, cutoff, now).map((p) => ({ date: p.date, value: p.cost })))
-  const taskSeries = $derived(closedTasksSeries(statsStore.data?.closedTasksDaily ?? [], cutoff, now))
+  const taskSeries = $derived(tasksDoneSeries(statsStore.data?.tasksDoneDaily ?? [], taskCutoff, utcDayKey(now)))
   const projectCosts = $derived(costByProject(recentRuns, cutoff))
 
   $effect(() => {
-    statsStore.load()
+    void refreshStats()
   })
+
+  async function refreshStats(): Promise<void> {
+    now = new Date()
+    await statsStore.load()
+  }
 
   function formatDuration(seconds: number): string {
     if (seconds < 60) return `${seconds.toFixed(0)}s`
@@ -116,7 +122,7 @@
     <button
       type="button"
       class="rounded-lg bg-surface-200 px-3 py-1.5 text-sm font-medium hover:bg-surface-300 dark:bg-surface-700 dark:hover:bg-surface-600"
-      onclick={() => statsStore.load()}
+      onclick={refreshStats}
     >
       Refresh
     </button>
@@ -258,10 +264,10 @@
       </div>
       <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
         <div class="mb-3 flex items-baseline justify-between gap-2">
-          <h3 class="text-sm font-semibold text-surface-500">Closed tasks over time</h3>
+          <h3 class="text-sm font-semibold text-surface-500">Tasks done over time</h3>
           <span class="text-[10px] text-surface-400">{periodLabel}</span>
         </div>
-        <StatsLineChart points={taskSeries} ariaLabel="Closed tasks over time" emptyLabel="No closed tasks in this range" />
+        <StatsLineChart points={taskSeries} ariaLabel="Tasks done over time" emptyLabel="No tasks done in this range" />
       </div>
     </div>
   {/if}

--- a/frontend/src/pages/Stats.svelte
+++ b/frontend/src/pages/Stats.svelte
@@ -1,6 +1,12 @@
 <script lang="ts">
   import { statsStore } from '../stores/stats.svelte.js'
-  import { periodCutoff, dailyCost, costByProject, type StatsPeriod } from '$lib/stats-charts.js'
+  import {
+    periodCutoff,
+    dailyCost,
+    costByProject,
+    closedTasksSeries,
+    type StatsPeriod,
+  } from '$lib/stats-charts.js'
   import StatsLineChart from '../components/stats/StatsLineChart.svelte'
   import StatsBarChart from '../components/stats/StatsBarChart.svelte'
 
@@ -32,7 +38,8 @@
   // The backend only caps recentRuns once there are MORE than 50 total runs.
   const sampleCapped = $derived((statsStore.data?.allTime?.totalRuns ?? 0) > 50)
   const cutoff = $derived(periodCutoff(period, now))
-  const costSeries = $derived(dailyCost(recentRuns, cutoff, now))
+  const costSeries = $derived(dailyCost(recentRuns, cutoff, now).map((p) => ({ date: p.date, value: p.cost })))
+  const taskSeries = $derived(closedTasksSeries(statsStore.data?.closedTasksDaily ?? [], cutoff, now))
   const projectCosts = $derived(costByProject(recentRuns, cutoff))
 
   $effect(() => {
@@ -240,7 +247,7 @@
           <h3 class="text-sm font-semibold text-surface-500">Cost over time</h3>
           <span class="text-[10px] text-surface-400">{periodLabel}{#if sampleCapped} · recent 50 runs{/if}</span>
         </div>
-        <StatsLineChart points={costSeries} />
+        <StatsLineChart points={costSeries} ariaLabel="Cost over time" emptyLabel="No cost in this range" />
       </div>
       <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
         <div class="mb-3 flex items-baseline justify-between gap-2">
@@ -248,6 +255,13 @@
           <span class="text-[10px] text-surface-400">{periodLabel}{#if sampleCapped} · recent 50 runs{/if}</span>
         </div>
         <StatsBarChart bars={projectCosts} />
+      </div>
+      <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <div class="mb-3 flex items-baseline justify-between gap-2">
+          <h3 class="text-sm font-semibold text-surface-500">Closed tasks over time</h3>
+          <span class="text-[10px] text-surface-400">{periodLabel}</span>
+        </div>
+        <StatsLineChart points={taskSeries} ariaLabel="Closed tasks over time" emptyLabel="No closed tasks in this range" />
       </div>
     </div>
   {/if}

--- a/frontend/src/pages/Stats.svelte
+++ b/frontend/src/pages/Stats.svelte
@@ -2,11 +2,9 @@
   import { statsStore } from '../stores/stats.svelte.js'
   import {
     periodCutoff,
-    periodCutoffDayKey,
-    utcDayKey,
     dailyCost,
     costByProject,
-    tasksDoneSeries,
+    closedTasksSeries,
     type StatsPeriod,
   } from '$lib/stats-charts.js'
   import StatsLineChart from '../components/stats/StatsLineChart.svelte'
@@ -38,9 +36,8 @@
   // The backend only caps recentRuns once there are MORE than 50 total runs.
   const sampleCapped = $derived((statsStore.data?.allTime?.totalRuns ?? 0) > 50)
   const cutoff = $derived(periodCutoff(period, now))
-  const taskCutoff = $derived(periodCutoffDayKey(period, now))
   const costSeries = $derived(dailyCost(recentRuns, cutoff, now).map((p) => ({ date: p.date, value: p.cost })))
-  const taskSeries = $derived(tasksDoneSeries(statsStore.data?.tasksDoneDaily ?? [], taskCutoff, utcDayKey(now)))
+  const taskSeries = $derived(closedTasksSeries(statsStore.data?.closedTasksDaily ?? [], cutoff, now))
   const projectCosts = $derived(costByProject(recentRuns, cutoff))
 
   $effect(() => {
@@ -264,10 +261,10 @@
       </div>
       <div class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
         <div class="mb-3 flex items-baseline justify-between gap-2">
-          <h3 class="text-sm font-semibold text-surface-500">Tasks done over time</h3>
+          <h3 class="text-sm font-semibold text-surface-500">Closed tasks over time</h3>
           <span class="text-[10px] text-surface-400">{periodLabel}</span>
         </div>
-        <StatsLineChart points={taskSeries} ariaLabel="Tasks done over time" emptyLabel="No tasks done in this range" />
+        <StatsLineChart points={taskSeries} ariaLabel="Closed tasks over time" emptyLabel="No closed tasks in this range" />
       </div>
     </div>
   {/if}

--- a/frontend/src/pages/Stats.svelte.test.ts
+++ b/frontend/src/pages/Stats.svelte.test.ts
@@ -56,6 +56,7 @@ describe('Stats', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     cleanup()
   })
 
@@ -298,6 +299,8 @@ describe('Stats', () => {
   })
 
   it('renders cost-over-time and cost-by-project charts', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-03T12:00:00Z'))
     const s = makeSummary()
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
@@ -330,6 +333,8 @@ describe('Stats', () => {
   })
 
   it('closed-task chart follows period switching', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-03T12:00:00Z'))
     const s = makeSummary()
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
@@ -340,9 +345,7 @@ describe('Stats', () => {
     render(Stats, { props: {} })
     expect(screen.getByRole('img', { name: 'Closed tasks over time' })).toBeDefined()
     await fireEvent.click(screen.getByText('Today'))
-    await vi.waitFor(() => {
-      expect(screen.getByText('No closed tasks in this range')).toBeDefined()
-    })
+    expect(screen.getByText('No closed tasks in this range')).toBeDefined()
   })
 
   it('flags the sample cap on the charts when there are more than 50 runs', () => {

--- a/frontend/src/pages/Stats.svelte.test.ts
+++ b/frontend/src/pages/Stats.svelte.test.ts
@@ -42,7 +42,7 @@ function makeStatsData(): StatsResponse {
     byRole: [],
     byMode: [],
     byModel: [],
-    tasksDoneDaily: [],
+    closedTasksDaily: [],
     recentRuns: [],
   })
 }
@@ -156,7 +156,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      tasksDoneDaily: [],
+      closedTasksDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -168,7 +168,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      tasksDoneDaily: [],
+      closedTasksDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -180,7 +180,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      tasksDoneDaily: [],
+      closedTasksDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -192,7 +192,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      tasksDoneDaily: [],
+      closedTasksDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -204,7 +204,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      tasksDoneDaily: [],
+      closedTasksDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -217,7 +217,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today, thisWeek: allTime, thisMonth: allTime, allTime,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      tasksDoneDaily: [],
+      closedTasksDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -247,7 +247,7 @@ describe('Stats', () => {
       ],
       byMode: [],
       byModel: [],
-      tasksDoneDaily: [],
+      closedTasksDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -260,7 +260,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      tasksDoneDaily: [],
+      closedTasksDaily: [],
       recentRuns: [
         {
           id: 'r1',
@@ -302,7 +302,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      tasksDoneDaily: [
+      closedTasksDaily: [
         { date: '2026-05-01', count: 1 },
         { date: '2026-05-02', count: 2 },
       ],
@@ -314,9 +314,9 @@ describe('Stats', () => {
     render(Stats, { props: {} })
     expect(screen.getByText('Cost over time')).toBeDefined()
     expect(screen.getByText('Cost by project')).toBeDefined()
-    expect(screen.getByText('Tasks done over time')).toBeDefined()
+    expect(screen.getByText('Closed tasks over time')).toBeDefined()
     expect(screen.getByRole('img', { name: 'Cost over time' })).toBeDefined()
-    expect(screen.getByRole('img', { name: 'Tasks done over time' })).toBeDefined()
+    expect(screen.getByRole('img', { name: 'Closed tasks over time' })).toBeDefined()
     // Bar chart renders both project labels (default period is All Time).
     expect(screen.getByText('org/repo')).toBeDefined()
     expect(screen.getByText('org/other')).toBeDefined()
@@ -326,22 +326,22 @@ describe('Stats', () => {
     mockStatsStore.data = makeStatsData()
     render(Stats, { props: {} })
     expect(screen.getAllByText('No cost in this range').length).toBeGreaterThan(0)
-    expect(screen.getByText('No tasks done in this range')).toBeDefined()
+    expect(screen.getByText('No closed tasks in this range')).toBeDefined()
   })
 
-  it('tasks-done chart follows period switching', async () => {
+  it('closed-task chart follows period switching', async () => {
     const s = makeSummary()
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      tasksDoneDaily: [{ date: '2026-05-01', count: 1 }],
+      closedTasksDaily: [{ date: '2026-05-01', count: 1 }],
       recentRuns: [],
     })
     render(Stats, { props: {} })
-    expect(screen.getByRole('img', { name: 'Tasks done over time' })).toBeDefined()
+    expect(screen.getByRole('img', { name: 'Closed tasks over time' })).toBeDefined()
     await fireEvent.click(screen.getByText('Today'))
     await vi.waitFor(() => {
-      expect(screen.getByText('No tasks done in this range')).toBeDefined()
+      expect(screen.getByText('No closed tasks in this range')).toBeDefined()
     })
   })
 
@@ -356,7 +356,7 @@ describe('Stats', () => {
       // The backend caps recentRuns only when total runs exceeds 50.
       today: s, thisWeek: s, thisMonth: s, allTime: makeSummary({ totalRuns: 60 }),
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      tasksDoneDaily: [{ date: '2026-05-01', count: 1 }],
+      closedTasksDaily: [{ date: '2026-05-01', count: 1 }],
       recentRuns: runs,
     })
     render(Stats, { props: {} })
@@ -368,7 +368,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      tasksDoneDaily: [],
+      closedTasksDaily: [],
       recentRuns: [
         {
           id: 'r1',

--- a/frontend/src/pages/Stats.svelte.test.ts
+++ b/frontend/src/pages/Stats.svelte.test.ts
@@ -42,6 +42,7 @@ function makeStatsData(): StatsResponse {
     byRole: [],
     byMode: [],
     byModel: [],
+    closedTasksDaily: [],
     recentRuns: [],
   })
 }
@@ -155,6 +156,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      closedTasksDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -166,6 +168,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      closedTasksDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -177,6 +180,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      closedTasksDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -188,6 +192,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      closedTasksDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -199,6 +204,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      closedTasksDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -211,6 +217,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today, thisWeek: allTime, thisMonth: allTime, allTime,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      closedTasksDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -240,6 +247,7 @@ describe('Stats', () => {
       ],
       byMode: [],
       byModel: [],
+      closedTasksDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -252,6 +260,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      closedTasksDaily: [],
       recentRuns: [
         {
           id: 'r1',
@@ -293,6 +302,10 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      closedTasksDaily: [
+        { date: '2026-05-01', count: 1 },
+        { date: '2026-05-02', count: 2 },
+      ],
       recentRuns: [
         { id: 'r1', taskId: 't1', projectId: 'org/repo', role: 'plan', mode: 'headless', model: 'm', costUsd: 1.5, durationS: 1, reasoningTokens: 0, timestamp: '2026-05-01T10:00:00Z', outcome: 'completed' },
         { id: 'r2', taskId: 't2', projectId: 'org/other', role: 'plan', mode: 'headless', model: 'm', costUsd: 0.5, durationS: 1, reasoningTokens: 0, timestamp: '2026-05-01T11:00:00Z', outcome: 'completed' },
@@ -301,9 +314,35 @@ describe('Stats', () => {
     render(Stats, { props: {} })
     expect(screen.getByText('Cost over time')).toBeDefined()
     expect(screen.getByText('Cost by project')).toBeDefined()
+    expect(screen.getByText('Closed tasks over time')).toBeDefined()
+    expect(screen.getByRole('img', { name: 'Cost over time' })).toBeDefined()
+    expect(screen.getByRole('img', { name: 'Closed tasks over time' })).toBeDefined()
     // Bar chart renders both project labels (default period is All Time).
     expect(screen.getByText('org/repo')).toBeDefined()
     expect(screen.getByText('org/other')).toBeDefined()
+  })
+
+  it('uses task-specific empty labels', () => {
+    mockStatsStore.data = makeStatsData()
+    render(Stats, { props: {} })
+    expect(screen.getAllByText('No cost in this range').length).toBeGreaterThan(0)
+    expect(screen.getByText('No closed tasks in this range')).toBeDefined()
+  })
+
+  it('closed-task chart follows period switching', async () => {
+    const s = makeSummary()
+    mockStatsStore.data = StatsResponse.createFrom({
+      today: s, thisWeek: s, thisMonth: s, allTime: s,
+      byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      closedTasksDaily: [{ date: '2026-05-01', count: 1 }],
+      recentRuns: [],
+    })
+    render(Stats, { props: {} })
+    expect(screen.getByRole('img', { name: 'Closed tasks over time' })).toBeDefined()
+    await fireEvent.click(screen.getByText('Today'))
+    await vi.waitFor(() => {
+      expect(screen.getByText('No closed tasks in this range')).toBeDefined()
+    })
   })
 
   it('flags the sample cap on the charts when there are more than 50 runs', () => {
@@ -317,11 +356,11 @@ describe('Stats', () => {
       // The backend caps recentRuns only when total runs exceeds 50.
       today: s, thisWeek: s, thisMonth: s, allTime: makeSummary({ totalRuns: 60 }),
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      closedTasksDaily: [{ date: '2026-05-01', count: 1 }],
       recentRuns: runs,
     })
     render(Stats, { props: {} })
-    // Both chart captions disclose the cap so the numbers aren't read as authoritative.
-    expect(screen.getAllByText(/recent 50 runs/).length).toBeGreaterThanOrEqual(2)
+    expect(screen.getAllByText(/recent 50 runs/)).toHaveLength(2)
   })
 
   it('shows dash for missing model in recent runs', () => {
@@ -329,6 +368,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
+      closedTasksDaily: [],
       recentRuns: [
         {
           id: 'r1',

--- a/frontend/src/pages/Stats.svelte.test.ts
+++ b/frontend/src/pages/Stats.svelte.test.ts
@@ -42,7 +42,7 @@ function makeStatsData(): StatsResponse {
     byRole: [],
     byMode: [],
     byModel: [],
-    closedTasksDaily: [],
+    tasksDoneDaily: [],
     recentRuns: [],
   })
 }
@@ -156,7 +156,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      closedTasksDaily: [],
+      tasksDoneDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -168,7 +168,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      closedTasksDaily: [],
+      tasksDoneDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -180,7 +180,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      closedTasksDaily: [],
+      tasksDoneDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -192,7 +192,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      closedTasksDaily: [],
+      tasksDoneDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -204,7 +204,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      closedTasksDaily: [],
+      tasksDoneDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -217,7 +217,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today, thisWeek: allTime, thisMonth: allTime, allTime,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      closedTasksDaily: [],
+      tasksDoneDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -247,7 +247,7 @@ describe('Stats', () => {
       ],
       byMode: [],
       byModel: [],
-      closedTasksDaily: [],
+      tasksDoneDaily: [],
       recentRuns: [],
     })
     render(Stats, { props: {} })
@@ -260,7 +260,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      closedTasksDaily: [],
+      tasksDoneDaily: [],
       recentRuns: [
         {
           id: 'r1',
@@ -302,7 +302,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      closedTasksDaily: [
+      tasksDoneDaily: [
         { date: '2026-05-01', count: 1 },
         { date: '2026-05-02', count: 2 },
       ],
@@ -314,9 +314,9 @@ describe('Stats', () => {
     render(Stats, { props: {} })
     expect(screen.getByText('Cost over time')).toBeDefined()
     expect(screen.getByText('Cost by project')).toBeDefined()
-    expect(screen.getByText('Closed tasks over time')).toBeDefined()
+    expect(screen.getByText('Tasks done over time')).toBeDefined()
     expect(screen.getByRole('img', { name: 'Cost over time' })).toBeDefined()
-    expect(screen.getByRole('img', { name: 'Closed tasks over time' })).toBeDefined()
+    expect(screen.getByRole('img', { name: 'Tasks done over time' })).toBeDefined()
     // Bar chart renders both project labels (default period is All Time).
     expect(screen.getByText('org/repo')).toBeDefined()
     expect(screen.getByText('org/other')).toBeDefined()
@@ -326,22 +326,22 @@ describe('Stats', () => {
     mockStatsStore.data = makeStatsData()
     render(Stats, { props: {} })
     expect(screen.getAllByText('No cost in this range').length).toBeGreaterThan(0)
-    expect(screen.getByText('No closed tasks in this range')).toBeDefined()
+    expect(screen.getByText('No tasks done in this range')).toBeDefined()
   })
 
-  it('closed-task chart follows period switching', async () => {
+  it('tasks-done chart follows period switching', async () => {
     const s = makeSummary()
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      closedTasksDaily: [{ date: '2026-05-01', count: 1 }],
+      tasksDoneDaily: [{ date: '2026-05-01', count: 1 }],
       recentRuns: [],
     })
     render(Stats, { props: {} })
-    expect(screen.getByRole('img', { name: 'Closed tasks over time' })).toBeDefined()
+    expect(screen.getByRole('img', { name: 'Tasks done over time' })).toBeDefined()
     await fireEvent.click(screen.getByText('Today'))
     await vi.waitFor(() => {
-      expect(screen.getByText('No closed tasks in this range')).toBeDefined()
+      expect(screen.getByText('No tasks done in this range')).toBeDefined()
     })
   })
 
@@ -356,7 +356,7 @@ describe('Stats', () => {
       // The backend caps recentRuns only when total runs exceeds 50.
       today: s, thisWeek: s, thisMonth: s, allTime: makeSummary({ totalRuns: 60 }),
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      closedTasksDaily: [{ date: '2026-05-01', count: 1 }],
+      tasksDoneDaily: [{ date: '2026-05-01', count: 1 }],
       recentRuns: runs,
     })
     render(Stats, { props: {} })
@@ -368,7 +368,7 @@ describe('Stats', () => {
     mockStatsStore.data = StatsResponse.createFrom({
       today: s, thisWeek: s, thisMonth: s, allTime: s,
       byProject: [], byProjectType: [], byRole: [], byMode: [], byModel: [],
-      closedTasksDaily: [],
+      tasksDoneDaily: [],
       recentRuns: [
         {
           id: 'r1',

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -16,6 +16,7 @@
     "skipLibCheck": true
   },
   "include": [
+    "bindings/**/*.ts",
     "src/**/*.d.ts",
     "src/**/*.ts",
     "src/**/*.js",

--- a/internal/stats/model.go
+++ b/internal/stats/model.go
@@ -64,18 +64,25 @@ type GroupedStat struct {
 	Stats Summary `json:"stats"`
 }
 
+// TaskSeriesPoint is a daily task-count bucket for time-series charts.
+type TaskSeriesPoint struct {
+	Date  string `json:"date"`
+	Count int    `json:"count"`
+}
+
 // StatsResponse is the full analytics payload returned to the frontend.
 type StatsResponse struct {
-	Today         Summary         `json:"today"`
-	ThisWeek      Summary         `json:"thisWeek"`
-	ThisMonth     Summary         `json:"thisMonth"`
-	AllTime       Summary         `json:"allTime"`
-	ByProject     []GroupedStat   `json:"byProject"`
-	ByProjectType []GroupedStat   `json:"byProjectType"`
-	ByMode        []GroupedStat   `json:"byMode"`
-	ByRole        []GroupedStat   `json:"byRole"`
-	ByModel       []GroupedStat   `json:"byModel"`
-	ByProvider    []GroupedStat   `json:"byProvider"`
-	RecentRuns    []RunRecord     `json:"recentRuns"`
-	Limits        *limits.Summary `json:"limits,omitempty"`
+	Today            Summary           `json:"today"`
+	ThisWeek         Summary           `json:"thisWeek"`
+	ThisMonth        Summary           `json:"thisMonth"`
+	AllTime          Summary           `json:"allTime"`
+	ByProject        []GroupedStat     `json:"byProject"`
+	ByProjectType    []GroupedStat     `json:"byProjectType"`
+	ByMode           []GroupedStat     `json:"byMode"`
+	ByRole           []GroupedStat     `json:"byRole"`
+	ByModel          []GroupedStat     `json:"byModel"`
+	ByProvider       []GroupedStat     `json:"byProvider"`
+	RecentRuns       []RunRecord       `json:"recentRuns"`
+	ClosedTasksDaily []TaskSeriesPoint `json:"closedTasksDaily"`
+	Limits           *limits.Summary   `json:"limits,omitempty"`
 }

--- a/internal/stats/model.go
+++ b/internal/stats/model.go
@@ -64,7 +64,7 @@ type GroupedStat struct {
 	Stats Summary `json:"stats"`
 }
 
-// TaskSeriesPoint is a daily task-count bucket for time-series charts.
+// TaskSeriesPoint is a UTC daily task-count bucket for time-series charts.
 type TaskSeriesPoint struct {
 	Date  string `json:"date"`
 	Count int    `json:"count"`
@@ -72,17 +72,17 @@ type TaskSeriesPoint struct {
 
 // StatsResponse is the full analytics payload returned to the frontend.
 type StatsResponse struct {
-	Today            Summary           `json:"today"`
-	ThisWeek         Summary           `json:"thisWeek"`
-	ThisMonth        Summary           `json:"thisMonth"`
-	AllTime          Summary           `json:"allTime"`
-	ByProject        []GroupedStat     `json:"byProject"`
-	ByProjectType    []GroupedStat     `json:"byProjectType"`
-	ByMode           []GroupedStat     `json:"byMode"`
-	ByRole           []GroupedStat     `json:"byRole"`
-	ByModel          []GroupedStat     `json:"byModel"`
-	ByProvider       []GroupedStat     `json:"byProvider"`
-	RecentRuns       []RunRecord       `json:"recentRuns"`
-	ClosedTasksDaily []TaskSeriesPoint `json:"closedTasksDaily"`
-	Limits           *limits.Summary   `json:"limits,omitempty"`
+	Today          Summary           `json:"today"`
+	ThisWeek       Summary           `json:"thisWeek"`
+	ThisMonth      Summary           `json:"thisMonth"`
+	AllTime        Summary           `json:"allTime"`
+	ByProject      []GroupedStat     `json:"byProject"`
+	ByProjectType  []GroupedStat     `json:"byProjectType"`
+	ByMode         []GroupedStat     `json:"byMode"`
+	ByRole         []GroupedStat     `json:"byRole"`
+	ByModel        []GroupedStat     `json:"byModel"`
+	ByProvider     []GroupedStat     `json:"byProvider"`
+	RecentRuns     []RunRecord       `json:"recentRuns"`
+	TasksDoneDaily []TaskSeriesPoint `json:"tasksDoneDaily"`
+	Limits         *limits.Summary   `json:"limits,omitempty"`
 }

--- a/internal/stats/model.go
+++ b/internal/stats/model.go
@@ -64,7 +64,7 @@ type GroupedStat struct {
 	Stats Summary `json:"stats"`
 }
 
-// TaskSeriesPoint is a UTC daily task-count bucket for time-series charts.
+// TaskSeriesPoint is a daily task-count bucket for time-series charts.
 type TaskSeriesPoint struct {
 	Date  string `json:"date"`
 	Count int    `json:"count"`
@@ -72,17 +72,17 @@ type TaskSeriesPoint struct {
 
 // StatsResponse is the full analytics payload returned to the frontend.
 type StatsResponse struct {
-	Today          Summary           `json:"today"`
-	ThisWeek       Summary           `json:"thisWeek"`
-	ThisMonth      Summary           `json:"thisMonth"`
-	AllTime        Summary           `json:"allTime"`
-	ByProject      []GroupedStat     `json:"byProject"`
-	ByProjectType  []GroupedStat     `json:"byProjectType"`
-	ByMode         []GroupedStat     `json:"byMode"`
-	ByRole         []GroupedStat     `json:"byRole"`
-	ByModel        []GroupedStat     `json:"byModel"`
-	ByProvider     []GroupedStat     `json:"byProvider"`
-	RecentRuns     []RunRecord       `json:"recentRuns"`
-	TasksDoneDaily []TaskSeriesPoint `json:"tasksDoneDaily"`
-	Limits         *limits.Summary   `json:"limits,omitempty"`
+	Today            Summary           `json:"today"`
+	ThisWeek         Summary           `json:"thisWeek"`
+	ThisMonth        Summary           `json:"thisMonth"`
+	AllTime          Summary           `json:"allTime"`
+	ByProject        []GroupedStat     `json:"byProject"`
+	ByProjectType    []GroupedStat     `json:"byProjectType"`
+	ByMode           []GroupedStat     `json:"byMode"`
+	ByRole           []GroupedStat     `json:"byRole"`
+	ByModel          []GroupedStat     `json:"byModel"`
+	ByProvider       []GroupedStat     `json:"byProvider"`
+	RecentRuns       []RunRecord       `json:"recentRuns"`
+	ClosedTasksDaily []TaskSeriesPoint `json:"closedTasksDaily"`
+	Limits           *limits.Summary   `json:"limits,omitempty"`
 }

--- a/internal/sybra/svc_stats.go
+++ b/internal/sybra/svc_stats.go
@@ -54,13 +54,13 @@ func taskCloseTime(t task.Task) time.Time {
 	return t.UpdatedAt
 }
 
-func tasksDoneDaily(list []task.Task) []stats.TaskSeriesPoint {
+func closedTasksDaily(list []task.Task, now time.Time) []stats.TaskSeriesPoint {
 	buckets := map[string]int{}
 	for i := range list {
 		if list[i].Status != task.StatusDone {
 			continue
 		}
-		key := taskCloseTime(list[i]).UTC().Format(time.DateOnly)
+		key := taskCloseTime(list[i]).In(now.Location()).Format(time.DateOnly)
 		buckets[key]++
 	}
 
@@ -80,17 +80,17 @@ func tasksDoneDaily(list []task.Task) []stats.TaskSeriesPoint {
 // GetStats returns aggregated agent run statistics.
 func (s *StatsService) GetStats() stats.StatsResponse {
 	if s.stats == nil {
-		return stats.StatsResponse{TasksDoneDaily: []stats.TaskSeriesPoint{}}
+		return stats.StatsResponse{ClosedTasksDaily: []stats.TaskSeriesPoint{}}
 	}
 	now := time.Now()
 	resp := s.stats.QueryAt(now)
-	resp.TasksDoneDaily = []stats.TaskSeriesPoint{}
+	resp.ClosedTasksDaily = []stats.TaskSeriesPoint{}
 	resp.ByProjectType = aggregateByProjectType(resp.ByProject, s.projectTypes())
 
 	if s.tasks != nil {
 		if list, err := s.tasks.List(); err == nil {
 			aggregateTasksDone(&resp, list, now)
-			resp.TasksDoneDaily = tasksDoneDaily(list)
+			resp.ClosedTasksDaily = closedTasksDaily(list, now)
 		} else {
 			slog.Warn("stats: failed to list tasks", "err", err)
 		}

--- a/internal/sybra/svc_stats.go
+++ b/internal/sybra/svc_stats.go
@@ -54,13 +54,13 @@ func taskCloseTime(t task.Task) time.Time {
 	return t.UpdatedAt
 }
 
-func closedTasksDaily(list []task.Task, now time.Time) []stats.TaskSeriesPoint {
+func tasksDoneDaily(list []task.Task) []stats.TaskSeriesPoint {
 	buckets := map[string]int{}
 	for i := range list {
 		if list[i].Status != task.StatusDone {
 			continue
 		}
-		key := taskCloseTime(list[i]).In(now.Location()).Format("2006-01-02")
+		key := taskCloseTime(list[i]).UTC().Format(time.DateOnly)
 		buckets[key]++
 	}
 
@@ -80,16 +80,17 @@ func closedTasksDaily(list []task.Task, now time.Time) []stats.TaskSeriesPoint {
 // GetStats returns aggregated agent run statistics.
 func (s *StatsService) GetStats() stats.StatsResponse {
 	if s.stats == nil {
-		return stats.StatsResponse{}
+		return stats.StatsResponse{TasksDoneDaily: []stats.TaskSeriesPoint{}}
 	}
 	now := time.Now()
 	resp := s.stats.QueryAt(now)
+	resp.TasksDoneDaily = []stats.TaskSeriesPoint{}
 	resp.ByProjectType = aggregateByProjectType(resp.ByProject, s.projectTypes())
 
 	if s.tasks != nil {
 		if list, err := s.tasks.List(); err == nil {
 			aggregateTasksDone(&resp, list, now)
-			resp.ClosedTasksDaily = closedTasksDaily(list, now)
+			resp.TasksDoneDaily = tasksDoneDaily(list)
 		} else {
 			slog.Warn("stats: failed to list tasks", "err", err)
 		}

--- a/internal/sybra/svc_stats.go
+++ b/internal/sybra/svc_stats.go
@@ -33,10 +33,7 @@ func aggregateTasksDone(resp *stats.StatsResponse, list []task.Task, now time.Ti
 
 		resp.AllTime.TasksDone++
 
-		t := list[i].UpdatedAt
-		if list[i].ClosedAt != nil {
-			t = *list[i].ClosedAt
-		}
+		t := taskCloseTime(list[i])
 
 		if !t.Before(todayStart) {
 			resp.Today.TasksDone++
@@ -48,6 +45,36 @@ func aggregateTasksDone(resp *stats.StatsResponse, list []task.Task, now time.Ti
 			resp.ThisMonth.TasksDone++
 		}
 	}
+}
+
+func taskCloseTime(t task.Task) time.Time {
+	if t.ClosedAt != nil {
+		return *t.ClosedAt
+	}
+	return t.UpdatedAt
+}
+
+func closedTasksDaily(list []task.Task, now time.Time) []stats.TaskSeriesPoint {
+	buckets := map[string]int{}
+	for i := range list {
+		if list[i].Status != task.StatusDone {
+			continue
+		}
+		key := taskCloseTime(list[i]).In(now.Location()).Format("2006-01-02")
+		buckets[key]++
+	}
+
+	days := make([]string, 0, len(buckets))
+	for day := range buckets {
+		days = append(days, day)
+	}
+	slices.Sort(days)
+
+	out := make([]stats.TaskSeriesPoint, 0, len(days))
+	for _, day := range days {
+		out = append(out, stats.TaskSeriesPoint{Date: day, Count: buckets[day]})
+	}
+	return out
 }
 
 // GetStats returns aggregated agent run statistics.
@@ -62,6 +89,7 @@ func (s *StatsService) GetStats() stats.StatsResponse {
 	if s.tasks != nil {
 		if list, err := s.tasks.List(); err == nil {
 			aggregateTasksDone(&resp, list, now)
+			resp.ClosedTasksDaily = closedTasksDaily(list, now)
 		} else {
 			slog.Warn("stats: failed to list tasks", "err", err)
 		}

--- a/internal/sybra/svc_stats_test.go
+++ b/internal/sybra/svc_stats_test.go
@@ -60,7 +60,7 @@ func TestAggregateTasksDone(t *testing.T) {
 	}
 }
 
-func TestTasksDoneDaily(t *testing.T) {
+func TestClosedTasksDaily(t *testing.T) {
 	loc := time.FixedZone("app", 2*60*60)
 	now := time.Date(2026, 6, 15, 12, 0, 0, 0, loc)
 	closedMorning := time.Date(2026, 6, 14, 8, 0, 0, 0, time.UTC)
@@ -77,36 +77,38 @@ func TestTasksDoneDaily(t *testing.T) {
 		{Status: task.StatusInProgress, UpdatedAt: now},
 	}
 
-	got := tasksDoneDaily(list)
+	got := closedTasksDaily(list, now)
 	want := []stats.TaskSeriesPoint{
 		{Date: "2026-06-13", Count: 1},
 		{Date: "2026-06-14", Count: 2},
 		{Date: "2026-06-15", Count: 1},
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("tasksDoneDaily() = %+v, want %+v", got, want)
+		t.Fatalf("closedTasksDaily() = %+v, want %+v", got, want)
 	}
 }
 
-func TestTasksDoneDailyEmpty(t *testing.T) {
-	got := tasksDoneDaily(nil)
+func TestClosedTasksDailyEmpty(t *testing.T) {
+	got := closedTasksDaily(nil, time.Now())
 	if len(got) != 0 {
-		t.Fatalf("tasksDoneDaily(nil) = %+v, want empty", got)
+		t.Fatalf("closedTasksDaily(nil) = %+v, want empty", got)
 	}
 }
 
-func TestTasksDoneDailyUsesUTCDateKeys(t *testing.T) {
+func TestClosedTasksDailyUsesBackendLocalDateKeys(t *testing.T) {
+	loc := time.FixedZone("app", 2*60*60)
+	now := time.Date(2026, 6, 2, 12, 0, 0, 0, loc)
 	closed := time.Date(2026, 6, 1, 22, 30, 0, 0, time.UTC)
 	list := []task.Task{{Status: task.StatusDone, UpdatedAt: time.Date(2026, 6, 1, 1, 0, 0, 0, time.UTC), ClosedAt: &closed}}
 
-	got := tasksDoneDaily(list)
-	want := []stats.TaskSeriesPoint{{Date: "2026-06-01", Count: 1}}
+	got := closedTasksDaily(list, now)
+	want := []stats.TaskSeriesPoint{{Date: "2026-06-02", Count: 1}}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("tasksDoneDaily() = %+v, want %+v", got, want)
+		t.Fatalf("closedTasksDaily() = %+v, want %+v", got, want)
 	}
 }
 
-func TestStatsServiceGetStatsAssignsTasksDoneDaily(t *testing.T) {
+func TestStatsServiceGetStatsAssignsClosedTasksDaily(t *testing.T) {
 	statsStore, err := stats.NewStore(filepath.Join(t.TempDir(), "stats.json"))
 	if err != nil {
 		t.Fatal(err)
@@ -140,16 +142,16 @@ func TestStatsServiceGetStatsAssignsTasksDoneDaily(t *testing.T) {
 	})
 
 	resp := (&StatsService{stats: statsStore, tasks: taskMgr}).GetStats()
-	want := []stats.TaskSeriesPoint{{Date: closed.UTC().Format(time.DateOnly), Count: 1}}
-	if !reflect.DeepEqual(resp.TasksDoneDaily, want) {
-		t.Fatalf("TasksDoneDaily = %+v, want %+v", resp.TasksDoneDaily, want)
+	want := []stats.TaskSeriesPoint{{Date: closed.In(time.Now().Location()).Format(time.DateOnly), Count: 1}}
+	if !reflect.DeepEqual(resp.ClosedTasksDaily, want) {
+		t.Fatalf("ClosedTasksDaily = %+v, want %+v", resp.ClosedTasksDaily, want)
 	}
 	if resp.AllTime.TasksDone != 1 {
 		t.Fatalf("AllTime.TasksDone = %d, want 1", resp.AllTime.TasksDone)
 	}
 }
 
-func TestStatsServiceGetStatsKeepsTasksDoneDailyArrayWhenTaskListFails(t *testing.T) {
+func TestStatsServiceGetStatsKeepsClosedTasksDailyArrayWhenTaskListFails(t *testing.T) {
 	statsStore, err := stats.NewStore(filepath.Join(t.TempDir(), "stats.json"))
 	if err != nil {
 		t.Fatal(err)
@@ -165,15 +167,15 @@ func TestStatsServiceGetStatsKeepsTasksDoneDailyArrayWhenTaskListFails(t *testin
 	}
 
 	resp := (&StatsService{stats: statsStore, tasks: taskMgr}).GetStats()
-	if resp.TasksDoneDaily == nil {
-		t.Fatal("TasksDoneDaily is nil, want empty slice")
+	if resp.ClosedTasksDaily == nil {
+		t.Fatal("ClosedTasksDaily is nil, want empty slice")
 	}
 	data, err := json.Marshal(resp)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(data), `"tasksDoneDaily":[]`) {
-		t.Fatalf("marshaled response = %s, want tasksDoneDaily array", data)
+	if !strings.Contains(string(data), `"closedTasksDaily":[]`) {
+		t.Fatalf("marshaled response = %s, want closedTasksDaily array", data)
 	}
 }
 

--- a/internal/sybra/svc_stats_test.go
+++ b/internal/sybra/svc_stats_test.go
@@ -2,6 +2,9 @@ package sybra
 
 import (
 	"math"
+	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -52,6 +55,97 @@ func TestAggregateTasksDone(t *testing.T) {
 	// ThisMonth (since June 1): t1, t2, t3
 	if resp.ThisMonth.TasksDone != 3 {
 		t.Errorf("ThisMonth: got %d, want 3", resp.ThisMonth.TasksDone)
+	}
+}
+
+func TestClosedTasksDaily(t *testing.T) {
+	loc := time.FixedZone("app", 2*60*60)
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, loc)
+	closedMorning := time.Date(2026, 6, 14, 8, 0, 0, 0, time.UTC)
+	closedEvening := time.Date(2026, 6, 14, 18, 0, 0, 0, time.UTC)
+	updatedFallback := time.Date(2026, 6, 13, 10, 0, 0, 0, time.UTC)
+	oldUpdated := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	preferredClosed := time.Date(2026, 6, 15, 9, 0, 0, 0, time.UTC)
+
+	list := []task.Task{
+		{Status: task.StatusDone, UpdatedAt: closedMorning},
+		{Status: task.StatusDone, UpdatedAt: closedEvening},
+		{Status: task.StatusDone, UpdatedAt: updatedFallback},
+		{Status: task.StatusDone, UpdatedAt: oldUpdated, ClosedAt: &preferredClosed},
+		{Status: task.StatusInProgress, UpdatedAt: now},
+	}
+
+	got := closedTasksDaily(list, now)
+	want := []stats.TaskSeriesPoint{
+		{Date: "2026-06-13", Count: 1},
+		{Date: "2026-06-14", Count: 2},
+		{Date: "2026-06-15", Count: 1},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("closedTasksDaily() = %+v, want %+v", got, want)
+	}
+}
+
+func TestClosedTasksDailyEmpty(t *testing.T) {
+	got := closedTasksDaily(nil, time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC))
+	if len(got) != 0 {
+		t.Fatalf("closedTasksDaily(nil) = %+v, want empty", got)
+	}
+}
+
+func TestClosedTasksDailyUsesNowLocation(t *testing.T) {
+	loc := time.FixedZone("app", 2*60*60)
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, loc)
+	closed := time.Date(2026, 6, 1, 22, 30, 0, 0, time.UTC)
+	list := []task.Task{{Status: task.StatusDone, UpdatedAt: time.Date(2026, 6, 1, 1, 0, 0, 0, time.UTC), ClosedAt: &closed}}
+
+	got := closedTasksDaily(list, now)
+	want := []stats.TaskSeriesPoint{{Date: "2026-06-02", Count: 1}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("closedTasksDaily() = %+v, want %+v", got, want)
+	}
+}
+
+func TestStatsServiceGetStatsAssignsClosedTasksDaily(t *testing.T) {
+	statsStore, err := stats.NewStore(filepath.Join(t.TempDir(), "stats.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasksDir := t.TempDir()
+	taskStore, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskMgr := task.NewManager(taskStore, nil)
+
+	closed := time.Now().Add(-1 * time.Hour)
+	writeStatsTask(t, tasksDir, task.Task{
+		ID:        "done",
+		Title:     "done task",
+		Status:    task.StatusDone,
+		TaskType:  task.TaskTypeNormal,
+		AgentMode: task.AgentModeHeadless,
+		CreatedAt: closed.Add(-1 * time.Hour),
+		UpdatedAt: closed.Add(-30 * time.Minute),
+		ClosedAt:  &closed,
+	})
+	writeStatsTask(t, tasksDir, task.Task{
+		ID:        "todo",
+		Title:     "todo task",
+		Status:    task.StatusTodo,
+		TaskType:  task.TaskTypeNormal,
+		AgentMode: task.AgentModeHeadless,
+		CreatedAt: closed,
+		UpdatedAt: closed,
+	})
+
+	resp := (&StatsService{stats: statsStore, tasks: taskMgr}).GetStats()
+	want := []stats.TaskSeriesPoint{{Date: closed.In(time.Now().Location()).Format("2006-01-02"), Count: 1}}
+	if !reflect.DeepEqual(resp.ClosedTasksDaily, want) {
+		t.Fatalf("ClosedTasksDaily = %+v, want %+v", resp.ClosedTasksDaily, want)
+	}
+	if resp.AllTime.TasksDone != 1 {
+		t.Fatalf("AllTime.TasksDone = %d, want 1", resp.AllTime.TasksDone)
 	}
 }
 
@@ -146,6 +240,17 @@ func find(t *testing.T, gs []stats.GroupedStat, key string) stats.Summary {
 	}
 	t.Fatalf("no bucket with key %q in %+v", key, gs)
 	return stats.Summary{}
+}
+
+func writeStatsTask(t *testing.T, dir string, tk task.Task) {
+	t.Helper()
+	data, err := task.Marshal(tk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, tk.ID+".md"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func nearly(a, b float64) bool { return math.Abs(a-b) < 1e-9 }

--- a/internal/sybra/svc_stats_test.go
+++ b/internal/sybra/svc_stats_test.go
@@ -1,10 +1,12 @@
 package sybra
 
 import (
+	"encoding/json"
 	"math"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -58,7 +60,7 @@ func TestAggregateTasksDone(t *testing.T) {
 	}
 }
 
-func TestClosedTasksDaily(t *testing.T) {
+func TestTasksDoneDaily(t *testing.T) {
 	loc := time.FixedZone("app", 2*60*60)
 	now := time.Date(2026, 6, 15, 12, 0, 0, 0, loc)
 	closedMorning := time.Date(2026, 6, 14, 8, 0, 0, 0, time.UTC)
@@ -75,38 +77,36 @@ func TestClosedTasksDaily(t *testing.T) {
 		{Status: task.StatusInProgress, UpdatedAt: now},
 	}
 
-	got := closedTasksDaily(list, now)
+	got := tasksDoneDaily(list)
 	want := []stats.TaskSeriesPoint{
 		{Date: "2026-06-13", Count: 1},
 		{Date: "2026-06-14", Count: 2},
 		{Date: "2026-06-15", Count: 1},
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("closedTasksDaily() = %+v, want %+v", got, want)
+		t.Fatalf("tasksDoneDaily() = %+v, want %+v", got, want)
 	}
 }
 
-func TestClosedTasksDailyEmpty(t *testing.T) {
-	got := closedTasksDaily(nil, time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC))
+func TestTasksDoneDailyEmpty(t *testing.T) {
+	got := tasksDoneDaily(nil)
 	if len(got) != 0 {
-		t.Fatalf("closedTasksDaily(nil) = %+v, want empty", got)
+		t.Fatalf("tasksDoneDaily(nil) = %+v, want empty", got)
 	}
 }
 
-func TestClosedTasksDailyUsesNowLocation(t *testing.T) {
-	loc := time.FixedZone("app", 2*60*60)
-	now := time.Date(2026, 6, 15, 12, 0, 0, 0, loc)
+func TestTasksDoneDailyUsesUTCDateKeys(t *testing.T) {
 	closed := time.Date(2026, 6, 1, 22, 30, 0, 0, time.UTC)
 	list := []task.Task{{Status: task.StatusDone, UpdatedAt: time.Date(2026, 6, 1, 1, 0, 0, 0, time.UTC), ClosedAt: &closed}}
 
-	got := closedTasksDaily(list, now)
-	want := []stats.TaskSeriesPoint{{Date: "2026-06-02", Count: 1}}
+	got := tasksDoneDaily(list)
+	want := []stats.TaskSeriesPoint{{Date: "2026-06-01", Count: 1}}
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("closedTasksDaily() = %+v, want %+v", got, want)
+		t.Fatalf("tasksDoneDaily() = %+v, want %+v", got, want)
 	}
 }
 
-func TestStatsServiceGetStatsAssignsClosedTasksDaily(t *testing.T) {
+func TestStatsServiceGetStatsAssignsTasksDoneDaily(t *testing.T) {
 	statsStore, err := stats.NewStore(filepath.Join(t.TempDir(), "stats.json"))
 	if err != nil {
 		t.Fatal(err)
@@ -140,12 +140,40 @@ func TestStatsServiceGetStatsAssignsClosedTasksDaily(t *testing.T) {
 	})
 
 	resp := (&StatsService{stats: statsStore, tasks: taskMgr}).GetStats()
-	want := []stats.TaskSeriesPoint{{Date: closed.In(time.Now().Location()).Format("2006-01-02"), Count: 1}}
-	if !reflect.DeepEqual(resp.ClosedTasksDaily, want) {
-		t.Fatalf("ClosedTasksDaily = %+v, want %+v", resp.ClosedTasksDaily, want)
+	want := []stats.TaskSeriesPoint{{Date: closed.UTC().Format(time.DateOnly), Count: 1}}
+	if !reflect.DeepEqual(resp.TasksDoneDaily, want) {
+		t.Fatalf("TasksDoneDaily = %+v, want %+v", resp.TasksDoneDaily, want)
 	}
 	if resp.AllTime.TasksDone != 1 {
 		t.Fatalf("AllTime.TasksDone = %d, want 1", resp.AllTime.TasksDone)
+	}
+}
+
+func TestStatsServiceGetStatsKeepsTasksDoneDailyArrayWhenTaskListFails(t *testing.T) {
+	statsStore, err := stats.NewStore(filepath.Join(t.TempDir(), "stats.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasksDir := t.TempDir()
+	taskStore, err := task.NewStore(tasksDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskMgr := task.NewManager(taskStore, nil)
+	if err := os.RemoveAll(tasksDir); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := (&StatsService{stats: statsStore, tasks: taskMgr}).GetStats()
+	if resp.TasksDoneDaily == nil {
+		t.Fatal("TasksDoneDaily is nil, want empty slice")
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"tasksDoneDaily":[]`) {
+		t.Fatalf("marshaled response = %s, want tasksDoneDaily array", data)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Closed-task stats need a time-series view so users can see completion trends instead of only aggregate counts.

## Implementation information

Adds the closed task time-series stats path and restores the series behavior after review fixes.