### PR TITLE
refactor(agent): require manager config

### DIFF
--- a/internal/agent/approval_server.go
+++ b/internal/agent/approval_server.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -82,7 +83,11 @@ func (s *ApprovalServer) SetManager(m *Manager) {
 
 // Shutdown gracefully stops the HTTP server.
 func (s *ApprovalServer) Shutdown(ctx context.Context) error {
-	return s.server.Shutdown(ctx)
+	err := s.server.Shutdown(ctx)
+	if closeErr := s.listener.Close(); closeErr != nil && !errors.Is(closeErr, net.ErrClosed) {
+		return errors.Join(err, closeErr)
+	}
+	return err
 }
 
 // hookInput matches the JSON the Claude CLI sends to PreToolUse hooks.

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -82,16 +82,61 @@ type LimitGate interface {
 	ChooseProvider(requested string, candidates []string, healthy func(string) bool, policy limits.Policy) (string, string)
 }
 
-func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir string) *Manager {
-	return &Manager{
+// ManagerConfig contains startup-only wiring. Values that are intentionally
+// live-editable are grouped in Runtime and updated via UpdateRuntimeConfig.
+type ManagerConfig struct {
+	Runtime ManagerRuntimeConfig
+
+	OnComplete        func(ag *Agent)
+	ApprovalAddr      string
+	SurviveRestartDir string
+	SessionSink       func(taskID, agentID, sessionID string) error
+	TaskExists        func(taskID string) bool
+	LimitSink         func(limits.Snapshot)
+}
+
+// ManagerRuntimeConfig holds settings that affect future runs and may change
+// on config reload without rebuilding the manager.
+type ManagerRuntimeConfig struct {
+	MaxConcurrent   int
+	DefaultProvider string
+	BashTimeoutMs   int
+	RetryWatchdog   int
+	FallbackModel   string
+	LimitGate       LimitGate
+	LimitPolicy     limits.Policy
+}
+
+func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir string, cfg ManagerConfig) (*Manager, error) {
+	m := &Manager{
 		agents:         make(map[string]*Agent),
 		dispatchClaims: make(map[string]struct{}),
 		ctx:            ctx,
 		emit:           emit,
+		onComplete:     cfg.OnComplete,
 		logger:         logger,
 		logDir:         logDir,
-		defaultProv:    "claude",
+		approvalAddr:   cfg.ApprovalAddr,
+		defaultProv:    normalizeProvider(cfg.Runtime.DefaultProvider),
+		maxConcurrent:  cfg.Runtime.MaxConcurrent,
+		bashTimeoutMs:  cfg.Runtime.BashTimeoutMs,
+		retryWatchdog:  cfg.Runtime.RetryWatchdog,
+		fallbackModel:  cfg.Runtime.FallbackModel,
+		limitGate:      cfg.Runtime.LimitGate,
+		limitPolicy:    copyLimitPolicy(cfg.Runtime.LimitPolicy),
+		limitSink:      cfg.LimitSink,
+		sessionSink:    cfg.SessionSink,
+		taskExists:     cfg.TaskExists,
 	}
+	if cfg.SurviveRestartDir != "" {
+		s, err := newRegistryStore(cfg.SurviveRestartDir)
+		if err != nil {
+			return nil, fmt.Errorf("agent survival registry: %w", err)
+		}
+		m.reg = s
+		m.surviveRestart = true
+	}
+	return m, nil
 }
 
 // ClaimTaskDispatch reserves the right to dispatch an agent for taskID,
@@ -121,32 +166,17 @@ func (m *Manager) ReleaseTaskDispatch(taskID string) {
 	m.mu.Unlock()
 }
 
-func (m *Manager) SetOnComplete(fn func(ag *Agent)) {
-	m.onComplete = fn
-}
-
-// EnableSurviveRestart turns on restart survival: headless (and, once
-// Phase 3 lands, interactive) subprocesses are detached and recorded in a
-// registry under dir so the next app instance can reattach to them. Call
-// once during startup before ReattachAll.
-func (m *Manager) EnableSurviveRestart(dir string) error {
-	s, err := newRegistryStore(dir)
-	if err != nil {
-		return err
-	}
+// UpdateRuntimeConfig updates settings that are intentionally live: they affect
+// future Run calls and config reloads without mutating startup-only callbacks.
+func (m *Manager) UpdateRuntimeConfig(cfg ManagerRuntimeConfig) {
 	m.mu.Lock()
-	m.reg = s
-	m.surviveRestart = true
-	m.mu.Unlock()
-	return nil
-}
-
-// SetSessionSink installs the callback used to persist a crashed agent's
-// session id into its task's AgentRun during dead-reattach. Set once at
-// startup before ReattachAll.
-func (m *Manager) SetSessionSink(fn func(taskID, agentID, sessionID string) error) {
-	m.mu.Lock()
-	m.sessionSink = fn
+	m.maxConcurrent = cfg.MaxConcurrent
+	m.defaultProv = normalizeProvider(cfg.DefaultProvider)
+	m.bashTimeoutMs = cfg.BashTimeoutMs
+	m.retryWatchdog = cfg.RetryWatchdog
+	m.fallbackModel = cfg.FallbackModel
+	m.limitGate = cfg.LimitGate
+	m.limitPolicy = copyLimitPolicy(cfg.LimitPolicy)
 	m.mu.Unlock()
 }
 
@@ -154,14 +184,6 @@ func (m *Manager) sessionSinkFn() func(taskID, agentID, sessionID string) error 
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.sessionSink
-}
-
-// SetTaskExists installs the callback used to skip recreating a codex agent
-// whose task was deleted. Set once at startup before ReattachAll.
-func (m *Manager) SetTaskExists(fn func(taskID string) bool) {
-	m.mu.Lock()
-	m.taskExists = fn
-	m.mu.Unlock()
 }
 
 func (m *Manager) taskExistsFn() func(taskID string) bool {
@@ -232,45 +254,12 @@ func (m *Manager) signalKill(a *Agent) {
 	signalPID(a.GetPID(), stopSIGINTGrace)
 }
 
-// SetApprovalAddr sets the HTTP address for the tool approval server.
-func (m *Manager) SetApprovalAddr(addr string) {
-	m.approvalAddr = addr
-}
-
-// SetMaxConcurrent sets the maximum number of concurrently running agents.
-// A value of 0 means unlimited.
-func (m *Manager) SetMaxConcurrent(n int) {
-	m.mu.Lock()
-	m.maxConcurrent = n
-	m.mu.Unlock()
-}
-
-func (m *Manager) SetDefaultProvider(name string) {
-	prov, err := lookupProvider(name)
-	if err != nil {
-		if m.logger != nil {
-			m.logger.Warn("agent.default_provider.invalid", "provider", name, "err", err)
-		}
-		return
-	}
-	m.mu.Lock()
-	m.defaultProv = prov.Name()
-	m.mu.Unlock()
-}
-
 // SetHealthGate wires in a provider health checker so Run() can refuse or
 // failover when the requested provider is unhealthy. A nil gate disables the
 // check entirely (tests, feature-disabled mode).
 func (m *Manager) SetHealthGate(g provider.HealthGate) {
 	m.mu.Lock()
 	m.gate = g
-	m.mu.Unlock()
-}
-
-func (m *Manager) SetLimitGate(g LimitGate, policy limits.Policy) {
-	m.mu.Lock()
-	m.limitGate = g
-	m.limitPolicy = copyLimitPolicy(policy)
 	m.mu.Unlock()
 }
 
@@ -296,12 +285,6 @@ func copyStringFloatMap(in map[string]float64) map[string]float64 {
 
 func copyStringBoolMap(in map[string]bool) map[string]bool {
 	return maps.Clone(in)
-}
-
-func (m *Manager) SetLimitSink(fn func(limits.Snapshot)) {
-	m.mu.Lock()
-	m.limitSink = fn
-	m.mu.Unlock()
 }
 
 // ProviderRateLimited reports whether the named provider is currently in a
@@ -379,31 +362,6 @@ func (m *Manager) DefaultProvider() string {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.defaultProv
-}
-
-// SetBashTimeoutMs sets the default --bashTimeoutMs passed to claude -p.
-// Zero disables the flag (no per-call timeout).
-func (m *Manager) SetBashTimeoutMs(ms int) {
-	m.mu.Lock()
-	m.bashTimeoutMs = ms
-	m.mu.Unlock()
-}
-
-// SetRetryWatchdog sets the default CLAUDE_CODE_RETRY_WATCHDOG value injected
-// into headless claude subprocess environments. Zero resets to "not set"
-// (no env var exported).
-func (m *Manager) SetRetryWatchdog(n int) {
-	m.mu.Lock()
-	m.retryWatchdog = n
-	m.mu.Unlock()
-}
-
-// SetFallbackModel sets the default --fallback-model passed to headless claude
-// runs. Empty string clears the fallback (no flag added).
-func (m *Manager) SetFallbackModel(model string) {
-	m.mu.Lock()
-	m.fallbackModel = model
-	m.mu.Unlock()
 }
 
 // SetGuardrails configures cost and turn limits applied to all agents.

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -14,6 +15,9 @@ import (
 )
 
 type EmitFunc func(event string, data any)
+
+// ErrSurvivalRegistry marks failures initializing restart-survival persistence.
+var ErrSurvivalRegistry = errors.New("agent survival registry")
 
 // Guardrails defines per-agent execution limits.
 type Guardrails struct {
@@ -83,7 +87,7 @@ type LimitGate interface {
 }
 
 // ManagerConfig contains startup-only wiring. Values that are intentionally
-// live-editable are grouped in Runtime and updated via UpdateRuntimeConfig.
+// live-editable are grouped in Runtime and updated via ReplaceRuntimeConfig.
 type ManagerConfig struct {
 	Runtime ManagerRuntimeConfig
 
@@ -108,6 +112,10 @@ type ManagerRuntimeConfig struct {
 }
 
 func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir string, cfg ManagerConfig) (*Manager, error) {
+	defaultProv, err := normalizeProviderName(cfg.Runtime.DefaultProvider)
+	if err != nil {
+		return nil, fmt.Errorf("default provider: %w", err)
+	}
 	m := &Manager{
 		agents:         make(map[string]*Agent),
 		dispatchClaims: make(map[string]struct{}),
@@ -117,7 +125,7 @@ func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir 
 		logger:         logger,
 		logDir:         logDir,
 		approvalAddr:   cfg.ApprovalAddr,
-		defaultProv:    normalizeProvider(cfg.Runtime.DefaultProvider),
+		defaultProv:    defaultProv,
 		maxConcurrent:  cfg.Runtime.MaxConcurrent,
 		bashTimeoutMs:  cfg.Runtime.BashTimeoutMs,
 		retryWatchdog:  cfg.Runtime.RetryWatchdog,
@@ -131,7 +139,7 @@ func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir 
 	if cfg.SurviveRestartDir != "" {
 		s, err := newRegistryStore(cfg.SurviveRestartDir)
 		if err != nil {
-			return nil, fmt.Errorf("agent survival registry: %w", err)
+			return nil, fmt.Errorf("%w: %w", ErrSurvivalRegistry, err)
 		}
 		m.reg = s
 		m.surviveRestart = true
@@ -166,18 +174,23 @@ func (m *Manager) ReleaseTaskDispatch(taskID string) {
 	m.mu.Unlock()
 }
 
-// UpdateRuntimeConfig updates settings that are intentionally live: they affect
-// future Run calls and config reloads without mutating startup-only callbacks.
-func (m *Manager) UpdateRuntimeConfig(cfg ManagerRuntimeConfig) {
+// ReplaceRuntimeConfig replaces the complete live runtime snapshot. Settings
+// affect future Run calls and config reloads without mutating startup-only callbacks.
+func (m *Manager) ReplaceRuntimeConfig(cfg ManagerRuntimeConfig) error {
+	defaultProv, err := normalizeProviderName(cfg.DefaultProvider)
+	if err != nil {
+		return fmt.Errorf("default provider: %w", err)
+	}
 	m.mu.Lock()
 	m.maxConcurrent = cfg.MaxConcurrent
-	m.defaultProv = normalizeProvider(cfg.DefaultProvider)
+	m.defaultProv = defaultProv
 	m.bashTimeoutMs = cfg.BashTimeoutMs
 	m.retryWatchdog = cfg.RetryWatchdog
 	m.fallbackModel = cfg.FallbackModel
 	m.limitGate = cfg.LimitGate
 	m.limitPolicy = copyLimitPolicy(cfg.LimitPolicy)
 	m.mu.Unlock()
+	return nil
 }
 
 func (m *Manager) sessionSinkFn() func(taskID, agentID, sessionID string) error {

--- a/internal/agent/manager_gate_test.go
+++ b/internal/agent/manager_gate_test.go
@@ -99,16 +99,16 @@ func TestLimitPolicy_DefensiveCopiesMaps(t *testing.T) {
 	policy.ProviderEnabled[limits.ProviderCodex] = true
 	policy.SubscriptionMonthlyUSD[limits.ProviderCodex] = 200
 
-	m.SetLimitGate(nil, policy)
+	m.UpdateRuntimeConfig(ManagerRuntimeConfig{LimitPolicy: policy})
 	policy.ProviderEnabled[limits.ProviderCodex] = false
 	policy.SubscriptionMonthlyUSD[limits.ProviderCodex] = 0
 
 	got := m.LimitPolicy()
 	if !got.ProviderEnabled[limits.ProviderCodex] {
-		t.Fatal("SetLimitGate retained caller-owned ProviderEnabled map")
+		t.Fatal("UpdateRuntimeConfig retained caller-owned ProviderEnabled map")
 	}
 	if got.SubscriptionMonthlyUSD[limits.ProviderCodex] != 200 {
-		t.Fatalf("SetLimitGate retained caller-owned SubscriptionMonthlyUSD map: %+v", got.SubscriptionMonthlyUSD)
+		t.Fatalf("UpdateRuntimeConfig retained caller-owned SubscriptionMonthlyUSD map: %+v", got.SubscriptionMonthlyUSD)
 	}
 
 	got.ProviderEnabled[limits.ProviderCodex] = false

--- a/internal/agent/manager_gate_test.go
+++ b/internal/agent/manager_gate_test.go
@@ -99,16 +99,21 @@ func TestLimitPolicy_DefensiveCopiesMaps(t *testing.T) {
 	policy.ProviderEnabled[limits.ProviderCodex] = true
 	policy.SubscriptionMonthlyUSD[limits.ProviderCodex] = 200
 
-	m.UpdateRuntimeConfig(ManagerRuntimeConfig{LimitPolicy: policy})
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+		DefaultProvider: m.DefaultProvider(),
+		LimitPolicy:     policy,
+	}); err != nil {
+		t.Fatal(err)
+	}
 	policy.ProviderEnabled[limits.ProviderCodex] = false
 	policy.SubscriptionMonthlyUSD[limits.ProviderCodex] = 0
 
 	got := m.LimitPolicy()
 	if !got.ProviderEnabled[limits.ProviderCodex] {
-		t.Fatal("UpdateRuntimeConfig retained caller-owned ProviderEnabled map")
+		t.Fatal("ReplaceRuntimeConfig retained caller-owned ProviderEnabled map")
 	}
 	if got.SubscriptionMonthlyUSD[limits.ProviderCodex] != 200 {
-		t.Fatalf("UpdateRuntimeConfig retained caller-owned SubscriptionMonthlyUSD map: %+v", got.SubscriptionMonthlyUSD)
+		t.Fatalf("ReplaceRuntimeConfig retained caller-owned SubscriptionMonthlyUSD map: %+v", got.SubscriptionMonthlyUSD)
 	}
 
 	got.ProviderEnabled[limits.ProviderCodex] = false

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -113,6 +113,41 @@ func TestNewManager(t *testing.T) {
 	}
 }
 
+func TestNewManagerRejectsInvalidDefaultProvider(t *testing.T) {
+	_, err := NewManager(t.Context(), func(string, any) {}, discardLogger(), t.TempDir(), ManagerConfig{
+		Runtime: ManagerRuntimeConfig{DefaultProvider: "bogus"},
+	})
+	if err == nil {
+		t.Fatal("expected invalid provider error")
+	}
+	if !strings.Contains(err.Error(), "unknown agent provider") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestReplaceRuntimeConfigRejectsInvalidProvider(t *testing.T) {
+	m, _ := newTestManager(t, ManagerConfig{
+		Runtime: ManagerRuntimeConfig{
+			DefaultProvider: "codex",
+			MaxConcurrent:   7,
+		},
+	})
+
+	err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+		DefaultProvider: "bogus",
+		MaxConcurrent:   3,
+	})
+	if err == nil {
+		t.Fatal("expected invalid provider error")
+	}
+	if got := m.DefaultProvider(); got != "codex" {
+		t.Fatalf("DefaultProvider = %q, want codex", got)
+	}
+	if m.maxConcurrent != 7 {
+		t.Fatalf("maxConcurrent = %d, want 7", m.maxConcurrent)
+	}
+}
+
 func TestStartAgentUnknownMode(t *testing.T) {
 	m, _ := newTestManager(t)
 	_, err := startTestAgent(t, m, "task-1", "Test Task", "invalid", "prompt", nil)

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -48,7 +48,7 @@ func (r *eventRecorder) Snapshot() []string {
 	return out
 }
 
-func newTestManager(t *testing.T) (mgr *Manager, emitted *eventRecorder) {
+func newTestManager(t *testing.T, cfgs ...ManagerConfig) (mgr *Manager, emitted *eventRecorder) {
 	t.Helper()
 	ctx := t.Context()
 
@@ -57,7 +57,7 @@ func newTestManager(t *testing.T) (mgr *Manager, emitted *eventRecorder) {
 		emitted.add(event)
 	}
 
-	m := NewManager(ctx, emit, discardLogger(), t.TempDir())
+	m := mustNewManager(t, ctx, emit, discardLogger(), t.TempDir(), cfgs...)
 	return m, emitted
 }
 
@@ -248,16 +248,16 @@ func TestStopAgent(t *testing.T) {
 // exactly once.
 func TestFireComplete_IdempotentUnderConcurrency(t *testing.T) {
 	t.Parallel()
-	m, _ := newTestManager(t)
-
 	var (
 		mu    sync.Mutex
 		count int
 	)
-	m.SetOnComplete(func(_ *Agent) {
-		mu.Lock()
-		count++
-		mu.Unlock()
+	m, _ := newTestManager(t, ManagerConfig{
+		OnComplete: func(_ *Agent) {
+			mu.Lock()
+			count++
+			mu.Unlock()
+		},
 	})
 
 	a := &Agent{
@@ -290,8 +290,6 @@ func TestFireComplete_IdempotentUnderConcurrency(t *testing.T) {
 // agent does not call onComplete immediately — only the goroutine may call it
 // after the process exits, preventing premature worktree cleanup.
 func TestStopHeadlessDoesNotCallOnComplete(t *testing.T) {
-	m, _ := newTestManager(t)
-
 	// Counter is written from the runner goroutine (onComplete path) and
 	// read from the test goroutine after StopAgent returns — protect
 	// with a mutex for the race detector.
@@ -309,11 +307,13 @@ func TestStopHeadlessDoesNotCallOnComplete(t *testing.T) {
 	holdOpen := make(chan struct{})
 	defer close(holdOpen)
 
-	m.SetOnComplete(func(_ *Agent) {
-		<-holdOpen
-		mu.Lock()
-		completeCalls++
-		mu.Unlock()
+	m, _ := newTestManager(t, ManagerConfig{
+		OnComplete: func(_ *Agent) {
+			<-holdOpen
+			mu.Lock()
+			completeCalls++
+			mu.Unlock()
+		},
 	})
 
 	a, err := startTestAgent(t, m, "task-1", "Test Task", "headless", "test", nil)

--- a/internal/agent/manager_test_helpers_test.go
+++ b/internal/agent/manager_test_helpers_test.go
@@ -1,0 +1,20 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+)
+
+func mustNewManager(tb testing.TB, ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir string, cfgs ...ManagerConfig) *Manager {
+	tb.Helper()
+	cfg := ManagerConfig{}
+	if len(cfgs) > 0 {
+		cfg = cfgs[0]
+	}
+	m, err := NewManager(ctx, emit, logger, logDir, cfg)
+	if err != nil {
+		tb.Fatalf("NewManager: %v", err)
+	}
+	return m
+}

--- a/internal/agent/provider.go
+++ b/internal/agent/provider.go
@@ -86,6 +86,14 @@ func normalizeProvider(name string) string {
 	return providerByName(name).Name()
 }
 
+func normalizeProviderName(name string) (string, error) {
+	p, err := lookupProvider(name)
+	if err != nil {
+		return "", err
+	}
+	return p.Name(), nil
+}
+
 func normalizeModel(prov, model string) string {
 	return providerByName(prov).NormalizeModel(model)
 }

--- a/internal/agent/registry_roundtrip_test.go
+++ b/internal/agent/registry_roundtrip_test.go
@@ -11,10 +11,8 @@ import (
 
 func TestAgentRegistryRoundTripPreservesPersistedFields(t *testing.T) {
 	startedAt := time.Date(2026, 6, 28, 20, 40, 0, 0, time.UTC)
-	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
-	if err := m.EnableSurviveRestart(t.TempDir()); err != nil {
-		t.Fatalf("EnableSurviveRestart: %v", err)
-	}
+	regDir := t.TempDir()
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir(), ManagerConfig{SurviveRestartDir: regDir})
 
 	original := &Agent{
 		ID:                       "agent-1",

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -18,11 +18,11 @@ import (
 // newParseTestManager returns a Manager suitable for unit-testing
 // streamHeadlessOutput: discard logs, no emit, no log dir. The health gate
 // and guardrails are left zero so no turn/cost limits fire.
-func newParseTestManager(t *testing.T) *Manager {
+func newParseTestManager(t *testing.T, cfgs ...ManagerConfig) *Manager {
 	t.Helper()
 	logger := slog.New(slog.DiscardHandler)
 	emit := func(string, any) {}
-	return NewManager(context.Background(), emit, logger, t.TempDir())
+	return mustNewManager(t, context.Background(), emit, logger, t.TempDir(), cfgs...)
 }
 
 // lastResult returns the last result event from the agent's output buffer,
@@ -93,17 +93,18 @@ func TestParseCodexStreamEvent_TurnCompleted(t *testing.T) {
 }
 
 func TestProcessHeadlessLine_SuppressesCodexLimitSnapshotOutput(t *testing.T) {
-	m := newParseTestManager(t)
 	var snapshots []limits.Snapshot
 	var emitted []any
+	m := newParseTestManager(t, ManagerConfig{
+		LimitSink: func(snapshot limits.Snapshot) {
+			snapshots = append(snapshots, snapshot)
+		},
+	})
 	m.emit = func(event string, data any) {
 		if event == events.AgentOutput("limit1") {
 			emitted = append(emitted, data)
 		}
 	}
-	m.SetLimitSink(func(snapshot limits.Snapshot) {
-		snapshots = append(snapshots, snapshot)
-	})
 	a := &Agent{ID: "limit1", TaskID: "t", Mode: "headless", Provider: "codex", StartedAt: time.Now().UTC()}
 	lastEmit := time.Now().Add(-time.Minute)
 	line := []byte(`{"timestamp":"2026-06-19T12:40:08.052Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}},"rate_limits":{"limit_id":"codex","primary":{"used_percent":12,"window_minutes":300,"resets_at":1781877547},"plan_type":"pro"}}}`)
@@ -356,7 +357,7 @@ func TestStreamHeadlessOutput_OversizedLineLogsError(t *testing.T) {
 
 	var logBuf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	m := NewManager(context.Background(), func(string, any) {}, logger, t.TempDir())
+	m := mustNewManager(t, context.Background(), func(string, any) {}, logger, t.TempDir())
 
 	a := &Agent{ID: "t", Provider: "claude"}
 	m.streamHeadlessOutput(t.Context(), a, bytes.NewReader([]byte(input)), nil)
@@ -529,7 +530,7 @@ func TestGuardrails_MaxCostZeroMeansUnlimited(t *testing.T) {
 		}
 	}
 	logger := slog.New(slog.DiscardHandler)
-	m := NewManager(context.Background(), emit, logger, t.TempDir())
+	m := mustNewManager(t, context.Background(), emit, logger, t.TempDir())
 	m.SetGuardrails(Guardrails{MaxCostUSD: 0, MaxTurns: 0})
 
 	a := &Agent{ID: "t", Provider: "claude"}
@@ -564,7 +565,7 @@ func TestGuardrails_MaxTurnsZeroMeansUnlimited(t *testing.T) {
 		}
 	}
 	logger := slog.New(slog.DiscardHandler)
-	m := NewManager(context.Background(), emit, logger, t.TempDir())
+	m := mustNewManager(t, context.Background(), emit, logger, t.TempDir())
 	m.SetGuardrails(Guardrails{MaxTurns: 0})
 
 	a := &Agent{ID: "t", Provider: "claude"}
@@ -607,7 +608,7 @@ func TestGuardrails_TurnsAutoContinue_CostBelowCap(t *testing.T) {
 		}
 	}
 	logger := slog.New(slog.DiscardHandler)
-	m := NewManager(context.Background(), emit, logger, t.TempDir())
+	m := mustNewManager(t, context.Background(), emit, logger, t.TempDir())
 	// Cost cap set, but agent has spent $0 — well below 80% of $10.
 	m.SetGuardrails(Guardrails{MaxCostUSD: 10.0, MaxTurns: 3})
 
@@ -659,7 +660,7 @@ func TestGuardrails_TurnsBlocks_CostNearCap(t *testing.T) {
 		}
 	}
 	logger := slog.New(slog.DiscardHandler)
-	m := NewManager(context.Background(), emit, logger, t.TempDir())
+	m := mustNewManager(t, context.Background(), emit, logger, t.TempDir())
 	// Cost cap $10, agent already spent $9 — above 80% threshold.
 	m.SetGuardrails(Guardrails{MaxCostUSD: 10.0, MaxTurns: 3})
 
@@ -712,7 +713,7 @@ func TestGuardrails_SetMidRunVisibleToStream(t *testing.T) {
 		}
 	}
 	logger := slog.New(slog.DiscardHandler)
-	m := NewManager(context.Background(), emit, logger, t.TempDir())
+	m := mustNewManager(t, context.Background(), emit, logger, t.TempDir())
 	managerRef = m
 	// Start unlimited so result #1 doesn't escalate.
 	m.SetGuardrails(Guardrails{MaxCostUSD: 0})
@@ -837,7 +838,7 @@ func TestGuardrails_PerAgentOverrideWins(t *testing.T) {
 		}
 	}
 	logger := slog.New(slog.DiscardHandler)
-	m := NewManager(context.Background(), emit, logger, t.TempDir())
+	m := mustNewManager(t, context.Background(), emit, logger, t.TempDir())
 	m.SetGuardrails(Guardrails{MaxTurns: 5})
 
 	a := &Agent{ID: "t", Provider: "claude", MaxTurns: 20}
@@ -870,7 +871,7 @@ func TestGuardrails_PerAgentOverrideLower(t *testing.T) {
 		}
 	}
 	logger := slog.New(slog.DiscardHandler)
-	m := NewManager(context.Background(), emit, logger, t.TempDir())
+	m := mustNewManager(t, context.Background(), emit, logger, t.TempDir())
 	// MaxCostUSD set; agent cost seeded above 80% threshold so auto-continue is suppressed.
 	m.SetGuardrails(Guardrails{MaxCostUSD: 10.0, MaxTurns: 20})
 

--- a/internal/agent/survive_convo_test.go
+++ b/internal/agent/survive_convo_test.go
@@ -40,7 +40,7 @@ func TestWillDetach(t *testing.T) {
 // stream-json from a pipe, not a regular file, so one-shot survival must
 // feed the prompt via argv, not stdin.
 func TestBuildOneShotConvoArgs(t *testing.T) {
-	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
 	a := &Agent{ID: "x", Provider: "claude", Model: "sonnet"}
 	args := m.buildOneShotConvoArgs(a, RunConfig{Prompt: "do the thing", RequirePermissions: false})
 
@@ -97,10 +97,7 @@ func TestReattachCodexConvo_RecreatesIdleAgent(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 
-	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir)
-	if err := m.EnableSurviveRestart(regDir); err != nil {
-		t.Fatalf("EnableSurviveRestart: %v", err)
-	}
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir, ManagerConfig{SurviveRestartDir: regDir})
 	// Codex record: PID 0 (no live process between turns).
 	rec := Record{ID: "cx9", TaskID: "t-cx", Mode: "interactive", Provider: "codex", PID: 0, LogPath: logPath, SessionID: "cx-9", StartedAt: time.Now().UTC()}
 	if err := m.reg.Save(rec); err != nil {
@@ -145,10 +142,7 @@ func TestReattachCodexConvo_RecreatesIdleAgent(t *testing.T) {
 }
 
 func TestSaveRegistry_PreservesOneShot(t *testing.T) {
-	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
-	if err := m.EnableSurviveRestart(t.TempDir()); err != nil {
-		t.Fatalf("EnableSurviveRestart: %v", err)
-	}
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir(), ManagerConfig{SurviveRestartDir: t.TempDir()})
 	m.saveRegistry(&Agent{
 		ID:        "cx-one",
 		TaskID:    "t-cx",
@@ -186,15 +180,14 @@ func TestReattachCodexConvo_OneShotNoResultFinalizes(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 
-	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir)
-	if err := m.EnableSurviveRestart(regDir); err != nil {
-		t.Fatalf("EnableSurviveRestart: %v", err)
-	}
 	var completed atomic.Bool
 	var failed atomic.Bool
-	m.SetOnComplete(func(a *Agent) {
-		completed.Store(true)
-		failed.Store(a.GetExitErr() != nil)
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir, ManagerConfig{
+		SurviveRestartDir: regDir,
+		OnComplete: func(a *Agent) {
+			completed.Store(true)
+			failed.Store(a.GetExitErr() != nil)
+		},
 	})
 
 	rec := Record{
@@ -235,11 +228,10 @@ func TestReattachCodexConvo_SkipsDeletedTask(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 
-	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir)
-	if err := m.EnableSurviveRestart(regDir); err != nil {
-		t.Fatalf("EnableSurviveRestart: %v", err)
-	}
-	m.SetTaskExists(func(string) bool { return false }) // task is gone
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir, ManagerConfig{
+		SurviveRestartDir: regDir,
+		TaskExists:        func(string) bool { return false }, // task is gone
+	})
 
 	if err := m.reg.Save(Record{ID: "gone1", TaskID: "deleted", Mode: "interactive", Provider: "codex", LogPath: logPath, StartedAt: time.Now().UTC()}); err != nil {
 		t.Fatalf("save: %v", err)
@@ -316,10 +308,7 @@ func TestRehydrateConvoFromLog(t *testing.T) {
 // non-detached (one-shot/legacy) interactive agent must not, while still
 // capturing the session id.
 func TestProcessConvoLine_RegistryGatedByDetached(t *testing.T) {
-	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
-	if err := m.EnableSurviveRestart(t.TempDir()); err != nil {
-		t.Fatalf("EnableSurviveRestart: %v", err)
-	}
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir(), ManagerConfig{SurviveRestartDir: t.TempDir()})
 	st := &convoEmitState{}
 
 	// Non-detached one-shot: session captured, NO registry record.
@@ -399,12 +388,11 @@ func TestReattachInteractive_OneShotTailOnly(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 
-	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir)
-	if err := m.EnableSurviveRestart(regDir); err != nil {
-		t.Fatalf("EnableSurviveRestart: %v", err)
-	}
 	var completed atomic.Bool
-	m.SetOnComplete(func(*Agent) { completed.Store(true) })
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir, ManagerConfig{
+		SurviveRestartDir: regDir,
+		OnComplete:        func(*Agent) { completed.Store(true) },
+	})
 
 	result := `{"type":"result","result":"done","session_id":"sess-os","total_cost_usd":0.1}`
 	cmd := exec.Command("sh", "-c", fmt.Sprintf("sleep 0.3; printf '%%s\\n' '%s' >> %q", result, logPath))
@@ -464,12 +452,11 @@ func TestReattachInteractive_ReattachesLiveAgent(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 
-	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir)
-	if err := m.EnableSurviveRestart(regDir); err != nil {
-		t.Fatalf("EnableSurviveRestart: %v", err)
-	}
 	var completed atomic.Bool
-	m.SetOnComplete(func(*Agent) { completed.Store(true) })
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir, ManagerConfig{
+		SurviveRestartDir: regDir,
+		OnComplete:        func(*Agent) { completed.Store(true) },
+	})
 
 	// FIFO must exist for the reopen to succeed.
 	fifoPath := m.reg.fifoPath("ic1")

--- a/internal/agent/survive_restart_test.go
+++ b/internal/agent/survive_restart_test.go
@@ -295,15 +295,14 @@ func TestReattachAll_ReattachesLiveHeadlessAgent(t *testing.T) {
 		t.Fatalf("seed log: %v", err)
 	}
 
-	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir)
-	if err := m.EnableSurviveRestart(regDir); err != nil {
-		t.Fatalf("EnableSurviveRestart: %v", err)
-	}
 	var completed atomic.Bool
 	var completedID atomic.Value
-	m.SetOnComplete(func(ag *Agent) {
-		completedID.Store(ag.ID)
-		completed.Store(true)
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir, ManagerConfig{
+		SurviveRestartDir: regDir,
+		OnComplete: func(ag *Agent) {
+			completedID.Store(ag.ID)
+			completed.Store(true)
+		},
 	})
 
 	// Live helper: after a short delay append a terminal result, then exit.
@@ -377,10 +376,7 @@ func TestReattachAll_ReattachesLiveHeadlessAgent(t *testing.T) {
 // TestReattachAll_DropsDeadRecords verifies a record whose process is gone
 // is deleted and not reattached.
 func TestReattachAll_DropsDeadRecords(t *testing.T) {
-	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
-	if err := m.EnableSurviveRestart(t.TempDir()); err != nil {
-		t.Fatalf("EnableSurviveRestart: %v", err)
-	}
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir(), ManagerConfig{SurviveRestartDir: t.TempDir()})
 	// PID 0 is never alive.
 	if err := m.reg.Save(Record{ID: "dead1", Mode: "headless", Provider: "claude", PID: 0}); err != nil {
 		t.Fatalf("save: %v", err)
@@ -398,7 +394,7 @@ func TestReattachAll_DropsDeadRecords(t *testing.T) {
 // was intentionally stopped, but survives (exited=false) on a plain app
 // shutdown.
 func TestTailHeadlessFile_StopVsShutdown(t *testing.T) {
-	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
 	logPath := filepath.Join(t.TempDir(), "tail.ndjson")
 	if err := os.WriteFile(logPath, nil, 0o644); err != nil {
 		t.Fatalf("seed: %v", err)
@@ -439,7 +435,7 @@ func TestTailHeadlessFile_StopVsShutdown(t *testing.T) {
 // returns the byte offset after the last COMPLETE line, not raw bytes read
 // — so a resume never skips the start of a still-incomplete trailing line.
 func TestTailHeadlessFile_EndOffsetExcludesPartialLine(t *testing.T) {
-	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
 	logPath := filepath.Join(t.TempDir(), "tail.ndjson")
 	complete := `{"type":"assistant","message":{"content":[{"type":"text","text":"x"}]}}` + "\n"
 	partial := `{"type":"result","result":"in-flight` // no newline yet
@@ -474,12 +470,11 @@ func TestReattachAll_RecoversCompletedDuringDowntime(t *testing.T) {
 		t.Fatalf("write log: %v", err)
 	}
 
-	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir)
-	if err := m.EnableSurviveRestart(t.TempDir()); err != nil {
-		t.Fatalf("EnableSurviveRestart: %v", err)
-	}
 	var completedID atomic.Value
-	m.SetOnComplete(func(ag *Agent) { completedID.Store(ag.ID) })
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir, ManagerConfig{
+		SurviveRestartDir: t.TempDir(),
+		OnComplete:        func(ag *Agent) { completedID.Store(ag.ID) },
+	})
 
 	// PID 0 -> process gone; log shows a terminal result.
 	if err := m.reg.Save(Record{ID: "comp1", TaskID: "t", Mode: "headless", Provider: "claude", PID: 0, LogPath: logPath}); err != nil {
@@ -503,10 +498,7 @@ func TestReattachAll_RecoversCompletedDuringDowntime(t *testing.T) {
 // otherwise a mid-run crash leaves no session to resume.
 func TestProcessHeadlessLine_CapturesSessionOnInit(t *testing.T) {
 	regDir := t.TempDir()
-	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
-	if err := m.EnableSurviveRestart(regDir); err != nil {
-		t.Fatalf("EnableSurviveRestart: %v", err)
-	}
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir(), ManagerConfig{SurviveRestartDir: regDir})
 	a := &Agent{ID: "cap1", TaskID: "t", Mode: "headless", Provider: "claude", StartedAt: time.Now().UTC()}
 	var lastEmit time.Time
 
@@ -540,16 +532,15 @@ func TestReattachAll_BridgesDeadSessionForResume(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 
-	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir)
-	if err := m.EnableSurviveRestart(t.TempDir()); err != nil {
-		t.Fatalf("EnableSurviveRestart: %v", err)
-	}
 	var gotTask, gotAgent, gotSession atomic.Value
-	m.SetSessionSink(func(taskID, agentID, sessionID string) error {
-		gotTask.Store(taskID)
-		gotAgent.Store(agentID)
-		gotSession.Store(sessionID)
-		return nil
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir, ManagerConfig{
+		SurviveRestartDir: t.TempDir(),
+		SessionSink: func(taskID, agentID, sessionID string) error {
+			gotTask.Store(taskID)
+			gotAgent.Store(agentID)
+			gotSession.Store(sessionID)
+			return nil
+		},
 	})
 
 	// Dead process (PID 0), session captured in the registry record.
@@ -586,11 +577,10 @@ func TestReattachAll_RetainsRecordWhenBridgeFails(t *testing.T) {
 	if err := os.WriteFile(logPath, []byte(`{"type":"assistant","message":{"content":[{"type":"text","text":"x"}]}}`+"\n"), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir)
-	if err := m.EnableSurviveRestart(t.TempDir()); err != nil {
-		t.Fatalf("EnableSurviveRestart: %v", err)
-	}
-	m.SetSessionSink(func(_, _, _ string) error { return fmt.Errorf("task store down") })
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir, ManagerConfig{
+		SurviveRestartDir: t.TempDir(),
+		SessionSink:       func(_, _, _ string) error { return fmt.Errorf("task store down") },
+	})
 
 	if err := m.reg.Save(Record{ID: "crash2", TaskID: "t", Mode: "headless", Provider: "claude", PID: 0, LogPath: logPath, SessionID: "s"}); err != nil {
 		t.Fatalf("save: %v", err)
@@ -606,7 +596,7 @@ func TestReattachAll_RetainsRecordWhenBridgeFails(t *testing.T) {
 // TestShutdownWithGrace_LeavesDetachedAgents verifies a detached agent is
 // neither cancelled nor waited on, while a normal agent is cancelled.
 func TestShutdownWithGrace_LeavesDetachedAgents(t *testing.T) {
-	m := NewManager(context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
 
 	var normalCancelled atomic.Bool
 	normal := &Agent{ID: "n1", Mode: "headless", done: make(chan struct{}), cancel: func() { normalCancelled.Store(true) }}

--- a/internal/recovery/agent_manager_test_helpers_test.go
+++ b/internal/recovery/agent_manager_test_helpers_test.go
@@ -1,0 +1,22 @@
+package recovery_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/agent"
+)
+
+func newTestAgentManager(tb testing.TB, ctx context.Context, emit agent.EmitFunc, logger *slog.Logger, logDir string, cfgs ...agent.ManagerConfig) *agent.Manager {
+	tb.Helper()
+	cfg := agent.ManagerConfig{}
+	if len(cfgs) > 0 {
+		cfg = cfgs[0]
+	}
+	m, err := agent.NewManager(ctx, emit, logger, logDir, cfg)
+	if err != nil {
+		tb.Fatalf("NewManager: %v", err)
+	}
+	return m
+}

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -54,7 +54,7 @@ func TestRunStartupCleanupEmpty(t *testing.T) {
 	tasks := task.NewManager(store, nil)
 
 	logger := discardLogger()
-	agents := agent.NewManager(t.Context(), func(string, any) {}, logger, t.TempDir())
+	agents := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
 	wm := worktree.New(worktree.Config{
 		WorktreesDir: t.TempDir(),
 		Tasks:        tasks,
@@ -91,7 +91,7 @@ func TestRestartStaleSkipsRecentRun(t *testing.T) {
 	}
 	tasks := task.NewManager(store, nil)
 	logger := discardLogger()
-	agents := agent.NewManager(ctx, func(string, any) {}, logger, t.TempDir())
+	agents := newTestAgentManager(t, ctx, func(string, any) {}, logger, t.TempDir())
 	wm := worktree.New(worktree.Config{
 		WorktreesDir: t.TempDir(),
 		Tasks:        tasks,
@@ -155,7 +155,7 @@ func TestRestartStaleSkipsRateLimitedProvider(t *testing.T) {
 	}
 	tasks := task.NewManager(store, nil)
 	logger := discardLogger()
-	agents := agent.NewManager(ctx, func(string, any) {}, logger, t.TempDir())
+	agents := newTestAgentManager(t, ctx, func(string, any) {}, logger, t.TempDir())
 	agents.SetHealthGate(fakeGate{rateLimited: true}) // provider rate-limited
 	wm := worktree.New(worktree.Config{
 		WorktreesDir: t.TempDir(),
@@ -220,7 +220,7 @@ func TestRestartStaleSteerBypassesRecentRunDebounce(t *testing.T) {
 	}
 	tasks := task.NewManager(store, nil)
 	logger := discardLogger()
-	agents := agent.NewManager(ctx, func(string, any) {}, logger, t.TempDir())
+	agents := newTestAgentManager(t, ctx, func(string, any) {}, logger, t.TempDir())
 	wm := worktree.New(worktree.Config{
 		WorktreesDir: t.TempDir(),
 		Tasks:        tasks,
@@ -285,7 +285,7 @@ func TestRestartStaleInteractiveOneShotRestartsAsOneShot(t *testing.T) {
 	}
 	tasks := task.NewManager(store, nil)
 	logger := discardLogger()
-	agents := agent.NewManager(ctx, func(string, any) {}, logger, t.TempDir())
+	agents := newTestAgentManager(t, ctx, func(string, any) {}, logger, t.TempDir())
 	wm := worktree.New(worktree.Config{
 		WorktreesDir: t.TempDir(),
 		Tasks:        tasks,
@@ -368,7 +368,7 @@ func TestRestartStalePRFixWorkflowRevertsToInReview(t *testing.T) {
 	}
 	tasks := task.NewManager(store, nil)
 	logger := discardLogger()
-	agents := agent.NewManager(ctx, func(string, any) {}, logger, t.TempDir())
+	agents := newTestAgentManager(t, ctx, func(string, any) {}, logger, t.TempDir())
 	wm := worktree.New(worktree.Config{
 		WorktreesDir: t.TempDir(),
 		Tasks:        tasks,

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -74,7 +74,7 @@ type AgentCompletionHandler struct {
 	prTracker      *github.IssueTracker
 }
 
-// OnComplete is the callback installed via agents.SetOnComplete. Called
+// OnComplete is called by the manager's construction-time completion callback.
 // once per terminal agent state transition.
 func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 	var resultContent string

--- a/internal/sybra/agent_manager_test_helpers_test.go
+++ b/internal/sybra/agent_manager_test_helpers_test.go
@@ -1,0 +1,22 @@
+package sybra
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/agent"
+)
+
+func newTestAgentManager(tb testing.TB, ctx context.Context, emit agent.EmitFunc, logger *slog.Logger, logDir string, cfgs ...agent.ManagerConfig) *agent.Manager {
+	tb.Helper()
+	cfg := agent.ManagerConfig{}
+	if len(cfgs) > 0 {
+		cfg = cfgs[0]
+	}
+	m, err := agent.NewManager(ctx, emit, logger, logDir, cfg)
+	if err != nil {
+		tb.Fatalf("NewManager: %v", err)
+	}
+	return m
+}

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -3,7 +3,7 @@ package sybra
 // Dependency graph (startup order):
 //
 //	config → audit/stats → task.Store → project.Store → loopagent.Store
-//	→ emit/bgops → task.Manager → agent.Manager → providerHealth
+//	→ emit/bgops → task.Manager → limits/approval → agent.Manager → providerHealth
 //	→ worktrees → sandboxes → agentOrch → reviewer → workflowEngine
 //	→ wireServices → [LifecycleManager: StartManagers → StartPollers → StartWatchers]
 
@@ -262,9 +262,10 @@ func (a *App) Startup(ctx context.Context) error {
 	a.initArtifacts()
 	a.notifier = notification.New(emit)
 	a.notifier.SetDesktop(a.cfg.Notification.Desktop)
-	a.agents = agent.NewManager(ctx, emit, a.logger, a.logDir)
-	a.agents.SetDefaultProvider(a.cfg.Agent.Provider)
 	a.initLimits()
+	if err := a.initAgentManager(ctx, emit); err != nil {
+		return err
+	}
 	a.initProviderHealth(ctx, emit)
 
 	a.prTracker = github.NewIssueTracker(30 * time.Minute)
@@ -286,7 +287,6 @@ func (a *App) Startup(ctx context.Context) error {
 	a.initWorkflowEngine()
 
 	a.initAgentConfig()
-	a.initApprovalServer(emit)
 
 	a.initLoopScheduler(ctx, emit)
 	a.initFileWatcher(ctx, emit)

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -3,6 +3,7 @@ package sybra
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -172,12 +173,6 @@ func (a *App) initLimits() {
 	}
 	a.limits = limitStore
 	policy := a.limitPolicy()
-	a.agents.SetLimitGate(limitStore, policy)
-	a.agents.SetLimitSink(func(snapshot limits.Snapshot) {
-		if err := limitStore.UpdateSnapshot(snapshot); err != nil {
-			a.logger.Warn("limits.snapshot", "provider", snapshot.Provider, "err", err)
-		}
-	})
 	if policy.Enabled {
 		cutoff := time.Now().AddDate(0, 0, -a.cfg.Providers.Limits.BackfillDays)
 		backfillCtx := a.ctx
@@ -199,6 +194,92 @@ func (a *App) initLimits() {
 			a.startLiveLimitPolling(a.ctx, limitStore, policy)
 		}
 	}
+}
+
+func (a *App) agentManagerConfig(approvalAddr string) agent.ManagerConfig {
+	cfg := agent.ManagerConfig{
+		Runtime:      a.agentRuntimeConfig(a.cfg),
+		OnComplete:   a.onAgentComplete,
+		ApprovalAddr: approvalAddr,
+		SessionSink: func(taskID, agentID, sessionID string) error {
+			return a.tasks.UpdateRun(taskID, agentID, map[string]any{"session_id": sessionID})
+		},
+		TaskExists: a.taskExistsForAgent,
+		LimitSink:  a.recordLimitSnapshot,
+	}
+	if a.cfg.SurviveRestartEnabled() {
+		cfg.SurviveRestartDir = config.AgentsDir()
+	}
+	return cfg
+}
+
+func (a *App) initAgentManager(ctx context.Context, emit func(string, any)) error {
+	approvalServer, approvalAddr := a.startApprovalServer(emit)
+	agentCfg := a.agentManagerConfig(approvalAddr)
+	var err error
+	a.agents, err = agent.NewManager(ctx, emit, a.logger, a.logDir, agentCfg)
+	if err != nil && agentCfg.SurviveRestartDir != "" {
+		a.logger.Error("agent.survive-restart.init", "err", err)
+		agentCfg.SurviveRestartDir = ""
+		a.agents, err = agent.NewManager(ctx, emit, a.logger, a.logDir, agentCfg)
+	}
+	if err != nil {
+		a.logger.Error("agent.manager.init", "err", err)
+		return fmt.Errorf("agent manager: %w", err)
+	}
+	if agentCfg.SurviveRestartDir != "" {
+		a.logger.Info("agent.survive-restart.enabled", "dir", agentCfg.SurviveRestartDir)
+	}
+	if approvalServer != nil {
+		approvalServer.SetManager(a.agents)
+		a.agentSvc.approval = approvalServer
+	}
+	return nil
+}
+
+func (a *App) agentRuntimeConfig(cfg *config.Config) agent.ManagerRuntimeConfig {
+	policy := limits.DefaultPolicy()
+	if a.limits != nil {
+		policy = a.limitPolicy()
+	}
+	return agent.ManagerRuntimeConfig{
+		MaxConcurrent:   cfg.Agent.MaxConcurrent,
+		DefaultProvider: cfg.Agent.Provider,
+		BashTimeoutMs:   cfg.BashTimeoutMs(),
+		RetryWatchdog:   cfg.RetryWatchdog(),
+		FallbackModel:   cfg.Agent.FallbackModel,
+		LimitGate:       a.limits,
+		LimitPolicy:     policy,
+	}
+}
+
+func (a *App) onAgentComplete(ag *agent.Agent) {
+	if a.agentCompletion == nil {
+		a.logger.Warn("agent.complete.unwired", "id", ag.ID, "task_id", ag.TaskID)
+		return
+	}
+	a.agentCompletion.OnComplete(ag)
+}
+
+func (a *App) recordLimitSnapshot(snapshot limits.Snapshot) {
+	if a.limits == nil {
+		return
+	}
+	if err := a.limits.UpdateSnapshot(snapshot); err != nil {
+		a.logger.Warn("limits.snapshot", "provider", snapshot.Provider, "err", err)
+	}
+}
+
+func (a *App) taskExistsForAgent(taskID string) bool {
+	_, err := a.tasks.Get(taskID)
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+	a.logger.Warn("agent.task-exists.error", "task_id", taskID, "err", err)
+	return true
 }
 
 func (a *App) startLiveLimitPolling(ctx context.Context, limitStore *limits.Store, policy limits.Policy) {
@@ -522,43 +603,11 @@ func (a *App) initWorkflowEngine() {
 		a.workflowEngine.SetArtifactRecorder(&artifactRecorderAdapter{store: a.artifacts})
 	}
 	a.workflowEngine.SetContext(a.ctx)
-	// SetOnComplete moves to wireServices so the callback closure binds
+	// Workflow completion moves to wireServices so the callback closure binds
 	// to the AgentCompletionHandler constructed there.
 }
 
 func (a *App) initAgentConfig() {
-	a.agents.SetMaxConcurrent(a.cfg.Agent.MaxConcurrent)
-	a.agents.SetBashTimeoutMs(a.cfg.BashTimeoutMs())
-	a.agents.SetRetryWatchdog(a.cfg.RetryWatchdog())
-	a.agents.SetFallbackModel(a.cfg.Agent.FallbackModel)
-	if a.cfg.SurviveRestartEnabled() {
-		if err := a.agents.EnableSurviveRestart(config.AgentsDir()); err != nil {
-			a.logger.Error("agent.survive-restart.init", "err", err)
-		} else {
-			a.logger.Info("agent.survive-restart.enabled", "dir", config.AgentsDir())
-		}
-		// Bridge a crashed agent's session id into its AgentRun on
-		// dead-reattach so restart-stale recovery resumes via --resume. The
-		// error is returned (not swallowed) so the manager retains the
-		// registry record for retry and logs the failure at Warn.
-		a.agents.SetSessionSink(func(taskID, agentID, sessionID string) error {
-			return a.tasks.UpdateRun(taskID, agentID, map[string]any{"session_id": sessionID})
-		})
-		// Skip recreating a codex chat agent whose task was deleted. Only a
-		// definite not-exist returns false; a transient error fails open
-		// (retain the record) so a surviving chat is not lost to a flaky read.
-		a.agents.SetTaskExists(func(taskID string) bool {
-			_, err := a.tasks.Get(taskID)
-			if err == nil {
-				return true
-			}
-			if errors.Is(err, os.ErrNotExist) {
-				return false
-			}
-			a.logger.Warn("agent.task-exists.error", "task_id", taskID, "err", err)
-			return true
-		})
-	}
 	a.agents.SetGuardrails(agent.Guardrails{
 		MaxCostUSD:       a.cfg.Agent.MaxCostUSD,
 		MaxTurns:         a.cfg.Agent.MaxTurns,
@@ -567,15 +616,13 @@ func (a *App) initAgentConfig() {
 	})
 }
 
-func (a *App) initApprovalServer(emit func(string, any)) {
+func (a *App) startApprovalServer(emit func(string, any)) (srv *agent.ApprovalServer, addr string) {
 	srv, err := agent.NewApprovalServer(emit, a.logger, a.cfg.Agent.ApprovalPort)
 	if err != nil {
 		a.logger.Error("approval-server.init", "err", err)
-		return
+		return nil, ""
 	}
-	srv.SetManager(a.agents)
-	a.agents.SetApprovalAddr(srv.Addr())
-	a.agentSvc.approval = srv
+	return srv, srv.Addr()
 }
 
 func (a *App) logAudit(eventType, taskID, agentID string, data map[string]any) {

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -34,6 +34,11 @@ import (
 
 const liveLimitPollInterval = 15 * time.Minute
 
+type startupDegradedEvent struct {
+	Subsystem string `json:"subsystem"`
+	Reason    string `json:"reason"`
+}
+
 func (a *App) initBgops(emit func(string, any)) {
 	a.bgops = bgop.NewTracker(emit, filepath.Join(config.HomeDir(), "bgops.json"))
 	a.bgops.LoadFromDisk()
@@ -218,8 +223,12 @@ func (a *App) initAgentManager(ctx context.Context, emit func(string, any)) erro
 	agentCfg := a.agentManagerConfig(approvalAddr)
 	var err error
 	a.agents, err = agent.NewManager(ctx, emit, a.logger, a.logDir, agentCfg)
-	if err != nil && agentCfg.SurviveRestartDir != "" {
+	if err != nil && agentCfg.SurviveRestartDir != "" && errors.Is(err, agent.ErrSurvivalRegistry) {
 		a.logger.Error("agent.survive-restart.init", "err", err)
+		emit(events.StartupDegraded, startupDegradedEvent{
+			Subsystem: "agents",
+			Reason:    "agent survival registry failed to initialize; detached agents will not reconnect",
+		})
 		agentCfg.SurviveRestartDir = ""
 		a.agents, err = agent.NewManager(ctx, emit, a.logger, a.logDir, agentCfg)
 	}
@@ -549,15 +558,11 @@ func (a *App) initProviderHealth(ctx context.Context, emit func(string, any)) {
 // emitDegradedWarnings fires startup:degraded for any subsystem that failed
 // to initialize. Called after emit is configured so the frontend receives the events.
 func (a *App) emitDegradedWarnings(emit func(string, any)) {
-	type degraded struct {
-		Subsystem string `json:"subsystem"`
-		Reason    string `json:"reason"`
-	}
 	if a.audit == nil {
-		emit(events.StartupDegraded, degraded{"audit", "audit logger failed to initialize; audit trail unavailable"})
+		emit(events.StartupDegraded, startupDegradedEvent{"audit", "audit logger failed to initialize; audit trail unavailable"})
 	}
 	if a.stats == nil {
-		emit(events.StartupDegraded, degraded{"stats", "stats store failed to initialize; metrics unavailable"})
+		emit(events.StartupDegraded, startupDegradedEvent{"stats", "stats store failed to initialize; metrics unavailable"})
 	}
 }
 

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -233,6 +233,13 @@ func (a *App) initAgentManager(ctx context.Context, emit func(string, any)) erro
 		a.agents, err = agent.NewManager(ctx, emit, a.logger, a.logDir, agentCfg)
 	}
 	if err != nil {
+		if approvalServer != nil {
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if shutdownErr := approvalServer.Shutdown(shutdownCtx); shutdownErr != nil {
+				a.logger.Warn("approval-server.shutdown-after-agent-manager-init-failure", "err", shutdownErr)
+			}
+			cancel()
+		}
 		a.logger.Error("agent.manager.init", "err", err)
 		return fmt.Errorf("agent manager: %w", err)
 	}

--- a/internal/sybra/app_reviews_automerge_test.go
+++ b/internal/sybra/app_reviews_automerge_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
@@ -262,7 +261,7 @@ func TestResolveAddressedCopilotThreads(t *testing.T) {
 		{ID: "T6", AuthorLogin: "Copilot", IsOutdated: false, LastAuthorLogin: "Copilot"},
 	}
 	var resolvedIDs []string
-	agents := agent.NewManager(t.Context(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
+	agents := newTestAgentManager(t, t.Context(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
 	r := &ReviewHandler{
 		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
 		tasks:         tasks,

--- a/internal/sybra/app_reviews_outbound_test.go
+++ b/internal/sybra/app_reviews_outbound_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/workflow"
@@ -22,7 +21,7 @@ func newOutboundTestHandler(t *testing.T) (*ReviewHandler, *task.Manager) {
 	}
 	tasks := task.NewManager(store, nil)
 	logger := slog.New(slog.DiscardHandler)
-	agents := agent.NewManager(t.Context(), func(string, any) {}, logger, t.TempDir())
+	agents := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
 	r := &ReviewHandler{
 		DomainHandler: DomainHandler{logger: logger},
 		tasks:         tasks,

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -592,7 +592,7 @@ func TestCancelResolvedPRFixWorkflows(t *testing.T) {
 	if err := workflow.SyncBuiltins(wfStore); err != nil {
 		t.Fatal(err)
 	}
-	agentMgr := agent.NewManager(t.Context(), func(string, any) {}, logger, t.TempDir())
+	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
 	engine := workflow.NewEngine(wfStore,
 		&taskAdapter{tasks: tasks},
 		&agentAdapter{agents: agentMgr, tasks: tasks},
@@ -1132,7 +1132,7 @@ func TestCloseFinishedReviewTasks(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			agentMgr := agent.NewManager(t.Context(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
+			agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
 
 			r := &ReviewHandler{
 				DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
@@ -1211,7 +1211,7 @@ func TestPollAndMonitorPRs_FetchErrorReconcile(t *testing.T) {
 			}
 
 			reconcileCalled := false
-			agentMgr := agent.NewManager(t.Context(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
+			agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
 			r := &ReviewHandler{
 				DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler), emit: func(string, any) {}},
 				tasks:         tasks,

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -42,7 +42,7 @@ func setupApp(t *testing.T) *App {
 	logger := discardLogger()
 	emit := func(string, any) {}
 	logDir := filepath.Join(os.TempDir(), "sybra-test-logs")
-	mgr := agent.NewManager(t.Context(), emit, logger, logDir)
+	mgr := newTestAgentManager(t, t.Context(), emit, logger, logDir)
 
 	wm := worktree.New(worktree.Config{
 		WorktreesDir: t.TempDir(),

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -1,10 +1,12 @@
 package sybra
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -12,6 +14,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/config"
+	eventnames "github.com/Automaat/sybra/internal/events"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 
@@ -59,6 +62,42 @@ func setupApp(t *testing.T) *App {
 		logger:    logger,
 		worktrees: wm,
 		agentOrch: agentOrch,
+	}
+}
+
+func TestInitAgentManagerEmitsDegradedWhenSurvivalDisabled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SYBRA_HOME", home)
+	if err := os.WriteFile(filepath.Join(home, "agents"), []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Agent.Provider = "claude"
+	a := &App{
+		cfg:      cfg,
+		logger:   discardLogger(),
+		logDir:   t.TempDir(),
+		agentSvc: &AgentService{},
+	}
+	var emitted []string
+	err := a.initAgentManager(t.Context(), func(event string, _ any) {
+		emitted = append(emitted, event)
+	})
+	if err != nil {
+		t.Fatalf("initAgentManager: %v", err)
+	}
+	if a.agentSvc.approval != nil {
+		t.Cleanup(func() { _ = a.agentSvc.approval.Shutdown(context.Background()) })
+	}
+	if a.agents == nil {
+		t.Fatal("manager was not initialized")
+	}
+	if a.agents.DefaultProvider() != "claude" {
+		t.Fatalf("DefaultProvider = %q, want claude", a.agents.DefaultProvider())
+	}
+	if !slices.Contains(emitted, eventnames.StartupDegraded) {
+		t.Fatalf("expected %s event, got %v", eventnames.StartupDegraded, emitted)
 	}
 }
 

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -2,7 +2,9 @@ package sybra
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -98,6 +100,39 @@ func TestInitAgentManagerEmitsDegradedWhenSurvivalDisabled(t *testing.T) {
 	}
 	if !slices.Contains(emitted, eventnames.StartupDegraded) {
 		t.Fatalf("expected %s event, got %v", eventnames.StartupDegraded, emitted)
+	}
+}
+
+func TestInitAgentManagerClosesApprovalServerOnFailure(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Agent.Provider = "unknown"
+	cfg.Agent.ApprovalPort = port
+	a := &App{
+		cfg:      cfg,
+		logger:   discardLogger(),
+		logDir:   t.TempDir(),
+		agentSvc: &AgentService{},
+	}
+
+	if err := a.initAgentManager(t.Context(), func(string, any) {}); err == nil {
+		t.Fatal("expected initAgentManager to fail")
+	}
+
+	rebound, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatalf("approval server still bound port %d: %v", port, err)
+	}
+	if err := rebound.Close(); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/sybra/e2e_bootstrap_test.go
+++ b/internal/sybra/e2e_bootstrap_test.go
@@ -155,8 +155,9 @@ func setupBootstrapE2E(t *testing.T, repoSetup, appSetup []string) *bootstrapE2E
 		t.Fatal(err)
 	}
 	logger := e2eLogger()
-	agentMgr := agent.NewManager(ctx, func(string, any) {}, logger, agentLogDir)
-	agentMgr.SetDefaultProvider("claude")
+	agentMgr := newTestAgentManager(t, ctx, func(string, any) {}, logger, agentLogDir, agent.ManagerConfig{
+		Runtime: agent.ManagerRuntimeConfig{DefaultProvider: "claude"},
+	})
 
 	wm := worktree.New(worktree.Config{
 		WorktreesDir: wtDir,

--- a/internal/sybra/e2e_stats_test.go
+++ b/internal/sybra/e2e_stats_test.go
@@ -91,8 +91,15 @@ func TestE2E_Stats_RecordedOnAgentComplete(t *testing.T) {
 			t.Cleanup(cancel)
 
 			logger := e2eLogger()
-			agentMgr := agent.NewManager(ctx, func(string, any) {}, logger, logDir)
-			agentMgr.SetDefaultProvider(tc.provider)
+			done := make(chan struct{})
+			var h *AgentCompletionHandler
+			agentMgr := newTestAgentManager(t, ctx, func(string, any) {}, logger, logDir, agent.ManagerConfig{
+				Runtime: agent.ManagerRuntimeConfig{DefaultProvider: tc.provider},
+				OnComplete: func(ag *agent.Agent) {
+					h.OnComplete(ag)
+					close(done)
+				},
+			})
 
 			wtDir := t.TempDir()
 			wm := worktree.New(worktree.Config{
@@ -101,17 +108,12 @@ func TestE2E_Stats_RecordedOnAgentComplete(t *testing.T) {
 				Logger:       logger,
 				AgentChecker: agentMgr.HasRunningAgentForTask,
 			})
-			h := &AgentCompletionHandler{
+			h = &AgentCompletionHandler{
 				DomainHandler: DomainHandler{logger: logger},
 				tasks:         taskMgr,
 				worktrees:     wm,
 				stats:         statsStore,
 			}
-			done := make(chan struct{})
-			agentMgr.SetOnComplete(func(ag *agent.Agent) {
-				h.OnComplete(ag)
-				close(done)
-			})
 
 			tk, err := taskMgr.Create("stats e2e", "", "headless")
 			if err != nil {

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -4750,7 +4750,9 @@ func TestE2E_StartWorkflowWithMalformedVars_NoPanic(t *testing.T) {
 func TestE2E_CrossDefaultEmptyProvider_ResolvesDeterministically(t *testing.T) {
 	env := setupE2EMultiProvider(t, "claude", []string{"success"})
 	writeWorkflowFixture(t, env, "test-cross-default", testCrossDefaultWorkflowYAML)
-	env.agents.UpdateRuntimeConfig(agent.ManagerRuntimeConfig{DefaultProvider: ""})
+	if err := env.agents.ReplaceRuntimeConfig(agent.ManagerRuntimeConfig{DefaultProvider: ""}); err != nil {
+		t.Fatal(err)
+	}
 
 	created, err := env.tasks.Create("cross default empty", "", "headless")
 	if err != nil {

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -99,6 +99,7 @@ type e2eEnv struct {
 	// gap between markAgentDone (which flips HasRunningAgentForTask to false)
 	// and HandleAgentComplete finishing its AdvanceStep/executeSteps chain.
 	pendingCompletions atomic.Int64
+	onAgentComplete    func(*agent.Agent)
 }
 
 // startWorkflow seeds the reserved _dir variable so that run_agent steps have
@@ -190,8 +191,16 @@ func setupE2EProvider(t *testing.T, provider, scenario string) *e2eEnv {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(logDir) })
 
-	agentMgr := agent.NewManager(ctx, func(string, any) {}, logger, logDir)
-	agentMgr.SetDefaultProvider(provider)
+	var env *e2eEnv
+	var engine *workflow.Engine
+	agentMgr := newTestAgentManager(t, ctx, func(string, any) {}, logger, logDir, agent.ManagerConfig{
+		Runtime: agent.ManagerRuntimeConfig{DefaultProvider: provider},
+		OnComplete: func(ag *agent.Agent) {
+			env.pendingCompletions.Add(1)
+			defer env.pendingCompletions.Add(-1)
+			env.onAgentComplete(ag)
+		},
+	})
 
 	wfDir, err := os.MkdirTemp("", "sybra-e2e-wf-*")
 	if err != nil {
@@ -226,7 +235,7 @@ func setupE2EProvider(t *testing.T, provider, scenario string) *e2eEnv {
 
 	ta := &taskAdapter{tasks: taskMgr}
 	aa := &agentAdapter{agents: agentMgr, agentOrch: agentOrch, tasks: taskMgr}
-	engine := workflow.NewEngine(wfStore, ta, aa, logger)
+	engine = workflow.NewEngine(wfStore, ta, aa, logger)
 	engine.SetWorktreeGetter(&worktreeGetterAdapter{tasks: taskMgr, mgr: wm})
 
 	// Pre-create a working directory so run_agent steps can satisfy the
@@ -237,7 +246,7 @@ func setupE2EProvider(t *testing.T, provider, scenario string) *e2eEnv {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(agentDir) })
 
-	env := &e2eEnv{
+	env = &e2eEnv{
 		tasks:        taskMgr,
 		agents:       agentMgr,
 		engine:       engine,
@@ -248,10 +257,7 @@ func setupE2EProvider(t *testing.T, provider, scenario string) *e2eEnv {
 		provider:     provider,
 		cancel:       cancel,
 	}
-
-	agentMgr.SetOnComplete(func(ag *agent.Agent) {
-		env.pendingCompletions.Add(1)
-		defer env.pendingCompletions.Add(-1)
+	env.onAgentComplete = func(ag *agent.Agent) {
 		var result string
 		var hasResult bool
 		output := ag.Output()
@@ -274,9 +280,9 @@ func setupE2EProvider(t *testing.T, provider, scenario string) *e2eEnv {
 			Success:  ag.GetExitErr() == nil,
 			Provider: ag.Provider,
 		})
-	})
+	}
 
-	// Mirror production cascade wiring (sybra/services.go: SetOnComplete →
+	// Mirror production cascade wiring (sybra/services.go →
 	// AgentCompletionHandler.OnWorkflowComplete) so tests that span multiple
 	// chained workflows (simple-task-plan → simple-task-implement →
 	// simple-task-review) advance through the cascade exactly like the
@@ -541,11 +547,7 @@ func TestE2E_HeadlessAgent_SignalKill_DoesNotAdvanceWorkflow(t *testing.T) {
 		worktrees:      worktree.New(worktree.Config{WorktreesDir: env.worktreesDir, Tasks: env.tasks, Logger: e2eLogger(), AgentChecker: env.agents.HasRunningAgentForTask}),
 		workflowEngine: env.engine,
 	}
-	env.agents.SetOnComplete(func(ag *agent.Agent) {
-		env.pendingCompletions.Add(1)
-		defer env.pendingCompletions.Add(-1)
-		h.OnComplete(ag)
-	})
+	env.onAgentComplete = h.OnComplete
 
 	created, err := env.tasks.Create("signal kill task", "", "headless")
 	if err != nil {
@@ -604,11 +606,7 @@ func TestE2E_HeadlessAgent_StopAgent_DoesNotAdvanceWorkflow(t *testing.T) {
 		worktrees:      worktree.New(worktree.Config{WorktreesDir: env.worktreesDir, Tasks: env.tasks, Logger: e2eLogger(), AgentChecker: env.agents.HasRunningAgentForTask}),
 		workflowEngine: env.engine,
 	}
-	env.agents.SetOnComplete(func(ag *agent.Agent) {
-		env.pendingCompletions.Add(1)
-		defer env.pendingCompletions.Add(-1)
-		h.OnComplete(ag)
-	})
+	env.onAgentComplete = h.OnComplete
 
 	created, err := env.tasks.Create("stop agent task", "", "headless")
 	if err != nil {
@@ -3151,8 +3149,25 @@ func rebuildEngineFromEnv(t *testing.T, env *e2eEnv) *workflow.Engine {
 	t.Cleanup(cancel)
 
 	logDir := t.TempDir()
-	agentMgr := agent.NewManager(ctx, func(string, any) {}, e2eLogger(), logDir)
-	agentMgr.SetDefaultProvider(env.provider)
+	var engine *workflow.Engine
+	agentMgr := newTestAgentManager(t, ctx, func(string, any) {}, e2eLogger(), logDir, agent.ManagerConfig{
+		Runtime: agent.ManagerRuntimeConfig{DefaultProvider: env.provider},
+		OnComplete: func(ag *agent.Agent) {
+			var result string
+			output := ag.Output()
+			for i := range output {
+				if output[i].Type == "result" {
+					result = output[i].Content
+				}
+			}
+			engine.HandleAgentComplete(ag.TaskID, workflow.AgentCompletion{
+				AgentID:  ag.ID,
+				Result:   result,
+				Success:  ag.GetExitErr() == nil,
+				Provider: ag.Provider,
+			})
+		},
+	})
 
 	wm := worktree.New(worktree.Config{
 		WorktreesDir: env.worktreesDir,
@@ -3164,25 +3179,10 @@ func rebuildEngineFromEnv(t *testing.T, env *e2eEnv) *workflow.Engine {
 
 	ta := &taskAdapter{tasks: taskMgr}
 	aa := &agentAdapter{agents: agentMgr, agentOrch: agentOrch, tasks: taskMgr}
-	engine := workflow.NewEngine(env.wfStore, ta, aa, e2eLogger())
+	engine = workflow.NewEngine(env.wfStore, ta, aa, e2eLogger())
 	engine.SetWorktreeGetter(&worktreeGetterAdapter{tasks: taskMgr, mgr: wm})
 	engine.SetPRLinker(nil)
 
-	agentMgr.SetOnComplete(func(ag *agent.Agent) {
-		var result string
-		output := ag.Output()
-		for i := range output {
-			if output[i].Type == "result" {
-				result = output[i].Content
-			}
-		}
-		engine.HandleAgentComplete(ag.TaskID, workflow.AgentCompletion{
-			AgentID:  ag.ID,
-			Result:   result,
-			Success:  ag.GetExitErr() == nil,
-			Provider: ag.Provider,
-		})
-	})
 	return engine
 }
 
@@ -4750,7 +4750,7 @@ func TestE2E_StartWorkflowWithMalformedVars_NoPanic(t *testing.T) {
 func TestE2E_CrossDefaultEmptyProvider_ResolvesDeterministically(t *testing.T) {
 	env := setupE2EMultiProvider(t, "claude", []string{"success"})
 	writeWorkflowFixture(t, env, "test-cross-default", testCrossDefaultWorkflowYAML)
-	env.agents.SetDefaultProvider("")
+	env.agents.UpdateRuntimeConfig(agent.ManagerRuntimeConfig{DefaultProvider: ""})
 
 	created, err := env.tasks.Create("cross default empty", "", "headless")
 	if err != nil {

--- a/internal/sybra/orchestrator_resume_test.go
+++ b/internal/sybra/orchestrator_resume_test.go
@@ -116,8 +116,9 @@ updated_at: 2025-01-01T00:00:00Z
 	logDir := filepath.Join(home, "logs")
 	_ = os.MkdirAll(logDir, 0o755)
 
-	agentMgr := agent.NewManager(t.Context(), func(string, any) {}, logger, logDir)
-	agentMgr.SetDefaultProvider("claude")
+	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, logDir, agent.ManagerConfig{
+		Runtime: agent.ManagerRuntimeConfig{DefaultProvider: "claude"},
+	})
 
 	wm := worktree.New(worktree.Config{
 		WorktreesDir: filepath.Join(home, "worktrees"),

--- a/internal/sybra/services.go
+++ b/internal/sybra/services.go
@@ -73,11 +73,10 @@ func (a *App) wireServices(emit func(string, any)) {
 	a.workflowSvc.store = a.workflowStore
 	a.browserSvc.open = a.openBrowser
 
-	// Subscribe handlers to manager callbacks last — by this point every
-	// dependency the handler reads is wired up, so the closures can't
-	// observe a partially-constructed App.
+	// Build completion handlers last — by this point every dependency they
+	// read is wired up, and the manager's construction-time callback delegates
+	// to a.agentCompletion once it is populated here.
 	a.agentCompletion = a.newAgentCompletionHandler(emit)
-	a.agents.SetOnComplete(a.agentCompletion.OnComplete)
 	if a.workflowEngine != nil {
 		a.workflowEngine.SetOnComplete(a.agentCompletion.OnWorkflowComplete)
 	}

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -80,7 +80,9 @@ func (s *ConfigService) UpdateSettings(settings AppSettings) error {
 	if err := s.validateSettings(settings); err != nil {
 		return err
 	}
-	s.applyFromConfig(settingsToConfig(s.cfg, settings))
+	if err := s.applyFromConfig(settingsToConfig(s.cfg, settings)); err != nil {
+		return err
+	}
 	return s.cfg.Save()
 }
 
@@ -128,7 +130,7 @@ func (s *ConfigService) validateSettings(settings AppSettings) error {
 // applyFromConfig assigns all hot-reloadable fields from next into s.cfg and
 // pushes the manager settings that are intentionally live. s.mu must be held by the caller.
 // This never writes to disk — callers that need persistence must call s.cfg.Save().
-func (s *ConfigService) applyFromConfig(next config.Config) {
+func (s *ConfigService) applyFromConfig(next config.Config) error {
 	s.cfg.Agent = next.Agent
 	s.cfg.Notification = next.Notification
 	s.cfg.Orchestrator = next.Orchestrator
@@ -149,8 +151,9 @@ func (s *ConfigService) applyFromConfig(next config.Config) {
 	s.cfg.Metrics = next.Metrics
 	s.cfg.ProjectTypes = next.ProjectTypes
 	s.notifier.SetDesktop(next.Notification.Desktop)
-	s.notifier.SetDesktop(next.Notification.Desktop)
-	s.refreshAgentRuntimeConfig(next)
+	if err := s.refreshAgentRuntimeConfig(next); err != nil {
+		return err
+	}
 	if s.agents != nil {
 		s.agents.SetGuardrails(agent.Guardrails{
 			MaxCostUSD:       next.Agent.MaxCostUSD,
@@ -165,13 +168,14 @@ func (s *ConfigService) applyFromConfig(next config.Config) {
 	if s.reloadHook != nil {
 		s.reloadHook()
 	}
+	return nil
 }
 
-func (s *ConfigService) refreshAgentRuntimeConfig(next config.Config) {
+func (s *ConfigService) refreshAgentRuntimeConfig(next config.Config) error {
 	if s.agents == nil {
-		return
+		return nil
 	}
-	s.agents.UpdateRuntimeConfig(s.managerRuntimeConfig(next))
+	return s.agents.ReplaceRuntimeConfig(s.managerRuntimeConfig(next))
 }
 
 func (s *ConfigService) managerRuntimeConfig(cfg config.Config) agent.ManagerRuntimeConfig {

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -126,7 +126,7 @@ func (s *ConfigService) validateSettings(settings AppSettings) error {
 }
 
 // applyFromConfig assigns all hot-reloadable fields from next into s.cfg and
-// calls the corresponding live setters. s.mu must be held by the caller.
+// pushes the manager settings that are intentionally live. s.mu must be held by the caller.
 // This never writes to disk — callers that need persistence must call s.cfg.Save().
 func (s *ConfigService) applyFromConfig(next config.Config) {
 	s.cfg.Agent = next.Agent
@@ -148,18 +148,17 @@ func (s *ConfigService) applyFromConfig(next config.Config) {
 	s.cfg.ABTesting = next.ABTesting
 	s.cfg.Metrics = next.Metrics
 	s.cfg.ProjectTypes = next.ProjectTypes
-
 	s.notifier.SetDesktop(next.Notification.Desktop)
-	s.agents.SetMaxConcurrent(next.Agent.MaxConcurrent)
-	s.agents.SetDefaultProvider(next.Agent.Provider)
-	s.agents.SetBashTimeoutMs(next.BashTimeoutMs())
-	s.agents.SetRetryWatchdog(next.RetryWatchdog())
-	s.agents.SetFallbackModel(next.Agent.FallbackModel)
-	s.agents.SetGuardrails(agent.Guardrails{
-		MaxCostUSD: next.Agent.MaxCostUSD,
-		MaxTurns:   next.Agent.MaxTurns,
-	})
-	s.refreshLimitGate()
+	s.notifier.SetDesktop(next.Notification.Desktop)
+	s.refreshAgentRuntimeConfig(next)
+	if s.agents != nil {
+		s.agents.SetGuardrails(agent.Guardrails{
+			MaxCostUSD:       next.Agent.MaxCostUSD,
+			MaxTurns:         next.Agent.MaxTurns,
+			TurnCostFraction: next.Agent.TurnCostFraction,
+			TurnMultiplier:   next.Agent.TurnMultiplier,
+		})
+	}
 	if s.logLevel != nil {
 		s.logLevel.Set(s.cfg.Logging.SlogLevel())
 	}
@@ -168,15 +167,27 @@ func (s *ConfigService) applyFromConfig(next config.Config) {
 	}
 }
 
-func (s *ConfigService) refreshLimitGate() {
-	if s.agents == nil || s.limits == nil {
+func (s *ConfigService) refreshAgentRuntimeConfig(next config.Config) {
+	if s.agents == nil {
 		return
 	}
+	s.agents.UpdateRuntimeConfig(s.managerRuntimeConfig(next))
+}
+
+func (s *ConfigService) managerRuntimeConfig(cfg config.Config) agent.ManagerRuntimeConfig {
 	policy := limits.DefaultPolicy()
 	if s.policy != nil {
 		policy = s.policy()
 	}
-	s.agents.SetLimitGate(s.limits, policy)
+	return agent.ManagerRuntimeConfig{
+		MaxConcurrent:   cfg.Agent.MaxConcurrent,
+		DefaultProvider: cfg.Agent.Provider,
+		BashTimeoutMs:   cfg.BashTimeoutMs(),
+		RetryWatchdog:   cfg.RetryWatchdog(),
+		FallbackModel:   cfg.Agent.FallbackModel,
+		LimitGate:       s.limits,
+		LimitPolicy:     policy,
+	}
 }
 
 // settingsToConfig converts AppSettings into a config.Config overlay, filling

--- a/internal/sybra/svc_config_reload.go
+++ b/internal/sybra/svc_config_reload.go
@@ -52,7 +52,9 @@ func (s *ConfigService) ReloadFromDisk() (changedHot []string, err error) {
 	s.cfg.Metrics = next.Metrics
 	s.cfg.AutoUpdate = next.AutoUpdate
 	s.cfg.ProjectTypes = next.ProjectTypes
-	s.refreshAgentRuntimeConfig(*next)
+	if err := s.refreshAgentRuntimeConfig(*next); err != nil {
+		return nil, err
+	}
 
 	// Selectively call live setters only for fields that actually changed.
 	// This avoids restarting Todoist or other services on every config write

--- a/internal/sybra/svc_config_reload.go
+++ b/internal/sybra/svc_config_reload.go
@@ -52,7 +52,7 @@ func (s *ConfigService) ReloadFromDisk() (changedHot []string, err error) {
 	s.cfg.Metrics = next.Metrics
 	s.cfg.AutoUpdate = next.AutoUpdate
 	s.cfg.ProjectTypes = next.ProjectTypes
-	s.refreshLimitGate()
+	s.refreshAgentRuntimeConfig(*next)
 
 	// Selectively call live setters only for fields that actually changed.
 	// This avoids restarting Todoist or other services on every config write
@@ -61,10 +61,6 @@ func (s *ConfigService) ReloadFromDisk() (changedHot []string, err error) {
 		switch k {
 		case "notification.desktop":
 			s.notifier.SetDesktop(next.Notification.Desktop)
-		case "agent.max_concurrent":
-			s.agents.SetMaxConcurrent(next.Agent.MaxConcurrent)
-		case "agent.provider":
-			s.agents.SetDefaultProvider(next.Agent.Provider)
 		case "logging.level":
 			if s.logLevel != nil {
 				s.logLevel.Set(next.Logging.SlogLevel())
@@ -85,16 +81,6 @@ func (s *ConfigService) ReloadFromDisk() (changedHot []string, err error) {
 			TurnMultiplier:   next.Agent.TurnMultiplier,
 		})
 	}
-	if slices.Contains(hot, "agent.bash_timeout_seconds") {
-		s.agents.SetBashTimeoutMs(next.BashTimeoutMs())
-	}
-	if slices.Contains(hot, "agent.retry_watchdog") {
-		s.agents.SetRetryWatchdog(next.RetryWatchdog())
-	}
-	if slices.Contains(hot, "agent.fallback_model") {
-		s.agents.SetFallbackModel(next.Agent.FallbackModel)
-	}
-
 	if s.logger != nil {
 		for _, k := range restart {
 			s.logger.Warn("config.reload.restart_required", "field", k)

--- a/internal/sybra/svc_config_reload_test.go
+++ b/internal/sybra/svc_config_reload_test.go
@@ -313,7 +313,9 @@ func TestReloadFromDisk_RefreshesLimitPolicyForProviderChanges(t *testing.T) {
 		}
 		return p
 	}
-	svc.refreshAgentRuntimeConfig(*svc.cfg)
+	if err := svc.refreshAgentRuntimeConfig(*svc.cfg); err != nil {
+		t.Fatal(err)
+	}
 	if !svc.agents.LimitPolicy().ProviderEnabled[limits.ProviderCodex] {
 		t.Fatal("initial manager limit policy did not enable codex")
 	}

--- a/internal/sybra/svc_config_reload_test.go
+++ b/internal/sybra/svc_config_reload_test.go
@@ -47,9 +47,12 @@ func setupConfigSvc(t *testing.T) (svc *ConfigService, cfgPath string) {
 	emit := func(string, any) {}
 	logger := slog.New(slog.DiscardHandler)
 	logDir := filepath.Join(home, "logs")
-	mgr := agent.NewManager(context.Background(), emit, logger, logDir)
-	mgr.SetMaxConcurrent(cfg.Agent.MaxConcurrent)
-	mgr.SetDefaultProvider(cfg.Agent.Provider)
+	mgr := newTestAgentManager(t, context.Background(), emit, logger, logDir, agent.ManagerConfig{
+		Runtime: agent.ManagerRuntimeConfig{
+			MaxConcurrent:   cfg.Agent.MaxConcurrent,
+			DefaultProvider: cfg.Agent.Provider,
+		},
+	})
 	mgr.SetGuardrails(agent.Guardrails{MaxCostUSD: cfg.Agent.MaxCostUSD, MaxTurns: cfg.Agent.MaxTurns})
 
 	notifier := notification.New(emit)
@@ -226,9 +229,12 @@ func TestReloadFromDisk_RestartRequiredWarned(t *testing.T) {
 	logLevel := new(slog.LevelVar)
 	logLevel.Set(slog.LevelInfo)
 	logDir := filepath.Join(home, "logs")
-	mgr := agent.NewManager(context.Background(), emit, logger, logDir)
-	mgr.SetMaxConcurrent(cfg.Agent.MaxConcurrent)
-	mgr.SetDefaultProvider(cfg.Agent.Provider)
+	mgr := newTestAgentManager(t, context.Background(), emit, logger, logDir, agent.ManagerConfig{
+		Runtime: agent.ManagerRuntimeConfig{
+			MaxConcurrent:   cfg.Agent.MaxConcurrent,
+			DefaultProvider: cfg.Agent.Provider,
+		},
+	})
 	mgr.SetGuardrails(agent.Guardrails{MaxCostUSD: cfg.Agent.MaxCostUSD, MaxTurns: cfg.Agent.MaxTurns})
 	notifier := notification.New(emit)
 
@@ -307,7 +313,7 @@ func TestReloadFromDisk_RefreshesLimitPolicyForProviderChanges(t *testing.T) {
 		}
 		return p
 	}
-	svc.refreshLimitGate()
+	svc.refreshAgentRuntimeConfig(*svc.cfg)
 	if !svc.agents.LimitPolicy().ProviderEnabled[limits.ProviderCodex] {
 		t.Fatal("initial manager limit policy did not enable codex")
 	}

--- a/internal/sybra/svc_orchestrator_test.go
+++ b/internal/sybra/svc_orchestrator_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/Automaat/sybra/internal/agent"
 )
 
-func newOrchSvcForTest(t *testing.T) (*OrchestratorService, *agent.Manager) {
+func newOrchSvcForTest(t *testing.T, cfgs ...agent.ManagerConfig) (*OrchestratorService, *agent.Manager) {
 	t.Helper()
 	ctx := t.Context()
 	logger := slog.New(slog.DiscardHandler)
 	emitted := make(chan struct{}, 16)
 	emit := func(string, any) { emitted <- struct{}{} }
-	mgr := agent.NewManager(ctx, emit, logger, t.TempDir())
+	mgr := newTestAgentManager(t, ctx, emit, logger, t.TempDir(), cfgs...)
 	svc := &OrchestratorService{
 		agents: mgr,
 		logger: logger,
@@ -145,8 +145,7 @@ func TestOrchestratorService_IgnoreConcurrencyLimit(t *testing.T) {
 	t.Setenv("FAKE_CLAUDE_SCENARIO", "interactive_implement")
 	t.Setenv("SYBRA_HOME", t.TempDir())
 
-	svc, mgr := newOrchSvcForTest(t)
-	mgr.SetMaxConcurrent(1)
+	svc, mgr := newOrchSvcForTest(t, agent.ManagerConfig{Runtime: agent.ManagerRuntimeConfig{MaxConcurrent: 1}})
 	t.Cleanup(func() { _ = svc.StopOrchestrator() })
 
 	// Fill the single slot with a normal agent.

--- a/internal/sybra/svc_reviews_test.go
+++ b/internal/sybra/svc_reviews_test.go
@@ -89,8 +89,9 @@ updated_at: 2025-01-01T00:00:00Z
 	logDir := filepath.Join(home, "logs")
 	_ = os.MkdirAll(logDir, 0o755)
 
-	agentMgr := agent.NewManager(t.Context(), func(string, any) {}, logger, logDir)
-	agentMgr.SetDefaultProvider("claude")
+	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, logDir, agent.ManagerConfig{
+		Runtime: agent.ManagerRuntimeConfig{DefaultProvider: "claude"},
+	})
 
 	wm := worktree.New(worktree.Config{
 		WorktreesDir: filepath.Join(home, "worktrees"),


### PR DESCRIPTION
## Motivation

Closes https://github.com/Automaat/sybra/issues/1127

Agent managers should be born with a valid configuration instead of relying on post-construction mutation. This keeps tests and app wiring aligned around explicit dependencies.

## Implementation information

- Require manager configuration at construction time and preserve provider registry setup through that path.
- Update Sybra app/service initialization and config reload wiring to pass manager config directly.
- Refresh agent, recovery, and Sybra tests/helpers around the new constructor contract.