### PR TITLE
fix(workflow): open PR on manual ready-pr move

### DIFF
--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -430,6 +430,26 @@ func (a *App) initStatusHook() {
 					a.logger.Error("workflow.dispatch.testing", "task_id", taskID, "err", err)
 				}
 			}
+		case string(task.StatusReadyPR):
+			if a.workflowEngine != nil {
+				// ErrWorkflowAlreadyActive is benign and the COMMON case: when
+				// testing-task flips to ready-pr on a PASS, this hook fires while
+				// the testing workflow is still active, so the start is rejected
+				// here and the cascade drives simple-task-pr via OnWorkflowComplete.
+				// The case that NEEDS this is recovery: a task flipped to ready-pr
+				// out of band — `sybra-cli update` (a separate process with no
+				// engine) or the UpdateTask UI path after a tester infra failure —
+				// has no terminal cascade to open its PR, so without this branch it
+				// sits inert with no PR. Mirrors the testing/ready-review cases.
+				if _, err := a.workflowEngine.DispatchEvent(
+					taskID,
+					"task.status_changed",
+					map[string]string{"task.status": string(task.StatusReadyPR)},
+					nil,
+				); err != nil && !errors.Is(err, workflow.ErrWorkflowAlreadyActive) {
+					a.logger.Error("workflow.dispatch.ready-pr", "task_id", taskID, "err", err)
+				}
+			}
 		}
 	})
 }

--- a/internal/sybra/app_watcher_status_test.go
+++ b/internal/sybra/app_watcher_status_test.go
@@ -204,3 +204,79 @@ steps:
 		t.Errorf("task status = %q, want testing (set_status step in test workflow)", tk.Status)
 	}
 }
+
+// TestApp_StatusHook_ReadyPR_DispatchesPRWorkflow verifies that initStatusHook
+// dispatches simple-task-pr when a task is moved to ready-pr. This reproduces
+// the production strand where tasks that hit a tester infra failure were
+// manually flipped to ready-pr (via sybra-cli or the UI) but no PR ever opened:
+// the switch handled testing and ready-review but had no ready-pr case, so the
+// hook silently no-opped and simple-task-pr never ran on re-entry.
+func TestApp_StatusHook_ReadyPR_DispatchesPRWorkflow(t *testing.T) {
+	a := setupApp(t)
+
+	// Lightweight simple-task-pr that completes without spawning agents — the
+	// real builtin's create_pr step needs a live gh/claude binary.
+	wfDir := t.TempDir()
+	wfStore, err := workflow.NewStore(wfDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const testPRWF = `id: simple-task-pr
+name: Test Open PR
+trigger:
+  on: task.status_changed
+  conditions:
+    - field: task.status
+      operator: equals
+      value: ready-pr
+steps:
+  - id: mark_in_review
+    name: Hand to In Review
+    type: set_status
+    config:
+      status: in-review
+    next:
+      - goto: ""
+`
+	if err := os.WriteFile(filepath.Join(wfDir, "simple-task-pr.yaml"), []byte(testPRWF), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ta := &taskAdapter{tasks: a.tasks}
+	aa := &agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks}
+	a.workflowEngine = workflow.NewEngine(wfStore, ta, aa, a.logger)
+	a.initStatusHook()
+
+	created, err := a.tasks.Create("ready-pr dispatch", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Act — move to ready-pr, mirroring a manual sybra-cli/UI recovery.
+	if _, err := a.tasks.UpdateMap(created.ID, map[string]any{
+		"status": string(task.StatusReadyPR),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert — the hook must have dispatched simple-task-pr, which runs
+	// synchronously (single set_status step) and completes before UpdateMap
+	// returns.
+	tk, err := a.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tk.Workflow == nil {
+		t.Fatal("no workflow attached — initStatusHook did not dispatch simple-task-pr on ready-pr")
+	}
+	if tk.Workflow.WorkflowID != "simple-task-pr" {
+		t.Errorf("workflow.id = %q, want simple-task-pr", tk.Workflow.WorkflowID)
+	}
+	if tk.Workflow.State != workflow.ExecCompleted {
+		t.Errorf("workflow.state = %q, want ExecCompleted", tk.Workflow.State)
+	}
+	// The test workflow's single step flips status to in-review.
+	if tk.Status != task.StatusInReview {
+		t.Errorf("task status = %q, want in-review (set_status step in test workflow)", tk.Status)
+	}
+}


### PR DESCRIPTION
## Motivation

Tasks that hit a tester infra failure were manually flipped to `ready-pr` (via `sybra-cli` or the UI) to recover, but no PR ever opened — they sat inert. Sybra's status-change hook (`initStatusHook`) is the single chokepoint every status write flows through (in-process `UpdateMap` and external `OnExternalUpdate` alike). It dispatched `simple-task-review` and `testing-task` on manual moves to `ready-review`/`testing`, but had **no `ready-pr` case**, so `simple-task-pr` never ran and the task stranded with no PR.

## Implementation information

- Add the `ready-pr` branch to the `initStatusHook` switch, mirroring the existing `testing`/`ready-review` cases: `DispatchEvent(task.status_changed, ready-pr)`. It self-gates on an active workflow (`ErrWorkflowAlreadyActive` is benign during the normal testing-task→ready-pr cascade) and is origin-agnostic.
- Regression test `TestApp_StatusHook_ReadyPR_DispatchesPRWorkflow`.
- `in-progress` intentionally left in `svc_tasks.UpdateTask` — it is special (a brand-new task moved to in-progress must not auto-start implement; `TestUpdateTask_InProgressNoWorkflowNoOp`).

> Changelog: fix(workflow): open PR on manual ready-pr move

## Supporting documentation

Found via three tasks (#1249/#1250/#1251) that infra-failed in testing, were moved to ready-pr, and never opened PRs.