### PR TITLE
fix(agent): lower default concurrency, add jitter

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -75,7 +75,7 @@ machine.
 | `agent.provider` | `string` | `claude` |  |
 | `agent.model` | `string` |  |  |
 | `agent.mode` | `string` |  |  |
-| `agent.max_concurrent` | `int` | `100` |  |
+| `agent.max_concurrent` | `int` | `25` |  |
 | `agent.research_machine_dir` | `string` |  |  |
 | `agent.max_cost_usd` | `float64` | `5` |  |
 | `agent.max_turns` | `int` | `150` |  |
@@ -90,7 +90,7 @@ machine.
 | `agent.survive_restart` | `*bool` | _(nil)_ | SurviveRestart keeps agent subprocesses running across an app restart (detached, output streamed to their log files) and reattaches to them on the next startup. nil means not configured (defaults to true). Set false to revert to the legacy behaviour where agents are killed on shutdown and recovered via restart-stale. |
 | `agent.approval_port` | `int` |  | ApprovalPort pins the localhost port of the PreToolUse approval server. The hook URL is baked into a permission-gated agent's --settings at spawn, so a fixed port lets a detached agent's approval requests still resolve after a restart. 0 (default) binds a random port (no cross-restart approval survival). |
 | `agent.headless_permission_mode` | `string` |  | HeadlessPermissionMode sets the default permission posture for unattended headless claude runs. "bypass" (default) keeps the current --dangerously-skip-permissions behavior. "auto" emits --permission-mode auto which activates the Claude Code auto-mode classifier (blocks destructive ops such as rm -rf $HOME, force-push, terraform destroy). Empty treated as "bypass". |
-| `agent.dispatch_jitter_ms` | `int` |  | DispatchJitterMs bounds a uniform random delay applied before headless agent dispatch, so a wave of concurrently ready tasks does not all probe the provider health gate in the same tick. 0 disables jitter. Never applied to interactive/chat dispatch. Default 0 (opt-in). |
+| `agent.dispatch_jitter_ms` | `int` | `1000` | DispatchJitterMs bounds a uniform random delay applied before headless agent dispatch, so a wave of concurrently ready tasks does not all probe the provider health gate in the same tick. 0 disables jitter. Never applied to interactive/chat dispatch. Default 1000 — set 0 to disable. |
 
 ## TestingConfig (`testing`)
 

--- a/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
+++ b/frontend/bindings/github.com/Automaat/sybra/internal/config/models.ts
@@ -102,7 +102,8 @@ export class AgentDefaults {
      * DispatchJitterMs bounds a uniform random delay applied before headless
      * agent dispatch, so a wave of concurrently ready tasks does not all
      * probe the provider health gate in the same tick. 0 disables jitter.
-     * Never applied to interactive/chat dispatch. Default 0 (opt-in).
+     * Never applied to interactive/chat dispatch. Default 1000 — set 0 to
+     * disable.
      */
     "dispatchJitterMs": number;
 

--- a/internal/config/config_agent.go
+++ b/internal/config/config_agent.go
@@ -62,6 +62,7 @@ type AgentDefaults struct {
 	// DispatchJitterMs bounds a uniform random delay applied before headless
 	// agent dispatch, so a wave of concurrently ready tasks does not all
 	// probe the provider health gate in the same tick. 0 disables jitter.
-	// Never applied to interactive/chat dispatch. Default 0 (opt-in).
+	// Never applied to interactive/chat dispatch. Default 1000 — set 0 to
+	// disable.
 	DispatchJitterMs int `yaml:"dispatch_jitter_ms" json:"dispatchJitterMs"`
 }

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -290,10 +290,10 @@ func DefaultConfig() *Config {
 		},
 		Agent: AgentDefaults{
 			Provider:         "claude",
-			MaxConcurrent:    100,
+			MaxConcurrent:    25,
 			MaxCostUSD:       5.0,
 			MaxTurns:         150,
-			DispatchJitterMs: 0,
+			DispatchJitterMs: 1000,
 		},
 		Notification: NotificationConfig{
 			Desktop: true,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -105,13 +105,14 @@ func TestLoadProviderDefaultAndPersistedValue(t *testing.T) {
 }
 
 // TestDefaultDispatchJitterAndInFlightCap locks in the jitter/soft-cap
-// defaults: both off (0) by default so existing deployments upgrade with no
-// behavior change; operators must opt in to either knob.
+// defaults: jitter defaults on (1000ms) to spread dispatch against a shared
+// subscription's rate limit; the in-flight soft-cap stays off (0) so
+// existing deployments upgrade with no behavior change there.
 func TestDefaultDispatchJitterAndInFlightCap(t *testing.T) {
 	t.Parallel()
 	cfg := DefaultConfig()
-	if cfg.Agent.DispatchJitterMs != 0 {
-		t.Errorf("Agent.DispatchJitterMs = %d, want 0 (disabled)", cfg.Agent.DispatchJitterMs)
+	if cfg.Agent.DispatchJitterMs != 1000 {
+		t.Errorf("Agent.DispatchJitterMs = %d, want 1000 (default enabled)", cfg.Agent.DispatchJitterMs)
 	}
 	if cfg.Providers.Limits.MaxInFlightPerProvider != 0 {
 		t.Errorf("Providers.Limits.MaxInFlightPerProvider = %d, want 0 (disabled)", cfg.Providers.Limits.MaxInFlightPerProvider)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -111,6 +111,9 @@ func TestLoadProviderDefaultAndPersistedValue(t *testing.T) {
 func TestDefaultDispatchJitterAndInFlightCap(t *testing.T) {
 	t.Parallel()
 	cfg := DefaultConfig()
+	if cfg.Agent.MaxConcurrent != 25 {
+		t.Errorf("Agent.MaxConcurrent = %d, want 25", cfg.Agent.MaxConcurrent)
+	}
 	if cfg.Agent.DispatchJitterMs != 1000 {
 		t.Errorf("Agent.DispatchJitterMs = %d, want 1000 (default enabled)", cfg.Agent.DispatchJitterMs)
 	}


### PR DESCRIPTION
## Motivation

A single subscription can't sustain 100 concurrent headless agents. `sybra.log` showed 963 rate-limit events and 1,379 stalls with jitter disabled — dispatch waves were all probing the provider health gate in the same tick.

## Implementation information

- Lower `agent.max_concurrent` default from 100 to 25.
- Enable `agent.dispatch_jitter_ms` by default (1000ms) instead of opt-in (0), spreading dispatch to reduce rate-limit storms.
- Update `TestDefaultDispatchJitterAndInFlightCap` to lock in the new default; `MaxInFlightPerProvider` soft-cap stays off (0) for upgrade compatibility.
- Regenerate `docs/CONFIG.md` and the config bindings to match.

Closes https://github.com/Automaat/sybra/issues/1484

_Generated by Sybra harness_