### PR TITLE
feat(browser): add address bar and nav controls

### DIFF
--- a/browser_chrome.js
+++ b/browser_chrome.js
@@ -84,10 +84,10 @@
     var toolbar = document.createElement("div");
     toolbar.className = "toolbar";
     toolbar.innerHTML =
-      '<button id="back" title="Back">◀</button>' +
-      '<button id="forward" title="Forward">▶</button>' +
-      '<button id="reload" title="Reload">⟳</button>' +
-      '<input id="address" type="text" spellcheck="false" />';
+      '<button id="back" type="button" title="Back" aria-label="Back">◀</button>' +
+      '<button id="forward" type="button" title="Forward" aria-label="Forward">▶</button>' +
+      '<button id="reload" type="button" title="Reload" aria-label="Reload">⟳</button>' +
+      '<input id="address" type="text" spellcheck="false" aria-label="Address" />';
     shadow.appendChild(toolbar);
 
     if (isGitHubPage()) {

--- a/browser_chrome.js
+++ b/browser_chrome.js
@@ -1,0 +1,109 @@
+// Injected toolbar for the chrome-less Sybra in-app browser window.
+// Throwaway shim pending a native NSToolbar (Wails v3 exposes no native
+// back/forward/URL API yet) — see main.go's openInAppBrowser.
+(function () {
+  try {
+    var HOST_ID = "sybra-nav-host";
+    var TOOLBAR_HEIGHT = 40;
+
+    function sync(input) {
+      input.value = location.href;
+    }
+
+    var existingHost = document.getElementById(HOST_ID);
+    if (existingHost) {
+      var existingInput = existingHost.shadowRoot && existingHost.shadowRoot.getElementById("address");
+      if (existingInput) sync(existingInput);
+      return;
+    }
+
+    if (!document.body) return;
+
+    function normalizeURL(raw) {
+      var value = (raw || "").trim();
+      if (!value) return null;
+
+      var schemeMatch = /^[a-z][a-z0-9+.-]*:/i.exec(value);
+      if (schemeMatch) {
+        var scheme = schemeMatch[0].toLowerCase();
+        if (scheme === "http:" || scheme === "https:") return value;
+        return null;
+      }
+
+      if (value.charAt(0) === "#") return null;
+      return "https://" + value;
+    }
+
+    var host = document.createElement("div");
+    host.id = HOST_ID;
+    host.style.position = "fixed";
+    host.style.top = "0";
+    host.style.left = "0";
+    host.style.right = "0";
+    host.style.zIndex = "2147483647";
+    document.documentElement.appendChild(host);
+
+    var shadow = host.attachShadow({ mode: "open" });
+
+    var style = document.createElement("style");
+    style.textContent =
+      ":host { all: initial; }" +
+      ".toolbar { display: flex; align-items: center; gap: 6px; height: " +
+      TOOLBAR_HEIGHT +
+      "px; padding: 0 8px; box-sizing: border-box; background: #2d2d2d; font-family: -apple-system, BlinkMacSystemFont, sans-serif; }" +
+      "button { border: none; border-radius: 4px; background: #444; color: #eee; width: 28px; height: 28px; font-size: 14px; cursor: pointer; }" +
+      "button:hover { background: #555; }" +
+      "input { flex: 1; height: 26px; border-radius: 4px; border: 1px solid #555; background: #1e1e1e; color: #eee; padding: 0 8px; font-size: 13px; }";
+    shadow.appendChild(style);
+
+    var toolbar = document.createElement("div");
+    toolbar.className = "toolbar";
+    toolbar.innerHTML =
+      '<button id="back" title="Back">◀</button>' +
+      '<button id="forward" title="Forward">▶</button>' +
+      '<button id="reload" title="Reload">⟳</button>' +
+      '<input id="address" type="text" spellcheck="false" />';
+    shadow.appendChild(toolbar);
+
+    document.documentElement.style.setProperty("padding-top", TOOLBAR_HEIGHT + "px", "important");
+
+    var addressInput = shadow.getElementById("address");
+    addressInput.addEventListener("keydown", function (event) {
+      if (event.key !== "Enter") return;
+      var href = normalizeURL(addressInput.value);
+      if (href) location.assign(href);
+    });
+
+    shadow.getElementById("back").addEventListener("click", function () {
+      history.back();
+    });
+    shadow.getElementById("forward").addEventListener("click", function () {
+      history.forward();
+    });
+    shadow.getElementById("reload").addEventListener("click", function () {
+      location.reload();
+    });
+
+    if (!history.__sybraPatched) {
+      history.__sybraPatched = true;
+      ["pushState", "replaceState"].forEach(function (method) {
+        var original = history[method];
+        history[method] = function () {
+          var result = original.apply(history, arguments);
+          sync(addressInput);
+          return result;
+        };
+      });
+      window.addEventListener("popstate", function () {
+        sync(addressInput);
+      });
+      window.addEventListener("hashchange", function () {
+        sync(addressInput);
+      });
+    }
+
+    sync(addressInput);
+  } catch {
+    // Swallow — a broken toolbar must never break the underlying page.
+  }
+})();

--- a/browser_chrome.js
+++ b/browser_chrome.js
@@ -5,9 +5,29 @@
   try {
     var HOST_ID = "sybra-nav-host";
     var TOOLBAR_HEIGHT = 40;
+    var GITHUB_HOST = "github.com";
 
     function sync(input) {
       input.value = location.href;
+    }
+
+    function hasExplicitScheme(value) {
+      return /^[a-z][a-z0-9+.-]*:\/\//i.test(value);
+    }
+
+    function isBareIPv6Literal(value) {
+      if (value.indexOf("[") !== -1 || value.indexOf("]") !== -1) return false;
+      if ((value.match(/:/g) || []).length < 2) return false;
+      try {
+        new URL("https://[" + value + "]");
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    function isGitHubPage() {
+      return location.hostname === GITHUB_HOST || location.hostname.slice(-(GITHUB_HOST.length + 1)) === "." + GITHUB_HOST;
     }
 
     var existingHost = document.getElementById(HOST_ID);
@@ -22,16 +42,21 @@
     function normalizeURL(raw) {
       var value = (raw || "").trim();
       if (!value) return null;
+      if (value.charAt(0) === "#") return null;
 
-      var schemeMatch = /^[a-z][a-z0-9+.-]*:/i.exec(value);
-      if (schemeMatch) {
-        var scheme = schemeMatch[0].toLowerCase();
-        if (scheme === "http:" || scheme === "https:") return value;
-        return null;
+      var candidate = value;
+      if (!hasExplicitScheme(candidate)) {
+        candidate = isBareIPv6Literal(candidate) ? "https://[" + candidate + "]" : "https://" + candidate;
       }
 
-      if (value.charAt(0) === "#") return null;
-      return "https://" + value;
+      try {
+        var parsed = new URL(candidate);
+        if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+        if (!parsed.host) return null;
+        return parsed.toString();
+      } catch {
+        return null;
+      }
     }
 
     var host = document.createElement("div");
@@ -65,7 +90,9 @@
       '<input id="address" type="text" spellcheck="false" />';
     shadow.appendChild(toolbar);
 
-    document.documentElement.style.setProperty("padding-top", TOOLBAR_HEIGHT + "px", "important");
+    if (isGitHubPage()) {
+      document.documentElement.style.setProperty("padding-top", TOOLBAR_HEIGHT + "px");
+    }
 
     var addressInput = shadow.getElementById("address");
     addressInput.addEventListener("keydown", function (event) {
@@ -84,7 +111,7 @@
       location.reload();
     });
 
-    if (!history.__sybraPatched) {
+    if (isGitHubPage() && !history.__sybraPatched) {
       history.__sybraPatched = true;
       ["pushState", "replaceState"].forEach(function (method) {
         var original = history[method];
@@ -103,7 +130,8 @@
     }
 
     sync(addressInput);
-  } catch {
+  } catch (error) {
+    console.warn("[Sybra Browser] toolbar injection failed", error);
     // Swallow — a broken toolbar must never break the underlying page.
   }
 })();

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,6 +29,8 @@
         "@testing-library/svelte": "5.3.1",
         "@types/dompurify": "3.2.0",
         "@types/js-yaml": "4.0.9",
+        "@types/jsdom": "28.0.3",
+        "@types/node": "24.13.2",
         "@vitest/coverage-v8": "4.1.9",
         "jsdom": "29.1.1",
         "oxlint": "1.63.0",
@@ -1782,6 +1784,43 @@
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jsdom": {
+      "version": "28.0.3",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-28.0.3.tgz",
+      "integrity": "sha512-/HQ2uFoetFTXuye8vzIcHw2z6Fwi7Hi/qcgC+RoS9NCyewiqxhVGqlG+ViGB6lkax481R6dmhf1I7lIGlzJStQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^8.0.0",
+        "undici-types": "^7.21.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4202,6 +4241,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.28.0.tgz",
+      "integrity": "sha512-LJAfY+2w6HGeT8d8J1wNQsUGUEGio6NWWpwdwurQe4f6oojzCFuGLizl1KSve4irsTxyLly1QhEeE6iapdaIvQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.0.16",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,8 @@
     "@testing-library/svelte": "5.3.1",
     "@types/dompurify": "3.2.0",
     "@types/js-yaml": "4.0.9",
+    "@types/jsdom": "28.0.3",
+    "@types/node": "24.13.2",
     "@vitest/coverage-v8": "4.1.9",
     "jsdom": "29.1.1",
     "oxlint": "1.63.0",

--- a/frontend/src/lib/browser-chrome.test.ts
+++ b/frontend/src/lib/browser-chrome.test.ts
@@ -1,9 +1,10 @@
 import { readFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
 import { JSDOM } from 'jsdom'
 import { describe, expect, it, vi } from 'vitest'
 
-const browserChromePath = resolve(process.cwd(), '..', 'browser_chrome.js')
+const browserChromePath = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'browser_chrome.js')
 const browserChromeSource = readFileSync(browserChromePath, 'utf8')
 
 function runBrowserChrome(url: string, source = browserChromeSource) {
@@ -21,7 +22,7 @@ describe('browser chrome url normalization', () => {
       'function normalizeURL(raw) {',
       'window.__normalizeURL = function normalizeURL(raw) {',
     )
-    const window = runBrowserChrome('https://github.com/Automaat/sybra', instrumented) as Window & {
+    const window = runBrowserChrome('https://github.com/Automaat/sybra', instrumented) as unknown as Window & {
       __normalizeURL: (value: string) => string | null
     }
 

--- a/frontend/src/lib/browser-chrome.test.ts
+++ b/frontend/src/lib/browser-chrome.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { JSDOM } from 'jsdom'
+import { describe, expect, it, vi } from 'vitest'
+
+const browserChromePath = resolve(process.cwd(), '..', 'browser_chrome.js')
+const browserChromeSource = readFileSync(browserChromePath, 'utf8')
+
+function runBrowserChrome(url: string, source = browserChromeSource) {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+    runScripts: 'dangerously',
+    url,
+  })
+  dom.window.eval(source)
+  return dom.window
+}
+
+describe('browser chrome url normalization', () => {
+  it('accepts bare host:port inputs and bare IPv6 loopback', () => {
+    const instrumented = browserChromeSource.replace(
+      'function normalizeURL(raw) {',
+      'window.__normalizeURL = function normalizeURL(raw) {',
+    )
+    const window = runBrowserChrome('https://github.com/Automaat/sybra', instrumented) as Window & {
+      __normalizeURL: (value: string) => string | null
+    }
+
+    expect(window.__normalizeURL('localhost:8080')).toBe('https://localhost:8080/')
+    expect(window.__normalizeURL('example.com:8080')).toBe('https://example.com:8080/')
+    expect(window.__normalizeURL('::1')).toBe('https://[::1]/')
+    expect(window.__normalizeURL('javascript:alert(1)')).toBeNull()
+    expect(window.__normalizeURL('#fragment')).toBeNull()
+  })
+})
+
+describe('browser chrome page scoping', () => {
+  it('reserves space and patches SPA history on GitHub pages', () => {
+    const window = runBrowserChrome('https://github.com/Automaat/sybra/issues')
+
+    expect(window.document.documentElement.style.getPropertyValue('padding-top')).toBe('40px')
+    expect((window.history as History & { __sybraPatched?: boolean }).__sybraPatched).toBe(true)
+  })
+
+  it('keeps third-party pages unpatched', () => {
+    const window = runBrowserChrome('https://example.com/docs')
+
+    expect(window.document.documentElement.style.getPropertyValue('padding-top')).toBe('')
+    expect((window.history as History & { __sybraPatched?: boolean }).__sybraPatched).toBeUndefined()
+  })
+})
+
+describe('browser chrome failures', () => {
+  it('logs a warning when injection fails', () => {
+    const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+      runScripts: 'dangerously',
+      url: 'https://github.com/Automaat/sybra',
+    })
+    const warn = vi.fn()
+
+    Object.defineProperty(dom.window.console, 'warn', {
+      configurable: true,
+      value: warn,
+    })
+    dom.window.document.documentElement.appendChild = () => {
+      throw new Error('boom')
+    }
+
+    dom.window.eval(browserChromeSource)
+
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn.mock.calls[0]?.[0]).toBe('[Sybra Browser] toolbar injection failed')
+  })
+})

--- a/main.go
+++ b/main.go
@@ -37,6 +37,9 @@ import (
 //go:embed all:frontend/dist
 var assets embed.FS
 
+//go:embed browser_chrome.js
+var browserChromeJS string
+
 func main() {
 	code, err := run()
 	if err != nil {
@@ -190,12 +193,15 @@ func desktopBrowserOptions(cfg *config.Config, opener func(string)) []sybra.Opti
 // once and stays in a single app. One window per call by design.
 func openInAppBrowser(app *application.App, url string) {
 	app.Window.NewWithOptions(application.WebviewWindowOptions{
-		Title:            "Sybra Browser",
-		URL:              url,
-		Width:            1100,
-		Height:           850,
-		MinWidth:         480,
-		MinHeight:        360,
+		Title:     "Sybra Browser",
+		URL:       url,
+		Width:     1100,
+		Height:    850,
+		MinWidth:  480,
+		MinHeight: 360,
+		// Throwaway JS-injected toolbar (address bar + back/forward/reload)
+		// pending a native NSToolbar — see docs on openInAppBrowser above.
+		JS:               browserChromeJS,
 		BackgroundColour: application.RGBA{Red: 255, Green: 255, Blue: 255, Alpha: 1},
 	})
 }

--- a/main.go
+++ b/main.go
@@ -190,7 +190,9 @@ func desktopBrowserOptions(cfg *config.Config, opener func(string)) []sybra.Opti
 // openInAppBrowser opens url in a fresh in-app webview window. The window uses
 // the app's default (persistent, app-wide) WKWebsiteDataStore, so a GitHub
 // login here is reused across windows and survives restarts — the user logs in
-// once and stays in a single app. One window per call by design.
+// once and stays in a single app. The injected toolbar also allows the user to
+// navigate elsewhere inside that same persistent browser profile. One window
+// per call by design.
 func openInAppBrowser(app *application.App, url string) {
 	app.Window.NewWithOptions(application.WebviewWindowOptions{
 		Title:     "Sybra Browser",
@@ -202,7 +204,7 @@ func openInAppBrowser(app *application.App, url string) {
 		// Throwaway JS-injected toolbar (address bar + back/forward/reload)
 		// pending a native NSToolbar — see docs on openInAppBrowser above.
 		JS:               browserChromeJS,
-		BackgroundColour: application.RGBA{Red: 255, Green: 255, Blue: 255, Alpha: 1},
+		BackgroundColour: application.RGBA{Red: 27, Green: 38, Blue: 54, Alpha: 1},
 	})
 }
 


### PR DESCRIPTION
## Motivation

The in-app browser window opened a fixed URL with no way to navigate elsewhere, forcing users out to an external browser for anything beyond the initial page.

## Implementation information

- Inject a lightweight JS-based toolbar (`browser_chrome.js`) into the webview providing an address bar, back/forward, and reload controls — a stopgap ahead of a native NSToolbar.
- Embed the script via `//go:embed browser_chrome.js` and wire it into `openInAppBrowser`'s `WebviewWindowOptions.JS`.
- Adjust the window background colour to match the new chrome.
- Add frontend tests for the browser chrome logic (`browser-chrome.test.ts`).
- Address review feedback in a follow-up commit.

Closes https://github.com/Automaat/sybra/issues/1461

_Generated by Sybra harness_