### PR TITLE
feat(llmexec): codex output-schema enforcement

### DIFF
--- a/internal/agent/inspector.go
+++ b/internal/agent/inspector.go
@@ -29,6 +29,12 @@ type InspectorVerdict struct {
 	ReasonKind string `json:"reason_kind,omitempty"` // "rate_limit" | "generic_stall" | "reward_hacking" | ""
 }
 
+// inspectorVerdictSchema is a hand-written strict JSON Schema for
+// InspectorVerdict: root object, additionalProperties:false, and every field
+// listed as required (including the omitempty ones) — codex's strict mode
+// rejects schemas that omit a struct field from "required".
+const inspectorVerdictSchema = `{"type":"object","properties":{"stuck":{"type":"boolean"},"reason":{"type":"string"},"recommendation":{"type":"string","enum":["stop","continue","escalate","nudge"]},"nudge":{"type":"string"},"reason_kind":{"type":"string","enum":["rate_limit","generic_stall","reward_hacking",""]}},"required":["stuck","reason","recommendation","nudge","reason_kind"],"additionalProperties":false}`
+
 // InspectInput holds the context handed to the inspector about the target agent.
 type InspectInput struct {
 	AgentID   string
@@ -58,6 +64,7 @@ func Inspect(ctx context.Context, logger *slog.Logger, in InspectInput) (Inspect
 	v, _, err := llmjob.Run(ctx, prompt, llmjob.Spec[InspectorVerdict]{
 		Name:     "inspect",
 		Tier:     llmjob.Cheap,
+		Schema:   inspectorVerdictSchema,
 		Validate: validateInspectorVerdict,
 	}, llmexec.Options{Logger: logger, Models: claudeModelOverride(in.Model)})
 	if err != nil {

--- a/internal/agent/inspector_test.go
+++ b/internal/agent/inspector_test.go
@@ -2,11 +2,49 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+// TestInspectorVerdictSchemaIsCodexStrict asserts inspectorVerdictSchema is a
+// root object schema with additionalProperties:false and every struct field
+// (including the omitempty ones, nudge and reason_kind) listed as required —
+// codex's strict output-schema mode rejects a schema that omits any property
+// from "required".
+func TestInspectorVerdictSchemaIsCodexStrict(t *testing.T) {
+	var schema struct {
+		Type                 string                     `json:"type"`
+		Properties           map[string]json.RawMessage `json:"properties"`
+		Required             []string                   `json:"required"`
+		AdditionalProperties *bool                      `json:"additionalProperties"`
+	}
+	if err := json.Unmarshal([]byte(inspectorVerdictSchema), &schema); err != nil {
+		t.Fatalf("unmarshal inspectorVerdictSchema: %v", err)
+	}
+	if schema.Type != "object" {
+		t.Fatalf("type = %q, want object", schema.Type)
+	}
+	if schema.AdditionalProperties == nil || *schema.AdditionalProperties {
+		t.Fatalf("additionalProperties = %v, want false", schema.AdditionalProperties)
+	}
+	required := make(map[string]bool, len(schema.Required))
+	for _, f := range schema.Required {
+		required[f] = true
+	}
+	for field := range schema.Properties {
+		if !required[field] {
+			t.Fatalf("codex strict output schema requires every property; %q missing from required", field)
+		}
+	}
+	for _, want := range []string{"stuck", "reason", "recommendation", "nudge", "reason_kind"} {
+		if !required[want] {
+			t.Fatalf("required is missing %q: %v", want, schema.Required)
+		}
+	}
+}
 
 func TestValidateInspectorVerdict(t *testing.T) {
 	tests := []struct {
@@ -19,6 +57,7 @@ func TestValidateInspectorVerdict(t *testing.T) {
 		{"valid stop with reward_hacking kind", InspectorVerdict{Recommendation: "stop", ReasonKind: "reward_hacking"}, false},
 		{"valid stop with empty kind (backwards compat)", InspectorVerdict{Recommendation: "stop", ReasonKind: ""}, false},
 		{"valid continue", InspectorVerdict{Recommendation: "continue"}, false},
+		{"valid stop with empty nudge and reason_kind (codex strict emission)", InspectorVerdict{Recommendation: "stop", Nudge: "", ReasonKind: ""}, false},
 		{"invalid recommendation", InspectorVerdict{Recommendation: "bogus"}, true},
 		{"invalid reason_kind", InspectorVerdict{Recommendation: "stop", ReasonKind: "bogus"}, true},
 	}

--- a/internal/llmexec/llmexec.go
+++ b/internal/llmexec/llmexec.go
@@ -86,6 +86,11 @@ func RunJSON(ctx context.Context, prompt string, opts Options) (Result, error) {
 				failures = append(failures, fmt.Sprintf("%s: %s", p, err))
 				continue
 			}
+			if schemaFlagRejected(p, opts.Schema, stderrOut, string(raw)) {
+				logFallback(opts.Logger, p, provider.SignalNone, "unsupported_output_schema")
+				failures = append(failures, fmt.Sprintf("%s: unsupported output-schema flag", p))
+				continue
+			}
 			if overloaded(stderrOut, string(raw)) {
 				logFallback(opts.Logger, p, provider.SignalRateLimit, "overloaded")
 				failures = append(failures, fmt.Sprintf("%s: overloaded", p))
@@ -103,6 +108,11 @@ func RunJSON(ctx context.Context, prompt string, opts Options) (Result, error) {
 
 		text, cost, parseErr := parseProviderText(p, raw)
 		if parseErr != nil {
+			if schemaFlagRejected(p, opts.Schema, stderrOut, string(raw)) {
+				logFallback(opts.Logger, p, provider.SignalNone, "unsupported_output_schema")
+				failures = append(failures, fmt.Sprintf("%s: unsupported output-schema flag", p))
+				continue
+			}
 			if overloaded(stderrOut, string(raw)) {
 				logFallback(opts.Logger, p, provider.SignalRateLimit, "overloaded")
 				failures = append(failures, fmt.Sprintf("%s: overloaded", p))
@@ -347,6 +357,45 @@ func overloaded(parts ...string) bool {
 	for _, p := range parts {
 		lower := strings.ToLower(p)
 		if strings.Contains(lower, "529") || strings.Contains(lower, "overloaded") {
+			return true
+		}
+	}
+	return false
+}
+
+func schemaFlagRejected(providerName, schema string, parts ...string) bool {
+	if providerName != "codex" || strings.TrimSpace(schema) == "" {
+		return false
+	}
+	for _, part := range parts {
+		lower := strings.ToLower(part)
+		if !strings.Contains(lower, "--output-schema") {
+			continue
+		}
+		if containsAnyString(lower,
+			"unknown option",
+			"unknown flag",
+			"unknown argument",
+			"unrecognized option",
+			"unrecognized argument",
+			"unexpected option",
+			"unexpected argument",
+			"found argument '--output-schema' which wasn't expected",
+			"no such option",
+			"unsupported option",
+		) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAnyString(haystack string, needles ...string) bool {
+	for _, needle := range needles {
+		if needle == "" {
+			continue
+		}
+		if strings.Contains(haystack, needle) {
 			return true
 		}
 	}

--- a/internal/llmexec/llmexec.go
+++ b/internal/llmexec/llmexec.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"slices"
 	"strings"
@@ -22,6 +23,12 @@ import (
 var providerOrder = []string{"claude", "codex", "copilot"}
 
 const streamScannerBuffer = 4 * 1024 * 1024
+
+// errSchemaDelivery wraps failures creating/writing the codex output-schema
+// temp file. RunJSON treats it as a failover-eligible provider failure rather
+// than a hard error, so a codex-local filesystem issue falls back to the next
+// provider instead of aborting the whole call.
+var errSchemaDelivery = errors.New("schema delivery failed")
 
 // Options configures a one-shot provider invocation.
 type Options struct {
@@ -38,6 +45,11 @@ type Options struct {
 	DisableTools bool
 	Logger       *slog.Logger
 	Gate         provider.HealthGate
+	// Schema is an optional JSON Schema describing the expected result shape.
+	// Codex receives it natively via `--output-schema <tempfile>` (no prose);
+	// claude and copilot have no such flag, so it is embedded as prose in the
+	// prompt instead. Empty means no schema is delivered by either path.
+	Schema string
 }
 
 // Result is the normalized final assistant text.
@@ -68,8 +80,12 @@ func RunJSON(ctx context.Context, prompt string, opts Options) (Result, error) {
 			continue
 		}
 
-		raw, stderrOut, err := runProvider(ctx, p, prompt, opts.Models[p], opts.DisableTools)
+		raw, stderrOut, err := runProvider(ctx, p, prompt, opts.Models[p], opts.DisableTools, opts.Schema)
 		if err != nil {
+			if errors.Is(err, errSchemaDelivery) {
+				failures = append(failures, fmt.Sprintf("%s: %s", p, err))
+				continue
+			}
 			if overloaded(stderrOut, string(raw)) {
 				logFallback(opts.Logger, p, provider.SignalRateLimit, "overloaded")
 				failures = append(failures, fmt.Sprintf("%s: overloaded", p))
@@ -143,8 +159,23 @@ func binaryName(p string) string {
 	return p
 }
 
-func runProvider(ctx context.Context, p, prompt, model string, disableTools bool) (stdout []byte, stderrOut string, err error) {
-	name, args, stdin := invocation(p, prompt, model, disableTools)
+func runProvider(ctx context.Context, p, prompt, model string, disableTools bool, schema string) (stdout []byte, stderrOut string, err error) {
+	effectivePrompt := prompt
+	schemaPath := ""
+	if strings.TrimSpace(schema) != "" {
+		if p == "codex" {
+			path, schemaErr := writeSchemaTempFile(schema)
+			if schemaErr != nil {
+				return nil, "", fmt.Errorf("%w: %w", errSchemaDelivery, schemaErr)
+			}
+			defer os.Remove(path)
+			schemaPath = path
+		} else {
+			effectivePrompt = prompt + "\n\nOutput schema:\n" + strings.TrimSpace(schema)
+		}
+	}
+
+	name, args, stdin := invocation(p, effectivePrompt, model, disableTools, schemaPath)
 	cmd := exec.CommandContext(ctx, name, args...)
 	if stdin != "" {
 		cmd.Stdin = strings.NewReader(stdin)
@@ -155,16 +186,37 @@ func runProvider(ctx context.Context, p, prompt, model string, disableTools bool
 	return out, stderr.String(), err
 }
 
-func invocation(p, prompt, model string, disableTools bool) (name string, args []string, stdin string) {
+func writeSchemaTempFile(schema string) (string, error) {
+	f, err := os.CreateTemp("", "sybra-llmexec-schema-*.json")
+	if err != nil {
+		return "", fmt.Errorf("create schema temp file: %w", err)
+	}
+	if _, err := f.WriteString(schema); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return "", fmt.Errorf("write schema temp file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return "", fmt.Errorf("close schema temp file: %w", err)
+	}
+	return f.Name(), nil
+}
+
+func invocation(p, prompt, model string, disableTools bool, schemaPath string) (name string, args []string, stdin string) {
 	switch p {
 	case "codex":
 		args := []string{
 			"exec", "--json", "--skip-git-repo-check", "--ignore-user-config", "--ignore-rules",
-			"--dangerously-bypass-approvals-and-sandbox", "-",
+			"--dangerously-bypass-approvals-and-sandbox",
 		}
 		if model != "" {
-			args = append(args[:len(args)-1], "--model", model, "-")
+			args = append(args, "--model", model)
 		}
+		if schemaPath != "" {
+			args = append(args, "--output-schema", schemaPath)
+		}
+		args = append(args, "-")
 		return "codex", args, prompt
 	case "copilot":
 		args := []string{"-p", prompt, "--output-format", "json", "--allow-all-tools", "--no-ask-user"}

--- a/internal/llmexec/llmexec_test.go
+++ b/internal/llmexec/llmexec_test.go
@@ -160,6 +160,117 @@ func TestParseCopilotTextAllowsLargeStreamLine(t *testing.T) {
 	}
 }
 
+func TestRunJSONPassesCodexOutputSchemaAsTempFile(t *testing.T) {
+	dir := t.TempDir()
+	captureDir := t.TempDir()
+	writeExe(t, filepath.Join(dir, "codex"), fmt.Sprintf(`#!/bin/bash
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--output-schema" ]; then
+    printf '%%s' "$arg" > %q/schema-arg.txt
+    printf '%%s' "$(< "$arg")" > %q/schema-path.txt
+  fi
+  prev="$arg"
+done
+printf '%%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"{\"ok\":true}"}}'
+`, captureDir, captureDir))
+	t.Setenv("PATH", dir)
+
+	const schema = `{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"],"additionalProperties":false}`
+	res, err := RunJSON(context.Background(), "classify", Options{Provider: "codex", Schema: schema})
+	if err != nil {
+		t.Fatalf("RunJSON: %v", err)
+	}
+	if res.Provider != "codex" {
+		t.Fatalf("provider = %q, want codex", res.Provider)
+	}
+
+	schemaPathRaw, err := os.ReadFile(filepath.Join(captureDir, "schema-arg.txt"))
+	if err != nil {
+		t.Fatalf("read captured schema arg: %v", err)
+	}
+	if strings.TrimSpace(string(schemaPathRaw)) == "" {
+		t.Fatalf("--output-schema flag was not passed to codex")
+	}
+
+	gotSchema, err := os.ReadFile(filepath.Join(captureDir, "schema-path.txt"))
+	if err != nil {
+		t.Fatalf("read schema temp file: %v", err)
+	}
+	if string(gotSchema) != schema {
+		t.Fatalf("schema temp file content = %q, want %q", gotSchema, schema)
+	}
+}
+
+func TestRunJSONEmbedsSchemaAsProseForClaude(t *testing.T) {
+	dir := t.TempDir()
+	writeExe(t, filepath.Join(dir, "claude"), `#!/bin/bash
+if [[ "$*" == *"--output-schema"* ]]; then
+  echo "claude must not receive --output-schema" >&2
+  exit 7
+fi
+if [[ "$*" != *"Output schema:"* ]]; then
+  echo "prompt missing schema prose: $*" >&2
+  exit 7
+fi
+printf '%s\n' '{"result":"{\"ok\":true}"}'
+`)
+	t.Setenv("PATH", dir)
+
+	const schema = `{"type":"object","properties":{"ok":{"type":"boolean"}}}`
+	res, err := RunJSON(context.Background(), "classify", Options{Provider: "claude", Schema: schema})
+	if err != nil {
+		t.Fatalf("RunJSON: %v", err)
+	}
+	if res.Provider != "claude" {
+		t.Fatalf("provider = %q, want claude", res.Provider)
+	}
+}
+
+func TestRunJSONEmptySchemaAddsNoFlagOrProse(t *testing.T) {
+	dir := t.TempDir()
+	writeExe(t, filepath.Join(dir, "codex"), `#!/bin/bash
+if [[ "$*" == *"--output-schema"* ]]; then
+  echo "unexpected --output-schema with empty schema" >&2
+  exit 7
+fi
+printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"{\"ok\":true}"}}'
+`)
+	t.Setenv("PATH", dir)
+
+	res, err := RunJSON(context.Background(), "classify", Options{Provider: "codex"})
+	if err != nil {
+		t.Fatalf("RunJSON: %v", err)
+	}
+	if res.Provider != "codex" {
+		t.Fatalf("provider = %q, want codex", res.Provider)
+	}
+}
+
+func TestRunJSONFallsBackWhenSchemaTempFileFails(t *testing.T) {
+	dir := t.TempDir()
+	writeExe(t, filepath.Join(dir, "codex"), `#!/bin/sh
+echo "codex should never run when schema delivery fails" >&2
+exit 7
+`)
+	writeExe(t, filepath.Join(dir, "claude"), `#!/bin/sh
+printf '%s\n' '{"result":"{\"ok\":true}"}'
+`)
+	t.Setenv("PATH", dir)
+	t.Setenv("TMPDIR", filepath.Join(dir, "does-not-exist"))
+
+	res, err := RunJSON(context.Background(), "classify", Options{
+		Provider: "codex",
+		Schema:   `{"type":"object"}`,
+	})
+	if err != nil {
+		t.Fatalf("RunJSON: %v", err)
+	}
+	if res.Provider != "claude" {
+		t.Fatalf("provider = %q, want claude fallback after schema delivery failure", res.Provider)
+	}
+}
+
 func writeExe(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {

--- a/internal/llmexec/llmexec_test.go
+++ b/internal/llmexec/llmexec_test.go
@@ -271,6 +271,29 @@ printf '%s\n' '{"result":"{\"ok\":true}"}'
 	}
 }
 
+func TestRunJSONFallsBackWhenCodexRejectsOutputSchemaFlag(t *testing.T) {
+	dir := t.TempDir()
+	writeExe(t, filepath.Join(dir, "codex"), `#!/bin/sh
+echo "error: unexpected argument '--output-schema' found" >&2
+exit 2
+`)
+	writeExe(t, filepath.Join(dir, "copilot"), `#!/bin/sh
+printf '%s\n' '{"type":"assistant.message","data":{"content":"{\"ok\":true}"}}'
+`)
+	t.Setenv("PATH", dir)
+
+	res, err := RunJSON(context.Background(), "classify", Options{
+		Provider: "codex",
+		Schema:   `{"type":"object"}`,
+	})
+	if err != nil {
+		t.Fatalf("RunJSON: %v", err)
+	}
+	if res.Provider != "copilot" {
+		t.Fatalf("provider = %q, want copilot fallback after codex rejects --output-schema", res.Provider)
+	}
+}
+
 func writeExe(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {

--- a/internal/llmjob/llmjob.go
+++ b/internal/llmjob/llmjob.go
@@ -41,9 +41,7 @@ type Meta struct {
 func Run[T any](ctx context.Context, prompt string, s Spec[T], o llmexec.Options) (T, Meta, error) {
 	var zero T
 	o.Models = mergeModels(modelsFor(s.Tier), o.Models)
-	if strings.TrimSpace(s.Schema) != "" {
-		prompt += "\n\nOutput schema:\n" + strings.TrimSpace(s.Schema)
-	}
+	o.Schema = s.Schema
 	if strings.TrimSpace(s.AvoidProvider) != "" {
 		var err error
 		o, err = avoidProvider(o, s.AvoidProvider)

--- a/internal/llmjob/llmjob_test.go
+++ b/internal/llmjob/llmjob_test.go
@@ -153,6 +153,28 @@ func TestRunPreservesExplicitModels(t *testing.T) {
 	}
 }
 
+func TestRunPassesSchemaViaOptionsNotPrompt(t *testing.T) {
+	const schema = `{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"],"additionalProperties":false}`
+	restore := stubRunner(func(_ context.Context, prompt string, opts llmexec.Options) (llmexec.Result, error) {
+		if opts.Schema != schema {
+			t.Fatalf("opts.Schema = %q, want %q", opts.Schema, schema)
+		}
+		if strings.Contains(prompt, schema) || strings.Contains(prompt, "Output schema:") {
+			t.Fatalf("prompt must not embed the schema (double delivery risk): %q", prompt)
+		}
+		return llmexec.Result{Provider: "codex", Text: `{"ok":true}`}, nil
+	})
+	defer restore()
+
+	if _, _, err := Run(context.Background(), "prompt", Spec[testOut]{
+		Name:   "schema-passthrough",
+		Tier:   Cheap,
+		Schema: schema,
+	}, llmexec.Options{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
 func TestModelsForClones(t *testing.T) {
 	got := modelsFor(Standard)
 	got["claude"] = "mutated"


### PR DESCRIPTION
## Motivation

Codex ships a native `--output-schema` flag that guarantees well-formed JSON output, which is more reliable than the current approach of stuffing the schema into the prompt as prose and repairing malformed output via the llmjob retry loop.

## Implementation information

- Wire `Options.Schema` through `internal/llmexec` so the codex provider writes the schema to a temp file and passes `--output-schema`; claude/copilot keep the existing prose-based fallback.
- Temp-file delivery failures failover to the next configured provider instead of aborting the whole call.
- `internal/llmjob` now passes the schema via `Options` instead of concatenating it into the prompt text.
- The agent inspector (`internal/agent/inspector.go`) uses a hand-written strict JSON schema for `InspectorVerdict`, verified against a live codex invocation.

Closes https://github.com/Automaat/sybra/issues/1316

_Generated by Sybra harness_