### PR TITLE
fix(workflow): auto-retry transient test failures

### DIFF
--- a/internal/workflow/builtin/testing-task.yaml
+++ b/internal/workflow/builtin/testing-task.yaml
@@ -41,7 +41,10 @@ steps:
         {"type":"object","properties":{"verdict":{"type":"string","enum":["PASS","FAIL"]},"outcome":{"type":"string","enum":["pass","product_bug","infra_failure","ambiguous_requirement","missing_evidence"]},"failures_markdown":{"type":"string"},"surface_kind":{"type":"string","enum":["web","cli","server","desktop","k8s","library","docs","none"]},"app_started":{"type":"boolean"},"start_command":{"type":"string"},"readiness_probe":{"type":"object","properties":{"command":{"type":"string"},"expected":{"type":"string"},"actual":{"type":"string"},"observed":{"type":"string"},"output":{"type":"string"},"status":{"type":"string"},"url":{"type":"string"}},"required":["command","expected","actual","observed","output","status","url"],"additionalProperties":false},"manual_probes":{"type":"array","items":{"type":"object","properties":{"command":{"type":"string"},"expected":{"type":"string"},"actual":{"type":"string"},"observed":{"type":"string"},"output":{"type":"string"},"status":{"type":"string"}},"required":["command","expected","actual","observed","output","status"],"additionalProperties":false}},"automated_checks":{"type":"array","items":{"type":"object","properties":{"command":{"type":"string"},"actual":{"type":"string"},"observed":{"type":"string"},"output":{"type":"string"},"status":{"type":"string"}},"required":["command","actual","observed","output","status"],"additionalProperties":false}},"unable_to_run_reason":{"type":"string"}},"required":["verdict","outcome","failures_markdown","surface_kind","app_started","start_command","readiness_probe","manual_probes","automated_checks","unable_to_run_reason"],"additionalProperties":false}
       prompt: >-
         Adversarially test task {{.Task.ID}} using the /sybra-test skill.
