### PR TITLE
fix(worktree): merge fallback when rebase fails

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -846,3 +846,24 @@ func RebaseOnto(ctx context.Context, worktreePath, ref string) error {
 	}
 	return nil
 }
+
+// MergeOnto merges ref into the worktree's current branch. Unlike RebaseOnto,
+// it never rewrites existing commits — the branch's prior history is
+// preserved and any subsequent push is a plain fast-forward, never a
+// force-push. Aborts and returns an error on conflict; the abort runs on the
+// same ctx as the merge itself (a canceled ctx skips both equally, same as
+// any other caller-scoped operation). -c user.*/commit.gpgsign=false mirror
+// AutoCommitUncommitted's fallback identity for worktrees where the agent
+// never configured one; --no-verify skips repo pre-commit hooks the same
+// way, so a failing hook can't defeat this recovery path.
+func MergeOnto(ctx context.Context, worktreePath, ref string) error {
+	if err := executil.Run(ctx, worktreePath, "git",
+		"-c", "user.name=Sybra",
+		"-c", "user.email=sybra@localhost",
+		"-c", "commit.gpgsign=false",
+		"merge", "--no-edit", "--no-verify", ref); err != nil {
+		_ = executil.Run(ctx, worktreePath, "git", "merge", "--abort")
+		return fmt.Errorf("merge %s: %w", ref, err)
+	}
+	return nil
+}

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -850,9 +850,12 @@ func RebaseOnto(ctx context.Context, worktreePath, ref string) error {
 // MergeOnto merges ref into the worktree's current branch. Unlike RebaseOnto,
 // it never rewrites existing commits — the branch's prior history is
 // preserved and any subsequent push is a plain fast-forward, never a
-// force-push. Aborts and returns an error on conflict; the abort runs on the
-// same ctx as the merge itself (a canceled ctx skips both equally, same as
-// any other caller-scoped operation). -c user.*/commit.gpgsign=false mirror
+// force-push. Aborts and returns an error on conflict. The abort runs on a
+// context derived from ctx via context.WithoutCancel, bounded by its own
+// timeout: if the merge failed because ctx was canceled or its deadline
+// expired, running the abort on that same ctx would skip cleanup and leave
+// MERGE_HEAD state behind in the worktree (mirrors RebaseOnto's cleanup
+// contract). -c user.name/user.email/commit.gpgsign=false mirror
 // AutoCommitUncommitted's fallback identity for worktrees where the agent
 // never configured one; --no-verify skips repo pre-commit hooks the same
 // way, so a failing hook can't defeat this recovery path.
@@ -862,7 +865,9 @@ func MergeOnto(ctx context.Context, worktreePath, ref string) error {
 		"-c", "user.email=sybra@localhost",
 		"-c", "commit.gpgsign=false",
 		"merge", "--no-edit", "--no-verify", ref); err != nil {
-		_ = executil.Run(ctx, worktreePath, "git", "merge", "--abort")
+		abortCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), rebaseAbortTimeout)
+		_ = executil.Run(abortCtx, worktreePath, "git", "merge", "--abort")
+		cancel()
 		return fmt.Errorf("merge %s: %w", ref, err)
 	}
 	return nil

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -1738,6 +1738,99 @@ func TestReconcileWithRemote_PropagatesFetchError(t *testing.T) {
 	}
 }
 
