### PR TITLE
fix(worktree): reconcile remote before rebase to stop force-push data loss

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -25,6 +25,19 @@ var (
 // ErrBranchMissing is returned by PushSync when the local branch ref does not exist.
 var ErrBranchMissing = errors.New("local branch ref does not exist")
 
+// ErrBranchDiverged is returned by ReconcileWithRemote when the local branch and
+// the remote branch head have genuinely diverged (neither is an ancestor of the
+// other). Proceeding would force-push over remote-only commits — e.g. a fix
+// pushed from another clone/machine — so callers must surface this rather than
+// silently clobber the remote.
+var ErrBranchDiverged = errors.New("local branch diverged from remote head")
+
+// ErrRemoteAdvanced is returned by PushSync when the live remote branch head no
+// longer matches the remote-tracking ref the push decision was based on. The
+// tracking ref is stale, so a --force-with-lease would clobber commits pushed
+// after the last fetch.
+var ErrRemoteAdvanced = errors.New("remote branch advanced past tracking ref")
+
 func runBare(barePath string, args ...string) error {
 	return executil.Run(barePath, "git", append([]string{"-c", "safe.bareRepository=all"}, args...)...)
 }
@@ -498,12 +511,85 @@ func CurrentBranch(worktreePath string) (string, error) {
 	return strings.TrimSpace(branch), nil
 }
 
+// isAncestor reports whether ancestor is reachable from descendant in the
+// worktree's history. Returns false when either ref is unknown.
+func isAncestor(worktreePath, ancestor, descendant string) bool {
+	cmd := exec.Command("git", "merge-base", "--is-ancestor", ancestor, descendant)
+	cmd.Dir = worktreePath
+	return cmd.Run() == nil
+}
+
+// remoteBranchHead queries the live head SHA of branch on remote via ls-remote.
+// Returns ("", nil) when the remote branch does not exist (never pushed).
+func remoteBranchHead(worktreePath, remote, branch string) (string, error) {
+	out, err := executil.Output(worktreePath, "git", "ls-remote", remote, "refs/heads/"+branch)
+	if err != nil {
+		return "", err
+	}
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return "", nil
+	}
+	// Output is "<sha>\trefs/heads/<branch>"; take the first field.
+	return strings.Fields(out)[0], nil
+}
+
+// ReconcileWithRemote fast-forwards the worktree's checked-out branch to the
+// remote branch head before a rebase, so remote-only commits (e.g. a review fix
+// pushed from another clone or machine) are carried forward instead of dropped
+// by a later rebase + force-push.
+//
+// A bare clone never advances refs/heads/* on fetch, so a reused worktree can
+// check out a branch that is strictly behind its own remote head. Rebasing that
+// stale branch onto the base and then force-pushing (PushSync's divergence path)
+// silently overwrites the remote — and --force-with-lease cannot catch it,
+// because the pre-rebase fetch already advanced the tracking ref to the very
+// commit about to be destroyed.
+//
+// Behaviour by comparison of local HEAD to the live remote head:
+//   - remote branch absent, or local == remote: no-op
+//   - local ahead (remote is ancestor of local): no-op, local already contains it
+//   - remote ahead (local is ancestor of remote): fast-forward local to remote
+//   - diverged (neither is an ancestor): ErrBranchDiverged, caller must not force
+func ReconcileWithRemote(worktreePath, branch string) error {
+	remote := PushRemote(worktreePath)
+	// Refresh the tracking ref from the live remote; fork remotes are not
+	// covered by the earlier FetchOrigin. Best-effort: a first-push branch has
+	// no remote head yet and fetch failing here is not fatal.
+	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
+	_ = executil.Run(worktreePath, "git", "fetch", remote, refspec)
+
+	// Best-effort: a remote-unreachable error or an absent branch (first push)
+	// both mean there is nothing to reconcile.
+	remoteSHA, _ := remoteBranchHead(worktreePath, remote, branch)
+	if remoteSHA == "" {
+		return nil
+	}
+
+	localSHA, err := executil.Output(worktreePath, "git", "rev-parse", "--verify", "HEAD")
+	if err != nil {
+		return err
+	}
+	if localSHA == remoteSHA {
+		return nil
+	}
+	if isAncestor(worktreePath, remoteSHA, localSHA) {
+		return nil // local already contains the remote head
+	}
+	if isAncestor(worktreePath, localSHA, remoteSHA) {
+		// Remote strictly ahead — adopt its commits before rebasing.
+		return executil.Run(worktreePath, "git", "merge", "--ff-only", remoteSHA)
+	}
+	return fmt.Errorf("%w: local %s vs remote %s/%s %s", ErrBranchDiverged, localSHA[:min(7, len(localSHA))], remote, branch, remoteSHA[:min(7, len(remoteSHA))])
+}
+
 // PushSync syncs the branch to the fork remote (if present) or origin using
 // the minimum mode required:
 //   - first push (remote tracking ref absent): regular push with -u
 //   - local SHA == remote tracking SHA: no-op
 //   - remote tracking SHA is an ancestor of local (fast-forward): regular push
