### PR TITLE
feat(abtest): cheap/expensive model brackets

### DIFF
--- a/.sybra.yaml
+++ b/.sybra.yaml
@@ -9,6 +9,7 @@
 setup:
   - mise install
   - (cd frontend && npm ci)
+  - (cd frontend && npm run build:desktop)
 
 # Black-box testing guidance for the testing workflow. Test-runners must prefer
 # this runnable surface over static inspection: start the server, wait for

--- a/internal/abtest/model.go
+++ b/internal/abtest/model.go
@@ -11,7 +11,8 @@ type Config struct {
 type Experiment struct {
 	ID             string    `yaml:"id" json:"id"`
 	Enabled        *bool     `yaml:"enabled" json:"enabled"`
-	AssignmentUnit string    `yaml:"assignment_unit" json:"assignmentUnit"` // "task" or "stage"
+	AssignmentUnit string    `yaml:"assignment_unit" json:"assignmentUnit"`      // "task" or "stage"
+	Bracket        string    `yaml:"bracket,omitempty" json:"bracket,omitempty"` // "cheap" or "expensive"
 	Roles          []string  `yaml:"roles" json:"roles"`
 	Variants       []Variant `yaml:"variants" json:"variants"`
 }
@@ -22,6 +23,7 @@ type Variant struct {
 	Provider        string `yaml:"provider" json:"provider"`
 	Model           string `yaml:"model" json:"model"`
 	ReasoningEffort string `yaml:"reasoning_effort,omitempty" json:"reasoningEffort,omitempty"`
+	Tier            string `yaml:"tier,omitempty" json:"tier,omitempty"` // "cheap" or "expensive"
 	Weight          int    `yaml:"weight" json:"weight"`
 }
 
@@ -36,27 +38,40 @@ type Assignment struct {
 	AssignmentKey   string
 }
 
-// DefaultConfig returns the default A/B suite: Claude Code Opus, Codex GPT-5.5,
-// and Copilot across Opus, GPT-5.5, and the current best Gemini model.
+// DefaultConfig returns the default A/B suite split by price bracket: code
+// author roles use cheap variants, while planning and review use premium ones.
 func DefaultConfig() Config {
 	enabled := true
 	expEnabled := true
 	return Config{
 		Enabled:              &enabled,
 		MinSamplesPerVariant: 20,
-		Experiments: []Experiment{{
-			ID:             "code-author-models-v1",
-			Enabled:        &expEnabled,
-			AssignmentUnit: "stage",
-			Roles:          []string{"implementation", "fix-review", "pr-fix"},
-			Variants: []Variant{
-				{ID: "claude-opus", Provider: "claude", Model: "opus", Weight: 1},
-				{ID: "codex-gpt-5.5", Provider: "codex", Model: "gpt-5.5", Weight: 1},
-				{ID: "copilot-opus", Provider: "copilot", Model: "claude-opus-4.6", Weight: 1},
-				{ID: "copilot-gpt-5.5", Provider: "copilot", Model: "gpt-5.5", Weight: 1},
-				{ID: "copilot-gemini-3.1-pro", Provider: "copilot", Model: "gemini-3.1-pro-preview", Weight: 1},
+		Experiments: []Experiment{
+			{
+				ID:             "code-author-cheap",
+				Enabled:        &expEnabled,
+				AssignmentUnit: "stage",
+				Bracket:        "cheap",
+				Roles:          []string{"implementation", "test-runner", "fix-review", "pr-fix"},
+				Variants: []Variant{
+					{ID: "claude-sonnet", Provider: "claude", Model: "sonnet", Tier: "cheap", Weight: 2},
+					{ID: "codex-gpt-5.4", Provider: "codex", Model: "gpt-5.4", Tier: "cheap", Weight: 2},
+					{ID: "copilot-sonnet", Provider: "copilot", Model: "claude-sonnet-4.6", Tier: "cheap", Weight: 1},
+				},
 			},
-		}},
+			{
+				ID:             "review-expensive",
+				Enabled:        &expEnabled,
+				AssignmentUnit: "stage",
+				Bracket:        "expensive",
+				Roles:          []string{"review", "plan"},
+				Variants: []Variant{
+					{ID: "claude-opus", Provider: "claude", Model: "opus", Tier: "expensive", Weight: 1},
+					{ID: "codex-gpt-5.5", Provider: "codex", Model: "gpt-5.5", Tier: "expensive", Weight: 1},
+					{ID: "copilot-gemini-3.1-pro", Provider: "copilot", Model: "gemini-3.1-pro-preview", Tier: "expensive", Weight: 1},
+				},
+			},
+		},
 	}
 }
 

--- a/internal/abtest/selector.go
+++ b/internal/abtest/selector.go
@@ -101,6 +101,12 @@ func roleMatches(roles []string, role string) bool {
 }
 
 func validateExperiment(exp Experiment) error {
+	bracket := strings.TrimSpace(exp.Bracket)
+	switch bracket {
+	case "", "cheap", "expensive":
+	default:
+		return fmt.Errorf("abtest: experiment %q has invalid bracket %q", exp.ID, exp.Bracket)
+	}
 	seen := map[string]bool{}
 	for i := range exp.Variants {
 		v := exp.Variants[i]
@@ -109,6 +115,9 @@ func validateExperiment(exp Experiment) error {
 		}
 		if err := validateVariant(exp.ID, v); err != nil {
 			return err
+		}
+		if bracket != "" && v.Tier != bracket {
+			return fmt.Errorf("abtest: experiment %q bracket %q but variant %q has tier %q", exp.ID, bracket, v.ID, v.Tier)
 		}
 		if seen[v.ID] {
 			return fmt.Errorf("abtest: experiment %q has duplicate variant id %q", exp.ID, v.ID)
@@ -129,6 +138,11 @@ func validateVariant(expID string, v Variant) error {
 	}
 	if strings.TrimSpace(v.Model) == "" {
 		return fmt.Errorf("abtest: variant %q must set model explicitly", v.ID)
+	}
+	switch v.Tier {
+	case "", "cheap", "expensive":
+	default:
+		return fmt.Errorf("abtest: variant %q has invalid tier %q", v.ID, v.Tier)
 	}
 	return nil
 }

--- a/internal/abtest/selector_test.go
+++ b/internal/abtest/selector_test.go
@@ -68,8 +68,52 @@ func TestSelectWeightedDistribution(t *testing.T) {
 
 func TestSelectSkipsNonMatchingRole(t *testing.T) {
 	cfg := DefaultConfig()
-	if _, ok, err := Select(cfg, "task-1", "review", "review"); err != nil || ok {
-		t.Fatalf("Select review ok=%v err=%v, want disabled", ok, err)
+	if _, ok, err := Select(cfg, "task-1", "deploy", "deploy"); err != nil || ok {
+		t.Fatalf("Select deploy ok=%v err=%v, want disabled", ok, err)
+	}
+}
+
+func TestDefaultConfigUsesCheapBracketForCodeAuthorRoles(t *testing.T) {
+	cfg := DefaultConfig()
+	for _, role := range []string{"implementation", "test-runner", "fix-review", "pr-fix"} {
+		t.Run(role, func(t *testing.T) {
+			for i := range 100 {
+				a, ok, err := Select(cfg, fmt.Sprintf("task-%d", i), role, "step")
+				if err != nil || !ok {
+					t.Fatalf("Select ok=%v err=%v", ok, err)
+				}
+				if a.ExperimentID != "code-author-cheap" {
+					t.Fatalf("ExperimentID = %q, want code-author-cheap", a.ExperimentID)
+				}
+				switch a.VariantID {
+				case "claude-sonnet", "codex-gpt-5.4", "copilot-sonnet":
+				default:
+					t.Fatalf("VariantID = %q, want cheap variant", a.VariantID)
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultConfigUsesExpensiveBracketForReviewRoles(t *testing.T) {
+	cfg := DefaultConfig()
+	for _, role := range []string{"review", "plan"} {
+		t.Run(role, func(t *testing.T) {
+			for i := range 100 {
+				a, ok, err := Select(cfg, fmt.Sprintf("task-%d", i), role, "step")
+				if err != nil || !ok {
+					t.Fatalf("Select ok=%v err=%v", ok, err)
+				}
+				if a.ExperimentID != "review-expensive" {
+					t.Fatalf("ExperimentID = %q, want review-expensive", a.ExperimentID)
+				}
+				switch a.VariantID {
+				case "claude-opus", "codex-gpt-5.5", "copilot-gemini-3.1-pro":
+				default:
+					t.Fatalf("VariantID = %q, want expensive variant", a.VariantID)
+				}
+			}
+		})
 	}
 }
 
@@ -86,6 +130,79 @@ func TestSelectValidatesAllPositiveWeightVariants(t *testing.T) {
 	}}}
 	if _, _, err := Select(cfg, "task-1", "implementation", "implement"); err == nil {
 		t.Fatal("Select should reject invalid positive-weight variant before hashing")
+	}
+}
+
+func TestSelectRejectsBracketTierMismatch(t *testing.T) {
+	enabled := true
+	cfg := Config{Enabled: &enabled, Experiments: []Experiment{{
+		ID:             "exp",
+		AssignmentUnit: "task",
+		Bracket:        "cheap",
+		Roles:          []string{"implementation"},
+		Variants: []Variant{
+			{ID: "sonnet", Provider: "claude", Model: "sonnet", Tier: "cheap", Weight: 1},
+			{ID: "opus", Provider: "claude", Model: "opus", Tier: "expensive", Weight: 1},
+		},
+	}}}
+	if _, _, err := Select(cfg, "task-1", "implementation", "implement"); err == nil {
+		t.Fatal("Select should reject expensive variant in cheap bracket")
+	}
+}
+
+func TestSelectAllowsUnbracketedMixedTiers(t *testing.T) {
+	enabled := true
+	cfg := Config{Enabled: &enabled, Experiments: []Experiment{{
+		ID:             "exp",
+		AssignmentUnit: "task",
+		Roles:          []string{"implementation"},
+		Variants: []Variant{
+			{ID: "sonnet", Provider: "claude", Model: "sonnet", Tier: "cheap", Weight: 1},
+			{ID: "opus", Provider: "claude", Model: "opus", Tier: "expensive", Weight: 1},
+		},
+	}}}
+	if _, ok, err := Select(cfg, "task-1", "implementation", "implement"); err != nil || !ok {
+		t.Fatalf("Select ok=%v err=%v, want unbracketed mixed tiers allowed", ok, err)
+	}
+}
+
+func TestSelectRejectsInvalidTierAndBracket(t *testing.T) {
+	tests := []struct {
+		name string
+		exp  Experiment
+	}{
+		{
+			name: "invalid tier",
+			exp: Experiment{
+				ID:             "exp",
+				AssignmentUnit: "task",
+				Roles:          []string{"implementation"},
+				Variants: []Variant{
+					{ID: "bad", Provider: "claude", Model: "sonnet", Tier: "budget", Weight: 1},
+				},
+			},
+		},
+		{
+			name: "invalid bracket",
+			exp: Experiment{
+				ID:             "exp",
+				AssignmentUnit: "task",
+				Bracket:        "budget",
+				Roles:          []string{"implementation"},
+				Variants: []Variant{
+					{ID: "sonnet", Provider: "claude", Model: "sonnet", Tier: "cheap", Weight: 1},
+				},
+			},
+		},
+	}
+	enabled := true
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{Enabled: &enabled, Experiments: []Experiment{tt.exp}}
+			if _, _, err := Select(cfg, "task-1", "implementation", "implement"); err == nil {
+				t.Fatal("Select should reject invalid tier/bracket config")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Motivation

5-day cost analysis ($892 spend, 91.6% on the claude API) showed bulk code-author work (impl/test/fix-review/pr-fix) routing to premium models because A/B config had no price-tier concept. Also the `//go:embed all:frontend/dist` lint trap drove ~25% of impl/test spend via 100-300-turn runaways.

> Changelog: feat(abtest): cheap/expensive model brackets

## Implementation information

- `internal/abtest`: add `Tier` to `Variant` and `Bracket` to `Experiment`; `DefaultConfig()` now splits into a `code-author-cheap` bracket (Sonnet / GPT-5.4 / copilot claude-sonnet-4.6) for impl/test/fix-review/pr-fix and a `review-expensive` bracket (Opus / GPT-5.5 / Gemini 3.1 Pro) for review/plan. Haiku intentionally excluded.
- `internal/abtest/selector.go`: fail-closed validation floor — invalid tier/bracket and any premium variant leaking into the cheap bracket are config errors that fall back to the default model rather than mis-routing.
- `.sybra.yaml`: append `npm run build:desktop` to `setup:` so `frontend/dist/` exists before golangci-lint's embed typecheck.

## Supporting documentation

Reviewed locally (APPROVE_WITH_COMMENTS, 0 blockers). Three non-blocking review comments are tracked as follow-ups: whitespace-bracket validation hole (`selector.go`), the server-side cost of `build:desktop` in setup, and moving validation to config-load time.