### PR TITLE
fix(worktree): serialize git ops on bare repo

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -211,10 +211,14 @@ func TrackedFilesAtDefaultBranch(barePath string) ([]string, error) {
 }
 
 func FetchOrigin(barePath string) error {
-	// Explicit refspec heals bare repos cloned before remote.origin.fetch was
-	// configured, where `git fetch origin` silently skipped updating
-	// refs/remotes/origin/*.
-	return runBare(barePath, "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*")
+	return withBareRepoLock(barePath, func() error {
+		return withLockRetry(func() error {
+			// Explicit refspec heals bare repos cloned before remote.origin.fetch
+			// was configured, where `git fetch origin` silently skipped updating
+			// refs/remotes/origin/*.
+			return runBare(barePath, "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*")
+		})
+	})
 }
 
 // FetchPRHead fetches a pull request's head commit into a stable local ref and
@@ -228,7 +232,12 @@ func FetchPRHead(barePath string, prNumber int) (string, error) {
 	// refs/remotes/origin/pr/<N>) cannot collide with the fetched PR head.
 	localRef := fmt.Sprintf("refs/sybra/pr/%d", prNumber)
 	refspec := fmt.Sprintf("+refs/pull/%d/head:%s", prNumber, localRef)
-	if err := runBare(barePath, "fetch", "origin", refspec); err != nil {
+	err := withBareRepoLock(barePath, func() error {
+		return withLockRetry(func() error {
+			return runBare(barePath, "fetch", "origin", refspec)
+		})
+	})
+	if err != nil {
 		return "", err
 	}
 	return localRef, nil
@@ -242,31 +251,37 @@ func FetchPRHead(barePath string, prNumber int) (string, error) {
 // never updates refs/heads/* after the initial clone, so FetchOrigin alone cannot
 // make head mode reflect current remote state.
 func SyncLocalBranch(barePath, branch string) error {
-	localRef := "refs/heads/" + branch
-	remoteRef := "refs/remotes/origin/" + branch
+	return withBareRepoLock(barePath, func() error {
+		localRef := "refs/heads/" + branch
+		remoteRef := "refs/remotes/origin/" + branch
 
-	remoteSHA, remoteOK := resolveRef(barePath, remoteRef)
-	if !remoteOK {
-		return nil // remote ref absent, nothing to sync
-	}
+		remoteSHA, remoteOK := resolveRef(barePath, remoteRef)
+		if !remoteOK {
+			return nil // remote ref absent, nothing to sync
+		}
 
-	localSHA, localOK := resolveRef(barePath, localRef)
-	if !localOK {
-		// local branch absent — create it at the remote SHA
-		return runBare(barePath, "update-ref", localRef, remoteSHA)
-	}
+		localSHA, localOK := resolveRef(barePath, localRef)
+		if !localOK {
+			// local branch absent — create it at the remote SHA
+			return withLockRetry(func() error {
+				return runBare(barePath, "update-ref", localRef, remoteSHA)
+			})
+		}
 
-	if localSHA == remoteSHA {
+		if localSHA == remoteSHA {
+			return nil
+		}
+
+		// Fast-forward only: advance local if it is a strict ancestor of remote.
+		// merge-base --is-ancestor exits 0 when local IS an ancestor; exits 1 when not.
+		if runBare(barePath, "merge-base", "--is-ancestor", localSHA, remoteSHA) == nil {
+			return withLockRetry(func() error {
+				return runBare(barePath, "update-ref", localRef, remoteSHA)
+			})
+		}
+		// local is not an ancestor (has local-only or diverged commits) — preserve
 		return nil
-	}
-
-	// Fast-forward only: advance local if it is a strict ancestor of remote.
-	// merge-base --is-ancestor exits 0 when local IS an ancestor; exits 1 when not.
-	if runBare(barePath, "merge-base", "--is-ancestor", localSHA, remoteSHA) == nil {
-		return runBare(barePath, "update-ref", localRef, remoteSHA)
-	}
-	// local is not an ancestor (has local-only or diverged commits) — preserve
-	return nil
+	})
 }
 
 // resolveRef resolves a git ref in the bare repo. Returns ("", false) if the
@@ -393,12 +408,20 @@ func rebaseStateDir(wtPath string) string {
 }
 
 func CreateWorktree(barePath, worktreePath, branch, baseBranch string) error {
-	return runBare(barePath, "worktree", "add", worktreePath, "-b", branch, baseBranch)
+	return withBareRepoLock(barePath, func() error {
+		return withLockRetry(func() error {
+			return runBare(barePath, "worktree", "add", worktreePath, "-b", branch, baseBranch)
+		})
+	})
 }
 
 // CreateWorktreeExisting checks out an existing branch into a new worktree.
 func CreateWorktreeExisting(barePath, worktreePath, branch string) error {
-	return runBare(barePath, "worktree", "add", worktreePath, branch)
+	return withBareRepoLock(barePath, func() error {
+		return withLockRetry(func() error {
+			return runBare(barePath, "worktree", "add", worktreePath, branch)
+		})
+	})
 }
 
 // BranchExists reports whether a local branch exists in the repo.
@@ -417,7 +440,11 @@ func RefExists(barePath, ref string) bool {
 // CreateWorktreeDetached creates a worktree in detached HEAD mode from a remote ref.
 // Used for read-only checkouts like code reviews.
 func CreateWorktreeDetached(barePath, worktreePath, ref string) error {
-	return runBare(barePath, "worktree", "add", "--detach", worktreePath, ref)
+	return withBareRepoLock(barePath, func() error {
+		return withLockRetry(func() error {
+			return runBare(barePath, "worktree", "add", "--detach", worktreePath, ref)
+		})
+	})
 }
 
 func ListWorktrees(barePath string) ([]Worktree, error) {
@@ -692,12 +719,20 @@ func PushSync(worktreePath, branch string) error {
 }
 
 func RemoveWorktree(barePath, worktreePath string) error {
-	return runBare(barePath, "worktree", "remove", "--force", worktreePath)
+	return withBareRepoLock(barePath, func() error {
+		return withLockRetry(func() error {
+			return runBare(barePath, "worktree", "remove", "--force", worktreePath)
+		})
+	})
 }
 
 // PruneWorktrees removes stale worktree admin entries from the bare repo.
 func PruneWorktrees(barePath string) error {
-	return runBare(barePath, "worktree", "prune")
+	return withBareRepoLock(barePath, func() error {
+		return withLockRetry(func() error {
+			return runBare(barePath, "worktree", "prune")
+		})
+	})
 }
 
 // WorktreeHealthy reports whether a checked-out worktree's git metadata is
@@ -713,7 +748,11 @@ func WorktreeHealthy(worktreePath string) bool {
 // rewrites the absolute path back-pointers in every checked-out worktree's
 // .git file and the bare's worktrees/<id>/gitdir file. Idempotent.
 func RepairWorktrees(barePath string) error {
-	return runBare(barePath, "worktree", "repair")
+	return withBareRepoLock(barePath, func() error {
+		return withLockRetry(func() error {
+			return runBare(barePath, "worktree", "repair")
+		})
+	})
 }
 
 // RebaseOnto rebases the worktree's current branch onto the given ref.

--- a/internal/project/git_lock.go
+++ b/internal/project/git_lock.go
@@ -1,0 +1,64 @@
+package project
+
+import (
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// bareRepoLocks serializes git mutations against a single bare clone within
+// this process. When N task worktrees are prepared concurrently off the same
+// bare repo, their fetch/worktree-add/prune calls otherwise race on the
+// repo's shared lock files (e.g. .git/index.lock, ref locks). Keyed by the
+// cleaned clone path so callers passing equivalent-but-differently-formatted
+// paths still serialize against each other.
+var bareRepoLocks sync.Map // map[string]*sync.Mutex
+
+// withBareRepoLock runs fn while holding the mutex for barePath, blocking
+// concurrent git mutations against the same bare clone from other goroutines
+// in this process. It does not protect against another OS process (e.g. a
+// second Sybra instance) touching the same clone — see gitOpRetryBackoffs for
+// that cross-process safety net.
+func withBareRepoLock(barePath string, fn func() error) error {
+	key := filepath.Clean(barePath)
+	v, _ := bareRepoLocks.LoadOrStore(key, &sync.Mutex{})
+	mu, ok := v.(*sync.Mutex)
+	if !ok {
+		// Unreachable: bareRepoLocks only ever stores *sync.Mutex values.
+		mu = &sync.Mutex{}
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	return fn()
+}
+
+// gitOpRetryBackoffs bounds retries for bare-repo git mutations that hit a
+// transient lock file left by a concurrent process touching the same bare
+// clone (e.g. .git/index.lock, a ref lock, or a worktree admin lock). The
+// in-process mutex above serializes same-process callers; this retry is the
+// backstop for cross-process races — e.g. a desktop app and a server instance
+// both preparing worktrees against one shared bare clone. Indirected for
+// tests.
+var (
+	gitOpRetryBackoffs = []time.Duration{200 * time.Millisecond, 500 * time.Millisecond, 1 * time.Second}
+	gitOpRetrySleep    = time.Sleep
+)
+
+// isLockContention reports whether err looks like a transient git lock-file
+// failure ("Unable to create '.../index.lock': File exists.", or similar for
+// ref/worktree admin locks) rather than a genuine, non-retriable failure.
+func isLockContention(err error) bool {
+	return err != nil && strings.Contains(err.Error(), ".lock")
+}
+
+// withLockRetry runs fn, retrying on gitOpRetryBackoffs when the failure looks
+// like lock contention. Non-lock errors return immediately without retrying.
+func withLockRetry(fn func() error) error {
+	err := fn()
+	for attempt := 0; attempt < len(gitOpRetryBackoffs) && isLockContention(err); attempt++ {
+		gitOpRetrySleep(gitOpRetryBackoffs[attempt])
+		err = fn()
+	}
+	return err
+}

--- a/internal/project/git_lock.go
+++ b/internal/project/git_lock.go
@@ -47,9 +47,14 @@ var (
 
 // isLockContention reports whether err looks like a transient git lock-file
 // failure ("Unable to create '.../index.lock': File exists.", or similar for
-// ref/worktree admin locks) rather than a genuine, non-retriable failure.
+// ref/worktree admin locks) rather than a genuine, non-retriable failure such
+// as a permission error on the lock file itself.
 func isLockContention(err error) bool {
-	return err != nil && strings.Contains(err.Error(), ".lock")
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, ".lock") && strings.Contains(msg, "File exists")
 }
 
 // withLockRetry runs fn, retrying on gitOpRetryBackoffs when the failure looks

--- a/internal/project/git_lock_test.go
+++ b/internal/project/git_lock_test.go
@@ -1,0 +1,194 @@
+package project
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWithBareRepoLock_SerializesSameClonePath(t *testing.T) {
+	t.Parallel()
+	bare := filepath.Join(t.TempDir(), "bare.git")
+
+	var (
+		mu          sync.Mutex
+		inFlight    int
+		maxInFlight int
+		wg          sync.WaitGroup
+	)
+	enter := func() {
+		mu.Lock()
+		inFlight++
+		if inFlight > maxInFlight {
+			maxInFlight = inFlight
+		}
+		mu.Unlock()
+	}
+	leave := func() {
+		mu.Lock()
+		inFlight--
+		mu.Unlock()
+	}
+
+	for range 8 {
+		wg.Go(func() {
+			_ = withBareRepoLock(bare, func() error {
+				enter()
+				time.Sleep(5 * time.Millisecond)
+				leave()
+				return nil
+			})
+		})
+	}
+	wg.Wait()
+
+	if maxInFlight != 1 {
+		t.Errorf("max concurrent holders of the same clone path = %d, want 1", maxInFlight)
+	}
+}
+
+func TestWithBareRepoLock_DoesNotSerializeDifferentClonePaths(t *testing.T) {
+	t.Parallel()
+	bareA := filepath.Join(t.TempDir(), "a.git")
+	bareB := filepath.Join(t.TempDir(), "b.git")
+
+	release := make(chan struct{})
+	started := make(chan struct{}, 2)
+
+	var wg sync.WaitGroup
+	for _, bare := range []string{bareA, bareB} {
+		wg.Add(1)
+		go func(bare string) {
+			defer wg.Done()
+			_ = withBareRepoLock(bare, func() error {
+				started <- struct{}{}
+				<-release
+				return nil
+			})
+		}(bare)
+	}
+
+	// Both distinct-path holders must be able to enter concurrently — if a
+	// single global lock were used instead of per-path, the second send to
+	// started would block until the first releases, and this would time out.
+	timeout := time.After(2 * time.Second)
+	for range 2 {
+		select {
+		case <-started:
+		case <-timeout:
+			t.Fatal("timed out waiting for both distinct-path holders to enter concurrently")
+		}
+	}
+	close(release)
+	wg.Wait()
+}
+
+func TestWithLockRetry_RetriesOnLockContention(t *testing.T) {
+	prevBackoffs, prevSleep := gitOpRetryBackoffs, gitOpRetrySleep
+	t.Cleanup(func() { gitOpRetryBackoffs, gitOpRetrySleep = prevBackoffs, prevSleep })
+	gitOpRetryBackoffs = []time.Duration{0, 0, 0}
+	gitOpRetrySleep = func(time.Duration) {}
+
+	var attempts int32
+	err := withLockRetry(func() error {
+		n := atomic.AddInt32(&attempts, 1)
+		if n < 3 {
+			return fmt.Errorf("fatal: Unable to create '/repo/.git/index.lock': File exists.")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("withLockRetry: %v", err)
+	}
+	if attempts != 3 {
+		t.Errorf("attempts = %d, want 3", attempts)
+	}
+}
+
+func TestWithLockRetry_DoesNotRetryNonLockErrors(t *testing.T) {
+	prevBackoffs, prevSleep := gitOpRetryBackoffs, gitOpRetrySleep
+	t.Cleanup(func() { gitOpRetryBackoffs, gitOpRetrySleep = prevBackoffs, prevSleep })
+	gitOpRetryBackoffs = []time.Duration{0, 0, 0}
+	gitOpRetrySleep = func(time.Duration) {
+		t.Fatal("should not sleep/retry a non-lock error")
+	}
+
+	wantErr := errors.New("fatal: not a git repository")
+	var attempts int32
+	err := withLockRetry(func() error {
+		atomic.AddInt32(&attempts, 1)
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1 (no retry for non-lock errors)", attempts)
+	}
+}
+
+func TestWithLockRetry_GivesUpAfterExhaustingBackoffs(t *testing.T) {
+	prevBackoffs, prevSleep := gitOpRetryBackoffs, gitOpRetrySleep
+	t.Cleanup(func() { gitOpRetryBackoffs, gitOpRetrySleep = prevBackoffs, prevSleep })
+	gitOpRetryBackoffs = []time.Duration{0, 0}
+	gitOpRetrySleep = func(time.Duration) {}
+
+	var attempts int32
+	lockErr := errors.New("fatal: Unable to create '.git/index.lock': File exists.")
+	err := withLockRetry(func() error {
+		atomic.AddInt32(&attempts, 1)
+		return lockErr
+	})
+	if !errors.Is(err, lockErr) {
+		t.Fatalf("err = %v, want %v", err, lockErr)
+	}
+	// One initial attempt plus one retry per configured backoff.
+	if want := int32(1 + len(gitOpRetryBackoffs)); attempts != want {
+		t.Errorf("attempts = %d, want %d", attempts, want)
+	}
+}
+
+// TestCreateWorktree_ConcurrentDistinctPathsSucceed exercises the fix's core
+// scenario: several task worktrees prepared concurrently off one shared bare
+// clone. Before the per-clone-path mutex, concurrent `git worktree add`
+// invocations against the same bare repo could transiently fail on lock
+// contention; this proves they now serialize instead of racing.
+func TestCreateWorktree_ConcurrentDistinctPathsSucceed(t *testing.T) {
+	t.Parallel()
+	if !hasGit() {
+		t.Skip("git not available")
+	}
+
+	src := initRepoWithCommit(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := CloneBare(src, bare); err != nil {
+		t.Fatalf("clone: %v", err)
+	}
+	branch, err := DefaultBranch(bare)
+	if err != nil {
+		t.Fatalf("default branch: %v", err)
+	}
+
+	const n = 6
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			wtPath := filepath.Join(t.TempDir(), fmt.Sprintf("wt-%d", i))
+			errs[i] = CreateWorktree(bare, wtPath, fmt.Sprintf("sybra/concurrent-%d", i), branch)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("CreateWorktree[%d]: %v", i, err)
+		}
+	}
+}

--- a/internal/worktree/branch_test.go
+++ b/internal/worktree/branch_test.go
@@ -37,6 +37,44 @@ func TestBranchNameForTask_PreservesExistingBranch(t *testing.T) {
 	}
 }
 
+// TestBranchNameForTask_NoCollisionAcrossTaskIDs guards the assumption
+// PrepareForTask relies on: two tasks with identical titles/slugs (so
+// identical branchPrefixForTask + DirName inputs modulo ID) must still
+// resolve to distinct branches, since the task ID is the only differentiator
+// once the branch name is derived rather than explicitly set. Task IDs come
+// from a uuid[:8] (see task.Store.Create) — mustn't collide.
+func TestBranchNameForTask_NoCollisionAcrossTaskIDs(t *testing.T) {
+	t.Parallel()
+	base := task.Task{Slug: "add-auth", Title: "feat(api): add auth endpoint"}
+
+	seen := make(map[string]string)
+	ids := []string{"fa6919fc", "0b6919fc", "fa6919fd", "aaaaaaaa", "bbbbbbbb"}
+	for _, id := range ids {
+		tk := base
+		tk.ID = id
+		branch := branchNameForTask(tk)
+		if other, ok := seen[branch]; ok {
+			t.Fatalf("branch %q derived for both task ID %q and %q", branch, other, id)
+		}
+		seen[branch] = id
+	}
+}
+
+// TestBranchNameForTask_DeterministicPerTaskID ensures the derivation is
+// stable across repeated calls (e.g. a reused worktree recomputing the branch
+// on every PrepareForTask call must land back on the same branch, not drift).
+func TestBranchNameForTask_DeterministicPerTaskID(t *testing.T) {
+	t.Parallel()
+	tk := task.Task{ID: "fa6919fc", Slug: "add-auth", Title: "feat(api): add auth endpoint"}
+
+	first := branchNameForTask(tk)
+	for range 5 {
+		if got := branchNameForTask(tk); got != first {
+			t.Fatalf("branchNameForTask is non-deterministic: got %q, want %q", got, first)
+		}
+	}
+}
+
 func TestBranchPrefixForTask_Fallbacks(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
## Motivation

Concurrent worktree preparers hitting the same bare clone raced on git's lock files (index.lock, ref locks, worktree admin locks), causing intermittent worktree-prep failures.

## Implementation information

- Add a per-clone in-process mutex around bare-repo mutations in `internal/project/git.go`.
- Broaden lock-contention retry (previously `git log`/`verify_commits` only) to also cover fetch, worktree add/prune/remove, and repair.
- The mutex only guards in-process races; the retry logic backs up cross-process races (desktop + server against one shared clone).
- Add tests confirming task-ID-derived branch names cannot collide across tasks.

Closes https://github.com/Automaat/sybra/issues/1321

_Generated by Sybra harness_