### PR TITLE
fix(task): --issue no longer clobbers PR link

### DIFF
--- a/cmd/sybra-cli/main.go
+++ b/cmd/sybra-cli/main.go
@@ -246,6 +246,9 @@ func cmdGet(s *task.Manager, args []string, jsonOut bool) int {
 	if t.Issue != "" {
 		fmt.Printf("Issue: %s\n", t.Issue)
 	}
+	if t.RefIssue != "" {
+		fmt.Printf("Ref Issue: %s\n", t.RefIssue)
+	}
 	if t.HandoffSourceProvider != "" {
 		fmt.Printf("Source: %s\n", t.HandoffSourceProvider)
 	}
@@ -961,7 +964,7 @@ func newUpdateFlags(fs *flag.FlagSet) updateFlags {
 		project:           fs.String("project", "", "project id (owner/repo)"),
 		branch:            fs.String("branch", "", "Git branch name"),
 		pr:                fs.Int("pr", 0, "GitHub PR number"),
-		issue:             fs.String("issue", "", "GitHub issue URL"),
+		issue:             fs.String("issue", "", "ad-hoc reference issue URL annotation — does not affect PR auto-close linkage (see task.Issue, set only at creation)"),
 		sourceProvider:    fs.String("source-provider", "", "handoff source provider: claude|codex|copilot|none"),
 		statusReason:      fs.String("status-reason", "", "reason for status change"),
 		maxTurns:          fs.Int("max-turns", -1, "per-task max turns override (0 clears override, >0 sets limit)"),
@@ -1010,7 +1013,7 @@ func applyBasicUpdateFlags(updates map[string]any, f updateFlags) {
 		updates["pr_number"] = float64(*f.pr)
 	}
 	if *f.issue != "" {
-		updates["issue"] = *f.issue
+		updates["ref_issue"] = *f.issue
 	}
 }
 
@@ -1795,6 +1798,8 @@ Commands:
            plus one blocked child per sub-issue, with dependency edges extracted by an
            LLM planner. Re-running only materializes sub-issues without an existing task.
   update   <id> [--title T] [--status S] [--status-reason R] [--body B] [--plan PLAN] [--plan-file PATH] [--plan-contract JSON|--plan-contract-file PATH] [--plan-research TEXT|--plan-research-file PATH] [--plan-decisions TEXT|--plan-decisions-file PATH] [--plan-brief TEXT|--plan-brief-file PATH] [--mode M] [--type TYPE] [--tags T] [--project ID] [--branch B] [--pr N] [--issue URL] [--source-provider P|none] [--max-turns N] [--reasoning-effort E]
+           --issue sets ref_issue, an ad-hoc reference annotation — it never
+           overwrites the task's canonical (auto-close) issue set at creation
   link-pr  <id> <pr-number>
            Link a PR number to a task and advance it to in-review. Use when a PR
            was opened outside of Sybra; the PR monitor will then auto-merge or

--- a/cmd/sybra-cli/main_test.go
+++ b/cmd/sybra-cli/main_test.go
@@ -686,6 +686,46 @@ func TestUpdateHandoffSourceProvider(t *testing.T) {
 	}
 }
 
