### PR TITLE
refactor(agent): clarify registry lock ownership

### DIFF
--- a/docs/agent-registry-lock-ownership.md
+++ b/docs/agent-registry-lock-ownership.md
@@ -1,0 +1,40 @@
+# Agent Registry Lock Ownership
+
+This note documents the lock boundary for restart-survival registry code before
+any further agent lifecycle split. The registry persists live-agent snapshots in
+`~/.sybra/agents/*.yaml` so a later app instance can reattach to detached
+processes.
+
+## Locks
+
+| Lock | Owner | Guards | Does not guard |
+| --- | --- | --- | --- |
+| `Manager.mu` | `internal/agent/manager.go` | `Manager.agents`, `liveCount`, dispatch claims, runtime config, and the `reg`/`surviveRestart` pointers | Registry file reads/writes, agent-internal fields |
+| `registryStore.mu` | `internal/agent/registry.go` | On-disk registry operations: `Save`, `List`, `Delete`, including FIFO cleanup in `Delete` | In-memory agent lifecycle state |
+| `Agent.mu` | `internal/agent/model.go` | Per-agent mutable state copied into `Record` by `Agent.toRecord()` | Manager maps, registry directory contents |
+
+## Registry Mutation Map
+
+| Path | Registry mutation | Lock ownership |
+| --- | --- | --- |
+| `runHeadlessAttemptSurvive` after subprocess start | `saveRegistry(a)` writes PID/log snapshot | `Agent.toRecord()` snapshots under `Agent.mu`; `registryStore.Save` serializes file write |
+| `processHeadlessLine` on `init`/`system` or terminal `result` | `saveRegistry(a)` refreshes captured session ID | `Agent.mu` snapshots changed fields; `registryStore.Save` serializes file write |
+| `startConvoProcessSurvive` and one-shot conversational survival | `saveRegistry(a)` writes FIFO/log/PID snapshot | `Agent.mu` snapshots changed fields; `registryStore.Save` serializes file write |
+| `processConvoLine` on session capture for detached interactive Claude | `saveRegistry(a)` refreshes session ID | `Agent.mu` snapshots changed fields; `registryStore.Save` serializes file write |
+| `markAgentDone` | `Delete(a.ID)` removes record and FIFO | `registryStore.Delete` serializes file/FIFO removal; `Manager.mu` separately decrements `liveCount` |
+| `ReattachAll` startup sweep | `List()` reads records; dead records call `Delete` | `registryStore.List/Delete` serialize file operations; each reattached agent registration uses `Manager.mu` |
+| `reattachInteractive` and `reattachPerTurnConvo` dead/zombie cleanup | `Delete(r.ID)` removes stale record/FIFO | `registryStore.Delete` serializes file/FIFO removal |
+| `finalizePerTurnOneShot` after recovered completion | `Delete(r.ID)` removes completed one-shot record | `registryStore.Delete` serializes file/FIFO removal |
+
+## Refactor Boundary
+
+The clean split is persistence-only: code outside `registry.go` should depend on
+the unexported `survivalRegistry` interface (`Save`, `List`, `Delete`,
+`fifoPath`) rather than the concrete store. Reattach policy still needs
+`Manager.mu` because it registers live agents and updates `liveCount`, so moving
+reattach wholesale out of `Manager` would require an explicit lifecycle API for
+map registration and completion callbacks.
+
+The `runner_*.go` family remains fused. Those files share provider-specific
+stream parsing and `ConvoEvent` normalization, and they only touch the registry
+through `saveRegistry` or the narrow survival registry interface.

--- a/docs/agent-registry-lock-ownership.md
+++ b/docs/agent-registry-lock-ownership.md
@@ -9,7 +9,7 @@ processes.
 
 | Lock | Owner | Guards | Does not guard |
 | --- | --- | --- | --- |
