### PR TITLE
feat(task-view): copy task ID and per-agent output

### DIFF
--- a/frontend/src/components/task-detail/AgentHistoryList.svelte
+++ b/frontend/src/components/task-detail/AgentHistoryList.svelte
@@ -181,8 +181,9 @@
             <div class="mb-2 flex justify-end">
               <button
                 type="button"
-                class="inline-flex items-center gap-1 rounded border border-surface-300 px-2 py-1 text-xs font-medium text-surface-600 transition-colors hover:bg-surface-200 dark:border-surface-600 dark:text-surface-300 dark:hover:bg-surface-700"
+                class="inline-flex items-center gap-1 rounded border border-surface-300 px-2 py-1 text-xs font-medium text-surface-600 transition-colors hover:bg-surface-200 disabled:cursor-not-allowed disabled:opacity-50 dark:border-surface-600 dark:text-surface-300 dark:hover:bg-surface-700"
                 onclick={() => copyRunOutput(run.agentId)}
+                disabled={runLogLoading.has(run.agentId)}
                 title="Copy this agent's output"
               >
                 {#if copiedRun === run.agentId}

--- a/frontend/src/components/task-detail/AgentHistoryList.svelte
+++ b/frontend/src/components/task-detail/AgentHistoryList.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { ChevronDown, RefreshCw } from '@lucide/svelte'
+  import { ChevronDown, RefreshCw, Copy, Check } from '@lucide/svelte'
   import type { ConvoEvent, StreamEvent } from '../../../bindings/github.com/Automaat/sybra/internal/agent/models.js'
   import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { GetAgentRunLog, GetAgentRunConvoLog } from '$lib/api'
+  import { notificationStore } from '../../stores/notifications.svelte.js'
   import { formatDateTime } from '../../lib/dates.js'
   import { formatCostShort } from '../../lib/cost.js'
   import { runStateClasses, runRoleLabel, runRoleClasses } from '../../lib/agent-run.js'
@@ -25,6 +26,7 @@
   let runLogConvoEvents = $state<Map<string, ConvoEvent[]>>(new Map())
   let runLogLoading = $state<Set<string>>(new Set())
   let runLogError = $state<Map<string, string>>(new Map())
+  let copiedRun = $state<string | null>(null)
 
   const pastRuns = $derived(
     (task.agentRuns ?? []).filter((r) => r.state !== 'running').reverse(),
@@ -87,6 +89,57 @@
     const e = new Map(runLogError); e.delete(agentId); runLogError = e
     await loadRunLog(agentId)
   }
+
+  // Assemble a single run's output as plain text from whichever log shape is
+  // loaded, falling back to the persisted result string.
+  function runOutputText(agentId: string): string {
+    const run = (task.agentRuns ?? []).find((r) => r.agentId === agentId)
+    if (run?.mode === 'interactive') {
+      const events = runLogConvoEvents.get(agentId) ?? []
+      if (events.length > 0) {
+        return events
+          .map((ev) => {
+            const parts: string[] = []
+            if (ev.text) parts.push(ev.text)
+            for (const tu of ev.toolUses ?? []) {
+              const input = tu.input ? JSON.stringify(tu.input) : ''
+              parts.push(`[tool_use ${tu.name ?? ''}] ${input}`.trim())
+            }
+            for (const tr of ev.toolResults ?? []) parts.push(tr.content ?? '')
+            return parts.filter(Boolean).join('\n')
+          })
+          .filter(Boolean)
+          .join('\n\n')
+      }
+    } else {
+      const events = runLogStreamEvents.get(agentId) ?? []
+      if (events.length > 0) {
+        return events.map((ev) => ev.content ?? '').filter(Boolean).join('\n')
+      }
+    }
+    return run?.result ?? ''
+  }
+
+  async function copyRunOutput(agentId: string) {
+    // Make sure the log is fetched before copying (the row may have just opened).
+    const run = (task.agentRuns ?? []).find((r) => r.agentId === agentId)
+    const loaded = run?.mode === 'interactive'
+      ? runLogConvoEvents.has(agentId)
+      : runLogStreamEvents.has(agentId)
+    if (!loaded) await loadRunLog(agentId)
+    const text = runOutputText(agentId)
+    if (!text) {
+      notificationStore.pushLocal('error', 'Nothing to copy', 'This run has no output.')
+      return
+    }
+    try {
+      await navigator.clipboard.writeText(text)
+      copiedRun = agentId
+      setTimeout(() => { if (copiedRun === agentId) copiedRun = null }, 1500)
+    } catch (e) {
+      notificationStore.pushLocal('error', 'Copy failed', String(e))
+    }
+  }
 </script>
 
 {#if pastRuns.length > 0}
@@ -125,6 +178,20 @@
         </button>
         {#if expandedRun === run.agentId}
           <div class="border-t border-surface-300 px-3 py-2 dark:border-surface-600">
+            <div class="mb-2 flex justify-end">
+              <button
+                type="button"
+                class="inline-flex items-center gap-1 rounded border border-surface-300 px-2 py-1 text-xs font-medium text-surface-600 transition-colors hover:bg-surface-200 dark:border-surface-600 dark:text-surface-300 dark:hover:bg-surface-700"
+                onclick={() => copyRunOutput(run.agentId)}
+                title="Copy this agent's output"
+              >
+                {#if copiedRun === run.agentId}
+                  <Check size={12} /> Copied!
+                {:else}
+                  <Copy size={12} /> Copy output
+                {/if}
+              </button>
+            </div>
             {#if run.prompt}
               <details class="mb-3 rounded-lg border border-surface-300 bg-surface-100 dark:border-surface-600 dark:bg-surface-900">
                 <summary class="cursor-pointer select-none px-3 py-2 text-xs font-medium text-surface-600 dark:text-surface-300">Prompt</summary>

--- a/frontend/src/components/task-detail/AgentHistoryList.svelte.test.ts
+++ b/frontend/src/components/task-detail/AgentHistoryList.svelte.test.ts
@@ -3,10 +3,17 @@ import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/sv
 
 const mockGetRunLog = vi.fn()
 const mockGetRunConvoLog = vi.fn()
+const mockPushLocal = vi.fn()
 
 vi.mock('$lib/api', () => ({
   GetAgentRunLog: (...args: unknown[]) => mockGetRunLog(...args),
   GetAgentRunConvoLog: (...args: unknown[]) => mockGetRunConvoLog(...args),
+}))
+
+vi.mock('../../stores/notifications.svelte.js', () => ({
+  notificationStore: {
+    pushLocal: (...args: unknown[]) => mockPushLocal(...args),
+  },
 }))
 
 vi.mock('../StreamOutput.svelte', () => ({ default: () => {} }))
@@ -53,6 +60,7 @@ describe('AgentHistoryList', () => {
   beforeEach(() => {
     mockGetRunLog.mockReset()
     mockGetRunConvoLog.mockReset()
+    mockPushLocal.mockReset()
   })
   afterEach(cleanup)
 
@@ -143,6 +151,59 @@ describe('AgentHistoryList', () => {
     await waitFor(() => {
       // Still 1 call — cached
       expect(mockGetRunLog).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('disables the Copy output button while the log is loading', async () => {
+    let resolveLog: (v: unknown[]) => void = () => {}
+    mockGetRunLog.mockReturnValue(new Promise((resolve) => { resolveLog = resolve }))
+    render(AgentHistoryList, { props: { task: baseTask as never } })
+    await fireEvent.click(screen.getByText('a-old-1'))
+    await waitFor(() => {
+      const button = screen.getByText('Copy output').closest('button') as HTMLButtonElement
+      expect(button.disabled).toBe(true)
+    })
+    resolveLog([{ type: 'assistant', content: 'hello' }])
+    await waitFor(() => {
+      const button = screen.getByText('Copy output').closest('button') as HTMLButtonElement
+      expect(button.disabled).toBe(false)
+    })
+  })
+
+  it('copies assembled stream output to the clipboard', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    mockGetRunLog.mockResolvedValue([{ type: 'assistant', content: 'hello' }, { type: 'assistant', content: 'world' }])
+    render(AgentHistoryList, { props: { task: baseTask as never } })
+    await fireEvent.click(screen.getByText('a-old-1'))
+    await waitFor(() => expect(mockGetRunLog).toHaveBeenCalled())
+    await fireEvent.click(screen.getByText('Copy output'))
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('hello\nworld')
+    })
+  })
+
+  it('copies assembled convo output to the clipboard, fetching the log first if needed', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    mockGetRunConvoLog.mockResolvedValue([{ text: 'hi there' }])
+    render(AgentHistoryList, { props: { task: baseTask as never } })
+    await fireEvent.click(screen.getByText('a-old-2'))
+    await waitFor(() => expect(mockGetRunConvoLog).toHaveBeenCalled())
+    await fireEvent.click(screen.getByText('Copy output'))
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('hi there')
+    })
+  })
+
+  it('shows "Nothing to copy" when the log and result are both empty', async () => {
+    mockGetRunLog.mockResolvedValue([])
+    render(AgentHistoryList, { props: { task: baseTask as never } })
+    await fireEvent.click(screen.getByText('a-old-1'))
+    await waitFor(() => expect(mockGetRunLog).toHaveBeenCalled())
+    await fireEvent.click(screen.getByText('Copy output'))
+    await waitFor(() => {
+      expect(mockPushLocal).toHaveBeenCalledWith('error', 'Nothing to copy', 'This run has no output.')
     })
   })
 })

--- a/frontend/src/components/task-detail/TaskMetadataRow.svelte
+++ b/frontend/src/components/task-detail/TaskMetadataRow.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CircleDot, Copy, FolderGit2, GitBranch, Bot, Tag, Calendar, Clock, CalendarClock, Wrench } from '@lucide/svelte'
+  import { CircleDot, Copy, FolderGit2, GitBranch, Bot, Tag, Calendar, Clock, CalendarClock, Wrench, Hash } from '@lucide/svelte'
   import { onMount } from 'svelte'
   import type { Task } from '../../../bindings/github.com/Automaat/sybra/internal/task/models.js'
   import { taskStore } from '../../stores/tasks.svelte.js'
@@ -19,6 +19,7 @@
   const { task }: Props = $props()
 
   let error = $state('')
+  let copiedId = $state(false)
   let copiedBranch = $state(false)
   let projectDialogOpen = $state(false)
 
@@ -57,6 +58,16 @@
     }
   }
 
