### PR TITLE
feat(project): strengthen verify gate to mirror CI

### DIFF
--- a/.sybra.yaml
+++ b/.sybra.yaml
@@ -57,6 +57,6 @@ checks:
   verify:
     - mise exec -- bash scripts/check-api-shim-sync.sh
     - mise exec -- go test ./internal/... ./cmd/...
-    - (cd frontend && npm run build:web)
-    - (cd frontend && npm run test:coverage)
+    - (cd frontend && mise exec -- npm run build:web)
+    - (cd frontend && mise exec -- npm run test:coverage)
     - mise exec -- go test -tags e2e -short -timeout 4m ./internal/sybra/...

--- a/.sybra.yaml
+++ b/.sybra.yaml
@@ -40,10 +40,23 @@ checks:
     - (cd frontend && npm run check)
   # Verify suite run by the verify_checks workflow step (reward-hacking
   # phase 2): runs on the agent's branch HEAD before review so an
-  # implementation that does not pass its own tests cannot reach a PR. Scoped
-  # to ./internal/... ./cmd/... because the root package's
-  # //go:embed all:frontend/dist needs a frontend build that worktrees don't
-  # run; the internal+cmd packages compile without it and hold the logic under
-  # test.
+  # implementation that does not pass its own tests cannot reach a PR. This
+  # is a portable, deterministic, read-only, sub-10-minute subset of the CI
+  # gate (.github/workflows/ci.yml) — chosen to catch the CI failure classes
+  # that dominate first-pass failures (api-shim drift, frontend coverage
+  # thresholds, and the e2e suite that plain `go test ./...` skips) without
+  # depending on darwin-only tooling or mutating tracked files. CI remains
+  # the source of truth for what this list excludes: Wails bindings
+  # generation (darwin/wails3-only), `-race` and full e2e (too slow for a
+  # pre-review gate), `go mod tidy`/npm lockfile drift, security scans, and
+  # browser-driven Playwright e2e. `hadolint` and `npm run check` are already
+  # covered by pre_commit/pre_push above and are not duplicated here.
+  # Ordered cheap-to-expensive; measured all-pass wall-clock on a dev
+  # machine is ~3 minutes, well under the shared 10-minute
+  # verifyChecksDefaultTimeout.
   verify:
+    - mise exec -- bash scripts/check-api-shim-sync.sh
     - mise exec -- go test ./internal/... ./cmd/...
+    - (cd frontend && npm run build:web)
+    - (cd frontend && npm run test:coverage)
+    - mise exec -- go test -tags e2e -short -timeout 4m ./internal/sybra/...


### PR DESCRIPTION
## Motivation

The verify gate (`.sybra.yaml` `checks.verify`) only ran `go test` on `internal/...` and `cmd/...`, missing the CI failure classes that actually dominate first-pass failures: api-shim drift, frontend coverage thresholds, and the e2e suite that plain `go test ./...` skips entirely. Implementations were reaching PR review with issues CI would have caught immediately.

## Implementation information

Extended `checks.verify` in `.sybra.yaml` with a portable, deterministic, sub-10-minute subset of the CI gate, ordered cheap-to-expensive:

- `scripts/check-api-shim-sync.sh` — catches api-shim drift
- `go test ./internal/... ./cmd/...` — existing check
- `frontend && npm run build:web` — frontend build verification
- `frontend && npm run test:coverage` — frontend coverage thresholds
- `go test -tags e2e -short -timeout 4m ./internal/sybra/...` — e2e smoke subset

Deliberately excludes Wails bindings generation (darwin/wails3-only), `-race` and full e2e (too slow for a pre-review gate), `go mod tidy`/npm lockfile drift, security scans, and browser-driven Playwright e2e — CI remains the source of truth for those.

Closes https://github.com/Automaat/sybra/issues/1483

_Generated by Sybra harness_