### PR TITLE
fix(workflow): re-probe live PR before human-required

### DIFF
--- a/internal/github/check_filter.go
+++ b/internal/github/check_filter.go
@@ -138,7 +138,7 @@ func rollupFromContexts(contexts []gqlCheckContext) (ciStatus string, hasPending
 
 	var sawCounted, sawFailure, sawPending, sawSuccess bool
 	for i := range contexts {
-		if isNonGatingCheck(contexts[i].Name) {
+		if isNonGatingCheck(contexts[i].effectiveName()) {
 			continue
 		}
 		state := effectiveCheckState(contexts[i])

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -175,15 +175,28 @@ const prQuery = `query($q: String!) {
 }`
 
 // gqlCheckContext captures both `CheckRun` and `StatusContext` shapes from
-// the StatusCheckRollup contexts edge. The GraphQL query aliases
-// `StatusContext.context` → `name` and only `CheckRun` populates
-// status/conclusion, so callers must dispatch on Typename.
+// the StatusCheckRollup contexts edge. The prQuery GraphQL fragment in this
+// file aliases `StatusContext.context` → `name`, but `gh pr view --json
+// statusCheckRollup` (used by FetchPRState) emits the raw field name
+// `context` instead — both are captured so effectiveName() works for either
+// source. Only `CheckRun` populates status/conclusion, so callers must
+// dispatch on Typename.
 type gqlCheckContext struct {
 	Typename   string `json:"__typename"`
 	Name       string `json:"name"`
+	Context    string `json:"context"`    // StatusContext, non-GraphQL-aliased sources only
 	Status     string `json:"status"`     // CheckRun only: QUEUED|IN_PROGRESS|COMPLETED|...
 	Conclusion string `json:"conclusion"` // CheckRun only: SUCCESS|FAILURE|NEUTRAL|...
 	State      string `json:"state"`      // StatusContext only: PENDING|SUCCESS|FAILURE|ERROR|EXPECTED
+}
+
+// effectiveName returns the check's display name regardless of which JSON
+// shape populated it (GraphQL-aliased `name`, or raw `context`).
+func (c gqlCheckContext) effectiveName() string {
+	if c.Name != "" {
+		return c.Name
+	}
+	return c.Context
 }
 
 type gqlStatusCheckRollup struct {

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -27,12 +27,18 @@ type PRStats struct {
 
 // PRState holds the current state of a specific PR.
 type PRState struct {
-	State             string `json:"state"`     // OPEN, CLOSED, MERGED
-	MergedAt          string `json:"mergedAt"`  // non-empty if merged
-	Mergeable         string `json:"mergeable"` // MERGEABLE, CONFLICTING, UNKNOWN
-	StatusCheckRollup []struct {
-		State string `json:"state"` // SUCCESS, FAILURE, PENDING, ERROR, etc.
-	} `json:"statusCheckRollup"`
+	State     string `json:"state"`     // OPEN, CLOSED, MERGED
+	MergedAt  string `json:"mergedAt"`  // non-empty if merged
+	Mergeable string `json:"mergeable"` // MERGEABLE, CONFLICTING, UNKNOWN
+	// StatusCheckRollup entries come back as one of two shapes depending on
+	// whether the check is a legacy commit status (StatusContext, carries
+	// `state`) or a GitHub Actions/App check run (CheckRun, carries
+	// `status`/`conclusion` instead — CheckRun never sets `state`).
+	// gqlCheckContext (shared with the GraphQL search path in client.go) and
+	// effectiveCheckState/rollupFromContexts already normalize both shapes
+	// and filter non-gating reporters (codecov, sonarcloud); reuse them here
+	// instead of re-deriving the dispatch logic.
+	StatusCheckRollup []gqlCheckContext `json:"statusCheckRollup"`
 	// BaseRefName is the PR's target branch.
 	BaseRefName string `json:"baseRefName"`
 	// AutoMergeEnabled reports whether GitHub's native auto-merge is armed,
@@ -41,24 +47,18 @@ type PRState struct {
 }
 
 // CIStatus returns a simplified CI status: SUCCESS, FAILURE, PENDING, or "".
-// FAILURE takes precedence over PENDING.
+// FAILURE takes precedence over PENDING. Delegates to rollupFromContexts so
+// CheckRun-shaped entries (status/conclusion, no state) classify the same
+// way here as they do for the GraphQL search/monitor path in client.go.
 func (s PRState) CIStatus() string {
-	if len(s.StatusCheckRollup) == 0 {
-		return ""
-	}
-	hasPending := false
-	for _, c := range s.StatusCheckRollup {
-		switch c.State {
-		case "FAILURE", "ERROR":
-			return "FAILURE"
-		case "PENDING", "QUEUED", "IN_PROGRESS", "WAITING", "STALE":
-			hasPending = true
-		}
-	}
-	if hasPending {
-		return "PENDING"
-	}
-	return "SUCCESS"
+	status, _ := rollupFromContexts(s.StatusCheckRollup)
+	return status
+}
+
+// HasPendingChecks reports whether any gating check is still running.
+func (s PRState) HasPendingChecks() bool {
+	_, pending := rollupFromContexts(s.StatusCheckRollup)
+	return pending
 }
 
 // ReadyToMerge reports whether the PR is open, has no conflicts, and CI passes.

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -68,6 +68,17 @@ func (s PRState) ReadyToMerge() bool {
 		(s.CIStatus() == "SUCCESS" || s.CIStatus() == "")
 }
 
+// Resolved reports whether this PR needs no further pr-fix action: it
+// merged, or it's open with green CI and no merge conflicts. An abandoned
+// (unmerged) close is NOT resolved — unlike a stale-worktree-vs-green-remote
+// false positive, a human genuinely needs to decide what happens to the task
+// now. Callers use this to re-probe the live PR before parking a task
+// human-required on a stale/diverged local worktree — an external bot may
+// have force-pushed a fix since the last poll, leaving nothing left to do.
+func (s PRState) Resolved() bool {
+	return s.State == "MERGED" || s.ReadyToMerge()
+}
+
 // PRFiles holds the list of files changed by a PR.
 type PRFiles struct {
 	Files []struct {

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -82,15 +82,71 @@ func TestPRState_CIStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			checks := make([]struct {
-				State string `json:"state"`
-			}, len(tt.checks))
+			checks := make([]gqlCheckContext, len(tt.checks))
 			for i, c := range tt.checks {
-				checks[i].State = c.State
+				checks[i] = gqlCheckContext{Typename: "StatusContext", State: c.State}
 			}
 			s := PRState{StatusCheckRollup: checks}
 			if got := s.CIStatus(); got != tt.want {
 				t.Errorf("CIStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPRState_CIStatus_CheckRunShape verifies the GitHub-Actions/App
+// CheckRun shape (`status`/`conclusion`, no `state`) classifies the same as
+// the legacy StatusContext shape — this is the exact shape `gh pr view
+// --json statusCheckRollup` emits for Actions-based CI, and the shape a
+// prior implementation of this task's fix mishandled (see task b569bcef
+// test failure: CheckRun entries parsed as permanently SUCCESS because only
+// `state` was read).
+func TestPRState_CIStatus_CheckRunShape(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		checks []gqlCheckContext
+		want   string
+	}{
+		{"no checks", nil, ""},
+		{
+			"all completed success",
+			[]gqlCheckContext{{Typename: "CheckRun", Status: "COMPLETED", Conclusion: "SUCCESS"}},
+			"SUCCESS",
+		},
+		{
+			"in progress is pending, not success",
+			[]gqlCheckContext{{Typename: "CheckRun", Status: "IN_PROGRESS", Conclusion: ""}},
+			"PENDING",
+		},
+		{
+			"queued is pending",
+			[]gqlCheckContext{{Typename: "CheckRun", Status: "QUEUED"}},
+			"PENDING",
+		},
+		{
+			"completed failure",
+			[]gqlCheckContext{{Typename: "CheckRun", Status: "COMPLETED", Conclusion: "FAILURE"}},
+			"FAILURE",
+		},
+		{
+			"failure beats pending across mixed shapes",
+			[]gqlCheckContext{
+				{Typename: "CheckRun", Status: "IN_PROGRESS"},
+				{Typename: "CheckRun", Status: "COMPLETED", Conclusion: "FAILURE"},
+			},
+			"FAILURE",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			s := PRState{StatusCheckRollup: tt.checks}
+			if got := s.CIStatus(); got != tt.want {
+				t.Errorf("CIStatus() = %q, want %q", got, tt.want)
+			}
+			if tt.want == "PENDING" && !s.HasPendingChecks() {
+				t.Errorf("HasPendingChecks() = false, want true for PENDING status")
 			}
 		})
 	}
@@ -104,18 +160,12 @@ func TestPRState_ReadyToMerge(t *testing.T) {
 		wantReady bool
 	}{
 		{"open mergeable no ci", PRState{State: "OPEN", Mergeable: "MERGEABLE"}, true},
-		{"open mergeable ci success", PRState{State: "OPEN", Mergeable: "MERGEABLE", StatusCheckRollup: []struct {
-			State string `json:"state"`
-		}{{"SUCCESS"}}}, true},
+		{"open mergeable ci success", PRState{State: "OPEN", Mergeable: "MERGEABLE", StatusCheckRollup: []gqlCheckContext{{Typename: "StatusContext", State: "SUCCESS"}}}, true},
 		{"not open", PRState{State: "MERGED", Mergeable: "MERGEABLE"}, false},
 		{"conflicting", PRState{State: "OPEN", Mergeable: "CONFLICTING"}, false},
 		{"unknown mergeable", PRState{State: "OPEN", Mergeable: "UNKNOWN"}, false},
-		{"ci failing", PRState{State: "OPEN", Mergeable: "MERGEABLE", StatusCheckRollup: []struct {
-			State string `json:"state"`
-		}{{"FAILURE"}}}, false},
-		{"ci pending", PRState{State: "OPEN", Mergeable: "MERGEABLE", StatusCheckRollup: []struct {
-			State string `json:"state"`
-		}{{"PENDING"}}}, false},
+		{"ci failing", PRState{State: "OPEN", Mergeable: "MERGEABLE", StatusCheckRollup: []gqlCheckContext{{Typename: "StatusContext", State: "FAILURE"}}}, false},
+		{"ci pending", PRState{State: "OPEN", Mergeable: "MERGEABLE", StatusCheckRollup: []gqlCheckContext{{Typename: "StatusContext", State: "PENDING"}}}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -141,12 +191,8 @@ func TestPRState_Resolved(t *testing.T) {
 		{"closed", PRState{State: "CLOSED"}, false},
 		{"open ready to merge", PRState{State: "OPEN", Mergeable: "MERGEABLE"}, true},
 		{"open conflicting", PRState{State: "OPEN", Mergeable: "CONFLICTING"}, false},
-		{"open ci pending", PRState{State: "OPEN", Mergeable: "MERGEABLE", StatusCheckRollup: []struct {
-			State string `json:"state"`
-		}{{"PENDING"}}}, false},
-		{"open ci failing", PRState{State: "OPEN", Mergeable: "MERGEABLE", StatusCheckRollup: []struct {
-			State string `json:"state"`
-		}{{"FAILURE"}}}, false},
+		{"open ci pending", PRState{State: "OPEN", Mergeable: "MERGEABLE", StatusCheckRollup: []gqlCheckContext{{Typename: "StatusContext", State: "PENDING"}}}, false},
+		{"open ci failing", PRState{State: "OPEN", Mergeable: "MERGEABLE", StatusCheckRollup: []gqlCheckContext{{Typename: "StatusContext", State: "FAILURE"}}}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/github/pr_test.go
+++ b/internal/github/pr_test.go
@@ -127,6 +127,37 @@ func TestPRState_ReadyToMerge(t *testing.T) {
 	}
 }
 
+func TestPRState_Resolved(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		state        PRState
+		wantResolved bool
+	}{
+		{"merged", PRState{State: "MERGED"}, true},
+		// An abandoned (unmerged) close is NOT treated as resolved: unlike a
+		// stale-worktree-vs-green-remote false positive, a human genuinely needs
+		// to decide what happens to the task now.
+		{"closed", PRState{State: "CLOSED"}, false},
+		{"open ready to merge", PRState{State: "OPEN", Mergeable: "MERGEABLE"}, true},
+		{"open conflicting", PRState{State: "OPEN", Mergeable: "CONFLICTING"}, false},
+		{"open ci pending", PRState{State: "OPEN", Mergeable: "MERGEABLE", StatusCheckRollup: []struct {
+			State string `json:"state"`
+		}{{"PENDING"}}}, false},
+		{"open ci failing", PRState{State: "OPEN", Mergeable: "MERGEABLE", StatusCheckRollup: []struct {
+			State string `json:"state"`
+		}{{"FAILURE"}}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.state.Resolved(); got != tt.wantResolved {
+				t.Errorf("Resolved() = %v, want %v", got, tt.wantResolved)
+			}
+		})
+	}
+}
+
 func TestFetchPRFilesWith(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/sybra/agentorch/agentorch.go
+++ b/internal/sybra/agentorch/agentorch.go
@@ -489,12 +489,30 @@ func (o *Orchestrator) resetWorktreeForCleanRetry(t task.Task, ref string) error
 // retry budget is spent) do we fall back to human-required. recoverConflict may
 // be nil (callers without a PR-monitor handle), which preserves the old
 // escalate-to-human behaviour.
+//
+// Before parking, re-probes the task's linked PR (if any): a rebase failure
+// can mean the local branch merely diverged from a remote an external bot
+// already force-pushed a green fix onto, in which case there is genuinely
+// nothing left to fix and human-required would be a false park. Only reached
+// when recoverConflict declined/is absent — the common case re-dispatches a
+// conflict pr-fix, whose own agent run flows through execRoutePRFixResult's
+// equivalent re-probe.
 func MarkRebaseBlocked(tasks *task.Manager, taskID string, err error, logger *slog.Logger, recoverConflict func(string) bool) bool {
 	if !errors.Is(err, worktree.ErrRebaseFailed) {
 		return false
 	}
 	if recoverConflict != nil && recoverConflict(taskID) {
 		logger.Info("worktree.rebase-block.recovered-as-conflict", "task_id", taskID)
+		return true
+	}
+	if reason, resolved := rebaseBlockedPRAlreadyResolved(tasks, taskID); resolved {
+		if _, uerr := tasks.Update(taskID, task.Update{
+			Status:       task.Ptr(task.StatusInReview),
+			StatusReason: task.Ptr(reason),
+		}); uerr != nil {
+			logger.Error("worktree.rebase-block.status", "task_id", taskID, "err", uerr)
+		}
+		logger.Info("worktree.rebase-block.already-resolved", "task_id", taskID)
 		return true
 	}
 	reason := worktreeerr.RebaseBlockedReason
@@ -505,6 +523,24 @@ func MarkRebaseBlocked(tasks *task.Manager, taskID string, err error, logger *sl
 		logger.Error("worktree.rebase-block.status", "task_id", taskID, "err", uerr)
 	}
 	return true
+}
+
+// fetchPRStateForRebaseBlock is overridable in tests to avoid shelling out to `gh`.
+var fetchPRStateForRebaseBlock = github.FetchPRState
+
+// rebaseBlockedPRAlreadyResolved re-probes the task's linked PR when a rebase
+// failure has no autonomous recovery path. A fetch error or an unlinked PR
+// falls through to the normal human-required park.
+func rebaseBlockedPRAlreadyResolved(tasks *task.Manager, taskID string) (reason string, resolved bool) {
+	t, err := tasks.Get(taskID)
+	if err != nil || t.ProjectID == "" || t.PRNumber == 0 {
+		return "", false
+	}
+	state, err := fetchPRStateForRebaseBlock(t.ProjectID, t.PRNumber)
+	if err != nil || !state.Resolved() {
+		return "", false
+	}
+	return fmt.Sprintf("worktree rebase-blocked: PR #%d already resolved on remote", t.PRNumber), true
 }
 
 // MarkRebaseBlockedWithRecoveryResult behaves like MarkRebaseBlocked but also

--- a/internal/sybra/agentorch/rebase_block_test.go
+++ b/internal/sybra/agentorch/rebase_block_test.go
@@ -1,0 +1,132 @@
+package agentorch
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/Automaat/sybra/internal/github"
+	"github.com/Automaat/sybra/internal/task"
+	"github.com/Automaat/sybra/internal/worktree"
+	"github.com/Automaat/sybra/internal/worktreeerr"
+)
+
+func newRebaseBlockTestManager(t *testing.T) *task.Manager {
+	t.Helper()
+	store, err := task.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return task.NewManager(store, nil)
+}
+
+func discardSlogLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+// TestMarkRebaseBlocked_ReProbesResolvedRemotePR pins the second half of the
+// bug report: when there is no autonomous conflict-recovery callback (or it
+// declined), a rebase failure must still re-probe the task's linked PR before
+// parking human-required — an external bot may have already force-pushed a
+// green fix onto a PR the local worktree merely diverged from.
+func TestMarkRebaseBlocked_ReProbesResolvedRemotePR(t *testing.T) {
+	orig := fetchPRStateForRebaseBlock
+	defer func() { fetchPRStateForRebaseBlock = orig }()
+	fetchPRStateForRebaseBlock = func(repo string, number int) (github.PRState, error) {
+		if repo != "acme/widgets" || number != 42 {
+			t.Fatalf("unexpected fetch: %s#%d", repo, number)
+		}
+		return github.PRState{State: "OPEN", Mergeable: "MERGEABLE"}, nil
+	}
+
+	tasks := newRebaseBlockTestManager(t)
+	tk, err := tasks.Create("pr-fix task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectID := "acme/widgets"
+	prNumber := 42
+	if _, err := tasks.Update(tk.ID, task.Update{ProjectID: &projectID, PRNumber: &prNumber}); err != nil {
+		t.Fatal(err)
+	}
+
+	handled := MarkRebaseBlocked(tasks, tk.ID, worktree.ErrRebaseFailed, discardSlogLogger(), nil)
+	if !handled {
+		t.Fatal("MarkRebaseBlocked = false, want true (handled)")
+	}
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusInReview {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusInReview)
+	}
+}
+
+// TestMarkRebaseBlocked_ParksHumanRequiredWhenNotResolved is the control:
+// an unresolved remote PR (or fetch failure) still parks human-required, and
+// a nil recoverConflict is not treated as automatic recovery.
+func TestMarkRebaseBlocked_ParksHumanRequiredWhenNotResolved(t *testing.T) {
+	orig := fetchPRStateForRebaseBlock
+	defer func() { fetchPRStateForRebaseBlock = orig }()
+	fetchPRStateForRebaseBlock = func(repo string, number int) (github.PRState, error) {
+		return github.PRState{State: "OPEN", Mergeable: "CONFLICTING"}, nil
+	}
+
+	tasks := newRebaseBlockTestManager(t)
+	tk, err := tasks.Create("pr-fix task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectID := "acme/widgets"
+	prNumber := 42
+	if _, err := tasks.Update(tk.ID, task.Update{ProjectID: &projectID, PRNumber: &prNumber}); err != nil {
+		t.Fatal(err)
+	}
+
+	handled := MarkRebaseBlocked(tasks, tk.ID, worktree.ErrRebaseFailed, discardSlogLogger(), nil)
+	if !handled {
+		t.Fatal("MarkRebaseBlocked = false, want true (handled)")
+	}
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusHumanRequired)
+	}
+	if got.StatusReason != worktreeerr.RebaseBlockedReason {
+		t.Fatalf("reason = %q, want %q", got.StatusReason, worktreeerr.RebaseBlockedReason)
+	}
+}
+
+// TestMarkRebaseBlocked_NoLinkedPRParksHumanRequired covers a task with no
+// project/PR: the resolved-probe must be skipped, not mistaken for resolved.
+func TestMarkRebaseBlocked_NoLinkedPRParksHumanRequired(t *testing.T) {
+	orig := fetchPRStateForRebaseBlock
+	defer func() { fetchPRStateForRebaseBlock = orig }()
+	fetchPRStateForRebaseBlock = func(repo string, number int) (github.PRState, error) {
+		t.Fatal("fetchPRStateForRebaseBlock should not be called without a linked PR")
+		return github.PRState{}, nil
+	}
+
+	tasks := newRebaseBlockTestManager(t)
+	tk, err := tasks.Create("no pr task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handled := MarkRebaseBlocked(tasks, tk.ID, worktree.ErrRebaseFailed, discardSlogLogger(), nil)
+	if !handled {
+		t.Fatal("MarkRebaseBlocked = false, want true (handled)")
+	}
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusHumanRequired {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusHumanRequired)
+	}
+}

--- a/internal/sybra/app_init.go
+++ b/internal/sybra/app_init.go
@@ -665,6 +665,7 @@ func (a *App) initWorkflowEngine() {
 		a.logger,
 	)
 	a.workflowEngine.SetPRLinker(prLinkerAdapter{})
+	a.workflowEngine.SetPRStateFetcher(prStateFetcherAdapter{})
 	a.workflowEngine.SetPRReviewRequester(prReviewRequesterAdapter{})
 	a.workflowEngine.SetWorktreeGetter(&worktreeGetterAdapter{tasks: a.tasks, mgr: a.worktrees})
 	a.workflowEngine.SetBranchSyncer(&branchSyncerAdapter{tasks: a.tasks, mgr: a.worktrees})

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -26,6 +26,7 @@ var (
 	_ workflow.TaskProvider           = (*taskAdapter)(nil)
 	_ workflow.AgentLauncher          = (*agentAdapter)(nil)
 	_ workflow.PRLinker               = (*prLinkerAdapter)(nil)
+	_ workflow.PRStateFetcher         = (*prStateFetcherAdapter)(nil)
 	_ workflow.PRReviewRequester      = (*prReviewRequesterAdapter)(nil)
 	_ workflow.WorktreeGetter         = (*worktreeGetterAdapter)(nil)
 	_ workflow.BranchSyncer           = (*branchSyncerAdapter)(nil)
@@ -245,6 +246,14 @@ func (prLinkerAdapter) GetClosingIssues(repo string, prNumber int) (issues []int
 
 func (prLinkerAdapter) EditBody(repo string, prNumber int, body string) error {
 	return github.EditPRBody(repo, prNumber, body)
+}
+
+// prStateFetcherAdapter wires the workflow engine's PRStateFetcher interface
+// to the github package. Stateless — all state lives in `gh` / GitHub.
+type prStateFetcherAdapter struct{}
+
+func (prStateFetcherAdapter) FetchPRState(repo string, number int) (github.PRState, error) {
+	return github.FetchPRState(repo, number)
 }
 
 // prReviewRequesterAdapter asks users who left actionable PR feedback to

--- a/internal/workflow/builtin/pr-fix.yaml
+++ b/internal/workflow/builtin/pr-fix.yaml
@@ -31,7 +31,11 @@ steps:
 
   # Mechanical check (no LLM): if the pr-fix agent deliberately stopped and
   # requested human review (for example too many merge conflicts), preserve that
-  # escalation before PR relinking can move the task back to in-review.
+  # escalation before PR relinking can move the task back to in-review. Before
+  # parking, re-probes the live PR: a stale/diverged local worktree can cause a
+  # false human-required when an external bot already pushed a green fix
+  # remotely — in that case the step sets in-review itself and ends the
+  # workflow here too.
   - id: route_pr_fix_result
     name: Route PR Fix Result
     type: route_pr_fix_result
@@ -40,6 +44,11 @@ steps:
           field: task.status
           operator: equals
           value: human-required
+        goto: ""
+      - when:
+          field: task.status
+          operator: equals
+          value: in-review
         goto: ""
       - goto: verify_commits
 

--- a/internal/workflow/engine.go
+++ b/internal/workflow/engine.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Automaat/sybra/internal/abtest"
+	"github.com/Automaat/sybra/internal/github"
 	"github.com/Automaat/sybra/internal/logging"
 	"github.com/Automaat/sybra/internal/prompteval"
 )
@@ -159,6 +160,16 @@ type PRReviewRequester interface {
 	RerequestReview(repo string, prNumber int) (reviewers []string, err error)
 }
 
+// PRStateFetcher fetches the live state of a GitHub pull request. Used by
+// `route_pr_fix_result` to re-probe the remote PR before parking a task
+// human-required — a pr-fix agent that declined to push because its local
+// worktree was stale/diverged may be sitting on a PR an external bot already
+// fixed. Engine operates with a nil fetcher — the re-probe is then skipped
+// and the agent's sentinel is trusted as-is, so tests don't need to wire one.
+type PRStateFetcher interface {
+	FetchPRState(repo string, number int) (github.PRState, error)
+}
+
 // ArtifactRecorder stores per-task workflow artifacts (plan snapshots, trace
 // events). Engine operates with a nil recorder — all recorder calls are
 // guarded by nil checks so engine unit tests compile and pass unchanged.
@@ -193,6 +204,7 @@ type Engine struct {
 	agents          AgentLauncher
 	prLinker        PRLinker
 	prReviewers     PRReviewRequester
+	prStates        PRStateFetcher
 	worktrees       WorktreeGetter
 	branchSyncer    BranchSyncer
 	checks          CheckConfigGetter
@@ -254,6 +266,11 @@ func (e *Engine) SetPRLinker(l PRLinker) { e.prLinker = l }
 
 // SetPRReviewRequester wires an implementation used by rerequest_review.
 func (e *Engine) SetPRReviewRequester(r PRReviewRequester) { e.prReviewers = r }
+
+// SetPRStateFetcher wires an implementation used by `route_pr_fix_result` to
+// re-probe the live PR before parking human-required. Leaving it unset skips
+// the re-probe and trusts the agent's sentinel as-is.
+func (e *Engine) SetPRStateFetcher(f PRStateFetcher) { e.prStates = f }
 
 // SetWorktreeGetter wires a WorktreeGetter used by the `verify_commits` step.
 // Leaving it unset makes the step a no-op.

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -448,7 +448,7 @@ func (e *Engine) execSyncStep(taskID string, step *Step, wfExec *Execution, ctx 
 	case StepVerifyChecks:
 		return e.execVerifyChecks(taskID, step, t)
 	case StepRoutePRFixResult:
-		return e.execRoutePRFixResult(taskID, step, wfExec)
+		return e.execRoutePRFixResult(taskID, step, wfExec, t)
 	case StepRouteTestResult:
 		return e.execRouteTestResult(taskID, step, wfExec, t)
 	case StepSyncBranch:

--- a/internal/workflow/engine_steps_prfix.go
+++ b/internal/workflow/engine_steps_prfix.go
@@ -20,16 +20,30 @@ const ReviewHoldParkVar = "review_hold_park"
 
 const reviewHoldParkReason = "review-hold: replies drafted as a pending review — verify & submit on GitHub"
 
-func (e *Engine) execRoutePRFixResult(taskID string, step *Step, wfExec *Execution) (StepOutput, error) {
+func (e *Engine) execRoutePRFixResult(taskID string, step *Step, wfExec *Execution, t TaskInfo) (StepOutput, error) {
 	requiresHuman, reason := prFixRequiresHuman(wfExec)
 	// Deterministic park wins over the sentinel: in push mode the agent pushed
 	// and its own sentinel says `continue`, which must NOT release the hold.
+	reviewHoldForced := false
 	if !requiresHuman && wfExec != nil && wfExec.Variables[ReviewHoldParkVar] == "true" {
 		requiresHuman = true
 		reason = reviewHoldParkReason
+		reviewHoldForced = true
 	}
 	if !requiresHuman {
 		return StepOutput{StepID: step.ID, Status: "completed", Output: "continue"}, nil
+	}
+	// The review-hold park exists because a pending review draft needs a human
+	// to submit it — that's true regardless of the remote PR's CI/mergeable
+	// state, so it must never be waved through by the re-probe below.
+	if !reviewHoldForced {
+		if msg, resolved := e.checkPRAlreadyResolved(taskID, t, reason); resolved {
+			if err := e.tasks.UpdateTaskStatus(taskID, "in-review", msg); err != nil {
+				return StepOutput{}, fmt.Errorf("route pr-fix result: resolved-on-remote: set in-review: %w", err)
+			}
+			e.logger.Info("workflow.pr-fix.resolved-on-remote", "task_id", taskID, "pr", t.PRNumber, "agent_reason", reason)
+			return StepOutput{StepID: step.ID, Status: "completed", Output: msg}, nil
+		}
 	}
 	if reason == "" {
 		reason = "pr-fix agent requested human review"
@@ -39,6 +53,30 @@ func (e *Engine) execRoutePRFixResult(taskID string, step *Step, wfExec *Executi
 	}
 	e.logger.Warn("workflow.pr-fix.human-required", "task_id", taskID, "reason", reason)
 	return StepOutput{StepID: step.ID, Status: "completed", Output: reason}, nil
+}
+
+// checkPRAlreadyResolved re-probes the live PR when the pr-fix agent (or a
+// pre-agent rebase-block) requested human review — the agent may have
+// correctly declined to push because its local worktree was stale/diverged
+// from a remote branch an external bot already force-fixed. A pending run
+// must never count as resolved, so any fetch error falls through to the
+// normal human-required park.
+func (e *Engine) checkPRAlreadyResolved(taskID string, t TaskInfo, agentReason string) (msg string, resolved bool) {
+	if e.prStates == nil || t.ProjectID == "" || t.PRNumber <= 0 {
+		return "", false
+	}
+	state, err := e.prStates.FetchPRState(t.ProjectID, t.PRNumber)
+	if err != nil {
+		e.logger.Warn("workflow.pr-fix.resolved-probe-failed", "task_id", taskID, "pr", t.PRNumber, "err", err)
+		return "", false
+	}
+	if !state.Resolved() {
+		return "", false
+	}
+	if agentReason == "" {
+		agentReason = "pr-fix agent requested human review"
+	}
+	return fmt.Sprintf("pr-fix skipped park: PR #%d already resolved on remote (agent reported: %s)", t.PRNumber, agentReason), true
 }
 
 func prFixRequiresHuman(wfExec *Execution) (requiresHuman bool, reason string) {

--- a/internal/workflow/engine_steps_prfix_test.go
+++ b/internal/workflow/engine_steps_prfix_test.go
@@ -4,7 +4,21 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Automaat/sybra/internal/github"
 )
+
+// scriptedPRStateFetcher returns a fixed state or error for every probe,
+// regardless of repo/number, so tests can pin the "remote already resolved"
+// signal without shelling out to `gh`.
+type scriptedPRStateFetcher struct {
+	state github.PRState
+	err   error
+}
+
+func (f scriptedPRStateFetcher) FetchPRState(string, int) (github.PRState, error) {
+	return f.state, f.err
+}
 
 func TestClassifyPRFixResult(t *testing.T) {
 	t.Parallel()
@@ -94,7 +108,7 @@ func TestExecRoutePRFixResult_HumanRequiredStopsBeforeRelink(t *testing.T) {
 		Workflow: wf,
 	})
 
-	out, err := engine.execRoutePRFixResult("t1", &Step{ID: "route_pr_fix_result"}, wf)
+	out, err := engine.execRoutePRFixResult("t1", &Step{ID: "route_pr_fix_result"}, wf, TaskInfo{ID: "t1", PRNumber: 1178})
 	if err != nil {
 		t.Fatalf("execRoutePRFixResult: %v", err)
 	}
@@ -110,6 +124,90 @@ func TestExecRoutePRFixResult_HumanRequiredStopsBeforeRelink(t *testing.T) {
 	}
 	if reason := tasks.Reason("t1"); !strings.Contains(reason, "Human review is required") {
 		t.Errorf("reason = %q, want agent output excerpt", reason)
+	}
+}
+
+// TestExecRoutePRFixResult_ReProbesResolvedRemotePR pins the bug report's
+// scenario: the pr-fix agent correctly declined to push because its local
+// worktree was stale/diverged, but the remote PR is already green and
+// mergeable (an external bot fixed it out from under the task). The step
+// must re-probe and route to in-review instead of parking human-required.
+func TestExecRoutePRFixResult_ReProbesResolvedRemotePR(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine.SetPRStateFetcher(scriptedPRStateFetcher{state: github.PRState{State: "OPEN", Mergeable: "MERGEABLE"}})
+	wf := &Execution{
+		WorkflowID:  "pr-fix",
+		CurrentStep: "route_pr_fix_result",
+		State:       ExecRunning,
+		StepHistory: []StepRecord{{
+			StepID:    "fix",
+			Status:    "completed",
+			Output:    "Local worktree is diverged from origin; declining to push.\nSYBRA_PR_FIX_RESULT: human-required\n",
+			AgentID:   "agent-1",
+			StartedAt: time.Now(),
+		}},
+	}
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", ProjectID: "acme/widgets", PRNumber: 1178, Workflow: wf})
+
+	out, err := engine.execRoutePRFixResult("t1", &Step{ID: "route_pr_fix_result"}, wf, TaskInfo{ID: "t1", ProjectID: "acme/widgets", PRNumber: 1178})
+	if err != nil {
+		t.Fatalf("execRoutePRFixResult: %v", err)
+	}
+	if out.Output == "continue" {
+		t.Fatal("route output = continue, want resolved-on-remote message")
+	}
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "in-review" {
+		t.Fatalf("status = %q, want in-review", got.Status)
+	}
+}
+
+// TestExecRoutePRFixResult_ReviewHoldParkIgnoresResolvedRemotePR asserts the
+// re-probe never overrides a review-hold park: that park exists because a
+// pending review draft needs a human to submit it, which is orthogonal to
+// whether CI is green.
+func TestExecRoutePRFixResult_ReviewHoldParkIgnoresResolvedRemotePR(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+	engine.SetPRStateFetcher(scriptedPRStateFetcher{state: github.PRState{State: "OPEN", Mergeable: "MERGEABLE"}})
+	wf := &Execution{
+		WorkflowID:  "pr-fix",
+		CurrentStep: "route_pr_fix_result",
+		State:       ExecRunning,
+		StepHistory: []StepRecord{{
+			StepID:    "fix",
+			Status:    "completed",
+			Output:    "Pushed the fix.\nSYBRA_PR_FIX_RESULT: continue",
+			AgentID:   "agent-1",
+			StartedAt: time.Now(),
+		}},
+		Variables: map[string]string{ReviewHoldParkVar: "true"},
+	}
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", ProjectID: "acme/widgets", PRNumber: 1446, Workflow: wf})
+
+	out, err := engine.execRoutePRFixResult("t1", &Step{ID: "route_pr_fix_result"}, wf, TaskInfo{ID: "t1", ProjectID: "acme/widgets", PRNumber: 1446})
+	if err != nil {
+		t.Fatalf("execRoutePRFixResult: %v", err)
+	}
+	if out.Output == "continue" {
+		t.Fatal("route output = continue; review-hold park must force human-required")
+	}
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required (review-hold must not be waved through)", got.Status)
 	}
 }
 
@@ -137,7 +235,7 @@ func TestExecRoutePRFixResult_ReviewHoldParkWinsOverContinue(t *testing.T) {
 	}
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress", PRNumber: 1446, Workflow: wf})
 
-	out, err := engine.execRoutePRFixResult("t1", &Step{ID: "route_pr_fix_result"}, wf)
+	out, err := engine.execRoutePRFixResult("t1", &Step{ID: "route_pr_fix_result"}, wf, TaskInfo{ID: "t1", PRNumber: 1446})
 	if err != nil {
 		t.Fatalf("execRoutePRFixResult: %v", err)
 	}


### PR DESCRIPTION
## Motivation

A stale/diverged local worktree could make the pr-fix agent (or a
worktree-prep rebase) decline to push even when an external bot had
already pushed a green fix to the same PR remotely. That parked the
task in human-required and wasted a human-review agent run on a PR
that needed no further work.

The underlying PR-state check also had a bug: `FetchPRState` only read
the `state` field on `statusCheckRollup` entries, but `gh pr view`
emits GitHub Actions checks as `CheckRun` objects carrying
status/conclusion instead. Those entries parsed as permanently empty,
so `CIStatus()` silently reported SUCCESS for pending or failing CI —
defeating the re-probe's anti-flap guard.

## Implementation information

- `execRoutePRFixResult` and `MarkRebaseBlocked` now re-fetch the live
  PR state and route to `in-review` instead of parking
  `human-required` when the PR is already resolved remotely.
- `FetchPRState`/`CIStatus`/`Resolved` reuse the already-tested
  `gqlCheckContext`/`rollupFromContexts` normalization from the
  GraphQL search path to correctly parse `CheckRun` entries in the PR
  rollup, instead of re-deriving the CheckRun/StatusContext dispatch
  logic a second time.

Closes https://github.com/Automaat/sybra/issues/1481

_Generated by Sybra harness_