### PR TITLE
fix(task): flock stores for cross-process safety

### DIFF
--- a/internal/fsutil/lock_other.go
+++ b/internal/fsutil/lock_other.go
@@ -1,0 +1,14 @@
+//go:build !unix
+
+package fsutil
+
+import "fmt"
+
+// LockFile is unimplemented on non-unix platforms (flock has no direct
+// equivalent without a platform-specific syscall). Sybra's GUI/server/CLI
+// builds are unix-only; this stub exists solely so cross-platform builds of
+// packages that import fsutil (e.g. `go vet ./...` on a Windows dev machine)
+// still compile.
+func LockFile(_ string) (func() error, error) {
+	return nil, fmt.Errorf("fsutil: cross-process file locking is not supported on this platform")
+}

--- a/internal/fsutil/lock_unix.go
+++ b/internal/fsutil/lock_unix.go
@@ -1,0 +1,39 @@
+//go:build unix
+
+package fsutil
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// LockFile acquires an advisory, cross-process exclusive lock for path by
+// flocking a sibling "<path>.lock" file, blocking until it is held. Sybra
+// runs the GUI server, sybra-cli, and the recovery sweep as separate OS
+// processes that all read-modify-write the same store files; an in-process
+// sync.Mutex only serializes goroutines within one of those processes; flock
+// is what serializes across all of them.
+//
+// The returned unlock releases the flock and closes the file descriptor.
+// Callers must call it exactly once, typically via defer, and must hold it
+// across the full read-modify-write critical section (not just the final
+// write) or a concurrent writer can still interleave between another
+// process's read and write.
+func LockFile(path string) (func() error, error) {
+	f, err := os.OpenFile(path+".lock", os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("flock: %w", err)
+	}
+	return func() error {
+		unlockErr := syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		if closeErr := f.Close(); unlockErr == nil {
+			unlockErr = closeErr
+		}
+		return unlockErr
+	}, nil
+}

--- a/internal/limits/collect_test.go
+++ b/internal/limits/collect_test.go
@@ -361,6 +361,41 @@ func TestStoreImport_DedupesAndPersistsBatch(t *testing.T) {
 	}
 }
 