-
+        {{if getvar .Vars "testing_reask_note"}}
+        RETRY GUIDANCE — your previous test report was rejected:
+        {{getvar .Vars "testing_reask_note"}}
+        {{end}}
         Your goal is to PROVE the implementation does NOT satisfy the task —
         exercise the happy path AND edge cases, boundary inputs, and failure
         modes. Test ONLY behaviour the task description states or directly

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const (
@@ -48,6 +49,100 @@ const (
 	testProtocolFixSuggestions  = "fix-suggestions"
 	testProtocolMissingEvidence = "missing-evidence"
 )
+
+const (
+	// testingAutoRetryCap bounds how many times route_test re-runs the tester
+	// for transient (infra) or agent-behaviour (missing-evidence) outcomes
+	// before handing the task to a human. These outcomes describe the *runner*,
+	// not the implementation, so a bounded auto-retry recovers most of them
+	// without a human — a batch of tasks fanning into testing at once no longer
+	// piles up in human-required on one-off runner flakiness.
+	testingAutoRetryCap = 2
+	// testingAutoRetryBackoff spaces re-dispatches so a persistently broken
+	// sandbox or provider is not hammered in a tight loop; ResumeStalled honours
+	// it via workflowRetryAfterVar.
+	testingAutoRetryBackoff = 3 * time.Minute
+	// testingReaskNoteVar carries a targeted instruction into the re-run tester
+	// prompt (see testing-task.yaml). Set on a missing-evidence retry so the
+	// runner is told exactly which machine-checkable evidence its prior report
+	// lacked, rather than being re-run blind.
+	testingReaskNoteVar = "testing_reask_note"
+
+	missingEvidenceReask = "Your previous FAIL report was rejected because it lacked machine-checkable " +
+		"evidence. For EVERY claimed defect you MUST include: the exact command you ran, its verbatim " +
+		"output, the expected behaviour citing the task's own words, and a code line quoted from the " +
+		"CURRENT file (file:line). Re-run the probes and produce that evidence — or, if the feature " +
+		"actually works, emit PASS with the required manual-testing evidence."
+)
+
+func testingAutoRetryKey(outcome string) string {
+	return "step." + testVerdictSourceStep + ".auto_retry." + outcome
+}
+
+// parkTestingRetryOrEscalate re-arms the run_test step for another adversarial
+// run when a transient/agent-behaviour outcome still has retry budget, spacing
+// the re-dispatch with a backoff that ResumeStalled honours. It returns
+// parked=true after scheduling a retry — the caller MUST return errStepParked so
+// executeSteps parks without advancing — and parked=false when the cap is
+// exhausted and the caller should escalate to human-required. The retry counter
+// is keyed by outcome and persists on the workflow across the rewind.
+func (e *Engine) parkTestingRetryOrEscalate(taskID, outcome, reaskNote string, wfExec *Execution, t TaskInfo) (parked bool, err error) {
+	key := testingAutoRetryKey(outcome)
+	attempts := parseWorkflowInt(wfExec.Variables[key])
+	if attempts >= testingAutoRetryCap {
+		return false, nil
+	}
+	wfExec.SetVar(key, strconv.Itoa(attempts+1))
+	wfExec.SetVar(workflowRetryAfterVar, time.Now().UTC().Add(testingAutoRetryBackoff).Format(time.RFC3339))
+	if reaskNote != "" {
+		wfExec.SetVar(testingReaskNoteVar, reaskNote)
+	}
+	// Clear the prior run's verdict/outcome/taint so the re-armed run is judged
+	// on its own output, not the stale report that triggered this retry.
+	clearTestVerdictVars(wfExec)
+	// Rewind to the tester step; ResumeStalled re-dispatches it once idle and
+	// past the backoff (run_test is a run_agent step).
+	wfExec.CurrentStep = testVerdictSourceStep
+	wfExec.State = ExecWaiting
+	if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
+		return false, err
+	}
+	reason := fmt.Sprintf("auto-retrying adversarial testing (%s, attempt %d/%d)", outcome, attempts+1, testingAutoRetryCap)
+	if err := e.tasks.UpdateTaskStatus(taskID, t.Status, reason); err != nil {
+		return false, err
+	}
+	e.logger.Info("workflow.test.auto-retry",
+		"task_id", taskID, "outcome", outcome, "attempt", attempts+1, "cap", testingAutoRetryCap)
+	return true, nil
+}
+
+// retryOrEscalateTransient auto-retries a transient/agent-behaviour test outcome
+// while retry budget remains (returning errStepParked so executeSteps parks),
+// otherwise escalates the task to human-required with humanReason and returns a
+// completed step output carrying doneOutput. logMsg names the escalation event.
+func (e *Engine) retryOrEscalateTransient(taskID, stepID, outcome, reask, humanReason, doneOutput, logMsg string, wfExec *Execution, t TaskInfo) (StepOutput, error) {
+	parked, err := e.parkTestingRetryOrEscalate(taskID, outcome, reask, wfExec, t)
+	if err != nil {
+		return StepOutput{}, err
+	}
+	if parked {
+		return StepOutput{}, errStepParked
+	}
+	if err := e.tasks.UpdateTaskStatus(taskID, "human-required", humanReason); err != nil {
+		return StepOutput{}, err
+	}
+	e.logger.Warn(logMsg, "task_id", taskID)
+	return StepOutput{StepID: stepID, Status: "completed", Output: doneOutput}, nil
+}
+
+func clearTestVerdictVars(wfExec *Execution) {
+	if wfExec == nil || wfExec.Variables == nil {
+		return
+	}
+	for _, suffix := range []string{".verdict", "." + testVerdictOutcomeKey, "." + testVerdictTaintedKey, "." + testFailureFingerprintKey} {
+		delete(wfExec.Variables, "step."+testVerdictSourceStep+suffix)
+	}
+}
 
 type structuredTestOutput struct {
 	Verdict           string                     `json:"verdict"`
@@ -1547,6 +1642,10 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 	// Read the untruncated verdict/outcome vars (set in engine_advance from the
 	// full agent output and current body delta). Missing or infrastructure-shaped
 	// outcomes fail closed, but do not burn implementation attempts.
+	// The reask note (if any) was consumed by the just-completed run_test prompt;
+	// drop it so it never bleeds into a later, unrelated testing cycle.
+	delete(wfExec.Variables, testingReaskNoteVar)
+
 	if wfExec.Variables["step."+testVerdictSourceStep+".verdict"] == "PASS" {
 		if err := e.tasks.UpdateTaskStatus(taskID, "ready-pr", "manual testing passed"); err != nil {
 			return StepOutput{}, err
@@ -1556,10 +1655,16 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 	}
 
 	if violation := wfExec.Variables["step."+testVerdictSourceStep+"."+testVerdictTaintedKey]; violation != "" {
-		reason := "test-runner report violated testing protocol after retry: contained fix suggestions instead of observed symptoms"
+		// A missing-evidence report describes the runner, not the code — re-ask
+		// the tester (with the specific evidence it owes) before a human. A
+		// fix-suggestions violation already had one in-step retry and rarely
+		// improves on re-ask, so it still escalates immediately.
 		if violation == testProtocolMissingEvidence {
-			reason = "test-runner report violated testing protocol after retry: missing machine-checkable evidence"
+			return e.retryOrEscalateTransient(taskID, step.ID, testOutcomeMissingEvidence, missingEvidenceReask,
+				"test-runner report lacked machine-checkable evidence after auto-retries — needs local reproduction",
+				"protocol violation: "+violation, "workflow.test.protocol-violation", wfExec, t)
 		}
+		reason := "test-runner report violated testing protocol after retry: contained fix suggestions instead of observed symptoms"
 		if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
 			return StepOutput{}, err
 		}
@@ -1569,19 +1674,13 @@ func (e *Engine) execRouteTestResult(taskID string, step *Step, wfExec *Executio
 	outcome := wfExec.Variables["step."+testVerdictSourceStep+"."+testVerdictOutcomeKey]
 	switch outcome {
 	case testOutcomeInfraFailure:
-		reason := "testing infrastructure failed after retry — no implementation attempt consumed; rerun testing or inspect the test-runner log"
-		if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
-			return StepOutput{}, err
-		}
-		e.logger.Warn("workflow.test.infra-failure", "task_id", taskID)
-		return StepOutput{StepID: step.ID, Status: "completed", Output: "infra failure"}, nil
+		return e.retryOrEscalateTransient(taskID, step.ID, testOutcomeInfraFailure, "",
+			"testing infrastructure failed after auto-retries — no implementation attempt consumed; rerun testing or inspect the test-runner log",
+			"infra failure", "workflow.test.infra-failure", wfExec, t)
 	case testOutcomeMissingEvidence:
-		reason := "test-runner failed without grounded evidence after retry — needs local reproduction before implementation retries"
-		if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {
-			return StepOutput{}, err
-		}
-		e.logger.Warn("workflow.test.missing-evidence", "task_id", taskID)
-		return StepOutput{StepID: step.ID, Status: "completed", Output: "missing evidence"}, nil
+		return e.retryOrEscalateTransient(taskID, step.ID, testOutcomeMissingEvidence, missingEvidenceReask,
+			"test-runner failed without grounded evidence after auto-retries — needs local reproduction before implementation retries",
+			"missing evidence", "workflow.test.missing-evidence", wfExec, t)
 	case testOutcomeAmbiguousRequirement:
 		reason := "testing found ambiguous or contradictory requirements — human decision needed; see latest ## Test Failures"
 		if err := e.tasks.UpdateTaskStatus(taskID, "human-required", reason); err != nil {

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -1223,7 +1223,14 @@ func hasGroundedFailureEvidence(report string) bool {
 			"actual output", "actual", "observed output", "observed",
 			"command output", "stdout", "stderr", "output",
 			"verbatim output", "actual behavior", "actual behaviour",
-			"observed behavior", "observed behaviour", "printed", "rendered")
+			"observed behavior", "observed behaviour", "printed", "rendered",
+			// Natural-language observed-evidence headers. hasLabeledSection only
+			// matches a keyword at the START of the line, so a report that writes
+			// "**What actually happened:**" (keyword mid-phrase) would otherwise be
+			// misclassified missing_evidence despite a fully grounded FAIL. Same
+			// class of false rejection #1344/#1345 closed for other markers.
+			"what actually happened", "what happened", "what i observed",
+			"what i saw", "what the code shows", "what the code does")
 	hasExpected := containsAny(lower,
 		"task says", "task requires", "from the task", "violates",
 		"should render", "should not") ||

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -100,6 +100,11 @@ func (e *Engine) parkTestingRetryOrEscalate(taskID, outcome, reaskNote string, w
 	// Clear the prior run's verdict/outcome/taint so the re-armed run is judged
 	// on its own output, not the stale report that triggered this retry.
 	clearTestVerdictVars(wfExec)
+	// Also clear run_test's step-history records: CountStep(run_test) counts
+	// every historical execution, not just the current retry cycle, so without
+	// this a route-level re-arm would leave the tester's own in-step
+	// max_retries budget looking exhausted from earlier cycles.
+	wfExec.ClearStepRecords(testVerdictSourceStep)
 	// Rewind to the tester step; ResumeStalled re-dispatches it once idle and
 	// past the backoff (run_test is a run_agent step).
 	wfExec.CurrentStep = testVerdictSourceStep

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -2,6 +2,8 @@ package workflow
 
 import (
 	"encoding/json"
+	"errors"
+	"maps"
 	"strconv"
 	"strings"
 	"testing"
@@ -1511,6 +1513,9 @@ func TestAdvanceStep_FailedRunnerWithPassMarkerRoutesAsInfraFailure(t *testing.T
 		}},
 	}
 	prepareTestVerdictAttemptVars(wf, testVerdictSourceStep, initialBody)
+	// Exhaust the auto-retry budget so an infra failure escalates instead of
+	// re-arming the tester (the re-arm path is covered separately).
+	wf.SetVar(testingAutoRetryKey(testOutcomeInfraFailure), strconv.Itoa(testingAutoRetryCap))
 	tasks.Put(TaskInfo{
 		ID:        "t-failed-pass",
 		Status:    "testing",
@@ -1573,6 +1578,9 @@ func TestAdvanceStep_CompletedRunnerWithEmptyStdoutRoutesAsInfraFailure(t *testi
 		}},
 	}
 	prepareTestVerdictAttemptVars(wf, testVerdictSourceStep, initialBody)
+	// Exhaust the auto-retry budget so an infra failure escalates instead of
+	// re-arming the tester (the re-arm path is covered separately).
+	wf.SetVar(testingAutoRetryKey(testOutcomeInfraFailure), strconv.Itoa(testingAutoRetryCap))
 	tasks.Put(TaskInfo{
 		ID:        "t-empty-stdout",
 		Status:    "testing",
@@ -1736,6 +1744,9 @@ func TestRouteTestResult_InfraFailureDoesNotCountTowardCap(t *testing.T) {
 		StartedAt:  now,
 		Variables: map[string]string{
 			"step." + testVerdictSourceStep + "." + testVerdictOutcomeKey: testOutcomeInfraFailure,
+			// Exhaust the auto-retry budget so this asserts the terminal
+			// escalation path, not a re-arm.
+			testingAutoRetryKey(testOutcomeInfraFailure): strconv.Itoa(testingAutoRetryCap),
 		},
 	}
 	out, err := e.execRouteTestResult("t-infra", &Step{ID: "route_test"}, wf, mustGetTaskInfo(t, tasks, "t-infra"))
@@ -1751,6 +1762,112 @@ func TestRouteTestResult_InfraFailureDoesNotCountTowardCap(t *testing.T) {
 	}
 	if reason := tasks.Reason("t-infra"); !strings.Contains(reason, "no implementation attempt consumed") {
 		t.Errorf("reason = %q, want no implementation attempt consumed", reason)
+	}
+}
+
+// routeWithOutcome drives execRouteTestResult with a pre-seeded outcome var and
+// arbitrary extra workflow vars (e.g. a primed auto-retry counter), returning
+// the step output, error, and the persisted post-call task state.
+func routeWithOutcome(t *testing.T, e *Engine, tasks *memTasks, taskID, outcome string, vars map[string]string) (StepOutput, TaskInfo, error) {
+	t.Helper()
+	tasks.Put(TaskInfo{ID: taskID, Status: "testing"})
+	wf := &Execution{
+		WorkflowID:  "testing-task",
+		CurrentStep: "route_test",
+		State:       ExecRunning,
+		StartedAt:   time.Now().UTC(),
+		Variables:   map[string]string{"step." + testVerdictSourceStep + "." + testVerdictOutcomeKey: outcome},
+	}
+	maps.Copy(wf.Variables, vars)
+	out, err := e.execRouteTestResult(taskID, &Step{ID: "route_test"}, wf, mustGetTaskInfo(t, tasks, taskID))
+	return out, mustGetTaskInfo(t, tasks, taskID), err
+}
+
+func TestRouteTestResult_InfraFailureParksForAutoRetry(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	out, ti, err := routeWithOutcome(t, e, tasks, "t-infra-retry", testOutcomeInfraFailure, nil)
+	if !errors.Is(err, errStepParked) {
+		t.Fatalf("err = %v, want errStepParked", err)
+	}
+	_ = out
+	if ti.Status != "testing" {
+		t.Errorf("status = %q, want testing (parked, not escalated)", ti.Status)
+	}
+	if ti.Workflow.CurrentStep != testVerdictSourceStep || ti.Workflow.State != ExecWaiting {
+		t.Errorf("workflow = %+v, want re-armed at run_test/ExecWaiting", ti.Workflow)
+	}
+	if got := ti.Workflow.Variables[testingAutoRetryKey(testOutcomeInfraFailure)]; got != "1" {
+		t.Errorf("auto-retry counter = %q, want 1", got)
+	}
+	if ti.Workflow.Variables[workflowRetryAfterVar] == "" {
+		t.Errorf("retry_after not set — ResumeStalled would re-dispatch immediately")
+	}
+	// Infra failures carry no re-ask note.
+	if ti.Workflow.Variables[testingReaskNoteVar] != "" {
+		t.Errorf("unexpected reask note for infra failure: %q", ti.Workflow.Variables[testingReaskNoteVar])
+	}
+}
+
+func TestRouteTestResult_InfraFailureEscalatesAtCap(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	vars := map[string]string{testingAutoRetryKey(testOutcomeInfraFailure): strconv.Itoa(testingAutoRetryCap)}
+	out, ti, err := routeWithOutcome(t, e, tasks, "t-infra-cap", testOutcomeInfraFailure, vars)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Output != "infra failure" {
+		t.Errorf("output = %q, want infra failure", out.Output)
+	}
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+	if reason := tasks.Reason("t-infra-cap"); !strings.Contains(reason, "auto-retries") {
+		t.Errorf("reason = %q, want auto-retries mention", reason)
+	}
+}
+
+func TestRouteTestResult_MissingEvidenceParksWithReaskThenEscalates(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	taintVar := "step." + testVerdictSourceStep + "." + testVerdictTaintedKey
+
+	// First pass: tainted missing-evidence → park with a targeted re-ask note.
+	out, ti, err := routeWithOutcome(t, e, tasks, "t-evidence", testOutcomeMissingEvidence,
+		map[string]string{taintVar: testProtocolMissingEvidence})
+	if !errors.Is(err, errStepParked) {
+		t.Fatalf("err = %v, want errStepParked", err)
+	}
+	_ = out
+	if ti.Status != "testing" {
+		t.Errorf("status = %q, want testing (parked)", ti.Status)
+	}
+	if note := ti.Workflow.Variables[testingReaskNoteVar]; !strings.Contains(note, "machine-checkable") {
+		t.Errorf("reask note = %q, want machine-checkable guidance", note)
+	}
+	if got := ti.Workflow.Variables[testingAutoRetryKey(testOutcomeMissingEvidence)]; got != "1" {
+		t.Errorf("auto-retry counter = %q, want 1", got)
+	}
+	// The taint var must be cleared so the re-armed run is judged fresh.
+	if ti.Workflow.Variables[taintVar] != "" {
+		t.Errorf("taint var = %q, want cleared", ti.Workflow.Variables[taintVar])
+	}
+
+	// At cap: escalate to human-required.
+	vars := map[string]string{
+		taintVar: testProtocolMissingEvidence,
+		testingAutoRetryKey(testOutcomeMissingEvidence): strconv.Itoa(testingAutoRetryCap),
+	}
+	_, ti, err = routeWithOutcome(t, e, tasks, "t-evidence-cap", testOutcomeMissingEvidence, vars)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ti.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", ti.Status)
+	}
+	if reason := tasks.Reason("t-evidence-cap"); !strings.Contains(reason, "machine-checkable") {
+		t.Errorf("reason = %q, want machine-checkable mention", reason)
 	}
 }
 

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -245,6 +245,25 @@ func TestHasGroundedFailureEvidence_AcceptsAnnotatedLabels(t *testing.T) {
 	}
 }
 
+func TestHasGroundedFailureEvidence_AcceptsNaturalObservedHeader(t *testing.T) {
+	t.Parallel()
+
+	// Reproduces task e000da0e: a fully grounded FAIL report whose observed
+	// section used the natural header "What actually happened:" (keyword
+	// mid-phrase). hasLabeledSection only matched observed keywords at the start
+	// of the line, so the report was misclassified missing_evidence and escalated
+	// to human-required despite reproducible evidence and a file:line citation.
+	report := "## Test Failures\n\n" +
+		"**Command run:** `curl -fsS http://127.0.0.1:8080/rpc`\n\n" +
+		"**What actually happened:**\n\n```text\npanic: runtime error: invalid memory address\n```\n\n" +
+		"**Expected (task's own words):** the per-provider cap degrades to a no-op with a warning.\n\n" +
+		"**Code evidence:** internal/limits/store.go:157 returns a typed-nil interface.\n"
+
+	if !hasGroundedFailureEvidence(report) {
+		t.Fatal("natural observed-header FAIL report rejected as ungrounded; want grounded")
+	}
+}
+
 func TestHasGroundedFailureEvidence_RejectsUngroundedReport(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -1828,6 +1828,42 @@ func TestRouteTestResult_InfraFailureParksForAutoRetry(t *testing.T) {
 	}
 }
 
+// TestRouteTestResult_AutoRetryClearsRunTestStepHistory guards against
+// CountStep(run_test) — which counts every historical execution, not just the
+// current retry cycle — silently exhausting run_test's own in-step
+// max_retries budget (configured as 1 in testing-task.yaml) across
+// route-level auto-retry cycles. Without clearing run_test's StepHistory
+// records on rewind, a run_test failure after a prior route-level auto-retry
+// would see CountStep(run_test) > 1 and skip its in-step retry entirely.
+func TestRouteTestResult_AutoRetryClearsRunTestStepHistory(t *testing.T) {
+	t.Parallel()
+	e, tasks := makeTestEngine(t)
+	tasks.Put(TaskInfo{ID: "t-history", Status: "testing"})
+	wf := &Execution{
+		WorkflowID:  "testing-task",
+		CurrentStep: "route_test",
+		State:       ExecRunning,
+		StartedAt:   time.Now().UTC(),
+		Variables:   map[string]string{"step." + testVerdictSourceStep + "." + testVerdictOutcomeKey: testOutcomeInfraFailure},
+		StepHistory: []StepRecord{
+			{StepID: testVerdictSourceStep, Status: "failed"},
+			{StepID: "some_other_step", Status: "completed"},
+		},
+	}
+	out, err := e.execRouteTestResult("t-history", &Step{ID: "route_test"}, wf, mustGetTaskInfo(t, tasks, "t-history"))
+	if !errors.Is(err, errStepParked) {
+		t.Fatalf("err = %v, want errStepParked", err)
+	}
+	_ = out
+	ti := mustGetTaskInfo(t, tasks, "t-history")
+	if n := ti.Workflow.CountStep(testVerdictSourceStep); n != 0 {
+		t.Errorf("CountStep(run_test) = %d, want 0 after re-arm", n)
+	}
+	if n := ti.Workflow.CountStep("some_other_step"); n != 1 {
+		t.Errorf("CountStep(some_other_step) = %d, want 1 (untouched)", n)
+	}
+}
+
 func TestRouteTestResult_InfraFailureEscalatesAtCap(t *testing.T) {
 	t.Parallel()
 	e, tasks := makeTestEngine(t)

--- a/internal/workflow/execution.go
+++ b/internal/workflow/execution.go
@@ -122,6 +122,23 @@ func (e *Execution) CountStep(stepID string) int {
 	return n
 }
 
+// ClearStepRecords removes all history records for a given step ID, resetting
+// CountStep(stepID) to 0. Used when a step is deliberately re-armed for a
+// fresh attempt cycle (e.g. route-level auto-retry) so its own in-step
+// max_retries budget is not seen as already exhausted by prior cycles.
+func (e *Execution) ClearStepRecords(stepID string) {
+	if len(e.StepHistory) == 0 {
+		return
+	}
+	kept := e.StepHistory[:0]
+	for i := range e.StepHistory {
+		if e.StepHistory[i].StepID != stepID {
+			kept = append(kept, e.StepHistory[i])
+		}
+	}
+	e.StepHistory = kept
+}
+
 // RecordForStep returns the latest record for a given step ID, or nil.
 func (e *Execution) RecordForStep(stepID string) *StepRecord {
 	for i := range slices.Backward(e.StepHistory) {

--- a/internal/workflow/execution_test.go
+++ b/internal/workflow/execution_test.go
@@ -127,6 +127,36 @@ func TestCountStep_CountsMatchingEntries(t *testing.T) {
 	}
 }
 
+func TestClearStepRecords_ResetsCountForStep(t *testing.T) {
+	e := &Execution{}
+	e.RecordStep(StepRecord{StepID: "run_test", Status: "failed"})
+	e.RecordStep(StepRecord{StepID: "run_test", Status: "failed"})
+	e.RecordStep(StepRecord{StepID: "implement", Status: "completed"})
+
+	e.ClearStepRecords("run_test")
+
+	if got := e.CountStep("run_test"); got != 0 {
+		t.Errorf("expected 0 run_test records after clear, got %d", got)
+	}
+	if got := e.CountStep("implement"); got != 1 {
+		t.Errorf("expected unrelated step records to survive, got %d", got)
+	}
+
+	// Re-arming should let a fresh in-step retry budget accrue again.
+	e.RecordStep(StepRecord{StepID: "run_test", Status: "failed"})
+	if got := e.CountStep("run_test"); got != 1 {
+		t.Errorf("expected 1 run_test record after re-arm, got %d", got)
+	}
+}
+
+func TestClearStepRecords_NoOpOnEmptyHistory(t *testing.T) {
+	e := &Execution{}
+	e.ClearStepRecords("run_test")
+	if got := e.CountStep("run_test"); got != 0 {
+		t.Errorf("expected 0, got %d", got)
+	}
+}
+
 func TestRecordForStep_ReturnsLatestMatch(t *testing.T) {
 	e := &Execution{}
 	e.RecordStep(StepRecord{StepID: "triage", Status: "failed", StartedAt: time.Now()})


### PR DESCRIPTION
## Motivation

`route_test` escalated to human-required on the first `infra_failure` or `missing_evidence` outcome after `run_test`'s single retry, so a batch of tasks fanning into testing at once piled up in human-required on one-off runner flakiness rather than the implementation being wrong.

## Implementation information

- Add a bounded route-level auto-retry (cap 2, 3m backoff) that re-arms `run_test` via `errStepParked`/`ResumeStalled`.
- Attach a targeted re-ask note to the retried prompt for missing-evidence outcomes, telling the tester exactly what evidence its prior report lacked.
- Escalate to human-required only after the retry budget is spent.