### PR TITLE
refactor(agent): extract shared runner core

### DIFF
--- a/internal/agent/runner_codex_convo.go
+++ b/internal/agent/runner_codex_convo.go
@@ -262,11 +262,7 @@ func (m *Manager) runConvoTurn(ctx context.Context, a *Agent, cfg RunConfig, pro
 
 	waitErr := cmd.Wait()
 	stderrOut := stderrBuf.String()
-	all := a.ConvoOutput()
-	if prevLen > len(all) {
-		prevLen = len(all)
-	}
-	attemptEvents := all[prevLen:]
+	attemptEvents := attemptEventsFrom(a.ConvoOutput(), prevLen)
 	if streamErr := resultConvoStreamError(attemptEvents); waitErr == nil && streamErr != nil {
 		waitErr = streamErr
 	}

--- a/internal/agent/runner_convo.go
+++ b/internal/agent/runner_convo.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -213,42 +212,13 @@ func (m *Manager) runConversational(ctx context.Context, a *Agent, cfg RunConfig
 	// tailOffset tracks the survival file tailer's position across retries.
 	var tailOffset int64
 
-	for attempt := range len(headlessRetryBackoffs) + 1 {
-		if attempt > 0 {
-			wait := headlessRetryBackoffs[attempt-1]
-			m.logger.Info("agent.convo.retry", "id", a.ID, "attempt", attempt, "backoff", wait)
-			select {
-			case <-ctx.Done():
-				if a.isDetached() && !a.WasStopped() {
-					return
-				}
-				goto done
-			case <-time.After(wait):
-			}
-		}
-
-		retry, fatalErr := m.runConvoAttempt(ctx, a, cfg, &outFile, &tailOffset)
-		if errors.Is(fatalErr, errSurviveShutdown) {
-			return
-		}
-		if fatalErr != nil {
-			m.handleError(a, fatalErr)
-			return
-		}
-		if !retry {
-			break
-		}
-		if attempt == len(headlessRetryBackoffs) {
-			m.logger.Error("agent.convo.retry.exhausted", "id", a.ID, "attempts", len(headlessRetryBackoffs))
-		}
+	if earlyReturn := m.runRetryLoop(ctx, a, "convo", func(int) (bool, error) {
+		return m.runConvoAttempt(ctx, a, cfg, &outFile, &tailOffset)
+	}); earlyReturn {
+		return
 	}
 
-done:
-	a.SetState(StateStopped)
-	m.logger.Info("agent.convo.done", "id", a.ID, "cost", a.GetCostUSD())
-	m.emit(events.AgentState(a.ID), a)
-	m.fireComplete(a, a.GetExitErr() == nil)
-	m.markAgentDone(a)
+	m.finalizeRun(a, "agent.convo.done")
 }
 
 func (m *Manager) runConvoAttempt(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File, tailOffset *int64) (retry bool, err error) {
@@ -311,11 +281,7 @@ func (m *Manager) runConvoAttempt(ctx context.Context, a *Agent, cfg RunConfig, 
 	if stderrOut != "" {
 		m.logger.Error("agent.convo.stderr", "id", a.ID, "stderr", stderrOut)
 	}
-	all := a.ConvoOutput()
-	if prevLen > len(all) {
-		prevLen = len(all)
-	}
-	attemptEvents := all[prevLen:]
+	attemptEvents := attemptEventsFrom(a.ConvoOutput(), prevLen)
 	if waitErr != nil {
 		m.logger.Error("agent.convo.exit", "id", a.ID, "err", waitErr)
 		a.SetExitErr(waitErr)

--- a/internal/agent/runner_convo_survive.go
+++ b/internal/agent/runner_convo_survive.go
@@ -159,11 +159,7 @@ func (m *Manager) runConvoAttemptSurvive(ctx context.Context, a *Agent, cfg RunC
 	if stderrOut != "" {
 		m.logger.Error("agent.convo.stderr", "id", a.ID, "stderr", stderrOut)
 	}
-	all := a.ConvoOutput()
-	if prevLen > len(all) {
-		prevLen = len(all)
-	}
-	attemptEvents := all[prevLen:]
+	attemptEvents := attemptEventsFrom(a.ConvoOutput(), prevLen)
 	if waitErr != nil {
 		m.logger.Error("agent.convo.exit", "id", a.ID, "err", waitErr)
 		a.SetExitErr(waitErr)
@@ -257,11 +253,7 @@ func (m *Manager) runConvoAttemptSurviveOneShot(ctx context.Context, a *Agent, c
 	if stderrOut != "" {
 		m.logger.Error("agent.convo.stderr", "id", a.ID, "stderr", stderrOut)
 	}
-	all := a.ConvoOutput()
-	if prevLen > len(all) {
-		prevLen = len(all)
-	}
-	attemptEvents := all[prevLen:]
+	attemptEvents := attemptEventsFrom(a.ConvoOutput(), prevLen)
 	if waitErr != nil {
 		m.logger.Error("agent.convo.exit", "id", a.ID, "err", waitErr)
 		a.SetExitErr(waitErr)

--- a/internal/agent/runner_core.go
+++ b/internal/agent/runner_core.go
@@ -1,0 +1,76 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/Automaat/sybra/internal/events"
+)
+
+// attemptEventsFrom slices the events produced since prevLen out of all,
+// clamping prevLen so a buffer that shrank between reads (should not happen,
+// but is cheap to guard) never panics. Shared by the StreamEvent (headless)
+// and ConvoEvent (conversational) attempt-scoping call sites.
+func attemptEventsFrom[T any](all []T, prevLen int) []T {
+	if prevLen > len(all) {
+		prevLen = len(all)
+	}
+	return all[prevLen:]
+}
+
+// runRetryLoop drives the attempt/backoff/retry state machine shared by
+// runHeadless and runConversational: it waits out headlessRetryBackoffs
+// between attempts, invokes attempt once per iteration, and reacts to its
+// (retry, err) result the same way regardless of provider mode.
+//
+// Returns true when the caller must return immediately without finalizing —
+// either the app is shutting down on a detached, not-intentionally-stopped
+// agent (leave it for the next reattach), the attempt left a detached
+// subprocess running across shutdown (errSurviveShutdown), or the attempt
+// returned a fatal error (already handled via m.handleError). Returns false
+// when the loop broke out normally (or exhausted retries) and the caller
+// should proceed to its own finalize step.
+func (m *Manager) runRetryLoop(ctx context.Context, a *Agent, logTag string, attempt func(n int) (retry bool, err error)) (earlyReturn bool) {
+	for n := range len(headlessRetryBackoffs) + 1 {
+		if n > 0 {
+			wait := headlessRetryBackoffs[n-1]
+			m.logger.Info("agent."+logTag+".retry", "id", a.ID, "attempt", n, "backoff", wait)
+			select {
+			case <-ctx.Done():
+				if a.isDetached() && !a.WasStopped() {
+					return true
+				}
+				return false
+			case <-time.After(wait):
+			}
+		}
+
+		retry, fatalErr := attempt(n)
+		if errors.Is(fatalErr, errSurviveShutdown) {
+			return true
+		}
+		if fatalErr != nil {
+			m.handleError(a, fatalErr)
+			return true
+		}
+		if !retry {
+			break
+		}
+		if n == len(headlessRetryBackoffs) {
+			m.logger.Error("agent."+logTag+".retry.exhausted", "id", a.ID, "attempts", len(headlessRetryBackoffs))
+		}
+	}
+	return false
+}
+
+// finalizeRun marks a completed run stopped, emits the terminal state/events,
+// and releases the agent. Shared tail of runHeadless and runConversational
+// once runRetryLoop has broken out normally.
+func (m *Manager) finalizeRun(a *Agent, doneLogEvent string) {
+	a.SetState(StateStopped)
+	m.logger.Info(doneLogEvent, "id", a.ID, "cost", a.GetCostUSD())
+	m.emit(events.AgentState(a.ID), a)
+	m.fireComplete(a, a.GetExitErr() == nil)
+	m.markAgentDone(a)
+}

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -77,55 +77,22 @@ func (m *Manager) runHeadless(ctx context.Context, a *Agent, cfg RunConfig) {
 	// of reprocessing them. Unused by the legacy pipe path.
 	var tailOffset int64
 
-	for attempt := range len(headlessRetryBackoffs) + 1 {
-		if attempt > 0 {
-			wait := headlessRetryBackoffs[attempt-1]
-			m.logger.Info("agent.headless.retry", "id", a.ID, "attempt", attempt, "backoff", wait)
-			select {
-			case <-ctx.Done():
-				// App shutdown between retries on a detached agent: the prior
-				// process is already gone, so leave finalize to the next
-				// reattach rather than advancing a workflow mid-shutdown.
-				if a.isDetached() && !a.WasStopped() {
-					return
-				}
-				goto done
-			case <-time.After(wait):
-			}
-		}
-
-		retry, fatalErr := m.runHeadlessAttempt(ctx, a, cfg, &outFile, &tailOffset)
-		if errors.Is(fatalErr, errSurviveShutdown) {
-			// Detached subprocess left running across shutdown — do not
-			// finalize; the next app instance reattaches via the registry.
-			return
-		}
-		if fatalErr != nil {
-			m.handleError(a, fatalErr)
-			return
-		}
-		if !retry {
-			break
-		}
-		if attempt == len(headlessRetryBackoffs) {
-			m.logger.Error("agent.headless.retry.exhausted", "id", a.ID, "attempts", len(headlessRetryBackoffs))
-		}
+	if earlyReturn := m.runRetryLoop(ctx, a, "headless", func(int) (bool, error) {
+		return m.runHeadlessAttempt(ctx, a, cfg, &outFile, &tailOffset)
+	}); earlyReturn {
+		return
 	}
 
-done:
 	// If CC exited after a graceful SIGINT (WasStopped + session_id captured
 	// from the final result event), the next run can pass --resume.
 	if a.WasStopped() && a.GetSessionID() != "" {
 		a.SetResumable(true)
 	}
-	a.SetState(StateStopped)
-	m.logger.Info("agent.headless.done", "id", a.ID, "cost", a.GetCostUSD())
-	m.emit(events.AgentState(a.ID), a)
-	m.fireComplete(a, a.GetExitErr() == nil)
-	// Close `done` only after onComplete returns. HasRunningAgentForTask
-	// gates ResumeStalled; releasing it before the workflow advance handler
-	// runs lets a tight ResumeStalled loop dispatch a duplicate agent.
-	m.markAgentDone(a)
+	// finalizeRun releases the agent only after onComplete returns.
+	// HasRunningAgentForTask gates ResumeStalled; releasing it before the
+	// workflow advance handler runs lets a tight ResumeStalled loop dispatch
+	// a duplicate agent.
+	m.finalizeRun(a, "agent.headless.done")
 }
 
 func (m *Manager) runHeadlessAttempt(ctx context.Context, a *Agent, cfg RunConfig, outFile **os.File, tailOffset *int64) (retry bool, err error) {
@@ -231,7 +198,7 @@ func (m *Manager) runHeadlessAttemptPipe(ctx context.Context, a *Agent, cfg RunC
 	if stderrOut != "" {
 		m.logger.Error("agent.headless.stderr", "id", a.ID, "stderr", stderrOut)
 	}
-	if streamErr := resultStreamError(attemptEventsFrom(a, prevLen)); waitErr == nil && streamErr != nil {
+	if streamErr := resultStreamError(attemptEventsFrom(a.Output(), prevLen)); waitErr == nil && streamErr != nil {
 		waitErr = streamErr
 	}
 	if waitErr != nil {
@@ -244,7 +211,7 @@ func (m *Manager) runHeadlessAttemptPipe(ctx context.Context, a *Agent, cfg RunC
 	// Only inspect the events produced during this attempt. Some CLIs report
 	// quota exhaustion as an exit-0 result event, so classify provider health
 	// even when the process itself looked successful.
-	attemptEvents := attemptEventsFrom(a, prevLen)
+	attemptEvents := attemptEventsFrom(a.Output(), prevLen)
 	if waitErr != nil {
 		if shouldRetry(stderrOut, attemptEvents, m.logger) {
 			return true, nil
@@ -346,7 +313,7 @@ func (m *Manager) runHeadlessAttemptSurvive(ctx context.Context, a *Agent, cfg R
 	if stderrOut != "" {
 		m.logger.Error("agent.headless.stderr", "id", a.ID, "stderr", stderrOut)
 	}
-	if streamErr := resultStreamError(attemptEventsFrom(a, prevLen)); waitErr == nil && streamErr != nil {
+	if streamErr := resultStreamError(attemptEventsFrom(a.Output(), prevLen)); waitErr == nil && streamErr != nil {
 		waitErr = streamErr
 	}
 	if waitErr != nil {
@@ -358,7 +325,7 @@ func (m *Manager) runHeadlessAttemptSurvive(ctx context.Context, a *Agent, cfg R
 	// Only inspect events from this attempt, mirroring the legacy path —
 	// otherwise a transient 529 from an earlier attempt makes every later
 	// attempt retry regardless of its real failure.
-	attemptEvents := attemptEventsFrom(a, prevLen)
+	attemptEvents := attemptEventsFrom(a.Output(), prevLen)
 	if waitErr != nil {
 		if shouldRetry(stderrOut, attemptEvents, m.logger) {
 			return true, nil
@@ -374,7 +341,7 @@ func (m *Manager) runHeadlessAttemptSurvive(ctx context.Context, a *Agent, cfg R
 // guard stopped, deriving completion from the terminal result event rather
 // than the kill signal that appears in the process wait error.
 func (m *Manager) finalizeFromResult(a *Agent, prevLen int) {
-	evs := attemptEventsFrom(a, prevLen)
+	evs := attemptEventsFrom(a.Output(), prevLen)
 	if streamErr := resultStreamError(evs); streamErr != nil {
 		a.SetExitErr(streamErr)
 		m.reportProviderHealthSignal(a, "", evs)
@@ -385,14 +352,6 @@ func (m *Manager) finalizeFromResult(a *Agent, prevLen int) {
 		return
 	}
 	a.SetExitErr(nil)
-}
-
-func attemptEventsFrom(a *Agent, prevLen int) []StreamEvent {
-	all := a.Output()
-	if prevLen > len(all) {
-		prevLen = len(all)
-	}
-	return all[prevLen:]
 }
 
 func resultStreamError(streamEvents []StreamEvent) error {


### PR DESCRIPTION
## Motivation

The Claude and Codex runner paths should share the same core execution plumbing instead of carrying duplicated process setup and stream handling logic.

Closes https://github.com/Automaat/sybra/issues/1302

## Implementation information

- Extracts shared runner core behavior behind the existing agent runner flow.
- Keeps provider-specific behavior isolated while reusing common lifecycle and execution code.