### PR TITLE
feat(umbrella): add zero-edge floor, critic re-ask

### DIFF
--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -15,8 +15,9 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 )
 
-// PlannerTimeout bounds a single planner LLM invocation so a hung process
-// cannot wedge an expansion indefinitely.
+// PlannerTimeout bounds the whole Generate call — every attemptPlan retry
+// plus the zero-edge-floor critic re-ask — so a hung process cannot wedge an
+// expansion indefinitely.
 const PlannerTimeout = 5 * time.Minute
 
 // FetchTimeout bounds the GitHub sub-issue fetch so a stalled gh call cannot

--- a/internal/umbrella/planner.go
+++ b/internal/umbrella/planner.go
@@ -115,13 +115,21 @@ func attemptPlan(ctx context.Context, run Runner, idx refIndex, prompt string, s
 }
 
 // flatPlanSuspicious reports whether a validated plan looks like it skipped
-// dependency derivation: 3 or more non-done sub-issues but zero total derived
-// edges across all children. Below that threshold small plans are legitimately
-// edge-free and are not flagged.
+// dependency derivation: 3 or more non-done sub-issues but zero derived edges
+// that will actually survive into the materialized plan. Below that threshold
+// small plans are legitimately edge-free and are not flagged. Edges on a
+// closed child, or pointing at a closed sub-issue, are excluded from the
+// count — ChildSpecs drops both (the closed child gets no task, and a
+// dependency on a closed sub-issue is already satisfied), so counting them
+// here would suppress the critic re-ask while the materialized plan for the
+// remaining non-done children is still fully parallel.
 func flatPlanSuspicious(p Plan, subs []SubIssue) bool {
+	closed := make(map[string]bool, len(subs))
 	nonDone := 0
 	for _, s := range subs {
-		if !s.Closed {
+		if s.Closed {
+			closed[NormalizeIssueRef(s.Ref)] = true
+		} else {
 			nonDone++
 		}
 	}
@@ -129,8 +137,14 @@ func flatPlanSuspicious(p Plan, subs []SubIssue) bool {
 		return false
 	}
 	for i := range p.Children {
-		if len(p.Children[i].DependsOn) > 0 {
-			return false
+		c := &p.Children[i]
+		if closed[NormalizeIssueRef(c.Ref)] {
+			continue
+		}
+		for _, d := range c.DependsOn {
+			if !closed[NormalizeIssueRef(d)] {
+				return false
+			}
 		}
 	}
 	return true

--- a/internal/umbrella/planner.go
+++ b/internal/umbrella/planner.go
@@ -48,10 +48,18 @@ type Plan struct {
 // Injected so the planner logic is unit-testable without spawning a CLI.
 type Runner func(ctx context.Context, prompt string) (string, error)
 
+// criticSuffix is appended to the prompt for the single re-ask Generate issues
+// when the first valid plan looks suspiciously flat (see flatPlanSuspicious).
+const criticSuffix = "You produced a fully-parallel plan — re-examine `touches`/`requires` for overlaps you missed. " +
+	"Sub-issues that edit the same files or need each other's symbols must reflect that in their metadata."
+
 // Generate runs the planner end to end: build the prompt, invoke the model,
 // then resolve and validate the result against the sub-issues. A malformed or
 // invalid plan is retried (the model is stochastic); a runner error is fatal.
-// All child and dependency refs in the returned plan are canonical.
+// All child and dependency refs in the returned plan are canonical. If the
+// first valid plan is suspiciously flat, Generate re-asks the model once with
+// a critic nudge; any failure of that re-ask (parse, validate, or run error)
+// falls back to the original plan rather than failing the whole expansion.
 func Generate(ctx context.Context, run Runner, umbrellaRef, umbrellaBody string, subs []SubIssue) (Plan, error) {
 	if len(subs) == 0 {
 		return Plan{}, fmt.Errorf("umbrella %s has no sub-issues to expand", umbrellaRef)
@@ -59,6 +67,25 @@ func Generate(ctx context.Context, run Runner, umbrellaRef, umbrellaBody string,
 	idx := buildRefIndex(subs)
 	prompt := BuildPrompt(umbrellaRef, umbrellaBody, subs)
 
+	plan, err := attemptPlan(ctx, run, idx, prompt, subs)
+	if err != nil {
+		return Plan{}, err
+	}
+	if flatPlanSuspicious(plan, subs) {
+		reasked, err := attemptPlan(ctx, run, idx, prompt+"\n\n"+criticSuffix, subs)
+		if err == nil {
+			return reasked, nil
+		}
+	}
+	return plan, nil
+}
+
+// attemptPlan runs up to plannerAttempts model invocations with the given
+// prompt, returning the first plan that parses, resolves, and validates
+// against subs, with MaxParallel defaulted. A runner error is fatal and
+// returned immediately; a parse or validate failure retries with the same
+// prompt.
+func attemptPlan(ctx context.Context, run Runner, idx refIndex, prompt string, subs []SubIssue) (Plan, error) {
 	var lastErr error
 	for range plannerAttempts {
 		raw, err := run(ctx, prompt)
@@ -85,6 +112,28 @@ func Generate(ctx context.Context, run Runner, umbrellaRef, umbrellaBody string,
 		return plan, nil
 	}
 	return Plan{}, fmt.Errorf("planner produced no valid plan in %d attempts: %w", plannerAttempts, lastErr)
+}
+
+// flatPlanSuspicious reports whether a validated plan looks like it skipped
+// dependency derivation: 3 or more non-done sub-issues but zero total derived
+// edges across all children. Below that threshold small plans are legitimately
+// edge-free and are not flagged.
+func flatPlanSuspicious(p Plan, subs []SubIssue) bool {
+	nonDone := 0
+	for _, s := range subs {
+		if !s.Closed {
+			nonDone++
+		}
+	}
+	if nonDone < 3 {
+		return false
+	}
+	for i := range p.Children {
+		if len(p.Children[i].DependsOn) > 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // BuildPrompt renders the planner instruction. The model is asked to emit ONLY

--- a/internal/umbrella/planner_test.go
+++ b/internal/umbrella/planner_test.go
@@ -420,6 +420,163 @@ func TestGenerate(t *testing.T) {
 			t.Error("expected derived cycle to be rejected")
 		}
 	})
+
+	flat := `{"children":[{"issue":"o/r#1"},{"issue":"o/r#2"},{"issue":"o/r#3"}],"maxParallel":2}`
+	edged := `{"children":[{"issue":"o/r#1"},{"issue":"o/r#2","dependsOn":["o/r#1"]},{"issue":"o/r#3"}],"maxParallel":2}`
+
+	t.Run("re-ask fires and returns edged plan", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		run := func(_ context.Context, prompt string) (string, error) {
+			calls++
+			if strings.Contains(prompt, criticSuffix) {
+				return edged, nil
+			}
+			return flat, nil
+		}
+		plan, err := Generate(context.Background(), run, "o/r#100", "body", subs("o/r#1", "o/r#2", "o/r#3"))
+		if err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		if calls != 2 {
+			t.Fatalf("expected exactly one re-ask (2 total calls), got %d", calls)
+		}
+		var child2 PlannedChild
+		for _, c := range plan.Children {
+			if c.Ref == "o/r#2" {
+				child2 = c
+			}
+		}
+		if len(child2.DependsOn) != 1 || child2.DependsOn[0] != "o/r#1" {
+			t.Fatalf("expected edged re-ask plan to be returned: %+v", plan)
+		}
+	})
+
+	t.Run("re-ask still flat is accepted", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		run := func(_ context.Context, _ string) (string, error) {
+			calls++
+			return flat, nil
+		}
+		plan, err := Generate(context.Background(), run, "o/r#100", "body", subs("o/r#1", "o/r#2", "o/r#3"))
+		if err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		if calls != 2 {
+			t.Fatalf("expected exactly one re-ask (2 total calls), got %d", calls)
+		}
+		for _, c := range plan.Children {
+			if len(c.DependsOn) != 0 {
+				t.Fatalf("expected still-flat plan to be accepted as-is: %+v", plan)
+			}
+		}
+	})
+
+	t.Run("re-ask parse error falls back to original plan", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		run := func(_ context.Context, prompt string) (string, error) {
+			calls++
+			if strings.Contains(prompt, criticSuffix) {
+				return "not json", nil
+			}
+			return flat, nil
+		}
+		plan, err := Generate(context.Background(), run, "o/r#100", "body", subs("o/r#1", "o/r#2", "o/r#3"))
+		if err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		if calls != 1+plannerAttempts {
+			t.Fatalf("expected 1 initial call + %d re-ask attempts, got %d", plannerAttempts, calls)
+		}
+		if len(plan.Children) != 3 {
+			t.Fatalf("expected fallback to original flat plan: %+v", plan)
+		}
+	})
+
+	t.Run("re-ask context deadline falls back to original plan", func(t *testing.T) {
+		t.Parallel()
+		run := func(_ context.Context, prompt string) (string, error) {
+			if strings.Contains(prompt, criticSuffix) {
+				return "", context.DeadlineExceeded
+			}
+			return flat, nil
+		}
+		plan, err := Generate(context.Background(), run, "o/r#100", "body", subs("o/r#1", "o/r#2", "o/r#3"))
+		if err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		if len(plan.Children) != 3 {
+			t.Fatalf("expected fallback to original flat plan: %+v", plan)
+		}
+	})
+
+	t.Run("no re-ask when fewer than three non-done children", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		run := func(_ context.Context, _ string) (string, error) {
+			calls++
+			return good, nil
+		}
+		if _, err := Generate(context.Background(), run, "o/r#100", "body", subs("o/r#1", "o/r#2")); err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		if calls != 1 {
+			t.Fatalf("expected no re-ask below the 3-child floor, got %d calls", calls)
+		}
+	})
+}
+
+func TestFlatPlanSuspicious(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		plan Plan
+		subs []SubIssue
+		want bool
+	}{
+		{
+			name: "below threshold not suspicious",
+			plan: Plan{Children: []PlannedChild{{Ref: "o/r#1"}, {Ref: "o/r#2"}}},
+			subs: subs("o/r#1", "o/r#2"),
+			want: false,
+		},
+		{
+			name: "flat with three non-done children is suspicious",
+			plan: Plan{Children: []PlannedChild{{Ref: "o/r#1"}, {Ref: "o/r#2"}, {Ref: "o/r#3"}}},
+			subs: subs("o/r#1", "o/r#2", "o/r#3"),
+			want: true,
+		},
+		{
+			name: "any derived edge is not suspicious",
+			plan: Plan{Children: []PlannedChild{
+				{Ref: "o/r#1"},
+				{Ref: "o/r#2", DependsOn: []string{"o/r#1"}},
+				{Ref: "o/r#3"},
+			}},
+			subs: subs("o/r#1", "o/r#2", "o/r#3"),
+			want: false,
+		},
+		{
+			name: "closed subs do not count toward the threshold",
+			plan: Plan{Children: []PlannedChild{{Ref: "o/r#1"}, {Ref: "o/r#2"}, {Ref: "o/r#3"}}},
+			subs: []SubIssue{
+				{Ref: "o/r#1", Closed: true},
+				{Ref: "o/r#2"},
+				{Ref: "o/r#3"},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := flatPlanSuspicious(tt.plan, tt.subs); got != tt.want {
+				t.Errorf("flatPlanSuspicious() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestFallbackPlannerRunnerPassesConfiguredClaudeModel(t *testing.T) {

--- a/internal/umbrella/planner_test.go
+++ b/internal/umbrella/planner_test.go
@@ -568,6 +568,38 @@ func TestFlatPlanSuspicious(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "edge only on a closed child is still suspicious",
+			plan: Plan{Children: []PlannedChild{
+				{Ref: "o/r#1", DependsOn: []string{"o/r#2"}}, // closed child, dropped by ChildSpecs
+				{Ref: "o/r#2"},
+				{Ref: "o/r#3"},
+				{Ref: "o/r#4"},
+			}},
+			subs: []SubIssue{
+				{Ref: "o/r#1", Closed: true},
+				{Ref: "o/r#2"},
+				{Ref: "o/r#3"},
+				{Ref: "o/r#4"},
+			},
+			want: true,
+		},
+		{
+			name: "edge pointing only at a closed sub-issue is still suspicious",
+			plan: Plan{Children: []PlannedChild{
+				{Ref: "o/r#1"},
+				{Ref: "o/r#2", DependsOn: []string{"o/r#1"}}, // dep already satisfied, dropped by ChildSpecs
+				{Ref: "o/r#3"},
+				{Ref: "o/r#4"},
+			}},
+			subs: []SubIssue{
+				{Ref: "o/r#1", Closed: true},
+				{Ref: "o/r#2"},
+				{Ref: "o/r#3"},
+				{Ref: "o/r#4"},
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Motivation

Metadata-derived DAG edges (#1343) can come back fully flat when the planner model skips deriving `touches`/`requires` overlaps on larger umbrellas, silently producing an all-parallel plan even when sub-issues clearly conflict.

## Implementation information

- `flatPlanSuspicious` flags a validated plan as suspect when there are 3+ non-done sub-issues but zero derived `DependsOn` edges across all children; smaller plans are allowed to be legitimately edge-free.
- `Generate` now re-asks the model once with a critic nudge (`criticSuffix`) when a plan is flagged, falling back to the original plan if the re-ask fails to parse/validate/run.
- Extracted `attemptPlan` to house the retry loop so both the initial pass and the critic re-ask share it.
- `PlannerTimeout` now bounds the whole `Generate` call (all retries plus the critic re-ask), not just a single invocation.

Closes https://github.com/Automaat/sybra/issues/1325