### PR TITLE
fix(workflow): trust structured FAIL verdicts

### DIFF
--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -1108,6 +1108,27 @@ func classifyTestOutcome(status, output, body string, wfExec *Execution, stepID 
 	if strings.TrimSpace(report) == "" {
 		return testOutcomeMissingEvidence, ""
 	}
+
+	// A well-formed structured verdict is authoritative: trust the tester's own
+	// `outcome` field straight off the JSON payload instead of re-deriving a
+	// classification from prose-evidence heuristics the tester's contract never
+	// guaranteed. Without this, a test-runner that reports the identical
+	// {"verdict":"FAIL","outcome":"product_bug"} every retry gets bounced back
+	// as missing_evidence solely because its failures_markdown lacks a
+	// file:line citation or a labeled "Command:"/"Expected:" section, burning
+	// the whole auto-retry budget on a result the first run already reported
+	// correctly (#1382). Reconstructed reports (body-delta fallback, or a bare
+	// "Classification:" line in prose) are NOT covered here — only an outcome
+	// parsed directly off the agent's own structured output.
+	if parsed, ok := parseStructuredTestOutput(output); ok &&
+		strings.EqualFold(strings.TrimSpace(parsed.Verdict), "FAIL") &&
+		strings.TrimSpace(parsed.FailuresMarkdown) != "" {
+		switch normalizeTestOutcome(parsed.Outcome) {
+		case testOutcomeProductBug, testOutcomeAmbiguousRequirement:
+			return normalizeTestOutcome(parsed.Outcome), testFailureFingerprint(report)
+		}
+	}
+
 	if explicit := explicitTestOutcome(report); explicit != "" {
 		if explicit == testOutcomePass {
 			return testOutcomeMissingEvidence, ""

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -1109,23 +1109,32 @@ func classifyTestOutcome(status, output, body string, wfExec *Execution, stepID 
 		return testOutcomeMissingEvidence, ""
 	}
 
-	// A well-formed structured verdict is authoritative: trust the tester's own
-	// `outcome` field straight off the JSON payload instead of re-deriving a
-	// classification from prose-evidence heuristics the tester's contract never
-	// guaranteed. Without this, a test-runner that reports the identical
-	// {"verdict":"FAIL","outcome":"product_bug"} every retry gets bounced back
-	// as missing_evidence solely because its failures_markdown lacks a
-	// file:line citation or a labeled "Command:"/"Expected:" section, burning
-	// the whole auto-retry budget on a result the first run already reported
-	// correctly (#1382). Reconstructed reports (body-delta fallback, or a bare
-	// "Classification:" line in prose) are NOT covered here — only an outcome
-	// parsed directly off the agent's own structured output.
+	// A well-formed structured verdict is authoritative about *classification*:
+	// trust the tester's own `outcome` field instead of re-deriving product_bug
+	// vs. ambiguous_requirement vs. missing_evidence from prose-shape heuristics
+	// the tester's contract never guaranteed a specific markdown layout for.
+	// This does NOT waive the evidence requirement itself — a tester still has
+	// to show a real command and observed result, either as grounded prose
+	// (hasGroundedFailureEvidence) or as populated structured evidence fields
+	// (hasStructuredFailureEvidence: readiness_probe/manual_probes/
+	// automated_checks). Without the grounded-prose fallback, a test-runner
+	// that reports the identical {"verdict":"FAIL","outcome":"product_bug"}
+	// with a real repro every retry, just formatted without a labeled
+	// "Command:"/"Expected:" section or file:line citation, got bounced back as
+	// missing_evidence and burned the whole auto-retry budget on a result the
+	// first run already reported correctly (#1382). A bare narrative sentence
+	// with no evidence anywhere still falls through to the evidence gate below.
+	// Reconstructed reports (body-delta fallback, or a bare "Classification:"
+	// line in prose) are NOT covered here — only an outcome parsed directly off
+	// the agent's own structured output.
 	if parsed, ok := parseStructuredTestOutput(output); ok &&
 		strings.EqualFold(strings.TrimSpace(parsed.Verdict), "FAIL") &&
 		strings.TrimSpace(parsed.FailuresMarkdown) != "" {
 		switch normalizeTestOutcome(parsed.Outcome) {
 		case testOutcomeProductBug, testOutcomeAmbiguousRequirement:
-			return normalizeTestOutcome(parsed.Outcome), testFailureFingerprint(report)
+			if hasGroundedFailureEvidence(report) || hasStructuredFailureEvidence(parsed) {
+				return normalizeTestOutcome(parsed.Outcome), testFailureFingerprint(report)
+			}
 		}
 	}
 
@@ -1229,6 +1238,48 @@ func reportScanLines(text string) []string {
 		out = append(out, trimmed)
 	}
 	return out
+}
+
+// hasStructuredFailureEvidence reports whether a structured FAIL payload's own
+// evidence fields (readiness_probe/manual_probes/automated_checks) record a
+// real reproduction, as an alternative to hasGroundedFailureEvidence's prose
+// scan. It lets a tester that fills these fields correctly skip the markdown
+// labeling hasGroundedFailureEvidence expects, without waiving evidence
+// entirely (see the classifyTestOutcome comment for the incident this covers).
+func hasStructuredFailureEvidence(parsed structuredTestOutput) bool {
+	for _, p := range parsed.ManualProbes {
+		if hasConcreteProbeEvidence(p.Command, p.Actual, p.Output, p.Observed, p.Status, p.Raw) {
+			return true
+		}
+	}
+	for _, c := range parsed.AutomatedChecks {
+		if hasConcreteProbeEvidence(c.Command, c.Actual, c.Output, c.Observed, c.Status, c.Raw) {
+			return true
+		}
+	}
+	rp := parsed.ReadinessProbe
+	return hasConcreteProbeEvidence(rp.Command, rp.Actual, rp.Output, rp.Observed, rp.Status, rp.Raw)
+}
+
+// hasConcreteProbeEvidence reports whether a structured probe records a real
+// reproduction: a command plus at least one populated result field, or a
+// free-form raw string with both a stated action and an observed result.
+// Unlike hasSuccessfulCheckResult (built to confirm a PASS), this makes no
+// success/failure judgment on the result — a FAIL report showing the probe
+// actually ran and what it returned is exactly the evidence we want.
+func hasConcreteProbeEvidence(command string, actual, output, observed, status evidenceText, raw string) bool {
+	if strings.TrimSpace(command) != "" &&
+		(strings.TrimSpace(string(actual)) != "" ||
+			strings.TrimSpace(string(output)) != "" ||
+			strings.TrimSpace(string(observed)) != "" ||
+			strings.TrimSpace(string(status)) != "") {
+		return true
+	}
+	lower := strings.ToLower(strings.TrimSpace(raw))
+	if lower == "" {
+		return false
+	}
+	return hasManualActionEvidence(lower) && hasManualObservationEvidence(lower)
 }
 
 func hasGroundedFailureEvidence(report string) bool {

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -1269,10 +1269,10 @@ func hasStructuredFailureEvidence(parsed structuredTestOutput) bool {
 // actually ran and what it returned is exactly the evidence we want.
 func hasConcreteProbeEvidence(command string, actual, output, observed, status evidenceText, raw string) bool {
 	if strings.TrimSpace(command) != "" &&
-		(strings.TrimSpace(string(actual)) != "" ||
-			strings.TrimSpace(string(output)) != "" ||
-			strings.TrimSpace(string(observed)) != "" ||
-			strings.TrimSpace(string(status)) != "") {
+		(hasConcreteProbeResult(actual) ||
+			hasConcreteProbeResult(output) ||
+			hasConcreteProbeResult(observed) ||
+			hasConcreteProbeResult(status)) {
 		return true
 	}
 	lower := strings.ToLower(strings.TrimSpace(raw))
@@ -1280,6 +1280,26 @@ func hasConcreteProbeEvidence(command string, actual, output, observed, status e
 		return false
 	}
 	return hasManualActionEvidence(lower) && hasManualObservationEvidence(lower)
+}
+
+// hasConcreteProbeResult reports whether a probe result field (actual/output/
+// observed/status) records a real outcome rather than a not-executed marker
+// (e.g. "not run", "skipped", "could not run"). Applied uniformly to all four
+// fields because fillAliases backfills an empty Actual from Status, so a
+// negative status would otherwise resurface as "concrete" Actual content and
+// let an admittedly-unexecuted probe pass as reproduction evidence. Unlike
+// hasRegressionNegativeEvidence, this must NOT flag "failed"/"failure" — a
+// probe result of "failed" means it ran and failed, which is exactly the
+// reproduction evidence this gate wants.
+func hasConcreteProbeResult(v evidenceText) bool {
+	trimmed := strings.TrimSpace(string(v))
+	if trimmed == "" {
+		return false
+	}
+	return !containsAny(strings.ToLower(trimmed),
+		"not run", "not executed", "never ran", "never run", "did not run", "didn't run",
+		"was not run", "were not run", "wasn't run", "weren't run", "could not run",
+		"cannot run", "skipped", "without running", "n/a", "unknown")
 }
 
 func hasGroundedFailureEvidence(report string) bool {

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -588,6 +588,21 @@ func TestApplyTestVerdictCompletion_ClassifiesOutcomes(t *testing.T) {
 			wantStatus: "completed",
 		},
 		{
+			// A structured probe whose only populated field is a command plus a
+			// status explicitly stating it was NOT executed (e.g. "not run",
+			// "could not run") must not count as reproduction evidence — the
+			// probe's own status says it never ran.
+			name:   "structured_product_bug_with_command_and_not_run_status_is_missing_evidence",
+			status: "completed",
+			output: `{"verdict":"FAIL","outcome":"product_bug","failures_markdown":` +
+				strconv.Quote("The feature seems broken.") + `,` +
+				`"manual_probes":[{"command":"curl /status","status":"could not run — server was down"}]}`,
+			bodySuffix: "",
+			want:       testOutcomeMissingEvidence,
+			wantStatus: "failed",
+			wantTaint:  testProtocolMissingEvidence,
+		},
+		{
 			name:       "explicit_product_bug_still_requires_evidence",
 			status:     "completed",
 			output:     `{"verdict":"FAIL"}`,

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -553,17 +553,36 @@ func TestApplyTestVerdictCompletion_ClassifiesOutcomes(t *testing.T) {
 			wantTaint:  testProtocolMissingEvidence,
 		},
 		{
+			// A structured {"verdict":"FAIL","outcome":"product_bug"} whose
+			// failures_markdown is thin one-sentence narrative with no command,
+			// no observed result, and no structured evidence fields must still
+			// bounce to missing_evidence — trusting the tester's own outcome
+			// field waives the markdown-*labeling* requirement, not the
+			// underlying evidence requirement itself.
+			name:   "structured_product_bug_with_no_evidence_anywhere_is_missing_evidence",
+			status: "completed",
+			output: `{"verdict":"FAIL","outcome":"product_bug","failures_markdown":` +
+				strconv.Quote("The feature seems broken.") + `}`,
+			bodySuffix: "",
+			want:       testOutcomeMissingEvidence,
+			wantStatus: "failed",
+			wantTaint:  testProtocolMissingEvidence,
+		},
+		{
 			// Literal incident shape (#1382): a well-formed structured
 			// {"verdict":"FAIL","outcome":"product_bug"} whose failures_markdown
-			// is thin narrative prose with no labeled Command/Expected/file:line
-			// evidence section. Trust the tester's own structured outcome field
-			// instead of bouncing it to missing_evidence and burning the
-			// auto-retry budget on an identical result every time.
-			name:   "structured_product_bug_with_thin_narrative_evidence_is_trusted",
+			// is thin narrative prose, but whose structured automated_checks
+			// field records a real command and observed result. Trust the
+			// tester's own structured outcome field instead of bouncing it to
+			// missing_evidence and burning the auto-retry budget on an
+			// identical, already-evidenced result every retry.
+			name:   "structured_product_bug_with_thin_narrative_but_structured_evidence_is_trusted",
 			status: "completed",
 			output: `{"verdict":"FAIL","outcome":"product_bug","failures_markdown":` +
 				strconv.Quote("mise run verify does not mirror CI: it skips the golangci-lint and "+
-					"frontend gates that CI runs, so a change can pass verify locally and still fail CI.") + `}`,
+					"frontend gates that CI runs, so a change can pass verify locally and still fail CI.") + `,` +
+				`"automated_checks":[{"command":"mise run verify && mise run ci:parity",` +
+				`"observed":"verify: PASS; ci:parity: FAIL — golangci-lint step missing"}]}`,
 			bodySuffix: "",
 			want:       testOutcomeProductBug,
 			wantStatus: "completed",

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -553,6 +553,22 @@ func TestApplyTestVerdictCompletion_ClassifiesOutcomes(t *testing.T) {
 			wantTaint:  testProtocolMissingEvidence,
 		},
 		{
+			// Literal incident shape (#1382): a well-formed structured
+			// {"verdict":"FAIL","outcome":"product_bug"} whose failures_markdown
+			// is thin narrative prose with no labeled Command/Expected/file:line
+			// evidence section. Trust the tester's own structured outcome field
+			// instead of bouncing it to missing_evidence and burning the
+			// auto-retry budget on an identical result every time.
+			name:   "structured_product_bug_with_thin_narrative_evidence_is_trusted",
+			status: "completed",
+			output: `{"verdict":"FAIL","outcome":"product_bug","failures_markdown":` +
+				strconv.Quote("mise run verify does not mirror CI: it skips the golangci-lint and "+
+					"frontend gates that CI runs, so a change can pass verify locally and still fail CI.") + `}`,
+			bodySuffix: "",
+			want:       testOutcomeProductBug,
+			wantStatus: "completed",
+		},
+		{
 			name:       "explicit_product_bug_still_requires_evidence",
 			status:     "completed",
 			output:     `{"verdict":"FAIL"}`,


### PR DESCRIPTION
## Motivation

`route_test_result` re-derived the test-runner's outcome from prose
heuristics (`hasGroundedFailureEvidence`) even when the tester's own
structured `{"verdict":"FAIL","outcome":"product_bug"}` JSON already
said so. A tester whose `failures_markdown` lacked a labeled
Command/Expected section or file:line citation got bounced to
`missing_evidence` and re-run identically until the auto-retry budget
exhausted, then escalated to `human-required` for a result the first
run already reported correctly.

## Implementation information

`classifyTestOutcome` now trusts an outcome parsed directly off the
agent's structured output for `product_bug`/`ambiguous_requirement`,
bypassing the prose evidence gate. Reports reconstructed from a body
delta or a bare "Classification:" line in prose still go through the
gate unchanged.

Closes https://github.com/Automaat/sybra/issues/1382

_Generated by Sybra harness_