### PR TITLE
feat(evaluation): show A/B uncertainty

### DIFF
--- a/cmd/sybra-cli/evaluation.go
+++ b/cmd/sybra-cli/evaluation.go
@@ -120,9 +120,10 @@ func cmdEvaluationScan(cfg *config.Config, jsonOut bool) int {
 		return fatal(jsonOut, "open stats: %v", err)
 	}
 	svc := evaluation.NewService(evaluation.Deps{
-		Cfg:   cfg.Evaluation,
-		Stats: statsStore,
-		Audit: evaluation.AuditDirReader(cfg.AuditDir()),
+		Cfg:       cfg.Evaluation,
+		ABTesting: cfg.ABTesting,
+		Stats:     statsStore,
+		Audit:     evaluation.AuditDirReader(cfg.AuditDir()),
 	})
 	report, err := svc.Scan(context.Background())
 	if err != nil {

--- a/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/index.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/index.ts
@@ -4,10 +4,13 @@
 export {
     Breakdown,
     ComparisonBreakdown,
+    ExperimentSampleStatus,
     PhaseReport,
     PhaseStat,
+    RateEstimate,
     Report,
     Scorecard,
     TaskPhases,
+    VariantSampleStatus,
     Weakness
 } from "./models.js";

--- a/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
@@ -72,7 +72,9 @@ export class ComparisonBreakdown {
     "runs": number;
     "failures": number;
     "failureRate": number;
+    "failureEstimate": RateEstimate;
     "landed": number;
+    "landedEstimate": RateEstimate;
     "merged": number;
     "mergedWithEdits": number;
     "closed": number;
@@ -81,6 +83,11 @@ export class ComparisonBreakdown {
     "ciFirstPassRate": number;
     "reworkRate": number;
     "revertRate": number;
+    "mergeEstimate": RateEstimate;
+    "ciFirstPassEstimate": RateEstimate;
+    "mergedWithEditsEstimate": RateEstimate;
+    "reworkEstimate": RateEstimate;
+    "revertEstimate": RateEstimate;
     "durationP50S": number;
     "durationP90S": number;
     "totalCostUsd": number;
@@ -91,6 +98,10 @@ export class ComparisonBreakdown {
     "toolsPerLanded": number;
     "insufficientData": boolean;
     "qualityAttributionLimited": boolean;
+    "baseline": boolean;
+    "baselineVariantId"?: string;
+    "sampleStatus"?: string;
+    "minSamplesPerVariant"?: number;
     "roleBreakdowns"?: ComparisonBreakdown[];
 
     /** Creates a new ComparisonBreakdown instance. */
@@ -110,8 +121,14 @@ export class ComparisonBreakdown {
         if (!("failureRate" in $$source)) {
             this["failureRate"] = 0;
         }
+        if (!("failureEstimate" in $$source)) {
+            this["failureEstimate"] = (new RateEstimate());
+        }
         if (!("landed" in $$source)) {
             this["landed"] = 0;
+        }
+        if (!("landedEstimate" in $$source)) {
+            this["landedEstimate"] = (new RateEstimate());
         }
         if (!("merged" in $$source)) {
             this["merged"] = 0;
@@ -136,6 +153,21 @@ export class ComparisonBreakdown {
         }
         if (!("revertRate" in $$source)) {
             this["revertRate"] = 0;
+        }
+        if (!("mergeEstimate" in $$source)) {
+            this["mergeEstimate"] = (new RateEstimate());
+        }
+        if (!("ciFirstPassEstimate" in $$source)) {
+            this["ciFirstPassEstimate"] = (new RateEstimate());
+        }
+        if (!("mergedWithEditsEstimate" in $$source)) {
+            this["mergedWithEditsEstimate"] = (new RateEstimate());
+        }
+        if (!("reworkEstimate" in $$source)) {
+            this["reworkEstimate"] = (new RateEstimate());
+        }
+        if (!("revertEstimate" in $$source)) {
+            this["revertEstimate"] = (new RateEstimate());
         }
         if (!("durationP50S" in $$source)) {
             this["durationP50S"] = 0;
@@ -167,6 +199,9 @@ export class ComparisonBreakdown {
         if (!("qualityAttributionLimited" in $$source)) {
             this["qualityAttributionLimited"] = false;
         }
+        if (!("baseline" in $$source)) {
+            this["baseline"] = false;
+        }
 
         Object.assign(this, $$source);
     }
@@ -175,12 +210,97 @@ export class ComparisonBreakdown {
      * Creates a new ComparisonBreakdown instance from a string or object.
      */
     static createFrom($$source: any = {}): ComparisonBreakdown {
-        const $$createField30_0 = $$createType1;
+        const $$createField11_0 = $$createType0;
+        const $$createField13_0 = $$createType0;
+        const $$createField22_0 = $$createType0;
+        const $$createField23_0 = $$createType0;
+        const $$createField24_0 = $$createType0;
+        const $$createField25_0 = $$createType0;
+        const $$createField26_0 = $$createType0;
+        const $$createField41_0 = $$createType2;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        if ("failureEstimate" in $$parsedSource) {
+            $$parsedSource["failureEstimate"] = $$createField11_0($$parsedSource["failureEstimate"]);
+        }
+        if ("landedEstimate" in $$parsedSource) {
+            $$parsedSource["landedEstimate"] = $$createField13_0($$parsedSource["landedEstimate"]);
+        }
+        if ("mergeEstimate" in $$parsedSource) {
+            $$parsedSource["mergeEstimate"] = $$createField22_0($$parsedSource["mergeEstimate"]);
+        }
+        if ("ciFirstPassEstimate" in $$parsedSource) {
+            $$parsedSource["ciFirstPassEstimate"] = $$createField23_0($$parsedSource["ciFirstPassEstimate"]);
+        }
+        if ("mergedWithEditsEstimate" in $$parsedSource) {
+            $$parsedSource["mergedWithEditsEstimate"] = $$createField24_0($$parsedSource["mergedWithEditsEstimate"]);
+        }
+        if ("reworkEstimate" in $$parsedSource) {
+            $$parsedSource["reworkEstimate"] = $$createField25_0($$parsedSource["reworkEstimate"]);
+        }
+        if ("revertEstimate" in $$parsedSource) {
+            $$parsedSource["revertEstimate"] = $$createField26_0($$parsedSource["revertEstimate"]);
+        }
         if ("roleBreakdowns" in $$parsedSource) {
-            $$parsedSource["roleBreakdowns"] = $$createField30_0($$parsedSource["roleBreakdowns"]);
+            $$parsedSource["roleBreakdowns"] = $$createField41_0($$parsedSource["roleBreakdowns"]);
         }
         return new ComparisonBreakdown($$parsedSource as Partial<ComparisonBreakdown>);
+    }
+}
+
+/**
+ * ExperimentSampleStatus summarizes sample readiness for an experiment/role.
+ */
+export class ExperimentSampleStatus {
+    "key": string;
+    "experimentId": string;
+    "role": string;
+    "baselineVariantId"?: string;
+    "minSamplesPerVariant": number;
+    "variants": VariantSampleStatus[];
+    "readyVariants": number;
+    "totalRuns": number;
+    "status": string;
+
+    /** Creates a new ExperimentSampleStatus instance. */
+    constructor($$source: Partial<ExperimentSampleStatus> = {}) {
+        if (!("key" in $$source)) {
+            this["key"] = "";
+        }
+        if (!("experimentId" in $$source)) {
+            this["experimentId"] = "";
+        }
+        if (!("role" in $$source)) {
+            this["role"] = "";
+        }
+        if (!("minSamplesPerVariant" in $$source)) {
+            this["minSamplesPerVariant"] = 0;
+        }
+        if (!("variants" in $$source)) {
+            this["variants"] = [];
+        }
+        if (!("readyVariants" in $$source)) {
+            this["readyVariants"] = 0;
+        }
+        if (!("totalRuns" in $$source)) {
+            this["totalRuns"] = 0;
+        }
+        if (!("status" in $$source)) {
+            this["status"] = "";
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new ExperimentSampleStatus instance from a string or object.
+     */
+    static createFrom($$source: any = {}): ExperimentSampleStatus {
+        const $$createField5_0 = $$createType4;
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        if ("variants" in $$parsedSource) {
+            $$parsedSource["variants"] = $$createField5_0($$parsedSource["variants"]);
+        }
+        return new ExperimentSampleStatus($$parsedSource as Partial<ExperimentSampleStatus>);
     }
 }
 
@@ -220,8 +340,8 @@ export class PhaseReport {
      * Creates a new PhaseReport instance from a string or object.
      */
     static createFrom($$source: any = {}): PhaseReport {
-        const $$createField3_0 = $$createType3;
-        const $$createField4_0 = $$createType5;
+        const $$createField3_0 = $$createType6;
+        const $$createField4_0 = $$createType8;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("phases" in $$parsedSource) {
             $$parsedSource["phases"] = $$createField3_0($$parsedSource["phases"]);
@@ -281,6 +401,59 @@ export class PhaseStat {
 }
 
 /**
+ * RateEstimate is a binomial rate with fixed 95% Wilson uncertainty and an
+ * optional effect delta relative to an A/B baseline row.
+ */
+export class RateEstimate {
+    "numerator": number;
+    "denominator": number;
+    "point": number;
+    "wilsonLower": number;
+    "wilsonUpper": number;
+    "deltaFromBaseline": number;
+    "hasDelta": boolean;
+    "hasData": boolean;
+
+    /** Creates a new RateEstimate instance. */
+    constructor($$source: Partial<RateEstimate> = {}) {
+        if (!("numerator" in $$source)) {
+            this["numerator"] = 0;
+        }
+        if (!("denominator" in $$source)) {
+            this["denominator"] = 0;
+        }
+        if (!("point" in $$source)) {
+            this["point"] = 0;
+        }
+        if (!("wilsonLower" in $$source)) {
+            this["wilsonLower"] = 0;
+        }
+        if (!("wilsonUpper" in $$source)) {
+            this["wilsonUpper"] = 0;
+        }
+        if (!("deltaFromBaseline" in $$source)) {
+            this["deltaFromBaseline"] = 0;
+        }
+        if (!("hasDelta" in $$source)) {
+            this["hasDelta"] = false;
+        }
+        if (!("hasData" in $$source)) {
+            this["hasData"] = false;
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new RateEstimate instance from a string or object.
+     */
+    static createFrom($$source: any = {}): RateEstimate {
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        return new RateEstimate($$parsedSource as Partial<RateEstimate>);
+    }
+}
+
+/**
  * Report is the persisted, emitted, and CLI-printed output of one evaluation tick.
  */
 export class Report {
@@ -294,6 +467,7 @@ export class Report {
     "byAgentModelContribution"?: ComparisonBreakdown[];
     "byVariant"?: ComparisonBreakdown[];
     "byVariantContribution"?: ComparisonBreakdown[];
+    "variantExperiments"?: ExperimentSampleStatus[];
     "weaknesses"?: Weakness[];
     "notes"?: string[];
 
@@ -319,15 +493,16 @@ export class Report {
      * Creates a new Report instance from a string or object.
      */
     static createFrom($$source: any = {}): Report {
-        const $$createField3_0 = $$createType6;
-        const $$createField4_0 = $$createType8;
-        const $$createField5_0 = $$createType8;
-        const $$createField6_0 = $$createType1;
-        const $$createField7_0 = $$createType1;
-        const $$createField8_0 = $$createType1;
-        const $$createField9_0 = $$createType1;
-        const $$createField10_0 = $$createType10;
-        const $$createField11_0 = $$createType11;
+        const $$createField3_0 = $$createType9;
+        const $$createField4_0 = $$createType11;
+        const $$createField5_0 = $$createType11;
+        const $$createField6_0 = $$createType2;
+        const $$createField7_0 = $$createType2;
+        const $$createField8_0 = $$createType2;
+        const $$createField9_0 = $$createType2;
+        const $$createField10_0 = $$createType13;
+        const $$createField11_0 = $$createType15;
+        const $$createField12_0 = $$createType16;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("overall" in $$parsedSource) {
             $$parsedSource["overall"] = $$createField3_0($$parsedSource["overall"]);
@@ -350,11 +525,14 @@ export class Report {
         if ("byVariantContribution" in $$parsedSource) {
             $$parsedSource["byVariantContribution"] = $$createField9_0($$parsedSource["byVariantContribution"]);
         }
+        if ("variantExperiments" in $$parsedSource) {
+            $$parsedSource["variantExperiments"] = $$createField10_0($$parsedSource["variantExperiments"]);
+        }
         if ("weaknesses" in $$parsedSource) {
-            $$parsedSource["weaknesses"] = $$createField10_0($$parsedSource["weaknesses"]);
+            $$parsedSource["weaknesses"] = $$createField11_0($$parsedSource["weaknesses"]);
         }
         if ("notes" in $$parsedSource) {
-            $$parsedSource["notes"] = $$createField11_0($$parsedSource["notes"]);
+            $$parsedSource["notes"] = $$createField12_0($$parsedSource["notes"]);
         }
         return new Report($$parsedSource as Partial<Report>);
     }
@@ -565,12 +743,57 @@ export class TaskPhases {
      * Creates a new TaskPhases instance from a string or object.
      */
     static createFrom($$source: any = {}): TaskPhases {
-        const $$createField2_0 = $$createType12;
+        const $$createField2_0 = $$createType17;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("byPhase" in $$parsedSource) {
             $$parsedSource["byPhase"] = $$createField2_0($$parsedSource["byPhase"]);
         }
         return new TaskPhases($$parsedSource as Partial<TaskPhases>);
+    }
+}
+
+/**
+ * VariantSampleStatus describes whether one configured or observed A/B variant
+ * has enough samples for the configured minimum.
+ */
+export class VariantSampleStatus {
+    "variantId": string;
+    "runs": number;
+    "ready": boolean;
+    "configured": boolean;
+    "observed": boolean;
+    "sampleStatus": string;
+
+    /** Creates a new VariantSampleStatus instance. */
+    constructor($$source: Partial<VariantSampleStatus> = {}) {
+        if (!("variantId" in $$source)) {
+            this["variantId"] = "";
+        }
+        if (!("runs" in $$source)) {
+            this["runs"] = 0;
+        }
+        if (!("ready" in $$source)) {
+            this["ready"] = false;
+        }
+        if (!("configured" in $$source)) {
+            this["configured"] = false;
+        }
+        if (!("observed" in $$source)) {
+            this["observed"] = false;
+        }
+        if (!("sampleStatus" in $$source)) {
+            this["sampleStatus"] = "";
+        }
+
+        Object.assign(this, $$source);
+    }
+
+    /**
+     * Creates a new VariantSampleStatus instance from a string or object.
+     */
+    static createFrom($$source: any = {}): VariantSampleStatus {
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        return new VariantSampleStatus($$parsedSource as Partial<VariantSampleStatus>);
     }
 }
 
@@ -615,16 +838,21 @@ export class Weakness {
 }
 
 // Private type creation functions
-const $$createType0 = ComparisonBreakdown.createFrom;
-const $$createType1 = $Create.Array($$createType0);
-const $$createType2 = PhaseStat.createFrom;
-const $$createType3 = $Create.Array($$createType2);
-const $$createType4 = TaskPhases.createFrom;
-const $$createType5 = $Create.Array($$createType4);
-const $$createType6 = Scorecard.createFrom;
-const $$createType7 = Breakdown.createFrom;
+const $$createType0 = RateEstimate.createFrom;
+const $$createType1 = ComparisonBreakdown.createFrom;
+const $$createType2 = $Create.Array($$createType1);
+const $$createType3 = VariantSampleStatus.createFrom;
+const $$createType4 = $Create.Array($$createType3);
+const $$createType5 = PhaseStat.createFrom;
+const $$createType6 = $Create.Array($$createType5);
+const $$createType7 = TaskPhases.createFrom;
 const $$createType8 = $Create.Array($$createType7);
-const $$createType9 = Weakness.createFrom;
-const $$createType10 = $Create.Array($$createType9);
-const $$createType11 = $Create.Array($Create.Any);
-const $$createType12 = $Create.Map($Create.Any, $Create.Any);
+const $$createType9 = Scorecard.createFrom;
+const $$createType10 = Breakdown.createFrom;
+const $$createType11 = $Create.Array($$createType10);
+const $$createType12 = ExperimentSampleStatus.createFrom;
+const $$createType13 = $Create.Array($$createType12);
+const $$createType14 = Weakness.createFrom;
+const $$createType15 = $Create.Array($$createType14);
+const $$createType16 = $Create.Array($Create.Any);
+const $$createType17 = $Create.Map($Create.Any, $Create.Any);

--- a/frontend/src/pages/Evaluation.svelte
+++ b/frontend/src/pages/Evaluation.svelte
@@ -49,6 +49,57 @@
   function pct(x: number | null | undefined): string {
     return Number.isFinite(x) ? `${((x ?? 0) * 100).toFixed(0)}%` : '—'
   }
+  type RateEstimateLike = {
+    point?: number
+    wilsonLower?: number
+    wilsonUpper?: number
+    deltaFromBaseline?: number
+    hasDelta?: boolean
+    hasData?: boolean
+  }
+  type EstimateKey =
+    | 'failureEstimate'
+    | 'landedEstimate'
+    | 'mergeEstimate'
+    | 'ciFirstPassEstimate'
+    | 'mergedWithEditsEstimate'
+    | 'reworkEstimate'
+    | 'revertEstimate'
+  type ComparisonRowLike = {
+    failureEstimate?: RateEstimateLike
+    landedEstimate?: RateEstimateLike
+    mergeEstimate?: RateEstimateLike
+    ciFirstPassEstimate?: RateEstimateLike
+    mergedWithEditsEstimate?: RateEstimateLike
+    reworkEstimate?: RateEstimateLike
+    revertEstimate?: RateEstimateLike
+    baseline?: boolean
+    baselineVariantId?: string
+    sampleStatus?: string
+  }
+  function estimate(row: ComparisonRowLike, key: EstimateKey): RateEstimateLike | undefined {
+    return row[key]
+  }
+  function estimatePct(row: ComparisonRowLike, key: EstimateKey, fallback: number | undefined): string {
+    const est = estimate(row, key)
+    return est?.hasData ? pct(est.point) : pct(fallback)
+  }
+  function estimateInterval(row: ComparisonRowLike, key: EstimateKey): string {
+    const est = estimate(row, key)
+    if (!est?.hasData) return ''
+    return `${pct(est.wilsonLower)}-${pct(est.wilsonUpper)}`
+  }
+  function estimateDelta(row: ComparisonRowLike, key: EstimateKey): string {
+    const est = estimate(row, key)
+    if (!est?.hasDelta || est.deltaFromBaseline === undefined) return ''
+    const pp = est.deltaFromBaseline * 100
+    return `${pp >= 0 ? '+' : ''}${pp.toFixed(0)}pp`
+  }
+  function rateCell(row: ComparisonRowLike, key: EstimateKey, fallback: number | undefined, showDelta: boolean): string {
+    const interval = estimateInterval(row, key)
+    const delta = showDelta ? estimateDelta(row, key) : ''
+    return [estimatePct(row, key, fallback), interval ? `CI ${interval}` : '', delta].filter(Boolean).join(' · ')
+  }
   function hours(x: number | undefined): string {
     return x === undefined ? '—' : `${x.toFixed(1)}h`
   }
@@ -84,6 +135,17 @@
     if (status === 'watch') return 'border-warning-300 text-warning-700 dark:border-warning-700 dark:text-warning-300'
     if (status === 'ok') return 'border-success-300 text-success-700 dark:border-success-700 dark:text-success-300'
     return 'border-surface-300 text-surface-500 dark:border-surface-600 dark:text-surface-300'
+  }
+  function sampleClasses(status: string | undefined): string {
+    if (status === 'actionable') return 'bg-success-100 text-success-700 dark:bg-success-900 dark:text-success-200'
+    if (status === 'directional') return 'bg-warning-100 text-warning-700 dark:bg-warning-900 dark:text-warning-200'
+    if (status === 'low-sample') return 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-200'
+    return 'bg-surface-100 text-surface-500 dark:bg-surface-800 dark:text-surface-300'
+  }
+  function rowState(row: ComparisonRowLike): string {
+    if (row.baseline) return 'baseline'
+    if (row.baselineVariantId && !estimate(row, 'failureEstimate')?.hasDelta) return 'no baseline'
+    return row.sampleStatus ?? ''
   }
 </script>
 
@@ -397,7 +459,7 @@
                     {/if}
                   </td>
                   <td class="py-1.5 text-right">
-                    {row.landed}
+                    <span class="text-xs">{row.landed} · {rateCell(row, 'landedEstimate', undefined, true)}</span>
                     {#if row.qualityAttributionLimited}
                       <span class="ml-1 rounded bg-warning-200 px-1 text-[10px] text-warning-800 dark:bg-warning-800 dark:text-warning-200">limited attribution</span>
                     {/if}
@@ -425,8 +487,26 @@
         <p class="mb-3 max-w-3xl text-xs text-surface-400">
           Primary signal: landed/run. Guardrails watch reliability, quality, speed, cost, and premium-model usage.
         </p>
+        {#if report?.variantExperiments && report.variantExperiments.length > 0}
+          <div class="mb-4 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+            {#each report.variantExperiments as exp (exp.key)}
+              <div class="rounded border border-surface-200 p-3 text-xs dark:border-surface-700">
+                <div class="mb-1 flex items-center justify-between gap-2">
+                  <span class="truncate font-mono">{exp.experimentId} · {exp.role}</span>
+                  <span class="rounded px-1.5 py-0.5 {sampleClasses(exp.status)}">{exp.status}</span>
+                </div>
+                <div class="text-surface-400">
+                  {exp.readyVariants}/{exp.variants.length} ready · {exp.totalRuns} runs · min {exp.minSamplesPerVariant}
+                </div>
+                {#if exp.baselineVariantId}
+                  <div class="mt-1 text-surface-400">baseline {exp.baselineVariantId}</div>
+                {/if}
+              </div>
+            {/each}
+          </div>
+        {/if}
         {#if report?.byVariant && report.byVariant.length > 0}
-          <table class="w-full min-w-[1080px] text-sm">
+          <table class="w-full min-w-[1180px] text-sm">
             <thead>
               <tr class="border-b border-surface-200 text-left text-xs text-surface-400 dark:border-surface-700">
                 <th class="pb-2">Variant</th>
@@ -466,17 +546,19 @@
                   <td class="py-1.5 text-xs font-medium">All roles</td>
                   <td class="py-1.5 text-right">
                     {row.runs}
-                    {#if row.insufficientData}
+                    {#if rowState(row)}
+                      <span class="ml-1 rounded px-1 text-[10px] {sampleClasses(row.sampleStatus)}">{rowState(row)}</span>
+                    {:else if row.insufficientData}
                       <span class="ml-1 rounded bg-surface-200 px-1 text-[10px] text-surface-500 dark:bg-surface-700">low N</span>
                     {/if}
                   </td>
-                  <td class="py-1.5 text-right">{row.landed}</td>
-                  <td class="py-1.5 text-right">{pct(row.failureRate)}</td>
-                  <td class="py-1.5 text-right">{pct(row.mergeRate)}</td>
-                  <td class="py-1.5 text-right">{pct(row.ciFirstPassRate)}</td>
-                  <td class="py-1.5 text-right">{pct(row.mergedWithEditsRate)}</td>
-                  <td class="py-1.5 text-right">{pct(row.reworkRate)}</td>
-                  <td class="py-1.5 text-right">{pct(row.revertRate)}</td>
+                  <td class="py-1.5 text-right text-xs">{row.landed} · {rateCell(row, 'landedEstimate', undefined, true)}</td>
+                  <td class="py-1.5 text-right text-xs">{rateCell(row, 'failureEstimate', row.failureRate, true)}</td>
+                  <td class="py-1.5 text-right text-xs">{rateCell(row, 'mergeEstimate', row.mergeRate, true)}</td>
+                  <td class="py-1.5 text-right text-xs">{rateCell(row, 'ciFirstPassEstimate', row.ciFirstPassRate, true)}</td>
+                  <td class="py-1.5 text-right text-xs">{rateCell(row, 'mergedWithEditsEstimate', row.mergedWithEditsRate, true)}</td>
+                  <td class="py-1.5 text-right text-xs">{rateCell(row, 'reworkEstimate', row.reworkRate, true)}</td>
+                  <td class="py-1.5 text-right text-xs">{rateCell(row, 'revertEstimate', row.revertRate, true)}</td>
                   <td class="py-1.5 text-right">p50 {seconds(row.durationP50S)} · p90 {seconds(row.durationP90S)}</td>
                   <td class="py-1.5 text-right">${num(row.totalCostUsd, 2)} · ${num(row.costPerLanded, 2)}/landed</td>
                   <td class="py-1.5 text-right">{num(row.premiumRequests, 1)} · {num(row.premiumRequestsPerLanded, 1)}/landed</td>
@@ -511,17 +593,19 @@
                     <td class="py-1.5 text-xs">{child.role || '—'}</td>
                     <td class="py-1.5 text-right">
                       {child.runs}
-                      {#if child.insufficientData}
+                      {#if rowState(child)}
+                        <span class="ml-1 rounded px-1 text-[10px] {sampleClasses(child.sampleStatus)}">{rowState(child)}</span>
+                      {:else if child.insufficientData}
                         <span class="ml-1 rounded bg-surface-200 px-1 text-[10px] text-surface-500 dark:bg-surface-700">low N</span>
                       {/if}
                     </td>
-                    <td class="py-1.5 text-right">{child.landed}</td>
-                    <td class="py-1.5 text-right">{pct(child.failureRate)}</td>
-                    <td class="py-1.5 text-right">{pct(child.mergeRate)}</td>
-                    <td class="py-1.5 text-right">{pct(child.ciFirstPassRate)}</td>
-                    <td class="py-1.5 text-right">{pct(child.mergedWithEditsRate)}</td>
-                    <td class="py-1.5 text-right">{pct(child.reworkRate)}</td>
-                    <td class="py-1.5 text-right">{pct(child.revertRate)}</td>
+                    <td class="py-1.5 text-right text-xs">{child.landed} · {rateCell(child, 'landedEstimate', undefined, true)}</td>
+                    <td class="py-1.5 text-right text-xs">{rateCell(child, 'failureEstimate', child.failureRate, true)}</td>
+                    <td class="py-1.5 text-right text-xs">{rateCell(child, 'mergeEstimate', child.mergeRate, true)}</td>
+                    <td class="py-1.5 text-right text-xs">{rateCell(child, 'ciFirstPassEstimate', child.ciFirstPassRate, true)}</td>
+                    <td class="py-1.5 text-right text-xs">{rateCell(child, 'mergedWithEditsEstimate', child.mergedWithEditsRate, true)}</td>
+                    <td class="py-1.5 text-right text-xs">{rateCell(child, 'reworkEstimate', child.reworkRate, true)}</td>
+                    <td class="py-1.5 text-right text-xs">{rateCell(child, 'revertEstimate', child.revertRate, true)}</td>
                     <td class="py-1.5 text-right">p50 {seconds(child.durationP50S)} · p90 {seconds(child.durationP90S)}</td>
                     <td class="py-1.5 text-right">${num(child.totalCostUsd, 2)} · ${num(child.costPerLanded, 2)}/landed</td>
                     <td class="py-1.5 text-right">{num(child.premiumRequests, 1)} · {num(child.premiumRequestsPerLanded, 1)}/landed</td>
@@ -541,7 +625,7 @@
           Credits each distinct in-window author group that contributed before landing; totals can exceed landed tasks.
         </p>
         {#if report?.byVariantContribution && report.byVariantContribution.length > 0}
-          <table class="w-full min-w-[1080px] text-sm">
+          <table class="w-full min-w-[1180px] text-sm">
             <thead>
               <tr class="border-b border-surface-200 text-left text-xs text-surface-400 dark:border-surface-700">
                 <th class="pb-2">Variant</th>
@@ -581,7 +665,9 @@
                   <td class="py-1.5 text-xs font-medium">All roles</td>
                   <td class="py-1.5 text-right">
                     {row.runs}
-                    {#if row.insufficientData}
+                    {#if rowState(row)}
+                      <span class="ml-1 rounded px-1 text-[10px] {sampleClasses(row.sampleStatus)}">{rowState(row)}</span>
+                    {:else if row.insufficientData}
                       <span class="ml-1 rounded bg-surface-200 px-1 text-[10px] text-surface-500 dark:bg-surface-700">low N</span>
                     {/if}
                   </td>
@@ -591,12 +677,12 @@
                       <span class="ml-1 rounded bg-warning-200 px-1 text-[10px] text-warning-800 dark:bg-warning-800 dark:text-warning-200">limited attribution</span>
                     {/if}
                   </td>
-                  <td class="py-1.5 text-right">{pct(row.failureRate)}</td>
-                  <td class="py-1.5 text-right">{pct(row.mergeRate)}</td>
-                  <td class="py-1.5 text-right">{pct(row.ciFirstPassRate)}</td>
-                  <td class="py-1.5 text-right">{pct(row.mergedWithEditsRate)}</td>
-                  <td class="py-1.5 text-right">{pct(row.reworkRate)}</td>
-                  <td class="py-1.5 text-right">{pct(row.revertRate)}</td>
+                  <td class="py-1.5 text-right text-xs">{rateCell(row, 'failureEstimate', row.failureRate, true)}</td>
+                  <td class="py-1.5 text-right text-xs">{rateCell(row, 'mergeEstimate', row.mergeRate, true)}</td>
+                  <td class="py-1.5 text-right text-xs">{rateCell(row, 'ciFirstPassEstimate', row.ciFirstPassRate, true)}</td>
+                  <td class="py-1.5 text-right text-xs">{rateCell(row, 'mergedWithEditsEstimate', row.mergedWithEditsRate, true)}</td>
+                  <td class="py-1.5 text-right text-xs">{rateCell(row, 'reworkEstimate', row.reworkRate, true)}</td>
+                  <td class="py-1.5 text-right text-xs">{rateCell(row, 'revertEstimate', row.revertRate, true)}</td>
                   <td class="py-1.5 text-right">p50 {seconds(row.durationP50S)} · p90 {seconds(row.durationP90S)}</td>
                   <td class="py-1.5 text-right">${num(row.totalCostUsd, 2)} · ${num(row.costPerLanded, 2)}/landed</td>
                   <td class="py-1.5 text-right">{num(row.premiumRequests, 1)} · {num(row.premiumRequestsPerLanded, 1)}/landed</td>
@@ -631,22 +717,24 @@
                     <td class="py-1.5 text-xs">{child.role || '—'}</td>
                     <td class="py-1.5 text-right">
                       {child.runs}
-                      {#if child.insufficientData}
+                      {#if rowState(child)}
+                        <span class="ml-1 rounded px-1 text-[10px] {sampleClasses(child.sampleStatus)}">{rowState(child)}</span>
+                      {:else if child.insufficientData}
                         <span class="ml-1 rounded bg-surface-200 px-1 text-[10px] text-surface-500 dark:bg-surface-700">low N</span>
                       {/if}
                     </td>
                     <td class="py-1.5 text-right">
-                      {child.landed}
+                      <span class="text-xs">{child.landed} · {rateCell(child, 'landedEstimate', undefined, true)}</span>
                       {#if child.qualityAttributionLimited}
                         <span class="ml-1 rounded bg-warning-200 px-1 text-[10px] text-warning-800 dark:bg-warning-800 dark:text-warning-200">limited attribution</span>
                       {/if}
                     </td>
-                    <td class="py-1.5 text-right">{pct(child.failureRate)}</td>
-                    <td class="py-1.5 text-right">{pct(child.mergeRate)}</td>
-                    <td class="py-1.5 text-right">{pct(child.ciFirstPassRate)}</td>
-                    <td class="py-1.5 text-right">{pct(child.mergedWithEditsRate)}</td>
-                    <td class="py-1.5 text-right">{pct(child.reworkRate)}</td>
-                    <td class="py-1.5 text-right">{pct(child.revertRate)}</td>
+                    <td class="py-1.5 text-right text-xs">{rateCell(child, 'failureEstimate', child.failureRate, true)}</td>
+                    <td class="py-1.5 text-right text-xs">{rateCell(child, 'mergeEstimate', child.mergeRate, true)}</td>
+                    <td class="py-1.5 text-right text-xs">{rateCell(child, 'ciFirstPassEstimate', child.ciFirstPassRate, true)}</td>
+                    <td class="py-1.5 text-right text-xs">{rateCell(child, 'mergedWithEditsEstimate', child.mergedWithEditsRate, true)}</td>
+                    <td class="py-1.5 text-right text-xs">{rateCell(child, 'reworkEstimate', child.reworkRate, true)}</td>
+                    <td class="py-1.5 text-right text-xs">{rateCell(child, 'revertEstimate', child.revertRate, true)}</td>
                     <td class="py-1.5 text-right">p50 {seconds(child.durationP50S)} · p90 {seconds(child.durationP90S)}</td>
                     <td class="py-1.5 text-right">${num(child.totalCostUsd, 2)} · ${num(child.costPerLanded, 2)}/landed</td>
                     <td class="py-1.5 text-right">{num(child.premiumRequests, 1)} · {num(child.premiumRequestsPerLanded, 1)}/landed</td>

--- a/internal/abtest/selector.go
+++ b/internal/abtest/selector.go
@@ -48,19 +48,7 @@ func selectFromExperiment(exp Experiment, taskID, role, stepID string, providerA
 	} else if unit != "task" {
 		return Assignment{}, false, fmt.Errorf("abtest: experiment %q has invalid assignment_unit %q", exp.ID, exp.AssignmentUnit)
 	}
-	var total int
-	eligible := make([]Variant, 0, len(exp.Variants))
-	for i := range exp.Variants {
-		v := exp.Variants[i]
-		if v.Weight <= 0 {
-			continue
-		}
-		if providerAllowed != nil && !providerAllowed(v.Provider) {
-			continue
-		}
-		total += v.Weight
-		eligible = append(eligible, v)
-	}
+	eligible, total := EligibleVariants(exp, providerAllowed)
 	if total <= 0 {
 		return Assignment{}, false, fmt.Errorf("abtest: experiment %q has no eligible positive-weight variants", exp.ID)
 	}
@@ -83,6 +71,23 @@ func selectFromExperiment(exp Experiment, taskID, role, stepID string, providerA
 		}
 	}
 	return Assignment{}, false, fmt.Errorf("abtest: experiment %q selection fell through", exp.ID)
+}
+
+// EligibleVariants returns the positive-weight variants that can be assigned.
+func EligibleVariants(exp Experiment, providerAllowed func(string) bool) (eligible []Variant, totalWeight int) {
+	eligible = make([]Variant, 0, len(exp.Variants))
+	for i := range exp.Variants {
+		v := exp.Variants[i]
+		if v.Weight <= 0 {
+			continue
+		}
+		if providerAllowed != nil && !providerAllowed(v.Provider) {
+			continue
+		}
+		totalWeight += v.Weight
+		eligible = append(eligible, v)
+	}
+	return eligible, totalWeight
 }
 
 func roleMatches(roles []string, role string) bool {

--- a/internal/evaluation/scorecard.go
+++ b/internal/evaluation/scorecard.go
@@ -7,9 +7,11 @@ package evaluation
 
 import (
 	"encoding/base64"
+	"math"
 	"sort"
 	"time"
 
+	"github.com/Automaat/sybra/internal/abtest"
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/stats"
 )
@@ -90,7 +92,9 @@ type ComparisonBreakdown struct {
 	Runs                      int                   `json:"runs"`
 	Failures                  int                   `json:"failures"`
 	FailureRate               float64               `json:"failureRate"`
+	FailureEstimate           RateEstimate          `json:"failureEstimate"`
 	Landed                    int                   `json:"landed"`
+	LandedEstimate            RateEstimate          `json:"landedEstimate"`
 	Merged                    int                   `json:"merged"`
 	MergedWithEdits           int                   `json:"mergedWithEdits"`
 	Closed                    int                   `json:"closed"`
@@ -99,6 +103,11 @@ type ComparisonBreakdown struct {
 	CIFirstPassRate           float64               `json:"ciFirstPassRate"`
 	ReworkRate                float64               `json:"reworkRate"`
 	RevertRate                float64               `json:"revertRate"`
+	MergeEstimate             RateEstimate          `json:"mergeEstimate"`
+	CIFirstPassEstimate       RateEstimate          `json:"ciFirstPassEstimate"`
+	MergedWithEditsEstimate   RateEstimate          `json:"mergedWithEditsEstimate"`
+	ReworkEstimate            RateEstimate          `json:"reworkEstimate"`
+	RevertEstimate            RateEstimate          `json:"revertEstimate"`
 	DurationP50S              float64               `json:"durationP50S"`
 	DurationP90S              float64               `json:"durationP90S"`
 	TotalCostUSD              float64               `json:"totalCostUsd"`
@@ -109,23 +118,65 @@ type ComparisonBreakdown struct {
 	ToolsPerLanded            float64               `json:"toolsPerLanded"`
 	InsufficientData          bool                  `json:"insufficientData"`
 	QualityAttributionLimited bool                  `json:"qualityAttributionLimited"`
+	Baseline                  bool                  `json:"baseline"`
+	BaselineVariantID         string                `json:"baselineVariantId,omitempty"`
+	SampleStatus              string                `json:"sampleStatus,omitempty"`
+	MinSamplesPerVariant      int                   `json:"minSamplesPerVariant,omitempty"`
 	RoleBreakdowns            []ComparisonBreakdown `json:"roleBreakdowns,omitempty"`
+}
+
+// RateEstimate is a binomial rate with fixed 95% Wilson uncertainty and an
+// optional effect delta relative to an A/B baseline row.
+type RateEstimate struct {
+	Numerator         int     `json:"numerator"`
+	Denominator       int     `json:"denominator"`
+	Point             float64 `json:"point"`
+	WilsonLower       float64 `json:"wilsonLower"`
+	WilsonUpper       float64 `json:"wilsonUpper"`
+	DeltaFromBaseline float64 `json:"deltaFromBaseline"`
+	HasDelta          bool    `json:"hasDelta"`
+	HasData           bool    `json:"hasData"`
+}
+
+// VariantSampleStatus describes whether one configured or observed A/B variant
+// has enough samples for the configured minimum.
+type VariantSampleStatus struct {
+	VariantID    string `json:"variantId"`
+	Runs         int    `json:"runs"`
+	Ready        bool   `json:"ready"`
+	Configured   bool   `json:"configured"`
+	Observed     bool   `json:"observed"`
+	SampleStatus string `json:"sampleStatus"`
+}
+
+// ExperimentSampleStatus summarizes sample readiness for an experiment/role.
+type ExperimentSampleStatus struct {
+	Key                  string                `json:"key"`
+	ExperimentID         string                `json:"experimentId"`
+	Role                 string                `json:"role"`
+	BaselineVariantID    string                `json:"baselineVariantId,omitempty"`
+	MinSamplesPerVariant int                   `json:"minSamplesPerVariant"`
+	Variants             []VariantSampleStatus `json:"variants"`
+	ReadyVariants        int                   `json:"readyVariants"`
+	TotalRuns            int                   `json:"totalRuns"`
+	Status               string                `json:"status"`
 }
 
 // Report is the persisted, emitted, and CLI-printed output of one evaluation tick.
 type Report struct {
-	GeneratedAt              time.Time             `json:"generatedAt"`
-	Since                    time.Time             `json:"since"`
-	Until                    time.Time             `json:"until"`
-	Overall                  Scorecard             `json:"overall"`
-	ByProvider               []Breakdown           `json:"byProvider,omitempty"`
-	ByRole                   []Breakdown           `json:"byRole,omitempty"`
-	ByAgentModel             []ComparisonBreakdown `json:"byAgentModel,omitempty"`
-	ByAgentModelContribution []ComparisonBreakdown `json:"byAgentModelContribution,omitempty"`
-	ByVariant                []ComparisonBreakdown `json:"byVariant,omitempty"`
-	ByVariantContribution    []ComparisonBreakdown `json:"byVariantContribution,omitempty"`
-	Weaknesses               []Weakness            `json:"weaknesses,omitempty"`
-	Notes                    []string              `json:"notes,omitempty"`
+	GeneratedAt              time.Time                `json:"generatedAt"`
+	Since                    time.Time                `json:"since"`
+	Until                    time.Time                `json:"until"`
+	Overall                  Scorecard                `json:"overall"`
+	ByProvider               []Breakdown              `json:"byProvider,omitempty"`
+	ByRole                   []Breakdown              `json:"byRole,omitempty"`
+	ByAgentModel             []ComparisonBreakdown    `json:"byAgentModel,omitempty"`
+	ByAgentModelContribution []ComparisonBreakdown    `json:"byAgentModelContribution,omitempty"`
+	ByVariant                []ComparisonBreakdown    `json:"byVariant,omitempty"`
+	ByVariantContribution    []ComparisonBreakdown    `json:"byVariantContribution,omitempty"`
+	VariantExperiments       []ExperimentSampleStatus `json:"variantExperiments,omitempty"`
+	Weaknesses               []Weakness               `json:"weaknesses,omitempty"`
+	Notes                    []string                 `json:"notes,omitempty"`
 }
 
 // deferredNotes documents metrics that need signals not yet captured, so the
@@ -390,6 +441,19 @@ func BreakdownBy(records []stats.RunRecord, since, until time.Time, key func(sta
 	return out
 }
 
+// CompareOptions controls optional comparison semantics. MinSamples controls the
+// InsufficientData flag only; rows are still emitted so users can see early data.
+type CompareOptions struct {
+	MinSamples  int
+	Experiments []abtest.Experiment
+}
+
+// CompareResult is the row set plus optional experiment readiness summaries.
+type CompareResult struct {
+	Rows        []ComparisonBreakdown
+	Experiments []ExperimentSampleStatus
+}
+
 // CompareByLatestAuthor and CompareByContribution group run records by key and
 // attribute landed-task outcomes using explicit final-stage or contribution
 // semantics. minSamples controls the InsufficientData flag only; rows are still
@@ -402,15 +466,19 @@ type comparisonAcc struct {
 	reverted        int
 }
 
+func CompareBy(records []stats.RunRecord, events []audit.Event, since, until time.Time, opts CompareOptions, key func(stats.RunRecord) string) CompareResult {
+	return compareByAttribution(records, events, since, until, opts, key, ComparisonAttributionLatestAuthor)
+}
+
 func CompareByLatestAuthor(records []stats.RunRecord, events []audit.Event, since, until time.Time, minSamples int, key func(stats.RunRecord) string) []ComparisonBreakdown {
-	return compareByAttribution(records, events, since, until, minSamples, key, ComparisonAttributionLatestAuthor)
+	return compareByAttribution(records, events, since, until, CompareOptions{MinSamples: minSamples}, key, ComparisonAttributionLatestAuthor).Rows
 }
 
 func CompareByContribution(records []stats.RunRecord, events []audit.Event, since, until time.Time, minSamples int, key func(stats.RunRecord) string) []ComparisonBreakdown {
-	return compareByAttribution(records, events, since, until, minSamples, key, ComparisonAttributionAnyContribution)
+	return compareByAttribution(records, events, since, until, CompareOptions{MinSamples: minSamples}, key, ComparisonAttributionAnyContribution).Rows
 }
 
-func compareByAttribution(records []stats.RunRecord, events []audit.Event, since, until time.Time, minSamples int, key func(stats.RunRecord) string, mode ComparisonAttributionMode) []ComparisonBreakdown {
+func compareByAttribution(records []stats.RunRecord, events []audit.Event, since, until time.Time, opts CompareOptions, key func(stats.RunRecord) string, mode ComparisonAttributionMode) CompareResult {
 	groups := map[string]*comparisonAcc{}
 	ensure := func(r stats.RunRecord, k string) *comparisonAcc {
 		a := groups[k]
@@ -451,22 +519,26 @@ func compareByAttribution(records []stats.RunRecord, events []audit.Event, since
 	}
 
 	applyComparisonLandings(ensure, records, events, since, until, key, mode)
-	return comparisonRows(groups, minSamples)
+	rows := comparisonRows(groups, opts.MinSamples)
+	experiments := applyVariantSemantics(rows, opts)
+	return CompareResult{Rows: rows, Experiments: experiments}
 }
 
 // CompareVariants returns A/B rows at experiment/variant granularity, with
 // role-specific rows attached as drilldowns. It uses latest-author attribution.
 func CompareVariants(records []stats.RunRecord, events []audit.Event, since, until time.Time, minSamples int) []ComparisonBreakdown {
-	return compareVariantsByAttribution(records, events, since, until, minSamples, ComparisonAttributionLatestAuthor)
+	return compareVariantsByAttribution(records, events, since, until, CompareOptions{MinSamples: minSamples}, ComparisonAttributionLatestAuthor).Rows
 }
 
 func CompareVariantsByContribution(records []stats.RunRecord, events []audit.Event, since, until time.Time, minSamples int) []ComparisonBreakdown {
-	return compareVariantsByAttribution(records, events, since, until, minSamples, ComparisonAttributionAnyContribution)
+	return compareVariantsByAttribution(records, events, since, until, CompareOptions{MinSamples: minSamples}, ComparisonAttributionAnyContribution).Rows
 }
 
-func compareVariantsByAttribution(records []stats.RunRecord, events []audit.Event, since, until time.Time, minSamples int, mode ComparisonAttributionMode) []ComparisonBreakdown {
-	parents := compareByAttribution(records, events, since, until, minSamples, variantKey, mode)
-	children := compareByAttribution(records, events, since, until, minSamples, variantRoleKey, mode)
+func compareVariantsByAttribution(records []stats.RunRecord, events []audit.Event, since, until time.Time, opts CompareOptions, mode ComparisonAttributionMode) CompareResult {
+	parentResult := compareByAttribution(records, events, since, until, CompareOptions{MinSamples: opts.MinSamples}, variantKey, mode)
+	childResult := compareByAttribution(records, events, since, until, opts, variantRoleKey, mode)
+	parents := parentResult.Rows
+	children := childResult.Rows
 	normalizeVariantParents(parents, records, since, until)
 
 	for i := range parents {
@@ -479,7 +551,7 @@ func compareVariantsByAttribution(records []stats.RunRecord, events []audit.Even
 			return parents[i].RoleBreakdowns[a].Key < parents[i].RoleBreakdowns[b].Key
 		})
 	}
-	return parents
+	return CompareResult{Rows: parents, Experiments: childResult.Experiments}
 }
 
 func variantKey(r stats.RunRecord) string {
@@ -649,15 +721,32 @@ func comparisonRows(groups map[string]*comparisonAcc, minSamples int) []Comparis
 	out := make([]ComparisonBreakdown, 0, len(groups))
 	for _, a := range groups {
 		row := a.row
-		if row.Runs > 0 {
-			row.FailureRate = float64(row.Failures) / float64(row.Runs)
+		row.FailureEstimate = wilson95(row.Failures, row.Runs)
+		row.LandedEstimate = wilson95(row.Landed, row.Runs)
+		row.MergeEstimate = wilson95(row.Merged, row.Landed)
+		row.MergedWithEditsEstimate = wilson95(row.MergedWithEdits, row.Landed)
+		row.CIFirstPassEstimate = wilson95(a.ciClean, row.Landed)
+		row.ReworkEstimate = wilson95(a.rework, row.Landed)
+		row.RevertEstimate = wilson95(a.reverted, row.Landed)
+		if row.FailureEstimate.HasData {
+			row.FailureRate = row.FailureEstimate.Point
+		}
+		if row.MergeEstimate.HasData {
+			row.MergeRate = row.MergeEstimate.Point
+		}
+		if row.MergedWithEditsEstimate.HasData {
+			row.MergedWithEditsRate = row.MergedWithEditsEstimate.Point
+		}
+		if row.CIFirstPassEstimate.HasData {
+			row.CIFirstPassRate = row.CIFirstPassEstimate.Point
+		}
+		if row.ReworkEstimate.HasData {
+			row.ReworkRate = row.ReworkEstimate.Point
+		}
+		if row.RevertEstimate.HasData {
+			row.RevertRate = row.RevertEstimate.Point
 		}
 		if row.Landed > 0 {
-			row.MergeRate = float64(row.Merged) / float64(row.Landed)
-			row.MergedWithEditsRate = float64(row.MergedWithEdits) / float64(row.Landed)
-			row.CIFirstPassRate = float64(a.ciClean) / float64(row.Landed)
-			row.ReworkRate = float64(a.rework) / float64(row.Landed)
-			row.RevertRate = float64(a.reverted) / float64(row.Landed)
 			row.CostPerLanded = row.TotalCostUSD / float64(row.Landed)
 			row.PremiumRequestsPerLanded = row.PremiumRequests / float64(row.Landed)
 			row.TurnsPerLanded = float64(a.turns) / float64(row.Landed)
@@ -670,6 +759,224 @@ func comparisonRows(groups map[string]*comparisonAcc, minSamples int) []Comparis
 		out = append(out, row)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out
+}
+
+func wilson95(numerator, denominator int) RateEstimate {
+	est := RateEstimate{Numerator: numerator, Denominator: denominator}
+	if denominator <= 0 {
+		return est
+	}
+	if numerator < 0 {
+		numerator = 0
+	}
+	if numerator > denominator {
+		numerator = denominator
+	}
+	const z = 1.959963984540054
+	n := float64(denominator)
+	p := float64(numerator) / n
+	z2 := z * z
+	center := p + z2/(2*n)
+	margin := z * math.Sqrt((p*(1-p)+z2/(4*n))/n)
+	denom := 1 + z2/n
+	est.Point = finiteOrZero(p)
+	est.WilsonLower = finiteOrZero((center - margin) / denom)
+	est.WilsonUpper = finiteOrZero((center + margin) / denom)
+	est.HasData = true
+	return est
+}
+
+func finiteOrZero(v float64) float64 {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0
+	}
+	return v
+}
+
+func applyVariantSemantics(rows []ComparisonBreakdown, opts CompareOptions) []ExperimentSampleStatus {
+	if len(opts.Experiments) == 0 {
+		return nil
+	}
+	configured := configuredExperimentRoles(opts.Experiments)
+	if len(configured) == 0 {
+		return nil
+	}
+	byGroup := map[string][]int{}
+	for i := range rows {
+		row := &rows[i]
+		if row.ExperimentID == "" || row.Role == "" || row.VariantID == "" {
+			continue
+		}
+		gk := experimentRoleKey(row.ExperimentID, row.Role)
+		byGroup[gk] = append(byGroup[gk], i)
+		if _, ok := configured[gk]; !ok {
+			configured[gk] = experimentRoleConfig{experimentID: row.ExperimentID, role: row.Role}
+		}
+	}
+	keys := make([]string, 0, len(configured))
+	for k := range configured {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	statuses := make([]ExperimentSampleStatus, 0, len(keys))
+	for _, gk := range keys {
+		cfg := configured[gk]
+		indexes := byGroup[gk]
+		rowByVariant := map[string]*ComparisonBreakdown{}
+		for _, idx := range indexes {
+			row := &rows[idx]
+			row.MinSamplesPerVariant = opts.MinSamples
+			row.BaselineVariantID = cfg.baselineVariantID
+			if opts.MinSamples > 0 && row.Runs < opts.MinSamples {
+				row.SampleStatus = "low-sample"
+			} else {
+				row.SampleStatus = "actionable"
+			}
+			rowByVariant[row.VariantID] = row
+		}
+		applyBaselineDeltas(rowByVariant, cfg.baselineVariantID)
+		statuses = append(statuses, experimentSampleStatus(gk, cfg, rowByVariant, opts.MinSamples))
+	}
+	return statuses
+}
+
+type experimentRoleConfig struct {
+	experimentID       string
+	role               string
+	baselineVariantID  string
+	configuredVariants []string
+}
+
+func configuredExperimentRoles(experiments []abtest.Experiment) map[string]experimentRoleConfig {
+	out := map[string]experimentRoleConfig{}
+	for _, exp := range experiments {
+		if exp.ID == "" || !exp.EnabledValue() || len(exp.Variants) == 0 {
+			continue
+		}
+		baseline := exp.Variants[0].ID
+		variants := make([]string, 0, len(exp.Variants))
+		for _, v := range exp.Variants {
+			if v.ID != "" {
+				variants = append(variants, v.ID)
+			}
+		}
+		for _, role := range exp.Roles {
+			role = normalizedRole(role)
+			out[experimentRoleKey(exp.ID, role)] = experimentRoleConfig{
+				experimentID:       exp.ID,
+				role:               role,
+				baselineVariantID:  baseline,
+				configuredVariants: variants,
+			}
+		}
+	}
+	return out
+}
+
+func experimentRoleKey(experimentID, role string) string {
+	return experimentID + "|" + role
+}
+
+func applyBaselineDeltas(rows map[string]*ComparisonBreakdown, baselineVariantID string) {
+	if baselineVariantID == "" {
+		return
+	}
+	baseline := rows[baselineVariantID]
+	if baseline == nil {
+		return
+	}
+	baseline.Baseline = true
+	applyDelta := func(est *RateEstimate, base RateEstimate) {
+		if !est.HasData || !base.HasData {
+			return
+		}
+		est.DeltaFromBaseline = est.Point - base.Point
+		est.HasDelta = true
+	}
+	for _, row := range rows {
+		applyDelta(&row.FailureEstimate, baseline.FailureEstimate)
+		applyDelta(&row.LandedEstimate, baseline.LandedEstimate)
+		applyDelta(&row.MergeEstimate, baseline.MergeEstimate)
+		applyDelta(&row.CIFirstPassEstimate, baseline.CIFirstPassEstimate)
+		applyDelta(&row.MergedWithEditsEstimate, baseline.MergedWithEditsEstimate)
+		applyDelta(&row.ReworkEstimate, baseline.ReworkEstimate)
+		applyDelta(&row.RevertEstimate, baseline.RevertEstimate)
+	}
+}
+
+func experimentSampleStatus(key string, cfg experimentRoleConfig, rows map[string]*ComparisonBreakdown, minSamples int) ExperimentSampleStatus {
+	variantIDs := orderedVariantIDs(cfg.configuredVariants, rows)
+	status := ExperimentSampleStatus{
+		Key:                  key,
+		ExperimentID:         cfg.experimentID,
+		Role:                 cfg.role,
+		BaselineVariantID:    cfg.baselineVariantID,
+		MinSamplesPerVariant: minSamples,
+		Variants:             make([]VariantSampleStatus, 0, len(variantIDs)),
+	}
+	configured := map[string]bool{}
+	for _, id := range cfg.configuredVariants {
+		configured[id] = true
+	}
+	for _, id := range variantIDs {
+		row := rows[id]
+		runs := 0
+		observed := false
+		if row != nil {
+			runs = row.Runs
+			observed = true
+		}
+		ready := minSamples <= 0 || runs >= minSamples
+		if ready {
+			status.ReadyVariants++
+		}
+		status.TotalRuns += runs
+		sampleStatus := "low-sample"
+		if ready {
+			sampleStatus = "actionable"
+		}
+		status.Variants = append(status.Variants, VariantSampleStatus{
+			VariantID:    id,
+			Runs:         runs,
+			Ready:        ready,
+			Configured:   configured[id],
+			Observed:     observed,
+			SampleStatus: sampleStatus,
+		})
+	}
+	switch {
+	case len(status.Variants) == 0 || status.TotalRuns == 0:
+		status.Status = "no-data"
+	case status.ReadyVariants == len(status.Variants):
+		status.Status = "actionable"
+	case status.ReadyVariants == 0:
+		status.Status = "low-sample"
+	default:
+		status.Status = "directional"
+	}
+	return status
+}
+
+func orderedVariantIDs(configured []string, rows map[string]*ComparisonBreakdown) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(configured)+len(rows))
+	for _, id := range configured {
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	observed := make([]string, 0, len(rows))
+	for id := range rows {
+		if id != "" && !seen[id] {
+			observed = append(observed, id)
+		}
+	}
+	sort.Strings(observed)
+	out = append(out, observed...)
 	return out
 }
 

--- a/internal/evaluation/scorecard.go
+++ b/internal/evaluation/scorecard.go
@@ -798,7 +798,7 @@ func applyVariantSemantics(rows []ComparisonBreakdown, opts CompareOptions) []Ex
 	if len(opts.Experiments) == 0 {
 		return nil
 	}
-	configured := configuredExperimentRoles(opts.Experiments)
+	configured := configuredExperimentRoles(opts.Experiments, rows)
 	if len(configured) == 0 {
 		return nil
 	}
@@ -827,6 +827,9 @@ func applyVariantSemantics(rows []ComparisonBreakdown, opts CompareOptions) []Ex
 		rowByVariant := map[string]*ComparisonBreakdown{}
 		for _, idx := range indexes {
 			row := &rows[idx]
+			if cfg.disabledVariants[row.VariantID] {
+				continue
+			}
 			row.MinSamplesPerVariant = opts.MinSamples
 			row.BaselineVariantID = cfg.baselineVariantID
 			if opts.MinSamples > 0 && row.Runs < opts.MinSamples {
@@ -847,32 +850,72 @@ type experimentRoleConfig struct {
 	role               string
 	baselineVariantID  string
 	configuredVariants []string
+	disabledVariants   map[string]bool
 }
 
-func configuredExperimentRoles(experiments []abtest.Experiment) map[string]experimentRoleConfig {
+func configuredExperimentRoles(experiments []abtest.Experiment, rows []ComparisonBreakdown) map[string]experimentRoleConfig {
 	out := map[string]experimentRoleConfig{}
 	for _, exp := range experiments {
 		if exp.ID == "" || !exp.EnabledValue() || len(exp.Variants) == 0 {
 			continue
 		}
-		baseline := exp.Variants[0].ID
-		variants := make([]string, 0, len(exp.Variants))
+		eligible, _ := abtest.EligibleVariants(exp, nil)
+		variants := make([]string, 0, len(eligible))
+		disabled := map[string]bool{}
 		for _, v := range exp.Variants {
+			if v.ID != "" && v.Weight <= 0 {
+				disabled[v.ID] = true
+			}
+		}
+		baseline := ""
+		for _, v := range eligible {
 			if v.ID != "" {
+				if baseline == "" {
+					baseline = v.ID
+				}
 				variants = append(variants, v.ID)
 			}
 		}
-		for _, role := range exp.Roles {
+		if len(variants) == 0 {
+			continue
+		}
+		for _, role := range configuredExperimentRoleNames(exp, rows) {
 			role = normalizedRole(role)
 			out[experimentRoleKey(exp.ID, role)] = experimentRoleConfig{
 				experimentID:       exp.ID,
 				role:               role,
 				baselineVariantID:  baseline,
 				configuredVariants: variants,
+				disabledVariants:   disabled,
 			}
 		}
 	}
 	return out
+}
+
+func configuredExperimentRoleNames(exp abtest.Experiment, rows []ComparisonBreakdown) []string {
+	if len(exp.Roles) > 0 {
+		return exp.Roles
+	}
+	seen := map[string]bool{}
+	roles := make([]string, 0)
+	for i := range rows {
+		row := &rows[i]
+		if row.ExperimentID != exp.ID || row.Role == "" {
+			continue
+		}
+		role := normalizedRole(row.Role)
+		if seen[role] {
+			continue
+		}
+		seen[role] = true
+		roles = append(roles, role)
+	}
+	if len(roles) == 0 {
+		return []string{normalizedRole("")}
+	}
+	sort.Strings(roles)
+	return roles
 }
 
 func experimentRoleKey(experimentID, role string) string {

--- a/internal/evaluation/scorecard_test.go
+++ b/internal/evaluation/scorecard_test.go
@@ -2,9 +2,12 @@ package evaluation
 
 import (
 	"context"
+	"encoding/json"
+	"math"
 	"testing"
 	"time"
 
+	"github.com/Automaat/sybra/internal/abtest"
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/stats"
@@ -380,6 +383,153 @@ func TestCompareByAttributionModes(t *testing.T) {
 	if unused.Landed != 0 || unused.RevertRate != 0 || !unused.QualityAttributionLimited {
 		t.Fatalf("unused out-of-cohort row = %+v, want no landing/revert quality attribution", unused)
 	}
+}
+
+func TestWilson95(t *testing.T) {
+	got := wilson95(5, 10)
+	if !got.HasData {
+		t.Fatalf("expected data: %+v", got)
+	}
+	if got.Numerator != 5 || got.Denominator != 10 || got.Point != 0.5 {
+		t.Fatalf("estimate counts/point = %+v", got)
+	}
+	if math.Abs(got.WilsonLower-0.2366) > 0.0001 || math.Abs(got.WilsonUpper-0.7634) > 0.0001 {
+		t.Fatalf("Wilson interval = %.4f..%.4f, want ~0.2366..0.7634", got.WilsonLower, got.WilsonUpper)
+	}
+	empty := wilson95(0, 0)
+	if empty.HasData || empty.Point != 0 || empty.WilsonLower != 0 || empty.WilsonUpper != 0 {
+		t.Fatalf("zero denominator estimate = %+v, want no data zeros", empty)
+	}
+	data, err := json.Marshal([]RateEstimate{got, empty, wilson95(1, -1)})
+	if err != nil {
+		t.Fatalf("marshal estimates: %v", err)
+	}
+	if len(data) == 0 || containsNonFinite(got) || containsNonFinite(empty) {
+		t.Fatalf("non-finite estimate JSON/data: %s %+v %+v", data, got, empty)
+	}
+}
+
+func TestCompareByVariantEstimatesAndExperimentStatus(t *testing.T) {
+	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -7)
+	in := base.Add(-1 * time.Hour)
+	records := []stats.RunRecord{
+		{TaskID: "A1", Role: "implementation", Provider: "claude", Model: "opus", ExperimentID: "exp", VariantID: "control", Outcome: "completed", Timestamp: in},
+		{TaskID: "A2", Role: "implementation", Provider: "claude", Model: "opus", ExperimentID: "exp", VariantID: "control", Outcome: "failed", Timestamp: in},
+		{TaskID: "B1", Role: "implementation", Provider: "codex", Model: "gpt-5.5", ExperimentID: "exp", VariantID: "treatment", Outcome: "completed", Timestamp: in},
+		{TaskID: "B2", Role: "implementation", Provider: "codex", Model: "gpt-5.5", ExperimentID: "exp", VariantID: "treatment", Outcome: "completed", Timestamp: in},
+		{TaskID: "C1", Role: "implementation", Provider: "other", Model: "model", ExperimentID: "exp", VariantID: "observed", Outcome: "completed", Timestamp: in},
+	}
+	events := []audit.Event{
+		{Type: audit.EventTaskLanded, TaskID: "A1", Timestamp: in, Data: map[string]any{"outcome": "merged"}},
+		{Type: audit.EventTaskLanded, TaskID: "B1", Timestamp: in, Data: map[string]any{"outcome": "merged_with_edits"}},
+		{Type: audit.EventTaskLanded, TaskID: "B2", Timestamp: in, Data: map[string]any{"outcome": "closed"}},
+		{Type: audit.EventPRCIFailureDetected, TaskID: "B2", Timestamp: in},
+		{Type: audit.EventTaskStatusChanged, TaskID: "B2", Timestamp: in, Data: map[string]any{"from": "testing", "to": "in-review"}},
+		{Type: audit.EventTaskStatusChanged, TaskID: "B2", Timestamp: in, Data: map[string]any{"from": "testing", "to": "in-review"}},
+		{Type: audit.EventPRReverted, TaskID: "B1", Timestamp: in},
+	}
+	res := CompareBy(records, events, since, base, CompareOptions{
+		MinSamples: 2,
+		Experiments: []abtest.Experiment{{
+			ID:       "exp",
+			Roles:    []string{"implementation"},
+			Variants: []abtest.Variant{{ID: "control"}, {ID: "treatment"}, {ID: "missing"}},
+		}},
+	}, func(r stats.RunRecord) string {
+		if r.ExperimentID == "" || r.VariantID == "" {
+			return ""
+		}
+		return r.ExperimentID + ":" + r.VariantID + ":" + normalizedRole(r.Role)
+	})
+	rows := rowsByVariant(res.Rows)
+	control := rows["control"]
+	treatment := rows["treatment"]
+	observed := rows["observed"]
+	if control == nil || treatment == nil || observed == nil {
+		t.Fatalf("rows by variant = %+v", res.Rows)
+	}
+	if !control.Baseline || control.BaselineVariantID != "control" {
+		t.Fatalf("control baseline fields = %+v", *control)
+	}
+	if !control.FailureEstimate.HasDelta || control.FailureEstimate.DeltaFromBaseline != 0 {
+		t.Fatalf("control failure delta = %+v", control.FailureEstimate)
+	}
+	if treatment.FailureRate != treatment.FailureEstimate.Point || treatment.MergeRate != treatment.MergeEstimate.Point {
+		t.Fatalf("scalar rates do not mirror estimates: %+v", *treatment)
+	}
+	if !treatment.MergeEstimate.HasDelta || treatment.MergeEstimate.DeltaFromBaseline != -1 {
+		t.Fatalf("treatment merge delta = %+v, want -1 from baseline", treatment.MergeEstimate)
+	}
+	if treatment.CIFirstPassEstimate.Point != 0.5 || treatment.MergedWithEditsEstimate.Point != 0.5 ||
+		treatment.ReworkEstimate.Point != 0.5 || treatment.RevertEstimate.Point != 0.5 {
+		t.Fatalf("treatment secondary estimates = ci %+v edited %+v rework %+v revert %+v",
+			treatment.CIFirstPassEstimate, treatment.MergedWithEditsEstimate, treatment.ReworkEstimate, treatment.RevertEstimate)
+	}
+	if observed.SampleStatus != "low-sample" || observed.MinSamplesPerVariant != 2 {
+		t.Fatalf("observed sample status = %+v", *observed)
+	}
+	if len(res.Experiments) != 1 {
+		t.Fatalf("experiment statuses = %+v", res.Experiments)
+	}
+	status := res.Experiments[0]
+	if status.BaselineVariantID != "control" || status.ReadyVariants != 2 || status.TotalRuns != 5 || status.Status != "directional" {
+		t.Fatalf("experiment status = %+v", status)
+	}
+	if len(status.Variants) != 4 {
+		t.Fatalf("variants = %+v, want configured plus observed-unconfigured", status.Variants)
+	}
+	missing := status.Variants[2]
+	if missing.VariantID != "missing" || missing.Observed || !missing.Configured || missing.Ready {
+		t.Fatalf("missing configured variant = %+v", missing)
+	}
+}
+
+func TestCompareByVariantMissingBaselineLeavesDeltasUnset(t *testing.T) {
+	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -7)
+	in := base.Add(-1 * time.Hour)
+	records := []stats.RunRecord{
+		{TaskID: "B1", Role: "implementation", ExperimentID: "exp", VariantID: "treatment", Outcome: "completed", Timestamp: in},
+	}
+	res := CompareBy(records, nil, since, base, CompareOptions{
+		MinSamples: 1,
+		Experiments: []abtest.Experiment{{
+			ID:       "exp",
+			Roles:    []string{"implementation"},
+			Variants: []abtest.Variant{{ID: "control"}, {ID: "treatment"}},
+		}},
+	}, func(r stats.RunRecord) string {
+		return r.ExperimentID + ":" + r.VariantID + ":" + normalizedRole(r.Role)
+	})
+	rows := rowsByVariant(res.Rows)
+	if rows["treatment"] == nil {
+		t.Fatalf("rows = %+v", res.Rows)
+	}
+	if rows["treatment"].FailureEstimate.HasDelta || rows["treatment"].Baseline {
+		t.Fatalf("missing baseline should not set delta/baseline: %+v", *rows["treatment"])
+	}
+	if len(res.Experiments) != 1 || res.Experiments[0].Status != "directional" {
+		t.Fatalf("experiment status = %+v", res.Experiments)
+	}
+}
+
+func containsNonFinite(est RateEstimate) bool {
+	values := []float64{est.Point, est.WilsonLower, est.WilsonUpper, est.DeltaFromBaseline}
+	for _, v := range values {
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return true
+		}
+	}
+	return false
+}
+
+func rowsByVariant(rows []ComparisonBreakdown) map[string]*ComparisonBreakdown {
+	out := map[string]*ComparisonBreakdown{}
+	for i := range rows {
+		out[rows[i].VariantID] = &rows[i]
+	}
+	return out
 }
 
 func TestCompute_MergedWithEditsNotAutonomous(t *testing.T) {

--- a/internal/evaluation/scorecard_test.go
+++ b/internal/evaluation/scorecard_test.go
@@ -434,7 +434,7 @@ func TestCompareByVariantEstimatesAndExperimentStatus(t *testing.T) {
 		Experiments: []abtest.Experiment{{
 			ID:       "exp",
 			Roles:    []string{"implementation"},
-			Variants: []abtest.Variant{{ID: "control"}, {ID: "treatment"}, {ID: "missing"}},
+			Variants: []abtest.Variant{{ID: "control", Weight: 1}, {ID: "treatment", Weight: 1}, {ID: "missing", Weight: 1}},
 		}},
 	}, func(r stats.RunRecord) string {
 		if r.ExperimentID == "" || r.VariantID == "" {
@@ -497,7 +497,7 @@ func TestCompareByVariantMissingBaselineLeavesDeltasUnset(t *testing.T) {
 		Experiments: []abtest.Experiment{{
 			ID:       "exp",
 			Roles:    []string{"implementation"},
-			Variants: []abtest.Variant{{ID: "control"}, {ID: "treatment"}},
+			Variants: []abtest.Variant{{ID: "control", Weight: 1}, {ID: "treatment", Weight: 1}},
 		}},
 	}, func(r stats.RunRecord) string {
 		return r.ExperimentID + ":" + r.VariantID + ":" + normalizedRole(r.Role)
@@ -511,6 +511,121 @@ func TestCompareByVariantMissingBaselineLeavesDeltasUnset(t *testing.T) {
 	}
 	if len(res.Experiments) != 1 || res.Experiments[0].Status != "directional" {
 		t.Fatalf("experiment status = %+v", res.Experiments)
+	}
+}
+
+func TestCompareByVariantEmptyExperimentRolesUseObservedRoles(t *testing.T) {
+	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -7)
+	in := base.Add(-1 * time.Hour)
+	records := []stats.RunRecord{
+		{TaskID: "A1", Role: "implementation", ExperimentID: "exp", VariantID: "control", Outcome: "completed", Timestamp: in},
+		{TaskID: "B1", Role: "implementation", ExperimentID: "exp", VariantID: "treatment", Outcome: "failed", Timestamp: in},
+	}
+	res := CompareBy(records, nil, since, base, CompareOptions{
+		MinSamples: 1,
+		Experiments: []abtest.Experiment{{
+			ID:       "exp",
+			Variants: []abtest.Variant{{ID: "control", Weight: 1}, {ID: "treatment", Weight: 1}},
+		}},
+	}, func(r stats.RunRecord) string {
+		return r.ExperimentID + ":" + r.VariantID + ":" + normalizedRole(r.Role)
+	})
+	rows := rowsByVariant(res.Rows)
+	control := rows["control"]
+	treatment := rows["treatment"]
+	if control == nil || treatment == nil {
+		t.Fatalf("rows = %+v", res.Rows)
+	}
+	if !control.Baseline || control.BaselineVariantID != "control" {
+		t.Fatalf("control baseline fields = %+v", *control)
+	}
+	if !treatment.FailureEstimate.HasDelta || treatment.FailureEstimate.DeltaFromBaseline != 1 {
+		t.Fatalf("treatment failure delta = %+v, want +1 from baseline", treatment.FailureEstimate)
+	}
+	if len(res.Experiments) != 1 {
+		t.Fatalf("experiment statuses = %+v", res.Experiments)
+	}
+	status := res.Experiments[0]
+	if status.ExperimentID != "exp" || status.Role != "implementation" || status.BaselineVariantID != "control" || status.Status != "actionable" {
+		t.Fatalf("experiment status = %+v", status)
+	}
+}
+
+func TestCompareByVariantZeroWeightFirstVariantDoesNotBecomeBaseline(t *testing.T) {
+	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -7)
+	in := base.Add(-1 * time.Hour)
+	records := []stats.RunRecord{
+		{TaskID: "A1", Role: "implementation", ExperimentID: "exp", VariantID: "control", Outcome: "completed", Timestamp: in},
+		{TaskID: "B1", Role: "implementation", ExperimentID: "exp", VariantID: "treatment", Outcome: "failed", Timestamp: in},
+	}
+	res := CompareBy(records, nil, since, base, CompareOptions{
+		MinSamples: 1,
+		Experiments: []abtest.Experiment{{
+			ID:    "exp",
+			Roles: []string{"implementation"},
+			Variants: []abtest.Variant{
+				{ID: "disabled", Weight: 0},
+				{ID: "control", Weight: 1},
+				{ID: "treatment", Weight: 1},
+			},
+		}},
+	}, func(r stats.RunRecord) string {
+		return r.ExperimentID + ":" + r.VariantID + ":" + normalizedRole(r.Role)
+	})
+	rows := rowsByVariant(res.Rows)
+	if rows["control"] == nil || !rows["control"].Baseline || rows["control"].BaselineVariantID != "control" {
+		t.Fatalf("control baseline fields = %+v", rows["control"])
+	}
+	if len(res.Experiments) != 1 {
+		t.Fatalf("experiment statuses = %+v", res.Experiments)
+	}
+	status := res.Experiments[0]
+	if status.BaselineVariantID != "control" || status.Status != "actionable" || len(status.Variants) != 2 {
+		t.Fatalf("experiment status = %+v", status)
+	}
+	for _, variant := range status.Variants {
+		if variant.VariantID == "disabled" {
+			t.Fatalf("zero-weight variant included in readiness: %+v", status.Variants)
+		}
+	}
+}
+
+func TestCompareByVariantZeroWeightNonBaselineDoesNotBlockReadiness(t *testing.T) {
+	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -7)
+	in := base.Add(-1 * time.Hour)
+	records := []stats.RunRecord{
+		{TaskID: "A1", Role: "implementation", ExperimentID: "exp", VariantID: "control", Outcome: "completed", Timestamp: in},
+		{TaskID: "B1", Role: "implementation", ExperimentID: "exp", VariantID: "treatment", Outcome: "completed", Timestamp: in},
+		{TaskID: "C1", Role: "implementation", ExperimentID: "exp", VariantID: "disabled", Outcome: "failed", Timestamp: in},
+	}
+	res := CompareBy(records, nil, since, base, CompareOptions{
+		MinSamples: 1,
+		Experiments: []abtest.Experiment{{
+			ID:    "exp",
+			Roles: []string{"implementation"},
+			Variants: []abtest.Variant{
+				{ID: "control", Weight: 1},
+				{ID: "disabled", Weight: 0},
+				{ID: "treatment", Weight: 1},
+			},
+		}},
+	}, func(r stats.RunRecord) string {
+		return r.ExperimentID + ":" + r.VariantID + ":" + normalizedRole(r.Role)
+	})
+	if len(res.Experiments) != 1 {
+		t.Fatalf("experiment statuses = %+v", res.Experiments)
+	}
+	status := res.Experiments[0]
+	if status.Status != "actionable" || status.ReadyVariants != 2 || status.TotalRuns != 2 || len(status.Variants) != 2 {
+		t.Fatalf("experiment status = %+v", status)
+	}
+	for _, variant := range status.Variants {
+		if variant.VariantID == "disabled" {
+			t.Fatalf("zero-weight variant included in readiness: %+v", status.Variants)
+		}
 	}
 }
 

--- a/internal/evaluation/service.go
+++ b/internal/evaluation/service.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Automaat/sybra/internal/abtest"
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/events"
@@ -36,6 +37,7 @@ func AuditDirReader(dir string) auditReader {
 // Deps are the collaborators for the evaluation service.
 type Deps struct {
 	Cfg        config.EvaluationConfig
+	ABTesting  abtest.Config
 	Stats      statsReader
 	Audit      auditReader
 	Emit       EmitFunc
@@ -48,6 +50,7 @@ type Deps struct {
 // Read-only: it never dispatches agents or files issues.
 type Service struct {
 	cfg        config.EvaluationConfig
+	abTesting  abtest.Config
 	stats      statsReader
 	audit      auditReader
 	emit       EmitFunc
@@ -72,6 +75,7 @@ func NewService(d Deps) *Service {
 	}
 	return &Service{
 		cfg:        d.Cfg,
+		abTesting:  d.ABTesting,
 		stats:      d.Stats,
 		audit:      d.Audit,
 		emit:       d.Emit,
@@ -146,6 +150,14 @@ func (s *Service) Scan(_ context.Context) (Report, error) {
 	if s.stats != nil {
 		recs = s.stats.All()
 	}
+	byVariant := compareVariantsByAttribution(recs, evts, since, now, CompareOptions{
+		MinSamples:  s.abTesting.MinSamplesPerVariant,
+		Experiments: s.abTesting.Experiments,
+	}, ComparisonAttributionLatestAuthor)
+	byVariantContribution := compareVariantsByAttribution(recs, evts, since, now, CompareOptions{
+		MinSamples:  s.abTesting.MinSamplesPerVariant,
+		Experiments: s.abTesting.Experiments,
+	}, ComparisonAttributionAnyContribution)
 	rep := Report{
 		GeneratedAt: now,
 		Since:       since,
@@ -165,8 +177,9 @@ func (s *Service) Scan(_ context.Context) (Report, error) {
 			}
 			return r.Provider + ":" + r.Model + ":" + r.ReasoningEffort + ":" + normalizedRole(r.Role)
 		}),
-		ByVariant:             CompareVariants(recs, evts, since, now, 20),
-		ByVariantContribution: CompareVariantsByContribution(recs, evts, since, now, 20),
+		ByVariant:             byVariant.Rows,
+		ByVariantContribution: byVariantContribution.Rows,
+		VariantExperiments:    byVariant.Experiments,
 		Notes:                 deferredNotes,
 	}
 	rep.Weaknesses = Weaknesses(rep)

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -398,6 +398,7 @@ func (lm *LifecycleManager) startEvaluationService(ctx context.Context, emit fun
 	a := lm.app
 	deps := evaluation.Deps{
 		Cfg:        a.cfg.Evaluation,
+		ABTesting:  a.cfg.ABTesting,
 		Audit:      evaluation.AuditDirReader(a.cfg.AuditDir()),
 		Emit:       emit,
 		Logger:     a.logger,


### PR DESCRIPTION
## Motivation

The A/B table showed point estimates only, making very small samples look more decisive than they are.

## Implementation information

Add statistical context to experiment comparison rows:
- Wilson confidence intervals for failure, landed, merge, CI-first-pass, edited-merge, rework, and revert rates
- effect deltas against the chosen baseline/control variant
- a low-sample state driven by `ab_testing.min_samples_per_variant` (hardcoded threshold removed)
- experiment-level sample-size status (directional vs actionable)

> Changelog: feat(evaluation): show A/B uncertainty

Closes #1249