### PR TITLE
fix(workflow): harden grounded-evidence gate against bare headers

### DIFF
--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -1112,46 +1112,63 @@ func reportScanLines(text string) []string {
 
 func hasGroundedFailureEvidence(report string) bool {
 	lower := strings.ToLower(report)
+	// Header-style keywords ("command:", "actual:", "expected:", "output:", ...)
+	// are routed through hasLabeledSection rather than a plain substring check:
+	// a bare header with nothing after the colon (e.g. a report that stacks
+	// "**Command:**\n**Actual:**\n**Expected:**" with no real content) must not
+	// satisfy the gate. Only phrases that are inherently content-bearing on
+	// their own (a shell invocation, a stated exit code) stay as plain
+	// substring checks.
 	hasCommand := containsAny(lower,
-		"command run:", "command:", "reproduction steps:", "repro:", "steps:",
-		"go test ", "npm run ", "pnpm ", "yarn ", "curl ", "rg ", "grep ")
-	hasObserved := containsAny(lower,
-		"actual output:", "actual:", "observed:", "observed output:",
-		"command output:", "stdout:", "stderr:", "exit code",
-		"verbatim output:", "actual behavior:", "actual behaviour:",
-		"observed behavior:", "observed behaviour:", "printed:", "rendered:") || hasReportLinePrefix(report, "output:")
-	hasExpected := containsAny(lower,
-		"expected:", "expected output:", "expected behavior:", "expected behaviour:",
-		"requirement tested:", "task expectation:", "task requirement:", "task says",
-		"task requires", "from the task", "violates", "should render", "should not") ||
+		"go test ", "npm run ", "pnpm ", "yarn ", "curl ", "rg ", "grep ") ||
 		hasLabeledSection(report,
-			"expected", "requirement tested", "task expectation", "task requirement")
+			"command run", "command", "reproduction steps", "repro", "steps")
+	hasObserved := containsAny(lower, "exit code") ||
+		hasLabeledSection(report,
+			"actual output", "actual", "observed output", "observed",
+			"command output", "stdout", "stderr", "output",
+			"verbatim output", "actual behavior", "actual behaviour",
+			"observed behavior", "observed behaviour", "printed", "rendered")
+	hasExpected := containsAny(lower,
+		"task says", "task requires", "from the task", "violates",
+		"should render", "should not") ||
+		hasLabeledSection(report,
+			"expected", "expected output", "expected behavior", "expected behaviour",
+			"requirement tested", "task expectation", "task requirement")
 	hasGrounding := containsAny(lower,
 		"code evidence:", "quoted code", "current source", "src/", "internal/",
 		"current file", "current code line evidence:", "code line evidence:",
 		"source quote", ".go:", ".ts:", ".tsx:", ".svelte:", ".js:", ".jsx:")
-	// Labeled-section fallbacks tolerate annotated headers such as
-	// "**Expected (task's own words):**", where a parenthetical qualifier sits
-	// between the keyword and the colon and defeats the literal substring checks
-	// above — otherwise a well-grounded FAIL report is wrongly rejected as
-	// missing_evidence and forces an unnecessary human escalation.
-	hasCommand = hasCommand || hasLabeledSection(report,
-		"command run", "command", "reproduction steps", "repro", "steps")
-	hasObserved = hasObserved || hasLabeledSection(report,
-		"actual output", "actual", "observed output", "observed",
-		"command output", "stdout", "stderr", "output")
 	return hasCommand && hasObserved && hasExpected && hasGrounding
 }
 
+// bareLabelLineRe matches a report line that is nothing but a markdown-decorated
+// label followed by a colon, e.g. "command:" or "actual (observed):" with all
+// decoration already stripped — no evidence content on the same line.
+var bareLabelLineRe = regexp.MustCompile(`^[a-z][a-z0-9 '/()-]*:\**$`)
+
 // hasLabeledSection reports whether any report line is a markdown section header
 // whose label starts with one of keywords, optionally followed by a parenthetical
