### PR TITLE
fix(worktree): don't gate fix-role setup on its own breakage

### DIFF
--- a/internal/sybra/app_reviews_fix.go
+++ b/internal/sybra/app_reviews_fix.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/workflow"
+	"github.com/Automaat/sybra/internal/worktree"
 )
 
 // branchConflictFixWorkflowID is the builtin workflow started directly (by
@@ -766,7 +767,9 @@ func (r *ReviewHandler) recoverBranchConflictNoPR(t task.Task) bool {
 		r.recordWorktreeFailure(taskID, err)
 		return false
 	}
-	delete(r.wtFailures, taskID)
+	if !r.allowPreparedWorktree(taskID, dir) {
+		return false
+	}
 	// Refetch: PrepareForBranchFix's ensureBranch call may have just set
 	// t.Branch for the first time (a task whose worktree never got created
 	// before this recovery), and branchConflictPrompt needs the resolved name.
@@ -861,6 +864,31 @@ func (r *ReviewHandler) recordWorktreeFailure(taskID string, wtErr error) {
 	r.logger.Error("pr-monitor.worktree", "task_id", taskID, "err", wtErr)
 }
 
+func (r *ReviewHandler) allowPreparedWorktree(taskID, dir string) bool {
+	setupFailure, ok, err := worktree.ReadSetupFailureMarker(dir)
+	if err != nil {
+		r.logger.Error("pr-monitor.worktree.setup-fail-read", "task_id", taskID, "dir", dir, "err", err)
+		r.recordWorktreeFailure(taskID, err)
+		return false
+	}
+	if !ok {
+		delete(r.wtFailures, taskID)
+		return true
+	}
+	if setupFailure == "" {
+		setupFailure = "worktree setup failed before the fix agent started"
+	}
+	err = errors.New(setupFailure)
+	r.logger.Warn("pr-monitor.worktree.setup-fail-nonfatal", "task_id", taskID, "dir", dir, "err", err)
+	r.recordWorktreeFailure(taskID, err)
+	got, err := r.tasks.Get(taskID)
+	if err != nil {
+		r.logger.Error("pr-monitor.worktree.setup-fail-refetch", "task_id", taskID, "err", err)
+		return false
+	}
+	return got.Status != task.StatusHumanRequired
+}
+
 // branchConflictPrompt is the no-PR analog of buildConflictPrompt: there is no
 // PR head to reference, so it resolves the task's own branch (t.Branch, set
 // by PrepareForBranchFix before this is called) and instructs a plain merge
@@ -929,7 +957,9 @@ func (r *ReviewHandler) prepareWorktree(ctx context.Context, t task.Task, issue 
 		r.recordWorktreeFailure(t.ID, wtErr)
 		return "", false
 	}
-	delete(r.wtFailures, t.ID)
+	if !r.allowPreparedWorktree(t.ID, d) {
+		return "", false
+	}
 	return d, true
 }
 

--- a/internal/sybra/app_reviews_unit_test.go
+++ b/internal/sybra/app_reviews_unit_test.go
@@ -1297,6 +1297,58 @@ func TestPrepareWorktree_CircuitBreaker(t *testing.T) {
 	}
 }
 
+// TestAllowPreparedWorktree_SetupFailureTripsCircuitBreaker verifies the
+// non-fatal fix-role setup-failure path still contributes to the same
+// per-task circuit breaker as hard worktree-prepare errors.
+func TestAllowPreparedWorktree_SetupFailureTripsCircuitBreaker(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := task.NewStore(filepath.Join(tmp, "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	tk, err := tasks.Create("test task", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := &ReviewHandler{
+		DomainHandler: DomainHandler{logger: slog.New(slog.DiscardHandler)},
+		tasks:         tasks,
+		wtFailures:    make(map[string]int),
+	}
+
+	wtDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(wtDir, ".sybra-setup-failure"), []byte("npm run build failed\n"), 0o600); err != nil {
+		t.Fatalf("write setup failure marker: %v", err)
+	}
+
+	for i := range wtFailureLimit - 1 {
+		if ok := r.allowPreparedWorktree(tk.ID, wtDir); !ok {
+			t.Fatalf("call %d: want ok=true below circuit threshold", i+1)
+		}
+		got, err := tasks.Get(tk.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status == task.StatusHumanRequired {
+			t.Fatalf("call %d: task escalated too early", i+1)
+		}
+	}
+
+	if ok := r.allowPreparedWorktree(tk.ID, wtDir); ok {
+		t.Fatal("threshold call: want ok=false when circuit opens")
+	}
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q after setup-failure circuit break, want human-required", got.Status)
+	}
+}
+
 // TestAdoptOrphanMergedPR verifies that a task stranded in human-required with
 // a known branch is advanced to done when a merged PR is found on that branch
 // via the findMergedPRFn hook, and that the slice entry is updated in place.

