### PR TITLE
fix(review): pin staff review provider

### DIFF
--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -29,6 +29,8 @@ const (
 	reviewSmallFiles     = 5
 )
 
+const staffCodeReviewProvider = "claude"
+
 const transientFetchWarnThreshold = 3
 
 // ReviewHandler manages PR review task creation, agent dispatch, and status tracking.

--- a/internal/sybra/app_reviews_inbound.go
+++ b/internal/sybra/app_reviews_inbound.go
@@ -176,17 +176,7 @@ func (r *ReviewHandler) startReviewAgent(t task.Task, force bool) error {
 
 	prompt := fmt.Sprintf("Run /staff-code-review on https://github.com/%s/pull/%d", current.ProjectID, current.PRNumber)
 
-	ag, err := r.agents.Run(agent.RunConfig{
-		TaskID:                 current.ID,
-		Name:                   agent.RoleReview.AgentName(current.Title),
-		Mode:                   "headless",
-		Prompt:                 prompt,
-		Dir:                    dir,
-		Model:                  "opus",
-		HeadlessPermissionMode: posture,
-		// MaxTurns intentionally not inherited: review agents need
-		// enough turns to fetch the PR, run the skill, and write findings.
-	})
+	ag, err := r.agents.Run(staffCodeReviewRunConfig(current, prompt, dir, posture))
 	if err != nil {
 		return err
 	}
@@ -203,6 +193,21 @@ func (r *ReviewHandler) startReviewAgent(t task.Task, force bool) error {
 	r.logAudit(audit.EventReviewStarted, current.ID, ag.ID, map[string]any{"pr": current.PRNumber})
 	r.logger.Info("review.agent-started", "task_id", current.ID, "agent_id", ag.ID, "pr", current.PRNumber)
 	return nil
+}
+
+func staffCodeReviewRunConfig(t task.Task, prompt, dir, posture string) agent.RunConfig {
+	return agent.RunConfig{
+		TaskID:                 t.ID,
+		Name:                   agent.RoleReview.AgentName(t.Title),
+		Mode:                   "headless",
+		Prompt:                 prompt,
+		Dir:                    dir,
+		Provider:               staffCodeReviewProvider,
+		Model:                  "opus",
+		HeadlessPermissionMode: posture,
+		// MaxTurns intentionally not inherited: review agents need
+		// enough turns to fetch the PR, run the skill, and write findings.
+	}
 }
 
 func reviewAgentAlreadyRan(t task.Task) bool {

--- a/internal/sybra/app_reviews_inbound.go
+++ b/internal/sybra/app_reviews_inbound.go
@@ -197,14 +197,15 @@ func (r *ReviewHandler) startReviewAgent(t task.Task, force bool) error {
 
 func staffCodeReviewRunConfig(t task.Task, prompt, dir, posture string) agent.RunConfig {
 	return agent.RunConfig{
-		TaskID:                 t.ID,
-		Name:                   agent.RoleReview.AgentName(t.Title),
-		Mode:                   "headless",
-		Prompt:                 prompt,
-		Dir:                    dir,
-		Provider:               staffCodeReviewProvider,
-		Model:                  "opus",
-		HeadlessPermissionMode: posture,
+		TaskID:                  t.ID,
+		Name:                    agent.RoleReview.AgentName(t.Title),
+		Mode:                    "headless",
+		Prompt:                  prompt,
+		Dir:                     dir,
+		Provider:                staffCodeReviewProvider,
+		Model:                   "opus",
+		DisableProviderFailover: true,
+		HeadlessPermissionMode:  posture,
 		// MaxTurns intentionally not inherited: review agents need
 		// enough turns to fetch the PR, run the skill, and write findings.
 	}

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -50,6 +50,17 @@ func TestConflictPrompt_ResolvesAllConflictsAutonomously(t *testing.T) {
 	}
 }
 
+func TestStaffCodeReviewRunConfigPinsClaudeProvider(t *testing.T) {
+	cfg := staffCodeReviewRunConfig(task.Task{ID: "review-task", Title: "Needs review"}, "Run /staff-code-review", t.TempDir(), "default")
+
+	if cfg.Provider != staffCodeReviewProvider {
+		t.Fatalf("Provider = %q, want %q", cfg.Provider, staffCodeReviewProvider)
+	}
+	if cfg.Model != "opus" {
+		t.Fatalf("Model = %q, want opus", cfg.Model)
+	}
+}
+
 func newExperienceProjectStore(t *testing.T, tmp string) *project.Store {
 	t.Helper()
 	projects, err := project.NewStore(filepath.Join(tmp, "projects"), filepath.Join(tmp, "clones"))

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -59,6 +59,9 @@ func TestStaffCodeReviewRunConfigPinsClaudeProvider(t *testing.T) {
 	if cfg.Model != "opus" {
 		t.Fatalf("Model = %q, want opus", cfg.Model)
 	}
+	if !cfg.DisableProviderFailover {
+		t.Fatal("DisableProviderFailover = false, want true")
+	}
 }
 
 func newExperienceProjectStore(t *testing.T, tmp string) *project.Store {

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -433,17 +433,7 @@ func (s *TaskService) startPRReviewAgent(t task.Task) error {
 	}
 
 	prompt := fmt.Sprintf("Run /staff-code-review on https://github.com/%s/pull/%d", t.ProjectID, t.PRNumber)
-	ag, err := s.agents.Run(agent.RunConfig{
-		TaskID:                 t.ID,
-		Name:                   agent.RoleReview.AgentName(t.Title),
-		Mode:                   "headless",
-		Prompt:                 prompt,
-		Dir:                    dir,
-		Model:                  "opus",
-		HeadlessPermissionMode: posture,
-		// MaxTurns intentionally not inherited: review agents need
-		// enough turns to fetch the PR, run the skill, and write findings.
-	})
+	ag, err := s.agents.Run(staffCodeReviewRunConfig(t, prompt, dir, posture))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Motivation

Staff review routing needs to preserve the intended provider instead of letting later review handling fall back to a different provider path. This keeps review follow-up execution aligned with the provider selected for the task.

## Implementation information

- Carry the review provider through inbound review handling.
- Remove the duplicate provider-selection path from task service review handling.
- Add unit coverage for staff review provider pinning.