### PR TITLE
feat(llmjob): add tiered structured LLM jobs

### DIFF
--- a/internal/agent/inspector.go
+++ b/internal/agent/inspector.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Automaat/sybra/internal/llmexec"
+	"github.com/Automaat/sybra/internal/llmjob"
 )
 
 // InspectorVerdict is the structured judgment returned by the inspector agent.
@@ -46,19 +47,24 @@ func Inspect(ctx context.Context, logger *slog.Logger, in InspectInput) (Inspect
 
 	prompt := buildInspectorPrompt(in)
 
-	model := in.Model
-	if model == "" {
-		model = "sonnet"
-	}
-	res, err := llmexec.RunJSON(ctx, prompt, llmexec.Options{Model: model, Logger: logger})
+	v, _, err := llmjob.Run(ctx, prompt, llmjob.Spec[InspectorVerdict]{
+		Name:     "inspect",
+		Tier:     llmjob.Cheap,
+		Validate: validateInspectorVerdict,
+	}, llmexec.Options{Logger: logger})
 	if err != nil {
 		return InspectorVerdict{}, fmt.Errorf("inspector: %w", err)
 	}
-	v, err := parseInspectorOutput([]byte(res.Text))
-	if err != nil {
-		return InspectorVerdict{}, fmt.Errorf("parse %s verdict: %w", res.Provider, err)
-	}
 	return v, nil
+}
+
+func validateInspectorVerdict(v *InspectorVerdict) error {
+	switch v.Recommendation {
+	case "stop", "continue", "escalate", "nudge":
+		return nil
+	default:
+		return fmt.Errorf("invalid recommendation: %q", v.Recommendation)
+	}
 }
 
 func buildInspectorPrompt(in InspectInput) string {

--- a/internal/agent/inspector.go
+++ b/internal/agent/inspector.go
@@ -51,11 +51,18 @@ func Inspect(ctx context.Context, logger *slog.Logger, in InspectInput) (Inspect
 		Name:     "inspect",
 		Tier:     llmjob.Cheap,
 		Validate: validateInspectorVerdict,
-	}, llmexec.Options{Logger: logger})
+	}, llmexec.Options{Logger: logger, Models: claudeModelOverride(in.Model)})
 	if err != nil {
 		return InspectorVerdict{}, fmt.Errorf("inspector: %w", err)
 	}
 	return v, nil
