### PR TITLE
feat(github): add ghGate priority tiers

### DIFF
--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -196,6 +196,7 @@ func fetchAssignedIssuesWith(e execer) ([]Issue, error) {
 			if stale, ok := assignedIssuesCache.GetStale(query); ok {
 				return stale, nil
 			}
+			return nil, ErrBudgetExhausted
 		}
 	}
 
@@ -234,6 +235,7 @@ func fetchLabeledIssuesForReposWith(e execer, repos []string, label string) ([]I
 			if stale, ok := labeledIssuesCache.GetStale(cacheKey); ok {
 				return stale, nil
 			}
+			return nil, ErrBudgetExhausted
 		}
 	}
 
@@ -347,6 +349,7 @@ func fetchIssueSnapshotWith(e execer, repos []string, label string) (IssueSnapsh
 			if snapshot.Assigned != nil || snapshot.Labeled != nil {
 				return snapshot, nil
 			}
+			return snapshot, ErrBudgetExhausted
 		}
 	}
 

--- a/internal/github/issues.go
+++ b/internal/github/issues.go
@@ -192,7 +192,7 @@ func fetchAssignedIssuesWith(e execer) ([]Issue, error) {
 		if cached, ok := assignedIssuesCache.Get(query); ok {
 			return cached, nil
 		}
-		if ghGate.shouldSkipOptional("graphql") {
+		if ghGate.shouldSkipOptional("graphql", priorityDiscovery) {
 			if stale, ok := assignedIssuesCache.GetStale(query); ok {
 				return stale, nil
 			}
@@ -230,7 +230,7 @@ func fetchLabeledIssuesForReposWith(e execer, repos []string, label string) ([]I
 		if cached, ok := labeledIssuesCache.Get(cacheKey); ok {
 			return cached, nil
 		}
-		if ghGate.shouldSkipOptional("graphql") {
+		if ghGate.shouldSkipOptional("graphql", priorityDiscovery) {
 			if stale, ok := labeledIssuesCache.GetStale(cacheKey); ok {
 				return stale, nil
 			}
@@ -337,7 +337,7 @@ func fetchIssueSnapshotWith(e execer, repos []string, label string) (IssueSnapsh
 	labeledCacheKey := "label:" + label + "||" + strings.Join(repos, ",")
 
 	if runtimeCacheEnabled(e) {
-		if ghGate.shouldSkipOptional("graphql") {
+		if ghGate.shouldSkipOptional("graphql", priorityDiscovery) {
 			if assigned, ok := assignedIssuesCache.GetStale(assignedQuery); ok {
 				snapshot.Assigned = assigned
 			}

--- a/internal/github/renovate.go
+++ b/internal/github/renovate.go
@@ -89,6 +89,7 @@ func fetchRenovatePRsWith(e execer, author string, repos []string) ([]RenovatePR
 			if stale, ok := renovatePRsCache.GetStale(cacheKey); ok {
 				return stale, nil
 			}
+			return nil, ErrBudgetExhausted
 		}
 	}
 

--- a/internal/github/renovate.go
+++ b/internal/github/renovate.go
@@ -85,7 +85,7 @@ func fetchRenovatePRsWith(e execer, author string, repos []string) ([]RenovatePR
 		if cached, ok := renovatePRsCache.Get(cacheKey); ok {
 			return cached, nil
 		}
-		if ghGate.shouldSkipOptional("graphql") {
+		if ghGate.shouldSkipOptional("graphql", priorityDiscovery) {
 			if stale, ok := renovatePRsCache.GetStale(cacheKey); ok {
 				return stale, nil
 			}

--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -174,7 +174,7 @@ func fetchPRForMonitorWith(e execer, repo string, number int) (PullRequest, bool
 	// points or hard-failing. The REST result omits thread/review-decision data,
 	// so callers must only act on its conflict/ci_failure/closed signals. Gated
 	// on runtimeCacheEnabled so unit tests (fake execer) keep the GraphQL path.
-	if runtimeCacheEnabled(e) && ghGate.shouldSkipOptional("graphql") {
+	if runtimeCacheEnabled(e) && ghGate.shouldSkipOptional("graphql", priorityMergePath) {
 		return fetchPRForMonitorViaREST(e, repo, number)
 	}
 
@@ -219,7 +219,7 @@ func fetchReviewsWith(e execer) (ReviewSummary, error) {
 		// a stale summary if we have one, otherwise back off (ErrBudgetExhausted
 		// is transient) instead of firing three searches that would only be
 		// rejected and burn the last of the shared budget.
-		if ghGate.shouldSkipOptional("graphql") {
+		if ghGate.shouldSkipOptional("graphql", priorityDiscovery) {
 			if stale, ok := reviewSummaryCache.GetStale(cacheKey); ok {
 				return stale, nil
 			}

--- a/internal/github/runtime.go
+++ b/internal/github/runtime.go
@@ -15,6 +15,22 @@ const (
 	ghFallbackRateBackoff = 1 * time.Minute
 	ghMaxRetries          = 2
 	ghRetryBaseBackoff    = 500 * time.Millisecond
+
+	// ghDiscoveryReserveFraction is the fraction of a resource bucket's limit
+	// reserved for merge-path polls once budget runs low. Discovery polls
+	// (issue fetch, renovate, review-request search) skip once remaining
+	// budget falls to this fraction, keeping the band between it and
+	// ghLowBudgetThreshold exclusively for merge-path GraphQL.
+	ghDiscoveryReserveFraction = 0.2
+)
+
+// pollPriority distinguishes merge-path advancement (never skip until the
+// hard floor) from discovery polls (skip earlier to reserve budget).
+type pollPriority int
+
+const (
+	priorityMergePath pollPriority = iota
+	priorityDiscovery
 )
 
 // ghRetrySleep waits before a transient-error retry (backoff grows with the
@@ -258,10 +274,13 @@ func (g *ghRequestGate) observe(resp ghHTTPResponse, err error) {
 	}
 }
 
-func (g *ghRequestGate) shouldSkipOptional(resource string) bool {
+func (g *ghRequestGate) shouldSkipOptional(resource string, prio pollPriority) bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
+	// The notBefore hard wall (secondary rate limit / bumped backoff) skips
+	// every tier — there is no budget to reserve for merge-path when the API
+	// itself has told us to back off entirely.
 	if time.Until(g.notBefore) > 0 {
 		return true
 	}
@@ -270,7 +289,15 @@ func (g *ghRequestGate) shouldSkipOptional(resource string) bool {
 	if !ok || window.remaining < 0 || window.resetAt.IsZero() {
 		return false
 	}
-	if window.remaining > ghLowBudgetThreshold {
+
+	threshold := ghLowBudgetThreshold
+	if prio == priorityDiscovery && window.limit > 0 {
+		if reserved := int(ghDiscoveryReserveFraction * float64(window.limit)); reserved > threshold {
+			threshold = reserved
+		}
+	}
+
+	if window.remaining > threshold {
 		return false
 	}
 	return time.Until(window.resetAt) > ghOptionalCooldown

--- a/internal/github/runtime_retry_test.go
+++ b/internal/github/runtime_retry_test.go
@@ -89,7 +89,7 @@ func TestGHRequestGate_ObservesGraphQLRateLimitBody(t *testing.T) {
 		body: []byte(`{"errors":[{"type":"RATE_LIMITED","message":"quota exhausted"}]}`),
 	}, nil)
 
-	if !g.shouldSkipOptional("graphql") {
+	if !g.shouldSkipOptional("graphql", priorityDiscovery) {
 		t.Fatal("want optional GraphQL calls skipped after rate-limit body")
 	}
 }

--- a/internal/github/runtime_test.go
+++ b/internal/github/runtime_test.go
@@ -1,0 +1,152 @@
+package github
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestShouldSkipOptional_PriorityTiers(t *testing.T) {
+	far := time.Now().Add(time.Hour)
+
+	tests := []struct {
+		name          string
+		remaining     int
+		limit         int
+		notBefore     bool
+		wantMerge     bool
+		wantDiscovery bool
+	}{
+		{name: "well above reserve", remaining: 1001, limit: 5000, wantMerge: false, wantDiscovery: false},
+		{name: "at reserve boundary", remaining: 1000, limit: 5000, wantMerge: false, wantDiscovery: true},
+		{name: "mid reserved band", remaining: 800, limit: 5000, wantMerge: false, wantDiscovery: true},
+		{name: "just above floor", remaining: 151, limit: 5000, wantMerge: false, wantDiscovery: true},
+		{name: "at floor boundary", remaining: 150, limit: 5000, wantMerge: true, wantDiscovery: true},
+		{name: "unknown limit at floor", remaining: 140, limit: 0, wantMerge: true, wantDiscovery: true},
+		{name: "unknown limit above floor", remaining: 200, limit: 0, wantMerge: false, wantDiscovery: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := newGHRequestGate()
+			g.resources["graphql"] = ghRateWindow{
+				remaining: tt.remaining,
+				limit:     tt.limit,
+				resetAt:   far,
+			}
+			if got := g.shouldSkipOptional("graphql", priorityMergePath); got != tt.wantMerge {
+				t.Errorf("merge-path shouldSkipOptional = %v, want %v", got, tt.wantMerge)
+			}
+			if got := g.shouldSkipOptional("graphql", priorityDiscovery); got != tt.wantDiscovery {
+				t.Errorf("discovery shouldSkipOptional = %v, want %v", got, tt.wantDiscovery)
+			}
+		})
+	}
+
+	t.Run("notBefore hard wall skips every tier", func(t *testing.T) {
+		g := newGHRequestGate()
+		g.resources["graphql"] = ghRateWindow{remaining: 4000, limit: 5000, resetAt: far}
+		g.notBefore = time.Now().Add(time.Hour)
+		if !g.shouldSkipOptional("graphql", priorityMergePath) {
+			t.Error("want merge-path skipped under notBefore wall")
+		}
+		if !g.shouldSkipOptional("graphql", priorityDiscovery) {
+			t.Error("want discovery skipped under notBefore wall")
+		}
+	})
+}
+
+// TestFetchReviews_DiscoverySkipsInReservedBand asserts that a discovery poll
+// sheds its GraphQL request (rather than degrading to REST, which the review
+// summary has no equivalent for) once the budget is inside the reserved band
+// that merge-path polls still get to spend.
+func TestFetchReviews_DiscoverySkipsInReservedBand(t *testing.T) {
+	origGate := ghGate
+	origExecer := defaultExecer
+	origCache := reviewSummaryCache
+	t.Cleanup(func() {
+		ghGate = origGate
+		defaultExecer = origExecer
+		reviewSummaryCache = origCache
+	})
+
+	ghGate = newGHRequestGate()
+	ghGate.resources["graphql"] = ghRateWindow{remaining: 800, limit: 5000, resetAt: time.Now().Add(time.Hour)}
+	reviewSummaryCache = newTTLCache[ReviewSummary]()
+
+	e := &fakeExecer{output: []byte(`{"errors":[{"message":"should not be called"}]}`)}
+	defaultExecer = e
+
+	_, err := fetchReviewsWith(defaultExecer)
+	if !errors.Is(err, ErrBudgetExhausted) {
+		t.Fatalf("err = %v, want ErrBudgetExhausted", err)
+	}
+	if e.calls != 0 {
+		t.Errorf("calls = %d, want 0 (no GraphQL search should fire in the reserved band)", e.calls)
+	}
+}
+
+// TestFetchPRForMonitor_MergePathContinuesInReservedBand asserts that a
+// merge-path poll keeps using GraphQL (not the REST fallback) throughout the
+// reserved band, since merge-path only degrades at the ghLowBudgetThreshold
+// floor.
+func TestFetchPRForMonitor_MergePathContinuesInReservedBand(t *testing.T) {
+	origGate := ghGate
+	origExecer := defaultExecer
+	t.Cleanup(func() {
+		ghGate = origGate
+		defaultExecer = origExecer
+	})
+
+	ghGate = newGHRequestGate()
+	ghGate.resources["graphql"] = ghRateWindow{remaining: 800, limit: 5000, resetAt: time.Now().Add(time.Hour)}
+
+	body := `{
+		"data": {
+			"viewer": {"login": "me"},
+			"repository": {
+				"pullRequest": {
+					"number": 7,
+					"title": "in review",
+					"url": "https://github.com/o/r/pull/7",
+					"state": "OPEN",
+					"author": {"login": "peer", "type": "User"},
+					"repository": {"name": "r", "nameWithOwner": "o/r"},
+					"labels": {"nodes": []},
+					"commits": {"nodes": []},
+					"reviewThreads": {"nodes": []},
+					"latestReviews": {"nodes": []}
+				}
+			}
+		}
+	}`
+	rec := &recordingExecer{output: []byte(body)}
+	defaultExecer = rec
+
+	pr, open, err := fetchPRForMonitorWith(defaultExecer, "o/r", 7)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !open {
+		t.Error("open = false, want true")
+	}
+	if pr.Number != 7 {
+		t.Errorf("Number = %d, want 7", pr.Number)
+	}
+	if rec.calls != 1 {
+		t.Fatalf("calls = %d, want 1", rec.calls)
+	}
+	if !containsArg(rec.lastArgs, "graphql") {
+		t.Errorf("lastArgs = %v, want a graphql call (merge-path must not fall back to REST in the reserved band)", rec.lastArgs)
+	}
+}
+
+func containsArg(args []string, want string) bool {
+	for _, a := range args {
+		if strings.EqualFold(a, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/github/runtime_test.go
+++ b/internal/github/runtime_test.go
@@ -14,7 +14,6 @@ func TestShouldSkipOptional_PriorityTiers(t *testing.T) {
 		name          string
 		remaining     int
 		limit         int
-		notBefore     bool
 		wantMerge     bool
 		wantDiscovery bool
 	}{


### PR DESCRIPTION
## Motivation

Discovery polls (issue fetch, renovate, review search) previously competed with merge-path advancement for the same low-budget threshold, so ready PRs could stall behind lower-value discovery work when the GitHub rate-limit budget ran low.

## Implementation information

`shouldSkipOptional` now takes a `pollPriority`: merge-path polling keeps today's floor-only skip behavior, while discovery polling (issues, renovate, review search) sheds earlier once budget falls to a reserved fraction of the bucket limit. This keeps ready PRs advancing even when the shared rate-limit budget is tight.

Closes https://github.com/Automaat/sybra/issues/1339

_Generated by Sybra harness_