### PR TITLE
feat(evaluation): frame A/B experiment guardrails

### DIFF
--- a/frontend/src/lib/evaluation-interpretation.test.ts
+++ b/frontend/src/lib/evaluation-interpretation.test.ts
@@ -84,6 +84,7 @@ describe('interpretExperiment', () => {
 
     expect(result.verdict).toBe('risky')
     expect(result.guardrails.find((g) => g.key === 'ci-first-pass')?.status).toBe('breach')
+    expect(result.guardrails.find((g) => g.key === 'ci-first-pass')?.category).toBe('risk')
   })
 
   it('marks peer-relative outlier breaches as costly', () => {
@@ -93,6 +94,21 @@ describe('interpretExperiment', () => {
 
     expect(result.verdict).toBe('costly')
     expect(result.guardrails.find((g) => g.key === 'durationP90S')?.status).toBe('breach')
+    expect(result.guardrails.find((g) => g.key === 'durationP90S')?.category).toBe('cost')
+  })
+
+  it('assigns explicit categories to every guardrail', () => {
+    const result = interpretExperiment(row(), [peer()])
+
+    expect(result.guardrails.map((g) => [g.key, g.category])).toEqual([
+      ['ci-first-pass', 'risk'],
+      ['edited-merge', 'risk'],
+      ['rework', 'risk'],
+      ['revert', 'risk'],
+      ['durationP90S', 'cost'],
+      ['costPerLanded', 'cost'],
+      ['premiumRequestsPerLanded', 'cost'],
+    ])
   })
 
   it('marks rows as promising when no guardrail breaches', () => {

--- a/frontend/src/lib/evaluation-interpretation.test.ts
+++ b/frontend/src/lib/evaluation-interpretation.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest'
+import { ComparisonBreakdown } from '../../bindings/github.com/Automaat/sybra/internal/evaluation/models.js'
+import { interpretExperiment } from './evaluation-interpretation.js'
+
+function row(overrides: Partial<ComparisonBreakdown> = {}): ComparisonBreakdown {
+  return ComparisonBreakdown.createFrom({
+    key: 'exp-a:v1:implementation',
+    experimentId: 'exp-a',
+    variantId: 'v1',
+    role: 'implementation',
+    runs: 20,
+    landed: 10,
+    merged: 8,
+    mergeRate: 0.8,
+    mergedWithEditsRate: 0.1,
+    ciFirstPassRate: 0.9,
+    reworkRate: 0.1,
+    revertRate: 0,
+    durationP50S: 600,
+    durationP90S: 1_000,
+    totalCostUsd: 50,
+    costPerLanded: 5,
+    premiumRequests: 20,
+    premiumRequestsPerLanded: 2,
+    turnsPerLanded: 3,
+    toolsPerLanded: 10,
+    ...overrides,
+  })
+}
+
+function peer(overrides: Partial<ComparisonBreakdown> = {}): ComparisonBreakdown {
+  return row({
+    key: 'exp-a:v2:implementation',
+    variantId: 'v2',
+    durationP90S: 900,
+    costPerLanded: 5,
+    premiumRequestsPerLanded: 2,
+    ...overrides,
+  })
+}
+
+describe('interpretExperiment', () => {
+  it('marks low-sample rows as underpowered before other verdicts', () => {
+    const result = interpretExperiment(row({ insufficientData: true, landed: 0, ciFirstPassRate: 0.2 }), [peer()])
+
+    expect(result.verdict).toBe('underpowered')
+    expect(result.verdictLabel).toBe('Underpowered')
+  })
+
+  it('marks rows with no landed tasks as needing more data', () => {
+    const result = interpretExperiment(row({ landed: 0, qualityAttributionLimited: false }), [peer()])
+
+    expect(result.verdict).toBe('needs-more-data')
+    expect(result.verdictReason).toContain('No landed tasks')
+  })
+
+  it('marks limited quality attribution as needing more data', () => {
+    const result = interpretExperiment(row({ landed: 0, qualityAttributionLimited: true }), [peer()])
+
+    expect(result.verdict).toBe('needs-more-data')
+    expect(result.limitedSignals).toContain(
+      'Quality attribution is limited because this variant has runs but no landed tasks.',
+    )
+  })
+
+  it('calculates the primary metric as landed per run', () => {
+    const result = interpretExperiment(row({ runs: 25, landed: 5 }), [peer()])
+
+    expect(result.primaryLabel).toBe('Landed/run')
+    expect(result.primaryValue).toBe('20%')
+    expect(result.primaryDetail).toBe('5/25 landed')
+  })
+
+  it('normalizes zero runs without producing a misleading ratio', () => {
+    const result = interpretExperiment(row({ runs: 0, landed: 0 }), [peer()])
+
+    expect(result.primaryValue).toBe('—')
+    expect(result.primaryDetail).toBe('0/0 landed')
+    expect(result.verdict).toBe('needs-more-data')
+  })
+
+  it('marks reliability and quality guardrail breaches as risky', () => {
+    const result = interpretExperiment(row({ ciFirstPassRate: 0.59 }), [peer()])
+
+    expect(result.verdict).toBe('risky')
+    expect(result.guardrails.find((g) => g.key === 'ci-first-pass')?.status).toBe('breach')
+  })
+
+  it('marks peer-relative outlier breaches as costly', () => {
+    const result = interpretExperiment(row({ durationP90S: 1_500, costPerLanded: 5 }), [
+      peer({ durationP90S: 1_000, costPerLanded: 10, premiumRequestsPerLanded: 3 }),
+    ])
+
+    expect(result.verdict).toBe('costly')
+    expect(result.guardrails.find((g) => g.key === 'durationP90S')?.status).toBe('breach')
+  })
+
+  it('marks rows as promising when no guardrail breaches', () => {
+    const result = interpretExperiment(row(), [peer()])
+
+    expect(result.verdict).toBe('promising')
+    expect(result.guardrails.every((g) => g.status === 'ok' || g.status === 'limited')).toBe(true)
+  })
+
+  it('does not breach duration, cost, or premium without usable peers', () => {
+    const result = interpretExperiment(row({ durationP90S: 10_000, costPerLanded: 500 }), [])
+
+    expect(result.verdict).toBe('promising')
+    expect(result.guardrails.filter((g) => g.status === 'limited').map((g) => g.key)).toEqual([
+      'durationP90S',
+      'costPerLanded',
+      'premiumRequestsPerLanded',
+    ])
+    expect(result.limitedSignals).toContain('Duration p90 has no usable same-experiment peer baseline.')
+  })
+
+  it('ignores low-N peers and peers without positive values', () => {
+    const result = interpretExperiment(row({ durationP90S: 10_000, costPerLanded: 500 }), [
+      peer({ insufficientData: true, durationP90S: 1, costPerLanded: 1, premiumRequestsPerLanded: 1 }),
+      peer({
+        key: 'exp-a:v3:implementation',
+        variantId: 'v3',
+        durationP90S: 0,
+        costPerLanded: 0,
+        premiumRequestsPerLanded: 0,
+      }),
+    ])
+
+    expect(result.verdict).toBe('promising')
+    expect(result.guardrails.filter((g) => g.status === 'limited')).toHaveLength(3)
+  })
+
+  it('uses only same-experiment same-role positive peers for outlier medians', () => {
+    const result = interpretExperiment(row({ durationP90S: 1_600 }), [
+      peer({ key: 'exp-b:v2:implementation', experimentId: 'exp-b', durationP90S: 100 }),
+      peer({ key: 'exp-a:v3:review', variantId: 'v3', role: 'review', durationP90S: 100 }),
+      peer({ key: 'exp-a:v4:implementation', variantId: 'v4', durationP90S: 1_000 }),
+    ])
+
+    expect(result.verdict).toBe('costly')
+    expect(result.guardrails.find((g) => g.key === 'durationP90S')?.detail).toContain('1.60x')
+  })
+})

--- a/frontend/src/lib/evaluation-interpretation.ts
+++ b/frontend/src/lib/evaluation-interpretation.ts
@@ -1,0 +1,223 @@
+import type { ComparisonBreakdown } from '../../bindings/github.com/Automaat/sybra/internal/evaluation/models.js'
+
+export type ExperimentVerdict = 'underpowered' | 'needs-more-data' | 'risky' | 'costly' | 'promising'
+
+export type GuardrailStatus = 'ok' | 'watch' | 'breach' | 'limited'
+
+export interface GuardrailSignal {
+  key: string
+  label: string
+  status: GuardrailStatus
+  detail: string
+}
+
+export interface ExperimentInterpretation {
+  verdict: ExperimentVerdict
+  verdictLabel: string
+  verdictReason: string
+  primaryLabel: string
+  primaryValue: string
+  primaryDetail: string
+  guardrails: GuardrailSignal[]
+  limitedSignals: string[]
+}
+
+const verdictLabels: Record<ExperimentVerdict, string> = {
+  underpowered: 'Underpowered',
+  'needs-more-data': 'Needs more data',
+  risky: 'Risky',
+  costly: 'Costly',
+  promising: 'Promising',
+}
+
+interface PeerMetric {
+  key: 'durationP90S' | 'costPerLanded' | 'premiumRequestsPerLanded'
+  label: string
+  value: number | undefined
+  unit: string
+  format: (value: number) => string
+}
+
+export function interpretExperiment(
+  row: ComparisonBreakdown,
+  peers: ComparisonBreakdown[] = [],
+): ExperimentInterpretation {
+  const runs = finiteNonNegative(row.runs)
+  const landed = finiteNonNegative(row.landed)
+  const landedPerRun = runs > 0 ? landed / runs : undefined
+  const guardrails: GuardrailSignal[] = [
+    thresholdLow('ci-first-pass', 'CI first pass', finiteRate(row.ciFirstPassRate), 0.6, 0.8),
+    thresholdHigh('edited-merge', 'Edited merge rate', finiteRate(row.mergedWithEditsRate), 0.3, 0.15),
+    thresholdHigh('rework', 'Rework', finiteRate(row.reworkRate), 0.3, 0.15),
+    thresholdHigh('revert', 'Revert', finiteRate(row.revertRate), 0, 0),
+  ]
+  const limitedSignals: string[] = []
+
+  const peerMetrics: PeerMetric[] = [
+    {
+      key: 'durationP90S',
+      label: 'Duration p90',
+      value: finitePositive(row.durationP90S),
+      unit: 'peer median',
+      format: formatSeconds,
+    },
+    {
+      key: 'costPerLanded',
+      label: 'Cost per landed',
+      value: finitePositive(row.costPerLanded),
+      unit: 'peer median',
+      format: (value) => `$${value.toFixed(2)}`,
+    },
+    {
+      key: 'premiumRequestsPerLanded',
+      label: 'Premium requests',
+      value: finitePositive(row.premiumRequestsPerLanded),
+      unit: 'peer median',
+      format: (value) => `${value.toFixed(1)}/landed`,
+    },
+  ]
+
+  for (const metric of peerMetrics) {
+    const peerMedian = median(peerValues(row, peers, metric.key))
+    if (peerMedian === undefined) {
+      guardrails.push({
+        key: metric.key,
+        label: metric.label,
+        status: 'limited',
+        detail: `No usable same-experiment ${metric.unit}.`,
+      })
+      limitedSignals.push(`${metric.label} has no usable same-experiment peer baseline.`)
+      continue
+    }
+
+    const value = metric.value
+    if (value === undefined) {
+      guardrails.push({
+        key: metric.key,
+        label: metric.label,
+        status: 'limited',
+        detail: `No positive ${metric.label.toLowerCase()} value for this variant.`,
+      })
+      limitedSignals.push(`${metric.label} is unavailable for this variant.`)
+      continue
+    }
+
+    const ratio = value / peerMedian
+    const status: GuardrailStatus = ratio >= 1.5 ? 'breach' : ratio >= 1.25 ? 'watch' : 'ok'
+    guardrails.push({
+      key: metric.key,
+      label: metric.label,
+      status,
+      detail: `${metric.format(value)} vs ${metric.format(peerMedian)} ${metric.unit} (${ratio.toFixed(2)}x).`,
+    })
+  }
+
+  if (row.qualityAttributionLimited) {
+    limitedSignals.push('Quality attribution is limited because this variant has runs but no landed tasks.')
+  }
+
+  const verdict = deriveVerdict(row, landed, guardrails)
+  return {
+    verdict,
+    verdictLabel: verdictLabels[verdict],
+    verdictReason: verdictReason(verdict, guardrails, row.qualityAttributionLimited, landed),
+    primaryLabel: 'Landed/run',
+    primaryValue: landedPerRun === undefined ? '—' : `${(landedPerRun * 100).toFixed(0)}%`,
+    primaryDetail: `${landed}/${runs} landed`,
+    guardrails,
+    limitedSignals,
+  }
+}
+
+function deriveVerdict(row: ComparisonBreakdown, landed: number, guardrails: GuardrailSignal[]): ExperimentVerdict {
+  if (row.insufficientData) return 'underpowered'
+  if (row.qualityAttributionLimited || landed === 0) return 'needs-more-data'
+  if (guardrails.slice(0, 4).some((g) => g.status === 'breach')) return 'risky'
+  if (guardrails.slice(4).some((g) => g.status === 'breach')) return 'costly'
+  return 'promising'
+}
+
+function verdictReason(
+  verdict: ExperimentVerdict,
+  guardrails: GuardrailSignal[],
+  qualityAttributionLimited: boolean,
+  landed: number,
+): string {
+  if (verdict === 'underpowered') return 'Run count is below the comparison minimum.'
+  if (qualityAttributionLimited) return 'Runs exist, but landed-task quality signals are not attributable yet.'
+  if (landed === 0) return 'No landed tasks yet, so outcome quality cannot be judged.'
+  const breach = guardrails.find((g) => g.status === 'breach')
+  if (breach) return `${breach.label} breached its guardrail.`
+  return 'Primary signal is available and no guardrail is breached.'
+}
+
+function thresholdLow(
+  key: string,
+  label: string,
+  value: number | undefined,
+  breachBelow: number,
+  watchBelow: number,
+): GuardrailSignal {
+  if (value === undefined) return { key, label, status: 'limited', detail: 'No finite rate available.' }
+  const status: GuardrailStatus = value < breachBelow ? 'breach' : value < watchBelow ? 'watch' : 'ok'
+  return { key, label, status, detail: `${formatPct(value)} (${formatPct(breachBelow)} breach floor).` }
+}
+
+function thresholdHigh(
+  key: string,
+  label: string,
+  value: number | undefined,
+  breachAbove: number,
+  watchAbove: number,
+): GuardrailSignal {
+  if (value === undefined) return { key, label, status: 'limited', detail: 'No finite rate available.' }
+  const status: GuardrailStatus = value > breachAbove ? 'breach' : value > watchAbove ? 'watch' : 'ok'
+  return { key, label, status, detail: `${formatPct(value)} (${formatPct(breachAbove)} breach ceiling).` }
+}
+
+function peerValues(
+  row: ComparisonBreakdown,
+  peers: ComparisonBreakdown[],
+  key: PeerMetric['key'],
+): number[] {
+  return peers
+    .filter((peer) => {
+      if (peer.key === row.key) return false
+      if (peer.insufficientData) return false
+      if (peer.experimentId !== row.experimentId) return false
+      if (row.role && peer.role !== row.role) return false
+      return true
+    })
+    .map((peer) => finitePositive(peer[key]))
+    .filter((value): value is number => value !== undefined)
+}
+
+function median(values: number[]): number | undefined {
+  if (values.length === 0) return undefined
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  if (sorted.length % 2 === 1) return sorted[mid]
+  return (sorted[mid - 1] + sorted[mid]) / 2
+}
+
+function finiteNonNegative(value: number | null | undefined): number {
+  return Number.isFinite(value) && value !== null && value !== undefined && value > 0 ? value : 0
+}
+
+function finitePositive(value: number | null | undefined): number | undefined {
+  return Number.isFinite(value) && value !== null && value !== undefined && value > 0 ? value : undefined
+}
+
+function finiteRate(value: number | null | undefined): number | undefined {
+  return Number.isFinite(value) && value !== null && value !== undefined ? Math.max(0, value) : undefined
+}
+
+function formatPct(value: number): string {
+  return `${(value * 100).toFixed(0)}%`
+}
+
+function formatSeconds(value: number): string {
+  if (value >= 3600) return `${(value / 3600).toFixed(1)}h`
+  if (value >= 60) return `${(value / 60).toFixed(1)}m`
+  return `${value.toFixed(0)}s`
+}

--- a/frontend/src/lib/evaluation-interpretation.ts
+++ b/frontend/src/lib/evaluation-interpretation.ts
@@ -3,10 +3,12 @@ import type { ComparisonBreakdown } from '../../bindings/github.com/Automaat/syb
 export type ExperimentVerdict = 'underpowered' | 'needs-more-data' | 'risky' | 'costly' | 'promising'
 
 export type GuardrailStatus = 'ok' | 'watch' | 'breach' | 'limited'
+export type GuardrailCategory = 'risk' | 'cost'
 
 export interface GuardrailSignal {
   key: string
   label: string
+  category: GuardrailCategory
   status: GuardrailStatus
   detail: string
 }
@@ -46,10 +48,10 @@ export function interpretExperiment(
   const landed = finiteNonNegative(row.landed)
   const landedPerRun = runs > 0 ? landed / runs : undefined
   const guardrails: GuardrailSignal[] = [
-    thresholdLow('ci-first-pass', 'CI first pass', finiteRate(row.ciFirstPassRate), 0.6, 0.8),
-    thresholdHigh('edited-merge', 'Edited merge rate', finiteRate(row.mergedWithEditsRate), 0.3, 0.15),
-    thresholdHigh('rework', 'Rework', finiteRate(row.reworkRate), 0.3, 0.15),
-    thresholdHigh('revert', 'Revert', finiteRate(row.revertRate), 0, 0),
+    thresholdLow('ci-first-pass', 'CI first pass', 'risk', finiteRate(row.ciFirstPassRate), 0.6, 0.8),
+    thresholdHigh('edited-merge', 'Edited merge rate', 'risk', finiteRate(row.mergedWithEditsRate), 0.3, 0.15),
+    thresholdHigh('rework', 'Rework', 'risk', finiteRate(row.reworkRate), 0.3, 0.15),
+    thresholdHigh('revert', 'Revert', 'risk', finiteRate(row.revertRate), 0, 0),
   ]
   const limitedSignals: string[] = []
 
@@ -83,6 +85,7 @@ export function interpretExperiment(
       guardrails.push({
         key: metric.key,
         label: metric.label,
+        category: 'cost',
         status: 'limited',
         detail: `No usable same-experiment ${metric.unit}.`,
       })
@@ -95,6 +98,7 @@ export function interpretExperiment(
       guardrails.push({
         key: metric.key,
         label: metric.label,
+        category: 'cost',
         status: 'limited',
         detail: `No positive ${metric.label.toLowerCase()} value for this variant.`,
       })
@@ -107,6 +111,7 @@ export function interpretExperiment(
     guardrails.push({
       key: metric.key,
       label: metric.label,
+      category: 'cost',
       status,
       detail: `${metric.format(value)} vs ${metric.format(peerMedian)} ${metric.unit} (${ratio.toFixed(2)}x).`,
     })
@@ -132,8 +137,8 @@ export function interpretExperiment(
 function deriveVerdict(row: ComparisonBreakdown, landed: number, guardrails: GuardrailSignal[]): ExperimentVerdict {
   if (row.insufficientData) return 'underpowered'
   if (row.qualityAttributionLimited || landed === 0) return 'needs-more-data'
-  if (guardrails.slice(0, 4).some((g) => g.status === 'breach')) return 'risky'
-  if (guardrails.slice(4).some((g) => g.status === 'breach')) return 'costly'
+  if (guardrails.some((g) => g.category === 'risk' && g.status === 'breach')) return 'risky'
+  if (guardrails.some((g) => g.category === 'cost' && g.status === 'breach')) return 'costly'
   return 'promising'
 }
 
@@ -154,25 +159,27 @@ function verdictReason(
 function thresholdLow(
   key: string,
   label: string,
+  category: GuardrailCategory,
   value: number | undefined,
   breachBelow: number,
   watchBelow: number,
 ): GuardrailSignal {
-  if (value === undefined) return { key, label, status: 'limited', detail: 'No finite rate available.' }
+  if (value === undefined) return { key, label, category, status: 'limited', detail: 'No finite rate available.' }
   const status: GuardrailStatus = value < breachBelow ? 'breach' : value < watchBelow ? 'watch' : 'ok'
-  return { key, label, status, detail: `${formatPct(value)} (${formatPct(breachBelow)} breach floor).` }
+  return { key, label, category, status, detail: `${formatPct(value)} (${formatPct(breachBelow)} breach floor).` }
 }
 
 function thresholdHigh(
   key: string,
   label: string,
+  category: GuardrailCategory,
   value: number | undefined,
   breachAbove: number,
   watchAbove: number,
 ): GuardrailSignal {
-  if (value === undefined) return { key, label, status: 'limited', detail: 'No finite rate available.' }
+  if (value === undefined) return { key, label, category, status: 'limited', detail: 'No finite rate available.' }
   const status: GuardrailStatus = value > breachAbove ? 'breach' : value > watchAbove ? 'watch' : 'ok'
-  return { key, label, status, detail: `${formatPct(value)} (${formatPct(breachAbove)} breach ceiling).` }
+  return { key, label, category, status, detail: `${formatPct(value)} (${formatPct(breachAbove)} breach ceiling).` }
 }
 
 function peerValues(

--- a/frontend/src/pages/Evaluation.svelte
+++ b/frontend/src/pages/Evaluation.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { interpretExperiment } from '$lib/evaluation-interpretation.js'
   import { evaluationStore } from '../stores/evaluation.svelte.js'
   import { lifecycleStore } from '../stores/lifecycle.svelte.js'
 
@@ -45,20 +46,21 @@
     return () => evaluationStore.stopListening()
   })
 
-  function pct(x: number | undefined): string {
-    return x === undefined ? '—' : `${(x * 100).toFixed(0)}%`
+  function pct(x: number | null | undefined): string {
+    return Number.isFinite(x) ? `${((x ?? 0) * 100).toFixed(0)}%` : '—'
   }
   function hours(x: number | undefined): string {
     return x === undefined ? '—' : `${x.toFixed(1)}h`
   }
-  function seconds(x: number | undefined): string {
-    if (x === undefined) return '—'
+  function seconds(x: number | null | undefined): string {
+    if (!Number.isFinite(x)) return '—'
+    x = x ?? 0
     if (x >= 3600) return `${(x / 3600).toFixed(1)}h`
     if (x >= 60) return `${(x / 60).toFixed(1)}m`
     return `${x.toFixed(0)}s`
   }
-  function num(x: number | undefined, digits = 1): string {
-    return x === undefined ? '—' : x.toFixed(digits)
+  function num(x: number | null | undefined, digits = 1): string {
+    return Number.isFinite(x) ? (x ?? 0).toFixed(digits) : '—'
   }
   // Higher is better for these; render the bar/colour accordingly.
   function goodScale(x: number): string {
@@ -70,6 +72,18 @@
     return sev === 'warn'
       ? 'bg-warning-200 text-warning-800 dark:bg-warning-800 dark:text-warning-200'
       : 'bg-surface-200 text-surface-700 dark:bg-surface-700 dark:text-surface-200'
+  }
+  function verdictClasses(verdict: string): string {
+    if (verdict === 'promising') return 'bg-success-200 text-success-800 dark:bg-success-800 dark:text-success-200'
+    if (verdict === 'risky') return 'bg-error-200 text-error-800 dark:bg-error-800 dark:text-error-200'
+    if (verdict === 'costly') return 'bg-warning-200 text-warning-800 dark:bg-warning-800 dark:text-warning-200'
+    return 'bg-surface-200 text-surface-700 dark:bg-surface-700 dark:text-surface-200'
+  }
+  function guardrailClasses(status: string): string {
+    if (status === 'breach') return 'border-error-300 text-error-700 dark:border-error-700 dark:text-error-300'
+    if (status === 'watch') return 'border-warning-300 text-warning-700 dark:border-warning-700 dark:text-warning-300'
+    if (status === 'ok') return 'border-success-300 text-success-700 dark:border-success-700 dark:text-success-300'
+    return 'border-surface-300 text-surface-500 dark:border-surface-600 dark:text-surface-300'
   }
 </script>
 
@@ -287,11 +301,16 @@
     <!-- A/B testing and model comparisons -->
     <div class="grid grid-cols-1 gap-6">
       {#each [
-        { title: 'Agent / Model', data: report?.byAgentModel },
-        { title: 'A/B Experiments', data: report?.byVariant },
+        { title: 'Agent / Model', kind: 'agent', data: report?.byAgentModel },
+        { title: 'A/B Experiments', kind: 'experiment', data: report?.byVariant },
       ] as section (section.title)}
         <div class="overflow-x-auto rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
           <h3 class="mb-3 text-sm font-semibold text-surface-500">{section.title}</h3>
+          {#if section.kind === 'experiment'}
+            <p class="mb-3 max-w-3xl text-xs text-surface-400">
+              Primary signal: landed/run. Guardrails watch reliability, quality, speed, cost, and premium-model usage.
+            </p>
+          {/if}
           {#if section.data && section.data.length > 0}
             <table class="w-full min-w-[980px] text-sm">
               <thead>
@@ -312,12 +331,24 @@
               </thead>
               <tbody>
                 {#each section.data as row (row.key)}
+                  {@const interpretation = section.kind === 'experiment' ? interpretExperiment(row, section.data) : null}
                   <tr class="border-b border-surface-100 last:border-0 dark:border-surface-700">
                     <td class="py-1.5">
                       <div class="font-mono text-xs">{row.variantId || row.key}</div>
                       <div class="text-xs text-surface-400">
                         {row.provider}{row.model ? ` · ${row.model}` : ''}{row.reasoningEffort ? ` · ${row.reasoningEffort}` : ''}
                       </div>
+                      {#if interpretation}
+                        <div class="mt-1 flex flex-wrap items-center gap-1.5">
+                          <span class="rounded px-1.5 py-0.5 text-[10px] font-medium {verdictClasses(interpretation.verdict)}">
+                            {interpretation.verdictLabel}
+                          </span>
+                          <span class="text-[10px] text-surface-500">
+                            {interpretation.primaryLabel}: {interpretation.primaryValue} ({interpretation.primaryDetail})
+                          </span>
+                        </div>
+                        <p class="mt-1 text-[10px] text-surface-400">{interpretation.verdictReason}</p>
+                      {/if}
                     </td>
                     <td class="py-1.5 text-xs">{row.role || '—'}</td>
                     <td class="py-1.5 text-right">
@@ -336,6 +367,27 @@
                     <td class="py-1.5 text-right">${num(row.costPerLanded, 2)}/landed</td>
                     <td class="py-1.5 text-right">{num(row.premiumRequestsPerLanded, 1)}/landed</td>
                   </tr>
+                  {#if interpretation}
+                    <tr class="border-b border-surface-100 last:border-0 dark:border-surface-700">
+                      <td class="pb-2 pt-0" colspan="12">
+                        <div class="flex flex-wrap gap-1.5">
+                          {#each interpretation.guardrails as guardrail (guardrail.key)}
+                            <span
+                              class="rounded border px-1.5 py-0.5 text-[10px] {guardrailClasses(guardrail.status)}"
+                              title={guardrail.detail}
+                            >
+                              {guardrail.label}: {guardrail.status}
+                            </span>
+                          {/each}
+                        </div>
+                        {#if interpretation.limitedSignals.length > 0}
+                          <p class="mt-1 text-[10px] text-surface-400">
+                            Limited signals: {interpretation.limitedSignals.join(' ')}
+                          </p>
+                        {/if}
+                      </td>
+                    </tr>
+                  {/if}
                 {/each}
               </tbody>
             </table>

--- a/frontend/src/pages/Evaluation.svelte.test.ts
+++ b/frontend/src/pages/Evaluation.svelte.test.ts
@@ -1,0 +1,134 @@
+import { cleanup, render, screen, within } from '@testing-library/svelte'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockEvaluationStore = {
+  data: null as Record<string, unknown> | null,
+  loading: false,
+  error: '',
+  load: vi.fn(),
+  listen: vi.fn(),
+  stopListening: vi.fn(),
+}
+
+const mockLifecycleStore = {
+  data: null as Record<string, unknown> | null,
+  load: vi.fn(),
+}
+
+vi.mock('../stores/evaluation.svelte.js', () => ({
+  evaluationStore: mockEvaluationStore,
+}))
+
+vi.mock('../stores/lifecycle.svelte.js', () => ({
+  lifecycleStore: mockLifecycleStore,
+}))
+
+const Evaluation = (await import('./Evaluation.svelte')).default
+
+function makeReport() {
+  const comparisonRow = {
+    key: 'provider:model:medium:implementation',
+    provider: 'provider',
+    model: 'model',
+    role: 'implementation',
+    reasoningEffort: 'medium',
+    runs: 20,
+    failures: 0,
+    failureRate: 0,
+    landed: 10,
+    merged: 9,
+    mergedWithEdits: 1,
+    closed: 0,
+    mergeRate: 0.9,
+    mergedWithEditsRate: 0.1,
+    ciFirstPassRate: 0.9,
+    reworkRate: 0.1,
+    revertRate: 0,
+    durationP50S: 600,
+    durationP90S: 1_000,
+    totalCostUsd: 50,
+    costPerLanded: 5,
+    premiumRequests: 20,
+    premiumRequestsPerLanded: 2,
+    turnsPerLanded: 3,
+    toolsPerLanded: 10,
+    insufficientData: false,
+    qualityAttributionLimited: false,
+  }
+  return {
+    overall: {
+      windowDays: 30,
+      agentRuns: 20,
+      tasksLanded: 10,
+      merged: 9,
+      mergedWithEdits: 1,
+      closed: 0,
+      autonomyRate: 0.8,
+      humanTouchedLandings: 2,
+      ciFirstPassRate: 0.9,
+      failureRate: 0.1,
+      agentFailures: 2,
+      reverted: 0,
+      changeFailureRate: 0,
+      costPerLanded: 5,
+      totalCostUsd: 50,
+      reworkTasks: 1,
+      leadTimeP50H: 1,
+      leadTimeP90H: 2,
+      cycleTimeP50H: 0.5,
+      cycleTimeP90H: 1,
+      turnsPerLanded: 3,
+      toolsPerLanded: 10,
+    },
+    weaknesses: [],
+    byProvider: [],
+    byRole: [],
+    byAgentModel: [comparisonRow],
+    byVariant: [
+      {
+        ...comparisonRow,
+        key: 'exp-a:v1:implementation',
+        experimentId: 'exp-a',
+        variantId: 'v1',
+        durationP90S: 1_500,
+      },
+    ],
+    notes: [],
+  }
+}
+
+describe('Evaluation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockEvaluationStore.data = makeReport()
+    mockEvaluationStore.loading = false
+    mockEvaluationStore.error = ''
+    mockLifecycleStore.data = null
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders A/B interpretation only for experiment rows while preserving raw metric columns', () => {
+    render(Evaluation, { props: {} })
+
+    const agentSection = screen.getByText('Agent / Model').closest('div')
+    const experimentSection = screen.getByText('A/B Experiments').closest('div')
+
+    expect(agentSection).not.toBeNull()
+    expect(experimentSection).not.toBeNull()
+    expect(within(experimentSection as HTMLElement).getByText('Promising')).toBeDefined()
+    expect(within(experimentSection as HTMLElement).getByText(/Landed\/run: 50%/)).toBeDefined()
+    expect(within(experimentSection as HTMLElement).getByText(/CI first pass: ok/)).toBeDefined()
+    expect(within(experimentSection as HTMLElement).getByText(/Limited signals:/)).toBeDefined()
+    expect(within(agentSection as HTMLElement).queryByText('Promising')).toBeNull()
+    expect(within(agentSection as HTMLElement).queryByText(/Landed\/run:/)).toBeNull()
+    expect(within(agentSection as HTMLElement).queryByText(/CI first pass: ok/)).toBeNull()
+
+    for (const label of ['Runs', 'Landed', 'Merge %', 'CI 1st', 'Edited', 'Rework', 'Revert', 'Duration', 'Cost', 'Premium req']) {
+      expect(within(agentSection as HTMLElement).getByText(label)).toBeDefined()
+      expect(within(experimentSection as HTMLElement).getByText(label)).toBeDefined()
+    }
+  })
+})


### PR DESCRIPTION
## Motivation

Evaluation frame changes should be guarded so experiments can compare variants without accidentally mixing incompatible inputs or producing misleading results.

Closes https://github.com/Automaat/sybra/issues/1252

## Implementation information

- Adds guardrails around evaluation frame A/B experiment handling.
- Keeps the change scoped to the evaluation workflow so existing task and agent flows remain unchanged outside the guarded experiment path.