### PR TITLE
feat(review): hold PR replies for human check

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -224,7 +224,7 @@ Per-machine toggle: enable on the machine where you review before publishing.
 | YAML key | Type | Default | Description |
 |---|---|---|---|
 | `review_hold.enabled` | `bool` |  | Enabled turns the hold on. Default off — preserves the live-reply behavior. |
-| `review_hold.mode` | `string` |  | Mode controls what the fix-review agent may push once its replies are held:   push       — reply held as a pending review; code fixes still committed                and pushed to the PR branch (default).   push_nits  — reply held; code pushed only when the diff is at most                NitMaxLines changed lines (a nit), otherwise held for review.   hold       — reply held AND code held; nothing is pushed, the human                reviews the diff too. Unknown/empty values fall back to "push". |
+| `review_hold.mode` | `string` |  | Mode controls what the fix-review agent may push once its replies are held:   push       — reply held as a pending review; code fixes still committed                and pushed to the PR branch (default).   push_nits  — reply held; code pushed only when the diff is at most                NitMaxLines changed lines (a nit), otherwise held for review.   hold       — reply held AND code held; nothing is pushed, the human                reviews the diff too. In a coalesced fix this also holds                bundled non-reply changes (e.g. a CI fix), so CI stays red                until the human pushes — the "review everything" tradeoff. Unknown/empty values fall back to "push". |
 | `review_hold.nit_max_lines` | `int` |  | NitMaxLines is the changed-line ceiling that still counts as a "nit" for the push_nits mode. Zero falls back to DefaultReviewHoldNitMaxLines. |
 
 ## MonitorConfig (`monitor`)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -29,6 +29,7 @@ machine.
 | `umbrella` | `UmbrellaConfig` | _(see below)_ |  |
 | `triage` | `TriageConfig` | _(see below)_ |  |
 | `human_review` | `HumanReviewConfig` | _(see below)_ |  |
+| `review_hold` | `ReviewHoldConfig` | _(see below)_ |  |
 | `monitor` | `MonitorConfig` | _(see below)_ |  |
 | `watchdog` | `WatchdogConfig` | _(see below)_ |  |
 | `self_monitor` | `SelfMonitorConfig` | _(see below)_ |  |
@@ -206,6 +207,25 @@ checkout, leave disabled on the server.
 | `human_review.max_per_hour` | `int` |  | MaxPerHour caps how many review agents may be spawned in any rolling 60-minute window across all tasks on this machine. Zero falls back to DefaultHumanReviewMaxPerHour. |
 | `human_review.issue_label` | `string` |  | IssueLabel is the label applied to filed issues (in addition to "bug"). Defaults to "sybra-bug". |
 | `human_review.sybra_bug_action` | `string` |  | SybraBugAction controls the side-effect for sybra_bug verdicts: file_issue (default), local_task, block_only, or note_only. |
+
+## ReviewHoldConfig (`review_hold`)
+
+ReviewHoldConfig gates whether Sybra may publish PR comment replies without a
+human check. When enabled, fix-review agents draft the replies they would
+have posted into a single PENDING (draft) pull-request review instead of
+posting live thread replies, never submit it, and the task is parked in
+human-required for the user to verify and submit on GitHub. Inbound reviews of
+a teammate's PR already work this way (a pending review + human-required); this
+extends the same gate to the reply/fix-review flow.
+
+Mode controls how far the hold extends to the agent's own code changes.
+Per-machine toggle: enable on the machine where you review before publishing.
+
+| YAML key | Type | Default | Description |
+|---|---|---|---|
+| `review_hold.enabled` | `bool` |  | Enabled turns the hold on. Default off — preserves the live-reply behavior. |
+| `review_hold.mode` | `string` |  | Mode controls what the fix-review agent may push once its replies are held:   push       — reply held as a pending review; code fixes still committed                and pushed to the PR branch (default).   push_nits  — reply held; code pushed only when the diff is at most                NitMaxLines changed lines (a nit), otherwise held for review.   hold       — reply held AND code held; nothing is pushed, the human                reviews the diff too. Unknown/empty values fall back to "push". |
+| `review_hold.nit_max_lines` | `int` |  | NitMaxLines is the changed-line ceiling that still counts as a "nit" for the push_nits mode. Zero falls back to DefaultReviewHoldNitMaxLines. |
 
 ## MonitorConfig (`monitor`)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	Umbrella       UmbrellaConfig       `yaml:"umbrella" json:"umbrella"`
 	Triage         TriageConfig         `yaml:"triage" json:"triage"`
 	HumanReview    HumanReviewConfig    `yaml:"human_review" json:"humanReview"`
