### PR TITLE
fix(worktree): reconcile orphan worktree dirs

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -726,6 +726,32 @@ func RemoveWorktree(barePath, worktreePath string) error {
 	})
 }
 
+// RemoveWorktreeReconcile removes a worktree directory, reconciling the
+// orphan case where the directory exists on disk but its admin entry under
+// the bare repo's worktrees/ dir is already gone (e.g. after a prior
+// `worktree prune`, or a crash mid-cleanup). Plain `worktree remove --force`
+// fails on an orphan ("not a git repository (null)") because git can't
+// resolve its admin entry, leaving the directory behind to collide with the
+// next `worktree add`. This tries the registered-removal path first, then
+// prunes stale admin entries, then falls back to a raw directory removal if
+// the path still exists.
+func RemoveWorktreeReconcile(barePath, worktreePath string) error {
+	// Registered case: this alone succeeds and removes the directory.
+	_ = RemoveWorktree(barePath, worktreePath)
+	// Drop stale admin entries so a subsequent `worktree add` doesn't trip
+	// over a registration that no longer has a live directory either.
+	_ = PruneWorktrees(barePath)
+	if _, statErr := os.Stat(worktreePath); statErr == nil {
+		// Orphan case: the directory survived because git couldn't resolve
+		// its admin entry. Fall back to a raw removal.
+		if err := os.RemoveAll(worktreePath); err != nil {
+			return fmt.Errorf("remove orphan worktree %s: %w", worktreePath, err)
+		}
+		_ = PruneWorktrees(barePath)
+	}
+	return nil
+}
+
 // PruneWorktrees removes stale worktree admin entries from the bare repo.
 func PruneWorktrees(barePath string) error {
 	return withBareRepoLock(barePath, func() error {

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -741,13 +741,17 @@ func RemoveWorktreeReconcile(barePath, worktreePath string) error {
 	// Drop stale admin entries so a subsequent `worktree add` doesn't trip
 	// over a registration that no longer has a live directory either.
 	_ = PruneWorktrees(barePath)
-	if _, statErr := os.Stat(worktreePath); statErr == nil {
+	_, statErr := os.Stat(worktreePath)
+	switch {
+	case statErr == nil:
 		// Orphan case: the directory survived because git couldn't resolve
 		// its admin entry. Fall back to a raw removal.
 		if err := os.RemoveAll(worktreePath); err != nil {
 			return fmt.Errorf("remove orphan worktree %s: %w", worktreePath, err)
 		}
 		_ = PruneWorktrees(barePath)
+	case !os.IsNotExist(statErr):
+		return fmt.Errorf("stat worktree %s: %w", worktreePath, statErr)
 	}
 	return nil
 }

--- a/internal/worktree/adopt_test.go
+++ b/internal/worktree/adopt_test.go
@@ -260,6 +260,9 @@ func TestPrepareForFix_ReconcilesOrphanWorktreeDir(t *testing.T) {
 	if adminDir == "" {
 		t.Fatalf("could not parse admin dir from .git file: %q", gitFile)
 	}
+	if !filepath.IsAbs(adminDir) {
+		adminDir = filepath.Join(wtPath, adminDir)
+	}
 	if err := os.RemoveAll(adminDir); err != nil {
 		t.Fatalf("remove admin dir: %v", err)
 	}

--- a/internal/worktree/adopt_test.go
+++ b/internal/worktree/adopt_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -201,6 +202,90 @@ func TestPrepareForFix_FallsBackToPRHead(t *testing.T) {
 	}
 	if got := strings.TrimSpace(string(headSHA)); got != prSHA {
 		t.Errorf("worktree HEAD = %q, want PR head %q", got, prSHA)
+	}
+}
+
+// TestPrepareForFix_ReconcilesOrphanWorktreeDir is the regression for the
+// human-required strand described in issue 1373 / task be14dfd3: a fix
+// worktree directory survives on disk (e.g. `worktree prune`, or a crash
+// mid-cleanup, dropped the admin entry under the bare repo's worktrees/ dir)
+// while the checkout dir remains. `git worktree remove --force` alone fails
+// on that orphan ("not a git repository (null)"), the error used to be
+// swallowed, and every retry of PrepareForFix hit `already exists` until the
+// circuit breaker escalated to human-required — for a failure mode that is
+// mechanically self-healing. PrepareForFix must reconcile the orphan and
+// succeed instead.
+func TestPrepareForFix_ReconcilesOrphanWorktreeDir(t *testing.T) {
+	h := prepareHarness(t, nil, 0)
+
+	const branch = "fix-branch"
+	srcGit := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", h.src}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	srcGit("checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(h.src, "fix.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "fix commit")
+
+	h.m.prBranch = func(_ string, _ int) (string, error) { return branch, nil }
+
+	tk, err := h.tasks.Create("orphan fix", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = h.tasks.UpdateMap(tk.ID, map[string]any{"project_id": h.proj.ID})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	wtPath, err := h.m.PrepareForFix(tk, 1)
+	if err != nil {
+		t.Fatalf("PrepareForFix (initial): %v", err)
+	}
+
+	// Simulate the orphan: drop the bare repo's admin entry for this worktree
+	// while leaving the checkout directory on disk. The .git file inside a
+	// linked worktree points at its admin dir via "gitdir: <bare>/worktrees/<name>".
+	gitFile, err := os.ReadFile(filepath.Join(wtPath, ".git"))
+	if err != nil {
+		t.Fatalf("read .git file: %v", err)
+	}
+	adminDir := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(string(gitFile)), "gitdir:"))
+	if adminDir == "" {
+		t.Fatalf("could not parse admin dir from .git file: %q", gitFile)
+	}
+	if err := os.RemoveAll(adminDir); err != nil {
+		t.Fatalf("remove admin dir: %v", err)
+	}
+	if project.WorktreeHealthy(wtPath) {
+		t.Fatalf("expected worktree to be unhealthy after dropping its admin entry")
+	}
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("expected orphan checkout dir to still exist: %v", err)
+	}
+
+	got, err := h.m.PrepareForFix(tk, 1)
+	if err != nil {
+		t.Fatalf("PrepareForFix (orphan reconcile): %v", err)
+	}
+	if got != wtPath {
+		t.Fatalf("reconciled path = %q, want %q", got, wtPath)
+	}
+	if !project.WorktreeHealthy(got) {
+		t.Fatalf("expected reconciled worktree to be healthy")
+	}
+	headBranch, err := exec.Command("git", "-C", got, "rev-parse", "--abbrev-ref", "HEAD").CombinedOutput()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD branch: %v: %s", err, headBranch)
+	}
+	if gotBranch := strings.TrimSpace(string(headBranch)); gotBranch != branch {
+		t.Errorf("worktree branch = %q, want %q", gotBranch, branch)
 	}
 }
 

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -380,10 +380,13 @@ func (m *Manager) PrepareForFix(t task.Task, prNumber int) (string, error) {
 	// Remove stale worktree — previous agent may have left dirty state, or a
 	// prior `worktree prune` (or crash) dropped the admin entry while the
 	// checkout dir survived (orphan). RemoveWorktreeReconcile handles both.
-	if _, statErr := os.Stat(wtPath); statErr == nil {
+	switch _, statErr := os.Stat(wtPath); {
+	case statErr == nil:
 		if err := project.RemoveWorktreeReconcile(proj.ClonePath, wtPath); err != nil {
 			return "", fmt.Errorf("remove stale fix worktree: %w", err)
 		}
+	case !os.IsNotExist(statErr):
+		return "", fmt.Errorf("stat fix worktree %s: %w", wtPath, statErr)
 	}
 
 	originRef := "refs/remotes/origin/" + branch

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -377,9 +377,13 @@ func (m *Manager) PrepareForFix(t task.Task, prNumber int) (string, error) {
 
 	wtPath := m.PathFor(t)
 
-	// Remove stale worktree — previous agent may have left dirty state.
+	// Remove stale worktree — previous agent may have left dirty state, or a
+	// prior `worktree prune` (or crash) dropped the admin entry while the
+	// checkout dir survived (orphan). RemoveWorktreeReconcile handles both.
 	if _, statErr := os.Stat(wtPath); statErr == nil {
-		_ = project.RemoveWorktree(proj.ClonePath, wtPath)
+		if err := project.RemoveWorktreeReconcile(proj.ClonePath, wtPath); err != nil {
+			return "", fmt.Errorf("remove stale fix worktree: %w", err)
+		}
 	}
 
 	originRef := "refs/remotes/origin/" + branch


### PR DESCRIPTION
## Motivation

`PrepareForFix` swallowed `RemoveWorktree` errors when clearing a stale worktree path, and a plain `worktree remove --force` fails on an orphan (directory present, admin entry gone after a prior prune or crashed cleanup). The directory survived, the next `worktree add` hit "already exists" on every retry, and the 5-strike circuit breaker stranded the task in `human-required` for what should have been a self-healing failure.

## Implementation information

- Add `project.RemoveWorktreeReconcile`: try the registered removal, prune stale admin entries, then fall back to a raw directory removal if the path still exists.
- `PrepareForFix` now surfaces its error instead of discarding it.
- Added test coverage in `internal/worktree/adopt_test.go`.

Closes https://github.com/Automaat/sybra/issues/1373

_Generated by Sybra harness_