### PR TITLE
test(ci): add mise run verify CI-parity gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,7 +337,7 @@ There is no Vite-backed hot reload — the frontend is built once per `mise run 
 
 ## Quality Gates
 
-**`mise run verify` is the pre-commit gate — it mirrors `.github/workflows/ci.yml` exactly** (frontend build, `go test -race ./...`, `go test -race -tags e2e ./internal/sybra/...`, golangci-lint, frontend check + oxlint, Wails bindings drift check, hadolint). Running only `go test ./...` skips the e2e suite entirely (it's gated behind `//go:build e2e`) and will ship green-local / red-CI.
+**`mise run verify` is the pre-commit gate — it runs every deterministic, offline gate in `.github/workflows/ci.yml`** (frontend build:desktop + build:web, `go build ./...`, `go mod verify`, `go test -race ./...`, `go test -race -tags e2e ./internal/sybra/...`, golangci-lint, frontend check + test:coverage + oxlint + pin-strategy, api-shim sync, Wails bindings drift check, hadolint). It intentionally excludes the CI jobs that need network downloads or a browser and so can't run as a reliable pre-commit loop — `lint-nilaway`, `security` (govulncheck + npm audit), and the Playwright `e2e` job; CI stays the source of truth for those three. Running only `go test ./...` skips the e2e suite entirely (it's gated behind `//go:build e2e`) and will ship green-local / red-CI.
 
 ```bash
 mise run verify

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,7 +327,7 @@ There is no Vite-backed hot reload — the frontend is built once per `mise run 
 ### Testing
 
 - Go: `go test ./...` — this does **not** compile or run the e2e suite (see below).
-- E2E: `go test -tags e2e ./internal/sybra/...` — 8 files behind `//go:build e2e`, run separately in CI (`test-go-e2e` job). Add `-short` for a ~45s smoke pass that skips the slowest retry-backoff and chaos tests.
+- E2E: `go test -race -tags e2e -timeout 10m ./internal/sybra/...` — matches the CI `test-go-e2e` job exactly; 8 files behind `//go:build e2e`. Add `-short` for a ~45s smoke pass that skips the slowest retry-backoff and chaos tests.
 - Use table-driven tests for Go packages
 - Frontend: `cd frontend && npm run check` (svelte-check)
 - Manual runtime smoke tests: see `docs/manual-testing.md` for the isolated
@@ -337,7 +337,7 @@ There is no Vite-backed hot reload — the frontend is built once per `mise run 
 
 ## Quality Gates
 
-**`mise run verify` is the pre-commit gate — it runs every deterministic, offline gate in `.github/workflows/ci.yml`** (frontend build:desktop + build:web, `go build ./...`, `go mod verify`, `go test -race ./...`, `go test -race -tags e2e ./internal/sybra/...`, golangci-lint, frontend check + test:coverage + oxlint + pin-strategy, api-shim sync, Wails bindings drift check, hadolint). It intentionally excludes the CI jobs that need network downloads or a browser and so can't run as a reliable pre-commit loop — `lint-nilaway`, `security` (govulncheck + npm audit), and the Playwright `e2e` job; CI stays the source of truth for those three. Running only `go test ./...` skips the e2e suite entirely (it's gated behind `//go:build e2e`) and will ship green-local / red-CI.
+**`mise run verify` is the pre-commit gate — it runs every deterministic, CI-aligned gate in `.github/workflows/ci.yml`** (frontend build:desktop + build:web, `go build ./...`, `go mod verify`, `go mod tidy` drift check, `go test -race ./...`, `go test -race -tags e2e ./internal/sybra/...`, golangci-lint, frontend check + test:coverage + oxlint + pin-strategy, api-shim sync, Wails bindings drift check, hadolint). "Deterministic" means the outcome depends only on repo state, not ambient CI infra — some steps (`npm ci`, Go module resolution) still need network access. It intentionally excludes the CI jobs that need external advisory DBs or a browser and so can't run as a reliable pre-commit loop — `lint-nilaway`, `security` (govulncheck + npm audit), and the Playwright `e2e` job; CI stays the source of truth for those three. Running only `go test ./...` skips the e2e suite entirely (it's gated behind `//go:build e2e`) and will ship green-local / red-CI.
 
 ```bash
 mise run verify

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,7 +326,8 @@ There is no Vite-backed hot reload — the frontend is built once per `mise run 
 
 ### Testing
 
-- Go: `go test ./...`
+- Go: `go test ./...` — this does **not** compile or run the e2e suite (see below).
+- E2E: `go test -tags e2e ./internal/sybra/...` — 8 files behind `//go:build e2e`, run separately in CI (`test-go-e2e` job). Add `-short` for a ~45s smoke pass that skips the slowest retry-backoff and chaos tests.
 - Use table-driven tests for Go packages
 - Frontend: `cd frontend && npm run check` (svelte-check)
 - Manual runtime smoke tests: see `docs/manual-testing.md` for the isolated
