### PR TITLE
feat(gui): bless tamper-flagged tasks

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/taskservice.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/taskservice.ts
@@ -15,6 +15,16 @@ import { Call as $Call, CancellablePromise as $CancellablePromise, Create as $Cr
 import * as task$0 from "../task/models.js";
 
 /**
+ * BlessTampering marks a human-reviewed tamper finding as accepted and sends
+ * the task back into the review lane.
+ */
+export function BlessTampering(taskID: string): $CancellablePromise<task$0.Task> {
+    return $Call.ByID(2730384212, taskID).then(($result: any) => {
+        return $$createType0($result);
+    });
+}
+
+/**
  * CreateTask creates a new task and starts a matching workflow.
  * If the title is a GitHub issue URL, fetches real title/body from GitHub.
  */

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -228,6 +228,12 @@ export class Task {
     "statusReason": string;
 
     /**
+     * CanBlessTampering is a computed API field set by TaskService when a
+     * human-required task was blocked by detect_tampering.
+     */
+    "canBlessTampering"?: boolean;
+
+    /**
      * HandoffSourceProvider records which local agent provider produced the
      * work before a handoff skipped directly into review/testing/PR. Workflow
      * steps with provider=cross use it when there is no Sybra-authored run
@@ -457,10 +463,10 @@ export class Task {
     static createFrom($$source: any = {}): Task {
         const $$createField6_0 = $$createType0;
         const $$createField7_0 = $$createType0;
-        const $$createField17_0 = $$createType0;
-        const $$createField35_0 = $$createType2;
-        const $$createField36_0 = $$createType4;
-        const $$createField47_0 = $$createType5;
+        const $$createField18_0 = $$createType0;
+        const $$createField36_0 = $$createType2;
+        const $$createField37_0 = $$createType4;
+        const $$createField48_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -469,16 +475,16 @@ export class Task {
             $$parsedSource["tags"] = $$createField7_0($$parsedSource["tags"]);
         }
         if ("dependsOn" in $$parsedSource) {
-            $$parsedSource["dependsOn"] = $$createField17_0($$parsedSource["dependsOn"]);
+            $$parsedSource["dependsOn"] = $$createField18_0($$parsedSource["dependsOn"]);
         }
         if ("agentRuns" in $$parsedSource) {
-            $$parsedSource["agentRuns"] = $$createField35_0($$parsedSource["agentRuns"]);
+            $$parsedSource["agentRuns"] = $$createField36_0($$parsedSource["agentRuns"]);
         }
         if ("workflow" in $$parsedSource) {
-            $$parsedSource["workflow"] = $$createField36_0($$parsedSource["workflow"]);
+            $$parsedSource["workflow"] = $$createField37_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField47_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField48_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }

--- a/frontend/src/components/task-detail/TaskHeaderBar.svelte
+++ b/frontend/src/components/task-detail/TaskHeaderBar.svelte
@@ -86,10 +86,7 @@
     ),
   )
   const isReviewTask = $derived(task.tags?.includes('review') ?? false)
-  const canBlessTampering = $derived(
-    task.status === 'human-required' &&
-      (task.statusReason ?? '').startsWith('possible test tampering'),
-  )
+  const canBlessTampering = $derived(task.canBlessTampering ?? false)
 
   $effect(() => {
     if (editingTitle && titleInputRef) titleInputRef.focus()
@@ -221,7 +218,8 @@
     try {
       await taskStore.blessTampering(task.id)
     } catch (e) {
-      error = String(e)
+      await taskStore.patchOne(task.id)
+      error = `${String(e)}. Task state was refreshed; retry only if it is still awaiting tamper blessing.`
     } finally {
       blessTamperingLoading = false
     }

--- a/frontend/src/components/task-detail/TaskHeaderBar.svelte
+++ b/frontend/src/components/task-detail/TaskHeaderBar.svelte
@@ -28,6 +28,7 @@
   let copiedBranch = $state(false)
   let reviewLoading = $state(false)
   let fixReviewLoading = $state(false)
+  let blessTamperingLoading = $state(false)
   let error = $state('')
   let menuOpen = $state(false)
 
@@ -85,6 +86,10 @@
     ),
   )
   const isReviewTask = $derived(task.tags?.includes('review') ?? false)
+  const canBlessTampering = $derived(
+    task.status === 'human-required' &&
+      (task.statusReason ?? '').startsWith('possible test tampering'),
+  )
 
   $effect(() => {
     if (editingTitle && titleInputRef) titleInputRef.focus()
@@ -210,6 +215,18 @@
     }
   }
 
+  async function blessTampering() {
+    blessTamperingLoading = true
+    error = ''
+    try {
+      await taskStore.blessTampering(task.id)
+    } catch (e) {
+      error = String(e)
+    } finally {
+      blessTamperingLoading = false
+    }
+  }
+
   async function deleteTask() {
     deleting = true
     try {
@@ -315,6 +332,16 @@
         title="Run fix-review skill to apply unresolved PR review comments"
       >
         {fixReviewLoading ? 'Starting...' : 'Fix Review Comments'}
+      </button>
+    {/if}
+    {#if canBlessTampering}
+      <button
+        type="button"
+        class="rounded bg-success-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-success-600 disabled:opacity-50"
+        onclick={blessTampering}
+        disabled={blessTamperingLoading}
+      >
+        {blessTamperingLoading ? 'Blessing...' : 'Bless & send to review'}
       </button>
     {/if}
     {#if fixingReviewAgent}

--- a/frontend/src/components/task-detail/TaskHeaderBar.svelte.test.ts
+++ b/frontend/src/components/task-detail/TaskHeaderBar.svelte.test.ts
@@ -4,6 +4,7 @@ import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/sv
 const mockUpdate = vi.fn()
 const mockRemove = vi.fn()
 const mockBlessTampering = vi.fn()
+const mockPatchOne = vi.fn()
 const mockStartReview = vi.fn()
 const mockStartFixReview = vi.fn()
 
@@ -12,6 +13,7 @@ vi.mock('../../stores/tasks.svelte.js', () => ({
     update: (...args: unknown[]) => mockUpdate(...args),
     remove: (...args: unknown[]) => mockRemove(...args),
     blessTampering: (...args: unknown[]) => mockBlessTampering(...args),
+    patchOne: (...args: unknown[]) => mockPatchOne(...args),
   },
 }))
 
@@ -56,11 +58,13 @@ describe('TaskHeaderBar', () => {
     mockUpdate.mockReset()
     mockRemove.mockReset()
     mockBlessTampering.mockReset()
+    mockPatchOne.mockReset()
     mockStartReview.mockReset()
     mockStartFixReview.mockReset()
     mockUpdate.mockResolvedValue(baseTask)
     mockRemove.mockResolvedValue(undefined)
     mockBlessTampering.mockResolvedValue({ ...baseTask, status: 'ready-review', tags: ['tamper-blessed'] })
+    mockPatchOne.mockResolvedValue(undefined)
   })
   afterEach(cleanup)
 
@@ -195,7 +199,8 @@ describe('TaskHeaderBar', () => {
         task: {
           ...baseTask,
           status: 'human-required',
-          statusReason: 'possible test tampering — needs human bless before review: test.go',
+          statusReason: 'human-readable detector details',
+          canBlessTampering: true,
         } as never,
         ondelete: vi.fn(),
       },
@@ -209,7 +214,12 @@ describe('TaskHeaderBar', () => {
   it('hides Bless Tampering for non-tamper human-required tasks', () => {
     render(TaskHeaderBar, {
       props: {
-        task: { ...baseTask, status: 'human-required', statusReason: 'approval required' } as never,
+        task: {
+          ...baseTask,
+          status: 'human-required',
+          statusReason: 'possible test tampering — old prose alone is insufficient',
+          canBlessTampering: false,
+        } as never,
         ondelete: vi.fn(),
       },
     })

--- a/frontend/src/components/task-detail/TaskHeaderBar.svelte.test.ts
+++ b/frontend/src/components/task-detail/TaskHeaderBar.svelte.test.ts
@@ -3,6 +3,7 @@ import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/sv
 
 const mockUpdate = vi.fn()
 const mockRemove = vi.fn()
+const mockBlessTampering = vi.fn()
 const mockStartReview = vi.fn()
 const mockStartFixReview = vi.fn()
 
@@ -10,6 +11,7 @@ vi.mock('../../stores/tasks.svelte.js', () => ({
   taskStore: {
     update: (...args: unknown[]) => mockUpdate(...args),
     remove: (...args: unknown[]) => mockRemove(...args),
+    blessTampering: (...args: unknown[]) => mockBlessTampering(...args),
   },
 }))
 
@@ -53,10 +55,12 @@ describe('TaskHeaderBar', () => {
   beforeEach(() => {
     mockUpdate.mockReset()
     mockRemove.mockReset()
+    mockBlessTampering.mockReset()
     mockStartReview.mockReset()
     mockStartFixReview.mockReset()
     mockUpdate.mockResolvedValue(baseTask)
     mockRemove.mockResolvedValue(undefined)
+    mockBlessTampering.mockResolvedValue({ ...baseTask, status: 'ready-review', tags: ['tamper-blessed'] })
   })
   afterEach(cleanup)
 
@@ -183,6 +187,33 @@ describe('TaskHeaderBar', () => {
     await waitFor(() => {
       expect(mockStartReview).toHaveBeenCalledWith('t1')
     })
+  })
+
+  it('shows and calls Bless Tampering for tamper-flagged human-required tasks', async () => {
+    render(TaskHeaderBar, {
+      props: {
+        task: {
+          ...baseTask,
+          status: 'human-required',
+          statusReason: 'possible test tampering — needs human bless before review: test.go',
+        } as never,
+        ondelete: vi.fn(),
+      },
+    })
+    await fireEvent.click(screen.getByText('Bless & send to review'))
+    await waitFor(() => {
+      expect(mockBlessTampering).toHaveBeenCalledWith('t1')
+    })
+  })
+
+  it('hides Bless Tampering for non-tamper human-required tasks', () => {
+    render(TaskHeaderBar, {
+      props: {
+        task: { ...baseTask, status: 'human-required', statusReason: 'approval required' } as never,
+        ondelete: vi.fn(),
+      },
+    })
+    expect(screen.queryByText('Bless & send to review')).toBeNull()
   })
 
   it('Copy ID / Copy branch live in the overflow menu', async () => {

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -137,6 +137,7 @@ export function StartReview(arg1: string): Promise<void> { return call('ReviewSe
 export function GetStats(): Promise<StatsResponse> { return call('StatsService', 'GetStats') }
 
 // TaskService
+export function BlessTampering(arg1: string): Promise<Task> { return call('TaskService', 'BlessTampering', arg1) }
 export function CreateTask(arg1: string, arg2: string, arg3: string): Promise<Task> { return call('TaskService', 'CreateTask', arg1, arg2, arg3) }
 export function DeleteTask(arg1: string): Promise<void> { return call('TaskService', 'DeleteTask', arg1) }
 export function GetTask(arg1: string): Promise<Task> { return call('TaskService', 'GetTask', arg1) }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -134,6 +134,7 @@ export const StartReview = pick(ReviewSvc.StartReview, http.StartReview)
 export const GetStats = pick(StatsSvc.GetStats, http.GetStats)
 
 // TaskService
+export const BlessTampering = pick(TaskSvc.BlessTampering, http.BlessTampering)
 export const CreateTask = pick(TaskSvc.CreateTask, http.CreateTask)
 export const DeleteTask = pick(TaskSvc.DeleteTask, http.DeleteTask)
 export const GetTask = pick(TaskSvc.GetTask, http.GetTask)

--- a/frontend/src/stores/tasks.svelte.ts
+++ b/frontend/src/stores/tasks.svelte.ts
@@ -1,6 +1,7 @@
 import {
   ListTasks,
   GetTask,
+  BlessTampering,
   CreateTask,
   UpdateTask,
   DeleteTask,
@@ -91,6 +92,12 @@ class TaskStore extends EntityStore<Task> {
 
   async update(id: string, updates: Record<string, any>): Promise<Task> {
     const result = await UpdateTask(id, updates)
+    this.set(result.id, result)
+    return result
+  }
+
+  async blessTampering(id: string): Promise<Task> {
+    const result = await BlessTampering(id)
     this.set(result.id, result)
     return result
   }

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -6,6 +6,7 @@ const (
 	EventTaskCreated              = "task.created"
 	EventTaskStatusChanged        = "task.status_changed"
 	EventTaskDeleted              = "task.deleted"
+	EventTamperBlessed            = "task.tamper_blessed"
 	EventAgentStarted             = "agent.started"
 	EventAgentCompleted           = "agent.completed"
 	EventAgentFailed              = "agent.failed"

--- a/internal/sybra/services.go
+++ b/internal/sybra/services.go
@@ -80,6 +80,7 @@ func (a *App) coreHTTPServices() map[string]httpapi.Service {
 			"CreateTask",
 			"UpdateTask",
 			"DeleteTask",
+			"BlessTampering",
 		),
 		"StatsService": httpapi.NewService(a.statsSvc,
 			"GetStats",

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -53,7 +53,7 @@ func (s *TaskService) ListTasks() ([]task.Task, error) {
 		if all[i].TaskType == task.TaskTypeChat {
 			continue
 		}
-		out = append(out, all[i])
+		out = append(out, s.withComputedTaskFields(all[i]))
 	}
 	return out, nil
 }
@@ -64,7 +64,7 @@ func (s *TaskService) GetTask(id string) (task.Task, error) {
 	if err != nil {
 		return t, err
 	}
-	return s.withEstimatedAgentRunCosts(t), nil
+	return s.withComputedTaskFields(s.withEstimatedAgentRunCosts(t)), nil
 }
 
 // BlessTampering marks a human-reviewed tamper finding as accepted and sends
@@ -74,15 +74,22 @@ func (s *TaskService) BlessTampering(taskID string) (task.Task, error) {
 	if err != nil {
 		return cur, err
 	}
-
-	tags := slices.Clone(cur.Tags)
-	if !slices.Contains(tags, workflow.TamperBlessedTag) {
-		tags = append(tags, workflow.TamperBlessedTag)
+	if !canBlessTampering(cur) {
+		return cur, fmt.Errorf("task %s is not awaiting tamper blessing", taskID)
 	}
 
-	updated, err := s.tasks.Update(taskID, task.Update{
-		Tags:   task.Ptr(tags),
-		Status: task.Ptr(task.StatusReadyReview),
+	updated, err := s.tasks.UpdateFromCurrent(taskID, func(latest task.Task) (task.Update, error) {
+		if !canBlessTampering(latest) {
+			return task.Update{}, fmt.Errorf("task %s is no longer awaiting tamper blessing", taskID)
+		}
+		tags := slices.Clone(latest.Tags)
+		if !slices.Contains(tags, workflow.TamperBlessedTag) {
+			tags = append(tags, workflow.TamperBlessedTag)
+		}
+		return task.Update{
+			Tags:   task.Ptr(tags),
+			Status: task.Ptr(task.StatusReadyReview),
+		}, nil
 	})
 	if err != nil {
 		return updated, err
@@ -92,12 +99,25 @@ func (s *TaskService) BlessTampering(taskID string) (task.Task, error) {
 			Type:   audit.EventTamperBlessed,
 			TaskID: taskID,
 			Data: map[string]any{
-				"from_status": cur.Status,
-				"to_status":   updated.Status,
+				"from_status":           cur.Status,
+				"to_status":             updated.Status,
+				"status_reason":         cur.StatusReason,
+				"finding_severity":      "high",
+				"tamper_blessed_tag":    workflow.TamperBlessedTag,
+				"accepted_finding_text": cur.StatusReason,
 			},
 		})
 	}
-	return updated, nil
+	return s.withComputedTaskFields(updated), nil
+}
+
+func canBlessTampering(t task.Task) bool {
+	return t.Status == task.StatusHumanRequired && workflow.IsTamperStatusReason(t.StatusReason)
+}
+
+func (s *TaskService) withComputedTaskFields(t task.Task) task.Task {
+	t.CanBlessTampering = canBlessTampering(t)
+	return t
 }
 
 func (s *TaskService) withEstimatedAgentRunCosts(t task.Task) task.Task {
@@ -268,7 +288,7 @@ func (s *TaskService) CreateTask(title, body, mode string) (task.Task, error) {
 	if !isURLStub {
 		s.startCreatedWorkflow(t)
 	}
-	return t, nil
+	return s.withComputedTaskFields(t), nil
 }
 
 func (s *TaskService) startCreatedWorkflow(t task.Task) {
@@ -373,7 +393,7 @@ func (s *TaskService) UpdateTask(id string, updates map[string]any) (task.Task, 
 		}
 	}
 
-	return t, nil
+	return s.withComputedTaskFields(t), nil
 }
 
 // DeleteTask removes a task file from disk and cleans up its worktree.

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -75,12 +75,12 @@ func (s *TaskService) BlessTampering(taskID string) (task.Task, error) {
 		return cur, err
 	}
 	if !canBlessTampering(cur) {
-		return cur, fmt.Errorf("task %s is not awaiting tamper blessing", taskID)
+		return cur, conflictError(fmt.Sprintf("task %s is not awaiting tamper blessing", taskID))
 	}
 
 	updated, err := s.tasks.UpdateFromCurrent(taskID, func(latest task.Task) (task.Update, error) {
 		if !canBlessTampering(latest) {
-			return task.Update{}, fmt.Errorf("task %s is no longer awaiting tamper blessing", taskID)
+			return task.Update{}, conflictError(fmt.Sprintf("task %s is no longer awaiting tamper blessing", taskID))
 		}
 		tags := slices.Clone(latest.Tags)
 		if !slices.Contains(tags, workflow.TamperBlessedTag) {

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -3,6 +3,7 @@ package sybra
 import (
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -64,6 +65,39 @@ func (s *TaskService) GetTask(id string) (task.Task, error) {
 		return t, err
 	}
 	return s.withEstimatedAgentRunCosts(t), nil
+}
+
+// BlessTampering marks a human-reviewed tamper finding as accepted and sends
+// the task back into the review lane.
+func (s *TaskService) BlessTampering(taskID string) (task.Task, error) {
+	cur, err := s.tasks.Get(taskID)
+	if err != nil {
+		return cur, err
+	}
+
+	tags := slices.Clone(cur.Tags)
+	if !slices.Contains(tags, workflow.TamperBlessedTag) {
+		tags = append(tags, workflow.TamperBlessedTag)
+	}
+
+	updated, err := s.tasks.Update(taskID, task.Update{
+		Tags:   task.Ptr(tags),
+		Status: task.Ptr(task.StatusReadyReview),
+	})
+	if err != nil {
+		return updated, err
+	}
+	if s.audit != nil {
+		_ = s.audit.Log(audit.Event{
+			Type:   audit.EventTamperBlessed,
+			TaskID: taskID,
+			Data: map[string]any{
+				"from_status": cur.Status,
+				"to_status":   updated.Status,
+			},
+		})
+	}
+	return updated, nil
 }
 
 func (s *TaskService) withEstimatedAgentRunCosts(t task.Task) task.Task {

--- a/internal/sybra/svc_tasks_test.go
+++ b/internal/sybra/svc_tasks_test.go
@@ -169,6 +169,9 @@ func TestTaskService_BlessTamperingMergesTagStatusAndAudit(t *testing.T) {
 	if !slices.Contains(updated.Tags, workflow.TamperBlessedTag) {
 		t.Fatalf("tags = %v, want %q", updated.Tags, workflow.TamperBlessedTag)
 	}
+	if updated.CanBlessTampering {
+		t.Fatalf("CanBlessTampering = true after bless, want false")
+	}
 
 	events, err := audit.Read(auditDir, audit.Query{
 		Since:  time.Now().Add(-time.Hour),
@@ -184,6 +187,63 @@ func TestTaskService_BlessTamperingMergesTagStatusAndAudit(t *testing.T) {
 	}
 	if events[0].Data["from_status"] != string(task.StatusHumanRequired) || events[0].Data["to_status"] != string(task.StatusReadyReview) {
 		t.Fatalf("audit data = %+v, want from/to status", events[0].Data)
+	}
+	if events[0].Data["status_reason"] != created.StatusReason {
+		t.Fatalf("audit data = %+v, want status_reason %q", events[0].Data, created.StatusReason)
+	}
+	if events[0].Data["finding_severity"] != "high" {
+		t.Fatalf("audit data = %+v, want finding_severity high", events[0].Data)
+	}
+}
+
+func TestTaskService_BlessTamperingRejectsNonTamperTasks(t *testing.T) {
+	svc, _ := setupTaskService(t)
+
+	cases := []struct {
+		name         string
+		status       task.Status
+		statusReason string
+	}{
+		{
+			name:         "human required unrelated reason",
+			status:       task.StatusHumanRequired,
+			statusReason: "approval required",
+		},
+		{
+			name:         "tamper reason wrong status",
+			status:       task.StatusInProgress,
+			statusReason: workflow.TamperReasonPrefix + " — needs human bless before review: test.go",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			created, err := svc.tasks.CreateFull(tc.name, "", "headless", task.Update{
+				Status:       task.Ptr(tc.status),
+				StatusReason: task.Ptr(tc.statusReason),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			updated, err := svc.BlessTampering(created.ID)
+			if err == nil {
+				t.Fatal("BlessTampering succeeded, want error")
+			}
+			if updated.Status != tc.status {
+				t.Fatalf("returned status = %q, want %q", updated.Status, tc.status)
+			}
+			persisted, err := svc.tasks.Get(created.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if persisted.Status != tc.status {
+				t.Fatalf("persisted status = %q, want %q", persisted.Status, tc.status)
+			}
+			if slices.Contains(persisted.Tags, workflow.TamperBlessedTag) {
+				t.Fatalf("persisted tags = %v, must not contain %q", persisted.Tags, workflow.TamperBlessedTag)
+			}
+		})
 	}
 }
 

--- a/internal/sybra/svc_tasks_test.go
+++ b/internal/sybra/svc_tasks_test.go
@@ -10,10 +10,12 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
+	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/umbrella"
+	"github.com/Automaat/sybra/internal/workflow"
 )
 
 func TestTaskService_WithEstimatedAgentRunCosts(t *testing.T) {
@@ -132,6 +134,56 @@ func TestTaskService_GetTaskPersistsEstimatedAgentRunCosts(t *testing.T) {
 	}
 	if persisted.AgentRuns[0].Provider != "copilot" {
 		t.Fatalf("persisted provider = %q, want copilot", persisted.AgentRuns[0].Provider)
+	}
+}
+
+func TestTaskService_BlessTamperingMergesTagStatusAndAudit(t *testing.T) {
+	svc, _ := setupTaskService(t)
+	auditDir := t.TempDir()
+	al, err := audit.NewLogger(auditDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = al.Close() }()
+	svc.audit = al
+
+	created, err := svc.tasks.CreateFull("flagged task", "", "headless", task.Update{
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr("possible test tampering — needs human bless before review: test.go: skipped test"),
+		Tags:         task.Ptr([]string{"existing"}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updated, err := svc.BlessTampering(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != task.StatusReadyReview {
+		t.Fatalf("status = %q, want %q", updated.Status, task.StatusReadyReview)
+	}
+	if !slices.Contains(updated.Tags, "existing") {
+		t.Fatalf("tags = %v, want existing tag preserved", updated.Tags)
+	}
+	if !slices.Contains(updated.Tags, workflow.TamperBlessedTag) {
+		t.Fatalf("tags = %v, want %q", updated.Tags, workflow.TamperBlessedTag)
+	}
+
+	events, err := audit.Read(auditDir, audit.Query{
+		Since:  time.Now().Add(-time.Hour),
+		Until:  time.Now().Add(time.Hour),
+		Type:   audit.EventTamperBlessed,
+		TaskID: created.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("tamper blessed audit count = %d, want 1", len(events))
+	}
+	if events[0].Data["from_status"] != string(task.StatusHumanRequired) || events[0].Data["to_status"] != string(task.StatusReadyReview) {
+		t.Fatalf("audit data = %+v, want from/to status", events[0].Data)
 	}
 }
 

--- a/internal/sybra/svc_tasks_test.go
+++ b/internal/sybra/svc_tasks_test.go
@@ -2,6 +2,7 @@ package sybra
 
 import (
 	"errors"
+	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
@@ -229,6 +230,13 @@ func TestTaskService_BlessTamperingRejectsNonTamperTasks(t *testing.T) {
 			updated, err := svc.BlessTampering(created.ID)
 			if err == nil {
 				t.Fatal("BlessTampering succeeded, want error")
+			}
+			var ce *clientError
+			if !errors.As(err, &ce) {
+				t.Fatalf("BlessTampering error = %v (%T), want *clientError so the HTTP handler surfaces it instead of sanitizing to internal error", err, err)
+			}
+			if ce.HTTPStatus() != http.StatusConflict {
+				t.Fatalf("BlessTampering error status = %d, want %d", ce.HTTPStatus(), http.StatusConflict)
 			}
 			if updated.Status != tc.status {
 				t.Fatalf("returned status = %q, want %q", updated.Status, tc.status)

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -205,17 +205,20 @@ func (m *Manager) CreateChat(projectID string) (Task, error) {
 // Update applies field updates to a task and emits task:updated.
 // Serializes with other Update/AddRun/UpdateRun/Delete calls for the same id.
 //
-// Note on hook ordering: the status-change hook is invoked *after* the
-// per-task mutex is released. Hooks commonly call back into the task
-// manager (e.g. the workflow engine advancing a step, which writes the
-// workflow field via taskAdapter.SetWorkflow → Manager.Update). Calling
-// the hook while still holding the lock would deadlock that re-entry.
+// Note on hook and emitter ordering: both the status-change hook and the
+// task:updated emitter are invoked *after* the per-task mutex is released.
+// Hooks (and the emitter, which app.go wires through Manager.OnExternalUpdate
+// to unify in-process and cross-process status changes) commonly call back
+// into the task manager — e.g. the workflow engine advancing a step, which
+// writes the workflow field via taskAdapter.SetWorkflow → Manager.Update.
+// Calling either while still holding the lock would deadlock that re-entry.
 func (m *Manager) Update(id string, u Update) (Task, error) {
 	mu := m.lockFor(id)
 	mu.Lock()
 
-	t, hook, err := m.updateLocked(id, u)
+	t, hook, filePath, err := m.updateLocked(id, u)
 	mu.Unlock()
+	m.emitUpdated(filePath)
 	m.fireStatusHook(hook)
 	return t, err
 }
@@ -237,8 +240,9 @@ func (m *Manager) UpdateFromCurrent(id string, build func(Task) (Update, error))
 		mu.Unlock()
 		return cur, err
 	}
-	t, hook, err := m.updateLocked(id, u)
+	t, hook, filePath, err := m.updateLocked(id, u)
 	mu.Unlock()
+	m.emitUpdated(filePath)
 	m.fireStatusHook(hook)
 	return t, err
 }
@@ -249,26 +253,48 @@ type statusHookCall struct {
 	newStatus  string
 }
 
-func (m *Manager) updateLocked(id string, u Update) (Task, *statusHookCall, error) {
+// updateLocked applies the update and reports what the caller must do once
+// the per-task lock is released: emit filePath (if non-empty) via
+// m.emitUpdated, then fire hook (if non-nil) via m.fireStatusHook. It never
+// calls the emitter or the status hook itself — both can re-enter the
+// Manager for the same task id, which would deadlock against this method's
+// still-held lock.
+func (m *Manager) updateLocked(id string, u Update) (t Task, hook *statusHookCall, filePath string, err error) {
 	t, prev, err := m.store.UpdateWithPrev(id, u)
 	if err != nil {
-		return t, nil, err
+		return t, nil, "", err
 	}
 	metrics.TaskUpdated()
-	m.emitter.Emit(events.TaskUpdated, t.FilePath)
 
 	if u.Status != nil && m.onStatusHook != nil {
 		prevStatus := string(prev)
 		newStatus := string(t.Status)
 		if newStatus != prevStatus {
-			return t, &statusHookCall{id: id, prevStatus: prevStatus, newStatus: newStatus}, nil
+			return t, &statusHookCall{id: id, prevStatus: prevStatus, newStatus: newStatus}, t.FilePath, nil
 		}
 	}
-	return t, nil, nil
+	return t, nil, t.FilePath, nil
 }
 
+// emitUpdated fires the task:updated event. Must only be called with no
+// per-task lock held — see the ordering note on Update.
+func (m *Manager) emitUpdated(filePath string) {
+	if filePath == "" {
+		return
+	}
+	m.emitter.Emit(events.TaskUpdated, filePath)
+}
+
+// fireStatusHook invokes the status-change hook for a locally-applied update.
+// emitUpdated (called just before this, in Update/UpdateFromCurrent) routes
+// through Manager.OnExternalUpdate, which may have already fired the hook
+// for this exact transition and recorded it in firedStatus; skip the
+// redundant second call so a single status change doesn't dispatch twice.
 func (m *Manager) fireStatusHook(call *statusHookCall) {
 	if call == nil {
+		return
+	}
+	if prev, ok := m.lastFiredStatus(call.id); ok && prev == call.newStatus {
 		return
 	}
 	m.recordFiredStatus(call.id, call.newStatus)
@@ -293,9 +319,9 @@ func (m *Manager) AppendBody(id, content string) (Task, error) {
 	}
 	mu := m.lockFor(id)
 	mu.Lock()
-	defer mu.Unlock()
 	t, err := m.store.Get(id)
 	if err != nil {
+		mu.Unlock()
 		return Task{}, err
 	}
 	body := strings.TrimRight(t.Body, "\n")
@@ -304,28 +330,33 @@ func (m *Manager) AppendBody(id, content string) (Task, error) {
 	}
 	body += content + "\n"
 	t, _, err = m.store.UpdateWithPrev(id, Update{Body: &body})
+	mu.Unlock()
 	if err != nil {
 		return t, err
 	}
 	metrics.TaskUpdated()
-	m.emitter.Emit(events.TaskUpdated, t.FilePath)
+	m.emitUpdated(t.FilePath)
 	return t, nil
 }
 
-// Delete removes a task and emits task:deleted.
+// Delete removes a task and emits task:deleted. The emitter and delete hook
+// are invoked after the per-task lock is released — see the ordering note
+// on Update.
 func (m *Manager) Delete(id string) error {
 	mu := m.lockFor(id)
 	mu.Lock()
-	defer mu.Unlock()
 	t, err := m.store.Get(id)
 	if err != nil {
+		mu.Unlock()
 		return err
 	}
 	if err := m.store.Delete(id); err != nil {
+		mu.Unlock()
 		return err
 	}
 	m.locks.Delete(id)
 	m.forgetFiredStatus(id)
+	mu.Unlock()
 	metrics.TaskDeleted()
 	m.emitter.Emit(events.TaskDeleted, t.FilePath)
 	if m.onDeleteHook != nil {
@@ -339,7 +370,9 @@ func (m *Manager) AddRun(taskID string, run AgentRun) error {
 	return m.AddRunWithStatus(taskID, run, nil)
 }
 
-// AddRunWithStatus appends an agent run and optionally changes task status in one write.
+// AddRunWithStatus appends an agent run and optionally changes task status
+// in one write. The emitter and status hook fire after the per-task lock is
+// released — see the ordering note on Update.
 func (m *Manager) AddRunWithStatus(taskID string, run AgentRun, status *Status) error {
 	mu := m.lockFor(taskID)
 	mu.Lock()
@@ -353,19 +386,19 @@ func (m *Manager) AddRunWithStatus(taskID string, run AgentRun, status *Status) 
 		mu.Unlock()
 		return err
 	}
-	t, err := m.store.Get(taskID)
-	if err == nil {
-		m.emitter.Emit(events.TaskUpdated, t.FilePath)
-	}
+	t, getErr := m.store.Get(taskID)
 	var (
 		fireHook  bool
 		newStatus string
 	)
-	if status != nil && m.onStatusHook != nil && err == nil {
+	if status != nil && m.onStatusHook != nil && getErr == nil {
 		newStatus = string(t.Status)
 		fireHook = newStatus != prevStatus
 	}
 	mu.Unlock()
+	if getErr == nil {
+		m.emitUpdated(t.FilePath)
+	}
 	if fireHook {
 		m.recordFiredStatus(taskID, newStatus)
 		m.onStatusHook(taskID, prevStatus, newStatus)
@@ -374,16 +407,19 @@ func (m *Manager) AddRunWithStatus(taskID string, run AgentRun, status *Status) 
 }
 
 // UpdateRun updates fields on a specific agent run and emits task:updated.
+// The emitter fires after the per-task lock is released — see the ordering
+// note on Update.
 func (m *Manager) UpdateRun(taskID, agentID string, patch RunPatch) error {
 	mu := m.lockFor(taskID)
 	mu.Lock()
-	defer mu.Unlock()
 	if err := m.store.UpdateRun(taskID, agentID, patch); err != nil {
+		mu.Unlock()
 		return err
 	}
 	t, err := m.store.Get(taskID)
+	mu.Unlock()
 	if err == nil {
-		m.emitter.Emit(events.TaskUpdated, t.FilePath)
+		m.emitUpdated(t.FilePath)
 	}
 	return nil
 }

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -214,30 +214,65 @@ func (m *Manager) Update(id string, u Update) (Task, error) {
 	mu := m.lockFor(id)
 	mu.Lock()
 
-	t, prev, err := m.store.UpdateWithPrev(id, u)
+	t, hook, err := m.updateLocked(id, u)
+	mu.Unlock()
+	m.fireStatusHook(hook)
+	return t, err
+}
+
+// UpdateFromCurrent builds and applies an update while holding the per-task
+// mutation lock, so callers can merge fields from the latest task state without
+// racing another Manager write for the same task.
+func (m *Manager) UpdateFromCurrent(id string, build func(Task) (Update, error)) (Task, error) {
+	mu := m.lockFor(id)
+	mu.Lock()
+
+	cur, err := m.store.Get(id)
 	if err != nil {
 		mu.Unlock()
-		return t, err
+		return cur, err
+	}
+	u, err := build(cur)
+	if err != nil {
+		mu.Unlock()
+		return cur, err
+	}
+	t, hook, err := m.updateLocked(id, u)
+	mu.Unlock()
+	m.fireStatusHook(hook)
+	return t, err
+}
+
+type statusHookCall struct {
+	id         string
+	prevStatus string
+	newStatus  string
+}
+
+func (m *Manager) updateLocked(id string, u Update) (Task, *statusHookCall, error) {
+	t, prev, err := m.store.UpdateWithPrev(id, u)
+	if err != nil {
+		return t, nil, err
 	}
 	metrics.TaskUpdated()
 	m.emitter.Emit(events.TaskUpdated, t.FilePath)
 
-	var (
-		fireHook            bool
-		prevStatus, newStat string
-	)
 	if u.Status != nil && m.onStatusHook != nil {
-		prevStatus = string(prev)
-		newStat = string(t.Status)
-		fireHook = newStat != prevStatus
+		prevStatus := string(prev)
+		newStatus := string(t.Status)
+		if newStatus != prevStatus {
+			return t, &statusHookCall{id: id, prevStatus: prevStatus, newStatus: newStatus}, nil
+		}
 	}
-	mu.Unlock()
+	return t, nil, nil
+}
 
-	if fireHook {
-		m.recordFiredStatus(id, newStat)
-		m.onStatusHook(id, prevStatus, newStat)
+func (m *Manager) fireStatusHook(call *statusHookCall) {
+	if call == nil {
+		return
 	}
-	return t, nil
+	m.recordFiredStatus(call.id, call.newStatus)
+	m.onStatusHook(call.id, call.prevStatus, call.newStatus)
 }
 
 // UpdateMap converts raw to a typed Update and applies it.

--- a/internal/task/manager_test.go
+++ b/internal/task/manager_test.go
@@ -4,7 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/events"
 )
@@ -360,6 +362,88 @@ func TestLockForTypeMismatchNoPanic(t *testing.T) {
 		mu.Lock()
 		defer mu.Unlock()
 	}()
+}
+
+// reentrantEmitter mimics app.go's emit closure: on task:updated it routes
+// through Manager.OnExternalUpdate (using the real, in-process Manager), the
+// same call app.go makes to unify cross-process and in-process status
+// changes. Manager must never invoke this emitter while its own per-task
+// lock is held, or a status hook that writes back through the Manager (as
+// the workflow engine does) deadlocks against itself.
+type reentrantEmitter struct {
+	m *Manager
+}
+
+func (r *reentrantEmitter) Emit(name string, data any) {
+	if name != events.TaskUpdated && name != events.TaskCreated {
+		return
+	}
+	path, ok := data.(string)
+	if !ok {
+		return
+	}
+	r.m.OnExternalUpdate(path)
+}
+
+// TestManagerUpdateFromCurrentDoesNotDeadlockOnReentrantHook is a regression
+// test for the BlessTampering deadlock: a status-change hook that writes
+// back to the same task id via Manager.Update, triggered synchronously from
+// the emitter, used to deadlock because the emitter fired while updateLocked
+// still held the per-task mutex.
+func TestManagerUpdateFromCurrentDoesNotDeadlockOnReentrantHook(t *testing.T) {
+	t.Parallel()
+
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	m := NewManager(store, nil)
+	m.emitter = &reentrantEmitter{m: m}
+
+	task, err := m.Create("Title", "", "headless")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var rewritten atomic.Bool
+	m.SetStatusChangeHook(func(id, from, to string) {
+		if to != string(StatusInReview) || !rewritten.CompareAndSwap(false, true) {
+			return
+		}
+		// Re-enter the Manager for the same task id, as the workflow engine
+		// does when a status hook starts a new workflow step.
+		if _, err := m.Update(id, Update{Body: Ptr("rewritten-by-hook")}); err != nil {
+			t.Errorf("re-entrant Update: %v", err)
+		}
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := m.UpdateFromCurrent(task.ID, func(_ Task) (Update, error) {
+			return Update{Status: Ptr(StatusInReview)}, nil
+		})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("UpdateFromCurrent: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("UpdateFromCurrent deadlocked on a re-entrant status hook")
+	}
+
+	got, err := m.Get(task.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != StatusInReview {
+		t.Fatalf("Status = %q, want %q", got.Status, StatusInReview)
+	}
+	if got.Body != "rewritten-by-hook" {
+		t.Fatalf("Body = %q, want rewritten-by-hook", got.Body)
+	}
 }
 
 func TestNoopEmitter(t *testing.T) {

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -244,6 +244,9 @@ type Task struct {
 	PRNumber     int    `json:"prNumber"`
 	Issue        string `json:"issue"`
 	StatusReason string `json:"statusReason"`
+	// CanBlessTampering is a computed API field set by TaskService when a
+	// human-required task was blocked by detect_tampering.
+	CanBlessTampering bool `json:"canBlessTampering,omitempty"`
 	// HandoffSourceProvider records which local agent provider produced the
 	// work before a handoff skipped directly into review/testing/PR. Workflow
 	// steps with provider=cross use it when there is no Sybra-authored run

--- a/internal/task/persistence_test.go
+++ b/internal/task/persistence_test.go
@@ -169,7 +169,7 @@ func TestPersistenceTypesHaveYAMLTags(t *testing.T) {
 
 func taskSidecarField(name string) bool {
 	switch name {
-	case "Body", "Plan", "PlanContract", "PlanCritique", "PlanResearch", "PlanDecisions", "PlanBrief", "CodeReview", "PlanDrafts", "FilePath":
+	case "Body", "Plan", "PlanContract", "PlanCritique", "PlanResearch", "PlanDecisions", "PlanBrief", "CodeReview", "PlanDrafts", "FilePath", "CanBlessTampering":
 		return true
 	default:
 		return false

--- a/internal/workflow/engine_steps_tamper.go
+++ b/internal/workflow/engine_steps_tamper.go
@@ -17,6 +17,9 @@ import (
 // committed diff and re-flag forever (livelock).
 const tamperBlessedTag = "tamper-blessed"
 
+// TamperBlessedTag marks a task whose tamper finding was manually accepted.
+const TamperBlessedTag = tamperBlessedTag
+
 // tamperCategory classifies a changed file by the role it plays in the
 // project's verification surface. Only test/snapshot/fixture/ci files are
 // scanned for tampering; everything else is treated as implementation.

--- a/internal/workflow/engine_steps_tamper.go
+++ b/internal/workflow/engine_steps_tamper.go
@@ -11,14 +11,19 @@ import (
 	"strings"
 )
 
-// tamperBlessedTag short-circuits the detector: a human who has reviewed a
+// TamperBlessedTag short-circuits the detector: a human who has reviewed a
 // flagged diff and accepted it adds this tag, then moves the task back into the
 // flow. Without it, re-dispatching a flagged task would re-scan the same
 // committed diff and re-flag forever (livelock).
-const tamperBlessedTag = "tamper-blessed"
+const TamperBlessedTag = "tamper-blessed"
 
-// TamperBlessedTag marks a task whose tamper finding was manually accepted.
-const TamperBlessedTag = tamperBlessedTag
+// TamperReasonPrefix prefixes human-required reasons emitted by detect_tampering.
+const TamperReasonPrefix = "possible test tampering"
+
+// IsTamperStatusReason reports whether reason was emitted by detect_tampering.
+func IsTamperStatusReason(reason string) bool {
+	return strings.HasPrefix(reason, TamperReasonPrefix)
+}
 
 // tamperCategory classifies a changed file by the role it plays in the
 // project's verification surface. Only test/snapshot/fixture/ci files are
@@ -448,7 +453,7 @@ func downgradeRemovedAssertionOnlyFindings(findings []tamperFinding) []tamperFin
 // worktrees to human-required, so a diff failure here is logged and passed
 // through rather than double-flipping or stranding the task.
 func (e *Engine) execDetectTampering(taskID string, step *Step, t TaskInfo) (StepOutput, error) {
-	if slices.Contains(t.Tags, tamperBlessedTag) {
+	if slices.Contains(t.Tags, TamperBlessedTag) {
 		e.logger.Info("workflow.detect-tampering.blessed", "task_id", taskID)
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "blessed"}, nil
 	}
@@ -602,7 +607,7 @@ func parseNameStatus(out string) []tamperChange {
 // tamperReason builds the human-required status reason from high findings.
 func tamperReason(r tamperReport) string {
 	var b strings.Builder
-	b.WriteString("possible test tampering — needs human bless before review: ")
+	b.WriteString(TamperReasonPrefix + " — needs human bless before review: ")
 	shown := 0
 	for i := range r.Findings {
 		f := r.Findings[i]


### PR DESCRIPTION
## Motivation

Tasks flagged by the tamper-detection gate had no in-app way to be
reviewed and cleared back into the pipeline — clearing a false-positive
required manual file edits.

## Implementation information

- Add `TaskService.BlessTampering` to merge the `tamper-blessed` tag,
  move the task back to `ready-review`, and emit a
  `task.tamper_blessed` audit event on success.
- Wire the action through the GUI (`TaskHeaderBar`), API client, and
  task store.
- Expose `BlessTampering` over the server HTTP allowlist (it was
  missing, so the desktop Wails path worked but the server returned
  404).
- Surface `BlessTampering` precondition errors as HTTP 409.
- Stop `Manager` emitting audit events while still holding its
  per-task lock, to avoid a listener re-entering the manager under
  lock.