### PR TITLE
feat(ui): display agent learning journal digests

### DIFF
--- a/frontend/src/components/LearningDigestCard.svelte
+++ b/frontend/src/components/LearningDigestCard.svelte
@@ -75,7 +75,6 @@
 
 {#snippet chip(text: string, tone: 'neutral' | 'warning' = 'neutral')}
   <span
-    class:class={false}
     class={[
       'inline-flex max-w-full items-center truncate rounded px-1.5 py-0.5 text-[10px] font-medium',
       tone === 'warning'
@@ -97,7 +96,7 @@
         {/if}
       </div>
       <ul class="flex flex-col gap-1.5">
-        {#each items as item (item)}
+        {#each items as item, index (`${index}-${item}`)}
           <li class="rounded border border-surface-200 bg-white px-3 py-2 text-sm dark:border-surface-700 dark:bg-surface-900">
             {item}
           </li>

--- a/frontend/src/components/LearningDigestCard.svelte
+++ b/frontend/src/components/LearningDigestCard.svelte
@@ -1,0 +1,212 @@
+<script lang="ts">
+  import type { Digest, EvidenceRef, Status, Takeaway } from '../../bindings/github.com/Automaat/sybra/internal/learning/models.js'
+
+  const HISTORY_CAP = 12
+
+  type Props = {
+    digests?: Digest[]
+    status?: Status | null
+    loading?: boolean
+    error?: string
+  }
+
+  type ViewState = 'error' | 'loading' | 'disabled' | 'empty' | 'invalid' | 'populated'
+
+  let { digests = [], status = null, loading = false, error = '' }: Props = $props()
+
+  const latest = $derived(digests[0] ?? null)
+  const history = $derived(digests.slice(1, HISTORY_CAP + 1))
+  const hiddenHistoryCount = $derived(Math.max(digests.length - 1 - HISTORY_CAP, 0))
+  const state = $derived<ViewState>(deriveState({ digests, status, loading, error }))
+
+  function hasItems<T>(items: T[] | undefined): items is T[] {
+    return Array.isArray(items) && items.length > 0
+  }
+
+  function validDigest(digest: Digest | null): digest is Digest {
+    return !!digest
+      && typeof digest.generatedAt === 'string'
+      && typeof digest.since === 'string'
+      && typeof digest.until === 'string'
+      && typeof digest.reportDigest === 'string'
+  }
+
+  function hasRenderableSections(digest: Digest): boolean {
+    return hasItems(digest.worked)
+      || hasItems(digest.notWorked)
+      || hasItems(digest.uncertain)
+      || hasItems(digest.nextBets)
+      || hasItems(digest.promptTakeaways)
+      || hasItems(digest.skillTakeaways)
+      || hasItems(digest.modelTakeaways)
+  }
+
+  function deriveState(input: Props): ViewState {
+    if (input.error) return 'error'
+    if (input.loading) return 'loading'
+    if (input.status && !input.status.enabled) return 'disabled'
+    if (!input.digests || input.digests.length === 0) return 'empty'
+    const first = input.digests[0] ?? null
+    if (!validDigest(first) || !hasRenderableSections(first)) return 'invalid'
+    return 'populated'
+  }
+
+  function formatDate(value: string | null | undefined): string {
+    if (!value) return 'unknown'
+    const date = new Date(value)
+    if (Number.isNaN(date.getTime())) return value
+    return new Intl.DateTimeFormat(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(date)
+  }
+
+  function shortDigest(value: string): string {
+    return value.length > 10 ? value.slice(0, 10) : value
+  }
+
+  function author(digest: Digest): string {
+    const parts = [digest.authorProvider, digest.authorModel].filter(Boolean)
+    return parts.length > 0 ? parts.join(' / ') : 'unknown author'
+  }
+</script>
+
+{#snippet chip(text: string, tone: 'neutral' | 'warning' = 'neutral')}
+  <span
+    class:class={false}
+    class={[
+      'inline-flex max-w-full items-center truncate rounded px-1.5 py-0.5 text-[10px] font-medium',
+      tone === 'warning'
+        ? 'bg-warning-200 text-warning-800 dark:bg-warning-800 dark:text-warning-200'
+        : 'bg-surface-200 text-surface-600 dark:bg-surface-700 dark:text-surface-200',
+    ].join(' ')}
+  >
+    {text}
+  </span>
+{/snippet}
+
+{#snippet textList(title: string, items: string[] | undefined, tentative = false)}
+  {#if hasItems(items)}
+    <section class="flex flex-col gap-2">
+      <div class="flex items-center gap-2">
+        <h4 class="text-xs font-semibold uppercase tracking-normal text-surface-500">{title}</h4>
+        {#if tentative}
+          {@render chip('tentative · low N', 'warning')}
+        {/if}
+      </div>
+      <ul class="flex flex-col gap-1.5">
+        {#each items as item (item)}
+          <li class="rounded border border-surface-200 bg-white px-3 py-2 text-sm dark:border-surface-700 dark:bg-surface-900">
+            {item}
+          </li>
+        {/each}
+      </ul>
+    </section>
+  {/if}
+{/snippet}
+
+{#snippet takeawayList(title: string, kind: string, items: Takeaway[] | undefined)}
+  {#if hasItems(items)}
+    <section class="flex flex-col gap-2">
+      <h4 class="text-xs font-semibold uppercase tracking-normal text-surface-500">{title}</h4>
+      <ul class="flex flex-col gap-1.5">
+        {#each items as item (`${kind}:${item.text}:${item.experimentRef ?? ''}:${item.variantRef ?? ''}`)}
+          <li class="rounded border border-surface-200 bg-white px-3 py-2 text-sm dark:border-surface-700 dark:bg-surface-900">
+            <div class="flex flex-wrap items-center gap-2">
+              {@render chip(kind)}
+              <span>{item.text}</span>
+            </div>
+            {#if item.experimentRef || item.variantRef}
+              <div class="mt-2 flex flex-wrap gap-1.5">
+                {#if item.experimentRef}
+                  {@render chip(`experiment ${item.experimentRef}`)}
+                {/if}
+                {#if item.variantRef}
+                  {@render chip(`variant ${item.variantRef}`)}
+                {/if}
+              </div>
+            {/if}
+          </li>
+        {/each}
+      </ul>
+    </section>
+  {/if}
+{/snippet}
+
+{#snippet evidenceList(items: EvidenceRef[] | undefined)}
+  {#if hasItems(items)}
+    <div class="flex flex-wrap gap-1.5">
+      {#each items as item (`${item.kind}:${item.id}`)}
+        {@render chip(`${item.kind} ${item.id}`)}
+      {/each}
+    </div>
+  {/if}
+{/snippet}
+
+{#snippet digestBody(digest: Digest)}
+  <div class="flex flex-col gap-4">
+    <div class="flex flex-wrap items-center gap-2 text-xs text-surface-400">
+      <span>{formatDate(digest.since)} → {formatDate(digest.until)}</span>
+      <span>generated {formatDate(digest.generatedAt)}</span>
+      <span>{author(digest)}</span>
+      {@render chip(`report ${shortDigest(digest.reportDigest)}`)}
+    </div>
+
+    {@render textList('Worked', digest.worked)}
+    {@render textList('Not worked', digest.notWorked)}
+    {@render textList('Uncertain', digest.uncertain, true)}
+    {@render textList('Next bets', digest.nextBets)}
+    {@render takeawayList('Prompt takeaways', 'prompt', digest.promptTakeaways)}
+    {@render takeawayList('Skill takeaways', 'skill', digest.skillTakeaways)}
+    {@render takeawayList('Model takeaways', 'model', digest.modelTakeaways)}
+    {@render evidenceList(digest.evidence)}
+  </div>
+{/snippet}
+
+<section class="rounded-lg border border-surface-300 bg-surface-50 p-4 dark:border-surface-600 dark:bg-surface-800">
+  <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
+    <h3 class="text-sm font-semibold text-surface-500">Agent learning journal</h3>
+    {#if status?.nextRun}
+      <span class="text-xs text-surface-400">next run {formatDate(status.nextRun)}</span>
+    {/if}
+  </div>
+
+  {#if state === 'error'}
+    <p class="text-sm text-error-500">Could not load the learning journal: {error}</p>
+  {:else if state === 'loading'}
+    <p class="text-sm text-surface-400">Loading the latest learning digest…</p>
+  {:else if state === 'disabled'}
+    <p class="text-sm text-surface-400">Learning digest pipeline is off. No journal entries will appear until it is enabled.</p>
+  {:else if state === 'empty'}
+    <p class="text-sm text-surface-400">No learning digests have been generated yet.</p>
+  {:else if state === 'invalid' || !latest}
+    <p class="text-sm text-warning-600 dark:text-warning-300">Latest learning digest is incomplete and cannot be rendered safely.</p>
+  {:else}
+    {@render digestBody(latest)}
+
+    {#if history.length > 0}
+      <div class="mt-5 border-t border-surface-200 pt-4 dark:border-surface-700">
+        <div class="mb-2 flex flex-wrap items-baseline justify-between gap-2">
+          <h4 class="text-xs font-semibold uppercase tracking-normal text-surface-500">History</h4>
+          {#if hiddenHistoryCount > 0}
+            <span class="text-xs text-surface-400">showing {history.length} of {digests.length - 1} older digests</span>
+          {/if}
+        </div>
+        <div class="flex flex-col gap-2">
+          {#each history as digest (`${digest.since}:${digest.until}:${digest.reportDigest}`)}
+            <details class="rounded border border-surface-200 bg-white p-3 dark:border-surface-700 dark:bg-surface-900">
+              <summary class="cursor-pointer text-sm text-surface-600 dark:text-surface-300">
+                {formatDate(digest.since)} → {formatDate(digest.until)} · generated {formatDate(digest.generatedAt)}
+              </summary>
+              <div class="mt-3">
+                {@render digestBody(digest)}
+              </div>
+            </details>
+          {/each}
+        </div>
+      </div>
+    {/if}
+  {/if}
+</section>

--- a/frontend/src/components/LearningDigestCard.svelte.test.ts
+++ b/frontend/src/components/LearningDigestCard.svelte.test.ts
@@ -1,0 +1,89 @@
+import { cleanup, render, screen } from '@testing-library/svelte'
+import { afterEach, describe, expect, it } from 'vitest'
+import LearningDigestCard from './LearningDigestCard.svelte'
+import type { Digest, Status } from '../../bindings/github.com/Automaat/sybra/internal/learning/models.js'
+
+function makeDigest(overrides: Partial<Digest> = {}): Digest {
+  return {
+    schemaVersion: 1,
+    generatedAt: '2026-07-02T10:30:00Z',
+    since: '2026-07-02T08:00:00Z',
+    until: '2026-07-02T10:00:00Z',
+    reportDigest: 'abcdef1234567890',
+    authorProvider: 'codex',
+    authorModel: 'gpt-5',
+    worked: ['Small scoped changes landed cleanly.'],
+    notWorked: ['Late review feedback created rework.'],
+    uncertain: ['Prompt variant might help, but sample size is low.'],
+    nextBets: ['Try the tighter reviewer prompt.'],
+    promptTakeaways: [{ text: 'Ask for evidence before edits.', experimentRef: 'exp-prompt', variantRef: 'v2' }],
+    evidence: [{ kind: 'task', id: '0271ee7f' }],
+    ...overrides,
+  } as Digest
+}
+
+function makeStatus(overrides: Partial<Status> = {}): Status {
+  return { enabled: true, nextRun: '2026-07-02T12:00:00Z', ...overrides } as Status
+}
+
+describe('LearningDigestCard', () => {
+  afterEach(() => cleanup())
+
+  it('renders a populated digest with bounded refs and history', () => {
+    const older = makeDigest({
+      reportDigest: 'old1234567890',
+      since: '2026-07-01T08:00:00Z',
+      until: '2026-07-01T10:00:00Z',
+      generatedAt: '2026-07-01T10:30:00Z',
+      worked: ['Older lesson.'],
+      notWorked: [],
+      uncertain: [],
+      nextBets: [],
+      promptTakeaways: [],
+      evidence: [],
+    })
+
+    render(LearningDigestCard, { props: { digests: [makeDigest(), older], status: makeStatus() } })
+
+    expect(screen.getByText('Agent learning journal')).toBeDefined()
+    expect(screen.getAllByText('Worked').length).toBeGreaterThan(0)
+    expect(screen.getByText('Small scoped changes landed cleanly.')).toBeDefined()
+    expect(screen.getByText('Prompt takeaways')).toBeDefined()
+    expect(screen.getByText('experiment exp-prompt')).toBeDefined()
+    expect(screen.getByText('variant v2')).toBeDefined()
+    expect(screen.getByText('task 0271ee7f')).toBeDefined()
+    expect(screen.queryByText('abcdef1234567890')).toBeNull()
+    expect(screen.getByText('History')).toBeDefined()
+    // latest digest body + at least one history entry each render a "generated" timestamp
+    expect(screen.getAllByText(/generated/i).length).toBeGreaterThan(1)
+  })
+
+  it('renders empty, disabled, and invalid states distinctly', () => {
+    const { unmount } = render(LearningDigestCard, { props: { digests: [], status: makeStatus() } })
+    expect(screen.getByText('No learning digests have been generated yet.')).toBeDefined()
+    unmount()
+
+    render(LearningDigestCard, { props: { digests: [], status: makeStatus({ enabled: false }) } })
+    expect(screen.getByText('Learning digest pipeline is off. No journal entries will appear until it is enabled.')).toBeDefined()
+    cleanup()
+
+    render(LearningDigestCard, { props: { digests: [makeDigest({ worked: [], notWorked: [], uncertain: [], nextBets: [], promptTakeaways: [] })], status: makeStatus() } })
+    expect(screen.getByText('Latest learning digest is incomplete and cannot be rendered safely.')).toBeDefined()
+  })
+
+  it('renders loading and error states as visible lines', () => {
+    const { unmount } = render(LearningDigestCard, { props: { loading: true } })
+    expect(screen.getByText('Loading the latest learning digest…')).toBeDefined()
+    unmount()
+
+    render(LearningDigestCard, { props: { error: 'boom' } })
+    expect(screen.getByText('Could not load the learning journal: boom')).toBeDefined()
+  })
+
+  it('marks uncertain claims as tentative low-sample evidence', () => {
+    render(LearningDigestCard, { props: { digests: [makeDigest()], status: makeStatus() } })
+
+    expect(screen.getByText('tentative · low N')).toBeDefined()
+    expect(screen.getByText('Prompt variant might help, but sample size is low.')).toBeDefined()
+  })
+})

--- a/frontend/src/pages/Evaluation.svelte
+++ b/frontend/src/pages/Evaluation.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import ExperimentGroup from '../components/ExperimentGroup.svelte'
+  import LearningDigestCard from '../components/LearningDigestCard.svelte'
   import { hours, num, pct, rateCell, seconds } from '$lib/evaluation-format.js'
   import { evaluationStore } from '../stores/evaluation.svelte.js'
+  import { learningStore } from '../stores/learning.svelte.js'
   import { lifecycleStore } from '../stores/lifecycle.svelte.js'
   import type { ExperimentKindBreakdown } from '../../bindings/github.com/Automaat/sybra/internal/evaluation/models.js'
 
@@ -47,7 +49,12 @@
     evaluationStore.load()
     evaluationStore.listen()
     lifecycleStore.load()
-    return () => evaluationStore.stopListening()
+    learningStore.load()
+    learningStore.listen()
+    return () => {
+      evaluationStore.stopListening()
+      learningStore.stopListening()
+    }
   })
 
   // Higher is better for these; render the bar/colour accordingly.
@@ -244,6 +251,13 @@
       </div>
     {/if}
 
+    <LearningDigestCard
+      digests={learningStore.digests}
+      status={learningStore.status}
+      loading={learningStore.loading}
+      error={learningStore.error}
+    />
+
     <!-- Breakdowns -->
     <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
       {#each [
@@ -426,5 +440,11 @@
     {/if}
   {:else if !evaluationStore.error}
     <p class="text-sm text-surface-400">No evaluation data yet.</p>
+    <LearningDigestCard
+      digests={learningStore.digests}
+      status={learningStore.status}
+      loading={learningStore.loading}
+      error={learningStore.error}
+    />
   {/if}
 </div>

--- a/frontend/src/pages/Evaluation.svelte.test.ts
+++ b/frontend/src/pages/Evaluation.svelte.test.ts
@@ -17,8 +17,22 @@ const mockLifecycleStore = {
   load: vi.fn(),
 }
 
+const mockLearningStore = {
+  digests: [] as Record<string, unknown>[],
+  status: null as Record<string, unknown> | null,
+  loading: false,
+  error: '',
+  load: vi.fn(),
+  listen: vi.fn(),
+  stopListening: vi.fn(),
+}
+
 vi.mock('../stores/evaluation.svelte.js', () => ({
   evaluationStore: mockEvaluationStore,
+}))
+
+vi.mock('../stores/learning.svelte.js', () => ({
+  learningStore: mockLearningStore,
 }))
 
 vi.mock('../stores/lifecycle.svelte.js', () => ({
@@ -120,6 +134,10 @@ describe('Evaluation', () => {
     mockEvaluationStore.loading = false
     mockEvaluationStore.error = ''
     mockLifecycleStore.data = null
+    mockLearningStore.digests = []
+    mockLearningStore.status = null
+    mockLearningStore.loading = false
+    mockLearningStore.error = ''
   })
 
   afterEach(() => {
@@ -196,5 +214,29 @@ describe('Evaluation', () => {
     expect(within(promptSection).getByText('prompt-author', { exact: false })).toBeDefined()
     expect(within(promptSection).getByText('prompt-review', { exact: false })).toBeDefined()
     expect(within(promptSection).getAllByRole('table')).toHaveLength(2)
+  })
+
+  it('mounts the learning digest card and cleans up the listener', () => {
+    const rendered = render(Evaluation, { props: {} })
+
+    expect(screen.getByText('Agent learning journal')).toBeDefined()
+    expect(mockLearningStore.load).toHaveBeenCalledTimes(1)
+    expect(mockLearningStore.listen).toHaveBeenCalledTimes(1)
+
+    rendered.unmount()
+
+    expect(mockLearningStore.stopListening).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the learning card visible when evaluation data is empty', () => {
+    mockEvaluationStore.data = null
+    mockLearningStore.status = { enabled: false, nextRun: null }
+
+    render(Evaluation, { props: {} })
+
+    expect(screen.getByText('No evaluation data yet.')).toBeDefined()
+    expect(
+      screen.getByText('Learning digest pipeline is off. No journal entries will appear until it is enabled.'),
+    ).toBeDefined()
   })
 })

--- a/frontend/src/stores/learning.svelte.test.ts
+++ b/frontend/src/stores/learning.svelte.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { LearningSummary } from '../lib/events.js'
+import type { Digest, Status } from '../../bindings/github.com/Automaat/sybra/internal/learning/models.js'
+
+const mockListDigests = vi.fn()
+const mockGetLearningDigestStatus = vi.fn()
+const eventCallbacks: Record<string, (data: unknown) => void> = {}
+const cancelListener = vi.fn()
+
+vi.mock('$lib/api', () => ({
+  ListDigests: (...args: unknown[]) => mockListDigests(...args),
+  GetLearningDigestStatus: (...args: unknown[]) => mockGetLearningDigestStatus(...args),
+  EventsOn: (event: string, cb: (data: unknown) => void) => {
+    eventCallbacks[event] = cb
+    return cancelListener
+  },
+}))
+
+const { LearningStore } = await import('./learning.svelte.js')
+
+function makeDigest(overrides: Partial<Digest> = {}): Digest {
+  return {
+    schemaVersion: 1,
+    generatedAt: '2026-07-02T10:00:00Z',
+    since: '2026-07-02T08:00:00Z',
+    until: '2026-07-02T09:00:00Z',
+    reportDigest: 'abcdef1234567890',
+    worked: ['kept changes small'],
+    ...overrides,
+  } as Digest
+}
+
+function makeStatus(overrides: Partial<Status> = {}): Status {
+  return {
+    enabled: true,
+    nextRun: '2026-07-02T11:00:00Z',
+    ...overrides,
+  } as Status
+}
+
+describe('LearningStore', () => {
+  let store: InstanceType<typeof LearningStore>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    for (const key of Object.keys(eventCallbacks)) delete eventCallbacks[key]
+    store = new LearningStore()
+  })
+
+  it('loads digests and status from the backend', async () => {
+    const digest = makeDigest()
+    const status = makeStatus()
+    mockListDigests.mockResolvedValue([digest])
+    mockGetLearningDigestStatus.mockResolvedValue(status)
+
+    await store.load()
+
+    expect(mockListDigests).toHaveBeenCalledTimes(1)
+    expect(mockGetLearningDigestStatus).toHaveBeenCalledTimes(1)
+    expect(store.digests).toEqual([digest])
+    expect(store.status).toEqual(status)
+    expect(store.loading).toBe(false)
+    expect(store.error).toBe('')
+  })
+
+  it('sets error and clears loading when load fails', async () => {
+    mockListDigests.mockRejectedValue(new Error('digest read failed'))
+    mockGetLearningDigestStatus.mockResolvedValue(makeStatus())
+
+    await store.load()
+
+    expect(store.error).toBe('Error: digest read failed')
+    expect(store.loading).toBe(false)
+  })
+
+  it('prepends learning summary events and deduplicates by digest key', () => {
+    const oldDigest = makeDigest({ reportDigest: 'old', since: '2026-07-02T06:00:00Z', until: '2026-07-02T07:00:00Z' })
+    const newDigest = makeDigest({ reportDigest: 'new', since: '2026-07-02T07:00:00Z', until: '2026-07-02T08:00:00Z' })
+    store.digests = [oldDigest]
+
+    store.listen()
+    eventCallbacks[LearningSummary](newDigest)
+    eventCallbacks[LearningSummary](newDigest)
+
+    expect(store.digests).toEqual([newDigest, oldDigest])
+  })
+
+  it('ignores malformed learning summary events', () => {
+    const digest = makeDigest()
+    store.digests = [digest]
+
+    store.listen()
+    eventCallbacks[LearningSummary]({ reportDigest: 'bad' })
+
+    expect(store.digests).toEqual([digest])
+  })
+
+  it('keeps disabled status distinct from an enabled empty journal', async () => {
+    mockListDigests.mockResolvedValue([])
+    mockGetLearningDigestStatus.mockResolvedValue(makeStatus({ enabled: false }))
+
+    await store.load()
+
+    expect(store.digests).toEqual([])
+    expect(store.status?.enabled).toBe(false)
+  })
+
+  it('cancels the active listener', () => {
+    store.listen()
+    store.stopListening()
+
+    expect(cancelListener).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/stores/learning.svelte.ts
+++ b/frontend/src/stores/learning.svelte.ts
@@ -1,0 +1,82 @@
+import { EventsOn, GetLearningDigestStatus, ListDigests } from '$lib/api'
+import { LearningSummary } from '../lib/events.js'
+import type { Digest, Status } from '../../bindings/github.com/Automaat/sybra/internal/learning/models.js'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object'
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string')
+}
+
+function isTakeawayArray(value: unknown): boolean {
+  return Array.isArray(value) && value.every((item) => isRecord(item) && typeof item.text === 'string')
+}
+
+function isEvidenceArray(value: unknown): boolean {
+  return Array.isArray(value) && value.every((item) => isRecord(item) && typeof item.kind === 'string' && typeof item.id === 'string')
+}
+
+function isDigest(value: unknown): value is Digest {
+  if (!isRecord(value)) return false
+  if (typeof value.schemaVersion !== 'number') return false
+  if (typeof value.generatedAt !== 'string') return false
+  if (typeof value.since !== 'string') return false
+  if (typeof value.until !== 'string') return false
+  if (typeof value.reportDigest !== 'string') return false
+
+  for (const key of ['worked', 'notWorked', 'uncertain', 'nextBets']) {
+    if (key in value && value[key] !== undefined && !isStringArray(value[key])) return false
+  }
+  for (const key of ['promptTakeaways', 'skillTakeaways', 'modelTakeaways']) {
+    if (key in value && value[key] !== undefined && !isTakeawayArray(value[key])) return false
+  }
+  if ('evidence' in value && value.evidence !== undefined && !isEvidenceArray(value.evidence)) return false
+
+  return true
+}
+
+function digestKey(digest: Digest): string {
+  return `${digest.since}|${digest.until}|${digest.reportDigest}`
+}
+
+export class LearningStore {
+  digests = $state<Digest[]>([])
+  status = $state<Status | null>(null)
+  loading = $state(false)
+  error = $state('')
+  private cancelListener: (() => void) | null = null
+
+  async load(): Promise<void> {
+    this.loading = true
+    this.error = ''
+    try {
+      const [digests, status] = await Promise.all([ListDigests(), GetLearningDigestStatus()])
+      this.digests = digests
+      this.status = status
+    } catch (e) {
+      this.error = String(e)
+    } finally {
+      this.loading = false
+    }
+  }
+
+  listen(): void {
+    this.stopListening()
+    this.cancelListener = EventsOn(LearningSummary, (digest: unknown) => {
+      if (!isDigest(digest)) return
+      const key = digestKey(digest)
+      this.digests = [digest, ...this.digests.filter((d) => digestKey(d) !== key)]
+    })
+  }
+
+  stopListening(): void {
+    if (this.cancelListener) {
+      this.cancelListener()
+      this.cancelListener = null
+    }
+  }
+}
+
+export const learningStore = new LearningStore()


### PR DESCRIPTION
## Motivation

Surface the Agent Learning Journal in the app so a human can read periodic retrospectives from recent Sybra runs. Closes #1212.

> Changelog: feat(ui): display agent learning journal digests

## Implementation information

- New `LearningDigestCard` component + `learning` store on the Evaluation page.
- Live-updates on the `learning:summary` event; renders populated, empty, disabled, invalid, loading, and error states.
- Bounded structured refs only (experiment/variant/task chips); raw report digest hidden.
- Expandable history timeline for older digests.
- Tests cover populated / empty / disabled / invalid / loading / error rendering.

## Supporting documentation

Backend (#1210 store, #1375 digest agent) already on main. Frontend-only change.

Recovered from an interrupted interactive agent run: the work was complete but uncommitted in the worktree; three test assertions written against stale component text/types were corrected. Full frontend suite green (1637 passed), svelte-check + oxlint clean.