### PR TITLE
fix(workflow): scope tamper scans

### DIFF
--- a/internal/sybra/app_agents.go
+++ b/internal/sybra/app_agents.go
@@ -203,10 +203,11 @@ func prependSupervisorSteer(tasks *task.Manager, taskID, prompt string) (string,
 }
 
 func (o *AgentOrchestrator) StartAgent(taskID, mode, prompt string, includeTaskDescription, oneShot bool) (*agent.Agent, error) {
-	return o.StartAgentWithAssignment(taskID, mode, prompt, includeTaskDescription, oneShot, workflow.AgentAssignment{})
+	ag, _, err := o.StartAgentWithAssignment(taskID, mode, prompt, includeTaskDescription, oneShot, workflow.AgentAssignment{})
+	return ag, err
 }
 
-func (o *AgentOrchestrator) StartAgentWithAssignment(taskID, mode, prompt string, includeTaskDescription, oneShot bool, assignment workflow.AgentAssignment) (*agent.Agent, error) {
+func (o *AgentOrchestrator) StartAgentWithAssignment(taskID, mode, prompt string, includeTaskDescription, oneShot bool, assignment workflow.AgentAssignment) (*agent.Agent, string, error) {
 	// Serialize dispatch per task. Held across the whole start — including the
 	// multi-second worktree prep below, during which the agent is not yet
 	// registered — so a concurrent dispatcher (recovery loop, ResumeStalled,
@@ -214,7 +215,7 @@ func (o *AgentOrchestrator) StartAgentWithAssignment(taskID, mode, prompt string
 	// on the same worktree. workflow.ErrDispatchInFlight is benign: the holder
 	// will produce the task's agent.
 	if !o.agents.ClaimTaskDispatch(taskID) {
-		return nil, workflow.ErrDispatchInFlight
+		return nil, "", workflow.ErrDispatchInFlight
 	}
 	defer o.agents.ReleaseTaskDispatch(taskID)
 
@@ -229,13 +230,13 @@ func (o *AgentOrchestrator) StartAgentWithAssignment(taskID, mode, prompt string
 
 	t, err := o.tasks.Get(taskID)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	// An umbrella tracker task runs no agent — it only rolls up its children.
 	// Refuse here, the single dispatch choke point, so no path (workflow,
 	// recovery, manual start) can launch an agent against it.
 	if t.TaskType == task.TaskTypeUmbrella {
-		return nil, fmt.Errorf("task %s is an umbrella tracker; it runs no agent", taskID)
+		return nil, "", fmt.Errorf("task %s is an umbrella tracker; it runs no agent", taskID)
 	}
 	researchDir := ""
 	if o.cfg != nil {
@@ -245,20 +246,23 @@ func (o *AgentOrchestrator) StartAgentWithAssignment(taskID, mode, prompt string
 	if !skipWT {
 		t = o.autoAssignProject(t)
 		if t.ProjectID == "" {
-			return nil, fmt.Errorf("task %s has no project_id: refusing to start agent without isolated worktree", taskID)
+			return nil, "", fmt.Errorf("task %s has no project_id: refusing to start agent without isolated worktree", taskID)
 		}
 		opID, onPhase := o.startWorktreeOp("Preparing worktree: "+t.Title, t.ProjectID, taskID)
 		d, wtErr := o.worktrees.PrepareForTask(t, onPhase)
 		if wtErr != nil {
 			o.failWorktreeOp(opID, wtErr)
-			return nil, fmt.Errorf("worktree required for project task: %w", wtErr)
+			markRebaseBlocked(o.tasks, taskID, wtErr, o.logger)
+			return nil, "", fmt.Errorf("worktree required for project task: %w", wtErr)
 		}
 		o.completeWorktreeOp(opID)
 		dir = d
 	}
 	if dir == "" {
-		return nil, fmt.Errorf("task %s: no working dir resolved (skipWorktree=%v) — refusing to run agent in Sybra cwd", taskID, skipWT)
+		return nil, "", fmt.Errorf("task %s: no working dir resolved (skipWorktree=%v) — refusing to run agent in Sybra cwd", taskID, skipWT)
 	}
+
+	baselineRef := currentWorktreeHead(dir)
 
 	var workflowStart time.Time
 	if t.Workflow != nil {
@@ -268,7 +272,7 @@ func (o *AgentOrchestrator) StartAgentWithAssignment(taskID, mode, prompt string
 
 	posture, postureErr := resolveHeadlessPermissionMode(t, o.cfg)
 	if postureErr != nil {
-		return nil, postureErr
+		return nil, "", postureErr
 	}
 
 	extraEnv := o.sandboxEnvIfRunning(taskID)
@@ -309,10 +313,24 @@ func (o *AgentOrchestrator) StartAgentWithAssignment(taskID, mode, prompt string
 			o.logAudit(audit.EventProviderGateBlocked, taskID, "", map[string]any{"err": err.Error()})
 			o.logger.Info("agent.start.gated", "task_id", taskID, "err", err)
 		}
-		return nil, err
+		return nil, "", err
 	}
 	o.recordImplAgentStart(ag, t, taskID, effMode, posture, requirePerm, oneShot, fullPrompt)
-	return ag, nil
+	return ag, baselineRef, nil
+}
+
+func markRebaseBlocked(tasks *task.Manager, taskID string, err error, logger *slog.Logger) bool {
+	if !errors.Is(err, worktree.ErrRebaseFailed) {
+		return false
+	}
+	reason := "branch stale: rebase failed before agent start; resolve conflicts or recreate the task branch"
+	if _, uerr := tasks.Update(taskID, task.Update{
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr(reason),
+	}); uerr != nil {
+		logger.Error("worktree.rebase-block.status", "task_id", taskID, "err", uerr)
+	}
+	return true
 }
 
 // recordImplAgentStart emits the agent.started audit event and persists the

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -242,6 +242,9 @@ func (r *ReviewHandler) prepareWorktree(t task.Task, issue github.PRIssue) (stri
 		d, wtErr = r.worktrees.PrepareForTask(t, nil)
 	}
 	if wtErr != nil {
+		if markRebaseBlocked(r.tasks, t.ID, wtErr, r.logger) {
+			return "", false
+		}
 		if r.wtFailures == nil {
 			r.wtFailures = make(map[string]int)
 		}

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/Automaat/sybra/internal/agent"
@@ -386,41 +387,36 @@ type agentAdapter struct {
 	sandboxes *sandbox.Manager
 }
 
-func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool, outputSchema string, assignment workflow.AgentAssignment) (agentID, startedDir string, err error) {
+func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool, outputSchema string, assignment workflow.AgentAssignment) (agentID, startedDir, baselineRef string, err error) {
 	// For implementation agents without a pre-staged dir, use the full
 	// orchestrator (handles worktree, project assignment). A workflow that
 	// seeds WorkflowVarDir (e.g. tests or flows that pre-stage via
 	// PrepareForFix) bypasses the orchestrator's worktree path and uses the
 	// caller-provided dir directly.
 	if (role == "" || role == string(agent.RoleImplementation)) && dir == "" {
-		ag, err := a.agentOrch.StartAgentWithAssignment(taskID, mode, prompt, false, oneShot, assignment)
+		ag, baselineRef, err := a.agentOrch.StartAgentWithAssignment(taskID, mode, prompt, false, oneShot, assignment)
 		if err != nil {
-			return "", "", err
+			return "", "", "", err
 		}
-		return ag.ID, "", nil
+		return ag.ID, "", baselineRef, nil
 	}
 
 	// For system agents (triage, eval, plan, etc.), build RunConfig directly.
 	r := agent.Role(role)
 	t, err := a.agentOrch.tasks.Get(taskID)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 
-	// Cap concurrent test-runner agents per machine — each one starts an
-	// isolated real-app/cluster sandbox, so this bounds sandbox load
-	// independently of Agent.MaxConcurrent. The benign race (two dispatches
-	// passing the check at once) is acceptable: the workflow step parks on
-	// ErrTestRunnerBusy and ResumeStalled retries when a slot frees.
 	if r == agent.RoleTestRunner {
 		if a.agents.CountLiveByRole(agent.RoleTestRunner) >= a.agentOrch.cfg.TestingMaxConcurrent() {
-			return "", "", workflow.ErrTestRunnerBusy
+			return "", "", "", workflow.ErrTestRunnerBusy
 		}
 	}
 
 	posture, postureErr := resolveHeadlessPermissionMode(t, a.agentOrch.cfg)
 	if postureErr != nil {
-		return "", "", postureErr
+		return "", "", "", postureErr
 	}
 
 	cfg := agent.RunConfig{
@@ -449,17 +445,15 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		OutputSchema:      outputSchema,
 	}
 
-	// Caller-provided dir takes precedence (e.g. pr-fix flow pre-stages a
-	// worktree via PrepareForFix). Only fall back to PrepareForTask when no
-	// dir is provided and the step declared needs_worktree.
 	if cfg.Dir == "" && needsWorktree {
 		t = a.agentOrch.autoAssignProject(t)
 		if t.ProjectID == "" {
-			return "", "", fmt.Errorf("task %s has no project_id: refusing to start %s agent without isolated worktree", taskID, role)
+			return "", "", "", fmt.Errorf("task %s has no project_id: refusing to start %s agent without isolated worktree", taskID, role)
 		}
 		d, wtErr := a.agentOrch.worktrees.PrepareForTask(t, nil)
 		if wtErr != nil {
-			return "", "", wtErr
+			markRebaseBlocked(a.tasks, taskID, wtErr, a.agentOrch.logger)
+			return "", "", "", wtErr
 		}
 		cfg.Dir = d
 	}
@@ -472,10 +466,8 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		cfg.Dir = config.HomeDir()
 	}
 
-	// Testing is where the real app/cluster runs: the test-runner starts (or
-	// reuses) the task's isolated sandbox and inherits SANDBOX_URL/KUBECONFIG.
-	// Every other role only inherits a sandbox that is already running — none
-	// is started during planning/implementation/review (gated to testing).
+	baselineRef = currentWorktreeHead(cfg.Dir)
+
 	if a.sandboxes != nil {
 		if r == agent.RoleTestRunner {
 			cfg.ExtraEnv = a.agentOrch.sandboxEnv(taskID, cfg.Dir, t)
@@ -486,19 +478,15 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 
 	ag, err := a.agents.Run(cfg)
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 
-	// Flip human-required → in-progress when a system-role agent starts.
-	// A competing inline path (e.g. review.triage.small) may have set
-	// human-required before the pr-review workflow fires; leaving the task
-	// there while an agent runs creates an inconsistent observable state.
-	// We only flip human-required: other statuses (todo, planning, …) have
-	// their own semantics and should not be pre-empted by agent start.
-	//
-	// Re-read current status rather than relying on the snapshot taken at the
-	// top of this function: another goroutine (e.g. triage) may have flipped
-	// the task to human-required after that read.
+	a.recordSystemAgentStart(taskID, role, mode, cfg, ag)
+
+	return ag.ID, cfg.Dir, baselineRef, nil
+}
+
+func (a *agentAdapter) recordSystemAgentStart(taskID, role, mode string, cfg agent.RunConfig, ag *agent.Agent) {
 	var nextStatus *task.Status
 	if cur, rerr := a.tasks.Get(taskID); rerr == nil && cur.Status == task.StatusHumanRequired {
 		nextStatus = task.Ptr(task.StatusInProgress)
@@ -521,8 +509,19 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 	}, nextStatus); addErr != nil {
 		slog.Error("agent-adapter.add-run", "task_id", taskID, "agent_id", ag.ID, "err", addErr)
 	}
+}
 
-	return ag.ID, cfg.Dir, nil
+func currentWorktreeHead(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	cmd := exec.Command("git", "rev-parse", "--verify", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 func (a *agentAdapter) HasRunningAgent(taskID string) bool {

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -21,7 +21,7 @@ type AgentCompletion struct {
 // workflow steps that expect a single turn — otherwise the agent sits paused
 // forever and the workflow never advances to the next step.
 type AgentLauncher interface {
-	StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool, outputSchema string, assignment AgentAssignment) (agentID, startedDir string, err error)
+	StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool, outputSchema string, assignment AgentAssignment) (agentID, startedDir, baselineRef string, err error)
 	HasRunningAgent(taskID string) bool
 	// HasOtherRunningAgentForTask reports whether an agent other than
 	// exceptAgentID is still running for the task. verify_commits uses it to

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -175,7 +175,7 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 	// event so claude exits and onComplete fires, unblocking the next step
 	// (e.g. evaluate). Without this, the workflow stalls on implement forever.
 	oneShot := mode == "interactive" && !step.Config.ReuseAgent && step.Config.WaitForStatus == ""
-	agentID, startedDir, err := e.agents.StartAgent(taskID, step.Config.Role, mode, model, provider, prompt, dir, step.Config.AllowedTools, step.Config.NeedsWorktree, oneShot, step.Config.OutputSchema, assignment)
+	agentID, startedDir, baselineRef, err := e.agents.StartAgent(taskID, step.Config.Role, mode, model, provider, prompt, dir, step.Config.AllowedTools, step.Config.NeedsWorktree, oneShot, step.Config.OutputSchema, assignment)
 	if err != nil {
 		// Another dispatcher already holds the per-task dispatch claim (e.g. the
 		// recovery loop won the race for this task). That agent will run and its
@@ -199,6 +199,9 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 	}
 	if startedDir != "" && (step.Config.NeedsWorktree || dir != "") {
 		wfExec.SetVar(WorkflowVarDir, startedDir)
+	}
+	if baselineRef != "" {
+		wfExec.SetVar(tamperBaselineVar(step.ID), baselineRef)
 	}
 
 	// Track which task+step this agent was spawned for so HandleAgentComplete

--- a/internal/workflow/engine_steps_parallel.go
+++ b/internal/workflow/engine_steps_parallel.go
@@ -150,10 +150,13 @@ func (e *Engine) spawnParallelChild(taskID string, parent, child *Step, wfExec *
 	// Fast-exiting agents (e.g. fail_exit in tests) can otherwise complete
 	// before agentSteps is populated, causing the wrong step to advance.
 	e.mu.Lock()
-	agentID, _, err := e.agents.StartAgent(taskID, child.Config.Role, mode, model, provider, prompt, dir, child.Config.AllowedTools, child.Config.NeedsWorktree, oneShot, child.Config.OutputSchema, assignment)
+	agentID, _, baselineRef, err := e.agents.StartAgent(taskID, child.Config.Role, mode, model, provider, prompt, dir, child.Config.AllowedTools, child.Config.NeedsWorktree, oneShot, child.Config.OutputSchema, assignment)
 	if err != nil {
 		e.mu.Unlock()
 		return fmt.Errorf("start agent: %w", err)
+	}
+	if baselineRef != "" {
+		wfExec.SetVar(tamperBaselineVar(child.ID), baselineRef)
 	}
 	// agentSteps key uses the *child* step ID. StepByID recurses into
 	// Parallel children so the lookup in lookupAgentStep / AdvanceStep

--- a/internal/workflow/engine_steps_tamper.go
+++ b/internal/workflow/engine_steps_tamper.go
@@ -147,7 +147,7 @@ var (
 	// only `require.` (testify-style assertions) counts.
 	tamperAssertionRe = regexp.MustCompile(
 		`\bassert\b|\brequire\.|\bexpect\s*\(|` +
-			`\b\w+\.(Error|Errorf|Fatal|Fatalf)\b|\bEXPECT_|\bASSERT_|\.should\b|\bshould\.`)
+			`\b(?:t|tb)\.(Error|Errorf|Fatal|Fatalf)\b|\bEXPECT_|\bASSERT_|\.should\b|\bshould\.`)
 	// tamperTestDeclRe matches a test-case declaration. Net removal flags
 	// deleted test cases.
 	tamperTestDeclRe = regexp.MustCompile(

--- a/internal/workflow/engine_steps_tamper.go
+++ b/internal/workflow/engine_steps_tamper.go
@@ -62,6 +62,7 @@ type tamperFinding struct {
 type tamperReport struct {
 	TaskID   string          `json:"taskId"`
 	Base     string          `json:"base"`
+	Range    string          `json:"range"`
 	Files    []string        `json:"files"`
 	Findings []tamperFinding `json:"findings"`
 }
@@ -82,6 +83,12 @@ type tamperChange struct {
 	Status string // "A", "M", "D", "R100", …
 	Path   string
 	Patch  string
+}
+
+type tamperPatchResult struct {
+	Findings  []tamperFinding
+	AddAssert int
+	DelAssert int
 }
 
 var (
@@ -140,7 +147,7 @@ var (
 	// only `require.` (testify-style assertions) counts.
 	tamperAssertionRe = regexp.MustCompile(
 		`\bassert\b|\brequire\.|\bexpect\s*\(|` +
-			`\bt\.(Error|Errorf|Fatal|Fatalf)\b|\bEXPECT_|\bASSERT_|\.should\b|\bshould\.`)
+			`\b\w+\.(Error|Errorf|Fatal|Fatalf)\b|\bEXPECT_|\bASSERT_|\.should\b|\bshould\.`)
 	// tamperTestDeclRe matches a test-case declaration. Net removal flags
 	// deleted test cases.
 	tamperTestDeclRe = regexp.MustCompile(
@@ -223,6 +230,10 @@ func splitTopArgs(s string) []string {
 // for a header. Comment-only additions are ignored, so commenting out a test or
 // assertion registers as a removal (the deletion side) with no offsetting add.
 func scanTamperPatch(path string, cat tamperCategory, patch string) []tamperFinding {
+	return scanTamperPatchResult(path, cat, patch).Findings
+}
+
+func scanTamperPatchResult(path string, cat tamperCategory, patch string) tamperPatchResult {
 	s := &tamperScan{path: path, cat: cat, isCI: cat == tamperCatCI, seen: map[string]bool{}}
 	inHunk := false
 	for line := range strings.SplitSeq(patch, "\n") {
@@ -335,7 +346,7 @@ func (s *tamperScan) feedRemoved(content string) {
 
 // finalize appends the net-removal findings (a deletion not offset by an
 // addition signals weakened coverage / a removed gate) and returns the result.
-func (s *tamperScan) finalize() []tamperFinding {
+func (s *tamperScan) finalize() tamperPatchResult {
 	netFinding := func(rule, noun string, del, add int) {
 		if net := del - add; net > 0 {
 			s.findings = append(s.findings, tamperFinding{
@@ -346,11 +357,11 @@ func (s *tamperScan) finalize() []tamperFinding {
 	}
 	if s.isCI {
 		netFinding("removed-ci-step", "check step(s)", s.delRun, s.addRun)
-		return s.findings
+		return tamperPatchResult{Findings: s.findings}
 	}
 	netFinding("removed-assertions", "assertion line(s)", s.delAssert, s.addAssert)
 	netFinding("removed-test-cases", "test declaration(s)", s.delDecl, s.addDecl)
-	return s.findings
+	return tamperPatchResult{Findings: s.findings, AddAssert: s.addAssert, DelAssert: s.delAssert}
 }
 
 // buildTamperReport assembles the report from the parsed diff. Pure function:
@@ -358,6 +369,7 @@ func (s *tamperScan) finalize() []tamperFinding {
 func buildTamperReport(taskID, base string, changes []tamperChange) tamperReport {
 	report := tamperReport{TaskID: taskID, Base: base}
 	scanned := 0
+	totalAddedAssertions := 0
 	for i := range changes {
 		c := changes[i]
 		cat := classifyTamperPath(c.Path)
@@ -378,13 +390,18 @@ func buildTamperReport(taskID, base string, changes []tamperChange) tamperReport
 			continue
 		}
 		scanned++
-		report.Findings = append(report.Findings, scanTamperPatch(c.Path, cat, c.Patch)...)
+		res := scanTamperPatchResult(c.Path, cat, c.Patch)
+		totalAddedAssertions += res.AddAssert
+		report.Findings = append(report.Findings, res.Findings...)
+	}
+	if totalAddedAssertions > 0 {
+		report.Findings = downgradeRemovedAssertionOnlyFindings(report.Findings)
 	}
 
 	// Verification files changed but nothing high fired: record one medium
 	// finding per file so the stored report and the reviewer still have the
 	// context (benign test edits are normal for feature work and do not block).
-	if report.highCount() == 0 {
+	if report.highCount() == 0 && len(report.Findings) == 0 {
 		for _, f := range report.Files {
 			report.Findings = append(report.Findings, tamperFinding{
 				File: f, Category: string(classifyTamperPath(f)),
@@ -393,6 +410,17 @@ func buildTamperReport(taskID, base string, changes []tamperChange) tamperReport
 		}
 	}
 	return report
+}
+
+func downgradeRemovedAssertionOnlyFindings(findings []tamperFinding) []tamperFinding {
+	out := findings[:0]
+	for _, f := range findings {
+		if f.Rule == "removed-assertions" {
+			f.Severity = tamperMedium
+		}
+		out = append(out, f)
+	}
+	return out
 }
 
 // execDetectTampering inspects the worktree diff (base...HEAD) for reward-
@@ -429,7 +457,7 @@ func (e *Engine) execDetectTampering(taskID string, step *Step, t TaskInfo) (Ste
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "skipped: no worktree for task"}, nil
 	}
 
-	report, err := e.collectTamperReport(taskID, wtPath)
+	report, err := e.collectTamperReport(taskID, wtPath, t)
 	if err != nil {
 		// collectTamperReport wraps the per-step timeout/cancel into the
 		// returned error, so check the chain (not e.ctx, which stays live when
@@ -469,11 +497,10 @@ func (e *Engine) execDetectTampering(taskID string, step *Step, t TaskInfo) (Ste
 
 // collectTamperReport runs git to gather the changed files and per-file patches
 // for verification files, then delegates to the pure buildTamperReport.
-func (e *Engine) collectTamperReport(taskID, wtPath string) (tamperReport, error) {
+func (e *Engine) collectTamperReport(taskID, wtPath string, t TaskInfo) (tamperReport, error) {
 	ctx, cancel := context.WithTimeout(e.ctx, shellTimeout)
 	defer cancel()
-	base := resolveOriginBase(ctx, wtPath)
-	rangeSpec := base + "...HEAD"
+	base, rangeSpec := resolveTamperRange(ctx, wtPath, t)
 
 	// core.quotePath=false keeps non-ASCII paths unquoted so classification and
 	// the per-file diff pathspec below see the real filename.
@@ -512,7 +539,29 @@ func (e *Engine) collectTamperReport(taskID, wtPath string) (tamperReport, error
 		}
 		c.Patch = patch
 	}
-	return buildTamperReport(taskID, base, changes), nil
+	report := buildTamperReport(taskID, base, changes)
+	report.Range = rangeSpec
+	return report, nil
+}
+
+func tamperBaselineVar(stepID string) string {
+	return "step." + stepID + ".tamper_base"
+}
+
+func resolveTamperRange(ctx context.Context, wtPath string, t TaskInfo) (base, rangeSpec string) {
+	if t.Workflow != nil {
+		if stepID := t.Workflow.LastAgentStepID(); stepID != "" {
+			if sha := strings.TrimSpace(t.Workflow.Variables[tamperBaselineVar(stepID)]); sha != "" {
+				cmd := exec.CommandContext(ctx, "git", "rev-parse", "--verify", sha+"^{commit}")
+				cmd.Dir = wtPath
+				if cmd.Run() == nil {
+					return sha, sha + "..HEAD"
+				}
+			}
+		}
+	}
+	base = resolveOriginBase(ctx, wtPath)
+	return base, base + "...HEAD"
 }
 
 func gitFilePatch(ctx context.Context, wtPath, rangeSpec, path string) (string, error) {

--- a/internal/workflow/engine_steps_tamper_test.go
+++ b/internal/workflow/engine_steps_tamper_test.go
@@ -2,7 +2,9 @@ package workflow
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -222,6 +224,19 @@ func TestBuildTamperReport(t *testing.T) {
 		}
 	})
 
+	t.Run("assertion_refactor_is_medium_not_blocking", func(t *testing.T) {
+		r := buildTamperReport("t1", "origin/main", []tamperChange{
+			{Status: "M", Path: "internal/foo/old_test.go", Patch: "@@ @@\n-\tif err != nil { t.Fatalf(\"bad: %v\", err) }\n"},
+			{Status: "A", Path: "internal/foo/helpers_test.go", Patch: "@@ @@\n+func mustOK(tb testing.TB, err error) {\n+\tif err != nil { tb.Fatalf(\"bad: %v\", err) }\n+}\n"},
+		})
+		if r.highCount() != 0 {
+			t.Fatalf("highCount = %d, want 0 (%v)", r.highCount(), r.Findings)
+		}
+		if len(r.Findings) != 1 || r.Findings[0].Rule != "removed-assertions" || r.Findings[0].Severity != tamperMedium {
+			t.Fatalf("want removed-assertions downgraded to medium, got %v", r.Findings)
+		}
+	})
+
 	t.Run("tampering_mixes_high_and_skips_medium", func(t *testing.T) {
 		r := buildTamperReport("t1", "origin/main", []tamperChange{
 			{Status: "M", Path: "a_test.go", Patch: "@@ @@\n+\tt.Skip(\"x\")\n"},
@@ -327,6 +342,17 @@ func writeRepoFile(t *testing.T, dir, rel, content string) {
 	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func gitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %v: %v", args, err)
+	}
+	return string(out)
 }
 
 // makeBaseRepo inits a repo with baseFiles committed as the origin/main state.
@@ -524,6 +550,42 @@ func TestExecDetectTampering_NeuteredCIFlags(t *testing.T) {
 	}
 	if out.Output != "flagged" {
 		t.Fatalf("Output = %q, want flagged (continue-on-error neuters the gate)", out.Output)
+	}
+}
+
+func TestExecDetectTampering_UsesAgentBaseline(t *testing.T) {
+	t.Parallel()
+	wt := makeBaseRepo(t, map[string]string{
+		"README.md":                  "init\n",
+		"frontend/Dashboard.test.ts": "test('dashboard', () => expect(true).toBe(true))\n",
+	})
+	gitRun(t, wt, "rm", "frontend/Dashboard.test.ts")
+	gitRun(t, wt, "commit", "-m", "refactor: remove dashboard")
+	baseline := strings.TrimSpace(gitOutput(t, wt, "rev-parse", "HEAD"))
+	writeRepoFile(t, wt, "internal/foo/foo.go", "package foo\n\nfunc Foo() int { return 1 }\n")
+	gitRun(t, wt, "add", ".")
+	gitRun(t, wt, "commit", "-m", "feat: add foo")
+
+	engine, tasks := newTamperEngine(t, wt)
+	wf := &Execution{
+		Variables: map[string]string{tamperBaselineVar("fix"): baseline},
+		StepHistory: []StepRecord{{
+			StepID:  "fix",
+			Status:  "completed",
+			AgentID: "agent-1",
+		}},
+	}
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+
+	out, err := engine.execDetectTampering("t1", newTamperStep(), TaskInfo{ID: "t1", Workflow: wf})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Output != "clean" {
+		t.Fatalf("Output = %q, want clean; baseline should ignore stale test deletion", out.Output)
+	}
+	if ti, _ := tasks.GetTask("t1"); ti.Status != "in-progress" {
+		t.Errorf("status = %q, want unchanged in-progress", ti.Status)
 	}
 }
 

--- a/internal/workflow/engine_steps_tamper_test.go
+++ b/internal/workflow/engine_steps_tamper_test.go
@@ -138,6 +138,11 @@ func TestScanTamperPatch(t *testing.T) {
 			wantRules: nil, // bare require is an import, not an assertion
 		},
 		{
+			name:      "fmt_errorf_is_not_an_assertion",
+			patch:     "@@ @@\n-\treturn fmt.Errorf(\"bad: %w\", err)\n",
+			wantRules: nil,
+		},
+		{
 			name:      "ci_removed_test_step",
 			cat:       tamperCatCI,
 			patch:     "@@ @@\n       - run: go vet ./...\n-      - run: go test ./...\n",

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -313,11 +313,11 @@ func newMockAgents() *mockAgents {
 	}
 }
 
-func (m *mockAgents) StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool, outputSchema string, assignment AgentAssignment) (agentID, startedDir string, err error) {
+func (m *mockAgents) StartAgent(taskID, role, mode, model, provider, prompt, dir string, allowedTools []string, needsWorktree, oneShot bool, outputSchema string, assignment AgentAssignment) (agentID, startedDir, baselineRef string, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.failSpawn != nil {
-		return "", "", m.failSpawn
+		return "", "", "", m.failSpawn
 	}
 	m.counter++
 	id := fmt.Sprintf("agent-%d", m.counter)
@@ -333,7 +333,7 @@ func (m *mockAgents) StartAgent(taskID, role, mode, model, provider, prompt, dir
 	if startedDir == "" && needsWorktree {
 		startedDir = filepath.Join(os.TempDir(), "sybra-test-"+taskID)
 	}
-	return id, startedDir, nil
+	return id, startedDir, "base-" + id, nil
 }
 
 // SetFailSpawn arms the mock so the next StartAgent calls return err. Pass
@@ -1107,7 +1107,7 @@ func TestCancelWorkflow(t *testing.T) {
 	tasks.Put(TaskInfo{ID: "no-wf", Status: "todo"})
 
 	// Pretend an agent is running for "active" so we can verify it's stopped.
-	if _, _, err := agents.StartAgent("active", "pr-fix", "headless", "sonnet", "claude", "p", "", nil, false, false, "", AgentAssignment{}); err != nil {
+	if _, _, _, err := agents.StartAgent("active", "pr-fix", "headless", "sonnet", "claude", "p", "", nil, false, false, "", AgentAssignment{}); err != nil {
 		t.Fatalf("seed agent: %v", err)
 	}
 
@@ -1678,7 +1678,7 @@ func TestResumeStalled_SkipsTaskWithRunningAgent(t *testing.T) {
 		},
 	})
 	// Simulate an agent already running.
-	_, _, _ = agents.StartAgent("t1", "implementation", "headless", "sonnet", "", "test", "", nil, false, false, "", AgentAssignment{})
+	_, _, _, _ = agents.StartAgent("t1", "implementation", "headless", "sonnet", "", "test", "", nil, false, false, "", AgentAssignment{})
 
 	initialCalls := agents.CallCount()
 	engine.ResumeStalled()

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -1,6 +1,7 @@
 package worktree
 
 import (
+	"errors"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -783,6 +784,50 @@ func TestPrepareForTask_WorktreeBaseRefHead(t *testing.T) {
 	}
 	if got := strings.TrimSpace(string(out)); got != wantSHA {
 		t.Errorf("worktree does not contain upstream commit %s; merge-base=%s", wantSHA, got)
+	}
+}
+
+func TestPrepareForTask_RebaseConflictFailsClosed(t *testing.T) {
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	h := prepareHarness(t, nil, 30*time.Second)
+
+	tk, err := h.tasks.Store().Create("conflicting task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.tasks.Update(tk.ID, task.Update{ProjectID: task.Ptr(h.proj.ID)}); err != nil {
+		t.Fatal(err)
+	}
+	tk, err = h.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wtPath, err := h.m.PrepareForTask(tk, nil)
+	if err != nil {
+		t.Fatalf("initial PrepareForTask: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), []byte("branch edit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunInDir(t, wtPath, "git", "add", "README.md")
+	mustRunInDir(t, wtPath, "git", "commit", "-m", "branch edit")
+
+	if err := os.WriteFile(filepath.Join(h.src, "README.md"), []byte("upstream edit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunInDir(t, h.src, "git", "add", "README.md")
+	mustRunInDir(t, h.src, "git", "commit", "-m", "upstream edit")
+
+	gotPath, err := h.m.PrepareForTask(tk, nil)
+	if !errors.Is(err, ErrRebaseFailed) {
+		t.Fatalf("PrepareForTask error = %v, want ErrRebaseFailed", err)
+	}
+	if gotPath != "" {
+		t.Fatalf("PrepareForTask path = %q, want empty path on rebase failure", gotPath)
 	}
 }
 

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -810,6 +810,8 @@ func TestPrepareForTask_RebaseConflictFailsClosed(t *testing.T) {
 		t.Fatalf("initial PrepareForTask: %v", err)
 	}
 
+	mustRunInDir(t, wtPath, "git", "config", "user.email", "test@test.com")
+	mustRunInDir(t, wtPath, "git", "config", "user.name", "Test")
 	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), []byte("branch edit\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -9,6 +9,8 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 )
 
+// ErrRebaseFailed indicates a reused task worktree could not be rebased onto
+// the project base ref and must be repaired before another agent run.
 var ErrRebaseFailed = errors.New("worktree rebase failed")
 
 // PrepareForTask creates (or reuses) a worktree for implementation work.

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -1,12 +1,15 @@
 package worktree
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 )
+
+var ErrRebaseFailed = errors.New("worktree rebase failed")
 
 // PrepareForTask creates (or reuses) a worktree for implementation work.
 // Fetches origin, creates a conventional-prefixed branch off default branch,
@@ -63,19 +66,18 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 			if err := project.SanitizeWorktree(wtPath); err != nil {
 				m.logger.Warn("worktree.sanitize", "task_id", t.ID, "err", err)
 			}
-			// Rebase is best-effort — conflicts with main shouldn't block agent
-			// start on a branch that already has committed work.
+			// Rebase must succeed before another agent run. Continuing from a
+			// stale branch makes downstream diff gates scan historical commits.
 			callPhase(onPhase, "Rebasing onto origin…")
 			if err := project.RebaseOnto(wtPath, baseRef); err != nil {
-				m.logger.Warn("worktree.rebase-skipped", "task_id", t.ID, "base", baseRef, "err", err)
-			} else {
-				m.logger.Info("worktree.rebased", "task_id", t.ID, "path", wtPath, "base", baseRef)
-				// Sync remote after rebase. PushSync picks the minimum mode —
-				// no-op when local matches remote, regular push for
-				// fast-forward, --force-with-lease only on divergence.
-				callPhase(onPhase, "Syncing upstream…")
-				m.logPushSync(t.ID, wtBranch, project.PushSync(wtPath, wtBranch))
+				return "", fmt.Errorf("%w: rebase %s onto %s: %w", ErrRebaseFailed, wtBranch, baseRef, err)
 			}
+			m.logger.Info("worktree.rebased", "task_id", t.ID, "path", wtPath, "base", baseRef)
+			// Sync remote after rebase. PushSync picks the minimum mode —
+			// no-op when local matches remote, regular push for
+			// fast-forward, --force-with-lease only on divergence.
+			callPhase(onPhase, "Syncing upstream…")
+			m.logPushSync(t.ID, wtBranch, project.PushSync(wtPath, wtBranch))
 			return m.finalizeWorktree(t, wtPath, wtBranch, proj)
 		}
 		// Worktree was wiped — fall through to create paths below.
@@ -93,12 +95,11 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 		}
 		callPhase(onPhase, "Rebasing onto origin…")
 		if err := project.RebaseOnto(wtPath, baseRef); err != nil {
-			m.logger.Warn("worktree.rebase-skipped", "task_id", t.ID, "base", baseRef, "err", err)
-		} else {
-			// Sync remote after rebase.
-			callPhase(onPhase, "Syncing upstream…")
-			m.logPushSync(t.ID, wtBranch, project.PushSync(wtPath, wtBranch))
+			return "", fmt.Errorf("%w: rebase %s onto %s: %w", ErrRebaseFailed, wtBranch, baseRef, err)
 		}
+		// Sync remote after rebase.
+		callPhase(onPhase, "Syncing upstream…")
+		m.logPushSync(t.ID, wtBranch, project.PushSync(wtPath, wtBranch))
 		m.logger.Info("worktree.reused-branch", "task_id", t.ID, "path", wtPath, "branch", wtBranch)
 		callPhase(onPhase, "Running setup…")
 		if err := m.runSetup(t.ID, wtPath, m.resolveSetupCommands(wtPath, proj)); err != nil {


### PR DESCRIPTION
## Motivation

Sybra escalated several autonomous tasks to human-required because tamper detection scanned stale branch history instead of the latest agent run. Reused worktrees with failed rebases also kept running agents on polluted branches.

> Changelog: fix(workflow): scope tamper scans

## Implementation information

Capture each run_agent step pre-run HEAD and use that as the detect_tampering range. Reused worktrees now fail closed when rebase fails before agent execution, and assertion-only test refactors are downgraded when new assertions are added elsewhere in the verification diff.

## Supporting documentation

Validated with `go test ./...`.