### PR TITLE
fix(umbrella): stop triage dropping gate tag

### DIFF
--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -316,7 +316,7 @@ func fetchPRsForMonitorWith(e execer, refs []PRRef) []MonitorPRResult {
 	// fallback per ref instead of batching — same behavior/data tradeoffs as
 	// fetchPRForMonitorWith. Gated on runtimeCacheEnabled so unit tests (fake
 	// execer) keep the GraphQL path.
-	if runtimeCacheEnabled(e) && ghGate.shouldSkipOptional("graphql") {
+	if runtimeCacheEnabled(e) && ghGate.shouldSkipOptional("graphql", priorityMergePath) {
 		results := make([]MonitorPRResult, len(refs))
 		for i, ref := range refs {
 			pr, open, err := fetchPRForMonitorViaREST(e, ref.Repo, ref.Number)
@@ -334,7 +334,7 @@ func fetchPRsForMonitorWith(e execer, refs []PRRef) []MonitorPRResult {
 		// gate into a low-budget state, in which case the remaining refs
 		// should fall back to REST instead of continuing to spend GraphQL
 		// budget or hitting rate-limit errors.
-		if cacheEnabled && ghGate.shouldSkipOptional("graphql") {
+		if cacheEnabled && ghGate.shouldSkipOptional("graphql", priorityMergePath) {
 			for _, ref := range refs[start:] {
 				pr, open, err := fetchPRForMonitorViaREST(e, ref.Repo, ref.Number)
 				results = append(results, MonitorPRResult{Repo: ref.Repo, Number: ref.Number, PR: pr, Open: open, Err: err})

--- a/internal/github/review_test.go
+++ b/internal/github/review_test.go
@@ -514,7 +514,7 @@ func TestFetchPRBatchWith_viewerErrorFailsWholeBatch(t *testing.T) {
 // TestFetchPRBatchWith_updatesGateForNextChunk locks the mechanism
 // fetchPRsForMonitorWith's per-chunk gate recheck depends on: a chunk
 // response carrying low-budget rate-limit headers must update ghGate so that
-// shouldSkipOptional("graphql") reports true immediately after, without
+// shouldSkipOptional("graphql", priorityMergePath) reports true immediately after, without
 // waiting for a separate /rate_limit refresh. (The recheck itself is gated on
 // runtimeCacheEnabled(e), i.e. the real defaultExecer, so it cannot be driven
 // end-to-end through a fake execer — see the identical constraint on the
@@ -535,11 +535,11 @@ func TestFetchPRBatchWith_updatesGateForNextChunk(t *testing.T) {
 	fe := &fakeExecer{output: []byte(chunk1)}
 	refs := []PRRef{{Repo: "o/r", Number: 1}}
 
-	if ghGate.shouldSkipOptional("graphql") {
+	if ghGate.shouldSkipOptional("graphql", priorityMergePath) {
 		t.Fatal("gate should not skip graphql before any call")
 	}
 	fetchPRBatchWith(fe, refs)
-	if !ghGate.shouldSkipOptional("graphql") {
+	if !ghGate.shouldSkipOptional("graphql", priorityMergePath) {
 		t.Fatal("want gate to skip graphql after a chunk response reports zero remaining budget")
 	}
 }

--- a/internal/sybra/workflow_dispatch.go
+++ b/internal/sybra/workflow_dispatch.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/umbrella"
 )
 
 const (
@@ -29,6 +30,11 @@ func skipTaskCreatedWorkflow(t task.Task) bool {
 	// A stub awaiting async enrichment is dispatched by the enrich step, not
 	// the emit path — skip until the real title/labels land.
 	if slices.Contains(t.Tags, enrichPendingTag) {
+		return true
+	}
+	// An umbrella-gated child must be held for releaseUnblockedChildren, not
+	// dispatched straight into triage/plan/implement.
+	if slices.Contains(t.Tags, umbrella.GatedTag) {
 		return true
 	}
 	if slices.Contains(t.Tags, handoffManualTag) {

--- a/internal/sybra/workflow_dispatch_test.go
+++ b/internal/sybra/workflow_dispatch_test.go
@@ -1,0 +1,22 @@
+package sybra
+
+import (
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/umbrella"
+)
+
+func TestSkipTaskCreatedWorkflowUmbrellaGated(t *testing.T) {
+	tsk := task.Task{Tags: []string{umbrella.GatedTag}}
+	if !skipTaskCreatedWorkflow(tsk) {
+		t.Errorf("expected umbrella-gated task to skip task:created dispatch")
+	}
+}
+
+func TestSkipTaskCreatedWorkflowUngated(t *testing.T) {
+	tsk := task.Task{Tags: []string{"backend", "medium"}}
+	if skipTaskCreatedWorkflow(tsk) {
+		t.Errorf("expected ungated task not to skip task:created dispatch")
+	}
+}

--- a/internal/triage/apply.go
+++ b/internal/triage/apply.go
@@ -64,7 +64,7 @@ func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project
 		// Preserve routing tags the classifier vocabulary excludes
 		// (escape-hatch opt-outs, umbrella gate marker) — replacing tags
 		// wholesale would otherwise silently drop them.
-		tags := v.Tags
+		tags := slices.Clone(v.Tags)
 		for _, keep := range preservedTags {
 			if slices.Contains(t.Tags, keep) && !slices.Contains(tags, keep) {
 				tags = append(tags, keep)

--- a/internal/triage/apply.go
+++ b/internal/triage/apply.go
@@ -7,7 +7,14 @@ import (
 
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/umbrella"
 )
+
+// preservedTags are tags never emitted by the classifier vocabulary but that
+// must survive a wholesale tag-replacement in Apply because dropping them
+// would silently break routing the task depends on: escape-hatch opt-outs
+// (see escapeHatchTags) and the umbrella dependency gate marker.
+var preservedTags = append(append([]string{}, escapeHatchTags...), umbrella.GatedTag)
 
 // Apply writes the classifier verdict to the task via Manager.UpdateMap.
 // All field changes happen in a single UpdateMap call so the write is
@@ -54,13 +61,13 @@ func Apply(mgr *task.Manager, t task.Task, v Verdict, projects []project.Project
 	}
 
 	if len(v.Tags) > 0 {
-		// Preserve escape-hatch routing tags (noplan/nocritic) already on the
-		// task — the classifier vocabulary excludes them, so replacing tags
-		// wholesale would silently drop a manually-set opt-out.
+		// Preserve routing tags the classifier vocabulary excludes
+		// (escape-hatch opt-outs, umbrella gate marker) — replacing tags
+		// wholesale would otherwise silently drop them.
 		tags := v.Tags
-		for _, hatch := range escapeHatchTags {
-			if slices.Contains(t.Tags, hatch) && !slices.Contains(tags, hatch) {
-				tags = append(tags, hatch)
+		for _, keep := range preservedTags {
+			if slices.Contains(t.Tags, keep) && !slices.Contains(tags, keep) {
+				tags = append(tags, keep)
 			}
 		}
 		updates["tags"] = tags

--- a/internal/triage/apply_test.go
+++ b/internal/triage/apply_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/umbrella"
 )
 
 func newTestManager(t *testing.T) *task.Manager {
@@ -80,6 +81,32 @@ func TestApplyPreservesEscapeHatchTags(t *testing.T) {
 	}
 	if !slices.Contains(updated.Tags, "noplan") {
 		t.Errorf("noplan escape-hatch tag dropped by triage; got %v", updated.Tags)
+	}
+}
+
+func TestApplyPreservesUmbrellaGatedTag(t *testing.T) {
+	mgr := newTestManager(t)
+	created, err := mgr.Create("gated child task", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// The umbrella expander sets the gate marker before triage runs.
+	created.Tags = []string{umbrella.GatedTag}
+
+	// Classifier verdict does not include umbrella-gated (it's outside the vocabulary).
+	v := Verdict{
+		Title: "feat(github): skip re-polling known-green PRs before merge",
+		Tags:  []string{"backend", "medium"},
+		Size:  "medium",
+		Type:  "feature",
+		Mode:  "headless",
+	}
+	updated, err := Apply(mgr, created, v, nil)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !slices.Contains(updated.Tags, umbrella.GatedTag) {
+		t.Errorf("umbrella-gated tag dropped by triage; got %v", updated.Tags)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Gated umbrella children could slip the dependency gate via two independent
defects: `task:created` dispatch didn't recognize `umbrella-gated` and sent
the child straight into triage, and `triage.Apply` then replaced the tag set
wholesale, dropping the gate marker so `releaseUnblockedChildren` could
never treat the task as gated again.

Closes https://github.com/Automaat/sybra/issues/1365

## Implementation information

- `internal/sybra/workflow_dispatch.go`: `skipTaskCreatedWorkflow` now skips
  dispatch for tasks carrying `umbrella.GatedTag`.
- `internal/triage/apply.go`: generalized the escape-hatch tag preservation
  into a `preservedTags` list that also includes `umbrella.GatedTag`, so a
  classifier verdict's wholesale tag replacement no longer drops it.
- Added unit tests covering both defects.

_Generated by Sybra harness_