+// TestRecordUsageCrossProcessSimulatesConcurrentWriters models two OS
+// processes (e.g. the GUI server and sybra-cli) each holding their own
+// *Store over the same path. s.events/s.snapshots are loaded once at
+// NewStore time and never re-read on the query paths, so without
+// RecordUsage reloading from disk under the flock before recording, s2's
+// write would overwrite s1's not-yet-visible-to-s2 event entirely instead of
+// merging with it.
+func TestRecordUsageCrossProcessSimulatesConcurrentWriters(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "limits.json")
+
+	s1, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s1.RecordUsage(UsageEvent{ID: "e1", Provider: ProviderClaude, Timestamp: time.Now()}); err != nil {
+		t.Fatalf("s1.RecordUsage: %v", err)
+	}
+	if err := s2.RecordUsage(UsageEvent{ID: "e2", Provider: ProviderCodex, Timestamp: time.Now()}); err != nil {
+		t.Fatalf("s2.RecordUsage: %v", err)
+	}
+
+	s3, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(s3.events) != 2 {
+		t.Fatalf("events = %d, want 2 — an event was dropped by concurrent cross-process writes", len(s3.events))
+	}
+}
+
 func TestSessionImport_DedupesEventsAndKeepsLatestSnapshot(t *testing.T) {
 	now := time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
 	batch := newSessionImport()

--- a/internal/limits/store.go
+++ b/internal/limits/store.go
@@ -116,8 +116,11 @@ func (s *Store) Import(events []UsageEvent, snapshots []Snapshot) error {
 	return s.flushLocked()
 }
 
-// reloadLocked re-reads s.path into s.snapshots/s.events/s.seen. Callers
-// must hold s.mu and the cross-process file lock.
+// reloadLocked re-reads s.path into s.snapshots/s.events/s.seen.
+// Read-modify-write callers (UpdateSnapshot, RecordUsage, Import) must hold
+// both s.mu and the cross-process file lock across the whole critical
+// section; NewStore calls it unlocked because it runs before s is returned
+// to any caller, so nothing else can observe or race it yet.
 func (s *Store) reloadLocked() error {
 	data, err := os.ReadFile(s.path)
 	if err != nil {

--- a/internal/limits/store.go
+++ b/internal/limits/store.go
@@ -37,40 +37,33 @@ func NewStore(path string) (*Store, error) {
 		snapshots: map[string]Snapshot{},
 		seen:      map[string]struct{}{},
 	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return s, nil
-		}
+	if err := s.reloadLocked(); err != nil {
 		return nil, err
-	}
-	if len(data) == 0 {
-		return s, nil
-	}
-	var p persisted
-	if err := json.Unmarshal(data, &p); err != nil {
-		return nil, err
-	}
-	if p.Snapshots != nil {
-		s.snapshots = p.Snapshots
-	}
-	for i := range p.Events {
-		e := p.Events[i]
-		if e.ID == "" {
-			continue
-		}
-		if _, ok := s.seen[e.ID]; ok {
-			continue
-		}
-		s.events = append(s.events, e)
-		s.seen[e.ID] = struct{}{}
 	}
 	return s, nil
 }
 
+// UpdateSnapshot, RecordUsage, and Import are read-modify-write against the
+// on-disk file: s.snapshots/s.events are populated once at NewStore time and
+// otherwise never re-read, but sybra-cli and the GUI server each hold a
+// separate Store over the same path in separate OS processes. Reloading
+// under the cross-process flock immediately before mutating resyncs this
+// process's view to the authoritative on-disk state, so a write from the
+// other process in the gap since this process last loaded isn't clobbered.
+
 func (s *Store) UpdateSnapshot(snapshot Snapshot) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	unlock, err := fsutil.LockFile(s.path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unlock() }()
+
+	if err := s.reloadLocked(); err != nil {
+		return err
+	}
 	if !s.updateSnapshotLocked(snapshot) {
 		return nil
 	}
@@ -80,6 +73,16 @@ func (s *Store) UpdateSnapshot(snapshot Snapshot) error {
 func (s *Store) RecordUsage(e UsageEvent) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	unlock, err := fsutil.LockFile(s.path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unlock() }()
+
+	if err := s.reloadLocked(); err != nil {
+		return err
+	}
 	if !s.recordUsageLocked(e) {
 		return nil
 	}
@@ -90,6 +93,16 @@ func (s *Store) RecordUsage(e UsageEvent) error {
 func (s *Store) Import(events []UsageEvent, snapshots []Snapshot) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	unlock, err := fsutil.LockFile(s.path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unlock() }()
+
+	if err := s.reloadLocked(); err != nil {
+		return err
+	}
 	changed := false
 	for i := range snapshots {
 		changed = s.updateSnapshotLocked(snapshots[i]) || changed
@@ -101,6 +114,49 @@ func (s *Store) Import(events []UsageEvent, snapshots []Snapshot) error {
 		return nil
 	}
 	return s.flushLocked()
+}
+
+// reloadLocked re-reads s.path into s.snapshots/s.events/s.seen. Callers
+// must hold s.mu and the cross-process file lock.
+func (s *Store) reloadLocked() error {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			s.snapshots = map[string]Snapshot{}
+			s.events = nil
+			s.seen = map[string]struct{}{}
+			return nil
+		}
+		return err
+	}
+	if len(data) == 0 {
+		s.snapshots = map[string]Snapshot{}
+		s.events = nil
+		s.seen = map[string]struct{}{}
+		return nil
+	}
+	var p persisted
+	if err := json.Unmarshal(data, &p); err != nil {
+		return err
+	}
+	s.snapshots = map[string]Snapshot{}
+	if p.Snapshots != nil {
+		s.snapshots = p.Snapshots
+	}
+	s.events = nil
+	s.seen = map[string]struct{}{}
+	for i := range p.Events {
+		e := p.Events[i]
+		if e.ID == "" {
+			continue
+		}
+		if _, ok := s.seen[e.ID]; ok {
+			continue
+		}
+		s.events = append(s.events, e)
+		s.seen[e.ID] = struct{}{}
+	}
+	return nil
 }
 
 func (s *Store) updateSnapshotLocked(snapshot Snapshot) bool {

--- a/internal/loopagent/scheduler.go
+++ b/internal/loopagent/scheduler.go
@@ -249,20 +249,11 @@ func (s *Scheduler) OnAgentComplete(ag *agent.Agent) {
 	}
 }
 
-// persistRun applies a mutator to a record and writes it back. Crucially
-// it does NOT bump UpdatedAt — that field tracks user config changes only.
-// Bumping it here would trip Sync()'s change detection and restart the
-// fetcher every time it fires.
+// persistRun applies a mutator to a record and writes it back through the
+// store's locked run-metadata path, so it participates in the same
+// cross-process flock as Update instead of racing it.
 func (s *Scheduler) persistRun(id string, mutate func(*LoopAgent)) (LoopAgent, error) {
-	rec, err := s.store.Get(id)
-	if err != nil {
-		return LoopAgent{}, err
-	}
-	mutate(&rec)
-	if err := s.store.writeFile(rec); err != nil {
-		return LoopAgent{}, err
-	}
-	return rec, nil
+	return s.store.UpdateRunMetadata(id, mutate)
 }
 
 // Stop cancels every running fetcher and waits for the goroutines to drain.

--- a/internal/loopagent/store.go
+++ b/internal/loopagent/store.go
@@ -115,6 +115,30 @@ func (s *Store) Update(la LoopAgent) (LoopAgent, error) {
 	return la, nil
 }
 
+// UpdateRunMetadata applies mutate to the on-disk record under the same
+// per-record flock as Update, but deliberately does NOT bump UpdatedAt —
+// that field tracks user config changes only, and bumping it here would
+// trip Sync()'s change detection and restart the fetcher every time it
+// fires. Used by the scheduler to persist run bookkeeping (LastRunAt,
+// LastRunID, LastRunCost) without racing GUI/API/CLI config updates.
+func (s *Store) UpdateRunMetadata(id string, mutate func(*LoopAgent)) (LoopAgent, error) {
+	unlock, err := fsutil.LockFile(s.filePath(id))
+	if err != nil {
+		return LoopAgent{}, fmt.Errorf("lock loop agent: %w", err)
+	}
+	defer func() { _ = unlock() }()
+
+	rec, err := s.Get(id)
+	if err != nil {
+		return LoopAgent{}, err
+	}
+	mutate(&rec)
+	if err := s.writeFile(rec); err != nil {
+		return LoopAgent{}, err
+	}
+	return rec, nil
+}
+
 // Delete removes the record file. Missing files are not an error.
 func (s *Store) Delete(id string) error {
 	path := s.filePath(id)

--- a/internal/loopagent/store.go
+++ b/internal/loopagent/store.go
@@ -84,7 +84,19 @@ func (s *Store) Create(la LoopAgent) (LoopAgent, error) {
 
 // Update overwrites mutable fields on an existing record. ID and CreatedAt
 // are preserved from the on-disk version regardless of caller input.
+//
+// The Get-then-writeFile sequence is a read-modify-write, so it is flocked
+// across the whole critical section: sybra-cli and the GUI server run
+// separate Store instances in separate OS processes against the same dir,
+// and without a cross-process lock a concurrent Update from the other
+// process can be read here, then clobbered by this write's stale CreatedAt.
 func (s *Store) Update(la LoopAgent) (LoopAgent, error) {
+	unlock, err := fsutil.LockFile(s.filePath(la.ID))
+	if err != nil {
+		return LoopAgent{}, fmt.Errorf("lock loop agent: %w", err)
+	}
+	defer func() { _ = unlock() }()
+
 	existing, err := s.Get(la.ID)
 	if err != nil {
 		return LoopAgent{}, err

--- a/internal/loopagent/store_test.go
+++ b/internal/loopagent/store_test.go
@@ -2,6 +2,7 @@ package loopagent
 
 import (
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -156,5 +157,55 @@ func TestStoreCRUD(t *testing.T) {
 	// Delete missing is not an error
 	if err := store.Delete("nonexistent"); err != nil {
 		t.Fatalf("delete missing: %v", err)
+	}
+}
+
+// TestStoreConcurrentUpdatePreservesCreatedAt exercises the Get-then-write
+// critical section inside Update under real concurrency. Both goroutines
+// start from the same on-disk CreatedAt; without flocking that section, one
+// Update can read the record while the other is mid-write and persist a
+// half-applied CreatedAt/UpdatedAt pairing. Because Update fully replaces
+// the caller-supplied fields (there is no field-level merge), the two
+// concurrent writers race for whichever mutation lands last — this test
+// only pins the invariant Update itself owns: the final record on disk is
+// always a complete, validly-parsed record whose CreatedAt matches the
+// original.
+func TestStoreConcurrentUpdatePreservesCreatedAt(t *testing.T) {
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	created, err := store.Create(LoopAgent{Name: "race", Prompt: "/race", IntervalSec: 60})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	const n = 20
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := range n {
+		la := created
+		la.Enabled = i%2 == 0
+		wg.Go(func() {
+			if _, err := store.Update(la); err != nil {
+				errs <- err
+			}
+		})
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent update: %v", err)
+	}
+
+	got, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("get after concurrent updates: %v", err)
+	}
+	if !got.CreatedAt.Equal(created.CreatedAt) {
+		t.Errorf("CreatedAt = %v, want %v — dropped by a concurrent write racing the read-modify-write", got.CreatedAt, created.CreatedAt)
+	}
+	if got.Name != "race" || got.IntervalSec != 60 {
+		t.Errorf("record corrupted by concurrent writes: %+v", got)
 	}
 }

--- a/internal/stats/backfill.go
+++ b/internal/stats/backfill.go
@@ -4,15 +4,18 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/fsutil"
 )
 
-// Backfill imports historical agent runs from audit logs into the stats store.
-// It skips import if the store already has records.
+// Backfill imports historical agent runs from audit logs into the stats
+// store. It skips import if the store already has records.
+//
+// The has-records guard and the append are one read-modify-write critical
+// section, flocked across it: without the reload immediately inside the
+// lock, a concurrent Record from another process (or another instance of
+// Backfill) between this process's stale in-memory check and its flush would
+// be silently discarded by the overwrite.
 func (s *Store) Backfill(auditDir string) error {
-	if s.Len() > 0 {
-		return nil
-	}
-
 	events, err := audit.Read(auditDir, audit.Query{
 		Since: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 		Until: time.Now().Add(24 * time.Hour),
@@ -24,6 +27,19 @@ func (s *Store) Backfill(auditDir string) error {
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	unlock, err := fsutil.LockFile(s.path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unlock() }()
+
+	if err := s.reloadLocked(); err != nil {
+		return err
+	}
+	if len(s.runs) > 0 {
+		return nil
+	}
 
 	for _, ev := range events {
 		if ev.Type != audit.EventAgentCompleted && ev.Type != audit.EventAgentFailed {

--- a/internal/stats/backfill.go
+++ b/internal/stats/backfill.go
@@ -10,12 +10,19 @@ import (
 // Backfill imports historical agent runs from audit logs into the stats
 // store. It skips import if the store already has records.
 //
-// The has-records guard and the append are one read-modify-write critical
-// section, flocked across it: without the reload immediately inside the
-// lock, a concurrent Record from another process (or another instance of
+// The in-memory Len() check is a fast path only, so backfill is a no-op cost
+// after the first successful run instead of scanning the full audit dir on
+// every startup. The authoritative guard is the reload+recheck inside the
+// lock below: the has-records guard and the append are one read-modify-write
+// critical section, flocked across it. Without the reload immediately inside
+// the lock, a concurrent Record from another process (or another instance of
 // Backfill) between this process's stale in-memory check and its flush would
 // be silently discarded by the overwrite.
 func (s *Store) Backfill(auditDir string) error {
+	if s.Len() > 0 {
+		return nil
+	}
+
 	events, err := audit.Read(auditDir, audit.Query{
 		Since: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 		Until: time.Now().Add(24 * time.Hour),

--- a/internal/stats/store.go
+++ b/internal/stats/store.go
@@ -20,29 +20,58 @@ type Store struct {
 
 func NewStore(path string) (*Store, error) {
 	s := &Store{path: path}
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return s, nil
-		}
+	if err := s.reloadLocked(); err != nil {
 		return nil, err
-	}
-
-	if len(data) > 0 {
-		if err := json.Unmarshal(data, &s.runs); err != nil {
-			return nil, err
-		}
 	}
 	return s, nil
 }
 
+// Record appends r and persists it. s.runs is populated once at NewStore
+// time and never re-read afterward on the query paths, so a naive
+// append-and-flush here would silently drop any run written by another
+// process (sybra-cli and the GUI server each hold their own Store over the
+// same path) in the gap since this process last loaded the file. Reloading
+// from disk under the cross-process flock, immediately before appending,
+// closes that gap: the in-memory s.runs is resynced to the authoritative
+// on-disk state before this run is added.
 func (s *Store) Record(r RunRecord) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	unlock, err := fsutil.LockFile(s.path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = unlock() }()
+
+	if err := s.reloadLocked(); err != nil {
+		return err
+	}
 	s.runs = append(s.runs, r)
 	return s.flush()
+}
+
+// reloadLocked re-reads s.path into s.runs. Callers must hold s.mu and the
+// cross-process file lock.
+func (s *Store) reloadLocked() error {
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			s.runs = nil
+			return nil
+		}
+		return err
+	}
+	if len(data) == 0 {
+		s.runs = nil
+		return nil
+	}
+	var runs []RunRecord
+	if err := json.Unmarshal(data, &runs); err != nil {
+		return err
+	}
+	s.runs = runs
+	return nil
 }
 
 func (s *Store) Len() int {

--- a/internal/stats/store.go
+++ b/internal/stats/store.go
@@ -51,8 +51,10 @@ func (s *Store) Record(r RunRecord) error {
 	return s.flush()
 }
 
-// reloadLocked re-reads s.path into s.runs. Callers must hold s.mu and the
-// cross-process file lock.
+// reloadLocked re-reads s.path into s.runs. Read-modify-write callers
+// (Record) must hold both s.mu and the cross-process file lock across the
+// whole critical section; NewStore calls it unlocked because it runs before
+// s is returned to any caller, so nothing else can observe or race it yet.
 func (s *Store) reloadLocked() error {
 	data, err := os.ReadFile(s.path)
 	if err != nil {

--- a/internal/stats/store_test.go
+++ b/internal/stats/store_test.go
@@ -135,6 +135,41 @@ func TestPersistence(t *testing.T) {
 	}
 }
 
+// TestRecordCrossProcessSimulatesConcurrentWriters models two OS processes
+// (e.g. the GUI server and sybra-cli) each holding their own *Store over the
+// same path. s.runs is loaded once at NewStore time and never re-read on the
+// query paths, so without Record reloading from disk under the flock before
+// appending, s2.Record would overwrite s1's not-yet-visible-to-s2 run
+// entirely instead of merging with it.
+func TestRecordCrossProcessSimulatesConcurrentWriters(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stats.json")
+
+	s1, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s2, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s1.Record(RunRecord{ID: "a1", TaskID: "t1", Timestamp: time.Now()}); err != nil {
+		t.Fatalf("s1.Record: %v", err)
+	}
+	if err := s2.Record(RunRecord{ID: "a2", TaskID: "t2", Timestamp: time.Now()}); err != nil {
+		t.Fatalf("s2.Record: %v", err)
+	}
+
+	s3, err := NewStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s3.Len() != 2 {
+		t.Fatalf("Len() = %d, want 2 — a run was dropped by concurrent cross-process writes", s3.Len())
+	}
+}
+
 func TestReasoningTokensPersistence(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "stats.json")

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -95,9 +95,16 @@ func (s *Store) CodeReviews() *CodeReviewStore {
 	return s.codeReviews
 }
 
-// lockTask serializes in-process read/modify/write calls for a single task
-// file. It is deliberately ref-counted so deleted or one-off task IDs do not
-// leave lock entries behind for the lifetime of a long-running server.
+// lockTask serializes read/modify/write calls for a single task file, both
+// within this process and across others. sybra-cli and the recovery sweep
+// run task.Store in separate OS processes from the GUI server against the
+// same tasks dir, so the in-process sync.Mutex alone cannot prevent two
+// processes from interleaving a read and a write and silently dropping
+// fields. The in-process lock is acquired first (cheap, avoids paying flock
+// syscalls for intra-process contention) and the cross-process flock second;
+// they are released in reverse order. It is deliberately ref-counted so
+// deleted or one-off task IDs do not leave lock entries behind for the
+// lifetime of a long-running server.
 func (s *Store) lockTask(id string) func() {
 	s.writeLocksMu.Lock()
 	if s.writeLocks == nil {
@@ -112,7 +119,22 @@ func (s *Store) lockTask(id string) func() {
 	s.writeLocksMu.Unlock()
 
 	lock.mu.Lock()
+
+	var unlockFile func() error
+	if path, err := s.safePath(id); err == nil {
+		if uf, ferr := fsutil.LockFile(path); ferr == nil {
+			unlockFile = uf
+		} else {
+			slog.Default().Warn("task.lockTask.flock_failed", "id", id, "err", ferr)
+		}
+	}
+
 	return func() {
+		if unlockFile != nil {
+			if err := unlockFile(); err != nil {
+				slog.Default().Warn("task.lockTask.unlock_failed", "id", id, "err", err)
+			}
+		}
 		lock.mu.Unlock()
 
 		s.writeLocksMu.Lock()

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -105,7 +105,12 @@ func (s *Store) CodeReviews() *CodeReviewStore {
 // they are released in reverse order. It is deliberately ref-counted so
 // deleted or one-off task IDs do not leave lock entries behind for the
 // lifetime of a long-running server.
-func (s *Store) lockTask(id string) func() {
+//
+// If the flock cannot be acquired, the write must not proceed with only the
+// in-process mutex held — that would silently reintroduce the cross-process
+// race this lock exists to close — so the in-process lock is released and an
+// error is returned instead.
+func (s *Store) lockTask(id string) (func(), error) {
 	s.writeLocksMu.Lock()
 	if s.writeLocks == nil {
 		s.writeLocks = map[string]*taskWriteLock{}
@@ -120,23 +125,8 @@ func (s *Store) lockTask(id string) func() {
 
 	lock.mu.Lock()
 
-	var unlockFile func() error
-	if path, err := s.safePath(id); err == nil {
-		if uf, ferr := fsutil.LockFile(path); ferr == nil {
-			unlockFile = uf
-		} else {
-			slog.Default().Warn("task.lockTask.flock_failed", "id", id, "err", ferr)
-		}
-	}
-
-	return func() {
-		if unlockFile != nil {
-			if err := unlockFile(); err != nil {
-				slog.Default().Warn("task.lockTask.unlock_failed", "id", id, "err", err)
-			}
-		}
+	releaseInProcess := func() {
 		lock.mu.Unlock()
-
 		s.writeLocksMu.Lock()
 		defer s.writeLocksMu.Unlock()
 		lock.refs--
@@ -144,6 +134,24 @@ func (s *Store) lockTask(id string) func() {
 			delete(s.writeLocks, id)
 		}
 	}
+
+	path, err := s.safePath(id)
+	if err != nil {
+		releaseInProcess()
+		return nil, err
+	}
+	unlockFile, err := fsutil.LockFile(path)
+	if err != nil {
+		releaseInProcess()
+		return nil, fmt.Errorf("lock task %s: %w", id, err)
+	}
+
+	return func() {
+		if err := unlockFile(); err != nil {
+			slog.Default().Warn("task.lockTask.unlock_failed", "id", id, "err", err)
+		}
+		releaseInProcess()
+	}, nil
 }
 
 // IsSidecarFile reports whether a filename (basename) belongs to a sidecar
@@ -558,7 +566,10 @@ func (s *Store) CreateChat(projectID string) (Task, error) {
 }
 
 func (s *Store) Delete(id string) error {
-	unlock := s.lockTask(id)
+	unlock, err := s.lockTask(id)
+	if err != nil {
+		return err
+	}
 	defer unlock()
 
 	t, err := s.read(id)
@@ -769,7 +780,10 @@ func applyUpdateFields(t *Task, u Update) error {
 }
 
 func (s *Store) UpdateWithPrev(id string, u Update) (Task, Status, error) {
-	unlock := s.lockTask(id)
+	unlock, err := s.lockTask(id)
+	if err != nil {
+		return Task{}, "", err
+	}
 	defer unlock()
 
 	t, err := s.read(id)
@@ -1007,7 +1021,10 @@ func (s *Store) AddRunWithStatus(taskID string, run AgentRun, status *Status) er
 }
 
 func (s *Store) addRun(taskID string, run AgentRun, status *Status) error {
-	unlock := s.lockTask(taskID)
+	unlock, err := s.lockTask(taskID)
+	if err != nil {
+		return err
+	}
 	defer unlock()
 
 	t, err := s.read(taskID)
@@ -1156,7 +1173,10 @@ func applyRunPatch(run *AgentRun, p RunPatch) {
 }
 
 func (s *Store) UpdateRun(taskID, agentID string, patch RunPatch) error {
-	unlock := s.lockTask(taskID)
+	unlock, err := s.lockTask(taskID)
+	if err != nil {
+		return err
+	}
 	defer unlock()
 
 	t, err := s.read(taskID)

--- a/internal/task/store_test.go
+++ b/internal/task/store_test.go
@@ -1,8 +1,10 @@
 package task
 
 import (
+	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"sync"
@@ -2011,5 +2013,115 @@ func TestReasoningEffortRoundTrip(t *testing.T) {
 	// Invalid value must error.
 	if _, err := store.UpdateMap(tk.ID, map[string]any{"reasoning_effort": "ultra"}); err == nil {
 		t.Error("expected error for invalid reasoning_effort, got nil")
+	}
+}
+
+// crossProcessHelperEnv triggers TestStoreCrossProcessUpdate to run as a
+// worker process instead of the top-level test. Set by
+// runCrossProcessHelper; unset (and thus falsy) in a normal `go test` run.
+const crossProcessHelperEnv = "SYBRA_TASK_CROSS_PROCESS_DIR"
+
+// TestStoreCrossProcessUpdate spawns two real OS processes — each with its
+// own *Store over the same tasks dir, exactly how the GUI server and
+// sybra-cli run in production — and has one flip Status while the other
+// appends an AgentRun on the same task concurrently. Both do an internal
+// read-modify-write (UpdateWithPrev / addRun); without a cross-process lock
+// held across that whole section, whichever process writes last does so from
+// its own stale read and silently drops the other's change. Regression test
+// for the flock added to lockTask.
+func TestStoreCrossProcessUpdate(t *testing.T) {
+	if dir := os.Getenv(crossProcessHelperEnv); dir != "" {
+		runCrossProcessUpdateWorker(t, dir)
+		return
+	}
+	t.Parallel()
+
+	dir := t.TempDir()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tk, err := store.Create("cross-process update", "body", "headless")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	const rounds = 8
+	for i := range rounds {
+		statusCmd := crossProcessUpdateCmd(t, dir, "status", tk.ID)
+		runCmd := crossProcessUpdateCmd(t, dir, "run", tk.ID)
+
+		if err := statusCmd.Start(); err != nil {
+			t.Fatalf("round %d: start status worker: %v", i, err)
+		}
+		if err := runCmd.Start(); err != nil {
+			t.Fatalf("round %d: start run worker: %v", i, err)
+		}
+		if err := statusCmd.Wait(); err != nil {
+			t.Fatalf("round %d: status worker: %v", i, err)
+		}
+		if err := runCmd.Wait(); err != nil {
+			t.Fatalf("round %d: run worker: %v", i, err)
+		}
+
+		got, err := store.Get(tk.ID)
+		if err != nil {
+			t.Fatalf("round %d: get: %v", i, err)
+		}
+		if got.Status != StatusInProgress {
+			t.Fatalf("round %d: Status = %q, want %q — dropped by concurrent cross-process write", i, got.Status, StatusInProgress)
+		}
+		if len(got.AgentRuns) != i+1 {
+			t.Fatalf("round %d: len(AgentRuns) = %d, want %d — dropped by concurrent cross-process write", i, len(got.AgentRuns), i+1)
+		}
+
+		// Reset status so the next round can observe a fresh flip.
+		if _, err := store.Update(tk.ID, Update{Status: new(StatusTodo)}); err != nil {
+			t.Fatalf("round %d: reset status: %v", i, err)
+		}
+	}
+}
+
+func crossProcessUpdateCmd(t *testing.T, dir, mode, taskID string) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^TestStoreCrossProcessUpdate$", "-test.v")
+	cmd.Env = append(os.Environ(),
+		crossProcessHelperEnv+"="+dir,
+		"SYBRA_TASK_CROSS_PROCESS_MODE="+mode,
+		"SYBRA_TASK_CROSS_PROCESS_TASK_ID="+taskID,
+	)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	t.Cleanup(func() {
+		if t.Failed() {
+			t.Logf("worker[%s] output:\n%s", mode, out.String())
+		}
+	})
+	return cmd
+}
+
+// runCrossProcessUpdateWorker is the body executed inside the spawned
+// worker process. It performs exactly one store operation, selected by
+// SYBRA_TASK_CROSS_PROCESS_MODE, against the shared tasks dir passed via
+// crossProcessHelperEnv.
+func runCrossProcessUpdateWorker(t *testing.T, dir string) {
+	t.Helper()
+	store, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("worker: new store: %v", err)
+	}
+	taskID := os.Getenv("SYBRA_TASK_CROSS_PROCESS_TASK_ID")
+	switch os.Getenv("SYBRA_TASK_CROSS_PROCESS_MODE") {
+	case "status":
+		if _, err := store.Update(taskID, Update{Status: new(StatusInProgress)}); err != nil {
+			t.Fatalf("worker: update status: %v", err)
+		}
+	case "run":
+		if err := store.AddRun(taskID, AgentRun{AgentID: fmt.Sprintf("agent-%d", os.Getpid())}); err != nil {
+			t.Fatalf("worker: add run: %v", err)
+		}
+	default:
+		t.Fatal("worker: unknown SYBRA_TASK_CROSS_PROCESS_MODE")
 	}
 }


### PR DESCRIPTION
## Motivation

sybra-cli, the recovery sweep, and the GUI server each open a separate `task.Store`/`loopagent.Store`/`stats.Store`/`limits.Store` over the same files as independent OS processes. Their read-modify-write paths only serialized within one process via `sync.Mutex`, so two processes updating the same task or store concurrently could silently drop a field.

Closes https://github.com/Automaat/sybra/issues/1317

## Implementation information

- Add `internal/fsutil.LockFile`, an advisory flock on a sibling `.lock` file, held across each read-modify-write critical section alongside the existing in-process mutex.
- Apply it to `task.Store` (`UpdateWithPrev`, `addRun`, `UpdateRun`, `Delete`), `loopagent.Store` (`Update`, new `UpdateRunMetadata`), `stats.Store`, and `limits.Store`.
- For stats and limits, whose in-memory state is otherwise loaded once at `NewStore` time, reload from disk under the lock immediately before merging a new write so a concurrent writer's update isn't clobbered by a stale in-memory view.
- Route the loop-agent scheduler's run-metadata bookkeeping (`LastRunAt`, `LastRunID`, `LastRunCost`) through the new locked `UpdateRunMetadata` path instead of a raw read+`writeFile`, so it no longer races `Update`.
- Add a `Len()` fast-path guard to `stats.Backfill` so it's a no-op cost after the first successful run instead of scanning the full audit dir on every startup.

_Generated by Sybra harness_