### PR TITLE
fix(workflow): skip resuming stalled done/cancelled tasks

### DIFF
--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -643,6 +643,16 @@ func (r *ReviewHandler) advanceClosedTaskPRsWithFetch(ctx context.Context, monit
 			r.logger.Error("pr-monitor.closed-update", "task_id", c.TaskID, "err", err)
 			continue
 		}
+		// The task just landed; any still-Running/Waiting workflow (e.g.
+		// paused at code_review_staff) is now stale. Cancel it so
+		// Engine.ResumeStalled doesn't pick the done task back up and rebase
+		// its already-merged branch against origin/main, which self-conflicts
+		// and flips the task back to human-required.
+		if r.workflowEngine != nil {
+			if _, cancelErr := r.workflowEngine.CancelWorkflow(c.TaskID, "pr-monitor: task landed ("+base+")"); cancelErr != nil {
+				r.logger.Error("pr-monitor.closed-cancel-workflow", "task_id", c.TaskID, "err", cancelErr)
+			}
+		}
 		eventType := audit.EventPRMerged
 		if c.State == "CLOSED" {
 			eventType = audit.EventPRClosed

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -1717,6 +1717,84 @@ func TestPollAndMonitorPRs_BudgetExhaustedUsesSingleRESTFallbackReconcile(t *tes
 	}
 }
 
