### PR TITLE
feat(umbrella): derive DAG edges from metadata

### DIFF
--- a/internal/umbrella/materialize.go
+++ b/internal/umbrella/materialize.go
@@ -31,7 +31,8 @@ func ChildSpecs(plan Plan, subs []SubIssue, existingRefs map[string]bool) []Chil
 	}
 
 	var specs []ChildSpec
-	for _, c := range plan.Children {
+	for i := range plan.Children {
+		c := &plan.Children[i]
 		key := NormalizeIssueRef(c.Ref)
 		if existingRefs[key] || closed[key] {
 			continue

--- a/internal/umbrella/planner.go
+++ b/internal/umbrella/planner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -25,11 +26,16 @@ type SubIssue struct {
 }
 
 // PlannedChild is one child task the planner proposes: the sub-issue it maps
-// to, the issue refs it depends on, and an advisory parallel-track label.
+// to, its change-surface metadata, and an advisory parallel-track label.
+// DependsOn may still carry explicit edges the model emits; deriveEdges unions
+// in edges derived from Touches/Produces/Requires on top of them.
 type PlannedChild struct {
 	Ref       string   `json:"issue"`
 	DependsOn []string `json:"dependsOn"`
 	Track     string   `json:"track,omitempty"`
+	Touches   []string `json:"touches,omitempty"`
+	Produces  []string `json:"produces,omitempty"`
+	Requires  []string `json:"requires,omitempty"`
 }
 
 // Plan is the dependency DAG the planner extracts from an umbrella body.
@@ -68,6 +74,7 @@ func Generate(ctx context.Context, run Runner, umbrellaRef, umbrellaBody string,
 			lastErr = err
 			continue
 		}
+		plan.deriveEdges(subs)
 		if err := plan.validate(subs); err != nil {
 			lastErr = err
 			continue
@@ -81,11 +88,12 @@ func Generate(ctx context.Context, run Runner, umbrellaRef, umbrellaBody string,
 }
 
 // BuildPrompt renders the planner instruction. The model is asked to emit ONLY
-// a JSON object covering every sub-issue, reading the umbrella body for
-// dependency edges and parallel tracks.
+// a JSON object covering every sub-issue with its change-surface metadata
+// (touches/produces/requires); dependency edges are derived from that
+// metadata afterward (see deriveEdges), not read from the model.
 func BuildPrompt(umbrellaRef, umbrellaBody string, subs []SubIssue) string {
 	var b strings.Builder
-	b.WriteString("You are decomposing a GitHub umbrella issue into a dependency DAG of its sub-issues.\n")
+	b.WriteString("You are decomposing a GitHub umbrella issue into per-sub-issue change-surface metadata.\n")
 	b.WriteString("Umbrella: " + umbrellaRef + "\n\n")
 	b.WriteString("Umbrella body:\n")
 	b.WriteString(umbrellaBody)
@@ -97,16 +105,23 @@ func BuildPrompt(umbrellaRef, umbrellaBody string, subs []SubIssue) string {
 		}
 		b.WriteString(line + "\n")
 	}
-	b.WriteString("\nFor each sub-issue, infer which other sub-issues it depends on (must finish first)")
-	b.WriteString(" and an optional parallel-track label. Read dependency markers like \"← #N\"")
-	b.WriteString(" (depends on N) and \"⛔ blocks all\", plus prose describing serial vs parallel work.\n\n")
-	b.WriteString("Serialize sub-issues that will edit the SAME files or code area. If two sub-issues")
-	b.WriteString(" clearly modify the same module, file, or feature surface (e.g. both rework the same")
-	b.WriteString(" report, view, schema, or endpoint), add a dependsOn edge so the later one waits and")
-	b.WriteString(" they merge one at a time — concurrent PRs touching the same files collide on merge.")
-	b.WriteString(" Only run sub-issues in parallel when their changes are clearly disjoint.\n\n")
+	b.WriteString("\nFor each sub-issue, report its change surface, not a dependency graph — dependency\n")
+	b.WriteString("edges are derived automatically from this metadata:\n")
+	b.WriteString("  - touches: files, directories, or packages it changes (e.g. \"internal/foo\",")
+	b.WriteString(" \"internal/bar/x.go\"). Sub-issues whose touches overlap on the SAME files or code")
+	b.WriteString(" area get serialized automatically — they merge one at a time instead of colliding,")
+	b.WriteString(" so only list a path here when the change is genuinely disjoint from siblings that")
+	b.WriteString(" should not wait on it.\n")
+	b.WriteString("  - produces: symbols, APIs, schemas, or flags it creates or changes (e.g. \"Foo.Run\",")
+	b.WriteString(" \"Tier type\").\n")
+	b.WriteString("  - requires: symbols, APIs, schemas, or flags it needs another sub-issue to have")
+	b.WriteString(" produced first. A sub-issue that requires something another produces will")
+	b.WriteString(" automatically depend on it.\n")
+	b.WriteString("  - dependsOn (optional): explicit hard-ordering edges the metadata above can't")
+	b.WriteString(" express, e.g. markers like \"← #N\" or \"⛔ blocks all\" in the umbrella body. Kept in")
+	b.WriteString(" addition to the derived edges, not instead of them.\n\n")
 	b.WriteString("Output ONLY a JSON object, no prose, no code fence:\n")
-	b.WriteString(`{"children":[{"issue":"<ref>","dependsOn":["<ref>"],"track":"<label>"}],"maxParallel":<int>}` + "\n")
+	b.WriteString(`{"children":[{"issue":"<ref>","touches":["<path>"],"produces":["<symbol>"],"requires":["<symbol>"],"dependsOn":["<ref>"],"track":"<label>"}],"maxParallel":<int>}` + "\n")
 	b.WriteString("Rules: include EVERY sub-issue exactly once (including done ones); dependsOn must")
 	b.WriteString(" reference only the sub-issues above; never create a cycle; maxParallel is the max")
 	b.WriteString(" children to run at once (default 5).\n")
@@ -197,6 +212,131 @@ func (p *Plan) resolve(idx refIndex) error {
 	return nil
 }
 
+// deriveEdges rewrites each child's DependsOn to union in edges derived from
+// change-surface metadata, on top of whatever explicit edges the model already
+// emitted: a child requiring a symbol depends on every child that produces it,
+// and a child touching a file/package another (earlier-ordered) child also
+// touches depends on that earlier child. subs establishes the canonical
+// ordering used both to pick the "earlier" side of a touch overlap and to make
+// edge derivation deterministic regardless of plan.Children's slice order.
+// resolve must run first so every ref here is canonical. Legacy input with no
+// touches/produces/requires is a no-op: DependsOn is left unchanged.
+func (p *Plan) deriveEdges(subs []SubIssue) {
+	order := make(map[string]int, len(subs))
+	for i, s := range subs {
+		order[NormalizeIssueRef(s.Ref)] = i
+	}
+
+	producers := make(map[string][]string, len(p.Children)) // normalized symbol -> producing refs
+	touchesByRef := make(map[string][]string, len(p.Children))
+	refs := make([]string, 0, len(p.Children))
+	for i := range p.Children {
+		c := &p.Children[i]
+		refs = append(refs, c.Ref)
+		for _, sym := range c.Produces {
+			if key := normalizeSymbol(sym); key != "" {
+				producers[key] = append(producers[key], c.Ref)
+			}
+		}
+		touchesByRef[c.Ref] = c.Touches
+	}
+	for key, list := range producers {
+		sort.Slice(list, func(a, b int) bool { return order[list[a]] < order[list[b]] })
+		producers[key] = list
+	}
+	// Sorted by subs order (not plan.Children order) so touch-overlap edges are
+	// derived the same way regardless of how the model ordered its children.
+	sort.Slice(refs, func(a, b int) bool { return order[refs[a]] < order[refs[b]] })
+
+	for i := range p.Children {
+		c := &p.Children[i]
+		seen := make(map[string]bool, len(c.DependsOn))
+		merged := make([]string, 0, len(c.DependsOn))
+		add := func(ref string) {
+			if ref == "" || ref == c.Ref || seen[ref] {
+				return
+			}
+			seen[ref] = true
+			merged = append(merged, ref)
+		}
+		for _, d := range c.DependsOn {
+			add(d)
+		}
+		for _, req := range c.Requires {
+			key := normalizeSymbol(req)
+			if key == "" {
+				continue
+			}
+			for _, producer := range producers[key] {
+				add(producer)
+			}
+		}
+		if len(c.Touches) > 0 {
+			for _, other := range refs {
+				if order[other] >= order[c.Ref] {
+					continue
+				}
+				if touchesOverlap(c.Touches, touchesByRef[other]) {
+					add(other)
+				}
+			}
+		}
+		c.DependsOn = merged
+	}
+}
+
+// normalizeSymbol canonicalizes a produces/requires entry for comparison.
+func normalizeSymbol(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// normalizePath canonicalizes a touches entry for comparison: trims
+// whitespace, strips a leading "./", and trims a trailing "/".
+func normalizePath(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "./")
+	s = strings.TrimSuffix(s, "/")
+	return s
+}
+
+// pathsOverlap reports whether two touches entries name the same file/package
+// or one is a slash-delimited ancestor directory of the other, compared
+// segment by segment — never by string prefix, so "internal/foo" does not
+// overlap "internal/foobar".
+func pathsOverlap(a, b string) bool {
+	na, nb := normalizePath(a), normalizePath(b)
+	if na == "" || nb == "" {
+		return false
+	}
+	if na == nb {
+		return true
+	}
+	sa := strings.Split(na, "/")
+	sb := strings.Split(nb, "/")
+	shorter, longer := sa, sb
+	if len(sb) < len(sa) {
+		shorter, longer = sb, sa
+	}
+	for i, seg := range shorter {
+		if longer[i] != seg {
+			return false
+		}
+	}
+	return true
+}
+
+// touchesOverlap reports whether any path in a overlaps any path in b.
+func touchesOverlap(a, b []string) bool {
+	for _, pa := range a {
+		for _, pb := range b {
+			if pathsOverlap(pa, pb) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // validate confirms the plan covers every sub-issue exactly once and is
 // acyclic. resolve must run first so all refs are canonical.
 func (p *Plan) validate(subs []SubIssue) error {
@@ -205,7 +345,8 @@ func (p *Plan) validate(subs []SubIssue) error {
 	}
 	seen := make(map[string]bool, len(p.Children))
 	nodes := make([]Node, 0, len(p.Children))
-	for _, c := range p.Children {
+	for i := range p.Children {
+		c := &p.Children[i]
 		if seen[c.Ref] {
 			return fmt.Errorf("planner listed %s more than once", c.Ref)
 		}

--- a/internal/umbrella/planner.go
+++ b/internal/umbrella/planner.go
@@ -107,11 +107,13 @@ func BuildPrompt(umbrellaRef, umbrellaBody string, subs []SubIssue) string {
 	}
 	b.WriteString("\nFor each sub-issue, report its change surface, not a dependency graph — dependency\n")
 	b.WriteString("edges are derived automatically from this metadata:\n")
-	b.WriteString("  - touches: files, directories, or packages it changes (e.g. \"internal/foo\",")
-	b.WriteString(" \"internal/bar/x.go\"). Sub-issues whose touches overlap on the SAME files or code")
-	b.WriteString(" area get serialized automatically — they merge one at a time instead of colliding,")
-	b.WriteString(" so only list a path here when the change is genuinely disjoint from siblings that")
-	b.WriteString(" should not wait on it.\n")
+	b.WriteString("  - touches: EVERY file, directory, or package this sub-issue will actually edit")
+	b.WriteString(" (e.g. \"internal/foo\", \"internal/bar/x.go\"). List all of them, including paths")
+	b.WriteString(" shared with other sub-issues — sub-issues whose touches overlap on the SAME files")
+	b.WriteString(" or code area get serialized automatically so they merge one at a time instead of")
+	b.WriteString(" colliding. Omitting a shared path to avoid ordering just causes silent merge")
+	b.WriteString(" conflicts later. Keep paths as narrow as the real edit (a single package or file),")
+	b.WriteString(" not a broad directory that creates false overlap with unrelated siblings.\n")
 	b.WriteString("  - produces: symbols, APIs, schemas, or flags it creates or changes (e.g. \"Foo.Run\",")
 	b.WriteString(" \"Tier type\").\n")
 	b.WriteString("  - requires: symbols, APIs, schemas, or flags it needs another sub-issue to have")
@@ -220,7 +222,8 @@ func (p *Plan) resolve(idx refIndex) error {
 // ordering used both to pick the "earlier" side of a touch overlap and to make
 // edge derivation deterministic regardless of plan.Children's slice order.
 // resolve must run first so every ref here is canonical. Legacy input with no
-// touches/produces/requires is a no-op: DependsOn is left unchanged.
+// touches/produces/requires derives no new edges, but DependsOn is still
+// rewritten: it is de-duped and self/empty entries are dropped.
 func (p *Plan) deriveEdges(subs []SubIssue) {
 	order := make(map[string]int, len(subs))
 	for i, s := range subs {

--- a/internal/umbrella/planner.go
+++ b/internal/umbrella/planner.go
@@ -291,12 +291,14 @@ func normalizeSymbol(s string) string {
 }
 
 // normalizePath canonicalizes a touches entry for comparison: trims
-// whitespace, strips a leading "./", and trims a trailing "/".
+// whitespace, strips a leading "./", trims a trailing "/", and lowercases
+// (matching normalizeSymbol) so casing differences in the LLM's output don't
+// hide a real overlap.
 func normalizePath(s string) string {
 	s = strings.TrimSpace(s)
 	s = strings.TrimPrefix(s, "./")
 	s = strings.TrimSuffix(s, "/")
-	return s
+	return strings.ToLower(s)
 }
 
 // pathsOverlap reports whether two touches entries name the same file/package

--- a/internal/umbrella/planner_test.go
+++ b/internal/umbrella/planner_test.go
@@ -24,7 +24,7 @@ func TestBuildPrompt_SerializesSameFileSubIssues(t *testing.T) {
 	// produces/requires) instead of reading a dependency graph, and that
 	// overlapping touches get serialized automatically.
 	for _, want := range []string{
-		"SAME files", "merge one at a time", "disjoint",
+		"SAME files", "merge one at a time", "false overlap",
 		"touches", "produces", "requires", "derived automatically",
 	} {
 		if !strings.Contains(prompt, want) {
@@ -314,12 +314,19 @@ func TestDeriveEdges(t *testing.T) {
 		p2 := Plan{Children: append([]PlannedChild(nil), reversed...)}
 		p2.deriveEdges(s)
 
-		if got, want := depsOf(p1, "o/r#3"), depsOf(p2, "o/r#3"); len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
-			t.Fatalf("non-deterministic: forward=%v reversed=%v", got, want)
+		assertEqual := func(t *testing.T, got, want []string, msg string) {
+			t.Helper()
+			if len(got) != len(want) {
+				t.Fatalf("%s: forward=%v reversed=%v", msg, got, want)
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("%s: forward=%v reversed=%v", msg, got, want)
+				}
+			}
 		}
-		if got, want := depsOf(p1, "o/r#2"), depsOf(p2, "o/r#2"); len(got) != len(want) || got[0] != want[0] {
-			t.Fatalf("non-deterministic touch overlap: forward=%v reversed=%v", got, want)
-		}
+		assertEqual(t, depsOf(p1, "o/r#3"), depsOf(p2, "o/r#3"), "non-deterministic")
+		assertEqual(t, depsOf(p1, "o/r#2"), depsOf(p2, "o/r#2"), "non-deterministic touch overlap")
 	})
 }
 

--- a/internal/umbrella/planner_test.go
+++ b/internal/umbrella/planner_test.go
@@ -399,6 +399,20 @@ func TestGenerate(t *testing.T) {
 			t.Error("expected cycle to be rejected")
 		}
 	})
+
+	t.Run("cycle derived from mutual requires/produces is rejected", func(t *testing.T) {
+		t.Parallel()
+		// No explicit dependsOn — the cycle only exists once deriveEdges turns
+		// each side's "requires" into an edge on the other's "produces".
+		cyclic := `{"children":[` +
+			`{"issue":"o/r#1","produces":["A"],"requires":["B"]},` +
+			`{"issue":"o/r#2","produces":["B"],"requires":["A"]}` +
+			`],"maxParallel":2}`
+		run := func(_ context.Context, _ string) (string, error) { return cyclic, nil }
+		if _, err := Generate(context.Background(), run, "o/r#100", "body", subs("o/r#1", "o/r#2")); err == nil {
+			t.Error("expected derived cycle to be rejected")
+		}
+	})
 }
 
 func TestFallbackPlannerRunnerPassesConfiguredClaudeModel(t *testing.T) {

--- a/internal/umbrella/planner_test.go
+++ b/internal/umbrella/planner_test.go
@@ -20,11 +20,15 @@ func subs(refs ...string) []SubIssue {
 func TestBuildPrompt_SerializesSameFileSubIssues(t *testing.T) {
 	t.Parallel()
 	prompt := BuildPrompt("o/r#100", "body", subs("o/r#1", "o/r#2"))
-	// The planner must be told to serialize sub-issues that edit the same files,
-	// so overlapping siblings merge one at a time instead of colliding.
-	for _, want := range []string{"SAME files", "merge one at a time", "disjoint"} {
+	// The planner must be told to report change-surface metadata (touches/
+	// produces/requires) instead of reading a dependency graph, and that
+	// overlapping touches get serialized automatically.
+	for _, want := range []string{
+		"SAME files", "merge one at a time", "disjoint",
+		"touches", "produces", "requires", "derived automatically",
+	} {
 		if !strings.Contains(prompt, want) {
-			t.Errorf("prompt missing serialization guidance %q:\n%s", want, prompt)
+			t.Errorf("prompt missing metadata guidance %q:\n%s", want, prompt)
 		}
 	}
 }
@@ -180,9 +184,148 @@ func TestPlanValidate(t *testing.T) {
 	}
 }
 
+func TestDeriveEdges(t *testing.T) {
+	t.Parallel()
+
+	depsOf := func(plan Plan, ref string) []string {
+		for _, c := range plan.Children {
+			if c.Ref == ref {
+				return c.DependsOn
+			}
+		}
+		t.Fatalf("no child %s in plan", ref)
+		return nil
+	}
+
+	tests := []struct {
+		name     string
+		subs     []SubIssue
+		children []PlannedChild
+		want     map[string][]string // ref -> expected DependsOn (order-sensitive)
+	}{
+		{
+			name: "produce/require match",
+			subs: subs("o/r#1", "o/r#2"),
+			children: []PlannedChild{
+				{Ref: "o/r#1", Produces: []string{"Foo.Run"}},
+				{Ref: "o/r#2", Requires: []string{"foo.run"}}, // case-insensitive match
+			},
+			want: map[string][]string{"o/r#1": nil, "o/r#2": {"o/r#1"}},
+		},
+		{
+			name: "multiple producers of the same symbol => depend on all",
+			subs: subs("o/r#1", "o/r#2", "o/r#3"),
+			children: []PlannedChild{
+				{Ref: "o/r#1", Produces: []string{"Sym"}},
+				{Ref: "o/r#2", Produces: []string{"Sym"}},
+				{Ref: "o/r#3", Requires: []string{"Sym"}},
+			},
+			want: map[string][]string{"o/r#1": nil, "o/r#2": nil, "o/r#3": {"o/r#1", "o/r#2"}},
+		},
+		{
+			name: "touch overlap including ancestor directory",
+			subs: subs("o/r#1", "o/r#2"),
+			children: []PlannedChild{
+				{Ref: "o/r#1", Touches: []string{"internal/foo"}},
+				{Ref: "o/r#2", Touches: []string{"internal/foo/x.go"}},
+			},
+			want: map[string][]string{"o/r#1": nil, "o/r#2": {"o/r#1"}},
+		},
+		{
+			name: "sibling directories do not overlap by string prefix",
+			subs: subs("o/r#1", "o/r#2"),
+			children: []PlannedChild{
+				{Ref: "o/r#1", Touches: []string{"internal/foo"}},
+				{Ref: "o/r#2", Touches: []string{"internal/foobar"}},
+			},
+			want: map[string][]string{"o/r#1": nil, "o/r#2": nil},
+		},
+		{
+			name: "explicit dependsOn is unioned with derived edges",
+			subs: subs("o/r#1", "o/r#2", "o/r#3"),
+			children: []PlannedChild{
+				{Ref: "o/r#1", Produces: []string{"Sym"}},
+				{Ref: "o/r#2"},
+				{Ref: "o/r#3", Requires: []string{"Sym"}, DependsOn: []string{"o/r#2"}},
+			},
+			want: map[string][]string{"o/r#1": nil, "o/r#2": nil, "o/r#3": {"o/r#2", "o/r#1"}},
+		},
+		{
+			name: "legacy dependsOn-only input is a no-op",
+			subs: subs("o/r#1", "o/r#2"),
+			children: []PlannedChild{
+				{Ref: "o/r#1"},
+				{Ref: "o/r#2", DependsOn: []string{"o/r#1"}},
+			},
+			want: map[string][]string{"o/r#1": nil, "o/r#2": {"o/r#1"}},
+		},
+		{
+			name: "self-edge is dropped",
+			subs: subs("o/r#1"),
+			children: []PlannedChild{
+				{Ref: "o/r#1", Produces: []string{"Sym"}, Requires: []string{"Sym"}},
+			},
+			want: map[string][]string{"o/r#1": nil},
+		},
+		{
+			name: "closed-producer edge is derived here (dropped later by ChildSpecs)",
+			subs: []SubIssue{
+				{Ref: "o/r#1", Closed: true},
+				{Ref: "o/r#2"},
+			},
+			children: []PlannedChild{
+				{Ref: "o/r#1", Produces: []string{"Sym"}},
+				{Ref: "o/r#2", Requires: []string{"Sym"}},
+			},
+			want: map[string][]string{"o/r#1": nil, "o/r#2": {"o/r#1"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			plan := Plan{Children: append([]PlannedChild(nil), tt.children...)}
+			plan.deriveEdges(tt.subs)
+			for ref, want := range tt.want {
+				got := depsOf(plan, ref)
+				if len(got) != len(want) {
+					t.Fatalf("%s: DependsOn = %v, want %v", ref, got, want)
+				}
+				for i := range want {
+					if got[i] != want[i] {
+						t.Fatalf("%s: DependsOn = %v, want %v", ref, got, want)
+					}
+				}
+			}
+		})
+	}
+
+	t.Run("determinism independent of plan.Children slice order", func(t *testing.T) {
+		t.Parallel()
+		s := subs("o/r#1", "o/r#2", "o/r#3")
+		forward := []PlannedChild{
+			{Ref: "o/r#1", Produces: []string{"Sym"}, Touches: []string{"internal/foo"}},
+			{Ref: "o/r#2", Produces: []string{"Sym"}, Touches: []string{"internal/foo/x.go"}},
+			{Ref: "o/r#3", Requires: []string{"Sym"}},
+		}
+		reversed := []PlannedChild{forward[2], forward[1], forward[0]}
+
+		p1 := Plan{Children: append([]PlannedChild(nil), forward...)}
+		p1.deriveEdges(s)
+		p2 := Plan{Children: append([]PlannedChild(nil), reversed...)}
+		p2.deriveEdges(s)
+
+		if got, want := depsOf(p1, "o/r#3"), depsOf(p2, "o/r#3"); len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+			t.Fatalf("non-deterministic: forward=%v reversed=%v", got, want)
+		}
+		if got, want := depsOf(p1, "o/r#2"), depsOf(p2, "o/r#2"); len(got) != len(want) || got[0] != want[0] {
+			t.Fatalf("non-deterministic touch overlap: forward=%v reversed=%v", got, want)
+		}
+	})
+}
+
 func TestGenerate(t *testing.T) {
 	t.Parallel()
-	good := `{"children":[{"issue":"o/r#1","dependsOn":[]},{"issue":"o/r#2","dependsOn":["o/r#1"]}],"maxParallel":2}`
+	good := `{"children":[{"issue":"o/r#1","produces":["Foo.Run"]},{"issue":"o/r#2","requires":["Foo.Run"]}],"maxParallel":2}`
 
 	t.Run("happy path", func(t *testing.T) {
 		t.Parallel()
@@ -199,6 +342,15 @@ func TestGenerate(t *testing.T) {
 		}
 		if plan.MaxParallel != 2 || len(plan.Children) != 2 {
 			t.Fatalf("unexpected plan: %+v", plan)
+		}
+		var child2 PlannedChild
+		for _, c := range plan.Children {
+			if c.Ref == "o/r#2" {
+				child2 = c
+			}
+		}
+		if len(child2.DependsOn) != 1 || child2.DependsOn[0] != "o/r#1" {
+			t.Fatalf("requires->produces edge not derived: %+v", child2)
 		}
 	})
 


### PR DESCRIPTION
## Motivation

The umbrella planner previously asked the model to emit a full sub-issue dependency DAG directly, which usually collapsed to a flat graph with no real ordering. Per-sub-issue touches/produces/requires metadata is easier for the model to reason about and yields a more accurate dependency graph.

## Implementation information

- Planner model now emits `touches`/`produces`/`requires` per sub-issue instead of an explicit DAG.
- `Generate` derives `DependsOn` deterministically: a `requires` entry matching another node's `produces` creates an edge (unioned across all producers), and `touches` overlap on the same file/package serializes the later sub-issue after the earlier one.
- Explicit `dependsOn` is still accepted and unioned in, so legacy dependsOn-only planner output remains a no-op.
- Indexed access replaces a `range` loop over `PlannedChild` in `materialize.go` since the struct grew past gocritic's copy threshold.

Closes https://github.com/Automaat/sybra/issues/1323