### PR TITLE
fix(worktree): fall back to PR head ref for fix worktree

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -323,6 +323,13 @@ func BranchExists(barePath, branch string) bool {
 	return err == nil
 }
 
+// RefExists reports whether an arbitrary ref (e.g. refs/remotes/origin/<branch>)
+// resolves in the repo.
+func RefExists(barePath, ref string) bool {
+	_, ok := resolveRef(barePath, ref)
+	return ok
+}
+
 // CreateWorktreeDetached creates a worktree in detached HEAD mode from a remote ref.
 // Used for read-only checkouts like code reviews.
 func CreateWorktreeDetached(barePath, worktreePath, ref string) error {

--- a/internal/worktree/adopt_test.go
+++ b/internal/worktree/adopt_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Automaat/sybra/internal/task"
@@ -130,6 +131,76 @@ func TestPrepareForFix_AdoptsExternalWorktree(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Errorf("managed worktrees dir not empty: %v", entries)
+	}
+}
+
+// TestPrepareForFix_FallsBackToPRHead is the regression for "fix review
+// comments" failing with `fatal: invalid reference:
+// refs/remotes/origin/<branch>`. When the PR head is not reachable under
+// refs/remotes/origin/* (a fork PR, or a branch FetchOrigin could not pull),
+// PrepareForFix must fall back to the refs/pull/<N>/head ref and still create a
+// real local branch to push.
+func TestPrepareForFix_FallsBackToPRHead(t *testing.T) {
+	h := prepareHarness(t, nil, 0)
+
+	const prNumber = 7
+	const branch = "default-delta-xds"
+
+	// Build a commit in the origin remote (src) that is reachable ONLY via
+	// refs/pull/<N>/head — never as a branch head. Mirrors a fork PR.
+	srcGit := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", h.src}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	srcGit("checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(h.src, "feature.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "pr head")
+	shaOut, err := exec.Command("git", "-C", h.src, "rev-parse", "HEAD").CombinedOutput()
+	if err != nil {
+		t.Fatalf("rev-parse: %v: %s", err, shaOut)
+	}
+	prSHA := strings.TrimSpace(string(shaOut))
+	srcGit("update-ref", "refs/pull/7/head", prSHA)
+	srcGit("checkout", "main")
+	srcGit("branch", "-D", branch)
+
+	// Resolver returns the PR branch name; the head is not on origin.
+	h.m.prBranch = func(_ string, _ int) (string, error) { return branch, nil }
+
+	tk, err := h.tasks.Create("fix fork pr", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = h.tasks.UpdateMap(tk.ID, map[string]any{"project_id": h.proj.ID})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	wtPath, err := h.m.PrepareForFix(tk, prNumber)
+	if err != nil {
+		t.Fatalf("PrepareForFix: %v", err)
+	}
+
+	// Worktree is on a real local branch (not detached) at the PR head commit.
+	headBranch, err := exec.Command("git", "-C", wtPath, "rev-parse", "--abbrev-ref", "HEAD").CombinedOutput()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD branch: %v: %s", err, headBranch)
+	}
+	if got := strings.TrimSpace(string(headBranch)); got != branch {
+		t.Errorf("worktree branch = %q, want %q", got, branch)
+	}
+	headSHA, err := exec.Command("git", "-C", wtPath, "rev-parse", "HEAD").CombinedOutput()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v: %s", err, headSHA)
+	}
+	if got := strings.TrimSpace(string(headSHA)); got != prSHA {
+		t.Errorf("worktree HEAD = %q, want PR head %q", got, prSHA)
 	}
 }
 

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -366,13 +366,28 @@ func (m *Manager) PrepareForFix(t task.Task, prNumber int) (string, error) {
 		_ = project.RemoveWorktree(proj.ClonePath, wtPath)
 	}
 
-	ref := "refs/remotes/origin/" + branch
-	if project.BranchExists(proj.ClonePath, branch) {
+	originRef := "refs/remotes/origin/" + branch
+	switch {
+	case project.BranchExists(proj.ClonePath, branch):
 		if err := project.CreateWorktreeExisting(proj.ClonePath, wtPath, branch); err != nil {
 			return "", fmt.Errorf("checkout fix branch %s: %w", branch, err)
 		}
-	} else if err := project.CreateWorktree(proj.ClonePath, wtPath, branch, ref); err != nil {
-		return "", fmt.Errorf("create fix worktree: %w", err)
+	case project.RefExists(proj.ClonePath, originRef):
+		if err := project.CreateWorktree(proj.ClonePath, wtPath, branch, originRef); err != nil {
+			return "", fmt.Errorf("create fix worktree: %w", err)
+		}
+	default:
+		// Branch head is not under refs/remotes/origin/* — e.g. a fork PR, or a
+		// branch FetchOrigin could not pull. Fall back to the PR head ref, which
+		// GitHub exposes at refs/pull/<N>/head for every PR, and branch off that
+		// so the fix agent still gets a real local branch to push.
+		prHeadRef, err := project.FetchPRHead(proj.ClonePath, prNumber)
+		if err != nil {
+			return "", fmt.Errorf("fetch pr head: %w", err)
+		}
+		if err := project.CreateWorktree(proj.ClonePath, wtPath, branch, prHeadRef); err != nil {
+			return "", fmt.Errorf("create fix worktree: %w", err)
+		}
 	}
 	if err := project.SanitizeWorktree(wtPath); err != nil {
 		m.logger.Warn("fix.worktree.sanitize", "task_id", t.ID, "err", err)


### PR DESCRIPTION
## Motivation

Clicking "fix review comments" on an in-review task failed with:

```
prepare worktree: create fix worktree: git ... worktree add ... -b default-delta-xds refs/remotes/origin/default-delta-xds: exit status 128: fatal: invalid reference: refs/remotes/origin/default-delta-xds
```

`PrepareForFix` hardcoded `refs/remotes/origin/<branch>` as the worktree base ref. When the PR head is not reachable under `refs/remotes/origin/*` — a fork PR (head lives on the fork) or a branch `FetchOrigin` could not pull — `git worktree add` fails with `invalid reference`. `PrepareForReview` already handled this via `FetchPRHead` (`refs/pull/<N>/head`), but the fix path never got the same treatment.

> Changelog: fix(worktree): fall back to PR head ref when creating fix worktree

## Implementation information

- `internal/project/git.go` — added exported `RefExists(barePath, ref)` helper.
- `internal/worktree/prepare.go` — `PrepareForFix` now branches three ways: local branch exists → check it out; `refs/remotes/origin/<branch>` exists → branch off it (prior default); otherwise fetch `refs/pull/<N>/head` and branch off that. Still creates a real local branch (not detached) so the fix agent can push.
- `internal/worktree/adopt_test.go` — regression test `TestPrepareForFix_FallsBackToPRHead` simulating a fork PR whose head is only reachable via `refs/pull/N/head`.

## Supporting documentation

Mirrors the existing `PrepareForReview` → `FetchPRHead` pattern.