### PR TITLE
build(codegen): generate hand-synced mirror text

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,15 @@ jobs:
           git diff --exit-code frontend/bindings/ || \
             (echo "::error::Wails v3 bindings out of sync. Run 'wails3 generate bindings -ts -d frontend/bindings ./...'." && exit 1)
 
+  check-api-shim-sync:
+    name: API Shim Sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Check HTTP-allowlisted methods have api.ts/api-http.ts shims
+        run: bash scripts/check-api-shim-sync.sh
+
   build:
     name: Build
     runs-on: macos-15

--- a/cmd/sybra-cli/handoff_test.go
+++ b/cmd/sybra-cli/handoff_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -62,5 +63,46 @@ func TestHandoffStageConfigForRejectsExternalPRStages(t *testing.T) {
 				t.Fatalf("isExternalPRHandoffStage(%q) = false, want true", stage)
 			}
 		})
+	}
+}
+
+// TestHandoffStageUsageErrorMatchesRegistry pins the error text to
+// handoffStageRegistry so a stage added to the registry without updating a
+// second hand-typed error string can never happen — there is no second
+// string to forget.
+func TestHandoffStageUsageErrorMatchesRegistry(t *testing.T) {
+	t.Parallel()
+
+	err := handoffStageUsageError("bogus")
+	for _, def := range handoffStageRegistry {
+		if !strings.Contains(err.Error(), def.name) {
+			t.Fatalf("handoffStageUsageError() = %q, missing stage name %q", err, def.name)
+		}
+		for _, alias := range def.aliases {
+			if alias == "" {
+				continue
+			}
+			if !strings.Contains(err.Error(), alias) {
+				t.Fatalf("handoffStageUsageError() = %q, missing alias %q", err, alias)
+			}
+		}
+	}
+}
+
+// TestHandoffStageRegistryEveryAliasResolves guards against a registry typo
+// (e.g. an alias that never maps back to its own stage).
+func TestHandoffStageRegistryEveryAliasResolves(t *testing.T) {
+	t.Parallel()
+
+	for _, def := range handoffStageRegistry {
+		for _, alias := range def.aliases {
+			got, ok := handoffStageConfigFor(alias)
+			if !ok {
+				t.Fatalf("handoffStageConfigFor(%q) returned ok=false", alias)
+			}
+			if got.name != def.name {
+				t.Fatalf("handoffStageConfigFor(%q).name = %q, want %q", alias, got.name, def.name)
+			}
+		}
 	}
 }

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -398,7 +398,7 @@ func cmdHandoff(s *task.Manager, ps *project.Store, args []string, jsonOut bool)
 	proj := fs.String("project", "", "project id (owner/repo); derived from the worktree origin remote when omitted")
 	wtDir := fs.String("worktree-dir", "", "git worktree Sybra should reuse (default: current directory)")
 	mode := fs.String("mode", "headless", "agent mode: headless|interactive")
-	stage := fs.String("stage", "implement", "workflow entry stage: implement|review|testing|ready-pr")
+	stage := fs.String("stage", "implement", "workflow entry stage: "+handoffStageCompactList())
 	rawStatus := fs.String("status", "", "raw task status to create without starting a workflow")
 	sourceProvider := fs.String("source-provider", "", "provider that produced the handed-off work: claude|codex|copilot")
 	pr := fs.Int("pr", 0, "existing PR number to link when using --stage ready-pr")
