### PR TITLE
feat(abtest): add prompt and skill experiment schema

### DIFF
--- a/internal/abtest/model.go
+++ b/internal/abtest/model.go
@@ -1,5 +1,7 @@
 package abtest
 
+import "strings"
+
 // Config controls deterministic A/B assignment for workflow agent runs.
 type Config struct {
 	Enabled              *bool        `yaml:"enabled" json:"enabled"`
@@ -10,11 +12,21 @@ type Config struct {
 // Experiment selects among variants for matching workflow roles.
 type Experiment struct {
 	ID             string    `yaml:"id" json:"id"`
+	Kind           string    `yaml:"kind,omitempty" json:"kind,omitempty"`
 	Enabled        *bool     `yaml:"enabled" json:"enabled"`
 	AssignmentUnit string    `yaml:"assignment_unit" json:"assignmentUnit"`      // "task" or "stage"
 	Bracket        string    `yaml:"bracket,omitempty" json:"bracket,omitempty"` // "cheap" or "expensive"
+	Subject        *Subject  `yaml:"subject,omitempty" json:"subject,omitempty"`
 	Roles          []string  `yaml:"roles" json:"roles"`
 	Variants       []Variant `yaml:"variants" json:"variants"`
+}
+
+// Subject identifies the workflow target for prompt and skill experiments.
+type Subject struct {
+	WorkflowID string `yaml:"workflow_id,omitempty" json:"workflowId,omitempty"`
+	StepID     string `yaml:"step_id,omitempty" json:"stepId,omitempty"`
+	Role       string `yaml:"role,omitempty" json:"role,omitempty"`
+	SkillName  string `yaml:"skill_name,omitempty" json:"skillName,omitempty"`
 }
 
 // Variant is one provider/model arm of an experiment.
@@ -24,12 +36,15 @@ type Variant struct {
 	Model           string `yaml:"model" json:"model"`
 	ReasoningEffort string `yaml:"reasoning_effort,omitempty" json:"reasoningEffort,omitempty"`
 	Tier            string `yaml:"tier,omitempty" json:"tier,omitempty"` // "cheap" or "expensive"
+	Version         string `yaml:"version,omitempty" json:"version,omitempty"`
+	Digest          string `yaml:"digest,omitempty" json:"digest,omitempty"`
 	Weight          int    `yaml:"weight" json:"weight"`
 }
 
 // Assignment is the durable identity selected for a workflow stage.
 type Assignment struct {
 	ExperimentID    string
+	Kind            string
 	VariantID       string
 	Provider        string
 	Model           string
@@ -75,6 +90,16 @@ func DefaultConfig() Config {
 	}
 }
 
+// Validate checks all configured experiments, including disabled experiments.
+func (c Config) Validate() error {
+	for i := range c.Experiments {
+		if err := validateExperiment(c.Experiments[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // EnabledValue reports whether A/B assignment should run.
 func (c Config) EnabledValue() bool {
 	return c.Enabled == nil || *c.Enabled
@@ -82,4 +107,12 @@ func (c Config) EnabledValue() bool {
 
 func (e Experiment) EnabledValue() bool {
 	return e.Enabled == nil || *e.Enabled
+}
+
+func (e Experiment) KindValue() string {
+	kind := strings.TrimSpace(e.Kind)
+	if kind == "" {
+		return "model"
+	}
+	return kind
 }

--- a/internal/abtest/model.go
+++ b/internal/abtest/model.go
@@ -93,7 +93,7 @@ func DefaultConfig() Config {
 // Validate checks all configured experiments, including disabled experiments.
 func (c Config) Validate() error {
 	for i := range c.Experiments {
-		if err := validateExperiment(c.Experiments[i]); err != nil {
+		if err := validateExperiment(c.Experiments[i], nil); err != nil {
 			return err
 		}
 	}

--- a/internal/abtest/selector.go
+++ b/internal/abtest/selector.go
@@ -151,8 +151,8 @@ func validateExperimentSubject(exp Experiment) error {
 	if exp.Subject == nil {
 		return fmt.Errorf("abtest: experiment %q kind %q requires subject", exp.ID, exp.KindValue())
 	}
-	if strings.TrimSpace(exp.Subject.StepID) == "" && strings.TrimSpace(exp.Subject.Role) == "" {
-		return fmt.Errorf("abtest: experiment %q kind %q requires subject step_id or role", exp.ID, exp.KindValue())
+	if strings.TrimSpace(exp.Subject.WorkflowID) == "" && strings.TrimSpace(exp.Subject.StepID) == "" && strings.TrimSpace(exp.Subject.Role) == "" {
+		return fmt.Errorf("abtest: experiment %q kind %q requires subject workflow_id, step_id, or role", exp.ID, exp.KindValue())
 	}
 	if exp.KindValue() == "skill" && strings.TrimSpace(exp.Subject.SkillName) == "" {
 		return fmt.Errorf("abtest: experiment %q kind %q requires subject skill_name", exp.ID, exp.KindValue())

--- a/internal/abtest/selector.go
+++ b/internal/abtest/selector.go
@@ -32,9 +32,6 @@ func SelectEligible(cfg Config, taskID, role, stepID string, providerAllowed fun
 }
 
 func selectFromExperiment(exp Experiment, taskID, role, stepID string, providerAllowed func(string) bool) (Assignment, bool, error) {
-	if strings.TrimSpace(exp.ID) == "" {
-		return Assignment{}, false, fmt.Errorf("abtest: experiment id is required")
-	}
 	if err := validateExperiment(exp); err != nil {
 		return Assignment{}, false, err
 	}
@@ -45,8 +42,6 @@ func selectFromExperiment(exp Experiment, taskID, role, stepID string, providerA
 	key := taskID
 	if unit == "stage" {
 		key = strings.Join([]string{taskID, role, stepID}, "|")
-	} else if unit != "task" {
-		return Assignment{}, false, fmt.Errorf("abtest: experiment %q has invalid assignment_unit %q", exp.ID, exp.AssignmentUnit)
 	}
 	eligible, total := EligibleVariants(exp, providerAllowed)
 	if total <= 0 {
@@ -61,6 +56,7 @@ func selectFromExperiment(exp Experiment, taskID, role, stepID string, providerA
 		if pick < acc {
 			return Assignment{
 				ExperimentID:    exp.ID,
+				Kind:            exp.KindValue(),
 				VariantID:       v.ID,
 				Provider:        v.Provider,
 				Model:           v.Model,
@@ -101,11 +97,27 @@ func roleMatches(roles []string, role string) bool {
 }
 
 func validateExperiment(exp Experiment) error {
+	if strings.TrimSpace(exp.ID) == "" {
+		return fmt.Errorf("abtest: experiment id is required")
+	}
+	switch exp.KindValue() {
+	case "model", "prompt", "skill", "compound":
+	default:
+		return fmt.Errorf("abtest: experiment %q has invalid kind %q", exp.ID, exp.Kind)
+	}
+	switch exp.AssignmentUnit {
+	case "", "stage", "task":
+	default:
+		return fmt.Errorf("abtest: experiment %q has invalid assignment_unit %q", exp.ID, exp.AssignmentUnit)
+	}
 	bracket := strings.TrimSpace(exp.Bracket)
 	switch bracket {
 	case "", "cheap", "expensive":
 	default:
 		return fmt.Errorf("abtest: experiment %q has invalid bracket %q", exp.ID, exp.Bracket)
+	}
+	if err := validateExperimentSubject(exp); err != nil {
+		return err
 	}
 	seen := map[string]bool{}
 	for i := range exp.Variants {
@@ -123,6 +135,50 @@ func validateExperiment(exp Experiment) error {
 			return fmt.Errorf("abtest: experiment %q has duplicate variant id %q", exp.ID, v.ID)
 		}
 		seen[v.ID] = true
+	}
+	if err := validatePromptSkillHomogeneity(exp); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateExperimentSubject(exp Experiment) error {
+	switch exp.KindValue() {
+	case "prompt", "skill":
+	default:
+		return nil
+	}
+	if exp.Subject == nil {
+		return fmt.Errorf("abtest: experiment %q kind %q requires subject", exp.ID, exp.KindValue())
+	}
+	if strings.TrimSpace(exp.Subject.StepID) == "" && strings.TrimSpace(exp.Subject.Role) == "" {
+		return fmt.Errorf("abtest: experiment %q kind %q requires subject step_id or role", exp.ID, exp.KindValue())
+	}
+	return nil
+}
+
+func validatePromptSkillHomogeneity(exp Experiment) error {
+	switch exp.KindValue() {
+	case "prompt", "skill":
+	default:
+		return nil
+	}
+	eligible, _ := EligibleVariants(exp, nil)
+	if len(eligible) < 2 {
+		return nil
+	}
+	base := eligible[0]
+	for i := 1; i < len(eligible); i++ {
+		v := eligible[i]
+		if v.Provider != base.Provider {
+			return fmt.Errorf("abtest: experiment %q provider mismatch on variant %q", exp.ID, v.ID)
+		}
+		if v.Model != base.Model {
+			return fmt.Errorf("abtest: experiment %q model mismatch on variant %q", exp.ID, v.ID)
+		}
+		if v.ReasoningEffort != base.ReasoningEffort {
+			return fmt.Errorf("abtest: experiment %q reasoning_effort mismatch on variant %q", exp.ID, v.ID)
+		}
 	}
 	return nil
 }

--- a/internal/abtest/selector.go
+++ b/internal/abtest/selector.go
@@ -32,7 +32,7 @@ func SelectEligible(cfg Config, taskID, role, stepID string, providerAllowed fun
 }
 
 func selectFromExperiment(exp Experiment, taskID, role, stepID string, providerAllowed func(string) bool) (Assignment, bool, error) {
-	if err := validateExperiment(exp); err != nil {
+	if err := validateExperiment(exp, providerAllowed); err != nil {
 		return Assignment{}, false, err
 	}
 	unit := exp.AssignmentUnit
@@ -96,7 +96,7 @@ func roleMatches(roles []string, role string) bool {
 	return slices.Contains(roles, role)
 }
 
-func validateExperiment(exp Experiment) error {
+func validateExperiment(exp Experiment, providerAllowed func(string) bool) error {
 	if strings.TrimSpace(exp.ID) == "" {
 		return fmt.Errorf("abtest: experiment id is required")
 	}
@@ -136,7 +136,7 @@ func validateExperiment(exp Experiment) error {
 		}
 		seen[v.ID] = true
 	}
-	if err := validatePromptSkillHomogeneity(exp); err != nil {
+	if err := validatePromptSkillHomogeneity(exp, providerAllowed); err != nil {
 		return err
 	}
 	return nil
@@ -154,16 +154,19 @@ func validateExperimentSubject(exp Experiment) error {
 	if strings.TrimSpace(exp.Subject.StepID) == "" && strings.TrimSpace(exp.Subject.Role) == "" {
 		return fmt.Errorf("abtest: experiment %q kind %q requires subject step_id or role", exp.ID, exp.KindValue())
 	}
+	if exp.KindValue() == "skill" && strings.TrimSpace(exp.Subject.SkillName) == "" {
+		return fmt.Errorf("abtest: experiment %q kind %q requires subject skill_name", exp.ID, exp.KindValue())
+	}
 	return nil
 }
 
-func validatePromptSkillHomogeneity(exp Experiment) error {
+func validatePromptSkillHomogeneity(exp Experiment, providerAllowed func(string) bool) error {
 	switch exp.KindValue() {
 	case "prompt", "skill":
 	default:
 		return nil
 	}
-	eligible, _ := EligibleVariants(exp, nil)
+	eligible, _ := EligibleVariants(exp, providerAllowed)
 	if len(eligible) < 2 {
 		return nil
 	}

--- a/internal/abtest/selector_test.go
+++ b/internal/abtest/selector_test.go
@@ -2,14 +2,23 @@ package abtest
 
 import (
 	"fmt"
+	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestSelectDeterministic(t *testing.T) {
 	cfg := DefaultConfig()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("DefaultConfig().Validate: %v", err)
+	}
 	a, ok, err := Select(cfg, "task-1", "implementation", "implement")
 	if err != nil || !ok {
 		t.Fatalf("Select: ok=%v err=%v", ok, err)
+	}
+	if a.Kind != "model" {
+		t.Fatalf("Kind = %q, want model", a.Kind)
 	}
 	for range 10 {
 		got, ok, err := Select(cfg, "task-1", "implementation", "implement")
@@ -225,5 +234,262 @@ func TestSelectEligibleSkipsUnavailableProvider(t *testing.T) {
 	}
 	if a.VariantID != "available" {
 		t.Fatalf("VariantID = %q, want available", a.VariantID)
+	}
+}
+
+func TestConfigValidateChecksDisabledExperiments(t *testing.T) {
+	disabled := false
+	cfg := Config{Experiments: []Experiment{{
+		ID:      "disabled-invalid",
+		Enabled: &disabled,
+		Kind:    "bogus",
+		Variants: []Variant{
+			{ID: "v", Provider: "claude", Model: "sonnet", Weight: 1},
+		},
+	}}}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Validate should reject disabled invalid experiment")
+	}
+}
+
+func TestConfigValidatePromptAndSkillYAML(t *testing.T) {
+	raw := []byte(`
+enabled: true
+experiments:
+  - id: prompt-copy
+    kind: prompt
+    assignment_unit: stage
+    subject:
+      workflow_id: test-workflow
+      step_id: draft_prompt
+      role: implementation
+    variants:
+      - id: control
+        provider: claude
+        model: sonnet
+        reasoning_effort: medium
+        version: v1
+        digest: sha256:control
+        weight: 1
+      - id: treatment
+        provider: claude
+        model: sonnet
+        reasoning_effort: medium
+        version: v2
+        digest: sha256:treatment
+        weight: 1
+  - id: skill-choice
+    kind: skill
+    assignment_unit: task
+    subject:
+      role: review
+      skill_name: sybra-test
+    variants:
+      - id: control
+        provider: codex
+        model: gpt-5.5
+        weight: 1
+      - id: treatment
+        provider: codex
+        model: gpt-5.5
+        version: v2
+        digest: sha256:skill
+        weight: 1
+`)
+	var cfg Config
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if got := cfg.Experiments[0].Subject.WorkflowID; got != "test-workflow" {
+		t.Fatalf("workflow_id = %q", got)
+	}
+	if got := cfg.Experiments[0].Variants[1].Version; got != "v2" {
+		t.Fatalf("version = %q", got)
+	}
+	if got := cfg.Experiments[1].Subject.SkillName; got != "sybra-test" {
+		t.Fatalf("skill_name = %q", got)
+	}
+	if got := cfg.Experiments[1].Variants[1].Digest; got != "sha256:skill" {
+		t.Fatalf("digest = %q", got)
+	}
+}
+
+func TestConfigValidatePromptSkillRejectsProviderModelReasoningDrift(t *testing.T) {
+	tests := []struct {
+		name       string
+		kind       string
+		variant    Variant
+		wantFields []string
+	}{
+		{
+			name:    "prompt provider",
+			kind:    "prompt",
+			variant: Variant{ID: "bad-provider", Provider: "codex", Model: "sonnet", ReasoningEffort: "medium", Weight: 1},
+			wantFields: []string{
+				`experiment "prompt-provider"`,
+				"provider",
+				`variant "bad-provider"`,
+			},
+		},
+		{
+			name:    "prompt model",
+			kind:    "prompt",
+			variant: Variant{ID: "bad-model", Provider: "claude", Model: "opus", ReasoningEffort: "medium", Weight: 1},
+			wantFields: []string{
+				`experiment "prompt-model"`,
+				"model",
+				`variant "bad-model"`,
+			},
+		},
+		{
+			name:    "skill reasoning",
+			kind:    "skill",
+			variant: Variant{ID: "bad-reasoning", Provider: "claude", Model: "sonnet", ReasoningEffort: "high", Weight: 1},
+			wantFields: []string{
+				`experiment "skill-reasoning"`,
+				"reasoning_effort",
+				`variant "bad-reasoning"`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expID := strings.ReplaceAll(tt.name, " ", "-")
+			cfg := Config{Experiments: []Experiment{{
+				ID:      expID,
+				Kind:    tt.kind,
+				Subject: &Subject{StepID: "implement"},
+				Variants: []Variant{
+					{ID: "base", Provider: "claude", Model: "sonnet", ReasoningEffort: "medium", Weight: 1},
+					tt.variant,
+				},
+			}}}
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatal("Validate should reject prompt/skill model attribution drift")
+			}
+			msg := err.Error()
+			for _, want := range tt.wantFields {
+				if !strings.Contains(msg, want) {
+					t.Fatalf("error %q does not contain %q", msg, want)
+				}
+			}
+		})
+	}
+}
+
+func TestConfigValidateCompoundAllowsProviderModelReasoningDrift(t *testing.T) {
+	cfg := Config{Experiments: []Experiment{{
+		ID:   "compound",
+		Kind: "compound",
+		Variants: []Variant{
+			{ID: "claude", Provider: "claude", Model: "sonnet", ReasoningEffort: "medium", Weight: 1},
+			{ID: "codex", Provider: "codex", Model: "gpt-5.5", ReasoningEffort: "high", Weight: 1},
+		},
+	}}}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+func TestConfigValidateRejectsInvalidKindAndAssignmentUnit(t *testing.T) {
+	tests := []struct {
+		name string
+		exp  Experiment
+	}{
+		{
+			name: "empty id",
+			exp: Experiment{
+				Variants: []Variant{{ID: "v", Provider: "claude", Model: "sonnet", Weight: 1}},
+			},
+		},
+		{
+			name: "invalid kind",
+			exp: Experiment{
+				ID:       "bad-kind",
+				Kind:     "Prompt",
+				Variants: []Variant{{ID: "v", Provider: "claude", Model: "sonnet", Weight: 1}},
+			},
+		},
+		{
+			name: "invalid assignment_unit",
+			exp: Experiment{
+				ID:             "bad-unit",
+				AssignmentUnit: "workflow",
+				Variants:       []Variant{{ID: "v", Provider: "claude", Model: "sonnet", Weight: 1}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := (Config{Experiments: []Experiment{tt.exp}}).Validate(); err == nil {
+				t.Fatal("Validate should reject invalid experiment")
+			}
+		})
+	}
+}
+
+func TestConfigValidateRejectsMissingPromptSkillSubject(t *testing.T) {
+	tests := []struct {
+		name    string
+		subject *Subject
+	}{
+		{name: "missing", subject: nil},
+		{name: "whitespace", subject: &Subject{StepID: " \t", Role: "  "}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{Experiments: []Experiment{{
+				ID:      "prompt-subject-" + tt.name,
+				Kind:    "prompt",
+				Subject: tt.subject,
+				Variants: []Variant{
+					{ID: "v", Provider: "claude", Model: "sonnet", Weight: 1},
+				},
+			}}}
+			if err := cfg.Validate(); err == nil {
+				t.Fatal("Validate should reject missing prompt subject")
+			}
+		})
+	}
+}
+
+func TestConfigValidateIgnoresZeroWeightPromptSkillDrift(t *testing.T) {
+	for _, kind := range []string{"prompt", "skill"} {
+		t.Run(kind, func(t *testing.T) {
+			cfg := Config{Experiments: []Experiment{{
+				ID:      kind + "-zero-weight",
+				Kind:    kind,
+				Subject: &Subject{Role: "implementation"},
+				Variants: []Variant{
+					{ID: "base", Provider: "claude", Model: "sonnet", ReasoningEffort: "medium", Weight: 1},
+					{ID: "ignored", Provider: "codex", Model: "gpt-5.5", ReasoningEffort: "high", Weight: 0},
+				},
+			}}}
+			if err := cfg.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+		})
+	}
+}
+
+func TestConfigValidateDuplicateVariantIDOnlyChecksPositiveWeight(t *testing.T) {
+	cfg := Config{Experiments: []Experiment{{
+		ID: "duplicates",
+		Variants: []Variant{
+			{ID: "same", Provider: "claude", Model: "sonnet", Weight: 1},
+			{ID: "same", Provider: "codex", Model: "gpt-5.5", Weight: 0},
+		},
+	}}}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	cfg.Experiments[0].Variants[1].Weight = 1
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Validate should reject duplicate positive-weight variant ids")
 	}
 }

--- a/internal/abtest/selector_test.go
+++ b/internal/abtest/selector_test.go
@@ -317,6 +317,28 @@ experiments:
 	}
 }
 
+func TestConfigValidatePromptAndSkillAllowWorkflowOnlySubject(t *testing.T) {
+	for _, kind := range []string{"prompt", "skill"} {
+		t.Run(kind, func(t *testing.T) {
+			subject := &Subject{WorkflowID: "simple-task"}
+			if kind == "skill" {
+				subject.SkillName = "sybra-test"
+			}
+			cfg := Config{Experiments: []Experiment{{
+				ID:      kind + "-workflow-only",
+				Kind:    kind,
+				Subject: subject,
+				Variants: []Variant{
+					{ID: "v", Provider: "claude", Model: "sonnet", Weight: 1},
+				},
+			}}}
+			if err := cfg.Validate(); err != nil {
+				t.Fatalf("Validate: %v", err)
+			}
+		})
+	}
+}
+
 func TestConfigValidatePromptSkillRejectsProviderModelReasoningDrift(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -442,7 +464,7 @@ func TestConfigValidateRejectsMissingPromptSkillSubject(t *testing.T) {
 		subject *Subject
 	}{
 		{name: "missing", subject: nil},
-		{name: "whitespace", subject: &Subject{StepID: " \t", Role: "  "}},
+		{name: "whitespace", subject: &Subject{WorkflowID: "  ", StepID: " \t", Role: "  "}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/abtest/selector_test.go
+++ b/internal/abtest/selector_test.go
@@ -358,10 +358,14 @@ func TestConfigValidatePromptSkillRejectsProviderModelReasoningDrift(t *testing.
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			expID := strings.ReplaceAll(tt.name, " ", "-")
+			subject := &Subject{StepID: "implement"}
+			if tt.kind == "skill" {
+				subject.SkillName = "sybra-test"
+			}
 			cfg := Config{Experiments: []Experiment{{
 				ID:      expID,
 				Kind:    tt.kind,
-				Subject: &Subject{StepID: "implement"},
+				Subject: subject,
 				Variants: []Variant{
 					{ID: "base", Provider: "claude", Model: "sonnet", ReasoningEffort: "medium", Weight: 1},
 					tt.variant,
@@ -457,13 +461,60 @@ func TestConfigValidateRejectsMissingPromptSkillSubject(t *testing.T) {
 	}
 }
 
+func TestConfigValidateRejectsMissingSkillName(t *testing.T) {
+	cfg := Config{Experiments: []Experiment{{
+		ID:      "skill-no-name",
+		Kind:    "skill",
+		Subject: &Subject{StepID: "implement"},
+		Variants: []Variant{
+			{ID: "v", Provider: "claude", Model: "sonnet", Weight: 1},
+		},
+	}}}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate should reject skill experiment without subject skill_name")
+	}
+	if !strings.Contains(err.Error(), "skill_name") {
+		t.Fatalf("error %q does not contain %q", err.Error(), "skill_name")
+	}
+}
+
+func TestSelectIgnoresProviderDriftOnIneligibleVariant(t *testing.T) {
+	enabled := true
+	cfg := Config{Enabled: &enabled, Experiments: []Experiment{{
+		ID:             "prompt-mixed-provider",
+		Kind:           "prompt",
+		Enabled:        &enabled,
+		AssignmentUnit: "task",
+		Roles:          []string{"implementation"},
+		Subject:        &Subject{StepID: "implement"},
+		Variants: []Variant{
+			{ID: "claude-variant", Provider: "claude", Model: "sonnet", ReasoningEffort: "medium", Weight: 1},
+			{ID: "codex-variant", Provider: "codex", Model: "gpt-5.5", ReasoningEffort: "medium", Weight: 1},
+		},
+	}}}
+	_, ok, err := SelectEligible(cfg, "task-1", "implementation", "implement", func(provider string) bool {
+		return provider == "claude"
+	})
+	if err != nil {
+		t.Fatalf("SelectEligible should not fail homogeneity check when the drifting variant is ineligible: %v", err)
+	}
+	if !ok {
+		t.Fatal("SelectEligible ok = false, want true")
+	}
+}
+
 func TestConfigValidateIgnoresZeroWeightPromptSkillDrift(t *testing.T) {
 	for _, kind := range []string{"prompt", "skill"} {
 		t.Run(kind, func(t *testing.T) {
+			subject := &Subject{Role: "implementation"}
+			if kind == "skill" {
+				subject.SkillName = "sybra-test"
+			}
 			cfg := Config{Experiments: []Experiment{{
 				ID:      kind + "-zero-weight",
 				Kind:    kind,
-				Subject: &Subject{Role: "implementation"},
+				Subject: subject,
 				Variants: []Variant{
 					{ID: "base", Provider: "claude", Model: "sonnet", ReasoningEffort: "medium", Weight: 1},
 					{ID: "ignored", Provider: "codex", Model: "gpt-5.5", ReasoningEffort: "high", Weight: 0},

--- a/internal/evaluation/scorecard.go
+++ b/internal/evaluation/scorecard.go
@@ -855,7 +855,8 @@ type experimentRoleConfig struct {
 
 func configuredExperimentRoles(experiments []abtest.Experiment, rows []ComparisonBreakdown) map[string]experimentRoleConfig {
 	out := map[string]experimentRoleConfig{}
-	for _, exp := range experiments {
+	for i := range experiments {
+		exp := experiments[i]
 		if exp.ID == "" || !exp.EnabledValue() || len(exp.Variants) == 0 {
 			continue
 		}

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -45,6 +45,7 @@ type AgentLauncher interface {
 // AgentAssignment carries A/B experiment attribution selected before dispatch.
 type AgentAssignment struct {
 	ExperimentID    string
+	Kind            string
 	VariantID       string
 	Provider        string
 	Model           string

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -231,6 +231,7 @@ func (e *Engine) selectABVariant(taskID, role, stepID string) (AgentAssignment, 
 	}
 	return AgentAssignment{
 		ExperimentID:    a.ExperimentID,
+		Kind:            a.Kind,
 		VariantID:       a.VariantID,
 		Provider:        a.Provider,
 		Model:           a.Model,

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2074,6 +2074,36 @@ func TestExecRunAgent_ABTestingOverridesProviderModel(t *testing.T) {
 	}
 }
 
+func TestSelectABVariantPropagatesExperimentKind(t *testing.T) {
+	prev := providerAvailable
+	providerAvailable = func(string) bool { return true }
+	t.Cleanup(func() { providerAvailable = prev })
+
+	engine := NewEngine(newTestStore(t), newMemTasks(), newMockAgents(), discardLogger())
+	enabled := true
+	engine.SetABTestingConfig(abtest.Config{
+		Enabled: &enabled,
+		Experiments: []abtest.Experiment{{
+			ID:             "prompt-exp",
+			Kind:           "prompt",
+			AssignmentUnit: "stage",
+			Roles:          []string{"implementation"},
+			Subject:        &abtest.Subject{StepID: "implement"},
+			Variants: []abtest.Variant{{
+				ID: "copy-v2", Provider: "claude", Model: "sonnet", Weight: 1,
+			}},
+		}},
+	})
+
+	assignment, ok, err := engine.selectABVariant("t1", "implementation", "implement")
+	if err != nil || !ok {
+		t.Fatalf("selectABVariant ok=%v err=%v", ok, err)
+	}
+	if assignment.Kind != "prompt" {
+		t.Fatalf("Kind = %q, want prompt", assignment.Kind)
+	}
+}
+
 func TestExecRunAgent_ABTestingSkipsRateLimitedProvider(t *testing.T) {
 	prev := providerAvailable
 	providerAvailable = func(string) bool { return true }


### PR DESCRIPTION
## Motivation

A/B experiments currently only compare provider/model variants. Prompt and skill-level experiments need a schema to identify their target (workflow/step/role) and enforce that non-model variants stay isolated to that dimension, so results aren't confounded by concurrent provider/model differences.

Closes https://github.com/Automaat/sybra/issues/1201

## Implementation information

- Add `Experiment.Kind` (`model`, `prompt`, `skill`, `compound`) and `Experiment.Subject` (workflow/step/role/skill target) to `internal/abtest/model.go`, plus `Variant.Version`/`Digest` for tracking non-model variant identity.
- Add `Config.Validate()` to validate all configured experiments, including disabled ones.
- Extend `internal/abtest/selector.go` validation: require a subject for `prompt`/`skill` kinds, and enforce provider/model/reasoning-effort homogeneity across eligible variants for those kinds so only the prompt/skill dimension varies.
- Propagate `Kind` through `Assignment` and `workflow.AgentAssignment` so downstream attribution records which experiment kind produced a dispatch.