### PR TITLE
fix(workflow): match evidence keywords anywhere in header

### DIFF
--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -1321,11 +1321,12 @@ func hasGroundedFailureEvidence(report string) bool {
 			"command output", "stdout", "stderr", "output",
 			"verbatim output", "actual behavior", "actual behaviour",
 			"observed behavior", "observed behaviour", "printed", "rendered",
-			// Natural-language observed-evidence headers. hasLabeledSection only
-			// matches a keyword at the START of the line, so a report that writes
-			// "**What actually happened:**" (keyword mid-phrase) would otherwise be
-			// misclassified missing_evidence despite a fully grounded FAIL. Same
-			// class of false rejection #1344/#1345 closed for other markers.
+			// Natural-language observed-evidence headers whose core keyword above
+			// isn't present as a standalone word (e.g. "what happened", "what i
+			// saw"). hasLabeledSection now matches keywords anywhere in a header
+			// label (#1386), so headers like "**What actually happened:**" are
+			// already covered by "actual"/"output"; these catch the phrasings that
+			// carry no core keyword at all.
 			"what actually happened", "what happened", "what i observed",
 			"what i saw", "what the code shows", "what the code does")
 	hasExpected := containsAny(lower,
@@ -1350,6 +1351,70 @@ func hasGroundedFailureEvidence(report string) bool {
 // header — a bare header immediately followed by another header's line (with
 // or without inline content) still has no content of its own.
 var headerLikeLineRe = regexp.MustCompile(`^[a-z][a-z0-9 '/()-]{0,40}:`)
+
+// evidenceLabelRe matches the label portion (the text before the colon) of a
+// header-like line: a short token of letters, digits and a little punctuation.
+// It keeps keyword matching scoped to real headers instead of arbitrary prose
+// that merely contains a colon (which would carry a comma, longer text, etc.).
+var evidenceLabelRe = regexp.MustCompile(`^[a-z][a-z0-9 '/()-]{0,60}$`)
+
+// labelMatchesKeyword reports whether a header label matches any keyword.
+// Single-word keywords must match at the label's START (as a whole word), so a
+// generic word like "output" is not credited inside a different-category label
+// such as "expected output". Multi-word phrase keywords ("actual output",
+// "what actually happened") may match ANYWHERE in the label — this is what lets
+// natural mid-phrase headers satisfy the gate (#1386) without collapsing the
+// observed/expected distinction.
+func labelMatchesKeyword(label string, keywords []string) bool {
+	for _, kw := range keywords {
+		if strings.Contains(kw, " ") {
+			if labelHasKeyword(label, kw) {
+				return true
+			}
+		} else if labelHasPrefixKeyword(label, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// labelHasPrefixKeyword reports whether label begins with kw as a whole word
+// (kw is the entire label, or is immediately followed by a non-alphanumeric
+// byte). label is expected to be already lower-cased.
+func labelHasPrefixKeyword(label, kw string) bool {
+	if !strings.HasPrefix(label, kw) {
+		return false
+	}
+	return len(label) == len(kw) || !isAlnumByte(label[len(kw)])
+}
+
+// labelHasKeyword reports whether kw occurs in label as a whole word/phrase,
+// bounded by non-alphanumeric characters. This lets "actual output" match
+// mid-label (e.g. "runtime actual output") while "actual" does not match inside
+// "actually". label is expected to be already lower-cased.
+func labelHasKeyword(label, kw string) bool {
+	if kw == "" {
+		return false
+	}
+	for start := 0; start <= len(label); {
+		rel := strings.Index(label[start:], kw)
+		if rel < 0 {
+			return false
+		}
+		i := start + rel
+		beforeOK := i == 0 || !isAlnumByte(label[i-1])
+		afterOK := i+len(kw) >= len(label) || !isAlnumByte(label[i+len(kw)])
+		if beforeOK && afterOK {
+			return true
+		}
+		start = i + 1
+	}
+	return false
+}
+
+func isAlnumByte(b byte) bool {
+	return b == '_' || (b >= 'a' && b <= 'z') || (b >= '0' && b <= '9')
+}
 
 // fileLineCitationRe matches a real file:line citation such as
 // "internal/x.go:42" or "src/App.svelte:10" — a path segment ending in a
@@ -1383,24 +1448,29 @@ func hasLabeledSection(report string, keywords ...string) bool {
 		}
 		lower := strings.ToLower(trimmed)
 		lower = strings.TrimLeft(lower, "*_>#- \t")
-		for _, kw := range keywords {
-			rest, ok := strings.CutPrefix(lower, kw)
-			if !ok {
-				continue
-			}
-			rest = strings.TrimSpace(rest)
-			if strings.HasPrefix(rest, "(") {
-				if idx := strings.Index(rest, ")"); idx >= 0 {
-					rest = strings.TrimSpace(rest[idx+1:])
-				}
-			}
-			if !strings.HasPrefix(rest, ":") {
-				continue
-			}
-			afterColon := strings.TrimSpace(strings.TrimRight(strings.TrimSpace(rest[1:]), "*_"))
-			if afterColon != "" || hasFollowingContent(rawLines, i) {
-				return true
-			}
+		// A header-like line is "<label>: <content>". Match keywords anywhere in
+		// the label (word-boundary aware) rather than only as its first token, so
+		// natural headers whose evidence keyword is mid-phrase — e.g. "Here is the
+		// actual output:" — are still recognized (#1386). The label must be a
+		// short header-like token and the header must be backed by real content,
+		// which preserves the bare-header rejections.
+		before, after, found := strings.Cut(lower, ":")
+		if !found {
+			continue
+		}
+		label := strings.TrimRight(strings.TrimSpace(before), "*_ ")
+		if p := strings.LastIndex(label, "("); p >= 0 && strings.HasSuffix(label, ")") {
+			label = strings.TrimSpace(label[:p])
+		}
+		if !evidenceLabelRe.MatchString(label) {
+			continue
+		}
+		if !labelMatchesKeyword(label, keywords) {
+			continue
+		}
+		afterColon := strings.TrimSpace(strings.TrimRight(strings.TrimSpace(after), "*_"))
+		if afterColon != "" || hasFollowingContent(rawLines, i) {
+			return true
 		}
 	}
 	return false

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -1347,7 +1347,7 @@ func hasGroundedFailureEvidence(report string) bool {
 // header-like line: a short token of letters, digits and a little punctuation.
 // It keeps keyword matching scoped to real headers instead of arbitrary prose
 // that merely contains a colon (which would carry a comma, longer text, etc.).
-var evidenceLabelRe = regexp.MustCompile(`^[a-z][a-z0-9 '/()-]{0,60}$`)
+var evidenceLabelRe = regexp.MustCompile(`^[a-z][a-z0-9 '/()-]{0,59}$`)
 
 // headerLikeLineRe matches a report line that STARTS with a short
 // markdown-decorated label followed by a colon, whether or not further text
@@ -1358,7 +1358,7 @@ var evidenceLabelRe = regexp.MustCompile(`^[a-z][a-z0-9 '/()-]{0,60}$`)
 // or without inline content) still has no content of its own. Its label
 // length ceiling must stay in sync with evidenceLabelRe's, otherwise a bare
 // header can borrow a longer header's content as its own (#1386 follow-up).
-var headerLikeLineRe = regexp.MustCompile(`^[a-z][a-z0-9 '/()-]{0,60}:`)
+var headerLikeLineRe = regexp.MustCompile(`^[a-z][a-z0-9 '/()-]{0,59}:`)
 
 // labelMatchesKeyword reports whether a header label matches any keyword.
 // Single-word keywords must match at the label's START (as a whole word), so a

--- a/internal/workflow/engine_steps_testroute.go
+++ b/internal/workflow/engine_steps_testroute.go
@@ -1343,20 +1343,22 @@ func hasGroundedFailureEvidence(report string) bool {
 	return hasCommand && hasObserved && hasExpected && hasGrounding
 }
 
+// evidenceLabelRe matches the label portion (the text before the colon) of a
+// header-like line: a short token of letters, digits and a little punctuation.
+// It keeps keyword matching scoped to real headers instead of arbitrary prose
+// that merely contains a colon (which would carry a comma, longer text, etc.).
+var evidenceLabelRe = regexp.MustCompile(`^[a-z][a-z0-9 '/()-]{0,60}$`)
+
 // headerLikeLineRe matches a report line that STARTS with a short
 // markdown-decorated label followed by a colon, whether or not further text
 // follows on the same line, e.g. "actual:** something happened" or
 // "command:". Used to recognize that a line belongs to a *different* header's
 // own section rather than being prose content continuing a preceding bare
 // header — a bare header immediately followed by another header's line (with
-// or without inline content) still has no content of its own.
-var headerLikeLineRe = regexp.MustCompile(`^[a-z][a-z0-9 '/()-]{0,40}:`)
-
-// evidenceLabelRe matches the label portion (the text before the colon) of a
-// header-like line: a short token of letters, digits and a little punctuation.
-// It keeps keyword matching scoped to real headers instead of arbitrary prose
-// that merely contains a colon (which would carry a comma, longer text, etc.).
-var evidenceLabelRe = regexp.MustCompile(`^[a-z][a-z0-9 '/()-]{0,60}$`)
+// or without inline content) still has no content of its own. Its label
+// length ceiling must stay in sync with evidenceLabelRe's, otherwise a bare
+// header can borrow a longer header's content as its own (#1386 follow-up).
+var headerLikeLineRe = regexp.MustCompile(`^[a-z][a-z0-9 '/()-]{0,60}:`)
 
 // labelMatchesKeyword reports whether a header label matches any keyword.
 // Single-word keywords must match at the label's START (as a whole word), so a

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -340,6 +340,29 @@ func TestHasGroundedFailureEvidence_RejectsBareHeaderBorrowingLongNextHeaderLabe
 	}
 }
 
+func TestEvidenceLabelRe_EnforcesSixtyCharCeiling(t *testing.T) {
+	t.Parallel()
+
+	// The label ceiling is documented as 60 chars total (1 leading letter +
+	// up to 59 more). A 61-char label must be rejected by both regexes, or a
+	// bare header could borrow an over-long following header's content.
+	sixty := "a" + strings.Repeat("b", 59)
+	sixtyOne := "a" + strings.Repeat("b", 60)
+
+	if !evidenceLabelRe.MatchString(sixty) {
+		t.Fatalf("evidenceLabelRe rejected a 60-char label %q; want accepted", sixty)
+	}
+	if evidenceLabelRe.MatchString(sixtyOne) {
+		t.Fatalf("evidenceLabelRe accepted a 61-char label %q; want rejected", sixtyOne)
+	}
+	if !headerLikeLineRe.MatchString(sixty + ":") {
+		t.Fatalf("headerLikeLineRe rejected a 60-char label header %q; want accepted", sixty)
+	}
+	if headerLikeLineRe.MatchString(sixtyOne + ":") {
+		t.Fatalf("headerLikeLineRe accepted a 61-char label header %q; want rejected", sixtyOne)
+	}
+}
+
 func TestHasGroundedFailureEvidence_RejectsBareCodeEvidenceHeader(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -264,6 +264,25 @@ func TestHasGroundedFailureEvidence_AcceptsNaturalObservedHeader(t *testing.T) {
 	}
 }
 
+func TestHasGroundedFailureEvidence_AcceptsKeywordMidHeaderLabel(t *testing.T) {
+	t.Parallel()
+
+	// #1386: evidence keywords that appear mid-label — not as the header's first
+	// token and not among the enumerated natural-language phrases — must still be
+	// recognized. Here the observed header is "Here is the actual output:" and the
+	// expected header is "Per the task requirement:"; both would be rejected by
+	// the old prefix-only (CutPrefix) matcher despite a fully grounded FAIL.
+	report := "## Test Failures\n\n" +
+		"**Reproduction command:** `go test ./internal/limits -run TestDegrade`\n\n" +
+		"**Here is the actual output:**\n\n```text\npanic: assignment to entry in nil map\n```\n\n" +
+		"**Per the task requirement:** the store must degrade to a no-op.\n\n" +
+		"**Code evidence:** internal/limits/store.go:157\n"
+
+	if !hasGroundedFailureEvidence(report) {
+		t.Fatal("mid-label evidence keywords rejected as ungrounded; want grounded")
+	}
+}
+
 func TestHasGroundedFailureEvidence_RejectsUngroundedReport(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workflow/engine_steps_testroute_test.go
+++ b/internal/workflow/engine_steps_testroute_test.go
@@ -321,6 +321,25 @@ func TestHasGroundedFailureEvidence_RejectsBareHeaderBorrowingNextHeaderContent(
 	}
 }
 
+func TestHasGroundedFailureEvidence_RejectsBareHeaderBorrowingLongNextHeaderLabel(t *testing.T) {
+	t.Parallel()
+
+	// Same borrowing bug as RejectsBareHeaderBorrowingNextHeaderContent, but
+	// the following header's label is 41-60 chars long — past the old
+	// headerLikeLineRe's 40-char ceiling but within evidenceLabelRe's 60-char
+	// ceiling used to accept it as an "actual output" header. hasFollowingContent
+	// must recognize that line as a header (not free content) regardless of its
+	// label length, or the bare Command header wrongly borrows it.
+	report := "**Command:**\n\n" +
+		"**Here is the actual output with enough words added:** panic\n\n" +
+		"**Expected:** task says the operation should not panic.\n\n" +
+		"**Code evidence:** internal/limits/store.go:157\n"
+
+	if hasGroundedFailureEvidence(report) {
+		t.Fatal("bare Command header borrowing long next-header label accepted as grounded; want rejected")
+	}
+}
+
 func TestHasGroundedFailureEvidence_RejectsBareCodeEvidenceHeader(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation

The grounded-evidence gate only matched observed/expected keywords as the first token of a header label, so natural headers like "Here is the actual output:" were misread as missing evidence and escalated to human-required despite a fully grounded FAIL report.

## Implementation information

- Match multi-word phrase keywords anywhere in the header label (word-boundary aware) while keeping single-word keywords anchored at the label start, preserving the observed/expected distinction and existing bare-header rejections.
- Sync `headerLikeLineRe`'s label-length ceiling with `evidenceLabelRe`'s (60 chars) so a bare header can no longer borrow a longer following header's content as its own.
- Add regression tests covering mid-label keyword matching and the long-label header-borrowing case.

_Generated by Sybra harness_