### PR TITLE
feat(github): auto-merge over REST on low budget

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/github/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/github/models.ts
@@ -176,18 +176,41 @@ export class PullRequest {
     "updatedAt": string;
 
     /**
-     * BaseRefName is the PR's target branch (e.g. "main"). Used to pre-flight
-     * native auto-merge eligibility against the base branch's protection —
-     * never the head branch.
+     * SourcedViaREST marks a PullRequest fetched over GitHub's REST API
+     * (fetchPRForMonitorViaREST) instead of GraphQL, used when the GraphQL
+     * budget is low. REST exposes no thread-resolution or Copilot-review data,
+     * so UnresolvedCount, ActionableCount, CopilotReviewed, and ReviewDecision
+     * are unset/zero on a REST-sourced PR — callers must not trust those fields
+     * and must gate any REST-sourced action on RESTApproved/RESTMergeableState/
+     * RESTCIFetched instead.
      */
-    "baseRefName": string;
+    "sourcedViaRest": boolean;
 
     /**
-     * AutoMergeEnabled reports whether GitHub's native auto-merge is currently
-     * armed on this PR (derived live from `autoMergeRequest` being non-null —
-     * never persisted on the task model).
+     * RESTMergeableState is the raw GitHub mergeable_state (clean|blocked|
+     * behind|unstable|dirty|unknown) as reported over REST. Only "clean"
+     * authorizes REST-sourced auto-merge — the coarser Mergeable enum also
+     * buckets blocked/behind/unstable under MERGEABLE, which must NOT
+     * authorize a REST-sourced merge.
      */
-    "autoMergeEnabled": boolean;
+    "restMergeableState": string;
+
+    /**
+     * RESTApproved reports an explicit, current-head approval computed over
+     * REST review data (fetchRESTReviews + restApproval): at least one
+     * non-dismissed APPROVED review whose commit_id matches HeadSHA, and no
+     * non-dismissed CHANGES_REQUESTED review. It is the only review signal the
+     * REST auto-merge gate trusts.
+     */
+    "restApproved": boolean;
+
+    /**
+     * RESTCIFetched reports whether both REST CI legs (check-runs and legacy
+     * commit status) were fetched successfully, distinguishing "fetched,
+     * genuinely no checks" (CIStatus=="") from "fetch failed" — an empty
+     * CIStatus must never read as green when this is false.
+     */
+    "restCiFetched": boolean;
 
     /** Creates a new PullRequest instance. */
     constructor($$source: Partial<PullRequest> = {}) {
@@ -254,11 +277,17 @@ export class PullRequest {
         if (!("updatedAt" in $$source)) {
             this["updatedAt"] = "";
         }
-        if (!("baseRefName" in $$source)) {
-            this["baseRefName"] = "";
+        if (!("sourcedViaRest" in $$source)) {
+            this["sourcedViaRest"] = false;
         }
-        if (!("autoMergeEnabled" in $$source)) {
-            this["autoMergeEnabled"] = false;
+        if (!("restMergeableState" in $$source)) {
+            this["restMergeableState"] = "";
+        }
+        if (!("restApproved" in $$source)) {
+            this["restApproved"] = false;
+        }
+        if (!("restCiFetched" in $$source)) {
+            this["restCiFetched"] = false;
         }
 
         Object.assign(this, $$source);
@@ -340,18 +369,41 @@ export class RenovatePR {
     "updatedAt": string;
 
     /**
-     * BaseRefName is the PR's target branch (e.g. "main"). Used to pre-flight
-     * native auto-merge eligibility against the base branch's protection —
-     * never the head branch.
+     * SourcedViaREST marks a PullRequest fetched over GitHub's REST API
+     * (fetchPRForMonitorViaREST) instead of GraphQL, used when the GraphQL
+     * budget is low. REST exposes no thread-resolution or Copilot-review data,
+     * so UnresolvedCount, ActionableCount, CopilotReviewed, and ReviewDecision
+     * are unset/zero on a REST-sourced PR — callers must not trust those fields
+     * and must gate any REST-sourced action on RESTApproved/RESTMergeableState/
+     * RESTCIFetched instead.
      */
-    "baseRefName": string;
+    "sourcedViaRest": boolean;
 
     /**
-     * AutoMergeEnabled reports whether GitHub's native auto-merge is currently
-     * armed on this PR (derived live from `autoMergeRequest` being non-null —
-     * never persisted on the task model).
+     * RESTMergeableState is the raw GitHub mergeable_state (clean|blocked|
+     * behind|unstable|dirty|unknown) as reported over REST. Only "clean"
+     * authorizes REST-sourced auto-merge — the coarser Mergeable enum also
+     * buckets blocked/behind/unstable under MERGEABLE, which must NOT
+     * authorize a REST-sourced merge.
      */
-    "autoMergeEnabled": boolean;
+    "restMergeableState": string;
+
+    /**
+     * RESTApproved reports an explicit, current-head approval computed over
+     * REST review data (fetchRESTReviews + restApproval): at least one
+     * non-dismissed APPROVED review whose commit_id matches HeadSHA, and no
+     * non-dismissed CHANGES_REQUESTED review. It is the only review signal the
+     * REST auto-merge gate trusts.
+     */
+    "restApproved": boolean;
+
+    /**
+     * RESTCIFetched reports whether both REST CI legs (check-runs and legacy
+     * commit status) were fetched successfully, distinguishing "fetched,
+     * genuinely no checks" (CIStatus=="") from "fetch failed" — an empty
+     * CIStatus must never read as green when this is false.
+     */
+    "restCiFetched": boolean;
     "checkRuns": CheckRunInfo[];
 
     /** Creates a new RenovatePR instance. */
@@ -419,11 +471,17 @@ export class RenovatePR {
         if (!("updatedAt" in $$source)) {
             this["updatedAt"] = "";
         }
-        if (!("baseRefName" in $$source)) {
-            this["baseRefName"] = "";
+        if (!("sourcedViaRest" in $$source)) {
+            this["sourcedViaRest"] = false;
         }
-        if (!("autoMergeEnabled" in $$source)) {
-            this["autoMergeEnabled"] = false;
+        if (!("restMergeableState" in $$source)) {
+            this["restMergeableState"] = "";
+        }
+        if (!("restApproved" in $$source)) {
+            this["restApproved"] = false;
+        }
+        if (!("restCiFetched" in $$source)) {
+            this["restCiFetched"] = false;
         }
         if (!("checkRuns" in $$source)) {
             this["checkRuns"] = [];
@@ -437,13 +495,13 @@ export class RenovatePR {
      */
     static createFrom($$source: any = {}): RenovatePR {
         const $$createField7_0 = $$createType0;
-        const $$createField23_0 = $$createType2;
+        const $$createField25_0 = $$createType2;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("labels" in $$parsedSource) {
             $$parsedSource["labels"] = $$createField7_0($$parsedSource["labels"]);
         }
         if ("checkRuns" in $$parsedSource) {
-            $$parsedSource["checkRuns"] = $$createField23_0($$parsedSource["checkRuns"]);
+            $$parsedSource["checkRuns"] = $$createField25_0($$parsedSource["checkRuns"]);
         }
         return new RenovatePR($$parsedSource as Partial<RenovatePR>);
     }

--- a/frontend/bindings/github.com/Automaat/sybra/internal/github/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/github/models.ts
@@ -176,6 +176,20 @@ export class PullRequest {
     "updatedAt": string;
 
     /**
+     * BaseRefName is the PR's target branch (e.g. "main"). Used to pre-flight
+     * native auto-merge eligibility against the base branch's protection —
+     * never the head branch.
+     */
+    "baseRefName": string;
+
+    /**
+     * AutoMergeEnabled reports whether GitHub's native auto-merge is currently
+     * armed on this PR (derived live from `autoMergeRequest` being non-null —
+     * never persisted on the task model).
+     */
+    "autoMergeEnabled": boolean;
+
+    /**
      * SourcedViaREST marks a PullRequest fetched over GitHub's REST API
      * (fetchPRForMonitorViaREST) instead of GraphQL, used when the GraphQL
      * budget is low. REST exposes no thread-resolution or Copilot-review data,
@@ -277,6 +291,12 @@ export class PullRequest {
         if (!("updatedAt" in $$source)) {
             this["updatedAt"] = "";
         }
+        if (!("baseRefName" in $$source)) {
+            this["baseRefName"] = "";
+        }
+        if (!("autoMergeEnabled" in $$source)) {
+            this["autoMergeEnabled"] = false;
+        }
         if (!("sourcedViaRest" in $$source)) {
             this["sourcedViaRest"] = false;
         }
@@ -367,6 +387,20 @@ export class RenovatePR {
     "copilotReviewed": boolean;
     "createdAt": string;
     "updatedAt": string;
+
+    /**
+     * BaseRefName is the PR's target branch (e.g. "main"). Used to pre-flight
+     * native auto-merge eligibility against the base branch's protection —
+     * never the head branch.
+     */
+    "baseRefName": string;
+
+    /**
+     * AutoMergeEnabled reports whether GitHub's native auto-merge is currently
+     * armed on this PR (derived live from `autoMergeRequest` being non-null —
+     * never persisted on the task model).
+     */
+    "autoMergeEnabled": boolean;
 
     /**
      * SourcedViaREST marks a PullRequest fetched over GitHub's REST API
@@ -471,6 +505,12 @@ export class RenovatePR {
         if (!("updatedAt" in $$source)) {
             this["updatedAt"] = "";
         }
+        if (!("baseRefName" in $$source)) {
+            this["baseRefName"] = "";
+        }
+        if (!("autoMergeEnabled" in $$source)) {
+            this["autoMergeEnabled"] = false;
+        }
         if (!("sourcedViaRest" in $$source)) {
             this["sourcedViaRest"] = false;
         }
@@ -495,13 +535,13 @@ export class RenovatePR {
      */
     static createFrom($$source: any = {}): RenovatePR {
         const $$createField7_0 = $$createType0;
-        const $$createField25_0 = $$createType2;
+        const $$createField27_0 = $$createType2;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("labels" in $$parsedSource) {
             $$parsedSource["labels"] = $$createField7_0($$parsedSource["labels"]);
         }
         if ("checkRuns" in $$parsedSource) {
-            $$parsedSource["checkRuns"] = $$createField25_0($$parsedSource["checkRuns"]);
+            $$parsedSource["checkRuns"] = $$createField27_0($$parsedSource["checkRuns"]);
         }
         return new RenovatePR($$parsedSource as Partial<RenovatePR>);
     }

--- a/frontend/src/components/PRCard.svelte.test.ts
+++ b/frontend/src/components/PRCard.svelte.test.ts
@@ -27,6 +27,10 @@ function makePR(overrides: Record<string, unknown> = {}) {
     copilotReviewed: false,
     createdAt: '2026-04-01T00:00:00Z',
     updatedAt: '2026-04-01T00:00:00Z',
+    sourcedViaRest: false,
+    restMergeableState: '',
+    restApproved: false,
+    restCiFetched: false,
     ...overrides,
   }
 }

--- a/internal/github/model.go
+++ b/internal/github/model.go
@@ -41,6 +41,31 @@ type PullRequest struct {
 	// armed on this PR (derived live from `autoMergeRequest` being non-null —
 	// never persisted on the task model).
 	AutoMergeEnabled bool `json:"autoMergeEnabled"`
+	// SourcedViaREST marks a PullRequest fetched over GitHub's REST API
+	// (fetchPRForMonitorViaREST) instead of GraphQL, used when the GraphQL
+	// budget is low. REST exposes no thread-resolution or Copilot-review data,
+	// so UnresolvedCount, ActionableCount, CopilotReviewed, and ReviewDecision
+	// are unset/zero on a REST-sourced PR — callers must not trust those fields
+	// and must gate any REST-sourced action on RESTApproved/RESTMergeableState/
+	// RESTCIFetched instead.
+	SourcedViaREST bool `json:"sourcedViaRest"`
+	// RESTMergeableState is the raw GitHub mergeable_state (clean|blocked|
+	// behind|unstable|dirty|unknown) as reported over REST. Only "clean"
+	// authorizes REST-sourced auto-merge — the coarser Mergeable enum also
+	// buckets blocked/behind/unstable under MERGEABLE, which must NOT
+	// authorize a REST-sourced merge.
+	RESTMergeableState string `json:"restMergeableState"`
+	// RESTApproved reports an explicit, current-head approval computed over
+	// REST review data (fetchRESTReviews + restApproval): at least one
+	// non-dismissed APPROVED review whose commit_id matches HeadSHA, and no
+	// non-dismissed CHANGES_REQUESTED review. It is the only review signal the
+	// REST auto-merge gate trusts.
+	RESTApproved bool `json:"restApproved"`
+	// RESTCIFetched reports whether both REST CI legs (check-runs and legacy
+	// commit status) were fetched successfully, distinguishing "fetched,
+	// genuinely no checks" (CIStatus=="") from "fetch failed" — an empty
+	// CIStatus must never read as green when this is false.
+	RESTCIFetched bool `json:"restCiFetched"`
 }
 
 // ReviewSummary contains PRs grouped by relationship to the user.

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -841,6 +841,54 @@ func setNativeAutoMergeCache(e execer, key string, val bool) bool {
 	return val
 }
 
+// MergePRViaREST merges a pull request over GitHub's REST API (PUT
+// .../merge), passing the observed head SHA as the sha parameter so GitHub
+// aborts the merge (409) instead of squashing on stale evidence if the head
+// moved since it was fetched. Used by the REST-sourced auto-merge path so the
+// whole merge stays on the idle REST bucket instead of GraphQL's `gh pr
+// merge`. A head-SHA mismatch is terminal — never retried; only the transient
+// base-branch race is retried, mirroring mergePRWith.
+func MergePRViaREST(repo string, number int, headSHA string) error {
+	return mergePRViaRESTWith(defaultExecer, repo, number, headSHA)
+}
+
+func mergePRViaRESTWith(e execer, repo string, number int, headSHA string) error {
+	owner, name, ok := strings.Cut(repo, "/")
+	if !ok || owner == "" || name == "" || number <= 0 {
+		return fmt.Errorf("invalid repo or PR: %s#%d", repo, number)
+	}
+	var lastResp ghHTTPResponse
+	var lastErr error
+	for attempt := 0; attempt <= len(mergeRetryDelays); attempt++ {
+		resp, err := runGHAPIWith(e, "",
+			fmt.Sprintf("repos/%s/%s/pulls/%d/merge", owner, name, number),
+			"--method", "PUT",
+			"-f", "merge_method=squash",
+			"-f", "sha="+headSHA,
+		)
+		if err == nil {
+			if runtimeCacheEnabled(e) {
+				invalidatePRCaches(repo, number)
+			}
+			return nil
+		}
+		lastResp, lastErr = resp, err
+		if isHeadSHAMismatchErr(resp) || !isBaseBranchModifiedErr(resp.body) || attempt == len(mergeRetryDelays) {
+			break
+		}
+		time.Sleep(mergeRetryDelays[attempt])
+	}
+	return fmt.Errorf("gh api merge %d: %s: %w", number, sanitizeGHOutput(lastResp.body), lastErr)
+}
+
+// isHeadSHAMismatchErr reports whether the REST merge response indicates the
+// supplied sha no longer matches the PR's current head — GitHub returns 409
+// with this message. Terminal: retrying would only re-merge on stale evidence
+// once the head advances further, so the caller must not retry it.
+func isHeadSHAMismatchErr(resp ghHTTPResponse) bool {
+	return resp.statusCode == 409 || strings.Contains(string(resp.body), "Head branch was modified")
+}
+
 // MarkReady marks a draft pull request as ready for review.
 func MarkReady(repo string, number int) error {
 	return markReadyWith(defaultExecer, repo, number)

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -857,6 +857,9 @@ func mergePRViaRESTWith(e execer, repo string, number int, headSHA string) error
 	if !ok || owner == "" || name == "" || number <= 0 {
 		return fmt.Errorf("invalid repo or PR: %s#%d", repo, number)
 	}
+	if headSHA == "" {
+		return fmt.Errorf("missing head SHA for %s#%d: refusing unprotected merge", repo, number)
+	}
 	var lastResp ghHTTPResponse
 	var lastErr error
 	for attempt := 0; attempt <= len(mergeRetryDelays); attempt++ {
@@ -883,10 +886,14 @@ func mergePRViaRESTWith(e execer, repo string, number int, headSHA string) error
 
 // isHeadSHAMismatchErr reports whether the REST merge response indicates the
 // supplied sha no longer matches the PR's current head — GitHub returns 409
-// with this message. Terminal: retrying would only re-merge on stale evidence
-// once the head advances further, so the caller must not retry it.
+// with this specific message. Terminal: retrying would only re-merge on stale
+// evidence once the head advances further, so the caller must not retry it.
+// Deliberately keyed on the message rather than the bare 409 status, since
+// the merge endpoint also returns 409 for other conditions (e.g. the
+// transient base-branch race handled by isBaseBranchModifiedErr), which must
+// stay retryable.
 func isHeadSHAMismatchErr(resp ghHTTPResponse) bool {
-	return resp.statusCode == 409 || strings.Contains(string(resp.body), "Head branch was modified")
+	return strings.Contains(string(resp.body), "Head branch was modified")
 }
 
 // MarkReady marks a draft pull request as ready for review.

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -697,6 +697,19 @@ func TestMergePRViaRESTWith(t *testing.T) {
 		}
 	})
 
+	t.Run("empty head sha is rejected before any request", func(t *testing.T) {
+		t.Parallel()
+		se := &scriptedExecer{results: []scriptedResult{
+			{output: []byte("HTTP/1.1 200 OK\n\n{\"merged\":true}"), err: nil},
+		}}
+		if err := mergePRViaRESTWith(se, "owner/repo", 42, ""); err == nil {
+			t.Fatal("expected error for empty head sha")
+		}
+		if se.calls != 0 {
+			t.Fatalf("calls = %d, want 0 (no request without a head sha)", se.calls)
+		}
+	})
+
 	t.Run("head sha mismatch (409) is terminal, no retry", func(t *testing.T) {
 		t.Parallel()
 		se := &scriptedExecer{results: []scriptedResult{
@@ -707,6 +720,19 @@ func TestMergePRViaRESTWith(t *testing.T) {
 		}
 		if se.calls != 1 {
 			t.Fatalf("calls = %d, want 1 (no retry on sha mismatch)", se.calls)
+		}
+	})
+
+	t.Run("generic 409 without the mismatch message is not treated as terminal", func(t *testing.T) {
+		t.Parallel()
+		se := &scriptedExecer{results: []scriptedResult{
+			{output: []byte("HTTP/1.1 409 Conflict\n\n{\"message\":\"some other conflict\"}"), err: fmt.Errorf("exit 1")},
+		}}
+		if err := mergePRViaRESTWith(se, "owner/repo", 42, "abc123"); err == nil {
+			t.Fatal("expected error")
+		}
+		if isHeadSHAMismatchErr(ghHTTPResponse{statusCode: 409, body: []byte("some other conflict")}) {
+			t.Fatal("generic 409 must not be classified as a head-SHA mismatch")
 		}
 	})
 

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -673,3 +673,59 @@ func TestSupportsNativeAutoMerge(t *testing.T) {
 		}
 	})
 }
+
+func TestMergePRViaRESTWith(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success carries head sha and PUT method", func(t *testing.T) {
+		t.Parallel()
+		se := &scriptedExecer{results: []scriptedResult{
+			{output: []byte("HTTP/1.1 200 OK\n\n{\"merged\":true}"), err: nil},
+		}}
+		if err := mergePRViaRESTWith(se, "owner/repo", 42, "abc123"); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		joined := strings.Join(se.lastArgs, " ")
+		if !strings.Contains(joined, "repos/owner/repo/pulls/42/merge") {
+			t.Errorf("args missing merge endpoint: %s", joined)
+		}
+		if !strings.Contains(joined, "PUT") {
+			t.Errorf("args missing PUT method: %s", joined)
+		}
+		if !strings.Contains(joined, "sha=abc123") {
+			t.Errorf("args missing head sha: %s", joined)
+		}
+	})
+
+	t.Run("head sha mismatch (409) is terminal, no retry", func(t *testing.T) {
+		t.Parallel()
+		se := &scriptedExecer{results: []scriptedResult{
+			{output: []byte("HTTP/1.1 409 Conflict\n\n{\"message\":\"Head branch was modified. Review and try the merge again.\"}"), err: fmt.Errorf("exit 1")},
+		}}
+		if err := mergePRViaRESTWith(se, "owner/repo", 42, "abc123"); err == nil {
+			t.Fatal("expected error")
+		}
+		if se.calls != 1 {
+			t.Fatalf("calls = %d, want 1 (no retry on sha mismatch)", se.calls)
+		}
+	})
+
+	t.Run("base branch modified retries then succeeds", func(t *testing.T) {
+		prev := mergeRetryDelays
+		mergeRetryDelays = []time.Duration{0, 0, 0}
+		t.Cleanup(func() { mergeRetryDelays = prev })
+
+		baseModified := []byte("HTTP/1.1 405 Method Not Allowed\n\nBase branch was modified. Review and try the merge again.")
+		se := &scriptedExecer{results: []scriptedResult{
+			{output: baseModified, err: fmt.Errorf("exit 1")},
+			{output: baseModified, err: fmt.Errorf("exit 1")},
+			{output: []byte("HTTP/1.1 200 OK\n\n{\"merged\":true}"), err: nil},
+		}}
+		if err := mergePRViaRESTWith(se, "owner/repo", 42, "abc123"); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if se.calls != 3 {
+			t.Fatalf("calls = %d, want 3", se.calls)
+		}
+	})
+}

--- a/internal/github/rest_monitor.go
+++ b/internal/github/rest_monitor.go
@@ -97,28 +97,39 @@ func fetchPRForMonitorViaREST(e execer, repo string, number int) (PullRequest, b
 		return PullRequest{}, false, nil
 	}
 
-	ci, pending := fetchCIStatusViaREST(e, owner, name, pr.Head.SHA)
+	ci, pending, ciFetchOK := fetchCIStatusViaREST(e, owner, name, pr.Head.SHA)
 
 	out := PullRequest{
-		Number:           pr.Number,
-		Title:            pr.Title,
-		URL:              pr.HTMLURL,
-		Repository:       repo,
-		RepoName:         name,
-		Author:           pr.User.Login,
-		IsDraft:          pr.Draft,
-		HeadRefName:      pr.Head.Ref,
-		HeadSHA:          pr.Head.SHA,
-		BaseRefName:      pr.Base.Ref,
-		Mergeable:        restMergeable(pr.MergeableState),
-		CIStatus:         ci,
-		HasPendingChecks: pending,
-		AutoMergeEnabled: pr.AutoMerge != nil,
-		CreatedAt:        pr.CreatedAt,
-		UpdatedAt:        pr.UpdatedAt,
+		Number:             pr.Number,
+		Title:              pr.Title,
+		URL:                pr.HTMLURL,
+		Repository:         repo,
+		RepoName:           name,
+		Author:             pr.User.Login,
+		IsDraft:            pr.Draft,
+		HeadRefName:        pr.Head.Ref,
+		HeadSHA:            pr.Head.SHA,
+		BaseRefName:        pr.Base.Ref,
+		Mergeable:          restMergeable(pr.MergeableState),
+		CIStatus:           ci,
+		HasPendingChecks:   pending,
+		AutoMergeEnabled:   pr.AutoMerge != nil,
+		CreatedAt:          pr.CreatedAt,
+		UpdatedAt:          pr.UpdatedAt,
+		SourcedViaREST:     true,
+		RESTMergeableState: strings.ToLower(strings.TrimSpace(pr.MergeableState)),
+		RESTCIFetched:      ciFetchOK,
 	}
 	for _, l := range pr.Labels {
 		out.Labels = append(out.Labels, l.Name)
+	}
+	// Approval is only meaningful once GitHub reports a strictly clean merge
+	// state; best-effort — an error leaves RESTApproved false so the merge
+	// gate fails closed rather than blocking the whole REST fetch.
+	if !out.IsDraft && out.RESTMergeableState == "clean" {
+		if resp, reviews, err := fetchRESTReviews(e, repo, pr.Number); err == nil && !hasMoreReviewPages(resp) {
+			out.RESTApproved = restApproval(reviews, pr.Head.SHA)
+		}
 	}
 	return out, true, nil
 }
@@ -175,17 +186,25 @@ func restMergeable(state string) string {
 // fetchCIStatusViaREST aggregates check-runs and legacy commit statuses for a
 // commit into the monitor's CIStatus semantics. It converts REST payloads into
 // the same context shape used by GraphQL so informational-check filtering and
-// cancelled-check handling stay identical across both paths.
-func fetchCIStatusViaREST(e execer, owner, name, sha string) (status string, pending bool) {
+// cancelled-check handling stay identical across both paths. ok reports
+// whether both legs were fetched and parsed successfully — false distinguishes
+// a failed fetch from a genuinely check-free commit, so callers never read an
+// empty CIStatus caused by a failed fetch as green.
+func fetchCIStatusViaREST(e execer, owner, name, sha string) (status string, pending, ok bool) {
 	if sha == "" {
-		return "", false
+		return "", false, false
 	}
 	contexts := make([]gqlCheckContext, 0)
+	ok = true
 
 	resp, err := runGHAPIWith(e, "30s", fmt.Sprintf("repos/%s/%s/commits/%s/check-runs", owner, name, sha))
-	if err == nil {
+	if err != nil {
+		ok = false
+	} else {
 		var runs restCheckRuns
-		if jErr := json.Unmarshal(resp.body, &runs); jErr == nil {
+		if jErr := json.Unmarshal(resp.body, &runs); jErr != nil {
+			ok = false
+		} else {
 			for _, c := range runs.CheckRuns {
 				contexts = append(contexts, gqlCheckContext{
 					Typename:   "CheckRun",
@@ -198,9 +217,13 @@ func fetchCIStatusViaREST(e execer, owner, name, sha string) (status string, pen
 	}
 
 	resp, err = runGHAPIWith(e, "30s", fmt.Sprintf("repos/%s/%s/commits/%s/status", owner, name, sha))
-	if err == nil {
+	if err != nil {
+		ok = false
+	} else {
 		var statuses restCommitStatuses
-		if jErr := json.Unmarshal(resp.body, &statuses); jErr == nil {
+		if jErr := json.Unmarshal(resp.body, &statuses); jErr != nil {
+			ok = false
+		} else {
 			for _, s := range statuses.Statuses {
 				contexts = append(contexts, gqlCheckContext{
 					Typename: "StatusContext",
@@ -211,5 +234,6 @@ func fetchCIStatusViaREST(e execer, owner, name, sha string) (status string, pen
 		}
 	}
 
-	return rollupFromContexts(contexts)
+	st, pend := rollupFromContexts(contexts)
+	return st, pend, ok
 }

--- a/internal/github/rest_monitor_test.go
+++ b/internal/github/rest_monitor_test.go
@@ -375,6 +375,22 @@ func TestRestApproval(t *testing.T) {
 			{State: "APPROVED", CommitID: "h"},
 			{State: "DISMISSED", CommitID: "h"},
 		}, "h", true},
+		{"stale changes-request superseded by later approval from same reviewer", []restReview{
+			{State: "CHANGES_REQUESTED", CommitID: "old", SubmittedAt: "2026-01-01T00:00:00Z", User: struct {
+				Login string `json:"login"`
+			}{Login: "alice"}},
+			{State: "APPROVED", CommitID: "h", SubmittedAt: "2026-01-02T00:00:00Z", User: struct {
+				Login string `json:"login"`
+			}{Login: "alice"}},
+		}, "h", true},
+		{"current changes-request from one reviewer blocks despite another's approval", []restReview{
+			{State: "APPROVED", CommitID: "h", SubmittedAt: "2026-01-01T00:00:00Z", User: struct {
+				Login string `json:"login"`
+			}{Login: "alice"}},
+			{State: "CHANGES_REQUESTED", CommitID: "h", SubmittedAt: "2026-01-02T00:00:00Z", User: struct {
+				Login string `json:"login"`
+			}{Login: "bob"}},
+		}, "h", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/github/rest_monitor_test.go
+++ b/internal/github/rest_monitor_test.go
@@ -6,9 +6,13 @@ import (
 	"testing"
 )
 
-// pathExecer returns a canned body for the first stub whose key is a substring
-// of the joined gh args, so a single fake can serve the pulls + check-runs legs
-// of one fetchPRForMonitorViaREST call.
+// pathExecer returns a canned body for the stub whose key matches the request
+// endpoint (the first non-flag "api" argument), so a single fake can serve the
+// pulls + check-runs + reviews legs of one fetchPRForMonitorViaREST call.
+// Matching is on the endpoint path exactly (trailing query stripped), not a
+// substring of the joined args — a substring match would let "/pulls/42"
+// wrongly match a request for "/pulls/42/reviews" (or vice versa,
+// nondeterministically, since Go map iteration order is randomized).
 type pathExecer struct {
 	responses map[string]string
 	err       error
@@ -18,13 +22,46 @@ func (p *pathExecer) run(args ...string) ([]byte, error) {
 	if p.err != nil {
 		return nil, p.err
 	}
-	joined := strings.Join(args, " ")
-	for key, body := range p.responses {
-		if strings.Contains(joined, key) {
-			return []byte(body), nil
+	endpoint := restAPIEndpoint(args)
+	if body, ok := p.responses[endpoint]; ok {
+		return []byte(body), nil
+	}
+	return nil, fmt.Errorf("no stub for endpoint %q (args: %s)", endpoint, strings.Join(args, " "))
+}
+
+// ghFlagsWithValue lists the `gh api` flags that consume the following argv
+// element as their value, so restAPIEndpoint can skip both and land on the
+// actual endpoint path instead of mistaking a flag value (e.g. "30s" from
+// "--cache 30s") for it.
+var ghFlagsWithValue = map[string]bool{
+	"--cache": true, "--method": true, "-f": true, "-F": true,
+	"-q": true, "-X": true, "--jq": true,
+}
+
+// restAPIEndpoint extracts the REST endpoint path from a `gh api ...` argv:
+// the first non-flag argument after "api", skipping any flag/value pairs.
+func restAPIEndpoint(args []string) string {
+	for i, a := range args {
+		if a != "api" {
+			continue
+		}
+		for j := i + 1; j < len(args); {
+			cur := args[j]
+			if ghFlagsWithValue[cur] {
+				j += 2
+				continue
+			}
+			if strings.HasPrefix(cur, "-") {
+				j++
+				continue
+			}
+			if path, _, ok := strings.Cut(cur, "?"); ok {
+				return path
+			}
+			return cur
 		}
 	}
-	return nil, fmt.Errorf("no stub for: %s", joined)
+	return strings.Join(args, " ")
 }
 
 func TestRestMergeable(t *testing.T) {
@@ -49,11 +86,11 @@ func TestRestMergeable(t *testing.T) {
 func TestFetchPRForMonitorViaREST_ConflictAndFailingCI(t *testing.T) {
 	t.Parallel()
 	e := &pathExecer{responses: map[string]string{
-		"/pulls/42": `{"number":42,"title":"feat: x","html_url":"https://gh/pr/42",
+		"repos/Automaat/sybra/pulls/42": `{"number":42,"title":"feat: x","html_url":"https://gh/pr/42",
 			"state":"open","draft":false,"mergeable_state":"dirty",
 			"head":{"ref":"feat/x","sha":"abc123"},"user":{"login":"me"},
 			"labels":[{"name":"backend"}],"created_at":"t1","updated_at":"t2"}`,
-		"/commits/abc123/check-runs": `{"check_runs":[
+		"repos/Automaat/sybra/commits/abc123/check-runs": `{"check_runs":[
 			{"status":"completed","conclusion":"success"},
 			{"status":"completed","conclusion":"failure"}]}`,
 	}}
@@ -87,10 +124,12 @@ func TestFetchPRForMonitorViaREST_ConflictAndFailingCI(t *testing.T) {
 func TestFetchPRForMonitorViaREST_PendingCI(t *testing.T) {
 	t.Parallel()
 	e := &pathExecer{responses: map[string]string{
-		"/pulls/7": `{"number":7,"state":"open","mergeable_state":"clean",
+		"repos/o/r/pulls/7": `{"number":7,"state":"open","mergeable_state":"clean",
 			"head":{"ref":"b","sha":"s7"}}`,
-		"/commits/s7/check-runs": `{"check_runs":[
+		"repos/o/r/commits/s7/check-runs": `{"check_runs":[
 			{"status":"in_progress","conclusion":""}]}`,
+		"repos/o/r/commits/s7/status": `{"statuses":[]}`,
+		"repos/o/r/pulls/7/reviews":   `[]`,
 	}}
 	pr, open, err := fetchPRForMonitorViaREST(e, "o/r", 7)
 	if err != nil || !open {
@@ -107,11 +146,12 @@ func TestFetchPRForMonitorViaREST_PendingCI(t *testing.T) {
 func TestFetchPRForMonitorViaREST_LegacyStatusFailure(t *testing.T) {
 	t.Parallel()
 	e := &pathExecer{responses: map[string]string{
-		"/pulls/8": `{"number":8,"state":"open","mergeable_state":"clean",
+		"repos/o/r/pulls/8": `{"number":8,"state":"open","mergeable_state":"clean",
 			"head":{"ref":"b","sha":"s8"}}`,
-		"/commits/s8/check-runs": `{"check_runs":[]}`,
-		"/commits/s8/status": `{"statuses":[
+		"repos/o/r/commits/s8/check-runs": `{"check_runs":[]}`,
+		"repos/o/r/commits/s8/status": `{"statuses":[
 			{"context":"ci/build","state":"failure"}]}`,
+		"repos/o/r/pulls/8/reviews": `[]`,
 	}}
 	pr, open, err := fetchPRForMonitorViaREST(e, "o/r", 8)
 	if err != nil || !open {
@@ -125,13 +165,14 @@ func TestFetchPRForMonitorViaREST_LegacyStatusFailure(t *testing.T) {
 func TestFetchPRForMonitorViaREST_FiltersInformationalAndCancelledChecks(t *testing.T) {
 	t.Parallel()
 	e := &pathExecer{responses: map[string]string{
-		"/pulls/10": `{"number":10,"state":"open","mergeable_state":"clean",
+		"repos/o/r/pulls/10": `{"number":10,"state":"open","mergeable_state":"clean",
 			"head":{"ref":"b","sha":"s10"}}`,
-		"/commits/s10/check-runs": `{"check_runs":[
+		"repos/o/r/commits/s10/check-runs": `{"check_runs":[
 			{"name":"codecov/patch","status":"completed","conclusion":"failure"},
 			{"name":"ci/cancelled-optional","status":"completed","conclusion":"cancelled"},
 			{"name":"ci/build","status":"completed","conclusion":"success"}]}`,
-		"/commits/s10/status": `{"statuses":[]}`,
+		"repos/o/r/commits/s10/status": `{"statuses":[]}`,
+		"repos/o/r/pulls/10/reviews":   `[]`,
 	}}
 	pr, open, err := fetchPRForMonitorViaREST(e, "o/r", 10)
 	if err != nil || !open {
@@ -145,7 +186,7 @@ func TestFetchPRForMonitorViaREST_FiltersInformationalAndCancelledChecks(t *test
 func TestFetchPRForMonitorViaREST_ClosedPR(t *testing.T) {
 	t.Parallel()
 	e := &pathExecer{responses: map[string]string{
-		"/pulls/9": `{"number":9,"state":"closed","head":{"sha":"x"}}`,
+		"repos/o/r/pulls/9": `{"number":9,"state":"closed","head":{"sha":"x"}}`,
 	}}
 	_, open, err := fetchPRForMonitorViaREST(e, "o/r", 9)
 	if err != nil {
@@ -181,7 +222,7 @@ func TestFetchPRStateViaREST_MergedAndClosed(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e := &pathExecer{responses: map[string]string{"/pulls/": tt.body}}
+			e := &pathExecer{responses: map[string]string{"repos/o/r/pulls/11": tt.body}}
 			got, err := fetchPRStateViaREST(e, "o/r", 11)
 			if err != nil {
 				t.Fatalf("fetchPRStateViaREST: %v", err)
@@ -190,6 +231,193 @@ func TestFetchPRStateViaREST_MergedAndClosed(t *testing.T) {
 				t.Errorf("State = %q, want %q", got.State, tt.want)
 			}
 		})
+	}
+}
+
+// TestFetchPRForMonitorViaREST_CleanApproved verifies a clean, !draft PR whose
+// CI is green and REST reviews show an APPROVED-at-head, non-dismissed review
+// sets SourcedViaREST/RESTMergeableState/RESTCIFetched/RESTApproved — the
+// signals the REST auto-merge gate needs.
+func TestFetchPRForMonitorViaREST_CleanApproved(t *testing.T) {
+	t.Parallel()
+	e := &pathExecer{responses: map[string]string{
+		"repos/o/r/pulls/20": `{"number":20,"state":"open","draft":false,"mergeable_state":"clean",
+			"head":{"ref":"b","sha":"headsha"}}`,
+		"repos/o/r/commits/headsha/check-runs": `{"check_runs":[
+			{"status":"completed","conclusion":"success"}]}`,
+		"repos/o/r/commits/headsha/status": `{"statuses":[]}`,
+		"repos/o/r/pulls/20/reviews": `[
+			{"state":"APPROVED","commit_id":"headsha","user":{"login":"alice"}}]`,
+	}}
+	pr, open, err := fetchPRForMonitorViaREST(e, "o/r", 20)
+	if err != nil || !open {
+		t.Fatalf("open=%v err=%v", open, err)
+	}
+	if !pr.SourcedViaREST {
+		t.Error("SourcedViaREST must be true")
+	}
+	if pr.RESTMergeableState != "clean" {
+		t.Errorf("RESTMergeableState = %q, want clean", pr.RESTMergeableState)
+	}
+	if !pr.RESTCIFetched {
+		t.Error("RESTCIFetched must be true when both CI legs fetch cleanly")
+	}
+	if !pr.RESTApproved {
+		t.Error("RESTApproved must be true for an APPROVED review at the current head")
+	}
+}
+
+// TestFetchPRForMonitorViaREST_CIFetchFails verifies a failed check-runs leg
+// leaves RESTCIFetched false even though the PR is otherwise clean — an empty
+// CIStatus caused by a failed fetch must never read as green.
+func TestFetchPRForMonitorViaREST_CIFetchFails(t *testing.T) {
+	t.Parallel()
+	e := &pathExecer{responses: map[string]string{
+		"repos/o/r/pulls/21": `{"number":21,"state":"open","draft":false,"mergeable_state":"clean",
+			"head":{"ref":"b","sha":"headsha21"}}`,
+		"repos/o/r/commits/headsha21/status": `{"statuses":[]}`,
+		"repos/o/r/pulls/21/reviews": `[
+			{"state":"APPROVED","commit_id":"headsha21","user":{"login":"alice"}}]`,
+	}}
+	pr, open, err := fetchPRForMonitorViaREST(e, "o/r", 21)
+	if err != nil || !open {
+		t.Fatalf("open=%v err=%v", open, err)
+	}
+	if pr.RESTCIFetched {
+		t.Error("RESTCIFetched must be false when the check-runs leg errors")
+	}
+}
+
+// TestFetchPRForMonitorViaREST_StaleApproval verifies an APPROVED review whose
+// commit_id doesn't match the PR's current head does not set RESTApproved.
+func TestFetchPRForMonitorViaREST_StaleApproval(t *testing.T) {
+	t.Parallel()
+	e := &pathExecer{responses: map[string]string{
+		"repos/o/r/pulls/22": `{"number":22,"state":"open","draft":false,"mergeable_state":"clean",
+			"head":{"ref":"b","sha":"newsha"}}`,
+		"repos/o/r/commits/newsha/check-runs": `{"check_runs":[]}`,
+		"repos/o/r/commits/newsha/status":     `{"statuses":[]}`,
+		"repos/o/r/pulls/22/reviews": `[
+			{"state":"APPROVED","commit_id":"oldsha","user":{"login":"alice"}}]`,
+	}}
+	pr, open, err := fetchPRForMonitorViaREST(e, "o/r", 22)
+	if err != nil || !open {
+		t.Fatalf("open=%v err=%v", open, err)
+	}
+	if pr.RESTApproved {
+		t.Error("a stale approval (commit_id != HeadSHA) must not set RESTApproved")
+	}
+}
+
+// TestFetchPRForMonitorViaREST_CopilotCommentedOnly verifies a Copilot
+// COMMENTED-only review never sets RESTApproved.
+func TestFetchPRForMonitorViaREST_CopilotCommentedOnly(t *testing.T) {
+	t.Parallel()
+	e := &pathExecer{responses: map[string]string{
+		"repos/o/r/pulls/23": `{"number":23,"state":"open","draft":false,"mergeable_state":"clean",
+			"head":{"ref":"b","sha":"sha23"}}`,
+		"repos/o/r/commits/sha23/check-runs": `{"check_runs":[]}`,
+		"repos/o/r/commits/sha23/status":     `{"statuses":[]}`,
+		"repos/o/r/pulls/23/reviews": `[
+			{"state":"COMMENTED","commit_id":"sha23","user":{"login":"copilot-pull-request-reviewer[bot]"}}]`,
+	}}
+	pr, open, err := fetchPRForMonitorViaREST(e, "o/r", 23)
+	if err != nil || !open {
+		t.Fatalf("open=%v err=%v", open, err)
+	}
+	if pr.RESTApproved {
+		t.Error("a Copilot COMMENTED-only review must not set RESTApproved")
+	}
+}
+
+// TestFetchPRForMonitorViaREST_BlockedNotApproved verifies a non-clean
+// mergeable_state (blocked/behind/unstable) skips the reviews fetch
+// altogether, so RESTApproved never gets set from a non-clean PR.
+func TestFetchPRForMonitorViaREST_BlockedNotApproved(t *testing.T) {
+	t.Parallel()
+	for _, state := range []string{"blocked", "behind", "unstable", "unknown"} {
+		e := &pathExecer{responses: map[string]string{
+			"repos/o/r/pulls/24": fmt.Sprintf(`{"number":24,"state":"open","draft":false,"mergeable_state":%q,
+				"head":{"ref":"b","sha":"sha24"}}`, state),
+			"repos/o/r/commits/sha24/check-runs": `{"check_runs":[]}`,
+			"repos/o/r/commits/sha24/status":     `{"statuses":[]}`,
+		}}
+		pr, open, err := fetchPRForMonitorViaREST(e, "o/r", 24)
+		if err != nil || !open {
+			t.Fatalf("state=%s: open=%v err=%v", state, open, err)
+		}
+		if pr.RESTApproved {
+			t.Errorf("state=%s: RESTApproved must stay false for a non-clean mergeable_state", state)
+		}
+		if pr.RESTMergeableState != state {
+			t.Errorf("RESTMergeableState = %q, want %q", pr.RESTMergeableState, state)
+		}
+	}
+}
+
+func TestRestApproval(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		reviews []restReview
+		headSHA string
+		want    bool
+	}{
+		{"no reviews", nil, "h", false},
+		{"approved at head", []restReview{{State: "APPROVED", CommitID: "h"}}, "h", true},
+		{"approved stale sha", []restReview{{State: "APPROVED", CommitID: "old"}}, "h", false},
+		{"changes requested blocks", []restReview{
+			{State: "APPROVED", CommitID: "h"},
+			{State: "CHANGES_REQUESTED", CommitID: "h"},
+		}, "h", false},
+		{"commented only is not approval", []restReview{{State: "COMMENTED", CommitID: "h"}}, "h", false},
+		{"dismissed changes-request does not block", []restReview{
+			{State: "APPROVED", CommitID: "h"},
+			{State: "DISMISSED", CommitID: "h"},
+		}, "h", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := restApproval(tt.reviews, tt.headSHA); got != tt.want {
+				t.Errorf("restApproval() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchCIStatusViaREST_OK(t *testing.T) {
+	t.Parallel()
+	e := &pathExecer{responses: map[string]string{
+		"repos/o/r/commits/sha/check-runs": `{"check_runs":[{"status":"completed","conclusion":"success"}]}`,
+		"repos/o/r/commits/sha/status":     `{"statuses":[]}`,
+	}}
+	status, pending, ok := fetchCIStatusViaREST(e, "o", "r", "sha")
+	if !ok {
+		t.Error("ok must be true when both legs fetch cleanly")
+	}
+	if status != "SUCCESS" || pending {
+		t.Errorf("status=%q pending=%v, want SUCCESS/false", status, pending)
+	}
+}
+
+func TestFetchCIStatusViaREST_CheckRunsLegErrors(t *testing.T) {
+	t.Parallel()
+	e := &pathExecer{responses: map[string]string{
+		"repos/o/r/commits/sha/status": `{"statuses":[]}`,
+	}}
+	_, _, ok := fetchCIStatusViaREST(e, "o", "r", "sha")
+	if ok {
+		t.Error("ok must be false when the check-runs leg errors")
+	}
+}
+
+func TestFetchCIStatusViaREST_EmptySHA(t *testing.T) {
+	t.Parallel()
+	e := &pathExecer{}
+	_, _, ok := fetchCIStatusViaREST(e, "o", "r", "")
+	if ok {
+		t.Error("ok must be false for an empty sha (nothing was actually fetched)")
 	}
 }
 

--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -542,6 +542,65 @@ func approvedOnly(prs []PullRequest) []PullRequest {
 	return out
 }
 
+// restReview is the subset of a GitHub REST pull-request review payload the
+// review-state helpers need. Shared by hasPendingReviewWith,
+// fetchMyReviewStateWith, and the REST auto-merge approval gate
+// (restApproval) so all three parse the same /pulls/{n}/reviews shape once.
+type restReview struct {
+	State       string `json:"state"`
+	CommitID    string `json:"commit_id"`
+	SubmittedAt string `json:"submitted_at"`
+	User        struct {
+		Login string `json:"login"`
+	} `json:"user"`
+}
+
+// fetchRESTReviews fetches a PR's reviews over REST. The returned
+// ghHTTPResponse lets callers that need it (the REST auto-merge approval
+// gate) check the Link header for pagination, since the review list is
+// unpaginated in practice for the accounts this fetches but a caller
+// computing merge-authorizing approval must fail closed rather than silently
+// miss a review on a second page.
+func fetchRESTReviews(e execer, repo string, number int) (ghHTTPResponse, []restReview, error) {
+	resp, err := runGHAPIWith(e, "30s", fmt.Sprintf("repos/%s/pulls/%d/reviews", repo, number))
+	if err != nil {
+		return resp, nil, fmt.Errorf("fetch reviews for %s#%d: %s: %w", repo, number, strings.TrimSpace(string(resp.body)), err)
+	}
+	var reviews []restReview
+	if err := json.Unmarshal(resp.body, &reviews); err != nil {
+		return resp, nil, fmt.Errorf("parse reviews: %w", err)
+	}
+	return resp, reviews, nil
+}
+
+// hasMoreReviewPages reports whether the reviews response's Link header
+// advertises a next page.
+func hasMoreReviewPages(resp ghHTTPResponse) bool {
+	return strings.Contains(resp.headers["link"], `rel="next"`)
+}
+
+// restApproval computes an explicit current-head approval from a PR's REST
+// reviews: approved iff at least one non-dismissed APPROVED review whose
+// commit_id matches headSHA, and no non-dismissed CHANGES_REQUESTED review
+// from any reviewer. A dismissed review's state is reported by GitHub as
+// DISMISSED, so checking State == "APPROVED"/"CHANGES_REQUESTED" already
+// excludes dismissed reviews. A Copilot COMMENTED review never counts as
+// approval.
+func restApproval(reviews []restReview, headSHA string) bool {
+	approved := false
+	for i := range reviews {
+		switch reviews[i].State {
+		case "CHANGES_REQUESTED":
+			return false
+		case "APPROVED":
+			if reviews[i].CommitID == headSHA {
+				approved = true
+			}
+		}
+	}
+	return approved
+}
+
 // HasPendingReview checks if the authenticated user has a pending (draft) review on a PR.
 // Pending reviews are only visible to their author via the REST API.
 func HasPendingReview(repo string, number int) (bool, error) {
@@ -556,20 +615,14 @@ func hasPendingReviewWith(e execer, repo string, number int) (bool, error) {
 		}
 	}
 
-	resp, err := runGHAPIWith(e, "30s", fmt.Sprintf("repos/%s/pulls/%d/reviews", repo, number))
+	_, reviews, err := fetchRESTReviews(e, repo, number)
 	if err != nil {
 		if runtimeCacheEnabled(e) {
 			if stale, ok := pendingReviewCache.GetStale(key); ok {
 				return stale, nil
 			}
 		}
-		return false, fmt.Errorf("fetch reviews for %s#%d: %s: %w", repo, number, strings.TrimSpace(string(resp.body)), err)
-	}
-	var reviews []struct {
-		State string `json:"state"`
-	}
-	if err := json.Unmarshal(resp.body, &reviews); err != nil {
-		return false, fmt.Errorf("parse reviews: %w", err)
+		return false, err
 	}
 	for i := range reviews {
 		if reviews[i].State == "PENDING" {
@@ -610,26 +663,14 @@ func fetchMyReviewStateWith(e execer, repo string, number int) (MyReviewState, e
 		}
 	}
 
-	resp, err := runGHAPIWith(e, "30s", fmt.Sprintf("repos/%s/pulls/%d/reviews", repo, number))
+	_, reviews, err := fetchRESTReviews(e, repo, number)
 	if err != nil {
 		if runtimeCacheEnabled(e) {
 			if stale, ok := myReviewStateCache.GetStale(key); ok {
 				return stale, nil
 			}
 		}
-		return MyReviewState{}, fmt.Errorf("fetch reviews for %s#%d: %s: %w", repo, number, strings.TrimSpace(string(resp.body)), err)
-	}
-
-	var reviews []struct {
-		State       string `json:"state"`
-		CommitID    string `json:"commit_id"`
-		SubmittedAt string `json:"submitted_at"`
-		User        struct {
-			Login string `json:"login"`
-		} `json:"user"`
-	}
-	if err := json.Unmarshal(resp.body, &reviews); err != nil {
-		return MyReviewState{}, fmt.Errorf("parse reviews: %w", err)
+		return MyReviewState{}, err
 	}
 
 	me := viewerLogin(e)

--- a/internal/github/review.go
+++ b/internal/github/review.go
@@ -580,22 +580,39 @@ func hasMoreReviewPages(resp ghHTTPResponse) bool {
 }
 
 // restApproval computes an explicit current-head approval from a PR's REST
-// reviews: approved iff at least one non-dismissed APPROVED review whose
-// commit_id matches headSHA, and no non-dismissed CHANGES_REQUESTED review
-// from any reviewer. A dismissed review's state is reported by GitHub as
-// DISMISSED, so checking State == "APPROVED"/"CHANGES_REQUESTED" already
-// excludes dismissed reviews. A Copilot COMMENTED review never counts as
-// approval.
+// reviews, using each reviewer's *latest* standing verdict rather than their
+// full history: approved iff at least one reviewer's latest APPROVED/
+// CHANGES_REQUESTED review is an APPROVED whose commit_id matches headSHA,
+// and no reviewer's latest such review is CHANGES_REQUESTED. This mirrors
+// GitHub's own PR merge-readiness semantics — an old CHANGES_REQUESTED
+// superseded by a later APPROVED from the same reviewer no longer blocks the
+// PR. A dismissed review's state is reported by GitHub as DISMISSED, so
+// checking State == "APPROVED"/"CHANGES_REQUESTED" already excludes
+// dismissed reviews. A Copilot COMMENTED review never counts as approval.
 func restApproval(reviews []restReview, headSHA string) bool {
-	approved := false
+	type verdict struct {
+		state       string
+		commitID    string
+		submittedAt string
+	}
+	latest := make(map[string]verdict)
 	for i := range reviews {
-		switch reviews[i].State {
-		case "CHANGES_REQUESTED":
+		r := reviews[i]
+		if r.State != "APPROVED" && r.State != "CHANGES_REQUESTED" {
+			continue
+		}
+		if r.SubmittedAt >= latest[r.User.Login].submittedAt {
+			latest[r.User.Login] = verdict{state: r.State, commitID: r.CommitID, submittedAt: r.SubmittedAt}
+		}
+	}
+
+	approved := false
+	for _, v := range latest {
+		if v.state == "CHANGES_REQUESTED" {
 			return false
-		case "APPROVED":
-			if reviews[i].CommitID == headSHA {
-				approved = true
-			}
+		}
+		if v.state == "APPROVED" && v.commitID == headSHA {
+			approved = true
 		}
 	}
 	return approved

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -63,6 +63,10 @@ type ReviewHandler struct {
 	// supports arming native auto-merge; overridable in tests. nil falls back
 	// to github.SupportsNativeAutoMerge.
 	supportsAutoMergeFn func(repo, baseBranch string) (bool, error)
+	// mergePRViaREST performs the REST-sourced squash-merge (PUT .../merge
+	// with the observed head SHA); overridable in tests. nil falls back to
+	// github.MergePRViaREST.
+	mergePRViaREST func(repo string, number int, headSHA string) error
 	// fetchThreads / resolveThread back the Copilot-thread auto-resolver;
 	// overridable in tests. nil falls back to the github package functions.
 	fetchThreads  func(repo string, number int) ([]github.ReviewThread, error)
@@ -146,6 +150,7 @@ func newReviewHandler(
 		mergePR:             github.MergePR,
 		enableAutoMergeFn:   github.EnableAutoMerge,
 		supportsAutoMergeFn: github.SupportsNativeAutoMerge,
+		mergePRViaREST:      github.MergePRViaREST,
 		fetchThreads:        github.FetchReviewThreads,
 		resolveThread:       github.ResolveReviewThread,
 		cfg:                 cfg,
@@ -322,13 +327,16 @@ func (r *ReviewHandler) pollAndMonitorPRs() time.Duration {
 	return r.pollSlow()
 }
 
-// handleKnownPRConflictsViaREST runs a REST-only conflict/CI pass over linked
-// task PRs, used when the GraphQL search backed off on an exhausted budget. The
-// per-PR fetch routes to the idle REST bucket, so conflict and ci_failure fixes
-// keep moving without GraphQL. Thread-driven kinds (comments, ready_to_merge)
-// are intentionally dropped — REST exposes no thread-resolution data, so acting
-// on them could merge a PR with unresolved threads; they resume once GraphQL
-// recovers.
+// handleKnownPRConflictsViaREST runs a REST-only conflict/CI/ready-to-merge
+// pass over linked task PRs, used when the GraphQL search backed off on an
+// exhausted budget. The per-PR fetch routes to the idle REST bucket, so
+// conflict and ci_failure fixes — and, now that fetchPRForMonitorViaREST
+// computes RESTApproved, auto-merge — keep moving without GraphQL. The
+// comments kind is still dropped: REST exposes no thread-resolution data, so
+// acting on it could stall on unresolved threads it can't see; it resumes
+// once GraphQL recovers. ready_to_merge issues reach handleAutoMerge, which
+// gates a SourcedViaREST PR on the strict REST readiness check
+// (readyForRESTAutoMerge) rather than the Copilot/thread-based gate.
 func (r *ReviewHandler) handleKnownPRConflictsViaREST(tasks []task.Task) {
 	var matchers, closedMatchers []github.TaskMatcher
 	for i := range tasks {
@@ -351,17 +359,21 @@ func (r *ReviewHandler) handleKnownPRConflictsViaREST(tasks []task.Task) {
 
 	monitoredPRs := r.fetchKnownTaskPRs(matchers)
 	if len(matchers) > 0 {
-		var conflictCI []github.PRIssue
+		var handled []github.PRIssue
 		matched := github.MatchTaskPRs(monitoredPRs, matchers)
 		for i := range matched {
-			if matched[i].Kind == github.PRIssueConflict || matched[i].Kind == github.PRIssueCIFailure {
-				conflictCI = append(conflictCI, matched[i])
+			switch matched[i].Kind {
+			case github.PRIssueConflict, github.PRIssueCIFailure, github.PRIssueReadyToMerge:
+				handled = append(handled, matched[i])
+			case github.PRIssueComments:
+				// REST exposes no thread-resolution data; comments stay
+				// dropped until GraphQL recovers.
 			}
 		}
 		if r.prTracker != nil {
 			r.prTracker.Cleanup()
 		}
-		r.handleMatchedPRIssues(conflictCI)
+		r.handleMatchedPRIssues(handled)
 	}
 	if len(closedMatchers) > 0 {
 		fetchState := github.FetchPRStateViaREST

--- a/internal/sybra/app_reviews_automerge_test.go
+++ b/internal/sybra/app_reviews_automerge_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Automaat/sybra/internal/audit"
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/project"
@@ -40,6 +41,8 @@ func TestReadyForCopilotAutoMerge(t *testing.T) {
 	noChecks.CIStatus = ""
 	approved := base
 	approved.ReviewDecision = "APPROVED"
+	sourcedViaREST := base
+	sourcedViaREST.SourcedViaREST = true
 
 	tests := []struct {
 		name string
@@ -56,12 +59,63 @@ func TestReadyForCopilotAutoMerge(t *testing.T) {
 		{"conflict blocks", conflict, false},
 		{"ci failure blocks", ciFail, false},
 		{"ci pending blocks", ciPending, false},
+		{"REST-sourced PR always blocks, even when otherwise green", sourcedViaREST, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := readyForCopilotAutoMerge(tt.pr); got != tt.want {
 				t.Errorf("readyForCopilotAutoMerge() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadyForRESTAutoMerge(t *testing.T) {
+	t.Parallel()
+	base := github.PullRequest{
+		RESTMergeableState: "clean",
+		RESTCIFetched:      true,
+		CIStatus:           "SUCCESS",
+		RESTApproved:       true,
+	}
+	withDraft := base
+	withDraft.IsDraft = true
+	noChecks := base
+	noChecks.CIStatus = ""
+	notApproved := base
+	notApproved.RESTApproved = false
+	ciFetchFailed := base
+	ciFetchFailed.RESTCIFetched = false
+	ciFail := base
+	ciFail.CIStatus = "FAILURE"
+
+	tests := []struct {
+		name string
+		pr   github.PullRequest
+		want bool
+	}{
+		{"clean, fetched, green, approved", base, true},
+		{"no checks counts as green", noChecks, true},
+		{"draft blocks", withDraft, false},
+		{"not approved blocks", notApproved, false},
+		{"unfetched CI blocks even though CIStatus is empty", ciFetchFailed, false},
+		{"ci failure blocks", ciFail, false},
+	}
+	for _, state := range []string{"blocked", "behind", "unstable", "unknown", ""} {
+		pr := base
+		pr.RESTMergeableState = state
+		tests = append(tests, struct {
+			name string
+			pr   github.PullRequest
+			want bool
+		}{name: "mergeable_state=" + state + " blocks", pr: pr, want: false})
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := readyForRESTAutoMerge(tt.pr); got != tt.want {
+				t.Errorf("readyForRESTAutoMerge() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -358,6 +412,274 @@ func TestHandleAutoMerge_ArmsNative(t *testing.T) {
 				t.Errorf("merged=%v (repo=%q num=%d), want merged=%v", merged, mergedRepo, mergedNum, tt.wantMerged)
 			}
 		})
+	}
+}
+
+func TestHandleAutoMerge_REST(t *testing.T) {
+	restApproved := github.PullRequest{
+		Repository: "pet-owner/pet-repo", Number: 30, HeadSHA: "sha30",
+		SourcedViaREST: true, RESTMergeableState: "clean", RESTCIFetched: true,
+		CIStatus: "SUCCESS", RESTApproved: true,
+	}
+	restNotApproved := restApproved
+	restNotApproved.Number = 31
+	restNotApproved.RESTApproved = false
+	restCIFetchFailed := restApproved
+	restCIFetchFailed.Number = 32
+	restCIFetchFailed.RESTCIFetched = false
+	restCIFetchFailed.CIStatus = ""
+	restBlocked := restApproved
+	restBlocked.Number = 33
+	restBlocked.RESTMergeableState = "blocked"
+	restCopilotCommentedOnly := restApproved
+	restCopilotCommentedOnly.Number = 34
+	restCopilotCommentedOnly.RESTApproved = false // Copilot COMMENTED never sets RESTApproved
+	restRenovateGreenPR := github.PullRequest{
+		Repository: "pet-owner/pet-repo", Number: 35, HeadSHA: "sha35",
+		SourcedViaREST: true, RESTMergeableState: "clean", RESTCIFetched: true,
+		CIStatus: "SUCCESS", RESTApproved: false,
+	}
+	nonRESTReadyIssue := github.PullRequest{
+		Repository: "pet-owner/pet-repo", Number: 36,
+		Mergeable: "MERGEABLE", CIStatus: "SUCCESS", CopilotReviewed: false,
+	}
+
+	tests := []struct {
+		name       string
+		tags       []string
+		pr         github.PullRequest
+		wantMerged bool
+	}{
+		{"REST-sourced, clean+fetched+green+approved -> merges via REST", nil, restApproved, true},
+		{"REST-sourced, not approved -> holds", nil, restNotApproved, false},
+		{"REST-sourced, CI fetch failed -> holds (empty CIStatus not read as green)", nil, restCIFetchFailed, false},
+		{"REST-sourced, blocked mergeable_state -> holds", nil, restBlocked, false},
+		{"REST-sourced, Copilot COMMENTED-only -> holds", nil, restCopilotCommentedOnly, false},
+		{"REST-sourced renovate-fix, clean+fetched+green, no approval needed -> merges", []string{"renovate-fix"}, restRenovateGreenPR, true},
+		{"non-REST-sourced ready issue in degraded handler -> holds (Copilot gate, not reviewed)", nil, nonRESTReadyIssue, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			projDir := t.TempDir()
+			projStore, err := project.NewStore(projDir, t.TempDir())
+			if err != nil {
+				t.Fatalf("NewStore: %v", err)
+			}
+			mustWriteProjectYAML(t, projDir, "pet-owner/pet-repo", project.ProjectTypePet)
+
+			taskStore, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+			if err != nil {
+				t.Fatalf("task NewStore: %v", err)
+			}
+			tasks := task.NewManager(taskStore, nil)
+			created, err := tasks.Create("ship it", "", string(task.AgentModeHeadless))
+			if err != nil {
+				t.Fatalf("create: %v", err)
+			}
+			upd := task.Update{
+				Status:    task.Ptr(task.StatusInReview),
+				PRNumber:  task.Ptr(tt.pr.Number),
+				ProjectID: task.Ptr("pet-owner/pet-repo"),
+			}
+			if tt.tags != nil {
+				upd.Tags = &tt.tags
+			}
+			if _, err := tasks.Update(created.ID, upd); err != nil {
+				t.Fatalf("update: %v", err)
+			}
+
+			var restMergedRepo, restMergedSHA string
+			var restMergedNum int
+			var gqlMergeCalled bool
+			r := &ReviewHandler{
+				DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
+				tasks:         tasks,
+				projects:      projStore,
+				prTracker:     github.NewIssueTracker(time.Minute),
+				mergePR: func(repo string, number int) error {
+					gqlMergeCalled = true
+					return nil
+				},
+				mergePRViaREST: func(repo string, number int, headSHA string) error {
+					restMergedRepo, restMergedNum, restMergedSHA = repo, number, headSHA
+					return nil
+				},
+			}
+
+			r.handleAutoMerge(github.PRIssue{
+				Kind:   github.PRIssueReadyToMerge,
+				TaskID: created.ID,
+				PR:     tt.pr,
+			})
+
+			merged := restMergedNum != 0
+			if merged != tt.wantMerged {
+				t.Fatalf("merged=%v (repo=%q num=%d), want merged=%v", merged, restMergedRepo, restMergedNum, tt.wantMerged)
+			}
+			if gqlMergeCalled {
+				t.Error("a REST-sourced PR must never merge via the GraphQL gh-pr-merge path")
+			}
+			if merged && restMergedSHA != tt.pr.HeadSHA {
+				t.Errorf("mergePRViaREST head sha = %q, want %q", restMergedSHA, tt.pr.HeadSHA)
+			}
+		})
+	}
+}
+
+// TestHandleAutoMerge_REST_AuditPayload verifies a REST-sourced merge stamps
+// sourced_via_rest, gate_evidence, and head_sha into the auto-merge audit
+// event, while a GraphQL-sourced merge's payload stays free of those REST-only
+// keys.
+func TestHandleAutoMerge_REST_AuditPayload(t *testing.T) {
+	tmp := t.TempDir()
+	auditDir := filepath.Join(tmp, "audit")
+	auditLog, err := audit.NewLogger(auditDir)
+	if err != nil {
+		t.Fatalf("audit.NewLogger: %v", err)
+	}
+	defer auditLog.Close()
+
+	projDir := t.TempDir()
+	projStore, err := project.NewStore(projDir, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	mustWriteProjectYAML(t, projDir, "pet-owner/pet-repo", project.ProjectTypePet)
+
+	taskStore, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatalf("task NewStore: %v", err)
+	}
+	tasks := task.NewManager(taskStore, nil)
+	created, err := tasks.Create("ship it", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:    task.Ptr(task.StatusInReview),
+		PRNumber:  task.Ptr(40),
+		ProjectID: task.Ptr("pet-owner/pet-repo"),
+	}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	r := &ReviewHandler{
+		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler), audit: auditLog},
+		tasks:         tasks,
+		projects:      projStore,
+		prTracker:     github.NewIssueTracker(time.Minute),
+		mergePRViaREST: func(repo string, number int, headSHA string) error {
+			return nil
+		},
+	}
+
+	r.handleAutoMerge(github.PRIssue{
+		Kind:   github.PRIssueReadyToMerge,
+		TaskID: created.ID,
+		PR: github.PullRequest{
+			Repository: "pet-owner/pet-repo", Number: 40, HeadSHA: "sha40",
+			SourcedViaREST: true, RESTMergeableState: "clean", RESTCIFetched: true,
+			CIStatus: "SUCCESS", RESTApproved: true,
+		},
+	})
+
+	events := readExperienceAuditEvents(t, auditDir)
+	var merged *audit.Event
+	for i := range events {
+		if events[i].Type == audit.EventPRAutoMerged {
+			merged = &events[i]
+		}
+	}
+	if merged == nil {
+		t.Fatalf("no %s audit event; events=%+v", audit.EventPRAutoMerged, events)
+	}
+	if merged.Data["sourced_via_rest"] != true {
+		t.Errorf("sourced_via_rest = %v, want true", merged.Data["sourced_via_rest"])
+	}
+	if merged.Data["gate_evidence"] != "approved" {
+		t.Errorf("gate_evidence = %v, want approved", merged.Data["gate_evidence"])
+	}
+	if merged.Data["head_sha"] != "sha40" {
+		t.Errorf("head_sha = %v, want sha40", merged.Data["head_sha"])
+	}
+}
+
+// TestHandleKnownPRConflictsViaREST_RoutesReadyToMerge verifies the
+// budget-exhausted REST-only pass now routes a ready_to_merge issue through
+// to handleAutoMerge (and its REST merge), where it used to be dropped
+// alongside comments.
+func TestHandleKnownPRConflictsViaREST_RoutesReadyToMerge(t *testing.T) {
+	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	tk, err := tasks.Create("Ready PR", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.Update(tk.ID, task.Update{
+		Status:    task.Ptr(task.StatusInReview),
+		ProjectID: task.Ptr("pet-owner/pet-repo"),
+		PRNumber:  task.Ptr(50),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	projDir := t.TempDir()
+	projStore, err := project.NewStore(projDir, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	mustWriteProjectYAML(t, projDir, "pet-owner/pet-repo", project.ProjectTypePet)
+
+	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, slog.New(slog.DiscardHandler), t.TempDir())
+
+	var restMergedNum int
+	var gqlMergeCalled bool
+	r := &ReviewHandler{
+		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
+		tasks:         tasks,
+		projects:      projStore,
+		agents:        agentMgr,
+		prTracker:     github.NewIssueTracker(time.Minute),
+		mergePR: func(repo string, number int) error {
+			gqlMergeCalled = true
+			return nil
+		},
+		mergePRViaREST: func(repo string, number int, headSHA string) error {
+			restMergedNum = number
+			return nil
+		},
+		fetchKnownPRsFn: func(refs []github.PRRef) []github.MonitorPRResult {
+			results := make([]github.MonitorPRResult, len(refs))
+			for i, ref := range refs {
+				results[i] = github.MonitorPRResult{
+					Repo: ref.Repo, Number: ref.Number, Open: true,
+					PR: github.PullRequest{
+						Number: ref.Number, Repository: ref.Repo, HeadSHA: "sha50",
+						Mergeable:      "MERGEABLE",
+						SourcedViaREST: true, RESTMergeableState: "clean", RESTCIFetched: true,
+						CIStatus: "SUCCESS", RESTApproved: true,
+					},
+				}
+			}
+			return results
+		},
+	}
+
+	got, err := tasks.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.handleKnownPRConflictsViaREST(got)
+
+	if restMergedNum != 50 {
+		t.Fatalf("restMergedNum = %d, want 50 (ready_to_merge must reach handleAutoMerge)", restMergedNum)
+	}
+	if gqlMergeCalled {
+		t.Error("must merge via REST, not the GraphQL gh-pr-merge path")
 	}
 }
 

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -26,8 +26,14 @@ const prFixResultContract = "\n\nBefore your final response, decide the outcome:
 // request. Human approval is intentionally NOT required — pet PRs never get one;
 // Copilot's review is the gate. A repo without Copilot enabled stays parked in
 // In Review until a human merges it.
+//
+// A SourcedViaREST PR always returns false here — REST fetches leave
+// CopilotReviewed/UnresolvedCount/ReviewDecision zero (thread and review data
+// are GraphQL-only), so this gate can never be honestly satisfied over REST;
+// readyForRESTAutoMerge is the REST-sourced equivalent.
 func readyForCopilotAutoMerge(pr github.PullRequest) bool {
-	return !pr.IsDraft &&
+	return !pr.SourcedViaREST &&
+		!pr.IsDraft &&
 		pr.Mergeable == "MERGEABLE" &&
 		(pr.CIStatus == "SUCCESS" || pr.CIStatus == "") &&
 		pr.CopilotReviewed &&
@@ -51,6 +57,35 @@ func readyToArmNativeAutoMerge(pr github.PullRequest) bool {
 		pr.ReviewDecision != "CHANGES_REQUESTED" &&
 		!pr.AutoMergeEnabled &&
 		pr.Author != "renovate[bot]"
+}
+
+// readyForRESTAutoMerge reports whether a REST-sourced PR satisfies the
+// REST auto-merge policy: not draft, GitHub's raw mergeable_state is exactly
+// "clean" (blocked/behind/unstable/unknown do NOT authorize it), both REST CI
+// legs were fetched successfully (an unfetched CI status must never read as
+// green), CI is green or genuinely absent, and RESTApproved — an explicit,
+// current-head approval computed over REST review data. Uses only
+// RESTApproved/RESTMergeableState/RESTCIFetched, never the thread-derived
+// UnresolvedCount/CopilotReviewed which REST never populates.
+func readyForRESTAutoMerge(pr github.PullRequest) bool {
+	return !pr.IsDraft &&
+		pr.RESTMergeableState == "clean" &&
+		pr.RESTCIFetched &&
+		(pr.CIStatus == "SUCCESS" || pr.CIStatus == "") &&
+		pr.RESTApproved
+}
+
+// restRenovateGreen reports whether a REST-sourced renovate-fix PR is
+// verified green over REST: strictly clean mergeable state and both CI legs
+// fetched successfully and passing. Mirrors the GraphQL renovate-fix bypass
+// (ReadyToMerge already implies green + mergeable + !draft) but re-derives it
+// from REST-only fields since a REST-sourced PR carries none of the
+// GraphQL-only review/thread data the Copilot gate would otherwise check.
+func restRenovateGreen(pr github.PullRequest) bool {
+	return !pr.IsDraft &&
+		pr.RESTMergeableState == "clean" &&
+		pr.RESTCIFetched &&
+		(pr.CIStatus == "SUCCESS" || pr.CIStatus == "")
 }
 
 func (r *ReviewHandler) handleAutoMerge(issue github.PRIssue) {
@@ -106,31 +141,63 @@ func (r *ReviewHandler) handleAutoMerge(issue github.PRIssue) {
 		}
 	}
 
-	// Hold the merge until Copilot has reviewed and its threads are resolved.
-	// Without this, a green PR merges on the first poll after CI passes — before
-	// Copilot's (asynchronous) review lands — and its feedback is skipped.
-	//
-	// Renovate dependency-bump PRs (surfaced via the "Fix CI" flow) are bot-
-	// authored and never receive a Copilot review, so the Copilot gate would
-	// strand them. The ReadyToMerge issue already implies green + mergeable +
-	// !draft, so preserve their prior green auto-merge.
-	if !slices.Contains(t.Tags, "renovate-fix") && !readyForCopilotAutoMerge(issue.PR) {
+	renovateFix := slices.Contains(t.Tags, "renovate-fix")
+
+	var ready bool
+	var gateEvidence string
+	if issue.PR.SourcedViaREST {
+		if renovateFix {
+			ready = restRenovateGreen(issue.PR)
+			gateEvidence = "renovate_green"
+		} else {
+			ready = readyForRESTAutoMerge(issue.PR)
+			gateEvidence = "approved"
+		}
+	} else {
+		// Hold the merge until Copilot has reviewed and its threads are resolved.
+		// Without this, a green PR merges on the first poll after CI passes —
+		// before Copilot's (asynchronous) review lands — and its feedback is
+		// skipped.
+		//
+		// Renovate dependency-bump PRs (surfaced via the "Fix CI" flow) are bot-
+		// authored and never receive a Copilot review, so the Copilot gate would
+		// strand them. The ReadyToMerge issue already implies green + mergeable +
+		// !draft, so preserve their prior green auto-merge.
+		ready = renovateFix || readyForCopilotAutoMerge(issue.PR)
+	}
+	if !ready {
 		return
 	}
 
-	merge := r.mergePR
-	if merge == nil {
-		merge = github.MergePR
+	var mergeErr error
+	if issue.PR.SourcedViaREST {
+		merge := r.mergePRViaREST
+		if merge == nil {
+			merge = github.MergePRViaREST
+		}
+		mergeErr = merge(issue.PR.Repository, issue.PR.Number, issue.PR.HeadSHA)
+	} else {
+		merge := r.mergePR
+		if merge == nil {
+			merge = github.MergePR
+		}
+		mergeErr = merge(issue.PR.Repository, issue.PR.Number)
 	}
-	if err := merge(issue.PR.Repository, issue.PR.Number); err != nil {
-		r.logger.Error("auto-merge.failed", "task_id", t.ID, "pr", issue.PR.Number, "err", err)
+	if mergeErr != nil {
+		r.logger.Error("auto-merge.failed", "task_id", t.ID, "pr", issue.PR.Number, "err", mergeErr)
 		return
 	}
 
 	r.prTracker.MarkHandled(t.ID, issue.Kind, issue.PR.HeadSHA)
-	r.logAudit(audit.EventPRAutoMerged, t.ID, "", map[string]any{
+	auditData := map[string]any{
 		"pr": issue.PR.Number, "repo": issue.PR.Repository,
-	})
+	}
+	if issue.PR.SourcedViaREST {
+		auditData["sourced_via_rest"] = true
+		auditData["gate_evidence"] = gateEvidence
+		auditData["head_sha"] = issue.PR.HeadSHA
+	}
+	r.logAudit(audit.EventPRAutoMerged, t.ID, "", auditData)
 	r.logger.Info("auto-merge.merged", "task_id", t.ID, "pr", issue.PR.Number)
 }
 


### PR DESCRIPTION
## Motivation

GraphQL budget exhaustion used to halt auto-merge entirely, since the REST monitor fallback path didn't carry approval data. This left ready PRs stuck waiting for budget to refresh instead of merging once verifiably clean.

## Implementation information

- `fetchPRForMonitorViaREST` now also fetches REST review state (`RESTApproved`) and the raw `mergeable_state`.
- `fetchCIStatusViaREST` reports whether both CI legs actually fetched, so merge-readiness only trusts fully-observed signals.
- A REST-sourced PR can now be merged via `PUT .../merge` (head-SHA-protected) once it's verifiably clean, green, and approved over REST, while staying fail-closed on any unverified signal.
- Threaded `pollPriority` through `shouldSkipOptional` call sites that were left on the old signature, and fixed the ready-to-merge regression test to stub the batched `fetchKnownPRsFn` used by `handleKnownPRConflictsViaREST` instead of the unrelated per-PR `fetchKnownPRFn`.

Closes https://github.com/Automaat/sybra/issues/1337

_Generated by Sybra harness_