### PR TITLE
fix(workflow): recover stale branches during active workflows

### DIFF
--- a/internal/sybra/app_agents.go
+++ b/internal/sybra/app_agents.go
@@ -256,7 +256,9 @@ func (o *AgentOrchestrator) StartAgentWithAssignment(taskID, mode, prompt string
 		d, wtErr := o.worktrees.PrepareForTask(t, onPhase)
 		if wtErr != nil {
 			o.failWorktreeOp(opID, wtErr)
-			markRebaseBlocked(o.tasks, taskID, wtErr, o.logger, o.conflictRecovery)
+			if _, recovered := markRebaseBlockedWithRecoveryResult(o.tasks, taskID, wtErr, o.logger, o.conflictRecovery); recovered {
+				return nil, "", workflow.ErrDispatchInFlight
+			}
 			return nil, "", fmt.Errorf("worktree required for project task: %w", wtErr)
 		}
 		o.completeWorktreeOp(opID)
@@ -347,6 +349,17 @@ func markRebaseBlocked(tasks *task.Manager, taskID string, err error, logger *sl
 		logger.Error("worktree.rebase-block.status", "task_id", taskID, "err", uerr)
 	}
 	return true
+}
+
+func markRebaseBlockedWithRecoveryResult(tasks *task.Manager, taskID string, err error, logger *slog.Logger, recoverConflict func(string) bool) (handled, recovered bool) {
+	if recoverConflict == nil {
+		return markRebaseBlocked(tasks, taskID, err, logger, nil), false
+	}
+	wrappedRecover := func(id string) bool {
+		recovered = recoverConflict(id)
+		return recovered
+	}
+	return markRebaseBlocked(tasks, taskID, err, logger, wrappedRecover), recovered
 }
 
 // recordImplAgentStart emits the agent.started audit event and persists the

--- a/internal/sybra/app_rebase_recover_test.go
+++ b/internal/sybra/app_rebase_recover_test.go
@@ -146,6 +146,41 @@ func TestRecoverStaleBranchConflict_EscalatesWhenWorkflowAlreadyActive(t *testin
 	}
 }
 
+func TestRecoverStaleBranchConflict_CancelsActiveWorkflowBeforeDispatch(t *testing.T) {
+	r, tk := setupRebaseRecoveryReviewHandler(t, true)
+	tk.Workflow = &workflow.Execution{
+		WorkflowID:  "review-workflow",
+		CurrentStep: "code_review_staff",
+		State:       workflow.ExecRunning,
+	}
+	if _, err := r.tasks.Update(tk.ID, task.Update{Workflow: &tk.Workflow}); err != nil {
+		t.Fatal(err)
+	}
+
+	rebaseErr := fmt.Errorf("rebase x onto main: %w", worktree.ErrRebaseFailed)
+	handled, recovered := markRebaseBlockedWithRecoveryResult(r.tasks, tk.ID, rebaseErr, r.logger, r.recoverStaleBranchConflict)
+	if !handled {
+		t.Fatal("markRebaseBlockedWithRecoveryResult returned handled=false for a rebase failure")
+	}
+	if !recovered {
+		t.Fatal("markRebaseBlockedWithRecoveryResult did not report successful recovery")
+	}
+
+	got, err := r.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status == task.StatusHumanRequired {
+		t.Fatalf("status = %q, want conflict workflow dispatch instead of human-required", got.Status)
+	}
+	if got.Workflow == nil || got.Workflow.WorkflowID != "pr-conflict-fix-test" {
+		t.Fatalf("workflow = %+v, want pr-conflict-fix-test", got.Workflow)
+	}
+	if r.prTracker.Retries(tk.ID, github.PRIssueConflict) == 0 {
+		t.Fatal("conflict issue was not marked handled after workflow start")
+	}
+}
+
 func TestRecoverStaleBranchConflict_EscalatesWhenNoWorkflowMatches(t *testing.T) {
 	r, tk := setupRebaseRecoveryReviewHandler(t, false)
 
@@ -194,6 +229,7 @@ func setupRebaseRecoveryReviewHandler(t *testing.T, withConflictWorkflow bool) (
 	runGit(t, "", "init", "-b", "main", repo)
 	runGit(t, repo, "config", "user.email", "test@example.com")
 	runGit(t, repo, "config", "user.name", "Test User")
+	runGit(t, repo, "config", "commit.gpgsign", "false")
 	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("test\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -264,6 +264,16 @@ func (r *ReviewHandler) recoverStaleBranchConflict(taskID string) bool {
 	}
 	r.logger.Info("pr-monitor.rebase-block.recover-as-conflict",
 		"task_id", taskID, "pr", t.PRNumber)
+	if r.workflowEngine.HasActiveWorkflow(taskID) {
+		if priorStep, cancelErr := r.workflowEngine.CancelWorkflow(taskID, "rebase conflict recovery"); cancelErr != nil {
+			r.logger.Error("pr-monitor.rebase-block.cancel-active-workflow",
+				"task_id", taskID, "err", cancelErr)
+			return false
+		} else {
+			r.logger.Info("pr-monitor.rebase-block.cancelled-active-workflow",
+				"task_id", taskID, "step", priorStep)
+		}
+	}
 	return r.handlePRIssue(github.PRIssue{TaskID: taskID, Kind: github.PRIssueConflict, PR: pr})
 }
 

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -460,7 +460,9 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		}
 		d, wtErr := a.agentOrch.worktrees.PrepareForTask(t, nil)
 		if wtErr != nil {
-			markRebaseBlocked(a.tasks, taskID, wtErr, a.agentOrch.logger, a.agentOrch.conflictRecovery)
+			if _, recovered := markRebaseBlockedWithRecoveryResult(a.tasks, taskID, wtErr, a.agentOrch.logger, a.agentOrch.conflictRecovery); recovered {
+				return "", "", "", workflow.ErrDispatchInFlight
+			}
 			return "", "", "", wtErr
 		}
 		cfg.Dir = d


### PR DESCRIPTION
## Summary
- cancel the superseded active workflow before dispatching stale-branch conflict recovery
- return the existing benign dispatch-in-flight signal when rebase recovery starts another workflow
- add regression coverage for conflict recovery from an active workflow

## Verification
- env GOCACHE=/private/tmp/sybra-go-cache go test ./internal/sybra -run 'Test(MarkRebaseBlocked|RecoverStaleBranchConflict)'
- env GOCACHE=/private/tmp/sybra-go-cache go test ./internal/workflow -run 'TestDispatchEvent_AlreadyActiveRejected|TestExecRunAgent_DispatchInFlight)'
- git push hook ran Go tests and frontend svelte-check successfully