### PR TITLE
fix(workflow): reject hypothetical readiness evidence

### DIFF
--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -56,10 +56,19 @@ type structuredTestOutput struct {
 	SurfaceKind       string                     `json:"surface_kind,omitempty"`
 	AppStarted        flexBool                   `json:"app_started,omitempty"`
 	StartCommand      string                     `json:"start_command,omitempty"`
-	ReadinessProbe    evidenceText               `json:"readiness_probe,omitempty"`
+	ReadinessProbe    readinessProbeEvidence     `json:"readiness_probe,omitzero"`
 	ManualProbes      manualProbeEvidenceList    `json:"manual_probes,omitempty"`
 	AutomatedChecks   automatedCheckEvidenceList `json:"automated_checks,omitempty"`
 	UnableToRunReason string                     `json:"unable_to_run_reason,omitempty"`
+}
+
+type readinessProbeEvidence struct {
+	Command  string       `json:"command"`
+	Actual   evidenceText `json:"actual"`
+	Output   evidenceText `json:"output"`
+	Observed evidenceText `json:"observed"`
+	Status   evidenceText `json:"status"`
+	Raw      string       `json:"-"`
 }
 
 type manualProbeEvidenceList []manualProbeEvidence
@@ -193,6 +202,36 @@ func (e *automatedCheckEvidence) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (e *readinessProbeEvidence) UnmarshalJSON(data []byte) error {
+	if raw, ok, err := unmarshalEvidenceString(data); err != nil || ok {
+		e.Raw = raw
+		return err
+	}
+	type alias readinessProbeEvidence
+	if err := json.Unmarshal(data, (*alias)(e)); err != nil {
+		return err
+	}
+	e.fillAliases()
+	return nil
+}
+
+func (e *readinessProbeEvidence) fillAliases() {
+	if strings.TrimSpace(string(e.Actual)) == "" {
+		e.Actual = firstNonEmptyText(e.Observed, e.Output, e.Status)
+	}
+}
+
+func (e *readinessProbeEvidence) text() string {
+	return strings.Join(collectNonEmptyStrings(
+		e.Command,
+		string(e.Actual),
+		string(e.Output),
+		string(e.Observed),
+		string(e.Status),
+		e.Raw,
+	), "\n")
+}
+
 func (e *manualProbeEvidence) fillAliases() {
 	if strings.TrimSpace(string(e.Actual)) == "" {
 		e.Actual = firstNonEmptyText(e.Observed, e.Output, e.Status)
@@ -258,6 +297,16 @@ func firstNonEmptyText(values ...evidenceText) evidenceText {
 		}
 	}
 	return ""
+}
+
+func collectNonEmptyStrings(values ...string) []string {
+	var out []string
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }
 
 // prepareTestVerdictAttemptVars resets per-attempt verdict metadata before a