+// TestMergeOnto_MergesNonConflictingHistories proves the core "additive, no
+// force-push" property: merging two branches whose commits touch different
+// files produces a merge commit carrying both sides' content, and pushing the
+// result afterward is a plain fast-forward (the remote SHA remains an
+// ancestor of the merge commit).
+func TestMergeOnto_MergesNonConflictingHistories(t *testing.T) {
+	t.Parallel()
+	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
+	makeCommit(t, wtPath, "one")
+	if err := PushSync(context.Background(), wtPath, branch); err != nil {
+		t.Fatalf("PushSync seed: %v", err)
+	}
+	remoteHead := pushRemoteCommit(t, remoteBare, branch, "remote-side")
+
+	// A local commit on a different file — nothing for the merge to conflict
+	// on with remote-side's data.txt change.
+	if err := os.WriteFile(filepath.Join(wtPath, "other.txt"), []byte("local-side"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"-C", wtPath, "add", "other.txt"},
+		{"-C", wtPath, "commit", "-m", "local-side"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+
+	if out, err := exec.Command("git", "-C", wtPath, "fetch", "origin").CombinedOutput(); err != nil {
+		t.Fatalf("fetch: %v: %s", err, out)
+	}
+	if err := MergeOnto(context.Background(), wtPath, "origin/"+branch); err != nil {
+		t.Fatalf("MergeOnto: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(wtPath, "data.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "remote-side" {
+		t.Fatalf("data.txt = %q, want remote-side's content", got)
+	}
+	got, err = os.ReadFile(filepath.Join(wtPath, "other.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "local-side" {
+		t.Fatalf("other.txt = %q, want local-side's content", got)
+	}
+
+	// The remote's pre-merge head must remain an ancestor of the merge commit
+	// — the property PushSync relies on to always take the fast-forward path,
+	// never --force-with-lease, after a MergeOnto recovery.
+	if out, err := exec.Command("git", "-C", wtPath, "merge-base", "--is-ancestor", remoteHead, "HEAD").CombinedOutput(); err != nil {
+		t.Fatalf("remote head %s is not an ancestor of the merge commit: %v: %s", remoteHead, err, out)
+	}
+}
+
+// TestMergeOnto_ConflictReturnsErrorAndCleansUp proves MergeOnto fails closed
+// on a genuine conflict and leaves the worktree in a clean, non-merging state
+// (mirroring RebaseOnto's --abort-on-failure contract) rather than stranding
+// a half-applied merge for the next operation to trip over.
+func TestMergeOnto_ConflictReturnsErrorAndCleansUp(t *testing.T) {
+	t.Parallel()
+	remoteBare, wtPath, branch := setupPushSyncWorktree(t)
+	makeCommit(t, wtPath, "one")
+	if err := PushSync(context.Background(), wtPath, branch); err != nil {
+		t.Fatalf("PushSync seed: %v", err)
+	}
+	pushRemoteCommit(t, remoteBare, branch, "remote-side")
+	makeCommit(t, wtPath, "local-side")
+
+	if out, err := exec.Command("git", "-C", wtPath, "fetch", "origin").CombinedOutput(); err != nil {
+		t.Fatalf("fetch: %v: %s", err, out)
+	}
+
+	err := MergeOnto(context.Background(), wtPath, "origin/"+branch)
+	if err == nil {
+		t.Fatal("MergeOnto with conflicting data.txt = nil error, want conflict")
+	}
+
+	if out, mergeErr := exec.Command("git", "-C", wtPath, "rev-parse", "-q", "--verify", "MERGE_HEAD").CombinedOutput(); mergeErr == nil {
+		t.Fatalf("MERGE_HEAD still present after MergeOnto failure, want abort to have cleaned it up: %s", out)
+	}
+	out, statusErr := exec.Command("git", "-C", wtPath, "status", "--porcelain").CombinedOutput()
+	if statusErr != nil {
+		t.Fatalf("git status: %v: %s", statusErr, out)
+	}
+	if len(strings.TrimSpace(string(out))) != 0 {
+		t.Fatalf("worktree not clean after MergeOnto failure: %s", out)
+	}
+}
+
 // TestPushSync_RefusesForceWhenRemoteAdvanced is the defense-in-depth net: when
 // the live remote head no longer matches the stale tracking ref the push
 // decision was based on, PushSync must refuse the --force-with-lease rather than

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -885,8 +885,11 @@ func TestPrepareForTask_RebaseFailureRecoversViaMerge(t *testing.T) {
 	}
 
 	// Commit A: append a line — this is the commit whose patch context will
-	// no longer match once upstream edits the same file.
-	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), append(base, []byte("line2\n")...), 0o644); err != nil {
+	// no longer match once upstream edits the same file. Clone base before
+	// appending: append can mutate base's backing array in place if it has
+	// spare capacity, which would corrupt commit B's revert below.
+	withLine2 := append(append([]byte{}, base...), []byte("line2\n")...)
+	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), withLine2, 0o644); err != nil {
 		t.Fatal(err)
 	}
 	mustRunInDir(t, wtPath, "git", "add", "README.md")

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -1,6 +1,7 @@
 package worktree
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"log/slog"
@@ -843,6 +844,96 @@ func TestPrepareForTask_RebaseConflictFailsClosed(t *testing.T) {
 	}
 	if gotPath != "" {
 		t.Fatalf("PrepareForTask path = %q, want empty path on rebase failure", gotPath)
+	}
+}
+
+// TestPrepareForTask_RebaseFailureRecoversViaMerge proves the merge fallback
+// in reconcileAndRebase: a task branch whose commits, replayed individually,
+// hit an intermediate patch-apply conflict against the new base — even though
+// the branch's *net* content change doesn't actually overlap with upstream's
+// edit — fails a plain rebase but succeeds via merge. The branch adds then
+// reverts a line (net no-op) while upstream edits a different line the
+// now-stale intermediate commit's patch context no longer matches; rebasing
+// commit-by-commit conflicts on that mismatched context, but a single
+// three-way merge of final states has nothing to reconcile.
+func TestPrepareForTask_RebaseFailureRecoversViaMerge(t *testing.T) {
+	h := prepareHarness(t, nil, 30*time.Second)
+
+	tk, err := h.tasks.Store().Create("recoverable task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.tasks.Update(tk.ID, task.Update{ProjectID: task.Ptr(h.proj.ID)}); err != nil {
+		t.Fatal(err)
+	}
+	tk, err = h.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wtPath, err := h.m.PrepareForTask(context.Background(), tk, nil)
+	if err != nil {
+		t.Fatalf("initial PrepareForTask: %v", err)
+	}
+
+	mustRunInDir(t, wtPath, "git", "config", "user.email", "test@test.com")
+	mustRunInDir(t, wtPath, "git", "config", "user.name", "Test")
+
+	base, err := os.ReadFile(filepath.Join(wtPath, "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Commit A: append a line — this is the commit whose patch context will
+	// no longer match once upstream edits the same file.
+	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), append(base, []byte("line2\n")...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunInDir(t, wtPath, "git", "add", "README.md")
+	mustRunInDir(t, wtPath, "git", "commit", "-m", "add line2")
+
+	// Commit B: revert it — net effect on the branch is byte-identical to
+	// base, so a three-way merge against upstream has nothing to reconcile.
+	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), base, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunInDir(t, wtPath, "git", "add", "README.md")
+	mustRunInDir(t, wtPath, "git", "commit", "-m", "revert line2")
+
+	// Upstream edits the same file commit A touched — unrelated to the
+	// branch's net (no-op) change, but enough to break commit A's patch
+	// context during a commit-by-commit rebase replay.
+	upstream := append(append([]byte{}, base...), []byte("upstream addition\n")...)
+	if err := os.WriteFile(filepath.Join(h.src, "README.md"), upstream, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunInDir(t, h.src, "git", "add", "README.md")
+	mustRunInDir(t, h.src, "git", "commit", "-m", "upstream edit")
+
+	gotPath, err := h.m.PrepareForTask(context.Background(), tk, nil)
+	if err != nil {
+		t.Fatalf("PrepareForTask should recover via merge fallback, got err: %v", err)
+	}
+	if gotPath == "" {
+		t.Fatal("PrepareForTask path is empty, want a recovered worktree path")
+	}
+
+	got, err := os.ReadFile(filepath.Join(gotPath, "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, upstream) {
+		t.Fatalf("README.md = %q, want upstream's content %q (branch's net change was a no-op)", got, upstream)
+	}
+
+	// The recovery must be a real merge commit, not a rebase — a subsequent
+	// push must never need to force.
+	out, err := exec.Command("git", "-C", gotPath, "log", "--merges", "-1", "--format=%H").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(strings.TrimSpace(string(out))) == 0 {
+		t.Fatal("expected a merge commit on the recovered branch, found none")
 	}
 }
 

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -137,7 +137,10 @@ func (m *Manager) PrepareForTask(ctx context.Context, t task.Task, onPhase func(
 // clone/machine), so the rebase carries them forward instead of a later
 // force-push dropping them. Rebasing must then succeed before the agent runs —
 // continuing from a stale branch makes downstream diff gates scan historical
-// commits. Both failures wrap ErrRebaseFailed so the caller can surface a
+// commits. If the rebase fails, it falls back to an additive merge (see
+// MergeOnto) before giving up, since most staleness under concurrent agents
+// is not a genuine content conflict. All three failures (reconcile, rebase,
+// and the merge fallback) wrap ErrRebaseFailed so the caller can surface a
 // repairable worktree.
 func (m *Manager) reconcileAndRebase(ctx context.Context, wtPath, wtBranch, baseRef string, onPhase func(string)) error {
 	callPhase(onPhase, "Reconciling with remote…")
@@ -145,8 +148,21 @@ func (m *Manager) reconcileAndRebase(ctx context.Context, wtPath, wtBranch, base
 		return fmt.Errorf("%w: reconcile %s with remote: %w", ErrRebaseFailed, wtBranch, err)
 	}
 	callPhase(onPhase, "Rebasing onto origin…")
-	if err := project.RebaseOnto(ctx, wtPath, baseRef); err != nil {
-		return fmt.Errorf("%w: rebase %s onto %s: %w", ErrRebaseFailed, wtBranch, baseRef, err)
+	if rebaseErr := project.RebaseOnto(ctx, wtPath, baseRef); rebaseErr != nil {
+		// A rebase failure here is very often not a genuine content conflict —
+		// under concurrent agents, base moves quickly and the branch's own
+		// history is otherwise clean. Try an additive merge before giving up:
+		// unlike rebase, it never rewrites existing commits, so recovery never
+		// needs a force-push (see MergeOnto). Only when the merge also fails
+		// (a real conflict) does this still surface ErrRebaseFailed for the
+		// caller to escalate — ordinarily to human-required, or to the PR-fix
+		// conflict-recovery agent when a PR is already open.
+		callPhase(onPhase, "Rebase failed, trying merge…")
+		if mergeErr := project.MergeOnto(ctx, wtPath, baseRef); mergeErr != nil {
+			return fmt.Errorf("%w: rebase %s onto %s: %w (merge fallback also failed: %w)",
+				ErrRebaseFailed, wtBranch, baseRef, rebaseErr, mergeErr)
+		}
+		m.logger.Info("worktree.rebase-recovered-via-merge", "branch", wtBranch, "base", baseRef)
 	}
 	return nil
 }


### PR DESCRIPTION
## Motivation

Under concurrent agents, a rebase failure at worktree-prep time is very
often not a genuine content conflict — base moves quickly and the
branch's own history is otherwise clean, but git's commit-by-commit
patch replay can still fail on an intermediate hunk whose context no
longer matches, even when the branch's net content change doesn't
overlap with upstream at all. This was hitting tasks well before a PR
ever opens (implementation, review, testing, create_pr), where the
existing PR-keyed conflict recovery has no chance to fire — they just
dead-end at `human-required` with "branch stale: rebase failed".

> Changelog: fix(worktree): merge fallback when rebase fails

## Implementation information

- `reconcileAndRebase` (`internal/worktree/prepare.go`) now tries an
  additive `MergeOnto` before giving up when `RebaseOnto` fails. Only
  when the merge also fails (a real conflict) does it still surface
  `ErrRebaseFailed` for the caller to escalate — same as before.
- `MergeOnto` (`internal/project/git.go`) merges `ref` into the current
  branch. Unlike rebase it never rewrites existing commits, so the
  subsequent push (`PushSync`) is always a plain fast-forward — the
  remote SHA remains an ancestor of the merge commit, never needing
  `--force-with-lease`.
- Added `TestMergeOnto_MergesNonConflictingHistories` and
  `TestMergeOnto_ConflictReturnsErrorAndCleansUp` in `internal/project`,
  and `TestPrepareForTask_RebaseFailureRecoversViaMerge` in
  `internal/worktree` — the latter reproduces the intermediate-conflict-
  but-net-no-op scenario end to end through `PrepareForTask` (a branch
  that adds then reverts a line hits a patch-context mismatch during
  rebase even though its net content change doesn't overlap upstream's
  edit at all; merge resolves it cleanly).
- `mise run verify` passed in full (build, lint, `go test -race`
  including e2e, frontend check/coverage/oxlint, bindings sync,
  hadolint).

## Supporting documentation

Subissue of Automaat/sybra#1437 (umbrella: auto-recover stale branches
additively, no force-push). Scoped narrower than the original subissue
description (agent-assisted pre-PR recovery for genuine conflicts,
task-branch-keyed like the PR-fix path) — this covers the deterministic
merge-fallback case only, which is empirically the majority of
staleness observed in practice (every stuck task checked during this
investigation had zero real content conflicts once the coverage-report
noise was excluded). Agent-assisted recovery for genuine pre-PR
conflicts remains a narrower follow-up if still needed after this
lands.