### PR TITLE
fix(github): pace polls + REST-shift on low budget

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"sort"
@@ -480,6 +481,11 @@ func ViewerLogin() string {
 func IsTransientError(err error) bool {
 	if err == nil {
 		return false
+	}
+	// A skipped optional poll (low GraphQL budget) is transient by design: back
+	// off and retry next cycle rather than treating it as a hard fetch failure.
+	if errors.Is(err, ErrBudgetExhausted) {
+		return true
 	}
 	msg := strings.ToLower(err.Error())
 	// HTTP 5xx: sanitized gh output produces "gh: http 5xx"

--- a/internal/github/rest_monitor.go
+++ b/internal/github/rest_monitor.go
@@ -1,0 +1,145 @@
+package github
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrBudgetExhausted signals the GraphQL points budget is too low to spend on
+// an optional poll this cycle. Callers treat it like a transient error — skip
+// the work, back off, retry next cycle — rather than firing a request that
+// would only get a hard rate-limit rejection. IsTransientError reports true.
+//
+// GraphQL and REST are separate 5k/hr buckets; when GraphQL is exhausted the
+// REST bucket is usually idle, so the per-PR monitor fetch falls back to REST
+// (fetchPRForMonitorViaREST) for the conflict/CI/state signals instead of
+// stalling. Review-thread data is GraphQL-only, so the REST path leaves those
+// fields zero and callers must not drive thread-dependent actions (auto-merge,
+// comments fixes) from a REST-sourced PR.
+var ErrBudgetExhausted = errors.New("github graphql budget low: skipping optional poll")
+
+// restPR is the subset of the GitHub REST pull-request payload the monitor
+// needs for conflict/CI/state detection.
+type restPR struct {
+	Number         int    `json:"number"`
+	Title          string `json:"title"`
+	HTMLURL        string `json:"html_url"`
+	State          string `json:"state"` // open | closed
+	Draft          bool   `json:"draft"`
+	MergeableState string `json:"mergeable_state"` // clean|dirty|blocked|unstable|behind|unknown
+	Head           struct {
+		Ref string `json:"ref"`
+		SHA string `json:"sha"`
+	} `json:"head"`
+	User struct {
+		Login string `json:"login"`
+	} `json:"user"`
+	Labels []struct {
+		Name string `json:"name"`
+	} `json:"labels"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+type restCheckRuns struct {
+	CheckRuns []struct {
+		Status     string `json:"status"`     // queued | in_progress | completed
+		Conclusion string `json:"conclusion"` // success | failure | ...
+	} `json:"check_runs"`
+}
+
+// fetchPRForMonitorViaREST fetches a PR's conflict/CI/state signals over the
+// REST API (a separate rate-limit bucket from GraphQL). Review-decision and
+// review-thread fields stay zero — REST does not expose thread resolution — so
+// the caller must only act on conflict/ci_failure/closed signals from the
+// result, never auto-merge or comments.
+func fetchPRForMonitorViaREST(e execer, repo string, number int) (PullRequest, bool, error) {
+	owner, name, ok := strings.Cut(repo, "/")
+	if !ok || owner == "" || name == "" || number <= 0 {
+		return PullRequest{}, false, fmt.Errorf("invalid repo or PR: %s#%d", repo, number)
+	}
+
+	resp, err := runGHAPIWith(e, "30s", fmt.Sprintf("repos/%s/%s/pulls/%d", owner, name, number))
+	if err != nil {
+		return PullRequest{}, false, fmt.Errorf("gh api rest pr %s#%d: %s: %w", repo, number, sanitizeGHOutput(resp.body), err)
+	}
+	var pr restPR
+	if err := json.Unmarshal(resp.body, &pr); err != nil {
+		return PullRequest{}, false, fmt.Errorf("parse rest pr %s#%d: %w", repo, number, err)
+	}
+	if !strings.EqualFold(pr.State, "open") {
+		return PullRequest{}, false, nil
+	}
+
+	ci, pending := fetchCIStatusViaREST(e, owner, name, pr.Head.SHA)
+
+	out := PullRequest{
+		Number:           pr.Number,
+		Title:            pr.Title,
+		URL:              pr.HTMLURL,
+		Repository:       repo,
+		RepoName:         name,
+		Author:           pr.User.Login,
+		IsDraft:          pr.Draft,
+		HeadRefName:      pr.Head.Ref,
+		HeadSHA:          pr.Head.SHA,
+		Mergeable:        restMergeable(pr.MergeableState),
+		CIStatus:         ci,
+		HasPendingChecks: pending,
+		CreatedAt:        pr.CreatedAt,
+		UpdatedAt:        pr.UpdatedAt,
+	}
+	for _, l := range pr.Labels {
+		out.Labels = append(out.Labels, l.Name)
+	}
+	return out, true, nil
+}
+
+// restMergeable maps the REST mergeable_state to the monitor's Mergeable enum.
+// Only "dirty" is a true merge conflict; "unknown"/"" means GitHub has not
+// computed it yet (treat as UNKNOWN so we don't act); everything else
+// (clean/blocked/unstable/behind) is not a conflict.
+func restMergeable(state string) string {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "dirty":
+		return "CONFLICTING"
+	case "", "unknown":
+		return "UNKNOWN"
+	default:
+		return "MERGEABLE"
+	}
+}
+
+// fetchCIStatusViaREST aggregates check-runs for a commit into the monitor's
+// CIStatus semantics. Conservative: only a clear failing conclusion yields
+// FAILURE; any incomplete run yields PENDING; all-complete-success yields
+// SUCCESS; no checks yields "" (treated as not-failing upstream).
+func fetchCIStatusViaREST(e execer, owner, name, sha string) (status string, pending bool) {
+	if sha == "" {
+		return "", false
+	}
+	resp, err := runGHAPIWith(e, "30s", fmt.Sprintf("repos/%s/%s/commits/%s/check-runs", owner, name, sha))
+	if err != nil {
+		return "", false
+	}
+	var runs restCheckRuns
+	if jErr := json.Unmarshal(resp.body, &runs); jErr != nil || len(runs.CheckRuns) == 0 {
+		return "", false
+	}
+	anyPending := false
+	for _, c := range runs.CheckRuns {
+		switch strings.ToLower(c.Conclusion) {
+		case "failure", "timed_out", "cancelled", "action_required", "startup_failure":
+			return "FAILURE", false
+		}
+		if !strings.EqualFold(c.Status, "completed") {
+			anyPending = true
+		}
+	}
+	if anyPending {
+		return "PENDING", true
+	}
+	return "SUCCESS", false
+}

--- a/internal/github/rest_monitor.go
+++ b/internal/github/rest_monitor.go
@@ -27,6 +27,7 @@ type restPR struct {
 	Title          string `json:"title"`
 	HTMLURL        string `json:"html_url"`
 	State          string `json:"state"` // open | closed
+	MergedAt       string `json:"merged_at"`
 	Draft          bool   `json:"draft"`
 	MergeableState string `json:"mergeable_state"` // clean|dirty|blocked|unstable|behind|unknown
 	Head           struct {
@@ -45,9 +46,17 @@ type restPR struct {
 
 type restCheckRuns struct {
 	CheckRuns []struct {
+		Name       string `json:"name"`
 		Status     string `json:"status"`     // queued | in_progress | completed
 		Conclusion string `json:"conclusion"` // success | failure | ...
 	} `json:"check_runs"`
+}
+
+type restCommitStatuses struct {
+	Statuses []struct {
+		Context string `json:"context"`
+		State   string `json:"state"` // error | failure | pending | success
+	} `json:"statuses"`
 }
 
 // fetchPRForMonitorViaREST fetches a PR's conflict/CI/state signals over the
@@ -97,6 +106,40 @@ func fetchPRForMonitorViaREST(e execer, repo string, number int) (PullRequest, b
 	return out, true, nil
 }
 
+// FetchPRStateViaREST fetches a PR's terminal/open state over GitHub's REST
+// API. It is used when the GraphQL budget is exhausted, so closed-task
+// reconciliation does not immediately re-enter the GraphQL-backed `gh pr view`
+// path.
+func FetchPRStateViaREST(repo string, number int) (PRState, error) {
+	return fetchPRStateViaREST(defaultExecer, repo, number)
+}
+
+func fetchPRStateViaREST(e execer, repo string, number int) (PRState, error) {
+	owner, name, ok := strings.Cut(repo, "/")
+	if !ok || owner == "" || name == "" || number <= 0 {
+		return PRState{}, fmt.Errorf("invalid repo or PR: %s#%d", repo, number)
+	}
+
+	resp, err := runGHAPIWith(e, "30s", fmt.Sprintf("repos/%s/%s/pulls/%d", owner, name, number))
+	if err != nil {
+		return PRState{}, fmt.Errorf("gh api rest pr state %s#%d: %s: %w", repo, number, sanitizeGHOutput(resp.body), err)
+	}
+	var pr restPR
+	if err := json.Unmarshal(resp.body, &pr); err != nil {
+		return PRState{}, fmt.Errorf("parse rest pr state %s#%d: %w", repo, number, err)
+	}
+
+	state := strings.ToUpper(strings.TrimSpace(pr.State))
+	if state == "CLOSED" && strings.TrimSpace(pr.MergedAt) != "" {
+		state = "MERGED"
+	}
+	return PRState{
+		State:     state,
+		MergedAt:  pr.MergedAt,
+		Mergeable: restMergeable(pr.MergeableState),
+	}, nil
+}
+
 // restMergeable maps the REST mergeable_state to the monitor's Mergeable enum.
 // Only "dirty" is a true merge conflict; "unknown"/"" means GitHub has not
 // computed it yet (treat as UNKNOWN so we don't act); everything else
@@ -112,34 +155,44 @@ func restMergeable(state string) string {
 	}
 }
 
-// fetchCIStatusViaREST aggregates check-runs for a commit into the monitor's
-// CIStatus semantics. Conservative: only a clear failing conclusion yields
-// FAILURE; any incomplete run yields PENDING; all-complete-success yields
-// SUCCESS; no checks yields "" (treated as not-failing upstream).
+// fetchCIStatusViaREST aggregates check-runs and legacy commit statuses for a
+// commit into the monitor's CIStatus semantics. It converts REST payloads into
+// the same context shape used by GraphQL so informational-check filtering and
+// cancelled-check handling stay identical across both paths.
 func fetchCIStatusViaREST(e execer, owner, name, sha string) (status string, pending bool) {
 	if sha == "" {
 		return "", false
 	}
+	contexts := make([]gqlCheckContext, 0)
+
 	resp, err := runGHAPIWith(e, "30s", fmt.Sprintf("repos/%s/%s/commits/%s/check-runs", owner, name, sha))
-	if err != nil {
-		return "", false
-	}
-	var runs restCheckRuns
-	if jErr := json.Unmarshal(resp.body, &runs); jErr != nil || len(runs.CheckRuns) == 0 {
-		return "", false
-	}
-	anyPending := false
-	for _, c := range runs.CheckRuns {
-		switch strings.ToLower(c.Conclusion) {
-		case "failure", "timed_out", "cancelled", "action_required", "startup_failure":
-			return "FAILURE", false
-		}
-		if !strings.EqualFold(c.Status, "completed") {
-			anyPending = true
+	if err == nil {
+		var runs restCheckRuns
+		if jErr := json.Unmarshal(resp.body, &runs); jErr == nil {
+			for _, c := range runs.CheckRuns {
+				contexts = append(contexts, gqlCheckContext{
+					Typename:   "CheckRun",
+					Name:       c.Name,
+					Status:     strings.ToUpper(c.Status),
+					Conclusion: strings.ToUpper(c.Conclusion),
+				})
+			}
 		}
 	}
-	if anyPending {
-		return "PENDING", true
+
+	resp, err = runGHAPIWith(e, "30s", fmt.Sprintf("repos/%s/%s/commits/%s/status", owner, name, sha))
+	if err == nil {
+		var statuses restCommitStatuses
+		if jErr := json.Unmarshal(resp.body, &statuses); jErr == nil {
+			for _, s := range statuses.Statuses {
+				contexts = append(contexts, gqlCheckContext{
+					Typename: "StatusContext",
+					Name:     s.Context,
+					State:    strings.ToUpper(s.State),
+				})
+			}
+		}
 	}
-	return "SUCCESS", false
+
+	return rollupFromContexts(contexts)
 }

--- a/internal/github/rest_monitor_test.go
+++ b/internal/github/rest_monitor_test.go
@@ -1,0 +1,129 @@
+package github
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// pathExecer returns a canned body for the first stub whose key is a substring
+// of the joined gh args, so a single fake can serve the pulls + check-runs legs
+// of one fetchPRForMonitorViaREST call.
+type pathExecer struct {
+	responses map[string]string
+	err       error
+}
+
+func (p *pathExecer) run(args ...string) ([]byte, error) {
+	if p.err != nil {
+		return nil, p.err
+	}
+	joined := strings.Join(args, " ")
+	for key, body := range p.responses {
+		if strings.Contains(joined, key) {
+			return []byte(body), nil
+		}
+	}
+	return nil, fmt.Errorf("no stub for: %s", joined)
+}
+
+func TestRestMergeable(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"dirty":    "CONFLICTING",
+		"DIRTY":    "CONFLICTING",
+		"unknown":  "UNKNOWN",
+		"":         "UNKNOWN",
+		"clean":    "MERGEABLE",
+		"blocked":  "MERGEABLE",
+		"unstable": "MERGEABLE",
+		"behind":   "MERGEABLE",
+	}
+	for in, want := range cases {
+		if got := restMergeable(in); got != want {
+			t.Errorf("restMergeable(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFetchPRForMonitorViaREST_ConflictAndFailingCI(t *testing.T) {
+	t.Parallel()
+	e := &pathExecer{responses: map[string]string{
+		"/pulls/42": `{"number":42,"title":"feat: x","html_url":"https://gh/pr/42",
+			"state":"open","draft":false,"mergeable_state":"dirty",
+			"head":{"ref":"feat/x","sha":"abc123"},"user":{"login":"me"},
+			"labels":[{"name":"backend"}],"created_at":"t1","updated_at":"t2"}`,
+		"/commits/abc123/check-runs": `{"check_runs":[
+			{"status":"completed","conclusion":"success"},
+			{"status":"completed","conclusion":"failure"}]}`,
+	}}
+
+	pr, open, err := fetchPRForMonitorViaREST(e, "Automaat/sybra", 42)
+	if err != nil {
+		t.Fatalf("fetchPRForMonitorViaREST: %v", err)
+	}
+	if !open {
+		t.Fatal("expected open=true")
+	}
+	if pr.Mergeable != "CONFLICTING" {
+		t.Errorf("Mergeable = %q, want CONFLICTING", pr.Mergeable)
+	}
+	if pr.CIStatus != "FAILURE" {
+		t.Errorf("CIStatus = %q, want FAILURE", pr.CIStatus)
+	}
+	if pr.Number != 42 || pr.HeadRefName != "feat/x" || pr.HeadSHA != "abc123" {
+		t.Errorf("unexpected basic fields: %+v", pr)
+	}
+	if pr.Repository != "Automaat/sybra" || pr.Author != "me" {
+		t.Errorf("repo/author = %q/%q", pr.Repository, pr.Author)
+	}
+	// Thread-dependent fields must stay zero — REST cannot supply them, and
+	// callers must not act on them.
+	if pr.UnresolvedCount != 0 || pr.ActionableCount != 0 || pr.CopilotReviewed || pr.ReviewDecision != "" {
+		t.Errorf("thread fields must be zero on REST path: %+v", pr)
+	}
+}
+
+func TestFetchPRForMonitorViaREST_PendingCI(t *testing.T) {
+	t.Parallel()
+	e := &pathExecer{responses: map[string]string{
+		"/pulls/7": `{"number":7,"state":"open","mergeable_state":"clean",
+			"head":{"ref":"b","sha":"s7"}}`,
+		"/commits/s7/check-runs": `{"check_runs":[
+			{"status":"in_progress","conclusion":""}]}`,
+	}}
+	pr, open, err := fetchPRForMonitorViaREST(e, "o/r", 7)
+	if err != nil || !open {
+		t.Fatalf("open=%v err=%v", open, err)
+	}
+	if pr.Mergeable != "MERGEABLE" {
+		t.Errorf("Mergeable = %q, want MERGEABLE", pr.Mergeable)
+	}
+	if pr.CIStatus != "PENDING" || !pr.HasPendingChecks {
+		t.Errorf("CIStatus=%q pending=%v, want PENDING/true", pr.CIStatus, pr.HasPendingChecks)
+	}
+}
+
+func TestFetchPRForMonitorViaREST_ClosedPR(t *testing.T) {
+	t.Parallel()
+	e := &pathExecer{responses: map[string]string{
+		"/pulls/9": `{"number":9,"state":"closed","head":{"sha":"x"}}`,
+	}}
+	_, open, err := fetchPRForMonitorViaREST(e, "o/r", 9)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if open {
+		t.Error("closed PR should report open=false")
+	}
+}
+
+func TestIsTransientError_BudgetExhausted(t *testing.T) {
+	t.Parallel()
+	if !IsTransientError(ErrBudgetExhausted) {
+		t.Error("ErrBudgetExhausted must be classified transient")
+	}
+	if !IsTransientError(fmt.Errorf("wrapped: %w", ErrBudgetExhausted)) {
+		t.Error("wrapped ErrBudgetExhausted must be classified transient")
+	}
+}

--- a/internal/github/rest_monitor_test.go
+++ b/internal/github/rest_monitor_test.go
@@ -104,6 +104,44 @@ func TestFetchPRForMonitorViaREST_PendingCI(t *testing.T) {
 	}
 }
 
+func TestFetchPRForMonitorViaREST_LegacyStatusFailure(t *testing.T) {
+	t.Parallel()
+	e := &pathExecer{responses: map[string]string{
+		"/pulls/8": `{"number":8,"state":"open","mergeable_state":"clean",
+			"head":{"ref":"b","sha":"s8"}}`,
+		"/commits/s8/check-runs": `{"check_runs":[]}`,
+		"/commits/s8/status": `{"statuses":[
+			{"context":"ci/build","state":"failure"}]}`,
+	}}
+	pr, open, err := fetchPRForMonitorViaREST(e, "o/r", 8)
+	if err != nil || !open {
+		t.Fatalf("open=%v err=%v", open, err)
+	}
+	if pr.CIStatus != "FAILURE" || pr.HasPendingChecks {
+		t.Errorf("CIStatus=%q pending=%v, want FAILURE/false", pr.CIStatus, pr.HasPendingChecks)
+	}
+}
+
+func TestFetchPRForMonitorViaREST_FiltersInformationalAndCancelledChecks(t *testing.T) {
+	t.Parallel()
+	e := &pathExecer{responses: map[string]string{
+		"/pulls/10": `{"number":10,"state":"open","mergeable_state":"clean",
+			"head":{"ref":"b","sha":"s10"}}`,
+		"/commits/s10/check-runs": `{"check_runs":[
+			{"name":"codecov/patch","status":"completed","conclusion":"failure"},
+			{"name":"ci/cancelled-optional","status":"completed","conclusion":"cancelled"},
+			{"name":"ci/build","status":"completed","conclusion":"success"}]}`,
+		"/commits/s10/status": `{"statuses":[]}`,
+	}}
+	pr, open, err := fetchPRForMonitorViaREST(e, "o/r", 10)
+	if err != nil || !open {
+		t.Fatalf("open=%v err=%v", open, err)
+	}
+	if pr.CIStatus != "SUCCESS" || pr.HasPendingChecks {
+		t.Errorf("CIStatus=%q pending=%v, want SUCCESS/false", pr.CIStatus, pr.HasPendingChecks)
+	}
+}
+
 func TestFetchPRForMonitorViaREST_ClosedPR(t *testing.T) {
 	t.Parallel()
 	e := &pathExecer{responses: map[string]string{
@@ -115,6 +153,43 @@ func TestFetchPRForMonitorViaREST_ClosedPR(t *testing.T) {
 	}
 	if open {
 		t.Error("closed PR should report open=false")
+	}
+}
+
+func TestFetchPRStateViaREST_MergedAndClosed(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "merged",
+			body: `{"number":11,"state":"closed","merged_at":"2026-06-29T10:00:00Z","mergeable_state":"clean"}`,
+			want: "MERGED",
+		},
+		{
+			name: "closed unmerged",
+			body: `{"number":12,"state":"closed","merged_at":null,"mergeable_state":"dirty"}`,
+			want: "CLOSED",
+		},
+		{
+			name: "open",
+			body: `{"number":13,"state":"open","mergeable_state":"clean"}`,
+			want: "OPEN",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &pathExecer{responses: map[string]string{"/pulls/": tt.body}}
+			got, err := fetchPRStateViaREST(e, "o/r", 11)
+			if err != nil {
+				t.Fatalf("fetchPRStateViaREST: %v", err)
+			}
+			if got.State != tt.want {
+				t.Errorf("State = %q, want %q", got.State, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -169,6 +169,15 @@ func fetchPRForMonitorWith(e execer, repo string, number int) (PullRequest, bool
 		return PullRequest{}, false, fmt.Errorf("invalid repo or PR: %s#%d", repo, number)
 	}
 
+	// When the GraphQL budget is low, fetch the conflict/CI/state signals over
+	// REST (a separate, usually-idle bucket) instead of spending scarce GraphQL
+	// points or hard-failing. The REST result omits thread/review-decision data,
+	// so callers must only act on its conflict/ci_failure/closed signals. Gated
+	// on runtimeCacheEnabled so unit tests (fake execer) keep the GraphQL path.
+	if runtimeCacheEnabled(e) && ghGate.shouldSkipOptional("graphql") {
+		return fetchPRForMonitorViaREST(e, repo, number)
+	}
+
 	resp, err := runGHAPIWith(e, "", "graphql",
 		"-f", "query="+prForMonitorQuery,
 		"-f", "owner="+owner,
@@ -206,10 +215,15 @@ func fetchReviewsWith(e execer) (ReviewSummary, error) {
 		if cached, ok := reviewSummaryCache.Get(cacheKey); ok {
 			return cached, nil
 		}
+		// Pace the search legs by the live GraphQL budget: when it is low, serve
+		// a stale summary if we have one, otherwise back off (ErrBudgetExhausted
+		// is transient) instead of firing three searches that would only be
+		// rejected and burn the last of the shared budget.
 		if ghGate.shouldSkipOptional("graphql") {
 			if stale, ok := reviewSummaryCache.GetStale(cacheKey); ok {
 				return stale, nil
 			}
+			return ReviewSummary{}, ErrBudgetExhausted
 		}
 	}
 

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -216,16 +216,24 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 			} else {
 				r.logger.Warn("pr-monitor.fetch", "err", fetchErr, "consecutive", r.transientFetchFails)
 			}
-			// Reconcile stale review tasks on transient failures only. Non-transient
-			// errors (auth, 4xx) mean the per-task FetchPRState calls will also fail
-			// or be wasted, compounding backoff under an already-throttled API.
-			r.closeFinishedReviewTasks(tasks, nil)
 			// GraphQL budget exhausted: the per-PR fetch falls back to the idle
 			// REST bucket, so keep conflict/CI handling moving instead of stalling
 			// until the hourly reset. Thread-driven kinds are skipped (REST lacks
 			// thread data) and resume when GraphQL recovers.
 			if errors.Is(fetchErr, github.ErrBudgetExhausted) {
 				r.handleKnownPRConflictsViaREST(tasks)
+				fetchState := github.FetchPRStateViaREST
+				if r.fetchPRStateFn != nil {
+					fetchState = r.fetchPRStateFn
+				}
+				r.closeFinishedReviewTasksWithFetch(tasks, nil, fetchState)
+			} else {
+				// Reconcile stale review tasks on transient failures only.
+				// Non-transient errors (auth, 4xx) mean the per-task FetchPRState
+				// calls will also fail or be wasted, compounding backoff under an
+				// already-throttled API. Budget exhaustion uses the REST fallback
+				// above instead of this GraphQL-backed path.
+				r.closeFinishedReviewTasks(tasks, nil)
 			}
 		} else {
 			r.transientFetchFails = 0
@@ -335,7 +343,11 @@ func (r *ReviewHandler) handleKnownPRConflictsViaREST(tasks []task.Task) {
 		r.handleMatchedPRIssues(conflictCI)
 	}
 	if len(closedMatchers) > 0 {
-		r.advanceClosedTaskPRs(monitoredPRs, closedMatchers)
+		fetchState := github.FetchPRStateViaREST
+		if r.fetchPRStateFn != nil {
+			fetchState = r.fetchPRStateFn
+		}
+		r.advanceClosedTaskPRsWithFetch(monitoredPRs, closedMatchers, fetchState)
 	}
 }
 
@@ -416,6 +428,10 @@ func (r *ReviewHandler) advanceClosedTaskPRs(monitoredPRs []github.PullRequest, 
 	if r.fetchPRStateFn != nil {
 		fetchFn = r.fetchPRStateFn
 	}
+	r.advanceClosedTaskPRsWithFetch(monitoredPRs, closedMatchers, fetchFn)
+}
+
+func (r *ReviewHandler) advanceClosedTaskPRsWithFetch(monitoredPRs []github.PullRequest, closedMatchers []github.TaskMatcher, fetchFn func(repo string, number int) (github.PRState, error)) {
 	closedPRs := github.DetectClosedTaskPRs(monitoredPRs, closedMatchers, fetchFn)
 	for _, c := range closedPRs {
 		if r.agents.HasRunningAgentForTask(c.TaskID) {

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -3,6 +3,7 @@ package sybra
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -219,6 +220,13 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 			// errors (auth, 4xx) mean the per-task FetchPRState calls will also fail
 			// or be wasted, compounding backoff under an already-throttled API.
 			r.closeFinishedReviewTasks(tasks, nil)
+			// GraphQL budget exhausted: the per-PR fetch falls back to the idle
+			// REST bucket, so keep conflict/CI handling moving instead of stalling
+			// until the hourly reset. Thread-driven kinds are skipped (REST lacks
+			// thread data) and resume when GraphQL recovers.
+			if errors.Is(fetchErr, github.ErrBudgetExhausted) {
+				r.handleKnownPRConflictsViaREST(tasks)
+			}
 		} else {
 			r.transientFetchFails = 0
 			r.logger.Warn("pr-monitor.fetch", "err", fetchErr)
@@ -283,6 +291,52 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 		return r.pollFast()
 	}
 	return r.pollSlow()
+}
+
+// handleKnownPRConflictsViaREST runs a REST-only conflict/CI pass over linked
+// task PRs, used when the GraphQL search backed off on an exhausted budget. The
+// per-PR fetch routes to the idle REST bucket, so conflict and ci_failure fixes
+// keep moving without GraphQL. Thread-driven kinds (comments, ready_to_merge)
+// are intentionally dropped — REST exposes no thread-resolution data, so acting
+// on them could merge a PR with unresolved threads; they resume once GraphQL
+// recovers.
+func (r *ReviewHandler) handleKnownPRConflictsViaREST(tasks []task.Task) {
+	var matchers, closedMatchers []github.TaskMatcher
+	for i := range tasks {
+		m := github.TaskMatcher{
+			ID:        tasks[i].ID,
+			PRNumber:  tasks[i].PRNumber,
+			Branch:    tasks[i].Branch,
+			ProjectID: tasks[i].ProjectID,
+		}
+		if prMonitorEligible(&tasks[i]) {
+			matchers = append(matchers, m)
+			closedMatchers = append(closedMatchers, m)
+		} else if prClosedEligible(&tasks[i]) {
+			closedMatchers = append(closedMatchers, m)
+		}
+	}
+	if len(matchers) == 0 && len(closedMatchers) == 0 {
+		return
+	}
+
+	monitoredPRs := r.fetchKnownTaskPRs(matchers)
+	if len(matchers) > 0 {
+		var conflictCI []github.PRIssue
+		matched := github.MatchTaskPRs(monitoredPRs, matchers)
+		for i := range matched {
+			if matched[i].Kind == github.PRIssueConflict || matched[i].Kind == github.PRIssueCIFailure {
+				conflictCI = append(conflictCI, matched[i])
+			}
+		}
+		if r.prTracker != nil {
+			r.prTracker.Cleanup()
+		}
+		r.handleMatchedPRIssues(conflictCI)
+	}
+	if len(closedMatchers) > 0 {
+		r.advanceClosedTaskPRs(monitoredPRs, closedMatchers)
+	}
 }
 
 func (r *ReviewHandler) handleMatchedPRIssues(issues []github.PRIssue) {

--- a/internal/sybra/app_reviews_inbound.go
+++ b/internal/sybra/app_reviews_inbound.go
@@ -477,6 +477,14 @@ func (r *ReviewHandler) closeFinishedReviewTasks(tasks []task.Task, openReviewPR
 	if r.fetchPRStateFn != nil {
 		fetchFn = r.fetchPRStateFn
 	}
+	r.closeFinishedReviewTasksWithFetch(tasks, openReviewPRs, fetchFn)
+}
+
+func (r *ReviewHandler) closeFinishedReviewTasksWithFetch(tasks []task.Task, openReviewPRs []github.PullRequest, fetchFn func(repo string, number int) (github.PRState, error)) {
+	matchers := reviewTaskMatchers(tasks)
+	if len(matchers) == 0 {
+		return
+	}
 	closedPRs := github.DetectClosedTaskPRs(openReviewPRs, matchers, fetchFn)
 	for _, c := range closedPRs {
 		if r.agents.HasRunningAgentForTask(c.TaskID) {

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -1545,6 +1545,57 @@ func TestPollAndMonitorPRs_FetchErrorReconcile(t *testing.T) {
 	}
 }
 
+func TestPollAndMonitorPRs_BudgetExhaustedUsesSingleRESTFallbackReconcile(t *testing.T) {
+	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	created, err := tasks.Create("Human review PR", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:    task.Ptr(task.StatusHumanRequired),
+		ProjectID: task.Ptr("o/r"),
+		PRNumber:  task.Ptr(77),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	reconcileCalls := 0
+	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
+	r := &ReviewHandler{
+		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler), emit: func(string, any) {}},
+		tasks:         tasks,
+		agents:        agentMgr,
+		fetchReviewsFn: func() (github.ReviewSummary, error) {
+			return github.ReviewSummary{}, github.ErrBudgetExhausted
+		},
+		fetchPRStateFn: func(repo string, number int) (github.PRState, error) {
+			reconcileCalls++
+			if repo != "o/r" || number != 77 {
+				t.Fatalf("state fetch = %s#%d, want o/r#77", repo, number)
+			}
+			return github.PRState{State: "MERGED"}, nil
+		},
+	}
+
+	r.pollAndMonitorPRs()
+
+	if reconcileCalls != 1 {
+		t.Fatalf("reconcileCalls = %d, want 1", reconcileCalls)
+	}
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusDone || got.Outcome != "merged" {
+		t.Fatalf("status/outcome = %q/%q, want done/merged", got.Status, got.Outcome)
+	}
+}
+
 func TestPollSecondaryReconcilesKnownTaskPRsWithoutSearch(t *testing.T) {
 	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
 	if err != nil {


### PR DESCRIPTION
## Motivation

GitHub REST and GraphQL are **separate** 5,000/hr buckets (the limit is per *user*, not per token — confirmed by `API rate limit ... for user ID` errors). The PR monitor's polling runs on GraphQL; when the shared token's GraphQL budget is bursted to zero (many concurrent harness agents running `gh` + manual ops), the monitor's search/per-PR fetches **hard-failed** and PR progress stalled until the hourly reset — while the REST bucket sat idle at 5,000. This is what stranded `086fb283`'s conflict during a GraphQL-exhausted window.

No GitHub App / bot account is available, so the ceiling can't be raised. Instead: stop bursting GraphQL, and tap the idle REST bucket.

## Implementation information

- `ErrBudgetExhausted` (classified transient via `IsTransientError`): when the live GraphQL budget is low, `fetchReviewsWith` serves a stale summary or backs off, instead of firing three searches that would only be rejected and burn the last points.
- `fetchPRForMonitorViaREST` (new): fetches conflict/CI/state/draft/head over REST (`pulls/{n}` + `commits/{sha}/check-runs`). `fetchPRForMonitorWith` routes to it when GraphQL is low (gated on `runtimeCacheEnabled` so unit tests keep the GraphQL path).
- `pollAndMonitorPRs` falls back to a REST-only **conflict + ci_failure** pass on `ErrBudgetExhausted`, so those fixes keep moving during a GraphQL stall.

### Scope / safety
Review-thread resolution is **GraphQL-only**, so the REST path leaves `UnresolvedCount`/`ActionableCount`/`CopilotReviewed`/`ReviewDecision` zero, and the fallback handles **only** conflict/ci_failure — never auto-merge or comments (which could merge past unresolved threads). Those resume when GraphQL recovers. Tests cover the REST mapping (mergeable/CI), closed-PR handling, and transient classification.

> Changelog: fix(github): pace polls + REST-shift on low budget

## Supporting documentation

Diagnosed from repeated `pr-monitor.fetch ... graphql_rate_limit` stalls while REST core stayed at 5,000 remaining.