+  async function copyId() {
+    try {
+      await navigator.clipboard.writeText(task.id)
+      copiedId = true
+      setTimeout(() => { copiedId = false }, 1500)
+    } catch (e) {
+      notificationStore.pushLocal('error', 'Copy failed', String(e))
+    }
+  }
+
   async function copyBranch() {
     if (!task.projectId) return
     try {
@@ -79,6 +90,20 @@
      value column with leading type icons, so the eye scans one edge. The row
      order runs primary → secondary (identity, then timestamps). -->
 <dl class="grid grid-cols-[auto_1fr] items-center gap-x-5 gap-y-2.5 text-sm">
+  <dt class="text-[11px] font-medium uppercase tracking-wide text-surface-400">Task ID</dt>
+  <dd>
+    <button
+      type="button"
+      class="-mx-1.5 inline-flex items-center gap-1.5 rounded px-1.5 py-0.5 text-left font-mono text-surface-700 transition-colors hover:bg-surface-200 dark:text-surface-300 dark:hover:bg-surface-700"
+      onclick={copyId}
+      title="Copy task ID (⌘.)"
+    >
+      <Hash size={13} class="shrink-0 text-surface-400" />
+      {copiedId ? 'Copied!' : task.id}
+      <Copy size={12} class="shrink-0 text-surface-400" />
+    </button>
+  </dd>
+
   <dt class="text-[11px] font-medium uppercase tracking-wide text-surface-400">Project</dt>
   <dd>
     <button

--- a/frontend/src/components/task-detail/TaskMetadataRow.svelte.test.ts
+++ b/frontend/src/components/task-detail/TaskMetadataRow.svelte.test.ts
@@ -133,4 +133,25 @@ describe('TaskMetadataRow', () => {
     await fireEvent.click(screen.getByText('https://example/i/1'))
     expect(mockOpenURL).toHaveBeenCalledWith('https://example/i/1', expect.anything())
   })
+
+  it('copies the task id to the clipboard and shows feedback', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, { clipboard: { writeText } })
+    render(TaskMetadataRow, { props: { task: baseTask as never } })
+    await fireEvent.click(screen.getByTitle('Copy task ID (⌘.)'))
+    expect(writeText).toHaveBeenCalledWith('t1')
+    await waitFor(() => {
+      expect(screen.getByText('Copied!')).toBeDefined()
+    })
+  })
+
+  it('shows an error notification when copying the task id fails', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('denied'))
+    Object.assign(navigator, { clipboard: { writeText } })
+    render(TaskMetadataRow, { props: { task: baseTask as never } })
+    await fireEvent.click(screen.getByTitle('Copy task ID (⌘.)'))
+    await waitFor(() => {
+      expect(mockPushLocal).toHaveBeenCalledWith('error', 'Copy failed', expect.stringContaining('denied'))
+    })
+  })
 })


### PR DESCRIPTION
## Motivation

The task view's right-side properties rail had no quick way to grab the task ID, and the Agent History section offered no way to copy a single agent run's output — you had to select text by hand.

> Changelog: feat(task-view): copy task ID and per-agent output

## Implementation information

- **Task ID row** (`TaskMetadataRow.svelte`): new first row in the properties rail showing the task ID in mono with a copy button ("Copied!" feedback). Reuses the existing ⌘. copy-id shortcut path.
- **Per-agent copy** (`AgentHistoryList.svelte`): each expanded run gets a "Copy output" button. Assembles the run's text from whichever log shape is loaded — stream events (headless), convo events incl. tool_use/tool_result (interactive), or the persisted `result` fallback — fetching the log first if the row was just opened.

## Supporting documentation

`npm run check`, `oxlint`, and the two affected component test suites (17 tests) pass.