--- a/internal/sybra/svc_integrations.go
+++ b/internal/sybra/svc_integrations.go
@@ -114,6 +114,16 @@ func (s *IntegrationService) FixRenovateCI(repo string, number int, branch, titl
 		d, wtErr := s.worktrees.PrepareForFix(context.Background(), t, number)
 		if wtErr != nil {
 			s.logger.Error("renovate-fix.worktree", "task_id", t.ID, "err", wtErr)
+			// The task already exists (created above) but no agent will ever
+			// start on it now — flip to human-required instead of leaving it
+			// silently stranded in its initial status (issue #1454).
+			reason := fmt.Sprintf("renovate-fix: worktree prepare failed: %v", wtErr)
+			if _, uerr := s.tasks.Update(t.ID, task.Update{
+				Status:       task.Ptr(task.StatusHumanRequired),
+				StatusReason: &reason,
+			}); uerr != nil {
+				s.logger.Error("renovate-fix.worktree.escalate", "task_id", t.ID, "err", uerr)
+			}
 			return fmt.Errorf("prepare worktree: %w", wtErr)
 		}
 		dir = d

--- a/internal/sybra/svc_integrations_test.go
+++ b/internal/sybra/svc_integrations_test.go
@@ -1,0 +1,69 @@
+package sybra
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/project"
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/worktree"
+)
+
+// TestFixRenovateCI_WorktreePrepareFailureEscalates is the regression test
+// for issue #1454's "no human-required flip" symptom: when preparing the fix
+// worktree fails for a reason PrepareForFix itself cannot recover from (here,
+// an unregistered project — the same code path a genuinely missing bare clone
+// would hit), the task must not be left silently stranded in its initial
+// status. It must flip to human-required with a reason, so it surfaces on
+// the board instead of only a log line.
+func TestFixRenovateCI_WorktreePrepareFailureEscalates(t *testing.T) {
+	taskStore, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("task.NewStore: %v", err)
+	}
+	tasks := task.NewManager(taskStore, nil)
+
+	projectStore, err := project.NewStore(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatalf("project.NewStore: %v", err)
+	}
+
+	logger := slog.New(slog.DiscardHandler)
+	worktrees := worktree.New(worktree.Config{
+		WorktreesDir: t.TempDir(),
+		Projects:     projectStore,
+		Tasks:        tasks,
+		Logger:       logger,
+	})
+
+	svc := &IntegrationService{
+		tasks:     tasks,
+		worktrees: worktrees,
+		logger:    logger,
+	}
+
+	// "owner/does-not-exist" is never registered with projectStore, so
+	// PrepareForFix's project lookup fails deterministically without needing
+	// a real git clone — mirroring any worktree-prepare failure that isn't
+	// itself a setup-command failure (those are now non-gating, see
+	// internal/worktree/setup.go's runSetupNonGating).
+	err = svc.FixRenovateCI("owner/does-not-exist", 42, "some-branch", "bump a dependency")
+	if err == nil {
+		t.Fatal("expected FixRenovateCI to return an error when worktree prepare fails")
+	}
+
+	tasksList, err := tasks.List()
+	if err != nil {
+		t.Fatalf("list tasks: %v", err)
+	}
+	if len(tasksList) != 1 {
+		t.Fatalf("expected exactly 1 task created, got %d", len(tasksList))
+	}
+	got := tasksList[0]
+	if got.Status != task.StatusHumanRequired {
+		t.Errorf("task status = %q, want %q — task must not be silently stranded", got.Status, task.StatusHumanRequired)
+	}
+	if got.StatusReason == "" {
+		t.Error("expected a non-empty status reason explaining the escalation")
+	}
+}

