### PR TITLE
feat(browser): add in-app browser toggle

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -42,6 +42,7 @@ machine.
 | `providers` | `ProvidersConfig` | _(see below)_ |  |
 | `metrics` | `MetricsConfig` | _(see below)_ |  |
 | `auto_update` | `AutoUpdateConfig` | _(see below)_ |  |
+| `browser` | `BrowserConfig` | _(see below)_ |  |
 | `project_types` | `[]string` |  |  |
 | `tasks_dir` | `string` | `~/.sybra/tasks` |  |
 | `skills_dir` | `string` |  |  |
@@ -462,4 +463,14 @@ fast-forward update is applied and Sybra requests a supervisor restart.
 | `auto_update.mode` | `string` | `notify` |  |
 | `auto_update.poll_seconds` | `int` | `300` |  |
 | `auto_update.restart_delay_seconds` | `int` | `2` | Deprecated: ignored. Kept so existing config files continue to load. |
+
+## BrowserConfig (`browser`)
+
+BrowserConfig controls how the desktop app opens external links (GitHub,
+PRs, issues). Read once at startup — flipping this value requires an app
+restart, since the opener closure is wired into the app at boot in main.go.
+
+| YAML key | Type | Default | Description |
+|---|---|---|---|
+| `browser.in_app` | `*bool` | _(nil)_ | InApp opens links in an in-app Sybra Browser webview window backed by a persistent, app-wide cookie store, so a login is reused across windows and survives restarts. Nil/unset defaults to true (current behavior). Set to false to always open links in the default system browser instead. |
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	Providers      ProvidersConfig      `yaml:"providers" json:"providers"`
 	Metrics        MetricsConfig        `yaml:"metrics" json:"metrics"`
 	AutoUpdate     AutoUpdateConfig     `yaml:"auto_update" json:"autoUpdate"`
+	Browser        BrowserConfig        `yaml:"browser" json:"browser"`
 	ProjectTypes   []string             `yaml:"project_types" json:"projectTypes"`
 	TasksDir       string               `yaml:"tasks_dir" json:"tasksDir"`
 	SkillsDir      string               `yaml:"skills_dir" json:"skillsDir"`

--- a/internal/config/config_browser.go
+++ b/internal/config/config_browser.go
@@ -1,0 +1,12 @@
+package config
+
+// BrowserConfig controls how the desktop app opens external links (GitHub,
+// PRs, issues). Read once at startup — flipping this value requires an app
+// restart, since the opener closure is wired into the app at boot in main.go.
+type BrowserConfig struct {
+	// InApp opens links in an in-app Sybra Browser webview window backed by a
+	// persistent, app-wide cookie store, so a login is reused across windows
+	// and survives restarts. Nil/unset defaults to true (current behavior).
+	// Set to false to always open links in the default system browser instead.
+	InApp *bool `yaml:"in_app" json:"inApp"`
+}

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -126,6 +126,16 @@ func (c *Config) SurviveRestartEnabled() bool {
 	return true
 }
 
+// InAppBrowserEnabled reports whether the desktop app should open external
+// links in the in-app Sybra Browser webview. Defaults to true when unset so
+// existing installs keep their current behavior without migration.
+func (c *Config) InAppBrowserEnabled() bool {
+	if c != nil && c.Browser.InApp != nil {
+		return *c.Browser.InApp
+	}
+	return true
+}
+
 // DefaultTestingMaxConcurrent bounds concurrent test-runner agents (each owns
 // an isolated sandbox) when TestingConfig.MaxConcurrent is unset.
 const DefaultTestingMaxConcurrent = 3

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -52,6 +52,32 @@ func TestLoadFromYAML(t *testing.T) {
 	}
 }
 