+	ReviewHold     ReviewHoldConfig     `yaml:"review_hold" json:"reviewHold"`
 	Monitor        MonitorConfig        `yaml:"monitor" json:"monitor"`
 	Watchdog       WatchdogConfig       `yaml:"watchdog" json:"watchdog"`
 	SelfMonitor    SelfMonitorConfig    `yaml:"self_monitor" json:"selfMonitor"`

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -467,8 +467,66 @@ func Load() (*Config, error) {
 	applyABTestingDefaults(cfg)
 	applyOrchestratorDefaults(cfg)
 	applyAutoUpdateDefaults(cfg)
+	applyReviewHoldDefaults(cfg)
 
 	return cfg, nil
+}
+
+// Review-hold modes control how far the hold extends to the fix-review agent's
+// own code changes once its replies are drafted into a pending review.
+const (
+	ReviewHoldModePush     = "push"      // reply held; code still pushed
+	ReviewHoldModePushNits = "push_nits" // reply held; code pushed only when a nit
+	ReviewHoldModeHold     = "hold"      // reply held; code held too (no push)
+
+	DefaultReviewHoldMode        = ReviewHoldModePush
+	DefaultReviewHoldNitMaxLines = 10
+)
+
+// applyReviewHoldDefaults fills the mode/threshold only when the hold is
+// enabled, so a disabled block stays at its zero value (and off).
+func applyReviewHoldDefaults(cfg *Config) {
+	if !cfg.ReviewHold.Enabled {
+		return
+	}
+	if !validReviewHoldMode(cfg.ReviewHold.Mode) {
+		cfg.ReviewHold.Mode = DefaultReviewHoldMode
+	}
+	if cfg.ReviewHold.NitMaxLines <= 0 {
+		cfg.ReviewHold.NitMaxLines = DefaultReviewHoldNitMaxLines
+	}
+}
+
+func validReviewHoldMode(mode string) bool {
+	switch mode {
+	case ReviewHoldModePush, ReviewHoldModePushNits, ReviewHoldModeHold:
+		return true
+	default:
+		return false
+	}
+}
+
+// ReviewHoldEnabled reports whether Sybra must draft PR comment replies as a
+// pending review instead of posting them live. Nil-safe for test construction.
+func (c *Config) ReviewHoldEnabled() bool {
+	return c != nil && c.ReviewHold.Enabled
+}
+
+// ReviewHoldMode returns the resolved hold mode, falling back to the default for
+// empty/unknown values so callers never branch on an invalid mode.
+func (c *Config) ReviewHoldMode() string {
+	if c == nil || !validReviewHoldMode(c.ReviewHold.Mode) {
+		return DefaultReviewHoldMode
+	}
+	return c.ReviewHold.Mode
+}
+
+// ReviewHoldNitMaxLines returns the resolved nit ceiling for push_nits mode.
+func (c *Config) ReviewHoldNitMaxLines() int {
+	if c == nil || c.ReviewHold.NitMaxLines <= 0 {
+		return DefaultReviewHoldNitMaxLines
+	}
+	return c.ReviewHold.NitMaxLines
 }
 
 func applyExperienceDefaults(cfg *Config) {

--- a/internal/config/config_reviewhold.go
+++ b/internal/config/config_reviewhold.go
@@ -19,7 +19,9 @@ type ReviewHoldConfig struct {
 	//   push_nits  — reply held; code pushed only when the diff is at most
 	//                NitMaxLines changed lines (a nit), otherwise held for review.
 	//   hold       — reply held AND code held; nothing is pushed, the human
-	//                reviews the diff too.
+	//                reviews the diff too. In a coalesced fix this also holds
+	//                bundled non-reply changes (e.g. a CI fix), so CI stays red
+	//                until the human pushes — the "review everything" tradeoff.
 	// Unknown/empty values fall back to "push".
 	Mode string `yaml:"mode" json:"mode"`
 	// NitMaxLines is the changed-line ceiling that still counts as a "nit" for

--- a/internal/config/config_reviewhold.go
+++ b/internal/config/config_reviewhold.go
@@ -1,0 +1,28 @@
+package config
+
+// ReviewHoldConfig gates whether Sybra may publish PR comment replies without a
+// human check. When enabled, fix-review agents draft the replies they would
+// have posted into a single PENDING (draft) pull-request review instead of
+// posting live thread replies, never submit it, and the task is parked in
+// human-required for the user to verify and submit on GitHub. Inbound reviews of
+// a teammate's PR already work this way (a pending review + human-required); this
+// extends the same gate to the reply/fix-review flow.
+//
+// Mode controls how far the hold extends to the agent's own code changes.
+// Per-machine toggle: enable on the machine where you review before publishing.
+type ReviewHoldConfig struct {
+	// Enabled turns the hold on. Default off — preserves the live-reply behavior.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+	// Mode controls what the fix-review agent may push once its replies are held:
+	//   push       — reply held as a pending review; code fixes still committed
+	//                and pushed to the PR branch (default).
+	//   push_nits  — reply held; code pushed only when the diff is at most
+	//                NitMaxLines changed lines (a nit), otherwise held for review.
+	//   hold       — reply held AND code held; nothing is pushed, the human
+	//                reviews the diff too.
+	// Unknown/empty values fall back to "push".
+	Mode string `yaml:"mode" json:"mode"`
+	// NitMaxLines is the changed-line ceiling that still counts as a "nit" for
+	// the push_nits mode. Zero falls back to DefaultReviewHoldNitMaxLines.
+	NitMaxLines int `yaml:"nit_max_lines" json:"nitMaxLines"`
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -346,6 +346,74 @@ func TestHumanReviewSybraBugAction(t *testing.T) {
 	}
 }
 
+func TestReviewHoldDefaults(t *testing.T) {
+	cases := []struct {
+		name        string
+		yaml        string
+		wantEnabled bool
+		wantMode    string
+		wantNit     int
+	}{
+		{
+			name:        "absent block is disabled",
+			yaml:        "logging:\n  level: info\n",
+			wantEnabled: false,
+			wantMode:    ReviewHoldModePush, // accessor falls back even when off
+			wantNit:     DefaultReviewHoldNitMaxLines,
+		},
+		{
+			name:        "enabled with empty mode defaults to push and nit ceiling",
+			yaml:        "review_hold:\n  enabled: true\n",
+			wantEnabled: true,
+			wantMode:    ReviewHoldModePush,
+			wantNit:     DefaultReviewHoldNitMaxLines,
+		},
+		{
+			name:        "invalid mode falls back to push",
+			yaml:        "review_hold:\n  enabled: true\n  mode: bogus\n",
+			wantEnabled: true,
+			wantMode:    ReviewHoldModePush,
+			wantNit:     DefaultReviewHoldNitMaxLines,
+		},
+		{
+			name:        "push_nits mode preserves an explicit threshold",
+			yaml:        "review_hold:\n  enabled: true\n  mode: push_nits\n  nit_max_lines: 42\n",
+			wantEnabled: true,
+			wantMode:    ReviewHoldModePushNits,
+			wantNit:     42,
+		},
+		{
+			name:        "hold mode is preserved",
+			yaml:        "review_hold:\n  enabled: true\n  mode: hold\n",
+			wantEnabled: true,
+			wantMode:    ReviewHoldModeHold,
+			wantNit:     DefaultReviewHoldNitMaxLines,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("SYBRA_HOME", dir)
+			if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte(tc.yaml), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := Load()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := cfg.ReviewHoldEnabled(); got != tc.wantEnabled {
+				t.Errorf("ReviewHoldEnabled() = %v, want %v", got, tc.wantEnabled)
+			}
+			if got := cfg.ReviewHoldMode(); got != tc.wantMode {
+				t.Errorf("ReviewHoldMode() = %q, want %q", got, tc.wantMode)
+			}
+			if got := cfg.ReviewHoldNitMaxLines(); got != tc.wantNit {
+				t.Errorf("ReviewHoldNitMaxLines() = %d, want %d", got, tc.wantNit)
+			}
+		})
+	}
+}
+
 func TestLoadWatchdogDefaults(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -290,37 +290,47 @@ func (h *AgentCompletionHandler) markCompletedReview(ag *agent.Agent, exitErr er
 	}
 }
 
-// handleFixReviewCompletion routes a finished manual fix-review agent. Under
-// review-hold the agent drafted its replies into a pending review and owns the
-// push decision per the configured mode, so Sybra must not force a push — it
-// parks the task for a human instead. Otherwise it auto-pushes the branch as
-// before.
+// handleFixReviewCompletion routes a finished manual fix-review agent. Without
+// the hold it auto-pushes the branch as before. Under review-hold the agent
+// drafted its replies into a pending review; Sybra still runs the deterministic
+// push backstop in `push` mode so a fix isn't stranded when the agent forgot to
+// push, then parks the task for a human. In `push_nits`/`hold` the push is
+// conditional/none and owned by the agent per its prompt (a blind backstop would
+// push a non-nit diff or break the "hold everything" contract), so Sybra parks
+// without forcing one.
 func (h *AgentCompletionHandler) handleFixReviewCompletion(ag *agent.Agent) {
-	if h.cfg.ReviewHoldEnabled() {
-		h.holdFixReviewForHuman(ag)
+	if !h.cfg.ReviewHoldEnabled() {
+		h.pushFixReviewBranch(ag)
 		return
 	}
-	h.pushFixReviewBranch(ag)
+	if h.cfg.ReviewHoldMode() == config.ReviewHoldModePush {
+		h.pushFixReviewBranch(ag)
+	}
+	h.holdFixReviewForHuman(ag)
 }
 
 // holdFixReviewForHuman parks a completed manual fix-review task in
-// human-required instead of auto-pushing its branch. Under review-hold the agent
-// has drafted its replies into a pending review (never posted live) and decided
-// the push itself per the configured mode, so the human verifies the pending
-// review and any local diff, then submits on GitHub.
+// human-required. Under review-hold the agent has drafted its replies into a
+// pending review (never posted live), so the human verifies the pending review
+// and any local diff, then submits on GitHub. Logs the mode and branch so a
+// stranded fix is diagnosable — whether a push was expected (push vs hold) and
+// which branch may hold unpushed commits.
 func (h *AgentCompletionHandler) holdFixReviewForHuman(ag *agent.Agent) {
 	if h.tasks == nil {
 		return
 	}
 	const reason = "review-hold: replies drafted as a pending review — verify & submit on GitHub"
-	if _, err := h.tasks.Update(ag.TaskID, task.Update{
+	t, err := h.tasks.Update(ag.TaskID, task.Update{
 		Status:       task.Ptr(task.StatusHumanRequired),
 		StatusReason: task.Ptr(reason),
-	}); err != nil {
+	})
+	if err != nil {
 		h.logger.Error("fix-review.hold.human-required", "task_id", ag.TaskID, "agent_id", ag.ID, "err", err)
 		return
 	}
-	h.logger.Info("fix-review.hold", "task_id", ag.TaskID, "agent_id", ag.ID)
+	h.logger.Info("fix-review.hold",
+		"task_id", ag.TaskID, "agent_id", ag.ID,
+		"mode", h.cfg.ReviewHoldMode(), "branch", t.Branch)
 }
 
 func (h *AgentCompletionHandler) pushFixReviewBranch(ag *agent.Agent) {

--- a/internal/sybra/agent_completion.go
+++ b/internal/sybra/agent_completion.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Automaat/sybra/internal/agent"
 	"github.com/Automaat/sybra/internal/audit"
+	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/limits"
 	"github.com/Automaat/sybra/internal/loopagent"
@@ -49,6 +50,7 @@ func (a *App) newAgentCompletionHandler(emit func(string, any)) *AgentCompletion
 		loopSched:      a.loopSched,
 		humanReview:    a.humanReview,
 		prTracker:      a.prTracker,
+		cfg:            a.cfg,
 	}
 }
 
@@ -73,6 +75,7 @@ type AgentCompletionHandler struct {
 	loopSched      *loopagent.Scheduler
 	humanReview    *humanReviewHandler
 	prTracker      *github.IssueTracker
+	cfg            *config.Config
 }
 
 // OnComplete is called by the manager's construction-time completion callback.
@@ -190,7 +193,7 @@ func (h *AgentCompletionHandler) OnComplete(ag *agent.Agent) {
 	}
 
 	if agent.RoleFromName(ag.Name) == agent.RoleFixReview && exitErr == nil {
-		h.pushFixReviewBranch(ag)
+		h.handleFixReviewCompletion(ag)
 	}
 
 	if !h.notifyWorkflowEngine(ag, resultContent, exitErr) {
@@ -285,6 +288,39 @@ func (h *AgentCompletionHandler) markCompletedReview(ag *agent.Agent, exitErr er
 	if _, err := h.tasks.Update(ag.TaskID, task.Update{Reviewed: &reviewed}); err != nil {
 		h.logger.Warn("task.mark-reviewed", "task_id", ag.TaskID, "agent_id", ag.ID, "err", err)
 	}
+}
+
+// handleFixReviewCompletion routes a finished manual fix-review agent. Under
+// review-hold the agent drafted its replies into a pending review and owns the
+// push decision per the configured mode, so Sybra must not force a push — it
+// parks the task for a human instead. Otherwise it auto-pushes the branch as
+// before.
+func (h *AgentCompletionHandler) handleFixReviewCompletion(ag *agent.Agent) {
+	if h.cfg.ReviewHoldEnabled() {
+		h.holdFixReviewForHuman(ag)
+		return
+	}
+	h.pushFixReviewBranch(ag)
+}
+
+// holdFixReviewForHuman parks a completed manual fix-review task in
+// human-required instead of auto-pushing its branch. Under review-hold the agent
+// has drafted its replies into a pending review (never posted live) and decided
+// the push itself per the configured mode, so the human verifies the pending
+// review and any local diff, then submits on GitHub.
+func (h *AgentCompletionHandler) holdFixReviewForHuman(ag *agent.Agent) {
+	if h.tasks == nil {
+		return
+	}
+	const reason = "review-hold: replies drafted as a pending review — verify & submit on GitHub"
+	if _, err := h.tasks.Update(ag.TaskID, task.Update{
+		Status:       task.Ptr(task.StatusHumanRequired),
+		StatusReason: task.Ptr(reason),
+	}); err != nil {
+		h.logger.Error("fix-review.hold.human-required", "task_id", ag.TaskID, "agent_id", ag.ID, "err", err)
+		return
+	}
+	h.logger.Info("fix-review.hold", "task_id", ag.TaskID, "agent_id", ag.ID)
 }
 
 func (h *AgentCompletionHandler) pushFixReviewBranch(ag *agent.Agent) {

--- a/internal/sybra/app_reviews_coalesce_test.go
+++ b/internal/sybra/app_reviews_coalesce_test.go
@@ -42,7 +42,7 @@ func TestCoalescedFixPrompt(t *testing.T) {
 	t.Parallel()
 	pr := github.PullRequest{Number: 7, Repository: "o/r", HeadRefName: "feat", URL: "https://github.com/o/r/pull/7"}
 
-	single := coalescedFixPrompt([]github.PRIssue{{Kind: github.PRIssueComments, PR: pr}})
+	single := coalescedFixPrompt([]github.PRIssue{{Kind: github.PRIssueComments, PR: pr}}, "")
 	if strings.Contains(single, "multiple open issues") {
 		t.Errorf("single-issue prompt must not carry the coalesced header:\n%s", single)
 	}
@@ -53,11 +53,37 @@ func TestCoalescedFixPrompt(t *testing.T) {
 	multi := coalescedFixPrompt([]github.PRIssue{
 		{Kind: github.PRIssueCIFailure, PR: pr},
 		{Kind: github.PRIssueComments, PR: pr},
-	})
+	}, "")
 	for _, want := range []string{"multiple open issues", "Failing CI", "Review comments", "/fix-review", "gh run view"} {
 		if !strings.Contains(multi, want) {
 			t.Errorf("coalesced prompt missing %q:\n%s", want, multi)
 		}
+	}
+}
+
+// TestCoalescedFixPrompt_ReviewHold locks how the review-hold suffix is grafted
+// on: appended once (at the end, after the reply-live instructions it overrides)
+// when the set includes a comments issue, and suppressed entirely when it does
+// not — a lone CI/conflict fix posts no replies, so it must stay unchanged.
+func TestCoalescedFixPrompt_ReviewHold(t *testing.T) {
+	t.Parallel()
+	pr := github.PullRequest{Number: 7, Repository: "o/r", HeadRefName: "feat", URL: "https://github.com/o/r/pull/7"}
+	const suffix = "\n\n---\nREVIEW HOLD sentinel"
+
+	withComments := coalescedFixPrompt([]github.PRIssue{{Kind: github.PRIssueComments, PR: pr}}, suffix)
+	if !strings.HasSuffix(withComments, suffix) {
+		t.Errorf("comments prompt must end with the hold suffix:\n%s", withComments)
+	}
+
+	noComments := coalescedFixPrompt([]github.PRIssue{{Kind: github.PRIssueCIFailure, PR: pr}}, suffix)
+	if strings.Contains(noComments, "REVIEW HOLD") {
+		t.Errorf("a non-comments fix posts no replies, so it must not carry the hold suffix:\n%s", noComments)
+	}
+
+	// Disabled hold (empty suffix) leaves a comments prompt byte-for-byte as-is.
+	plain := coalescedFixPrompt([]github.PRIssue{{Kind: github.PRIssueComments, PR: pr}}, "")
+	if strings.Contains(plain, "REVIEW HOLD") {
+		t.Errorf("empty suffix must not alter the prompt:\n%s", plain)
 	}
 }
 

--- a/internal/sybra/app_reviews_coalesce_test.go
+++ b/internal/sybra/app_reviews_coalesce_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/workflow"
@@ -58,6 +59,79 @@ func TestCoalescedFixPrompt(t *testing.T) {
 		if !strings.Contains(multi, want) {
 			t.Errorf("coalesced prompt missing %q:\n%s", want, multi)
 		}
+	}
+}
+
+// TestDispatchFixIssues_ReviewHoldSetsParkVar is the regression guard for the
+// blocking review finding: relying on the prompt sentinel is unsafe because
+// dispatchPRIssue appends prFixResultContract AFTER the hold suffix, and in push
+// mode the agent pushes and emits `continue`, which classifyPRFixResult would
+// pick as the last sentinel. So parking must be deterministic — a review-hold +
+// comments dispatch sets the ReviewHoldParkVar workflow var that
+// route_pr_fix_result honors regardless of agent output.
+func TestDispatchFixIssues_ReviewHoldSetsParkVar(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := task.NewStore(filepath.Join(tmp, "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := slog.New(slog.DiscardHandler)
+	wfStore, err := workflow.NewStore(filepath.Join(tmp, "workflows"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wfStore.Dir(), "test-pr-fix.yaml"),
+		[]byte(mechanicalPRFixYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
+	engine := workflow.NewEngine(
+		wfStore,
+		&taskAdapter{tasks: tasks},
+		&agentAdapter{agents: agentMgr, tasks: tasks},
+		logger,
+	)
+
+	created, err := tasks.Create("ship it", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:   task.Ptr(task.StatusInReview),
+		PRNumber: task.Ptr(1446),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &ReviewHandler{
+		DomainHandler:  DomainHandler{logger: logger},
+		tasks:          tasks,
+		agents:         agentMgr,
+		prTracker:      github.NewIssueTracker(time.Minute),
+		workflowEngine: engine,
+		// push mode: the agent pushes and would emit `continue`; the park var
+		// must still force human-required.
+		cfg: &config.Config{ReviewHold: config.ReviewHoldConfig{Enabled: true, Mode: config.ReviewHoldModePush}},
+	}
+
+	pr := github.PullRequest{
+		Number: 1446, Repository: "o/r", HeadRefName: "feat", HeadSHA: "sha1",
+		URL: "https://github.com/o/r/pull/1446", FeedbackSig: "sig",
+	}
+	r.handleMatchedPRIssues(context.Background(), []github.PRIssue{
+		{Kind: github.PRIssueComments, TaskID: created.ID, PR: pr},
+	})
+
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow == nil {
+		t.Fatal("no workflow dispatched")
+	}
+	if v := got.Workflow.Variables[workflow.ReviewHoldParkVar]; v != "true" {
+		t.Errorf("%s = %q, want \"true\" (deterministic park backstop must be set)", workflow.ReviewHoldParkVar, v)
 	}
 }
 

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -435,6 +435,17 @@ func (r *ReviewHandler) dispatchPRIssue(t task.Task, primary github.PRIssue, han
 		"pr_issue_kinds":        strings.Join(kinds, ","),
 		workflow.WorkflowVarDir: dir,
 	}
+	// Deterministic backstop for review-hold: when the hold is active and this
+	// fix touches review comments, the agent drafted its replies into a pending
+	// review, so route_pr_fix_result must park the task for a human regardless of
+	// the agent's terminal sentinel (in push mode it pushed and would otherwise
+	// emit `continue`). Relying on the prompt sentinel alone is unsafe — the
+	// prFixResultContract appended after the hold suffix re-introduces `continue`.
+	if r.cfg.ReviewHoldEnabled() && slices.ContainsFunc(handle, func(i github.PRIssue) bool {
+		return i.Kind == github.PRIssueComments
+	}) {
+		vars[workflow.ReviewHoldParkVar] = "true"
+	}
 	wfID, err := r.workflowEngine.DispatchEvent(t.ID, "pr.event",
 		map[string]string{"pr.issue_kind": string(primary.Kind)}, vars)
 	if err != nil {

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -343,23 +343,35 @@ func (r *ReviewHandler) logPRIssueDetected(taskID string, issue github.PRIssue) 
 // per-kind prompt (behavior unchanged); multiple issues — e.g. a push that both
 // fails CI and drew review comments — are stitched into one pass so exactly one
 // agent runs per review round instead of one agent per kind across cycles.
-func coalescedFixPrompt(issues []github.PRIssue) string {
+//
+// holdSuffix (from reviewHoldFixSuffix) is appended once at the end when the
+// review-hold setting is on AND the set includes a review-comments issue — the
+// only kind that posts thread replies. It overrides the "reply live and push"
+// instructions above, so it must land after them.
+func coalescedFixPrompt(issues []github.PRIssue, holdSuffix string) string {
+	var prompt string
 	if len(issues) == 1 {
-		body, _ := prIssueBody(issues[0])
-		return body
-	}
-	var b strings.Builder
-	b.WriteString("This PR has multiple open issues from the same push. Address " +
-		"ALL of them in one pass, then push once at the end (the per-section push " +
-		"commands are equivalent — run it a single time).\n\n")
-	for i := range issues {
-		body, ok := prIssueBody(issues[i])
-		if !ok {
-			continue
+		prompt, _ = prIssueBody(issues[0])
+	} else {
+		var b strings.Builder
+		b.WriteString("This PR has multiple open issues from the same push. Address " +
+			"ALL of them in one pass, then push once at the end (the per-section push " +
+			"commands are equivalent — run it a single time).\n\n")
+		for i := range issues {
+			body, ok := prIssueBody(issues[i])
+			if !ok {
+				continue
+			}
+			fmt.Fprintf(&b, "=== Issue %d: %s ===\n%s\n\n", i+1, fixKindLabel(issues[i].Kind), body)
 		}
-		fmt.Fprintf(&b, "=== Issue %d: %s ===\n%s\n\n", i+1, fixKindLabel(issues[i].Kind), body)
+		prompt = strings.TrimRight(b.String(), "\n")
 	}
-	return strings.TrimRight(b.String(), "\n")
+	if holdSuffix != "" && slices.ContainsFunc(issues, func(i github.PRIssue) bool {
+		return i.Kind == github.PRIssueComments
+	}) {
+		prompt += holdSuffix
+	}
+	return prompt
 }
 
 func (r *ReviewHandler) handlePRIssue(ctx context.Context, issue github.PRIssue) bool {
@@ -396,7 +408,7 @@ func (r *ReviewHandler) dispatchFixIssues(ctx context.Context, taskID string, ha
 	// dispatchPRIssue -> workflowEngine.DispatchEvent eventually reaches
 	// execShell, which derives its context from workflow.Engine's own e.ctx
 	// field (Engine.SetContext), not an explicit parameter threaded here.
-	return r.dispatchPRIssue(t, primary, handle, coalescedFixPrompt(handle), dir) //nolint:contextcheck // Engine uses its own e.ctx field, see comment above
+	return r.dispatchPRIssue(t, primary, handle, coalescedFixPrompt(handle, reviewHoldFixSuffix(r.cfg)), dir) //nolint:contextcheck // Engine uses its own e.ctx field, see comment above
 }
 
 // dispatchPRIssue starts the pr-fix workflow for primary and, on success, marks

--- a/internal/sybra/app_reviews_inbound.go
+++ b/internal/sybra/app_reviews_inbound.go
@@ -108,7 +108,7 @@ func (r *ReviewHandler) startFixReviewAgent(t task.Task) error {
 			"`fix(review): address PR review comments` (type(scope) required by repo hooks). "+
 			"Sign the commit with `git commit -s -S`. Push the branch when done.",
 		t.ProjectID, t.PRNumber,
-	)
+	) + reviewHoldFixSuffix(r.cfg)
 
 	ag, err := r.agents.Run(agent.RunConfig{
 		TaskID:                 t.ID,

--- a/internal/sybra/app_test.go
+++ b/internal/sybra/app_test.go
@@ -414,6 +414,78 @@ func TestOnAgentComplete_FixReviewPushesBranch(t *testing.T) {
 	}
 }
 
+// TestOnAgentComplete_FixReviewHoldParksForHuman locks the review-hold branch of
+// the manual fix-review path: the task is parked in human-required for the user
+// to verify and submit the pending review, rather than following the auto-push
+// path (which never touches status). The push decision is owned by the agent per
+// the configured mode, so Sybra runs no force-push here.
+func TestOnAgentComplete_FixReviewHoldParksForHuman(t *testing.T) {
+	h, taskMgr, _ := setupFixReviewPushTest(t)
+	h.cfg = &config.Config{ReviewHold: config.ReviewHoldConfig{
+		Enabled: true, Mode: config.ReviewHoldModeHold,
+	}}
+
+	tk, err := taskMgr.Create("fix pr", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tk, err = taskMgr.Update(tk.ID, task.Update{
+		ProjectID: task.Ptr("testowner/testrepo"),
+		PRNumber:  task.Ptr(42),
+		Status:    task.Ptr(task.StatusInReview),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wtPath, err := h.worktrees.PrepareForFix(context.Background(), tk, 42)
+	if err != nil {
+		t.Fatalf("PrepareForFix: %v", err)
+	}
+	for _, args := range [][]string{
+		{"-C", wtPath, "config", "user.email", "test@test.com"},
+		{"-C", wtPath, "config", "user.name", "Test"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(wtPath, "README.md"), []byte("# updated\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"-C", wtPath, "add", "."},
+		{"-C", wtPath, "commit", "-m", "fix(review): update pr"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+
+	if err := taskMgr.AddRun(tk.ID, task.AgentRun{
+		AgentID: "agent-1", Role: string(agent.RoleFixReview), Mode: "headless",
+		State: string(agent.StateRunning), StartedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	h.OnComplete(&agent.Agent{
+		ID:        "agent-1",
+		TaskID:    tk.ID,
+		Mode:      "headless",
+		Name:      agent.RoleFixReview.AgentName(tk.Title),
+		StartedAt: time.Now(),
+	})
+
+	got, err := taskMgr.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusHumanRequired)
+	}
+}
+
 func TestNewApp(t *testing.T) {
 	cfg := testConfig(t)
 	a := NewApp(discardLogger(), &slog.LevelVar{}, cfg)

--- a/internal/sybra/review_hold.go
+++ b/internal/sybra/review_hold.go
@@ -1,0 +1,44 @@
+package sybra
+
+import (
+	"fmt"
+
+	"github.com/Automaat/sybra/internal/config"
+)
+
+// reviewHoldFixSuffix returns the instruction block appended to a fix-review
+// agent's prompt when the review-hold setting is on. It converts the agent's
+// default "reply live on every thread and push" behavior into "draft the replies
+// into one PENDING review, don't submit, and park the task for a human". The
+// push clause varies by mode. Returns "" when the hold is disabled, so prompts
+// stay byte-for-byte unchanged in the common case. Nil-safe (nil cfg = disabled).
+func reviewHoldFixSuffix(cfg *config.Config) string {
+	if !cfg.ReviewHoldEnabled() {
+		return ""
+	}
+
+	var push string
+	switch cfg.ReviewHoldMode() {
+	case config.ReviewHoldModeHold:
+		push = "- Do NOT push. Commit your code fixes locally only (or leave them " +
+			"uncommitted) so a human reviews the diff before anything reaches the PR branch."
+	case config.ReviewHoldModePushNits:
+		push = fmt.Sprintf("- Push your code fixes ONLY if the whole diff is at most %d "+
+			"changed lines (a nit). If it is larger, commit locally but do NOT push — "+
+			"leave the branch for a human to review.", cfg.ReviewHoldNitMaxLines())
+	default: // ReviewHoldModePush
+		push = "- Push your code fixes to the PR branch as usual."
+	}
+
+	return "\n\n---\n" +
+		"REVIEW HOLD is enabled — do NOT publish anything to the PR without a human check.\n" +
+		"- Do NOT post live thread replies. Do NOT run `gh pr review`, and never submit, " +
+		"approve, or request changes.\n" +
+		"- Instead, collect every reply you would have posted and attach them to a SINGLE " +
+		"PENDING (draft) pull-request review, left UNSUBMITTED — create the pending review " +
+		"and add each thread reply to it (e.g. `gh api graphql` `addPullRequestReview` with " +
+		"no event, then `addPullRequestReviewComment` with `inReplyTo` per thread). Leave it pending.\n" +
+		push + "\n" +
+		"- When done, end your final message with `SYBRA_PR_FIX_RESULT: human-required` and " +
+		"`SYBRA_PR_FIX_REASON: replies drafted as a pending review — awaiting human check`."
+}

--- a/internal/sybra/review_hold.go
+++ b/internal/sybra/review_hold.go
@@ -20,8 +20,12 @@ func reviewHoldFixSuffix(cfg *config.Config) string {
 	var push string
 	switch cfg.ReviewHoldMode() {
 	case config.ReviewHoldModeHold:
-		push = "- Do NOT push. Commit your code fixes locally only (or leave them " +
-			"uncommitted) so a human reviews the diff before anything reaches the PR branch."
+		// hold also holds any non-reply code fix in a coalesced set (e.g. a
+		// bundled CI fix), so CI stays red until a human pushes — the intended
+		// "human reviews everything" tradeoff.
+		push = "- Do NOT push anything — not even a bundled CI or conflict fix. Commit your " +
+			"changes locally only (or leave them uncommitted) so a human reviews the whole " +
+			"diff before it reaches the PR branch."
 	case config.ReviewHoldModePushNits:
 		push = fmt.Sprintf("- Push your code fixes ONLY if the whole diff is at most %d "+
 			"changed lines (a nit). If it is larger, commit locally but do NOT push — "+
@@ -39,6 +43,6 @@ func reviewHoldFixSuffix(cfg *config.Config) string {
 		"and add each thread reply to it (e.g. `gh api graphql` `addPullRequestReview` with " +
 		"no event, then `addPullRequestReviewComment` with `inReplyTo` per thread). Leave it pending.\n" +
 		push + "\n" +
-		"- When done, end your final message with `SYBRA_PR_FIX_RESULT: human-required` and " +
-		"`SYBRA_PR_FIX_REASON: replies drafted as a pending review — awaiting human check`."
+		"- Sybra parks the task in human-required automatically; do not re-request review, " +
+		"submit the review, or merge. A human verifies the pending review and submits it."
 }

--- a/internal/sybra/review_hold_test.go
+++ b/internal/sybra/review_hold_test.go
@@ -11,18 +11,23 @@ func TestReviewHoldFixSuffix(t *testing.T) {
 	t.Parallel()
 
 	// Common assertions for any enabled suffix: never post live, draft a pending
-	// review, and end with the human-required sentinel that routes the task.
+	// review, and note that Sybra parks the task (routing is deterministic — the
+	// suffix must not itself instruct a sentinel that the appended contract can
+	// override).
 	assertEnabled := func(t *testing.T, s string) {
 		t.Helper()
 		for _, want := range []string{
 			"REVIEW HOLD",
 			"Do NOT post live thread replies",
 			"PENDING",
-			"SYBRA_PR_FIX_RESULT: human-required",
+			"human-required",
 		} {
 			if !strings.Contains(s, want) {
 				t.Errorf("suffix missing %q:\n%s", want, s)
 			}
+		}
+		if strings.Contains(s, "SYBRA_PR_FIX_RESULT") {
+			t.Errorf("suffix must not instruct the result sentinel (routing is deterministic):\n%s", s)
 		}
 	}
 

--- a/internal/sybra/review_hold_test.go
+++ b/internal/sybra/review_hold_test.go
@@ -1,0 +1,95 @@
+package sybra
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/config"
+)
+
+func TestReviewHoldFixSuffix(t *testing.T) {
+	t.Parallel()
+
+	// Common assertions for any enabled suffix: never post live, draft a pending
+	// review, and end with the human-required sentinel that routes the task.
+	assertEnabled := func(t *testing.T, s string) {
+		t.Helper()
+		for _, want := range []string{
+			"REVIEW HOLD",
+			"Do NOT post live thread replies",
+			"PENDING",
+			"SYBRA_PR_FIX_RESULT: human-required",
+		} {
+			if !strings.Contains(s, want) {
+				t.Errorf("suffix missing %q:\n%s", want, s)
+			}
+		}
+	}
+
+	tests := []struct {
+		name    string
+		cfg     *config.Config
+		enabled bool
+		wantIn  []string
+		notIn   []string
+	}{
+		{
+			name:    "nil config is disabled",
+			cfg:     nil,
+			enabled: false,
+		},
+		{
+			name:    "disabled block yields empty suffix",
+			cfg:     &config.Config{},
+			enabled: false,
+		},
+		{
+			name:    "push mode still pushes",
+			cfg:     &config.Config{ReviewHold: config.ReviewHoldConfig{Enabled: true, Mode: config.ReviewHoldModePush}},
+			enabled: true,
+			wantIn:  []string{"Push your code fixes to the PR branch as usual"},
+		},
+		{
+			name:    "hold mode blocks the push",
+			cfg:     &config.Config{ReviewHold: config.ReviewHoldConfig{Enabled: true, Mode: config.ReviewHoldModeHold}},
+			enabled: true,
+			wantIn:  []string{"Do NOT push"},
+		},
+		{
+			name:    "push_nits mode names the resolved threshold",
+			cfg:     &config.Config{ReviewHold: config.ReviewHoldConfig{Enabled: true, Mode: config.ReviewHoldModePushNits, NitMaxLines: 25}},
+			enabled: true,
+			wantIn:  []string{"at most 25", "ONLY if"},
+		},
+		{
+			name:    "empty mode falls back to push",
+			cfg:     &config.Config{ReviewHold: config.ReviewHoldConfig{Enabled: true}},
+			enabled: true,
+			wantIn:  []string{"as usual"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := reviewHoldFixSuffix(tt.cfg)
+			if !tt.enabled {
+				if got != "" {
+					t.Fatalf("disabled hold must yield empty suffix, got:\n%s", got)
+				}
+				return
+			}
+			assertEnabled(t, got)
+			for _, want := range tt.wantIn {
+				if !strings.Contains(got, want) {
+					t.Errorf("suffix missing %q:\n%s", want, got)
+				}
+			}
+			for _, no := range tt.notIn {
+				if strings.Contains(got, no) {
+					t.Errorf("suffix unexpectedly contains %q:\n%s", no, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/workflow/engine_steps_prfix.go
+++ b/internal/workflow/engine_steps_prfix.go
@@ -9,8 +9,25 @@ import (
 var prFixSentinelRe = regexp.MustCompile(`(?im)^SYBRA_PR_FIX_RESULT:\s*([a-z_-]+)\s*$`)
 var prFixReasonRe = regexp.MustCompile(`(?im)^SYBRA_PR_FIX_REASON:\s*(.+?)\s*$`)
 
+// ReviewHoldParkVar, when set to "true" on the execution, forces the pr-fix
+// result to human-required regardless of the agent's sentinel. It's a
+// deterministic backstop for the review-hold setting: the fix-review agent
+// drafted its replies into a pending review, so the task must park for a human
+// to submit even if the agent (correctly, in push mode) reported that it pushed
+// and would otherwise route to `continue`. Set by the dispatcher when the hold
+// is active and the handled issue set includes review comments.
+const ReviewHoldParkVar = "review_hold_park"
+
+const reviewHoldParkReason = "review-hold: replies drafted as a pending review — verify & submit on GitHub"
+
 func (e *Engine) execRoutePRFixResult(taskID string, step *Step, wfExec *Execution) (StepOutput, error) {
 	requiresHuman, reason := prFixRequiresHuman(wfExec)
+	// Deterministic park wins over the sentinel: in push mode the agent pushed
+	// and its own sentinel says `continue`, which must NOT release the hold.
+	if !requiresHuman && wfExec != nil && wfExec.Variables[ReviewHoldParkVar] == "true" {
+		requiresHuman = true
+		reason = reviewHoldParkReason
+	}
 	if !requiresHuman {
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "continue"}, nil
 	}

--- a/internal/workflow/engine_steps_prfix_test.go
+++ b/internal/workflow/engine_steps_prfix_test.go
@@ -113,6 +113,46 @@ func TestExecRoutePRFixResult_HumanRequiredStopsBeforeRelink(t *testing.T) {
 	}
 }
 
+func TestExecRoutePRFixResult_ReviewHoldParkWinsOverContinue(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	// The agent pushed in review-hold push mode and reported `continue`; the
+	// deterministic park var must still route the task to human-required so the
+	// drafted pending review isn't silently left unsubmitted.
+	wf := &Execution{
+		WorkflowID:  "pr-fix",
+		CurrentStep: "route_pr_fix_result",
+		State:       ExecRunning,
+		StepHistory: []StepRecord{{
+			StepID:    "fix",
+			Status:    "completed",
+			Output:    "Pushed the fix.\nSYBRA_PR_FIX_RESULT: continue",
+			AgentID:   "agent-1",
+			StartedAt: time.Now(),
+		}},
+		Variables: map[string]string{ReviewHoldParkVar: "true"},
+	}
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", PRNumber: 1446, Workflow: wf})
+
+	out, err := engine.execRoutePRFixResult("t1", &Step{ID: "route_pr_fix_result"}, wf)
+	if err != nil {
+		t.Fatalf("execRoutePRFixResult: %v", err)
+	}
+	if out.Output == "continue" {
+		t.Fatal("route output = continue; review-hold park must force human-required")
+	}
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required", got.Status)
+	}
+}
+
 func TestPRFixRequiresHuman_UsesLastAgentStepVars(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Motivation

Sybra should never publish a PR comment or reply without an explicit human check. Inbound reviews of a teammate's PR already work this way (a pending review + the task parked in human-required). But the reply/fix-review flow doesn't: it replies on every thread live and pushes. This adds a setting that extends the same gate to replies, so they're drafted into a pending review and the task waits for me to verify and submit.

> Changelog: feat(review): hold PR replies as a pending review behind a setting

## Implementation information

New `review_hold` config block (off by default, so existing behavior is unchanged):

```yaml
review_hold:
  enabled: true
  mode: push_nits   # push | push_nits | hold
  nit_max_lines: 10
```

When enabled, fix-review agents draft the replies they'd post into a single pending (draft) review instead of posting live, never submit/approve, and flip the task to human-required.

`mode` controls how far the hold extends to the agent's own code changes:

- `push` (default): reply held as a pending review; code still committed + pushed
- `push_nits`: reply held; code pushed only when the diff is <= `nit_max_lines`, else held
- `hold`: reply + code held; nothing pushed

Wiring:

- `internal/config/config_reviewhold.go` + accessors/defaults in `config_defaults.go` (unknown/empty mode falls back to `push`, zero `nit_max_lines` falls back to 10).
- `reviewHoldFixSuffix` (`internal/sybra/review_hold.go`) appends override instructions to the fix-review prompt. Returns `""` when disabled, so prompts stay byte-for-byte unchanged.
- Applied to both reply paths: the pr-monitor coalesced path (`coalescedFixPrompt`, appended only when the set includes a comments issue) and the manual `StartFixReview` path.
- Routing to human-required is deterministic, not sentinel-dependent: `dispatchPRIssue` sets a `review_hold_park` workflow var when the hold is active and the handled set includes review comments, and `route_pr_fix_result` forces human-required on it — so an agent that pushed in `push` mode and emitted `continue` can't release the hold. The manual path is routed in `agent_completion.go` (parks instead of auto-pushing; `push` mode still runs `pushFixReviewBranch` first as a safety-net).
- Enforcement is prompt + status routing (no hard tool block), matching how inbound reviews already work.

Tests: `TestReviewHoldDefaults`, `TestReviewHoldFixSuffix`, `TestCoalescedFixPrompt_ReviewHold`, `TestDispatchFixIssues_ReviewHoldSetsParkVar`, `TestExecRoutePRFixResult_ReviewHoldParkWinsOverContinue`, `TestOnAgentComplete_FixReviewHoldParksForHuman`.

## Supporting documentation

`docs/CONFIG.md` regenerated with the `ReviewHoldConfig` (`review_hold`) section documenting the three modes and the nit threshold. See the "Agent Execution Modes" and inbound-review flow in `CLAUDE.md` for the existing pending-review + human-required precedent this mirrors.