--- a/internal/worktree/adopt_test.go
+++ b/internal/worktree/adopt_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Automaat/sybra/internal/notes"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 )
@@ -203,6 +204,56 @@ func TestPrepareForFix_FallsBackToPRHead(t *testing.T) {
 	}
 	if got := strings.TrimSpace(string(headSHA)); got != prSHA {
 		t.Errorf("worktree HEAD = %q, want PR head %q", got, prSHA)
+	}
+}
+
+// TestPrepareForFix_SetupFailureDoesNotBlock is the regression test for
+// issue #1454: a project whose setup: command fails (e.g. the PR under
+// repair broke the build) must not prevent PrepareForFix from creating the
+// fix worktree — gating on that exact breakage would deadlock the task, since
+// the fixer this worktree is for exists specifically to repair it.
+func TestPrepareForFix_SetupFailureDoesNotBlock(t *testing.T) {
+	h := prepareHarness(t, []string{"exit 1"}, 0)
+
+	const prNumber = 9
+	const branch = "fix-broken-build"
+	srcGit := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", h.src}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	srcGit("checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(h.src, "feature.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "pr commit")
+	srcGit("checkout", "main")
+
+	h.m.prBranch = func(_ string, _ int) (string, error) { return branch, nil }
+
+	tk, err := h.tasks.Create("fix broken build", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = h.tasks.UpdateMap(tk.ID, map[string]any{"project_id": h.proj.ID})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	wtPath, err := h.m.PrepareForFix(context.Background(), tk, prNumber)
+	if err != nil {
+		t.Fatalf("PrepareForFix must succeed despite a failing setup command: %v", err)
+	}
+
+	content, readErr := os.ReadFile(filepath.Join(wtPath, notes.FileName))
+	if readErr != nil {
+		t.Fatalf("read scratchpad: %v", readErr)
+	}
+	if !strings.Contains(string(content), "Setup failure") {
+		t.Errorf("scratchpad missing setup failure note: %q", content)
 	}
 }
 

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -474,6 +474,31 @@ func TestRunSetupNonGating_SuccessLeavesNoNote(t *testing.T) {
 	}
 }
 
+// TestRunSetupNonGating_PersistFailureReturnsError proves the prepare still
+// fails closed when Sybra cannot persist the non-fatal setup failure context.
+// Without this, fix-role worktrees would silently start with neither the note
+// nor the marker that downstream circuit breakers rely on.
+func TestRunSetupNonGating_PersistFailureReturnsError(t *testing.T) {
+	t.Parallel()
+	logsDir := t.TempDir()
+	wtDir := t.TempDir()
+	mustRunInDir(t, wtDir, "git", "init", "-b", "main")
+	if err := os.Mkdir(filepath.Join(wtDir, notes.FileName), 0o755); err != nil {
+		t.Fatalf("mkdir fake NOTES.md: %v", err)
+	}
+	m := New(Config{WorktreesDir: wtDir, LogsDir: logsDir, Logger: discardLogger()})
+
+	err := m.runSetupNonGating(context.Background(), "task-fix-persist-fail", wtDir, []string{
+		"echo broken build >&2 && exit 1",
+	})
+	if err == nil {
+		t.Fatal("expected error when failure context cannot be persisted")
+	}
+	if !strings.Contains(err.Error(), "persist setup failure context") {
+		t.Fatalf("error = %v, want persistence failure context", err)
+	}
+}
+
 // TestRunSetup_CwdIsWorktreeRoot guards against cwd leaks: a bootstrap
 // script that writes `pwd > .cwd` must see the worktree path, not the
 // caller's cwd.

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Automaat/sybra/internal/notes"
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/task"
 )
