### PR TITLE
fix(workflow): escalate rebase-fail retry to human

### DIFF
--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -3,6 +3,7 @@ package recovery_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
@@ -16,6 +17,7 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/workflow"
 	"github.com/Automaat/sybra/internal/worktree"
+	"github.com/Automaat/sybra/internal/worktreeerr"
 )
 
 func discardLogger() *slog.Logger {
@@ -336,6 +338,93 @@ func TestRestartStaleInteractiveOneShotRestartsAsOneShot(t *testing.T) {
 	}
 	if !stub.lastOneShot {
 		t.Fatal("interactive one-shot stale restart must preserve oneShot=true")
+	}
+}
+
+// TestRestartStalePRFixRebaseFailedFlipsToHumanRequired covers the actual
+// path that had the infinite-retry bug this PR fixes: run_role=="pr-fix"
+// skips markRebaseBlocked (unlike the other three agent-start call sites) and
+// returns worktreeerr.ErrRebaseFailed straight through to
+// Recovery.surfaceStartFailure. Before ClassifyAgentStartError learned to
+// treat it as permanent, RestartStaleInProgress would keep re-dispatching
+// StartPRFixAgent against the same doomed rebase every restartStaleMinAge
+// tick, forever.
+func TestRestartStalePRFixRebaseFailedFlipsToHumanRequired(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	dir := t.TempDir()
+	store, err := task.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := discardLogger()
+	agents := newTestAgentManager(t, ctx, func(string, any) {}, logger, t.TempDir())
+	wm := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Tasks:        tasks,
+		Logger:       logger,
+		AgentChecker: agents.HasRunningAgentForTask,
+	})
+
+	created, err := tasks.Create("pr-fix rebase failed", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inProg := task.StatusInProgress
+	projID := "owner/repo"
+	runRole := "pr-fix"
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:    &inProg,
+		ProjectID: &projID,
+		RunRole:   &runRole,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Old run → debounce passes so the pr-fix branch actually re-dispatches.
+	// Role is deliberately NOT "pr-fix" here: a last run with Role=="pr-fix"
+	// hits the earlier revert-to-in-review shortcut (stale.go) before this
+	// dispatch is ever reached — task.RunRole (not AgentRun.Role) is what
+	// selects the StartPRFixAgent branch under test.
+	if err := tasks.AddRun(created.ID, task.AgentRun{
+		AgentID:   "ag-impl",
+		Mode:      "headless",
+		State:     string(agent.StateStopped),
+		StartedAt: time.Now().Add(-30 * time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	stub := stubOrchestrator{prFixErr: fmt.Errorf("prepare worktree: %w", worktreeerr.ErrRebaseFailed)}
+	r := &recovery.Recovery{
+		Tasks:        tasks,
+		Agents:       agents,
+		Worktrees:    wm,
+		Orchestrator: &stub,
+		Projects:     stubProjects{},
+		Logger:       logger,
+		Throttle:     logging.NewErrorThrottle(),
+		WG:           &wg,
+		LogDir:       t.TempDir(),
+	}
+	r.RestartStaleInProgress(context.Background())
+	wg.Wait()
+
+	if stub.prFixCalls != 1 {
+		t.Fatalf("StartPRFixAgent calls = %d, want 1", stub.prFixCalls)
+	}
+
+	updated, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status != task.StatusHumanRequired {
+		t.Errorf("status = %s, want %s (rebase failure must escalate, not retry forever)", updated.Status, task.StatusHumanRequired)
+	}
+	if !strings.Contains(updated.StatusReason, "branch stale") {
+		t.Errorf("status reason = %q, want rebase-failed classification", updated.StatusReason)
 	}
 }
 

--- a/internal/sybra/app_agents.go
+++ b/internal/sybra/app_agents.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/workflow"
 	"github.com/Automaat/sybra/internal/worktree"
+	"github.com/Automaat/sybra/internal/worktreeerr"
 )
 
 // resolveExecution derives the effective mode, directory, permission mode, and
@@ -418,7 +419,7 @@ func markRebaseBlocked(tasks *task.Manager, taskID string, err error, logger *sl
 		logger.Info("worktree.rebase-block.recovered-as-conflict", "task_id", taskID)
 		return true
 	}
-	reason := "branch stale: rebase failed before agent start; resolve conflicts or recreate the task branch"
+	reason := worktreeerr.RebaseBlockedReason
 	if _, uerr := tasks.Update(taskID, task.Update{
 		Status:       task.Ptr(task.StatusHumanRequired),
 		StatusReason: task.Ptr(reason),

--- a/internal/workflow/start_error.go
+++ b/internal/workflow/start_error.go
@@ -53,7 +53,7 @@ func ClassifyAgentStartError(err error) (reason string, permanent bool) {
 		reason = "agent start blocked: project not registered locally — create the project to resume"
 	case errors.Is(err, worktreeerr.ErrRebaseFailed):
 		permanent = true
-		reason = "branch stale: rebase failed before agent start; resolve conflicts or recreate the task branch"
+		reason = worktreeerr.RebaseBlockedReason
 	case errors.Is(err, provider.ErrProviderUnhealthy):
 		reason = "agent start blocked: " + err.Error()
 	default:

--- a/internal/workflow/start_error.go
+++ b/internal/workflow/start_error.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/provider"
+	"github.com/Automaat/sybra/internal/worktreeerr"
 )
 
 // startReasonMaxLen caps the human-facing reason written to task.StatusReason.
@@ -50,6 +51,9 @@ func ClassifyAgentStartError(err error) (reason string, permanent bool) {
 	case errors.Is(err, project.ErrProjectNotRegistered):
 		permanent = true
 		reason = "agent start blocked: project not registered locally — create the project to resume"
+	case errors.Is(err, worktreeerr.ErrRebaseFailed):
+		permanent = true
+		reason = "branch stale: rebase failed before agent start; resolve conflicts or recreate the task branch"
 	case errors.Is(err, provider.ErrProviderUnhealthy):
 		reason = "agent start blocked: " + err.Error()
 	default:

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/provider"
+	"github.com/Automaat/sybra/internal/worktreeerr"
 )
 
 func TestClassifyAgentStartError(t *testing.T) {
@@ -31,6 +32,12 @@ func TestClassifyAgentStartError(t *testing.T) {
 			name:         "generic error is transient",
 			err:          errors.New("fetch origin: connection refused"),
 			wantContains: "agent start failed: fetch origin: connection refused",
+		},
+		{
+			name:          "rebase failed is permanent",
+			err:           fmt.Errorf("prepare worktree: %w", worktreeerr.ErrRebaseFailed),
+			wantPermanent: true,
+			wantContains:  "branch stale: rebase failed before agent start",
 		},
 		{
 			name:         "provider unhealthy is transient",
@@ -131,6 +138,26 @@ func TestSurfaceStartFailure_PermanentFlipsToHumanRequired(t *testing.T) {
 	reason := tasks.Reason("t1")
 	if !strings.Contains(reason, "project not registered") {
 		t.Errorf("reason %q missing permanent classification", reason)
+	}
+}
+
+func TestSurfaceStartFailure_RebaseFailedFlipsToHumanRequired(t *testing.T) {
+	// Regression: ResumeStalled must escalate on the first rebase-conflict
+	// retry instead of hammering the doomed rebase every ~60s forever.
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+
+	wrapped := fmt.Errorf("prepare worktree: %w", worktreeerr.ErrRebaseFailed)
+	engine.surfaceStartFailure("t1", "in-progress", wrapped)
+
+	got, _ := tasks.GetTask("t1")
+	if got.Status != "human-required" {
+		t.Errorf("rebase failure should flip to human-required, got %q", got.Status)
+	}
+	reason := tasks.Reason("t1")
+	if !strings.Contains(reason, "branch stale") {
+		t.Errorf("reason %q missing rebase-failed classification", reason)
 	}
 }
 

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -142,8 +142,15 @@ func TestSurfaceStartFailure_PermanentFlipsToHumanRequired(t *testing.T) {
 }
 
 func TestSurfaceStartFailure_RebaseFailedFlipsToHumanRequired(t *testing.T) {
-	// Regression: ResumeStalled must escalate on the first rebase-conflict
-	// retry instead of hammering the doomed rebase every ~60s forever.
+	// Engine.surfaceStartFailure must classify ErrRebaseFailed as permanent
+	// too, as defense in depth: the three Engine-routed callers already flip
+	// to human-required via markRebaseBlocked before the error reaches here,
+	// but should that upstream guard ever regress, this classification is
+	// what stops the resume loop from hammering the doomed rebase forever.
+	// The actual regression this PR fixes is in the recovery.StartPRFixAgent
+	// path, which skips markRebaseBlocked entirely — see
+	// TestRestartStalePRFixRebaseFailedFlipsToHumanRequired in
+	// internal/recovery/recovery_test.go.
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -2,17 +2,20 @@ package worktree
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/worktreeerr"
 )
 
 // ErrRebaseFailed indicates a reused task worktree could not be rebased onto
-// the project base ref and must be repaired before another agent run.
-var ErrRebaseFailed = errors.New("worktree rebase failed")
+// the project base ref and must be repaired before another agent run. Alias
+// of worktreeerr.ErrRebaseFailed so internal/workflow can classify it without
+// importing internal/worktree (which would create an import cycle via
+// internal/task -> internal/workflow).
+var ErrRebaseFailed = worktreeerr.ErrRebaseFailed
 
 // PrepareForTask creates (or reuses) a worktree for implementation work.
 // Fetches origin, creates a conventional-prefixed branch off default branch,

--- a/internal/worktreeerr/worktreeerr.go
+++ b/internal/worktreeerr/worktreeerr.go
@@ -1,0 +1,13 @@
+// Package worktreeerr holds worktree sentinel errors that need to be
+// classified from internal/workflow. It exists as a standalone leaf package
+// (no internal/task or internal/workflow dependency) because internal/task
+// already imports internal/workflow, and internal/worktree imports
+// internal/task — importing internal/worktree directly from
+// internal/workflow would close that cycle.
+package worktreeerr
+
+import "errors"
+
+// ErrRebaseFailed indicates a reused task worktree could not be rebased onto
+// the project base ref and must be repaired before another agent run.
+var ErrRebaseFailed = errors.New("worktree rebase failed")

--- a/internal/worktreeerr/worktreeerr.go
+++ b/internal/worktreeerr/worktreeerr.go
@@ -11,3 +11,9 @@ import "errors"
 // ErrRebaseFailed indicates a reused task worktree could not be rebased onto
 // the project base ref and must be repaired before another agent run.
 var ErrRebaseFailed = errors.New("worktree rebase failed")
+
+// RebaseBlockedReason is the human-facing status_reason written whenever
+// ErrRebaseFailed escalates a task to human-required. Shared between
+// internal/sybra's markRebaseBlocked and workflow.ClassifyAgentStartError so
+// the two escalation paths can't drift apart in wording.
+const RebaseBlockedReason = "branch stale: rebase failed before agent start; resolve conflicts or recreate the task branch"


### PR DESCRIPTION
## Motivation

`ClassifyAgentStartError` had no case for `worktree.ErrRebaseFailed`, so a
failed rebase fell through to the transient default and `surfaceStartFailure`
kept retrying the same doomed rebase every ~60s instead of flipping the task
to `human-required` once — which the initial-dispatch path already does via
`markRebaseBlocked`.

## Implementation information

- Added a new leaf package `internal/worktreeerr` holding the rebase-failure
  sentinel (aliased from `worktree.ErrRebaseFailed`), since `internal/workflow`
  importing `internal/worktree` directly would close an import cycle through
  `internal/task`.
- `internal/workflow/start_error.go` now classifies rebase failures as
  escalate-to-human instead of retriable.
- Addressed review comments from the initial pass.

Closes https://github.com/Automaat/sybra/issues/1430

_Generated by Sybra harness_