### PR TITLE
refactor(agent): hide provider dispatch

### DIFF
--- a/internal/agent/logfile.go
+++ b/internal/agent/logfile.go
@@ -28,7 +28,7 @@ func ParseLogFile(path string, maxEvents int, provider string) ([]StreamEvent, e
 	}
 	defer func() { _ = f.Close() }()
 
-	prov := normalizeProvider(provider)
+	prov := providerByName(provider)
 	var events []StreamEvent
 	sc := bufio.NewScanner(f)
 	sc.Buffer(make([]byte, 0, 256*1024), 1024*1024)

--- a/internal/agent/logfile.go
+++ b/internal/agent/logfile.go
@@ -16,9 +16,8 @@ import (
 // `message.content[]` and the rendered UI shows labeled bubbles with empty
 // text (the bug fixed alongside the interactive history rewrite).
 //
-// `provider` selects the parser ("codex" → ParseCodexLine, "copilot" →
-// ParseCopilotLine, anything else → ParseClaudeLine). Pass the value from
-// AgentRun.Provider.
+// `provider` selects the parser ("claude", "codex", or "copilot"). Empty
+// means the default Claude parser. Pass the value from AgentRun.Provider.
 //
 // Malformed lines are skipped silently.
 func ParseLogFile(path string, maxEvents int, provider string) ([]StreamEvent, error) {
@@ -28,7 +27,10 @@ func ParseLogFile(path string, maxEvents int, provider string) ([]StreamEvent, e
 	}
 	defer func() { _ = f.Close() }()
 
-	prov := providerByName(provider)
+	prov, providerErr := lookupProvider(provider)
+	if providerErr != nil {
+		return nil, providerErr
+	}
 	var events []StreamEvent
 	sc := bufio.NewScanner(f)
 	sc.Buffer(make([]byte, 0, 256*1024), 1024*1024)

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -261,8 +261,15 @@ func (m *Manager) SetMaxConcurrent(n int) {
 }
 
 func (m *Manager) SetDefaultProvider(name string) {
+	prov, err := lookupProvider(name)
+	if err != nil {
+		if m.logger != nil {
+			m.logger.Warn("agent.default_provider.invalid", "provider", name, "err", err)
+		}
+		return
+	}
 	m.mu.Lock()
-	m.defaultProv = normalizeProvider(name)
+	m.defaultProv = prov.Name()
 	m.mu.Unlock()
 }
 
@@ -342,7 +349,14 @@ func (m *Manager) ProviderCanFailover(name string) bool {
 		name = m.defaultProv
 	}
 	m.mu.RUnlock()
-	resolved := normalizeProvider(name)
+	prov, err := lookupProvider(name)
+	if err != nil {
+		if m.logger != nil {
+			m.logger.Warn("agent.failover.provider", "provider", name, "err", err)
+		}
+		return false
+	}
+	resolved := prov.Name()
 	healthy := func(p string) bool {
 		return g == nil || g.IsHealthy(p)
 	}

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -57,7 +57,10 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 	if gateErr != nil {
 		return nil, gateErr
 	}
-	prov := providerByName(resolvedProvider)
+	prov, providerErr := lookupProvider(resolvedProvider)
+	if providerErr != nil {
+		return nil, providerErr
+	}
 	cfg.provider = prov
 
 	m.mu.RLock()
@@ -179,7 +182,14 @@ func (m *Manager) markAgentDone(a *Agent) {
 }
 
 func (m *Manager) buildCommand(cfg RunConfig) (string, error) {
-	prov := providerByName(m.providerForRun(cfg.Provider))
+	resolved, err := m.providerForRun(cfg.Provider)
+	if err != nil {
+		return "", err
+	}
+	prov, err := lookupProvider(resolved)
+	if err != nil {
+		return "", err
+	}
 	model := prov.NormalizeModel(cfg.Model)
 	if model != "" && !safeArgRe.MatchString(model) {
 		return "", fmt.Errorf("invalid model %q: must match %s", cfg.Model, safeArgRe)
@@ -197,7 +207,10 @@ func (m *Manager) buildCommand(cfg RunConfig) (string, error) {
 // peer, the peer is returned. Otherwise returns a typed UnhealthyError so
 // callers can detect via errors.Is(err, provider.ErrProviderUnhealthy).
 func (m *Manager) gateProvider(cfg RunConfig) (string, error) {
-	resolved := m.providerForRun(cfg.Provider)
+	resolved, err := m.providerForRun(cfg.Provider)
+	if err != nil {
+		return "", err
+	}
 	if cfg.IgnoreHealthGate {
 		return resolved, nil
 	}
@@ -219,9 +232,13 @@ func (m *Manager) gateProvider(cfg RunConfig) (string, error) {
 			}
 		}
 		if alt := g.Failover(resolved); alt != "" {
-			metrics.AgentFailover(resolved, alt)
-			m.logger.Warn("agent.run.failover", "from", resolved, "to", alt, "task", cfg.TaskID, "reason", g.Reason(resolved))
-			resolved = alt
+			altProv, err := lookupProvider(alt)
+			if err != nil {
+				return "", err
+			}
+			metrics.AgentFailover(resolved, altProv.Name())
+			m.logger.Warn("agent.run.failover", "from", resolved, "to", altProv.Name(), "task", cfg.TaskID, "reason", g.Reason(resolved))
+			resolved = altProv.Name()
 		} else {
 			reason := g.Reason(resolved)
 			metrics.AgentGated(resolved, reason)
@@ -263,14 +280,18 @@ func (m *Manager) gateProvider(cfg RunConfig) (string, error) {
 	}
 }
 
-func (m *Manager) providerForRun(name string) string {
+func (m *Manager) providerForRun(name string) (string, error) {
 	m.mu.RLock()
 	def := m.defaultProv
 	m.mu.RUnlock()
 	if name == "" {
 		name = def
 	}
-	return normalizeProvider(name)
+	prov, err := lookupProvider(name)
+	if err != nil {
+		return "", err
+	}
+	return prov.Name(), nil
 }
 
 // safeArgRe matches only characters safe to embed in a shell command

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -57,6 +57,8 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 	if gateErr != nil {
 		return nil, gateErr
 	}
+	prov := providerByName(resolvedProvider)
+	cfg.provider = prov
 
 	m.mu.RLock()
 	if cfg.BashTimeoutMs == 0 {
@@ -79,8 +81,8 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 		TaskID:                 cfg.TaskID,
 		Name:                   cfg.Name,
 		Mode:                   cfg.Mode,
-		Provider:               resolvedProvider,
-		Model:                  normalizeModel(resolvedProvider, cfg.Model),
+		Provider:               prov.Name(),
+		Model:                  prov.NormalizeModel(cfg.Model),
 		ReasoningEffort:        cfg.ReasoningEffort,
 		Prompt:                 cfg.Prompt,
 		State:                  StateRunning,
@@ -135,7 +137,7 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 		// spawns a fresh process); claude uses the persistent approval-hook
 		// runner. Copilot's permission model is CLI-flag based (no HTTP
 		// approval hook), so the per-turn shape fits it like codex.
-		if a.Provider == "codex" || a.Provider == "copilot" {
+		if prov.UsesPerTurnConvo() {
 			a.promptCh = make(chan string, 1)
 			go m.runPerTurnConversational(ctx, a, cfg, false)
 		} else {
@@ -177,8 +179,8 @@ func (m *Manager) markAgentDone(a *Agent) {
 }
 
 func (m *Manager) buildCommand(cfg RunConfig) (string, error) {
-	prov := m.providerForRun(cfg.Provider)
-	model := normalizeModel(prov, cfg.Model)
+	prov := providerByName(m.providerForRun(cfg.Provider))
+	model := prov.NormalizeModel(cfg.Model)
 	if model != "" && !safeArgRe.MatchString(model) {
 		return "", fmt.Errorf("invalid model %q: must match %s", cfg.Model, safeArgRe)
 	}
@@ -187,92 +189,7 @@ func (m *Manager) buildCommand(cfg RunConfig) (string, error) {
 			return "", fmt.Errorf("invalid tool %q: must match %s", tool, safeArgRe)
 		}
 	}
-	switch prov {
-	case "codex":
-		return buildCodexCommand(model, cfg.ReasoningEffort, cfg.RequirePermissions, cfg.Mode == "headless"), nil
-	case "copilot":
-		return buildCopilotCommand(model), nil
-	default:
-		return buildClaudeCommand(model, cfg.AllowedTools, cfg.RequirePermissions, cfg.HeadlessPermissionMode), nil
-	}
-}
-
-// buildClaudeCommand builds the display command string for a Claude agent.
-func buildClaudeCommand(model string, allowedTools []string, requirePerms bool, mode string) string {
-	parts := []string{"claude"}
-	parts = append(parts, claudePermissionArgs(allowedTools, requirePerms, mode)...)
-	if model != "" {
-		parts = append(parts, "--model", model)
-	}
-	return strings.Join(parts, " ")
-}
-
-// buildCodexCommand builds the display command string for a Codex agent.
-func buildCodexCommand(model, effort string, requirePerms, headless bool) string {
-	parts := []string{"codex", "exec", "--json", "--skip-git-repo-check", "--ignore-user-config", "--ignore-rules"}
-	parts = append(parts, codexSandboxArgs(requirePerms, headless)...)
-	if model != "" {
-		parts = append(parts, "--model", model)
-	}
-	parts = append(parts, codexReasoningArgs(effort)...)
-	return strings.Join(parts, " ")
-}
-
-// buildCopilotCommand builds the display command string for a Copilot agent.
-// Headless Copilot always runs --allow-all-tools (required for non-interactive
-// mode) and --no-ask-user so it never blocks waiting on a human. The prompt
-// (and its `-p` flag) are omitted here — like buildClaudeCommand /
-// buildCodexCommand, this is a display-only string showing the flags, not a
-// runnable line.
-func buildCopilotCommand(model string) string {
-	parts := []string{"copilot", "--output-format", "json", "--allow-all-tools", "--no-ask-user"}
-	if model != "" {
-		parts = append(parts, "--model", model)
-	}
-	return strings.Join(parts, " ")
-}
-
-// codexReasoningArgs returns the codex config override for model reasoning
-// effort, or nil when effort is empty (model default). Centralizing the
-// empty-value no-op here keeps all three codex builders from each re-deriving
-// it — a bare -c model_reasoning_effort= (empty value) is NOT the same as
-// omitting the flag.
-func codexReasoningArgs(effort string) []string {
-	if effort == "" {
-		return nil
-	}
-	// Allowlist guards against tampered task YAML bypassing API-layer validation.
-	switch effort {
-	case "low", "medium", "high", "xhigh":
-	default:
-		return nil
-	}
-	return []string{"-c", "model_reasoning_effort=" + effort}
-}
-
-// codexSandboxArgs returns the sandbox/permission flags for `codex exec`.
-// When SYBRA_DISABLE_CODEX_SANDBOX=1 is set, the bwrap-backed sandbox is
-// replaced with `--sandbox danger-full-access`. Required when running
-// inside a Docker/LXC container whose kernel blocks unprivileged user
-// namespaces (kernel.unprivileged_userns_clone=0), where bwrap crashes
-// before the agent can execute any command.
-//
-// headless must be true for headless runs. --sandbox workspace-write asks
-// for user approval on writes outside the workspace; in headless mode there
-// is no UI to serve those approval prompts, so they auto-reject and the run
-// fails. Bypass mode is used instead.
-func codexSandboxArgs(requirePerms, headless bool) []string {
-	if os.Getenv("SYBRA_DISABLE_CODEX_SANDBOX") == "1" {
-		return []string{"--sandbox", "danger-full-access"}
-	}
-	if !requirePerms || headless {
-		// Bypass all approval prompts and sandbox restrictions.
-		// For headless runs this is required regardless of RequirePermissions:
-		// --sandbox workspace-write auto-rejects approval requests since there
-		// is no TTY/UI to serve them, which silently breaks the agent run.
-		return []string{"--dangerously-bypass-approvals-and-sandbox"}
-	}
-	return []string{"--sandbox", "workspace-write"}
+	return prov.BuildCommand(cfg, model), nil
 }
 
 // gateProvider resolves the run's provider through the health gate. If the
@@ -354,70 +271,6 @@ func (m *Manager) providerForRun(name string) string {
 		name = def
 	}
 	return normalizeProvider(name)
-}
-
-func normalizeProvider(name string) string {
-	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "", "claude":
-		return "claude"
-	case "codex":
-		return "codex"
-	case "copilot":
-		return "copilot"
-	default:
-		return "claude"
-	}
-}
-
-// copilotDefaultModel is the model Copilot agents use when none is specified.
-// Per the integration decision the default is the latest GPT model available
-// in the installed Copilot binary's registry. If a user's Copilot plan lacks
-// this slug, `copilot --model` errors at exec time — pin a newer slug or
-// "auto" here when that happens.
-const copilotDefaultModel = "gpt-5.5"
-
-func normalizeModel(prov, model string) string {
-	switch normalizeProvider(prov) {
-	case "codex":
-		// Codex models come from `codex debug models` and never carry a [1m]
-		// suffix — a stray suffix stays untouched and is rejected by safeArgRe.
-		switch strings.TrimSpace(model) {
-		case "", "sonnet", "opus", "fable":
-			return "gpt-5.5"
-		case "haiku":
-			return "gpt-5.4-mini"
-		default:
-			return model
-		}
-	case "copilot":
-		// The provider-agnostic short aliases (and the empty default the chat
-		// path passes) map to the latest GPT. Full Copilot slugs
-		// (claude-opus-4.6, gpt-5.5, gemini-3.1-pro-preview, …) selected
-		// in the model picker pass through untouched.
-		switch strings.TrimSpace(model) {
-		case "", "sonnet", "opus", "haiku", "fable":
-			return copilotDefaultModel
-		default:
-			return model
-		}
-	default:
-		// [1m] is a Claude-Code-only context marker. Fable 5 ships a 1M context
-		// window by default, so CC 2.1.173 strips the redundant suffix; Sybra
-		// exposes no 1M variants, so the marker is always redundant here.
-		// Stripping before safeArgRe keeps the validator strict — it intentionally
-		// rejects '[' and ']'. Scoped to the Claude path; Codex strings untouched.
-		model = stripContextSuffix(model)
-		if strings.TrimSpace(model) == "" {
-			return "sonnet"
-		}
-		return model
-	}
-}
-
-var oneMSuffixRe = regexp.MustCompile(`(?i)\[1m\]$`)
-
-func stripContextSuffix(model string) string {
-	return oneMSuffixRe.ReplaceAllString(strings.TrimSpace(model), "")
 }
 
 // safeArgRe matches only characters safe to embed in a shell command

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -27,39 +27,48 @@ func (a *Agent) setAssignment(cfg RunConfig) {
 }
 
 func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
-	// Hard guard: every agent must run in an explicit, existing directory.
-	// An empty Dir means the spawned process inherits Sybra's cwd, which in
-	// dev mode is the Sybra source repo — agents would then mutate its
-	// branches via git checkout. Reject rather than silently leak.
-	if strings.TrimSpace(cfg.Dir) == "" {
-		return nil, fmt.Errorf("agent.Run: Dir is required (empty Dir would leak agent process into Sybra cwd)")
-	}
-	if info, err := os.Stat(cfg.Dir); err != nil {
-		return nil, fmt.Errorf("agent.Run: Dir %q not accessible: %w", cfg.Dir, err)
-	} else if !info.IsDir() {
-		return nil, fmt.Errorf("agent.Run: Dir %q is not a directory", cfg.Dir)
+	cfg, prov, err := m.prepareRunConfig(cfg)
+	if err != nil {
+		return nil, err
 	}
 
-	// Inject the worktree's working-memory scratchpad (NOTES.md): a standing
-	// read/maintain instruction plus the file's current contents, giving Codex
-	// (no --resume) and any restarted agent cross-run continuity. Gated on
-	// SeedWorkingMemory, set only for code-author roles: verifier roles (review,
-	// test-runner, eval) reuse the SAME per-task worktree, so seeding them would
-	// feed an independent reviewer/tester the implementer's notes and quietly
-	// erode the reward-hacking defense. Done on the local cfg copy so the inlined
-	// notes never reach the persisted AgentRun.Prompt, which callers record from
-	// their own prompt variable. No-op when Dir has no NOTES.md.
+	id := uuid.NewString()[:8]
+	ctx, cancel := context.WithCancel(m.ctx)
+	a := newRunningAgent(id, cfg, prov, cancel)
+	if m.survives() && willDetach(cfg) {
+		a.setDetached(true)
+	}
+
+	if err := m.registerRunningAgent(a, cfg, cancel); err != nil {
+		return nil, err
+	}
+
+	metrics.AgentStarted(a.Provider, a.Mode)
+	m.logger.Info("agent.start", "id", id, "taskID", cfg.TaskID, "mode", cfg.Mode, "provider", a.Provider, "model", a.Model)
+
+	if err := m.startAgentRunner(ctx, a, cfg, prov, cancel); err != nil {
+		return nil, err
+	}
+
+	m.emit(events.AgentState(id), a)
+	return a, nil
+}
+
+func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
+	if err := validateRunDir(cfg.Dir); err != nil {
+		return cfg, nil, err
+	}
 	if cfg.SeedWorkingMemory {
 		cfg.Prompt = notes.SeedPrompt(cfg.Prompt, cfg.Dir)
 	}
 
 	resolvedProvider, gateErr := m.gateProvider(cfg)
 	if gateErr != nil {
-		return nil, gateErr
+		return cfg, nil, gateErr
 	}
 	prov, providerErr := lookupProvider(resolvedProvider)
 	if providerErr != nil {
-		return nil, providerErr
+		return cfg, nil, providerErr
 	}
 	cfg.provider = prov
 
@@ -74,10 +83,22 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 		cfg.FallbackModel = m.fallbackModel
 	}
 	m.mu.RUnlock()
+	return cfg, prov, nil
+}
 
-	id := uuid.NewString()[:8]
-	ctx, cancel := context.WithCancel(m.ctx)
+func validateRunDir(dir string) error {
+	if strings.TrimSpace(dir) == "" {
+		return fmt.Errorf("agent.Run: Dir is required (empty Dir would leak agent process into Sybra cwd)")
+	}
+	if info, err := os.Stat(dir); err != nil {
+		return fmt.Errorf("agent.Run: Dir %q not accessible: %w", dir, err)
+	} else if !info.IsDir() {
+		return fmt.Errorf("agent.Run: Dir %q is not a directory", dir)
+	}
+	return nil
+}
 
+func newRunningAgent(id string, cfg RunConfig, prov Provider, cancel context.CancelFunc) *Agent {
 	now := time.Now().UTC()
 	a := &Agent{
 		ID:                     id,
@@ -108,30 +129,25 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 		a.escalationCh = make(chan bool, 1)
 	}
 	a.setAssignment(cfg)
-	// Pre-mark detached so a shutdown racing the runner goroutine already
-	// knows to leave this agent's record alive. Headless and interactive
-	// Claude survive as detached processes; codex interactive has no
-	// persistent process and survives by recreate-on-restart, but is still
-	// marked so ShutdownWithGrace leaves its record for recreate.
-	if m.survives() && willDetach(cfg) {
-		a.setDetached(true)
-	}
+	return a
+}
 
+func (m *Manager) registerRunningAgent(a *Agent, cfg RunConfig, cancel context.CancelFunc) error {
 	m.mu.Lock()
 	if !cfg.IgnoreConcurrencyLimit && m.maxConcurrent > 0 && m.liveCount >= m.maxConcurrent {
 		m.mu.Unlock()
 		cancel()
-		return nil, fmt.Errorf("max concurrent agents reached (%d)", m.maxConcurrent)
+		return fmt.Errorf("max concurrent agents reached (%d)", m.maxConcurrent)
 	}
-	m.agents[id] = a
+	m.agents[a.ID] = a
 	if a.done != nil {
 		m.liveCount++
 	}
 	m.mu.Unlock()
+	return nil
+}
 
-	metrics.AgentStarted(a.Provider, a.Mode)
-	m.logger.Info("agent.start", "id", id, "taskID", cfg.TaskID, "mode", cfg.Mode, "provider", a.Provider, "model", a.Model)
-
+func (m *Manager) startAgentRunner(ctx context.Context, a *Agent, cfg RunConfig, prov Provider, cancel context.CancelFunc) error {
 	switch cfg.Mode {
 	case "headless":
 		go m.runHeadless(ctx, a, cfg)
@@ -149,11 +165,9 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 		}
 	default:
 		cancel()
-		return nil, fmt.Errorf("unknown mode: %s", cfg.Mode)
+		return fmt.Errorf("unknown mode: %s", cfg.Mode)
 	}
-
-	m.emit(events.AgentState(id), a)
-	return a, nil
+	return nil
 }
 
 func (m *Manager) markAgentDone(a *Agent) {

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -749,6 +749,10 @@ type RunConfig struct {
 	// Only effective for claude headless runs when AllowedTools is empty and
 	// RequirePermissions is false.
 	HeadlessPermissionMode string
+	// provider is the implementation selected once at run start after health
+	// gates and failover. Replay paths that do not have RunConfig resolve from
+	// the persisted provider string instead.
+	provider Provider
 }
 
 // PermissionDenial records a single auto-mode classifier denial observed during

--- a/internal/agent/provider.go
+++ b/internal/agent/provider.go
@@ -1,0 +1,89 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	providerpkg "github.com/Automaat/sybra/internal/provider"
+)
+
+type headlessInvocation struct {
+	name    string
+	args    []string
+	env     []string
+	command string
+}
+
+type perTurnConvoInvocation struct {
+	bin  string
+	args []string
+}
+
+type Provider interface {
+	Name() string
+	NormalizeModel(model string) string
+	BuildCommand(cfg RunConfig, model string) string
+	BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headlessInvocation, error)
+	ParseHeadlessLine(line []byte) (StreamEvent, error)
+	SandboxArgs(requirePerms, headless bool) []string
+	SupportsOutputSchema() bool
+	UsesPerTurnConvo() bool
+	BuildPerTurnConvoInvocation(a *Agent, cfg RunConfig, prompt string) perTurnConvoInvocation
+	ParseConvoLine(line []byte) (ConvoEvent, error)
+	SessionFilePath(sessionID string) string
+	ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration)
+}
+
+type baseProvider struct{}
+
+func (baseProvider) SandboxArgs(bool, bool) []string { return nil }
+
+func (baseProvider) SupportsOutputSchema() bool { return false }
+
+func (baseProvider) UsesPerTurnConvo() bool { return false }
+
+func (baseProvider) BuildPerTurnConvoInvocation(a *Agent, _ RunConfig, _ string) perTurnConvoInvocation {
+	return perTurnConvoInvocation{bin: providerByName(a.Provider).Name()}
+}
+
+func (baseProvider) ParseConvoLine([]byte) (ConvoEvent, error) {
+	return ConvoEvent{}, fmt.Errorf("provider does not support per-turn conversational parsing")
+}
+
+func (baseProvider) SessionFilePath(string) string { return "" }
+
+var agentProviders = map[string]Provider{}
+
+func registerAgentProvider(p Provider) {
+	agentProviders[p.Name()] = p
+}
+
+func providerByName(name string) Provider {
+	key := strings.ToLower(strings.TrimSpace(name))
+	if p, ok := agentProviders[key]; ok {
+		return p
+	}
+	if p, ok := agentProviders["claude"]; ok {
+		return p
+	}
+	panic("agent: claude provider not registered")
+}
+
+func normalizeProvider(name string) string {
+	return providerByName(name).Name()
+}
+
+func normalizeModel(prov, model string) string {
+	return providerByName(prov).NormalizeModel(model)
+}
+
+func providerForInvocation(a *Agent, cfg RunConfig) Provider {
+	if cfg.provider != nil {
+		return cfg.provider
+	}
+	if a != nil && a.Provider != "" {
+		return providerByName(a.Provider)
+	}
+	return providerByName(cfg.Provider)
+}

--- a/internal/agent/provider.go
+++ b/internal/agent/provider.go
@@ -44,7 +44,11 @@ func (baseProvider) SupportsOutputSchema() bool { return false }
 func (baseProvider) UsesPerTurnConvo() bool { return false }
 
 func (baseProvider) BuildPerTurnConvoInvocation(a *Agent, _ RunConfig, _ string) perTurnConvoInvocation {
-	return perTurnConvoInvocation{bin: providerByName(a.Provider).Name()}
+	bin := strings.ToLower(strings.TrimSpace(a.Provider))
+	if bin == "" {
+		bin = "claude"
+	}
+	return perTurnConvoInvocation{bin: bin}
 }
 
 func (baseProvider) ParseConvoLine([]byte) (ConvoEvent, error) {
@@ -59,15 +63,23 @@ func registerAgentProvider(p Provider) {
 	agentProviders[p.Name()] = p
 }
 
-func providerByName(name string) Provider {
+func lookupProvider(name string) (Provider, error) {
 	key := strings.ToLower(strings.TrimSpace(name))
+	if key == "" {
+		key = "claude"
+	}
 	if p, ok := agentProviders[key]; ok {
-		return p
+		return p, nil
 	}
-	if p, ok := agentProviders["claude"]; ok {
-		return p
+	return nil, fmt.Errorf("unknown agent provider %q", name)
+}
+
+func providerByName(name string) Provider {
+	p, err := lookupProvider(name)
+	if err != nil {
+		panic(err)
 	}
-	panic("agent: claude provider not registered")
+	return p
 }
 
 func normalizeProvider(name string) string {
@@ -78,12 +90,12 @@ func normalizeModel(prov, model string) string {
 	return providerByName(prov).NormalizeModel(model)
 }
 
-func providerForInvocation(a *Agent, cfg RunConfig) Provider {
+func providerForInvocation(a *Agent, cfg RunConfig) (Provider, error) {
 	if cfg.provider != nil {
-		return cfg.provider
+		return cfg.provider, nil
 	}
 	if a != nil && a.Provider != "" {
-		return providerByName(a.Provider)
+		return lookupProvider(a.Provider)
 	}
-	return providerByName(cfg.Provider)
+	return lookupProvider(cfg.Provider)
 }

--- a/internal/agent/provider_claude.go
+++ b/internal/agent/provider_claude.go
@@ -1,0 +1,126 @@
+package agent
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	providerpkg "github.com/Automaat/sybra/internal/provider"
+)
+
+type claudeProvider struct {
+	baseProvider
+}
+
+func init() {
+	registerAgentProvider(claudeProvider{})
+}
+
+func (claudeProvider) Name() string { return "claude" }
+
+func (claudeProvider) NormalizeModel(model string) string {
+	// [1m] is a Claude-Code-only context marker. Fable 5 ships a 1M context
+	// window by default, so CC 2.1.173 strips the redundant suffix; Sybra
+	// exposes no 1M variants, so the marker is always redundant here.
+	// Stripping before safeArgRe keeps the validator strict — it intentionally
+	// rejects '[' and ']'. Scoped to the Claude path; Codex strings untouched.
+	model = stripContextSuffix(model)
+	if strings.TrimSpace(model) == "" {
+		return "sonnet"
+	}
+	return model
+}
+
+func (claudeProvider) BuildCommand(cfg RunConfig, model string) string {
+	return buildClaudeCommand(model, cfg.AllowedTools, cfg.RequirePermissions, cfg.HeadlessPermissionMode)
+}
+
+func (claudeProvider) BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headlessInvocation, error) {
+	args := []string{"-p", cfg.Prompt, "--output-format", "stream-json", "--verbose"}
+	if sid := a.GetSessionID(); sid != "" {
+		args = append(args, "--resume", sid)
+	}
+	args = append(args, claudePermissionArgs(cfg.AllowedTools, cfg.RequirePermissions, cfg.HeadlessPermissionMode)...)
+	if a.Model != "" {
+		args = append(args, "--model", a.Model)
+	}
+	if cfg.FallbackModel != "" {
+		args = append(args, "--fallback-model", cfg.FallbackModel)
+	}
+	var env []string
+	if cfg.BashTimeoutMs > 0 {
+		// Claude has no `--bashTimeoutMs` CLI flag — the supported channel is
+		// the BASH_DEFAULT_TIMEOUT_MS / BASH_MAX_TIMEOUT_MS env vars. Set both
+		// so the configured value is honored even when it exceeds claude's
+		// built-in max (600000 ms).
+		ms := strconv.Itoa(cfg.BashTimeoutMs)
+		env = append(env,
+			"BASH_DEFAULT_TIMEOUT_MS="+ms,
+			"BASH_MAX_TIMEOUT_MS="+ms,
+		)
+	}
+	if cfg.ForkSubagent {
+		env = append(env, "CLAUDE_CODE_FORK_SUBAGENT=1")
+	}
+	if cfg.RetryWatchdog > 0 {
+		// CLAUDE_CODE_RETRY_WATCHDOG replaces CLAUDE_CODE_MAX_RETRIES (now
+		// capped at 15) for unattended/server headless runs. Delivered via env
+		// because claude has no equivalent CLI flag.
+		env = append(env, "CLAUDE_CODE_RETRY_WATCHDOG="+strconv.Itoa(cfg.RetryWatchdog))
+	}
+	return headlessInvocation{
+		name:    "claude",
+		args:    args,
+		env:     env,
+		command: "claude " + strings.Join(args, " "),
+	}, nil
+}
+
+func (claudeProvider) ParseHeadlessLine(line []byte) (StreamEvent, error) {
+	ce, err := ParseClaudeLine(line)
+	if err != nil {
+		return StreamEvent{}, err
+	}
+	return claudeEventToStreamEvent(ce), nil
+}
+
+func (claudeProvider) ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration) {
+	return providerpkg.ClassifyClaudeError(sample)
+}
+
+// buildClaudeCommand builds the display command string for a Claude agent.
+func buildClaudeCommand(model string, allowedTools []string, requirePerms bool, mode string) string {
+	parts := []string{"claude"}
+	parts = append(parts, claudePermissionArgs(allowedTools, requirePerms, mode)...)
+	if model != "" {
+		parts = append(parts, "--model", model)
+	}
+	return strings.Join(parts, " ")
+}
+
+// claudePermissionArgs returns the permission-related CLI flags for a claude headless run.
+//
+// Precedence:
+//  1. len(allowed)>0 -> --allowedTools <list> (explicit tool allowlist wins)
+//  2. requirePerms -> nil (approval-hook mode; no bypass or auto flag)
+//  3. mode=="auto" -> --permission-mode auto (auto-mode classifier)
+//  4. else -> --dangerously-skip-permissions (legacy bypass, default)
+func claudePermissionArgs(allowed []string, requirePerms bool, mode string) []string {
+	if len(allowed) > 0 {
+		return []string{"--allowedTools", strings.Join(allowed, ",")}
+	}
+	if requirePerms {
+		return nil
+	}
+	if mode == "auto" {
+		return []string{"--permission-mode", "auto"}
+	}
+	return []string{"--dangerously-skip-permissions"}
+}
+
+var oneMSuffixRe = regexp.MustCompile(`(?i)\[1m\]$`)
+
+func stripContextSuffix(model string) string {
+	return oneMSuffixRe.ReplaceAllString(strings.TrimSpace(model), "")
+}

--- a/internal/agent/provider_codex.go
+++ b/internal/agent/provider_codex.go
@@ -1,0 +1,150 @@
+package agent
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	providerpkg "github.com/Automaat/sybra/internal/provider"
+)
+
+type codexProvider struct{}
+
+func init() {
+	registerAgentProvider(codexProvider{})
+}
+
+func (codexProvider) Name() string { return "codex" }
+
+func (codexProvider) NormalizeModel(model string) string {
+	// Codex models come from `codex debug models` and never carry a [1m]
+	// suffix — a stray suffix stays untouched and is rejected by safeArgRe.
+	switch strings.TrimSpace(model) {
+	case "", "sonnet", "opus", "fable":
+		return "gpt-5.5"
+	case "haiku":
+		return "gpt-5.4-mini"
+	default:
+		return model
+	}
+}
+
+func (p codexProvider) BuildCommand(cfg RunConfig, model string) string {
+	return buildCodexCommand(model, cfg.ReasoningEffort, cfg.RequirePermissions, cfg.Mode == "headless", p)
+}
+
+func (p codexProvider) BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headlessInvocation, error) {
+	args := []string{"exec", "--json", "--skip-git-repo-check", "--ignore-user-config", "--ignore-rules"}
+	// headless=true: --sandbox workspace-write requires approval prompts
+	// which auto-reject in headless mode (no TTY/UI). Always bypass.
+	args = append(args, p.SandboxArgs(cfg.RequirePermissions, true)...)
+	if a.Model != "" {
+		args = append(args, "--model", a.Model)
+	}
+	args = append(args, codexReasoningArgs(a.ReasoningEffort)...)
+	if a.sessionCWD != "" {
+		args = append(args, "-C", a.sessionCWD)
+	}
+	if cfg.outputSchemaPath != "" {
+		args = append(args, "--output-schema", cfg.outputSchemaPath)
+	}
+	// Lifecycle hooks (fail-open: omitted when sybra-cli unresolvable or taskID unsafe).
+	args = append(args, buildCodexHookArgs(a.TaskID)...)
+	prompt := rewriteSkillInvocations(cfg.Prompt, discoverCodexSkills())
+	args = append(args, prompt)
+	return headlessInvocation{
+		name:    "codex",
+		args:    args,
+		command: "codex " + strings.Join(args, " "),
+	}, nil
+}
+
+func (codexProvider) ParseHeadlessLine(line []byte) (StreamEvent, error) {
+	ce, err := ParseCodexLine(line)
+	if err != nil {
+		return StreamEvent{}, err
+	}
+	return codexEventToStreamEvent(ce), nil
+}
+
+func (codexProvider) SandboxArgs(requirePerms, headless bool) []string {
+	if os.Getenv("SYBRA_DISABLE_CODEX_SANDBOX") == "1" {
+		return []string{"--sandbox", "danger-full-access"}
+	}
+	if !requirePerms || headless {
+		// Bypass all approval prompts and sandbox restrictions.
+		// For headless runs this is required regardless of RequirePermissions:
+		// --sandbox workspace-write auto-rejects approval requests since there
+		// is no TTY/UI to serve them, which silently breaks the agent run.
+		return []string{"--dangerously-bypass-approvals-and-sandbox"}
+	}
+	return []string{"--sandbox", "workspace-write"}
+}
+
+func (codexProvider) SupportsOutputSchema() bool { return true }
+
+func (codexProvider) UsesPerTurnConvo() bool { return true }
+
+func (p codexProvider) BuildPerTurnConvoInvocation(a *Agent, cfg RunConfig, prompt string) perTurnConvoInvocation {
+	return perTurnConvoInvocation{bin: "codex", args: buildCodexConvoArgsWithProvider(a, cfg, prompt, p)}
+}
+
+func (codexProvider) ParseConvoLine(line []byte) (ConvoEvent, error) {
+	ce, err := ParseCodexLine(line)
+	if err != nil {
+		return ConvoEvent{}, err
+	}
+	return codexEventToConvoEvent(ce), nil
+}
+
+func (codexProvider) SessionFilePath(sessionID string) string {
+	return resolveCodexSessionFile(sessionID)
+}
+
+func (codexProvider) ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration) {
+	return providerpkg.ClassifyCodexError(sample)
+}
+
+// buildCodexCommand builds the display command string for a Codex agent.
+func buildCodexCommand(model, effort string, requirePerms, headless bool, p Provider) string {
+	parts := []string{"codex", "exec", "--json", "--skip-git-repo-check", "--ignore-user-config", "--ignore-rules"}
+	parts = append(parts, p.SandboxArgs(requirePerms, headless)...)
+	if model != "" {
+		parts = append(parts, "--model", model)
+	}
+	parts = append(parts, codexReasoningArgs(effort)...)
+	return strings.Join(parts, " ")
+}
+
+// codexReasoningArgs returns the codex config override for model reasoning
+// effort, or nil when effort is empty (model default). Centralizing the
+// empty-value no-op here keeps all three codex builders from each re-deriving
+// it — a bare -c model_reasoning_effort= (empty value) is NOT the same as
+// omitting the flag.
+func codexReasoningArgs(effort string) []string {
+	if effort == "" {
+		return nil
+	}
+	// Allowlist guards against tampered task YAML bypassing API-layer validation.
+	switch effort {
+	case "low", "medium", "high", "xhigh":
+	default:
+		return nil
+	}
+	return []string{"-c", "model_reasoning_effort=" + effort}
+}
+
+// codexSandboxArgs returns the sandbox/permission flags for `codex exec`.
+// When SYBRA_DISABLE_CODEX_SANDBOX=1 is set, the bwrap-backed sandbox is
+// replaced with `--sandbox danger-full-access`. Required when running
+// inside a Docker/LXC container whose kernel blocks unprivileged user
+// namespaces (kernel.unprivileged_userns_clone=0), where bwrap crashes
+// before the agent can execute any command.
+//
+// headless must be true for headless runs. --sandbox workspace-write asks
+// for user approval on writes outside the workspace; in headless mode there
+// is no UI to serve those approval prompts, so they auto-reject and the run
+// fails. Bypass mode is used instead.
+func codexSandboxArgs(requirePerms, headless bool) []string {
+	return providerByName("codex").SandboxArgs(requirePerms, headless)
+}

