### PR TITLE
feat(umbrella): serial-by-default planner edges

### DIFF
--- a/internal/umbrella/planner.go
+++ b/internal/umbrella/planner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -36,6 +37,11 @@ type PlannedChild struct {
 	Touches   []string `json:"touches,omitempty"`
 	Produces  []string `json:"produces,omitempty"`
 	Requires  []string `json:"requires,omitempty"`
+	// ParallelJustification maps a sibling ref to why it is safe to run in
+	// parallel with this child (disjoint change surfaces). Its presence on
+	// either side of a pair exempts that pair from deriveEdges's serial-default
+	// layer; the text itself is advisory only (never validated or enforced).
+	ParallelJustification map[string]string `json:"parallelJustification,omitempty"`
 }
 
 // Plan is the dependency DAG the planner extracts from an umbrella body.
@@ -168,15 +174,20 @@ func BuildPrompt(umbrellaRef, umbrellaBody string, subs []SubIssue) string {
 		}
 		b.WriteString(line + "\n")
 	}
-	b.WriteString("\nFor each sub-issue, report its change surface, not a dependency graph — dependency\n")
+	b.WriteString("\nSub-issues of one umbrella in this codebase almost always share code. Assume a\n")
+	b.WriteString("dependency exists between any two sub-issues by default — serial execution is the\n")
+	b.WriteString("safe, zero-cost default. Running a pair in parallel is the expensive claim: it is\n")
+	b.WriteString("only allowed when you back it with a parallelJustification (see below).\n\n")
+	b.WriteString("For each sub-issue, report its change surface, not a dependency graph — dependency\n")
 	b.WriteString("edges are derived automatically from this metadata:\n")
 	b.WriteString("  - touches: EVERY file, directory, or package this sub-issue will actually edit")
 	b.WriteString(" (e.g. \"internal/foo\", \"internal/bar/x.go\"). List all of them, including paths")
 	b.WriteString(" shared with other sub-issues — sub-issues whose touches overlap on the SAME files")
 	b.WriteString(" or code area get serialized automatically so they merge one at a time instead of")
-	b.WriteString(" colliding. Omitting a shared path to avoid ordering just causes silent merge")
-	b.WriteString(" conflicts later. Keep paths as narrow as the real edit (a single package or file),")
-	b.WriteString(" not a broad directory that creates false overlap with unrelated siblings.\n")
+	b.WriteString(" colliding, regardless of any parallelJustification. Omitting a shared path to avoid")
+	b.WriteString(" ordering just causes silent merge conflicts later. Keep paths as narrow as the real")
+	b.WriteString(" edit (a single package or file), not a broad directory that creates false overlap")
+	b.WriteString(" with unrelated siblings.\n")
 	b.WriteString("  - produces: symbols, APIs, schemas, or flags it creates or changes (e.g. \"Foo.Run\",")
 	b.WriteString(" \"Tier type\").\n")
 	b.WriteString("  - requires: symbols, APIs, schemas, or flags it needs another sub-issue to have")
@@ -184,12 +195,17 @@ func BuildPrompt(umbrellaRef, umbrellaBody string, subs []SubIssue) string {
 	b.WriteString(" automatically depend on it.\n")
 	b.WriteString("  - dependsOn (optional): explicit hard-ordering edges the metadata above can't")
 	b.WriteString(" express, e.g. markers like \"← #N\" or \"⛔ blocks all\" in the umbrella body. Kept in")
-	b.WriteString(" addition to the derived edges, not instead of them.\n\n")
+	b.WriteString(" addition to the derived edges, not instead of them.\n")
+	b.WriteString("  - parallelJustification (optional): to run this sub-issue in parallel with another,")
+	b.WriteString(" add an entry keyed by that sub-issue's ref explaining concretely why their change")
+	b.WriteString(" surfaces are disjoint. Without an entry for a pair, that pair defaults to serial")
+	b.WriteString(" (the later sub-issue depends on the earlier one). An overlapping touches always")
+	b.WriteString(" re-serializes the pair even with a justification present.\n\n")
 	b.WriteString("Output ONLY a JSON object, no prose, no code fence:\n")
-	b.WriteString(`{"children":[{"issue":"<ref>","touches":["<path>"],"produces":["<symbol>"],"requires":["<symbol>"],"dependsOn":["<ref>"],"track":"<label>"}],"maxParallel":<int>}` + "\n")
-	b.WriteString("Rules: include EVERY sub-issue exactly once (including done ones); dependsOn must")
-	b.WriteString(" reference only the sub-issues above; never create a cycle; maxParallel is the max")
-	b.WriteString(" children to run at once (default 5).\n")
+	b.WriteString(`{"children":[{"issue":"<ref>","touches":["<path>"],"produces":["<symbol>"],"requires":["<symbol>"],"dependsOn":["<ref>"],"parallelJustification":{"<ref>":"<why disjoint>"},"track":"<label>"}],"maxParallel":<int>}` + "\n")
+	b.WriteString("Rules: include EVERY sub-issue exactly once (including done ones); dependsOn and")
+	b.WriteString(" parallelJustification keys must reference only the sub-issues above; never create a")
+	b.WriteString(" cycle; maxParallel is the max children to run at once (default 5).\n")
 	return b.String()
 }
 
