### PR TITLE
test(test): replace sleep-based waits with polling

### DIFF
--- a/internal/agent/approval_server_test.go
+++ b/internal/agent/approval_server_test.go
@@ -168,15 +168,15 @@ func TestApprovalServer_CanceledContext(t *testing.T) {
 
 	// Cancel once the handler has registered the pending approval (i.e. is
 	// actually blocked waiting), instead of guessing a sleep duration.
+	registered := make(chan bool, 1)
 	go func() {
-		if !pollUntil(2*time.Second, time.Millisecond, func() bool {
+		ok := pollUntil(2*time.Second, time.Millisecond, func() bool {
 			srv.mu.Lock()
 			defer srv.mu.Unlock()
 			_, ok := srv.pending["tuid-cancel"]
 			return ok
-		}) {
-			t.Errorf("pending approval %q was not registered before cancellation", "tuid-cancel")
-		}
+		})
+		registered <- ok
 		cancel()
 	}()
 
@@ -191,6 +191,10 @@ func TestApprovalServer_CanceledContext(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("handler blocked after context cancellation")
+	}
+
+	if !<-registered {
+		t.Errorf("pending approval %q was not registered before cancellation", "tuid-cancel")
 	}
 
 	var out hookResponse
@@ -237,16 +241,18 @@ func TestApprovalServer_ApprovalFlow_Approve(t *testing.T) {
 
 	// Respond approve once the pending item is actually registered, instead
 	// of guessing how long registration takes.
+	registered := make(chan bool, 1)
 	go func() {
-		if !pollUntil(2*time.Second, time.Millisecond, func() bool {
+		ok := pollUntil(2*time.Second, time.Millisecond, func() bool {
 			srv.mu.Lock()
 			defer srv.mu.Unlock()
 			_, ok := srv.pending["tuid-approve"]
 			return ok
-		}) {
-			t.Errorf("pending approval %q was not registered before approving", "tuid-approve")
+		})
+		if ok {
+			_ = srv.RespondApproval("tuid-approve", true)
 		}
-		_ = srv.RespondApproval("tuid-approve", true)
+		registered <- ok
 	}()
 
 	resp := postHook(t, srv.Addr(), map[string]any{
@@ -255,6 +261,10 @@ func TestApprovalServer_ApprovalFlow_Approve(t *testing.T) {
 		"tool_use_id": "tuid-approve",
 		"tool_input":  map[string]any{"command": "echo hi"},
 	})
+
+	if !<-registered {
+		t.Errorf("pending approval %q was not registered before approving", "tuid-approve")
+	}
 	if resp.HookSpecificOutput.PermissionDecision != "allow" {
 		t.Errorf("expected allow after approve, got %q", resp.HookSpecificOutput.PermissionDecision)
 	}
@@ -281,16 +291,18 @@ func TestApprovalServer_ApprovalFlow_Deny(t *testing.T) {
 	srv.SetManager(mgr)
 	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
 
+	registered := make(chan bool, 1)
 	go func() {
-		if !pollUntil(2*time.Second, time.Millisecond, func() bool {
+		ok := pollUntil(2*time.Second, time.Millisecond, func() bool {
 			srv.mu.Lock()
 			defer srv.mu.Unlock()
 			_, ok := srv.pending["tuid-deny"]
 			return ok
-		}) {
-			t.Errorf("pending approval %q was not registered before denying", "tuid-deny")
+		})
+		if ok {
+			_ = srv.RespondApproval("tuid-deny", false)
 		}
-		_ = srv.RespondApproval("tuid-deny", false)
+		registered <- ok
 	}()
 
 	resp := postHook(t, srv.Addr(), map[string]any{
@@ -299,6 +311,10 @@ func TestApprovalServer_ApprovalFlow_Deny(t *testing.T) {
 		"tool_use_id": "tuid-deny",
 		"tool_input":  map[string]any{"file_path": "/tmp/x"},
 	})
+
+	if !<-registered {
+		t.Errorf("pending approval %q was not registered before denying", "tuid-deny")
+	}
 	if resp.HookSpecificOutput.PermissionDecision != "deny" {
 		t.Errorf("expected deny, got %q", resp.HookSpecificOutput.PermissionDecision)
 	}

--- a/internal/agent/approval_server_test.go
+++ b/internal/agent/approval_server_test.go
@@ -166,9 +166,15 @@ func TestApprovalServer_CanceledContext(t *testing.T) {
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	// Cancel context shortly after handler starts waiting for approval.
+	// Cancel once the handler has registered the pending approval (i.e. is
+	// actually blocked waiting), instead of guessing a sleep duration.
 	go func() {
-		time.Sleep(50 * time.Millisecond)
+		pollUntil(2*time.Second, time.Millisecond, func() bool {
+			srv.mu.Lock()
+			defer srv.mu.Unlock()
+			_, ok := srv.pending["tuid-cancel"]
+			return ok
+		})
 		cancel()
 	}()
 
@@ -227,9 +233,15 @@ func TestApprovalServer_ApprovalFlow_Approve(t *testing.T) {
 	srv.SetManager(mgr)
 	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
 
-	// Respond approve concurrently after the pending item is registered.
+	// Respond approve once the pending item is actually registered, instead
+	// of guessing how long registration takes.
 	go func() {
-		time.Sleep(100 * time.Millisecond)
+		pollUntil(2*time.Second, time.Millisecond, func() bool {
+			srv.mu.Lock()
+			defer srv.mu.Unlock()
+			_, ok := srv.pending["tuid-approve"]
+			return ok
+		})
 		_ = srv.RespondApproval("tuid-approve", true)
 	}()
 
@@ -266,7 +278,12 @@ func TestApprovalServer_ApprovalFlow_Deny(t *testing.T) {
 	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
 
 	go func() {
-		time.Sleep(100 * time.Millisecond)
+		pollUntil(2*time.Second, time.Millisecond, func() bool {
+			srv.mu.Lock()
+			defer srv.mu.Unlock()
+			_, ok := srv.pending["tuid-deny"]
+			return ok
+		})
 		_ = srv.RespondApproval("tuid-deny", false)
 	}()
 

--- a/internal/agent/approval_server_test.go
+++ b/internal/agent/approval_server_test.go
@@ -169,12 +169,14 @@ func TestApprovalServer_CanceledContext(t *testing.T) {
 	// Cancel once the handler has registered the pending approval (i.e. is
 	// actually blocked waiting), instead of guessing a sleep duration.
 	go func() {
-		pollUntil(2*time.Second, time.Millisecond, func() bool {
+		if !pollUntil(2*time.Second, time.Millisecond, func() bool {
 			srv.mu.Lock()
 			defer srv.mu.Unlock()
 			_, ok := srv.pending["tuid-cancel"]
 			return ok
-		})
+		}) {
+			t.Errorf("pending approval %q was not registered before cancellation", "tuid-cancel")
+		}
 		cancel()
 	}()
 
@@ -236,12 +238,14 @@ func TestApprovalServer_ApprovalFlow_Approve(t *testing.T) {
 	// Respond approve once the pending item is actually registered, instead
 	// of guessing how long registration takes.
 	go func() {
-		pollUntil(2*time.Second, time.Millisecond, func() bool {
+		if !pollUntil(2*time.Second, time.Millisecond, func() bool {
 			srv.mu.Lock()
 			defer srv.mu.Unlock()
 			_, ok := srv.pending["tuid-approve"]
 			return ok
-		})
+		}) {
+			t.Errorf("pending approval %q was not registered before approving", "tuid-approve")
+		}
 		_ = srv.RespondApproval("tuid-approve", true)
 	}()
 
@@ -278,12 +282,14 @@ func TestApprovalServer_ApprovalFlow_Deny(t *testing.T) {
 	t.Cleanup(func() { _ = srv.Shutdown(context.Background()) })
 
 	go func() {
-		pollUntil(2*time.Second, time.Millisecond, func() bool {
+		if !pollUntil(2*time.Second, time.Millisecond, func() bool {
 			srv.mu.Lock()
 			defer srv.mu.Unlock()
 			_, ok := srv.pending["tuid-deny"]
 			return ok
-		})
+		}) {
+			t.Errorf("pending approval %q was not registered before denying", "tuid-deny")
+		}
 		_ = srv.RespondApproval("tuid-deny", false)
 	}()
 

--- a/internal/agent/manager_test_helpers_test.go
+++ b/internal/agent/manager_test_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"testing"
+	"time"
 )
 
 func mustNewManager(tb testing.TB, ctx context.Context, emit EmitFunc, logger *slog.Logger, logDir string, cfgs ...ManagerConfig) *Manager {
@@ -17,4 +18,22 @@ func mustNewManager(tb testing.TB, ctx context.Context, emit EmitFunc, logger *s
 		tb.Fatalf("NewManager: %v", err)
 	}
 	return m
+}
+
+// pollUntil polls cond every interval until it returns true or timeout
+// elapses, returning whether cond was observed true. Use in place of a fixed
+// time.Sleep before an action that depends on background state becoming
+// ready — it succeeds as soon as the condition holds instead of waiting out
+// a worst-case guess, and still bounds the wait on a slow/failing run.
+func pollUntil(timeout, interval time.Duration, cond func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if cond() {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(interval)
+	}
 }

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -583,9 +583,11 @@ func TestStreamHeadlessOutput_ContextCancelReturns(t *testing.T) {
 
 	// Wait until the reader has actually consumed the first line, instead of
 	// guessing how long that takes.
-	pollUntil(2*time.Second, time.Millisecond, func() bool {
+	if !pollUntil(2*time.Second, time.Millisecond, func() bool {
 		return len(a.Output()) >= 1
-	})
+	}) {
+		t.Error("stream never recorded the first event before cancellation")
+	}
 	cancel()
 	// Closing the writer is what actually unblocks bufio.Scanner — this is
 	// the same effect as the subprocess dying after ctx cancel propagates.
@@ -763,11 +765,13 @@ func TestGuardrails_TurnsBlocks_CostNearCap(t *testing.T) {
 	a := &Agent{ID: "t", Provider: "claude", escalationCh: make(chan bool, 1)}
 	go func() {
 		// Wait until the escalation has actually been raised, then cancel.
-		pollUntil(2*time.Second, time.Millisecond, func() bool {
+		if !pollUntil(2*time.Second, time.Millisecond, func() bool {
 			mu.Lock()
 			defer mu.Unlock()
 			return blocked > 0
-		})
+		}) {
+			t.Error("turns escalation was never raised before cancellation")
+		}
 		cancel()
 	}()
 	m.streamHeadlessOutput(ctx, a, bytes.NewReader([]byte(input)), nil)

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -581,8 +581,11 @@ func TestStreamHeadlessOutput_ContextCancelReturns(t *testing.T) {
 		close(done)
 	}()
 
-	// Give the reader time to consume the first line.
-	time.Sleep(100 * time.Millisecond)
+	// Wait until the reader has actually consumed the first line, instead of
+	// guessing how long that takes.
+	pollUntil(2*time.Second, time.Millisecond, func() bool {
+		return len(a.Output()) >= 1
+	})
 	cancel()
 	// Closing the writer is what actually unblocks bufio.Scanner — this is
 	// the same effect as the subprocess dying after ctx cancel propagates.
@@ -759,8 +762,12 @@ func TestGuardrails_TurnsBlocks_CostNearCap(t *testing.T) {
 	// exits cleanly without hanging the test.
 	a := &Agent{ID: "t", Provider: "claude", escalationCh: make(chan bool, 1)}
 	go func() {
-		// Wait briefly for the escalation to be raised, then cancel.
-		time.Sleep(50 * time.Millisecond)
+		// Wait until the escalation has actually been raised, then cancel.
+		pollUntil(2*time.Second, time.Millisecond, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return blocked > 0
+		})
 		cancel()
 	}()
 	m.streamHeadlessOutput(ctx, a, bytes.NewReader([]byte(input)), nil)

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -763,18 +763,21 @@ func TestGuardrails_TurnsBlocks_CostNearCap(t *testing.T) {
 	// Respond to the escalation immediately: send false (kill) so the stream
 	// exits cleanly without hanging the test.
 	a := &Agent{ID: "t", Provider: "claude", escalationCh: make(chan bool, 1)}
+	raised := make(chan bool, 1)
 	go func() {
 		// Wait until the escalation has actually been raised, then cancel.
-		if !pollUntil(2*time.Second, time.Millisecond, func() bool {
+		raised <- pollUntil(2*time.Second, time.Millisecond, func() bool {
 			mu.Lock()
 			defer mu.Unlock()
 			return blocked > 0
-		}) {
-			t.Error("turns escalation was never raised before cancellation")
-		}
+		})
 		cancel()
 	}()
 	m.streamHeadlessOutput(ctx, a, bytes.NewReader([]byte(input)), nil)
+
+	if !<-raised {
+		t.Error("turns escalation was never raised before cancellation")
+	}
 
 	mu.Lock()
 	defer mu.Unlock()

--- a/internal/confighot/watcher_test.go
+++ b/internal/confighot/watcher_test.go
@@ -76,7 +76,10 @@ func TestWatcher_BurstCoalescesToOne(t *testing.T) {
 	}
 
 	waitForCount(t, &calls, 1, 3*time.Second)
-	// Pause to ensure no extra calls arrive
+	// Absence check: confirm no further debounced call arrives once the
+	// real 500ms debounce window has elapsed. There is no event to poll for
+	// here — the real-time window itself is the behavior under test — so a
+	// bounded sleep past it is the correct wait, not a guess.
 	time.Sleep(700 * time.Millisecond)
 	if got := calls.Load(); got != 1 {
 		t.Errorf("burst produced %d calls, want 1", got)
@@ -134,7 +137,8 @@ func TestWatcher_DeleteIgnored(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Wait long enough to see if any spurious call comes through
+	// Absence check bound by the real 500ms debounce window — see comment in
+	// TestWatcher_BurstCoalescesToOne.
 	time.Sleep(700 * time.Millisecond)
 	if got := calls.Load(); got != 0 {
 		t.Errorf("delete triggered %d calls, want 0", got)
@@ -162,6 +166,8 @@ func TestWatcher_SiblingFileIgnored(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Absence check bound by the real 500ms debounce window — see comment in
+	// TestWatcher_BurstCoalescesToOne.
 	time.Sleep(700 * time.Millisecond)
 	if got := calls.Load(); got != 0 {
 		t.Errorf("sibling write triggered %d calls, want 0", got)

--- a/internal/sybra/e2e_workflow_test.go
+++ b/internal/sybra/e2e_workflow_test.go
@@ -3305,8 +3305,10 @@ func TestE2E_WaitForStatus_MismatchDoesNotAdvance(t *testing.T) {
 		return gErr == nil && tk.Workflow != nil && tk.Workflow.CurrentStep == "plan_wait" && tk.Workflow.State == workflow.ExecWaiting
 	})
 
+	// HandleStatusChange returns synchronously on a mismatched status (it
+	// bails out before scheduling any async work), so the workflow state can
+	// be asserted immediately with no wait.
 	env.engine.HandleStatusChange(created.ID, "in-progress")
-	time.Sleep(250 * time.Millisecond)
 
 	tk, err := env.tasks.Get(created.ID)
 	if err != nil {
@@ -3345,8 +3347,9 @@ func TestE2E_WaitForStatus_ExactAdvancesOnce(t *testing.T) {
 		t.Fatal(err)
 	}
 	recordsBefore := len(tk.Workflow.StepHistory)
+	// The workflow is already terminal, so HandleStatusChange bails out
+	// synchronously without scheduling any async work — no wait needed.
 	env.engine.HandleStatusChange(created.ID, "plan-review")
-	time.Sleep(150 * time.Millisecond)
 	tkAfter, _ := env.tasks.Get(created.ID)
 	if len(tkAfter.Workflow.StepHistory) != recordsBefore {
 		t.Fatalf("duplicate advancement on repeated status: before=%d after=%d", recordsBefore, len(tkAfter.Workflow.StepHistory))
@@ -4577,7 +4580,7 @@ func TestE2E_RateLimitCooldownWindowCorrectness(t *testing.T) {
 	}
 	waitFor(t, 10*time.Second, "cooldown run1 stops", func() bool { return ag1.GetState() == agent.StateStopped })
 
-	time.Sleep(250 * time.Millisecond)
+	waitFor(t, 2*time.Second, "cooldown window elapses", func() bool { return g.IsHealthy("claude") })
 	ag2, err := env.agents.Run(agent.RunConfig{
 		TaskID:   "cooldown-2",
 		Name:     "cooldown 2",
@@ -5045,8 +5048,9 @@ func TestE2E_StatusChange_AfterTerminal_NoMutation(t *testing.T) {
 
 	tk, _ := env.tasks.Get(created.ID)
 	historyBefore := len(tk.Workflow.StepHistory)
+	// The workflow is already terminal, so HandleStatusChange bails out
+	// synchronously without scheduling any async work — no wait needed.
 	env.engine.HandleStatusChange(created.ID, "plan-review")
-	time.Sleep(150 * time.Millisecond)
 	after, _ := env.tasks.Get(created.ID)
 	if len(after.Workflow.StepHistory) != historyBefore {
 		t.Fatalf("terminal status change mutated history: before=%d after=%d", historyBefore, len(after.Workflow.StepHistory))

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -310,7 +310,9 @@ func TestDebounceDoesNotDropTrailingWrite(t *testing.T) {
 		}
 		return n
 	}
-	pollUntil(500*time.Millisecond, 10*time.Millisecond, func() bool { return afterSecondCount() > 0 })
+	if !pollUntil(500*time.Millisecond, 10*time.Millisecond, func() bool { return afterSecondCount() > 0 }) {
+		t.Errorf("timed out waiting for an event after the trailing write at %v", secondWriteAt)
+	}
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -379,11 +381,13 @@ func TestAtomicRenameOverExistingEmitsUpdate(t *testing.T) {
 
 	// Poll for the emission instead of blindly sleeping past the 200ms
 	// debounce window; 500ms remains the worst-case bound.
-	pollUntil(500*time.Millisecond, 10*time.Millisecond, func() bool {
+	if !pollUntil(500*time.Millisecond, 10*time.Millisecond, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
 		return len(seen) > 0
-	})
+	}) {
+		t.Errorf("timed out waiting for an event after atomic rename")
+	}
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -488,11 +492,13 @@ func TestDebounceIsolatesPerFile(t *testing.T) {
 
 	// Poll for both files' events instead of blindly sleeping past the
 	// debounce window; 500ms remains the worst-case bound.
-	pollUntil(500*time.Millisecond, 10*time.Millisecond, func() bool {
+	if !pollUntil(500*time.Millisecond, 10*time.Millisecond, func() bool {
 		mu.Lock()
 		defer mu.Unlock()
 		return counts["a.md"] >= 1 && counts["b.md"] >= 1
-	})
+	}) {
+		t.Errorf("timed out waiting for events on both a.md and b.md")
+	}
 
 	mu.Lock()
 	defer mu.Unlock()

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -26,6 +26,23 @@ func waitReady(t *testing.T, w *Watcher) {
 	}
 }
 
+// pollUntil polls cond every interval until it returns true or timeout
+// elapses, returning whether cond was observed true. Used in place of a
+// fixed time.Sleep before checking async/debounced state — it returns as
+// soon as the condition holds instead of waiting out a worst-case guess.
+func pollUntil(timeout, interval time.Duration, cond func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if cond() {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(interval)
+	}
+}
+
 func TestNew(t *testing.T) {
 	w := New("/tmp/test", func(string, any) {}, discardLogger())
 	if w == nil {
@@ -279,10 +296,21 @@ func TestDebounceDoesNotDropTrailingWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Allow plenty of time for any deferred emission. 500ms is well past
-	// the 200ms debounce window so a correctly-implemented trailing-edge
-	// debounce would have fired by now.
-	time.Sleep(500 * time.Millisecond)
+	// Poll for the deferred emission instead of blindly sleeping past the
+	// 200ms debounce window; 500ms remains the worst-case bound for a
+	// correctly-implemented trailing-edge debounce to fire.
+	afterSecondCount := func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		var n int
+		for _, ts := range events {
+			if ts.After(secondWriteAt) {
+				n++
+			}
+		}
+		return n
+	}
+	pollUntil(500*time.Millisecond, 10*time.Millisecond, func() bool { return afterSecondCount() > 0 })
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -349,8 +377,13 @@ func TestAtomicRenameOverExistingEmitsUpdate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Wait well past the 200ms debounce window for any emission to flush.
-	time.Sleep(500 * time.Millisecond)
+	// Poll for the emission instead of blindly sleeping past the 200ms
+	// debounce window; 500ms remains the worst-case bound.
+	pollUntil(500*time.Millisecond, 10*time.Millisecond, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(seen) > 0
+	})
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -394,16 +427,19 @@ func TestWatcherNoGoroutineLeakOnCancel(t *testing.T) {
 		}
 	}
 
-	// Let the runtime settle — goroutine exit is observed lazily.
-	runtime.GC()
-	runtime.Gosched()
-	time.Sleep(100 * time.Millisecond)
-
-	endCount := runtime.NumGoroutine()
-	// Allow a small slack for unrelated runtime goroutines (GC workers, etc.)
-	// that may come and go, but 20 leaked loop goroutines would blow past this.
+	// Poll for the runtime to settle — goroutine exit is observed lazily, so
+	// a single fixed-delay sample can flake under load. Allow a small slack
+	// for unrelated runtime goroutines (GC workers, etc.) that may come and
+	// go, but 20 leaked loop goroutines would blow past this.
 	const slack = 5
-	if endCount-startCount > slack {
+	var endCount int
+	settled := pollUntil(2*time.Second, 50*time.Millisecond, func() bool {
+		runtime.GC()
+		runtime.Gosched()
+		endCount = runtime.NumGoroutine()
+		return endCount-startCount <= slack
+	})
+	if !settled {
 		t.Errorf("goroutine leak: start=%d end=%d diff=%d (>%d slack)", startCount, endCount, endCount-startCount, slack)
 	}
 }
@@ -450,8 +486,13 @@ func TestDebounceIsolatesPerFile(t *testing.T) {
 		}
 	}
 
-	// Wait well past the debounce window.
-	time.Sleep(500 * time.Millisecond)
+	// Poll for both files' events instead of blindly sleeping past the
+	// debounce window; 500ms remains the worst-case bound.
+	pollUntil(500*time.Millisecond, 10*time.Millisecond, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return counts["a.md"] >= 1 && counts["b.md"] >= 1
+	})
 
 	mu.Lock()
 	defer mu.Unlock()


### PR DESCRIPTION
## Motivation

Sleep-based waits in tests are slow and flaky — a fixed `time.Sleep` either
under-waits (intermittent failures under load) or over-waits (wasted CI time).
Replacing them with condition polling makes these tests both faster and more
reliable.

## Implementation information

Replaced `time.Sleep`-based synchronization with polling loops across:
- `internal/agent/approval_server_test.go`
- `internal/agent/manager_test_helpers_test.go`
- `internal/agent/runner_headless_test.go`
- `internal/confighot/watcher_test.go`
- `internal/sybra/e2e_workflow_test.go`
- `internal/watcher/watcher_test.go`

Also addresses review feedback from the initial pass.

Closes https://github.com/Automaat/sybra/issues/855

_Generated by Sybra harness_