+// TestAdvanceClosedTaskPRs_CancelsStaleWorkflow is the regression guard for
+// the self-conflict bug: a merge that flips a task to done while its
+// workflow is still Running/Waiting at an earlier step (e.g.
+// code_review_staff) must have that workflow cancelled so
+// Engine.ResumeStalled never re-dispatches a rebase against the
+// already-merged branch and flips the task back to human-required.
+func TestAdvanceClosedTaskPRs_CancelsStaleWorkflow(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := task.NewStore(filepath.Join(tmp, "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+	logger := slog.New(slog.DiscardHandler)
+	wfStore, err := workflow.NewStore(filepath.Join(tmp, "workflows"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := workflow.SyncBuiltins(wfStore); err != nil {
+		t.Fatal(err)
+	}
+	agentMgr := newTestAgentManager(t, t.Context(), func(string, any) {}, logger, t.TempDir())
+	engine := workflow.NewEngine(wfStore,
+		&taskAdapter{tasks: tasks},
+		&agentAdapter{agents: agentMgr, tasks: tasks},
+		logger,
+	)
+
+	created, err := tasks.Create("Task with merged PR", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wf := &workflow.Execution{
+		WorkflowID:  "test-simple",
+		CurrentStep: "code_review_staff",
+		State:       workflow.ExecWaiting,
+		Variables:   map[string]string{},
+	}
+	if _, err := tasks.Update(created.ID, task.Update{
+		Status:    task.Ptr(task.StatusInReview),
+		ProjectID: task.Ptr("o/r"),
+		PRNumber:  task.Ptr(1443),
+		Workflow:  &wf,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &ReviewHandler{
+		DomainHandler:  DomainHandler{logger: logger, emit: func(string, any) {}},
+		tasks:          tasks,
+		agents:         agentMgr,
+		prTracker:      github.NewIssueTracker(time.Minute),
+		workflowEngine: engine,
+	}
+
+	monitoredPRs := []github.PullRequest{} // PR no longer appears among open PRs
+	closedMatchers := []github.TaskMatcher{{ID: created.ID, PRNumber: 1443, ProjectID: "o/r"}}
+	fetchFn := func(repo string, number int) (github.PRState, error) {
+		return github.PRState{State: "MERGED"}, nil
+	}
+
+	r.advanceClosedTaskPRsWithFetch(context.Background(), monitoredPRs, closedMatchers, fetchFn)
+
+	got, err := tasks.Get(created.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusDone {
+		t.Errorf("status = %q, want done", got.Status)
+	}
+	if got.Workflow == nil || got.Workflow.State != workflow.ExecCompleted {
+		t.Errorf("workflow state = %+v, want completed", got.Workflow)
+	}
+	if got.Workflow != nil && got.Workflow.CurrentStep != "" {
+		t.Errorf("workflow CurrentStep = %q, want empty", got.Workflow.CurrentStep)
+	}
+}
+
 func TestPollSecondaryReconcilesKnownTaskPRsWithoutSearch(t *testing.T) {
 	store, err := task.NewStore(filepath.Join(t.TempDir(), "tasks"))
 	if err != nil {

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -552,6 +552,31 @@ func (e *Engine) rescheduleRateLimitedParallelChild(taskID, agentID string, pare
 	}
 }
 
+// resumeSkipReasonForStatus reports whether ResumeStalled must not resume a
+// task in the given status, and why.
+//
+// human-required: the task was halted by a competing path (e.g. the inline
+// review triage deciding the PR is too small). Resuming would override the
+// triage verdict and re-dispatch an agent the operator already suppressed.
+//
+// done/cancelled: the task reached a terminal status (e.g. its PR merged)
+// while its Workflow record was still Running/Waiting from before that
+// transition landed. Resuming would reprep the worktree and rebase an
+// already-merged branch against origin/main, which self-conflicts and flips
+// the task back to human-required. The cancel-on-landing path clears
+// Workflow going forward; this guard covers any terminal status this ticker
+// still finds stale.
+func resumeSkipReasonForStatus(status string) (reason string, skip bool) {
+	switch status {
+	case "human-required":
+		return "human_required", true
+	case "done", "cancelled":
+		return "terminal_status", true
+	default:
+		return "", false
+	}
+}
+
 // ResumeStalled finds tasks with running/waiting workflows where no agent
 // is active, and attempts to re-execute the current step.
 func (e *Engine) ResumeStalled() {
@@ -591,13 +616,9 @@ func (e *Engine) ResumeStalled() {
 				"task_id", t.ID, "reason", "retry_after", "retry_after", retryAt.Format(time.RFC3339), "step", step.ID)
 			continue
 		}
-		// A task in human-required was halted by a competing path (e.g. the
-		// inline review triage deciding the PR is too small). Do not resume its
-		// workflow: that would override the triage verdict and re-dispatch an
-		// agent that the operator already suppressed.
-		if t.Status == "human-required" {
+		if reason, skip := resumeSkipReasonForStatus(t.Status); skip {
 			e.logger.Debug("workflow.resume-stalled.skip",
-				"task_id", t.ID, "reason", "human_required", "step", step.ID)
+				"task_id", t.ID, "reason", reason, "status", t.Status, "step", step.ID)
 			continue
 		}
 		if e.agents.HasRunningAgent(t.ID) {

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -419,7 +419,7 @@ func (e *Engine) RescheduleRateLimitedAgent(taskID, agentID string) {
 		e.clearAgentStep(agentID)
 		return
 	}
-	if t.Workflow.State == ExecCompleted || t.Workflow.State == ExecFailed || t.Status == "human-required" {
+	if _, skip := resumeSkipReasonForStatus(t.Status); t.Workflow.State == ExecCompleted || t.Workflow.State == ExecFailed || skip {
 		e.clearAgentStep(agentID)
 		return
 	}
@@ -503,7 +503,8 @@ func (e *Engine) rescheduleRateLimitedParallelChild(taskID, agentID string, pare
 	defer e.releaseInflight(taskID)
 
 	fresh, err := e.tasks.GetTask(taskID)
-	if err != nil || fresh.Workflow == nil || fresh.Workflow.CurrentStep != parent.ID || fresh.Workflow.State == ExecCompleted || fresh.Workflow.State == ExecFailed || fresh.Status == "human-required" {
+	_, skip := resumeSkipReasonForStatus(fresh.Status)
+	if err != nil || fresh.Workflow == nil || fresh.Workflow.CurrentStep != parent.ID || fresh.Workflow.State == ExecCompleted || fresh.Workflow.State == ExecFailed || skip {
 		e.clearAgentStep(agentID)
 		return
 	}
@@ -682,7 +683,8 @@ func (e *Engine) ResumeStalled() {
 		// calls: by the time we acquire dispatching, a prior goroutine may have
 		// already advanced the workflow past this step.
 		fresh, fErr := e.tasks.GetTask(t.ID)
-		if fErr != nil || fresh.Workflow == nil || fresh.Workflow.CurrentStep != t.Workflow.CurrentStep || fresh.Workflow.State == ExecCompleted || fresh.Workflow.State == ExecFailed || fresh.Status == "human-required" {
+		_, skip := resumeSkipReasonForStatus(fresh.Status)
+		if fErr != nil || fresh.Workflow == nil || fresh.Workflow.CurrentStep != t.Workflow.CurrentStep || fresh.Workflow.State == ExecCompleted || fresh.Workflow.State == ExecFailed || skip {
 			e.mu.Lock()
 			delete(e.dispatching, t.ID)
 			e.mu.Unlock()

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -578,6 +578,67 @@ func resumeSkipReasonForStatus(status string) (reason string, skip bool) {
 	}
 }
 
+func (e *Engine) tryMarkResumeDispatching(taskID string, step *Step) (reason string, acquired bool) {
+	// Skip tasks whose step is currently being dispatched. Interactive spawns
+	// (worktree creation, rebase, agent process start) take several seconds
+	// during which no agent is yet registered — without this guard the ticker
+	// would spawn a duplicate and the second agent's completion would corrupt
+	// the workflow at the wait_human gate.
+	// inflightMutexes is a non-blocking probe: TryLock distinguishes "another
+	// goroutine currently holds the advance lock" from "free". We only set
+	// dispatching when both the advance lock and prior dispatching guard are
+	// free.
+	mu := e.taskInflightMutex(taskID)
+	advancing := !mu.TryLock()
+	if !advancing {
+		mu.Unlock()
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	_, dispatching := e.dispatching[taskID]
+	// agentSteps holds outstanding agents the engine spawned but hasn't yet
+	// routed completion for. Required because interactive agents pass through
+	// StatePaused after their first result event (one-shot path closes stdin →
+	// state Paused → process exits → onComplete fires → AdvanceStep), and
+	// HasRunningAgent returns false during that window. Without this check a
+	// tight ResumeStalled loop dispatches a duplicate.
+	hasOutstandingAgent := false
+	for _, entry := range e.agentSteps {
+		if entry.taskID == taskID && (entry.stepID == step.ID || parallelHasChild(step, entry.stepID)) {
+			hasOutstandingAgent = true
+			break
+		}
+	}
+
+	if !advancing && !dispatching && !hasOutstandingAgent {
+		e.dispatching[taskID] = struct{}{}
+		return "", true
+	}
+
+	switch {
+	case advancing:
+		return "inflight", false
+	case hasOutstandingAgent:
+		return "agent-pending-completion", false
+	default:
+		return "dispatching", false
+	}
+}
+
+func (e *Engine) shouldSkipResumeAfterFreshRead(taskID string, wf *Execution) (TaskInfo, bool) {
+	fresh, err := e.tasks.GetTask(taskID)
+	if err != nil || fresh.Workflow == nil {
+		return fresh, true
+	}
+	if fresh.Workflow.CurrentStep != wf.CurrentStep || fresh.Workflow.State == ExecCompleted || fresh.Workflow.State == ExecFailed {
+		return fresh, true
+	}
+	_, skip := resumeSkipReasonForStatus(fresh.Status)
+	return fresh, skip
+}
+
 // ResumeStalled finds tasks with running/waiting workflows where no agent
 // is active, and attempts to re-execute the current step.
 func (e *Engine) ResumeStalled() {
@@ -631,49 +692,8 @@ func (e *Engine) ResumeStalled() {
 		if e.handleWatchdogHangRetry(t, step) {
 			continue
 		}
-		// Skip tasks whose step is currently being dispatched. Interactive
-		// spawns (worktree creation, rebase, agent process start) take
-		// several seconds during which no agent is yet registered — without
-		// this guard the ticker would spawn a duplicate and the second
-		// agent's completion would corrupt the workflow at the wait_human
-		// gate.
-		// inflightMutexes is a non-blocking probe: TryLock distinguishes
-		// "another goroutine currently holds the advance lock" from "free".
-		// We only set dispatching when both the advance lock and prior
-		// dispatching guard are free.
-		mu := e.taskInflightMutex(t.ID)
-		advancing := !mu.TryLock()
-		if !advancing {
-			mu.Unlock()
-		}
-		e.mu.Lock()
-		_, dispatching := e.dispatching[t.ID]
-		// agentSteps holds outstanding agents the engine spawned but hasn't
-		// yet routed completion for. Required because interactive agents pass
-		// through StatePaused after their first result event (one-shot path
-		// closes stdin → state Paused → process exits → onComplete fires →
-		// AdvanceStep), and HasRunningAgent returns false during that window.
-		// Without this check a tight ResumeStalled loop dispatches a duplicate.
-		hasOutstandingAgent := false
-		for _, entry := range e.agentSteps {
-			if entry.taskID == t.ID && (entry.stepID == step.ID || parallelHasChild(step, entry.stepID)) {
-				hasOutstandingAgent = true
-				break
-			}
-		}
-
-		if !advancing && !dispatching && !hasOutstandingAgent {
-			e.dispatching[t.ID] = struct{}{}
-		}
-		e.mu.Unlock()
-		if advancing || dispatching || hasOutstandingAgent {
-			reason := "dispatching"
-			switch {
-			case advancing:
-				reason = "inflight"
-			case hasOutstandingAgent:
-				reason = "agent-pending-completion"
-			}
+		reason, acquired := e.tryMarkResumeDispatching(t.ID, step)
+		if !acquired {
 			e.logger.Debug("workflow.resume-stalled.skip",
 				"task_id", t.ID, "reason", reason, "step", step.ID)
 			continue
@@ -682,9 +702,8 @@ func (e *Engine) ResumeStalled() {
 		// Re-read to guard against stale snapshots from concurrent ResumeStalled
 		// calls: by the time we acquire dispatching, a prior goroutine may have
 		// already advanced the workflow past this step.
-		fresh, fErr := e.tasks.GetTask(t.ID)
-		_, skip := resumeSkipReasonForStatus(fresh.Status)
-		if fErr != nil || fresh.Workflow == nil || fresh.Workflow.CurrentStep != t.Workflow.CurrentStep || fresh.Workflow.State == ExecCompleted || fresh.Workflow.State == ExecFailed || skip {
+		fresh, skip := e.shouldSkipResumeAfterFreshRead(t.ID, t.Workflow)
+		if skip {
 			e.mu.Lock()
 			delete(e.dispatching, t.ID)
 			e.mu.Unlock()

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -69,10 +69,17 @@ type memTasks struct {
 	tasks   map[string]*TaskInfo
 	reasons map[string]string
 	steers  map[string]string
+	gets    map[string]int
+	onGet   func(id string, t *TaskInfo, count int)
 }
 
 func newMemTasks() *memTasks {
-	return &memTasks{tasks: make(map[string]*TaskInfo), reasons: make(map[string]string), steers: make(map[string]string)}
+	return &memTasks{
+		tasks:   make(map[string]*TaskInfo),
+		reasons: make(map[string]string),
+		steers:  make(map[string]string),
+		gets:    make(map[string]int),
+	}
 }
 
 // SetSteer arms a pending supervisor steer for a task, as the watchdog's
@@ -100,12 +107,22 @@ func (m *memTasks) Put(t TaskInfo) {
 	m.tasks[t.ID] = &t
 }
 
+func (m *memTasks) SetGetTaskHook(hook func(id string, t *TaskInfo, count int)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onGet = hook
+}
+
 func (m *memTasks) GetTask(id string) (TaskInfo, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	t, ok := m.tasks[id]
 	if !ok {
 		return TaskInfo{}, fmt.Errorf("task %s not found", id)
+	}
+	m.gets[id]++
+	if m.onGet != nil {
+		m.onGet(id, t, m.gets[id])
 	}
 	cp := *t
 	// Shallow-copy the Execution struct so concurrent callers each get their
@@ -2222,6 +2239,115 @@ func TestResumeStalled_SkipsDoneStatus(t *testing.T) {
 
 	if agents.CallCount() != 0 {
 		t.Fatalf("expected 0 agent starts for done task, got %d", agents.CallCount())
+	}
+}
+
+func TestResumeStalled_SkipsTerminalStatusAfterFreshRead(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+	}{
+		{name: "done", status: "done"},
+		{name: "cancelled", status: "cancelled"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newTestStore(t)
+			tasks := newMemTasks()
+			agents := newMockAgents()
+			engine := NewEngine(store, tasks, agents, discardLogger())
+
+			tasks.Put(TaskInfo{
+				ID:        "t1",
+				Status:    "in-review",
+				AgentMode: "headless",
+				Workflow: &Execution{
+					WorkflowID:  "test-simple",
+					CurrentStep: "implement",
+					State:       ExecRunning,
+					Variables:   make(map[string]string),
+				},
+			})
+			tasks.SetGetTaskHook(func(id string, task *TaskInfo, count int) {
+				if id == "t1" && count == 1 {
+					task.Status = tc.status
+				}
+			})
+
+			engine.ResumeStalled()
+
+			if got := agents.CallCount(); got != 0 {
+				t.Fatalf("expected 0 agent starts after status flipped to %s, got %d", tc.status, got)
+			}
+			got, err := tasks.GetTask("t1")
+			if err != nil {
+				t.Fatalf("get task: %v", err)
+			}
+			if got.Status != tc.status {
+				t.Fatalf("status = %q, want %q", got.Status, tc.status)
+			}
+		})
+	}
+}
+
+func TestRescheduleRateLimitedAgent_ParallelChildSkipsTerminalStatusAfterFreshRead(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+	}{
+		{name: "done", status: "done"},
+		{name: "cancelled", status: "cancelled"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newTestStoreWith(t, "test-parallel.yaml")
+			tasks := newMemTasks()
+			agents := newMockAgents()
+			engine := NewEngine(store, tasks, agents, discardLogger())
+
+			tasks.Put(TaskInfo{
+				ID:        "t1",
+				Status:    "in-progress",
+				AgentMode: "headless",
+				Workflow: &Execution{
+					WorkflowID:  "test-parallel",
+					CurrentStep: "plan",
+					State:       ExecWaiting,
+					Variables:   make(map[string]string),
+					ParallelInflight: map[string]*ParallelChildren{
+						"plan": {
+							ParentStepID: "plan",
+							Children: map[string]*ChildStatus{
+								"plan_a": {Status: "pending", AgentID: "limited-agent", Provider: "claude"},
+								"plan_b": {Status: "pending", AgentID: "other-agent", Provider: "codex"},
+							},
+						},
+					},
+				},
+			})
+			engine.agentSteps["limited-agent"] = agentEntry{taskID: "t1", stepID: "plan_a"}
+			tasks.SetGetTaskHook(func(id string, task *TaskInfo, count int) {
+				if id == "t1" && count == 2 {
+					task.Status = tc.status
+				}
+			})
+
+			engine.RescheduleRateLimitedAgent("t1", "limited-agent")
+
+			if got := agents.CallCount(); got != 0 {
+				t.Fatalf("expected 0 replacement agent starts after status flipped to %s, got %d", tc.status, got)
+			}
+			if _, tracked := engine.lookupAgentStep("limited-agent"); tracked {
+				t.Fatal("rate-limited child step mapping was not cleared")
+			}
+			got, err := tasks.GetTask("t1")
+			if err != nil {
+				t.Fatalf("get task: %v", err)
+			}
+			if got.Status != tc.status {
+				t.Fatalf("status = %q, want %q", got.Status, tc.status)
+			}
+		})
 	}
 }
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -2194,6 +2194,37 @@ func TestResumeStalled_SkipsHumanRequired(t *testing.T) {
 	}
 }
 
+func TestResumeStalled_SkipsDoneStatus(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	// Simulate a task whose PR merged (flipping Status to done) while its
+	// workflow was still paused Running/Waiting at an earlier step — e.g.
+	// advanceClosedTaskPRsWithFetch racing ResumeStalled before the workflow
+	// is cancelled. Resuming would rebase the already-merged branch against
+	// origin/main and self-conflict, flipping the done task back to
+	// human-required.
+	tasks.Put(TaskInfo{
+		ID:        "t1",
+		Status:    "done",
+		AgentMode: "headless",
+		Workflow: &Execution{
+			WorkflowID:  "test-simple",
+			CurrentStep: "implement",
+			State:       ExecRunning,
+			Variables:   make(map[string]string),
+		},
+	})
+
+	engine.ResumeStalled()
+
+	if agents.CallCount() != 0 {
+		t.Fatalf("expected 0 agent starts for done task, got %d", agents.CallCount())
+	}
+}
+
 func TestHandleHumanAction_NotWaiting(t *testing.T) {
 	store := newTestStore(t)
 	tasks := newMemTasks()


### PR DESCRIPTION
## Motivation

`Engine.ResumeStalled` only skipped `human-required` tasks. When a task's PR
landed while its `Workflow` record was still `Running`/`Waiting` (e.g. paused
at `code_review_staff`), the ticker could pick the now-`done` task back up and
rebase its already-merged branch against `origin/main` — a self-conflict that
flipped the task back to `human-required`.

Closes https://github.com/Automaat/sybra/issues/1444

## Implementation information

- Added `resumeSkipReasonForStatus` to centralize the set of terminal/halted
  statuses (`human-required`, `done`, `cancelled`) that must not be resumed,
  reused across `ResumeStalled`, `RescheduleRateLimitedAgent`, and
  `rescheduleRateLimitedParallelChild`.
- `ReviewHandler.advanceClosedTaskPRsWithFetch` now cancels any still
  running/waiting workflow the moment a task's PR is recorded as merged or
  closed, so `ResumeStalled` has nothing stale left to find going forward.
- Added unit coverage for both the review-handler cancel and the engine skip
  logic.

_Generated by Sybra harness_