### PR TITLE
fix(monitor): plan-review waits for human review

### DIFF
--- a/internal/monitor/detector.go
+++ b/internal/monitor/detector.go
@@ -155,7 +155,10 @@ func detectUntriaged(t *task.Task, now time.Time) *Anomaly {
 }
 
 func detectStuckHumanBlocked(t *task.Task, now time.Time, budget time.Duration) *Anomaly {
-	if t.Status != task.StatusPlanReview && t.Status != task.StatusHumanRequired {
+	// plan-review is intentionally excluded: a plan awaits the human's approval
+	// indefinitely and must never be auto-escalated to human-required. Only tasks
+	// already in human-required are flagged when they exceed their dwell budget.
+	if t.Status != task.StatusHumanRequired {
 		return nil
 	}
 	dwell := now.Sub(t.UpdatedAt)
@@ -190,9 +193,10 @@ func detectStuckHumanBlocked(t *task.Task, now time.Time, budget time.Duration) 
 			ev["human_review_verdict"] = verdict
 		}
 	}
-	// plan-review is always deterministic: human must approve or reject the plan.
-	// For human-required, skip LLM only when human-review confirmed verdict=human.
-	requiresLLM := t.Status != task.StatusPlanReview && ev["human_review_verdict"] != "human"
+	// Skip the LLM only when human-review already confirmed verdict=human;
+	// otherwise an LLM investigates whether the block is a real human need or a
+	// Sybra misfire.
+	requiresLLM := ev["human_review_verdict"] != "human"
 	return &Anomaly{
 		Kind:        KindStuckHumanBlocked,
 		TaskID:      t.ID,

--- a/internal/monitor/detector_test.go
+++ b/internal/monitor/detector_test.go
@@ -141,10 +141,21 @@ func TestDetect(t *testing.T) {
 			want: []AnomalyKind{KindUntriaged},
 		},
 		{
-			name: "stuck_human_blocked on plan-review past budget",
+			name: "plan-review past budget is NOT flagged — waits indefinitely for human",
 			in: DetectInput{
 				Now: now,
 				Tasks: []task.Task{mkTask("a", task.StatusPlanReview, func(t *task.Task) {
+					t.UpdatedAt = now.Add(-9 * time.Hour)
+				})},
+				Cfg: cfg,
+			},
+			want: nil,
+		},
+		{
+			name: "stuck_human_blocked on human-required past budget",
+			in: DetectInput{
+				Now: now,
+				Tasks: []task.Task{mkTask("a", task.StatusHumanRequired, func(t *task.Task) {
 					t.UpdatedAt = now.Add(-9 * time.Hour)
 				})},
 				Cfg: cfg,
@@ -801,17 +812,16 @@ func TestDetectStuckHumanBlocked_RequiresLLM(t *testing.T) {
 	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
 	cfg := defaultCfg()
 
-	t.Run("RequiresLLM=false when status is plan-review", func(t *testing.T) {
+	t.Run("plan-review is never flagged, regardless of dwell", func(t *testing.T) {
 		tk := mkTask("a", task.StatusPlanReview, func(t *task.Task) {
 			t.UpdatedAt = now.Add(-9 * time.Hour)
 		})
 		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}
 		report := Detect(in)
-		if len(report.Anomalies) != 1 {
-			t.Fatalf("want 1 anomaly, got %d", len(report.Anomalies))
-		}
-		if report.Anomalies[0].RequiresLLM {
-			t.Error("RequiresLLM must be false for plan-review — action is deterministic")
+		for _, a := range report.Anomalies {
+			if a.Kind == KindStuckHumanBlocked {
+				t.Fatal("plan-review must not produce a stuck_human_blocked anomaly — it waits indefinitely")
+			}
 		}
 	})
 
@@ -936,8 +946,10 @@ func TestDetectStuckHumanBlocked_RequiresLLM(t *testing.T) {
 			t.UpdatedAt = now.Add(-9 * time.Hour)
 			t.AgentRuns = []task.AgentRun{
 				{AgentID: "rev1", Role: "human-review", State: "stopped", Verdict: "human"},
-				{AgentID: "rev2", Role: "human-review", State: "stopped",
-					Result: "API Error: 529 Overloaded."},
+				{
+					AgentID: "rev2", Role: "human-review", State: "stopped",
+					Result: "API Error: 529 Overloaded.",
+				},
 			}
 		})
 		in := DetectInput{Now: now, Tasks: []task.Task{tk}, Cfg: cfg}

--- a/internal/monitor/prompts.go
+++ b/internal/monitor/prompts.go
@@ -7,8 +7,6 @@ import (
 	"slices"
 	"strings"
 	"time"
-
-	"github.com/Automaat/sybra/internal/task"
 )
 
 // DeterministicIssueBody renders the issue body the IssueSink files for
@@ -60,7 +58,8 @@ func prGapPrompt(a Anomaly, pushRemote string) string {
 	if pushRemote == "" {
 		pushRemote = "origin"
 	}
-	return fmt.Sprintf(`You are the sybra monitor PR-gap remediator.
+	return fmt.Sprintf(
+		`You are the sybra monitor PR-gap remediator.
 
 Task: %s — %q
 This task is in 'in-review' but has no PR number recorded.
@@ -137,7 +136,8 @@ func stuckPrompt(a Anomaly, issueRepo string) string {
 			doneCmd
 	}
 
-	return fmt.Sprintf(`You are the sybra monitor stuck-task investigator.
+	return fmt.Sprintf(
+		`You are the sybra monitor stuck-task investigator.
 
 Task: %s — %q
 Status: %s   Dwell: %.1fh
@@ -164,7 +164,8 @@ Output exactly one final JSON line:
 func failureSpikePrompt(a Anomaly, issueRepo string) string {
 	rate, _ := a.Evidence["failure_rate"].(float64)
 	runs, _ := a.Evidence["agent_runs"].(int)
-	return fmt.Sprintf(`You are the sybra monitor failure-spike investigator.
+	return fmt.Sprintf(
+		`You are the sybra monitor failure-spike investigator.
 
 Audit summary (last 1h):
   failure_rate=%.2f  agent_runs=%d
@@ -191,7 +192,8 @@ func bottleneckPrompt(a Anomaly, issueRepo string) string {
 	status, _ := a.Evidence["status"].(string)
 	dwell, _ := a.Evidence["dwell_h"].(float64)
 	threshold, _ := a.Evidence["threshold"].(float64)
-	return fmt.Sprintf(`You are the sybra monitor bottleneck investigator.
+	return fmt.Sprintf(
+		`You are the sybra monitor bottleneck investigator.
 
 Status %q has average dwell %.1fh, exceeding threshold %.1fh.
 
@@ -215,7 +217,8 @@ Output exactly one final JSON line:
 // investigatePrompt is the catch-all handler for kinds that have no specific
 // template — should never run today, but keeps DispatchPrompt total.
 func investigatePrompt(a Anomaly, issueRepo string) string {
-	return fmt.Sprintf(`You are the sybra monitor anomaly investigator.
+	return fmt.Sprintf(
+		`You are the sybra monitor anomaly investigator.
 
 Anomaly: %s
 Fingerprint: %s
@@ -248,9 +251,6 @@ func suggestedInvestigation(a Anomaly) string {
 	case KindUntriaged:
 		return "- Run `/sybra-triage` against the affected task to fill `agent_mode` and `tags`.\n"
 	case KindStuckHumanBlocked:
-		if status, _ := a.Evidence["status"].(string); status == string(task.StatusPlanReview) {
-			return "- Approve or reject the plan to advance the task.\n"
-		}
 		hint := "- Review the task file and `status_reason`, then provide the required human input to unblock progress.\n"
 		if reason, _ := a.Evidence["status_reason"].(string); reason != "" {
 			hint += "- Blocking reason: " + reason + "\n"

--- a/internal/monitor/prompts_test.go
+++ b/internal/monitor/prompts_test.go
@@ -7,38 +7,6 @@ import (
 	"time"
 )
 
-func TestDeterministicIssueBody_StuckHumanBlocked_PlanReview(t *testing.T) {
-	a := Anomaly{
-		Kind:        KindStuckHumanBlocked,
-		TaskID:      "abc123",
-		Severity:    SeverityWarn,
-		Fingerprint: "stuck_human_blocked:abc123",
-		DetectedAt:  time.Date(2026, 5, 14, 9, 0, 0, 0, time.UTC),
-		Evidence: map[string]any{
-			"task_id": "abc123",
-			"status":  "plan-review",
-			"dwell_h": 8.5,
-		},
-	}
-
-	body := DeterministicIssueBody(a)
-
-	if !strings.Contains(body, "stuck_human_blocked") {
-		t.Error("body missing kind")
-	}
-	if !strings.Contains(body, "abc123") {
-		t.Error("body missing task id")
-	}
-	// Must NOT reference "dispatched agent's issue comment" — for work-typed
-	// downgraded anomalies no agent is dispatched and no GH issue is filed.
-	if strings.Contains(body, "dispatched agent") {
-		t.Error("body must not mention dispatched agent for stuck_human_blocked")
-	}
-	if !strings.Contains(body, "Approve or reject the plan") {
-		t.Error("plan-review hint missing")
-	}
-}
-
 func TestDeterministicIssueBody_StuckHumanBlocked_HumanRequired(t *testing.T) {
 	a := Anomaly{
 		Kind:        KindStuckHumanBlocked,

--- a/internal/monitor/remediator.go
+++ b/internal/monitor/remediator.go
@@ -36,13 +36,10 @@ func (r *remediator) Apply(_ context.Context, a Anomaly) (string, error) {
 	case KindUntriaged:
 		return r.tagUntriaged(a)
 	case KindStuckHumanBlocked:
-		if isPlanReviewStuck(a) {
-			return r.remediatePlanReviewStuck(a)
-		}
 		if isHumanRequiredStuck(a) {
 			return r.remediateHumanRequiredStuck(a)
 		}
-		return "", fmt.Errorf("remediator: stuck_human_blocked remediation requires plan-review or human-required status")
+		return "", fmt.Errorf("remediator: stuck_human_blocked remediation requires human-required status")
 	default:
 		return "", fmt.Errorf("remediator: kind %q has no in-process action", a.Kind)
 	}
@@ -84,23 +81,6 @@ func (r *remediator) tagUntriaged(a Anomaly) (string, error) {
 	return string(a.Kind) + ":" + a.TaskID, nil
 }
 
-// remediatePlanReviewStuck sets a plan-review stuck task to human-required
-// so it surfaces on the blocked queue without spawning a new meta-task.
-// Only called when isPlanReviewStuck(a) is true.
-func (r *remediator) remediatePlanReviewStuck(a Anomaly) (string, error) {
-	if a.TaskID == "" {
-		return "", fmt.Errorf("stuck_human_blocked without task id")
-	}
-	upd := task.Update{
-		Status:       task.Ptr(task.StatusHumanRequired),
-		StatusReason: task.Ptr("monitor: plan-review stalled"),
-	}
-	if _, err := r.tasks.Update(a.TaskID, upd); err != nil {
-		return "", fmt.Errorf("set plan-review task %s human-required: %w", a.TaskID, err)
-	}
-	return string(a.Kind) + ":" + a.TaskID, nil
-}
-
 // remediateHumanRequiredStuck refreshes the status reason on a task that is
 // already human-required and has exceeded its dwell budget. Updating the task
 // file stamps a new UpdatedAt, resetting the dwell timer and suppressing
@@ -115,18 +95,6 @@ func (r *remediator) remediateHumanRequiredStuck(a Anomaly) (string, error) {
 		return "", fmt.Errorf("tag human-required task %s stalled: %w", a.TaskID, err)
 	}
 	return string(a.Kind) + ":" + a.TaskID, nil
-}
-
-// isPlanReviewStuck reports whether a is a stuck_human_blocked anomaly for a
-// plan-review task. These are remediated in-process (task promoted to
-// human-required) and must not reach the issue sink, which would create a
-// redundant meta-task.
-func isPlanReviewStuck(a Anomaly) bool {
-	if a.Kind != KindStuckHumanBlocked {
-		return false
-	}
-	status, _ := a.Evidence["status"].(string)
-	return status == string(task.StatusPlanReview)
 }
 
 // isHumanRequiredStuck reports whether a is a stuck_human_blocked anomaly for

--- a/internal/monitor/remediator_test.go
+++ b/internal/monitor/remediator_test.go
@@ -75,7 +75,10 @@ func TestRemediator_LostAgent_NoRunningRun_SkipsRunUpdate(t *testing.T) {
 	}
 }
 
-func TestRemediator_PlanReviewStuck_SetsHumanRequired(t *testing.T) {
+// A plan-review task must wait indefinitely for the human — the remediator has
+// no plan-review action, so a plan-review-shaped anomaly is an error, never an
+// escalation to human-required.
+func TestRemediator_PlanReviewStuck_NotRemediated(t *testing.T) {
 	t.Parallel()
 	ft := &fakeTasks{tasks: []task.Task{
 		mkTask("pr1", task.StatusPlanReview),
@@ -88,25 +91,11 @@ func TestRemediator_PlanReviewStuck_SetsHumanRequired(t *testing.T) {
 			"status": "plan-review",
 		},
 	}
-	label, err := rem.Apply(context.Background(), a)
-	if err != nil {
-		t.Fatalf("Apply: %v", err)
+	if _, err := rem.Apply(context.Background(), a); err == nil {
+		t.Fatal("expected error: plan-review must not be remediated to human-required")
 	}
-	if label == "" {
-		t.Fatal("expected non-empty label")
-	}
-	if len(ft.updates) != 1 {
-		t.Fatalf("want 1 update, got %d", len(ft.updates))
-	}
-	u := ft.updates[0]
-	if u.id != "pr1" {
-		t.Errorf("updated wrong task: %q", u.id)
-	}
-	if u.u.Status == nil || *u.u.Status != task.StatusHumanRequired {
-		t.Errorf("status = %v, want human-required", u.u.Status)
-	}
-	if u.u.StatusReason == nil || *u.u.StatusReason == "" {
-		t.Error("status_reason should be set")
+	if len(ft.updates) != 0 {
+		t.Fatalf("want 0 updates (plan-review left untouched), got %d", len(ft.updates))
 	}
 }
 
@@ -165,43 +154,6 @@ func TestRemediator_StuckHumanBlocked_UnknownStatus_Errors(t *testing.T) {
 	}
 	if len(ft.updates) != 0 {
 		t.Fatalf("want 0 updates, got %d", len(ft.updates))
-	}
-}
-
-func TestIsPlanReviewStuck(t *testing.T) {
-	t.Parallel()
-	cases := []struct {
-		name string
-		a    Anomaly
-		want bool
-	}{
-		{
-			name: "plan-review stuck",
-			a:    Anomaly{Kind: KindStuckHumanBlocked, Evidence: map[string]any{"status": "plan-review"}},
-			want: true,
-		},
-		{
-			name: "human-required stuck",
-			a:    Anomaly{Kind: KindStuckHumanBlocked, Evidence: map[string]any{"status": "human-required"}},
-			want: false,
-		},
-		{
-			name: "different kind",
-			a:    Anomaly{Kind: KindLostAgent, Evidence: map[string]any{"status": "plan-review"}},
-			want: false,
-		},
-		{
-			name: "no evidence",
-			a:    Anomaly{Kind: KindStuckHumanBlocked},
-			want: false,
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := isPlanReviewStuck(tc.a); got != tc.want {
-				t.Errorf("isPlanReviewStuck = %v, want %v", got, tc.want)
-			}
-		})
 	}
 }
 

--- a/internal/monitor/service.go
+++ b/internal/monitor/service.go
@@ -145,7 +145,8 @@ func (s *Service) tickAndLog(ctx context.Context) {
 		s.logger.Warn("monitor.tick.failed", "err", err)
 		return
 	}
-	s.logger.Info("monitor.tick",
+	s.logger.Info(
+		"monitor.tick",
 		"in_progress", report.Counts.InProgress,
 		"todo", report.Counts.Todo,
 		"anomalies", len(report.Anomalies),
@@ -222,7 +223,8 @@ func (s *Service) logPRGapGraceSuppressions(tasks []task.Task, now time.Time) {
 		if dwell < 0 || dwell >= grace {
 			continue
 		}
-		s.logger.Debug("monitor.pr_gap.grace_suppressed",
+		s.logger.Debug(
+			"monitor.pr_gap.grace_suppressed",
 			"task_id", t.ID,
 			"updated_at", t.UpdatedAt.Format(time.RFC3339),
 			"grace", grace.String(),
@@ -291,7 +293,7 @@ func (s *Service) applyRemediations(ctx context.Context, anoms []Anomaly) []stri
 		if a.RequiresLLM {
 			continue
 		}
-		if a.Kind != KindLostAgent && a.Kind != KindUntriaged && !isPlanReviewStuck(a) && !isHumanRequiredStuck(a) {
+		if a.Kind != KindLostAgent && a.Kind != KindUntriaged && !isHumanRequiredStuck(a) {
 			continue
 		}
 		label, err := s.rem.Apply(ctx, a)
@@ -343,7 +345,7 @@ func (s *Service) fileIssues(ctx context.Context, now time.Time, anoms []Anomaly
 	cooldown := time.Duration(s.cfg.IssueCooldownMinutes) * time.Minute
 	for i := range anoms {
 		a := anoms[i]
-		if a.RequiresLLM || isPlanReviewStuck(a) || isHumanRequiredStuck(a) {
+		if a.RequiresLLM || isHumanRequiredStuck(a) {
 			continue
 		}
 		if !s.state.canIssue(a.Fingerprint, now, cooldown) {

--- a/internal/monitor/service.go
+++ b/internal/monitor/service.go
@@ -338,10 +338,6 @@ func (s *Service) dispatchLLMAnomalies(ctx context.Context, now time.Time, anoms
 // dispatched to an LLM (the dispatched ones file their own issue from the
 // agent prompt). Returns (opened, updated).
 func (s *Service) fileIssues(ctx context.Context, now time.Time, anoms []Anomaly, dispatched []string) (opened, updated int) {
-	dispatchedKinds := make(map[string]bool, len(dispatched))
-	for _, d := range dispatched {
-		dispatchedKinds[d] = true
-	}
 	cooldown := time.Duration(s.cfg.IssueCooldownMinutes) * time.Minute
 	for i := range anoms {
 		a := anoms[i]

--- a/internal/monitor/service_test.go
+++ b/internal/monitor/service_test.go
@@ -317,11 +317,12 @@ func TestServiceScanHasNoSideEffects(t *testing.T) {
 	}
 }
 
-func TestServiceTick_PlanReviewStuck_RemediatesDirectly(t *testing.T) {
+// A plan-review task, however long it dwells, must not be flagged, remediated,
+// dispatched, or filed — it waits indefinitely for the human's plan review.
+func TestServiceTick_PlanReviewStuck_NotFlagged(t *testing.T) {
 	now := time.Date(2026, 4, 14, 12, 0, 0, 0, time.UTC)
 	cfg := defaultCfg()
 	tasks := &fakeTasks{tasks: []task.Task{
-		// plan-review stuck: service must set it to human-required in-process.
 		mkTask("pr-stuck", task.StatusPlanReview, func(t *task.Task) {
 			t.UpdatedAt = now.Add(-9 * time.Hour)
 		}),
@@ -344,32 +345,19 @@ func TestServiceTick_PlanReviewStuck_RemediatesDirectly(t *testing.T) {
 		t.Fatalf("tick: %v", err)
 	}
 
-	if len(report.Anomalies) != 1 || report.Anomalies[0].Kind != KindStuckHumanBlocked {
-		t.Fatalf("want 1 stuck_human_blocked anomaly, got %v", report.Anomalies)
+	for _, a := range report.Anomalies {
+		if a.Kind == KindStuckHumanBlocked {
+			t.Fatalf("plan-review must not produce a stuck_human_blocked anomaly, got %v", report.Anomalies)
+		}
 	}
-
-	// Remediator must have set the task to human-required.
-	if len(tasks.updates) != 1 {
-		t.Fatalf("want 1 task update, got %d", len(tasks.updates))
+	if len(tasks.updates) != 0 {
+		t.Fatalf("plan-review must be left untouched, got %d task updates", len(tasks.updates))
 	}
-	u := tasks.updates[0]
-	if u.id != "pr-stuck" {
-		t.Errorf("updated wrong task: %q", u.id)
-	}
-	if u.u.Status == nil || *u.u.Status != task.StatusHumanRequired {
-		t.Errorf("status = %v, want human-required", u.u.Status)
-	}
-
-	// Sink must NOT receive the plan-review anomaly — no meta-task created.
 	if len(sink.submissions) != 0 {
-		t.Fatalf("sink must not see plan-review anomaly, got %d submissions", len(sink.submissions))
+		t.Fatalf("sink must not see plan-review, got %d submissions", len(sink.submissions))
 	}
 	if len(disp.calls) != 0 {
-		t.Fatalf("dispatcher must not be called for plan-review anomaly, got %d calls", len(disp.calls))
-	}
-
-	if len(report.Remediated) != 1 {
-		t.Fatalf("want 1 remediated, got %d", len(report.Remediated))
+		t.Fatalf("dispatcher must not be called for plan-review, got %d calls", len(disp.calls))
 	}
 }
 


### PR DESCRIPTION
## Motivation

The stall detector escalated plan-review tasks to human-required after a dwell budget elapsed, so plans piled up in the blocked queue instead of simply waiting on the human's approval. Plan-review is a queue that should wait indefinitely, not a stall condition.

## Implementation information

Excludes plan-review from `detectStuckHumanBlocked` so only tasks already in human-required are flagged past budget, and removes the now-unreachable plan-review remediation path (`remediatePlanReviewStuck`, `isPlanReviewStuck`) from the remediator. Updates detector/remediator/service tests and prompts accordingly.

_Generated by Sybra harness_