### PR TITLE
refactor(agent): dedupe registry mapping

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -209,7 +209,15 @@ func (m *Manager) saveRegistry(a *Agent) {
 	rec := a.toRecord()
 	rec.ProcStartedAt = processStartString(rec.PID)
 	if err := reg.Save(rec); err != nil {
-		m.logger.Warn("agent.registry.save", "id", rec.ID, "err", err)
+		m.logger.Warn(
+			"agent.registry.save",
+			"id", rec.ID,
+			"task_id", rec.TaskID,
+			"mode", rec.Mode,
+			"pid", rec.PID,
+			"log_path", rec.LogPath,
+			"err", err,
+		)
 	}
 }
 

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -206,33 +206,10 @@ func (m *Manager) saveRegistry(a *Agent) {
 	if reg == nil || a == nil {
 		return
 	}
-	a.mu.RLock()
-	rec := Record{
-		ID:                 a.ID,
-		TaskID:             a.TaskID,
-		Name:               a.Name,
-		Mode:               a.Mode,
-		Provider:           a.Provider,
-		Model:              a.Model,
-		ExperimentID:       a.ExperimentID,
-		VariantID:          a.VariantID,
-		AssignmentUnit:     a.AssignmentUnit,
-		AssignmentKey:      a.AssignmentKey,
-		PID:                a.PID,
-		SessionID:          a.SessionID,
-		LogPath:            a.LogPath,
-		CWD:                a.sessionCWD,
-		StartedAt:          a.StartedAt,
-		StdinPath:          a.stdinPath,
-		OneShot:            a.oneShot,
-		MaxTurns:           a.MaxTurns,
-		RequirePermissions: a.requirePermissions,
-		ReasoningEffort:    a.ReasoningEffort,
-	}
-	a.mu.RUnlock()
+	rec := a.toRecord()
 	rec.ProcStartedAt = processStartString(rec.PID)
 	if err := reg.Save(rec); err != nil {
-		m.logger.Warn("agent.registry.save", "id", a.ID, "err", err)
+		m.logger.Warn("agent.registry.save", "id", rec.ID, "err", err)
 	}
 }
 

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -165,6 +165,9 @@ type Agent struct {
 	mu sync.RWMutex
 }
 
+// toRecord snapshots only the fields persisted for restart survival.
+// Callers that write a live process record must fill ProcStartedAt after the
+// snapshot so the PID-reuse guard reflects the current process state.
 func (a *Agent) toRecord() Record {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
@@ -192,6 +195,8 @@ func (a *Agent) toRecord() Record {
 	}
 }
 
