### PR TITLE
fix(handoff): keep PR handoffs internal

### DIFF
--- a/cmd/sybra-cli/handoff_test.go
+++ b/cmd/sybra-cli/handoff_test.go
@@ -22,8 +22,6 @@ func TestHandoffStageConfigForAliases(t *testing.T) {
 		{stage: "testing", name: "testing", tags: []string{"handoff", "handoff-testing"}},
 		{stage: "ready-pr", name: "ready-pr", tags: []string{"handoff", "handoff-ready-pr"}},
 		{stage: "open-pr", name: "ready-pr", tags: []string{"handoff", "handoff-ready-pr"}},
-		{stage: "in-review", name: "pr", tags: []string{"review", handoffPRTag}},
-		{stage: "pr", name: "pr", tags: []string{"review", handoffPRTag}},
 	}
 
 	for _, tt := range tests {
@@ -48,5 +46,21 @@ func TestHandoffStageConfigForRejectsUnknownStage(t *testing.T) {
 
 	if _, ok := handoffStageConfigFor("done"); ok {
 		t.Fatal("handoffStageConfigFor(\"done\") returned ok=true")
+	}
+}
+
+func TestHandoffStageConfigForRejectsExternalPRStages(t *testing.T) {
+	t.Parallel()
+
+	for _, stage := range []string{"pr", "in-review", "pull-request", "pull_request"} {
+		t.Run(stage, func(t *testing.T) {
+			t.Parallel()
+			if _, ok := handoffStageConfigFor(stage); ok {
+				t.Fatalf("handoffStageConfigFor(%q) returned ok=true", stage)
+			}
+			if !isExternalPRHandoffStage(stage) {
+				t.Fatalf("isExternalPRHandoffStage(%q) = false, want true", stage)
+			}
+		})
 	}
 }

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -385,7 +385,7 @@ func cmdHandoff(s *task.Manager, ps *project.Store, args []string, jsonOut bool)
 	proj := fs.String("project", "", "project id (owner/repo); derived from the worktree origin remote when omitted")
 	wtDir := fs.String("worktree-dir", "", "git worktree Sybra should reuse (default: current directory)")
 	mode := fs.String("mode", "headless", "agent mode: headless|interactive")
-	stage := fs.String("stage", "implement", "workflow entry stage: implement|in-progress|review|ready-review|agentic-review|testing|ready-pr")
+	stage := fs.String("stage", "implement", "workflow entry stage: implement|review|testing|ready-pr")
 	rawStatus := fs.String("status", "", "raw task status to create without starting a workflow")
 	sourceProvider := fs.String("source-provider", "", "provider that produced the handed-off work: claude|codex|copilot")
 	pr := fs.Int("pr", 0, "existing PR number to link when using --stage ready-pr")
@@ -492,7 +492,7 @@ func resolveHandoffMode(fs *flag.FlagSet, stage, rawStatus string, pr int) (hand
 		if isExternalPRHandoffStage(stage) {
 			return handoffStageConfig{}, "", false, fmt.Errorf("--stage %s is not supported by handoff: handoff only creates internal Sybra tasks; use --stage ready-pr --pr N to link an existing PR from this worktree", stage)
 		}
-		return handoffStageConfig{}, "", false, fmt.Errorf("invalid --stage %q (valid: implement, in-progress, review, ready-review, agentic-review, testing, ready-pr)", stage)
+		return handoffStageConfig{}, "", false, fmt.Errorf("invalid --stage %q (valid: implement, review, testing, ready-pr; aliases: in-progress, ready-review, agentic-review, test, open-pr, create-pr)", stage)
 	}
 	if pr > 0 && stageCfg.name != "ready-pr" {
 		return handoffStageConfig{}, "", false, fmt.Errorf("--pr is only valid with --stage ready-pr so the PR stays linked to an internal Sybra task")
@@ -1684,8 +1684,8 @@ Commands:
              implement      have a plan -> Sybra implements, reviews, tests, opens the PR
              review         implemented locally -> Sybra enters agentic review
              testing        reviewed locally -> Sybra tests, then opens the PR
-             ready-pr       tested locally -> Sybra opens or updates the PR
-                            pass --pr N only to link an existing same-branch PR
+             ready-pr       tested locally -> Sybra opens or updates the PR; pass --pr N
+                            only to link an existing same-branch PR
            --source-provider records which local agent produced handed-off work
            so review/testing/PR steps can run on a different provider.
            Required for --stage review|testing; optional for implement/ready-pr.

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -375,8 +375,7 @@ func cmdCreate(s *task.Manager, args []string, jsonOut bool) int {
 
 // cmdHandoff creates a task pre-tagged for a Sybra workflow entry point. It
 // bypasses triage/planning and either starts the requested agentic stage in an
-// existing worktree, reviews an existing PR, or places the task in a raw status
-// without workflow dispatch.
+// existing worktree or places the task in a raw status without workflow dispatch.
 func cmdHandoff(s *task.Manager, ps *project.Store, args []string, jsonOut bool) int {
 	fs := flag.NewFlagSet("handoff", flag.ContinueOnError)
 	title := fs.String("title", "", "task title (required)")
@@ -386,10 +385,10 @@ func cmdHandoff(s *task.Manager, ps *project.Store, args []string, jsonOut bool)
 	proj := fs.String("project", "", "project id (owner/repo); derived from the worktree origin remote when omitted")
 	wtDir := fs.String("worktree-dir", "", "git worktree Sybra should reuse (default: current directory)")
 	mode := fs.String("mode", "headless", "agent mode: headless|interactive")
-	stage := fs.String("stage", "implement", "workflow entry stage: implement|in-progress|review|ready-review|agentic-review|testing|ready-pr|pr|in-review")
+	stage := fs.String("stage", "implement", "workflow entry stage: implement|in-progress|review|ready-review|agentic-review|testing|ready-pr")
 	rawStatus := fs.String("status", "", "raw task status to create without starting a workflow")
 	sourceProvider := fs.String("source-provider", "", "provider that produced the handed-off work: claude|codex|copilot")
-	pr := fs.Int("pr", 0, "PR number (required for --stage pr)")
+	pr := fs.Int("pr", 0, "existing PR number to link when using --stage ready-pr")
 	extraTags := fs.String("tags", "", "extra comma-separated tags")
 	if err := fs.Parse(args); err != nil {
 		return fatal(jsonOut, "%v", err)
@@ -439,31 +438,19 @@ func cmdHandoff(s *task.Manager, ps *project.Store, args []string, jsonOut bool)
 	if rawStatusMode {
 		init.Status = &status
 	}
-	switch stageCfg.name {
-	case "pr":
-		// Existing PR: Sybra reviews it via the pr-review lane. No worktree
-		// adoption — pr-review checks out the PR head itself.
-		if *pr <= 0 {
-			return fatal(jsonOut, "--stage pr requires --pr <number>")
-		}
+	// Handoff always adopts the current worktree and routes through the internal
+	// Sybra task pipeline. It must never create the inbound PR-review lane's
+	// `review` task shape, because that represents external PRs awaiting human
+	// review rather than Sybra-authored work.
+	if wtProj, e := deriveProjectID(dir); e == nil && !strings.EqualFold(wtProj, projectID) {
+		return fatal(jsonOut, "worktree origin is %q but --project is %q — refusing to push agent work to a different repo", wtProj, projectID)
+	}
+	if e := assertFeatureBranch(dir, projRec); e != nil {
+		return fatal(jsonOut, "%v", e)
+	}
+	init.WorktreeDir = task.Ptr(dir)
+	if *pr > 0 {
 		init.PRNumber = task.Ptr(*pr)
-	default:
-		// Non-PR stages adopt the worktree. Guard that the chosen project
-		// matches the worktree's origin — a mismatched --project (or stale
-		// ProjectID) would make agents run and push against the wrong repo.
-		// Best-effort: only enforced when origin is a parseable GitHub remote.
-		if wtProj, e := deriveProjectID(dir); e == nil && !strings.EqualFold(wtProj, projectID) {
-			return fatal(jsonOut, "worktree origin is %q but --project is %q — refusing to push agent work to a different repo", wtProj, projectID)
-		}
-		// The worktree must be on a dedicated feature branch (enforced again at
-		// adoption).
-		if e := assertFeatureBranch(dir, projRec); e != nil {
-			return fatal(jsonOut, "%v", e)
-		}
-		init.WorktreeDir = task.Ptr(dir)
-		if *pr > 0 {
-			init.PRNumber = task.Ptr(*pr)
-		}
 	}
 
 	t, err := s.CreateFull(*title, *body, *mode, init)
@@ -502,10 +489,13 @@ func resolveHandoffMode(fs *flag.FlagSet, stage, rawStatus string, pr int) (hand
 
 	stageCfg, ok := handoffStageConfigFor(stage)
 	if !ok {
-		return handoffStageConfig{}, "", false, fmt.Errorf("invalid --stage %q (valid: implement, in-progress, review, ready-review, agentic-review, testing, ready-pr, pr, in-review)", stage)
+		if isExternalPRHandoffStage(stage) {
+			return handoffStageConfig{}, "", false, fmt.Errorf("--stage %s is not supported by handoff: handoff only creates internal Sybra tasks; use --stage ready-pr --pr N to link an existing PR from this worktree", stage)
+		}
+		return handoffStageConfig{}, "", false, fmt.Errorf("invalid --stage %q (valid: implement, in-progress, review, ready-review, agentic-review, testing, ready-pr)", stage)
 	}
-	if pr > 0 && stageCfg.name != "pr" && stageCfg.name != "ready-pr" {
-		return handoffStageConfig{}, "", false, fmt.Errorf("--pr is only valid with --stage pr or --stage ready-pr")
+	if pr > 0 && stageCfg.name != "ready-pr" {
+		return handoffStageConfig{}, "", false, fmt.Errorf("--pr is only valid with --stage ready-pr so the PR stays linked to an internal Sybra task")
 	}
 	return stageCfg, "", false, nil
 }
@@ -541,10 +531,7 @@ type handoffStageConfig struct {
 	tags []string
 }
 
-const (
-	handoffManualTag = "handoff-manual"
-	handoffPRTag     = "handoff-pr"
-)
+const handoffManualTag = "handoff-manual"
 
 // handoffStageConfigFor maps a handoff stage to the tags that route the task
 // into the right Sybra lane on creation, or false for an unknown stage.
@@ -552,7 +539,6 @@ const (
 //   - review:    simple-task-handoff-review → ready-review → review → testing → PR
 //   - testing:   simple-task-handoff-testing → testing → adversarial test → PR
 //   - ready-pr:  simple-task-handoff-ready-pr → ready-pr → open/update PR
-//   - pr:        pr-review lane for an existing PR
 func handoffStageConfigFor(stage string) (handoffStageConfig, bool) {
 	switch strings.ToLower(strings.TrimSpace(stage)) {
 	case "", "implement", "in-progress":
@@ -563,16 +549,23 @@ func handoffStageConfigFor(stage string) (handoffStageConfig, bool) {
 		return handoffStageConfig{name: "testing", tags: []string{"handoff", "handoff-testing"}}, true
 	case "ready-pr", "open-pr", "create-pr":
 		return handoffStageConfig{name: "ready-pr", tags: []string{"handoff", "handoff-ready-pr"}}, true
-	case "pr", "in-review", "pull-request", "pull_request":
-		return handoffStageConfig{name: "pr", tags: []string{"review", handoffPRTag}}, true
 	default:
 		return handoffStageConfig{}, false
 	}
 }
 
+func isExternalPRHandoffStage(stage string) bool {
+	switch strings.ToLower(strings.TrimSpace(stage)) {
+	case "pr", "in-review", "pull-request", "pull_request":
+		return true
+	default:
+		return false
+	}
+}
+
 func handoffStageRequiresSource(stage string) bool {
 	switch stage {
-	case "review", "testing", "pr":
+	case "review", "testing":
 		return true
 	default:
 		return false
@@ -666,9 +659,6 @@ func printHandoffResult(t task.Task, stage, projectID, dir string) {
 	case "ready-pr":
 		fmt.Printf("  worktree: %s\n", dir)
 		fmt.Println("  Sybra will skip straight to opening or updating the PR from this worktree.")
-	case "pr":
-		fmt.Printf("  pr:       #%d\n", t.PRNumber)
-		fmt.Println("  Sybra will review the existing PR.")
 	default:
 		fmt.Printf("  worktree: %s\n", dir)
 		fmt.Println("  Sybra will skip planning and start implementing in this worktree.")
@@ -1695,10 +1685,10 @@ Commands:
              review         implemented locally -> Sybra enters agentic review
              testing        reviewed locally -> Sybra tests, then opens the PR
              ready-pr       tested locally -> Sybra opens or updates the PR
-             pr|in-review   existing PR (--pr N) -> Sybra reviews the PR
+                            pass --pr N only to link an existing same-branch PR
            --source-provider records which local agent produced handed-off work
            so review/testing/PR steps can run on a different provider.
-           Required for --stage review|testing|pr; optional for implement/ready-pr.
+           Required for --stage review|testing; optional for implement/ready-pr.
            --status STATUS creates the task directly in that status without workflow dispatch
   umbrella <issue-url> [--model M]
            Expand a GitHub umbrella issue into a gated task DAG: one umbrella tracker

--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -500,6 +501,63 @@ func TestHandoffPersistsSourceProviderAtomically(t *testing.T) {
 	}
 }
 
+func TestHandoffReadyPRLinksExistingPRAsInternalTask(t *testing.T) {
+	setupStore(t)
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	ps, err := project.NewStore(cfg.ProjectsDir, cfg.ClonesDir)
+	if err != nil {
+		t.Fatalf("project.NewStore: %v", err)
+	}
+	proj, err := ps.CreateMeta("https://github.com/acme/repo.git", project.ProjectTypePet)
+	if err != nil {
+		t.Fatalf("CreateMeta: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(proj.ClonePath), 0o755); err != nil {
+		t.Fatalf("mkdir clone parent: %v", err)
+	}
+	runGit(t, "", "init", "--bare", proj.ClonePath)
+	runGit(t, "", "--git-dir="+proj.ClonePath, "symbolic-ref", "HEAD", "refs/heads/main")
+
+	worktree := filepath.Join(t.TempDir(), "repo")
+	runGit(t, "", "init", worktree)
+	runGit(t, worktree, "checkout", "-b", "feature/handoff")
+	runGit(t, worktree, "remote", "add", "origin", "https://github.com/acme/repo.git")
+
+	code, out := runCLI(t,
+		"--json", "handoff",
+		"--title", "fix(test): ready pr",
+		"--project", "acme/repo",
+		"--worktree-dir", worktree,
+		"--stage", "ready-pr",
+		"--pr", "123",
+		"--source-provider", "copilot",
+	)
+	if code != 0 {
+		t.Fatalf("handoff exit %d: %s", code, out)
+	}
+
+	var created task.Task
+	mustUnmarshal(t, out, &created)
+	if created.PRNumber != 123 {
+		t.Fatalf("PRNumber = %d, want 123", created.PRNumber)
+	}
+	if created.WorktreeDir != worktree {
+		t.Fatalf("WorktreeDir = %q, want %q", created.WorktreeDir, worktree)
+	}
+	if slices.Contains(created.Tags, "review") || slices.Contains(created.Tags, "handoff-pr") {
+		t.Fatalf("Tags = %v, want internal handoff tags only", created.Tags)
+	}
+	wantTags := []string{"handoff", "handoff-ready-pr"}
+	for i := range wantTags {
+		if i >= len(created.Tags) || created.Tags[i] != wantTags[i] {
+			t.Fatalf("Tags = %v, want prefix %v", created.Tags, wantTags)
+		}
+	}
+}
+
 func TestHandoffReviewRequiresSourceProvider(t *testing.T) {
 	setupStore(t)
 
@@ -510,6 +568,36 @@ func TestHandoffReviewRequiresSourceProvider(t *testing.T) {
 	)
 	if code == 0 {
 		t.Fatal("handoff review without source provider succeeded, want failure")
+	}
+}
+
+func TestHandoffRejectsExternalPRStage(t *testing.T) {
+	setupStore(t)
+
+	code, _ := runCLI(t,
+		"--json", "handoff",
+		"--title", "fix(test): review pr",
+		"--stage", "pr",
+		"--pr", "123",
+		"--source-provider", "copilot",
+	)
+	if code == 0 {
+		t.Fatal("handoff --stage pr succeeded, want failure")
+	}
+}
+
+func TestHandoffPrNumberRequiresReadyPrStage(t *testing.T) {
+	setupStore(t)
+
+	code, _ := runCLI(t,
+		"--json", "handoff",
+		"--title", "fix(test): link pr",
+		"--stage", "review",
+		"--pr", "123",
+		"--source-provider", "copilot",
+	)
+	if code == 0 {
+		t.Fatal("handoff --stage review --pr succeeded, want failure")
 	}
 }
 

--- a/frontend/src/lib/review-phase.ts
+++ b/frontend/src/lib/review-phase.ts
@@ -84,7 +84,7 @@ export function isReviewTask(t: { tags?: string[] }): boolean {
   return t.tags?.includes('review') ?? false
 }
 
-/** Tag set by `sybra-cli handoff --stage pr` on a self-authored PR. */
+/** Legacy tag once used for self-authored PR handoffs. New handoffs do not set it. */
 export const HANDOFF_PR_TAG = 'handoff-pr'
 
 /**

--- a/internal/skills/data/sybra-handoff.md
+++ b/internal/skills/data/sybra-handoff.md
@@ -25,9 +25,9 @@ Hand off at whatever stage you have reached — Sybra picks up from there:
 - You have **implemented and reviewed** locally and want the testing gate →
   `--stage testing` with a different provider.
 - You have **implemented, reviewed, and tested** locally and want Sybra to open
-  or update the PR from this worktree → `--stage ready-pr`.
-- You already **opened a PR** and want Sybra to review it with a different
-  provider → `--stage pr --pr N` (alias: `in-review --pr N`).
+  or update the PR from this worktree → `--stage ready-pr`. If the PR already
+  exists for this same worktree branch, pass `--pr N` with `--stage ready-pr` so
+  Sybra links and pushes the internal task rather than creating a duplicate PR.
 
 In all cases the approach is decided and you want Sybra to carry it the rest of
 the way autonomously. Do **not** use for exploratory work that still needs human
@@ -40,9 +40,14 @@ workflow entry points, not just column names.
 ## What it does
 
 `sybra-cli handoff` creates a task that skips straight to the requested stage —
-no triage, no planning gate — and (for all non-PR stages) reuses **this** git
+no triage, no planning gate — and always reuses **this** git
 worktree (`--worktree-dir`, default: cwd) instead of creating a fresh one: no
 rebase, no force-push, and Sybra never deletes it.
+
+Handoff only creates **internal Sybra tasks**. It must not route work into the
+inbound/external PR-review lane (the lane for reviewing someone else's PR). Do
+not use `--stage pr`, `--stage in-review`, `pull-request`, or tags like
+`review`/`handoff-pr`; the CLI rejects those stages.
 
 `sybra-cli handoff --status <status>` creates the task directly in that status
 with a `handoff-manual` tag and does **not** start any workflow. This is for
@@ -56,10 +61,9 @@ Stages:
 - **testing**: flips to `testing`; Sybra runs the adversarial testing gate in the
   adopted worktree with a different provider and opens the PR if tests pass.
 - **ready-pr**: flips to `ready-pr`; Sybra opens or updates the PR from the
-  adopted worktree (no implementation, review, or testing step).
-- **pr**: for an existing PR (`--pr N`); Sybra reviews the open PR via its
-  pr-review lane with a different provider (no worktree adoption — it checks out
-  the PR head itself).
+  adopted worktree (no implementation, review, or testing step). With `--pr N`,
+  it links/pushes the existing PR for this same branch while staying an internal
+  Sybra task.
 
 ## Workflow entry context
 
@@ -71,21 +75,18 @@ column label:
 | `implement` | `in-progress` | `simple-task-handoff` -> `simple-task-implement` | The approach is decided but code is not written. |
 | `review` | `ready-review`, `agentic-review` | `simple-task-handoff-review` -> `simple-task-review` | Code exists in this worktree and needs Sybra's review/test/PR flow. |
 | `testing` | `test` | `simple-task-handoff-testing` -> `testing-task` | Code has already had the review you want and only needs Sybra's test/PR flow. |
-| `ready-pr` | `open-pr`, `create-pr` | `simple-task-handoff-ready-pr` -> `simple-task-pr` | Code has already been reviewed and tested, and Sybra should open/update the PR from this worktree. |
-| `pr` | `in-review`, `pull-request` | `pr-review` | A real PR already exists; pass `--pr N`. |
+| `ready-pr` | `open-pr`, `create-pr` | `simple-task-handoff-ready-pr` -> `simple-task-pr` | Code has already been reviewed and tested, and Sybra should open/update the PR from this worktree. Pass `--pr N` only here to link an existing same-branch PR. |
 
 Important status distinction:
 - `ready-review` / `agentic-review` means "start Sybra's review workflow".
 - `ready-pr` means "open or update a PR from this adopted worktree".
-- `in-review` means "an existing PR is already open and needs PR review"; it
-  requires `--pr N` and does not adopt the local worktree.
 - `--status in-review` means "place this task in the in-review column without
   starting any review workflow"; use this only when a human or another system is
   handling the next action.
 
 If unsure, inspect `internal/workflow/builtin/*.yaml` and choose the entry point
 whose trigger matches the next agentic step. Do not add broad workflow-lane tags
-such as `review` unless you intentionally want the existing-PR lane.
+such as `review`; handoff tasks must stay in the internal simple-task workflow.
 
 ## Procedure
 
@@ -124,14 +125,14 @@ such as `review` unless you intentionally want the existing-PR lane.
    ```
    Set `--source-provider` to the provider running this skill: Claude Code uses
    `claude`, Codex uses `codex`, and Copilot uses `copilot`. It is required for
-   `--stage review`, `--stage testing`, and `--stage pr`, and recommended for
-   `--stage implement` and `--stage ready-pr` so provenance is visible on the
-   task.
+   `--stage review` and `--stage testing`, and recommended for `--stage implement`
+   and `--stage ready-pr` so provenance is visible on the task.
    - `--stage review` / `ready-review` / `agentic-review` to skip implementation
      (you already coded it); `--stage testing` to skip implementation and
-     review; `--stage ready-pr` to skip directly to PR creation/update;
-     `--stage pr --pr N` to hand off an existing PR. Default is
-     `--stage implement`.
+     review; `--stage ready-pr` to skip directly to PR creation/update. Default
+     is `--stage implement`.
+   - `--pr N` is valid only with `--stage ready-pr`, where it links an existing
+     PR for the adopted worktree branch. Never use PR handoff as a review lane.
    - `--status STATUS` is mutually exclusive with `--stage` and creates a manual
      task in that exact status without workflow dispatch.
    - `--plan-file` matters most for `--stage implement`; for later stages it is

--- a/internal/skills/data/sybra-handoff.md
+++ b/internal/skills/data/sybra-handoff.md
@@ -46,8 +46,10 @@ rebase, no force-push, and Sybra never deletes it.
 
 Handoff only creates **internal Sybra tasks**. It must not route work into the
 inbound/external PR-review lane (the lane for reviewing someone else's PR). Do
-not use `--stage pr`, `--stage in-review`, `pull-request`, or tags like
-`review`/`handoff-pr`; the CLI rejects those stages.
+not use external PR stages such as `--stage pr`, `--stage in-review`, or
+`--stage pull-request`; the CLI rejects those stages. Extra tags such as
+`review`/`handoff-pr` are legacy external-lane markers and should not be passed
+with handoffs.
 
 `sybra-cli handoff --status <status>` creates the task directly in that status
 with a `handoff-manual` tag and does **not** start any workflow. This is for

--- a/internal/sybra/app_external_task_test.go
+++ b/internal/sybra/app_external_task_test.go
@@ -131,9 +131,9 @@ func TestSkipTaskCreatedWorkflow_PRLinkedHandoffExceptions(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "explicit PR handoff may enter task.created pr-review lane",
-			task: task.Task{PRNumber: 42, Tags: []string{"review", handoffPRTag}},
-			want: false,
+			name: "legacy handoff-pr task cannot enter external pr-review lane",
+			task: task.Task{PRNumber: 42, Tags: []string{"review", "handoff-pr"}},
+			want: true,
 		},
 		{
 			name: "ready-pr worktree handoff may enter task.created lane with known PR",

--- a/internal/sybra/workflow_dispatch.go
+++ b/internal/sybra/workflow_dispatch.go
@@ -8,7 +8,6 @@ import (
 
 const (
 	handoffManualTag = "handoff-manual"
-	handoffPRTag     = "handoff-pr"
 	// enrichPendingTag marks a stub created from a raw GitHub issue/PR URL
 	// whose real title/body/labels are still being fetched asynchronously
 	// (TaskService.enrichFromIssue/enrichFromPR). It is set atomically at
@@ -45,5 +44,5 @@ func skipTaskCreatedWorkflow(t task.Task) bool {
 }
 
 func allowsTaskCreatedWorkflowWithPR(t task.Task) bool {
-	return slices.Contains(t.Tags, "handoff") || slices.Contains(t.Tags, handoffPRTag)
+	return slices.Contains(t.Tags, "handoff")
 }

--- a/internal/workflow/builtin/pr-review.yaml
+++ b/internal/workflow/builtin/pr-review.yaml
@@ -8,6 +8,9 @@ trigger:
     - field: task.tags
       operator: contains
       value: review
+    - field: task.tags
+      operator: not_contains
+      value: handoff-pr
 steps:
   # Mechanical heuristic: pick simple vs staff review based on PR diff size.
   # Same step type used by simple-task; here it falls back to `gh pr diff`

--- a/internal/workflow/handoff_test.go
+++ b/internal/workflow/handoff_test.go
@@ -202,7 +202,7 @@ func TestBuiltinHandoffReview_DoesNotEnterPRReview(t *testing.T) {
 	}
 }
 
-func TestBuiltinHandoffPR_EntersPRReview(t *testing.T) {
+func TestBuiltinHandoffPR_DoesNotEnterPRReview(t *testing.T) {
 	t.Parallel()
 
 	fields := map[string]string{
@@ -210,8 +210,8 @@ func TestBuiltinHandoffPR_EntersPRReview(t *testing.T) {
 	}
 
 	pr := defByID(t, "pr-review")
-	if !EvalConditions(pr.Trigger.Conditions, fields) {
-		t.Fatalf("pr-review should match handoff-pr tags %q; conditions=%+v", fields["task.tags"], pr.Trigger.Conditions)
+	if EvalConditions(pr.Trigger.Conditions, fields) {
+		t.Fatalf("pr-review must not match handoff-pr tags %q; conditions=%+v", fields["task.tags"], pr.Trigger.Conditions)
 	}
 
 	plan := defByID(t, "simple-task-plan")


### PR DESCRIPTION
## Motivation

Handoff should always create Sybra-owned workflow tasks. The old `--stage pr` path created tasks tagged like inbound PR-review work, so a self-authored PR appeared as an external "To review" item.

> Changelog: fix(handoff): keep PR handoffs internal

## Implementation information

- Removed the `pr` / `in-review` handoff stage and reject those aliases with a clear error.
- Allow `--pr N` only with `--stage ready-pr`, keeping the task tagged as internal handoff work while linking an existing same-branch PR.
- Made the legacy `handoff-pr` tag inert for task-created PR-review dispatch and updated the handoff skill docs.

## Supporting documentation

Added regression coverage for rejected external PR stages, ready-pr PR linking, dispatch guards, and workflow trigger matching.