### PR TITLE
feat(umbrella): serial fallback on planner exhaust

### DIFF
--- a/cmd/sybra-cli/umbrella.go
+++ b/cmd/sybra-cli/umbrella.go
@@ -33,19 +33,23 @@ func cmdUmbrella(s *task.Manager, args []string, jsonOut bool) int {
 	if err != nil {
 		return fatal(jsonOut, "%v", err)
 	}
-	return reportUmbrella(jsonOut, res.UmbrellaURL, res.Created, res.Skipped)
+	return reportUmbrella(jsonOut, res.UmbrellaURL, res.Created, res.Skipped, res.Degraded)
 }
 
-func reportUmbrella(jsonOut bool, umbrellaURL string, created, skipped int) int {
+func reportUmbrella(jsonOut bool, umbrellaURL string, created, skipped int, degraded bool) int {
 	if jsonOut {
 		out, _ := json.Marshal(map[string]any{
 			"umbrella": umbrellaURL,
 			"created":  created,
 			"skipped":  skipped,
+			"degraded": degraded,
 		})
 		fmt.Println(string(out))
 		return 0
 	}
 	fmt.Printf("Expanded %s: created %d child task(s), %d skipped (done or already present).\n", umbrellaURL, created, skipped)
+	if degraded {
+		fmt.Println("WARNING: planner exhausted its retries — fell back to a linear-chain plan (serial, no parallelism).")
+	}
 	return 0
 }

--- a/internal/poll/issues.go
+++ b/internal/poll/issues.go
@@ -274,6 +274,9 @@ func (f *IssuesFetcher) expandUmbrellaIssue(issue *github.Issue) {
 	if res.Created > 0 {
 		f.logger.Info("issue-sync.umbrella-expanded", "issue", issue.URL, "created", res.Created)
 	}
+	if res.Degraded {
+		f.logger.Warn("issue-sync.umbrella-degraded", "issue", issue.URL, "created", res.Created)
+	}
 }
 
 // syncFlatIssue creates or enriches a single non-umbrella issue task, honoring

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -3,6 +3,7 @@ package umbrella
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -14,6 +15,11 @@ import (
 	"github.com/Automaat/sybra/internal/provider"
 	"github.com/Automaat/sybra/internal/task"
 )
+
+// errSkipUpdate signals tagTrackerDegraded's UpdateFn callback that the tag
+// is already present, so the read-modify-write should short-circuit without
+// writing (and without firing a task:updated event).
+var errSkipUpdate = errors.New("skip update")
 
 // PlannerTimeout bounds the whole Generate call — every attemptPlan retry
 // plus the zero-edge-floor critic re-ask — so a hung process cannot wedge an
@@ -185,16 +191,18 @@ func materialize(tasks *task.Manager, umb github.Issue, specs []ChildSpec, byRef
 // already present, so a repeated degraded re-expansion against the same
 // tracker doesn't emit a spurious task:updated event.
 func tagTrackerDegraded(tasks *task.Manager, trackerID string) error {
-	cur, err := tasks.Get(trackerID)
+	_, err := tasks.UpdateFn(trackerID, func(cur task.Task) (task.Update, error) {
+		if slices.Contains(cur.Tags, FallbackTag) {
+			return task.Update{}, errSkipUpdate
+		}
+		return task.Update{
+			Tags: task.Ptr(append(slices.Clone(cur.Tags), FallbackTag)),
+		}, nil
+	})
 	if err != nil {
-		return fmt.Errorf("get tracker: %w", err)
-	}
-	if slices.Contains(cur.Tags, FallbackTag) {
-		return nil
-	}
-	if _, err := tasks.Update(trackerID, task.Update{
-		Tags: task.Ptr(append(slices.Clone(cur.Tags), FallbackTag)),
-	}); err != nil {
+		if errors.Is(err, errSkipUpdate) {
+			return nil
+		}
 		return fmt.Errorf("tag tracker degraded: %w", err)
 	}
 	return nil

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -35,8 +35,9 @@ func fetchUmbrellaBounded(ctx context.Context, repo string, number int) (umbrell
 // Result summarizes an expansion.
 type Result struct {
 	UmbrellaURL string
-	Created     int // child tasks created this run
-	Skipped     int // sub-issues already materialized or done
+	Created     int  // child tasks created this run
+	Skipped     int  // sub-issues already materialized or done
+	Degraded    bool // true when the DAG came from linearChainFallback, not the model
 }
 
 // Expand fetches a GitHub umbrella issue's native sub-issues, runs the planner
@@ -72,7 +73,7 @@ func Expand(ctx context.Context, tasks *task.Manager, run Runner, issueURL strin
 		byRef[NormalizeIssueRef(subs[i].URL)] = subs[i]
 	}
 
-	existing, trackerExists, err := scanExisting(tasks, umb.URL)
+	existing, trackerExists, trackerID, err := scanExisting(tasks, umb.URL)
 	if err != nil {
 		return Result{}, fmt.Errorf("scan existing tasks: %w", err)
 	}
@@ -90,11 +91,11 @@ func Expand(ctx context.Context, tasks *task.Manager, run Runner, issueURL strin
 	}
 
 	specs := ChildSpecs(plan, planSubs, existing)
-	created, err := materialize(tasks, umb, specs, byRef, trackerExists, plan.MaxParallel)
+	created, err := materialize(tasks, umb, specs, byRef, trackerExists, trackerID, plan.MaxParallel, plan.Fallback)
 	if err != nil {
 		return Result{}, err
 	}
-	return Result{UmbrellaURL: umb.URL, Created: created, Skipped: len(subs) - created}, nil
+	return Result{UmbrellaURL: umb.URL, Created: created, Skipped: len(subs) - created, Degraded: plan.Fallback}, nil
 }
 
 // allMaterialized reports whether every open sub-issue already has a task.
@@ -111,13 +112,13 @@ func allMaterialized(subs []SubIssue, existing map[string]bool) bool {
 }
 
 // scanExisting returns the set of normalized issue refs that already have a
-// task, and whether the umbrella tracker exists. A List failure is propagated
-// so the caller aborts rather than treating an unreadable store as empty and
-// creating a duplicate DAG.
-func scanExisting(tasks *task.Manager, umbrellaURL string) (refs map[string]bool, trackerExists bool, err error) {
+// task, whether the umbrella tracker exists, and its task id when it does. A
+// List failure is propagated so the caller aborts rather than treating an
+// unreadable store as empty and creating a duplicate DAG.
+func scanExisting(tasks *task.Manager, umbrellaURL string) (refs map[string]bool, trackerExists bool, trackerID string, err error) {
 	all, err := tasks.List()
 	if err != nil {
-		return nil, false, err
+		return nil, false, "", err
 	}
 	refs = make(map[string]bool, len(all))
 	umbKey := NormalizeIssueRef(umbrellaURL)
@@ -128,22 +129,37 @@ func scanExisting(tasks *task.Manager, umbrellaURL string) (refs map[string]bool
 		}
 		if t.TaskType == task.TaskTypeUmbrella && NormalizeIssueRef(t.Issue) == umbKey {
 			trackerExists = true
+			trackerID = t.ID
 		}
 	}
-	return refs, trackerExists, nil
+	return refs, trackerExists, trackerID, nil
 }
 
-// materialize creates the tracker (when absent) and one gated todo child per spec.
-func materialize(tasks *task.Manager, umb github.Issue, specs []ChildSpec, byRef map[string]github.Issue, trackerExists bool, maxParallel int) (int, error) {
+// materialize creates the tracker (when absent) and one gated todo child per
+// spec. When degraded (the plan came from linearChainFallback), the tracker
+// carries FallbackTag so a systematically-failing planner is board-visible:
+// on a fresh tracker the tag is included at creation; on re-expansion against
+// an already-materialized tracker it is appended idempotently (add-if-absent)
+// via UpdateFn, since a partial re-expansion can hit the fallback on a
+// tracker created by an earlier, successful run.
+func materialize(tasks *task.Manager, umb github.Issue, specs []ChildSpec, byRef map[string]github.Issue, trackerExists bool, trackerID string, maxParallel int, degraded bool) (int, error) {
 	if !trackerExists {
+		tags := []string{"umbrella", MaxParallelTag(maxParallel)}
+		if degraded {
+			tags = append(tags, FallbackTag)
+		}
 		if _, err := tasks.CreateFull(umb.Title, umb.Body, task.AgentModeHeadless, task.Update{
 			Issue:     task.Ptr(umb.URL),
 			TaskType:  task.Ptr(task.TaskTypeUmbrella),
 			ProjectID: task.Ptr(umb.Repository),
 			Status:    task.Ptr(task.StatusInProgress),
-			Tags:      task.Ptr([]string{"umbrella", MaxParallelTag(maxParallel)}),
+			Tags:      task.Ptr(tags),
 		}); err != nil {
 			return 0, fmt.Errorf("create tracker: %w", err)
+		}
+	} else if degraded {
+		if err := tagTrackerDegraded(tasks, trackerID); err != nil {
+			return 0, err
 		}
 	}
 
@@ -162,6 +178,26 @@ func materialize(tasks *task.Manager, umb github.Issue, specs []ChildSpec, byRef
 		created++
 	}
 	return created, nil
+}
+
+// tagTrackerDegraded appends FallbackTag to an already-materialized tracker
+// if it isn't there yet. Reads first and skips the write when the tag is
+// already present, so a repeated degraded re-expansion against the same
+// tracker doesn't emit a spurious task:updated event.
+func tagTrackerDegraded(tasks *task.Manager, trackerID string) error {
+	cur, err := tasks.Get(trackerID)
+	if err != nil {
+		return fmt.Errorf("get tracker: %w", err)
+	}
+	if slices.Contains(cur.Tags, FallbackTag) {
+		return nil
+	}
+	if _, err := tasks.Update(trackerID, task.Update{
+		Tags: task.Ptr(append(slices.Clone(cur.Tags), FallbackTag)),
+	}); err != nil {
+		return fmt.Errorf("tag tracker degraded: %w", err)
+	}
+	return nil
 }
 
 // childProjectID returns the repo a child should be worked in: the sub-issue's

--- a/internal/umbrella/expand_test.go
+++ b/internal/umbrella/expand_test.go
@@ -1,6 +1,122 @@
 package umbrella
 
-import "testing"
+import (
+	"slices"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func newTestTaskManager(t *testing.T) *task.Manager {
+	t.Helper()
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("task.NewStore: %v", err)
+	}
+	return task.NewManager(store, task.EmitterFunc(func(string, any) {}))
+}
+
+func TestMaterialize_DegradedFreshTrackerCarriesFallbackTag(t *testing.T) {
+	t.Parallel()
+	tasks := newTestTaskManager(t)
+	umb := github.Issue{Title: "umbrella", URL: "https://github.com/o/r/issues/100", Repository: "o/r"}
+	specs := []ChildSpec{{Title: "c1", Issue: "o/r#1"}}
+
+	if _, err := materialize(tasks, umb, specs, map[string]github.Issue{}, false, "", DefaultMaxParallel, true); err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+
+	all, err := tasks.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var tracker *task.Task
+	for i := range all {
+		if all[i].TaskType == task.TaskTypeUmbrella {
+			tracker = &all[i]
+		}
+	}
+	if tracker == nil {
+		t.Fatal("no tracker task created")
+	}
+	if !slices.Contains(tracker.Tags, FallbackTag) {
+		t.Errorf("fresh degraded tracker tags = %v, want to contain %q", tracker.Tags, FallbackTag)
+	}
+}
+
+func TestMaterialize_DegradedExistingTrackerGetsFallbackTagIdempotently(t *testing.T) {
+	t.Parallel()
+	tasks := newTestTaskManager(t)
+	umb := github.Issue{Title: "umbrella", URL: "https://github.com/o/r/issues/100", Repository: "o/r"}
+
+	tracker, err := tasks.CreateFull(umb.Title, "", task.AgentModeHeadless, task.Update{
+		Issue:    task.Ptr(umb.URL),
+		TaskType: task.Ptr(task.TaskTypeUmbrella),
+		Status:   task.Ptr(task.StatusInProgress),
+		Tags:     task.Ptr([]string{"umbrella", MaxParallelTag(DefaultMaxParallel)}),
+	})
+	if err != nil {
+		t.Fatalf("create tracker: %v", err)
+	}
+
+	specs := []ChildSpec{{Title: "c1", Issue: "o/r#1"}}
+	if _, err := materialize(tasks, umb, specs, map[string]github.Issue{}, true, tracker.ID, DefaultMaxParallel, true); err != nil {
+		t.Fatalf("materialize (first, degraded): %v", err)
+	}
+	got, err := tasks.Get(tracker.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !slices.Contains(got.Tags, FallbackTag) {
+		t.Fatalf("existing tracker tags = %v, want to contain %q after degraded re-expansion", got.Tags, FallbackTag)
+	}
+
+	// A second degraded re-expansion against the same tracker must not
+	// duplicate the tag.
+	if _, err := materialize(tasks, umb, nil, map[string]github.Issue{}, true, tracker.ID, DefaultMaxParallel, true); err != nil {
+		t.Fatalf("materialize (second, degraded): %v", err)
+	}
+	got, err = tasks.Get(tracker.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	count := 0
+	for _, tag := range got.Tags {
+		if tag == FallbackTag {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("FallbackTag count = %d, want exactly 1 (idempotent): %v", count, got.Tags)
+	}
+}
+
+func TestScanExisting_ReturnsTrackerID(t *testing.T) {
+	t.Parallel()
+	tasks := newTestTaskManager(t)
+	const umb = "https://github.com/o/r/issues/100"
+	tracker, err := tasks.CreateFull("umbrella", "", task.AgentModeHeadless, task.Update{
+		Issue:    task.Ptr(umb),
+		TaskType: task.Ptr(task.TaskTypeUmbrella),
+		Status:   task.Ptr(task.StatusInProgress),
+		Tags:     task.Ptr([]string{"umbrella"}),
+	})
+	if err != nil {
+		t.Fatalf("create tracker: %v", err)
+	}
+
+	_, trackerExists, trackerID, err := scanExisting(tasks, umb)
+	if err != nil {
+		t.Fatalf("scanExisting: %v", err)
+	}
+	if !trackerExists {
+		t.Fatal("trackerExists = false, want true")
+	}
+	if trackerID != tracker.ID {
+		t.Fatalf("trackerID = %q, want %q", trackerID, tracker.ID)
+	}
+}
 
 func TestIsUmbrellaIssue(t *testing.T) {
 	t.Parallel()

--- a/internal/umbrella/planner.go
+++ b/internal/umbrella/planner.go
@@ -3,9 +3,11 @@ package umbrella
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -17,6 +19,12 @@ const DefaultMaxParallel = 5
 // fails to parse or validate. The planner is stochastic, so a fresh sample
 // often fixes a malformed or incomplete DAG.
 const plannerAttempts = 3
+
+// errPlannerExhausted marks attemptPlan's exhaustion return (plannerAttempts
+// samples, none parsed/resolved/validated) so Generate can distinguish it from
+// a fatal runner error via errors.Is and fall back to a linear chain instead
+// of aborting the whole expansion.
+var errPlannerExhausted = errors.New("planner exhausted retries")
 
 // SubIssue is the minimal projection of a GitHub sub-issue the planner needs.
 type SubIssue struct {
@@ -50,6 +58,9 @@ type PlannedChild struct {
 type Plan struct {
 	Children    []PlannedChild `json:"children"`
 	MaxParallel int            `json:"maxParallel"`
+	// Fallback marks a plan built by linearChainFallback instead of the model,
+	// so callers can surface degradation loudly. Never persisted on the wire.
+	Fallback bool `json:"-"`
 }
 
 // Runner executes one planner prompt and returns the model's raw stdout.
@@ -68,6 +79,10 @@ const criticSuffix = "You produced a fully-parallel plan — re-examine `touches
 // first valid plan is suspiciously flat, Generate re-asks the model once with
 // a critic nudge; any failure of that re-ask (parse, validate, or run error)
 // falls back to the original plan rather than failing the whole expansion.
+// If the first attempt exhausts plannerAttempts without ever producing a
+// valid plan, Generate falls back to a fully-serial linear chain
+// (linearChainFallback) instead of aborting the expansion; a fatal runner
+// error (couldn't launch the model) is not exhaustion and still aborts.
 func Generate(ctx context.Context, run Runner, umbrellaRef, umbrellaBody string, subs []SubIssue) (Plan, error) {
 	if len(subs) == 0 {
 		return Plan{}, fmt.Errorf("umbrella %s has no sub-issues to expand", umbrellaRef)
@@ -77,6 +92,9 @@ func Generate(ctx context.Context, run Runner, umbrellaRef, umbrellaBody string,
 
 	plan, err := attemptPlan(ctx, run, idx, prompt, subs)
 	if err != nil {
+		if errors.Is(err, errPlannerExhausted) {
+			return linearChainFallback(subs)
+		}
 		return Plan{}, err
 	}
 	if flatPlanSuspicious(plan, subs) {
@@ -119,7 +137,59 @@ func attemptPlan(ctx context.Context, run Runner, idx refIndex, prompt string, s
 		}
 		return plan, nil
 	}
-	return Plan{}, fmt.Errorf("planner produced no valid plan in %d attempts: %w", plannerAttempts, lastErr)
+	return Plan{}, fmt.Errorf("planner produced no valid plan in %d attempts: %w: %w", plannerAttempts, errPlannerExhausted, lastErr)
+}
+
+// linearChainFallback builds a fully-serial fallback plan for when the
+// planner exhausts its retries without producing a valid DAG: sub-issues are
+// ordered by numeric issue number (ties and non-numeric refs keep fetch
+// order, via a stable sort), and each open child depends on the previous open
+// child. A closed sub-issue carries no edges — ChildSpecs already drops any
+// dependency on a closed sub-issue as satisfied — so a closed sub-issue in
+// the middle of the chain cannot split the remaining open children into
+// parallel islands; the open child that follows it still chains to the last
+// open child before it. MaxParallel is pinned to 1 and Fallback is set so
+// callers can surface the degradation. The constructed plan still runs
+// through validate as a real guard: a validation failure is returned rather
+// than silently committing a malformed chain.
+func linearChainFallback(subs []SubIssue) (Plan, error) {
+	type numberedSub struct {
+		sub    SubIssue
+		num    int
+		hasNum bool
+	}
+	keyed := make([]numberedSub, len(subs))
+	for i, s := range subs {
+		ns := numberedSub{sub: s}
+		if n, err := strconv.Atoi(numberOf(NormalizeIssueRef(s.Ref))); err == nil {
+			ns.num, ns.hasNum = n, true
+		}
+		keyed[i] = ns
+	}
+	sort.SliceStable(keyed, func(i, j int) bool {
+		if keyed[i].hasNum && keyed[j].hasNum {
+			return keyed[i].num < keyed[j].num
+		}
+		return false
+	})
+
+	p := Plan{MaxParallel: 1, Fallback: true}
+	prevOpen := ""
+	for _, ks := range keyed {
+		canon := NormalizeIssueRef(ks.sub.Ref)
+		child := PlannedChild{Ref: canon}
+		if !ks.sub.Closed {
+			if prevOpen != "" {
+				child.DependsOn = []string{prevOpen}
+			}
+			prevOpen = canon
+		}
+		p.Children = append(p.Children, child)
+	}
+	if err := p.validate(subs); err != nil {
+		return Plan{}, fmt.Errorf("linear-chain fallback failed validation: %w", err)
+	}
+	return p, nil
 }
 
 // flatPlanSuspicious reports whether a validated plan looks like it skipped

--- a/internal/umbrella/planner.go
+++ b/internal/umbrella/planner.go
@@ -166,12 +166,26 @@ func linearChainFallback(subs []SubIssue) (Plan, error) {
 		}
 		keyed[i] = ns
 	}
-	sort.SliceStable(keyed, func(i, j int) bool {
-		if keyed[i].hasNum && keyed[j].hasNum {
-			return keyed[i].num < keyed[j].num
+	// Sort only the numbered entries by number, then drop them back into the
+	// slots they originally occupied. Non-numbered entries never move, so
+	// they keep fetch order and numeric entries reorder around them instead
+	// of being blocked by a non-numeric ref sitting between them.
+	var numberedIdx []int
+	for i, ns := range keyed {
+		if ns.hasNum {
+			numberedIdx = append(numberedIdx, i)
 		}
-		return false
+	}
+	numbered := make([]numberedSub, len(numberedIdx))
+	for i, idx := range numberedIdx {
+		numbered[i] = keyed[idx]
+	}
+	sort.SliceStable(numbered, func(i, j int) bool {
+		return numbered[i].num < numbered[j].num
 	})
+	for i, idx := range numberedIdx {
+		keyed[idx] = numbered[i]
+	}
 
 	p := Plan{MaxParallel: 1, Fallback: true}
 	prevOpen := ""

--- a/internal/umbrella/planner_test.go
+++ b/internal/umbrella/planner_test.go
@@ -562,11 +562,51 @@ func TestGenerate(t *testing.T) {
 		}
 	})
 
-	t.Run("runner error", func(t *testing.T) {
+	t.Run("runner error stays fatal, fallback does not fire", func(t *testing.T) {
 		t.Parallel()
 		run := func(_ context.Context, _ string) (string, error) { return "", errors.New("boom") }
-		if _, err := Generate(context.Background(), run, "o/r#100", "body", subs("o/r#1")); err == nil {
-			t.Error("expected runner error to propagate")
+		_, err := Generate(context.Background(), run, "o/r#100", "body", subs("o/r#1"))
+		if err == nil {
+			t.Fatal("expected runner error to propagate")
+		}
+		if errors.Is(err, errPlannerExhausted) {
+			t.Errorf("runner error must not match errPlannerExhausted (fallback must not fire): %v", err)
+		}
+	})
+
+	t.Run("exhausted retries fall back to a linear chain instead of erroring", func(t *testing.T) {
+		t.Parallel()
+		run := func(_ context.Context, _ string) (string, error) { return "not json", nil }
+		plan, err := Generate(context.Background(), run, "o/r#100", "body", subs("o/r#1", "o/r#2", "o/r#3"))
+		if err != nil {
+			t.Fatalf("Generate: %v, want a fallback plan instead of an error", err)
+		}
+		if !plan.Fallback {
+			t.Fatalf("Fallback = false, want true")
+		}
+		if plan.MaxParallel != 1 {
+			t.Fatalf("MaxParallel = %d, want 1", plan.MaxParallel)
+		}
+		if len(plan.Children) != 3 {
+			t.Fatalf("Children = %d, want 3", len(plan.Children))
+		}
+		depsOf := func(ref string) []string {
+			for _, c := range plan.Children {
+				if c.Ref == ref {
+					return c.DependsOn
+				}
+			}
+			t.Fatalf("no child %s in fallback plan", ref)
+			return nil
+		}
+		if got := depsOf("o/r#1"); len(got) != 0 {
+			t.Errorf("o/r#1 deps = %v, want none", got)
+		}
+		if got := depsOf("o/r#2"); len(got) != 1 || got[0] != "o/r#1" {
+			t.Errorf("o/r#2 deps = %v, want [o/r#1]", got)
+		}
+		if got := depsOf("o/r#3"); len(got) != 1 || got[0] != "o/r#2" {
+			t.Errorf("o/r#3 deps = %v, want [o/r#2]", got)
 		}
 	})
 
@@ -580,24 +620,36 @@ func TestGenerate(t *testing.T) {
 
 	t.Run("cycle rejected", func(t *testing.T) {
 		t.Parallel()
+		// A persistently cyclic plan is never accepted as valid; attemptPlan
+		// exhausts its retries and Generate falls back to a linear chain
+		// rather than committing the cyclic plan or hard-erroring.
 		cyclic := `{"children":[{"issue":"o/r#1","dependsOn":["o/r#2"]},{"issue":"o/r#2","dependsOn":["o/r#1"]}],"maxParallel":2}`
 		run := func(_ context.Context, _ string) (string, error) { return cyclic, nil }
-		if _, err := Generate(context.Background(), run, "o/r#100", "body", subs("o/r#1", "o/r#2")); err == nil {
-			t.Error("expected cycle to be rejected")
+		plan, err := Generate(context.Background(), run, "o/r#100", "body", subs("o/r#1", "o/r#2"))
+		if err != nil {
+			t.Fatalf("Generate: %v, want a fallback plan instead of an error", err)
+		}
+		if !plan.Fallback {
+			t.Fatalf("expected the cyclic plan to be rejected in favor of a fallback: %+v", plan)
 		}
 	})
 
-	t.Run("cycle derived from mutual requires/produces is rejected", func(t *testing.T) {
+	t.Run("cycle derived from mutual requires/produces falls back", func(t *testing.T) {
 		t.Parallel()
 		// No explicit dependsOn — the cycle only exists once deriveEdges turns
-		// each side's "requires" into an edge on the other's "produces".
+		// each side's "requires" into an edge on the other's "produces". Same
+		// exhaustion-then-fallback behavior as the explicit-cycle case above.
 		cyclic := `{"children":[` +
 			`{"issue":"o/r#1","produces":["A"],"requires":["B"]},` +
 			`{"issue":"o/r#2","produces":["B"],"requires":["A"]}` +
 			`],"maxParallel":2}`
 		run := func(_ context.Context, _ string) (string, error) { return cyclic, nil }
-		if _, err := Generate(context.Background(), run, "o/r#100", "body", subs("o/r#1", "o/r#2")); err == nil {
-			t.Error("expected derived cycle to be rejected")
+		plan, err := Generate(context.Background(), run, "o/r#100", "body", subs("o/r#1", "o/r#2"))
+		if err != nil {
+			t.Fatalf("Generate: %v, want a fallback plan instead of an error", err)
+		}
+		if !plan.Fallback {
+			t.Fatalf("expected the derived cycle to be rejected in favor of a fallback: %+v", plan)
 		}
 	})
 
@@ -681,6 +733,9 @@ func TestGenerate(t *testing.T) {
 		if len(plan.Children) != 3 {
 			t.Fatalf("expected fallback to original flat plan: %+v", plan)
 		}
+		if plan.Fallback {
+			t.Fatalf("re-ask failure must return the original valid plan, not linearChainFallback: %+v", plan)
+		}
 	})
 
 	t.Run("re-ask context deadline falls back to original plan", func(t *testing.T) {
@@ -698,6 +753,9 @@ func TestGenerate(t *testing.T) {
 		if len(plan.Children) != 3 {
 			t.Fatalf("expected fallback to original flat plan: %+v", plan)
 		}
+		if plan.Fallback {
+			t.Fatalf("re-ask failure must return the original valid plan, not linearChainFallback: %+v", plan)
+		}
 	})
 
 	t.Run("no re-ask when fewer than three non-done children", func(t *testing.T) {
@@ -714,6 +772,188 @@ func TestGenerate(t *testing.T) {
 			t.Fatalf("expected no re-ask below the 3-child floor, got %d calls", calls)
 		}
 	})
+}
+
+func TestLinearChainFallback(t *testing.T) {
+	t.Parallel()
+
+	depsOf := func(t *testing.T, p Plan, ref string) []string {
+		t.Helper()
+		for _, c := range p.Children {
+			if c.Ref == ref {
+				return c.DependsOn
+			}
+		}
+		t.Fatalf("no child %s in fallback plan", ref)
+		return nil
+	}
+
+	t.Run("orders by issue number regardless of fetch order", func(t *testing.T) {
+		t.Parallel()
+		p, err := linearChainFallback(subs("o/r#3", "o/r#1", "o/r#2"))
+		if err != nil {
+			t.Fatalf("linearChainFallback: %v", err)
+		}
+		if len(depsOf(t, p, "o/r#1")) != 0 {
+			t.Errorf("o/r#1 should be first, deps = %v", depsOf(t, p, "o/r#1"))
+		}
+		if got := depsOf(t, p, "o/r#2"); len(got) != 1 || got[0] != "o/r#1" {
+			t.Errorf("o/r#2 deps = %v, want [o/r#1]", got)
+		}
+		if got := depsOf(t, p, "o/r#3"); len(got) != 1 || got[0] != "o/r#2" {
+			t.Errorf("o/r#3 deps = %v, want [o/r#2]", got)
+		}
+	})
+
+	t.Run("closed sub mid-chain keeps remaining open children serially chained", func(t *testing.T) {
+		t.Parallel()
+		s := []SubIssue{
+			{Ref: "o/r#1"},
+			{Ref: "o/r#2", Closed: true},
+			{Ref: "o/r#3"},
+			{Ref: "o/r#4"},
+		}
+		p, err := linearChainFallback(s)
+		if err != nil {
+			t.Fatalf("linearChainFallback: %v", err)
+		}
+		if got := depsOf(t, p, "o/r#2"); len(got) != 0 {
+			t.Errorf("closed o/r#2 should carry no edges, got %v", got)
+		}
+		// #3 must chain to the last OPEN sibling (#1), skipping the closed #2 —
+		// not split into a parallel island by the gap.
+		if got := depsOf(t, p, "o/r#3"); len(got) != 1 || got[0] != "o/r#1" {
+			t.Errorf("o/r#3 deps = %v, want [o/r#1] (skips closed o/r#2)", got)
+		}
+		if got := depsOf(t, p, "o/r#4"); len(got) != 1 || got[0] != "o/r#3" {
+			t.Errorf("o/r#4 deps = %v, want [o/r#3]", got)
+		}
+	})
+
+	t.Run("covers every sub-issue exactly once", func(t *testing.T) {
+		t.Parallel()
+		s := subs("o/r#1", "o/r#2", "o/r#3")
+		p, err := linearChainFallback(s)
+		if err != nil {
+			t.Fatalf("linearChainFallback: %v", err)
+		}
+		if err := p.validate(s); err != nil {
+			t.Errorf("validate: %v", err)
+		}
+		if len(p.Children) != len(s) {
+			t.Errorf("Children = %d, want %d", len(p.Children), len(s))
+		}
+	})
+
+	t.Run("ties on issue number keep fetch order", func(t *testing.T) {
+		t.Parallel()
+		// o/r#1 and x/y#1 share the numeric tail "1" but are different
+		// sub-issues (different repos); the tie must not reorder them.
+		s := []SubIssue{{Ref: "o/r#1"}, {Ref: "x/y#1"}, {Ref: "o/r#2"}}
+		p, err := linearChainFallback(s)
+		if err != nil {
+			t.Fatalf("linearChainFallback: %v", err)
+		}
+		if got := depsOf(t, p, "x/y#1"); len(got) != 1 || got[0] != "o/r#1" {
+			t.Errorf("x/y#1 deps = %v, want [o/r#1] (tie keeps fetch order)", got)
+		}
+		if got := depsOf(t, p, "o/r#2"); len(got) != 1 || got[0] != "x/y#1" {
+			t.Errorf("o/r#2 deps = %v, want [x/y#1]", got)
+		}
+	})
+
+	t.Run("non-numeric refs keep fetch order", func(t *testing.T) {
+		t.Parallel()
+		s := []SubIssue{{Ref: "o/r#foo"}, {Ref: "o/r#bar"}, {Ref: "o/r#baz"}}
+		p, err := linearChainFallback(s)
+		if err != nil {
+			t.Fatalf("linearChainFallback: %v", err)
+		}
+		if got := depsOf(t, p, "o/r#bar"); len(got) != 1 || got[0] != "o/r#foo" {
+			t.Errorf("o/r#bar deps = %v, want [o/r#foo] (fetch order preserved)", got)
+		}
+		if got := depsOf(t, p, "o/r#baz"); len(got) != 1 || got[0] != "o/r#bar" {
+			t.Errorf("o/r#baz deps = %v, want [o/r#bar]", got)
+		}
+	})
+
+	t.Run("semantic agreement: same serial reachability as a metadata-free plan", func(t *testing.T) {
+		t.Parallel()
+		// A closed sub-issue sits mid-chain so the fallback's sparse edges
+		// (chain to the last OPEN sibling) differ textually from a
+		// metadata-free plan run through deriveEdges (which serializes
+		// against every earlier canonical sibling, closed or not). Both must
+		// still materialize to the same reachability/topological order over
+		// the open children once ChildSpecs drops edges into closed subs.
+		s := []SubIssue{
+			{Ref: "o/r#1"},
+			{Ref: "o/r#2", Closed: true},
+			{Ref: "o/r#3"},
+			{Ref: "o/r#4"},
+		}
+		fallback, err := linearChainFallback(s)
+		if err != nil {
+			t.Fatalf("linearChainFallback: %v", err)
+		}
+
+		dense := Plan{Children: []PlannedChild{
+			{Ref: "o/r#1"}, {Ref: "o/r#2"}, {Ref: "o/r#3"}, {Ref: "o/r#4"},
+		}}
+		dense.deriveEdges(s)
+		if err := dense.validate(s); err != nil {
+			t.Fatalf("dense plan validate: %v", err)
+		}
+
+		existing := map[string]bool{}
+		fallbackDeps := depsMap(ChildSpecs(fallback, s, existing))
+		denseDeps := depsMap(ChildSpecs(dense, s, existing))
+
+		open := []string{"o/r#1", "o/r#3", "o/r#4"} // canonical order, closed o/r#2 excluded
+		for i, later := range open {
+			for _, earlier := range open[:i] {
+				if !reachableFrom(fallbackDeps, later, earlier) {
+					t.Errorf("fallback: %s should transitively depend on %s", later, earlier)
+				}
+				if !reachableFrom(denseDeps, later, earlier) {
+					t.Errorf("dense: %s should transitively depend on %s", later, earlier)
+				}
+			}
+		}
+		// No back-edges: nothing earlier depends on something later, in either plan.
+		for i, earlier := range open {
+			for _, later := range open[i+1:] {
+				if reachableFrom(fallbackDeps, earlier, later) {
+					t.Errorf("fallback: %s must not depend on later sibling %s", earlier, later)
+				}
+				if reachableFrom(denseDeps, earlier, later) {
+					t.Errorf("dense: %s must not depend on later sibling %s", earlier, later)
+				}
+			}
+		}
+	})
+}
+
+// depsMap flattens ChildSpecs into ref -> DependsOn for reachability checks.
+func depsMap(specs []ChildSpec) map[string][]string {
+	out := make(map[string][]string, len(specs))
+	for _, s := range specs {
+		out[s.Issue] = s.DependsOn
+	}
+	return out
+}
+
+// reachableFrom walks deps transitively from `from`, reporting whether
+// `target` is reachable.
+func reachableFrom(deps map[string][]string, from, target string) bool {
+	if from == target {
+		return true
+	}
+	for _, d := range deps[from] {
+		if reachableFrom(deps, d, target) {
+			return true
+		}
+	}
+	return false
 }
 
 func TestFlatPlanSuspicious(t *testing.T) {

--- a/internal/umbrella/planner_test.go
+++ b/internal/umbrella/planner_test.go
@@ -877,6 +877,26 @@ func TestLinearChainFallback(t *testing.T) {
 		}
 	})
 
+	t.Run("mixed numeric and non-numeric refs still sort numeric ones by number", func(t *testing.T) {
+		t.Parallel()
+		// A leading non-numeric ref must not block later numeric refs from
+		// being reordered into numeric order around it.
+		s := []SubIssue{{Ref: "o/r#foo"}, {Ref: "o/r#3"}, {Ref: "o/r#1"}, {Ref: "o/r#2"}}
+		p, err := linearChainFallback(s)
+		if err != nil {
+			t.Fatalf("linearChainFallback: %v", err)
+		}
+		if got := depsOf(t, p, "o/r#1"); len(got) != 1 || got[0] != "o/r#foo" {
+			t.Errorf("o/r#1 deps = %v, want [o/r#foo] (non-numeric keeps its fetch slot)", got)
+		}
+		if got := depsOf(t, p, "o/r#2"); len(got) != 1 || got[0] != "o/r#1" {
+			t.Errorf("o/r#2 deps = %v, want [o/r#1]", got)
+		}
+		if got := depsOf(t, p, "o/r#3"); len(got) != 1 || got[0] != "o/r#2" {
+			t.Errorf("o/r#3 deps = %v, want [o/r#2]", got)
+		}
+	})
+
 	t.Run("semantic agreement: same serial reachability as a metadata-free plan", func(t *testing.T) {
 		t.Parallel()
 		// A closed sub-issue sits mid-chain so the fallback's sparse edges

--- a/internal/umbrella/tags.go
+++ b/internal/umbrella/tags.go
@@ -10,6 +10,12 @@ import (
 // suffix, e.g. "umbrella-max-parallel:5".
 const MaxParallelTagPrefix = "umbrella-max-parallel:"
 
+// FallbackTag marks an umbrella tracker whose DAG was built by
+// linearChainFallback (the planner exhausted its retries) instead of the
+// model, so a systematically-failing planner is board-visible rather than
+// silently masked.
+const FallbackTag = "umbrella-planner-fallback"
+
 // MaxParallelTag renders the tracker tag encoding n.
 func MaxParallelTag(n int) string {
 	return MaxParallelTagPrefix + strconv.Itoa(n)


### PR DESCRIPTION
## Motivation

When the DAG planner exhausts its retries without producing a valid plan, umbrella expansion currently aborts entirely. This leaves the umbrella un-expanded with no visible signal beyond a log line, and a systematically-failing planner blocks the whole DAG from materializing.

## Implementation information

- `internal/umbrella/planner.go`: introduce `errPlannerExhausted`, wrapped from `attemptPlan`'s exhaustion return so `Generate` can distinguish it (via `errors.Is`) from a fatal runner error. On exhaustion, `Generate` falls back to `linearChainFallback`, which builds a fully-serial plan ordered by issue number (stable sort for ties/non-numeric refs), chaining each open child to the previous open child while skipping closed sub-issues without splitting the chain. `MaxParallel` is pinned to 1 and `Plan.Fallback` is set; the fallback plan still runs through `validate`.
- `internal/umbrella/expand.go`: thread `trackerID` and `Plan.Fallback` through `scanExisting`/`materialize` so a degraded expansion tags the tracker with `FallbackTag` — at creation time on a fresh tracker, or idempotently via `tagTrackerDegraded` (read-then-append, skip if already tagged) on re-expansion against an existing tracker. `Result.Degraded` surfaces the state to callers.
- `internal/poll/issues.go`: log a WARN when a poll-driven expansion degrades.
- `cmd/sybra-cli/umbrella.go`: surface degradation in CLI output.
- Follow-up fix commit hardens `tagTrackerDegraded` to use `task.Manager.UpdateFn` (read-modify-write under the store's per-task lock) instead of separate `Get`+`Update` calls, closing a race window between the read and the write.

Closes https://github.com/Automaat/sybra/issues/1326

_Generated by Sybra harness_