+// TestUpdateIssueDoesNotClobberCanonicalIssue guards against #1450: `update
+// --issue` used to overwrite task.Issue, the field ensure_pr_closes_issue
+// reads verbatim to append "Closes <url>" to a task's PR body. A later
+// `--issue` annotation (e.g. the why-human unblock flow attaching an
+// unrelated finding) must land in RefIssue only, never touch the originating
+// Issue set at creation.
+func TestUpdateIssueDoesNotClobberCanonicalIssue(t *testing.T) {
+	setupStore(t)
+
+	code, out := runCLI(t, "--json", "create",
+		"--title", "fix auth bug",
+		"--project", "owner/repo",
+		"--issue", "https://github.com/owner/repo/issues/1403",
+	)
+	if code != 0 {
+		t.Fatalf("create exit %d: %s", code, out)
+	}
+	var created task.Task
+	mustUnmarshal(t, out, &created)
+	if created.Issue != "https://github.com/owner/repo/issues/1403" {
+		t.Fatalf("Issue = %q, want originating issue set at creation", created.Issue)
+	}
+
+	code, out = runCLI(t, "--json", "update", created.ID,
+		"--status", "todo",
+		"--issue", "https://github.com/owner/repo/issues/1428",
+	)
+	if code != 0 {
+		t.Fatalf("update exit %d: %s", code, out)
+	}
+	var updated task.Task
+	mustUnmarshal(t, out, &updated)
+	if updated.Issue != "https://github.com/owner/repo/issues/1403" {
+		t.Fatalf("Issue = %q, want unchanged originating issue #1403 (update --issue must not clobber it)", updated.Issue)
+	}
+	if updated.RefIssue != "https://github.com/owner/repo/issues/1428" {
+		t.Fatalf("RefIssue = %q, want the update --issue annotation", updated.RefIssue)
+	}
+}
+
 // TestCreateDedupActiveDuplicate covers the orchestrator double-dispatch case:
 // two `sybra-cli create` calls with the same project+issue+title within seconds
 // must collapse onto the first task instead of forking a parallel one.