+// fromRecord builds a detached reattach skeleton, not a general Agent factory.
+// Reattach callers own runtime wiring such as cancel, done, cmd, and promptCh.
 func fromRecord(r Record) *Agent {
 	return &Agent{
 		ID:                 r.ID,

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -165,6 +165,61 @@ type Agent struct {
 	mu sync.RWMutex
 }
 
+func (a *Agent) toRecord() Record {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return Record{
+		ID:                 a.ID,
+		TaskID:             a.TaskID,
+		Name:               a.Name,
+		Mode:               a.Mode,
+		Provider:           a.Provider,
+		Model:              a.Model,
+		ExperimentID:       a.ExperimentID,
+		VariantID:          a.VariantID,
+		AssignmentUnit:     a.AssignmentUnit,
+		AssignmentKey:      a.AssignmentKey,
+		PID:                a.PID,
+		SessionID:          a.SessionID,
+		LogPath:            a.LogPath,
+		CWD:                a.sessionCWD,
+		StartedAt:          a.StartedAt,
+		StdinPath:          a.stdinPath,
+		OneShot:            a.oneShot,
+		MaxTurns:           a.MaxTurns,
+		RequirePermissions: a.requirePermissions,
+		ReasoningEffort:    a.ReasoningEffort,
+	}
+}
+
+func fromRecord(r Record) *Agent {
+	return &Agent{
+		ID:                 r.ID,
+		TaskID:             r.TaskID,
+		Name:               r.Name,
+		Mode:               r.Mode,
+		Provider:           r.Provider,
+		Model:              r.Model,
+		ExperimentID:       r.ExperimentID,
+		VariantID:          r.VariantID,
+		AssignmentUnit:     r.AssignmentUnit,
+		AssignmentKey:      r.AssignmentKey,
+		PID:                r.PID,
+		SessionID:          r.SessionID,
+		LogPath:            r.LogPath,
+		sessionCWD:         r.CWD,
+		StartedAt:          r.StartedAt,
+		LastEventAt:        time.Now().UTC(),
+		State:              StateRunning,
+		MaxTurns:           r.MaxTurns,
+		oneShot:            r.OneShot,
+		stdinPath:          r.StdinPath,
+		requirePermissions: r.RequirePermissions,
+		ReasoningEffort:    r.ReasoningEffort,
+		detached:           true,
+	}
+}
+
 // SetState atomically updates the agent state.
 func (a *Agent) SetState(s State) {
 	a.mu.Lock()

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -88,7 +88,7 @@ func (m *Manager) ReattachAll() []*Agent {
 			continue
 		}
 
-		a := agentFromRecord(r)
+		a := fromRecord(r)
 		// Rehydrate the buffer and capture the exact byte offset consumed, so
 		// the tailer resumes from there with no gap (a line appended between
 		// rehydration and the tail's first read is not lost) and no
@@ -130,7 +130,7 @@ func (m *Manager) finalizeIfCompleted(r Record) bool {
 	if r.LogPath == "" || r.Mode != "headless" {
 		return false
 	}
-	a := agentFromRecord(r)
+	a := fromRecord(r)
 	rehydrateFromLog(a, r.LogPath)
 	found, isError := a.lastHeadlessResult()
 	if !found {
@@ -195,7 +195,7 @@ func (m *Manager) reattachInteractive(r Record, reg *registryStore) *Agent {
 	// compatibility, but prefer the explicit flag for current records.
 	oneShot := r.OneShot || r.StdinPath == ""
 
-	a := agentFromRecord(r)
+	a := fromRecord(r)
 	a.oneShot = oneShot
 	var startOffset int64
 	if r.LogPath != "" {
@@ -261,7 +261,7 @@ func (m *Manager) reattachPerTurnConvo(r Record, reg *registryStore) *Agent {
 		}
 	}
 
-	a := agentFromRecord(r)
+	a := fromRecord(r)
 	if r.LogPath != "" {
 		rehydratePerTurnConvoFromLog(a, r.LogPath)
 	}
@@ -447,34 +447,6 @@ func reattachAlive(r Record) bool {
 		}
 	}
 	return true
-}
-
-func agentFromRecord(r Record) *Agent {
-	return &Agent{
-		ID:                 r.ID,
-		TaskID:             r.TaskID,
-		Name:               r.Name,
-		Mode:               r.Mode,
-		Provider:           r.Provider,
-		Model:              r.Model,
-		ExperimentID:       r.ExperimentID,
-		VariantID:          r.VariantID,
-		AssignmentUnit:     r.AssignmentUnit,
-		AssignmentKey:      r.AssignmentKey,
-		PID:                r.PID,
-		SessionID:          r.SessionID,
-		LogPath:            r.LogPath,
-		sessionCWD:         r.CWD,
-		StartedAt:          r.StartedAt,
-		LastEventAt:        time.Now().UTC(),
-		State:              StateRunning,
-		MaxTurns:           r.MaxTurns,
-		oneShot:            r.OneShot,
-		stdinPath:          r.StdinPath,
-		requirePermissions: r.RequirePermissions,
-		ReasoningEffort:    r.ReasoningEffort,
-		detached:           true,
-	}
 }
 
 // processStartString returns the OS-reported start time of a process as an

--- a/internal/agent/registry_roundtrip_test.go
+++ b/internal/agent/registry_roundtrip_test.go
@@ -62,7 +62,7 @@ func TestAgentRegistryRoundTripPreservesPersistedFields(t *testing.T) {
 	}
 
 	beforeRehydrate := time.Now().UTC()
-	rehydrated := agentFromRecord(records[0])
+	rehydrated := fromRecord(records[0])
 	afterRehydrate := time.Now().UTC()
 
 	got := persistedAgentFields{

--- a/internal/agent/survive_restart_test.go
+++ b/internal/agent/survive_restart_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -55,6 +56,105 @@ func TestRegistryStore_RoundTrip(t *testing.T) {
 	// Deleting a missing record is not an error.
 	if err := s.Delete("a1"); err != nil {
 		t.Fatalf("Delete missing: %v", err)
+	}
+}
+
+func TestAgentRecordMappingRoundTrip(t *testing.T) {
+	started := time.Date(2026, 6, 28, 20, 30, 0, 0, time.UTC)
+	a := &Agent{
+		ID:              "a-map",
+		TaskID:          "task-map",
+		Name:            "mapper",
+		Mode:            "interactive",
+		Provider:        "codex",
+		Model:           "gpt-5.3-codex",
+		ExperimentID:    "exp-1",
+		VariantID:       "variant-a",
+		AssignmentUnit:  "task",
+		AssignmentKey:   "task-map",
+		PID:             12345,
+		SessionID:       "sess-map",
+		LogPath:         "/tmp/sybra/agents/a-map.ndjson",
+		StartedAt:       started,
+		MaxTurns:        7,
+		ReasoningEffort: "high",
+	}
+	a.sessionCWD = "/tmp/sybra/worktrees/task-map"
+	a.stdinPath = "/tmp/sybra/agents/a-map.stdin"
+	a.oneShot = true
+	a.requirePermissions = true
+
+	want := Record{
+		ID:                 "a-map",
+		TaskID:             "task-map",
+		Name:               "mapper",
+		Mode:               "interactive",
+		Provider:           "codex",
+		Model:              "gpt-5.3-codex",
+		ExperimentID:       "exp-1",
+		VariantID:          "variant-a",
+		AssignmentUnit:     "task",
+		AssignmentKey:      "task-map",
+		PID:                12345,
+		SessionID:          "sess-map",
+		LogPath:            "/tmp/sybra/agents/a-map.ndjson",
+		CWD:                "/tmp/sybra/worktrees/task-map",
+		StartedAt:          started,
+		StdinPath:          "/tmp/sybra/agents/a-map.stdin",
+		OneShot:            true,
+		MaxTurns:           7,
+		RequirePermissions: true,
+		ReasoningEffort:    "high",
+	}
+	assertRecordFixtureCoversFields(t, want, "ProcStartedAt")
+
+	if got := a.toRecord(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("toRecord mismatch:\n got: %+v\nwant: %+v", got, want)
+	}
+
+	before := time.Now().UTC()
+	restored := fromRecord(want)
+	after := time.Now().UTC()
+	if got := restored.toRecord(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("fromRecord/toRecord mismatch:\n got: %+v\nwant: %+v", got, want)
+	}
+	if got := restored.GetState(); got != StateRunning {
+		t.Fatalf("fromRecord must force running state, got %s", got)
+	}
+	last := restored.GetLastEventAt()
+	if last.Before(before) || last.After(after) {
+		t.Fatalf("fromRecord must refresh LastEventAt, got %s outside [%s, %s]", last, before, after)
+	}
+	if !restored.isDetached() {
+		t.Fatal("fromRecord must mark the skeleton agent detached")
+	}
+	if restored.cancel != nil || restored.done != nil || restored.promptCh != nil || restored.GetCmd() != nil {
+		t.Fatal("fromRecord must leave live runtime wiring to reattach callers")
+	}
+
+	withProcStart := want
+	withProcStart.ProcStartedAt = "Mon Jun 28 20:30:00 2026"
+	if got := fromRecord(withProcStart).toRecord(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("ProcStartedAt must stay caller-owned:\n got: %+v\nwant: %+v", got, want)
+	}
+}
+
+func assertRecordFixtureCoversFields(t *testing.T, rec Record, ignore ...string) {
+	t.Helper()
+	ignored := map[string]struct{}{}
+	for _, field := range ignore {
+		ignored[field] = struct{}{}
+	}
+	value := reflect.ValueOf(rec)
+	typ := value.Type()
+	for i := range value.NumField() {
+		field := typ.Field(i)
+		if _, ok := ignored[field.Name]; ok {
+			continue
+		}
+		if value.Field(i).IsZero() {
+			t.Fatalf("record mapping test fixture does not cover Record.%s", field.Name)
+		}
 	}
 }
 

--- a/internal/agent/survive_restart_test.go
+++ b/internal/agent/survive_restart_test.go
@@ -8,9 +8,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestRegistryStore_RoundTrip(t *testing.T) {
@@ -60,52 +63,14 @@ func TestRegistryStore_RoundTrip(t *testing.T) {
 }
 
 func TestAgentRecordMappingRoundTrip(t *testing.T) {
-	started := time.Date(2026, 6, 28, 20, 30, 0, 0, time.UTC)
-	a := &Agent{
-		ID:              "a-map",
-		TaskID:          "task-map",
-		Name:            "mapper",
-		Mode:            "interactive",
-		Provider:        "codex",
-		Model:           "gpt-5.3-codex",
-		ExperimentID:    "exp-1",
-		VariantID:       "variant-a",
-		AssignmentUnit:  "task",
-		AssignmentKey:   "task-map",
-		PID:             12345,
-		SessionID:       "sess-map",
-		LogPath:         "/tmp/sybra/agents/a-map.ndjson",
-		StartedAt:       started,
-		MaxTurns:        7,
-		ReasoningEffort: "high",
-	}
+	started := recordMappingStartedAt()
+	a := recordMappingAgent(started)
 	a.sessionCWD = "/tmp/sybra/worktrees/task-map"
 	a.stdinPath = "/tmp/sybra/agents/a-map.stdin"
 	a.oneShot = true
 	a.requirePermissions = true
 
-	want := Record{
-		ID:                 "a-map",
-		TaskID:             "task-map",
-		Name:               "mapper",
-		Mode:               "interactive",
-		Provider:           "codex",
-		Model:              "gpt-5.3-codex",
-		ExperimentID:       "exp-1",
-		VariantID:          "variant-a",
-		AssignmentUnit:     "task",
-		AssignmentKey:      "task-map",
-		PID:                12345,
-		SessionID:          "sess-map",
-		LogPath:            "/tmp/sybra/agents/a-map.ndjson",
-		CWD:                "/tmp/sybra/worktrees/task-map",
-		StartedAt:          started,
-		StdinPath:          "/tmp/sybra/agents/a-map.stdin",
-		OneShot:            true,
-		MaxTurns:           7,
-		RequirePermissions: true,
-		ReasoningEffort:    "high",
-	}
+	want := recordMappingRecord(started)
 	assertRecordFixtureCoversFields(t, want, "ProcStartedAt")
 
 	if got := a.toRecord(); !reflect.DeepEqual(got, want) {
@@ -137,6 +102,119 @@ func TestAgentRecordMappingRoundTrip(t *testing.T) {
 	if got := fromRecord(withProcStart).toRecord(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("ProcStartedAt must stay caller-owned:\n got: %+v\nwant: %+v", got, want)
 	}
+}
+
+func TestRegistryStore_CurrentYAMLFixture(t *testing.T) {
+	want := recordMappingRecord(recordMappingStartedAt())
+	want.ProcStartedAt = "Mon Jun 28 20:30:00 2026"
+
+	var got Record
+	raw := readRegistryFixture(t, "registry_current.yaml")
+	if err := yaml.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal current registry fixture: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("current registry fixture mismatch:\n got: %+v\nwant: %+v", got, want)
+	}
+
+	marshaled, err := yaml.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal current registry fixture: %v", err)
+	}
+	if strings.TrimSpace(string(marshaled)) != strings.TrimSpace(string(raw)) {
+		t.Fatalf("current registry YAML drift:\n got:\n%s\nwant:\n%s", marshaled, raw)
+	}
+}
+
+func TestRegistryStore_LegacyYAMLFixture(t *testing.T) {
+	wantStartedAt := recordMappingStartedAt()
+	want := Record{
+		ID:            "legacy-agent",
+		TaskID:        "legacy-task",
+		Mode:          "headless",
+		Provider:      "claude",
+		PID:           23456,
+		SessionID:     "legacy-session",
+		LogPath:       "/tmp/sybra/agents/legacy-agent.ndjson",
+		CWD:           "/tmp/sybra/worktrees/legacy-task",
+		StartedAt:     wantStartedAt,
+		ProcStartedAt: "Mon Jun 28 20:30:00 2026",
+	}
+
+	var got Record
+	if err := yaml.Unmarshal(readRegistryFixture(t, "registry_legacy.yaml"), &got); err != nil {
+		t.Fatalf("unmarshal legacy registry fixture: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("legacy registry fixture mismatch:\n got: %+v\nwant: %+v", got, want)
+	}
+
+	restored := fromRecord(got)
+	if restored.ID != want.ID || restored.TaskID != want.TaskID || restored.Mode != want.Mode ||
+		restored.Provider != want.Provider || restored.PID != want.PID ||
+		restored.SessionID != want.SessionID || restored.LogPath != want.LogPath ||
+		restored.sessionCWD != want.CWD || !restored.StartedAt.Equal(wantStartedAt) {
+		t.Fatalf("legacy registry reattach skeleton mismatch: %+v", restored)
+	}
+}
+
+func recordMappingStartedAt() time.Time {
+	return time.Date(2026, 6, 28, 20, 30, 0, 0, time.UTC)
+}
+
+func recordMappingAgent(started time.Time) *Agent {
+	return &Agent{
+		ID:              "a-map",
+		TaskID:          "task-map",
+		Name:            "mapper",
+		Mode:            "interactive",
+		Provider:        "codex",
+		Model:           "gpt-5.3-codex",
+		ExperimentID:    "exp-1",
+		VariantID:       "variant-a",
+		AssignmentUnit:  "task",
+		AssignmentKey:   "task-map",
+		PID:             12345,
+		SessionID:       "sess-map",
+		LogPath:         "/tmp/sybra/agents/a-map.ndjson",
+		StartedAt:       started,
+		MaxTurns:        7,
+		ReasoningEffort: "high",
+	}
+}
+
+func recordMappingRecord(started time.Time) Record {
+	return Record{
+		ID:                 "a-map",
+		TaskID:             "task-map",
+		Name:               "mapper",
+		Mode:               "interactive",
+		Provider:           "codex",
+		Model:              "gpt-5.3-codex",
+		ExperimentID:       "exp-1",
+		VariantID:          "variant-a",
+		AssignmentUnit:     "task",
+		AssignmentKey:      "task-map",
+		PID:                12345,
+		SessionID:          "sess-map",
+		LogPath:            "/tmp/sybra/agents/a-map.ndjson",
+		CWD:                "/tmp/sybra/worktrees/task-map",
+		StartedAt:          started,
+		StdinPath:          "/tmp/sybra/agents/a-map.stdin",
+		OneShot:            true,
+		MaxTurns:           7,
+		RequirePermissions: true,
+		ReasoningEffort:    "high",
+	}
+}
+
+func readRegistryFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read registry fixture %s: %v", name, err)
+	}
+	return raw
 }
 
 func assertRecordFixtureCoversFields(t *testing.T, rec Record, ignore ...string) {

--- a/internal/agent/survive_restart_test.go
+++ b/internal/agent/survive_restart_test.go
@@ -224,13 +224,11 @@ func assertRecordFixtureCoversFields(t *testing.T, rec Record, ignore ...string)
 		ignored[field] = struct{}{}
 	}
 	value := reflect.ValueOf(rec)
-	typ := value.Type()
-	for i := range value.NumField() {
-		field := typ.Field(i)
+	for _, field := range reflect.VisibleFields(value.Type()) {
 		if _, ok := ignored[field.Name]; ok {
 			continue
 		}
-		if value.Field(i).IsZero() {
+		if value.FieldByIndex(field.Index).IsZero() {
 			t.Fatalf("record mapping test fixture does not cover Record.%s", field.Name)
 		}
 	}

--- a/internal/agent/testdata/registry_current.yaml
+++ b/internal/agent/testdata/registry_current.yaml
@@ -1,0 +1,21 @@
+id: a-map
+task_id: task-map
+name: mapper
+mode: interactive
+provider: codex
+model: gpt-5.3-codex
+experiment_id: exp-1
+variant_id: variant-a
+assignment_unit: task
+assignment_key: task-map
+pid: 12345
+session_id: sess-map
+log_path: /tmp/sybra/agents/a-map.ndjson
+cwd: /tmp/sybra/worktrees/task-map
+started_at: 2026-06-28T20:30:00Z
+proc_started_at: Mon Jun 28 20:30:00 2026
+stdin_path: /tmp/sybra/agents/a-map.stdin
+one_shot: true
+max_turns: 7
+require_permissions: true
+reasoning_effort: high

--- a/internal/agent/testdata/registry_legacy.yaml
+++ b/internal/agent/testdata/registry_legacy.yaml
@@ -1,0 +1,10 @@
+id: legacy-agent
+task_id: legacy-task
+mode: headless
+provider: claude
+pid: 23456
+session_id: legacy-session
+log_path: /tmp/sybra/agents/legacy-agent.ndjson
+cwd: /tmp/sybra/worktrees/legacy-task
+started_at: 2026-06-28T20:30:00Z
+proc_started_at: Mon Jun 28 20:30:00 2026


### PR DESCRIPTION
## Motivation

Closes https://github.com/Automaat/sybra/issues/1125

Agent registry persistence had duplicate record-mapping logic across manager and reattach paths, making restart behavior harder to maintain consistently.

## Implementation information

- Centralized registry record conversion on the agent model.
- Updated manager and reattach flows to share the same mapping helper.
- Added restart-survival coverage for current and legacy registry fixtures.