-// qualifier, then a colon — e.g. "**Expected (task's own words):**". Leading
-// markdown decoration (*, _, >, #, -) is stripped before matching. This keeps
+// qualifier, then a colon — e.g. "**Expected (task's own words):**" — AND that
+// header is backed by real evidence: either inline text after the colon, or a
+// fenced code block / non-header line immediately following it. Leading markdown
+// decoration (*, _, >, #, -) is stripped before matching. This keeps
 // hasGroundedFailureEvidence from rejecting grounded FAIL reports that annotate
-// their evidence headers.
+// their evidence headers, while still rejecting reports that stack empty headers
+// with no real content to game the gate.
 func hasLabeledSection(report string, keywords ...string) bool {
-	for _, line := range reportScanLines(report) {
-		lower := strings.ToLower(strings.TrimSpace(line))
+	rawLines := strings.Split(report, "\n")
+	inFence := false
+	for i, line := range rawLines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			inFence = !inFence
+			continue
+		}
+		if inFence || trimmed == "" {
+			continue
+		}
+		lower := strings.ToLower(trimmed)
 		lower = strings.TrimLeft(lower, "*_>#- \t")
 		for _, kw := range keywords {
 			rest, ok := strings.CutPrefix(lower, kw)
@@ -1164,10 +1181,35 @@ func hasLabeledSection(report string, keywords ...string) bool {
 					rest = strings.TrimSpace(rest[idx+1:])
 				}
 			}
-			if strings.HasPrefix(rest, ":") {
+			if !strings.HasPrefix(rest, ":") {
+				continue
+			}
+			afterColon := strings.TrimSpace(strings.TrimRight(strings.TrimSpace(rest[1:]), "*"))
+			if afterColon != "" || hasFollowingContent(rawLines, i) {
 				return true
 			}
 		}
+	}
+	return false
+}
+
+// hasFollowingContent reports whether the bare label line at rawLines[idx] (a
+// header with nothing after its colon) is backed by real evidence on a
+// following line — a fenced code block, or any non-blank line that is not
+// itself another bare label. It stops at the first non-blank line: a header
+// immediately followed by another header, with nothing in between, has no
+// content of its own.
+func hasFollowingContent(rawLines []string, idx int) bool {
+	for j := idx + 1; j < len(rawLines); j++ {
+		trimmed := strings.TrimSpace(rawLines[j])
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			return true
+		}
+		stripped := strings.TrimLeft(strings.ToLower(trimmed), "*_>#- \t")
+		return !bareLabelLineRe.MatchString(stripped)
 	}
 	return false
 }

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -1136,9 +1136,10 @@ func hasGroundedFailureEvidence(report string) bool {
 			"expected", "expected output", "expected behavior", "expected behaviour",
 			"requirement tested", "task expectation", "task requirement")
 	hasGrounding := containsAny(lower,
-		"code evidence:", "quoted code", "current source", "src/", "internal/",
-		"current file", "current code line evidence:", "code line evidence:",
-		"source quote", ".go:", ".ts:", ".tsx:", ".svelte:", ".js:", ".jsx:")
+		"quoted code", "current source", "current file", "source quote") ||
+		fileLineCitationRe.MatchString(report) ||
+		hasLabeledSection(report,
+			"code evidence", "current code line evidence", "code line evidence")
 	return hasCommand && hasObserved && hasExpected && hasGrounding
 }
 
