### PR TITLE
feat(github): reduce gh rate-limit consumption

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,8 @@ Sybra can run on multiple machines (e.g. laptop + remote server). Each instance 
 - All project-scoped automations filter via `cfg.AllowsProjectType(...)` (config helper).
 - Example: server handles `pet`, laptop handles `work`.
 
+**3. `github.poller_role`** (shared-token de-dupe): `secondary` skips the periodic GitHub search polls (reviews/issues/renovate) so only the `primary` instance spends the shared token's rate budget. See `docs/github-rate-limits.md` for the full `github:` block (poll-interval overrides, GitHub App installation-token auth for a 15k/hr ceiling). Request volume is paced by `ghGate` and auto-throttled when the live budget (refreshed from the free `/rate_limit` endpoint) runs low.
+
 ```yaml
 # server config
 project_types: [pet]

--- a/docs/github-rate-limits.md
+++ b/docs/github-rate-limits.md
@@ -1,0 +1,114 @@
+# GitHub Rate Limits
+
+Sybra drives GitHub entirely through the `gh` CLI (`internal/github`). All calls
+funnel through a single request gate (`ghGate`) that paces requests (150ms
+spacing), backs off on `Retry-After` / rate-limit responses, and now tracks the
+live budget for every resource bucket.
+
+This doc covers the knobs that control GitHub request volume and how to lift the
+ceiling with a GitHub App.
+
+## Where the requests come from
+
+The volume drivers are the **periodic GraphQL search polls**, not per-PR REST
+calls:
+
+| Poller | What it searches | Default cadence |
+|--------|------------------|-----------------|
+| reviews | `author:@me`, `review-requested:@me`, `reviewed-by:@me` (3 legs) | fast 2m / slow 10m |
+| issues  | assigned + labeled (`sybra`) issues, combined in one request | 10m |
+| renovate | Renovate-bot PRs across project repos | fast 2m / slow 10m |
+
+Per-PR REST reads (`gh pr view`, `/pulls/{n}/reviews`) are bounded and short-TTL
+cached; they are not the bottleneck.
+
+## Tuning knobs (`github:` config block)
+
+```yaml
+github:
+  enabled: true
+
+  # Split polling across machines that share one token. "secondary" skips the
+  # reviews/issues/renovate search polls so only the primary spends the shared
+  # budget. Empty/"primary" runs them. Triage and on-demand per-PR calls run
+  # everywhere regardless.
+  poller_role: primary
+
+  # Poll-interval overrides in seconds (0 = built-in default). Raise these on a
+  # low-limit (personal token) instance; lower them on a high-limit App-token
+  # instance.
+  reviews_fast_seconds: 120      # default 120 (was 60)
+  reviews_slow_seconds: 600      # default 600 (was 300)
+  issues_seconds: 600            # default 600 (was 300)
+  renovate_fast_seconds: 120     # default 120 (was 60)
+  renovate_slow_seconds: 600     # default 600 (was 300)
+```
+
+On top of the configured interval, every poller is stretched automatically when
+the shared budget runs low (`github.ScaleInterval` → up to 4x as the lowest
+resource bucket approaches exhaustion). The budget is refreshed every 60s from
+the **free** `GET /rate_limit` endpoint, so the throttle and the gate see
+accurate remaining quota for every `gh` path — including the `gh pr view` /
+`gh issue` subcommands whose response headers the gate can't observe directly.
+
+### Running two machines on one token
+
+Set the laptop to `poller_role: secondary` (or split by `project_types`) so the
+server is the sole search poller. Without this, both instances run the same
+`@me` searches and double-bill the shared token — the fastest way to trip the
+**secondary** rate limit.
+
+## Lifting the ceiling: GitHub App auth
+
+A personal token gets 5,000 REST req/hr. A GitHub App **installation token**
+gets 15,000 REST req/hr (and higher GraphQL headroom). Sybra mints a short-lived
+installation token, refreshes it every 30m, and injects it into the `gh`
+subprocess via `GH_TOKEN` — no call site changes.
+
+```yaml
+github:
+  app:
+    enabled: true
+    app_id: 123456
+    installation_id: 7891011
+    private_key_path: /data/sybra/github-app.pem
+```
+
+When unset/disabled, `gh` uses its own auth unchanged.
+
+### Manual setup (one-time, done in the GitHub UI)
+
+1. **Create the App** — Settings → Developer settings → GitHub Apps → *New
+   GitHub App*. Give it a name; homepage URL can be anything.
+2. **Permissions** — Repository: *Contents* (read/write), *Issues* (read/write),
+   *Pull requests* (read/write), *Metadata* (read). Organization/Account: none.
+   Match these to what your automations actually do.
+3. **Webhook** — uncheck *Active* (Sybra polls; it doesn't receive webhooks).
+4. **Create**, then note the **App ID** (shown on the App's page).
+5. **Generate a private key** — on the App's page, *Private keys → Generate a
+   private key*. A `.pem` downloads. Put it where the server can read it
+   (e.g. `/data/sybra/github-app.pem`, mode `0600`) and set `private_key_path`.
+6. **Install the App** — *Install App* → choose the account/org → select the
+   repositories Sybra manages.
+7. **Get the installation ID** — after install, the URL is
+   `https://github.com/settings/installations/<INSTALLATION_ID>`. Use that
+   number for `installation_id`.
+8. Set the `github.app` block above and restart Sybra. Startup logs
+   `github.app.enabled`; a bad key/permission logs `github.app.disabled` and
+   falls back to gh's own auth (never fatal).
+
+The private key never appears in config — only its path is stored. For
+work-typed projects, keep the key off any artifact that could reach a public
+issue/PR (see Work-Data Confidentiality in `CLAUDE.md`).
+
+## What was deliberately *not* done
+
+- **Combining the 3 reviews search legs into one request.** The combined form
+  (multiple aliased `search` connections in one query) times out at GitHub's
+  edge for accounts with many open review requests — it was split for that
+  reason (see `internal/github/review.go`). The reviews rate reduction comes
+  from longer intervals + the budget throttle + App-token headroom instead.
+- **A go-github/githubv4 client with ETag conditional requests.** ETag 304s are
+  free only against the REST budget, but Sybra's load is GraphQL-search-dominated
+  (POST, which can't use conditional requests). The live-rate-header limiter half
+  of that idea is already covered by the `/rate_limit` refresher + gate.

--- a/frontend/src/lib/evaluation-interpretation.test.ts
+++ b/frontend/src/lib/evaluation-interpretation.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest'
+import { ComparisonBreakdown } from '../../bindings/github.com/Automaat/sybra/internal/evaluation/models.js'
+import { interpretExperiment } from './evaluation-interpretation.js'
+
+function row(overrides: Partial<ComparisonBreakdown> = {}): ComparisonBreakdown {
+  return ComparisonBreakdown.createFrom({
+    key: 'exp-a:v1:implementation',
+    experimentId: 'exp-a',
+    variantId: 'v1',
+    role: 'implementation',
+    runs: 20,
+    landed: 10,
+    merged: 8,
+    mergeRate: 0.8,
+    mergedWithEditsRate: 0.1,
+    ciFirstPassRate: 0.9,
+    reworkRate: 0.1,
+    revertRate: 0,
+    durationP50S: 600,
+    durationP90S: 1_000,
+    totalCostUsd: 50,
+    costPerLanded: 5,
+    premiumRequests: 20,
+    premiumRequestsPerLanded: 2,
+    turnsPerLanded: 3,
+    toolsPerLanded: 10,
+    ...overrides,
+  })
+}
+
+function peer(overrides: Partial<ComparisonBreakdown> = {}): ComparisonBreakdown {
+  return row({
+    key: 'exp-a:v2:implementation',
+    variantId: 'v2',
+    durationP90S: 900,
+    costPerLanded: 5,
+    premiumRequestsPerLanded: 2,
+    ...overrides,
+  })
+}
+
+describe('interpretExperiment', () => {
+  it('marks low-sample rows as underpowered before other verdicts', () => {
+    const result = interpretExperiment(row({ insufficientData: true, landed: 0, ciFirstPassRate: 0.2 }), [peer()])
+
+    expect(result.verdict).toBe('underpowered')
+    expect(result.verdictLabel).toBe('Underpowered')
+  })
+
+  it('marks rows with no landed tasks as needing more data', () => {
+    const result = interpretExperiment(row({ landed: 0, qualityAttributionLimited: false }), [peer()])
+
+    expect(result.verdict).toBe('needs-more-data')
+    expect(result.verdictReason).toContain('No landed tasks')
+  })
+
+  it('marks limited quality attribution as needing more data', () => {
+    const result = interpretExperiment(row({ landed: 0, qualityAttributionLimited: true }), [peer()])
+
+    expect(result.verdict).toBe('needs-more-data')
+    expect(result.limitedSignals).toContain(
+      'Quality attribution is limited because this variant has runs but no landed tasks.',
+    )
+  })
+
+  it('calculates the primary metric as landed per run', () => {
+    const result = interpretExperiment(row({ runs: 25, landed: 5 }), [peer()])
+
+    expect(result.primaryLabel).toBe('Landed/run')
+    expect(result.primaryValue).toBe('20%')
+    expect(result.primaryDetail).toBe('5/25 landed')
+  })
+
+  it('normalizes zero runs without producing a misleading ratio', () => {
+    const result = interpretExperiment(row({ runs: 0, landed: 0 }), [peer()])
+
+    expect(result.primaryValue).toBe('—')
+    expect(result.primaryDetail).toBe('0/0 landed')
+    expect(result.verdict).toBe('needs-more-data')
+  })
+
+  it('marks reliability and quality guardrail breaches as risky', () => {
+    const result = interpretExperiment(row({ ciFirstPassRate: 0.59 }), [peer()])
+
+    expect(result.verdict).toBe('risky')
+    expect(result.guardrails.find((g) => g.key === 'ci-first-pass')?.status).toBe('breach')
+    expect(result.guardrails.find((g) => g.key === 'ci-first-pass')?.category).toBe('risk')
+  })
+
+  it('marks peer-relative outlier breaches as costly', () => {
+    const result = interpretExperiment(row({ durationP90S: 1_500, costPerLanded: 5 }), [
+      peer({ durationP90S: 1_000, costPerLanded: 10, premiumRequestsPerLanded: 3 }),
+    ])
+
+    expect(result.verdict).toBe('costly')
+    expect(result.guardrails.find((g) => g.key === 'durationP90S')?.status).toBe('breach')
+    expect(result.guardrails.find((g) => g.key === 'durationP90S')?.category).toBe('cost')
+  })
+
+  it('assigns explicit categories to every guardrail', () => {
+    const result = interpretExperiment(row(), [peer()])
+
+    expect(result.guardrails.map((g) => [g.key, g.category])).toEqual([
+      ['ci-first-pass', 'risk'],
+      ['edited-merge', 'risk'],
+      ['rework', 'risk'],
+      ['revert', 'risk'],
+      ['durationP90S', 'cost'],
+      ['costPerLanded', 'cost'],
+      ['premiumRequestsPerLanded', 'cost'],
+    ])
+  })
+
+  it('marks rows as promising when no guardrail breaches', () => {
+    const result = interpretExperiment(row(), [peer()])
+
+    expect(result.verdict).toBe('promising')
+    expect(result.guardrails.every((g) => g.status === 'ok' || g.status === 'limited')).toBe(true)
+  })
+
+  it('does not breach duration, cost, or premium without usable peers', () => {
+    const result = interpretExperiment(row({ durationP90S: 10_000, costPerLanded: 500 }), [])
+
+    expect(result.verdict).toBe('promising')
+    expect(result.guardrails.filter((g) => g.status === 'limited').map((g) => g.key)).toEqual([
+      'durationP90S',
+      'costPerLanded',
+      'premiumRequestsPerLanded',
+    ])
+    expect(result.limitedSignals).toContain('Duration p90 has no usable same-experiment peer baseline.')
+  })
+
+  it('ignores low-N peers and peers without positive values', () => {
+    const result = interpretExperiment(row({ durationP90S: 10_000, costPerLanded: 500 }), [
+      peer({ insufficientData: true, durationP90S: 1, costPerLanded: 1, premiumRequestsPerLanded: 1 }),
+      peer({
+        key: 'exp-a:v3:implementation',
+        variantId: 'v3',
+        durationP90S: 0,
+        costPerLanded: 0,
+        premiumRequestsPerLanded: 0,
+      }),
+    ])
+
+    expect(result.verdict).toBe('promising')
+    expect(result.guardrails.filter((g) => g.status === 'limited')).toHaveLength(3)
+  })
+
+  it('uses only same-experiment same-role positive peers for outlier medians', () => {
+    const result = interpretExperiment(row({ durationP90S: 1_600 }), [
+      peer({ key: 'exp-b:v2:implementation', experimentId: 'exp-b', durationP90S: 100 }),
+      peer({ key: 'exp-a:v3:review', variantId: 'v3', role: 'review', durationP90S: 100 }),
+      peer({ key: 'exp-a:v4:implementation', variantId: 'v4', durationP90S: 1_000 }),
+    ])
+
+    expect(result.verdict).toBe('costly')
+    expect(result.guardrails.find((g) => g.key === 'durationP90S')?.detail).toContain('1.60x')
+  })
+})

--- a/frontend/src/lib/evaluation-interpretation.ts
+++ b/frontend/src/lib/evaluation-interpretation.ts
@@ -1,0 +1,230 @@
+import type { ComparisonBreakdown } from '../../bindings/github.com/Automaat/sybra/internal/evaluation/models.js'
+
+export type ExperimentVerdict = 'underpowered' | 'needs-more-data' | 'risky' | 'costly' | 'promising'
+
+export type GuardrailStatus = 'ok' | 'watch' | 'breach' | 'limited'
+export type GuardrailCategory = 'risk' | 'cost'
+
+export interface GuardrailSignal {
+  key: string
+  label: string
+  category: GuardrailCategory
+  status: GuardrailStatus
+  detail: string
+}
+
+export interface ExperimentInterpretation {
+  verdict: ExperimentVerdict
+  verdictLabel: string
+  verdictReason: string
+  primaryLabel: string
+  primaryValue: string
+  primaryDetail: string
+  guardrails: GuardrailSignal[]
+  limitedSignals: string[]
+}
+
+const verdictLabels: Record<ExperimentVerdict, string> = {
+  underpowered: 'Underpowered',
+  'needs-more-data': 'Needs more data',
+  risky: 'Risky',
+  costly: 'Costly',
+  promising: 'Promising',
+}
+
+interface PeerMetric {
+  key: 'durationP90S' | 'costPerLanded' | 'premiumRequestsPerLanded'
+  label: string
+  value: number | undefined
+  unit: string
+  format: (value: number) => string
+}
+
+export function interpretExperiment(
+  row: ComparisonBreakdown,
+  peers: ComparisonBreakdown[] = [],
+): ExperimentInterpretation {
+  const runs = finiteNonNegative(row.runs)
+  const landed = finiteNonNegative(row.landed)
+  const landedPerRun = runs > 0 ? landed / runs : undefined
+  const guardrails: GuardrailSignal[] = [
+    thresholdLow('ci-first-pass', 'CI first pass', 'risk', finiteRate(row.ciFirstPassRate), 0.6, 0.8),
+    thresholdHigh('edited-merge', 'Edited merge rate', 'risk', finiteRate(row.mergedWithEditsRate), 0.3, 0.15),
+    thresholdHigh('rework', 'Rework', 'risk', finiteRate(row.reworkRate), 0.3, 0.15),
+    thresholdHigh('revert', 'Revert', 'risk', finiteRate(row.revertRate), 0, 0),
+  ]
+  const limitedSignals: string[] = []
+
+  const peerMetrics: PeerMetric[] = [
+    {
+      key: 'durationP90S',
+      label: 'Duration p90',
+      value: finitePositive(row.durationP90S),
+      unit: 'peer median',
+      format: formatSeconds,
+    },
+    {
+      key: 'costPerLanded',
+      label: 'Cost per landed',
+      value: finitePositive(row.costPerLanded),
+      unit: 'peer median',
+      format: (value) => `$${value.toFixed(2)}`,
+    },
+    {
+      key: 'premiumRequestsPerLanded',
+      label: 'Premium requests',
+      value: finitePositive(row.premiumRequestsPerLanded),
+      unit: 'peer median',
+      format: (value) => `${value.toFixed(1)}/landed`,
+    },
+  ]
+
+  for (const metric of peerMetrics) {
+    const peerMedian = median(peerValues(row, peers, metric.key))
+    if (peerMedian === undefined) {
+      guardrails.push({
+        key: metric.key,
+        label: metric.label,
+        category: 'cost',
+        status: 'limited',
+        detail: `No usable same-experiment ${metric.unit}.`,
+      })
+      limitedSignals.push(`${metric.label} has no usable same-experiment peer baseline.`)
+      continue
+    }
+
+    const value = metric.value
+    if (value === undefined) {
+      guardrails.push({
+        key: metric.key,
+        label: metric.label,
+        category: 'cost',
+        status: 'limited',
+        detail: `No positive ${metric.label.toLowerCase()} value for this variant.`,
+      })
+      limitedSignals.push(`${metric.label} is unavailable for this variant.`)
+      continue
+    }
+
+    const ratio = value / peerMedian
+    const status: GuardrailStatus = ratio >= 1.5 ? 'breach' : ratio >= 1.25 ? 'watch' : 'ok'
+    guardrails.push({
+      key: metric.key,
+      label: metric.label,
+      category: 'cost',
+      status,
+      detail: `${metric.format(value)} vs ${metric.format(peerMedian)} ${metric.unit} (${ratio.toFixed(2)}x).`,
+    })
+  }
+
+  if (row.qualityAttributionLimited) {
+    limitedSignals.push('Quality attribution is limited because this variant has runs but no landed tasks.')
+  }
+
+  const verdict = deriveVerdict(row, landed, guardrails)
+  return {
+    verdict,
+    verdictLabel: verdictLabels[verdict],
+    verdictReason: verdictReason(verdict, guardrails, row.qualityAttributionLimited, landed),
+    primaryLabel: 'Landed/run',
+    primaryValue: landedPerRun === undefined ? '—' : `${(landedPerRun * 100).toFixed(0)}%`,
+    primaryDetail: `${landed}/${runs} landed`,
+    guardrails,
+    limitedSignals,
+  }
+}
+
+function deriveVerdict(row: ComparisonBreakdown, landed: number, guardrails: GuardrailSignal[]): ExperimentVerdict {
+  if (row.insufficientData) return 'underpowered'
+  if (row.qualityAttributionLimited || landed === 0) return 'needs-more-data'
+  if (guardrails.some((g) => g.category === 'risk' && g.status === 'breach')) return 'risky'
+  if (guardrails.some((g) => g.category === 'cost' && g.status === 'breach')) return 'costly'
+  return 'promising'
+}
+
+function verdictReason(
+  verdict: ExperimentVerdict,
+  guardrails: GuardrailSignal[],
+  qualityAttributionLimited: boolean,
+  landed: number,
+): string {
+  if (verdict === 'underpowered') return 'Run count is below the comparison minimum.'
+  if (qualityAttributionLimited) return 'Runs exist, but landed-task quality signals are not attributable yet.'
+  if (landed === 0) return 'No landed tasks yet, so outcome quality cannot be judged.'
+  const breach = guardrails.find((g) => g.status === 'breach')
+  if (breach) return `${breach.label} breached its guardrail.`
+  return 'Primary signal is available and no guardrail is breached.'
+}
+
+function thresholdLow(
+  key: string,
+  label: string,
+  category: GuardrailCategory,
+  value: number | undefined,
+  breachBelow: number,
+  watchBelow: number,
+): GuardrailSignal {
+  if (value === undefined) return { key, label, category, status: 'limited', detail: 'No finite rate available.' }
+  const status: GuardrailStatus = value < breachBelow ? 'breach' : value < watchBelow ? 'watch' : 'ok'
+  return { key, label, category, status, detail: `${formatPct(value)} (${formatPct(breachBelow)} breach floor).` }
+}
+
+function thresholdHigh(
+  key: string,
+  label: string,
+  category: GuardrailCategory,
+  value: number | undefined,
+  breachAbove: number,
+  watchAbove: number,
+): GuardrailSignal {
+  if (value === undefined) return { key, label, category, status: 'limited', detail: 'No finite rate available.' }
+  const status: GuardrailStatus = value > breachAbove ? 'breach' : value > watchAbove ? 'watch' : 'ok'
+  return { key, label, category, status, detail: `${formatPct(value)} (${formatPct(breachAbove)} breach ceiling).` }
+}
+
+function peerValues(
+  row: ComparisonBreakdown,
+  peers: ComparisonBreakdown[],
+  key: PeerMetric['key'],
+): number[] {
+  return peers
+    .filter((peer) => {
+      if (peer.key === row.key) return false
+      if (peer.insufficientData) return false
+      if (peer.experimentId !== row.experimentId) return false
+      if (row.role && peer.role !== row.role) return false
+      return true
+    })
+    .map((peer) => finitePositive(peer[key]))
+    .filter((value): value is number => value !== undefined)
+}
+
+function median(values: number[]): number | undefined {
+  if (values.length === 0) return undefined
+  const sorted = [...values].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  if (sorted.length % 2 === 1) return sorted[mid]
+  return (sorted[mid - 1] + sorted[mid]) / 2
+}
+
+function finiteNonNegative(value: number | null | undefined): number {
+  return Number.isFinite(value) && value !== null && value !== undefined && value > 0 ? value : 0
+}
+
+function finitePositive(value: number | null | undefined): number | undefined {
+  return Number.isFinite(value) && value !== null && value !== undefined && value > 0 ? value : undefined
+}
+
+function finiteRate(value: number | null | undefined): number | undefined {
+  return Number.isFinite(value) && value !== null && value !== undefined ? Math.max(0, value) : undefined
+}
+
+function formatPct(value: number): string {
+  return `${(value * 100).toFixed(0)}%`
+}
+
+function formatSeconds(value: number): string {
+  if (value >= 3600) return `${(value / 3600).toFixed(1)}h`
+  if (value >= 60) return `${(value / 60).toFixed(1)}m`
+  return `${value.toFixed(0)}s`
+}

--- a/frontend/src/pages/Evaluation.svelte
+++ b/frontend/src/pages/Evaluation.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { interpretExperiment } from '$lib/evaluation-interpretation.js'
   import { evaluationStore } from '../stores/evaluation.svelte.js'
   import { lifecycleStore } from '../stores/lifecycle.svelte.js'
 
@@ -70,6 +71,18 @@
     return sev === 'warn'
       ? 'bg-warning-200 text-warning-800 dark:bg-warning-800 dark:text-warning-200'
       : 'bg-surface-200 text-surface-700 dark:bg-surface-700 dark:text-surface-200'
+  }
+  function verdictClasses(verdict: string): string {
+    if (verdict === 'promising') return 'bg-success-200 text-success-800 dark:bg-success-800 dark:text-success-200'
+    if (verdict === 'risky') return 'bg-error-200 text-error-800 dark:bg-error-800 dark:text-error-200'
+    if (verdict === 'costly') return 'bg-warning-200 text-warning-800 dark:bg-warning-800 dark:text-warning-200'
+    return 'bg-surface-200 text-surface-700 dark:bg-surface-700 dark:text-surface-200'
+  }
+  function guardrailClasses(status: string): string {
+    if (status === 'breach') return 'border-error-300 text-error-700 dark:border-error-700 dark:text-error-300'
+    if (status === 'watch') return 'border-warning-300 text-warning-700 dark:border-warning-700 dark:text-warning-300'
+    if (status === 'ok') return 'border-success-300 text-success-700 dark:border-success-700 dark:text-success-300'
+    return 'border-surface-300 text-surface-500 dark:border-surface-600 dark:text-surface-300'
   }
 </script>
 