@@ -439,7 +488,7 @@ func hasManualPassEvidence(output string, t TaskInfo) (ok bool, reason string) {
 	if strings.TrimSpace(parsed.StartCommand) == "" {
 		return false, "PASS report omitted start_command"
 	}
-	if strings.TrimSpace(string(parsed.ReadinessProbe)) == "" {
+	if strings.TrimSpace(parsed.ReadinessProbe.text()) == "" {
 		return false, "PASS report omitted readiness_probe"
 	}
 	if !hasManualProbeEvidence(parsed.ManualProbes) {
@@ -454,6 +503,7 @@ func normalizeSurfaceKind(s string) string {
 	case "web", "cli", "server", "desktop", "k8s", "library", "docs", "none":
 		return lower
 	}
+	var fallback string
 	for _, token := range strings.FieldsFunc(lower, func(r rune) bool {
 		return (r < 'a' || r > 'z') && (r < '0' || r > '9')
 	}) {
@@ -463,18 +513,16 @@ func normalizeSurfaceKind(s string) string {
 		case "cli", "server", "desktop", "k8s":
 			return token
 		case "kubernetes":
-			return "k8s"
-		}
-	}
-	for _, token := range strings.FieldsFunc(lower, func(r rune) bool {
-		return (r < 'a' || r > 'z') && (r < '0' || r > '9')
-	}) {
-		switch token {
+			if fallback == "" {
+				fallback = "k8s"
+			}
 		case "library", "docs", "none":
-			return token
+			if fallback == "" || fallback == "k8s" {
+				fallback = token
+			}
 		}
 	}
-	return ""
+	return fallback
 }
 
 func isManualTestExemption(surface string, t TaskInfo) bool {
@@ -586,9 +634,28 @@ func hasManualProbeEvidence(probes manualProbeEvidenceList) bool {
 	return false
 }
 
-func hasReadinessProbeEvidence(probe evidenceText) bool {
-	raw := string(probe)
-	return hasRawRegressionCheckEvidence(raw) || hasRawManualProbeEvidence(raw)
+func hasReadinessProbeEvidence(probe readinessProbeEvidence) bool {
+	cmd := strings.ToLower(strings.TrimSpace(probe.Command))
+	if cmd != "" {
+		if hasRegressionCheckCommandEvidence(cmd) {
+			return hasSuccessfulCheckResult(probe.Actual, probe.Output, probe.Observed, probe.Status)
+		}
+		if strings.TrimSpace(string(probe.Actual)) != "" ||
+			strings.TrimSpace(string(probe.Output)) != "" ||
+			strings.TrimSpace(string(probe.Observed)) != "" ||
+			strings.TrimSpace(string(probe.Status)) != "" {
+			return hasRawManualProbeEvidence(probe.text())
+		}
+	}
+	return hasRawReadinessProbeEvidence(probe.Raw)
+}
+
+func hasRawReadinessProbeEvidence(raw string) bool {
+	lower := strings.ToLower(strings.TrimSpace(raw))
+	if lower == "" || !hasExecutedResultEvidence(lower) {
+		return false
+	}
+	return hasRawRegressionCheckEvidence(lower) || hasRawManualProbeEvidence(lower)
 }
 
 func hasRegressionCheckEvidence(checks automatedCheckEvidenceList) bool {
@@ -698,6 +765,12 @@ func hasRawRegressionCheckEvidence(raw string) bool {
 		return false
 	}
 	return hasRegressionCheckCommandEvidence(lower) && hasPositiveRegressionEvidence(lower)
+}
+
+func hasExecutedResultEvidence(lower string) bool {
+	return containsAny(lower,
+		"->", "=>", "ran ", "ran:", "executed", "exit code", "exit status",
+		"output:", "actual:", "observed:", "returned", "confirmed", "status:")
 }
 
 func hasManualActionEvidence(lower string) bool {

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -423,7 +423,9 @@ func hasManualPassEvidence(output string, t TaskInfo) (ok bool, reason string) {
 		if strings.TrimSpace(parsed.UnableToRunReason) == "" {
 			return false, "PASS used a no-app exemption but omitted unable_to_run_reason"
 		}
-		if !hasRegressionCheckEvidence(parsed.AutomatedChecks) {
+		if !hasRegressionCheckEvidence(parsed.AutomatedChecks) &&
+			!hasReadinessProbeEvidence(parsed.ReadinessProbe) &&
+			!hasManualProbeEvidence(parsed.ManualProbes) {
 			return false, "PASS used a no-app exemption without CLI/test harness evidence"
 		}
 		return true, ""
@@ -460,6 +462,8 @@ func normalizeSurfaceKind(s string) string {
 			return "web"
 		case "cli", "server", "desktop", "k8s":
 			return token
+		case "kubernetes":
+			return "k8s"
 		}
 	}
 	for _, token := range strings.FieldsFunc(lower, func(r rune) bool {
@@ -580,6 +584,11 @@ func hasManualProbeEvidence(probes manualProbeEvidenceList) bool {
 		}
 	}
 	return false
+}
+
+func hasReadinessProbeEvidence(probe evidenceText) bool {
+	raw := string(probe)
+	return hasRawRegressionCheckEvidence(raw) || hasRawManualProbeEvidence(raw)
 }
 
 func hasRegressionCheckEvidence(checks automatedCheckEvidenceList) bool {

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -652,7 +652,7 @@ func hasReadinessProbeEvidence(probe readinessProbeEvidence) bool {
 
 func hasRawReadinessProbeEvidence(raw string) bool {
 	lower := strings.ToLower(strings.TrimSpace(raw))
-	if lower == "" || !hasExecutedResultEvidence(lower) {
+	if lower == "" || hasReadinessHypotheticalEvidence(lower) || !hasExecutedResultEvidence(lower) {
 		return false
 	}
 	return hasRawRegressionCheckEvidence(lower) || hasRawManualProbeEvidence(lower)
@@ -770,7 +770,14 @@ func hasRawRegressionCheckEvidence(raw string) bool {
 func hasExecutedResultEvidence(lower string) bool {
 	return containsAny(lower,
 		"->", "=>", "ran ", "ran:", "executed", "exit code", "exit status",
-		"output:", "actual:", "observed:", "returned", "confirmed", "status:")
+		"output:", "actual:", "observed:", "confirmed", "status:")
+}
+
+func hasReadinessHypotheticalEvidence(lower string) bool {
+	return containsAny(lower,
+		"would ", "would've", "would have", "could ", "could've", "could have",
+		"should ", "should've", "should have", "expected to", "if the ",
+		"if it ", "if this ", "if run", "assuming ", "hypothetical")
 }
 
 func hasManualActionEvidence(lower string) bool {

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -691,7 +691,7 @@ func TestApplyTestVerdictCompletion_ClassifiesOutcomes(t *testing.T) {
 		{
 			name:       "pass_with_library_exemption_rejects_fabricated_readiness_probe",
 			status:     "completed",
-			output:     `{"verdict":"PASS","outcome":"pass","failures_markdown":"","surface_kind":"library","app_started":false,"start_command":"","readiness_probe":"curl would return 200 if the server were running, but this is a pure library change","manual_probes":[],"automated_checks":[],"unable_to_run_reason":"pure internal-library refactor"}`,
+			output:     `{"verdict":"PASS","outcome":"pass","failures_markdown":"","surface_kind":"library","app_started":false,"start_command":"","readiness_probe":"curl would have returned 200 for the health endpoint if the server were running, but this is a pure library change","manual_probes":[],"automated_checks":[],"unable_to_run_reason":"pure internal-library refactor"}`,
 			bodySuffix: "",
 			want:       testOutcomeMissingEvidence,
 			wantStatus: "failed",
@@ -876,6 +876,15 @@ func TestApplyTestVerdictCompletion_ClassifiesOutcomes(t *testing.T) {
 				t.Fatal("fingerprint is empty for evidenced failure")
 			}
 		})
+	}
+}
+
+func TestHasRawReadinessProbeEvidenceRejectsHypotheticalText(t *testing.T) {
+	t.Parallel()
+
+	raw := "curl would have returned 200 for the health endpoint if the server were running, but this is a pure library change"
+	if hasRawReadinessProbeEvidence(raw) {
+		t.Fatalf("hypothetical readiness probe evidence was accepted: %q", raw)
 	}
 }
 

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -597,6 +597,18 @@ func TestApplyTestVerdictCompletion_ClassifiesOutcomes(t *testing.T) {
 			wantStatus: "completed",
 		},
 		{
+			name:   "pass_with_kubernetes_surface_word",
+			status: "completed",
+			output: `{"verdict":"PASS","outcome":"pass","failures_markdown":"","surface_kind":"internal Kubernetes informer event handler","app_started":true,` +
+				`"start_command":"kubectl apply -f testdata/informer.yaml",` +
+				`"readiness_probe":"kubectl get pods confirmed the controller pod was running",` +
+				`"manual_probes":[{"command":"kubectl describe pod controller","expected":"event handler active","actual":"event handler active"}],` +
+				`"automated_checks":[{"command":"go test ./internal/workflow","actual":"ok"}],"unable_to_run_reason":""}`,
+			bodySuffix: "",
+			want:       testOutcomePass,
+			wantStatus: "completed",
+		},
+		{
 			name:       "pass_with_weak_raw_ui_status_rejected",
 			status:     "completed",
 			output:     `{"verdict":"PASS","outcome":"pass","failures_markdown":"","surface_kind":"web","app_started":true,"start_command":"npm run dev","readiness_probe":"curl /health -> ok","manual_probes":["UI status: not tested"],"automated_checks":["npm test -> pass"],"unable_to_run_reason":""}`,
@@ -656,6 +668,14 @@ func TestApplyTestVerdictCompletion_ClassifiesOutcomes(t *testing.T) {
 			name:       "pass_with_library_exemption_requires_regression_check",
 			status:     "completed",
 			output:     `{"verdict":"PASS","outcome":"pass","failures_markdown":"","surface_kind":"library","app_started":false,"start_command":"","readiness_probe":"","manual_probes":[],"automated_checks":[{"command":"go test ./internal/foo","actual":"ok"}],"unable_to_run_reason":"pure internal-library refactor"}`,
+			bodySuffix: "",
+			want:       testOutcomePass,
+			wantStatus: "completed",
+		},
+		{
+			name:       "pass_with_library_exemption_accepts_readiness_probe_evidence",
+			status:     "completed",
+			output:     `{"verdict":"PASS","outcome":"pass","failures_markdown":"","surface_kind":"library","app_started":false,"start_command":"","readiness_probe":"go test ./internal/foo -> ok","manual_probes":[],"automated_checks":[],"unable_to_run_reason":"pure internal-library refactor"}`,
 			bodySuffix: "",
 			want:       testOutcomePass,
 			wantStatus: "completed",

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -609,6 +609,14 @@ func TestApplyTestVerdictCompletion_ClassifiesOutcomes(t *testing.T) {
 			wantStatus: "completed",
 		},
 		{
+			name:       "pass_with_docs_surface_word_before_kubernetes_uses_docs_exemption",
+			status:     "completed",
+			output:     `{"verdict":"PASS","outcome":"pass","failures_markdown":"","surface_kind":"docs for Kubernetes","app_started":false,"start_command":"","readiness_probe":"","manual_probes":[],"automated_checks":[{"command":"npm run check","actual":"ok"}],"unable_to_run_reason":"documentation-only update"}`,
+			bodySuffix: "",
+			want:       testOutcomePass,
+			wantStatus: "completed",
+		},
+		{
 			name:       "pass_with_weak_raw_ui_status_rejected",
 			status:     "completed",
 			output:     `{"verdict":"PASS","outcome":"pass","failures_markdown":"","surface_kind":"web","app_started":true,"start_command":"npm run dev","readiness_probe":"curl /health -> ok","manual_probes":["UI status: not tested"],"automated_checks":["npm test -> pass"],"unable_to_run_reason":""}`,
@@ -679,6 +687,15 @@ func TestApplyTestVerdictCompletion_ClassifiesOutcomes(t *testing.T) {
 			bodySuffix: "",
 			want:       testOutcomePass,
 			wantStatus: "completed",
+		},
+		{
+			name:       "pass_with_library_exemption_rejects_fabricated_readiness_probe",
+			status:     "completed",
+			output:     `{"verdict":"PASS","outcome":"pass","failures_markdown":"","surface_kind":"library","app_started":false,"start_command":"","readiness_probe":"curl would return 200 if the server were running, but this is a pure library change","manual_probes":[],"automated_checks":[],"unable_to_run_reason":"pure internal-library refactor"}`,
+			bodySuffix: "",
+			want:       testOutcomeMissingEvidence,
+			wantStatus: "failed",
+			wantTaint:  testProtocolMissingEvidence,
 		},
 		{
 			name:       "pass_with_notest_exemption_still_requires_regression_check",


### PR DESCRIPTION
## Motivation

The test-route workflow should only advance when readiness is backed by concrete evidence. Hypothetical, planned, or future-tense readiness claims can make the workflow treat unverified work as ready and move tasks forward prematurely.

## Implementation information

- Reject readiness evidence that is phrased as hypothetical or planned rather than observed.
- Extend the workflow test-route coverage to lock in the rejection behavior for future readiness claims.