### PR TITLE
build(docker): verify remote klaudiush installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o /bin/sybra-server ./cmd/sybra
 #   - `COPY --from=<builder>` only inside Layer F+G
 #   - HEALTHCHECK uses curl (not node -e)
 #   - Every FROM is sha256-pinned
+#   - No `curl|sh`/`curl|bash` remote-installer pipes (verify checksums instead)
 #
 # Why it matters: bumping sybra invalidates only the last COPY layers;
 # bumping a tool ARG invalidates just that tool's layer. If `apt-get
@@ -63,10 +64,30 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # --- Layer B: klaudiush binary ---
+# Downloads the release archive directly from GitHub and verifies it
+# against the release's published checksums.txt, instead of piping the
+# klaudiu.sh installer script into `sh` (an unpinned, unverified remote
+# script that could change or be compromised without any diff in this
+# repo).
 # renovate: datasource=github-releases depName=smykla-skalski/klaudiush
 ARG KLAUDIUSH_VERSION=v1.32.4
-RUN curl -sSfL https://klaudiu.sh/install.sh \
-         | sh -s -- -b /usr/local/bin -v "${KLAUDIUSH_VERSION}"
+RUN ARCH="$(dpkg --print-architecture)" \
+    && case "${ARCH}" in \
+         amd64|arm64) KLAUDIUSH_ARCH="${ARCH}" ;; \
+         *) echo "unsupported arch: ${ARCH}" >&2 && exit 1 ;; \
+       esac \
+    && VERSION_NUM="${KLAUDIUSH_VERSION#v}" \
+    && ARCHIVE="klaudiush_${VERSION_NUM}_linux_${KLAUDIUSH_ARCH}.tar.gz" \
+    && BASE_URL="https://github.com/smykla-skalski/klaudiush/releases/download/${KLAUDIUSH_VERSION}" \
+    && TMPDIR="$(mktemp -d)" \
+    && curl -sSfL -o "${TMPDIR}/${ARCHIVE}" "${BASE_URL}/${ARCHIVE}" \
+    && curl -sSfL -o "${TMPDIR}/checksums.txt" "${BASE_URL}/checksums.txt" \
+    && grep "  ${ARCHIVE}\$" "${TMPDIR}/checksums.txt" \
+       | sed "s#  ${ARCHIVE}\$#  ${TMPDIR}/${ARCHIVE}#" \
+       | sha256sum -c - \
+    && tar -xzf "${TMPDIR}/${ARCHIVE}" -C "${TMPDIR}" klaudiush \
+    && install -m 0755 "${TMPDIR}/klaudiush" /usr/local/bin/klaudiush \
+    && rm -rf "${TMPDIR}"
 
 # --- Layer C: node CLIs (claude code + codex), pinned for cache stability ---
 # renovate: datasource=npm depName=@anthropic-ai/claude-code

--- a/scripts/check-dockerfile-layers.sh
+++ b/scripts/check-dockerfile-layers.sh
@@ -107,9 +107,29 @@ awk -v dockerfile="${DOCKERFILE}" '
 # pinning or checksum verification — a changed or compromised endpoint can
 # alter the image with no diff in this repo. Require direct artifact
 # downloads verified against a checksum instead (see Layer B, Layer D).
+#
+# RUN instructions commonly split a pipeline across backslash-continuation
+# lines, so join continued lines into one logical line (tagged with the
+# starting line number) before matching — a line-at-a-time grep misses
+# `curl ... \` / `| \` / `sh` split across three lines.
+installer_pipe_re='\|[[:space:]]*(sudo[[:space:]]+)?(/usr/bin/env[[:space:]]+)?(/bin/)?(sh|bash)([[:space:]]+-s)?([[:space:]]|$)'
 while IFS=: read -r lineno content; do
   err "unverified remote installer pipe (curl|sh / curl|bash) at line ${lineno}: ${content}"
-done < <(grep -nE '\|[[:space:]]*(sudo[[:space:]]+)?(sh|bash)([[:space:]]|$)' "${DOCKERFILE}" || true)
+done < <(
+  awk '
+    {
+      line = $0
+      cont = (line ~ /\\[[:space:]]*$/)
+      gsub(/\\[[:space:]]*$/, "", line)
+      if (buf == "") { start = NR }
+      buf = (buf == "" ? line : buf " " line)
+      if (!cont) {
+        print start ":" buf
+        buf = ""
+      }
+    }
+  ' "${DOCKERFILE}" | grep -E "${installer_pipe_re}" || true
+)
 
 # --- 5. Healthcheck uses curl, not node ----------------------------------
 # Node-based healthchecks are fragile: they depend on the node runtime

