### PR TITLE
feat(agent): jitter/stagger agent dispatch

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,6 +94,7 @@ linters:
         - G302 # file permissions 0644 — intentional for user-readable data files
         - G304 # file inclusion via variable — intentional in this app
         - G306 # WriteFile permissions 0644 — intentional for user-readable files
+        - G404 # non-cryptographic dispatch jitter delay — depguard already forces math/rand/v2 over math/rand
         - G703 # paths validated against known-good roots (homeDir/tmpDir + HasPrefix); gosec taint cannot verify the guard
 
     govet:

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -53,6 +53,19 @@ type Manager struct {
 	limitPolicy   limits.Policy
 	limitSink     func(limits.Snapshot)
 
+	// liveByProvider tracks in-flight agent counts per provider, incremented
+	// and decremented in lockstep with liveCount (registerRunningAgent,
+	// markAgentDone, and the three ReattachAll restart paths) so
+	// sum(liveByProvider) == liveCount always holds. Read by gateProvider to
+	// steer dispatch away from an at-cap provider.
+	liveByProvider map[string]int
+	// maxInFlightPerProvider caps concurrent in-flight agents per provider.
+	// 0 disables the cap (soft cap: never blocks dispatch, only redirects).
+	maxInFlightPerProvider int
+	// dispatchJitterMs bounds a uniform random delay applied before headless
+	// dispatch to de-correlate a wave of same-tick starts. 0 disables jitter.
+	dispatchJitterMs int
+
 	// reg persists live-agent records so subprocesses can be reattached
 	// after an app restart. nil disables survival (legacy behaviour).
 	// Manager.mu guards only this pointer and survival config; registryStore
@@ -112,6 +125,12 @@ type ManagerRuntimeConfig struct {
 	FallbackModel   string
 	LimitGate       LimitGate
 	LimitPolicy     limits.Policy
+	// MaxInFlightPerProvider caps concurrent in-flight agents per provider.
+	// 0 disables the cap.
+	MaxInFlightPerProvider int
+	// DispatchJitterMs bounds a uniform random delay applied before headless
+	// dispatch. 0 disables jitter.
+	DispatchJitterMs int
 }
 
 func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir string, cfg ManagerConfig) (*Manager, error) {
@@ -120,24 +139,27 @@ func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir 
 		return nil, fmt.Errorf("default provider: %w", err)
 	}
 	m := &Manager{
-		agents:         make(map[string]*Agent),
-		dispatchClaims: make(map[string]struct{}),
-		ctx:            ctx,
-		emit:           emit,
-		onComplete:     cfg.OnComplete,
-		logger:         logger,
-		logDir:         logDir,
-		approvalAddr:   cfg.ApprovalAddr,
-		defaultProv:    defaultProv,
-		maxConcurrent:  cfg.Runtime.MaxConcurrent,
-		bashTimeoutMs:  cfg.Runtime.BashTimeoutMs,
-		retryWatchdog:  cfg.Runtime.RetryWatchdog,
-		fallbackModel:  cfg.Runtime.FallbackModel,
-		limitGate:      cfg.Runtime.LimitGate,
-		limitPolicy:    copyLimitPolicy(cfg.Runtime.LimitPolicy),
-		limitSink:      cfg.LimitSink,
-		sessionSink:    cfg.SessionSink,
-		taskExists:     cfg.TaskExists,
+		agents:                 make(map[string]*Agent),
+		dispatchClaims:         make(map[string]struct{}),
+		liveByProvider:         make(map[string]int),
+		ctx:                    ctx,
+		emit:                   emit,
+		onComplete:             cfg.OnComplete,
+		logger:                 logger,
+		logDir:                 logDir,
+		approvalAddr:           cfg.ApprovalAddr,
+		defaultProv:            defaultProv,
+		maxConcurrent:          cfg.Runtime.MaxConcurrent,
+		bashTimeoutMs:          cfg.Runtime.BashTimeoutMs,
+		retryWatchdog:          cfg.Runtime.RetryWatchdog,
+		fallbackModel:          cfg.Runtime.FallbackModel,
+		limitGate:              cfg.Runtime.LimitGate,
+		limitPolicy:            copyLimitPolicy(cfg.Runtime.LimitPolicy),
+		limitSink:              cfg.LimitSink,
+		sessionSink:            cfg.SessionSink,
+		taskExists:             cfg.TaskExists,
+		maxInFlightPerProvider: cfg.Runtime.MaxInFlightPerProvider,
+		dispatchJitterMs:       cfg.Runtime.DispatchJitterMs,
 	}
 	if cfg.SurviveRestartDir != "" {
 		s, err := newRegistryStore(cfg.SurviveRestartDir)
@@ -193,8 +215,18 @@ func (m *Manager) ReplaceRuntimeConfig(cfg ManagerRuntimeConfig) error {
 	m.fallbackModel = cfg.FallbackModel
 	m.limitGate = cfg.LimitGate
 	m.limitPolicy = copyLimitPolicy(cfg.LimitPolicy)
+	m.maxInFlightPerProvider = cfg.MaxInFlightPerProvider
+	m.dispatchJitterMs = cfg.DispatchJitterMs
 	m.mu.Unlock()
 	return nil
+}
+
+// InFlightByProvider returns a snapshot of in-flight agent counts by
+// provider, kept in lockstep with RunningCount's liveCount.
+func (m *Manager) InFlightByProvider() map[string]int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return maps.Clone(m.liveByProvider)
 }
 
 func (m *Manager) sessionSinkFn() func(taskID, agentID, sessionID string) error {

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -161,6 +161,7 @@ func NewManager(ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir 
 		maxInFlightPerProvider: cfg.Runtime.MaxInFlightPerProvider,
 		dispatchJitterMs:       cfg.Runtime.DispatchJitterMs,
 	}
+	warnInertCap(logger, m.maxInFlightPerProvider, m.limitGate)
 	if cfg.SurviveRestartDir != "" {
 		s, err := newRegistryStore(cfg.SurviveRestartDir)
 		if err != nil {
@@ -218,7 +219,18 @@ func (m *Manager) ReplaceRuntimeConfig(cfg ManagerRuntimeConfig) error {
 	m.maxInFlightPerProvider = cfg.MaxInFlightPerProvider
 	m.dispatchJitterMs = cfg.DispatchJitterMs
 	m.mu.Unlock()
+	warnInertCap(m.logger, cfg.MaxInFlightPerProvider, cfg.LimitGate)
 	return nil
+}
+
+// warnInertCap logs once when MaxInFlightPerProvider is configured but no
+// LimitGate is wired up (e.g. limits.NewStore failed at startup), since
+// gateProvider then skips the cap-redirect logic entirely and the cap has
+// zero effect for as long as the gate stays nil.
+func warnInertCap(logger *slog.Logger, maxInFlightPerProvider int, limitGate LimitGate) {
+	if maxInFlightPerProvider > 0 && limitGate == nil {
+		logger.Warn("agent.max_in_flight_per_provider.inert", "max_in_flight_per_provider", maxInFlightPerProvider)
+	}
 }
 
 // InFlightByProvider returns a snapshot of in-flight agent counts by

--- a/internal/agent/manager_gate_test.go
+++ b/internal/agent/manager_gate_test.go
@@ -93,6 +93,142 @@ func TestGateProvider_IgnoreHealthGateBypasses(t *testing.T) {
 	}
 }
 
+// fakeLimitGate lets a test control ProviderAvailable/ChooseProvider
+// decisions without a real limits.Store.
+type fakeLimitGate struct {
+	available    map[string]bool
+	reasons      map[string]string
+	chooseReason string
+}
+
+func (f *fakeLimitGate) ProviderAvailable(p string, _ limits.Policy) (available bool, reason string) {
+	if f.available == nil {
+		return true, ""
+	}
+	if ok, exists := f.available[p]; exists {
+		return ok, f.reasons[p]
+	}
+	return true, ""
+}
+
+func (f *fakeLimitGate) ChooseProvider(requested string, candidates []string, healthy func(string) bool, _ limits.Policy) (chosen, reason string) {
+	for _, c := range candidates {
+		if c == requested {
+			continue
+		}
+		if healthy(c) {
+			return c, f.chooseReason
+		}
+	}
+	return "", ""
+}
+
+// TestGateProvider_CapRedirectsEvenWhenPreferUnderusedFalse verifies the
+// per-provider in-flight cap steers dispatch away from an at-cap resolved
+// provider regardless of PreferUnderused — otherwise the cap silently no-ops
+// on the common "prefer_underused: false" configuration.
+func TestGateProvider_CapRedirectsEvenWhenPreferUnderusedFalse(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"claude": true, "codex": true}})
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+		DefaultProvider:        "claude",
+		LimitGate:              &fakeLimitGate{},
+		LimitPolicy:            limits.Policy{PreferUnderused: false},
+		MaxInFlightPerProvider: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	m.mu.Lock()
+	m.liveByProvider["claude"] = 1
+	m.mu.Unlock()
+
+	got, err := m.gateProvider(RunConfig{Provider: "claude"})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != "codex" {
+		t.Errorf("got %q, want codex (cap must redirect even with PreferUnderused=false)", got)
+	}
+}
+
+// TestGateProvider_CapWithNoHealthyAlternativeFallsBackToResolved verifies the
+// cap is soft: when no other candidate is healthy, dispatch is never blocked
+// — it falls back to the at-cap resolved provider instead.
+func TestGateProvider_CapWithNoHealthyAlternativeFallsBackToResolved(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"claude": true}})
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+		DefaultProvider:        "claude",
+		LimitGate:              &fakeLimitGate{},
+		LimitPolicy:            limits.Policy{PreferUnderused: false},
+		MaxInFlightPerProvider: 1,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	m.mu.Lock()
+	m.liveByProvider["claude"] = 1
+	m.mu.Unlock()
+
+	got, err := m.gateProvider(RunConfig{Provider: "claude"})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != "claude" {
+		t.Errorf("got %q, want claude (no healthy alt: soft cap must not block dispatch)", got)
+	}
+}
+
+// TestGateProvider_PreferUnderusedStillUsesChooseProviderUnderCap verifies
+// the pre-existing PreferUnderused behavior is preserved when the resolved
+// provider is under its cap: selection still goes through the limits store's
+// quota-aware ChooseProvider (unlike the at-cap path, which bypasses it).
+func TestGateProvider_PreferUnderusedStillUsesChooseProviderUnderCap(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"claude": true, "codex": true}})
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+		DefaultProvider: "claude",
+		LimitGate:       &fakeLimitGate{chooseReason: "lower quota pressure"},
+		LimitPolicy:     limits.Policy{PreferUnderused: true},
+		// No cap configured — the resolved provider is always "under cap",
+		// so any redirect observed here must come from ChooseProvider.
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := m.gateProvider(RunConfig{Provider: "claude"})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != "codex" {
+		t.Errorf("got %q, want codex (PreferUnderused path must still route via ChooseProvider)", got)
+	}
+}
+
+// TestGateProvider_CapDisabledByDefaultNeverRedirects verifies
+// MaxInFlightPerProvider=0 (the default) disables the cap entirely.
+func TestGateProvider_CapDisabledByDefaultNeverRedirects(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.SetHealthGate(&fakeGate{healthy: map[string]bool{"claude": true, "codex": true}})
+	if err := m.ReplaceRuntimeConfig(ManagerRuntimeConfig{
+		DefaultProvider: "claude",
+		LimitGate:       &fakeLimitGate{},
+		LimitPolicy:     limits.Policy{PreferUnderused: false},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	m.mu.Lock()
+	m.liveByProvider["claude"] = 1000
+	m.mu.Unlock()
+
+	got, err := m.gateProvider(RunConfig{Provider: "claude"})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != "claude" {
+		t.Errorf("got %q, want claude (cap disabled, no redirect expected)", got)
+	}
+}
+
 func TestLimitPolicy_DefensiveCopiesMaps(t *testing.T) {
 	m, _ := newTestManager(t)
 	policy := limits.DefaultPolicy()

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -295,7 +295,17 @@ func (m *Manager) gateProvider(cfg RunConfig) (string, error) {
 				Reason:   reason,
 			}
 		}
-		if alt := g.Failover(resolved); alt != "" {
+		alt := g.Failover(resolved)
+		if alt != "" && !underCap(alt) {
+			// g.Failover only consults health, so its pick may already be at
+			// its in-flight cap. AutoFailover being enabled is established by
+			// alt != "", so it's safe to look for another peer that is both
+			// healthy and under cap before settling for the at-cap pick.
+			if capAlt := firstHealthyProvider(resolved, candidateProviders, healthy); capAlt != "" {
+				alt = capAlt
+			}
+		}
+		if alt != "" {
 			altProv, err := lookupProvider(alt)
 			if err != nil {
 				return "", err

--- a/internal/agent/manager_run.go
+++ b/internal/agent/manager_run.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"context"
 	"fmt"
+	"maps"
+	"math/rand/v2"
 	"os"
 	"regexp"
 	"strings"
@@ -27,6 +29,12 @@ func (a *Agent) setAssignment(cfg RunConfig) {
 }
 
 func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
+	if cfg.Mode == "headless" {
+		if err := m.jitterDispatch(); err != nil {
+			return nil, err
+		}
+	}
+
 	cfg, prov, err := m.prepareRunConfig(cfg)
 	if err != nil {
 		return nil, err
@@ -52,6 +60,29 @@ func (m *Manager) Run(cfg RunConfig) (*Agent, error) {
 
 	m.emit(events.AgentState(id), a)
 	return a, nil
+}
+
+// jitterDispatch sleeps a uniform random [0, dispatchJitterMs] duration so a
+// wave of ready headless dispatches does not all probe the provider health
+// gate in the same tick. Returns the context error if the manager shuts down
+// mid-sleep, so the caller aborts the dispatch instead of racing shutdown.
+func (m *Manager) jitterDispatch() error {
+	m.mu.RLock()
+	ms := m.dispatchJitterMs
+	m.mu.RUnlock()
+	if ms <= 0 {
+		return nil
+	}
+	d := time.Duration(rand.N(ms+1)) * time.Millisecond
+	if d <= 0 {
+		return nil
+	}
+	select {
+	case <-time.After(d):
+		return nil
+	case <-m.ctx.Done():
+		return m.ctx.Err()
+	}
 }
 
 func (m *Manager) prepareRunConfig(cfg RunConfig) (RunConfig, Provider, error) {
@@ -149,6 +180,9 @@ func (m *Manager) registerRunningAgent(a *Agent, cfg RunConfig, cancel context.C
 	m.agents[a.ID] = a
 	if a.done != nil {
 		m.liveCount++
+		if a.Provider != "" {
+			m.liveByProvider[a.Provider]++
+		}
 	}
 	m.mu.Unlock()
 	return nil
@@ -192,6 +226,15 @@ func (m *Manager) markAgentDone(a *Agent) {
 		if m.liveCount > 0 {
 			m.liveCount--
 		}
+		if a.Provider != "" {
+			if v, ok := m.liveByProvider[a.Provider]; ok {
+				if v <= 1 {
+					delete(m.liveByProvider, a.Provider)
+				} else {
+					m.liveByProvider[a.Provider] = v - 1
+				}
+			}
+		}
 		m.mu.Unlock()
 	})
 }
@@ -233,10 +276,16 @@ func (m *Manager) gateProvider(cfg RunConfig) (string, error) {
 	g := m.gate
 	lg := m.limitGate
 	lp := m.limitPolicy
+	maxInFlight := m.maxInFlightPerProvider
+	live := maps.Clone(m.liveByProvider)
 	m.mu.RUnlock()
-	healthy := func(p string) bool {
-		return g == nil || g.IsHealthy(p)
+	underCap := func(p string) bool {
+		return maxInFlight == 0 || live[p] < maxInFlight
 	}
+	healthy := func(p string) bool {
+		return (g == nil || g.IsHealthy(p)) && underCap(p)
+	}
+	candidateProviders := []string{"claude", "codex", "copilot"}
 	if g != nil && !g.IsHealthy(resolved) {
 		if cfg.DisableProviderFailover {
 			reason := g.Reason(resolved)
@@ -267,16 +316,32 @@ func (m *Manager) gateProvider(cfg RunConfig) (string, error) {
 		return resolved, nil
 	}
 	if ok, reason := lg.ProviderAvailable(resolved, lp); ok {
-		if lp.PreferUnderused && !cfg.DisableProviderFailover {
-			if alt, altReason := lg.ChooseProvider(resolved, []string{"claude", "codex", "copilot"}, healthy, lp); alt != "" {
-				metrics.AgentFailover(resolved, alt)
-				m.logger.Info("agent.run.limit_select", "from", resolved, "to", alt, "task", cfg.TaskID, "reason", altReason)
-				return alt, nil
+		if !cfg.DisableProviderFailover {
+			// The soft in-flight cap must redirect regardless of
+			// PreferUnderused and regardless of quota data: the limits
+			// store's ChooseProvider only recommends an alternative from
+			// exact quota-pressure data (see limits.Store.ChooseProvider),
+			// so it silently no-ops when the requested provider merely sits
+			// at its in-flight cap with no quota signal. Picking the first
+			// healthy, under-cap candidate directly — bypassing that
+			// quota heuristic — is what makes the cap actually redirect.
+			if !underCap(resolved) {
+				if alt := firstHealthyProvider(resolved, candidateProviders, healthy); alt != "" {
+					metrics.AgentFailover(resolved, alt)
+					m.logger.Info("agent.run.cap_redirect", "from", resolved, "to", alt, "task", cfg.TaskID)
+					return alt, nil
+				}
+			} else if lp.PreferUnderused {
+				if alt, altReason := lg.ChooseProvider(resolved, candidateProviders, healthy, lp); alt != "" {
+					metrics.AgentFailover(resolved, alt)
+					m.logger.Info("agent.run.limit_select", "from", resolved, "to", alt, "task", cfg.TaskID, "reason", altReason)
+					return alt, nil
+				}
 			}
 		}
 		return resolved, nil
 	} else if !cfg.DisableProviderFailover {
-		if alt, altReason := lg.ChooseProvider(resolved, []string{"claude", "codex", "copilot"}, healthy, lp); alt != "" {
+		if alt, altReason := lg.ChooseProvider(resolved, candidateProviders, healthy, lp); alt != "" {
 			metrics.AgentFailover(resolved, alt)
 			m.logger.Warn("agent.run.limit_failover", "from", resolved, "to", alt, "task", cfg.TaskID, "reason", reason, "alt_reason", altReason)
 			return alt, nil
@@ -293,6 +358,22 @@ func (m *Manager) gateProvider(cfg RunConfig) (string, error) {
 			Reason:   reason,
 		}
 	}
+}
+
+// firstHealthyProvider returns the first candidate (other than exclude) for
+// which healthy reports true, or "" if none qualify. Used for the in-flight
+// cap redirect, which must pick deterministically without consulting the
+// limits store's quota-pressure heuristics.
+func firstHealthyProvider(exclude string, candidates []string, healthy func(string) bool) string {
+	for _, p := range candidates {
+		if p == exclude {
+			continue
+		}
+		if healthy(p) {
+			return p
+		}
+	}
+	return ""
 }
 
 func (m *Manager) providerForRun(name string) (string, error) {

--- a/internal/agent/manager_run_test.go
+++ b/internal/agent/manager_run_test.go
@@ -1,0 +1,175 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestRegisterMarkAgentDone_ProviderAccountingInvariant locks in that
+// liveByProvider is incremented/decremented in lockstep with liveCount across
+// registerRunningAgent and markAgentDone, including the zero-clamp and
+// bucket-delete-at-zero behavior.
+func TestRegisterMarkAgentDone_ProviderAccountingInvariant(t *testing.T) {
+	m, _ := newTestManager(t)
+
+	agents := []*Agent{
+		{ID: "a1", Provider: "claude", done: make(chan struct{})},
+		{ID: "a2", Provider: "claude", done: make(chan struct{})},
+		{ID: "a3", Provider: "codex", done: make(chan struct{})},
+	}
+	for _, a := range agents {
+		if err := m.registerRunningAgent(a, RunConfig{}, func() {}); err != nil {
+			t.Fatalf("registerRunningAgent(%s): %v", a.ID, err)
+		}
+	}
+	assertAccountingInvariant(t, m)
+	if got := m.InFlightByProvider()["claude"]; got != 2 {
+		t.Fatalf("claude in-flight = %d, want 2", got)
+	}
+	if got := m.InFlightByProvider()["codex"]; got != 1 {
+		t.Fatalf("codex in-flight = %d, want 1", got)
+	}
+
+	m.markAgentDone(agents[0])
+	assertAccountingInvariant(t, m)
+	if got := m.InFlightByProvider()["claude"]; got != 1 {
+		t.Fatalf("claude in-flight after one done = %d, want 1", got)
+	}
+
+	m.markAgentDone(agents[1])
+	assertAccountingInvariant(t, m)
+	if _, ok := m.InFlightByProvider()["claude"]; ok {
+		t.Fatal("claude bucket should be deleted once its count reaches zero")
+	}
+
+	// Idempotent: a repeated terminal call must not double-decrement.
+	m.markAgentDone(agents[1])
+	assertAccountingInvariant(t, m)
+
+	m.markAgentDone(agents[2])
+	assertAccountingInvariant(t, m)
+	if got := m.InFlightByProvider(); len(got) != 0 {
+		t.Fatalf("expected empty in-flight map, got %+v", got)
+	}
+}
+
+// TestRegisterRunningAgent_ConcurrentAccountingRace spreads concurrent
+// registrations across providers (mirrors a dispatch wave under the soft
+// in-flight cap) and asserts the invariant holds under the race detector.
+func TestRegisterRunningAgent_ConcurrentAccountingRace(t *testing.T) {
+	m, _ := newTestManager(t)
+	providers := []string{"claude", "codex", "copilot"}
+	const n = 30
+
+	var wg sync.WaitGroup
+	registered := make([]*Agent, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			a := &Agent{ID: fmt.Sprintf("a%d", i), Provider: providers[i%len(providers)], done: make(chan struct{})}
+			if err := m.registerRunningAgent(a, RunConfig{}, func() {}); err != nil {
+				t.Errorf("registerRunningAgent(%s): %v", a.ID, err)
+				return
+			}
+			registered[i] = a
+		}(i)
+	}
+	wg.Wait()
+
+	assertAccountingInvariant(t, m)
+	if got := m.RunningCount(); got != n {
+		t.Fatalf("RunningCount = %d, want %d", got, n)
+	}
+
+	for _, a := range registered {
+		if a != nil {
+			m.markAgentDone(a)
+		}
+	}
+	assertAccountingInvariant(t, m)
+	if got := m.RunningCount(); got != 0 {
+		t.Fatalf("RunningCount after all done = %d, want 0", got)
+	}
+	if got := m.InFlightByProvider(); len(got) != 0 {
+		t.Fatalf("expected empty in-flight map, got %+v", got)
+	}
+}
+
+// TestJitterDispatch_DisabledIsNoop verifies a zero dispatchJitterMs (the
+// interactive/chat default posture, and headless when the knob is disabled)
+// never sleeps.
+func TestJitterDispatch_DisabledIsNoop(t *testing.T) {
+	m, _ := newTestManager(t)
+	start := time.Now()
+	if err := m.jitterDispatch(); err != nil {
+		t.Fatalf("jitterDispatch: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 50*time.Millisecond {
+		t.Fatalf("expected no delay when dispatchJitterMs=0, took %s", elapsed)
+	}
+}
+
+// TestJitterDispatch_SleepsWithinBound verifies the sleep is uniformly bounded
+// by [0, dispatchJitterMs] rather than always waiting the full window.
+func TestJitterDispatch_SleepsWithinBound(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.mu.Lock()
+	m.dispatchJitterMs = 50
+	m.mu.Unlock()
+
+	start := time.Now()
+	if err := m.jitterDispatch(); err != nil {
+		t.Fatalf("jitterDispatch: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 300*time.Millisecond {
+		t.Fatalf("jitter slept too long: %s, want <= ~50ms bound", elapsed)
+	}
+}
+
+// TestJitterDispatch_AbortsOnContextCancel verifies a manager shutdown mid-
+// jitter aborts the dispatch promptly instead of blocking for the full window.
+func TestJitterDispatch_AbortsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	m := mustNewManager(t, ctx, func(string, any) {}, discardLogger(), t.TempDir())
+	m.mu.Lock()
+	m.dispatchJitterMs = 10_000
+	m.mu.Unlock()
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := m.jitterDispatch()
+	if err == nil {
+		t.Fatal("expected context error when the manager shuts down mid-jitter")
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("jitterDispatch did not abort promptly on ctx cancel: %s", elapsed)
+	}
+}
+
+// TestRun_JitterSkippedForInteractiveMode verifies jitter is applied only to
+// headless dispatch — interactive/chat must never be delayed.
+func TestRun_JitterSkippedForInteractiveMode(t *testing.T) {
+	m, _ := newTestManager(t)
+	m.mu.Lock()
+	m.dispatchJitterMs = 5_000
+	m.mu.Unlock()
+
+	dir := t.TempDir()
+	start := time.Now()
+	a, err := m.Run(RunConfig{TaskID: "t1", Mode: "interactive", Dir: dir, OneShot: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	t.Cleanup(func() { _ = m.StopAgent(a.ID) })
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("interactive Run must skip jitter, took %s", elapsed)
+	}
+}

--- a/internal/agent/reattach.go
+++ b/internal/agent/reattach.go
@@ -115,6 +115,9 @@ func (m *Manager) ReattachAll() []*Agent {
 		}
 		m.agents[a.ID] = a
 		m.liveCount++
+		if a.Provider != "" {
+			m.liveByProvider[a.Provider]++
+		}
 		m.mu.Unlock()
 
 		m.logger.Info("agent.reattach", "id", a.ID, "pid", a.PID, "task", a.TaskID, "events", len(a.Output()))
@@ -223,6 +226,9 @@ func (m *Manager) reattachInteractive(r Record, reg survivalRegistry) *Agent {
 	}
 	m.agents[a.ID] = a
 	m.liveCount++
+	if a.Provider != "" {
+		m.liveByProvider[a.Provider]++
+	}
 	m.mu.Unlock()
 
 	m.logger.Info("agent.reattach", "id", a.ID, "pid", a.PID, "task", a.TaskID, "mode", "interactive", "oneshot", oneShot, "events", len(a.ConvoOutput()))
@@ -289,6 +295,9 @@ func (m *Manager) reattachPerTurnConvo(r Record, reg survivalRegistry) *Agent {
 	}
 	m.agents[a.ID] = a
 	m.liveCount++
+	if a.Provider != "" {
+		m.liveByProvider[a.Provider]++
+	}
 	m.mu.Unlock()
 
 	m.logger.Info("agent.reattach", "id", a.ID, "task", a.TaskID, "mode", "interactive", "provider", a.Provider, "events", len(a.ConvoOutput()))

--- a/internal/agent/reattach_test.go
+++ b/internal/agent/reattach_test.go
@@ -1,0 +1,149 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// invariantSnapshot atomically reads liveCount and sum(liveByProvider) under
+// the same lock, so a concurrently running reattach/completion goroutine
+// cannot skew the comparison between two independent lock acquisitions.
+func invariantSnapshot(m *Manager) (sum, liveCount int) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, v := range m.liveByProvider {
+		sum += v
+	}
+	return sum, m.liveCount
+}
+
+func assertAccountingInvariant(t *testing.T, m *Manager) {
+	t.Helper()
+	sum, liveCount := invariantSnapshot(m)
+	if sum != liveCount {
+		t.Fatalf("sum(liveByProvider)=%d != liveCount=%d", sum, liveCount)
+	}
+}
+
+// TestReattachAccountingInvariant exercises all three restart-reattach code
+// paths (headless via ReattachAll, reattachInteractive, reattachPerTurnConvo)
+// and asserts liveByProvider never drifts from liveCount. Each of these
+// paths increments liveCount directly (mirroring registerRunningAgent) and
+// must co-locate a matching liveByProvider increment, or the soft
+// per-provider dispatch cap silently desyncs after every restart that finds
+// in-flight agents.
+func TestReattachAccountingInvariant(t *testing.T) {
+	prevPoll := reattachPIDPoll
+	reattachPIDPoll = 30 * time.Millisecond
+	t.Cleanup(func() { reattachPIDPoll = prevPoll })
+
+	logDir := t.TempDir()
+	regDir := t.TempDir()
+	agentsLogDir := filepath.Join(logDir, "agents")
+	if err := os.MkdirAll(agentsLogDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	m := mustNewManager(t, context.Background(), func(string, any) {}, slog.New(slog.DiscardHandler), logDir, ManagerConfig{
+		SurviveRestartDir: regDir,
+		OnComplete:        func(*Agent) {},
+	})
+	assertAccountingInvariant(t, m)
+
+	spawnSleeper := func(t *testing.T) *exec.Cmd {
+		t.Helper()
+		cmd := exec.Command("sleep", "2")
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("start helper process: %v", err)
+		}
+		t.Cleanup(func() { _ = cmd.Process.Kill() })
+		go func() { _ = cmd.Wait() }()
+		return cmd
+	}
+
+	// --- Headless path: registered via the registry and reattached through
+	// the full ReattachAll sweep (mirrors app startup). ---
+	headlessLog := filepath.Join(agentsLogDir, "h1.ndjson")
+	if err := os.WriteFile(headlessLog, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	headlessCmd := spawnSleeper(t)
+	if err := m.reg.Save(Record{
+		ID:            "h1",
+		TaskID:        "task-h",
+		Mode:          "headless",
+		Provider:      "claude",
+		PID:           headlessCmd.Process.Pid,
+		LogPath:       headlessLog,
+		StartedAt:     time.Now().UTC(),
+		ProcStartedAt: processStartString(headlessCmd.Process.Pid),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	reattached := m.ReattachAll()
+	if len(reattached) != 1 {
+		t.Fatalf("ReattachAll: got %d reattached agents, want 1", len(reattached))
+	}
+	assertAccountingInvariant(t, m)
+
+	// --- Interactive path: reattachInteractive directly (line ~225 site). ---
+	interactiveLog := filepath.Join(agentsLogDir, "i1.ndjson")
+	if err := os.WriteFile(interactiveLog, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	interactiveCmd := spawnSleeper(t)
+	reg := m.registry()
+	interactiveAgent := m.reattachInteractive(Record{
+		ID:            "i1",
+		TaskID:        "task-i",
+		Mode:          "interactive",
+		Provider:      "claude",
+		PID:           interactiveCmd.Process.Pid,
+		LogPath:       interactiveLog,
+		StartedAt:     time.Now().UTC(),
+		ProcStartedAt: processStartString(interactiveCmd.Process.Pid),
+	}, reg)
+	if interactiveAgent == nil {
+		t.Fatal("reattachInteractive returned nil, expected a live agent")
+	}
+	assertAccountingInvariant(t, m)
+
+	// --- Per-turn-convo path: reattachPerTurnConvo directly (line ~291 site). ---
+	perTurnAgent := m.reattachPerTurnConvo(Record{
+		ID:       "p1",
+		TaskID:   "task-p",
+		Mode:     "interactive",
+		Provider: "codex",
+		OneShot:  false,
+	}, reg)
+	if perTurnAgent == nil {
+		t.Fatal("reattachPerTurnConvo returned nil, expected a live agent")
+	}
+	assertAccountingInvariant(t, m)
+
+	// Kill the live helpers so every agent runs to completion, then confirm
+	// the invariant still holds once liveCount/liveByProvider both drain.
+	_ = headlessCmd.Process.Kill()
+	_ = interactiveCmd.Process.Kill()
+	_ = m.StopAgent(perTurnAgent.ID)
+
+	deadline := time.After(5 * time.Second)
+	for m.RunningCount() > 0 {
+		select {
+		case <-deadline:
+			t.Fatalf("agents did not drain to 0 within 5s (liveCount=%d, liveByProvider=%+v)",
+				m.RunningCount(), m.InFlightByProvider())
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+	assertAccountingInvariant(t, m)
+	if got := m.InFlightByProvider(); len(got) != 0 {
+		t.Fatalf("expected empty in-flight map after full drain, got %+v", got)
+	}
+}

--- a/internal/config/config_agent.go
+++ b/internal/config/config_agent.go
@@ -62,6 +62,6 @@ type AgentDefaults struct {
 	// DispatchJitterMs bounds a uniform random delay applied before headless
 	// agent dispatch, so a wave of concurrently ready tasks does not all
 	// probe the provider health gate in the same tick. 0 disables jitter.
-	// Never applied to interactive/chat dispatch. Default 500.
+	// Never applied to interactive/chat dispatch. Default 0 (opt-in).
 	DispatchJitterMs int `yaml:"dispatch_jitter_ms" json:"dispatchJitterMs"`
 }

--- a/internal/config/config_agent.go
+++ b/internal/config/config_agent.go
@@ -59,4 +59,9 @@ type AgentDefaults struct {
 	// which activates the Claude Code auto-mode classifier (blocks destructive ops
 	// such as rm -rf $HOME, force-push, terraform destroy). Empty treated as "bypass".
 	HeadlessPermissionMode string `yaml:"headless_permission_mode" json:"headlessPermissionMode"`
+	// DispatchJitterMs bounds a uniform random delay applied before headless
+	// agent dispatch, so a wave of concurrently ready tasks does not all
+	// probe the provider health gate in the same tick. 0 disables jitter.
+	// Never applied to interactive/chat dispatch. Default 500.
+	DispatchJitterMs int `yaml:"dispatch_jitter_ms" json:"dispatchJitterMs"`
 }

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -283,7 +283,7 @@ func DefaultConfig() *Config {
 			MaxConcurrent:    100,
 			MaxCostUSD:       5.0,
 			MaxTurns:         150,
-			DispatchJitterMs: 500,
+			DispatchJitterMs: 0,
 		},
 		Notification: NotificationConfig{
 			Desktop: true,

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -279,10 +279,11 @@ func DefaultConfig() *Config {
 			RetentionDays: 30,
 		},
 		Agent: AgentDefaults{
-			Provider:      "claude",
-			MaxConcurrent: 100,
-			MaxCostUSD:    5.0,
-			MaxTurns:      150,
+			Provider:         "claude",
+			MaxConcurrent:    100,
+			MaxCostUSD:       5.0,
+			MaxTurns:         150,
+			DispatchJitterMs: 500,
 		},
 		Notification: NotificationConfig{
 			Desktop: true,
@@ -326,6 +327,7 @@ func DefaultConfig() *Config {
 				WeeklyThresholdPercent:  90,
 				PreferUnderused:         true,
 				BackfillDays:            14,
+				MaxInFlightPerProvider:  0,
 			},
 			AutoFailover: true,
 		},

--- a/internal/config/config_providers.go
+++ b/internal/config/config_providers.go
@@ -31,4 +31,10 @@ type ProviderLimitsConfig struct {
 	WeeklyThresholdPercent  float64 `yaml:"weekly_threshold_percent" json:"weeklyThresholdPercent"`
 	PreferUnderused         bool    `yaml:"prefer_underused" json:"preferUnderused"`
 	BackfillDays            int     `yaml:"backfill_days" json:"backfillDays"`
+	// MaxInFlightPerProvider caps concurrent in-flight agents per provider,
+	// distinct from the global agent.max_concurrent ceiling. 0 (default)
+	// disables the cap. When set, gateProvider redirects new dispatches away
+	// from an at-cap provider even when PreferUnderused is false, so the cap
+	// cannot silently no-op.
+	MaxInFlightPerProvider int `yaml:"max_in_flight_per_provider" json:"maxInFlightPerProvider"`
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -78,6 +78,43 @@ func TestLoadProviderDefaultAndPersistedValue(t *testing.T) {
 	}
 }
 
+// TestDefaultDispatchJitterAndInFlightCap locks in the jitter/soft-cap
+// defaults: jitter on (500ms) so a dispatch wave de-correlates out of the
+// box, cap off (0) so operators must opt in to a per-provider ceiling.
+func TestDefaultDispatchJitterAndInFlightCap(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultConfig()
+	if cfg.Agent.DispatchJitterMs != 500 {
+		t.Errorf("Agent.DispatchJitterMs = %d, want 500", cfg.Agent.DispatchJitterMs)
+	}
+	if cfg.Providers.Limits.MaxInFlightPerProvider != 0 {
+		t.Errorf("Providers.Limits.MaxInFlightPerProvider = %d, want 0 (disabled)", cfg.Providers.Limits.MaxInFlightPerProvider)
+	}
+}
+
+// TestLoadPreservesDispatchJitterAndInFlightCapOverrides verifies both new
+// knobs round-trip through YAML like the other Agent/Providers.Limits fields.
+func TestLoadPreservesDispatchJitterAndInFlightCapOverrides(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SYBRA_HOME", dir)
+
+	yamlDoc := []byte("agent:\n  dispatch_jitter_ms: 250\nproviders:\n  limits:\n    max_in_flight_per_provider: 3\n")
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), yamlDoc, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Agent.DispatchJitterMs != 250 {
+		t.Errorf("Agent.DispatchJitterMs = %d, want 250", cfg.Agent.DispatchJitterMs)
+	}
+	if cfg.Providers.Limits.MaxInFlightPerProvider != 3 {
+		t.Errorf("Providers.Limits.MaxInFlightPerProvider = %d, want 3", cfg.Providers.Limits.MaxInFlightPerProvider)
+	}
+}
+
 func TestLoadExperienceDefaults(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("SYBRA_HOME", dir)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -79,13 +79,13 @@ func TestLoadProviderDefaultAndPersistedValue(t *testing.T) {
 }
 
 // TestDefaultDispatchJitterAndInFlightCap locks in the jitter/soft-cap
-// defaults: jitter on (500ms) so a dispatch wave de-correlates out of the
-// box, cap off (0) so operators must opt in to a per-provider ceiling.
+// defaults: both off (0) by default so existing deployments upgrade with no
+// behavior change; operators must opt in to either knob.
 func TestDefaultDispatchJitterAndInFlightCap(t *testing.T) {
 	t.Parallel()
 	cfg := DefaultConfig()
-	if cfg.Agent.DispatchJitterMs != 500 {
-		t.Errorf("Agent.DispatchJitterMs = %d, want 500", cfg.Agent.DispatchJitterMs)
+	if cfg.Agent.DispatchJitterMs != 0 {
+		t.Errorf("Agent.DispatchJitterMs = %d, want 0 (disabled)", cfg.Agent.DispatchJitterMs)
 	}
 	if cfg.Providers.Limits.MaxInFlightPerProvider != 0 {
 		t.Errorf("Providers.Limits.MaxInFlightPerProvider = %d, want 0 (disabled)", cfg.Providers.Limits.MaxInFlightPerProvider)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -70,15 +70,17 @@ var (
 
 	// Observable gauge providers, mutated at wiring time and read from the
 	// meter's registered callback. Guarded by obsMu.
-	obsMu              sync.RWMutex
-	tasksByStatusFn    func() map[string]int64
-	agentsActiveFn     func() map[string]int64
-	renovatePRsFetchFn func() int64
-	providerHealthFn   func() map[string]int64
-	tasksByStatusGauge metric.Int64ObservableGauge
-	agentsActiveGauge  metric.Int64ObservableGauge
-	renovatePRsGauge   metric.Int64ObservableGauge
-	providerHealthyG   metric.Int64ObservableGauge
+	obsMu               sync.RWMutex
+	tasksByStatusFn     func() map[string]int64
+	agentsActiveFn      func() map[string]int64
+	renovatePRsFetchFn  func() int64
+	providerHealthFn    func() map[string]int64
+	agentsInFlightFn    func() map[string]int64
+	tasksByStatusGauge  metric.Int64ObservableGauge
+	agentsActiveGauge   metric.Int64ObservableGauge
+	renovatePRsGauge    metric.Int64ObservableGauge
+	providerHealthyG    metric.Int64ObservableGauge
+	agentsInFlightGauge metric.Int64ObservableGauge
 )
 
 // Enabled reports whether the metrics pipeline was initialized and is active.
@@ -364,9 +366,15 @@ func createObservableGauges() error {
 	); err != nil {
 		return err
 	}
+	if agentsInFlightGauge, err = m.Int64ObservableGauge(
+		"sybra_agents_in_flight",
+		metric.WithDescription("Current in-flight agent count, by provider."),
+	); err != nil {
+		return err
+	}
 	_, err = m.RegisterCallback(
 		observe,
-		tasksByStatusGauge, agentsActiveGauge, renovatePRsGauge, providerHealthyG,
+		tasksByStatusGauge, agentsActiveGauge, renovatePRsGauge, providerHealthyG, agentsInFlightGauge,
 	)
 	return err
 }
@@ -377,6 +385,7 @@ func observe(_ context.Context, obs metric.Observer) error {
 	byState := agentsActiveFn
 	prs := renovatePRsFetchFn
 	providerHealth := providerHealthFn
+	inFlight := agentsInFlightFn
 	obsMu.RUnlock()
 
 	if byStatus != nil {
@@ -397,6 +406,12 @@ func observe(_ context.Context, obs metric.Observer) error {
 	if providerHealth != nil {
 		for name, healthy := range providerHealth() {
 			obs.ObserveInt64(providerHealthyG, healthy,
+				metric.WithAttributes(attribute.String("provider", name)))
+		}
+	}
+	if inFlight != nil {
+		for name, n := range inFlight() {
+			obs.ObserveInt64(agentsInFlightGauge, n,
 				metric.WithAttributes(attribute.String("provider", name)))
 		}
 	}
@@ -432,6 +447,14 @@ func RegisterRenovatePRsFetched(fn func() int64) {
 func RegisterProviderHealth(fn func() map[string]int64) {
 	obsMu.Lock()
 	providerHealthFn = fn
+	obsMu.Unlock()
+}
+
+// RegisterAgentsInFlightByProvider wires a provider callback returning
+// provider name -> in-flight agent count for the agents_in_flight gauge.
+func RegisterAgentsInFlightByProvider(fn func() map[string]int64) {
+	obsMu.Lock()
+	agentsInFlightFn = fn
 	obsMu.Unlock()
 }
 

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -301,13 +301,15 @@ func (a *App) agentRuntimeConfig(cfg *config.Config) agent.ManagerRuntimeConfig 
 		policy = a.limitPolicy()
 	}
 	return agent.ManagerRuntimeConfig{
-		MaxConcurrent:   cfg.Agent.MaxConcurrent,
-		DefaultProvider: cfg.Agent.Provider,
-		BashTimeoutMs:   cfg.BashTimeoutMs(),
-		RetryWatchdog:   cfg.RetryWatchdog(),
-		FallbackModel:   cfg.Agent.FallbackModel,
-		LimitGate:       a.limits,
-		LimitPolicy:     policy,
+		MaxConcurrent:          cfg.Agent.MaxConcurrent,
+		DefaultProvider:        cfg.Agent.Provider,
+		BashTimeoutMs:          cfg.BashTimeoutMs(),
+		RetryWatchdog:          cfg.RetryWatchdog(),
+		FallbackModel:          cfg.Agent.FallbackModel,
+		LimitGate:              a.limits,
+		LimitPolicy:            policy,
+		MaxInFlightPerProvider: cfg.Providers.Limits.MaxInFlightPerProvider,
+		DispatchJitterMs:       cfg.Agent.DispatchJitterMs,
 	}
 }
 

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -295,6 +295,17 @@ func (a *App) initAgentManager(ctx context.Context, emit func(string, any)) erro
 	return nil
 }
 
+// limitGateOrNil returns a genuine nil agent.LimitGate when store is nil.
+// Assigning a nil *limits.Store straight into the interface field produces a
+// non-nil typed-nil interface, which defeats the manager's lg == nil guard and
+// panics on first use whenever the limits store degraded at startup.
+func limitGateOrNil(store *limits.Store) agent.LimitGate {
+	if store == nil {
+		return nil
+	}
+	return store
+}
+
 func (a *App) agentRuntimeConfig(cfg *config.Config) agent.ManagerRuntimeConfig {
 	policy := limits.DefaultPolicy()
 	if a.limits != nil {
@@ -306,7 +317,7 @@ func (a *App) agentRuntimeConfig(cfg *config.Config) agent.ManagerRuntimeConfig 
 		BashTimeoutMs:          cfg.BashTimeoutMs(),
 		RetryWatchdog:          cfg.RetryWatchdog(),
 		FallbackModel:          cfg.Agent.FallbackModel,
-		LimitGate:              a.limits,
+		LimitGate:              limitGateOrNil(a.limits),
 		LimitPolicy:            policy,
 		MaxInFlightPerProvider: cfg.Providers.Limits.MaxInFlightPerProvider,
 		DispatchJitterMs:       cfg.Agent.DispatchJitterMs,

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -271,6 +271,14 @@ func (lm *LifecycleManager) registerMetricsObservers() {
 			return out
 		})
 	}
+	metrics.RegisterAgentsInFlightByProvider(func() map[string]int64 {
+		snapshot := a.agents.InFlightByProvider()
+		out := make(map[string]int64, len(snapshot))
+		for name, n := range snapshot {
+			out[name] = int64(n)
+		}
+		return out
+	})
 }
 
 // startMonitorService wires the in-process monitor loop when enabled.

--- a/internal/sybra/limit_gate_nil_test.go
+++ b/internal/sybra/limit_gate_nil_test.go
@@ -1,0 +1,32 @@
+package sybra
+
+import (
+	"testing"
+
+	"github.com/Automaat/sybra/internal/config"
+	"github.com/Automaat/sybra/internal/limits"
+)
+
+// TestLimitGateOrNil_DegradedStoreYieldsGenuineNilInterface guards the
+// typed-nil-interface footgun: assigning a nil *limits.Store straight into the
+// agent.LimitGate field yields a non-nil interface, which defeats the manager's
+// lg == nil guard and panics on first use during degraded limits init. The
+// helper must instead return a genuine nil interface.
+func TestLimitGateOrNil_DegradedStoreYieldsGenuineNilInterface(t *testing.T) {
+	var store *limits.Store // limits.NewStore failed at startup -> nil
+
+	if gate := limitGateOrNil(store); gate != nil {
+		t.Fatal("limitGateOrNil(nil) must return a genuine nil LimitGate")
+	}
+}
+
+// TestAgentRuntimeConfig_DegradedLimitsHasNilGate exercises the real wiring
+// site: with a degraded (nil) limits store the produced runtime config must
+// carry a nil LimitGate so dispatch takes the no-gate path instead of panicking.
+func TestAgentRuntimeConfig_DegradedLimitsHasNilGate(t *testing.T) {
+	a := &App{} // a.limits nil == degraded limits init
+	rc := a.agentRuntimeConfig(&config.Config{})
+	if rc.LimitGate != nil {
+		t.Fatal("degraded limits store must yield a nil LimitGate so the manager guard fires")
+	}
+}

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -184,13 +184,15 @@ func (s *ConfigService) managerRuntimeConfig(cfg config.Config) agent.ManagerRun
 		policy = s.policy()
 	}
 	return agent.ManagerRuntimeConfig{
-		MaxConcurrent:   cfg.Agent.MaxConcurrent,
-		DefaultProvider: cfg.Agent.Provider,
-		BashTimeoutMs:   cfg.BashTimeoutMs(),
-		RetryWatchdog:   cfg.RetryWatchdog(),
-		FallbackModel:   cfg.Agent.FallbackModel,
-		LimitGate:       s.limits,
-		LimitPolicy:     policy,
+		MaxConcurrent:          cfg.Agent.MaxConcurrent,
+		DefaultProvider:        cfg.Agent.Provider,
+		BashTimeoutMs:          cfg.BashTimeoutMs(),
+		RetryWatchdog:          cfg.RetryWatchdog(),
+		FallbackModel:          cfg.Agent.FallbackModel,
+		LimitGate:              s.limits,
+		LimitPolicy:            policy,
+		MaxInFlightPerProvider: cfg.Providers.Limits.MaxInFlightPerProvider,
+		DispatchJitterMs:       cfg.Agent.DispatchJitterMs,
 	}
 }
 

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -189,7 +189,7 @@ func (s *ConfigService) managerRuntimeConfig(cfg config.Config) agent.ManagerRun
 		BashTimeoutMs:          cfg.BashTimeoutMs(),
 		RetryWatchdog:          cfg.RetryWatchdog(),
 		FallbackModel:          cfg.Agent.FallbackModel,
-		LimitGate:              s.limits,
+		LimitGate:              limitGateOrNil(s.limits),
 		LimitPolicy:            policy,
 		MaxInFlightPerProvider: cfg.Providers.Limits.MaxInFlightPerProvider,
 		DispatchJitterMs:       cfg.Agent.DispatchJitterMs,


### PR DESCRIPTION
## Motivation

Bursty simultaneous agent dispatch hammers providers (thundering herd) and trips rate-limit cooldowns. Add per-provider in-flight caps + dispatch jitter to stagger starts. Closes #1335.

> Changelog: feat(agent): jitter/stagger agent dispatch to avoid provider thundering herd

## Implementation information

- `internal/agent`: `liveByProvider` accounting, `maxInFlightPerProvider` cap, `dispatchJitterMs` stagger, `InFlightByProvider()` snapshot; failover prefers a peer that is both healthy and under its cap.
- Config surface: `providers.limits.max_in_flight_per_provider`, `agent.dispatch_jitter_ms`.
- **Fix (blocking bug found in testing):** a nil `*limits.Store` assigned straight into the `agent.LimitGate` interface produced a non-nil typed-nil, defeating the manager's `lg == nil` guard and panicking dispatch whenever the limits store degraded at startup (`providers.limits.enabled` defaults true). Both wiring sites now route through `limitGateOrNil`, plus regression coverage.

## Supporting documentation

Rebased onto current main (was 22 behind). Recovered from a stuck `ready-pr` state that would have shipped the panic. Affected-package tests + golangci-lint green. The two underlying Sybra-reliability bugs are tracked in #1385 (this panic class) and #1386 (evidence-gate false-negative that caused the test thrash).