--- a/internal/agent/provider_copilot.go
+++ b/internal/agent/provider_copilot.go
@@ -1,0 +1,102 @@
+package agent
+
+import (
+	"strings"
+	"time"
+
+	providerpkg "github.com/Automaat/sybra/internal/provider"
+)
+
+// copilotDefaultModel is the model Copilot agents use when none is specified.
+// Per the integration decision the default is the latest GPT model available
+// in the installed Copilot binary's registry. If a user's Copilot plan lacks
+// this slug, `copilot --model` errors at exec time — pin a newer slug or
+// "auto" here when that happens.
+const copilotDefaultModel = "gpt-5.5"
+
+type copilotProvider struct {
+	baseProvider
+}
+
+func init() {
+	registerAgentProvider(copilotProvider{})
+}
+
+func (copilotProvider) Name() string { return "copilot" }
+
+func (copilotProvider) NormalizeModel(model string) string {
+	// The provider-agnostic short aliases (and the empty default the chat
+	// path passes) map to the latest GPT. Full Copilot slugs
+	// (claude-opus-4.6, gpt-5.5, gemini-3.1-pro-preview, ...) selected
+	// in the model picker pass through untouched.
+	switch strings.TrimSpace(model) {
+	case "", "sonnet", "opus", "haiku", "fable":
+		return copilotDefaultModel
+	default:
+		return model
+	}
+}
+
+func (copilotProvider) BuildCommand(_ RunConfig, model string) string {
+	return buildCopilotCommand(model)
+}
+
+func (copilotProvider) BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headlessInvocation, error) {
+	// --allow-all-tools is required for non-interactive mode; --no-ask-user
+	// stops the agent blocking on questions (no TTY/UI to answer them).
+	args := []string{"-p", cfg.Prompt, "--output-format", "json", "--allow-all-tools", "--no-ask-user"}
+	if a.Model != "" {
+		args = append(args, "--model", a.Model)
+	}
+	// Copilot only reports its session id on the terminal result event, so
+	// a resume id is available only for an intentional stop/restart. Use
+	// --session-id (unambiguous required-value flag) over --resume[=value].
+	if sid := a.GetSessionID(); sid != "" {
+		args = append(args, "--session-id", sid)
+	}
+	return headlessInvocation{
+		name:    "copilot",
+		args:    args,
+		command: "copilot " + strings.Join(args, " "),
+	}, nil
+}
+
+func (copilotProvider) ParseHeadlessLine(line []byte) (StreamEvent, error) {
+	ce, err := ParseCopilotLine(line)
+	if err != nil {
+		return StreamEvent{}, err
+	}
+	return copilotEventToStreamEvent(ce), nil
+}
+
+func (copilotProvider) UsesPerTurnConvo() bool { return true }
+
+func (copilotProvider) BuildPerTurnConvoInvocation(a *Agent, _ RunConfig, prompt string) perTurnConvoInvocation {
+	return perTurnConvoInvocation{bin: "copilot", args: buildCopilotConvoArgs(a, prompt)}
+}
+
+func (copilotProvider) ParseConvoLine(line []byte) (ConvoEvent, error) {
+	ce, err := ParseCopilotLine(line)
+	if err != nil {
+		return ConvoEvent{}, err
+	}
+	return copilotEventToConvoEvent(ce), nil
+}
+
+func (copilotProvider) ClassifyError(sample providerpkg.ErrorSample) (providerpkg.Signal, string, time.Duration) {
+	return providerpkg.ClassifyCopilotError(sample)
+}
+
+// buildCopilotCommand builds the display command string for a Copilot agent.
+// Headless Copilot always runs --allow-all-tools (required for non-interactive
+// mode) and --no-ask-user so it never blocks waiting on a human. The prompt
+// (and its `-p` flag) are omitted here — like buildClaudeCommand /
+// buildCodexCommand, this is a display-only string showing the flags, not a
+// runnable line.
+func buildCopilotCommand(model string) string {
+	parts := []string{"copilot", "--output-format", "json", "--allow-all-tools", "--no-ask-user"}
+	if model != "" {
+		parts = append(parts, "--model", model)
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/agent/provider_lookup_test.go
+++ b/internal/agent/provider_lookup_test.go
@@ -1,0 +1,56 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestProviderLookupDefaultsOnlyEmptyName(t *testing.T) {
+	t.Parallel()
+
+	prov, err := lookupProvider("")
+	if err != nil {
+		t.Fatalf("lookupProvider(empty): %v", err)
+	}
+	if prov.Name() != "claude" {
+		t.Fatalf("lookupProvider(empty) = %q, want claude", prov.Name())
+	}
+
+	if _, err := lookupProvider("future-provider"); err == nil || !strings.Contains(err.Error(), "unknown agent provider") {
+		t.Fatalf("lookupProvider(unknown) err = %v, want unknown provider error", err)
+	}
+}
+
+func TestUnknownProviderRejectedByInvocationReplayAndConvoParsing(t *testing.T) {
+	t.Parallel()
+
+	if name, _, _, _, err := buildHeadlessInvocation(&Agent{Provider: ""}, RunConfig{Prompt: "ok"}); err != nil || name != "claude" {
+		t.Fatalf("buildHeadlessInvocation(empty provider) = name %q err %v, want claude nil", name, err)
+	}
+	if _, _, _, _, err := buildHeadlessInvocation(&Agent{Provider: "future-provider"}, RunConfig{Prompt: "ok"}); err == nil {
+		t.Fatal("buildHeadlessInvocation(unknown provider) succeeded, want error")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.ndjson")
+	line := `{"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}` + "\n"
+	if err := os.WriteFile(path, []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	events, err := ParseLogFile(path, 0, "")
+	if err != nil {
+		t.Fatalf("ParseLogFile(empty provider): %v", err)
+	}
+	if len(events) != 1 || events[0].Content != "hello" {
+		t.Fatalf("ParseLogFile(empty provider) = %+v, want assistant hello", events)
+	}
+	if _, err := ParseLogFile(path, 0, "future-provider"); err == nil {
+		t.Fatal("ParseLogFile(unknown provider) succeeded, want error")
+	}
+
+	if _, err := parseConvoEvent("future-provider", []byte(line)); err == nil || !strings.Contains(err.Error(), "unknown agent provider") {
+		t.Fatalf("parseConvoEvent(unknown provider) err = %v, want unknown provider error", err)
+	}
+}

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -58,7 +58,7 @@ func (m *Manager) ReattachAll() []*Agent {
 		if r.Mode == "interactive" {
 			// codex and copilot are per-turn conversational agents recreated
 			// on restart; claude interactive reattaches to its live process.
-			if p := normalizeProvider(r.Provider); p == "codex" || p == "copilot" {
+			if providerByName(r.Provider).UsesPerTurnConvo() {
 				if a := m.reattachPerTurnConvo(r, reg); a != nil {
 					out = append(out, a)
 				}
@@ -396,7 +396,7 @@ func rehydrateFromLog(a *Agent, path string) int64 {
 		return 0
 	}
 
-	provider := normalizeProvider(a.Provider)
+	provider := providerByName(a.Provider)
 	var offset int64
 	start := 0
 	for i := range data {

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -58,7 +58,12 @@ func (m *Manager) ReattachAll() []*Agent {
 		if r.Mode == "interactive" {
 			// codex and copilot are per-turn conversational agents recreated
 			// on restart; claude interactive reattaches to its live process.
-			if providerByName(r.Provider).UsesPerTurnConvo() {
+			prov, providerErr := lookupProvider(r.Provider)
+			if providerErr != nil {
+				m.logger.Warn("agent.reattach.provider", "id", r.ID, "provider", r.Provider, "err", providerErr)
+				continue
+			}
+			if prov.UsesPerTurnConvo() {
 				if a := m.reattachPerTurnConvo(r, reg); a != nil {
 					out = append(out, a)
 				}
@@ -396,7 +401,11 @@ func rehydrateFromLog(a *Agent, path string) int64 {
 		return 0
 	}
 
-	provider := providerByName(a.Provider)
+	provider, providerErr := lookupProvider(a.Provider)
+	if providerErr != nil {
+		a.SetError("provider", providerErr.Error())
+		return 0
+	}
 	var offset int64
 	start := 0
 	for i := range data {

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -229,7 +229,12 @@ func (m *Manager) runPerTurnConversational(ctx context.Context, a *Agent, cfg Ru
 // `copilot -p --output-format json`) and streams output as ConvoEvents.
 // Returns true only when the turn produced a terminal result and exited cleanly.
 func (m *Manager) runConvoTurn(ctx context.Context, a *Agent, cfg RunConfig, prompt string, logWriter io.Writer) bool {
-	bin, args := buildPerTurnConvoArgs(a, cfg, prompt)
+	bin, args, err := buildPerTurnConvoArgs(a, cfg, prompt)
+	if err != nil {
+		m.logger.Error("agent.convo.provider", "id", a.ID, "provider", a.Provider, "err", err)
+		a.SetError("provider", err.Error())
+		return false
+	}
 	cmd := exec.CommandContext(ctx, bin, args...)
 	configureGracefulShutdown(cmd)
 	if a.sessionCWD != "" {
@@ -308,9 +313,13 @@ func resultConvoStreamError(streamEvents []ConvoEvent) error {
 
 // buildPerTurnConvoArgs returns the binary name and argv for one per-turn
 // conversational turn, dispatching on the agent's provider.
-func buildPerTurnConvoArgs(a *Agent, cfg RunConfig, prompt string) (bin string, args []string) {
-	inv := providerForInvocation(a, cfg).BuildPerTurnConvoInvocation(a, cfg, prompt)
-	return inv.bin, inv.args
+func buildPerTurnConvoArgs(a *Agent, cfg RunConfig, prompt string) (bin string, args []string, err error) {
+	prov, err := providerForInvocation(a, cfg)
+	if err != nil {
+		return "", nil, err
+	}
+	inv := prov.BuildPerTurnConvoInvocation(a, cfg, prompt)
+	return inv.bin, inv.args, nil
 }
 
 func buildCodexConvoArgs(a *Agent, cfg RunConfig, prompt string) []string {
@@ -448,7 +457,11 @@ func (m *Manager) streamPerTurnConvoOutput(a *Agent, stdout io.Reader, outFile i
 // provider-appropriate parser. Only codex/copilot use the per-turn path;
 // claude conversational is handled in runner_convo.go.
 func parseConvoEvent(provider string, line []byte) (ConvoEvent, error) {
-	return providerByName(provider).ParseConvoLine(line)
+	prov, err := lookupProvider(provider)
+	if err != nil {
+		return ConvoEvent{}, err
+	}
+	return prov.ParseConvoLine(line)
 }
 
 // rehydratePerTurnConvoFromLog replays a per-turn (codex/copilot)

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -309,17 +309,19 @@ func resultConvoStreamError(streamEvents []ConvoEvent) error {
 // buildPerTurnConvoArgs returns the binary name and argv for one per-turn
 // conversational turn, dispatching on the agent's provider.
 func buildPerTurnConvoArgs(a *Agent, cfg RunConfig, prompt string) (bin string, args []string) {
-	if normalizeProvider(a.Provider) == "copilot" {
-		return "copilot", buildCopilotConvoArgs(a, prompt)
-	}
-	return "codex", buildCodexConvoArgs(a, cfg, prompt)
+	inv := providerForInvocation(a, cfg).BuildPerTurnConvoInvocation(a, cfg, prompt)
+	return inv.bin, inv.args
 }
 
 func buildCodexConvoArgs(a *Agent, cfg RunConfig, prompt string) []string {
+	return buildCodexConvoArgsWithProvider(a, cfg, prompt, providerByName("codex"))
+}
+
+func buildCodexConvoArgsWithProvider(a *Agent, cfg RunConfig, prompt string, provider Provider) []string {
 	args := []string{"exec", "--json", "--skip-git-repo-check", "--ignore-user-config", "--ignore-rules"}
 	// headless=false: interactive (conversational) mode has a human present
 	// who can approve sandbox prompts via the UI.
-	args = append(args, codexSandboxArgs(cfg.RequirePermissions, false)...)
+	args = append(args, provider.SandboxArgs(cfg.RequirePermissions, false)...)
 	if a.Model != "" {
 		args = append(args, "--model", a.Model)
 	}
@@ -443,21 +445,10 @@ func (m *Manager) streamPerTurnConvoOutput(a *Agent, stdout io.Reader, outFile i
 }
 
 // parseConvoEvent parses one per-turn NDJSON line into a ConvoEvent using the
-// provider-appropriate parser. Only codex/copilot use the per-turn path
-// (claude conversational is handled in runner_convo.go), so the default is codex.
+// provider-appropriate parser. Only codex/copilot use the per-turn path;
+// claude conversational is handled in runner_convo.go.
 func parseConvoEvent(provider string, line []byte) (ConvoEvent, error) {
-	if normalizeProvider(provider) == "copilot" {
-		ce, err := ParseCopilotLine(line)
-		if err != nil {
-			return ConvoEvent{}, err
-		}
-		return copilotEventToConvoEvent(ce), nil
-	}
-	ce, err := ParseCodexLine(line)
-	if err != nil {
-		return ConvoEvent{}, err
-	}
-	return codexEventToConvoEvent(ce), nil
+	return providerByName(provider).ParseConvoLine(line)
 }
 
 // rehydratePerTurnConvoFromLog replays a per-turn (codex/copilot)

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -119,7 +119,11 @@ func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfi
 	// removed after cmd.Wait() returns (subprocess has exited), so there is no
 	// read-after-delete risk. os.CreateTemp gives a unique name per attempt so
 	// concurrent agents or retries never collide.
-	if providerForInvocation(a, cfg).SupportsOutputSchema() && cfg.OutputSchema != "" {
+	prov, err := providerForInvocation(a, cfg)
+	if err != nil {
+		return false, err
+	}
+	if prov.SupportsOutputSchema() && cfg.OutputSchema != "" {
 		f, schemaErr := os.CreateTemp("", "sybra-codex-schema-*.json")
 		if schemaErr != nil {
 			return false, fmt.Errorf("create codex output schema: %w", schemaErr)
@@ -389,7 +393,12 @@ func (m *Manager) tailHeadlessFile(ctx context.Context, a *Agent, path string, s
 
 	var buf []byte
 	var lastEmit time.Time
-	prov := providerByName(a.Provider)
+	prov, providerErr := lookupProvider(a.Provider)
+	if providerErr != nil {
+		m.logger.Error("agent.headless.tail.provider", "id", a.ID, "provider", a.Provider, "err", providerErr)
+		a.SetError("provider", providerErr.Error())
+		return true, offset
+	}
 
 	// end is the byte position after the last complete line consumed: total
 	// bytes read minus any trailing partial line still buffered. Resuming a
@@ -488,7 +497,12 @@ func (m *Manager) streamHeadlessOutput(ctx context.Context, a *Agent, stdout io.
 	scanner := bufio.NewScanner(tracked)
 	scanner.Buffer(make([]byte, 0, headlessScannerBuffer), headlessScannerBuffer)
 	var lastEmit time.Time
-	prov := providerByName(a.Provider)
+	prov, providerErr := lookupProvider(a.Provider)
+	if providerErr != nil {
+		m.logger.Error("agent.headless.stream.provider", "id", a.ID, "provider", a.Provider, "err", providerErr)
+		a.SetError("provider", providerErr.Error())
+		return
+	}
 	for scanner.Scan() {
 		line := scanner.Bytes()
 

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -119,7 +119,7 @@ func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfi
 	// removed after cmd.Wait() returns (subprocess has exited), so there is no
 	// read-after-delete risk. os.CreateTemp gives a unique name per attempt so
 	// concurrent agents or retries never collide.
-	if normalizeProvider(a.Provider) == "codex" && cfg.OutputSchema != "" {
+	if providerForInvocation(a, cfg).SupportsOutputSchema() && cfg.OutputSchema != "" {
 		f, schemaErr := os.CreateTemp("", "sybra-codex-schema-*.json")
 		if schemaErr != nil {
 			return false, fmt.Errorf("create codex output schema: %w", schemaErr)
@@ -389,7 +389,7 @@ func (m *Manager) tailHeadlessFile(ctx context.Context, a *Agent, path string, s
 
 	var buf []byte
 	var lastEmit time.Time
-	provider := normalizeProvider(a.Provider)
+	prov := providerByName(a.Provider)
 
 	// end is the byte position after the last complete line consumed: total
 	// bytes read minus any trailing partial line still buffered. Resuming a
@@ -416,7 +416,7 @@ func (m *Manager) tailHeadlessFile(ctx context.Context, a *Agent, path string, s
 			}
 			line := buf[:i]
 			buf = buf[i+1:]
-			if m.processHeadlessLine(ctx, a, line, &lastEmit, provider) {
+			if m.processHeadlessLine(ctx, a, line, &lastEmit, prov) {
 				return true
 			}
 		}
@@ -488,7 +488,7 @@ func (m *Manager) streamHeadlessOutput(ctx context.Context, a *Agent, stdout io.
 	scanner := bufio.NewScanner(tracked)
 	scanner.Buffer(make([]byte, 0, headlessScannerBuffer), headlessScannerBuffer)
 	var lastEmit time.Time
-	provider := normalizeProvider(a.Provider)
+	prov := providerByName(a.Provider)
 	for scanner.Scan() {
 		line := scanner.Bytes()
 
@@ -497,7 +497,7 @@ func (m *Manager) streamHeadlessOutput(ctx context.Context, a *Agent, stdout io.
 			_, _ = outFile.Write([]byte("\n"))
 		}
 
-		if m.processHeadlessLine(ctx, a, line, &lastEmit, provider) {
+		if m.processHeadlessLine(ctx, a, line, &lastEmit, prov) {
 			// Guardrail asked to stop: cancel the context so the pipe-backed
 			// subprocess is terminated, then unwind. cancel may be nil in
 			// unit tests that drive the streamer directly.
@@ -512,28 +512,9 @@ func (m *Manager) streamHeadlessOutput(ctx context.Context, a *Agent, stdout io.
 
 // parseHeadlessEvent parses one raw NDJSON line into a StreamEvent using the
 // provider-appropriate parser. Shared by the live line handler and the
-// reattach rehydrator. `provider` is the normalized provider name.
-func parseHeadlessEvent(line []byte, provider string) (StreamEvent, error) {
-	switch provider {
-	case "codex":
-		ce, err := ParseCodexLine(line)
-		if err != nil {
-			return StreamEvent{}, err
-		}
-		return codexEventToStreamEvent(ce), nil
-	case "copilot":
-		ce, err := ParseCopilotLine(line)
-		if err != nil {
-			return StreamEvent{}, err
-		}
-		return copilotEventToStreamEvent(ce), nil
-	default:
-		ce, err := ParseClaudeLine(line)
-		if err != nil {
-			return StreamEvent{}, err
-		}
-		return claudeEventToStreamEvent(ce), nil
-	}
+// reattach rehydrator.
+func parseHeadlessEvent(line []byte, provider Provider) (StreamEvent, error) {
+	return provider.ParseHeadlessLine(line)
 }
 
 // processHeadlessLine parses one NDJSON line, appends and emits the event,
@@ -541,7 +522,7 @@ func parseHeadlessEvent(line []byte, provider string) (StreamEvent, error) {
 // guardrails. Returns true when a guardrail decision says to stop the
 // stream. Shared by the pipe-backed streamer and the file tailer; it never
 // writes the log file (the caller or the child process owns that).
-func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte, lastEmit *time.Time, provider string) (stop bool) {
+func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte, lastEmit *time.Time, provider Provider) (stop bool) {
 	event, parseErr := parseHeadlessEvent(line, provider)
 	if parseErr != nil {
 		m.logger.Warn("agent.headless.parse", "id", a.ID, "err", parseErr, "line", string(line))
@@ -555,7 +536,7 @@ func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte
 	if event.LimitSnapshot != nil {
 		snapshot := *event.LimitSnapshot
 		if snapshot.Provider == "" {
-			snapshot.Provider = provider
+			snapshot.Provider = provider.Name()
 		}
 		if snapshot.CapturedAt.IsZero() {
 			snapshot.CapturedAt = event.Timestamp
@@ -595,10 +576,8 @@ func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte
 			a.SetSessionID(event.SessionID)
 			m.saveRegistry(a)
 		}
-		if provider == "codex" {
-			if p := resolveCodexSessionFile(event.SessionID); p != "" {
-				a.SetSessionFilePath(p)
-			}
+		if p := provider.SessionFilePath(event.SessionID); p != "" {
+			a.SetSessionFilePath(p)
 		}
 	}
 

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -43,6 +43,12 @@ var headlessRetryBackoffs = []time.Duration{30 * time.Second, 60 * time.Second, 
 // stream_tooLong log lines.
 const headlessScannerBuffer = 4 * 1024 * 1024
 
+type preparedHeadlessAttempt struct {
+	cfg     RunConfig
+	inv     headlessInvocation
+	cleanup func()
+}
+
 func (m *Manager) runHeadless(ctx context.Context, a *Agent, cfg RunConfig) {
 	// outFile is opened lazily on first successful cmd.Start and shared across
 	// retry attempts so all output lands in one file. Closed on function exit.
@@ -114,49 +120,62 @@ func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfi
 		return false, nil
 	}
 
-	// Materialize the output schema to a temp file for codex so
-	// buildHeadlessInvocation can pass --output-schema <path>. The file is
-	// removed after cmd.Wait() returns (subprocess has exited), so there is no
-	// read-after-delete risk. os.CreateTemp gives a unique name per attempt so
-	// concurrent agents or retries never collide.
-	prov, err := providerForInvocation(a, cfg)
+	prepared, err := prepareHeadlessAttempt(a, cfg)
 	if err != nil {
 		return false, err
+	}
+	defer prepared.cleanup()
+
+	if m.survives() && a.Mode == "headless" {
+		inv := prepared.inv
+		return m.runHeadlessAttemptSurvive(ctx, a, prepared.cfg, outFile, tailOffset, inv.name, inv.args, inv.env, inv.command)
+	}
+	return m.runHeadlessAttemptPipe(ctx, a, prepared.cfg, outFile, prepared.inv)
+}
+
+func prepareHeadlessAttempt(a *Agent, cfg RunConfig) (preparedHeadlessAttempt, error) {
+	prepared := preparedHeadlessAttempt{cfg: cfg, cleanup: func() {}}
+	prov, err := providerForInvocation(a, cfg)
+	if err != nil {
+		return prepared, err
 	}
 	if prov.SupportsOutputSchema() && cfg.OutputSchema != "" {
 		f, schemaErr := os.CreateTemp("", "sybra-codex-schema-*.json")
 		if schemaErr != nil {
-			return false, fmt.Errorf("create codex output schema: %w", schemaErr)
+			return prepared, fmt.Errorf("create codex output schema: %w", schemaErr)
 		}
 		if _, wErr := f.WriteString(cfg.OutputSchema); wErr != nil {
 			_ = f.Close()
 			_ = os.Remove(f.Name())
-			return false, fmt.Errorf("write codex output schema: %w", wErr)
+			return prepared, fmt.Errorf("write codex output schema: %w", wErr)
 		}
 		_ = f.Close()
 		cfg.outputSchemaPath = f.Name()
-		defer os.Remove(cfg.outputSchemaPath)
+		prepared.cfg = cfg
+		prepared.cleanup = func() { _ = os.Remove(cfg.outputSchemaPath) }
 	}
 
 	name, args, invokeEnv, command, err := buildHeadlessInvocation(a, cfg)
 	if err != nil {
-		return false, err
+		prepared.cleanup()
+		prepared.cleanup = func() {}
+		return prepared, err
 	}
+	prepared.inv = headlessInvocation{name: name, args: args, env: invokeEnv, command: command}
+	return prepared, nil
+}
 
-	if m.survives() && a.Mode == "headless" {
-		return m.runHeadlessAttemptSurvive(ctx, a, cfg, outFile, tailOffset, name, args, invokeEnv, command)
-	}
-
-	cmd := exec.CommandContext(ctx, name, args...)
+func (m *Manager) runHeadlessAttemptPipe(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File, inv headlessInvocation) (retry bool, err error) {
+	cmd := exec.CommandContext(ctx, inv.name, inv.args...)
 	configureGracefulShutdown(cmd)
 	if a.sessionCWD != "" {
 		cmd.Dir = a.sessionCWD
 	}
-	if len(cfg.ExtraEnv) > 0 || len(invokeEnv) > 0 {
-		cmd.Env = append(os.Environ(), invokeEnv...)
+	if len(cfg.ExtraEnv) > 0 || len(inv.env) > 0 {
+		cmd.Env = append(os.Environ(), inv.env...)
 		cmd.Env = append(cmd.Env, cfg.ExtraEnv...)
 	}
-	a.Command = command
+	a.Command = inv.command
 
 	stdout, pipeErr := cmd.StdoutPipe()
 	if pipeErr != nil {
@@ -167,7 +186,7 @@ func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfi
 	cmd.Stderr = &stderrBuf
 
 	if startErr := cmd.Start(); startErr != nil {
-		return false, fmt.Errorf("start %s: %w", name, startErr)
+		return false, fmt.Errorf("start %s: %w", inv.name, startErr)
 	}
 	a.SetCmd(cmd)
 

--- a/internal/agent/runner_headless_invocation.go
+++ b/internal/agent/runner_headless_invocation.go
@@ -9,7 +9,11 @@ import (
 // merge into cmd.Env (Bash tool timeout for claude is delivered this way —
 // claude has no CLI flag for it).
 func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args, env []string, command string, err error) {
-	prov := providerForInvocation(a, cfg)
+	prov, providerErr := providerForInvocation(a, cfg)
+	if providerErr != nil {
+		err = providerErr
+		return
+	}
 	for _, tool := range cfg.AllowedTools {
 		if !safeArgRe.MatchString(tool) {
 			err = fmt.Errorf("invalid tool %q: must match %s", tool, safeArgRe)

--- a/internal/agent/runner_headless_invocation.go
+++ b/internal/agent/runner_headless_invocation.go
@@ -2,8 +2,6 @@ package agent
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 )
 
 // buildHeadlessInvocation builds the subprocess invocation for a headless
@@ -11,10 +9,7 @@ import (
 // merge into cmd.Env (Bash tool timeout for claude is delivered this way —
 // claude has no CLI flag for it).
 func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args, env []string, command string, err error) {
-	if a.Provider != "claude" && a.Provider != "codex" && a.Provider != "copilot" {
-		err = fmt.Errorf("unsupported provider: %s", a.Provider)
-		return
-	}
+	prov := providerForInvocation(a, cfg)
 	for _, tool := range cfg.AllowedTools {
 		if !safeArgRe.MatchString(tool) {
 			err = fmt.Errorf("invalid tool %q: must match %s", tool, safeArgRe)
@@ -30,100 +25,10 @@ func buildHeadlessInvocation(a *Agent, cfg RunConfig) (name string, args, env []
 		return
 	}
 
-	if a.Provider == "codex" {
-		name = "codex"
-		args = []string{"exec", "--json", "--skip-git-repo-check", "--ignore-user-config", "--ignore-rules"}
-		// headless=true: --sandbox workspace-write requires approval prompts
-		// which auto-reject in headless mode (no TTY/UI). Always bypass.
-		args = append(args, codexSandboxArgs(cfg.RequirePermissions, true)...)
-		if a.Model != "" {
-			args = append(args, "--model", a.Model)
-		}
-		args = append(args, codexReasoningArgs(a.ReasoningEffort)...)
-		if a.sessionCWD != "" {
-			args = append(args, "-C", a.sessionCWD)
-		}
-		if cfg.outputSchemaPath != "" {
-			args = append(args, "--output-schema", cfg.outputSchemaPath)
-		}
-		// Lifecycle hooks (fail-open: omitted when sybra-cli unresolvable or taskID unsafe).
-		args = append(args, buildCodexHookArgs(a.TaskID)...)
-		prompt := rewriteSkillInvocations(cfg.Prompt, discoverCodexSkills())
-		args = append(args, prompt)
-		command = "codex " + strings.Join(args, " ")
+	inv, buildErr := prov.BuildHeadlessInvocation(a, cfg)
+	if buildErr != nil {
+		err = buildErr
 		return
 	}
-
-	if a.Provider == "copilot" {
-		name = "copilot"
-		// --allow-all-tools is required for non-interactive mode; --no-ask-user
-		// stops the agent blocking on questions (no TTY/UI to answer them).
-		args = []string{"-p", cfg.Prompt, "--output-format", "json", "--allow-all-tools", "--no-ask-user"}
-		if a.Model != "" {
-			args = append(args, "--model", a.Model)
-		}
-		// Copilot only reports its session id on the terminal result event, so
-		// a resume id is available only for an intentional stop/restart. Use
-		// --session-id (unambiguous required-value flag) over --resume[=value].
-		if sid := a.GetSessionID(); sid != "" {
-			args = append(args, "--session-id", sid)
-		}
-		command = "copilot " + strings.Join(args, " ")
-		return
-	}
-
-	name = "claude"
-	args = []string{"-p", cfg.Prompt, "--output-format", "stream-json", "--verbose"}
-	if sid := a.GetSessionID(); sid != "" {
-		args = append(args, "--resume", sid)
-	}
-	args = append(args, claudePermissionArgs(cfg.AllowedTools, cfg.RequirePermissions, cfg.HeadlessPermissionMode)...)
-	if a.Model != "" {
-		args = append(args, "--model", a.Model)
-	}
-	if cfg.FallbackModel != "" {
-		args = append(args, "--fallback-model", cfg.FallbackModel)
-	}
-	if cfg.BashTimeoutMs > 0 {
-		// Claude has no `--bashTimeoutMs` CLI flag — the supported channel is
-		// the BASH_DEFAULT_TIMEOUT_MS / BASH_MAX_TIMEOUT_MS env vars. Set both
-		// so the configured value is honored even when it exceeds claude's
-		// built-in max (600000 ms).
-		ms := strconv.Itoa(cfg.BashTimeoutMs)
-		env = append(env,
-			"BASH_DEFAULT_TIMEOUT_MS="+ms,
-			"BASH_MAX_TIMEOUT_MS="+ms,
-		)
-	}
-	if cfg.ForkSubagent {
-		env = append(env, "CLAUDE_CODE_FORK_SUBAGENT=1")
-	}
-	if cfg.RetryWatchdog > 0 {
-		// CLAUDE_CODE_RETRY_WATCHDOG replaces CLAUDE_CODE_MAX_RETRIES (now
-		// capped at 15) for unattended/server headless runs. Delivered via env
-		// because claude has no equivalent CLI flag.
-		env = append(env, "CLAUDE_CODE_RETRY_WATCHDOG="+strconv.Itoa(cfg.RetryWatchdog))
-	}
-	command = "claude " + strings.Join(args, " ")
-	return
-}
-
-// claudePermissionArgs returns the permission-related CLI flags for a claude headless run.
-//
-// Precedence:
-//  1. len(allowed)>0 → --allowedTools <list> (explicit tool allowlist wins)
-//  2. requirePerms → nil (approval-hook mode; no bypass or auto flag)
-//  3. mode=="auto" → --permission-mode auto (auto-mode classifier)
-//  4. else → --dangerously-skip-permissions (legacy bypass, default)
-func claudePermissionArgs(allowed []string, requirePerms bool, mode string) []string {
-	if len(allowed) > 0 {
-		return []string{"--allowedTools", strings.Join(allowed, ",")}
-	}
-	if requirePerms {
-		return nil
-	}
-	if mode == "auto" {
-		return []string{"--permission-mode", "auto"}
-	}
-	return []string{"--dangerously-skip-permissions"}
+	return inv.name, inv.args, inv.env, inv.command, nil
 }

--- a/internal/agent/runner_headless_retry.go
+++ b/internal/agent/runner_headless_retry.go
@@ -94,7 +94,11 @@ func (m *Manager) reportCleanProviderHealthSignalConvo(a *Agent, stderrOut strin
 // classifier. Without a copilot branch a logged-out / quota-exhausted copilot
 // would never be flagged, leaving the health gate routing failover work to it.
 func classifyProviderError(prov string, sample provider.ErrorSample) (provider.Signal, string, time.Duration) {
-	return providerByName(prov).ClassifyError(sample)
+	p, err := lookupProvider(prov)
+	if err != nil {
+		return provider.SignalNone, "", 0
+	}
+	return p.ClassifyError(sample)
 }
 
 func buildErrorSampleConvo(stderrOut string, attemptEvents []ConvoEvent) provider.ErrorSample {

--- a/internal/agent/runner_headless_retry.go
+++ b/internal/agent/runner_headless_retry.go
@@ -94,14 +94,7 @@ func (m *Manager) reportCleanProviderHealthSignalConvo(a *Agent, stderrOut strin
 // classifier. Without a copilot branch a logged-out / quota-exhausted copilot
 // would never be flagged, leaving the health gate routing failover work to it.
 func classifyProviderError(prov string, sample provider.ErrorSample) (provider.Signal, string, time.Duration) {
-	switch normalizeProvider(prov) {
-	case "codex":
-		return provider.ClassifyCodexError(sample)
-	case "copilot":
-		return provider.ClassifyCopilotError(sample)
-	default:
-		return provider.ClassifyClaudeError(sample)
-	}
+	return providerByName(prov).ClassifyError(sample)
 }
 
 func buildErrorSampleConvo(stderrOut string, attemptEvents []ConvoEvent) provider.ErrorSample {

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -108,7 +108,7 @@ func TestProcessHeadlessLine_SuppressesCodexLimitSnapshotOutput(t *testing.T) {
 	lastEmit := time.Now().Add(-time.Minute)
 	line := []byte(`{"timestamp":"2026-06-19T12:40:08.052Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}},"rate_limits":{"limit_id":"codex","primary":{"used_percent":12,"window_minutes":300,"resets_at":1781877547},"plan_type":"pro"}}}`)
 
-	if stop := m.processHeadlessLine(context.Background(), a, line, &lastEmit, "codex"); stop {
+	if stop := m.processHeadlessLine(context.Background(), a, line, &lastEmit, providerByName("codex")); stop {
 		t.Fatal("limit snapshot event must not stop the stream")
 	}
 	if len(snapshots) != 1 {

--- a/internal/agent/survive_restart_test.go
+++ b/internal/agent/survive_restart_test.go
@@ -336,7 +336,7 @@ func TestProcessHeadlessLine_CapturesSessionOnInit(t *testing.T) {
 
 	// Claude reports the session id on the init/system event (no result yet).
 	line := []byte(`{"type":"system","subtype":"init","session_id":"sess-real"}`)
-	if stop := m.processHeadlessLine(context.Background(), a, line, &lastEmit, "claude"); stop {
+	if stop := m.processHeadlessLine(context.Background(), a, line, &lastEmit, providerByName("claude")); stop {
 		t.Fatal("init event must not stop the stream")
 	}
 


### PR DESCRIPTION
## Motivation

Closes https://github.com/Automaat/sybra/issues/1126

Move provider-specific launch details behind a dedicated interface so agent orchestration does not branch on provider internals.

> Changelog: refactor(agent): hide provider dispatch

## Implementation information

- Add provider implementations for Claude, Codex, and Copilot.
- Move invocation construction and process setup out of manager run flow.
- Keep restart, logging, and lookup behavior covered by agent tests.