@@ -422,6 +423,54 @@ func TestRunSetup_FailureBlocks(t *testing.T) {
 	data, _ := os.ReadFile(logPath)
 	if !strings.Contains(string(data), "exit err=") {
 		t.Errorf("setup log missing failure record; got:\n%s", string(data))
+	}
+}
+
+// TestRunSetupNonGating_FailureDoesNotBlock proves the fix-role setup path
+// (issue #1454) never returns an error on a failing setup command — a fixer
+// worktree must always be creatable even when the PR under repair broke the
+// project's build step, since that's exactly what the fixer exists to
+// repair. The failure must instead be captured into NOTES.md.
+func TestRunSetupNonGating_FailureDoesNotBlock(t *testing.T) {
+	t.Parallel()
+	logsDir := t.TempDir()
+	wtDir := t.TempDir()
+	mustRunInDir(t, wtDir, "git", "init", "-b", "main")
+	m := New(Config{WorktreesDir: wtDir, LogsDir: logsDir, Logger: discardLogger()})
+
+	err := m.runSetupNonGating(context.Background(), "task-fix-fail", wtDir, []string{
+		"echo broken build >&2 && exit 1",
+	})
+	if err != nil {
+		t.Fatalf("runSetupNonGating must not fail worktree creation: %v", err)
+	}
+
+	content, readErr := os.ReadFile(filepath.Join(wtDir, notes.FileName))
+	if readErr != nil {
+		t.Fatalf("read scratchpad: %v", readErr)
+	}
+	if !strings.Contains(string(content), "Setup failure") {
+		t.Errorf("scratchpad missing setup failure note: %q", content)
+	}
+}
+
+// TestRunSetupNonGating_SuccessLeavesNoNote confirms a clean setup run does
+// not create a spurious NOTES.md — the scratchpad is only seeded on failure
+// for fix-role worktrees (implementation worktrees seed it separately via
+// seedWorktree).
+func TestRunSetupNonGating_SuccessLeavesNoNote(t *testing.T) {
+	t.Parallel()
+	logsDir := t.TempDir()
+	wtDir := t.TempDir()
+	mustRunInDir(t, wtDir, "git", "init", "-b", "main")
+	m := New(Config{WorktreesDir: wtDir, LogsDir: logsDir, Logger: discardLogger()})
+
+	if err := m.runSetupNonGating(context.Background(), "task-fix-ok", wtDir, []string{"true"}); err != nil {
+		t.Fatalf("runSetupNonGating: %v", err)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(wtDir, notes.FileName)); !os.IsNotExist(statErr) {
+		t.Errorf("expected no NOTES.md on successful setup, stat err: %v", statErr)
 	}
 }
 

--- a/internal/worktree/notes.go
+++ b/internal/worktree/notes.go
@@ -43,3 +43,29 @@ func ensureNotesFile(ctx context.Context, wtPath string) error {
 		return fmt.Errorf("stat %s: %w", notes.FileName, statErr)
 	}
 }
+
+// appendSetupFailureNote records a non-gating setup failure (see
+// runSetupNonGating) into the worktree's NOTES.md scratchpad so a fix-role
+// agent sees it as its starting signal — NOTES.md is already inlined into
+// those agents' prompts via SeedWorkingMemory. Creates and git-excludes the
+// scratchpad first since fix-role prepares don't otherwise seed it.
+func appendSetupFailureNote(ctx context.Context, wtPath string, setupErr error) error {
+	if err := ensureNotesFile(ctx, wtPath); err != nil {
+		return err
+	}
+	path := filepath.Join(wtPath, notes.FileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", notes.FileName, err)
+	}
+	section := fmt.Sprintf(
+		"\n## Setup failure (pre-existing)\n\n"+
+			"Worktree setup failed before this agent started:\n\n```\n%s\n```\n\n"+
+			"This is very likely the exact defect this task exists to fix — start there.\n",
+		setupErr,
+	)
+	if err := os.WriteFile(path, append(data, []byte(section)...), 0o600); err != nil {
+		return fmt.Errorf("append %s: %w", notes.FileName, err)
+	}
+	return nil
+}

