### PR TITLE
test(app): cover startup agent manager wiring

### DIFF
--- a/internal/agent/survive_restart_test.go
+++ b/internal/agent/survive_restart_test.go
@@ -374,6 +374,8 @@ func TestReattachAll_ReattachesLiveHeadlessAgent(t *testing.T) {
 }
 
 func TestManagerRunPersistsAndReattachesLiveHeadlessAgent(t *testing.T) {
+	// Exercises the full Run -> persisted registry record -> fresh manager
+	// ReattachAll path; sibling reattach tests start from injected records.
 	prev := reattachPIDPoll
 	reattachPIDPoll = 50 * time.Millisecond
 	t.Cleanup(func() { reattachPIDPoll = prev })
@@ -384,7 +386,7 @@ func TestManagerRunPersistsAndReattachesLiveHeadlessAgent(t *testing.T) {
 trap 'exit 130' INT TERM
 printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-lifecycle"}'
 i=0
-while [ "$i" -lt 20 ]; do
+while [ "$i" -lt 5 ]; do
   sleep 0.1
   i=$((i + 1))
 done
@@ -666,9 +668,9 @@ func waitForRegistryRecord(t *testing.T, m *Manager, agentID string) Record {
 			t.Fatalf("registry list: %v", err)
 		}
 		for i := range recs {
-			rec := recs[i]
+			rec := &recs[i]
 			if rec.ID == agentID && rec.PID != 0 && rec.LogPath != "" && rec.SessionID != "" {
-				return rec
+				return *rec
 			}
 		}
 		select {
@@ -682,7 +684,7 @@ func waitForRegistryRecord(t *testing.T, m *Manager, agentID string) Record {
 func waitForAgentDone(t *testing.T, ag *Agent, timeout time.Duration) {
 	t.Helper()
 	if ag.done == nil {
-		return
+		t.Fatal("waitForAgentDone: agent has no done channel; reattach wiring incomplete")
 	}
 	select {
 	case <-ag.done:

--- a/internal/agent/survive_restart_test.go
+++ b/internal/agent/survive_restart_test.go
@@ -373,6 +373,98 @@ func TestReattachAll_ReattachesLiveHeadlessAgent(t *testing.T) {
 	}
 }
 
+func TestManagerRunPersistsAndReattachesLiveHeadlessAgent(t *testing.T) {
+	prev := reattachPIDPoll
+	reattachPIDPoll = 50 * time.Millisecond
+	t.Cleanup(func() { reattachPIDPoll = prev })
+
+	binDir := t.TempDir()
+	fakeClaude := filepath.Join(binDir, "claude")
+	if err := os.WriteFile(fakeClaude, []byte(`#!/bin/sh
+trap 'exit 130' INT TERM
+printf '%s\n' '{"type":"system","subtype":"init","session_id":"sess-lifecycle"}'
+i=0
+while [ "$i" -lt 20 ]; do
+  sleep 0.1
+  i=$((i + 1))
+done
+printf '%s\n' '{"type":"result","result":"done","session_id":"sess-lifecycle","total_cost_usd":0}'
+`), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	logDir := t.TempDir()
+	regDir := t.TempDir()
+	runDir := t.TempDir()
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	m1 := mustNewManager(t, ctx1, func(string, any) {}, slog.New(slog.DiscardHandler), logDir, ManagerConfig{
+		Runtime:           ManagerRuntimeConfig{DefaultProvider: "claude"},
+		SurviveRestartDir: regDir,
+	})
+	ag, err := m1.Run(RunConfig{
+		TaskID:             "task-lifecycle",
+		Name:               "implementation: lifecycle",
+		Mode:               "headless",
+		Prompt:             "exercise lifecycle",
+		Dir:                runDir,
+		RequirePermissions: false,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	rec := waitForRegistryRecord(t, m1, ag.ID)
+	if rec.TaskID != "task-lifecycle" || rec.Mode != "headless" || rec.Provider != "claude" {
+		t.Fatalf("unexpected persisted record: %+v", rec)
+	}
+	if rec.PID == 0 || rec.LogPath == "" || rec.CWD != runDir {
+		t.Fatalf("record missing real process boundary fields: %+v", rec)
+	}
+	if rec.ProcStartedAt == "" {
+		t.Fatalf("record missing PID reuse guard: %+v", rec)
+	}
+	if rec.SessionID != "sess-lifecycle" {
+		t.Fatalf("record session = %q, want sess-lifecycle", rec.SessionID)
+	}
+
+	// Model an app restart: cancel the first manager's root context but leave
+	// the detached child alive, then construct a fresh manager over the same
+	// registry and log directories.
+	cancel1()
+
+	m2 := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir, ManagerConfig{
+		Runtime:           ManagerRuntimeConfig{DefaultProvider: "claude"},
+		SurviveRestartDir: regDir,
+	})
+	reattached := m2.ReattachAll()
+	if len(reattached) != 1 {
+		t.Fatalf("expected 1 reattached agent, got %d", len(reattached))
+	}
+	got := reattached[0]
+	if got.ID != ag.ID || got.TaskID != "task-lifecycle" || got.GetPID() != rec.PID || got.LogPath != rec.LogPath {
+		t.Fatalf("reattached agent mismatch:\n got: %+v\nrecord: %+v", got, rec)
+	}
+	if got.GetState() != StateRunning {
+		t.Fatalf("reattached state = %s, want %s", got.GetState(), StateRunning)
+	}
+	if got.GetSessionID() != "sess-lifecycle" {
+		t.Fatalf("reattached session = %q, want sess-lifecycle", got.GetSessionID())
+	}
+	if len(got.Output()) == 0 {
+		t.Fatal("expected reattached agent to rehydrate output from log")
+	}
+
+	waitForAgentDone(t, got, 5*time.Second)
+	if got.GetState() != StateStopped {
+		t.Fatalf("completed reattached state = %s, want %s", got.GetState(), StateStopped)
+	}
+	if got.GetExitErr() != nil {
+		t.Fatalf("completed reattached agent has exit error: %v", got.GetExitErr())
+	}
+}
+
 // TestReattachAll_DropsDeadRecords verifies a record whose process is gone
 // is deleted and not reattached.
 func TestReattachAll_DropsDeadRecords(t *testing.T) {
@@ -562,6 +654,40 @@ func TestReattachAll_BridgesDeadSessionForResume(t *testing.T) {
 	}
 	if list, _ := m.reg.List(); len(list) != 0 {
 		t.Fatal("expected record deleted after bridge")
+	}
+}
+
+func waitForRegistryRecord(t *testing.T, m *Manager, agentID string) Record {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		recs, err := m.reg.List()
+		if err != nil {
+			t.Fatalf("registry list: %v", err)
+		}
+		for i := range recs {
+			rec := recs[i]
+			if rec.ID == agentID && rec.PID != 0 && rec.LogPath != "" && rec.SessionID != "" {
+				return rec
+			}
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for registry record for %s; records=%+v", agentID, recs)
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}
+
+func waitForAgentDone(t *testing.T, ag *Agent, timeout time.Duration) {
+	t.Helper()
+	if ag.done == nil {
+		return
+	}
+	select {
+	case <-ag.done:
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for agent %s to stop", ag.ID)
 	}
 }
 

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -357,7 +357,9 @@ func (a *App) Shutdown(_ context.Context) {
 		a.cancel()
 	}
 	a.wg.Wait()
-	a.agents.Shutdown()
+	if a.agents != nil {
+		a.agents.Shutdown()
+	}
 	if a.audit != nil {
 		_ = a.audit.Close()
 	}

--- a/internal/sybra/app_startup_test.go
+++ b/internal/sybra/app_startup_test.go
@@ -1,0 +1,167 @@
+package sybra
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/events"
+)
+
+func TestAppStartupWiresSubsystemsAndServices(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SYBRA_HOME", home)
+	t.Setenv("SYBRA_DISABLE_WORKFLOWS", "")
+
+	cfg := startupTestConfig(home)
+	logger := slog.New(slog.DiscardHandler)
+	logLevel := &slog.LevelVar{}
+
+	var emitted []string
+	app := NewApp(logger, logLevel, cfg, WithEmit(func(event string, _ any) {
+		emitted = append(emitted, event)
+	}))
+
+	// NewApp must pre-allocate the bound service structs before Startup so
+	// desktop binding generation can see stable service targets.
+	if app.taskSvc == nil || app.agentSvc == nil || app.projectSvc == nil || app.configSvc == nil {
+		t.Fatal("NewApp did not pre-allocate bound services")
+	}
+
+	if err := app.Startup(context.Background()); err != nil {
+		t.Fatalf("Startup: %v", err)
+	}
+	t.Cleanup(func() {
+		if app.agentSvc != nil && app.agentSvc.approval != nil {
+			_ = app.agentSvc.approval.Shutdown(context.Background())
+		}
+		app.Shutdown(context.Background())
+	})
+
+	assertStartupCoreWiring(t, app, logger, cfg, logLevel)
+	assertStartupServiceWiring(t, app)
+
+	for _, event := range emitted {
+		if event == events.StartupDegraded {
+			t.Fatalf("isolated startup emitted degraded event: %v", emitted)
+		}
+	}
+}
+
+func startupTestConfig(home string) *config.Config {
+	cfg := config.DefaultConfig()
+	cfg.TasksDir = filepath.Join(home, "tasks")
+	cfg.SkillsDir = filepath.Join(home, "claude", "skills")
+	cfg.RepoDir = home
+	cfg.ProjectsDir = filepath.Join(home, "projects")
+	cfg.ClonesDir = filepath.Join(home, "clones")
+	cfg.WorktreesDir = filepath.Join(home, "worktrees")
+	cfg.LoopAgentsDir = filepath.Join(home, "loop-agents")
+	cfg.Logging.Dir = filepath.Join(home, "logs")
+
+	cfg.Notification.Desktop = false
+	cfg.GitHub.Enabled = false
+	cfg.Renovate.Enabled = false
+	cfg.Todoist.Enabled = false
+	cfg.Triage.Enabled = false
+	cfg.Umbrella.Enabled = false
+	cfg.Watchdog.Enabled = false
+	cfg.Monitor.Enabled = false
+	cfg.SelfMonitor.Enabled = false
+	cfg.Evaluation.Enabled = false
+	cfg.HarnessEvolve.Enabled = false
+	cfg.AutoUpdate.Enabled = false
+	cfg.Providers.HealthCheck.Enabled = false
+	cfg.Providers.Limits.Enabled = false
+	return cfg
+}
+
+func assertStartupCoreWiring(t *testing.T, app *App, logger *slog.Logger, cfg *config.Config, logLevel *slog.LevelVar) {
+	t.Helper()
+
+	if app.ctx == nil || app.cancel == nil {
+		t.Fatal("startup context was not installed")
+	}
+	if app.cfg != cfg || app.logger != logger || app.logLevel != logLevel {
+		t.Fatal("constructor-supplied app dependencies were not retained")
+	}
+	if app.tasks == nil {
+		t.Fatal("task manager is nil")
+	}
+	if app.projects == nil {
+		t.Fatal("project store is nil")
+	}
+	if app.loopAgents == nil || app.loopSched == nil {
+		t.Fatal("loop agent store/scheduler were not initialized")
+	}
+	if app.bgops == nil {
+		t.Fatal("background operation tracker is nil")
+	}
+	if app.agents == nil {
+		t.Fatal("agent manager is nil")
+	}
+	if app.providerHealth != nil {
+		t.Fatal("provider health checker should be nil when disabled")
+	}
+	if app.worktrees == nil || app.sandboxes == nil {
+		t.Fatal("worktree/sandbox managers were not initialized")
+	}
+	if app.agentOrch == nil || app.reviewer == nil {
+		t.Fatal("agent orchestrator/reviewer were not initialized")
+	}
+	if app.workflowEngine == nil || app.workflowStore == nil {
+		t.Fatal("workflow engine/store were not initialized")
+	}
+	if app.agentCompletion == nil || app.recovery == nil {
+		t.Fatal("completion/recovery handlers were not initialized")
+	}
+	if app.watcher == nil || app.configWatcher == nil {
+		t.Fatal("file/config watchers were not started")
+	}
+	if app.notifier == nil || app.artifacts == nil || app.experience == nil || app.stats == nil || app.limits == nil {
+		t.Fatal("support stores were not initialized")
+	}
+}
+
+func assertStartupServiceWiring(t *testing.T, app *App) {
+	t.Helper()
+
+	if app.taskSvc.tasks != app.tasks || app.taskSvc.agents != app.agents || app.taskSvc.workflowEngine != app.workflowEngine {
+		t.Fatal("task service was not wired after core managers")
+	}
+	if app.agentSvc.agents != app.agents || app.agentSvc.tasks != app.tasks || app.agentSvc.worktrees != app.worktrees {
+		t.Fatal("agent service was not wired after agent/worktree managers")
+	}
+	if app.orchSvc.agents != app.agents || app.orchSvc.audit != app.audit {
+		t.Fatal("orchestrator service was not wired")
+	}
+	if app.projectSvc.projects != app.projects || app.projectSvc.worktrees != app.worktrees || app.projectSvc.bgops != app.bgops {
+		t.Fatal("project service was not wired")
+	}
+	if app.loopAgentSvc.store != app.loopAgents || app.loopAgentSvc.sched != app.loopSched {
+		t.Fatal("loop-agent service was not wired")
+	}
+	if app.configSvc.cfg != app.cfg || app.configSvc.agents != app.agents || app.configSvc.limits != app.limits {
+		t.Fatal("config service was not wired")
+	}
+	if app.intgSvc.tasks != app.tasks || app.intgSvc.projects != app.projects || app.intgSvc.workflowEngine != app.workflowEngine {
+		t.Fatal("integration service was not wired")
+	}
+	if app.reviewSvc.reviewer != app.reviewer || app.reviewSvc.tasks != app.tasks {
+		t.Fatal("review service was not wired")
+	}
+	if app.workflowSvc.engine != app.workflowEngine || app.workflowSvc.store != app.workflowStore {
+		t.Fatal("workflow service was not wired")
+	}
+	if app.reviewer.workflowEngine != app.workflowEngine {
+		t.Fatal("reviewer was not back-wired to the workflow engine")
+	}
+	if app.agentOrch.sandboxes != app.sandboxes || app.agentOrch.bgops != app.bgops {
+		t.Fatal("agent orchestrator was not fully wired")
+	}
+	if app.statsSvc.stats != app.stats || app.statsSvc.limits != app.limits || app.statsSvc.projects != app.projects {
+		t.Fatal("stats service was not wired")
+	}
+}

--- a/internal/sybra/app_startup_test.go
+++ b/internal/sybra/app_startup_test.go
@@ -13,7 +13,7 @@ import (
 func TestAppStartupWiresSubsystemsAndServices(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("SYBRA_HOME", home)
-	t.Setenv("SYBRA_DISABLE_WORKFLOWS", "")
+	t.Setenv("SYBRA_DISABLE_WORKFLOWS", "0")
 
 	cfg := startupTestConfig(home)
 	logger := slog.New(slog.DiscardHandler)
@@ -50,6 +50,18 @@ func TestAppStartupWiresSubsystemsAndServices(t *testing.T) {
 	}
 }
 
+func TestAppShutdownBeforeStartupDoesNotPanic(t *testing.T) {
+	app := NewApp(slog.New(slog.DiscardHandler), &slog.LevelVar{}, startupTestConfig(t.TempDir()))
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Shutdown before Startup panicked: %v", r)
+		}
+	}()
+
+	app.Shutdown(context.Background())
+}
+
 func startupTestConfig(home string) *config.Config {
 	cfg := config.DefaultConfig()
 	cfg.TasksDir = filepath.Join(home, "tasks")
@@ -61,6 +73,7 @@ func startupTestConfig(home string) *config.Config {
 	cfg.LoopAgentsDir = filepath.Join(home, "loop-agents")
 	cfg.Logging.Dir = filepath.Join(home, "logs")
 
+	// Keep every background automation disabled; this test only verifies startup wiring.
 	cfg.Notification.Desktop = false
 	cfg.GitHub.Enabled = false
 	cfg.Renovate.Enabled = false

--- a/internal/sybra/app_startup_test.go
+++ b/internal/sybra/app_startup_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/Automaat/sybra/internal/config"
@@ -19,9 +20,9 @@ func TestAppStartupWiresSubsystemsAndServices(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	logLevel := &slog.LevelVar{}
 
-	var emitted []string
+	var emitted startupEventRecorder
 	app := NewApp(logger, logLevel, cfg, WithEmit(func(event string, _ any) {
-		emitted = append(emitted, event)
+		emitted.append(event)
 	}))
 
 	// NewApp must pre-allocate the bound service structs before Startup so
@@ -43,11 +44,29 @@ func TestAppStartupWiresSubsystemsAndServices(t *testing.T) {
 	assertStartupCoreWiring(t, app, logger, cfg, logLevel)
 	assertStartupServiceWiring(t, app)
 
-	for _, event := range emitted {
+	emittedEvents := emitted.snapshot()
+	for _, event := range emittedEvents {
 		if event == events.StartupDegraded {
-			t.Fatalf("isolated startup emitted degraded event: %v", emitted)
+			t.Fatalf("isolated startup emitted degraded event: %v", emittedEvents)
 		}
 	}
+}
+
+type startupEventRecorder struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (r *startupEventRecorder) append(event string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, event)
+}
+
+func (r *startupEventRecorder) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.events...)
 }
 
 func TestAppShutdownBeforeStartupDoesNotPanic(t *testing.T) {


### PR DESCRIPTION
## Motivation

Closes https://github.com/Automaat/sybra/issues/1269

Add regression coverage for startup wiring so the app restores and supervises agent manager state correctly after restart.

## Implementation information

- Adds startup tests covering agent manager wiring during app initialization.
- Adds agent lifecycle restart survival coverage.
- Adjusts app startup wiring so tests exercise the expected manager initialization path.