### PR TITLE
feat(frontend): show agent role in history rows

### DIFF
--- a/frontend/src/components/task-detail/AgentHistoryList.svelte
+++ b/frontend/src/components/task-detail/AgentHistoryList.svelte
@@ -5,7 +5,7 @@
   import { GetAgentRunLog, GetAgentRunConvoLog } from '$lib/api'
   import { formatDateTime } from '../../lib/dates.js'
   import { formatCostShort } from '../../lib/cost.js'
-  import { runStateClasses } from '../../lib/agent-run.js'
+  import { runStateClasses, roleLabel } from '../../lib/agent-run.js'
   import StreamOutput from '../StreamOutput.svelte'
   import MessageBubble from '../MessageBubble.svelte'
   import ProviderLogo from '../ProviderLogo.svelte'
@@ -105,6 +105,9 @@
               <ProviderLogo provider={run.provider} class="h-3.5 w-3.5 text-surface-400" />
             {/if}
             <span class="font-mono text-surface-400">{run.agentId}</span>
+            {#if roleLabel(run.role)}
+              <span class="rounded bg-tertiary-100 px-1.5 py-0.5 font-medium text-tertiary-700 dark:bg-tertiary-900/50 dark:text-tertiary-300">{roleLabel(run.role)}</span>
+            {/if}
             <span class="rounded bg-surface-200 px-1.5 py-0.5 dark:bg-surface-700">{run.mode}</span>
             <span class="rounded px-1.5 py-0.5 {runStateClasses(run.state || 'running')}">
               {run.state || 'running'}

--- a/frontend/src/lib/agent-run.ts
+++ b/frontend/src/lib/agent-run.ts
@@ -21,3 +21,34 @@ export function runStateClasses(state: string): string {
       return 'bg-surface-200 text-surface-700 dark:bg-surface-700 dark:text-surface-300'
   }
 }
+
+// Human-friendly label for an agent run's role (what the agent was doing).
+// The backend persists the role prefix from the agent name; "" and
+// "implementation" are the same thing. Returns "" for roles we don't want to
+// surface as a badge (plain implementation carries no extra signal).
+export function roleLabel(role: string | undefined): string {
+  switch (role) {
+    case 'triage':
+      return 'Triage'
+    case 'plan':
+      return 'Plan'
+    case 'plan-critic':
+      return 'Plan Critic'
+    case 'eval':
+      return 'Eval'
+    case 'pr-fix':
+      return 'PR Fix'
+    case 'review':
+      return 'Review'
+    case 'fix-review':
+      return 'Fix Review'
+    case 'test-runner':
+      return 'Testing'
+    case 'human-review':
+      return 'Human Review'
+    case 'chat':
+      return 'Chat'
+    default: // "" / "implementation" / unknown — no distinct role signal
+      return ''
+  }
+}


### PR DESCRIPTION
## Motivation

The Agent History panel on a task showed each run's agent id, mode (`headless`), state (`stopped`), cost and timestamp — but not *what the agent was doing*. Rows for a triage run, a review run, and a test-runner run were visually indistinguishable, so you couldn't tell at a glance which phase each historical run belonged to.

> Changelog: feat(frontend): show agent role in history rows

## Implementation information

- `run.role` is already persisted on every `AgentRun` (set from the agent name prefix at record time), so this is a pure frontend surfacing change — no backend or bindings change.
- Added `roleLabel(role)` to `frontend/src/lib/agent-run.ts` mapping role values to friendly labels: `triage`→Triage, `review`→Review, `test-runner`→Testing, `fix-review`→Fix Review, `pr-fix`→PR Fix, `plan`→Plan, `plan-critic`→Plan Critic, `eval`→Eval, `human-review`→Human Review, `chat`→Chat.
- Plain implementation runs (`""`/`implementation`) return `""` and render **no** badge — they carry no extra signal beyond the existing mode badge.
- `AgentHistoryList.svelte` renders the label as a tertiary-colored badge before the mode/state badges when present.

## Supporting documentation

`npm run check` passes (0 errors); `golangci-lint run ./...` clean.