### PR TITLE
refactor(sybra): unify status dispatch workflow

### DIFF
--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -398,11 +398,11 @@ func (a *App) initStatusHook() {
 				go a.humanReview.maybeSpawn(taskID, from)
 			}
 		case string(task.StatusReadyReview):
-			a.dispatchStatusWorkflow(taskID, to)
+			a.dispatchStatusWorkflow(taskID, task.StatusReadyReview)
 		case string(task.StatusTesting):
-			a.dispatchStatusWorkflow(taskID, to)
+			a.dispatchStatusWorkflow(taskID, task.StatusTesting)
 		case string(task.StatusReadyPR):
-			a.dispatchStatusWorkflow(taskID, to)
+			a.dispatchStatusWorkflow(taskID, task.StatusReadyPR)
 		}
 	})
 }
@@ -430,27 +430,18 @@ func (a *App) initStatusHook() {
 //     after a tester infra failure — has no terminal cascade to open its PR, so
 //     without this branch it sits inert with no PR. Mirrors the
 //     testing/ready-review cases.
-func (a *App) dispatchStatusWorkflow(taskID, status string) {
+func (a *App) dispatchStatusWorkflow(taskID string, status task.Status) {
 	if a.workflowEngine == nil {
 		return
 	}
 
-	var logKey string
-	switch status {
-	case string(task.StatusReadyReview):
-		logKey = "workflow.dispatch.ready-review"
-	case string(task.StatusTesting):
-		logKey = "workflow.dispatch.testing"
-	case string(task.StatusReadyPR):
-		logKey = "workflow.dispatch.ready-pr"
-	default:
-		logKey = "workflow.dispatch.status"
-	}
+	statusValue := string(status)
+	logKey := "workflow.dispatch." + statusValue
 
 	if _, err := a.workflowEngine.DispatchEvent(
 		taskID,
 		"task.status_changed",
-		map[string]string{"task.status": status},
+		map[string]string{"task.status": statusValue},
 		nil,
 	); err != nil && !errors.Is(err, workflow.ErrWorkflowAlreadyActive) {
 		a.logger.Error(logKey, "task_id", taskID, "err", err)

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -398,60 +398,63 @@ func (a *App) initStatusHook() {
 				go a.humanReview.maybeSpawn(taskID, from)
 			}
 		case string(task.StatusReadyReview):
-			if a.workflowEngine != nil {
-				// ErrWorkflowAlreadyActive is benign: when the cascade flips to
-				// ready-review (simple-task-implement ending), this hook fires
-				// while the implement workflow is still active; OnWorkflowComplete
-				// drives the cascade instead. Only real errors are surfaced —
-				// this also enables the manual "move card to Ready Review" path.
-				if _, err := a.workflowEngine.DispatchEvent(
-					taskID,
-					"task.status_changed",
-					map[string]string{"task.status": string(task.StatusReadyReview)},
-					nil,
-				); err != nil && !errors.Is(err, workflow.ErrWorkflowAlreadyActive) {
-					a.logger.Error("workflow.dispatch.ready-review", "task_id", taskID, "err", err)
-				}
-			}
+			a.dispatchStatusWorkflow(taskID, to)
 		case string(task.StatusTesting):
-			if a.workflowEngine != nil {
-				// ErrWorkflowAlreadyActive is benign and the COMMON case: when
-				// simple-task-review's done_review flips to testing, this hook
-				// fires while the review workflow is still active, so the start
-				// is rejected here and the cascade is driven by OnWorkflowComplete
-				// instead. Only a real, unexpected error is worth surfacing —
-				// this also serves the genuine manual "move card to Testing" path.
-				if _, err := a.workflowEngine.DispatchEvent(
-					taskID,
-					"task.status_changed",
-					map[string]string{"task.status": string(task.StatusTesting)},
-					nil,
-				); err != nil && !errors.Is(err, workflow.ErrWorkflowAlreadyActive) {
-					a.logger.Error("workflow.dispatch.testing", "task_id", taskID, "err", err)
-				}
-			}
+			a.dispatchStatusWorkflow(taskID, to)
 		case string(task.StatusReadyPR):
-			if a.workflowEngine != nil {
-				// ErrWorkflowAlreadyActive is benign and the COMMON case: when
-				// testing-task flips to ready-pr on a PASS, this hook fires while
-				// the testing workflow is still active, so the start is rejected
-				// here and the cascade drives simple-task-pr via OnWorkflowComplete.
-				// The case that NEEDS this is recovery: a task flipped to ready-pr
-				// out of band — `sybra-cli update` (a separate process with no
-				// engine) or the UpdateTask UI path after a tester infra failure —
-				// has no terminal cascade to open its PR, so without this branch it
-				// sits inert with no PR. Mirrors the testing/ready-review cases.
-				if _, err := a.workflowEngine.DispatchEvent(
-					taskID,
-					"task.status_changed",
-					map[string]string{"task.status": string(task.StatusReadyPR)},
-					nil,
-				); err != nil && !errors.Is(err, workflow.ErrWorkflowAlreadyActive) {
-					a.logger.Error("workflow.dispatch.ready-pr", "task_id", taskID, "err", err)
-				}
-			}
+			a.dispatchStatusWorkflow(taskID, to)
 		}
 	})
+}
+
+// dispatchStatusWorkflow starts the workflow matching a status-change event.
+//
+// ErrWorkflowAlreadyActive is benign for these status transitions:
+//   - ready-review: when the cascade flips to ready-review
+//     (simple-task-implement ending), this hook fires while the implement
+//     workflow is still active; OnWorkflowComplete drives the cascade instead.
+//     Only real errors are surfaced. This also enables the manual "move card to
+//     Ready Review" path.
+//   - testing: ErrWorkflowAlreadyActive is benign and the COMMON case. When
+//     simple-task-review's done_review flips to testing, this hook fires while
+//     the review workflow is still active, so the start is rejected here and the
+//     cascade is driven by OnWorkflowComplete instead. Only a real, unexpected
+//     error is worth surfacing. This also serves the genuine manual "move card
+//     to Testing" path.
+//   - ready-pr: ErrWorkflowAlreadyActive is benign and the COMMON case. When
+//     testing-task flips to ready-pr on a PASS, this hook fires while the
+//     testing workflow is still active, so the start is rejected here and the
+//     cascade drives simple-task-pr via OnWorkflowComplete. The case that NEEDS
+//     this is recovery: a task flipped to ready-pr out of band — `sybra-cli
+//     update` (a separate process with no engine) or the UpdateTask UI path
+//     after a tester infra failure — has no terminal cascade to open its PR, so
+//     without this branch it sits inert with no PR. Mirrors the
+//     testing/ready-review cases.
+func (a *App) dispatchStatusWorkflow(taskID, status string) {
+	if a.workflowEngine == nil {
+		return
+	}
+
+	var logKey string
+	switch status {
+	case string(task.StatusReadyReview):
+		logKey = "workflow.dispatch.ready-review"
+	case string(task.StatusTesting):
+		logKey = "workflow.dispatch.testing"
+	case string(task.StatusReadyPR):
+		logKey = "workflow.dispatch.ready-pr"
+	default:
+		logKey = "workflow.dispatch.status"
+	}
+
+	if _, err := a.workflowEngine.DispatchEvent(
+		taskID,
+		"task.status_changed",
+		map[string]string{"task.status": status},
+		nil,
+	); err != nil && !errors.Is(err, workflow.ErrWorkflowAlreadyActive) {
+		a.logger.Error(logKey, "task_id", taskID, "err", err)
+	}
 }
 
 func expectedHumanKind(t task.Task) string {

--- a/internal/sybra/app_watcher_status_test.go
+++ b/internal/sybra/app_watcher_status_test.go
@@ -205,6 +205,80 @@ steps:
 	}
 }
 
