### PR TITLE
fix(workflow): circuit breaker for flapping tasks

### DIFF
--- a/internal/sybra/agentorch/rebase_block_test.go
+++ b/internal/sybra/agentorch/rebase_block_test.go
@@ -158,3 +158,47 @@ func TestMarkRebaseBlocked_IgnoresTransientFetch(t *testing.T) {
 		t.Fatalf("status = %q, want unchanged %q", got.Status, task.StatusTodo)
 	}
 }
+
+// TestMarkRebaseBlockedWithRecoveryResult_HandledWithoutRecovery pins the
+// handled/recovered distinction sybra#1487's fix depends on: when the rebase
+// failure resolves via the already-resolved-remote-PR downgrade (not an
+// autonomous conflict-fix redispatch), the call is still fully "handled" —
+// callers must not treat handled=false-equivalent (checking only `recovered`)
+// and fall through to their own status write, which would clobber the
+// in_review status this call already set back to human-required using a
+// stale pre-dispatch snapshot.
+func TestMarkRebaseBlockedWithRecoveryResult_HandledWithoutRecovery(t *testing.T) {
+	orig := fetchPRStateForRebaseBlock
+	defer func() { fetchPRStateForRebaseBlock = orig }()
+	fetchPRStateForRebaseBlock = func(repo string, number int) (github.PRState, error) {
+		return github.PRState{State: "OPEN", Mergeable: "MERGEABLE"}, nil
+	}
+
+	tasks := newRebaseBlockTestManager(t)
+	tk, err := tasks.Create("pr-fix task", "", "headless")
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectID := "acme/widgets"
+	prNumber := 42
+	if _, err := tasks.Update(tk.ID, task.Update{ProjectID: &projectID, PRNumber: &prNumber}); err != nil {
+		t.Fatal(err)
+	}
+
+	handled, recovered := MarkRebaseBlockedWithRecoveryResult(tasks, tk.ID, worktree.ErrRebaseFailed, discardSlogLogger(),
+		func(string) bool { return false })
+	if !handled {
+		t.Fatal("handled = false, want true — the already-resolved downgrade fully applies the status change")
+	}
+	if recovered {
+		t.Fatal("recovered = true, want false — no conflict-fix agent was dispatched")
+	}
+
+	got, err := tasks.Get(tk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != task.StatusInReview {
+		t.Fatalf("status = %q, want %q", got.Status, task.StatusInReview)
+	}
+}

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -28,6 +28,14 @@ const (
 	humanReviewMaxAgentTurns  = 40
 	humanReviewMaxAgentResult = 4000
 	humanReviewWindow         = time.Hour
+
+	// humanReviewMaxPerTaskPerWindow caps how many times a SINGLE task can
+	// spawn a review agent within humanReviewWindow. The global window
+	// (allowSpawnLocked) bounds total fleet spend but does not stop one
+	// flapping task (e.g. status oscillating todo<->human-required) from
+	// consuming every slot in the window and starving every other task's
+	// diagnosis. This is a per-task budget layered on top of that global one.
+	humanReviewMaxPerTaskPerWindow = 2
 )
 
 // humanReviewIssueFiler is the subset of monitor.GHIssueSink the handler
@@ -63,8 +71,9 @@ type humanReviewHandler struct {
 	workCtx func(projectID string) *WorkScrubContext
 
 	mu       sync.Mutex
-	inflight map[string]string // taskID -> agent ID
-	recent   []time.Time       // spawn timestamps (rolling window)
+	inflight map[string]string      // taskID -> agent ID
+	recent   []time.Time            // spawn timestamps (rolling window), global cap
+	perTask  map[string][]time.Time // taskID -> spawn timestamps (rolling window), per-task cap
 }
 
 // verdictDecision is the agent's structured output, produced via
@@ -94,6 +103,7 @@ func newHumanReviewHandler(
 		now:      time.Now,
 		workCtx:  workCtx,
 		inflight: make(map[string]string),
+		perTask:  make(map[string][]time.Time),
 	}
 }
 
@@ -161,9 +171,16 @@ func (h *humanReviewHandler) maybeSpawn(taskID, prevStatus string) {
 		h.skip(taskID, "rate_limited")
 		return
 	}
+	if !h.allowSpawnForTaskLocked(taskID) {
+		h.mu.Unlock()
+		h.skip(taskID, "task_rate_limited")
+		return
+	}
 	// Reserve the slot before spawning so a racing second flip is rejected.
 	h.inflight[taskID] = ""