-| `Manager.mu` | `internal/agent/manager.go` | `Manager.agents`, `liveCount`, dispatch claims, runtime config, and the `reg`/`surviveRestart` pointers | Registry file reads/writes, agent-internal fields |
+| `Manager.mu` | `internal/agent/manager.go` | `Manager.agents`, `liveCount`, dispatch claims, runtime config, and survival config | Registry file reads/writes, agent-internal fields |
 | `registryStore.mu` | `internal/agent/registry.go` | On-disk registry operations: `Save`, `List`, `Delete`, including FIFO cleanup in `Delete` | In-memory agent lifecycle state |
 | `Agent.mu` | `internal/agent/model.go` | Per-agent mutable state copied into `Record` by `Agent.toRecord()` | Manager maps, registry directory contents |
 
@@ -29,8 +29,9 @@ processes.
 ## Refactor Boundary
 
 The clean split is persistence-only: code outside `registry.go` should depend on
-the unexported `survivalRegistry` interface (`Save`, `List`, `Delete`,
-`fifoPath`) rather than the concrete store. Reattach policy still needs
+the unexported `survivalRegistry` interface (`Save`, `List`, `Delete`) rather
+than the concrete store. FIFO path construction is a pure layout helper, not a
+persistence capability. Reattach policy still needs
 `Manager.mu` because it registers live agents and updates `liveCount`, so moving
 reattach wholesale out of `Manager` would require an explicit lifecycle API for
 map registration and completion callbacks.

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -55,10 +55,11 @@ type Manager struct {
 
 	// reg persists live-agent records so subprocesses can be reattached
 	// after an app restart. nil disables survival (legacy behaviour).
-	// Manager.mu guards only this pointer and surviveRestart; registryStore
+	// Manager.mu guards only this pointer and survival config; registryStore
 	// owns serialization of its on-disk Save/List/Delete operations.
-	reg            survivalRegistry
-	surviveRestart bool
+	reg               survivalRegistry
+	surviveRestart    bool
+	surviveRestartDir string
 
 	// sessionSink, when set, persists a crashed agent's captured session id
 	// to its task's AgentRun on dead-reattach, so restart-stale recovery can
@@ -145,6 +146,7 @@ func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir 
 		}
 		m.reg = s
 		m.surviveRestart = true
+		m.surviveRestartDir = cfg.SurviveRestartDir
 	}
 	return m, nil
 }
@@ -235,6 +237,12 @@ func (m *Manager) registry() survivalRegistry {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.reg
+}
+
+func (m *Manager) registryDir() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.surviveRestartDir
 }
 
 // saveRegistry snapshots the agent to disk. No-op when survival is off.

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -55,7 +55,9 @@ type Manager struct {
 
 	// reg persists live-agent records so subprocesses can be reattached
 	// after an app restart. nil disables survival (legacy behaviour).
-	reg            *registryStore
+	// Manager.mu guards only this pointer and surviveRestart; registryStore
+	// owns serialization of its on-disk Save/List/Delete operations.
+	reg            survivalRegistry
 	surviveRestart bool
 
 	// sessionSink, when set, persists a crashed agent's captured session id
@@ -228,8 +230,8 @@ func willDetach(cfg RunConfig) bool {
 	}
 }
 
