### PR TITLE
fix(workflow): close system-role dispatch race

### DIFF
--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -408,6 +408,11 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 
 	// For system agents (triage, eval, plan, etc.), build RunConfig directly.
 	r := agent.Role(role)
+	if err := a.claimSystemAgentDispatch(taskID); err != nil {
+		return "", "", "", err
+	}
+	defer a.agents.ReleaseTaskDispatch(taskID)
+
 	t, err := a.agentOrch.tasks.Get(taskID)
 	if err != nil {
 		return "", "", "", err
@@ -512,6 +517,18 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 	a.recordSystemAgentStart(taskID, role, mode, cfg, ag)
 
 	return ag.ID, cfg.Dir, baselineRef, nil
+}
+
+// claimSystemAgentDispatch serializes system-role (triage, eval, plan, ...)
+// agent dispatch per task, closing the same check-then-act race that
+// StartAgentWithAssignment closes for implementation agents above: without
+// it, two dispatchers (e.g. a fast ResumeStalled retry) can each observe no
+// running agent and start a duplicate agent against the same task/worktree.
+func (a *agentAdapter) claimSystemAgentDispatch(taskID string) error {
+	if !a.agents.ClaimTaskDispatch(taskID) {
+		return workflow.ErrDispatchInFlight
+	}
+	return nil
 }
 
 func (a *agentAdapter) resetWorktreeForRetry(t task.Task, dir, ref string) error {

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -406,9 +406,10 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		return ag.ID, "", baselineRef, nil
 	}
 
-	// For system agents (triage, eval, plan, etc.), build RunConfig directly.
+	// For roles that don't go through StartAgentWithAssignment (triage, eval,
+	// plan, pr-fix, fix-review, test-runner, ...), build RunConfig directly.
 	r := agent.Role(role)
-	if err := a.claimSystemAgentDispatch(taskID); err != nil {
+	if err := a.claimDirectDispatch(taskID); err != nil {
 		return "", "", "", err
 	}
 	defer a.agents.ReleaseTaskDispatch(taskID)
@@ -519,12 +520,14 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 	return ag.ID, cfg.Dir, baselineRef, nil
 }
 
-// claimSystemAgentDispatch serializes system-role (triage, eval, plan, ...)
-// agent dispatch per task, closing the same check-then-act race that
-// StartAgentWithAssignment closes for implementation agents above: without
-// it, two dispatchers (e.g. a fast ResumeStalled retry) can each observe no
-// running agent and start a duplicate agent against the same task/worktree.
-func (a *agentAdapter) claimSystemAgentDispatch(taskID string) error {
+// claimDirectDispatch serializes the direct-run dispatch path (every role
+// that bypasses StartAgentWithAssignment: triage, eval, plan, pr-fix,
+// fix-review, test-runner, ...) per task, closing the same check-then-act
+// race that StartAgentWithAssignment closes for implementation agents above:
+// without it, two dispatchers (e.g. a fast ResumeStalled retry) can each
+// observe no running agent and start a duplicate agent against the same
+// task/worktree.
+func (a *agentAdapter) claimDirectDispatch(taskID string) error {
 	if !a.agents.ClaimTaskDispatch(taskID) {
 		return workflow.ErrDispatchInFlight
 	}

--- a/internal/sybra/app_workflow_test.go
+++ b/internal/sybra/app_workflow_test.go
@@ -1,6 +1,7 @@
 package sybra
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/Automaat/sybra/internal/experience"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/workflow"
 	"github.com/Automaat/sybra/internal/worktree"
 )
 
@@ -185,5 +187,35 @@ manual_test:
 	got := getter.ManualTestConfig(created.ID)
 	if got.Kind != "cli" || got.Command != "sybra-cli --json list" {
 		t.Fatalf("ManualTestConfig = %+v, want project-level cli config", got)
+	}
+}
+
+// TestAgentAdapterStartAgentSystemRoleHonorsDispatchClaim guards against the
+// dispatch-claim race (sybra#1406): a second dispatcher for the same task
+// (e.g. a fast ResumeStalled retry) must be turned away with
+// ErrDispatchInFlight rather than racing a system-role (plan/eval/triage)
+// agent start against an in-flight one. Simulates the race directly by
+// pre-holding the claim the way a concurrent dispatcher would, instead of
+// spawning real concurrent goroutines against a live provider.
+func TestAgentAdapterStartAgentSystemRoleHonorsDispatchClaim(t *testing.T) {
+	a := setupApp(t)
+	created, err := a.tasks.Create("plan race guard", "body", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aa := &agentAdapter{agents: a.agents, agentOrch: a.agentOrch, tasks: a.tasks}
+
+	if !a.agents.ClaimTaskDispatch(created.ID) {
+		t.Fatal("failed to seed dispatch claim")
+	}
+	defer a.agents.ReleaseTaskDispatch(created.ID)
+
+	agentID, _, _, err := aa.StartAgent(created.ID, string(agent.RolePlan), "headless", "sonnet", "claude", "prompt", "", nil, false, false, "", "", workflow.AgentAssignment{})
+	if !errors.Is(err, workflow.ErrDispatchInFlight) {
+		t.Fatalf("StartAgent() err = %v, want ErrDispatchInFlight", err)
+	}
+	if agentID != "" {
+		t.Fatalf("StartAgent() agentID = %q, want empty on dispatch-in-flight", agentID)
 	}
 }


### PR DESCRIPTION
## Motivation

`agentAdapter.StartAgent` only acquired the per-task dispatch claim on the implementation-agent path (via `StartAgentWithAssignment`). The system-role path (plan, eval, triage, ...) built `RunConfig` and called `agents.Run` directly, skipping the claim. Two concurrent dispatchers — e.g. a fast `ResumeStalled` retry racing the original dispatch — could both pass the check and start duplicate agents against the same task/worktree.

## Implementation information

- `claimSystemAgentDispatch` now guards the system-role branch of `StartAgent`, acquiring `ClaimTaskDispatch` before building `RunConfig` and releasing it via `defer` after the run starts.
- Returns `workflow.ErrDispatchInFlight` when a claim is already held, matching the existing implementation-agent path's behavior.
- Added `TestAgentAdapterStartAgentSystemRoleHonorsDispatchClaim` to guard the race: pre-seeds the dispatch claim the way a concurrent dispatcher would, then asserts a second `StartAgent` call for a system role is turned away.

Closes https://github.com/Automaat/sybra/issues/1406

_Generated by Sybra harness_