### PR TITLE
docs: fix getting-started clean-clone startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,14 @@ Complex tasks go through a planning phase. Simple tasks go straight to execution
 **Prerequisites:** Go 1.26.4, Node 24, [mise](https://mise.jdx.dev/). Desktop builds run on macOS only (Wails v3 alpha needs gtk3/webkit2gtk-4.1 on Linux, which CI does not install).
 
 ```bash
-# Install tool versions
+# Trust the repo's mise config, then install tool versions
+mise trust
 mise install
 
-# Dev server with hot reload (Go + Svelte)
+# Install frontend deps (mise run dev/build do NOT do this for you)
+cd frontend && npm ci && cd ..
+
+# Rebuild frontend + run the desktop app (no hot reload — restart to pick up changes)
 mise run dev
 
 # Production build


### PR DESCRIPTION
## Motivation

Tried starting the app by following the README getting-started verbatim on a clean checkout. It failed twice:

1. `mise install` errors until you run `mise trust` first (mise refuses the untrusted repo config).
2. Neither `mise run dev` nor `mise run build` install frontend deps, so `npm run build:desktop` dies with `Cannot find package vite`. There was no `npm ci` step anywhere in getting-started.

## Implementation information

- Add `mise trust` before `mise install`.
- Add `cd frontend && npm ci` step (mise dev/build do not do it for you).
- Drop the "hot reload" claim - the frontend is built once per `mise run dev`, restart to pick up changes (already documented that way in CLAUDE.md).

## Verification

After these steps the full path works locally: mise trust -> mise install -> npm ci -> mise run dev launches the desktop app (window comes up, assets serve), and `go build .` + `go install ./cmd/sybra-cli` succeed.