### PR TITLE
feat(evaluation): aggregate A/B variants

### DIFF
--- a/docs/manual-testing.md
+++ b/docs/manual-testing.md
@@ -198,7 +198,7 @@ Expected:
 - `agentRuns[-1]` has `model`, `experimentId`, `variantId`, `assignmentUnit`, and `assignmentKey`.
 - `stats.json[-1]` has the same A/B metadata.
 - Copilot smoke runs preserve fractional `premiumRequests` such as `7.5`.
-- Evaluation report includes rows in `byAgentModel` and `byVariant`.
+- Evaluation report includes rows in `byAgentModel` and aggregate `byVariant` rows with role drilldowns when multiple roles are present.
 
 To test landed-task attribution in Evaluation, append a synthetic audit event in the isolated audit log after the workflow finishes:
 

--- a/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
@@ -94,6 +94,7 @@ export class ComparisonBreakdown {
     "toolsPerLanded": number;
     "insufficientData": boolean;
     "qualityAttributionLimited": boolean;
+    "roleBreakdowns"?: ComparisonBreakdown[];
 
     /** Creates a new ComparisonBreakdown instance. */
     constructor($$source: Partial<ComparisonBreakdown> = {}) {
@@ -174,7 +175,11 @@ export class ComparisonBreakdown {
      * Creates a new ComparisonBreakdown instance from a string or object.
      */
     static createFrom($$source: any = {}): ComparisonBreakdown {
+        const $$createField29_0 = $$createType1;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        if ("roleBreakdowns" in $$parsedSource) {
+            $$parsedSource["roleBreakdowns"] = $$createField29_0($$parsedSource["roleBreakdowns"]);
+        }
         return new ComparisonBreakdown($$parsedSource as Partial<ComparisonBreakdown>);
     }
 }
@@ -215,8 +220,8 @@ export class PhaseReport {
      * Creates a new PhaseReport instance from a string or object.
      */
     static createFrom($$source: any = {}): PhaseReport {
-        const $$createField3_0 = $$createType1;
-        const $$createField4_0 = $$createType3;
+        const $$createField3_0 = $$createType3;
+        const $$createField4_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("phases" in $$parsedSource) {
             $$parsedSource["phases"] = $$createField3_0($$parsedSource["phases"]);
@@ -312,11 +317,11 @@ export class Report {
      * Creates a new Report instance from a string or object.
      */
     static createFrom($$source: any = {}): Report {
-        const $$createField3_0 = $$createType4;
-        const $$createField4_0 = $$createType6;
-        const $$createField5_0 = $$createType6;
-        const $$createField6_0 = $$createType8;
-        const $$createField7_0 = $$createType8;
+        const $$createField3_0 = $$createType6;
+        const $$createField4_0 = $$createType8;
+        const $$createField5_0 = $$createType8;
+        const $$createField6_0 = $$createType1;
+        const $$createField7_0 = $$createType1;
         const $$createField8_0 = $$createType10;
         const $$createField9_0 = $$createType11;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
@@ -600,14 +605,14 @@ export class Weakness {
 }
 
 // Private type creation functions
-const $$createType0 = PhaseStat.createFrom;
+const $$createType0 = ComparisonBreakdown.createFrom;
 const $$createType1 = $Create.Array($$createType0);
-const $$createType2 = TaskPhases.createFrom;
+const $$createType2 = PhaseStat.createFrom;
 const $$createType3 = $Create.Array($$createType2);
-const $$createType4 = Scorecard.createFrom;
-const $$createType5 = Breakdown.createFrom;
-const $$createType6 = $Create.Array($$createType5);
-const $$createType7 = ComparisonBreakdown.createFrom;
+const $$createType4 = TaskPhases.createFrom;
+const $$createType5 = $Create.Array($$createType4);
+const $$createType6 = Scorecard.createFrom;
+const $$createType7 = Breakdown.createFrom;
 const $$createType8 = $Create.Array($$createType7);
 const $$createType9 = Weakness.createFrom;
 const $$createType10 = $Create.Array($$createType9);

--- a/frontend/src/pages/Evaluation.svelte
+++ b/frontend/src/pages/Evaluation.svelte
@@ -300,102 +300,176 @@
 
     <!-- A/B testing and model comparisons -->
     <div class="grid grid-cols-1 gap-6">
-      {#each [
-        { title: 'Agent / Model', kind: 'agent', data: report?.byAgentModel },
-        { title: 'A/B Experiments', kind: 'experiment', data: report?.byVariant },
-      ] as section (section.title)}
-        <div class="overflow-x-auto rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
-          <h3 class="mb-3 text-sm font-semibold text-surface-500">{section.title}</h3>
-          {#if section.kind === 'experiment'}
-            <p class="mb-3 max-w-3xl text-xs text-surface-400">
-              Primary signal: landed/run. Guardrails watch reliability, quality, speed, cost, and premium-model usage.
-            </p>
-          {/if}
-          {#if section.data && section.data.length > 0}
-            <table class="w-full min-w-[980px] text-sm">
-              <thead>
-                <tr class="border-b border-surface-200 text-left text-xs text-surface-400 dark:border-surface-700">
-                  <th class="pb-2">Variant</th>
-                  <th class="pb-2">Role</th>
-                  <th class="pb-2 text-right">Runs</th>
-                  <th class="pb-2 text-right">Landed</th>
-                  <th class="pb-2 text-right">Merge %</th>
-                  <th class="pb-2 text-right">CI 1st</th>
-                  <th class="pb-2 text-right">Edited</th>
-                  <th class="pb-2 text-right">Rework</th>
-                  <th class="pb-2 text-right">Revert</th>
-                  <th class="pb-2 text-right">Duration</th>
-                  <th class="pb-2 text-right">Cost</th>
-                  <th class="pb-2 text-right">Premium req</th>
+      <div class="overflow-x-auto rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <h3 class="mb-3 text-sm font-semibold text-surface-500">Agent / Model</h3>
+        {#if report?.byAgentModel && report.byAgentModel.length > 0}
+          <table class="w-full min-w-[1080px] text-sm">
+            <thead>
+              <tr class="border-b border-surface-200 text-left text-xs text-surface-400 dark:border-surface-700">
+                <th class="pb-2">Variant</th>
+                <th class="pb-2">Role</th>
+                <th class="pb-2 text-right">Runs</th>
+                <th class="pb-2 text-right">Landed</th>
+                <th class="pb-2 text-right">Fail %</th>
+                <th class="pb-2 text-right">Merge %</th>
+                <th class="pb-2 text-right">CI 1st</th>
+                <th class="pb-2 text-right">Edited</th>
+                <th class="pb-2 text-right">Rework</th>
+                <th class="pb-2 text-right">Revert</th>
+                <th class="pb-2 text-right">Duration</th>
+                <th class="pb-2 text-right">Cost</th>
+                <th class="pb-2 text-right">Premium req</th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each report.byAgentModel as row (row.key)}
+                <tr class="border-b border-surface-100 last:border-0 dark:border-surface-700">
+                  <td class="py-1.5">
+                    <div class="font-mono text-xs">{row.variantId || row.key}</div>
+                    <div class="text-xs text-surface-400">
+                      {row.provider}{row.model ? ` · ${row.model}` : ''}{row.reasoningEffort ? ` · ${row.reasoningEffort}` : ''}
+                    </div>
+                  </td>
+                  <td class="py-1.5 text-xs">{row.role || '—'}</td>
+                  <td class="py-1.5 text-right">
+                    {row.runs}
+                    {#if row.insufficientData}
+                      <span class="ml-1 rounded bg-surface-200 px-1 text-[10px] text-surface-500 dark:bg-surface-700">low N</span>
+                    {/if}
+                  </td>
+                  <td class="py-1.5 text-right">{row.landed}</td>
+                  <td class="py-1.5 text-right">{pct(row.failureRate)}</td>
+                  <td class="py-1.5 text-right">{pct(row.mergeRate)}</td>
+                  <td class="py-1.5 text-right">{pct(row.ciFirstPassRate)}</td>
+                  <td class="py-1.5 text-right">{pct(row.mergedWithEditsRate)}</td>
+                  <td class="py-1.5 text-right">{pct(row.reworkRate)}</td>
+                  <td class="py-1.5 text-right">{pct(row.revertRate)}</td>
+                  <td class="py-1.5 text-right">p50 {seconds(row.durationP50S)} · p90 {seconds(row.durationP90S)}</td>
+                  <td class="py-1.5 text-right">${num(row.totalCostUsd, 2)} · ${num(row.costPerLanded, 2)}/landed</td>
+                  <td class="py-1.5 text-right">{num(row.premiumRequests, 1)} · {num(row.premiumRequestsPerLanded, 1)}/landed</td>
                 </tr>
-              </thead>
-              <tbody>
-                {#each section.data as row (row.key)}
-                  {@const interpretation = section.kind === 'experiment' ? interpretExperiment(row, section.data) : null}
+              {/each}
+            </tbody>
+          </table>
+        {:else}
+          <p class="text-xs text-surface-400">No data</p>
+        {/if}
+      </div>
+
+      <div class="overflow-x-auto rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <h3 class="mb-3 text-sm font-semibold text-surface-500">A/B Experiments</h3>
+        <p class="mb-3 max-w-3xl text-xs text-surface-400">
+          Primary signal: landed/run. Guardrails watch reliability, quality, speed, cost, and premium-model usage.
+        </p>
+        {#if report?.byVariant && report.byVariant.length > 0}
+          <table class="w-full min-w-[1080px] text-sm">
+            <thead>
+              <tr class="border-b border-surface-200 text-left text-xs text-surface-400 dark:border-surface-700">
+                <th class="pb-2">Variant</th>
+                <th class="pb-2">Role</th>
+                <th class="pb-2 text-right">Runs</th>
+                <th class="pb-2 text-right">Landed</th>
+                <th class="pb-2 text-right">Fail %</th>
+                <th class="pb-2 text-right">Merge %</th>
+                <th class="pb-2 text-right">CI 1st</th>
+                <th class="pb-2 text-right">Edited</th>
+                <th class="pb-2 text-right">Rework</th>
+                <th class="pb-2 text-right">Revert</th>
+                <th class="pb-2 text-right">Duration</th>
+                <th class="pb-2 text-right">Cost</th>
+                <th class="pb-2 text-right">Premium req</th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each report.byVariant as row (row.key)}
+                {@const interpretation = interpretExperiment(row, report.byVariant)}
+                <tr class="border-b border-surface-100 bg-surface-100/60 dark:border-surface-700 dark:bg-surface-700/30">
+                  <td class="py-1.5">
+                    <div class="font-mono text-xs">{row.variantId || row.key}</div>
+                    <div class="text-xs text-surface-400">
+                      {row.provider}{row.model ? ` · ${row.model}` : ''}{row.reasoningEffort ? ` · ${row.reasoningEffort}` : ''}
+                    </div>
+                    <div class="mt-1 flex flex-wrap items-center gap-1.5">
+                      <span class="rounded px-1.5 py-0.5 text-[10px] font-medium {verdictClasses(interpretation.verdict)}">
+                        {interpretation.verdictLabel}
+                      </span>
+                      <span class="text-[10px] text-surface-500">
+                        {interpretation.primaryLabel}: {interpretation.primaryValue} ({interpretation.primaryDetail})
+                      </span>
+                    </div>
+                    <p class="mt-1 text-[10px] text-surface-400">{interpretation.verdictReason}</p>
+                  </td>
+                  <td class="py-1.5 text-xs font-medium">All roles</td>
+                  <td class="py-1.5 text-right">
+                    {row.runs}
+                    {#if row.insufficientData}
+                      <span class="ml-1 rounded bg-surface-200 px-1 text-[10px] text-surface-500 dark:bg-surface-700">low N</span>
+                    {/if}
+                  </td>
+                  <td class="py-1.5 text-right">{row.landed}</td>
+                  <td class="py-1.5 text-right">{pct(row.failureRate)}</td>
+                  <td class="py-1.5 text-right">{pct(row.mergeRate)}</td>
+                  <td class="py-1.5 text-right">{pct(row.ciFirstPassRate)}</td>
+                  <td class="py-1.5 text-right">{pct(row.mergedWithEditsRate)}</td>
+                  <td class="py-1.5 text-right">{pct(row.reworkRate)}</td>
+                  <td class="py-1.5 text-right">{pct(row.revertRate)}</td>
+                  <td class="py-1.5 text-right">p50 {seconds(row.durationP50S)} · p90 {seconds(row.durationP90S)}</td>
+                  <td class="py-1.5 text-right">${num(row.totalCostUsd, 2)} · ${num(row.costPerLanded, 2)}/landed</td>
+                  <td class="py-1.5 text-right">{num(row.premiumRequests, 1)} · {num(row.premiumRequestsPerLanded, 1)}/landed</td>
+                </tr>
+                <tr class="border-b border-surface-100 dark:border-surface-700">
+                  <td class="pb-2 pt-0" colspan="13">
+                    <div class="flex flex-wrap gap-1.5">
+                      {#each interpretation.guardrails as guardrail (guardrail.key)}
+                        <span
+                          class="rounded border px-1.5 py-0.5 text-[10px] {guardrailClasses(guardrail.status)}"
+                          title={guardrail.detail}
+                        >
+                          {guardrail.label}: {guardrail.status}
+                        </span>
+                      {/each}
+                    </div>
+                    {#if interpretation.limitedSignals.length > 0}
+                      <p class="mt-1 text-[10px] text-surface-400">
+                        Limited signals: {interpretation.limitedSignals.join(' ')}
+                      </p>
+                    {/if}
+                  </td>
+                </tr>
+                {#each row.roleBreakdowns ?? [] as child (child.key)}
                   <tr class="border-b border-surface-100 last:border-0 dark:border-surface-700">
-                    <td class="py-1.5">
-                      <div class="font-mono text-xs">{row.variantId || row.key}</div>
+                    <td class="py-1.5 pl-6">
+                      <div class="font-mono text-xs text-surface-500">{child.variantId || row.variantId || child.key}</div>
                       <div class="text-xs text-surface-400">
-                        {row.provider}{row.model ? ` · ${row.model}` : ''}{row.reasoningEffort ? ` · ${row.reasoningEffort}` : ''}
+                        {child.provider}{child.model ? ` · ${child.model}` : ''}{child.reasoningEffort ? ` · ${child.reasoningEffort}` : ''}
                       </div>
-                      {#if interpretation}
-                        <div class="mt-1 flex flex-wrap items-center gap-1.5">
-                          <span class="rounded px-1.5 py-0.5 text-[10px] font-medium {verdictClasses(interpretation.verdict)}">
-                            {interpretation.verdictLabel}
-                          </span>
-                          <span class="text-[10px] text-surface-500">
-                            {interpretation.primaryLabel}: {interpretation.primaryValue} ({interpretation.primaryDetail})
-                          </span>
-                        </div>
-                        <p class="mt-1 text-[10px] text-surface-400">{interpretation.verdictReason}</p>
-                      {/if}
                     </td>
-                    <td class="py-1.5 text-xs">{row.role || '—'}</td>
+                    <td class="py-1.5 text-xs">{child.role || '—'}</td>
                     <td class="py-1.5 text-right">
-                      {row.runs}
-                      {#if row.insufficientData}
+                      {child.runs}
+                      {#if child.insufficientData}
                         <span class="ml-1 rounded bg-surface-200 px-1 text-[10px] text-surface-500 dark:bg-surface-700">low N</span>
                       {/if}
                     </td>
-                    <td class="py-1.5 text-right">{row.landed}</td>
-                    <td class="py-1.5 text-right">{pct(row.mergeRate)}</td>
-                    <td class="py-1.5 text-right">{pct(row.ciFirstPassRate)}</td>
-                    <td class="py-1.5 text-right">{pct(row.mergedWithEditsRate)}</td>
-                    <td class="py-1.5 text-right">{pct(row.reworkRate)}</td>
-                    <td class="py-1.5 text-right">{pct(row.revertRate)}</td>
-                    <td class="py-1.5 text-right">p50 {seconds(row.durationP50S)} · p90 {seconds(row.durationP90S)}</td>
-                    <td class="py-1.5 text-right">${num(row.costPerLanded, 2)}/landed</td>
-                    <td class="py-1.5 text-right">{num(row.premiumRequestsPerLanded, 1)}/landed</td>
+                    <td class="py-1.5 text-right">{child.landed}</td>
+                    <td class="py-1.5 text-right">{pct(child.failureRate)}</td>
+                    <td class="py-1.5 text-right">{pct(child.mergeRate)}</td>
+                    <td class="py-1.5 text-right">{pct(child.ciFirstPassRate)}</td>
+                    <td class="py-1.5 text-right">{pct(child.mergedWithEditsRate)}</td>
+                    <td class="py-1.5 text-right">{pct(child.reworkRate)}</td>
+                    <td class="py-1.5 text-right">{pct(child.revertRate)}</td>
+                    <td class="py-1.5 text-right">p50 {seconds(child.durationP50S)} · p90 {seconds(child.durationP90S)}</td>
+                    <td class="py-1.5 text-right">${num(child.totalCostUsd, 2)} · ${num(child.costPerLanded, 2)}/landed</td>
+                    <td class="py-1.5 text-right">{num(child.premiumRequests, 1)} · {num(child.premiumRequestsPerLanded, 1)}/landed</td>
                   </tr>
-                  {#if interpretation}
-                    <tr class="border-b border-surface-100 last:border-0 dark:border-surface-700">
-                      <td class="pb-2 pt-0" colspan="12">
-                        <div class="flex flex-wrap gap-1.5">
-                          {#each interpretation.guardrails as guardrail (guardrail.key)}
-                            <span
-                              class="rounded border px-1.5 py-0.5 text-[10px] {guardrailClasses(guardrail.status)}"
-                              title={guardrail.detail}
-                            >
-                              {guardrail.label}: {guardrail.status}
-                            </span>
-                          {/each}
-                        </div>
-                        {#if interpretation.limitedSignals.length > 0}
-                          <p class="mt-1 text-[10px] text-surface-400">
-                            Limited signals: {interpretation.limitedSignals.join(' ')}
-                          </p>
-                        {/if}
-                      </td>
-                    </tr>
-                  {/if}
                 {/each}
-              </tbody>
-            </table>
-          {:else}
-            <p class="text-xs text-surface-400">No data</p>
-          {/if}
-        </div>
-      {/each}
+              {/each}
+            </tbody>
+          </table>
+        {:else}
+          <p class="text-xs text-surface-400">No data</p>
+        {/if}
+      </div>
     </div>
 
     {#if report?.notes && report.notes.length > 0}

--- a/internal/evaluation/scorecard.go
+++ b/internal/evaluation/scorecard.go
@@ -6,6 +6,7 @@
 package evaluation
 
 import (
+	"encoding/base64"
 	"sort"
 	"time"
 
@@ -71,35 +72,36 @@ type Breakdown struct {
 // ComparisonBreakdown compares agent/model or experiment variants on the
 // speed, quality, and cost signals Sybra already records.
 type ComparisonBreakdown struct {
-	Key                       string  `json:"key"`
-	Provider                  string  `json:"provider,omitempty"`
-	Model                     string  `json:"model,omitempty"`
-	Role                      string  `json:"role,omitempty"`
-	ReasoningEffort           string  `json:"reasoningEffort,omitempty"`
-	ExperimentID              string  `json:"experimentId,omitempty"`
-	VariantID                 string  `json:"variantId,omitempty"`
-	Runs                      int     `json:"runs"`
-	Failures                  int     `json:"failures"`
-	FailureRate               float64 `json:"failureRate"`
-	Landed                    int     `json:"landed"`
-	Merged                    int     `json:"merged"`
-	MergedWithEdits           int     `json:"mergedWithEdits"`
-	Closed                    int     `json:"closed"`
-	MergeRate                 float64 `json:"mergeRate"`
-	MergedWithEditsRate       float64 `json:"mergedWithEditsRate"`
-	CIFirstPassRate           float64 `json:"ciFirstPassRate"`
-	ReworkRate                float64 `json:"reworkRate"`
-	RevertRate                float64 `json:"revertRate"`
-	DurationP50S              float64 `json:"durationP50S"`
-	DurationP90S              float64 `json:"durationP90S"`
-	TotalCostUSD              float64 `json:"totalCostUsd"`
-	CostPerLanded             float64 `json:"costPerLanded"`
-	PremiumRequests           float64 `json:"premiumRequests"`
-	PremiumRequestsPerLanded  float64 `json:"premiumRequestsPerLanded"`
-	TurnsPerLanded            float64 `json:"turnsPerLanded"`
-	ToolsPerLanded            float64 `json:"toolsPerLanded"`
-	InsufficientData          bool    `json:"insufficientData"`
-	QualityAttributionLimited bool    `json:"qualityAttributionLimited"`
+	Key                       string                `json:"key"`
+	Provider                  string                `json:"provider,omitempty"`
+	Model                     string                `json:"model,omitempty"`
+	Role                      string                `json:"role,omitempty"`
+	ReasoningEffort           string                `json:"reasoningEffort,omitempty"`
+	ExperimentID              string                `json:"experimentId,omitempty"`
+	VariantID                 string                `json:"variantId,omitempty"`
+	Runs                      int                   `json:"runs"`
+	Failures                  int                   `json:"failures"`
+	FailureRate               float64               `json:"failureRate"`
+	Landed                    int                   `json:"landed"`
+	Merged                    int                   `json:"merged"`
+	MergedWithEdits           int                   `json:"mergedWithEdits"`
+	Closed                    int                   `json:"closed"`
+	MergeRate                 float64               `json:"mergeRate"`
+	MergedWithEditsRate       float64               `json:"mergedWithEditsRate"`
+	CIFirstPassRate           float64               `json:"ciFirstPassRate"`
+	ReworkRate                float64               `json:"reworkRate"`
+	RevertRate                float64               `json:"revertRate"`
+	DurationP50S              float64               `json:"durationP50S"`
+	DurationP90S              float64               `json:"durationP90S"`
+	TotalCostUSD              float64               `json:"totalCostUsd"`
+	CostPerLanded             float64               `json:"costPerLanded"`
+	PremiumRequests           float64               `json:"premiumRequests"`
+	PremiumRequestsPerLanded  float64               `json:"premiumRequestsPerLanded"`
+	TurnsPerLanded            float64               `json:"turnsPerLanded"`
+	ToolsPerLanded            float64               `json:"toolsPerLanded"`
+	InsufficientData          bool                  `json:"insufficientData"`
+	QualityAttributionLimited bool                  `json:"qualityAttributionLimited"`
+	RoleBreakdowns            []ComparisonBreakdown `json:"roleBreakdowns,omitempty"`
 }
 
 // Report is the persisted, emitted, and CLI-printed output of one evaluation tick.
@@ -430,6 +432,110 @@ func CompareBy(records []stats.RunRecord, events []audit.Event, since, until tim
 
 	applyComparisonLandings(ensure, records, events, since, until, key)
 	return comparisonRows(groups, minSamples)
+}
+
+// CompareVariants returns A/B rows at experiment/variant granularity, with
+// role-specific rows attached as drilldowns. It deliberately reuses CompareBy
+// for both levels so attribution and low-sample semantics stay identical to the
+// flat comparison path.
+func CompareVariants(records []stats.RunRecord, events []audit.Event, since, until time.Time, minSamples int) []ComparisonBreakdown {
+	parents := CompareBy(records, events, since, until, minSamples, variantKey)
+	children := CompareBy(records, events, since, until, minSamples, variantRoleKey)
+	normalizeVariantParents(parents, records, since, until)
+
+	for i := range parents {
+		for j := range children {
+			if children[j].ExperimentID == parents[i].ExperimentID && children[j].VariantID == parents[i].VariantID {
+				parents[i].RoleBreakdowns = append(parents[i].RoleBreakdowns, children[j])
+			}
+		}
+		sort.Slice(parents[i].RoleBreakdowns, func(a, b int) bool {
+			return parents[i].RoleBreakdowns[a].Key < parents[i].RoleBreakdowns[b].Key
+		})
+	}
+	return parents
+}
+
+func variantKey(r stats.RunRecord) string {
+	if r.ExperimentID == "" || r.VariantID == "" {
+		return ""
+	}
+	return encodedComparisonKey(r.ExperimentID, r.VariantID)
+}
+
+func variantRoleKey(r stats.RunRecord) string {
+	if r.ExperimentID == "" || r.VariantID == "" {
+		return ""
+	}
+	return encodedComparisonKey(r.ExperimentID, r.VariantID, normalizedRole(r.Role))
+}
+
+func encodedComparisonKey(parts ...string) string {
+	out := make([]byte, 0, len(parts)*12)
+	for i, part := range parts {
+		if i > 0 {
+			out = append(out, ':')
+		}
+		out = base64.RawURLEncoding.AppendEncode(out, []byte(part))
+	}
+	return string(out)
+}
+
+func normalizeVariantParents(rows []ComparisonBreakdown, records []stats.RunRecord, since, until time.Time) {
+	type meta struct {
+		provider, model, reasoning valueConsensus
+	}
+	metas := map[string]*meta{}
+	for i := range records {
+		r := records[i]
+		if r.Timestamp.Before(since) || r.Timestamp.After(until) {
+			continue
+		}
+		k := variantKey(r)
+		if k == "" {
+			continue
+		}
+		m := metas[k]
+		if m == nil {
+			m = &meta{}
+			metas[k] = m
+		}
+		m.provider.add(r.Provider)
+		m.model.add(r.Model)
+		m.reasoning.add(r.ReasoningEffort)
+	}
+	for i := range rows {
+		rows[i].Role = ""
+		if m := metas[rows[i].Key]; m != nil {
+			rows[i].Provider = m.provider.value()
+			rows[i].Model = m.model.value()
+			rows[i].ReasoningEffort = m.reasoning.value()
+		}
+	}
+}
+
+type valueConsensus struct {
+	seen   bool
+	mixed  bool
+	chosen string
+}
+
+func (v *valueConsensus) add(next string) {
+	if !v.seen {
+		v.seen = true
+		v.chosen = next
+		return
+	}
+	if v.chosen != next {
+		v.mixed = true
+	}
+}
+
+func (v *valueConsensus) value() string {
+	if v.mixed {
+		return ""
+	}
+	return v.chosen
 }
 
 func applyComparisonLandings(ensure func(stats.RunRecord, string) *comparisonAcc, records []stats.RunRecord, events []audit.Event, since, until time.Time, key func(stats.RunRecord) string) {

--- a/internal/evaluation/scorecard_test.go
+++ b/internal/evaluation/scorecard_test.go
@@ -162,6 +162,163 @@ func TestCompareByVariantDoesNotAttributePreWindowRun(t *testing.T) {
 	}
 }
 
+func TestCompareVariantsAggregatesRoles(t *testing.T) {
+	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -7)
+	in := base.Add(-1 * time.Hour)
+	records := []stats.RunRecord{
+		{TaskID: "A", Role: "implementation", Provider: "claude", Model: "sonnet", ReasoningEffort: "medium", ExperimentID: "exp", VariantID: "a", DurationS: 120, CostUSD: 2, PremiumRequests: 4, Outcome: "completed", Timestamp: in},
+		{TaskID: "B", Role: "fix-review", Provider: "claude", Model: "sonnet", ReasoningEffort: "medium", ExperimentID: "exp", VariantID: "a", DurationS: 240, CostUSD: 3, PremiumRequests: 6, Outcome: "failed", Timestamp: in},
+	}
+	events := []audit.Event{
+		{Type: audit.EventTaskLanded, TaskID: "A", Timestamp: in.Add(30 * time.Minute), Data: map[string]any{"outcome": "merged"}},
+	}
+
+	got := CompareVariants(records, events, since, base, 0)
+	if len(got) != 1 {
+		t.Fatalf("variant rows = %d, want 1: %+v", len(got), got)
+	}
+	parent := got[0]
+	if parent.ExperimentID != "exp" || parent.VariantID != "a" || parent.Role != "" {
+		t.Fatalf("parent identity = %+v, want exp/a with empty role", parent)
+	}
+	if parent.Runs != 2 || parent.Failures != 1 || parent.Landed != 1 || parent.MergeRate != 1 || parent.FailureRate != 0.5 {
+		t.Fatalf("parent metrics = %+v", parent)
+	}
+	if parent.TotalCostUSD != 5 || parent.CostPerLanded != 5 || parent.PremiumRequests != 10 || parent.PremiumRequestsPerLanded != 10 {
+		t.Fatalf("parent cost/premium metrics = %+v", parent)
+	}
+	if parent.DurationP50S != 120 || parent.DurationP90S != 240 {
+		t.Fatalf("parent duration = p50 %v p90 %v, want 120/240", parent.DurationP50S, parent.DurationP90S)
+	}
+	if len(parent.RoleBreakdowns) != 2 {
+		t.Fatalf("role breakdowns = %d, want 2: %+v", len(parent.RoleBreakdowns), parent.RoleBreakdowns)
+	}
+	impl := comparisonByRole(t, parent.RoleBreakdowns, "implementation")
+	if impl.Runs != 1 || impl.Landed != 1 || impl.MergeRate != 1 || impl.TotalCostUSD != 2 || impl.PremiumRequests != 4 {
+		t.Fatalf("implementation child = %+v", impl)
+	}
+	fix := comparisonByRole(t, parent.RoleBreakdowns, "fix-review")
+	if fix.Runs != 1 || fix.Failures != 1 || fix.Landed != 0 || fix.FailureRate != 1 {
+		t.Fatalf("fix-review child = %+v", fix)
+	}
+}
+
+func TestCompareVariantsKeepsChildLowSampleRows(t *testing.T) {
+	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -7)
+	in := base.Add(-1 * time.Hour)
+	records := []stats.RunRecord{
+		{TaskID: "A", Role: "implementation", ExperimentID: "exp", VariantID: "a", Outcome: "completed", Timestamp: in},
+		{TaskID: "B", Role: "testing", ExperimentID: "exp", VariantID: "a", Outcome: "completed", Timestamp: in},
+	}
+
+	got := CompareVariants(records, nil, since, base, 20)
+	if len(got) != 1 {
+		t.Fatalf("variant rows = %d, want 1: %+v", len(got), got)
+	}
+	if !got[0].InsufficientData {
+		t.Fatalf("parent should be low sample: %+v", got[0])
+	}
+	if len(got[0].RoleBreakdowns) != 2 {
+		t.Fatalf("role breakdowns = %d, want 2: %+v", len(got[0].RoleBreakdowns), got[0].RoleBreakdowns)
+	}
+	for _, child := range got[0].RoleBreakdowns {
+		if !child.InsufficientData {
+			t.Fatalf("child should be low sample: %+v", child)
+		}
+	}
+}
+
+func TestCompareVariantsClearsMixedParentMetadata(t *testing.T) {
+	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -7)
+	in := base.Add(-1 * time.Hour)
+	records := []stats.RunRecord{
+		{Role: "implementation", Provider: "claude", Model: "sonnet", ReasoningEffort: "medium", ExperimentID: "exp", VariantID: "a", Outcome: "completed", Timestamp: in},
+		{Role: "fix-review", Provider: "codex", Model: "gpt-5", ReasoningEffort: "high", ExperimentID: "exp", VariantID: "a", Outcome: "completed", Timestamp: in},
+	}
+
+	got := CompareVariants(records, nil, since, base, 0)
+	if len(got) != 1 {
+		t.Fatalf("variant rows = %d, want 1: %+v", len(got), got)
+	}
+	if got[0].Provider != "" || got[0].Model != "" || got[0].ReasoningEffort != "" {
+		t.Fatalf("mixed parent metadata should be cleared: %+v", got[0])
+	}
+}
+
+func TestCompareVariantsUsesDelimiterSafeIdentity(t *testing.T) {
+	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -7)
+	in := base.Add(-1 * time.Hour)
+	records := []stats.RunRecord{
+		{TaskID: "A", Role: "implementation", ExperimentID: "exp:a", VariantID: "var:b", Outcome: "completed", Timestamp: in},
+		{TaskID: "B", Role: "fix-review", ExperimentID: "exp:a", VariantID: "var:b", Outcome: "completed", Timestamp: in},
+	}
+
+	got := CompareVariants(records, nil, since, base, 0)
+	if len(got) != 1 {
+		t.Fatalf("variant rows = %d, want 1: %+v", len(got), got)
+	}
+	if got[0].ExperimentID != "exp:a" || got[0].VariantID != "var:b" {
+		t.Fatalf("parent identity lost delimiters: %+v", got[0])
+	}
+	if len(got[0].RoleBreakdowns) != 2 {
+		t.Fatalf("children did not attach to delimiter-containing parent: %+v", got[0])
+	}
+}
+
+func TestCompareVariantsPreservesLatestAuthorAttribution(t *testing.T) {
+	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -7)
+	t1 := base.Add(-3 * time.Hour)
+	t2 := base.Add(-2 * time.Hour)
+	landedAt := base.Add(-1 * time.Hour)
+	revertedAt := base.Add(-30 * time.Minute)
+	records := []stats.RunRecord{
+		{TaskID: "A", Role: "implementation", ExperimentID: "exp", VariantID: "a", Outcome: "completed", Timestamp: t1},
+		{TaskID: "A", Role: "fix-review", ExperimentID: "exp", VariantID: "a", Outcome: "completed", Timestamp: t2},
+		{TaskID: "B", Role: "implementation", ExperimentID: "exp", VariantID: "a", CostUSD: 4, PremiumRequests: 8, Outcome: "completed", Timestamp: t2},
+	}
+	events := []audit.Event{
+		{Type: audit.EventTaskLanded, TaskID: "A", Timestamp: landedAt, Data: map[string]any{"outcome": "merged"}},
+		{Type: audit.EventTaskLanded, TaskID: "B", Timestamp: landedAt, Data: map[string]any{"outcome": "merged_with_edits"}},
+		{Type: audit.EventPRCIFailureDetected, TaskID: "B", Timestamp: t2},
+		{Type: audit.EventTaskStatusChanged, TaskID: "B", Timestamp: t2, Data: map[string]any{"from": "in-progress", "to": "in-review"}},
+		{Type: audit.EventTaskStatusChanged, TaskID: "B", Timestamp: t2.Add(time.Minute), Data: map[string]any{"from": "in-progress", "to": "in-review"}},
+		{Type: audit.EventPRReverted, TaskID: "B", Timestamp: revertedAt},
+	}
+
+	got := CompareVariants(records, events, since, base, 0)
+	if len(got) != 1 {
+		t.Fatalf("variant rows = %d, want 1: %+v", len(got), got)
+	}
+	parent := got[0]
+	if parent.Landed != 2 || parent.Merged != 1 || parent.MergedWithEdits != 1 || parent.CIFirstPassRate != 0.5 || parent.ReworkRate != 0.5 || parent.RevertRate != 0.5 {
+		t.Fatalf("parent attribution metrics = %+v", parent)
+	}
+	impl := comparisonByRole(t, parent.RoleBreakdowns, "implementation")
+	if impl.Landed != 1 || impl.MergedWithEdits != 1 || impl.CIFirstPassRate != 0 || impl.ReworkRate != 1 || impl.RevertRate != 1 {
+		t.Fatalf("implementation child attribution = %+v", impl)
+	}
+	fix := comparisonByRole(t, parent.RoleBreakdowns, "fix-review")
+	if fix.Landed != 1 || fix.Merged != 1 || fix.CIFirstPassRate != 1 || fix.ReworkRate != 0 || fix.RevertRate != 0 {
+		t.Fatalf("fix-review child attribution = %+v", fix)
+	}
+}
+
+func comparisonByRole(t *testing.T, rows []ComparisonBreakdown, role string) ComparisonBreakdown {
+	t.Helper()
+	for i := range rows {
+		if rows[i].Role == role {
+			return rows[i]
+		}
+	}
+	t.Fatalf("role %q not found in %+v", role, rows)
+	return ComparisonBreakdown{}
+}
+
 func TestCompute_MergedWithEditsNotAutonomous(t *testing.T) {
 	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
 	since := base.AddDate(0, 0, -30)

--- a/internal/evaluation/service.go
+++ b/internal/evaluation/service.go
@@ -159,13 +159,8 @@ func (s *Service) Scan(_ context.Context) (Report, error) {
 			}
 			return r.Provider + ":" + r.Model + ":" + r.ReasoningEffort + ":" + normalizedRole(r.Role)
 		}),
-		ByVariant: CompareBy(recs, evts, since, now, 20, func(r stats.RunRecord) string {
-			if r.ExperimentID == "" || r.VariantID == "" {
-				return ""
-			}
-			return r.ExperimentID + ":" + r.VariantID + ":" + normalizedRole(r.Role)
-		}),
-		Notes: deferredNotes,
+		ByVariant: CompareVariants(recs, evts, since, now, 20),
+		Notes:     deferredNotes,
 	}
 	rep.Weaknesses = Weaknesses(rep)
 	return rep, nil

--- a/internal/evaluation/service_test.go
+++ b/internal/evaluation/service_test.go
@@ -1,0 +1,56 @@
+package evaluation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/stats"
+)
+
+type testStatsReader struct {
+	records []stats.RunRecord
+}
+
+func (r testStatsReader) All() []stats.RunRecord {
+	return r.records
+}
+
+func TestServiceScanBuildsVariantParentsWithRoleBreakdowns(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	in := now.Add(-1 * time.Hour)
+	svc := NewService(Deps{
+		Cfg: config.EvaluationConfig{WindowDays: 7},
+		Stats: testStatsReader{records: []stats.RunRecord{
+			{TaskID: "A", Role: "implementation", Provider: "claude", Model: "sonnet", ExperimentID: "exp", VariantID: "a", Outcome: "completed", Timestamp: in},
+			{TaskID: "B", Role: "fix-review", Provider: "claude", Model: "sonnet", ExperimentID: "exp", VariantID: "a", Outcome: "completed", Timestamp: in},
+		}},
+		Audit: auditFunc(func(q audit.Query) ([]audit.Event, error) {
+			return []audit.Event{
+				{Type: audit.EventTaskLanded, TaskID: "A", Timestamp: in, Data: map[string]any{"outcome": "merged"}},
+				{Type: audit.EventTaskLanded, TaskID: "B", Timestamp: in, Data: map[string]any{"outcome": "merged"}},
+			}, nil
+		}),
+		Now: func() time.Time { return now },
+	})
+
+	got, err := svc.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan returned error: %v", err)
+	}
+	if len(got.ByVariant) != 1 {
+		t.Fatalf("ByVariant rows = %d, want 1 aggregate parent: %+v", len(got.ByVariant), got.ByVariant)
+	}
+	parent := got.ByVariant[0]
+	if parent.ExperimentID != "exp" || parent.VariantID != "a" || parent.Role != "" || parent.Runs != 2 || parent.Landed != 2 {
+		t.Fatalf("ByVariant parent = %+v, want aggregate exp/a row across roles", parent)
+	}
+	if len(parent.RoleBreakdowns) != 2 {
+		t.Fatalf("roleBreakdowns = %d, want 2: %+v", len(parent.RoleBreakdowns), parent.RoleBreakdowns)
+	}
+	if got.ByAgentModel[0].RoleBreakdowns != nil {
+		t.Fatalf("ByAgentModel should remain flat, got nested rows: %+v", got.ByAgentModel[0])
+	}
+}


### PR DESCRIPTION
## Motivation

A/B rows were grouped by experiment + variant + role, fragmenting already-small samples and hiding the main experiment-level comparison.

## Implementation information

Show variant-level rows first, then role-specific drilldowns:
- experiment/variant aggregate view across roles
- role-level rows kept as a secondary breakdown
- run/landed counts, failure rate, CI-first-pass, edited-merge, rework, revert, duration, cost, premium requests at both levels
- existing JSON fields preserved

> Changelog: feat(evaluation): aggregate A/B variants

Closes #1250