### PR TITLE
fix(workflow): accept annotated evidence labels in test gate

### DIFF
--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -1123,12 +1123,53 @@ func hasGroundedFailureEvidence(report string) bool {
 	hasExpected := containsAny(lower,
 		"expected:", "expected output:", "expected behavior:", "expected behaviour:",
 		"requirement tested:", "task expectation:", "task requirement:", "task says",
-		"task requires", "from the task", "violates", "should render", "should not")
+		"task requires", "from the task", "violates", "should render", "should not") ||
+		hasLabeledSection(report,
+			"expected", "requirement tested", "task expectation", "task requirement")
 	hasGrounding := containsAny(lower,
 		"code evidence:", "quoted code", "current source", "src/", "internal/",
 		"current file", "current code line evidence:", "code line evidence:",
 		"source quote", ".go:", ".ts:", ".tsx:", ".svelte:", ".js:", ".jsx:")
+	// Labeled-section fallbacks tolerate annotated headers such as
+	// "**Expected (task's own words):**", where a parenthetical qualifier sits
+	// between the keyword and the colon and defeats the literal substring checks
+	// above — otherwise a well-grounded FAIL report is wrongly rejected as
+	// missing_evidence and forces an unnecessary human escalation.
+	hasCommand = hasCommand || hasLabeledSection(report,
+		"command run", "command", "reproduction steps", "repro", "steps")
+	hasObserved = hasObserved || hasLabeledSection(report,
+		"actual output", "actual", "observed output", "observed",
+		"command output", "stdout", "stderr", "output")
 	return hasCommand && hasObserved && hasExpected && hasGrounding
+}
+
+// hasLabeledSection reports whether any report line is a markdown section header
+// whose label starts with one of keywords, optionally followed by a parenthetical
+// qualifier, then a colon — e.g. "**Expected (task's own words):**". Leading
+// markdown decoration (*, _, >, #, -) is stripped before matching. This keeps
+// hasGroundedFailureEvidence from rejecting grounded FAIL reports that annotate
+// their evidence headers.
+func hasLabeledSection(report string, keywords ...string) bool {
+	for _, line := range reportScanLines(report) {
+		lower := strings.ToLower(strings.TrimSpace(line))
+		lower = strings.TrimLeft(lower, "*_>#- \t")
+		for _, kw := range keywords {
+			rest, ok := strings.CutPrefix(lower, kw)
+			if !ok {
+				continue
+			}
+			rest = strings.TrimSpace(rest)
+			if strings.HasPrefix(rest, "(") {
+				if idx := strings.Index(rest, ")"); idx >= 0 {
+					rest = strings.TrimSpace(rest[idx+1:])
+				}
+			}
+			if strings.HasPrefix(rest, ":") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func containsAny(s string, needles ...string) bool {

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -224,6 +224,33 @@ func TestClassifyTestOutcome_AcceptsVerbatimOutputEvidence(t *testing.T) {
 	}
 }
 
+func TestHasGroundedFailureEvidence_AcceptsAnnotatedLabels(t *testing.T) {
+	t.Parallel()
+
+	// Reproduces task b9d9181f: a fully grounded FAIL report whose headers were
+	// annotated with a parenthetical qualifier (e.g. "Expected (task's own
+	// words):"), which defeated the literal "expected:" substring check and
+	// forced an unnecessary human escalation.
+	report := "## Test Failures\n\n" +
+		"**Command run:** `curl -fsS http://127.0.0.1:8080/rpc`\n\n" +
+		"**Actual (observed):**\n\n```text\nHTTP/1.1 404 Not Found\n" +
+		`{"error":"unknown method: TaskService.BlessTampering"}` + "\n```\n\n" +
+		"**Expected (task's own words):** the GUI blesses tamper-flagged tasks in one click.\n\n" +
+		"**Code evidence:** internal/sybra/services.go missing BlessTampering from allowlist.\n"
+
+	if !hasGroundedFailureEvidence(report) {
+		t.Fatal("annotated-label FAIL report rejected as ungrounded; want grounded")
+	}
+}
+
+func TestHasGroundedFailureEvidence_RejectsUngroundedReport(t *testing.T) {
+	t.Parallel()
+
+	if hasGroundedFailureEvidence("The feature seems broken and should be fixed.") {
+		t.Fatal("prose-only report accepted as grounded; want rejected")
+	}
+}
+
 func TestTestFailureSectionIgnoresStaleLookingHeading(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation

Task b9d9181f was escalated to `human-required` despite two thorough, correctly-grounded test-runner FAIL reports for a real product bug. Root cause: `hasGroundedFailureEvidence` (`internal/workflow/engine_steps_testroute.go`) gates FAIL reports on literal substrings like `expected:`. Both reports labeled their section `**Expected (task's own words):**` — the parenthetical qualifier between `expected` and `:` breaks the substring match, so the reports were classified `missing_evidence`, exhausting the retry budget and forcing an unnecessary human escalation.

> Changelog: fix(workflow): accept annotated evidence labels in test gate

## Implementation information

- Add `hasLabeledSection`: matches a markdown header line whose label starts with a keyword, optionally followed by a parenthetical qualifier, then a colon (e.g. `**Expected (task's own words):**`). Leading markdown decoration is stripped before matching.
- OR it into the command, observed, and expected evidence checks. The tight parenthetical-then-colon shape keeps false positives out (prose-only reports still rejected).
- Tests: annotated-label FAIL report is now accepted; prose-only report still rejected.

## Supporting documentation

Verified: `go build ./cmd/sybra-server`, `go test ./internal/workflow/`, `golangci-lint run ./internal/workflow/`.