### PR TITLE
perf(github): batch per-PR monitor fetches

### DIFF
--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -171,9 +171,11 @@ type gqlBatchPRResponse struct {
 }
 
 // aliasErrors buckets the response's errors by the top-level aliased field
-// (e.g. "repo3") their path points at. Errors without a path, or whose path
-// doesn't start with a string (a query-level error), are global: they apply
-// to every alias since GitHub returned no usable per-alias distinction.
+// (e.g. "repo3") their path points at. Errors without a path, whose path
+// doesn't start with a string, or whose path points at a field other than a
+// "repoN" ref alias (e.g. the shared "viewer" field) are global: they apply
+// to every ref since GitHub returned no usable per-ref distinction, or the
+// error is scoped to a field every ref's result depends on.
 func (r *gqlBatchPRResponse) aliasErrors() (perAlias map[string]string, global string) {
 	perAlias = make(map[string]string)
 	for _, ge := range r.Errors {
@@ -182,7 +184,7 @@ func (r *gqlBatchPRResponse) aliasErrors() (perAlias map[string]string, global s
 			continue
 		}
 		alias, ok := ge.Path[0].(string)
-		if !ok {
+		if !ok || !isRefAlias(alias) {
 			global = ge.Message
 			continue
 		}
@@ -191,6 +193,22 @@ func (r *gqlBatchPRResponse) aliasErrors() (perAlias map[string]string, global s
 		}
 	}
 	return perAlias, global
+}
+
+// isRefAlias reports whether alias has the "repoN" shape used for per-ref
+// aliases in the batched monitor query (as opposed to shared top-level
+// fields like "viewer").
+func isRefAlias(alias string) bool {
+	rest, ok := strings.CutPrefix(alias, "repo")
+	if !ok || rest == "" {
+		return false
+	}
+	for _, c := range rest {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func (r *gqlBatchPRResponse) viewerLogin() string {

--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -68,10 +68,9 @@ const reviewSummaryQuery = `query($q: String!) {
   }
 }`
 
-const prForMonitorQuery = `query($owner: String!, $name: String!, $number: Int!) {
-  viewer { login }
-  repository(owner: $owner, name: $name) {
-    pullRequest(number: $number) {
+// monitorPRFields is the field selection shared by the single-PR and batched
+// monitor queries, kept in one place so the two paths can never drift apart.
+const monitorPRFields = `
       number
       title
       url
@@ -118,10 +117,19 @@ const prForMonitorQuery = `query($owner: String!, $name: String!, $number: Int!)
       }
       latestReviews(first: 10) {
         nodes { state author { login } }
-      }
+      }`
+
+const prForMonitorQuery = `query($owner: String!, $name: String!, $number: Int!) {
+  viewer { login }
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {` + monitorPRFields + `
     }
   }
 }`
+
+// maxBatchPRsPerQuery caps how many PRs are aliased into a single batched
+// monitor query, staying under GitHub's per-request node/complexity limits.
+const maxBatchPRsPerQuery = 20
 
 type gqlReviewSummaryResponse struct {
 	Data struct {
@@ -149,6 +157,51 @@ type gqlPRForMonitorResponse struct {
 	Errors []struct {
 		Message string `json:"message"`
 	} `json:"errors"`
+}
+
+// gqlBatchPRResponse decodes a batched monitor query. Each requested PR gets
+// its own top-level aliased field (repo0, repo1, ...), so Data is decoded as
+// a raw map instead of a fixed struct.
+type gqlBatchPRResponse struct {
+	Data   map[string]json.RawMessage `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+func (r *gqlBatchPRResponse) viewerLogin() string {
+	raw, ok := r.Data["viewer"]
+	if !ok {
+		return ""
+	}
+	var v struct {
+		Login string `json:"login"`
+	}
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return ""
+	}
+	return v.Login
+}
+
+type gqlBatchRepoNode struct {
+	PullRequest *gqlPR `json:"pullRequest"`
+}
+
+// PRRef identifies a single PR to fetch in a batched monitor request.
+type PRRef struct {
+	Repo   string
+	Number int
+}
+
+// MonitorPRResult is one PR's outcome from a batched monitor fetch. Open
+// mirrors the bool FetchPRForMonitor returns: false for closed/merged PRs
+// (left to FetchPRState-based reconciliation) as well as fetch errors.
+type MonitorPRResult struct {
+	Repo   string
+	Number int
+	PR     PullRequest
+	Open   bool
+	Err    error
 }
 
 // FetchReviews returns open PRs created by the user and review requests, excluding bots.
@@ -202,6 +255,133 @@ func fetchPRForMonitorWith(e execer, repo string, number int) (PullRequest, bool
 		return PullRequest{}, false, nil
 	}
 	return convertCommonPR(pr, gqlResp.Data.Viewer.Login), true, nil
+}
+
+// FetchPRsForMonitor fetches multiple PRs' monitor signals, aliasing them
+// into as few GraphQL requests as possible (chunked to stay under GitHub's
+// node/complexity limits) instead of issuing one query per PR. Results are
+// returned in the same order as refs.
+func FetchPRsForMonitor(refs []PRRef) []MonitorPRResult {
+	return fetchPRsForMonitorWith(defaultExecer, refs)
+}
+
+func fetchPRsForMonitorWith(e execer, refs []PRRef) []MonitorPRResult {
+	if len(refs) == 0 {
+		return nil
+	}
+
+	// When the GraphQL budget is low, keep the existing single-PR REST
+	// fallback per ref instead of batching — same behavior/data tradeoffs as
+	// fetchPRForMonitorWith. Gated on runtimeCacheEnabled so unit tests (fake
+	// execer) keep the GraphQL path.
+	if runtimeCacheEnabled(e) && ghGate.shouldSkipOptional("graphql") {
+		results := make([]MonitorPRResult, len(refs))
+		for i, ref := range refs {
+			pr, open, err := fetchPRForMonitorViaREST(e, ref.Repo, ref.Number)
+			results[i] = MonitorPRResult{Repo: ref.Repo, Number: ref.Number, PR: pr, Open: open, Err: err}
+		}
+		return results
+	}
+
+	results := make([]MonitorPRResult, 0, len(refs))
+	for start := 0; start < len(refs); start += maxBatchPRsPerQuery {
+		end := min(start+maxBatchPRsPerQuery, len(refs))
+		results = append(results, fetchPRBatchWith(e, refs[start:end])...)
+	}
+	return results
+}
+
+// fetchPRBatchWith fetches one chunk of refs (already capped to
+// maxBatchPRsPerQuery) in a single GraphQL request, aliasing
+// repository(owner,name){ pullRequest(number) } per ref.
+func fetchPRBatchWith(e execer, refs []PRRef) []MonitorPRResult {
+	type validRef struct {
+		idx    int // index into refs/results
+		owner  string
+		name   string
+		number int
+	}
+	results := make([]MonitorPRResult, len(refs))
+	valid := make([]validRef, 0, len(refs))
+	for i, ref := range refs {
+		results[i] = MonitorPRResult{Repo: ref.Repo, Number: ref.Number}
+		owner, name, ok := strings.Cut(ref.Repo, "/")
+		if !ok || owner == "" || name == "" || ref.Number <= 0 {
+			results[i].Err = fmt.Errorf("invalid repo or PR: %s#%d", ref.Repo, ref.Number)
+			continue
+		}
+		valid = append(valid, validRef{idx: i, owner: owner, name: name, number: ref.Number})
+	}
+	if len(valid) == 0 {
+		return results
+	}
+
+	var query strings.Builder
+	query.WriteString("query(")
+	for j := range valid {
+		fmt.Fprintf(&query, "$owner%d: String!, $name%d: String!, $number%d: Int!, ", j, j, j)
+	}
+	query.WriteString(") {\n  viewer { login }\n")
+	for j := range valid {
+		fmt.Fprintf(&query, "  repo%d: repository(owner: $owner%d, name: $name%d) {\n    pullRequest(number: $number%d) {%s\n    }\n  }\n", j, j, j, j, monitorPRFields)
+	}
+	query.WriteString("}")
+
+	args := make([]string, 0, 4+len(valid)*6)
+	args = append(args, "graphql", "-f", "query="+query.String())
+	for j, v := range valid {
+		args = append(args,
+			"-f", fmt.Sprintf("owner%d=%s", j, v.owner),
+			"-f", fmt.Sprintf("name%d=%s", j, v.name),
+			"-F", fmt.Sprintf("number%d=%d", j, v.number),
+		)
+	}
+
+	resp, err := runGHAPIWith(e, "", args...)
+	if err != nil {
+		batchErr := fmt.Errorf("gh api graphql pr batch: %s: %w", sanitizeGHOutput(resp.body), err)
+		for _, v := range valid {
+			results[v.idx].Err = batchErr
+		}
+		return results
+	}
+
+	var gqlResp gqlBatchPRResponse
+	if err := json.Unmarshal(resp.body, &gqlResp); err != nil {
+		parseErr := fmt.Errorf("parse graphql pr batch response: %w", err)
+		for _, v := range valid {
+			results[v.idx].Err = parseErr
+		}
+		return results
+	}
+	if len(gqlResp.Errors) > 0 {
+		gqlErr := fmt.Errorf("graphql pr batch: %s", gqlResp.Errors[0].Message)
+		for _, v := range valid {
+			results[v.idx].Err = gqlErr
+		}
+		return results
+	}
+
+	viewer := gqlResp.viewerLogin()
+	for j, v := range valid {
+		alias := fmt.Sprintf("repo%d", j)
+		raw, ok := gqlResp.Data[alias]
+		if !ok {
+			results[v.idx].Err = fmt.Errorf("graphql pr batch: missing %s in response", alias)
+			continue
+		}
+		var node gqlBatchRepoNode
+		if err := json.Unmarshal(raw, &node); err != nil {
+			results[v.idx].Err = fmt.Errorf("parse graphql pr batch %s: %w", alias, err)
+			continue
+		}
+		if node.PullRequest == nil || node.PullRequest.State != "OPEN" {
+			continue
+		}
+		results[v.idx].PR = convertCommonPR(node.PullRequest, viewer)
+		results[v.idx].Open = true
+	}
+	return results
 }
 
 func fetchReviewsWith(e execer) (ReviewSummary, error) {

--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -374,7 +374,10 @@ func fetchPRBatchWith(e execer, refs []PRRef) []MonitorPRResult {
 	var query strings.Builder
 	query.WriteString("query(")
 	for j := range valid {
-		fmt.Fprintf(&query, "$owner%d: String!, $name%d: String!, $number%d: Int!, ", j, j, j)
+		if j > 0 {
+			query.WriteString(", ")
+		}
+		fmt.Fprintf(&query, "$owner%d: String!, $name%d: String!, $number%d: Int!", j, j, j)
 	}
 	query.WriteString(") {\n  viewer { login }\n")
 	for j := range valid {

--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -166,7 +166,31 @@ type gqlBatchPRResponse struct {
 	Data   map[string]json.RawMessage `json:"data"`
 	Errors []struct {
 		Message string `json:"message"`
+		Path    []any  `json:"path"`
 	} `json:"errors"`
+}
+
+// aliasErrors buckets the response's errors by the top-level aliased field
+// (e.g. "repo3") their path points at. Errors without a path, or whose path
+// doesn't start with a string (a query-level error), are global: they apply
+// to every alias since GitHub returned no usable per-alias distinction.
+func (r *gqlBatchPRResponse) aliasErrors() (perAlias map[string]string, global string) {
+	perAlias = make(map[string]string)
+	for _, ge := range r.Errors {
+		if len(ge.Path) == 0 {
+			global = ge.Message
+			continue
+		}
+		alias, ok := ge.Path[0].(string)
+		if !ok {
+			global = ge.Message
+			continue
+		}
+		if _, exists := perAlias[alias]; !exists {
+			perAlias[alias] = ge.Message
+		}
+	}
+	return perAlias, global
 }
 
 func (r *gqlBatchPRResponse) viewerLogin() string {
@@ -284,8 +308,21 @@ func fetchPRsForMonitorWith(e execer, refs []PRRef) []MonitorPRResult {
 	}
 
 	results := make([]MonitorPRResult, 0, len(refs))
+	cacheEnabled := runtimeCacheEnabled(e)
 	for start := 0; start < len(refs); start += maxBatchPRsPerQuery {
 		end := min(start+maxBatchPRsPerQuery, len(refs))
+		// Recheck the gate before every chunk: an earlier chunk in this same
+		// loop can observe rate-limit headers (via runGHAPIWith) and trip the
+		// gate into a low-budget state, in which case the remaining refs
+		// should fall back to REST instead of continuing to spend GraphQL
+		// budget or hitting rate-limit errors.
+		if cacheEnabled && ghGate.shouldSkipOptional("graphql") {
+			for _, ref := range refs[start:] {
+				pr, open, err := fetchPRForMonitorViaREST(e, ref.Repo, ref.Number)
+				results = append(results, MonitorPRResult{Repo: ref.Repo, Number: ref.Number, PR: pr, Open: open, Err: err})
+			}
+			return results
+		}
 		results = append(results, fetchPRBatchWith(e, refs[start:end])...)
 	}
 	return results
@@ -354,8 +391,14 @@ func fetchPRBatchWith(e execer, refs []PRRef) []MonitorPRResult {
 		}
 		return results
 	}
-	if len(gqlResp.Errors) > 0 {
-		gqlErr := fmt.Errorf("graphql pr batch: %s", gqlResp.Errors[0].Message)
+	// GitHub GraphQL can return partial data: an error scoped to one alias
+	// (e.g. a deleted/inaccessible repo or PR) alongside valid data for every
+	// other alias in the batch. Only fail the aliases named in a per-alias
+	// error path; a query-level error with no path (global) still fails the
+	// whole batch, since there's no per-alias data to salvage.
+	perAliasErr, globalErr := gqlResp.aliasErrors()
+	if globalErr != "" {
+		gqlErr := fmt.Errorf("graphql pr batch: %s", globalErr)
 		for _, v := range valid {
 			results[v.idx].Err = gqlErr
 		}
@@ -365,6 +408,10 @@ func fetchPRBatchWith(e execer, refs []PRRef) []MonitorPRResult {
 	viewer := gqlResp.viewerLogin()
 	for j, v := range valid {
 		alias := fmt.Sprintf("repo%d", j)
+		if msg, failed := perAliasErr[alias]; failed {
+			results[v.idx].Err = fmt.Errorf("graphql pr batch %s: %s", alias, msg)
+			continue
+		}
 		raw, ok := gqlResp.Data[alias]
 		if !ok {
 			results[v.idx].Err = fmt.Errorf("graphql pr batch: missing %s in response", alias)

--- a/internal/github/review_test.go
+++ b/internal/github/review_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestFetchReviewsWith_success(t *testing.T) {
@@ -412,5 +413,97 @@ func TestFetchPRsForMonitorWith_invalidRefSkipsQuery(t *testing.T) {
 	}
 	if len(results) != 1 || results[0].Err == nil {
 		t.Fatalf("results = %+v, want single error result", results)
+	}
+}
+
+// TestFetchPRBatchWith_partialError locks that a GraphQL error scoped to one
+// alias (via errors[].path) only fails that alias — the other aliases in the
+// same batch, which have valid data alongside the error, must still resolve.
+func TestFetchPRBatchWith_partialError(t *testing.T) {
+	t.Parallel()
+	fe := &fakeExecer{output: []byte(`{
+		"data": {
+			"viewer": {"login": "me"},
+			"repo0": {
+				"pullRequest": {
+					"number": 1,
+					"title": "one",
+					"url": "https://github.com/o/r/pull/1",
+					"state": "OPEN",
+					"author": {"login": "me", "type": "User"},
+					"repository": {"name": "r", "nameWithOwner": "o/r"},
+					"labels": {"nodes": []},
+					"commits": {"nodes": []},
+					"reviewThreads": {"nodes": []},
+					"latestReviews": {"nodes": []}
+				}
+			},
+			"repo1": null
+		},
+		"errors": [
+			{"message": "Could not resolve to a PullRequest", "path": ["repo1", "pullRequest"]}
+		]
+	}`)}
+
+	refs := []PRRef{{Repo: "o/r", Number: 1}, {Repo: "o/r", Number: 2}}
+	results := fetchPRsForMonitorWith(fe, refs)
+
+	if fe.calls != 1 {
+		t.Fatalf("calls = %d, want 1", fe.calls)
+	}
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if results[0].Err != nil || !results[0].Open || results[0].PR.Title != "one" {
+		t.Fatalf("results[0] = %+v, want valid open PR unaffected by repo1's error", results[0])
+	}
+	if results[1].Err == nil {
+		t.Fatalf("results[1] = %+v, want error for the aliased PR that GraphQL reported", results[1])
+	}
+}
+
+// TestFetchPRBatchWith_globalErrorFailsWholeBatch locks that a query-level
+// GraphQL error with no path (no per-alias distinction to salvage) still
+// fails every ref in the batch, same as before this change.
+func TestFetchPRBatchWith_globalErrorFailsWholeBatch(t *testing.T) {
+	t.Parallel()
+	fe := &fakeExecer{output: []byte(`{"errors":[{"message":"rate limited"}]}`)}
+	refs := []PRRef{{Repo: "o/r", Number: 1}, {Repo: "o/r", Number: 2}}
+	results := fetchPRsForMonitorWith(fe, refs)
+	if len(results) != 2 || results[0].Err == nil || results[1].Err == nil {
+		t.Fatalf("results = %+v, want both refs to error", results)
+	}
+}
+
+// TestFetchPRBatchWith_updatesGateForNextChunk locks the mechanism
+// fetchPRsForMonitorWith's per-chunk gate recheck depends on: a chunk
+// response carrying low-budget rate-limit headers must update ghGate so that
+// shouldSkipOptional("graphql") reports true immediately after, without
+// waiting for a separate /rate_limit refresh. (The recheck itself is gated on
+// runtimeCacheEnabled(e), i.e. the real defaultExecer, so it cannot be driven
+// end-to-end through a fake execer — see the identical constraint on the
+// pre-loop check a few lines above in fetchPRsForMonitorWith.)
+func TestFetchPRBatchWith_updatesGateForNextChunk(t *testing.T) {
+	orig := ghGate
+	t.Cleanup(func() { ghGate = orig })
+	ghGate = newGHRequestGate()
+
+	resetAt := time.Now().Add(time.Hour).Unix()
+	chunk1 := fmt.Sprintf("HTTP/1.1 200 OK\n"+
+		"x-ratelimit-resource: graphql\n"+
+		"x-ratelimit-remaining: 0\n"+
+		"x-ratelimit-limit: 5000\n"+
+		"x-ratelimit-reset: %d\n\n"+
+		`{"data": {"viewer": {"login": "me"}}}`, resetAt)
+
+	fe := &fakeExecer{output: []byte(chunk1)}
+	refs := []PRRef{{Repo: "o/r", Number: 1}}
+
+	if ghGate.shouldSkipOptional("graphql") {
+		t.Fatal("gate should not skip graphql before any call")
+	}
+	fetchPRBatchWith(fe, refs)
+	if !ghGate.shouldSkipOptional("graphql") {
+		t.Fatal("want gate to skip graphql after a chunk response reports zero remaining budget")
 	}
 }

--- a/internal/github/review_test.go
+++ b/internal/github/review_test.go
@@ -317,3 +317,100 @@ func TestHasPendingReview_error(t *testing.T) {
 		t.Fatal("expected error")
 	}
 }
+
+func TestFetchPRsForMonitorWith_batchesIntoOneCall(t *testing.T) {
+	t.Parallel()
+	fe := &fakeExecer{output: []byte(`{
+		"data": {
+			"viewer": {"login": "me"},
+			"repo0": {
+				"pullRequest": {
+					"number": 1,
+					"title": "one",
+					"url": "https://github.com/o/r/pull/1",
+					"state": "OPEN",
+					"author": {"login": "me", "type": "User"},
+					"repository": {"name": "r", "nameWithOwner": "o/r"},
+					"labels": {"nodes": []},
+					"commits": {"nodes": []},
+					"reviewThreads": {"nodes": []},
+					"latestReviews": {"nodes": []}
+				}
+			},
+			"repo1": {
+				"pullRequest": {
+					"number": 2,
+					"title": "two",
+					"url": "https://github.com/o/r/pull/2",
+					"state": "MERGED",
+					"author": {"login": "peer", "type": "User"},
+					"repository": {"name": "r", "nameWithOwner": "o/r"},
+					"labels": {"nodes": []},
+					"commits": {"nodes": []},
+					"reviewThreads": {"nodes": []},
+					"latestReviews": {"nodes": []}
+				}
+			}
+		}
+	}`)}
+
+	refs := []PRRef{{Repo: "o/r", Number: 1}, {Repo: "o/r", Number: 2}}
+	results := fetchPRsForMonitorWith(fe, refs)
+
+	if fe.calls != 1 {
+		t.Fatalf("calls = %d, want 1", fe.calls)
+	}
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if results[0].Err != nil || !results[0].Open || results[0].PR.Title != "one" {
+		t.Fatalf("results[0] = %+v", results[0])
+	}
+	if results[1].Err != nil || results[1].Open {
+		t.Fatalf("results[1] = %+v, want closed PR with no error", results[1])
+	}
+}
+
+func TestFetchPRsForMonitorWith_chunksOverLimit(t *testing.T) {
+	t.Parallel()
+	fe := &sequenceExecer{
+		outputs: [][]byte{
+			[]byte(`{"data": {"viewer": {"login": "me"}}}`),
+			[]byte(`{"data": {"viewer": {"login": "me"}}}`),
+		},
+	}
+
+	refs := make([]PRRef, maxBatchPRsPerQuery+3)
+	for i := range refs {
+		refs[i] = PRRef{Repo: "o/r", Number: i + 1}
+	}
+	results := fetchPRsForMonitorWith(fe, refs)
+
+	if fe.calls != 2 {
+		t.Fatalf("calls = %d, want 2", fe.calls)
+	}
+	if len(results) != len(refs) {
+		t.Fatalf("len(results) = %d, want %d", len(results), len(refs))
+	}
+}
+
+func TestFetchPRsForMonitorWith_graphqlError(t *testing.T) {
+	t.Parallel()
+	fe := &fakeExecer{output: []byte(`{"errors":[{"message":"rate limited"}]}`)}
+	results := fetchPRsForMonitorWith(fe, []PRRef{{Repo: "o/r", Number: 1}})
+	if len(results) != 1 || results[0].Err == nil {
+		t.Fatalf("results = %+v, want single error result", results)
+	}
+}
+
+func TestFetchPRsForMonitorWith_invalidRefSkipsQuery(t *testing.T) {
+	t.Parallel()
+	fe := &fakeExecer{}
+	results := fetchPRsForMonitorWith(fe, []PRRef{{Repo: "bad", Number: 1}})
+	if fe.calls != 0 {
+		t.Fatalf("calls = %d, want 0", fe.calls)
+	}
+	if len(results) != 1 || results[0].Err == nil {
+		t.Fatalf("results = %+v, want single error result", results)
+	}
+}

--- a/internal/github/review_test.go
+++ b/internal/github/review_test.go
@@ -475,6 +475,42 @@ func TestFetchPRBatchWith_globalErrorFailsWholeBatch(t *testing.T) {
 	}
 }
 
+// TestFetchPRBatchWith_viewerErrorFailsWholeBatch locks that a GraphQL error
+// scoped to the shared top-level "viewer" field (not a "repoN" ref alias) is
+// treated as global, not silently dropped or misfiled under a "viewer" key
+// that no ref ever looks up.
+func TestFetchPRBatchWith_viewerErrorFailsWholeBatch(t *testing.T) {
+	t.Parallel()
+	fe := &fakeExecer{output: []byte(`{
+		"data": {
+			"repo0": {
+				"pullRequest": {
+					"number": 1,
+					"title": "one",
+					"url": "https://github.com/o/r/pull/1",
+					"state": "OPEN",
+					"author": {"login": "me", "type": "User"},
+					"repository": {"name": "r", "nameWithOwner": "o/r"},
+					"labels": {"nodes": []},
+					"commits": {"nodes": []},
+					"reviewThreads": {"nodes": []},
+					"latestReviews": {"nodes": []}
+				}
+			}
+		},
+		"errors": [{"message": "viewer unavailable", "path": ["viewer"]}]
+	}`)}
+
+	refs := []PRRef{{Repo: "o/r", Number: 1}}
+	results := fetchPRsForMonitorWith(fe, refs)
+	if len(results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(results))
+	}
+	if results[0].Err == nil {
+		t.Fatalf("results[0] = %+v, want an error for the viewer-scoped failure, not a silently reported open PR", results[0])
+	}
+}
+
 // TestFetchPRBatchWith_updatesGateForNextChunk locks the mechanism
 // fetchPRsForMonitorWith's per-chunk gate recheck depends on: a chunk
 // response carrying low-budget rate-limit headers must update ghGate so that

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -65,9 +65,15 @@ type ReviewHandler struct {
 	// github.FetchPRState.
 	fetchPRStateFn func(repo string, number int) (github.PRState, error)
 	// fetchKnownPRFn fetches one linked PR without using a GitHub search leg.
-	// Secondary pollers use this to keep local task PRs moving while leaving
-	// global search polling to the primary instance.
+	// Used by the single-PR conflict-recovery path. Overridable in tests; nil
+	// falls back to github.FetchPRForMonitor.
 	fetchKnownPRFn func(repo string, number int) (github.PullRequest, bool, error)
+	// fetchKnownPRsFn batches the linked-PR fetch for every task monitored by
+	// fetchKnownTaskPRs into as few GraphQL requests as possible. Secondary
+	// pollers use this to keep local task PRs moving while leaving global
+	// search polling to the primary instance. Overridable in tests; nil falls
+	// back to github.FetchPRsForMonitor.
+	fetchKnownPRsFn func(refs []github.PRRef) []github.MonitorPRResult
 	// fetchReviewsFn fetches the PR review summary. Overridable in tests; nil
 	// falls back to github.FetchReviews.
 	fetchReviewsFn func() (github.ReviewSummary, error)
@@ -437,11 +443,11 @@ func (r *ReviewHandler) handleTaskPRIssues(taskID string, issues []github.PRIssu
 }
 
 func (r *ReviewHandler) fetchKnownTaskPRs(matchers []github.TaskMatcher) []github.PullRequest {
-	fetchFn := github.FetchPRForMonitor
-	if r.fetchKnownPRFn != nil {
-		fetchFn = r.fetchKnownPRFn
+	fetchFn := github.FetchPRsForMonitor
+	if r.fetchKnownPRsFn != nil {
+		fetchFn = r.fetchKnownPRsFn
 	}
-	prs := make([]github.PullRequest, 0, len(matchers))
+	refs := make([]github.PRRef, 0, len(matchers))
 	seen := make(map[string]struct{}, len(matchers))
 	for i := range matchers {
 		m := &matchers[i]
@@ -453,15 +459,24 @@ func (r *ReviewHandler) fetchKnownTaskPRs(matchers []github.TaskMatcher) []githu
 			continue
 		}
 		seen[key] = struct{}{}
-		pr, open, err := fetchFn(m.ProjectID, m.PRNumber)
-		if err != nil {
-			r.logger.Warn("pr-monitor.known-pr-fetch", "repo", m.ProjectID, "pr", m.PRNumber, "err", err)
+		refs = append(refs, github.PRRef{Repo: m.ProjectID, Number: m.PRNumber})
+	}
+	if len(refs) == 0 {
+		return nil
+	}
+
+	results := fetchFn(refs)
+	prs := make([]github.PullRequest, 0, len(results))
+	for i := range results {
+		res := &results[i]
+		if res.Err != nil {
+			r.logger.Warn("pr-monitor.known-pr-fetch", "repo", res.Repo, "pr", res.Number, "err", res.Err)
 			continue
 		}
-		if !open {
+		if !res.Open {
 			continue
 		}
-		prs = append(prs, pr)
+		prs = append(prs, res.PR)
 	}
 	return prs
 }

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -1743,19 +1743,25 @@ func TestPollSecondaryReconcilesKnownTaskPRsWithoutSearch(t *testing.T) {
 			fetchReviewsCalled = true
 			return github.ReviewSummary{}, nil
 		},
-		fetchKnownPRFn: func(repo string, number int) (github.PullRequest, bool, error) {
+		fetchKnownPRsFn: func(refs []github.PRRef) []github.MonitorPRResult {
 			knownFetches++
-			if number != 42 {
-				return github.PullRequest{}, false, nil
+			results := make([]github.MonitorPRResult, len(refs))
+			for i, ref := range refs {
+				results[i] = github.MonitorPRResult{Repo: ref.Repo, Number: ref.Number}
+				if ref.Number != 42 {
+					continue
+				}
+				results[i].Open = true
+				results[i].PR = github.PullRequest{
+					Number:          42,
+					Repository:      ref.Repo,
+					HeadSHA:         "abc123",
+					Mergeable:       "MERGEABLE",
+					CIStatus:        "SUCCESS",
+					CopilotReviewed: true,
+				}
 			}
-			return github.PullRequest{
-				Number:          42,
-				Repository:      repo,
-				HeadSHA:         "abc123",
-				Mergeable:       "MERGEABLE",
-				CIStatus:        "SUCCESS",
-				CopilotReviewed: true,
-			}, true, nil
+			return results
 		},
 		fetchPRStateFn: func(repo string, number int) (github.PRState, error) {
 			if repo != "o/r" {


### PR DESCRIPTION
## Motivation

The monitor loop fetches per-PR GitHub review signals one PR at a time via GraphQL, so a board with many in-flight PRs spends one round trip per PR. This burns GraphQL rate-limit budget and slows each monitor cycle proportional to PR count.

## Implementation information

- Add `FetchPRsForMonitor` (`internal/github/review.go`) which aliases multiple `repository(owner,name){ pullRequest(number) }` lookups into a single GraphQL query, chunked by `maxBatchPRsPerQuery` to stay under GitHub's node/complexity limits.
- Extract the shared field selection into `monitorPRFields` so the single-PR and batched queries can't drift apart.
- Decode batched responses via `gqlBatchPRResponse`, bucketing GraphQL errors by their per-alias path (`aliasErrors`) so one bad ref (deleted/inaccessible repo or PR) doesn't fail the whole batch — a query-level error with no path still fails everything, since there's no per-alias data to salvage.
- Preserve the existing REST fallback: when the GraphQL rate-limit gate trips (`ghGate.shouldSkipOptional`), fall back to the per-PR REST path for the remaining refs, rechecked before every chunk since an earlier chunk can trip the gate mid-loop.
- Wire `app_reviews.go` to call the batched fetch instead of looping per PR.
- A follow-up fix ensures viewer-scoped batch errors (errors on the shared `viewer` field) are treated as global rather than silently dropped.

Closes https://github.com/Automaat/sybra/issues/1338

_Generated by Sybra harness_