### PR TITLE
feat(prompts): add automated Prompt Lab loop

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -123,6 +123,8 @@ func run(args []string) int {
 		return cmdEvaluation(cfg, store, rest, jsonOut)
 	case "harness-evolution":
 		return cmdHarnessEvolution(cfg, store, rest, jsonOut)
+	case "prompt-lab":
+		return cmdPromptLab(cfg, store, projStore, rest, jsonOut)
 	case "stats":
 		return cmdStats(cfg, rest, jsonOut)
 	case "install-skills":
@@ -1724,6 +1726,8 @@ Commands:
   evaluation scan [--json]  fleet scorecard (autonomy, throughput, efficiency)
   harness-evolution run [--lookback 168h] [--min-cluster-size 2] [--file] [--json]
            Cluster selfmonitor failures into governed harness-change proposals.
+  prompt-lab run [--lookback 168h] [--min-samples 5] [--file] [--dry-run] [--json]
+           Scaffold versioned prompt/skill variant proposals from fleet evidence.
   stats lifecycle [--since 30d] [--slowest N] [--json]
            Per-phase lead-time breakdown (planning/implementing/testing/review/
            waiting) for tasks that landed in the window — where time is spent.

--- a/cmd/sybra-cli/prompt_lab.go
+++ b/cmd/sybra-cli/prompt_lab.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/promptlab"
+	"github.com/Automaat/sybra/internal/scrub"
+	"github.com/Automaat/sybra/internal/stats"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func cmdPromptLab(cfg *config.Config, store *task.Manager, projStore *project.Store, args []string, jsonOut bool) int {
+	if len(args) == 0 {
+		return fatal(jsonOut, "usage: prompt-lab <run> [flags]")
+	}
+	switch args[0] {
+	case "run":
+		return cmdPromptLabRun(cfg, store, projStore, args[1:], jsonOut)
+	default:
+		return fatal(jsonOut, "unknown prompt-lab subcommand: %s", args[0])
+	}
+}
+
+func cmdPromptLabRun(cfg *config.Config, store *task.Manager, projStore *project.Store, args []string, jsonOut bool) int {
+	fs := flag.NewFlagSet("prompt-lab run", flag.ContinueOnError)
+	defaultLookback := time.Duration(cfg.PromptLab.LookbackHours * float64(time.Hour))
+	lookbackFlag := fs.String("lookback", defaultLookback.String(), "lookback window (e.g. 168h or 7d)")
+	minSamples := fs.Int("min-samples", cfg.PromptLab.MinSamples, "minimum runs required to propose")
+	fileTasks := fs.Bool("file", false, "create local Sybra proposal tasks")
+	dryRun := fs.Bool("dry-run", false, "compute proposals without filing tasks, even if --file is set")
+	if err := fs.Parse(args); err != nil {
+		return fatal(jsonOut, "%v", err)
+	}
+	lookback, err := parseDurationFlag(*lookbackFlag)
+	if err != nil {
+		return fatal(jsonOut, "parse --lookback: %v", err)
+	}
+
+	statsStore, err := stats.NewStore(config.StatsFile())
+	if err != nil {
+		return fatal(jsonOut, "open stats: %v", err)
+	}
+
+	result, err := promptlab.Run(context.Background(), promptlab.Options{
+		ReportPath:    config.EvaluationReportPath(),
+		Records:       statsStore.All(),
+		OutputDir:     config.PromptLabDir(),
+		Lookback:      lookback,
+		MinSamples:    *minSamples,
+		MinEffectSize: cfg.PromptLab.MinEffectSize,
+		MaxProposals:  cfg.PromptLab.MaxProposalsPerRun,
+	})
+	if err != nil {
+		return fatal(jsonOut, "prompt lab: %v", err)
+	}
+
+	var filed []task.Task
+	if *fileTasks && !*dryRun {
+		filed, err = filePromptLabProposals(store, projStore, result)
+		if err != nil {
+			return fatal(jsonOut, "file proposals: %v", err)
+		}
+	}
+	if jsonOut {
+		return printJSON(map[string]any{"result": result, "filed": filed})
+	}
+	printPromptLabResult(result, filed)
+	return 0
+}
+
+// filePromptLabProposals files each proposal as a reviewed local task, skipping
+// rejected/duplicate proposals and scrubbing the body before persistence. Scrub
+// is EXPLICIT here, not inherited: fileHarnessProposals (harness_evolution.go)
+// does not scrub, so this filer builds and applies its own work-typed
+// blocklist per subject rather than assuming that precedent covers it too.
+func filePromptLabProposals(store *task.Manager, projStore *project.Store, result promptlab.RunResult) ([]task.Task, error) {
+	existing, err := store.List()
+	if err != nil {
+		return nil, err
+	}
+	var filed []task.Task
+	for i := range result.Proposals {
+		p := result.Proposals[i]
+		if _, ok := findExistingPromptLabProposal(existing, p.ID); ok {
+			continue
+		}
+		body := scrubProposalBody(projStore, promptlab.RenderProposalBody(p), p.Evidence.ProjectIDs)
+		tags := []string{"prompt-lab-proposal", "role:" + p.Subject.Role}
+		status := task.StatusTodo
+		if p.RequiresHumanApproval {
+			tags = append(tags, "requires-human")
+			status = task.StatusHumanRequired
+		}
+		created, err := store.CreateFull(p.Title, body, task.AgentModeInteractive, task.Update{
+			Status: &status,
+			Tags:   &tags,
+		})
+		if err != nil {
+			return filed, err
+		}
+		filed = append(filed, created)
+		existing = append(existing, created)
+	}
+	return filed, nil
+}
+
+// scrubProposalBody redacts a proposal body against every work-typed
+// project's blocklist among projectIDs. A project ID that fails to resolve
+// or is pet-typed contributes nothing — fail-open on unknown/non-work
+// projects mirrors App.workScrubContextForTask.
+func scrubProposalBody(projStore *project.Store, body string, projectIDs []string) string {
+	for _, id := range projectIDs {
+		p, err := projStore.Get(id)
+		if err != nil || p.Type != project.ProjectTypeWork {
+			continue
+		}
+		blocklist := []string{p.ID, p.Owner, p.Repo}
+		if p.URL != "" {
+			blocklist = append(blocklist, p.URL)
+		}
+		body, _ = scrub.Scrub(body, blocklist)
+	}
+	return body
+}
+
+func findExistingPromptLabProposal(tasks []task.Task, proposalID string) (task.Task, bool) {
+	marker := "Proposal ID:** `" + proposalID + "`"
+	for i := range tasks {
+		if task.IsTerminalStatus(tasks[i].Status) {
+			continue
+		}
+		if !slices.Contains(tasks[i].Tags, "prompt-lab-proposal") {
+			continue
+		}
+		if strings.Contains(tasks[i].Body, marker) {
+			return tasks[i], true
+		}
+	}
+	return task.Task{}, false
+}
+
+func printPromptLabResult(result promptlab.RunResult, filed []task.Task) {
+	fmt.Printf("prompt-lab: weak_subjects=%d proposals=%d dropped=%d filed=%d\n",
+		len(result.WeakSubjects), len(result.Proposals), result.Dropped, len(filed))
+	if len(result.Proposals) == 0 {
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "ID\tROLE\tINTENT\tVERDICT\tGATE\tTITLE")
+	for i := range result.Proposals {
+		p := result.Proposals[i]
+		gate := "standard"
+		if p.RequiresHumanApproval {
+			gate = "human"
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			p.ID, p.Subject.Role, p.Candidate.Intent, p.Offline.Verdict, gate, p.Title)
+	}
+	_ = w.Flush()
+}

--- a/cmd/sybra-cli/prompt_lab.go
+++ b/cmd/sybra-cli/prompt_lab.go
@@ -51,7 +51,6 @@ func cmdPromptLabRun(cfg *config.Config, store *task.Manager, projStore *project
 	}
 
 	result, err := promptlab.Run(context.Background(), promptlab.Options{
-		ReportPath:    config.EvaluationReportPath(),
 		Records:       statsStore.All(),
 		OutputDir:     config.PromptLabDir(),
 		Lookback:      lookback,

--- a/cmd/sybra-cli/prompt_lab_test.go
+++ b/cmd/sybra-cli/prompt_lab_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/promptlab"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+func newTaskManager(t *testing.T, dir string) *task.Manager {
+	t.Helper()
+	store, err := task.NewStore(filepath.Join(dir, "tasks"))
+	if err != nil {
+		t.Fatalf("task.NewStore: %v", err)
+	}
+	return task.NewManager(store, task.NoopEmitter())
+}
+
+func newProjectStore(t *testing.T, dir string) *project.Store {
+	t.Helper()
+	ps, err := project.NewStore(filepath.Join(dir, "projects"), filepath.Join(dir, "clones"))
+	if err != nil {
+		t.Fatalf("project.NewStore: %v", err)
+	}
+	return ps
+}
+
+func testProposal(id, role string, projectIDs []string) promptlab.Proposal {
+	return promptlab.Proposal{
+		ID:      id,
+		Subject: promptlab.Subject{Role: role},
+		Title:   "Prompt Lab: tighten instructions for role " + role,
+		Rationale: "role " + role + " fails 40% vs 10% overall over 20 runs referencing " +
+			"https://github.com/acme/work-repo/pull/9",
+		Candidate:             promptlab.VariantCandidate{ID: id, Intent: "tighten-instructions"},
+		Evidence:              promptlab.WeakSubject{Subject: promptlab.Subject{Role: role}, ProjectIDs: projectIDs},
+		Offline:               promptlab.OfflineResult{Verdict: promptlab.VerdictNoVerdict},
+		RequiresHumanApproval: true,
+	}
+}
+
+func TestFilePromptLabProposalsScrubsWorkTyped(t *testing.T) {
+	dir := setupStore(t)
+	tasks := newTaskManager(t, dir)
+	projects := newProjectStore(t, dir)
+
+	proj, err := projects.CreateMeta("https://github.com/acme/work-repo.git", project.ProjectTypeWork)
+	if err != nil {
+		t.Fatalf("CreateMeta: %v", err)
+	}
+
+	p := testProposal("pl-work-1", "implementation", []string{proj.ID})
+	result := promptlab.RunResult{Proposals: []promptlab.Proposal{p}}
+
+	filed, err := filePromptLabProposals(tasks, projects, result)
+	if err != nil {
+		t.Fatalf("filePromptLabProposals: %v", err)
+	}
+	if len(filed) != 1 {
+		t.Fatalf("len(filed) = %d, want 1", len(filed))
+	}
+	body := filed[0].Body
+	if strings.Contains(body, proj.Owner) || strings.Contains(body, proj.Repo) || strings.Contains(body, proj.ID) {
+		t.Fatalf("work-typed proposal body was not scrubbed: %s", body)
+	}
+	if strings.Contains(body, "github.com/acme") {
+		t.Fatalf("work-typed proposal body still contains a github URL: %s", body)
+	}
+	if !strings.Contains(body, "[redacted]") {
+		t.Fatalf("expected redaction placeholder in scrubbed body: %s", body)
+	}
+	if filed[0].Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want human-required", filed[0].Status)
+	}
+}
+
+func TestFilePromptLabProposalsLeavesPetUnredacted(t *testing.T) {
+	dir := setupStore(t)
+	tasks := newTaskManager(t, dir)
+	projects := newProjectStore(t, dir)
+
+	proj, err := projects.CreateMeta("https://github.com/acme/pet-repo.git", project.ProjectTypePet)
+	if err != nil {
+		t.Fatalf("CreateMeta: %v", err)
+	}
+
+	petProposal := testProposal("pl-pet-1", "implementation", []string{proj.ID})
+	nilProjectProposal := testProposal("pl-nil-1", "review", nil)
+	result := promptlab.RunResult{Proposals: []promptlab.Proposal{petProposal, nilProjectProposal}}
+
+	filed, err := filePromptLabProposals(tasks, projects, result)
+	if err != nil {
+		t.Fatalf("filePromptLabProposals: %v", err)
+	}
+	if len(filed) != 2 {
+		t.Fatalf("len(filed) = %d, want 2", len(filed))
+	}
+	for _, f := range filed {
+		if strings.Contains(f.Body, "[redacted]") {
+			t.Fatalf("pet/nil-project proposal body was unexpectedly scrubbed: %s", f.Body)
+		}
+	}
+	if !strings.Contains(filed[0].Body, proj.Owner) {
+		t.Fatalf("pet-typed proposal body should retain project identifiers: %s", filed[0].Body)
+	}
+}
+
+func TestFilePromptLabProposalsSkipsDuplicates(t *testing.T) {
+	dir := setupStore(t)
+	tasks := newTaskManager(t, dir)
+	projects := newProjectStore(t, dir)
+
+	p := testProposal("pl-dup-1", "implementation", nil)
+	result := promptlab.RunResult{Proposals: []promptlab.Proposal{p}}
+
+	first, err := filePromptLabProposals(tasks, projects, result)
+	if err != nil {
+		t.Fatalf("first file: %v", err)
+	}
+	if len(first) != 1 {
+		t.Fatalf("len(first) = %d, want 1", len(first))
+	}
+	second, err := filePromptLabProposals(tasks, projects, result)
+	if err != nil {
+		t.Fatalf("second file: %v", err)
+	}
+	if len(second) != 0 {
+		t.Fatalf("len(second) = %d, want 0 (duplicate proposal ID must not refile)", len(second))
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	SelfMonitor   SelfMonitorConfig   `yaml:"self_monitor" json:"selfMonitor"`
 	Evaluation    EvaluationConfig    `yaml:"evaluation" json:"evaluation"`
 	HarnessEvolve HarnessEvolveConfig `yaml:"harness_evolution" json:"harnessEvolution"`
+	PromptLab     PromptLabConfig     `yaml:"prompt_lab" json:"promptLab"`
 	Experience    ExperienceConfig    `yaml:"experience" json:"experience"`
 	ABTesting     abtest.Config       `yaml:"ab_testing" json:"abTesting"`
 	Providers     ProvidersConfig     `yaml:"providers" json:"providers"`

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -459,6 +459,7 @@ func Load() (*Config, error) {
 	applySelfMonitorDefaults(cfg)
 	applyEvaluationDefaults(cfg)
 	applyHarnessEvolveDefaults(cfg)
+	applyPromptLabDefaults(cfg)
 	applyExperienceDefaults(cfg)
 	applyABTestingDefaults(cfg)
 	applyOrchestratorDefaults(cfg)
@@ -556,6 +557,28 @@ func applyHarnessEvolveDefaults(cfg *Config) {
 	}
 	if h.Sink == "" {
 		h.Sink = "local-task"
+	}
+}
+
+// applyPromptLabDefaults fills zero values while preserving Enabled from an
+// explicit YAML override — the zero value (false) is exactly the desired
+// default, so no DefaultConfig entry is needed.
+func applyPromptLabDefaults(cfg *Config) {
+	p := &cfg.PromptLab
+	if p.IntervalHours < 1 {
+		p.IntervalHours = 24
+	}
+	if p.LookbackHours <= 0 {
+		p.LookbackHours = 168
+	}
+	if p.MinSamples <= 0 {
+		p.MinSamples = 5
+	}
+	if p.MinEffectSize <= 0 {
+		p.MinEffectSize = 0.15
+	}
+	if p.MaxProposalsPerRun <= 0 {
+		p.MaxProposalsPerRun = 3
 	}
 }
 
@@ -801,6 +824,13 @@ func SelfMonitorDir() string {
 // records and run snapshots.
 func HarnessEvolveDir() string {
 	return filepath.Join(HomeDir(), "harness-evolution")
+}
+
+// PromptLabDir is the local store for promptlab run snapshots and scaffolded
+// proposal records. It never holds authored prompt/skill text — see
+// internal/promptlab.
+func PromptLabDir() string {
+	return filepath.Join(HomeDir(), "prompt-lab")
 }
 
 // PromptEvalDir is the local store for offline prompt/skill eval verdicts

--- a/internal/config/config_promptlab.go
+++ b/internal/config/config_promptlab.go
@@ -1,0 +1,17 @@
+package config
+
+// PromptLabConfig controls the automated Prompt Lab loop that scaffolds
+// versioned prompt/skill variant proposals from fleet evidence (Evaluation
+// report + stats). It never authors or applies prompt/skill text itself —
+// every proposal is filed as a reviewed local task for a human (or a later
+// agent run) to author and gate through the standard offline-eval + A/B
+// path. Disabled by default: unlike HarnessEvolveConfig, a fresh install
+// must not start filing tasks before an operator opts in.
+type PromptLabConfig struct {
+	Enabled            bool    `yaml:"enabled" json:"enabled"`
+	IntervalHours      float64 `yaml:"interval_hours" json:"intervalHours"`
+	LookbackHours      float64 `yaml:"lookback_hours" json:"lookbackHours"`
+	MinSamples         int     `yaml:"min_samples" json:"minSamples"`
+	MinEffectSize      float64 `yaml:"min_effect_size" json:"minEffectSize"`
+	MaxProposalsPerRun int     `yaml:"max_proposals_per_run" json:"maxProposalsPerRun"`
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -228,6 +228,57 @@ func TestLoadHarnessEvolutionPreservesExplicitDisabled(t *testing.T) {
 	}
 }
 
+func TestLoadPromptLabDefaults(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Unlike harness evolution, prompt lab must default disabled: a config
+	// predating this feature (or a fresh install) must not start filing
+	// proposal tasks until an operator opts in.
+	if cfg.PromptLab.Enabled {
+		t.Fatal("prompt lab should default disabled")
+	}
+	if cfg.PromptLab.IntervalHours != 24 {
+		t.Fatalf("interval = %.0f, want 24", cfg.PromptLab.IntervalHours)
+	}
+	if cfg.PromptLab.LookbackHours != 168 {
+		t.Fatalf("lookback = %.0f, want 168", cfg.PromptLab.LookbackHours)
+	}
+	if cfg.PromptLab.MinSamples != 5 {
+		t.Fatalf("min samples = %d, want 5", cfg.PromptLab.MinSamples)
+	}
+	if cfg.PromptLab.MinEffectSize != 0.15 {
+		t.Fatalf("min effect size = %v, want 0.15", cfg.PromptLab.MinEffectSize)
+	}
+	if cfg.PromptLab.MaxProposalsPerRun != 3 {
+		t.Fatalf("max proposals per run = %d, want 3", cfg.PromptLab.MaxProposalsPerRun)
+	}
+}
+
+func TestLoadPromptLabPreservesExplicitDisabled(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+	yaml := []byte("prompt_lab:\n  enabled: true\n  min_samples: 10\n")
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), yaml, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.PromptLab.Enabled {
+		t.Fatal("explicit prompt_lab.enabled=true was not preserved")
+	}
+	if cfg.PromptLab.MinSamples != 10 {
+		t.Fatalf("explicit prompt_lab.min_samples=10 was not preserved, got %d", cfg.PromptLab.MinSamples)
+	}
+}
+
 func TestHumanReviewSybraBugAction(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -259,7 +259,7 @@ func TestLoadPromptLabDefaults(t *testing.T) {
 	}
 }
 
-func TestLoadPromptLabPreservesExplicitDisabled(t *testing.T) {
+func TestLoadPromptLabPreservesExplicitEnabled(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("SYBRA_HOME", dir)
 	yaml := []byte("prompt_lab:\n  enabled: true\n  min_samples: 10\n")

--- a/internal/promptlab/collect.go
+++ b/internal/promptlab/collect.go
@@ -1,9 +1,7 @@
 package promptlab
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"sort"
 	"time"
 
@@ -11,39 +9,37 @@ import (
 	"github.com/Automaat/sybra/internal/stats"
 )
 
-// loadEvaluationReport reads the persisted fleet scorecard. A missing file
-// (evaluation service hasn't ticked yet) is treated as "no evidence yet" —
-// not an error — so a fresh install can run the loop without crashing. A
-// present-but-corrupt file is a genuine error: it would be wrong to treat
-// unparsable data as "nothing wrong".
-func loadEvaluationReport(path string) (evaluation.Report, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return evaluation.Report{}, nil
-		}
-		return evaluation.Report{}, err
-	}
-	var report evaluation.Report
-	if err := json.Unmarshal(data, &report); err != nil {
-		return evaluation.Report{}, fmt.Errorf("parse evaluation report: %w", err)
-	}
-	return report, nil
-}
+// unboundedSince/unboundedUntil span effectively all time. CollectWeakSubjects
+// receives records already scoped by the caller's lookback window (see
+// withinLookback); passing an all-time window into evaluation.BreakdownBy and
+// evaluation.Compute means the lookback trim is the only one that applies —
+// there is no second, independent window to fall out of sync with it.
+var (
+	unboundedSince time.Time
+	unboundedUntil = time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC)
+)
 
-// CollectWeakSubjects derives per-role WeakSubjects from an evaluation report
-// and supporting run records. A role is only surfaced when it clears BOTH
-// gates — MinSamples (enough runs to trust the number) and MinEffectSize
-// (the failure rate is actually worse than the fleet baseline, not noise) —
-// so a single unlucky run never triggers a proposal. Results are sorted by
-// effect size, worst first.
-func CollectWeakSubjects(report evaluation.Report, records []stats.RunRecord, minSamples int, minEffectSize float64) []WeakSubject {
+// CollectWeakSubjects derives per-role WeakSubjects directly from run
+// records — not a persisted evaluation report — so the same lookback-
+// filtered evidence backs both the gating metrics (samples, failure rate,
+// effect size vs the fleet baseline) and the representative project/task
+// attribution. A role is only surfaced when it clears BOTH gates —
+// MinSamples (enough runs to trust the number) and MinEffectSize (the
+// failure rate is actually worse than the fleet baseline, not noise) — so a
+// single unlucky run never triggers a proposal. Results are sorted by effect
+// size, worst first.
+func CollectWeakSubjects(records []stats.RunRecord, minSamples int, minEffectSize float64) []WeakSubject {
+	overall := evaluation.Compute(records, nil, unboundedSince, unboundedUntil)
+	byRole := evaluation.BreakdownBy(records, unboundedSince, unboundedUntil, func(r stats.RunRecord) string {
+		return normalizedRole(r.Role)
+	})
+
 	var out []WeakSubject
-	for _, b := range report.ByRole {
-		if b.Key == "" || b.Runs < minSamples {
+	for _, b := range byRole {
+		if b.Runs < minSamples {
 			continue
 		}
-		effect := b.FailureRate - report.Overall.FailureRate
+		effect := b.FailureRate - overall.FailureRate
 		if effect < minEffectSize {
 			continue
 		}
@@ -51,7 +47,7 @@ func CollectWeakSubjects(report evaluation.Report, records []stats.RunRecord, mi
 			Subject: Subject{Role: b.Key},
 			Metric:  "failure_rate",
 			Detail: fmt.Sprintf("role %s fails %.0f%% vs %.0f%% overall over %d runs",
-				b.Key, b.FailureRate*100, report.Overall.FailureRate*100, b.Runs),
+				b.Key, b.FailureRate*100, overall.FailureRate*100, b.Runs),
 			Samples:    b.Runs,
 			EffectSize: effect,
 			ProjectIDs: projectIDsForRole(records, b.Key),

--- a/internal/promptlab/collect.go
+++ b/internal/promptlab/collect.go
@@ -77,7 +77,7 @@ func projectIDsForRole(records []stats.RunRecord, role string) []string {
 	return out
 }
 
-// taskIdsForRole returns up to limit distinct, sorted task IDs so a reviewer
+// taskIDsForRole returns up to limit distinct, sorted task IDs so a reviewer
 // can jump straight to representative failing runs.
 func taskIDsForRole(records []stats.RunRecord, role string, limit int) []string {
 	seen := map[string]bool{}

--- a/internal/promptlab/collect.go
+++ b/internal/promptlab/collect.go
@@ -1,0 +1,126 @@
+package promptlab
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/Automaat/sybra/internal/evaluation"
+	"github.com/Automaat/sybra/internal/stats"
+)
+
+// loadEvaluationReport reads the persisted fleet scorecard. A missing file
+// (evaluation service hasn't ticked yet) is treated as "no evidence yet" —
+// not an error — so a fresh install can run the loop without crashing. A
+// present-but-corrupt file is a genuine error: it would be wrong to treat
+// unparsable data as "nothing wrong".
+func loadEvaluationReport(path string) (evaluation.Report, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return evaluation.Report{}, nil
+		}
+		return evaluation.Report{}, err
+	}
+	var report evaluation.Report
+	if err := json.Unmarshal(data, &report); err != nil {
+		return evaluation.Report{}, fmt.Errorf("parse evaluation report: %w", err)
+	}
+	return report, nil
+}
+
+// CollectWeakSubjects derives per-role WeakSubjects from an evaluation report
+// and supporting run records. A role is only surfaced when it clears BOTH
+// gates — MinSamples (enough runs to trust the number) and MinEffectSize
+// (the failure rate is actually worse than the fleet baseline, not noise) —
+// so a single unlucky run never triggers a proposal. Results are sorted by
+// effect size, worst first.
+func CollectWeakSubjects(report evaluation.Report, records []stats.RunRecord, minSamples int, minEffectSize float64) []WeakSubject {
+	var out []WeakSubject
+	for _, b := range report.ByRole {
+		if b.Key == "" || b.Runs < minSamples {
+			continue
+		}
+		effect := b.FailureRate - report.Overall.FailureRate
+		if effect < minEffectSize {
+			continue
+		}
+		out = append(out, WeakSubject{
+			Subject: Subject{Role: b.Key},
+			Metric:  "failure_rate",
+			Detail: fmt.Sprintf("role %s fails %.0f%% vs %.0f%% overall over %d runs",
+				b.Key, b.FailureRate*100, report.Overall.FailureRate*100, b.Runs),
+			Samples:    b.Runs,
+			EffectSize: effect,
+			ProjectIDs: projectIDsForRole(records, b.Key),
+			TaskIDs:    taskIDsForRole(records, b.Key, 5),
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].EffectSize > out[j].EffectSize })
+	return out
+}
+
+// projectIDsForRole returns the distinct, sorted project IDs behind a role's
+// run records — the originating context a filer needs to resolve a
+// work-typed scrub blocklist before persisting a proposal derived from this
+// evidence.
+func projectIDsForRole(records []stats.RunRecord, role string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for i := range records {
+		r := &records[i]
+		if normalizedRole(r.Role) != role || r.ProjectID == "" || seen[r.ProjectID] {
+			continue
+		}
+		seen[r.ProjectID] = true
+		out = append(out, r.ProjectID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// taskIdsForRole returns up to limit distinct, sorted task IDs so a reviewer
+// can jump straight to representative failing runs.
+func taskIDsForRole(records []stats.RunRecord, role string, limit int) []string {
+	seen := map[string]bool{}
+	var out []string
+	for i := range records {
+		r := &records[i]
+		if normalizedRole(r.Role) != role || r.TaskID == "" || seen[r.TaskID] {
+			continue
+		}
+		seen[r.TaskID] = true
+		out = append(out, r.TaskID)
+	}
+	sort.Strings(out)
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+func normalizedRole(role string) string {
+	if role == "" {
+		return "implementation"
+	}
+	return role
+}
+
+// withinLookback filters records to those at or after now-lookback. Zero
+// lookback disables the filter (all history considered).
+func withinLookback(records []stats.RunRecord, lookback time.Duration, now time.Time) []stats.RunRecord {
+	if lookback <= 0 {
+		return records
+	}
+	since := now.Add(-lookback)
+	out := make([]stats.RunRecord, 0, len(records))
+	for i := range records {
+		r := &records[i]
+		if !r.Timestamp.Before(since) {
+			out = append(out, *r)
+		}
+	}
+	return out
+}

--- a/internal/promptlab/collect_test.go
+++ b/internal/promptlab/collect_test.go
@@ -4,35 +4,48 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Automaat/sybra/internal/evaluation"
 	"github.com/Automaat/sybra/internal/stats"
 )
 
-func TestCollectWeakSubjectsGates(t *testing.T) {
-	report := evaluation.Report{
-		Overall: evaluation.Scorecard{FailureRate: 0.10},
-		ByRole: []evaluation.Breakdown{
-			{Key: "implementation", Runs: 20, FailureRate: 0.40}, // clears both gates
-			{Key: "review", Runs: 20, FailureRate: 0.15},         // below min effect size
-			{Key: "fix-review", Runs: 2, FailureRate: 0.90},      // below min samples
-		},
+// repeatRecords returns n records for role with the given outcome, so tests
+// can build up per-role run/failure counts without hand-listing each record.
+func repeatRecords(n int, role, outcome, projectID, taskIDPrefix string) []stats.RunRecord {
+	out := make([]stats.RunRecord, n)
+	for i := range out {
+		out[i] = stats.RunRecord{
+			Role:      role,
+			Outcome:   outcome,
+			ProjectID: projectID,
+			TaskID:    taskIDPrefix + string(rune('a'+i)),
+		}
 	}
-	records := []stats.RunRecord{
-		{Role: "implementation", ProjectID: "p1", TaskID: "t1"},
-		{Role: "implementation", ProjectID: "p2", TaskID: "t2"},
-	}
+	return out
+}
 
-	got := CollectWeakSubjects(report, records, 10, 0.15)
+func TestCollectWeakSubjectsGates(t *testing.T) {
+	var records []stats.RunRecord
+	// implementation: 10 runs, 5 failed -> 0.50 failure rate, clears both gates.
+	records = append(records, repeatRecords(5, "implementation", "failed", "p1", "impl-fail-")...)
+	records = append(records, repeatRecords(5, "implementation", "ok", "p2", "impl-ok-")...)
+	// review: 10 runs, 1 failed -> 0.10 failure rate, below min effect size.
+	records = append(records, repeatRecords(1, "review", "failed", "p1", "review-fail-")...)
+	records = append(records, repeatRecords(9, "review", "ok", "p1", "review-ok-")...)
+	// fix-review: 2 runs, both failed -> below min samples despite high rate.
+	records = append(records, repeatRecords(2, "fix-review", "failed", "p1", "fix-review-")...)
+	// docs: 10 runs, all passing -> dilutes the fleet baseline to 0.25.
+	records = append(records, repeatRecords(10, "docs", "ok", "p1", "docs-")...)
+
+	got := CollectWeakSubjects(records, 5, 0.15)
 	if len(got) != 1 {
 		t.Fatalf("len(got) = %d, want 1: %+v", len(got), got)
 	}
 	if got[0].Role != "implementation" {
 		t.Fatalf("role = %q, want implementation", got[0].Role)
 	}
-	if got[0].Samples != 20 {
-		t.Fatalf("samples = %d, want 20", got[0].Samples)
+	if got[0].Samples != 10 {
+		t.Fatalf("samples = %d, want 10", got[0].Samples)
 	}
-	wantEffect := 0.30
+	wantEffect := 0.25 // 0.50 role rate - 0.25 overall rate
 	if diff := got[0].EffectSize - wantEffect; diff > 1e-9 || diff < -1e-9 {
 		t.Fatalf("effect size = %v, want %v", got[0].EffectSize, wantEffect)
 	}
@@ -41,8 +54,8 @@ func TestCollectWeakSubjectsGates(t *testing.T) {
 	}
 }
 
-func TestCollectWeakSubjectsEmptyReport(t *testing.T) {
-	got := CollectWeakSubjects(evaluation.Report{}, nil, 5, 0.15)
+func TestCollectWeakSubjectsNoRecords(t *testing.T) {
+	got := CollectWeakSubjects(nil, 5, 0.15)
 	if len(got) != 0 {
 		t.Fatalf("len(got) = %d, want 0", len(got))
 	}

--- a/internal/promptlab/collect_test.go
+++ b/internal/promptlab/collect_test.go
@@ -1,0 +1,64 @@
+package promptlab
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/evaluation"
+	"github.com/Automaat/sybra/internal/stats"
+)
+
+func TestCollectWeakSubjectsGates(t *testing.T) {
+	report := evaluation.Report{
+		Overall: evaluation.Scorecard{FailureRate: 0.10},
+		ByRole: []evaluation.Breakdown{
+			{Key: "implementation", Runs: 20, FailureRate: 0.40}, // clears both gates
+			{Key: "review", Runs: 20, FailureRate: 0.15},         // below min effect size
+			{Key: "fix-review", Runs: 2, FailureRate: 0.90},      // below min samples
+		},
+	}
+	records := []stats.RunRecord{
+		{Role: "implementation", ProjectID: "p1", TaskID: "t1"},
+		{Role: "implementation", ProjectID: "p2", TaskID: "t2"},
+	}
+
+	got := CollectWeakSubjects(report, records, 10, 0.15)
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1: %+v", len(got), got)
+	}
+	if got[0].Role != "implementation" {
+		t.Fatalf("role = %q, want implementation", got[0].Role)
+	}
+	if got[0].Samples != 20 {
+		t.Fatalf("samples = %d, want 20", got[0].Samples)
+	}
+	wantEffect := 0.30
+	if diff := got[0].EffectSize - wantEffect; diff > 1e-9 || diff < -1e-9 {
+		t.Fatalf("effect size = %v, want %v", got[0].EffectSize, wantEffect)
+	}
+	if len(got[0].ProjectIDs) != 2 {
+		t.Fatalf("projectIds = %v, want 2 entries", got[0].ProjectIDs)
+	}
+}
+
+func TestCollectWeakSubjectsEmptyReport(t *testing.T) {
+	got := CollectWeakSubjects(evaluation.Report{}, nil, 5, 0.15)
+	if len(got) != 0 {
+		t.Fatalf("len(got) = %d, want 0", len(got))
+	}
+}
+
+func TestWithinLookback(t *testing.T) {
+	now := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	records := []stats.RunRecord{
+		{TaskID: "old", Timestamp: now.Add(-30 * 24 * time.Hour)},
+		{TaskID: "recent", Timestamp: now.Add(-1 * time.Hour)},
+	}
+	got := withinLookback(records, 7*24*time.Hour, now)
+	if len(got) != 1 || got[0].TaskID != "recent" {
+		t.Fatalf("withinLookback = %+v, want only 'recent'", got)
+	}
+	if all := withinLookback(records, 0, now); len(all) != 2 {
+		t.Fatalf("zero lookback should disable filtering, got %d records", len(all))
+	}
+}

--- a/internal/promptlab/evaluate.go
+++ b/internal/promptlab/evaluate.go
@@ -1,0 +1,15 @@
+package promptlab
+
+// EvaluateProposal runs a proposal's candidate through ev and sets the
+// tri-state offline result plus the human-approval gate. NoVerdict is
+// fail-closed — treated exactly like Failed, it forces human approval — see
+// OfflineEvaluator's doc comment for why a resolved-text runner can't
+// produce a real Passed verdict at this stage.
+func EvaluateProposal(p Proposal, ev OfflineEvaluator) Proposal {
+	if ev == nil {
+		ev = stubEvaluator{}
+	}
+	p.Offline = ev.Evaluate(p.Candidate)
+	p.RequiresHumanApproval = p.Offline.Verdict != VerdictPassed
+	return p
+}

--- a/internal/promptlab/model.go
+++ b/internal/promptlab/model.go
@@ -1,0 +1,114 @@
+// Package promptlab identifies underperforming prompt/skill subjects from
+// fleet evidence (the Evaluation report + stats run records) and scaffolds
+// reviewable proposals for new versioned variants. It never authors variant
+// text and never mutates a production prompt or skill file — proposals are
+// filed as local Sybra tasks for a human (or a later agent run) to flesh out
+// and gate through the normal offline-eval + A/B path.
+package promptlab
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+// Subject identifies a role/workflow-step slice of the fleet whose
+// prompt/skill may be underperforming.
+type Subject struct {
+	Role         string `json:"role"`
+	WorkflowStep string `json:"workflowStep,omitempty"`
+}
+
+// WeakSubject is a Subject flagged by fleet evidence, gated on both sample
+// size and effect size so a single noisy run never triggers a proposal.
+type WeakSubject struct {
+	Subject
+	Metric     string   `json:"metric"`
+	Detail     string   `json:"detail"`
+	Samples    int      `json:"samples"`
+	EffectSize float64  `json:"effectSize"`
+	ProjectIDs []string `json:"projectIds,omitempty"`
+	TaskIDs    []string `json:"taskIds,omitempty"`
+}
+
+// VariantCandidate is a versioned, content-addressed scaffold for a future
+// prompt/skill variant. Intent records only the DIRECTION of the change —
+// promptlab never authors the variant's actual text; that happens later, by
+// hand or by an agent, in the task this candidate is filed under.
+type VariantCandidate struct {
+	ID     string `json:"id"`
+	Intent string `json:"intent"`
+}
+
+// OfflineVerdict is the tri-state result of screening a VariantCandidate.
+type OfflineVerdict string
+
+const (
+	VerdictPassed    OfflineVerdict = "passed"
+	VerdictFailed    OfflineVerdict = "failed"
+	VerdictNoVerdict OfflineVerdict = "no-verdict"
+)
+
+// OfflineResult is the outcome of running a VariantCandidate through an
+// OfflineEvaluator.
+type OfflineResult struct {
+	Verdict OfflineVerdict `json:"verdict"`
+	Reason  string         `json:"reason,omitempty"`
+}
+
+// OfflineEvaluator screens a VariantCandidate before its proposal is filed.
+//
+// promptlab proposals are scaffolds (rationale + expected impact — see
+// propose.go), not authored prompt/skill bytes, so there is nothing yet to
+// run through internal/prompteval's real runner: that screening happens once
+// a human or agent authors the variant text inside the filed task.
+// stubEvaluator reflects that by always returning NoVerdict, which
+// evaluate.go treats the same as Failed — fail-closed until a real candidate
+// with resolved text exists.
+type OfflineEvaluator interface {
+	Evaluate(VariantCandidate) OfflineResult
+}
+
+type stubEvaluator struct{}
+
+func (stubEvaluator) Evaluate(VariantCandidate) OfflineResult {
+	return OfflineResult{
+		Verdict: VerdictNoVerdict,
+		Reason:  "no resolved prompt/skill text to evaluate yet; author it in the filed task",
+	}
+}
+
+// Proposal is one reviewable suggestion to create a new prompt/skill variant,
+// scaffolded from fleet evidence. It never mutates a production prompt or
+// skill file itself.
+type Proposal struct {
+	ID                    string           `json:"id"`
+	Subject               Subject          `json:"subject"`
+	Title                 string           `json:"title"`
+	Rationale             string           `json:"rationale"`
+	ExpectedImpact        string           `json:"expectedImpact"`
+	Candidate             VariantCandidate `json:"candidate"`
+	Evidence              WeakSubject      `json:"evidence"`
+	Offline               OfflineResult    `json:"offline"`
+	RequiresHumanApproval bool             `json:"requiresHumanApproval"`
+	CreatedAt             time.Time        `json:"createdAt"`
+}
+
+// RunResult is the persisted, filed, and CLI-printed output of one promptlab run.
+type RunResult struct {
+	GeneratedAt  time.Time     `json:"generatedAt"`
+	WeakSubjects []WeakSubject `json:"weakSubjects"`
+	Proposals    []Proposal    `json:"proposals"`
+	Dropped      int           `json:"dropped,omitempty"`
+}
+
+// proposalID is content-addressed on the subject, evidence window (sample
+// count + effect size), and variant intent — stable across runs over
+// unchanged evidence, with no wall-clock input, so re-running the loop before
+// new data lands never re-proposes the same idea under a new ID.
+func proposalID(s WeakSubject, intent string) string {
+	raw := fmt.Sprintf("%s|%s|%d|%.3f|%s", s.Role, s.WorkflowStep, s.Samples, s.EffectSize, intent)
+	sum := sha256.Sum256([]byte(raw))
+	return "pl-" + hex.EncodeToString(sum[:])[:12]
+}

--- a/internal/promptlab/model_test.go
+++ b/internal/promptlab/model_test.go
@@ -1,0 +1,57 @@
+package promptlab
+
+import "testing"
+
+func TestProposalIDStable(t *testing.T) {
+	s := WeakSubject{
+		Subject:    Subject{Role: "implementation"},
+		Samples:    12,
+		EffectSize: 0.234,
+	}
+	id1 := proposalID(s, "tighten-instructions")
+	id2 := proposalID(s, "tighten-instructions")
+	if id1 != id2 {
+		t.Fatalf("proposalID not stable: %q != %q", id1, id2)
+	}
+	if id1 == proposalID(s, "restructure-context") {
+		t.Fatalf("proposalID collided across distinct intents")
+	}
+	other := s
+	other.Samples = 13
+	if id1 == proposalID(other, "tighten-instructions") {
+		t.Fatalf("proposalID collided across distinct sample counts")
+	}
+}
+
+func TestStubEvaluatorForcesHumanApproval(t *testing.T) {
+	p := Proposal{Candidate: VariantCandidate{ID: "pl-abc", Intent: "tighten-instructions"}}
+	got := EvaluateProposal(p, stubEvaluator{})
+	if got.Offline.Verdict != VerdictNoVerdict {
+		t.Fatalf("verdict = %q, want %q", got.Offline.Verdict, VerdictNoVerdict)
+	}
+	if !got.RequiresHumanApproval {
+		t.Fatal("stub NoVerdict must require human approval (fail-closed)")
+	}
+}
+
+func TestEvaluateProposalFailedRequiresHumanApproval(t *testing.T) {
+	p := Proposal{Candidate: VariantCandidate{ID: "pl-abc"}}
+	failing := fixedEvaluator{OfflineResult{Verdict: VerdictFailed, Reason: "regression"}}
+	got := EvaluateProposal(p, failing)
+	if !got.RequiresHumanApproval {
+		t.Fatal("Failed verdict must require human approval")
+	}
+}
+
+func TestEvaluateProposalPassedDoesNotRequireApproval(t *testing.T) {
+	p := Proposal{Candidate: VariantCandidate{ID: "pl-abc"}}
+	passing := fixedEvaluator{OfflineResult{Verdict: VerdictPassed}}
+	got := EvaluateProposal(p, passing)
+	if got.RequiresHumanApproval {
+		t.Fatal("Passed verdict must not require human approval")
+	}
+}
+
+type fixedEvaluator struct{ result OfflineResult }
+
+func (f fixedEvaluator) Evaluate(VariantCandidate) OfflineResult { return f.result }

--- a/internal/promptlab/propose.go
+++ b/internal/promptlab/propose.go
@@ -1,0 +1,127 @@
+package promptlab
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// candidateIntents are the directions promptlab may scaffold from a weak
+// subject: tightening guardrails/instructions, or restructuring what
+// evidence/context the role is given. Real prompt/skill authoring happens
+// later, in the filed task — see VariantCandidate.
+var candidateIntents = []string{
+	"tighten-instructions",
+	"restructure-context",
+}
+
+// strongEffectSize is the EffectSize above which a subject gets both
+// candidate intents scaffolded instead of one — proportionate review queue
+// depth to how much evidence backs the subject.
+const strongEffectSize = 0.30
+
+// Propose scaffolds 1-2 VariantCandidate proposals per weak subject, then
+// caps the total at maxProposals (<=0 means unbounded) by keeping the
+// highest-effect-size proposals. Returns the number dropped by the cap so
+// the caller can log it — proposals are never silently truncated.
+func Propose(subjects []WeakSubject, maxProposals int, now time.Time) (proposals []Proposal, dropped int) {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	for i := range subjects {
+		s := &subjects[i]
+		intents := candidateIntents
+		if s.EffectSize < strongEffectSize {
+			intents = candidateIntents[:1]
+		}
+		for _, intent := range intents {
+			proposals = append(proposals, buildProposal(*s, intent, now))
+		}
+	}
+	sort.SliceStable(proposals, func(i, j int) bool { return proposals[i].Evidence.EffectSize > proposals[j].Evidence.EffectSize })
+
+	if maxProposals > 0 && len(proposals) > maxProposals {
+		dropped = len(proposals) - maxProposals
+		proposals = proposals[:maxProposals]
+	}
+	return proposals, dropped
+}
+
+func buildProposal(s WeakSubject, intent string, now time.Time) Proposal {
+	candidate := VariantCandidate{ID: proposalID(s, intent), Intent: intent}
+	return Proposal{
+		ID:             candidate.ID,
+		Subject:        s.Subject,
+		Title:          proposalTitle(s, intent),
+		Rationale:      s.Detail,
+		ExpectedImpact: expectedImpact(s, intent),
+		Candidate:      candidate,
+		Evidence:       s,
+		CreatedAt:      now,
+	}
+}
+
+func proposalTitle(s WeakSubject, intent string) string {
+	base := fmt.Sprintf("Prompt Lab: %s for role %s", strings.ReplaceAll(intent, "-", " "), s.Role)
+	if len(base) <= 80 {
+		return base
+	}
+	return base[:77] + "..."
+}
+
+func expectedImpact(s WeakSubject, intent string) string {
+	return fmt.Sprintf(
+		"Reduce the %.0f-point failure-rate gap observed for role %s (over %d recent runs) by scaffolding a %s variant for offline eval and review.",
+		s.EffectSize*100, s.Role, s.Samples, strings.ReplaceAll(intent, "-", " "),
+	)
+}
+
+// RenderProposalBody renders the reviewable task body for a Proposal. Never
+// includes authored prompt/skill text — only evidence, rationale, and the
+// offline eval verdict that gates it.
+func RenderProposalBody(p Proposal) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "## Prompt Lab Proposal\n\n")
+	fmt.Fprintf(&b, "**Proposal ID:** `%s`\n", p.ID)
+	fmt.Fprintf(&b, "**Subject role:** `%s`\n", p.Subject.Role)
+	fmt.Fprintf(&b, "**Candidate intent:** `%s`\n", p.Candidate.Intent)
+	fmt.Fprintf(&b, "**Review gate:** %s\n\n", reviewGate(p))
+
+	fmt.Fprintf(&b, "## Rationale\n\n%s\n\n", p.Rationale)
+
+	fmt.Fprintf(&b, "## Evidence\n\n")
+	fmt.Fprintf(&b, "- Metric: `%s`\n", p.Evidence.Metric)
+	fmt.Fprintf(&b, "- Samples: %d\n", p.Evidence.Samples)
+	fmt.Fprintf(&b, "- Effect size: %.3f\n", p.Evidence.EffectSize)
+	for _, id := range p.Evidence.TaskIDs {
+		fmt.Fprintf(&b, "- Task `%s`\n", id)
+	}
+
+	fmt.Fprintf(&b, "\n## Proposed change\n\n")
+	fmt.Fprintf(&b, "Scaffold a new versioned prompt/skill variant for role `%s` (intent: `%s`). ", p.Subject.Role, p.Candidate.Intent)
+	fmt.Fprintf(&b, "This proposal does not itself contain variant prompt/skill text and does not mutate any production prompt or skill file — author the variant text in this task, then run it through the offline eval gate before online A/B enrollment.\n\n")
+
+	fmt.Fprintf(&b, "## Expected impact\n\n%s\n\n", p.ExpectedImpact)
+
+	fmt.Fprintf(&b, "## Offline eval\n\n")
+	fmt.Fprintf(&b, "- Verdict: `%s`\n", p.Offline.Verdict)
+	if p.Offline.Reason != "" {
+		fmt.Fprintf(&b, "- Reason: %s\n", p.Offline.Reason)
+	}
+
+	fmt.Fprintf(&b, "\n## Approval\n\n")
+	if p.RequiresHumanApproval {
+		fmt.Fprintf(&b, "REQUIRES HUMAN APPROVAL before this candidate is authored and enrolled.\n")
+	} else {
+		fmt.Fprintf(&b, "Standard Sybra review required before enrollment.\n")
+	}
+	return b.String()
+}
+
+func reviewGate(p Proposal) string {
+	if p.RequiresHumanApproval {
+		return "requires human approval"
+	}
+	return "standard review"
+}

--- a/internal/promptlab/service.go
+++ b/internal/promptlab/service.go
@@ -13,7 +13,6 @@ import (
 
 // Options configures one Run.
 type Options struct {
-	ReportPath    string
 	Records       []stats.RunRecord
 	OutputDir     string
 	Lookback      time.Duration
@@ -25,11 +24,11 @@ type Options struct {
 	Logger        *slog.Logger
 }
 
-// Run orchestrates collect -> propose -> evaluate -> SaveRunResult. A
-// missing evaluation report is treated as "no evidence yet" (empty
-// RunResult, nil error); a present-but-malformed report is a genuine error
-// and Run returns early without writing anything, so a parse failure can
-// never be mistaken for "no weak subjects" and silently persisted.
+// Run orchestrates collect -> propose -> evaluate -> SaveRunResult. Gating
+// metrics are derived entirely from opts.Records within the lookback window —
+// not a separately persisted evaluation report — so there is no window to
+// fall out of sync with --lookback and no on-disk report the ticker has to
+// race to read.
 func Run(ctx context.Context, opts Options) (RunResult, error) {
 	select {
 	case <-ctx.Done():
@@ -45,13 +44,8 @@ func Run(ctx context.Context, opts Options) (RunResult, error) {
 		now = time.Now().UTC()
 	}
 
-	report, err := loadEvaluationReport(opts.ReportPath)
-	if err != nil {
-		return RunResult{}, err
-	}
-
 	records := withinLookback(opts.Records, opts.Lookback, now)
-	subjects := CollectWeakSubjects(report, records, opts.MinSamples, opts.MinEffectSize)
+	subjects := CollectWeakSubjects(records, opts.MinSamples, opts.MinEffectSize)
 	proposals, dropped := Propose(subjects, opts.MaxProposals, now)
 	if dropped > 0 {
 		logger.Info("promptlab.capped", "dropped", dropped, "kept", len(proposals))

--- a/internal/promptlab/service.go
+++ b/internal/promptlab/service.go
@@ -1,0 +1,92 @@
+package promptlab
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Automaat/sybra/internal/stats"
+)
+
+// Options configures one Run.
+type Options struct {
+	ReportPath    string
+	Records       []stats.RunRecord
+	OutputDir     string
+	Lookback      time.Duration
+	MinSamples    int
+	MinEffectSize float64
+	MaxProposals  int
+	Evaluator     OfflineEvaluator
+	Now           time.Time
+	Logger        *slog.Logger
+}
+
+// Run orchestrates collect -> propose -> evaluate -> SaveRunResult. A
+// missing evaluation report is treated as "no evidence yet" (empty
+// RunResult, nil error); a present-but-malformed report is a genuine error
+// and Run returns early without writing anything, so a parse failure can
+// never be mistaken for "no weak subjects" and silently persisted.
+func Run(ctx context.Context, opts Options) (RunResult, error) {
+	select {
+	case <-ctx.Done():
+		return RunResult{}, ctx.Err()
+	default:
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	report, err := loadEvaluationReport(opts.ReportPath)
+	if err != nil {
+		return RunResult{}, err
+	}
+
+	records := withinLookback(opts.Records, opts.Lookback, now)
+	subjects := CollectWeakSubjects(report, records, opts.MinSamples, opts.MinEffectSize)
+	proposals, dropped := Propose(subjects, opts.MaxProposals, now)
+	if dropped > 0 {
+		logger.Info("promptlab.capped", "dropped", dropped, "kept", len(proposals))
+	}
+
+	evaluator := opts.Evaluator
+	if evaluator == nil {
+		evaluator = stubEvaluator{}
+	}
+	for i := range proposals {
+		proposals[i] = EvaluateProposal(proposals[i], evaluator)
+	}
+
+	result := RunResult{
+		GeneratedAt:  now,
+		WeakSubjects: subjects,
+		Proposals:    proposals,
+		Dropped:      dropped,
+	}
+	if opts.OutputDir != "" {
+		if err := SaveRunResult(opts.OutputDir, result); err != nil {
+			return RunResult{}, err
+		}
+	}
+	return result, nil
+}
+
+// SaveRunResult persists the most recent run snapshot to <dir>/last-run.json.
+func SaveRunResult(dir string, result RunResult) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "last-run.json"), data, 0o600)
+}

--- a/internal/promptlab/service_test.go
+++ b/internal/promptlab/service_test.go
@@ -2,66 +2,38 @@ package promptlab
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/Automaat/sybra/internal/evaluation"
+	"github.com/Automaat/sybra/internal/stats"
 )
 
-func writeReport(t *testing.T, dir string, report evaluation.Report) string {
-	t.Helper()
-	path := filepath.Join(dir, "evaluation-report.json")
-	data, err := json.Marshal(report)
-	if err != nil {
-		t.Fatalf("marshal report: %v", err)
-	}
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		t.Fatalf("write report: %v", err)
-	}
-	return path
-}
-
-func TestRunEmptyReport(t *testing.T) {
+func TestRunNoRecords(t *testing.T) {
 	dir := t.TempDir()
 
-	// Missing report file: treated as "no evidence yet", not an error.
-	missing := filepath.Join(dir, "does-not-exist.json")
-	result, err := Run(context.Background(), Options{ReportPath: missing, OutputDir: filepath.Join(dir, "out")})
+	result, err := Run(context.Background(), Options{OutputDir: filepath.Join(dir, "out")})
 	if err != nil {
-		t.Fatalf("Run with missing report: %v", err)
+		t.Fatalf("Run with no records: %v", err)
 	}
 	if len(result.Proposals) != 0 || len(result.WeakSubjects) != 0 {
-		t.Fatalf("expected empty result for missing report, got %+v", result)
+		t.Fatalf("expected empty result for no records, got %+v", result)
 	}
-
-	// Malformed report file: genuine error, nothing written.
-	badPath := filepath.Join(dir, "bad.json")
-	if err := os.WriteFile(badPath, []byte("{not json"), 0o600); err != nil {
-		t.Fatalf("write bad report: %v", err)
-	}
-	outDir := filepath.Join(dir, "out-bad")
-	if _, err := Run(context.Background(), Options{ReportPath: badPath, OutputDir: outDir}); err == nil {
-		t.Fatal("expected error for malformed report")
-	}
-	if _, err := os.Stat(filepath.Join(outDir, "last-run.json")); !os.IsNotExist(err) {
-		t.Fatalf("malformed report must write nothing, stat err = %v", err)
+	if _, err := os.Stat(filepath.Join(dir, "out", "last-run.json")); err != nil {
+		t.Fatalf("expected last-run.json to still be written: %v", err)
 	}
 }
 
 func TestRunFilesHumanRequired(t *testing.T) {
 	dir := t.TempDir()
-	report := evaluation.Report{
-		Overall: evaluation.Scorecard{FailureRate: 0.10},
-		ByRole:  []evaluation.Breakdown{{Key: "implementation", Runs: 20, FailureRate: 0.50}},
-	}
-	path := writeReport(t, dir, report)
 	outDir := filepath.Join(dir, "out")
+	var records []stats.RunRecord
+	records = append(records, weakRoleRecords("implementation", 10, 20)...) // 0.50 failure rate
+	records = append(records, weakRoleRecords("review", 0, 20)...)          // 0.00, dilutes baseline to 0.25
 
 	result, err := Run(context.Background(), Options{
-		ReportPath:    path,
+		Records:       records,
 		OutputDir:     outDir,
 		MinSamples:    5,
 		MinEffectSize: 0.1,
@@ -88,18 +60,14 @@ func TestRunFilesHumanRequired(t *testing.T) {
 
 func TestRunCapsProposalsAndLogs(t *testing.T) {
 	dir := t.TempDir()
-	report := evaluation.Report{
-		Overall: evaluation.Scorecard{FailureRate: 0.0},
-		ByRole: []evaluation.Breakdown{
-			{Key: "implementation", Runs: 20, FailureRate: 0.60},
-			{Key: "review", Runs: 20, FailureRate: 0.50},
-			{Key: "fix-review", Runs: 20, FailureRate: 0.40},
-		},
-	}
-	path := writeReport(t, dir, report)
+	var records []stats.RunRecord
+	records = append(records, weakRoleRecords("implementation", 12, 20)...) // 0.60
+	records = append(records, weakRoleRecords("review", 10, 20)...)         // 0.50
+	records = append(records, weakRoleRecords("fix-review", 8, 20)...)      // 0.40
+	records = append(records, weakRoleRecords("docs", 0, 100)...)           // dilutes baseline to 0.1875
 
 	result, err := Run(context.Background(), Options{
-		ReportPath:    path,
+		Records:       records,
 		OutputDir:     filepath.Join(dir, "out"),
 		MinSamples:    5,
 		MinEffectSize: 0.1,
@@ -118,4 +86,19 @@ func TestRunCapsProposalsAndLogs(t *testing.T) {
 	if result.Proposals[0].Subject.Role != "implementation" {
 		t.Fatalf("kept proposal role = %q, want implementation (highest effect size)", result.Proposals[0].Subject.Role)
 	}
+}
+
+// weakRoleRecords returns `runs` records for role with `fails` of them failed
+// and the rest passing, so tests can build up a role's failure rate without
+// hand-listing each record.
+func weakRoleRecords(role string, fails, runs int) []stats.RunRecord {
+	out := make([]stats.RunRecord, runs)
+	for i := range out {
+		outcome := "ok"
+		if i < fails {
+			outcome = "failed"
+		}
+		out[i] = stats.RunRecord{Role: role, Outcome: outcome, TaskID: role + string(rune('a'+i))}
+	}
+	return out
 }

--- a/internal/promptlab/service_test.go
+++ b/internal/promptlab/service_test.go
@@ -1,0 +1,121 @@
+package promptlab
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Automaat/sybra/internal/evaluation"
+)
+
+func writeReport(t *testing.T, dir string, report evaluation.Report) string {
+	t.Helper()
+	path := filepath.Join(dir, "evaluation-report.json")
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write report: %v", err)
+	}
+	return path
+}
+
+func TestRunEmptyReport(t *testing.T) {
+	dir := t.TempDir()
+
+	// Missing report file: treated as "no evidence yet", not an error.
+	missing := filepath.Join(dir, "does-not-exist.json")
+	result, err := Run(context.Background(), Options{ReportPath: missing, OutputDir: filepath.Join(dir, "out")})
+	if err != nil {
+		t.Fatalf("Run with missing report: %v", err)
+	}
+	if len(result.Proposals) != 0 || len(result.WeakSubjects) != 0 {
+		t.Fatalf("expected empty result for missing report, got %+v", result)
+	}
+
+	// Malformed report file: genuine error, nothing written.
+	badPath := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(badPath, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("write bad report: %v", err)
+	}
+	outDir := filepath.Join(dir, "out-bad")
+	if _, err := Run(context.Background(), Options{ReportPath: badPath, OutputDir: outDir}); err == nil {
+		t.Fatal("expected error for malformed report")
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "last-run.json")); !os.IsNotExist(err) {
+		t.Fatalf("malformed report must write nothing, stat err = %v", err)
+	}
+}
+
+func TestRunFilesHumanRequired(t *testing.T) {
+	dir := t.TempDir()
+	report := evaluation.Report{
+		Overall: evaluation.Scorecard{FailureRate: 0.10},
+		ByRole:  []evaluation.Breakdown{{Key: "implementation", Runs: 20, FailureRate: 0.50}},
+	}
+	path := writeReport(t, dir, report)
+	outDir := filepath.Join(dir, "out")
+
+	result, err := Run(context.Background(), Options{
+		ReportPath:    path,
+		OutputDir:     outDir,
+		MinSamples:    5,
+		MinEffectSize: 0.1,
+		Now:           time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(result.Proposals) == 0 {
+		t.Fatal("expected at least one proposal")
+	}
+	for _, p := range result.Proposals {
+		if !p.RequiresHumanApproval {
+			t.Fatalf("proposal %s: default stub evaluator must force human approval", p.ID)
+		}
+		if p.Offline.Verdict != VerdictNoVerdict {
+			t.Fatalf("proposal %s: verdict = %q, want no-verdict", p.ID, p.Offline.Verdict)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "last-run.json")); err != nil {
+		t.Fatalf("expected last-run.json to be written: %v", err)
+	}
+}
+
+func TestRunCapsProposalsAndLogs(t *testing.T) {
+	dir := t.TempDir()
+	report := evaluation.Report{
+		Overall: evaluation.Scorecard{FailureRate: 0.0},
+		ByRole: []evaluation.Breakdown{
+			{Key: "implementation", Runs: 20, FailureRate: 0.60},
+			{Key: "review", Runs: 20, FailureRate: 0.50},
+			{Key: "fix-review", Runs: 20, FailureRate: 0.40},
+		},
+	}
+	path := writeReport(t, dir, report)
+
+	result, err := Run(context.Background(), Options{
+		ReportPath:    path,
+		OutputDir:     filepath.Join(dir, "out"),
+		MinSamples:    5,
+		MinEffectSize: 0.1,
+		MaxProposals:  1,
+		Now:           time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(result.Proposals) != 1 {
+		t.Fatalf("len(result.Proposals) = %d, want 1", len(result.Proposals))
+	}
+	if result.Dropped == 0 {
+		t.Fatal("expected Dropped > 0 when cap is hit")
+	}
+	if result.Proposals[0].Subject.Role != "implementation" {
+		t.Fatalf("kept proposal role = %q, want implementation (highest effect size)", result.Proposals[0].Subject.Role)
+	}
+}

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -84,6 +84,7 @@ type App struct {
 	workflowStore   *workflow.Store
 	todoist         *todoistCoordinator
 	renovate        *renovateCoordinator
+	promptLab       *promptLabCoordinator
 	triage          *triageCoordinator
 	humanReview     *humanReviewHandler
 	cfg             *config.Config

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -629,6 +629,7 @@ func (a *App) emitDegradedWarnings(emit func(string, any)) {
 func (a *App) initAutomations(emit func(string, any)) *poll.IssuesFetcher {
 	a.initTodoist(emit)
 	a.initRenovate(emit)
+	a.initPromptLab()
 	a.initTriage()
 	a.initHumanReview()
 	return a.initIssuesFetcher(emit)

--- a/internal/sybra/app_promptlab.go
+++ b/internal/sybra/app_promptlab.go
@@ -148,23 +148,26 @@ func (c *promptLabCoordinator) fileScrubbedProposals(result promptlab.RunResult)
 
 // allowsAnyProject reports whether this machine should file a proposal
 // backed by the given evidence project IDs. A subject with no known project
-// (fleet-wide evidence, not traced to one project) is treated as pet-typed —
+// (fleet-wide evidence, not traced to one project) — or one whose project
+// IDs no longer resolve (e.g. a deleted project) — is treated as pet-typed —
 // the least restrictive routing — so it is never silently dropped for lack
 // of attribution.
 func (c *promptLabCoordinator) allowsAnyProject(projectIDs []string) bool {
-	if len(projectIDs) == 0 {
-		return c.allowsProjectType(project.ProjectTypePet)
-	}
+	resolved := false
 	for _, id := range projectIDs {
 		p, err := c.projects.Get(id)
 		if err != nil {
 			continue
 		}
+		resolved = true
 		if c.allowsProjectType(p.Type) {
 			return true
 		}
 	}
-	return false
+	if resolved {
+		return false
+	}
+	return c.allowsProjectType(project.ProjectTypePet)
 }
 
 func (c *promptLabCoordinator) scrubBody(body string, projectIDs []string) string {

--- a/internal/sybra/app_promptlab.go
+++ b/internal/sybra/app_promptlab.go
@@ -1,0 +1,201 @@
+package sybra
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/promptlab"
+	"github.com/Automaat/sybra/internal/scrub"
+	"github.com/Automaat/sybra/internal/stats"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// promptLabCoordinator runs the deterministic (non-LLM) Prompt Lab ticker:
+// collect -> propose -> evaluate -> file reviewed local tasks. Gated on
+// cfg.PromptLab.Enabled and, per weak subject, on AllowsProjectType so a
+// machine that doesn't own a subject's originating project never files a
+// proposal derived from it.
+type promptLabCoordinator struct {
+	tasks             *task.Manager
+	projects          *project.Store
+	stats             *stats.Store
+	logger            *slog.Logger
+	cfg               *config.Config
+	allowsProjectType func(project.ProjectType) bool
+	scrubContext      func(projectID string) *WorkScrubContext
+}
+
+func newPromptLabCoordinator(
+	tasks *task.Manager,
+	projects *project.Store,
+	statsStore *stats.Store,
+	logger *slog.Logger,
+	cfg *config.Config,
+	allowsProjectType func(project.ProjectType) bool,
+	scrubContext func(string) *WorkScrubContext,
+) *promptLabCoordinator {
+	return &promptLabCoordinator{
+		tasks:             tasks,
+		projects:          projects,
+		stats:             statsStore,
+		logger:            logger,
+		cfg:               cfg,
+		allowsProjectType: allowsProjectType,
+		scrubContext:      scrubContext,
+	}
+}
+
+// run ticks on the configured interval, computing and filing proposals each
+// time. No-op when disabled. Returns when ctx is cancelled.
+func (c *promptLabCoordinator) run(ctx context.Context) {
+	if !c.cfg.PromptLab.Enabled {
+		c.logger.Info("promptlab.disabled")
+		return
+	}
+	interval := time.Duration(c.cfg.PromptLab.IntervalHours * float64(time.Hour))
+	if interval < time.Hour {
+		interval = 24 * time.Hour
+	}
+	c.logger.Info("promptlab.start", "interval", interval.String())
+
+	c.tick(ctx)
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			c.tick(ctx)
+		}
+	}
+}
+
+func (c *promptLabCoordinator) tick(ctx context.Context) {
+	var records []stats.RunRecord
+	if c.stats != nil {
+		records = c.stats.All()
+	}
+	lookback := time.Duration(c.cfg.PromptLab.LookbackHours * float64(time.Hour))
+	result, err := promptlab.Run(ctx, promptlab.Options{
+		ReportPath:    config.EvaluationReportPath(),
+		Records:       records,
+		OutputDir:     config.PromptLabDir(),
+		Lookback:      lookback,
+		MinSamples:    c.cfg.PromptLab.MinSamples,
+		MinEffectSize: c.cfg.PromptLab.MinEffectSize,
+		MaxProposals:  c.cfg.PromptLab.MaxProposalsPerRun,
+		Logger:        c.logger,
+	})
+	if err != nil {
+		c.logger.Warn("promptlab.tick.failed", "err", err)
+		return
+	}
+	filed, err := c.fileScrubbedProposals(result)
+	if err != nil {
+		c.logger.Warn("promptlab.file.failed", "err", err)
+		return
+	}
+	c.logger.Info("promptlab.tick",
+		"weak_subjects", len(result.WeakSubjects),
+		"proposals", len(result.Proposals),
+		"filed", len(filed))
+}
+
+// fileScrubbedProposals files each proposal as a reviewed local task, gated
+// per subject on AllowsProjectType and scrubbed via scrubContext when the
+// subject's evidence traces back to a work-typed project. Scrub is EXPLICIT
+// here, not inherited: internal/harnessevolution's filer does not scrub, so
+// this coordinator builds and applies the blocklist itself rather than
+// assuming that precedent covers it too.
+func (c *promptLabCoordinator) fileScrubbedProposals(result promptlab.RunResult) ([]task.Task, error) {
+	existing, err := c.tasks.List()
+	if err != nil {
+		return nil, err
+	}
+	var filed []task.Task
+	for i := range result.Proposals {
+		p := result.Proposals[i]
+		if !c.allowsAnyProject(p.Evidence.ProjectIDs) {
+			continue
+		}
+		if _, ok := findExistingPromptLabProposal(existing, p.ID); ok {
+			continue
+		}
+		body := c.scrubBody(promptlab.RenderProposalBody(p), p.Evidence.ProjectIDs)
+		tags := []string{"prompt-lab-proposal", "role:" + p.Subject.Role}
+		status := task.StatusTodo
+		if p.RequiresHumanApproval {
+			tags = append(tags, "requires-human")
+			status = task.StatusHumanRequired
+		}
+		created, err := c.tasks.CreateFull(p.Title, body, task.AgentModeInteractive, task.Update{
+			Status: &status,
+			Tags:   &tags,
+		})
+		if err != nil {
+			return filed, err
+		}
+		filed = append(filed, created)
+		existing = append(existing, created)
+	}
+	return filed, nil
+}
+
+// allowsAnyProject reports whether this machine should file a proposal
+// backed by the given evidence project IDs. A subject with no known project
+// (fleet-wide evidence, not traced to one project) is treated as pet-typed —
+// the least restrictive routing — so it is never silently dropped for lack
+// of attribution.
+func (c *promptLabCoordinator) allowsAnyProject(projectIDs []string) bool {
+	if len(projectIDs) == 0 {
+		return c.allowsProjectType(project.ProjectTypePet)
+	}
+	for _, id := range projectIDs {
+		p, err := c.projects.Get(id)
+		if err != nil {
+			continue
+		}
+		if c.allowsProjectType(p.Type) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *promptLabCoordinator) scrubBody(body string, projectIDs []string) string {
+	for _, id := range projectIDs {
+		if ctx := c.scrubContext(id); ctx != nil {
+			body, _ = scrub.Scrub(body, ctx.Blocklist)
+		}
+	}
+	return body
+}
+
+func findExistingPromptLabProposal(tasks []task.Task, proposalID string) (task.Task, bool) {
+	marker := "Proposal ID:** `" + proposalID + "`"
+	for i := range tasks {
+		if task.IsTerminalStatus(tasks[i].Status) {
+			continue
+		}
+		if !slices.Contains(tasks[i].Tags, "prompt-lab-proposal") {
+			continue
+		}
+		if strings.Contains(tasks[i].Body, marker) {
+			return tasks[i], true
+		}
+	}
+	return task.Task{}, false
+}
+
+// initPromptLab constructs the promptlab coordinator. Cheap to always build
+// (mirrors renovateCoordinator): the ticker itself no-ops when disabled, so
+// the coordinator can be built unconditionally without an extra guard here.
+func (a *App) initPromptLab() {
+	a.promptLab = newPromptLabCoordinator(a.tasks, a.projects, a.stats, a.logger, a.cfg, a.allowsProjectType, a.workScrubContextForTask)
+}

--- a/internal/sybra/app_promptlab.go
+++ b/internal/sybra/app_promptlab.go
@@ -83,7 +83,6 @@ func (c *promptLabCoordinator) tick(ctx context.Context) {
 	}
 	lookback := time.Duration(c.cfg.PromptLab.LookbackHours * float64(time.Hour))
 	result, err := promptlab.Run(ctx, promptlab.Options{
-		ReportPath:    config.EvaluationReportPath(),
 		Records:       records,
 		OutputDir:     config.PromptLabDir(),
 		Lookback:      lookback,

--- a/internal/sybra/config_diff.go
+++ b/internal/sybra/config_diff.go
@@ -94,6 +94,9 @@ func diffConfig(old, next config.Config) (hot, restart []string) {
 	if !reflect.DeepEqual(old.HarnessEvolve, next.HarnessEvolve) {
 		restart = append(restart, "harness_evolution")
 	}
+	if !reflect.DeepEqual(old.PromptLab, next.PromptLab) {
+		restart = append(restart, "prompt_lab")
+	}
 	if !reflect.DeepEqual(old.ABTesting, next.ABTesting) {
 		restart = append(restart, "ab_testing")
 	}

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -414,10 +414,12 @@ func (lm *LifecycleManager) startEvaluationService(ctx context.Context, emit fun
 }
 
 // startPromptLabService launches the deterministic (non-LLM) Prompt Lab
-// ticker built by initPromptLab. No-op when the coordinator is nil (Startup
-// not yet through initAutomations) or cfg.PromptLab.Enabled is false — the
-// disabled check lives inside promptLabCoordinator.run so this stays a thin
-// launch point, consistent with the other startX helpers in this file.
+// ticker built by initPromptLab. No-op when the coordinator is nil (e.g.
+// tests or other callers that exercise LifecycleManager without going
+// through App.Startup's initAutomations step) or cfg.PromptLab.Enabled is
+// false — the disabled check lives inside promptLabCoordinator.run so this
+// stays a thin launch point, consistent with the other startX helpers in
+// this file.
 func (lm *LifecycleManager) startPromptLabService(ctx context.Context, _ func(string, any)) {
 	a := lm.app
 	if a.promptLab == nil {

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -54,6 +54,7 @@ func (lm *LifecycleManager) StartManagers(ctx context.Context, emit func(string,
 	lm.startMonitorService(ctx, emit)
 	lm.startSelfMonitorService(ctx, emit)
 	lm.startEvaluationService(ctx, emit)
+	lm.startPromptLabService(ctx, emit)
 	lm.startAutoUpdate(ctx)
 	lm.startAgentLogPruneLoop(ctx)
 	lm.registerMetricsObservers()
@@ -410,6 +411,19 @@ func (lm *LifecycleManager) startEvaluationService(ctx context.Context, emit fun
 	svc := evaluation.NewService(deps)
 	a.evaluationSvc = svc
 	a.wg.Go(func() { svc.Run(ctx) })
+}
+
+// startPromptLabService launches the deterministic (non-LLM) Prompt Lab
+// ticker built by initPromptLab. No-op when the coordinator is nil (Startup
+// not yet through initAutomations) or cfg.PromptLab.Enabled is false — the
+// disabled check lives inside promptLabCoordinator.run so this stays a thin
+// launch point, consistent with the other startX helpers in this file.
+func (lm *LifecycleManager) startPromptLabService(ctx context.Context, _ func(string, any)) {
+	a := lm.app
+	if a.promptLab == nil {
+		return
+	}
+	a.wg.Go(func() { a.promptLab.run(ctx) })
 }
 
 // startPollHub registers all enabled poll handlers and starts the hub.

--- a/internal/sybra/svc_config_reload.go
+++ b/internal/sybra/svc_config_reload.go
@@ -48,6 +48,7 @@ func (s *ConfigService) ReloadFromDisk() (changedHot []string, err error) {
 	s.cfg.Monitor = next.Monitor
 	s.cfg.SelfMonitor = next.SelfMonitor
 	s.cfg.HarnessEvolve = next.HarnessEvolve
+	s.cfg.PromptLab = next.PromptLab
 	s.cfg.ABTesting = next.ABTesting
 	s.cfg.Metrics = next.Metrics
 	s.cfg.AutoUpdate = next.AutoUpdate


### PR DESCRIPTION
## Motivation

Sybra collects fleet evidence (evaluation reports, stats) but has no
automated path from that evidence to prompt/skill improvement proposals.
Prompt Lab closes that loop: it scaffolds versioned prompt/skill variant
proposals from fleet evidence, gated on sample size and effect size, and
files them as human-required reviewed tasks.

## Implementation information

- New `internal/promptlab` package: collects evidence, evaluates gating
  thresholds, and proposes variants.
- Never authors variant text or mutates a production prompt/skill file —
  the offline eval seam defaults to a fail-closed no-verdict stub since
  promptlab has no resolved text to screen yet.
- Disabled by default; opt in via `prompt_lab.enabled` in `config.yaml`.
- Wired into `internal/sybra/app_promptlab.go` and app lifecycle/init.
- CLI support added in `cmd/sybra-cli/prompt_lab.go`.
- Follow-up commit addresses review comments (simplified collect/service
  logic, tightened tests).

Closes https://github.com/Automaat/sybra/issues/1206

_Generated by Sybra harness_