### PR TITLE
fix(github): pass merge-path priority to monitor poll gate

### DIFF
--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -316,7 +316,7 @@ func fetchPRsForMonitorWith(e execer, refs []PRRef) []MonitorPRResult {
 	// fallback per ref instead of batching — same behavior/data tradeoffs as
 	// fetchPRForMonitorWith. Gated on runtimeCacheEnabled so unit tests (fake
 	// execer) keep the GraphQL path.
-	if runtimeCacheEnabled(e) && ghGate.shouldSkipOptional("graphql") {
+	if runtimeCacheEnabled(e) && ghGate.shouldSkipOptional("graphql", priorityMergePath) {
 		results := make([]MonitorPRResult, len(refs))
 		for i, ref := range refs {
 			pr, open, err := fetchPRForMonitorViaREST(e, ref.Repo, ref.Number)
@@ -334,7 +334,7 @@ func fetchPRsForMonitorWith(e execer, refs []PRRef) []MonitorPRResult {
 		// gate into a low-budget state, in which case the remaining refs
 		// should fall back to REST instead of continuing to spend GraphQL
 		// budget or hitting rate-limit errors.
-		if cacheEnabled && ghGate.shouldSkipOptional("graphql") {
+		if cacheEnabled && ghGate.shouldSkipOptional("graphql", priorityMergePath) {
 			for _, ref := range refs[start:] {
 				pr, open, err := fetchPRForMonitorViaREST(e, ref.Repo, ref.Number)
 				results = append(results, MonitorPRResult{Repo: ref.Repo, Number: ref.Number, PR: pr, Open: open, Err: err})

--- a/internal/github/review_test.go
+++ b/internal/github/review_test.go
@@ -535,11 +535,11 @@ func TestFetchPRBatchWith_updatesGateForNextChunk(t *testing.T) {
 	fe := &fakeExecer{output: []byte(chunk1)}
 	refs := []PRRef{{Repo: "o/r", Number: 1}}
 
-	if ghGate.shouldSkipOptional("graphql") {
+	if ghGate.shouldSkipOptional("graphql", priorityMergePath) {
 		t.Fatal("gate should not skip graphql before any call")
 	}
 	fetchPRBatchWith(fe, refs)
-	if !ghGate.shouldSkipOptional("graphql") {
+	if !ghGate.shouldSkipOptional("graphql", priorityMergePath) {
 		t.Fatal("want gate to skip graphql after a chunk response reports zero remaining budget")
 	}
 }


### PR DESCRIPTION
## Motivation

`mise run dev` failed to compile: the two monitor-fetch fallbacks in `internal/github/review.go` called `ghGate.shouldSkipOptional("graphql")` without the `pollPriority` argument added in the ghGate priority-tier change.

> Changelog: fix(github): pass merge-path priority to monitor poll gate

## Implementation information

- `fetchPRsForMonitorWith` low-budget fallback and the per-chunk recheck now pass `priorityMergePath`, matching the sibling single-PR `fetchPRForMonitorWith` path — monitor fetches advance PRs toward merge, so they belong in the never-skip-until-hard-floor tier.
- Updated the two matching assertions in `review_test.go`.
- `go build ./...`, `go test ./internal/github/`, and `mise run dev` all pass.

## Supporting documentation

N/A