### PR TITLE
feat(workflow): route prompt and skill variants

### DIFF
--- a/internal/abtest/model.go
+++ b/internal/abtest/model.go
@@ -31,14 +31,22 @@ type Subject struct {
 
 // Variant is one provider/model arm of an experiment.
 type Variant struct {
-	ID              string `yaml:"id" json:"id"`
-	Provider        string `yaml:"provider" json:"provider"`
-	Model           string `yaml:"model" json:"model"`
-	ReasoningEffort string `yaml:"reasoning_effort,omitempty" json:"reasoningEffort,omitempty"`
-	Tier            string `yaml:"tier,omitempty" json:"tier,omitempty"` // "cheap" or "expensive"
-	Version         string `yaml:"version,omitempty" json:"version,omitempty"`
-	Digest          string `yaml:"digest,omitempty" json:"digest,omitempty"`
-	Weight          int    `yaml:"weight" json:"weight"`
+	ID              string            `yaml:"id" json:"id"`
+	Provider        string            `yaml:"provider" json:"provider"`
+	Model           string            `yaml:"model" json:"model"`
+	ReasoningEffort string            `yaml:"reasoning_effort,omitempty" json:"reasoningEffort,omitempty"`
+	Tier            string            `yaml:"tier,omitempty" json:"tier,omitempty"` // "cheap" or "expensive"
+	Version         string            `yaml:"version,omitempty" json:"version,omitempty"`
+	Digest          string            `yaml:"digest,omitempty" json:"digest,omitempty"`
+	PromptTransform *PromptTransform  `yaml:"prompt_transform,omitempty" json:"promptTransform,omitempty"`
+	SkillAliases    map[string]string `yaml:"skill_aliases,omitempty" json:"skillAliases,omitempty"`
+	Weight          int               `yaml:"weight" json:"weight"`
+}
+
+// PromptTransform describes an optional variant-specific prompt rewrite.
+type PromptTransform struct {
+	Op   string `yaml:"op,omitempty" json:"op,omitempty"`
+	Text string `yaml:"text,omitempty" json:"text,omitempty"`
 }
 
 // Assignment is the durable identity selected for a workflow stage.
@@ -51,6 +59,8 @@ type Assignment struct {
 	ReasoningEffort string
 	AssignmentUnit  string
 	AssignmentKey   string
+	PromptTransform *PromptTransform
+	SkillAliases    map[string]string
 }
 
 // DefaultConfig returns the default A/B suite split by price bracket: code

--- a/internal/abtest/selector.go
+++ b/internal/abtest/selector.go
@@ -15,20 +15,34 @@ func Select(cfg Config, taskID, role, stepID string) (Assignment, bool, error) {
 	return SelectEligible(cfg, taskID, role, stepID, nil)
 }
 
+// SelectionContext identifies the workflow step currently being assigned.
+type SelectionContext struct {
+	TaskID     string
+	WorkflowID string
+	Role       string
+	StepID     string
+	Prompt     string
+}
+
 // SelectEligible is Select with an optional provider eligibility predicate.
 // Ineligible positive-weight variants are excluded before hashing so machines
 // without a CLI do not silently fall back to a different provider while keeping
 // stale experiment attribution.
 func SelectEligible(cfg Config, taskID, role, stepID string, providerAllowed func(string) bool) (Assignment, bool, error) {
+	return SelectEligibleForContext(cfg, SelectionContext{TaskID: taskID, Role: role, StepID: stepID}, providerAllowed)
+}
+
+// SelectEligibleForContext is SelectEligible with workflow subject context.
+func SelectEligibleForContext(cfg Config, ctx SelectionContext, providerAllowed func(string) bool) (Assignment, bool, error) {
 	if !cfg.EnabledValue() {
 		return Assignment{}, false, nil
 	}
 	for i := range cfg.Experiments {
 		exp := cfg.Experiments[i]
-		if !exp.EnabledValue() || !roleMatches(exp.Roles, role) {
+		if !exp.EnabledValue() || !roleMatches(exp.Roles, ctx.Role) || !subjectMatches(exp.Subject, ctx) {
 			continue
 		}
-		return selectFromExperiment(exp, taskID, role, stepID, providerAllowed)
+		return selectFromExperiment(exp, ctx.TaskID, ctx.Role, ctx.StepID, providerAllowed)
 	}
 	return Assignment{}, false, nil
 }
@@ -98,6 +112,32 @@ func roleMatches(roles []string, role string) bool {
 		role = "implementation"
 	}
 	return slices.Contains(roles, role)
+}
+
+func subjectMatches(subject *Subject, ctx SelectionContext) bool {
+	if subject == nil {
+		return true
+	}
+	if want := strings.TrimSpace(subject.WorkflowID); want != "" && want != ctx.WorkflowID {
+		return false
+	}
+	if want := strings.TrimSpace(subject.StepID); want != "" && want != ctx.StepID {
+		return false
+	}
+	if want := strings.TrimSpace(subject.Role); want != "" && want != defaultRole(ctx.Role) {
+		return false
+	}
+	if want := strings.TrimSpace(subject.SkillName); want != "" && !skillinvoke.ContainsInvocation(ctx.Prompt, want) {
+		return false
+	}
+	return true
+}
+
+func defaultRole(role string) string {
+	if role == "" {
+		return "implementation"
+	}
+	return role
 }
 
 func validateExperiment(exp Experiment, providerAllowed func(string) bool) error {

--- a/internal/abtest/selector.go
+++ b/internal/abtest/selector.go
@@ -5,6 +5,8 @@ import (
 	"hash/fnv"
 	"slices"
 	"strings"
+
+	"github.com/Automaat/sybra/internal/skillinvoke"
 )
 
 // Select deterministically chooses a variant for the task/stage. It returns
@@ -63,6 +65,8 @@ func selectFromExperiment(exp Experiment, taskID, role, stepID string, providerA
 				ReasoningEffort: v.ReasoningEffort,
 				AssignmentUnit:  unit,
 				AssignmentKey:   key,
+				PromptTransform: clonePromptTransform(v.PromptTransform),
+				SkillAliases:    cloneSkillAliases(v.SkillAliases),
 			}, true, nil
 		}
 	}