--- a/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/task/models.ts
@@ -248,6 +248,15 @@ export class Task {
      */
     "worktreeDir"?: string;
     "prNumber": number;
+
+    /**
+     * Issue is the canonical originating GitHub issue this task implements —
+     * set once at creation (or by auto-sources like the GitHub poller and
+     * umbrella expansion) and consumed verbatim by execEnsurePRClosesIssue to
+     * append "Closes <url>" to the task's PR body, by findActiveDuplicate for
+     * dedup, and by the umbrella gate/DAG for state tracking. Never overwrite
+     * this after creation to attach an unrelated reference — use RefIssue.
+     */
     "issue": string;
     "statusReason": string;
 
@@ -273,6 +282,14 @@ export class Task {
      * `blocked`.
      */
     "umbrellaIssue"?: string;
+
+    /**
+     * RefIssue is an ad-hoc reference URL attached after creation — e.g. a
+     * related finding or duplicate noted while diagnosing why a task was
+     * stuck. Purely informational: unlike Issue, nothing reads RefIssue to
+     * drive PR auto-close, dedup, or umbrella state.
+     */
+    "refIssue"?: string;
 
     /**
      * DependsOn lists the issue refs (full github.com issue/PR URL or
@@ -494,10 +511,10 @@ export class Task {
     static createFrom($$source: any = {}): Task {
         const $$createField6_0 = $$createType0;
         const $$createField7_0 = $$createType0;
-        const $$createField17_0 = $$createType0;
-        const $$createField35_0 = $$createType2;
-        const $$createField36_0 = $$createType4;
-        const $$createField47_0 = $$createType5;
+        const $$createField18_0 = $$createType0;
+        const $$createField36_0 = $$createType2;
+        const $$createField37_0 = $$createType4;
+        const $$createField48_0 = $$createType5;
         let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
         if ("allowedTools" in $$parsedSource) {
             $$parsedSource["allowedTools"] = $$createField6_0($$parsedSource["allowedTools"]);
@@ -506,16 +523,16 @@ export class Task {
             $$parsedSource["tags"] = $$createField7_0($$parsedSource["tags"]);
         }
         if ("dependsOn" in $$parsedSource) {
-            $$parsedSource["dependsOn"] = $$createField17_0($$parsedSource["dependsOn"]);
+            $$parsedSource["dependsOn"] = $$createField18_0($$parsedSource["dependsOn"]);
         }
         if ("agentRuns" in $$parsedSource) {
-            $$parsedSource["agentRuns"] = $$createField35_0($$parsedSource["agentRuns"]);
+            $$parsedSource["agentRuns"] = $$createField36_0($$parsedSource["agentRuns"]);
         }
         if ("workflow" in $$parsedSource) {
-            $$parsedSource["workflow"] = $$createField36_0($$parsedSource["workflow"]);
+            $$parsedSource["workflow"] = $$createField37_0($$parsedSource["workflow"]);
         }
         if ("planDrafts" in $$parsedSource) {
-            $$parsedSource["planDrafts"] = $$createField47_0($$parsedSource["planDrafts"]);
+            $$parsedSource["planDrafts"] = $$createField48_0($$parsedSource["planDrafts"]);
         }
         return new Task($$parsedSource as Partial<Task>);
     }

--- a/internal/skills/data/why-human.md
+++ b/internal/skills/data/why-human.md
@@ -116,9 +116,10 @@ rate-limited. Never re-diagnose a task the automation already flagged
      --status-reason "root cause: <one line>; see <issue-url-or-task-id>" \
      --issue <issue-url>   # omit --issue when you filed a local scrubbed task instead
    ```
-   `--issue` only annotates the task record with a reference URL — it doesn't
-   file or link anything by itself, so it's safe to attach alongside either
-   filing path above.
+   `update --issue` writes only the task's `ref_issue` annotation field, never
+   the canonical `issue` field consumed for PR auto-close — it doesn't file or
+   link anything by itself, so it's safe to attach alongside either filing
+   path above.
 
    Two exceptions, both from prior painful experience with this exact flow:
    - **Do not use `link-pr`** here — `link-pr <id> <pr-number>` does exactly

--- a/internal/task/model.go
+++ b/internal/task/model.go
@@ -265,8 +265,14 @@ type Task struct {
 	// for this task runs in this directory, and Sybra never rebases, force-
 	// pushes, or removes it — the external tool owns its lifecycle. Empty =
 	// Sybra-managed worktree (default).
-	WorktreeDir  string `json:"worktreeDir,omitempty"`
-	PRNumber     int    `json:"prNumber"`
+	WorktreeDir string `json:"worktreeDir,omitempty"`
+	PRNumber    int    `json:"prNumber"`
+	// Issue is the canonical originating GitHub issue this task implements —
+	// set once at creation (or by auto-sources like the GitHub poller and
+	// umbrella expansion) and consumed verbatim by execEnsurePRClosesIssue to
+	// append "Closes <url>" to the task's PR body, by findActiveDuplicate for
+	// dedup, and by the umbrella gate/DAG for state tracking. Never overwrite
+	// this after creation to attach an unrelated reference — use RefIssue.
 	Issue        string `json:"issue"`
 	StatusReason string `json:"statusReason"`
 	// HandoffSourceProvider records which local agent provider produced the
@@ -283,6 +289,11 @@ type Task struct {
 	// dependency gate reads it with DependsOn to decide when a child may leave
 	// `blocked`.
 	UmbrellaIssue string `json:"umbrellaIssue,omitempty"`
+	// RefIssue is an ad-hoc reference URL attached after creation — e.g. a
+	// related finding or duplicate noted while diagnosing why a task was
+	// stuck. Purely informational: unlike Issue, nothing reads RefIssue to
+	// drive PR auto-close, dedup, or umbrella state.
+	RefIssue string `json:"refIssue,omitempty"`
 	// DependsOn lists the issue refs (full github.com issue/PR URL or
 	// owner/repo#n shorthand) this task waits on — resolved by issue ref only,
 	// not task IDs. While the task is `blocked`, the gate holds it until every

--- a/internal/task/persistence.go
+++ b/internal/task/persistence.go
@@ -23,6 +23,7 @@ type taskFrontmatter struct {
 	WorktreeDir            string              `yaml:"worktree_dir,omitempty"`
 	PRNumber               int                 `yaml:"pr_number,omitempty"`
 	Issue                  string              `yaml:"issue,omitempty"`
+	RefIssue               string              `yaml:"ref_issue,omitempty"`
 	StatusReason           string              `yaml:"status_reason,omitempty"`
 	HandoffSourceProvider  string              `yaml:"handoff_source_provider,omitempty"`
 	BlockedByIssue         string              `yaml:"blocked_by_issue,omitempty"`
@@ -96,6 +97,7 @@ func taskFromFrontmatter(fm taskFrontmatter, body string) Task {
 		WorktreeDir:            fm.WorktreeDir,
 		PRNumber:               fm.PRNumber,
 		Issue:                  fm.Issue,
+		RefIssue:               fm.RefIssue,
 		StatusReason:           fm.StatusReason,
 		HandoffSourceProvider:  fm.HandoffSourceProvider,
 		BlockedByIssue:         fm.BlockedByIssue,
@@ -149,6 +151,7 @@ func frontmatterFromTask(t Task) taskFrontmatter {
 		WorktreeDir:            t.WorktreeDir,
 		PRNumber:               t.PRNumber,
 		Issue:                  t.Issue,
+		RefIssue:               t.RefIssue,
 		StatusReason:           t.StatusReason,
 		HandoffSourceProvider:  t.HandoffSourceProvider,
 		BlockedByIssue:         t.BlockedByIssue,

--- a/internal/task/persistence_test.go
+++ b/internal/task/persistence_test.go
@@ -30,6 +30,7 @@ func TestTaskFrontmatterMappingRoundTrip(t *testing.T) {
 		WorktreeDir:            "/tmp/worktree",
 		PRNumber:               42,
 		Issue:                  "https://github.com/owner/repo/issues/1",
+		RefIssue:               "https://github.com/owner/repo/issues/9",
 		StatusReason:           "testing",
 		HandoffSourceProvider:  "codex",
 		BlockedByIssue:         "https://github.com/owner/repo/issues/2",
@@ -210,6 +211,8 @@ func setTaskFieldForPersistenceTest(t *testing.T, task *Task, name string) {
 		task.PRNumber = 123
 	case "Issue":
 		task.Issue = "owner/repo#123"
+	case "RefIssue":
+		task.RefIssue = "owner/repo#999"
 	case "StatusReason":
 		task.StatusReason = "testing"
 	case "HandoffSourceProvider":

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -729,6 +729,9 @@ func applyLinkFields(t *Task, u Update) {
 	if u.Issue != nil {
 		t.Issue = *u.Issue
 	}
+	if u.RefIssue != nil {
+		t.RefIssue = *u.RefIssue
+	}
 	if u.UmbrellaIssue != nil {
 		t.UmbrellaIssue = *u.UmbrellaIssue
 	}

--- a/internal/task/update.go
+++ b/internal/task/update.go
@@ -29,6 +29,7 @@ type Update struct {
 	HandoffSourceProvider *string
 	PRNumber              *int
 	Issue                 *string
+	RefIssue              *string
 	Reviewed              *bool
 	RunRole               *string
 	SupervisorSteer       *string
@@ -86,7 +87,7 @@ func UpdateFromMap(raw map[string]any) (Update, error) {
 func applyMapField(u *Update, k string, v any) error {
 	switch k {
 	case "title", "slug", "status_reason", "blocked_by_issue", "umbrella_issue", "body",
-		"project_id", "branch", "worktree_dir", "issue", "run_role", "todoist_id", "plan", "plan_critique",
+		"project_id", "branch", "worktree_dir", "issue", "ref_issue", "run_role", "todoist_id", "plan", "plan_critique",
 		"plan_contract", "plan_research", "plan_decisions", "plan_brief", "code_review",
 		"review_phase", "pr_phase", "outcome", "merge_commit", "supervisor_steer":
 		return applyPlainStringField(u, k, v)
@@ -170,6 +171,8 @@ func applyPlainStringField(u *Update, k string, v any) error {
 		u.WorktreeDir = &s
 	case "issue":
 		u.Issue = &s
+	case "ref_issue":
+		u.RefIssue = &s
 	case "run_role":
 		u.RunRole = &s
 	case "supervisor_steer":


### PR DESCRIPTION
## Motivation

`sybra-cli update --issue` wrote to the same `task.Issue` field that
`execEnsurePRClosesIssue` reads verbatim to append "Closes <url>" to a
task's PR body. The why-human skill documents `--issue` as a safe,
non-linking annotation, but writing to that field silently corrupted
the originating issue link on affected tasks, closing the wrong issue
on merge.

## Implementation information

- Added `task.RefIssue` as a distinct ad-hoc reference field, separate
  from the canonical `task.Issue` link.
- `update --issue` now writes `ref_issue` instead of `issue`.
- `create --issue` keeps writing the canonical `issue` field (nothing
  to clobber at creation time).
- Updated generated TS bindings, the why-human skill docs, and added
  test coverage.

Closes https://github.com/Automaat/sybra/issues/1450

_Generated by Sybra harness_