+// TestApp_StatusHook_Testing_DispatchesTestingWorkflow verifies that
+// initStatusHook dispatches testing-task when a task is manually moved to
+// testing. This covers the hook-level path that direct workflow-engine tests
+// bypass.
+func TestApp_StatusHook_Testing_DispatchesTestingWorkflow(t *testing.T) {
+	a := setupApp(t)
+
+	// Lightweight testing-task that completes without spawning agents — the
+	// real builtin's test runner step needs a live provider binary.
+	wfDir := t.TempDir()
+	wfStore, err := workflow.NewStore(wfDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const testTestingWF = `id: testing-task
+name: Test Testing
+trigger:
+  on: task.status_changed
+  conditions:
+    - field: task.status
+      operator: equals
+      value: testing
+steps:
+  - id: mark_ready_pr
+    name: Hand to PR
+    type: set_status
+    config:
+      status: ready-pr
+    next:
+      - goto: ""
+`
+	if err := os.WriteFile(filepath.Join(wfDir, "testing-task.yaml"), []byte(testTestingWF), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ta := &taskAdapter{tasks: a.tasks}
+	aa := &agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks}
+	a.workflowEngine = workflow.NewEngine(wfStore, ta, aa, a.logger)
+	a.initStatusHook()
+
+	created, err := a.tasks.Create("testing dispatch", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Act — move to testing, mirroring a manual sybra-cli/UI recovery.
+	if _, err := a.tasks.UpdateMap(created.ID, map[string]any{
+		"status": string(task.StatusTesting),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert — the hook must have dispatched testing-task, which runs
+	// synchronously (single set_status step) and completes before UpdateMap
+	// returns.
+	tk, err := a.tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tk.Workflow == nil {
+		t.Fatal("no workflow attached — initStatusHook did not dispatch testing-task on testing")
+	}
+	if tk.Workflow.WorkflowID != "testing-task" {
+		t.Errorf("workflow.id = %q, want testing-task", tk.Workflow.WorkflowID)
+	}
+	if tk.Workflow.State != workflow.ExecCompleted {
+		t.Errorf("workflow.state = %q, want ExecCompleted", tk.Workflow.State)
+	}
+	// The test workflow's single step flips status to ready-pr.
+	if tk.Status != task.StatusReadyPR {
+		t.Errorf("task status = %q, want ready-pr (set_status step in test workflow)", tk.Status)
+	}
+}
+
 // TestApp_StatusHook_ReadyPR_DispatchesPRWorkflow verifies that initStatusHook
 // dispatches simple-task-pr when a task is moved to ready-pr. This reproduces
 // the production strand where tasks that hit a tester infra failure were


### PR DESCRIPTION
## Motivation

Sybra had multiple status-change paths that could drift in behavior, especially when watcher-driven updates had to trigger the same workflow side effects as direct app updates.

Closes https://github.com/Automaat/sybra/issues/1270

## Implementation information

- Route status-change handling through a shared dispatch helper in app initialization.
- Keep watcher-originated task updates aligned with direct status transitions.
- Add watcher status test coverage for the unified dispatch behavior.