--- a/internal/worktree/notes.go
+++ b/internal/worktree/notes.go
@@ -6,9 +6,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/Automaat/sybra/internal/notes"
 )
+
+const setupFailureMarkerName = ".sybra-setup-failure"
 
 // ensureNotesFile seeds the agent working-memory scratchpad (notes.FileName) at
 // the worktree root and git-excludes it, mirroring the identity beacon. Unlike
@@ -68,4 +71,38 @@ func appendSetupFailureNote(ctx context.Context, wtPath string, setupErr error) 
 		return fmt.Errorf("append %s: %w", notes.FileName, err)
 	}
 	return nil
+}
+
+func writeSetupFailureMarker(ctx context.Context, wtPath string, setupErr error) error {
+	if err := addToInfoExclude(ctx, wtPath, setupFailureMarkerName); err != nil {
+		return fmt.Errorf("exclude %s: %w", setupFailureMarkerName, err)
+	}
+	path := filepath.Join(wtPath, setupFailureMarkerName)
+	if err := os.WriteFile(path, []byte(strings.TrimSpace(setupErr.Error())+"\n"), 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", setupFailureMarkerName, err)
+	}
+	return nil
+}
+
+func clearSetupFailureMarker(wtPath string) error {
+	path := filepath.Join(wtPath, setupFailureMarkerName)
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove %s: %w", setupFailureMarkerName, err)
+	}
+	return nil
+}
+
+// ReadSetupFailureMarker reports whether a fix-role worktree carried a
+// non-fatal setup failure during prepare, without requiring callers to parse
+// NOTES.md. The returned text is advisory context for logs/circuit breakers.
+func ReadSetupFailureMarker(wtPath string) (message string, exists bool, err error) {
+	data, err := os.ReadFile(filepath.Join(wtPath, setupFailureMarkerName))
+	switch {
+	case err == nil:
+		return strings.TrimSpace(string(data)), true, nil
+	case errors.Is(err, os.ErrNotExist):
+		return "", false, nil
+	default:
+		return "", false, fmt.Errorf("read %s: %w", setupFailureMarkerName, err)
+	}
 }

