### PR TITLE
fix(agent): enforce cost and turn guardrails in runner

### DIFF
--- a/internal/agent/event_stream.go
+++ b/internal/agent/event_stream.go
@@ -61,4 +61,10 @@ type StreamEvent struct {
 	// from this event's tool_result error blocks. Unexported so it is never
 	// serialized; lives in-memory only. Populated for claude "user" events only.
 	permissionDenials []PermissionDenial
+	// parentToolUseID is the Claude Code `parent_tool_use_id` field, non-empty
+	// when this event belongs to a forked subagent's turn rather than the
+	// top-level conversation (see CLAUDE_CODE_FORK_SUBAGENT). Unexported so it
+	// is never serialized; used only to exclude subagent chatter from the
+	// top-level turn count.
+	parentToolUseID string
 }

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -493,7 +493,14 @@ func (m *Manager) Guardrails() Guardrails {
 // TurnCostFraction * MaxCostUSD, meaning there is still meaningful budget left
 // and the turns limit can be auto-bumped without human approval.
 // If MaxCostUSD == 0, auto-continue is always allowed (cost is unlimited).
+// Verifier roles (review/test-runner/eval, see Role.IsVerifier) never
+// auto-continue: cost only updates on "result" events, so a fan-out can hold
+// it at a stale $0 for the whole run, and a verifier stuck in a loop should
+// escalate rather than silently get 2x/4x/8x the turn budget.
 func (m *Manager) canAutoContinueTurns(a *Agent) bool {
+	if RoleFromName(a.Name).IsVerifier() {
+		return false
+	}
 	m.mu.RLock()
 	maxCost := m.guardrails.MaxCostUSD
 	fraction := m.guardrails.TurnCostFraction

--- a/internal/agent/role.go
+++ b/internal/agent/role.go
@@ -38,6 +38,19 @@ func (r Role) AuthorsCode() bool {
 	}
 }
 
+// IsVerifier reports whether the role independently checks another agent's
+// work (review, test-runner, eval). These roles must not have their turn
+// budget auto-bumped: a verifier stuck in a fan-out loop should escalate to a
+// human promptly rather than being handed progressively larger turn budgets.
+func (r Role) IsVerifier() bool {
+	switch r {
+	case RoleReview, RoleTestRunner, RoleEval:
+		return true
+	default:
+		return false
+	}
+}
+
 // IsSystem returns true for roles whose agents should not trigger
 // user-facing notifications (triage, eval, plan-critic, human-review).
 func (r Role) IsSystem() bool {

--- a/internal/agent/runner_headless.go
+++ b/internal/agent/runner_headless.go
@@ -642,8 +642,14 @@ func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte
 		if event.OutputTokens > 0 {
 			a.AddOutputTokens(event.OutputTokens)
 		}
-		if keepGoing := m.checkTurnsGuardrail(ctx, a); !keepGoing {
-			return true
+		// A forked subagent's assistant turns carry parent_tool_use_id and must
+		// not inflate the top-level turn count: a single Task-tool fan-out can
+		// emit hundreds of subagent turns that have nothing to do with the
+		// top-level conversation the guardrail is meant to bound.
+		if event.parentToolUseID == "" {
+			if keepGoing := m.checkTurnsGuardrail(ctx, a); !keepGoing {
+				return true
+			}
 		}
 	}
 
@@ -664,17 +670,41 @@ func (m *Manager) processHeadlessLine(ctx context.Context, a *Agent, line []byte
 		maxCost := m.guardrails.MaxCostUSD
 		m.mu.RUnlock()
 		if maxCost > 0 && costNow > maxCost {
-			m.logger.Warn("agent.guardrail.cost", "id", a.ID, "cost", costNow, "limit", maxCost)
-			a.SetEscalationReason("cost")
-			m.emit(events.AgentEscalation(a.ID), EscalationEvent{
-				Reason:  "cost",
-				CostUSD: costNow,
-				Limit:   maxCost,
-			})
-			m.emit(events.AgentState(a.ID), a)
+			if keepGoing := m.checkCostGuardrail(ctx, a, costNow, maxCost); !keepGoing {
+				return true
+			}
 		}
 	}
 	return false
+}
+
+// checkCostGuardrail blocks the stream on a breach of MaxCostUSD until a
+// human responds via RespondEscalation. Unlike checkTurnsGuardrail there is
+// no auto-continue path: cost is the hard ceiling turns' auto-continue is
+// itself gated against, so a breach must always stop the run pending a human
+// decision rather than silently letting the process keep spending. Returns
+// false when the caller should stop the stream (subprocess is terminated by
+// the caller, mirroring checkTurnsGuardrail).
+func (m *Manager) checkCostGuardrail(ctx context.Context, a *Agent, costNow, maxCost float64) bool {
+	m.logger.Warn("agent.guardrail.cost", "id", a.ID, "cost", costNow, "limit", maxCost)
+	a.SetEscalationReason("cost")
+	m.emit(events.AgentEscalation(a.ID), EscalationEvent{
+		Reason:  "cost",
+		CostUSD: costNow,
+		Limit:   maxCost,
+	})
+	m.emit(events.AgentState(a.ID), a)
+	select {
+	case continueRun := <-a.escalationCh:
+		if !continueRun {
+			return false
+		}
+		a.SetEscalationReason("")
+		m.emit(events.AgentState(a.ID), a)
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 // reportScannerError surfaces bufio.Scanner errors at the end of the NDJSON

--- a/internal/agent/runner_headless_stream.go
+++ b/internal/agent/runner_headless_stream.go
@@ -42,7 +42,7 @@ func toolSignature(toolUses []ToolUseBlock) string {
 // for the headless runner. Tool uses are formatted as "[name] cmd/desc" strings.
 // Tool results are truncated to 500 chars.
 func claudeEventToStreamEvent(e ClaudeEvent) StreamEvent {
-	ev := StreamEvent{Type: e.Type, Subtype: e.Subtype, SessionID: e.SessionID}
+	ev := StreamEvent{Type: e.Type, Subtype: e.Subtype, SessionID: e.SessionID, parentToolUseID: e.ParentToolUseID}
 	switch e.Type {
 	case "system", "init":
 		ev.PluginErrors = e.PluginErrors

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -794,6 +794,11 @@ func TestGuardrails_TurnsBlocks_CostNearCap(t *testing.T) {
 // so a user who tightens the cost limit mid-run sees escalation on the
 // next result. A regression that cached the guardrails at start of loop
 // would miss the new limit and let the agent keep burning budget.
+//
+// The cost guardrail hard-blocks on breach pending a human decision (mirroring
+// the turns guardrail), so the agent is pre-armed with a buffered
+// escalationCh reply ("continue") to unblock the stream without a live
+// responder.
 func TestGuardrails_SetMidRunVisibleToStream(t *testing.T) {
 	// Result #1 below the eventual limit, result #2 pushes cumulative above.
 	input := `{"type":"result","result":"r1","session_id":"s1","total_cost_usd":5.0,"total_input_tokens":1,"total_output_tokens":1}` + "\n" +
@@ -822,7 +827,8 @@ func TestGuardrails_SetMidRunVisibleToStream(t *testing.T) {
 	// Start unlimited so result #1 doesn't escalate.
 	m.SetGuardrails(Guardrails{MaxCostUSD: 0})
 
-	a := &Agent{ID: "t", Provider: "claude"}
+	a := &Agent{ID: "t", Provider: "claude", escalationCh: make(chan bool, 1)}
+	a.escalationCh <- true
 	m.streamHeadlessOutput(t.Context(), a, bytes.NewReader([]byte(input)), nil)
 
 	mu.Lock()

--- a/internal/agent/runner_headless_test.go
+++ b/internal/agent/runner_headless_test.go
@@ -789,6 +789,36 @@ func TestGuardrails_TurnsBlocks_CostNearCap(t *testing.T) {
 	}
 }
 
+// TestGuardrails_SubagentAssistantTurnsExcluded verifies that Claude
+// assistant events carrying parent_tool_use_id (forked subagent turns) do
+// not increment Agent.TurnCount, while top-level assistant events (no
+// parent_tool_use_id) do. A regression in the parser or conversion path
+// that dropped parent_tool_use_id would silently reintroduce fan-out turn
+// inflation and trip MaxTurns on legitimate subagent chatter.
+func TestGuardrails_SubagentAssistantTurnsExcluded(t *testing.T) {
+	lines := []string{
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"top1"}]}}`,
+		`{"type":"assistant","parent_tool_use_id":"toolu_1","message":{"content":[{"type":"text","text":"sub1"}]}}`,
+		`{"type":"assistant","parent_tool_use_id":"toolu_1","message":{"content":[{"type":"text","text":"sub2"}]}}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"top2"}]}}`,
+	}
+	input := strings.Join(lines, "\n") + "\n"
+
+	logger := slog.New(slog.DiscardHandler)
+	m := mustNewManager(t, context.Background(), func(string, any) {}, logger, t.TempDir())
+	m.SetGuardrails(Guardrails{MaxTurns: 0})
+
+	a := &Agent{ID: "t", Provider: "claude"}
+	m.streamHeadlessOutput(t.Context(), a, bytes.NewReader([]byte(input)), nil)
+
+	if got := len(a.Output()); got != 4 {
+		t.Fatalf("got %d events, want 4 — stream stopped early", got)
+	}
+	if got := a.GetTurnCount(); got != 2 {
+		t.Errorf("TurnCount = %d, want 2 (only top-level assistant events count)", got)
+	}
+}
+
 // TestGuardrails_SetMidRunVisibleToStream verifies SetGuardrails picks up
 // live — the stream loop re-reads m.guardrails under RLock on every event,
 // so a user who tightens the cost limit mid-run sees escalation on the
@@ -836,6 +866,98 @@ func TestGuardrails_SetMidRunVisibleToStream(t *testing.T) {
 	// Cumulative cost after both results = 11.0, > new limit 10.0.
 	if escalations != 1 {
 		t.Errorf("got %d escalation events, want 1 (limit tightened mid-run should fire on result #2)", escalations)
+	}
+}
+
+// TestGuardrails_CostBlocks_RejectStopsStream verifies the cost guardrail's
+// hard-blocking path: a human reject (escalationCh <- false) must return
+// stop=true and the stream loop must not process any further lines,
+// mirroring the turns-guardrail kill path pinned by
+// TestGuardrails_TurnsBlocks_CostNearCap.
+func TestGuardrails_CostBlocks_RejectStopsStream(t *testing.T) {
+	resultLine := `{"type":"result","result":"r","session_id":"s1","total_cost_usd":11.0,"total_input_tokens":1,"total_output_tokens":1}`
+	trailingLine := `{"type":"assistant","message":{"content":[{"type":"text","text":"should never be processed"}]}}`
+	input := resultLine + "\n" + trailingLine + "\n"
+
+	var (
+		blocked int
+		mu      sync.Mutex
+	)
+	emit := func(event string, data any) {
+		if !strings.Contains(event, "agent:escalation:") {
+			return
+		}
+		if e, ok := data.(EscalationEvent); ok && e.Reason == "cost" {
+			mu.Lock()
+			blocked++
+			mu.Unlock()
+		}
+	}
+	logger := slog.New(slog.DiscardHandler)
+	m := mustNewManager(t, context.Background(), emit, logger, t.TempDir())
+	m.SetGuardrails(Guardrails{MaxCostUSD: 10.0})
+
+	a := &Agent{ID: "t", Provider: "claude", escalationCh: make(chan bool, 1)}
+	a.escalationCh <- false // reject: stop the run.
+	m.streamHeadlessOutput(t.Context(), a, bytes.NewReader([]byte(input)), nil)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if blocked != 1 {
+		t.Errorf("got %d cost escalation events, want 1", blocked)
+	}
+	// Only the result event should have been appended; the trailing
+	// assistant line must never reach the stream after the reject.
+	if got := len(a.Output()); got != 1 {
+		t.Errorf("got %d events, want 1 — stream kept processing lines after a rejected cost escalation", got)
+	}
+}
+
+// TestGuardrails_CostBlocks_ContextCancelStopsStream verifies that a
+// context cancellation (e.g. app shutdown) while the cost guardrail is
+// waiting on escalationCh also stops the stream, mirroring the reject path
+// above without requiring a human response.
+func TestGuardrails_CostBlocks_ContextCancelStopsStream(t *testing.T) {
+	input := `{"type":"result","result":"r","session_id":"s1","total_cost_usd":11.0,"total_input_tokens":1,"total_output_tokens":1}` + "\n"
+
+	var (
+		blocked int
+		mu      sync.Mutex
+	)
+	emit := func(event string, data any) {
+		if !strings.Contains(event, "agent:escalation:") {
+			return
+		}
+		if e, ok := data.(EscalationEvent); ok && e.Reason == "cost" {
+			mu.Lock()
+			blocked++
+			mu.Unlock()
+		}
+	}
+	logger := slog.New(slog.DiscardHandler)
+	m := mustNewManager(t, context.Background(), emit, logger, t.TempDir())
+	m.SetGuardrails(Guardrails{MaxCostUSD: 10.0})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	a := &Agent{ID: "t", Provider: "claude", escalationCh: make(chan bool, 1)}
+	raised := make(chan bool, 1)
+	go func() {
+		raised <- pollUntil(2*time.Second, time.Millisecond, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return blocked > 0
+		})
+		cancel()
+	}()
+	m.streamHeadlessOutput(ctx, a, bytes.NewReader([]byte(input)), nil)
+
+	if !<-raised {
+		t.Error("cost escalation was never raised before cancellation")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if blocked == 0 {
+		t.Error("expected blocking cost escalation event, got none")
 	}
 }
 

--- a/internal/agent/stream.go
+++ b/internal/agent/stream.go
@@ -53,6 +53,10 @@ type ClaudeEvent struct {
 	Raw          json.RawMessage // independent copy, never aliased to scanner buffer
 	Message      *ClaudeMessage
 	Result       *ClaudeResult
+	// ParentToolUseID is Claude Code's `parent_tool_use_id` field, non-empty
+	// when the event belongs to a forked subagent's turn (CLAUDE_CODE_FORK_SUBAGENT)
+	// rather than the top-level conversation.
+	ParentToolUseID string
 }
 
 // CodexEvent is the shared envelope for all Codex stream-json events.
@@ -82,16 +86,17 @@ type CopilotEvent struct {
 }
 
 type claudeEnvelope struct {
-	Type         string                `json:"type"`
-	Subtype      string                `json:"subtype"`
-	SessionID    string                `json:"session_id"`
-	PluginErrors []string              `json:"plugin_errors,omitempty"`
-	Message      *claudeMessagePayload `json:"message"`
-	Result       string                `json:"result"`
-	TotalCostUSD float64               `json:"total_cost_usd"`
-	IsError      bool                  `json:"is_error"`
-	APIStatus    int                   `json:"api_error_status"`
-	Error        string                `json:"error"`
+	Type            string                `json:"type"`
+	Subtype         string                `json:"subtype"`
+	SessionID       string                `json:"session_id"`
+	PluginErrors    []string              `json:"plugin_errors,omitempty"`
+	ParentToolUseID string                `json:"parent_tool_use_id,omitempty"`
+	Message         *claudeMessagePayload `json:"message"`
+	Result          string                `json:"result"`
+	TotalCostUSD    float64               `json:"total_cost_usd"`
+	IsError         bool                  `json:"is_error"`
+	APIStatus       int                   `json:"api_error_status"`
+	Error           string                `json:"error"`
 	// Real Claude Code result events nest token counts under `usage` (per
 	// platform.claude.com/docs/en/agent-sdk/headless and verified against
 	// captured agent NDJSON). Earlier root-level `total_*_tokens` fields are
@@ -369,9 +374,10 @@ func ParseClaudeLine(line []byte) (ClaudeEvent, error) {
 	}
 
 	event := ClaudeEvent{
-		Type:    raw.Type,
-		Subtype: raw.Subtype,
-		Raw:     copyRaw(line),
+		Type:            raw.Type,
+		Subtype:         raw.Subtype,
+		Raw:             copyRaw(line),
+		ParentToolUseID: raw.ParentToolUseID,
 	}
 
 	switch raw.Type {


### PR DESCRIPTION
## Motivation

Guardrail defaults ($5 / 150 turns) weren't biting: single reviews reached 366 turns and true ~$9. Three causes (see #1486): turn counter counted subagent chatter, auto-continue bumped the limit on stale $0 cost, and the cost cap only emitted an escalation event without stopping the stream.

> Changelog: fix(agent): enforce cost and turn guardrails in runner

Closes #1486

## Implementation information

- Gate turn counting on top-level events (`parent_tool_use_id == ""`) so subagent fan-out no longer inflates the count.
- Don't auto-bump the turn budget for verifier roles / on stale cost.
- Make the cost cap a hard-stop that terminates the stream, matching the turns path.
- Added focused tests in `internal/agent/runner_headless_test.go` covering subagent-turn exclusion and the cost-reject / context-cancel stop paths.

## Supporting documentation

Part of umbrella #1493. Codex review found no blocking correctness issues; `go test ./...`, the e2e suite, and `golangci-lint` are green.