+}
+
+func claudeModelOverride(model string) map[string]string {
+	if strings.TrimSpace(model) == "" {
+		return nil
+	}
+	return map[string]string{"claude": model}
 }
 
 func validateInspectorVerdict(v *InspectorVerdict) error {

--- a/internal/agent/inspector_test.go
+++ b/internal/agent/inspector_test.go
@@ -1,6 +1,12 @@
 package agent
 
-import "testing"
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestParseInspectorOutput(t *testing.T) {
 	tests := []struct {
@@ -131,5 +137,37 @@ func TestExtractLastJSONObject_BraceInsideString(t *testing.T) {
 				t.Errorf("extractLastJSONObject(%q) = %q, want %q (brace inside string literal mis-parsed)", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestInspectPassesConfiguredClaudeModel(t *testing.T) {
+	dir := t.TempDir()
+	writeInspectorTestExe(t, filepath.Join(dir, "claude"), `#!/bin/bash
+if [[ "$*" != *"--model claude-haiku-4-5-20251001"* ]]; then
+  echo "missing configured model flag: $*" >&2
+  exit 7
+fi
+printf '%s\n' '{"result":"{\"stuck\":false,\"reason\":\"progress\",\"recommendation\":\"continue\"}"}'
+`)
+	t.Setenv("PATH", dir)
+
+	logger := slog.New(slog.DiscardHandler)
+	got, err := Inspect(context.Background(), logger, InspectInput{
+		AgentID:   "agent-1",
+		TaskTitle: "task",
+		Model:     "claude-haiku-4-5-20251001",
+	})
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if got.Recommendation != "continue" {
+		t.Fatalf("Recommendation = %q, want continue", got.Recommendation)
+	}
+}
+
+func writeInspectorTestExe(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }

--- a/internal/evaluation/judge.go
+++ b/internal/evaluation/judge.go
@@ -11,6 +11,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/Automaat/sybra/internal/llmexec"
+	"github.com/Automaat/sybra/internal/llmjob"
 	"github.com/Automaat/sybra/internal/provider"
 )
 
@@ -81,16 +82,23 @@ func (j *ClaudeQualityJudge) Judge(ctx context.Context, req JudgeRequest) (Quali
 		model = defaultJudgeModel
 	}
 	prompt := buildQualityPrompt(req, shuffledRubric(j.DimSeed))
-	res, err := llmexec.RunJSON(ctx, prompt, llmexec.Options{Model: model, Logger: j.Logger, Gate: j.Gate})
+	v, _, err := llmjob.Run(ctx, prompt, llmjob.Spec[QualityVerdict]{
+		Name:     "quality-judge",
+		Tier:     qualityTier(model),
+		Validate: validateQualityVerdict,
+	}, llmexec.Options{Logger: j.Logger, Gate: j.Gate})
 	if err != nil {
 		return QualityVerdict{}, err
 	}
-	v, err := parseQualityVerdict([]byte(res.Text))
-	if err != nil {
-		return QualityVerdict{}, fmt.Errorf("parse %s verdict: %w", res.Provider, err)
-	}
 	v.TaskID = req.TaskID
 	return v, nil
+}
+
+func qualityTier(model string) llmjob.Tier {
+	if strings.Contains(strings.ToLower(model), "opus") {
+		return llmjob.Deep
+	}
+	return llmjob.Standard
 }
 
 // shuffledRubric returns the rubric in a deterministic permutation for the seed,
@@ -171,6 +179,13 @@ func parseQualityVerdict(raw []byte) (QualityVerdict, error) {
 	if err := json.Unmarshal([]byte(jsonStr), &v); err != nil {
 		return QualityVerdict{}, fmt.Errorf("unmarshal verdict: %w", err)
 	}
+	if err := validateQualityVerdict(&v); err != nil {
+		return QualityVerdict{}, err
+	}
+	return v, nil
+}
+
+func validateQualityVerdict(v *QualityVerdict) error {
 	// Require every rubric dimension: a partial verdict would skew Overall and
 	// the outcome calibration. Clamp scores and sum over the rubric keys (not
 	// len(v.Dimensions)) so extra/unknown keys can't distort the mean.
@@ -178,7 +193,7 @@ func parseQualityVerdict(raw []byte) (QualityVerdict, error) {
 	for _, d := range Rubric {
 		ds, ok := v.Dimensions[d.Key]
 		if !ok {
-			return QualityVerdict{}, fmt.Errorf("verdict missing dimension %q", d.Key)
+			return fmt.Errorf("verdict missing dimension %q", d.Key)
 		}
 		ds.Score = clampScore(ds.Score)
 		v.Dimensions[d.Key] = ds
@@ -193,7 +208,7 @@ func parseQualityVerdict(raw []byte) (QualityVerdict, error) {
 	if v.Overall < 0 || v.Overall > 10 || (v.Overall == 0 && mean != 0) {
 		v.Overall = mean
 	}
-	return v, nil
+	return nil
 }
 
 // AgreesWithOutcome reports whether a verdict is consistent with the task's

--- a/internal/evaluation/scorecard.go
+++ b/internal/evaluation/scorecard.go
@@ -856,11 +856,11 @@ type experimentRoleConfig struct {
 func configuredExperimentRoles(experiments []abtest.Experiment, rows []ComparisonBreakdown) map[string]experimentRoleConfig {
 	out := map[string]experimentRoleConfig{}
 	for i := range experiments {
-		exp := experiments[i]
+		exp := &experiments[i]
 		if exp.ID == "" || !exp.EnabledValue() || len(exp.Variants) == 0 {
 			continue
 		}
-		eligible, _ := abtest.EligibleVariants(exp, nil)
+		eligible, _ := abtest.EligibleVariants(*exp, nil)
 		variants := make([]string, 0, len(eligible))
 		disabled := map[string]bool{}
 		for i := range exp.Variants {
@@ -882,7 +882,7 @@ func configuredExperimentRoles(experiments []abtest.Experiment, rows []Compariso
 		if len(variants) == 0 {
 			continue
 		}
-		for _, role := range configuredExperimentRoleNames(exp, rows) {
+		for _, role := range configuredExperimentRoleNames(*exp, rows) {
 			role = normalizedRole(role)
 			out[experimentRoleKey(exp.ID, role)] = experimentRoleConfig{
 				experimentID:       exp.ID,

--- a/internal/llmexec/llmexec.go
+++ b/internal/llmexec/llmexec.go
@@ -27,9 +27,8 @@ const streamScannerBuffer = 4 * 1024 * 1024
 type Options struct {
 	// Provider is the preferred provider. Empty means claude first, then peers.
 	Provider string
-	// Model is passed only to Claude; alternate providers keep their CLI default
-	// because Claude aliases like "sonnet" are not portable.
-	Model  string
+	// Models maps provider name to the model slug passed to that provider's CLI.
+	Models map[string]string
 	Logger *slog.Logger
 	Gate   provider.HealthGate
 }
@@ -58,7 +57,7 @@ func RunJSON(ctx context.Context, prompt string, opts Options) (Result, error) {
 			continue
 		}
 
-		raw, stderrOut, err := runProvider(ctx, p, prompt, opts.Model)
+		raw, stderrOut, err := runProvider(ctx, p, prompt, opts.Models[p])
 		if err != nil {
 			if overloaded(stderrOut, string(raw)) {
 				logFallback(opts.Logger, p, provider.SignalRateLimit, "overloaded")
@@ -148,12 +147,20 @@ func runProvider(ctx context.Context, p, prompt, model string) (stdout []byte, s
 func invocation(p, prompt, model string) (name string, args []string, stdin string) {
 	switch p {
 	case "codex":
-		return "codex", []string{
+		args := []string{
 			"exec", "--json", "--skip-git-repo-check", "--ignore-user-config", "--ignore-rules",
 			"--dangerously-bypass-approvals-and-sandbox", "-",
-		}, prompt
+		}
+		if model != "" {
+			args = append(args[:len(args)-1], "--model", model, "-")
+		}
+		return "codex", args, prompt
 	case "copilot":
-		return "copilot", []string{"-p", prompt, "--output-format", "json", "--allow-all-tools", "--no-ask-user"}, ""
+		args := []string{"-p", prompt, "--output-format", "json", "--allow-all-tools", "--no-ask-user"}
+		if model != "" {
+			args = append(args, "--model", model)
+		}
+		return "copilot", args, ""
 	default:
 		args := []string{"-p", prompt, "--output-format", "json", "--dangerously-skip-permissions"}
 		if model != "" {

--- a/internal/llmexec/llmexec_test.go
+++ b/internal/llmexec/llmexec_test.go
@@ -61,6 +61,52 @@ printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"{
 	}
 }
 
+func TestRunJSONPassesCodexModel(t *testing.T) {
+	dir := t.TempDir()
+	writeExe(t, filepath.Join(dir, "codex"), `#!/bin/bash
+if [[ "$*" != *"--model gpt-5.4-mini"* ]]; then
+  echo "missing model flag: $*" >&2
+  exit 7
+fi
+printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"{\"ok\":true}"}}'
+`)
+	t.Setenv("PATH", dir)
+
+	res, err := RunJSON(context.Background(), "classify", Options{
+		Provider: "codex",
+		Models:   map[string]string{"codex": "gpt-5.4-mini"},
+	})
+	if err != nil {
+		t.Fatalf("RunJSON: %v", err)
+	}
+	if res.Provider != "codex" {
+		t.Fatalf("provider = %q, want codex", res.Provider)
+	}
+}
+
+func TestRunJSONPassesCopilotModel(t *testing.T) {
+	dir := t.TempDir()
+	writeExe(t, filepath.Join(dir, "copilot"), `#!/bin/bash
+if [[ "$*" != *"--model gpt-5-mini"* ]]; then
+  echo "missing model flag: $*" >&2
+  exit 7
+fi
+printf '%s\n' '{"type":"assistant.message","data":{"content":"{\"ok\":true}"}}'
+`)
+	t.Setenv("PATH", dir)
+
+	res, err := RunJSON(context.Background(), "classify", Options{
+		Provider: "copilot",
+		Models:   map[string]string{"copilot": "gpt-5-mini"},
+	})
+	if err != nil {
+		t.Fatalf("RunJSON: %v", err)
+	}
+	if res.Provider != "copilot" {
+		t.Fatalf("provider = %q, want copilot", res.Provider)
+	}
+}
+
 func TestRunJSONFallsBackOnCodexUsageLimit(t *testing.T) {
 	dir := t.TempDir()
 	writeExe(t, filepath.Join(dir, "claude"), `#!/bin/sh

--- a/internal/llmjob/llmjob.go
+++ b/internal/llmjob/llmjob.go
@@ -1,0 +1,176 @@
+package llmjob
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/Automaat/sybra/internal/llmexec"
+	"github.com/Automaat/sybra/internal/provider"
+)
+
+const defaultMaxRepairs = 2
+
+type runnerFunc func(context.Context, string, llmexec.Options) (llmexec.Result, error)
+
+var runJSON runnerFunc = llmexec.RunJSON
+
+// Spec describes a short structured-output LLM job.
+type Spec[T any] struct {
+	Name          string
+	Tier          Tier
+	Schema        string
+	Validate      func(*T) error
+	MaxRepairs    int
+	AvoidProvider string
+}
+
+type Meta struct {
+	Provider string
+	Tier     Tier
+	Repairs  int
+}
+
+// Run invokes a short JSON job, optionally repairing malformed or invalid
+// responses with fresh one-shot attempts.
+func Run[T any](ctx context.Context, prompt string, s Spec[T], o llmexec.Options) (T, Meta, error) {
+	var zero T
+	o.Models = modelsFor(s.Tier)
+	if strings.TrimSpace(s.Schema) != "" {
+		prompt += "\n\nOutput schema:\n" + strings.TrimSpace(s.Schema)
+	}
+	if strings.TrimSpace(s.AvoidProvider) != "" {
+		var err error
+		o, err = avoidProvider(o, s.AvoidProvider)
+		if err != nil {
+			logJob(o.Logger, s.Name, "", s.Tier, 0, false)
+			return zero, Meta{Tier: s.Tier}, err
+		}
+	}
+
+	maxRepairs := s.MaxRepairs
+	if maxRepairs == 0 {
+		maxRepairs = defaultMaxRepairs
+	}
+	attempts := 1 + maxRepairs
+	attemptPrompt := prompt
+	var lastErr error
+	var lastProvider string
+	for attempt := range attempts {
+		res, err := runJSON(ctx, attemptPrompt, o)
+		if err != nil {
+			lastErr = err
+			lastProvider = res.Provider
+			break
+		}
+		lastProvider = res.Provider
+		var out T
+		if err := json.Unmarshal([]byte(res.Text), &out); err != nil {
+			lastErr = fmt.Errorf("parse JSON: %w", err)
+		} else if s.Validate != nil {
+			lastErr = s.Validate(&out)
+		} else {
+			lastErr = nil
+		}
+		if lastErr == nil {
+			repairs := attempt
+			logJob(o.Logger, s.Name, res.Provider, s.Tier, repairs, true)
+			return out, Meta{Provider: res.Provider, Tier: s.Tier, Repairs: repairs}, nil
+		}
+		if attempt < attempts-1 {
+			attemptPrompt = prompt + "\n\nYour previous output was invalid: " + lastErr.Error() + ". Re-emit ONLY the corrected JSON object."
+		}
+	}
+	if lastErr == nil {
+		lastErr = errors.New("no result")
+	}
+	logJob(o.Logger, s.Name, lastProvider, s.Tier, maxRepairs, false)
+	return zero, Meta{Provider: lastProvider, Tier: s.Tier, Repairs: maxRepairs},
+		fmt.Errorf("%s job failed with provider %q after %d attempts: %w", s.Name, lastProvider, attempts, lastErr)
+}
+
+func avoidProvider(o llmexec.Options, avoid string) (llmexec.Options, error) {
+	avoid = strings.ToLower(strings.TrimSpace(avoid))
+	if avoid == "" {
+		return o, nil
+	}
+	preferred := strings.ToLower(strings.TrimSpace(o.Provider))
+	if preferred != "" && preferred != avoid {
+		o.Gate = avoidingGate{base: o.Gate, avoid: avoid}
+		return o, nil
+	}
+	for _, p := range []string{"claude", "codex", "copilot"} {
+		if p != avoid {
+			o.Provider = p
+			o.Gate = avoidingGate{base: o.Gate, avoid: avoid}
+			return o, nil
+		}
+	}
+	return o, fmt.Errorf("no provider remains after avoiding %q", avoid)
+}
+
+type avoidingGate struct {
+	base  provider.HealthGate
+	avoid string
+}
+
+func (g avoidingGate) IsHealthy(providerName string) bool {
+	if providerName == g.avoid {
+		return false
+	}
+	if g.base == nil {
+		return true
+	}
+	return g.base.IsHealthy(providerName)
+}
+
+func (g avoidingGate) Reason(providerName string) string {
+	if providerName == g.avoid {
+		return "avoided for independence"
+	}
+	if g.base == nil {
+		return ""
+	}
+	return g.base.Reason(providerName)
+}
+
+func (g avoidingGate) RateLimited(providerName string) bool {
+	if providerName == g.avoid {
+		return false
+	}
+	return g.base != nil && g.base.RateLimited(providerName)
+}
+
+func (g avoidingGate) Failover(unhealthy string) string {
+	if g.base == nil {
+		return ""
+	}
+	next := g.base.Failover(unhealthy)
+	if next == g.avoid {
+		return ""
+	}
+	return next
+}
+
+func (g avoidingGate) ReportAuthFailure(providerName, reason string) {
+	if g.base != nil && providerName != g.avoid {
+		g.base.ReportAuthFailure(providerName, reason)
+	}
+}
+
+func (g avoidingGate) ReportRateLimit(providerName string, retryAfter time.Duration, reason string) {
+	if g.base != nil && providerName != g.avoid {
+		g.base.ReportRateLimit(providerName, retryAfter, reason)
+	}
+}
+
+func logJob(logger *slog.Logger, name, providerName string, tier Tier, repairs int, ok bool) {
+	if logger == nil {
+		return
+	}
+	logger.Info("llmjob.done", "name", name, "provider", providerName, "tier", tier, "repairs", repairs, "ok", ok)
+}

--- a/internal/llmjob/llmjob.go
+++ b/internal/llmjob/llmjob.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"strings"
 	"time"
 
@@ -39,7 +40,7 @@ type Meta struct {
 // responses with fresh one-shot attempts.
 func Run[T any](ctx context.Context, prompt string, s Spec[T], o llmexec.Options) (T, Meta, error) {
 	var zero T
-	o.Models = modelsFor(s.Tier)
+	o.Models = mergeModels(modelsFor(s.Tier), o.Models)
 	if strings.TrimSpace(s.Schema) != "" {
 		prompt += "\n\nOutput schema:\n" + strings.TrimSpace(s.Schema)
 	}
@@ -69,7 +70,10 @@ func Run[T any](ctx context.Context, prompt string, s Spec[T], o llmexec.Options
 		}
 		lastProvider = res.Provider
 		var out T
-		if err := json.Unmarshal([]byte(res.Text), &out); err != nil {
+		jsonText := extractLastJSONObject(res.Text)
+		if jsonText == "" {
+			lastErr = fmt.Errorf("parse JSON: no JSON object in result: %q", res.Text)
+		} else if err := json.Unmarshal([]byte(jsonText), &out); err != nil {
 			lastErr = fmt.Errorf("parse JSON: %w", err)
 		} else if s.Validate != nil {
 			lastErr = s.Validate(&out)
@@ -91,6 +95,66 @@ func Run[T any](ctx context.Context, prompt string, s Spec[T], o llmexec.Options
 	logJob(o.Logger, s.Name, lastProvider, s.Tier, maxRepairs, false)
 	return zero, Meta{Provider: lastProvider, Tier: s.Tier, Repairs: maxRepairs},
 		fmt.Errorf("%s job failed with provider %q after %d attempts: %w", s.Name, lastProvider, attempts, lastErr)
+}
+
+func mergeModels(defaults, explicit map[string]string) map[string]string {
+	out := make(map[string]string, len(defaults)+len(explicit))
+	maps.Copy(out, defaults)
+	maps.Copy(out, explicit)
+	return out
+}
+
+// extractLastJSONObject returns the last balanced {...} substring in s, or "".
+// It tolerates common provider wrappers such as prose and fenced code blocks.
+func extractLastJSONObject(s string) string {
+	s = strings.TrimSpace(s)
+	var (
+		inString  bool
+		escape    bool
+		depth     int
+		objStart  = -1
+		lastStart = -1
+		lastEnd   = -1
+	)
+	for i := range len(s) {
+		c := s[i]
+		if escape {
+			escape = false
+			continue
+		}
+		if inString {
+			switch c {
+			case '\\':
+				escape = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inString = true
+		case '{':
+			if depth == 0 {
+				objStart = i
+			}
+			depth++
+		case '}':
+			if depth == 0 {
+				continue
+			}
+			depth--
+			if depth == 0 && objStart >= 0 {
+				lastStart = objStart
+				lastEnd = i
+				objStart = -1
+			}
+		}
+	}
+	if lastStart < 0 {
+		return ""
+	}
+	return s[lastStart : lastEnd+1]
 }
 
 func avoidProvider(o llmexec.Options, avoid string) (llmexec.Options, error) {

--- a/internal/llmjob/llmjob_test.go
+++ b/internal/llmjob/llmjob_test.go
@@ -29,6 +29,11 @@ func TestRun(t *testing.T) {
 			wantRepairs: 0,
 		},
 		{
+			name:        "decode-fenced-json-without-repair",
+			results:     []llmexec.Result{{Provider: "claude", Text: "Here is the result:\n```json\n{\"ok\":true}\n```"}},
+			wantRepairs: 0,
+		},
+		{
 			name:        "repair-on-bad-json",
 			results:     []llmexec.Result{{Provider: "claude", Text: `{`}, {Provider: "claude", Text: `{"ok":true}`}},
 			wantRepairs: 1,
@@ -127,6 +132,23 @@ func TestRunSetsTierModels(t *testing.T) {
 	defer restore()
 
 	if _, _, err := Run(context.Background(), "prompt", Spec[testOut]{Name: "models", Tier: Cheap}, llmexec.Options{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+func TestRunPreservesExplicitModels(t *testing.T) {
+	restore := stubRunner(func(_ context.Context, _ string, opts llmexec.Options) (llmexec.Result, error) {
+		want := map[string]string{"claude": "opus", "codex": "gpt-5.4-mini", "copilot": "gpt-5-mini"}
+		if !reflect.DeepEqual(opts.Models, want) {
+			t.Fatalf("models = %#v, want %#v", opts.Models, want)
+		}
+		return llmexec.Result{Provider: "claude", Text: `{"ok":true}`}, nil
+	})
+	defer restore()
+
+	if _, _, err := Run(context.Background(), "prompt", Spec[testOut]{Name: "models", Tier: Cheap}, llmexec.Options{
+		Models: map[string]string{"claude": "opus"},
+	}); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 }

--- a/internal/llmjob/llmjob_test.go
+++ b/internal/llmjob/llmjob_test.go
@@ -1,0 +1,149 @@
+package llmjob
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/llmexec"
+)
+
+type testOut struct {
+	OK bool `json:"ok"`
+}
+
+func TestRun(t *testing.T) {
+	tests := []struct {
+		name        string
+		results     []llmexec.Result
+		validate    func(*testOut) error
+		maxRepairs  int
+		wantRepairs int
+		wantErr     string
+	}{
+		{
+			name:        "decode-success",
+			results:     []llmexec.Result{{Provider: "claude", Text: `{"ok":true}`}},
+			wantRepairs: 0,
+		},
+		{
+			name:        "repair-on-bad-json",
+			results:     []llmexec.Result{{Provider: "claude", Text: `{`}, {Provider: "claude", Text: `{"ok":true}`}},
+			wantRepairs: 1,
+		},
+		{
+			name:    "repair-on-validate-fail",
+			results: []llmexec.Result{{Provider: "claude", Text: `{"ok":false}`}, {Provider: "claude", Text: `{"ok":true}`}},
+			validate: func(out *testOut) error {
+				if !out.OK {
+					return errors.New("not ok")
+				}
+				return nil
+			},
+			wantRepairs: 1,
+		},
+		{
+			name:       "exhausted-repairs",
+			results:    []llmexec.Result{{Provider: "claude", Text: `{`}, {Provider: "claude", Text: `{`}},
+			maxRepairs: 1,
+			wantErr:    "job failed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var prompts []string
+			restore := stubRunner(func(_ context.Context, prompt string, _ llmexec.Options) (llmexec.Result, error) {
+				prompts = append(prompts, prompt)
+				if len(prompts) > len(tt.results) {
+					t.Fatalf("unexpected attempt %d", len(prompts))
+				}
+				return tt.results[len(prompts)-1], nil
+			})
+			defer restore()
+
+			out, meta, err := Run(context.Background(), "prompt", Spec[testOut]{
+				Name:       "test",
+				Tier:       Cheap,
+				Validate:   tt.validate,
+				MaxRepairs: tt.maxRepairs,
+			}, llmexec.Options{})
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			if !out.OK {
+				t.Fatalf("out.OK = false")
+			}
+			if meta.Repairs != tt.wantRepairs {
+				t.Fatalf("repairs = %d, want %d", meta.Repairs, tt.wantRepairs)
+			}
+			if tt.wantRepairs > 0 && !strings.Contains(prompts[len(prompts)-1], "previous output was invalid") {
+				t.Fatalf("repair prompt missing invalid-output context: %q", prompts[len(prompts)-1])
+			}
+		})
+	}
+}
+
+func TestRunAvoidProviderExcludedFromOrder(t *testing.T) {
+	restore := stubRunner(func(_ context.Context, _ string, opts llmexec.Options) (llmexec.Result, error) {
+		if opts.Provider == "claude" {
+			t.Fatalf("Provider = claude, want avoided provider excluded from preferred provider")
+		}
+		if opts.Gate == nil || opts.Gate.IsHealthy("claude") {
+			t.Fatalf("avoided provider was not marked unhealthy")
+		}
+		return llmexec.Result{Provider: opts.Provider, Text: `{"ok":true}`}, nil
+	})
+	defer restore()
+
+	_, meta, err := Run(context.Background(), "prompt", Spec[testOut]{
+		Name:          "avoid",
+		Tier:          Cheap,
+		AvoidProvider: "claude",
+	}, llmexec.Options{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if meta.Provider == "claude" {
+		t.Fatalf("provider = claude, want different provider")
+	}
+}
+
+func TestRunSetsTierModels(t *testing.T) {
+	restore := stubRunner(func(_ context.Context, _ string, opts llmexec.Options) (llmexec.Result, error) {
+		want := map[string]string{"claude": "haiku", "codex": "gpt-5.4-mini", "copilot": "gpt-5-mini"}
+		if !reflect.DeepEqual(opts.Models, want) {
+			t.Fatalf("models = %#v, want %#v", opts.Models, want)
+		}
+		return llmexec.Result{Provider: "claude", Text: `{"ok":true}`}, nil
+	})
+	defer restore()
+
+	if _, _, err := Run(context.Background(), "prompt", Spec[testOut]{Name: "models", Tier: Cheap}, llmexec.Options{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+func TestModelsForClones(t *testing.T) {
+	got := modelsFor(Standard)
+	got["claude"] = "mutated"
+	again := modelsFor(Standard)
+	if again["claude"] != "sonnet" || again["codex"] != "gpt-5.5" || again["copilot"] != "" {
+		t.Fatalf("modelsFor did not clone standard row: %#v", again)
+	}
+}
+
+func stubRunner(fn runnerFunc) func() {
+	prev := runJSON
+	runJSON = fn
+	return func() {
+		runJSON = prev
+	}
+}

--- a/internal/llmjob/tier.go
+++ b/internal/llmjob/tier.go
@@ -1,0 +1,41 @@
+package llmjob
+
+import "maps"
+
+// Tier describes the cost/capability class for a short structured LLM job.
+type Tier int
+
+const (
+	Cheap Tier = iota
+	Standard
+	Deep
+)
+
+var tierModels = map[Tier]map[string]string{
+	Cheap: {
+		"claude": "haiku",
+		"codex":  "gpt-5.4-mini",
+		// GPT-5 mini and GPT-4.1 are Copilot's no-premium-request tiers.
+		"copilot": "gpt-5-mini",
+	},
+	Standard: {
+		"claude":  "sonnet",
+		"codex":   "gpt-5.5",
+		"copilot": "",
+	},
+	Deep: {
+		"claude":  "opus",
+		"codex":   "gpt-5.5",
+		"copilot": "",
+	},
+}
+
+func modelsFor(t Tier) map[string]string {
+	row, ok := tierModels[t]
+	if !ok {
+		row = tierModels[Standard]
+	}
+	out := make(map[string]string, len(row))
+	maps.Copy(out, row)
+	return out
+}

--- a/internal/selfmonitor/judge.go
+++ b/internal/selfmonitor/judge.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/health"
 	"github.com/Automaat/sybra/internal/llmexec"
+	"github.com/Automaat/sybra/internal/llmjob"
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/task"
 )
@@ -39,16 +40,34 @@ func (j *ClaudeJudge) Judge(ctx context.Context, f health.Finding, ls *LogSummar
 
 	prompt := buildJudgePrompt(f, ls, t)
 
-	res, err := llmexec.RunJSON(ctx, prompt, llmexec.Options{Model: model, Logger: j.Logger, Gate: j.Gate})
+	v, _, err := llmjob.Run(ctx, prompt, llmjob.Spec[Verdict]{
+		Name:     "selfmonitor-judge",
+		Tier:     selfMonitorTier(model),
+		Validate: validateJudgeVerdict,
+	}, llmexec.Options{Logger: j.Logger, Gate: j.Gate})
 	if err != nil {
 		return Verdict{Classification: VerdictPending}, err
 	}
-
-	v, err := parseJudgeVerdict([]byte(res.Text))
-	if err != nil {
-		return Verdict{Classification: VerdictPending}, fmt.Errorf("parse %s verdict: %w", res.Provider, err)
-	}
 	return v, nil
+}
+
+func selfMonitorTier(model string) llmjob.Tier {
+	model = strings.ToLower(model)
+	switch {
+	case strings.Contains(model, "opus"):
+		return llmjob.Deep
+	case strings.Contains(model, "haiku"):
+		return llmjob.Cheap
+	default:
+		return llmjob.Standard
+	}
+}
+
+func validateJudgeVerdict(v *Verdict) error {
+	if v.Classification == "" {
+		v.Classification = VerdictPending
+	}
+	return nil
 }
 
 func buildJudgePrompt(f health.Finding, ls *LogSummary, t *task.Task) string {
@@ -134,9 +153,7 @@ func parseJudgeVerdict(raw []byte) (Verdict, error) {
 	if err := json.Unmarshal([]byte(jsonStr), &v); err != nil {
 		return Verdict{}, fmt.Errorf("unmarshal verdict: %w", err)
 	}
-	if v.Classification == "" {
-		v.Classification = VerdictPending
-	}
+	_ = validateJudgeVerdict(&v)
 	return v, nil
 }
 

--- a/internal/triage/classifier.go
+++ b/internal/triage/classifier.go
@@ -75,11 +75,19 @@ func (c *FallbackClassifier) Classify(ctx context.Context, t task.Task, projects
 	}, llmexec.Options{
 		Logger: c.Logger,
 		Gate:   c.Gate,
+		Models: claudeModelOverride(c.Model),
 	})
 	if err != nil {
 		return Verdict{}, err
 	}
 	return v, nil
+}
+
+func claudeModelOverride(model string) map[string]string {
+	if strings.TrimSpace(model) == "" {
+		return nil
+	}
+	return map[string]string{"claude": model}
 }
 
 func buildPrompt(t task.Task, projects []project.Project) string {

--- a/internal/triage/classifier.go
+++ b/internal/triage/classifier.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Automaat/sybra/internal/llmexec"
+	"github.com/Automaat/sybra/internal/llmjob"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/task"
@@ -67,24 +68,16 @@ func (c *ClaudeClassifier) Classify(ctx context.Context, t task.Task, projects [
 // Classify shells out to the first available provider and falls back when it is
 // rate-limited/logged-out/unavailable.
 func (c *FallbackClassifier) Classify(ctx context.Context, t task.Task, projects []project.Project) (Verdict, error) {
-	model := c.Model
-	if model == "" {
-		model = "sonnet"
-	}
-	res, err := llmexec.RunJSON(ctx, buildPrompt(t, projects), llmexec.Options{
-		Model:  model,
+	v, _, err := llmjob.Run(ctx, buildPrompt(t, projects), llmjob.Spec[Verdict]{
+		Name:     "triage",
+		Tier:     llmjob.Cheap,
+		Validate: ValidateVerdict,
+	}, llmexec.Options{
 		Logger: c.Logger,
 		Gate:   c.Gate,
 	})
 	if err != nil {
 		return Verdict{}, err
-	}
-	v, err := parseVerdict([]byte(res.Text))
-	if err != nil {
-		return Verdict{}, fmt.Errorf("parse %s verdict: %w", res.Provider, err)
-	}
-	if err := ValidateVerdict(&v); err != nil {
-		return Verdict{}, fmt.Errorf("validate verdict: %w", err)
 	}
 	return v, nil
 }

--- a/internal/triage/classifier_test.go
+++ b/internal/triage/classifier_test.go
@@ -1,6 +1,10 @@
 package triage
 
 import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -62,5 +66,32 @@ func TestExtractLastJSONObject(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("extract(%q) = %q, want %q", tc.in, got, tc.want)
 		}
+	}
+}
+
+func TestFallbackClassifierPassesConfiguredClaudeModel(t *testing.T) {
+	dir := t.TempDir()
+	writeTestExe(t, filepath.Join(dir, "claude"), `#!/bin/bash
+if [[ "$*" != *"--model opus"* ]]; then
+  echo "missing configured model flag: $*" >&2
+  exit 7
+fi
+printf '%s\n' '{"result":"{\"title\":\"fix(api): handle bug\",\"original_title\":\"bug\",\"description\":\"\",\"tags\":[\"backend\",\"small\",\"bug\"],\"size\":\"small\",\"type\":\"bug\",\"mode\":\"headless\",\"project_id\":\"\"}"}'
+`)
+	t.Setenv("PATH", dir)
+
+	_, err := (&FallbackClassifier{
+		Model:  "opus",
+		Logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
+	}).Classify(context.Background(), task.Task{Title: "bug"}, nil)
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+}
+
+func writeTestExe(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -217,7 +217,7 @@ func FallbackPlannerRunner(model string, gates ...provider.HealthGate) Runner {
 		plan, _, err := llmjob.Run(ctx, prompt, llmjob.Spec[Plan]{
 			Name: "umbrella-order",
 			Tier: llmjob.Standard,
-		}, llmexec.Options{Gate: gate})
+		}, llmexec.Options{Gate: gate, Models: claudeModelOverride(model)})
 		if err != nil {
 			return "", err
 		}
@@ -227,6 +227,13 @@ func FallbackPlannerRunner(model string, gates ...provider.HealthGate) Runner {
 		}
 		return string(out), nil
 	}
+}
+
+func claudeModelOverride(model string) map[string]string {
+	if strings.TrimSpace(model) == "" {
+		return nil
+	}
+	return map[string]string{"claude": model}
 }
 
 // IsUmbrellaIssue reports whether a GitHub issue should be auto-expanded as an

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -2,6 +2,7 @@ package umbrella
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/llmexec"
+	"github.com/Automaat/sybra/internal/llmjob"
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/task"
 )
@@ -212,11 +214,18 @@ func FallbackPlannerRunner(model string, gates ...provider.HealthGate) Runner {
 		gate = gates[0]
 	}
 	return func(ctx context.Context, prompt string) (string, error) {
-		res, err := llmexec.RunJSON(ctx, prompt, llmexec.Options{Model: model, Gate: gate})
+		plan, _, err := llmjob.Run(ctx, prompt, llmjob.Spec[Plan]{
+			Name: "umbrella-order",
+			Tier: llmjob.Standard,
+		}, llmexec.Options{Gate: gate})
 		if err != nil {
 			return "", err
 		}
-		return res.Text, nil
+		out, err := json.Marshal(plan)
+		if err != nil {
+			return "", fmt.Errorf("marshal planner result: %w", err)
+		}
+		return string(out), nil
 	}
 }
 

--- a/internal/umbrella/planner_test.go
+++ b/internal/umbrella/planner_test.go
@@ -3,6 +3,8 @@ package umbrella
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -245,4 +247,31 @@ func TestGenerate(t *testing.T) {
 			t.Error("expected cycle to be rejected")
 		}
 	})
+}
+
+func TestFallbackPlannerRunnerPassesConfiguredClaudeModel(t *testing.T) {
+	dir := t.TempDir()
+	writePlannerTestExe(t, filepath.Join(dir, "claude"), `#!/bin/bash
+if [[ "$*" != *"--model opus"* ]]; then
+  echo "missing configured model flag: $*" >&2
+  exit 7
+fi
+printf '%s\n' '{"result":"{\"children\":[{\"issue\":\"o/r#1\",\"dependsOn\":[]}],\"maxParallel\":1}"}'
+`)
+	t.Setenv("PATH", dir)
+
+	out, err := FallbackPlannerRunner("opus")(context.Background(), "prompt")
+	if err != nil {
+		t.Fatalf("runner: %v", err)
+	}
+	if !strings.Contains(out, `"maxParallel":1`) {
+		t.Fatalf("planner output = %q, want marshaled plan", out)
+	}
+}
+
+func writePlannerTestExe(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
 }


### PR DESCRIPTION
## Motivation
Structured LLM calls need a shared job layer that can pick an appropriate model tier, apply consistent retry/fallback behavior, and keep downstream callers from duplicating provider-specific execution policy.

## Implementation information
- Adds an `internal/llmjob` package with typed job specs, model tier selection, and structured execution helpers.
- Wires tiered job execution into A/B selection, agent inspection, evaluation judging, self-monitoring, triage classification, and umbrella planning.
- Extends `llmexec` behavior and adds focused tests for tier selection, fallbacks, selector behavior, classifier handling, and planner output.