### PR TITLE
fix(tasks): reconcile orphaned URL-stub enrichment

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/taskservice.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/taskservice.ts
@@ -74,6 +74,24 @@ export function ListTasks(): $CancellablePromise<task$0.Task[]> {
 }
 
 /**
+ * ReconcilePendingEnrichment re-attempts GitHub enrichment for URL stubs whose
+ * initial async enrichment never completed. A stub is created with the raw URL
+ * as its title and the enrich-pending marker; enrichment then runs in a
+ * fire-and-forget goroutine that, on any failure (a transient GitHub rate
+ * limit / gateway blip, or the app exiting before it finished), simply logs and
+ * returns. The marker is never cleared, so the stub keeps its raw-URL title
+ * forever and — because URL stubs only dispatch a workflow once the marker
+ * clears — never starts one. This is the recovery path for that orphaned state:
+ * the still-present marker is the retry signal, and the enrich functions are
+ * idempotent, so re-running them either succeeds now or fails the same benign
+ * way. Driven from the maintenance pass so recovery is continuous rather than a
+ * one-shot at startup.
+ */
+export function ReconcilePendingEnrichment(): $CancellablePromise<void> {
+    return $Call.ByID(4012524128);
+}
+
+/**
  * UpdateTask applies field updates to a task. The workflow engine drives
  * all status-based transitions; this method only handles cleanup on done.
  * 

--- a/internal/sybra/app_orchestrator.go
+++ b/internal/sybra/app_orchestrator.go
@@ -51,6 +51,12 @@ func (a *App) maintenancePass() {
 	// Recover in-progress tasks whose agent died — runs continuously, not just at
 	// startup, to catch agents that finished without advancing the workflow.
 	a.recovery.RestartStaleInProgress()
+	// Re-attempt enrichment for URL stubs orphaned by a failed/interrupted
+	// initial fetch — otherwise they keep the enrich-pending marker (and their
+	// raw-URL title) forever and never dispatch a workflow.
+	if a.taskSvc != nil {
+		a.taskSvc.ReconcilePendingEnrichment()
+	}
 	a.worktrees.CleanupOrphaned()
 }
 

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -44,9 +44,10 @@ type TaskService struct {
 	// DAG instead of a flat task. Wired in wireServices; gated at call time on
 	// cfg.Umbrella.Enabled. nil in tests that don't exercise umbrellas.
 	umbrellaExpand func(issueURL string) (umbrella.Result, error)
-	// enrichReconciling holds task IDs whose enrichment the reconcile pass is
-	// re-attempting, so successive maintenance ticks don't stack a second
-	// goroutine on a stub whose gh fetch is still in flight. Zero value ready.
+	// enrichReconciling holds task IDs with an in-flight enrichment goroutine —
+	// either the original CreateTask async fetch or a reconcile-pass retry — so
+	// a maintenance tick never stacks a second concurrent gh fetch on the same
+	// stub. Zero value ready.
 	enrichReconciling sync.Map
 }
 
@@ -345,11 +346,15 @@ func (s *TaskService) CreateTask(title, body, mode string) (task.Task, error) {
 	}
 
 	if prRepo != "" {
+		s.enrichReconciling.Store(t.ID, struct{}{})
 		s.wg.Go(func() {
+			defer s.enrichReconciling.Delete(t.ID)
 			s.enrichFromPR(t.ID, prRepo, prNumber)
 		})
 	} else if issueRepo != "" {
+		s.enrichReconciling.Store(t.ID, struct{}{})
 		s.wg.Go(func() {
+			defer s.enrichReconciling.Delete(t.ID)
 			s.enrichFromIssue(t.ID, issueRepo, issueNumber)
 		})
 	}
@@ -662,6 +667,11 @@ func (s *TaskService) ReconcilePendingEnrichment() {
 	for i := range all {
 		t := all[i]
 		if !slices.Contains(t.Tags, enrichPendingTag) {
+			continue
+		}
+		// The user took the task out of the queue (e.g. cancelled/done); don't
+		// spend a GitHub fetch reviving it.
+		if task.IsTerminalStatus(t.Status) {
 			continue
 		}
 		// An in-flight agent means the stub is already being worked; leave it be.

--- a/internal/sybra/svc_tasks.go
+++ b/internal/sybra/svc_tasks.go
@@ -44,6 +44,10 @@ type TaskService struct {
 	// DAG instead of a flat task. Wired in wireServices; gated at call time on
 	// cfg.Umbrella.Enabled. nil in tests that don't exercise umbrellas.
 	umbrellaExpand func(issueURL string) (umbrella.Result, error)
+	// enrichReconciling holds task IDs whose enrichment the reconcile pass is
+	// re-attempting, so successive maintenance ticks don't stack a second
+	// goroutine on a stub whose gh fetch is still in flight. Zero value ready.
+	enrichReconciling sync.Map
 }
 
 type TamperReportDTO struct {
@@ -635,6 +639,66 @@ func (s *TaskService) enrichFromIssue(taskID, repo string, number int) {
 		s.startCreatedWorkflow(updated)
 	}
 	s.logger.Info("enrich-issue.done", "task_id", taskID, "title", issue.Title)
+}
+
+// ReconcilePendingEnrichment re-attempts GitHub enrichment for URL stubs whose
+// initial async enrichment never completed. A stub is created with the raw URL
+// as its title and the enrich-pending marker; enrichment then runs in a
+// fire-and-forget goroutine that, on any failure (a transient GitHub rate
+// limit / gateway blip, or the app exiting before it finished), simply logs and
+// returns. The marker is never cleared, so the stub keeps its raw-URL title
+// forever and — because URL stubs only dispatch a workflow once the marker
+// clears — never starts one. This is the recovery path for that orphaned state:
+// the still-present marker is the retry signal, and the enrich functions are
+// idempotent, so re-running them either succeeds now or fails the same benign
+// way. Driven from the maintenance pass so recovery is continuous rather than a
+// one-shot at startup.
+func (s *TaskService) ReconcilePendingEnrichment() {
+	all, err := s.tasks.List()
+	if err != nil {
+		s.logger.Error("enrich-reconcile.list", "err", err)
+		return
+	}
+	for i := range all {
+		t := all[i]
+		if !slices.Contains(t.Tags, enrichPendingTag) {
+			continue
+		}
+		// An in-flight agent means the stub is already being worked; leave it be.
+		if s.agents.HasRunningAgentForTask(t.ID) {
+			continue
+		}
+		// The stub still carries its raw URL as the title; re-derive the target.
+		prRepo, prNumber := github.ParsePRURL(t.Title)
+		issueRepo, issueNumber := github.ParseIssueURL(t.Title)
+		if prRepo == "" && issueRepo == "" {
+			// Title no longer parses as a GitHub URL (manually edited) yet the
+			// marker lingers — nothing to fetch. Warn once per tick; leave the
+			// task for the user to resolve.
+			s.logger.Warn("enrich-reconcile.unparseable", "task_id", t.ID, "title", t.Title)
+			continue
+		}
+		// Dedupe across ticks: skip if a reconcile enrichment is already running
+		// for this task (a slow gh call can span more than one maintenance tick).
+		if _, inFlight := s.enrichReconciling.LoadOrStore(t.ID, struct{}{}); inFlight {
+			continue
+		}
+		id := t.ID
+		s.logger.Info("enrich-reconcile.retry", "task_id", id, "title", t.Title)
+		if prRepo != "" {
+			repo, number := prRepo, prNumber
+			s.wg.Go(func() {
+				defer s.enrichReconciling.Delete(id)
+				s.enrichFromPR(id, repo, number)
+			})
+			continue
+		}
+		repo, number := issueRepo, issueNumber
+		s.wg.Go(func() {
+			defer s.enrichReconciling.Delete(id)
+			s.enrichFromIssue(id, repo, number)
+		})
+	}
 }
 
 // umbrellaExpansionEnabled reports whether a detected umbrella issue should be

--- a/internal/sybra/svc_tasks_test.go
+++ b/internal/sybra/svc_tasks_test.go
@@ -683,3 +683,84 @@ func TestTaskService_CreateTask_IssueURLNoPRStartsWorkflowAfterEnrichment(t *tes
 		t.Fatalf("Status = %q, want workflow-owned issue status", got.Status)
 	}
 }
+
+func TestTaskService_ReconcilePendingEnrichment_RetriesOrphanedStub(t *testing.T) {
+	svc, _ := setupTaskService(t)
+
+	var succeed atomic.Bool
+	svc.fetchIssue = func(string, int) (github.Issue, error) {
+		if !succeed.Load() {
+			return github.Issue{}, errors.New("gh issue view: API rate limit exceeded")
+		}
+		return github.Issue{
+			Number:     42,
+			Title:      "recovered issue",
+			URL:        "https://github.com/owner/repo/issues/42",
+			Repository: "owner/repo",
+		}, nil
+	}
+	svc.fetchIssueLinkedPRs = func(string, int) ([]github.PullRequest, error) { return nil, nil }
+	svc.viewerLogin = func() string { return "me" }
+
+	// The initial async fetch fails, orphaning the stub with the marker intact.
+	created, err := svc.CreateTask("https://github.com/owner/repo/issues/42", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc.wg.Wait()
+
+	got, err := svc.GetTask(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(got.Tags, enrichPendingTag) {
+		t.Fatalf("Tags = %v, want enrich-pending marker after a failed initial fetch", got.Tags)
+	}
+	if got.Title != "https://github.com/owner/repo/issues/42" {
+		t.Fatalf("Title = %q, want the raw URL to survive a failed fetch", got.Title)
+	}
+	if got.Workflow != nil {
+		t.Fatalf("Workflow = %+v, want none while the stub is still enrich-pending", got.Workflow)
+	}
+
+	// gh recovers; the maintenance reconcile pass re-enriches and dispatches.
+	succeed.Store(true)
+	svc.ReconcilePendingEnrichment()
+	svc.wg.Wait()
+
+	got = waitForWorkflow(t, svc, created.ID)
+	if slices.Contains(got.Tags, enrichPendingTag) {
+		t.Fatalf("Tags = %v, marker should clear after reconcile", got.Tags)
+	}
+	if got.Title != "recovered issue" {
+		t.Fatalf("Title = %q, want enriched title after reconcile", got.Title)
+	}
+}
+
+func TestTaskService_ReconcilePendingEnrichment_SkipsNonStubs(t *testing.T) {
+	svc, _ := setupTaskService(t)
+
+	var fetched atomic.Bool
+	svc.fetchIssue = func(string, int) (github.Issue, error) {
+		fetched.Store(true)
+		return github.Issue{}, errors.New("should not be called")
+	}
+
+	// An ordinary task without the marker must never be touched by reconcile.
+	if _, err := svc.tasks.Create("ordinary task", "", "headless"); err != nil {
+		t.Fatal(err)
+	}
+	// A stub whose title is no longer a URL cannot be re-fetched; reconcile
+	// must skip it rather than crash or spuriously fetch.
+	if _, err := svc.tasks.CreateFull("hand-edited title", "", "headless",
+		task.Update{Tags: task.Ptr([]string{enrichPendingTag})}); err != nil {
+		t.Fatal(err)
+	}
+
+	svc.ReconcilePendingEnrichment()
+	svc.wg.Wait()
+
+	if fetched.Load() {
+		t.Fatal("reconcile fetched GitHub for a non-URL / unmarked task")
+	}
+}

--- a/internal/sybra/svc_tasks_test.go
+++ b/internal/sybra/svc_tasks_test.go
@@ -737,6 +737,79 @@ func TestTaskService_ReconcilePendingEnrichment_RetriesOrphanedStub(t *testing.T
 	}
 }
 
+func TestTaskService_ReconcilePendingEnrichment_SkipsTerminalStatus(t *testing.T) {
+	svc, _ := setupTaskService(t)
+
+	var fetched atomic.Bool
+	svc.fetchIssue = func(string, int) (github.Issue, error) {
+		fetched.Store(true)
+		return github.Issue{}, errors.New("should not be called")
+	}
+
+	// A stub the user cancelled must not be revived for another gh fetch.
+	if _, err := svc.tasks.CreateFull("https://github.com/owner/repo/issues/42", "", "headless",
+		task.Update{
+			Tags:   task.Ptr([]string{enrichPendingTag}),
+			Status: task.Ptr(task.StatusCancelled),
+		}); err != nil {
+		t.Fatal(err)
+	}
+
+	svc.ReconcilePendingEnrichment()
+	svc.wg.Wait()
+
+	if fetched.Load() {
+		t.Fatal("reconcile fetched GitHub for a stub with a terminal (cancelled) status")
+	}
+}
+
+func TestTaskService_ReconcilePendingEnrichment_SkipsInFlightInitialEnrichment(t *testing.T) {
+	svc, _ := setupTaskService(t)
+
+	var calls atomic.Int32
+	block := make(chan struct{})
+	release := make(chan struct{})
+	svc.fetchIssue = func(string, int) (github.Issue, error) {
+		calls.Add(1)
+		close(block)
+		<-release
+		return github.Issue{
+			Number:     42,
+			Title:      "recovered issue",
+			URL:        "https://github.com/owner/repo/issues/42",
+			Repository: "owner/repo",
+		}, nil
+	}
+	svc.fetchIssueLinkedPRs = func(string, int) ([]github.PullRequest, error) { return nil, nil }
+	svc.viewerLogin = func() string { return "me" }
+
+	// The original CreateTask enrichment goroutine is still in flight (blocked
+	// on the gh fetch) when a maintenance tick fires; reconcile must not start
+	// a second concurrent fetch for the same stub.
+	created, err := svc.CreateTask("https://github.com/owner/repo/issues/42", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-block
+
+	svc.ReconcilePendingEnrichment()
+
+	close(release)
+	svc.wg.Wait()
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("fetchIssue called %d times, want exactly 1 (reconcile must dedupe against the in-flight initial fetch)", got)
+	}
+
+	got, err := svc.GetTask(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Title != "recovered issue" {
+		t.Fatalf("Title = %q, want the enriched title once the in-flight fetch completes", got.Title)
+	}
+}
+
 func TestTaskService_ReconcilePendingEnrichment_SkipsNonStubs(t *testing.T) {
 	svc, _ := setupTaskService(t)
 


### PR DESCRIPTION
## Motivation

A GitHub URL stub (task created from a pasted issue/PR URL) is persisted with
the `enrich-pending` marker and its raw URL as the title, then enriched in a
fire-and-forget goroutine. On **any** fetch failure — a transient GitHub rate
limit / gateway blip, or the app exiting before the goroutine finishes — that
goroutine just logs and returns. The marker is never cleared, and since a URL
stub only dispatches its workflow once the marker clears, the task is orphaned
forever: stuck in `todo`, raw-URL title, empty body, no workflow.

Observed in the wild: a stub for issue #1327 hit `API rate limit already
exceeded` during enrichment and sat inert with no retry path anywhere in the
code.

> Changelog: fix(tasks): reconcile orphaned URL-stub enrichment

## Implementation information

- Add `TaskService.ReconcilePendingEnrichment`: scans for tasks that still carry
  the `enrich-pending` marker, re-derives the target repo/number from the
  still-present raw-URL title, and re-runs the idempotent `enrichFromIssue` /
  `enrichFromPR`.
- Wire it into the orchestrator **maintenance pass** (alongside `ResumeStalled`
  / `RestartStaleInProgress`) so recovery is continuous — a stub survives both
  transient fetch failures and app restarts, not just a one-shot at startup.
- Dedupe in-flight retries across ticks via a `sync.Map` guard so a slow `gh`
  call spanning multiple ticks isn't stacked; skip tasks with a running agent
  and stubs whose title is no longer a parseable URL.
- Tests: end-to-end retry of an orphaned stub (fetch fails → marker survives →
  reconcile re-enriches and dispatches the workflow) and a no-op guard for
  unmarked / non-URL tasks.

## Supporting documentation

`go test ./internal/sybra/...` and `golangci-lint run` pass.

_Generated by Sybra harness_