### PR TITLE
feat(evaluation): improve A/B attribution

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/evaluation/models.ts
@@ -60,12 +60,9 @@ export class Breakdown {
     }
 }
 
-/**
- * ComparisonBreakdown compares agent/model or experiment variants on the
- * speed, quality, and cost signals Sybra already records.
- */
 export class ComparisonBreakdown {
     "key": string;
+    "attributionMode": string;
     "provider"?: string;
     "model"?: string;
     "role"?: string;
@@ -100,6 +97,9 @@ export class ComparisonBreakdown {
     constructor($$source: Partial<ComparisonBreakdown> = {}) {
         if (!("key" in $$source)) {
             this["key"] = "";
+        }
+        if (!("attributionMode" in $$source)) {
+            this["attributionMode"] = "";
         }
         if (!("runs" in $$source)) {
             this["runs"] = 0;
@@ -175,10 +175,10 @@ export class ComparisonBreakdown {
      * Creates a new ComparisonBreakdown instance from a string or object.
      */
     static createFrom($$source: any = {}): ComparisonBreakdown {
-        const $$createField29_0 = $$createType1;
+        const $$createField30_0 = $$createType1;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("roleBreakdowns" in $$parsedSource) {
-            $$parsedSource["roleBreakdowns"] = $$createField29_0($$parsedSource["roleBreakdowns"]);
+            $$parsedSource["roleBreakdowns"] = $$createField30_0($$parsedSource["roleBreakdowns"]);
         }
         return new ComparisonBreakdown($$parsedSource as Partial<ComparisonBreakdown>);
     }
@@ -291,7 +291,9 @@ export class Report {
     "byProvider"?: Breakdown[];
     "byRole"?: Breakdown[];
     "byAgentModel"?: ComparisonBreakdown[];
+    "byAgentModelContribution"?: ComparisonBreakdown[];
     "byVariant"?: ComparisonBreakdown[];
+    "byVariantContribution"?: ComparisonBreakdown[];
     "weaknesses"?: Weakness[];
     "notes"?: string[];
 
@@ -322,8 +324,10 @@ export class Report {
         const $$createField5_0 = $$createType8;
         const $$createField6_0 = $$createType1;
         const $$createField7_0 = $$createType1;
-        const $$createField8_0 = $$createType10;
-        const $$createField9_0 = $$createType11;
+        const $$createField8_0 = $$createType1;
+        const $$createField9_0 = $$createType1;
+        const $$createField10_0 = $$createType10;
+        const $$createField11_0 = $$createType11;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("overall" in $$parsedSource) {
             $$parsedSource["overall"] = $$createField3_0($$parsedSource["overall"]);
@@ -337,14 +341,20 @@ export class Report {
         if ("byAgentModel" in $$parsedSource) {
             $$parsedSource["byAgentModel"] = $$createField6_0($$parsedSource["byAgentModel"]);
         }
+        if ("byAgentModelContribution" in $$parsedSource) {
+            $$parsedSource["byAgentModelContribution"] = $$createField7_0($$parsedSource["byAgentModelContribution"]);
+        }
         if ("byVariant" in $$parsedSource) {
-            $$parsedSource["byVariant"] = $$createField7_0($$parsedSource["byVariant"]);
+            $$parsedSource["byVariant"] = $$createField8_0($$parsedSource["byVariant"]);
+        }
+        if ("byVariantContribution" in $$parsedSource) {
+            $$parsedSource["byVariantContribution"] = $$createField9_0($$parsedSource["byVariantContribution"]);
         }
         if ("weaknesses" in $$parsedSource) {
-            $$parsedSource["weaknesses"] = $$createField8_0($$parsedSource["weaknesses"]);
+            $$parsedSource["weaknesses"] = $$createField10_0($$parsedSource["weaknesses"]);
         }
         if ("notes" in $$parsedSource) {
-            $$parsedSource["notes"] = $$createField9_0($$parsedSource["notes"]);
+            $$parsedSource["notes"] = $$createField11_0($$parsedSource["notes"]);
         }
         return new Report($$parsedSource as Partial<Report>);
     }

--- a/frontend/src/pages/Evaluation.svelte
+++ b/frontend/src/pages/Evaluation.svelte
@@ -421,7 +421,7 @@
       </div>
 
       <div class="overflow-x-auto rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
-        <h3 class="mb-3 text-sm font-semibold text-surface-500">A/B Experiments final-stage</h3>
+        <h3 class="mb-3 text-sm font-semibold text-surface-500">A/B Experiments</h3>
         <p class="mb-3 max-w-3xl text-xs text-surface-400">
           Primary signal: landed/run. Guardrails watch reliability, quality, speed, cost, and premium-model usage.
         </p>

--- a/frontend/src/pages/Evaluation.svelte
+++ b/frontend/src/pages/Evaluation.svelte
@@ -357,7 +357,71 @@
       </div>
 
       <div class="overflow-x-auto rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
-        <h3 class="mb-3 text-sm font-semibold text-surface-500">A/B Experiments</h3>
+        <h3 class="mb-1 text-sm font-semibold text-surface-500">Agent / Model contribution</h3>
+        <p class="mb-3 text-xs text-surface-400">
+          Credits each distinct in-window author group that contributed before landing; totals can exceed landed tasks.
+        </p>
+        {#if report?.byAgentModelContribution && report.byAgentModelContribution.length > 0}
+          <table class="w-full min-w-[1080px] text-sm">
+            <thead>
+              <tr class="border-b border-surface-200 text-left text-xs text-surface-400 dark:border-surface-700">
+                <th class="pb-2">Variant</th>
+                <th class="pb-2">Role</th>
+                <th class="pb-2 text-right">Runs</th>
+                <th class="pb-2 text-right">Landed</th>
+                <th class="pb-2 text-right">Fail %</th>
+                <th class="pb-2 text-right">Merge %</th>
+                <th class="pb-2 text-right">CI 1st</th>
+                <th class="pb-2 text-right">Edited</th>
+                <th class="pb-2 text-right">Rework</th>
+                <th class="pb-2 text-right">Revert</th>
+                <th class="pb-2 text-right">Duration</th>
+                <th class="pb-2 text-right">Cost</th>
+                <th class="pb-2 text-right">Premium req</th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each report.byAgentModelContribution as row (row.key)}
+                <tr class="border-b border-surface-100 last:border-0 dark:border-surface-700">
+                  <td class="py-1.5">
+                    <div class="font-mono text-xs">{row.variantId || row.key}</div>
+                    <div class="text-xs text-surface-400">
+                      {row.provider}{row.model ? ` · ${row.model}` : ''}{row.reasoningEffort ? ` · ${row.reasoningEffort}` : ''}
+                    </div>
+                  </td>
+                  <td class="py-1.5 text-xs">{row.role || '—'}</td>
+                  <td class="py-1.5 text-right">
+                    {row.runs}
+                    {#if row.insufficientData}
+                      <span class="ml-1 rounded bg-surface-200 px-1 text-[10px] text-surface-500 dark:bg-surface-700">low N</span>
+                    {/if}
+                  </td>
+                  <td class="py-1.5 text-right">
+                    {row.landed}
+                    {#if row.qualityAttributionLimited}
+                      <span class="ml-1 rounded bg-warning-200 px-1 text-[10px] text-warning-800 dark:bg-warning-800 dark:text-warning-200">limited attribution</span>
+                    {/if}
+                  </td>
+                  <td class="py-1.5 text-right">{pct(row.failureRate)}</td>
+                  <td class="py-1.5 text-right">{pct(row.mergeRate)}</td>
+                  <td class="py-1.5 text-right">{pct(row.ciFirstPassRate)}</td>
+                  <td class="py-1.5 text-right">{pct(row.mergedWithEditsRate)}</td>
+                  <td class="py-1.5 text-right">{pct(row.reworkRate)}</td>
+                  <td class="py-1.5 text-right">{pct(row.revertRate)}</td>
+                  <td class="py-1.5 text-right">p50 {seconds(row.durationP50S)} · p90 {seconds(row.durationP90S)}</td>
+                  <td class="py-1.5 text-right">${num(row.totalCostUsd, 2)} · ${num(row.costPerLanded, 2)}/landed</td>
+                  <td class="py-1.5 text-right">{num(row.premiumRequests, 1)} · {num(row.premiumRequestsPerLanded, 1)}/landed</td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        {:else}
+          <p class="text-xs text-surface-400">No data</p>
+        {/if}
+      </div>
+
+      <div class="overflow-x-auto rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <h3 class="mb-3 text-sm font-semibold text-surface-500">A/B Experiments final-stage</h3>
         <p class="mb-3 max-w-3xl text-xs text-surface-400">
           Primary signal: landed/run. Guardrails watch reliability, quality, speed, cost, and premium-model usage.
         </p>
@@ -452,6 +516,131 @@
                       {/if}
                     </td>
                     <td class="py-1.5 text-right">{child.landed}</td>
+                    <td class="py-1.5 text-right">{pct(child.failureRate)}</td>
+                    <td class="py-1.5 text-right">{pct(child.mergeRate)}</td>
+                    <td class="py-1.5 text-right">{pct(child.ciFirstPassRate)}</td>
+                    <td class="py-1.5 text-right">{pct(child.mergedWithEditsRate)}</td>
+                    <td class="py-1.5 text-right">{pct(child.reworkRate)}</td>
+                    <td class="py-1.5 text-right">{pct(child.revertRate)}</td>
+                    <td class="py-1.5 text-right">p50 {seconds(child.durationP50S)} · p90 {seconds(child.durationP90S)}</td>
+                    <td class="py-1.5 text-right">${num(child.totalCostUsd, 2)} · ${num(child.costPerLanded, 2)}/landed</td>
+                    <td class="py-1.5 text-right">{num(child.premiumRequests, 1)} · {num(child.premiumRequestsPerLanded, 1)}/landed</td>
+                  </tr>
+                {/each}
+              {/each}
+            </tbody>
+          </table>
+        {:else}
+          <p class="text-xs text-surface-400">No data</p>
+        {/if}
+      </div>
+
+      <div class="overflow-x-auto rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+        <h3 class="mb-1 text-sm font-semibold text-surface-500">A/B Experiments contribution</h3>
+        <p class="mb-3 max-w-3xl text-xs text-surface-400">
+          Credits each distinct in-window author group that contributed before landing; totals can exceed landed tasks.
+        </p>
+        {#if report?.byVariantContribution && report.byVariantContribution.length > 0}
+          <table class="w-full min-w-[1080px] text-sm">
+            <thead>
+              <tr class="border-b border-surface-200 text-left text-xs text-surface-400 dark:border-surface-700">
+                <th class="pb-2">Variant</th>
+                <th class="pb-2">Role</th>
+                <th class="pb-2 text-right">Runs</th>
+                <th class="pb-2 text-right">Landed</th>
+                <th class="pb-2 text-right">Fail %</th>
+                <th class="pb-2 text-right">Merge %</th>
+                <th class="pb-2 text-right">CI 1st</th>
+                <th class="pb-2 text-right">Edited</th>
+                <th class="pb-2 text-right">Rework</th>
+                <th class="pb-2 text-right">Revert</th>
+                <th class="pb-2 text-right">Duration</th>
+                <th class="pb-2 text-right">Cost</th>
+                <th class="pb-2 text-right">Premium req</th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each report.byVariantContribution as row (row.key)}
+                {@const interpretation = interpretExperiment(row, report.byVariantContribution)}
+                <tr class="border-b border-surface-100 bg-surface-100/60 dark:border-surface-700 dark:bg-surface-700/30">
+                  <td class="py-1.5">
+                    <div class="font-mono text-xs">{row.variantId || row.key}</div>
+                    <div class="text-xs text-surface-400">
+                      {row.provider}{row.model ? ` · ${row.model}` : ''}{row.reasoningEffort ? ` · ${row.reasoningEffort}` : ''}
+                    </div>
+                    <div class="mt-1 flex flex-wrap items-center gap-1.5">
+                      <span class="rounded px-1.5 py-0.5 text-[10px] font-medium {verdictClasses(interpretation.verdict)}">
+                        {interpretation.verdictLabel}
+                      </span>
+                      <span class="text-[10px] text-surface-500">
+                        {interpretation.primaryLabel}: {interpretation.primaryValue} ({interpretation.primaryDetail})
+                      </span>
+                    </div>
+                    <p class="mt-1 text-[10px] text-surface-400">{interpretation.verdictReason}</p>
+                  </td>
+                  <td class="py-1.5 text-xs font-medium">All roles</td>
+                  <td class="py-1.5 text-right">
+                    {row.runs}
+                    {#if row.insufficientData}
+                      <span class="ml-1 rounded bg-surface-200 px-1 text-[10px] text-surface-500 dark:bg-surface-700">low N</span>
+                    {/if}
+                  </td>
+                  <td class="py-1.5 text-right">
+                    {row.landed}
+                    {#if row.qualityAttributionLimited}
+                      <span class="ml-1 rounded bg-warning-200 px-1 text-[10px] text-warning-800 dark:bg-warning-800 dark:text-warning-200">limited attribution</span>
+                    {/if}
+                  </td>
+                  <td class="py-1.5 text-right">{pct(row.failureRate)}</td>
+                  <td class="py-1.5 text-right">{pct(row.mergeRate)}</td>
+                  <td class="py-1.5 text-right">{pct(row.ciFirstPassRate)}</td>
+                  <td class="py-1.5 text-right">{pct(row.mergedWithEditsRate)}</td>
+                  <td class="py-1.5 text-right">{pct(row.reworkRate)}</td>
+                  <td class="py-1.5 text-right">{pct(row.revertRate)}</td>
+                  <td class="py-1.5 text-right">p50 {seconds(row.durationP50S)} · p90 {seconds(row.durationP90S)}</td>
+                  <td class="py-1.5 text-right">${num(row.totalCostUsd, 2)} · ${num(row.costPerLanded, 2)}/landed</td>
+                  <td class="py-1.5 text-right">{num(row.premiumRequests, 1)} · {num(row.premiumRequestsPerLanded, 1)}/landed</td>
+                </tr>
+                <tr class="border-b border-surface-100 dark:border-surface-700">
+                  <td class="pb-2 pt-0" colspan="13">
+                    <div class="flex flex-wrap gap-1.5">
+                      {#each interpretation.guardrails as guardrail (guardrail.key)}
+                        <span
+                          class="rounded border px-1.5 py-0.5 text-[10px] {guardrailClasses(guardrail.status)}"
+                          title={guardrail.detail}
+                        >
+                          {guardrail.label}: {guardrail.status}
+                        </span>
+                      {/each}
+                    </div>
+                    {#if interpretation.limitedSignals.length > 0}
+                      <p class="mt-1 text-[10px] text-surface-400">
+                        Limited signals: {interpretation.limitedSignals.join(' ')}
+                      </p>
+                    {/if}
+                  </td>
+                </tr>
+                {#each row.roleBreakdowns ?? [] as child (child.key)}
+                  <tr class="border-b border-surface-100 last:border-0 dark:border-surface-700">
+                    <td class="py-1.5 pl-6">
+                      <div class="font-mono text-xs text-surface-500">{child.variantId || row.variantId || child.key}</div>
+                      <div class="text-xs text-surface-400">
+                        {child.provider}{child.model ? ` · ${child.model}` : ''}{child.reasoningEffort ? ` · ${child.reasoningEffort}` : ''}
+                      </div>
+                    </td>
+                    <td class="py-1.5 text-xs">{child.role || '—'}</td>
+                    <td class="py-1.5 text-right">
+                      {child.runs}
+                      {#if child.insufficientData}
+                        <span class="ml-1 rounded bg-surface-200 px-1 text-[10px] text-surface-500 dark:bg-surface-700">low N</span>
+                      {/if}
+                    </td>
+                    <td class="py-1.5 text-right">
+                      {child.landed}
+                      {#if child.qualityAttributionLimited}
+                        <span class="ml-1 rounded bg-warning-200 px-1 text-[10px] text-warning-800 dark:bg-warning-800 dark:text-warning-200">limited attribution</span>
+                      {/if}
+                    </td>
                     <td class="py-1.5 text-right">{pct(child.failureRate)}</td>
                     <td class="py-1.5 text-right">{pct(child.mergeRate)}</td>
                     <td class="py-1.5 text-right">{pct(child.ciFirstPassRate)}</td>

--- a/internal/evaluation/scorecard.go
+++ b/internal/evaluation/scorecard.go
@@ -71,8 +71,16 @@ type Breakdown struct {
 
 // ComparisonBreakdown compares agent/model or experiment variants on the
 // speed, quality, and cost signals Sybra already records.
+type ComparisonAttributionMode string
+
+const (
+	ComparisonAttributionLatestAuthor    ComparisonAttributionMode = "latest_author"
+	ComparisonAttributionAnyContribution ComparisonAttributionMode = "any_author_contribution"
+)
+
 type ComparisonBreakdown struct {
 	Key                       string                `json:"key"`
+	AttributionMode           string                `json:"attributionMode"`
 	Provider                  string                `json:"provider,omitempty"`
 	Model                     string                `json:"model,omitempty"`
 	Role                      string                `json:"role,omitempty"`
@@ -106,16 +114,18 @@ type ComparisonBreakdown struct {
 
 // Report is the persisted, emitted, and CLI-printed output of one evaluation tick.
 type Report struct {
-	GeneratedAt  time.Time             `json:"generatedAt"`
-	Since        time.Time             `json:"since"`
-	Until        time.Time             `json:"until"`
-	Overall      Scorecard             `json:"overall"`
-	ByProvider   []Breakdown           `json:"byProvider,omitempty"`
-	ByRole       []Breakdown           `json:"byRole,omitempty"`
-	ByAgentModel []ComparisonBreakdown `json:"byAgentModel,omitempty"`
-	ByVariant    []ComparisonBreakdown `json:"byVariant,omitempty"`
-	Weaknesses   []Weakness            `json:"weaknesses,omitempty"`
-	Notes        []string              `json:"notes,omitempty"`
+	GeneratedAt              time.Time             `json:"generatedAt"`
+	Since                    time.Time             `json:"since"`
+	Until                    time.Time             `json:"until"`
+	Overall                  Scorecard             `json:"overall"`
+	ByProvider               []Breakdown           `json:"byProvider,omitempty"`
+	ByRole                   []Breakdown           `json:"byRole,omitempty"`
+	ByAgentModel             []ComparisonBreakdown `json:"byAgentModel,omitempty"`
+	ByAgentModelContribution []ComparisonBreakdown `json:"byAgentModelContribution,omitempty"`
+	ByVariant                []ComparisonBreakdown `json:"byVariant,omitempty"`
+	ByVariantContribution    []ComparisonBreakdown `json:"byVariantContribution,omitempty"`
+	Weaknesses               []Weakness            `json:"weaknesses,omitempty"`
+	Notes                    []string              `json:"notes,omitempty"`
 }
 
 // deferredNotes documents metrics that need signals not yet captured, so the
@@ -380,9 +390,10 @@ func BreakdownBy(records []stats.RunRecord, since, until time.Time, key func(sta
 	return out
 }
 
-// CompareBy groups run records by key and attributes landed-task outcomes to
-// the latest code-author run for that task. minSamples controls the
-// InsufficientData flag only; rows are still emitted so users can see early data.
+// CompareByLatestAuthor and CompareByContribution group run records by key and
+// attribute landed-task outcomes using explicit final-stage or contribution
+// semantics. minSamples controls the InsufficientData flag only; rows are still
+// emitted so users can see early data.
 type comparisonAcc struct {
 	row             ComparisonBreakdown
 	durations       []float64
@@ -391,13 +402,22 @@ type comparisonAcc struct {
 	reverted        int
 }
 
-func CompareBy(records []stats.RunRecord, events []audit.Event, since, until time.Time, minSamples int, key func(stats.RunRecord) string) []ComparisonBreakdown {
+func CompareByLatestAuthor(records []stats.RunRecord, events []audit.Event, since, until time.Time, minSamples int, key func(stats.RunRecord) string) []ComparisonBreakdown {
+	return compareByAttribution(records, events, since, until, minSamples, key, ComparisonAttributionLatestAuthor)
+}
+
+func CompareByContribution(records []stats.RunRecord, events []audit.Event, since, until time.Time, minSamples int, key func(stats.RunRecord) string) []ComparisonBreakdown {
+	return compareByAttribution(records, events, since, until, minSamples, key, ComparisonAttributionAnyContribution)
+}
+
+func compareByAttribution(records []stats.RunRecord, events []audit.Event, since, until time.Time, minSamples int, key func(stats.RunRecord) string, mode ComparisonAttributionMode) []ComparisonBreakdown {
 	groups := map[string]*comparisonAcc{}
 	ensure := func(r stats.RunRecord, k string) *comparisonAcc {
 		a := groups[k]
 		if a == nil {
 			a = &comparisonAcc{row: ComparisonBreakdown{
 				Key:             k,
+				AttributionMode: string(mode),
 				Provider:        r.Provider,
 				Model:           r.Model,
 				Role:            normalizedRole(r.Role),
@@ -430,17 +450,23 @@ func CompareBy(records []stats.RunRecord, events []audit.Event, since, until tim
 		a.tools += r.ToolCalls
 	}
 
-	applyComparisonLandings(ensure, records, events, since, until, key)
+	applyComparisonLandings(ensure, records, events, since, until, key, mode)
 	return comparisonRows(groups, minSamples)
 }
 
 // CompareVariants returns A/B rows at experiment/variant granularity, with
-// role-specific rows attached as drilldowns. It deliberately reuses CompareBy
-// for both levels so attribution and low-sample semantics stay identical to the
-// flat comparison path.
+// role-specific rows attached as drilldowns. It uses latest-author attribution.
 func CompareVariants(records []stats.RunRecord, events []audit.Event, since, until time.Time, minSamples int) []ComparisonBreakdown {
-	parents := CompareBy(records, events, since, until, minSamples, variantKey)
-	children := CompareBy(records, events, since, until, minSamples, variantRoleKey)
+	return compareVariantsByAttribution(records, events, since, until, minSamples, ComparisonAttributionLatestAuthor)
+}
+
+func CompareVariantsByContribution(records []stats.RunRecord, events []audit.Event, since, until time.Time, minSamples int) []ComparisonBreakdown {
+	return compareVariantsByAttribution(records, events, since, until, minSamples, ComparisonAttributionAnyContribution)
+}
+
+func compareVariantsByAttribution(records []stats.RunRecord, events []audit.Event, since, until time.Time, minSamples int, mode ComparisonAttributionMode) []ComparisonBreakdown {
+	parents := compareByAttribution(records, events, since, until, minSamples, variantKey, mode)
+	children := compareByAttribution(records, events, since, until, minSamples, variantRoleKey, mode)
 	normalizeVariantParents(parents, records, since, until)
 
 	for i := range parents {
@@ -538,41 +564,42 @@ func (v *valueConsensus) value() string {
 	return v.chosen
 }
 
-func applyComparisonLandings(ensure func(stats.RunRecord, string) *comparisonAcc, records []stats.RunRecord, events []audit.Event, since, until time.Time, key func(stats.RunRecord) string) {
+func applyComparisonLandings(ensure func(stats.RunRecord, string) *comparisonAcc, records []stats.RunRecord, events []audit.Event, since, until time.Time, key func(stats.RunRecord) string, mode ComparisonAttributionMode) {
 	landed := scanLandings(events, func(t time.Time) bool { return !t.Before(since) && !t.After(until) })
 	sigs := scanTaskSignals(events)
+	credited := map[string]map[string]stats.RunRecord{}
 	for taskID := range landed.tasks {
 		landedAt := landingTimestamp(events, taskID, since, until)
 		if landedAt.IsZero() {
 			continue
 		}
-		r, ok := latestAuthorRun(records, taskID, since, landedAt, key)
-		if !ok {
+		taskCredits := creditedAuthorRuns(records, taskID, since, landedAt, key, mode)
+		if len(taskCredits) == 0 {
 			continue
 		}
-		k := key(r)
-		if k == "" {
-			continue
-		}
-		a := ensure(r, k)
-		a.row.Landed++
-		if landed.edited[taskID] {
-			a.row.MergedWithEdits++
-		} else {
-			// scanLandings tracks closed only as aggregate; read the per-task
-			// outcome directly so variant rows preserve merged vs closed.
-			switch landingOutcome(events, taskID, since, until) {
-			case "closed":
-				a.row.Closed++
-			default:
-				a.row.Merged++
+		credited[taskID] = taskCredits
+		for k := range taskCredits {
+			r := taskCredits[k]
+			a := ensure(r, k)
+			a.row.Landed++
+			if landed.edited[taskID] {
+				a.row.MergedWithEdits++
+			} else {
+				// scanLandings tracks closed only as aggregate; read the per-task
+				// outcome directly so variant rows preserve merged vs closed.
+				switch landingOutcome(events, taskID, since, until) {
+				case "closed":
+					a.row.Closed++
+				default:
+					a.row.Merged++
+				}
 			}
-		}
-		if s := sigs[taskID]; s == nil || !s.ciFixNeeded {
-			a.ciClean++
-		}
-		if taskHasRework(sigs[taskID]) {
-			a.rework++
+			if s := sigs[taskID]; s == nil || !s.ciFixNeeded {
+				a.ciClean++
+			}
+			if taskHasRework(sigs[taskID]) {
+				a.rework++
+			}
 		}
 	}
 	for i := range events {
@@ -580,14 +607,42 @@ func applyComparisonLandings(ensure func(stats.RunRecord, string) *comparisonAcc
 		if e.Type != audit.EventPRReverted || e.TaskID == "" || e.Timestamp.Before(since) || e.Timestamp.After(until) {
 			continue
 		}
-		r, ok := latestAuthorRun(records, e.TaskID, since, e.Timestamp, key)
-		if !ok {
-			continue
-		}
-		if k := key(r); k != "" {
+		for k := range credited[e.TaskID] {
+			r := credited[e.TaskID][k]
 			ensure(r, k).reverted++
 		}
 	}
+}
+
+func creditedAuthorRuns(records []stats.RunRecord, taskID string, since, landedAt time.Time, key func(stats.RunRecord) string, mode ComparisonAttributionMode) map[string]stats.RunRecord {
+	switch mode {
+	case ComparisonAttributionAnyContribution:
+		return latestAuthorRunsByKey(records, taskID, since, landedAt, key)
+	default:
+		r, ok := latestAuthorRun(records, taskID, since, landedAt, key)
+		if !ok {
+			return nil
+		}
+		return map[string]stats.RunRecord{key(r): r}
+	}
+}
+
+func latestAuthorRunsByKey(records []stats.RunRecord, taskID string, since, until time.Time, key func(stats.RunRecord) string) map[string]stats.RunRecord {
+	best := map[string]stats.RunRecord{}
+	for i := range records {
+		r := records[i]
+		if r.TaskID != taskID || r.Timestamp.Before(since) || r.Timestamp.After(until) || !isAuthorRole(r.Role) {
+			continue
+		}
+		k := key(r)
+		if k == "" {
+			continue
+		}
+		if prev, ok := best[k]; !ok || r.Timestamp.After(prev.Timestamp) {
+			best[k] = r
+		}
+	}
+	return best
 }
 
 func comparisonRows(groups map[string]*comparisonAcc, minSamples int) []ComparisonBreakdown {

--- a/internal/evaluation/scorecard_test.go
+++ b/internal/evaluation/scorecard_test.go
@@ -1,10 +1,12 @@
 package evaluation
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/stats"
 )
 
@@ -124,7 +126,7 @@ func TestCompareByVariant(t *testing.T) {
 	events := []audit.Event{
 		{Type: audit.EventTaskLanded, TaskID: "A", Timestamp: in, Data: map[string]any{"outcome": "merged"}},
 	}
-	got := CompareBy(records, events, since, base, 20, func(r stats.RunRecord) string {
+	got := CompareByLatestAuthor(records, events, since, base, 20, func(r stats.RunRecord) string {
 		if r.ExperimentID == "" || r.VariantID == "" {
 			return ""
 		}
@@ -140,6 +142,9 @@ func TestCompareByVariant(t *testing.T) {
 	if gpt.Runs != 1 || gpt.Landed != 1 || gpt.MergeRate != 1 || gpt.PremiumRequests != 7.5 || gpt.PremiumRequestsPerLanded != 7.5 {
 		t.Fatalf("gpt row = %+v", gpt)
 	}
+	if gpt.AttributionMode != string(ComparisonAttributionLatestAuthor) {
+		t.Fatalf("attribution mode = %q, want latest author", gpt.AttributionMode)
+	}
 	if !gpt.InsufficientData {
 		t.Fatalf("gpt row should be marked low sample: %+v", gpt)
 	}
@@ -154,7 +159,7 @@ func TestCompareByVariantDoesNotAttributePreWindowRun(t *testing.T) {
 	events := []audit.Event{
 		{Type: audit.EventTaskLanded, TaskID: "A", Timestamp: base.Add(-1 * time.Hour), Data: map[string]any{"outcome": "merged"}},
 	}
-	got := CompareBy(records, events, since, base, 0, func(r stats.RunRecord) string {
+	got := CompareByLatestAuthor(records, events, since, base, 0, func(r stats.RunRecord) string {
 		return r.ExperimentID + ":" + r.VariantID
 	})
 	if len(got) != 0 {
@@ -319,6 +324,64 @@ func comparisonByRole(t *testing.T, rows []ComparisonBreakdown, role string) Com
 	return ComparisonBreakdown{}
 }
 
+func TestCompareByAttributionModes(t *testing.T) {
+	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	since := base.AddDate(0, 0, -7)
+	landedAt := base.Add(-1 * time.Hour)
+	records := []stats.RunRecord{
+		// Pre-window author must not be credited.
+		{TaskID: "A", Role: "implementation", Provider: "claude", Model: "old", ExperimentID: "exp", VariantID: "old", Outcome: "completed", Timestamp: since.Add(-1 * time.Nanosecond)},
+		// Same key appears twice before landing; contribution mode credits it once.
+		{TaskID: "A", Role: "implementation", Provider: "copilot", Model: "gpt", ExperimentID: "exp", VariantID: "gpt", Outcome: "completed", Timestamp: since},
+		{TaskID: "A", Role: "implementation", Provider: "copilot", Model: "gpt", ExperimentID: "exp", VariantID: "gpt", Outcome: "completed", Timestamp: landedAt.Add(-10 * time.Minute)},
+		// Inclusive landedAt cutoff: this final-stage author is eligible exactly at landing.
+		{TaskID: "A", Role: "fix-review", Provider: "claude", Model: "opus", ExperimentID: "exp", VariantID: "opus", Outcome: "completed", Timestamp: landedAt},
+		// Reverted but never landed in this window: runs remain visible, quality attribution does not move.
+		{TaskID: "B", Role: "implementation", Provider: "codex", Model: "gpt", ExperimentID: "exp", VariantID: "unused", Outcome: "completed", Timestamp: landedAt},
+	}
+	events := []audit.Event{
+		{Type: audit.EventTaskLanded, TaskID: "A", Timestamp: landedAt, Data: map[string]any{"outcome": "merged"}},
+		{Type: audit.EventTaskLanded, TaskID: "A", Timestamp: landedAt.Add(1 * time.Minute), Data: map[string]any{"outcome": "merged"}}, // duplicate audit event
+		{Type: audit.EventPRReverted, TaskID: "A", Timestamp: landedAt.Add(30 * time.Minute)},
+		{Type: audit.EventPRReverted, TaskID: "B", Timestamp: landedAt.Add(30 * time.Minute)},
+	}
+	key := func(r stats.RunRecord) string {
+		if r.ExperimentID == "" || r.VariantID == "" {
+			return ""
+		}
+		return r.ExperimentID + ":" + r.VariantID + ":" + normalizedRole(r.Role)
+	}
+
+	latest := CompareByLatestAuthor(records, events, since, base, 0, key)
+	latestOpus := mustComparisonRow(t, latest, "exp:opus:fix-review")
+	if latestOpus.Landed != 1 || latestOpus.Merged != 1 || latestOpus.RevertRate != 1 {
+		t.Fatalf("latest opus row = %+v, want one landed merged revert", latestOpus)
+	}
+	if latestOpus.AttributionMode != string(ComparisonAttributionLatestAuthor) {
+		t.Fatalf("latest attribution mode = %q", latestOpus.AttributionMode)
+	}
+	if row, ok := comparisonRow(latest, "exp:gpt:implementation"); !ok || row.Landed != 0 || !row.QualityAttributionLimited {
+		t.Fatalf("latest gpt row = %+v/%v, want visible limited-attribution run with no landing", row, ok)
+	}
+
+	contrib := CompareByContribution(records, events, since, base, 0, key)
+	gpt := mustComparisonRow(t, contrib, "exp:gpt:implementation")
+	if gpt.Landed != 1 || gpt.Merged != 1 || gpt.RevertRate != 1 {
+		t.Fatalf("contribution gpt row = %+v, want one de-duplicated landed merged revert", gpt)
+	}
+	if gpt.AttributionMode != string(ComparisonAttributionAnyContribution) {
+		t.Fatalf("contribution attribution mode = %q", gpt.AttributionMode)
+	}
+	opus := mustComparisonRow(t, contrib, "exp:opus:fix-review")
+	if opus.Landed != 1 || opus.RevertRate != 1 {
+		t.Fatalf("contribution opus row = %+v, want same landed cohort revert attribution", opus)
+	}
+	unused := mustComparisonRow(t, contrib, "exp:unused:implementation")
+	if unused.Landed != 0 || unused.RevertRate != 0 || !unused.QualityAttributionLimited {
+		t.Fatalf("unused out-of-cohort row = %+v, want no landing/revert quality attribution", unused)
+	}
+}
+
 func TestCompute_MergedWithEditsNotAutonomous(t *testing.T) {
 	base := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
 	since := base.AddDate(0, 0, -30)
@@ -389,6 +452,45 @@ func TestCompute_RevertOfOutOfWindowMergeNotCounted(t *testing.T) {
 	}
 }
 
+type staticStats struct {
+	records []stats.RunRecord
+}
+
+func (s staticStats) All() []stats.RunRecord { return append([]stats.RunRecord(nil), s.records...) }
+
+func TestServiceScanPopulatesAttributionReports(t *testing.T) {
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	landedAt := now.Add(-1 * time.Hour)
+	records := []stats.RunRecord{
+		{TaskID: "A", Role: "implementation", Provider: "copilot", Model: "gpt", ReasoningEffort: "high", ExperimentID: "exp", VariantID: "gpt", Outcome: "completed", Timestamp: landedAt.Add(-30 * time.Minute)},
+		{TaskID: "A", Role: "pr-fix", Provider: "claude", Model: "opus", ReasoningEffort: "medium", ExperimentID: "exp", VariantID: "opus", Outcome: "completed", Timestamp: landedAt},
+	}
+	events := []audit.Event{
+		{Type: audit.EventTaskLanded, TaskID: "A", Timestamp: landedAt, Data: map[string]any{"outcome": "merged"}},
+	}
+	svc := NewService(Deps{
+		Cfg:   config.EvaluationConfig{WindowDays: 7},
+		Stats: staticStats{records: records},
+		Audit: auditFunc(func(audit.Query) ([]audit.Event, error) { return events, nil }),
+		Now:   func() time.Time { return now },
+	})
+	rep, err := svc.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("Scan returned error: %v", err)
+	}
+	if len(rep.ByAgentModel) == 0 || len(rep.ByAgentModelContribution) == 0 || len(rep.ByVariant) == 0 || len(rep.ByVariantContribution) == 0 {
+		t.Fatalf("missing attribution report slices: agent=%d agentContrib=%d variant=%d variantContrib=%d", len(rep.ByAgentModel), len(rep.ByAgentModelContribution), len(rep.ByVariant), len(rep.ByVariantContribution))
+	}
+	if row := mustComparisonVariant(t, rep.ByVariant, "opus"); row.Landed != 1 || row.AttributionMode != string(ComparisonAttributionLatestAuthor) {
+		t.Fatalf("latest variant row = %+v, want final-stage opus landing", row)
+	}
+	if row := mustComparisonVariant(t, rep.ByVariantContribution, "gpt"); row.Landed != 1 || row.AttributionMode != string(ComparisonAttributionAnyContribution) {
+		t.Fatalf("contribution variant row = %+v, want gpt contribution landing", row)
+	} else if child := comparisonByRole(t, row.RoleBreakdowns, "implementation"); child.Landed != 1 {
+		t.Fatalf("contribution variant child = %+v, want implementation gpt contribution landing", child)
+	}
+}
+
 func TestComputeEmpty(t *testing.T) {
 	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
 	got := Compute(nil, nil, now.AddDate(0, 0, -7), now)
@@ -399,6 +501,35 @@ func TestComputeEmpty(t *testing.T) {
 	if got.WindowDays != 7 {
 		t.Errorf("WindowDays = %v, want 7", got.WindowDays)
 	}
+}
+
+func mustComparisonRow(t *testing.T, rows []ComparisonBreakdown, key string) ComparisonBreakdown {
+	t.Helper()
+	row, ok := comparisonRow(rows, key)
+	if !ok {
+		t.Fatalf("missing comparison row %q in %+v", key, rows)
+	}
+	return row
+}
+
+func mustComparisonVariant(t *testing.T, rows []ComparisonBreakdown, variant string) ComparisonBreakdown {
+	t.Helper()
+	for i := range rows {
+		if rows[i].VariantID == variant {
+			return rows[i]
+		}
+	}
+	t.Fatalf("missing comparison variant %q in %+v", variant, rows)
+	return ComparisonBreakdown{}
+}
+
+func comparisonRow(rows []ComparisonBreakdown, key string) (ComparisonBreakdown, bool) {
+	for i := range rows {
+		if rows[i].Key == key {
+			return rows[i], true
+		}
+	}
+	return ComparisonBreakdown{}, false
 }
 
 func TestPercentile(t *testing.T) {

--- a/internal/evaluation/service.go
+++ b/internal/evaluation/service.go
@@ -153,14 +153,21 @@ func (s *Service) Scan(_ context.Context) (Report, error) {
 		Overall:     Compute(recs, evts, since, now),
 		ByProvider:  BreakdownBy(recs, since, now, func(r stats.RunRecord) string { return r.Provider }),
 		ByRole:      BreakdownBy(recs, since, now, func(r stats.RunRecord) string { return r.Role }),
-		ByAgentModel: CompareBy(recs, evts, since, now, 20, func(r stats.RunRecord) string {
+		ByAgentModel: CompareByLatestAuthor(recs, evts, since, now, 20, func(r stats.RunRecord) string {
 			if r.Provider == "" || r.Model == "" {
 				return ""
 			}
 			return r.Provider + ":" + r.Model + ":" + r.ReasoningEffort + ":" + normalizedRole(r.Role)
 		}),
-		ByVariant: CompareVariants(recs, evts, since, now, 20),
-		Notes:     deferredNotes,
+		ByAgentModelContribution: CompareByContribution(recs, evts, since, now, 20, func(r stats.RunRecord) string {
+			if r.Provider == "" || r.Model == "" {
+				return ""
+			}
+			return r.Provider + ":" + r.Model + ":" + r.ReasoningEffort + ":" + normalizedRole(r.Role)
+		}),
+		ByVariant:             CompareVariants(recs, evts, since, now, 20),
+		ByVariantContribution: CompareVariantsByContribution(recs, evts, since, now, 20),
+		Notes:                 deferredNotes,
 	}
 	rep.Weaknesses = Weaknesses(rep)
 	return rep, nil


### PR DESCRIPTION
## Motivation

Landing-derived A/B metrics were attributed only to the latest code-author run before landing, so pr-fix/fix-review variants could look responsible for a landing while the original implementation variant got no landed credit.

## Implementation information

Clearer landed-task attribution for experiment variants:
- keep latest-author attribution for the final-stage view
- add per-task contribution counts so implementation variants get visibility when they participated in landed work
- expose the attribution mode in the report/UI

> Changelog: feat(evaluation): improve A/B attribution

Closes #1251