### PR TITLE
fix(agent): default medium effort for all providers

### DIFF
--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -61,6 +61,9 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 	if cfg.SeedWorkingMemory {
 		cfg.Prompt = notes.SeedPrompt(cfg.Prompt, cfg.Dir)
 	}
+	if cfg.ReasoningEffort == "" {
+		cfg.ReasoningEffort = DefaultReasoningEffort
+	}
 
 	resolvedProvider, gateErr := m.gateProvider(cfg)
 	if gateErr != nil {

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -70,7 +70,7 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 		return cfg, nil, providerErr
 	}
 	cfg.provider = prov
-	cfg.ReasoningEffort = defaultReasoningEffort(cfg.ReasoningEffort, prov)
+	cfg.ReasoningEffort = defaultReasoningEffort(cfg.ReasoningEffort)
 
 	m.mu.RLock()
 	if cfg.BashTimeoutMs == 0 {
@@ -86,7 +86,7 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 	return cfg, prov, nil
 }
 
-func defaultReasoningEffort(effort string, prov Provider) string {
+func defaultReasoningEffort(effort string) string {
 	if effort != "" {
 		return effort
 	}

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -90,10 +90,7 @@ func defaultReasoningEffort(effort string, prov Provider) string {
 	if effort != "" {
 		return effort
 	}
-	if prov != nil && prov.Name() == "codex" {
-		return DefaultReasoningEffort
-	}
-	return ""
+	return DefaultReasoningEffort
 }
 
 func validateRunDir(dir string) error {

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -61,10 +61,6 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 	if cfg.SeedWorkingMemory {
 		cfg.Prompt = notes.SeedPrompt(cfg.Prompt, cfg.Dir)
 	}
-	if cfg.ReasoningEffort == "" {
-		cfg.ReasoningEffort = DefaultReasoningEffort
-	}
-
 	resolvedProvider, gateErr := m.gateProvider(cfg)
 	if gateErr != nil {
 		return cfg, nil, gateErr
@@ -74,6 +70,7 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 		return cfg, nil, providerErr
 	}
 	cfg.provider = prov
+	cfg.ReasoningEffort = defaultReasoningEffort(cfg.ReasoningEffort, prov)
 
 	m.mu.RLock()
 	if cfg.BashTimeoutMs == 0 {
@@ -87,6 +84,16 @@ func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
 	}
 	m.mu.RUnlock()
 	return cfg, prov, nil
+}
+
+func defaultReasoningEffort(effort string, prov Provider) string {
+	if effort != "" {
+		return effort
+	}
+	if prov != nil && prov.Name() == "codex" {
+		return DefaultReasoningEffort
+	}
+	return ""
 }
 
 func validateRunDir(dir string) error {

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -34,6 +34,8 @@ const (
 	StateStopped State = "stopped"
 )
 
+const DefaultReasoningEffort = "medium"
+
 type Agent struct {
 	ID                       string  `json:"id"`
 	TaskID                   string  `json:"taskId"`
@@ -827,7 +829,9 @@ type RunConfig struct {
 	// default; the flag is omitted only when the manager default is also empty.
 	FallbackModel string
 	// ReasoningEffort sets the agent's reasoning effort for this run
-	// (low/medium/high/xhigh). Empty = model default. Applied to every provider
+	// (low/medium/high/xhigh). Empty is resolved to DefaultReasoningEffort by
+	// Manager.Run; lower-level command builders still omit the provider flag
+	// when handed an empty value directly. Applied to every provider
 	// via its own CLI surface: codex `-c model_reasoning_effort=`, claude and
 	// copilot `--effort`. The value set is the common subset all three accept.
 	ReasoningEffort string

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -830,10 +830,10 @@ type RunConfig struct {
 	FallbackModel string
 	// ReasoningEffort sets the agent's reasoning effort for this run
 	// (low/medium/high/xhigh). Empty is resolved to DefaultReasoningEffort by
-	// Manager.Run only for providers with a validated reasoning surface. Lower-level
+	// Manager.Run for every provider before command construction. Lower-level
 	// command builders still omit the provider flag when handed an empty value
 	// directly. Codex uses `-c model_reasoning_effort=`; claude and copilot use
-	// `--effort` only when a caller explicitly sets the field.
+	// `--effort`.
 	ReasoningEffort string
 	// SeedWorkingMemory, when true, inlines the worktree's NOTES.md scratchpad
 	// into the prompt (read/maintain instruction + current contents). Set only

--- a/internal/agent/model.go
+++ b/internal/agent/model.go
@@ -830,10 +830,10 @@ type RunConfig struct {
 	FallbackModel string
 	// ReasoningEffort sets the agent's reasoning effort for this run
 	// (low/medium/high/xhigh). Empty is resolved to DefaultReasoningEffort by
-	// Manager.Run; lower-level command builders still omit the provider flag
-	// when handed an empty value directly. Applied to every provider
-	// via its own CLI surface: codex `-c model_reasoning_effort=`, claude and
-	// copilot `--effort`. The value set is the common subset all three accept.
+	// Manager.Run only for providers with a validated reasoning surface. Lower-level
+	// command builders still omit the provider flag when handed an empty value
+	// directly. Codex uses `-c model_reasoning_effort=`; claude and copilot use
+	// `--effort` only when a caller explicitly sets the field.
 	ReasoningEffort string
 	// SeedWorkingMemory, when true, inlines the worktree's NOTES.md scratchpad
 	// into the prompt (read/maintain instruction + current contents). Set only

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -1110,7 +1110,7 @@ func TestBuildHeadlessInvocation_EffortFlag(t *testing.T) {
 	}
 }
 
-func TestPrepareRunConfig_DefaultsReasoningEffortForCodex(t *testing.T) {
+func TestPrepareRunConfig_DefaultsReasoningEffortForAllProviders(t *testing.T) {
 	t.Parallel()
 
 	hasPair := func(args []string, key, value string) bool {
@@ -1122,33 +1122,7 @@ func TestPrepareRunConfig_DefaultsReasoningEffortForCodex(t *testing.T) {
 		return false
 	}
 
-	m := newParseTestManager(t)
-	cfg, prov, err := m.prepareRunConfig(RunConfig{
-		Provider: "codex",
-		Mode:     "headless",
-		Prompt:   "hi",
-		Dir:      t.TempDir(),
-	})
-	if err != nil {
-		t.Fatalf("prepareRunConfig: %v", err)
-	}
-	if cfg.ReasoningEffort != DefaultReasoningEffort {
-		t.Fatalf("ReasoningEffort = %q, want %q", cfg.ReasoningEffort, DefaultReasoningEffort)
-	}
-	a := newRunningAgent("a", cfg, prov, func() {})
-	_, args, _, _, err := buildHeadlessInvocation(a, cfg)
-	if err != nil {
-		t.Fatalf("buildHeadlessInvocation: %v", err)
-	}
-	if !hasPair(args, "-c", "model_reasoning_effort="+DefaultReasoningEffort) {
-		t.Fatalf("expected -c model_reasoning_effort=%s in args; got %v", DefaultReasoningEffort, args)
-	}
-}
-
-func TestPrepareRunConfig_DoesNotDefaultEffortForEffortFlagProviders(t *testing.T) {
-	t.Parallel()
-
-	for _, provider := range []string{"claude", "copilot"} {
+	for _, provider := range []string{"claude", "codex", "copilot"} {
 		t.Run(provider, func(t *testing.T) {
 			t.Parallel()
 			m := newParseTestManager(t)
@@ -1161,16 +1135,22 @@ func TestPrepareRunConfig_DoesNotDefaultEffortForEffortFlagProviders(t *testing.
 			if err != nil {
 				t.Fatalf("prepareRunConfig: %v", err)
 			}
-			if cfg.ReasoningEffort != "" {
-				t.Fatalf("ReasoningEffort = %q, want empty", cfg.ReasoningEffort)
+			if cfg.ReasoningEffort != DefaultReasoningEffort {
+				t.Fatalf("ReasoningEffort = %q, want %q", cfg.ReasoningEffort, DefaultReasoningEffort)
 			}
 			a := newRunningAgent("a", cfg, prov, func() {})
 			_, args, _, _, err := buildHeadlessInvocation(a, cfg)
 			if err != nil {
 				t.Fatalf("buildHeadlessInvocation: %v", err)
 			}
-			if slices.Contains(args, "--effort") {
-				t.Fatalf("--effort must be absent for default %s run; got %v", provider, args)
+			if provider == "codex" {
+				if !hasPair(args, "-c", "model_reasoning_effort="+DefaultReasoningEffort) {
+					t.Fatalf("expected -c model_reasoning_effort=%s in args; got %v", DefaultReasoningEffort, args)
+				}
+				return
+			}
+			if !hasPair(args, "--effort", DefaultReasoningEffort) {
+				t.Fatalf("expected --effort %s in %s args; got %v", DefaultReasoningEffort, provider, args)
 			}
 		})
 	}
@@ -1179,19 +1159,24 @@ func TestPrepareRunConfig_DoesNotDefaultEffortForEffortFlagProviders(t *testing.
 func TestPrepareRunConfig_PreservesExplicitReasoningEffort(t *testing.T) {
 	t.Parallel()
 
-	m := newParseTestManager(t)
-	cfg, _, err := m.prepareRunConfig(RunConfig{
-		Provider:        "codex",
-		Mode:            "headless",
-		Prompt:          "hi",
-		Dir:             t.TempDir(),
-		ReasoningEffort: "high",
-	})
-	if err != nil {
-		t.Fatalf("prepareRunConfig: %v", err)
-	}
-	if cfg.ReasoningEffort != "high" {
-		t.Fatalf("ReasoningEffort = %q, want high", cfg.ReasoningEffort)
+	for _, provider := range []string{"claude", "codex", "copilot"} {
+		t.Run(provider, func(t *testing.T) {
+			t.Parallel()
+			m := newParseTestManager(t)
+			cfg, _, err := m.prepareRunConfig(RunConfig{
+				Provider:        provider,
+				Mode:            "headless",
+				Prompt:          "hi",
+				Dir:             t.TempDir(),
+				ReasoningEffort: "high",
+			})
+			if err != nil {
+				t.Fatalf("prepareRunConfig: %v", err)
+			}
+			if cfg.ReasoningEffort != "high" {
+				t.Fatalf("ReasoningEffort = %q, want high", cfg.ReasoningEffort)
+			}
+		})
 	}
 }
 

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -1110,6 +1110,75 @@ func TestBuildHeadlessInvocation_EffortFlag(t *testing.T) {
 	}
 }
 
+func TestPrepareRunConfig_DefaultsReasoningEffortForHeadlessProviders(t *testing.T) {
+	t.Parallel()
+
+	hasPair := func(args []string, key, value string) bool {
+		for i := range len(args) - 1 {
+			if args[i] == key && args[i+1] == value {
+				return true
+			}
+		}
+		return false
+	}
+
+	tests := []struct {
+		provider string
+		flag     string
+		value    string
+	}{
+		{provider: "claude", flag: "--effort", value: DefaultReasoningEffort},
+		{provider: "copilot", flag: "--effort", value: DefaultReasoningEffort},
+		{provider: "codex", flag: "-c", value: "model_reasoning_effort=" + DefaultReasoningEffort},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			t.Parallel()
+			m := newParseTestManager(t)
+			cfg, prov, err := m.prepareRunConfig(RunConfig{
+				Provider: tt.provider,
+				Mode:     "headless",
+				Prompt:   "hi",
+				Dir:      t.TempDir(),
+			})
+			if err != nil {
+				t.Fatalf("prepareRunConfig: %v", err)
+			}
+			if cfg.ReasoningEffort != DefaultReasoningEffort {
+				t.Fatalf("ReasoningEffort = %q, want %q", cfg.ReasoningEffort, DefaultReasoningEffort)
+			}
+			a := newRunningAgent("a", cfg, prov, func() {})
+			_, args, _, _, err := buildHeadlessInvocation(a, cfg)
+			if err != nil {
+				t.Fatalf("buildHeadlessInvocation: %v", err)
+			}
+			if !hasPair(args, tt.flag, tt.value) {
+				t.Fatalf("expected %s %s in args; got %v", tt.flag, tt.value, args)
+			}
+		})
+	}
+}
+
+func TestPrepareRunConfig_PreservesExplicitReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	m := newParseTestManager(t)
+	cfg, _, err := m.prepareRunConfig(RunConfig{
+		Provider:        "codex",
+		Mode:            "headless",
+		Prompt:          "hi",
+		Dir:             t.TempDir(),
+		ReasoningEffort: "high",
+	})
+	if err != nil {
+		t.Fatalf("prepareRunConfig: %v", err)
+	}
+	if cfg.ReasoningEffort != "high" {
+		t.Fatalf("ReasoningEffort = %q, want high", cfg.ReasoningEffort)
+	}
+}
+
 // TestBuildHeadlessInvocation_CodexAlwaysBypassesSandbox verifies that headless
 // codex invocations always use --dangerously-bypass-approvals-and-sandbox,
 // even when RequirePermissions=true. In headless mode there is no UI to serve

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -1110,7 +1110,7 @@ func TestBuildHeadlessInvocation_EffortFlag(t *testing.T) {
 	}
 }
 
-func TestPrepareRunConfig_DefaultsReasoningEffortForHeadlessProviders(t *testing.T) {
+func TestPrepareRunConfig_DefaultsReasoningEffortForCodex(t *testing.T) {
 	t.Parallel()
 
 	hasPair := func(args []string, key, value string) bool {
@@ -1122,22 +1122,38 @@ func TestPrepareRunConfig_DefaultsReasoningEffortForHeadlessProviders(t *testing
 		return false
 	}
 
-	tests := []struct {
-		provider string
-		flag     string
-		value    string
-	}{
-		{provider: "claude", flag: "--effort", value: DefaultReasoningEffort},
-		{provider: "copilot", flag: "--effort", value: DefaultReasoningEffort},
-		{provider: "codex", flag: "-c", value: "model_reasoning_effort=" + DefaultReasoningEffort},
+	m := newParseTestManager(t)
+	cfg, prov, err := m.prepareRunConfig(RunConfig{
+		Provider: "codex",
+		Mode:     "headless",
+		Prompt:   "hi",
+		Dir:      t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("prepareRunConfig: %v", err)
 	}
+	if cfg.ReasoningEffort != DefaultReasoningEffort {
+		t.Fatalf("ReasoningEffort = %q, want %q", cfg.ReasoningEffort, DefaultReasoningEffort)
+	}
+	a := newRunningAgent("a", cfg, prov, func() {})
+	_, args, _, _, err := buildHeadlessInvocation(a, cfg)
+	if err != nil {
+		t.Fatalf("buildHeadlessInvocation: %v", err)
+	}
+	if !hasPair(args, "-c", "model_reasoning_effort="+DefaultReasoningEffort) {
+		t.Fatalf("expected -c model_reasoning_effort=%s in args; got %v", DefaultReasoningEffort, args)
+	}
+}
 
-	for _, tt := range tests {
-		t.Run(tt.provider, func(t *testing.T) {
+func TestPrepareRunConfig_DoesNotDefaultEffortForEffortFlagProviders(t *testing.T) {
+	t.Parallel()
+
+	for _, provider := range []string{"claude", "copilot"} {
+		t.Run(provider, func(t *testing.T) {
 			t.Parallel()
 			m := newParseTestManager(t)
 			cfg, prov, err := m.prepareRunConfig(RunConfig{
-				Provider: tt.provider,
+				Provider: provider,
 				Mode:     "headless",
 				Prompt:   "hi",
 				Dir:      t.TempDir(),
@@ -1145,16 +1161,16 @@ func TestPrepareRunConfig_DefaultsReasoningEffortForHeadlessProviders(t *testing
 			if err != nil {
 				t.Fatalf("prepareRunConfig: %v", err)
 			}
-			if cfg.ReasoningEffort != DefaultReasoningEffort {
-				t.Fatalf("ReasoningEffort = %q, want %q", cfg.ReasoningEffort, DefaultReasoningEffort)
+			if cfg.ReasoningEffort != "" {
+				t.Fatalf("ReasoningEffort = %q, want empty", cfg.ReasoningEffort)
 			}
 			a := newRunningAgent("a", cfg, prov, func() {})
 			_, args, _, _, err := buildHeadlessInvocation(a, cfg)
 			if err != nil {
 				t.Fatalf("buildHeadlessInvocation: %v", err)
 			}
-			if !hasPair(args, tt.flag, tt.value) {
-				t.Fatalf("expected %s %s in args; got %v", tt.flag, tt.value, args)
+			if slices.Contains(args, "--effort") {
+				t.Fatalf("--effort must be absent for default %s run; got %v", provider, args)
 			}
 		})
 	}

--- a/internal/stats/pricing.go
+++ b/internal/stats/pricing.go
@@ -1,6 +1,9 @@
 package stats
 
-import "strings"
+import (
+	"strings"
+	"time"
+)
 
 const copilotAICreditUSD = 0.01
 
@@ -8,7 +11,7 @@ const copilotAICreditUSD = 0.01
 // `cached_input_tokens` (Codex) or `cache_read_input_tokens` (Claude) subset.
 // Cache-write rate applies to Claude `cache_creation_input_tokens`.
 //
-// Sources (May 2026): platform.openai.com/docs/pricing,
+// Sources (OpenAI May 2026, Anthropic July 2026): platform.openai.com/docs/pricing,
 // docs.claude.com/en/docs/about-claude/pricing.
 type modelPrice struct {
 	in           float64
@@ -18,49 +21,87 @@ type modelPrice struct {
 	cacheWrite1h float64 // Claude only: 2.00× standard input
 }
 
-var pricingTable = map[string]modelPrice{
+type pricedTier struct {
+	from  time.Time
+	price modelPrice
+}
+
+var sonnet5StandardFrom = time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+
+var (
+	gpt5Price            = modelPrice{in: 1.25, out: 10.00, cacheRead: 0.125}
+	gpt5MiniPrice        = modelPrice{in: 0.25, out: 2.00, cacheRead: 0.025}
+	gpt5NanoPrice        = modelPrice{in: 0.05, out: 0.40, cacheRead: 0.005}
+	haiku45Price         = modelPrice{in: 1.00, out: 5.00, cacheRead: 0.10, cacheWrite5m: 1.25, cacheWrite1h: 2.00}
+	sonnet46Price        = modelPrice{in: 3.00, out: 15.00, cacheRead: 0.30, cacheWrite5m: 3.75, cacheWrite1h: 6.00}
+	sonnet5IntroPrice    = modelPrice{in: 2.00, out: 10.00, cacheRead: 0.20, cacheWrite5m: 2.50, cacheWrite1h: 4.00}
+	sonnet5StandardPrice = modelPrice{in: 3.00, out: 15.00, cacheRead: 0.30, cacheWrite5m: 3.75, cacheWrite1h: 6.00}
+	opus48Price          = modelPrice{in: 5.00, out: 25.00, cacheRead: 0.50, cacheWrite5m: 6.25, cacheWrite1h: 10.00}
+	opus41Price          = modelPrice{in: 15.00, out: 75.00, cacheRead: 1.50, cacheWrite5m: 18.75, cacheWrite1h: 30.00}
+)
+
+func tiers(price modelPrice) []pricedTier {
+	return []pricedTier{{price: price}}
+}
+
+func sonnet5Tiers() []pricedTier {
+	return []pricedTier{
+		{price: sonnet5IntroPrice},
+		{from: sonnet5StandardFrom, price: sonnet5StandardPrice},
+	}
+}
+
+var pricingTable = map[string][]pricedTier{
 	// OpenAI / Codex CLI defaults.
 	// gpt-5 / gpt-5-mini are the underlying models behind `gpt-5.4` (codex
 	// alias) and `gpt-5.4-mini`. Cached input is billed at 10% of standard.
-	"gpt-5":         {in: 1.25, out: 10.00, cacheRead: 0.125},
-	"gpt-5-codex":   {in: 1.25, out: 10.00, cacheRead: 0.125},
-	"gpt-5-mini":    {in: 0.25, out: 2.00, cacheRead: 0.025},
-	"gpt-5-nano":    {in: 0.05, out: 0.40, cacheRead: 0.005},
-	"gpt-5.5":       {in: 1.25, out: 10.00, cacheRead: 0.125}, // codex default (0.142.2+)
-	"gpt-5.4":       {in: 1.25, out: 10.00, cacheRead: 0.125}, // codex alias
-	"gpt-5.4-mini":  {in: 0.25, out: 2.00, cacheRead: 0.025},  // codex alias
-	"gpt-5.3-codex": {in: 1.25, out: 10.00, cacheRead: 0.125}, // selectable codex option; gpt-5-codex pricing
+	"gpt-5":         tiers(gpt5Price),
+	"gpt-5-codex":   tiers(gpt5Price),
+	"gpt-5-mini":    tiers(gpt5MiniPrice),
+	"gpt-5-nano":    tiers(gpt5NanoPrice),
+	"gpt-5.5":       tiers(gpt5Price), // codex default (0.142.2+)
+	"gpt-5.4":       tiers(gpt5Price), // codex alias
+	"gpt-5.4-mini":  tiers(gpt5MiniPrice),
+	"gpt-5.3-codex": tiers(gpt5Price), // selectable codex option; gpt-5-codex pricing
 
 	// Legacy OpenAI (kept for back-compat with old run records).
-	"o4-mini":      {in: 1.10, out: 4.40, cacheRead: 0.275},
-	"o3":           {in: 2.00, out: 8.00, cacheRead: 0.50},
-	"o3-mini":      {in: 1.10, out: 4.40, cacheRead: 0.55},
-	"gpt-4o":       {in: 2.50, out: 10.00, cacheRead: 1.25},
-	"gpt-4o-mini":  {in: 0.15, out: 0.60, cacheRead: 0.075},
-	"gpt-4.1":      {in: 2.00, out: 8.00, cacheRead: 0.50},
-	"gpt-4.1-mini": {in: 0.40, out: 1.60, cacheRead: 0.10},
-	"gpt-4.1-nano": {in: 0.10, out: 0.40, cacheRead: 0.025},
+	"o4-mini":      tiers(modelPrice{in: 1.10, out: 4.40, cacheRead: 0.275}),
+	"o3":           tiers(modelPrice{in: 2.00, out: 8.00, cacheRead: 0.50}),
+	"o3-mini":      tiers(modelPrice{in: 1.10, out: 4.40, cacheRead: 0.55}),
+	"gpt-4o":       tiers(modelPrice{in: 2.50, out: 10.00, cacheRead: 1.25}),
+	"gpt-4o-mini":  tiers(modelPrice{in: 0.15, out: 0.60, cacheRead: 0.075}),
+	"gpt-4.1":      tiers(modelPrice{in: 2.00, out: 8.00, cacheRead: 0.50}),
+	"gpt-4.1-mini": tiers(modelPrice{in: 0.40, out: 1.60, cacheRead: 0.10}),
+	"gpt-4.1-nano": tiers(modelPrice{in: 0.10, out: 0.40, cacheRead: 0.025}),
 
 	// Anthropic — used for cross-checking Claude's reported total_cost_usd
 	// and for runs where Claude's result event omits cost (older CLI versions).
-	"claude-haiku-4-5":          {in: 1.00, out: 5.00, cacheRead: 0.10, cacheWrite5m: 1.25, cacheWrite1h: 2.00},
-	"claude-haiku-4-5-20251001": {in: 1.00, out: 5.00, cacheRead: 0.10, cacheWrite5m: 1.25, cacheWrite1h: 2.00},
-	"claude-sonnet-4-5":         {in: 3.00, out: 15.00, cacheRead: 0.30, cacheWrite5m: 3.75, cacheWrite1h: 6.00},
-	"claude-sonnet-4-6":         {in: 3.00, out: 15.00, cacheRead: 0.30, cacheWrite5m: 3.75, cacheWrite1h: 6.00},
-	"claude-opus-4-5":           {in: 15.00, out: 75.00, cacheRead: 1.50, cacheWrite5m: 18.75, cacheWrite1h: 30.00},
-	"claude-opus-4-6":           {in: 15.00, out: 75.00, cacheRead: 1.50, cacheWrite5m: 18.75, cacheWrite1h: 30.00},
-	"claude-opus-4-7":           {in: 15.00, out: 75.00, cacheRead: 1.50, cacheWrite5m: 18.75, cacheWrite1h: 30.00},
+	//
+	// Pricing is effective-dated. To change a model rate, append a new tier
+	// with its effective date; do not mutate an existing tier or historical
+	// runs will be repriced when read-time estimates are recomputed.
+	"claude-haiku-4-5":          tiers(haiku45Price),
+	"claude-haiku-4-5-20251001": tiers(haiku45Price),
+	"claude-sonnet-4-5":         tiers(sonnet46Price),
+	"claude-sonnet-4-6":         tiers(sonnet46Price),
+	"claude-sonnet-5":           sonnet5Tiers(),
+	"claude-opus-4-1":           tiers(opus41Price),
+	"claude-opus-4":             tiers(opus41Price),
+	"claude-opus-4-5":           tiers(opus48Price),
+	"claude-opus-4-6":           tiers(opus48Price),
+	"claude-opus-4-7":           tiers(opus48Price),
+	"claude-opus-4-8":           tiers(opus48Price),
 	// Aliases used by `claude --model <name>` — map to current generation.
-	"haiku":  {in: 1.00, out: 5.00, cacheRead: 0.10, cacheWrite5m: 1.25, cacheWrite1h: 2.00},
-	"sonnet": {in: 3.00, out: 15.00, cacheRead: 0.30, cacheWrite5m: 3.75, cacheWrite1h: 6.00},
-	"opus":   {in: 15.00, out: 75.00, cacheRead: 1.50, cacheWrite5m: 18.75, cacheWrite1h: 30.00},
+	"haiku":  tiers(haiku45Price),
+	"sonnet": sonnet5Tiers(),
+	"opus":   tiers(opus48Price),
 }
 
 // EstimateCost estimates USD cost from raw input/output tokens. Returns 0 for
 // unknown models. Provided for back-compat with callers that don't track cache
 // tokens — prefer EstimateCostDetailed when cache breakdown is available.
-func EstimateCost(model string, inputTokens, outputTokens int) float64 {
-	p, ok := lookupPrice(model)
+func EstimateCost(model string, inputTokens, outputTokens int, at time.Time) float64 {
+	p, ok := lookupPrice(model, at)
 	if !ok {
 		return 0
 	}
@@ -86,9 +127,9 @@ func EstimateCopilotCost(premiumRequests float64) float64 {
 // cacheRead is `usage.cache_read_input_tokens`. Reasoning output tokens are
 // already part of `output_tokens` for both providers, so the `reasoning` arg
 // is informational and not double-billed here.
-func EstimateCostDetailed(model string, input, output, cacheCreate, cacheRead, reasoning int) float64 {
+func EstimateCostDetailed(model string, input, output, cacheCreate, cacheRead, reasoning int, at time.Time) float64 {
 	_ = reasoning // tokens already counted under `output`; arg kept for future per-tier pricing
-	p, ok := lookupPrice(model)
+	p, ok := lookupPrice(model, at)
 	if !ok {
 		return 0
 	}
@@ -107,19 +148,36 @@ func EstimateCostDetailed(model string, input, output, cacheCreate, cacheRead, r
 		float64(cacheCreate)/1_000_000*cacheWriteRate
 }
 
-func lookupPrice(model string) (modelPrice, bool) {
-	p, ok := pricingTable[model]
-	if ok {
-		return p, true
+func lookupPrice(model string, at time.Time) (modelPrice, bool) {
+	if at.IsZero() {
+		at = time.Now()
+	}
+	if tiers, ok := pricingTable[model]; ok {
+		return priceForTier(tiers, at)
 	}
 	// Loose match: trim provider prefix (e.g. "openai/gpt-5" -> "gpt-5") and
 	// drop trailing date suffixes ("-20251001"). Keeps the table small without
 	// silently returning $0 for slightly-different model strings.
 	stripped := stripModelSuffix(model)
-	if p, ok := pricingTable[stripped]; ok {
-		return p, true
+	if tiers, ok := pricingTable[stripped]; ok {
+		return priceForTier(tiers, at)
 	}
 	return modelPrice{}, false
+}
+
+func priceForTier(tiers []pricedTier, at time.Time) (modelPrice, bool) {
+	if len(tiers) == 0 {
+		return modelPrice{}, false
+	}
+	var selected modelPrice
+	found := false
+	for _, tier := range tiers {
+		if tier.from.IsZero() || !tier.from.After(at) {
+			selected = tier.price
+			found = true
+		}
+	}
+	return selected, found
 }
 
 func stripModelSuffix(m string) string {

--- a/internal/stats/pricing.go
+++ b/internal/stats/pricing.go
@@ -170,10 +170,12 @@ func priceForTier(tiers []pricedTier, at time.Time) (modelPrice, bool) {
 		return modelPrice{}, false
 	}
 	var selected modelPrice
+	var selectedFrom time.Time
 	found := false
 	for _, tier := range tiers {
-		if tier.from.IsZero() || !tier.from.After(at) {
+		if (tier.from.IsZero() || !tier.from.After(at)) && (!found || tier.from.After(selectedFrom)) {
 			selected = tier.price
+			selectedFrom = tier.from
 			found = true
 		}
 	}

--- a/internal/stats/pricing_test.go
+++ b/internal/stats/pricing_test.go
@@ -121,6 +121,28 @@ func TestLookupPrice_ClaudeEffectiveDatedPricing(t *testing.T) {
 	}
 }
 
+func TestPriceForTier_SelectsLatestEligibleTierOutOfOrder(t *testing.T) {
+	t.Parallel()
+
+	intro := modelPrice{in: 2, out: 10}
+	standard := modelPrice{in: 3, out: 15}
+	future := modelPrice{in: 4, out: 20}
+	standardFrom := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+	futureFrom := standardFrom.Add(24 * time.Hour)
+
+	got, ok := priceForTier([]pricedTier{
+		{from: futureFrom, price: future},
+		{from: standardFrom, price: standard},
+		{price: intro},
+	}, standardFrom)
+	if !ok {
+		t.Fatal("priceForTier returned ok=false")
+	}
+	if got != standard {
+		t.Fatalf("priceForTier = %#v, want %#v", got, standard)
+	}
+}
+
 func TestLookupPrice_ZeroTimeFallsBackToNow(t *testing.T) {
 	if _, ok := lookupPrice("gpt-5", time.Time{}); !ok {
 		t.Fatal("lookupPrice with zero time should still resolve known models")

--- a/internal/stats/pricing_test.go
+++ b/internal/stats/pricing_test.go
@@ -1,8 +1,12 @@
 package stats
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestEstimateCost(t *testing.T) {
+	beforeSonnetStandard := time.Date(2026, 8, 31, 23, 59, 59, 0, time.UTC)
 	tests := []struct {
 		model   string
 		in, out int
@@ -18,14 +22,14 @@ func TestEstimateCost(t *testing.T) {
 		{"gpt-5.4", 1_000_000, 1_000_000, 1.25 + 10.00},
 		{"gpt-5.4-mini", 1_000_000, 1_000_000, 0.25 + 2.00},
 		{"gpt-5.3-codex", 1_000_000, 1_000_000, 1.25 + 10.00},
-		{"sonnet", 1_000_000, 1_000_000, 3.00 + 15.00},
+		{"sonnet", 1_000_000, 1_000_000, 2.00 + 10.00},
 		{"haiku", 1_000_000, 1_000_000, 1.00 + 5.00},
 		{"unknown-model", 1_000_000, 1_000_000, 0},
 		{"", 100, 50, 0},
 		{"o4-mini", 100, 50, 100.0/1_000_000*1.10 + 50.0/1_000_000*4.40},
 	}
 	for _, tt := range tests {
-		got := EstimateCost(tt.model, tt.in, tt.out)
+		got := EstimateCost(tt.model, tt.in, tt.out, beforeSonnetStandard)
 		diff := got - tt.want
 		if diff > 1e-9 || diff < -1e-9 {
 			t.Errorf("EstimateCost(%q, %d, %d) = %g, want %g", tt.model, tt.in, tt.out, got, tt.want)
@@ -53,6 +57,7 @@ func TestEstimateCostDetailed_ClaudeMatchesReportedTotalCost(t *testing.T) {
 		48071,   // usage.cache_creation_input_tokens (5m ephemeral)
 		1070865, // usage.cache_read_input_tokens
 		0,       // reasoning (Claude doesn't report)
+		time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
 	)
 	want := 0.6614377500000002
 	diff := got - want
@@ -65,12 +70,60 @@ func TestEstimateCostDetailed_CodexSubtractsCachedFromGrossInput(t *testing.T) {
 	// Codex `usage.input_tokens` is the gross prompt total; `cached_input_tokens`
 	// is a subset billed at the cache-read rate. The estimator must subtract
 	// the cached subset before applying the standard input price.
-	got := EstimateCostDetailed("gpt-5", 1_000_000, 100_000, 0, 800_000, 0)
+	got := EstimateCostDetailed("gpt-5", 1_000_000, 100_000, 0, 800_000, 0, time.Time{})
 	// Billed: 200k @ $1.25 + 100k @ $10 + 800k @ $0.125 = 0.25 + 1.00 + 0.10 = $1.35
 	want := 1.35
 	diff := got - want
 	if diff > 1e-9 || diff < -1e-9 {
 		t.Errorf("EstimateCostDetailed gpt-5 = %g, want %g", got, want)
+	}
+}
+
+func TestLookupPrice_ClaudeEffectiveDatedPricing(t *testing.T) {
+	intro := time.Date(2026, 8, 31, 23, 59, 59, 0, time.UTC)
+	standard := time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		model string
+		at    time.Time
+		want  modelPrice
+		ok    bool
+	}{
+		{name: "sonnet 5 intro explicit", model: "claude-sonnet-5", at: intro, want: sonnet5IntroPrice, ok: true},
+		{name: "sonnet alias intro", model: "sonnet", at: intro, want: sonnet5IntroPrice, ok: true},
+		{name: "sonnet 5 standard explicit", model: "claude-sonnet-5", at: standard, want: sonnet5StandardPrice, ok: true},
+		{name: "sonnet alias standard", model: "sonnet", at: standard, want: sonnet5StandardPrice, ok: true},
+		{name: "sonnet dated suffix", model: "claude-sonnet-5-20260701", at: intro, want: sonnet5IntroPrice, ok: true},
+		{name: "sonnet 4.6", model: "claude-sonnet-4-6", at: standard, want: sonnet46Price, ok: true},
+		{name: "opus alias", model: "opus", at: standard, want: opus48Price, ok: true},
+		{name: "opus 4.5", model: "claude-opus-4-5", at: standard, want: opus48Price, ok: true},
+		{name: "opus 4.6", model: "claude-opus-4-6", at: standard, want: opus48Price, ok: true},
+		{name: "opus 4.7", model: "claude-opus-4-7", at: standard, want: opus48Price, ok: true},
+		{name: "opus 4.8", model: "claude-opus-4-8", at: standard, want: opus48Price, ok: true},
+		{name: "opus 4.1 stays legacy", model: "claude-opus-4-1", at: standard, want: opus41Price, ok: true},
+		{name: "unknown", model: "unknown-model", at: standard, ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := lookupPrice(tt.model, tt.at)
+			if ok != tt.ok {
+				t.Fatalf("lookupPrice(%q) ok = %v, want %v", tt.model, ok, tt.ok)
+			}
+			if !ok {
+				return
+			}
+			if got != tt.want {
+				t.Fatalf("lookupPrice(%q) = %#v, want %#v", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLookupPrice_ZeroTimeFallsBackToNow(t *testing.T) {
+	if _, ok := lookupPrice("gpt-5", time.Time{}); !ok {
+		t.Fatal("lookupPrice with zero time should still resolve known models")
 	}
 }
 

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -426,6 +426,7 @@ func estimatedRunCost(ag *agent.Agent, cost, premiumRequests float64) float64 {
 			0,
 			ag.GetCacheReadInputTokens(),
 			ag.GetReasoningTokens(),
+			time.Now(),
 		)
 	}
 	return 0

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -426,7 +426,7 @@ func estimatedRunCost(ag *agent.Agent, cost, premiumRequests float64) float64 {
 			0,
 			ag.GetCacheReadInputTokens(),
 			ag.GetReasoningTokens(),
-			time.Now(),
+			ag.StartedAt,
 		)
 	}
 	return 0

--- a/internal/sybra/agent_completion_test.go
+++ b/internal/sybra/agent_completion_test.go
@@ -257,6 +257,19 @@ func TestEstimatedRunCost(t *testing.T) {
 			t.Errorf("estimatedRunCost copilot = %g, want %g", got, want)
 		}
 	})
+
+	t.Run("uses started time for dated pricing", func(t *testing.T) {
+		t.Parallel()
+		ag := &agent.Agent{
+			Provider:  "codex",
+			Model:     "claude-sonnet-5",
+			StartedAt: time.Date(2026, 8, 31, 23, 59, 59, 0, time.UTC),
+		}
+		ag.AddResultStats("", 0, 1_000_000, 1_000_000, 0)
+		if got, want := estimatedRunCost(ag, 0, 0), 12.0; got != want {
+			t.Errorf("estimatedRunCost dated = %g, want %g", got, want)
+		}
+	})
 }
 
 // itoa converts a small non-negative int to its decimal string representation

--- a/internal/sybra/e2e_stats_test.go
+++ b/internal/sybra/e2e_stats_test.go
@@ -42,7 +42,7 @@ func TestE2E_Stats_RecordedOnAgentComplete(t *testing.T) {
 			provider: "codex",
 			scenario: "success",
 			// Codex emits no cost — agent_completion estimates it via
-			// stats.EstimateCostDetailed("gpt-5.4", 100 in, 20 out, 0, 0, 0)
+			// stats.EstimateCostDetailed("gpt-5.4", 100 in, 20 out, 0, 0, 0, time.Now())
 			// = 100*1.25/1M + 20*10/1M = 0.000325.
 			wantCost:     0.000325,
 			wantIn:       100,

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -115,7 +115,7 @@ func estimateAgentRunUsage(run task.AgentRun) (agentRunUsageEstimate, bool) {
 		if err != nil {
 			continue
 		}
-		estimate, ok := estimateUsageFromEvents(run.Model, provider, events)
+		estimate, ok := estimateUsageFromEvents(run.Model, provider, events, run.StartedAt)
 		if ok {
 			return estimate, true
 		}
@@ -123,7 +123,7 @@ func estimateAgentRunUsage(run task.AgentRun) (agentRunUsageEstimate, bool) {
 	return agentRunUsageEstimate{}, false
 }
 
-func estimateUsageFromEvents(model, provider string, events []agent.StreamEvent) (agentRunUsageEstimate, bool) {
+func estimateUsageFromEvents(model, provider string, events []agent.StreamEvent, startedAt time.Time) (agentRunUsageEstimate, bool) {
 	var input, output, cacheCreate, cacheRead, reasoning int
 	var cost, premiumRequests float64
 	var resultSeen bool
@@ -148,7 +148,7 @@ func estimateUsageFromEvents(model, provider string, events []agent.StreamEvent)
 		case "copilot":
 			cost = stats.EstimateCopilotCost(premiumRequests)
 		case "codex", "claude":
-			cost = stats.EstimateCostDetailed(model, input, output, cacheCreate, cacheRead, reasoning)
+			cost = stats.EstimateCostDetailed(model, input, output, cacheCreate, cacheRead, reasoning, startedAt)
 		}
 	}
 	if cost == 0 && premiumRequests == 0 {

--- a/internal/sybra/svc_tasks_test.go
+++ b/internal/sybra/svc_tasks_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/task"
@@ -54,6 +55,41 @@ func TestTaskService_WithEstimatedAgentRunCosts(t *testing.T) {
 	}
 	if got.AgentRuns[3].CostUSD != 0.42 {
 		t.Fatalf("reported cost = %g, want 0.42", got.AgentRuns[3].CostUSD)
+	}
+}
+
+func TestEstimateUsageFromEvents_UsesRunStartedAtForDatedPricing(t *testing.T) {
+	t.Parallel()
+
+	events := []agent.StreamEvent{{
+		Type:         "result",
+		InputTokens:  1_000_000,
+		OutputTokens: 1_000_000,
+	}}
+	intro, ok := estimateUsageFromEvents(
+		"claude-sonnet-5",
+		"claude",
+		events,
+		time.Date(2026, 8, 31, 23, 59, 59, 0, time.UTC),
+	)
+	if !ok {
+		t.Fatal("intro estimate not produced")
+	}
+	if diff := intro.CostUSD - 12.0; diff > 1e-9 || diff < -1e-9 {
+		t.Fatalf("intro cost = %g, want 12", intro.CostUSD)
+	}
+
+	standard, ok := estimateUsageFromEvents(
+		"claude-sonnet-5",
+		"claude",
+		events,
+		time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC),
+	)
+	if !ok {
+		t.Fatal("standard estimate not produced")
+	}
+	if diff := standard.CostUSD - 18.0; diff > 1e-9 || diff < -1e-9 {
+		t.Fatalf("standard cost = %g, want 18", standard.CostUSD)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Agent cost reporting should account for provider effort consistently. Previously, missing effort metadata could under-specify cost calculations and leave provider-specific defaults uneven.

## Implementation

- Default agent runs to medium effort across providers when effort is not explicitly set.
- Carry effort through agent completion/task service paths so persisted run metadata remains consistent.
- Update pricing logic and tests to date model pricing with effort-aware coverage.