### PR TITLE
feat(ui): tabbed task detail with role badges

### DIFF
--- a/frontend/bindings/github.com/Automaat/sybra/internal/sybra/agentservice.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/sybra/agentservice.ts
@@ -115,16 +115,6 @@ export function RespondEscalation(agentID: string, continueRun: boolean): $Cance
 }
 
 /**
- * ResumeInClaudeCode opens a Ghostty terminal tab with a Claude Code session
- * resumed for taskID. If Sybra has a session_id from a prior implementation
- * run, it passes --resume directly. Otherwise the PR URL is copied to the
- * clipboard so the user can paste it into /resume manually.
- */
-export function ResumeInClaudeCode(taskID: string): $CancellablePromise<void> {
-    return $Call.ByID(1675184245, taskID);
-}
-
-/**
  * SendMessage sends a follow-up message to a conversational agent.
  */
 export function SendMessage(agentID: string, text: string): $CancellablePromise<void> {

--- a/frontend/e2e/history.spec.ts
+++ b/frontend/e2e/history.spec.ts
@@ -126,6 +126,9 @@ test.describe('TaskDetail agent history', () => {
     await page.getByRole('button', { name: 'Board view' }).click()
     await page.locator('button:has(h3)', { hasText: 'history fixture task' }).first().click()
 
+    // Agent history now lives in the Runs tab (Overview is the default tab).
+    await page.locator('[data-part="item"]', { hasText: 'Runs' }).click()
+
     // Agent history section must be present with the fixture agent.
     const historyHeading = page.getByText('Agent History', { exact: true })
     await expect(historyHeading).toBeVisible({ timeout: 10_000 })

--- a/frontend/e2e/screenshots.spec.ts
+++ b/frontend/e2e/screenshots.spec.ts
@@ -125,6 +125,8 @@ for (const theme of ['light', 'dark'] as const) {
       await goToTaskList(page)
       await page.getByRole('button', { name: 'Refactor logging system' }).click()
       await page.locator('h1', { hasText: 'Refactor logging system' }).waitFor()
+      // Plan review lives in the Plan tab (Overview is the default tab).
+      await page.locator('[data-part="item"]', { hasText: 'Plan' }).click()
       await page.getByRole('button', { name: 'Approve Plan' }).waitFor()
       await shot(page, theme, 'task-detail-plan-review')
     })

--- a/frontend/e2e/tasks.spec.ts
+++ b/frontend/e2e/tasks.spec.ts
@@ -121,9 +121,10 @@ test.describe('Task Detail', () => {
 
     const main = page.getByRole('main')
 
-    // Agent mode (labelled "Mode" in the properties rail)
+    // Agent mode (labelled "Mode" in the properties rail). Exact match avoids
+    // the case-insensitive collision with the "Headless" run-launcher checkbox.
     await expect(main.getByText('Mode', { exact: true })).toBeVisible()
-    await expect(main.getByText('headless').first()).toBeVisible()
+    await expect(main.getByText('headless', { exact: true }).first()).toBeVisible()
 
     // Tags
     await expect(main.getByText('Tags')).toBeVisible()

--- a/frontend/e2e/tasks.spec.ts
+++ b/frontend/e2e/tasks.spec.ts
@@ -20,7 +20,7 @@ async function cleanupCreatedTasks() {
 async function goToTaskList(page: Page) {
   await page.goto('/')
   await page.locator('[data-part="trigger"]', { hasText: /Board/ }).click()
-  // List is the default view now; switch to the board for these column-based tests.
+  // Board is the default view; make sure we're on it for these column-based tests.
   await page.getByRole('button', { name: 'Board view' }).click()
   await page.waitForSelector('button:has(h3), :text("No tasks")', { timeout: 10_000 })
 }
@@ -121,8 +121,8 @@ test.describe('Task Detail', () => {
 
     const main = page.getByRole('main')
 
-    // Agent mode
-    await expect(main.getByText('Agent Mode', { exact: true })).toBeVisible()
+    // Agent mode (labelled "Mode" in the properties rail)
+    await expect(main.getByText('Mode', { exact: true })).toBeVisible()
     await expect(main.getByText('headless').first()).toBeVisible()
 
     // Tags
@@ -133,9 +133,9 @@ test.describe('Task Detail', () => {
     // Body
     await expect(main.getByText('Add JWT middleware to the API router.')).toBeVisible()
 
-    // Timestamps
-    await expect(main.getByText(/Created:/)).toBeVisible()
-    await expect(main.getByText(/Updated:/)).toBeVisible()
+    // Timestamps (relative values under quiet Created / Updated labels)
+    await expect(main.getByText('Created', { exact: true })).toBeVisible()
+    await expect(main.getByText('Updated', { exact: true })).toBeVisible()
   })
 
   test('navigates back to list', async ({ page }) => {
@@ -208,9 +208,9 @@ test.describe('Create Task', () => {
     await expect(page.locator('h1', { hasText: 'E2E Test Task' })).toBeVisible({ timeout: 5_000 })
     await expect(page.getByText('Created by Playwright e2e test')).toBeVisible()
 
-    // Agent mode should show interactive in the detail metadata
+    // Agent mode should show interactive in the detail metadata (Mode row)
     const main = page.getByRole('main')
-    await expect(main.getByText('Agent Mode').locator('..').getByText('interactive')).toBeVisible()
+    await expect(main.getByText('Mode', { exact: true }).locator('..').getByText('interactive')).toBeVisible()
 
     // Go back — new task should appear in list
     await page.getByText('Back to tasks').click()

--- a/frontend/e2e/workflow.spec.ts
+++ b/frontend/e2e/workflow.spec.ts
@@ -86,6 +86,9 @@ test.describe('Plan Review Workflow', () => {
       page.locator('h1', { hasText: 'Refactor logging system' }),
     ).toBeVisible()
 
+    // Plan review lives in the Plan tab (Overview is the default tab).
+    await page.locator('[data-part="item"]', { hasText: 'Plan' }).click()
+
     // Plan review actions should be visible
     await expect(
       page.getByRole('button', { name: 'Approve Plan' }),
@@ -104,6 +107,9 @@ test.describe('Plan Review Workflow', () => {
     await expect(
       page.locator('h1', { hasText: 'Refactor logging system' }),
     ).toBeVisible()
+
+    // Plan content lives in the Plan tab (Overview is the default tab).
+    await page.locator('[data-part="item"]', { hasText: 'Plan' }).click()
 
     // Plan content should be rendered
     await expect(

--- a/frontend/e2e/workflow.spec.ts
+++ b/frontend/e2e/workflow.spec.ts
@@ -108,10 +108,8 @@ test.describe('Plan Review Workflow', () => {
       page.locator('h1', { hasText: 'Refactor logging system' }),
     ).toBeVisible()
 
-    // Plan content lives in the Plan tab (Overview is the default tab).
-    await page.locator('[data-part="item"]', { hasText: 'Plan' }).click()
-
-    // Plan content should be rendered
+    // This fixture's plan lives in the task body, so it renders in the
+    // description on the default Overview tab (no tab switch needed).
     await expect(
       page.getByText('Replace log.Printf with slog'),
     ).toBeVisible()

--- a/frontend/src/components/CreateTaskDialog.svelte
+++ b/frontend/src/components/CreateTaskDialog.svelte
@@ -17,7 +17,6 @@
   let title = $state('')
   let body = $state('')
   let headless = $state(false)
-  let forkSubagent = $state(false)
   let reasoningEffort = $state('')
   let taskType = $state('normal')
   let selectedProject = $state('')
@@ -61,7 +60,6 @@
     title = ''
     body = ''
     headless = false
-    forkSubagent = false
     reasoningEffort = ''
     taskType = 'normal'
     selectedProject = ''
@@ -90,7 +88,6 @@
       const updates: Record<string, unknown> = {}
       if (taskType !== 'normal') updates.task_type = taskType
       if (selectedProject) updates.project_id = selectedProject
-      if (forkSubagent && effectiveMode === 'headless') updates.fork_subagent = true
       if (reasoningEffort) updates.reasoning_effort = reasoningEffort
       if (Object.keys(updates).length > 0) {
         t = await taskStore.update(t.id, updates)
@@ -209,17 +206,6 @@
             />
             <span class="text-sm font-medium">Headless</span>
           </label>
-          {#if headless}
-            <label class="flex items-center gap-2">
-              <input
-                type="checkbox"
-                bind:checked={forkSubagent}
-                class="rounded border-surface-300 dark:border-surface-600"
-              />
-              <span class="text-sm font-medium">Fork subagents</span>
-              <span class="text-xs text-surface-400">(parallel, higher token cost)</span>
-            </label>
-          {/if}
           <label class="flex flex-col gap-1">
             <span class="text-sm font-medium">Reasoning effort</span>
             <select

--- a/frontend/src/components/task-detail/AgentHistoryList.svelte
+++ b/frontend/src/components/task-detail/AgentHistoryList.svelte
@@ -5,7 +5,7 @@
   import { GetAgentRunLog, GetAgentRunConvoLog } from '$lib/api'
   import { formatDateTime } from '../../lib/dates.js'
   import { formatCostShort } from '../../lib/cost.js'
-  import { runStateClasses, roleLabel } from '../../lib/agent-run.js'
+  import { runStateClasses, runRoleLabel, runRoleClasses } from '../../lib/agent-run.js'
   import StreamOutput from '../StreamOutput.svelte'
   import MessageBubble from '../MessageBubble.svelte'
   import ProviderLogo from '../ProviderLogo.svelte'
@@ -104,10 +104,12 @@
             {#if run.provider}
               <ProviderLogo provider={run.provider} class="h-3.5 w-3.5 text-surface-400" />
             {/if}
-            <span class="font-mono text-surface-400">{run.agentId}</span>
-            {#if roleLabel(run.role)}
-              <span class="rounded bg-tertiary-100 px-1.5 py-0.5 font-medium text-tertiary-700 dark:bg-tertiary-900/50 dark:text-tertiary-300">{roleLabel(run.role)}</span>
+            {#if runRoleLabel(run.role)}
+              <!-- Role is the signal ("which run is the plan/review/eval"); the
+                   opaque agentId is demoted to a quiet mono id beside it. -->
+              <span class="rounded px-1.5 py-0.5 font-medium {runRoleClasses(run.role)}">{runRoleLabel(run.role)}</span>
             {/if}
+            <span class="font-mono text-[11px] text-surface-400">{run.agentId}</span>
             <span class="rounded bg-surface-200 px-1.5 py-0.5 dark:bg-surface-700">{run.mode}</span>
             <span class="rounded px-1.5 py-0.5 {runStateClasses(run.state || 'running')}">
               {run.state || 'running'}

--- a/frontend/src/components/task-detail/AgentHistoryList.svelte.test.ts
+++ b/frontend/src/components/task-detail/AgentHistoryList.svelte.test.ts
@@ -69,6 +69,27 @@ describe('AgentHistoryList', () => {
     expect(screen.getByText('a-old-2')).toBeDefined()
   })
 
+  it('shows a friendly role badge for runs that carry a role', () => {
+    const task = {
+      ...baseTask,
+      agentRuns: [
+        { ...headlessRun, agentId: 'a-plan', role: 'plan' },
+        { ...headlessRun, agentId: 'a-review', role: 'review' },
+      ],
+    }
+    render(AgentHistoryList, { props: { task: task as never } })
+    expect(screen.getByText('Plan')).toBeDefined()
+    expect(screen.getByText('Review')).toBeDefined()
+    // The opaque id stays visible (demoted) alongside the role.
+    expect(screen.getByText('a-plan')).toBeDefined()
+  })
+
+  it('omits the role badge for a run with no role', () => {
+    // baseTask runs carry no role — only mode/state chips, no role label.
+    render(AgentHistoryList, { props: { task: baseTask as never } })
+    expect(screen.queryByText('Implementation')).toBeNull()
+  })
+
   it('expanding headless run fetches stream log', async () => {
     mockGetRunLog.mockResolvedValue([{ type: 'assistant', content: 'hello' }])
     render(AgentHistoryList, { props: { task: baseTask as never } })

--- a/frontend/src/components/task-detail/AgentLauncher.svelte
+++ b/frontend/src/components/task-detail/AgentLauncher.svelte
@@ -1,22 +1,14 @@
 <script lang="ts">
-  import type { Agent } from '../../../bindings/github.com/Automaat/sybra/internal/agent/models.js'
   import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { agentStore } from '../../stores/agents.svelte.js'
   import { connectionStore } from '../../stores/connection.svelte.js'
-  import { EventsOn } from '$lib/api'
-  import { agentState } from '../../lib/events.js'
-  import StreamOutput from '../StreamOutput.svelte'
-  import ChatView from '../ChatView.svelte'
-  import ProviderLogo from '../ProviderLogo.svelte'
 
   interface Props {
     task: Task
-    onviewagent: (agentId: string) => void
   }
 
-  const { task, onviewagent }: Props = $props()
+  const { task }: Props = $props()
 
-  let runningAgent = $state<Agent | null>(null)
   let prompt = $state('')
   let agentMode = $state('interactive')
   let includeTaskDescription = $state(false)
@@ -31,29 +23,15 @@
     }
   })
 
-  $effect(() => {
-    const existing = agentStore.byTask(task.id)
-    if (existing && existing.state === 'running') {
-      runningAgent = existing
-    }
-  })
-
-  $effect(() => {
-    if (!runningAgent) return
-    const id = runningAgent.id
-    const unsub = EventsOn(agentState(id), (data: Agent) => {
-      runningAgent = data
-      agentStore.updateAgent(data.id, data)
-    })
-    return () => { unsub() }
-  })
-
   async function startAgent() {
     if (!prompt.trim()) return
     starting = true
     error = ''
     try {
-      runningAgent = await agentStore.start(task.id, agentMode, prompt.trim(), includeTaskDescription)
+      // The started agent is surfaced by LiveAgentPanel (pinned above the tabs),
+      // which tracks the running agent off the store — so this form only kicks
+      // it off and resets.
+      await agentStore.start(task.id, agentMode, prompt.trim(), includeTaskDescription)
       prompt = ''
     } catch (e) {
       error = String(e)
@@ -67,63 +45,10 @@
   <p class="text-xs text-error-500">{error}</p>
 {/if}
 
-{#if runningAgent}
-  <div class="flex flex-col gap-3">
-    <div class="flex items-center justify-between">
-      <div class="flex items-center gap-2">
-        <span class="text-sm font-medium text-surface-500">Agent</span>
-        {#if runningAgent.provider}
-          <ProviderLogo provider={runningAgent.provider} class="h-4 w-4 text-surface-500" />
-        {/if}
-        <button
-          type="button"
-          class="font-mono text-sm text-primary-500 hover:underline"
-          onclick={() => onviewagent(runningAgent!.id)}
-        >
-          {runningAgent.id}
-        </button>
-        <span
-          class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium {runningAgent.state === 'running' ? 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200' : 'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200'}"
-        >
-          {#if runningAgent.state === 'running'}
-            <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-primary-500"></span>
-          {/if}
-          {runningAgent.state}
-        </span>
-      </div>
-      {#if runningAgent.state === 'running'}
-        <button
-          type="button"
-          class="rounded bg-error-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-error-600"
-          onclick={() => agentStore.stop(runningAgent!.id)}
-        >
-          Stop
-        </button>
-      {/if}
-    </div>
-    {#if runningAgent.prompt}
-      <details class="rounded-lg border border-surface-300 bg-surface-50 dark:border-surface-600 dark:bg-surface-800">
-        <summary class="cursor-pointer select-none px-3 py-2 text-xs font-medium text-surface-600 dark:text-surface-300">Prompt</summary>
-        <pre class="max-h-64 overflow-y-auto whitespace-pre-wrap border-t border-surface-300 px-3 py-2 text-xs text-surface-700 dark:border-surface-600 dark:text-surface-300">{runningAgent.prompt}</pre>
-      </details>
-    {/if}
-    {#if runningAgent.mode === 'interactive'}
-      <ChatView
-        agentId={runningAgent.id}
-        agentState={runningAgent.state}
-        costUsd={runningAgent.costUsd}
-        inputTokens={runningAgent.inputTokens ?? 0}
-        outputTokens={runningAgent.outputTokens ?? 0}
-        bounded={true}
-      />
-    {:else}
-      <StreamOutput agentId={runningAgent.id} />
-    {/if}
-  </div>
-{:else if task.status !== 'plan-review'}
-  <!-- A plan-review task's job is to approve/reject the plan, not launch a new
-       ad-hoc run, so the generic "new run" form is collapsed for it. The live
-       running-agent view above still always shows. -->
+{#if task.status !== 'plan-review'}
+  <!-- A plan-review task's job is to approve/reject the plan (Plan tab), not
+       launch a new ad-hoc run, so the generic "new run" form is collapsed for
+       it. A live running agent still shows via LiveAgentPanel above the tabs. -->
   <div class="flex flex-col gap-3">
     <div class="flex flex-col gap-0.5">
       <span class="text-sm font-medium text-surface-500">New agent run</span>

--- a/frontend/src/components/task-detail/AgentLauncher.svelte.test.ts
+++ b/frontend/src/components/task-detail/AgentLauncher.svelte.test.ts
@@ -2,19 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/svelte'
 
 const mockStart = vi.fn()
-const mockStop = vi.fn()
-const mockByTask = vi.fn()
-const mockUpdateAgent = vi.fn()
-const mockEventsOn = vi.fn((..._args: unknown[]) => vi.fn())
 
 let onlineState = true
 
 vi.mock('../../stores/agents.svelte.js', () => ({
   agentStore: {
     start: (...args: unknown[]) => mockStart(...args),
-    stop: (...args: unknown[]) => mockStop(...args),
-    byTask: (...args: unknown[]) => mockByTask(...args),
-    updateAgent: (...args: unknown[]) => mockUpdateAgent(...args),
   },
 }))
 
@@ -25,14 +18,6 @@ vi.mock('../../stores/connection.svelte.js', () => ({
     },
   },
 }))
-
-vi.mock('$lib/api', () => ({
-  EventsOn: (...args: any[]) => mockEventsOn(...args),
-}))
-
-vi.mock('../StreamOutput.svelte', () => ({ default: () => {} }))
-vi.mock('../ChatView.svelte', () => ({ default: () => {} }))
-vi.mock('../ProviderLogo.svelte', () => ({ default: () => {} }))
 
 const AgentLauncher = (await import('./AgentLauncher.svelte')).default
 
@@ -52,30 +37,24 @@ const baseTask = {
 describe('AgentLauncher', () => {
   beforeEach(() => {
     mockStart.mockReset()
-    mockStop.mockReset()
-    mockByTask.mockReset()
-    mockUpdateAgent.mockReset()
-    mockEventsOn.mockReset()
-    mockEventsOn.mockReturnValue(vi.fn())
-    mockByTask.mockReturnValue(undefined)
     onlineState = true
   })
   afterEach(cleanup)
 
-  it('shows Start agent form when no running agent', () => {
-    render(AgentLauncher, { props: { task: baseTask as never, onviewagent: vi.fn() } })
+  it('shows the Start agent form', () => {
+    render(AgentLauncher, { props: { task: baseTask as never } })
     expect(screen.getByText('Start agent')).toBeDefined()
   })
 
   it('Start agent button is disabled when prompt empty', () => {
-    render(AgentLauncher, { props: { task: baseTask as never, onviewagent: vi.fn() } })
+    render(AgentLauncher, { props: { task: baseTask as never } })
     const btn = screen.getByText('Start agent') as HTMLButtonElement
     expect(btn.disabled).toBe(true)
   })
 
   it('calls agentStore.start with prompt', async () => {
     mockStart.mockResolvedValue({ id: 'a1', state: 'running', mode: 'headless' })
-    render(AgentLauncher, { props: { task: baseTask as never, onviewagent: vi.fn() } })
+    render(AgentLauncher, { props: { task: baseTask as never } })
     const ta = screen.getByPlaceholderText('Enter prompt for the agent...') as HTMLTextAreaElement
     await fireEvent.input(ta, { target: { value: 'do the thing' } })
     await fireEvent.click(screen.getByText('Start agent'))
@@ -86,7 +65,7 @@ describe('AgentLauncher', () => {
 
   it('includes task description when opted in', async () => {
     mockStart.mockResolvedValue({ id: 'a1', state: 'running', mode: 'headless' })
-    render(AgentLauncher, { props: { task: baseTask as never, onviewagent: vi.fn() } })
+    render(AgentLauncher, { props: { task: baseTask as never } })
     const ta = screen.getByPlaceholderText('Enter prompt for the agent...') as HTMLTextAreaElement
     await fireEvent.input(ta, { target: { value: 'do the thing' } })
     const include = screen.getByLabelText('Include task description') as HTMLInputElement
@@ -99,48 +78,14 @@ describe('AgentLauncher', () => {
 
   it('shows Offline indicator when connection.offline', () => {
     onlineState = false
-    render(AgentLauncher, { props: { task: baseTask as never, onviewagent: vi.fn() } })
+    render(AgentLauncher, { props: { task: baseTask as never } })
     expect(screen.getByText('Offline')).toBeDefined()
-  })
-
-  it('renders running agent header with stop button', () => {
-    mockByTask.mockReturnValue({
-      id: 'a1',
-      state: 'running',
-      mode: 'headless',
-      prompt: 'hi',
-      taskId: 't1',
-    })
-    render(AgentLauncher, { props: { task: baseTask as never, onviewagent: vi.fn() } })
-    expect(screen.getByText('Stop')).toBeDefined()
-  })
-
-  it('clicking Stop calls agentStore.stop', async () => {
-    mockByTask.mockReturnValue({
-      id: 'a1',
-      state: 'running',
-      mode: 'headless',
-      taskId: 't1',
-    })
-    render(AgentLauncher, { props: { task: baseTask as never, onviewagent: vi.fn() } })
-    await fireEvent.click(screen.getByText('Stop'))
-    expect(mockStop).toHaveBeenCalledWith('a1')
   })
 
   it('collapses the new-run form for a plan-review task', () => {
     render(AgentLauncher, {
-      props: { task: { ...baseTask, status: 'plan-review' } as never, onviewagent: vi.fn() },
+      props: { task: { ...baseTask, status: 'plan-review' } as never },
     })
     expect(screen.queryByText('Start agent')).toBeNull()
-  })
-
-  it('still shows a running agent (output + Stop) on a plan-review task', () => {
-    // Regression: the interactive plan flow keeps an agent running while the
-    // task sits in plan-review; its live view + Stop must not be hidden.
-    mockByTask.mockReturnValue({ id: 'a1', state: 'running', mode: 'interactive', taskId: 't1' })
-    render(AgentLauncher, {
-      props: { task: { ...baseTask, status: 'plan-review' } as never, onviewagent: vi.fn() },
-    })
-    expect(screen.getByText('Stop')).toBeDefined()
   })
 })

--- a/frontend/src/components/task-detail/LiveAgentPanel.svelte
+++ b/frontend/src/components/task-detail/LiveAgentPanel.svelte
@@ -15,22 +15,24 @@
 
   const { task, onviewagent }: Props = $props()
 
-  // The currently-running agent for this task, tracked off the reactive store so
-  // this panel can live *outside* the tabbed body: StreamOutput subscribes to a
-  // live SSE feed with local state, so unmounting it on a tab switch would drop
-  // the stream. Pinning it above the tabs keeps live output visible on every tab.
-  let runningAgent = $state<Agent | null>(null)
+  // The running agent for this task, derived off the reactive store. Scan the
+  // running set (not the most-recent agent for the task, which may be stopped
+  // while an older run is still live) so the pinned live view never misses it.
+  // Derived, not $state, so store updates flow straight through — this panel
+  // lives *outside* the tabbed body so StreamOutput's live SSE subscription is
+  // never torn down by a tab switch.
+  const runningAgent = $derived(
+    agentStore.byState('running').find((a) => a.taskId === task.id) ?? null,
+  )
+  // Key the subscription on the id alone: a same-id state update keeps this
+  // value stable, so the effect does not churn unsubscribe/resubscribe on every
+  // event — it only re-subscribes when a different agent starts running.
+  const runningAgentId = $derived(runningAgent?.id)
 
   $effect(() => {
-    const existing = agentStore.byTask(task.id)
-    runningAgent = existing && existing.state === 'running' ? existing : null
-  })
-
-  $effect(() => {
-    if (!runningAgent) return
-    const id = runningAgent.id
+    const id = runningAgentId
+    if (!id) return
     const unsub = EventsOn(agentState(id), (data: Agent) => {
-      runningAgent = data
       agentStore.updateAgent(data.id, data)
     })
     return () => { unsub() }

--- a/frontend/src/components/task-detail/LiveAgentPanel.svelte
+++ b/frontend/src/components/task-detail/LiveAgentPanel.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+  import type { Agent } from '../../../bindings/github.com/Automaat/sybra/internal/agent/models.js'
+  import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
+  import { agentStore } from '../../stores/agents.svelte.js'
+  import { EventsOn } from '$lib/api'
+  import { agentState } from '../../lib/events.js'
+  import StreamOutput from '../StreamOutput.svelte'
+  import ChatView from '../ChatView.svelte'
+  import ProviderLogo from '../ProviderLogo.svelte'
+
+  interface Props {
+    task: Task
+    onviewagent: (agentId: string) => void
+  }
+
+  const { task, onviewagent }: Props = $props()
+
+  // The currently-running agent for this task, tracked off the reactive store so
+  // this panel can live *outside* the tabbed body: StreamOutput subscribes to a
+  // live SSE feed with local state, so unmounting it on a tab switch would drop
+  // the stream. Pinning it above the tabs keeps live output visible on every tab.
+  let runningAgent = $state<Agent | null>(null)
+
+  $effect(() => {
+    const existing = agentStore.byTask(task.id)
+    runningAgent = existing && existing.state === 'running' ? existing : null
+  })
+
+  $effect(() => {
+    if (!runningAgent) return
+    const id = runningAgent.id
+    const unsub = EventsOn(agentState(id), (data: Agent) => {
+      runningAgent = data
+      agentStore.updateAgent(data.id, data)
+    })
+    return () => { unsub() }
+  })
+</script>
+
+{#if runningAgent}
+  <div class="flex flex-col gap-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <span class="text-sm font-medium text-surface-500">Agent</span>
+        {#if runningAgent.provider}
+          <ProviderLogo provider={runningAgent.provider} class="h-4 w-4 text-surface-500" />
+        {/if}
+        <button
+          type="button"
+          class="font-mono text-sm text-primary-500 hover:underline"
+          onclick={() => onviewagent(runningAgent!.id)}
+        >
+          {runningAgent.id}
+        </button>
+        <span
+          class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium {runningAgent.state === 'running' ? 'bg-primary-200 text-primary-800 dark:bg-primary-700 dark:text-primary-200' : 'bg-surface-200 text-surface-800 dark:bg-surface-700 dark:text-surface-200'}"
+        >
+          {#if runningAgent.state === 'running'}
+            <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-primary-500"></span>
+          {/if}
+          {runningAgent.state}
+        </span>
+      </div>
+      {#if runningAgent.state === 'running'}
+        <button
+          type="button"
+          class="rounded bg-error-500 px-2.5 py-1 text-xs font-medium text-white hover:bg-error-600"
+          onclick={() => agentStore.stop(runningAgent!.id)}
+        >
+          Stop
+        </button>
+      {/if}
+    </div>
+    {#if runningAgent.prompt}
+      <details class="rounded-lg border border-surface-300 bg-surface-50 dark:border-surface-600 dark:bg-surface-800">
+        <summary class="cursor-pointer select-none px-3 py-2 text-xs font-medium text-surface-600 dark:text-surface-300">Prompt</summary>
+        <pre class="max-h-64 overflow-y-auto whitespace-pre-wrap border-t border-surface-300 px-3 py-2 text-xs text-surface-700 dark:border-surface-600 dark:text-surface-300">{runningAgent.prompt}</pre>
+      </details>
+    {/if}
+    {#if runningAgent.mode === 'interactive'}
+      <ChatView
+        agentId={runningAgent.id}
+        agentState={runningAgent.state}
+        costUsd={runningAgent.costUsd}
+        inputTokens={runningAgent.inputTokens ?? 0}
+        outputTokens={runningAgent.outputTokens ?? 0}
+        bounded={true}
+      />
+    {:else}
+      <StreamOutput agentId={runningAgent.id} />
+    {/if}
+  </div>
+{/if}

--- a/frontend/src/components/task-detail/LiveAgentPanel.svelte.test.ts
+++ b/frontend/src/components/task-detail/LiveAgentPanel.svelte.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
 
 const mockStop = vi.fn()
-const mockByTask = vi.fn()
+const mockByState = vi.fn()
 const mockUpdateAgent = vi.fn()
 const mockEventsOn = vi.fn((..._args: unknown[]) => vi.fn())
 
 vi.mock('../../stores/agents.svelte.js', () => ({
   agentStore: {
     stop: (...args: unknown[]) => mockStop(...args),
-    byTask: (...args: unknown[]) => mockByTask(...args),
+    byState: (...args: unknown[]) => mockByState(...args),
     updateAgent: (...args: unknown[]) => mockUpdateAgent(...args),
   },
 }))
@@ -39,11 +39,12 @@ const baseTask = {
 describe('LiveAgentPanel', () => {
   beforeEach(() => {
     mockStop.mockReset()
-    mockByTask.mockReset()
+    mockByState.mockReset()
     mockUpdateAgent.mockReset()
     mockEventsOn.mockReset()
     mockEventsOn.mockReturnValue(vi.fn())
-    mockByTask.mockReturnValue(undefined)
+    // byState('running') returns the running agents; default: none.
+    mockByState.mockReturnValue([])
   })
   afterEach(cleanup)
 
@@ -55,39 +56,49 @@ describe('LiveAgentPanel', () => {
   })
 
   it('renders the running agent header with a Stop button', () => {
-    mockByTask.mockReturnValue({ id: 'a1', state: 'running', mode: 'headless', prompt: 'hi', taskId: 't1' })
+    mockByState.mockReturnValue([{ id: 'a1', state: 'running', mode: 'headless', prompt: 'hi', taskId: 't1' }])
     render(LiveAgentPanel, { props: { task: baseTask as never, onviewagent: vi.fn() } })
     expect(screen.getByText('a1')).toBeDefined()
     expect(screen.getByText('Stop')).toBeDefined()
   })
 
   it('clicking Stop calls agentStore.stop', async () => {
-    mockByTask.mockReturnValue({ id: 'a1', state: 'running', mode: 'headless', taskId: 't1' })
+    mockByState.mockReturnValue([{ id: 'a1', state: 'running', mode: 'headless', taskId: 't1' }])
     render(LiveAgentPanel, { props: { task: baseTask as never, onviewagent: vi.fn() } })
     await fireEvent.click(screen.getByText('Stop'))
     expect(mockStop).toHaveBeenCalledWith('a1')
   })
 
   it('calls onviewagent when the agent id is clicked', async () => {
-    mockByTask.mockReturnValue({ id: 'a1', state: 'running', mode: 'headless', taskId: 't1' })
+    mockByState.mockReturnValue([{ id: 'a1', state: 'running', mode: 'headless', taskId: 't1' }])
     const onviewagent = vi.fn()
     render(LiveAgentPanel, { props: { task: baseTask as never, onviewagent } })
     await fireEvent.click(screen.getByText('a1'))
     expect(onviewagent).toHaveBeenCalledWith('a1')
   })
 
-  it('ignores a non-running agent for the task', () => {
-    mockByTask.mockReturnValue({ id: 'a1', state: 'stopped', mode: 'headless', taskId: 't1' })
+  it('picks the running agent for this task, not one from another task', () => {
+    // A running agent that belongs to a different task must be ignored — the
+    // panel scans the running set and filters by taskId.
+    mockByState.mockReturnValue([{ id: 'a1', state: 'running', mode: 'headless', taskId: 'other' }])
     const { container } = render(LiveAgentPanel, {
       props: { task: baseTask as never, onviewagent: vi.fn() },
     })
     expect(container.textContent).toBe('')
   })
 
+  it('finds an older running run even when a newer run has stopped', () => {
+    // byState('running') already excludes stopped runs, so an older still-running
+    // agent for this task is surfaced regardless of ordering.
+    mockByState.mockReturnValue([{ id: 'a-old', state: 'running', mode: 'headless', taskId: 't1' }])
+    render(LiveAgentPanel, { props: { task: baseTask as never, onviewagent: vi.fn() } })
+    expect(screen.getByText('a-old')).toBeDefined()
+  })
+
   // A plan-review task can keep an interactive planner running; its live view
   // must still show (it lives above the tabs, independent of task status).
   it('shows a running agent even on a plan-review task', () => {
-    mockByTask.mockReturnValue({ id: 'a1', state: 'running', mode: 'interactive', taskId: 't1' })
+    mockByState.mockReturnValue([{ id: 'a1', state: 'running', mode: 'interactive', taskId: 't1' }])
     render(LiveAgentPanel, {
       props: { task: { ...baseTask, status: 'plan-review' } as never, onviewagent: vi.fn() },
     })

--- a/frontend/src/components/task-detail/LiveAgentPanel.svelte.test.ts
+++ b/frontend/src/components/task-detail/LiveAgentPanel.svelte.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/svelte'
+
+const mockStop = vi.fn()
+const mockByTask = vi.fn()
+const mockUpdateAgent = vi.fn()
+const mockEventsOn = vi.fn((..._args: unknown[]) => vi.fn())
+
+vi.mock('../../stores/agents.svelte.js', () => ({
+  agentStore: {
+    stop: (...args: unknown[]) => mockStop(...args),
+    byTask: (...args: unknown[]) => mockByTask(...args),
+    updateAgent: (...args: unknown[]) => mockUpdateAgent(...args),
+  },
+}))
+
+vi.mock('$lib/api', () => ({
+  EventsOn: (...args: unknown[]) => mockEventsOn(...args),
+}))
+
+vi.mock('../StreamOutput.svelte', () => ({ default: () => {} }))
+vi.mock('../ChatView.svelte', () => ({ default: () => {} }))
+vi.mock('../ProviderLogo.svelte', () => ({ default: () => {} }))
+
+const LiveAgentPanel = (await import('./LiveAgentPanel.svelte')).default
+
+const baseTask = {
+  id: 't1',
+  title: 'X',
+  status: 'in-progress',
+  body: '',
+  tags: [],
+  agentMode: 'headless',
+  allowedTools: [],
+  createdAt: '2026-04-01T00:00:00Z',
+  updatedAt: '2026-04-01T00:00:00Z',
+}
+
+describe('LiveAgentPanel', () => {
+  beforeEach(() => {
+    mockStop.mockReset()
+    mockByTask.mockReset()
+    mockUpdateAgent.mockReset()
+    mockEventsOn.mockReset()
+    mockEventsOn.mockReturnValue(vi.fn())
+    mockByTask.mockReturnValue(undefined)
+  })
+  afterEach(cleanup)
+
+  it('renders nothing when no running agent', () => {
+    const { container } = render(LiveAgentPanel, {
+      props: { task: baseTask as never, onviewagent: vi.fn() },
+    })
+    expect(container.textContent).toBe('')
+  })
+
+  it('renders the running agent header with a Stop button', () => {
+    mockByTask.mockReturnValue({ id: 'a1', state: 'running', mode: 'headless', prompt: 'hi', taskId: 't1' })
+    render(LiveAgentPanel, { props: { task: baseTask as never, onviewagent: vi.fn() } })
+    expect(screen.getByText('a1')).toBeDefined()
+    expect(screen.getByText('Stop')).toBeDefined()
+  })
+
+  it('clicking Stop calls agentStore.stop', async () => {
+    mockByTask.mockReturnValue({ id: 'a1', state: 'running', mode: 'headless', taskId: 't1' })
+    render(LiveAgentPanel, { props: { task: baseTask as never, onviewagent: vi.fn() } })
+    await fireEvent.click(screen.getByText('Stop'))
+    expect(mockStop).toHaveBeenCalledWith('a1')
+  })
+
+  it('calls onviewagent when the agent id is clicked', async () => {
+    mockByTask.mockReturnValue({ id: 'a1', state: 'running', mode: 'headless', taskId: 't1' })
+    const onviewagent = vi.fn()
+    render(LiveAgentPanel, { props: { task: baseTask as never, onviewagent } })
+    await fireEvent.click(screen.getByText('a1'))
+    expect(onviewagent).toHaveBeenCalledWith('a1')
+  })
+
+  it('ignores a non-running agent for the task', () => {
+    mockByTask.mockReturnValue({ id: 'a1', state: 'stopped', mode: 'headless', taskId: 't1' })
+    const { container } = render(LiveAgentPanel, {
+      props: { task: baseTask as never, onviewagent: vi.fn() },
+    })
+    expect(container.textContent).toBe('')
+  })
+
+  // A plan-review task can keep an interactive planner running; its live view
+  // must still show (it lives above the tabs, independent of task status).
+  it('shows a running agent even on a plan-review task', () => {
+    mockByTask.mockReturnValue({ id: 'a1', state: 'running', mode: 'interactive', taskId: 't1' })
+    render(LiveAgentPanel, {
+      props: { task: { ...baseTask, status: 'plan-review' } as never, onviewagent: vi.fn() },
+    })
+    expect(screen.getByText('Stop')).toBeDefined()
+  })
+})

--- a/frontend/src/components/task-detail/TaskDescriptionEditor.svelte
+++ b/frontend/src/components/task-detail/TaskDescriptionEditor.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import { ChevronRight } from '@lucide/svelte'
+  import { Pencil } from '@lucide/svelte'
   import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { taskStore } from '../../stores/tasks.svelte.js'
-  import { renderMarkdown, renderChecklistMarkdown } from '../../lib/markdown.js'
+  import { renderChecklistMarkdown } from '../../lib/markdown.js'
 
   interface Props {
     task: Task
@@ -10,23 +10,13 @@
 
   const { task }: Props = $props()
 
-  const PLAN_COLLAPSED_KEY = 'task-detail:plan-collapsed'
-
   let editing = $state(false)
   let draft = $state('')
   let error = $state('')
-  let planCollapsed = $state(typeof localStorage !== 'undefined' && localStorage.getItem(PLAN_COLLAPSED_KEY) === '1')
 
-  function togglePlan() {
-    planCollapsed = !planCollapsed
-    if (typeof localStorage !== 'undefined') {
-      localStorage.setItem(PLAN_COLLAPSED_KEY, planCollapsed ? '1' : '0')
-    }
-  }
-
+  // The read-only Plan and Code Review artifacts moved to the Plan/Review tabs
+  // (TaskPlanPanel / TaskReviewPanel); this editor is now only the task body.
   const renderedBody = $derived(renderChecklistMarkdown(task.body))
-  const renderedPlan = $derived(renderMarkdown(task.plan))
-  const renderedCodeReview = $derived(renderMarkdown(task.codeReview))
 
   function startEditing() {
     draft = task.body ?? ''
@@ -64,11 +54,21 @@
 
 <div class="flex flex-col gap-1">
   <div class="flex items-center justify-between">
-    <span class="text-sm font-medium text-surface-500">Description</span>
+    <span class="text-[11px] font-medium uppercase tracking-wide text-surface-400">Description</span>
     {#if editing}
       <span class="text-xs text-surface-400">
         {navigator.platform.includes('Mac') ? '⌘' : 'Ctrl'}+Enter to save · Esc to cancel
       </span>
+    {:else}
+      <button
+        type="button"
+        class="text-surface-400 transition-colors hover:text-surface-600 dark:hover:text-surface-300"
+        onclick={startEditing}
+        title="Edit description (e)"
+        aria-label="Edit description"
+      >
+        <Pencil size={14} />
+      </button>
     {/if}
   </div>
   {#if error}
@@ -84,9 +84,10 @@
       autofocus
     ></textarea>
   {:else}
+    <!-- Low-chrome, content-first: borderless until hover signals it's editable. -->
     <button
       type="button"
-      class="w-full cursor-text rounded-lg border border-surface-300 bg-surface-100 p-4 text-left transition-colors hover:border-primary-400 dark:border-surface-600 dark:bg-surface-900 dark:hover:border-primary-500"
+      class="w-full cursor-text rounded-lg p-3 text-left transition-colors hover:bg-surface-100 dark:hover:bg-surface-900"
       onclick={startEditing}
     >
       {#if task.body}
@@ -97,36 +98,3 @@
     </button>
   {/if}
 </div>
-
-<!-- For a plan-review task the plan is shown (and decided on) at the top in
-     PlanReviewPanel, so the lower read-only copy here would duplicate it. -->
-{#if task.plan && task.status !== 'plan-review'}
-  <div class="flex flex-col gap-1">
-    <button
-      type="button"
-      class="flex w-fit items-center gap-2 text-left"
-      onclick={togglePlan}
-      aria-expanded={!planCollapsed}
-    >
-      <ChevronRight size={14} class="text-surface-400 transition-transform {planCollapsed ? '' : 'rotate-90'}" />
-      <span class="text-sm font-medium text-surface-500">Plan</span>
-      <span class="text-xs text-surface-400 italic">read-only</span>
-    </button>
-    {#if !planCollapsed}
-      <div class="rounded-lg border border-surface-300 bg-surface-100 p-4 dark:border-surface-600 dark:bg-surface-900">
-        <div class="markdown-body text-sm text-surface-900 dark:text-surface-100">{@html renderedPlan}</div>
-      </div>
-    {/if}
-  </div>
-{/if}
-
-{#if task.codeReview}
-  <details open class="rounded-lg border border-warning-300 bg-warning-50 dark:border-warning-700 dark:bg-warning-900/20">
-    <summary class="cursor-pointer px-4 py-2 text-sm font-semibold text-warning-800 dark:text-warning-200">
-      Code Review (auto-generated)
-    </summary>
-    <div class="markdown-body px-4 pb-4 text-sm text-surface-900 dark:text-surface-100">
-      {@html renderedCodeReview}
-    </div>
-  </details>
-{/if}

--- a/frontend/src/components/task-detail/TaskDescriptionEditor.svelte.test.ts
+++ b/frontend/src/components/task-detail/TaskDescriptionEditor.svelte.test.ts
@@ -68,7 +68,7 @@ describe('TaskDescriptionEditor', () => {
     expect(mockUpdate).not.toHaveBeenCalled()
   })
 
-  it('renders plan and code-review when present', () => {
+  it('no longer renders plan or code review (moved to Plan/Review tabs)', () => {
     render(TaskDescriptionEditor, {
       props: {
         task: {
@@ -78,8 +78,9 @@ describe('TaskDescriptionEditor', () => {
         } as never,
       },
     })
-    expect(screen.getByText('Plan')).toBeDefined()
-    expect(screen.getByText('Code Review (auto-generated)')).toBeDefined()
+    expect(screen.queryByText('plan body')).toBeNull()
+    expect(screen.queryByText('review body')).toBeNull()
+    expect(screen.queryByText(/Code Review/)).toBeNull()
   })
 
   it('opens editor when task-detail:edit-body event fires', async () => {

--- a/frontend/src/components/task-detail/TaskMetadataRow.svelte
+++ b/frontend/src/components/task-detail/TaskMetadataRow.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-  import { CircleDot, Copy } from '@lucide/svelte'
+  import { CircleDot, Copy, FolderGit2, GitBranch, Bot, Tag, Calendar, Clock, CalendarClock, Wrench } from '@lucide/svelte'
   import { onMount } from 'svelte'
   import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { taskStore } from '../../stores/tasks.svelte.js'
   import { notificationStore } from '../../stores/notifications.svelte.js'
   import { openLink } from '$lib/browser.svelte.js'
-  import { formatDateTime } from '../../lib/dates.js'
+  import { formatDateTime, formatShortDate, timeAgo } from '../../lib/dates.js'
   import { fallbackReasoningEffortOptions, loadReasoningEffortOptions } from '../../lib/codex-reasoning.js'
   import AssignProjectDialog from '../AssignProjectDialog.svelte'
   import TaskTagEditor from './TaskTagEditor.svelte'
@@ -75,107 +75,105 @@
   <p class="text-xs text-error-500">{error}</p>
 {/if}
 
-<div class="flex gap-6 text-sm">
-  <div class="flex flex-col gap-1">
-    <span class="font-medium text-surface-500">Agent Mode</span>
-    <!-- Read-only: plain text, no pill chrome, so it doesn't imply the
-         click-to-edit affordance the Project/Tags pills carry. -->
-    <span class="text-surface-700 dark:text-surface-300">{task.agentMode}</span>
-  </div>
-
-  <div class="flex flex-col gap-1">
-    <span class="font-medium text-surface-500">Tags</span>
-    <TaskTagEditor bind:this={tagEditor} {task} onerror={handleError} />
-  </div>
-
-  <div class="flex flex-col gap-1">
-    <span class="font-medium text-surface-500">Project</span>
+<!-- Metadata as an aligned properties list: a quiet label column + a single
+     value column with leading type icons, so the eye scans one edge. The row
+     order runs primary → secondary (identity, then timestamps). -->
+<dl class="grid grid-cols-[auto_1fr] items-center gap-x-5 gap-y-2.5 text-sm">
+  <dt class="text-[11px] font-medium uppercase tracking-wide text-surface-400">Project</dt>
+  <dd>
     <button
       type="button"
-      class="w-fit rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-200 hover:text-surface-700 dark:hover:bg-surface-700 dark:hover:text-surface-300"
+      class="-mx-1.5 inline-flex items-center gap-1.5 rounded px-1.5 py-0.5 text-left transition-colors hover:bg-surface-200 dark:hover:bg-surface-700"
       onclick={() => (projectDialogOpen = true)}
       title="Click to change project"
     >
+      <FolderGit2 size={13} class="shrink-0 text-surface-400" />
       {#if task.projectId}
-        <span class="rounded bg-surface-200 px-2 py-0.5 font-mono dark:bg-surface-700">{task.projectId}</span>
+        <span class="font-mono text-surface-700 dark:text-surface-300">{task.projectId}</span>
       {:else}
         <span class="text-xs italic text-surface-400">assign project</span>
       {/if}
     </button>
-  </div>
+  </dd>
 
   {#if task.projectId}
-    <div class="flex flex-col gap-1">
-      <span class="font-medium text-surface-500">Branch</span>
+    <dt class="text-[11px] font-medium uppercase tracking-wide text-surface-400">Branch</dt>
+    <dd>
       <button
         type="button"
-        class="inline-flex items-center gap-1.5 rounded bg-surface-200 px-2 py-0.5 font-mono text-left transition-colors hover:bg-surface-300 dark:bg-surface-700 dark:hover:bg-surface-600"
+        class="-mx-1.5 inline-flex items-center gap-1.5 rounded px-1.5 py-0.5 text-left font-mono text-surface-700 transition-colors hover:bg-surface-200 dark:text-surface-300 dark:hover:bg-surface-700"
         onclick={copyBranch}
         title="Copy branch name (⇧⌘.)"
       >
+        <GitBranch size={13} class="shrink-0 text-surface-400" />
         {copiedBranch ? 'Copied!' : taskBranchName}
         <Copy size={12} class="shrink-0 text-surface-400" />
       </button>
-    </div>
+    </dd>
   {/if}
 
+  <dt class="text-[11px] font-medium uppercase tracking-wide text-surface-400">Mode</dt>
+  <dd class="flex items-center gap-1.5 text-surface-700 dark:text-surface-300">
+    <Bot size={13} class="shrink-0 text-surface-400" />
+    {task.agentMode}
+  </dd>
+
+  <dt class="text-[11px] font-medium uppercase tracking-wide text-surface-400">Tags</dt>
+  <dd class="flex items-center gap-1.5">
+    <Tag size={13} class="shrink-0 text-surface-400" />
+    <TaskTagEditor bind:this={tagEditor} {task} onerror={handleError} />
+  </dd>
+
   {#if task.issue}
-    <div class="flex flex-col gap-1">
-      <span class="font-medium text-surface-500">Issue</span>
+    <dt class="text-[11px] font-medium uppercase tracking-wide text-surface-400">Issue</dt>
+    <dd>
       <button
         type="button"
-        class="flex w-fit items-center gap-1.5 text-sm text-secondary-600 hover:underline dark:text-secondary-400"
+        class="flex w-fit items-center gap-1.5 text-secondary-600 hover:underline dark:text-secondary-400"
         onclick={(e) => openLink(task.issue, e)}
       >
-        <CircleDot size={16} class="shrink-0" />
+        <CircleDot size={13} class="shrink-0" />
         {task.issue}
       </button>
-    </div>
+    </dd>
   {/if}
 
   {#if task.allowedTools?.length}
-    <div class="flex flex-col gap-1">
-      <span class="font-medium text-surface-500">Allowed Tools</span>
-      <div class="flex gap-1">
+    <dt class="text-[11px] font-medium uppercase tracking-wide text-surface-400">Tools</dt>
+    <dd class="flex items-center gap-1.5">
+      <Wrench size={13} class="shrink-0 text-surface-400" />
+      <div class="flex flex-wrap gap-1">
         {#each task.allowedTools as tool}
           <span class="rounded bg-surface-200 px-2 py-0.5 font-mono text-xs dark:bg-surface-700">{tool}</span>
         {/each}
       </div>
-    </div>
+    </dd>
   {/if}
 
-  <!-- Per-run knobs stay editable (they're the only place to set them), but
-       render quietly at their default so they don't shout: Fork shows a muted
-       "disabled", Max Turns a muted "global default". -->
-  {#if task.agentMode === 'headless'}
-  <div class="flex flex-col gap-1">
-    <span class="font-medium text-surface-500">Fork Subagents</span>
-    <button
-      type="button"
-      class="w-fit rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-200 hover:text-surface-700 dark:hover:bg-surface-700 dark:hover:text-surface-300"
-      onclick={async () => {
-        try {
-          await taskStore.update(task.id, { fork_subagent: !task.forkSubagent })
-        } catch (e) {
-          error = String(e)
-        }
-      }}
-      title="Enable CLAUDE_CODE_FORK_SUBAGENT=1 — parallel subagents, higher token cost"
-    >
-      {#if task.forkSubagent}
-        <span class="text-primary-600 dark:text-primary-400">enabled</span>
-      {:else}
-        <span class="italic text-surface-400">disabled</span>
-      {/if}
-    </button>
-  </div>
-  {/if}
+  <dt class="text-[11px] font-medium uppercase tracking-wide text-surface-400">Created</dt>
+  <dd class="flex items-center gap-1.5 text-surface-500" title={formatDateTime(task.createdAt)}>
+    <Calendar size={13} class="shrink-0 text-surface-400" />
+    {formatShortDate(task.createdAt)}
+  </dd>
 
-  <div class="flex flex-col gap-1">
-    <span class="font-medium text-surface-500">Reasoning Effort</span>
+  <dt class="text-[11px] font-medium uppercase tracking-wide text-surface-400">Updated</dt>
+  <dd class="flex items-center gap-1.5 text-surface-500" title={formatDateTime(task.updatedAt)}>
+    <Clock size={13} class="shrink-0 text-surface-400" />
+    {timeAgo(task.updatedAt)}
+  </dd>
+
+  <dt class="text-[11px] font-medium uppercase tracking-wide text-surface-400">Due</dt>
+  <dd class="flex items-center gap-1.5">
+    <CalendarClock size={13} class="shrink-0 text-surface-400" />
+    <TaskDueDateEditor bind:this={dueDateEditor} {task} onerror={handleError} />
+  </dd>
+
+  <!-- Per-run execution knobs, shown inline with the rest of the properties. -->
+  <dt class="text-[11px] font-medium uppercase tracking-wide text-surface-400">Reasoning Effort</dt>
+  <dd>
     <select
       aria-label="Reasoning Effort"
-      class="w-fit rounded bg-transparent px-1 py-0.5 text-sm text-surface-600 dark:text-surface-300"
+      class="-mx-1 w-fit rounded bg-transparent px-1 py-0.5 text-sm text-surface-600 dark:text-surface-300"
       value={task.reasoningEffort ?? ''}
       onchange={async (e) => {
         try {
@@ -191,22 +189,11 @@
         <option value={option.value}>{option.label}</option>
       {/each}
     </select>
-  </div>
+  </dd>
 
-  <div class="flex flex-col gap-1">
-    <span class="font-medium text-surface-500">Max Turns</span>
-    <TaskMaxTurnsEditor {task} onerror={handleError} />
-  </div>
-</div>
-
-<div class="flex flex-wrap items-center gap-4 text-xs text-surface-400">
-  <span>Created: {formatDateTime(task.createdAt)}</span>
-  <span>Updated: {formatDateTime(task.updatedAt)}</span>
-  <div class="flex items-center gap-1">
-    <span>Due:</span>
-    <TaskDueDateEditor bind:this={dueDateEditor} {task} onerror={handleError} />
-  </div>
-</div>
+  <dt class="text-[11px] font-medium uppercase tracking-wide text-surface-400">Max Turns</dt>
+  <dd><TaskMaxTurnsEditor {task} onerror={handleError} /></dd>
+</dl>
 
 <AssignProjectDialog
   open={projectDialogOpen}

--- a/frontend/src/components/task-detail/TaskMetadataRow.svelte.test.ts
+++ b/frontend/src/components/task-detail/TaskMetadataRow.svelte.test.ts
@@ -49,13 +49,22 @@ describe('TaskMetadataRow', () => {
   afterEach(cleanup)
 
   it('keeps the per-run knobs editable even at their default value', () => {
-    // They render quietly at default (muted "disabled"/"global default") but
-    // stay present — they are the only place to set max turns / fork.
+    // They render quietly at default (muted "global default") but stay present —
+    // they are the only place to set max turns / reasoning effort.
     render(TaskMetadataRow, { props: { task: baseTask as never } })
-    expect(screen.getByText('Fork Subagents')).toBeDefined()
-    expect(screen.getByText('disabled')).toBeDefined()
     expect(screen.getByText('Max Turns')).toBeDefined()
     expect(screen.getByText('global default')).toBeDefined()
+  })
+
+  it('shows the per-run knobs inline in the properties list (no Advanced disclosure)', () => {
+    render(TaskMetadataRow, { props: { task: baseTask as never } })
+    // No Advanced wrapper — the knobs sit directly among Project/Branch/etc.
+    expect(screen.queryByText('Advanced')).toBeNull()
+    expect(document.querySelector('details')).toBeNull()
+    expect(screen.getByText('Reasoning Effort')).toBeDefined()
+    expect(screen.getByText('Max Turns')).toBeDefined()
+    // Fork Subagents was removed from the task UI.
+    expect(screen.queryByText('Fork Subagents')).toBeNull()
   })
 
   it('describes reasoning effort as provider-wide', () => {
@@ -69,7 +78,7 @@ describe('TaskMetadataRow', () => {
 
   it('renders agent mode + tags + project + branch + issue + allowed tools', () => {
     render(TaskMetadataRow, { props: { task: baseTask as never } })
-    expect(screen.getByText('Agent Mode')).toBeDefined()
+    expect(screen.getByText('Mode')).toBeDefined()
     expect(screen.getByText('headless')).toBeDefined()
     expect(screen.getByText('backend')).toBeDefined()
     expect(screen.getByText('foo/bar')).toBeDefined()

--- a/frontend/src/components/task-detail/TaskPlanPanel.svelte
+++ b/frontend/src/components/task-detail/TaskPlanPanel.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
+  import { renderMarkdown } from '../../lib/markdown.js'
+
+  interface Props {
+    task: Task
+  }
+
+  const { task }: Props = $props()
+
+  // Read-only view of a task's planning artifacts, for the Plan tab of a task
+  // that is past plan-review. The plan-review *decision* (approve/reject +
+  // open decisions) is handled separately by PlanReviewPanel.
+  const renderedPlan = $derived(renderMarkdown(task.plan))
+  const renderedCritique = $derived(renderMarkdown(task.planCritique))
+  const renderedResearch = $derived(renderMarkdown(task.planResearch))
+  const renderedBrief = $derived(renderMarkdown(task.planBrief))
+  const renderedDecisions = $derived(renderMarkdown(task.planDecisions))
+</script>
+
+{#if task.plan}
+  <div class="flex flex-col gap-1">
+    <span class="text-sm font-medium text-surface-500">Plan <span class="text-xs font-normal italic text-surface-400">read-only</span></span>
+    <div class="rounded-lg border border-surface-300 bg-surface-100 p-4 dark:border-surface-600 dark:bg-surface-900">
+      <div class="markdown-body text-sm text-surface-900 dark:text-surface-100">{@html renderedPlan}</div>
+    </div>
+  </div>
+{/if}
+
+{#if task.planBrief}
+  <div class="rounded-md border border-surface-300 bg-surface-50 p-3 dark:border-surface-700 dark:bg-surface-900">
+    <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-surface-500">Final brief</div>
+    <div class="markdown-body text-sm text-surface-900 dark:text-surface-100">{@html renderedBrief}</div>
+  </div>
+{/if}
+
+{#if task.planCritique}
+  <details class="rounded-md border border-surface-300 bg-surface-50 dark:border-surface-600 dark:bg-surface-900">
+    <summary class="cursor-pointer select-none px-3 py-2 text-xs font-medium text-surface-600 dark:text-surface-300">Plan critique</summary>
+    <div class="markdown-body max-h-96 overflow-y-auto border-t border-surface-300 p-3 text-sm dark:border-surface-600">
+      {@html renderedCritique}
+    </div>
+  </details>
+{/if}
+
+{#if task.planResearch}
+  <details class="rounded-md border border-surface-300 bg-surface-50 dark:border-surface-600 dark:bg-surface-900">
+    <summary class="cursor-pointer select-none px-3 py-2 text-xs font-medium text-surface-600 dark:text-surface-300">Plan research</summary>
+    <div class="markdown-body max-h-96 overflow-y-auto border-t border-surface-300 p-3 text-sm dark:border-surface-600">
+      {@html renderedResearch}
+    </div>
+  </details>
+{/if}
+
+{#if task.planDecisions}
+  <details class="rounded-md border border-surface-300 bg-surface-50 dark:border-surface-600 dark:bg-surface-900">
+    <summary class="cursor-pointer select-none px-3 py-2 text-xs font-medium text-surface-600 dark:text-surface-300">Decision brief</summary>
+    <div class="markdown-body max-h-96 overflow-y-auto border-t border-surface-300 p-3 text-sm dark:border-surface-600">
+      {@html renderedDecisions}
+    </div>
+  </details>
+{/if}

--- a/frontend/src/components/task-detail/TaskPlanPanel.svelte.test.ts
+++ b/frontend/src/components/task-detail/TaskPlanPanel.svelte.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/svelte'
+
+vi.mock('../../lib/markdown.js', () => ({
+  renderMarkdown: (s: unknown) => (s ? `<p>${s}</p>` : ''),
+}))
+
+const TaskPlanPanel = (await import('./TaskPlanPanel.svelte')).default
+
+const baseTask = {
+  id: 't1',
+  title: 'X',
+  status: 'done',
+  body: '',
+  tags: [],
+  agentMode: 'headless',
+  allowedTools: [],
+  createdAt: '2026-04-01T00:00:00Z',
+  updatedAt: '2026-04-01T00:00:00Z',
+}
+
+describe('TaskPlanPanel', () => {
+  afterEach(cleanup)
+
+  it('renders nothing when the task has no planning artifacts', () => {
+    const { container } = render(TaskPlanPanel, { props: { task: baseTask as never } })
+    expect(container.textContent?.trim()).toBe('')
+  })
+
+  it('renders the plan body and the read-only label', () => {
+    render(TaskPlanPanel, { props: { task: { ...baseTask, plan: 'the plan' } as never } })
+    expect(screen.getByText('the plan')).toBeDefined()
+    expect(screen.getByText('read-only')).toBeDefined()
+  })
+
+  it('renders collapsible critique, research, and decision brief when present', () => {
+    render(TaskPlanPanel, {
+      props: {
+        task: {
+          ...baseTask,
+          plan: 'p',
+          planCritique: 'crit',
+          planResearch: 'res',
+          planDecisions: 'dec',
+        } as never,
+      },
+    })
+    expect(screen.getByText('Plan critique')).toBeDefined()
+    expect(screen.getByText('Plan research')).toBeDefined()
+    expect(screen.getByText('Decision brief')).toBeDefined()
+  })
+})

--- a/frontend/src/components/task-detail/TaskPullRequestsPanel.svelte
+++ b/frontend/src/components/task-detail/TaskPullRequestsPanel.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-  import { GitPullRequest, RotateCcw } from '@lucide/svelte'
+  import { GitPullRequest } from '@lucide/svelte'
   import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { reviewStore } from '../../stores/reviews.svelte.js'
-  import { ResumeInClaudeCode } from '$lib/api'
   import { openLink } from '$lib/browser.svelte.js'
 
   interface Props {
@@ -12,32 +11,11 @@
   const { task }: Props = $props()
 
   const linkedPRs = $derived(reviewStore.byTask(task))
-
-  // Show resume button only when the backend can succeed: either a stored
-  // implementation session_id exists, or the task has a directly linked PR.
-  // Branch-matched PRs alone are not enough — the backend requires prNumber.
-  const hasImplementationSession = $derived(
-    task.agentRuns?.some(
-      (r) => (r.role === '' || r.role === 'implementation') && !!r.sessionId,
-    ) ?? false,
-  )
-  const hasPR = $derived(hasImplementationSession || (task.prNumber > 0 && !!task.projectId))
-
-  let resuming = $state(false)
-
-  async function resumeInCC() {
-    resuming = true
-    try {
-      await ResumeInClaudeCode(task.id)
-    } finally {
-      resuming = false
-    }
-  }
 </script>
 
 {#if linkedPRs.length > 0}
   <div class="flex flex-col gap-2">
-    <span class="text-sm font-medium text-surface-500">Pull Requests</span>
+    <span class="text-[11px] font-medium uppercase tracking-wide text-surface-400">Pull Requests</span>
     {#each linkedPRs as pr (pr.number)}
       <button
         type="button"
@@ -80,7 +58,7 @@
   </div>
 {:else if task.prNumber && task.projectId}
   <div class="flex flex-col gap-1">
-    <span class="text-sm font-medium text-surface-500">Pull Request</span>
+    <span class="text-[11px] font-medium uppercase tracking-wide text-surface-400">Pull Request</span>
     <button
       type="button"
       class="flex w-fit items-center gap-1.5 text-sm text-warning-700 hover:underline dark:text-warning-400"
@@ -90,17 +68,4 @@
       {task.projectId}#{task.prNumber}
     </button>
   </div>
-{/if}
-
-{#if hasPR}
-  <button
-    type="button"
-    class="flex w-fit items-center gap-1.5 rounded-md border border-surface-300 bg-surface-50 px-2.5 py-1.5 text-sm transition-colors hover:bg-surface-100 disabled:opacity-50 dark:border-surface-600 dark:bg-surface-800 dark:hover:bg-surface-700"
-    onclick={resumeInCC}
-    disabled={resuming}
-    title="Resume the Claude Code session that produced this PR"
-  >
-    <RotateCcw size={14} class="shrink-0" />
-    {resuming ? 'Resuming…' : 'Resume in Claude Code'}
-  </button>
 {/if}

--- a/frontend/src/components/task-detail/TaskPullRequestsPanel.svelte.test.ts
+++ b/frontend/src/components/task-detail/TaskPullRequestsPanel.svelte.test.ts
@@ -10,10 +10,6 @@ vi.mock('../../stores/reviews.svelte.js', () => ({
   },
 }))
 
-vi.mock('$lib/api', () => ({
-  ResumeInClaudeCode: vi.fn(),
-}))
-
 vi.mock('$lib/browser.svelte.js', () => ({
   openLink: (...args: unknown[]) => mockOpenURL(...args),
 }))

--- a/frontend/src/components/task-detail/TaskReviewPanel.svelte
+++ b/frontend/src/components/task-detail/TaskReviewPanel.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
+  import { renderMarkdown } from '../../lib/markdown.js'
+  import { runRoleLabel, runRoleClasses, runStateClasses } from '../../lib/agent-run.js'
+  import { formatCostShort } from '../../lib/cost.js'
+
+  interface Props {
+    task: Task
+  }
+
+  const { task }: Props = $props()
+
+  const renderedReview = $derived(renderMarkdown(task.codeReview))
+
+  // The review/test runs behind the verdict — a compact summary; full
+  // transcripts live in the Runs tab.
+  const REVIEW_ROLES = new Set(['review', 'fix-review', 'test-runner'])
+  const reviewRuns = $derived(
+    (task.agentRuns ?? []).filter((r) => REVIEW_ROLES.has(r.role)).reverse(),
+  )
+</script>
+
+{#if task.codeReview}
+  <div class="flex flex-col gap-1">
+    <span class="text-sm font-medium text-surface-500">Code review <span class="text-xs font-normal italic text-surface-400">auto-generated</span></span>
+    <div class="rounded-lg border border-warning-300 bg-warning-50 p-4 dark:border-warning-700 dark:bg-warning-900/20">
+      <div class="markdown-body text-sm text-surface-900 dark:text-surface-100">{@html renderedReview}</div>
+    </div>
+  </div>
+{/if}
+
+{#if reviewRuns.length > 0}
+  <div class="flex flex-col gap-2">
+    <span class="text-sm font-medium text-surface-500">Review &amp; test runs</span>
+    <div class="flex flex-col gap-1.5">
+      {#each reviewRuns as run (run.agentId)}
+        <div class="flex flex-wrap items-center gap-2 rounded-md border border-surface-300 bg-surface-50 px-3 py-1.5 text-xs dark:border-surface-600 dark:bg-surface-800">
+          {#if runRoleLabel(run.role)}
+            <span class="rounded px-1.5 py-0.5 font-medium {runRoleClasses(run.role)}">{runRoleLabel(run.role)}</span>
+          {/if}
+          <span class="font-mono text-[11px] text-surface-400">{run.agentId}</span>
+          <span class="rounded px-1.5 py-0.5 {runStateClasses(run.state || 'running')}">{run.state || 'running'}</span>
+          {#if run.verdict}
+            <span class="rounded bg-surface-200 px-1.5 py-0.5 dark:bg-surface-700">{run.verdict}</span>
+          {/if}
+          {#if run.costUsd > 0}
+            <span class="ml-auto tabular-nums text-surface-400">{formatCostShort(run.costUsd)}</span>
+          {/if}
+        </div>
+      {/each}
+    </div>
+    <span class="text-xs text-surface-400">Full transcripts are in the Runs tab.</span>
+  </div>
+{/if}

--- a/frontend/src/components/task-detail/TaskReviewPanel.svelte.test.ts
+++ b/frontend/src/components/task-detail/TaskReviewPanel.svelte.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/svelte'
+
+vi.mock('../../lib/markdown.js', () => ({
+  renderMarkdown: (s: unknown) => (s ? `<p>${s}</p>` : ''),
+}))
+
+const TaskReviewPanel = (await import('./TaskReviewPanel.svelte')).default
+
+const baseTask = {
+  id: 't1',
+  title: 'X',
+  status: 'done',
+  body: '',
+  tags: [],
+  agentMode: 'headless',
+  allowedTools: [],
+  createdAt: '2026-04-01T00:00:00Z',
+  updatedAt: '2026-04-01T00:00:00Z',
+}
+
+describe('TaskReviewPanel', () => {
+  afterEach(cleanup)
+
+  it('renders nothing when there is no review or review runs', () => {
+    const { container } = render(TaskReviewPanel, { props: { task: baseTask as never } })
+    expect(container.textContent?.trim()).toBe('')
+  })
+
+  it('renders the code review artifact with a single heading', () => {
+    render(TaskReviewPanel, { props: { task: { ...baseTask, codeReview: 'review body' } as never } })
+    expect(screen.getByText('review body')).toBeDefined()
+    expect(screen.getByText('auto-generated')).toBeDefined()
+  })
+
+  it('summarises review and test runs with role badges', () => {
+    const task = {
+      ...baseTask,
+      codeReview: 'r',
+      agentRuns: [
+        { agentId: 'a-impl', role: 'implementation', state: 'done', mode: 'headless', costUsd: 0.4 },
+        { agentId: 'a-review', role: 'review', state: 'done', mode: 'headless', costUsd: 0.1 },
+        { agentId: 'a-test', role: 'test-runner', state: 'done', mode: 'headless', costUsd: 0.07 },
+      ],
+    }
+    render(TaskReviewPanel, { props: { task: task as never } })
+    expect(screen.getByText('Review')).toBeDefined()
+    expect(screen.getByText('Test')).toBeDefined()
+    // The implementation run is not a review/test run — excluded from this panel.
+    expect(screen.queryByText('a-impl')).toBeNull()
+  })
+})

--- a/frontend/src/lib/agent-run.test.ts
+++ b/frontend/src/lib/agent-run.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { runStateClasses } from './agent-run.js'
+import { runStateClasses, runRoleLabel, runRoleClasses } from './agent-run.js'
 
 describe('runStateClasses', () => {
   // The actual persisted terminal state for finished runs — must be neutral,
@@ -31,5 +31,54 @@ describe('runStateClasses', () => {
   it('falls back to neutral grey for unknown states', () => {
     expect(runStateClasses('mystery')).toMatch(/surface/)
     expect(runStateClasses('mystery')).not.toMatch(/primary/)
+  })
+})
+
+describe('runRoleLabel', () => {
+  it('maps the known pipeline roles to friendly labels', () => {
+    expect(runRoleLabel('triage')).toBe('Triage')
+    expect(runRoleLabel('plan')).toBe('Plan')
+    expect(runRoleLabel('plan-critic')).toBe('Plan Critic')
+    expect(runRoleLabel('implementation')).toBe('Implementation')
+    expect(runRoleLabel('review')).toBe('Review')
+    expect(runRoleLabel('fix-review')).toBe('Fix Review')
+    expect(runRoleLabel('pr-fix')).toBe('PR Fix')
+    expect(runRoleLabel('test-runner')).toBe('Test')
+    expect(runRoleLabel('eval')).toBe('Eval')
+    expect(runRoleLabel('human-review')).toBe('Human Review')
+    expect(runRoleLabel('chat')).toBe('Chat')
+  })
+
+  // Empty/absent role is ambiguous (legacy impl runs and un-tagged runs both
+  // look like "") — return '' so the caller renders no badge rather than guessing.
+  it('returns empty string for an absent role so no badge renders', () => {
+    expect(runRoleLabel('')).toBe('')
+    expect(runRoleLabel(undefined)).toBe('')
+    expect(runRoleLabel(null)).toBe('')
+  })
+
+  it('passes an unknown non-empty role through verbatim', () => {
+    expect(runRoleLabel('custom-role')).toBe('custom-role')
+  })
+})
+
+describe('runRoleClasses', () => {
+  it('groups planning roles under tertiary', () => {
+    for (const r of ['triage', 'plan', 'plan-critic']) {
+      expect(runRoleClasses(r)).toMatch(/tertiary/)
+    }
+  })
+
+  it('colours implementation primary and review/fix warning', () => {
+    expect(runRoleClasses('implementation')).toMatch(/primary/)
+    for (const r of ['review', 'fix-review', 'pr-fix']) {
+      expect(runRoleClasses(r)).toMatch(/warning/)
+    }
+  })
+
+  it('colours testing roles secondary and everything else neutral', () => {
+    expect(runRoleClasses('test-runner')).toMatch(/secondary/)
+    expect(runRoleClasses('eval')).toMatch(/surface/)
+    expect(runRoleClasses(undefined)).toMatch(/surface/)
   })
 })

--- a/frontend/src/lib/agent-run.ts
+++ b/frontend/src/lib/agent-run.ts
@@ -22,33 +22,53 @@ export function runStateClasses(state: string): string {
   }
 }
 
-// Human-friendly label for an agent run's role (what the agent was doing).
-// The backend persists the role prefix from the agent name; "" and
-// "implementation" are the same thing. Returns "" for roles we don't want to
-// surface as a badge (plain implementation carries no extra signal).
-export function roleLabel(role: string | undefined): string {
+// Human-readable label for an agent run's pipeline role (AgentRun.role). Roles
+// are the lowercase technical values the backend persists (see
+// internal/agent/role.go and lib/agent-name.ts). An empty/absent role carries
+// no reliable meaning — legacy implementation runs and un-tagged runs both look
+// like "" — so it returns '' and the caller renders no badge rather than
+// guessing "Implementation".
+export function runRoleLabel(role: string | undefined | null): string {
+  switch (role) {
+    case 'triage': return 'Triage'
+    case 'plan': return 'Plan'
+    case 'plan-critic': return 'Plan Critic'
+    case 'implementation': return 'Implementation'
+    case 'review': return 'Review'
+    case 'fix-review': return 'Fix Review'
+    case 'pr-fix': return 'PR Fix'
+    case 'test-plan': return 'Test Plan'
+    case 'test-plan-critic': return 'Test Plan Critic'
+    case 'test-runner': return 'Test'
+    case 'eval': return 'Eval'
+    case 'human-review': return 'Human Review'
+    case 'chat': return 'Chat'
+    default: return role ? role : ''
+  }
+}
+
+// Colour for a run's role badge, grouped by pipeline phase so a glance reads the
+// shape of the run history: planning (tertiary), implementation (primary),
+// review/fix (warning), testing (secondary), everything else neutral. Distinct
+// from runStateClasses — role answers "what kind of run", state answers "how it
+// ended".
+export function runRoleClasses(role: string | undefined | null): string {
   switch (role) {
     case 'triage':
-      return 'Triage'
     case 'plan':
-      return 'Plan'
     case 'plan-critic':
-      return 'Plan Critic'
-    case 'eval':
-      return 'Eval'
-    case 'pr-fix':
-      return 'PR Fix'
+      return 'bg-tertiary-100 text-tertiary-700 dark:bg-tertiary-900/50 dark:text-tertiary-300'
+    case 'implementation':
+      return 'bg-primary-100 text-primary-700 dark:bg-primary-900/50 dark:text-primary-300'
     case 'review':
-      return 'Review'
     case 'fix-review':
-      return 'Fix Review'
+    case 'pr-fix':
+      return 'bg-warning-100 text-warning-700 dark:bg-warning-900/50 dark:text-warning-300'
+    case 'test-plan':
+    case 'test-plan-critic':
     case 'test-runner':
-      return 'Testing'
-    case 'human-review':
-      return 'Human Review'
-    case 'chat':
-      return 'Chat'
-    default: // "" / "implementation" / unknown — no distinct role signal
-      return ''
+      return 'bg-secondary-100 text-secondary-700 dark:bg-secondary-900/50 dark:text-secondary-300'
+    default:
+      return 'bg-surface-200 text-surface-700 dark:bg-surface-700 dark:text-surface-300'
   }
 }

--- a/frontend/src/lib/api-http.ts
+++ b/frontend/src/lib/api-http.ts
@@ -51,7 +51,6 @@ export function RespondEscalation(arg1: string, arg2: boolean): Promise<void> { 
 export function SendMessage(arg1: string, arg2: string): Promise<void> { return call('AgentService', 'SendMessage', arg1, arg2) }
 export function StopAgent(arg1: string): Promise<void> { return call('AgentService', 'StopAgent', arg1) }
 export function OpenWorktree(_arg1: string): Promise<void> { return Promise.reject(new Error('not available in web mode')) }
-export function ResumeInClaudeCode(_arg1: string): Promise<void> { return Promise.reject(new Error('not available in web mode')) }
 
 // App
 export function GetMonitorReport(): Promise<MonitorReportBinding> { return call('App', 'GetMonitorReport') }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -48,7 +48,6 @@ export const RespondEscalation = pick(AgentSvc.RespondEscalation, http.RespondEs
 export const SendMessage = pick(AgentSvc.SendMessage, http.SendMessage)
 export const StopAgent = pick(AgentSvc.StopAgent, http.StopAgent)
 export const OpenWorktree = pick(AgentSvc.OpenWorktree, http.OpenWorktree)
-export const ResumeInClaudeCode = pick(AgentSvc.ResumeInClaudeCode, http.ResumeInClaudeCode)
 
 // App
 export const GetMonitorReport = pick(AppSvc.GetMonitorReport, http.GetMonitorReport)

--- a/frontend/src/lib/view-mode.svelte.ts
+++ b/frontend/src/lib/view-mode.svelte.ts
@@ -12,9 +12,10 @@ function loadStored(): ViewMode {
   } catch {
     // localStorage unavailable (SSR / restricted context)
   }
-  // List is the most scannable surface and stays useful even when the board's
-  // columns are mostly empty, so it's the default first paint.
-  return 'list'
+  // Board is the default first paint — the pipeline columns give the clearest
+  // at-a-glance picture of where work sits. Users can switch to list (⌘B) and
+  // that choice is remembered.
+  return 'board'
 }
 
 function createViewModeStore() {

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -35,6 +35,9 @@
   const hasPlan = $derived(
     !!(t && (t.plan || t.planBrief || t.planDecisions || t.planCritique || t.planResearch)),
   )
+  // A plan-review task always needs a Plan tab to host the approve/reject
+  // decision, even when its plan lives in the body rather than a sidecar.
+  const showPlanTab = $derived(hasPlan || t?.status === 'plan-review')
   const hasReview = $derived(
     !!(t && (t.codeReview || (t.agentRuns ?? []).some((r) => REVIEW_ROLES.has(r.role)))),
   )
@@ -42,7 +45,7 @@
 
   const tabs = $derived([
     { value: 'overview', label: 'Overview' },
-    ...(hasPlan ? [{ value: 'plan', label: t?.status === 'plan-review' ? 'Plan ●' : 'Plan' }] : []),
+    ...(showPlanTab ? [{ value: 'plan', label: t?.status === 'plan-review' ? 'Plan ●' : 'Plan' }] : []),
     ...(hasReview ? [{ value: 'review', label: 'Review' }] : []),
     { value: 'runs', label: runsCount > 0 ? `Runs · ${runsCount}` : 'Runs' },
   ])
@@ -182,7 +185,7 @@
             <TaskDescriptionEditor task={t} />
           </section>
 
-          {#if hasPlan}
+          {#if showPlanTab}
             <section class={panelClass('plan', 'flex flex-col gap-4')}>
               {#if t.status === 'plan-review'}
                 <PlanReviewPanel task={t} {onreviewplan} />

--- a/frontend/src/pages/TaskDetail.svelte
+++ b/frontend/src/pages/TaskDetail.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { ChevronLeft } from '@lucide/svelte'
+  import { SegmentedControl } from '@skeletonlabs/skeleton-svelte'
   import type { Task } from '../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { taskStore } from '../stores/tasks.svelte.js'
   import TaskHeaderBar from '../components/task-detail/TaskHeaderBar.svelte'
@@ -8,6 +9,9 @@
   import TaskPullRequestsPanel from '../components/task-detail/TaskPullRequestsPanel.svelte'
   import TaskDescriptionEditor from '../components/task-detail/TaskDescriptionEditor.svelte'
   import PlanReviewPanel from '../components/task-detail/PlanReviewPanel.svelte'
+  import TaskPlanPanel from '../components/task-detail/TaskPlanPanel.svelte'
+  import TaskReviewPanel from '../components/task-detail/TaskReviewPanel.svelte'
+  import LiveAgentPanel from '../components/task-detail/LiveAgentPanel.svelte'
   import AgentLauncher from '../components/task-detail/AgentLauncher.svelte'
   import AgentHistoryList from '../components/task-detail/AgentHistoryList.svelte'
 
@@ -23,6 +27,41 @@
 
   let t = $state<Task | null>(null)
   let error = $state('')
+  // The detail body is split into tabs so a big task (plan + review + many runs)
+  // is scannable instead of a single long scroll. Default is always Overview.
+  let activeTab = $state('overview')
+
+  const REVIEW_ROLES = new Set(['review', 'fix-review', 'test-runner'])
+  const hasPlan = $derived(
+    !!(t && (t.plan || t.planBrief || t.planDecisions || t.planCritique || t.planResearch)),
+  )
+  const hasReview = $derived(
+    !!(t && (t.codeReview || (t.agentRuns ?? []).some((r) => REVIEW_ROLES.has(r.role)))),
+  )
+  const runsCount = $derived((t?.agentRuns ?? []).filter((r) => r.state !== 'running').length)
+
+  const tabs = $derived([
+    { value: 'overview', label: 'Overview' },
+    ...(hasPlan ? [{ value: 'plan', label: t?.status === 'plan-review' ? 'Plan ●' : 'Plan' }] : []),
+    ...(hasReview ? [{ value: 'review', label: 'Review' }] : []),
+    { value: 'runs', label: runsCount > 0 ? `Runs · ${runsCount}` : 'Runs' },
+  ])
+
+  // If the active tab disappears (e.g. its data was cleared), fall back to Overview.
+  $effect(() => {
+    if (!tabs.some((tb) => tb.value === activeTab)) activeTab = 'overview'
+  })
+
+  function panelClass(tab: string, layout = 'flex flex-col gap-6'): string {
+    return activeTab === tab ? layout : 'hidden'
+  }
+
+  function cycleTab(dir: number) {
+    const vals = tabs.map((tb) => tb.value)
+    const i = vals.indexOf(activeTab)
+    if (i < 0) return
+    activeTab = vals[(i + dir + vals.length) % vals.length]
+  }
 
   $effect(() => {
     loadTask()
@@ -58,8 +97,20 @@
     const target = e.target as HTMLElement
     if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) return
     if (e.metaKey || e.ctrlKey || e.altKey) return
+    if (e.key === '[') {
+      e.preventDefault()
+      cycleTab(-1)
+      return
+    }
+    if (e.key === ']') {
+      e.preventDefault()
+      cycleTab(1)
+      return
+    }
     if (e.key === 'e') {
       e.preventDefault()
+      // The body editor lives on Overview; make sure it's visible before editing.
+      activeTab = 'overview'
       window.dispatchEvent(new CustomEvent('task-detail:edit-body'))
       return
     }
@@ -80,7 +131,7 @@
   })
 </script>
 
-<div class="flex flex-col gap-4 p-4 md:gap-6 md:p-6">
+<div class="mx-auto flex w-full max-w-[1600px] flex-col gap-4 p-4 md:gap-6 md:p-6">
   <button
     type="button"
     class="flex w-fit items-center gap-1 text-sm text-surface-500 hover:text-surface-800 dark:hover:text-surface-200"
@@ -96,20 +147,68 @@
 
   {#if t}
     <div class="flex flex-col gap-6">
+      <!-- Persistent header: always visible above the tabs. -->
       <TaskHeaderBar task={t} {ondelete} />
       <TaskStatusBanner task={t} />
-      <!-- Plan approve/reject is the only decision for a plan-review task, so it
-           sits directly under the banner — above the fold, not below it. -->
-      <PlanReviewPanel task={t} {onreviewplan} />
-      <TaskMetadataRow task={t} />
-      <TaskPullRequestsPanel task={t} />
-      <TaskDescriptionEditor task={t} />
-      <hr class="border-surface-300 dark:border-surface-600" />
-      <!-- AgentLauncher always renders: it also hosts a live running agent's
-           output + Stop. It collapses only its generic "new run" FORM for a
-           plan-review task (whose job is approve/reject). -->
-      <AgentLauncher task={t} {onviewagent} />
-      <AgentHistoryList task={t} />
+      {#if t.status === 'plan-review' && activeTab !== 'plan'}
+        <!-- Default is Overview, so nudge the pending approve/reject to the fore. -->
+        <button
+          type="button"
+          class="w-fit text-sm text-primary-500 hover:underline"
+          onclick={() => (activeTab = 'plan')}
+        >Review the plan →</button>
+      {/if}
+      <!-- Pinned outside the tabs so a live SSE stream never unmounts on a switch. -->
+      <LiveAgentPanel task={t} {onviewagent} />
+
+      <SegmentedControl orientation="horizontal" value={activeTab} onValueChange={(details) => (activeTab = details.value ?? 'overview')}>
+        <SegmentedControl.Control>
+          <SegmentedControl.Indicator />
+          {#each tabs as tab}
+            <SegmentedControl.Item value={tab.value}>
+              <SegmentedControl.ItemText>{tab.label}</SegmentedControl.ItemText>
+              <SegmentedControl.ItemHiddenInput />
+            </SegmentedControl.Item>
+          {/each}
+        </SegmentedControl.Control>
+      </SegmentedControl>
+
+      <!-- Two-column: a wide main content column + a persistent properties rail,
+           so the page uses its width instead of stranding a narrow column on the
+           left. The rail (task properties + PR) stays visible on every tab. -->
+      <div class="flex flex-col gap-6 lg:flex-row lg:items-start lg:gap-8">
+        <div class="flex min-w-0 flex-1 flex-col gap-6">
+          <section class={panelClass('overview', 'flex flex-col gap-6')}>
+            <TaskDescriptionEditor task={t} />
+          </section>
+
+          {#if hasPlan}
+            <section class={panelClass('plan', 'flex flex-col gap-4')}>
+              {#if t.status === 'plan-review'}
+                <PlanReviewPanel task={t} {onreviewplan} />
+              {:else}
+                <TaskPlanPanel task={t} />
+              {/if}
+            </section>
+          {/if}
+
+          {#if hasReview}
+            <section class={panelClass('review', 'flex flex-col gap-4')}>
+              <TaskReviewPanel task={t} />
+            </section>
+          {/if}
+
+          <section class={panelClass('runs')}>
+            <AgentLauncher task={t} />
+            <AgentHistoryList task={t} />
+          </section>
+        </div>
+
+        <aside class="flex w-full flex-col gap-6 lg:w-80 lg:shrink-0">
+          <TaskMetadataRow task={t} />
+          <TaskPullRequestsPanel task={t} />
+        </aside>
+      </div>
     </div>
   {:else if !error}
     <p class="text-sm opacity-60">Loading...</p>
@@ -134,7 +233,10 @@
     border-radius: 0.25rem;
     background: rgb(var(--color-surface-800) / 0.5);
   }
-  :global(.markdown-body ul, .markdown-body ol) { padding-left: 1.5em; margin: 0.25em 0; }
+  /* Tailwind's preflight resets list-style to none, which strips the markers
+     from ordered/unordered lists in rendered plan/review markdown. Restore them. */
+  :global(.markdown-body ul) { list-style: disc; padding-left: 1.5em; margin: 0.25em 0; }
+  :global(.markdown-body ol) { list-style: decimal; padding-left: 1.5em; margin: 0.25em 0; }
   :global(.markdown-body h1, .markdown-body h2, .markdown-body h3) { margin: 0.5em 0 0.25em; font-weight: 600; }
   :global(.markdown-body blockquote) { border-left: 3px solid currentColor; padding-left: 0.75em; opacity: 0.8; margin: 0.25em 0; }
   :global(.markdown-body a) { text-decoration: underline; }

--- a/frontend/src/pages/TaskDetail.svelte.test.ts
+++ b/frontend/src/pages/TaskDetail.svelte.test.ts
@@ -319,6 +319,18 @@ describe('TaskDetail', () => {
         expect(screen.getByText('Stop')).toBeDefined()
       })
     })
+
+    it('offers a Plan tab with approve/reject for plan-review, even with no plan sidecar', async () => {
+      // A plan-review task keeps its decision even when the plan is in the body.
+      mockGet.mockResolvedValue({ ...mockTask, status: 'plan-review' })
+      render(TaskDetail, {
+        props: { taskId: 'task-1', onback: vi.fn(), onviewagent: vi.fn(), ondelete: vi.fn() },
+      })
+      await vi.waitFor(() => {
+        expect(screen.getByText('Approve Plan')).toBeDefined()
+        expect(screen.getByText('Reject Plan')).toBeDefined()
+      })
+    })
   })
 
   describe('copyId', () => {

--- a/frontend/src/pages/TaskDetail.svelte.test.ts
+++ b/frontend/src/pages/TaskDetail.svelte.test.ts
@@ -274,6 +274,50 @@ describe('TaskDetail', () => {
     })
   })
 
+  describe('tabs', () => {
+    it('defaults to the Overview tab (metadata visible)', async () => {
+      mockGet.mockResolvedValue(mockTask)
+      render(TaskDetail, {
+        props: { taskId: 'task-1', onback: vi.fn(), onviewagent: vi.fn(), ondelete: vi.fn() },
+      })
+      await vi.waitFor(() => {
+        expect(screen.getByText('Mode')).toBeDefined()
+      })
+    })
+
+    it('shows the read-only Plan panel when the task has a plan', async () => {
+      mockGet.mockResolvedValue({ ...mockTask, status: 'done', plan: '# Plan\n\ndo it' })
+      render(TaskDetail, {
+        props: { taskId: 'task-1', onback: vi.fn(), onviewagent: vi.fn(), ondelete: vi.fn() },
+      })
+      await vi.waitFor(() => {
+        // TaskPlanPanel renders a static "read-only" marker beside the plan.
+        expect(screen.getByText('read-only')).toBeDefined()
+      })
+    })
+
+    it('shows the Review panel when the task has a code review', async () => {
+      mockGet.mockResolvedValue({ ...mockTask, status: 'done', codeReview: '# Code Review\n\nlgtm' })
+      render(TaskDetail, {
+        props: { taskId: 'task-1', onback: vi.fn(), onviewagent: vi.fn(), ondelete: vi.fn() },
+      })
+      await vi.waitFor(() => {
+        expect(screen.getByText('auto-generated')).toBeDefined()
+      })
+    })
+
+    it('pins a live running agent above the tabs', async () => {
+      mockByTask.mockReturnValue({ id: 'a1', state: 'running', mode: 'headless', taskId: 'task-1' })
+      mockGet.mockResolvedValue({ ...mockTask, status: 'in-progress' })
+      render(TaskDetail, {
+        props: { taskId: 'task-1', onback: vi.fn(), onviewagent: vi.fn(), ondelete: vi.fn() },
+      })
+      await vi.waitFor(() => {
+        expect(screen.getByText('Stop')).toBeDefined()
+      })
+    })
+  })
+
   describe('copyId', () => {
     beforeEach(() => {
       Object.defineProperty(navigator, 'clipboard', {

--- a/frontend/src/pages/TaskDetail.svelte.test.ts
+++ b/frontend/src/pages/TaskDetail.svelte.test.ts
@@ -7,6 +7,7 @@ const mockRemove = vi.fn()
 const mockStart = vi.fn()
 const mockStop = vi.fn()
 const mockByTask = vi.fn()
+const mockByState = vi.fn()
 const mockUpdateAgent = vi.fn()
 const mockEventsOn = vi.fn((..._args: any[]) => vi.fn())
 const mockPushLocal = vi.fn()
@@ -24,6 +25,7 @@ vi.mock('../stores/agents.svelte.js', () => ({
     start: (...args: unknown[]) => mockStart(...args),
     stop: (...args: unknown[]) => mockStop(...args),
     byTask: (...args: unknown[]) => mockByTask(...args),
+    byState: (...args: unknown[]) => mockByState(...args),
     updateAgent: (...args: unknown[]) => mockUpdateAgent(...args),
   },
 }))
@@ -105,6 +107,7 @@ describe('TaskDetail', () => {
     mockStart.mockReset()
     mockStop.mockReset()
     mockByTask.mockReturnValue(null)
+    mockByState.mockReturnValue([])
     mockUpdateAgent.mockReset()
     mockEventsOn.mockReturnValue(vi.fn())
     mockPushLocal.mockReset()
@@ -307,7 +310,7 @@ describe('TaskDetail', () => {
     })
 
     it('pins a live running agent above the tabs', async () => {
-      mockByTask.mockReturnValue({ id: 'a1', state: 'running', mode: 'headless', taskId: 'task-1' })
+      mockByState.mockReturnValue([{ id: 'a1', state: 'running', mode: 'headless', taskId: 'task-1' }])
       mockGet.mockResolvedValue({ ...mockTask, status: 'in-progress' })
       render(TaskDetail, {
         props: { taskId: 'task-1', onback: vi.fn(), onviewagent: vi.fn(), ondelete: vi.fn() },

--- a/internal/sybra/app_projects.go
+++ b/internal/sybra/app_projects.go
@@ -4,43 +4,9 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
-	"strings"
 
 	"github.com/Automaat/sybra/internal/executil"
 )
-
-// openCommandInGhostty opens a Ghostty terminal tab running claudeCmd.
-// If dir is non-empty the shell changes to that directory first.
-func openCommandInGhostty(dir, claudeCmd string) error {
-	shellCmd := claudeCmd
-	if dir != "" {
-		shellCmd = "cd " + dir + " && " + claudeCmd
-	}
-	script := fmt.Sprintf(`tell application "Ghostty"
-	activate
-	set synapseWins to (every window whose name contains "Sybra:")
-	set winCount to (count of synapseWins)
-	set cfg to new surface configuration
-	set command of cfg to "/bin/zsh -lic '%s'"
-	if winCount > 0 then
-		new tab in (item 1 of synapseWins) with configuration cfg
-	else
-		new window with configuration cfg
-	end if
-end tell`, executil.EscapeAppleScript(shellCmd))
-	out, err := exec.CommandContext(context.Background(), "osascript", "-e", script).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("osascript: %w: %s", err, string(out))
-	}
-	return nil
-}
-
-// copyToClipboard copies text to the macOS system clipboard via pbcopy.
-func copyToClipboard(text string) error {
-	cmd := exec.CommandContext(context.Background(), "pbcopy")
-	cmd.Stdin = strings.NewReader(text)
-	return cmd.Run()
-}
 
 func openDirInGhostty(dir string) error {
 	script := fmt.Sprintf(`tell application "Ghostty"

--- a/internal/sybra/services.go
+++ b/internal/sybra/services.go
@@ -66,7 +66,7 @@ func (a *App) coreHTTPServices() map[string]httpapi.Service {
 			"GetAgentRunConvoLog",
 			"RespondEscalation",
 			"GetAgentDiff",
-			// OpenWorktree and ResumeInClaudeCode open local GUI apps.
+			// OpenWorktree opens a local GUI app.
 		),
 		"ConfigService": httpapi.NewService(a.configSvc,
 			"GetSettings",

--- a/internal/sybra/svc_agents.go
+++ b/internal/sybra/svc_agents.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"slices"
 	"strings"
 	"time"
 
@@ -244,45 +243,4 @@ func (s *AgentService) OpenWorktree(taskID string) error {
 		return fmt.Errorf("no worktree for task %s", taskID)
 	}
 	return sysopen.Dir(context.Background(), s.worktrees.PathFor(t))
-}
-
-// ResumeInClaudeCode opens a Ghostty terminal tab with a Claude Code session
-// resumed for taskID. If Sybra has a session_id from a prior implementation
-// run, it passes --resume directly. Otherwise the PR URL is copied to the
-// clipboard so the user can paste it into /resume manually.
-func (s *AgentService) ResumeInClaudeCode(taskID string) error {
-	t, err := s.tasks.Get(taskID)
-	if err != nil {
-		return fmt.Errorf("task %s: %w", taskID, err)
-	}
-
-	// Find the latest implementation run that has a session_id.
-	// Accept role=="" (legacy runs predating role recording) or role==RoleImplementation.
-	sessionID := ""
-	for i := range slices.Backward(t.AgentRuns) {
-		r := &t.AgentRuns[i]
-		if (r.Role == "" || r.Role == string(agent.RoleImplementation)) && r.SessionID != "" {
-			sessionID = r.SessionID
-			break
-		}
-	}
-
-	// Best-effort: use the worktree directory so the CC session opens in context.
-	dir := ""
-	if s.worktrees != nil && s.worktrees.Exists(t) {
-		dir = s.worktrees.PathFor(t)
-	}
-
-	if sessionID != "" {
-		return openCommandInGhostty(dir, "claude --resume "+sessionID)
-	}
-
-	if t.PRNumber == 0 || t.ProjectID == "" {
-		return fmt.Errorf("task %s has no session_id or linked PR", taskID)
-	}
-	prURL := fmt.Sprintf("https://github.com/%s/pull/%d", t.ProjectID, t.PRNumber)
-	if err := copyToClipboard(prURL); err != nil {
-		s.logger.Warn("clipboard copy failed", "err", err)
-	}
-	return openCommandInGhostty(dir, "claude")
 }

--- a/scripts/dev-mock/seed.sh
+++ b/scripts/dev-mock/seed.sh
@@ -67,8 +67,8 @@ task() {
     echo "created_at: ${EARLIER}"
     echo "updated_at: ${NOW}"
     echo "---"
-    echo "## Description"
-    echo ""
+    # The UI already labels this section "Description"; the body is just the
+    # markdown, no redundant "## Description" heading.
     echo "${body}"
   } >"$TASKS/${id}.md"
 }
@@ -396,4 +396,132 @@ task task-cxl01 cancelled "Rewrite frontend in React" low "" "frontend" \
   "outcome: wontfix" \
   "closed_at: ${OLDER}"
 
-echo "Seeded $(find "$TASKS" -name '*.md' | wc -l | tr -d ' ') tasks + $(find "$PROJECTS" -name '*.yaml' | wc -l | tr -d ' ') projects into $SYBRA_HOME"
+# ---------------------------------------------------------------------------
+# Planning / review sidecars
+# The plan, critique, decisions, and code review live in per-task sidecar files
+# (loaded onto Task.Plan/PlanCritique/PlanDecisions/PlanBrief/CodeReview on read,
+# not the frontmatter) — so the Plan and Review tabs have real content to render.
+# task-done01 = a shipped task with a plan + critique + code review.
+# task-plan02 = a plan-review task awaiting approval, with open decisions.
+# ---------------------------------------------------------------------------
+cat >"$TASKS/task-done01.plan.md" <<'EOF'
+# Plan: SSE multiplexing for web mode
+
+## Goal
+
+Collapse the per-subscription EventSource connections into a single multiplexed `/events` stream so the web build stops exhausting the browser's 6-connection-per-origin cap.
+
+## Approach
+
+1. Add a server-side broker that fans one upstream feed out to N subscribers keyed by event name.
+2. Replace the client's N EventSource objects with one connection to `/events`, demultiplexing by the `event:` field.
+3. Keep the desktop (Wails) path untouched — it already uses native events.
+
+## Steps
+
+- [x] Introduce `broker.ServeAll` for the multiplexed endpoint
+- [x] Client `eventBus` subscribes once, dispatches by name
+- [x] Backpressure: drop-oldest per slow subscriber
+- [x] Reconnect with `Last-Event-ID` replay
+- [ ] Load test: 200 concurrent tabs (deferred)
+
+## Risks
+
+- Slow consumers stalling the shared stream — mitigated by per-subscriber bounded channels.
+- Reconnect storms on server restart — jittered backoff on the client.
+EOF
+
+cat >"$TASKS/task-done01.plan-critique.md" <<'EOF'
+# Plan critique
+
+Strengths: the single-broker approach is the standard fix and keeps the desktop path isolated.
+
+Concerns:
+
+- The drop-oldest policy can silently lose task-updated events during a burst. Consider a coalescing buffer keyed by event name instead.
+- `Last-Event-ID` replay needs a bounded ring buffer or a server restart will attempt an unbounded backfill.
+- No mention of auth/session scoping on the shared stream — confirm the broker does not leak another session's events.
+
+Verdict: approve with the coalescing-buffer note folded into the implementation.
+EOF
+
+cat >"$TASKS/task-done01.review.md" <<'EOF'
+# Code Review
+
+**Summary:** Implementation matches the approved plan. One blocking issue, two nits.
+
+## Blocking
+
+- `broker.go:88` — the per-subscriber channel is unbuffered, so a slow tab blocks the fan-out goroutine and stalls every other subscriber. Give it a bounded buffer + drop-oldest as the plan specified.
+
+## Nits
+
+- `eventBus.ts:41` — reconnect backoff is fixed at 1s; add jitter to avoid a thundering herd on server restart.
+- `broker_test.go` — no test covers the slow-consumer path. Add one that never reads and asserts the others still receive.
+
+## Verdict
+
+Request changes — fix the unbuffered channel, then good to merge.
+EOF
+
+cat >"$TASKS/task-plan02.plan.md" <<'EOF'
+# Plan: Introduce a project archive state
+
+## Goal
+
+Let a project be archived so it drops out of the active board and automations without deleting its history.
+
+## Approach
+
+- Add `archived: bool` to the project record (default false).
+- Filter archived projects out of the board, pickers, and every project-scoped automation.
+- Add an Archive / Unarchive action in the Project → Setup tab.
+
+## Steps
+
+- [ ] Schema + migration (empty = active, no backfill needed)
+- [ ] Board + picker filters
+- [ ] Automation `AllowsProject` guard
+- [ ] Setup-tab toggle + confirm dialog
+
+## Out of scope
+
+- Bulk archive
+- Auto-archive on inactivity
+EOF
+
+cat >"$TASKS/task-plan02.plan-brief.md" <<'EOF'
+Archiving hides a project everywhere without data loss. Two open decisions below need a call before implementation starts.
+EOF
+
+cat >"$TASKS/task-plan02.plan-decisions.md" <<'EOF'
+## Archived tasks visibility
+
+Question: What happens to in-flight tasks when their project is archived?
+
+Recommended: Freeze
+
+Options:
+
+- Freeze — leave tasks as-is but hide them; unarchive restores them.
+- Cancel — mark all non-done tasks cancelled on archive.
+- Block archive — refuse to archive while active tasks exist.
+
+## Storage location
+
+Question: Where should the archived flag live?
+
+Recommended: Project record
+
+Options:
+
+- Project record — one `archived` field on the YAML, simplest.
+- Separate archive index — a dedicated file listing archived ids.
+EOF
+
+# Count only task frontmatter files, not the .plan/.review/etc. sidecars.
+task_count=$(find "$TASKS" -name '*.md' \
+  ! -name '*.plan.md' ! -name '*.plan-critique.md' ! -name '*.plan-research.md' \
+  ! -name '*.plan-decisions.md' ! -name '*.plan-brief.md' ! -name '*.review.md' \
+  | wc -l | tr -d ' ')
+echo "Seeded ${task_count} tasks + $(find "$PROJECTS" -name '*.yaml' | wc -l | tr -d ' ') projects into $SYBRA_HOME"


### PR DESCRIPTION
## Motivation

> Changelog: feat(ui): tabbed task detail with role badges

The task detail page was one long vertical scroll: a done task with a
plan, code review, and many agent runs ran ~2500px tall with no
navigation, and agent-history rows were opaque (mode/state/time, with
no sign of what each run was doing).

## Implementation information

- Split the detail body into tabs — Overview, Plan, Review, Runs — with
  a persistent properties rail on the right, so the page uses its width
  instead of a narrow left column.
- Agent-history rows lead with a per-role colour badge (Triage, Plan,
  Review, Test, Eval, ...); the opaque id is demoted. Extends the earlier
  single-colour role badge with phase-grouped colours.
- Metadata is an aligned properties list: quiet labels, type icons,
  relative timestamps; the per-run knobs render inline.
- Description panel is low-chrome with a pencil edit affordance.
- Remove the Resume in Claude Code action (macOS/Ghostty-only, seldom
  used) — backend method, helpers, UI button, and api shims.
- Drop the fork-subagent toggle from the task UI; the backend field
  stays, so it still works via YAML/CLI.
- Default the board tab to the board view (a saved list choice is kept).
- Seed plan/critique/decisions/review sidecars so the mock renders the
  Plan and Review tabs.

## Supporting documentation

Verified against the web-mode mock. Local gates green: svelte-check,
1663 frontend tests, go build, golangci-lint, both frontend builds,
bindings + api-shim sync.