-// registry returns the registry store (nil when survival is disabled).
-func (m *Manager) registry() *registryStore {
+// registry returns the survival registry (nil when survival is disabled).
+func (m *Manager) registry() survivalRegistry {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.reg

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -189,7 +189,7 @@ func (m *Manager) persistDeadSession(r Record) (done bool) {
 // recovery is handled by the workflow's recoverStaleInteractive / chat gc).
 // Returns the reattached agent, or nil when the process is gone or a
 // duplicate already exists.
-func (m *Manager) reattachInteractive(r Record, reg *registryStore) *Agent {
+func (m *Manager) reattachInteractive(r Record, reg survivalRegistry) *Agent {
 	if !reattachAlive(r) {
 		_ = reg.Delete(r.ID)
 		m.logger.Info("agent.reattach.dead", "id", r.ID, "pid", r.PID, "task", r.TaskID, "mode", "interactive")
@@ -254,7 +254,7 @@ func convoResumeState(evs []ConvoEvent) State {
 // rehydrate its chat from the log, and restart the loop in resume-wait mode
 // (waiting for the next prompt). Liveness is not checked — the agent is
 // recreated regardless. Returns nil only on a duplicate.
-func (m *Manager) reattachPerTurnConvo(r Record, reg *registryStore) *Agent {
+func (m *Manager) reattachPerTurnConvo(r Record, reg survivalRegistry) *Agent {
 	// Per-turn recreate is unconditional (no live process to gate on), so guard
 	// against resurrecting an agent for a task that was deleted while the app
 	// was down — that would leak a zombie agent gcOrphanChats can't reap.
@@ -300,7 +300,7 @@ func (m *Manager) reattachPerTurnConvo(r Record, reg *registryStore) *Agent {
 	return a
 }
 
-func (m *Manager) finalizePerTurnOneShot(r Record, a *Agent, reg *registryStore) {
+func (m *Manager) finalizePerTurnOneShot(r Record, a *Agent, reg survivalRegistry) {
 	if found, isError := a.lastConvoResult(); !found {
 		a.SetExitErr(errReattachedGone)
 	} else if isError {

--- a/internal/agent/registry.go
+++ b/internal/agent/registry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/Automaat/sybra/internal/fsutil"
@@ -45,9 +46,21 @@ type Record struct {
 	ReasoningEffort string `yaml:"reasoning_effort,omitempty"`
 }
 
+type survivalRegistry interface {
+	Save(Record) error
+	List() ([]Record, error)
+	Delete(string) error
+	fifoPath(string) string
+}
+
 // registryStore persists Records as one YAML file per agent under dir.
+// It owns registry persistence serialization. Manager.mu owns the live
+// in-memory agent map and runtime config, not registry file I/O; keeping the
+// registry lock here lets reattach/lifecycle code depend on the narrow
+// survivalRegistry interface without carrying Manager's lifecycle mutex.
 // Mirrors internal/loopagent.Store.
 type registryStore struct {
+	mu  sync.Mutex
 	dir string
 }
 
@@ -68,6 +81,8 @@ func (s *registryStore) Save(r Record) error {
 	if err != nil {
 		return fmt.Errorf("marshal record: %w", err)
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return fsutil.AtomicWrite(s.path(r.ID), data)
 }
 
@@ -75,6 +90,8 @@ func (s *registryStore) Save(r Record) error {
 // skipped rather than failing the whole sweep — a corrupt record must not
 // block reattachment of healthy ones.
 func (s *registryStore) List() ([]Record, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	paths, err := fsutil.ListFiles(s.dir, ".yaml")
 	if err != nil {
 		return nil, fmt.Errorf("read agents dir: %w", err)
@@ -97,6 +114,8 @@ func (s *registryStore) List() ([]Record, error) {
 // Delete removes the record file and the agent's stdin FIFO (if any). A
 // missing file is not an error.
 func (s *registryStore) Delete(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	// Best-effort FIFO cleanup so detached conversational agents don't leak
 	// a named pipe per run under the agents dir.
 	_ = os.Remove(s.fifoPath(id))

--- a/internal/agent/registry.go
+++ b/internal/agent/registry.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -46,11 +47,11 @@ type Record struct {
 	ReasoningEffort string `yaml:"reasoning_effort,omitempty"`
 }
 
+// survivalRegistry implementations must be safe for concurrent use.
 type survivalRegistry interface {
 	Save(Record) error
 	List() ([]Record, error)
 	Delete(string) error
-	fifoPath(string) string
 }
 
 // registryStore persists Records as one YAML file per agent under dir.
@@ -58,7 +59,8 @@ type survivalRegistry interface {
 // in-memory agent map and runtime config, not registry file I/O; keeping the
 // registry lock here lets reattach/lifecycle code depend on the narrow
 // survivalRegistry interface without carrying Manager's lifecycle mutex.
-// Mirrors internal/loopagent.Store.
+// Unlike internal/loopagent.Store, this store owns its own serialization lock
+// because runner goroutines can save and delete agent records concurrently.
 type registryStore struct {
 	mu  sync.Mutex
 	dir string
@@ -77,6 +79,8 @@ func (s *registryStore) Save(r Record) error {
 	if r.ID == "" {
 		return fmt.Errorf("registry: empty agent id")
 	}
+	// Record is a value type; this marshal captures a complete snapshot before
+	// registry file serialization is acquired.
 	data, err := yaml.Marshal(r)
 	if err != nil {
 		return fmt.Errorf("marshal record: %w", err)
@@ -116,21 +120,39 @@ func (s *registryStore) List() ([]Record, error) {
 func (s *registryStore) Delete(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	// Best-effort FIFO cleanup so detached conversational agents don't leak
-	// a named pipe per run under the agents dir.
-	_ = os.Remove(s.fifoPath(id))
+	s.removeFIFO(s.stdinPathForDelete(id), id)
 	if err := os.Remove(s.path(id)); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("delete record: %w", err)
 	}
 	return nil
 }
 
+func (s *registryStore) stdinPathForDelete(id string) string {
+	data, err := os.ReadFile(s.path(id))
+	if err != nil {
+		return agentFIFOPath(s.dir, id)
+	}
+	var r Record
+	if yaml.Unmarshal(data, &r) != nil || r.StdinPath == "" {
+		return agentFIFOPath(s.dir, id)
+	}
+	return r.StdinPath
+}
+
+func (s *registryStore) removeFIFO(path, id string) {
+	// Best-effort FIFO cleanup so detached conversational agents don't leak
+	// a named pipe per run under the agents dir.
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		slog.Warn("agent.registry.fifo.remove", "id", id, "path", path, "err", err)
+	}
+}
+
 func (s *registryStore) path(id string) string {
 	return filepath.Join(s.dir, id+".yaml")
 }
 
-// fifoPath returns the stdin FIFO path for a detached conversational agent,
-// alongside its registry record under the agents dir.
-func (s *registryStore) fifoPath(id string) string {
-	return filepath.Join(s.dir, id+".stdin")
+// agentFIFOPath returns the stdin FIFO path for a detached conversational
+// agent, alongside its registry record under the agents dir.
+func agentFIFOPath(registryDir, id string) string {
+	return filepath.Join(registryDir, id+".stdin")
 }

--- a/internal/agent/registry_roundtrip_test.go
+++ b/internal/agent/registry_roundtrip_test.go
@@ -2,9 +2,11 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 )
@@ -128,6 +130,67 @@ func TestAgentRegistryRoundTripPreservesPersistedFields(t *testing.T) {
 		rehydrated.ReasoningTokens != 0 ||
 		rehydrated.PremiumRequests != 0 {
 		t.Fatalf("usage fields rehydrated from registry, want zero: %#v", rehydrated)
+	}
+}
+
+func TestRegistryStore_ConcurrentSaveDeleteList(t *testing.T) {
+	regDir := t.TempDir()
+	s, err := newRegistryStore(regDir)
+	if err != nil {
+		t.Fatalf("newRegistryStore: %v", err)
+	}
+
+	const workers = 16
+	const iterations = 20
+	var wg sync.WaitGroup
+	errs := make(chan error, workers*iterations*3)
+	for worker := range workers {
+		wg.Go(func() {
+			for iteration := range iterations {
+				id := fmt.Sprintf("agent-%02d-%02d", worker, iteration)
+				fifo := agentFIFOPath(regDir, id)
+				if mkErr := makeFIFO(fifo); mkErr != nil {
+					errs <- fmt.Errorf("mkfifo %s: %w", id, mkErr)
+					continue
+				}
+				if saveErr := s.Save(Record{
+					ID:        id,
+					Mode:      "interactive",
+					Provider:  "claude",
+					PID:       os.Getpid(),
+					StartedAt: time.Now().UTC(),
+					StdinPath: fifo,
+				}); saveErr != nil {
+					errs <- fmt.Errorf("save %s: %w", id, saveErr)
+					continue
+				}
+				if _, listErr := s.List(); listErr != nil {
+					errs <- fmt.Errorf("list %s: %w", id, listErr)
+				}
+				if deleteErr := s.Delete(id); deleteErr != nil {
+					errs <- fmt.Errorf("delete %s: %w", id, deleteErr)
+					continue
+				}
+				if _, statErr := os.Stat(fifo); !os.IsNotExist(statErr) {
+					errs <- fmt.Errorf("fifo %s still present, stat err=%w", id, statErr)
+				}
+			}
+		})
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+	if t.Failed() {
+		return
+	}
+	records, err := s.List()
+	if err != nil {
+		t.Fatalf("final list: %v", err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("records left after concurrent delete = %d, want 0", len(records))
 	}
 }
 

--- a/internal/agent/runner_convo_survive.go
+++ b/internal/agent/runner_convo_survive.go
@@ -45,7 +45,7 @@ func (m *Manager) startConvoProcessSurvive(a *Agent, cfg RunConfig, outFile **os
 		cmd.Env = append(os.Environ(), cfg.ExtraEnv...)
 	}
 
-	fifoPath := reg.fifoPath(a.ID)
+	fifoPath := agentFIFOPath(m.registryDir(), a.ID)
 	if err := makeFIFO(fifoPath); err != nil {
 		return nil, fmt.Errorf("mkfifo: %w", err)
 	}

--- a/internal/agent/survive_convo_test.go
+++ b/internal/agent/survive_convo_test.go
@@ -349,14 +349,15 @@ func TestConvoResumeState(t *testing.T) {
 }
 
 func TestRegistryDelete_RemovesFIFO(t *testing.T) {
-	s, err := newRegistryStore(t.TempDir())
+	regDir := t.TempDir()
+	s, err := newRegistryStore(regDir)
 	if err != nil {
 		t.Fatalf("newRegistryStore: %v", err)
 	}
-	if err := s.Save(Record{ID: "f1", Mode: "interactive", Provider: "claude"}); err != nil {
+	fifo := agentFIFOPath(regDir, "f1")
+	if err := s.Save(Record{ID: "f1", Mode: "interactive", Provider: "claude", StdinPath: fifo}); err != nil {
 		t.Fatalf("save: %v", err)
 	}
-	fifo := s.fifoPath("f1")
 	if err := makeFIFO(fifo); err != nil {
 		t.Fatalf("mkfifo: %v", err)
 	}
@@ -459,7 +460,7 @@ func TestReattachInteractive_ReattachesLiveAgent(t *testing.T) {
 	})
 
 	// FIFO must exist for the reopen to succeed.
-	fifoPath := m.reg.fifoPath("ic1")
+	fifoPath := agentFIFOPath(regDir, "ic1")
 	if err := makeFIFO(fifoPath); err != nil {
 		t.Fatalf("mkfifo: %v", err)
 	}


### PR DESCRIPTION
## Motivation

Agent registry persistence had unclear lock ownership between manager and registry call sites, making it easy to add future paths that save or mutate registry state without holding the intended registry lock.

Closes https://github.com/Automaat/sybra/issues/1275

## Implementation information

- Documented the registry lock ownership model for agent lifecycle persistence.
- Centralized registry save behavior around lock-held helpers and adjusted manager/reattach call sites accordingly.
- Added round-trip coverage for registry persistence and updated survivor/conversation tests for the revised flow.