@@ -274,19 +290,51 @@ func (p *Plan) resolve(idx refIndex) error {
 		}
 		c.DependsOn = deps
 	}
+	// Canonicalize parallelJustification keys in a second pass (after every
+	// child's Ref is already canonical above). Unlike DependsOn, an unresolved
+	// or self-referencing key is dropped silently instead of erroring: a
+	// justification only relaxes the serial-default safety net in
+	// deriveEdges, it never introduces an ordering constraint, so a malformed
+	// key should fail closed to serial rather than abort an otherwise-valid
+	// plan. Do not "fix" this into matching DependsOn's loud failure — the two
+	// fields have opposite risk profiles by design.
+	for i := range p.Children {
+		c := &p.Children[i]
+		if len(c.ParallelJustification) == 0 {
+			continue
+		}
+		canon := make(map[string]string, len(c.ParallelJustification))
+		for k, v := range c.ParallelJustification {
+			ck, ok := idx.lookup(k)
+			if !ok || ck == c.Ref {
+				continue
+			}
+			canon[ck] = v
+		}
+		c.ParallelJustification = canon
+		if len(c.ParallelJustification) == 0 {
+			c.ParallelJustification = nil
+		}
+	}
 	return nil
 }
 
-// deriveEdges rewrites each child's DependsOn to union in edges derived from
-// change-surface metadata, on top of whatever explicit edges the model already
-// emitted: a child requiring a symbol depends on every child that produces it,
-// and a child touching a file/package another (earlier-ordered) child also
-// touches depends on that earlier child. subs establishes the canonical
-// ordering used both to pick the "earlier" side of a touch overlap and to make
-// edge derivation deterministic regardless of plan.Children's slice order.
-// resolve must run first so every ref here is canonical. Legacy input with no
-// touches/produces/requires derives no new edges, but DependsOn is still
-// rewritten: it is de-duped and self/empty entries are dropped.
+// deriveEdges rewrites each child's DependsOn in two passes. Pass 1 unions in
+// edges derived from change-surface metadata, on top of whatever explicit
+// edges the model already emitted: a child requiring a symbol depends on
+// every child that produces it, and a child touching a file/package another
+// (earlier-ordered) child also touches depends on that earlier child. Pass 2
+// applies a serial-default layer on top of pass 1's fully-merged result: every
+// child depends on every earlier canonical sibling unless that pair carries a
+// ParallelJustification on either side, or the sibling already depends on it
+// (direct 2-cycle guard) — so a plan with no metadata at all is serialized
+// end to end rather than treated as all-parallel. subs establishes the
+// canonical ordering used to pick the "earlier" side of both the touch
+// overlap and the serial-default layer, and to make edge derivation
+// deterministic regardless of plan.Children's slice order. resolve must run
+// first so every ref (including ParallelJustification keys) here is
+// canonical. DependsOn is always rewritten: it is de-duped and self/empty
+// entries are dropped even for legacy input with no touches/produces/requires.
 func (p *Plan) deriveEdges(subs []SubIssue) {
 	order := make(map[string]int, len(subs))
 	for i, s := range subs {
@@ -348,6 +396,42 @@ func (p *Plan) deriveEdges(subs []SubIssue) {
 			}
 		}
 		c.DependsOn = merged
+	}
+
+	// Pass 2: the serial-default layer. Every child depends on every earlier
+	// canonical sibling unless the pair is justified parallel or that would
+	// create a direct 2-cycle. This is a DISTINCT second loop, not grafted
+	// into pass 1 above: the 2-cycle guard must read each sibling's DependsOn
+	// only after pass 1 has fully merged it, otherwise which pairs get
+	// serialized would depend on iteration order instead of being
+	// deterministic.
+	byRef := make(map[string]*PlannedChild, len(p.Children))
+	for i := range p.Children {
+		byRef[p.Children[i].Ref] = &p.Children[i]
+	}
+	dependsOn := func(c *PlannedChild, ref string) bool {
+		return slices.Contains(c.DependsOn, ref)
+	}
+	justifiedParallel := func(a, b *PlannedChild) bool {
+		return a.ParallelJustification[b.Ref] != "" || b.ParallelJustification[a.Ref] != ""
+	}
+	for _, ref := range refs {
+		c := byRef[ref]
+		for _, otherRef := range refs {
+			if order[otherRef] >= order[ref] {
+				continue
+			}
+			other := byRef[otherRef]
+			if justifiedParallel(c, other) {
+				continue
+			}
+			if dependsOn(other, ref) {
+				continue // direct 2-cycle guard: other already depends on c
+			}
+			if !dependsOn(c, otherRef) {
+				c.DependsOn = append(c.DependsOn, otherRef)
+			}
+		}
 	}
 }
 