-	h.recent = append(h.recent, h.now())
+	now := h.now()
+	h.recent = append(h.recent, now)
+	h.perTask[taskID] = append(h.perTask[taskID], now)
 	h.mu.Unlock()
 
 	prompt := h.buildPrompt(t, wctx)
@@ -633,6 +650,26 @@ func (h *humanReviewHandler) allowSpawnLocked() bool {
 	}
 	h.recent = kept
 	return len(h.recent) < limit
+}
+
+// allowSpawnForTaskLocked must be called with h.mu held. Trims expired
+// entries from h.perTask[taskID] and returns false once that single task has
+// spawned humanReviewMaxPerTaskPerWindow reviews within the window — the
+// per-task counterpart to allowSpawnLocked's fleet-wide budget. Without this,
+// a single task whose status keeps oscillating into human-required can spend
+// every slot the global window allows, starving every other task's
+// diagnosis (see task 90befcef's origin incident: 235 flaps drained the
+// fleet's review budget on one task).
+func (h *humanReviewHandler) allowSpawnForTaskLocked(taskID string) bool {
+	cutoff := h.now().Add(-humanReviewWindow)
+	kept := h.perTask[taskID][:0]
+	for _, ts := range h.perTask[taskID] {
+		if ts.After(cutoff) {
+			kept = append(kept, ts)
+		}
+	}
+	h.perTask[taskID] = kept
+	return len(kept) < humanReviewMaxPerTaskPerWindow
 }
 
 func (h *humanReviewHandler) logAudit(evt, taskID, agentID string, data map[string]any) {

--- a/internal/sybra/app_human_review.go
+++ b/internal/sybra/app_human_review.go
@@ -668,7 +668,11 @@ func (h *humanReviewHandler) allowSpawnForTaskLocked(taskID string) bool {
 			kept = append(kept, ts)
 		}
 	}
-	h.perTask[taskID] = kept
+	if len(kept) == 0 {
+		delete(h.perTask, taskID)
+	} else {
+		h.perTask[taskID] = kept
+	}
 	return len(kept) < humanReviewMaxPerTaskPerWindow
 }
 

--- a/internal/sybra/app_human_review_test.go
+++ b/internal/sybra/app_human_review_test.go
@@ -147,6 +147,54 @@ func TestRateLimiter(t *testing.T) {
 	}
 }
 
