### PR TITLE
test(bgop): cover persisted operation state

### DIFF
--- a/internal/bgop/tracker.go
+++ b/internal/bgop/tracker.go
@@ -124,7 +124,7 @@ func (t *Tracker) List() []Operation {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	cutoff := time.Now().Add(-completionTTL)
-	var out []Operation
+	out := make([]Operation, 0, len(t.ops))
 	for _, op := range t.ops {
 		if op.Status != StatusRunning && op.CompletedAt.Before(cutoff) {
 			continue

--- a/internal/bgop/tracker.go
+++ b/internal/bgop/tracker.go
@@ -2,11 +2,14 @@ package bgop
 
 import (
 	"encoding/json"
+	"errors"
+	"log/slog"
 	"os"
 	"sync"
 	"time"
 
 	"github.com/Automaat/sybra/internal/events"
+	"github.com/Automaat/sybra/internal/fsutil"
 	"github.com/google/uuid"
 )
 
@@ -20,14 +23,20 @@ type Tracker struct {
 	ops      map[string]*Operation
 	emit     func(string, any)
 	diskPath string
+	logger   *slog.Logger
 }
 
 // NewTracker creates a Tracker that broadcasts events via emit and persists to diskPath.
-func NewTracker(emit func(string, any), diskPath string) *Tracker {
+// A nil logger falls back to slog.Default().
+func NewTracker(emit func(string, any), diskPath string, logger *slog.Logger) *Tracker {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	return &Tracker{
 		ops:      make(map[string]*Operation),
 		emit:     emit,
 		diskPath: diskPath,
+		logger:   logger,
 	}
 }
 
@@ -53,7 +62,10 @@ func (t *Tracker) Start(opType Type, label, projectID, taskID string) string {
 	return id
 }
 
-// UpdatePhase updates the current phase text of a running operation.
+// UpdatePhase updates the current phase text of a running operation. Phase is
+// in-memory/event-only — it is not persisted to disk, so a restart loses the
+// last phase text but keeps the operation's lifecycle status (see Start,
+// Complete, Fail).
 func (t *Tracker) UpdatePhase(id, phase string) {
 	t.mu.Lock()
 	op, ok := t.ops[id]
@@ -128,10 +140,14 @@ func (t *Tracker) List() []Operation {
 func (t *Tracker) LoadFromDisk() {
 	data, err := os.ReadFile(t.diskPath)
 	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			t.logger.Error("bgop.load.read", "path", t.diskPath, "err", err)
+		}
 		return
 	}
 	var ops []Operation
 	if err := json.Unmarshal(data, &ops); err != nil {
+		t.logger.Error("bgop.load.unmarshal", "path", t.diskPath, "err", err)
 		return
 	}
 	cutoff := time.Now().Add(-completionTTL)
@@ -162,7 +178,10 @@ func (t *Tracker) saveToDisk() {
 
 	data, err := json.MarshalIndent(ops, "", "  ")
 	if err != nil {
+		t.logger.Error("bgop.save.marshal", "path", t.diskPath, "err", err)
 		return
 	}
-	_ = os.WriteFile(t.diskPath, data, 0o644)
+	if err := fsutil.AtomicWrite(t.diskPath, data); err != nil {
+		t.logger.Error("bgop.save.write", "path", t.diskPath, "err", err)
+	}
 }

--- a/internal/bgop/tracker.go
+++ b/internal/bgop/tracker.go
@@ -151,30 +151,46 @@ func (t *Tracker) LoadFromDisk() {
 		return
 	}
 	cutoff := time.Now().Add(-completionTTL)
+	now := time.Now().UTC()
+	changed := false
 	t.mu.Lock()
 	for i := range ops {
 		op := ops[i]
 		if op.Status != StatusRunning && op.CompletedAt.Before(cutoff) {
+			changed = true
 			continue
 		}
 		// Running ops at shutdown are now stale — mark failed.
 		if op.Status == StatusRunning {
 			op.Status = StatusFailed
 			op.Error = "interrupted by restart"
-			op.CompletedAt = time.Now().UTC()
+			op.CompletedAt = now
+			op.Phase = ""
+			changed = true
 		}
 		t.ops[op.ID] = &op
 	}
 	t.mu.Unlock()
+
+	if changed {
+		t.saveToDisk()
+	}
 }
 
 func (t *Tracker) saveToDisk() {
-	t.mu.RLock()
+	cutoff := time.Now().Add(-completionTTL)
+	t.mu.Lock()
 	ops := make([]Operation, 0, len(t.ops))
 	for _, op := range t.ops {
-		ops = append(ops, *op)
+		if op.Status != StatusRunning && op.CompletedAt.Before(cutoff) {
+			delete(t.ops, op.ID)
+			continue
+		}
+		snapshot := *op
+		snapshot.Phase = ""
+		ops = append(ops, snapshot)
 	}
-	t.mu.RUnlock()
+	t.mu.Unlock()
 
 	data, err := json.MarshalIndent(ops, "", "  ")
 	if err != nil {

--- a/internal/bgop/tracker_test.go
+++ b/internal/bgop/tracker_test.go
@@ -35,6 +35,9 @@ func TestTracker_StartCompleteFail(t *testing.T) {
 
 	tr.UpdatePhase(id, "fetching")
 	ops = tr.List()
+	if len(ops) != 1 {
+		t.Fatalf("expected 1 op after UpdatePhase, got %d", len(ops))
+	}
 	if ops[0].Phase != "fetching" {
 		t.Errorf("expected phase 'fetching', got %q", ops[0].Phase)
 	}
@@ -94,7 +97,12 @@ func TestTracker_List_FiltersExpiredCompletions(t *testing.T) {
 
 	// Manually age the completion past the TTL.
 	tr.mu.Lock()
-	tr.ops[id].CompletedAt = time.Now().Add(-completionTTL - time.Minute)
+	op := tr.ops[id]
+	if op == nil {
+		tr.mu.Unlock()
+		t.Fatalf("expected op %q to exist", id)
+	}
+	op.CompletedAt = time.Now().Add(-completionTTL - time.Minute)
 	tr.mu.Unlock()
 
 	if ops := tr.List(); len(ops) != 0 {
@@ -107,7 +115,12 @@ func TestTracker_List_KeepsRunningRegardlessOfAge(t *testing.T) {
 
 	id := tr.Start(TypeClone, "cloning", "proj1", "task1")
 	tr.mu.Lock()
-	tr.ops[id].StartedAt = time.Now().Add(-completionTTL - time.Hour)
+	op := tr.ops[id]
+	if op == nil {
+		tr.mu.Unlock()
+		t.Fatalf("expected op %q to exist", id)
+	}
+	op.StartedAt = time.Now().Add(-completionTTL - time.Hour)
 	tr.mu.Unlock()
 
 	ops := tr.List()

--- a/internal/bgop/tracker_test.go
+++ b/internal/bgop/tracker_test.go
@@ -1,0 +1,279 @@
+package bgop
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newTestTracker(t *testing.T) *Tracker {
+	t.Helper()
+	diskPath := filepath.Join(t.TempDir(), "bgops.json")
+	return NewTracker(func(string, any) {}, diskPath, nil)
+}
+
+func TestTracker_StartCompleteFail(t *testing.T) {
+	tr := newTestTracker(t)
+
+	id := tr.Start(TypeClone, "cloning repo", "proj1", "task1")
+	if id == "" {
+		t.Fatal("expected non-empty operation id")
+	}
+
+	ops := tr.List()
+	if len(ops) != 1 {
+		t.Fatalf("expected 1 op after Start, got %d", len(ops))
+	}
+	if ops[0].Status != StatusRunning {
+		t.Errorf("expected status running, got %s", ops[0].Status)
+	}
+
+	tr.UpdatePhase(id, "fetching")
+	ops = tr.List()
+	if ops[0].Phase != "fetching" {
+		t.Errorf("expected phase 'fetching', got %q", ops[0].Phase)
+	}
+
+	tr.Complete(id)
+	ops = tr.List()
+	if len(ops) != 1 {
+		t.Fatalf("expected 1 op after Complete, got %d", len(ops))
+	}
+	if ops[0].Status != StatusDone {
+		t.Errorf("expected status done, got %s", ops[0].Status)
+	}
+	if ops[0].Phase != "" {
+		t.Errorf("expected phase cleared on completion, got %q", ops[0].Phase)
+	}
+	if ops[0].CompletedAt.IsZero() {
+		t.Error("expected CompletedAt to be set")
+	}
+}
+
+func TestTracker_Fail(t *testing.T) {
+	tr := newTestTracker(t)
+
+	id := tr.Start(TypeWorktreePrep, "prep", "proj1", "task1")
+	tr.Fail(id, errors.New("boom"))
+
+	ops := tr.List()
+	if len(ops) != 1 {
+		t.Fatalf("expected 1 op, got %d", len(ops))
+	}
+	if ops[0].Status != StatusFailed {
+		t.Errorf("expected status failed, got %s", ops[0].Status)
+	}
+	if ops[0].Error != "boom" {
+		t.Errorf("expected error 'boom', got %q", ops[0].Error)
+	}
+}
+
+func TestTracker_UnknownID_NoOp(t *testing.T) {
+	tr := newTestTracker(t)
+
+	// None of these should panic or create entries for an unknown id.
+	tr.UpdatePhase("missing", "phase")
+	tr.Complete("missing")
+	tr.Fail("missing", errors.New("boom"))
+
+	if ops := tr.List(); len(ops) != 0 {
+		t.Fatalf("expected 0 ops, got %d", len(ops))
+	}
+}
+
+func TestTracker_List_FiltersExpiredCompletions(t *testing.T) {
+	tr := newTestTracker(t)
+
+	id := tr.Start(TypeClone, "cloning", "proj1", "task1")
+	tr.Complete(id)
+
+	// Manually age the completion past the TTL.
+	tr.mu.Lock()
+	tr.ops[id].CompletedAt = time.Now().Add(-completionTTL - time.Minute)
+	tr.mu.Unlock()
+
+	if ops := tr.List(); len(ops) != 0 {
+		t.Fatalf("expected expired completed op to be filtered out, got %d", len(ops))
+	}
+}
+
+func TestTracker_List_KeepsRunningRegardlessOfAge(t *testing.T) {
+	tr := newTestTracker(t)
+
+	id := tr.Start(TypeClone, "cloning", "proj1", "task1")
+	tr.mu.Lock()
+	tr.ops[id].StartedAt = time.Now().Add(-completionTTL - time.Hour)
+	tr.mu.Unlock()
+
+	ops := tr.List()
+	if len(ops) != 1 {
+		t.Fatalf("expected running op to survive regardless of age, got %d", len(ops))
+	}
+}
+
+func TestTracker_SaveAndLoadFromDisk_RoundTrip(t *testing.T) {
+	tr := newTestTracker(t)
+
+	id := tr.Start(TypeClone, "cloning", "proj1", "task1")
+	tr.Complete(id)
+
+	if _, err := os.Stat(tr.diskPath); err != nil {
+		t.Fatalf("expected persisted file at %s: %v", tr.diskPath, err)
+	}
+
+	// Fresh tracker sharing the same disk path should restore the op.
+	tr2 := NewTracker(func(string, any) {}, tr.diskPath, nil)
+	tr2.LoadFromDisk()
+
+	ops := tr2.List()
+	if len(ops) != 1 {
+		t.Fatalf("expected 1 restored op, got %d", len(ops))
+	}
+	if ops[0].ID != id {
+		t.Errorf("expected restored op id %s, got %s", id, ops[0].ID)
+	}
+	if ops[0].Status != StatusDone {
+		t.Errorf("expected restored status done, got %s", ops[0].Status)
+	}
+}
+
+func TestTracker_LoadFromDisk_MarksRunningOpsFailed(t *testing.T) {
+	diskPath := filepath.Join(t.TempDir(), "bgops.json")
+	ops := []Operation{
+		{
+			ID:        "op1",
+			Type:      TypeClone,
+			Label:     "cloning",
+			Status:    StatusRunning,
+			StartedAt: time.Now().UTC(),
+		},
+	}
+	data, err := json.Marshal(ops)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if err := os.WriteFile(diskPath, data, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	tr := NewTracker(func(string, any) {}, diskPath, nil)
+	tr.LoadFromDisk()
+
+	loaded := tr.List()
+	if len(loaded) != 1 {
+		t.Fatalf("expected 1 restored op, got %d", len(loaded))
+	}
+	if loaded[0].Status != StatusFailed {
+		t.Errorf("expected running op to be marked failed after restart, got %s", loaded[0].Status)
+	}
+	if loaded[0].Error == "" {
+		t.Error("expected an error message explaining the interruption")
+	}
+	if loaded[0].CompletedAt.IsZero() {
+		t.Error("expected CompletedAt to be set for the reclassified op")
+	}
+}
+
+func TestTracker_LoadFromDisk_DiscardsExpiredCompletions(t *testing.T) {
+	diskPath := filepath.Join(t.TempDir(), "bgops.json")
+	ops := []Operation{
+		{
+			ID:          "old-done",
+			Type:        TypeClone,
+			Status:      StatusDone,
+			StartedAt:   time.Now().Add(-2 * completionTTL),
+			CompletedAt: time.Now().Add(-2 * completionTTL),
+		},
+		{
+			ID:          "recent-done",
+			Type:        TypeClone,
+			Status:      StatusDone,
+			StartedAt:   time.Now().Add(-time.Minute),
+			CompletedAt: time.Now().Add(-time.Minute),
+		},
+	}
+	data, err := json.Marshal(ops)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	if err := os.WriteFile(diskPath, data, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	tr := NewTracker(func(string, any) {}, diskPath, nil)
+	tr.LoadFromDisk()
+
+	loaded := tr.List()
+	if len(loaded) != 1 {
+		t.Fatalf("expected only the recent completion to survive, got %d", len(loaded))
+	}
+	if loaded[0].ID != "recent-done" {
+		t.Errorf("expected recent-done to survive, got %s", loaded[0].ID)
+	}
+}
+
+func TestTracker_LoadFromDisk_MissingFile_NoErrorLogged(t *testing.T) {
+	diskPath := filepath.Join(t.TempDir(), "does-not-exist.json")
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	tr := NewTracker(func(string, any) {}, diskPath, logger)
+	tr.LoadFromDisk()
+
+	if ops := tr.List(); len(ops) != 0 {
+		t.Fatalf("expected 0 ops on missing file, got %d", len(ops))
+	}
+	if logBuf.Len() != 0 {
+		t.Errorf("expected no log output for a missing file on first startup, got %q", logBuf.String())
+	}
+}
+
+func TestTracker_LoadFromDisk_CorruptedJSON_LogsAndKeepsRunning(t *testing.T) {
+	diskPath := filepath.Join(t.TempDir(), "bgops.json")
+	if err := os.WriteFile(diskPath, []byte("{ not valid json "), 0o644); err != nil {
+		t.Fatalf("write corrupt fixture: %v", err)
+	}
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+	tr := NewTracker(func(string, any) {}, diskPath, logger)
+
+	// Should not panic on corrupted data.
+	tr.LoadFromDisk()
+
+	if ops := tr.List(); len(ops) != 0 {
+		t.Fatalf("expected 0 ops after failing to parse corrupted disk state, got %d", len(ops))
+	}
+	if logBuf.Len() == 0 {
+		t.Error("expected corrupted JSON to be logged")
+	}
+
+	// Tracker must remain fully usable after a failed load.
+	id := tr.Start(TypeClone, "cloning", "proj1", "task1")
+	if ops := tr.List(); len(ops) != 1 || ops[0].ID != id {
+		t.Fatalf("expected tracker to remain usable after corrupted load, got %+v", ops)
+	}
+}
+
+func TestTracker_SaveToDisk_WriteFailureIsLogged(t *testing.T) {
+	// Point diskPath at a location whose parent directory doesn't exist so
+	// the atomic write's temp-file creation fails.
+	diskPath := filepath.Join(t.TempDir(), "missing-dir", "bgops.json")
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	tr := NewTracker(func(string, any) {}, diskPath, logger)
+	tr.Start(TypeClone, "cloning", "proj1", "task1")
+
+	if logBuf.Len() == 0 {
+		t.Error("expected a write failure to be logged")
+	}
+	if _, err := os.Stat(diskPath); !os.IsNotExist(err) {
+		t.Errorf("expected no file to be written, got err=%v", err)
+	}
+}

--- a/internal/bgop/tracker_test.go
+++ b/internal/bgop/tracker_test.go
@@ -153,6 +153,9 @@ func TestTracker_SaveAndLoadFromDisk_RoundTrip(t *testing.T) {
 	if ops[0].Status != StatusDone {
 		t.Errorf("expected restored status done, got %s", ops[0].Status)
 	}
+	if ops[0].Phase != "" {
+		t.Errorf("expected restored phase to remain non-persistent, got %q", ops[0].Phase)
+	}
 }
 
 func TestTracker_LoadFromDisk_MarksRunningOpsFailed(t *testing.T) {
@@ -189,6 +192,24 @@ func TestTracker_LoadFromDisk_MarksRunningOpsFailed(t *testing.T) {
 	}
 	if loaded[0].CompletedAt.IsZero() {
 		t.Error("expected CompletedAt to be set for the reclassified op")
+	}
+
+	data, err = os.ReadFile(diskPath)
+	if err != nil {
+		t.Fatalf("read persisted file: %v", err)
+	}
+	var persisted []Operation
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatalf("unmarshal persisted file: %v", err)
+	}
+	if len(persisted) != 1 {
+		t.Fatalf("expected 1 persisted op after rewrite, got %d", len(persisted))
+	}
+	if persisted[0].Status != StatusFailed {
+		t.Errorf("expected rewritten op status failed, got %s", persisted[0].Status)
+	}
+	if persisted[0].Phase != "" {
+		t.Errorf("expected rewritten op phase to be cleared, got %q", persisted[0].Phase)
 	}
 }
 
@@ -227,6 +248,60 @@ func TestTracker_LoadFromDisk_DiscardsExpiredCompletions(t *testing.T) {
 	}
 	if loaded[0].ID != "recent-done" {
 		t.Errorf("expected recent-done to survive, got %s", loaded[0].ID)
+	}
+
+	data, err = os.ReadFile(diskPath)
+	if err != nil {
+		t.Fatalf("read rewritten file: %v", err)
+	}
+	var persisted []Operation
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatalf("unmarshal rewritten file: %v", err)
+	}
+	if len(persisted) != 1 || persisted[0].ID != "recent-done" {
+		t.Fatalf("expected rewritten file to keep only recent-done, got %+v", persisted)
+	}
+}
+
+func TestTracker_SaveToDisk_DropsTransientState(t *testing.T) {
+	tr := newTestTracker(t)
+
+	id := tr.Start(TypeClone, "cloning", "proj1", "task1")
+	tr.UpdatePhase(id, "fetching")
+
+	tr.mu.Lock()
+	op := tr.ops[id]
+	if op == nil {
+		tr.mu.Unlock()
+		t.Fatalf("expected op %q to exist", id)
+	}
+	op.Status = StatusDone
+	op.CompletedAt = time.Now().Add(-completionTTL - time.Minute)
+	tr.mu.Unlock()
+
+	doneID := tr.Start(TypeWorktreePrep, "prep", "proj1", "task1")
+	tr.UpdatePhase(doneID, "phase should not persist")
+	tr.Complete(doneID)
+
+	data, err := os.ReadFile(tr.diskPath)
+	if err != nil {
+		t.Fatalf("read persisted file: %v", err)
+	}
+	var persisted []Operation
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatalf("unmarshal persisted file: %v", err)
+	}
+	if len(persisted) != 1 {
+		t.Fatalf("expected only the non-expired op to persist, got %d", len(persisted))
+	}
+	if persisted[0].ID != doneID {
+		t.Fatalf("expected persisted op %q, got %q", doneID, persisted[0].ID)
+	}
+	if persisted[0].Phase != "" {
+		t.Errorf("expected phase to stay non-persistent, got %q", persisted[0].Phase)
+	}
+	if _, ok := tr.ops[id]; ok {
+		t.Fatalf("expected expired op %q to be pruned from memory during save", id)
 	}
 }
 

--- a/internal/fsutil/fsutil.go
+++ b/internal/fsutil/fsutil.go
@@ -6,10 +6,6 @@ import (
 	"strings"
 )
 
-// defaultWriteMode is applied to newly created files — matches the historical
-// os.WriteFile(path, data, 0o644) behavior AtomicWrite replaced.
-const defaultWriteMode = 0o644
-
 // AtomicWrite writes data to path via a temp file + rename to prevent
 // partial reads from concurrent goroutines. The temp file is removed on
 // every error path — including a failed rename into a read-only target
@@ -17,9 +13,10 @@ const defaultWriteMode = 0o644
 //
 // The rename preserves whatever mode the temp file has, which os.CreateTemp
 // sets to 0600 regardless of the target's existing permissions. To avoid
-// silently downgrading an existing file's mode on every write, AtomicWrite
-// chmods the temp file to match path's current mode before renaming — or
-// defaultWriteMode if path doesn't exist yet.
+// silently changing an existing file's mode on every write, AtomicWrite chmods
+// the temp file to match path's current mode before renaming. Newly created
+// files keep CreateTemp's restrictive default, which avoids overriding the
+// caller's umask with a broader mode.
 func AtomicWrite(path string, data []byte) error {
 	dir := filepath.Dir(path)
 	f, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
@@ -37,13 +34,11 @@ func AtomicWrite(path string, data []byte) error {
 		return err
 	}
 
-	mode := os.FileMode(defaultWriteMode)
 	if info, err := os.Stat(path); err == nil {
-		mode = info.Mode().Perm()
-	}
-	if err := os.Chmod(tmp, mode); err != nil {
-		_ = os.Remove(tmp)
-		return err
+		if err := os.Chmod(tmp, info.Mode().Perm()); err != nil {
+			_ = os.Remove(tmp)
+			return err
+		}
 	}
 
 	if err := os.Rename(tmp, path); err != nil {

--- a/internal/fsutil/fsutil.go
+++ b/internal/fsutil/fsutil.go
@@ -6,10 +6,20 @@ import (
 	"strings"
 )
 
+// defaultWriteMode is applied to newly created files — matches the historical
+// os.WriteFile(path, data, 0o644) behavior AtomicWrite replaced.
+const defaultWriteMode = 0o644
+
 // AtomicWrite writes data to path via a temp file + rename to prevent
 // partial reads from concurrent goroutines. The temp file is removed on
 // every error path — including a failed rename into a read-only target
 // directory — so repeated write failures don't fill the disk with orphans.
+//
+// The rename preserves whatever mode the temp file has, which os.CreateTemp
+// sets to 0600 regardless of the target's existing permissions. To avoid
+// silently downgrading an existing file's mode on every write, AtomicWrite
+// chmods the temp file to match path's current mode before renaming — or
+// defaultWriteMode if path doesn't exist yet.
 func AtomicWrite(path string, data []byte) error {
 	dir := filepath.Dir(path)
 	f, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
@@ -26,6 +36,16 @@ func AtomicWrite(path string, data []byte) error {
 		_ = os.Remove(tmp)
 		return err
 	}
+
+	mode := os.FileMode(defaultWriteMode)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+	if err := os.Chmod(tmp, mode); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+
 	if err := os.Rename(tmp, path); err != nil {
 		_ = os.Remove(tmp)
 		return err

--- a/internal/fsutil/fsutil_test.go
+++ b/internal/fsutil/fsutil_test.go
@@ -69,7 +69,7 @@ func TestAtomicWrite_PreservesExistingMode(t *testing.T) {
 	}
 }
 
-func TestAtomicWrite_NewFileDefaultsTo0644(t *testing.T) {
+func TestAtomicWrite_NewFileKeepsRestrictiveTempMode(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "file.txt")
@@ -82,8 +82,8 @@ func TestAtomicWrite_NewFileDefaultsTo0644(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Stat: %v", err)
 	}
-	if got := info.Mode().Perm(); got != 0o644 {
-		t.Errorf("mode for new file = %o, want %o", got, 0o644)
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("mode for new file = %o, want %o", got, 0o600)
 	}
 }
 

--- a/internal/fsutil/fsutil_test.go
+++ b/internal/fsutil/fsutil_test.go
@@ -47,6 +47,46 @@ func TestAtomicWrite_Overwrite(t *testing.T) {
 	}
 }
 
+func TestAtomicWrite_PreservesExistingMode(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if err := AtomicWrite(path, []byte("new")); err != nil {
+		t.Fatalf("AtomicWrite: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o644 {
+		t.Errorf("mode after overwrite = %o, want %o", got, 0o644)
+	}
+}
+
+func TestAtomicWrite_NewFileDefaultsTo0644(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+
+	if err := AtomicWrite(path, []byte("data")); err != nil {
+		t.Fatalf("AtomicWrite: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o644 {
+		t.Errorf("mode for new file = %o, want %o", got, 0o644)
+	}
+}
+
 func TestAtomicWrite_BadDir(t *testing.T) {
 	t.Parallel()
 	path := filepath.Join(t.TempDir(), "nonexistent", "file.txt")

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -43,7 +43,7 @@ type startupDegradedEvent struct {
 }
 
 func (a *App) initBgops(emit func(string, any)) {
-	a.bgops = bgop.NewTracker(emit, filepath.Join(config.HomeDir(), "bgops.json"))
+	a.bgops = bgop.NewTracker(emit, filepath.Join(config.HomeDir(), "bgops.json"), a.logger)
 	a.bgops.LoadFromDisk()
 }
 


### PR DESCRIPTION
## Motivation

Background-operation state in `internal/bgop/tracker.go` was persisted
best-effort with no test coverage, and read/write/unmarshal errors were
silently swallowed — a partial or corrupt `bgops.json` write could
disappear across restarts unnoticed.

## Implementation information

- Added coverage for persisted operation state in
  `internal/bgop/tracker_test.go`, including corrupt/partial file
  handling.
- Adjusted `internal/bgop/tracker.go` persistence paths surfaced by the
  new tests.
- Follow-up commit addresses review comments by adding tests and
  hardening `internal/fsutil/fsutil.go`.

Closes https://github.com/Automaat/sybra/issues/1397

_Generated by Sybra harness_