### PR TITLE
fix(worktree): recover conflicts pre-PR

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/workflow/models.ts
@@ -718,6 +718,18 @@ export enum StepType {
      * continues to its next step regardless of outcome.
      */
     StepSyncBranch = "sync_branch",
+
+    /**
+     * StepResumeWorkflow is the terminal step of a recovery workflow
+     * (branch-conflict-fix) that re-enters the task's original interrupted
+     * workflow/stage. Reads resume_workflow_id/resume_workflow_vars/
+     * resume_status vars captured before the recovery workflow was started;
+     * a missing resume_workflow_id is a no-op (the workflow simply ends, and
+     * normal status-driven cascade dispatch — see
+     * AgentCompletionHandler.OnWorkflowComplete — picks up whatever workflow
+     * matches the restored task status).
+     */
+    StepResumeWorkflow = "resume_workflow",
 };
 
 /**

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -37,22 +37,28 @@ const (
 	// cleanly and was pushed. Data carries only pr and issue kind — never PR
 	// titles, branch names, or agent output.
 	EventPRConflictAutoResolved = "pr_monitor.conflict_auto_resolved"
-	EventReviewStarted          = "review.agent_started"
-	EventFixReviewStarted       = "fix_review.agent_started"
-	EventReviewPublished        = "review.published"
-	EventTodoistImported        = "todoist.imported"
-	EventTodoistCompleted       = "todoist.completed"
-	EventRenovateCIFix          = "renovate.ci_fix_started"
-	EventHealthReport           = "health.report"
-	EventAgentStartFailed       = "agent.start_failed"
-	EventProviderGateBlocked    = "provider.gate_blocked"
-	EventHumanReviewSpawned     = "human_review.spawned"
-	EventHumanReviewVerdict     = "human_review.verdict"
-	EventHumanReviewIssue       = "human_review.issue_filed"
-	EventHumanReviewSkipped     = "human_review.skipped"
-	EventExperienceRecorded     = "experience.recorded"
-	EventExperienceSkipped      = "experience.skipped"
-	EventExperienceInjected     = "experience.injected"
+	// EventBranchConflictAutoResolved records that a no-PR worktree-prep
+	// rebase conflict was recovered autonomously by merging base into the
+	// task's own branch and resuming its interrupted workflow/stage. Data
+	// carries only the task ID (via the audit envelope) — never branch
+	// names, commit SHAs, or agent output.
+	EventBranchConflictAutoResolved = "pr_monitor.branch_conflict_auto_resolved"
+	EventReviewStarted              = "review.agent_started"
+	EventFixReviewStarted           = "fix_review.agent_started"
+	EventReviewPublished            = "review.published"
+	EventTodoistImported            = "todoist.imported"
+	EventTodoistCompleted           = "todoist.completed"
+	EventRenovateCIFix              = "renovate.ci_fix_started"
+	EventHealthReport               = "health.report"
+	EventAgentStartFailed           = "agent.start_failed"
+	EventProviderGateBlocked        = "provider.gate_blocked"
+	EventHumanReviewSpawned         = "human_review.spawned"
+	EventHumanReviewVerdict         = "human_review.verdict"
+	EventHumanReviewIssue           = "human_review.issue_filed"
+	EventHumanReviewSkipped         = "human_review.skipped"
+	EventExperienceRecorded         = "experience.recorded"
+	EventExperienceSkipped          = "experience.skipped"
+	EventExperienceInjected         = "experience.injected"
 
 	// EventTaskLanded records a task's terminal outcome (merged/closed) with
 	// queue-inclusive and work-based timing for the evaluation scorecard.

--- a/internal/github/monitor.go
+++ b/internal/github/monitor.go
@@ -6,10 +6,15 @@ import "strconv"
 type PRIssueKind string
 
 const (
-	PRIssueConflict     PRIssueKind = "conflict"
-	PRIssueCIFailure    PRIssueKind = "ci_failure"
-	PRIssueComments     PRIssueKind = "comments"
-	PRIssueReadyToMerge PRIssueKind = "ready_to_merge"
+	PRIssueConflict PRIssueKind = "conflict"
+	// PRIssueBranchConflictNoPR is a tracker-only kind for branch-conflict
+	// recovery before a task has opened a PR. It is never emitted by PR monitor
+	// matching and exists only to keep its retry budget separate from PR-backed
+	// conflicts.
+	PRIssueBranchConflictNoPR PRIssueKind = "branch_conflict_no_pr"
+	PRIssueCIFailure          PRIssueKind = "ci_failure"
+	PRIssueComments           PRIssueKind = "comments"
+	PRIssueReadyToMerge       PRIssueKind = "ready_to_merge"
 )
 
 // PRIssue represents a detected problem on a PR linked to a task.

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -248,7 +248,12 @@ func (a *App) Startup(ctx context.Context) error {
 	} else {
 		a.emit = func(string, any) {}
 	}
-	emit := func(event string, data any) { //nolint:contextcheck // workflow engine uses its own e.ctx field, see Startup's contextcheck note
+	// This closure's DispatchEvent -> execShell eventually derives its
+	// context from workflow.Engine's own e.ctx field (Engine.SetContext),
+	// not an explicit parameter threaded through the closure. contextcheck
+	// no longer flags this call site (verified with a clean build+lint
+	// cache), so no suppression directive is needed here.
+	emit := func(event string, data any) {
 		switch event {
 		case events.TaskCreated, events.TaskUpdated, events.TaskDeleted:
 			if path, ok := data.(string); ok {

--- a/internal/sybra/app_rebase_recover_test.go
+++ b/internal/sybra/app_rebase_recover_test.go
@@ -323,6 +323,281 @@ func setupRebaseRecoveryReviewHandler(t *testing.T, withConflictWorkflow bool) (
 	return r, tk
 }
 
+// mechanicalBranchConflictFixYAML is a stand-in for the real
+// branch-conflict-fix builtin (internal/workflow/builtin/branch-conflict-fix.yaml)
+// with its run_agent step removed, mirroring the existing
+// mechanicalPRFixYAML/wait_human convention used elsewhere in this package's
+// tests (see setupRebaseRecoveryReviewHandler's "pr-conflict-fix-test"
+// stand-in) to dispatch a real recovery workflow deterministically without
+// spawning a real agent process. Exercises the same set_status ->
+// resume_workflow chain the real workflow ends with; the run_agent/
+// route_pr_fix_result/verify_commits/detect_tampering steps this omits are
+// covered by the workflow package's own tests (TestBuiltinDefinitions_Valid
+// validates the real production YAML parses; TestExecResumeWorkflow_*
+// exercises resume_workflow directly).
+const branchConflictFixTestWorkflowID = "branch-conflict-fix"
+
+// setupBranchConflictNoPRReviewHandler mirrors setupRebaseRecoveryReviewHandler
+// but for the no-PR path: the task carries no PRNumber, and its branch
+// already exists (checked out, then returned to main so a managed worktree
+// can be added for it) so PrepareForBranchFix can resolve it by name instead
+// of via a PR lookup.
+func setupBranchConflictNoPRReviewHandler(t *testing.T, initialStatus task.Status, priorWorkflow *workflow.Execution) (*ReviewHandler, task.Task) {
+	t.Helper()
+
+	a := setupApp(t)
+	tmp := t.TempDir()
+	repo := filepath.Join(tmp, "repo")
+	runGit(t, "", "init", "-b", "main", repo)
+	runGit(t, repo, "config", "user.email", "test@example.com")
+	runGit(t, repo, "config", "user.name", "Test User")
+	runGit(t, repo, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", "initial")
+	runGit(t, repo, "checkout", "-b", "feature/no-pr-recover")
+	if err := os.WriteFile(filepath.Join(repo, "work.md"), []byte("wip\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, repo, "add", "work.md")
+	runGit(t, repo, "commit", "-m", "task work")
+	// Leave the branch un-checked-out so a managed worktree can be added for
+	// it (git refuses to check out a branch already checked out elsewhere).
+	runGit(t, repo, "checkout", "main")
+
+	projects, err := project.NewStore(filepath.Join(tmp, "projects"), filepath.Join(tmp, "clones"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedExperienceProject(t, filepath.Join(tmp, "projects"), project.Project{
+		ID:        "owner/repo",
+		Name:      "repo",
+		Owner:     "owner",
+		Repo:      "repo",
+		URL:       "https://github.com/owner/repo",
+		ClonePath: repo,
+		Type:      project.ProjectTypePet,
+	})
+
+	wfStore, err := workflow.NewStore(filepath.Join(tmp, "workflows"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := wfStore.Save(workflow.Definition{
+		ID:   branchConflictFixTestWorkflowID,
+		Name: "Branch conflict fix (test stand-in)",
+		Trigger: workflow.Trigger{On: "task.status_changed", Conditions: []workflow.Condition{{
+			Field: "task.tags", Operator: "contains", Value: "__never_dispatch_branch_conflict_fix_test__",
+		}}},
+		Steps: []workflow.Step{
+			{
+				ID:   "set_recovering",
+				Name: "Mark Recovering",
+				Type: workflow.StepSetStatus,
+				Config: workflow.StepConfig{
+					Status:       "in-progress",
+					StatusReason: "recovering from a branch conflict (no PR yet)",
+				},
+				Next: []workflow.Transition{{GoTo: "await_fix"}},
+			},
+			// A wait_human stand-in for the real workflow's run_agent "fix"
+			// step: like run_agent, it is an async step that breaks the
+			// synchronous chain, matching the real workflow's structure
+			// (resume_original always sits behind an async step) closely
+			// enough for this test — StartWorkflowWithVars returns once it
+			// parks here instead of running resume_original nested inside its
+			// own "starting" marker, exactly like the real "fix" run_agent
+			// step does in production.
+			{
+				ID:   "await_fix",
+				Name: "Await Fix",
+				Type: workflow.StepWaitHuman,
+				Config: workflow.StepConfig{
+					HumanActions: []string{"done"},
+				},
+				Next: []workflow.Transition{{GoTo: "resume_original"}},
+			},
+			{
+				ID:   "resume_original",
+				Name: "Resume Interrupted Workflow",
+				Type: workflow.StepResumeWorkflow,
+				Next: []workflow.Transition{{GoTo: ""}},
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// Mechanical stand-in resume target (no run_agent step, same rationale as
+	// above): lets the happy-path test assert that resume_workflow actually
+	// re-entered and ran the captured workflow, deterministically and without
+	// spawning a real agent.
+	if err := wfStore.Save(workflow.Definition{
+		ID:   "resume-target-test",
+		Name: "Resume target (test stand-in)",
+		Trigger: workflow.Trigger{On: "task.status_changed", Conditions: []workflow.Condition{{
+			Field: "task.tags", Operator: "contains", Value: "__never_dispatch_resume_target_test__",
+		}}},
+		Steps: []workflow.Step{{
+			ID:   "mark_resumed",
+			Name: "Mark Resumed",
+			Type: workflow.StepSetStatus,
+			Config: workflow.StepConfig{
+				Status: "in-review",
+			},
+			Next: []workflow.Transition{{GoTo: ""}},
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	engine := workflow.NewEngine(wfStore,
+		&taskAdapter{tasks: a.tasks},
+		&agentAdapter{agents: a.agents, tasks: a.tasks},
+		a.logger,
+	)
+	r := &ReviewHandler{
+		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler), emit: func(string, any) {}},
+		tasks:         a.tasks,
+		projects:      projects,
+		agents:        a.agents,
+		prTracker:     github.NewIssueTracker(0),
+		worktrees: worktree.New(worktree.Config{
+			WorktreesDir: filepath.Join(tmp, "worktrees"),
+			Projects:     projects,
+			Tasks:        a.tasks,
+			Logger:       slog.New(slog.DiscardHandler),
+		}),
+		workflowEngine: engine,
+		wtFailures:     make(map[string]int),
+	}
+
+	tk, err := a.tasks.Create("no pr rebase recover", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tk, err = a.tasks.Update(tk.ID, task.Update{
+		ProjectID: task.Ptr("owner/repo"),
+		Branch:    task.Ptr("feature/no-pr-recover"),
+		Status:    task.Ptr(initialStatus),
+		Workflow:  &priorWorkflow,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r, tk
+}
+
+// TestRecoverBranchConflictNoPR_ReturnsTrueAndDispatchesRecoveryWorkflow
+// verifies the happy path: a task with no PR yet, whose branch already
+// exists, gets its worktree prepared via PrepareForBranchFix, the recovery
+// workflow is dispatched (never jumped straight to a terminal status), the
+// captured interrupted workflow is resumed by resume_workflow (not skipped),
+// and the conflict-issue retry budget is marked handled so the same
+// conflict doesn't immediately re-trigger.
+func TestRecoverBranchConflictNoPR_ReturnsTrueAndDispatchesRecoveryWorkflow(t *testing.T) {
+	priorWorkflow := &workflow.Execution{
+		WorkflowID:  "resume-target-test",
+		CurrentStep: "mark_resumed",
+		State:       workflow.ExecRunning,
+		Variables:   map[string]string{"attempt": "1"},
+	}
+	r, tk := setupBranchConflictNoPRReviewHandler(t, task.StatusTesting, priorWorkflow)
+
+	if !r.recoverStaleBranchConflict(tk.ID) {
+		t.Fatal("recoverStaleBranchConflict returned false for a no-PR task with a real branch")
+	}
+
+	got, err := r.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status == task.StatusHumanRequired {
+		t.Fatalf("status = %q, want dispatched recovery instead of human-required", got.Status)
+	}
+	// set_recovering (sync) ran and the workflow parked at the async
+	// await_fix step (the stand-in for the real workflow's run_agent "fix"
+	// step) — the same shape as production, where resume_workflow only ever
+	// runs after that async step's own completion drives AdvanceStep forward.
+	if got.Workflow == nil || got.Workflow.WorkflowID != branchConflictFixTestWorkflowID {
+		t.Fatalf("workflow = %+v, want %s dispatched", got.Workflow, branchConflictFixTestWorkflowID)
+	}
+	if got.Workflow.CurrentStep != "await_fix" {
+		t.Fatalf("current step = %q, want await_fix", got.Workflow.CurrentStep)
+	}
+	// The captured interrupted workflow (ID + a copy of its vars) and the
+	// task's pre-recovery status travel with the recovery execution so
+	// resume_workflow can re-enter the exact interrupted stage once the fix
+	// lands — proven directly (without a real agent) by
+	// TestExecResumeWorkflow_ResumesCapturedTarget in the workflow package.
+	if resumeID := got.Workflow.Variables["resume_workflow_id"]; resumeID != "resume-target-test" {
+		t.Fatalf("resume_workflow_id = %q, want captured resume-target-test", resumeID)
+	}
+	if resumeStatus := got.Workflow.Variables["resume_status"]; resumeStatus != string(task.StatusTesting) {
+		t.Fatalf("resume_status = %q, want captured %q", resumeStatus, task.StatusTesting)
+	}
+	if resumeVars := got.Workflow.Variables["resume_workflow_vars"]; resumeVars != `{"attempt":"1"}` {
+		t.Fatalf("resume_workflow_vars = %q, want captured prior workflow vars", resumeVars)
+	}
+	if r.prTracker.Retries(tk.ID, github.PRIssueConflict) == 0 {
+		t.Fatal("conflict issue was not marked handled after recovery dispatch")
+	}
+}
+
+// TestRecoverBranchConflictNoPR_AtCapEscalates verifies the retry-budget
+// guard: an exhausted github.PRIssueConflict budget (reused, not a new kind)
+// returns false so the caller escalates to human-required instead of
+// retrying forever on a genuinely unresolvable conflict.
+func TestRecoverBranchConflictNoPR_AtCapEscalates(t *testing.T) {
+	r, tk := setupBranchConflictNoPRReviewHandler(t, task.StatusInProgress, nil)
+	for range github.MaxRetries {
+		r.prTracker.MarkHandled(tk.ID, github.PRIssueConflict, "somesha")
+	}
+
+	if r.recoverStaleBranchConflict(tk.ID) {
+		t.Fatal("recoverStaleBranchConflict returned true despite exhausted retry budget")
+	}
+	got, err := r.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Workflow != nil {
+		t.Fatalf("workflow = %+v, want no recovery workflow dispatched", got.Workflow)
+	}
+}
+
+// TestRecoverBranchConflictNoPR_MissingBranchEscalates verifies that a task
+// whose branch does not exist (PrepareForBranchFix returns
+// worktree.ErrTaskBranchMissing) fails closed rather than guessing at a ref.
+func TestRecoverBranchConflictNoPR_MissingBranchEscalates(t *testing.T) {
+	r, tk := setupBranchConflictNoPRReviewHandler(t, task.StatusInProgress, nil)
+	if _, err := r.tasks.Update(tk.ID, task.Update{Branch: task.Ptr("branch/does-not-exist")}); err != nil {
+		t.Fatal(err)
+	}
+
+	if r.recoverStaleBranchConflict(tk.ID) {
+		t.Fatal("recoverStaleBranchConflict returned true for a missing branch")
+	}
+}
+
+// TestRecoverBranchConflictNoPR_InFlightGuardPreventsDoubleDispatch verifies
+// that a second recovery attempt for a task already mid-recovery bails out
+// instead of starting a duplicate worktree prep / workflow dispatch.
+func TestRecoverBranchConflictNoPR_InFlightGuardPreventsDoubleDispatch(t *testing.T) {
+	r, tk := setupBranchConflictNoPRReviewHandler(t, task.StatusInProgress, nil)
+	r.branchRecoveryMu.Lock()
+	r.branchRecoveryInFlight = map[string]struct{}{tk.ID: {}}
+	r.branchRecoveryMu.Unlock()
+
+	if r.recoverStaleBranchConflict(tk.ID) {
+		t.Fatal("recoverStaleBranchConflict returned true while a recovery was already marked in-flight")
+	}
+	if r.prTracker.Retries(tk.ID, github.PRIssueConflict) != 0 {
+		t.Fatal("conflict issue was marked handled despite the in-flight guard rejecting the attempt")
+	}
+}
+
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)

--- a/internal/sybra/app_rebase_recover_test.go
+++ b/internal/sybra/app_rebase_recover_test.go
@@ -504,6 +504,10 @@ func TestRecoverBranchConflictNoPR_ReturnsTrueAndDispatchesRecoveryWorkflow(t *t
 		Variables:   map[string]string{"attempt": "1"},
 	}
 	r, tk := setupBranchConflictNoPRReviewHandler(t, task.StatusTesting, priorWorkflow)
+	tk, err := r.tasks.Update(tk.ID, task.Update{StatusReason: task.Ptr("paused for testing before recovery")})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if !r.recoverStaleBranchConflict(tk.ID) {
 		t.Fatal("recoverStaleBranchConflict returned false for a no-PR task with a real branch")
@@ -539,6 +543,9 @@ func TestRecoverBranchConflictNoPR_ReturnsTrueAndDispatchesRecoveryWorkflow(t *t
 	}
 	if resumeStatus := got.Workflow.Variables["resume_status"]; resumeStatus != string(task.StatusTesting) {
 		t.Fatalf("resume_status = %q, want captured %q", resumeStatus, task.StatusTesting)
+	}
+	if resumeStatusReason := got.Workflow.Variables["resume_status_reason"]; resumeStatusReason != "paused for testing before recovery" {
+		t.Fatalf("resume_status_reason = %q, want captured pre-recovery reason", resumeStatusReason)
 	}
 	if resumeVars := got.Workflow.Variables["resume_workflow_vars"]; resumeVars != `{"attempt":"1"}` {
 		t.Fatalf("resume_workflow_vars = %q, want captured prior workflow vars", resumeVars)

--- a/internal/sybra/app_rebase_recover_test.go
+++ b/internal/sybra/app_rebase_recover_test.go
@@ -534,25 +534,31 @@ func TestRecoverBranchConflictNoPR_ReturnsTrueAndDispatchesRecoveryWorkflow(t *t
 	if resumeID := got.Workflow.Variables["resume_workflow_id"]; resumeID != "resume-target-test" {
 		t.Fatalf("resume_workflow_id = %q, want captured resume-target-test", resumeID)
 	}
+	if resumeStep := got.Workflow.Variables["resume_workflow_step"]; resumeStep != "mark_resumed" {
+		t.Fatalf("resume_workflow_step = %q, want captured mark_resumed", resumeStep)
+	}
 	if resumeStatus := got.Workflow.Variables["resume_status"]; resumeStatus != string(task.StatusTesting) {
 		t.Fatalf("resume_status = %q, want captured %q", resumeStatus, task.StatusTesting)
 	}
 	if resumeVars := got.Workflow.Variables["resume_workflow_vars"]; resumeVars != `{"attempt":"1"}` {
 		t.Fatalf("resume_workflow_vars = %q, want captured prior workflow vars", resumeVars)
 	}
-	if r.prTracker.Retries(tk.ID, github.PRIssueConflict) == 0 {
-		t.Fatal("conflict issue was not marked handled after recovery dispatch")
+	if r.prTracker.Retries(tk.ID, github.PRIssueBranchConflictNoPR) == 0 {
+		t.Fatal("branch-conflict retry budget was not marked handled after recovery dispatch")
+	}
+	if r.prTracker.Retries(tk.ID, github.PRIssueConflict) != 0 {
+		t.Fatal("PR conflict retry budget should stay untouched for no-PR recovery")
 	}
 }
 
 // TestRecoverBranchConflictNoPR_AtCapEscalates verifies the retry-budget
-// guard: an exhausted github.PRIssueConflict budget (reused, not a new kind)
+// guard: an exhausted branch-conflict-no-PR budget
 // returns false so the caller escalates to human-required instead of
 // retrying forever on a genuinely unresolvable conflict.
 func TestRecoverBranchConflictNoPR_AtCapEscalates(t *testing.T) {
 	r, tk := setupBranchConflictNoPRReviewHandler(t, task.StatusInProgress, nil)
 	for range github.MaxRetries {
-		r.prTracker.MarkHandled(tk.ID, github.PRIssueConflict, "somesha")
+		r.prTracker.MarkHandled(tk.ID, github.PRIssueBranchConflictNoPR, "somesha")
 	}
 
 	if r.recoverStaleBranchConflict(tk.ID) {
@@ -593,8 +599,78 @@ func TestRecoverBranchConflictNoPR_InFlightGuardPreventsDoubleDispatch(t *testin
 	if r.recoverStaleBranchConflict(tk.ID) {
 		t.Fatal("recoverStaleBranchConflict returned true while a recovery was already marked in-flight")
 	}
-	if r.prTracker.Retries(tk.ID, github.PRIssueConflict) != 0 {
-		t.Fatal("conflict issue was marked handled despite the in-flight guard rejecting the attempt")
+	if r.prTracker.Retries(tk.ID, github.PRIssueBranchConflictNoPR) != 0 {
+		t.Fatal("branch-conflict retry budget was marked handled despite the in-flight guard rejecting the attempt")
+	}
+}
+
+func TestRecoverBranchConflictNoPR_DispatchFailureRestoresPriorWorkflow(t *testing.T) {
+	priorWorkflow := &workflow.Execution{
+		WorkflowID:  "resume-target-test",
+		CurrentStep: "mark_resumed",
+		State:       workflow.ExecRunning,
+		Variables:   map[string]string{"attempt": "2"},
+	}
+	r, tk := setupBranchConflictNoPRReviewHandler(t, task.StatusTesting, priorWorkflow)
+	emptyStore, err := workflow.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.workflowEngine = workflow.NewEngine(emptyStore, &taskAdapter{tasks: r.tasks}, &agentAdapter{agents: r.agents, tasks: r.tasks}, slog.New(slog.DiscardHandler))
+
+	if r.recoverStaleBranchConflict(tk.ID) {
+		t.Fatal("recoverBranchConflictNoPR returned true despite dispatch failure")
+	}
+
+	got, err := r.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusTesting {
+		t.Fatalf("status = %q, want restored %q", got.Status, task.StatusTesting)
+	}
+	if got.Workflow == nil || got.Workflow.WorkflowID != priorWorkflow.WorkflowID {
+		t.Fatalf("workflow = %+v, want restored prior workflow", got.Workflow)
+	}
+	if got.Workflow.CurrentStep != priorWorkflow.CurrentStep {
+		t.Fatalf("current step = %q, want restored %q", got.Workflow.CurrentStep, priorWorkflow.CurrentStep)
+	}
+	if got.Workflow.State != priorWorkflow.State {
+		t.Fatalf("state = %q, want restored %q", got.Workflow.State, priorWorkflow.State)
+	}
+}
+
+func TestRecoverBranchConflictNoPR_WorktreeFailuresTripCircuitBreaker(t *testing.T) {
+	r, tk := setupBranchConflictNoPRReviewHandler(t, task.StatusInProgress, nil)
+	if _, err := r.tasks.Update(tk.ID, task.Update{Branch: task.Ptr("branch/does-not-exist")}); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := range wtFailureLimit - 1 {
+		if r.recoverStaleBranchConflict(tk.ID) {
+			t.Fatalf("call %d: want false on worktree failure", i+1)
+		}
+		got, err := r.tasks.Get(tk.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status == task.StatusHumanRequired {
+			t.Fatalf("call %d: escalated too early", i+1)
+		}
+	}
+
+	if r.recoverStaleBranchConflict(tk.ID) {
+		t.Fatal("circuit-open call: want false")
+	}
+	got, err := r.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q after circuit break, want human-required", got.Status)
+	}
+	if n := r.wtFailures[tk.ID]; n != 0 {
+		t.Fatalf("wtFailures[%s] = %d after circuit trip, want 0", tk.ID, n)
 	}
 }
 

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -417,7 +417,7 @@ func (r *ReviewHandler) handleKnownPRConflictsViaREST(ctx context.Context, tasks
 		matched := github.MatchTaskPRs(monitoredPRs, matchers)
 		for i := range matched {
 			switch matched[i].Kind {
-			case github.PRIssueConflict, github.PRIssueCIFailure, github.PRIssueReadyToMerge:
+			case github.PRIssueConflict, github.PRIssueBranchConflictNoPR, github.PRIssueCIFailure, github.PRIssueReadyToMerge:
 				handled = append(handled, matched[i])
 			case github.PRIssueComments:
 				// REST exposes no thread-resolution data; comments stay

--- a/internal/sybra/app_reviews.go
+++ b/internal/sybra/app_reviews.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Automaat/sybra/internal/agent"
@@ -98,6 +99,17 @@ type ReviewHandler struct {
 	// Used by the single-PR conflict-recovery path. Overridable in tests; nil
 	// falls back to github.FetchPRForMonitor.
 	fetchKnownPRFn func(repo string, number int) (github.PullRequest, bool, error)
+	// branchRecoveryMu guards branchRecoveryInFlight, the in-flight marker set
+	// for recoverBranchConflictNoPR (the no-PR sibling of the PR-numbered
+	// conflict recovery above). recoverBranchConflictNoPR runs synchronously
+	// end-to-end (worktree prep, workflow dispatch), so acquiring the marker on
+	// entry and releasing it via defer brackets the whole attempt: a second
+	// worktree-prep rebase failure for the same task arriving mid-recovery
+	// (e.g. two dispatch paths both hitting markRebaseBlocked) sees the marker
+	// set and bails out to human-required instead of starting a duplicate
+	// recovery workflow.
+	branchRecoveryMu       sync.Mutex
+	branchRecoveryInFlight map[string]struct{}
 	// fetchKnownPRsFn batches the linked-PR fetch for every task monitored by
 	// fetchKnownTaskPRs into as few GraphQL requests as possible. Secondary
 	// pollers use this to keep local task PRs moving while leaving global

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -29,6 +29,7 @@ const wtFailureLimit = 5
 
 type branchConflictResumeState struct {
 	status       string
+	statusReason string
 	workflowID   string
 	workflowStep string
 	workflowVars string
@@ -789,8 +790,9 @@ func (r *ReviewHandler) recoverBranchConflictNoPR(t task.Task) bool {
 
 func (r *ReviewHandler) captureBranchConflictResumeState(t task.Task) branchConflictResumeState {
 	state := branchConflictResumeState{
-		status: string(t.Status),
-		prior:  t.Workflow.Clone(),
+		status:       string(t.Status),
+		statusReason: t.StatusReason,
+		prior:        t.Workflow.Clone(),
 	}
 	if t.Workflow == nil {
 		return state
@@ -812,6 +814,7 @@ func (r *ReviewHandler) dispatchBranchConflictRecovery(taskID, dir, base string,
 		"prompt":                branchConflictPrompt(t, base) + prFixResultContract,
 		workflow.WorkflowVarDir: dir,
 		"resume_status":         resume.status,
+		"resume_status_reason":  resume.statusReason,
 	}
 	if resume.workflowID != "" {
 		vars["resume_workflow_id"] = resume.workflowID

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -2,8 +2,10 @@ package sybra
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -15,6 +17,12 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/workflow"
 )
+
+// branchConflictFixWorkflowID is the builtin workflow started directly (by
+// ID, via StartWorkflowWithVars) to recover a no-PR branch conflict. It is
+// never reached via DispatchEvent/trigger matching — see
+// internal/workflow/builtin/branch-conflict-fix.yaml.
+const branchConflictFixWorkflowID = "branch-conflict-fix"
 
 const wtFailureLimit = 5
 
@@ -427,7 +435,9 @@ func (r *ReviewHandler) dispatchFixIssues(ctx context.Context, taskID string, ha
 	// dispatchPRIssue -> workflowEngine.DispatchEvent eventually reaches
 	// execShell, which derives its context from workflow.Engine's own e.ctx
 	// field (Engine.SetContext), not an explicit parameter threaded here.
-	return r.dispatchPRIssue(t, primary, handle, coalescedFixPrompt(handle, reviewHoldFixSuffix(r.cfg)), dir) //nolint:contextcheck // Engine uses its own e.ctx field, see comment above
+	// contextcheck no longer flags this call site (verified with a clean
+	// build+lint cache), so no suppression directive is needed here.
+	return r.dispatchPRIssue(t, primary, handle, coalescedFixPrompt(handle, reviewHoldFixSuffix(r.cfg)), dir)
 }
 
 // autoResolveConflict attempts the deterministic clean-merge fast-path for a
@@ -639,8 +649,17 @@ func (r *ReviewHandler) recoverStaleBranchConflict(taskID string) bool {
 		return false
 	}
 	t, err := r.tasks.Get(taskID)
-	if err != nil || t.PRNumber == 0 || t.ProjectID == "" {
+	if err != nil || t.ProjectID == "" {
 		return false
+	}
+	// No PR yet (still in implementation/review/testing, or at create_pr) —
+	// there is no PR to check out via the PR-numbered path below. Resolve the
+	// task's own branch by name instead. This never re-enters the PR-numbered
+	// branch: recoverBranchConflictNoPR has its own return, so the code below
+	// (and its byte-for-byte behavior for t.PRNumber != 0) is unreachable from
+	// this branch.
+	if t.PRNumber == 0 {
+		return r.recoverBranchConflictNoPR(t)
 	}
 	// Don't loop forever on a genuinely unresolvable conflict — once the
 	// conflict-fix budget is spent the normal exhaustion path escalates.
@@ -671,6 +690,164 @@ func (r *ReviewHandler) recoverStaleBranchConflict(taskID string) bool {
 	// wired as AgentOrchestrator.conflictRecovery, a fixed func(taskID string)
 	// bool callback (see app_agents.go) with no ctx parameter to thread from.
 	return r.handlePRIssue(context.Background(), github.PRIssue{TaskID: taskID, Kind: github.PRIssueConflict, PR: pr})
+}
+
+// recoverBranchConflictNoPR is the no-PR sibling of recoverStaleBranchConflict:
+// the task has no linked PR yet (still in implementation/review/testing, or
+// at create_pr), so there is no PR head to check out. Instead it resolves the
+// task's OWN branch by name (PrepareForBranchFix), merges base into it via a
+// bounded headless pr-fix sub-run (branch-conflict-fix workflow — a merge,
+// never a rebase, so a plain push always succeeds), and on success resumes
+// the task's original interrupted workflow/stage rather than jumping to a
+// terminal status.
+//
+// Guards fail closed exactly like the PR-numbered path: a missing dependency,
+// an exhausted github.PRIssueConflict retry budget (reused — no separate
+// branch-conflict retry-budget kind is added), or an already-in-flight
+// recovery for this task
+// (branchRecoveryMu/branchRecoveryInFlight) all return false so the caller
+// (markRebaseBlocked) escalates to human-required as before. Never loops:
+// a conflict discovered while resolving THIS conflict re-enters
+// markRebaseBlocked -> recoverStaleBranchConflict -> here, and the in-flight
+// marker (still held from the outer call, since this method runs
+// synchronously start to finish) makes the re-entrant call bail out
+// immediately.
+func (r *ReviewHandler) recoverBranchConflictNoPR(t task.Task) bool {
+	taskID := t.ID
+	if r.prTracker.AtCap(taskID, github.PRIssueConflict) {
+		return false
+	}
+
+	r.branchRecoveryMu.Lock()
+	if r.branchRecoveryInFlight == nil {
+		r.branchRecoveryInFlight = make(map[string]struct{})
+	}
+	if _, busy := r.branchRecoveryInFlight[taskID]; busy {
+		r.branchRecoveryMu.Unlock()
+		return false
+	}
+	r.branchRecoveryInFlight[taskID] = struct{}{}
+	r.branchRecoveryMu.Unlock()
+	defer func() {
+		r.branchRecoveryMu.Lock()
+		delete(r.branchRecoveryInFlight, taskID)
+		r.branchRecoveryMu.Unlock()
+	}()
+
+	proj, err := r.projects.Get(t.ProjectID)
+	if err != nil {
+		r.logger.Warn("pr-monitor.branch-conflict.project", "task_id", taskID, "err", err)
+		return false
+	}
+	ctx := context.Background()
+	base, err := project.DefaultBranch(ctx, proj.ClonePath)
+	if err != nil {
+		r.logger.Warn("pr-monitor.branch-conflict.base", "task_id", taskID, "err", err)
+		return false
+	}
+	base = strings.TrimSpace(base)
+	if base == "" {
+		r.logger.Warn("pr-monitor.branch-conflict.base-empty", "task_id", taskID)
+		return false
+	}
+
+	dir, err := r.worktrees.PrepareForBranchFix(ctx, t)
+	if err != nil {
+		r.logger.Warn("pr-monitor.branch-conflict.prepare", "task_id", taskID, "err", err)
+		return false
+	}
+	// Refetch: PrepareForBranchFix's ensureBranch call may have just set
+	// t.Branch for the first time (a task whose worktree never got created
+	// before this recovery), and branchConflictPrompt needs the resolved name.
+	if refetched, gerr := r.tasks.Get(taskID); gerr == nil {
+		t = refetched
+	}
+
+	// Capture the task's currently-active workflow (ID + a copy of its vars)
+	// and its visible status BEFORE cancelling anything, so the recovery
+	// workflow's terminal resume_workflow step can re-enter the exact stage
+	// that was interrupted — never skipping review/testing gates — instead of
+	// stranding the task on whatever transient status the recovery itself
+	// sets.
+	resumeStatus := string(t.Status)
+	var resumeWorkflowID string
+	var resumeVarsJSON string
+	if t.Workflow != nil {
+		resumeWorkflowID = t.Workflow.WorkflowID
+		captured := make(map[string]string, len(t.Workflow.Variables))
+		maps.Copy(captured, t.Workflow.Variables)
+		if encoded, mErr := json.Marshal(captured); mErr == nil {
+			resumeVarsJSON = string(encoded)
+		} else {
+			r.logger.Warn("pr-monitor.branch-conflict.resume-vars-encode", "task_id", taskID, "err", mErr)
+		}
+	}
+	if r.workflowEngine.HasActiveWorkflow(taskID) {
+		if _, cancelErr := r.workflowEngine.CancelWorkflow(taskID, "branch conflict recovery"); cancelErr != nil {
+			r.logger.Error("pr-monitor.branch-conflict.cancel-active-workflow", "task_id", taskID, "err", cancelErr)
+			return false
+		}
+	}
+
+	headSHA, shaErr := project.CurrentCommit(ctx, dir)
+	if shaErr != nil {
+		r.logger.Warn("pr-monitor.branch-conflict.head-sha", "task_id", taskID, "err", shaErr)
+	}
+
+	vars := map[string]string{
+		"prompt":                branchConflictPrompt(t, base) + prFixResultContract,
+		workflow.WorkflowVarDir: dir,
+		"resume_status":         resumeStatus,
+	}
+	if resumeWorkflowID != "" {
+		vars["resume_workflow_id"] = resumeWorkflowID
+		vars["resume_workflow_vars"] = resumeVarsJSON
+	}
+
+	if err := r.workflowEngine.StartWorkflowWithVars(taskID, branchConflictFixWorkflowID, vars); err != nil {
+		r.logger.Error("pr-monitor.branch-conflict.dispatch", "task_id", taskID, "err", err)
+		return false
+	}
+
+	r.prTracker.MarkHandled(taskID, github.PRIssueConflict, headSHA)
+	r.logAudit(audit.EventBranchConflictAutoResolved, taskID, "", map[string]any{})
+	r.logger.Info("pr-monitor.branch-conflict.recovered", "task_id", taskID)
+	return true
+}
+
+// branchConflictPrompt is the no-PR analog of buildConflictPrompt: there is no
+// PR head to reference, so it resolves the task's own branch (t.Branch, set
+// by PrepareForBranchFix before this is called) and instructs a plain merge
+// (never a rebase, so a plain push is always expected to succeed).
+func branchConflictPrompt(t task.Task, base string) string {
+	branch := t.Branch
+	if branch == "" {
+		branch = "the task's current branch"
+	}
+	return fmt.Sprintf(
+		"Fix merge conflicts on branch `%s` (this task has no PR yet). "+
+			"Use the task description and current code as context, then merge.\n\n"+
+			"Steps:\n"+
+			"```bash\n"+
+			"git fetch origin\n"+
+			"git merge refs/remotes/origin/%s\n"+
+			"# If the merge stopped for conflicts: resolve every conflict preserving\n"+
+			"# this branch's intent and the upstream changes, run targeted tests for\n"+
+			"# touched code, then git add and git commit to complete the merge.\n"+
+			"# If the merge already completed on its own (clean/fast-forward, no\n"+
+			"# conflicts), it is already committed — do not run git commit again, it\n"+
+			"# will fail with \"nothing to commit\". Still run targeted tests before pushing.\n"+
+			"git push origin HEAD:%s\n"+
+			"```\n\n"+
+			"Rules:\n"+
+			"- Use `refs/remotes/origin/%s` (not `origin/%s`) to avoid ambiguous refs\n"+
+			"- Do not force-push or rewrite existing commits — this is a merge, never a rebase; a plain push is always expected to succeed\n"+
+			"- Resolve conflicts keeping BOTH sides' intent\n"+
+			"- Do not stop just because the conflict count is high — split by file and resolve all conflicts autonomously\n"+
+			"- Stop only for a concrete blocker: binary conflict, missing secret/credential, deleted context you cannot reconstruct, or a semantic decision that the task context does not answer\n"+
+			"- No investigation, no extra commits, no unrelated changes",
+		branch, base, branch, base, base,
+	)
 }
 
 // prepareWorktree sets up the fix worktree for the given task and PR issue.

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -23,6 +23,7 @@ import (
 // never reached via DispatchEvent/trigger matching — see
 // internal/workflow/builtin/branch-conflict-fix.yaml.
 const branchConflictFixWorkflowID = "branch-conflict-fix"
+const branchConflictRetryKind = github.PRIssueBranchConflictNoPR
 
 const wtFailureLimit = 5
 
@@ -702,8 +703,7 @@ func (r *ReviewHandler) recoverStaleBranchConflict(taskID string) bool {
 // terminal status.
 //
 // Guards fail closed exactly like the PR-numbered path: a missing dependency,
-// an exhausted github.PRIssueConflict retry budget (reused — no separate
-// branch-conflict retry-budget kind is added), or an already-in-flight
+// an exhausted no-PR branch-conflict retry budget, or an already-in-flight
 // recovery for this task
 // (branchRecoveryMu/branchRecoveryInFlight) all return false so the caller
 // (markRebaseBlocked) escalates to human-required as before. Never loops:
@@ -714,7 +714,7 @@ func (r *ReviewHandler) recoverStaleBranchConflict(taskID string) bool {
 // immediately.
 func (r *ReviewHandler) recoverBranchConflictNoPR(t task.Task) bool {
 	taskID := t.ID
-	if r.prTracker.AtCap(taskID, github.PRIssueConflict) {
+	if r.prTracker.AtCap(taskID, branchConflictRetryKind) {
 		return false
 	}
 
@@ -754,8 +754,10 @@ func (r *ReviewHandler) recoverBranchConflictNoPR(t task.Task) bool {
 	dir, err := r.worktrees.PrepareForBranchFix(ctx, t)
 	if err != nil {
 		r.logger.Warn("pr-monitor.branch-conflict.prepare", "task_id", taskID, "err", err)
+		r.recordWorktreeFailure(taskID, err)
 		return false
 	}
+	delete(r.wtFailures, taskID)
 	// Refetch: PrepareForBranchFix's ensureBranch call may have just set
 	// t.Branch for the first time (a task whose worktree never got created
 	// before this recovery), and branchConflictPrompt needs the resolved name.
@@ -771,9 +773,12 @@ func (r *ReviewHandler) recoverBranchConflictNoPR(t task.Task) bool {
 	// sets.
 	resumeStatus := string(t.Status)
 	var resumeWorkflowID string
+	var resumeWorkflowStep string
 	var resumeVarsJSON string
+	priorWorkflow := t.Workflow.Clone()
 	if t.Workflow != nil {
 		resumeWorkflowID = t.Workflow.WorkflowID
+		resumeWorkflowStep = t.Workflow.CurrentStep
 		captured := make(map[string]string, len(t.Workflow.Variables))
 		maps.Copy(captured, t.Workflow.Variables)
 		if encoded, mErr := json.Marshal(captured); mErr == nil {
@@ -801,18 +806,47 @@ func (r *ReviewHandler) recoverBranchConflictNoPR(t task.Task) bool {
 	}
 	if resumeWorkflowID != "" {
 		vars["resume_workflow_id"] = resumeWorkflowID
+		vars["resume_workflow_step"] = resumeWorkflowStep
 		vars["resume_workflow_vars"] = resumeVarsJSON
 	}
 
 	if err := r.workflowEngine.StartWorkflowWithVars(taskID, branchConflictFixWorkflowID, vars); err != nil {
 		r.logger.Error("pr-monitor.branch-conflict.dispatch", "task_id", taskID, "err", err)
+		if priorWorkflow != nil {
+			if _, restoreErr := r.tasks.Update(taskID, task.Update{
+				Status:   task.Ptr(task.Status(resumeStatus)),
+				Workflow: task.Ptr(priorWorkflow),
+			}); restoreErr != nil {
+				r.logger.Error("pr-monitor.branch-conflict.restore-prior-workflow", "task_id", taskID, "err", restoreErr)
+			}
+		}
 		return false
 	}
 
-	r.prTracker.MarkHandled(taskID, github.PRIssueConflict, headSHA)
+	r.prTracker.MarkHandled(taskID, branchConflictRetryKind, headSHA)
 	r.logAudit(audit.EventBranchConflictAutoResolved, taskID, "", map[string]any{})
 	r.logger.Info("pr-monitor.branch-conflict.recovered", "task_id", taskID)
 	return true
+}
+
+func (r *ReviewHandler) recordWorktreeFailure(taskID string, wtErr error) {
+	if r.wtFailures == nil {
+		r.wtFailures = make(map[string]int)
+	}
+	r.wtFailures[taskID]++
+	if r.wtFailures[taskID] >= wtFailureLimit {
+		delete(r.wtFailures, taskID)
+		r.logger.Error("pr-monitor.worktree.circuit-open",
+			"task_id", taskID, "failures", wtFailureLimit, "err", wtErr)
+		if _, uerr := r.tasks.Update(taskID, task.Update{
+			Status:       task.Ptr(task.StatusHumanRequired),
+			StatusReason: task.Ptr(fmt.Sprintf("pr-monitor: worktree creation failed %d times", wtFailureLimit)),
+		}); uerr != nil {
+			r.logger.Error("pr-monitor.worktree.escalate", "task_id", taskID, "err", uerr)
+		}
+		return
+	}
+	r.logger.Error("pr-monitor.worktree", "task_id", taskID, "err", wtErr)
 }
 
 // branchConflictPrompt is the no-PR analog of buildConflictPrompt: there is no
@@ -880,23 +914,7 @@ func (r *ReviewHandler) prepareWorktree(ctx context.Context, t task.Task, issue 
 		if markRebaseBlocked(r.tasks, t.ID, wtErr, r.logger, recoverFn) {
 			return "", false
 		}
-		if r.wtFailures == nil {
-			r.wtFailures = make(map[string]int)
-		}
-		r.wtFailures[t.ID]++
-		if r.wtFailures[t.ID] >= wtFailureLimit {
-			delete(r.wtFailures, t.ID)
-			r.logger.Error("pr-monitor.worktree.circuit-open",
-				"task_id", t.ID, "failures", wtFailureLimit, "err", wtErr)
-			if _, uerr := r.tasks.Update(t.ID, task.Update{
-				Status:       task.Ptr(task.StatusHumanRequired),
-				StatusReason: task.Ptr(fmt.Sprintf("pr-monitor: worktree creation failed %d times", wtFailureLimit)),
-			}); uerr != nil {
-				r.logger.Error("pr-monitor.worktree.escalate", "task_id", t.ID, "err", uerr)
-			}
-			return "", false
-		}
-		r.logger.Error("pr-monitor.worktree", "task_id", t.ID, "err", wtErr)
+		r.recordWorktreeFailure(t.ID, wtErr)
 		return "", false
 	}
 	delete(r.wtFailures, t.ID)

--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -27,6 +27,14 @@ const branchConflictRetryKind = github.PRIssueBranchConflictNoPR
 
 const wtFailureLimit = 5
 
+type branchConflictResumeState struct {
+	status       string
+	workflowID   string
+	workflowStep string
+	workflowVars string
+	prior        *workflow.Execution
+}
+
 const prFixResultContract = "\n\nBefore your final response, decide the outcome:\n" +
 	"- If you completed and pushed the fix, end with `SYBRA_PR_FIX_RESULT: continue`.\n" +
 	"- If you intentionally stopped because the PR needs a human, end with " +
@@ -764,29 +772,7 @@ func (r *ReviewHandler) recoverBranchConflictNoPR(t task.Task) bool {
 	if refetched, gerr := r.tasks.Get(taskID); gerr == nil {
 		t = refetched
 	}
-
-	// Capture the task's currently-active workflow (ID + a copy of its vars)
-	// and its visible status BEFORE cancelling anything, so the recovery
-	// workflow's terminal resume_workflow step can re-enter the exact stage
-	// that was interrupted — never skipping review/testing gates — instead of
-	// stranding the task on whatever transient status the recovery itself
-	// sets.
-	resumeStatus := string(t.Status)
-	var resumeWorkflowID string
-	var resumeWorkflowStep string
-	var resumeVarsJSON string
-	priorWorkflow := t.Workflow.Clone()
-	if t.Workflow != nil {
-		resumeWorkflowID = t.Workflow.WorkflowID
-		resumeWorkflowStep = t.Workflow.CurrentStep
-		captured := make(map[string]string, len(t.Workflow.Variables))
-		maps.Copy(captured, t.Workflow.Variables)
-		if encoded, mErr := json.Marshal(captured); mErr == nil {
-			resumeVarsJSON = string(encoded)
-		} else {
-			r.logger.Warn("pr-monitor.branch-conflict.resume-vars-encode", "task_id", taskID, "err", mErr)
-		}
-	}
+	resume := r.captureBranchConflictResumeState(t)
 	if r.workflowEngine.HasActiveWorkflow(taskID) {
 		if _, cancelErr := r.workflowEngine.CancelWorkflow(taskID, "branch conflict recovery"); cancelErr != nil {
 			r.logger.Error("pr-monitor.branch-conflict.cancel-active-workflow", "task_id", taskID, "err", cancelErr)
@@ -798,24 +784,47 @@ func (r *ReviewHandler) recoverBranchConflictNoPR(t task.Task) bool {
 	if shaErr != nil {
 		r.logger.Warn("pr-monitor.branch-conflict.head-sha", "task_id", taskID, "err", shaErr)
 	}
+	return r.dispatchBranchConflictRecovery(taskID, dir, base, t, headSHA, resume)
+}
 
+func (r *ReviewHandler) captureBranchConflictResumeState(t task.Task) branchConflictResumeState {
+	state := branchConflictResumeState{
+		status: string(t.Status),
+		prior:  t.Workflow.Clone(),
+	}
+	if t.Workflow == nil {
+		return state
+	}
+	state.workflowID = t.Workflow.WorkflowID
+	state.workflowStep = t.Workflow.CurrentStep
+	captured := make(map[string]string, len(t.Workflow.Variables))
+	maps.Copy(captured, t.Workflow.Variables)
+	if encoded, err := json.Marshal(captured); err == nil {
+		state.workflowVars = string(encoded)
+	} else {
+		r.logger.Warn("pr-monitor.branch-conflict.resume-vars-encode", "task_id", t.ID, "err", err)
+	}
+	return state
+}
+
+func (r *ReviewHandler) dispatchBranchConflictRecovery(taskID, dir, base string, t task.Task, headSHA string, resume branchConflictResumeState) bool {
 	vars := map[string]string{
 		"prompt":                branchConflictPrompt(t, base) + prFixResultContract,
 		workflow.WorkflowVarDir: dir,
-		"resume_status":         resumeStatus,
+		"resume_status":         resume.status,
 	}
-	if resumeWorkflowID != "" {
-		vars["resume_workflow_id"] = resumeWorkflowID
-		vars["resume_workflow_step"] = resumeWorkflowStep
-		vars["resume_workflow_vars"] = resumeVarsJSON
+	if resume.workflowID != "" {
+		vars["resume_workflow_id"] = resume.workflowID
+		vars["resume_workflow_step"] = resume.workflowStep
+		vars["resume_workflow_vars"] = resume.workflowVars
 	}
 
 	if err := r.workflowEngine.StartWorkflowWithVars(taskID, branchConflictFixWorkflowID, vars); err != nil {
 		r.logger.Error("pr-monitor.branch-conflict.dispatch", "task_id", taskID, "err", err)
-		if priorWorkflow != nil {
+		if resume.prior != nil {
 			if _, restoreErr := r.tasks.Update(taskID, task.Update{
-				Status:   task.Ptr(task.Status(resumeStatus)),
-				Workflow: task.Ptr(priorWorkflow),
+				Status:   task.Ptr(task.Status(resume.status)),
+				Workflow: task.Ptr(resume.prior),
 			}); restoreErr != nil {
 				r.logger.Error("pr-monitor.branch-conflict.restore-prior-workflow", "task_id", taskID, "err", restoreErr)
 			}

--- a/internal/sybra/lifecycle.go
+++ b/internal/sybra/lifecycle.go
@@ -311,8 +311,10 @@ func (lm *LifecycleManager) startMonitorService(ctx context.Context, emit func(s
 	innerSink := monitor.NewGHIssueSink(a.cfg.Monitor.IssueLabel, a.cfg.Monitor.IssueRepo)
 	// This callback's DispatchEvent -> execShell eventually derives its
 	// context from workflow.Engine's own e.ctx field (Engine.SetContext),
-	// not an explicit parameter threaded through the closure.
-	routingSink := newMonitorRoutingSink(innerSink, a.tasks, a.workScrubContextForTask, a.cfg.Monitor.IssueRepo, func(taskID string) { //nolint:contextcheck // Engine uses its own e.ctx field, see comment above
+	// not an explicit parameter threaded through the closure. contextcheck no
+	// longer flags this call site (verified with a clean build+lint cache),
+	// so no suppression directive is needed here.
+	routingSink := newMonitorRoutingSink(innerSink, a.tasks, a.workScrubContextForTask, a.cfg.Monitor.IssueRepo, func(taskID string) {
 		if a.workflowEngine == nil {
 			return
 		}

--- a/internal/workflow/builtin/branch-conflict-fix.yaml
+++ b/internal/workflow/builtin/branch-conflict-fix.yaml
@@ -1,0 +1,103 @@
+id: branch-conflict-fix
+name: Branch Conflict Fix (no PR)
+description: >-
+  Recover a worktree-prep merge conflict for a task with no linked PR yet by
+  merging the project's base branch into the task's own branch (a bounded
+  headless pr-fix sub-run), then resume the task's original interrupted
+  workflow/stage. Contains no PR-tail steps (link_pr_and_review,
+  ensure_pr_closes_issue, rerequest_review, route_pr_fix_result's PR-relink
+  path) since there is no PR yet.
+builtin: true
+trigger:
+  # Started directly by ID via ReviewHandler.recoverBranchConflictNoPR ->
+  # workflowEngine.StartWorkflowWithVars, never dispatched through a matched
+  # trigger. This condition references a tag no task ever carries, so
+  # DispatchEvent/matchWorkflow can never accidentally pick this workflow.
+  on: task.status_changed
+  conditions:
+    - field: task.tags
+      operator: contains
+      value: __never_dispatch_branch_conflict_fix__
+steps:
+  # Visible status during recovery. Does not permanently change task_type or
+  # agent_mode — only THIS step's sub-run is headless (config.mode below);
+  # the resumed original workflow keeps the task's own agent_mode, restored by
+  # resume_original's resume_status var before it re-enters.
+  - id: set_recovering
+    name: Mark Recovering
+    type: set_status
+    config:
+      status: in-progress
+      status_reason: "recovering from a branch conflict (no PR yet)"
+    next:
+      - goto: fix
+
+  - id: fix
+    name: Fix Branch Conflict
+    type: run_agent
+    config:
+      role: pr-fix
+      mode: headless
+      model: sonnet
+      prompt: >-
+        {{ getvar .Vars "prompt" }}
+    next:
+      - goto: route_result
+
+  # Mechanical check (no LLM): same escalation contract as pr-fix.yaml's
+  # route_pr_fix_result — if the agent deliberately stopped and requested a
+  # human, preserve that escalation before anything else can move the task on.
+  - id: route_result
+    name: Route Fix Result
+    type: route_pr_fix_result
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
+      - goto: verify_commits
+
+  # Mechanical check (no LLM): verifies the branch has at least one commit
+  # ahead of origin/main. Skips gracefully when there is no worktree.
+  - id: verify_commits
+    name: Verify Commits
+    type: verify_commits
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
+      - when:
+          field: task.status
+          operator: equals
+          value: done
+        goto: ""
+      - goto: detect_tampering
+
+  # Mechanical check (no LLM): scans the diff for test/CI tampering before
+  # letting the task move on. A high-severity finding flips to human-required.
+  - id: detect_tampering
+    name: Detect Test Tampering
+    type: detect_tampering
+    next:
+      - when:
+          field: task.status
+          operator: equals
+          value: human-required
+        goto: ""
+      - goto: resume_original
+
+  # Mechanical step (no LLM): restores the task's pre-recovery status and, if
+  # a specific workflow was captured before recovery began, resumes it
+  # directly — this is what re-enters the interrupted review/testing stage
+  # instead of skipping to a terminal status. With no captured workflow, ends
+  # normally: the task's restored status drives the ordinary status-based
+  # cascade (AgentCompletionHandler.OnWorkflowComplete) to pick the right
+  # workflow back up.
+  - id: resume_original
+    name: Resume Interrupted Workflow
+    type: resume_workflow
+    next:
+      - goto: ""

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -353,7 +353,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 			return e.execParallel(taskID, def, step, wfExec, ctx)
 		case StepWaitHuman:
 			return nil, e.execWaitHuman(taskID, step, wfExec)
-		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepStampPRAttribution, StepRerequestReview, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepValidatePlanContract, StepTriageReview, StepDetectTampering, StepVerifyChecks, StepRoutePRFixResult, StepRouteTestResult, StepSyncBranch:
+		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepStampPRAttribution, StepRerequestReview, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepValidatePlanContract, StepTriageReview, StepDetectTampering, StepVerifyChecks, StepRoutePRFixResult, StepRouteTestResult, StepSyncBranch, StepResumeWorkflow:
 			// handled below as sync steps
 		default:
 			return nil, fmt.Errorf("unknown step type %q", step.Type)
@@ -453,6 +453,8 @@ func (e *Engine) execSyncStep(taskID string, step *Step, wfExec *Execution, ctx 
 		return e.execRouteTestResult(taskID, step, wfExec, t)
 	case StepSyncBranch:
 		return e.execSyncBranch(taskID, step)
+	case StepResumeWorkflow:
+		return e.execResumeWorkflow(taskID, step, wfExec)
 	default:
 		return StepOutput{}, fmt.Errorf("unknown step type %q", step.Type)
 	}

--- a/internal/workflow/engine_dispatch.go
+++ b/internal/workflow/engine_dispatch.go
@@ -25,11 +25,19 @@ func (e *Engine) StartWorkflow(taskID, workflowID string) error {
 // (restart + UI button, two loop-agent ticks, etc) never both spawn agents
 // for the same task. Second caller gets ErrWorkflowAlreadyActive.
 func (e *Engine) StartWorkflowWithVars(taskID, workflowID string, vars map[string]string) error {
+	return e.StartWorkflowFromStepWithVars(taskID, workflowID, "", vars)
+}
+
+// StartWorkflowFromStepWithVars is StartWorkflowWithVars with an optional
+// explicit entry step. An empty startStepID uses the workflow's first step.
+// Used by recovery flows that must resume at the interrupted step rather than
+// replaying the workflow from the beginning.
+func (e *Engine) StartWorkflowFromStepWithVars(taskID, workflowID, startStepID string, vars map[string]string) error {
 	// startWorkflowLocked holds the `starting` marker; it is released by the
 	// time this returns, so firing the completion here cannot re-enter against
 	// it. This is what lets a synchronous mechanical workflow (e.g.
 	// simple-task-handoff) cascade into its successor.
-	comp, err := e.startWorkflowLocked(taskID, workflowID, vars)
+	comp, err := e.startWorkflowLocked(taskID, workflowID, startStepID, vars)
 	e.fireComplete(comp)
 	return err
 }
@@ -40,7 +48,7 @@ func (e *Engine) StartWorkflowWithVars(taskID, workflowID string, vars map[strin
 // fireComplete only AFTER releasing its own per-task marker (starting via this
 // function's defer, plus dispatching for DispatchEvent) so the completion's
 // cascade dispatch is not rejected as re-entrant.
-func (e *Engine) startWorkflowLocked(taskID, workflowID string, vars map[string]string) (*CompletionInfo, error) {
+func (e *Engine) startWorkflowLocked(taskID, workflowID, startStepID string, vars map[string]string) (*CompletionInfo, error) {
 	e.mu.Lock()
 	if _, busy := e.starting[taskID]; busy {
 		e.mu.Unlock()
@@ -73,8 +81,13 @@ func (e *Engine) startWorkflowLocked(taskID, workflowID string, vars map[string]
 		return nil, fmt.Errorf("get workflow %s: %w", workflowID, err)
 	}
 
-	first := def.FirstStep()
-	if first == nil {
+	start := def.FirstStep()
+	if startStepID != "" {
+		start = def.StepByID(startStepID)
+		if start == nil {
+			return nil, fmt.Errorf("workflow %s step %s not found", workflowID, startStepID)
+		}
+	} else if start == nil {
 		return nil, fmt.Errorf("workflow %s has no steps", workflowID)
 	}
 
@@ -83,7 +96,7 @@ func (e *Engine) startWorkflowLocked(taskID, workflowID string, vars map[string]
 
 	wfExec := &Execution{
 		WorkflowID:  workflowID,
-		CurrentStep: first.ID,
+		CurrentStep: start.ID,
 		State:       ExecRunning,
 		Variables:   variables,
 		StartedAt:   time.Now().UTC(),
@@ -93,8 +106,8 @@ func (e *Engine) startWorkflowLocked(taskID, workflowID string, vars map[string]
 		return nil, fmt.Errorf("set workflow on task: %w", err)
 	}
 
-	e.logger.Info("workflow.start", "task_id", taskID, "workflow", workflowID, "step", first.ID)
-	return e.executeSteps(taskID, &def, first, wfExec)
+	e.logger.Info("workflow.start", "task_id", taskID, "workflow", workflowID, "step", start.ID)
+	return e.executeSteps(taskID, &def, start, wfExec)
 }
 
 // MatchWorkflow finds the best workflow for a task based on trigger conditions.
@@ -188,7 +201,7 @@ func (e *Engine) DispatchEvent(taskID, event string, extraFields, vars map[strin
 	if def == nil {
 		return "", nil
 	}
-	comp, sErr := e.startWorkflowLocked(taskID, def.ID, vars)
+	comp, sErr := e.startWorkflowLocked(taskID, def.ID, "", vars)
 	if sErr != nil {
 		return "", fmt.Errorf("start %s: %w", def.ID, sErr)
 	}

--- a/internal/workflow/engine_parallel_test.go
+++ b/internal/workflow/engine_parallel_test.go
@@ -189,6 +189,10 @@ func TestParallel_DispatchesAllChildren(t *testing.T) {
 			t.Errorf("Children count = %d, want 2", len(rec.Children))
 		}
 		for id, c := range rec.Children {
+			if c == nil {
+				t.Errorf("child %q status record is nil", id)
+				continue
+			}
 			if c.Status != "pending" {
 				t.Errorf("child %q status = %q, want pending", id, c.Status)
 			}

--- a/internal/workflow/engine_steps_resume.go
+++ b/internal/workflow/engine_steps_resume.go
@@ -14,6 +14,7 @@ import (
 // AgentCompletionHandler.OnWorkflowComplete) picks up wherever it left off.
 const (
 	resumeWorkflowIDVar   = "resume_workflow_id"
+	resumeWorkflowStepVar = "resume_workflow_step"
 	resumeWorkflowVarsVar = "resume_workflow_vars"
 	resumeStatusVar       = "resume_status"
 )
@@ -48,6 +49,7 @@ func (e *Engine) execResumeWorkflow(taskID string, step *Step, wfExec *Execution
 	if resumeID == "" {
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "no resume target"}, nil
 	}
+	resumeStep := wfExec.Variables[resumeWorkflowStepVar]
 
 	var resumeVars map[string]string
 	if raw := wfExec.Variables[resumeWorkflowVarsVar]; raw != "" {
@@ -71,13 +73,15 @@ func (e *Engine) execResumeWorkflow(taskID string, step *Step, wfExec *Execution
 		return StepOutput{}, err
 	}
 
-	if err := e.StartWorkflowWithVars(taskID, resumeID, resumeVars); err != nil {
+	if err := e.StartWorkflowFromStepWithVars(taskID, resumeID, resumeStep, resumeVars); err != nil {
 		// Not fatal to the recovery itself — the branch conflict is already
 		// resolved and pushed. Leave the task at its restored status; a human
 		// or the next monitor pass can re-drive it.
-		e.logger.Error("workflow.resume.start-failed", "task_id", taskID, "resume_workflow", resumeID, "err", err)
+		e.logger.Error("workflow.resume.start-failed",
+			"task_id", taskID, "resume_workflow", resumeID, "resume_step", resumeStep, "err", err)
 		return StepOutput{}, errStepParked
 	}
-	e.logger.Info("workflow.resume.started", "task_id", taskID, "resume_workflow", resumeID)
+	e.logger.Info("workflow.resume.started",
+		"task_id", taskID, "resume_workflow", resumeID, "resume_step", resumeStep)
 	return StepOutput{}, errStepParked
 }

--- a/internal/workflow/engine_steps_resume.go
+++ b/internal/workflow/engine_steps_resume.go
@@ -1,0 +1,83 @@
+package workflow
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// resumeWorkflowIDVar/resumeWorkflowVarsVar/resumeStatusVar are the vars a
+// recovery workflow (branch-conflict-fix) is seeded with before it starts,
+// captured from the task's active workflow (if any) before it was cancelled.
+// resumeStatusVar is always set (to the task's status at the moment recovery
+// began) so a task that had no active workflow still gets its visible status
+// restored before the normal status-driven cascade (see
+// AgentCompletionHandler.OnWorkflowComplete) picks up wherever it left off.
+const (
+	resumeWorkflowIDVar   = "resume_workflow_id"
+	resumeWorkflowVarsVar = "resume_workflow_vars"
+	resumeStatusVar       = "resume_status"
+)
+
+// execResumeWorkflow is the terminal step of a recovery workflow: it restores
+// the task's pre-recovery status and, when a specific workflow was captured
+// before recovery began, re-enters it directly via StartWorkflowWithVars —
+// this is how a branch-conflict recovery resumes the exact interrupted
+// stage (review/testing/etc.) instead of skipping to a terminal status.
+//
+// When no workflow was captured (the task had no active workflow at the
+// time recovery began), this is a no-op beyond restoring status: the step
+// completes normally, the recovery workflow ends, and
+// AgentCompletionHandler.OnWorkflowComplete's existing status-driven cascade
+// dispatches whatever workflow matches the now-restored task.status — the
+// same mechanism every other builtin workflow chain (plan → implement →
+// review → ...) already relies on.
+//
+// Double-dispatch note: this step is not a run_agent step, so
+// ResumeStalled/tryMarkResumeDispatching never targets it — it only ever
+// runs once, synchronously, as part of executeSteps for the recovery
+// workflow's own single pass. No separate re-dispatch path exists for a
+// resume_workflow step, so no additional claim/lock is needed here.
+func (e *Engine) execResumeWorkflow(taskID string, step *Step, wfExec *Execution) (StepOutput, error) {
+	if status := wfExec.Variables[resumeStatusVar]; status != "" {
+		if err := e.tasks.UpdateTaskStatus(taskID, status, ""); err != nil {
+			e.logger.Warn("workflow.resume.restore-status", "task_id", taskID, "status", status, "err", err)
+		}
+	}
+
+	resumeID := wfExec.Variables[resumeWorkflowIDVar]
+	if resumeID == "" {
+		return StepOutput{StepID: step.ID, Status: "completed", Output: "no resume target"}, nil
+	}
+
+	var resumeVars map[string]string
+	if raw := wfExec.Variables[resumeWorkflowVarsVar]; raw != "" {
+		if err := json.Unmarshal([]byte(raw), &resumeVars); err != nil {
+			e.logger.Warn("workflow.resume.vars-decode", "task_id", taskID, "err", err)
+		}
+	}
+
+	// StartWorkflowWithVars refuses to start a new workflow while the task's
+	// current workflow (this one) is non-terminal, so finalize THIS execution
+	// first and persist it before dispatching the resume target. Returning
+	// errStepParked afterward tells executeSteps to stop without its own
+	// record/resolveNext/SetWorkflow pass — which would otherwise re-persist
+	// this now-stale (but already-completed) Execution over the freshly
+	// started resume workflow's own state.
+	now := time.Now().UTC()
+	wfExec.State = ExecCompleted
+	wfExec.CompletedAt = &now
+	wfExec.CurrentStep = ""
+	if err := e.tasks.SetWorkflow(taskID, wfExec); err != nil {
+		return StepOutput{}, err
+	}
+
+	if err := e.StartWorkflowWithVars(taskID, resumeID, resumeVars); err != nil {
+		// Not fatal to the recovery itself — the branch conflict is already
+		// resolved and pushed. Leave the task at its restored status; a human
+		// or the next monitor pass can re-drive it.
+		e.logger.Error("workflow.resume.start-failed", "task_id", taskID, "resume_workflow", resumeID, "err", err)
+		return StepOutput{}, errStepParked
+	}
+	e.logger.Info("workflow.resume.started", "task_id", taskID, "resume_workflow", resumeID)
+	return StepOutput{}, errStepParked
+}

--- a/internal/workflow/engine_steps_resume.go
+++ b/internal/workflow/engine_steps_resume.go
@@ -17,6 +17,7 @@ const (
 	resumeWorkflowStepVar = "resume_workflow_step"
 	resumeWorkflowVarsVar = "resume_workflow_vars"
 	resumeStatusVar       = "resume_status"
+	resumeStatusReasonVar = "resume_status_reason"
 )
 
 // execResumeWorkflow is the terminal step of a recovery workflow: it restores
@@ -40,7 +41,7 @@ const (
 // resume_workflow step, so no additional claim/lock is needed here.
 func (e *Engine) execResumeWorkflow(taskID string, step *Step, wfExec *Execution) (StepOutput, error) {
 	if status := wfExec.Variables[resumeStatusVar]; status != "" {
-		if err := e.tasks.UpdateTaskStatus(taskID, status, ""); err != nil {
+		if err := e.tasks.UpdateTaskStatus(taskID, status, wfExec.Variables[resumeStatusReasonVar]); err != nil {
 			e.logger.Warn("workflow.resume.restore-status", "task_id", taskID, "status", status, "err", err)
 		}
 	}

--- a/internal/workflow/engine_steps_resume_test.go
+++ b/internal/workflow/engine_steps_resume_test.go
@@ -1,0 +1,106 @@
+package workflow
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestExecResumeWorkflow_ResumesCapturedTarget verifies that when a resume
+// target was captured (resume_workflow_id set), execResumeWorkflow restores
+// the task's pre-recovery status and re-enters that exact workflow directly
+// — this is how branch-conflict recovery resumes the interrupted
+// review/testing stage instead of skipping to a terminal status.
+func TestExecResumeWorkflow_ResumesCapturedTarget(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t) // seeds "test-simple" workflow
+	tasks := newMemTasks()
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+
+	wf := &Execution{
+		WorkflowID:  "branch-conflict-fix",
+		CurrentStep: "resume_original",
+		State:       ExecRunning,
+		Variables: map[string]string{
+			"resume_workflow_id": "test-simple",
+			"resume_status":      "testing",
+		},
+	}
+	tasks.Put(TaskInfo{
+		ID:       "t1",
+		Status:   "in-progress", // set by branch-conflict-fix's own set_recovering step
+		Workflow: wf,
+	})
+
+	_, err := engine.execResumeWorkflow("t1", &Step{ID: "resume_original"}, wf)
+	if !errors.Is(err, errStepParked) {
+		t.Fatalf("execResumeWorkflow error = %v, want errStepParked", err)
+	}
+
+	got, gerr := tasks.GetTask("t1")
+	if gerr != nil {
+		t.Fatal(gerr)
+	}
+	if got.Status != "testing" {
+		t.Fatalf("status = %q, want restored %q", got.Status, "testing")
+	}
+	if got.Workflow == nil || got.Workflow.WorkflowID != "test-simple" {
+		t.Fatalf("workflow = %+v, want resumed test-simple", got.Workflow)
+	}
+	// test-simple's first step (triage) is a run_agent step — an async step,
+	// so the resumed workflow should be parked there waiting for the agent.
+	if got.Workflow.CurrentStep != "triage" {
+		t.Fatalf("current step = %q, want triage (test-simple's first step)", got.Workflow.CurrentStep)
+	}
+}
+
+// TestExecResumeWorkflow_NoTargetCompletesNormally verifies the no-op case:
+// when no resume_workflow_id was captured (the task had no active workflow
+// when recovery began), execResumeWorkflow only restores status and
+// completes normally so the recovery workflow ends via the ordinary
+// resolveNext path — leaving the status-driven cascade
+// (AgentCompletionHandler.OnWorkflowComplete in package sybra) to pick up
+// whatever workflow matches the restored status.
+func TestExecResumeWorkflow_NoTargetCompletesNormally(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+
+	wf := &Execution{
+		WorkflowID:  "branch-conflict-fix",
+		CurrentStep: "resume_original",
+		State:       ExecRunning,
+		Variables: map[string]string{
+			"resume_status": "in-progress",
+		},
+	}
+	tasks.Put(TaskInfo{
+		ID:       "t2",
+		Status:   "in-progress",
+		Workflow: wf,
+	})
+
+	out, err := engine.execResumeWorkflow("t2", &Step{ID: "resume_original"}, wf)
+	if err != nil {
+		t.Fatalf("execResumeWorkflow: %v", err)
+	}
+	if out.Status != "completed" {
+		t.Fatalf("status = %q, want completed", out.Status)
+	}
+
+	got, gerr := tasks.GetTask("t2")
+	if gerr != nil {
+		t.Fatal(gerr)
+	}
+	if got.Status != "in-progress" {
+		t.Fatalf("status = %q, want restored in-progress", got.Status)
+	}
+	// No workflow was started — the (still-branch-conflict-fix) execution is
+	// left for the caller (executeSteps) to finalize via the normal
+	// resolveNext path.
+	if got.Workflow == nil || got.Workflow.WorkflowID != "branch-conflict-fix" {
+		t.Fatalf("workflow = %+v, want unchanged branch-conflict-fix pending resolveNext", got.Workflow)
+	}
+}

--- a/internal/workflow/engine_steps_resume_test.go
+++ b/internal/workflow/engine_steps_resume_test.go
@@ -13,7 +13,33 @@ import (
 func TestExecResumeWorkflow_ResumesCapturedTarget(t *testing.T) {
 	t.Parallel()
 
-	store := newTestStore(t) // seeds "test-simple" workflow
+	store := newTestStore(t)
+	if err := store.Save(Definition{
+		ID:   "resume-target",
+		Name: "resume target",
+		Steps: []Step{
+			{
+				ID:   "triage",
+				Name: "Triage",
+				Type: StepSetStatus,
+				Config: StepConfig{
+					Status: "in-progress",
+				},
+				Next: []Transition{{GoTo: "resume_here"}},
+			},
+			{
+				ID:   "resume_here",
+				Name: "Resume Here",
+				Type: StepWaitHuman,
+				Config: StepConfig{
+					HumanActions: []string{"done"},
+				},
+				Next: []Transition{{GoTo: ""}},
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
 	tasks := newMemTasks()
 	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
 
@@ -22,8 +48,9 @@ func TestExecResumeWorkflow_ResumesCapturedTarget(t *testing.T) {
 		CurrentStep: "resume_original",
 		State:       ExecRunning,
 		Variables: map[string]string{
-			"resume_workflow_id": "test-simple",
-			"resume_status":      "testing",
+			"resume_workflow_id":   "resume-target",
+			"resume_workflow_step": "resume_here",
+			"resume_status":        "testing",
 		},
 	}
 	tasks.Put(TaskInfo{
@@ -44,13 +71,11 @@ func TestExecResumeWorkflow_ResumesCapturedTarget(t *testing.T) {
 	if got.Status != "testing" {
 		t.Fatalf("status = %q, want restored %q", got.Status, "testing")
 	}
-	if got.Workflow == nil || got.Workflow.WorkflowID != "test-simple" {
-		t.Fatalf("workflow = %+v, want resumed test-simple", got.Workflow)
+	if got.Workflow == nil || got.Workflow.WorkflowID != "resume-target" {
+		t.Fatalf("workflow = %+v, want resumed resume-target", got.Workflow)
 	}
-	// test-simple's first step (triage) is a run_agent step — an async step,
-	// so the resumed workflow should be parked there waiting for the agent.
-	if got.Workflow.CurrentStep != "triage" {
-		t.Fatalf("current step = %q, want triage (test-simple's first step)", got.Workflow.CurrentStep)
+	if got.Workflow.CurrentStep != "resume_here" {
+		t.Fatalf("current step = %q, want captured resume_here step", got.Workflow.CurrentStep)
 	}
 }
 

--- a/internal/workflow/engine_steps_resume_test.go
+++ b/internal/workflow/engine_steps_resume_test.go
@@ -51,12 +51,14 @@ func TestExecResumeWorkflow_ResumesCapturedTarget(t *testing.T) {
 			"resume_workflow_id":   "resume-target",
 			"resume_workflow_step": "resume_here",
 			"resume_status":        "testing",
+			"resume_status_reason": "waiting for branch-conflict recovery",
 		},
 	}
 	tasks.Put(TaskInfo{
-		ID:       "t1",
-		Status:   "in-progress", // set by branch-conflict-fix's own set_recovering step
-		Workflow: wf,
+		ID:           "t1",
+		Status:       "in-progress", // set by branch-conflict-fix's own set_recovering step
+		StatusReason: "recovering branch conflict",
+		Workflow:     wf,
 	})
 
 	_, err := engine.execResumeWorkflow("t1", &Step{ID: "resume_original"}, wf)
@@ -70,6 +72,9 @@ func TestExecResumeWorkflow_ResumesCapturedTarget(t *testing.T) {
 	}
 	if got.Status != "testing" {
 		t.Fatalf("status = %q, want restored %q", got.Status, "testing")
+	}
+	if got.StatusReason != "waiting for branch-conflict recovery" {
+		t.Fatalf("status_reason = %q, want restored reason", got.StatusReason)
 	}
 	if got.Workflow == nil || got.Workflow.WorkflowID != "resume-target" {
 		t.Fatalf("workflow = %+v, want resumed resume-target", got.Workflow)
@@ -98,13 +103,15 @@ func TestExecResumeWorkflow_NoTargetCompletesNormally(t *testing.T) {
 		CurrentStep: "resume_original",
 		State:       ExecRunning,
 		Variables: map[string]string{
-			"resume_status": "in-progress",
+			"resume_status":        "in-progress",
+			"resume_status_reason": "keep me",
 		},
 	}
 	tasks.Put(TaskInfo{
-		ID:       "t2",
-		Status:   "in-progress",
-		Workflow: wf,
+		ID:           "t2",
+		Status:       "in-progress",
+		StatusReason: "recovering branch conflict",
+		Workflow:     wf,
 	})
 
 	out, err := engine.execResumeWorkflow("t2", &Step{ID: "resume_original"}, wf)
@@ -121,6 +128,9 @@ func TestExecResumeWorkflow_NoTargetCompletesNormally(t *testing.T) {
 	}
 	if got.Status != "in-progress" {
 		t.Fatalf("status = %q, want restored in-progress", got.Status)
+	}
+	if got.StatusReason != "keep me" {
+		t.Fatalf("status_reason = %q, want restored reason", got.StatusReason)
 	}
 	// No workflow was started — the (still-branch-conflict-fix) execution is
 	// left for the caller (executeSteps) to finalize via the normal

--- a/internal/workflow/execution.go
+++ b/internal/workflow/execution.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"maps"
 	"slices"
 	"time"
 )
@@ -52,6 +53,44 @@ type ChildStatus struct {
 	Status  string `yaml:"status" json:"status"`
 	Output  string `yaml:"output,omitempty" json:"output,omitempty"`
 	Retries int    `yaml:"retries,omitempty" json:"retries,omitempty"`
+}
+
+// Clone returns a deep copy of the execution so callers can persist or restore
+// workflow state without aliasing mutable maps/slices from the original.
+func (e *Execution) Clone() *Execution {
+	if e == nil {
+		return nil
+	}
+	cloned := *e
+	if e.StepHistory != nil {
+		cloned.StepHistory = slices.Clone(e.StepHistory)
+	}
+	if e.Variables != nil {
+		cloned.Variables = maps.Clone(e.Variables)
+	}
+	if e.ParallelInflight != nil {
+		cloned.ParallelInflight = make(map[string]*ParallelChildren, len(e.ParallelInflight))
+		for key, child := range e.ParallelInflight {
+			if child == nil {
+				cloned.ParallelInflight[key] = nil
+				continue
+			}
+			childClone := *child
+			if child.Children != nil {
+				childClone.Children = make(map[string]*ChildStatus, len(child.Children))
+				for childID, status := range child.Children {
+					if status == nil {
+						childClone.Children[childID] = nil
+						continue
+					}
+					statusClone := *status
+					childClone.Children[childID] = &statusClone
+				}
+			}
+			cloned.ParallelInflight[key] = &childClone
+		}
+	}
+	return &cloned
 }
 
 // AllChildrenDone reports whether every child reached a terminal status.

--- a/internal/workflow/model.go
+++ b/internal/workflow/model.go
@@ -121,6 +121,15 @@ const (
 	// recorded but never flip the task to human-required — the workflow
 	// continues to its next step regardless of outcome.
 	StepSyncBranch StepType = "sync_branch"
+	// StepResumeWorkflow is the terminal step of a recovery workflow
+	// (branch-conflict-fix) that re-enters the task's original interrupted
+	// workflow/stage. Reads resume_workflow_id/resume_workflow_vars/
+	// resume_status vars captured before the recovery workflow was started;
+	// a missing resume_workflow_id is a no-op (the workflow simply ends, and
+	// normal status-driven cascade dispatch — see
+	// AgentCompletionHandler.OnWorkflowComplete — picks up whatever workflow
+	// matches the restored task status).
+	StepResumeWorkflow StepType = "resume_workflow"
 )
 
 // Step is one node in the workflow graph.

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -494,8 +494,9 @@ func (m *Manager) PrepareForBranchFix(ctx context.Context, t task.Task) (string,
 	if err != nil {
 		return "", fmt.Errorf("get project: %w", err)
 	}
-	if err := project.FetchOrigin(ctx, proj.ClonePath); err != nil {
-		m.logger.Warn("branch-fix.worktree.fetch", "project", proj.ID, "err", err)
+	var fetchErr error
+	if fetchErr = project.FetchOrigin(ctx, proj.ClonePath); fetchErr != nil {
+		m.logger.Warn("branch-fix.worktree.fetch", "project", proj.ID, "err", fetchErr)
 	}
 
 	branch := branchNameForTask(t)
@@ -522,6 +523,9 @@ func (m *Manager) PrepareForBranchFix(ctx context.Context, t task.Task) (string,
 			return "", fmt.Errorf("create branch-fix worktree: %w", err)
 		}
 	default:
+		if fetchErr != nil {
+			return "", fmt.Errorf("fetch origin for task branch %s: %w", branch, fetchErr)
+		}
 		// No PR to fall back to (unlike PrepareForFix) — the branch is
 		// genuinely missing. Escalate rather than guess.
 		return "", fmt.Errorf("%w: %s", ErrTaskBranchMissing, branch)

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -18,6 +18,14 @@ import (
 // internal/task -> internal/workflow).
 var ErrRebaseFailed = worktreeerr.ErrRebaseFailed
 
+// ErrTaskBranchMissing indicates a task's own branch does not exist locally
+// or on origin, so PrepareForBranchFix cannot check it out for no-PR conflict
+// recovery. Unlike PrepareForFix (which falls back to the PR head ref via
+// refs/pull/<N>/head), there is no PR yet to fall back to — a missing branch
+// here is a hard failure the caller must escalate to human-required rather
+// than guess at.
+var ErrTaskBranchMissing = errors.New("task branch does not exist locally or on origin")
+
 // SyncResult classifies the outcome of a proactive branch sync
 // (Manager.SyncTaskBranch). String values are stable — they are recorded as
 // workflow step output and generic artifacts, so renaming a constant changes
@@ -462,6 +470,76 @@ func (m *Manager) PrepareForReview(ctx context.Context, t task.Task) (string, er
 	m.logger.Info("review.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
 	if err := m.runSetup(ctx, t.ID, wtPath, m.resolveSetupCommands(wtPath, proj)); err != nil {
 		return "", fmt.Errorf("review setup: %w", err)
+	}
+	return wtPath, nil
+}
+
+// PrepareForBranchFix creates a worktree checking out the task's OWN branch
+// (resolved by name via branchNameForTask, not via a PR lookup) so a no-PR
+// conflict-recovery agent can merge base in and push. Sibling of
+// PrepareForFix for tasks with no PR yet (still in
+// implementation/review/testing, or at create_pr): the same non-rebasing
+// checkout dance, minus PrepareForFix's PR-head fallback — a task's own
+// branch either exists (locally or on origin) or this is a hard failure
+// (ErrTaskBranchMissing) that must escalate rather than guess at a ref to
+// check out. Does not change PrepareForFix's behavior for its own PR-keyed
+// callers.
+func (m *Manager) PrepareForBranchFix(ctx context.Context, t task.Task) (string, error) {
+	// Adopt an externally-created worktree as-is, mirroring PrepareForFix.
+	if t.WorktreeDir != "" {
+		return m.adoptWorktree(ctx, t, nil)
+	}
+
+	proj, err := m.projects.Get(t.ProjectID)
+	if err != nil {
+		return "", fmt.Errorf("get project: %w", err)
+	}
+	if err := project.FetchOrigin(ctx, proj.ClonePath); err != nil {
+		m.logger.Warn("branch-fix.worktree.fetch", "project", proj.ID, "err", err)
+	}
+
+	branch := branchNameForTask(t)
+	wtPath := m.PathFor(t)
+
+	// Remove stale worktree, same rationale as PrepareForFix.
+	switch _, statErr := os.Stat(wtPath); {
+	case statErr == nil:
+		if err := project.RemoveWorktreeReconcile(ctx, proj.ClonePath, wtPath); err != nil {
+			return "", fmt.Errorf("remove stale branch-fix worktree: %w", err)
+		}
+	case !os.IsNotExist(statErr):
+		return "", fmt.Errorf("stat branch-fix worktree %s: %w", wtPath, statErr)
+	}
+
+	originRef := "refs/remotes/origin/" + branch
+	switch {
+	case project.BranchExists(ctx, proj.ClonePath, branch):
+		if err := project.CreateWorktreeExisting(ctx, proj.ClonePath, wtPath, branch); err != nil {
+			return "", fmt.Errorf("checkout task branch %s: %w", branch, err)
+		}
+	case project.RefExists(ctx, proj.ClonePath, originRef):
+		if err := project.CreateWorktree(ctx, proj.ClonePath, wtPath, branch, originRef); err != nil {
+			return "", fmt.Errorf("create branch-fix worktree: %w", err)
+		}
+	default:
+		// No PR to fall back to (unlike PrepareForFix) — the branch is
+		// genuinely missing. Escalate rather than guess.
+		return "", fmt.Errorf("%w: %s", ErrTaskBranchMissing, branch)
+	}
+	if err := project.SanitizeWorktree(ctx, wtPath); err != nil {
+		m.logger.Warn("branch-fix.worktree.sanitize", "task_id", t.ID, "err", err)
+	}
+	m.ensureBranch(t, branch)
+	m.logger.Info("branch-fix.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
+	if err := m.runSetup(ctx, t.ID, wtPath, m.resolveSetupCommands(wtPath, proj)); err != nil {
+		return "", fmt.Errorf("branch-fix setup: %w", err)
+	}
+	// pr-fix-role recovery runs must push straight to origin (the task's own
+	// branch lives there, no fork), mirroring PrepareForFix's RunRole guard.
+	if t.RunRole != "pr-fix" {
+		if err := project.EnforceForkOnlyPush(ctx, wtPath); err != nil {
+			m.logger.Warn("branch-fix.worktree.fork-only-push", "task_id", t.ID, "err", err)
+		}
 	}
 	return wtPath, nil
 }

--- a/internal/worktree/prepare_branch_fix_test.go
+++ b/internal/worktree/prepare_branch_fix_test.go
@@ -1,0 +1,135 @@
+package worktree
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/task"
+)
+
+// TestPrepareForBranchFix_ExistingBranch verifies the happy path: a task
+// whose branch already exists (locally or on origin) gets a worktree checked
+// out on that branch by name — no PR lookup involved.
+func TestPrepareForBranchFix_ExistingBranch(t *testing.T) {
+	h := prepareHarness(t, nil, 0)
+
+	const branch = "fix/no-pr-branch"
+	srcGit := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", h.src}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	srcGit("checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(h.src, "feature.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "branch commit")
+	srcGit("checkout", "main")
+
+	tk, err := h.tasks.Create("no pr branch fix", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = h.tasks.UpdateMap(tk.ID, map[string]any{
+		"project_id": h.proj.ID,
+		"branch":     branch,
+	})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	wtPath, err := h.m.PrepareForBranchFix(context.Background(), tk)
+	if err != nil {
+		t.Fatalf("PrepareForBranchFix: %v", err)
+	}
+
+	headBranch, err := exec.Command("git", "-C", wtPath, "rev-parse", "--abbrev-ref", "HEAD").CombinedOutput()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD branch: %v: %s", err, headBranch)
+	}
+	if got := strings.TrimSpace(string(headBranch)); got != branch {
+		t.Errorf("worktree branch = %q, want %q", got, branch)
+	}
+
+	reloaded, err := h.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if reloaded.Branch != branch {
+		t.Errorf("task branch = %q, want %q", reloaded.Branch, branch)
+	}
+}
+
+// TestPrepareForBranchFix_MissingBranch verifies the hard-failure path: a
+// task branch that exists neither locally nor on origin returns
+// ErrTaskBranchMissing so the caller can escalate rather than guess at a ref
+// (unlike PrepareForFix, there is no PR head to fall back to here).
+func TestPrepareForBranchFix_MissingBranch(t *testing.T) {
+	h := prepareHarness(t, nil, 0)
+
+	tk, err := h.tasks.Create("missing branch fix", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = h.tasks.UpdateMap(tk.ID, map[string]any{
+		"project_id": h.proj.ID,
+		"branch":     "fix/does-not-exist-anywhere",
+	})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	_, err = h.m.PrepareForBranchFix(context.Background(), tk)
+	if !errors.Is(err, ErrTaskBranchMissing) {
+		t.Fatalf("PrepareForBranchFix error = %v, want ErrTaskBranchMissing", err)
+	}
+}
+
+// TestPrepareForBranchFix_AdoptsExternalWorktree mirrors
+// TestPrepareForFix_AdoptsExternalWorktree: a task carrying an explicit
+// WorktreeDir must be reused as-is, never re-created with `git worktree add`.
+func TestPrepareForBranchFix_AdoptsExternalWorktree(t *testing.T) {
+	h := prepareHarness(t, nil, 0)
+
+	ext := filepath.Join(t.TempDir(), "orca-worktree")
+	const extBranch = "orca/branch-fix-x"
+	if out, err := exec.Command("git", "-c", "safe.bareRepository=all", "-C", h.proj.ClonePath, "worktree", "add", "-b", extBranch, ext, "main").CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %v: %s", err, out)
+	}
+
+	tk, err := h.tasks.Create("adopt branch fix", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = h.tasks.UpdateMap(tk.ID, map[string]any{
+		"project_id":   h.proj.ID,
+		"worktree_dir": ext,
+	})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	got, err := h.m.PrepareForBranchFix(context.Background(), tk)
+	if err != nil {
+		t.Fatalf("PrepareForBranchFix: %v", err)
+	}
+	if got != ext {
+		t.Fatalf("adopted path = %q, want %q", got, ext)
+	}
+
+	entries, err := os.ReadDir(h.wtDir)
+	if err != nil {
+		t.Fatalf("read worktrees dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("managed worktrees dir not empty: %v", entries)
+	}
+}

--- a/internal/worktree/prepare_branch_fix_test.go
+++ b/internal/worktree/prepare_branch_fix_test.go
@@ -93,6 +93,54 @@ func TestPrepareForBranchFix_MissingBranch(t *testing.T) {
 	}
 }
 
+// TestPrepareForBranchFix_FetchFailureDoesNotMasqueradeAsMissingBranch verifies
+// that a transient fetch failure is surfaced as such when the task branch is
+// only discoverable via origin, rather than being misclassified as
+// ErrTaskBranchMissing.
+func TestPrepareForBranchFix_FetchFailureDoesNotMasqueradeAsMissingBranch(t *testing.T) {
+	h := prepareHarness(t, nil, 0)
+
+	const branch = "fix/fetch-needed"
+	srcGit := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", h.src}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	srcGit("checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(h.src, "fetch-needed.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "fetch-needed branch")
+	srcGit("checkout", "main")
+
+	if out, err := exec.Command("git", "-c", "safe.bareRepository=all", "-C", h.proj.ClonePath, "remote", "set-url", "origin", filepath.Join(t.TempDir(), "missing-origin.git")).CombinedOutput(); err != nil {
+		t.Fatalf("git remote set-url: %v: %s", err, out)
+	}
+
+	tk, err := h.tasks.Create("fetch failure branch fix", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = h.tasks.UpdateMap(tk.ID, map[string]any{
+		"project_id": h.proj.ID,
+		"branch":     branch,
+	})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	_, err = h.m.PrepareForBranchFix(context.Background(), tk)
+	if err == nil {
+		t.Fatal("PrepareForBranchFix error = nil, want fetch failure")
+	}
+	if errors.Is(err, ErrTaskBranchMissing) {
+		t.Fatalf("PrepareForBranchFix error = %v, must not be ErrTaskBranchMissing when fetch failed", err)
+	}
+}
+
 // TestPrepareForBranchFix_AdoptsExternalWorktree mirrors
 // TestPrepareForFix_AdoptsExternalWorktree: a task carrying an explicit
 // WorktreeDir must be reused as-is, never re-created with `git worktree add`.


### PR DESCRIPTION
## Motivation

`recoverStaleBranchConflict` only fired for tasks that already had a
linked PR, so any rebase conflict hit before `create_pr` escalated
straight to `human-required` instead of being auto-recovered like the
post-PR case.

## Implementation information

Adds a no-PR sibling recovery path that resolves the task's own branch
by name, merges the base branch in via the existing merge-based
mechanism, and resumes the interrupted workflow/stage afterward instead
of skipping review or testing. Includes a new `branch-conflict-fix.yaml`
builtin workflow, resume-step engine support, and coverage in
`app_rebase_recover_test.go` / `engine_steps_resume_test.go` /
`prepare_branch_fix_test.go`.

Closes https://github.com/Automaat/sybra/issues/1440

_Generated by Sybra harness_