### PR TITLE
test(project): fail loud on missing git, not silent skip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,6 +338,12 @@ There is no Vite-backed hot reload — the frontend is built once per `mise run 
   `SYBRA_HOME` + fake-provider CLI harness that exercises the real HTTP server,
   workflows, agent runners, stats, audit, and Evaluation report without
   touching local user data or spending model credits.
+- Never guard a git-dependent test with a per-test `t.Skip("git not
+  available")` — a broken environment then reports green while silently
+  dropping coverage. `internal/project`, `internal/worktree`, and
+  `internal/sybra` each enforce this via a package-level `TestMain` that
+  `os.Exit(1)`s immediately if `git` is missing from `PATH`; add new
+  git-dependent test packages to that pattern instead of a local skip.
 
 ## Quality Gates
 

--- a/internal/project/git_lock_test.go
+++ b/internal/project/git_lock_test.go
@@ -159,10 +159,6 @@ func TestWithLockRetry_GivesUpAfterExhaustingBackoffs(t *testing.T) {
 // contention; this proves they now serialize instead of racing.
 func TestCreateWorktree_ConcurrentDistinctPathsSucceed(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
-
 	src := initRepoWithCommit(t)
 	bare := filepath.Join(t.TempDir(), "bare.git")
 	if err := CloneBare(src, bare); err != nil {

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -307,9 +307,6 @@ func TestParseWorktreePorcelain(t *testing.T) {
 
 func TestAutoCommitUncommitted(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 
 	dir := initRepoWithCommit(t)
 

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -96,11 +96,6 @@ func TestSplitOwnerRepo(t *testing.T) {
 	}
 }
 
-func hasGit() bool {
-	_, err := exec.LookPath("git")
-	return err == nil
-}
-
 func initBareRepo(t *testing.T) string {
 	t.Helper()
 	dir := filepath.Join(t.TempDir(), "test.git")
@@ -139,10 +134,6 @@ func initRepoWithCommit(t *testing.T) string {
 
 func TestCloneBare(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
-
 	src := initRepoWithCommit(t)
 	dest := filepath.Join(t.TempDir(), "clone.git")
 
@@ -157,10 +148,6 @@ func TestCloneBare(t *testing.T) {
 
 func TestCloneBareInvalidURL(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
-
 	dest := filepath.Join(t.TempDir(), "clone.git")
 	if err := CloneBare("/nonexistent/repo", dest); err == nil {
 		t.Fatal("expected error for invalid source")
@@ -169,10 +156,6 @@ func TestCloneBareInvalidURL(t *testing.T) {
 
 func TestDefaultBranch(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
-
 	bare := initBareRepo(t)
 	branch, err := DefaultBranch(bare)
 	if err != nil {
@@ -185,10 +168,6 @@ func TestDefaultBranch(t *testing.T) {
 
 func TestFetchOriginNoRemote(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
-
 	bare := initBareRepo(t)
 	err := FetchOrigin(bare)
 	if err == nil {
@@ -198,10 +177,6 @@ func TestFetchOriginNoRemote(t *testing.T) {
 
 func TestWorktreeHealthyAndRepair(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
-
 	src := initRepoWithCommit(t)
 	bare := filepath.Join(t.TempDir(), "bare.git")
 	if err := CloneBare(src, bare); err != nil {
@@ -240,10 +215,6 @@ func TestWorktreeHealthyAndRepair(t *testing.T) {
 
 func TestCreateAndRemoveWorktree(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
-
 	src := initRepoWithCommit(t)
 	bare := filepath.Join(t.TempDir(), "bare.git")
 	if err := CloneBare(src, bare); err != nil {
@@ -377,10 +348,6 @@ func TestAutoCommitUncommitted(t *testing.T) {
 
 func TestSanitizeWorktree_AbortsRebase(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
-
 	src := initRepoWithCommit(t)
 	bare := filepath.Join(t.TempDir(), "bare.git")
 	if err := CloneBare(src, bare); err != nil {
@@ -443,10 +410,6 @@ func TestSanitizeWorktree_AbortsRebase(t *testing.T) {
 
 func TestSanitizeWorktree_DeletesShadowBranches(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
-
 	src := initRepoWithCommit(t)
 	bare := filepath.Join(t.TempDir(), "bare.git")
 	if err := CloneBare(src, bare); err != nil {
@@ -483,10 +446,6 @@ func contains(s, sub string) bool {
 
 func TestSanitizeWorktree_AutoCommitsUncommitted(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
-
 	src := initRepoWithCommit(t)
 	bare := filepath.Join(t.TempDir(), "bare.git")
 	if err := CloneBare(src, bare); err != nil {
@@ -538,10 +497,6 @@ func TestSanitizeWorktree_AutoCommitsUncommitted(t *testing.T) {
 
 func TestResetWorktreeForRetry_DiscardsPartialWorkAndKeepsIgnoredNotes(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
-
 	src := initRepoWithCommit(t)
 	bare := filepath.Join(t.TempDir(), "bare.git")
 	if err := CloneBare(src, bare); err != nil {
@@ -628,10 +583,6 @@ func TestResetWorktreeForRetry_DiscardsPartialWorkAndKeepsIgnoredNotes(t *testin
 
 func TestCreateWorktreeInvalidBase(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
-
 	bare := initBareRepo(t)
 	wtPath := filepath.Join(t.TempDir(), "wt")
 	err := CreateWorktree(bare, wtPath, "test-branch", "nonexistent-base")
@@ -930,9 +881,6 @@ func TestLoadRepoConfig_Invalid(t *testing.T) {
 
 func TestInstallHooks_RepoConfigPriority(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	_, wtPath := initWorktree(t)
 
 	// Write .sybra.yaml with a failing pre-commit to prove repo config is used.
@@ -969,9 +917,6 @@ func TestInstallHooks_RepoConfigPriority(t *testing.T) {
 
 func TestInstallHooks_NilChecks(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	_, wtPath := initWorktree(t)
 	if err := InstallHooks(wtPath, nil); err != nil {
 		t.Fatalf("InstallHooks(nil): %v", err)
@@ -980,9 +925,6 @@ func TestInstallHooks_NilChecks(t *testing.T) {
 
 func TestInstallHooks_EmptySlices(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	_, wtPath := initWorktree(t)
 	if err := InstallHooks(wtPath, &ChecksConfig{}); err != nil {
 		t.Fatalf("InstallHooks(empty): %v", err)
@@ -1004,9 +946,6 @@ func TestInstallHooks_EmptySlices(t *testing.T) {
 
 func TestInstallHooks_PreCommitBlocksOnFailure(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	_, wtPath := initWorktree(t)
 
 	checks := &ChecksConfig{
@@ -1051,9 +990,6 @@ func TestInstallHooks_PreCommitBlocksOnFailure(t *testing.T) {
 
 func TestInstallHooks_PreCommitPassesOnSuccess(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	_, wtPath := initWorktree(t)
 
 	checks := &ChecksConfig{
@@ -1080,9 +1016,6 @@ func TestInstallHooks_PreCommitPassesOnSuccess(t *testing.T) {
 
 func TestInstallHooks_PrePushInstalled(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	_, wtPath := initWorktree(t)
 
 	checks := &ChecksConfig{
@@ -1115,9 +1048,6 @@ func TestInstallHooks_PrePushInstalled(t *testing.T) {
 
 func TestInstallHooks_Overwrites(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	_, wtPath := initWorktree(t)
 
 	// Install first version.
@@ -1155,9 +1085,6 @@ func TestInstallHooks_Overwrites(t *testing.T) {
 // failing to start the agent.
 func TestCreateWorktree_PathExistsWithFiles(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	src := initRepoWithCommit(t)
 	bare := filepath.Join(t.TempDir(), "bare.git")
 	if err := CloneBare(src, bare); err != nil {
@@ -1198,9 +1125,6 @@ func TestCreateWorktree_PathExistsWithFiles(t *testing.T) {
 // again, assert the second call errors.
 func TestCreateWorktree_DuplicatePathRejected(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	src := initRepoWithCommit(t)
 	bare := filepath.Join(t.TempDir(), "bare.git")
 	if err := CloneBare(src, bare); err != nil {
@@ -1230,9 +1154,6 @@ func TestCreateWorktree_DuplicatePathRejected(t *testing.T) {
 
 func TestPushRemote_DefaultOrigin(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	_, wtPath := initWorktree(t)
 	if got := PushRemote(wtPath); got != "origin" {
 		t.Errorf("PushRemote without fork = %q, want %q", got, "origin")
@@ -1241,9 +1162,6 @@ func TestPushRemote_DefaultOrigin(t *testing.T) {
 
 func TestPushRemote_DetectsFork(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	_, wtPath := initWorktree(t)
 
 	forkBare := filepath.Join(t.TempDir(), "fork.git")
@@ -1265,9 +1183,6 @@ func TestPushRemote_DetectsFork(t *testing.T) {
 // repo and gh pr create then opens a same-repo PR.
 func TestPushUpstream_RoutesToFork(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	_, wtPath := initWorktree(t)
 
 	originBare := filepath.Join(t.TempDir(), "origin.git")
@@ -1311,9 +1226,6 @@ func TestPushUpstream_RoutesToFork(t *testing.T) {
 // floor that backs up the prompt-level guidance pointing agents at fork.
 func TestEnforceForkOnlyPush_BlocksOriginPush(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	_, wtPath := initWorktree(t)
 
 	originBare := filepath.Join(t.TempDir(), "origin.git")
@@ -1365,9 +1277,6 @@ func TestEnforceForkOnlyPush_BlocksOriginPush(t *testing.T) {
 // origin must keep working.
 func TestEnforceForkOnlyPush_NoForkLeavesOriginPushable(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	_, wtPath := initWorktree(t)
 
 	originBare := filepath.Join(t.TempDir(), "origin.git")
@@ -1402,9 +1311,6 @@ func TestEnforceForkOnlyPush_NoForkLeavesOriginPushable(t *testing.T) {
 // by the user are left untouched.
 func TestEnforceForkOnlyPush_RestoresAfterForkRemoved(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	_, wtPath := initWorktree(t)
 
 	originBare := filepath.Join(t.TempDir(), "origin.git")
@@ -1451,9 +1357,6 @@ func TestEnforceForkOnlyPush_RestoresAfterForkRemoved(t *testing.T) {
 // sentinel value.
 func TestEnforceForkOnlyPush_PreservesForeignPushURL(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	_, wtPath := initWorktree(t)
 
 	foreignURL := "https://user.example.com/custom-push-url.git"
@@ -1486,9 +1389,6 @@ func TestEnforceForkOnlyPush_PreservesForeignPushURL(t *testing.T) {
 // silently drops (or crashes on) orphaned entries is visible.
 func TestListWorktrees_OrphanedAdminDir(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	src := initRepoWithCommit(t)
 	bare := filepath.Join(t.TempDir(), "bare.git")
 	if err := CloneBare(src, bare); err != nil {
@@ -1644,9 +1544,6 @@ func remoteReflogCount(t *testing.T, remoteBare, branch string) int {
 
 func TestPushSync_BranchMissing(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	_, wtPath, _ := setupPushSyncWorktree(t)
 	if err := PushSync(wtPath, "no-such-branch"); !errors.Is(err, ErrBranchMissing) {
 		t.Fatalf("PushSync missing branch: got %v, want ErrBranchMissing", err)
@@ -1655,9 +1552,6 @@ func TestPushSync_BranchMissing(t *testing.T) {
 
 func TestPushSync_FirstPushSetsTracking(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
 	localSHA := makeCommit(t, wtPath, "first")
 
@@ -1671,9 +1565,6 @@ func TestPushSync_FirstPushSetsTracking(t *testing.T) {
 
 func TestPushSync_NoopWhenSynced(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
 	makeCommit(t, wtPath, "one")
 	if err := PushSync(wtPath, branch); err != nil {
@@ -1695,9 +1586,6 @@ func TestPushSync_NoopWhenSynced(t *testing.T) {
 
 func TestPushSync_FastForwardWithoutForce(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
 	makeCommit(t, wtPath, "one")
 	if err := PushSync(wtPath, branch); err != nil {
@@ -1720,9 +1608,6 @@ func TestPushSync_FastForwardWithoutForce(t *testing.T) {
 
 func TestPushSync_DivergenceForcePushes(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
 	makeCommit(t, wtPath, "one")
 	makeCommit(t, wtPath, "two")
@@ -1786,9 +1671,6 @@ func pushRemoteCommit(t *testing.T, remoteBare, branch, content string) string {
 // it is not dropped by a later force-push.
 func TestReconcileWithRemote_FastForwardsStaleLocal(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
 	makeCommit(t, wtPath, "one")
 	if err := PushSync(wtPath, branch); err != nil {
@@ -1819,9 +1701,6 @@ func TestReconcileWithRemote_FastForwardsStaleLocal(t *testing.T) {
 // later force-push silently overwrite remote-only commits.
 func TestReconcileWithRemote_DivergedReturnsError(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
 	makeCommit(t, wtPath, "one")
 	if err := PushSync(wtPath, branch); err != nil {
@@ -1844,9 +1723,6 @@ func TestReconcileWithRemote_DivergedReturnsError(t *testing.T) {
 // stale history.
 func TestReconcileWithRemote_PropagatesFetchError(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	_, wtPath, branch := setupPushSyncWorktree(t)
 	makeCommit(t, wtPath, "one")
 	if err := PushSync(wtPath, branch); err != nil {
@@ -1870,9 +1746,6 @@ func TestReconcileWithRemote_PropagatesFetchError(t *testing.T) {
 // clobber the newer commits (which the lease would wrongly permit).
 func TestPushSync_RefusesForceWhenRemoteAdvanced(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
 	makeCommit(t, wtPath, "one")
 	makeCommit(t, wtPath, "two")
@@ -1906,9 +1779,6 @@ func TestPushSync_RefusesForceWhenRemoteAdvanced(t *testing.T) {
 // remote state.
 func TestPushSync_FailsClosedWhenRemoteHeadUnverifiable(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
 	makeCommit(t, wtPath, "one")
 	makeCommit(t, wtPath, "two")
@@ -1940,10 +1810,6 @@ func TestPushSync_FailsClosedWhenRemoteHeadUnverifiable(t *testing.T) {
 
 func TestFetchPRHead(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
-
 	// Build an upstream whose PR-42 head commit is reachable ONLY via
 	// refs/pull/42/head — never as a normal branch head. This mirrors a fork
 	// PR: the head branch lives in the fork, but GitHub still publishes the
@@ -2007,10 +1873,6 @@ func TestFetchPRHead(t *testing.T) {
 
 func TestListTrackedFiles(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
-
 	src := t.TempDir()
 	for _, args := range [][]string{
 		{"git", "init", src},
@@ -2093,10 +1955,6 @@ func TestListTrackedFiles(t *testing.T) {
 
 func TestTrackedFilesAtDefaultBranch(t *testing.T) {
 	t.Parallel()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
-
 	t.Run("falls back to local head before first fetch", func(t *testing.T) {
 		t.Parallel()
 		src := initRepoWithCommit(t)

--- a/internal/project/testmain_test.go
+++ b/internal/project/testmain_test.go
@@ -1,0 +1,19 @@
+package project
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// TestMain fails the whole package immediately if git is missing, rather
+// than letting individual tests silently t.Skip — a stripped-down test
+// environment should show up as a red CI run, not quietly reduced coverage.
+func TestMain(m *testing.M) {
+	if _, err := exec.LookPath("git"); err != nil {
+		fmt.Fprintln(os.Stderr, "internal/project tests require git on PATH:", err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -246,10 +246,6 @@ func TestOnAgentComplete_EmptyTaskID_NoCrash(t *testing.T) {
 
 func setupFixReviewPushTest(t *testing.T) (*AgentCompletionHandler, *task.Manager, string) {
 	t.Helper()
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git not available")
-	}
-
 	home, err := os.MkdirTemp("", "sybra-fix-review-*")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/sybra/app_umbrella_gate_test.go
+++ b/internal/sybra/app_umbrella_gate_test.go
@@ -565,9 +565,6 @@ func mustWriteProjectYAMLWithClone(t *testing.T, dir, id, clonePath string) {
 // bare-clones it, and returns the bare clone path and its default branch.
 func newBareRepoWithTrackedFile(t *testing.T) (barePath, branch string) {
 	t.Helper()
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git not available")
-	}
 	src := t.TempDir()
 	for _, args := range [][]string{
 		{"git", "init", src},

--- a/internal/sybra/e2e_bootstrap_test.go
+++ b/internal/sybra/e2e_bootstrap_test.go
@@ -38,10 +38,6 @@ type bootstrapE2E struct {
 func setupBootstrapE2E(t *testing.T, repoSetup, appSetup []string) *bootstrapE2E {
 	t.Helper()
 
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git not available")
-	}
-
 	binDir := buildTestBinaries(t)
 	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 	t.Setenv("FAKE_CLAUDE_SCENARIO", "success")

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -37,6 +37,10 @@ var (
 // SYBRA_HOME is seeded by the package-level init in main_test.go before
 // this runs.
 func TestMain(m *testing.M) {
+	if _, err := exec.LookPath("git"); err != nil {
+		fmt.Fprintln(os.Stderr, "internal/sybra e2e tests require git on PATH:", err)
+		os.Exit(1)
+	}
 	code := m.Run()
 	if testBinDir != "" {
 		_ = os.RemoveAll(testBinDir)

--- a/internal/sybra/main_unit_test.go
+++ b/internal/sybra/main_unit_test.go
@@ -3,6 +3,9 @@
 package sybra
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
 	"testing"
 
 	"go.uber.org/goleak"
@@ -16,6 +19,10 @@ import (
 // Known long-lived backgrounders that have no Stop hook today are ignored
 // below. Trim this list as packages add explicit teardown.
 func TestMain(m *testing.M) {
+	if _, err := exec.LookPath("git"); err != nil {
+		fmt.Fprintln(os.Stderr, "internal/sybra tests require git on PATH:", err)
+		os.Exit(1)
+	}
 	goleak.VerifyTestMain(m,
 		goleak.IgnoreTopFunction("runtime.cgocall"),
 		goleak.IgnoreAnyFunction("net/http.(*Transport).dialConnFor"),

--- a/internal/sybra/orchestrator_resume_test.go
+++ b/internal/sybra/orchestrator_resume_test.go
@@ -5,7 +5,6 @@ package sybra
 import (
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -53,10 +52,6 @@ import (
 // asserts that the resulting fake-claude argv does NOT carry --resume
 // pointing at the stale session.
 func TestOrchestrator_StartAgent_DoesNotResumeStaleSessionFromPriorWorkflow(t *testing.T) {
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git not available")
-	}
-
 	binDir := buildTestBinaries(t)
 	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 	t.Setenv("FAKE_CLAUDE_SCENARIO", "interactive_implement")

--- a/internal/sybra/svc_reviews_test.go
+++ b/internal/sybra/svc_reviews_test.go
@@ -24,10 +24,6 @@ import (
 // use to simulate PR branches.
 func setupReviewService(t *testing.T) (*ReviewService, *task.Manager, string) {
 	t.Helper()
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git not available")
-	}
-
 	binDir := buildTestBinaries(t)
 	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 	t.Setenv("FAKE_CLAUDE_SCENARIO", "success")

--- a/internal/worktree/context_test.go
+++ b/internal/worktree/context_test.go
@@ -11,9 +11,6 @@ import (
 )
 
 func TestWriteContextFile_WritesBeacon(t *testing.T) {
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	wt := t.TempDir()
 	mustRunInDir(t, wt, "git", "init", "-b", "main")
 
@@ -42,9 +39,6 @@ func TestWriteContextFile_WritesBeacon(t *testing.T) {
 }
 
 func TestWriteContextFile_AddsToInfoExclude(t *testing.T) {
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	wt := t.TempDir()
 	mustRunInDir(t, wt, "git", "init", "-b", "main")
 
@@ -63,10 +57,6 @@ func TestWriteContextFile_AddsToInfoExclude(t *testing.T) {
 }
 
 func TestWriteContextFile_IdempotentExclude(t *testing.T) {
-	if !hasGit() {
-		t.Skip("git not available")
-	}
-
 	wt := t.TempDir()
 	mustRunInDir(t, wt, "git", "init", "-b", "main")
 
@@ -96,9 +86,6 @@ func TestWriteContextFile_IdempotentExclude(t *testing.T) {
 }
 
 func TestExcludeWorkflowScratchFiles(t *testing.T) {
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	wt := t.TempDir()
 	mustRunInDir(t, wt, "git", "init", "-b", "main")
 

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -15,11 +15,6 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 )
 
-func hasGit() bool {
-	_, err := exec.LookPath("git")
-	return err == nil
-}
-
 // initBareWithCommit creates a bare repo containing a single commit on
 // `main`. PrepareForTask branches off origin/main so the bare repo must
 // have something checked in for the flow to succeed. Returns (bare, src)
@@ -78,10 +73,6 @@ type preparedHarness struct {
 
 func prepareHarness(t *testing.T, setupCommands []string, timeout time.Duration) preparedHarness {
 	t.Helper()
-	if !hasGit() {
-		t.Skip("git not available")
-	}
-
 	bare, src := initBareWithCommitReturnSrc(t)
 	wtDir := t.TempDir()
 	logsDir := t.TempDir()
@@ -633,9 +624,6 @@ func TestHasMiseConfig(t *testing.T) {
 // class of failure where agents start on a worktree missing required
 // toolchain.
 func TestPrepareForTask_RunsBootstrap(t *testing.T) {
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	h := prepareHarness(t, []string{"touch bootstrap-marker"}, 30*time.Second)
 
 	tk, err := h.tasks.Store().Create("bootstrap task", "", "headless")
@@ -676,9 +664,6 @@ func TestPrepareForTask_RunsBootstrap(t *testing.T) {
 // order must be repo → app so per-machine additions can depend on
 // repo-installed tools.
 func TestPrepareForTask_MergesRepoAndAppSetup(t *testing.T) {
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	// App-level adds one command; repo-level (written to the worktree's
 	// .sybra.yaml below) adds two.
 	h := prepareHarness(t, []string{"echo app > app.marker"}, 30*time.Second)
@@ -734,9 +719,6 @@ func TestPrepareForTask_MergesRepoAndAppSetup(t *testing.T) {
 // refs/heads/<branch> in a bare clone was never updated after FetchOrigin, so
 // selecting "head" silently produced worktrees rooted at the original clone SHA.
 func TestPrepareForTask_WorktreeBaseRefHead(t *testing.T) {
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	h := prepareHarness(t, nil, 30*time.Second)
 
 	// Switch the project to head mode.
@@ -788,9 +770,6 @@ func TestPrepareForTask_WorktreeBaseRefHead(t *testing.T) {
 }
 
 func TestPrepareForTask_RebaseConflictFailsClosed(t *testing.T) {
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	h := prepareHarness(t, nil, 30*time.Second)
 
 	tk, err := h.tasks.Store().Create("conflicting task", "", "headless")
@@ -838,9 +817,6 @@ func TestPrepareForTask_RebaseConflictFailsClosed(t *testing.T) {
 // PrepareForTask rejects a path-traversal slug before calling PathFor.
 // This is defense-in-depth on top of the parse-time guard in ParseBytes.
 func TestPrepareForTask_BadSlugRejected(t *testing.T) {
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	h := prepareHarness(t, nil, 30*time.Second)
 
 	badTask := task.Task{
@@ -875,9 +851,6 @@ func mustRunInDir(t *testing.T, dir, name string, args ...string) {
 // Without this, an agent would start on a broken worktree and waste tokens
 // hitting missing-tool errors.
 func TestPrepareForTask_BootstrapFailureBlocks(t *testing.T) {
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	h := prepareHarness(t, []string{"exit 42"}, 30*time.Second)
 
 	tk, err := h.tasks.Store().Create("failing bootstrap", "", "headless")

--- a/internal/worktree/notes_test.go
+++ b/internal/worktree/notes_test.go
@@ -11,9 +11,6 @@ import (
 )
 
 func TestEnsureNotesFile_SeedsAndExcludes(t *testing.T) {
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	wt := t.TempDir()
 	mustRunInDir(t, wt, "git", "init", "-b", "main")
 
@@ -39,9 +36,6 @@ func TestEnsureNotesFile_SeedsAndExcludes(t *testing.T) {
 }
 
 func TestEnsureNotesFile_PreservesExistingContent(t *testing.T) {
-	if !hasGit() {
-		t.Skip("git not available")
-	}
 	wt := t.TempDir()
 	mustRunInDir(t, wt, "git", "init", "-b", "main")
 

--- a/internal/worktree/testmain_test.go
+++ b/internal/worktree/testmain_test.go
@@ -1,0 +1,19 @@
+package worktree
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// TestMain fails the whole package immediately if git is missing, rather
+// than letting individual tests silently t.Skip — a stripped-down test
+// environment should show up as a red CI run, not quietly reduced coverage.
+func TestMain(m *testing.M) {
+	if _, err := exec.LookPath("git"); err != nil {
+		fmt.Fprintln(os.Stderr, "internal/worktree tests require git on PATH:", err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Motivation

> Changelog: test(project): fail loud instead of skipping on missing git

`internal/project`, `internal/worktree`, and `internal/sybra` had ~56
per-test `t.Skip("git not available")` guards. In every environment these
tests actually run in (dev machine, CI, the Docker runtime image), git is
present, so the guards never fire — but if an environment ever did lack
git, the suite would report green while silently dropping dozens of tests.

## Implementation information

- Removed the per-test skip guards and their `hasGit()` helpers.
- Added one `TestMain` per package (two in `internal/sybra`, for the unit
  and `e2e` build tags) that exits nonzero immediately if `git` is missing
  from `PATH`, turning a broken environment into a hard failure.
- Documented the pattern in `CLAUDE.md` so new git-dependent test packages
  follow it instead of reintroducing a local skip.

## Supporting documentation

N/A