### PR TITLE
fix(workflow): net removed-test-cases across whole diff

### DIFF
--- a/internal/workflow/engine_steps_tamper.go
+++ b/internal/workflow/engine_steps_tamper.go
@@ -112,6 +112,8 @@ type tamperPatchResult struct {
 	Findings  []tamperFinding
 	AddAssert int
 	DelAssert int
+	AddDecl   int
+	DelDecl   int
 }
 
 var (
@@ -408,7 +410,10 @@ func (s *tamperScan) finalize() tamperPatchResult {
 	}
 	netFinding("removed-assertions", "assertion line(s)", s.delAssert, s.addAssert)
 	netFinding("removed-test-cases", "test declaration(s)", s.delDecl, s.addDecl)
-	return tamperPatchResult{Findings: s.findings, AddAssert: s.addAssert, DelAssert: s.delAssert}
+	return tamperPatchResult{
+		Findings: s.findings, AddAssert: s.addAssert, DelAssert: s.delAssert,
+		AddDecl: s.addDecl, DelDecl: s.delDecl,
+	}
 }
 
 // buildTamperReport assembles the report from the parsed diff. Pure function:
@@ -417,6 +422,8 @@ func buildTamperReport(taskID, base string, changes []tamperChange) tamperReport
 	report := tamperReport{TaskID: taskID, Base: base}
 	scanned := 0
 	totalAddedAssertions := 0
+	totalAddedDecl := 0
+	totalDeletedDecl := 0
 	for i := range changes {
 		c := changes[i]
 		cat := classifyTamperPath(c.Path)
@@ -439,10 +446,19 @@ func buildTamperReport(taskID, base string, changes []tamperChange) tamperReport
 		scanned++
 		res := scanTamperPatchResult(c.Path, cat, c.Patch, c.BaseContent)
 		totalAddedAssertions += res.AddAssert
+		totalAddedDecl += res.AddDecl
+		totalDeletedDecl += res.DelDecl
 		report.Findings = append(report.Findings, res.Findings...)
 	}
 	if totalAddedAssertions > 0 {
-		report.Findings = downgradeRemovedAssertionOnlyFindings(report.Findings)
+		report.Findings = downgradeFindingsByRule(report.Findings, "removed-assertions")
+	}
+	// A test declaration deleted in one file and re-added (moved/renamed/
+	// consolidated) in another nets to zero across the diff even though each
+	// file's own scan sees only its half — so the pass/fail decision is based
+	// on the diff-wide net, not the per-file net computed in finalize().
+	if totalDeletedDecl-totalAddedDecl <= 0 {
+		report.Findings = downgradeFindingsByRule(report.Findings, "removed-test-cases")
 	}
 
 	// Verification files changed but nothing high fired: record one medium
@@ -459,10 +475,13 @@ func buildTamperReport(taskID, base string, changes []tamperChange) tamperReport
 	return report
 }
 
