### PR TITLE
fix(github): back off on rate limits

### DIFF
--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -124,7 +124,7 @@ func fetchReviewsWith(e execer) (ReviewSummary, error) {
 		ReviewedByMe:    approvedOnly(reviewed),
 	}
 	if runtimeCacheEnabled(e) {
-		reviewSummaryCache.Set(cacheKey, summary, 20*time.Second)
+		reviewSummaryCache.Set(cacheKey, summary, 2*time.Minute)
 	}
 
 	return summary, nil

--- a/internal/github/runtime.go
+++ b/internal/github/runtime.go
@@ -215,7 +215,7 @@ func (g *ghRequestGate) observe(resp ghHTTPResponse, err error) {
 		}
 	}
 
-	if err != nil && isRateLimitedMessage(string(resp.body)) {
+	if (err != nil || isGraphQLRateLimitBody(resp.body)) && isRateLimitedMessage(string(resp.body)) {
 		g.bumpLocked(now.Add(ghFallbackRateBackoff))
 	}
 }
@@ -250,6 +250,11 @@ func isRateLimitedMessage(msg string) bool {
 		strings.Contains(lower, "api rate limit exceeded") ||
 		strings.Contains(lower, "rate limit exceeded") ||
 		strings.Contains(lower, "retry after")
+}
+
+func isGraphQLRateLimitBody(body []byte) bool {
+	lower := strings.ToLower(string(body))
+	return strings.Contains(lower, `"errors"`) && strings.Contains(lower, "rate")
 }
 
 func runGHAPIWith(e execer, cacheTTL string, args ...string) (ghHTTPResponse, error) {

--- a/internal/github/runtime.go
+++ b/internal/github/runtime.go
@@ -249,6 +249,7 @@ func isRateLimitedMessage(msg string) bool {
 	return strings.Contains(lower, "secondary rate limit") ||
 		strings.Contains(lower, "api rate limit exceeded") ||
 		strings.Contains(lower, "rate limit exceeded") ||
+		strings.Contains(lower, "rate_limit") ||
 		strings.Contains(lower, "retry after")
 }
 

--- a/internal/github/runtime_retry_test.go
+++ b/internal/github/runtime_retry_test.go
@@ -86,7 +86,7 @@ func TestGHRequestGate_ObservesGraphQLRateLimitBody(t *testing.T) {
 	g := newGHRequestGate()
 
 	g.observe(ghHTTPResponse{
-		body: []byte(`{"errors":[{"type":"RATE_LIMITED","message":"API rate limit exceeded for user ID 1."}]}`),
+		body: []byte(`{"errors":[{"type":"RATE_LIMITED","message":"quota exhausted"}]}`),
 	}, nil)
 
 	if !g.shouldSkipOptional("graphql") {

--- a/internal/github/runtime_retry_test.go
+++ b/internal/github/runtime_retry_test.go
@@ -82,6 +82,18 @@ func TestRunGHAPIWith_NoRetryOnRateLimit(t *testing.T) {
 	}
 }
 
+func TestGHRequestGate_ObservesGraphQLRateLimitBody(t *testing.T) {
+	g := newGHRequestGate()
+
+	g.observe(ghHTTPResponse{
+		body: []byte(`{"errors":[{"type":"RATE_LIMITED","message":"API rate limit exceeded for user ID 1."}]}`),
+	}, nil)
+
+	if !g.shouldSkipOptional("graphql") {
+		t.Fatal("want optional GraphQL calls skipped after rate-limit body")
+	}
+}
+
 func TestRunGHAPIWith_NoRetryOnWrite(t *testing.T) {
 	stubRetrySleep(t)
 


### PR DESCRIPTION
## Motivation

Sybra can burn through the GitHub GraphQL budget during PR-monitor bursts because GraphQL rate-limit responses can arrive as successful HTTP responses with an errors payload. Review polling also refreshed too aggressively during fast monitor cycles.

> Changelog: fix(github): back off on rate limits

## Implementation information

Treat GraphQL rate-limit error bodies as shared GitHub gate signals so optional polling backs off. Increase the review-summary runtime cache from 20 seconds to 2 minutes to reduce repeated GraphQL searches during hot polling.

## Supporting documentation

- go test ./internal/github
- go test ./internal/sybra
- go test ./...