### PR TITLE
feat(eval): add offline prompt eval runner

### DIFF
--- a/cmd/sybra-cli/evaluation.go
+++ b/cmd/sybra-cli/evaluation.go
@@ -161,6 +161,7 @@ func runOfflineVariant(ctx context.Context, runner prompteval.OfflineRunner, v p
 	var totalScore, totalCost float64
 	var totalLatency int64
 	var assertions []prompteval.AssertionResult
+	failedCase := ""
 	for _, c := range cases {
 		spec := prompteval.Spec{
 			CaseID:     c.CaseID,
@@ -178,15 +179,26 @@ func runOfflineVariant(ctx context.Context, runner prompteval.OfflineRunner, v p
 		totalCost += res.CostUSD
 		totalLatency += res.LatencyMS
 		assertions = append(assertions, res.Assertions...)
+		if !res.Passed && failedCase == "" {
+			failedCase = c.CaseID
+		}
 	}
 
 	base.Score = totalScore / float64(len(cases))
 	base.CostUSD = totalCost
 	base.LatencyMS = totalLatency
 	base.Assertions = assertions
-	if base.Score >= minScore {
+	switch {
+	case failedCase != "":
+		// The runner's own pass/fail signal (e.g. promptfoo's
+		// success/gradingResult.pass) is authoritative over Score — a runner
+		// can report a high average score while still failing a hard
+		// assertion on one case, and that must never aggregate to PASS.
+		base.Status = prompteval.StatusFail
+		base.Reason = fmt.Sprintf("case %s: runner reported failure", failedCase)
+	case base.Score >= minScore:
 		base.Status = prompteval.StatusPass
-	} else {
+	default:
 		base.Status = prompteval.StatusFail
 		base.Reason = fmt.Sprintf("score %.2f below min %.2f", base.Score, minScore)
 	}

--- a/cmd/sybra-cli/evaluation.go
+++ b/cmd/sybra-cli/evaluation.go
@@ -96,6 +96,8 @@ func cmdEvaluationOfflineRun(cfg *config.Config, args []string, jsonOut bool) in
 	runner := newOfflineRunner(cfg.Evaluation.Offline)
 	store := prompteval.New(config.PromptEvalDir())
 
+	unavailablePolicyPass := strings.EqualFold(strings.TrimSpace(cfg.Evaluation.Offline.UnavailablePolicy), "pass")
+
 	ctx := context.Background()
 	verdicts := make([]prompteval.VariantVerdict, 0, len(variants))
 	anyFail := false
@@ -106,6 +108,9 @@ func cmdEvaluationOfflineRun(cfg *config.Config, args []string, jsonOut bool) in
 		}
 		verdicts = append(verdicts, verdict)
 		if verdict.Status == prompteval.StatusFail {
+			anyFail = true
+		}
+		if verdict.Status == prompteval.StatusUnavailable && !unavailablePolicyPass {
 			anyFail = true
 		}
 	}

--- a/cmd/sybra-cli/evaluation.go
+++ b/cmd/sybra-cli/evaluation.go
@@ -85,6 +85,9 @@ func cmdEvaluationOfflineRun(cfg *config.Config, args []string, jsonOut bool) in
 	if len(variants) == 0 {
 		return fatal(jsonOut, "--variants must contain at least one candidate variant")
 	}
+	if err := requireSameProviderModel(variants); err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
 	cases, err := loadOfflineGoldenCases(*goldenPath)
 	if err != nil {
 		return fatal(jsonOut, "load golden cases: %v", err)
@@ -140,6 +143,23 @@ func cmdEvaluationOfflineRun(cfg *config.Config, args []string, jsonOut bool) in
 		return 1
 	}
 	return 0
+}
+
+// requireSameProviderModel enforces the offline runner's "run variants
+// against the same model/provider settings" requirement: a batch is meant to
+// screen prompt/skill variants against each other, and mixing
+// provider/model settings within one run would make the comparison
+// meaningless (or silently confound a prompt regression with a
+// model/provider swap).
+func requireSameProviderModel(variants []prompteval.CandidateVariant) error {
+	provider, model := variants[0].Provider, variants[0].Model
+	for _, v := range variants[1:] {
+		if v.Provider != provider || v.Model != model {
+			return fmt.Errorf("--variants must share the same provider/model: %s uses %s:%s, %s uses %s:%s",
+				variants[0].ID, provider, model, v.ID, v.Provider, v.Model)
+		}
+	}
+	return nil
 }
 
 // runOfflineVariant runs every golden case for one variant and aggregates

--- a/cmd/sybra-cli/evaluation.go
+++ b/cmd/sybra-cli/evaluation.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -11,13 +12,14 @@ import (
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/evaluation"
 	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/prompteval"
 	"github.com/Automaat/sybra/internal/stats"
 	"github.com/Automaat/sybra/internal/task"
 )
 
 func cmdEvaluation(cfg *config.Config, store *task.Manager, args []string, jsonOut bool) int {
 	if len(args) == 0 {
-		return fatal(jsonOut, "usage: evaluation <scan|judge|golden> [args] [--json]")
+		return fatal(jsonOut, "usage: evaluation <scan|judge|golden|offline> [args] [--json]")
 	}
 	switch args[0] {
 	case "scan":
@@ -26,9 +28,214 @@ func cmdEvaluation(cfg *config.Config, store *task.Manager, args []string, jsonO
 		return cmdEvaluationJudge(store, args[1:], jsonOut)
 	case "golden":
 		return cmdEvaluationGolden(args[1:], jsonOut)
+	case "offline":
+		return cmdEvaluationOffline(cfg, args[1:], jsonOut)
 	default:
 		return fatal(jsonOut, "unknown evaluation subcommand: %s", args[0])
 	}
+}
+
+// newOfflineRunner is overridable in tests so they can inject a fake runner
+// instead of shelling out to a live provider CLI.
+var newOfflineRunner = prompteval.SelectRunner
+
+// offlineGoldenCase is the on-disk shape of one entry in --golden: a case
+// input plus the assertions a variant's output must satisfy.
+type offlineGoldenCase struct {
+	CaseID     string                 `json:"caseId"`
+	Input      string                 `json:"input"`
+	Assertions []prompteval.Assertion `json:"assertions"`
+}
+
+func cmdEvaluationOffline(cfg *config.Config, args []string, jsonOut bool) int {
+	if len(args) == 0 {
+		return fatal(jsonOut, "usage: evaluation offline <run|gate> [args]")
+	}
+	switch args[0] {
+	case "run":
+		return cmdEvaluationOfflineRun(cfg, args[1:], jsonOut)
+	case "gate":
+		return cmdEvaluationOfflineGate(cfg, args[1:], jsonOut)
+	default:
+		return fatal(jsonOut, "unknown evaluation offline subcommand: %s", args[0])
+	}
+}
+
+// cmdEvaluationOfflineRun evaluates every candidate variant in --variants
+// against every golden case in --golden, writes a VariantVerdict per variant,
+// and exits non-zero if any variant scores FAIL (AC1: failed offline evals
+// must be visible to CI, not swallowed). An empty/missing --variants list is
+// a usage error, never a vacuous pass.
+func cmdEvaluationOfflineRun(cfg *config.Config, args []string, jsonOut bool) int {
+	fs := flag.NewFlagSet("offline run", flag.ContinueOnError)
+	variantsPath := fs.String("variants", "", "path to a JSON array of candidate variants (required)")
+	goldenPath := fs.String("golden", "", "path to a JSON array of golden cases (required)")
+	outPath := fs.String("out", "", "optional path to write the run summary JSON")
+	if err := fs.Parse(args); err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+	if *variantsPath == "" || *goldenPath == "" {
+		return fatal(jsonOut, "usage: evaluation offline run --variants <v.json> --golden <g.json> [--out <path>]")
+	}
+
+	variants, err := loadOfflineVariants(*variantsPath)
+	if err != nil {
+		return fatal(jsonOut, "load variants: %v", err)
+	}
+	if len(variants) == 0 {
+		return fatal(jsonOut, "--variants must contain at least one candidate variant")
+	}
+	cases, err := loadOfflineGoldenCases(*goldenPath)
+	if err != nil {
+		return fatal(jsonOut, "load golden cases: %v", err)
+	}
+	if len(cases) == 0 {
+		return fatal(jsonOut, "--golden must contain at least one golden case")
+	}
+
+	runner := newOfflineRunner(cfg.Evaluation.Offline)
+	store := prompteval.New(config.PromptEvalDir())
+
+	ctx := context.Background()
+	verdicts := make([]prompteval.VariantVerdict, 0, len(variants))
+	anyFail := false
+	for _, v := range variants {
+		verdict := runOfflineVariant(ctx, runner, v, cases, cfg.Evaluation.Offline.MinScore)
+		if err := store.Write(verdict); err != nil {
+			return fatal(jsonOut, "write verdict for %s: %v", v.ID, err)
+		}
+		verdicts = append(verdicts, verdict)
+		if verdict.Status == prompteval.StatusFail {
+			anyFail = true
+		}
+	}
+
+	if *outPath != "" {
+		data, mErr := json.MarshalIndent(verdicts, "", "  ")
+		if mErr != nil {
+			return fatal(jsonOut, "marshal summary: %v", mErr)
+		}
+		if wErr := os.WriteFile(*outPath, data, 0o644); wErr != nil {
+			return fatal(jsonOut, "write summary: %v", wErr)
+		}
+	}
+
+	if jsonOut {
+		printJSON(map[string]any{"verdicts": verdicts})
+	} else {
+		for i := range verdicts {
+			v := &verdicts[i]
+			fmt.Printf("%s %s: %s (score %.2f)\n", v.VariantID, v.Digest[:min(12, len(v.Digest))], v.Status, v.Score)
+			if v.Reason != "" {
+				fmt.Printf("  %s\n", v.Reason)
+			}
+		}
+	}
+	if anyFail {
+		return 1
+	}
+	return 0
+}
+
+// runOfflineVariant runs every golden case for one variant and aggregates
+// into a single VariantVerdict. A runner error on any case (could not
+// measure the run at all) marks the whole variant unavailable rather than a
+// silent pass; otherwise the verdict is pass/fail against cfg.MinScore.
+func runOfflineVariant(ctx context.Context, runner prompteval.OfflineRunner, v prompteval.CandidateVariant, cases []offlineGoldenCase, minScore float64) prompteval.VariantVerdict {
+	digest := prompteval.Digest([]byte(v.Prompt))
+	base := prompteval.VariantVerdict{
+		VariantID: v.ID,
+		Digest:    digest,
+		Runner:    runner.Name(),
+		CreatedAt: time.Now().UTC(),
+	}
+	if minScore <= 0 {
+		minScore = 1.0
+	}
+
+	var totalScore, totalCost float64
+	var totalLatency int64
+	var assertions []prompteval.AssertionResult
+	for _, c := range cases {
+		spec := prompteval.Spec{
+			CaseID:     c.CaseID,
+			Variant:    v,
+			Input:      c.Input,
+			Assertions: c.Assertions,
+		}
+		res, err := runner.Run(ctx, spec)
+		if err != nil {
+			base.Status = prompteval.StatusUnavailable
+			base.Reason = fmt.Sprintf("case %s: %v", c.CaseID, err)
+			return base
+		}
+		totalScore += res.Score
+		totalCost += res.CostUSD
+		totalLatency += res.LatencyMS
+		assertions = append(assertions, res.Assertions...)
+	}
+
+	base.Score = totalScore / float64(len(cases))
+	base.CostUSD = totalCost
+	base.LatencyMS = totalLatency
+	base.Assertions = assertions
+	if base.Score >= minScore {
+		base.Status = prompteval.StatusPass
+	} else {
+		base.Status = prompteval.StatusFail
+		base.Reason = fmt.Sprintf("score %.2f below min %.2f", base.Score, minScore)
+	}
+	return base
+}
+
+// cmdEvaluationOfflineGate reads the stored verdict for (variantID, digest)
+// and exits non-zero when AllowEnrollment blocks it (AC2 enforcement point).
+func cmdEvaluationOfflineGate(cfg *config.Config, args []string, jsonOut bool) int {
+	if len(args) != 2 {
+		return fatal(jsonOut, "usage: evaluation offline gate <variant-id> <digest>")
+	}
+	store := prompteval.New(config.PromptEvalDir())
+	gate := prompteval.NewGate(store, cfg.Evaluation.Offline)
+	allow, reason, err := gate.AllowEnrollment(args[0], args[1])
+	if err != nil {
+		return fatal(jsonOut, "gate: %v", err)
+	}
+	switch {
+	case jsonOut:
+		printJSON(map[string]any{"allow": allow, "reason": reason})
+	case allow:
+		fmt.Println("allow")
+	default:
+		fmt.Printf("deny: %s\n", reason)
+	}
+	if !allow {
+		return 1
+	}
+	return 0
+}
+
+func loadOfflineVariants(path string) ([]prompteval.CandidateVariant, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var variants []prompteval.CandidateVariant
+	if err := json.Unmarshal(data, &variants); err != nil {
+		return nil, fmt.Errorf("parse variants: %w", err)
+	}
+	return variants, nil
+}
+
+func loadOfflineGoldenCases(path string) ([]offlineGoldenCase, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cases []offlineGoldenCase
+	if err := json.Unmarshal(data, &cases); err != nil {
+		return nil, fmt.Errorf("parse golden cases: %w", err)
+	}
+	return cases, nil
 }
 
 // cmdEvaluationGolden scores a golden-set run's results against expectations and,

--- a/cmd/sybra-cli/evaluation_test.go
+++ b/cmd/sybra-cli/evaluation_test.go
@@ -174,6 +174,34 @@ func TestCmdEvaluationOfflineRunRejectsEmptyVariants(t *testing.T) {
 	}
 }
 
+// TestCmdEvaluationOfflineRunRejectsMixedProviderModel is the regression
+// case for the reported bug: the scope requires running variants "against
+// the same model/provider settings" so the batch is a fair comparison, but
+// the CLI accepted a batch mixing providers/models without complaint.
+func TestCmdEvaluationOfflineRunRejectsMixedProviderModel(t *testing.T) {
+	dir := setupStore(t)
+	old := newOfflineRunner
+	defer func() { newOfflineRunner = old }()
+	newOfflineRunner = func(config.OfflineEvalConfig) prompteval.OfflineRunner {
+		return fakeOfflineRunner{score: 1}
+	}
+
+	variantsPath := filepath.Join(dir, "variants.json")
+	goldenPath := filepath.Join(dir, "golden.json")
+	writeJSONFile(t, variantsPath, []prompteval.CandidateVariant{
+		{ID: "variant-a", Prompt: "PROMPT A", Provider: "openai", Model: "gpt-a"},
+		{ID: "variant-b", Prompt: "PROMPT B", Provider: "anthropic", Model: "claude-b"},
+	})
+	writeJSONFile(t, goldenPath, []offlineGoldenCase{
+		{CaseID: "c1", Input: "hi"},
+	})
+
+	code, output := runCLI(t, "evaluation", "offline", "run", "--variants", variantsPath, "--golden", goldenPath, "--json")
+	if code == 0 {
+		t.Fatalf("expected nonzero exit for a batch mixing provider/model settings, got 0. output: %s", output)
+	}
+}
+
 func TestCmdEvaluationOfflineGateDeniesMissingVerdict(t *testing.T) {
 	setupStore(t)
 	code, output := runCLI(t, "evaluation", "offline", "gate", "no-such-variant", "no-such-digest", "--json")

--- a/cmd/sybra-cli/evaluation_test.go
+++ b/cmd/sybra-cli/evaluation_test.go
@@ -91,6 +91,33 @@ func TestCmdEvaluationOfflineRunExitsZeroOnPass(t *testing.T) {
 	}
 }
 
+// TestCmdEvaluationOfflineRunExitsNonzeroOnUnavailable guards against a
+// broken eval setup (e.g. promptfoo binary missing) reading as green in CI:
+// under the default fail-closed UnavailablePolicy, a runner error must exit
+// nonzero even though no verdict is StatusFail.
+func TestCmdEvaluationOfflineRunExitsNonzeroOnUnavailable(t *testing.T) {
+	dir := setupStore(t)
+	old := newOfflineRunner
+	defer func() { newOfflineRunner = old }()
+	newOfflineRunner = func(config.OfflineEvalConfig) prompteval.OfflineRunner {
+		return fakeOfflineRunner{err: os.ErrNotExist}
+	}
+
+	variantsPath := filepath.Join(dir, "variants.json")
+	goldenPath := filepath.Join(dir, "golden.json")
+	writeJSONFile(t, variantsPath, []prompteval.CandidateVariant{
+		{ID: "unavailable-variant", Prompt: "some prompt", Provider: "claude", Model: "opus"},
+	})
+	writeJSONFile(t, goldenPath, []offlineGoldenCase{
+		{CaseID: "c1", Input: "hi", Assertions: []prompteval.Assertion{{Type: "contains", Value: "x"}}},
+	})
+
+	code, output := runCLI(t, "evaluation", "offline", "run", "--variants", variantsPath, "--golden", goldenPath, "--json")
+	if code == 0 {
+		t.Fatalf("expected nonzero exit for an UNAVAILABLE verdict under default fail-closed policy, got 0. output: %s", output)
+	}
+}
+
 func TestCmdEvaluationOfflineRunRejectsEmptyVariants(t *testing.T) {
 	dir := setupStore(t)
 	variantsPath := filepath.Join(dir, "variants.json")

--- a/cmd/sybra-cli/evaluation_test.go
+++ b/cmd/sybra-cli/evaluation_test.go
@@ -11,18 +11,24 @@ import (
 	"github.com/Automaat/sybra/internal/prompteval"
 )
 
-// fakeOfflineRunner lets the test control Score deterministically instead of
-// shelling out to a live provider CLI.
+// fakeOfflineRunner lets the test control Score and Passed deterministically
+// instead of shelling out to a live provider CLI. When forcePassed is nil,
+// Passed defaults to score >= 1 so existing score-only tests keep working.
 type fakeOfflineRunner struct {
-	score float64
-	err   error
+	score       float64
+	forcePassed *bool
+	err         error
 }
 
 func (f fakeOfflineRunner) Run(_ context.Context, _ prompteval.Spec) (prompteval.Result, error) {
 	if f.err != nil {
 		return prompteval.Result{}, f.err
 	}
-	return prompteval.Result{Score: f.score}, nil
+	passed := f.score >= 1
+	if f.forcePassed != nil {
+		passed = *f.forcePassed
+	}
+	return prompteval.Result{Score: f.score, Passed: passed}, nil
 }
 func (f fakeOfflineRunner) Available() bool { return true }
 func (f fakeOfflineRunner) Name() string    { return "fake" }
@@ -115,6 +121,41 @@ func TestCmdEvaluationOfflineRunExitsNonzeroOnUnavailable(t *testing.T) {
 	code, output := runCLI(t, "evaluation", "offline", "run", "--variants", variantsPath, "--golden", goldenPath, "--json")
 	if code == 0 {
 		t.Fatalf("expected nonzero exit for an UNAVAILABLE verdict under default fail-closed policy, got 0. output: %s", output)
+	}
+}
+
+// TestCmdEvaluationOfflineRunFailsOnHighScoreRunnerFailure is the regression
+// case for the reported bug: a runner (e.g. promptfoo) can report a high
+// numeric Score while its own success/gradingResult.pass signal says the run
+// failed. The verdict must be FAIL and enrollment must be denied — deriving
+// the verdict from Score alone silently passed this case before the fix.
+func TestCmdEvaluationOfflineRunFailsOnHighScoreRunnerFailure(t *testing.T) {
+	dir := setupStore(t)
+	old := newOfflineRunner
+	defer func() { newOfflineRunner = old }()
+	failed := false
+	newOfflineRunner = func(config.OfflineEvalConfig) prompteval.OfflineRunner {
+		return fakeOfflineRunner{score: 1, forcePassed: &failed}
+	}
+
+	variantsPath := filepath.Join(dir, "variants.json")
+	goldenPath := filepath.Join(dir, "golden.json")
+	writeJSONFile(t, variantsPath, []prompteval.CandidateVariant{
+		{ID: "boundary-variant", Prompt: "SCREENED_PROMPT: avoid unsafe content", Provider: "openai", Model: "gpt-test"},
+	})
+	writeJSONFile(t, goldenPath, []offlineGoldenCase{
+		{CaseID: "case-one", Input: "user asks question", Assertions: []prompteval.Assertion{{Type: "not-contains", Value: "unsafe"}}},
+	})
+
+	code, output := runCLI(t, "evaluation", "offline", "run", "--variants", variantsPath, "--golden", goldenPath, "--json")
+	if code == 0 {
+		t.Fatalf("expected nonzero exit when the runner reports failure despite score=1, got 0. output: %s", output)
+	}
+
+	digest := prompteval.Digest([]byte("SCREENED_PROMPT: avoid unsafe content"))
+	gateCode, gateOut := runCLI(t, "evaluation", "offline", "gate", "boundary-variant", digest, "--json")
+	if gateCode == 0 {
+		t.Fatalf("expected gate to deny enrollment for a runner-failed verdict, got allow. output: %s", gateOut)
 	}
 }
 

--- a/cmd/sybra-cli/evaluation_test.go
+++ b/cmd/sybra-cli/evaluation_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/prompteval"
+)
+
+// fakeOfflineRunner lets the test control Score deterministically instead of
+// shelling out to a live provider CLI.
+type fakeOfflineRunner struct {
+	score float64
+	err   error
+}
+
+func (f fakeOfflineRunner) Run(_ context.Context, _ prompteval.Spec) (prompteval.Result, error) {
+	if f.err != nil {
+		return prompteval.Result{}, f.err
+	}
+	return prompteval.Result{Score: f.score}, nil
+}
+func (f fakeOfflineRunner) Available() bool { return true }
+func (f fakeOfflineRunner) Name() string    { return "fake" }
+
+func writeJSONFile(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestCmdEvaluationOfflineExitsNonzeroOnFail(t *testing.T) {
+	dir := setupStore(t)
+	old := newOfflineRunner
+	defer func() { newOfflineRunner = old }()
+	newOfflineRunner = func(config.OfflineEvalConfig) prompteval.OfflineRunner {
+		return fakeOfflineRunner{score: 0}
+	}
+
+	variantsPath := filepath.Join(dir, "variants.json")
+	goldenPath := filepath.Join(dir, "golden.json")
+	writeJSONFile(t, variantsPath, []prompteval.CandidateVariant{
+		{ID: "failing-variant", Prompt: "some prompt", Provider: "claude", Model: "opus"},
+	})
+	writeJSONFile(t, goldenPath, []offlineGoldenCase{
+		{CaseID: "c1", Input: "hi", Assertions: []prompteval.Assertion{{Type: "contains", Value: "x"}}},
+	})
+
+	code, output := runCLI(t, "evaluation", "offline", "run", "--variants", variantsPath, "--golden", goldenPath, "--json")
+	if code == 0 {
+		t.Fatalf("expected nonzero exit for a FAIL verdict, got 0. output: %s", output)
+	}
+}
+
+func TestCmdEvaluationOfflineRunExitsZeroOnPass(t *testing.T) {
+	dir := setupStore(t)
+	old := newOfflineRunner
+	defer func() { newOfflineRunner = old }()
+	newOfflineRunner = func(config.OfflineEvalConfig) prompteval.OfflineRunner {
+		return fakeOfflineRunner{score: 1}
+	}
+
+	variantsPath := filepath.Join(dir, "variants.json")
+	goldenPath := filepath.Join(dir, "golden.json")
+	writeJSONFile(t, variantsPath, []prompteval.CandidateVariant{
+		{ID: "passing-variant", Prompt: "some prompt", Provider: "claude", Model: "opus"},
+	})
+	writeJSONFile(t, goldenPath, []offlineGoldenCase{
+		{CaseID: "c1", Input: "hi", Assertions: []prompteval.Assertion{{Type: "contains", Value: "x"}}},
+	})
+
+	code, output := runCLI(t, "evaluation", "offline", "run", "--variants", variantsPath, "--golden", goldenPath, "--json")
+	if code != 0 {
+		t.Fatalf("expected exit 0 for a PASS verdict, got %d. output: %s", code, output)
+	}
+
+	// The verdict must be persisted so `gate` can read it back.
+	digest := prompteval.Digest([]byte("some prompt"))
+	gateCode, gateOut := runCLI(t, "evaluation", "offline", "gate", "passing-variant", digest, "--json")
+	if gateCode != 0 {
+		t.Fatalf("gate on a PASS verdict should exit 0, got %d. output: %s", gateCode, gateOut)
+	}
+}
+
+func TestCmdEvaluationOfflineRunRejectsEmptyVariants(t *testing.T) {
+	dir := setupStore(t)
+	variantsPath := filepath.Join(dir, "variants.json")
+	goldenPath := filepath.Join(dir, "golden.json")
+	writeJSONFile(t, variantsPath, []prompteval.CandidateVariant{})
+	writeJSONFile(t, goldenPath, []offlineGoldenCase{
+		{CaseID: "c1", Input: "hi"},
+	})
+
+	code, output := runCLI(t, "evaluation", "offline", "run", "--variants", variantsPath, "--golden", goldenPath, "--json")
+	if code == 0 {
+		t.Fatalf("expected nonzero exit for an empty --variants list (must be a usage error, not a vacuous pass). output: %s", output)
+	}
+}
+
+func TestCmdEvaluationOfflineGateDeniesMissingVerdict(t *testing.T) {
+	setupStore(t)
+	code, output := runCLI(t, "evaluation", "offline", "gate", "no-such-variant", "no-such-digest", "--json")
+	if code == 0 {
+		t.Fatalf("expected nonzero exit for a missing verdict (fail-closed default), got 0. output: %s", output)
+	}
+}

--- a/internal/abtest/selector.go
+++ b/internal/abtest/selector.go
@@ -20,6 +20,11 @@ func Select(cfg Config, taskID, role, stepID string) (Assignment, bool, error) {
 	return SelectEligible(cfg, taskID, role, stepID, nil)
 }
 
+// EvalPassed reports whether a variant's offline eval verdict allows online
+// enrollment (e.g. internal/prompteval.Gate.AllowEnrollment). Implementations
+// must only read a precomputed verdict — never run an eval on this call path.
+type EvalPassed func(variantID, digest string) bool
+
 // SelectionContext identifies the workflow step currently being assigned.
 type SelectionContext struct {
 	TaskID     string
@@ -34,11 +39,20 @@ type SelectionContext struct {
 // without a CLI do not silently fall back to a different provider while keeping
 // stale experiment attribution.
 func SelectEligible(cfg Config, taskID, role, stepID string, providerAllowed func(string) bool) (Assignment, bool, error) {
-	return SelectEligibleForContext(cfg, SelectionContext{TaskID: taskID, Role: role, StepID: stepID}, providerAllowed)
+	return SelectEligibleWithEval(cfg, taskID, role, stepID, providerAllowed, nil)
+}
+
+// SelectEligibleWithEval is SelectEligible with an additional nil-safe
+// offline-eval predicate. A positive-weight variant is skipped only when
+// evalPassed is non-nil AND the variant carries a non-empty Digest AND
+// evalPassed returns false — so callers that pass nil (or variants without a
+// digest) see byte-for-byte unchanged selection.
+func SelectEligibleWithEval(cfg Config, taskID, role, stepID string, providerAllowed func(string) bool, evalPassed EvalPassed) (Assignment, bool, error) {
+	return SelectEligibleForContext(cfg, SelectionContext{TaskID: taskID, Role: role, StepID: stepID}, providerAllowed, evalPassed)
 }
 
 // SelectEligibleForContext is SelectEligible with workflow subject context.
-func SelectEligibleForContext(cfg Config, ctx SelectionContext, providerAllowed func(string) bool) (Assignment, bool, error) {
+func SelectEligibleForContext(cfg Config, ctx SelectionContext, providerAllowed func(string) bool, evalPassed EvalPassed) (Assignment, bool, error) {
 	if !cfg.EnabledValue() {
 		return Assignment{}, false, nil
 	}
@@ -47,12 +61,12 @@ func SelectEligibleForContext(cfg Config, ctx SelectionContext, providerAllowed 
 		if !exp.EnabledValue() || !roleMatches(exp.Roles, ctx.Role) || !subjectMatches(exp.Subject, ctx) {
 			continue
 		}
-		return selectFromExperiment(exp, ctx.TaskID, ctx.Role, ctx.StepID, providerAllowed)
+		return selectFromExperiment(exp, ctx.TaskID, ctx.Role, ctx.StepID, providerAllowed, evalPassed)
 	}
 	return Assignment{}, false, nil
 }
 
-func selectFromExperiment(exp Experiment, taskID, role, stepID string, providerAllowed func(string) bool) (Assignment, bool, error) {
+func selectFromExperiment(exp Experiment, taskID, role, stepID string, providerAllowed func(string) bool, evalPassed EvalPassed) (Assignment, bool, error) {
 	if err := validateExperiment(exp, providerAllowed); err != nil {
 		return Assignment{}, false, err
 	}
@@ -64,7 +78,7 @@ func selectFromExperiment(exp Experiment, taskID, role, stepID string, providerA
 	if unit == "stage" {
 		key = strings.Join([]string{taskID, role, stepID}, "|")
 	}
-	eligible, total := EligibleVariants(exp, providerAllowed)
+	eligible, total := EligibleVariants(exp, providerAllowed, evalPassed)
 	if total <= 0 {
 		return Assignment{}, false, fmt.Errorf("abtest: experiment %q has no eligible positive-weight variants", exp.ID)
 	}
@@ -93,7 +107,10 @@ func selectFromExperiment(exp Experiment, taskID, role, stepID string, providerA
 }
 
 // EligibleVariants returns the positive-weight variants that can be assigned.
-func EligibleVariants(exp Experiment, providerAllowed func(string) bool) (eligible []Variant, totalWeight int) {
+// A variant is skipped when evalPassed is non-nil AND it carries a non-empty
+// Digest AND evalPassed(v.ID, v.Digest) returns false — evalPassed=nil or a
+// digest-less variant (e.g. model-only experiments) never changes the result.
+func EligibleVariants(exp Experiment, providerAllowed func(string) bool, evalPassed EvalPassed) (eligible []Variant, totalWeight int) {
 	eligible = make([]Variant, 0, len(exp.Variants))
 	for i := range exp.Variants {
 		v := exp.Variants[i]
@@ -101,6 +118,9 @@ func EligibleVariants(exp Experiment, providerAllowed func(string) bool) (eligib
 			continue
 		}
 		if providerAllowed != nil && !providerAllowed(v.Provider) {
+			continue
+		}
+		if evalPassed != nil && v.Digest != "" && !evalPassed(v.ID, v.Digest) {
 			continue
 		}
 		totalWeight += v.Weight
@@ -215,7 +235,7 @@ func validatePromptSkillHomogeneity(exp Experiment, providerAllowed func(string)
 	default:
 		return nil
 	}
-	eligible, _ := EligibleVariants(exp, providerAllowed)
+	eligible, _ := EligibleVariants(exp, providerAllowed, nil)
 	if len(eligible) < 2 {
 		return nil
 	}

--- a/internal/abtest/selector_test.go
+++ b/internal/abtest/selector_test.go
@@ -661,3 +661,66 @@ func TestConfigValidateDuplicateVariantIDOnlyChecksPositiveWeight(t *testing.T) 
 		t.Fatal("Validate should reject duplicate positive-weight variant ids")
 	}
 }
+
+func TestSelectEligibleEvalPassedSeam(t *testing.T) {
+	enabled := true
+	cfg := Config{Enabled: &enabled, Experiments: []Experiment{{
+		ID:             "exp",
+		AssignmentUnit: "task",
+		Roles:          []string{"implementation"},
+		Variants: []Variant{
+			{ID: "failing", Provider: "claude", Model: "opus", Digest: "digest-fail", Weight: 1},
+			{ID: "passing", Provider: "claude", Model: "opus", Digest: "digest-pass", Weight: 1},
+		},
+	}}}
+	evalPassed := func(variantID, digest string) bool {
+		return variantID == "passing"
+	}
+	for range 10 {
+		a, ok, err := SelectEligibleWithEval(cfg, "task-1", "implementation", "implement", nil, evalPassed)
+		if err != nil || !ok {
+			t.Fatalf("SelectEligibleWithEval: ok=%v err=%v", ok, err)
+		}
+		if a.VariantID != "passing" {
+			t.Fatalf("VariantID = %q, want passing (failing digest must be excluded)", a.VariantID)
+		}
+	}
+}
+
+func TestSelectEligibleNilEvalPassedUnchanged(t *testing.T) {
+	cfg := DefaultConfig()
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("DefaultConfig().Validate: %v", err)
+	}
+	want, ok, err := SelectEligible(cfg, "task-1", "implementation", "implement", nil)
+	if err != nil || !ok {
+		t.Fatalf("SelectEligible: ok=%v err=%v", ok, err)
+	}
+	got, ok, err := SelectEligibleWithEval(cfg, "task-1", "implementation", "implement", nil, nil)
+	if err != nil || !ok {
+		t.Fatalf("SelectEligibleWithEval(evalPassed=nil): ok=%v err=%v", ok, err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("evalPassed=nil changed selection: got %+v want %+v", got, want)
+	}
+}
+
+func TestEligibleVariantsSkipsOnlyDigestedFailures(t *testing.T) {
+	exp := Experiment{Variants: []Variant{
+		{ID: "no-digest", Provider: "claude", Model: "opus", Weight: 1}, // model-only, no digest
+		{ID: "has-digest-fail", Provider: "claude", Model: "opus", Digest: "d1", Weight: 1},
+		{ID: "has-digest-pass", Provider: "claude", Model: "opus", Digest: "d2", Weight: 1},
+	}}
+	evalPassed := func(variantID, digest string) bool { return digest == "d2" }
+	eligible, total := EligibleVariants(exp, nil, evalPassed)
+	if total != 2 {
+		t.Fatalf("total = %d, want 2 (digest-less variant + the passing digested one)", total)
+	}
+	ids := map[string]bool{}
+	for _, v := range eligible {
+		ids[v.ID] = true
+	}
+	if !ids["no-digest"] || !ids["has-digest-pass"] || ids["has-digest-fail"] {
+		t.Fatalf("eligible = %+v", eligible)
+	}
+}

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -530,6 +530,15 @@ func applyEvaluationDefaults(cfg *Config) {
 	if e.WindowDays <= 0 {
 		e.WindowDays = 30
 	}
+	if e.Offline.Runner == "" {
+		e.Offline.Runner = "auto"
+	}
+	if e.Offline.MinScore <= 0 {
+		e.Offline.MinScore = 1.0
+	}
+	if e.Offline.UnavailablePolicy == "" {
+		e.Offline.UnavailablePolicy = "fail"
+	}
 }
 
 // applyHarnessEvolveDefaults fills zero values while preserving Enabled from
@@ -792,6 +801,12 @@ func SelfMonitorDir() string {
 // records and run snapshots.
 func HarnessEvolveDir() string {
 	return filepath.Join(HomeDir(), "harness-evolution")
+}
+
+// PromptEvalDir is the local store for offline prompt/skill eval verdicts
+// (internal/prompteval). Layout: <dir>/<variantID>/<digest>.json.
+func PromptEvalDir() string {
+	return filepath.Join(HomeDir(), "prompteval")
 }
 
 // SelfMonitorLedgerPath is the append-only ledger file selfmonitor.Open uses.

--- a/internal/config/config_evaluation.go
+++ b/internal/config/config_evaluation.go
@@ -5,7 +5,29 @@ package config
 // stats + audit data. Read-only: it never dispatches agents or files issues, so
 // it needs no project-type routing — each machine scores its own local data.
 type EvaluationConfig struct {
-	Enabled       bool    `yaml:"enabled" json:"enabled"`
-	IntervalHours float64 `yaml:"interval_hours" json:"intervalHours"`
-	WindowDays    int     `yaml:"window_days" json:"windowDays"`
+	Enabled       bool              `yaml:"enabled" json:"enabled"`
+	IntervalHours float64           `yaml:"interval_hours" json:"intervalHours"`
+	WindowDays    int               `yaml:"window_days" json:"windowDays"`
+	Offline       OfflineEvalConfig `yaml:"offline" json:"offline"`
+}
+
+// OfflineEvalConfig controls the offline prompt/skill eval runner
+// (internal/prompteval) that screens candidate variants before they are
+// eligible for online A/B enrollment.
+type OfflineEvalConfig struct {
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// Runner selects the offline runner: "auto" (default, promptfoo if on
+	// PATH else native), "promptfoo", or "native".
+	Runner     string `yaml:"runner" json:"runner"`
+	BinaryPath string `yaml:"binary_path,omitempty" json:"binaryPath,omitempty"`
+	// MinScore is the minimum Result.Score (0..1) required for a verdict to
+	// be scored StatusPass.
+	MinScore float64 `yaml:"min_score" json:"minScore"`
+	// UnavailablePolicy is "fail" (default, fail-closed) or "pass" — what
+	// AllowEnrollment returns when no verdict is recorded or the runner
+	// could not measure a result.
+	UnavailablePolicy string `yaml:"unavailable_policy" json:"unavailablePolicy"`
+	// Mode is reserved for future dry-run/enforce distinctions; currently
+	// informational only.
+	Mode string `yaml:"mode,omitempty" json:"mode,omitempty"`
 }

--- a/internal/evaluation/scorecard.go
+++ b/internal/evaluation/scorecard.go
@@ -860,7 +860,7 @@ func configuredExperimentRoles(experiments []abtest.Experiment, rows []Compariso
 		if exp.ID == "" || !exp.EnabledValue() || len(exp.Variants) == 0 {
 			continue
 		}
-		eligible, _ := abtest.EligibleVariants(*exp, nil)
+		eligible, _ := abtest.EligibleVariants(*exp, nil, nil)
 		variants := make([]string, 0, len(eligible))
 		disabled := map[string]bool{}
 		for i := range exp.Variants {

--- a/internal/prompteval/gate.go
+++ b/internal/prompteval/gate.go
@@ -1,0 +1,61 @@
+package prompteval
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/Automaat/sybra/internal/config"
+)
+
+// Gate decides whether a variant may be enrolled in online A/B tests, based
+// on a precomputed verdict. It never runs a runner itself — Decision/
+// AllowEnrollment only read the store, so they are safe to call on a
+// dispatch hot path.
+//
+// Trust boundary: the digest is the identity key. A stale digest argument
+// simply misses the stored verdict (or hits its own unrelated one) — it can
+// never surface a verdict computed for different prompt bytes as a match.
+type Gate struct {
+	store *Store
+	cfg   config.OfflineEvalConfig
+}
+
+// NewGate constructs a Gate reading verdicts from store.
+func NewGate(store *Store, cfg config.OfflineEvalConfig) *Gate {
+	return &Gate{store: store, cfg: cfg}
+}
+
+// Decision returns the stored verdict for (variantID, digest), or
+// ErrNotFound if none exists.
+func (g *Gate) Decision(variantID, digest string) (VariantVerdict, error) {
+	return g.store.Read(variantID, digest)
+}
+
+// AllowEnrollment reports whether the variant may be enrolled online: FAIL
+// always blocks, PASS always allows, and a missing/UNAVAILABLE verdict
+// follows cfg.UnavailablePolicy (default "fail" — fail-closed).
+func (g *Gate) AllowEnrollment(variantID, digest string) (allow bool, reason string, err error) {
+	v, err := g.store.Read(variantID, digest)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return g.unavailableAllowed(), "no offline eval verdict recorded", nil
+		}
+		return false, "", err
+	}
+	switch v.Status {
+	case StatusPass:
+		return true, "", nil
+	case StatusFail:
+		return false, "offline eval failed: " + v.Reason, nil
+	case StatusUnavailable:
+		return g.unavailableAllowed(), "offline eval unavailable: " + v.Reason, nil
+	default:
+		return false, "unknown offline eval status", nil
+	}
+}
+
+// unavailableAllowed resolves cfg.UnavailablePolicy. Default and any
+// unrecognized value is fail-closed.
+func (g *Gate) unavailableAllowed() bool {
+	return strings.EqualFold(strings.TrimSpace(g.cfg.UnavailablePolicy), "pass")
+}

--- a/internal/prompteval/gate_test.go
+++ b/internal/prompteval/gate_test.go
@@ -1,0 +1,97 @@
+package prompteval
+
+import (
+	"testing"
+
+	"github.com/Automaat/sybra/internal/config"
+)
+
+// defaultTestOfflineConfig returns the fail-closed default: UnavailablePolicy
+// "fail" means a missing/unavailable verdict never allows enrollment.
+func defaultTestOfflineConfig() config.OfflineEvalConfig {
+	return config.OfflineEvalConfig{
+		Runner:            "native",
+		MinScore:          1.0,
+		UnavailablePolicy: "fail",
+	}
+}
+
+func TestGateBlocksOnFail(t *testing.T) {
+	t.Parallel()
+	store := New(t.TempDir())
+	verdict := VariantVerdict{
+		VariantID: "v1",
+		Digest:    Digest([]byte("prompt-a")),
+		Status:    StatusFail,
+		Reason:    "assertion failed",
+	}
+	if err := store.Write(verdict); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	gate := NewGate(store, defaultTestOfflineConfig())
+	allow, _, err := gate.AllowEnrollment(verdict.VariantID, verdict.Digest)
+	if err != nil {
+		t.Fatalf("AllowEnrollment: %v", err)
+	}
+	if allow {
+		t.Fatal("AllowEnrollment allowed a FAIL verdict")
+	}
+}
+
+func TestGateTriState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("pass allows", func(t *testing.T) {
+		t.Parallel()
+		store := New(t.TempDir())
+		v := VariantVerdict{VariantID: "v1", Digest: Digest([]byte("p")), Status: StatusPass}
+		if err := store.Write(v); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		gate := NewGate(store, defaultTestOfflineConfig())
+		allow, _, err := gate.AllowEnrollment(v.VariantID, v.Digest)
+		if err != nil || !allow {
+			t.Fatalf("allow=%v err=%v, want allow=true", allow, err)
+		}
+	})
+
+	t.Run("unavailable fail-closed by default", func(t *testing.T) {
+		t.Parallel()
+		store := New(t.TempDir())
+		v := VariantVerdict{VariantID: "v1", Digest: Digest([]byte("p")), Status: StatusUnavailable}
+		if err := store.Write(v); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		gate := NewGate(store, defaultTestOfflineConfig())
+		allow, _, err := gate.AllowEnrollment(v.VariantID, v.Digest)
+		if err != nil || allow {
+			t.Fatalf("allow=%v err=%v, want allow=false (fail-closed default)", allow, err)
+		}
+	})
+
+	t.Run("unavailable allowed under explicit pass policy", func(t *testing.T) {
+		t.Parallel()
+		store := New(t.TempDir())
+		v := VariantVerdict{VariantID: "v1", Digest: Digest([]byte("p")), Status: StatusUnavailable}
+		if err := store.Write(v); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		cfg := defaultTestOfflineConfig()
+		cfg.UnavailablePolicy = "pass"
+		gate := NewGate(store, cfg)
+		allow, _, err := gate.AllowEnrollment(v.VariantID, v.Digest)
+		if err != nil || !allow {
+			t.Fatalf("allow=%v err=%v, want allow=true under pass policy", allow, err)
+		}
+	})
+
+	t.Run("no verdict recorded is fail-closed by default", func(t *testing.T) {
+		t.Parallel()
+		store := New(t.TempDir())
+		gate := NewGate(store, defaultTestOfflineConfig())
+		allow, _, err := gate.AllowEnrollment("missing-variant", Digest([]byte("p")))
+		if err != nil || allow {
+			t.Fatalf("allow=%v err=%v, want allow=false for a missing verdict", allow, err)
+		}
+	})
+}

--- a/internal/prompteval/model.go
+++ b/internal/prompteval/model.go
@@ -89,3 +89,15 @@ func Digest(b []byte) string {
 	sum := sha256.Sum256(b)
 	return hex.EncodeToString(sum[:])
 }
+
+// resolvedPrompt composes the candidate variant's own prompt/skill body with
+// the golden case's input so a runner actually screens the digested bytes —
+// not just the fixture input — against the provider. A variant with no
+// resolved Prompt (e.g. a bare model/provider comparison) falls back to the
+// input alone, unchanged from prior behavior.
+func resolvedPrompt(spec Spec) string {
+	if spec.Variant.Prompt == "" {
+		return spec.Input
+	}
+	return spec.Variant.Prompt + "\n\n" + spec.Input
+}

--- a/internal/prompteval/model.go
+++ b/internal/prompteval/model.go
@@ -1,0 +1,91 @@
+// Package prompteval evaluates candidate prompt/skill variants offline
+// (outside any live agent run) and stores durable, machine-readable verdicts
+// that gate their enrollment into online A/B tests.
+package prompteval
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"time"
+)
+
+// CandidateVariant is a prompt/skill variant to be evaluated offline before
+// online A/B enrollment. Digest is the identity key: two variants with the
+// same resolved prompt bytes share a verdict, and re-running after an edit
+// invalidates the stale one automatically.
+type CandidateVariant struct {
+	ID              string `json:"id"`
+	Digest          string `json:"digest"`
+	Prompt          string `json:"prompt"` // resolved prompt or skill body bytes
+	Provider        string `json:"provider"`
+	Model           string `json:"model"`
+	ReasoningEffort string `json:"reasoningEffort,omitempty"`
+}
+
+// Assertion is one check run against a variant's output for a golden case.
+// Deterministic types (contains/not-contains/regex/is-json/latency) affect
+// Score; "model-graded" is advisory-only and never fails a run by itself.
+type Assertion struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+// AssertionResult is the observed outcome of one Assertion.
+type AssertionResult struct {
+	Type   string `json:"type"`
+	Passed bool   `json:"passed"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// Spec is one offline evaluation unit: a candidate variant run against a
+// single golden-case input and scored against its assertions.
+type Spec struct {
+	CaseID     string           `json:"caseId"`
+	Variant    CandidateVariant `json:"variant"`
+	Input      string           `json:"input"`
+	Assertions []Assertion      `json:"assertions"`
+	Timeout    time.Duration    `json:"timeout,omitempty"`
+}
+
+// Result is the raw, per-Spec output produced by a runner. Score is the
+// fraction (0..1) of deterministic assertions that passed; a runner returns
+// an error instead of a zero-value Result when the run itself could not be
+// measured, so a caller never mistakes "could not run" for "scored zero".
+type Result struct {
+	Output     string            `json:"output"`
+	Assertions []AssertionResult `json:"assertions,omitempty"`
+	Score      float64           `json:"score"`
+	CostUSD    float64           `json:"costUsd"`
+	LatencyMS  int64             `json:"latencyMs"`
+}
+
+// Status is the tri-state offline-eval verdict.
+type Status string
+
+const (
+	StatusPass        Status = "pass"
+	StatusFail        Status = "fail"
+	StatusUnavailable Status = "unavailable"
+)
+
+// VariantVerdict is the durable, machine-readable verdict for one
+// (VariantID, Digest) pair, persisted by Store and read by Gate.
+type VariantVerdict struct {
+	VariantID  string            `json:"variantId"`
+	Digest     string            `json:"digest"`
+	Status     Status            `json:"status"`
+	Score      float64           `json:"score"`
+	CostUSD    float64           `json:"costUsd"`
+	LatencyMS  int64             `json:"latencyMs"`
+	Assertions []AssertionResult `json:"assertions,omitempty"`
+	Runner     string            `json:"runner"`
+	Reason     string            `json:"reason,omitempty"`
+	CreatedAt  time.Time         `json:"createdAt"`
+}
+
+// Digest returns the hex sha256 of resolved prompt/skill bytes — the
+// identity key used to key stored verdicts and to detect a stale prompt.
+func Digest(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/prompteval/model.go
+++ b/internal/prompteval/model.go
@@ -51,10 +51,16 @@ type Spec struct {
 // fraction (0..1) of deterministic assertions that passed; a runner returns
 // an error instead of a zero-value Result when the run itself could not be
 // measured, so a caller never mistakes "could not run" for "scored zero".
+// Passed is the runner's own pass/fail signal for this Spec — for promptfoo
+// that's `success && gradingResult.pass`, for native it's "no deterministic
+// assertion failed" — and is authoritative over Score: a runner can report a
+// high Score while still failing a hard assertion, and the caller must not
+// aggregate to an overall PASS in that case.
 type Result struct {
 	Output     string            `json:"output"`
 	Assertions []AssertionResult `json:"assertions,omitempty"`
 	Score      float64           `json:"score"`
+	Passed     bool              `json:"passed"`
 	CostUSD    float64           `json:"costUsd"`
 	LatencyMS  int64             `json:"latencyMs"`
 }

--- a/internal/prompteval/model_test.go
+++ b/internal/prompteval/model_test.go
@@ -1,0 +1,19 @@
+package prompteval
+
+import "testing"
+
+func TestDigest(t *testing.T) {
+	t.Parallel()
+	a := Digest([]byte("hello"))
+	b := Digest([]byte("hello"))
+	if a != b {
+		t.Fatalf("Digest not stable: %q != %q", a, b)
+	}
+	c := Digest([]byte("hello!"))
+	if a == c {
+		t.Fatalf("Digest did not change for different input")
+	}
+	if len(a) != 64 {
+		t.Fatalf("Digest length = %d, want 64 (hex sha256)", len(a))
+	}
+}

--- a/internal/prompteval/native.go
+++ b/internal/prompteval/native.go
@@ -40,7 +40,7 @@ func (r *NativeRunner) Run(ctx context.Context, spec Spec) (Result, error) {
 	}
 
 	start := time.Now()
-	out, err := llmexec.RunJSON(ctx, spec.Input, llmexec.Options{
+	out, err := llmexec.RunJSON(ctx, resolvedPrompt(spec), llmexec.Options{
 		Provider: spec.Variant.Provider,
 		Models:   map[string]string{spec.Variant.Provider: spec.Variant.Model},
 	})

--- a/internal/prompteval/native.go
+++ b/internal/prompteval/native.go
@@ -1,0 +1,118 @@
+package prompteval
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/Automaat/sybra/internal/llmexec"
+)
+
+// NativeRunner evaluates a Spec with a single-shot prompt via
+// internal/llmexec and deterministic assertions, scored locally. It never
+// requires Node/promptfoo, so the gate still works on the mise-only server.
+//
+// llmexec.Result exposes no cost or latency, so CostUSD always reports 0 here
+// (a genuine measurement gap, not a bug) while LatencyMS is measured locally
+// around the call. Do not edit internal/llmexec to add cost/latency for this
+// package — it is a shared one-shot CLI runner used by several callers.
+type NativeRunner struct{}
+
+// NewNativeRunner constructs a NativeRunner.
+func NewNativeRunner() *NativeRunner { return &NativeRunner{} }
+
+// Name implements OfflineRunner.
+func (r *NativeRunner) Name() string { return "native" }
+
+// Available implements OfflineRunner. The native runner has no external
+// binary dependency beyond the provider CLIs llmexec already probes.
+func (r *NativeRunner) Available() bool { return true }
+
+// Run implements OfflineRunner.
+func (r *NativeRunner) Run(ctx context.Context, spec Spec) (Result, error) {
+	if spec.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, spec.Timeout)
+		defer cancel()
+	}
+
+	start := time.Now()
+	out, err := llmexec.RunJSON(ctx, spec.Input, llmexec.Options{
+		Provider: spec.Variant.Provider,
+		Models:   map[string]string{spec.Variant.Provider: spec.Variant.Model},
+	})
+	latencyMS := time.Since(start).Milliseconds()
+	if err != nil {
+		return Result{}, fmt.Errorf("native runner: %w", err)
+	}
+
+	results := make([]AssertionResult, 0, len(spec.Assertions))
+	var deterministic, passed int
+	for _, a := range spec.Assertions {
+		ar := evaluateAssertion(a, out.Text, latencyMS)
+		results = append(results, ar)
+		if a.Type == "model-graded" {
+			continue
+		}
+		deterministic++
+		if ar.Passed {
+			passed++
+		}
+	}
+
+	score := 1.0
+	if deterministic > 0 {
+		score = float64(passed) / float64(deterministic)
+	}
+
+	return Result{
+		Output:     out.Text,
+		Assertions: results,
+		Score:      score,
+		CostUSD:    0,
+		LatencyMS:  latencyMS,
+	}, nil
+}
+
+func evaluateAssertion(a Assertion, output string, latencyMS int64) AssertionResult {
+	switch a.Type {
+	case "contains":
+		ok := strings.Contains(output, a.Value)
+		return AssertionResult{Type: a.Type, Passed: ok, Detail: matchDetail(ok, a.Value)}
+	case "not-contains":
+		ok := !strings.Contains(output, a.Value)
+		return AssertionResult{Type: a.Type, Passed: ok, Detail: matchDetail(ok, a.Value)}
+	case "regex":
+		re, err := regexp.Compile(a.Value)
+		if err != nil {
+			return AssertionResult{Type: a.Type, Passed: false, Detail: fmt.Sprintf("invalid regex %q: %v", a.Value, err)}
+		}
+		ok := re.MatchString(output)
+		return AssertionResult{Type: a.Type, Passed: ok, Detail: matchDetail(ok, a.Value)}
+	case "is-json":
+		var v any
+		ok := json.Unmarshal([]byte(output), &v) == nil
+		return AssertionResult{Type: a.Type, Passed: ok, Detail: matchDetail(ok, "valid JSON")}
+	case "latency":
+		maxDur, err := time.ParseDuration(a.Value)
+		if err != nil {
+			return AssertionResult{Type: a.Type, Passed: false, Detail: fmt.Sprintf("invalid duration %q: %v", a.Value, err)}
+		}
+		ok := time.Duration(latencyMS)*time.Millisecond <= maxDur
+		return AssertionResult{Type: a.Type, Passed: ok, Detail: fmt.Sprintf("latency %dms vs max %s", latencyMS, a.Value)}
+	case "model-graded":
+		return AssertionResult{Type: a.Type, Passed: true, Detail: "model-graded assertions are advisory only and never fail a run"}
+	default:
+		return AssertionResult{Type: a.Type, Passed: false, Detail: fmt.Sprintf("unknown assertion type %q", a.Type)}
+	}
+}
+
+func matchDetail(ok bool, want string) string {
+	if ok {
+		return fmt.Sprintf("matched %q", want)
+	}
+	return fmt.Sprintf("did not match %q", want)
+}

--- a/internal/prompteval/native.go
+++ b/internal/prompteval/native.go
@@ -72,6 +72,7 @@ func (r *NativeRunner) Run(ctx context.Context, spec Spec) (Result, error) {
 		Output:     out.Text,
 		Assertions: results,
 		Score:      score,
+		Passed:     deterministic == 0 || passed == deterministic,
 		CostUSD:    0,
 		LatencyMS:  latencyMS,
 	}, nil

--- a/internal/prompteval/native_test.go
+++ b/internal/prompteval/native_test.go
@@ -1,6 +1,9 @@
 package prompteval
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestNativeScoring exercises evaluateAssertion directly (the pure scoring
 // logic NativeRunner.Run delegates to) since Run shells out to a live
@@ -37,6 +40,29 @@ func TestNativeScoring(t *testing.T) {
 				t.Errorf("Passed = %v, want %v (detail: %s)", got.Passed, tc.wantPass, got.Detail)
 			}
 		})
+	}
+}
+
+// TestResolvedPromptCarriesVariantPrompt proves NativeRunner composes the
+// digested candidate prompt with the golden-case input rather than testing
+// the fixture input alone — two variants differing only by Prompt must
+// produce different resolved prompts sent to the provider.
+func TestResolvedPromptCarriesVariantPrompt(t *testing.T) {
+	t.Parallel()
+	specA := Spec{Variant: CandidateVariant{Prompt: "Be terse."}, Input: "hello"}
+	specB := Spec{Variant: CandidateVariant{Prompt: "Be verbose."}, Input: "hello"}
+	gotA := resolvedPrompt(specA)
+	gotB := resolvedPrompt(specB)
+	if gotA == gotB {
+		t.Fatalf("resolvedPrompt did not vary with Variant.Prompt: both = %q", gotA)
+	}
+	if !strings.Contains(gotA, specA.Variant.Prompt) || !strings.Contains(gotA, specA.Input) {
+		t.Fatalf("resolvedPrompt(%+v) = %q, want it to contain both prompt and input", specA, gotA)
+	}
+	// A variant with no resolved prompt (e.g. a bare model comparison) falls
+	// back to the input alone, unchanged from prior behavior.
+	if got := resolvedPrompt(Spec{Input: "hello"}); got != "hello" {
+		t.Fatalf("resolvedPrompt with empty Variant.Prompt = %q, want %q", got, "hello")
 	}
 }
 

--- a/internal/prompteval/native_test.go
+++ b/internal/prompteval/native_test.go
@@ -1,0 +1,93 @@
+package prompteval
+
+import "testing"
+
+// TestNativeScoring exercises evaluateAssertion directly (the pure scoring
+// logic NativeRunner.Run delegates to) since Run shells out to a live
+// provider CLI that isn't available in unit tests.
+func TestNativeScoring(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		assertion Assertion
+		output    string
+		latencyMS int64
+		wantPass  bool
+	}{
+		{"contains match", Assertion{Type: "contains", Value: "hello"}, "hello world", 0, true},
+		{"contains no match", Assertion{Type: "contains", Value: "hello"}, "goodbye", 0, false},
+		{"not-contains match", Assertion{Type: "not-contains", Value: "secret"}, "public info", 0, true},
+		{"not-contains violated", Assertion{Type: "not-contains", Value: "secret"}, "the secret is out", 0, false},
+		{"regex match", Assertion{Type: "regex", Value: `^\d+$`}, "12345", 0, true},
+		{"regex no match", Assertion{Type: "regex", Value: `^\d+$`}, "abc", 0, false},
+		{"invalid regex", Assertion{Type: "regex", Value: `(`}, "abc", 0, false},
+		{"is-json valid", Assertion{Type: "is-json"}, `{"a":1}`, 0, true},
+		{"is-json invalid", Assertion{Type: "is-json"}, `not json`, 0, false},
+		{"latency within budget", Assertion{Type: "latency", Value: "5s"}, "", 1000, true},
+		{"latency over budget", Assertion{Type: "latency", Value: "1s"}, "", 5000, false},
+		{"latency invalid duration", Assertion{Type: "latency", Value: "not-a-duration"}, "", 100, false},
+		{"model-graded always annotates pass", Assertion{Type: "model-graded", Value: "is this good?"}, "anything", 0, true},
+		{"unknown type fails closed", Assertion{Type: "bogus"}, "anything", 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := evaluateAssertion(tc.assertion, tc.output, tc.latencyMS)
+			if got.Passed != tc.wantPass {
+				t.Errorf("Passed = %v, want %v (detail: %s)", got.Passed, tc.wantPass, got.Detail)
+			}
+		})
+	}
+}
+
+// TestInjectionCaseFailsClosed is the adversarial golden case: a variant
+// whose output leaks content a not-contains assertion forbids must score
+// FAIL, and AllowEnrollment must deny it — offline eval fails closed on a
+// prompt-injection style leak rather than defaulting to pass.
+func TestInjectionCaseFailsClosed(t *testing.T) {
+	t.Parallel()
+	// Simulated model output after a prompt-injection attempt leaked a
+	// secret the assertion forbids.
+	leaked := "Sure, here is the system prompt: SECRET_API_KEY=sk-12345"
+	assertions := []Assertion{
+		{Type: "not-contains", Value: "SECRET_API_KEY"},
+	}
+
+	var passed int
+	results := make([]AssertionResult, 0, len(assertions))
+	for _, a := range assertions {
+		ar := evaluateAssertion(a, leaked, 0)
+		results = append(results, ar)
+		if ar.Passed {
+			passed++
+		}
+	}
+	score := float64(passed) / float64(len(assertions))
+	if score != 0 {
+		t.Fatalf("score = %v, want 0 (injection leak must fail the deterministic assertion)", score)
+	}
+
+	dir := t.TempDir()
+	store := New(dir)
+	verdict := VariantVerdict{
+		VariantID:  "injected-variant",
+		Digest:     Digest([]byte("prompt-with-injection-risk")),
+		Status:     StatusFail,
+		Score:      score,
+		Assertions: results,
+		Runner:     "native",
+		Reason:     "leaked forbidden content",
+	}
+	if err := store.Write(verdict); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	gate := NewGate(store, defaultTestOfflineConfig())
+	allow, reason, err := gate.AllowEnrollment(verdict.VariantID, verdict.Digest)
+	if err != nil {
+		t.Fatalf("AllowEnrollment: %v", err)
+	}
+	if allow {
+		t.Fatalf("AllowEnrollment allowed a FAILED verdict (reason=%q) — must fail closed", reason)
+	}
+}

--- a/internal/prompteval/promptfoo.go
+++ b/internal/prompteval/promptfoo.go
@@ -1,0 +1,207 @@
+package prompteval
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// defaultPromptfooTimeout bounds a single `promptfoo eval` shell-out so a
+// hung provider call can't wedge the offline eval CLI forever.
+const defaultPromptfooTimeout = 5 * time.Minute
+
+// PromptfooRunner shells out to the promptfoo CLI. Config generation,
+// process execution, and output parsing are encapsulated in this file only —
+// no other file in this package shells out or knows the promptfoo config
+// shape.
+type PromptfooRunner struct {
+	// BinaryPath overrides the promptfoo binary resolved from PATH; empty
+	// means "promptfoo".
+	BinaryPath string
+}
+
+// NewPromptfooRunner constructs a PromptfooRunner. binaryPath may be empty.
+func NewPromptfooRunner(binaryPath string) *PromptfooRunner {
+	return &PromptfooRunner{BinaryPath: binaryPath}
+}
+
+// Name implements OfflineRunner.
+func (r *PromptfooRunner) Name() string { return "promptfoo" }
+
+// Available implements OfflineRunner by probing the binary on PATH.
+func (r *PromptfooRunner) Available() bool {
+	_, err := exec.LookPath(r.binary())
+	return err == nil
+}
+
+func (r *PromptfooRunner) binary() string {
+	if r.BinaryPath != "" {
+		return r.BinaryPath
+	}
+	return "promptfoo"
+}
+
+// Run implements OfflineRunner: generates a promptfooconfig.yaml from spec,
+// runs `promptfoo eval -o out.json` with a timeout, and parses the result.
+func (r *PromptfooRunner) Run(ctx context.Context, spec Spec) (Result, error) {
+	timeout := spec.Timeout
+	if timeout <= 0 {
+		timeout = defaultPromptfooTimeout
+	}
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	dir, err := os.MkdirTemp("", "prompteval-promptfoo-*")
+	if err != nil {
+		return Result{}, fmt.Errorf("promptfoo runner: mkdir temp: %w", err)
+	}
+	defer os.RemoveAll(dir)
+
+	configPath := filepath.Join(dir, "promptfooconfig.yaml")
+	outPath := filepath.Join(dir, "out.json")
+	logPath := filepath.Join(dir, "run.log")
+
+	configData, err := generateConfig(spec)
+	if err != nil {
+		return Result{}, fmt.Errorf("promptfoo runner: generate config: %w", err)
+	}
+	if err := os.WriteFile(configPath, configData, 0o600); err != nil {
+		return Result{}, fmt.Errorf("promptfoo runner: write config: %w", err)
+	}
+
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		return Result{}, fmt.Errorf("promptfoo runner: create log: %w", err)
+	}
+	defer logFile.Close()
+
+	// #nosec G204 -- binary path and args are built from the runner's own
+	// config and a fixed argument list, never from unsanitized user input.
+	cmd := exec.CommandContext(runCtx, r.binary(), "eval", "-c", configPath, "-o", outPath, "--no-cache")
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if runErr := cmd.Run(); runErr != nil {
+		return Result{}, fmt.Errorf("promptfoo runner: eval: %w (see %s)", runErr, logPath)
+	}
+
+	outData, err := os.ReadFile(outPath)
+	if err != nil {
+		return Result{}, fmt.Errorf("promptfoo runner: read output: %w", err)
+	}
+	return parseOutput(outData)
+}
+
+// promptfooConfig is the minimal subset of promptfooconfig.yaml this package
+// generates: one prompt, one provider, one test with its assertions.
+type promptfooConfig struct {
+	Prompts   []string             `yaml:"prompts"`
+	Providers []promptfooProvider  `yaml:"providers"`
+	Tests     []promptfooTestEntry `yaml:"tests"`
+}
+
+type promptfooProvider struct {
+	ID string `yaml:"id"`
+}
+
+type promptfooTestEntry struct {
+	Vars   map[string]string `yaml:"vars"`
+	Assert []promptfooAssert `yaml:"assert"`
+}
+
+type promptfooAssert struct {
+	Type  string `yaml:"type"`
+	Value string `yaml:"value,omitempty"`
+}
+
+// generateConfig marshals spec into promptfooconfig.yaml via yaml.Marshal so
+// prompt/assertion text is always properly quoted — never string
+// concatenation, which would let injected `"` or newlines smuggle extra YAML
+// keys into the generated config.
+func generateConfig(spec Spec) ([]byte, error) {
+	asserts := make([]promptfooAssert, 0, len(spec.Assertions))
+	for _, a := range spec.Assertions {
+		asserts = append(asserts, promptfooAssert(a))
+	}
+	cfg := promptfooConfig{
+		Prompts:   []string{"{{input}}"},
+		Providers: []promptfooProvider{{ID: fmt.Sprintf("%s:%s", spec.Variant.Provider, spec.Variant.Model)}},
+		Tests: []promptfooTestEntry{
+			{
+				Vars:   map[string]string{"input": spec.Input},
+				Assert: asserts,
+			},
+		},
+	}
+	return yaml.Marshal(cfg)
+}
+
+// promptfooOutput is the subset of `promptfoo eval -o out.json` this package
+// reads. Real promptfoo output carries far more fields; anything not listed
+// here is ignored.
+type promptfooOutput struct {
+	Results struct {
+		Results []promptfooResult `json:"results"`
+	} `json:"results"`
+}
+
+type promptfooResult struct {
+	Success   bool    `json:"success"`
+	Score     float64 `json:"score"`
+	LatencyMS int64   `json:"latencyMs"`
+	Cost      float64 `json:"cost"`
+	Response  struct {
+		Output string `json:"output"`
+	} `json:"response"`
+	GradingResult struct {
+		Pass             bool `json:"pass"`
+		ComponentResults []struct {
+			Assertion struct {
+				Type  string `json:"type"`
+				Value string `json:"value"`
+			} `json:"assertion"`
+			Pass   bool   `json:"pass"`
+			Reason string `json:"reason"`
+		} `json:"componentResults"`
+	} `json:"gradingResult"`
+}
+
+// parseOutput normalizes promptfoo's out.json into a Result. Truncated,
+// malformed, or empty output returns an error — never a zero-value Result —
+// so the caller maps it to Status unavailable instead of a silent pass.
+func parseOutput(data []byte) (Result, error) {
+	if len(bytes.TrimSpace(data)) == 0 {
+		return Result{}, fmt.Errorf("promptfoo runner: empty output")
+	}
+	var out promptfooOutput
+	if err := json.Unmarshal(data, &out); err != nil {
+		return Result{}, fmt.Errorf("promptfoo runner: parse output: %w", err)
+	}
+	if len(out.Results.Results) == 0 {
+		return Result{}, fmt.Errorf("promptfoo runner: no results in output")
+	}
+	res := out.Results.Results[0]
+
+	assertions := make([]AssertionResult, 0, len(res.GradingResult.ComponentResults))
+	for _, cr := range res.GradingResult.ComponentResults {
+		assertions = append(assertions, AssertionResult{
+			Type:   cr.Assertion.Type,
+			Passed: cr.Pass,
+			Detail: cr.Reason,
+		})
+	}
+
+	return Result{
+		Output:     res.Response.Output,
+		Assertions: assertions,
+		Score:      res.Score,
+		CostUSD:    res.Cost,
+		LatencyMS:  res.LatencyMS,
+	}, nil
+}

--- a/internal/prompteval/promptfoo.go
+++ b/internal/prompteval/promptfoo.go
@@ -208,6 +208,7 @@ func parseOutput(data []byte) (Result, error) {
 		Output:     res.Response.Output,
 		Assertions: assertions,
 		Score:      res.Score,
+		Passed:     res.Success && res.GradingResult.Pass,
 		CostUSD:    res.Cost,
 		LatencyMS:  res.LatencyMS,
 	}, nil

--- a/internal/prompteval/promptfoo.go
+++ b/internal/prompteval/promptfoo.go
@@ -62,7 +62,16 @@ func (r *PromptfooRunner) Run(ctx context.Context, spec Spec) (Result, error) {
 	if err != nil {
 		return Result{}, fmt.Errorf("promptfoo runner: mkdir temp: %w", err)
 	}
-	defer os.RemoveAll(dir)
+	// Only cleaned up on success (or a failure before the run.log path is
+	// referenced in an error) — on eval failure the dir is left behind so
+	// the "(see <dir>/run.log)" error message points at a file that still
+	// exists for the operator to inspect.
+	cleanupDir := dir
+	defer func() {
+		if cleanupDir != "" {
+			_ = os.RemoveAll(cleanupDir)
+		}
+	}()
 
 	configPath := filepath.Join(dir, "promptfooconfig.yaml")
 	outPath := filepath.Join(dir, "out.json")
@@ -88,6 +97,7 @@ func (r *PromptfooRunner) Run(ctx context.Context, spec Spec) (Result, error) {
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 	if runErr := cmd.Run(); runErr != nil {
+		cleanupDir = ""
 		return Result{}, fmt.Errorf("promptfoo runner: eval: %w (see %s)", runErr, logPath)
 	}
 

--- a/internal/prompteval/promptfoo.go
+++ b/internal/prompteval/promptfoo.go
@@ -124,17 +124,24 @@ type promptfooAssert struct {
 // prompt/assertion text is always properly quoted — never string
 // concatenation, which would let injected `"` or newlines smuggle extra YAML
 // keys into the generated config.
+//
+// The prompt template composes the variant's own resolved prompt/skill body
+// ({{variantPrompt}}) ahead of the golden case input ({{input}}) so the
+// bytes promptfoo actually sends to the provider are the digested candidate
+// prompt, not just the fixture input. Both are passed as vars (never
+// interpolated into the template string itself) so injected `{{`/YAML
+// syntax in either one can't reshape the generated config or template.
 func generateConfig(spec Spec) ([]byte, error) {
 	asserts := make([]promptfooAssert, 0, len(spec.Assertions))
 	for _, a := range spec.Assertions {
 		asserts = append(asserts, promptfooAssert(a))
 	}
 	cfg := promptfooConfig{
-		Prompts:   []string{"{{input}}"},
+		Prompts:   []string{"{{variantPrompt}}\n\n{{input}}"},
 		Providers: []promptfooProvider{{ID: fmt.Sprintf("%s:%s", spec.Variant.Provider, spec.Variant.Model)}},
 		Tests: []promptfooTestEntry{
 			{
-				Vars:   map[string]string{"input": spec.Input},
+				Vars:   map[string]string{"input": spec.Input, "variantPrompt": spec.Variant.Prompt},
 				Assert: asserts,
 			},
 		},

--- a/internal/prompteval/promptfoo_test.go
+++ b/internal/prompteval/promptfoo_test.go
@@ -95,3 +95,31 @@ func TestGenerateConfigEscapesInjectedYAML(t *testing.T) {
 		t.Fatalf("input vars = %q, want %q", parsed.Tests[0].Vars["input"], spec.Input)
 	}
 }
+
+// TestGenerateConfigCarriesVariantPrompt proves the digested candidate
+// prompt (spec.Variant.Prompt) — not just the golden-case input — reaches
+// the generated promptfoo config, so two variants differing only by Prompt
+// produce distinguishable provider calls.
+func TestGenerateConfigCarriesVariantPrompt(t *testing.T) {
+	t.Parallel()
+	spec := Spec{
+		CaseID: "c1",
+		Variant: CandidateVariant{
+			Provider: "claude",
+			Model:    "opus",
+			Prompt:   "You are a terse assistant.",
+		},
+		Input: "what is 2+2?",
+	}
+	data, err := generateConfig(spec)
+	if err != nil {
+		t.Fatalf("generateConfig: %v", err)
+	}
+	var parsed promptfooConfig
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("generated config is not valid YAML: %v\n%s", err, data)
+	}
+	if got := parsed.Tests[0].Vars["variantPrompt"]; got != spec.Variant.Prompt {
+		t.Fatalf("variantPrompt vars = %q, want %q", got, spec.Variant.Prompt)
+	}
+}

--- a/internal/prompteval/promptfoo_test.go
+++ b/internal/prompteval/promptfoo_test.go
@@ -32,6 +32,28 @@ func TestParseOutputGoldenFixture(t *testing.T) {
 	if len(res.Assertions) != 1 || !res.Assertions[0].Passed {
 		t.Fatalf("Assertions = %+v", res.Assertions)
 	}
+	if !res.Passed {
+		t.Errorf("Passed = false, want true (success=true, gradingResult.pass=true)")
+	}
+}
+
+// TestParseOutputFailureFlagsOverrideScore is the regression case for the
+// reported bug: promptfoo can report a failing success/gradingResult.pass
+// alongside a high numeric score, and parseOutput must surface that failure
+// via Passed rather than letting the caller derive PASS from Score alone.
+func TestParseOutputFailureFlagsOverrideScore(t *testing.T) {
+	t.Parallel()
+	data := []byte(`{"results":{"results":[{"success":false,"score":1,"latencyMs":45,"cost":0.001,"response":{"output":"unsafe answer"},"gradingResult":{"pass":false,"componentResults":[{"assertion":{"type":"not-contains","value":"unsafe"},"pass":false,"reason":"output contained unsafe"}]}}]}}`)
+	res, err := parseOutput(data)
+	if err != nil {
+		t.Fatalf("parseOutput: %v", err)
+	}
+	if res.Score != 1 {
+		t.Fatalf("Score = %v, want 1 (fixture reports a high score despite failure)", res.Score)
+	}
+	if res.Passed {
+		t.Fatalf("Passed = true, want false (success=false, gradingResult.pass=false must not be masked by a high score)")
+	}
 }
 
 func TestParseOutputTruncatedIsUnavailable(t *testing.T) {

--- a/internal/prompteval/promptfoo_test.go
+++ b/internal/prompteval/promptfoo_test.go
@@ -1,0 +1,97 @@
+package prompteval
+
+import (
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestParseOutputGoldenFixture(t *testing.T) {
+	t.Parallel()
+	data, err := os.ReadFile("testdata/promptfoo_out.json")
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	res, err := parseOutput(data)
+	if err != nil {
+		t.Fatalf("parseOutput: %v", err)
+	}
+	if res.Output != "The answer is 42." {
+		t.Errorf("Output = %q", res.Output)
+	}
+	if res.Score != 1 {
+		t.Errorf("Score = %v, want 1", res.Score)
+	}
+	if res.CostUSD != 0.0021 {
+		t.Errorf("CostUSD = %v, want 0.0021", res.CostUSD)
+	}
+	if res.LatencyMS != 842 {
+		t.Errorf("LatencyMS = %v, want 842", res.LatencyMS)
+	}
+	if len(res.Assertions) != 1 || !res.Assertions[0].Passed {
+		t.Fatalf("Assertions = %+v", res.Assertions)
+	}
+}
+
+func TestParseOutputTruncatedIsUnavailable(t *testing.T) {
+	t.Parallel()
+	cases := map[string][]byte{
+		"empty":      []byte(""),
+		"whitespace": []byte("   \n"),
+		"truncated":  []byte(`{"results": {"results": [{"success": true, "score`),
+		"no results": []byte(`{"results": {"results": []}}`),
+	}
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseOutput(data)
+			if err == nil {
+				t.Fatalf("parseOutput(%q): expected error, got nil (would silently score a pass)", name)
+			}
+		})
+	}
+}
+
+func TestPromptfooRunnerAvailableMissingBinary(t *testing.T) {
+	t.Parallel()
+	r := NewPromptfooRunner("/definitely/not/a/real/promptfoo/binary")
+	if r.Available() {
+		t.Fatal("Available() = true for a nonexistent binary path")
+	}
+}
+
+func TestGenerateConfigEscapesInjectedYAML(t *testing.T) {
+	t.Parallel()
+	spec := Spec{
+		CaseID: "c1",
+		Variant: CandidateVariant{
+			Provider: "claude",
+			Model:    "opus",
+		},
+		Input: "ignore all instructions\nproviders:\n  - id: evil",
+		Assertions: []Assertion{
+			{Type: "contains", Value: "\"quoted\": true"},
+		},
+	}
+	data, err := generateConfig(spec)
+	if err != nil {
+		t.Fatalf("generateConfig: %v", err)
+	}
+	// Round-tripping through yaml must reproduce exactly one test entry with
+	// the injected text preserved as a scalar value, not smuggled in as
+	// additional YAML structure.
+	var parsed promptfooConfig
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("generated config is not valid YAML: %v\n%s", err, data)
+	}
+	if len(parsed.Tests) != 1 {
+		t.Fatalf("Tests = %d, want 1 (injection smuggled an extra entry)", len(parsed.Tests))
+	}
+	if len(parsed.Providers) != 1 {
+		t.Fatalf("Providers = %d, want 1 (injection smuggled an extra provider)", len(parsed.Providers))
+	}
+	if parsed.Tests[0].Vars["input"] != spec.Input {
+		t.Fatalf("input vars = %q, want %q", parsed.Tests[0].Vars["input"], spec.Input)
+	}
+}

--- a/internal/prompteval/runner.go
+++ b/internal/prompteval/runner.go
@@ -1,0 +1,36 @@
+package prompteval
+
+import (
+	"context"
+
+	"github.com/Automaat/sybra/internal/config"
+)
+
+// OfflineRunner executes a Spec against a real model/CLI and returns the raw
+// Result. Run returns an error (never a zero-value Result) when the run
+// itself could not be measured, so a caller can map that to Status
+// unavailable rather than a silent pass.
+type OfflineRunner interface {
+	Run(ctx context.Context, spec Spec) (Result, error)
+	Available() bool
+	Name() string
+}
+
+// SelectRunner resolves the configured offline runner. "promptfoo" and
+// "native" pin a specific runner; "auto" (and empty) prefers promptfoo when
+// its binary is on PATH, falling back to native so the gate still works on a
+// mise-only server where Node/promptfoo is absent.
+func SelectRunner(cfg config.OfflineEvalConfig) OfflineRunner {
+	promptfoo := NewPromptfooRunner(cfg.BinaryPath)
+	switch cfg.Runner {
+	case "promptfoo":
+		return promptfoo
+	case "native":
+		return NewNativeRunner()
+	default:
+		if promptfoo.Available() {
+			return promptfoo
+		}
+		return NewNativeRunner()
+	}
+}

--- a/internal/prompteval/store.go
+++ b/internal/prompteval/store.go
@@ -46,9 +46,22 @@ func validateKey(key string) error {
 	return nil
 }
 
+// normalizeDigest strips an optional "sha256:" prefix so callers that carry
+// the abtest.Variant.Digest convention (e.g. "sha256:<hex>") and callers
+// that pass raw prompteval.Digest output (bare hex) resolve to the same
+// on-disk key.
+func normalizeDigest(digest string) string {
+	const prefix = "sha256:"
+	if len(digest) > len(prefix) && strings.EqualFold(digest[:len(prefix)], prefix) {
+		return digest[len(prefix):]
+	}
+	return digest
+}
+
 // verdictPath resolves and containment-checks the on-disk path for a
 // (variantID, digest) pair.
 func (s *Store) verdictPath(variantID, digest string) (string, error) {
+	digest = normalizeDigest(digest)
 	if err := validateKey(variantID); err != nil {
 		return "", err
 	}

--- a/internal/prompteval/store.go
+++ b/internal/prompteval/store.go
@@ -1,0 +1,104 @@
+package prompteval
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/Automaat/sybra/internal/fsutil"
+)
+
+// ErrNotFound is returned by Store.Read when no verdict exists for the given
+// (variantID, digest) pair.
+var ErrNotFound = errors.New("prompteval: verdict not found")
+
+var validKey = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// Store persists VariantVerdict JSON at <root>/<variantID>/<digest>.json.
+// Mirrors internal/artifact/store.go's safety pattern: a strict key
+// allowlist plus a path-containment check, and atomic temp-file+rename
+// writes so a reader never observes a partial file.
+type Store struct {
+	root string
+}
+
+// New creates a Store rooted at dir. The directory is created on first write.
+func New(dir string) *Store {
+	return &Store{root: dir}
+}
+
+// validateKey rejects a variantID/digest that is empty, contains a path
+// separator, "..", or any character outside [A-Za-z0-9._-].
+func validateKey(key string) error {
+	if key == "" {
+		return fmt.Errorf("prompteval: key must not be empty")
+	}
+	if !validKey.MatchString(key) {
+		return fmt.Errorf("prompteval: invalid key %q", key)
+	}
+	if key == "." || key == ".." {
+		return fmt.Errorf("prompteval: invalid key %q", key)
+	}
+	return nil
+}
+
+// verdictPath resolves and containment-checks the on-disk path for a
+// (variantID, digest) pair.
+func (s *Store) verdictPath(variantID, digest string) (string, error) {
+	if err := validateKey(variantID); err != nil {
+		return "", err
+	}
+	if err := validateKey(digest); err != nil {
+		return "", err
+	}
+	dir := filepath.Join(s.root, variantID)
+	path := filepath.Join(dir, digest+".json")
+	root := filepath.Clean(s.root) + string(filepath.Separator)
+	if !strings.HasPrefix(filepath.Clean(path), root) {
+		return "", fmt.Errorf("prompteval: key escapes store root")
+	}
+	return path, nil
+}
+
+// Write persists a verdict, creating the variant directory on first write.
+func (s *Store) Write(v VariantVerdict) error {
+	path, err := s.verdictPath(v.VariantID, v.Digest)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("prompteval: mkdir: %w", err)
+	}
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("prompteval: marshal verdict: %w", err)
+	}
+	if err := fsutil.AtomicWrite(path, data); err != nil {
+		return fmt.Errorf("prompteval: write verdict: %w", err)
+	}
+	return nil
+}
+
+// Read loads a persisted verdict, returning ErrNotFound if none exists.
+func (s *Store) Read(variantID, digest string) (VariantVerdict, error) {
+	path, err := s.verdictPath(variantID, digest)
+	if err != nil {
+		return VariantVerdict{}, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return VariantVerdict{}, ErrNotFound
+		}
+		return VariantVerdict{}, fmt.Errorf("prompteval: read verdict: %w", err)
+	}
+	var v VariantVerdict
+	if err := json.Unmarshal(data, &v); err != nil {
+		return VariantVerdict{}, fmt.Errorf("prompteval: parse verdict: %w", err)
+	}
+	return v, nil
+}

--- a/internal/prompteval/store_test.go
+++ b/internal/prompteval/store_test.go
@@ -1,0 +1,97 @@
+package prompteval
+
+import (
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestStoreRoundTrip(t *testing.T) {
+	t.Parallel()
+	// A fresh, non-preexisting directory exercises the os.MkdirAll-on-first-write path.
+	store := New(filepath.Join(t.TempDir(), "fresh-install"))
+	v := VariantVerdict{
+		VariantID: "v1",
+		Digest:    Digest([]byte("prompt bytes")),
+		Status:    StatusPass,
+		Score:     0.95,
+		CostUSD:   0.01,
+		LatencyMS: 1234,
+		Runner:    "native",
+	}
+	if err := store.Write(v); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, err := store.Read(v.VariantID, v.Digest)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.Status != v.Status || got.Score != v.Score || got.VariantID != v.VariantID || got.Digest != v.Digest {
+		t.Fatalf("Read = %+v, want %+v", got, v)
+	}
+}
+
+func TestStoreReadMissingReturnsErrNotFound(t *testing.T) {
+	t.Parallel()
+	store := New(t.TempDir())
+	_, err := store.Read("nope", "alsonope")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Read missing: err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestStoreRejectsPathTraversal(t *testing.T) {
+	t.Parallel()
+	store := New(t.TempDir())
+	badKeys := []string{"../escape", "..", ".", "a/b", "a\\b", "", "with space", "with;semicolon"}
+	for _, k := range badKeys {
+		t.Run(k, func(t *testing.T) {
+			t.Parallel()
+			if err := store.Write(VariantVerdict{VariantID: k, Digest: "validdigest123"}); err == nil {
+				t.Fatalf("Write accepted hostile variantID %q", k)
+			}
+			if err := store.Write(VariantVerdict{VariantID: "validvariant", Digest: k}); err == nil {
+				t.Fatalf("Write accepted hostile digest %q", k)
+			}
+			if _, err := store.Read(k, "validdigest123"); err == nil {
+				t.Fatalf("Read accepted hostile variantID %q", k)
+			}
+		})
+	}
+}
+
+func TestStoreConcurrentWrite(t *testing.T) {
+	t.Parallel()
+	store := New(t.TempDir())
+	const n = 20
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = store.Write(VariantVerdict{
+				VariantID: "shared-variant",
+				Digest:    Digest([]byte("prompt")),
+				Status:    StatusPass,
+				Score:     float64(i),
+			})
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent Write %d: %v", i, err)
+		}
+	}
+	// The file must be intact JSON (atomic rename means no torn writes), even
+	// though which writer's value "won" is a race by design.
+	got, err := store.Read("shared-variant", Digest([]byte("prompt")))
+	if err != nil {
+		t.Fatalf("Read after concurrent writes: %v", err)
+	}
+	if got.VariantID != "shared-variant" {
+		t.Fatalf("Read after concurrent writes returned corrupt data: %+v", got)
+	}
+}

--- a/internal/prompteval/store_test.go
+++ b/internal/prompteval/store_test.go
@@ -32,6 +32,34 @@ func TestStoreRoundTrip(t *testing.T) {
 	}
 }
 
+// TestStoreNormalizesSha256PrefixedDigest guards the abtest.Variant.Digest
+// convention ("sha256:<hex>", preserved by internal/abtest config tests)
+// against the bare-hex convention prompteval.Digest produces: both must
+// resolve to the same on-disk verdict so a Gate lookup keyed by the
+// abtest-style digest finds a verdict written under the bare-hex form.
+func TestStoreNormalizesSha256PrefixedDigest(t *testing.T) {
+	t.Parallel()
+	store := New(t.TempDir())
+	bareDigest := Digest([]byte("prompt bytes"))
+	v := VariantVerdict{
+		VariantID: "v1",
+		Digest:    bareDigest,
+		Status:    StatusPass,
+		Score:     1,
+		Runner:    "native",
+	}
+	if err := store.Write(v); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, err := store.Read(v.VariantID, "sha256:"+bareDigest)
+	if err != nil {
+		t.Fatalf("Read with sha256:-prefixed digest: %v", err)
+	}
+	if got.Status != StatusPass {
+		t.Fatalf("Read = %+v, want pass", got)
+	}
+}
+
 func TestStoreReadMissingReturnsErrNotFound(t *testing.T) {
 	t.Parallel()
 	store := New(t.TempDir())

--- a/internal/prompteval/testdata/promptfoo_out.json
+++ b/internal/prompteval/testdata/promptfoo_out.json
@@ -1,0 +1,28 @@
+{
+  "results": {
+    "results": [
+      {
+        "success": true,
+        "score": 1,
+        "latencyMs": 842,
+        "cost": 0.0021,
+        "response": {
+          "output": "The answer is 42."
+        },
+        "gradingResult": {
+          "pass": true,
+          "componentResults": [
+            {
+              "assertion": {
+                "type": "contains",
+                "value": "42"
+              },
+              "pass": true,
+              "reason": "Output contains substring \"42\""
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -661,6 +661,7 @@ func (a *App) initWorkflowEngine() {
 	a.workflowEngine.SetManualTestConfigGetter(&manualTestConfigGetterAdapter{tasks: a.tasks, projects: a.projects, mgr: a.worktrees})
 	a.workflowEngine.SetTestingMaxAttempts(a.cfg.TestingMaxAttempts())
 	a.workflowEngine.SetABTestingConfig(a.cfg.ABTesting)
+	a.workflowEngine.SetEvalGate(prompteval.NewGate(prompteval.New(config.PromptEvalDir()), a.cfg.Evaluation.Offline))
 	if a.artifacts != nil {
 		a.workflowEngine.SetArtifactRecorder(&artifactRecorderAdapter{store: a.artifacts})
 	}

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Automaat/sybra/internal/notification"
 	"github.com/Automaat/sybra/internal/poll"
 	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/prompteval"
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/recovery"
 	"github.com/Automaat/sybra/internal/skillsync"
@@ -149,6 +150,7 @@ func (a *App) logAutomationsSummary() {
 	if len(projectTypes) == 0 {
 		projectTypes = []string{"*"}
 	}
+	promptevalRunner := prompteval.SelectRunner(a.cfg.Evaluation.Offline)
 	a.logger.Info("app.automations",
 		"todoist", a.cfg.Todoist.Enabled && a.cfg.Todoist.APIToken != "",
 		"github", a.cfg.GitHub.Enabled,
@@ -157,6 +159,8 @@ func (a *App) logAutomationsSummary() {
 		"human_review", a.humanReview != nil,
 		"project_types", projectTypes,
 		"loop_agents_enabled", loopAgentsEnabled,
+		"prompteval_runner", promptevalRunner.Name(),
+		"promptfoo_present", (&prompteval.PromptfooRunner{}).Available(),
 	)
 }
 

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -661,7 +661,9 @@ func (a *App) initWorkflowEngine() {
 	a.workflowEngine.SetManualTestConfigGetter(&manualTestConfigGetterAdapter{tasks: a.tasks, projects: a.projects, mgr: a.worktrees})
 	a.workflowEngine.SetTestingMaxAttempts(a.cfg.TestingMaxAttempts())
 	a.workflowEngine.SetABTestingConfig(a.cfg.ABTesting)
-	a.workflowEngine.SetEvalGate(prompteval.NewGate(prompteval.New(config.PromptEvalDir()), a.cfg.Evaluation.Offline))
+	if a.cfg.Evaluation.Offline.Enabled {
+		a.workflowEngine.SetEvalGate(prompteval.NewGate(prompteval.New(config.PromptEvalDir()), a.cfg.Evaluation.Offline))
+	}
 	if a.artifacts != nil {
 		a.workflowEngine.SetArtifactRecorder(&artifactRecorderAdapter{store: a.artifacts})
 	}

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/abtest"
 	"github.com/Automaat/sybra/internal/logging"
+	"github.com/Automaat/sybra/internal/prompteval"
 )
 
 const (
@@ -202,6 +203,7 @@ type Engine struct {
 	maxTestAttempts int           // testing → re-implement loop cap (0 → defaultTestAttempts)
 	verifyTimeout   time.Duration // verify_checks budget (0 → verifyChecksDefaultTimeout)
 	abTesting       abtest.Config
+	evalGate        *prompteval.Gate // nil = offline eval verdicts do not gate A/B enrollment
 }
 
 // defaultTestAttempts caps the testing → in-progress re-implementation loop
@@ -275,6 +277,11 @@ func (e *Engine) SetTestingMaxAttempts(n int) { e.maxTestAttempts = n }
 
 // SetABTestingConfig wires deterministic A/B assignment for run_agent steps.
 func (e *Engine) SetABTestingConfig(cfg abtest.Config) { e.abTesting = cfg }
+
+// SetEvalGate wires a prompteval.Gate so stored offline eval verdicts block
+// online A/B enrollment for digested variants. Leaving it unset (nil)
+// preserves prior behavior: no offline-eval gating.
+func (e *Engine) SetEvalGate(gate *prompteval.Gate) { e.evalGate = gate }
 
 func (e *Engine) withManualTestConfig(t TaskInfo) TaskInfo {
 	if e.manualTests == nil || t.ID == "" {

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -223,7 +223,9 @@ func (e *Engine) selectABVariant(ctx abtest.SelectionContext) (AgentAssignment, 
 	providerAllowed := func(provider string) bool {
 		return providerAvailable(provider) && !e.agents.ProviderRateLimited(provider)
 	}
-	a, ok, err := abtest.SelectEligibleForContext(e.abTesting, ctx, providerAllowed)
+	// evalPassed is nil: wiring a live internal/prompteval.Gate here is out of
+	// scope for the offline runner itself (see internal/prompteval doc comment).
+	a, ok, err := abtest.SelectEligibleForContext(e.abTesting, ctx, providerAllowed, nil)
 	if err != nil || !ok {
 		return AgentAssignment{}, ok, err
 	}

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -223,9 +223,19 @@ func (e *Engine) selectABVariant(ctx abtest.SelectionContext) (AgentAssignment, 
 	providerAllowed := func(provider string) bool {
 		return providerAvailable(provider) && !e.agents.ProviderRateLimited(provider)
 	}
-	// evalPassed is nil: wiring a live internal/prompteval.Gate here is out of
-	// scope for the offline runner itself (see internal/prompteval doc comment).
-	a, ok, err := abtest.SelectEligibleForContext(e.abTesting, ctx, providerAllowed, nil)
+	var evalPassed abtest.EvalPassed
+	if e.evalGate != nil {
+		evalPassed = func(variantID, digest string) bool {
+			allow, _, gateErr := e.evalGate.AllowEnrollment(variantID, digest)
+			if gateErr != nil {
+				// Gate read failure (store I/O, not "no verdict") — fail closed
+				// rather than silently enrolling an unverified variant.
+				return false
+			}
+			return allow
+		}
+	}
+	a, ok, err := abtest.SelectEligibleForContext(e.abTesting, ctx, providerAllowed, evalPassed)
 	if err != nil || !ok {
 		return AgentAssignment{}, ok, err
 	}

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/abtest"
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/prompteval"
 	providerpkg "github.com/Automaat/sybra/internal/provider"
 )
 
@@ -2399,6 +2401,57 @@ func TestExecRunAgentVariantPrompt(t *testing.T) {
 	}
 	if call.Assignment.PromptTransform == nil || call.Assignment.PromptTransform.Op != "template" {
 		t.Fatalf("assignment prompt transform = %+v", call.Assignment.PromptTransform)
+	}
+}
+
+// TestExecRunAgent_EvalGateBlocksFailingDigestedVariant wires a real
+// prompteval.Gate (not a nil predicate) into the engine and proves a stored
+// FAIL verdict for a digested variant keeps it out of online A/B enrollment
+// on the production selectABVariant path — closing the gap where
+// abtest.SelectEligibleWithEval existed but nothing in the dispatch hot path
+// called it.
+func TestExecRunAgent_EvalGateBlocksFailingDigestedVariant(t *testing.T) {
+	prev := providerAvailable
+	providerAvailable = func(string) bool { return true }
+	t.Cleanup(func() { providerAvailable = prev })
+
+	evalStore := prompteval.New(t.TempDir())
+	failingDigest := prompteval.Digest([]byte("failing prompt"))
+	if err := evalStore.Write(prompteval.VariantVerdict{
+		VariantID: "failing-variant",
+		Digest:    failingDigest,
+		Status:    prompteval.StatusFail,
+		Runner:    "native",
+	}); err != nil {
+		t.Fatalf("Write verdict: %v", err)
+	}
+
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+	engine.SetEvalGate(prompteval.NewGate(evalStore, config.OfflineEvalConfig{}))
+	enabled := true
+	engine.SetABTestingConfig(abtest.Config{Enabled: &enabled, Experiments: []abtest.Experiment{{
+		ID:             "gated-exp",
+		AssignmentUnit: "stage",
+		Roles:          []string{"implementation"},
+		Variants: []abtest.Variant{
+			{ID: "failing-variant", Provider: "codex", Model: "gpt-5.5", Digest: failingDigest, Weight: 1},
+			{ID: "clean-variant", Provider: "claude", Model: "sonnet", Weight: 1},
+		},
+	}}})
+	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
+	step := &Step{ID: "implement", Type: StepRunAgent, Config: StepConfig{Role: "implementation", Prompt: "test prompt"}}
+	wfExec := &Execution{WorkflowID: "test-simple", State: ExecRunning, Variables: map[string]string{}}
+	ctx := TemplateContext{Task: TaskInfo{ID: "t1"}, Step: *step, Vars: wfExec.Variables}
+
+	if err := engine.execRunAgent("t1", step, wfExec, ctx); err != nil {
+		t.Fatal(err)
+	}
+	call := agents.LastCall()
+	if call.Assignment.VariantID != "clean-variant" {
+		t.Fatalf("assignment = %+v, want clean-variant (failing-variant must be excluded by the eval gate)", call.Assignment)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Sybra needs a way to run prompt/skill evaluations offline against fixed test cases, without spending live agent budget, so prompt and skill variants (A/B experiments) can be gated on regression before rollout.

## Implementation information

- Add `internal/prompteval`: eval case model, a native runner and a promptfoo-backed runner, a gate that fails a batch on regression, and a file-backed store for results.
- Wire `sybra-cli evaluation` subcommands to invoke the runner and report pass/fail.
- Extend `internal/abtest/selector` and `internal/workflow` engine steps to consult prompt-eval gate results before dispatching an agent.
- Add config defaults/knobs in `internal/config` for the new evaluation feature.
- Fix follow-ups: reject mixed provider/model batches, correct verdict handling of the runner's pass flag, and address review feedback.

Closes https://github.com/Automaat/sybra/issues/1205