-func downgradeRemovedAssertionOnlyFindings(findings []tamperFinding) []tamperFinding {
+// downgradeFindingsByRule lowers the severity of every finding matching rule
+// to medium (non-blocking) — used once the diff-wide net for that rule shows
+// the apparent removal was offset elsewhere in the same diff.
+func downgradeFindingsByRule(findings []tamperFinding, rule string) []tamperFinding {
 	out := findings[:0]
 	for _, f := range findings {
-		if f.Rule == "removed-assertions" {
+		if f.Rule == rule {
 			f.Severity = tamperMedium
 		}
 		out = append(out, f)

--- a/internal/workflow/engine_steps_tamper.go
+++ b/internal/workflow/engine_steps_tamper.go
@@ -422,6 +422,7 @@ func buildTamperReport(taskID, base string, changes []tamperChange) tamperReport
 	report := tamperReport{TaskID: taskID, Base: base}
 	scanned := 0
 	totalAddedAssertions := 0
+	totalDeletedAssertions := 0
 	totalAddedDecl := 0
 	totalDeletedDecl := 0
 	for i := range changes {
@@ -446,17 +447,20 @@ func buildTamperReport(taskID, base string, changes []tamperChange) tamperReport
 		scanned++
 		res := scanTamperPatchResult(c.Path, cat, c.Patch, c.BaseContent)
 		totalAddedAssertions += res.AddAssert
+		totalDeletedAssertions += res.DelAssert
 		totalAddedDecl += res.AddDecl
 		totalDeletedDecl += res.DelDecl
 		report.Findings = append(report.Findings, res.Findings...)
 	}
-	if totalAddedAssertions > 0 {
+	// An assertion or test declaration deleted in one file and re-added
+	// (moved/renamed/consolidated) in another nets to zero across the diff
+	// even though each file's own scan sees only its half — so the pass/fail
+	// decision is based on the diff-wide net, not the per-file net computed
+	// in finalize(). Both rules use the same strict net-offset formula so
+	// they downgrade consistently.
+	if totalDeletedAssertions-totalAddedAssertions <= 0 {
 		report.Findings = downgradeFindingsByRule(report.Findings, "removed-assertions")
 	}
-	// A test declaration deleted in one file and re-added (moved/renamed/
-	// consolidated) in another nets to zero across the diff even though each
-	// file's own scan sees only its half — so the pass/fail decision is based
-	// on the diff-wide net, not the per-file net computed in finalize().
 	if totalDeletedDecl-totalAddedDecl <= 0 {
 		report.Findings = downgradeFindingsByRule(report.Findings, "removed-test-cases")
 	}

--- a/internal/workflow/engine_steps_tamper_test.go
+++ b/internal/workflow/engine_steps_tamper_test.go
@@ -264,6 +264,47 @@ func TestBuildTamperReport(t *testing.T) {
 		}
 	})
 
+	t.Run("test_case_moved_across_files_is_medium_not_blocking", func(t *testing.T) {
+		r := buildTamperReport("t1", "origin/main", []tamperChange{
+			{Status: "M", Path: "internal/foo/old_test.go", Patch: "@@ @@\n-func TestGone(t *testing.T) {\n-\tt.Errorf(\"x\")\n-}\n"},
+			{Status: "A", Path: "internal/foo/new_test.go", Patch: "@@ @@\n+func TestGone(t *testing.T) {\n+\tt.Errorf(\"x\")\n+}\n+func TestExtra(t *testing.T) {\n+\tt.Errorf(\"y\")\n+}\n"},
+		})
+		if r.highCount() != 0 {
+			t.Fatalf("highCount = %d, want 0 (consolidation is diff-wide net-neutral): %v", r.highCount(), r.Findings)
+		}
+		foundDecl := false
+		for _, f := range r.Findings {
+			if f.Rule == "removed-test-cases" {
+				foundDecl = true
+				if f.Severity != tamperMedium {
+					t.Errorf("removed-test-cases severity = %q, want medium", f.Severity)
+				}
+			}
+		}
+		if !foundDecl {
+			t.Fatalf("want a removed-test-cases finding (downgraded), got %v", r.Findings)
+		}
+	})
+
+	t.Run("test_case_removed_with_no_offsetting_addition_stays_high", func(t *testing.T) {
+		r := buildTamperReport("t1", "origin/main", []tamperChange{
+			{Status: "M", Path: "internal/foo/old_test.go", Patch: "@@ @@\n-func TestGone(t *testing.T) {\n-\tt.Errorf(\"x\")\n-}\n"},
+			{Status: "M", Path: "internal/foo/other_test.go", Patch: "@@ @@\n+\tfoo := 1\n"},
+		})
+		found := false
+		for _, f := range r.Findings {
+			if f.Rule == "removed-test-cases" {
+				found = true
+				if f.Severity != tamperHigh {
+					t.Errorf("removed-test-cases severity = %q, want high (no offsetting addition anywhere in diff)", f.Severity)
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("want a removed-test-cases finding, got %v", r.Findings)
+		}
+	})
+
 	t.Run("tampering_mixes_high_and_skips_medium", func(t *testing.T) {
 		r := buildTamperReport("t1", "origin/main", []tamperChange{
 			{Status: "M", Path: "a_test.go", Patch: "@@ @@\n+\tt.Skip(\"x\")\n"},

--- a/internal/workflow/engine_steps_tamper_test.go
+++ b/internal/workflow/engine_steps_tamper_test.go
@@ -305,6 +305,25 @@ func TestBuildTamperReport(t *testing.T) {
 		}
 	})
 
+	t.Run("removed_assertions_with_unrelated_addition_stays_high", func(t *testing.T) {
+		r := buildTamperReport("t1", "origin/main", []tamperChange{
+			{Status: "M", Path: "internal/foo/old_test.go", Patch: "@@ @@\n-\tif err != nil { t.Fatalf(\"bad: %v\", err) }\n-\tif y != 2 { t.Fatalf(\"bad y\") }\n"},
+			{Status: "A", Path: "internal/foo/new_feature_test.go", Patch: "@@ @@\n+func TestUnrelated(t *testing.T) {\n+\trequire.NoError(t, err)\n+}\n"},
+		})
+		found := false
+		for _, f := range r.Findings {
+			if f.Rule == "removed-assertions" {
+				found = true
+				if f.Severity != tamperHigh {
+					t.Errorf("removed-assertions severity = %q, want high (only 1 of 2 removed assertions offset)", f.Severity)
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("want a removed-assertions finding, got %v", r.Findings)
+		}
+	})
+
 	t.Run("tampering_mixes_high_and_skips_medium", func(t *testing.T) {
 		r := buildTamperReport("t1", "origin/main", []tamperChange{
 			{Status: "M", Path: "a_test.go", Patch: "@@ @@\n+\tt.Skip(\"x\")\n"},


### PR DESCRIPTION
## Motivation

The tamper-scan gate's removed-test-cases rule was evaluated per-file, so a test declaration deleted in one file and re-added in another (a move/rename/consolidation) still tripped a high-severity finding even though the diff-wide net change was zero. The removed-assertions rule already needed the same diff-wide netting fix.

## Implementation information

- `tamperPatchResult` now also carries `AddDecl`/`DelDecl` per file, alongside the existing assertion counts.
- `buildTamperReport` accumulates deleted/added totals for both assertions and test declarations across the whole diff, and downgrades either rule's findings to medium when its diff-wide net is `<= 0`.
- Renamed `downgradeRemovedAssertionOnlyFindings` to `downgradeFindingsByRule` (takes a rule name) so both rules share one downgrade path with a consistent net-offset formula.
- Added test coverage for the moved/renamed test-case scenario.

Closes https://github.com/Automaat/sybra/issues/1498

_Generated by Sybra harness_