-//   - histories diverged: --force-with-lease
+//   - histories diverged: --force-with-lease, but only after confirming the live
+//     remote head still matches the tracking ref (else ErrRemoteAdvanced)
 //
 // Compared to an unconditional force push, this avoids gratuitous rewrites of
 // the remote when a rebase was a no-op or the agent produced no new commits.
@@ -534,10 +620,17 @@ func PushSync(worktreePath, branch string) error {
 	}
 
 	// Fast-forward when remote SHA is reachable from local SHA.
-	ffCmd := exec.Command("git", "merge-base", "--is-ancestor", remoteSHA, localSHA)
-	ffCmd.Dir = worktreePath
-	if ffCmd.Run() == nil {
+	if isAncestor(worktreePath, remoteSHA, localSHA) {
 		return executil.Run(worktreePath, "git", "push", "-u", remote, branch)
+	}
+
+	// Divergence path: about to force-push. Verify the live remote head still
+	// matches the tracking ref this decision was based on. If it advanced since
+	// the last fetch, --force-with-lease would pass against the stale tracking
+	// ref and clobber the newer commits — refuse instead.
+	liveSHA, err := remoteBranchHead(worktreePath, remote, branch)
+	if err == nil && liveSHA != "" && liveSHA != remoteSHA {
+		return fmt.Errorf("%w: tracking %s but remote %s/%s is at %s", ErrRemoteAdvanced, remoteSHA[:min(7, len(remoteSHA))], remote, branch, liveSHA[:min(7, len(liveSHA))])
 	}
 
 	return executil.Run(worktreePath, "git", "push", "--force-with-lease", "-u", remote, branch)

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -554,14 +554,22 @@ func remoteBranchHead(worktreePath, remote, branch string) (string, error) {
 func ReconcileWithRemote(worktreePath, branch string) error {
 	remote := PushRemote(worktreePath)
 	// Refresh the tracking ref from the live remote; fork remotes are not
-	// covered by the earlier FetchOrigin. Best-effort: a first-push branch has
-	// no remote head yet and fetch failing here is not fatal.
+	// covered by the earlier FetchOrigin. A first-push branch has no remote
+	// head yet, so "couldn't find remote ref" is expected and not fatal — any
+	// other failure (network/auth/remote misconfig) must propagate, since
+	// continuing on stale history is exactly the data-loss scenario this
+	// function exists to prevent.
 	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
-	_ = executil.Run(worktreePath, "git", "fetch", remote, refspec)
+	if err := executil.Run(worktreePath, "git", "fetch", remote, refspec); err != nil && !strings.Contains(err.Error(), "couldn't find remote ref") {
+		return fmt.Errorf("fetch %s %s: %w", remote, refspec, err)
+	}
 
-	// Best-effort: a remote-unreachable error or an absent branch (first push)
-	// both mean there is nothing to reconcile.
-	remoteSHA, _ := remoteBranchHead(worktreePath, remote, branch)
+	// An absent branch (first push) means there is nothing to reconcile; any
+	// other ls-remote failure must propagate rather than silently no-op.
+	remoteSHA, err := remoteBranchHead(worktreePath, remote, branch)
+	if err != nil {
+		return fmt.Errorf("ls-remote %s %s: %w", remote, branch, err)
+	}
 	if remoteSHA == "" {
 		return nil
 	}
@@ -627,9 +635,14 @@ func PushSync(worktreePath, branch string) error {
 	// Divergence path: about to force-push. Verify the live remote head still
 	// matches the tracking ref this decision was based on. If it advanced since
 	// the last fetch, --force-with-lease would pass against the stale tracking
-	// ref and clobber the newer commits — refuse instead.
+	// ref and clobber the newer commits — refuse instead. Fail closed if the
+	// live head can't even be verified, rather than proceeding with a force
+	// push against an unconfirmed remote state.
 	liveSHA, err := remoteBranchHead(worktreePath, remote, branch)
-	if err == nil && liveSHA != "" && liveSHA != remoteSHA {
+	if err != nil {
+		return fmt.Errorf("%w: could not verify live remote head before force push: %w", ErrRemoteAdvanced, err)
+	}
+	if liveSHA != "" && liveSHA != remoteSHA {
 		return fmt.Errorf("%w: tracking %s but remote %s/%s is at %s", ErrRemoteAdvanced, remoteSHA[:min(7, len(remoteSHA))], remote, branch, liveSHA[:min(7, len(liveSHA))])
 	}
 

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -1710,6 +1710,129 @@ func TestPushSync_DivergenceForcePushes(t *testing.T) {
 	}
 }
 
+// pushRemoteCommit simulates a fix pushed to branch from another clone/machine:
+// it clones remoteBare, commits on branch, pushes, and returns the new SHA. This
+// leaves the caller's worktree local ref stale relative to the remote head.
+func pushRemoteCommit(t *testing.T, remoteBare, branch, content string) string {
+	t.Helper()
+	other := filepath.Join(t.TempDir(), "other")
+	if out, err := exec.Command("git", "clone", "-b", branch, remoteBare, other).CombinedOutput(); err != nil {
+		t.Fatalf("clone other: %v: %s", err, out)
+	}
+	for _, args := range [][]string{
+		{"config", "user.email", "other@test.com"},
+		{"config", "user.name", "Other"},
+		{"config", "commit.gpgsign", "false"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = other
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	sha := makeCommit(t, other, content)
+	push := exec.Command("git", "push", "origin", "HEAD:"+branch)
+	push.Dir = other
+	if out, err := push.CombinedOutput(); err != nil {
+		t.Fatalf("push other: %v: %s", err, out)
+	}
+	return sha
+}
+
+// TestReconcileWithRemote_FastForwardsStaleLocal is the regression for the
+// force-push data-loss bug: a fix pushed to the PR branch from another clone
+// must be adopted into a reused worktree's stale local branch before rebase, so
+// it is not dropped by a later force-push.
+func TestReconcileWithRemote_FastForwardsStaleLocal(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
+	makeCommit(t, wtPath, "one")
+	if err := PushSync(wtPath, branch); err != nil {
+		t.Fatalf("PushSync seed: %v", err)
+	}
+
+	// Another clone pushes a fix; wtPath's local branch is now stale.
+	fixSHA := pushRemoteCommit(t, remoteBare, branch, "review-fix")
+
+	if err := ReconcileWithRemote(wtPath, branch); err != nil {
+		t.Fatalf("ReconcileWithRemote: %v", err)
+	}
+
+	headCmd := exec.Command("git", "rev-parse", "HEAD")
+	headCmd.Dir = wtPath
+	headOut, err := headCmd.Output()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	head := strings.TrimSpace(string(headOut))
+	if head != fixSHA {
+		t.Fatalf("local HEAD after reconcile = %q, want fix SHA %q (fast-forward failed)", head, fixSHA)
+	}
+}
+
+// TestReconcileWithRemote_DivergedReturnsError guards against clobbering a
+// remote that has genuinely diverged: reconcile must refuse rather than let a
+// later force-push silently overwrite remote-only commits.
+func TestReconcileWithRemote_DivergedReturnsError(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
+	makeCommit(t, wtPath, "one")
+	if err := PushSync(wtPath, branch); err != nil {
+		t.Fatalf("PushSync seed: %v", err)
+	}
+
+	// Remote advances one way; local advances a different, incompatible way.
+	pushRemoteCommit(t, remoteBare, branch, "remote-side")
+	makeCommit(t, wtPath, "local-side")
+
+	err := ReconcileWithRemote(wtPath, branch)
+	if !errors.Is(err, ErrBranchDiverged) {
+		t.Fatalf("ReconcileWithRemote diverged = %v, want ErrBranchDiverged", err)
+	}
+}
+
+// TestPushSync_RefusesForceWhenRemoteAdvanced is the defense-in-depth net: when
+// the live remote head no longer matches the stale tracking ref the push
+// decision was based on, PushSync must refuse the --force-with-lease rather than
+// clobber the newer commits (which the lease would wrongly permit).
+func TestPushSync_RefusesForceWhenRemoteAdvanced(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
+	makeCommit(t, wtPath, "one")
+	makeCommit(t, wtPath, "two")
+	if err := PushSync(wtPath, branch); err != nil {
+		t.Fatalf("PushSync seed: %v", err)
+	}
+
+	// Diverge local from the tracking ref so PushSync takes the force path.
+	if out, err := exec.Command("git", "-C", wtPath, "reset", "--hard", "HEAD~1").CombinedOutput(); err != nil {
+		t.Fatalf("reset: %v: %s", err, out)
+	}
+	makeCommit(t, wtPath, "two-prime")
+
+	// Meanwhile the remote branch advances from another clone. wtPath never
+	// fetches, so its tracking ref stays behind the live remote head.
+	advancedSHA := pushRemoteCommit(t, remoteBare, branch, "concurrent-fix")
+
+	err := PushSync(wtPath, branch)
+	if !errors.Is(err, ErrRemoteAdvanced) {
+		t.Fatalf("PushSync = %v, want ErrRemoteAdvanced", err)
+	}
+	// The remote fix must survive untouched.
+	if got := remoteRefSHA(t, remoteBare, branch); got != advancedSHA {
+		t.Fatalf("remote SHA = %q, want untouched fix %q", got, advancedSHA)
+	}
+}
+
 func TestFetchPRHead(t *testing.T) {
 	t.Parallel()
 	if !hasGit() {

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -1797,6 +1797,32 @@ func TestReconcileWithRemote_DivergedReturnsError(t *testing.T) {
 	}
 }
 
+// TestReconcileWithRemote_PropagatesFetchError guards the fail-closed fix: a
+// fetch failure other than the expected "couldn't find remote ref" (first
+// push) case must propagate instead of letting reconcile silently no-op on
+// stale history.
+func TestReconcileWithRemote_PropagatesFetchError(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	_, wtPath, branch := setupPushSyncWorktree(t)
+	makeCommit(t, wtPath, "one")
+	if err := PushSync(wtPath, branch); err != nil {
+		t.Fatalf("PushSync seed: %v", err)
+	}
+
+	// Point origin at an unreachable path so fetch fails for a reason other
+	// than a missing remote ref.
+	if out, err := exec.Command("git", "-C", wtPath, "remote", "set-url", "origin", filepath.Join(t.TempDir(), "no-such-remote.git")).CombinedOutput(); err != nil {
+		t.Fatalf("remote set-url: %v: %s", err, out)
+	}
+
+	if err := ReconcileWithRemote(wtPath, branch); err == nil {
+		t.Fatal("ReconcileWithRemote with broken remote = nil error, want propagated fetch failure")
+	}
+}
+
 // TestPushSync_RefusesForceWhenRemoteAdvanced is the defense-in-depth net: when
 // the live remote head no longer matches the stale tracking ref the push
 // decision was based on, PushSync must refuse the --force-with-lease rather than
@@ -1830,6 +1856,44 @@ func TestPushSync_RefusesForceWhenRemoteAdvanced(t *testing.T) {
 	// The remote fix must survive untouched.
 	if got := remoteRefSHA(t, remoteBare, branch); got != advancedSHA {
 		t.Fatalf("remote SHA = %q, want untouched fix %q", got, advancedSHA)
+	}
+}
+
+// TestPushSync_FailsClosedWhenRemoteHeadUnverifiable guards the fail-closed
+// fix: if the live remote head can't be verified before a force push, PushSync
+// must refuse rather than proceed with --force-with-lease against unconfirmed
+// remote state.
+func TestPushSync_FailsClosedWhenRemoteHeadUnverifiable(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
+	makeCommit(t, wtPath, "one")
+	makeCommit(t, wtPath, "two")
+	if err := PushSync(wtPath, branch); err != nil {
+		t.Fatalf("PushSync seed: %v", err)
+	}
+	beforeSHA := remoteRefSHA(t, remoteBare, branch)
+
+	// Diverge local from the tracking ref so PushSync takes the force path.
+	if out, err := exec.Command("git", "-C", wtPath, "reset", "--hard", "HEAD~1").CombinedOutput(); err != nil {
+		t.Fatalf("reset: %v: %s", err, out)
+	}
+	makeCommit(t, wtPath, "two-prime")
+
+	// Break the remote so the live-head verification (ls-remote) errors
+	// instead of returning a SHA.
+	if out, err := exec.Command("git", "-C", wtPath, "remote", "set-url", "origin", filepath.Join(t.TempDir(), "no-such-remote.git")).CombinedOutput(); err != nil {
+		t.Fatalf("remote set-url: %v: %s", err, out)
+	}
+
+	err := PushSync(wtPath, branch)
+	if !errors.Is(err, ErrRemoteAdvanced) {
+		t.Fatalf("PushSync = %v, want ErrRemoteAdvanced (fail closed)", err)
+	}
+	if got := remoteRefSHA(t, remoteBare, branch); got != beforeSHA {
+		t.Fatalf("remote SHA = %q, want untouched %q", got, beforeSHA)
 	}
 }
 

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -68,11 +68,8 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 			if err := project.SanitizeWorktree(wtPath); err != nil {
 				m.logger.Warn("worktree.sanitize", "task_id", t.ID, "err", err)
 			}
-			// Rebase must succeed before another agent run. Continuing from a
-			// stale branch makes downstream diff gates scan historical commits.
-			callPhase(onPhase, "Rebasing onto origin…")
-			if err := project.RebaseOnto(wtPath, baseRef); err != nil {
-				return "", fmt.Errorf("%w: rebase %s onto %s: %w", ErrRebaseFailed, wtBranch, baseRef, err)
+			if err := m.reconcileAndRebase(wtPath, wtBranch, baseRef, onPhase); err != nil {
+				return "", err
 			}
 			m.logger.Info("worktree.rebased", "task_id", t.ID, "path", wtPath, "base", baseRef)
 			// Sync remote after rebase. PushSync picks the minimum mode —
@@ -95,9 +92,8 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 		if err := project.SanitizeWorktree(wtPath); err != nil {
 			m.logger.Warn("worktree.sanitize", "task_id", t.ID, "err", err)
 		}
-		callPhase(onPhase, "Rebasing onto origin…")
-		if err := project.RebaseOnto(wtPath, baseRef); err != nil {
-			return "", fmt.Errorf("%w: rebase %s onto %s: %w", ErrRebaseFailed, wtBranch, baseRef, err)
+		if err := m.reconcileAndRebase(wtPath, wtBranch, baseRef, onPhase); err != nil {
+			return "", err
 		}
 		// Sync remote after rebase.
 		callPhase(onPhase, "Syncing upstream…")
@@ -129,6 +125,26 @@ func (m *Manager) PrepareForTask(t task.Task, onPhase func(string)) (string, err
 	m.ensureBranch(t, wtBranch)
 	m.seedWorktree(t, wtPath, wtBranch)
 	return wtPath, nil
+}
+
+// reconcileAndRebase prepares a reused worktree branch for another agent run.
+// It first adopts any commits pushed to the remote branch since this worktree's
+// local ref was last updated (e.g. a review fix pushed from another
+// clone/machine), so the rebase carries them forward instead of a later
+// force-push dropping them. Rebasing must then succeed before the agent runs —
+// continuing from a stale branch makes downstream diff gates scan historical
+// commits. Both failures wrap ErrRebaseFailed so the caller can surface a
+// repairable worktree.
+func (m *Manager) reconcileAndRebase(wtPath, wtBranch, baseRef string, onPhase func(string)) error {
+	callPhase(onPhase, "Reconciling with remote…")
+	if err := project.ReconcileWithRemote(wtPath, wtBranch); err != nil {
+		return fmt.Errorf("%w: reconcile %s with remote: %w", ErrRebaseFailed, wtBranch, err)
+	}
+	callPhase(onPhase, "Rebasing onto origin…")
+	if err := project.RebaseOnto(wtPath, baseRef); err != nil {
+		return fmt.Errorf("%w: rebase %s onto %s: %w", ErrRebaseFailed, wtBranch, baseRef, err)
+	}
+	return nil
 }
 
 // seedWorktree drops the per-worktree agent context into an implementation


### PR DESCRIPTION
## Motivation

> Changelog: fix(worktree): reconcile remote before rebase to stop force-push data loss

Agents were silently losing pushed work to force-pushes. Concretely: an agent fixes review comments and pushes the fix to the PR branch, then a later dispatch on the same PR overwrites it — the fix vanishes from the PR.

Root cause: a reused worktree checks out the **stale local branch ref**. A bare clone never advances `refs/heads/*` on fetch, so the checked-out branch can be strictly behind its own remote head. `PrepareForTask` then rebases that stale branch onto the base and `PushSync` force-pushes on divergence. `--force-with-lease` cannot protect here — the pre-rebase `FetchOrigin` already advanced the remote-tracking ref to the exact commit about to be destroyed, so the lease check passes and clobbers the fix. Very likely amplified by the multi-machine setup (fix pushed from one clone, re-prepare run from another whose local branch is behind).

## Implementation information

- **`ReconcileWithRemote`** (`internal/project/git.go`) — before rebasing a reused branch, fast-forward the worktree branch to the **live** remote head (queried via `ls-remote`, not the possibly-stale tracking ref) so remote-only commits are carried forward by the rebase. On genuine divergence (neither side an ancestor) it returns `ErrBranchDiverged` rather than letting a later force-push clobber remote work. In the common case the subsequent push is now a plain fast-forward — no force needed at all.
- **`PushSync` guard** (`internal/project/git.go`) — defense in depth: before `--force-with-lease`, confirm the live remote head still matches the tracking ref the push decision was based on; otherwise return `ErrRemoteAdvanced` and refuse. Catches the concurrent-advance race the lease misses when the tracking ref was pre-fetched.
- **`PrepareForTask`** (`internal/worktree/prepare.go`) — both reused-worktree paths now reconcile before rebase via a new `reconcileAndRebase` helper.
- Tests: stale-local fast-forward regression, divergence-returns-error, and `PushSync` refuses-force-when-remote-advanced (all in `internal/project/git_test.go`).

## Supporting documentation

`go test ./internal/project/... ./internal/worktree/...` and `golangci-lint run` on both packages pass locally.

_Generated by Sybra harness_