@@ -203,7 +207,77 @@ func validateVariant(expID string, v Variant) error {
 	default:
 		return fmt.Errorf("abtest: variant %q has invalid tier %q", v.ID, v.Tier)
 	}
+	if err := validatePromptTransform(v); err != nil {
+		return err
+	}
+	if err := validateSkillAliases(v); err != nil {
+		return err
+	}
 	return nil
+}
+
+func validatePromptTransform(v Variant) error {
+	if v.PromptTransform == nil {
+		return nil
+	}
+	op := strings.TrimSpace(v.PromptTransform.Op)
+	text := strings.TrimSpace(v.PromptTransform.Text)
+	switch op {
+	case "":
+		return nil
+	case "replace", "template":
+		if text == "" {
+			return fmt.Errorf("abtest: variant %q prompt_transform %q requires text", v.ID, op)
+		}
+	case "prepend", "append":
+	default:
+		return fmt.Errorf("abtest: variant %q has invalid prompt_transform op %q", v.ID, v.PromptTransform.Op)
+	}
+	return nil
+}
+
+func validateSkillAliases(v Variant) error {
+	for from, to := range v.SkillAliases {
+		if from != strings.TrimSpace(from) {
+			return fmt.Errorf("abtest: variant %q has invalid skill alias source %q", v.ID, from)
+		}
+		if to != strings.TrimSpace(to) {
+			return fmt.Errorf("abtest: variant %q has invalid skill alias target %q", v.ID, to)
+		}
+		normalizedFrom, ok := skillinvoke.NormalizeName(from)
+		if !ok || normalizedFrom != strings.TrimPrefix(strings.TrimSpace(from), "/") {
+			return fmt.Errorf("abtest: variant %q has invalid skill alias source %q", v.ID, from)
+		}
+		normalizedTo, ok := skillinvoke.NormalizeName(to)
+		if !ok || normalizedTo != strings.TrimPrefix(strings.TrimSpace(to), "/") {
+			return fmt.Errorf("abtest: variant %q has invalid skill alias target %q", v.ID, to)
+		}
+	}
+	return nil
+}
+
+func clonePromptTransform(in *PromptTransform) *PromptTransform {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	return &out
+}
+
+func cloneSkillAliases(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for from, to := range in {
+		normalizedFrom, okFrom := skillinvoke.NormalizeName(from)
+		normalizedTo, okTo := skillinvoke.NormalizeName(to)
+		if !okFrom || !okTo {
+			continue
+		}
+		out[normalizedFrom] = normalizedTo
+	}
+	return out
 }
 
 func hashKey(s string) uint64 {

--- a/internal/abtest/selector_test.go
+++ b/internal/abtest/selector_test.go
@@ -2,6 +2,7 @@ package abtest
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -25,7 +26,7 @@ func TestSelectDeterministic(t *testing.T) {
 		if err != nil || !ok {
 			t.Fatalf("Select repeat: ok=%v err=%v", ok, err)
 		}
-		if got != a {
+		if !reflect.DeepEqual(got, a) {
 			t.Fatalf("assignment changed: got %+v want %+v", got, a)
 		}
 	}
@@ -234,6 +235,85 @@ func TestSelectEligibleSkipsUnavailableProvider(t *testing.T) {
 	}
 	if a.VariantID != "available" {
 		t.Fatalf("VariantID = %q, want available", a.VariantID)
+	}
+}
+
+func TestSelectPromptSkillPayload(t *testing.T) {
+	enabled := true
+	cfg := Config{Enabled: &enabled, Experiments: []Experiment{{
+		ID:             "payload",
+		Kind:           "compound",
+		AssignmentUnit: "task",
+		Roles:          []string{"implementation"},
+		Variants: []Variant{{
+			ID:              "v2",
+			Provider:        "codex",
+			Model:           "gpt-5.5",
+			PromptTransform: &PromptTransform{Op: "append", Text: "\nUse the variant."},
+			SkillAliases:    map[string]string{"/sybra-test": "/sybra-test-v2"},
+			Weight:          1,
+		}},
+	}}}
+	a, ok, err := Select(cfg, "task-1", "implementation", "implement")
+	if err != nil || !ok {
+		t.Fatalf("Select ok=%v err=%v", ok, err)
+	}
+	if a.PromptTransform == nil || a.PromptTransform.Op != "append" || a.PromptTransform.Text != "\nUse the variant." {
+		t.Fatalf("PromptTransform = %+v", a.PromptTransform)
+	}
+	if got := a.SkillAliases["sybra-test"]; got != "sybra-test-v2" {
+		t.Fatalf("SkillAliases[sybra-test] = %q", got)
+	}
+}
+
+func TestValidateVariantPromptTransform(t *testing.T) {
+	tests := []struct {
+		name    string
+		pt      *PromptTransform
+		wantErr bool
+	}{
+		{name: "nil"},
+		{name: "empty op", pt: &PromptTransform{}},
+		{name: "prepend empty text", pt: &PromptTransform{Op: "prepend"}},
+		{name: "append empty text", pt: &PromptTransform{Op: "append"}},
+		{name: "replace text", pt: &PromptTransform{Op: "replace", Text: "x"}},
+		{name: "template text", pt: &PromptTransform{Op: "template", Text: "x"}},
+		{name: "replace empty", pt: &PromptTransform{Op: "replace"}, wantErr: true},
+		{name: "template whitespace", pt: &PromptTransform{Op: "template", Text: " \t"}, wantErr: true},
+		{name: "unknown", pt: &PromptTransform{Op: "merge", Text: "x"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateVariant("exp", Variant{ID: "v", Provider: "claude", Model: "sonnet", PromptTransform: tt.pt})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateVariant err = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateVariantSkillAliases(t *testing.T) {
+	tests := []struct {
+		name    string
+		aliases map[string]string
+		wantErr bool
+	}{
+		{name: "nil"},
+		{name: "slash and no slash", aliases: map[string]string{"/sybra-test": "sybra-test-v2"}},
+		{name: "empty source", aliases: map[string]string{"": "sybra-test-v2"}, wantErr: true},
+		{name: "empty target", aliases: map[string]string{"sybra-test": ""}, wantErr: true},
+		{name: "whitespace source", aliases: map[string]string{" sybra-test": "sybra-test-v2"}, wantErr: true},
+		{name: "path source", aliases: map[string]string{"tmp/sybra-test": "sybra-test-v2"}, wantErr: true},
+		{name: "dollar target", aliases: map[string]string{"sybra-test": "$sybra-test-v2"}, wantErr: true},
+		{name: "uppercase target", aliases: map[string]string{"sybra-test": "Sybra-Test-V2"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateVariant("exp", Variant{ID: "v", Provider: "claude", Model: "sonnet", SkillAliases: tt.aliases})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateVariant err = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/internal/agent/skill_invoke.go
+++ b/internal/agent/skill_invoke.go
@@ -1,19 +1,18 @@
 package agent
 
 import (
-	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"slices"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/Automaat/sybra/internal/skillinvoke"
 	"gopkg.in/yaml.v3"
 )
 
@@ -24,26 +23,7 @@ import (
 // character, and followed by a non-identifier char or end — so path
 // segments like `/tmp/sybra-plan-xxx.md` are never touched.
 func rewriteSkillInvocations(prompt string, skillNames []string) string {
-	if len(skillNames) == 0 || prompt == "" {
-		return prompt
-	}
-	// Sort descending by length so longer names are tried first (avoids a
-	// shorter prefix like "plan" consuming part of "plan-critic").
-	sorted := make([]string, len(skillNames))
-	copy(sorted, skillNames)
-	slices.SortFunc(sorted, func(a, b string) int { return cmp.Compare(len(b), len(a)) })
-	for _, name := range sorted {
-		if name == "" {
-			continue
-		}
-		pattern := `(^|[^\w/])/` + regexp.QuoteMeta(name) + `([^a-z0-9-]|$)`
-		re, err := regexp.Compile(pattern)
-		if err != nil {
-			continue
-		}
-		prompt = re.ReplaceAllString(prompt, "${1}$$"+name+"${2}")
-	}
-	return prompt
+	return skillinvoke.RewriteInvocations(prompt, skillNames)
 }
 
 // discoverCodexSkills returns the union of skill names sybra knows about for

--- a/internal/agent/skill_invoke_test.go
+++ b/internal/agent/skill_invoke_test.go
@@ -6,7 +6,11 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/skillinvoke"
 )
 
 func TestRewriteSkillInvocations(t *testing.T) {
@@ -80,6 +84,27 @@ func TestRewriteSkillInvocations(t *testing.T) {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestBuildHeadlessInvocation_CodexConvertsAliasedSkill(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	resetCodexSkillsCache(t)
+	mkLocalSkill(t, filepath.Join(home, ".codex", "skills"), "sybra-test-v2")
+	withCodexPluginListJSON(t, []byte(`{"installed":[]}`))
+
+	aliased := skillinvoke.ApplyAliases("Run /sybra-test now", map[string]string{"sybra-test": "sybra-test-v2"})
+	inv, err := (codexProvider{}).BuildHeadlessInvocation(&Agent{ID: "a", Provider: "codex"}, RunConfig{Prompt: aliased})
+	if err != nil {
+		t.Fatalf("BuildHeadlessInvocation: %v", err)
+	}
+	got := inv.args[len(inv.args)-1]
+	if got != "Run $sybra-test-v2 now" {
+		t.Fatalf("prompt arg = %q, want Codex dollar invocation", got)
+	}
+	if strings.Contains(got, "/sybra-test") || strings.Contains(got, "$sybra-test now") {
+		t.Fatalf("prompt was not fully aliased before Codex rewrite: %q", got)
 	}
 }
 
@@ -586,6 +611,25 @@ func writePluginManifest(t *testing.T, path, skills string) {
 		t.Fatal(err)
 	}
 	writePluginManifestJSON(t, path, data)
+}
+
+func resetCodexSkillsCache(t *testing.T) {
+	t.Helper()
+	codexSkillsCacheMu.Lock()
+	origHome := codexSkillsCacheHome
+	origNames := cloneSkillNames(codexSkillsCacheNames)
+	origExpires := codexSkillsCacheExpires
+	codexSkillsCacheHome = ""
+	codexSkillsCacheNames = nil
+	codexSkillsCacheExpires = time.Time{}
+	codexSkillsCacheMu.Unlock()
+	t.Cleanup(func() {
+		codexSkillsCacheMu.Lock()
+		codexSkillsCacheHome = origHome
+		codexSkillsCacheNames = origNames
+		codexSkillsCacheExpires = origExpires
+		codexSkillsCacheMu.Unlock()
+	})
 }
 
 func writePluginManifestJSON(t *testing.T, path string, data []byte) {

--- a/internal/evaluation/scorecard.go
+++ b/internal/evaluation/scorecard.go
@@ -863,13 +863,15 @@ func configuredExperimentRoles(experiments []abtest.Experiment, rows []Compariso
 		eligible, _ := abtest.EligibleVariants(exp, nil)
 		variants := make([]string, 0, len(eligible))
 		disabled := map[string]bool{}
-		for _, v := range exp.Variants {
+		for i := range exp.Variants {
+			v := &exp.Variants[i]
 			if v.ID != "" && v.Weight <= 0 {
 				disabled[v.ID] = true
 			}
 		}
 		baseline := ""
-		for _, v := range eligible {
+		for i := range eligible {
+			v := &eligible[i]
 			if v.ID != "" {
 				if baseline == "" {
 					baseline = v.ID

--- a/internal/skillinvoke/skillinvoke.go
+++ b/internal/skillinvoke/skillinvoke.go
@@ -52,6 +52,16 @@ func RewriteInvocations(prompt string, skillNames []string) string {
 	return out.String()
 }
 
+// ContainsInvocation reports whether prompt contains a slash invocation for
+// the named skill. Path-like text such as /tmp/skill.md is ignored.
+func ContainsInvocation(prompt, skillName string) bool {
+	normalized, ok := NormalizeName(skillName)
+	if !ok || prompt == "" {
+		return false
+	}
+	return len(findMatches(prompt, []string{normalized})) > 0
+}
+
 // ApplyAliases rewrites known slash skill invocations to another slash skill
 // name. The pass is non-chaining: all matches are found against the original
 // prompt before replacements are emitted.

--- a/internal/skillinvoke/skillinvoke.go
+++ b/internal/skillinvoke/skillinvoke.go
@@ -1,0 +1,168 @@
+package skillinvoke
+
+import (
+	"cmp"
+	"regexp"
+	"slices"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+var validNameRe = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+
+// NormalizeName returns the canonical skill invocation name without a leading
+// slash. Invalid names return ok=false.
+func NormalizeName(name string) (normalized string, ok bool) {
+	name = strings.TrimSpace(name)
+	name = strings.TrimPrefix(name, "/")
+	if name == "" || strings.HasPrefix(name, "$") || strings.Contains(name, "/") {
+		return "", false
+	}
+	if !validNameRe.MatchString(name) {
+		return "", false
+	}
+	return name, true
+}
+
+// RewriteInvocations converts known slash skill invocations to Codex's
+// dollar-prefixed syntax.
+func RewriteInvocations(prompt string, skillNames []string) string {
+	if prompt == "" || len(skillNames) == 0 {
+		return prompt
+	}
+	names := normalizedUniqueNames(skillNames)
+	if len(names) == 0 {
+		return prompt
+	}
+	matches := findMatches(prompt, names)
+	if len(matches) == 0 {
+		return prompt
+	}
+	var out strings.Builder
+	out.Grow(len(prompt))
+	last := 0
+	for _, m := range matches {
+		out.WriteString(prompt[last:m.start])
+		out.WriteByte('$')
+		out.WriteString(m.name)
+		last = m.end
+	}
+	out.WriteString(prompt[last:])
+	return out.String()
+}
+
+// ApplyAliases rewrites known slash skill invocations to another slash skill
+// name. The pass is non-chaining: all matches are found against the original
+// prompt before replacements are emitted.
+func ApplyAliases(prompt string, aliases map[string]string) string {
+	if prompt == "" || len(aliases) == 0 {
+		return prompt
+	}
+	normalized := make(map[string]string, len(aliases))
+	names := make([]string, 0, len(aliases))
+	for src, dst := range aliases {
+		from, ok := NormalizeName(src)
+		if !ok {
+			continue
+		}
+		to, ok := NormalizeName(dst)
+		if !ok {
+			continue
+		}
+		normalized[from] = to
+		names = append(names, from)
+	}
+	names = normalizedUniqueNames(names)
+	if len(names) == 0 {
+		return prompt
+	}
+	matches := findMatches(prompt, names)
+	if len(matches) == 0 {
+		return prompt
+	}
+	var out strings.Builder
+	out.Grow(len(prompt))
+	last := 0
+	for _, m := range matches {
+		out.WriteString(prompt[last:m.start])
+		out.WriteByte('/')
+		out.WriteString(normalized[m.name])
+		last = m.end
+	}
+	out.WriteString(prompt[last:])
+	return out.String()
+}
+
+type invocationMatch struct {
+	start int
+	end   int
+	name  string
+}
+
+func normalizedUniqueNames(names []string) []string {
+	seen := make(map[string]struct{}, len(names))
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		normalized, ok := NormalizeName(name)
+		if !ok {
+			continue
+		}
+		if _, exists := seen[normalized]; exists {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		out = append(out, normalized)
+	}
+	slices.SortFunc(out, func(a, b string) int {
+		if byLen := cmp.Compare(len(b), len(a)); byLen != 0 {
+			return byLen
+		}
+		return cmp.Compare(a, b)
+	})
+	return out
+}
+
+func findMatches(prompt string, names []string) []invocationMatch {
+	var matches []invocationMatch
+	for i := 0; i < len(prompt); i++ {
+		if prompt[i] != '/' || !validBefore(prompt, i) {
+			continue
+		}
+		afterSlash := i + 1
+		for _, name := range names {
+			end := afterSlash + len(name)
+			if end > len(prompt) || prompt[afterSlash:end] != name || !validAfter(prompt, end) {
+				continue
+			}
+			matches = append(matches, invocationMatch{start: i, end: end, name: name})
+			i = end - 1
+			break
+		}
+	}
+	return matches
+}
+
+func validBefore(s string, idx int) bool {
+	if idx == 0 {
+		return true
+	}
+	r, _ := utf8.DecodeLastRuneInString(s[:idx])
+	return !isWord(r) && r != '/'
+}
+
+func validAfter(s string, idx int) bool {
+	if idx >= len(s) {
+		return true
+	}
+	r, _ := utf8.DecodeRuneInString(s[idx:])
+	return !isNameRune(r)
+}
+
+func isWord(r rune) bool {
+	return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+func isNameRune(r rune) bool {
+	return r == '-' || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+}

--- a/internal/skillinvoke/skillinvoke_test.go
+++ b/internal/skillinvoke/skillinvoke_test.go
@@ -38,6 +38,16 @@ func TestRewriteInvocations(t *testing.T) {
 	}
 }
 
+func TestContainsInvocation(t *testing.T) {
+	t.Parallel()
+	if !ContainsInvocation("Run /sybra-test now.", "sybra-test") {
+		t.Fatal("ContainsInvocation returned false for a slash invocation")
+	}
+	if ContainsInvocation("Ignore /tmp/sybra-test.md and /sybra-test-v2.", "sybra-test") {
+		t.Fatal("ContainsInvocation matched a path or longer skill name")
+	}
+}
+
 func TestApplyAliases(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/skillinvoke/skillinvoke_test.go
+++ b/internal/skillinvoke/skillinvoke_test.go
@@ -1,0 +1,82 @@
+package skillinvoke
+
+import "testing"
+
+func TestNormalizeName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{in: "sybra-test", want: "sybra-test", ok: true},
+		{in: "/sybra-test", want: "sybra-test", ok: true},
+		{in: "", ok: false},
+		{in: " ", ok: false},
+		{in: "Sybra-Test", ok: false},
+		{in: "$sybra-test", ok: false},
+		{in: "tmp/sybra-test", ok: false},
+		{in: "sybra_test", ok: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
+			got, ok := NormalizeName(tt.in)
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("NormalizeName(%q) = %q, %v; want %q, %v", tt.in, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestRewriteInvocations(t *testing.T) {
+	t.Parallel()
+	got := RewriteInvocations("Run /plan-critic, not /tmp/plan-critic or /plan-critic-extra.", []string{"plan", "plan-critic"})
+	want := "Run $plan-critic, not /tmp/plan-critic or /plan-critic-extra."
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestApplyAliases(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		prompt  string
+		aliases map[string]string
+		want    string
+	}{
+		{
+			name:    "slash aliases",
+			prompt:  "Run /sybra-test now.",
+			aliases: map[string]string{"/sybra-test": "/sybra-test-v2"},
+			want:    "Run /sybra-test-v2 now.",
+		},
+		{
+			name:    "boundary and path",
+			prompt:  "/sybra-test /tmp/sybra-test.md /sybra-test-extra x/sybra-test",
+			aliases: map[string]string{"sybra-test": "sybra-test-v2"},
+			want:    "/sybra-test-v2 /tmp/sybra-test.md /sybra-test-extra x/sybra-test",
+		},
+		{
+			name:    "overlap longest wins",
+			prompt:  "/plan-critic /plan",
+			aliases: map[string]string{"plan": "plan-v2", "plan-critic": "plan-critic-v2"},
+			want:    "/plan-critic-v2 /plan-v2",
+		},
+		{
+			name:    "no chaining",
+			prompt:  "/a",
+			aliases: map[string]string{"a": "b", "b": "c"},
+			want:    "/b",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ApplyAliases(tt.prompt, tt.aliases); got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/workflow/agent_iface.go
+++ b/internal/workflow/agent_iface.go
@@ -52,6 +52,15 @@ type AgentAssignment struct {
 	AssignmentUnit  string
 	AssignmentKey   string
 	ReasoningEffort string
+	PromptTransform *PromptTransform
+	SkillAliases    map[string]string
+}
+
+// PromptTransform mirrors the A/B assignment payload used to rewrite a prompt
+// template before workflow rendering.
+type PromptTransform struct {
+	Op   string
+	Text string
 }
 
 // WorkflowVarDir is the reserved variable name used to pass a pre-prepared

--- a/internal/workflow/engine_parallel_test.go
+++ b/internal/workflow/engine_parallel_test.go
@@ -245,6 +245,61 @@ func TestParallel_AppliesABAssignmentToAuthorChildren(t *testing.T) {
 	}
 }
 
+func TestParallel_AppliesPromptAndSkillVariantPayloads(t *testing.T) {
+	prev := providerAvailable
+	providerAvailable = func(string) bool { return true }
+	t.Cleanup(func() { providerAvailable = prev })
+
+	store := newTestStore(t)
+	def := Definition{
+		ID:      "ab-parallel-payload",
+		Trigger: Trigger{On: "manual"},
+		Steps: []Step{{
+			ID:   "implement_both",
+			Type: StepParallel,
+			Parallel: []Step{
+				{ID: "impl_a", Type: StepRunAgent, Config: StepConfig{Role: "implementation", Mode: "headless", Prompt: "control {{.Step.ID}} /sybra-test"}},
+				{ID: "impl_b", Type: StepRunAgent, Config: StepConfig{Role: "implementation", Mode: "headless", Prompt: "control {{.Step.ID}} /sybra-test"}},
+			},
+		}},
+	}
+	if err := store.Save(def); err != nil {
+		t.Fatalf("save workflow: %v", err)
+	}
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	enabled := true
+	engine.SetABTestingConfig(abtest.Config{Enabled: &enabled, Experiments: []abtest.Experiment{{
+		ID:             "payload-exp",
+		Kind:           "compound",
+		AssignmentUnit: "stage",
+		Roles:          []string{"implementation"},
+		Variants: []abtest.Variant{{
+			ID: "payload", Provider: "claude", Model: "sonnet", Weight: 1,
+			PromptTransform: &abtest.PromptTransform{Op: "prepend", Text: "variant {{.Step.ID}}: "},
+			SkillAliases:    map[string]string{"sybra-test": "sybra-test-v2"},
+		}},
+	}}})
+	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
+
+	if err := engine.StartWorkflow("t1", "ab-parallel-payload"); err != nil {
+		t.Fatalf("StartWorkflow: %v", err)
+	}
+	if got := agents.CallCount(); got != 2 {
+		t.Fatalf("StartAgent calls = %d, want 2", got)
+	}
+	for _, c := range agents.calls {
+		want := "variant " + c.Assignment.AssignmentKey[strings.LastIndex(c.Assignment.AssignmentKey, "|")+1:] + ": control " + c.Assignment.AssignmentKey[strings.LastIndex(c.Assignment.AssignmentKey, "|")+1:] + " /sybra-test-v2"
+		if c.Prompt != want {
+			t.Fatalf("parallel prompt = %q, want %q", c.Prompt, want)
+		}
+		if c.Assignment.PromptTransform == nil || c.Assignment.SkillAliases["sybra-test"] != "sybra-test-v2" {
+			t.Fatalf("parallel assignment missing payload: %+v", c.Assignment)
+		}
+	}
+}
+
 // TestParallel_AllCompleteAdvancesParent verifies that once every child
 // reports status=completed the parent step is recorded with status=completed
 // and the next step is dispatched.

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -214,11 +214,11 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 	return e.tasks.SetWorkflow(taskID, wfExec)
 }
 
-func (e *Engine) selectABVariant(taskID, role, stepID string) (AgentAssignment, bool, error) {
+func (e *Engine) selectABVariant(ctx abtest.SelectionContext) (AgentAssignment, bool, error) {
 	providerAllowed := func(provider string) bool {
 		return providerAvailable(provider) && !e.agents.ProviderRateLimited(provider)
 	}
-	a, ok, err := abtest.SelectEligible(e.abTesting, taskID, role, stepID, providerAllowed)
+	a, ok, err := abtest.SelectEligibleForContext(e.abTesting, ctx, providerAllowed)
 	if err != nil || !ok {
 		return AgentAssignment{}, ok, err
 	}
@@ -287,7 +287,13 @@ func (e *Engine) resolveAgentVariant(t TaskInfo, step *Step, wfExec *Execution, 
 	provider = resolveProvider(step.Config.Provider, wfExec, e.agents.DefaultProvider(), t)
 	resolvedModel = model
 	if step.Config.Provider == "" || step.Config.Provider == "ab" {
-		selected, ok, err := e.selectABVariant(t.ID, step.Config.Role, step.ID)
+		selected, ok, err := e.selectABVariant(abtest.SelectionContext{
+			TaskID:     t.ID,
+			WorkflowID: wfExec.WorkflowID,
+			Role:       step.Config.Role,
+			StepID:     step.ID,
+			Prompt:     step.Config.Prompt,
+		})
 		if err != nil {
 			return "", "", AgentAssignment{}, fmt.Errorf("select ab variant: %w", err)
 		}

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"slices"
 	"strings"
 
 	"github.com/Automaat/sybra/internal/abtest"
+	"github.com/Automaat/sybra/internal/skillinvoke"
 )
 
 // importSidecarIfConfigured reads the file the agent produced (template
@@ -111,34 +113,6 @@ func (e *Engine) failRequiredImport(taskID, stepID, kind, state string) {
 }
 
 func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx TemplateContext) error {
-	prompt, err := RenderTemplate(step.Config.Prompt, ctx)
-	if err != nil {
-		return fmt.Errorf("render prompt: %w", err)
-	}
-
-	// Consume a pending watchdog headless-nudge steer (no-op when none). Done
-	// here, before dispatch (fresh or resumed via ResumeStalled), so a step
-	// re-run after the watchdog stopped a looping agent carries the correction.
-	if steered, sErr := e.tasks.ConsumeSupervisorSteer(taskID, prompt); sErr != nil {
-		e.logger.Warn("workflow.consume-steer", "task_id", taskID, "step", step.ID, "err", sErr)
-	} else {
-		prompt = steered
-	}
-
-	// Reuse a live agent if configured and one exists for this role.
-	if step.Config.ReuseAgent {
-		if agentID, found := e.agents.FindRunningAgentForRole(taskID, step.Config.Role); found {
-			if sendErr := e.agents.SendPrompt(agentID, prompt); sendErr != nil {
-				e.logger.Warn("workflow.reuse-agent.send-failed", "task_id", taskID, "agent_id", agentID, "err", sendErr)
-				e.agents.StopAgentsForTask(taskID, step.Config.Role)
-			} else {
-				wfExec.State = ExecWaiting
-				e.logger.Info("workflow.reuse-agent", "task_id", taskID, "step", step.ID, "agent_id", agentID)
-				return e.tasks.SetWorkflow(taskID, wfExec)
-			}
-		}
-	}
-
 	prepareTestVerdictAttemptVars(wfExec, step.ID, ctx.Task.Body)
 
 	mode := step.Config.Mode
@@ -160,6 +134,25 @@ func (e *Engine) execRunAgent(taskID string, step *Step, wfExec *Execution, ctx 
 	provider, model, assignment, err := e.resolveAgentVariant(ctx.Task, step, wfExec, model, "workflow.cross-provider.fallback")
 	if err != nil {
 		return err
+	}
+
+	prompt, err := e.renderAssignedPrompt(taskID, step, ctx, assignment, "workflow.consume-steer")
+	if err != nil {
+		return err
+	}
+
+	// Reuse a live agent if configured and one exists for this role.
+	if step.Config.ReuseAgent {
+		if agentID, found := e.agents.FindRunningAgentForRole(taskID, step.Config.Role); found {
+			if sendErr := e.agents.SendPrompt(agentID, prompt); sendErr != nil {
+				e.logger.Warn("workflow.reuse-agent.send-failed", "task_id", taskID, "agent_id", agentID, "err", sendErr)
+				e.agents.StopAgentsForTask(taskID, step.Config.Role)
+			} else {
+				wfExec.State = ExecWaiting
+				e.logger.Info("workflow.reuse-agent", "task_id", taskID, "step", step.ID, "agent_id", agentID)
+				return e.tasks.SetWorkflow(taskID, wfExec)
+			}
+		}
 	}
 
 	dir := wfExec.Variables[WorkflowVarDir]
@@ -238,7 +231,55 @@ func (e *Engine) selectABVariant(taskID, role, stepID string) (AgentAssignment, 
 		AssignmentUnit:  a.AssignmentUnit,
 		AssignmentKey:   a.AssignmentKey,
 		ReasoningEffort: a.ReasoningEffort,
+		PromptTransform: workflowPromptTransform(a.PromptTransform),
+		SkillAliases:    cloneWorkflowSkillAliases(a.SkillAliases),
 	}, true, nil
+}
+
+func (e *Engine) renderAssignedPrompt(taskID string, step *Step, ctx TemplateContext, assignment AgentAssignment, steerLog string) (string, error) {
+	templateText := applyPromptTransform(step.Config.Prompt, assignment.PromptTransform)
+	prompt, err := RenderTemplate(templateText, ctx)
+	if err != nil {
+		return "", fmt.Errorf("render prompt: %w", err)
+	}
+	if steered, sErr := e.tasks.ConsumeSupervisorSteer(taskID, prompt); sErr != nil {
+		e.logger.Warn(steerLog, "task_id", taskID, "step", step.ID, "err", sErr)
+	} else {
+		prompt = steered
+	}
+	return skillinvoke.ApplyAliases(prompt, assignment.SkillAliases), nil
+}
+
+func applyPromptTransform(prompt string, transform *PromptTransform) string {
+	if transform == nil {
+		return prompt
+	}
+	switch strings.TrimSpace(transform.Op) {
+	case "replace", "template":
+		return transform.Text
+	case "prepend":
+		return transform.Text + prompt
+	case "append":
+		return prompt + transform.Text
+	default:
+		return prompt
+	}
+}
+
+func workflowPromptTransform(in *abtest.PromptTransform) *PromptTransform {
+	if in == nil {
+		return nil
+	}
+	return &PromptTransform{Op: in.Op, Text: in.Text}
+}
+
+func cloneWorkflowSkillAliases(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	maps.Copy(out, in)
+	return out
 }
 
 func (e *Engine) resolveAgentVariant(t TaskInfo, step *Step, wfExec *Execution, model, fallbackLog string) (provider, resolvedModel string, assignment AgentAssignment, err error) {

--- a/internal/workflow/engine_steps_parallel.go
+++ b/internal/workflow/engine_steps_parallel.go
@@ -107,19 +107,6 @@ func (e *Engine) spawnParallelChild(taskID string, parent, child *Step, wfExec *
 	// so {{.Step.ID}} et al. resolve correctly inside the prompt template.
 	childCtx := parentCtx
 	childCtx.Step = *child
-	prompt, err := RenderTemplate(child.Config.Prompt, childCtx)
-	if err != nil {
-		return fmt.Errorf("render prompt: %w", err)
-	}
-
-	// Consume a pending watchdog headless-nudge steer here too, so a steer set
-	// for a looping parallel child is delivered to (and cleared by) this
-	// dispatch rather than leaking into a later run_agent step's prompt.
-	if steered, sErr := e.tasks.ConsumeSupervisorSteer(taskID, prompt); sErr != nil {
-		e.logger.Warn("workflow.parallel.consume-steer", "task_id", taskID, "child", child.ID, "err", sErr)
-	} else {
-		prompt = steered
-	}
 
 	mode := child.Config.Mode
 	if strings.Contains(mode, "{{") {
@@ -136,6 +123,11 @@ func (e *Engine) spawnParallelChild(taskID string, parent, child *Step, wfExec *
 	}
 
 	provider, model, assignment, err := e.resolveAgentVariant(childCtx.Task, child, wfExec, model, "workflow.parallel.cross-provider.fallback")
+	if err != nil {
+		return err
+	}
+
+	prompt, err := e.renderAssignedPrompt(taskID, child, childCtx, assignment, "workflow.parallel.consume-steer")
 	if err != nil {
 		return err
 	}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2074,6 +2074,123 @@ func TestExecRunAgent_ABTestingOverridesProviderModel(t *testing.T) {
 	}
 }
 
+func TestExecRunAgentVariantPrompt(t *testing.T) {
+	prev := providerAvailable
+	providerAvailable = func(string) bool { return true }
+	t.Cleanup(func() { providerAvailable = prev })
+
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	enabled := true
+	engine.SetABTestingConfig(abtest.Config{Enabled: &enabled, Experiments: []abtest.Experiment{{
+		ID:             "prompt-exp",
+		Kind:           "prompt",
+		AssignmentUnit: "stage",
+		Roles:          []string{"implementation"},
+		Subject:        &abtest.Subject{StepID: "implement"},
+		Variants: []abtest.Variant{{
+			ID: "copy-v2", Provider: "claude", Model: "sonnet", Weight: 1,
+			PromptTransform: &abtest.PromptTransform{Op: "template", Text: "variant {{.Task.ID}} {{.Step.ID}}"},
+		}},
+	}}})
+	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
+	step := &Step{ID: "implement", Type: StepRunAgent, Config: StepConfig{Role: "implementation", Prompt: "control {{.Task.ID}}"}}
+	wfExec := &Execution{WorkflowID: "test-simple", State: ExecRunning, Variables: map[string]string{}}
+	ctx := TemplateContext{Task: TaskInfo{ID: "t1"}, Step: *step, Vars: wfExec.Variables}
+
+	if err := engine.execRunAgent("t1", step, wfExec, ctx); err != nil {
+		t.Fatal(err)
+	}
+	call := agents.LastCall()
+	if call.Prompt != "variant t1 implement" {
+		t.Fatalf("Prompt = %q", call.Prompt)
+	}
+	if call.Assignment.PromptTransform == nil || call.Assignment.PromptTransform.Op != "template" {
+		t.Fatalf("assignment prompt transform = %+v", call.Assignment.PromptTransform)
+	}
+}
+
+func TestExecRunAgentSkillAlias(t *testing.T) {
+	prev := providerAvailable
+	providerAvailable = func(string) bool { return true }
+	t.Cleanup(func() { providerAvailable = prev })
+
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	enabled := true
+	engine.SetABTestingConfig(abtest.Config{Enabled: &enabled, Experiments: []abtest.Experiment{{
+		ID:             "skill-exp",
+		Kind:           "skill",
+		AssignmentUnit: "stage",
+		Roles:          []string{"implementation"},
+		Subject:        &abtest.Subject{StepID: "implement", SkillName: "sybra-test"},
+		Variants: []abtest.Variant{{
+			ID: "skill-v2", Provider: "codex", Model: "gpt-5.5", Weight: 1,
+			SkillAliases: map[string]string{"sybra-test": "sybra-test-v2"},
+		}},
+	}}})
+	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
+	step := &Step{ID: "implement", Type: StepRunAgent, Config: StepConfig{Role: "implementation", Prompt: "Run /sybra-test, not /tmp/sybra-test.md."}}
+	wfExec := &Execution{WorkflowID: "test-simple", State: ExecRunning, Variables: map[string]string{}}
+	ctx := TemplateContext{Task: TaskInfo{ID: "t1"}, Step: *step, Vars: wfExec.Variables}
+
+	if err := engine.execRunAgent("t1", step, wfExec, ctx); err != nil {
+		t.Fatal(err)
+	}
+	call := agents.LastCall()
+	if call.Prompt != "Run /sybra-test-v2, not /tmp/sybra-test.md." {
+		t.Fatalf("Prompt = %q", call.Prompt)
+	}
+	if got := call.Assignment.SkillAliases["sybra-test"]; got != "sybra-test-v2" {
+		t.Fatalf("assignment alias = %q", got)
+	}
+}
+
+func TestExecRunAgentReuseAgentSkillAlias(t *testing.T) {
+	prev := providerAvailable
+	providerAvailable = func(string) bool { return true }
+	t.Cleanup(func() { providerAvailable = prev })
+
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	enabled := true
+	engine.SetABTestingConfig(abtest.Config{Enabled: &enabled, Experiments: []abtest.Experiment{{
+		ID:             "skill-exp",
+		Kind:           "skill",
+		AssignmentUnit: "stage",
+		Roles:          []string{"implementation"},
+		Subject:        &abtest.Subject{StepID: "followup", SkillName: "sybra-test"},
+		Variants: []abtest.Variant{{
+			ID: "skill-v2", Provider: "claude", Model: "sonnet", Weight: 1,
+			SkillAliases: map[string]string{"sybra-test": "sybra-test-v2"},
+		}},
+	}}})
+	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
+	if _, _, _, err := agents.StartAgent("t1", "implementation", "headless", "sonnet", "claude", "initial", "", nil, false, false, "", AgentAssignment{}); err != nil {
+		t.Fatal(err)
+	}
+	step := &Step{ID: "followup", Type: StepRunAgent, Config: StepConfig{Role: "implementation", ReuseAgent: true, Prompt: "Run /sybra-test"}}
+	wfExec := &Execution{WorkflowID: "test-simple", State: ExecRunning, Variables: map[string]string{}}
+	ctx := TemplateContext{Task: TaskInfo{ID: "t1"}, Step: *step, Vars: wfExec.Variables}
+
+	if err := engine.execRunAgent("t1", step, wfExec, ctx); err != nil {
+		t.Fatal(err)
+	}
+	sent := agents.SentPrompts()
+	if len(sent) != 1 {
+		t.Fatalf("SendPrompt count = %d, want 1", len(sent))
+	}
+	if sent[0].Message != "Run /sybra-test-v2" {
+		t.Fatalf("sent prompt = %q", sent[0].Message)
+	}
+}
+
 func TestSelectABVariantPropagatesExperimentKind(t *testing.T) {
 	prev := providerAvailable
 	providerAvailable = func(string) bool { return true }

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2150,6 +2150,73 @@ func TestExecRunAgentSkillAlias(t *testing.T) {
 	}
 }
 
+func TestExecRunAgentVariantSubjectMismatchDoesNotApplyPayload(t *testing.T) {
+	prev := providerAvailable
+	providerAvailable = func(string) bool { return true }
+	t.Cleanup(func() { providerAvailable = prev })
+
+	tests := []struct {
+		name    string
+		subject *abtest.Subject
+		step    Step
+		wfID    string
+	}{
+		{
+			name:    "step",
+			subject: &abtest.Subject{StepID: "implement", SkillName: "sybra-test"},
+			step:    Step{ID: "evaluate", Type: StepRunAgent, Config: StepConfig{Role: "implementation", Prompt: "control /sybra-test"}},
+			wfID:    "test-simple",
+		},
+		{
+			name:    "workflow",
+			subject: &abtest.Subject{WorkflowID: "target-workflow", SkillName: "sybra-test"},
+			step:    Step{ID: "implement", Type: StepRunAgent, Config: StepConfig{Role: "implementation", Prompt: "control /sybra-test"}},
+			wfID:    "other-workflow",
+		},
+		{
+			name:    "skill",
+			subject: &abtest.Subject{StepID: "implement", SkillName: "sybra-test"},
+			step:    Step{ID: "implement", Type: StepRunAgent, Config: StepConfig{Role: "implementation", Prompt: "control /other-skill"}},
+			wfID:    "test-simple",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newTestStore(t)
+			tasks := newMemTasks()
+			agents := newMockAgents()
+			engine := NewEngine(store, tasks, agents, discardLogger())
+			enabled := true
+			engine.SetABTestingConfig(abtest.Config{Enabled: &enabled, Experiments: []abtest.Experiment{{
+				ID:             "subject-exp",
+				Kind:           "skill",
+				AssignmentUnit: "stage",
+				Roles:          []string{"implementation"},
+				Subject:        tt.subject,
+				Variants: []abtest.Variant{{
+					ID: "variant", Provider: "claude", Model: "sonnet", Weight: 1,
+					PromptTransform: &abtest.PromptTransform{Op: "prepend", Text: "variant: "},
+					SkillAliases:    map[string]string{"sybra-test": "sybra-test-v2"},
+				}},
+			}}})
+			tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
+			wfExec := &Execution{WorkflowID: tt.wfID, State: ExecRunning, Variables: map[string]string{}}
+			ctx := TemplateContext{Task: TaskInfo{ID: "t1"}, Step: tt.step, Vars: wfExec.Variables}
+
+			if err := engine.execRunAgent("t1", &tt.step, wfExec, ctx); err != nil {
+				t.Fatal(err)
+			}
+			call := agents.LastCall()
+			if call.Assignment.ExperimentID != "" {
+				t.Fatalf("assignment applied despite subject mismatch: %+v", call.Assignment)
+			}
+			if call.Prompt != tt.step.Config.Prompt {
+				t.Fatalf("prompt = %q, want %q", call.Prompt, tt.step.Config.Prompt)
+			}
+		})
+	}
+}
+
 func TestExecRunAgentReuseAgentSkillAlias(t *testing.T) {
 	prev := providerAvailable
 	providerAvailable = func(string) bool { return true }
@@ -2212,7 +2279,13 @@ func TestSelectABVariantPropagatesExperimentKind(t *testing.T) {
 		}},
 	})
 
-	assignment, ok, err := engine.selectABVariant("t1", "implementation", "implement")
+	assignment, ok, err := engine.selectABVariant(abtest.SelectionContext{
+		TaskID:     "t1",
+		WorkflowID: "test-simple",
+		Role:       "implementation",
+		StepID:     "implement",
+		Prompt:     "Run /sybra-test",
+	})
 	if err != nil || !ok {
 		t.Fatalf("selectABVariant ok=%v err=%v", ok, err)
 	}


### PR DESCRIPTION
## Motivation

Workflow agents need to receive the prompt and skill variants selected for each run so experiment assignments affect actual execution instead of only being recorded in metadata.

Closes https://github.com/Automaat/sybra/issues/1202

## Implementation information

- Add reusable skill invocation formatting and tests.
- Route selected prompt and skill variants through workflow agent launch paths, including parallel execution.
- Extend AB test selection and workflow tests to cover payload propagation and variant attribution.