@@ -336,19 +337,22 @@ There is no Vite-backed hot reload — the frontend is built once per `mise run 
 
 ## Quality Gates
 
+**`mise run verify` is the pre-commit gate — it mirrors `.github/workflows/ci.yml` exactly** (frontend build, `go test -race ./...`, `go test -race -tags e2e ./internal/sybra/...`, golangci-lint, frontend check + oxlint, Wails bindings drift check, hadolint). Running only `go test ./...` skips the e2e suite entirely (it's gated behind `//go:build e2e`) and will ship green-local / red-CI.
+
+```bash
+mise run verify
+```
+
 Before committing:
 
-- [ ] golangci-lint passes
-- [ ] oxlint passes
-- [ ] svelte-check passes
-- [ ] Go tests pass
+- [ ] `mise run verify` passes
 - [ ] `cd frontend && npm run build:desktop && cd .. && go build .` succeeds (darwin)
 
 ```bash
 # Lint all
 mise run lint
 
-# Go tests
+# Go tests (excludes e2e — see Testing above)
 go test ./...
 
 # Frontend type-check

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -906,6 +906,9 @@ func TestE2E_CodexInteractiveAgent_StopTransitionsToStopped(t *testing.T) {
 // Before the provider-guard fix, Codex never retried and the agent stayed
 // failed permanently.
 func TestE2E_Codex_HeadlessRetry_Overloaded(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping 30s retry-backoff wait in short mode")
+	}
 	env := setupE2EMultiProvider(t, "codex", []string{"overloaded_error", "success"})
 
 	ag, err := env.agents.Run(agent.RunConfig{
@@ -943,6 +946,9 @@ func TestE2E_Codex_HeadlessRetry_Overloaded(t *testing.T) {
 // TestE2E_Codex_HeadlessRetry_OverloadedStructured verifies retry behavior
 // when Codex emits a structured overloaded envelope (code=529).
 func TestE2E_Codex_HeadlessRetry_OverloadedStructured(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping 30s retry-backoff wait in short mode")
+	}
 	env := setupE2EMultiProvider(t, "codex", []string{"overloaded_error_structured", "success"})
 
 	ag, err := env.agents.Run(agent.RunConfig{
@@ -4040,6 +4046,9 @@ func TestE2E_CrossProvider_FlipsFromLatestMixedHistory(t *testing.T) {
 }
 
 func TestE2E_CodexRetry_OverloadedThenAuthStopsRetry(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping 30s retry-backoff wait in short mode")
+	}
 	env := setupE2EMultiProvider(t, "codex", []string{"overloaded_error", "auth_error", "success"})
 
 	ag, err := env.agents.Run(agent.RunConfig{

--- a/mise.toml
+++ b/mise.toml
@@ -40,17 +40,21 @@ run = [
 ]
 description = "Run all linters"
 
-# Mirrors every deterministic, offline CI gate so a local pass predicts a green
-# CI run. Intentionally excludes gates that need network downloads or a browser
-# and so cannot run reliably as a pre-commit loop: lint-nilaway (installs
-# nilaway), security (govulncheck + npm audit hit the advisory DBs), and the
-# e2e job (Playwright + chromium + a live server). CI remains the source of
-# truth for those three.
+# Mirrors every deterministic, CI-aligned gate so a local pass predicts a
+# green CI run. "Deterministic" here doesn't mean no network access — npm ci
+# and Go module resolution may still hit the network — it means the gate's
+# outcome depends only on repo state, not on ambient CI infra. Intentionally
+# excludes gates that need external advisory DBs or a browser and so cannot
+# run reliably as a pre-commit loop: lint-nilaway (installs nilaway),
+# security (govulncheck + npm audit hit the advisory DBs), and the e2e job
+# (Playwright + chromium + a live server). CI remains the source of truth for
+# those three.
 [tasks.verify]
 run = [
   "cd frontend && npm ci && npm run build:desktop",
   "go build ./...",
   "go mod verify",
+  "go mod tidy && git diff --exit-code go.mod go.sum",
   "go test -race -timeout 5m ./...",
   "go test -race -tags e2e -timeout 10m ./internal/sybra/...",
   "golangci-lint run ./...",
@@ -60,10 +64,11 @@ run = [
   "cd frontend && npx oxlint .",
   "cd frontend && node scripts/check-pin-strategy.mjs",
   "bash scripts/check-api-shim-sync.sh",
+  "command -v wails3 >/dev/null 2>&1 || (echo 'wails3 not found — install with: go install github.com/wailsapp/wails/v3/cmd/wails3@v3.0.0-alpha.87 (see .github/workflows/ci.yml for the full workaround)' && exit 1)",
   "wails3 generate bindings -ts -clean -d frontend/bindings ./... && git diff --exit-code frontend/bindings/",
   "hadolint Dockerfile",
 ]
-description = "Run every deterministic offline CI gate (go build+mod+tests+e2e, golangci-lint, frontend check+build:web+tests+oxlint+pins, api-shim sync, bindings sync, hadolint). Run before committing. Excludes nilaway/security/playwright — CI owns those."
+description = "Run every deterministic CI-aligned gate (go build+mod+tidy+tests+e2e, golangci-lint, frontend check+build:web+tests+oxlint+pins, api-shim sync, bindings sync, hadolint). Run before committing. Excludes nilaway/security/playwright — CI owns those."
 
 [tasks."build:frontend:desktop"]
 run = "cd frontend && npm run build:desktop"

--- a/mise.toml
+++ b/mise.toml
@@ -40,18 +40,30 @@ run = [
 ]
 description = "Run all linters"
 
+# Mirrors every deterministic, offline CI gate so a local pass predicts a green
+# CI run. Intentionally excludes gates that need network downloads or a browser
+# and so cannot run reliably as a pre-commit loop: lint-nilaway (installs
+# nilaway), security (govulncheck + npm audit hit the advisory DBs), and the
+# e2e job (Playwright + chromium + a live server). CI remains the source of
+# truth for those three.
 [tasks.verify]
 run = [
   "cd frontend && npm ci && npm run build:desktop",
+  "go build ./...",
+  "go mod verify",
   "go test -race -timeout 5m ./...",
   "go test -race -tags e2e -timeout 10m ./internal/sybra/...",
   "golangci-lint run ./...",
   "cd frontend && npm run check",
+  "cd frontend && npm run build:web",
+  "cd frontend && npm run test:coverage",
   "cd frontend && npx oxlint .",
+  "cd frontend && node scripts/check-pin-strategy.mjs",
+  "bash scripts/check-api-shim-sync.sh",
   "wails3 generate bindings -ts -clean -d frontend/bindings ./... && git diff --exit-code frontend/bindings/",
   "hadolint Dockerfile",
 ]
-description = "Mirror the CI gate exactly (go tests+e2e, lint, frontend check+oxlint, bindings sync, hadolint). Run before committing."
+description = "Run every deterministic offline CI gate (go build+mod+tests+e2e, golangci-lint, frontend check+build:web+tests+oxlint+pins, api-shim sync, bindings sync, hadolint). Run before committing. Excludes nilaway/security/playwright — CI owns those."
 
 [tasks."build:frontend:desktop"]
 run = "cd frontend && npm run build:desktop"

--- a/mise.toml
+++ b/mise.toml
@@ -40,6 +40,19 @@ run = [
 ]
 description = "Run all linters"
 
+[tasks.verify]
+run = [
+  "cd frontend && npm ci && npm run build:desktop",
+  "go test -race -timeout 5m ./...",
+  "go test -race -tags e2e -timeout 10m ./internal/sybra/...",
+  "golangci-lint run ./...",
+  "cd frontend && npm run check",
+  "cd frontend && npx oxlint .",
+  "wails3 generate bindings -ts -clean -d frontend/bindings ./... && git diff --exit-code frontend/bindings/",
+  "hadolint Dockerfile",
+]
+description = "Mirror the CI gate exactly (go tests+e2e, lint, frontend check+oxlint, bindings sync, hadolint). Run before committing."
+
 [tasks."build:frontend:desktop"]
 run = "cd frontend && npm run build:desktop"
 description = "Build frontend for desktop (output: frontend/dist/)"


### PR DESCRIPTION
## Motivation

An agent running only the documented `go test ./...` gate compiles none of the `//go:build e2e` files and ships green-local / red-CI. Add a single `mise run verify` that runs the deterministic offline CI gates locally. Closes #1320. Parent #1314.

> Changelog: test(ci): add mise run verify CI-parity gate

## Implementation information

- `mise.toml`: `verify` task running go build + go mod verify + `go test -race ./...` + e2e + golangci-lint + frontend check/build:web/test:coverage/oxlint/pin-strategy + api-shim sync + Wails bindings drift + hadolint.
- Gates the three 30s Codex retry-backoff e2e tests behind `if testing.Short()` (matching the existing `e2e_chaos_test.go` convention) so `go test -short` gives a fast smoke loop.
- Documents `verify` as the pre-commit gate in CLAUDE.md.
- Intentionally excludes `lint-nilaway`, `security` (govulncheck + npm audit), and Playwright `e2e` — they need network downloads or a browser and can't run as a reliable pre-commit loop; CI stays the source of truth for those.

## Supporting documentation

Second commit expands the initial subset to full offline parity and replaces the unqualified 'mirrors CI exactly' wording (a strict reading of which could never pass) with the documented offline scope.