--- a/internal/worktree/notes_test.go
+++ b/internal/worktree/notes_test.go
@@ -2,6 +2,7 @@ package worktree
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -77,5 +78,67 @@ func TestEnsureNotesFile_PreservesExistingContent(t *testing.T) {
 	}
 	if n := strings.Count(string(data), "/"+notes.FileName); n != 1 {
 		t.Errorf("expected exactly 1 exclude entry, got %d. exclude:\n%s", n, data)
+	}
+}
+
+// TestAppendSetupFailureNote_SeedsAndAppends confirms a fresh worktree (no
+// NOTES.md yet, as fix-role prepares don't call seedWorktree) gets the
+// scratchpad created, excluded, and the failure recorded so SeedWorkingMemory
+// surfaces it to the fix agent.
+func TestAppendSetupFailureNote_SeedsAndAppends(t *testing.T) {
+	wt := t.TempDir()
+	mustRunInDir(t, wt, "git", "init", "-b", "main")
+
+	setupErr := errors.New(`setup command "npm run build:desktop" failed: exit status 1`)
+	if err := appendSetupFailureNote(context.Background(), wt, setupErr); err != nil {
+		t.Fatalf("appendSetupFailureNote: %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(wt, notes.FileName))
+	if err != nil {
+		t.Fatalf("read scratchpad: %v", err)
+	}
+	got := string(content)
+	if !strings.HasPrefix(got, notes.SeedTemplate) {
+		t.Errorf("expected seed template preserved as prefix, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Setup failure") || !strings.Contains(got, setupErr.Error()) {
+		t.Errorf("scratchpad missing setup failure note: %q", got)
+	}
+
+	out, err := exec.Command("git", "-C", wt, "status", "--porcelain").Output()
+	if err != nil {
+		t.Fatalf("git status: %v", err)
+	}
+	if strings.Contains(string(out), notes.FileName) {
+		t.Errorf("expected %s to be git-excluded, got status:\n%s", notes.FileName, out)
+	}
+}
+
+// TestAppendSetupFailureNote_PreservesExisting confirms the note is appended
+// after any accrued agent memory, not clobbering it.
+func TestAppendSetupFailureNote_PreservesExisting(t *testing.T) {
+	wt := t.TempDir()
+	mustRunInDir(t, wt, "git", "init", "-b", "main")
+
+	accrued := "# Working Notes\n\n## Decisions\n- picked the BK-tree approach\n"
+	if err := os.WriteFile(filepath.Join(wt, notes.FileName), []byte(accrued), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	setupErr := errors.New("exit status 1")
+	if err := appendSetupFailureNote(context.Background(), wt, setupErr); err != nil {
+		t.Fatalf("appendSetupFailureNote: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(wt, notes.FileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(string(got), accrued) {
+		t.Errorf("appendSetupFailureNote clobbered accrued memory: %q", got)
+	}
+	if !strings.Contains(string(got), setupErr.Error()) {
+		t.Errorf("scratchpad missing setup failure note: %q", got)
 	}
 }

--- a/internal/worktree/notes_test.go
+++ b/internal/worktree/notes_test.go
@@ -142,3 +142,35 @@ func TestAppendSetupFailureNote_PreservesExisting(t *testing.T) {
 		t.Errorf("scratchpad missing setup failure note: %q", got)
 	}
 }
+
+func TestSetupFailureMarker_WriteReadClear(t *testing.T) {
+	wt := t.TempDir()
+	mustRunInDir(t, wt, "git", "init", "-b", "main")
+
+	setupErr := errors.New("exit status 1")
+	if err := writeSetupFailureMarker(context.Background(), wt, setupErr); err != nil {
+		t.Fatalf("writeSetupFailureMarker: %v", err)
+	}
+
+	got, ok, err := ReadSetupFailureMarker(wt)
+	if err != nil {
+		t.Fatalf("ReadSetupFailureMarker: %v", err)
+	}
+	if !ok {
+		t.Fatal("ReadSetupFailureMarker reported no marker")
+	}
+	if got != setupErr.Error() {
+		t.Fatalf("ReadSetupFailureMarker = %q, want %q", got, setupErr.Error())
+	}
+
+	if err := clearSetupFailureMarker(wt); err != nil {
+		t.Fatalf("clearSetupFailureMarker: %v", err)
+	}
+	got, ok, err = ReadSetupFailureMarker(wt)
+	if err != nil {
+		t.Fatalf("ReadSetupFailureMarker after clear: %v", err)
+	}
+	if ok || got != "" {
+		t.Fatalf("ReadSetupFailureMarker after clear = (%q, %v), want empty,false", got, ok)
+	}
+}

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -483,7 +483,7 @@ func (m *Manager) PrepareForReview(ctx context.Context, t task.Task) (string, er
 // branch either exists (locally or on origin) or this is a hard failure
 // (ErrTaskBranchMissing) that must escalate rather than guess at a ref to
 // check out. Does not change PrepareForFix's behavior for its own PR-keyed
-// callers.
+// callers. Setup failures are non-gating, same rationale as PrepareForFix.
 func (m *Manager) PrepareForBranchFix(ctx context.Context, t task.Task) (string, error) {
 	// Adopt an externally-created worktree as-is, mirroring PrepareForFix.
 	if t.WorktreeDir != "" {
@@ -535,7 +535,7 @@ func (m *Manager) PrepareForBranchFix(ctx context.Context, t task.Task) (string,
 	}
 	m.ensureBranch(t, branch)
 	m.logger.Info("branch-fix.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
-	if err := m.runSetup(ctx, t.ID, wtPath, m.resolveSetupCommands(wtPath, proj)); err != nil {
+	if err := m.runSetupNonGating(ctx, t.ID, wtPath, m.resolveSetupCommands(wtPath, proj)); err != nil {
 		return "", fmt.Errorf("branch-fix setup: %w", err)
 	}
 	// pr-fix-role recovery runs must push straight to origin (the task's own
@@ -549,7 +549,10 @@ func (m *Manager) PrepareForBranchFix(ctx context.Context, t task.Task) (string,
 }
 
 // PrepareForFix creates a worktree checking out the PR's head branch
-// so the agent can rebase and push.
+// so the agent can rebase and push. Setup command failures do not abort
+// worktree creation (see runSetupNonGating) — the fixer this worktree is for
+// may exist precisely because that PR broke a gating setup command (e.g. a
+// build step), so refusing to create the worktree would deadlock the task.
 func (m *Manager) PrepareForFix(ctx context.Context, t task.Task, prNumber int) (string, error) {
 	// Adopt an externally-created worktree (e.g. an Orca handoff) as-is instead
 	// of re-creating it. Without this guard PrepareForFix runs
@@ -617,7 +620,7 @@ func (m *Manager) PrepareForFix(ctx context.Context, t task.Task, prNumber int) 
 	}
 	m.ensureBranch(t, branch)
 	m.logger.Info("fix.worktree.created", "task_id", t.ID, "path", wtPath, "branch", branch)
-	if err := m.runSetup(ctx, t.ID, wtPath, m.resolveSetupCommands(wtPath, proj)); err != nil {
+	if err := m.runSetupNonGating(ctx, t.ID, wtPath, m.resolveSetupCommands(wtPath, proj)); err != nil {
 		return "", fmt.Errorf("fix setup: %w", err)
 	}
 	// pr-fix tasks must push to the existing PR's head branch on origin — not

--- a/internal/worktree/prepare_branch_fix_test.go
+++ b/internal/worktree/prepare_branch_fix_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Automaat/sybra/internal/notes"
 	"github.com/Automaat/sybra/internal/task"
 )
 
@@ -65,6 +66,56 @@ func TestPrepareForBranchFix_ExistingBranch(t *testing.T) {
 	}
 	if reloaded.Branch != branch {
 		t.Errorf("task branch = %q, want %q", reloaded.Branch, branch)
+	}
+}
+
+// TestPrepareForBranchFix_SetupFailureDoesNotBlock is the regression test for
+// issue #1454: a project whose setup: command fails (e.g. a broken build)
+// must not prevent PrepareForBranchFix from creating the fix worktree — that
+// would deadlock the task, since the fixer this worktree is for exists
+// specifically to repair the breakage.
+func TestPrepareForBranchFix_SetupFailureDoesNotBlock(t *testing.T) {
+	h := prepareHarness(t, []string{"exit 1"}, 0)
+
+	const branch = "fix/broken-setup-branch"
+	srcGit := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", h.src}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	srcGit("checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(h.src, "feature.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcGit("add", ".")
+	srcGit("commit", "-m", "branch commit")
+	srcGit("checkout", "main")
+
+	tk, err := h.tasks.Create("broken setup branch fix", "", task.AgentModeHeadless)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	tk, err = h.tasks.UpdateMap(tk.ID, map[string]any{
+		"project_id": h.proj.ID,
+		"branch":     branch,
+	})
+	if err != nil {
+		t.Fatalf("update task: %v", err)
+	}
+
+	wtPath, err := h.m.PrepareForBranchFix(context.Background(), tk)
+	if err != nil {
+		t.Fatalf("PrepareForBranchFix must succeed despite a failing setup command: %v", err)
+	}
+
+	content, readErr := os.ReadFile(filepath.Join(wtPath, notes.FileName))
+	if readErr != nil {
+		t.Fatalf("read scratchpad: %v", readErr)
+	}
+	if !strings.Contains(string(content), "Setup failure") {
+		t.Errorf("scratchpad missing setup failure note: %q", content)
 	}
 }
 

--- a/internal/worktree/setup.go
+++ b/internal/worktree/setup.go
@@ -128,6 +128,28 @@ func (m *Manager) runSetup(parent context.Context, taskID, wtPath string, comman
 	return nil
 }
 
+// runSetupNonGating runs a worktree's setup commands like runSetup, but never
+// aborts worktree creation on failure. Fix-role worktrees (PrepareForFix,
+// PrepareForBranchFix) exist specifically to repair a broken build/CI run, so
+// gating their own creation on that exact breakage is a deadlock: the task can
+// never dispatch an agent to fix what blocks it from starting (issue #1454).
+// A failure is instead captured into the worktree's NOTES.md scratchpad,
+// which SeedWorkingMemory already inlines into fix-role agent prompts, so the
+// fixer sees the setup failure as its starting signal instead of the task
+// silently stranding in todo.
+func (m *Manager) runSetupNonGating(ctx context.Context, taskID, wtPath string, commands []string) error {
+	setupErr := m.runSetup(ctx, taskID, wtPath, commands)
+	if setupErr == nil {
+		return nil
+	}
+	m.logger.Warn("worktree.setup-fail-nonfatal",
+		"task_id", taskID, "path", wtPath, "err", setupErr)
+	if noteErr := appendSetupFailureNote(ctx, wtPath, setupErr); noteErr != nil {
+		m.logger.Warn("worktree.setup-fail-note", "task_id", taskID, "path", wtPath, "err", noteErr)
+	}
+	return nil
+}
+
 // setupLogPath returns the per-task setup log file path. Empty logsDir
 // disables file logging (returns ""), keeping in-memory/test setups working
 // without needing to configure a log dir.

--- a/internal/worktree/setup.go
+++ b/internal/worktree/setup.go
@@ -2,6 +2,7 @@ package worktree
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -140,12 +141,23 @@ func (m *Manager) runSetup(parent context.Context, taskID, wtPath string, comman
 func (m *Manager) runSetupNonGating(ctx context.Context, taskID, wtPath string, commands []string) error {
 	setupErr := m.runSetup(ctx, taskID, wtPath, commands)
 	if setupErr == nil {
+		if err := clearSetupFailureMarker(wtPath); err != nil {
+			m.logger.Warn("worktree.setup-fail-marker-clear", "task_id", taskID, "path", wtPath, "err", err)
+		}
 		return nil
 	}
 	m.logger.Warn("worktree.setup-fail-nonfatal",
 		"task_id", taskID, "path", wtPath, "err", setupErr)
-	if noteErr := appendSetupFailureNote(ctx, wtPath, setupErr); noteErr != nil {
+	noteErr := appendSetupFailureNote(ctx, wtPath, setupErr)
+	if noteErr != nil {
 		m.logger.Warn("worktree.setup-fail-note", "task_id", taskID, "path", wtPath, "err", noteErr)
+	}
+	markerErr := writeSetupFailureMarker(ctx, wtPath, setupErr)
+	if markerErr != nil {
+		m.logger.Warn("worktree.setup-fail-marker", "task_id", taskID, "path", wtPath, "err", markerErr)
+	}
+	if persistErr := errors.Join(noteErr, markerErr); persistErr != nil {
+		return fmt.Errorf("persist setup failure context: %w", persistErr)
 	}
 	return nil
 }


### PR DESCRIPTION
## Motivation

`PrepareForFix` and `PrepareForBranchFix` create worktrees for tasks whose
entire job is to repair a broken build/CI run. Gating worktree creation on
that same setup command succeeding was a deadlock: the fixer task could never
get a worktree to dispatch an agent into, because the thing it exists to fix
is exactly what makes setup fail. Tasks landed stuck in `todo` with no path
forward.

## Implementation information

- Added `runSetupNonGating`, used by `PrepareForFix` and
  `PrepareForBranchFix` in place of `runSetup` — setup failures are logged
  and captured into the worktree's `NOTES.md` instead of aborting worktree
  creation, so the fix-role agent sees the failure as its starting signal.
- Added a setup-failure marker (`writeSetupFailureMarker` /
  `clearSetupFailureMarker`) so a later successful setup clears the earlier
  failure state.
- Failures persisting the failure note/marker are now joined and surfaced
  via `errors.Join` rather than swallowed.
- Added coverage in `internal/worktree/prepare_branch_fix_test.go`,
  `internal/worktree/notes_test.go`, `internal/worktree/manager_test.go`,
  `internal/worktree/adopt_test.go`, and related `internal/sybra` tests.

Closes https://github.com/Automaat/sybra/issues/1454

_Generated by Sybra harness_