### PR TITLE
refactor(sybra): extract app field clusters

### DIFF
--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -32,7 +32,6 @@ import (
 	"github.com/Automaat/sybra/internal/loopagent"
 	"github.com/Automaat/sybra/internal/monitor"
 	"github.com/Automaat/sybra/internal/notification"
-	"github.com/Automaat/sybra/internal/poll"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/recovery"
@@ -47,53 +46,51 @@ import (
 )
 
 type App struct {
-	ctx                           context.Context
-	cancel                        context.CancelFunc
-	wg                            sync.WaitGroup
-	tasks                         *task.Manager
-	projects                      *project.Store
-	loopAgents                    *loopagent.Store
-	loopSched                     *loopagent.Scheduler
-	agents                        *agent.Manager
-	watcher                       *watcher.Watcher
-	configWatcher                 *confighot.Watcher
-	notifier                      *notification.Emitter
-	audit                         *audit.Logger
-	artifacts                     *artifact.Store
-	experience                    *experience.Store
-	stats                         *stats.Store
-	limits                        *limits.Store
-	tasksDir                      string
-	skillsDir                     string
-	repoDir                       string
-	worktreesDir                  string
-	logger                        *slog.Logger
-	logDir                        string
-	auditDir                      string
-	prTracker                     *github.IssueTracker
-	providerHealth                *provider.Checker
-	worktrees                     *worktree.Manager
-	sandboxes                     *sandbox.Manager
-	monitorSvc                    *monitor.Service
-	selfMonitorSvc                *selfmonitor.Service
-	evaluationSvc                 *evaluation.Service
-	agentOrch                     *AgentOrchestrator
-	reviewer                      *ReviewHandler
-	workflowEngine                *workflow.Engine
-	workflowStore                 *workflow.Store
-	todoistHandler                *poll.TodoistHandler
-	todoistCancel                 context.CancelFunc
-	renovateHandler               *poll.RenovateHandler
-	renovateMonitorTransientFails int
-	triageHandler                 *poll.TriageHandler
-	humanReview                   *humanReviewHandler
-	cfg                           *config.Config
-	logLevel                      *slog.LevelVar
-	emit                          func(string, any)
-	emitFactory                   func(context.Context) func(string, any)
-	openBrowser                   func(string)
-	requestRestart                func()
-	restartStaleErr               *logging.ErrorThrottle
+	ctx             context.Context
+	cancel          context.CancelFunc
+	wg              sync.WaitGroup
+	tasks           *task.Manager
+	projects        *project.Store
+	loopAgents      *loopagent.Store
+	loopSched       *loopagent.Scheduler
+	agents          *agent.Manager
+	watcher         *watcher.Watcher
+	configWatcher   *confighot.Watcher
+	notifier        *notification.Emitter
+	audit           *audit.Logger
+	artifacts       *artifact.Store
+	experience      *experience.Store
+	stats           *stats.Store
+	limits          *limits.Store
+	tasksDir        string
+	skillsDir       string
+	repoDir         string
+	worktreesDir    string
+	logger          *slog.Logger
+	logDir          string
+	auditDir        string
+	prTracker       *github.IssueTracker
+	providerHealth  *provider.Checker
+	worktrees       *worktree.Manager
+	sandboxes       *sandbox.Manager
+	monitorSvc      *monitor.Service
+	selfMonitorSvc  *selfmonitor.Service
+	evaluationSvc   *evaluation.Service
+	agentOrch       *AgentOrchestrator
+	reviewer        *ReviewHandler
+	workflowEngine  *workflow.Engine
+	workflowStore   *workflow.Store
+	todoist         *todoistCoordinator
+	renovate        *renovateCoordinator
+	triage          *triageCoordinator
+	humanReview     *humanReviewHandler
+	cfg             *config.Config
+	logLevel        *slog.LevelVar
+	emit            func(string, any)
+	emitFactory     func(context.Context) func(string, any)
+	openBrowser     func(string)
+	requestRestart  func()
+	restartStaleErr *logging.ErrorThrottle
 	// dispatchNudge wakes the orchestrator dispatch pass on demand (e.g. on a
 	// status change) so a freshly-ready task isn't left idle until the next
 	// fast tick. Buffered, size 1, coalescing — see nudgeDispatch.

--- a/internal/sybra/app_renovate.go
+++ b/internal/sybra/app_renovate.go
@@ -2,6 +2,7 @@ package sybra
 
 import (
 	"log/slog"
+	"sync"
 
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/github"
@@ -9,7 +10,10 @@ import (
 	"github.com/Automaat/sybra/internal/project"
 )
 
+// renovateCoordinator owns the Renovate poll handler. Its handler lifetime is
+// managed by the shared poll hub, so it has no stop/reload path.
 type renovateCoordinator struct {
+	mu                    sync.Mutex
 	projects              *project.Store
 	logger                *slog.Logger
 	emit                  func(string, any)
@@ -39,6 +43,7 @@ func (c *renovateCoordinator) init() {
 	if !c.cfg.Renovate.Enabled {
 		return
 	}
+	c.monitorTransientFails = 0
 	c.handler = poll.NewRenovateHandler(c.projects, c.logger, c.emit, &c.cfg.Renovate, c.allowsProjectType)
 	c.handler.SetIntervals(c.cfg.GitHub.RenovateFast(), c.cfg.GitHub.RenovateSlow())
 	c.logger.Info("renovate.enabled", "author", c.cfg.Renovate.Author)
@@ -65,6 +70,46 @@ func (c *renovateCoordinator) lastFetchedCount() func() int64 {
 	return c.handler.LastFetchedCount
 }
 
+func (c *renovateCoordinator) prsForMonitor() []github.PullRequest {
+	repos := c.repos()
+	if len(repos) == 0 {
+		return nil
+	}
+	rps, err := github.FetchRenovatePRs(c.cfg.Renovate.Author, repos)
+	if err != nil {
+		c.recordMonitorFetchError(err)
+		return nil
+	}
+	c.resetMonitorFetchErrors()
+	prs := make([]github.PullRequest, len(rps))
+	for i := range rps {
+		prs[i] = rps[i].PullRequest
+	}
+	return prs
+}
+
+func (c *renovateCoordinator) recordMonitorFetchError(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if github.IsTransientError(err) {
+		c.monitorTransientFails++
+		if c.monitorTransientFails < transientFetchWarnThreshold {
+			c.logger.Info("pr-monitor.renovate-fetch", "err", err)
+		} else {
+			c.logger.Warn("pr-monitor.renovate-fetch", "err", err, "consecutive", c.monitorTransientFails)
+		}
+		return
+	}
+	c.monitorTransientFails = 0
+	c.logger.Warn("pr-monitor.renovate-fetch", "err", err)
+}
+
+func (c *renovateCoordinator) resetMonitorFetchErrors() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.monitorTransientFails = 0
+}
+
 func (a *App) initRenovate(emit func(string, any)) {
 	a.renovate = newRenovateCoordinator(a.projects, a.logger, emit, a.cfg, a.allowsProjectType)
 	a.renovate.init()
@@ -76,29 +121,5 @@ func (a *App) initRenovate(emit func(string, any)) {
 // never gets re-dispatched to pr-fix when CI keeps failing. Returns nil when
 // renovate is disabled or no projects are registered for this machine.
 func (a *App) renovatePRsForMonitor() []github.PullRequest {
-	repos := a.renovate.repos()
-	if len(repos) == 0 {
-		return nil
-	}
-	rps, err := github.FetchRenovatePRs(a.cfg.Renovate.Author, repos)
-	if err != nil {
-		if github.IsTransientError(err) {
-			a.renovate.monitorTransientFails++
-			if a.renovate.monitorTransientFails < transientFetchWarnThreshold {
-				a.logger.Info("pr-monitor.renovate-fetch", "err", err)
-			} else {
-				a.logger.Warn("pr-monitor.renovate-fetch", "err", err, "consecutive", a.renovate.monitorTransientFails)
-			}
-		} else {
-			a.renovate.monitorTransientFails = 0
-			a.logger.Warn("pr-monitor.renovate-fetch", "err", err)
-		}
-		return nil
-	}
-	a.renovate.monitorTransientFails = 0
-	prs := make([]github.PullRequest, len(rps))
-	for i := range rps {
-		prs[i] = rps[i].PullRequest
-	}
-	return prs
+	return a.renovate.prsForMonitor()
 }

--- a/internal/sybra/app_renovate.go
+++ b/internal/sybra/app_renovate.go
@@ -1,17 +1,73 @@
 package sybra
 
 import (
+	"log/slog"
+
+	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/poll"
+	"github.com/Automaat/sybra/internal/project"
 )
 
-func (a *App) initRenovate(emit func(string, any)) {
-	if !a.cfg.Renovate.Enabled {
+type renovateCoordinator struct {
+	projects              *project.Store
+	logger                *slog.Logger
+	emit                  func(string, any)
+	cfg                   *config.Config
+	allowsProjectType     func(project.ProjectType) bool
+	handler               *poll.RenovateHandler
+	monitorTransientFails int
+}
+
+func newRenovateCoordinator(
+	projects *project.Store,
+	logger *slog.Logger,
+	emit func(string, any),
+	cfg *config.Config,
+	allowsProjectType func(project.ProjectType) bool,
+) *renovateCoordinator {
+	return &renovateCoordinator{
+		projects:          projects,
+		logger:            logger,
+		emit:              emit,
+		cfg:               cfg,
+		allowsProjectType: allowsProjectType,
+	}
+}
+
+func (c *renovateCoordinator) init() {
+	if !c.cfg.Renovate.Enabled {
 		return
 	}
-	a.renovateHandler = poll.NewRenovateHandler(a.projects, a.logger, emit, &a.cfg.Renovate, a.allowsProjectType)
-	a.renovateHandler.SetIntervals(a.cfg.GitHub.RenovateFast(), a.cfg.GitHub.RenovateSlow())
-	a.logger.Info("renovate.enabled", "author", a.cfg.Renovate.Author)
+	c.handler = poll.NewRenovateHandler(c.projects, c.logger, c.emit, &c.cfg.Renovate, c.allowsProjectType)
+	c.handler.SetIntervals(c.cfg.GitHub.RenovateFast(), c.cfg.GitHub.RenovateSlow())
+	c.logger.Info("renovate.enabled", "author", c.cfg.Renovate.Author)
+}
+
+func (c *renovateCoordinator) poller() *poll.RenovateHandler {
+	if c == nil {
+		return nil
+	}
+	return c.handler
+}
+
+func (c *renovateCoordinator) repos() []string {
+	if c == nil || c.handler == nil {
+		return nil
+	}
+	return c.handler.Repos()
+}
+
+func (c *renovateCoordinator) lastFetchedCount() func() int64 {
+	if c == nil || c.handler == nil {
+		return nil
+	}
+	return c.handler.LastFetchedCount
+}
+
+func (a *App) initRenovate(emit func(string, any)) {
+	a.renovate = newRenovateCoordinator(a.projects, a.logger, emit, a.cfg, a.allowsProjectType)
+	a.renovate.init()
 }
 
 // renovatePRsForMonitor returns Renovate-bot PRs flattened to PullRequest for
@@ -20,29 +76,26 @@ func (a *App) initRenovate(emit func(string, any)) {
 // never gets re-dispatched to pr-fix when CI keeps failing. Returns nil when
 // renovate is disabled or no projects are registered for this machine.
 func (a *App) renovatePRsForMonitor() []github.PullRequest {
-	if a.renovateHandler == nil {
-		return nil
-	}
-	repos := a.renovateHandler.Repos()
+	repos := a.renovate.repos()
 	if len(repos) == 0 {
 		return nil
 	}
 	rps, err := github.FetchRenovatePRs(a.cfg.Renovate.Author, repos)
 	if err != nil {
 		if github.IsTransientError(err) {
-			a.renovateMonitorTransientFails++
-			if a.renovateMonitorTransientFails < transientFetchWarnThreshold {
+			a.renovate.monitorTransientFails++
+			if a.renovate.monitorTransientFails < transientFetchWarnThreshold {
 				a.logger.Info("pr-monitor.renovate-fetch", "err", err)
 			} else {
-				a.logger.Warn("pr-monitor.renovate-fetch", "err", err, "consecutive", a.renovateMonitorTransientFails)
+				a.logger.Warn("pr-monitor.renovate-fetch", "err", err, "consecutive", a.renovate.monitorTransientFails)
 			}
 		} else {
-			a.renovateMonitorTransientFails = 0
+			a.renovate.monitorTransientFails = 0
 			a.logger.Warn("pr-monitor.renovate-fetch", "err", err)
 		}
 		return nil
 	}
-	a.renovateMonitorTransientFails = 0
+	a.renovate.monitorTransientFails = 0
 	prs := make([]github.PullRequest, len(rps))
 	for i := range rps {
 		prs[i] = rps[i].PullRequest

--- a/internal/sybra/app_todoist.go
+++ b/internal/sybra/app_todoist.go
@@ -2,7 +2,9 @@ package sybra
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/Automaat/sybra/internal/audit"
@@ -11,6 +13,38 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/todoist"
 )
+
+type todoistCoordinator struct {
+	tasks    *task.Manager
+	svc      *TaskService
+	auditLog *audit.Logger
+	logger   *slog.Logger
+	emit     func(string, any)
+	cfg      *config.Config
+	wg       *sync.WaitGroup
+	handler  *poll.TodoistHandler
+	cancel   context.CancelFunc
+}
+
+func newTodoistCoordinator(
+	tasks *task.Manager,
+	svc *TaskService,
+	auditLog *audit.Logger,
+	logger *slog.Logger,
+	emit func(string, any),
+	cfg *config.Config,
+	wg *sync.WaitGroup,
+) *todoistCoordinator {
+	return &todoistCoordinator{
+		tasks:    tasks,
+		svc:      svc,
+		auditLog: auditLog,
+		logger:   logger,
+		emit:     emit,
+		cfg:      cfg,
+		wg:       wg,
+	}
+}
 
 // newTodoistHandler constructs a poll.TodoistHandler using a TaskService.
 func newTodoistHandler(
@@ -25,38 +59,68 @@ func newTodoistHandler(
 	return poll.NewTodoistHandler(tasks, svc.CreateTask, client, al, logger, emit, cfg)
 }
 
-func (a *App) initTodoist(emit func(string, any)) {
-	if !a.cfg.Todoist.Enabled || a.cfg.Todoist.APIToken == "" {
+func (c *todoistCoordinator) init() {
+	if !c.cfg.Todoist.Enabled || c.cfg.Todoist.APIToken == "" {
 		return
 	}
-	tc := todoist.NewClient(a.cfg.Todoist.APIToken)
-	a.todoistHandler = poll.NewTodoistHandler(a.tasks, a.taskSvc.CreateTask, tc, a.audit, a.logger, emit, a.cfg.Todoist)
-	a.logger.Info("todoist.enabled", "project_id", a.cfg.Todoist.ProjectID)
+	tc := todoist.NewClient(c.cfg.Todoist.APIToken)
+	c.handler = poll.NewTodoistHandler(c.tasks, c.svc.CreateTask, tc, c.auditLog, c.logger, c.emit, c.cfg.Todoist)
+	c.logger.Info("todoist.enabled", "project_id", c.cfg.Todoist.ProjectID)
+}
+
+func (c *todoistCoordinator) start(parent context.Context) {
+	if c.handler == nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(parent)
+	c.cancel = cancel
+	p := poll.New(c.handler, 15*time.Second, c.logger)
+	c.wg.Go(func() { p.Run(ctx) })
+}
+
+func (c *todoistCoordinator) stop() {
+	if c.cancel != nil {
+		c.cancel()
+		c.cancel = nil
+	}
+	c.handler = nil
+}
+
+func (c *todoistCoordinator) reload(parent context.Context) {
+	c.stop()
+	c.init()
+	c.start(parent)
+}
+
+func (c *todoistCoordinator) enabled() bool {
+	return c != nil && c.handler != nil
+}
+
+func (c *todoistCoordinator) syncNow() error {
+	if !c.enabled() {
+		return fmt.Errorf("todoist integration not enabled")
+	}
+	c.handler.PollAndSync()
+	return nil
+}
+
+func (a *App) initTodoist(emit func(string, any)) {
+	a.todoist = newTodoistCoordinator(a.tasks, a.taskSvc, a.audit, a.logger, emit, a.cfg, &a.wg)
+	a.todoist.init()
 }
 
 // startTodoistLoop launches the poll goroutine if the handler is initialized.
 func (a *App) startTodoistLoop(parent context.Context) {
-	if a.todoistHandler == nil {
+	if a.todoist == nil {
 		return
 	}
-	ctx, cancel := context.WithCancel(parent)
-	a.todoistCancel = cancel
-	p := poll.New(a.todoistHandler, 15*time.Second, a.logger)
-	a.wg.Go(func() { p.Run(ctx) })
-}
-
-// stopTodoistLoop cancels the running poll goroutine if any.
-func (a *App) stopTodoistLoop() {
-	if a.todoistCancel != nil {
-		a.todoistCancel()
-		a.todoistCancel = nil
-	}
-	a.todoistHandler = nil
+	a.todoist.start(parent)
 }
 
 // reloadTodoist tears down and (if enabled) re-creates the Todoist handler + poll loop.
 func (a *App) reloadTodoist() {
-	a.stopTodoistLoop()
-	a.initTodoist(a.emit)
-	a.startTodoistLoop(a.ctx)
+	if a.todoist == nil {
+		a.initTodoist(a.emit)
+	}
+	a.todoist.reload(a.ctx)
 }

--- a/internal/sybra/app_todoist.go
+++ b/internal/sybra/app_todoist.go
@@ -15,6 +15,7 @@ import (
 )
 
 type todoistCoordinator struct {
+	mu       sync.Mutex
 	tasks    *task.Manager
 	svc      *TaskService
 	auditLog *audit.Logger
@@ -46,20 +47,16 @@ func newTodoistCoordinator(
 	}
 }
 
-// newTodoistHandler constructs a poll.TodoistHandler using a TaskService.
-func newTodoistHandler(
-	tasks *task.Manager,
-	svc *TaskService,
-	client *todoist.Client,
-	al *audit.Logger,
-	logger *slog.Logger,
-	emit func(string, any),
-	cfg config.TodoistConfig,
-) *poll.TodoistHandler {
-	return poll.NewTodoistHandler(tasks, svc.CreateTask, client, al, logger, emit, cfg)
+func (c *todoistCoordinator) init() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.initLocked()
 }
 
-func (c *todoistCoordinator) init() {
+func (c *todoistCoordinator) initLocked() {
 	if !c.cfg.Todoist.Enabled || c.cfg.Todoist.APIToken == "" {
 		return
 	}
@@ -69,6 +66,15 @@ func (c *todoistCoordinator) init() {
 }
 
 func (c *todoistCoordinator) start(parent context.Context) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.startLocked(parent)
+}
+
+func (c *todoistCoordinator) startLocked(parent context.Context) {
 	if c.handler == nil {
 		return
 	}
@@ -78,7 +84,7 @@ func (c *todoistCoordinator) start(parent context.Context) {
 	c.wg.Go(func() { p.Run(ctx) })
 }
 
-func (c *todoistCoordinator) stop() {
+func (c *todoistCoordinator) stopLocked() {
 	if c.cancel != nil {
 		c.cancel()
 		c.cancel = nil
@@ -87,17 +93,32 @@ func (c *todoistCoordinator) stop() {
 }
 
 func (c *todoistCoordinator) reload(parent context.Context) {
-	c.stop()
-	c.init()
-	c.start(parent)
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.stopLocked()
+	c.initLocked()
+	c.startLocked(parent)
 }
 
 func (c *todoistCoordinator) enabled() bool {
-	return c != nil && c.handler != nil
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.handler != nil
 }
 
 func (c *todoistCoordinator) syncNow() error {
-	if !c.enabled() {
+	if c == nil {
+		return fmt.Errorf("todoist integration not enabled")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.handler == nil {
 		return fmt.Errorf("todoist integration not enabled")
 	}
 	c.handler.PollAndSync()

--- a/internal/sybra/app_todoist_test.go
+++ b/internal/sybra/app_todoist_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/poll"
 	"github.com/Automaat/sybra/internal/todoist"
 )
 
@@ -52,9 +53,9 @@ func TestTodoistImport_SetsDefaultProjectID(t *testing.T) {
 	}
 	client := todoist.NewClientWith(cfg.APIToken, http.DefaultClient, srv.URL)
 
-	h := newTodoistHandler(
+	h := poll.NewTodoistHandler(
 		a.tasks,
-		taskSvc,
+		taskSvc.CreateTask,
 		client,
 		nil,
 		a.logger,
@@ -110,9 +111,9 @@ func TestTodoistImport_EmptyDefaultProjectIDLeavesUnset(t *testing.T) {
 	}
 	client := todoist.NewClientWith(cfg.APIToken, http.DefaultClient, srv.URL)
 
-	h := newTodoistHandler(
+	h := poll.NewTodoistHandler(
 		a.tasks,
-		taskSvc,
+		taskSvc.CreateTask,
 		client,
 		nil,
 		a.logger,

--- a/internal/sybra/app_triage.go
+++ b/internal/sybra/app_triage.go
@@ -11,6 +11,8 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 )
 
+// triageCoordinator owns the auto-triage poll handler. Its handler lifetime is
+// managed by the shared poll hub, so runtime config changes take effect on restart.
 type triageCoordinator struct {
 	tasks          *task.Manager
 	projects       *project.Store

--- a/internal/sybra/app_triage.go
+++ b/internal/sybra/app_triage.go
@@ -1,15 +1,64 @@
 package sybra
 
-import "github.com/Automaat/sybra/internal/poll"
+import (
+	"log/slog"
+
+	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/poll"
+	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/provider"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+type triageCoordinator struct {
+	tasks          *task.Manager
+	projects       *project.Store
+	auditLog       *audit.Logger
+	logger         *slog.Logger
+	cfg            *config.Config
+	providerHealth *provider.Checker
+	handler        *poll.TriageHandler
+}
+
+func newTriageCoordinator(
+	tasks *task.Manager,
+	projects *project.Store,
+	auditLog *audit.Logger,
+	logger *slog.Logger,
+	cfg *config.Config,
+	providerHealth *provider.Checker,
+) *triageCoordinator {
+	return &triageCoordinator{
+		tasks:          tasks,
+		projects:       projects,
+		auditLog:       auditLog,
+		logger:         logger,
+		cfg:            cfg,
+		providerHealth: providerHealth,
+	}
+}
+
+func (c *triageCoordinator) init() {
+	if !c.cfg.Triage.Enabled {
+		return
+	}
+	c.handler = poll.NewTriageHandler(c.tasks, c.projects, c.auditLog, c.logger, &c.cfg.Triage)
+	c.handler.SetProviderGate(c.providerHealth)
+	c.logger.Info("triage.enabled", "poll_seconds", c.cfg.Triage.PollSeconds, "model", c.cfg.Triage.Model)
+}
+
+func (c *triageCoordinator) poller() *poll.TriageHandler {
+	if c == nil {
+		return nil
+	}
+	return c.handler
+}
 
 // initTriage constructs the background auto-triage handler if enabled.
 // The handler is registered with the poll hub in startPollHub alongside
 // renovate and the issues fetcher.
 func (a *App) initTriage() {
-	if !a.cfg.Triage.Enabled {
-		return
-	}
-	a.triageHandler = poll.NewTriageHandler(a.tasks, a.projects, a.audit, a.logger, &a.cfg.Triage)
-	a.triageHandler.SetProviderGate(a.providerHealth)
-	a.logger.Info("triage.enabled", "poll_seconds", a.cfg.Triage.PollSeconds, "model", a.cfg.Triage.Model)
+	a.triage = newTriageCoordinator(a.tasks, a.projects, a.audit, a.logger, a.cfg, a.providerHealth)
+	a.triage.init()
 }

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -252,8 +252,8 @@ func (lm *LifecycleManager) registerMetricsObservers() {
 		}
 		return out
 	})
-	if a.renovateHandler != nil {
-		metrics.RegisterRenovatePRsFetched(a.renovateHandler.LastFetchedCount)
+	if fn := a.renovate.lastFetchedCount(); fn != nil {
+		metrics.RegisterRenovatePRsFetched(fn)
 	}
 	if a.providerHealth != nil {
 		metrics.RegisterProviderHealth(func() map[string]int64 {
@@ -431,12 +431,12 @@ func (lm *LifecycleManager) startPollHub(ctx context.Context, issuesFetcher *pol
 		if issuesFetcher != nil {
 			hub.Register(issuesFetcher, 20*time.Second)
 		}
-		if a.renovateHandler != nil {
-			hub.Register(a.renovateHandler, 15*time.Second)
+		if renovatePoller := a.renovate.poller(); renovatePoller != nil {
+			hub.Register(renovatePoller, 15*time.Second)
 		}
 	}
-	if a.triageHandler != nil {
-		hub.Register(a.triageHandler, 30*time.Second)
+	if triagePoller := a.triage.poller(); triagePoller != nil {
+		hub.Register(triagePoller, 30*time.Second)
 	}
 	hub.Start(ctx, &a.wg, a.logger)
 }

--- a/internal/sybra/services_wire_integrations.go
+++ b/internal/sybra/services_wire_integrations.go
@@ -8,8 +8,8 @@ func (a *App) wireIntegrationService() {
 	a.intgSvc.audit = a.audit
 	a.intgSvc.cfg = a.cfg
 	a.intgSvc.logger = a.logger
-	a.intgSvc.todoistHandler = a.todoistHandler
-	a.intgSvc.renovateHandler = a.renovateHandler
+	a.intgSvc.todoist = a.todoist
+	a.intgSvc.renovate = a.renovate
 	a.intgSvc.workflowEngine = a.workflowEngine
 	a.intgSvc.providerHealth = a.providerHealth
 	// Read a.cfg inside the closure so config reloads save the current config.

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -139,7 +139,7 @@ func (s *ConfigService) applyFromConfig(next config.Config) error {
 	s.cfg.Logging.MaxFiles = next.Logging.MaxFiles
 	s.cfg.Audit = next.Audit
 	s.cfg.Todoist = next.Todoist
-	// In-place field assignment: renovateHandler holds &s.cfg.Renovate
+	// In-place field assignment: the renovate coordinator holds &s.cfg.Renovate.
 	s.cfg.Renovate.Enabled = next.Renovate.Enabled
 	s.cfg.Renovate.Author = next.Renovate.Author
 	s.cfg.Providers = next.Providers

--- a/internal/sybra/svc_config_reload.go
+++ b/internal/sybra/svc_config_reload.go
@@ -29,8 +29,8 @@ func (s *ConfigService) ReloadFromDisk() (changedHot []string, err error) {
 
 	// Always update s.cfg to match disk — including restart-required fields —
 	// so subsequent reloads with the same content produce no diff and no
-	// repeated restart warnings. renovateHandler holds &s.cfg.Renovate, so
-	// assign its fields in-place rather than replacing the whole struct.
+	// repeated restart warnings. The renovate coordinator holds &s.cfg.Renovate,
+	// so assign its fields in-place rather than replacing the whole struct.
 	s.cfg.Agent = next.Agent
 	s.cfg.Notification = next.Notification
 	s.cfg.Orchestrator = next.Orchestrator

--- a/internal/sybra/svc_integrations.go
+++ b/internal/sybra/svc_integrations.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/github"
-	"github.com/Automaat/sybra/internal/poll"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/task"
@@ -22,27 +21,23 @@ import (
 // IntegrationService exposes Todoist, Renovate, and GitHub issue operations
 // as Wails-bound methods.
 type IntegrationService struct {
-	tasks           *task.Manager
-	projects        *project.Store
-	agents          *agent.Manager
-	worktrees       *worktree.Manager
-	audit           *audit.Logger
-	cfg             *config.Config
-	logger          *slog.Logger
-	todoistHandler  *poll.TodoistHandler
-	renovateHandler *poll.RenovateHandler
-	workflowEngine  *workflow.Engine
-	providerHealth  *provider.Checker
-	saveConfig      func() error
+	tasks          *task.Manager
+	projects       *project.Store
+	agents         *agent.Manager
+	worktrees      *worktree.Manager
+	audit          *audit.Logger
+	cfg            *config.Config
+	logger         *slog.Logger
+	todoist        *todoistCoordinator
+	renovate       *renovateCoordinator
+	workflowEngine *workflow.Engine
+	providerHealth *provider.Checker
+	saveConfig     func() error
 }
 
 // SyncTodoist triggers an immediate Todoist sync.
 func (s *IntegrationService) SyncTodoist() error {
-	if s.todoistHandler == nil {
-		return fmt.Errorf("todoist integration not enabled")
-	}
-	s.todoistHandler.PollAndSync()
-	return nil
+	return s.todoist.syncNow()
 }
 
 // GetTodoistProjects returns Todoist projects for the settings UI.
@@ -57,15 +52,12 @@ func (s *IntegrationService) GetTodoistProjects() ([]todoist.Project, error) {
 
 // TodoistEnabled returns whether the todoist handler is active.
 func (s *IntegrationService) TodoistEnabled() bool {
-	return s.todoistHandler != nil
+	return s.todoist.enabled()
 }
 
 // FetchRenovatePRs returns Renovate PRs for manual refresh.
 func (s *IntegrationService) FetchRenovatePRs() ([]github.RenovatePR, error) {
-	if s.renovateHandler == nil {
-		return nil, nil
-	}
-	repos := s.renovateHandler.Repos()
+	repos := s.renovate.repos()
 	if len(repos) == 0 {
 		return nil, nil
 	}


### PR DESCRIPTION
## Motivation

The Sybra app orchestration code had several tightly coupled field clusters spread across automation, integration, and lifecycle paths. Extracting those clusters makes the app structure easier to navigate and keeps related dependencies closer to the code that uses them.

Closes https://github.com/Automaat/sybra/issues/1272

## Implementation information

- Extracted poller and integration coordinator field groupings across the Sybra app wiring.
- Updated Todoist, Renovate, triage, lifecycle, config, and integration service call sites to use the extracted structures.
- Adjusted the affected Todoist test coverage for the new structure.