### PR TITLE
fix(agent): finalize hung headless run after result

### DIFF
--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -120,6 +120,12 @@ type Agent struct {
 	// workflow step to "failed".
 	stopped bool
 
+	// completedByResult is set when the post-result-hang guard stopped a
+	// headless process that emitted a terminal (non-error) result but never
+	// exited on its own. It tells the finalize path to derive completion
+	// status from the result event rather than the kill signal.
+	completedByResult bool
+
 	// detached is true when the agent's subprocess was spawned to survive
 	// an app restart (Setsid, output redirected to its log file, no ctx
 	// kill). ShutdownWithGrace leaves detached agents running instead of
@@ -690,6 +696,44 @@ func (a *Agent) lastConvoResult() (found, isError bool) {
 		}
 	}
 	return false, false
+}
+
+// CompletedSuccessfully reports whether the headless agent's stream buffer
+// ends in a non-error terminal result. The watchdog uses it to skip
+// inspecting (and never escalate) an agent that has already produced its
+// final result but whose process has not yet exited — a skill that spawns
+// subagents can leave CC alive after the terminal result.
+func (a *Agent) CompletedSuccessfully() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	found, isError := lastHeadlessResultEvent(a.outputBuffer)
+	return found && !isError
+}
+
+// TerminalResultIdle reports whether the headless stream's last event is a
+// non-error terminal result and no further output has arrived for at least
+// grace. It flags a process that finished its work (emitted the final result)
+// but did not exit, so the runner can stop it and finalize from the result.
+func (a *Agent) TerminalResultIdle(grace time.Duration) bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	found, isError := lastHeadlessResultEvent(a.outputBuffer)
+	if !found || isError {
+		return false
+	}
+	return time.Since(a.LastEventAt) >= grace
+}
+
+func (a *Agent) setCompletedByResult(v bool) {
+	a.mu.Lock()
+	a.completedByResult = v
+	a.mu.Unlock()
+}
+
+func (a *Agent) wasCompletedByResult() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.completedByResult
 }
 
 // GetLastEventAt returns the most recent event timestamp.

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -28,6 +28,19 @@ var errSurviveShutdown = errors.New("agent: detached, leaving process running fo
 // log file for new NDJSON lines.
 const headlessTailPoll = 100 * time.Millisecond
 
+// postResultGrace bounds how long the tailer waits for a headless process to
+// exit on its own after it has emitted a terminal (non-error) result event.
+// CC normally exits within a second or two; a skill that spawns subagents or
+// leaves a background task alive can hang the process indefinitely after the
+// final result (observed in task c4a0fda0, where a staff-code-review workflow
+// finished but the process never exited and the stall watchdog mis-escalated
+// the completed run to human-required). When the stream ends in a result and
+// stays idle past this window the run is logically complete, so the tailer
+// stops the orphaned process and finalizes from the result. Any further
+// output re-arms the clock, so a provider that legitimately emits multiple
+// result events is never cut off mid-work.
+const postResultGrace = 90 * time.Second
+
 // headlessEmitInterval caps per-agent stream event emission rate.
 // Result events always emit immediately (terminal signal). Frontend
 // subscribers may miss intermediate events but can recover via
@@ -318,6 +331,14 @@ func (m *Manager) runHeadlessAttemptSurvive(ctx context.Context, a *Agent, cfg R
 		return false, nil
 	}
 
+	// Post-result-hang finalize: the tailer stopped a process that had already
+	// emitted a terminal result, so the kill signal in waitErr is expected and
+	// not a failure. Completion status comes from the result event.
+	if a.wasCompletedByResult() {
+		m.finalizeFromResult(a, prevLen)
+		return false, nil
+	}
+
 	var stderrOut string
 	if b, readErr := os.ReadFile(stderrPath); readErr == nil {
 		stderrOut = string(b)
@@ -347,6 +368,23 @@ func (m *Manager) runHeadlessAttemptSurvive(ctx context.Context, a *Agent, cfg R
 		a.SetExitErr(errProviderRateLimited)
 	}
 	return false, nil
+}
+
+// finalizeFromResult sets the exit status of a run that the post-result-hang
+// guard stopped, deriving completion from the terminal result event rather
+// than the kill signal that appears in the process wait error.
+func (m *Manager) finalizeFromResult(a *Agent, prevLen int) {
+	evs := attemptEventsFrom(a, prevLen)
+	if streamErr := resultStreamError(evs); streamErr != nil {
+		a.SetExitErr(streamErr)
+		m.reportProviderHealthSignal(a, "", evs)
+		return
+	}
+	if m.reportCleanProviderHealthSignal(a, "", evs) == providerpkg.SignalRateLimit {
+		a.SetExitErr(errProviderRateLimited)
+		return
+	}
+	a.SetExitErr(nil)
 }
 
 func attemptEventsFrom(a *Agent, prevLen int) []StreamEvent {
@@ -472,6 +510,19 @@ func (m *Manager) tailHeadlessFile(ctx context.Context, a *Agent, path string, s
 
 		if drain() {
 			// Guardrail kill: force the child to stop, wait for it, finalize.
+			m.signalKill(a)
+			waitExit()
+			return true, end()
+		}
+
+		// Post-result hang: the process emitted its terminal result but has
+		// not exited. The run is logically complete — stop the orphan and
+		// finalize from the result so the workflow advances instead of the
+		// stall watchdog escalating a finished run to human-required.
+		if a.TerminalResultIdle(postResultGrace) {
+			m.logger.Warn("agent.headless.post_result_hang", "id", a.ID,
+				"idle_sec", int(time.Since(a.GetLastEventAt()).Seconds()))
+			a.setCompletedByResult(true)
 			m.signalKill(a)
 			waitExit()
 			return true, end()

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -283,6 +283,74 @@ func TestLastHeadlessResultMarksErrorSubtype(t *testing.T) {
 	}
 }
 
+func TestCompletedSuccessfully(t *testing.T) {
+	t.Run("success result", func(t *testing.T) {
+		a := &Agent{}
+		a.AppendOutput(StreamEvent{Type: "assistant", Content: "working"})
+		a.AppendOutput(StreamEvent{Type: "result", Content: "done"})
+		if !a.CompletedSuccessfully() {
+			t.Fatal("CompletedSuccessfully = false on clean terminal result, want true")
+		}
+	})
+	t.Run("error result", func(t *testing.T) {
+		a := &Agent{}
+		a.AppendOutput(StreamEvent{Type: "result", Subtype: "error_during_execution"})
+		if a.CompletedSuccessfully() {
+			t.Fatal("CompletedSuccessfully = true on error result, want false")
+		}
+	})
+	t.Run("not terminated on result", func(t *testing.T) {
+		a := &Agent{}
+		a.AppendOutput(StreamEvent{Type: "result", Content: "done"})
+		a.AppendOutput(StreamEvent{Type: "assistant", Content: "still going"})
+		if a.CompletedSuccessfully() {
+			t.Fatal("CompletedSuccessfully = true when result is not the last event, want false")
+		}
+	})
+}
+
+func TestTerminalResultIdle(t *testing.T) {
+	t.Run("idle past grace after clean result", func(t *testing.T) {
+		a := &Agent{}
+		a.AppendOutput(StreamEvent{Type: "result", Content: "done"})
+		a.mu.Lock()
+		a.LastEventAt = time.Now().Add(-2 * time.Minute)
+		a.mu.Unlock()
+		if !a.TerminalResultIdle(90 * time.Second) {
+			t.Fatal("TerminalResultIdle = false on result idle past grace, want true")
+		}
+	})
+	t.Run("within grace", func(t *testing.T) {
+		a := &Agent{}
+		a.AppendOutput(StreamEvent{Type: "result", Content: "done"})
+		a.TouchLastEvent()
+		if a.TerminalResultIdle(90 * time.Second) {
+			t.Fatal("TerminalResultIdle = true within grace, want false")
+		}
+	})
+	t.Run("error result never idles out", func(t *testing.T) {
+		a := &Agent{}
+		a.AppendOutput(StreamEvent{Type: "result", Subtype: "error_during_execution"})
+		a.mu.Lock()
+		a.LastEventAt = time.Now().Add(-2 * time.Minute)
+		a.mu.Unlock()
+		if a.TerminalResultIdle(90 * time.Second) {
+			t.Fatal("TerminalResultIdle = true on error result, want false")
+		}
+	})
+	t.Run("non-result last event", func(t *testing.T) {
+		a := &Agent{}
+		a.AppendOutput(StreamEvent{Type: "result", Content: "done"})
+		a.AppendOutput(StreamEvent{Type: "assistant", Content: "long bash running"})
+		a.mu.Lock()
+		a.LastEventAt = time.Now().Add(-2 * time.Minute)
+		a.mu.Unlock()
+		if a.TerminalResultIdle(90 * time.Second) {
+			t.Fatal("TerminalResultIdle = true when last event is not a result, want false")
+		}
+	})
+}
+
 func TestLastHeadlessResultIgnoresPriorRetryResult(t *testing.T) {
 	a := &Agent{}
 	a.AppendOutput(StreamEvent{Type: "result", Content: "overloaded", ErrorType: "overloaded_error", ErrorStatus: 529})

--- a/internal/watchdog/agent.go
+++ b/internal/watchdog/agent.go
@@ -137,6 +137,15 @@ func (w *Watchdog) tick(ctx context.Context, s *state, now time.Time) {
 		if ag.GetState() != agent.StateRunning || ag.Mode != "headless" || ag.External {
 			continue
 		}
+		// A headless agent whose stream already ended in a successful terminal
+		// result is logically complete; its process just has not exited yet (a
+		// skill that spawns subagents can leave CC alive after the final
+		// result). The runner's post-result guard finalizes it shortly. Never
+		// inspect or escalate such an agent — doing so flips a finished run to
+		// human-required on a false stall (task c4a0fda0).
+		if ag.CompletedSuccessfully() {
+			continue
+		}
 		logPath := ag.GetLogPath()
 		if logPath == "" {
 			continue


### PR DESCRIPTION
## Motivation

Task \`c4a0fda0\` (a successful code review) ended in \`human-required\`. Root cause: a headless \`claude -p\` process can emit its terminal \`result\` event yet **not exit** — a skill (here staff-code-review) spawns subagents/a Workflow that leave CC's event loop alive after the final result.

Sybra's detached tailer (\`tailHeadlessFile\`) only finalizes on process exit, so the agent stayed \`StateRunning\` indefinitely. ~16 min later the stall watchdog inspected it; the cheap LLM judge first correctly returned \`continue\`, then **flip-flopped to \`stop\`**, escalating the finished, successful review to \`human-required\`.

> Changelog: fix(agent): finalize hung headless run after result

## Implementation information

Two-layer fix:

1. **Runner (root cause)** — \`internal/agent/runner_headless.go\`: once a headless stream ends in a non-error terminal \`result\` and stays idle past a 90s \`postResultGrace\`, the tailer stops the orphaned process and finalizes from the result event (\`finalizeFromResult\`, gated by \`completedByResult\`) so the workflow advances. Any further output re-arms the clock, so a provider legitimately emitting multiple result events is never cut off mid-work.
2. **Watchdog (safety net)** — \`internal/watchdog/agent.go\`: \`tick\` now skips any headless agent whose stream already ended in a successful terminal result (\`Agent.CompletedSuccessfully()\`). Covers the legacy pipe path too and guarantees the LLM judge can never flip a finished run to \`human-required\`.

New \`Agent\` helpers \`CompletedSuccessfully\` / \`TerminalResultIdle\` in \`model.go\`, covered by table tests in \`runner_headless_test.go\`. Agent + watchdog tests pass; lint clean.

## Supporting documentation

Diagnosed from \`~/.sybra/logs/sybra.log\` (watchdog inspect/verdict trail) and the agent NDJSON stream logs.