@@ -553,20 +553,27 @@ const handoffManualTag = "handoff-manual"
 // --stage usage text all derive from this slice, so nothing else needs to
 // change to keep a new stage reachable.
 type handoffStageDef struct {
-	name    string
-	aliases []string
-	tags    []string
+	name           string
+	aliases        []string
+	tags           []string
+	usage          string
+	requiresSource bool
 }
 
 var handoffStageRegistry = []handoffStageDef{
 	// implement: simple-task-handoff → in-progress → implement → review → testing → PR
-	{name: "implement", aliases: []string{"", "in-progress"}, tags: []string{"handoff"}},
+	{name: "implement", aliases: []string{"", "in-progress"}, tags: []string{"handoff"},
+		usage: "have a plan -> Sybra implements, reviews, tests, opens the PR"},
 	// review: simple-task-handoff-review → ready-review → review → testing → PR
-	{name: "review", aliases: []string{"ready-review", "agentic-review"}, tags: []string{"handoff", "handoff-review"}},
+	{name: "review", aliases: []string{"ready-review", "agentic-review"}, tags: []string{"handoff", "handoff-review"},
+		usage: "implemented locally -> Sybra enters agentic review", requiresSource: true},
 	// testing: simple-task-handoff-testing → testing → adversarial test → PR
-	{name: "testing", aliases: []string{"test"}, tags: []string{"handoff", "handoff-testing"}},
+	{name: "testing", aliases: []string{"test"}, tags: []string{"handoff", "handoff-testing"},
+		usage: "reviewed locally -> Sybra tests, then opens the PR", requiresSource: true},
 	// ready-pr: simple-task-handoff-ready-pr → ready-pr → open/update PR
-	{name: "ready-pr", aliases: []string{"open-pr", "create-pr"}, tags: []string{"handoff", "handoff-ready-pr"}},
+	{name: "ready-pr", aliases: []string{"open-pr", "create-pr"}, tags: []string{"handoff", "handoff-ready-pr"},
+		usage: "tested locally -> Sybra opens or updates the PR; pass --pr N\n" +
+			strings.Repeat(" ", 27) + "only to link an existing same-branch PR"},
 }
 
 // handoffStageConfigFor maps a handoff stage (or one of its aliases) to the
