### PR TITLE
fix(agent): wire klaudiush hooks

### DIFF
--- a/docs/codex-setup.md
+++ b/docs/codex-setup.md
@@ -110,38 +110,42 @@ Existing Sybra skills (`/sybra-tasks`, `/sybra-triage`, `/sybra-plan`, etc.) are
 
 The orchestrator prompt (`orchestrator/CLAUDE.md`) governs the Sybra orchestrator session, which always runs as a Claude Code agent. Codex is used for implementation agents dispatched by the orchestrator, not for the orchestrator itself.
 
-## Lifecycle Hook Telemetry
+## Hook Telemetry And Validation
 
-Sybra injects observe-only lifecycle hooks into every `codex exec` invocation using inline `-c hooks.<Event>=...` config overrides. This is the only channel that survives Sybra's `--ignore-user-config --ignore-rules` flags — per-worktree `.codex/hooks.json` and `~/.codex` plugin files are explicitly ignored by those flags and do not fire.
+Sybra injects hooks into every `codex exec` invocation using inline `-c hooks.<Event>=...` config overrides. This is the only channel that survives Sybra's `--ignore-user-config --ignore-rules` flags — per-worktree `.codex/hooks.json` and `~/.codex` plugin files are explicitly ignored by those flags and do not fire.
 
 ### Instrumented events
 
-| Event | Audit type |
-|-------|-----------|
-| `SessionStart` | `codex.session.start` |
-| `SubagentStart` | `codex.subagent.start` |
-| `SubagentStop` | `codex.subagent.stop` |
-| `Stop` | `codex.session.stop` |
+| Event | Purpose |
+|-------|---------|
+| `PreToolUse` | Klaudiush validation before tool execution |
+| `SessionStart` | Observe-only `codex.session.start` audit event |
+| `SubagentStart` | Observe-only `codex.subagent.start` audit event |
+| `SubagentStop` | Observe-only `codex.subagent.stop` audit event |
+| `Stop` | Observe-only `codex.session.stop` audit event |
 
-`PreToolUse` and `PostToolUse` are deliberately excluded — per-tool-call hooks would sit on the agent's critical path.
+`PreToolUse` uses Codex's foreground command-hook default so klaudiush can deny unsafe git commands such as commits missing required `-s`/`-S` flags. Lifecycle hooks run in the background and remain fail-open telemetry.
 
 ### How it works
 
 For each event, Sybra appends a `-c` override to the `codex exec` command:
 
 ```
+-c 'hooks.PreToolUse=[{hooks=[{type="command",command="klaudiush --provider codex --event PreToolUse",timeout_seconds=30}]}]'
 -c 'hooks.SessionStart=[{hooks=[{type="command",command="sybra-cli hook SessionStart --task <id>",run_mode="background",timeout_seconds=5}]}]'
 ```
 
 The `--dangerously-bypass-hook-trust` flag is also passed so codex executes the hook without requiring a trusted source check.
 
-`sybra-cli hook <Event> --task <id>` is the hook receiver: it reads the JSON payload from stdin, maps it to a structural-only `audit.Event` (session_id, subagent_id, kind, model — never cwd, prompts, tool_input, or file paths), and appends it to the daily audit NDJSON (`~/.sybra/logs/audit/<date>.ndjson`). The receiver always exits 0 (fail-open) so hook errors never stall the agent run.
+`klaudiush` reads the provider hook payload from stdin and returns the provider-native permission decision JSON. Sybra omits the klaudiush hook only when the binary is not resolvable on `PATH` or adjacent to the Sybra binary.
+
+`sybra-cli hook <Event> --task <id>` is the lifecycle telemetry receiver: it reads the JSON payload from stdin, maps it to a structural-only `audit.Event` (session_id, subagent_id, kind, model — never cwd, prompts, tool_input, or file paths), and appends it to the daily audit NDJSON (`~/.sybra/logs/audit/<date>.ndjson`). The receiver always exits 0 (fail-open) so hook errors never stall the agent run.
 
 ### Fail-open behaviour
 
