### PR TITLE
fix(reviews): coalesce per-PR fix dispatch

### DIFF
--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -840,16 +840,23 @@ func earliestRunStart(runs []task.AgentRun) time.Time {
 }
 
 // cancelResolvedPRFixWorkflows terminates any in-flight pr-fix workflow
-// whose originating PR issue (`pr_issue_kind` in workflow vars) is no
-// longer present on the live PR. Prevents ResumeStalled from re-spawning
-// fix agents forever when the underlying CI failure or conflict has
-// since been resolved on a newer push.
+// whose originating PR issue(s) (`pr_issue_kinds` in workflow vars, falling
+// back to the single-kind `pr_issue_kind`) are no longer present on the live
+// PR. Prevents ResumeStalled from re-spawning fix agents forever when the
+// underlying CI failure or conflict has since been resolved on a newer push.
 //
 // Without this, a pr-fix workflow remains in state=waiting on the `fix`
 // step until its agent succeeds or the task is deleted — there is no
 // trigger-re-evaluation between dispatch and completion. The orchestrator
 // loop then re-dispatches the step every minute, spawning a fresh agent
 // each time even though the PR is now green.
+//
+// A coalesced fix workflow (dispatchFixIssues) carries every kind it was
+// dispatched for in `pr_issue_kinds`, not just the primary `pr_issue_kind`.
+// The workflow must stay alive as long as ANY of those kinds is still live —
+// cancelling on the primary alone would kill the workflow (and drop the
+// still-unresolved sibling, already marked handled for this SHA) the moment
+// the primary kind resolves first.
 func (r *ReviewHandler) cancelResolvedPRFixWorkflows(tasks []task.Task, issues []github.PRIssue) {
 	if r.workflowEngine == nil {
 		return
@@ -874,35 +881,62 @@ func (r *ReviewHandler) cancelResolvedPRFixWorkflows(tasks []task.Task, issues [
 		if t.Workflow.State == workflow.ExecCompleted || t.Workflow.State == workflow.ExecFailed {
 			continue
 		}
-		kind := t.Workflow.Variables["pr_issue_kind"]
-		if kind == "" {
+		kinds := coalescedWorkflowKinds(t.Workflow.Variables)
+		if len(kinds) == 0 {
 			continue
 		}
-		if liveByTask[t.ID][kind] {
-			continue // condition still holds — let the workflow proceed
+		if anyKindLive(liveByTask[t.ID], kinds) {
+			continue // at least one coalesced kind still holds — let the workflow proceed
 		}
-		step, err := r.workflowEngine.CancelWorkflow(t.ID, "pr-monitor: "+kind+" resolved")
+		reason := strings.Join(kinds, "+")
+		step, err := r.workflowEngine.CancelWorkflow(t.ID, "pr-monitor: "+reason+" resolved")
 		if err != nil {
-			r.logger.Error("pr-monitor.cancel-resolved", "task_id", t.ID, "kind", kind, "err", err)
+			r.logger.Error("pr-monitor.cancel-resolved", "task_id", t.ID, "kind", reason, "err", err)
 			continue
 		}
-		// Clear cooldown so a future failure of the same kind on a new
-		// SHA re-triggers fresh (the closed-PR path does the same via
-		// prTracker.Cleanup; we need the explicit clear here because
-		// the PR is still open).
-		r.prTracker.Clear(t.ID, github.PRIssueKind(kind))
+		// Clear cooldown for every coalesced kind so a future failure of any
+		// of them on a new SHA re-triggers fresh (the closed-PR path does
+		// the same via prTracker.Cleanup; we need the explicit clear here
+		// because the PR is still open).
+		for _, kind := range kinds {
+			r.prTracker.Clear(t.ID, github.PRIssueKind(kind))
+		}
 		status := task.StatusInReview
-		reason := "pr-fix cancelled: " + kind + " resolved"
+		statusReason := "pr-fix cancelled: " + reason + " resolved"
 		if _, updErr := r.tasks.Update(t.ID, task.Update{
 			Status:       &status,
-			StatusReason: &reason,
+			StatusReason: &statusReason,
 		}); updErr != nil {
-			r.logger.Error("pr-monitor.cancel-resolved.status", "task_id", t.ID, "kind", kind, "err", updErr)
+			r.logger.Error("pr-monitor.cancel-resolved.status", "task_id", t.ID, "kind", reason, "err", updErr)
 			continue
 		}
 		r.logger.Info("pr-monitor.cancel-resolved",
-			"task_id", t.ID, "kind", kind, "step", step, "pr", t.PRNumber)
+			"task_id", t.ID, "kind", reason, "step", step, "pr", t.PRNumber)
 	}
+}
+
+// coalescedWorkflowKinds returns every PR issue kind a pr-fix workflow was
+// dispatched for, preferring the plural `pr_issue_kinds` (comma-joined, set
+// by dispatchPRIssue for coalesced fixes) and falling back to the singular
+// `pr_issue_kind` for single-kind dispatches (e.g. the Renovate fix path).
+func coalescedWorkflowKinds(vars map[string]string) []string {
+	if kinds := vars["pr_issue_kinds"]; kinds != "" {
+		return strings.Split(kinds, ",")
+	}
+	if kind := vars["pr_issue_kind"]; kind != "" {
+		return []string{kind}
+	}
+	return nil
+}
+
+// anyKindLive reports whether at least one of kinds is present in live.
+func anyKindLive(live map[string]bool, kinds []string) bool {
+	for _, kind := range kinds {
+		if live[kind] {
+			return true
+		}
+	}
+	return false
 }
 
 // monitoredPRs returns the union of user-authored PRs (from FetchReviews) and

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -354,20 +354,48 @@ func (r *ReviewHandler) handleKnownPRConflictsViaREST(tasks []task.Task) {
 }
 
 func (r *ReviewHandler) handleMatchedPRIssues(issues []github.PRIssue) {
+	// Group issues per task (first-seen order) so a single poll that surfaces
+	// several fixable kinds for one PR — e.g. a push that both fails CI and drew
+	// review comments — dispatches ONE coalesced fix agent instead of a separate
+	// agent per kind across consecutive cycles.
+	order := make([]string, 0, len(issues))
+	byTask := make(map[string][]github.PRIssue, len(issues))
 	for i := range issues {
-		if r.agents.HasRunningAgentForTask(issues[i].TaskID) {
-			continue
+		id := issues[i].TaskID
+		if _, seen := byTask[id]; !seen {
+			order = append(order, id)
 		}
-		// Gate dispatch on workflow state too: an agent may have just
-		// exited while the workflow is still in verify_commits /
-		// link_pr_and_review. Without this, a fresh issue (e.g.
-		// kind=conflict appearing because main moved during the agent
-		// run) races the in-flight workflow's tail steps and triggers
-		// a layered re-dispatch that DispatchEvent later rejects, but
-		// only after we've prepped a worktree and emitted audit noise.
-		if r.workflowEngine != nil && r.workflowEngine.HasActiveWorkflow(issues[i].TaskID) {
-			continue
-		}
+		byTask[id] = append(byTask[id], issues[i])
+	}
+	for _, id := range order {
+		r.handleTaskPRIssues(id, byTask[id])
+	}
+}
+
+// handleTaskPRIssues applies the running-agent, active-workflow, and
+// retry/cooldown gates for one task, then dispatches at most one action:
+// a coalesced fix agent for every handleable fixable issue, an escalation when
+// the only remaining fixable issue has exhausted its budget, or an auto-merge.
+func (r *ReviewHandler) handleTaskPRIssues(taskID string, issues []github.PRIssue) {
+	if r.agents.HasRunningAgentForTask(taskID) {
+		return
+	}
+	// Gate dispatch on workflow state too: an agent may have just exited while
+	// the workflow is still in verify_commits / link_pr_and_review. Without
+	// this, a fresh issue (e.g. kind=conflict appearing because main moved
+	// during the agent run) races the in-flight workflow's tail steps and
+	// triggers a layered re-dispatch that DispatchEvent later rejects, but only
+	// after we've prepped a worktree and emitted audit noise.
+	if r.workflowEngine != nil && r.workflowEngine.HasActiveWorkflow(taskID) {
+		return
+	}
+
+	var (
+		toHandle  []github.PRIssue
+		exhausted *github.PRIssue
+		merge     *github.PRIssue
+	)
+	for i := range issues {
 		// Only the comments kind carries a feedback fingerprint; conflict,
 		// ci_failure, and ready_to_merge fall back to SHA-only gating.
 		var sig string
@@ -376,19 +404,35 @@ func (r *ReviewHandler) handleMatchedPRIssues(issues []github.PRIssue) {
 		}
 		decision := github.DispatchHandle
 		if r.prTracker != nil {
-			decision = r.prTracker.Decide(issues[i].TaskID, issues[i].Kind, issues[i].PR.HeadSHA, sig)
+			decision = r.prTracker.Decide(taskID, issues[i].Kind, issues[i].PR.HeadSHA, sig)
 		}
 		switch decision {
 		case github.DispatchHandle:
 			if issues[i].Kind == github.PRIssueReadyToMerge {
-				r.handleAutoMerge(issues[i])
+				if merge == nil {
+					merge = &issues[i]
+				}
 				continue
 			}
-			r.handlePRIssue(issues[i])
+			toHandle = append(toHandle, issues[i])
 		case github.DispatchExhausted:
-			r.escalateExhaustedFix(issues[i])
+			if exhausted == nil {
+				exhausted = &issues[i]
+			}
 		case github.DispatchSkip:
 		}
+	}
+
+	// Prefer making progress: dispatch every handleable fix in one agent. Only
+	// escalate when nothing is handleable and a fix budget is spent — escalating
+	// flips the task to human-required and would strand a still-fixable sibling.
+	switch {
+	case len(toHandle) > 0:
+		r.dispatchFixIssues(taskID, toHandle)
+	case exhausted != nil:
+		r.escalateExhaustedFix(*exhausted)
+	case merge != nil:
+		r.handleAutoMerge(*merge)
 	}
 }
 

--- a/internal/sybra/app_reviews_coalesce_test.go
+++ b/internal/sybra/app_reviews_coalesce_test.go
@@ -1,0 +1,148 @@
+package sybra
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
+)
+
+// mechanicalPRFixYAML is a pr.event workflow with no run_agent step, so
+// DispatchEvent completes without spawning an agent — enough to exercise the
+// coalescing dispatch bookkeeping.
+const mechanicalPRFixYAML = `id: test-pr-fix
+name: Test PR Fix Coalesce
+trigger:
+  on: pr.event
+  conditions:
+    - field: pr.issue_kind
+      operator: in
+      value: conflict,ci_failure,comments
+steps:
+  - id: mark
+    name: Mark In Progress
+    type: set_status
+    config:
+      status: in-progress
+    next:
+      - goto: ""
+`
+
+// TestCoalescedFixPrompt locks the composition: a single issue yields its bare
+// per-kind body (unchanged behavior), while multiple issues from one push are
+// stitched into a single agent prompt covering every kind under one header.
+func TestCoalescedFixPrompt(t *testing.T) {
+	t.Parallel()
+	pr := github.PullRequest{Number: 7, Repository: "o/r", HeadRefName: "feat", URL: "https://github.com/o/r/pull/7"}
+
+	single := coalescedFixPrompt([]github.PRIssue{{Kind: github.PRIssueComments, PR: pr}})
+	if strings.Contains(single, "multiple open issues") {
+		t.Errorf("single-issue prompt must not carry the coalesced header:\n%s", single)
+	}
+	if !strings.Contains(single, "/fix-review") {
+		t.Errorf("single comments prompt missing its body:\n%s", single)
+	}
+
+	multi := coalescedFixPrompt([]github.PRIssue{
+		{Kind: github.PRIssueCIFailure, PR: pr},
+		{Kind: github.PRIssueComments, PR: pr},
+	})
+	for _, want := range []string{"multiple open issues", "Failing CI", "Review comments", "/fix-review", "gh run view"} {
+		if !strings.Contains(multi, want) {
+			t.Errorf("coalesced prompt missing %q:\n%s", want, multi)
+		}
+	}
+}
+
+// TestHandleMatchedPRIssues_CoalescesFixIssues is the regression guard for the
+// double pr-fix (PR #1352): a single poll surfacing both a ci_failure and
+// review comments for one PR must dispatch ONE fix agent that addresses both,
+// not two sequential agents across cycles. Under the old per-kind loop the
+// comments issue was blocked by HasActiveWorkflow after ci_failure dispatched,
+// so it re-fired as a separate agent on the next cycle.
+func TestHandleMatchedPRIssues_CoalescesFixIssues(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := task.NewStore(filepath.Join(tmp, "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := slog.New(slog.DiscardHandler)
+	wfStore, err := workflow.NewStore(filepath.Join(tmp, "workflows"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wfStore.Dir(), "test-pr-fix.yaml"),
+		[]byte(mechanicalPRFixYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
+	engine := workflow.NewEngine(
+		wfStore,
+		&taskAdapter{tasks: tasks},
+		&agentAdapter{agents: agentMgr, tasks: tasks},
+		logger,
+	)
+
+	created, err := tasks.Create("ship it", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// ProjectID left empty so prepareWorktree short-circuits (no worktree).
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:   task.Ptr(task.StatusInReview),
+		PRNumber: task.Ptr(1352),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &ReviewHandler{
+		DomainHandler:  DomainHandler{logger: logger},
+		tasks:          tasks,
+		agents:         agentMgr,
+		prTracker:      github.NewIssueTracker(time.Minute),
+		workflowEngine: engine,
+	}
+
+	pr := github.PullRequest{
+		Number: 1352, Repository: "o/r", HeadRefName: "feat", HeadSHA: "sha1",
+		URL: "https://github.com/o/r/pull/1352", FeedbackSig: "sig",
+	}
+	// Same order MatchTaskPRs emits: ci_failure before comments.
+	issues := []github.PRIssue{
+		{Kind: github.PRIssueCIFailure, TaskID: created.ID, PR: pr},
+		{Kind: github.PRIssueComments, TaskID: created.ID, PR: pr},
+	}
+
+	r.handleMatchedPRIssues(issues)
+
+	if got := r.prTracker.Retries(created.ID, github.PRIssueCIFailure); got != 1 {
+		t.Errorf("ci_failure retries = %d, want 1", got)
+	}
+	if got := r.prTracker.Retries(created.ID, github.PRIssueComments); got != 1 {
+		t.Errorf("comments retries = %d, want 1 (coalesced dispatch must mark it handled)", got)
+	}
+
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow == nil {
+		t.Fatal("no workflow dispatched")
+	}
+	// comments outranks ci_failure for the primary kind (branch-preserving
+	// worktree prep + cancel/phase reconciliation key on it).
+	if k := got.Workflow.Variables["pr_issue_kind"]; k != string(github.PRIssueComments) {
+		t.Errorf("pr_issue_kind = %q, want %q (primary)", k, github.PRIssueComments)
+	}
+	prompt := got.Workflow.Variables["prompt"]
+	if !strings.Contains(prompt, "Failing CI") || !strings.Contains(prompt, "Review comments") {
+		t.Errorf("coalesced prompt missing a section:\n%s", prompt)
+	}
+}

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -129,63 +129,158 @@ func (r *ReviewHandler) escalateExhaustedFix(issue github.PRIssue) {
 		"kind", string(issue.Kind), "attempts", github.MaxRetries)
 }
 
+// ciFailurePrompt is the pr-fix agent prompt for a failing-CI issue.
+func ciFailurePrompt(pr github.PullRequest) string {
+	return fmt.Sprintf(
+		"Fix failing CI on branch `%s` (PR #%d). "+
+			"Check the failing run with `gh run view --log-failed`, "+
+			"fix the code, commit and push. No unrelated changes.\n\n"+
+			"Never weaken, skip, delete, or hardcode tests, snapshots, or "+
+			"fixtures to make CI pass, and never edit CI config to neuter a "+
+			"gate — fix the underlying code. Tampering is detected and blocks "+
+			"the task.\n\n"+
+			"Push to the remote that hosts the PR's head branch:\n"+
+			"```sh\n"+
+			"PUSH_REMOTE=origin\n"+
+			"PR_HEAD=\"$(gh pr view %d --json headRepository --jq '.headRepository.nameWithOwner')\"\n"+
+			"FORK_URL=\"$(git config --get remote.fork.url 2>/dev/null || true)\"\n"+
+			"if [ -n \"$FORK_URL\" ] && echo \"$FORK_URL\" | grep -qF \"$PR_HEAD\"; then PUSH_REMOTE=fork; fi\n"+
+			"git push \"$PUSH_REMOTE\" HEAD:%s\n"+
+			"```",
+		pr.HeadRefName, pr.Number, pr.Number, pr.HeadRefName,
+	)
+}
+
+// prIssueBody returns the pr-fix agent prompt for one fixable issue kind. ok is
+// false for kinds with no agent prompt (ready_to_merge), which never reach the
+// dispatch path.
+func prIssueBody(issue github.PRIssue) (string, bool) {
+	switch issue.Kind {
+	case github.PRIssueConflict:
+		return conflictPrompt(issue.PR), true
+	case github.PRIssueCIFailure:
+		return ciFailurePrompt(issue.PR), true
+	case github.PRIssueComments:
+		return commentsPrompt(issue.PR), true
+	default:
+		return "", false
+	}
+}
+
+// fixKindPriority orders fixable kinds for coalesced dispatch. The lowest-priority
+// kind becomes the "primary": it drives worktree prep, the workflow's
+// pr_issue_kind var, and cancel/phase reconciliation. Conflicts sort first so a
+// conflicting PR checks out its branch WITHOUT rebasing (PrepareForFix), then
+// comments so any pair that includes review feedback also prefers the
+// branch-preserving checkout; a lone ci_failure keeps its rebasing PrepareForTask
+// path unchanged.
+func fixKindPriority(kind github.PRIssueKind) int {
+	switch kind {
+	case github.PRIssueConflict:
+		return 0
+	case github.PRIssueComments:
+		return 1
+	case github.PRIssueCIFailure:
+		return 2
+	default:
+		return 3
+	}
+}
+
+func fixKindLabel(kind github.PRIssueKind) string {
+	switch kind {
+	case github.PRIssueConflict:
+		return "Merge conflicts"
+	case github.PRIssueCIFailure:
+		return "Failing CI"
+	case github.PRIssueComments:
+		return "Review comments"
+	default:
+		return string(kind)
+	}
+}
+
+func (r *ReviewHandler) logPRIssueDetected(taskID string, issue github.PRIssue) {
+	var event string
+	switch issue.Kind {
+	case github.PRIssueConflict:
+		event = audit.EventPRConflictDetected
+	case github.PRIssueCIFailure:
+		event = audit.EventPRCIFailureDetected
+	case github.PRIssueComments:
+		event = audit.EventPRCommentsDetected
+	default:
+		return
+	}
+	r.logAudit(event, taskID, "", map[string]any{
+		"pr": issue.PR.Number, "repo": issue.PR.Repository,
+	})
+}
+
+// coalescedFixPrompt composes a single pr-fix agent prompt covering every issue
+// the monitor wants fixed on a PR this cycle. A single issue yields its bare
+// per-kind prompt (behavior unchanged); multiple issues — e.g. a push that both
+// fails CI and drew review comments — are stitched into one pass so exactly one
+// agent runs per review round instead of one agent per kind across cycles.
+func coalescedFixPrompt(issues []github.PRIssue) string {
+	if len(issues) == 1 {
+		body, _ := prIssueBody(issues[0])
+		return body
+	}
+	var b strings.Builder
+	b.WriteString("This PR has multiple open issues from the same push. Address " +
+		"ALL of them in one pass, then push once at the end (the per-section push " +
+		"commands are equivalent — run it a single time).\n\n")
+	for i := range issues {
+		body, ok := prIssueBody(issues[i])
+		if !ok {
+			continue
+		}
+		fmt.Fprintf(&b, "=== Issue %d: %s ===\n%s\n\n", i+1, fixKindLabel(issues[i].Kind), body)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
 func (r *ReviewHandler) handlePRIssue(issue github.PRIssue) bool {
-	t, err := r.tasks.Get(issue.TaskID)
+	return r.dispatchFixIssues(issue.TaskID, []github.PRIssue{issue})
+}
+
+// dispatchFixIssues spawns a single pr-fix agent that addresses every handled
+// issue for a task. handle must be non-empty and contain only fixable kinds
+// (conflict, ci_failure, comments); the caller (handleTaskPRIssues) filters out
+// ready_to_merge and applies the retry/cooldown gate. Coalescing avoids the
+// double-dispatch where a CI failure and review comments from the same push each
+// spawned their own sequential agent.
+func (r *ReviewHandler) dispatchFixIssues(taskID string, handle []github.PRIssue) bool {
+	if len(handle) == 0 {
+		return false
+	}
+	t, err := r.tasks.Get(taskID)
 	if err != nil {
 		return false
 	}
-
-	var prompt string
-	switch issue.Kind {
-	case github.PRIssueConflict:
-		prompt = conflictPrompt(issue.PR)
-		r.logAudit(audit.EventPRConflictDetected, t.ID, "", map[string]any{
-			"pr": issue.PR.Number, "repo": issue.PR.Repository,
-		})
-
-	case github.PRIssueCIFailure:
-		prompt = fmt.Sprintf(
-			"Fix failing CI on branch `%s` (PR #%d). "+
-				"Check the failing run with `gh run view --log-failed`, "+
-				"fix the code, commit and push. No unrelated changes.\n\n"+
-				"Never weaken, skip, delete, or hardcode tests, snapshots, or "+
-				"fixtures to make CI pass, and never edit CI config to neuter a "+
-				"gate — fix the underlying code. Tampering is detected and blocks "+
-				"the task.\n\n"+
-				"Push to the remote that hosts the PR's head branch:\n"+
-				"```sh\n"+
-				"PUSH_REMOTE=origin\n"+
-				"PR_HEAD=\"$(gh pr view %d --json headRepository --jq '.headRepository.nameWithOwner')\"\n"+
-				"FORK_URL=\"$(git config --get remote.fork.url 2>/dev/null || true)\"\n"+
-				"if [ -n \"$FORK_URL\" ] && echo \"$FORK_URL\" | grep -qF \"$PR_HEAD\"; then PUSH_REMOTE=fork; fi\n"+
-				"git push \"$PUSH_REMOTE\" HEAD:%s\n"+
-				"```",
-			issue.PR.HeadRefName, issue.PR.Number, issue.PR.Number, issue.PR.HeadRefName,
-		)
-		r.logAudit(audit.EventPRCIFailureDetected, t.ID, "", map[string]any{
-			"pr": issue.PR.Number, "repo": issue.PR.Repository,
-		})
-
-	case github.PRIssueComments:
-		prompt = commentsPrompt(issue.PR)
-		r.logAudit(audit.EventPRCommentsDetected, t.ID, "", map[string]any{
-			"pr": issue.PR.Number, "repo": issue.PR.Repository,
-		})
-
-	case github.PRIssueReadyToMerge:
-		// handled by handleAutoMerge, not by agent spawn
-		return false
+	// Stable-sort by fix priority so the primary (index 0) drives worktree prep
+	// and the prompt reads in execution order (conflicts → comments → CI).
+	slices.SortStableFunc(handle, func(a, b github.PRIssue) int {
+		return fixKindPriority(a.Kind) - fixKindPriority(b.Kind)
+	})
+	for i := range handle {
+		r.logPRIssueDetected(t.ID, handle[i])
 	}
-
-	dir, ok := r.prepareWorktree(t, issue)
+	primary := handle[0]
+	dir, ok := r.prepareWorktree(t, primary)
 	if !ok {
 		return false
 	}
-
-	return r.dispatchPRIssue(t, issue, prompt, dir)
+	return r.dispatchPRIssue(t, primary, handle, coalescedFixPrompt(handle), dir)
 }
 
-func (r *ReviewHandler) dispatchPRIssue(t task.Task, issue github.PRIssue, prompt, dir string) bool {
+// dispatchPRIssue starts the pr-fix workflow for primary and, on success, marks
+// every coalesced issue in handle as handled so none re-fires next cycle. The
+// primary kind is authoritative for the workflow's pr_issue_kind var (cancel and
+// phase reconciliation key on it); handle carries the full set for the retry
+// tracker.
+func (r *ReviewHandler) dispatchPRIssue(t task.Task, primary github.PRIssue, handle []github.PRIssue, prompt, dir string) bool {
 	if r.workflowEngine == nil {
 		r.logger.Error("pr-monitor.no-workflow-engine", "task_id", t.ID)
 		return false
@@ -196,15 +291,15 @@ func (r *ReviewHandler) dispatchPRIssue(t task.Task, issue github.PRIssue, promp
 	fullPrompt := fmt.Sprintf("# Task: %s\n\n%s%s", t.Title, prompt, prFixResultContract)
 	vars := map[string]string{
 		"prompt":                fullPrompt,
-		"pr_issue_kind":         string(issue.Kind),
+		"pr_issue_kind":         string(primary.Kind),
 		workflow.WorkflowVarDir: dir,
 	}
 	wfID, err := r.workflowEngine.DispatchEvent(t.ID, "pr.event",
-		map[string]string{"pr.issue_kind": string(issue.Kind)}, vars)
+		map[string]string{"pr.issue_kind": string(primary.Kind)}, vars)
 	if err != nil {
 		if errors.Is(err, workflow.ErrWorkflowAlreadyActive) {
 			r.logger.Info("pr-monitor.workflow-already-active",
-				"task_id", t.ID, "kind", string(issue.Kind))
+				"task_id", t.ID, "kind", string(primary.Kind))
 			return false
 		}
 		r.logger.Error("pr-monitor.workflow-dispatch", "task_id", t.ID, "err", err)
@@ -212,18 +307,23 @@ func (r *ReviewHandler) dispatchPRIssue(t task.Task, issue github.PRIssue, promp
 	}
 	if wfID == "" {
 		r.logger.Warn("pr-monitor.no-matching-workflow",
-			"task_id", t.ID, "kind", string(issue.Kind))
+			"task_id", t.ID, "kind", string(primary.Kind))
 		return false
 	}
 
-	r.prTracker.MarkHandled(t.ID, issue.Kind, issue.PR.HeadSHA)
+	kinds := make([]string, 0, len(handle))
+	for i := range handle {
+		r.prTracker.MarkHandled(t.ID, handle[i].Kind, handle[i].PR.HeadSHA)
+		kinds = append(kinds, string(handle[i].Kind))
+	}
 	r.logAudit(audit.EventPRFixAgentStarted, t.ID, "", map[string]any{
-		"issue": string(issue.Kind), "pr": issue.PR.Number, "workflow": wfID,
+		"issue": string(primary.Kind), "kinds": strings.Join(kinds, ","),
+		"pr": primary.PR.Number, "workflow": wfID,
 	})
 
 	r.logger.Info("pr-monitor.fix-started",
-		"task_id", t.ID, "issue", string(issue.Kind),
-		"pr", issue.PR.Number, "workflow", wfID,
+		"task_id", t.ID, "issue", string(primary.Kind), "kinds", strings.Join(kinds, ","),
+		"pr", primary.PR.Number, "workflow", wfID,
 	)
 	return true
 }

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -167,9 +167,10 @@ func prIssueBody(issue github.PRIssue) (string, bool) {
 	}
 }
 
-// fixKindPriority orders fixable kinds for coalesced dispatch. The lowest-priority
-// kind becomes the "primary": it drives worktree prep, the workflow's
-// pr_issue_kind var, and cancel/phase reconciliation. Conflicts sort first so a
+// fixKindPriority orders fixable kinds for coalesced dispatch. The kind with
+// the lowest numeric priority (i.e. highest priority) becomes the "primary":
+// it drives worktree prep, the workflow's pr_issue_kind var, and cancel/phase
+// reconciliation. Conflicts sort first so a
 // conflicting PR checks out its branch WITHOUT rebasing (PrepareForFix), then
 // comments so any pair that includes review feedback also prefers the
 // branch-preserving checkout; a lone ci_failure keeps its rebasing PrepareForTask

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -289,9 +289,14 @@ func (r *ReviewHandler) dispatchPRIssue(t task.Task, primary github.PRIssue, han
 	// Dispatch pr.event through the engine so trigger conditions in the
 	// workflow YAML stay authoritative. StartWorkflow would bypass them.
 	fullPrompt := fmt.Sprintf("# Task: %s\n\n%s%s", t.Title, prompt, prFixResultContract)
+	kinds := make([]string, 0, len(handle))
+	for i := range handle {
+		kinds = append(kinds, string(handle[i].Kind))
+	}
 	vars := map[string]string{
 		"prompt":                fullPrompt,
 		"pr_issue_kind":         string(primary.Kind),
+		"pr_issue_kinds":        strings.Join(kinds, ","),
 		workflow.WorkflowVarDir: dir,
 	}
 	wfID, err := r.workflowEngine.DispatchEvent(t.ID, "pr.event",
@@ -311,10 +316,8 @@ func (r *ReviewHandler) dispatchPRIssue(t task.Task, primary github.PRIssue, han
 		return false
 	}
 
-	kinds := make([]string, 0, len(handle))
 	for i := range handle {
 		r.prTracker.MarkHandled(t.ID, handle[i].Kind, handle[i].PR.HeadSHA)
-		kinds = append(kinds, string(handle[i].Kind))
 	}
 	r.logAudit(audit.EventPRFixAgentStarted, t.ID, "", map[string]any{
 		"issue": string(primary.Kind), "kinds": strings.Join(kinds, ","),

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -1011,6 +1011,84 @@ func TestCancelResolvedPRFixWorkflows(t *testing.T) {
 	}
 }
 
+// TestCancelResolvedPRFixWorkflows_CoalescedSiblingStillLive is the
+// regression guard for the cancel-vs-coalesce interaction: a workflow
+// dispatched for {ci_failure, comments} with comments as primary must NOT be
+// cancelled just because comments resolved first — ci_failure (recorded in
+// the plural pr_issue_kinds var) is still live and the workflow must keep
+// running to address it.
+func TestCancelResolvedPRFixWorkflows_CoalescedSiblingStillLive(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := task.NewStore(filepath.Join(tmp, "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := slog.New(slog.DiscardHandler)
+	wfStore, err := workflow.NewStore(filepath.Join(tmp, "workflows"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := workflow.SyncBuiltins(wfStore); err != nil {
+		t.Fatal(err)
+	}
+	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
+	engine := workflow.NewEngine(wfStore,
+		&taskAdapter{tasks: tasks},
+		&agentAdapter{agents: agentMgr, tasks: tasks},
+		logger,
+	)
+
+	created, err := tasks.Create("coalesced", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pr := 1352
+	status := task.StatusInProgress
+	wf := &workflow.Execution{
+		WorkflowID:  "pr-fix",
+		CurrentStep: "fix",
+		State:       workflow.ExecWaiting,
+		Variables: map[string]string{
+			"pr_issue_kind":  string(github.PRIssueComments),
+			"pr_issue_kinds": string(github.PRIssueCIFailure) + "," + string(github.PRIssueComments),
+		},
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		PRNumber: &pr, Status: &status, Workflow: &wf,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := &ReviewHandler{
+		DomainHandler:  DomainHandler{logger: logger},
+		tasks:          tasks,
+		prTracker:      github.NewIssueTracker(time.Minute),
+		workflowEngine: engine,
+	}
+	r.prTracker.MarkHandled(created.ID, github.PRIssueComments, "sha1")
+	r.prTracker.MarkHandled(created.ID, github.PRIssueCIFailure, "sha1")
+	// comments has resolved; ci_failure is still live on the same push.
+	issues := []github.PRIssue{
+		{Kind: github.PRIssueCIFailure, TaskID: created.ID},
+	}
+
+	r.cancelResolvedPRFixWorkflows(all, issues)
+
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow == nil || got.Workflow.State != workflow.ExecWaiting {
+		t.Errorf("workflow state = %+v, want still waiting while coalesced ci_failure is still live", got.Workflow)
+	}
+}
+
 // TestMonitoredPRs covers the regression where Renovate-bot PRs linked to a
 // task by pr_number were silently skipped by the pr-monitor because
 // FetchReviews uses author:@me. monitoredPRs folds renovatePRsFn output into


### PR DESCRIPTION
## Motivation

On PR #1352 a single push both failed a CI lint gate (nilaway) and drew
Copilot review comments. The pr-monitor dispatched **two** separate fix
agents back-to-back for that one review round — `ci_failure` first, then
`comments` after it finished — costing two worktree setups and two model
runs, with the second commit rebased on the first.

Root cause: `handleMatchedPRIssues` dispatched one PR-issue kind at a
time. When a poll surfaced several fixable kinds for the same task, the
running-agent / active-workflow gate blocked all but the first; the rest
re-appeared on later cycles as fresh agent runs. Nothing coalesced
"fix CI + address review comments" into one agent even though they share
a worktree and a review round.

> Changelog: fix(reviews): coalesce per-PR fix dispatch

## Implementation information

- `handleMatchedPRIssues` now groups matched issues per task and
  delegates to a new `handleTaskPRIssues`, which gates once per task and
  dispatches a single action: a coalesced fix agent for every handleable
  kind, else an escalation for a spent budget, else auto-merge. Escalation
  is deferred while any sibling is still fixable (escalating flips the task
  to human-required and would strand it).
- `coalescedFixPrompt` composes one agent prompt: a single issue keeps its
  bare per-kind body (unchanged); multiple issues are stitched under one
  header with labeled sections.
- `dispatchFixIssues` picks a priority-ordered primary kind
  (conflict → comments → ci_failure) that drives worktree prep and the
  `pr_issue_kind` workflow var, so cancel/phase reconciliation stay
  unchanged; every coalesced kind is marked handled so none re-fires.
- Single-kind dispatch (including `recoverStaleBranchConflict`) is
  behaviorally identical.

## Supporting documentation

- `TestCoalescedFixPrompt` — single vs multi prompt composition.
- `TestHandleMatchedPRIssues_CoalescesFixIssues` — regression guard: one
  poll with `ci_failure` + `comments` dispatches once and marks both kinds
  handled (old code left `comments` unhandled), primary = `comments`.

_Generated by Sybra harness_