### PR TITLE
feat(umbrella): ground change-surface in repo

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -98,7 +98,7 @@ func run(args []string) int {
 	case "handoff":
 		return cmdHandoff(store, projStore, rest, jsonOut)
 	case "umbrella":
-		return cmdUmbrella(store, rest, jsonOut)
+		return cmdUmbrella(cfg, store, projStore, rest, jsonOut)
 	case "update":
 		return cmdUpdate(store, rest, jsonOut)
 	case "link-pr":

--- a/cmd/sybra-cli/umbrella.go
+++ b/cmd/sybra-cli/umbrella.go
@@ -53,11 +53,11 @@ func cliGroundLister(projStore *project.Store) umbrella.TrackedFilesFunc {
 		if err != nil {
 			return nil, fmt.Errorf("ground: project %s: %w", repo, err)
 		}
-		branch, err := project.DefaultBranch(p.ClonePath)
+		files, err := project.TrackedFilesAtDefaultBranch(p.ClonePath)
 		if err != nil {
-			return nil, fmt.Errorf("ground: default branch for %s: %w", repo, err)
+			return nil, fmt.Errorf("ground: tracked files for %s: %w", repo, err)
 		}
-		return project.ListTrackedFiles(p.ClonePath, "refs/heads/"+branch)
+		return files, nil
 	}
 }
 

--- a/cmd/sybra-cli/umbrella.go
+++ b/cmd/sybra-cli/umbrella.go
@@ -6,6 +6,8 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/umbrella"
 )
