### PR TITLE
fix(workflow): stop stale completions and non-code CI from escalating to human

### DIFF
--- a/internal/github/check_filter.go
+++ b/internal/github/check_filter.go
@@ -21,15 +21,48 @@ var informationalCheckPrefixes = []string{
 	"deepsource/",
 }
 
+// aiReviewCheckPrefixes lists check-name prefixes for AI/LLM PR-review checks
+// (e.g. GitHub Copilot code review). Like the informational reporters above
+// these do not gate mergeability: their useful output is advisory review
+// *comments* (handled by the comments path), and a failing run is usually an
+// external condition no code change fixes — most commonly "you have exceeded
+// your monthly quota" (HTTP 402). Counting such a failure as CI FAILURE makes
+// pr-monitor dispatch the pr-fix loop, which burns its whole retry budget
+// re-confirming "nothing to fix here" before escalating to a human. Excluding
+// the check keeps CIStatus driven by the real CI gates.
+//
+// Matched by lowercase prefix, so `Copilot` and `Copilot review` both match.
+var aiReviewCheckPrefixes = []string{
+	"copilot",
+}
+
 // isInformationalCheck reports whether the check name belongs to a
 // non-gating reporter (coverage, quality scan). Empty name returns
 // false so unparseable contexts still feed the rollup.
 func isInformationalCheck(name string) bool {
+	return hasAnyPrefix(name, informationalCheckPrefixes)
+}
+
+// isAIReviewCheck reports whether the check is an AI code-review reporter
+// whose pass/fail must not gate mergeability (see aiReviewCheckPrefixes).
+func isAIReviewCheck(name string) bool {
+	return hasAnyPrefix(name, aiReviewCheckPrefixes)
+}
+
+// isNonGatingCheck reports whether a check should be left out of the CIStatus
+// rollup entirely — either an informational reporter or an AI-review check.
+func isNonGatingCheck(name string) bool {
+	return isInformationalCheck(name) || isAIReviewCheck(name)
+}
+
+// hasAnyPrefix reports whether name (lowercased) starts with any of prefixes.
+// Empty name returns false so unparseable contexts still feed the rollup.
+func hasAnyPrefix(name string, prefixes []string) bool {
 	if name == "" {
 		return false
 	}
 	lower := strings.ToLower(name)
-	for _, p := range informationalCheckPrefixes {
+	for _, p := range prefixes {
 		if strings.HasPrefix(lower, p) {
 			return true
 		}
@@ -105,7 +138,7 @@ func rollupFromContexts(contexts []gqlCheckContext) (ciStatus string, hasPending
 
 	var sawCounted, sawFailure, sawPending, sawSuccess bool
 	for i := range contexts {
-		if isInformationalCheck(contexts[i].Name) {
+		if isNonGatingCheck(contexts[i].Name) {
 			continue
 		}
 		state := effectiveCheckState(contexts[i])

--- a/internal/github/check_filter_test.go
+++ b/internal/github/check_filter_test.go
@@ -33,6 +33,30 @@ func TestIsInformationalCheck(t *testing.T) {
 	}
 }
 
+func TestIsAIReviewCheck(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"Copilot", true},
+		{"Copilot review", true},
+		{"copilot", true},
+		{"build", false},
+		{"CI", false},
+		{"codecov/patch", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isAIReviewCheck(tt.name); got != tt.want {
+				t.Errorf("isAIReviewCheck(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestEffectiveCheckState_CheckRun(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -201,6 +225,32 @@ func TestRollupFromContexts(t *testing.T) {
 				statusCtx("codecov/project", "FAILURE"),
 			},
 			wantStatus: "",
+		},
+		{
+			// Real CI green, Copilot AI-review check failing on monthly quota
+			// (HTTP 402). The review check must not gate, so the PR stays
+			// SUCCESS and pr-monitor never dispatches the pr-fix loop.
+			name: "real CI green, Copilot review fails on quota -> SUCCESS",
+			contexts: []gqlCheckContext{
+				checkRun("CI", "COMPLETED", "SUCCESS"),
+				checkRun("Copilot review", "COMPLETED", "FAILURE"),
+			},
+			wantStatus: "SUCCESS",
+		},
+		{
+			name: "only Copilot review fails -> filtered to caller fallback",
+			contexts: []gqlCheckContext{
+				checkRun("Copilot", "COMPLETED", "FAILURE"),
+			},
+			wantStatus: "",
+		},
+		{
+			name: "real check fails alongside Copilot review -> FAILURE",
+			contexts: []gqlCheckContext{
+				checkRun("build", "COMPLETED", "FAILURE"),
+				checkRun("Copilot review", "COMPLETED", "FAILURE"),
+			},
+			wantStatus: "FAILURE",
 		},
 	}
 

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -357,7 +357,9 @@ func (a *App) Shutdown(_ context.Context) {
 		a.cancel()
 	}
 	a.wg.Wait()
-	a.agents.Shutdown()
+	if a.agents != nil {
+		a.agents.Shutdown()
+	}
 	if a.audit != nil {
 		_ = a.audit.Close()
 	}

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -637,6 +637,11 @@ func TestShutdown(t *testing.T) {
 	a.Shutdown(t.Context())
 }
 
+func TestShutdownBeforeStartup(t *testing.T) {
+	a := NewApp(discardLogger(), &slog.LevelVar{}, testConfig(t))
+	a.Shutdown(t.Context())
+}
+
 func TestStartup(t *testing.T) {
 	a := NewApp(discardLogger(), &slog.LevelVar{}, testConfig(t))
 	if a.tasksDir == "" {

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -330,6 +330,28 @@ func (e *Engine) clearAgentStep(agentID string) {
 	e.mu.Unlock()
 }
 
+// clearAgentStepsForTask drops every agent→step mapping owned by a task. Called
+// right after StopAgentsForTask on a (re)dispatch: any agent we just stopped is
+// superseded by the one about to be spawned, so its late or double-delivered
+// completion must not be credited to the workflow. Clearing the entry turns
+// that completion "untracked", at which point the phantom-completion guard in
+// HandleAgentComplete drops it (the freshly-dispatched agent is the only tracked
+// agent for the current step). Without this a stopped test-runner's late
+// provider-error completion lands on the still-current run_test step and burns
+// the retry budget before the retry agent has produced a verdict.
+func (e *Engine) clearAgentStepsForTask(taskID string) {
+	if taskID == "" {
+		return
+	}
+	e.mu.Lock()
+	for id, entry := range e.agentSteps {
+		if entry.taskID == taskID {
+			delete(e.agentSteps, id)
+		}
+	}
+	e.mu.Unlock()
+}
+
 // ClearAgentStep removes the agent→step mapping without advancing the workflow.
 // Used when an agent exits due to an infrastructure-level signal kill so the
 // tracked-agent entry is released while the workflow step stays stalled for

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -168,6 +168,11 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 	// interactive plan agent with reuse_agent that outlived plan approval).
 	// Empty role = stop all roles for this task.
 	e.agents.StopAgentsForTask(taskID, "")
+	// Drop the stopped agents' step mappings so a late/double completion from a
+	// superseded agent (e.g. a stopped test-runner during a run_test retry) is
+	// treated as untracked and dropped rather than counted against the step's
+	// retry budget. The agent spawned just below becomes the only tracked one.
+	e.clearAgentStepsForTask(taskID)
 
 	// Interactive agents that aren't meant to persist across turns (no
 	// reuse_agent, no wait_for_status) must signal completion via process

--- a/internal/workflow/engine_steps_parallel.go
+++ b/internal/workflow/engine_steps_parallel.go
@@ -48,6 +48,10 @@ func (e *Engine) execParallel(taskID string, def *Definition, step *Step, wfExec
 	// Doing this inside the per-child loop would kill the child we just
 	// spawned for the previous iteration.
 	e.agents.StopAgentsForTask(taskID, "")
+	// Drop the stopped agents' step mappings so their late completions are
+	// dropped as untracked rather than crediting a superseded step (mirrors
+	// execRunAgent). The children spawned below register fresh entries.
+	e.clearAgentStepsForTask(taskID)
 
 	// Persist the inflight record before spawning so an agent that
 	// completes mid-loop finds the parent record on AdvanceStep.

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -780,6 +780,78 @@ func TestTriageRetry_Exhausted(t *testing.T) {
 	}
 }
 
+// TestRetry_SupersededAgentLateCompletionDropped reproduces the production bug
+// where a stopped/superseded agent's late (double-delivered) completion was
+// credited to the still-current step and burned its retry budget before the
+// retry agent could produce a result. A headless test-runner that is
+// interrupted can emit more than one terminal completion (e.g. an
+// aborted_streaming result followed by a provider-error exit); both used to
+// land on the run_test step and exhaust max_retries instantly.
+//
+// After the fix, dispatching the retry stops the original agent AND clears its
+// step mapping, so its second completion is untracked and dropped by the
+// phantom-completion guard rather than triggering a further retry.
+func TestRetry_SupersededAgentLateCompletionDropped(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
+	if err := engine.StartWorkflow("t1", "test-simple"); err != nil {
+		t.Fatal(err)
+	}
+
+	// First triage agent is dispatched and tracked by execRunAgent.
+	agentA := agents.LastID()
+
+	// Agent A fails once → workflow retries and dispatches agent B (still on the
+	// triage step, max_retries: 3). Driving this through AdvanceStep (rather than
+	// HandleAgentComplete) reproduces the production race: A's step mapping is
+	// NOT yet cleared when its late completion arrives, because the two
+	// completions run on different goroutines and HandleAgentComplete's trailing
+	// clearAgentStep for the first hasn't executed yet.
+	agents.SimulateComplete("t1")
+	if err := engine.AdvanceStep("t1", StepOutput{StepID: "triage", AgentID: agentA, Status: "failed"}); err != nil {
+		t.Fatal(err)
+	}
+	agentB := agents.LastID()
+	if agentB == agentA {
+		t.Fatalf("retry did not dispatch a new agent: still %s", agentA)
+	}
+	if got := triageStartCount(agents); got != 2 {
+		t.Fatalf("after first failure: triage calls = %d, want 2 (initial + 1 retry)", got)
+	}
+
+	// Agent A (now superseded/stopped) double-fires a second late completion
+	// while its mapping is still live. This must be dropped, not counted as
+	// another retry attempt against the step's retry budget.
+	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: agentA, Success: false})
+
+	if got := triageStartCount(agents); got != 2 {
+		t.Fatalf("after superseded late completion: triage calls = %d, want 2 — stale completion must not trigger another retry", got)
+	}
+	ti, _ := tasks.GetTask("t1")
+	if got := ti.Workflow.CountStep("triage"); got != 1 {
+		t.Errorf("CountStep(triage) = %d, want 1 — superseded completion must not be recorded", got)
+	}
+	if ti.Workflow.CurrentStep != "triage" {
+		t.Errorf("current_step = %q, want triage — retry agent B should still own the step", ti.Workflow.CurrentStep)
+	}
+}
+
+func triageStartCount(agents *mockAgents) int {
+	agents.mu.Lock()
+	defer agents.mu.Unlock()
+	n := 0
+	for i := range agents.calls {
+		if agents.calls[i].Role == "triage" {
+			n++
+		}
+	}
+	return n
+}
+
 func TestTriageRetryableReasonTreatsCompletedRunAsFailed(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()


### PR DESCRIPTION
## Motivation

Two tasks ended in `human-required` from workflow/monitor bugs rather than real
code problems:

- A `testing-task` escalated as "testing infrastructure failed after retry" with
  no test verdict. A stopped test-runner's late/double-delivered completion
  landed on the still-current `run_test` step and exhausted the retry budget
  before the retry agent ran.
- A refactor PR looped `pr-fix` four times then escalated, because a Copilot
  AI-review CI check failing on monthly quota (HTTP 402) was counted as a code
  CI failure. Real CI was green; no code change could fix it.

## Implementation information

- **workflow:** on every (re)dispatch, clear the stopped agents' `agentSteps`
  mappings right after `StopAgentsForTask` (`clearAgentStepsForTask`). A
  superseded agent's late completion then reads as untracked and is dropped by
  the existing phantom-completion guard, since the freshly-dispatched agent is
  the only tracked agent for the current step. Covers both `execRunAgent` and
  `execParallel`. Regression test reproduces the race.
- **github:** AI-review checks (`copilot*`) are excluded from the `CIStatus`
  rollup via a new `isNonGatingCheck`, mirroring the existing
  informational-reporter exclusion (codecov/sonar). Applies to both the GraphQL
  and REST monitor paths, so a quota-failed Copilot review no longer triggers
  the pr-fix loop. Tests cover green-CI-plus-failed-Copilot and the
  real-failure-alongside cases.

> Changelog: fix(workflow): stop superseded agent completions from exhausting step retries

## Supporting documentation

`go test ./...`, `golangci-lint run`, and `oxlint` all green.