--- a/scripts/check-dockerfile-layers.sh
+++ b/scripts/check-dockerfile-layers.sh
@@ -102,7 +102,16 @@ awk -v dockerfile="${DOCKERFILE}" '
   END { exit bad ? 1 : 0 }
 ' "${DOCKERFILE}" || fail=1
 
-# --- 4. Healthcheck uses curl, not node ----------------------------------
+# --- 4. No unverified remote installer pipes ------------------------------
+# `curl ... | sh` (or `| bash`) executes a mutable remote script with no
+# pinning or checksum verification — a changed or compromised endpoint can
+# alter the image with no diff in this repo. Require direct artifact
+# downloads verified against a checksum instead (see Layer B, Layer D).
+while IFS=: read -r lineno content; do
+  err "unverified remote installer pipe (curl|sh / curl|bash) at line ${lineno}: ${content}"
+done < <(grep -nE '\|[[:space:]]*(sudo[[:space:]]+)?(sh|bash)([[:space:]]|$)' "${DOCKERFILE}" || true)
+
+# --- 5. Healthcheck uses curl, not node ----------------------------------
 # Node-based healthchecks are fragile: they depend on the node runtime
 # being on PATH inside the runtime stage. curl is installed in Layer A
 # and is the portable choice. HEALTHCHECK spans line-continuations, so

--- a/scripts/check-dockerfile-layers.sh
+++ b/scripts/check-dockerfile-layers.sh
@@ -111,12 +111,14 @@ awk -v dockerfile="${DOCKERFILE}" '
 # RUN instructions commonly split a pipeline across backslash-continuation
 # lines, so join continued lines into one logical line (tagged with the
 # starting line number) before matching — a line-at-a-time grep misses
-# `curl ... \` / `| \` / `sh` split across three lines.
-installer_pipe_re='\|[[:space:]]*(sudo[[:space:]]+)?(/usr/bin/env[[:space:]]+)?(/bin/)?(sh|bash)([[:space:]]+-s)?([[:space:]]|$)'
+# `curl ... \` / `| \` / `sh` split across three lines. Limit the match to
+# RUN instructions where curl/wget appears before the pipe, so unrelated
+# `| sh` pipelines and comments do not trigger this rule.
+installer_pipe_re='\\|[[:space:]]*(sudo[[:space:]]+)?(/usr/bin/env[[:space:]]+)?(/bin/)?(sh|bash)([[:space:]]+-s)?([[:space:]]|$)'
 while IFS=: read -r lineno content; do
   err "unverified remote installer pipe (curl|sh / curl|bash) at line ${lineno}: ${content}"
 done < <(
-  awk '
+  awk -v installer_pipe_re="${installer_pipe_re}" '
     {
       line = $0
       cont = (line ~ /\\[[:space:]]*$/)
@@ -124,11 +126,17 @@ done < <(
       if (buf == "") { start = NR }
       buf = (buf == "" ? line : buf " " line)
       if (!cont) {
-        print start ":" buf
+        if (buf ~ /^[[:space:]]*RUN([[:space:]]|\\)/ && buf ~ installer_pipe_re) {
+          pipe_start = match(buf, installer_pipe_re)
+          prefix = substr(buf, 1, pipe_start - 1)
+          if (prefix ~ /(^|[[:space:](&;])(curl|wget)([[:space:]]|$)/) {
+            print start ":" buf
+          }
+        }
         buf = ""
       }
     }
-  ' "${DOCKERFILE}" | grep -E "${installer_pipe_re}" || true
+  ' "${DOCKERFILE}" || true
 )
 
 # --- 5. Healthcheck uses curl, not node ----------------------------------


### PR DESCRIPTION
## Motivation

The Dockerfile installed klaudiush by piping `klaudiu.sh/install.sh` into `sh` — an unpinned, unverified remote script. A compromised or changed installer endpoint could alter the image with no diff visible in this repo.

Closes https://github.com/Automaat/sybra/issues/1396

## Implementation information

- Replace the `curl | sh` install with a direct download of the pinned release archive (`klaudiush_<version>_linux_<arch>.tar.gz`) from GitHub releases, verified against the release's published `checksums.txt` via `sha256sum -c`.
- Extend `scripts/check-dockerfile-layers.sh` with a new layer check forbidding any `curl|sh` / `curl|bash` remote-installer pipe pattern in the Dockerfile.
- The pipe-detection check joins backslash-continuation lines into one logical line before matching, so a pipe split across multiple `RUN` lines is still caught.

_Generated by Sybra harness_