@@ -609,12 +616,44 @@ func isExternalPRHandoffStage(stage string) bool {
 }
 
 func handoffStageRequiresSource(stage string) bool {
-	switch stage {
-	case "review", "testing":
-		return true
-	default:
-		return false
+	for _, def := range handoffStageRegistry {
+		if def.name == stage {
+			return def.requiresSource
+		}
 	}
+	return false
+}
+
+// handoffStageCompactList renders the "implement|review|testing|ready-pr"
+// summary used in the --stage flag help, derived from handoffStageRegistry.
+func handoffStageCompactList() string {
+	names := make([]string, len(handoffStageRegistry))
+	for i, def := range handoffStageRegistry {
+		names[i] = def.name
+	}
+	return strings.Join(names, "|")
+}
+
+// handoffStageUsageLines renders one "  name  usage" row per registry stage
+// for the handoff command's long usage text.
+func handoffStageUsageLines() string {
+	var b strings.Builder
+	for _, def := range handoffStageRegistry {
+		fmt.Fprintf(&b, "    %-14s %s\n", def.name, def.usage)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// handoffStageSourceRequirementList renders the comma-separated list of
+// stages that require --source-provider, derived from handoffStageRegistry.
+func handoffStageSourceRequirementList() string {
+	var required []string
+	for _, def := range handoffStageRegistry {
+		if def.requiresSource {
+			required = append(required, def.name)
+		}
+	}
+	return strings.Join(required, "|")
 }
 
 func normalizeHandoffSourceProvider(raw string) (string, error) {
@@ -1737,14 +1776,10 @@ Commands:
            Hand a task to Sybra at a workflow entry point, reusing the given git worktree
            (default: cwd). Project is derived from the worktree's origin remote
            when --project is omitted. STAGE (default implement):
-             implement      have a plan -> Sybra implements, reviews, tests, opens the PR
-             review         implemented locally -> Sybra enters agentic review
-             testing        reviewed locally -> Sybra tests, then opens the PR
-             ready-pr       tested locally -> Sybra opens or updates the PR; pass --pr N
-                            only to link an existing same-branch PR
+%s
            --source-provider records which local agent produced handed-off work
            so review/testing/PR steps can run on a different provider.
-           Required for --stage review|testing; optional for implement/ready-pr.
+           Required for --stage %s; optional for the other stages.
            --status STATUS creates the task directly in that status without workflow dispatch
   umbrella <issue-url> [--model M]
            Expand a GitHub umbrella issue into a gated task DAG: one umbrella tracker
@@ -1788,7 +1823,7 @@ Commands:
   artifact reindex <task-id>   Rebuild index.json from *.meta.json files.
 
 Global flags:
-  --json   Output as JSON`, statusListForUsage())
+  --json   Output as JSON`, statusListForUsage(), handoffStageUsageLines(), handoffStageSourceRequirementList())
 }
 
 func cmdArtifact(args []string, jsonOut bool) int {

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -505,7 +505,7 @@ func resolveHandoffMode(fs *flag.FlagSet, stage, rawStatus string, pr int) (hand
 		if isExternalPRHandoffStage(stage) {
 			return handoffStageConfig{}, "", false, fmt.Errorf("--stage %s is not supported by handoff: handoff only creates internal Sybra tasks; use --stage ready-pr --pr N to link an existing PR from this worktree", stage)
 		}
-		return handoffStageConfig{}, "", false, fmt.Errorf("invalid --stage %q (valid: implement, review, testing, ready-pr; aliases: in-progress, ready-review, agentic-review, test, open-pr, create-pr)", stage)
+		return handoffStageConfig{}, "", false, handoffStageUsageError(stage)
 	}
 	if pr > 0 && stageCfg.name != "ready-pr" {
 		return handoffStageConfig{}, "", false, fmt.Errorf("--pr is only valid with --stage ready-pr so the PR stays linked to an internal Sybra task")
@@ -546,25 +546,57 @@ type handoffStageConfig struct {
 
 const handoffManualTag = "handoff-manual"
 
-// handoffStageConfigFor maps a handoff stage to the tags that route the task
-// into the right Sybra lane on creation, or false for an unknown stage.
-//   - implement: simple-task-handoff → in-progress → implement → review → testing → PR
-//   - review:    simple-task-handoff-review → ready-review → review → testing → PR
-//   - testing:   simple-task-handoff-testing → testing → adversarial test → PR
-//   - ready-pr:  simple-task-handoff-ready-pr → ready-pr → open/update PR
+// handoffStageDef is one entry in the handoff-stage registry: a canonical
+// name, its input aliases, and the tags that route a task into the matching
+// Sybra lane (simple-task-handoff-<name>.yaml) on creation. Adding a stage
+// is a data edit here — handoffStageConfigFor, its error message, and the
+// --stage usage text all derive from this slice, so nothing else needs to
+// change to keep a new stage reachable.
+type handoffStageDef struct {
+	name    string
+	aliases []string
+	tags    []string
+}
+
+var handoffStageRegistry = []handoffStageDef{
+	// implement: simple-task-handoff → in-progress → implement → review → testing → PR
+	{name: "implement", aliases: []string{"", "in-progress"}, tags: []string{"handoff"}},
+	// review: simple-task-handoff-review → ready-review → review → testing → PR
+	{name: "review", aliases: []string{"ready-review", "agentic-review"}, tags: []string{"handoff", "handoff-review"}},
+	// testing: simple-task-handoff-testing → testing → adversarial test → PR
+	{name: "testing", aliases: []string{"test"}, tags: []string{"handoff", "handoff-testing"}},
+	// ready-pr: simple-task-handoff-ready-pr → ready-pr → open/update PR
+	{name: "ready-pr", aliases: []string{"open-pr", "create-pr"}, tags: []string{"handoff", "handoff-ready-pr"}},
+}
+
+// handoffStageConfigFor maps a handoff stage (or one of its aliases) to the
+// tags that route the task into the right Sybra lane on creation, or false
+// for an unknown stage. See handoffStageRegistry for the stage definitions.
 func handoffStageConfigFor(stage string) (handoffStageConfig, bool) {
-	switch strings.ToLower(strings.TrimSpace(stage)) {
-	case "", "implement", "in-progress":
-		return handoffStageConfig{name: "implement", tags: []string{"handoff"}}, true
-	case "review", "ready-review", "agentic-review":
-		return handoffStageConfig{name: "review", tags: []string{"handoff", "handoff-review"}}, true
-	case "testing", "test":
-		return handoffStageConfig{name: "testing", tags: []string{"handoff", "handoff-testing"}}, true
-	case "ready-pr", "open-pr", "create-pr":
-		return handoffStageConfig{name: "ready-pr", tags: []string{"handoff", "handoff-ready-pr"}}, true
-	default:
-		return handoffStageConfig{}, false
+	normalized := strings.ToLower(strings.TrimSpace(stage))
+	for _, def := range handoffStageRegistry {
+		if normalized == def.name || slices.Contains(def.aliases, normalized) {
+			return handoffStageConfig{name: def.name, tags: def.tags}, true
+		}
 	}
+	return handoffStageConfig{}, false
+}
+
+// handoffStageUsageError renders the "invalid --stage" error from the same
+// registry that drives handoffStageConfigFor, so the valid-stage/alias list
+// can never drift from what the CLI actually accepts.
+func handoffStageUsageError(stage string) error {
+	names := make([]string, 0, len(handoffStageRegistry))
+	var aliases []string
+	for _, def := range handoffStageRegistry {
+		names = append(names, def.name)
+		for _, a := range def.aliases {
+			if a != "" {
+				aliases = append(aliases, a)
+			}
+		}
+	}
+	return fmt.Errorf("invalid --stage %q (valid: %s; aliases: %s)", stage, strings.Join(names, ", "), strings.Join(aliases, ", "))
 }
 
 func isExternalPRHandoffStage(stage string) bool {
@@ -1681,12 +1713,23 @@ func logHookFailure(cfg *config.Config, taskID, reason string) {
 	})
 }
 
+// statusListForUsage renders task.AllStatuses() as a pipe-joined string so
+// the CLI help text can never drift from the enum's single source of truth.
+func statusListForUsage() string {
+	statuses := task.AllStatuses()
+	names := make([]string, len(statuses))
+	for i, s := range statuses {
+		names[i] = string(s)
+	}
+	return strings.Join(names, "|")
+}
+
 func usage() {
-	fmt.Fprintln(os.Stderr, `Usage: sybra-cli [--json] <command> [flags]
+	fmt.Fprintf(os.Stderr, `Usage: sybra-cli [--json] <command> [flags]
 
 Commands:
   list     [--status STATUS] [--tag TAG] [--project ID]
-           STATUS: new|todo|planning|plan-review|in-progress|in-review|testing|ready-pr|human-required|done|cancelled
+           STATUS: %s
   get      [--compact] <id>
   create   --title TITLE [--body BODY] [--plan PLAN] [--plan-contract JSON] [--mode MODE] [--type TYPE] [--tags t1,t2] [--project ID] [--branch B] [--pr N] [--issue URL] [--allow-dup]
            TYPE: normal|debug|research
@@ -1745,7 +1788,7 @@ Commands:
   artifact reindex <task-id>   Rebuild index.json from *.meta.json files.
 
 Global flags:
-  --json   Output as JSON`)
+  --json   Output as JSON`, statusListForUsage())
 }
 
 func cmdArtifact(args []string, jsonOut bool) int {

--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -573,7 +573,7 @@ var handoffStageRegistry = []handoffStageDef{
 	// ready-pr: simple-task-handoff-ready-pr → ready-pr → open/update PR
 	{name: "ready-pr", aliases: []string{"open-pr", "create-pr"}, tags: []string{"handoff", "handoff-ready-pr"},
 		usage: "tested locally -> Sybra opens or updates the PR; pass --pr N\n" +
-			strings.Repeat(" ", 27) + "only to link an existing same-branch PR"},
+			strings.Repeat(" ", 19) + "only to link an existing same-branch PR"},
 }
 
 // handoffStageConfigFor maps a handoff stage (or one of its aliases) to the
@@ -644,8 +644,8 @@ func handoffStageUsageLines() string {
 	return strings.TrimRight(b.String(), "\n")
 }
 
-// handoffStageSourceRequirementList renders the comma-separated list of
-// stages that require --source-provider, derived from handoffStageRegistry.
+// handoffStageSourceRequirementList renders the "|"-joined list of stages
+// that require --source-provider, derived from handoffStageRegistry.
 func handoffStageSourceRequirementList() string {
 	var required []string
 	for _, def := range handoffStageRegistry {
@@ -1823,7 +1823,8 @@ Commands:
   artifact reindex <task-id>   Rebuild index.json from *.meta.json files.
 
 Global flags:
-  --json   Output as JSON`, statusListForUsage(), handoffStageUsageLines(), handoffStageSourceRequirementList())
+  --json   Output as JSON
+`, statusListForUsage(), handoffStageUsageLines(), handoffStageSourceRequirementList())
 }
 
 func cmdArtifact(args []string, jsonOut bool) int {

--- a/cmd/sybra-cli/usage_test.go
+++ b/cmd/sybra-cli/usage_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// TestStatusListForUsageMatchesAllStatuses pins the `list --status` help
+// text to task.AllStatuses() so the CLI usage string can never drift from
+// the Status enum again — there is only one list to edit.
+func TestStatusListForUsageMatchesAllStatuses(t *testing.T) {
+	t.Parallel()
+
+	statuses := task.AllStatuses()
+	want := make([]string, len(statuses))
+	for i, s := range statuses {
+		want[i] = string(s)
+	}
+
+	got := strings.Split(statusListForUsage(), "|")
+	if len(got) != len(want) {
+		t.Fatalf("statusListForUsage() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("statusListForUsage()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/scripts/check-api-shim-sync.sh
+++ b/scripts/check-api-shim-sync.sh
@@ -25,19 +25,30 @@ for f in "${SERVICES_GO}" "${API_TS}" "${API_HTTP_TS}"; do
   fi
 done
 
+# Reads newline-delimited stdin into the named array. Used instead of
+# `mapfile -t` (bash 4+) so this also runs on the default macOS /bin/bash (3.2).
+read_lines_into() {
+  local __arr_name="$1"
+  eval "${__arr_name}=()"
+  local line
+  while IFS= read -r line; do
+    eval "${__arr_name}+=(\"\${line}\")"
+  done
+}
+
 # Exported Go method names allowlisted for HTTP dispatch, e.g. `"GetTask",`.
 # Restricted to capitalized identifiers so this doesn't also match unrelated
 # quoted strings (import paths, package names) elsewhere in the file. Uses
 # BRE grep + sed instead of PCRE (-P) so this also runs on macOS/BSD grep.
-mapfile -t methods < <(grep -oE '^[[:space:]]*"[A-Z][A-Za-z0-9_]*",?$' "${SERVICES_GO}" | sed -E 's/^[[:space:]]*"([A-Za-z0-9_]+)",?$/\1/' | sort -u)
+read_lines_into methods < <(grep -oE '^[[:space:]]*"[A-Z][A-Za-z0-9_]*",?$' "${SERVICES_GO}" | sed -E 's/^[[:space:]]*"([A-Za-z0-9_]+)",?$/\1/' | sort -u)
 
 if [[ "${#methods[@]}" -eq 0 ]]; then
   echo "::error::no methods parsed from ${SERVICES_GO} — check the extraction regex" >&2
   exit 1
 fi
 
-mapfile -t api_ts_exports < <(grep -oE '^export const [A-Za-z0-9_]+' "${API_TS}" | sed -E 's/^export const //' | sort -u)
-mapfile -t api_http_exports < <(grep -oE '^export (async )?function [A-Za-z0-9_]+' "${API_HTTP_TS}" | sed -E 's/^export (async )?function //' | sort -u)
+read_lines_into api_ts_exports < <(grep -oE '^export const [A-Za-z0-9_]+' "${API_TS}" | sed -E 's/^export const //' | sort -u)
+read_lines_into api_http_exports < <(grep -oE '^export (async )?function [A-Za-z0-9_]+' "${API_HTTP_TS}" | sed -E 's/^export (async )?function //' | sort -u)
 
 fail=0
 

--- a/scripts/check-api-shim-sync.sh
+++ b/scripts/check-api-shim-sync.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Every Wails-bound method that is also allowlisted for HTTP dispatch in
+# internal/sybra/services.go (ServiceRegistry) must have a matching shim
+# export in both frontend/src/lib/api.ts (the pick() re-export used by the
+# rest of the frontend) and frontend/src/lib/api-http.ts (the actual HTTP
+# implementation used by the web build). Miss either one and the method is
+# silently unreachable from one of the two build targets.
+#
+# services.go is the source of truth: it is the one hand-maintained list a
+# method must be added to for HTTP dispatch to work at all, so drift here
+# means a shim genuinely wasn't written — not just a naming mismatch.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+SERVICES_GO="internal/sybra/services.go"
+API_TS="frontend/src/lib/api.ts"
+API_HTTP_TS="frontend/src/lib/api-http.ts"
+
+for f in "${SERVICES_GO}" "${API_TS}" "${API_HTTP_TS}"; do
+  if [[ ! -f "${f}" ]]; then
+    echo "::error::${f} not found" >&2
+    exit 1
+  fi
+done
+
+# Exported Go method names allowlisted for HTTP dispatch, e.g. `"GetTask",`.
+# Restricted to capitalized identifiers so this doesn't also match unrelated
+# quoted strings (import paths, package names) elsewhere in the file. Uses
+# BRE grep + sed instead of PCRE (-P) so this also runs on macOS/BSD grep.
+mapfile -t methods < <(grep -oE '^[[:space:]]*"[A-Z][A-Za-z0-9_]*",?$' "${SERVICES_GO}" | sed -E 's/^[[:space:]]*"([A-Za-z0-9_]+)",?$/\1/' | sort -u)
+
+if [[ "${#methods[@]}" -eq 0 ]]; then
+  echo "::error::no methods parsed from ${SERVICES_GO} — check the extraction regex" >&2
+  exit 1
+fi
+
+mapfile -t api_ts_exports < <(grep -oE '^export const [A-Za-z0-9_]+' "${API_TS}" | sed -E 's/^export const //' | sort -u)
+mapfile -t api_http_exports < <(grep -oE '^export (async )?function [A-Za-z0-9_]+' "${API_HTTP_TS}" | sed -E 's/^export (async )?function //' | sort -u)
+
+fail=0
+
+for method in "${methods[@]}"; do
+  if ! printf '%s\n' "${api_ts_exports[@]}" | grep -qx "${method}"; then
+    echo "::error file=${API_TS}::HTTP-allowlisted method ${method} (${SERVICES_GO}) has no 'export const ${method}' shim" >&2
+    fail=1
+  fi
+  if ! printf '%s\n' "${api_http_exports[@]}" | grep -qx "${method}"; then
+    echo "::error file=${API_HTTP_TS}::HTTP-allowlisted method ${method} (${SERVICES_GO}) has no 'export function ${method}' implementation" >&2
+    fail=1
+  fi
+done
+
+if [[ "${fail}" -eq 0 ]]; then
+  echo "api shim sync OK — ${#methods[@]} HTTP-allowlisted methods all have api.ts + api-http.ts shims"
+fi
+
+exit "${fail}"


### PR DESCRIPTION
## Motivation

CLI status help and the handoff-stage switch were hand-typed copies of
`task.AllStatuses()` and the stage list, and had already drifted
(`ready-review` and `blocked` missing from `--status` help). Hand-synced
mirrors like this silently rot; generating the text from the single-owner
data source removes the drift class entirely. Also adds a CI check that
fails when an HTTP-allowlisted Wails method has no matching shim in
`api.ts`/`api-http.ts`, so a forgotten shim fails CI instead of shipping
silently unreachable.

## Implementation information

- `cmd/sybra-cli/main.go`: derive `--status` help text and the
  handoff-stage error message from `task.AllStatuses()` / the stage list
  instead of hand-typed copies
- `cmd/sybra-cli/usage_test.go`, `cmd/sybra-cli/handoff_test.go`: cover the
  generated help/error text against the source data
- `scripts/check-api-shim-sync.sh`: new script verifying every
  HTTP-allowlisted Wails method has a shim in `api.ts`/`api-http.ts`
- `.github/workflows/ci.yml`: wire the shim-sync script into CI
- Follow-up commit addresses review comments on the same file

Closes https://github.com/Automaat/sybra/issues/1318

_Generated by Sybra harness_