+func TestInAppBrowserEnabled(t *testing.T) {
+	t.Parallel()
+
+	truthy, falsy := true, false
+
+	cases := []struct {
+		name string
+		cfg  *Config
+		want bool
+	}{
+		{"nil config", nil, true},
+		{"nil field", &Config{}, true},
+		{"explicit true", &Config{Browser: BrowserConfig{InApp: &truthy}}, true},
+		{"explicit false", &Config{Browser: BrowserConfig{InApp: &falsy}}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.cfg.InAppBrowserEnabled(); got != tc.want {
+				t.Errorf("InAppBrowserEnabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestLoadProviderDefaultAndPersistedValue(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("SYBRA_HOME", dir)

--- a/internal/sybra/config_diff.go
+++ b/internal/sybra/config_diff.go
@@ -6,6 +6,13 @@ import (
 	"github.com/Automaat/sybra/internal/config"
 )
 
+func appendDeepChanged(keys []string, name string, old, next any) []string {
+	if !reflect.DeepEqual(old, next) {
+		return append(keys, name)
+	}
+	return keys
+}
+
 // diffConfig compares old and new configs and returns two slices of dot-separated
 // key names: hot (live-reloadable without restart) and restart (require restart).
 func diffConfig(old, next config.Config) (hot, restart []string) {
@@ -79,39 +86,18 @@ func diffConfig(old, next config.Config) (hot, restart []string) {
 	}
 
 	// Restart-required blocks
-	if !reflect.DeepEqual(old.Providers, next.Providers) {
-		restart = append(restart, "providers")
-	}
-	if !reflect.DeepEqual(old.Metrics, next.Metrics) {
-		restart = append(restart, "metrics")
-	}
-	if !reflect.DeepEqual(old.Monitor, next.Monitor) {
-		restart = append(restart, "monitor")
-	}
-	if !reflect.DeepEqual(old.SelfMonitor, next.SelfMonitor) {
-		restart = append(restart, "self_monitor")
-	}
-	if !reflect.DeepEqual(old.HarnessEvolve, next.HarnessEvolve) {
-		restart = append(restart, "harness_evolution")
-	}
-	if !reflect.DeepEqual(old.PromptLab, next.PromptLab) {
-		restart = append(restart, "prompt_lab")
-	}
-	if !reflect.DeepEqual(old.ABTesting, next.ABTesting) {
-		restart = append(restart, "ab_testing")
-	}
-	if !reflect.DeepEqual(old.Triage, next.Triage) {
-		restart = append(restart, "triage")
-	}
-	if !reflect.DeepEqual(old.GitHub, next.GitHub) {
-		restart = append(restart, "github")
-	}
-	if !reflect.DeepEqual(old.ProjectTypes, next.ProjectTypes) {
-		restart = append(restart, "project_types")
-	}
-	if !reflect.DeepEqual(old.AutoUpdate, next.AutoUpdate) {
-		restart = append(restart, "auto_update")
-	}
+	restart = appendDeepChanged(restart, "providers", old.Providers, next.Providers)
+	restart = appendDeepChanged(restart, "metrics", old.Metrics, next.Metrics)
+	restart = appendDeepChanged(restart, "monitor", old.Monitor, next.Monitor)
+	restart = appendDeepChanged(restart, "self_monitor", old.SelfMonitor, next.SelfMonitor)
+	restart = appendDeepChanged(restart, "harness_evolution", old.HarnessEvolve, next.HarnessEvolve)
+	restart = appendDeepChanged(restart, "prompt_lab", old.PromptLab, next.PromptLab)
+	restart = appendDeepChanged(restart, "ab_testing", old.ABTesting, next.ABTesting)
+	restart = appendDeepChanged(restart, "triage", old.Triage, next.Triage)
+	restart = appendDeepChanged(restart, "github", old.GitHub, next.GitHub)
+	restart = appendDeepChanged(restart, "project_types", old.ProjectTypes, next.ProjectTypes)
+	restart = appendDeepChanged(restart, "auto_update", old.AutoUpdate, next.AutoUpdate)
+	restart = appendDeepChanged(restart, "browser", old.Browser, next.Browser)
 
 	return hot, restart
 }

--- a/internal/sybra/config_diff_test.go
+++ b/internal/sybra/config_diff_test.go
@@ -113,3 +113,19 @@ func TestDiffConfig_MetricsRestart(t *testing.T) {
 		t.Errorf("expected metrics in restart, got %v", restart)
 	}
 }
+
+func TestDiffConfig_BrowserRestart(t *testing.T) {
+	t.Parallel()
+	old := config.DefaultConfig()
+	next := *old
+	disabled := false
+	next.Browser.InApp = &disabled
+
+	hot, restart := diffConfig(*old, next)
+	if len(hot) != 0 {
+		t.Errorf("expected no hot keys, got %v", hot)
+	}
+	if !slices.Contains(restart, "browser") {
+		t.Errorf("expected browser in restart, got %v", restart)
+	}
+}

--- a/internal/sybra/svc_config_reload.go
+++ b/internal/sybra/svc_config_reload.go
@@ -52,6 +52,7 @@ func (s *ConfigService) ReloadFromDisk() (changedHot []string, err error) {
 	s.cfg.ABTesting = next.ABTesting
 	s.cfg.Metrics = next.Metrics
 	s.cfg.AutoUpdate = next.AutoUpdate
+	s.cfg.Browser = next.Browser
 	s.cfg.ProjectTypes = next.ProjectTypes
 	if err := s.refreshAgentRuntimeConfig(*next); err != nil {
 		return nil, err

--- a/internal/sybra/svc_config_reload_test.go
+++ b/internal/sybra/svc_config_reload_test.go
@@ -296,6 +296,81 @@ func TestReloadFromDisk_RestartRequiredWarned(t *testing.T) {
 	}
 }
 
+func TestReloadFromDisk_BrowserRestartRequiredWarned(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SYBRA_HOME", home)
+
+	seed := config.DefaultConfig()
+	cfgPath := filepath.Join(home, "config.yaml")
+	writeConfigYAML(t, cfgPath, seed)
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+
+	records := make([]slog.Record, 0)
+	handler := &recordHandler{records: &records}
+	logger := slog.New(handler)
+
+	emit := func(string, any) {}
+	logLevel := new(slog.LevelVar)
+	logLevel.Set(slog.LevelInfo)
+	logDir := filepath.Join(home, "logs")
+	mgr := newTestAgentManager(t, context.Background(), emit, logger, logDir, agent.ManagerConfig{
+		Runtime: agent.ManagerRuntimeConfig{
+			MaxConcurrent:   cfg.Agent.MaxConcurrent,
+			DefaultProvider: cfg.Agent.Provider,
+		},
+	})
+	mgr.SetGuardrails(agent.Guardrails{MaxCostUSD: cfg.Agent.MaxCostUSD, MaxTurns: cfg.Agent.MaxTurns})
+	notifier := notification.New(emit)
+
+	svc := &ConfigService{
+		cfg:      cfg,
+		logLevel: logLevel,
+		notifier: notifier,
+		agents:   mgr,
+		logger:   logger,
+	}
+
+	next := *cfg
+	disabled := false
+	next.Browser.InApp = &disabled
+	writeConfigYAML(t, cfgPath, &next)
+
+	hot, err := svc.ReloadFromDisk()
+	if err != nil {
+		t.Fatalf("ReloadFromDisk: %v", err)
+	}
+	if len(hot) != 0 {
+		t.Errorf("expected no hot keys, got %v", hot)
+	}
+
+	found := false
+	for _, r := range records {
+		if r.Message == "config.reload.restart_required" {
+			var field string
+			r.Attrs(func(a slog.Attr) bool {
+				if a.Key == "field" {
+					field = a.Value.String()
+				}
+				return true
+			})
+			if field == "browser" {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Error("expected browser restart warning, got none")
+	}
+	if svc.cfg.Browser.InApp == nil || *svc.cfg.Browser.InApp {
+		t.Error("s.cfg browser settings not updated after reload")
+	}
+}
+
 func TestReloadFromDisk_RefreshesLimitPolicyForProviderChanges(t *testing.T) {
 	svc, cfgPath := setupConfigSvc(t)
 	limitStore, err := limits.NewStore(filepath.Join(t.TempDir(), "limits.json"))

--- a/main.go
+++ b/main.go
@@ -67,30 +67,15 @@ func run() (int, error) {
 
 	startPprof(logger)
 
+	logger.Info("browser.in_app", "enabled", cfg.InAppBrowserEnabled())
+
 	v3emit := func(string, any) {}
 	v3openBrowser := func(string) {}
 	var restartRequested atomic.Bool
 	var v3app *application.App
 
-	sybraApp := sybra.NewApp(logger, levelVar, cfg,
-		sybra.WithSkillsFS(skills.FS),
-		sybra.WithEmitFactory(func(_ context.Context) func(string, any) {
-			return func(event string, data any) { v3emit(event, data) }
-		}),
-		sybra.WithBrowserOpener(func(url string) { v3openBrowser(url) }),
-		sybra.WithRestartRequest(func() {
-			homeDir := config.HomeDir()
-			if err := autoupdate.WriteRestartMarker(homeDir); err != nil {
-				logger.Error("autoupdate.restart.marker.failed", "err", err)
-			} else {
-				logger.Info("autoupdate.restart.marker.written", "path", autoupdate.RestartMarkerPath(homeDir))
-			}
-			restartRequested.Store(true)
-			if v3app != nil {
-				v3app.Quit()
-			}
-		}),
-	)
+	opts := buildAppOptions(cfg, logger, &v3emit, &v3openBrowser, &restartRequested, &v3app)
+	sybraApp := sybra.NewApp(logger, levelVar, cfg, opts...)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -152,6 +137,51 @@ func run() (int, error) {
 		return autoupdate.RestartExitCode, nil
 	}
 	return 0, nil
+}
+
+// buildAppOptions assembles the sybra.Option set for the desktop app.
+// v3emit/v3openBrowser/v3app are pointers to run's locals so the restart and
+// browser-opener callbacks can reach state that isn't set up until later in
+// startup (the v3app application.App and the wired emit/opener funcs).
+func buildAppOptions(
+	cfg *config.Config,
+	logger *slog.Logger,
+	v3emit *func(string, any),
+	v3openBrowser *func(string),
+	restartRequested *atomic.Bool,
+	v3app **application.App,
+) []sybra.Option {
+	opts := []sybra.Option{
+		sybra.WithSkillsFS(skills.FS),
+		sybra.WithEmitFactory(func(_ context.Context) func(string, any) {
+			return func(event string, data any) { (*v3emit)(event, data) }
+		}),
+	}
+	opts = append(opts, desktopBrowserOptions(cfg, func(url string) { (*v3openBrowser)(url) })...)
+	opts = append(opts, sybra.WithRestartRequest(func() {
+		homeDir := config.HomeDir()
+		if err := autoupdate.WriteRestartMarker(homeDir); err != nil {
+			logger.Error("autoupdate.restart.marker.failed", "err", err)
+		} else {
+			logger.Info("autoupdate.restart.marker.written", "path", autoupdate.RestartMarkerPath(homeDir))
+		}
+		restartRequested.Store(true)
+		if *v3app != nil {
+			(*v3app).Quit()
+		}
+	}))
+	return opts
+}
+
+// desktopBrowserOptions returns the sybra.Option(s) that wire the in-app
+// browser opener, or none when the config toggle disables it. When omitted,
+// BrowserService.Open keeps its nil-opener "unavailable" behavior, and the
+// frontend's existing catch handler falls back to the system browser.
+func desktopBrowserOptions(cfg *config.Config, opener func(string)) []sybra.Option {
+	if !cfg.InAppBrowserEnabled() {
+		return nil
+	}
+	return []sybra.Option{sybra.WithBrowserOpener(opener)}
 }
 
 // openInAppBrowser opens url in a fresh in-app webview window. The window uses

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,36 @@
+//go:build darwin
+
+package main
+
+import (
+	"testing"
+
+	"github.com/Automaat/sybra/internal/config"
+)
+
+func TestDesktopBrowserOptions(t *testing.T) {
+	t.Parallel()
+
+	truthy, falsy := true, false
+
+	cases := []struct {
+		name    string
+		cfg     *config.Config
+		wantLen int
+	}{
+		{"default/nil config wires the opener", nil, 1},
+		{"nil field wires the opener", &config.Config{}, 1},
+		{"explicit true wires the opener", &config.Config{Browser: config.BrowserConfig{InApp: &truthy}}, 1},
+		{"explicit false omits the opener", &config.Config{Browser: config.BrowserConfig{InApp: &falsy}}, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			opts := desktopBrowserOptions(tc.cfg, func(string) {})
+			if len(opts) != tc.wantLen {
+				t.Errorf("desktopBrowserOptions() returned %d options, want %d", len(opts), tc.wantLen)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Some users prefer their default system browser (existing sessions, extensions, password managers) over the in-app Sybra Browser webview. This adds a config toggle to opt out of the in-app browser and fall back to the system browser.

## Implementation information

- Add `browser.in_app` config key (default `true`) in `internal/config/config_browser.go` / `config_defaults.go`.
- Gate desktop opener wiring in `main.go` on the new setting; when disabled, `BrowserService.Open` falls back to the existing unavailable path and the frontend opens the system browser instead.
- Document the new key in `docs/CONFIG.md`.
- Follow-up commit addresses review comments: simplify `internal/sybra/config_diff.go` and cover config reload behavior with new tests.

Closes https://github.com/Automaat/sybra/issues/1460

_Generated by Sybra harness_