### PR TITLE
fix(agent): fix typed-nil LimitGate dispatch panic

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -89,6 +89,17 @@ type LimitGate interface {
 	ChooseProvider(requested string, candidates []string, healthy func(string) bool, policy limits.Policy) (string, string)
 }
 
+// LimitGateOrNil wraps store as a LimitGate, returning a genuine nil
+// interface when store is nil. Assigning a nil *limits.Store directly to a
+// LimitGate field produces a non-nil interface holding a nil pointer, which
+// defeats `== nil` guards and panics on the first method call.
+func LimitGateOrNil(store *limits.Store) LimitGate {
+	if store == nil {
+		return nil
+	}
+	return store
+}
+
 // ManagerConfig contains startup-only wiring. Values that are intentionally
 // live-editable are grouped in Runtime and updated via ReplaceRuntimeConfig.
 type ManagerConfig struct {

--- a/internal/agent/manager_gate_test.go
+++ b/internal/agent/manager_gate_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"errors"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -180,7 +181,7 @@ func TestLimitGateOrNil_NilStoreYieldsNilInterface(t *testing.T) {
 }
 
 func TestLimitGateOrNil_NonNilStorePassesThrough(t *testing.T) {
-	store, err := limits.NewStore(t.TempDir() + "/limits.json")
+	store, err := limits.NewStore(filepath.Join(t.TempDir(), "limits.json"))
 	if err != nil {
 		t.Fatalf("NewStore: %v", err)
 	}

--- a/internal/agent/manager_gate_test.go
+++ b/internal/agent/manager_gate_test.go
@@ -171,6 +171,50 @@ func TestReportProviderHealthSignal_CleanLimitResultMarksRateLimit(t *testing.T)
 	}
 }
 
+func TestLimitGateOrNil_NilStoreYieldsNilInterface(t *testing.T) {
+	var store *limits.Store
+	gate := LimitGateOrNil(store)
+	if gate != nil {
+		t.Fatalf("expected nil interface for nil *limits.Store, got %#v", gate)
+	}
+}
+
+func TestLimitGateOrNil_NonNilStorePassesThrough(t *testing.T) {
+	store, err := limits.NewStore(t.TempDir() + "/limits.json")
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	gate := LimitGateOrNil(store)
+	if gate == nil {
+		t.Fatal("expected non-nil LimitGate for non-nil store")
+	}
+}
+
+// TestGateProvider_DegradedLimitsStoreNoPanic reproduces a degraded
+// limits.Store init (nil *limits.Store) wired through LimitGateOrNil, as
+// app_init.go and svc_config.go do. Before the fix, assigning the nil
+// *limits.Store directly to the LimitGate interface field produced a
+// non-nil interface holding a nil pointer, defeating the manager's
+// `lg == nil` guard and panicking on Store.ProviderAvailable's nil
+// receiver mutex.
+func TestGateProvider_DegradedLimitsStoreNoPanic(t *testing.T) {
+	var degradedStore *limits.Store
+	m, _ := newTestManager(t, ManagerConfig{
+		Runtime: ManagerRuntimeConfig{
+			DefaultProvider: "claude",
+			LimitGate:       LimitGateOrNil(degradedStore),
+			LimitPolicy:     limits.DefaultPolicy(),
+		},
+	})
+	got, err := m.gateProvider(RunConfig{Provider: "claude"})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got != "claude" {
+		t.Errorf("got %q, want claude", got)
+	}
+}
+
 func TestReportProviderHealthSignal_CleanSuccessMentioningRateLimitDoesNotMarkRateLimit(t *testing.T) {
 	m, _ := newTestManager(t)
 	fg := &fakeGate{healthy: map[string]bool{"claude": true}}

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -306,7 +306,7 @@ func (a *App) agentRuntimeConfig(cfg *config.Config) agent.ManagerRuntimeConfig 
 		BashTimeoutMs:   cfg.BashTimeoutMs(),
 		RetryWatchdog:   cfg.RetryWatchdog(),
 		FallbackModel:   cfg.Agent.FallbackModel,
-		LimitGate:       a.limits,
+		LimitGate:       agent.LimitGateOrNil(a.limits),
 		LimitPolicy:     policy,
 	}
 }

--- a/internal/sybra/svc_config.go
+++ b/internal/sybra/svc_config.go
@@ -189,7 +189,7 @@ func (s *ConfigService) managerRuntimeConfig(cfg config.Config) agent.ManagerRun
 		BashTimeoutMs:   cfg.BashTimeoutMs(),
 		RetryWatchdog:   cfg.RetryWatchdog(),
 		FallbackModel:   cfg.Agent.FallbackModel,
-		LimitGate:       s.limits,
+		LimitGate:       agent.LimitGateOrNil(s.limits),
 		LimitPolicy:     policy,
 	}
 }


### PR DESCRIPTION
## Motivation

Assigning a nil `*limits.Store` directly to a `LimitGate` interface field produces a non-nil interface holding a nil pointer, which defeats `== nil` guards in the agent manager and panics on the first method call (nil receiver mutex in `Store.ProviderAvailable`) when the limits store is degraded/uninitialized.

## Implementation information

- Added `agent.LimitGateOrNil(store *limits.Store) LimitGate` which returns a genuine nil interface when the store pointer is nil, instead of a typed-nil interface.
- Wired `app_init.go` and `svc_config.go` to use `agent.LimitGateOrNil(...)` instead of assigning the raw store pointer to the `LimitGate` field.
- Added regression tests covering the typed-nil-to-nil-interface conversion and a reproduction of the dispatch panic with a degraded limits store.

Closes https://github.com/Automaat/sybra/issues/1385

_Generated by Sybra harness_