### PR TITLE
fix(workflow): run plan critique-address step headless

### DIFF
--- a/internal/workflow/builtin/simple-task-plan.yaml
+++ b/internal/workflow/builtin/simple-task-plan.yaml
@@ -455,7 +455,11 @@ steps:
     type: run_agent
     config:
       role: plan
-      mode: interactive
+      # headless, like every other planning step: this runs autonomously with no
+      # human attached. An interactive-mode agent escapes the watchdog
+      # (internal/watchdog skips ag.Mode != "headless"), so a hang here wedges the
+      # workflow in `waiting` forever with no stall recovery.
+      mode: headless
       model: opus
       reuse_agent: true
       wait_for_status: plan-review

--- a/internal/workflow/builtin_test.go
+++ b/internal/workflow/builtin_test.go
@@ -169,6 +169,45 @@ func TestBuiltinSimpleTask_AddressCritiqueRevalidatesPlanArtifacts(t *testing.T)
 	}
 }
 
+// The planning pipeline runs autonomously with no human attached. Every
+// run_agent step must therefore be headless: an interactive-mode agent is
+// skipped by the watchdog (internal/watchdog only supervises ag.Mode ==
+// "headless"), so a hang leaves the workflow waiting forever with no stall
+// recovery — the failure mode that wedged task 3c1c4f12 in `planning`.
+func TestBuiltinSimpleTaskPlan_AgentStepsAreHeadless(t *testing.T) {
+	t.Parallel()
+
+	defs, err := BuiltinDefinitions()
+	if err != nil {
+		t.Fatalf("BuiltinDefinitions: %v", err)
+	}
+	var simple *Definition
+	for i := range defs {
+		if defs[i].ID == "simple-task-plan" {
+			simple = &defs[i]
+			break
+		}
+	}
+	if simple == nil {
+		t.Fatal("simple-task-plan builtin definition not found")
+	}
+
+	var agentSteps int
+	for i := range simple.Steps {
+		step := &simple.Steps[i]
+		if step.Type != StepRunAgent {
+			continue
+		}
+		agentSteps++
+		if step.Config.Mode != "headless" {
+			t.Errorf("run_agent step %q mode = %q, want headless (autonomous planning agents must stay under watchdog supervision)", step.ID, step.Config.Mode)
+		}
+	}
+	if agentSteps == 0 {
+		t.Fatal("expected simple-task-plan to contain run_agent steps")
+	}
+}
+
 func TestBuiltinSimpleTaskImplement_UsesCompactTaskView(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation

Task `3c1c4f12` sat in `planning` for 16+ hours with no progress. Root
cause: its `address_critique` plan-revision agent was a live-but-hung
`claude -p` process (0% CPU, no `result` event, never exited) that the
workflow waited on forever.

Why it was never recovered: the `address_critique` step in
`simple-task-plan` was configured `mode: interactive` — the only
`run_agent` step in any builtin that wasn't `headless`. The in-process
watchdog (`internal/watchdog`) only supervises headless agents (it skips
`ag.Mode != "headless"`), so this agent escaped stall/budget detection
entirely. On every restart Sybra just reattached to the still-alive pid
and kept `waiting`.

The planning pipeline runs autonomously with no human attached, so an
interactive-mode planning agent is wrong by design: no one drives the
tmux session, and it forfeits the watchdog safety net.

> Changelog: fix(workflow): run plan critique-address step headless

## Implementation information

- `internal/workflow/builtin/simple-task-plan.yaml`: `address_critique`
  step `mode: interactive` → `mode: headless`, matching every sibling
  planning step (triage/plan/critique_plan). This restores watchdog
  supervision, so a future hang here flows through the existing
  stall → `watchdog hang` → `ResumeStalled` → retry(2) → human-required
  contract instead of wedging in `waiting`.
- `internal/workflow/builtin_test.go`: regression test
  `TestBuiltinSimpleTaskPlan_AgentStepsAreHeadless` asserts every
  `run_agent` step in `simple-task-plan` is headless.

## Supporting documentation

- `golangci-lint run ./internal/workflow/...` — 0 issues
- `go test ./internal/workflow/ ./internal/watchdog/` — pass
