### PR TITLE
refactor(task): extract task feature cluster persistence coverage

### DIFF
--- a/internal/task/persistence_test.go
+++ b/internal/task/persistence_test.go
@@ -98,12 +98,29 @@ func TestTaskFrontmatterMappingRoundTrip(t *testing.T) {
 	}
 }
 
+// persistedFields returns the leaf (non-anonymous) fields of a struct type,
+// recursing into embedded fields so a Task built from feature-cluster
+// sub-structs (e.g. `ReviewState`) is still checked field-by-field rather
+// than by its container name. Unlike Type.Fields()/NumField(), which only
+// walk the direct field list, reflect.VisibleFields flattens promoted fields
+// from anonymous embeds.
+func persistedFields(typ reflect.Type) []reflect.StructField {
+	var fields []reflect.StructField
+	for _, field := range reflect.VisibleFields(typ) {
+		if field.Anonymous {
+			continue
+		}
+		fields = append(fields, field)
+	}
+	return fields
+}
+
 func TestTaskFrontmatterMappingCoversPersistedFields(t *testing.T) {
 	t.Parallel()
 	taskType := reflect.TypeFor[Task]()
 	frontmatterType := reflect.TypeFor[taskFrontmatter]()
 
-	for field := range taskType.Fields() {
+	for _, field := range persistedFields(taskType) {
 		if taskSidecarField(field.Name) {
 			continue
 		}
@@ -111,7 +128,7 @@ func TestTaskFrontmatterMappingCoversPersistedFields(t *testing.T) {
 			t.Errorf("Task.%s is persisted but missing from taskFrontmatter", field.Name)
 		}
 	}
-	for field := range frontmatterType.Fields() {
+	for _, field := range persistedFields(frontmatterType) {
 		if _, ok := taskType.FieldByName(field.Name); !ok {
 			t.Errorf("taskFrontmatter.%s has no matching Task field", field.Name)
 		}
@@ -122,7 +139,7 @@ func TestTaskFrontmatterMappingPreservesEachPersistedField(t *testing.T) {
 	t.Parallel()
 	taskType := reflect.TypeFor[Task]()
 
-	for field := range taskType.Fields() {
+	for _, field := range persistedFields(taskType) {
 		if taskSidecarField(field.Name) {
 			continue
 		}


### PR DESCRIPTION
## Motivation

Task model fields are being split into embedded feature-cluster structs. The persistence mapping tests need to keep covering promoted leaf fields so frontmatter serialization does not silently miss persisted task data after that refactor.

Closes https://github.com/Automaat/sybra/issues/1301

## Implementation information

- Added a helper that uses reflection to flatten visible promoted fields while skipping anonymous container fields.
- Updated task/frontmatter persistence coverage tests to validate persisted leaf fields from embedded structs rather than only direct struct fields.