+// TestPerTaskRateLimiter is a regression guard for sybra#1487: a single task
+// whose status keeps oscillating into human-required must not be allowed to
+// consume the entire global review budget (cfg.HumanReview.MaxPerHour=3 in
+// this test env) and starve every other task's diagnosis.
+func TestPerTaskRateLimiter(t *testing.T) {
+	t.Parallel()
+	h, _, _, cleanup := newReviewTestEnv(t)
+	defer cleanup()
+
+	now := time.Now()
+	h.now = func() time.Time { return now }
+
+	for i := range humanReviewMaxPerTaskPerWindow {
+		h.mu.Lock()
+		ok := h.allowSpawnForTaskLocked("flapping-task")
+		if ok {
+			h.perTask["flapping-task"] = append(h.perTask["flapping-task"], h.now())
+		}
+		h.mu.Unlock()
+		if !ok {
+			t.Fatalf("spawn %d for the same task should be allowed", i)
+		}
+	}
+	h.mu.Lock()
+	overLimit := h.allowSpawnForTaskLocked("flapping-task")
+	h.mu.Unlock()
+	if overLimit {
+		t.Errorf("task should be rate-limited after %d spawns within the window", humanReviewMaxPerTaskPerWindow)
+	}
+
+	// A different task must be unaffected by the flapping task's budget.
+	h.mu.Lock()
+	otherAllowed := h.allowSpawnForTaskLocked("other-task")
+	h.mu.Unlock()
+	if !otherAllowed {
+		t.Errorf("an unrelated task should not be rate-limited by another task's spawns")
+	}
+
+	// Advance past the window: the flapping task's own budget frees up.
+	h.now = func() time.Time { return now.Add(humanReviewWindow + time.Minute) }
+	h.mu.Lock()
+	allowedAfterWindow := h.allowSpawnForTaskLocked("flapping-task")
+	h.mu.Unlock()
+	if !allowedAfterWindow {
+		t.Errorf("after window, the flapping task should be allowed again")
+	}
+}
+
 func TestOnComplete_HumanVerdict_AppendsNote(t *testing.T) {
 	t.Parallel()
 	h, tasks, sink, cleanup := newReviewTestEnv(t)

--- a/internal/sybra/app_workflow.go
+++ b/internal/sybra/app_workflow.go
@@ -568,7 +568,17 @@ func (a *agentAdapter) classifyDirectDispatchWorktreeErr(taskID string, wtErr er
 	if errors.Is(wtErr, worktreeerr.ErrAgentRunning) {
 		return workflow.ErrDispatchInFlight
 	}
-	if _, recovered := a.agentOrch.RecoverFromWorktreePrepFailure(a.tasks, taskID, wtErr); recovered {
+	// handled=true covers every branch of RecoverFromWorktreePrepFailure that
+	// already wrote the task's terminal status itself: an autonomous
+	// conflict-fix redispatch (recovered=true), MarkRebaseBlocked parking the
+	// task at human-required, or its already-resolved-on-remote downgrade to
+	// in_review. Only checking recovered (as before) let an unhandled-but-not-
+	// recovered rebase failure fall through to `return wtErr` below even
+	// though the status was already resolved — the caller's surfaceStartFailure
+	// would then reclassify the same wtErr and clobber that resolved status
+	// (e.g. overwriting in_review back to human-required) using a stale
+	// pre-dispatch status snapshot.
+	if handled, _ := a.agentOrch.RecoverFromWorktreePrepFailure(a.tasks, taskID, wtErr); handled {
 		return workflow.ErrDispatchInFlight
 	}
 	return wtErr

--- a/internal/workflow/engine_advance.go
+++ b/internal/workflow/engine_advance.go
@@ -288,6 +288,39 @@ func parallelHasChild(parent *Step, childID string) bool {
 	return false
 }
 
+// dispatchStepError wraps an error that occurred while executeSteps was
+// trying to start a specific step, so callers that only hold the *previous*
+// step's ID (e.g. HandleAgentComplete, which calls AdvanceStep and only knows
+// the step that just completed) can attribute the failure — and any
+// circuit-breaker bookkeeping keyed off it — to the step that actually failed
+// to dispatch instead of the one that finished successfully.
+type dispatchStepError struct {
+	stepID string
+	err    error
+}
+
+func (d *dispatchStepError) Error() string { return d.err.Error() }
+func (d *dispatchStepError) Unwrap() error { return d.err }
+
+// wrapDispatchErr tags a non-nil dispatch error with the step that failed to
+// start; nil passes through unchanged.
+func wrapDispatchErr(stepID string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &dispatchStepError{stepID: stepID, err: err}
+}
+
+// dispatchFailureStepID returns the step ID a dispatchStepError was recorded
+// against, or fallback if err doesn't carry one.
+func dispatchFailureStepID(err error, fallback string) string {
+	var dse *dispatchStepError
+	if errors.As(err, &dse) {
+		return dse.stepID
+	}
+	return fallback
+}
+
 // CycleError is returned when executeSteps detects a cycle in the synchronous
 // step chain — the same step ID was visited twice without an async step
 // (run_agent, wait_human) breaking the loop.
@@ -348,11 +381,11 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 		// will call AdvanceStep later.
 		switch step.Type {
 		case StepRunAgent:
-			return nil, e.execRunAgent(taskID, step, wfExec, ctx)
+			return nil, wrapDispatchErr(step.ID, e.execRunAgent(taskID, step, wfExec, ctx))
 		case StepParallel:
 			return e.execParallel(taskID, def, step, wfExec, ctx)
 		case StepWaitHuman:
-			return nil, e.execWaitHuman(taskID, step, wfExec)
+			return nil, wrapDispatchErr(step.ID, e.execWaitHuman(taskID, step, wfExec))
 		case StepSetStatus, StepCondition, StepShell, StepEnsurePRClosesIssue, StepStampPRAttribution, StepRerequestReview, StepVerifyCommits, StepLinkPRAndReview, StepEvaluate, StepRequireSidecar, StepValidatePlan, StepValidatePlanContract, StepTriageReview, StepDetectTampering, StepVerifyChecks, StepRoutePRFixResult, StepRouteTestResult, StepSyncBranch, StepResumeWorkflow:
 			// handled below as sync steps
 		default:
@@ -378,7 +411,7 @@ func (e *Engine) executeSteps(taskID string, def *Definition, step *Step, wfExec
 				var parkedNoCompletion *CompletionInfo
 				return parkedNoCompletion, nil
 			}
-			return nil, execErr
+			return nil, wrapDispatchErr(step.ID, execErr)
 		}
 
 		now := time.Now().UTC()

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -20,6 +20,10 @@ const (
 	maxWatchdogRateLimitRetries     = 2
 	transientFetchRetryVarPrefix    = "transient_fetch.retry."
 	maxTransientFetchRetries        = 2
+	circuitBreakerFailureVarPrefix  = "circuit_breaker.failures."
+	circuitBreakerFirstVarPrefix    = "circuit_breaker.first_failure."
+	maxCircuitBreakerFailures       = 3
+	circuitBreakerWindow            = 15 * time.Minute
 )
 
 // HandleHumanAction processes approve/reject/input from the UI.
@@ -300,7 +304,7 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 		// Without this, the task sits in-progress with the only signal in
 		// logs until ResumeStalled gets a chance to retry.
 		if t.Status != "" {
-			e.surfaceStartFailure(taskID, t.Status, err)
+			e.surfaceStartFailure(taskID, t.Status, err, t.Workflow, spawnedStep)
 		}
 	}
 	e.clearAgentStep(c.AgentID)
@@ -496,7 +500,7 @@ func (e *Engine) RescheduleRateLimitedAgent(taskID, agentID string) {
 	e.fireComplete(comp)
 	e.resumeError.Log(e.logger, "workflow.rate-limit-reschedule.exec", taskID, rErr, "task_id", taskID)
 	if rErr != nil {
-		e.surfaceStartFailure(taskID, t.Status, rErr)
+		e.surfaceStartFailure(taskID, t.Status, rErr, t.Workflow, step.ID)
 	}
 }
 
@@ -551,7 +555,7 @@ func (e *Engine) rescheduleRateLimitedParallelChild(taskID, agentID string, pare
 		e.logger.Error("workflow.rate-limit-reschedule.parallel.set", "task_id", taskID, "parent", parent.ID, "child", child.ID, "err", setErr)
 	}
 	if spawnErr != nil {
-		e.surfaceStartFailure(taskID, fresh.Status, spawnErr)
+		e.surfaceStartFailure(taskID, fresh.Status, spawnErr, wfExec, child.ID)
 	}
 }
 
@@ -736,9 +740,10 @@ func (e *Engine) ResumeStalled() {
 		e.fireComplete(comp)
 		e.resumeError.Log(e.logger, "workflow.resume-stalled.exec", t.ID, rErr, "task_id", t.ID)
 		if rErr != nil {
-			e.surfaceStartFailure(t.ID, fresh.Status, rErr)
+			e.surfaceStartFailure(t.ID, fresh.Status, rErr, fresh.Workflow, step.ID)
 		} else {
 			e.clearTransientFetchRetry(fresh.ID, fresh.Workflow, step.ID)
+			e.clearCircuitBreakerOnSuccess(fresh.ID, fresh.Workflow, step.ID)
 		}
 	}
 }
