### PR TITLE
perf(github): skip re-poll of known-green PRs

### DIFF
--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -447,6 +447,33 @@ func FetchPRStatsContext(ctx context.Context, repo string, number int) (PRStats,
 	return s, nil
 }
 
+// FetchPRHeadState returns the head commit SHA and open/closed state of a PR.
+// Unlike FetchPRHeadSHA, it also detects a PR that was merged or closed at
+// the same head commit it had while open — a head-SHA-only probe cannot tell
+// those apart, since merging or closing a PR does not change its head SHA.
+// Deliberately uncached: callers use this to validate a cached ready-PR
+// snapshot, and caching it would reintroduce the same staleness it exists to
+// catch.
+func FetchPRHeadState(repo string, number int) (sha string, open bool, err error) {
+	return fetchPRHeadStateWith(defaultExecer, repo, number)
+}
+
+func fetchPRHeadStateWith(e execer, repo string, number int) (sha string, open bool, err error) {
+	out, err := e.run("pr", "view", strconv.Itoa(number),
+		"--repo", repo, "--json", "headRefOid,state")
+	if err != nil {
+		return "", false, fmt.Errorf("gh pr view %d head state: %s: %w", number, strings.TrimSpace(string(out)), err)
+	}
+	var raw struct {
+		HeadRefOid string `json:"headRefOid"`
+		State      string `json:"state"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return "", false, fmt.Errorf("parse pr head state: %w", err)
+	}
+	return raw.HeadRefOid, raw.State == "OPEN", nil
+}
+
 // FetchPRHeadSHAContext is a context-bounded FetchPRHeadSHA for the poll path.
 func FetchPRHeadSHAContext(ctx context.Context, repo string, number int) (string, error) {
 	out, err := ghRunCtx(ctx, "pr", "view", strconv.Itoa(number), "--repo", repo, "--json", "headRefOid")

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -447,31 +447,36 @@ func FetchPRStatsContext(ctx context.Context, repo string, number int) (PRStats,
 	return s, nil
 }
 
-// FetchPRHeadState returns the head commit SHA and open/closed state of a PR.
-// Unlike FetchPRHeadSHA, it also detects a PR that was merged or closed at
-// the same head commit it had while open — a head-SHA-only probe cannot tell
-// those apart, since merging or closing a PR does not change its head SHA.
+// FetchPRHeadState returns the head commit SHA, open/closed state, and
+// updatedAt timestamp of a PR. Unlike FetchPRHeadSHA, it also detects a PR
+// that was merged or closed at the same head commit it had while open — a
+// head-SHA-only probe cannot tell those apart, since merging or closing a PR
+// does not change its head SHA. updatedAt further detects a new review or
+// status/check event landing at the same head commit (e.g. a re-run CI
+// job failing, or a reviewer requesting changes) — GitHub bumps a PR's
+// updatedAt on any such event even without a new commit.
 // Deliberately uncached: callers use this to validate a cached ready-PR
 // snapshot, and caching it would reintroduce the same staleness it exists to
 // catch.
-func FetchPRHeadState(repo string, number int) (sha string, open bool, err error) {
+func FetchPRHeadState(repo string, number int) (sha string, open bool, updatedAt string, err error) {
 	return fetchPRHeadStateWith(defaultExecer, repo, number)
 }
 
-func fetchPRHeadStateWith(e execer, repo string, number int) (sha string, open bool, err error) {
+func fetchPRHeadStateWith(e execer, repo string, number int) (sha string, open bool, updatedAt string, err error) {
 	out, err := e.run("pr", "view", strconv.Itoa(number),
-		"--repo", repo, "--json", "headRefOid,state")
+		"--repo", repo, "--json", "headRefOid,state,updatedAt")
 	if err != nil {
-		return "", false, fmt.Errorf("gh pr view %d head state: %s: %w", number, strings.TrimSpace(string(out)), err)
+		return "", false, "", fmt.Errorf("gh pr view %d head state: %s: %w", number, strings.TrimSpace(string(out)), err)
 	}
 	var raw struct {
 		HeadRefOid string `json:"headRefOid"`
 		State      string `json:"state"`
+		UpdatedAt  string `json:"updatedAt"`
 	}
 	if err := json.Unmarshal(out, &raw); err != nil {
-		return "", false, fmt.Errorf("parse pr head state: %w", err)
+		return "", false, "", fmt.Errorf("parse pr head state: %w", err)
 	}
-	return raw.HeadRefOid, raw.State == "OPEN", nil
+	return raw.HeadRefOid, raw.State == "OPEN", raw.UpdatedAt, nil
 }
 
 // FetchPRHeadSHAContext is a context-bounded FetchPRHeadSHA for the poll path.

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -458,12 +458,16 @@ func FetchPRStatsContext(ctx context.Context, repo string, number int) (PRStats,
 // Deliberately uncached: callers use this to validate a cached ready-PR
 // snapshot, and caching it would reintroduce the same staleness it exists to
 // catch.
+// Context-bounded (10s) so a stalled probe in the poll path releases the
+// global ghGate instead of holding it for the kernel TCP timeout.
 func FetchPRHeadState(repo string, number int) (sha string, open bool, updatedAt string, err error) {
-	return fetchPRHeadStateWith(defaultExecer, repo, number)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return fetchPRHeadStateWith(ctx, defaultExecer, repo, number)
 }
 
-func fetchPRHeadStateWith(e execer, repo string, number int) (sha string, open bool, updatedAt string, err error) {
-	out, err := e.run("pr", "view", strconv.Itoa(number),
+func fetchPRHeadStateWith(ctx context.Context, e execer, repo string, number int) (sha string, open bool, updatedAt string, err error) {
+	out, err := runE(ctx, e, "pr", "view", strconv.Itoa(number),
 		"--repo", repo, "--json", "headRefOid,state,updatedAt")
 	if err != nil {
 		return "", false, "", fmt.Errorf("gh pr view %d head state: %s: %w", number, strings.TrimSpace(string(out)), err)

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -33,6 +33,22 @@ const staffCodeReviewProvider = "claude"
 
 const transientFetchWarnThreshold = 3
 
+// readyPRState is a cached "confirmed ready to merge" snapshot for a task's
+// linked PR, keyed by "repo#number". fetchKnownTaskPRs reuses it across poll
+// cycles instead of re-running the full per-PR fetch (reviews, threads,
+// status checks) once a PR has already been observed OPEN + clean +
+// checks-green + approved — as long as a cheap head-SHA-only probe confirms
+// the head commit hasn't moved. A force-push (or any other head-SHA change)
+// invalidates the entry immediately, since the cached approval/CI verdict is
+// pinned to the old commit. handleAutoMerge evicts the entry the moment it
+// acts on the PR (arm native auto-merge or attempt a squash merge), so the
+// next cycle always does a fresh fetch to observe the post-action state
+// (merged/closed, or armed) instead of replaying a stale snapshot.
+type readyPRState struct {
+	HeadSHA string
+	PR      github.PullRequest
+}
+
 // ReviewHandler manages PR review task creation, agent dispatch, and status tracking.
 type ReviewHandler struct {
 	DomainHandler
@@ -85,6 +101,13 @@ type ReviewHandler struct {
 	// search polling to the primary instance. Overridable in tests; nil falls
 	// back to github.FetchPRsForMonitor.
 	fetchKnownPRsFn func(refs []github.PRRef) []github.MonitorPRResult
+	// fetchHeadSHAFn cheaply probes a PR's current head SHA, used to validate
+	// (or invalidate) a readyPRCache entry without doing a full per-PR fetch.
+	// Overridable in tests; nil falls back to github.FetchPRHeadSHA.
+	fetchHeadSHAFn func(repo string, number int) (string, error)
+	// readyPRCache holds known-ready PR snapshots keyed by "repo#number"; see
+	// readyPRState.
+	readyPRCache map[string]readyPRState
 	// fetchReviewsFn fetches the PR review summary. Overridable in tests; nil
 	// falls back to github.FetchReviews.
 	fetchReviewsFn func() (github.ReviewSummary, error)
@@ -153,6 +176,8 @@ func newReviewHandler(
 		mergePRViaREST:      github.MergePRViaREST,
 		fetchThreads:        github.FetchReviewThreads,
 		resolveThread:       github.ResolveReviewThread,
+		fetchHeadSHAFn:      github.FetchPRHeadSHA,
+		readyPRCache:        make(map[string]readyPRState),
 		cfg:                 cfg,
 		experience:          experienceStore,
 	}
@@ -467,31 +492,64 @@ func (r *ReviewHandler) handleTaskPRIssues(taskID string, issues []github.PRIssu
 	}
 }
 
+func prRefCacheKey(repo string, number int) string {
+	return fmt.Sprintf("%s#%d", repo, number)
+}
+
+// fetchKnownTaskPRs fetches the current state of every task's linked PR. A PR
+// last observed ready-to-merge (readyPRCache) skips the full fetch as long as
+// a cheap head-SHA-only probe confirms the head commit hasn't moved since —
+// avoiding a wasted full re-poll for PRs that are green but stuck behind an
+// unrelated dispatch gate (a running agent/workflow, or prTracker cooldown).
+// A head-SHA mismatch (force-push) or a failed probe evicts the cache entry
+// and falls back to a full fetch, so a stale ready-state is never reused.
 func (r *ReviewHandler) fetchKnownTaskPRs(matchers []github.TaskMatcher) []github.PullRequest {
 	fetchFn := github.FetchPRsForMonitor
 	if r.fetchKnownPRsFn != nil {
 		fetchFn = r.fetchKnownPRsFn
 	}
+	headSHAFn := r.fetchHeadSHAFn
+	if headSHAFn == nil {
+		headSHAFn = github.FetchPRHeadSHA
+	}
+
 	refs := make([]github.PRRef, 0, len(matchers))
 	seen := make(map[string]struct{}, len(matchers))
+	prs := make([]github.PullRequest, 0, len(matchers))
 	for i := range matchers {
 		m := &matchers[i]
 		if m.ProjectID == "" || m.PRNumber == 0 {
 			continue
 		}
-		key := fmt.Sprintf("%s#%d", m.ProjectID, m.PRNumber)
+		key := prRefCacheKey(m.ProjectID, m.PRNumber)
 		if _, ok := seen[key]; ok {
 			continue
 		}
 		seen[key] = struct{}{}
+
+		if cached, ok := r.readyPRCache[key]; ok {
+			sha, err := headSHAFn(m.ProjectID, m.PRNumber)
+			if err == nil && sha != "" && sha == cached.HeadSHA {
+				prs = append(prs, cached.PR)
+				continue
+			}
+			delete(r.readyPRCache, key)
+		}
 		refs = append(refs, github.PRRef{Repo: m.ProjectID, Number: m.PRNumber})
 	}
+
+	// Drop cache entries for PRs no longer linked to a monitored task.
+	for key := range r.readyPRCache {
+		if _, ok := seen[key]; !ok {
+			delete(r.readyPRCache, key)
+		}
+	}
+
 	if len(refs) == 0 {
-		return nil
+		return prs
 	}
 
 	results := fetchFn(refs)
-	prs := make([]github.PullRequest, 0, len(results))
 	for i := range results {
 		res := &results[i]
 		if res.Err != nil {
@@ -499,11 +557,41 @@ func (r *ReviewHandler) fetchKnownTaskPRs(matchers []github.TaskMatcher) []githu
 			continue
 		}
 		if !res.Open {
+			delete(r.readyPRCache, prRefCacheKey(res.Repo, res.Number))
 			continue
 		}
 		prs = append(prs, res.PR)
+		r.updateReadyPRCache(res.Repo, res.Number, res.PR)
 	}
 	return prs
+}
+
+// updateReadyPRCache records pr as a known-ready snapshot when it satisfies
+// the auto-merge readiness gate, or evicts any stale entry otherwise. Uses
+// the strict (non-renovate-bypass) gate only: the renovate-fix relaxation in
+// handleAutoMerge depends on the task's tags, which TaskMatcher does not
+// carry, so a renovate-fix PR is simply never cached and always gets a fresh
+// fetch — under-caching a narrow case beats risking a stale merge decision.
+func (r *ReviewHandler) updateReadyPRCache(repo string, number int, pr github.PullRequest) {
+	key := prRefCacheKey(repo, number)
+	ready := pr.SourcedViaREST && readyForRESTAutoMerge(pr) || !pr.SourcedViaREST && readyForCopilotAutoMerge(pr)
+	if !ready || pr.HeadSHA == "" {
+		delete(r.readyPRCache, key)
+		return
+	}
+	if r.readyPRCache == nil {
+		r.readyPRCache = make(map[string]readyPRState)
+	}
+	r.readyPRCache[key] = readyPRState{HeadSHA: pr.HeadSHA, PR: pr}
+}
+
+// evictReadyPRCache drops a cached ready-state, forcing the next poll cycle
+// to do a full fetch. Called by handleAutoMerge the moment it acts on a PR
+// (arms native auto-merge or attempts a squash merge) since either action
+// makes the cached snapshot stale — the PR may now be merged/closed, or have
+// native auto-merge armed — and only a fresh fetch can observe that.
+func (r *ReviewHandler) evictReadyPRCache(repo string, number int) {
+	delete(r.readyPRCache, prRefCacheKey(repo, number))
 }
 
 // advanceClosedTaskPRs moves tasks whose linked PR is no longer open to done,

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -101,10 +101,11 @@ type ReviewHandler struct {
 	// search polling to the primary instance. Overridable in tests; nil falls
 	// back to github.FetchPRsForMonitor.
 	fetchKnownPRsFn func(refs []github.PRRef) []github.MonitorPRResult
-	// fetchHeadSHAFn cheaply probes a PR's current head SHA, used to validate
-	// (or invalidate) a readyPRCache entry without doing a full per-PR fetch.
-	// Overridable in tests; nil falls back to github.FetchPRHeadSHA.
-	fetchHeadSHAFn func(repo string, number int) (string, error)
+	// fetchHeadStateFn cheaply probes a PR's current head SHA and open/closed
+	// state, used to validate (or invalidate) a readyPRCache entry without
+	// doing a full per-PR fetch. Overridable in tests; nil falls back to
+	// github.FetchPRHeadState.
+	fetchHeadStateFn func(repo string, number int) (sha string, open bool, err error)
 	// readyPRCache holds known-ready PR snapshots keyed by "repo#number"; see
 	// readyPRState.
 	readyPRCache map[string]readyPRState
@@ -176,7 +177,7 @@ func newReviewHandler(
 		mergePRViaREST:      github.MergePRViaREST,
 		fetchThreads:        github.FetchReviewThreads,
 		resolveThread:       github.ResolveReviewThread,
-		fetchHeadSHAFn:      github.FetchPRHeadSHA,
+		fetchHeadStateFn:    github.FetchPRHeadState,
 		readyPRCache:        make(map[string]readyPRState),
 		cfg:                 cfg,
 		experience:          experienceStore,
@@ -498,19 +499,21 @@ func prRefCacheKey(repo string, number int) string {
 
 // fetchKnownTaskPRs fetches the current state of every task's linked PR. A PR
 // last observed ready-to-merge (readyPRCache) skips the full fetch as long as
-// a cheap head-SHA-only probe confirms the head commit hasn't moved since —
-// avoiding a wasted full re-poll for PRs that are green but stuck behind an
-// unrelated dispatch gate (a running agent/workflow, or prTracker cooldown).
-// A head-SHA mismatch (force-push) or a failed probe evicts the cache entry
-// and falls back to a full fetch, so a stale ready-state is never reused.
+// a cheap head-SHA-plus-state probe confirms the PR is still open at the same
+// head commit — avoiding a wasted full re-poll for PRs that are green but
+// stuck behind an unrelated dispatch gate (a running agent/workflow, or
+// prTracker cooldown). A head-SHA mismatch (force-push), a state other than
+// open (merged/closed, e.g. by a human outside Sybra), or a failed probe
+// evicts the cache entry and falls back to a full fetch, so a stale
+// ready-state is never reused.
 func (r *ReviewHandler) fetchKnownTaskPRs(matchers []github.TaskMatcher) []github.PullRequest {
 	fetchFn := github.FetchPRsForMonitor
 	if r.fetchKnownPRsFn != nil {
 		fetchFn = r.fetchKnownPRsFn
 	}
-	headSHAFn := r.fetchHeadSHAFn
-	if headSHAFn == nil {
-		headSHAFn = github.FetchPRHeadSHA
+	headStateFn := r.fetchHeadStateFn
+	if headStateFn == nil {
+		headStateFn = github.FetchPRHeadState
 	}
 
 	refs := make([]github.PRRef, 0, len(matchers))
@@ -528,8 +531,8 @@ func (r *ReviewHandler) fetchKnownTaskPRs(matchers []github.TaskMatcher) []githu
 		seen[key] = struct{}{}
 
 		if cached, ok := r.readyPRCache[key]; ok {
-			sha, err := headSHAFn(m.ProjectID, m.PRNumber)
-			if err == nil && sha != "" && sha == cached.HeadSHA {
+			sha, open, err := headStateFn(m.ProjectID, m.PRNumber)
+			if err == nil && open && sha != "" && sha == cached.HeadSHA {
 				prs = append(prs, cached.PR)
 				continue
 			}

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -37,16 +37,19 @@ const transientFetchWarnThreshold = 3
 // linked PR, keyed by "repo#number". fetchKnownTaskPRs reuses it across poll
 // cycles instead of re-running the full per-PR fetch (reviews, threads,
 // status checks) once a PR has already been observed OPEN + clean +
-// checks-green + approved — as long as a cheap head-SHA-only probe confirms
-// the head commit hasn't moved. A force-push (or any other head-SHA change)
-// invalidates the entry immediately, since the cached approval/CI verdict is
-// pinned to the old commit. handleAutoMerge evicts the entry the moment it
-// acts on the PR (arm native auto-merge or attempt a squash merge), so the
-// next cycle always does a fresh fetch to observe the post-action state
-// (merged/closed, or armed) instead of replaying a stale snapshot.
+// checks-green + approved — as long as a cheap probe confirms neither the
+// head commit nor the PR's updatedAt timestamp has moved. A force-push (any
+// head-SHA change) or a new review/status event at the same head (which
+// bumps updatedAt without moving the head SHA) invalidates the entry
+// immediately, since the cached approval/CI verdict is pinned to the old
+// snapshot. handleAutoMerge evicts the entry the moment it acts on the PR
+// (arm native auto-merge or attempt a squash merge), so the next cycle
+// always does a fresh fetch to observe the post-action state (merged/closed,
+// or armed) instead of replaying a stale snapshot.
 type readyPRState struct {
-	HeadSHA string
-	PR      github.PullRequest
+	HeadSHA   string
+	UpdatedAt string
+	PR        github.PullRequest
 }
 
 // ReviewHandler manages PR review task creation, agent dispatch, and status tracking.
@@ -101,11 +104,11 @@ type ReviewHandler struct {
 	// search polling to the primary instance. Overridable in tests; nil falls
 	// back to github.FetchPRsForMonitor.
 	fetchKnownPRsFn func(refs []github.PRRef) []github.MonitorPRResult
-	// fetchHeadStateFn cheaply probes a PR's current head SHA and open/closed
-	// state, used to validate (or invalidate) a readyPRCache entry without
-	// doing a full per-PR fetch. Overridable in tests; nil falls back to
-	// github.FetchPRHeadState.
-	fetchHeadStateFn func(repo string, number int) (sha string, open bool, err error)
+	// fetchHeadStateFn cheaply probes a PR's current head SHA, open/closed
+	// state, and updatedAt timestamp, used to validate (or invalidate) a
+	// readyPRCache entry without doing a full per-PR fetch. Overridable in
+	// tests; nil falls back to github.FetchPRHeadState.
+	fetchHeadStateFn func(repo string, number int) (sha string, open bool, updatedAt string, err error)
 	// readyPRCache holds known-ready PR snapshots keyed by "repo#number"; see
 	// readyPRState.
 	readyPRCache map[string]readyPRState
@@ -499,13 +502,15 @@ func prRefCacheKey(repo string, number int) string {
 
 // fetchKnownTaskPRs fetches the current state of every task's linked PR. A PR
 // last observed ready-to-merge (readyPRCache) skips the full fetch as long as
-// a cheap head-SHA-plus-state probe confirms the PR is still open at the same
-// head commit — avoiding a wasted full re-poll for PRs that are green but
-// stuck behind an unrelated dispatch gate (a running agent/workflow, or
-// prTracker cooldown). A head-SHA mismatch (force-push), a state other than
-// open (merged/closed, e.g. by a human outside Sybra), or a failed probe
-// evicts the cache entry and falls back to a full fetch, so a stale
-// ready-state is never reused.
+// a cheap head-SHA-plus-state-plus-updatedAt probe confirms the PR is still
+// open at the same head commit with no newer review/status event — avoiding
+// a wasted full re-poll for PRs that are green but stuck behind an unrelated
+// dispatch gate (a running agent/workflow, or prTracker cooldown). A
+// head-SHA mismatch (force-push), a state other than open (merged/closed,
+// e.g. by a human outside Sybra), an updatedAt change (a new review or
+// status/check event at the same head, e.g. a re-run CI job failing), or a
+// failed probe evicts the cache entry and falls back to a full fetch, so a
+// stale ready-state is never reused.
 func (r *ReviewHandler) fetchKnownTaskPRs(matchers []github.TaskMatcher) []github.PullRequest {
 	fetchFn := github.FetchPRsForMonitor
 	if r.fetchKnownPRsFn != nil {
@@ -531,8 +536,8 @@ func (r *ReviewHandler) fetchKnownTaskPRs(matchers []github.TaskMatcher) []githu
 		seen[key] = struct{}{}
 
 		if cached, ok := r.readyPRCache[key]; ok {
-			sha, open, err := headStateFn(m.ProjectID, m.PRNumber)
-			if err == nil && open && sha != "" && sha == cached.HeadSHA {
+			sha, open, updatedAt, err := headStateFn(m.ProjectID, m.PRNumber)
+			if err == nil && open && sha != "" && sha == cached.HeadSHA && updatedAt == cached.UpdatedAt {
 				prs = append(prs, cached.PR)
 				continue
 			}
@@ -585,7 +590,7 @@ func (r *ReviewHandler) updateReadyPRCache(repo string, number int, pr github.Pu
 	if r.readyPRCache == nil {
 		r.readyPRCache = make(map[string]readyPRState)
 	}
-	r.readyPRCache[key] = readyPRState{HeadSHA: pr.HeadSHA, PR: pr}
+	r.readyPRCache[key] = readyPRState{HeadSHA: pr.HeadSHA, UpdatedAt: pr.UpdatedAt, PR: pr}
 }
 
 // evictReadyPRCache drops a cached ready-state, forcing the next poll cycle

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -131,6 +131,7 @@ func (r *ReviewHandler) handleAutoMerge(issue github.PRIssue) {
 			if aerr := enableFn(issue.PR.Repository, issue.PR.Number); aerr != nil {
 				r.logger.Error("auto-merge.native-arm-failed", "task_id", t.ID, "pr", issue.PR.Number, "err", aerr)
 			} else {
+				r.evictReadyPRCache(issue.PR.Repository, issue.PR.Number)
 				r.prTracker.MarkHandled(t.ID, issue.Kind, issue.PR.HeadSHA)
 				r.logAudit(audit.EventAutoMergeEnabled, t.ID, "", map[string]any{
 					"pr": issue.PR.Number, "repo": issue.PR.Repository,
@@ -183,6 +184,7 @@ func (r *ReviewHandler) handleAutoMerge(issue github.PRIssue) {
 		}
 		mergeErr = merge(issue.PR.Repository, issue.PR.Number)
 	}
+	r.evictReadyPRCache(issue.PR.Repository, issue.PR.Number)
 	if mergeErr != nil {
 		r.logger.Error("auto-merge.failed", "task_id", t.ID, "pr", issue.PR.Number, "err", mergeErr)
 		return

--- a/internal/sybra/app_reviews_readycache_test.go
+++ b/internal/sybra/app_reviews_readycache_test.go
@@ -33,8 +33,8 @@ func TestFetchKnownTaskPRs_SkipsFullFetchForKnownReadyPR(t *testing.T) {
 			}
 			return results
 		},
-		fetchHeadSHAFn: func(repo string, number int) (string, error) {
-			return "sha50", nil
+		fetchHeadStateFn: func(repo string, number int) (string, bool, error) {
+			return "sha50", true, nil
 		},
 	}
 
@@ -88,8 +88,8 @@ func TestFetchKnownTaskPRs_ForcePushInvalidatesReadyCache(t *testing.T) {
 			}
 			return results
 		},
-		fetchHeadSHAFn: func(repo string, number int) (string, error) {
-			return currentHeadSHA, nil
+		fetchHeadStateFn: func(repo string, number int) (string, bool, error) {
+			return currentHeadSHA, true, nil
 		},
 	}
 
@@ -126,6 +126,58 @@ func TestFetchKnownTaskPRs_ForcePushInvalidatesReadyCache(t *testing.T) {
 	}
 	if len(third) != 1 {
 		t.Fatalf("third cycle: got %+v", third)
+	}
+}
+
+// TestFetchKnownTaskPRs_ClosedAtSameHeadInvalidatesReadyCache verifies that a
+// PR merged or closed externally (e.g. by a human outside Sybra) at the exact
+// same head SHA it had while cached as ready is not replayed as still open.
+// A head-SHA-only probe cannot distinguish this from "still open and ready"
+// since merging/closing a PR does not change its head commit — the probe
+// must also check state, or advanceClosedTaskPRs would never see the PR as
+// closed and the task would be stuck in review forever.
+func TestFetchKnownTaskPRs_ClosedAtSameHeadInvalidatesReadyCache(t *testing.T) {
+	readyPR := github.PullRequest{
+		Repository: "pet-owner/pet-repo", Number: 50, HeadSHA: "sha50",
+		Mergeable:      "MERGEABLE",
+		SourcedViaREST: true, RESTMergeableState: "clean", RESTCIFetched: true,
+		CIStatus: "SUCCESS", RESTApproved: true,
+	}
+
+	fullFetches := 0
+	r := &ReviewHandler{
+		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
+		fetchKnownPRsFn: func(refs []github.PRRef) []github.MonitorPRResult {
+			fullFetches++
+			results := make([]github.MonitorPRResult, len(refs))
+			for i, ref := range refs {
+				// The PR was merged externally: same head SHA, but no longer open.
+				results[i] = github.MonitorPRResult{Repo: ref.Repo, Number: ref.Number, Open: false, PR: readyPR}
+			}
+			return results
+		},
+		// The cheap probe reports the same head SHA but a closed state — this is
+		// exactly what `gh pr view` returns for a PR merged/closed without a
+		// subsequent push.
+		fetchHeadStateFn: func(repo string, number int) (string, bool, error) {
+			return "sha50", false, nil
+		},
+		readyPRCache: map[string]readyPRState{
+			"pet-owner/pet-repo#50": {HeadSHA: "sha50", PR: readyPR},
+		},
+	}
+
+	matchers := []github.TaskMatcher{{ID: "t1", PRNumber: 50, ProjectID: "pet-owner/pet-repo"}}
+
+	got := r.fetchKnownTaskPRs(matchers)
+	if len(got) != 0 {
+		t.Fatalf("got %+v, want no open PRs (the cached PR is now closed)", got)
+	}
+	if fullFetches != 1 {
+		t.Fatalf("full fetches = %d, want 1 (closed state must force a full fetch, not reuse the cache)", fullFetches)
+	}
+	if _, ok := r.readyPRCache["pet-owner/pet-repo#50"]; ok {
+		t.Fatal("readyPRCache entry must be evicted once the cheap probe reports the PR is no longer open")
 	}
 }
 

--- a/internal/sybra/app_reviews_readycache_test.go
+++ b/internal/sybra/app_reviews_readycache_test.go
@@ -19,7 +19,7 @@ func TestFetchKnownTaskPRs_SkipsFullFetchForKnownReadyPR(t *testing.T) {
 		Repository: "pet-owner/pet-repo", Number: 50, HeadSHA: "sha50",
 		Mergeable:      "MERGEABLE",
 		SourcedViaREST: true, RESTMergeableState: "clean", RESTCIFetched: true,
-		CIStatus: "SUCCESS", RESTApproved: true,
+		CIStatus: "SUCCESS", RESTApproved: true, UpdatedAt: "2026-07-02T10:00:00Z",
 	}
 
 	fullFetches := 0
@@ -33,8 +33,8 @@ func TestFetchKnownTaskPRs_SkipsFullFetchForKnownReadyPR(t *testing.T) {
 			}
 			return results
 		},
-		fetchHeadStateFn: func(repo string, number int) (string, bool, error) {
-			return "sha50", true, nil
+		fetchHeadStateFn: func(repo string, number int) (string, bool, string, error) {
+			return "sha50", true, "2026-07-02T10:00:00Z", nil
 		},
 	}
 
@@ -65,15 +65,17 @@ func TestFetchKnownTaskPRs_ForcePushInvalidatesReadyCache(t *testing.T) {
 		Repository: "pet-owner/pet-repo", Number: 50, HeadSHA: "sha50",
 		Mergeable:      "MERGEABLE",
 		SourcedViaREST: true, RESTMergeableState: "clean", RESTCIFetched: true,
-		CIStatus: "SUCCESS", RESTApproved: true,
+		CIStatus: "SUCCESS", RESTApproved: true, UpdatedAt: "2026-07-02T10:00:00Z",
 	}
 	// After the force-push, the new head is no longer approved/clean.
 	forcedPushedPR := readyPR
 	forcedPushedPR.HeadSHA = "sha-forced"
 	forcedPushedPR.RESTApproved = false
+	forcedPushedPR.UpdatedAt = "2026-07-02T11:00:00Z"
 
 	fullFetches := 0
 	currentHeadSHA := "sha50"
+	currentUpdatedAt := "2026-07-02T10:00:00Z"
 	r := &ReviewHandler{
 		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
 		fetchKnownPRsFn: func(refs []github.PRRef) []github.MonitorPRResult {
@@ -88,8 +90,8 @@ func TestFetchKnownTaskPRs_ForcePushInvalidatesReadyCache(t *testing.T) {
 			}
 			return results
 		},
-		fetchHeadStateFn: func(repo string, number int) (string, bool, error) {
-			return currentHeadSHA, true, nil
+		fetchHeadStateFn: func(repo string, number int) (string, bool, string, error) {
+			return currentHeadSHA, true, currentUpdatedAt, nil
 		},
 	}
 
@@ -104,6 +106,7 @@ func TestFetchKnownTaskPRs_ForcePushInvalidatesReadyCache(t *testing.T) {
 
 	// Simulate a force-push: the head SHA moves and the cheap probe observes it.
 	currentHeadSHA = "sha-forced"
+	currentUpdatedAt = "2026-07-02T11:00:00Z"
 
 	got := r.fetchKnownTaskPRs(matchers)
 	if len(got) != 1 || got[0].HeadSHA != "sha-forced" {
@@ -141,7 +144,7 @@ func TestFetchKnownTaskPRs_ClosedAtSameHeadInvalidatesReadyCache(t *testing.T) {
 		Repository: "pet-owner/pet-repo", Number: 50, HeadSHA: "sha50",
 		Mergeable:      "MERGEABLE",
 		SourcedViaREST: true, RESTMergeableState: "clean", RESTCIFetched: true,
-		CIStatus: "SUCCESS", RESTApproved: true,
+		CIStatus: "SUCCESS", RESTApproved: true, UpdatedAt: "2026-07-02T10:00:00Z",
 	}
 
 	fullFetches := 0
@@ -159,11 +162,11 @@ func TestFetchKnownTaskPRs_ClosedAtSameHeadInvalidatesReadyCache(t *testing.T) {
 		// The cheap probe reports the same head SHA but a closed state — this is
 		// exactly what `gh pr view` returns for a PR merged/closed without a
 		// subsequent push.
-		fetchHeadStateFn: func(repo string, number int) (string, bool, error) {
-			return "sha50", false, nil
+		fetchHeadStateFn: func(repo string, number int) (string, bool, string, error) {
+			return "sha50", false, "2026-07-02T10:00:00Z", nil
 		},
 		readyPRCache: map[string]readyPRState{
-			"pet-owner/pet-repo#50": {HeadSHA: "sha50", PR: readyPR},
+			"pet-owner/pet-repo#50": {HeadSHA: "sha50", UpdatedAt: "2026-07-02T10:00:00Z", PR: readyPR},
 		},
 	}
 
@@ -178,6 +181,74 @@ func TestFetchKnownTaskPRs_ClosedAtSameHeadInvalidatesReadyCache(t *testing.T) {
 	}
 	if _, ok := r.readyPRCache["pet-owner/pet-repo#50"]; ok {
 		t.Fatal("readyPRCache entry must be evicted once the cheap probe reports the PR is no longer open")
+	}
+}
+
+// TestFetchKnownTaskPRs_StatusEventInvalidatesReadyCacheAtSameHead verifies
+// that a new CI/status or review event at the exact same head SHA the PR had
+// while cached as ready forces a full re-fetch instead of replaying the
+// stale "green" snapshot. A head-SHA-only probe cannot see this: re-running
+// (or newly failing) a check, or a reviewer leaving a fresh review, does not
+// move the head commit, but GitHub bumps the PR's updatedAt on both — the
+// probe must compare updatedAt too, or a PR that regresses to failing CI
+// after being cached ready would be merged anyway.
+func TestFetchKnownTaskPRs_StatusEventInvalidatesReadyCacheAtSameHead(t *testing.T) {
+	readyPR := github.PullRequest{
+		Repository: "pet-owner/pet-repo", Number: 50, HeadSHA: "sha50",
+		Mergeable:      "MERGEABLE",
+		SourcedViaREST: true, RESTMergeableState: "clean", RESTCIFetched: true,
+		CIStatus: "SUCCESS", RESTApproved: true, UpdatedAt: "2026-07-02T10:00:00Z",
+	}
+	// A later CI re-run fails at the same head SHA; GitHub bumps updatedAt.
+	failedCIPR := readyPR
+	failedCIPR.CIStatus = "FAILURE"
+	failedCIPR.UpdatedAt = "2026-07-02T11:00:00Z"
+
+	fullFetches := 0
+	currentUpdatedAt := "2026-07-02T10:00:00Z"
+	r := &ReviewHandler{
+		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
+		fetchKnownPRsFn: func(refs []github.PRRef) []github.MonitorPRResult {
+			fullFetches++
+			results := make([]github.MonitorPRResult, len(refs))
+			for i, ref := range refs {
+				pr := readyPR
+				if currentUpdatedAt == failedCIPR.UpdatedAt {
+					pr = failedCIPR
+				}
+				results[i] = github.MonitorPRResult{Repo: ref.Repo, Number: ref.Number, Open: true, PR: pr}
+			}
+			return results
+		},
+		// The cheap probe reports the same head SHA and open state, but the
+		// updatedAt timestamp has moved — exactly what `gh pr view` returns
+		// after a same-head status/review event.
+		fetchHeadStateFn: func(repo string, number int) (string, bool, string, error) {
+			return "sha50", true, currentUpdatedAt, nil
+		},
+	}
+
+	matchers := []github.TaskMatcher{{ID: "t1", PRNumber: 50, ProjectID: "pet-owner/pet-repo"}}
+
+	if got := r.fetchKnownTaskPRs(matchers); len(got) != 1 || got[0].CIStatus != "SUCCESS" {
+		t.Fatalf("first cycle: got %+v, want cached ready PR", got)
+	}
+	if fullFetches != 1 {
+		t.Fatalf("full fetches after first cycle = %d, want 1", fullFetches)
+	}
+
+	// Simulate a same-head CI/status event: updatedAt moves, head SHA doesn't.
+	currentUpdatedAt = failedCIPR.UpdatedAt
+
+	got := r.fetchKnownTaskPRs(matchers)
+	if fullFetches != 2 {
+		t.Fatalf("full fetches after same-head status event = %d, want 2 (updatedAt change must invalidate the cache)", fullFetches)
+	}
+	if len(got) != 1 || got[0].CIStatus != "FAILURE" {
+		t.Fatalf("second cycle: got %+v, want fresh failed-CI snapshot, not the stale cached green one", got)
+	}
+	if _, ok := r.readyPRCache["pet-owner/pet-repo#50"]; ok {
+		t.Fatal("readyPRCache must not cache a no-longer-ready (CI failed) snapshot")
 	}
 }
 
@@ -213,7 +284,7 @@ func TestHandleAutoMerge_EvictsReadyCache(t *testing.T) {
 	pr := github.PullRequest{
 		Repository: "pet-owner/pet-repo", Number: 50, HeadSHA: "sha50",
 		SourcedViaREST: true, RESTMergeableState: "clean", RESTCIFetched: true,
-		CIStatus: "SUCCESS", RESTApproved: true,
+		CIStatus: "SUCCESS", RESTApproved: true, UpdatedAt: "2026-07-02T10:00:00Z",
 	}
 
 	r := &ReviewHandler{
@@ -225,7 +296,7 @@ func TestHandleAutoMerge_EvictsReadyCache(t *testing.T) {
 			return nil
 		},
 		readyPRCache: map[string]readyPRState{
-			"pet-owner/pet-repo#50": {HeadSHA: "sha50", PR: pr},
+			"pet-owner/pet-repo#50": {HeadSHA: "sha50", UpdatedAt: "2026-07-02T10:00:00Z", PR: pr},
 		},
 	}
 

--- a/internal/sybra/app_reviews_readycache_test.go
+++ b/internal/sybra/app_reviews_readycache_test.go
@@ -1,0 +1,185 @@
+package sybra
+
+import (
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// TestFetchKnownTaskPRs_SkipsFullFetchForKnownReadyPR verifies that once a PR
+// has been observed ready-to-merge (REST-sourced clean+approved+green), a
+// later poll cycle for the same, unmoved head SHA reuses the cached snapshot
+// instead of issuing another full per-PR fetch.
+func TestFetchKnownTaskPRs_SkipsFullFetchForKnownReadyPR(t *testing.T) {
+	readyPR := github.PullRequest{
+		Repository: "pet-owner/pet-repo", Number: 50, HeadSHA: "sha50",
+		Mergeable:      "MERGEABLE",
+		SourcedViaREST: true, RESTMergeableState: "clean", RESTCIFetched: true,
+		CIStatus: "SUCCESS", RESTApproved: true,
+	}
+
+	fullFetches := 0
+	r := &ReviewHandler{
+		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
+		fetchKnownPRsFn: func(refs []github.PRRef) []github.MonitorPRResult {
+			fullFetches++
+			results := make([]github.MonitorPRResult, len(refs))
+			for i, ref := range refs {
+				results[i] = github.MonitorPRResult{Repo: ref.Repo, Number: ref.Number, Open: true, PR: readyPR}
+			}
+			return results
+		},
+		fetchHeadSHAFn: func(repo string, number int) (string, error) {
+			return "sha50", nil
+		},
+	}
+
+	matchers := []github.TaskMatcher{{ID: "t1", PRNumber: 50, ProjectID: "pet-owner/pet-repo"}}
+
+	first := r.fetchKnownTaskPRs(matchers)
+	if len(first) != 1 || first[0].Number != 50 {
+		t.Fatalf("first cycle: got %+v, want [readyPR]", first)
+	}
+	if fullFetches != 1 {
+		t.Fatalf("full fetches after first cycle = %d, want 1", fullFetches)
+	}
+
+	second := r.fetchKnownTaskPRs(matchers)
+	if len(second) != 1 || second[0].Number != 50 {
+		t.Fatalf("second cycle: got %+v, want [readyPR]", second)
+	}
+	if fullFetches != 1 {
+		t.Fatalf("full fetches after second cycle = %d, want still 1 (cache should have skipped it)", fullFetches)
+	}
+}
+
+// TestFetchKnownTaskPRs_ForcePushInvalidatesReadyCache verifies that a head
+// SHA change (force-push) between cycles evicts the cached ready-state and
+// forces a full re-fetch instead of trusting the stale approval/CI verdict.
+func TestFetchKnownTaskPRs_ForcePushInvalidatesReadyCache(t *testing.T) {
+	readyPR := github.PullRequest{
+		Repository: "pet-owner/pet-repo", Number: 50, HeadSHA: "sha50",
+		Mergeable:      "MERGEABLE",
+		SourcedViaREST: true, RESTMergeableState: "clean", RESTCIFetched: true,
+		CIStatus: "SUCCESS", RESTApproved: true,
+	}
+	// After the force-push, the new head is no longer approved/clean.
+	forcedPushedPR := readyPR
+	forcedPushedPR.HeadSHA = "sha-forced"
+	forcedPushedPR.RESTApproved = false
+
+	fullFetches := 0
+	currentHeadSHA := "sha50"
+	r := &ReviewHandler{
+		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
+		fetchKnownPRsFn: func(refs []github.PRRef) []github.MonitorPRResult {
+			fullFetches++
+			results := make([]github.MonitorPRResult, len(refs))
+			for i, ref := range refs {
+				pr := readyPR
+				if currentHeadSHA == "sha-forced" {
+					pr = forcedPushedPR
+				}
+				results[i] = github.MonitorPRResult{Repo: ref.Repo, Number: ref.Number, Open: true, PR: pr}
+			}
+			return results
+		},
+		fetchHeadSHAFn: func(repo string, number int) (string, error) {
+			return currentHeadSHA, nil
+		},
+	}
+
+	matchers := []github.TaskMatcher{{ID: "t1", PRNumber: 50, ProjectID: "pet-owner/pet-repo"}}
+
+	if got := r.fetchKnownTaskPRs(matchers); len(got) != 1 || got[0].HeadSHA != "sha50" {
+		t.Fatalf("first cycle: got %+v", got)
+	}
+	if fullFetches != 1 {
+		t.Fatalf("full fetches after first cycle = %d, want 1", fullFetches)
+	}
+
+	// Simulate a force-push: the head SHA moves and the cheap probe observes it.
+	currentHeadSHA = "sha-forced"
+
+	got := r.fetchKnownTaskPRs(matchers)
+	if len(got) != 1 || got[0].HeadSHA != "sha-forced" {
+		t.Fatalf("second cycle: got %+v, want fresh forced-push snapshot", got)
+	}
+	if fullFetches != 2 {
+		t.Fatalf("full fetches after second cycle = %d, want 2 (force-push must invalidate the cache)", fullFetches)
+	}
+	if got[0].RESTApproved {
+		t.Fatal("stale approval must not survive a force-push")
+	}
+
+	// A third cycle at the same (unmoved) new head SHA should again skip the
+	// full fetch — but only if the new state was itself ready; here it isn't
+	// (RESTApproved=false), so the cache should stay empty and every
+	// subsequent cycle keeps re-fetching until re-approved.
+	third := r.fetchKnownTaskPRs(matchers)
+	if fullFetches != 3 {
+		t.Fatalf("full fetches after third cycle = %d, want 3 (not-ready state must never be cached)", fullFetches)
+	}
+	if len(third) != 1 {
+		t.Fatalf("third cycle: got %+v", third)
+	}
+}
+
+// TestHandleAutoMerge_EvictsReadyCache verifies that a successful merge
+// evicts the PR's readyPRCache entry, so the next poll cycle does a fresh
+// fetch instead of replaying a stale "still open and ready" snapshot for a
+// PR that is now actually merged and closed.
+func TestHandleAutoMerge_EvictsReadyCache(t *testing.T) {
+	projDir := t.TempDir()
+	projStore, err := project.NewStore(projDir, t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	mustWriteProjectYAML(t, projDir, "pet-owner/pet-repo", project.ProjectTypePet)
+
+	taskStore, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
+	if err != nil {
+		t.Fatalf("task NewStore: %v", err)
+	}
+	tasks := task.NewManager(taskStore, nil)
+	created, err := tasks.Create("ship it", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:    task.Ptr(task.StatusInReview),
+		PRNumber:  task.Ptr(50),
+		ProjectID: task.Ptr("pet-owner/pet-repo"),
+	}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	pr := github.PullRequest{
+		Repository: "pet-owner/pet-repo", Number: 50, HeadSHA: "sha50",
+		SourcedViaREST: true, RESTMergeableState: "clean", RESTCIFetched: true,
+		CIStatus: "SUCCESS", RESTApproved: true,
+	}
+
+	r := &ReviewHandler{
+		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
+		tasks:         tasks,
+		projects:      projStore,
+		prTracker:     github.NewIssueTracker(0),
+		mergePRViaREST: func(repo string, number int, headSHA string) error {
+			return nil
+		},
+		readyPRCache: map[string]readyPRState{
+			"pet-owner/pet-repo#50": {HeadSHA: "sha50", PR: pr},
+		},
+	}
+
+	r.handleAutoMerge(github.PRIssue{Kind: github.PRIssueReadyToMerge, TaskID: created.ID, PR: pr})
+
+	if _, ok := r.readyPRCache["pet-owner/pet-repo#50"]; ok {
+		t.Fatal("readyPRCache entry must be evicted after a merge attempt")
+	}
+}


### PR DESCRIPTION
## Motivation

The GitHub monitor poll cycle did a full per-PR fetch every cycle even for
PRs stuck behind an unrelated dispatch gate (running agent, active workflow,
tracker cooldown), wasting rate-limited API budget on PRs whose state hadn't
changed.

## Implementation information

- Cache a task PR's confirmed-ready snapshot once it's OPEN + clean +
  checks-green + approved, keyed by `repo#number`. The next poll cycle does a
  cheap head-SHA-only probe instead of a full per-PR fetch; a matching SHA
  reuses the cached snapshot, a mismatch (force-push) or failed probe evicts
  it and falls back to a full fetch.
- `handleAutoMerge` evicts the cache entry the moment it acts on a PR (arms
  native auto-merge or attempts a squash merge) so the next cycle always
  observes fresh state instead of replaying a stale snapshot after the PR
  has actually merged.
- The cheap probe also checked open state only, so a PR merged/closed
  externally at the same head was replayed as still-open forever, blocking
  task completion — fixed to evict on state mismatch too.
- `FetchPRHeadState` now also returns the PR's `updatedAt`, which GitHub
  bumps on any review/status/check event even without a new commit;
  `fetchKnownTaskPRs` compares it against the cached value and falls back to
  a full fetch on mismatch, so a CI re-run or new review at the same head
  commit no longer replays a stale "ready" snapshot.

Closes https://github.com/Automaat/sybra/issues/1340

_Generated by Sybra harness_