### PR TITLE
refactor(task): split persistence schema

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -354,7 +354,7 @@ export class Task {
      */
     "testingCycleStartedAt"?: time$0.Time | null;
     "agentRuns": AgentRun[];
-    "workflow": workflow$0.Execution | null;
+    "workflow"?: workflow$0.Execution | null;
     "createdAt": time$0.Time;
     "updatedAt": time$0.Time;
     "body": string;
@@ -434,9 +434,6 @@ export class Task {
         }
         if (!("agentRuns" in $$source)) {
             this["agentRuns"] = [];
-        }
-        if (!("workflow" in $$source)) {
-            this["workflow"] = null;
         }
         if (!("createdAt" in $$source)) {
             this["createdAt"] = null;

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -173,176 +173,176 @@ func ValidateAgentProvider(s string) (string, error) {
 }
 
 type AgentRun struct {
-	AgentID  string `yaml:"agent_id" json:"agentId"`
-	Role     string `yaml:"role,omitempty" json:"role"` // triage, plan, eval, pr-fix, or "" for implementation
-	Mode     string `yaml:"mode" json:"mode"`
-	Provider string `yaml:"provider,omitempty" json:"provider,omitempty"`
-	Model    string `yaml:"model,omitempty" json:"model,omitempty"`
+	AgentID  string `json:"agentId"`
+	Role     string `json:"role"` // triage, plan, eval, pr-fix, or "" for implementation
+	Mode     string `json:"mode"`
+	Provider string `json:"provider,omitempty"`
+	Model    string `json:"model,omitempty"`
 	// ExperimentID/VariantID capture deterministic A/B assignment selected
 	// before the run started.
-	ExperimentID    string    `yaml:"experiment_id,omitempty" json:"experimentId,omitempty"`
-	VariantID       string    `yaml:"variant_id,omitempty" json:"variantId,omitempty"`
-	AssignmentUnit  string    `yaml:"assignment_unit,omitempty" json:"assignmentUnit,omitempty"`
-	AssignmentKey   string    `yaml:"assignment_key,omitempty" json:"assignmentKey,omitempty"`
-	ReasoningEffort string    `yaml:"reasoning_effort,omitempty" json:"reasoningEffort,omitempty"`
-	State           string    `yaml:"state" json:"state"`
-	StartedAt       time.Time `yaml:"started_at" json:"startedAt"`
-	CostUSD         float64   `yaml:"cost_usd,omitempty" json:"costUsd"`
-	PremiumRequests float64   `yaml:"premium_requests,omitempty" json:"premiumRequests,omitempty"`
-	Prompt          string    `yaml:"prompt,omitempty" json:"prompt,omitempty"`
-	Result          string    `yaml:"result,omitempty" json:"result"`
-	OneShot         bool      `yaml:"one_shot,omitempty" json:"oneShot,omitempty"`
+	ExperimentID    string    `json:"experimentId,omitempty"`
+	VariantID       string    `json:"variantId,omitempty"`
+	AssignmentUnit  string    `json:"assignmentUnit,omitempty"`
+	AssignmentKey   string    `json:"assignmentKey,omitempty"`
+	ReasoningEffort string    `json:"reasoningEffort,omitempty"`
+	State           string    `json:"state"`
+	StartedAt       time.Time `json:"startedAt"`
+	CostUSD         float64   `json:"costUsd"`
+	PremiumRequests float64   `json:"premiumRequests,omitempty"`
+	Prompt          string    `json:"prompt,omitempty"`
+	Result          string    `json:"result"`
+	OneShot         bool      `json:"oneShot,omitempty"`
 	// Verdict holds the parsed decision for human-review runs ("human" or
 	// "sybra_bug"). Extracted from live agent output at completion time so
 	// it survives Result truncation.
-	Verdict string `yaml:"verdict,omitempty" json:"verdict,omitempty"`
+	Verdict string `json:"verdict,omitempty"`
 	// VerdictRendered is set to true after onComplete has successfully applied
 	// all side-effects for this run (note appended, issue filed, local task
 	// created). Used by verdictAlreadyRendered as the durable rendered-marker
 	// instead of body-text patterns which can collide with user content.
-	VerdictRendered bool   `yaml:"verdict_rendered,omitempty" json:"verdictRendered,omitempty"`
-	LogFile         string `yaml:"log_file,omitempty" json:"logFile"`
-	SessionID       string `yaml:"session_id,omitempty" json:"sessionId,omitempty"`
+	VerdictRendered bool   `json:"verdictRendered,omitempty"`
+	LogFile         string `json:"logFile"`
+	SessionID       string `json:"sessionId,omitempty"`
 	// ProtocolViolation records deterministic workflow-level contract failures
 	// for this run. Test routing uses it to avoid counting a bad verifier report
 	// as an implementation failure across later workflow executions.
-	ProtocolViolation string `yaml:"protocol_violation,omitempty" json:"protocolViolation,omitempty"`
+	ProtocolViolation string `json:"protocolViolation,omitempty"`
 	// TestOutcome records the deterministic classification of a test-runner run
 	// (product_bug, infra_failure, ambiguous_requirement, etc.). The testing
 	// router counts only product_bug outcomes against the implementation budget.
-	TestOutcome string `yaml:"test_outcome,omitempty" json:"testOutcome,omitempty"`
+	TestOutcome string `json:"testOutcome,omitempty"`
 	// TestFailureFingerprint is a stable hash of the grounded failure report.
 	// Repeated fingerprints mean the same repro survived a fix attempt and should
 	// get targeted human/local reproduction instead of another broad retry.
-	TestFailureFingerprint string `yaml:"test_failure_fingerprint,omitempty" json:"testFailureFingerprint,omitempty"`
+	TestFailureFingerprint string `json:"testFailureFingerprint,omitempty"`
 	// HeadSHA is the worktree HEAD commit at this run's completion — what the
 	// agent left on the branch. Compared against the merged PR head to detect
 	// human edits after the agent (merged_with_edits) and measure edit distance.
-	HeadSHA string `yaml:"head_sha,omitempty" json:"headSha,omitempty"`
+	HeadSHA string `json:"headSha,omitempty"`
 }
 
 type Task struct {
-	ID           string   `yaml:"id" json:"id"`
-	Slug         string   `yaml:"slug,omitempty" json:"slug"`
-	Title        string   `yaml:"title" json:"title"`
-	Status       Status   `yaml:"status" json:"status"`
-	TaskType     TaskType `yaml:"task_type,omitempty" json:"taskType"`
-	AgentMode    string   `yaml:"agent_mode" json:"agentMode"`
-	AllowedTools []string `yaml:"allowed_tools" json:"allowedTools"`
-	Tags         []string `yaml:"tags" json:"tags"`
-	ProjectID    string   `yaml:"project_id,omitempty" json:"projectId"`
-	Branch       string   `yaml:"branch,omitempty" json:"branch"`
+	ID           string   `json:"id"`
+	Slug         string   `json:"slug"`
+	Title        string   `json:"title"`
+	Status       Status   `json:"status"`
+	TaskType     TaskType `json:"taskType"`
+	AgentMode    string   `json:"agentMode"`
+	AllowedTools []string `json:"allowedTools"`
+	Tags         []string `json:"tags"`
+	ProjectID    string   `json:"projectId"`
+	Branch       string   `json:"branch"`
 	// WorktreeDir, when non-empty, makes Sybra adopt an externally-created git
 	// worktree at this path instead of creating its own under
 	// ~/.sybra/worktrees. Used for handoff from tools like Orca: every agent
 	// for this task runs in this directory, and Sybra never rebases, force-
 	// pushes, or removes it — the external tool owns its lifecycle. Empty =
 	// Sybra-managed worktree (default).
-	WorktreeDir  string `yaml:"worktree_dir,omitempty" json:"worktreeDir,omitempty"`
-	PRNumber     int    `yaml:"pr_number,omitempty" json:"prNumber"`
-	Issue        string `yaml:"issue,omitempty" json:"issue"`
-	StatusReason string `yaml:"status_reason,omitempty" json:"statusReason"`
+	WorktreeDir  string `json:"worktreeDir,omitempty"`
+	PRNumber     int    `json:"prNumber"`
+	Issue        string `json:"issue"`
+	StatusReason string `json:"statusReason"`
 	// HandoffSourceProvider records which local agent provider produced the
 	// work before a handoff skipped directly into review/testing/PR. Workflow
 	// steps with provider=cross use it when there is no Sybra-authored run
 	// history to flip from.
-	HandoffSourceProvider string `yaml:"handoff_source_provider,omitempty" json:"handoffSourceProvider,omitempty"`
+	HandoffSourceProvider string `json:"handoffSourceProvider,omitempty"`
 	// BlockedByIssue stores the URL of the GitHub issue that put the task
 	// into status=blocked. Set by the human-review automation when it
 	// concludes the human-required transition was caused by a Sybra bug.
-	BlockedByIssue string `yaml:"blocked_by_issue,omitempty" json:"blockedByIssue,omitempty"`
+	BlockedByIssue string `json:"blockedByIssue,omitempty"`
 	// UmbrellaIssue links this task to the ☂️ umbrella issue it was expanded
 	// from. Set on child tasks; empty for standalone tasks. The orchestrator's
 	// dependency gate reads it with DependsOn to decide when a child may leave
 	// `blocked`.
-	UmbrellaIssue string `yaml:"umbrella_issue,omitempty" json:"umbrellaIssue,omitempty"`
+	UmbrellaIssue string `json:"umbrellaIssue,omitempty"`
 	// DependsOn lists the issue refs (full github.com issue/PR URL or
 	// owner/repo#n shorthand) this task waits on — resolved by issue ref only,
 	// not task IDs. While the task is `blocked`, the gate holds it until every
 	// referenced task has reached `done`; an empty list releases immediately.
 	// Used only by umbrella child tasks.
-	DependsOn []string `yaml:"depends_on,omitempty" json:"dependsOn,omitempty"`
-	Reviewed  bool     `yaml:"reviewed,omitempty" json:"reviewed"`
-	RunRole   string   `yaml:"run_role,omitempty" json:"runRole"` // pr-fix when fixing review issues, "" for initial impl
+	DependsOn []string `json:"dependsOn,omitempty"`
+	Reviewed  bool     `json:"reviewed"`
+	RunRole   string   `json:"runRole"` // pr-fix when fixing review issues, "" for initial impl
 	// SupervisorSteer is a one-shot corrective message left by the watchdog's
 	// headless nudge: it stops a looping headless agent (which has no mid-stream
 	// channel) and persists the steer here so the recovery loop re-dispatches
 	// the resumed agent with the correction prepended to its prompt. Recovery
 	// clears it after consuming it exactly once. Empty for tasks with no pending
 	// nudge.
-	SupervisorSteer string `yaml:"supervisor_steer,omitempty" json:"supervisorSteer,omitempty"`
+	SupervisorSteer string `json:"supervisorSteer,omitempty"`
 	// ReviewPhase tracks where an inbound PR-review task (tag `review`) sits in
 	// the review lifecycle: reviewing → drafted → awaiting-author →
 	// needs-approval → approved (plus `manual` for small PRs punted to the
 	// human). Computed by the PR poller; drives the board's PR Reviews lane.
 	// Empty for non-review tasks.
-	ReviewPhase string `yaml:"review_phase,omitempty" json:"reviewPhase,omitempty"`
+	ReviewPhase string `json:"reviewPhase,omitempty"`
 	// PRPhase tracks where an outbound own-PR task (status in-review/ready-review,
 	// not tag `review`) sits in its lifecycle: draft → building → fixing →
 	// changes-requested → awaiting-approval → approved. Computed by the PR poller;
 	// drives the phase glyph on the board's In Review cards. Empty for tasks
 	// without an own PR (and for inbound review tasks, which use ReviewPhase).
-	PRPhase   string     `yaml:"pr_phase,omitempty" json:"prPhase,omitempty"`
-	TodoistID string     `yaml:"todoist_id,omitempty" json:"todoistId"`
-	Priority  Priority   `yaml:"priority,omitempty" json:"priority,omitempty"`
-	DueDate   *time.Time `yaml:"due_date,omitempty" json:"dueDate,omitempty"`
-	ClosedAt  *time.Time `yaml:"closed_at,omitempty" json:"closedAt,omitempty"`
+	PRPhase   string     `json:"prPhase,omitempty"`
+	TodoistID string     `json:"todoistId"`
+	Priority  Priority   `json:"priority,omitempty"`
+	DueDate   *time.Time `json:"dueDate,omitempty"`
+	ClosedAt  *time.Time `json:"closedAt,omitempty"`
 	// Outcome records how a task's own PR concluded: "merged", "merged_with_edits",
 	// "closed", or "reverted". Stamped by the PR monitor when the task auto-advances
 	// to done (and updated to "reverted" by the revert scanner). Empty for tasks
 	// that never produced a PR. Feeds the evaluation scorecard.
-	Outcome string `yaml:"outcome,omitempty" json:"outcome,omitempty"`
+	Outcome string `json:"outcome,omitempty"`
 	// MergeCommit is the default-branch commit a merged PR produced, recorded at
 	// landing so the revert scanner can detect a later revert of it.
-	MergeCommit string `yaml:"merge_commit,omitempty" json:"mergeCommit,omitempty"`
+	MergeCommit string `json:"mergeCommit,omitempty"`
 	// MaxTurns overrides the global agent turn limit for this task.
 	// Zero means "use global default".
-	MaxTurns int `yaml:"max_turns,omitempty" json:"maxTurns,omitempty"`
+	MaxTurns int `json:"maxTurns,omitempty"`
 	// RequirePermissions overrides the system default when set.
 	// nil = use system default (true). false = opt out (--dangerously-skip-permissions).
-	RequirePermissions *bool `yaml:"require_permissions,omitempty" json:"requirePermissions,omitempty"`
+	RequirePermissions *bool `json:"requirePermissions,omitempty"`
 	// HeadlessPermissionMode overrides the permission posture for headless claude
 	// runs on this task. "auto" emits --permission-mode auto; "bypass" keeps
 	// --dangerously-skip-permissions. Empty = use config default.
-	HeadlessPermissionMode string `yaml:"headless_permission_mode,omitempty" json:"headlessPermissionMode,omitempty"`
+	HeadlessPermissionMode string `json:"headlessPermissionMode,omitempty"`
 	// ForkSubagent enables CLAUDE_CODE_FORK_SUBAGENT=1 for this task's headless
 	// agent, allowing a single prompt to spawn parallel subagent runs. Trades
 	// higher token cost for reduced wall-clock time on multi-part prompts.
-	ForkSubagent bool `yaml:"fork_subagent,omitempty" json:"forkSubagent,omitempty"`
+	ForkSubagent bool `json:"forkSubagent,omitempty"`
 	// ReasoningEffort sets the Codex model reasoning level for this task's agents
 	// via -c model_reasoning_effort=<v>. Empty = model default. Codex-only;
 	// ignored for claude agents. Distinct from the claude-only extended-thinking
 	// knob — different CLI surface and vocabulary (xhigh vs max).
-	ReasoningEffort string `yaml:"reasoning_effort,omitempty" json:"reasoningEffort,omitempty"`
+	ReasoningEffort string `json:"reasoningEffort,omitempty"`
 	// TestingCycleStartedAt marks the start of the current testing cycle. It is
 	// set when a human re-dispatches the task after a human-required escalation,
 	// so route_test_result can exclude test-runner runs from prior cycles when
 	// counting toward TestingMaxAttempts. Nil means no re-dispatch has occurred
 	// and all test-runner runs count (correct for first-ever cycles).
-	TestingCycleStartedAt *time.Time          `yaml:"testing_cycle_started_at,omitempty" json:"testingCycleStartedAt,omitempty"`
-	AgentRuns             []AgentRun          `yaml:"agent_runs,omitempty" json:"agentRuns"`
-	Workflow              *workflow.Execution `yaml:"workflow,omitempty" json:"workflow"`
-	CreatedAt             time.Time           `yaml:"created_at" json:"createdAt"`
-	UpdatedAt             time.Time           `yaml:"updated_at" json:"updatedAt"`
+	TestingCycleStartedAt *time.Time          `json:"testingCycleStartedAt,omitempty"`
+	AgentRuns             []AgentRun          `json:"agentRuns"`
+	Workflow              *workflow.Execution `json:"workflow,omitempty"`
+	CreatedAt             time.Time           `json:"createdAt"`
+	UpdatedAt             time.Time           `json:"updatedAt"`
 
-	Body         string `yaml:"-" json:"body"`
-	Plan         string `yaml:"-" json:"plan,omitempty"`
-	PlanContract string `yaml:"-" json:"planContract,omitempty"`
-	PlanCritique string `yaml:"-" json:"planCritique,omitempty"`
+	Body         string `json:"body"`
+	Plan         string `json:"plan,omitempty"`
+	PlanContract string `json:"planContract,omitempty"`
+	PlanCritique string `json:"planCritique,omitempty"`
 	// Planning sidecars. Plan is the human-readable compact plan; PlanContract
 	// is the machine-validated JSON contract consumed by implementation agents.
 	// The remaining sidecars hold review/evidence material.
-	PlanResearch  string `yaml:"-" json:"planResearch,omitempty"`
-	PlanDecisions string `yaml:"-" json:"planDecisions,omitempty"`
-	PlanBrief     string `yaml:"-" json:"planBrief,omitempty"`
-	CodeReview    string `yaml:"-" json:"codeReview,omitempty"`
+	PlanResearch  string `json:"planResearch,omitempty"`
+	PlanDecisions string `json:"planDecisions,omitempty"`
+	PlanBrief     string `json:"planBrief,omitempty"`
+	CodeReview    string `json:"codeReview,omitempty"`
 	// PlanDrafts holds per-provider raw plan outputs during dual- (or N-)
 	// provider planning. Keys are typically the parallel child step ID
 	// (e.g. "plan_claude", "plan_codex"). Populated from PlanDraftStore on
 	// task load; the convergence step reads this map and writes the merged
 	// result to Plan.
-	PlanDrafts map[string]string `yaml:"-" json:"planDrafts,omitempty"`
-	FilePath   string            `yaml:"-" json:"filePath"`
+	PlanDrafts map[string]string `json:"planDrafts,omitempty"`
+	FilePath   string            `json:"filePath"`
 }
 
 func (t Task) DirName() string {

--- a/internal/task/model_test.go
+++ b/internal/task/model_test.go
@@ -1,6 +1,9 @@
 package task
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestValidateStatus_Valid(t *testing.T) {
 	t.Parallel()
@@ -207,5 +210,16 @@ func TestTask_DirName_NoSlug(t *testing.T) {
 	got := task.DirName()
 	if got != "a1b2c3d4" {
 		t.Errorf("got %q, want %q", got, "a1b2c3d4")
+	}
+}
+
+func TestTaskDomainTypesHaveNoYAMLTags(t *testing.T) {
+	t.Parallel()
+	for _, typ := range []reflect.Type{reflect.TypeFor[Task](), reflect.TypeFor[AgentRun]()} {
+		for field := range typ.Fields() {
+			if tag := field.Tag.Get("yaml"); tag != "" {
+				t.Errorf("%s.%s has yaml tag %q; task persistence tags belong in taskFrontmatter/agentRunRecord", typ.Name(), field.Name, tag)
+			}
+		}
 	}
 }

--- a/internal/task/parser.go
+++ b/internal/task/parser.go
@@ -44,18 +44,12 @@ func ParseBytes(data []byte) (Task, error) {
 
 	fm := data[locs[0][1]:locs[1][0]]
 
-	var t Task
-	if err := yaml.Unmarshal(fm, &t); err != nil {
+	var persisted taskFrontmatter
+	if err := yaml.Unmarshal(fm, &persisted); err != nil {
 		return Task{}, fmt.Errorf("unmarshal frontmatter: %w", err)
 	}
 
-	t.Body = string(bytes.TrimSpace(data[locs[1][1]:]))
-	if t.TaskType == "" {
-		t.TaskType = TaskTypeNormal
-	}
-	if t.AgentRuns == nil {
-		t.AgentRuns = []AgentRun{}
-	}
+	t := taskFromFrontmatter(persisted, string(bytes.TrimSpace(data[locs[1][1]:])))
 	if t.AgentMode != "" {
 		if _, err := ValidateAgentMode(t.AgentMode); err != nil {
 			return Task{}, err
@@ -82,7 +76,7 @@ func Marshal(t Task) ([]byte, error) {
 		t.AgentRuns[i].Prompt = strings.TrimLeft(t.AgentRuns[i].Prompt, " \t\n\r")
 	}
 
-	fm, err := yaml.Marshal(t)
+	fm, err := yaml.Marshal(frontmatterFromTask(t))
 	if err != nil {
 		return nil, fmt.Errorf("marshal frontmatter: %w", err)
 	}

--- a/internal/task/parser_test.go
+++ b/internal/task/parser_test.go
@@ -403,6 +403,55 @@ func TestMarshalRoundTripAgentRuns(t *testing.T) {
 	}
 }
 
+func TestMarshalRoundTripAgentRunOperationalFields(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC().Truncate(time.Second)
+	original := Task{
+		ID:        "ar-operational",
+		Title:     "AgentRun operational fields",
+		Status:    StatusInReview,
+		AgentMode: "headless",
+		AgentRuns: []AgentRun{{
+			AgentID:           "agent-001",
+			Mode:              "headless",
+			State:             "done",
+			StartedAt:         now,
+			Verdict:           "sybra_bug",
+			VerdictRendered:   true,
+			SessionID:         "session-001",
+			ProtocolViolation: "missing-contract",
+			HeadSHA:           "abcdef123456",
+		}},
+	}
+
+	data, err := Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	parsed, err := ParseBytes(data)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if len(parsed.AgentRuns) != 1 {
+		t.Fatalf("AgentRuns len = %d, want 1", len(parsed.AgentRuns))
+	}
+	got := parsed.AgentRuns[0]
+	if !got.VerdictRendered {
+		t.Error("VerdictRendered = false, want true")
+	}
+	if got.SessionID != original.AgentRuns[0].SessionID {
+		t.Errorf("SessionID = %q, want %q", got.SessionID, original.AgentRuns[0].SessionID)
+	}
+	if got.ProtocolViolation != original.AgentRuns[0].ProtocolViolation {
+		t.Errorf("ProtocolViolation = %q, want %q", got.ProtocolViolation, original.AgentRuns[0].ProtocolViolation)
+	}
+	if got.HeadSHA != original.AgentRuns[0].HeadSHA {
+		t.Errorf("HeadSHA = %q, want %q", got.HeadSHA, original.AgentRuns[0].HeadSHA)
+	}
+}
+
 func TestMarshalRoundTripAgentRunsIndentedResult(t *testing.T) {
 	t.Parallel()
 	now := time.Now().UTC().Truncate(time.Second)

--- a/internal/task/persistence.go
+++ b/internal/task/persistence.go
@@ -1,0 +1,198 @@
+package task
+
+import (
+	"time"
+
+	"github.com/Automaat/sybra/internal/workflow"
+)
+
+// taskFrontmatter is the on-disk YAML schema for a task file. Keep persistence
+// field names here so Task can evolve as the domain/API model without carrying
+// serialization tags.
+type taskFrontmatter struct {
+	ID                     string              `yaml:"id"`
+	Slug                   string              `yaml:"slug,omitempty"`
+	Title                  string              `yaml:"title"`
+	Status                 Status              `yaml:"status"`
+	TaskType               TaskType            `yaml:"task_type,omitempty"`
+	AgentMode              string              `yaml:"agent_mode"`
+	AllowedTools           []string            `yaml:"allowed_tools"`
+	Tags                   []string            `yaml:"tags"`
+	ProjectID              string              `yaml:"project_id,omitempty"`
+	Branch                 string              `yaml:"branch,omitempty"`
+	WorktreeDir            string              `yaml:"worktree_dir,omitempty"`
+	PRNumber               int                 `yaml:"pr_number,omitempty"`
+	Issue                  string              `yaml:"issue,omitempty"`
+	StatusReason           string              `yaml:"status_reason,omitempty"`
+	HandoffSourceProvider  string              `yaml:"handoff_source_provider,omitempty"`
+	BlockedByIssue         string              `yaml:"blocked_by_issue,omitempty"`
+	UmbrellaIssue          string              `yaml:"umbrella_issue,omitempty"`
+	DependsOn              []string            `yaml:"depends_on,omitempty"`
+	Reviewed               bool                `yaml:"reviewed,omitempty"`
+	RunRole                string              `yaml:"run_role,omitempty"`
+	SupervisorSteer        string              `yaml:"supervisor_steer,omitempty"`
+	ReviewPhase            string              `yaml:"review_phase,omitempty"`
+	PRPhase                string              `yaml:"pr_phase,omitempty"`
+	TodoistID              string              `yaml:"todoist_id,omitempty"`
+	Priority               Priority            `yaml:"priority,omitempty"`
+	DueDate                *time.Time          `yaml:"due_date,omitempty"`
+	ClosedAt               *time.Time          `yaml:"closed_at,omitempty"`
+	Outcome                string              `yaml:"outcome,omitempty"`
+	MergeCommit            string              `yaml:"merge_commit,omitempty"`
+	MaxTurns               int                 `yaml:"max_turns,omitempty"`
+	RequirePermissions     *bool               `yaml:"require_permissions,omitempty"`
+	HeadlessPermissionMode string              `yaml:"headless_permission_mode,omitempty"`
+	ForkSubagent           bool                `yaml:"fork_subagent,omitempty"`
+	ReasoningEffort        string              `yaml:"reasoning_effort,omitempty"`
+	TestingCycleStartedAt  *time.Time          `yaml:"testing_cycle_started_at,omitempty"`
+	AgentRuns              []agentRunRecord    `yaml:"agent_runs,omitempty"`
+	Workflow               *workflow.Execution `yaml:"workflow,omitempty"`
+	CreatedAt              time.Time           `yaml:"created_at"`
+	UpdatedAt              time.Time           `yaml:"updated_at"`
+}
+
+type agentRunRecord struct {
+	AgentID                string    `yaml:"agent_id"`
+	Role                   string    `yaml:"role,omitempty"`
+	Mode                   string    `yaml:"mode"`
+	Provider               string    `yaml:"provider,omitempty"`
+	Model                  string    `yaml:"model,omitempty"`
+	ExperimentID           string    `yaml:"experiment_id,omitempty"`
+	VariantID              string    `yaml:"variant_id,omitempty"`
+	AssignmentUnit         string    `yaml:"assignment_unit,omitempty"`
+	AssignmentKey          string    `yaml:"assignment_key,omitempty"`
+	ReasoningEffort        string    `yaml:"reasoning_effort,omitempty"`
+	State                  string    `yaml:"state"`
+	StartedAt              time.Time `yaml:"started_at"`
+	CostUSD                float64   `yaml:"cost_usd,omitempty"`
+	PremiumRequests        float64   `yaml:"premium_requests,omitempty"`
+	Prompt                 string    `yaml:"prompt,omitempty"`
+	Result                 string    `yaml:"result,omitempty"`
+	OneShot                bool      `yaml:"one_shot,omitempty"`
+	Verdict                string    `yaml:"verdict,omitempty"`
+	VerdictRendered        bool      `yaml:"verdict_rendered,omitempty"`
+	LogFile                string    `yaml:"log_file,omitempty"`
+	SessionID              string    `yaml:"session_id,omitempty"`
+	ProtocolViolation      string    `yaml:"protocol_violation,omitempty"`
+	TestOutcome            string    `yaml:"test_outcome,omitempty"`
+	TestFailureFingerprint string    `yaml:"test_failure_fingerprint,omitempty"`
+	HeadSHA                string    `yaml:"head_sha,omitempty"`
+}
+
+func taskFromFrontmatter(fm taskFrontmatter, body string) Task {
+	t := Task{
+		ID:                     fm.ID,
+		Slug:                   fm.Slug,
+		Title:                  fm.Title,
+		Status:                 fm.Status,
+		TaskType:               fm.TaskType,
+		AgentMode:              fm.AgentMode,
+		AllowedTools:           fm.AllowedTools,
+		Tags:                   fm.Tags,
+		ProjectID:              fm.ProjectID,
+		Branch:                 fm.Branch,
+		WorktreeDir:            fm.WorktreeDir,
+		PRNumber:               fm.PRNumber,
+		Issue:                  fm.Issue,
+		StatusReason:           fm.StatusReason,
+		HandoffSourceProvider:  fm.HandoffSourceProvider,
+		BlockedByIssue:         fm.BlockedByIssue,
+		UmbrellaIssue:          fm.UmbrellaIssue,
+		DependsOn:              fm.DependsOn,
+		Reviewed:               fm.Reviewed,
+		RunRole:                fm.RunRole,
+		SupervisorSteer:        fm.SupervisorSteer,
+		ReviewPhase:            fm.ReviewPhase,
+		PRPhase:                fm.PRPhase,
+		TodoistID:              fm.TodoistID,
+		Priority:               fm.Priority,
+		DueDate:                fm.DueDate,
+		ClosedAt:               fm.ClosedAt,
+		Outcome:                fm.Outcome,
+		MergeCommit:            fm.MergeCommit,
+		MaxTurns:               fm.MaxTurns,
+		RequirePermissions:     fm.RequirePermissions,
+		HeadlessPermissionMode: fm.HeadlessPermissionMode,
+		ForkSubagent:           fm.ForkSubagent,
+		ReasoningEffort:        fm.ReasoningEffort,
+		TestingCycleStartedAt:  fm.TestingCycleStartedAt,
+		Workflow:               fm.Workflow,
+		CreatedAt:              fm.CreatedAt,
+		UpdatedAt:              fm.UpdatedAt,
+		Body:                   body,
+	}
+	if t.TaskType == "" {
+		t.TaskType = TaskTypeNormal
+	}
+	t.AgentRuns = agentRunsFromRecords(fm.AgentRuns)
+	if t.AgentRuns == nil {
+		t.AgentRuns = []AgentRun{}
+	}
+	return t
+}
+
+func frontmatterFromTask(t Task) taskFrontmatter {
+	return taskFrontmatter{
+		ID:                     t.ID,
+		Slug:                   t.Slug,
+		Title:                  t.Title,
+		Status:                 t.Status,
+		TaskType:               t.TaskType,
+		AgentMode:              t.AgentMode,
+		AllowedTools:           t.AllowedTools,
+		Tags:                   t.Tags,
+		ProjectID:              t.ProjectID,
+		Branch:                 t.Branch,
+		WorktreeDir:            t.WorktreeDir,
+		PRNumber:               t.PRNumber,
+		Issue:                  t.Issue,
+		StatusReason:           t.StatusReason,
+		HandoffSourceProvider:  t.HandoffSourceProvider,
+		BlockedByIssue:         t.BlockedByIssue,
+		UmbrellaIssue:          t.UmbrellaIssue,
+		DependsOn:              t.DependsOn,
+		Reviewed:               t.Reviewed,
+		RunRole:                t.RunRole,
+		SupervisorSteer:        t.SupervisorSteer,
+		ReviewPhase:            t.ReviewPhase,
+		PRPhase:                t.PRPhase,
+		TodoistID:              t.TodoistID,
+		Priority:               t.Priority,
+		DueDate:                t.DueDate,
+		ClosedAt:               t.ClosedAt,
+		Outcome:                t.Outcome,
+		MergeCommit:            t.MergeCommit,
+		MaxTurns:               t.MaxTurns,
+		RequirePermissions:     t.RequirePermissions,
+		HeadlessPermissionMode: t.HeadlessPermissionMode,
+		ForkSubagent:           t.ForkSubagent,
+		ReasoningEffort:        t.ReasoningEffort,
+		TestingCycleStartedAt:  t.TestingCycleStartedAt,
+		AgentRuns:              agentRunRecordsFromRuns(t.AgentRuns),
+		Workflow:               t.Workflow,
+		CreatedAt:              t.CreatedAt,
+		UpdatedAt:              t.UpdatedAt,
+	}
+}
+
+func agentRunsFromRecords(records []agentRunRecord) []AgentRun {
+	if records == nil {
+		return nil
+	}
+	runs := make([]AgentRun, len(records))
+	for i := range records {
+		runs[i] = AgentRun(records[i])
+	}
+	return runs
+}
+
+func agentRunRecordsFromRuns(runs []AgentRun) []agentRunRecord {
+	if runs == nil {
+		return nil
+	}
+	records := make([]agentRunRecord, len(runs))
+	for i := range runs {
+		records[i] = agentRunRecord(runs[i])
+	}
+	return records
+}

--- a/internal/task/persistence.go
+++ b/internal/task/persistence.go
@@ -79,6 +79,8 @@ type agentRunRecord struct {
 	HeadSHA                string    `yaml:"head_sha,omitempty"`
 }
 
+// taskFromFrontmatter rebuilds the persisted task fields. Store loading
+// populates sidecar fields such as Plan, CodeReview, PlanDrafts, and FilePath.
 func taskFromFrontmatter(fm taskFrontmatter, body string) Task {
 	t := Task{
 		ID:                     fm.ID,

--- a/internal/task/persistence_test.go
+++ b/internal/task/persistence_test.go
@@ -1,0 +1,99 @@
+package task
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/workflow"
+)
+
+func TestTaskFrontmatterMappingRoundTrip(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 29, 12, 0, 0, 0, time.UTC)
+	closedAt := now.Add(time.Hour)
+	dueDate := now.Add(24 * time.Hour)
+	requirePermissions := false
+	testingCycleStartedAt := now.Add(2 * time.Hour)
+	completedAt := now.Add(3 * time.Hour)
+	original := Task{
+		ID:                     "task1234",
+		Slug:                   "task-slug",
+		Title:                  "Task title",
+		Status:                 StatusTesting,
+		TaskType:               TaskTypeResearch,
+		AgentMode:              AgentModeHeadless,
+		AllowedTools:           []string{"Read", "Write"},
+		Tags:                   []string{"backend", "refactor"},
+		ProjectID:              "owner/repo",
+		Branch:                 "feature/task",
+		WorktreeDir:            "/tmp/worktree",
+		PRNumber:               42,
+		Issue:                  "https://github.com/owner/repo/issues/1",
+		StatusReason:           "testing",
+		HandoffSourceProvider:  "codex",
+		BlockedByIssue:         "https://github.com/owner/repo/issues/2",
+		UmbrellaIssue:          "owner/repo#3",
+		DependsOn:              []string{"owner/repo#4"},
+		Reviewed:               true,
+		RunRole:                "pr-fix",
+		SupervisorSteer:        "read the failure",
+		ReviewPhase:            "awaiting-author",
+		PRPhase:                "fixing",
+		TodoistID:              "todoist-1",
+		Priority:               PriorityHigh,
+		DueDate:                &dueDate,
+		ClosedAt:               &closedAt,
+		Outcome:                "merged",
+		MergeCommit:            "abc123",
+		MaxTurns:               7,
+		RequirePermissions:     &requirePermissions,
+		HeadlessPermissionMode: "auto",
+		ForkSubagent:           true,
+		ReasoningEffort:        "xhigh",
+		TestingCycleStartedAt:  &testingCycleStartedAt,
+		AgentRuns: []AgentRun{{
+			AgentID:                "agent-1",
+			Role:                   "test-runner",
+			Mode:                   AgentModeHeadless,
+			Provider:               "claude",
+			Model:                  "model-a",
+			ExperimentID:           "exp",
+			VariantID:              "variant",
+			AssignmentUnit:         "task",
+			AssignmentKey:          "task1234",
+			ReasoningEffort:        "high",
+			State:                  "done",
+			StartedAt:              now,
+			CostUSD:                1.25,
+			PremiumRequests:        2.5,
+			Prompt:                 "prompt",
+			Result:                 "result",
+			OneShot:                true,
+			Verdict:                "human",
+			VerdictRendered:        true,
+			LogFile:                "/tmp/log",
+			SessionID:              "session-1",
+			ProtocolViolation:      "bad-report",
+			TestOutcome:            "product_bug",
+			TestFailureFingerprint: "fp",
+			HeadSHA:                "def456",
+		}},
+		Workflow: &workflow.Execution{
+			WorkflowID:  "workflow-1",
+			CurrentStep: "step-1",
+			State:       workflow.ExecRunning,
+			StartedAt:   now,
+			CompletedAt: &completedAt,
+			Variables:   map[string]string{"k": "v"},
+		},
+		CreatedAt: now.Add(-time.Hour),
+		UpdatedAt: now,
+		Body:      "body",
+	}
+
+	got := taskFromFrontmatter(frontmatterFromTask(original), original.Body)
+	if !reflect.DeepEqual(got, original) {
+		t.Fatalf("frontmatter mapping mismatch\n got: %#v\nwant: %#v", got, original)
+	}
+}

--- a/internal/task/persistence_test.go
+++ b/internal/task/persistence_test.go
@@ -97,3 +97,188 @@ func TestTaskFrontmatterMappingRoundTrip(t *testing.T) {
 		t.Fatalf("frontmatter mapping mismatch\n got: %#v\nwant: %#v", got, original)
 	}
 }
+
+func TestTaskFrontmatterMappingCoversPersistedFields(t *testing.T) {
+	t.Parallel()
+	taskType := reflect.TypeFor[Task]()
+	frontmatterType := reflect.TypeFor[taskFrontmatter]()
+
+	for field := range taskType.Fields() {
+		if taskSidecarField(field.Name) {
+			continue
+		}
+		if _, ok := frontmatterType.FieldByName(field.Name); !ok {
+			t.Errorf("Task.%s is persisted but missing from taskFrontmatter", field.Name)
+		}
+	}
+	for field := range frontmatterType.Fields() {
+		if _, ok := taskType.FieldByName(field.Name); !ok {
+			t.Errorf("taskFrontmatter.%s has no matching Task field", field.Name)
+		}
+	}
+}
+
+func TestTaskFrontmatterMappingPreservesEachPersistedField(t *testing.T) {
+	t.Parallel()
+	taskType := reflect.TypeFor[Task]()
+
+	for field := range taskType.Fields() {
+		if taskSidecarField(field.Name) {
+			continue
+		}
+		t.Run(field.Name, func(t *testing.T) {
+			t.Parallel()
+			original := Task{}
+			setTaskFieldForPersistenceTest(t, &original, field.Name)
+
+			got := taskFromFrontmatter(frontmatterFromTask(original), "")
+			if !reflect.DeepEqual(reflect.ValueOf(got).FieldByName(field.Name).Interface(), reflect.ValueOf(original).FieldByName(field.Name).Interface()) {
+				t.Fatalf("Task.%s did not survive frontmatter mapping\n got: %#v\nwant: %#v", field.Name, reflect.ValueOf(got).FieldByName(field.Name).Interface(), reflect.ValueOf(original).FieldByName(field.Name).Interface())
+			}
+		})
+	}
+}
+
+func TestPersistenceTypesHaveYAMLTags(t *testing.T) {
+	t.Parallel()
+	for _, typ := range []reflect.Type{reflect.TypeFor[taskFrontmatter](), reflect.TypeFor[agentRunRecord]()} {
+		for field := range typ.Fields() {
+			if tag := field.Tag.Get("yaml"); tag == "" {
+				t.Errorf("%s.%s is missing a yaml tag", typ.Name(), field.Name)
+			}
+		}
+	}
+}
+
+func taskSidecarField(name string) bool {
+	switch name {
+	case "Body", "Plan", "PlanContract", "PlanCritique", "PlanResearch", "PlanDecisions", "PlanBrief", "CodeReview", "PlanDrafts", "FilePath":
+		return true
+	default:
+		return false
+	}
+}
+
+func setTaskFieldForPersistenceTest(t *testing.T, task *Task, name string) {
+	t.Helper()
+	now := time.Date(2026, 6, 29, 12, 0, 0, 0, time.UTC)
+	falseValue := false
+	later := now.Add(time.Hour)
+	completedAt := now.Add(2 * time.Hour)
+
+	switch name {
+	case "ID":
+		task.ID = "task-persist"
+	case "Slug":
+		task.Slug = "task-persist-slug"
+	case "Title":
+		task.Title = "Task persistence title"
+	case "Status":
+		task.Status = StatusTesting
+	case "TaskType":
+		task.TaskType = TaskTypeResearch
+	case "AgentMode":
+		task.AgentMode = AgentModeHeadless
+	case "AllowedTools":
+		task.AllowedTools = []string{"Read", "Write"}
+	case "Tags":
+		task.Tags = []string{"backend", "review"}
+	case "ProjectID":
+		task.ProjectID = "owner/repo"
+	case "Branch":
+		task.Branch = "feature/task-persist"
+	case "WorktreeDir":
+		task.WorktreeDir = "/tmp/task-persist"
+	case "PRNumber":
+		task.PRNumber = 123
+	case "Issue":
+		task.Issue = "owner/repo#123"
+	case "StatusReason":
+		task.StatusReason = "testing"
+	case "HandoffSourceProvider":
+		task.HandoffSourceProvider = "codex"
+	case "BlockedByIssue":
+		task.BlockedByIssue = "owner/repo#456"
+	case "UmbrellaIssue":
+		task.UmbrellaIssue = "owner/repo#789"
+	case "DependsOn":
+		task.DependsOn = []string{"owner/repo#321"}
+	case "Reviewed":
+		task.Reviewed = true
+	case "RunRole":
+		task.RunRole = "pr-fix"
+	case "SupervisorSteer":
+		task.SupervisorSteer = "read the failure"
+	case "ReviewPhase":
+		task.ReviewPhase = "awaiting-author"
+	case "PRPhase":
+		task.PRPhase = "fixing"
+	case "TodoistID":
+		task.TodoistID = "todoist-123"
+	case "Priority":
+		task.Priority = PriorityHigh
+	case "DueDate":
+		task.DueDate = &later
+	case "ClosedAt":
+		task.ClosedAt = &later
+	case "Outcome":
+		task.Outcome = "merged"
+	case "MergeCommit":
+		task.MergeCommit = "abc123"
+	case "MaxTurns":
+		task.MaxTurns = 7
+	case "RequirePermissions":
+		task.RequirePermissions = &falseValue
+	case "HeadlessPermissionMode":
+		task.HeadlessPermissionMode = "auto"
+	case "ForkSubagent":
+		task.ForkSubagent = true
+	case "ReasoningEffort":
+		task.ReasoningEffort = "xhigh"
+	case "TestingCycleStartedAt":
+		task.TestingCycleStartedAt = &later
+	case "AgentRuns":
+		task.AgentRuns = []AgentRun{{
+			AgentID:                "agent-1",
+			Role:                   "test-runner",
+			Mode:                   AgentModeHeadless,
+			Provider:               "claude",
+			Model:                  "model-a",
+			ExperimentID:           "exp",
+			VariantID:              "variant",
+			AssignmentUnit:         "task",
+			AssignmentKey:          "task-persist",
+			ReasoningEffort:        "high",
+			State:                  "done",
+			StartedAt:              now,
+			CostUSD:                1.25,
+			PremiumRequests:        2.5,
+			Prompt:                 "prompt",
+			Result:                 "result",
+			OneShot:                true,
+			Verdict:                "human",
+			VerdictRendered:        true,
+			LogFile:                "/tmp/log",
+			SessionID:              "session-1",
+			ProtocolViolation:      "bad-report",
+			TestOutcome:            "product_bug",
+			TestFailureFingerprint: "fp",
+			HeadSHA:                "def456",
+		}}
+	case "Workflow":
+		task.Workflow = &workflow.Execution{
+			WorkflowID:  "workflow-1",
+			CurrentStep: "step-1",
+			State:       workflow.ExecRunning,
+			StartedAt:   now,
+			CompletedAt: &completedAt,
+			Variables:   map[string]string{"k": "v"},
+		}
+	case "CreatedAt":
+		task.CreatedAt = now
+	case "UpdatedAt":
+		task.UpdatedAt = later
+	default:
+		t.Fatalf("no persistence test value for Task.%s", name)
+	}
+}

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -304,9 +304,9 @@ func (s *Store) Get(id string) (Task, error) {
 
 // read parses just the task file for id, skipping the sidecar fan-out that
 // Get performs. Write paths (Update, Delete) and the watcher status hook only
-// need the task's own frontmatter/body — the sidecar fields are yaml:"-" so
-// Marshal never serializes them, and no List() consumer reads them off a
-// cached entry. Loading them there is pure waste, dominated by
+// need the task's own frontmatter/body — sidecars live outside the task
+// frontmatter schema, and no List() consumer reads them off a cached entry.
+// Loading them there is pure waste, dominated by
 // PlanDraftStore.List, which scans the entire tasks dir (~one lstat per file)
 // on every call. That scan was ~20% of server CPU and ~50% of allocations
 // under churn because Update/Delete/OnExternalUpdate each paid it.


### PR DESCRIPTION
## Motivation

Closes https://github.com/Automaat/sybra/issues/1274

Task metadata currently mixes the domain model with the YAML persistence representation. That makes parser/store behavior harder to evolve safely and leaves frontmatter compatibility concerns spread across the task model.

## Implementation information

- Add a dedicated task persistence schema for YAML frontmatter marshal/unmarshal.
- Keep conversion between the persisted schema and the task domain model explicit.
- Cover persistence conversion, parser behavior, and legacy frontmatter handling with focused Go tests.