### PR TITLE
fix(task): serialize per-task store writes

### DIFF
--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -987,7 +987,7 @@ func (s *Store) addRun(taskID string, run AgentRun, status *Status) error {
 	unlock := s.lockTask(taskID)
 	defer unlock()
 
-	t, err := s.Get(taskID)
+	t, err := s.read(taskID)
 	if err != nil {
 		return err
 	}
@@ -1136,7 +1136,7 @@ func (s *Store) UpdateRun(taskID, agentID string, patch RunPatch) error {
 	unlock := s.lockTask(taskID)
 	defer unlock()
 
-	t, err := s.Get(taskID)
+	t, err := s.read(taskID)
 	if err != nil {
 		return err
 	}

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -28,10 +28,16 @@ type Store struct {
 	planDecisions *PlanningSidecarStore
 	planBrief     *PlanningSidecarStore
 	codeReviews   *CodeReviewStore
-	writeLocks    sync.Map // map task ID -> *sync.Mutex
+	writeLocksMu  sync.Mutex
+	writeLocks    map[string]*taskWriteLock
 	cacheMu       sync.RWMutex
 	listCache     []Task
 	listValid     bool
+}
+
+type taskWriteLock struct {
+	mu   sync.Mutex
+	refs int
 }
 
 func NewStore(dir string) (*Store, error) {
@@ -49,6 +55,7 @@ func NewStore(dir string) (*Store, error) {
 		planDecisions: NewPlanningSidecarStore(dir, ".plan-decisions.md", "plan decisions"),
 		planBrief:     NewPlanningSidecarStore(dir, ".plan-brief.md", "plan brief"),
 		codeReviews:   NewCodeReviewStore(dir),
+		writeLocks:    map[string]*taskWriteLock{},
 	}, nil
 }
 
@@ -88,13 +95,33 @@ func (s *Store) CodeReviews() *CodeReviewStore {
 	return s.codeReviews
 }
 
-func (s *Store) lockFor(id string) *sync.Mutex {
-	actual, _ := s.writeLocks.LoadOrStore(id, &sync.Mutex{})
-	mu, ok := actual.(*sync.Mutex)
-	if !ok {
-		panic("task store write lock has unexpected type")
+// lockTask serializes in-process read/modify/write calls for a single task
+// file. It is deliberately ref-counted so deleted or one-off task IDs do not
+// leave lock entries behind for the lifetime of a long-running server.
+func (s *Store) lockTask(id string) func() {
+	s.writeLocksMu.Lock()
+	if s.writeLocks == nil {
+		s.writeLocks = map[string]*taskWriteLock{}
 	}
-	return mu
+	lock := s.writeLocks[id]
+	if lock == nil {
+		lock = &taskWriteLock{}
+		s.writeLocks[id] = lock
+	}
+	lock.refs++
+	s.writeLocksMu.Unlock()
+
+	lock.mu.Lock()
+	return func() {
+		lock.mu.Unlock()
+
+		s.writeLocksMu.Lock()
+		defer s.writeLocksMu.Unlock()
+		lock.refs--
+		if lock.refs == 0 {
+			delete(s.writeLocks, id)
+		}
+	}
 }
 
 // IsSidecarFile reports whether a filename (basename) belongs to a sidecar
@@ -509,9 +536,8 @@ func (s *Store) CreateChat(projectID string) (Task, error) {
 }
 
 func (s *Store) Delete(id string) error {
-	mu := s.lockFor(id)
-	mu.Lock()
-	defer mu.Unlock()
+	unlock := s.lockTask(id)
+	defer unlock()
 
 	t, err := s.read(id)
 	if err != nil {
@@ -721,9 +747,8 @@ func applyUpdateFields(t *Task, u Update) error {
 }
 
 func (s *Store) UpdateWithPrev(id string, u Update) (Task, Status, error) {
-	mu := s.lockFor(id)
-	mu.Lock()
-	defer mu.Unlock()
+	unlock := s.lockTask(id)
+	defer unlock()
 
 	t, err := s.read(id)
 	if err != nil {
@@ -959,9 +984,8 @@ func (s *Store) AddRunWithStatus(taskID string, run AgentRun, status *Status) er
 }
 
 func (s *Store) addRun(taskID string, run AgentRun, status *Status) error {
-	mu := s.lockFor(taskID)
-	mu.Lock()
-	defer mu.Unlock()
+	unlock := s.lockTask(taskID)
+	defer unlock()
 
 	t, err := s.Get(taskID)
 	if err != nil {
@@ -1109,9 +1133,8 @@ func applyRunPatch(run *AgentRun, p RunPatch) {
 }
 
 func (s *Store) UpdateRun(taskID, agentID string, patch RunPatch) error {
-	mu := s.lockFor(taskID)
-	mu.Lock()
-	defer mu.Unlock()
+	unlock := s.lockTask(taskID)
+	defer unlock()
 
 	t, err := s.Get(taskID)
 	if err != nil {

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -28,6 +28,7 @@ type Store struct {
 	planDecisions *PlanningSidecarStore
 	planBrief     *PlanningSidecarStore
 	codeReviews   *CodeReviewStore
+	writeLocks    sync.Map // map task ID -> *sync.Mutex
 	cacheMu       sync.RWMutex
 	listCache     []Task
 	listValid     bool
@@ -85,6 +86,15 @@ func (s *Store) PlanBrief() *PlanningSidecarStore {
 
 func (s *Store) CodeReviews() *CodeReviewStore {
 	return s.codeReviews
+}
+
+func (s *Store) lockFor(id string) *sync.Mutex {
+	actual, _ := s.writeLocks.LoadOrStore(id, &sync.Mutex{})
+	mu, ok := actual.(*sync.Mutex)
+	if !ok {
+		panic("task store write lock has unexpected type")
+	}
+	return mu
 }
 
 // IsSidecarFile reports whether a filename (basename) belongs to a sidecar
@@ -499,6 +509,10 @@ func (s *Store) CreateChat(projectID string) (Task, error) {
 }
 
 func (s *Store) Delete(id string) error {
+	mu := s.lockFor(id)
+	mu.Lock()
+	defer mu.Unlock()
+
 	t, err := s.read(id)
 	if err != nil {
 		return err
@@ -707,6 +721,10 @@ func applyUpdateFields(t *Task, u Update) error {
 }
 
 func (s *Store) UpdateWithPrev(id string, u Update) (Task, Status, error) {
+	mu := s.lockFor(id)
+	mu.Lock()
+	defer mu.Unlock()
+
 	t, err := s.read(id)
 	if err != nil {
 		return Task{}, "", err
@@ -941,6 +959,10 @@ func (s *Store) AddRunWithStatus(taskID string, run AgentRun, status *Status) er
 }
 
 func (s *Store) addRun(taskID string, run AgentRun, status *Status) error {
+	mu := s.lockFor(taskID)
+	mu.Lock()
+	defer mu.Unlock()
+
 	t, err := s.Get(taskID)
 	if err != nil {
 		return err
@@ -1087,6 +1109,10 @@ func applyRunPatch(run *AgentRun, p RunPatch) {
 }
 
 func (s *Store) UpdateRun(taskID, agentID string, patch RunPatch) error {
+	mu := s.lockFor(taskID)
+	mu.Lock()
+	defer mu.Unlock()
+
 	t, err := s.Get(taskID)
 	if err != nil {
 		return err

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -238,6 +238,39 @@ func TestStoreDelete(t *testing.T) {
 	}
 }
 
+func TestStoreWriteLocksAreReclaimed(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("Lock lifecycle", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Update(created.ID, Update{Body: Ptr("updated")}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	store.writeLocksMu.Lock()
+	lockCount := len(store.writeLocks)
+	store.writeLocksMu.Unlock()
+	if lockCount != 0 {
+		t.Fatalf("writeLocks length after update = %d, want 0", lockCount)
+	}
+
+	if err := store.Delete(created.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	store.writeLocksMu.Lock()
+	lockCount = len(store.writeLocks)
+	store.writeLocksMu.Unlock()
+	if lockCount != 0 {
+		t.Fatalf("writeLocks length after delete = %d, want 0", lockCount)
+	}
+}
+
 func TestStoreDeleteNotFound(t *testing.T) {
 	t.Parallel()
 	store, err := NewStore(t.TempDir())

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -1358,9 +1358,9 @@ func TestStoreSafePathRejectsTraversal(t *testing.T) {
 }
 
 // TestStoreConcurrentUpdateSameTask verifies that two goroutines updating the
-// same task concurrently never leave the file corrupted (unparseable) or with
-// a lost StatusReason/Title state — the last writer must win cleanly. The test
-// also checks that the on-disk file parses successfully after the race.
+// same task concurrently never leave the file corrupted (unparseable) or lose
+// independently updated fields. The test also checks that the on-disk file
+// parses successfully after the race.
 func TestStoreConcurrentUpdateSameTask(t *testing.T) {
 	t.Parallel()
 	store, err := NewStore(t.TempDir())
@@ -1406,6 +1406,12 @@ func TestStoreConcurrentUpdateSameTask(t *testing.T) {
 	if final.ID != created.ID {
 		t.Errorf("ID changed across updates: got %q, want %q", final.ID, created.ID)
 	}
+	if final.Title != "A-99" {
+		t.Errorf("Title = %q, want A-99", final.Title)
+	}
+	if final.Body != "B-99" {
+		t.Errorf("Body = %q, want B-99", final.Body)
+	}
 
 	// Parse the raw file to confirm on-disk consistency independent of cache.
 	reloaded, err := Parse(final.FilePath)
@@ -1414,6 +1420,60 @@ func TestStoreConcurrentUpdateSameTask(t *testing.T) {
 	}
 	if reloaded.ID != created.ID {
 		t.Errorf("reloaded ID = %q, want %q", reloaded.ID, created.ID)
+	}
+}
+
+func TestStoreConcurrentUpdateAndUpdateRunSameTask(t *testing.T) {
+	t.Parallel()
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	created, err := store.Create("orig", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.AddRun(created.ID, AgentRun{AgentID: "agent-1", State: "queued"}); err != nil {
+		t.Fatalf("AddRun: %v", err)
+	}
+
+	const rounds = 100
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := range rounds {
+			if _, err := store.Update(created.ID, Update{Body: Ptr(fmt.Sprintf("body-%d", i))}); err != nil {
+				t.Errorf("Update body: %v", err)
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := range rounds {
+			state := fmt.Sprintf("state-%d", i)
+			if err := store.UpdateRun(created.ID, "agent-1", RunPatch{State: &state}); err != nil {
+				t.Errorf("UpdateRun state: %v", err)
+				return
+			}
+		}
+	}()
+	wg.Wait()
+
+	final, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get after concurrent updates: %v", err)
+	}
+	if final.Body != "body-99" {
+		t.Errorf("Body = %q, want body-99", final.Body)
+	}
+	if len(final.AgentRuns) != 1 {
+		t.Fatalf("AgentRuns length = %d, want 1", len(final.AgentRuns))
+	}
+	if final.AgentRuns[0].State != "state-99" {
+		t.Errorf("AgentRuns[0].State = %q, want state-99", final.AgentRuns[0].State)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Concurrent task mutations can race through independent read/modify/write paths for the same task file, which risks dropped updates when agent run updates and task metadata updates happen at the same time.

Closes https://github.com/Automaat/sybra/issues/1296

## Implementation information

- Add ref-counted per-task write locks to the task store and apply them to delete, task update, run append, and run patch paths.
- Reclaim lock entries after each operation so long-running servers do not retain one-off task IDs indefinitely.
- Expand task store tests to cover lock reclamation and concurrent task/run updates preserving independent fields.

Closes https://github.com/Automaat/sybra/issues/1296