### PR TITLE
feat(agent): apply reasoning effort to all providers

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -883,7 +883,7 @@ func newUpdateFlags(fs *flag.FlagSet) updateFlags {
 		sourceProvider:    fs.String("source-provider", "", "handoff source provider: claude|codex|copilot|none"),
 		statusReason:      fs.String("status-reason", "", "reason for status change"),
 		maxTurns:          fs.Int("max-turns", -1, "per-task max turns override (0 clears override, >0 sets limit)"),
-		reasoningEffort:   fs.String("reasoning-effort", "", "codex reasoning effort: low|medium|high|xhigh ('default' or 'none' clears the override)"),
+		reasoningEffort:   fs.String("reasoning-effort", "", "reasoning effort (all providers): low|medium|high|xhigh ('default' or 'none' clears the override)"),
 	}
 }
 

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -338,10 +338,10 @@ export class Task {
     "forkSubagent"?: boolean;
 
     /**
-     * ReasoningEffort sets the Codex model reasoning level for this task's agents
-     * via -c model_reasoning_effort=<v>. Empty = model default. Codex-only;
-     * ignored for claude agents. Distinct from the claude-only extended-thinking
-     * knob — different CLI surface and vocabulary (xhigh vs max).
+     * ReasoningEffort sets the reasoning level for this task's agents
+     * (low/medium/high/xhigh). Empty = model default. Applied across providers:
+     * codex via -c model_reasoning_effort=<v>, claude and copilot via --effort.
+     * The value set is the common subset all three CLIs accept.
      */
     "reasoningEffort"?: string;
 

--- a/frontend/src/components/CreateTaskDialog.svelte
+++ b/frontend/src/components/CreateTaskDialog.svelte
@@ -221,7 +221,7 @@
             </label>
           {/if}
           <label class="flex flex-col gap-1">
-            <span class="text-sm font-medium">Reasoning effort <span class="font-normal text-surface-400">(Codex only)</span></span>
+            <span class="text-sm font-medium">Reasoning effort</span>
             <select
               bind:value={reasoningEffort}
               class="rounded-lg border border-surface-300 bg-surface-100 px-3 py-2 text-sm dark:border-surface-600 dark:bg-surface-700"

--- a/frontend/src/components/task-detail/TaskMetadataRow.svelte
+++ b/frontend/src/components/task-detail/TaskMetadataRow.svelte
@@ -172,7 +172,7 @@
   {/if}
 
   <div class="flex flex-col gap-1">
-    <span class="font-medium text-surface-500">Reasoning Effort <span class="font-normal text-surface-400 text-xs">(Codex only)</span></span>
+    <span class="font-medium text-surface-500">Reasoning Effort</span>
     <select
       aria-label="Reasoning Effort"
       class="w-fit rounded bg-transparent px-1 py-0.5 text-sm text-surface-600 dark:text-surface-300"
@@ -184,7 +184,7 @@
           error = String(e)
         }
       }}
