### PR TITLE
refactor(task): type UpdateRun patches

### DIFF
--- a/internal/monitor/dispatcher_test.go
+++ b/internal/monitor/dispatcher_test.go
@@ -61,7 +61,7 @@ func (d dispatcherTasksStub) Get(id string) (task.Task, error) {
 func (d dispatcherTasksStub) Update(string, task.Update) (task.Task, error) {
 	return task.Task{}, errors.New("not implemented")
 }
-func (d dispatcherTasksStub) UpdateRun(string, string, map[string]any) error {
+func (d dispatcherTasksStub) UpdateRun(string, string, task.RunPatch) error {
 	return errors.New("not implemented")
 }
 

--- a/internal/monitor/remediator.go
+++ b/internal/monitor/remediator.go
@@ -14,7 +14,7 @@ type taskAPI interface {
 	List() ([]task.Task, error)
 	Get(id string) (task.Task, error)
 	Update(id string, u task.Update) (task.Task, error)
-	UpdateRun(taskID, agentID string, updates map[string]any) error
+	UpdateRun(taskID, agentID string, patch task.RunPatch) error
 }
 
 // remediator runs the in-process actions for anomalies that don't need LLM
@@ -57,7 +57,7 @@ func (r *remediator) resetLostAgent(a Anomaly) (string, error) {
 	if t, err := r.tasks.Get(a.TaskID); err == nil {
 		for i := range slices.Backward(t.AgentRuns) {
 			if t.AgentRuns[i].State == "running" {
-				_ = r.tasks.UpdateRun(a.TaskID, t.AgentRuns[i].AgentID, map[string]any{"state": "stopped"})
+				_ = r.tasks.UpdateRun(a.TaskID, t.AgentRuns[i].AgentID, task.RunPatch{State: task.Ptr("stopped")})
 				break
 			}
 		}

--- a/internal/monitor/remediator_test.go
+++ b/internal/monitor/remediator_test.go
@@ -53,8 +53,8 @@ func TestRemediator_LostAgent_MarksRunningRunStopped(t *testing.T) {
 	if ru.agentID != "lost-agent" {
 		t.Errorf("runUpdate agentID = %q, want lost-agent", ru.agentID)
 	}
-	if ru.updates["state"] != "stopped" {
-		t.Errorf("runUpdate state = %v, want stopped", ru.updates["state"])
+	if ru.patch.State == nil || *ru.patch.State != "stopped" {
+		t.Errorf("runUpdate state = %v, want stopped", ru.patch.State)
 	}
 }
 

--- a/internal/monitor/service_test.go
+++ b/internal/monitor/service_test.go
@@ -27,7 +27,7 @@ type taskUpdate struct {
 type runUpdate struct {
 	taskID  string
 	agentID string
-	updates map[string]any
+	patch   task.RunPatch
 }
 
 func (f *fakeTasks) List() ([]task.Task, error) {
@@ -68,10 +68,10 @@ func (f *fakeTasks) Update(id string, u task.Update) (task.Task, error) {
 	return task.Task{}, errNotFound
 }
 
-func (f *fakeTasks) UpdateRun(taskID, agentID string, updates map[string]any) error {
+func (f *fakeTasks) UpdateRun(taskID, agentID string, patch task.RunPatch) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.runUpdates = append(f.runUpdates, runUpdate{taskID: taskID, agentID: agentID, updates: updates})
+	f.runUpdates = append(f.runUpdates, runUpdate{taskID: taskID, agentID: agentID, patch: patch})
 	for i := range f.tasks {
 		if f.tasks[i].ID != taskID {
 			continue
@@ -80,8 +80,8 @@ func (f *fakeTasks) UpdateRun(taskID, agentID string, updates map[string]any) er
 			if f.tasks[i].AgentRuns[j].AgentID != agentID {
 				continue
 			}
-			if v, ok := updates["state"].(string); ok {
-				f.tasks[i].AgentRuns[j].State = v
+			if patch.State != nil {
+				f.tasks[i].AgentRuns[j].State = *patch.State
 			}
 			return nil
 		}

--- a/internal/recovery/cleanup.go
+++ b/internal/recovery/cleanup.go
@@ -26,9 +26,9 @@ func (r *Recovery) cleanStaleRuns() {
 				continue
 			}
 			r.Logger.Info("stale-run.cleanup", "task_id", tasks[i].ID, "agent_id", run.AgentID)
-			_ = r.Tasks.UpdateRun(tasks[i].ID, run.AgentID, map[string]any{
-				"state":  string(agent.StateStopped),
-				"result": "stale: marked stopped on startup",
+			_ = r.Tasks.UpdateRun(tasks[i].ID, run.AgentID, task.RunPatch{
+				State:  task.Ptr(string(agent.StateStopped)),
+				Result: task.Ptr("stale: marked stopped on startup"),
 			})
 		}
 	}

--- a/internal/recovery/stale.go
+++ b/internal/recovery/stale.go
@@ -258,9 +258,9 @@ func (r *Recovery) recoverStaleInteractive(t *task.Task) {
 		return
 	}
 	if lr.State == string(agent.StateRunning) {
-		if err := r.Tasks.UpdateRun(t.ID, lr.AgentID, map[string]any{
-			"state":  string(agent.StateStopped),
-			"result": "stale: agent gone, auto-recovered",
+		if err := r.Tasks.UpdateRun(t.ID, lr.AgentID, task.RunPatch{
+			State:  task.Ptr(string(agent.StateStopped)),
+			Result: task.Ptr("stale: agent gone, auto-recovered"),
 		}); err != nil {
 			r.Logger.Error("recover-stale.update-run", "task_id", t.ID, "err", err)
 		}

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -148,29 +148,29 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 	if len(truncated) > maxResultLen {
 		truncated = truncated[:maxResultLen] + "\n... (truncated)"
 	}
-	runUpdates := map[string]any{
-		"state":            string(state),
-		"cost_usd":         cost,
-		"premium_requests": premiumRequests,
-		"result":           truncated,
-		"log_file":         ag.LogPath,
-		"session_id":       ag.GetSessionID(),
-		"model":            ag.Model,
-		"provider":         ag.Provider,
+	runUpdates := task.RunPatch{
+		State:           task.Ptr(string(state)),
+		CostUSD:         task.Ptr(cost),
+		PremiumRequests: task.Ptr(premiumRequests),
+		Result:          task.Ptr(truncated),
+		LogFile:         task.Ptr(ag.LogPath),
+		SessionID:       task.Ptr(ag.GetSessionID()),
+		Model:           task.Ptr(ag.Model),
+		Provider:        task.Ptr(ag.Provider),
 	}
-	addRunMetadata(runUpdates, ag)
+	addRunMetadata(&runUpdates, ag)
 	// For human-review agents, parse the verdict from the live (untruncated)
 	// output and persist it in its own field so detector.go can read it even
 	// when the full result text is longer than maxResultLen.
 	if agent.RoleFromName(ag.Name) == agent.RoleHumanReview {
 		if v, err := parseVerdict(finalAssistantText(ag)); err == nil {
-			runUpdates["verdict"] = v.Decision
+			runUpdates.Verdict = task.Ptr(v.Decision)
 		}
 	}
 	// Capture the worktree HEAD while it still exists (cleanup below is async) so
 	// landing can later detect human edits after the agent (merged_with_edits).
 	if sha := h.captureHeadSHA(ag.TaskID); sha != "" {
-		runUpdates["head_sha"] = sha
+		runUpdates.HeadSHA = task.Ptr(sha)
 	}
 	if err := h.tasks.UpdateRun(ag.TaskID, ag.ID, runUpdates); err != nil {
 		h.logger.Error("task.update-run", "task_id", ag.TaskID, "agent_id", ag.ID, "err", err)
@@ -225,15 +225,15 @@ func (h *AgentCompletionHandler) emitPermissionDenialAudits(ag *agent.Agent) {
 	}
 }
 
-func addRunMetadata(updates map[string]any, ag *agent.Agent) {
+func addRunMetadata(updates *task.RunPatch, ag *agent.Agent) {
 	if ag.ExperimentID != "" {
-		updates["experiment_id"] = ag.ExperimentID
-		updates["variant_id"] = ag.VariantID
-		updates["assignment_unit"] = ag.AssignmentUnit
-		updates["assignment_key"] = ag.AssignmentKey
+		updates.ExperimentID = task.Ptr(ag.ExperimentID)
+		updates.VariantID = task.Ptr(ag.VariantID)
+		updates.AssignmentUnit = task.Ptr(ag.AssignmentUnit)
+		updates.AssignmentKey = task.Ptr(ag.AssignmentKey)
 	}
 	if ag.ReasoningEffort != "" {
-		updates["reasoning_effort"] = ag.ReasoningEffort
+		updates.ReasoningEffort = task.Ptr(ag.ReasoningEffort)
 	}
 }
 

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -594,7 +594,7 @@ func (h *humanReviewHandler) appendNote(taskID, header, body string) bool {
 // that onComplete applied all side-effects. verdictAlreadyRendered reads this
 // field as the durable rendered-marker.
 func (h *humanReviewHandler) markVerdictRendered(taskID, agentID string) {
-	if err := h.tasks.UpdateRun(taskID, agentID, map[string]any{"verdict_rendered": true}); err != nil {
+	if err := h.tasks.UpdateRun(taskID, agentID, task.RunPatch{VerdictRendered: task.Ptr(true)}); err != nil {
 		h.logger.Warn("human-review.mark-rendered", "task_id", taskID, "agent_id", agentID, "err", err)
 	}
 }

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -218,7 +218,7 @@ func (a *App) agentManagerConfig(approvalAddr string) agent.ManagerConfig {
 		OnComplete:   a.onAgentComplete,
 		ApprovalAddr: approvalAddr,
 		SessionSink: func(taskID, agentID, sessionID string) error {
-			return a.tasks.UpdateRun(taskID, agentID, map[string]any{"session_id": sessionID})
+			return a.tasks.UpdateRun(taskID, agentID, task.RunPatch{SessionID: task.Ptr(sessionID)})
 		},
 		TaskExists: a.taskExistsForAgent,
 		LimitSink:  a.recordLimitSnapshot,

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -127,15 +127,15 @@ func (a *taskAdapter) MarkTaskReviewed(id string) error {
 }
 
 func (a *taskAdapter) MarkAgentRunProtocolViolation(taskID, agentID, violation string) error {
-	return a.tasks.UpdateRun(taskID, agentID, map[string]any{"protocol_violation": violation})
+	return a.tasks.UpdateRun(taskID, agentID, task.RunPatch{ProtocolViolation: task.Ptr(violation)})
 }
 
 func (a *taskAdapter) MarkAgentRunTestOutcome(taskID, agentID, outcome, fingerprint string) error {
-	updates := map[string]any{"test_outcome": outcome}
+	patch := task.RunPatch{TestOutcome: task.Ptr(outcome)}
 	if fingerprint != "" {
-		updates["test_failure_fingerprint"] = fingerprint
+		patch.TestFailureFingerprint = task.Ptr(fingerprint)
 	}
-	return a.tasks.UpdateRun(taskID, agentID, updates)
+	return a.tasks.UpdateRun(taskID, agentID, patch)
 }
 
 func (a *taskAdapter) AppendTaskBody(id, content string) error {

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -87,15 +87,15 @@ func (s *TaskService) withEstimatedAgentRunCosts(t task.Task) task.Task {
 		}
 		run.CostUSD = estimate.CostUSD
 		if estimate.CostUSD > 0 && s.tasks != nil {
-			updates := map[string]any{"cost_usd": estimate.CostUSD}
+			patch := task.RunPatch{CostUSD: task.Ptr(estimate.CostUSD)}
 			if estimate.PremiumRequests > 0 {
-				updates["premium_requests"] = estimate.PremiumRequests
+				patch.PremiumRequests = task.Ptr(estimate.PremiumRequests)
 			}
 			if run.Provider == "" && estimate.Provider != "" {
-				updates["provider"] = estimate.Provider
+				patch.Provider = task.Ptr(estimate.Provider)
 				run.Provider = estimate.Provider
 			}
-			if err := s.tasks.UpdateRun(t.ID, run.AgentID, updates); err != nil && s.logger != nil {
+			if err := s.tasks.UpdateRun(t.ID, run.AgentID, patch); err != nil && s.logger != nil {
 				s.logger.Debug("task.agent-run-cost.persist-skipped", "task_id", t.ID, "agent_id", run.AgentID, "err", err)
 			}
 		}

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -339,11 +339,11 @@ func (m *Manager) AddRunWithStatus(taskID string, run AgentRun, status *Status) 
 }
 
 // UpdateRun updates fields on a specific agent run and emits task:updated.
-func (m *Manager) UpdateRun(taskID, agentID string, updates map[string]any) error {
+func (m *Manager) UpdateRun(taskID, agentID string, patch RunPatch) error {
 	mu := m.lockFor(taskID)
 	mu.Lock()
 	defer mu.Unlock()
-	if err := m.store.UpdateRun(taskID, agentID, updates); err != nil {
+	if err := m.store.UpdateRun(taskID, agentID, patch); err != nil {
 		return err
 	}
 	t, err := m.store.Get(taskID)

--- a/internal/task/manager_test.go
+++ b/internal/task/manager_test.go
@@ -250,7 +250,7 @@ func TestManagerUpdateRunEmitsUpdated(t *testing.T) {
 	if err := m.AddRun(task.ID, AgentRun{AgentID: "a1", State: "running"}); err != nil {
 		t.Fatalf("AddRun: %v", err)
 	}
-	if err := m.UpdateRun(task.ID, "a1", map[string]any{"state": "stopped"}); err != nil {
+	if err := m.UpdateRun(task.ID, "a1", RunPatch{State: Ptr("stopped")}); err != nil {
 		t.Fatalf("UpdateRun: %v", err)
 	}
 

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -972,8 +972,9 @@ func (s *Store) addRun(taskID string, run AgentRun, status *Status) error {
 // RunPatch describes a partial update to an AgentRun. Every field is a
 // pointer: nil means "leave unchanged". Fields that carried an implicit
 // non-empty/true guard in the old map[string]any path keep that guard here
-// (see applyRunVerdict/applyRunTestOutcome/applyRunIdentity) so a caller
-// can't accidentally blank out a durable value with a zero value.
+// (see applyRunLifecycle/applyRunVerdict/applyRunTestOutcome/applyRunIdentity):
+// HeadSHA and string verdict/test/session values ignore empty strings, and
+// VerdictRendered is a latch that only ever flips true.
 type RunPatch struct {
 	// Lifecycle
 	State   *string

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -969,7 +969,123 @@ func (s *Store) addRun(taskID string, run AgentRun, status *Status) error {
 	return nil
 }
 
-func (s *Store) UpdateRun(taskID, agentID string, updates map[string]any) error {
+// RunPatch describes a partial update to an AgentRun. Every field is a
+// pointer: nil means "leave unchanged". Fields that carried an implicit
+// non-empty/true guard in the old map[string]any path keep that guard here
+// (see applyRunVerdict/applyRunTestOutcome/applyRunIdentity) so a caller
+// can't accidentally blank out a durable value with a zero value.
+type RunPatch struct {
+	// Lifecycle
+	State   *string
+	Result  *string
+	LogFile *string
+	HeadSHA *string
+
+	// Cost/tokens
+	CostUSD         *float64
+	PremiumRequests *float64
+
+	// Verdict
+	Verdict         *string
+	VerdictRendered *bool
+
+	// Test outcome
+	TestOutcome            *string
+	TestFailureFingerprint *string
+	ProtocolViolation      *string
+
+	// Identity
+	Provider        *string
+	Model           *string
+	ExperimentID    *string
+	VariantID       *string
+	AssignmentUnit  *string
+	AssignmentKey   *string
+	ReasoningEffort *string
+	SessionID       *string
+}
+
+func applyRunLifecycle(run *AgentRun, p RunPatch) {
+	if p.State != nil {
+		run.State = *p.State
+	}
+	if p.Result != nil {
+		run.Result = *p.Result
+	}
+	if p.LogFile != nil {
+		run.LogFile = *p.LogFile
+	}
+	if p.HeadSHA != nil && *p.HeadSHA != "" {
+		run.HeadSHA = *p.HeadSHA
+	}
+}
+
+func applyRunCostTokens(run *AgentRun, p RunPatch) {
+	if p.CostUSD != nil {
+		run.CostUSD = *p.CostUSD
+	}
+	if p.PremiumRequests != nil {
+		run.PremiumRequests = *p.PremiumRequests
+	}
+}
+
+func applyRunVerdict(run *AgentRun, p RunPatch) {
+	if p.Verdict != nil && *p.Verdict != "" {
+		run.Verdict = *p.Verdict
+	}
+	if p.VerdictRendered != nil && *p.VerdictRendered {
+		run.VerdictRendered = true
+	}
+}
+
+func applyRunTestOutcome(run *AgentRun, p RunPatch) {
+	if p.TestOutcome != nil && *p.TestOutcome != "" {
+		run.TestOutcome = *p.TestOutcome
+	}
+	if p.TestFailureFingerprint != nil && *p.TestFailureFingerprint != "" {
+		run.TestFailureFingerprint = *p.TestFailureFingerprint
+	}
+	if p.ProtocolViolation != nil && *p.ProtocolViolation != "" {
+		run.ProtocolViolation = *p.ProtocolViolation
+	}
+}
+
+func applyRunIdentity(run *AgentRun, p RunPatch) {
+	if p.Provider != nil {
+		run.Provider = *p.Provider
+	}
+	if p.Model != nil {
+		run.Model = *p.Model
+	}
+	if p.ExperimentID != nil {
+		run.ExperimentID = *p.ExperimentID
+	}
+	if p.VariantID != nil {
+		run.VariantID = *p.VariantID
+	}
+	if p.AssignmentUnit != nil {
+		run.AssignmentUnit = *p.AssignmentUnit
+	}
+	if p.AssignmentKey != nil {
+		run.AssignmentKey = *p.AssignmentKey
+	}
+	if p.ReasoningEffort != nil {
+		run.ReasoningEffort = *p.ReasoningEffort
+	}
+	if p.SessionID != nil && *p.SessionID != "" {
+		run.SessionID = *p.SessionID
+	}
+}
+
+func applyRunPatch(run *AgentRun, p RunPatch) {
+	applyRunLifecycle(run, p)
+	applyRunCostTokens(run, p)
+	applyRunVerdict(run, p)
+	applyRunTestOutcome(run, p)
+	applyRunIdentity(run, p)
+}
+
+func (s *Store) UpdateRun(taskID, agentID string, patch RunPatch) error {
 	t, err := s.Get(taskID)
 	if err != nil {
 		return err
@@ -980,63 +1096,7 @@ func (s *Store) UpdateRun(taskID, agentID string, updates map[string]any) error 
 			continue
 		}
 		found = true
-		if v, ok := updates["state"].(string); ok {
-			t.AgentRuns[i].State = v
-		}
-		if v, ok := updates["cost_usd"].(float64); ok {
-			t.AgentRuns[i].CostUSD = v
-		}
-		if v, ok := updates["premium_requests"].(float64); ok {
-			t.AgentRuns[i].PremiumRequests = v
-		}
-		if v, ok := updates["result"].(string); ok {
-			t.AgentRuns[i].Result = v
-		}
-		if v, ok := updates["verdict"].(string); ok && v != "" {
-			t.AgentRuns[i].Verdict = v
-		}
-		if v, ok := updates["verdict_rendered"].(bool); ok && v {
-			t.AgentRuns[i].VerdictRendered = true
-		}
-		if v, ok := updates["log_file"].(string); ok {
-			t.AgentRuns[i].LogFile = v
-		}
-		if v, ok := updates["provider"].(string); ok {
-			t.AgentRuns[i].Provider = v
-		}
-		if v, ok := updates["model"].(string); ok {
-			t.AgentRuns[i].Model = v
-		}
-		if v, ok := updates["experiment_id"].(string); ok {
-			t.AgentRuns[i].ExperimentID = v
-		}
-		if v, ok := updates["variant_id"].(string); ok {
-			t.AgentRuns[i].VariantID = v
-		}
-		if v, ok := updates["assignment_unit"].(string); ok {
-			t.AgentRuns[i].AssignmentUnit = v
-		}
-		if v, ok := updates["assignment_key"].(string); ok {
-			t.AgentRuns[i].AssignmentKey = v
-		}
-		if v, ok := updates["reasoning_effort"].(string); ok {
-			t.AgentRuns[i].ReasoningEffort = v
-		}
-		if v, ok := updates["session_id"].(string); ok && v != "" {
-			t.AgentRuns[i].SessionID = v
-		}
-		if v, ok := updates["protocol_violation"].(string); ok && v != "" {
-			t.AgentRuns[i].ProtocolViolation = v
-		}
-		if v, ok := updates["test_outcome"].(string); ok && v != "" {
-			t.AgentRuns[i].TestOutcome = v
-		}
-		if v, ok := updates["test_failure_fingerprint"].(string); ok && v != "" {
-			t.AgentRuns[i].TestFailureFingerprint = v
-		}
-		if v, ok := updates["head_sha"].(string); ok && v != "" {
-			t.AgentRuns[i].HeadSHA = v
-		}
+		applyRunPatch(&t.AgentRuns[i], patch)
 		break
 	}
 	if !found {

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -647,13 +647,13 @@ func TestStoreUpdateRun(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = store.UpdateRun(created.ID, "agent-upd", map[string]any{
-		"state":                    "done",
-		"cost_usd":                 0.42,
-		"premium_requests":         1.5,
-		"result":                   "success",
-		"test_outcome":             "product_bug",
-		"test_failure_fingerprint": "abc123",
+	err = store.UpdateRun(created.ID, "agent-upd", RunPatch{
+		State:                  Ptr("done"),
+		CostUSD:                Ptr(0.42),
+		PremiumRequests:        Ptr(1.5),
+		Result:                 Ptr("success"),
+		TestOutcome:            Ptr("product_bug"),
+		TestFailureFingerprint: Ptr("abc123"),
 	})
 	if err != nil {
 		t.Fatalf("UpdateRun: %v", err)
@@ -694,7 +694,7 @@ func TestStoreUpdateRunNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = store.UpdateRun("nonexistent", "agent-x", map[string]any{"state": "done"})
+	err = store.UpdateRun("nonexistent", "agent-x", RunPatch{State: Ptr("done")})
 	if err == nil {
 		t.Fatal("expected error for nonexistent task")
 	}
@@ -715,7 +715,7 @@ func TestStoreUpdateRunNoMatchingAgent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = store.UpdateRun(created.ID, "agent-wrong", map[string]any{"state": "done"})
+	err = store.UpdateRun(created.ID, "agent-wrong", RunPatch{State: Ptr("done")})
 	if err == nil {
 		t.Fatal("expected error for wrong agent")
 	}
@@ -744,9 +744,9 @@ func TestStoreUpdateRunSessionID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = store.UpdateRun(created.ID, "agent-s", map[string]any{
-		"state":      "done",
-		"session_id": "ses-abc123",
+	err = store.UpdateRun(created.ID, "agent-s", RunPatch{
+		State:     Ptr("done"),
+		SessionID: Ptr("ses-abc123"),
 	})
 	if err != nil {
 		t.Fatalf("UpdateRun: %v", err)
@@ -786,9 +786,9 @@ func TestStoreUpdateRunSessionIDEmpty(t *testing.T) {
 	}
 
 	// Empty session_id should not overwrite existing value
-	err = store.UpdateRun(created.ID, "agent-e", map[string]any{
-		"state":      "done",
-		"session_id": "",
+	err = store.UpdateRun(created.ID, "agent-e", RunPatch{
+		State:     Ptr("done"),
+		SessionID: Ptr(""),
 	})
 	if err != nil {
 		t.Fatalf("UpdateRun: %v", err)

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -781,14 +781,21 @@ func TestStoreUpdateRunSessionIDEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := store.AddRun(created.ID, AgentRun{AgentID: "agent-e", Mode: "headless", State: "running", SessionID: "existing-id"}); err != nil {
+	if err := store.AddRun(created.ID, AgentRun{
+		AgentID:   "agent-e",
+		Mode:      "headless",
+		State:     "running",
+		SessionID: "existing-id",
+		HeadSHA:   "existing-sha",
+	}); err != nil {
 		t.Fatal(err)
 	}
 
-	// Empty session_id should not overwrite existing value
+	// Empty durable values should not overwrite existing values.
 	err = store.UpdateRun(created.ID, "agent-e", RunPatch{
 		State:     Ptr("done"),
 		SessionID: Ptr(""),
+		HeadSHA:   Ptr(""),
 	})
 	if err != nil {
 		t.Fatalf("UpdateRun: %v", err)
@@ -800,6 +807,9 @@ func TestStoreUpdateRunSessionIDEmpty(t *testing.T) {
 	}
 	if got.AgentRuns[0].SessionID != "existing-id" {
 		t.Errorf("SessionID = %q, want existing-id preserved", got.AgentRuns[0].SessionID)
+	}
+	if got.AgentRuns[0].HeadSHA != "existing-sha" {
+		t.Errorf("HeadSHA = %q, want existing-sha preserved", got.AgentRuns[0].HeadSHA)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Replace unstructured map-based UpdateRun patch inputs with a typed patch model so callers and persistence code share an explicit contract.

Closes https://github.com/Automaat/sybra/issues/1299

## Implementation information

- Add a typed RunPatch shape for task run updates.
- Update UpdateRun call sites to use typed patch fields instead of map[string]any.
- Keep existing task run update behavior while improving compile-time checking.