-Hooks are omitted (the codex run proceeds normally, without hooks) when:
-- `sybra-cli` is not on `PATH` and not adjacent to the Sybra binary
-- The resolved `sybra-cli` path contains shell-sensitive characters
+Hooks are omitted (the codex run proceeds normally, without the affected hook) when:
+- `klaudiush` or `sybra-cli` is not on `PATH` and not adjacent to the Sybra binary
+- The resolved hook binary path contains shell-sensitive characters
 - The task ID is empty or contains characters outside `[a-zA-Z0-9._/-]`
 
 ### Minimum supported codex version

--- a/internal/agent/codexhooks.go
+++ b/internal/agent/codexhooks.go
@@ -8,9 +8,8 @@ import (
 )
 
 // codexHookEvents are the low-frequency lifecycle events for which Sybra
-// registers observe-only hooks on codex invocations. Per-tool-call events
-// (PreToolUse, PostToolUse) are explicitly excluded — only session and
-// subagent boundaries are instrumented to keep hooks off the critical path.
+// registers observe-only hooks on codex invocations. Command validation is
+// handled separately by a foreground PreToolUse klaudiush hook.
 var codexHookEvents = []string{
 	"SessionStart",
 	"SubagentStart",
@@ -24,14 +23,22 @@ var codexHookEvents = []string{
 // executable is checked. Returns ("", false) if no shell-safe path is
 // resolvable; the caller must omit hooks in that case (fail-open).
 func resolveCodexHookBin() (string, bool) {
-	if _, err := exec.LookPath("sybra-cli"); err == nil {
-		return "sybra-cli", true
+	return resolveHookBin("sybra-cli")
+}
+
+func resolveKlaudiushHookBin() (string, bool) {
+	return resolveHookBin("klaudiush")
+}
+
+func resolveHookBin(name string) (string, bool) {
+	if _, err := exec.LookPath(name); err == nil {
+		return name, true
 	}
 	self, err := os.Executable()
 	if err != nil {
 		return "", false
 	}
-	adjacent := filepath.Join(filepath.Dir(self), "sybra-cli")
+	adjacent := filepath.Join(filepath.Dir(self), name)
 	if _, err := exec.LookPath(adjacent); err != nil {
 		return "", false
 	}
@@ -45,30 +52,49 @@ func resolveCodexHookBin() (string, bool) {
 
 // buildCodexHookArgs returns the -c override pairs and
 // --dangerously-bypass-hook-trust flag to append to a codex exec invocation.
-// If sybra-cli cannot be resolved to a shell-safe path, or taskID fails the
-// allowlist check, an empty slice is returned (fail-open — the run proceeds
+// If hook binaries cannot be resolved to shell-safe paths, or taskID fails the
+// allowlist check, those hooks are omitted (fail-open — the run proceeds
 // without hooks rather than erroring).
 func buildCodexHookArgs(taskID string) []string {
 	if !safeArgRe.MatchString(taskID) {
 		return nil
 	}
-	bin, ok := resolveCodexHookBin()
-	if !ok {
-		return nil
+
+	args := make([]string, 0, (len(codexHookEvents)+1)*2+1)
+
+	if bin, ok := resolveKlaudiushHookBin(); ok {
+		args = append(args, "-c", codexCommandHookValue(
+			"PreToolUse",
+			bin+" --provider codex --event PreToolUse",
+			"",
+			30,
+		))
 	}
 
-	args := make([]string, 0, len(codexHookEvents)*2+1)
-	for _, event := range codexHookEvents {
-		cmd := fmt.Sprintf("%s hook %s --task %s", bin, event, taskID)
-		// TOML inline-table value for the hooks.<Event> config key.
-		// Outer array: hook-filter entry. Inner hooks: the action list.
-		// run_mode=background keeps hooks off the critical path.
-		val := fmt.Sprintf(
-			`hooks.%s=[{hooks=[{type="command",command=%q,run_mode="background",timeout_seconds=5}]}]`,
-			event, cmd,
-		)
-		args = append(args, "-c", val)
+	if bin, ok := resolveCodexHookBin(); ok {
+		for _, event := range codexHookEvents {
+			cmd := fmt.Sprintf("%s hook %s --task %s", bin, event, taskID)
+			args = append(args, "-c", codexCommandHookValue(event, cmd, "background", 5))
+		}
+	}
+	if len(args) == 0 {
+		return nil
 	}
 	args = append(args, "--dangerously-bypass-hook-trust")
 	return args
+}
+
+func codexCommandHookValue(event, command, runMode string, timeoutSeconds int) string {
+	// TOML inline-table value for the hooks.<Event> config key.
+	// Outer array: hook-filter entry. Inner hooks: the action list.
+	if runMode == "" {
+		return fmt.Sprintf(
+			`hooks.%s=[{hooks=[{type="command",command=%q,timeout_seconds=%d}]}]`,
+			event, command, timeoutSeconds,
+		)
+	}
+	return fmt.Sprintf(
+		`hooks.%s=[{hooks=[{type="command",command=%q,run_mode=%q,timeout_seconds=%d}]}]`,
+		event, command, runMode, timeoutSeconds,
+	)
 }

--- a/internal/agent/codexhooks_test.go
+++ b/internal/agent/codexhooks_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"slices"
@@ -12,12 +13,28 @@ import (
 // prepends dir to PATH so resolveCodexHookBin finds it via exec.LookPath.
 func makeFakeSybraCLI(t *testing.T) string {
 	t.Helper()
+	return makeFakeHookBinary(t, "sybra-cli")
+}
+
+func makeFakeHookBinary(t *testing.T, name string) string {
+	t.Helper()
 	dir := t.TempDir()
-	fake := filepath.Join(dir, "sybra-cli")
+	fake := filepath.Join(dir, name)
 	if err := os.WriteFile(fake, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("create fake sybra-cli: %v", err)
+		t.Fatalf("create fake %s: %v", name, err)
 	}
 	t.Setenv("PATH", dir+":"+os.Getenv("PATH"))
+	return dir
+}
+
+func makeOnlyFakeHookBinary(t *testing.T, name string) string {
+	t.Helper()
+	dir := t.TempDir()
+	fake := filepath.Join(dir, name)
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("create fake %s: %v", name, err)
+	}
+	t.Setenv("PATH", dir)
 	return dir
 }
 
@@ -45,14 +62,21 @@ func TestBuildCodexHookArgs_FourEvents(t *testing.T) {
 	}
 }
 
-func TestBuildCodexHookArgs_NoOutOfScopeEvents(t *testing.T) {
-	makeFakeSybraCLI(t)
+func TestBuildCodexHookArgs_KlaudiushPreToolUse(t *testing.T) {
+	makeFakeHookBinary(t, "klaudiush")
 
 	args := buildCodexHookArgs("task-abc123")
+	found := false
 	for _, arg := range args {
-		if strings.Contains(arg, "PreToolUse") || strings.Contains(arg, "PostToolUse") {
-			t.Errorf("hook args contain out-of-scope event; arg=%q", arg)
+		if strings.HasPrefix(arg, "hooks.PreToolUse=") &&
+			strings.Contains(arg, "klaudiush --provider codex --event PreToolUse") &&
+			!strings.Contains(arg, `run_mode=`) {
+			found = true
+			break
 		}
+	}
+	if !found {
+		t.Errorf("klaudiush PreToolUse hook not found; args=%v", args)
 	}
 }
 
@@ -95,13 +119,34 @@ func TestBuildCodexHookArgs_TaskIDInjectionRejected(t *testing.T) {
 	}
 }
 
-func TestBuildCodexHookArgs_MissingBinaryReturnsNil(t *testing.T) {
-	// Point PATH to an empty dir with no sybra-cli.
+func TestBuildCodexHookArgs_MissingBinariesReturnsNil(t *testing.T) {
+	// Point PATH to an empty dir with no sybra-cli or klaudiush.
 	t.Setenv("PATH", t.TempDir())
 
 	args := buildCodexHookArgs("task-abc123")
 	if len(args) != 0 {
-		t.Errorf("expected nil when sybra-cli missing; got %v", args)
+		t.Errorf("expected nil when hook binaries are missing; got %v", args)
+	}
+}
+
+func TestBuildCodexHookArgs_KlaudiushOnlyStillHooks(t *testing.T) {
+	makeOnlyFakeHookBinary(t, "klaudiush")
+
+	args := buildCodexHookArgs("task-abc123")
+	if !slices.Contains(args, "--dangerously-bypass-hook-trust") {
+		t.Errorf("--dangerously-bypass-hook-trust missing; args=%v", args)
+	}
+	found := false
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "hooks.PreToolUse=") {
+			found = true
+		}
+		if strings.HasPrefix(arg, "hooks.SessionStart=") {
+			t.Errorf("sybra-cli telemetry hook should be absent without sybra-cli; args=%v", args)
+		}
+	}
+	if !found {
+		t.Errorf("klaudiush PreToolUse hook missing; args=%v", args)
 	}
 }
 
@@ -114,9 +159,50 @@ func TestBuildCodexHookArgs_CommandContainsTaskID(t *testing.T) {
 	// Each hook override value must embed the task ID.
 	for i, arg := range args {
 		if arg == "-c" && i+1 < len(args) {
+			if strings.HasPrefix(args[i+1], "hooks.PreToolUse=") {
+				continue
+			}
 			if !strings.Contains(args[i+1], taskID) {
 				t.Errorf("-c value at index %d does not contain taskID %q; value=%q", i+1, taskID, args[i+1])
 			}
 		}
+	}
+}
+
+func TestBuildClaudeHookSettings_KlaudiushPreToolUse(t *testing.T) {
+	makeFakeHookBinary(t, "klaudiush")
+
+	settings := buildClaudeHookSettings("", false)
+	if settings == "" {
+		t.Fatal("expected Claude hook settings")
+	}
+	if !strings.Contains(settings, "klaudiush --hook-type PreToolUse") {
+		t.Fatalf("settings missing klaudiush command: %s", settings)
+	}
+
+	var decoded struct {
+		Hooks map[string][]claudeHookEntry `json:"hooks"`
+	}
+	if err := json.Unmarshal([]byte(settings), &decoded); err != nil {
+		t.Fatalf("settings is not JSON: %v\n%s", err, settings)
+	}
+	entries := decoded.Hooks["PreToolUse"]
+	if len(entries) != 1 || len(entries[0].Hooks) != 1 {
+		t.Fatalf("PreToolUse hooks = %+v, want one klaudiush hook", entries)
+	}
+	if got := entries[0].Hooks[0].Type; got != "command" {
+		t.Errorf("hook type = %q, want command", got)
+	}
+}
+
+func TestBuildClaudeHookSettings_KeepsApprovalHook(t *testing.T) {
+	makeFakeHookBinary(t, "klaudiush")
+
+	settings := buildClaudeHookSettings("127.0.0.1:12345", true)
+	if !strings.Contains(settings, "klaudiush --hook-type PreToolUse") {
+		t.Fatalf("settings missing klaudiush command: %s", settings)
+	}
+	if !strings.Contains(settings, "http://127.0.0.1:12345/hooks/pre-tool-use") {
+		t.Fatalf("settings missing approval hook: %s", settings)
 	}
 }

--- a/internal/agent/provider_claude.go
+++ b/internal/agent/provider_claude.go
@@ -42,6 +42,9 @@ func (claudeProvider) BuildHeadlessInvocation(a *Agent, cfg RunConfig) (headless
 		args = append(args, "--resume", sid)
 	}
 	args = append(args, claudePermissionArgs(cfg.AllowedTools, cfg.RequirePermissions, cfg.HeadlessPermissionMode)...)
+	if hookSettings := buildClaudeHookSettings("", false); hookSettings != "" {
+		args = append(args, "--settings", hookSettings)
+	}
 	args = append(args, effortArgs(a.ReasoningEffort)...)
 	if a.Model != "" {
 		args = append(args, "--model", a.Model)

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -108,17 +108,65 @@ func (m *Manager) convoCommonArgs(a *Agent, cfg RunConfig) []string {
 	if a.Model != "" {
 		args = append(args, "--model", a.Model)
 	}
-	// Only wire the approval hook for agents that actually need permission checks.
-	// Agents with --dangerously-skip-permissions should not be blocked by the hook.
 	needsApproval := cfg.RequirePermissions || cfg.PermissionMode != ""
-	if m.approvalAddr != "" && needsApproval {
-		hookSettings := fmt.Sprintf(
-			`{"hooks":{"PreToolUse":[{"matcher":"","hooks":[{"type":"http","url":"http://%s/hooks/pre-tool-use","timeout":300}]}]}}`,
-			m.approvalAddr,
-		)
+	if hookSettings := buildClaudeHookSettings(m.approvalAddr, needsApproval); hookSettings != "" {
 		args = append(args, "--settings", hookSettings)
 	}
 	return args
+}
+
+type claudeHookSettings struct {
+	Hooks map[string][]claudeHookEntry `json:"hooks"`
+}
+
+type claudeHookEntry struct {
+	Matcher string             `json:"matcher"`
+	Hooks   []claudeHookAction `json:"hooks"`
+}
+
+type claudeHookAction struct {
+	Type    string `json:"type"`
+	Command string `json:"command,omitempty"`
+	URL     string `json:"url,omitempty"`
+	Timeout int    `json:"timeout"`
+}
+
+func buildClaudeHookSettings(approvalAddr string, needsApproval bool) string {
+	var actions []claudeHookAction
+	if bin, ok := resolveKlaudiushHookBin(); ok {
+		actions = append(actions, claudeHookAction{
+			Type:    "command",
+			Command: bin + " --hook-type PreToolUse",
+			Timeout: 30,
+		})
+	}
+
+	// Only wire the approval hook for agents that actually need permission checks.
+	// Agents with --dangerously-skip-permissions still get klaudiush validation,
+	// but should not block on Sybra's human approval server.
+	if approvalAddr != "" && needsApproval {
+		actions = append(actions, claudeHookAction{
+			Type:    "http",
+			URL:     fmt.Sprintf("http://%s/hooks/pre-tool-use", approvalAddr),
+			Timeout: 300,
+		})
+	}
+	if len(actions) == 0 {
+		return ""
+	}
+	settings := claudeHookSettings{
+		Hooks: map[string][]claudeHookEntry{
+			"PreToolUse": {{
+				Matcher: "",
+				Hooks:   actions,
+			}},
+		},
+	}
+	data, err := json.Marshal(settings)
+	if err != nil {
+		return ""
+	}
+	return string(data)
 }
 
 func (m *Manager) startConvoProcess(ctx context.Context, a *Agent, cfg RunConfig) (*exec.Cmd, io.ReadCloser, *bytes.Buffer, error) {

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -1496,9 +1496,25 @@ func TestBuildHeadlessInvocation_CodexHooksAbsentWithEmptyTaskID(t *testing.T) {
 	}
 }
 
-// TestBuildHeadlessInvocation_Claude_NoHooks verifies that Claude and Copilot
-// invocations never receive codex hook args regardless of TaskID.
-func TestBuildHeadlessInvocation_Claude_NoHooks(t *testing.T) {
+func TestBuildHeadlessInvocation_ClaudeKlaudiushHookPresent(t *testing.T) {
+	makeFakeHookBinary(t, "klaudiush")
+
+	a := &Agent{ID: "a", Provider: "claude", TaskID: "task-abc123"}
+	_, args, _, _, err := buildHeadlessInvocation(a, RunConfig{Prompt: "do stuff"})
+	if err != nil {
+		t.Fatalf("buildHeadlessInvocation: %v", err)
+	}
+	for i, arg := range args {
+		if arg == "--settings" && i+1 < len(args) && strings.Contains(args[i+1], "klaudiush --hook-type PreToolUse") {
+			return
+		}
+	}
+	t.Fatalf("Claude headless args missing klaudiush --settings hook: %v", args)
+}
+
+// TestBuildHeadlessInvocation_NonCodex_NoCodexHookArgs verifies that Claude and
+// Copilot invocations never receive codex hook args regardless of TaskID.
+func TestBuildHeadlessInvocation_NonCodex_NoCodexHookArgs(t *testing.T) {
 	makeFakeSybraCLI(t)
 
 	for _, provider := range []string{"claude", "copilot"} {


### PR DESCRIPTION
## Summary
- inject klaudiush PreToolUse validation into Codex invocations through inline hook config
- inject klaudiush PreToolUse validation into Claude headless and conversational invocations
- keep Codex lifecycle telemetry hooks and document the validation behavior

## Verification
- go test ./internal/agent
- push hook: go test ./... and frontend svelte-check

## Notes
- Copilot CLI does not currently expose a provider-native hook API comparable to Claude or Codex, so this PR does not pretend to hook Copilot. A provider-agnostic commit verification gate should cover Copilot and hook-missing environments next.