### PR TITLE
fix(monitor): debounce PR gap detection

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -276,6 +276,7 @@ type MonitorConfig struct {
 	DispatchLimit        int                `yaml:"dispatch_limit" json:"dispatchLimit"`
 	StuckHumanHours      float64            `yaml:"stuck_human_hours" json:"stuckHumanHours"`
 	LostAgentMinutes     int                `yaml:"lost_agent_minutes" json:"lostAgentMinutes"`
+	PRGapGraceMinutes    int                `yaml:"pr_gap_grace_minutes" json:"prGapGraceMinutes"`
 	FailureRateThreshold float64            `yaml:"failure_rate_threshold" json:"failureRateThreshold"`
 	BottleneckHours      map[string]float64 `yaml:"bottleneck_hours" json:"bottleneckHours"`
 	IssueLabel           string             `yaml:"issue_label" json:"issueLabel"`

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -637,6 +637,9 @@ func applyMonitorDefaults(cfg *Config) {
 	if cfg.Monitor.LostAgentMinutes <= 0 {
 		cfg.Monitor.LostAgentMinutes = 15
 	}
+	if cfg.Monitor.PRGapGraceMinutes <= 0 {
+		cfg.Monitor.PRGapGraceMinutes = 15
+	}
 	if cfg.Monitor.FailureRateThreshold <= 0 {
 		cfg.Monitor.FailureRateThreshold = 0.3
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -169,6 +169,23 @@ func TestLoadMonitorDispatchLimitPreservesOverride(t *testing.T) {
 	}
 }
 
+func TestLoadMonitorPRGapGraceDefaults(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("monitor:\n  pr_gap_grace_minutes: 0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Monitor.PRGapGraceMinutes != 15 {
+		t.Fatalf("PRGapGraceMinutes = %d, want 15", cfg.Monitor.PRGapGraceMinutes)
+	}
+}
+
 func TestLoadHarnessEvolutionDefaults(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("SYBRA_HOME", dir)

--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -112,7 +112,7 @@ func detectPerTask(in DetectInput) []Anomaly {
 		if a := detectStuckHumanBlocked(t, in.Now, stuckBudget); a != nil {
 			out = append(out, *a)
 		}
-		if a := detectPRGap(t, in.Now); a != nil {
+		if a := detectPRGap(t, in.Now, time.Duration(in.Cfg.PRGapGraceMinutes)*time.Minute); a != nil {
 			out = append(out, *a)
 		}
 	}
@@ -204,11 +204,14 @@ func detectStuckHumanBlocked(t *task.Task, now time.Time, budget time.Duration) 
 	}
 }
 
-func detectPRGap(t *task.Task, now time.Time) *Anomaly {
+func detectPRGap(t *task.Task, now time.Time, grace time.Duration) *Anomaly {
 	if t.Status != task.StatusInReview {
 		return nil
 	}
 	if t.ProjectID == "" || t.PRNumber > 0 {
+		return nil
+	}
+	if prGapWithinGrace(t, now, grace) {
 		return nil
 	}
 	ev := map[string]any{
@@ -226,6 +229,17 @@ func detectPRGap(t *task.Task, now time.Time) *Anomaly {
 		Evidence:    ev,
 		DetectedAt:  now,
 	}
+}
+
+func prGapWithinGrace(t *task.Task, now time.Time, grace time.Duration) bool {
+	if grace <= 0 {
+		return false
+	}
+	if t.UpdatedAt.IsZero() {
+		return false
+	}
+	dwell := now.Sub(t.UpdatedAt)
+	return dwell >= 0 && dwell < grace
 }
 
 func detectLostAgents(in DetectInput) []Anomaly {

--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -211,14 +211,21 @@ func detectPRGap(t *task.Task, now time.Time, grace time.Duration) *Anomaly {
 	if t.ProjectID == "" || t.PRNumber > 0 {
 		return nil
 	}
-	if prGapWithinGrace(t, now, grace) {
+	dwell := time.Duration(0)
+	if !t.UpdatedAt.IsZero() {
+		dwell = now.Sub(t.UpdatedAt)
+	}
+	if grace > 0 && !t.UpdatedAt.IsZero() && dwell >= 0 && dwell < grace {
 		return nil
 	}
 	ev := map[string]any{
-		"task_id":    t.ID,
-		"title":      t.Title,
-		"project_id": t.ProjectID,
-		"branch":     t.Branch,
+		"task_id":       t.ID,
+		"title":         t.Title,
+		"project_id":    t.ProjectID,
+		"branch":        t.Branch,
+		"updated_at":    t.UpdatedAt.Format(time.RFC3339),
+		"dwell_minutes": dwell.Minutes(),
+		"grace_minutes": grace.Minutes(),
 	}
 	return &Anomaly{
 		Kind:        KindPRGap,
@@ -229,17 +236,6 @@ func detectPRGap(t *task.Task, now time.Time, grace time.Duration) *Anomaly {
 		Evidence:    ev,
 		DetectedAt:  now,
 	}
-}
-
-func prGapWithinGrace(t *task.Task, now time.Time, grace time.Duration) bool {
-	if grace <= 0 {
-		return false
-	}
-	if t.UpdatedAt.IsZero() {
-		return false
-	}
-	dwell := now.Sub(t.UpdatedAt)
-	return dwell >= 0 && dwell < grace
 }
 
 func detectLostAgents(in DetectInput) []Anomaly {

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -358,6 +358,32 @@ func TestDetect(t *testing.T) {
 	}
 }
 
+func TestDetectPRGap_EvidenceIncludesTiming(t *testing.T) {
+	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
+	cfg := defaultCfg()
+	updatedAt := now.Add(-20 * time.Minute)
+	tk := mkTask("a", task.StatusInReview, func(t *task.Task) {
+		t.ProjectID = "owner/repo"
+		t.Branch = "task-a"
+		t.UpdatedAt = updatedAt
+	})
+
+	report := Detect(DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg})
+	if len(report.Anomalies) != 1 {
+		t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
+	}
+	ev := report.Anomalies[0].Evidence
+	if ev["updated_at"] != updatedAt.Format(time.RFC3339) {
+		t.Errorf("updated_at = %v, want %s", ev["updated_at"], updatedAt.Format(time.RFC3339))
+	}
+	if ev["dwell_minutes"] != 20.0 {
+		t.Errorf("dwell_minutes = %v, want 20", ev["dwell_minutes"])
+	}
+	if ev["grace_minutes"] != 15.0 {
+		t.Errorf("grace_minutes = %v, want 15", ev["grace_minutes"])
+	}
+}
+
 func TestDetectStuckHumanBlocked_Evidence(t *testing.T) {
 	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
 	cfg := defaultCfg()

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -18,6 +18,7 @@ func defaultCfg() config.MonitorConfig {
 		DispatchLimit:        3,
 		StuckHumanHours:      8,
 		LostAgentMinutes:     15,
+		PRGapGraceMinutes:    15,
 		FailureRateThreshold: 0.3,
 		BottleneckHours: map[string]float64{
 			"plan-review":    4,
@@ -162,15 +163,28 @@ func TestDetect(t *testing.T) {
 			want: nil,
 		},
 		{
-			name: "pr_gap on in-review with project but no PR",
+			name: "pr_gap on stale in-review with project but no PR",
 			in: DetectInput{
 				Now: now,
 				Tasks: []task.Task{mkTask("a", task.StatusInReview, func(t *task.Task) {
 					t.ProjectID = "owner/repo"
+					t.UpdatedAt = now.Add(-20 * time.Minute)
 				})},
 				Cfg: cfg,
 			},
 			want: []AnomalyKind{KindPRGap},
+		},
+		{
+			name: "pr_gap suppressed during grace period",
+			in: DetectInput{
+				Now: now,
+				Tasks: []task.Task{mkTask("a", task.StatusInReview, func(t *task.Task) {
+					t.ProjectID = "owner/repo"
+					t.UpdatedAt = now.Add(-5 * time.Minute)
+				})},
+				Cfg: cfg,
+			},
+			want: nil,
 		},
 		{
 			name: "pr_gap suppressed when PR is set",

--- a/internal/monitor/service.go
+++ b/internal/monitor/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/events"
 	"github.com/Automaat/sybra/internal/metrics"
+	"github.com/Automaat/sybra/internal/task"
 )
 
 // auditAPI mirrors the slice of internal/audit the service needs. Tests
@@ -170,6 +171,7 @@ func (s *Service) tick(ctx context.Context) (Report, error) {
 	summary := audit.Summarize(events1h, since1h, now)
 
 	live := snapshotLiveAgents(s.agents)
+	s.logPRGapGraceSuppressions(tasks, now)
 	report := Detect(DetectInput{
 		Now:           now,
 		Tasks:         tasks,
@@ -195,6 +197,38 @@ func (s *Service) tick(ctx context.Context) (Report, error) {
 		metrics.MonitorAnomaly(string(report.Anomalies[i].Kind))
 	}
 	return report, nil
+}
+
+func (s *Service) logPRGapGraceSuppressions(tasks []task.Task, now time.Time) {
+	grace := time.Duration(s.cfg.PRGapGraceMinutes) * time.Minute
+	if grace <= 0 {
+		return
+	}
+	for i := range tasks {
+		t := &tasks[i]
+		if t.Status != task.StatusInReview {
+			continue
+		}
+		if t.ProjectID == "" || t.PRNumber > 0 {
+			continue
+		}
+		if !projectAllowed(s.allowsProject, t.ProjectID) {
+			continue
+		}
+		if t.UpdatedAt.IsZero() {
+			continue
+		}
+		dwell := now.Sub(t.UpdatedAt)
+		if dwell < 0 || dwell >= grace {
+			continue
+		}
+		s.logger.Debug("monitor.pr_gap.grace_suppressed",
+			"task_id", t.ID,
+			"updated_at", t.UpdatedAt.Format(time.RFC3339),
+			"grace", grace.String(),
+			"dwell", dwell.String(),
+		)
+	}
 }
 
 // Scan runs one detector pass with no remediation, dispatch, or issue side

--- a/internal/monitor/service_test.go
+++ b/internal/monitor/service_test.go
@@ -170,7 +170,10 @@ func TestServiceTickEndToEnd(t *testing.T) {
 			t.AgentMode = ""
 		}),
 		// PR gap: in-review with project but no PR.
-		mkTask("pr", task.StatusInReview, func(t *task.Task) { t.ProjectID = "owner/repo" }),
+		mkTask("pr", task.StatusInReview, func(t *task.Task) {
+			t.ProjectID = "owner/repo"
+			t.UpdatedAt = now.Add(-20 * time.Minute)
+		}),
 	}}
 	disp := &fakeDispatcher{}
 	sink := &fakeSink{createNext: true}


### PR DESCRIPTION
## Motivation

The monitor can report a PR gap too quickly while task metadata and remote PR state are still settling, which creates noisy follow-up work for branches that are already in flight.

## Implementation information

- Add configurable debounce timing for PR gap detection.
- Track first-seen timestamps before emitting PR gap findings.
- Cover the new debounce behavior with monitor and config tests.