@@ -1150,6 +1151,15 @@ func hasGroundedFailureEvidence(report string) bool {
 // header — a bare header immediately followed by another header's line (with
 // or without inline content) still has no content of its own.
 var headerLikeLineRe = regexp.MustCompile(`^[a-z][a-z0-9 '/()-]{0,40}:`)
+
+// fileLineCitationRe matches a real file:line citation such as
+// "internal/x.go:42" or "src/App.svelte:10" — a path segment ending in a
+// known source extension, followed by a line number. Unlike a bare "src/" or
+// "internal/" substring (which can appear incidentally, e.g. inside a `go
+// test ./internal/workflow/ ...` command line), this requires the extension
+// AND line number together, so it can't be satisfied by quoting a package
+// path with no actual code citation.
+var fileLineCitationRe = regexp.MustCompile(`[\w./-]+\.(?:go|ts|tsx|js|jsx|svelte):\d+`)
 
 // hasLabeledSection reports whether any report line is a markdown section header
 // whose label starts with one of keywords, optionally followed by a parenthetical

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -1179,7 +1179,7 @@ func hasLabeledSection(report string, keywords ...string) bool {
 			inFence = !inFence
 			continue
 		}
-		if inFence || trimmed == "" {
+		if inFence || trimmed == "" || strings.HasPrefix(line, "    ") || strings.HasPrefix(line, "\t") {
 			continue
 		}
 		lower := strings.ToLower(trimmed)
@@ -1198,7 +1198,7 @@ func hasLabeledSection(report string, keywords ...string) bool {
 			if !strings.HasPrefix(rest, ":") {
 				continue
 			}
-			afterColon := strings.TrimSpace(strings.TrimRight(strings.TrimSpace(rest[1:]), "*"))
+			afterColon := strings.TrimSpace(strings.TrimRight(strings.TrimSpace(rest[1:]), "*_"))
 			if afterColon != "" || hasFollowingContent(rawLines, i) {
 				return true
 			}
@@ -1222,12 +1222,35 @@ func hasFollowingContent(rawLines []string, idx int) bool {
 			continue
 		}
 		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
-			return true
+			content, end := fenceContentEnd(rawLines, j+1)
+			if content {
+				return true
+			}
+			j = end
+			continue
 		}
 		stripped := strings.TrimLeft(strings.ToLower(trimmed), "*_>#- \t")
 		return !headerLikeLineRe.MatchString(stripped)
 	}
 	return false
+}
+
+// fenceContentEnd scans a fenced code block starting at rawLines[start] (the
+// line immediately after the opening fence marker) and reports whether the
+// block contains any non-blank line before its closing fence, plus the index
+// of that closing fence marker (or the last line, if the fence never closes).
+// An empty fence must not count as evidence backing a bare header.
+func fenceContentEnd(rawLines []string, start int) (hasContent bool, end int) {
+	for j := start; j < len(rawLines); j++ {
+		trimmed := strings.TrimSpace(rawLines[j])
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			return hasContent, j
+		}
+		if trimmed != "" {
+			hasContent = true
+		}
+	}
+	return hasContent, len(rawLines) - 1
 }
 
 func containsAny(s string, needles ...string) bool {

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -1142,10 +1142,14 @@ func hasGroundedFailureEvidence(report string) bool {
 	return hasCommand && hasObserved && hasExpected && hasGrounding
 }
 
-// bareLabelLineRe matches a report line that is nothing but a markdown-decorated
-// label followed by a colon, e.g. "command:" or "actual (observed):" with all
-// decoration already stripped — no evidence content on the same line.
-var bareLabelLineRe = regexp.MustCompile(`^[a-z][a-z0-9 '/()-]*:\**$`)
+// headerLikeLineRe matches a report line that STARTS with a short
+// markdown-decorated label followed by a colon, whether or not further text
+// follows on the same line, e.g. "actual:** something happened" or
+// "command:". Used to recognize that a line belongs to a *different* header's
+// own section rather than being prose content continuing a preceding bare
+// header — a bare header immediately followed by another header's line (with
+// or without inline content) still has no content of its own.
+var headerLikeLineRe = regexp.MustCompile(`^[a-z][a-z0-9 '/()-]{0,40}:`)
 
 // hasLabeledSection reports whether any report line is a markdown section header
 // whose label starts with one of keywords, optionally followed by a parenthetical
@@ -1196,9 +1200,11 @@ func hasLabeledSection(report string, keywords ...string) bool {
 // hasFollowingContent reports whether the bare label line at rawLines[idx] (a
 // header with nothing after its colon) is backed by real evidence on a
 // following line — a fenced code block, or any non-blank line that is not
-// itself another bare label. It stops at the first non-blank line: a header
-// immediately followed by another header, with nothing in between, has no
-// content of its own.
+// itself a header line (bare or otherwise). It stops at the first non-blank
+// line: a header immediately followed by another header — whether that
+// header itself carries inline content or not — has no content of its own,
+// since the inline content belongs to the *other* header's section, not the
+// bare one being tested.
 func hasFollowingContent(rawLines []string, idx int) bool {
 	for j := idx + 1; j < len(rawLines); j++ {
 		trimmed := strings.TrimSpace(rawLines[j])
@@ -1209,7 +1215,7 @@ func hasFollowingContent(rawLines []string, idx int) bool {
 			return true
 		}
 		stripped := strings.TrimLeft(strings.ToLower(trimmed), "*_>#- \t")
-		return !bareLabelLineRe.MatchString(stripped)
+		return !headerLikeLineRe.MatchString(stripped)
 	}
 	return false
 }

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -311,6 +311,50 @@ func TestHasGroundedFailureEvidence_AcceptsRealFileLineCitation(t *testing.T) {
 	}
 }
 
+func TestHasGroundedFailureEvidence_RejectsUnderscoreBareHeader(t *testing.T) {
+	t.Parallel()
+
+	// A bare header decorated with underscore emphasis (__Command:__) instead
+	// of asterisks must not be credited with content: the trailing "__" is
+	// decoration, not a real reproduction command.
+	report := "__Command:__\n\n**Actual:** something happened\n\n**Expected:** nothing\n\n" +
+		"**Code evidence:** internal/x.go:1\n"
+
+	if hasGroundedFailureEvidence(report) {
+		t.Fatal("underscore-decorated bare Command header accepted as grounded; want rejected")
+	}
+}
+
+func TestHasGroundedFailureEvidence_RejectsHeaderKeywordInsideIndentedSnippet(t *testing.T) {
+	t.Parallel()
+
+	// "command:" appearing inside an indented (4-space) code snippet must not
+	// be misread as a real evidence header — there is no actual reproduction
+	// command stated anywhere in this report.
+	report := "Some notes about the failure:\n\n" +
+		"    command: this is just quoted snippet text, not a real header\n\n" +
+		"**Actual:** something happened\n\n**Expected:** nothing\n\n" +
+		"**Code evidence:** internal/x.go:1\n"
+
+	if hasGroundedFailureEvidence(report) {
+		t.Fatal("indented snippet text accepted as a grounded Command header; want rejected")
+	}
+}
+
+func TestHasGroundedFailureEvidence_RejectsBareHeaderBackedByEmptyFence(t *testing.T) {
+	t.Parallel()
+
+	// A bare "**Command:**" header immediately followed by an empty fenced
+	// code block has no real content — the empty fence must not count as
+	// evidence backing the header.
+	report := "**Command:**\n```\n```\n\n**Actual:** something happened\n\n**Expected:** nothing\n\n" +
+		"**Code evidence:** internal/x.go:1\n"
+
+	if hasGroundedFailureEvidence(report) {
+		t.Fatal("bare Command header backed by empty fence accepted as grounded; want rejected")
+	}
+}
+
 func TestTestFailureSectionIgnoresStaleLookingHeading(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -251,6 +251,20 @@ func TestHasGroundedFailureEvidence_RejectsUngroundedReport(t *testing.T) {
 	}
 }
 
+func TestHasGroundedFailureEvidence_RejectsBareHeadersWithNoContent(t *testing.T) {
+	t.Parallel()
+
+	// A report that stacks empty headers with nothing after the colon must not
+	// satisfy the gate — only the "code evidence" header here carries real
+	// content, so command/observed/expected evidence is missing despite the
+	// headers being present.
+	report := "**Command:**\n\n**Actual:**\n\n**Expected:**\n\n**Code evidence:** internal/x.go:1\n"
+
+	if hasGroundedFailureEvidence(report) {
+		t.Fatal("bare-header report with no evidence accepted as grounded; want rejected")
+	}
+}
+
 func TestTestFailureSectionIgnoresStaleLookingHeading(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -281,6 +281,36 @@ func TestHasGroundedFailureEvidence_RejectsBareHeaderBorrowingNextHeaderContent(
 	}
 }
 
+func TestHasGroundedFailureEvidence_RejectsBareCodeEvidenceHeader(t *testing.T) {
+	t.Parallel()
+
+	// hasGrounding (the code-evidence clause) was a plain substring check that
+	// never verified any content followed the header, unlike the other three
+	// clauses. A bare "**Code evidence:**" header with nothing after the colon
+	// must not satisfy the gate even when command/observed/expected are real.
+	report := "**Command:** go test ./internal/workflow/ -run Foo -v\n\n" +
+		"**Actual:** the test failed with a nil pointer panic\n\n" +
+		"**Expected:** the task says the handler should return an error, not panic\n\n" +
+		"**Code evidence:**\n"
+
+	if hasGroundedFailureEvidence(report) {
+		t.Fatal("bare code evidence header accepted as grounded; want rejected")
+	}
+}
+
+func TestHasGroundedFailureEvidence_AcceptsRealFileLineCitation(t *testing.T) {
+	t.Parallel()
+
+	report := "**Command:** go test ./internal/workflow/ -run Foo -v\n\n" +
+		"**Actual:** the test failed with a nil pointer panic\n\n" +
+		"**Expected:** the task says the handler should return an error, not panic\n\n" +
+		"**Code evidence:** internal/workflow/engine_steps_testroute.go:1142\n"
+
+	if !hasGroundedFailureEvidence(report) {
+		t.Fatal("real file:line citation rejected as ungrounded; want grounded")
+	}
+}
+
 func TestTestFailureSectionIgnoresStaleLookingHeading(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -265,6 +265,22 @@ func TestHasGroundedFailureEvidence_RejectsBareHeadersWithNoContent(t *testing.T
 	}
 }
 
+func TestHasGroundedFailureEvidence_RejectsBareHeaderBorrowingNextHeaderContent(t *testing.T) {
+	t.Parallel()
+
+	// A bare "**Command:**" header must not be credited with the *following*
+	// header's inline content ("**Actual:** something happened") — that
+	// content belongs to Actual's own section, not Command's. Without this
+	// distinction the report has no stated reproduction command anywhere yet
+	// still passes the gate as grounded.
+	report := "**Command:**\n\n**Actual:** something happened\n\n**Expected:** nothing\n\n" +
+		"**Code evidence:** internal/x.go:1\n"
+
+	if hasGroundedFailureEvidence(report) {
+		t.Fatal("bare Command header borrowing next header's content accepted as grounded; want rejected")
+	}
+}
+
 func TestTestFailureSectionIgnoresStaleLookingHeading(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation

The test-route's grounded-failure-evidence gate (\`hasGroundedFailureEvidence\`) had two gaps that let ungrounded FAIL/product_bug reports slip through, forcing an unnecessary human escalation or silently bypassing it:

1. The command/observed/expected header checks accepted a bare label (e.g. \`**Command:**\` with nothing after the colon) as long as *some* non-blank line followed it — even if that line actually belonged to the next header's own section.
2. The code-evidence clause was a plain substring check that never verified any content followed the header, and its loose \`src/\`/\`internal/\` match could fire on an incidental path fragment (like the stated test command's own package path) instead of a real file:line citation.

## Implementation information

- Added \`hasLabeledSection\`, tolerating a parenthetical qualifier between the keyword and the colon on a markdown header line, and OR'd it into the command/observed/expected checks.
- Hardened \`hasFollowingContent\` to recognize any line starting with a short label-then-colon shape (\`headerLikeLineRe\`) as belonging to a distinct header's section, so it's never credited to a preceding bare header. Removed the now-unused \`bareLabelLineRe\`.
- Routed the code-evidence header through \`hasLabeledSection\` so a bare header with no content is rejected, and replaced the bare \`src/\`/\`internal/\`/\`.go:\` substring checks with \`fileLineCitationRe\`, requiring an actual file:line citation.
- Added regression tests reproducing the adversarial reports these gaps let through.

> Changelog: fix(workflow): harden grounded-evidence gate against bare headers