@@ -287,11 +300,16 @@
     <!-- A/B testing and model comparisons -->
     <div class="grid grid-cols-1 gap-6">
       {#each [
-        { title: 'Agent / Model', data: report?.byAgentModel },
-        { title: 'A/B Experiments', data: report?.byVariant },
+        { title: 'Agent / Model', kind: 'agent', data: report?.byAgentModel },
+        { title: 'A/B Experiments', kind: 'experiment', data: report?.byVariant },
       ] as section (section.title)}
         <div class="overflow-x-auto rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
           <h3 class="mb-3 text-sm font-semibold text-surface-500">{section.title}</h3>
+          {#if section.kind === 'experiment'}
+            <p class="mb-3 max-w-3xl text-xs text-surface-400">
+              Primary signal: landed/run. Guardrails watch reliability, quality, speed, cost, and premium-model usage.
+            </p>
+          {/if}
           {#if section.data && section.data.length > 0}
             <table class="w-full min-w-[980px] text-sm">
               <thead>
@@ -312,12 +330,24 @@
               </thead>
               <tbody>
                 {#each section.data as row (row.key)}
+                  {@const interpretation = section.kind === 'experiment' ? interpretExperiment(row, section.data) : null}
                   <tr class="border-b border-surface-100 last:border-0 dark:border-surface-700">
                     <td class="py-1.5">
                       <div class="font-mono text-xs">{row.variantId || row.key}</div>
                       <div class="text-xs text-surface-400">
                         {row.provider}{row.model ? ` · ${row.model}` : ''}{row.reasoningEffort ? ` · ${row.reasoningEffort}` : ''}
                       </div>
+                      {#if interpretation}
+                        <div class="mt-1 flex flex-wrap items-center gap-1.5">
+                          <span class="rounded px-1.5 py-0.5 text-[10px] font-medium {verdictClasses(interpretation.verdict)}">
+                            {interpretation.verdictLabel}
+                          </span>
+                          <span class="text-[10px] text-surface-500">
+                            {interpretation.primaryLabel}: {interpretation.primaryValue} ({interpretation.primaryDetail})
+                          </span>
+                        </div>
+                        <p class="mt-1 text-[10px] text-surface-400">{interpretation.verdictReason}</p>
+                      {/if}
                     </td>
                     <td class="py-1.5 text-xs">{row.role || '—'}</td>
                     <td class="py-1.5 text-right">
@@ -336,6 +366,27 @@
                     <td class="py-1.5 text-right">${num(row.costPerLanded, 2)}/landed</td>
                     <td class="py-1.5 text-right">{num(row.premiumRequestsPerLanded, 1)}/landed</td>
                   </tr>
+                  {#if interpretation}
+                    <tr class="border-b border-surface-100 last:border-0 dark:border-surface-700">
+                      <td class="pb-2 pt-0" colspan="12">
+                        <div class="flex flex-wrap gap-1.5">
+                          {#each interpretation.guardrails as guardrail (guardrail.key)}
+                            <span
+                              class="rounded border px-1.5 py-0.5 text-[10px] {guardrailClasses(guardrail.status)}"
+                              title={guardrail.detail}
+                            >
+                              {guardrail.label}: {guardrail.status}
+                            </span>
+                          {/each}
+                        </div>
+                        {#if interpretation.limitedSignals.length > 0}
+                          <p class="mt-1 text-[10px] text-surface-400">
+                            Limited signals: {interpretation.limitedSignals.join(' ')}
+                          </p>
+                        {/if}
+                      </td>
+                    </tr>
+                  {/if}
                 {/each}
               </tbody>
             </table>

--- a/frontend/src/pages/Evaluation.svelte.test.ts
+++ b/frontend/src/pages/Evaluation.svelte.test.ts
@@ -1,0 +1,134 @@
+import { cleanup, render, screen, within } from '@testing-library/svelte'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockEvaluationStore = {
+  data: null as Record<string, unknown> | null,
+  loading: false,
+  error: '',
+  load: vi.fn(),
+  listen: vi.fn(),
+  stopListening: vi.fn(),
+}
+
+const mockLifecycleStore = {
+  data: null as Record<string, unknown> | null,
+  load: vi.fn(),
+}
+
+vi.mock('../stores/evaluation.svelte.js', () => ({
+  evaluationStore: mockEvaluationStore,
+}))
+
+vi.mock('../stores/lifecycle.svelte.js', () => ({
+  lifecycleStore: mockLifecycleStore,
+}))
+
+const Evaluation = (await import('./Evaluation.svelte')).default
+
+function makeReport() {
+  const comparisonRow = {
+    key: 'provider:model:medium:implementation',
+    provider: 'provider',
+    model: 'model',
+    role: 'implementation',
+    reasoningEffort: 'medium',
+    runs: 20,
+    failures: 0,
+    failureRate: 0,
+    landed: 10,
+    merged: 9,
+    mergedWithEdits: 1,
+    closed: 0,
+    mergeRate: 0.9,
+    mergedWithEditsRate: 0.1,
+    ciFirstPassRate: 0.9,
+    reworkRate: 0.1,
+    revertRate: 0,
+    durationP50S: 600,
+    durationP90S: 1_000,
+    totalCostUsd: 50,
+    costPerLanded: 5,
+    premiumRequests: 20,
+    premiumRequestsPerLanded: 2,
+    turnsPerLanded: 3,
+    toolsPerLanded: 10,
+    insufficientData: false,
+    qualityAttributionLimited: false,
+  }
+  return {
+    overall: {
+      windowDays: 30,
+      agentRuns: 20,
+      tasksLanded: 10,
+      merged: 9,
+      mergedWithEdits: 1,
+      closed: 0,
+      autonomyRate: 0.8,
+      humanTouchedLandings: 2,
+      ciFirstPassRate: 0.9,
+      failureRate: 0.1,
+      agentFailures: 2,
+      reverted: 0,
+      changeFailureRate: 0,
+      costPerLanded: 5,
+      totalCostUsd: 50,
+      reworkTasks: 1,
+      leadTimeP50H: 1,
+      leadTimeP90H: 2,
+      cycleTimeP50H: 0.5,
+      cycleTimeP90H: 1,
+      turnsPerLanded: 3,
+      toolsPerLanded: 10,
+    },
+    weaknesses: [],
+    byProvider: [],
+    byRole: [],
+    byAgentModel: [comparisonRow],
+    byVariant: [
+      {
+        ...comparisonRow,
+        key: 'exp-a:v1:implementation',
+        experimentId: 'exp-a',
+        variantId: 'v1',
+        durationP90S: 1_500,
+      },
+    ],
+    notes: [],
+  }
+}
+
+describe('Evaluation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockEvaluationStore.data = makeReport()
+    mockEvaluationStore.loading = false
+    mockEvaluationStore.error = ''
+    mockLifecycleStore.data = null
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders A/B interpretation only for experiment rows while preserving raw metric columns', () => {
+    render(Evaluation, { props: {} })
+
+    const agentSection = screen.getByText('Agent / Model').closest('div')
+    const experimentSection = screen.getByText('A/B Experiments').closest('div')
+
+    expect(agentSection).not.toBeNull()
+    expect(experimentSection).not.toBeNull()
+    expect(within(experimentSection as HTMLElement).getByText('Promising')).toBeDefined()
+    expect(within(experimentSection as HTMLElement).getByText(/Landed\/run: 50%/)).toBeDefined()
+    expect(within(experimentSection as HTMLElement).getByText(/CI first pass: ok/)).toBeDefined()
+    expect(within(experimentSection as HTMLElement).getByText(/Limited signals:/)).toBeDefined()
+    expect(within(agentSection as HTMLElement).queryByText('Promising')).toBeNull()
+    expect(within(agentSection as HTMLElement).queryByText(/Landed\/run:/)).toBeNull()
+    expect(within(agentSection as HTMLElement).queryByText(/CI first pass: ok/)).toBeNull()
+
+    for (const label of ['Runs', 'Landed', 'Merge %', 'CI 1st', 'Edited', 'Rework', 'Revert', 'Duration', 'Cost', 'Premium req']) {
+      expect(within(agentSection as HTMLElement).getByText(label)).toBeDefined()
+      expect(within(experimentSection as HTMLElement).getByText(label)).toBeDefined()
+    }
+  })
+})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/Automaat/sybra/internal/abtest"
 	"gopkg.in/yaml.v3"
@@ -310,6 +311,80 @@ type RenovateConfig struct {
 
 type GitHubConfig struct {
 	Enabled bool `yaml:"enabled" json:"enabled"`
+	// PollerRole splits GitHub search polling (reviews/issues/renovate) across
+	// machines sharing one token. "primary" (or empty) runs the search pollers;
+	// "secondary" skips them so a sibling instance owns the searches and the
+	// shared token isn't billed twice. On-demand per-PR/issue calls still run on
+	// every machine — only the periodic searches are gated.
+	PollerRole string `yaml:"poller_role" json:"pollerRole"`
+	// Poll-interval overrides in seconds. Zero falls back to the built-in
+	// default. Raised defaults (vs. the original 1m/5m) cut steady-state request
+	// volume; lower them only on a high-limit (App-token) instance.
+	ReviewsFastSeconds  int `yaml:"reviews_fast_seconds" json:"reviewsFastSeconds"`
+	ReviewsSlowSeconds  int `yaml:"reviews_slow_seconds" json:"reviewsSlowSeconds"`
+	IssuesSeconds       int `yaml:"issues_seconds" json:"issuesSeconds"`
+	RenovateFastSeconds int `yaml:"renovate_fast_seconds" json:"renovateFastSeconds"`
+	RenovateSlowSeconds int `yaml:"renovate_slow_seconds" json:"renovateSlowSeconds"`
+	// App configures GitHub App installation-token auth. When enabled, Sybra
+	// mints a short-lived installation token and injects it into the gh
+	// subprocess (GH_TOKEN), raising the REST ceiling to 15k/hr. Unset = fall
+	// back to gh's own auth.
+	App GitHubAppConfig `yaml:"app" json:"app"`
+}
+
+// GitHubAppConfig holds GitHub App installation-token credentials. The private
+// key never leaves disk as plaintext config — only its path is stored.
+type GitHubAppConfig struct {
+	Enabled        bool   `yaml:"enabled" json:"enabled"`
+	AppID          int64  `yaml:"app_id" json:"appId"`
+	InstallationID int64  `yaml:"installation_id" json:"installationId"`
+	PrivateKeyPath string `yaml:"private_key_path" json:"privateKeyPath"`
+}
+
+// PollDefaults exposes the resolved poll intervals (override-or-default) so the
+// poll handlers don't each re-implement the fallback logic.
+const (
+	DefaultReviewsFastSeconds  = 120 // was 60
+	DefaultReviewsSlowSeconds  = 600 // was 300
+	DefaultIssuesSeconds       = 600 // was 300
+	DefaultRenovateFastSeconds = 120 // was 60
+	DefaultRenovateSlowSeconds = 600 // was 300
+)
+
+// RunsSearchPollers reports whether this machine owns the periodic GitHub
+// search pollers. Secondary instances skip them to avoid double-billing a
+// shared token.
+func (c GitHubConfig) RunsSearchPollers() bool {
+	return !strings.EqualFold(strings.TrimSpace(c.PollerRole), "secondary")
+}
+
+func (c GitHubConfig) reviewsFast() time.Duration {
+	return secsOr(c.ReviewsFastSeconds, DefaultReviewsFastSeconds)
+}
+
+func (c GitHubConfig) reviewsSlow() time.Duration {
+	return secsOr(c.ReviewsSlowSeconds, DefaultReviewsSlowSeconds)
+}
+
+// ReviewsFast/ReviewsSlow/Issues/RenovateFast/RenovateSlow return resolved poll
+// intervals (override or raised default).
+func (c GitHubConfig) ReviewsFast() time.Duration { return c.reviewsFast() }
+func (c GitHubConfig) ReviewsSlow() time.Duration { return c.reviewsSlow() }
+func (c GitHubConfig) Issues() time.Duration {
+	return secsOr(c.IssuesSeconds, DefaultIssuesSeconds)
+}
+func (c GitHubConfig) RenovateFast() time.Duration {
+	return secsOr(c.RenovateFastSeconds, DefaultRenovateFastSeconds)
+}
+func (c GitHubConfig) RenovateSlow() time.Duration {
+	return secsOr(c.RenovateSlowSeconds, DefaultRenovateSlowSeconds)
+}
+
+func secsOr(v, def int) time.Duration {
+	if v <= 0 {
+		v = def
+	}
+	return time.Duration(v) * time.Second
 }
 
 // UmbrellaConfig governs auto-expansion of ☂️ umbrella issues by the GitHub

--- a/internal/github/appauth.go
+++ b/internal/github/appauth.go
@@ -142,6 +142,9 @@ func (s *appTokenSource) refresh(ctx context.Context) error {
 // signJWT builds the short-lived App JWT (RS256) used to authenticate the
 // installation-token request. Hand-rolled to avoid a JWT dependency.
 func (s *appTokenSource) signJWT(now time.Time) (string, error) {
+	if s == nil {
+		return "", fmt.Errorf("sign app jwt: app auth is disabled")
+	}
 	header := base64URL([]byte(`{"alg":"RS256","typ":"JWT"}`))
 	// iat backdated 60s to tolerate clock skew; exp capped at 10m (GitHub max).
 	claims := fmt.Sprintf(`{"iat":%d,"exp":%d,"iss":"%d"}`,

--- a/internal/github/appauth.go
+++ b/internal/github/appauth.go
@@ -1,0 +1,229 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+// AppCredentials identifies a GitHub App installation. The private key stays on
+// disk — only its path is held.
+type AppCredentials struct {
+	AppID          int64
+	InstallationID int64
+	PrivateKeyPath string
+}
+
+// appTokenSource mints and caches GitHub App installation tokens. Installation
+// tokens last ~1h; we refresh a few minutes early. A minted token is injected
+// into the gh subprocess via GH_TOKEN, lifting the REST ceiling to 15k/hr
+// without rewriting any call site.
+type appTokenSource struct {
+	creds  AppCredentials
+	key    *rsa.PrivateKey
+	client *http.Client
+
+	mu      sync.RWMutex
+	token   string
+	expires time.Time
+}
+
+const appTokenRenewBefore = 5 * time.Minute
+
+// appAPIBaseURL is the GitHub REST host for minting installation tokens.
+// Overridable in tests.
+var appAPIBaseURL = "https://api.github.com"
+
+// appSource is the package-global token source. nil = App auth disabled, in
+// which case gh uses its own auth and nothing is injected.
+var (
+	appSourceMu sync.RWMutex
+	appSource   *appTokenSource
+)
+
+// EnableAppAuth configures GitHub App installation-token auth. It loads and
+// validates the private key so a misconfiguration fails loudly at startup
+// rather than silently on the first gh call. Pass a zero-value creds (or call
+// DisableAppAuth) to turn it off.
+func EnableAppAuth(creds AppCredentials) error {
+	if creds.AppID == 0 || creds.InstallationID == 0 || creds.PrivateKeyPath == "" {
+		return fmt.Errorf("github app auth: app_id, installation_id and private_key_path are required")
+	}
+	key, err := loadPrivateKey(creds.PrivateKeyPath)
+	if err != nil {
+		return err
+	}
+	src := &appTokenSource{
+		creds:  creds,
+		key:    key,
+		client: &http.Client{Timeout: 15 * time.Second},
+	}
+	appSourceMu.Lock()
+	appSource = src
+	appSourceMu.Unlock()
+	return nil
+}
+
+// DisableAppAuth clears any configured App auth (used by tests and config
+// reload when the App block is removed).
+func DisableAppAuth() {
+	appSourceMu.Lock()
+	appSource = nil
+	appSourceMu.Unlock()
+}
+
+func currentAppSource() *appTokenSource {
+	appSourceMu.RLock()
+	defer appSourceMu.RUnlock()
+	return appSource
+}
+
+// RefreshAppToken mints or renews the installation token if App auth is enabled
+// and the cached token is missing or near expiry. Safe to call on a timer and
+// at startup; a no-op when App auth is disabled.
+func RefreshAppToken(ctx context.Context) error {
+	src := currentAppSource()
+	if src == nil {
+		return nil
+	}
+	return src.refresh(ctx)
+}
+
+// cachedAppToken returns the current installation token, or "" when App auth is
+// disabled or no token has been minted yet. Non-blocking — never performs I/O —
+// so the request gate is never stalled on a token mint.
+func cachedAppToken() string {
+	src := currentAppSource()
+	if src == nil {
+		return ""
+	}
+	src.mu.RLock()
+	defer src.mu.RUnlock()
+	if src.token == "" || time.Now().After(src.expires) {
+		return ""
+	}
+	return src.token
+}
+
+func (s *appTokenSource) refresh(ctx context.Context) error {
+	s.mu.RLock()
+	fresh := s.token != "" && time.Until(s.expires) > appTokenRenewBefore
+	s.mu.RUnlock()
+	if fresh {
+		return nil
+	}
+
+	jwt, err := s.signJWT(time.Now())
+	if err != nil {
+		return err
+	}
+	token, expires, err := s.mintInstallationToken(ctx, jwt)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.token, s.expires = token, expires
+	s.mu.Unlock()
+	return nil
+}
+
+// signJWT builds the short-lived App JWT (RS256) used to authenticate the
+// installation-token request. Hand-rolled to avoid a JWT dependency.
+func (s *appTokenSource) signJWT(now time.Time) (string, error) {
+	header := base64URL([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	// iat backdated 60s to tolerate clock skew; exp capped at 10m (GitHub max).
+	claims := fmt.Sprintf(`{"iat":%d,"exp":%d,"iss":"%d"}`,
+		now.Add(-60*time.Second).Unix(), now.Add(9*time.Minute).Unix(), s.creds.AppID)
+	signingInput := header + "." + base64URL([]byte(claims))
+	digest := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, s.key, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", fmt.Errorf("sign app jwt: %w", err)
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+func (s *appTokenSource) mintInstallationToken(ctx context.Context, jwt string) (string, time.Time, error) {
+	url := fmt.Sprintf("%s/app/installations/%d/access_tokens", appAPIBaseURL, s.creds.InstallationID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(nil))
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("mint installation token: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var body struct {
+		Token     string `json:"token"`
+		ExpiresAt string `json:"expires_at"`
+		Message   string `json:"message"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", time.Time{}, fmt.Errorf("decode installation token: %w", err)
+	}
+	if resp.StatusCode != http.StatusCreated || body.Token == "" {
+		return "", time.Time{}, fmt.Errorf("mint installation token: HTTP %d: %s", resp.StatusCode, body.Message)
+	}
+	expires, err := time.Parse(time.RFC3339, body.ExpiresAt)
+	if err != nil {
+		// Fall back to a conservative 50m lifetime if GitHub omits the field.
+		expires = time.Now().Add(50 * time.Minute)
+	}
+	return body.Token, expires, nil
+}
+
+func loadPrivateKey(path string) (*rsa.PrivateKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read app private key: %w", err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("app private key: no PEM block in %s", path)
+	}
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("app private key: parse %s: %w", path, err)
+	}
+	rsaKey, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("app private key: %s is not an RSA key", path)
+	}
+	return rsaKey, nil
+}
+
+func base64URL(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+// ghEnv returns the environment for a gh subprocess, injecting GH_TOKEN when an
+// App installation token is available. Returns nil to mean "inherit unchanged"
+// so non-App setups keep gh's own auth.
+func ghEnv() []string {
+	token := cachedAppToken()
+	if token == "" {
+		return nil
+	}
+	return append(os.Environ(), "GH_TOKEN="+token)
+}

--- a/internal/github/appauth_test.go
+++ b/internal/github/appauth_test.go
@@ -1,0 +1,145 @@
+package github
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeTestKey(t *testing.T, pkcs8 bool) (string, *rsa.PrivateKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	var der []byte
+	var typ string
+	if pkcs8 {
+		der, err = x509.MarshalPKCS8PrivateKey(key)
+		typ = "PRIVATE KEY"
+	} else {
+		der = x509.MarshalPKCS1PrivateKey(key)
+		typ = "RSA PRIVATE KEY"
+	}
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "key.pem")
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: typ, Bytes: der}), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return path, key
+}
+
+func TestLoadPrivateKey_PKCS1AndPKCS8(t *testing.T) {
+	for _, pkcs8 := range []bool{false, true} {
+		path, _ := writeTestKey(t, pkcs8)
+		if _, err := loadPrivateKey(path); err != nil {
+			t.Fatalf("pkcs8=%v load: %v", pkcs8, err)
+		}
+	}
+}
+
+func TestSignJWT_VerifiableRS256(t *testing.T) {
+	path, key := writeTestKey(t, false)
+	t.Cleanup(DisableAppAuth)
+	if err := EnableAppAuth(AppCredentials{AppID: 42, InstallationID: 7, PrivateKeyPath: path}); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	src := currentAppSource()
+	now := time.Unix(1_700_000_000, 0)
+	tok, err := src.signJWT(now)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	parts := strings.Split(tok, ".")
+	if len(parts) != 3 {
+		t.Fatalf("jwt has %d parts, want 3", len(parts))
+	}
+	digest := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		t.Fatalf("decode sig: %v", err)
+	}
+	if err := rsa.VerifyPKCS1v15(&key.PublicKey, crypto.SHA256, digest[:], sig); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	claims, _ := base64.RawURLEncoding.DecodeString(parts[1])
+	var c struct {
+		Iss string `json:"iss"`
+		Exp int64  `json:"exp"`
+	}
+	if err := json.Unmarshal(claims, &c); err != nil {
+		t.Fatalf("claims: %v", err)
+	}
+	if c.Iss != "42" {
+		t.Fatalf("iss = %q, want 42", c.Iss)
+	}
+}
+
+func TestRefreshAppToken_MintsAndInjectsEnv(t *testing.T) {
+	path, _ := writeTestKey(t, false)
+	t.Cleanup(DisableAppAuth)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ") {
+			t.Errorf("missing bearer jwt")
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"token":"ghs_installationtoken","expires_at":"` +
+			time.Now().Add(time.Hour).UTC().Format(time.RFC3339) + `"}`))
+	}))
+	defer srv.Close()
+	origBase := appAPIBaseURL
+	appAPIBaseURL = srv.URL
+	t.Cleanup(func() { appAPIBaseURL = origBase })
+
+	if err := EnableAppAuth(AppCredentials{AppID: 42, InstallationID: 7, PrivateKeyPath: path}); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	if cachedAppToken() != "" {
+		t.Fatal("expected no token before refresh")
+	}
+	if err := RefreshAppToken(context.Background()); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	if got := cachedAppToken(); got != "ghs_installationtoken" {
+		t.Fatalf("cached token = %q", got)
+	}
+	env := ghEnv()
+	var found bool
+	for _, kv := range env {
+		if kv == "GH_TOKEN=ghs_installationtoken" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("GH_TOKEN not injected into gh env")
+	}
+
+	// Disabled source injects nothing.
+	DisableAppAuth()
+	if ghEnv() != nil {
+		t.Fatal("expected nil env when app auth disabled")
+	}
+}
+
+func TestEnableAppAuth_RequiresAllFields(t *testing.T) {
+	t.Cleanup(DisableAppAuth)
+	if err := EnableAppAuth(AppCredentials{AppID: 1}); err == nil {
+		t.Fatal("expected error for incomplete credentials")
+	}
+}

--- a/internal/github/budget.go
+++ b/internal/github/budget.go
@@ -1,0 +1,79 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// rateLimitResponse mirrors the GET /rate_limit body. The endpoint is free —
+// it never counts against any quota — so polling it cheaply keeps the request
+// gate's budget view accurate for every gh path, including the `gh pr view` /
+// `gh issue` subcommands whose response headers the gate can't observe.
+type rateLimitResponse struct {
+	Resources map[string]struct {
+		Limit     int   `json:"limit"`
+		Remaining int   `json:"remaining"`
+		Reset     int64 `json:"reset"`
+	} `json:"resources"`
+}
+
+// RefreshRateBudget queries GET /rate_limit and feeds every resource bucket
+// into the shared request gate. Safe to call on a timer; the endpoint is
+// exempt from rate limiting.
+func RefreshRateBudget(ctx context.Context) error {
+	return refreshRateBudgetWith(ctx, defaultExecer)
+}
+
+func refreshRateBudgetWith(ctx context.Context, e execer) error {
+	// No --cache: a stale budget snapshot defeats the purpose.
+	resp, err := runGHAPICtxWith(ctx, e, "", "rate_limit")
+	if err != nil {
+		return fmt.Errorf("gh api rate_limit: %s: %w", sanitizeGHOutput(resp.body), err)
+	}
+	var parsed rateLimitResponse
+	if err := json.Unmarshal(resp.body, &parsed); err != nil {
+		return fmt.Errorf("parse rate_limit: %w", err)
+	}
+	for name, r := range parsed.Resources {
+		var resetAt time.Time
+		if r.Reset > 0 {
+			resetAt = time.Unix(r.Reset, 0)
+		}
+		ghGate.setResource(name, r.Remaining, r.Limit, resetAt)
+	}
+	return nil
+}
+
+// BudgetPressureFactor returns a multiplier (>= 1) to stretch poll intervals
+// when the GitHub rate budget runs low. It is 1 when budget is healthy or
+// unknown, scaling up to 4x as the lowest resource bucket approaches
+// exhaustion. Lets every poller back off in concert under a shared, possibly
+// near-exhausted, token without each re-implementing the heuristic.
+func BudgetPressureFactor() float64 {
+	frac, known := ghGate.pressure()
+	if !known {
+		return 1
+	}
+	switch {
+	case frac <= 0.05:
+		return 4
+	case frac <= 0.15:
+		return 2
+	case frac <= 0.30:
+		return 1.5
+	default:
+		return 1
+	}
+}
+
+// ScaleInterval stretches a poll interval by the current budget pressure so all
+// pollers back off together when the shared token runs low.
+func ScaleInterval(d time.Duration) time.Duration {
+	f := BudgetPressureFactor()
+	if f <= 1 {
+		return d
+	}
+	return time.Duration(float64(d) * f)
+}

--- a/internal/github/budget_test.go
+++ b/internal/github/budget_test.go
@@ -1,0 +1,61 @@
+package github
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestRefreshRateBudget_FeedsGateAndScalesIntervals(t *testing.T) {
+	orig := ghGate
+	t.Cleanup(func() { ghGate = orig })
+
+	tests := []struct {
+		name       string
+		body       string
+		wantFactor float64
+	}{
+		{
+			name:       "healthy budget keeps intervals",
+			body:       `{"resources":{"core":{"limit":5000,"remaining":4800,"reset":0},"search":{"limit":30,"remaining":29,"reset":0}}}`,
+			wantFactor: 1,
+		},
+		{
+			name:       "low search budget stretches intervals",
+			body:       `{"resources":{"core":{"limit":5000,"remaining":4800,"reset":0},"search":{"limit":30,"remaining":1,"reset":0}}}`,
+			wantFactor: 4,
+		},
+		{
+			name:       "moderate pressure scales 2x",
+			body:       `{"resources":{"core":{"limit":5000,"remaining":500,"reset":0}}}`,
+			wantFactor: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ghGate = newGHRequestGate()
+			e := &fakeExecer{output: []byte(tt.body)}
+			if err := refreshRateBudgetWith(context.Background(), e); err != nil {
+				t.Fatalf("refresh: %v", err)
+			}
+			if got := BudgetPressureFactor(); got != tt.wantFactor {
+				t.Fatalf("factor = %v, want %v", got, tt.wantFactor)
+			}
+			base := 5 * time.Minute
+			want := time.Duration(float64(base) * tt.wantFactor)
+			if got := ScaleInterval(base); got != want {
+				t.Fatalf("ScaleInterval = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestBudgetPressureFactor_UnknownIsNeutral(t *testing.T) {
+	orig := ghGate
+	t.Cleanup(func() { ghGate = orig })
+	ghGate = newGHRequestGate()
+	if got := BudgetPressureFactor(); got != 1 {
+		t.Fatalf("unknown budget factor = %v, want 1", got)
+	}
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -212,6 +212,7 @@ type gqlPR struct {
 	Number         int    `json:"number"`
 	Title          string `json:"title"`
 	URL            string `json:"url"`
+	State          string `json:"state"`
 	HeadRefName    string `json:"headRefName"`
 	IsDraft        bool   `json:"isDraft"`
 	Mergeable      string `json:"mergeable"`

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -23,6 +23,9 @@ type ghExecer struct{}
 func (ghExecer) run(args ...string) ([]byte, error) {
 	return ghGate.execute(func() ([]byte, error) {
 		cmd := exec.Command("gh", args...)
+		if env := ghEnv(); env != nil {
+			cmd.Env = env
+		}
 		return cmd.CombinedOutput()
 	})
 }
@@ -33,6 +36,9 @@ func (ghExecer) run(args ...string) ([]byte, error) {
 func ghRunCtx(ctx context.Context, args ...string) ([]byte, error) {
 	return ghGate.execute(func() ([]byte, error) {
 		cmd := exec.CommandContext(ctx, "gh", args...)
+		if env := ghEnv(); env != nil {
+			cmd.Env = env
+		}
 		return cmd.CombinedOutput()
 	})
 }

--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -223,35 +223,65 @@ func fetchLabeledIssuesForReposWith(e execer, repos []string, label string) ([]I
 	if len(repos) == 0 {
 		return nil, nil
 	}
-	parts := make([]string, len(repos))
-	for i, r := range repos {
-		parts[i] = "repo:" + r
-	}
-	query := fmt.Sprintf("is:issue is:open label:%s %s sort:updated-desc", label, strings.Join(parts, " "))
+	// Cache against the full repo set; the per-chunk searches below are an
+	// implementation detail callers shouldn't see.
+	cacheKey := "label:" + label + "||" + strings.Join(repos, ",")
 	if runtimeCacheEnabled(e) {
-		if cached, ok := labeledIssuesCache.Get(query); ok {
+		if cached, ok := labeledIssuesCache.Get(cacheKey); ok {
 			return cached, nil
 		}
 		if ghGate.shouldSkipOptional("graphql") {
-			if stale, ok := labeledIssuesCache.GetStale(query); ok {
+			if stale, ok := labeledIssuesCache.GetStale(cacheKey); ok {
 				return stale, nil
 			}
 		}
 	}
 
-	issues, err := searchIssuesWith(e, query)
+	issues, err := searchLabeledChunked(e, repos, label)
 	if err != nil {
 		if runtimeCacheEnabled(e) {
-			if stale, ok := labeledIssuesCache.GetStale(query); ok {
+			if stale, ok := labeledIssuesCache.GetStale(cacheKey); ok {
 				return stale, nil
 			}
 		}
 		return nil, err
 	}
 	if runtimeCacheEnabled(e) {
-		labeledIssuesCache.Set(query, issues, 30*time.Second)
+		labeledIssuesCache.Set(cacheKey, issues, 30*time.Second)
 	}
 	return issues, nil
+}
+
+// labeledRepoQuery builds the labeled-issue search query for one repo chunk.
+func labeledRepoQuery(repos []string, label string) string {
+	parts := make([]string, len(repos))
+	for i, r := range repos {
+		parts[i] = "repo:" + r
+	}
+	return fmt.Sprintf("is:issue is:open label:%s %s sort:updated-desc", label, strings.Join(parts, " "))
+}
+
+// searchLabeledChunked runs the labeled-issue search in repo chunks so the
+// query string can't grow unbounded (GitHub rejects/truncates oversized search
+// queries with many repo: qualifiers), then dedupes by URL.
+func searchLabeledChunked(e execer, repos []string, label string) ([]Issue, error) {
+	seen := make(map[string]struct{})
+	var all []Issue
+	for start := 0; start < len(repos); start += issueSearchChunkSize {
+		end := min(start+issueSearchChunkSize, len(repos))
+		issues, err := searchIssuesWith(e, labeledRepoQuery(repos[start:end], label))
+		if err != nil {
+			return nil, err
+		}
+		for i := range issues {
+			if _, dup := seen[issues[i].URL]; dup {
+				continue
+			}
+			seen[issues[i].URL] = struct{}{}
+			all = append(all, issues[i])
+		}
+	}
+	return all, nil
 }
 
 func searchIssuesWith(e execer, query string) ([]Issue, error) {
@@ -273,7 +303,14 @@ func searchIssuesWith(e execer, query string) ([]Issue, error) {
 	return convertIssues(gqlResp.Data.Search.Nodes), nil
 }
 
-// FetchIssueSnapshot returns assigned issues and labeled issues in one GraphQL call.
+// issueSearchChunkSize bounds how many repo: qualifiers go into one labeled
+// search query, so a large project set can't produce an oversized query that
+// GitHub rejects or silently truncates.
+const issueSearchChunkSize = 15
+
+// FetchIssueSnapshot returns assigned issues and labeled issues. The first repo
+// chunk's labeled search rides the same GraphQL request as the assigned search;
+// extra chunks are fetched as labeled-only searches and merged.
 func FetchIssueSnapshot(repos []string, label string) (IssueSnapshot, error) {
 	return fetchIssueSnapshotWith(defaultExecer, repos, label)
 }
@@ -289,19 +326,22 @@ func fetchIssueSnapshotWith(e execer, repos []string, label string) (IssueSnapsh
 		return snapshot, nil
 	}
 
-	labeledParts := make([]string, len(repos))
-	for i, repo := range repos {
-		labeledParts[i] = "repo:" + repo
-	}
+	// The combined assigned+labeled request only carries the first repo chunk's
+	// labeled qualifiers, so the query can't grow unbounded with many projects.
+	// Any remaining chunks are fetched as labeled-only searches below and merged.
+	firstChunkEnd := min(issueSearchChunkSize, len(repos))
 	assignedQuery := "is:issue is:open assignee:@me sort:updated-desc"
-	labeledQuery := fmt.Sprintf("is:issue is:open label:%s %s sort:updated-desc", label, strings.Join(labeledParts, " "))
+	labeledQuery := labeledRepoQuery(repos[:firstChunkEnd], label)
+	// Cache labeled results against the full repo set, not just the first
+	// chunk, so the stale-fallback returns the complete labeled list.
+	labeledCacheKey := "label:" + label + "||" + strings.Join(repos, ",")
 
 	if runtimeCacheEnabled(e) {
 		if ghGate.shouldSkipOptional("graphql") {
 			if assigned, ok := assignedIssuesCache.GetStale(assignedQuery); ok {
 				snapshot.Assigned = assigned
 			}
-			if labeled, ok := labeledIssuesCache.GetStale(labeledQuery); ok {
+			if labeled, ok := labeledIssuesCache.GetStale(labeledCacheKey); ok {
 				snapshot.Labeled = labeled
 			}
 			if snapshot.Assigned != nil || snapshot.Labeled != nil {
@@ -319,7 +359,7 @@ func fetchIssueSnapshotWith(e execer, repos []string, label string) (IssueSnapsh
 			if assigned, ok := assignedIssuesCache.GetStale(assignedQuery); ok {
 				snapshot.Assigned = assigned
 			}
-			if labeled, ok := labeledIssuesCache.GetStale(labeledQuery); ok {
+			if labeled, ok := labeledIssuesCache.GetStale(labeledCacheKey); ok {
 				snapshot.Labeled = labeled
 			}
 			if snapshot.Assigned != nil || snapshot.Labeled != nil {
@@ -339,9 +379,28 @@ func fetchIssueSnapshotWith(e execer, repos []string, label string) (IssueSnapsh
 
 	snapshot.Assigned = convertIssues(gqlResp.Data.Assigned.Nodes)
 	snapshot.Labeled = convertIssues(gqlResp.Data.Labeled.Nodes)
+
+	// Merge labeled issues from any repo chunks beyond the first (fetched as
+	// standalone labeled-only searches to keep each query bounded).
+	if len(repos) > firstChunkEnd {
+		rest, err := searchLabeledChunked(e, repos[firstChunkEnd:], label)
+		if err != nil {
+			return snapshot, fmt.Errorf("fetch labeled issues (chunked): %w", err)
+		}
+		seen := make(map[string]struct{}, len(snapshot.Labeled))
+		for i := range snapshot.Labeled {
+			seen[snapshot.Labeled[i].URL] = struct{}{}
+		}
+		for i := range rest {
+			if _, dup := seen[rest[i].URL]; !dup {
+				snapshot.Labeled = append(snapshot.Labeled, rest[i])
+			}
+		}
+	}
+
 	if runtimeCacheEnabled(e) {
 		assignedIssuesCache.Set(assignedQuery, snapshot.Assigned, 30*time.Second)
-		labeledIssuesCache.Set(labeledQuery, snapshot.Labeled, 30*time.Second)
+		labeledIssuesCache.Set(labeledCacheKey, snapshot.Labeled, 30*time.Second)
 	}
 	return snapshot, nil
 }

--- a/internal/github/issues_chunk_test.go
+++ b/internal/github/issues_chunk_test.go
@@ -1,0 +1,79 @@
+package github
+
+import (
+	"strings"
+	"testing"
+)
+
+// chunkExecer returns a snapshot body for the combined assigned+labeled query
+// and a search body for each labeled-only chunk, recording every query string.
+type chunkExecer struct {
+	queries []string
+}
+
+func (c *chunkExecer) run(args ...string) ([]byte, error) {
+	var q string
+	combined := false
+	for i, a := range args {
+		if strings.HasPrefix(a, "labeledQ=") || strings.HasPrefix(a, "assignedQ=") {
+			combined = true
+		}
+		if a == "-f" && i+1 < len(args) {
+			if v, ok := strings.CutPrefix(args[i+1], "q="); ok {
+				q = v
+			}
+		}
+		if v, ok := strings.CutPrefix(a, "labeledQ="); ok {
+			q = v
+		}
+	}
+	c.queries = append(c.queries, q)
+	if combined {
+		// assigned empty; labeled has one issue from the first chunk.
+		return []byte(`{"data":{"assigned":{"nodes":[]},"labeled":{"nodes":[` +
+			issueNode("https://github.com/o/r0/issues/1") + `]}}}`), nil
+	}
+	// Each labeled-only chunk returns one distinct issue.
+	return []byte(`{"data":{"search":{"nodes":[` +
+		issueNode("https://github.com/o/chunk/issues/"+itoaLen(c.queries)) + `]}}}`), nil
+}
+
+func issueNode(url string) string {
+	return `{"number":1,"title":"t","url":"` + url + `","labels":{"nodes":[{"name":"sybra"}]}}`
+}
+
+func itoaLen(s []string) string {
+	return string(rune('0' + len(s)))
+}
+
+func TestFetchIssueSnapshot_ChunksLabeledRepos(t *testing.T) {
+	repos := make([]string, 32) // > 2 chunks of 15
+	for i := range repos {
+		repos[i] = "o/r" + string(rune('a'+i))
+	}
+	ce := &chunkExecer{}
+	snap, err := fetchIssueSnapshotWith(ce, repos, "sybra")
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	// 32 repos: combined(15) + labeled chunks for repos[15:32] => 15 + 2 = 2 calls.
+	// Total gh calls = 1 combined + 2 labeled = 3.
+	if len(ce.queries) != 3 {
+		t.Fatalf("gh calls = %d, want 3 (1 combined + 2 labeled chunks)", len(ce.queries))
+	}
+	// First combined query must carry only the first 15 repo qualifiers.
+	if got := strings.Count(ce.queries[0], "repo:"); got != 15 {
+		t.Fatalf("combined query repo count = %d, want 15", got)
+	}
+	// Labeled chunks cover the remaining 17 repos (15 + 2).
+	if got := strings.Count(ce.queries[1], "repo:"); got != 15 {
+		t.Fatalf("chunk 2 repo count = %d, want 15", got)
+	}
+	if got := strings.Count(ce.queries[2], "repo:"); got != 2 {
+		t.Fatalf("chunk 3 repo count = %d, want 2", got)
+	}
+	// Labeled results merged across chunks (1 from combined + 2 from chunks).
+	if len(snap.Labeled) != 3 {
+		t.Fatalf("merged labeled = %d, want 3", len(snap.Labeled))
+	}
+}

--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -68,6 +68,61 @@ const reviewSummaryQuery = `query($q: String!) {
   }
 }`
 
+const prForMonitorQuery = `query($owner: String!, $name: String!, $number: Int!) {
+  viewer { login }
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      number
+      title
+      url
+      state
+      headRefName
+      isDraft
+      mergeable
+      createdAt
+      updatedAt
+      reviewDecision
+      author { login type: __typename }
+      repository { name nameWithOwner }
+      labels(first: 5) { nodes { name } }
+      commits(last: 1) {
+        nodes {
+          commit {
+            oid
+            statusCheckRollup {
+              state
+              contexts(first: 20) {
+                nodes {
+                  __typename
+                  ... on CheckRun {
+                    name
+                    status
+                    conclusion
+                  }
+                  ... on StatusContext {
+                    name: context
+                    state
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          comments(last: 1) { nodes { author { login } } }
+        }
+      }
+      latestReviews(first: 10) {
+        nodes { state author { login } }
+      }
+    }
+  }
+}`
+
 type gqlReviewSummaryResponse struct {
 	Data struct {
 		Viewer struct {
@@ -82,9 +137,62 @@ type gqlReviewSummaryResponse struct {
 	} `json:"errors"`
 }
 
+type gqlPRForMonitorResponse struct {
+	Data struct {
+		Viewer struct {
+			Login string `json:"login"`
+		} `json:"viewer"`
+		Repository struct {
+			PullRequest *gqlPR `json:"pullRequest"`
+		} `json:"repository"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
 // FetchReviews returns open PRs created by the user and review requests, excluding bots.
 func FetchReviews() (ReviewSummary, error) {
 	return fetchReviewsWith(defaultExecer)
+}
+
+// FetchPRForMonitor fetches one PR with the same signals used by FetchReviews,
+// but without a GitHub search query. The bool reports whether the PR is still
+// open; closed/merged PRs are left to FetchPRState-based reconciliation.
+func FetchPRForMonitor(repo string, number int) (PullRequest, bool, error) {
+	return fetchPRForMonitorWith(defaultExecer, repo, number)
+}
+
+func fetchPRForMonitorWith(e execer, repo string, number int) (PullRequest, bool, error) {
+	owner, name, ok := strings.Cut(repo, "/")
+	if !ok || owner == "" || name == "" || number <= 0 {
+		return PullRequest{}, false, fmt.Errorf("invalid repo or PR: %s#%d", repo, number)
+	}
+
+	resp, err := runGHAPIWith(e, "", "graphql",
+		"-f", "query="+prForMonitorQuery,
+		"-f", "owner="+owner,
+		"-f", "name="+name,
+		"-F", "number="+strconv.Itoa(number))
+	if err != nil {
+		return PullRequest{}, false, fmt.Errorf("gh api graphql pr %s#%d: %s: %w", repo, number, sanitizeGHOutput(resp.body), err)
+	}
+
+	var gqlResp gqlPRForMonitorResponse
+	if err := json.Unmarshal(resp.body, &gqlResp); err != nil {
+		return PullRequest{}, false, fmt.Errorf("parse graphql pr response: %w", err)
+	}
+	if len(gqlResp.Errors) > 0 {
+		return PullRequest{}, false, fmt.Errorf("graphql pr %s#%d: %s", repo, number, gqlResp.Errors[0].Message)
+	}
+	if gqlResp.Data.Repository.PullRequest == nil {
+		return PullRequest{}, false, nil
+	}
+	pr := gqlResp.Data.Repository.PullRequest
+	if pr.State != "OPEN" {
+		return PullRequest{}, false, nil
+	}
+	return convertCommonPR(pr, gqlResp.Data.Viewer.Login), true, nil
 }
 
 func fetchReviewsWith(e execer) (ReviewSummary, error) {

--- a/internal/github/runtime.go
+++ b/internal/github/runtime.go
@@ -181,6 +181,7 @@ func parseGHHTTPResponse(out []byte) ghHTTPResponse {
 
 type ghRateWindow struct {
 	remaining int
+	limit     int
 	resetAt   time.Time
 }
 
@@ -236,6 +237,11 @@ func (g *ghRequestGate) observe(resp ghHTTPResponse, err error) {
 				window.remaining = n
 			}
 		}
+		if limit, ok := resp.headers["x-ratelimit-limit"]; ok {
+			if n, convErr := strconv.Atoi(strings.TrimSpace(limit)); convErr == nil {
+				window.limit = n
+			}
+		}
 		if reset, ok := resp.headers["x-ratelimit-reset"]; ok {
 			if ts, convErr := strconv.ParseInt(strings.TrimSpace(reset), 10, 64); convErr == nil && ts > 0 {
 				window.resetAt = time.Unix(ts, 0)
@@ -274,6 +280,43 @@ func (g *ghRequestGate) bumpLocked(until time.Time) {
 	if until.After(g.notBefore) {
 		g.notBefore = until
 	}
+}
+
+// setResource records a rate-limit window for a resource bucket. Used by the
+// /rate_limit refresher to give the gate budget visibility for every gh path,
+// not only `gh api --include` calls whose response headers it can observe.
+func (g *ghRequestGate) setResource(resource string, remaining, limit int, resetAt time.Time) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.resources[strings.ToLower(strings.TrimSpace(resource))] = ghRateWindow{
+		remaining: remaining,
+		limit:     limit,
+		resetAt:   resetAt,
+	}
+}
+
+// lowestBudgetFraction returns the smallest remaining/limit ratio across the
+// known resource buckets, plus whether any bucket is known. Used to scale poll
+// intervals globally when budget runs low. A bucket with no recorded limit is
+// skipped.
+func (g *ghRequestGate) pressure() (fraction float64, known bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if time.Until(g.notBefore) > 0 {
+		return 0, true
+	}
+	minFrac := 1.0
+	for _, w := range g.resources {
+		if w.remaining < 0 || w.limit <= 0 {
+			continue
+		}
+		f := float64(w.remaining) / float64(w.limit)
+		if f < minFrac {
+			minFrac = f
+		}
+		known = true
+	}
+	return minFrac, known
 }
 
 func isRateLimitedMessage(msg string) bool {

--- a/internal/poll/issues.go
+++ b/internal/poll/issues.go
@@ -41,6 +41,22 @@ type IssuesFetcher struct {
 	// after an expansion failure, so a broken umbrella does not re-run the
 	// planner every poll.
 	umbrellaCooldown map[string]time.Time
+	// pollInterval overrides IssuesPollInterval when > 0 (set from config).
+	pollInterval time.Duration
+}
+
+// SetPollInterval overrides the fixed issues poll cadence. Zero keeps the
+// package default.
+func (f *IssuesFetcher) SetPollInterval(d time.Duration) {
+	f.pollInterval = d
+}
+
+func (f *IssuesFetcher) interval() time.Duration {
+	base := f.pollInterval
+	if base <= 0 {
+		base = IssuesPollInterval
+	}
+	return github.ScaleInterval(base)
 }
 
 // umbrellaRetryCooldown is how long to wait before re-attempting an umbrella
@@ -87,7 +103,7 @@ func (f *IssuesFetcher) Name() string { return "issues" }
 func (f *IssuesFetcher) Poll(_ context.Context) time.Duration {
 	if f.fetchSnapshot != nil {
 		f.pollSnapshot()
-		return IssuesPollInterval
+		return f.interval()
 	}
 
 	issues, err := f.fetchAssigned()
@@ -104,7 +120,7 @@ func (f *IssuesFetcher) Poll(_ context.Context) time.Duration {
 			f.transientFetchFails = 0
 			f.logger.Warn("issues.fetch", "err", err)
 		}
-		return IssuesPollInterval
+		return f.interval()
 	}
 	f.transientFetchFails = 0
 	f.emit("issues:updated", issues)
@@ -112,7 +128,7 @@ func (f *IssuesFetcher) Poll(_ context.Context) time.Duration {
 	metrics.GitHubIssuesImported(len(issues))
 	f.syncIssuesToTasks(issues)
 	f.syncLabeledIssuesToTasks()
-	return IssuesPollInterval
+	return f.interval()
 }
 
 func (f *IssuesFetcher) pollSnapshot() {

--- a/internal/poll/renovate.go
+++ b/internal/poll/renovate.go
@@ -29,6 +29,26 @@ type RenovateHandler struct {
 	allowsType          func(project.ProjectType) bool
 	lastPRsCount        atomic.Int64
 	transientFetchFails int
+	// fast/slow are the resolved poll intervals (override-or-default). Zero
+	// falls back to the package constants.
+	fast time.Duration
+	slow time.Duration
+}
+
+func (h *RenovateHandler) fastInterval() time.Duration {
+	base := h.fast
+	if base <= 0 {
+		base = RenovatePollFast
+	}
+	return github.ScaleInterval(base)
+}
+
+func (h *RenovateHandler) slowInterval() time.Duration {
+	base := h.slow
+	if base <= 0 {
+		base = RenovatePollSlow
+	}
+	return github.ScaleInterval(base)
 }
 
 // NewRenovateHandler creates a RenovateHandler. allowsType filters which
@@ -50,6 +70,12 @@ func NewRenovateHandler(
 		cfg:        cfg,
 		allowsType: allowsType,
 	}
+}
+
+// SetIntervals overrides the fast/slow poll cadence. Zero values keep the
+// package defaults. Called at wiring time from the resolved github config.
+func (h *RenovateHandler) SetIntervals(fast, slow time.Duration) {
+	h.fast, h.slow = fast, slow
 }
 
 // Repos returns owner/repo strings for registered projects whose type is
@@ -85,7 +111,7 @@ func (h *RenovateHandler) LastFetchedCount() int64 {
 func (h *RenovateHandler) pollRenovatePRs() time.Duration {
 	repos := h.Repos()
 	if len(repos) == 0 {
-		return RenovatePollSlow
+		return h.slowInterval()
 	}
 
 	prs, err := github.FetchRenovatePRs(h.cfg.Author, repos)
@@ -102,7 +128,7 @@ func (h *RenovateHandler) pollRenovatePRs() time.Duration {
 			h.transientFetchFails = 0
 			h.logger.Warn("renovate.fetch", "err", err)
 		}
-		return RenovatePollSlow
+		return h.slowInterval()
 	}
 	h.transientFetchFails = 0
 
@@ -112,8 +138,8 @@ func (h *RenovateHandler) pollRenovatePRs() time.Duration {
 
 	for i := range prs {
 		if prs[i].CIStatus == "PENDING" || prs[i].CIStatus == "FAILURE" {
-			return RenovatePollFast
+			return h.fastInterval()
 		}
 	}
-	return RenovatePollSlow
+	return h.slowInterval()
 }

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -120,6 +120,7 @@ func (a *App) initIssuesFetcher(emit func(string, any)) *poll.IssuesFetcher {
 		return nil
 	}
 	f := poll.NewIssuesFetcher(a.tasks, a.projects, emit, a.logger, a.allowsProjectType)
+	f.SetPollInterval(a.cfg.GitHub.Issues())
 	if a.cfg.Umbrella.Enabled {
 		model := a.cfg.Umbrella.Model
 		f.SetUmbrellaExpander(func(issueURL string) (umbrella.Result, error) {

--- a/internal/sybra/app_renovate.go
+++ b/internal/sybra/app_renovate.go
@@ -10,6 +10,7 @@ func (a *App) initRenovate(emit func(string, any)) {
 		return
 	}
 	a.renovateHandler = poll.NewRenovateHandler(a.projects, a.logger, emit, &a.cfg.Renovate, a.allowsProjectType)
+	a.renovateHandler.SetIntervals(a.cfg.GitHub.RenovateFast(), a.cfg.GitHub.RenovateSlow())
 	a.logger.Info("renovate.enabled", "author", a.cfg.Renovate.Author)
 }
 

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -24,11 +24,6 @@ import (
 )
 
 const (
-	prPollFast = 1 * time.Minute
-	prPollSlow = 5 * time.Minute
-)
-
-const (
 	reviewSmallAdditions = 40
 	reviewSmallFiles     = 5
 )
@@ -89,6 +84,23 @@ func (r *ReviewHandler) agentLogin() string {
 	return github.ViewerLogin()
 }
 
+// pollFast/pollSlow resolve the review poll cadence from config (github.*),
+// falling back to the raised defaults, then scaled by GitHub budget pressure.
+// nil cfg (test construction) uses defaults too.
+func (r *ReviewHandler) pollFast() time.Duration {
+	if r.cfg == nil {
+		return github.ScaleInterval(config.DefaultReviewsFastSeconds * time.Second)
+	}
+	return github.ScaleInterval(r.cfg.GitHub.ReviewsFast())
+}
+
+func (r *ReviewHandler) pollSlow() time.Duration {
+	if r.cfg == nil {
+		return github.ScaleInterval(config.DefaultReviewsSlowSeconds * time.Second)
+	}
+	return github.ScaleInterval(r.cfg.GitHub.ReviewsSlow())
+}
+
 func newReviewHandler(
 	tasks *task.Manager,
 	projects *project.Store,
@@ -130,7 +142,7 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 	// when FetchReviews fails (transient errors, rate limits, etc.).
 	tasks, err := r.tasks.List()
 	if err != nil {
-		return prPollSlow
+		return r.pollSlow()
 	}
 
 	fetchFn := github.FetchReviews
@@ -154,7 +166,7 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 			r.transientFetchFails = 0
 			r.logger.Warn("pr-monitor.fetch", "err", fetchErr)
 		}
-		return prPollSlow
+		return r.pollSlow()
 	}
 	r.transientFetchFails = 0
 
@@ -242,9 +254,9 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 	r.closeFinishedReviewTasks(tasks, openReviewPRs(summary))
 
 	if prNeedsAttention(monitoredPRs) {
-		return prPollFast
+		return r.pollFast()
 	}
-	return prPollSlow
+	return r.pollSlow()
 }
 
 // advanceClosedTaskPRs moves tasks whose linked PR is no longer open to done,

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -61,6 +61,10 @@ type ReviewHandler struct {
 	// review-task's PR is still open. Overridable in tests; nil falls back to
 	// github.FetchPRState.
 	fetchPRStateFn func(repo string, number int) (github.PRState, error)
+	// fetchKnownPRFn fetches one linked PR without using a GitHub search leg.
+	// Secondary pollers use this to keep local task PRs moving while leaving
+	// global search polling to the primary instance.
+	fetchKnownPRFn func(repo string, number int) (github.PullRequest, bool, error)
 	// fetchReviewsFn fetches the PR review summary. Overridable in tests; nil
 	// falls back to github.FetchReviews.
 	fetchReviewsFn func() (github.ReviewSummary, error)
@@ -134,7 +138,60 @@ func newReviewHandler(
 func (r *ReviewHandler) Name() string { return "reviews" }
 
 func (r *ReviewHandler) Poll(_ context.Context) time.Duration {
+	if r.cfg != nil && !r.cfg.GitHub.RunsSearchPollers() {
+		return r.pollKnownTaskPRs()
+	}
 	return r.pollAndMonitorPRs()
+}
+
+func (r *ReviewHandler) pollKnownTaskPRs() time.Duration {
+	tasks, err := r.tasks.List()
+	if err != nil {
+		return r.pollSlow()
+	}
+
+	var (
+		matchers       []github.TaskMatcher
+		closedMatchers []github.TaskMatcher
+	)
+	for i := range tasks {
+		m := github.TaskMatcher{
+			ID:        tasks[i].ID,
+			PRNumber:  tasks[i].PRNumber,
+			Branch:    tasks[i].Branch,
+			ProjectID: tasks[i].ProjectID,
+		}
+		if prMonitorEligible(&tasks[i]) {
+			matchers = append(matchers, m)
+			closedMatchers = append(closedMatchers, m)
+		} else if prClosedEligible(&tasks[i]) {
+			closedMatchers = append(closedMatchers, m)
+		}
+	}
+
+	monitoredPRs := r.fetchKnownTaskPRs(matchers)
+	if len(matchers) > 0 {
+		issues := github.MatchTaskPRs(monitoredPRs, matchers)
+		if r.prTracker != nil {
+			r.prTracker.Cleanup()
+		}
+		r.cancelResolvedPRFixWorkflows(tasks, issues)
+		r.handleMatchedPRIssues(issues)
+	}
+
+	if len(closedMatchers) > 0 {
+		r.advanceClosedTaskPRs(monitoredPRs, closedMatchers)
+	}
+
+	r.scanForReverts(tasks)
+	r.resolveAddressedCopilotThreads(tasks, monitoredPRs)
+	r.reconcilePRPhases(tasks, monitoredPRs)
+	r.closeFinishedReviewTasks(tasks, nil)
+
+	if prNeedsAttention(monitoredPRs) {
+		return r.pollFast()
+	}
+	return r.pollSlow()
 }
 
 func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
@@ -204,42 +261,11 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 
 	if len(matchers) > 0 {
 		issues := github.MatchTaskPRs(monitoredPRs, matchers)
-		r.prTracker.Cleanup()
-		r.cancelResolvedPRFixWorkflows(tasks, issues)
-
-		for i := range issues {
-			if r.agents.HasRunningAgentForTask(issues[i].TaskID) {
-				continue
-			}
-			// Gate dispatch on workflow state too: an agent may have just
-			// exited while the workflow is still in verify_commits /
-			// link_pr_and_review. Without this, a fresh issue (e.g.
-			// kind=conflict appearing because main moved during the agent
-			// run) races the in-flight workflow's tail steps and triggers
-			// a layered re-dispatch that DispatchEvent later rejects, but
-			// only after we've prepped a worktree and emitted audit
-			// noise.
-			if r.workflowEngine != nil && r.workflowEngine.HasActiveWorkflow(issues[i].TaskID) {
-				continue
-			}
-			// Only the comments kind carries a feedback fingerprint; conflict,
-			// ci_failure, and ready_to_merge fall back to SHA-only gating.
-			var sig string
-			if issues[i].Kind == github.PRIssueComments {
-				sig = issues[i].PR.FeedbackSig
-			}
-			switch r.prTracker.Decide(issues[i].TaskID, issues[i].Kind, issues[i].PR.HeadSHA, sig) {
-			case github.DispatchHandle:
-				if issues[i].Kind == github.PRIssueReadyToMerge {
-					r.handleAutoMerge(issues[i])
-					continue
-				}
-				r.handlePRIssue(issues[i])
-			case github.DispatchExhausted:
-				r.escalateExhaustedFix(issues[i])
-			case github.DispatchSkip:
-			}
+		if r.prTracker != nil {
+			r.prTracker.Cleanup()
 		}
+		r.cancelResolvedPRFixWorkflows(tasks, issues)
+		r.handleMatchedPRIssues(issues)
 	}
 
 	if len(closedMatchers) > 0 {
@@ -259,11 +285,84 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 	return r.pollSlow()
 }
 
+func (r *ReviewHandler) handleMatchedPRIssues(issues []github.PRIssue) {
+	for i := range issues {
+		if r.agents.HasRunningAgentForTask(issues[i].TaskID) {
+			continue
+		}
+		// Gate dispatch on workflow state too: an agent may have just
+		// exited while the workflow is still in verify_commits /
+		// link_pr_and_review. Without this, a fresh issue (e.g.
+		// kind=conflict appearing because main moved during the agent
+		// run) races the in-flight workflow's tail steps and triggers
+		// a layered re-dispatch that DispatchEvent later rejects, but
+		// only after we've prepped a worktree and emitted audit noise.
+		if r.workflowEngine != nil && r.workflowEngine.HasActiveWorkflow(issues[i].TaskID) {
+			continue
+		}
+		// Only the comments kind carries a feedback fingerprint; conflict,
+		// ci_failure, and ready_to_merge fall back to SHA-only gating.
+		var sig string
+		if issues[i].Kind == github.PRIssueComments {
+			sig = issues[i].PR.FeedbackSig
+		}
+		decision := github.DispatchHandle
+		if r.prTracker != nil {
+			decision = r.prTracker.Decide(issues[i].TaskID, issues[i].Kind, issues[i].PR.HeadSHA, sig)
+		}
+		switch decision {
+		case github.DispatchHandle:
+			if issues[i].Kind == github.PRIssueReadyToMerge {
+				r.handleAutoMerge(issues[i])
+				continue
+			}
+			r.handlePRIssue(issues[i])
+		case github.DispatchExhausted:
+			r.escalateExhaustedFix(issues[i])
+		case github.DispatchSkip:
+		}
+	}
+}
+
+func (r *ReviewHandler) fetchKnownTaskPRs(matchers []github.TaskMatcher) []github.PullRequest {
+	fetchFn := github.FetchPRForMonitor
+	if r.fetchKnownPRFn != nil {
+		fetchFn = r.fetchKnownPRFn
+	}
+	prs := make([]github.PullRequest, 0, len(matchers))
+	seen := make(map[string]struct{}, len(matchers))
+	for i := range matchers {
+		m := &matchers[i]
+		if m.ProjectID == "" || m.PRNumber == 0 {
+			continue
+		}
+		key := fmt.Sprintf("%s#%d", m.ProjectID, m.PRNumber)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		pr, open, err := fetchFn(m.ProjectID, m.PRNumber)
+		if err != nil {
+			r.logger.Warn("pr-monitor.known-pr-fetch", "repo", m.ProjectID, "pr", m.PRNumber, "err", err)
+			continue
+		}
+		if !open {
+			continue
+		}
+		prs = append(prs, pr)
+	}
+	return prs
+}
+
 // advanceClosedTaskPRs moves tasks whose linked PR is no longer open to done,
 // stamping the terminal outcome and emitting the audit + task.landed events the
 // evaluation scorecard reads. Skips tasks with a still-running agent.
 func (r *ReviewHandler) advanceClosedTaskPRs(monitoredPRs []github.PullRequest, closedMatchers []github.TaskMatcher) {
-	closedPRs := github.DetectClosedTaskPRs(monitoredPRs, closedMatchers, github.FetchPRState)
+	fetchFn := github.FetchPRState
+	if r.fetchPRStateFn != nil {
+		fetchFn = r.fetchPRStateFn
+	}
+	closedPRs := github.DetectClosedTaskPRs(monitoredPRs, closedMatchers, fetchFn)
 	for _, c := range closedPRs {
 		if r.agents.HasRunningAgentForTask(c.TaskID) {
 			r.logger.Info("pr-monitor.closed-skip-running-agent", "task_id", c.TaskID, "pr", c.PRNumber)

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -1544,3 +1544,115 @@ func TestPollAndMonitorPRs_FetchErrorReconcile(t *testing.T) {
 		})
 	}
 }
+
+func TestPollSecondaryReconcilesKnownTaskPRsWithoutSearch(t *testing.T) {
+	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	openTask, err := tasks.Create("Ready PR", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.Update(openTask.ID, task.Update{
+		Status:    task.Ptr(task.StatusInReview),
+		ProjectID: task.Ptr("o/r"),
+		PRNumber:  task.Ptr(42),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	closedTask, err := tasks.Create("Merged PR", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.Update(closedTask.ID, task.Update{
+		Status:    task.Ptr(task.StatusHumanRequired),
+		ProjectID: task.Ptr("o/r"),
+		PRNumber:  task.Ptr(43),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	tmp := t.TempDir()
+	projects, err := project.NewStore(filepath.Join(tmp, "projects"), filepath.Join(tmp, "clones"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := projects.CreateMeta("https://github.com/o/r", project.ProjectTypePet); err != nil {
+		t.Fatal(err)
+	}
+	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
+
+	fetchReviewsCalled := false
+	knownFetches := 0
+	merged := false
+	r := &ReviewHandler{
+		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler), emit: func(string, any) {}},
+		tasks:         tasks,
+		projects:      projects,
+		agents:        agentMgr,
+		prTracker:     github.NewIssueTracker(0),
+		cfg:           &config.Config{GitHub: config.GitHubConfig{PollerRole: "secondary"}},
+		fetchReviewsFn: func() (github.ReviewSummary, error) {
+			fetchReviewsCalled = true
+			return github.ReviewSummary{}, nil
+		},
+		fetchKnownPRFn: func(repo string, number int) (github.PullRequest, bool, error) {
+			knownFetches++
+			if number != 42 {
+				return github.PullRequest{}, false, nil
+			}
+			return github.PullRequest{
+				Number:          42,
+				Repository:      repo,
+				HeadSHA:         "abc123",
+				Mergeable:       "MERGEABLE",
+				CIStatus:        "SUCCESS",
+				CopilotReviewed: true,
+			}, true, nil
+		},
+		fetchPRStateFn: func(repo string, number int) (github.PRState, error) {
+			if repo != "o/r" {
+				t.Fatalf("repo = %q, want o/r", repo)
+			}
+			switch number {
+			case 42:
+				return github.PRState{State: "OPEN"}, nil
+			case 43:
+				return github.PRState{State: "MERGED"}, nil
+			default:
+				t.Fatalf("unexpected PR number %d", number)
+				return github.PRState{}, nil
+			}
+		},
+		mergePR: func(repo string, number int) error {
+			if repo != "o/r" || number != 42 {
+				t.Fatalf("merge target = %s#%d, want o/r#42", repo, number)
+			}
+			merged = true
+			return nil
+		},
+	}
+
+	r.Poll(t.Context())
+
+	if fetchReviewsCalled {
+		t.Fatal("secondary poller called FetchReviews search path")
+	}
+	if knownFetches != 1 {
+		t.Fatalf("knownFetches = %d, want 1", knownFetches)
+	}
+	if !merged {
+		t.Fatal("secondary poller did not act on ready linked PR")
+	}
+	got, err := tasks.Get(closedTask.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusDone || got.Outcome != "merged" {
+		t.Fatalf("closed linked PR status/outcome = %q/%q, want done/merged", got.Status, got.Outcome)
+	}
+}

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -423,8 +423,10 @@ func (lm *LifecycleManager) startPollHub(ctx context.Context, issuesFetcher *pol
 	if !runSearch {
 		a.logger.Info("github.pollers.secondary", "reason", "poller_role=secondary; skipping reviews/issues/renovate searches")
 	}
-	if runSearch {
+	if a.reviewer != nil {
 		hub.Register(a.reviewer, 10*time.Second)
+	}
+	if runSearch {
 		if issuesFetcher != nil {
 			hub.Register(issuesFetcher, 20*time.Second)
 		}

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/confighot"
 	"github.com/Automaat/sybra/internal/evaluation"
+	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/health"
 	"github.com/Automaat/sybra/internal/logging"
 	"github.com/Automaat/sybra/internal/metrics"
@@ -62,8 +63,79 @@ func (lm *LifecycleManager) StartManagers(ctx context.Context, emit func(string,
 func (lm *LifecycleManager) StartPollers(ctx context.Context, emit func(string, any), issuesFetcher *poll.IssuesFetcher) {
 	a := lm.app
 	a.wg.Go(func() { a.orchestratorLoop(ctx) })
+	lm.startAppAuthLoop(ctx)
+	lm.startRateBudgetLoop(ctx)
 	lm.startPollHub(ctx, issuesFetcher)
 	a.startTodoistLoop(ctx)
+}
+
+// appTokenRefreshInterval is how often the GitHub App installation token is
+// renewed. Tokens last ~1h; refreshing well inside that keeps gh authenticated.
+const appTokenRefreshInterval = 30 * time.Minute
+
+// startAppAuthLoop enables GitHub App installation-token auth (when configured)
+// and keeps the token fresh. With App auth on, every gh call runs against the
+// installation token (15k/hr REST) instead of the personal token. A
+// misconfiguration is logged and leaves gh on its own auth — never fatal.
+func (lm *LifecycleManager) startAppAuthLoop(ctx context.Context) {
+	a := lm.app
+	app := a.cfg.GitHub.App
+	if !app.Enabled {
+		return
+	}
+	if err := github.EnableAppAuth(github.AppCredentials{
+		AppID:          app.AppID,
+		InstallationID: app.InstallationID,
+		PrivateKeyPath: app.PrivateKeyPath,
+	}); err != nil {
+		a.logger.Error("github.app.disabled", "err", err)
+		return
+	}
+	a.logger.Info("github.app.enabled", "app_id", app.AppID, "installation_id", app.InstallationID)
+	a.wg.Go(func() {
+		ticker := time.NewTicker(appTokenRefreshInterval)
+		defer ticker.Stop()
+		for {
+			if err := github.RefreshAppToken(ctx); err != nil {
+				a.logger.Warn("github.app.token.refresh", "err", err)
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	})
+}
+
+// rateBudgetRefreshInterval is how often the free GET /rate_limit endpoint is
+// polled to keep the request gate's budget view current for every gh path.
+const rateBudgetRefreshInterval = 60 * time.Second
+
+// startRateBudgetLoop periodically refreshes the shared GitHub rate-limit
+// budget from the free /rate_limit endpoint, so the request gate and the
+// global poll-interval throttle see accurate remaining quota across all gh
+// subcommands — not only the `gh api --include` calls whose headers it can
+// observe directly.
+func (lm *LifecycleManager) startRateBudgetLoop(ctx context.Context) {
+	a := lm.app
+	if !a.cfg.GitHub.Enabled {
+		return
+	}
+	a.wg.Go(func() {
+		ticker := time.NewTicker(rateBudgetRefreshInterval)
+		defer ticker.Stop()
+		for {
+			if err := github.RefreshRateBudget(ctx); err != nil {
+				a.logger.Debug("github.budget.refresh", "err", err)
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	})
 }
 
 // StartWatchers launches the config-file hot-reload watcher.
@@ -343,12 +415,22 @@ func (lm *LifecycleManager) startEvaluationService(ctx context.Context, emit fun
 func (lm *LifecycleManager) startPollHub(ctx context.Context, issuesFetcher *poll.IssuesFetcher) {
 	a := lm.app
 	hub := poll.NewHub()
-	hub.Register(a.reviewer, 10*time.Second)
-	if issuesFetcher != nil {
-		hub.Register(issuesFetcher, 20*time.Second)
+	// Periodic GitHub search pollers (reviews/issues/renovate) only run on the
+	// primary instance — a "secondary" machine sharing the same token skips them
+	// so the shared rate budget isn't billed twice. Triage is local (no GitHub
+	// search) and always runs.
+	runSearch := a.cfg.GitHub.RunsSearchPollers()
+	if !runSearch {
+		a.logger.Info("github.pollers.secondary", "reason", "poller_role=secondary; skipping reviews/issues/renovate searches")
 	}
-	if a.renovateHandler != nil {
-		hub.Register(a.renovateHandler, 15*time.Second)
+	if runSearch {
+		hub.Register(a.reviewer, 10*time.Second)
+		if issuesFetcher != nil {
+			hub.Register(issuesFetcher, 20*time.Second)
+		}
+		if a.renovateHandler != nil {
+			hub.Register(a.renovateHandler, 15*time.Second)
+		}
 	}
 	if a.triageHandler != nil {
 		hub.Register(a.triageHandler, 30*time.Second)


### PR DESCRIPTION
## Motivation

Sybra was burning through GitHub API rate limits. The dominant cost is the periodic GraphQL search polls (reviews/issues/renovate), made worse when two instances share one token, with no global budget awareness and only a 5k/hr personal-token ceiling. Requests must also stay small — the combined reviews search was already reverted once for timing out at GitHub's edge.

> Changelog: feat(github): reduce gh API request volume

## Implementation information

- **Rate-budget tracking + throttle** — a 60s loop polls the free `GET /rate_limit` endpoint into `ghGate`, so the gate sees budget spent by every gh path (not just `gh api --include`). All pollers stretch up to 4x as the lowest resource bucket nears exhaustion.
- **Configurable poll intervals + raised defaults** — new `github:` config block; reviews 1m/5m → 2m/10m, issues 5m → 10m, renovate 1m/5m → 2m/10m.
- **Cross-machine de-dupe** — `github.poller_role: secondary` skips the shared-token search polls so two instances don't double-bill one token.
- **GitHub App auth** — mints a short-lived installation token (hand-rolled RS256 JWT, no new dependency), refreshes it, and injects via `GH_TOKEN` into the gh subprocess. Lifts the REST ceiling to 15k/hr with no call-site changes; falls back to gh's own auth when unset.
- **Chunked labeled-issue search** — split into repo chunks of 15 so a large project set can't produce an oversized query that GitHub rejects or truncates.

Deliberately **not** done, with reasons:
- Combining the 3 reviews search legs into one request — already times out at GitHub's edge for accounts with many review requests (see `internal/github/review.go`); the reduction is delivered via intervals + throttle + dedupe + App headroom instead.
- A go-github ETag client — ETag 304s are free only against the REST budget, but the load is GraphQL-search dominated (POST, no conditional requests); the live-rate-limiter half is already covered by the budget refresher.

Tests added: budget refresh/throttle, App JWT mint+inject, issue chunking. `go test ./internal/...` and lint are green.

## Supporting documentation

`docs/github-rate-limits.md` — config knobs + step-by-step GitHub App setup (one-time manual GitHub UI steps).