### PR TITLE
fix(workflow): tolerate string app_started in verdict

### DIFF
--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -54,7 +54,7 @@ type structuredTestOutput struct {
 	Outcome           string                     `json:"outcome,omitempty"`
 	FailuresMarkdown  string                     `json:"failures_markdown,omitempty"`
 	SurfaceKind       string                     `json:"surface_kind,omitempty"`
-	AppStarted        bool                       `json:"app_started,omitempty"`
+	AppStarted        flexBool                   `json:"app_started,omitempty"`
 	StartCommand      string                     `json:"start_command,omitempty"`
 	ReadinessProbe    evidenceText               `json:"readiness_probe,omitempty"`
 	ManualProbes      manualProbeEvidenceList    `json:"manual_probes,omitempty"`
@@ -86,6 +86,32 @@ type automatedCheckEvidence struct {
 }
 
 type evidenceText string
+
+// flexBool tolerates LLM JSON drift on boolean verdict fields: a model often
+// emits app_started as the quoted string "true"/"false" instead of a JSON
+// bool. A strict bool unmarshal would fail the WHOLE structuredTestOutput
+// object and discard an otherwise-valid PASS verdict — misclassifying a passing
+// test as infra_failure. Accept either shape.
+type flexBool bool
+
+func (b *flexBool) UnmarshalJSON(data []byte) error {
+	var bv bool
+	if err := json.Unmarshal(data, &bv); err == nil {
+		*b = flexBool(bv)
+		return nil
+	}
+	var sv string
+	if err := json.Unmarshal(data, &sv); err != nil {
+		return err
+	}
+	switch strings.ToLower(strings.TrimSpace(sv)) {
+	case "true", "yes", "y", "t", "1":
+		*b = true
+	default:
+		*b = false
+	}
+	return nil
+}
 
 func (l *manualProbeEvidenceList) UnmarshalJSON(data []byte) error {
 	*l = nil

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -51,6 +51,8 @@ func TestExtractTestVerdict(t *testing.T) {
 		{"json_array_not_object", `[{"verdict":"PASS"}]`, ""},
 		{"fenced_json_no_marker", "```json\n{\"verdict\":\"PASS\"}\n```", "PASS"},
 		{"prose_then_fenced_json", "All probes passed.\n\n```json\n{\"verdict\":\"PASS\"}\n```", "PASS"},
+		// app_started emitted as a quoted string must not break the verdict parse.
+		{"json_string_app_started", `{"verdict":"PASS","app_started":"true"}`, "PASS"},
 	}
 
 	for _, tc := range cases {
@@ -477,6 +479,22 @@ func TestApplyTestVerdictCompletion_ClassifiesOutcomes(t *testing.T) {
 				`"readiness_probe":"curl -fsS http://127.0.0.1:55990/health -> {\"status\":\"ok\"}",` +
 				`"manual_probes":["POST /api/TaskService/ListTasks -> []","sybra-cli --json create --title smoke -> created task"],` +
 				`"automated_checks":["go test ./... -> pass","go build ./cmd/sybra-server -> pass"],"unable_to_run_reason":""}`,
+			bodySuffix: "",
+			want:       testOutcomePass,
+			wantStatus: "completed",
+		},
+		{
+			// Regression: a model emitted app_started as the quoted string
+			// "true" instead of a bool. A strict bool unmarshal failed the whole
+			// verdict object, losing a valid PASS and misclassifying it as
+			// infra_failure. flexBool must accept the string shape.
+			name:   "pass_with_string_app_started",
+			status: "completed",
+			output: `{"verdict":"PASS","outcome":"pass","failures_markdown":"","surface_kind":"server","app_started":"true",` +
+				`"start_command":"SYBRA_HOME=$(mktemp -d) go run ./cmd/sybra-server",` +
+				`"readiness_probe":{"command":"curl -fsS http://127.0.0.1:57942/health","actual":"{\"status\":\"ok\"}"},` +
+				`"manual_probes":[{"command":"curl -fsS http://127.0.0.1:57942/health","actual":"{\"status\":\"ok\"}"}],` +
+				`"automated_checks":[{"command":"go test ./internal/attribution/...","actual":"pass"}],"unable_to_run_reason":""}`,
 			bodySuffix: "",
 			want:       testOutcomePass,
 			wantStatus: "completed",


### PR DESCRIPTION
## Motivation

A test-runner returned a complete, valid `PASS` verdict (app started, probes green, `go test` passing) but emitted one field as a quoted string:

```json
"app_started": "true"
```

`structuredTestOutput.AppStarted` was a strict Go `bool`, so `json.Unmarshal` rejected the **whole** object → the verdict couldn't be extracted (`v=""`) → with no failure report, `classifyTestOutcome` fell through to `infra_failure` → after retry, `human-required`. Same tolerant-parsing class as the fenced-JSON fix (#1258): string-vs-bool is common LLM JSON drift and must not discard an otherwise-valid verdict. It also made the escalation non-deterministic — a rerun emitting a real bool would pass.

Observed live on task `379debef` ("testing infrastructure failed after retry").

## Implementation information

- Add a `flexBool` type that unmarshals from either a JSON bool or a quoted `true`/`false` string, and use it for `structuredTestOutput.AppStarted`. `!parsed.AppStarted` reads unchanged.
- Mirrors the existing tolerant verdict types (`evidenceText`, `manualProbeEvidenceList`).
- Tests: `extractTestVerdict` and `applyTestVerdictCompletion` accept a PASS whose `app_started` is the string `"true"`.

> Changelog: fix(workflow): tolerate string app_started in verdict

## Supporting documentation

Diagnosed from `379debef`: claude test-runner exited clean (`is_error:false`) with a full PASS JSON, yet was tagged `infra_failure`.
