### PR TITLE
fix(worktree): don't classify transient fetch as rebase conflict

### DIFF
--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -660,7 +660,7 @@ func isAncestor(ctx context.Context, worktreePath, ancestor, descendant string) 
 // Returns ("", nil) when the remote branch does not exist (never pushed).
 func remoteBranchHead(ctx context.Context, worktreePath, remote, branch string) (string, error) {
 	var out string
-	err := withNetworkRetry(func() error {
+	err := withNetworkRetry(ctx, func() error {
 		var runErr error
 		out, runErr = executil.Output(ctx, worktreePath, "git", "ls-remote", remote, "refs/heads/"+branch)
 		return runErr
@@ -702,7 +702,7 @@ func ReconcileWithRemote(ctx context.Context, worktreePath, branch string) error
 	// continuing on stale history is exactly the data-loss scenario this
 	// function exists to prevent.
 	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
-	fetchErr := withNetworkRetry(func() error {
+	fetchErr := withNetworkRetry(ctx, func() error {
 		return executil.Run(ctx, worktreePath, "git", "fetch", remote, refspec)
 	})
 	if fetchErr != nil && !strings.Contains(fetchErr.Error(), "couldn't find remote ref") {

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -659,7 +659,12 @@ func isAncestor(ctx context.Context, worktreePath, ancestor, descendant string) 
 // remoteBranchHead queries the live head SHA of branch on remote via ls-remote.
 // Returns ("", nil) when the remote branch does not exist (never pushed).
 func remoteBranchHead(ctx context.Context, worktreePath, remote, branch string) (string, error) {
-	out, err := executil.Output(ctx, worktreePath, "git", "ls-remote", remote, "refs/heads/"+branch)
+	var out string
+	err := withNetworkRetry(func() error {
+		var runErr error
+		out, runErr = executil.Output(ctx, worktreePath, "git", "ls-remote", remote, "refs/heads/"+branch)
+		return runErr
+	})
 	if err != nil {
 		return "", err
 	}
@@ -697,8 +702,11 @@ func ReconcileWithRemote(ctx context.Context, worktreePath, branch string) error
 	// continuing on stale history is exactly the data-loss scenario this
 	// function exists to prevent.
 	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
-	if err := executil.Run(ctx, worktreePath, "git", "fetch", remote, refspec); err != nil && !strings.Contains(err.Error(), "couldn't find remote ref") {
-		return fmt.Errorf("fetch %s %s: %w", remote, refspec, err)
+	fetchErr := withNetworkRetry(func() error {
+		return executil.Run(ctx, worktreePath, "git", "fetch", remote, refspec)
+	})
+	if fetchErr != nil && !strings.Contains(fetchErr.Error(), "couldn't find remote ref") {
+		return fmt.Errorf("fetch %s %s: %w", remote, refspec, fetchErr)
 	}
 
 	// An absent branch (first push) means there is nothing to reconcile; any

--- a/internal/project/git_network.go
+++ b/internal/project/git_network.go
@@ -1,0 +1,56 @@
+package project
+
+import "strings"
+
+// transientNetworkMarkers are substrings of git/ssh/curl transport failures
+// that indicate a connectivity blip (DNS, refused/reset connection, timeout)
+// rather than a genuine content conflict or an auth/config problem. Matching
+// is deliberately narrow — a false positive here would retry (and briefly
+// delay reporting) a permanent failure, but a false negative would wrongly
+// classify a transient outage as a content conflict and escalate a task to
+// human-required on a perfectly clean branch.
+var transientNetworkMarkers = []string{
+	"connection refused",
+	"connection reset",
+	"connection timed out",
+	"could not resolve host",
+	"couldn't resolve host",
+	"network is unreachable",
+	"operation timed out",
+	"temporary failure in name resolution",
+	"no route to host",
+	"ssh: connect to host",
+	"recv failure",
+	"tls handshake timeout",
+	"empty reply from server",
+}
+
+// IsTransientNetworkError reports whether err looks like a transient
+// network/transport failure from a git remote operation (fetch, ls-remote)
+// rather than a genuine content conflict, auth failure, or misconfiguration.
+func IsTransientNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, marker := range transientNetworkMarkers {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// withNetworkRetry runs fn, retrying on gitOpRetryBackoffs when the failure
+// looks like a transient network error. Non-network errors return
+// immediately without retrying. Shares its backoff schedule with
+// withLockRetry — both are bounded, short retries for conditions that
+// typically clear within seconds.
+func withNetworkRetry(fn func() error) error {
+	err := fn()
+	for attempt := 0; attempt < len(gitOpRetryBackoffs) && IsTransientNetworkError(err); attempt++ {
+		gitOpRetrySleep(gitOpRetryBackoffs[attempt])
+		err = fn()
+	}
+	return err
+}

--- a/internal/project/git_network.go
+++ b/internal/project/git_network.go
@@ -1,6 +1,10 @@
 package project
 
-import "strings"
+import (
+	"context"
+	"strings"
+	"time"
+)
 
 // transientNetworkMarkers are substrings of git/ssh/curl transport failures
 // that indicate a connectivity blip (DNS, refused/reset connection, timeout)
@@ -23,7 +27,11 @@ var transientNetworkMarkers = []string{
 	"recv failure",
 	"tls handshake timeout",
 	"empty reply from server",
+	"early eof",
+	"unexpected disconnect while reading sideband packet",
 }
+
+var gitOpRetrySleepContext = sleepWithContext
 
 // IsTransientNetworkError reports whether err looks like a transient
 // network/transport failure from a git remote operation (fetch, ls-remote)
@@ -46,11 +54,27 @@ func IsTransientNetworkError(err error) bool {
 // immediately without retrying. Shares its backoff schedule with
 // withLockRetry — both are bounded, short retries for conditions that
 // typically clear within seconds.
-func withNetworkRetry(fn func() error) error {
+func withNetworkRetry(ctx context.Context, fn func() error) error {
 	err := fn()
 	for attempt := 0; attempt < len(gitOpRetryBackoffs) && IsTransientNetworkError(err); attempt++ {
-		gitOpRetrySleep(gitOpRetryBackoffs[attempt])
+		if sleepErr := gitOpRetrySleepContext(ctx, gitOpRetryBackoffs[attempt]); sleepErr != nil {
+			return sleepErr
+		}
 		err = fn()
 	}
 	return err
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }

--- a/internal/project/git_network_test.go
+++ b/internal/project/git_network_test.go
@@ -1,0 +1,99 @@
+package project
+
+import (
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestIsTransientNetworkError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"ssh connection refused", errors.New("ssh: connect to host github.com port 22: Connection refused"), true},
+		{"dns failure", errors.New("fatal: unable to access 'https://github.com/x/y.git/': Could not resolve host: github.com"), true},
+		{"connection reset", errors.New("fatal: Connection reset by peer"), true},
+		{"timed out", errors.New("ssh: connect to host github.com port 22: Operation timed out"), true},
+		{"content conflict", errors.New("CONFLICT (content): Merge conflict in foo.go"), false},
+		{"auth failure", errors.New("fatal: Authentication failed for 'https://github.com/x/y.git/'"), false},
+		{"missing repo", errors.New("fatal: repository 'https://github.com/x/y.git/' not found"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsTransientNetworkError(tc.err); got != tc.want {
+				t.Errorf("IsTransientNetworkError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWithNetworkRetry_RetriesOnTransientNetworkError(t *testing.T) {
+	prevBackoffs, prevSleep := gitOpRetryBackoffs, gitOpRetrySleep
+	t.Cleanup(func() { gitOpRetryBackoffs, gitOpRetrySleep = prevBackoffs, prevSleep })
+	gitOpRetryBackoffs = []time.Duration{0, 0, 0}
+	gitOpRetrySleep = func(time.Duration) {}
+
+	var attempts int32
+	err := withNetworkRetry(func() error {
+		n := atomic.AddInt32(&attempts, 1)
+		if n < 3 {
+			return fmt.Errorf("ssh: connect to host github.com port 22: Connection refused")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("withNetworkRetry: %v", err)
+	}
+	if attempts != 3 {
+		t.Errorf("attempts = %d, want 3", attempts)
+	}
+}
+
+func TestWithNetworkRetry_DoesNotRetryNonNetworkErrors(t *testing.T) {
+	prevBackoffs, prevSleep := gitOpRetryBackoffs, gitOpRetrySleep
+	t.Cleanup(func() { gitOpRetryBackoffs, gitOpRetrySleep = prevBackoffs, prevSleep })
+	gitOpRetryBackoffs = []time.Duration{0, 0, 0}
+	gitOpRetrySleep = func(time.Duration) {
+		t.Fatal("should not sleep/retry a non-network error")
+	}
+
+	wantErr := errors.New("CONFLICT (content): Merge conflict in foo.go")
+	var attempts int32
+	err := withNetworkRetry(func() error {
+		atomic.AddInt32(&attempts, 1)
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1 (no retry for non-network errors)", attempts)
+	}
+}
+
+func TestWithNetworkRetry_GivesUpAfterExhaustingBackoffs(t *testing.T) {
+	prevBackoffs, prevSleep := gitOpRetryBackoffs, gitOpRetrySleep
+	t.Cleanup(func() { gitOpRetryBackoffs, gitOpRetrySleep = prevBackoffs, prevSleep })
+	gitOpRetryBackoffs = []time.Duration{0, 0}
+	gitOpRetrySleep = func(time.Duration) {}
+
+	var attempts int32
+	netErr := errors.New("fatal: Network is unreachable")
+	err := withNetworkRetry(func() error {
+		atomic.AddInt32(&attempts, 1)
+		return netErr
+	})
+	if !errors.Is(err, netErr) {
+		t.Fatalf("err = %v, want %v", err, netErr)
+	}
+	if want := int32(1 + len(gitOpRetryBackoffs)); attempts != want {
+		t.Errorf("attempts = %d, want %d", attempts, want)
+	}
+}

--- a/internal/project/git_network_test.go
+++ b/internal/project/git_network_test.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync/atomic"
@@ -20,6 +21,8 @@ func TestIsTransientNetworkError(t *testing.T) {
 		{"dns failure", errors.New("fatal: unable to access 'https://github.com/x/y.git/': Could not resolve host: github.com"), true},
 		{"connection reset", errors.New("fatal: Connection reset by peer"), true},
 		{"timed out", errors.New("ssh: connect to host github.com port 22: Operation timed out"), true},
+		{"early eof", errors.New("fatal: early EOF"), true},
+		{"sideband disconnect", errors.New("fatal: unexpected disconnect while reading sideband packet"), true},
 		{"content conflict", errors.New("CONFLICT (content): Merge conflict in foo.go"), false},
 		{"auth failure", errors.New("fatal: Authentication failed for 'https://github.com/x/y.git/'"), false},
 		{"missing repo", errors.New("fatal: repository 'https://github.com/x/y.git/' not found"), false},
@@ -35,13 +38,13 @@ func TestIsTransientNetworkError(t *testing.T) {
 }
 
 func TestWithNetworkRetry_RetriesOnTransientNetworkError(t *testing.T) {
-	prevBackoffs, prevSleep := gitOpRetryBackoffs, gitOpRetrySleep
-	t.Cleanup(func() { gitOpRetryBackoffs, gitOpRetrySleep = prevBackoffs, prevSleep })
+	prevBackoffs, prevSleep := gitOpRetryBackoffs, gitOpRetrySleepContext
+	t.Cleanup(func() { gitOpRetryBackoffs, gitOpRetrySleepContext = prevBackoffs, prevSleep })
 	gitOpRetryBackoffs = []time.Duration{0, 0, 0}
-	gitOpRetrySleep = func(time.Duration) {}
+	gitOpRetrySleepContext = func(context.Context, time.Duration) error { return nil }
 
 	var attempts int32
-	err := withNetworkRetry(func() error {
+	err := withNetworkRetry(context.Background(), func() error {
 		n := atomic.AddInt32(&attempts, 1)
 		if n < 3 {
 			return fmt.Errorf("ssh: connect to host github.com port 22: Connection refused")
@@ -57,16 +60,17 @@ func TestWithNetworkRetry_RetriesOnTransientNetworkError(t *testing.T) {
 }
 
 func TestWithNetworkRetry_DoesNotRetryNonNetworkErrors(t *testing.T) {
-	prevBackoffs, prevSleep := gitOpRetryBackoffs, gitOpRetrySleep
-	t.Cleanup(func() { gitOpRetryBackoffs, gitOpRetrySleep = prevBackoffs, prevSleep })
+	prevBackoffs, prevSleep := gitOpRetryBackoffs, gitOpRetrySleepContext
+	t.Cleanup(func() { gitOpRetryBackoffs, gitOpRetrySleepContext = prevBackoffs, prevSleep })
 	gitOpRetryBackoffs = []time.Duration{0, 0, 0}
-	gitOpRetrySleep = func(time.Duration) {
+	gitOpRetrySleepContext = func(context.Context, time.Duration) error {
 		t.Fatal("should not sleep/retry a non-network error")
+		return nil
 	}
 
 	wantErr := errors.New("CONFLICT (content): Merge conflict in foo.go")
 	var attempts int32
-	err := withNetworkRetry(func() error {
+	err := withNetworkRetry(context.Background(), func() error {
 		atomic.AddInt32(&attempts, 1)
 		return wantErr
 	})
@@ -79,14 +83,14 @@ func TestWithNetworkRetry_DoesNotRetryNonNetworkErrors(t *testing.T) {
 }
 
 func TestWithNetworkRetry_GivesUpAfterExhaustingBackoffs(t *testing.T) {
-	prevBackoffs, prevSleep := gitOpRetryBackoffs, gitOpRetrySleep
-	t.Cleanup(func() { gitOpRetryBackoffs, gitOpRetrySleep = prevBackoffs, prevSleep })
+	prevBackoffs, prevSleep := gitOpRetryBackoffs, gitOpRetrySleepContext
+	t.Cleanup(func() { gitOpRetryBackoffs, gitOpRetrySleepContext = prevBackoffs, prevSleep })
 	gitOpRetryBackoffs = []time.Duration{0, 0}
-	gitOpRetrySleep = func(time.Duration) {}
+	gitOpRetrySleepContext = func(context.Context, time.Duration) error { return nil }
 
 	var attempts int32
 	netErr := errors.New("fatal: Network is unreachable")
-	err := withNetworkRetry(func() error {
+	err := withNetworkRetry(context.Background(), func() error {
 		atomic.AddInt32(&attempts, 1)
 		return netErr
 	})
@@ -95,5 +99,27 @@ func TestWithNetworkRetry_GivesUpAfterExhaustingBackoffs(t *testing.T) {
 	}
 	if want := int32(1 + len(gitOpRetryBackoffs)); attempts != want {
 		t.Errorf("attempts = %d, want %d", attempts, want)
+	}
+}
+
+func TestWithNetworkRetry_StopsWhenContextCancelled(t *testing.T) {
+	prevBackoffs, prevSleep := gitOpRetryBackoffs, gitOpRetrySleepContext
+	t.Cleanup(func() { gitOpRetryBackoffs, gitOpRetrySleepContext = prevBackoffs, prevSleep })
+	gitOpRetryBackoffs = []time.Duration{time.Second}
+	gitOpRetrySleepContext = sleepWithContext
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var attempts int32
+	err := withNetworkRetry(ctx, func() error {
+		atomic.AddInt32(&attempts, 1)
+		return errors.New("ssh: connect to host github.com port 22: Connection refused")
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
 	}
 }

--- a/internal/sybra/agentorch/rebase_block_test.go
+++ b/internal/sybra/agentorch/rebase_block_test.go
@@ -130,3 +130,31 @@ func TestMarkRebaseBlocked_NoLinkedPRParksHumanRequired(t *testing.T) {
 		t.Fatalf("status = %q, want %q", got.Status, task.StatusHumanRequired)
 	}
 }
+
+func TestMarkRebaseBlocked_IgnoresTransientFetch(t *testing.T) {
+	tasks := newRebaseBlockTestManager(t)
+	tk, err := tasks.Create("transient fetch task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	handled := MarkRebaseBlocked(tasks, tk.ID, worktree.ErrTransientFetch, discardSlogLogger(), func(string) bool {
+		called = true
+		return true
+	})
+	if handled {
+		t.Fatal("MarkRebaseBlocked = true, want false for transient fetch")
+	}
+	if called {
+		t.Fatal("recoverConflict should not be called for transient fetch")
+	}
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusTodo {
+		t.Fatalf("status = %q, want unchanged %q", got.Status, task.StatusTodo)
+	}
+}

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -18,6 +18,8 @@ const (
 	watchdogRateLimitStatusPrefix   = "watchdog: rate limit"
 	watchdogRateLimitRetryVarPrefix = "watchdog.rate_limit_retry."
 	maxWatchdogRateLimitRetries     = 2
+	transientFetchRetryVarPrefix    = "transient_fetch.retry."
+	maxTransientFetchRetries        = 2
 )
 
 // HandleHumanAction processes approve/reject/input from the UI.
@@ -692,6 +694,9 @@ func (e *Engine) ResumeStalled() {
 		if e.handleWatchdogHangRetry(t, step) {
 			continue
 		}
+		if e.handleTransientFetchRetry(t, step) {
+			continue
+		}
 		reason, acquired := e.tryMarkResumeDispatching(t.ID, step)
 		if !acquired {
 			e.logger.Debug("workflow.resume-stalled.skip",
@@ -723,6 +728,8 @@ func (e *Engine) ResumeStalled() {
 		e.resumeError.Log(e.logger, "workflow.resume-stalled.exec", t.ID, rErr, "task_id", t.ID)
 		if rErr != nil {
 			e.surfaceStartFailure(t.ID, fresh.Status, rErr)
+		} else {
+			e.clearTransientFetchRetry(fresh.ID, fresh.Workflow, step.ID)
 		}
 	}
 }
@@ -807,6 +814,45 @@ func isWatchdogRateLimitReason(reason string) bool {
 	return reason == watchdogRateLimitStatusPrefix || strings.HasPrefix(reason, watchdogRateLimitStatusPrefix+":")
 }
 
+func (e *Engine) handleTransientFetchRetry(t *TaskInfo, step *Step) bool {
+	if t == nil || t.Workflow == nil || step == nil || step.Type != StepRunAgent || !isTransientFetchReason(t.StatusReason) {
+		return false
+	}
+	retryKey := transientFetchRetryKey(step.ID)
+	attempts := parseWorkflowInt(t.Workflow.Variables[retryKey])
+	if attempts >= maxTransientFetchRetries {
+		reason := fmt.Sprintf("agent start blocked: transient network retry budget exhausted after %d attempts reconciling worktree with remote", attempts)
+		if err := e.tasks.UpdateTaskStatus(t.ID, "human-required", reason); err != nil {
+			e.logger.Error("workflow.transient-fetch.escalate", "task_id", t.ID, "step", step.ID, "err", err)
+		} else {
+			e.logger.Warn("workflow.transient-fetch.exhausted", "task_id", t.ID, "step", step.ID, "attempts", attempts)
+		}
+		return true
+	}
+	t.Workflow.SetVar(retryKey, strconv.Itoa(attempts+1))
+	if err := e.tasks.SetWorkflow(t.ID, t.Workflow); err != nil {
+		e.logger.Error("workflow.transient-fetch.persist", "task_id", t.ID, "step", step.ID, "err", err)
+		return true
+	}
+	e.logger.Info("workflow.transient-fetch.retry",
+		"task_id", t.ID, "step", step.ID, "attempt", attempts+1, "max", maxTransientFetchRetries)
+	return false
+}
+
+func (e *Engine) clearTransientFetchRetry(taskID string, wf *Execution, stepID string) {
+	if wf == nil || wf.Variables == nil || stepID == "" {
+		return
+	}
+	retryKey := transientFetchRetryKey(stepID)
+	if _, ok := wf.Variables[retryKey]; !ok {
+		return
+	}
+	delete(wf.Variables, retryKey)
+	if err := e.tasks.SetWorkflow(taskID, wf); err != nil {
+		e.logger.Error("workflow.transient-fetch.clear", "task_id", taskID, "step", stepID, "err", err)
+	}
+}
+
 func watchdogHangRetryKey(stepID string) string {
 	return watchdogHangRetryVarPrefix + stepID
 }
@@ -817,6 +863,10 @@ func watchdogHangCleanRetryKey(stepID string) string {
 
 func watchdogRateLimitRetryKey(stepID string) string {
 	return watchdogRateLimitRetryVarPrefix + stepID
+}
+
+func transientFetchRetryKey(stepID string) string {
+	return transientFetchRetryVarPrefix + stepID
 }
 
 func parseWorkflowInt(raw string) int {

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -694,13 +694,22 @@ func (e *Engine) ResumeStalled() {
 		if e.handleWatchdogHangRetry(t, step) {
 			continue
 		}
-		if e.handleTransientFetchRetry(t, step) {
-			continue
-		}
 		reason, acquired := e.tryMarkResumeDispatching(t.ID, step)
 		if !acquired {
 			e.logger.Debug("workflow.resume-stalled.skip",
 				"task_id", t.ID, "reason", reason, "step", step.ID)
+			continue
+		}
+
+		// handleTransientFetchRetry runs only after the dispatching claim is
+		// acquired, so the retry budget tracks actual re-dispatch attempts —
+		// a tick that loses the claim to a concurrent goroutine (already
+		// dispatching/advancing) never burns budget for a retry that didn't
+		// happen.
+		if e.handleTransientFetchRetry(t, step) {
+			e.mu.Lock()
+			delete(e.dispatching, t.ID)
+			e.mu.Unlock()
 			continue
 		}
 

--- a/internal/workflow/engine_test.go
+++ b/internal/workflow/engine_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -18,6 +19,7 @@ import (
 	"github.com/Automaat/sybra/internal/config"
 	"github.com/Automaat/sybra/internal/prompteval"
 	providerpkg "github.com/Automaat/sybra/internal/provider"
+	"github.com/Automaat/sybra/internal/worktreeerr"
 )
 
 // --- Test helpers ---
@@ -943,6 +945,62 @@ func TestResumeStalled_WatchdogLoopHumanRequiredDoesNotRetry(t *testing.T) {
 	}
 	if got.StatusReason != "watchdog: looping on toolchain setup" {
 		t.Fatalf("status_reason = %q, want loop reason preserved", got.StatusReason)
+	}
+}
+
+func TestResumeStalled_TransientFetchRetriesThenEscalates(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	agents.SetFailSpawn(worktreeerr.ErrTransientFetch)
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{
+		ID:           "t1",
+		Status:       "in-progress",
+		StatusReason: transientFetchStatusReason,
+		AgentMode:    "headless",
+		Workflow: &Execution{
+			WorkflowID:  "test-simple",
+			CurrentStep: "implement",
+			State:       ExecWaiting,
+			Variables:   map[string]string{},
+			StartedAt:   time.Now().UTC(),
+		},
+	})
+
+	for attempt := 1; attempt <= maxTransientFetchRetries; attempt++ {
+		engine.ResumeStalled()
+		got, err := tasks.GetTask("t1")
+		if err != nil {
+			t.Fatalf("get task after attempt %d: %v", attempt, err)
+		}
+		if got.Status != "in-progress" {
+			t.Fatalf("attempt %d status = %q, want in-progress", attempt, got.Status)
+		}
+		if got.Workflow.Variables[transientFetchRetryKey("implement")] != strconv.Itoa(attempt) {
+			t.Fatalf("attempt %d retry var = %q, want %q", attempt, got.Workflow.Variables[transientFetchRetryKey("implement")], strconv.Itoa(attempt))
+		}
+		if got.StatusReason != transientFetchStatusReason {
+			t.Fatalf("attempt %d status_reason = %q, want %q", attempt, got.StatusReason, transientFetchStatusReason)
+		}
+	}
+
+	engine.ResumeStalled()
+
+	got, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "human-required" {
+		t.Fatalf("status = %q, want human-required after retry exhaustion", got.Status)
+	}
+	wantReason := "agent start blocked: transient network retry budget exhausted after 2 attempts reconciling worktree with remote"
+	if got.StatusReason != wantReason {
+		t.Fatalf("status_reason = %q, want %q", got.StatusReason, wantReason)
+	}
+	if got.Workflow.Variables[transientFetchRetryKey("implement")] != strconv.Itoa(maxTransientFetchRetries) {
+		t.Fatalf("retry var = %q, want %d", got.Workflow.Variables[transientFetchRetryKey("implement")], maxTransientFetchRetries)
 	}
 }
 

--- a/internal/workflow/start_error.go
+++ b/internal/workflow/start_error.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/provider"
@@ -12,6 +13,8 @@ import (
 // startReasonMaxLen caps the human-facing reason written to task.StatusReason.
 // Longer messages clutter the UI and rarely add value beyond the lead error.
 const startReasonMaxLen = 200
+
+const transientFetchStatusReason = "agent start delayed: transient network failure reconciling worktree with remote"
 
 // ErrDispatchInFlight is returned by an agent-start path when another dispatch
 // for the same task is already in flight (the per-task dispatch claim is held).
@@ -58,7 +61,7 @@ func ClassifyAgentStartError(err error) (reason string, permanent bool) {
 		// Transient: a network blip during the remote fetch/ls-remote, not a
 		// genuine content conflict. Never escalate — let the resume loop retry
 		// once connectivity recovers.
-		reason = "agent start delayed: transient network failure reconciling worktree with remote"
+		reason = transientFetchStatusReason
 	case errors.Is(err, provider.ErrProviderUnhealthy):
 		reason = "agent start blocked: " + err.Error()
 	default:
@@ -72,6 +75,10 @@ func transientAgentStartError(err error) bool {
 		errors.Is(err, ErrTestRunnerBusy) ||
 		errors.Is(err, worktreeerr.ErrTransientFetch) ||
 		errors.Is(err, provider.ErrProviderUnhealthy)
+}
+
+func isTransientFetchReason(reason string) bool {
+	return strings.TrimSpace(reason) == transientFetchStatusReason
 }
 
 // truncateReason caps a status_reason to startReasonMaxLen bytes with an

--- a/internal/workflow/start_error.go
+++ b/internal/workflow/start_error.go
@@ -54,6 +54,11 @@ func ClassifyAgentStartError(err error) (reason string, permanent bool) {
 	case errors.Is(err, worktreeerr.ErrRebaseFailed):
 		permanent = true
 		reason = worktreeerr.RebaseBlockedReason
+	case errors.Is(err, worktreeerr.ErrTransientFetch):
+		// Transient: a network blip during the remote fetch/ls-remote, not a
+		// genuine content conflict. Never escalate — let the resume loop retry
+		// once connectivity recovers.
+		reason = "agent start delayed: transient network failure reconciling worktree with remote"
 	case errors.Is(err, provider.ErrProviderUnhealthy):
 		reason = "agent start blocked: " + err.Error()
 	default:
@@ -65,6 +70,7 @@ func ClassifyAgentStartError(err error) (reason string, permanent bool) {
 func transientAgentStartError(err error) bool {
 	return errors.Is(err, ErrDispatchInFlight) ||
 		errors.Is(err, ErrTestRunnerBusy) ||
+		errors.Is(err, worktreeerr.ErrTransientFetch) ||
 		errors.Is(err, provider.ErrProviderUnhealthy)
 }
 

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -40,6 +40,11 @@ func TestClassifyAgentStartError(t *testing.T) {
 			wantContains:  "branch stale: rebase failed before agent start",
 		},
 		{
+			name:         "transient fetch failure is not permanent",
+			err:          fmt.Errorf("prepare worktree: %w", worktreeerr.ErrTransientFetch),
+			wantContains: "agent start delayed: transient network failure",
+		},
+		{
 			name:         "provider unhealthy is transient",
 			err:          &provider.UnhealthyError{Provider: "codex", Reason: "rate_limited"},
 			wantContains: "agent start blocked: provider codex unhealthy (rate_limited)",
@@ -120,6 +125,28 @@ func TestSurfaceStartFailure_TransientKeepsStatus(t *testing.T) {
 	reason := tasks.Reason("t1")
 	if !strings.Contains(reason, "git fetch: timeout") {
 		t.Errorf("reason %q missing transient error text", reason)
+	}
+}
+
+func TestSurfaceStartFailure_TransientFetchKeepsStatus(t *testing.T) {
+	// Regression guard for the bug this PR fixes: a network blip during
+	// worktree reconcile must never park the task human-required — it should
+	// behave exactly like any other transient failure and let the resume loop
+	// retry once connectivity recovers.
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
+	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+
+	wrapped := fmt.Errorf("prepare worktree: %w", worktreeerr.ErrTransientFetch)
+	engine.surfaceStartFailure("t1", "in-progress", wrapped)
+
+	got, _ := tasks.GetTask("t1")
+	if got.Status != "in-progress" {
+		t.Errorf("transient fetch failure flipped status: got %q, want in-progress", got.Status)
+	}
+	reason := tasks.Reason("t1")
+	if !strings.Contains(reason, "transient network failure") {
+		t.Errorf("reason %q missing transient-fetch classification", reason)
 	}
 }
 

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -150,6 +150,16 @@ func TestSurfaceStartFailure_TransientFetchKeepsStatus(t *testing.T) {
 	}
 }
 
+func TestIsTransientFetchReason(t *testing.T) {
+	t.Parallel()
+	if !isTransientFetchReason(transientFetchStatusReason) {
+		t.Fatal("expected canonical transient fetch reason to match")
+	}
+	if isTransientFetchReason("agent start failed: transient network failure reconciling worktree with remote") {
+		t.Fatal("unexpected match for non-canonical reason")
+	}
+}
+
 func TestSurfaceStartFailure_PermanentFlipsToHumanRequired(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})

--- a/internal/worktree/manager_test.go
+++ b/internal/worktree/manager_test.go
@@ -921,6 +921,56 @@ func TestPrepareForTask_RebaseConflictFailsClosed(t *testing.T) {
 	}
 }
 
+// TestPrepareForTask_TransientFetchFailureIsNotRebaseFailed proves the fix for
+// the bug where a network blip during reconcileAndRebase's remote fetch was
+// indistinguishable from a genuine content conflict: both wrapped
+// ErrRebaseFailed, so a transient SSH/DNS outage falsely parked a task
+// human-required on an otherwise clean branch.
+//
+// reconcileAndRebase's fetch/ls-remote target PushRemote's chosen remote
+// ("fork" when configured, else "origin"). Configuring an unreachable "fork"
+// remote isolates the failure to that step alone: PrepareForTask's earlier
+// "Fetching origin…" step (against the real local bare clone) keeps
+// succeeding, and only the reconcile step hits a real, deterministic
+// "Connection refused" transport error — reproducing the reported outage
+// without any external network dependency.
+func TestPrepareForTask_TransientFetchFailureIsNotRebaseFailed(t *testing.T) {
+	h := prepareHarness(t, nil, 30*time.Second)
+
+	tk, err := h.tasks.Store().Create("transient network task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.tasks.Update(tk.ID, task.Update{ProjectID: task.Ptr(h.proj.ID)}); err != nil {
+		t.Fatal(err)
+	}
+	tk, err = h.tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wtPath, err := h.m.PrepareForTask(context.Background(), tk, nil)
+	if err != nil {
+		t.Fatalf("initial PrepareForTask: %v", err)
+	}
+
+	// Point the push remote at a port nothing listens on: fetch fails fast
+	// with a real "Connection refused" transport error, exactly like the
+	// reported outage, while origin's own fetch remains healthy.
+	mustRunInDir(t, wtPath, "git", "remote", "add", "fork", "ssh://127.0.0.1:1/unreachable.git")
+
+	gotPath, err := h.m.PrepareForTask(context.Background(), tk, nil)
+	if !errors.Is(err, ErrTransientFetch) {
+		t.Fatalf("PrepareForTask error = %v, want ErrTransientFetch", err)
+	}
+	if errors.Is(err, ErrRebaseFailed) {
+		t.Fatalf("PrepareForTask error = %v must not also classify as ErrRebaseFailed (would wrongly escalate to human-required)", err)
+	}
+	if gotPath != "" {
+		t.Fatalf("PrepareForTask path = %q, want empty path on transient fetch failure", gotPath)
+	}
+}
+
 // TestPrepareForTask_RebaseFailureRecoversViaMerge proves the merge fallback
 // in reconcileAndRebase: a task branch whose commits, replayed individually,
 // hit an intermediate patch-apply conflict against the new base — even though

--- a/internal/worktree/prepare.go
+++ b/internal/worktree/prepare.go
@@ -18,6 +18,12 @@ import (
 // internal/task -> internal/workflow).
 var ErrRebaseFailed = worktreeerr.ErrRebaseFailed
 
+// ErrTransientFetch indicates reconcileAndRebase's remote fetch/ls-remote
+// step failed for a transient network reason rather than a genuine content
+// conflict. Alias of worktreeerr.ErrTransientFetch for the same import-cycle
+// reason as ErrRebaseFailed above.
+var ErrTransientFetch = worktreeerr.ErrTransientFetch
+
 // ErrTaskBranchMissing indicates a task's own branch does not exist locally
 // or on origin, so PrepareForBranchFix cannot check it out for no-PR conflict
 // recovery. Unlike PrepareForFix (which falls back to the PR head ref via
@@ -245,12 +251,18 @@ func (m *Manager) PrepareForTask(ctx context.Context, t task.Task, onPhase func(
 // continuing from a stale branch makes downstream diff gates scan historical
 // commits. If the rebase fails, it falls back to an additive merge (see
 // MergeOnto) before giving up, since most staleness under concurrent agents
-// is not a genuine content conflict. All three failures (reconcile, rebase,
-// and the merge fallback) wrap ErrRebaseFailed so the caller can surface a
-// repairable worktree.
+// is not a genuine content conflict. The rebase and merge-fallback failures
+// wrap ErrRebaseFailed so the caller can surface a repairable worktree. The
+// reconcile step is different: it performs a network fetch/ls-remote, and a
+// transient connectivity blip there (SSH/DNS/timeout) looks identical to a
+// genuine failure unless distinguished — so that case wraps ErrTransientFetch
+// instead, which callers must never escalate to human-required.
 func (m *Manager) reconcileAndRebase(ctx context.Context, wtPath, wtBranch, baseRef string, onPhase func(string)) error {
 	callPhase(onPhase, "Reconciling with remote…")
 	if err := project.ReconcileWithRemote(ctx, wtPath, wtBranch); err != nil {
+		if project.IsTransientNetworkError(err) {
+			return fmt.Errorf("%w: reconcile %s with remote: %w", ErrTransientFetch, wtBranch, err)
+		}
 		return fmt.Errorf("%w: reconcile %s with remote: %w", ErrRebaseFailed, wtBranch, err)
 	}
 	callPhase(onPhase, "Rebasing onto origin…")

--- a/internal/worktreeerr/worktreeerr.go
+++ b/internal/worktreeerr/worktreeerr.go
@@ -17,3 +17,12 @@ var ErrRebaseFailed = errors.New("worktree rebase failed")
 // internal/sybra's markRebaseBlocked and workflow.ClassifyAgentStartError so
 // the two escalation paths can't drift apart in wording.
 const RebaseBlockedReason = "branch stale: rebase failed before agent start; resolve conflicts or recreate the task branch"
+
+// ErrTransientFetch indicates a reused task worktree's remote reconcile step
+// failed for a transient network/transport reason (e.g. SSH connection
+// refused, DNS resolution failure, timeout) rather than a genuine content
+// conflict. Unlike ErrRebaseFailed, this must never escalate a task to
+// human-required — callers should treat it like any other transient
+// agent-start failure and let the normal resume/retry loop pick it back up
+// once connectivity recovers.
+var ErrTransientFetch = errors.New("worktree remote fetch failed transiently")


### PR DESCRIPTION
## Motivation

`reconcileAndRebase`'s remote reconcile step (fetch/ls-remote) wrapped every
failure in `ErrRebaseFailed`, so a transient SSH/DNS/timeout blip against the
remote looked identical to a genuine content conflict — escalating a
perfectly clean worktree to `human-required` and pausing an otherwise healthy
task on nothing more than a network hiccup.

## Implementation information

- Add `internal/project/git_network.go`: `IsTransientNetworkError` matches a
  narrow set of transport-failure substrings (connection refused/reset, DNS
  resolution, timeouts, etc.), and `withNetworkRetry` retries `fn` on the
  shared `gitOpRetryBackoffs` schedule when the failure looks transient.
- Wrap `remoteBranchHead`'s `ls-remote` and `ReconcileWithRemote`'s `fetch`
  calls in `withNetworkRetry` (`internal/project/git.go`).
- Add `worktreeerr.ErrTransientFetch` / `worktree.ErrTransientFetch` alias and
  have `reconcileAndRebase` wrap the reconcile failure in it instead of
  `ErrRebaseFailed` when `IsTransientNetworkError` matches
  (`internal/worktree/prepare.go`).
- `ClassifyAgentStartError` / `transientAgentStartError`
  (`internal/workflow/start_error.go`) treat `ErrTransientFetch` as
  non-permanent with a dedicated status reason, so `MarkRebaseBlocked` no
  longer escalates it to `human-required`.
- `Engine.ResumeStalled` (`internal/workflow/engine_events.go`) adds a bounded
  retry loop keyed off the transient-fetch status reason (max 2 attempts,
  tracked via a workflow variable) before falling back to escalation, and
  clears the retry counter once the agent starts cleanly.
- Tests: `internal/project/git_network_test.go`,
  `internal/worktree/manager_test.go`, `internal/workflow/engine_test.go`,
  `internal/workflow/start_error_test.go`, and
  `internal/sybra/agentorch/rebase_block_test.go` cover the retry/classify/
  escalation paths.

Closes https://github.com/Automaat/sybra/issues/1497

_Generated by Sybra harness_