@@ -14,7 +16,7 @@ import (
 // `umbrella` tracker task plus one `blocked` child per sub-issue, with
 // dependency edges extracted by an LLM planner. Re-running is idempotent —
 // only sub-issues without an existing task are materialized.
-func cmdUmbrella(s *task.Manager, args []string, jsonOut bool) int {
+func cmdUmbrella(cfg *config.Config, s *task.Manager, projStore *project.Store, args []string, jsonOut bool) int {
 	fs := flag.NewFlagSet("umbrella", flag.ContinueOnError)
 	urlFlag := fs.String("url", "", "umbrella issue URL (or pass as first argument)")
 	model := fs.String("model", "", "planner model (default: claude default)")
@@ -29,11 +31,34 @@ func cmdUmbrella(s *task.Manager, args []string, jsonOut bool) int {
 		return fatal(jsonOut, "umbrella: an issue URL is required")
 	}
 
-	res, err := umbrella.Expand(context.Background(), s, umbrella.FallbackPlannerRunner(*model), issueURL)
+	var opts []umbrella.ExpandOption
+	if cfg.Umbrella.Ground {
+		opts = append(opts, umbrella.WithExpandGrounder(cliGroundLister(projStore), cfg.Umbrella.GroundMinSubIssues))
+	}
+
+	res, err := umbrella.Expand(context.Background(), s, umbrella.FallbackPlannerRunner(*model), issueURL, opts...)
 	if err != nil {
 		return fatal(jsonOut, "%v", err)
 	}
 	return reportUmbrella(jsonOut, res.UmbrellaURL, res.Created, res.Skipped, res.Degraded)
+}
+
+// cliGroundLister mirrors the GUI/auto-expand buildGroundLister wiring
+// (internal/sybra): repo -> registered project -> clone's default branch ->
+// tracked files at that branch, no network fetch. Any resolution failure
+// propagates so grounding fails open rather than silently skipping.
+func cliGroundLister(projStore *project.Store) umbrella.TrackedFilesFunc {
+	return func(_ context.Context, repo string) ([]string, error) {
+		p, err := projStore.Get(repo)
+		if err != nil {
+			return nil, fmt.Errorf("ground: project %s: %w", repo, err)
+		}
+		branch, err := project.DefaultBranch(p.ClonePath)
+		if err != nil {
+			return nil, fmt.Errorf("ground: default branch for %s: %w", repo, err)
+		}
+		return project.ListTrackedFiles(p.ClonePath, "refs/heads/"+branch)
+	}
 }
 
 func reportUmbrella(jsonOut bool, umbrellaURL string, created, skipped int, degraded bool) int {

--- a/internal/config/config_umbrella.go
+++ b/internal/config/config_umbrella.go
@@ -7,4 +7,12 @@ type UmbrellaConfig struct {
 	Enabled bool `yaml:"enabled" json:"enabled"`
 	// Model overrides the planner model (empty = claude default).
 	Model string `yaml:"model" json:"model"`
+	// Ground gates the optional grounding step that confirms each
+	// sub-issue's touches against the real repo's tracked files. Disabled
+	// by default (extra git/tool calls); additive on top of planner output.
+	Ground bool `yaml:"ground" json:"ground"`
+	// GroundMinSubIssues gates grounding on umbrella size: grounding only
+	// runs when the umbrella has at least this many sub-issues. Zero or
+	// negative means always ground when Ground is enabled.
+	GroundMinSubIssues int `yaml:"ground_min_sub_issues" json:"groundMinSubIssues"`
 }

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -155,6 +155,29 @@ func DefaultBranch(barePath string) (string, error) {
 	return filepath.Base(ref), nil
 }
 
+// ListTrackedFiles returns every file path tracked at ref in the bare repo,
+// via `git ls-tree -r --name-only`. An empty tree yields an empty (non-nil
+// wanted) slice; a missing ref returns an error.
+func ListTrackedFiles(barePath, ref string) ([]string, error) {
+	out, err := outputBare(barePath, "ls-tree", "-r", "--name-only", ref)
+	if err != nil {
+		return nil, err
+	}
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return nil, nil
+	}
+	lines := strings.Split(out, "\n")
+	files := make([]string, 0, len(lines))
+	for _, l := range lines {
+		l = strings.TrimSpace(l)
+		if l != "" {
+			files = append(files, l)
+		}
+	}
+	return files, nil
+}
+
 func FetchOrigin(barePath string) error {
 	// Explicit refspec heals bare repos cloned before remote.origin.fetch was
 	// configured, where `git fetch origin` silently skipped updating

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -164,18 +164,37 @@ func ListTrackedFiles(barePath, ref string) ([]string, error) {
 		return nil, err
 	}
 	out = strings.TrimSpace(out)
+	files := make([]string, 0)
 	if out == "" {
-		return nil, nil
+		return files, nil
 	}
-	lines := strings.Split(out, "\n")
-	files := make([]string, 0, len(lines))
-	for _, l := range lines {
+	for l := range strings.SplitSeq(out, "\n") {
 		l = strings.TrimSpace(l)
 		if l != "" {
 			files = append(files, l)
 		}
 	}
 	return files, nil
+}
+
+// TrackedFilesAtDefaultBranch resolves barePath's default branch and returns
+// the files tracked there, preferring the remote-tracking ref
+// (refs/remotes/origin/<branch>) and falling back to the local ref
+// (refs/heads/<branch>) if the tracking ref is absent. Bare clones don't keep
+// local heads current on fetch (remote.origin.fetch only updates
+// refs/remotes/origin/*, see CloneBare), so the tracking ref reflects pushed
+// state most reliably; the local-head fallback covers a fresh clone that
+// hasn't been fetched yet, where only refs/heads/* exist.
+func TrackedFilesAtDefaultBranch(barePath string) ([]string, error) {
+	branch, err := DefaultBranch(barePath)
+	if err != nil {
+		return nil, err
+	}
+	files, err := ListTrackedFiles(barePath, "refs/remotes/origin/"+branch)
+	if err == nil {
+		return files, nil
+	}
+	return ListTrackedFiles(barePath, "refs/heads/"+branch)
 }
 
 func FetchOrigin(barePath string) error {

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -1847,6 +1847,9 @@ func TestListTrackedFiles(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ListTrackedFiles on empty tree: %v", err)
 		}
+		if files == nil {
+			t.Error("files is nil, want non-nil empty slice")
+		}
 		if len(files) != 0 {
 			t.Errorf("files = %v, want empty", files)
 		}
@@ -1856,6 +1859,85 @@ func TestListTrackedFiles(t *testing.T) {
 		t.Parallel()
 		if _, err := ListTrackedFiles(bare, "refs/heads/does-not-exist"); err == nil {
 			t.Fatal("expected error for missing ref")
+		}
+	})
+}
+
+func TestTrackedFilesAtDefaultBranch(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+
+	t.Run("falls back to local head before first fetch", func(t *testing.T) {
+		t.Parallel()
+		src := initRepoWithCommit(t)
+		bare := filepath.Join(t.TempDir(), "bare.git")
+		if err := CloneBare(src, bare); err != nil {
+			t.Fatalf("CloneBare: %v", err)
+		}
+		// git clone --bare only populates refs/heads/*, not
+		// refs/remotes/origin/* (that requires a subsequent fetch), so this
+		// must resolve via the refs/heads/<branch> fallback.
+		files, err := TrackedFilesAtDefaultBranch(bare)
+		if err != nil {
+			t.Fatalf("TrackedFilesAtDefaultBranch: %v", err)
+		}
+		if len(files) != 1 || files[0] != "README.md" {
+			t.Fatalf("files = %v, want [README.md]", files)
+		}
+	})
+
+	t.Run("prefers remote-tracking ref once fetched", func(t *testing.T) {
+		t.Parallel()
+		src := initRepoWithCommit(t)
+		bare := filepath.Join(t.TempDir(), "bare.git")
+		if err := CloneBare(src, bare); err != nil {
+			t.Fatalf("CloneBare: %v", err)
+		}
+		branch, err := DefaultBranch(bare)
+		if err != nil {
+			t.Fatalf("DefaultBranch: %v", err)
+		}
+
+		// Add a file upstream and fetch it into the bare clone, but leave
+		// the local refs/heads/<branch> stale — simulates a bare clone
+		// that's been fetched without its local head being advanced.
+		if err := os.WriteFile(filepath.Join(src, "new.txt"), []byte("new"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		for _, args := range [][]string{
+			{"git", "-C", src, "add", "."},
+			{"git", "-C", src, "commit", "-m", "add new.txt"},
+		} {
+			if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+				t.Fatalf("%v: %v: %s", args, err, out)
+			}
+		}
+		if err := FetchOrigin(bare); err != nil {
+			t.Fatalf("FetchOrigin: %v", err)
+		}
+
+		files, err := TrackedFilesAtDefaultBranch(bare)
+		if err != nil {
+			t.Fatalf("TrackedFilesAtDefaultBranch: %v", err)
+		}
+		want := map[string]bool{"README.md": true, "new.txt": true}
+		if len(files) != len(want) {
+			t.Fatalf("files = %v, want %v", files, want)
+		}
+		for _, f := range files {
+			if !want[f] {
+				t.Errorf("unexpected file %q", f)
+			}
+		}
+		// The stale local head must not have been consulted.
+		staleFiles, err := ListTrackedFiles(bare, "refs/heads/"+branch)
+		if err != nil {
+			t.Fatalf("ListTrackedFiles on stale head: %v", err)
+		}
+		if len(staleFiles) != 1 {
+			t.Fatalf("expected stale local head to remain at 1 file, got %v", staleFiles)
 		}
 	})
 }

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -1776,3 +1776,86 @@ func TestFetchPRHead(t *testing.T) {
 		t.Fatalf("CreateWorktreeDetached from PR head: %v", err)
 	}
 }
+
+func TestListTrackedFiles(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+
+	src := t.TempDir()
+	for _, args := range [][]string{
+		{"git", "init", src},
+		{"git", "-C", src, "config", "user.email", "test@test.com"},
+		{"git", "-C", src, "config", "user.name", "Test"},
+	} {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v: %s", args, err, out)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(src, "internal", "foo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "internal", "foo", "bar.go"), []byte("package foo"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "README.md"), []byte("# test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "-C", src, "add", "."},
+		{"git", "-C", src, "commit", "-m", "init"},
+	} {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v: %s", args, err, out)
+		}
+	}
+	branch, err := exec.Command("git", "-C", src, "branch", "--show-current").CombinedOutput()
+	if err != nil {
+		t.Fatalf("branch --show-current: %v: %s", err, branch)
+	}
+	branchName := strings.TrimSpace(string(branch))
+
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(src, bare); err != nil {
+		t.Fatalf("CloneBare: %v", err)
+	}
+
+	t.Run("tracked files", func(t *testing.T) {
+		t.Parallel()
+		files, err := ListTrackedFiles(bare, "refs/heads/"+branchName)
+		if err != nil {
+			t.Fatalf("ListTrackedFiles: %v", err)
+		}
+		want := map[string]bool{"internal/foo/bar.go": true, "README.md": true}
+		if len(files) != len(want) {
+			t.Fatalf("files = %v, want %v", files, want)
+		}
+		for _, f := range files {
+			if !want[f] {
+				t.Errorf("unexpected file %q", f)
+			}
+		}
+	})
+
+	t.Run("empty tree", func(t *testing.T) {
+		t.Parallel()
+		empty := initBareRepo(t)
+		// The well-known empty-tree SHA1 is valid in every git repo without
+		// needing any commits.
+		files, err := ListTrackedFiles(empty, "4b825dc642cb6eb9a060e54bf8d69288fbee4904")
+		if err != nil {
+			t.Fatalf("ListTrackedFiles on empty tree: %v", err)
+		}
+		if len(files) != 0 {
+			t.Errorf("files = %v, want empty", files)
+		}
+	})
+
+	t.Run("missing ref", func(t *testing.T) {
+		t.Parallel()
+		if _, err := ListTrackedFiles(bare, "refs/heads/does-not-exist"); err == nil {
+			t.Fatal("expected error for missing ref")
+		}
+	})
+}

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -125,8 +125,14 @@ func (a *App) initIssuesFetcher(emit func(string, any)) *poll.IssuesFetcher {
 	f.SetPollInterval(a.cfg.GitHub.Issues())
 	if a.cfg.Umbrella.Enabled {
 		model := a.cfg.Umbrella.Model
+		ground := a.cfg.Umbrella.Ground
+		minSubs := a.cfg.Umbrella.GroundMinSubIssues
 		f.SetUmbrellaExpander(func(issueURL string) (umbrella.Result, error) {
-			return umbrella.Expand(context.Background(), a.tasks, umbrella.FallbackPlannerRunner(model, a.providerHealth), issueURL)
+			var opts []umbrella.ExpandOption
+			if ground {
+				opts = append(opts, umbrella.WithExpandGrounder(buildGroundLister(a.projects), minSubs))
+			}
+			return umbrella.Expand(context.Background(), a.tasks, umbrella.FallbackPlannerRunner(model, a.providerHealth), issueURL, opts...)
 		})
 		a.logger.Info("umbrella.autodetect.enabled")
 	}

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -373,11 +373,7 @@ func buildGroundLister(projStore *project.Store) umbrella.TrackedFilesFunc {
 		if err != nil {
 			return nil, fmt.Errorf("ground: project %s: %w", repo, err)
 		}
-		branch, err := project.DefaultBranch(p.ClonePath)
-		if err != nil {
-			return nil, fmt.Errorf("ground: default branch for %s: %w", repo, err)
-		}
-		files, err := project.ListTrackedFiles(p.ClonePath, "refs/heads/"+branch)
+		files, err := project.TrackedFilesAtDefaultBranch(p.ClonePath)
 		if err != nil {
 			return nil, fmt.Errorf("ground: tracked files for %s: %w", repo, err)
 		}

--- a/internal/sybra/app_umbrella_gate.go
+++ b/internal/sybra/app_umbrella_gate.go
@@ -1,12 +1,14 @@
 package sybra
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
 	"time"
 
 	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/umbrella"
 )
@@ -358,4 +360,27 @@ func (a *App) closeUmbrellaIssue(umbRef string) (retry bool) {
 	}
 	a.logger.Info("umbrella.closed", "repo", repo, "number", number)
 	return false
+}
+
+// buildGroundLister returns a TrackedFilesFunc backed by projStore's existing
+// bare clones: it resolves repo -> registered project -> clone's default
+// branch -> tracked files at that branch, with no network fetch. Any
+// resolution failure (unregistered repo, unreadable clone) is returned to the
+// caller so grounding fails open rather than silently skipping.
+func buildGroundLister(projStore *project.Store) umbrella.TrackedFilesFunc {
+	return func(_ context.Context, repo string) ([]string, error) {
+		p, err := projStore.Get(repo)
+		if err != nil {
+			return nil, fmt.Errorf("ground: project %s: %w", repo, err)
+		}
+		branch, err := project.DefaultBranch(p.ClonePath)
+		if err != nil {
+			return nil, fmt.Errorf("ground: default branch for %s: %w", repo, err)
+		}
+		files, err := project.ListTrackedFiles(p.ClonePath, "refs/heads/"+branch)
+		if err != nil {
+			return nil, fmt.Errorf("ground: tracked files for %s: %w", repo, err)
+		}
+		return files, nil
+	}
 }

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -1,12 +1,17 @@
 package sybra
 
 import (
+	"context"
 	"errors"
 	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 
+	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/umbrella"
 )
@@ -539,5 +544,131 @@ func TestReleaseUnblockedChildren_NoUmbrellaNoOp(t *testing.T) {
 	app.releaseUnblockedChildren()
 	if got := mustStatus(t, m, tk.ID); got != task.StatusBlocked {
 		t.Fatalf("plain blocked task changed to %q, want blocked", got)
+	}
+}
+
+// mustWriteProjectYAMLWithClone writes a minimal project YAML that resolves
+// via project.Store.Get with ClonePath pointed at a real bare clone, so
+// buildGroundLister can exercise the real DefaultBranch + ListTrackedFiles
+// path without a network fetch.
+func mustWriteProjectYAMLWithClone(t *testing.T, dir, id, clonePath string) {
+	t.Helper()
+	safe := strings.ReplaceAll(id, "/", "--")
+	path := filepath.Join(dir, safe+".yaml")
+	content := "id: " + id + "\ntype: pet\nowner: stub\nrepo: stub\nclone_path: " + clonePath + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write project YAML: %v", err)
+	}
+}
+
+// newBareRepoWithTrackedFile creates a source repo with one committed file,
+// bare-clones it, and returns the bare clone path and its default branch.
+func newBareRepoWithTrackedFile(t *testing.T) (barePath, branch string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	src := t.TempDir()
+	for _, args := range [][]string{
+		{"git", "init", src},
+		{"git", "-C", src, "config", "user.email", "test@test.com"},
+		{"git", "-C", src, "config", "user.name", "Test"},
+	} {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v: %s", args, err, out)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(src, "internal", "foo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "internal", "foo", "bar.go"), []byte("package foo"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "-C", src, "add", "."},
+		{"git", "-C", src, "commit", "-m", "init"},
+	} {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v: %s", args, err, out)
+		}
+	}
+	branchOut, err := exec.Command("git", "-C", src, "branch", "--show-current").CombinedOutput()
+	if err != nil {
+		t.Fatalf("branch --show-current: %v: %s", err, branchOut)
+	}
+	branch = strings.TrimSpace(string(branchOut))
+
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := project.CloneBare(src, bare); err != nil {
+		t.Fatalf("CloneBare: %v", err)
+	}
+	return bare, branch
+}
+
+func TestBuildGroundLister(t *testing.T) {
+	t.Parallel()
+	bare, _ := newBareRepoWithTrackedFile(t)
+
+	dir := t.TempDir()
+	store, err := project.NewStore(dir, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	mustWriteProjectYAMLWithClone(t, dir, "o/r", bare)
+
+	lister := buildGroundLister(store)
+
+	t.Run("resolves tracked files for a registered project", func(t *testing.T) {
+		t.Parallel()
+		files, err := lister(context.Background(), "o/r")
+		if err != nil {
+			t.Fatalf("lister: %v", err)
+		}
+		if len(files) != 1 || files[0] != "internal/foo/bar.go" {
+			t.Fatalf("files = %v, want [internal/foo/bar.go]", files)
+		}
+	})
+
+	t.Run("fails open for an unregistered project", func(t *testing.T) {
+		t.Parallel()
+		if _, err := lister(context.Background(), "no/such-project"); err == nil {
+			t.Fatal("expected an error for an unregistered project")
+		}
+	})
+}
+
+// TestUmbrellaGroundingWired proves the wiring contract: the umbrella.Ground
+// config toggle controls whether a lister-backed ExpandOption is threaded
+// through, for both the GitHub-issues-fetcher path (app_init.go) and the
+// manual/GUI expand path (services_wire_tasks.go). It exercises the same
+// closure-building logic those files use rather than reaching into private
+// App internals that would require a full app.Startup().
+func TestUmbrellaGroundingWired(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	store, err := project.NewStore(dir, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	cases := []struct {
+		name       string
+		ground     bool
+		wantLister bool
+	}{
+		{"ground enabled threads a grounder", true, true},
+		{"ground disabled leaves grounding off", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var opts []umbrella.ExpandOption
+			if tc.ground {
+				opts = append(opts, umbrella.WithExpandGrounder(buildGroundLister(store), 0))
+			}
+			if got := len(opts) > 0; got != tc.wantLister {
+				t.Fatalf("grounder threaded = %v, want %v", got, tc.wantLister)
+			}
+		})
 	}
 }

--- a/internal/sybra/services_wire_tasks.go
+++ b/internal/sybra/services_wire_tasks.go
@@ -24,6 +24,10 @@ func (a *App) wireTaskService() {
 	// Read a.cfg inside the closure so config reloads update the planner model.
 	// Mirrors initIssuesFetcher's poll-loop expander (same Expand entry point).
 	a.taskSvc.umbrellaExpand = func(issueURL string) (umbrella.Result, error) {
-		return umbrella.Expand(context.Background(), a.tasks, umbrella.FallbackPlannerRunner(a.cfg.Umbrella.Model, a.providerHealth), issueURL)
+		var opts []umbrella.ExpandOption
+		if a.cfg.Umbrella.Ground {
+			opts = append(opts, umbrella.WithExpandGrounder(buildGroundLister(a.projects), a.cfg.Umbrella.GroundMinSubIssues))
+		}
+		return umbrella.Expand(context.Background(), a.tasks, umbrella.FallbackPlannerRunner(a.cfg.Umbrella.Model, a.providerHealth), issueURL, opts...)
 	}
 }

--- a/internal/umbrella/expand.go
+++ b/internal/umbrella/expand.go
@@ -38,6 +38,25 @@ func fetchUmbrellaBounded(ctx context.Context, repo string, number int) (umbrell
 	return github.FetchUmbrella(fctx, repo, number)
 }
 
+// expandConfig holds the optional settings ExpandOption values apply.
+type expandConfig struct {
+	lister  TrackedFilesFunc
+	minSubs int
+}
+
+// ExpandOption configures an optional Expand behavior.
+type ExpandOption func(*expandConfig)
+
+// WithExpandGrounder threads a tracked-file lister into the planner's
+// grounding step (see WithGrounder). Omitting this option leaves Expand's
+// behavior unchanged (today's LLM-only touches).
+func WithExpandGrounder(lister TrackedFilesFunc, minSubs int) ExpandOption {
+	return func(c *expandConfig) {
+		c.lister = lister
+		c.minSubs = minSubs
+	}
+}
+
 // Result summarizes an expansion.
 type Result struct {
 	UmbrellaURL string
@@ -53,7 +72,11 @@ type Result struct {
 // re-run skips the planner entirely. The planner run is bounded by
 // PlannerTimeout. Shared by the `sybra-cli umbrella` command and the GitHub
 // issue fetcher's auto-detect path.
-func Expand(ctx context.Context, tasks *task.Manager, run Runner, issueURL string) (Result, error) {
+func Expand(ctx context.Context, tasks *task.Manager, run Runner, issueURL string, opts ...ExpandOption) (Result, error) {
+	var cfg expandConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 	repo, number, ok := ParseRef(issueURL)
 	if !ok {
 		return Result{}, fmt.Errorf("not a GitHub issue URL: %s", issueURL)
@@ -89,9 +112,14 @@ func Expand(ctx context.Context, tasks *task.Manager, run Runner, issueURL strin
 		return Result{UmbrellaURL: umb.URL, Skipped: len(subs)}, nil
 	}
 
+	var genOpts []GenerateOption
+	if cfg.lister != nil {
+		genOpts = append(genOpts, WithGrounder(cfg.lister, cfg.minSubs))
+	}
+
 	pctx, cancel := context.WithTimeout(ctx, PlannerTimeout)
 	defer cancel()
-	plan, err := Generate(pctx, run, umb.URL, umb.Body, planSubs)
+	plan, err := Generate(pctx, run, umb.URL, umb.Body, planSubs, genOpts...)
 	if err != nil {
 		return Result{}, fmt.Errorf("plan umbrella: %w", err)
 	}

--- a/internal/umbrella/expand_test.go
+++ b/internal/umbrella/expand_test.go
@@ -1,6 +1,7 @@
 package umbrella
 
 import (
+	"context"
 	"slices"
 	"testing"
 
@@ -116,6 +117,30 @@ func TestScanExisting_ReturnsTrackerID(t *testing.T) {
 	if trackerID != tracker.ID {
 		t.Fatalf("trackerID = %q, want %q", trackerID, tracker.ID)
 	}
+}
+
+func TestExpandThreadsGrounder(t *testing.T) {
+	t.Parallel()
+	t.Run("WithExpandGrounder sets the lister and threshold", func(t *testing.T) {
+		t.Parallel()
+		lister := func(_ context.Context, _ string) ([]string, error) { return nil, nil }
+		var cfg expandConfig
+		WithExpandGrounder(lister, 5)(&cfg)
+		if cfg.lister == nil {
+			t.Fatal("lister not set")
+		}
+		if cfg.minSubs != 5 {
+			t.Fatalf("minSubs = %d, want 5", cfg.minSubs)
+		}
+	})
+
+	t.Run("no option leaves the grounder unset", func(t *testing.T) {
+		t.Parallel()
+		var cfg expandConfig
+		if cfg.lister != nil {
+			t.Fatal("lister should be nil without WithExpandGrounder")
+		}
+	})
 }
 
 func TestIsUmbrellaIssue(t *testing.T) {

--- a/internal/umbrella/ground.go
+++ b/internal/umbrella/ground.go
@@ -1,0 +1,229 @@
+package umbrella
+
+import (
+	"context"
+	"log/slog"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// TrackedFilesFunc resolves the set of file paths currently tracked in a
+// repo's default branch. Injected so grounding never network-fetches on the
+// hot expansion path and stays unit-testable without a real repo.
+type TrackedFilesFunc func(ctx context.Context, repo string) ([]string, error)
+
+// groundReport summarizes a Plan.ground run: which repos were successfully
+// grounded, and which repos/refs were skipped (fail-open — a lister error or
+// an unregistered repo never aborts expansion, it just leaves that child's
+// touches as the planner reported them).
+type groundReport struct {
+	groundedRepos []string
+	skipped       []string
+}
+
+var (
+	backtickSpanRe = regexp.MustCompile("`([^`]+)`")
+	// pathTokenRe matches slash-delimited, path-shaped tokens in plain text.
+	// A path shape requires at least one '/' so bare words are never treated
+	// as paths.
+	pathTokenRe = regexp.MustCompile(`[A-Za-z0-9_.\-]+(?:/[A-Za-z0-9_.\-]+)+`)
+	// issueRefRe matches a full "owner/repo#n" issue/PR reference so it is
+	// never mistaken for a repo path.
+	issueRefRe = regexp.MustCompile(`^[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+#\d+$`)
+	// urlRe matches a whole URL so it is stripped from plain text before
+	// path-token scanning — otherwise a URL's path segment (e.g.
+	// "github.com/o/r/blob/main/internal/foo.go") would be mistaken for a
+	// repo-relative path.
+	urlRe = regexp.MustCompile(`\S+://\S+`)
+)
+
+// extractPaths pulls candidate repo-relative paths out of a sub-issue body:
+// backtick code spans (verbatim, including spaces) plus bare path-shaped
+// tokens in the surrounding text. It skips `://` URLs and issue references
+// (`owner/repo#n` or bare `#n`) so those never get mistaken for a path, and
+// strips trailing markdown punctuation. Order-preserving, de-duplicated
+// case-insensitively.
+func extractPaths(body string) []string {
+	var tokens []string
+	seen := make(map[string]bool)
+	add := func(tok string) {
+		tok = strings.TrimSpace(tok)
+		tok = strings.Trim(tok, ",.():;!?'\"")
+		if tok == "" || !strings.Contains(tok, "/") {
+			return
+		}
+		if strings.Contains(tok, "://") {
+			return
+		}
+		if strings.HasPrefix(tok, "#") || issueRefRe.MatchString(tok) {
+			return
+		}
+		key := strings.ToLower(tok)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		tokens = append(tokens, tok)
+	}
+
+	for _, m := range backtickSpanRe.FindAllStringSubmatch(body, -1) {
+		add(m[1])
+	}
+	plain := backtickSpanRe.ReplaceAllString(body, " ")
+	plain = urlRe.ReplaceAllString(plain, " ")
+	for _, m := range pathTokenRe.FindAllString(plain, -1) {
+		add(m)
+	}
+	return tokens
+}
+
+// fileSet indexes a repo's tracked files for confirming candidate paths:
+// exact tracked files plus every ancestor directory of each, so a directory
+// mention (e.g. "internal/foo") confirms without requiring the caller to name
+// a specific file inside it.
+type fileSet struct {
+	files map[string]bool
+	dirs  map[string]bool
+}
+
+// newFileSet builds a fileSet from a repo's tracked file list.
+func newFileSet(tracked []string) fileSet {
+	fs := fileSet{files: make(map[string]bool, len(tracked)), dirs: make(map[string]bool)}
+	for _, f := range tracked {
+		n := normalizePath(f)
+		if n == "" {
+			continue
+		}
+		fs.files[n] = true
+		segs := strings.Split(n, "/")
+		for i := 1; i < len(segs); i++ {
+			fs.dirs[strings.Join(segs[:i], "/")] = true
+		}
+	}
+	return fs
+}
+
+// confirm reports whether token names a tracked file or a real ancestor
+// directory, comparing segment-wise (via normalizePath's exact-string keys)
+// so "internal/foo" never confirms against a sibling "internal/foobar/x.go".
+// Returns the normalized path on success.
+func (fs fileSet) confirm(token string) (string, bool) {
+	n := normalizePath(token)
+	if n == "" {
+		return "", false
+	}
+	if fs.files[n] || fs.dirs[n] {
+		return n, true
+	}
+	return "", false
+}
+
+// groundTouches extracts candidate paths from body and returns the ones
+// confirmed against fs, normalized and de-duplicated, order-preserving.
+func groundTouches(fs fileSet, body string) []string {
+	var out []string
+	seen := make(map[string]bool)
+	for _, tok := range extractPaths(body) {
+		n, ok := fs.confirm(tok)
+		if !ok || seen[n] {
+			continue
+		}
+		seen[n] = true
+		out = append(out, n)
+	}
+	return out
+}
+
+// ground confirms each child's touches against its repo's real tracked files
+// and unions any newly-confirmed paths in, in place. Gated once on len(subs)
+// vs minSubs (minSubs <= 0 means always ground). Per child, an unresolvable
+// ref or a lister failure records a skip and moves on — grounding never
+// aborts expansion. The tracked-file lookup is memoized per repo so a shared
+// repo across children only calls lister once.
+func (p *Plan) ground(ctx context.Context, lister TrackedFilesFunc, subs []SubIssue, minSubs int) groundReport {
+	var report groundReport
+	if lister == nil {
+		return report
+	}
+	if minSubs > 0 && len(subs) < minSubs {
+		return report
+	}
+
+	bodyByRef := make(map[string]string, len(subs))
+	for _, s := range subs {
+		bodyByRef[NormalizeIssueRef(s.Ref)] = s.Body
+	}
+
+	type cacheEntry struct {
+		fs fileSet
+		ok bool
+	}
+	cache := make(map[string]cacheEntry)
+	groundedRepos := make(map[string]bool)
+
+	for i := range p.Children {
+		c := &p.Children[i]
+		repo, _, ok := ParseRef(c.Ref)
+		if !ok {
+			report.skipped = append(report.skipped, c.Ref)
+			continue
+		}
+
+		entry, cached := cache[repo]
+		if !cached {
+			files, err := lister(ctx, repo)
+			if err != nil {
+				slog.DebugContext(ctx, "umbrella.ground.skip", "repo", repo, "error", err)
+				cache[repo] = cacheEntry{}
+				report.skipped = append(report.skipped, repo)
+				continue
+			}
+			entry = cacheEntry{fs: newFileSet(files), ok: true}
+			cache[repo] = entry
+			groundedRepos[repo] = true
+		}
+		if !entry.ok {
+			report.skipped = append(report.skipped, repo)
+			continue
+		}
+
+		grounded := groundTouches(entry.fs, bodyByRef[NormalizeIssueRef(c.Ref)])
+		if len(grounded) == 0 {
+			continue
+		}
+		c.Touches = unionTouches(c.Touches, grounded)
+	}
+
+	repos := make([]string, 0, len(groundedRepos))
+	for r := range groundedRepos {
+		repos = append(repos, r)
+	}
+	sort.Strings(repos)
+	report.groundedRepos = repos
+	return report
+}
+
+// unionTouches merges add into existing, de-duplicated by normalizePath,
+// keeping the existing entries' original spelling first.
+func unionTouches(existing, add []string) []string {
+	seen := make(map[string]bool, len(existing)+len(add))
+	out := make([]string, 0, len(existing)+len(add))
+	for _, e := range existing {
+		n := normalizePath(e)
+		if n == "" || seen[n] {
+			continue
+		}
+		seen[n] = true
+		out = append(out, e)
+	}
+	for _, a := range add {
+		n := normalizePath(a)
+		if n == "" || seen[n] {
+			continue
+		}
+		seen[n] = true
+		out = append(out, a)
+	}
+	return out
+}

--- a/internal/umbrella/ground_test.go
+++ b/internal/umbrella/ground_test.go
@@ -1,0 +1,250 @@
+package umbrella
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestExtractPaths(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{
+			"backtick path",
+			"Edit `internal/foo/bar.go` to fix this.",
+			[]string{"internal/foo/bar.go"},
+		},
+		{
+			"plain text path",
+			"Look at internal/foo/bar.go for the bug.",
+			[]string{"internal/foo/bar.go"},
+		},
+		{
+			"trailing punctuation stripped",
+			"See `internal/foo/bar.go,` and (internal/baz/qux.go).",
+			[]string{"internal/foo/bar.go", "internal/baz/qux.go"},
+		},
+		{
+			"skips URLs",
+			"See https://github.com/o/r/blob/main/internal/foo.go for context.",
+			nil,
+		},
+		{
+			"skips owner/repo#n refs",
+			"Depends on `Automaat/sybra#123` finishing first.",
+			nil,
+		},
+		{
+			"skips bare #n refs",
+			"See #123 for the discussion.",
+			nil,
+		},
+		{
+			"dedups case-insensitively",
+			"Touches `internal/Foo/bar.go` and internal/foo/bar.go again.",
+			[]string{"internal/Foo/bar.go"},
+		},
+		{
+			"files with spaces via backtick",
+			"Edit `internal/my file/bar.go` please.",
+			[]string{"internal/my file/bar.go"},
+		},
+		{
+			"bare word without slash is not a path",
+			"Update the README and CHANGELOG.",
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := extractPaths(tt.body)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractPaths(%q) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfirm(t *testing.T) {
+	t.Parallel()
+	fs := newFileSet([]string{
+		"internal/foo/bar.go",
+		"internal/foobar/baz.go",
+	})
+
+	tests := []struct {
+		name     string
+		token    string
+		wantOK   bool
+		wantPath string
+	}{
+		{"tracked file matches", "internal/foo/bar.go", true, "internal/foo/bar.go"},
+		{"real ancestor dir matches", "internal/foo", true, "internal/foo"},
+		{"sibling file does not collide", "internal/foo/other.go", false, ""},
+		{"unrelated path does not match", "internal/bar", false, ""},
+		{"casing is normalized", "INTERNAL/FOO/BAR.GO", true, "internal/foo/bar.go"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := fs.confirm(tt.token)
+			if ok != tt.wantOK {
+				t.Fatalf("confirm(%q) ok = %v, want %v", tt.token, ok, tt.wantOK)
+			}
+			if ok && got != tt.wantPath {
+				t.Errorf("confirm(%q) = %q, want %q", tt.token, got, tt.wantPath)
+			}
+		})
+	}
+
+	// internal/foo must never be confirmed as an ancestor of internal/foobar
+	// (segment-wise comparison, not string-prefix).
+	if _, ok := fs.confirm("internal/foobarbaz"); ok {
+		t.Error("internal/foobarbaz must not confirm against internal/foo or internal/foobar")
+	}
+}
+
+func TestGroundTouches(t *testing.T) {
+	t.Parallel()
+	fs := newFileSet([]string{"internal/foo/bar.go", "internal/baz/qux.go"})
+	body := "Edit `internal/foo/bar.go` and mention https://example.com/internal/nope.go, " +
+		"also touches internal/foo/bar.go again and internal/baz."
+	got := groundTouches(fs, body)
+	want := []string{"internal/foo/bar.go", "internal/baz"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("groundTouches = %v, want %v", got, want)
+	}
+}
+
+func TestPlanGroundGate(t *testing.T) {
+	t.Parallel()
+	lister := func(_ context.Context, _ string) ([]string, error) {
+		return []string{"internal/foo/bar.go"}, nil
+	}
+
+	newPlanSubs := func(n int) ([]SubIssue, *Plan) {
+		s := make([]SubIssue, n)
+		p := &Plan{}
+		for i := range n {
+			ref := "o/r#" + string(rune('1'+i))
+			s[i] = SubIssue{Ref: ref, Body: "touches `internal/foo/bar.go`"}
+			p.Children = append(p.Children, PlannedChild{Ref: ref})
+		}
+		return s, p
+	}
+
+	tests := []struct {
+		name       string
+		minSubs    int
+		numSubs    int
+		wantGround bool
+	}{
+		{"zero threshold always grounds", 0, 2, true},
+		{"negative threshold always grounds", -1, 2, true},
+		{"below threshold skips", 3, 2, false},
+		{"at threshold grounds", 2, 2, true},
+		{"above threshold grounds", 1, 2, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			subs, plan := newPlanSubs(tt.numSubs)
+			report := plan.ground(context.Background(), lister, subs, tt.minSubs)
+			grounded := len(plan.Children[0].Touches) > 0
+			if grounded != tt.wantGround {
+				t.Fatalf("grounded = %v, want %v (touches=%v)", grounded, tt.wantGround, plan.Children[0].Touches)
+			}
+			if tt.wantGround && len(report.groundedRepos) == 0 {
+				t.Error("expected groundedRepos to be non-empty when grounding ran")
+			}
+			if !tt.wantGround && len(report.groundedRepos) != 0 {
+				t.Errorf("groundedRepos = %v, want empty when gated off", report.groundedRepos)
+			}
+		})
+	}
+}
+
+func TestPlanGroundFailOpen(t *testing.T) {
+	t.Parallel()
+
+	t.Run("lister error skips and leaves touches unchanged", func(t *testing.T) {
+		t.Parallel()
+		subs := []SubIssue{{Ref: "o/r#1", Body: "touches `internal/foo/bar.go`"}}
+		plan := &Plan{Children: []PlannedChild{{Ref: "o/r#1", Touches: []string{"existing/path"}}}}
+		lister := func(_ context.Context, _ string) ([]string, error) {
+			return nil, errors.New("boom")
+		}
+		report := plan.ground(context.Background(), lister, subs, 0)
+		if !reflect.DeepEqual(plan.Children[0].Touches, []string{"existing/path"}) {
+			t.Errorf("Touches = %v, want unchanged [existing/path]", plan.Children[0].Touches)
+		}
+		if len(report.skipped) != 1 || report.skipped[0] != "o/r" {
+			t.Errorf("skipped = %v, want [o/r]", report.skipped)
+		}
+		if len(report.groundedRepos) != 0 {
+			t.Errorf("groundedRepos = %v, want empty", report.groundedRepos)
+		}
+	})
+
+	t.Run("unresolvable ref skips and leaves touches unchanged", func(t *testing.T) {
+		t.Parallel()
+		subs := []SubIssue{{Ref: "not-a-valid-ref", Body: "touches `internal/foo/bar.go`"}}
+		plan := &Plan{Children: []PlannedChild{{Ref: "not-a-valid-ref"}}}
+		lister := func(_ context.Context, _ string) ([]string, error) {
+			return []string{"internal/foo/bar.go"}, nil
+		}
+		report := plan.ground(context.Background(), lister, subs, 0)
+		if len(plan.Children[0].Touches) != 0 {
+			t.Errorf("Touches = %v, want empty", plan.Children[0].Touches)
+		}
+		if len(report.skipped) != 1 || report.skipped[0] != "not-a-valid-ref" {
+			t.Errorf("skipped = %v, want [not-a-valid-ref]", report.skipped)
+		}
+	})
+
+	t.Run("nil lister is a no-op", func(t *testing.T) {
+		t.Parallel()
+		subs := []SubIssue{{Ref: "o/r#1", Body: "touches `internal/foo/bar.go`"}}
+		plan := &Plan{Children: []PlannedChild{{Ref: "o/r#1"}}}
+		report := plan.ground(context.Background(), nil, subs, 0)
+		if len(plan.Children[0].Touches) != 0 {
+			t.Errorf("Touches = %v, want empty (grounding skipped)", plan.Children[0].Touches)
+		}
+		if len(report.skipped) != 0 || len(report.groundedRepos) != 0 {
+			t.Errorf("report = %+v, want empty", report)
+		}
+	})
+
+	t.Run("lister called once per repo across multiple children", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		lister := func(_ context.Context, _ string) ([]string, error) {
+			calls++
+			return []string{"internal/foo/bar.go"}, nil
+		}
+		subs := []SubIssue{
+			{Ref: "o/r#1", Body: "touches `internal/foo/bar.go`"},
+			{Ref: "o/r#2", Body: "touches `internal/foo/bar.go`"},
+		}
+		plan := &Plan{Children: []PlannedChild{{Ref: "o/r#1"}, {Ref: "o/r#2"}}}
+		plan.ground(context.Background(), lister, subs, 0)
+		if calls != 1 {
+			t.Errorf("lister called %d times, want 1 (memoized per repo)", calls)
+		}
+	})
+}
+
+func TestUnionTouches(t *testing.T) {
+	t.Parallel()
+	got := unionTouches([]string{"internal/foo", "internal/bar"}, []string{"INTERNAL/FOO", "internal/baz"})
+	want := []string{"internal/foo", "internal/bar", "internal/baz"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("unionTouches = %v, want %v", got, want)
+	}
+}

--- a/internal/umbrella/planner.go
+++ b/internal/umbrella/planner.go
@@ -67,6 +67,27 @@ type Plan struct {
 // Injected so the planner logic is unit-testable without spawning a CLI.
 type Runner func(ctx context.Context, prompt string) (string, error)
 
+// generateConfig holds the optional settings GenerateOption values apply.
+type generateConfig struct {
+	lister  TrackedFilesFunc
+	minSubs int
+}
+
+// GenerateOption configures an optional Generate behavior.
+type GenerateOption func(*generateConfig)
+
+// WithGrounder enables the grounding step: after a plan resolves and before
+// dependency edges are derived, each child's touches are confirmed against
+// lister's real tracked-file listing for its repo and unioned in. minSubs
+// gates grounding on umbrella size (<=0 means always ground once a lister is
+// set). Omitting this option leaves Generate's behavior unchanged.
+func WithGrounder(lister TrackedFilesFunc, minSubs int) GenerateOption {
+	return func(c *generateConfig) {
+		c.lister = lister
+		c.minSubs = minSubs
+	}
+}
+
 // criticSuffix is appended to the prompt for the single re-ask Generate issues
 // when the first valid plan looks suspiciously flat (see flatPlanSuspicious).
 const criticSuffix = "You produced a fully-parallel plan — re-examine `touches`/`requires` for overlaps you missed. " +
@@ -83,14 +104,18 @@ const criticSuffix = "You produced a fully-parallel plan — re-examine `touches
 // valid plan, Generate falls back to a fully-serial linear chain
 // (linearChainFallback) instead of aborting the expansion; a fatal runner
 // error (couldn't launch the model) is not exhaustion and still aborts.
-func Generate(ctx context.Context, run Runner, umbrellaRef, umbrellaBody string, subs []SubIssue) (Plan, error) {
+func Generate(ctx context.Context, run Runner, umbrellaRef, umbrellaBody string, subs []SubIssue, opts ...GenerateOption) (Plan, error) {
 	if len(subs) == 0 {
 		return Plan{}, fmt.Errorf("umbrella %s has no sub-issues to expand", umbrellaRef)
+	}
+	var cfg generateConfig
+	for _, opt := range opts {
+		opt(&cfg)
 	}
 	idx := buildRefIndex(subs)
 	prompt := BuildPrompt(umbrellaRef, umbrellaBody, subs)
 
-	plan, err := attemptPlan(ctx, run, idx, prompt, subs)
+	plan, err := attemptPlan(ctx, run, idx, prompt, subs, cfg)
 	if err != nil {
 		if errors.Is(err, errPlannerExhausted) {
 			return linearChainFallback(subs)
@@ -98,7 +123,7 @@ func Generate(ctx context.Context, run Runner, umbrellaRef, umbrellaBody string,
 		return Plan{}, err
 	}
 	if flatPlanSuspicious(plan, subs) {
-		reasked, err := attemptPlan(ctx, run, idx, prompt+"\n\n"+criticSuffix, subs)
+		reasked, err := attemptPlan(ctx, run, idx, prompt+"\n\n"+criticSuffix, subs, cfg)
 		if err == nil {
 			return reasked, nil
 		}
@@ -111,7 +136,7 @@ func Generate(ctx context.Context, run Runner, umbrellaRef, umbrellaBody string,
 // against subs, with MaxParallel defaulted. A runner error is fatal and
 // returned immediately; a parse or validate failure retries with the same
 // prompt.
-func attemptPlan(ctx context.Context, run Runner, idx refIndex, prompt string, subs []SubIssue) (Plan, error) {
+func attemptPlan(ctx context.Context, run Runner, idx refIndex, prompt string, subs []SubIssue, cfg generateConfig) (Plan, error) {
 	var lastErr error
 	for range plannerAttempts {
 		raw, err := run(ctx, prompt)
@@ -126,6 +151,9 @@ func attemptPlan(ctx context.Context, run Runner, idx refIndex, prompt string, s
 		if err := plan.resolve(idx); err != nil {
 			lastErr = err
 			continue
+		}
+		if cfg.lister != nil {
+			plan.ground(ctx, cfg.lister, subs, cfg.minSubs)
 		}
 		plan.deriveEdges(subs)
 		if err := plan.validate(subs); err != nil {

--- a/internal/umbrella/planner_test.go
+++ b/internal/umbrella/planner_test.go
@@ -774,6 +774,57 @@ func TestGenerate(t *testing.T) {
 	})
 }
 
+func TestGenerateGroundedEdge(t *testing.T) {
+	t.Parallel()
+	// Both children are explicitly justified parallel and report no touches
+	// at all — an ungrounded run must therefore leave them fully parallel.
+	plainPlan := `{"children":[` +
+		`{"issue":"o/r#1","parallelJustification":{"o/r#2":"disjoint"}},` +
+		`{"issue":"o/r#2","parallelJustification":{"o/r#1":"disjoint"}}` +
+		`],"maxParallel":2}`
+	run := func(_ context.Context, _ string) (string, error) { return plainPlan, nil }
+
+	body1 := "This change edits `internal/foo/bar.go`."
+	body2 := "This change also edits `internal/foo/bar.go`."
+	s := []SubIssue{{Ref: "o/r#1", Body: body1}, {Ref: "o/r#2", Body: body2}}
+
+	t.Run("ungrounded stays parallel", func(t *testing.T) {
+		t.Parallel()
+		plan, err := Generate(context.Background(), run, "o/r#100", "body", s)
+		if err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		for _, c := range plan.Children {
+			if len(c.DependsOn) != 0 {
+				t.Fatalf("ungrounded plan should stay fully parallel, got child %s deps %v", c.Ref, c.DependsOn)
+			}
+		}
+	})
+
+	t.Run("grounded shared path adds a touch-overlap edge", func(t *testing.T) {
+		t.Parallel()
+		lister := func(_ context.Context, repo string) ([]string, error) {
+			if repo != "o/r" {
+				t.Fatalf("lister called with unexpected repo %q", repo)
+			}
+			return []string{"internal/foo/bar.go"}, nil
+		}
+		plan, err := Generate(context.Background(), run, "o/r#100", "body", s, WithGrounder(lister, 0))
+		if err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		var child2 PlannedChild
+		for _, c := range plan.Children {
+			if c.Ref == "o/r#2" {
+				child2 = c
+			}
+		}
+		if len(child2.DependsOn) != 1 || child2.DependsOn[0] != "o/r#1" {
+			t.Fatalf("grounding a shared path should add a touch-overlap edge an ungrounded run misses, got deps %v", child2.DependsOn)
+		}
+	})
+}
+
 func TestLinearChainFallback(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation

Umbrella sub-issue dependency edges are currently derived solely from the planner's guessed file touches, which can drift from what actually exists in the repo. Closes https://github.com/Automaat/sybra/issues/1327

## Implementation information

Adds an optional grounding step that confirms each sub-issue's touches against the real repo's tracked files before dependency edges are derived. Gated by `umbrella.ground` (plus a `ground_min_sub_issues` size gate) so default behavior is unchanged, and fails open on lister errors or unregistered repos.

_Generated by Sybra harness_