--- a/internal/umbrella/planner.go
+++ b/internal/umbrella/planner.go
@@ -398,13 +398,16 @@ func (p *Plan) deriveEdges(subs []SubIssue) {
 		c.DependsOn = merged
 	}
 
-	// Pass 2: the serial-default layer. Every child depends on every earlier
-	// canonical sibling unless the pair is justified parallel or that would
-	// create a direct 2-cycle. This is a DISTINCT second loop, not grafted
-	// into pass 1 above: the 2-cycle guard must read each sibling's DependsOn
-	// only after pass 1 has fully merged it, otherwise which pairs get
-	// serialized would depend on iteration order instead of being
-	// deterministic.
+	p.applySerialDefault(refs, order)
+}
+
+// applySerialDefault is pass 2 of deriveEdges: every child depends on every
+// earlier canonical sibling unless the pair is justified parallel or that
+// would create a cycle. This is a DISTINCT second pass, not grafted into
+// pass 1: the cycle guard must read each sibling's DependsOn only after
+// pass 1 has fully merged it, otherwise which pairs get serialized would
+// depend on iteration order instead of being deterministic.
+func (p *Plan) applySerialDefault(refs []string, order map[string]int) {
 	byRef := make(map[string]*PlannedChild, len(p.Children))
 	for i := range p.Children {
 		byRef[p.Children[i].Ref] = &p.Children[i]
@@ -425,14 +428,39 @@ func (p *Plan) deriveEdges(subs []SubIssue) {
 			if justifiedParallel(c, other) {
 				continue
 			}
-			if dependsOn(other, ref) {
-				continue // direct 2-cycle guard: other already depends on c
+			if reachable(byRef, otherRef, ref, map[string]bool{}) {
+				continue // other already transitively depends on ref; adding the reverse edge would close a cycle
 			}
 			if !dependsOn(c, otherRef) {
 				c.DependsOn = append(c.DependsOn, otherRef)
 			}
 		}
 	}
+}
+
+// reachable reports whether fromRef transitively depends on target by
+// walking the (partially built) DependsOn graph. Used instead of a direct
+// membership check so a serial-default edge is never added if it would close
+// a longer cycle through edges pass 1 (or an earlier pass-2 iteration)
+// already created.
+func reachable(byRef map[string]*PlannedChild, fromRef, target string, visiting map[string]bool) bool {
+	if fromRef == target {
+		return true
+	}
+	if visiting[fromRef] {
+		return false
+	}
+	visiting[fromRef] = true
+	from := byRef[fromRef]
+	if from == nil {
+		return false
+	}
+	for _, dep := range from.DependsOn {
+		if reachable(byRef, dep, target, visiting) {
+			return true
+		}
+	}
+	return false
 }
 
 // normalizeSymbol canonicalizes a produces/requires entry for comparison.

--- a/internal/umbrella/planner.go
+++ b/internal/umbrella/planner.go
@@ -38,9 +38,11 @@ type PlannedChild struct {
 	Produces  []string `json:"produces,omitempty"`
 	Requires  []string `json:"requires,omitempty"`
 	// ParallelJustification maps a sibling ref to why it is safe to run in
-	// parallel with this child (disjoint change surfaces). Its presence on
-	// either side of a pair exempts that pair from deriveEdges's serial-default
-	// layer; the text itself is advisory only (never validated or enforced).
+	// parallel with this child (disjoint change surfaces). A non-empty entry
+	// on either side of a pair exempts that pair from deriveEdges's
+	// serial-default layer; resolve trims and drops blank values so a
+	// whitespace-only entry cannot count. The text itself is advisory only
+	// beyond that presence check (never further validated or enforced).
 	ParallelJustification map[string]string `json:"parallelJustification,omitempty"`
 }
 
@@ -199,7 +201,7 @@ func BuildPrompt(umbrellaRef, umbrellaBody string, subs []SubIssue) string {
 	b.WriteString("  - parallelJustification (optional): to run this sub-issue in parallel with another,")
 	b.WriteString(" add an entry keyed by that sub-issue's ref explaining concretely why their change")
 	b.WriteString(" surfaces are disjoint. Without an entry for a pair, that pair defaults to serial")
-	b.WriteString(" (the later sub-issue depends on the earlier one). An overlapping touches always")
+	b.WriteString(" (the later sub-issue depends on the earlier one). Overlapping touches always")
 	b.WriteString(" re-serializes the pair even with a justification present.\n\n")
 	b.WriteString("Output ONLY a JSON object, no prose, no code fence:\n")
 	b.WriteString(`{"children":[{"issue":"<ref>","touches":["<path>"],"produces":["<symbol>"],"requires":["<symbol>"],"dependsOn":["<ref>"],"parallelJustification":{"<ref>":"<why disjoint>"},"track":"<label>"}],"maxParallel":<int>}` + "\n")
@@ -297,7 +299,10 @@ func (p *Plan) resolve(idx refIndex) error {
 	// deriveEdges, it never introduces an ordering constraint, so a malformed
 	// key should fail closed to serial rather than abort an otherwise-valid
 	// plan. Do not "fix" this into matching DependsOn's loud failure — the two
-	// fields have opposite risk profiles by design.
+	// fields have opposite risk profiles by design. Values are trimmed and
+	// dropped when blank so a whitespace-only justification can't exempt a
+	// pair from the safety net, and so two raw keys canonicalizing to the same
+	// ref don't produce a nondeterministic blank/non-blank result.
 	for i := range p.Children {
 		c := &p.Children[i]
 		if len(c.ParallelJustification) == 0 {
@@ -307,6 +312,10 @@ func (p *Plan) resolve(idx refIndex) error {
 		for k, v := range c.ParallelJustification {
 			ck, ok := idx.lookup(k)
 			if !ok || ck == c.Ref {
+				continue
+			}
+			v = strings.TrimSpace(v)
+			if v == "" {
 				continue
 			}
 			canon[ck] = v
@@ -326,8 +335,9 @@ func (p *Plan) resolve(idx refIndex) error {
 // (earlier-ordered) child also touches depends on that earlier child. Pass 2
 // applies a serial-default layer on top of pass 1's fully-merged result: every
 // child depends on every earlier canonical sibling unless that pair carries a
-// ParallelJustification on either side, or the sibling already depends on it
-// (direct 2-cycle guard) — so a plan with no metadata at all is serialized
+// ParallelJustification on either side, or the sibling already transitively
+// depends on it (reachability guard, not a direct 2-cycle check) — so a plan
+// with no metadata at all is serialized
 // end to end rather than treated as all-parallel. subs establishes the
 // canonical ordering used to pick the "earlier" side of both the touch
 // overlap and the serial-default layer, and to make edge derivation

--- a/internal/umbrella/planner.go
+++ b/internal/umbrella/planner.go
@@ -420,11 +420,17 @@ func (p *Plan) applySerialDefault(refs []string, order map[string]int) {
 	}
 	for _, ref := range refs {
 		c := byRef[ref]
+		if c == nil {
+			continue
+		}
 		for _, otherRef := range refs {
 			if order[otherRef] >= order[ref] {
 				continue
 			}
 			other := byRef[otherRef]
+			if other == nil {
+				continue
+			}
 			if justifiedParallel(c, other) {
 				continue
 			}

--- a/internal/umbrella/planner_test.go
+++ b/internal/umbrella/planner_test.go
@@ -26,6 +26,8 @@ func TestBuildPrompt_SerializesSameFileSubIssues(t *testing.T) {
 	for _, want := range []string{
 		"SAME files", "merge one at a time", "false overlap",
 		"touches", "produces", "requires", "derived automatically",
+		"almost always share code", "dependency exists between any two",
+		"safe, zero-cost default", "parallelJustification",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Errorf("prompt missing metadata guidance %q:\n%s", want, prompt)
@@ -124,6 +126,49 @@ func TestPlanResolve(t *testing.T) {
 			t.Error("expected error for unresolved dependency (must not be silently dropped)")
 		}
 	})
+
+	t.Run("unknown parallelJustification key is dropped, not an error", func(t *testing.T) {
+		t.Parallel()
+		// Unlike DependsOn, a hallucinated justification key must fail closed
+		// (drop, keep the pair serial) rather than abort the whole plan.
+		p := Plan{Children: []PlannedChild{
+			{Ref: "o/r#1"},
+			{Ref: "o/r#2", ParallelJustification: map[string]string{"o/r#404": "disjoint"}},
+		}}
+		if err := p.resolve(idx); err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if len(p.Children[1].ParallelJustification) != 0 {
+			t.Errorf("ParallelJustification = %v, want dropped", p.Children[1].ParallelJustification)
+		}
+	})
+
+	t.Run("self-key parallelJustification is dropped", func(t *testing.T) {
+		t.Parallel()
+		p := Plan{Children: []PlannedChild{
+			{Ref: "o/r#1", ParallelJustification: map[string]string{"o/r#1": "self, nonsensical"}},
+		}}
+		if err := p.resolve(idx); err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if len(p.Children[0].ParallelJustification) != 0 {
+			t.Errorf("ParallelJustification = %v, want self-key dropped", p.Children[0].ParallelJustification)
+		}
+	})
+
+	t.Run("shorthand parallelJustification key is canonicalized", func(t *testing.T) {
+		t.Parallel()
+		p := Plan{Children: []PlannedChild{
+			{Ref: "o/r#1"},
+			{Ref: "o/r#2", ParallelJustification: map[string]string{"#1": "disjoint dirs"}},
+		}}
+		if err := p.resolve(idx); err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if got := p.Children[1].ParallelJustification["o/r#1"]; got != "disjoint dirs" {
+			t.Errorf("ParallelJustification = %v, want canonical key o/r#1", p.Children[1].ParallelJustification)
+		}
+	})
 }
 
 func TestPlanValidate(t *testing.T) {
@@ -220,7 +265,9 @@ func TestDeriveEdges(t *testing.T) {
 				{Ref: "o/r#2", Produces: []string{"Sym"}},
 				{Ref: "o/r#3", Requires: []string{"Sym"}},
 			},
-			want: map[string][]string{"o/r#1": nil, "o/r#2": nil, "o/r#3": {"o/r#1", "o/r#2"}},
+			// o/r#2 used to have no deps; the serial-default layer now adds its
+			// only earlier canonical sibling (#1), since no justification exists.
+			want: map[string][]string{"o/r#1": nil, "o/r#2": {"o/r#1"}, "o/r#3": {"o/r#1", "o/r#2"}},
 		},
 		{
 			name: "touch overlap including ancestor directory",
@@ -232,13 +279,24 @@ func TestDeriveEdges(t *testing.T) {
 			want: map[string][]string{"o/r#1": nil, "o/r#2": {"o/r#1"}},
 		},
 		{
-			name: "sibling directories do not overlap by string prefix",
+			name: "sibling directories do not overlap and are mutually justified parallel",
+			subs: subs("o/r#1", "o/r#2"),
+			children: []PlannedChild{
+				{Ref: "o/r#1", Touches: []string{"internal/foo"}, ParallelJustification: map[string]string{"o/r#2": "disjoint packages"}},
+				{Ref: "o/r#2", Touches: []string{"internal/foobar"}, ParallelJustification: map[string]string{"o/r#1": "disjoint packages"}},
+			},
+			// Proves both pathsOverlap (no touch-derived edge) and the
+			// justification exemption (no serial-default edge either).
+			want: map[string][]string{"o/r#1": nil, "o/r#2": nil},
+		},
+		{
+			name: "serial-default fires with no justification even when directories look disjoint",
 			subs: subs("o/r#1", "o/r#2"),
 			children: []PlannedChild{
 				{Ref: "o/r#1", Touches: []string{"internal/foo"}},
 				{Ref: "o/r#2", Touches: []string{"internal/foobar"}},
 			},
-			want: map[string][]string{"o/r#1": nil, "o/r#2": nil},
+			want: map[string][]string{"o/r#1": nil, "o/r#2": {"o/r#1"}},
 		},
 		{
 			name: "explicit dependsOn is unioned with derived edges",
@@ -248,7 +306,8 @@ func TestDeriveEdges(t *testing.T) {
 				{Ref: "o/r#2"},
 				{Ref: "o/r#3", Requires: []string{"Sym"}, DependsOn: []string{"o/r#2"}},
 			},
-			want: map[string][]string{"o/r#1": nil, "o/r#2": nil, "o/r#3": {"o/r#2", "o/r#1"}},
+			// o/r#2 used to have no deps; serial-default now adds #1.
+			want: map[string][]string{"o/r#1": nil, "o/r#2": {"o/r#1"}, "o/r#3": {"o/r#2", "o/r#1"}},
 		},
 		{
 			name: "legacy dependsOn-only input is a no-op",
@@ -279,6 +338,57 @@ func TestDeriveEdges(t *testing.T) {
 			},
 			want: map[string][]string{"o/r#1": nil, "o/r#2": {"o/r#1"}},
 		},
+		{
+			name: "no metadata at all still serializes end to end",
+			subs: subs("o/r#1", "o/r#2"),
+			children: []PlannedChild{
+				{Ref: "o/r#1"},
+				{Ref: "o/r#2"},
+			},
+			want: map[string][]string{"o/r#1": nil, "o/r#2": {"o/r#1"}},
+		},
+		{
+			name: "one-sided justification exempts the pair (OR semantics)",
+			subs: subs("o/r#1", "o/r#2"),
+			children: []PlannedChild{
+				{Ref: "o/r#1"},
+				{Ref: "o/r#2", ParallelJustification: map[string]string{"o/r#1": "disjoint surfaces"}},
+			},
+			want: map[string][]string{"o/r#1": nil, "o/r#2": nil},
+		},
+		{
+			name: "mutual (both-sided) justification also exempts the pair",
+			subs: subs("o/r#1", "o/r#2"),
+			children: []PlannedChild{
+				{Ref: "o/r#1", ParallelJustification: map[string]string{"o/r#2": "disjoint surfaces"}},
+				{Ref: "o/r#2", ParallelJustification: map[string]string{"o/r#1": "disjoint surfaces"}},
+			},
+			// Guards against an accidental OR->AND regression: both sides
+			// carrying a justification must not somehow re-add the edge.
+			want: map[string][]string{"o/r#1": nil, "o/r#2": nil},
+		},
+		{
+			name: "justified pair still re-serializes on overlapping touches",
+			subs: subs("o/r#1", "o/r#2"),
+			children: []PlannedChild{
+				{Ref: "o/r#1", Touches: []string{"internal/foo"}, ParallelJustification: map[string]string{"o/r#2": "thought disjoint"}},
+				{Ref: "o/r#2", Touches: []string{"internal/foo/x.go"}, ParallelJustification: map[string]string{"o/r#1": "thought disjoint"}},
+			},
+			want: map[string][]string{"o/r#1": nil, "o/r#2": {"o/r#1"}},
+		},
+		{
+			name: "producer listed after its consumer avoids a direct 2-cycle",
+			subs: subs("o/r#1", "o/r#2"),
+			children: []PlannedChild{
+				// o/r#1 is canonically earlier but requires a symbol only
+				// o/r#2 (canonically later) produces, forcing a forward
+				// requires edge #1 -> #2. Serial-default must not also add
+				// #2 -> #1, which would be a direct 2-cycle.
+				{Ref: "o/r#1", Requires: []string{"Sym"}},
+				{Ref: "o/r#2", Produces: []string{"Sym"}},
+			},
+			want: map[string][]string{"o/r#1": {"o/r#2"}, "o/r#2": nil},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -301,13 +411,14 @@ func TestDeriveEdges(t *testing.T) {
 
 	t.Run("determinism independent of plan.Children slice order", func(t *testing.T) {
 		t.Parallel()
-		s := subs("o/r#1", "o/r#2", "o/r#3")
+		s := subs("o/r#1", "o/r#2", "o/r#3", "o/r#4")
 		forward := []PlannedChild{
 			{Ref: "o/r#1", Produces: []string{"Sym"}, Touches: []string{"internal/foo"}},
 			{Ref: "o/r#2", Produces: []string{"Sym"}, Touches: []string{"internal/foo/x.go"}},
 			{Ref: "o/r#3", Requires: []string{"Sym"}},
+			{Ref: "o/r#4"}, // no metadata at all: purely a serial-default case
 		}
-		reversed := []PlannedChild{forward[2], forward[1], forward[0]}
+		reversed := []PlannedChild{forward[3], forward[2], forward[1], forward[0]}
 
 		p1 := Plan{Children: append([]PlannedChild(nil), forward...)}
 		p1.deriveEdges(s)
@@ -325,8 +436,42 @@ func TestDeriveEdges(t *testing.T) {
 				}
 			}
 		}
-		assertEqual(t, depsOf(p1, "o/r#3"), depsOf(p2, "o/r#3"), "non-deterministic")
+		assertEqual(t, depsOf(p1, "o/r#1"), depsOf(p2, "o/r#1"), "non-deterministic")
 		assertEqual(t, depsOf(p1, "o/r#2"), depsOf(p2, "o/r#2"), "non-deterministic touch overlap")
+		assertEqual(t, depsOf(p1, "o/r#3"), depsOf(p2, "o/r#3"), "non-deterministic")
+		assertEqual(t, depsOf(p1, "o/r#4"), depsOf(p2, "o/r#4"), "non-deterministic serial-default")
+		// o/r#4 carries no metadata at all: the serial-default layer must still
+		// serialize it after every earlier canonical sibling, regardless of
+		// where the model happened to place it in plan.Children.
+		if got := depsOf(p1, "o/r#4"); len(got) != 3 {
+			t.Fatalf("o/r#4 DependsOn = %v, want all 3 earlier canonical siblings", got)
+		}
+	})
+
+	t.Run("transitive requires-before-produces stays acyclic through serial-default", func(t *testing.T) {
+		t.Parallel()
+		// o/r#1 is canonically earlier but requires a symbol only the later
+		// o/r#2 produces (forward requires edge). o/r#3 carries no metadata.
+		// The serial-default layer adds edges from o/r#3 to both earlier
+		// siblings, and must not add o/r#2 -> o/r#1 (would be a direct
+		// 2-cycle against the forward requires edge). The resulting DAG must
+		// still validate as acyclic.
+		s := subs("o/r#1", "o/r#2", "o/r#3")
+		plan := Plan{Children: []PlannedChild{
+			{Ref: "o/r#1", Requires: []string{"Sym"}},
+			{Ref: "o/r#2", Produces: []string{"Sym"}},
+			{Ref: "o/r#3"},
+		}}
+		plan.deriveEdges(s)
+		if err := plan.validate(s); err != nil {
+			t.Fatalf("validate: %v (deps: %+v)", err, plan.Children)
+		}
+		if got := depsOf(plan, "o/r#1"); len(got) != 1 || got[0] != "o/r#2" {
+			t.Fatalf("o/r#1 DependsOn = %v, want [o/r#2]", got)
+		}
+		if got := depsOf(plan, "o/r#2"); len(got) != 0 {
+			t.Fatalf("o/r#2 DependsOn = %v, want none (2-cycle guard)", got)
+		}
 	})
 }
 

--- a/internal/umbrella/planner_test.go
+++ b/internal/umbrella/planner_test.go
@@ -587,7 +587,15 @@ func TestGenerate(t *testing.T) {
 		}
 	})
 
-	flat := `{"children":[{"issue":"o/r#1"},{"issue":"o/r#2"},{"issue":"o/r#3"}],"maxParallel":2}`
+	// Every pair must carry a parallelJustification: under the serial-default
+	// derivation, an unjustified 3-child plan is never flat (applySerialDefault
+	// fills it in), so a genuinely flat plan now requires the model to have
+	// justified every pair as disjoint.
+	flat := `{"children":[` +
+		`{"issue":"o/r#1","parallelJustification":{"o/r#2":"disjoint","o/r#3":"disjoint"}},` +
+		`{"issue":"o/r#2","parallelJustification":{"o/r#3":"disjoint"}},` +
+		`{"issue":"o/r#3"}` +
+		`],"maxParallel":2}`
 	edged := `{"children":[{"issue":"o/r#1"},{"issue":"o/r#2","dependsOn":["o/r#1"]},{"issue":"o/r#3"}],"maxParallel":2}`
 
 	t.Run("re-ask fires and returns edged plan", func(t *testing.T) {

--- a/internal/umbrella/planner_test.go
+++ b/internal/umbrella/planner_test.go
@@ -473,6 +473,27 @@ func TestDeriveEdges(t *testing.T) {
 			t.Fatalf("o/r#2 DependsOn = %v, want none (2-cycle guard)", got)
 		}
 	})
+
+	t.Run("indirect cycle through an intermediate sibling stays acyclic", func(t *testing.T) {
+		t.Parallel()
+		// o/r#1 is canonically first but requires a symbol only the
+		// canonically-last o/r#3 produces (forward requires edge #1 -> #3).
+		// o/r#2 sits between them with no metadata. A direct-only 2-cycle
+		// guard misses this: pass 2 adds #2 -> #1 (no direct edge #1 -> #2),
+		// then reaches #3 vs #2 and — checking only the direct edge — adds
+		// #3 -> #2, closing #1 -> #3 -> #2 -> #1. The guard must walk
+		// transitively so the reverse edge (#3 -> #2) is skipped instead.
+		s := subs("o/r#1", "o/r#2", "o/r#3")
+		plan := Plan{Children: []PlannedChild{
+			{Ref: "o/r#1", Requires: []string{"Sym"}},
+			{Ref: "o/r#2"},
+			{Ref: "o/r#3", Produces: []string{"Sym"}},
+		}}
+		plan.deriveEdges(s)
+		if err := plan.validate(s); err != nil {
+			t.Fatalf("validate: %v (deps: %+v)", err, plan.Children)
+		}
+	})
 }
 
 func TestGenerate(t *testing.T) {

--- a/internal/umbrella/planner_test.go
+++ b/internal/umbrella/planner_test.go
@@ -156,6 +156,20 @@ func TestPlanResolve(t *testing.T) {
 		}
 	})
 
+	t.Run("whitespace-only parallelJustification value is dropped", func(t *testing.T) {
+		t.Parallel()
+		p := Plan{Children: []PlannedChild{
+			{Ref: "o/r#1"},
+			{Ref: "o/r#2", ParallelJustification: map[string]string{"o/r#1": "   "}},
+		}}
+		if err := p.resolve(idx); err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if len(p.Children[1].ParallelJustification) != 0 {
+			t.Errorf("ParallelJustification = %v, want blank value dropped", p.Children[1].ParallelJustification)
+		}
+	})
+
 	t.Run("shorthand parallelJustification key is canonicalized", func(t *testing.T) {
 		t.Parallel()
 		p := Plan{Children: []PlannedChild{


### PR DESCRIPTION
## Motivation

Cheap models default to an all-parallel plan when the planner prompt only tells them to parallelize disjoint work, causing siblings that actually share code to run concurrently and collide. Flipping the default to serial makes the safe choice the cheap one: parallelism now has to be earned with an explicit justification instead of assumed.

## Implementation information

- `BuildPrompt` now tells the model to assume a dependency between any two sub-issues by default, and introduces an optional `parallelJustification` field (keyed by sibling ref) the model can set to explain why a pair's change surfaces are disjoint enough to run in parallel.
- `deriveEdges` gains a second pass (`applySerialDefault`) that serializes every pair of siblings unless one side supplies a `parallelJustification` for the other, using a transitive-reachability check (`reachable`) instead of a direct 2-cycle guard so a serial-default edge is never added if it would close a longer cycle already built by pass 1 or an earlier pass-2 iteration.
- Overlapping `touches` always re-serialize a pair regardless of any justification present.
- `resolve` canonicalizes `parallelJustification` keys in a second pass after `Ref` canonicalization, dropping unresolved/self-referencing keys silently (fail closed to serial) rather than erroring like `DependsOn` does — the two fields have opposite risk profiles.

Closes https://github.com/Automaat/sybra/issues/1324