@@ -923,16 +928,105 @@ func workflowRetryAfter(wf *Execution) (time.Time, bool) {
 // Idempotent: writing the same reason twice is a no-op for the user — the
 // task already shows it. The transient branch deliberately does not change
 // status, so retries continue.
-func (e *Engine) surfaceStartFailure(taskID, currentStatus string, err error) {
+//
+// wf and stepID feed the circuit breaker below; pass the caller's Execution
+// and the failing step's ID so repeated failures for that (task, step) are
+// tracked. Either may be zero-valued (nil wf, empty stepID) for callers that
+// don't have them handy — the breaker simply stays inactive for that call.
+func (e *Engine) surfaceStartFailure(taskID, currentStatus string, err error, wf *Execution, stepID string) {
 	reason, permanent := ClassifyAgentStartError(err)
 	if reason == "" {
+		return
+	}
+	// Sticky: a task already parked at human-required must not be touched
+	// again from here. Without this, a call driven by a stale pre-dispatch
+	// status snapshot could rewrite a status a concurrent handler resolved
+	// to something more specific (e.g. in_review) back to human-required.
+	if currentStatus == "human-required" {
 		return
 	}
 	target := currentStatus
 	if permanent {
 		target = "human-required"
 	}
+	if wf != nil && stepID != "" {
+		attempts, trip := recordCircuitBreakerFailure(wf, stepID, time.Now())
+		if trip {
+			// The status skip in resumeSkipReasonForStatus alone is not a
+			// sufficient backstop against a flapping loop: it only stops
+			// ResumeStalled from touching a task that is CURRENTLY
+			// human-required, but does nothing once some other path (a
+			// racing recovery branch, a status-change hook, a future bug)
+			// flips it back off human-required. Marking the workflow
+			// ExecFailed makes the halt independent of task.Status entirely
+			// — every resume path in this file (ResumeStalled,
+			// RescheduleRateLimitedAgent, HandleStatusChange) already
+			// refuses to touch a workflow whose State is ExecFailed.
+			wf.State = ExecFailed
+			target = "human-required"
+			reason = fmt.Sprintf("circuit breaker: %s (tripped after %d dispatch failures for step %q within %s)",
+				reason, attempts, stepID, circuitBreakerWindow)
+			e.logger.Warn("workflow.circuit-breaker.tripped",
+				"task_id", taskID, "step", stepID, "attempts", attempts)
+		}
+		if setErr := e.tasks.SetWorkflow(taskID, wf); setErr != nil {
+			e.logger.Error("workflow.circuit-breaker.persist", "task_id", taskID, "step", stepID, "err", setErr)
+		}
+	}
 	if uErr := e.tasks.UpdateTaskStatus(taskID, target, reason); uErr != nil {
 		e.logger.Error("workflow.resume-stalled.surface", "task_id", taskID, "err", uErr)
+	}
+}
+
+func circuitBreakerFailureKey(stepID string) string { return circuitBreakerFailureVarPrefix + stepID }
+func circuitBreakerFirstKey(stepID string) string   { return circuitBreakerFirstVarPrefix + stepID }
+
+// recordCircuitBreakerFailure is the generic counterpart to
+// handleWatchdogHangRetry's retry budget: instead of bounding retries of one
+// specific known failure signature, it bounds ANY repeated agent-start
+// failure for the same (task, step), regardless of cause. Once the count
+// crosses maxCircuitBreakerFailures within circuitBreakerWindow, the caller
+// trips the breaker.
+func recordCircuitBreakerFailure(wf *Execution, stepID string, now time.Time) (attempts int, trip bool) {
+	firstKey := circuitBreakerFirstKey(stepID)
+	failKey := circuitBreakerFailureKey(stepID)
+	first, err := time.Parse(time.RFC3339, wf.Variables[firstKey])
+	if err != nil || now.Sub(first) > circuitBreakerWindow {
+		wf.SetVar(firstKey, now.Format(time.RFC3339))
+		wf.SetVar(failKey, "1")
+		return 1, false
+	}
+	attempts = parseWorkflowInt(wf.Variables[failKey]) + 1
+	wf.SetVar(failKey, strconv.Itoa(attempts))
+	return attempts, attempts >= maxCircuitBreakerFailures
+}
+
+// clearCircuitBreakerFailures drops the per-(task,step) failure counter once
+// a dispatch attempt for that step succeeds, so a step that fails a couple of
+// times, recovers, and later fails again starts a fresh window rather than
+// inheriting stale attempts from an unrelated earlier incident.
+func clearCircuitBreakerFailures(wf *Execution, stepID string) {
+	if wf == nil || wf.Variables == nil || stepID == "" {
+		return
+	}
+	delete(wf.Variables, circuitBreakerFailureKey(stepID))
+	delete(wf.Variables, circuitBreakerFirstKey(stepID))
+}
+
+// clearCircuitBreakerOnSuccess persists the failure-counter reset performed
+// by clearCircuitBreakerFailures. Split out so callers that don't have a
+// failure counter to begin with (the common case) skip a wasted SetWorkflow.
+func (e *Engine) clearCircuitBreakerOnSuccess(taskID string, wf *Execution, stepID string) {
+	if wf == nil || wf.Variables == nil || stepID == "" {
+		return
+	}
+	_, hasFail := wf.Variables[circuitBreakerFailureKey(stepID)]
+	_, hasFirst := wf.Variables[circuitBreakerFirstKey(stepID)]
+	if !hasFail && !hasFirst {
+		return
+	}
+	clearCircuitBreakerFailures(wf, stepID)
+	if err := e.tasks.SetWorkflow(taskID, wf); err != nil {
+		e.logger.Error("workflow.circuit-breaker.clear", "task_id", taskID, "step", stepID, "err", err)
 	}
 }

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -509,6 +509,8 @@ func (e *Engine) RescheduleRateLimitedAgent(taskID, agentID string) {
 	e.resumeError.Log(e.logger, "workflow.rate-limit-reschedule.exec", taskID, rErr, "task_id", taskID)
 	if rErr != nil {
 		e.surfaceStartFailure(taskID, t.Status, rErr, t.Workflow, step.ID)
+	} else {
+		e.clearCircuitBreakerOnSuccess(taskID, t.Workflow, step.ID)
 	}
 }
 
@@ -558,6 +560,8 @@ func (e *Engine) rescheduleRateLimitedParallelChild(taskID, agentID string, pare
 		status.Status = "pending"
 		status.Output = "reschedule failed: " + spawnErr.Error()
 		status.AgentID = ""
+	} else {
+		clearCircuitBreakerFailures(wfExec, child.ID)
 	}
 	if setErr := e.tasks.SetWorkflow(taskID, wfExec); setErr != nil {
 		e.logger.Error("workflow.rate-limit-reschedule.parallel.set", "task_id", taskID, "parent", parent.ID, "child", child.ID, "err", setErr)

--- a/internal/workflow/engine_events.go
+++ b/internal/workflow/engine_events.go
@@ -303,8 +303,16 @@ func (e *Engine) HandleAgentComplete(taskID string, c AgentCompletion) {
 		// the *next* step couldn't spawn its agent (e.g. project missing).
 		// Without this, the task sits in-progress with the only signal in
 		// logs until ResumeStalled gets a chance to retry.
+		//
+		// The failure is attributed to the step that actually failed to
+		// dispatch (unwrapped from a dispatchStepError), not spawnedStep —
+		// AdvanceStep usually fails advancing *past* spawnedStep, into the
+		// next step, so keying circuit-breaker/reason bookkeeping off
+		// spawnedStep would blame the wrong step and let the real offender's
+		// stale counters leak into unrelated future chains.
 		if t.Status != "" {
-			e.surfaceStartFailure(taskID, t.Status, err, t.Workflow, spawnedStep)
+			failedStep := dispatchFailureStepID(err, spawnedStep)
+			e.surfaceStartFailure(taskID, t.Status, err, t.Workflow, failedStep)
 		}
 	}
 	e.clearAgentStep(c.AgentID)

--- a/internal/workflow/engine_steps_parallel.go
+++ b/internal/workflow/engine_steps_parallel.go
@@ -77,7 +77,7 @@ func (e *Engine) execParallel(taskID string, def *Definition, step *Step, wfExec
 			if transientAgentStartError(err) {
 				status.Status = "pending"
 				status.Output = "spawn blocked: " + err.Error()
-				e.surfaceStartFailure(taskID, ctx.Task.Status, err)
+				e.surfaceStartFailure(taskID, ctx.Task.Status, err, wfExec, child.ID)
 				continue
 			}
 			// Mark this child failed up front; AdvanceStep treats failed

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -3,8 +3,10 @@ package workflow
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Automaat/sybra/internal/project"
 	"github.com/Automaat/sybra/internal/provider"
@@ -118,7 +120,7 @@ func TestSurfaceStartFailure_DispatchInFlightIsNoOp(t *testing.T) {
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
 
-	engine.surfaceStartFailure("t1", "in-progress", ErrDispatchInFlight)
+	engine.surfaceStartFailure("t1", "in-progress", ErrDispatchInFlight, nil, "")
 
 	got, _ := tasks.GetTask("t1")
 	if got.Status != "in-progress" {
@@ -134,7 +136,7 @@ func TestSurfaceStartFailure_TransientKeepsStatus(t *testing.T) {
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
 
-	engine.surfaceStartFailure("t1", "in-progress", errors.New("git fetch: timeout"))
+	engine.surfaceStartFailure("t1", "in-progress", errors.New("git fetch: timeout"), nil, "")
 
 	got, _ := tasks.GetTask("t1")
 	if got.Status != "in-progress" {
@@ -156,7 +158,7 @@ func TestSurfaceStartFailure_TransientFetchKeepsStatus(t *testing.T) {
 	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
 
 	wrapped := fmt.Errorf("prepare worktree: %w", worktreeerr.ErrTransientFetch)
-	engine.surfaceStartFailure("t1", "in-progress", wrapped)
+	engine.surfaceStartFailure("t1", "in-progress", wrapped, nil, "")
 
 	got, _ := tasks.GetTask("t1")
 	if got.Status != "in-progress" {
@@ -184,7 +186,7 @@ func TestSurfaceStartFailure_PermanentFlipsToHumanRequired(t *testing.T) {
 	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
 
 	wrapped := fmt.Errorf("worktree required: %w", project.ErrProjectNotRegistered)
-	engine.surfaceStartFailure("t1", "in-progress", wrapped)
+	engine.surfaceStartFailure("t1", "in-progress", wrapped, nil, "")
 
 	got, _ := tasks.GetTask("t1")
 	if got.Status != "human-required" {
@@ -211,7 +213,7 @@ func TestSurfaceStartFailure_RebaseFailedFlipsToHumanRequired(t *testing.T) {
 	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
 
 	wrapped := fmt.Errorf("prepare worktree: %w", worktreeerr.ErrRebaseFailed)
-	engine.surfaceStartFailure("t1", "in-progress", wrapped)
+	engine.surfaceStartFailure("t1", "in-progress", wrapped, nil, "")
 
 	got, _ := tasks.GetTask("t1")
 	if got.Status != "human-required" {
@@ -228,9 +230,83 @@ func TestSurfaceStartFailure_NilErrIsNoOp(t *testing.T) {
 	tasks.Put(TaskInfo{ID: "t1", Status: "in-progress"})
 	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
 
-	engine.surfaceStartFailure("t1", "in-progress", nil)
+	engine.surfaceStartFailure("t1", "in-progress", nil, nil, "")
 
 	if reason := tasks.Reason("t1"); reason != "" {
 		t.Errorf("nil err wrote reason %q, want empty", reason)
+	}
+}
+
+func TestSurfaceStartFailure_CircuitBreakerTripsAfterRepeatedFailures(t *testing.T) {
+	// Regression guard for the flapping-task circuit breaker (sybra#1487): a
+	// task whose dispatch keeps failing for the same step must eventually be
+	// halted independent of status.Status alone, since something else in the
+	// system (a racing recovery branch, a status-change hook) could otherwise
+	// keep flipping it off human-required and letting the resume loop retry
+	// forever.
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
+	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+
+	wrapped := fmt.Errorf("prepare worktree: %w", worktreeerr.ErrRebaseFailed)
+	wf := &Execution{CurrentStep: "run_test", State: ExecRunning, Variables: map[string]string{}}
+
+	for i := range maxCircuitBreakerFailures - 1 {
+		engine.surfaceStartFailure("t1", "todo", wrapped, wf, "run_test")
+		if wf.State == ExecFailed {
+			t.Fatalf("breaker tripped early on attempt %d, want after %d", i+1, maxCircuitBreakerFailures)
+		}
+	}
+	engine.surfaceStartFailure("t1", "todo", wrapped, wf, "run_test")
+
+	if wf.State != ExecFailed {
+		t.Errorf("wf.State = %q, want ExecFailed after %d failures", wf.State, maxCircuitBreakerFailures)
+	}
+	got, _ := tasks.GetTask("t1")
+	if got.Status != "human-required" {
+		t.Errorf("status = %q, want human-required", got.Status)
+	}
+	if reason := tasks.Reason("t1"); !strings.Contains(reason, "circuit breaker") {
+		t.Errorf("reason %q missing circuit-breaker classification", reason)
+	}
+}
+
+func TestSurfaceStartFailure_CircuitBreakerResetsAfterWindow(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "todo"})
+	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+
+	wrapped := fmt.Errorf("prepare worktree: %w", worktreeerr.ErrRebaseFailed)
+	old := time.Now().Add(-2 * circuitBreakerWindow).Format(time.RFC3339)
+	wf := &Execution{
+		CurrentStep: "run_test",
+		State:       ExecRunning,
+		Variables: map[string]string{
+			circuitBreakerFirstKey("run_test"):   old,
+			circuitBreakerFailureKey("run_test"): strconv.Itoa(maxCircuitBreakerFailures),
+		},
+	}
+
+	engine.surfaceStartFailure("t1", "todo", wrapped, wf, "run_test")
+
+	if wf.State == ExecFailed {
+		t.Error("breaker tripped using a stale, expired failure window")
+	}
+	if got := wf.Variables[circuitBreakerFailureKey("run_test")]; got != "1" {
+		t.Errorf("failure count = %q, want reset to 1", got)
+	}
+}
+
+func TestSurfaceStartFailure_AlreadyHumanRequiredIsNoOp(t *testing.T) {
+	tasks := newMemTasks()
+	tasks.Put(TaskInfo{ID: "t1", Status: "human-required", StatusReason: "existing reason"})
+	engine := NewEngine(nil, tasks, newMockAgents(), discardLogger())
+
+	wrapped := fmt.Errorf("prepare worktree: %w", worktreeerr.ErrRebaseFailed)
+	engine.surfaceStartFailure("t1", "human-required", wrapped, nil, "")
+
+	got, _ := tasks.GetTask("t1")
+	if got.StatusReason != "existing reason" {
+		t.Errorf("StatusReason = %q, want unchanged existing reason", got.StatusReason)
 	}
 }

--- a/internal/workflow/start_error_test.go
+++ b/internal/workflow/start_error_test.go
@@ -297,6 +297,46 @@ func TestSurfaceStartFailure_CircuitBreakerResetsAfterWindow(t *testing.T) {
 	}
 }
 
+// TestHandleAgentComplete_CircuitBreakerAttributesNextStepNotCompletedStep is
+// a regression guard for the review finding on 90befcef: HandleAgentComplete
+// only knows the step that just completed (spawnedStep), but the error
+// AdvanceStep returns typically comes from failing to dispatch the *next*
+// step. Recording the circuit-breaker failure against spawnedStep would
+// misdiagnose which step is flapping and let a later successful dispatch of
+// the real offender never clear it.
+func TestHandleAgentComplete_CircuitBreakerAttributesNextStepNotCompletedStep(t *testing.T) {
+	store := newTestStore(t)
+	tasks := newMemTasks()
+	agents := newMockAgents()
+	engine := NewEngine(store, tasks, agents, discardLogger())
+
+	tasks.Put(TaskInfo{ID: "t1", Status: "todo", AgentMode: "headless"})
+	if err := engine.StartWorkflow("t1", "test-simple"); err != nil {
+		t.Fatal(err)
+	}
+	if agents.LastCall().Role != "triage" {
+		t.Fatalf("expected triage, got %q", agents.LastCall().Role)
+	}
+	triageAgentID := agents.LastID()
+
+	// Arm the mock so the next dispatch (implement, reached via
+	// triage -> set_in_progress -> implement) fails to spawn.
+	agents.SetFailSpawn(fmt.Errorf("prepare worktree: %w", worktreeerr.ErrRebaseFailed))
+	agents.SimulateComplete("t1")
+	engine.HandleAgentComplete("t1", AgentCompletion{AgentID: triageAgentID, Success: true, Result: "triaged"})
+
+	ti, err := tasks.GetTask("t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, tripped := ti.Workflow.Variables[circuitBreakerFailureKey("implement")]; !tripped {
+		t.Errorf("expected circuit breaker failure recorded against %q, vars=%v", "implement", ti.Workflow.Variables)
+	}
+	if _, wrong := ti.Workflow.Variables[circuitBreakerFailureKey("triage")]; wrong {
+		t.Errorf("circuit breaker failure wrongly recorded against completed step %q instead of the step that failed to dispatch", "triage")
+	}
+}
+
 func TestSurfaceStartFailure_AlreadyHumanRequiredIsNoOp(t *testing.T) {
 	tasks := newMemTasks()
 	tasks.Put(TaskInfo{ID: "t1", Status: "human-required", StatusReason: "existing reason"})


### PR DESCRIPTION
## Motivation

Task 17507143 flapped todo<->human-required 235 times in ~13h, draining the fleet's human-review budget. Root cause per audit log: each resume tick, a rebase failure gets escalated to human-required and then overwritten back within the same tick by a status-write path that either used a stale snapshot or discarded the already-handled signal.

## Implementation information

- `surfaceStartFailure` now tracks per-(task,step) dispatch failures and trips a circuit breaker (3 failures / 15min): forces human-required and marks the workflow ExecFailed, halting every resume path regardless of what else touches task.Status. Also made it a sticky no-op once a task is already human-required.
- `classifyDirectDispatchWorktreeErr` now checks the `handled` signal from `RecoverFromWorktreePrepFailure` instead of only `recovered`, so an already-resolved-in_review downgrade isn't clobbered back to human-required.
- Review follow-up: attribute circuit-breaker/dispatch failures in `HandleAgentComplete` to the step that actually failed to start, not the step that completed (`AdvanceStep`'s error usually comes from failing to spawn the next step). Wraps dispatch errors with the failing step ID and unwraps it before recording breaker state.

Closes https://github.com/Automaat/sybra/issues/1487

_Generated by Sybra harness_