### PR TITLE
fix(workflow): block reuse of live-agent worktree

### DIFF
--- a/internal/agent/manager_control.go
+++ b/internal/agent/manager_control.go
@@ -199,6 +199,27 @@ func (m *Manager) HasRunningAgentForTask(taskID string) bool {
 	if _, held := m.dispatchClaims[taskID]; held {
 		return true
 	}
+	return m.hasLiveRegisteredAgent(taskID)
+}
+
+// HasLiveRegisteredAgentForTask reports whether a genuinely registered Agent
+// (already past dispatch setup) is live for taskID — unlike
+// HasRunningAgentForTask, it does NOT treat an in-flight dispatch claim as
+// "running". Used to gate worktree mutation (worktree.AgentChecker) from
+// inside the very dispatch call that holds the claim: that caller already IS
+// the in-flight dispatch, so checking dispatchClaims there would always see
+// its own claim and deadlock against itself. It must instead ask "is some
+// OTHER, already-started agent process still using this worktree?".
+func (m *Manager) HasLiveRegisteredAgentForTask(taskID string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.hasLiveRegisteredAgent(taskID)
+}
+
+// hasLiveRegisteredAgent is the shared core of HasRunningAgentForTask and
+// HasLiveRegisteredAgentForTask. Callers must hold m.mu (read lock is
+// sufficient).
+func (m *Manager) hasLiveRegisteredAgent(taskID string) bool {
 	for _, a := range m.agents {
 		if a.TaskID != taskID {
 			continue

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -655,6 +655,40 @@ func TestClaimTaskDispatch(t *testing.T) {
 	m.ReleaseTaskDispatch("never-claimed")
 }
 
+// TestHasLiveRegisteredAgentForTask_IgnoresOwnDispatchClaim guards against
+// the sybra#1495 self-deadlock: a dispatcher that holds its own dispatch
+// claim while preparing a worktree (StartAgentWithAssignment holds the claim
+// across PrepareForTask) must not see that same claim reported back as "an
+// agent is running" when it asks worktree.PrepareForTask's hasAgent guard
+// whether it's safe to proceed — otherwise no dispatch could ever complete.
+// HasRunningAgentForTask (used elsewhere to gate re-dispatch) intentionally
+// still counts the claim; HasLiveRegisteredAgentForTask must not.
+func TestHasLiveRegisteredAgentForTask_IgnoresOwnDispatchClaim(t *testing.T) {
+	m, _ := newTestManager(t)
+
+	if !m.ClaimTaskDispatch("t1") {
+		t.Fatal("claim should succeed")
+	}
+	defer m.ReleaseTaskDispatch("t1")
+
+	if !m.HasRunningAgentForTask("t1") {
+		t.Error("HasRunningAgentForTask must count the held claim")
+	}
+	if m.HasLiveRegisteredAgentForTask("t1") {
+		t.Error("HasLiveRegisteredAgentForTask must not count the held claim — no agent is registered yet")
+	}
+
+	// Once a real agent is registered under the same task, both must agree.
+	running := &Agent{ID: "a1", TaskID: "t1", State: StateRunning, done: make(chan struct{}), cancel: func() {}}
+	m.mu.Lock()
+	m.agents[running.ID] = running
+	m.mu.Unlock()
+
+	if !m.HasLiveRegisteredAgentForTask("t1") {
+		t.Error("HasLiveRegisteredAgentForTask must report true once a real agent is registered")
+	}
+}
+
 func TestHasOtherRunningAgentForTask(t *testing.T) {
 	m, _ := newTestManager(t)
 

--- a/internal/sybra/agentorch/agentorch.go
+++ b/internal/sybra/agentorch/agentorch.go
@@ -384,6 +384,15 @@ func (o *Orchestrator) StartAgentWithAssignment(taskID, mode, prompt string, inc
 		d, wtErr := o.worktrees.PrepareForTask(context.Background(), t, onPhase)
 		if wtErr != nil {
 			o.failWorktreeOp(opID, wtErr)
+			// A tracked agent is still live in this worktree (see
+			// worktree.PrepareForTask's hasAgent guard) — this is a benign
+			// timing collision with a stale "no agent running" read
+			// upstream, not a real worktree conflict. Wait rather than
+			// escalate; the agent's own completion (or a later ResumeStalled
+			// tick, once it is genuinely idle) drives the workflow forward.
+			if errors.Is(wtErr, worktreeerr.ErrAgentRunning) {
+				return nil, "", workflow.ErrDispatchInFlight
+			}
 			if _, recovered := MarkRebaseBlockedWithRecoveryResult(o.tasks, taskID, wtErr, o.logger, o.conflictRecovery); recovered {
 				return nil, "", workflow.ErrDispatchInFlight
 			}

--- a/internal/sybra/app.go
+++ b/internal/sybra/app.go
@@ -304,6 +304,7 @@ func (a *App) Startup(ctx context.Context) error {
 		LogsDir:          a.logDir,
 		PRBranchResolver: github.FetchPRBranch,
 		AgentChecker:     a.agents.HasRunningAgentForTask,
+		LiveAgentChecker: a.agents.HasLiveRegisteredAgentForTask,
 	})
 	a.sandboxes = sandbox.NewManager(filepath.Join(config.HomeDir(), "sandboxes"), a.logger)
 	a.agentOrch = agentorch.New(a.tasks, a.projects, a.agents, a.audit, a.logger, a.worktrees, a.cfg)

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -2,6 +2,7 @@ package sybra
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -19,6 +20,7 @@ import (
 	"github.com/Automaat/sybra/internal/task"
 	"github.com/Automaat/sybra/internal/workflow"
 	"github.com/Automaat/sybra/internal/worktree"
+	"github.com/Automaat/sybra/internal/worktreeerr"
 )
 
 // Compile-time interface checks.
@@ -495,10 +497,7 @@ func (a *agentAdapter) StartAgent(taskID, role, mode, model, provider, prompt, d
 		// scope for this pass.
 		d, wtErr := a.agentOrch.Worktrees().PrepareForTask(context.Background(), t, nil)
 		if wtErr != nil {
-			if _, recovered := a.agentOrch.RecoverFromWorktreePrepFailure(a.tasks, taskID, wtErr); recovered {
-				return "", "", "", workflow.ErrDispatchInFlight
-			}
-			return "", "", "", wtErr
+			return "", "", "", a.classifyDirectDispatchWorktreeErr(taskID, wtErr)
 		}
 		cfg.Dir = d
 	}
@@ -548,6 +547,22 @@ func (a *agentAdapter) claimDirectDispatch(taskID string) error {
 		return workflow.ErrDispatchInFlight
 	}
 	return nil
+}
+
+// classifyDirectDispatchWorktreeErr translates a PrepareForTask failure from
+// the direct-dispatch path into the error execRunAgent should see. A tracked
+// agent still live in the worktree (worktree.ErrAgentRunning) is a benign
+// timing collision with a stale "no agent running" read upstream, not a real
+// worktree conflict — treat it like ErrDispatchInFlight so the step parks
+// and retries once the agent is genuinely idle, instead of escalating.
+func (a *agentAdapter) classifyDirectDispatchWorktreeErr(taskID string, wtErr error) error {
+	if errors.Is(wtErr, worktreeerr.ErrAgentRunning) {
+		return workflow.ErrDispatchInFlight
+	}
+	if _, recovered := a.agentOrch.RecoverFromWorktreePrepFailure(a.tasks, taskID, wtErr); recovered {
+		return workflow.ErrDispatchInFlight
+	}
+	return wtErr
 }
 
 func (a *agentAdapter) resetWorktreeForRetry(t task.Task, dir, ref string) error {

--- a/internal/sybra/e2e_bootstrap_test.go
+++ b/internal/sybra/e2e_bootstrap_test.go
@@ -157,12 +157,13 @@ func setupBootstrapE2E(t *testing.T, repoSetup, appSetup []string) *bootstrapE2E
 	})
 
 	wm := worktree.New(worktree.Config{
-		WorktreesDir: wtDir,
-		Projects:     projStore,
-		Tasks:        taskMgr,
-		Logger:       logger,
-		LogsDir:      logsDir,
-		AgentChecker: agentMgr.HasRunningAgentForTask,
+		WorktreesDir:     wtDir,
+		Projects:         projStore,
+		Tasks:            taskMgr,
+		Logger:           logger,
+		LogsDir:          logsDir,
+		AgentChecker:     agentMgr.HasRunningAgentForTask,
+		LiveAgentChecker: agentMgr.HasLiveRegisteredAgentForTask,
 	})
 	agentOrch := agentorch.New(taskMgr, projStore, agentMgr, nil, logger, wm, nil)
 

--- a/internal/sybra/orchestrator_resume_test.go
+++ b/internal/sybra/orchestrator_resume_test.go
@@ -118,11 +118,12 @@ updated_at: 2025-01-01T00:00:00Z
 	})
 
 	wm := worktree.New(worktree.Config{
-		WorktreesDir: filepath.Join(home, "worktrees"),
-		Projects:     projStore,
-		Tasks:        taskMgr,
-		Logger:       logger,
-		AgentChecker: agentMgr.HasRunningAgentForTask,
+		WorktreesDir:     filepath.Join(home, "worktrees"),
+		Projects:         projStore,
+		Tasks:            taskMgr,
+		Logger:           logger,
+		AgentChecker:     agentMgr.HasRunningAgentForTask,
+		LiveAgentChecker: agentMgr.HasLiveRegisteredAgentForTask,
 	})
 
 	orch := agentorch.New(taskMgr, projStore, agentMgr, nil, logger, wm, nil)

--- a/internal/sybra/review/fix.go
+++ b/internal/sybra/review/fix.go
@@ -944,6 +944,10 @@ func (r *Handler) prepareWorktree(ctx context.Context, t task.Task, issue github
 		d, wtErr = r.worktrees.PrepareForTask(ctx, t, nil)
 	}
 	if wtErr != nil {
+		if errors.Is(wtErr, worktree.ErrAgentRunning) {
+			r.logger.Warn("pr-monitor.worktree.agent-running", "task_id", t.ID, "err", wtErr)
+			return "", false
+		}
 		// A conflict fix already operates on the non-rebasing PrepareForFix path,
 		// so a rebase failure here can only come from the CI-fix PrepareForTask
 		// branch. Recover by re-routing to the conflict fix unless this already

--- a/internal/sybra/review/unit_test.go
+++ b/internal/sybra/review/unit_test.go
@@ -1297,6 +1297,70 @@ func TestPrepareWorktree_CircuitBreaker(t *testing.T) {
 	}
 }
 
+func TestPrepareWorktree_AgentRunningDoesNotTripCircuitBreaker(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := task.NewStore(filepath.Join(tmp, "tasks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tasks := task.NewManager(store, nil)
+
+	tk, err := tasks.Create("test task", "", string(task.AgentModeHeadless))
+	if err != nil {
+		t.Fatal(err)
+	}
+	projID := "owner/repo"
+	tk, err = tasks.Update(tk.ID, task.Update{ProjectID: task.Ptr(projID)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	projStore, err := project.NewStore(filepath.Join(tmp, "projects"), filepath.Join(tmp, "clones"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wt := worktree.New(worktree.Config{
+		WorktreesDir: filepath.Join(tmp, "worktrees"),
+		Projects:     projStore,
+		Tasks:        tasks,
+		Logger:       slog.New(slog.DiscardHandler),
+		LogsDir:      filepath.Join(tmp, "logs"),
+		LiveAgentChecker: func(string) bool {
+			return true
+		},
+	})
+
+	r := &Handler{
+		logger:     slog.New(slog.DiscardHandler),
+		tasks:      tasks,
+		worktrees:  wt,
+		wtFailures: make(map[string]int),
+	}
+
+	issue := github.PRIssue{
+		Kind:   github.PRIssueCIFailure,
+		TaskID: tk.ID,
+		PR:     github.PullRequest{Number: 1, HeadRefName: "feat/x"},
+	}
+
+	for i := range wtFailureLimit + 1 {
+		_, ok := r.prepareWorktree(context.Background(), tk, issue)
+		if ok {
+			t.Fatalf("call %d: want ok=false while a live agent blocks worktree reuse", i+1)
+		}
+		got, err := tasks.Get(tk.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status == task.StatusHumanRequired {
+			t.Fatalf("call %d: agent-running collision must not escalate to human-required", i+1)
+		}
+		if n := r.wtFailures[tk.ID]; n != 0 {
+			t.Fatalf("call %d: wtFailures[%s] = %d, want 0 for transient live-agent collisions", i+1, tk.ID, n)
+		}
+	}
+}
+
 // TestAllowPreparedWorktree_SetupFailureTripsCircuitBreaker verifies the
 // non-fatal fix-role setup-failure path still contributes to the same
 // per-task circuit breaker as hard worktree-prepare errors.

--- a/internal/workflow/engine_import_sidecar_test.go
+++ b/internal/workflow/engine_import_sidecar_test.go
@@ -155,6 +155,36 @@ func TestImportSidecar_MissingFileWithDirSetStillReportsMissing(t *testing.T) {
 	}
 }
 
+func TestImportSidecar_NonReservedDirTemplateStillReportsMissing(t *testing.T) {
+	store := newTestStoreWith(t, "test-import-required-sidecar-nonreserved-dir.yaml")
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{
+		ID:     "t1",
+		Status: "in-progress",
+		Workflow: &Execution{
+			WorkflowID:  "test-import-required-sidecar-nonreserved-dir",
+			CurrentStep: "review",
+			Variables:   map[string]string{},
+		},
+	})
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+
+	info, _ := tasks.GetTask("t1")
+	engine.importSidecarIfConfigured("t1", "review", info)
+
+	got, _ := tasks.GetTask("t1")
+	if got.Status != "human-required" {
+		t.Fatalf("Status = %q, want human-required", got.Status)
+	}
+	reason := tasks.Reason("t1")
+	if !strings.Contains(reason, "sidecar missing") {
+		t.Fatalf("reason = %q, want plain missing sidecar", reason)
+	}
+	if strings.Contains(reason, "unresolved: worktree dir variable was empty at render time") {
+		t.Fatalf("reason = %q, must not claim reserved _dir was unresolved for a non-reserved path", reason)
+	}
+}
+
 func TestImportSidecar_NoConfigIsNoop(t *testing.T) {
 	store := newTestStore(t) // test-simple.yaml has no import_sidecar
 	tasks := newMemTasks()

--- a/internal/workflow/engine_import_sidecar_test.go
+++ b/internal/workflow/engine_import_sidecar_test.go
@@ -86,6 +86,75 @@ func TestImportSidecar_RequiredMissingFileFlipsHumanRequired(t *testing.T) {
 	}
 }
 
+// TestImportSidecar_EmptyDirVarDistinguishedFromMissing proves the
+// sybra#1495 diagnostic fix: when a sidecar path template references the
+// reserved worktree-dir var (_dir) and that var is empty at render time, the
+// escalation reason says so explicitly instead of the generic "missing" —
+// so an investigator doesn't misread an engine-lost-worktree-dir bug as "the
+// agent never wrote the review".
+func TestImportSidecar_EmptyDirVarDistinguishedFromMissing(t *testing.T) {
+	store := newTestStoreWith(t, "test-import-required-sidecar-dir.yaml")
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{
+		ID:     "t1",
+		Status: "in-progress",
+		Workflow: &Execution{
+			WorkflowID:  "test-import-required-sidecar-dir",
+			CurrentStep: "review",
+			Variables:   map[string]string{}, // _dir never set
+		},
+	})
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+
+	info, _ := tasks.GetTask("t1")
+	engine.importSidecarIfConfigured("t1", "review", info)
+
+	got, _ := tasks.GetTask("t1")
+	if got.Status != "human-required" {
+		t.Fatalf("Status = %q, want human-required", got.Status)
+	}
+	reason := tasks.Reason("t1")
+	if !strings.Contains(reason, "unresolved: worktree dir variable was empty at render time") {
+		t.Fatalf("reason = %q, want empty-dir-var diagnostic, not generic missing", reason)
+	}
+	if strings.Contains(reason, "sidecar missing") {
+		t.Fatalf("reason = %q, must not read as a plain missing sidecar", reason)
+	}
+}
+
+// TestImportSidecar_MissingFileWithDirSetStillReportsMissing proves the new
+// empty-_dir diagnostic in importOneSidecar doesn't shadow the ordinary
+// "agent never wrote the file" case once _dir is genuinely populated.
+func TestImportSidecar_MissingFileWithDirSetStillReportsMissing(t *testing.T) {
+	store := newTestStoreWith(t, "test-import-required-sidecar-dir.yaml")
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{
+		ID:     "t1",
+		Status: "in-progress",
+		Workflow: &Execution{
+			WorkflowID:  "test-import-required-sidecar-dir",
+			CurrentStep: "review",
+			Variables:   map[string]string{"_dir": t.TempDir()},
+		},
+	})
+	engine := NewEngine(store, tasks, newMockAgents(), discardLogger())
+
+	info, _ := tasks.GetTask("t1")
+	engine.importSidecarIfConfigured("t1", "review", info)
+
+	got, _ := tasks.GetTask("t1")
+	if got.Status != "human-required" {
+		t.Fatalf("Status = %q, want human-required", got.Status)
+	}
+	reason := tasks.Reason("t1")
+	if !strings.Contains(reason, "sidecar missing") {
+		t.Fatalf("reason = %q, want plain missing sidecar", reason)
+	}
+	if strings.Contains(reason, "unresolved") {
+		t.Fatalf("reason = %q, must not claim an unresolved dir var when _dir was set", reason)
+	}
+}
+
 func TestImportSidecar_NoConfigIsNoop(t *testing.T) {
 	store := newTestStore(t) // test-simple.yaml has no import_sidecar
 	tasks := newMemTasks()

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"os"
 	"os/exec"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -47,6 +48,8 @@ func (c StepConfig) sidecarImports() []ImportSidecar {
 	return out
 }
 
+var worktreeDirTemplatePattern = regexp.MustCompile(`\{\{\s*getvar\s+\.Vars\s+"` + WorkflowVarDir + `"\s*\}\}`)
+
 func (e *Engine) importOneSidecar(taskID, stepID string, step *Step, info TaskInfo, cfg ImportSidecar) {
 	path, rErr := RenderTemplate(cfg.From, TemplateContext{
 		Task:     info,
@@ -69,7 +72,7 @@ func (e *Engine) importOneSidecar(taskID, stepID string, step *Step, info TaskIn
 			// never produced the artifact — the file may well exist in the
 			// worktree the agent actually ran in. Surface this distinctly so
 			// it isn't misread as "review missing" when investigating.
-			if strings.Contains(cfg.From, WorkflowVarDir) && strings.TrimSpace(info.Workflow.Variables[WorkflowVarDir]) == "" {
+			if worktreeDirTemplatePattern.MatchString(cfg.From) && strings.TrimSpace(info.Workflow.Variables[WorkflowVarDir]) == "" {
 				e.failRequiredImport(taskID, stepID, cfg.Kind, "unresolved: worktree dir variable was empty at render time")
 			} else {
 				e.failRequiredImport(taskID, stepID, cfg.Kind, "missing")

--- a/internal/workflow/engine_steps_agent.go
+++ b/internal/workflow/engine_steps_agent.go
@@ -62,7 +62,18 @@ func (e *Engine) importOneSidecar(taskID, stepID string, step *Step, info TaskIn
 	if readErr != nil {
 		e.logger.Warn("workflow.import-sidecar.read", "task_id", taskID, "step", stepID, "path", path, "err", readErr)
 		if cfg.Required {
-			e.failRequiredImport(taskID, stepID, cfg.Kind, "missing")
+			// A template referencing the reserved worktree-dir var that
+			// rendered empty (e.g. "/.sybra-review-<id>.md" instead of
+			// "<worktree>/.sybra-review-<id>.md") means the engine lost
+			// track of the agent's working directory, not that the agent
+			// never produced the artifact — the file may well exist in the
+			// worktree the agent actually ran in. Surface this distinctly so
+			// it isn't misread as "review missing" when investigating.
+			if strings.Contains(cfg.From, WorkflowVarDir) && strings.TrimSpace(info.Workflow.Variables[WorkflowVarDir]) == "" {
+				e.failRequiredImport(taskID, stepID, cfg.Kind, "unresolved: worktree dir variable was empty at render time")
+			} else {
+				e.failRequiredImport(taskID, stepID, cfg.Kind, "missing")
+			}
 		}
 		return
 	}

--- a/internal/workflow/start_error.go
+++ b/internal/workflow/start_error.go
@@ -48,6 +48,12 @@ func ClassifyAgentStartError(err error) (reason string, permanent bool) {
 	case errors.Is(err, ErrTestRunnerBusy):
 		// Transient: the testing slot frees and ResumeStalled retries. No reason.
 		return "", false
+	case errors.Is(err, worktreeerr.ErrAgentRunning):
+		// Transient: PrepareForTask refused to rebase a worktree a tracked
+		// agent is still live in. The agent's own completion (or a later
+		// ResumeStalled tick once it's genuinely idle) drives the workflow
+		// forward — no reason, no escalation.
+		return "", false
 	case errors.Is(err, project.ErrProjectNotRegistered):
 		permanent = true
 		reason = "agent start blocked: project not registered locally — create the project to resume"
@@ -65,6 +71,7 @@ func ClassifyAgentStartError(err error) (reason string, permanent bool) {
 func transientAgentStartError(err error) bool {
 	return errors.Is(err, ErrDispatchInFlight) ||
 		errors.Is(err, ErrTestRunnerBusy) ||
+		errors.Is(err, worktreeerr.ErrAgentRunning) ||
 		errors.Is(err, provider.ErrProviderUnhealthy)
 }
 

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -90,6 +90,24 @@ func TestClassifyAgentStartError_DispatchInFlightSuppressed(t *testing.T) {
 	}
 }
 
+func TestClassifyAgentStartError_AgentRunningSuppressed(t *testing.T) {
+	// PrepareForTask refusing to reuse a worktree a tracked agent is still
+	// live in (sybra#1495) is benign and self-healing — the agent's own
+	// completion drives the workflow forward. Must yield an empty reason and
+	// be non-permanent, same as ErrDispatchInFlight.
+	wrapped := fmt.Errorf("prepare worktree for reuse: %w", worktreeerr.ErrAgentRunning)
+	reason, permanent := ClassifyAgentStartError(wrapped)
+	if reason != "" {
+		t.Errorf("reason = %q, want empty", reason)
+	}
+	if permanent {
+		t.Error("agent-running must not be permanent")
+	}
+	if !transientAgentStartError(wrapped) {
+		t.Error("transientAgentStartError() = false, want true")
+	}
+}
+
 func TestSurfaceStartFailure_DispatchInFlightIsNoOp(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})

--- a/internal/workflow/testdata/test-import-required-sidecar-dir.yaml
+++ b/internal/workflow/testdata/test-import-required-sidecar-dir.yaml
@@ -1,0 +1,15 @@
+id: test-import-required-sidecar-dir
+name: Test Required Import Sidecar (worktree dir template)
+builtin: false
+steps:
+  - id: review
+    type: run_agent
+    config:
+      role: review
+      mode: headless
+      prompt: review
+      needs_worktree: true
+      import_sidecar:
+        kind: plan_contract
+        from: '{{getvar .Vars "_dir"}}/review.md'
+        required: true

--- a/internal/workflow/testdata/test-import-required-sidecar-nonreserved-dir.yaml
+++ b/internal/workflow/testdata/test-import-required-sidecar-nonreserved-dir.yaml
@@ -1,0 +1,14 @@
+id: test-import-required-sidecar-nonreserved-dir
+name: Test Required Import Sidecar (non-reserved _dir substring)
+builtin: false
+steps:
+  - id: review
+    type: run_agent
+    config:
+      role: review
+      mode: headless
+      prompt: review
+      import_sidecar:
+        kind: plan_contract
+        from: 'build_dir/review.md'
+        required: true

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -40,8 +40,10 @@ type Config struct {
 	// dispatch claim as "running". PrepareForTask/SyncTaskBranch call it from
 	// inside the very dispatch that holds that claim, so a claim-inclusive
 	// check would always see its own claim and refuse to ever prepare.
-	// Defaults to AgentChecker when unset (tests that don't wire it get the
-	// same, safe behavior AgentChecker provides).
+	// Production must wire a claim-exclusive checker (for example
+	// agent.Manager.HasLiveRegisteredAgentForTask). When unset, New falls back
+	// to AgentChecker only for legacy/test harnesses that never hold an
+	// in-flight dispatch claim while preparing the worktree.
 	LiveAgentChecker AgentChecker
 	// MisePath is the path to the mise binary. Defaults to "mise" (PATH lookup).
 	// Tests inject a concrete path so parallel tests don't race on os.Setenv(PATH).

--- a/internal/worktree/manager.go
+++ b/internal/worktree/manager.go
@@ -35,21 +35,30 @@ type Config struct {
 	SetupTimeout     time.Duration
 	PRBranchResolver PRBranchResolver
 	AgentChecker     AgentChecker
+	// LiveAgentChecker reports whether an already-registered agent process is
+	// live for a task — unlike AgentChecker, it must NOT count an in-flight
+	// dispatch claim as "running". PrepareForTask/SyncTaskBranch call it from
+	// inside the very dispatch that holds that claim, so a claim-inclusive
+	// check would always see its own claim and refuse to ever prepare.
+	// Defaults to AgentChecker when unset (tests that don't wire it get the
+	// same, safe behavior AgentChecker provides).
+	LiveAgentChecker AgentChecker
 	// MisePath is the path to the mise binary. Defaults to "mise" (PATH lookup).
 	// Tests inject a concrete path so parallel tests don't race on os.Setenv(PATH).
 	MisePath string
 }
 
 type Manager struct {
-	dir          string
-	projects     *project.Store
-	tasks        *task.Manager
-	logger       *slog.Logger
-	logsDir      string
-	setupTimeout time.Duration
-	prBranch     PRBranchResolver
-	hasAgent     AgentChecker
-	misePath     string
+	dir              string
+	projects         *project.Store
+	tasks            *task.Manager
+	logger           *slog.Logger
+	logsDir          string
+	setupTimeout     time.Duration
+	prBranch         PRBranchResolver
+	hasAgent         AgentChecker
+	hasLiveAgentOnly AgentChecker
+	misePath         string
 }
 
 func New(cfg Config) *Manager {
@@ -62,16 +71,21 @@ func New(cfg Config) *Manager {
 	if mp == "" || (mp != "mise" && !filepath.IsAbs(mp)) {
 		mp = "mise"
 	}
+	liveAgentChecker := cfg.LiveAgentChecker
+	if liveAgentChecker == nil {
+		liveAgentChecker = cfg.AgentChecker
+	}
 	return &Manager{
-		dir:          cfg.WorktreesDir,
-		projects:     cfg.Projects,
-		tasks:        cfg.Tasks,
-		logger:       cfg.Logger,
-		logsDir:      cfg.LogsDir,
-		setupTimeout: timeout,
-		prBranch:     cfg.PRBranchResolver,
-		hasAgent:     cfg.AgentChecker,
-		misePath:     mp,
+		dir:              cfg.WorktreesDir,
+		projects:         cfg.Projects,
+		tasks:            cfg.Tasks,
+		logger:           cfg.Logger,
+		logsDir:          cfg.LogsDir,
+		setupTimeout:     timeout,
+		prBranch:         cfg.PRBranchResolver,
+		hasAgent:         cfg.AgentChecker,
+		hasLiveAgentOnly: liveAgentChecker,
+		misePath:         mp,
 	}
 }
 

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -1064,6 +1064,70 @@ func TestPrepareForTask_ReuseRecreatesOnBranchMismatch(t *testing.T) {
 	}
 }
 
+// TestPrepareForTask_RefusesReuseWhileAgentRunning proves the sybra#1495
+// regression guard: a dispatcher that reaches PrepareForTask for a task
+// whose worktree a tracked agent is still live in (e.g. a stale "no agent
+// running" read racing ResumeStalled) must not rebase that worktree out from
+// under the agent's in-flight edits. It must instead see ErrAgentRunning and
+// leave the worktree untouched.
+func TestPrepareForTask_RefusesReuseWhileAgentRunning(t *testing.T) {
+	h := prepareHarness(t, nil, 30*time.Second)
+
+	tk, err := h.tasks.Store().Create("live agent task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.tasks.Update(tk.ID, task.Update{ProjectID: task.Ptr(h.proj.ID)}); err != nil {
+		t.Fatal(err)
+	}
+	tk, err = h.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wtPath, err := h.m.PrepareForTask(context.Background(), tk, nil)
+	if err != nil {
+		t.Fatalf("initial PrepareForTask: %v", err)
+	}
+	preHEAD, err := project.CurrentCommit(context.Background(), wtPath)
+	if err != nil {
+		t.Fatalf("resolve pre-attempt HEAD: %v", err)
+	}
+
+	// Advance the upstream default branch so a rebase, if it ran, would be
+	// observable (HEAD would move).
+	if err := os.WriteFile(filepath.Join(h.src, "README.md"), []byte("upstream edit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRunInDir(t, h.src, "git", "add", "README.md")
+	mustRunInDir(t, h.src, "git", "commit", "-m", "upstream edit")
+
+	mWithLiveAgent := New(Config{
+		WorktreesDir: h.wtDir,
+		Projects:     h.store,
+		Tasks:        h.tasks,
+		Logger:       discardLogger(),
+		LogsDir:      h.logsDir,
+		AgentChecker: func(taskID string) bool { return taskID == tk.ID },
+	})
+
+	gotPath, err := mWithLiveAgent.PrepareForTask(context.Background(), tk, nil)
+	if !errors.Is(err, ErrAgentRunning) {
+		t.Fatalf("PrepareForTask error = %v, want ErrAgentRunning", err)
+	}
+	if gotPath != "" {
+		t.Fatalf("PrepareForTask path = %q, want empty path when refusing reuse", gotPath)
+	}
+
+	postHEAD, err := project.CurrentCommit(context.Background(), wtPath)
+	if err != nil {
+		t.Fatalf("resolve post-attempt HEAD: %v", err)
+	}
+	if postHEAD != preHEAD {
+		t.Fatalf("worktree HEAD changed from %q to %q — PrepareForTask must not touch a worktree with a live agent", preHEAD, postHEAD)
+	}
+}
+
 // TestPrepareForTask_BadSlugRejected proves the use-site guard: even if a
 // Task struct is constructed directly (bypassing the store and ParseBytes),
 // PrepareForTask rejects a path-traversal slug before calling PathFor.

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -18,6 +18,12 @@ import (
 // internal/task -> internal/workflow).
 var ErrRebaseFailed = worktreeerr.ErrRebaseFailed
 
+// ErrAgentRunning indicates PrepareForTask refused to reuse (and rebase) a
+// worktree that a tracked agent is still live in. Alias of
+// worktreeerr.ErrAgentRunning for the same import-cycle reason as
+// ErrRebaseFailed above.
+var ErrAgentRunning = worktreeerr.ErrAgentRunning
+
 // ErrTaskBranchMissing indicates a task's own branch does not exist locally
 // or on origin, so PrepareForBranchFix cannot check it out for no-PR conflict
 // recovery. Unlike PrepareForFix (which falls back to the PR head ref via
@@ -72,6 +78,13 @@ func (m *Manager) SyncTaskBranch(ctx context.Context, t task.Task) (SyncResult, 
 		return SyncSkipped, nil
 	}
 	if !m.Exists(t) {
+		return SyncSkipped, nil
+	}
+	// A tracked agent is still live in this worktree: rebasing here would
+	// corrupt its in-flight edits. This sync is opportunistic (never blocks
+	// workflow advancement per the doc above), so skip rather than fail —
+	// the next tick retries once the agent is idle.
+	if m.hasLiveAgentOnly != nil && m.hasLiveAgentOnly(t.ID) {
 		return SyncSkipped, nil
 	}
 	wtPath := m.PathFor(t)
@@ -142,6 +155,16 @@ func (m *Manager) PrepareForTask(ctx context.Context, t task.Task, onPhase func(
 	// checked out" refusal that a second worktree on the same branch would hit.
 	if t.WorktreeDir != "" {
 		return m.adoptWorktree(ctx, t, onPhase)
+	}
+
+	// A tracked agent is still live for this task: reusing its worktree
+	// below would rebase (or recreate) the branch out from under its
+	// in-flight edits. This is the last line of defense against a
+	// stale/incorrect "no agent running" read upstream (e.g. ResumeStalled)
+	// triggering a rebase against a live run — the caller must retry once
+	// idle, same as workflow.ErrDispatchInFlight.
+	if m.hasLiveAgentOnly != nil && m.hasLiveAgentOnly(t.ID) {
+		return "", fmt.Errorf("prepare worktree for reuse: %w", ErrAgentRunning)
 	}
 
 	proj, err := m.projects.Get(t.ProjectID)

--- a/internal/worktree/sync_task_branch_test.go
+++ b/internal/worktree/sync_task_branch_test.go
@@ -84,6 +84,52 @@ func TestSyncTaskBranch_AdoptedWorktreeSkipped(t *testing.T) {
 	}
 }
 
+// TestSyncTaskBranch_LiveAgentSkipped proves the opportunistic branch sync
+// never rebases a worktree a tracked agent is still live in — sync_branch
+// is best-effort and must not risk corrupting an in-flight run.
+func TestSyncTaskBranch_LiveAgentSkipped(t *testing.T) {
+	h := prepareHarness(t, nil, 30*time.Second)
+
+	tk, err := h.tasks.Store().Create("live agent sync task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.tasks.Update(tk.ID, task.Update{ProjectID: task.Ptr(h.proj.ID)}); err != nil {
+		t.Fatal(err)
+	}
+	tk, err = h.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wtPath, err := h.m.PrepareForTask(context.Background(), tk, nil)
+	if err != nil {
+		t.Fatalf("initial PrepareForTask: %v", err)
+	}
+	tk, err = h.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mWithLiveAgent := New(Config{
+		WorktreesDir: h.wtDir,
+		Projects:     h.store,
+		Tasks:        h.tasks,
+		Logger:       discardLogger(),
+		LogsDir:      h.logsDir,
+		AgentChecker: func(taskID string) bool { return taskID == tk.ID },
+	})
+
+	result, err := mWithLiveAgent.SyncTaskBranch(context.Background(), tk)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != SyncSkipped {
+		t.Errorf("result = %q, want %q", result, SyncSkipped)
+	}
+	assertWorktreeClean(t, wtPath)
+}
+
 func TestSyncTaskBranch_Noop(t *testing.T) {
 	h := prepareHarness(t, nil, 30*time.Second)
 

--- a/internal/worktreeerr/worktreeerr.go
+++ b/internal/worktreeerr/worktreeerr.go
@@ -12,6 +12,13 @@ import "errors"
 // the project base ref and must be repaired before another agent run.
 var ErrRebaseFailed = errors.New("worktree rebase failed")
 
+// ErrAgentRunning indicates PrepareForTask was asked to reuse (and rebase) a
+// worktree that a tracked agent is still live in. Rebasing out from under a
+// running agent corrupts its in-flight edits, so callers must treat this as
+// a transient "retry once idle" condition (like workflow.ErrDispatchInFlight)
+// rather than a real worktree conflict.
+var ErrAgentRunning = errors.New("worktree busy: agent still running for task")
+
 // RebaseBlockedReason is the human-facing status_reason written whenever
 // ErrRebaseFailed escalates a task to human-required. Shared between
 // internal/sybra's markRebaseBlocked and workflow.ClassifyAgentStartError so


### PR DESCRIPTION
## Motivation

`ResumeStalled` could re-enter `PrepareForTask`'s reused-worktree path and rebase a task's worktree against `origin/main` while a tracked agent was still writing to it — corrupting the in-flight run and, for required sidecars, losing the worktree-dir template var along the way.

## Implementation information

- `worktree.Manager` now refuses to rebase/recreate a reused worktree (or opportunistically sync its branch) while an agent is still registered for the task.
- A new claim-exclusive liveness check (`Manager.HasLiveRegisteredAgentForTask`) avoids this guard deadlocking against a dispatcher's own in-flight claim, distinct from `HasRunningAgentForTask` which still counts the claim.
- The refusal (`worktreeerr.ErrAgentRunning`) maps to the existing benign/retryable dispatch-in-flight path in both the workflow-engine and direct-dispatch call sites instead of escalating to human-required, and the PR-monitor's `prepareWorktree` no longer trips its circuit breaker on this transient collision.
- `import_sidecar` now distinguishes an empty worktree-dir template variable from a genuinely missing file, using a regex match on the actual template placeholder instead of a substring check, so a lost var doesn't misreport as "review missing" during investigation and a coincidental `_dir` substring in an unrelated path doesn't misreport the opposite way.

Closes https://github.com/Automaat/sybra/issues/1495

_Generated by Sybra harness_