-      title="Codex model_reasoning_effort. Empty = model default. Ignored for claude agents."
+      title="Provider reasoning effort. Empty = model default."
     >
       <option value="">default</option>
       {#each reasoningEffortOptions as option}

--- a/frontend/src/components/task-detail/TaskMetadataRow.svelte.test.ts
+++ b/frontend/src/components/task-detail/TaskMetadataRow.svelte.test.ts
@@ -58,6 +58,15 @@ describe('TaskMetadataRow', () => {
     expect(screen.getByText('global default')).toBeDefined()
   })
 
+  it('describes reasoning effort as provider-wide', () => {
+    render(TaskMetadataRow, { props: { task: baseTask as never } })
+    expect(screen.getByText('Reasoning Effort')).toBeDefined()
+    expect(screen.getByLabelText('Reasoning Effort').getAttribute('title')).toBe(
+      'Provider reasoning effort. Empty = model default.',
+    )
+    expect(screen.queryByText(/Codex only/)).toBeNull()
+  })
+
   it('renders agent mode + tags + project + branch + issue + allowed tools', () => {
     render(TaskMetadataRow, { props: { task: baseTask as never } })
     expect(screen.getByText('Agent Mode')).toBeDefined()

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -735,7 +735,6 @@ type RunConfig struct {
 	AssignmentKey      string
 	RequirePermissions bool   // when true, suppress --dangerously-skip-permissions
 	PermissionMode     string // "default", "acceptEdits", "bypassPermissions" (conversational mode)
-	Effort             string // "low", "medium", "high", "max" (extended thinking)
 	// OneShot closes stdin after the first `result` event in conversational
 	// mode so the claude process exits naturally. Without this, interactive
 	// agents sit in StatePaused forever and onComplete never fires, stranding
@@ -783,9 +782,10 @@ type RunConfig struct {
 	// model when the primary is overloaded. Empty means inherit the manager's
 	// default; the flag is omitted only when the manager default is also empty.
 	FallbackModel string
-	// ReasoningEffort sets codex's model_reasoning_effort (low/medium/high/xhigh)
-	// for this run. Empty = model default. Codex-only. NOT the same as Effort
-	// (claude --effort) — different provider, CLI surface, and value set.
+	// ReasoningEffort sets the agent's reasoning effort for this run
+	// (low/medium/high/xhigh). Empty = model default. Applied to every provider
+	// via its own CLI surface: codex `-c model_reasoning_effort=`, claude and
+	// copilot `--effort`. The value set is the common subset all three accept.
 	ReasoningEffort string
 	// SeedWorkingMemory, when true, inlines the worktree's NOTES.md scratchpad
 	// into the prompt (read/maintain instruction + current contents). Set only

--- a/internal/agent/provider_claude.go
+++ b/internal/agent/provider_claude.go
@@ -33,7 +33,7 @@ func (claudeProvider) NormalizeModel(model string) string {
 }
 
 func (claudeProvider) BuildCommand(cfg RunConfig, model string) string {
-	return buildClaudeCommand(model, cfg.AllowedTools, cfg.RequirePermissions, cfg.HeadlessPermissionMode)
+	return buildClaudeCommand(model, cfg.ReasoningEffort, cfg.AllowedTools, cfg.RequirePermissions, cfg.HeadlessPermissionMode)
 }
 
 func (claudeProvider) BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headlessInvocation, error) {
@@ -42,6 +42,7 @@ func (claudeProvider) BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headless
 		args = append(args, "--resume", sid)
 	}
 	args = append(args, claudePermissionArgs(cfg.AllowedTools, cfg.RequirePermissions, cfg.HeadlessPermissionMode)...)
+	args = append(args, effortArgs(a.ReasoningEffort)...)
 	if a.Model != "" {
 		args = append(args, "--model", a.Model)
 	}
@@ -90,13 +91,24 @@ func (claudeProvider) ClassifyError(sample providerpkg.ErrorSample) (providerpkg
 }
 
 // buildClaudeCommand builds the display command string for a Claude agent.
-func buildClaudeCommand(model string, allowedTools []string, requirePerms bool, mode string) string {
+func buildClaudeCommand(model, effort string, allowedTools []string, requirePerms bool, mode string) string {
 	parts := []string{"claude"}
 	parts = append(parts, claudePermissionArgs(allowedTools, requirePerms, mode)...)
+	parts = append(parts, effortArgs(effort)...)
 	if model != "" {
 		parts = append(parts, "--model", model)
 	}
 	return strings.Join(parts, " ")
+}
+
+// effortArgs returns the reasoning-effort CLI flag shared by the claude and
+// copilot CLIs (`--effort <level>`), or nil when effort is empty so the model
+// default is used. Codex uses a different surface — see codexReasoningArgs.
+func effortArgs(effort string) []string {
+	if effort == "" {
+		return nil
+	}
+	return []string{"--effort", effort}
 }
 
 // claudePermissionArgs returns the permission-related CLI flags for a claude headless run.

--- a/internal/agent/provider_claude.go
+++ b/internal/agent/provider_claude.go
@@ -102,11 +102,11 @@ func buildClaudeCommand(model, effort string, allowedTools []string, requirePerm
 }
 
 // effortArgs returns the reasoning-effort CLI flag shared by the claude and
-// copilot CLIs (`--effort <level>`), or nil when effort is empty so the model
-// default is used. Codex uses a different surface — see codexReasoningArgs.
+// copilot CLIs (`--effort <level>`), or an empty slice when effort is empty so
+// the model default is used. Codex uses a different surface — see codexReasoningArgs.
 func effortArgs(effort string) []string {
 	if effort == "" {
-		return nil
+		return []string{}
 	}
 	return []string{"--effort", effort}
 }

--- a/internal/agent/provider_copilot.go
+++ b/internal/agent/provider_copilot.go
@@ -37,14 +37,15 @@ func (copilotProvider) NormalizeModel(model string) string {
 	}
 }
 
-func (copilotProvider) BuildCommand(_ RunConfig, model string) string {
-	return buildCopilotCommand(model)
+func (copilotProvider) BuildCommand(cfg RunConfig, model string) string {
+	return buildCopilotCommand(model, cfg.ReasoningEffort)
 }
 
 func (copilotProvider) BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headlessInvocation, error) {
 	// --allow-all-tools is required for non-interactive mode; --no-ask-user
 	// stops the agent blocking on questions (no TTY/UI to answer them).
 	args := []string{"-p", cfg.Prompt, "--output-format", "json", "--allow-all-tools", "--no-ask-user"}
+	args = append(args, effortArgs(a.ReasoningEffort)...)
 	if a.Model != "" {
 		args = append(args, "--model", a.Model)
 	}
@@ -93,8 +94,9 @@ func (copilotProvider) ClassifyError(sample providerpkg.ErrorSample) (providerpk
 // (and its `-p` flag) are omitted here — like buildClaudeCommand /
 // buildCodexCommand, this is a display-only string showing the flags, not a
 // runnable line.
-func buildCopilotCommand(model string) string {
+func buildCopilotCommand(model, effort string) string {
 	parts := []string{"copilot", "--output-format", "json", "--allow-all-tools", "--no-ask-user"}
+	parts = append(parts, effortArgs(effort)...)
 	if model != "" {
 		parts = append(parts, "--model", model)
 	}

--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -349,6 +349,7 @@ func buildCodexConvoArgsWithProvider(a *Agent, cfg RunConfig, prompt string, pro
 // --session-id to resume the same conversation.
 func buildCopilotConvoArgs(a *Agent, prompt string) []string {
 	args := []string{"-p", prompt, "--output-format", "json", "--allow-all-tools", "--no-ask-user"}
+	args = append(args, effortArgs(a.ReasoningEffort)...)
 	if a.Model != "" {
 		args = append(args, "--model", a.Model)
 	}

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -99,9 +99,7 @@ func (m *Manager) convoCommonArgs(a *Agent, cfg RunConfig) []string {
 	if cfg.PermissionMode != "" {
 		args = append(args, "--permission-mode", cfg.PermissionMode)
 	}
-	if cfg.Effort != "" {
-		args = append(args, "--effort", cfg.Effort)
-	}
+	args = append(args, effortArgs(a.ReasoningEffort)...)
 	if len(cfg.AllowedTools) > 0 {
 		args = append(args, "--allowedTools", strings.Join(cfg.AllowedTools, ","))
 	} else if !cfg.RequirePermissions && cfg.PermissionMode == "" {

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -1000,6 +1000,48 @@ func TestBuildHeadlessInvocation_CodexReasoningEffort(t *testing.T) {
 	})
 }
 
+// TestBuildHeadlessInvocation_EffortFlag verifies claude and copilot headless
+// runs carry --effort <level> from the agent's ReasoningEffort (the same value
+// codex feeds to model_reasoning_effort), and omit it when unset.
+func TestBuildHeadlessInvocation_EffortFlag(t *testing.T) {
+	t.Parallel()
+
+	hasEffort := func(args []string, level string) bool {
+		for i := range len(args) - 1 {
+			if args[i] == "--effort" && args[i+1] == level {
+				return true
+			}
+		}
+		return false
+	}
+	hasEffortFlag := func(args []string) bool {
+		return slices.Contains(args, "--effort")
+	}
+
+	for _, provider := range []string{"claude", "copilot"} {
+		t.Run(provider+"_present_when_set", func(t *testing.T) {
+			a := &Agent{ID: "a", Provider: provider, ReasoningEffort: "medium"}
+			_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{Prompt: "hi"})
+			if err != nil {
+				t.Fatalf("buildHeadlessInvocation: %v", err)
+			}
+			if !hasEffort(args, "medium") {
+				t.Errorf("expected --effort medium in %s args; got %v", provider, args)
+			}
+		})
+		t.Run(provider+"_absent_when_empty", func(t *testing.T) {
+			a := &Agent{ID: "a", Provider: provider, ReasoningEffort: ""}
+			_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{Prompt: "hi"})
+			if err != nil {
+				t.Fatalf("buildHeadlessInvocation: %v", err)
+			}
+			if hasEffortFlag(args) {
+				t.Errorf("--effort must be absent when empty; got %v", args)
+			}
+		})
+	}
+}
+
 // TestBuildHeadlessInvocation_CodexAlwaysBypassesSandbox verifies that headless
 // codex invocations always use --dangerously-bypass-approvals-and-sandbox,
 // even when RequirePermissions=true. In headless mode there is no UI to serve

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -137,13 +137,15 @@ func ValidateAgentMode(s string) (string, error) {
 	return s, nil
 }
 
-// AllReasoningEfforts returns every valid codex reasoning effort level.
+// AllReasoningEfforts returns every valid reasoning effort level. This is the
+// common subset accepted by all providers (codex model_reasoning_effort and the
+// claude/copilot --effort flag).
 func AllReasoningEfforts() []string { return []string{"low", "medium", "high", "xhigh"} }
 
 var validReasoningEfforts = map[string]bool{"low": true, "medium": true, "high": true, "xhigh": true}
 
 // ValidateReasoningEffort accepts the empty string (model default) or one of the
-// codex-advertised levels. Static allowlist — offline-safe, no codex probe.
+// supported levels. Static allowlist — offline-safe, no provider probe.
 func ValidateReasoningEffort(s string) (string, error) {
 	if s == "" {
 		return "", nil
@@ -309,10 +311,10 @@ type Task struct {
 	// agent, allowing a single prompt to spawn parallel subagent runs. Trades
 	// higher token cost for reduced wall-clock time on multi-part prompts.
 	ForkSubagent bool `json:"forkSubagent,omitempty"`
-	// ReasoningEffort sets the Codex model reasoning level for this task's agents
-	// via -c model_reasoning_effort=<v>. Empty = model default. Codex-only;
-	// ignored for claude agents. Distinct from the claude-only extended-thinking
-	// knob — different CLI surface and vocabulary (xhigh vs max).
+	// ReasoningEffort sets the reasoning level for this task's agents
+	// (low/medium/high/xhigh). Empty = model default. Applied across providers:
+	// codex via -c model_reasoning_effort=<v>, claude and copilot via --effort.
+	// The value set is the common subset all three CLIs accept.
 	ReasoningEffort string `json:"reasoningEffort,omitempty"`
 	// TestingCycleStartedAt marks the start of the current testing cycle. It is
 	// set when a human re-dispatches the task after a human-required escalation,


### PR DESCRIPTION
## Motivation

Reasoning effort was only honored for Codex agents (`-c model_reasoning_effort=`).
The Claude `--effort` plumbing existed as a `RunConfig.Effort` field but nothing
ever set it, and Copilot had no effort wiring at all — so Claude and Copilot
agents always ran at model-default effort regardless of the task's
`reasoning_effort`.

## Implementation information

- Drive the single task-level `reasoning_effort` value (also settable per-step
  via A/B variants) through **every** provider:
  - codex: `-c model_reasoning_effort=<level>` (unchanged)
  - claude / copilot: `--effort <level>` (new), via a shared `effortArgs` helper
- Applied on both headless and conversational paths, plus the display-command
  builders.
- Folded the redundant, never-set claude-only `RunConfig.Effort` field into the
  existing `ReasoningEffort`; `runner_convo` now reads the same value.
- Value set unchanged: `low|medium|high|xhigh` — the common subset all three CLIs
  accept (`low`/`medium` are valid everywhere). `copilot --help` advertises
  `none|low|medium|high|xhigh|max`; `claude --help` `low|medium|high|xhigh|max`.
- Doc/help comments updated to drop the "codex-only" framing.

Set it with `sybra-cli update <id> --reasoning-effort low|medium` (or on create);
it now applies to whichever provider runs the task.

> Changelog: feat(agent): apply reasoning effort to all providers

## Supporting documentation

New `TestBuildHeadlessInvocation_EffortFlag` covers claude+copilot `--effort`
presence/absence; existing codex effort tests unchanged. `go test ./...`,
`golangci-lint run`, `oxlint` green.
